### PR TITLE
add adaptations submodule to alphabet module

### DIFF
--- a/include/seqan3/alphabet/adaptation.hpp
+++ b/include/seqan3/alphabet/adaptation.hpp
@@ -32,22 +32,27 @@
 //
 // ============================================================================
 
-/*!\file alphabet.hpp
- * \ingroup alphabet
+/*!\file alphabet/adaptation.hpp
+ * \ingroup adaptation
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
- * \brief Meta-header for the alphabet module.
- *
- * \defgroup alphabet
- *
- * The alphabet module contains different biological alphabets and related functionality.
- *
- * TODO more details.
+ * \brief Meta-header for the adaptation submodule; includes all headers from alphabet/adaptation/.
  */
 
-#pragma once
+#include <seqan3/alphabet/adaptation/char.hpp>
+#include <seqan3/alphabet/adaptation/uint.hpp>
 
-#include <seqan3/alphabet/adpaptation.hpp>
-#include <seqan3/alphabet/composition.hpp>
+/*!\defgroup adaptation
+ * \brief Contains alphabet adaptions of some standard char and uint types.
+ * \ingroup alphabet
+ */
+
+#ifndef NDEBUG
 #include <seqan3/alphabet/concept.hpp>
-#include <seqan3/alphabet/quality.hpp>
-#include <seqan3/alphabet/range.hpp>
+static_assert(seqan3::alphabet_concept<char>);
+static_assert(seqan3::alphabet_concept<wchar_t>);
+static_assert(seqan3::alphabet_concept<char16_t>);
+static_assert(seqan3::alphabet_concept<char32_t>);
+static_assert(seqan3::alphabet_concept<uint8_t>);
+static_assert(seqan3::alphabet_concept<uint16_t>);
+static_assert(seqan3::alphabet_concept<uint32_t>);
+#endif

