### PR TITLE
Add serialisation support to SeqAn3

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ To include SeqAn3 in your app, you need the following:
 |**build system**   | [cmake](https://cmake.org)                           | ≥ 3.4    | optional, but recommended                  |
 |**required libs**  | [SDSL](https://github.com/xxsds/sdsl-lite)           | ≥ 3      | succint datastructures                    |
 |                   | [Ranges-V3](https://github.com/ericniebler/range-v3) | == 0.3.0 | ranges and views                          |
-|                   | [Cereal](https://github.com/USCiLab/cereal)          | ≥ 1.2.2  | serialization                             |
-   
+|**optional libs**  | [Cereal](https://github.com/USCiLab/cereal)          | ≥ 1.2.3  | serialisation                             |
+
 ### Developers of the library
 
 To build the tests and API documentation, you also need:

--- a/include/seqan3/alphabet/aminoacid/translation.hpp
+++ b/include/seqan3/alphabet/aminoacid/translation.hpp
@@ -42,6 +42,8 @@
 
 #include <tuple>
 
+#include <range/v3/view/any_view.hpp>
+
 #include <seqan3/alphabet/aminoacid/aa27.hpp>
 #include <seqan3/range/concept.hpp>
 

--- a/include/seqan3/alphabet/concept.hpp
+++ b/include/seqan3/alphabet/concept.hpp
@@ -45,6 +45,7 @@
 #include <iostream>
 #include <string>
 
+#include <seqan3/core/concept/cereal.hpp>
 #include <seqan3/alphabet/concept_pre.hpp>
 #include <seqan3/alphabet/detail/member_exposure.hpp>
 
@@ -123,5 +124,55 @@ concept bool alphabet_concept = requires (t t1, t t2)
     { assign_char(t{}, 0) } -> t &&;
 };
 //!\endcond
+
+/*!\cond DEV
+ * \name Generic serialisation functions for all seqan3::semi_alphabet_concept
+ * \brief All types that satisfy seqan3::semi_alphabet_concept can be serialised via Cereal.
+ *
+ * \{
+ */
+/*!
+ * \brief Save an alphabet letter to stream.
+ * \tparam archive_t Must satisfy seqan3::cereal_output_archive_concept.
+ * \tparam alphabet_t Type of l; must satisfy seqan3::semi_alphabet_concept.
+ * \param l The alphabet letter.
+ * \relates seqan3::semi_alphabet_concept
+ *
+ * \details
+ *
+ * Delegates to seqan3::semi_alphabet_concept::to_rank.
+ *
+ * \attention These functions are never called directly, see the \ref alphabet module on how to use serialisation.
+ */
+template <cereal_output_archive_concept archive_t, semi_alphabet_concept alphabet_t>
+underlying_rank_t<alphabet_t> CEREAL_SAVE_MINIMAL_FUNCTION_NAME(archive_t const &, alphabet_t const & l)
+{
+    return to_rank(l);
+}
+
+/*!\brief Restore an alphabet letter from a saved rank.
+ * \tparam archive_t Must satisfy seqan3::cereal_input_archive_concept.
+ * \tparam wrapped_alphabet_t A seqan3::semi_alphabet_concept after Cereal mangles it up.
+ * \param l The alphabet letter (cereal wrapped).
+ * \param r The assigned value.
+ * \relates seqan3::semi_alphabet_concept
+ *
+ * \details
+ *
+ * Delegates to seqan3::semi_alphabet_concept::assign_rank.
+ *
+ * \attention These functions are never called directly, see the \ref alphabet module on how to use serialisation.
+ */
+template <cereal_input_archive_concept archive_t, typename wrapped_alphabet_t>
+void CEREAL_LOAD_MINIMAL_FUNCTION_NAME(archive_t const &,
+                                       wrapped_alphabet_t && l,
+                                       underlying_rank_t<detail::strip_cereal_wrapper_t<wrapped_alphabet_t>> const & r)
+    requires semi_alphabet_concept<detail::strip_cereal_wrapper_t<wrapped_alphabet_t>>
+{
+    assign_rank(static_cast<detail::strip_cereal_wrapper_t<wrapped_alphabet_t>&&>(l), r);
+}
+/*!\}
+ * \endcond
+ */
 
 } // namespace seqan3

--- a/include/seqan3/core/concept/cereal.hpp
+++ b/include/seqan3/core/concept/cereal.hpp
@@ -1,0 +1,151 @@
+// ============================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ============================================================================
+//
+// Copyright (c) 2006-2017, Knut Reinert & Freie Universitaet Berlin
+// Copyright (c) 2016-2017, Knut Reinert & MPI Molekulare Genetik
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ============================================================================
+
+/*!\file
+ * \brief Adaptions of concepts from the Cereal library.
+ * \ingroup core
+ * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <type_traits>
+
+#include <seqan3/core/platform.hpp>
+
+#if SEQAN3_WITH_CEREAL
+#include <cereal/details/traits.hpp>
+#endif
+
+namespace seqan3
+{
+
+/*!\interface seqan3::cereal_output_archive_concept <>
+ * \brief All output archives of the Cereal library satisfy this.
+ * \extends seqan3::cereal_archive_concept
+ * \ingroup core
+ *
+ * This includes cereal::BinaryOutputArchive, cereal::PortableBinaryOutputArchive, cereal::JSONOutputArchive,
+ * and cereal::XMLOutputArchive.
+ *
+ * \attention
+ * The cereal library is an optional dependency of SeqAn, if it is not found **no types** satisfy this concept.
+ */
+//!\cond
+#if SEQAN3_WITH_CEREAL
+template <typename t>
+concept bool cereal_output_archive_concept = std::is_base_of_v<cereal::detail::OutputArchiveBase, t>;
+#else
+template <typename t>
+concept bool cereal_output_archive_concept = false;
+#endif
+//!\endcond
+
+/*!\interface seqan3::cereal_input_archive_concept <>
+ * \brief All input archives of the Cereal library satisfy this.
+ * \extends seqan3::cereal_archive_concept
+ * \ingroup core
+ *
+ * This includes cereal::BinaryInputArchive, cereal::PortableBinaryInputArchive, cereal::JSONInputArchive,
+ * and cereal::XMLInputArchive.
+ *
+ * \attention
+ * The cereal library is an optional dependency of SeqAn, if it is not found **no types** satisfy this concept.
+ */
+//!\cond
+#if SEQAN3_WITH_CEREAL
+template <typename t>
+concept bool cereal_input_archive_concept = std::is_base_of_v<cereal::detail::InputArchiveBase, t>;
+#else
+template <typename t>
+concept bool cereal_input_archive_concept = false;
+#endif
+//!\endcond
+
+/*!\interface seqan3::cereal_archive_concept <>
+ * \brief All archives of the Cereal library satisfy this.
+ * \ingroup core
+ *
+ * \attention
+ * The cereal library is an optional dependency of SeqAn, if it is not found **no types** satisfy this concept.
+ */
+//!\cond
+#if SEQAN3_WITH_CEREAL
+template <typename t>
+concept bool cereal_archive_concept = cereal_output_archive_concept<t> || cereal_input_archive_concept<t>;
+#else
+template <typename t>
+concept bool cereal_archive_concept = false;
+#endif
+//!\endcond
+
+/*!\interface seqan3::cereal_text_archive_concept <>
+ * \brief All text archives of the Cereal library satisfy this.
+ * \extends seqan3::cereal_archive_concept
+ * \ingroup core
+ *
+ * This includes cereal::JSONOutputArchive, cereal::XMLOutputArchive, cereal::JSONInputArchive,
+ * and cereal::XMLInputArchive.
+ *
+ * \attention
+ * The cereal library is an optional dependency of SeqAn, if it is not found **no types** satisfy this concept.
+ */
+//!\cond
+#if SEQAN3_WITH_CEREAL
+template <typename t>
+concept bool cereal_text_archive_concept = std::is_base_of_v<cereal::traits::TextArchive, t>;
+#else
+template <typename t>
+concept bool cereal_text_archive_concept = false;
+#endif
+//!\endcond
+
+} // namespace seqan3
+
+namespace seqan3::detail
+{
+
+/*!\brief Removes type-mangling that Cereal does with certain types on loading.
+ * \details Helpful when defining templatised save/load/serialize functions.
+ * \ingroup core
+ */
+#if SEQAN3_WITH_CEREAL
+template <typename type>
+using strip_cereal_wrapper_t = typename cereal::traits::strip_minimal<std::decay_t<type>>::type;
+#else
+template <typename type>
+using strip_cereal_wrapper_t = type;
+#endif
+
+} // namespace seqan3::detail

--- a/include/seqan3/core/platform.hpp
+++ b/include/seqan3/core/platform.hpp
@@ -50,26 +50,26 @@
 #define STR(x) STR_HELPER(x)
 //!\endcond
 
-// C++ standard
+// C++ standard [required]
 #ifdef __cplusplus
     static_assert(__cplusplus >= 201500, "SeqAn3 requires C++17, make sure that you have set -std=c++17.");
 #else
 #   error "This is not a C++ compiler."
 #endif
 
-// Concepts TS
+// Concepts TS [required]
 #ifdef __cpp_concepts
     static_assert(__cpp_concepts >= 201507, "Your compiler supports Concepts, but the support is not recent enough.");
 #else
 #   error "SeqAn3 requires the Concepts TS, make sure that you have set -fconcepts (not all compilers support this)."
 #endif
 
-// SeqAn
+// SeqAn [required]
 #if !__has_include(<seqan3/version.hpp>)
 #   error SeqAn3 include directory not set correctly. Forgot to add -I ${INSTALLDIR}/include to your CXXFLAGS?
 #endif
 
-// Ranges
+// Ranges [required]
 #if __has_include(<range/v3/version.hpp>)
 #   define RANGE_V3_MINVERSION 300
 #   define RANGE_V3_MAXVERSION 399
@@ -90,7 +90,39 @@
 #   error The range-v3 library was not included correctly. Forgot to add -I ${INSTALLDIR}/include to your CXXFLAGS?
 #endif
 
-// SDSL
+// SDSL [required]
+// TODO (doesn't have a version.hpp, yet)
+
+// Cereal [optional]
+/*!\def SEQAN3_WITH_CEREAL
+ * \brief Whether CEREAL support is available or not.
+ * \ingroup core
+ */
+#ifndef SEQAN3_WITH_CEREAL
+#   if __has_include(<cereal/cereal.hpp>)
+#       define SEQAN3_WITH_CEREAL 1
+#   else
+#       define SEQAN3_WITH_CEREAL 0
+#   endif
+#endif
+
+#if !SEQAN3_WITH_CEREAL
+    /*!\cond DEV
+     * \name Cereal function macros
+     * \ingroup core
+     * \brief These can be changed by apps so we used the macros instead of the values internally.
+     * \{
+     */
+#   define CEREAL_SERIALIZE_FUNCTION_NAME serialize
+#   define CEREAL_LOAD_FUNCTION_NAME load
+#   define CEREAL_SAVE_FUNCTION_NAME save
+#   define CEREAL_LOAD_MINIMAL_FUNCTION_NAME load_minimal
+#   define CEREAL_SAVE_MINIMAL_FUNCTION_NAME save_minimal
+    /*!\}
+     * \endcond
+     */
+#endif
+
 // TODO (doesn't have a version.hpp, yet)
 
 #undef STR

--- a/include/seqan3/range/container/concatenated_sequences.hpp
+++ b/include/seqan3/range/container/concatenated_sequences.hpp
@@ -49,10 +49,15 @@
 #include <range/v3/view/repeat_n.hpp>
 #include <range/v3/view/slice.hpp>
 
+#include <seqan3/core/concept/cereal.hpp>
 #include <seqan3/core/concept/iterator.hpp>
 #include <seqan3/range/container/concept.hpp>
 #include <seqan3/range/detail/random_access_iterator.hpp>
 #include <seqan3/range/metafunction.hpp>
+
+#if SEQAN3_WITH_CEREAL
+#include <cereal/types/vector.hpp>
+#endif
 
 namespace seqan3
 {
@@ -62,6 +67,7 @@ namespace seqan3
  * \tparam data_delimiters_type A container that stores the begin/end positions in the inner_type. Must be
  * seqan3::reservable_sequence_concept and have inner_type's size_type as value_type.
  * \implements seqan3::reservable_sequence_concept
+ * \ingroup container
  *
  * This class may be used whenever you would usually use `std::vector<std::vector<some_alphabet>>` or
  * `std::vector<std::string>`, i.e. whenever you have a collection of sequences. It is the spiritual successor of
@@ -1282,6 +1288,20 @@ public:
         return data() >= rhs.data();
     }
     //!\}
+
+    /*!\cond DEV
+     * \brief Serialisation support function.
+     * \tparam archive_t Type of `archive`; must satisfy seqan3::cereal_archive_concept.
+     * \param archive The archive being serialised from/to.
+     *
+     * \attention These functions are never called directly, see \ref serialisation for more details.
+     */
+    template <cereal_archive_concept archive_t>
+    void CEREAL_SERIALIZE_FUNCTION_NAME(archive_t & archive)
+    {
+        archive(data_values, data_delimiters);
+    }
+    //!\endcond
 };
 
 } // namespace seqan3

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -65,7 +65,16 @@ include_directories("${GOOGLETEST_ROOT}/googletest/include/")
 include_directories("${SEQAN3_ROOT}/include/")
 include_directories("${SEQAN3_ROOT}/range-v3/include/")
 include_directories("${SEQAN3_ROOT}/sdsl-lite/include/")
