### PR TITLE
add complement() and view::complement

### DIFF
--- a/include/seqan3/alphabet/concept_pre.hpp
+++ b/include/seqan3/alphabet/concept_pre.hpp
@@ -130,6 +130,10 @@ constexpr auto alphabet_size_v = alphabet_size<alphabet_type>::value;
  * \relates seqan3::semi_alphabet_concept
  * \param alph The alphabet letter that you wish to convert to rank.
  * \returns The letter's value in the alphabet's rank type (seqan3::underlying_rank).
+ *
+ * \details
+ * \attention This is a concept requirement, not an actual function (however types satisfying this concept
+ * will provide an implementation).
  */
 // just implement the interface
 
@@ -139,6 +143,10 @@ constexpr auto alphabet_size_v = alphabet_size<alphabet_type>::value;
  * \param alph The alphabet letter that you wish to assign to.
  * \param rank The rank you wish to assign.
  * \returns A reference to `alph` or a temporary if `alph` was a temporary.
+ *
+ * \details
+ * \attention This is a concept requirement, not an actual function (however types satisfying this concept
+ * will provide an implementation).
  */
 // just implement the interface
 
@@ -178,6 +186,10 @@ using underlying_char_t = typename underlying_char<alphabet_type>::type;
  * \relates seqan3::alphabet_concept
  * \param alph The alphabet letter that you wish to convert to char.
  * \returns The letter's value in the alphabet's char type (seqan3::underlying_char).
+ *
+ * \details
+ * \attention This is a concept requirement, not an actual function (however types satisfying this concept
+ * will provide an implementation).
  */
 // just implement the interface
 
@@ -187,6 +199,10 @@ using underlying_char_t = typename underlying_char<alphabet_type>::type;
  * \param alph The alphabet letter that you wish to assign to.
  * \param chr The `char` you wish to assign.
  * \returns A reference to `alph` or a temporary if `alph` was a temporary.
+ *
+ * \details
+ * \attention This is a concept requirement, not an actual function (however types satisfying this concept
+ * will provide an implementation).
  */
 // just implement the interface
 
@@ -196,6 +212,10 @@ using underlying_char_t = typename underlying_char<alphabet_type>::type;
  * \param os The output stream you are printing to.
  * \param alph The alphabet letter that you wish to convert to char.
  * \returns A reference to the output stream.
+ *
+ * \details
+ * \attention This is a concept requirement, not an actual function (however types satisfying this concept
+ * will provide an implementation).
  */
 // just implement the interface
 

--- a/include/seqan3/alphabet/detail/member_exposure.hpp
+++ b/include/seqan3/alphabet/detail/member_exposure.hpp
@@ -89,8 +89,7 @@ struct alphabet_size<alphabet_type_with_members>
         alphabet_type_with_members::value_size;
 };
 
-/*!\brief Implementation of \link rank_type seqan3::to_rank(semi_alphabet_concept const alph) \endlink
- * that delegates to a member function.
+/*!\brief Implementation of seqan3::semi_alphabet_concept::to_rank() that delegates to a member function.
  * \tparam alphabet_type Must provide a `.to_rank()` member function.
  * \param alph The alphabet letter that you wish to convert to rank.
  * \returns The letter's value in the alphabet's rank type (usually a `uint*_t`).
@@ -102,9 +101,7 @@ constexpr underlying_rank_t<alphabet_type> to_rank(alphabet_type const alph)
     return alph.to_rank();
 }
 
-/*!\brief Implementation of
- * \link semi_alphabet_concept && seqan3::assign_rank(semi_alphabet_concept && a, rank_type const rank) \endlink
- * that delegates to a member function.
+/*!\brief Implementation of seqan3::semi_alphabet_concept::assign_rank() that delegates to a member function.
  * \tparam alphabet_type Must provide an `.assign_rank()` member function.
  * \param alph The alphabet letter that you wish to assign to.
  * \param rank The `rank` value you wish to assign.
@@ -117,9 +114,7 @@ constexpr alphabet_type & assign_rank(alphabet_type & alph, underlying_rank_t<al
     return alph.assign_rank(rank);
 }
 
-/*!\brief Implementation of
- * \link semi_alphabet_concept && seqan3::assign_rank(semi_alphabet_concept && a, rank_type const rank) \endlink
- * that delegates to a member function.
+/*!\brief Implementation of seqan3::semi_alphabet_concept::assign_rank() that delegates to a member function.
  * \tparam alphabet_type Must provide an `.assign_rank()` member function.
  * \param alph An alphabet letter temporary.
  * \param rank The `rank` value you wish to assign.
@@ -162,8 +157,7 @@ struct underlying_char<alphabet_type_with_members>
     using type = typename alphabet_type_with_members::char_type;
 };
 
-/*!\brief Implementation of \link char_type seqan3::to_char(alphabet_concept const alph) \endlink
- * that delegates to a member function.
+/*!\brief Implementation of seqan3::alphabet_concept::to_char() that delegates to a member function.
  * \tparam alphabet_type Must provide a `.to_char()` member function.
  * \param alph The alphabet letter that you wish to convert to char.
  * \returns The letter's value in the alphabet's rank type (usually `char`).
@@ -175,8 +169,7 @@ constexpr underlying_char_t<alphabet_type> to_char(alphabet_type const alph)
     return alph.to_char();
 }
 
-/*!\brief Implementation of \link std::ostream & operator<<(std::ostream & os, alphabet_type const alph) \endlink
- * that delegates to `alph.to_char()`.
+/*!\brief Implementation of seqan3::alphabet_concept::operator<<() that delegates to `alph.to_char()`.
  * \tparam alphabet_type Must provide a `.to_char()` member function.
  * \param os The output stream you are printing to.
  * \param alph The alphabet letter that you wish to print.
@@ -192,9 +185,7 @@ std::ostream & operator<<(std::ostream & os, alphabet_type const alph)
     return os;
 }
 
-/*!\brief Implementation of
- * \link alphabet_concept && seqan3::assign_char(alphabet_concept && a, char_type const chr)\endlink
- * that delegates to a member function.
+/*!\brief Implementation of seqan3::alphabet_concept::assign_char() that delegates to a member function.
  * \tparam alphabet_type Must provide an `.assign_char()` member function.
  * \param alph The alphabet letter that you wish to assign to.
  * \param chr The `char` value you wish to assign.
@@ -207,9 +198,7 @@ constexpr alphabet_type & assign_char(alphabet_type & alph, underlying_char_t<al
     return alph.assign_char(chr);
 }
 
-/*!\brief Implementation of
- * \link alphabet_concept && seqan3::assign_char(alphabet_concept && a, char_type const chr)\endlink
- * that delegates to a member function.
+/*!\brief Implementation of seqan3::alphabet_concept::assign_char() that delegates to a member function.
  * \tparam alphabet_type Must provide an `.assign_char()` member function.
  * \param alph An alphabet letter temporary.
  * \param chr The `char` value you wish to assign.

--- a/include/seqan3/alphabet/detail/member_exposure.hpp
+++ b/include/seqan3/alphabet/detail/member_exposure.hpp
@@ -228,4 +228,28 @@ constexpr alphabet_type && assign_char(alphabet_type && alph, underlying_char_t<
 }
 //!\}
 
+// ------------------------------------------------------------------
+// seqan3::nucleotide_concept
+// ------------------------------------------------------------------
+
+/*!\name Helpers for seqan3::nucleotide_concept
+ * \brief These functions and metafunctions expose member variables and types so that they satisfy
+ * seqan3::nucleotide_concept.
+ * \ingroup nucleotide
+ * \{
+ */
+
+/*!\brief Implementation of seqan3::nucleotide_concept::complement() that delegates to a member function.
+ * \tparam nucleotide_type Must provide a `.complement()` member function.
+ * \param alph The alphabet letter for whom you wish to receive the complement.
+ * \returns The letter's complement, e.g. 'T' for 'A'.
+ */
+template <typename nucleotide_type>
+constexpr nucleotide_type complement(nucleotide_type const alph)
+    requires requires (nucleotide_type alph) { { alph.complement() } -> nucleotide_type; }
+{
+    return alph.complement();
+}
+//!\}
+
 } // namespace seqan3