--- a/include/seqan3/alphabet/adaptation/char.hpp
+++ b/include/seqan3/alphabet/adaptation/char.hpp
@@ -1,0 +1,254 @@
+// ============================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ============================================================================
+//
+// Copyright (c) 2006-2017, Knut Reinert & Freie Universitaet Berlin
+// Copyright (c) 2016-2017, Knut Reinert & MPI Molekulare Genetik
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ============================================================================
+
+/*!\file alphabet/adaptation/char.hpp
+ * \ingroup adaptation
+ * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
+ * \brief Provides alphabet adaptations for standard char types.
+ * \details
+ * This file provides function and metafunction overloads so that the following types
+ * fulfil the seqan3::alphabet_concept:
+ *   * `char`
+ *   * `wchar_t`
+ *   * `char16_t`
+ *   * `char32_t`
+ *
+ * You will likely not use these interfaces directly, they are, however, very helpful
+ * for conversions between other alphabets and between other alphabets and characters.
+ *
+ * \attention
+ *   * Note that `signed char` and `unsigned char` are absent from the list, because of
+ * their type ambiguity with `int8_t` and `uint8_t`.
+ *   * Please be aware that if you also include alphabet/concept.hpp, you need to do so **after**
+ * including this file, not before.
+ */
+
+#pragma once
+
+#include <limits>
+
+#include <meta/meta.hpp>
+
+#include <seqan3/alphabet/concept_fwd.hpp>
+#include <seqan3/core/detail/int_types.hpp>
+
+//!\cond
+// NOTE(h-2): 'tis some nice code witchery that gives an error if the include order is wrong.
+namespace
+{
+
+template <std::nullptr_t t>
+concept bool alphabet_concept = true;
+
+}
+
+namespace seqan3
+{
+
+static_assert(alphabet_concept<nullptr>, "You must include alphabet/concept.hpp AFTER including alphabet/adaptation/char.hpp, not before!");
+
+}
+//!\endcond
+
+namespace seqan3::detail
+{
+//!\addtogroup adaptation
+//!\{
+
+//!\brief The list of types that are defined as char adaptations.
+using char_adaptations            = meta::list<char,
+                                               wchar_t,
+                                               char16_t,
+                                               char32_t>;
+//!\brief The corresponding list of rank types
+using char_adaptations_rank_types = meta::list<std::uint_least8_t,
+                                               std::uint_least32_t,
+                                               std::uint_least16_t,
+                                               std::uint_least32_t>;
+
+//!\brief Metafunction that indicates whether a type is a char alphabet adaptation.
+template <typename type>
+struct is_char_adaptation :
+    public std::conditional_t<meta::in<char_adaptations, type>::value, std::true_type, std::false_type>
+{};
+
+//!\brief Shortcut for seqan3::detail::is_char_adaptation.
+template <typename type>
+constexpr bool is_char_adaptation_v = is_char_adaptation<type>::value;
+
+//!\}
+} // namespace seqan3::detail
+
+namespace seqan3
+{
+
+//!\addtogroup adaptation
+//!\{
+
+// ------------------------------------------------------------------
+// type metafunctions
+// ------------------------------------------------------------------
+
+//!\brief Type metafunction that shall return the type of an alphabet in char representation. [char specialization]
+//!\tparam char_type One of `char`, `wchar_t`, `char16_t` or `char32_t`.
+//!\sa seqan3::underlying_char
+template <typename char_type>
+    requires detail::is_char_adaptation_v<char_type>
+struct underlying_char<char_type>
+{
+    //!\brief The same type as char_type.
+    using type = char_type;
+};
+
+//!\brief Type metafunction that shall return the type of an alphabet in rank representation. [char specialization]
+//!\tparam char_type One of `char`, `wchar_t`, `char16_t` or `char32_t`.
+//!\sa seqan3::underlying_rank
+template <typename char_type>
+    requires detail::is_char_adaptation_v<char_type>
+struct underlying_rank<char_type>
+{
+    //!\brief An unsigned integer type of the same size as `char_type`.
+    using type = meta::at<detail::char_adaptations_rank_types,
+                          meta::find_index<detail::char_adaptations, char_type>>;
+};
+
+// ------------------------------------------------------------------
+// value metafunctions
+// ------------------------------------------------------------------
+
+//!\brief Value metafunction that shall return the size of an alphabet. [char specialization]
+//!\tparam char_type One of `char`, `wchar_t`, `char16_t` or `char32_t`.
+//!\sa seqan3::alphabet_size
+template <typename char_type>
+    requires detail::is_char_adaptation_v<char_type>
+struct alphabet_size<char_type>
+{
+    //!\brief Smallest unsigned integral type that can hold value;
+    using type = detail::min_viable_uint_t<(std::size_t)std::numeric_limits<char_type>::max() + 1 -
+                                            std::numeric_limits<char_type>::lowest()>;
+    //!\brief The alphabet's size.
+    static constexpr type value =
+        (type)std::numeric_limits<char_type>::max() + 1 - std::numeric_limits<char_type>::lowest();
+};
+
+// ------------------------------------------------------------------
+// free functions
+// ------------------------------------------------------------------
+
+/*!\name Free function wrappers for the char alphabet adaptation
+ * \brief For `char`, `wchar_t`, `char16_t` and `char32_t` do conversion to/from uint types.
+ * \ingroup adaptation
+ * \{
+ */
+/*!\brief Converting char to char is no-op (it will just return the value you pass in).
+ * \tparam char_type One of `char`, `wchar_t`, `char16_t` or `char32_t`.
+ * \param c The alphabet letter that you wish to convert to char.
+ * \returns The letter's value in the alphabet's rank type (usually `char`).
+ */
+template <typename char_type>
+constexpr underlying_char_t<char_type> to_char(char_type const c)
+    requires detail::is_char_adaptation_v<char_type>
+{
+    return c;
+}
+
+/*!\brief Convert char to rank by casting to an unsigned integral type of same size.
+ * \tparam char_type One of `char`, `wchar_t`, `char16_t` or `char32_t`.
+ * \param c The alphabet letter that you wish to convert to rank.
+ * \returns The letter's value in the alphabet's rank type (usually a `uint*_t`).
+ */
+template <typename char_type>
+constexpr underlying_rank_t<char_type> to_rank(char_type const c)
+    requires detail::is_char_adaptation_v<char_type>
+{
+    return c;
+}
+
+/*!\brief The same as calling `=` on the char.
+ * \tparam char_type One of `char`, `wchar_t`, `char16_t` or `char32_t`.
+ * \param c The alphabet letter that you wish to assign to.
+ * \param in The `char` value you wish to assign.
+ * \returns A reference to the alphabet letter you passed in.
+ */
+template <typename char_type>
+constexpr char_type & assign_char(char_type & c, underlying_char_t<char_type> const in)
+    requires detail::is_char_adaptation_v<char_type>
+{
+    return c = in;
+}
+
+/*!\brief The same as calling `=` on the char.
+ * \tparam char_type One of `char`, `wchar_t`, `char16_t` or `char32_t`.
+ * \param c An alphabet letter temporary.
+ * \param in The `char` value you wish to assign.
+ * \returns The assignment result as a temporary.
+ */
+template <typename char_type>
+constexpr char_type && assign_char(char_type && c, underlying_char_t<char_type> const in)
+    requires detail::is_char_adaptation_v<std::remove_reference_t<char_type>>
+{
+    return std::move(c = in);
+}
+
+/*!\brief Assigning a rank to a char is the same assigning it a numeric value.
+ * \tparam char_type One of `char`, `wchar_t`, `char16_t` or `char32_t`.
+ * \param c The alphabet letter that you wish to assign to.
+ * \param in The `rank` value you wish to assign.
+ * \returns A reference to the alphabet letter you passed in.
+ */
+template <typename char_type>
+constexpr char_type & assign_rank(char_type & c, underlying_rank_t<char_type> const in)
+    requires detail::is_char_adaptation_v<char_type>
+{
+    return c = in;
+}
+
+/*!\brief Assigning a rank to a char is the same assigning it a numeric value.
+ * \tparam char_type One of `char`, `wchar_t`, `char16_t` or `char32_t`.
+ * \param c An alphabet letter temporary.
+ * \param in The `rank` value you wish to assign.
+ * \returns The assignment result as a temporary.
+ */
+template <typename char_type>
+constexpr char_type && assign_rank(char_type && c, underlying_rank_t<char_type> const in)
+    requires detail::is_char_adaptation_v<std::remove_reference_t<char_type>>
+{
+    return std::move(c = in);
+}
+//!\}
+//!\}
+
+} // namespace seqan3
+
+// concept tests in alphabet/adaptation.hpp because of include order constraints

