### PR TITLE
Feature/add range module

### DIFF
--- a/include/seqan3/range.hpp
+++ b/include/seqan3/range.hpp
@@ -1,0 +1,70 @@
+// ============================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ============================================================================
+//
+// Copyright (c) 2006-2017, Knut Reinert & Freie Universitaet Berlin
+// Copyright (c) 2016-2017, Knut Reinert & MPI Molekulare Genetik
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ============================================================================
+
+/*!\file range.hpp
+ * \ingroup range
+ * \brief Meta-header for the \link range range module \endlink.
+ * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <seqan3/range/concept.hpp>
+#include <seqan3/range/action.hpp>
+#include <seqan3/range/container.hpp>
+#include <seqan3/range/view.hpp>
+
+/*!\defgroup range Range
+ * \brief The range module contains containers, views and actions.
+ *
+ * *Ranges* are an abstraction of "a collection of items", or "something iterable". The most basic definition
+ * requires only the existence of begin() and end() on the range. See range/concept.hpp for the different range
+ * concepts.
+ *
+ * *Containers* are ranges that own their elements. SeqAn3 makes use of standard STL containers like std::vector,
+ * but also implements some custom containers. See range/container.hpp for more details.
+ *
+ * *Views* are "lazy range combinators" that provide operations on other ranges, e.g. containers, but do so on-demand,
+ * i.e. views don't own elements, but return (mutated) elements on request. This is similar to how iterators can
+ * provide different behaviours on the same underlying data structure (while not actually changing it). See
+ * range/view.hpp for more details.
+ *
+ * *Actions* on the other hand are "eager range combinators", i.e. they immediately change the underlying range
+ * they are applied to. See range/action.hpp for more details.
+ *
+ * Both views and actions can be chained via the pipe operator.
+ *
+ * \sa range.hpp
+ * \sa https://ericniebler.github.io/range-v3/index.html
+ */

--- a/include/seqan3/range/action.hpp
+++ b/include/seqan3/range/action.hpp
@@ -1,0 +1,83 @@
+// ============================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ============================================================================
+//
+// Copyright (c) 2006-2017, Knut Reinert & Freie Universitaet Berlin
+// Copyright (c) 2016-2017, Knut Reinert & MPI Molekulare Genetik
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ============================================================================
+
+/*!\file range/action.hpp
+ * \ingroup action
+ * \brief Meta-header for the \link action action submodule \endlink.
+ * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
+ */
+
+#pragma once
+
+/*!\defgroup action Action
+ * \brief Actions are "eager range combinators" that modify ranges in-place.
+ * \ingroup range
+ * \sa https://ericniebler.github.io/range-v3/index.html#range-actions
+ * \sa range/action.hpp
+ *
+ * SeqAn3 makes use of actions as defined in the
+ * [Ranges Technical Specification](http://en.cppreference.com/w/cpp/experimental/ranges). Currently the
+ * implementation is based on the [range-v3 library](https://github.com/ericniebler/range-v3) and all those actions
+ * are available in the namespace ranges::action, see
+ * [the overview](https://ericniebler.github.io/range-v3/index.html#range-actions) for more details.
+ *
+ * This submodule provides additional actions, specifically for operations on biological data and
+ * sequence analysis.
+ *
+ * \attention
+ * To prevent naming conflicts, all SeqAn actions are inside the namespace seqan3::action.
+ *
+ * \par Example
+ *
+ * ```cpp
+ * dna4_vector vec{"ACGGTC"_dna4};
+ * vec |= action::complement;                           // == "TGCCAG"
+ * vec |= ranges::action::reverse;                      // == "GACCGT"
+ *
+ * // or in one line:
+ * vec = "ACGGTC"_dna4;                                 // == "ACGGTC"
+ * vec |= action::complement | ranges::action::reverse; // == "GACCGT"
+ * ```
+ */
+
+/*!
+ * \namespace seqan3::action
+ * \brief The SeqAn3 namespace for actions.
+ * \sa action
+ *
+ * Since actions often have name clashes with regular functions and views they are implemented in the sub
+ * namespace `action`.
+ *
+ * See the \link action action submodule \endlink of the range module for more details.
+ */

--- a/include/seqan3/range/concept.hpp
+++ b/include/seqan3/range/concept.hpp
@@ -32,15 +32,15 @@
 //
 // ============================================================================
 
+/*!\file range/concept.hpp
+ * \brief Adaptations of concepts from the Ranges TS
+ * \ingroup range
+ * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
+ */
+
 #pragma once
 
 #include <range/v3/range_concepts.hpp>
