### PR TITLE
[FEATURE,TEST] fix down-conversion of nucl16; don't hardcode conversi…

### DIFF
--- a/include/seqan3/alphabet/nucleotide.hpp
+++ b/include/seqan3/alphabet/nucleotide.hpp
@@ -49,6 +49,49 @@
  * \brief Contains the different DNA and RNA alphabet types.
  * \ingroup alphabet
  *
+ * \par Introduction
+ *
+ * Nucleotide sequences are at the core of most bioinformatic data processing and while it is possible
+ * to represent them in a regular std::string, it makes sense to have specialised data structures in most cases.
+ * This sub-module offers multiple nucleotide alphabets that can be used with regular container and ranges.
+ *
+ * | Letter   | Description     | seqan3::nucl16 | seqan3::dna5 | seqan3::dna4 | seqan3::rna5 | seqan3::rna4 |
+ * |:--------:|-----------------|:--------------:|:------------:|:------------:|:------------:|:------------:|
+ * |   A      | Adenine         |      ☑         |      ☑       |      ☑       |      ☑       |      ☑       |
+ * |   C      | Cytosine        |      ☑         |      ☑       |      ☑       |      ☑       |      ☑       |
+ * |   G      | Guanine         |      ☑         |      ☑       |      ☑       |      ☑       |      ☑       |
+ * |   T      | Thymine (DNA)   |      ☑         |      ☑       |      ☑       |      ☐       |      ☐       |
+ * |   U      | Uracil (RNA)    |      ☑         |      ☐       |      ☐       |      ☑       |      ☑       |
+ * |   R      | A *or* G        |      ☑         |      ☐       |      ☐       |      ☐       |      ☐       |
+ * |   Y      | C *or* T        |      ☑         |      ☐       |      ☐       |      ☐       |      ☐       |
+ * |   S      | G *or* C        |      ☑         |      ☐       |      ☐       |      ☐       |      ☐       |
+ * |   W      | A *or* T        |      ☑         |      ☐       |      ☐       |      ☐       |      ☐       |
+ * |   K      | G *or* T        |      ☑         |      ☐       |      ☐       |      ☐       |      ☐       |
+ * |   M      | A *or* C        |      ☑         |      ☐       |      ☐       |      ☐       |      ☐       |
+ * |   B      | C *or* G *or* T |      ☑         |      ☐       |      ☐       |      ☐       |      ☐       |
+ * |   D      | A *or* G *or* T |      ☑         |      ☐       |      ☐       |      ☐       |      ☐       |
+ * |   H      | A *or* C *or* T |      ☑         |      ☐       |      ☐       |      ☐       |      ☐       |
+ * |   V      | A *or* C *or* G |      ☑         |      ☐       |      ☐       |      ☐       |      ☐       |
+ * |   N      | any base        |      ☑         |      ☑       |      ☐       |      ☑       |      ☐       |
+ * | **Size** |                 |     16         |      5       |      4       |      5       |      4       |
+ *
+ * Keep in mind, that while we think of "the nucleotide alphabet" as consisting of four bases, there are indeed
+ * more characters defined with different levels of ambiguity. Depending on your application it will make sense
+ * to preserve this ambiguity or to discard it to save space and/or optimise computations.
+ * SeqAn offers five distinct nucleotide alphabet types to accommodate for this.
+ *
+ * For seqan3::nucl16 there are also the following aliases (typedefs): `dna16, rna16, dna, rna`
+ *
+ * The specialised RNA alphabets are provided for convenience, however the DNA alphabets provide a `::U` member
+ * and can handle being assigned and `'U'` character, as well. See below for the details.
+ *
+ * Which alphabet to chose?
+ *   1. in most cases, take seqan3::nucl16
+ *   2. if you are memory constrained and sequence data is actually the main memory consumer, use seqan3::dna5
+ *   3. if you use specialised algorithms that profit from a 2-bit representation, use seqan3::dna4
+ *   4. if 2. or 3. and you are doing only RNA input/output, use seqan3::rna5 or seqan3::rna4
+ *   5. to actually save space from using smaller alphabets, you need a compressed container (TODO link)
+ *
  * \par Concept
  *
  * The nucleotide submodule defines seqan3::nucleotide_concept which encompasses all the alphabets defined in the
