### PR TITLE
fix error with include inside namespace (aa27)

### DIFF
--- a/include/seqan3/alphabet/aminoacid/aa27.hpp
+++ b/include/seqan3/alphabet/aminoacid/aa27.hpp
@@ -338,13 +338,14 @@ constexpr aa27 aa27::Z{internal_type::Z};
 constexpr aa27 aa27::TERMINATOR{internal_type::TERMINATOR};
 constexpr aa27 aa27::UNKNOWN{aa27::X};
 
+} // namespace seqan3
+
 #ifndef NDEBUGs
 
 #include <seqan3/alphabet/concept.hpp>
 
-static_assert(alphabet_concept<aa27>);
+static_assert(seqan3::alphabet_concept<seqan3::aa27>);
 #endif
-} // namespace seqan3
 
 // ------------------------------------------------------------------
 // containers


### PR DESCRIPTION
Includes should never be inside the seqan3 namespace. The problem was seqan3::seqan3::alphabet_concept and this pr fixes this. 