### PR TITLE
add alphabet meta header, clean-up

### DIFF
--- a/include/seqan3/alphabet.hpp
+++ b/include/seqan3/alphabet.hpp
@@ -1,0 +1,52 @@
+// ============================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ============================================================================
+//
+// Copyright (c) 2006-2017, Knut Reinert & Freie Universitaet Berlin
+// Copyright (c) 2016-2017, Knut Reinert & MPI Molekulare Genetik
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ============================================================================
+
+/*!\file alphabet.hpp
+ * \ingroup alphabet
+ * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
+ * \brief Meta-header for the alphabet module.
+ *
+ * \defgroup alphabet
+ *
+ * The alphabet module contains different biological alphabets and related functionality.
+ *
+ * TODO more details.
+ */
+
+#pragma once
+
+#include <seqan3/alphabet/composition.hpp>
+#include <seqan3/alphabet/concept.hpp>
+#include <seqan3/alphabet/quality.hpp>
+#include <seqan3/alphabet/range.hpp>

--- a/include/seqan3/alphabet/aminoacid/aa27.hpp
+++ b/include/seqan3/alphabet/aminoacid/aa27.hpp
@@ -38,7 +38,7 @@
 
 #include <cassert>
 
-#include "../alphabet.hpp"
+#include <seqan3/alphabet/concept.hpp>
 
 /*! The twenty-seven letter amino acid alphabet
  * \ingroup alphabet

--- a/include/seqan3/alphabet/aminoacid/aa27_container.hpp
+++ b/include/seqan3/alphabet/aminoacid/aa27_container.hpp
@@ -40,8 +40,8 @@
 #include <string>
 #include <vector>
 
-#include "../alphabet.hpp"
-#include "../alphabet_container.hpp"
+#include <seqan3/alphabet/concept.hpp>
+#include <seqan3/alphabet/range.hpp>
 #include "aa27.hpp"
 
 /*! Containers of @link aa27 @endlink

--- a/include/seqan3/alphabet/composition.hpp
+++ b/include/seqan3/alphabet/composition.hpp
@@ -45,7 +45,7 @@
 
 #include <meta/meta.hpp>
 
-#include <seqan3/alphabet/alphabet.hpp>
+#include <seqan3/alphabet/concept.hpp>
 #include <seqan3/alphabet/quality/concept.hpp>
 #include <seqan3/core/pod_tuple.hpp>
 #include <seqan3/core/detail/int_types.hpp>

--- a/include/seqan3/alphabet/concept.hpp
+++ b/include/seqan3/alphabet/concept.hpp
@@ -42,7 +42,7 @@
 namespace seqan3
 {
 
-/*!\file alphabet.hpp
+/*!\file concept.hpp
  * \ingroup alphabet
  * Alphabet header with concept defintions and some general purpose free functions.
  */

--- a/include/seqan3/alphabet/concept.hpp
+++ b/include/seqan3/alphabet/concept.hpp
@@ -31,8 +31,12 @@
 // DAMAGE.
 //
 // ============================================================================
-// Author: Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
-// ============================================================================
+
+/*!\file alphabet/concept.hpp
+ * \ingroup alphabet
+ * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
+ * \brief Core alphabet concept.
+ */
 
 #pragma once
 
