### PR TITLE
[INTERNAL] rework documentation of union_composition

### DIFF
--- a/include/seqan3/alphabet/composition/union_composition.hpp
+++ b/include/seqan3/alphabet/composition/union_composition.hpp
@@ -160,10 +160,10 @@ public:
     //!\brief The size of the alphabet, i.e. the number of different values it can take.
     static constexpr size_t value_size = alphabet_sum_size_v<alphabet_types...>;
 
-    //!\brief The type of the alphabet when converted to char (e.g. via \link to_char \endlink)
+    //!\brief The type of the alphabet when converted to char (e.g. via \link to_char \endlink).
     using char_type = underlying_char_t<meta::front<meta::list<alphabet_types...>>>;
 
-    //!\brief The type of the alphabet when represented as a number (e.g. via \link to_rank \endlink)
+    //!\brief The type of the alphabet when represented as a number (e.g. via \link to_rank \endlink).
     using rank_type = detail::min_viable_uint_t<value_size>;
 
     /*!\name Default constructors
@@ -185,7 +185,7 @@ public:
      * \{
      */
 
-    /*!\brief Construction via a value of the base alphabets
+    /*!\brief Construction via a value of the base alphabets.
      * \tparam alphabet_t One of the base alphabet types
      * \param alphabet The value of a base alphabet that should be assigned.
      *
@@ -202,7 +202,7 @@ public:
         _value{rank_by_type_(alphabet)}
     {}
 
-    /*!\brief Construction via a value of reoccurring alphabets
+    /*!\brief Construction via a value of reoccurring alphabets.
      * \tparam I The index of the i-th base alphabet
      * \tparam alphabet_t The i-th given base alphabet type
      * \param alphabet The value of a base alphabet that should be assigned.
@@ -230,7 +230,7 @@ public:
      * \{
      */
 
-    /*!\brief Assignment via a value of the base alphabets
+    /*!\brief Assignment via a value of the base alphabets.
      * \tparam alphabet_t One of the base alphabet types
      * \param alphabet The value of a base alphabet that should be assigned.
      *
@@ -486,19 +486,19 @@ protected:
         return char_to_value;
     }
 
-    //!\brief Compile-time generated lookup table which contains the prefix sum up to the position of each alphabet
+    //!\brief Compile-time generated lookup table which contains the prefix sum up to the position of each alphabet.
     //!\sa alphabet_prefix_sum_sizes
     static constexpr auto prefix_sum_sizes = alphabet_prefix_sum_sizes<alphabet_types...>();
 
-    //!\brief Compile-time generated lookup table which maps the rank to char
+    //!\brief Compile-time generated lookup table which maps the rank to char.
     //!\sa value_to_char_table
     static constexpr auto value_to_char = value_to_char_table();
 
-    //!\brief Compile-time generated lookup table which maps the char to rank
+    //!\brief Compile-time generated lookup table which maps the char to rank.
     //!\sa char_to_value_table
     static constexpr auto char_to_value = char_to_value_table();
 
-    //!\brief Converts an object of one of the given alphabets into the internal representation
+    //!\brief Converts an object of one of the given alphabets into the internal representation.
     //!\tparam index The position of `alphabet_t` in the template pack `alphabet_types`
     //!\tparam alphabet_t One of the base alphabet types
     //!\param alphabet The value of a base alphabet that should be assigned.
@@ -511,7 +511,7 @@ protected:
         return static_cast<rank_type>(prefix_sum_sizes[index] + alphabet.to_rank());
     }
 
-    //!\brief Converts an object of one of the given alphabets into the internal representation
+    //!\brief Converts an object of one of the given alphabets into the internal representation.
     //!\details Finds the index of alphabet_t in the given types.
     //!\tparam alphabet_t One of the base alphabet types
     //!\param alphabet The value of a base alphabet that should be assigned.

--- a/include/seqan3/alphabet/composition/union_composition.hpp
+++ b/include/seqan3/alphabet/composition/union_composition.hpp
@@ -146,13 +146,13 @@ public:
      * ```cpp
      * using union_t = union_composition<dna4, gap>;
      *
-     * static_assert(union_t::has_type<dna4>(), "should be true");
-     * static_assert(union_t::has_type<gap>(), "should be true");
-     * static_assert(!union_t::has_type<dna5>(), "should be false");
+     * static_assert(union_t::has_alternative<dna4>(), "should be true");
+     * static_assert(union_t::has_alternative<gap>(), "should be true");
+     * static_assert(!union_t::has_alternative<dna5>(), "should be false");
      * ```
      */
     template <typename alphabet_t>
-    static constexpr bool has_type() noexcept
+    static constexpr bool has_alternative() noexcept
     {
         return meta::in<meta::list<alphabet_types...>, alphabet_t>::value;
     }
@@ -196,7 +196,7 @@ public:
      */
     template <typename alphabet_t>
     //!\cond
-        requires has_type<alphabet_t>()
+        requires has_alternative<alphabet_t>()
     //!\endcond
     constexpr union_composition(alphabet_t const & alphabet) noexcept :
         _value{rank_by_type_(alphabet)}
@@ -219,7 +219,7 @@ public:
      */
     template <size_t I, typename alphabet_t>
     //!\cond
-        requires has_type<alphabet_t>()
+        requires has_alternative<alphabet_t>()
     //!\endcond
     constexpr union_composition(std::in_place_index_t<I>, alphabet_t const & alphabet) noexcept :
         _value{rank_by_index_<I>(alphabet)}
@@ -241,7 +241,7 @@ public:
      */
     template <typename alphabet_t>
     //!\cond