--- a/include/seqan3/alphabet/adaptation/uint.hpp
+++ b/include/seqan3/alphabet/adaptation/uint.hpp
@@ -1,0 +1,262 @@
+// ============================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ============================================================================
+//
+// Copyright (c) 2006-2017, Knut Reinert & Freie Universitaet Berlin
+// Copyright (c) 2016-2017, Knut Reinert & MPI Molekulare Genetik
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ============================================================================
+
+/*!\file alphabet/adaptation/uint.hpp
+ * \ingroup adaptation
+ * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
+ * \brief Provides alphabet adaptations for standard uint types.
+ * \details
+ * This file provides function and metafunction overloads so that the following types
+ * fulfil the seqan3::alphabet_concept:
+ *   * `uint`
+ *   * `uint16_t`
+ *   * `uint32_t`
+ *
+ * You will likely not use these interfaces directly, they are, however, very helpful
+ * for conversions between other alphabets and between other alphabets and characters.
+ *
+ * \attention
+ * Note that `uint64_t` is absent from the list, because of there is no corresponding
+ * character type.
+ *
+ * \attention
+ * Please be aware that if you also include alphabet/concept.hpp, you need to do so **after**
+ * including this file, not before.
+ */
+
+#pragma once
+
+#include <limits>
+
+#include <meta/meta.hpp>
+
+#include <seqan3/alphabet/concept_fwd.hpp>
+
+//!\cond
+// NOTE(h-2): 'tis some nice code witchery that gives an error if the include order is wrong.
+namespace
+{
+
+template <std::nullptr_t t>
+concept bool alphabet_concept = true;
+
+}
+
+namespace seqan3
+{
+
+static_assert(alphabet_concept<nullptr>, "You must include alphabet/concept.hpp AFTER including alphabet/adaptation/uint.hpp, not before!");
+
+}
+//!\endcond
+
+namespace seqan3::detail
+{
+//!\addtogroup adaptation
+//!\{
+
+//!\brief The list of types that are defined as uint adaptations.
+using uint_adaptations            = meta::list<uint8_t,
+                                               uint16_t,
+                                               uint32_t>;
+//!\brief The corresponding list of rank types
+using uint_adaptations_char_types = meta::list<char,
+                                               char16_t,
+                                               char32_t>;
+
+//!\brief Metafunction that indicates whether a type is a uint alphabet adaptation.
+template <typename type>
+struct is_uint_adaptation :
+    public std::conditional_t<meta::in<uint_adaptations, type>::value, std::true_type, std::false_type>
+{};
+
+//!\brief Shortcut for seqan3::detail::is_uint_adaptation.
+template <typename type>
+constexpr bool is_uint_adaptation_v = is_uint_adaptation<type>::value;
+
+//!\}
+} // namespace seqan3::detail
+
+namespace seqan3
+{
+
+//!\addtogroup adaptation
+//!\{
+
+// ------------------------------------------------------------------
+// type metafunctions
+// ------------------------------------------------------------------
+
+//!\brief Type metafunction that shall return the type of an alphabet in uint representation. [uint specialization]
+//!\tparam uint_type One of `uint8_t`, `uint16_t` or `uint32_t`.
+//!\sa seqan3::underlying_char
+template <typename uint_type>
+    requires detail::is_uint_adaptation_v<uint_type>
+struct underlying_char<uint_type>
+{
+    //!\brief The character type of the same size as `uint_type`.
+    using type = meta::at<detail::uint_adaptations_char_types,
+                          meta::find_index<detail::uint_adaptations, uint_type>>;
+};
+
+//!\brief Type metafunction that shall return the type of an alphabet in rank representation. [uint specialization]
+//!\tparam uint_type One of `uint8_t`, `uint16_t` or `uint32_t`.
+//!\sa seqan3::underlying_rank
+template <typename uint_type>
+    requires detail::is_uint_adaptation_v<uint_type>
+struct underlying_rank<uint_type>
+{
+    //!\brief The same as `uint_type`.
+    using type = uint_type;
+};
+
+// ------------------------------------------------------------------
+// value metafunctions
+// ------------------------------------------------------------------
+
+//!\brief Value metafunction that shall return the size of an alphabet. [uint specialization]
+//!\tparam uint_type One of `uint8_t`, `uint16_t` or `uint32_t`.
+//!\sa seqan3::alphabet_size
+template <typename uint_type>
+    requires detail::is_uint_adaptation_v<uint_type>
+struct alphabet_size<uint_type>
+{
+    //!\brief Smallest unsigned integral type that can hold value;
+    using type = detail::min_viable_uint_t<(std::size_t)std::numeric_limits<uint_type>::max() + 1 -
+                                            std::numeric_limits<uint_type>::lowest()>;
+    //!\brief The alphabet's size.
+    static constexpr type value =
+        (type)std::numeric_limits<uint_type>::max() + 1 - std::numeric_limits<uint_type>::lowest();
+};
+
+// ------------------------------------------------------------------
+// free functions
+// ------------------------------------------------------------------
+
+/*!\name Free function wrappers for the uint alphabet adaptation
+ * \brief For `uint8_t`, `uint16_t` and `uint32_t` do conversion to/from char types.
+ * \ingroup adaptation
+ * \{
+ */
+/*!\brief Converting uint to char casts to an character type of same size.
+ * \tparam uint_type One of `uint8_t`, `uint16_t` or `uint32_t`.
+ * \param c The alphabet letter that you wish to convert to char.
+ * \returns The letter's value in the alphabet's rank type (usually `uint`).
+ */
+template <typename uint_type>
+constexpr underlying_char_t<uint_type> to_char(uint_type const c)
+    requires detail::is_uint_adaptation_v<uint_type>
+{
+    return c;
+}
+
+/*!\brief Converting uint to rank is a no-op (it will just return the value you pass in).
+ * \tparam uint_type One of `uint8_t`, `uint16_t` or `uint32_t`.
+ * \param c The alphabet letter that you wish to convert to rank.
+ * \returns The letter's value in the alphabet's rank type (usually a `uint*_t`).
+ */
+template <typename uint_type>
+constexpr underlying_rank_t<uint_type> to_rank(uint_type const c)
+    requires detail::is_uint_adaptation_v<uint_type>
+{
+    return c;
+}
+
+/*!\brief Assign from a character type vie implicit or explicit cast.
+ * \tparam uint_type One of `uint8_t`, `uint16_t` or `uint32_t`.
+ * \param c The alphabet letter that you wish to assign to.
+ * \param in The `uint` value you wish to assign.
+ * \returns A reference to the alphabet letter you passed in.
+ */
+template <typename uint_type>
+constexpr uint_type & assign_char(uint_type & c, underlying_char_t<uint_type> const in)
+    requires detail::is_uint_adaptation_v<uint_type>
+{
+    return c = in;
+}
+
+/*!\brief Assign from a character type vie implicit or explicit cast.
+ * \tparam uint_type One of `uint8_t`, `uint16_t` or `uint32_t`.
+ * \param c An alphabet letter temporary.
+ * \param in The `uint` value you wish to assign.
+ * \returns The assignment result as a temporary.
+ * \details
+ * Use this e.g. to newly create alphabet letters from uint:
+ * ```cpp
+ * auto l = assign_char(dna5{}, 'G');  // l is of type dna5
+ * ```
+ */
+template <typename uint_type>
+constexpr uint_type && assign_char(uint_type && c, underlying_char_t<uint_type> const in)
+    requires detail::is_uint_adaptation_v<std::remove_reference_t<uint_type>>
+{
+    return std::move(c = in);
+}
+
+/*!\brief The same as calling `=` on the uint.
+ * \tparam uint_type One of `uint8_t`, `uint16_t` or `uint32_t`.
+ * \param c The alphabet letter that you wish to assign to.
+ * \param in The `rank` value you wish to assign.
+ * \returns A reference to the alphabet letter you passed in.
+ */
+template <typename uint_type>
+constexpr uint_type & assign_rank(uint_type & c, underlying_rank_t<uint_type> const in)
+    requires detail::is_uint_adaptation_v<uint_type>
+{
+    return c = in;
+}
+
+/*!\brief The same as calling `=` on the uint.
+ * \tparam uint_type One of `uint8_t`, `uint16_t` or `uint32_t`.
+ * \param c An alphabet letter temporary.
+ * \param in The `rank` value you wish to assign.
+ * \returns The assignment result as a temporary.
+ * \details
+ * Use this e.g. to newly create alphabet letters from rank:
+ * ```cpp
+ * auto l = assign_rank(dna5{}, 1);  // l is of type dna5 and == dna5::C
+ * ```
+ */
+template <typename uint_type>
+constexpr uint_type && assign_rank(uint_type && c, underlying_rank_t<uint_type> const in)
+    requires detail::is_uint_adaptation_v<std::remove_reference_t<uint_type>>
+{
+    return std::move(c = in);
+}
+//!\}
+//!\}
+
+} // namespace seqan3
+
+// concept tests in alphabet/adaptation.hpp because of include order constraints