--- a/include/seqan3/alphabet/nucleotide/all.hpp
+++ b/include/seqan3/alphabet/nucleotide/all.hpp
@@ -55,25 +55,25 @@
  * to represent them in a regular std::string, it makes sense to have specialised data structures in most cases.
  * This sub-module offers multiple nucleotide alphabets that can be used with regular container and ranges.
  *
- * | Letter   | Description     | seqan3::nucl16 | seqan3::dna5 | seqan3::dna4 | seqan3::rna5 | seqan3::rna4 |
- * |:--------:|-----------------|:--------------:|:------------:|:------------:|:------------:|:------------:|
- * |   A      | Adenine         |      ☑         |      ☑       |      ☑       |      ☑       |      ☑       |
- * |   C      | Cytosine        |      ☑         |      ☑       |      ☑       |      ☑       |      ☑       |
- * |   G      | Guanine         |      ☑         |      ☑       |      ☑       |      ☑       |      ☑       |
- * |   T      | Thymine (DNA)   |      ☑         |      ☑       |      ☑       |      ☐       |      ☐       |
- * |   U      | Uracil (RNA)    |      ☑         |      ☐       |      ☐       |      ☑       |      ☑       |
- * |   R      | A *or* G        |      ☑         |      ☐       |      ☐       |      ☐       |      ☐       |
- * |   Y      | C *or* T        |      ☑         |      ☐       |      ☐       |      ☐       |      ☐       |
- * |   S      | G *or* C        |      ☑         |      ☐       |      ☐       |      ☐       |      ☐       |
- * |   W      | A *or* T        |      ☑         |      ☐       |      ☐       |      ☐       |      ☐       |
- * |   K      | G *or* T        |      ☑         |      ☐       |      ☐       |      ☐       |      ☐       |
- * |   M      | A *or* C        |      ☑         |      ☐       |      ☐       |      ☐       |      ☐       |
- * |   B      | C *or* G *or* T |      ☑         |      ☐       |      ☐       |      ☐       |      ☐       |
- * |   D      | A *or* G *or* T |      ☑         |      ☐       |      ☐       |      ☐       |      ☐       |
- * |   H      | A *or* C *or* T |      ☑         |      ☐       |      ☐       |      ☐       |      ☐       |
- * |   V      | A *or* C *or* G |      ☑         |      ☐       |      ☐       |      ☐       |      ☐       |
- * |   N      | any base        |      ☑         |      ☑       |      ☐       |      ☑       |      ☐       |
- * | **Size** |                 |     16         |      5       |      4       |      5       |      4       |
+ * | Letter   | Description            | seqan3::nucl16 | seqan3::dna5 | seqan3::dna4 | seqan3::rna5 | seqan3::rna4 |
+ * |:--------:|------------------------|:--------------:|:------------:|:------------:|:------------:|:------------:|
+ * |   A      | Adenine                |      ☑         |      ☑       |      ☑       |      ☑       |      ☑       |
+ * |   C      | Cytosine               |      ☑         |      ☑       |      ☑       |      ☑       |      ☑       |
+ * |   G      | Guanine                |      ☑         |      ☑       |      ☑       |      ☑       |      ☑       |
+ * |   T      | Thymine (DNA)          |      ☑         |      ☑       |      ☑       |      ☐       |      ☐       |
+ * |   U      | Uracil (RNA)           |      ☑         |      ☐       |      ☐       |      ☑       |      ☑       |
+ * |   M      | A *or* C               |      ☑         |      ☐       |      ☐       |      ☐       |      ☐       |
+ * |   R      | A *or* G               |      ☑         |      ☐       |      ☐       |      ☐       |      ☐       |
+ * |   W      | A *or* T               |      ☑         |      ☐       |      ☐       |      ☐       |      ☐       |
+ * |   Y      | C *or* T               |      ☑         |      ☐       |      ☐       |      ☐       |      ☐       |
+ * |   S      | C *or* G               |      ☑         |      ☐       |      ☐       |      ☐       |      ☐       |
+ * |   K      | G *or* T               |      ☑         |      ☐       |      ☐       |      ☐       |      ☐       |
+ * |   V      | A *or* C *or* G        |      ☑         |      ☐       |      ☐       |      ☐       |      ☐       |
+ * |   H      | A *or* C *or* T        |      ☑         |      ☐       |      ☐       |      ☐       |      ☐       |
+ * |   D      | A *or* G *or* T        |      ☑         |      ☐       |      ☐       |      ☐       |      ☐       |
+ * |   B      | C *or* G *or* T        |      ☑         |      ☐       |      ☐       |      ☐       |      ☐       |
+ * |   N      | A *or* C *or* G *or* T |      ☑         |      ☑       |      ☐       |      ☑       |      ☐       |
+ * | **Size** |                        |     16         |      5       |      4       |      5       |      4       |
  *
  * Keep in mind, that while we think of "the nucleotide alphabet" as consisting of four bases, there are indeed
  * more characters defined with different levels of ambiguity. Depending on your application it will make sense