@@ -64,29 +107,53 @@
  *     // ...
  * ~~~
  *
- * \par Alphabets
+ * All alphabets define at least the letters `::A`, `::C`, `::G`, `::T`, `::U`, `::UNKNOWN` (although some might be
+ * aliases of others).
  *
- * The nucleotide module contains alphabet data types for nucleic acids. The types differ mainly
- * in their size and how they treat the T and U bases:
+ * \par Printing and conversion to char
  *
- * | Alphabet       | Aliases                | Size | 'T' | 'U' | `UNKNOWN` |
- * |----------------|------------------------|------|-----|-----|-----------|
- * |   seqan3::dna4 |                        |    4 |  ☑  |  ☐  |       'A' |
- * |   seqan3::rna4 |                        |    4 |  ☐  |  ☑  |       'A' |
- * |   seqan3::dna5 |                        |    5 |  ☑  |  ☐  |       'N' |
- * |   seqan3::rna5 |                        |    5 |  ☐  |  ☑  |       'N' |
- * | seqan3::nucl16 | dna16, rna16, dna, rna |   16 |  ☑  |  ☑  |       'N' |
  *
- * The default and recommended alphabet is seqan3::nucl16. It can contain all the IUPAC symbols for nucleic acid data.
- * The other alphabets are smaller representations that are especially useful inside compressed containers (TODO link).
+ * | to_char()      | seqan3::nucl16 | seqan3::dna5 | seqan3::dna4 | seqan3::rna5 | seqan3::rna4 |
+ * |:--------------:|:--------------:|:------------:|:------------:|:------------:|:------------:|
+ * | type::A        |    `'A'`       |    `'A'`     |    `'A'`     |    `'A'`     |    `'A'`     |
+ * |   ...          |    ...         |    ...       |    ...       |    ...       |    ...       |
+ * | type::T        |    `'T'`       |    `'T'`     |    `'T'`     |    `'U'`     |    `'U'`     |
+ * | type::U        |    `'U'`       |    `'T'`     |    `'T'`     |    `'U'`     |    `'U'`     |
+ * | type::R        |    `'R'`       |     ---      |    ---       |     ---      |     ---      |
+ * |   ...          |    ...         |     ---      |    ---       |     ---      |     ---      |
+ * | type::N        |    `'N'`       |    `'N'`     |    ---       |    `'N'`     |     ---      |
+ * | type::UNKNOWN  |    `'N'`       |    `'N'`     |    `'A'`     |    `'N'`     |    `'A'`     |
  *
- * In the smaller alphabets `T` and `U` are represented by the same rank and you cannot differentiate between them,
- * they are, however, converted into each other and not to the `UNKNOWN` character. i.e. you can use seqan3::dna5 to
- * represent RNA data, as well, the only difference is the output when calling to_char().
+ * In the smaller alphabets `T` and `U` are represented by the same rank and you cannot differentiate between them
+ * (the static members `::T` and `::U` are synonymous). The only difference between e.g. seqan3::dna4 and
+ * seqan3::rna4 is the output when calling to_char().
  *
- * \par Conversion
+ * \par Assignment and Conversion
  *
  *   * seqan3::dna4 ↔ seqan3::rna4, as well as seqan3::dna5 ↔ seqan3::rna5 are directly assignable to each other.
- *   * All nucleotide alphabets are convertible to each other via convert().
+ *   * All nucleotide alphabets are convertible to each other, as well as from their `char` and rank types via
+ *     seqan3::convert(), although the behaviour depends on the type, see below.
  *   * All ranges of nucleotide alphabets are convertible to each other via seqan3::view::convert.
