### PR TITLE
[FEATURE] Add error message type for parsing errors.

### DIFF
--- a/include/seqan3/core/detail/static_string.hpp
+++ b/include/seqan3/core/detail/static_string.hpp
@@ -1,0 +1,123 @@
+// ============================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ============================================================================
+//
+// Copyright (c) 2006-2017, Knut Reinert & Freie Universitaet Berlin
+// Copyright (c) 2016-2017, Knut Reinert & MPI Molekulare Genetik
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ============================================================================
+
+/*!\file
+ * \ingroup core
+ * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ * \brief A static string implementation to manipulate string literals at compile time.
+ */
+
+#include <type_traits>
+#include <array>
+
+namespace seqan3
+{
+
+template <std::size_t N>
+class static_string
+{
+public:
+
+    static_string() = delete;
+    static_string(static_string const &) = default;
+    static_string(static_string &&) = default;
+    static_string & operator=(static_string const &) = default;
+    static_string & operator=(static_string &&) = default;
+
+    // Construction from two static_strings.
+    template <std::size_t N1>
+    constexpr static_string(static_string<N1> const & lhs,
+                            static_string<N - N1> const & rhs) noexcept
+    {
+        for (unsigned i = 0; i < N1; ++i)
+            _lit[i] = lhs[i];
+        for (unsigned i = N1; i < N + 1; ++i)
+            _lit[i] = rhs[i - N1];
+    }
+
+    // Construction from literal.
+    constexpr static_string(const char (&lit)[N + 1]) noexcept
+    {
+        // static_assert(lit[N] == '\0'); TODO(rrahn): Fix me
+        for (unsigned i = 0; i < N + 1; ++i)
+            _lit[i] = lit[i];
+    }
+
+    // Construction from char.
+    constexpr static_string(const char c) noexcept
+    {
+        _lit[0] = c;
+        _lit[1] = '\0';
+    }
+
+    // access via subscript
+    constexpr char operator[](std::size_t n) const noexcept
+    {
+        return _lit[n];
+    }
+
+    // Concatenation
+    template <std::size_t N2>
+    constexpr static_string<N + N2> operator+(static_string<N2> const & rhs) noexcept
+    {
+        return static_string<N + N2>{*this, rhs};
+    }
+
+    constexpr std::size_t size() noexcept
+    {
+        return N;
+    }
+
+    std::string string()
+    {
+        return std::string{ _lit.cbegin(), _lit.cend() - 1};
+    }
+
+    constexpr const char * c_str() noexcept
+    {
+        return _lit.data();
+    }
+
+protected:
+  std::array<char, N + 1> _lit{};
+};
+
+// User defined deduction guide for string literals
+template <std::size_t N>
+static_string(const char (&)[N]) -> static_string<N - 1>;
+
+// User defined deduction guide for chars
+static_string(const char) -> static_string<1>;
+
+}  // namespace seqan3

--- a/test/core/detail/CMakeLists.txt
+++ b/test/core/detail/CMakeLists.txt
@@ -1,1 +1,2 @@
 seqan3_test(int_types_test.cpp)
+seqan3_test(static_string_test.cpp)