--- a/include/seqan3/alphabet/concept.hpp
+++ b/include/seqan3/alphabet/concept.hpp
@@ -43,7 +43,7 @@
 #include <iostream>
 #include <string>
 
-#include <seqan3/core/platform.hpp>
+#include <seqan3/alphabet/concept_fwd.hpp>
 
 namespace seqan3
 {
@@ -65,16 +65,11 @@ template <typename alphabet_type>
 //!\cond
     requires requires (alphabet_type c) { typename alphabet_type::char_type; }
 //!\endcond
-struct underlying_char
+struct underlying_char<alphabet_type>
 {
     //!\brief The alphabet's char_type.
     using type = typename alphabet_type::char_type;
 };
-
-//!\brief Shortcut for seqan3::underlying_char
-template <typename alphabet_type>
-//!\relates seqan3::underlying_char
-using underlying_char_t = typename underlying_char<alphabet_type>::type;
 
 //!\brief Type metafunction that returns the `rank_type` defined inside an alphabet type.
 //!\tparam alphabet_type Must provide a `rank_type` member type.
@@ -82,16 +77,11 @@ template <typename alphabet_type>
 //!\cond
     requires requires (alphabet_type c) { typename alphabet_type::rank_type; }
 //!\endcond
-struct underlying_rank
+struct underlying_rank<alphabet_type>
 {
     //!\brief The alphabet's rank_type.
     using type = typename alphabet_type::rank_type;
 };
-
-//!\brief Shortcut for seqan3::underlying_rank
-//!\relates seqan3::underlying_rank
-template <typename alphabet_type>
-using underlying_rank_t = typename underlying_rank<alphabet_type>::type;
 
 // ------------------------------------------------------------------
 // value metafunctions
@@ -103,16 +93,11 @@ template <typename alphabet_type>
 //!\cond
     requires requires (alphabet_type c) { alphabet_type::value_size; }
 //!\endcond
-struct alphabet_size
+struct alphabet_size<alphabet_type>
 {
     //!\brief The alphabet's size.
     static constexpr underlying_rank_t<alphabet_type> value = alphabet_type::value_size;
 };
-
-//!\brief Shortcut for seqan3::alphabet_size
-//!\relates seqan3::alphabet_size
-template <typename alphabet_type>
-constexpr underlying_rank_t<alphabet_type> alphabet_size_v = alphabet_size<alphabet_type>::value;
 
 // ------------------------------------------------------------------
 // free functions

--- a/include/seqan3/alphabet/concept_fwd.hpp
+++ b/include/seqan3/alphabet/concept_fwd.hpp
@@ -1,0 +1,101 @@
+// ============================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ============================================================================
+//
+// Copyright (c) 2006-2017, Knut Reinert & Freie Universitaet Berlin
+// Copyright (c) 2016-2017, Knut Reinert & MPI Molekulare Genetik
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ============================================================================
+
+/*!\file alphabet/concept_fwd.hpp
+ * \ingroup alphabet
+ * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
+ * \brief Core alphabet concept metafunction base classes.
+ *
+ * Include this file, if you implement an alphabet type with Free/global function
+ * and metafunction interface.
+ */
+
+#pragma once
+
+#include <iostream>
+#include <string>
+
+#include <seqan3/core/platform.hpp>
+
+namespace seqan3
+{
+
+// ============================================================================
+// Free/Global interface wrappers
+// ============================================================================
+
+//!\addtogroup alphabet
+//!\{
+
+// ------------------------------------------------------------------
+// type metafunctions
+// ------------------------------------------------------------------
+
+//!\brief Type metafunction that shall return the type of an alphabet in char representation. [base type]
+//!\tparam alphabet_type The unspecialized and unconstrained template takes any type.
+template <typename alphabet_type>
+struct underlying_char;
+
+//!\brief Shortcut for seqan3::underlying_char
+template <typename alphabet_type>
+//!\relates seqan3::underlying_char
+using underlying_char_t = typename underlying_char<alphabet_type>::type;
+
+//!\brief Type metafunction that shall return the type of an alphabet in rank representation. [base type]
+//!\tparam alphabet_type Must provide a `rank_type` member type.
+template <typename alphabet_type>
+struct underlying_rank;
+
+//!\brief Shortcut for seqan3::underlying_rank
+//!\relates seqan3::underlying_rank
+template <typename alphabet_type>
+using underlying_rank_t = typename underlying_rank<alphabet_type>::type;
+
+// ------------------------------------------------------------------
+// value metafunctions
+// ------------------------------------------------------------------
+
+//!\brief Value metafunction that shall return the size of an alphabet. [base type]
+//!\tparam alphabet_type The unspecialized and unconstrained template takes any type.
+template <typename alphabet_type>
+struct alphabet_size;
+
+//!\brief Shortcut for seqan3::alphabet_size
+//!\relates seqan3::alphabet_size
+template <typename alphabet_type>
+constexpr auto alphabet_size_v = alphabet_size<alphabet_type>::value;
+
+//!\}
+
+} // namespace seqan3

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -38,5 +38,18 @@ include_directories("${CMAKE_SOURCE_DIR}/../include/")
 include_directories("${CMAKE_SOURCE_DIR}/../range-v3/include/")
 include_directories("${CMAKE_SOURCE_DIR}/../sdsl-lite/include/")
 
-add_subdirectory(alphabet)
-add_subdirectory(core)
+macro (add_all_subdirectories)
+    file (GLOB ENTRIES
+          RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
+          ${CMAKE_CURRENT_SOURCE_DIR}/[!.]*)
+
+    foreach (ENTRY ${ENTRIES})
+        if (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${ENTRY})
+            if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${ENTRY}/CMakeLists.txt)
+                add_subdirectory(${ENTRY})
+            endif ()
+        endif ()
+    endforeach ()
+endmacro ()
+
+add_all_subdirectories()