@@ -156,4 +156,33 @@
  * bases (letters other than A, C, G, T, U) are converted to `'N'` to preserve ambiguity at that position, while
  * for seqan3::dna4 and seqan3::rna4 they are converted to the first of the possibilities they represent (because
  * there is no letter `'N'` to represent ambiguity).
+ *
+ * \par Complement
+ *
+ * | Letter   | Description            | Complement |
+ * |:--------:|------------------------|:----------:|
+ * |   A      | Adenine                |     T      |
+ * |   C      | Cytosine               |     G      |
+ * |   G      | Guanine                |     C      |
+ * |   T      | Thymine (DNA)          |     A      |
+ * |   U      | Uracil (RNA)           |     A      |
+ * |   M      | A *or* C               |     K      |
+ * |   R      | A *or* G               |     Y      |
+ * |   W      | A *or* T               |     W      |
+ * |   Y      | C *or* T               |     S      |
+ * |   S      | C *or* G               |     R      |
+ * |   K      | G *or* T               |     M      |
+ * |   V      | A *or* C *or* G        |     B      |
+ * |   H      | A *or* C *or* T        |     D      |
+ * |   D      | A *or* G *or* T        |     H      |
+ * |   B      | C *or* G *or* T        |     V      |
+ * |   N      | A *or* C *or* G *or* T |     N      |
+ *
+ * In the typical structure of DNA molecules (or double-stranded RNA), each nucleotide has a complement that it
+ * pairs with. To generate the complement value of a nucleotide letter, you can call an implementation of
+ * seqan3::nucleotide_concept::complement() on it.
+ *
+ * For the ambiguous letters, the complement is the (possibly also ambiguous) letter representing the union of the
+ * individual complements.
+ *
  */

--- a/include/seqan3/alphabet/nucleotide/concept.hpp
+++ b/include/seqan3/alphabet/nucleotide/concept.hpp
@@ -43,35 +43,19 @@
 #include <seqan3/alphabet/concept.hpp>
 
 // ============================================================================
-// auxiliary metafunction
-// ============================================================================
-
-namespace seqan3::detail
-{
-
-//!\brief Metafunction that indicates whether an alphabet is a nucleotide alphabet.
-//!\ingroup nucleotide
-template <typename type>
-struct is_nucleotide : public std::false_type
-{};
-
-//!\brief Shortcut for seqan3::detail::is_nucleotide.
-//!\ingroup nucleotide
-template <typename type>
-constexpr bool is_nucleotide_v = is_nucleotide<type>::value;
-
-} // namespace seqan3::detail
-
-// ============================================================================
 // concept
 // ============================================================================
 
 namespace seqan3
 {
+
 /*!\interface seqan3::nucleotide_concept <>
  * \extends seqan3::alphabet_concept
  * \brief A concept that indicates whether an alphabet represents nucleotides.
  * \ingroup nucleotide
+ *
+ * In addition to the requirements for seqan3::alphabet_concept, the nucleotide_concept introduces
+ * a requirement for a complement function: seqan3::nucleotide_concept::complement.
  *
  * \par Concepts and doxygen
  * The requirements for this concept are given as related functions and metafunctions.
@@ -79,6 +63,27 @@ namespace seqan3
  */
 //!\cond
 template <typename type>
-concept bool nucleotide_concept = alphabet_concept<type> && detail::is_nucleotide_v<type>;
+concept bool nucleotide_concept = requires (type v)
+{
+    requires alphabet_concept<type>;
+
+    { complement(v) } -> type;
+};
 //!\endcond
+
+/*!\name Requirements for seqan3::nucleotide_concept
+ * \brief You can expect these functions on all types that implement seqan3::nucleotide_concept.
+ * \{
+ */
+/*!\fn nucleotide_type seqan3::complement(nucleotide_type const alph)
+ * \brief Returns the alphabet letter's complement value.
+ * \relates seqan3::nucleotide_concept
+ * \param alph The alphabet letter for whom you wish to receive the complement.
+ * \returns The letter's complement, e.g. 'T' for 'A'.
+ * \details
+ *
+ * \attention This is a concept requirement, not an actual function (however types satisfying this concept
+ * will provide an implementation).
+ */
+//!\}
 } // namespace seqan3

--- a/include/seqan3/alphabet/nucleotide/dna4.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna4.hpp
@@ -111,6 +111,12 @@ struct dna4
     {
         return static_cast<rank_type>(_value);
     }
