### PR TITLE
Gap cleanup

### DIFF
--- a/include/seqan3/alphabet/all.hpp
+++ b/include/seqan3/alphabet/all.hpp
@@ -50,5 +50,5 @@
 #include <seqan3/alphabet/nucleotide/all.hpp>
 #include <seqan3/alphabet/quality/all.hpp>
 #include <seqan3/alphabet/aminoacid/all.hpp>
-#include <seqan3/alphabet/gap/gap.hpp>
+#include <seqan3/alphabet/gap/all.hpp>
 #include <seqan3/alphabet/composition/all.hpp>

--- a/include/seqan3/alphabet/gap/all.hpp
+++ b/include/seqan3/alphabet/gap/all.hpp
@@ -47,11 +47,11 @@
  * \ingroup alphabet
  *
  * \par Introduction
- * The gap '-' symbol is used in alignments to show that there is at a certain position an insertion or deletion between
- * two or more input sequences. The seqan3::gap alphabet represents this (single) gap symbol and satisfies the
+ * The gap symbol (`-`) is used in alignments to represent an interruption in an alignment, usually the result of an
+ * insertion or deletion. The seqan3::gap alphabet represents this (single) gap symbol and satisfies the
  * seqan3::alphabet_concept.
  *
- * This enables us to combine any given alphabet with the seqan3::gap alphabet. This can be achieved by using the
- * seqan3::gapped class, there you can transform any arbitrary alphabet into a gapped alphabet with the same symbols,
- * but with the additional gap '-' symbol.
+ * The main purpose of seqan3::gap is to be combined with other alphabets. This can easily be achieved by using the
+ * seqan3::gapped<> template which transforms any other alphabet to be a composition of that alphabet + the gap
+ * character.
  */

--- a/include/seqan3/alphabet/gap/all.hpp
+++ b/include/seqan3/alphabet/gap/all.hpp
@@ -1,0 +1,57 @@
+// ============================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ============================================================================
+//
+// Copyright (c) 2006-2017, Knut Reinert & Freie Universitaet Berlin
+// Copyright (c) 2016-2017, Knut Reinert & MPI Molekulare Genetik
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ============================================================================
+
+/*!\file
+ * \ingroup gap
+ * \author Marcel Ehrhardt <marcel.ehrhardt AT fu-berlin.de>
+ * \brief Meta-header for the gap submodule; includes all headers from alphabet/gap/.
+ * \group gap
+ */
+
+#include <seqan3/alphabet/gap/gap.hpp>
+#include <seqan3/alphabet/gap/gapped.hpp>
+
+/*!\defgroup gap
+ * \brief Contains the gap alphabet and functionality to make an alphabet a gapped alphabet.
+ * \ingroup alphabet
+ *
+ * \par Introduction
+ * The gap '-' symbol is used in alignments to show that there is at a certain position an insertion or deletion between
+ * two or more input sequences. The seqan3::gap alphabet represents this (single) gap symbol and satisfies the
+ * seqan3::alphabet_concept.
+ *
+ * This enables us to combine any given alphabet with the seqan3::gap alphabet. This can be achieved by using the
+ * seqan3::gapped class, there you can transform any arbitrary alphabet into a gapped alphabet with the same symbols,
+ * but with the additional gap '-' symbol.
+ */

