### PR TITLE
[INTERNAL] Infrastructure: add -pthread flag and activate bin dir for built binaries.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,10 +1,14 @@
 cmake_minimum_required(VERSION 3.2)
 project(seqan3_tests CXX)
 
+### set bin directory to place the binaries.
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
 ### set googletest
 enable_testing()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1z -fconcepts -pedantic -Werror -Wall -Wextra")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1z -fconcepts -pedantic -Werror -Wall -Wextra -pthread")
 
 # CMAKE_SOURCE_DIR is seqan3/test (the path of this CMakeLists.txt)
 set(SEQAN3_ROOT "${CMAKE_SOURCE_DIR}/..")


### PR DESCRIPTION
Not on all systems it is sufficient to only include pthread with "-lpthread".
Some platforms need also the respective compiler flag "-pthread".
So we include it for the test cxx flags in order to ensure it is detected correctly on all platforms.

Furthermore I activated a `bin` dir to put the binaries in.
 