+ *
+ * | assign_char() | seqan3::nucl16 | seqan3::dna5  | seqan3::dna4  | seqan3::rna5 | seqan3::rna4  |
+ * |:-------------:|:--------------:|:-------------:|:-------------:|:------------:|:-------------:|
+ * |   `'A'`       |  nucl16::A     |  dna5::A      | dna4::A       |  rna5::A     | rna4::A       |
+ * |   ...         |    ...         |    ...        | ...           |    ...       |     ...       |
+ * |   `'T'`       |  nucl16::T     |  dna5::T ¹    | dna4::T ¹     |  rna5::T ¹   | rna4::T ¹     |
+ * |   `'U'`       |  nucl16::U     |  dna5::T ¹    | dna4::T ¹     |  rna5::T ¹   | rna4::T ¹     |
+ * |   `'R'`       |  nucl16::R     |  dna5::N ²    | dna4::A ³     |  rna5::N ²   | rna4::A ³     |
+ * |   `'Y'`       |  nucl16::Y     |  dna5::N ²    | dna4::C ³     |  rna5::N ²   | rna4::C ³     |
+ * |   ...         |    ...         |  dna5::N ²    | ... ³         |  rna5::N ²   | ... ³         |
+ * |   `'N'`       |  nucl16::N     |  dna5::N ²    | dna4::A ³     |  rna5::N ²   | rna4::A ³     |
+ * | e.g. `'!'`    |  nucl16::N     |  dna5::N ²    | dna4::A ²     |  rna5::N ²   | rna4::A ²     |
+ *
+ * ¹ same as `type::U`<br>
+ * ² same as `type::UNKNOWN`<br>
+ * ³ the first character in the ambiguous set
+ *
+ * When converting from `char` or a larger nucleotide alphabet to smaller one, *loss of information* can occur since
+ * obviously some bases are not available. When converting to seqan3::dna5 or seqan3::rna5, non-canonical
+ * bases (letters other than A, C, G, T, U) are converted to `'N'` to preserve ambiguity at that position, while
+ * for seqan3::dna4 and seqan3::rna4 they are converted to the first of the possibilities they represent (because
+ * there is no letter `'N'` to represent ambiguity).
  */

--- a/include/seqan3/alphabet/nucleotide/dna4.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna4.hpp
@@ -193,86 +193,40 @@ protected:
     };
 
     //!\brief Char to value conversion table.
-    static constexpr internal_type char_to_value[256]
+    static constexpr std::array<internal_type, 256> char_to_value
     {
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, //15
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, //31
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, //47
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, //63
-        //              ,                      A,                      B,                      C,
-        internal_type::UNKNOWN, internal_type::A,       internal_type::UNKNOWN, internal_type::C,
-        //             D,                      E,                      F,                      G,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::G,
-        //             H,                      I,                      J,                      K,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        //             L,                      M,                      N,                      O,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, //79
-        //             P,                      Q,                      R,                      S,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        //             T,                      U,                      V,                      W,
-        internal_type::T,       internal_type::T,       internal_type::UNKNOWN, internal_type::UNKNOWN,
-        //             X,                      Y,                      Z,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, //95
-        //              ,                      a,                      b,                      c,
-        internal_type::UNKNOWN, internal_type::A,       internal_type::UNKNOWN, internal_type::C,
-        //             d,                      e,                      f,                      g,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::G,
-        //             h,                      i,                      j,                      k,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        //             l,                      m,                      n,                      o,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, //111
-        //             p,                      q,                      r,                      s,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        //             t,                      u,                      v,                      w,
-        internal_type::T,       internal_type::T,       internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, //127
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, //143
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, //159
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, //175
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, //191
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, //207
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, //223
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, //239
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN  //255
+        [] () constexpr
+        {
+            using in_t = internal_type;
+            std::array<in_t, 256> ret{};
+
+            // initialize with UNKNOWN (std::array::fill unfortunately not constexpr)
+            for (auto & c : ret)
+                c = in_t::UNKNOWN;
+
+            // canonical
+            ret['A'] = in_t::A; ret['a'] = in_t::A;
+            ret['C'] = in_t::C; ret['c'] = in_t::C;
+            ret['G'] = in_t::G; ret['g'] = in_t::G;
+            ret['T'] = in_t::T; ret['t'] = in_t::T;
+            ret['U'] = in_t::U; ret['u'] = in_t::U;
+
+            // iupac characters get special treatment, because there is no N
+            ret['R'] = in_t::A; ret['r'] = in_t::A; // or G
+            ret['Y'] = in_t::C; ret['y'] = in_t::C; // or T
+            ret['S'] = in_t::C; ret['s'] = in_t::C; // or G
+            ret['W'] = in_t::A; ret['w'] = in_t::A; // or T
+            ret['K'] = in_t::G; ret['k'] = in_t::G; // or T
+            ret['M'] = in_t::A; ret['m'] = in_t::A; // or T
+            ret['B'] = in_t::C; ret['b'] = in_t::C; // or G or T
+            ret['D'] = in_t::A; ret['d'] = in_t::A; // or G or T
+            ret['H'] = in_t::A; ret['h'] = in_t::A; // or C or T
+            ret['V'] = in_t::A; ret['v'] = in_t::A; // or C or G
+
+            return ret;
+        }()
     };