-
-/*!\file core/concept/range.hpp
- * \brief Adaptations of concepts from the Ranges TS
- * \ingroup core
- * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
- */
 
 namespace seqan3
 {
@@ -52,12 +52,6 @@ template <typename type>
 concept bool range_concept               = (bool)ranges::Range<type>();
 
 /* these are independent specializations of range_concept */
-
-/*! resolves to `ranges::View<type>()`
- * \sa http://en.cppreference.com/w/cpp/experimental/ranges/iterator/View
- */
-template <typename type>
-concept bool view_concept                = range_concept<type> && (bool)ranges::View<type>();
 
 /*! resolves to `ranges::SizedRange<type>()`
  * \sa http://en.cppreference.com/w/cpp/experimental/ranges/iterator/SizedRange

--- a/include/seqan3/range/concept.hpp
+++ b/include/seqan3/range/concept.hpp
@@ -44,8 +44,13 @@
 
 namespace seqan3
 {
-
-/*! resolves to `ranges::Range<type>()`
+/*!\name Range concepts
+ * \brief Adapted from the Ranges TS.
+ * \ingroup range
+ * \{
+ */
+/*!\brief Defines the requirements of a type that allows iteration over its elements by providing a begin iterator
+ * and an end sentinel.
  * \sa http://en.cppreference.com/w/cpp/experimental/ranges/iterator/Range
  */
 template <typename type>
@@ -53,51 +58,56 @@ concept bool range_concept               = (bool)ranges::Range<type>();
 
 /* these are independent specializations of range_concept */
 
-/*! resolves to `ranges::SizedRange<type>()`
+/*!\brief Specifies the requirements of a Range type that knows its size in constant time with the size function.
  * \sa http://en.cppreference.com/w/cpp/experimental/ranges/iterator/SizedRange
  */
 template <typename type>
 concept bool sized_range_concept         = range_concept<type> && (bool)ranges::SizedRange<type>();
 
-/*! resolves to `ranges::BoundedRange<type>()`
+/*!\brief Specifies requirements of a Range type for which `begin` and `end` return objects of the same type.
  * \sa http://en.cppreference.com/w/cpp/experimental/ranges/iterator/BoundedRange
  */
 template <typename type>
 concept bool bounded_range_concept       = range_concept<type> && (bool)ranges::BoundedRange<type>();
 
-/*! resolves to `ranges::OutputRange<type>()`
+/*!\brief Specifies requirements of a Range type for which `begin` returns a type that satisfies
+ * seqan3::output_iterator_concept.
  * \sa http://en.cppreference.com/w/cpp/experimental/ranges/iterator/OutputRange
  */
 template <typename type, typename out_type>
 concept bool output_range_concept        = range_concept<type> && (bool)ranges::OutputRange<type, out_type>();
 
-
 /* the following specialize incrementally */
 
-/*! resolves to `ranges::InputRange<type>()`
+/*!\brief Specifies requirements of an Range type for which `begin` returns a type that satisfies
+ * seqan3::input_iterator_concept.
  * \sa http://en.cppreference.com/w/cpp/experimental/ranges/iterator/InputRange
  */
 template <typename type>
 concept bool input_range_concept         = range_concept<type> && (bool)ranges::InputRange<type>();
 
-/*! resolves to `ranges::ForwardRange<type>()`
+/*!\brief Specifies requirements of an Range type for which `begin` returns a type that satisfies
+ * seqan3::forward_iterator_concept.
  * \sa http://en.cppreference.com/w/cpp/experimental/ranges/iterator/ForwardRange
  */
 template <typename type>
 concept bool forward_range_concept       = input_range_concept<type> && (bool)ranges::ForwardRange<type>();
 
-/*! resolves to `ranges::BidirectionalRange<type>()`
+/*!\brief Specifies requirements of an Range type for which `begin` returns a type that satisfies
+ * seqan3::bidirectional_iterator_concept.
  * \sa http://en.cppreference.com/w/cpp/experimental/ranges/iterator/BidirectionalRange
  */
 template <typename type>
 concept bool bidirectional_range_concept = forward_range_concept<type> && (bool)ranges::BidirectionalRange<type>();
 
-/*! resolves to `ranges::RandomAccessRange<type>()`
+/*!\brief Specifies requirements of an Range type for which `begin` returns a type that satisfies
+ * seqan3::random_access_iterator_concept.
  * \sa http://en.cppreference.com/w/cpp/experimental/ranges/iterator/RandomAccessRange
  */
 template <typename type>
 concept bool random_access_range_concept = bidirectional_range_concept<type> && (bool)ranges::RandomAccessRange<type>();
 
+//!\}
 } // namespace seqan3
 
 #ifndef NDEBUG