--- a/include/seqan3/alphabet/gap/gap.hpp
+++ b/include/seqan3/alphabet/gap/gap.hpp
@@ -81,13 +81,13 @@ struct gap
      * \{
      */
     //!\brief Return the letter as a character of char_type (returns always '-').
-    constexpr char_type to_char() const
+    constexpr char_type to_char() const noexcept
     {
         return '-';
     }
 
     //!\brief Return the letter's numeric value or rank in the alphabet. (returns always 0)
-    constexpr rank_type to_rank() const
+    constexpr rank_type to_rank() const noexcept
     {
         return 0;
     }
@@ -98,15 +98,17 @@ struct gap
      */
     //!\brief Assign from a character (no-op, since gap has only one character).
     //!\param c not used, since gap has only one character
-    constexpr gap & assign_char(char_type const)
+    constexpr gap & assign_char(char_type const) noexcept
     {
         return *this;
     }
 
     //!\brief Assign from a numeric value (no-op, since gap has only one character).
     //!\param i not used, since gap has only one character
-    constexpr gap & assign_rank(rank_type const i)
+    constexpr gap & assign_rank(rank_type const i) /*noexcept*/
     {
+        // TODO(marehr): mark function noexcept if assert is replaced
+        // https://github.com/seqan/seqan3/issues/85
         assert(i == 0);
         return *this;
     }
@@ -117,32 +119,32 @@ struct gap
 
     //!\name Comparison operators
     //!\{
-    constexpr bool operator==(gap const &) const
+    constexpr bool operator==(gap const &) const noexcept
     {
         return true;
     }
 
-    constexpr bool operator!=(gap const &) const
+    constexpr bool operator!=(gap const &) const noexcept
     {
         return false;
     }
 
-    constexpr bool operator<(gap const &) const
+    constexpr bool operator<(gap const &) const noexcept
     {
         return false;
     }
 
-    constexpr bool operator>(gap const &) const
+    constexpr bool operator>(gap const &) const noexcept
     {
         return false;
     }
 
-    constexpr bool operator<=(gap const &) const
+    constexpr bool operator<=(gap const &) const noexcept
     {
         return true;
     }
 
-    constexpr bool operator>=(gap const &) const
+    constexpr bool operator>=(gap const &) const noexcept
     {
         return true;
     }

--- a/include/seqan3/alphabet/gap/gap.hpp
+++ b/include/seqan3/alphabet/gap/gap.hpp
@@ -105,7 +105,7 @@ struct gap
 
     //!\brief Assign from a numeric value (no-op, since gap has only one character).
     //!\param i not used, since gap has only one character
-    constexpr gap & assign_rank(rank_type const i) /*noexcept*/
+    constexpr gap & assign_rank([[maybe_unused]] rank_type const i) /*noexcept*/
     {
         // TODO(marehr): mark function noexcept if assert is replaced
         // https://github.com/seqan/seqan3/issues/85

--- a/include/seqan3/alphabet/gap/gap.hpp
+++ b/include/seqan3/alphabet/gap/gap.hpp
@@ -33,7 +33,7 @@
 // ==========================================================================
 
 /*!\file
- * \ingroup alphabet
+ * \ingroup gap
  * \author Marcel Ehrhardt <marcel.ehrhardt AT fu-berlin.de>
  * \author David Heller <david.heller AT fu-berlin.de>
  * \brief Contains seqan3::gap.
@@ -49,6 +49,7 @@ namespace seqan3
 {
 
 /*!\brief The alphabet of a gap character '-'
+ * \ingroup gap
  *
  * The alphabet always has the same value ('-').
  *

--- a/include/seqan3/alphabet/gap/gap.hpp
+++ b/include/seqan3/alphabet/gap/gap.hpp
@@ -50,6 +50,7 @@ namespace seqan3
 
 /*!\brief The alphabet of a gap character '-'
  * \ingroup gap
+ * \implements seqan3::alphabet_concept
  *
  * The alphabet always has the same value ('-').
  *

--- a/include/seqan3/alphabet/gap/gap.hpp
+++ b/include/seqan3/alphabet/gap/gap.hpp
@@ -97,15 +97,17 @@ struct gap
      * \{
      */
     //!\brief Assign from a character (no-op, since gap has only one character).
+    //!\param c not used, since gap has only one character
     constexpr gap & assign_char(char_type const)
     {
         return *this;
     }
 
     //!\brief Assign from a numeric value (no-op, since gap has only one character).
-    constexpr gap & assign_rank(rank_type const in)
+    //!\param i not used, since gap has only one character
+    constexpr gap & assign_rank(rank_type const i)
     {
-        assert(in == 0);
+        assert(i == 0);
         return *this;
     }
     //!\}

--- a/include/seqan3/alphabet/gap/gapped.hpp
+++ b/include/seqan3/alphabet/gap/gapped.hpp
@@ -33,7 +33,7 @@
 // ==========================================================================
 
 /*!\file
- * \ingroup alphabet
+ * \ingroup gap
  * \author Marcel Ehrhardt <marcel.ehrhardt AT fu-berlin.de>
  * \author David Heller <david.heller AT fu-berlin.de>
  * \brief Contains seqan3::gapped.
@@ -49,7 +49,7 @@ namespace seqan3
 
 
 /*!\brief A gapped that extends a given alphabet with a gap character.
- * \ingroup alphabet
+ * \ingroup gap
  * \tparam alphabet_t Type of the letter, e.g. dna4; must satisfy seqan3::alphabet_concept.
  *
  * The gapped represents the union of a given alphabet and the

--- a/include/seqan3/alphabet/gap/gapped.hpp
+++ b/include/seqan3/alphabet/gap/gapped.hpp
@@ -86,6 +86,9 @@ struct gapped : public union_composition<alphabet_t, gap>
     //!\copydoc union_composition::assign_char
     constexpr gapped & assign_char(char_type const c) noexcept
     {
+        // We can't just use `using union_composition<alphabet_t, gap>::assign_char;` and need to explicitly forward
+        // `assign_char`, because otherwise the return type would be `union_composition` and not `gapped`, which is
+        // required by the `alphabet_concept`.
         union_composition<alphabet_t, gap>::assign_char(c);
         return *this;
     }

--- a/include/seqan3/alphabet/gap/gapped.hpp
+++ b/include/seqan3/alphabet/gap/gapped.hpp
@@ -36,7 +36,7 @@
  * \ingroup alphabet
  * \author Marcel Ehrhardt <marcel.ehrhardt AT fu-berlin.de>
  * \author David Heller <david.heller AT fu-berlin.de>
- * \brief Contains seqan3::gapped_alphabet.
+ * \brief Contains seqan3::gapped.
  */
 
 #pragma once
@@ -48,32 +48,32 @@ namespace seqan3
 {
 
 
-/*!\brief A gapped_alphabet that extends a given alphabet with a gap character.
+/*!\brief A gapped that extends a given alphabet with a gap character.
  * \ingroup alphabet
  * \tparam alphabet_t Type of the letter, e.g. dna4; must satisfy seqan3::alphabet_concept.
  *
- * The gapped_alphabet represents the union of a given alphabet and the
+ * The gapped represents the union of a given alphabet and the
  * seqan3::gap alphabet (e.g. the four letter DNA alphabet + a gap character).
  * Note that you cannot assign regular characters, but additional functions for
  * this are available.
  *
  * ```cpp
- * gapped_alphabet<dna4> gapped_letter{};
- * gapped_alphabet<dna4> converted_letter{dna4::C};
+ * gapped<dna4> gapped_letter{};
+ * gapped<dna4> converted_letter{dna4::C};
  * // doesn't work:
- * // gapped_alphabet<dna4> my_letter{'A'};
+ * // gapped<dna4> my_letter{'A'};
  *
- * gapped_alphabet<dna4>{}.assign_char('C'); // <- this does!
- * gapped_alphabet<dna4>{}.assign_char('-'); // gap character
- * gapped_alphabet<dna4>{}.assign_char('K'); // unknown characters map to the default/unknown
+ * gapped<dna4>{}.assign_char('C'); // <- this does!
+ * gapped<dna4>{}.assign_char('-'); // gap character
+ * gapped<dna4>{}.assign_char('K'); // unknown characters map to the default/unknown
  *                                           // character of the given alphabet type (i.e. A of dna4)
  * ```
  *
- * \sa For more details see union_composition, which is the base class and more general than the gapped_alphabet.
+ * \sa For more details see union_composition, which is the base class and more general than the gapped.
  */
 template <typename alphabet_t>
     requires alphabet_concept<alphabet_t>
-struct gapped_alphabet : public union_composition<alphabet_t, gap>
+struct gapped : public union_composition<alphabet_t, gap>
 {
     using union_composition<alphabet_t, gap>::_value;
     using union_composition<alphabet_t, gap>::value_size;
@@ -86,7 +86,7 @@ struct gapped_alphabet : public union_composition<alphabet_t, gap>
     /*!\brief Returns true if it is a gap
      * \details
      * ```cpp
-     * gapped_alphabet<dna4> letter = dna4::T;
+     * gapped<dna4> letter = dna4::T;
      *
      * if (!letter.is_gap())
      *     std::cout << "T is NOT a gap character";
@@ -104,28 +104,28 @@ struct gapped_alphabet : public union_composition<alphabet_t, gap>
     /*!\brief Change it into a gap.
      * \details
      * ```cpp
-     * gapped_alphabet<dna4> letter;
+     * gapped<dna4> letter;
      * letter.set_gap();
      *
      * // the same as set_gap()
      * letter = gap::GAP;
      * ```
      */
-    constexpr gapped_alphabet set_gap()
+    constexpr gapped set_gap()
     {
         _value = value_size - 1;
         return *this;
     }
 
     //!\copydoc union_composition::assign_rank
-    constexpr gapped_alphabet & assign_rank(rank_type const i)
+    constexpr gapped & assign_rank(rank_type const i)
     {
         union_composition<alphabet_t, gap>::assign_rank(i);
         return *this;
     }
 
     //!\copydoc union_composition::assign_char
-    constexpr gapped_alphabet & assign_char(char_type const c)
+    constexpr gapped & assign_char(char_type const c)
     {
         union_composition<alphabet_t, gap>::assign_char(c);
         return *this;
@@ -136,5 +136,5 @@ struct gapped_alphabet : public union_composition<alphabet_t, gap>
 
 #ifndef NDEBUG
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
-static_assert(seqan3::alphabet_concept<seqan3::gapped_alphabet<seqan3::dna4>>);
+static_assert(seqan3::alphabet_concept<seqan3::gapped<seqan3::dna4>>);
 #endif

--- a/include/seqan3/alphabet/gap/gapped.hpp
+++ b/include/seqan3/alphabet/gap/gapped.hpp
@@ -83,17 +83,19 @@ struct gapped : public union_composition<alphabet_t, gap>
     using typename union_composition<alphabet_t, gap>::rank_type;
     using typename union_composition<alphabet_t, gap>::char_type;
 
-    //!\copydoc union_composition::assign_rank
-    constexpr gapped & assign_rank(rank_type const i)
+    //!\copydoc union_composition::assign_char
+    constexpr gapped & assign_char(char_type const c) noexcept
     {
-        union_composition<alphabet_t, gap>::assign_rank(i);
+        union_composition<alphabet_t, gap>::assign_char(c);
         return *this;
     }
 
-    //!\copydoc union_composition::assign_char
-    constexpr gapped & assign_char(char_type const c)
+    //!\copydoc union_composition::assign_rank
+    constexpr gapped & assign_rank(rank_type const i) /*noexcept*/
     {
-        union_composition<alphabet_t, gap>::assign_char(c);
+        // TODO(marehr): mark function noexcept if assert (within union_composition) is replaced
+        // https://github.com/seqan/seqan3/issues/85
+        union_composition<alphabet_t, gap>::assign_rank(i);
         return *this;
     }
 };

--- a/include/seqan3/alphabet/gap/gapped.hpp
+++ b/include/seqan3/alphabet/gap/gapped.hpp
@@ -51,6 +51,7 @@ namespace seqan3
 /*!\brief A gapped that extends a given alphabet with a gap character.
  * \ingroup gap
  * \tparam alphabet_t Type of the letter, e.g. dna4; must satisfy seqan3::alphabet_concept.
+ * \implements seqan3::alphabet_concept
  *
  * The gapped represents the union of a given alphabet and the
  * seqan3::gap alphabet (e.g. the four letter DNA alphabet + a gap character).

--- a/include/seqan3/alphabet/gap/gapped.hpp
+++ b/include/seqan3/alphabet/gap/gapped.hpp
@@ -83,40 +83,6 @@ struct gapped : public union_composition<alphabet_t, gap>
     using typename union_composition<alphabet_t, gap>::rank_type;
     using typename union_composition<alphabet_t, gap>::char_type;
 
-    /*!\brief Returns true if it is a gap
-     * \details
-     * ```cpp
-     * gapped<dna4> letter = dna4::T;
-     *
-     * if (!letter.is_gap())
-     *     std::cout << "T is NOT a gap character";
-     *
-     * letter.set_gap();
-     * if (letter.is_gap())
-     *     std::cout << "Now it is a gap character";
-     * ```
-     */
-    constexpr bool is_gap() const
-    {
-        return _value == value_size - 1;
-    }
-
-    /*!\brief Change it into a gap.
-     * \details
-     * ```cpp
-     * gapped<dna4> letter;
-     * letter.set_gap();
-     *
-     * // the same as set_gap()
-     * letter = gap::GAP;
-     * ```
-     */
-    constexpr gapped set_gap()
-    {
-        _value = value_size - 1;
-        return *this;
-    }
-
     //!\copydoc union_composition::assign_rank
     constexpr gapped & assign_rank(rank_type const i)
     {

--- a/test/alphabet/alphabet_test.cpp
+++ b/test/alphabet/alphabet_test.cpp
@@ -49,7 +49,10 @@ using alphabet_types = ::testing::Types<dna4, dna5, rna4, rna5, nucl16,
                                         union_composition<dna4>,
                                         union_composition<dna4, gap>,
                                         union_composition<dna4, dna5, gap>,
-                                        /*gap, gapped<nucl16>, */
+                                        /*gap, */
+                                        gapped<dna4>,
+                                        gapped<nucl16>,
+                                        gapped<illumina18>,
                                         illumina18, dna4q>;
 
 TYPED_TEST_CASE(alphabet, alphabet_types);

--- a/test/alphabet/gap/CMakeLists.txt
+++ b/test/alphabet/gap/CMakeLists.txt
@@ -1,2 +1,2 @@
 seqan3_test(gap_test.cpp)
-seqan3_test(gapped_alphabet_test.cpp)
+seqan3_test(gapped_test.cpp)

--- a/test/alphabet/gap/gapped_test.cpp
+++ b/test/alphabet/gap/gapped_test.cpp
@@ -41,15 +41,11 @@
 
 using namespace seqan3;
 
-TEST(gapped_test, default_constructor)
-{
-    using alphabet_t = gapped<dna4>;
+// These test case only test seqan3::gapped specific functions/properties that are not offered by the general
+// `seqan3::alphabet_concept` interface. Those common interface function of `seqan3::gapped` will be tested
+// in `alphabet/alphabet_test.hpp`.
 
-    constexpr auto letter1 = alphabet_t{};
-    EXPECT_EQ(letter1._value, 0);
-}
-
-TEST(gapped_test, initialize_from_component_alphabet)
+TEST(gapped_test, initialise_from_component_alphabet)
 {
     using alphabet_t = gapped<dna4>;
 
@@ -99,135 +95,13 @@ TEST(gapped_test, assign_from_component_alphabet)
     EXPECT_EQ(letter.to_rank(), 4);
 }
 
-TEST(gapped_test, copy_constructor)
-{
-    using alphabet_t = gapped<dna4>;
-    constexpr alphabet_t letter1{dna4::T};
-    alphabet_t letter2{letter1};
-
-    EXPECT_EQ(letter1._value, 3);
-    EXPECT_EQ(letter2._value, 3);
-}
-
-TEST(gapped_test, move_constructor)
-{
-    using alphabet_t = gapped<dna4>;
-    alphabet_t letter1{dna4::G};
-    alphabet_t letter2{std::move(letter1)};
-
-    EXPECT_EQ(letter2._value, 2);
-}
-
-TEST(gapped_test, copy_assignment)
-{
-    using alphabet_t = gapped<dna4>;
-    constexpr alphabet_t letter1{dna4::T};
-    alphabet_t letter2, letter3;
-    letter2 = letter1;
-    letter3 = {letter1};
-
-    EXPECT_EQ(letter1.to_rank(), 3);
-    EXPECT_EQ(letter2.to_rank(), 3);
-    EXPECT_EQ(letter3.to_rank(), 3);
-}
-
-TEST(gapped_test, move_assignment)
-{
-    using alphabet_t = gapped<dna4>;
-    alphabet_t letter1 = dna4::G;
-    alphabet_t letter2{std::move(letter1)};
-
-    EXPECT_EQ(letter2.to_rank(), 2);
-}
-
 TEST(gapped_test, fulfills_concepts)
 {
     using alphabet_t = gapped<dna4>;
-    static_assert(std::is_pod_v<alphabet_t>);
-    EXPECT_TRUE(alphabet_concept<alphabet_t>);
-}
-
-TEST( gapped_test, assign_char)
-{
-    using alphabet_t = gapped<dna4>;
-
-    auto letter = alphabet_t{};
-    auto letterA = alphabet_t{dna4::A};
-    auto letterC = alphabet_t{dna4::C};
-    auto letterG = alphabet_t{dna4::G};
-    auto letterT = alphabet_t{dna4::T};
-    auto letterD = alphabet_t{gap::GAP};
-
-    EXPECT_EQ(letter.assign_char('A'), letterA);
-    EXPECT_EQ(letter.assign_char('C'), letterC);
-    EXPECT_EQ(letter.assign_char('G'), letterG);
-    EXPECT_EQ(letter.assign_char('T'), letterT);
-    EXPECT_EQ(letter.assign_char('-'), letterD);
-}
-
-TEST(gapped_test, to_char)
-{
-    using alphabet_t = gapped<dna4>;
-
-    auto letterA = alphabet_t{dna4::A};
-    auto letterC = alphabet_t{dna4::C};
-    auto letterG = alphabet_t{dna4::G};
-    auto letterT = alphabet_t{dna4::T};
-    auto letterD = alphabet_t{gap::GAP};
-
-    EXPECT_EQ(letterA.to_char(), 'A');
-    EXPECT_EQ(letterC.to_char(), 'C');
-    EXPECT_EQ(letterG.to_char(), 'G');
-    EXPECT_EQ(letterT.to_char(), 'T');
-    EXPECT_EQ(letterD.to_char(), '-');
-}
-
-TEST(gapped_test, to_rank)
-{
-    using alphabet_t = gapped<dna4>;
-    auto letter = alphabet_t{};
-
-    EXPECT_EQ(letter.assign_char('A').to_rank(), 0);
-    EXPECT_EQ(letter.assign_char('C').to_rank(), 1);
-    EXPECT_EQ(letter.assign_char('G').to_rank(), 2);
-    EXPECT_EQ(letter.assign_char('T').to_rank(), 3);
-    EXPECT_EQ(letter.assign_char('-').to_rank(), 4);
-}
-
-TEST(gapped_test, assign_rank)
-{
-    using alphabet_t = gapped<dna4>;
-
-    auto letter = alphabet_t{};
-    auto letterA = alphabet_t{dna4::A};
-    auto letterC = alphabet_t{dna4::C};
-    auto letterG = alphabet_t{dna4::G};
-    auto letterT = alphabet_t{dna4::T};
-    auto letterD = alphabet_t{gap::GAP};
-
-    EXPECT_EQ(letter.assign_rank(0), letterA);
-    EXPECT_EQ(letter.assign_rank(1), letterC);
-    EXPECT_EQ(letter.assign_rank(2), letterG);
-    EXPECT_EQ(letter.assign_rank(3), letterT);
-    EXPECT_EQ(letter.assign_rank(4), letterD);
-}
-
-TEST(gapped_test, relations)
-{
-    using alphabet_t = gapped<dna4>;
-    auto letter1 = alphabet_t{};
-    auto letter2 = alphabet_t{};
-
-    EXPECT_EQ(letter1.assign_char('A'), letter2.assign_char('A'));
-    EXPECT_EQ(letter1.assign_char('a'), letter2.assign_char('A'));
-    EXPECT_NE(letter1.assign_char('A'), letter2.assign_char('C'));
-    EXPECT_NE(letter1.assign_char('A'), letter2.assign_char('-'));
-    EXPECT_LT(letter1.assign_char('A'), letter2.assign_char('C'));
-    EXPECT_LE(letter1.assign_char('C'), letter2.assign_char('C'));
-    EXPECT_LE(letter1.assign_char('A'), letter2.assign_char('C'));
-    EXPECT_GT(letter1.assign_char('T'), letter2.assign_char('A'));
-    EXPECT_GE(letter1.assign_char('T'), letter2.assign_char('T'));
-    EXPECT_GE(letter1.assign_char('T'), letter2.assign_char('C'));
+    EXPECT_TRUE((std::is_pod_v<alphabet_t>));
+    EXPECT_TRUE((std::is_trivial_v<alphabet_t>));
+    EXPECT_TRUE((std::is_trivially_copyable_v<alphabet_t>));
+    EXPECT_TRUE((std::is_standard_layout_v<alphabet_t>));
 }
 
 TEST(gapped_test, stream_operator)
@@ -238,9 +112,9 @@ TEST(gapped_test, stream_operator)
     auto letterC = alphabet_t{dna4::C};
     auto letterG = alphabet_t{dna4::G};
     auto letterT = alphabet_t{dna4::T};
-    auto letterD = alphabet_t{gap::GAP};
+    auto letterGAP = alphabet_t{gap::GAP};
 
     std::stringstream ss;
-    ss << letterA << letterT << letterG << letterD << letterC;
+    ss << letterA << letterT << letterG << letterGAP << letterC;
     EXPECT_EQ(ss.str(), "ATG-C");
 }

--- a/test/alphabet/gap/gapped_test.cpp
+++ b/test/alphabet/gap/gapped_test.cpp
@@ -36,22 +36,22 @@
 
 #include <gtest/gtest.h>
 
-#include <seqan3/alphabet/gap/gapped_alphabet.hpp>
+#include <seqan3/alphabet/gap/gapped.hpp>
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 
 using namespace seqan3;
 
-TEST(gapped_alphabet_test, default_constructor)
+TEST(gapped_test, default_constructor)
 {
-    using alphabet_t = gapped_alphabet<dna4>;
+    using alphabet_t = gapped<dna4>;
 
     constexpr auto letter1 = alphabet_t{};
     EXPECT_EQ(letter1._value, 0);
 }
 
-TEST(gapped_alphabet_test, initialize_from_component_alphabet)
+TEST(gapped_test, initialize_from_component_alphabet)
 {
-    using alphabet_t = gapped_alphabet<dna4>;
+    using alphabet_t = gapped<dna4>;
 
     constexpr alphabet_t letter0{dna4::A};
     constexpr alphabet_t letter1 = dna4::C;
@@ -78,9 +78,9 @@ TEST(gapped_alphabet_test, initialize_from_component_alphabet)
     EXPECT_EQ(letter9.to_rank(), 4);
 }
 
-TEST(gapped_alphabet_test, assign_from_component_alphabet)
+TEST(gapped_test, assign_from_component_alphabet)
 {
-    using alphabet_t = gapped_alphabet<dna4>;
+    using alphabet_t = gapped<dna4>;
     alphabet_t letter{};
 
     letter = dna4::A;
@@ -99,9 +99,9 @@ TEST(gapped_alphabet_test, assign_from_component_alphabet)
     EXPECT_EQ(letter.to_rank(), 4);
 }
 
-TEST(gapped_alphabet_test, copy_constructor)
+TEST(gapped_test, copy_constructor)
 {
-    using alphabet_t = gapped_alphabet<dna4>;
+    using alphabet_t = gapped<dna4>;
     constexpr alphabet_t letter1{dna4::T};
     alphabet_t letter2{letter1};
 
@@ -109,18 +109,18 @@ TEST(gapped_alphabet_test, copy_constructor)
     EXPECT_EQ(letter2._value, 3);
 }
 
-TEST(gapped_alphabet_test, move_constructor)
+TEST(gapped_test, move_constructor)
 {
-    using alphabet_t = gapped_alphabet<dna4>;
+    using alphabet_t = gapped<dna4>;
     alphabet_t letter1{dna4::G};
     alphabet_t letter2{std::move(letter1)};
 
     EXPECT_EQ(letter2._value, 2);
 }
 
-TEST(gapped_alphabet_test, copy_assignment)
+TEST(gapped_test, copy_assignment)
 {
-    using alphabet_t = gapped_alphabet<dna4>;
+    using alphabet_t = gapped<dna4>;
     constexpr alphabet_t letter1{dna4::T};
     alphabet_t letter2, letter3;
     letter2 = letter1;
@@ -131,25 +131,25 @@ TEST(gapped_alphabet_test, copy_assignment)
     EXPECT_EQ(letter3.to_rank(), 3);
 }
 
-TEST(gapped_alphabet_test, move_assignment)
+TEST(gapped_test, move_assignment)
 {
-    using alphabet_t = gapped_alphabet<dna4>;
+    using alphabet_t = gapped<dna4>;
     alphabet_t letter1 = dna4::G;
     alphabet_t letter2{std::move(letter1)};
 
     EXPECT_EQ(letter2.to_rank(), 2);
 }
 
-TEST(gapped_alphabet_test, fulfills_concepts)
+TEST(gapped_test, fulfills_concepts)
 {
-    using alphabet_t = gapped_alphabet<dna4>;
+    using alphabet_t = gapped<dna4>;
     static_assert(std::is_pod_v<alphabet_t>);
     EXPECT_TRUE(alphabet_concept<alphabet_t>);
 }
 
-TEST( gapped_alphabet_test, assign_char)
+TEST( gapped_test, assign_char)
 {
-    using alphabet_t = gapped_alphabet<dna4>;
+    using alphabet_t = gapped<dna4>;
 
     auto letter = alphabet_t{};
     auto letterA = alphabet_t{dna4::A};
@@ -165,9 +165,9 @@ TEST( gapped_alphabet_test, assign_char)
     EXPECT_EQ(letter.assign_char('-'), letterD);
 }
 
-TEST(gapped_alphabet_test, to_char)
+TEST(gapped_test, to_char)
 {
-    using alphabet_t = gapped_alphabet<dna4>;
+    using alphabet_t = gapped<dna4>;
 
     auto letterA = alphabet_t{dna4::A};
     auto letterC = alphabet_t{dna4::C};
@@ -182,9 +182,9 @@ TEST(gapped_alphabet_test, to_char)
     EXPECT_EQ(letterD.to_char(), '-');
 }
 
-TEST(gapped_alphabet_test, to_rank)
+TEST(gapped_test, to_rank)
 {
-    using alphabet_t = gapped_alphabet<dna4>;
+    using alphabet_t = gapped<dna4>;
     auto letter = alphabet_t{};
 
     EXPECT_EQ(letter.assign_char('A').to_rank(), 0);
@@ -194,9 +194,9 @@ TEST(gapped_alphabet_test, to_rank)
     EXPECT_EQ(letter.assign_char('-').to_rank(), 4);
 }
 
-TEST(gapped_alphabet_test, assign_rank)
+TEST(gapped_test, assign_rank)
 {
-    using alphabet_t = gapped_alphabet<dna4>;
+    using alphabet_t = gapped<dna4>;
 
     auto letter = alphabet_t{};
     auto letterA = alphabet_t{dna4::A};
@@ -212,9 +212,9 @@ TEST(gapped_alphabet_test, assign_rank)
     EXPECT_EQ(letter.assign_rank(4), letterD);
 }
 
-TEST(gapped_alphabet_test, relations)
+TEST(gapped_test, relations)
 {
-    using alphabet_t = gapped_alphabet<dna4>;
+    using alphabet_t = gapped<dna4>;
     auto letter1 = alphabet_t{};
     auto letter2 = alphabet_t{};
 
@@ -230,9 +230,9 @@ TEST(gapped_alphabet_test, relations)
     EXPECT_GE(letter1.assign_char('T'), letter2.assign_char('C'));
 }
 
-TEST(gapped_alphabet_test, stream_operator)
+TEST(gapped_test, stream_operator)
 {
-    using alphabet_t = gapped_alphabet<dna4>;
+    using alphabet_t = gapped<dna4>;
 
     auto letterA = alphabet_t{dna4::A};
     auto letterC = alphabet_t{dna4::C};


### PR DESCRIPTION
resolves #59 

* deduplicate the test cases, add to the generic test cases
* add `noexcept` where adequate
* streamline documentation, in particular add `\param` documentation to functions and `\ingroup` to everything
* add gap submodule meta-header, either `alphabet/gap.hpp` or `alphabet/gap/all.hpp` depending or where the library is then
* remove `set_gap` and `is_gap` since one can now just do `= gap::GAP` and `== gap::GAP` in constant time
* rename `gapped_alphabet<>` to `gapped<>` (it will be `gapped<dna4>` for example so it is clear)