+
+    //!\brief Return the complement of the letter. See \ref nucleotide for the actual values.
+    constexpr dna4 complement() const noexcept
+    {
+        return complement_table[to_rank()];
+    }
     //!\}
 
     /*!\name Write functions
@@ -256,6 +262,9 @@ protected:
         }()
     };
 
+    //!\brief The complement table.
+    static const std::array<dna4, value_size> complement_table;
+
 public:
     //!\privatesection
     //!\brief The data member.
@@ -270,18 +279,15 @@ constexpr dna4 dna4::T{internal_type::T};
 constexpr dna4 dna4::U{dna4::T};
 constexpr dna4 dna4::UNKNOWN{dna4::A};
 
-} // namespace seqan3
-
-namespace seqan3::detail
+constexpr std::array<dna4, dna4::value_size> dna4::complement_table
 {
+    dna4::T,    // complement of dna4::A
+    dna4::G,    // complement of dna4::C
+    dna4::C,    // complement of dna4::G
+    dna4::A     // complement of dna4::T
+};
 
-//!\brief seqan3::dna4 is defined as being a nucleotide alphabet.
-//!\ingroup nucleotide
-template <>
-struct is_nucleotide<dna4> : public std::true_type
-{};
-
-} // namespace seqan3::detail
+} // namespace seqan3
 
 #ifndef NDEBUG
 static_assert(seqan3::alphabet_concept<seqan3::dna4>);

--- a/include/seqan3/alphabet/nucleotide/dna4.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna4.hpp
@@ -100,19 +100,60 @@ struct dna4
     /*!\name Read functions
      * \{
      */
-    //!\brief Return the letter as a character of char_type.
+    /*!\brief Return the letter as a character of char_type.
+     *
+     * \details
+     *
+     * Satisfies the seqan3::alphabet_concept::to_char() requirement via the seqan3::to_char() wrapper.
+     *
+     * \par Complexity
+     *
+     * Constant.
+     *
+     * \par Exceptions
+     *
+     * Guaranteed not to throw.
+     */
     constexpr char_type to_char() const noexcept
     {
         return value_to_char[static_cast<rank_type>(_value)];
     }
 
-    //!\brief Return the letter's numeric value or rank in the alphabet.
+    /*!\brief Return the letter's numeric value or rank in the alphabet.
+     *
+     * \details
+     *
+     * Satisfies the seqan3::semi_alphabet_concept::to_rank() requirement via the seqan3::to_rank() wrapper.
+     *
+     * \par Complexity
+     *
+     * Constant.
+     *
+     * \par Exceptions
+     *
+     * Guaranteed not to throw.
+     */
     constexpr rank_type to_rank() const noexcept
     {
         return static_cast<rank_type>(_value);
     }
 
