### PR TITLE
[Feature] alphabet name

### DIFF
--- a/include/seqan3/alphabet/adaptation/char.hpp
+++ b/include/seqan3/alphabet/adaptation/char.hpp
@@ -72,6 +72,7 @@
 
 #include <seqan3/alphabet/concept_pre.hpp>
 #include <seqan3/core/detail/int_types.hpp>
+#include <seqan3/core/detail/static_string.hpp>
 
 namespace seqan3::detail
 {
@@ -161,6 +162,22 @@ struct alphabet_size<char_type>
     //!\brief The alphabet's size.
     static constexpr type value =
         static_cast<type>(std::numeric_limits<char_type>::max()) + 1 - std::numeric_limits<char_type>::lowest();
+};
+
+// ------------------------------------------------------------------
+// name metafunctions
+// ------------------------------------------------------------------
+
+template <typename char_type>
+//!\cond
+    requires detail::is_char_adaptation_v<char_type>
+//!\endcond
+struct alphabet_name<char_type>
+{
+    static constexpr std::tuple _t{static_string{"char"}, static_string{"char16"}, static_string{"char32"}};
+
+    static constexpr static_string value =
+        std::get<meta::find_index<detail::char_adaptations, char_type>::value>(_t);
 };
 
 // ------------------------------------------------------------------

--- a/include/seqan3/alphabet/adaptation/uint.hpp
+++ b/include/seqan3/alphabet/adaptation/uint.hpp
@@ -69,6 +69,7 @@
 #include <meta/meta.hpp>
 
 #include <seqan3/core/detail/int_types.hpp>
+#include <seqan3/core/detail/static_string.hpp>
 #include <seqan3/alphabet/concept_pre.hpp>
 
 namespace seqan3::detail
@@ -157,6 +158,22 @@ struct alphabet_size<uint_type>
     //!\brief The alphabet's size.
     static constexpr type value =
         static_cast<type>(std::numeric_limits<uint_type>::max()) + 1 - std::numeric_limits<uint_type>::lowest();
+};
+
+// ------------------------------------------------------------------
+// name metafunctions
+// ------------------------------------------------------------------
+
+template <typename uint_type>
+//!\cond
+    requires detail::is_uint_adaptation_v<uint_type>
+//!\endcond
+struct alphabet_name<uint_type>
+{
+    static constexpr std::tuple _t{static_string{"uint8_t"}, static_string{"uint16_t"}, static_string{"uint32_t"}};
+
+    static constexpr static_string value =
+        std::get<meta::find_index<detail::uint_adaptations, uint_type>::value>(_t);
 };
 
 // ------------------------------------------------------------------

--- a/include/seqan3/alphabet/aminoacid/aa27.hpp
+++ b/include/seqan3/alphabet/aminoacid/aa27.hpp
@@ -46,6 +46,7 @@
 #include <vector>
 
 #include <seqan3/core/platform.hpp>