--- a/test/alphabet/CMakeLists.txt
+++ b/test/alphabet/CMakeLists.txt
@@ -1,10 +1,7 @@
 cmake_minimum_required(VERSION 3.2)
 project(alphabet_test CXX)
 
-add_subdirectory(quality)
-add_subdirectory(aminoacid)
-add_subdirectory(nucleotide)
-add_subdirectory(gap)
+add_all_subdirectories()
 
 add_executable(alphabet_union_alphabet_test union_alphabet.cpp)
 add_test(NAME test_alphabet_union_alphabet_test COMMAND alphabet_union_alphabet_test)

--- a/test/alphabet/adaptation/CMakeLists.txt
+++ b/test/alphabet/adaptation/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_executable(char_test char_test.cpp)
+target_link_libraries(char_test ${SEQAN3_LIBRARIES})
+add_test(NAME alphabet_adaptation_char COMMAND char_test)
+
+add_executable(uint_test uint_test.cpp)
+target_link_libraries(uint_test ${SEQAN3_LIBRARIES})
+add_test(NAME alphabet_adaptation_uint COMMAND uint_test)

--- a/test/alphabet/adaptation/char_test.cpp
+++ b/test/alphabet/adaptation/char_test.cpp
@@ -1,0 +1,101 @@
+// ==========================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ==========================================================================
+//
+// Copyright (c) 2006-2017, Knut Reinert, FU Berlin
+// Copyright (c) 2016-2017, Knut Reinert & MPI Molekulare Genetik
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ==========================================================================
+
+#include <iostream>
+
+#include <gtest/gtest.h>
+
+#include <seqan3/alphabet/adaptation.hpp>
+
+using namespace seqan3;
+
+template <typename T>
+class char_adaptation : public ::testing::Test
+{};
+
+using char_types = ::testing::Types<char, wchar_t, char16_t, char32_t>;
+
+TYPED_TEST_CASE(char_adaptation, char_types);
+
+TYPED_TEST(char_adaptation, underlying_char_t)
+{
+    EXPECT_TRUE((std::is_same_v<underlying_char_t<TypeParam>, TypeParam>));
+}
+
+TYPED_TEST(char_adaptation, to_char)
+{
+    TypeParam l{'A'};
+    EXPECT_TRUE((std::is_same_v<decltype(to_char(l)), underlying_char_t<TypeParam>>));
+    EXPECT_TRUE((std::is_same_v<decltype(to_char(TypeParam{'A'})), underlying_char_t<TypeParam>>));
+    EXPECT_EQ(to_char(TypeParam{'A'}), l);
+}
+
+TYPED_TEST(char_adaptation, assign_char)
+{
+    TypeParam l{'A'};
+    EXPECT_TRUE((std::is_same_v<decltype(assign_char(l, 'A')), underlying_char_t<TypeParam> &>));
+    EXPECT_TRUE((std::is_same_v<decltype(assign_char(TypeParam{'A'}, 'A')), underlying_char_t<TypeParam> &&>));
+    EXPECT_EQ((assign_char(TypeParam{'C'}, 'A')), l);
+    EXPECT_EQ((assign_char(l, 'C')), TypeParam{'C'});
+}
+
+TYPED_TEST(char_adaptation, underlying_rank_t)
+{
+    EXPECT_TRUE((std::is_integral_v<underlying_rank_t<TypeParam>>));
+    EXPECT_TRUE((std::is_unsigned_v<underlying_rank_t<TypeParam>>));
+    EXPECT_GE(sizeof(underlying_rank_t<TypeParam>), sizeof(TypeParam));
+}
+
+TYPED_TEST(char_adaptation, to_rank)
+{
+    TypeParam l{'A'};
+    EXPECT_TRUE((std::is_same_v<decltype(to_rank(l)), underlying_rank_t<TypeParam>>));
+    EXPECT_TRUE((std::is_same_v<decltype(to_rank(TypeParam{'A'})), underlying_rank_t<TypeParam>>));
+    EXPECT_EQ(to_rank(TypeParam{'A'}), 65);
+}
+
+TYPED_TEST(char_adaptation, assign_rank)
+{
+    TypeParam l{'A'};
+    EXPECT_TRUE((std::is_same_v<decltype(assign_rank(l, 65)), underlying_char_t<TypeParam> &>));
+    EXPECT_TRUE((std::is_same_v<decltype(assign_rank(TypeParam{'A'}, 65)), underlying_char_t<TypeParam> &&>));
+    EXPECT_EQ((assign_rank(TypeParam{'C'}, 65)), l);
+    EXPECT_EQ((assign_rank(l, 67)), TypeParam{'C'});
+}
+
+TYPED_TEST(char_adaptation, alphabet_size_v)
+{
+    EXPECT_EQ(alphabet_size_v<TypeParam>,
+              (size_t)std::numeric_limits<TypeParam>::max() + 1 - std::numeric_limits<TypeParam>::lowest());
+}