+
 public:
     //!\privatesection
     //!\brief The data member.

--- a/include/seqan3/alphabet/nucleotide/dna5.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna5.hpp
@@ -197,87 +197,29 @@ protected:
     };
 
     //!\brief Char to value conversion table.
-    static constexpr internal_type char_to_value[256]
+    static constexpr std::array<internal_type, 256> char_to_value
     {
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,//3
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,//23
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,//43
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,//63
-        //                      A,                      B,                      C
-        internal_type::UNKNOWN, internal_type::A,       internal_type::UNKNOWN, internal_type::C,
-        //D,                    E,                      F,                      G,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::G,
-        //H,                    I,                      J,                      K,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        //L,                    M,                      N,                      O,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::N,       internal_type::UNKNOWN,
-        //P,                    Q,                      R,                      S,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,//83
-        //T,                    U,                      V,                      W,
-        internal_type::T,       internal_type::T,       internal_type::UNKNOWN, internal_type::UNKNOWN,
-        //X,                    Y,                      Z
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        //                      a,                      b,                      c,
-        internal_type::UNKNOWN, internal_type::A,       internal_type::UNKNOWN, internal_type::C,
-        //d,                    e,                      f,                      g,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::G,//103
-        //h,                    i,                      j,                      k,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        //l,                    m,                      n,                      o,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::N,       internal_type::UNKNOWN,
-        //p,                    q,                      r,                      s,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        //t,                    u,                      v,                      w,
-        internal_type::T,       internal_type::T,       internal_type::UNKNOWN, internal_type::UNKNOWN,
-        //x,             y,               z
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,//123
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,//143
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,//163
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,//183
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,//203
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,//223
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,//243
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN
+        [] () constexpr
+        {
+            using in_t = internal_type;
+            std::array<in_t, 256> ret{};
+
+            // initialize with UNKNOWN (std::array::fill unfortunately not constexpr)
+            for (auto & c : ret)
+                c = in_t::UNKNOWN;
+
+            // canonical
+            ret['A'] = in_t::A; ret['a'] = in_t::A;
+            ret['C'] = in_t::C; ret['c'] = in_t::C;
+            ret['G'] = in_t::G; ret['g'] = in_t::G;
+            ret['T'] = in_t::T; ret['t'] = in_t::T;
+            ret['U'] = in_t::U; ret['u'] = in_t::U;
+
+            // iupac characters are implicitly "UNKNOWN"
+            return ret;
+        }()
     };
+
 public:
     //!\privatesection
     //!\brief The data member.

--- a/include/seqan3/alphabet/nucleotide/nucl16.hpp
+++ b/include/seqan3/alphabet/nucleotide/nucl16.hpp
@@ -227,87 +227,40 @@ protected:
     };
 
     //!\brief Char to value conversion table.