-        requires has_type<alphabet_t>()
+        requires has_alternative<alphabet_t>()
     //!\endcond
     constexpr union_composition & operator= (alphabet_t const & alphabet) noexcept
     {
@@ -504,7 +504,7 @@ protected:
     //!\param alphabet The value of a base alphabet that should be assigned.
     template <size_t index, typename alphabet_t>
     //!\cond
-        requires has_type<alphabet_t>()
+        requires has_alternative<alphabet_t>()
     //!\endcond
     static constexpr rank_type rank_by_index_(alphabet_t const & alphabet) noexcept
     {
@@ -517,7 +517,7 @@ protected:
     //!\param alphabet The value of a base alphabet that should be assigned.
     template <typename alphabet_t>
     //!\cond
-        requires has_type<alphabet_t>()
+        requires has_alternative<alphabet_t>()
     //!\endcond
     static constexpr rank_type rank_by_type_(alphabet_t const & alphabet) noexcept
     {

--- a/include/seqan3/alphabet/composition/union_composition.hpp
+++ b/include/seqan3/alphabet/composition/union_composition.hpp
@@ -57,6 +57,7 @@ namespace seqan3
 /*!\brief A composition that merges different regular alphabets as a single alphabet.
  * \ingroup composition
  * \tparam ...alphabet_types Types of further letters; must satisfy seqan3::alphabet_concept, e.g. dna4.
+ * \implements seqan3::alphabet_concept
  *
  * The union alphabet represents the union of two or more alphabets (e.g. the
  * four letter DNA alphabet + the gap alphabet). Note that you cannot assign

--- a/include/seqan3/alphabet/composition/union_composition.hpp
+++ b/include/seqan3/alphabet/composition/union_composition.hpp
@@ -127,7 +127,7 @@ protected:
      * \hideinitializer
      *
      * ```cpp
-     * constexpr auto sum = sum_of_alphabet_sizes_v<dna4, gap, dna5>;
+     * constexpr size_t sum = sum_of_alphabet_sizes_v<dna4, gap, dna5>;
      * assert(sum == 10);
      * ```
      */
@@ -135,7 +135,7 @@ protected:
     //!\cond
         requires (alphabet_concept<alphabets_t> && ...)
     //!\endcond
-    static constexpr auto sum_of_alphabet_sizes_v =
+    static constexpr size_t sum_of_alphabet_sizes_v =
         (static_cast<size_t>(alphabet_size_v<alphabets_t>) + ... + static_cast<size_t>(0));
 
     //!\publicsection
@@ -334,7 +334,7 @@ protected:
      * \tparam ...alphabets_t The types must satisfy seqan3::alphabet_concept.
      *
      * ```cpp
-     * constexpr auto max = max_of_alphabet_sizes_v<dna4, gap, dna5>;
+     * constexpr size_t max = max_of_alphabet_sizes_v<dna4, gap, dna5>;
      * assert(max == 5);
      * ```
      */
@@ -342,14 +342,14 @@ protected:
     //!\cond
         requires (alphabet_concept<alphabets_t> && ...)
     //!\endcond
-    static constexpr auto max_of_alphabet_sizes_v =
+    static constexpr size_t max_of_alphabet_sizes_v =
         std::max({static_cast<size_t>(0), static_cast<size_t>(alphabet_size_v<alphabets_t>)...});
 
     /*!\brief Returns an array which contains the prefix sum over all alphabet_types::value_size's.
      * \tparam ...alphabet_types The types must satisfy seqan3::alphabet_concept.
      *
      * ```cpp
-     * constexpr auto partial_sum = partial_sum_of_alphabet_sizes<dna4, gap, dna5>();
+     * constexpr std::array partial_sum = partial_sum_of_alphabet_sizes<dna4, gap, dna5>();
      * assert(partial_sum.size() == 4);
      * assert(partial_sum[0] == 0);
      * assert(partial_sum[1] == 4);
@@ -363,14 +363,14 @@ protected:
     //!\endcond
     static constexpr auto partial_sum_of_alphabet_sizes() noexcept
     {
-        constexpr auto value_size = sum_of_alphabet_sizes_v<alphabets_t...>;
+        constexpr size_t value_size = sum_of_alphabet_sizes_v<alphabets_t...>;
         using rank_t = detail::min_viable_uint_t<value_size>;
 
         constexpr size_t N = sizeof...(alphabets_t) + 1;
         using array_t = std::array<rank_t, N>;
 
         array_t partial_sum{0, alphabet_size_v<alphabets_t>...};
-        for (auto i = 1u; i < N; ++i)
+        for (size_t i = 1u; i < N; ++i)
             partial_sum[i] = static_cast<rank_t>(partial_sum[i] + partial_sum[i-1]);
 
         return partial_sum;
@@ -381,7 +381,7 @@ protected:
      * \sa value_to_char_table
      *
      * ```cpp
-     * constexpr auto table1 = value_to_char_table_I<5, char>(dna4{});
+     * constexpr std::array table1 = value_to_char_table_I<5, char>(dna4{});
      * assert(table1.size() == 5);
      * assert(table1[0] == 'A');
      * assert(table1[1] == 'C');
@@ -407,7 +407,7 @@ protected:
      * alphabet.
      *
      * ```cpp
-     * constexpr auto value_to_char = value_to_char_table<char, dna4, gap, dna5>();
+     * constexpr std::array value_to_char = value_to_char_table<char, dna4, gap, dna5>();
      * assert(value_to_char.size() == 10);
      * assert(value_to_char[0] == 'A');
      * assert(value_to_char[1] == 'C');
@@ -421,25 +421,25 @@ protected:
      */
     static constexpr auto value_to_char_table() noexcept
     {
-        constexpr auto table_size = sum_of_alphabet_sizes_v<alphabet_types...>;
-        constexpr auto value_sizes = std::array<size_t, table_size>
+        constexpr size_t table_size = sum_of_alphabet_sizes_v<alphabet_types...>;
+        constexpr std::array value_sizes = std::array<size_t, table_size>
         {
             alphabet_size_v<alphabet_types>...
         };
-        constexpr auto max_value_size = max_of_alphabet_sizes_v<alphabet_types...>;
+        constexpr size_t max_value_size = max_of_alphabet_sizes_v<alphabet_types...>;
 
         using array_t = std::array<char_type, table_size>;
         using array_inner_t = std::array<char_type, max_value_size>;
         using array_array_t = std::array<array_inner_t, table_size>;
 
-        constexpr auto array_array = array_array_t
+        constexpr std::array array_array = array_array_t
         {
             value_to_char_table_I<max_value_size>(alphabet_types{})...
         };
 
         array_t value_to_char{};
-        for (auto i = 0u, value = 0u; i < table_size; ++i)
-            for (auto k = 0u; k < value_sizes[i]; ++k, ++value)
+        for (size_t i = 0u, value = 0u; i < table_size; ++i)
+            for (size_t k = 0u; k < value_sizes[i]; ++k, ++value)
                 value_to_char[value] = array_array[i][k];
 
         return value_to_char;
@@ -450,7 +450,7 @@ protected:
      * conflict will default to the first).
      *
      * ```cpp
-     * constexpr auto char_to_value = char_to_value_table<char, dna4, gap, dna5>();
+     * constexpr std::array char_to_value = char_to_value_table<char, dna4, gap, dna5>();
      * assert(char_to_value.size() == 256);
      * assert(char_to_value['A'] == 0);
      * assert(char_to_value['C'] == 1);
@@ -467,19 +467,19 @@ protected:
      */
     static constexpr auto char_to_value_table() noexcept
     {
-        constexpr auto value_size = sum_of_alphabet_sizes_v<alphabet_types...>;
+        constexpr size_t value_size = sum_of_alphabet_sizes_v<alphabet_types...>;
         using rank_t = detail::min_viable_uint_t<value_size>;
 
-        constexpr auto table_size = 1 << (sizeof(char_type) * 8);
-        constexpr auto value_to_char = value_to_char_table();
+        constexpr size_t table_size = 1 << (sizeof(char_type) * 8);
+        constexpr std::array value_to_char = value_to_char_table();
 
         using array_t = std::array<rank_t, table_size>;
 
         array_t char_to_value{};
-        for (auto i = 0u; i < value_to_char.size(); ++i)
+        for (size_t i = 0u; i < value_to_char.size(); ++i)
         {
-            auto & old_entry = char_to_value[value_to_char[i]];
-            auto is_new_entry = value_to_char[0] != value_to_char[i] && old_entry == 0;
+            rank_t & old_entry = char_to_value[value_to_char[i]];
+            bool is_new_entry = value_to_char[0] != value_to_char[i] && old_entry == 0;
             if (is_new_entry)
                 old_entry = static_cast<rank_t>(i);
         }
@@ -488,15 +488,15 @@ protected:
 
     //!\brief Compile-time generated lookup table which contains the prefix sum up to the position of each alphabet.
     //!\sa partial_sum_of_alphabet_sizes
-    static constexpr auto partial_sum_sizes = partial_sum_of_alphabet_sizes<alphabet_types...>();
+    static constexpr std::array partial_sum_sizes = partial_sum_of_alphabet_sizes<alphabet_types...>();
 
     //!\brief Compile-time generated lookup table which maps the rank to char.
     //!\sa value_to_char_table
-    static constexpr auto value_to_char = value_to_char_table();
+    static constexpr std::array value_to_char = value_to_char_table();
 
     //!\brief Compile-time generated lookup table which maps the char to rank.
     //!\sa char_to_value_table
-    static constexpr auto char_to_value = char_to_value_table();
+    static constexpr std::array char_to_value = char_to_value_table();
 
     //!\brief Converts an object of one of the given alphabets into the internal representation.
     //!\tparam index The position of `alphabet_t` in the template pack `alphabet_types`

--- a/include/seqan3/alphabet/composition/union_composition.hpp
+++ b/include/seqan3/alphabet/composition/union_composition.hpp
@@ -127,7 +127,7 @@ protected:
      * \hideinitializer
      *
      * ```cpp
-     * constexpr auto sum = alphabet_sum_size_v<dna4, gap, dna5>;
+     * constexpr auto sum = sum_of_alphabet_sizes_v<dna4, gap, dna5>;
      * assert(sum == 10);
      * ```
      */
@@ -135,7 +135,7 @@ protected:
     //!\cond
         requires (alphabet_concept<alphabets_t> && ...)
     //!\endcond
-    static constexpr auto alphabet_sum_size_v =
+    static constexpr auto sum_of_alphabet_sizes_v =
         (static_cast<size_t>(alphabet_size_v<alphabets_t>) + ... + static_cast<size_t>(0));
 
     //!\publicsection
@@ -158,7 +158,7 @@ public:
     }
 
     //!\brief The size of the alphabet, i.e. the number of different values it can take.
-    static constexpr size_t value_size = alphabet_sum_size_v<alphabet_types...>;
+    static constexpr size_t value_size = sum_of_alphabet_sizes_v<alphabet_types...>;
 
     //!\brief The type of the alphabet when converted to char (e.g. via \link to_char \endlink).
     using char_type = underlying_char_t<meta::front<meta::list<alphabet_types...>>>;
@@ -334,7 +334,7 @@ protected:
      * \tparam ...alphabets_t The types must satisfy seqan3::alphabet_concept.
      *
      * ```cpp
-     * constexpr auto max = alphabet_max_size_v<dna4, gap, dna5>;
+     * constexpr auto max = max_of_alphabet_sizes_v<dna4, gap, dna5>;
      * assert(max == 5);
      * ```
      */
@@ -342,38 +342,38 @@ protected:
     //!\cond
         requires (alphabet_concept<alphabets_t> && ...)
     //!\endcond
-    static constexpr auto alphabet_max_size_v =
+    static constexpr auto max_of_alphabet_sizes_v =
         std::max({static_cast<size_t>(0), static_cast<size_t>(alphabet_size_v<alphabets_t>)...});
 
     /*!\brief Returns an array which contains the prefix sum over all alphabet_types::value_size's.
      * \tparam ...alphabet_types The types must satisfy seqan3::alphabet_concept.
      *
      * ```cpp
-     * constexpr auto prefix_sum = alphabet_prefix_sum_sizes<dna4, gap, dna5>();
-     * assert(prefix_sum.size() == 4);
-     * assert(prefix_sum[0] == 0);
-     * assert(prefix_sum[1] == 4);
-     * assert(prefix_sum[2] == 5);
-     * assert(prefix_sum[3] == 10);
+     * constexpr auto partial_sum = partial_sum_of_alphabet_sizes<dna4, gap, dna5>();
+     * assert(partial_sum.size() == 4);
+     * assert(partial_sum[0] == 0);
+     * assert(partial_sum[1] == 4);
+     * assert(partial_sum[2] == 5);
+     * assert(partial_sum[3] == 10);
      * ```
      */
     template <typename ...alphabets_t>
     //!\cond
         requires (alphabet_concept<alphabets_t> && ...)
     //!\endcond
-    static constexpr auto alphabet_prefix_sum_sizes() noexcept
+    static constexpr auto partial_sum_of_alphabet_sizes() noexcept
     {
-        constexpr auto value_size = alphabet_sum_size_v<alphabets_t...>;
+        constexpr auto value_size = sum_of_alphabet_sizes_v<alphabets_t...>;
         using rank_t = detail::min_viable_uint_t<value_size>;
 
         constexpr size_t N = sizeof...(alphabets_t) + 1;
         using array_t = std::array<rank_t, N>;
 
-        array_t prefix_sum{0, alphabet_size_v<alphabets_t>...};
+        array_t partial_sum{0, alphabet_size_v<alphabets_t>...};
         for (auto i = 1u; i < N; ++i)
-            prefix_sum[i] = static_cast<rank_t>(prefix_sum[i] + prefix_sum[i-1]);
+            partial_sum[i] = static_cast<rank_t>(partial_sum[i] + partial_sum[i-1]);
 
-        return prefix_sum;
+        return partial_sum;
     }
 
     /*!\brief Returns an fixed sized map at compile time where the key is the rank
@@ -421,12 +421,12 @@ protected:
      */
     static constexpr auto value_to_char_table() noexcept
     {
-        constexpr auto table_size = alphabet_sum_size_v<alphabet_types...>;
+        constexpr auto table_size = sum_of_alphabet_sizes_v<alphabet_types...>;
         constexpr auto value_sizes = std::array<size_t, table_size>
         {
             alphabet_size_v<alphabet_types>...
         };
-        constexpr auto max_value_size = alphabet_max_size_v<alphabet_types...>;
+        constexpr auto max_value_size = max_of_alphabet_sizes_v<alphabet_types...>;
 
         using array_t = std::array<char_type, table_size>;
         using array_inner_t = std::array<char_type, max_value_size>;
@@ -467,7 +467,7 @@ protected:
      */
     static constexpr auto char_to_value_table() noexcept
     {
-        constexpr auto value_size = alphabet_sum_size_v<alphabet_types...>;
+        constexpr auto value_size = sum_of_alphabet_sizes_v<alphabet_types...>;
         using rank_t = detail::min_viable_uint_t<value_size>;
 
         constexpr auto table_size = 1 << (sizeof(char_type) * 8);
@@ -487,8 +487,8 @@ protected:
     }
 
     //!\brief Compile-time generated lookup table which contains the prefix sum up to the position of each alphabet.
-    //!\sa alphabet_prefix_sum_sizes
-    static constexpr auto prefix_sum_sizes = alphabet_prefix_sum_sizes<alphabet_types...>();
+    //!\sa partial_sum_of_alphabet_sizes
+    static constexpr auto partial_sum_sizes = partial_sum_of_alphabet_sizes<alphabet_types...>();
 
     //!\brief Compile-time generated lookup table which maps the rank to char.
     //!\sa value_to_char_table
@@ -508,7 +508,7 @@ protected:
     //!\endcond
     static constexpr rank_type rank_by_index_(alphabet_t const & alphabet) noexcept
     {
-        return static_cast<rank_type>(prefix_sum_sizes[index] + alphabet.to_rank());
+        return static_cast<rank_type>(partial_sum_sizes[index] + alphabet.to_rank());
     }
 
     //!\brief Converts an object of one of the given alphabets into the internal representation.

--- a/include/seqan3/alphabet/composition/union_composition.hpp
+++ b/include/seqan3/alphabet/composition/union_composition.hpp
@@ -51,177 +51,12 @@
 #include <seqan3/alphabet/concept.hpp>
 #include <seqan3/core/detail/int_types.hpp>
 
-namespace seqan3::detail
-{
-
-//!\privatesection
-
-/*!\brief Returns an array which contains the prefix sum over all alphabet_types::value_size's.
- * \relates seqan3::union_composition
- *
- * ```cpp
- * using namespace seqan3::detail;
- *
- * constexpr auto prefix_sum = alphabet_prefix_sum_sizes<dna4, gap, dna5>();
- * assert(prefix_sum.size() == 4);
- * assert(prefix_sum[0] == 0);
- * assert(prefix_sum[1] == 4);
- * assert(prefix_sum[2] == 5);
- * assert(prefix_sum[3] == 10);
- * ```
- */
-template <typename ...alphabet_types>
-constexpr auto alphabet_prefix_sum_sizes()
-{
-    constexpr size_t value_size = ((size_t)alphabet_types::value_size + ... + 0);
-    using rank_t = min_viable_uint_t<value_size>;
-
-    constexpr size_t N = sizeof...(alphabet_types) + 1;
-    using array_t = std::array<rank_t, N>;
-
-    array_t prefix_sum{0, alphabet_types::value_size...};
-    for (auto i = 1u; i < N; ++i)
-        prefix_sum[i] = static_cast<rank_t>(prefix_sum[i] + prefix_sum[i-1]);
-
-    return prefix_sum;
-}
-//!\publicsection
-
-} // namespace seqan3::detail
-
-namespace seqan3::detail::union_composition
-{
-
-//!\privatesection
-
-/*!\brief Returns an fixed sized map at compile time where the key is the rank
- * of alphabet_t and the value is the corresponding char of that rank.
- * \sa value_to_char_table
- *
- * ```cpp
- * using namespace seqan3::detail::union_composition;
- *
- * constexpr auto table1 = value_to_char_table_I<5, char>(dna4{});
- * assert(table1.size() == 5);
- * assert(table1[0] == 'A');
- * assert(table1[1] == 'C');
- * assert(table1[2] == 'G');
- * assert(table1[3] == 'T');
- * assert(table1[4] == '\0');
- * ```
- */
-template <size_t max_value_size, typename char_t, typename alphabet_t>
-constexpr auto value_to_char_table_I(alphabet_t alphabet) noexcept
-{
-    using array_t = std::array<char_t, max_value_size>;
-    array_t value_to_char_{};
-
-    for (char_t i = 0; i < alphabet_t::value_size; ++i)
-        value_to_char_[i] = alphabet.assign_rank(i).to_char();
-
-    return value_to_char_;
-}
-
-/*!\brief Returns an map at compile time where the key is the rank of the union
- * of all alphabets and the value is the corresponding char of that rank and
- * alphabet.
- * \relates seqan3::union_composition
- *
- * ```cpp
- * using namespace seqan3::detail::union_composition;
- *
- * constexpr auto value_to_char = value_to_char_table<char, dna4, gap, dna5>();
- * assert(value_to_char.size() == 10);
- * assert(value_to_char[0] == 'A');
- * assert(value_to_char[1] == 'C');
- * assert(value_to_char[2] == 'G');
- * assert(value_to_char[3] == 'T');
- * assert(value_to_char[4] == '-');
- * assert(value_to_char[5] == 'A');
- * assert(value_to_char[6] == 'C');
- * // and so on
- * ```
- */
-template <typename char_t, typename ...alphabet_types>
-constexpr auto value_to_char_table() noexcept
-{
-    constexpr auto table_size = (alphabet_types::value_size + ... + 0);
-    constexpr auto value_sizes = std::array<size_t, table_size>{alphabet_types::value_size...};
-    constexpr auto max_value_size
-        = std::max({static_cast<size_t>(0), static_cast<size_t>(alphabet_types::value_size)...});
-
-    using array_t = std::array<char_t, table_size>;
-    using array_inner_t = std::array<char_t, max_value_size>;
-    using array_array_t = std::array<array_inner_t, table_size>;
-
-    constexpr auto array_array = array_array_t
-    {
-        value_to_char_table_I<max_value_size, char_t>(alphabet_types{})...
-    };
-
-    array_t value_to_char{};
-    for (auto i = 0u, value = 0u; i < table_size; ++i)
-        for (auto k = 0u; k < value_sizes[i]; ++k, ++value)
-            value_to_char[value] = array_array[i][k];
-
-    return value_to_char;
-}
-
-/*!\brief Returns an map at compile time where the key is the char of one of the
- * alphabets and the value is the corresponding rank over all alphabets (by
- * conflict will default to the first).
- * \relates seqan3::union_composition
- *
- * ```cpp
- * using namespace seqan3::detail::union_composition;
- *
- * constexpr auto char_to_value = char_to_value_table<char, dna4, gap, dna5>();
- * assert(char_to_value.size() == 256);
- * assert(char_to_value['A'] == 0);
- * assert(char_to_value['C'] == 1);
- * assert(char_to_value['G'] == 2);
- * assert(char_to_value['T'] == 3);
- * assert(char_to_value['-'] == 4);
- * assert(char_to_value['A'] == 0);
- * assert(char_to_value['C'] == 1);
- * assert(char_to_value['G'] == 2);
- * assert(char_to_value['T'] == 3);
- * assert(char_to_value['N'] == 9);
- * assert(char_to_value['*'] == 0); // every other character defaults to 0
- * ```
- */
-template <typename char_t, typename ...alphabet_types>
-constexpr auto char_to_value_table() noexcept
-{
-    constexpr size_t value_size = ((size_t)alphabet_types::value_size + ... + 0);
-    using rank_t = min_viable_uint_t<value_size>;
-
-    constexpr auto table_size = 1 << (sizeof(char_t) * 8);
-    constexpr auto value_to_char = value_to_char_table<char_t, alphabet_types...>();
-
-    using array_t = std::array<rank_t, table_size>;
-
-    array_t char_to_value{};
-    for (auto i = 0u; i < value_to_char.size(); ++i)
-    {
-        auto & old_entry = char_to_value[value_to_char[i]];
-        auto is_new_entry = value_to_char[0] != value_to_char[i] && old_entry == 0;
-        if (is_new_entry)
-            old_entry = static_cast<rank_t>(i);
-    }
-    return char_to_value;
-}
-//!\publicsection
-
-} // namespace seqan3::detail::union_composition
-
 namespace seqan3
 {
 
 /*!\brief A composition that merges different regular alphabets as a single alphabet.
  * \ingroup composition
- * \tparam first_alphabet_type Type of the first letter, e.g. dna4; must satisfy seqan3::alphabet_concept.
- * \tparam alphabet_types Types of further letters; must satisfy seqan3::alphabet_concept.
+ * \tparam ...alphabet_types Types of further letters; must satisfy seqan3::alphabet_concept, e.g. dna4.
  *
  * The union alphabet represents the union of two or more alphabets (e.g. the
  * four letter DNA alphabet + the gap alphabet). Note that you cannot assign
@@ -277,27 +112,55 @@ namespace seqan3
  * assert(letter.to_rank() == 6);
  * ```
  */
-template <typename first_alphabet_type, typename ...alphabet_types>
+template <typename ...alphabet_types>
 //!\cond
-    requires alphabet_concept<first_alphabet_type> && (alphabet_concept<alphabet_types> && ...)
+    requires (alphabet_concept<alphabet_types> && ... && (sizeof...(alphabet_types) >= 1))
 //!\endcond
 class union_composition
 {
+protected:
+    //!\privatesection
+
+    /*!\brief Returns the sum over all alphabet_size_v<alphabets_t>'s.
+     * \tparam ...alphabets_t The types must satisfy seqan3::alphabet_concept.
+     * \hideinitializer
+     *
+     * ```cpp
+     * constexpr auto sum = alphabet_sum_size_v<dna4, gap, dna5>;
+     * assert(sum == 10);
+     * ```
+     */
+    template <typename ...alphabets_t>
+    //!\cond
+        requires (alphabet_concept<alphabets_t> && ...)
+    //!\endcond
+    static constexpr auto alphabet_sum_size_v =
+        (static_cast<size_t>(alphabet_size_v<alphabets_t>) + ... + static_cast<size_t>(0));
+
+    //!\publicsection
 public:
     /*!\brief Returns true if alphabet_t is one of the given alphabet types.
      * \tparam alphabet_t The type to check
+     *
+     * ```cpp
+     * using union_t = union_composition<dna4, gap>;
+     *
+     * static_assert(union_t::has_type<dna4>(), "should be true");
+     * static_assert(union_t::has_type<gap>(), "should be true");
+     * static_assert(!union_t::has_type<dna5>(), "should be false");
+     * ```
      */
     template <typename alphabet_t>
     static constexpr bool has_type() noexcept
     {
-        return meta::in<meta::list<first_alphabet_type, alphabet_types...>, alphabet_t>::value;
+        return meta::in<meta::list<alphabet_types...>, alphabet_t>::value;
     }
 
     //!\brief The size of the alphabet, i.e. the number of different values it can take.
-    static constexpr size_t value_size = (alphabet_types::value_size + ... + first_alphabet_type::value_size);
+    static constexpr size_t value_size = alphabet_sum_size_v<alphabet_types...>;
 
     //!\brief The type of the alphabet when converted to char (e.g. via \link to_char \endlink)
-    using char_type = typename first_alphabet_type::char_type;
+    using char_type = underlying_char_t<meta::front<meta::list<alphabet_types...>>>;
 
     //!\brief The type of the alphabet when represented as a number (e.g. via \link to_rank \endlink)
     using rank_type = detail::min_viable_uint_t<value_size>;
@@ -323,6 +186,7 @@ public:
 
     /*!\brief Construction via a value of the base alphabets
      * \tparam alphabet_t One of the base alphabet types
+     * \param alphabet The value of a base alphabet that should be assigned.
      *
      * ```cpp
      *     union_composition<dna4, gap> letter1{dna4::C}; // or
@@ -340,6 +204,7 @@ public:
     /*!\brief Construction via a value of reoccurring alphabets
      * \tparam I The index of the i-th base alphabet
      * \tparam alphabet_t The i-th given base alphabet type
+     * \param alphabet The value of a base alphabet that should be assigned.
      *
      * ```cpp
      * using alphabet_t = union_composition<dna4, dna4>;
@@ -366,6 +231,7 @@ public:
 
     /*!\brief Assignment via a value of the base alphabets
      * \tparam alphabet_t One of the base alphabet types
+     * \param alphabet The value of a base alphabet that should be assigned.
      *
      * ```cpp
      *     union_composition<dna4, gap> letter1{};
@@ -403,6 +269,7 @@ public:
      * \{
      */
     //!\brief Assign from a character.
+    //!\param c The character to assign to.
     constexpr union_composition & assign_char(char_type const c) noexcept
     {
         _value = char_to_value[c];
@@ -410,6 +277,7 @@ public:
     }
 
     //!\brief Assign from a numeric value.
+    //!\param i The rank of a character to assign to.
     constexpr union_composition & assign_rank(rank_type const i) /*noexcept*/
     {
         // TODO(marehr): mark function noexcept if assert is replaced
@@ -461,8 +329,182 @@ public:
 protected:
     //!\privatesection
 
+    /*!\brief Returns the max over all alphabet_size_v<alphabets_t>'s.
+     * \tparam ...alphabets_t The types must satisfy seqan3::alphabet_concept.
+     *
+     * ```cpp
+     * constexpr auto max = alphabet_max_size_v<dna4, gap, dna5>;
+     * assert(max == 5);
+     * ```
+     */
+    template <typename ...alphabets_t>
+    //!\cond
+        requires (alphabet_concept<alphabets_t> && ...)
+    //!\endcond
+    static constexpr auto alphabet_max_size_v =
+        std::max({static_cast<size_t>(0), static_cast<size_t>(alphabet_size_v<alphabets_t>)...});
+
+    /*!\brief Returns an array which contains the prefix sum over all alphabet_types::value_size's.
+     * \tparam ...alphabet_types The types must satisfy seqan3::alphabet_concept.
+     *
+     * ```cpp
+     * constexpr auto prefix_sum = alphabet_prefix_sum_sizes<dna4, gap, dna5>();
+     * assert(prefix_sum.size() == 4);
+     * assert(prefix_sum[0] == 0);
+     * assert(prefix_sum[1] == 4);
+     * assert(prefix_sum[2] == 5);
+     * assert(prefix_sum[3] == 10);
+     * ```
+     */
+    template <typename ...alphabets_t>
+    //!\cond
+        requires (alphabet_concept<alphabets_t> && ...)
+    //!\endcond
+    static constexpr auto alphabet_prefix_sum_sizes() noexcept
+    {
+        constexpr auto value_size = alphabet_sum_size_v<alphabets_t...>;
+        using rank_t = detail::min_viable_uint_t<value_size>;
+
+        constexpr size_t N = sizeof...(alphabets_t) + 1;
+        using array_t = std::array<rank_t, N>;
+
+        array_t prefix_sum{0, alphabet_size_v<alphabets_t>...};
+        for (auto i = 1u; i < N; ++i)
+            prefix_sum[i] = static_cast<rank_t>(prefix_sum[i] + prefix_sum[i-1]);
+
+        return prefix_sum;
+    }
+
+    /*!\brief Returns an fixed sized map at compile time where the key is the rank
+     * of alphabet_t and the value is the corresponding char of that rank.
+     * \sa value_to_char_table
+     *
+     * ```cpp
+     * constexpr auto table1 = value_to_char_table_I<5, char>(dna4{});
+     * assert(table1.size() == 5);
+     * assert(table1[0] == 'A');
+     * assert(table1[1] == 'C');
+     * assert(table1[2] == 'G');
+     * assert(table1[3] == 'T');
+     * assert(table1[4] == '\0');
+     * ```
+     */
+    template <size_t max_value_size, typename alphabet_t>
+    static constexpr auto value_to_char_table_I(alphabet_t alphabet) noexcept
+    {
+        using array_t = std::array<char_type, max_value_size>;
+        array_t value_to_char_{};
+
+        for (char_type i = 0; i < alphabet_size_v<alphabet_t>; ++i)
+            value_to_char_[i] = alphabet.assign_rank(i).to_char();
+
+        return value_to_char_;
+    }
+
+    /*!\brief Returns an map at compile time where the key is the rank of the union
+     * of all alphabets and the value is the corresponding char of that rank and
+     * alphabet.
+     *
+     * ```cpp
+     * constexpr auto value_to_char = value_to_char_table<char, dna4, gap, dna5>();
+     * assert(value_to_char.size() == 10);
+     * assert(value_to_char[0] == 'A');
+     * assert(value_to_char[1] == 'C');
+     * assert(value_to_char[2] == 'G');
+     * assert(value_to_char[3] == 'T');
+     * assert(value_to_char[4] == '-');
+     * assert(value_to_char[5] == 'A');
+     * assert(value_to_char[6] == 'C');
+     * // and so on
+     * ```
+     */
+    static constexpr auto value_to_char_table() noexcept
+    {
+        constexpr auto table_size = alphabet_sum_size_v<alphabet_types...>;
+        constexpr auto value_sizes = std::array<size_t, table_size>
+        {
+            alphabet_size_v<alphabet_types>...
+        };
+        constexpr auto max_value_size = alphabet_max_size_v<alphabet_types...>;
+
+        using array_t = std::array<char_type, table_size>;
+        using array_inner_t = std::array<char_type, max_value_size>;
+        using array_array_t = std::array<array_inner_t, table_size>;
+
+        constexpr auto array_array = array_array_t
+        {
+            value_to_char_table_I<max_value_size>(alphabet_types{})...
+        };
+
+        array_t value_to_char{};
+        for (auto i = 0u, value = 0u; i < table_size; ++i)
+            for (auto k = 0u; k < value_sizes[i]; ++k, ++value)
+                value_to_char[value] = array_array[i][k];
+
+        return value_to_char;
+    }
+
+    /*!\brief Returns an map at compile time where the key is the char of one of the
+     * alphabets and the value is the corresponding rank over all alphabets (by
+     * conflict will default to the first).
+     *
+     * ```cpp
+     * constexpr auto char_to_value = char_to_value_table<char, dna4, gap, dna5>();
+     * assert(char_to_value.size() == 256);
+     * assert(char_to_value['A'] == 0);
+     * assert(char_to_value['C'] == 1);
+     * assert(char_to_value['G'] == 2);
+     * assert(char_to_value['T'] == 3);
+     * assert(char_to_value['-'] == 4);
+     * assert(char_to_value['A'] == 0);
+     * assert(char_to_value['C'] == 1);
+     * assert(char_to_value['G'] == 2);
+     * assert(char_to_value['T'] == 3);
+     * assert(char_to_value['N'] == 9);
+     * assert(char_to_value['*'] == 0); // every other character defaults to 0
+     * ```
+     */
+    static constexpr auto char_to_value_table() noexcept
+    {
+        constexpr auto value_size = alphabet_sum_size_v<alphabet_types...>;
+        using rank_t = detail::min_viable_uint_t<value_size>;
+
+        constexpr auto table_size = 1 << (sizeof(char_type) * 8);
+        constexpr auto value_to_char = value_to_char_table();
+
+        using array_t = std::array<rank_t, table_size>;
+
+        array_t char_to_value{};
+        for (auto i = 0u; i < value_to_char.size(); ++i)
+        {
+            auto & old_entry = char_to_value[value_to_char[i]];
+            auto is_new_entry = value_to_char[0] != value_to_char[i] && old_entry == 0;
+            if (is_new_entry)
+                old_entry = static_cast<rank_t>(i);
+        }
+        return char_to_value;
+    }
+
+    //!\brief Compile-time generated lookup table which contains the prefix sum up to the position of each alphabet
+    //!\sa alphabet_prefix_sum_sizes
+    static constexpr auto prefix_sum_sizes = alphabet_prefix_sum_sizes<alphabet_types...>();
+
+    //!\brief Compile-time generated lookup table which maps the rank to char
+    //!\sa value_to_char_table
+    static constexpr auto value_to_char = value_to_char_table();
+
+    //!\brief Compile-time generated lookup table which maps the char to rank
+    //!\sa char_to_value_table
+    static constexpr auto char_to_value = char_to_value_table();
+
     //!\brief Converts an object of one of the given alphabets into the internal representation
+    //!\tparam index The position of `alphabet_t` in the template pack `alphabet_types`
+    //!\tparam alphabet_t One of the base alphabet types
+    //!\param alphabet The value of a base alphabet that should be assigned.
     template <size_t index, typename alphabet_t>
+    //!\cond
+        requires has_type<alphabet_t>()
+    //!\endcond
     static constexpr rank_type rank_by_index_(alphabet_t const & alphabet) noexcept
     {
         return static_cast<rank_type>(prefix_sum_sizes[index] + alphabet.to_rank());
@@ -470,30 +512,17 @@ protected:
 
     //!\brief Converts an object of one of the given alphabets into the internal representation
     //!\details Finds the index of alphabet_t in the given types.
+    //!\tparam alphabet_t One of the base alphabet types
+    //!\param alphabet The value of a base alphabet that should be assigned.
     template <typename alphabet_t>
+    //!\cond
+        requires has_type<alphabet_t>()
+    //!\endcond
     static constexpr rank_type rank_by_type_(alphabet_t const & alphabet) noexcept
     {
-        constexpr size_t index = meta::find_index<meta::list<first_alphabet_type, alphabet_types...>, alphabet_t>::value;
+        constexpr size_t index = meta::find_index<meta::list<alphabet_types...>, alphabet_t>::value;
         return rank_by_index_<index>(alphabet);
     }
-
-    //!\brief Compile-time generated lookup table which contains the prefix sum up to the position of each alphabet
-    //!\hideinitializer
-    //!\sa alphabet_prefix_sum_sizes
-    static constexpr auto prefix_sum_sizes =
-        detail::alphabet_prefix_sum_sizes<first_alphabet_type, alphabet_types...>();
-
-    //!\brief Compile-time generated lookup table which maps the rank to char
-    //!\hideinitializer
-    //!\sa value_to_char_table
-    static constexpr auto value_to_char =
-        detail::union_composition::value_to_char_table<char_type, first_alphabet_type, alphabet_types...>();
-
-    //!\brief Compile-time generated lookup table which maps the char to rank
-    //!\hideinitializer
-    //!\sa char_to_value_table
-    static constexpr auto char_to_value =
-        detail::union_composition::char_to_value_table<char_type, first_alphabet_type, alphabet_types...>();
 };
 
 } // namespace seqan3

--- a/include/seqan3/alphabet/composition/union_composition.hpp
+++ b/include/seqan3/alphabet/composition/union_composition.hpp
@@ -371,7 +371,7 @@ protected:
 
         array_t partial_sum{0, alphabet_size_v<alphabets_t>...};
         for (size_t i = 1u; i < N; ++i)
-            partial_sum[i] = static_cast<rank_t>(partial_sum[i] + partial_sum[i-1]);
+            partial_sum[i] += partial_sum[i-1];
 
         return partial_sum;
     }
@@ -510,7 +510,7 @@ protected:
     //!\endcond
     static constexpr rank_type rank_by_index_(alphabet_t const & alphabet) noexcept
     {
-        return static_cast<rank_type>(partial_sum_sizes[index] + alphabet.to_rank());
+        return partial_sum_sizes[index] + static_cast<rank_type>(alphabet.to_rank());
     }
 
     //!\brief Converts an object of one of the given alphabets into the internal representation.

--- a/include/seqan3/alphabet/composition/union_composition.hpp
+++ b/include/seqan3/alphabet/composition/union_composition.hpp
@@ -54,7 +54,7 @@
 namespace seqan3
 {
 
-/*!\brief A composition that merges different regular alphabets as a single alphabet.
+/*!\brief A composition that merges different regular alphabets into a single alphabet.
  * \ingroup composition
  * \tparam ...alphabet_types Types of further letters; must satisfy seqan3::alphabet_concept, e.g. dna4.
  * \implements seqan3::alphabet_concept
@@ -141,7 +141,7 @@ protected:
     //!\publicsection
 public:
     /*!\brief Returns true if alphabet_t is one of the given alphabet types.
-     * \tparam alphabet_t The type to check
+     * \tparam alphabet_t The type to check.
      *
      * ```cpp
      * using union_t = union_composition<dna4, gap>;
@@ -186,7 +186,7 @@ public:
      */
 
     /*!\brief Construction via a value of the base alphabets.
-     * \tparam alphabet_t One of the base alphabet types
+     * \tparam alphabet_t One of the base alphabet types.
      * \param alphabet The value of a base alphabet that should be assigned.
      *
      * ```cpp
@@ -203,8 +203,8 @@ public:
     {}
 
     /*!\brief Construction via a value of reoccurring alphabets.
-     * \tparam I The index of the i-th base alphabet
-     * \tparam alphabet_t The i-th given base alphabet type
+     * \tparam I The index of the i-th base alphabet.
+     * \tparam alphabet_t The i-th given base alphabet type.
      * \param alphabet The value of a base alphabet that should be assigned.
      *
      * ```cpp
@@ -231,7 +231,7 @@ public:
      */
 
     /*!\brief Assignment via a value of the base alphabets.
-     * \tparam alphabet_t One of the base alphabet types
+     * \tparam alphabet_t One of the base alphabet types.
      * \param alphabet The value of a base alphabet that should be assigned.
      *
      * ```cpp
@@ -501,8 +501,8 @@ protected:
     static constexpr std::array char_to_value = char_to_value_table();
 
     //!\brief Converts an object of one of the given alphabets into the internal representation.
-    //!\tparam index The position of `alphabet_t` in the template pack `alphabet_types`
-    //!\tparam alphabet_t One of the base alphabet types
+    //!\tparam index The position of `alphabet_t` in the template pack `alphabet_types`.
+    //!\tparam alphabet_t One of the base alphabet types.
     //!\param alphabet The value of a base alphabet that should be assigned.
     template <size_t index, typename alphabet_t>
     //!\cond
@@ -515,7 +515,7 @@ protected:
 
     //!\brief Converts an object of one of the given alphabets into the internal representation.
     //!\details Finds the index of alphabet_t in the given types.
-    //!\tparam alphabet_t One of the base alphabet types
+    //!\tparam alphabet_t One of the base alphabet types.
     //!\param alphabet The value of a base alphabet that should be assigned.
     template <typename alphabet_t>
     //!\cond

--- a/include/seqan3/alphabet/composition/union_composition.hpp
+++ b/include/seqan3/alphabet/composition/union_composition.hpp
@@ -158,7 +158,7 @@ public:
     }
 
     //!\brief The size of the alphabet, i.e. the number of different values it can take.
-    static constexpr size_t value_size = sum_of_alphabet_sizes_v<alphabet_types...>;
+    static constexpr auto value_size = detail::min_viable_uint_v<sum_of_alphabet_sizes_v<alphabet_types...>>;
 
     //!\brief The type of the alphabet when converted to char (e.g. via \link to_char \endlink).
     using char_type = underlying_char_t<meta::front<meta::list<alphabet_types...>>>;

--- a/include/seqan3/core/detail/int_types.hpp
+++ b/include/seqan3/core/detail/int_types.hpp
@@ -54,6 +54,11 @@ using min_viable_uint_t = std::conditional_t<value <= 1ull,          bool,
                           std::conditional_t<value <= 255ull,        uint8_t,
                           std::conditional_t<value <= 65535ull,      uint16_t,
                           std::conditional_t<value <= 4294967295ull, uint32_t, uint64_t>>>>;
+
+//!\brief Given a value, cast the value as the smallest unsigned integer that can hold it.
+//!\sa seqan3::min_viable_uint_t
+template <uint64_t value>
+constexpr auto min_viable_uint_v = static_cast<min_viable_uint_t<value>>(value);
 //!\endcond
 
 } // namespace seqan3::detail

--- a/test/alphabet/alphabet_test.cpp
+++ b/test/alphabet/alphabet_test.cpp
@@ -61,6 +61,7 @@ using alphabet_types = ::testing::Types<dna4, dna5, rna4, rna5, nucl16,
                                         union_composition<dna4, gap>,
                                         union_composition<dna5, dna5>,
                                         union_composition<dna4, dna5, gap>,
+                                        union_composition<char, gap>,
                                         /*gap,*/
                                         gapped<dna4>,
                                         gapped<nucl16>,

--- a/test/alphabet/composition/union_composition_detail_test.cpp
+++ b/test/alphabet/composition/union_composition_detail_test.cpp
@@ -50,7 +50,7 @@ public:
     using union_composition<alphabet_types...>::sum_of_alphabet_sizes_v;
     using union_composition<alphabet_types...>::max_of_alphabet_sizes_v;
     using union_composition<alphabet_types...>::partial_sum_of_alphabet_sizes;
-    using union_composition<alphabet_types...>::value_to_char_table_I;
+    using union_composition<alphabet_types...>::make_value_to_char_table;
     using union_composition<alphabet_types...>::value_to_char_table;
     using union_composition<alphabet_types...>::char_to_value_table;
 };
@@ -123,12 +123,12 @@ TEST(union_composition_detail_test, partial_sum_of_alphabet_sizes)
     EXPECT_EQ(partial_sum4[3], 10);
 }
 
-TEST(union_composition_detail_test, union_composition_value_to_char_table_I)
+TEST(union_composition_detail_test, make_value_to_char_table)
 {
     using detail = detail_union_composition<dna4>;
     EXPECT_TRUE((std::is_same_v<detail::char_type, char>));
 
-    constexpr std::array table1 = detail::value_to_char_table_I<5>(dna4{});
+    constexpr std::array table1 = detail::make_value_to_char_table<5>(dna4{});
     EXPECT_EQ(table1.size(), 5u);
     EXPECT_EQ(table1[0], 'A');
     EXPECT_EQ(table1[1], 'C');
@@ -136,7 +136,7 @@ TEST(union_composition_detail_test, union_composition_value_to_char_table_I)
     EXPECT_EQ(table1[3], 'T');
     EXPECT_EQ(table1[4], '\0');
 
-    constexpr std::array table2 = detail::value_to_char_table_I<5>(dna5{});
+    constexpr std::array table2 = detail::make_value_to_char_table<5>(dna5{});
     EXPECT_EQ(table2.size(), 5u);
     EXPECT_EQ(table2[0], 'A');
     EXPECT_EQ(table2[1], 'C');
@@ -144,7 +144,7 @@ TEST(union_composition_detail_test, union_composition_value_to_char_table_I)
     EXPECT_EQ(table2[3], 'T');
     EXPECT_EQ(table2[4], 'N');
 
-    constexpr std::array table3 = detail::value_to_char_table_I<5>(gap{});
+    constexpr std::array table3 = detail::make_value_to_char_table<5>(gap{});
     EXPECT_EQ(table3.size(), 5u);
     EXPECT_EQ(table3[0], '-');
     EXPECT_EQ(table3[1], '\0');
@@ -153,7 +153,7 @@ TEST(union_composition_detail_test, union_composition_value_to_char_table_I)
     EXPECT_EQ(table3[4], '\0');
 }
 
-TEST(union_composition_detail_test, union_composition_value_to_char_table)
+TEST(union_composition_detail_test, value_to_char_table)
 {
     constexpr std::array value_to_char1 = detail_union_composition<dna4>::value_to_char_table();
     EXPECT_EQ(value_to_char1.size(), 4u);
@@ -197,7 +197,7 @@ TEST(union_composition_detail_test, union_composition_value_to_char_table)
     EXPECT_EQ(value_to_char4[9], 'T');
 }
 
-TEST(union_composition_detail_test, union_composition_char_to_value_table)
+TEST(union_composition_detail_test, char_to_value_table)
 {
     constexpr std::array char_to_value1 = detail_union_composition<dna4>::char_to_value_table();
     EXPECT_EQ(char_to_value1.size(), 256u);

--- a/test/alphabet/composition/union_composition_detail_test.cpp
+++ b/test/alphabet/composition/union_composition_detail_test.cpp
@@ -59,11 +59,11 @@ TEST(union_composition_detail_test, sum_of_alphabet_sizes_v)
 {
     using detail = detail_union_composition<dna4>;
 
-    constexpr auto sum0 = detail::sum_of_alphabet_sizes_v<>;
-    constexpr auto sum1 = detail::sum_of_alphabet_sizes_v<dna4>;
-    constexpr auto sum2 = detail::sum_of_alphabet_sizes_v<dna4, gap>;
-    constexpr auto sum3 = detail::sum_of_alphabet_sizes_v<dna4, gap, dna5>;
-    constexpr auto sum4 = detail::sum_of_alphabet_sizes_v<dna5, gap, dna4>;
+    constexpr size_t sum0 = detail::sum_of_alphabet_sizes_v<>;
+    constexpr size_t sum1 = detail::sum_of_alphabet_sizes_v<dna4>;
+    constexpr size_t sum2 = detail::sum_of_alphabet_sizes_v<dna4, gap>;
+    constexpr size_t sum3 = detail::sum_of_alphabet_sizes_v<dna4, gap, dna5>;
+    constexpr size_t sum4 = detail::sum_of_alphabet_sizes_v<dna5, gap, dna4>;
 
     EXPECT_EQ(sum0, 0u);
     EXPECT_EQ(sum1, 4u);
@@ -76,11 +76,11 @@ TEST(union_composition_detail_test, max_of_alphabet_sizes_v)
 {
     using detail = detail_union_composition<dna4>;
 
-    constexpr auto max0 = detail::max_of_alphabet_sizes_v<>;
-    constexpr auto max1 = detail::max_of_alphabet_sizes_v<dna4>;
-    constexpr auto max2 = detail::max_of_alphabet_sizes_v<dna4, gap>;
-    constexpr auto max3 = detail::max_of_alphabet_sizes_v<dna4, gap, dna5>;
-    constexpr auto max4 = detail::max_of_alphabet_sizes_v<dna5, gap, dna4>;
+    constexpr size_t max0 = detail::max_of_alphabet_sizes_v<>;
+    constexpr size_t max1 = detail::max_of_alphabet_sizes_v<dna4>;
+    constexpr size_t max2 = detail::max_of_alphabet_sizes_v<dna4, gap>;
+    constexpr size_t max3 = detail::max_of_alphabet_sizes_v<dna4, gap, dna5>;
+    constexpr size_t max4 = detail::max_of_alphabet_sizes_v<dna5, gap, dna4>;
 
     EXPECT_EQ(max0, 0u);
     EXPECT_EQ(max1, 4u);
@@ -93,29 +93,29 @@ TEST(union_composition_detail_test, partial_sum_of_alphabet_sizes)
 {
     using detail = detail_union_composition<dna4>;
 
-    constexpr auto partial_sum0 = detail::partial_sum_of_alphabet_sizes<>();
+    constexpr std::array partial_sum0 = detail::partial_sum_of_alphabet_sizes<>();
     EXPECT_EQ(partial_sum0.size(), 1u);
     EXPECT_EQ(partial_sum0[0], 0);
 
-    constexpr auto partial_sum1 = detail::partial_sum_of_alphabet_sizes<dna4>();
+    constexpr std::array partial_sum1 = detail::partial_sum_of_alphabet_sizes<dna4>();
     EXPECT_EQ(partial_sum1.size(), 2u);
     EXPECT_EQ(partial_sum1[0], 0);
     EXPECT_EQ(partial_sum1[1], 4);
 
-    constexpr auto partial_sum2 = detail::partial_sum_of_alphabet_sizes<dna4, gap>();
+    constexpr std::array partial_sum2 = detail::partial_sum_of_alphabet_sizes<dna4, gap>();
     EXPECT_EQ(partial_sum2.size(), 3u);
     EXPECT_EQ(partial_sum2[0], 0);
     EXPECT_EQ(partial_sum2[1], 4);
     EXPECT_EQ(partial_sum2[2], 5);
 
-    constexpr auto partial_sum3 = detail::partial_sum_of_alphabet_sizes<dna4, gap, dna5>();
+    constexpr std::array partial_sum3 = detail::partial_sum_of_alphabet_sizes<dna4, gap, dna5>();
     EXPECT_EQ(partial_sum3.size(), 4u);
     EXPECT_EQ(partial_sum3[0], 0);
     EXPECT_EQ(partial_sum3[1], 4);
     EXPECT_EQ(partial_sum3[2], 5);
     EXPECT_EQ(partial_sum3[3], 10);
 
-    constexpr auto partial_sum4 = detail::partial_sum_of_alphabet_sizes<dna5, gap, dna4>();
+    constexpr std::array partial_sum4 = detail::partial_sum_of_alphabet_sizes<dna5, gap, dna4>();
     EXPECT_EQ(partial_sum4.size(), 4u);
     EXPECT_EQ(partial_sum4[0], 0);
     EXPECT_EQ(partial_sum4[1], 5);
@@ -128,7 +128,7 @@ TEST(union_composition_detail_test, union_composition_value_to_char_table_I)
     using detail = detail_union_composition<dna4>;
     EXPECT_TRUE((std::is_same_v<detail::char_type, char>));
 
-    constexpr auto table1 = detail::value_to_char_table_I<5>(dna4{});
+    constexpr std::array table1 = detail::value_to_char_table_I<5>(dna4{});
     EXPECT_EQ(table1.size(), 5u);
     EXPECT_EQ(table1[0], 'A');
     EXPECT_EQ(table1[1], 'C');
@@ -136,7 +136,7 @@ TEST(union_composition_detail_test, union_composition_value_to_char_table_I)
     EXPECT_EQ(table1[3], 'T');
     EXPECT_EQ(table1[4], '\0');
 
-    constexpr auto table2 = detail::value_to_char_table_I<5>(dna5{});
+    constexpr std::array table2 = detail::value_to_char_table_I<5>(dna5{});
     EXPECT_EQ(table2.size(), 5u);
     EXPECT_EQ(table2[0], 'A');
     EXPECT_EQ(table2[1], 'C');
@@ -144,7 +144,7 @@ TEST(union_composition_detail_test, union_composition_value_to_char_table_I)
     EXPECT_EQ(table2[3], 'T');
     EXPECT_EQ(table2[4], 'N');
 
-    constexpr auto table3 = detail::value_to_char_table_I<5>(gap{});
+    constexpr std::array table3 = detail::value_to_char_table_I<5>(gap{});
     EXPECT_EQ(table3.size(), 5u);
     EXPECT_EQ(table3[0], '-');
     EXPECT_EQ(table3[1], '\0');
@@ -155,14 +155,14 @@ TEST(union_composition_detail_test, union_composition_value_to_char_table_I)
 
 TEST(union_composition_detail_test, union_composition_value_to_char_table)
 {
-    constexpr auto value_to_char1 = detail_union_composition<dna4>::value_to_char_table();
+    constexpr std::array value_to_char1 = detail_union_composition<dna4>::value_to_char_table();
     EXPECT_EQ(value_to_char1.size(), 4u);
     EXPECT_EQ(value_to_char1[0], 'A');
     EXPECT_EQ(value_to_char1[1], 'C');
     EXPECT_EQ(value_to_char1[2], 'G');
     EXPECT_EQ(value_to_char1[3], 'T');
 
-    constexpr auto value_to_char2 = detail_union_composition<dna4, gap>::value_to_char_table();
+    constexpr std::array value_to_char2 = detail_union_composition<dna4, gap>::value_to_char_table();
     EXPECT_EQ(value_to_char2.size(), 5u);
     EXPECT_EQ(value_to_char2[0], 'A');
     EXPECT_EQ(value_to_char2[1], 'C');
@@ -170,7 +170,7 @@ TEST(union_composition_detail_test, union_composition_value_to_char_table)
     EXPECT_EQ(value_to_char2[3], 'T');
     EXPECT_EQ(value_to_char2[4], '-');
 
-    constexpr auto value_to_char3 = detail_union_composition<dna4, gap, dna5>::value_to_char_table();
+    constexpr std::array value_to_char3 = detail_union_composition<dna4, gap, dna5>::value_to_char_table();
     EXPECT_EQ(value_to_char3.size(), 10u);
     EXPECT_EQ(value_to_char3[0], 'A');
     EXPECT_EQ(value_to_char3[1], 'C');
@@ -183,7 +183,7 @@ TEST(union_composition_detail_test, union_composition_value_to_char_table)
     EXPECT_EQ(value_to_char3[8], 'T');
     EXPECT_EQ(value_to_char3[9], 'N');
 
-    constexpr auto value_to_char4 = detail_union_composition<dna5, gap, dna4>::value_to_char_table();
+    constexpr std::array value_to_char4 = detail_union_composition<dna5, gap, dna4>::value_to_char_table();
     EXPECT_EQ(value_to_char4.size(), 10u);
     EXPECT_EQ(value_to_char4[0], 'A');
     EXPECT_EQ(value_to_char4[1], 'C');
@@ -199,14 +199,14 @@ TEST(union_composition_detail_test, union_composition_value_to_char_table)
 
 TEST(union_composition_detail_test, union_composition_char_to_value_table)
 {
-    constexpr auto char_to_value1 = detail_union_composition<dna4>::char_to_value_table();
+    constexpr std::array char_to_value1 = detail_union_composition<dna4>::char_to_value_table();
     EXPECT_EQ(char_to_value1.size(), 256u);
     EXPECT_EQ(char_to_value1['A'], 0);
     EXPECT_EQ(char_to_value1['C'], 1);
     EXPECT_EQ(char_to_value1['G'], 2);
     EXPECT_EQ(char_to_value1['T'], 3);
 
-    constexpr auto char_to_value2 = detail_union_composition<dna4, gap>::char_to_value_table();
+    constexpr std::array char_to_value2 = detail_union_composition<dna4, gap>::char_to_value_table();
     EXPECT_EQ(char_to_value2.size(), 256u);
     EXPECT_EQ(char_to_value2['A'], 0);
     EXPECT_EQ(char_to_value2['C'], 1);
@@ -214,7 +214,7 @@ TEST(union_composition_detail_test, union_composition_char_to_value_table)
     EXPECT_EQ(char_to_value2['T'], 3);
     EXPECT_EQ(char_to_value2['-'], 4);
 
-    constexpr auto char_to_value3 = detail_union_composition<dna4, gap, dna5>::char_to_value_table();
+    constexpr std::array char_to_value3 = detail_union_composition<dna4, gap, dna5>::char_to_value_table();
     EXPECT_EQ(char_to_value3.size(), 256u);
     EXPECT_EQ(char_to_value3['A'], 0);
     EXPECT_EQ(char_to_value3['C'], 1);
@@ -227,7 +227,7 @@ TEST(union_composition_detail_test, union_composition_char_to_value_table)
     EXPECT_EQ(char_to_value3['T'], 3);
     EXPECT_EQ(char_to_value3['N'], 9);
 
-    constexpr auto char_to_value4 = detail_union_composition<dna5, gap, dna4>::char_to_value_table();
+    constexpr std::array char_to_value4 = detail_union_composition<dna5, gap, dna4>::char_to_value_table();
     EXPECT_EQ(char_to_value4.size(), 256u);
     EXPECT_EQ(char_to_value4['A'], 0);
     EXPECT_EQ(char_to_value4['C'], 1);

--- a/test/alphabet/composition/union_composition_detail_test.cpp
+++ b/test/alphabet/composition/union_composition_detail_test.cpp
@@ -47,23 +47,23 @@ template <typename ...alphabet_types>
 class detail_union_composition : public union_composition<alphabet_types...>
 {
 public:
-    using union_composition<alphabet_types...>::alphabet_sum_size_v;
-    using union_composition<alphabet_types...>::alphabet_max_size_v;
-    using union_composition<alphabet_types...>::alphabet_prefix_sum_sizes;
+    using union_composition<alphabet_types...>::sum_of_alphabet_sizes_v;
+    using union_composition<alphabet_types...>::max_of_alphabet_sizes_v;
+    using union_composition<alphabet_types...>::partial_sum_of_alphabet_sizes;
     using union_composition<alphabet_types...>::value_to_char_table_I;
     using union_composition<alphabet_types...>::value_to_char_table;
     using union_composition<alphabet_types...>::char_to_value_table;
 };
 
-TEST(union_composition_detail_test, alphabet_sum_size_v)
+TEST(union_composition_detail_test, sum_of_alphabet_sizes_v)
 {
     using detail = detail_union_composition<dna4>;
 
-    constexpr auto sum0 = detail::alphabet_sum_size_v<>;
-    constexpr auto sum1 = detail::alphabet_sum_size_v<dna4>;
-    constexpr auto sum2 = detail::alphabet_sum_size_v<dna4, gap>;
-    constexpr auto sum3 = detail::alphabet_sum_size_v<dna4, gap, dna5>;
-    constexpr auto sum4 = detail::alphabet_sum_size_v<dna5, gap, dna4>;
+    constexpr auto sum0 = detail::sum_of_alphabet_sizes_v<>;
+    constexpr auto sum1 = detail::sum_of_alphabet_sizes_v<dna4>;
+    constexpr auto sum2 = detail::sum_of_alphabet_sizes_v<dna4, gap>;
+    constexpr auto sum3 = detail::sum_of_alphabet_sizes_v<dna4, gap, dna5>;
+    constexpr auto sum4 = detail::sum_of_alphabet_sizes_v<dna5, gap, dna4>;
 
     EXPECT_EQ(sum0, 0u);
     EXPECT_EQ(sum1, 4u);
@@ -72,15 +72,15 @@ TEST(union_composition_detail_test, alphabet_sum_size_v)
     EXPECT_EQ(sum4, 10u);
 }
 
-TEST(union_composition_detail_test, alphabet_max_size_v)
+TEST(union_composition_detail_test, max_of_alphabet_sizes_v)
 {
     using detail = detail_union_composition<dna4>;
 
-    constexpr auto max0 = detail::alphabet_max_size_v<>;
-    constexpr auto max1 = detail::alphabet_max_size_v<dna4>;
-    constexpr auto max2 = detail::alphabet_max_size_v<dna4, gap>;
-    constexpr auto max3 = detail::alphabet_max_size_v<dna4, gap, dna5>;
-    constexpr auto max4 = detail::alphabet_max_size_v<dna5, gap, dna4>;
+    constexpr auto max0 = detail::max_of_alphabet_sizes_v<>;
+    constexpr auto max1 = detail::max_of_alphabet_sizes_v<dna4>;
+    constexpr auto max2 = detail::max_of_alphabet_sizes_v<dna4, gap>;
+    constexpr auto max3 = detail::max_of_alphabet_sizes_v<dna4, gap, dna5>;
+    constexpr auto max4 = detail::max_of_alphabet_sizes_v<dna5, gap, dna4>;
 
     EXPECT_EQ(max0, 0u);
     EXPECT_EQ(max1, 4u);
@@ -89,38 +89,38 @@ TEST(union_composition_detail_test, alphabet_max_size_v)
     EXPECT_EQ(max4, 5u);
 }
 
-TEST(union_composition_detail_test, alphabet_prefix_sum_sizes)
+TEST(union_composition_detail_test, partial_sum_of_alphabet_sizes)
 {
     using detail = detail_union_composition<dna4>;
 
-    constexpr auto sizes0 = detail::alphabet_prefix_sum_sizes<>();
-    EXPECT_EQ(sizes0.size(), 1u);
-    EXPECT_EQ(sizes0[0], 0);
+    constexpr auto partial_sum0 = detail::partial_sum_of_alphabet_sizes<>();
+    EXPECT_EQ(partial_sum0.size(), 1u);
+    EXPECT_EQ(partial_sum0[0], 0);
 
-    constexpr auto sizes1 = detail::alphabet_prefix_sum_sizes<dna4>();
-    EXPECT_EQ(sizes1.size(), 2u);
-    EXPECT_EQ(sizes1[0], 0);
-    EXPECT_EQ(sizes1[1], 4);
+    constexpr auto partial_sum1 = detail::partial_sum_of_alphabet_sizes<dna4>();
+    EXPECT_EQ(partial_sum1.size(), 2u);
+    EXPECT_EQ(partial_sum1[0], 0);
+    EXPECT_EQ(partial_sum1[1], 4);
 
-    constexpr auto sizes2 = detail::alphabet_prefix_sum_sizes<dna4, gap>();
-    EXPECT_EQ(sizes2.size(), 3u);
-    EXPECT_EQ(sizes2[0], 0);
-    EXPECT_EQ(sizes2[1], 4);
-    EXPECT_EQ(sizes2[2], 5);
+    constexpr auto partial_sum2 = detail::partial_sum_of_alphabet_sizes<dna4, gap>();
+    EXPECT_EQ(partial_sum2.size(), 3u);
+    EXPECT_EQ(partial_sum2[0], 0);
+    EXPECT_EQ(partial_sum2[1], 4);
+    EXPECT_EQ(partial_sum2[2], 5);
 
-    constexpr auto sizes3 = detail::alphabet_prefix_sum_sizes<dna4, gap, dna5>();
-    EXPECT_EQ(sizes3.size(), 4u);
-    EXPECT_EQ(sizes3[0], 0);
-    EXPECT_EQ(sizes3[1], 4);
-    EXPECT_EQ(sizes3[2], 5);
-    EXPECT_EQ(sizes3[3], 10);
+    constexpr auto partial_sum3 = detail::partial_sum_of_alphabet_sizes<dna4, gap, dna5>();
+    EXPECT_EQ(partial_sum3.size(), 4u);
+    EXPECT_EQ(partial_sum3[0], 0);
+    EXPECT_EQ(partial_sum3[1], 4);
+    EXPECT_EQ(partial_sum3[2], 5);
+    EXPECT_EQ(partial_sum3[3], 10);
 
-    constexpr auto sizes4 = detail::alphabet_prefix_sum_sizes<dna5, gap, dna4>();
-    EXPECT_EQ(sizes4.size(), 4u);
-    EXPECT_EQ(sizes4[0], 0);
-    EXPECT_EQ(sizes4[1], 5);
-    EXPECT_EQ(sizes4[2], 6);
-    EXPECT_EQ(sizes4[3], 10);
+    constexpr auto partial_sum4 = detail::partial_sum_of_alphabet_sizes<dna5, gap, dna4>();
+    EXPECT_EQ(partial_sum4.size(), 4u);
+    EXPECT_EQ(partial_sum4[0], 0);
+    EXPECT_EQ(partial_sum4[1], 5);
+    EXPECT_EQ(partial_sum4[2], 6);
+    EXPECT_EQ(partial_sum4[3], 10);
 }
 
 TEST(union_composition_detail_test, union_composition_value_to_char_table_I)

--- a/test/alphabet/composition/union_composition_detail_test.cpp
+++ b/test/alphabet/composition/union_composition_detail_test.cpp
@@ -47,75 +47,32 @@ template <typename ...alphabet_types>
 class detail_union_composition : public union_composition<alphabet_types...>
 {
 public:
-    using union_composition<alphabet_types...>::sum_of_alphabet_sizes_v;
-    using union_composition<alphabet_types...>::max_of_alphabet_sizes_v;
-    using union_composition<alphabet_types...>::partial_sum_of_alphabet_sizes;
-    using union_composition<alphabet_types...>::make_value_to_char_table;
-    using union_composition<alphabet_types...>::value_to_char_table;
-    using union_composition<alphabet_types...>::char_to_value_table;
+    using union_composition<alphabet_types...>::partial_sum_sizes;
+    using union_composition<alphabet_types...>::value_to_char;
+    using union_composition<alphabet_types...>::char_to_value;
 };
 
-TEST(union_composition_detail_test, sum_of_alphabet_sizes_v)
+TEST(union_composition_detail_test, partial_sum_sizes)
 {
-    using detail = detail_union_composition<dna4>;
-
-    constexpr size_t sum0 = detail::sum_of_alphabet_sizes_v<>;
-    constexpr size_t sum1 = detail::sum_of_alphabet_sizes_v<dna4>;
-    constexpr size_t sum2 = detail::sum_of_alphabet_sizes_v<dna4, gap>;
-    constexpr size_t sum3 = detail::sum_of_alphabet_sizes_v<dna4, gap, dna5>;
-    constexpr size_t sum4 = detail::sum_of_alphabet_sizes_v<dna5, gap, dna4>;
-
-    EXPECT_EQ(sum0, 0u);
-    EXPECT_EQ(sum1, 4u);
-    EXPECT_EQ(sum2, 5u);
-    EXPECT_EQ(sum3, 10u);
-    EXPECT_EQ(sum4, 10u);
-}
-
-TEST(union_composition_detail_test, max_of_alphabet_sizes_v)
-{
-    using detail = detail_union_composition<dna4>;
-
-    constexpr size_t max0 = detail::max_of_alphabet_sizes_v<>;
-    constexpr size_t max1 = detail::max_of_alphabet_sizes_v<dna4>;
-    constexpr size_t max2 = detail::max_of_alphabet_sizes_v<dna4, gap>;
-    constexpr size_t max3 = detail::max_of_alphabet_sizes_v<dna4, gap, dna5>;
-    constexpr size_t max4 = detail::max_of_alphabet_sizes_v<dna5, gap, dna4>;
-
-    EXPECT_EQ(max0, 0u);
-    EXPECT_EQ(max1, 4u);
-    EXPECT_EQ(max2, 4u);
-    EXPECT_EQ(max3, 5u);
-    EXPECT_EQ(max4, 5u);
-}
-
-TEST(union_composition_detail_test, partial_sum_of_alphabet_sizes)
-{
-    using detail = detail_union_composition<dna4>;
-
-    constexpr std::array partial_sum0 = detail::partial_sum_of_alphabet_sizes<>();
-    EXPECT_EQ(partial_sum0.size(), 1u);
-    EXPECT_EQ(partial_sum0[0], 0);
-
-    constexpr std::array partial_sum1 = detail::partial_sum_of_alphabet_sizes<dna4>();
+    constexpr std::array partial_sum1 = detail_union_composition<dna4>::partial_sum_sizes;
     EXPECT_EQ(partial_sum1.size(), 2u);
     EXPECT_EQ(partial_sum1[0], 0);
     EXPECT_EQ(partial_sum1[1], 4);
 
-    constexpr std::array partial_sum2 = detail::partial_sum_of_alphabet_sizes<dna4, gap>();
+    constexpr std::array partial_sum2 = detail_union_composition<dna4, gap>::partial_sum_sizes;
     EXPECT_EQ(partial_sum2.size(), 3u);
     EXPECT_EQ(partial_sum2[0], 0);
     EXPECT_EQ(partial_sum2[1], 4);
     EXPECT_EQ(partial_sum2[2], 5);
 
-    constexpr std::array partial_sum3 = detail::partial_sum_of_alphabet_sizes<dna4, gap, dna5>();
+    constexpr std::array partial_sum3 = detail_union_composition<dna4, gap, dna5>::partial_sum_sizes;
     EXPECT_EQ(partial_sum3.size(), 4u);
     EXPECT_EQ(partial_sum3[0], 0);
     EXPECT_EQ(partial_sum3[1], 4);
     EXPECT_EQ(partial_sum3[2], 5);
     EXPECT_EQ(partial_sum3[3], 10);
 
-    constexpr std::array partial_sum4 = detail::partial_sum_of_alphabet_sizes<dna5, gap, dna4>();
+    constexpr std::array partial_sum4 = detail_union_composition<dna5, gap, dna4>::partial_sum_sizes;
     EXPECT_EQ(partial_sum4.size(), 4u);
     EXPECT_EQ(partial_sum4[0], 0);
     EXPECT_EQ(partial_sum4[1], 5);
@@ -123,46 +80,16 @@ TEST(union_composition_detail_test, partial_sum_of_alphabet_sizes)
     EXPECT_EQ(partial_sum4[3], 10);
 }
 
-TEST(union_composition_detail_test, make_value_to_char_table)
+TEST(union_composition_detail_test, value_to_char)
 {
-    using detail = detail_union_composition<dna4>;
-    EXPECT_TRUE((std::is_same_v<detail::char_type, char>));
-
-    constexpr std::array table1 = detail::make_value_to_char_table<5>(dna4{});
-    EXPECT_EQ(table1.size(), 5u);
-    EXPECT_EQ(table1[0], 'A');
-    EXPECT_EQ(table1[1], 'C');
-    EXPECT_EQ(table1[2], 'G');
-    EXPECT_EQ(table1[3], 'T');
-    EXPECT_EQ(table1[4], '\0');
-
-    constexpr std::array table2 = detail::make_value_to_char_table<5>(dna5{});
-    EXPECT_EQ(table2.size(), 5u);
-    EXPECT_EQ(table2[0], 'A');
-    EXPECT_EQ(table2[1], 'C');
-    EXPECT_EQ(table2[2], 'G');
-    EXPECT_EQ(table2[3], 'T');
-    EXPECT_EQ(table2[4], 'N');
-
-    constexpr std::array table3 = detail::make_value_to_char_table<5>(gap{});
-    EXPECT_EQ(table3.size(), 5u);
-    EXPECT_EQ(table3[0], '-');
-    EXPECT_EQ(table3[1], '\0');
-    EXPECT_EQ(table3[2], '\0');
-    EXPECT_EQ(table3[3], '\0');
-    EXPECT_EQ(table3[4], '\0');
-}
-
-TEST(union_composition_detail_test, value_to_char_table)
-{
-    constexpr std::array value_to_char1 = detail_union_composition<dna4>::value_to_char_table();
+    constexpr std::array value_to_char1 = detail_union_composition<dna4>::value_to_char;
     EXPECT_EQ(value_to_char1.size(), 4u);
     EXPECT_EQ(value_to_char1[0], 'A');
     EXPECT_EQ(value_to_char1[1], 'C');
     EXPECT_EQ(value_to_char1[2], 'G');
     EXPECT_EQ(value_to_char1[3], 'T');
 
-    constexpr std::array value_to_char2 = detail_union_composition<dna4, gap>::value_to_char_table();
+    constexpr std::array value_to_char2 = detail_union_composition<dna4, gap>::value_to_char;
     EXPECT_EQ(value_to_char2.size(), 5u);
     EXPECT_EQ(value_to_char2[0], 'A');
     EXPECT_EQ(value_to_char2[1], 'C');
@@ -170,7 +97,7 @@ TEST(union_composition_detail_test, value_to_char_table)
     EXPECT_EQ(value_to_char2[3], 'T');
     EXPECT_EQ(value_to_char2[4], '-');
 
-    constexpr std::array value_to_char3 = detail_union_composition<dna4, gap, dna5>::value_to_char_table();
+    constexpr std::array value_to_char3 = detail_union_composition<dna4, gap, dna5>::value_to_char;
     EXPECT_EQ(value_to_char3.size(), 10u);
     EXPECT_EQ(value_to_char3[0], 'A');
     EXPECT_EQ(value_to_char3[1], 'C');
@@ -183,7 +110,7 @@ TEST(union_composition_detail_test, value_to_char_table)
     EXPECT_EQ(value_to_char3[8], 'T');
     EXPECT_EQ(value_to_char3[9], 'N');
 
-    constexpr std::array value_to_char4 = detail_union_composition<dna5, gap, dna4>::value_to_char_table();
+    constexpr std::array value_to_char4 = detail_union_composition<dna5, gap, dna4>::value_to_char;
     EXPECT_EQ(value_to_char4.size(), 10u);
     EXPECT_EQ(value_to_char4[0], 'A');
     EXPECT_EQ(value_to_char4[1], 'C');
@@ -197,16 +124,16 @@ TEST(union_composition_detail_test, value_to_char_table)
     EXPECT_EQ(value_to_char4[9], 'T');
 }
 
-TEST(union_composition_detail_test, char_to_value_table)
+TEST(union_composition_detail_test, char_to_value)
 {
-    constexpr std::array char_to_value1 = detail_union_composition<dna4>::char_to_value_table();
+    constexpr std::array char_to_value1 = detail_union_composition<dna4>::char_to_value;
     EXPECT_EQ(char_to_value1.size(), 256u);
     EXPECT_EQ(char_to_value1['A'], 0);
     EXPECT_EQ(char_to_value1['C'], 1);
     EXPECT_EQ(char_to_value1['G'], 2);
     EXPECT_EQ(char_to_value1['T'], 3);
 
-    constexpr std::array char_to_value2 = detail_union_composition<dna4, gap>::char_to_value_table();
+    constexpr std::array char_to_value2 = detail_union_composition<dna4, gap>::char_to_value;
     EXPECT_EQ(char_to_value2.size(), 256u);
     EXPECT_EQ(char_to_value2['A'], 0);
     EXPECT_EQ(char_to_value2['C'], 1);
@@ -214,7 +141,7 @@ TEST(union_composition_detail_test, char_to_value_table)
     EXPECT_EQ(char_to_value2['T'], 3);
     EXPECT_EQ(char_to_value2['-'], 4);
 
-    constexpr std::array char_to_value3 = detail_union_composition<dna4, gap, dna5>::char_to_value_table();
+    constexpr std::array char_to_value3 = detail_union_composition<dna4, gap, dna5>::char_to_value;
     EXPECT_EQ(char_to_value3.size(), 256u);
     EXPECT_EQ(char_to_value3['A'], 0);
     EXPECT_EQ(char_to_value3['C'], 1);
@@ -227,7 +154,7 @@ TEST(union_composition_detail_test, char_to_value_table)
     EXPECT_EQ(char_to_value3['T'], 3);
     EXPECT_EQ(char_to_value3['N'], 9);
 
-    constexpr std::array char_to_value4 = detail_union_composition<dna5, gap, dna4>::char_to_value_table();
+    constexpr std::array char_to_value4 = detail_union_composition<dna5, gap, dna4>::char_to_value;
     EXPECT_EQ(char_to_value4.size(), 256u);
     EXPECT_EQ(char_to_value4['A'], 0);
     EXPECT_EQ(char_to_value4['C'], 1);

--- a/test/alphabet/composition/union_composition_test.cpp
+++ b/test/alphabet/composition/union_composition_test.cpp
@@ -176,11 +176,22 @@ TEST(union_composition_test, rank_type)
     using alphabet2_t = union_composition<gap, dna5, dna4>;
     using alphabet3_t = union_composition<gap>;
 
-    constexpr auto expect1 = std::is_same_v<alphabet1_t::rank_type, uint8_t>;
-    constexpr auto expect2 = std::is_same_v<alphabet2_t::rank_type, uint8_t>;
-    constexpr auto expect3 = std::is_same_v<alphabet3_t::rank_type, bool>;
+    EXPECT_TRUE((std::is_same_v<alphabet1_t::rank_type, uint8_t>));
+    EXPECT_TRUE((std::is_same_v<alphabet2_t::rank_type, uint8_t>));
+    EXPECT_TRUE((std::is_same_v<alphabet3_t::rank_type, bool>));
+}
 
-    EXPECT_TRUE(expect1);
-    EXPECT_TRUE(expect2);
-    EXPECT_TRUE(expect3);
+TEST(union_composition_test, value_size)
+{
+    using alphabet1_t = union_composition<dna4, dna5, gap>;
+    using alphabet2_t = union_composition<gap, dna5, dna4>;
+    using alphabet3_t = union_composition<gap>;
+
+    EXPECT_TRUE((std::is_same_v<decltype(alphabet1_t::value_size), const uint8_t>));
+    EXPECT_TRUE((std::is_same_v<decltype(alphabet2_t::value_size), const uint8_t>));
+    EXPECT_TRUE((std::is_same_v<decltype(alphabet3_t::value_size), const bool>));
+
+    EXPECT_EQ(alphabet1_t::value_size, 10);
+    EXPECT_EQ(alphabet2_t::value_size, 10);
+    EXPECT_EQ(alphabet3_t::value_size, 1);
 }

--- a/test/core/detail/int_types_test.cpp
+++ b/test/core/detail/int_types_test.cpp
@@ -61,3 +61,39 @@ TEST(int_types_test, min_viable_uint_t)
     EXPECT_TRUE((std::is_same_v<uint64_1_t, uint64_t>));
     EXPECT_TRUE((std::is_same_v<uint64_2_t, uint64_t>));
 }
+
+TEST(int_types_test, min_viable_uint_v)
+{
+    auto bool_1_v = detail::min_viable_uint_v<0ull>;
+    auto bool_2_v = detail::min_viable_uint_v<1ull>;
+    auto uint8_1_v = detail::min_viable_uint_v<2ull>;
+    auto uint8_2_v = detail::min_viable_uint_v<0xFFull>;
+    auto uint16_1_v = detail::min_viable_uint_v<0x100ull>;
+    auto uint16_2_v = detail::min_viable_uint_v<0xFFFFull>;
+    auto uint32_1_v = detail::min_viable_uint_v<0x10000ull>;
+    auto uint32_2_v = detail::min_viable_uint_v<0xFFFFFFFFull>;
+    auto uint64_1_v = detail::min_viable_uint_v<0x100000000ull>;
+    auto uint64_2_v = detail::min_viable_uint_v<0xFFFFFFFFFFFFFFFFull>;
+
+    EXPECT_EQ(static_cast<uint64_t>(bool_1_v), 0ull);
+    EXPECT_EQ(static_cast<uint64_t>(bool_2_v), 1ull);
+    EXPECT_EQ(static_cast<uint64_t>(uint8_1_v), 2ull);
+    EXPECT_EQ(static_cast<uint64_t>(uint8_2_v), 0xFFull);
+    EXPECT_EQ(static_cast<uint64_t>(uint16_1_v), 0x100ull);
+    EXPECT_EQ(static_cast<uint64_t>(uint16_2_v), 0xFFFFull);
+    EXPECT_EQ(static_cast<uint64_t>(uint32_1_v), 0x10000ull);
+    EXPECT_EQ(static_cast<uint64_t>(uint32_2_v), 0xFFFFFFFFull);
+    EXPECT_EQ(static_cast<uint64_t>(uint64_1_v), 0x100000000ull);
+    EXPECT_EQ(static_cast<uint64_t>(uint64_2_v), 0xFFFFFFFFFFFFFFFFull);
+
+    EXPECT_TRUE((std::is_same_v<decltype(bool_1_v), bool>));
+    EXPECT_TRUE((std::is_same_v<decltype(bool_2_v), bool>));
+    EXPECT_TRUE((std::is_same_v<decltype(uint8_1_v), uint8_t>));
+    EXPECT_TRUE((std::is_same_v<decltype(uint8_2_v), uint8_t>));
+    EXPECT_TRUE((std::is_same_v<decltype(uint16_1_v), uint16_t>));
+    EXPECT_TRUE((std::is_same_v<decltype(uint16_2_v), uint16_t>));
+    EXPECT_TRUE((std::is_same_v<decltype(uint32_1_v), uint32_t>));
+    EXPECT_TRUE((std::is_same_v<decltype(uint32_2_v), uint32_t>));
+    EXPECT_TRUE((std::is_same_v<decltype(uint64_1_v), uint64_t>));
+    EXPECT_TRUE((std::is_same_v<decltype(uint64_2_v), uint64_t>));
+}


### PR DESCRIPTION
* don't use `namespace seqan3::detail::union_alphabet` since it doesn't
appear in doxygen
* don't use `\privatesection` and `\publicsection` outside of class
scope (it doesn't have any effect there)
* add `\ingroup composition` where needed!
* fix testcases of union_composition
* add \param documentation to union_composition

resolves #68 and resolves #60