+include_directories("${SEQAN3_ROOT}/cereal/include/")
 
+## Optional dependency handling
+option (NO_CEREAL "Don't use cereal, even if present." OFF)
+
+if (NO_CEREAL)
+    add_definitions (-DSEQAN3_WITH_CEREAL=0)
+endif (NO_CEREAL)
+
+## Add the tests
 macro (add_subdirectories)
     file (GLOB ENTRIES
           RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,7 +4,7 @@ project(seqan3_tests CXX)
 ### set googletest
 enable_testing()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1z -fconcepts -Wall -Wextra")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1z -fconcepts -pedantic -Werror -Wall -Wextra")
 
 # CMAKE_SOURCE_DIR is seqan3/test (the path of this CMakeLists.txt)
 set(SEQAN3_ROOT "${CMAKE_SOURCE_DIR}/..")

--- a/test/alphabet/quality/quality_composition_test.cpp
+++ b/test/alphabet/quality/quality_composition_test.cpp
@@ -52,9 +52,7 @@ TEST(quality_composition, ctr)
 // aggregate initialization
 TEST(quality_composition, aggr)
 {
-    quality_composition<dna4, illumina18> t1;
-    quality_composition<dna4, illumina18> t2{dna4::C, 7};
-    EXPECT_NE(t1, t2);
+    [[maybe_unused]]  quality_composition<dna4, illumina18> t1{dna4::C, 7};
 }
 
 // zero initialization