--- a/test/core/detail/static_string_test.cpp
+++ b/test/core/detail/static_string_test.cpp
@@ -1,0 +1,126 @@
+// ==========================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ==========================================================================
+//
+// Copyright (c) 2006-2017, Knut Reinert, FU Berlin
+// Copyright (c) 2016-2017, Knut Reinert & MPI Molekulare Genetik
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ==========================================================================
+
+#include <gtest/gtest.h>
+
+#include <seqan3/core/detail/static_string.hpp>
+
+#include <string>
+
+using namespace std::literals;
+using namespace seqan3;
+
+// standard construction.
+TEST(static_string, standard_construction)
+{
+    EXPECT_FALSE((std::is_default_constructible_v<static_string<4>>));
+    EXPECT_TRUE((std::is_copy_constructible_v<static_string<4>>));
+    EXPECT_TRUE((std::is_trivially_copy_constructible_v<static_string<4>>));
+    EXPECT_TRUE((std::is_nothrow_copy_constructible_v<static_string<4>>));
+    EXPECT_TRUE((std::is_move_constructible_v<static_string<4>>));
+    EXPECT_TRUE((std::is_trivially_move_constructible_v<static_string<4>>));
+    EXPECT_TRUE((std::is_nothrow_move_constructible_v<static_string<4>>));
+    EXPECT_TRUE((std::is_copy_assignable_v<static_string<4>>));
+    EXPECT_TRUE((std::is_trivially_copy_assignable_v<static_string<4>>));
+    EXPECT_TRUE((std::is_nothrow_copy_assignable_v<static_string<4>>));
+    EXPECT_TRUE((std::is_move_assignable_v<static_string<4>>));
+    EXPECT_TRUE((std::is_trivially_move_assignable_v<static_string<4>>));
+    EXPECT_TRUE((std::is_nothrow_move_assignable_v<static_string<4>>));
+}
+
+// construction from literal.
+TEST(static_string, construct_from_literal)
+{
+     EXPECT_TRUE((std::is_same_v<static_string<5>, decltype(static_string{"hello"})>));
+}
+
+// construction from char.
+TEST(static_string, construct_from_char)
+{
+     EXPECT_TRUE((std::is_same_v<static_string<1>, decltype(static_string{'h'})>));
+}
+
+template <size_t S>
+struct foo
+{
+    inline size_t get() const {return S;};
+};
+
+TEST(static_string, size)
+{
+    static_string em{"hello"};
+    foo<em.size()> f;
+
+    EXPECT_EQ(em.size(), 5u);
+    EXPECT_EQ(f.get(), 5u);
+}
+
+TEST(static_string, c_str)
+{
+    {
+        static_string em{"hello"};
+        EXPECT_EQ(std::string{em.c_str()}, "hello"s);
+    }
+
+    {
+        static_string em{'x'};
+        EXPECT_EQ(std::string{em.c_str()}, "x"s);
+    }
+}
+
+TEST(static_string, string)
+{
+    static_string em{"hello"};
+    EXPECT_EQ(em.string(), "hello"s);
+}
+
+TEST(static_string, concat)
+{
+    {
+        static_string em = static_string{"hello"} + static_string{' '} + static_string{"world"};
+        foo<em.size()> f;
+        EXPECT_EQ(f.get(), 11u);
+        EXPECT_EQ(em.string(), "hello world"s);
+    }
+
+    {
+        static constexpr char const a[] = "hello";
+        static constexpr char const b[] = " ";
+        static constexpr char const c[] = "world";
+        auto em = static_string{a} + static_string{b} + static_string{c};
+        EXPECT_EQ(em.string(), "hello world"s);
+        foo<em.size()> f;
+        EXPECT_EQ(f.get(), 11u);
+    }
+}

--- a/test/io/CMakeLists.txt
+++ b/test/io/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectories()


### PR DESCRIPTION
I moved the initial error message implementation to a `static_string` class.
This is more convenient, as it can be used by other things too.
Furthermore the design is now much more simpler and easier to understand.

There are still some open questions. The name suggest compatibility with strings, but it is far from implementing a full `sequence_concept`.
Right now, I mostly see it to be used to solve issues with compile time definitions such as 
```cpp

struct baz
{
    static constecpr char const foo[] = "bar";
};

constexpr auto baz_v = baz::foo;
```
Here the type of `baz_v` would be `char const *` losing the information of the array size.
Second, we can concat compile time strings, which is a feature useful for the tokenization.
It should not extend the concept of whatever an `std::array` defines. Do you agree?
Might find a better name though.

### TODO
- [ ] add docu
- [ ] fix copyright year