-    static constexpr internal_type char_to_value[256]
+    static constexpr std::array<internal_type, 256> char_to_value
     {
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        //                      A,                      B,                      C,
-        internal_type::UNKNOWN, internal_type::A,       internal_type::B,       internal_type::C,
-        //D,                    E,                      F,                      G,
-        internal_type::D,       internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::G,
-        //H,                    I,                      J,                      K,
-        internal_type::H,       internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::K,
-        //L,                    M,                      N,                      O,
-        internal_type::UNKNOWN, internal_type::M,       internal_type::N,       internal_type::UNKNOWN,
-        //P,                    Q,                      R,                      S,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::R,       internal_type::S,
-        //T,                    U,                      V,                      W,
-        internal_type::T,       internal_type::U,       internal_type::V,       internal_type::W,
-        //X,                    Y,                      Z
-        internal_type::UNKNOWN, internal_type::Y,       internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        //                      a,                      b,                      c,
-        internal_type::UNKNOWN, internal_type::A,       internal_type::B,       internal_type::C,
-        //d,                    e,                      f,                      g,
-        internal_type::D,       internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::G,
-        //h,                    i,                      j,                      k,
-        internal_type::H,       internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::K,
-        //l,                    m,                      n,                      o,
-        internal_type::UNKNOWN, internal_type::M,       internal_type::N,       internal_type::UNKNOWN,
-        //p,                    q,                      r,                      s,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::R,       internal_type::S,
-        //t,                    u,                      v,                      w,
-        internal_type::T,       internal_type::U,       internal_type::V,       internal_type::W,
-        //x,                    y,                      z
-        internal_type::UNKNOWN, internal_type::Y,       internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN,
-        internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN, internal_type::UNKNOWN
+        [] () constexpr
+        {
+            using in_t = internal_type;
+            std::array<in_t, 256> ret{};
+
+            // initialize with UNKNOWN (std::array::fill unfortunately not constexpr)
+            for (auto & c : ret)
+                c = in_t::UNKNOWN;
+
+            // canonical
+            ret['A'] = in_t::A; ret['a'] = in_t::A;
+            ret['C'] = in_t::C; ret['c'] = in_t::C;
+            ret['G'] = in_t::G; ret['g'] = in_t::G;
+            ret['T'] = in_t::T; ret['t'] = in_t::T;
+            ret['U'] = in_t::U; ret['u'] = in_t::U;
+
+            // iupac characters
+            ret['R'] = in_t::R; ret['r'] = in_t::R;
+            ret['Y'] = in_t::Y; ret['y'] = in_t::Y;
+            ret['S'] = in_t::S; ret['s'] = in_t::S;
+            ret['W'] = in_t::W; ret['w'] = in_t::W;
+            ret['K'] = in_t::K; ret['k'] = in_t::K;
+            ret['M'] = in_t::M; ret['m'] = in_t::M;
+            ret['B'] = in_t::B; ret['b'] = in_t::B;
+            ret['D'] = in_t::D; ret['d'] = in_t::D;
+            ret['H'] = in_t::H; ret['h'] = in_t::H;
+            ret['V'] = in_t::V; ret['v'] = in_t::V;
+            ret['N'] = in_t::N; ret['n'] = in_t::N;
+            return ret;
+        }()
     };
+
 public:
     //!\privatesection
     //!\brief The data member.

--- a/test/alphabet/nucleotide_test.cpp
+++ b/test/alphabet/nucleotide_test.cpp
@@ -32,8 +32,11 @@
 //
 // ==========================================================================
 
-#include <gtest/gtest.h>
 #include <sstream>
+
+#include <gtest/gtest.h>
+
+#include <range/v3/view/zip.hpp>
 
 #include <seqan3/alphabet/nucleotide.hpp>
 