--- a/test/alphabet/adaptation/uint_test.cpp
+++ b/test/alphabet/adaptation/uint_test.cpp
@@ -1,0 +1,100 @@
+// ==========================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ==========================================================================
+//
+// Copyright (c) 2006-2017, Knut Reinert, FU Berlin
+// Copyright (c) 2016-2017, Knut Reinert & MPI Molekulare Genetik
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ==========================================================================
+
+#include <iostream>
+
+#include <gtest/gtest.h>
+
+#include <seqan3/alphabet/adaptation.hpp>
+
+using namespace seqan3;
+
+template <typename T>
+class uint_adaptation : public ::testing::Test
+{};
+
+using uint_types = ::testing::Types<uint8_t, uint16_t, uint32_t>;
+
+TYPED_TEST_CASE(uint_adaptation, uint_types);
+
+TYPED_TEST(uint_adaptation, underlying_rank_t)
+{
+    EXPECT_TRUE((std::is_same_v<underlying_rank_t<TypeParam>, TypeParam>));
+}
+
+TYPED_TEST(uint_adaptation, to_rank)
+{
+    TypeParam l{65};
+    EXPECT_TRUE((std::is_same_v<decltype(to_rank(l)), underlying_rank_t<TypeParam>>));
+    EXPECT_TRUE((std::is_same_v<decltype(to_rank(TypeParam{65})), underlying_rank_t<TypeParam>>));
+    EXPECT_EQ(to_rank(TypeParam{65}), l);
+}
+
+TYPED_TEST(uint_adaptation, assign_rank)
+{
+    TypeParam l{65};
+    EXPECT_TRUE((std::is_same_v<decltype(assign_rank(l, 65)), underlying_rank_t<TypeParam> &>));
+    EXPECT_TRUE((std::is_same_v<decltype(assign_rank(TypeParam{65}, 65)), underlying_rank_t<TypeParam> &&>));
+    EXPECT_EQ((assign_rank(TypeParam{65}, 65)), l);
+    EXPECT_EQ((assign_rank(l, 67)), TypeParam{67});
+}
+
+TYPED_TEST(uint_adaptation, underlying_char_t)
+{
+    EXPECT_TRUE((std::is_integral_v<underlying_rank_t<TypeParam>>));
+    EXPECT_GE(sizeof(underlying_rank_t<TypeParam>), sizeof(TypeParam));
+}
+
+TYPED_TEST(uint_adaptation, to_char)
+{
+    TypeParam l{65};
+    EXPECT_TRUE((std::is_same_v<decltype(to_char(l)), underlying_char_t<TypeParam>>));
+    EXPECT_TRUE((std::is_same_v<decltype(to_char(TypeParam{65})), underlying_char_t<TypeParam>>));
+    EXPECT_EQ(to_rank(TypeParam{65}), 'A');
+}
+
+TYPED_TEST(uint_adaptation, assign_char)
+{
+    TypeParam l{65};
+    EXPECT_TRUE((std::is_same_v<decltype(assign_char(l, 'A')), underlying_rank_t<TypeParam> &>));
+    EXPECT_TRUE((std::is_same_v<decltype(assign_char(TypeParam{'A'}, 'A')), underlying_rank_t<TypeParam> &&>));
+    EXPECT_EQ((assign_char(TypeParam{67}, 'A')), l);
+    EXPECT_EQ((assign_char(l, 'C')), TypeParam{67});
+}
+
+TYPED_TEST(uint_adaptation, alphabet_size_v)
+{
+    EXPECT_EQ(alphabet_size_v<TypeParam>,
+              (size_t)std::numeric_limits<TypeParam>::max() + 1 - std::numeric_limits<TypeParam>::lowest());
+}


### PR DESCRIPTION
Adds adaptations of characters and unsigned integers to our alphabet_concept. This makes it possible to use them in contexts where we rely on `alphabet_size_v` like bitcompressed containers or indexes. It also defines equally sized char types for uint types and vice versa.

**A noteworthy structural decision:**
If alphabets implement their interface via free functions instead of members, than these need to be defined before including `alphabet/concept.hpp`, otherwise the concept definition and constrained templates won't resolve them correctly. 
There are two ways to resolve this:
  1. make extra files with only struct and function forwards, include these inside `concept.hpp`
  2. enforce the correct include order.

Since the first is kind of ugly and destroys the nice encapsulation of the submodules, I decided to go for the second solution. It is documented than one shall include `adaptation.hpp` before `concept.hpp`, the natural (alphabetic) order implies this, as well, and I added small hacks to the files that immediately give a readable error if someone messes up the include order.
Seeing that this is the only submodule where this is necessary and it is also only really used inside other library code and not manually included, I think this solution is the superior one. 

@marehr contains small changes to the test system, do you agree? We can later adapt this solution to the other tests, as well, but I didn't want to got out-of-scope with this PR.