@@ -41,18 +45,6 @@
 
 namespace seqan3
 {
-
-/*!\file concept.hpp
- * \ingroup alphabet
- * Alphabet header with concept defintions and some general purpose free functions.
- */
-
-/*!\defgroup alphabet
- *
- * The alphabet module contains different biological alphabets and related functionality.
- *
- * TODO more details.
- */
 
 // ------------------------------------------------------------------
 // free functions to member function wrapper

--- a/include/seqan3/alphabet/gap/gap.hpp
+++ b/include/seqan3/alphabet/gap/gap.hpp
@@ -41,7 +41,7 @@
 #include <optional>
 #include <cassert>
 
-#include "../alphabet.hpp"
+#include <seqan3/alphabet/concept.hpp>
 
 /*! The gap alphabet
  * \ingroup alphabet

--- a/include/seqan3/alphabet/nucleotide/dna4.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna4.hpp
@@ -38,7 +38,7 @@
 
 #include <cassert>
 
-#include "../alphabet.hpp"
+#include <seqan3/alphabet/concept.hpp>
 
 /*! The four letter DNA alphabet
  * \ingroup alphabet

--- a/include/seqan3/alphabet/nucleotide/dna4_container.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna4_container.hpp
@@ -40,8 +40,8 @@
 #include <string>
 #include <vector>
 
-#include "../alphabet.hpp"
-#include "../alphabet_container.hpp"
+#include <seqan3/alphabet/concept.hpp>
+#include <seqan3/alphabet/range.hpp>
 #include "dna4.hpp"
 
 

--- a/include/seqan3/alphabet/nucleotide/dna5.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna5.hpp
@@ -36,7 +36,7 @@
 
 #pragma once
 
-#include "../alphabet.hpp"
+#include <seqan3/alphabet/concept.hpp>
 
 /*! The five letter DNA alphabet
  * \ingroup alphabet

--- a/include/seqan3/alphabet/nucleotide/dna5_container.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna5_container.hpp
@@ -40,8 +40,8 @@
 #include <string>
 #include <vector>
 
-#include "../alphabet.hpp"
-#include "../alphabet_container.hpp"
+#include <seqan3/alphabet/concept.hpp>
+#include <seqan3/alphabet/range.hpp>
 #include "dna5.hpp"
 
 /*! Containers of @link dna5 @endlink

--- a/include/seqan3/alphabet/nucleotide/nucl16.hpp
+++ b/include/seqan3/alphabet/nucleotide/nucl16.hpp
@@ -38,7 +38,7 @@
 
 #include <cassert>
 
-#include "../alphabet.hpp"
+#include <seqan3/alphabet/concept.hpp>
 
 /*! The sixteen letter nucleotide alphabet
  * \ingroup alphabet

--- a/include/seqan3/alphabet/nucleotide/nucl16_container.hpp
+++ b/include/seqan3/alphabet/nucleotide/nucl16_container.hpp
@@ -40,8 +40,8 @@
 #include <string>
 #include <vector>
 
-#include "../alphabet.hpp"
-#include "../alphabet_container.hpp"
+#include <seqan3/alphabet/concept.hpp>
+#include <seqan3/alphabet/range.hpp>
 #include "nucl16.hpp"
 
 /*! Containers of @link nucl16 @endlink

--- a/include/seqan3/alphabet/quality/aliases.hpp
+++ b/include/seqan3/alphabet/quality/aliases.hpp
@@ -44,7 +44,7 @@
 #include <string>
 #include <utility>
 
-#include <seqan3/alphabet/alphabet.hpp>
+#include <seqan3/alphabet/concept.hpp>
 #include <seqan3/alphabet/quality/composition.hpp>
 #include <seqan3/alphabet/quality/concept.hpp>
 #include <seqan3/alphabet/quality/illumina18.hpp>

--- a/include/seqan3/alphabet/quality/concept.hpp
+++ b/include/seqan3/alphabet/quality/concept.hpp
@@ -39,7 +39,7 @@
 #include <iostream>
 #include <string>
 
-#include <seqan3/alphabet/alphabet.hpp>
+#include <seqan3/alphabet/concept.hpp>
 
 namespace seqan3
 {

--- a/include/seqan3/alphabet/quality/illumina18.hpp
+++ b/include/seqan3/alphabet/quality/illumina18.hpp
@@ -153,7 +153,7 @@ struct illumina18
 } // namespace seqan3
 
 #ifndef NDEBUG
-#include <seqan3/alphabet/alphabet.hpp>
+#include <seqan3/alphabet/concept.hpp>
 #include <seqan3/alphabet/quality/concept.hpp>
 static_assert(seqan3::alphabet_concept<seqan3::illumina18>);
 static_assert(seqan3::detail::internal_alphabet_concept<seqan3::illumina18>);

--- a/include/seqan3/alphabet/range.hpp
+++ b/include/seqan3/alphabet/range.hpp
@@ -45,12 +45,12 @@
 #include <deque>
 #include <string>
 
-#include "alphabet.hpp"
+#include <seqan3/alphabet/concept.hpp>
 
 namespace seqan3
 {
 
-/*! \file alphabet_container.hpp
+/*! \file range.hpp
  * \ingroup alphabet
  * Free function overloads for containers over alphabets
  */

--- a/include/seqan3/alphabet/union_alphabet.hpp
+++ b/include/seqan3/alphabet/union_alphabet.hpp
@@ -45,7 +45,7 @@
 #include <cassert>
 
 #include "nucleotide/dna5.hpp"
-#include "alphabet.hpp"
+#include <seqan3/alphabet/concept.hpp>
 
 /*! The union alphabet
  * \ingroup alphabet

--- a/test/alphabet/quality/composition_test.cpp
+++ b/test/alphabet/quality/composition_test.cpp
@@ -34,7 +34,7 @@
 
 #include <gtest/gtest.h>
 
-#include <seqan3/alphabet/alphabet.hpp>
+#include <seqan3/alphabet/concept.hpp>
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/alphabet/quality/illumina18.hpp>
 #include <seqan3/alphabet/quality/composition.hpp>

--- a/test/alphabet/quality/illumina18_test.cpp
+++ b/test/alphabet/quality/illumina18_test.cpp
@@ -36,7 +36,7 @@
 
 #include <gtest/gtest.h>
 
-#include <seqan3/alphabet/alphabet.hpp>
+#include <seqan3/alphabet/concept.hpp>
 #include <seqan3/alphabet/quality/concept.hpp>
 #include <seqan3/alphabet/quality/illumina18.hpp>
 


### PR DESCRIPTION
@rrahn can you do a quick review of this soon?
It's just two renames and adding the meta header. The reason for the renames is to avoid `alphabet/alphabet_something.hpp` and just have `alphabet/something.hpp`.

Also the structure of the alphabet module is now in general

```
alphabet/concept.hpp             general concepts
alphabet/range.hpp               free function overloads on ranges of the general concept
alphabet/composition.hpp         alphabet composition

alphabet/quality/concept.hpp        quality concept
alphabet/quality/range.hpp          free function overloads on ranges of the quality concept (doesn't exist yet)
alphabet/quality/composition.hpp    the quality composition

....
```

I will adapt the nucleotide and aminoacid submodules in seperate PRs, but since this potentially effects a lot of other people and PRs, it would be great to have it merged ASAP.

Thanks!

PS: yes, the edited files don't correspond to current standard, but that can happen in different PRs.