@@ -62,12 +65,51 @@ TYPED_TEST(nucleotide, static_members)
 
 TYPED_TEST(nucleotide, assign_char)
 {
-    EXPECT_EQ((assign_char(TypeParam{}, 'A')), TypeParam::A);
-    EXPECT_EQ((assign_char(TypeParam{}, 'C')), TypeParam::C);
-    EXPECT_EQ((assign_char(TypeParam{}, 'G')), TypeParam::G);
-    EXPECT_EQ((assign_char(TypeParam{}, 'T')), TypeParam::T);
-    EXPECT_EQ((assign_char(TypeParam{}, 'U')), TypeParam::U);
-    EXPECT_EQ((assign_char(TypeParam{}, '!')), TypeParam::UNKNOWN);
+    using t = TypeParam;
+    std::vector<char> input
+    {
+        'A', 'C', 'G', 'T', 'U', 'N',
+        'a', 'c', 'g', 't', 'u', 'n',
+        'R', 'Y', 'S', 'W', 'K', 'M', 'B', 'D', 'H', 'V',
+        'r', 'y', 's', 'w', 'k', 'm', 'b', 'd', 'h', 'v',
+        '!'
+    };
+
+    std::vector<TypeParam> cmp;
+    if constexpr (std::is_same_v<TypeParam, dna4> || std::is_same_v<TypeParam, rna4>)
+    {
+        cmp =
+        {
+            t::A, t::C, t::G, t::T, t::U, t::A,
+            t::A, t::C, t::G, t::T, t::U, t::A,
+            t::A, t::C, t::C, t::A, t::G, t::A, t::C, t::A, t::A, t::A,
+            t::A, t::C, t::C, t::A, t::G, t::A, t::C, t::A, t::A, t::A,
+            t::A
+        };
+    } else if constexpr (std::is_same_v<TypeParam, dna5> || std::is_same_v<TypeParam, rna5>)
+    {
+        cmp =
+        {
+            t::A, t::C, t::G, t::T, t::U, t::N,
+            t::A, t::C, t::G, t::T, t::U, t::N,
+            t::N, t::N, t::N, t::N, t::N, t::N, t::N, t::N, t::N, t::N,
+            t::N, t::N, t::N, t::N, t::N, t::N, t::N, t::N, t::N, t::N,
+            t::N
+        };
+    } else if constexpr (std::is_same_v<TypeParam, nucl16>)
+    {
+        cmp =
+        {
+            t::A, t::C, t::G, t::T, t::U, t::N,
+            t::A, t::C, t::G, t::T, t::U, t::N,
+            t::R, t::Y, t::S, t::W, t::K, t::M, t::B, t::D, t::H, t::V,
+            t::R, t::Y, t::S, t::W, t::K, t::M, t::B, t::D, t::H, t::V,
+            t::N
+        };
+    }
+
+    for (auto [ ch, cm ] : ranges::view::zip(input, cmp))
+        EXPECT_EQ((assign_char(TypeParam{}, ch)), cm);
 }
 
 TYPED_TEST(nucleotide, to_char)
@@ -89,6 +131,17 @@ TYPED_TEST(nucleotide, to_char)
     {
         EXPECT_EQ(to_char(TypeParam::U), 'U');
         EXPECT_EQ(to_char(TypeParam::T), 'T');
+
+        EXPECT_EQ(to_char(TypeParam::R), 'R');
+        EXPECT_EQ(to_char(TypeParam::Y), 'Y');
+        EXPECT_EQ(to_char(TypeParam::S), 'S');
+        EXPECT_EQ(to_char(TypeParam::W), 'W');
+        EXPECT_EQ(to_char(TypeParam::K), 'K');
+        EXPECT_EQ(to_char(TypeParam::M), 'M');
+        EXPECT_EQ(to_char(TypeParam::B), 'B');
+        EXPECT_EQ(to_char(TypeParam::D), 'D');
+        EXPECT_EQ(to_char(TypeParam::H), 'H');
+        EXPECT_EQ(to_char(TypeParam::V), 'V');
     }
 
     if constexpr (std::is_same_v<TypeParam, dna4> || std::is_same_v<TypeParam, rna4>)


### PR DESCRIPTION
* fix down-conversion of nucl16 to smaller cardinality (i.e. non-generic iupac are converted to smallest member, not to unknown)
* remove the hardcoded conversion tables with ones generated from constexpr
* updated tests to include non-canonical letters

@eldariont @sarahet can you review this? (then you are also up-to-date on what the alphabets look like now)