--- a/test/alphabet/structure_test.cpp
+++ b/test/alphabet/structure_test.cpp
@@ -44,6 +44,7 @@
 
 #include <seqan3/alphabet/concept.hpp>
 #include <seqan3/alphabet/nucleotide/rna4.hpp>
+#include <seqan3/alphabet/nucleotide/rna5.hpp>
 #include <seqan3/alphabet/structure/all.hpp>
 
 using namespace seqan3;
@@ -316,9 +317,7 @@ TEST(structured_rna, ctr)
 // aggregate initialization
 TEST(structured_rna, aggr)
 {
-    structured_rna<rna4, dot_bracket3> t1;
-    structured_rna<rna4, dot_bracket3> t2{rna4::C, dot_bracket3::PAIR_CLOSE};
-    EXPECT_NE(t1, t2);
+    [[maybe_unused]]  structured_rna<rna4, dot_bracket3> t1{rna4::C, dot_bracket3::PAIR_CLOSE};
 }
 
 // zero initialization
@@ -629,9 +628,7 @@ TEST(structured_aa, ctr)
 // aggregate initialization
 TEST(structured_aa, aggr)
 {
-    structured_aa<aa27, dssp9> t1;
-    structured_aa<aa27, dssp9> t2{aa27::C, dssp9::B};
-    EXPECT_NE(t1, t2);
+    [[maybe_unused]] structured_aa<aa27, dssp9> t1{aa27::C, dssp9::B};
 }
 
 // zero initialization