--- a/include/seqan3/range/container.hpp
+++ b/include/seqan3/range/container.hpp
@@ -1,0 +1,50 @@
+// ============================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ============================================================================
+//
+// Copyright (c) 2006-2017, Knut Reinert & Freie Universitaet Berlin
+// Copyright (c) 2016-2017, Knut Reinert & MPI Molekulare Genetik
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ============================================================================
+
+/*!\file range/container.hpp
+ * \ingroup container
+ * \brief Meta-header for the \link container container submodule \endlink.
+ * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <seqan3/range/container/concept.hpp>
+
+/*!\defgroup container Container
+ * \brief The container submodule contains special SeqAn3 containers and generic container concepts.
+ * \ingroup range
+ * \sa http://en.cppreference.com/w/cpp/container
+ * \sa range/container.hpp
+ */

--- a/include/seqan3/range/container/concept.hpp
+++ b/include/seqan3/range/container/concept.hpp
@@ -36,9 +36,9 @@
 
 #include <initializer_list>
 
-/*! \file core/concept/stl_container.hpp
- * \brief Adaptations of concepts from the standard library
- * \ingroup core
+/*!\file range/container/concept.hpp
+ * \brief Adaptations of concepts from the standard library.
+ * \ingroup container
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  */
 

--- a/include/seqan3/range/view.hpp
+++ b/include/seqan3/range/view.hpp
@@ -1,0 +1,83 @@
+// ============================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ============================================================================
+//
+// Copyright (c) 2006-2017, Knut Reinert & Freie Universitaet Berlin
+// Copyright (c) 2016-2017, Knut Reinert & MPI Molekulare Genetik
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ============================================================================
+
+/*!\file range/view.hpp
+ * \ingroup view
+ * \brief Meta-header for the \link view view submodule \endlink.
+ * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <seqan3/range/view/concept.hpp>
+
+/*!\defgroup view View
+ * \brief Views are "lazy range combinators" that offer modified views onto other ranges.
+ * \ingroup range
+ * \sa https://ericniebler.github.io/range-v3/index.html#range-views
+ * \sa range/view.hpp
+ *
+ * SeqAn3 makes heavy use of views as defined in the
+ * [Ranges Technical Specification](http://en.cppreference.com/w/cpp/experimental/ranges). Currently the
+ * implementation is based on the [range-v3 library](https://github.com/ericniebler/range-v3) and all those views
+ * are available in the namespace ranges::view, see
+ * [the overview](https://ericniebler.github.io/range-v3/index.html#range-views) for more details.
+ *
+ * This submodule provides additional views, specifically for operations on biological data and
+ * sequence analysis.
+ *
+ * \attention
+ * To prevent naming conflicts, all SeqAn views are inside the namespace seqan3::view.
+ *
+ * \par Example
+ *
+ * ```cpp
+ * dna4_vector vec{"ACGGTC"_dna4};
+ * auto vec_view  = vec | view::complement;                         // == "TGCCAG" (but doesn't own any data)
+ * auto vec_view2 = vec | ranges::view::reverse;                    // == "CTGGCA" (but doesn't own any data)
+ *
+ * // or in one line:
+ * auto vec_view3 = vec | view::complement | ranges::view::reverse; // == "GACCGT" (but doesn't own any data)
+ * ```
+ */
+
+/*!
+ * \namespace seqan3::view
+ * \brief The SeqAn3 namespace for views.
+ *
+ * Since views often have name clashes with regular functions and ranges they are implemented in the sub
+ * namespace `view`.
+ *
+ * See the \link view view submodule \endlink of the range module for more details.
+ */

--- a/include/seqan3/range/view/concept.hpp
+++ b/include/seqan3/range/view/concept.hpp
@@ -1,0 +1,59 @@
+// ============================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ============================================================================
+//
+// Copyright (c) 2006-2017, Knut Reinert & Freie Universitaet Berlin
+// Copyright (c) 2016-2017, Knut Reinert & MPI Molekulare Genetik
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ============================================================================
+
+/*!\file range/view/concept.hpp
+ * \brief Adaptation of the view concept from the Ranges TS.
+ * \ingroup view
+ * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <seqan3/range/concept.hpp>
+
+namespace seqan3
+{
+
+/*!\brief Specifies the requirements of a Range type that has constant time copy, move and assignment operators.
+ * \sa http://en.cppreference.com/w/cpp/experimental/ranges/iterator/View
+ */
+template <typename type>
+concept bool view_concept = range_concept<type> && (bool)ranges::View<type>();
+
+} // namespace seqan3
+
+#ifndef NDEBUG
+#include <range/v3/view/any_view.hpp>
+static_assert(seqan3::view_concept<ranges::any_random_access_view<char>>);
+#endif


### PR DESCRIPTION
This add the range module which has submodules for containers, actions and views. This PR is mostly skeleton code for the module, but already contains much improved documentation. It also moves the concepts for these types to the new module, as is in the alphabet module ("only things in core that fit nowhere else").
Also cleans up container concept definitions to be like formally in the STL, drops "sequence_light_concept" that we invented.