-    //!\brief Return the complement of the letter. See \ref nucleotide for the actual values.
+    /*!\brief Return the complement of the letter.
+     *
+     * \details
+     *
+     * See \ref nucleotide for the actual values.
+     *
+     * Satisfies the seqan3::nucleotide_concept::complement() requirement via the seqan3::complement() wrapper.
+     *
+     * \par Complexity
+     *
+     * Constant.
+     *
+     * \par Exceptions
+     *
+     * Guaranteed not to throw.
+     */
     constexpr dna4 complement() const noexcept
     {
         return complement_table[to_rank()];
@@ -122,14 +163,40 @@ struct dna4
     /*!\name Write functions
      * \{
      */
-    //!\brief Assign from a character.
+    /*!\brief Assign from a character.
+     *
+     * \details
+     *
+     * Satisfies the seqan3::alphabet_concept::assign_char() requirement via the seqan3::assign_char() wrapper.
+     *
+     * \par Complexity
+     *
+     * Constant.
+     *
+     * \par Exceptions
+     *
+     * Guaranteed not to throw.
+     */
     constexpr dna4 & assign_char(char_type const c) noexcept
     {
         _value = char_to_value[c];
         return *this;
     }
 
-    //!\brief Assign from a numeric value.
+    /*!\brief Assign from a numeric value.
+     *
+     * \details
+     *
+     * Satisfies the seqan3::semi_alphabet_concept::assign_rank() requirement via the seqan3::assign_rank() wrapper.
+     *
+     * \par Complexity
+     *
+     * Constant.
+     *
+     * \par Exceptions
+     *
+     * Guaranteed not to throw.
+     */
     constexpr dna4 & assign_rank(rank_type const c)
     {
         assert(c < value_size);

--- a/include/seqan3/alphabet/nucleotide/dna5.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna5.hpp
@@ -112,6 +112,12 @@ struct dna5
     {
         return static_cast<rank_type>(_value);
     }
+
+    //!\brief Return the complement of the letter. See \ref nucleotide for the actual values.
+    constexpr dna5 complement() const noexcept
+    {
+        return complement_table[to_rank()];
+    }
     //!\}
 
     /*!\name Write functions
@@ -248,6 +254,8 @@ protected:
         }()
     };
 
+    //!\brief The complement table.
+    static const std::array<dna5, value_size> complement_table;
 public:
     //!\privatesection
     //!\brief The data member.
@@ -263,18 +271,16 @@ constexpr dna5 dna5::N{internal_type::N};
 constexpr dna5 dna5::U{dna5::T};
 constexpr dna5 dna5::UNKNOWN{dna5::N};
 
-} // namespace seqan3
-
-namespace seqan3::detail
+constexpr std::array<dna5, dna5::value_size> dna5::complement_table
 {
+    dna5::T,    // complement of dna5::A
+    dna5::G,    // complement of dna5::C
+    dna5::C,    // complement of dna5::G
+    dna5::A,    // complement of dna5::T
+    dna5::N     // complement of dna5::N
+};
 
-//!\brief seqan3::dna5 is defined as being a nucleotide alphabet.
-//!\ingroup nucleotide
-template <>
-struct is_nucleotide<dna5> : public std::true_type
-{};
-
-} // namespace seqan3::detail
+} // namespace seqan3
 
 #ifndef NDEBUG
 static_assert(seqan3::alphabet_concept<seqan3::dna5>);

--- a/include/seqan3/alphabet/nucleotide/dna5.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna5.hpp
@@ -79,9 +79,9 @@ namespace seqan3
 
 struct dna5
 {
-    //!\brief The type of the alphabet when converted to char (e.g. via to_char()).
+    //!\copydoc seqan3::dna4::char_type
     using char_type = char;
-    //!\brief The type of the alphabet when represented as a number (e.g. via to_rank()).
+    //!\copydoc seqan3::dna4::rank_type
     using rank_type = uint8_t;
 
     /*!\name Letter values
@@ -101,19 +101,19 @@ struct dna5
     /*!\name Read functions
      * \{
      */
-    //!\brief Return the letter as a character of char_type.
+    //!\copydoc seqan3::dna4::to_char
     constexpr char_type to_char() const noexcept
     {
         return value_to_char[static_cast<rank_type>(_value)];
     }
 
-    //!\brief Return the letter's numeric value or rank in the alphabet.
+    //!\copydoc seqan3::dna4::to_rank
     constexpr rank_type to_rank() const noexcept
     {
         return static_cast<rank_type>(_value);
     }
 
-    //!\brief Return the complement of the letter. See \ref nucleotide for the actual values.
+    //!\copydoc seqan3::dna4::complement
     constexpr dna5 complement() const noexcept
     {
         return complement_table[to_rank()];
@@ -123,14 +123,14 @@ struct dna5
     /*!\name Write functions
      * \{
      */
-    //!\brief Assign from a character.
+    //!\copydoc seqan3::dna4::assign_char
     constexpr dna5 & assign_char(char_type const c) noexcept
     {
         _value = char_to_value[c];
         return *this;
     }
 
-    //!\brief Assign from a numeric value.
+    //!\copydoc seqan3::dna4::assign_rank
     constexpr dna5 & assign_rank(rank_type const c)
     {
         assert(c < value_size);
@@ -139,7 +139,7 @@ struct dna5
     }
     //!\}
 
-    //!\brief The size of the alphabet, i.e. the number of different values it can take.
+    //!\copydoc seqan3::dna4::value_size
     static constexpr rank_type value_size{5};
 
     /*!\name Conversion operators
@@ -203,12 +203,7 @@ struct dna5
 
 protected:
     //!\privatesection
-    /*!\brief The internal type is a strictly typed enum.
-     *
-     * This is done to prevent aggregate initialization from numbers and/or chars.
-     * It is has the drawback that it also introduces a scope which in turn makes
-     * the static "letter values " members necessary.
-     */
+    //!\copydoc seqan3::dna4::internal_type
     enum struct internal_type : rank_type
     {
         A,
@@ -220,7 +215,7 @@ protected:
         UNKNOWN = N
     };
 
-    //!\brief Value to char conversion table.
+    //!\copydoc seqan3::dna4::value_to_char
     static constexpr char_type value_to_char[value_size]
     {
         'A',
@@ -230,7 +225,7 @@ protected:
         'N'
     };
 
-    //!\brief Char to value conversion table.
+    //!\copydoc seqan3::dna4::char_to_value
     static constexpr std::array<internal_type, 256> char_to_value
     {
         [] () constexpr
@@ -254,7 +249,7 @@ protected:
         }()
     };
 
-    //!\brief The complement table.
+    //!\copydoc seqan3::dna4::complement_table
     static const std::array<dna5, value_size> complement_table;
 public:
     //!\privatesection

--- a/include/seqan3/alphabet/nucleotide/nucl16.hpp
+++ b/include/seqan3/alphabet/nucleotide/nucl16.hpp
@@ -78,9 +78,9 @@ namespace seqan3
 
 struct nucl16
 {
-    //!\brief The type of the alphabet when converted to char (e.g. via to_char()).
+    //!\copydoc seqan3::dna4::char_type
     using char_type = char;
-    //!\brief The type of the alphabet when represented as a number (e.g. via to_rank()).
+    //!\copydoc seqan3::dna4::rank_type
     using rank_type = uint8_t;
 
     /*!\name Letter values
@@ -110,19 +110,19 @@ struct nucl16
     /*!\name Read functions
      * \{
      */
-    //!\brief Return the letter as a character of char_type.
+    //!\copydoc seqan3::dna4::to_char
     constexpr char_type to_char() const noexcept
     {
         return value_to_char[static_cast<rank_type>(_value)];
     }
 
-    //!\brief Return the letter's numeric value or rank in the alphabet.
+    //!\copydoc seqan3::dna4::to_rank
     constexpr rank_type to_rank() const noexcept
     {
         return static_cast<rank_type>(_value);
     }
 
-    //!\brief Return the complement of the letter. See \ref nucleotide for the actual values.
+    //!\copydoc seqan3::dna4::complement
     constexpr nucl16 complement() const noexcept
     {
         return complement_table[to_rank()];
@@ -132,14 +132,14 @@ struct nucl16
     /*!\name Write functions
      * \{
      */
-    //!\brief Assign from a character.
+    //!\copydoc seqan3::dna4::assign_char
     constexpr nucl16 & assign_char(char_type const c) noexcept
     {
         _value = char_to_value[c];
         return *this;
     }
 
-    //!\brief Assign from a numeric value.
+    //!\copydoc seqan3::dna4::assign_rank
     constexpr nucl16 & assign_rank(rank_type const c)
     {
         assert(c < value_size);
@@ -148,7 +148,7 @@ struct nucl16
     }
     //!\}
 
-    //!\brief The size of the alphabet, i.e. the number of different values it can take.
+    //!\copydoc seqan3::dna4::value_size
     static constexpr rank_type value_size{16};
 
     /*!\name Conversion operators
@@ -201,12 +201,7 @@ struct nucl16
 
 protected:
     //!\privatesection
-    /*!\brief The internal type is a strictly typed enum.
-     *
-     * This is done to prevent aggregate initialization from numbers and/or chars.
-     * It is has the drawback that it also introduces a scope which in turn makes
-     * the static "letter values " members necessary.
-     */
+    //!\copydoc seqan3::dna4::internal_type
     enum struct internal_type : rank_type
     {
         A,
@@ -228,7 +223,7 @@ protected:
         UNKNOWN = N
     };
 
-    //!\brief Value to char conversion table.
+    //!\copydoc seqan3::dna4::value_to_char
     static constexpr char_type value_to_char[value_size]
     {
         'A',
@@ -249,7 +244,7 @@ protected:
         'Y'
     };
 
-    //!\brief Char to value conversion table.
+    //!\copydoc seqan3::dna4::char_to_value
     static constexpr std::array<internal_type, 256> char_to_value
     {
         [] () constexpr
@@ -284,7 +279,7 @@ protected:
         }()
     };
 
-    //!\brief The complement table.
+    //!\copydoc seqan3::dna4::complement_table
     static const std::array<nucl16, value_size> complement_table;
 
 public:

--- a/include/seqan3/alphabet/nucleotide/nucl16.hpp
+++ b/include/seqan3/alphabet/nucleotide/nucl16.hpp
@@ -121,6 +121,12 @@ struct nucl16
     {
         return static_cast<rank_type>(_value);
     }
+
+    //!\brief Return the complement of the letter. See \ref nucleotide for the actual values.
+    constexpr nucl16 complement() const noexcept
+    {
+        return complement_table[to_rank()];
+    }
     //!\}
 
     /*!\name Write functions
@@ -278,6 +284,9 @@ protected:
         }()
     };
 
+    //!\brief The complement table.
+    static const std::array<nucl16, value_size> complement_table;
+
 public:
     //!\privatesection
     //!\brief The data member.
@@ -303,18 +312,27 @@ constexpr nucl16 nucl16::W{internal_type::W};
 constexpr nucl16 nucl16::Y{internal_type::Y};
 constexpr nucl16 nucl16::UNKNOWN{nucl16::N};
 
-} // namespace seqan3
-
-namespace seqan3::detail
+constexpr std::array<nucl16, nucl16::value_size> nucl16::complement_table
 {
+    nucl16::T,    // complement of nucl16::A
+    nucl16::V,    // complement of nucl16::B
+    nucl16::G,    // complement of nucl16::C
+    nucl16::H,    // complement of nucl16::D
+    nucl16::C,    // complement of nucl16::G
+    nucl16::D,    // complement of nucl16::H
+    nucl16::M,    // complement of nucl16::K
+    nucl16::K,    // complement of nucl16::M
+    nucl16::N,    // complement of nucl16::N
+    nucl16::Y,    // complement of nucl16::R
+    nucl16::S,    // complement of nucl16::S
+    nucl16::A,    // complement of nucl16::T
+    nucl16::A,    // complement of nucl16::U
+    nucl16::B,    // complement of nucl16::V
+    nucl16::W,    // complement of nucl16::W
+    nucl16::R     // complement of nucl16::Y
+};
 
-//!\brief seqan3::nucl16 is defined as being a nucleotide alphabet.
-//!\ingroup nucleotide
-template <>
-struct is_nucleotide<nucl16> : public std::true_type
-{};
-
-} // namespace seqan3::detail
+} // namespace seqan3
 
 #ifndef NDEBUG
 static_assert(seqan3::alphabet_concept<seqan3::nucl16>);

--- a/include/seqan3/alphabet/nucleotide/rna4.hpp
+++ b/include/seqan3/alphabet/nucleotide/rna4.hpp
@@ -95,13 +95,13 @@ struct rna4 : public dna4
     /*!\name Read functions
      * \{
      */
-    //!\brief Return the letter as a character of char_type.
+    //!\copydoc seqan3::dna4::to_char
     constexpr char_type to_char() const noexcept
     {
         return value_to_char[static_cast<rank_type>(_value)];
     }
 
-    //!\brief Return the complement of the letter. See \ref nucleotide for the actual values.
+    //!\copydoc seqan3::dna4::complement
     constexpr rna4 complement() const noexcept
     {
         return rna4{dna4::complement()};
@@ -111,14 +111,14 @@ struct rna4 : public dna4
     /*!\name Write functions
      * \{
      */
-    //!\brief Assign from a character.
+    //!\copydoc seqan3::dna4::assign_char
     constexpr rna4 & assign_char(char_type const c) noexcept
     {
         _value = char_to_value[c];
         return *this;
     }
 
-    //!\brief Assign from a numeric value.
+    //!\copydoc seqan3::dna4::assign_rank
     constexpr rna4 & assign_rank(rank_type const c)
     {
         assert(c < value_size);
@@ -154,7 +154,7 @@ struct rna4 : public dna4
     //!\}
 
 private:
-    //!\brief Value to char conversion table.
+    //!\copydoc seqan3::dna4::value_to_char
     static constexpr char_type value_to_char[value_size]
     {
         'A',

--- a/include/seqan3/alphabet/nucleotide/rna4.hpp
+++ b/include/seqan3/alphabet/nucleotide/rna4.hpp
@@ -100,6 +100,12 @@ struct rna4 : public dna4
     {
         return value_to_char[static_cast<rank_type>(_value)];
     }
+
+    //!\brief Return the complement of the letter. See \ref nucleotide for the actual values.
+    constexpr rna4 complement() const noexcept
+    {
+        return rna4{dna4::complement()};
+    }
     //!\}
 
     /*!\name Write functions
@@ -166,17 +172,6 @@ constexpr rna4 rna4::T{rna4::U};
 constexpr rna4 rna4::UNKNOWN{rna4::A};
 
 } // namespace seqan3
-
-namespace seqan3::detail
-{
-
-//!\brief seqan3::rna4 is defined as being a nucleotide alphabet.
-//!\ingroup nucleotide
-template <>
-struct is_nucleotide<rna4> : public std::true_type
-{};
-
-} // namespace seqan3::detail
 
 #ifndef NDEBUG
 static_assert(seqan3::alphabet_concept<seqan3::rna4>);

--- a/include/seqan3/alphabet/nucleotide/rna5.hpp
+++ b/include/seqan3/alphabet/nucleotide/rna5.hpp
@@ -96,13 +96,13 @@ struct rna5 : public dna5
     /*!\name Read functions
      * \{
      */
-    //!\brief Return the letter as a character of char_type.
+    //!\copydoc seqan3::dna4::to_char
     constexpr char_type to_char() const noexcept
     {
         return value_to_char[static_cast<rank_type>(_value)];
     }
 
-    //!\brief Return the complement of the letter. See \ref nucleotide for the actual values.
+    //!\copydoc seqan3::dna4::complement
     constexpr rna5 complement() const noexcept
     {
         return rna5{dna5::complement()};
@@ -112,14 +112,14 @@ struct rna5 : public dna5
     /*!\name Write functions
      * \{
      */
-    //!\brief Assign from a character.
+    //!\copydoc seqan3::dna4::assign_char
     constexpr rna5 & assign_char(char_type const c) noexcept
     {
         _value = char_to_value[c];
         return *this;
     }
 
-    //!\brief Assign from a numeric value.
+    //!\copydoc seqan3::dna4::assign_rank
     constexpr rna5 & assign_rank(rank_type const c)
     {
         assert(c < value_size);
@@ -155,7 +155,7 @@ struct rna5 : public dna5
     //!\}
 
 private:
-    //!\brief Value to char conversion table.
+    //!\copydoc seqan3::dna4::value_to_char
     static constexpr char_type value_to_char[value_size]
     {
         'A',

--- a/include/seqan3/alphabet/nucleotide/rna5.hpp
+++ b/include/seqan3/alphabet/nucleotide/rna5.hpp
@@ -101,6 +101,12 @@ struct rna5 : public dna5
     {
         return value_to_char[static_cast<rank_type>(_value)];
     }
+
+    //!\brief Return the complement of the letter. See \ref nucleotide for the actual values.
+    constexpr rna5 complement() const noexcept
+    {
+        return rna5{dna5::complement()};
+    }
     //!\}
 
     /*!\name Write functions
@@ -169,17 +175,6 @@ constexpr rna5 rna5::T{rna5::U};
 constexpr rna5 rna5::UNKNOWN{rna5::N};
 
 } // namespace seqan3
-
-namespace seqan3::detail
-{
-
-//!\brief seqan3::rna5 is defined as being a nucleotide alphabet.
-//!\ingroup nucleotide
-template <>
-struct is_nucleotide<rna5> : public std::true_type
-{};
-
-} // namespace seqan3::detail
 
 #ifndef NDEBUG
 static_assert(seqan3::alphabet_concept<seqan3::rna5>);

--- a/include/seqan3/alphabet/quality/quality_composition.hpp
+++ b/include/seqan3/alphabet/quality/quality_composition.hpp
@@ -156,6 +156,16 @@ struct quality_composition :
     {
         return seqan3::to_char(get<0>(*this));
     }
+
+    /*!\brief Return a quality_composition where the quality is preserved, but the sequence letter is complemented.
+     * \sa seqan3::complement
+     * \sa seqan3::nucleotide_concept::complement
+     */
+    constexpr quality_composition complement() const noexcept
+    {
+        using seqan3::complement;
+        return quality_composition{complement(get<0>(*this)), get<1>(*this)};
+    }
     //!\}
 };
 
@@ -166,16 +176,6 @@ quality_composition(sequence_alphabet_type &&, quality_alphabet_type &&)
     -> quality_composition<std::decay_t<sequence_alphabet_type>, std::decay_t<quality_alphabet_type>>;
 
 } // namespace seqan3
-
-namespace seqan3::detail
-{
-
-//!\brief Since seqan3::quality_composition wraps a nucleotide alphabet it is also one.
-template <typename sequence_alphabet_type, typename quality_alphabet_type>
-struct is_nucleotide<quality_composition<sequence_alphabet_type, quality_alphabet_type>> : public std::true_type
-{};
-
-} // namespace seqan3::detail
 
 #ifndef NDEBUG
 #include <seqan3/alphabet/nucleotide/dna4.hpp>

--- a/include/seqan3/range/view/complement.hpp
+++ b/include/seqan3/range/view/complement.hpp
@@ -34,56 +34,56 @@
 
 /*!\file
  * \ingroup view
- * \brief Meta-header for the \link view view submodule \endlink.
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
+ * \brief Provides seqan3::view::complement.
  */
 
 #pragma once
 
-#include <seqan3/range/view/char_to.hpp>
-#include <seqan3/range/view/concept.hpp>
-#include <seqan3/range/view/complement.hpp>
-#include <seqan3/range/view/convert.hpp>
-#include <seqan3/range/view/rank_to.hpp>
-#include <seqan3/range/view/to_char.hpp>
-#include <seqan3/range/view/to_rank.hpp>
+#include <range/v3/view/transform.hpp>
 
-/*!\defgroup view View
- * \brief Views are "lazy range combinators" that offer modified views onto other ranges.
- * \ingroup range
- * \sa https://ericniebler.github.io/range-v3/index.html#range-views
- * \sa range/view.hpp
- *
- * SeqAn3 makes heavy use of views as defined in the
- * [Ranges Technical Specification](http://en.cppreference.com/w/cpp/experimental/ranges). Currently the
- * implementation is based on the [range-v3 library](https://github.com/ericniebler/range-v3) and all those views
- * are available in the namespace ranges::view, see
- * [the overview](https://ericniebler.github.io/range-v3/index.html#range-views) for more details.
- *
- * This submodule provides additional views, specifically for operations on biological data and
- * sequence analysis.
- *
- * \attention
- * To prevent naming conflicts, all SeqAn views are inside the namespace seqan3::view.
- *
+#include <seqan3/alphabet/nucleotide/concept.hpp>
+
+namespace seqan3::view
+{
+
+/*!\brief A view that converts a range of nucleotides to their complement.
+ * \param input_range The range you wish to convert, must satisfy seqan3::input_range_concept and the value_type
+ * must satisfy seqan3::nucleotide_concept.
+ * \ingroup view
+ * \details
+ * \par View properties
+ * * view type: same as input_range
+ * * value type: remove_reference_t<value_type_t<input_range>>
+ * * `const` iterable: yes
+ * \par Complexity
+ * Linear in the size if the input range (\f$O(n)\f$).
+ * \par Exceptions
+ * Strong exception guarantee (does not modify data).
+ * \par Thread safety
+ * Does not modify data.
  * \par Example
  *
  * ```cpp
- * dna4_vector vec{"ACGGTC"_dna4};
- * auto vec_view  = vec | view::complement;                         // == "TGCCAG" (but doesn't own any data)
- * auto vec_view2 = vec | ranges::view::reverse;                    // == "CTGGCA" (but doesn't own any data)
+ *  dna5_vector foo{"ACGTA"_dna5};
  *
- * // or in one line:
- * auto vec_view3 = vec | view::complement | ranges::view::reverse; // == "GACCGT" (but doesn't own any data)
+ *  // pipe notation
+ *  auto v = foo | view::complement;                                  // == "TGCAT"
+ *
+ *  // function notation
+ *  dna5_vector v2(view::complement(foo));                            // == "TGCAT"
+ *
+ *  // generate the reverse complement:
+ *  dna5_vector v3 = foo | view::complement | ranges::view::reverse;  // == "TACGT"
  * ```
+ * \hideinitializer
  */
 
-/*!
- * \namespace seqan3::view
- * \brief The SeqAn3 namespace for views.
- *
- * Since views often have name clashes with regular functions and ranges they are implemented in the sub
- * namespace `view`.
- *
- * See the \link view view submodule \endlink of the range module for more details.
- */
+//TODO enforce nucleotide_concept via c++2a and/or terse concept syntax
+auto const complement = ranges::view::transform([] (auto const & in)
+{
+    using seqan3::complement;
+    return complement(in);
+});
+
+} // namespace seqan3::view

--- a/test/alphabet/nucleotide_test.cpp
+++ b/test/alphabet/nucleotide_test.cpp
@@ -140,6 +140,32 @@ TYPED_TEST(nucleotide, to_char)
         EXPECT_EQ(to_char(TypeParam::UNKNOWN), 'N');
 }
 
+TYPED_TEST(nucleotide, complement)
+{
+    EXPECT_EQ(complement(TypeParam::A), TypeParam::T);
+    EXPECT_EQ(complement(TypeParam::C), TypeParam::G);
+    EXPECT_EQ(complement(TypeParam::G), TypeParam::C);
+    EXPECT_EQ(complement(TypeParam::T), TypeParam::A);
+
+    using vsize_t = std::decay_t<decltype(alphabet_size_v<TypeParam>)>;
+
+    for (vsize_t i = 0u; i < alphabet_size_v<TypeParam>; ++i)
+    {
+        TypeParam c = assign_rank(TypeParam{}, i);
+
+        if constexpr (std::is_same_v<TypeParam, nucl16>)
+        {
+            if (c == nucl16::U)
+                EXPECT_EQ(complement(complement(c)), nucl16::T);
+            else
+                EXPECT_EQ(complement(complement(c)), c);
+        } else
+        {
+            EXPECT_EQ(complement(complement(c)), c);
+        }
+    }
+}
+
 TYPED_TEST(nucleotide, stream_operator)
 {
     std::stringstream ss;

--- a/test/range/view/CMakeLists.txt
+++ b/test/range/view/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_subdirectories()
 
 seqan3_test(view_char_to_test.cpp)
+seqan3_test(view_complement_test.cpp)
 seqan3_test(view_convert_test.cpp)
 seqan3_test(view_rank_to_test.cpp)
 seqan3_test(view_to_char_test.cpp)

--- a/test/range/view/view_complement_test.cpp
+++ b/test/range/view/view_complement_test.cpp
@@ -1,0 +1,62 @@
+// ==========================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ==========================================================================
+//
+// Copyright (c) 2006-2017, Knut Reinert, FU Berlin
+// Copyright (c) 2016-2017, Knut Reinert & MPI Molekulare Genetik
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ==========================================================================
+
+#include <iostream>
+
+#include <gtest/gtest.h>
+
+#include <range/v3/view/reverse.hpp>
+
+#include <seqan3/alphabet/nucleotide/all.hpp>
+#include <seqan3/range/view/complement.hpp>
+
+using namespace seqan3;
+using namespace seqan3::literal;
+
+TEST(view_convert, basic)
+{
+    dna5_vector foo{"ACGTA"_dna5};
+
+    // pipe notation
+    dna5_vector v = foo | view::complement;
+    EXPECT_EQ(v, "TGCAT"_dna5);
+
+    // function notation
+    dna5_vector v2(view::complement(foo));
+    EXPECT_EQ(v2, "TGCAT"_dna5);
+
+    // combinability
+    dna5_vector v3 = foo | view::complement | ranges::view::reverse;
+    EXPECT_EQ(v3, "TACGT"_dna5);
+}


### PR DESCRIPTION
also update the nucleotide concept to be defined as alphabet+complement() and clean up the documentation big time.