--- a/test/core/pod_tuple_test.cpp
+++ b/test/core/pod_tuple_test.cpp
@@ -49,9 +49,7 @@ TEST(pod_tuple_ctr, ctr)
 // aggregate initialization
 TEST(pod_tuple_aggr, aggr)
 {
-    pod_tuple<int, long, float> t1;
-    pod_tuple<int, long, float> t2{4, 7l, 3.0f};
-    EXPECT_NE(t1, t2);
+    [[maybe_unused]] pod_tuple<int, long, float> t1{4, 7l, 3.0f};
 }
 
 // zero initialization

--- a/test/range/detail/random_access_iterator_test.cpp
+++ b/test/range/detail/random_access_iterator_test.cpp
@@ -50,7 +50,7 @@ protected:
     std::vector<uint8_t> const v3_const{'a', 't', 'z'};
     std::vector<uint8_t> const v4_const{'a', 'u', 'v', 'w', 'x'};
     std::vector<uint8_t> const w_const{'c', 't'};
-    std::vector<uint8_t> const w2_const{'b', 'v'};;
+    std::vector<uint8_t> const w2_const{'b', 'v'};
     std::array<long int, 3> a;
     std::array<long int, 3> const a_const = {11, 22, 33};
 


### PR DESCRIPTION
This adds proper serialisation support. It is completely optional so SeqAn will build with and without Cereal. You don't have to do macro voodoo when adding serialisation functions as the serialisation functions are templates.

Have a look at f13d7db how easy this for specific types.

Generic versions are more difficult, but we won't need to implement them often.

This PR also adds `-pedantic` to our tests, because I was having warnings and fixing them anyway.

Please also note the changes here:
* https://github.com/seqan/seqan3/wiki/File-structure-and-naming#contents (order of includes, optional deps go **after SeqAn**)
* https://github.com/seqan/seqan3/wiki/Documentation#configuration (some changes to doxygen config)