+#include <seqan3/core/detail/static_string.hpp>
 
 namespace seqan3
 {
@@ -154,6 +155,9 @@ struct aa27
 
     //!\brief The size of the alphabet, i.e. the number of different values it can take.
     static constexpr rank_type value_size{27};
+
+    //!\brief The name of the alphabet.
+    static constexpr static_string name{"aa27"};
 
     //!\name Comparison operators
     //!\{

--- a/include/seqan3/alphabet/composition/cartesian_composition.hpp
+++ b/include/seqan3/alphabet/composition/cartesian_composition.hpp
@@ -49,6 +49,7 @@
 #include <seqan3/alphabet/quality/concept.hpp>
 #include <seqan3/core/pod_tuple.hpp>
 #include <seqan3/core/detail/int_types.hpp>
+#include <seqan3/core/detail/static_string.hpp>
 
 namespace seqan3
 {
@@ -93,6 +94,12 @@ public:
     //!\brief The product of the sizes of the individual alphabets.
     static constexpr rank_type value_size{(alphabet_size_v<first_alphabet_type> * ... *
                                                alphabet_size_v<alphabet_types>)};
+
+    //!\brief The name of the alphabet.
+    static constexpr static_string name = static_string{"cartesian<"} +
+                                                (alphabet_name_v<first_alphabet_type> + ... +
+                                                (static_string{" * "} + alphabet_name_v<alphabet_types>)) +
+                                          static_string{'>'};
 
     /*!\name Read functions
      * \{

--- a/include/seqan3/alphabet/composition/union_composition.hpp
+++ b/include/seqan3/alphabet/composition/union_composition.hpp
@@ -50,6 +50,7 @@
 
 #include <seqan3/alphabet/concept.hpp>
 #include <seqan3/core/detail/int_types.hpp>
+#include <seqan3/core/detail/static_string.hpp>
 
 namespace seqan3::detail
 {
@@ -295,6 +296,12 @@ public:
 
     //!\brief The size of the alphabet, i.e. the number of different values it can take.
     static constexpr size_t value_size = (alphabet_types::value_size + ... + first_alphabet_type::value_size);
+
+    //!\brief The name of the alphabet.
+    static constexpr static_string name = static_string{"union<"} +
+                                          (alphabet_name_v<first_alphabet_type> + ... +
+                                                (static_string{" & "} + alphabet_name_v<alphabet_types>)) +
+                                          static_string{'>'};
 
     //!\brief The type of the alphabet when converted to char (e.g. via \link to_char \endlink)
     using char_type = typename first_alphabet_type::char_type;

--- a/include/seqan3/alphabet/concept.hpp
+++ b/include/seqan3/alphabet/concept.hpp
@@ -95,6 +95,10 @@ concept bool semi_alphabet_concept = requires (t t1, t t2)
     { t1 >  t2 } -> bool;
     { t1 <= t2 } -> bool;
     { t1 >= t2 } -> bool;
+
+    // alphabet name
+    alphabet_name<t>::value;
+    alphabet_name_v<t>;
 };
 //!\endcond
 

--- a/include/seqan3/alphabet/concept_pre.hpp
+++ b/include/seqan3/alphabet/concept_pre.hpp
@@ -126,6 +126,39 @@ template <typename alphabet_type>
 //!\endcond
 constexpr auto alphabet_size_v = alphabet_size<alphabet_type>::value;
 
+/*!\brief The size of the alphabet. [value metafunction base template]
+ * \tparam alphabet_type Must satisfy seqan3::semi_alphabet_concept.
+ * \ingroup alphabet
+ *
+ * This is the expression to retrieve the value:
+ * ```cpp
+ * auto i = seqan3::alphabet_size<alphabet_type>::value;
+ * // or
+ * auto i = seqan3::alphabet_size_v<alphabet_type>;
+ * ```
+ * The type of the variable is seqan3::underlying_rank_t<alphabet_type>.
+ *
+ * \par Helper variable template
+ *   seqan3::alphabet_size_v as a shorthand for `seqan3::alphabet_size<alphabet_type>::%value`
+ *
+ * \attention This is the base template, it needs to be specialised.
+ */
+template <typename alphabet_type>
+struct alphabet_name{};
+
+/*!\brief The size of the alphabet. [value metafunction shortcut]
+ * \tparam alphabet_type Must satisfy seqan3::semi_alphabet_concept.
+ * \ingroup alphabet
+ *
+ * \attention Do not specialise this shortcut, instead specialise seqan3::alphabet_name.
+ */
+template <typename alphabet_type>
+//!\cond
+    // TODO(rrahn): check if condition can be met here already.
+    requires requires (alphabet_type alph) { alphabet_name<alphabet_type>::value; }
+//!\endcond
+constexpr auto alphabet_name_v = alphabet_name<alphabet_type>::value;
+
 /*!\fn rank_type seqan3::to_rank(semi_alphabet_concept const alph)
  * \brief Returns the alphabet letter's value in rank representation.
  * \ingroup alphabet

--- a/include/seqan3/alphabet/detail/member_exposure.hpp
+++ b/include/seqan3/alphabet/detail/member_exposure.hpp
@@ -45,6 +45,7 @@
 #include <iostream>
 
 #include <seqan3/alphabet/concept_pre.hpp>
+#include <seqan3/core/detail/static_string.hpp>
 
 namespace seqan3
 {
@@ -87,6 +88,21 @@ struct alphabet_size<alphabet_type_with_members>
     //!\brief The size retrieved from the type's member.
     static constexpr underlying_rank_t<alphabet_type_with_members> value =
         alphabet_type_with_members::value_size;
+};
+
+/*!\brief Specialisation of seqan3::alphabet_name that delegates to `alphabet_type::name`.
+ * \tparam alphabet_type Must provide a static member variable calls `name`.
+ *
+ * Instead of accessing this struct directly, just use seqan3::alphabet_name_v.
+ */
+template <typename alphabet_type_with_members>
+//!\cond
+    requires requires (alphabet_type_with_members alph) { alphabet_type_with_members::name; }
+//!\endcond
+struct alphabet_name<alphabet_type_with_members>
+{
+    //!\brief The name retrieved from the type's member.
+    static constexpr static_string value{alphabet_type_with_members::name};
 };
 
 /*!\brief Implementation of seqan3::semi_alphabet_concept::to_rank() that delegates to a member function.

--- a/include/seqan3/alphabet/gap/gap.hpp
+++ b/include/seqan3/alphabet/gap/gap.hpp
@@ -118,6 +118,9 @@ struct gap
     //!\brief The size of the alphabet, i.e. the number of different values it can take.
     static constexpr rank_type value_size{1};
 
+    //!\brief The name of the alphabet.
+    static constexpr static_string name{"gap"};
+
     //!\name Comparison operators
     //!\{
     constexpr bool operator==(gap const &) const noexcept

--- a/include/seqan3/alphabet/gap/gapped.hpp
+++ b/include/seqan3/alphabet/gap/gapped.hpp
@@ -84,6 +84,9 @@ struct gapped : public union_composition<alphabet_t, gap>
     using typename union_composition<alphabet_t, gap>::rank_type;
     using typename union_composition<alphabet_t, gap>::char_type;
 
+    //!\brief The name of the alphabet.
+    static constexpr static_string name{static_string{"gapped_"} + alphabet_t::name};
+
     //!\copydoc union_composition::assign_char
     constexpr gapped & assign_char(char_type const c) noexcept
     {

--- a/include/seqan3/alphabet/nucleotide/dna4.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna4.hpp
@@ -48,6 +48,7 @@
 
 #include <seqan3/alphabet/detail/convert.hpp>
 #include <seqan3/alphabet/nucleotide/concept.hpp>
+#include <seqan3/core/detail/static_string.hpp>
 
 // ------------------------------------------------------------------
 // dna4
@@ -207,6 +208,9 @@ struct dna4
 
     //!\brief The size of the alphabet, i.e. the number of different values it can take.
     static constexpr rank_type value_size{4};
+
+    //!\brief The name of the alphabet.
+    static constexpr static_string name{"dna4"};
 
     /*!\name Conversion operators
      * \{

--- a/include/seqan3/alphabet/nucleotide/dna5.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna5.hpp
@@ -48,6 +48,7 @@
 
 #include <seqan3/alphabet/detail/convert.hpp>
 #include <seqan3/alphabet/nucleotide/concept.hpp>
+#include <seqan3/core/detail/static_string.hpp>
 
 // ------------------------------------------------------------------
 // dna5
@@ -141,6 +142,9 @@ struct dna5
 
     //!\copydoc seqan3::dna4::value_size
     static constexpr rank_type value_size{5};
+
+    //!\brief The name of the alphabet.
+    static constexpr static_string name{"dna5"};
 
     /*!\name Conversion operators
      * \{

--- a/include/seqan3/alphabet/nucleotide/nucl16.hpp
+++ b/include/seqan3/alphabet/nucleotide/nucl16.hpp
@@ -47,6 +47,7 @@
 
 #include <seqan3/alphabet/detail/convert.hpp>
 #include <seqan3/alphabet/nucleotide/concept.hpp>
+#include <seqan3/core/detail/static_string.hpp>
 
 // ------------------------------------------------------------------
 // nucl16
@@ -150,6 +151,9 @@ struct nucl16
 
     //!\copydoc seqan3::dna4::value_size
     static constexpr rank_type value_size{16};
+
+    //!\brief The name of the alphabet.
+    static constexpr static_string name{"nucl16"};
 
     /*!\name Conversion operators
      * \{
@@ -455,4 +459,3 @@ inline nucl16_string operator""_nucl16s(const char * s, std::size_t n)
 }
 
 } // namespace seqan3::literal
-

--- a/include/seqan3/alphabet/nucleotide/rna4.hpp
+++ b/include/seqan3/alphabet/nucleotide/rna4.hpp
@@ -48,6 +48,7 @@
 #include <seqan3/alphabet/detail/convert.hpp>
 #include <seqan3/alphabet/nucleotide/concept.hpp>
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
+#include <seqan3/core/detail/static_string.hpp>
 
 // ------------------------------------------------------------------
 // rna4
@@ -126,6 +127,9 @@ struct rna4 : public dna4
         return *this;
     }
     //!\}
+
+    //!\brief The name of the alphabet.
+    static constexpr static_string name{"rna4"};
 
     /*!\name Conversion operators
      * \{
@@ -279,4 +283,3 @@ inline rna4_string operator""_rna4s(const char * s, std::size_t n)
 }
 
 } // namespace seqan3::literal
-

--- a/include/seqan3/alphabet/nucleotide/rna5.hpp
+++ b/include/seqan3/alphabet/nucleotide/rna5.hpp
@@ -48,6 +48,7 @@
 #include <seqan3/alphabet/detail/convert.hpp>
 #include <seqan3/alphabet/nucleotide/concept.hpp>
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
+#include <seqan3/core/detail/static_string.hpp>
 
 // ------------------------------------------------------------------
 // rna5
@@ -127,6 +128,9 @@ struct rna5 : public dna5
         return *this;
     }
     //!\}
+
+    //!\brief The name of the alphabet.
+    static constexpr static_string name{"rna5"};
 
     /*!\name Conversion operators
      * \{
@@ -282,4 +286,3 @@ inline rna5_string operator""_rna5s(const char * s, std::size_t n)
 }
 
 } // namespace seqan3::literal
-

--- a/include/seqan3/alphabet/quality/illumina18.hpp
+++ b/include/seqan3/alphabet/quality/illumina18.hpp
@@ -38,6 +38,8 @@
 
 #include <cassert>
 
+#include <seqan3/core/detail/static_string.hpp>
+
 namespace seqan3
 {
 
@@ -149,6 +151,9 @@ struct illumina18
 
     //! phred score range for Illumina 1.8 standard
     static constexpr rank_type value_size{42};
+
+    //! The name of this alphabet.
+    static constexpr static_string name{"illumina18"};
 
 protected:
 

--- a/include/seqan3/alphabet/quality/quality_composition.hpp
+++ b/include/seqan3/alphabet/quality/quality_composition.hpp
@@ -110,6 +110,11 @@ struct quality_composition :
     //!\brief Equals the phred_type of the quality_alphabet_type.
     using phred_type = underlying_phred_t<quality_alphabet_type>;
 
+    //! The name of this alphabet.
+    static constexpr static_string name = static_string{"quality<"} + alphabet_name_v<sequence_alphabet_t> +
+                                          static_string{'-'} + alphabet_name_v<quality_alphabet_t> +
+                                          static_string{'>'};
+
     /*!\name Write functions
      * \{
      */

--- a/include/seqan3/alphabet/structure/dot_bracket3.hpp
+++ b/include/seqan3/alphabet/structure/dot_bracket3.hpp
@@ -45,6 +45,7 @@
 #include <vector>
 
 #include <seqan3/alphabet/structure/rna_structure_concept.hpp>
+#include <seqan3/core/detail/static_string.hpp>
 
 // ------------------------------------------------------------------
 // dot_bracket3
@@ -143,6 +144,9 @@ struct dot_bracket3
 
     //!\brief The size of the alphabet, i.e. the number of different values it can take.
     static constexpr rank_type value_size{3};
+
+    //! The name of this alphabet.
+    static constexpr static_string name{"dot_bracket3"};
 
     //!\name Comparison operators
     //!\{

--- a/include/seqan3/alphabet/structure/dssp9.hpp
+++ b/include/seqan3/alphabet/structure/dssp9.hpp
@@ -45,6 +45,7 @@
 #include <vector>
 
 #include <seqan3/alphabet/concept.hpp>
+#include <seqan3/core/detail/static_string.hpp>
 
 // ------------------------------------------------------------------
 // dssp9
@@ -156,6 +157,9 @@ struct dssp9
 
     //!\brief The size of the alphabet, i.e. the number of different values it can take.
     static constexpr rank_type value_size{9};
+
+    //! The name of this alphabet.
+    static constexpr static_string name{"dssp9"};
 
     //!\name Comparison operators
     //!\{

--- a/include/seqan3/alphabet/structure/structured_aa.hpp
+++ b/include/seqan3/alphabet/structure/structured_aa.hpp
@@ -48,6 +48,7 @@
 #include <seqan3/alphabet/composition/cartesian_composition.hpp>
 #include <seqan3/alphabet/concept.hpp>
 #include <seqan3/alphabet/structure/dssp9.hpp>
+#include <seqan3/core/detail/static_string.hpp>
 
 namespace seqan3
 {
@@ -103,6 +104,11 @@ struct structured_aa :
 
     //!\brief Equals the char_type of sequence_alphabet_type.
     using char_type = underlying_char_t<sequence_alphabet_type>;
+
+    //! The name of this alphabet.
+    static constexpr static_string name = static_string{"structured_aa<"} + alphabet_name_v<sequence_alphabet_t> +
+                                          static_string{'_'} + alphabet_name_v<structure_alphabet_t> +
+                                          static_string{'>'};
 
     /*!\name Write functions
      * \{

--- a/include/seqan3/alphabet/structure/structured_rna.hpp
+++ b/include/seqan3/alphabet/structure/structured_rna.hpp
@@ -47,6 +47,7 @@
 #include <seqan3/alphabet/composition/cartesian_composition.hpp>
 #include <seqan3/alphabet/nucleotide/concept.hpp>
 #include <seqan3/alphabet/structure/rna_structure_concept.hpp>
+#include <seqan3/core/detail/static_string.hpp>
 
 namespace seqan3
 {
@@ -102,6 +103,12 @@ struct structured_rna :
 
     //!\brief Equals the char_type of sequence_alphabet_type.
     using char_type = underlying_char_t<sequence_alphabet_type>;
+
+    //! The name of this alphabet.
+    static constexpr static_string name = static_string{"structured_rna<"} +
+                                          alphabet_name_v<sequence_alphabet_t> +
+                                          static_string{'_'} + alphabet_name_v<structure_alphabet_t> +
+                                          static_string{'>'};
 
     //!\name Write functions
     //!\{

--- a/include/seqan3/alphabet/structure/wuss.hpp
+++ b/include/seqan3/alphabet/structure/wuss.hpp
@@ -45,6 +45,7 @@
 #include <vector>
 
 #include <seqan3/alphabet/concept.hpp>
+#include <seqan3/core/detail/static_string.hpp>
 
 // ------------------------------------------------------------------
 // wuss
@@ -52,6 +53,27 @@
 
 namespace seqan3
 {
+
+namespace detail
+{
+template<unsigned... digits>
+struct to_chars
+{
+    constexpr static const char value[] = {('0' + digits)..., 0};
+};
+
+template<unsigned rem, unsigned... digits>
+struct explode : explode<rem / 10, rem % 10, digits...>
+{};
+
+template<unsigned... digits>
+struct explode<0, digits...> : to_chars<digits...>
+{};
+
+template<unsigned num>
+struct num_to_string : explode<num>
+{};
+}
 
 /*!\brief The WUSS structure alphabet of the characters `.<>:,-_~;()[]{}AaBbCcDd`...
  * \tparam SIZE The alphabet size defaults to 50 and must be an odd number in range 15..67.
@@ -183,6 +205,11 @@ struct wuss
 
     //!\brief The size of the alphabet, i.e. the number of different values it can take.
     static constexpr rank_type value_size{SIZE};
+
+    //! The name of this alphabet.
+    static constexpr static_string name = static_string{"wuss<"} +
+                                          static_string{detail::explode<static_cast<unsigned>(SIZE)>::value} +
+                                          static_string{'>'};
 
     //!\name Comparison operators
     //!\{

--- a/include/seqan3/core/detail/static_string.hpp
+++ b/include/seqan3/core/detail/static_string.hpp
@@ -1,0 +1,123 @@
+// ============================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ============================================================================
+//
+// Copyright (c) 2006-2017, Knut Reinert & Freie Universitaet Berlin
+// Copyright (c) 2016-2017, Knut Reinert & MPI Molekulare Genetik
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ============================================================================
+
+/*!\file
+ * \ingroup core
+ * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ * \brief A static string implementation to manipulate string literals at compile time.
+ */
+
+#include <type_traits>
+#include <array>
+
+namespace seqan3
+{
+
+template <std::size_t N>
+class static_string
+{
+public:
+
+    static_string() = delete;
+    static_string(static_string const &) = default;
+    static_string(static_string &&) = default;
+    static_string & operator=(static_string const &) = default;
+    static_string & operator=(static_string &&) = default;
+
+    // Construction from two static_strings.
+    template <std::size_t N1>
+    constexpr static_string(static_string<N1> const & lhs,
+                            static_string<N - N1> const & rhs) noexcept
+    {
+        for (unsigned i = 0; i < N1; ++i)
+            _lit[i] = lhs[i];
+        for (unsigned i = N1; i < N + 1; ++i)
+            _lit[i] = rhs[i - N1];
+    }
+
+    // Construction from literal.
+    constexpr static_string(const char (&lit)[N + 1]) noexcept
+    {
+        // static_assert(lit[N] == '\0'); TODO(rrahn): Fix me
+        for (unsigned i = 0; i < N + 1; ++i)
+            _lit[i] = lit[i];
+    }
+
+    // Construction from char.
+    constexpr static_string(const char c) noexcept
+    {
+        _lit[0] = c;
+        _lit[1] = '\0';
+    }
+
+    // access via subscript
+    constexpr char operator[](std::size_t n) const noexcept
+    {
+        return _lit[n];
+    }
+
+    // Concatenation
+    template <std::size_t N2>
+    constexpr static_string<N + N2> operator+(static_string<N2> const & rhs) noexcept
+    {
+        return static_string<N + N2>{*this, rhs};
+    }
+
+    constexpr std::size_t size() noexcept
+    {
+        return N;
+    }
+
+    std::string string()
+    {
+        return std::string{ _lit.cbegin(), _lit.cend() - 1};
+    }
+
+    constexpr const char * c_str() noexcept
+    {
+        return _lit.data();
+    }
+
+protected:
+  std::array<char, N + 1> _lit{};
+};
+
+// User defined deduction guide for string literals
+template <std::size_t N>
+static_string(const char (&)[N]) -> static_string<N - 1>;
+
+// User defined deduction guide for chars
+static_string(const char) -> static_string<1>;
+
+}  // namespace seqan3

--- a/include/seqan3/core/detail/static_string.hpp
+++ b/include/seqan3/core/detail/static_string.hpp
@@ -32,6 +32,8 @@
 //
 // ============================================================================
 
+#pragma once
+
 /*!\file
  * \ingroup core
  * \author Rene Rahn <rene.rahn AT fu-berlin.de>
@@ -89,22 +91,22 @@ public:
 
     // Concatenation
     template <std::size_t N2>
-    constexpr static_string<N + N2> operator+(static_string<N2> const & rhs) noexcept
+    constexpr static_string<N + N2> operator+(static_string<N2> const & rhs) const noexcept
     {
         return static_string<N + N2>{*this, rhs};
     }
 
-    constexpr std::size_t size() noexcept
+    constexpr std::size_t size() const noexcept
     {
         return N;
     }
 
-    std::string string()
+    std::string string() const
     {
         return std::string{ _lit.cbegin(), _lit.cend() - 1};
     }
 
-    constexpr const char * c_str() noexcept
+    constexpr const char * c_str() const noexcept
     {
         return _lit.data();
     }

--- a/test/alphabet/adaptation/char_test.cpp
+++ b/test/alphabet/adaptation/char_test.cpp
@@ -108,3 +108,22 @@ TYPED_TEST(char_adaptation, alphabet_size_v)
     EXPECT_EQ(alphabet_size_v<TypeParam>,
         static_cast<size_t>(std::numeric_limits<TypeParam>::max()) + 1 - std::numeric_limits<TypeParam>::lowest());
 }
+
+TYPED_TEST(char_adaptation, alphabet_name)
+{
+    if constexpr (sizeof(TypeParam) == 1)
+    {
+        EXPECT_EQ(alphabet_name<TypeParam>::value.string(), std::string{"char"});
+        EXPECT_EQ(alphabet_name_v<TypeParam>.string(), std::string{"char"});
+    }
+    else if constexpr (sizeof(TypeParam) == 2)
+    {
+        EXPECT_EQ(alphabet_name<TypeParam>::value.string(), std::string{"char16"});
+        EXPECT_EQ(alphabet_name_v<TypeParam>.string(), std::string{"char16"});
+    }
+    else
+    {
+        EXPECT_EQ(alphabet_name<TypeParam>::value.string(), std::string{"char32"});
+        EXPECT_EQ(alphabet_name_v<TypeParam>.string(), std::string{"char32"});
+    }
+}

--- a/test/alphabet/adaptation/uint_test.cpp
+++ b/test/alphabet/adaptation/uint_test.cpp
@@ -106,3 +106,22 @@ TYPED_TEST(uint_adaptation, alphabet_size_v)
     EXPECT_EQ(alphabet_size_v<TypeParam>,
         static_cast<uint64_t>(std::numeric_limits<TypeParam>::max()) + 1 - std::numeric_limits<TypeParam>::lowest());
 }
+
+TYPED_TEST(uint_adaptation, alphabet_name)
+{
+    if constexpr (sizeof(TypeParam) == 1)
+    {
+        EXPECT_EQ(alphabet_name<TypeParam>::value.string(), std::string{"uint8_t"});
+        EXPECT_EQ(alphabet_name_v<TypeParam>.string(), std::string{"uint8_t"});
+    }
+    else if constexpr (sizeof(TypeParam) == 2)
+    {
+        EXPECT_EQ(alphabet_name<TypeParam>::value.string(), std::string{"uint16_t"});
+        EXPECT_EQ(alphabet_name_v<TypeParam>.string(), std::string{"uint16_t"});
+    }
+    else
+    {
+        EXPECT_EQ(alphabet_name<TypeParam>::value.string(), std::string{"uint32_t"});
+        EXPECT_EQ(alphabet_name_v<TypeParam>.string(), std::string{"uint32_t"});
+    }
+}

--- a/test/alphabet/alphabet_test.cpp
+++ b/test/alphabet/alphabet_test.cpp
@@ -78,6 +78,11 @@ TYPED_TEST(alphabet, alphabet_size)
     EXPECT_GT(alphabet_size_v<TypeParam>, 0u);
 }
 
+TYPED_TEST(alphabet, alphabet_name)
+{
+    EXPECT_GT(alphabet_size_v<TypeParam>, 0u);
+}
+
 TYPED_TEST(alphabet, default_value_constructor)
 {
     [[maybe_unused]] TypeParam t1;

--- a/test/alphabet/aminoacid_test.cpp
+++ b/test/alphabet/aminoacid_test.cpp
@@ -119,6 +119,12 @@ TYPED_TEST(aminoacid, stream_operator)
     EXPECT_EQ(ss.str(), "ACG");
 }
 
+TYPED_TEST(aminoacid, alphabet_name)
+{
+    EXPECT_EQ(alphabet_name<TypeParam>::value.string(), std::string{"aa27"});
+    EXPECT_EQ(alphabet_name_v<TypeParam>.string(), std::string{"aa27"});
+}
+
 // ------------------------------------------------------------------
 // literals
 // ------------------------------------------------------------------

--- a/test/alphabet/composition/union_composition_test.cpp
+++ b/test/alphabet/composition/union_composition_test.cpp
@@ -40,6 +40,7 @@
 #include <seqan3/alphabet/gap/gap.hpp>
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
+#include <seqan3/alphabet/aminoacid/aa27.hpp>
 
 using namespace seqan3;
 
@@ -183,4 +184,26 @@ TEST(union_composition_test, rank_type)
     EXPECT_TRUE(expect1);
     EXPECT_TRUE(expect2);
     EXPECT_TRUE(expect3);
+}
+
+TEST(union_composition_test, alphabet_name)
+{
+    {
+        using alphabet_t = union_composition<dna4>;
+        EXPECT_EQ(alphabet_name<alphabet_t>::value.string(), std::string{"union<dna4>"});
+        EXPECT_EQ(alphabet_name_v<alphabet_t>.string(), std::string{"union<dna4>"});
+    }
+
+    {
+        using alphabet_t = union_composition<dna4, gap>;
+        EXPECT_EQ(alphabet_name<alphabet_t>::value.string(), std::string{"union<dna4 & gap>"});
+        EXPECT_EQ(alphabet_name_v<alphabet_t>.string(), std::string{"union<dna4 & gap>"});
+    }
+
+    {
+        using alphabet_t = union_composition<dna4, gap, aa27>;
+        EXPECT_EQ(alphabet_name<alphabet_t>::value.string(), std::string{"union<dna4 & gap & aa27>"});
+        EXPECT_EQ(alphabet_name_v<alphabet_t>.string(), std::string{"union<dna4 & gap & aa27>"});
+    }
+
 }

--- a/test/alphabet/gap/gap_test.cpp
+++ b/test/alphabet/gap/gap_test.cpp
@@ -89,3 +89,9 @@ TEST(gap_test, assign_rank)
     EXPECT_EQ(gap{}.assign_rank(0), gap{});
     // EXPECT_EQ(gap{}.assign_rank(13), gap{});
 }
+
+TEST(gap_test, alphabet_name)
+{
+    EXPECT_EQ(alphabet_name<gap>::value.string(), std::string{"gap"});
+    EXPECT_EQ(alphabet_name_v<gap>.string(), std::string{"gap"});
+}

--- a/test/alphabet/gap/gapped_test.cpp
+++ b/test/alphabet/gap/gapped_test.cpp
@@ -118,3 +118,11 @@ TEST(gapped_test, stream_operator)
     ss << letterA << letterT << letterG << letterGAP << letterC;
     EXPECT_EQ(ss.str(), "ATG-C");
 }
+
+TEST(gapped_test, alphabet_name)
+{
+    using alphabet_t = gapped<dna4>;
+
+    EXPECT_EQ(alphabet_name<alphabet_t>::value.string(), std::string{"gapped_dna4"});
+    EXPECT_EQ(alphabet_name_v<alphabet_t>.string(), std::string{"gapped_dna4"});
+}

--- a/test/alphabet/nucleotide_test.cpp
+++ b/test/alphabet/nucleotide_test.cpp
@@ -212,6 +212,35 @@ TYPED_TEST(nucleotide, explicit_conversion)
     });
 }
 
+TYPED_TEST(nucleotide, alphabet_name)
+{
+    if constexpr (std::is_same_v<TypeParam, dna4>)
+    {
+        EXPECT_EQ(alphabet_name<TypeParam>::value.string(), std::string{"dna4"});
+        EXPECT_EQ(alphabet_name_v<TypeParam>.string(), std::string{"dna4"});
+    }
+    if constexpr (std::is_same_v<TypeParam, dna5>)
+    {
+        EXPECT_EQ(alphabet_name<TypeParam>::value.string(), std::string{"dna5"});
+        EXPECT_EQ(alphabet_name_v<TypeParam>.string(), std::string{"dna5"});
+    }
+    if constexpr (std::is_same_v<TypeParam, rna4>)
+    {
+        EXPECT_EQ(alphabet_name<TypeParam>::value.string(), std::string{"rna4"});
+        EXPECT_EQ(alphabet_name_v<TypeParam>.string(), std::string{"rna4"});
+    }
+    if constexpr (std::is_same_v<TypeParam, rna5>)
+    {
+        EXPECT_EQ(alphabet_name<TypeParam>::value.string(), std::string{"rna5"});
+        EXPECT_EQ(alphabet_name_v<TypeParam>.string(), std::string{"rna5"});
+    }
+    if constexpr (std::is_same_v<TypeParam, nucl16>)
+    {
+        EXPECT_EQ(alphabet_name<TypeParam>::value.string(), std::string{"nucl16"});
+        EXPECT_EQ(alphabet_name_v<TypeParam>.string(), std::string{"nucl16"});
+    }
+}
+
 // ------------------------------------------------------------------
 // literals
 // ------------------------------------------------------------------

--- a/test/alphabet/structure_test.cpp
+++ b/test/alphabet/structure_test.cpp
@@ -172,6 +172,30 @@ TYPED_TEST(structure, rna_structure_concept)
 }
 
 // ------------------------------------------------------------------
+// alphabet name
+// ------------------------------------------------------------------
+
+TEST(structure_name, dot_bracket3)
+{
+    using alphabet_t = dot_bracket3;
+    EXPECT_EQ(alphabet_name<alphabet_t>::value.string(), std::string{"dot_bracket3"});
+    EXPECT_EQ(alphabet_name_v<alphabet_t>.string(), std::string{"dot_bracket3"});
+}
+
+TEST(structure_name, dssp9)
+{
+    using alphabet_t = dssp9;
+    EXPECT_EQ(alphabet_name<alphabet_t>::value.string(), std::string{"dssp9"});
+    EXPECT_EQ(alphabet_name_v<alphabet_t>.string(), std::string{"dssp9"});
+}
+
+TEST(structure_name, wuss)
+{
+    using alphabet_t = wuss51;
+    EXPECT_EQ(alphabet_name<alphabet_t>::value.string(), std::string{"wuss<51>"});
+    EXPECT_EQ(alphabet_name_v<alphabet_t>.string(), std::string{"wuss<51>"});
+}
+// ------------------------------------------------------------------
 // stream operator
 // ------------------------------------------------------------------
 
@@ -615,6 +639,13 @@ TEST(structured_rna, complement)
     EXPECT_EQ(complement(tU), complement(tU));
 }
 
+TEST(structured_rna, alphabet_name)
+{
+    using alphabet_t = structured_rna<rna5, dot_bracket3>;
+    EXPECT_EQ(alphabet_name<alphabet_t>::value.string(), std::string{"structured_rna<rna5_dot_bracket3>"});
+    EXPECT_EQ(alphabet_name_v<alphabet_t>.string(), std::string{"structured_rna<rna5_dot_bracket3>"});
+}
+
 // ------------------------------------------------------------------
 // composition aminoacid x protein structure
 // ------------------------------------------------------------------
@@ -895,4 +926,11 @@ TEST(structured_aa, outstream)
     s << t0;
 
     EXPECT_EQ(s.str(), "CA");
+}
+
+TEST(structured_aa, alphabet_name)
+{
+    using alphabet_t = structured_aa<aa27, dssp9>;
+    EXPECT_EQ(alphabet_name<alphabet_t>::value.string(), std::string{"structured_aa<aa27_dssp9>"});
+    EXPECT_EQ(alphabet_name_v<alphabet_t>.string(), std::string{"structured_aa<aa27_dssp9>"});
 }

--- a/test/core/detail/CMakeLists.txt
+++ b/test/core/detail/CMakeLists.txt
@@ -1,1 +1,2 @@
 seqan3_test(int_types_test.cpp)
+seqan3_test(static_string_test.cpp)

--- a/test/core/detail/static_string_test.cpp
+++ b/test/core/detail/static_string_test.cpp
@@ -1,0 +1,126 @@
+// ==========================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ==========================================================================
+//
+// Copyright (c) 2006-2017, Knut Reinert, FU Berlin
+// Copyright (c) 2016-2017, Knut Reinert & MPI Molekulare Genetik
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ==========================================================================
+
+#include <gtest/gtest.h>
+
+#include <seqan3/core/detail/static_string.hpp>
+
+#include <string>
+
+using namespace std::literals;
+using namespace seqan3;
+
+// standard construction.
+TEST(static_string, standard_construction)
+{
+    EXPECT_FALSE((std::is_default_constructible_v<static_string<4>>));
+    EXPECT_TRUE((std::is_copy_constructible_v<static_string<4>>));
+    EXPECT_TRUE((std::is_trivially_copy_constructible_v<static_string<4>>));
+    EXPECT_TRUE((std::is_nothrow_copy_constructible_v<static_string<4>>));
+    EXPECT_TRUE((std::is_move_constructible_v<static_string<4>>));
+    EXPECT_TRUE((std::is_trivially_move_constructible_v<static_string<4>>));
+    EXPECT_TRUE((std::is_nothrow_move_constructible_v<static_string<4>>));
+    EXPECT_TRUE((std::is_copy_assignable_v<static_string<4>>));
+    EXPECT_TRUE((std::is_trivially_copy_assignable_v<static_string<4>>));
+    EXPECT_TRUE((std::is_nothrow_copy_assignable_v<static_string<4>>));
+    EXPECT_TRUE((std::is_move_assignable_v<static_string<4>>));
+    EXPECT_TRUE((std::is_trivially_move_assignable_v<static_string<4>>));
+    EXPECT_TRUE((std::is_nothrow_move_assignable_v<static_string<4>>));
+}
+
+// construction from literal.
+TEST(static_string, construct_from_literal)
+{
+     EXPECT_TRUE((std::is_same_v<static_string<5>, decltype(static_string{"hello"})>));
+}
+
+// construction from char.
+TEST(static_string, construct_from_char)
+{
+     EXPECT_TRUE((std::is_same_v<static_string<1>, decltype(static_string{'h'})>));
+}
+
+template <size_t S>
+struct foo
+{
+    inline size_t get() const {return S;};
+};
+
+TEST(static_string, size)
+{
+    static_string em{"hello"};
+    foo<em.size()> f;
+
+    EXPECT_EQ(em.size(), 5u);
+    EXPECT_EQ(f.get(), 5u);
+}
+
+TEST(static_string, c_str)
+{
+    {
+        static_string em{"hello"};
+        EXPECT_EQ(std::string{em.c_str()}, "hello"s);
+    }
+
+    {
+        static_string em{'x'};
+        EXPECT_EQ(std::string{em.c_str()}, "x"s);
+    }
+}
+
+TEST(static_string, string)
+{
+    static_string em{"hello"};
+    EXPECT_EQ(em.string(), "hello"s);
+}
+
+TEST(static_string, concat)
+{
+    {
+        static_string em = static_string{"hello"} + static_string{' '} + static_string{"world"};
+        foo<em.size()> f;
+        EXPECT_EQ(f.get(), 11u);
+        EXPECT_EQ(em.string(), "hello world"s);
+    }
+
+    {
+        static constexpr char const a[] = "hello";
+        static constexpr char const b[] = " ";
+        static constexpr char const c[] = "world";
+        auto em = static_string{a} + static_string{b} + static_string{c};
+        EXPECT_EQ(em.string(), "hello world"s);
+        foo<em.size()> f;
+        EXPECT_EQ(f.get(), 11u);
+    }
+}

--- a/test/io/CMakeLists.txt
+++ b/test/io/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectories()


### PR DESCRIPTION
Adds a name field to the alphabet concept and all implemented alphabets.
It uses the `static_string` from #131 to assemble names at compile time.
This will be used in the tokenisation to give the user pretty names to better understand what went wrong.
Like `The value 'N' is not part of the alphabet 'dna4'`.

Regarding the static_string please look into #131  first.
This PR is rebased on #131 .

###ToDO
 - [ ] docu