### PR TITLE
[DOC] Fix some more doxygen warnings

### DIFF
--- a/include/seqan3/alphabet/aminoacid/translation_details.hpp
+++ b/include/seqan3/alphabet/aminoacid/translation_details.hpp
@@ -54,6 +54,7 @@ namespace seqan3::detail
 template <typename nucl_type, seqan3::genetic_code gc = seqan3::genetic_code::CANONICAL, typename void_type = void>
 struct translation_table
 {
+    //!\brief Holds the generic translation table.
     static constexpr std::array<std::array<std::array<aa27, alphabet_size_v<nucl_type>>, alphabet_size_v<nucl_type>>,
                                                       alphabet_size_v<nucl_type>> VALUE
     {
@@ -85,7 +86,7 @@ struct translation_table
 template <typename void_type>
 struct translation_table<nucl16, seqan3::genetic_code::CANONICAL, void_type>
 {
-
+    //!\brief Holds the translation table for canonical genetic code and nucl16 alphabet.
     static constexpr aa27 VALUE[nucl16::value_size][nucl16::value_size][nucl16::value_size]
     {
         { // a??

--- a/include/seqan3/alphabet/detail/member_exposure.hpp
+++ b/include/seqan3/alphabet/detail/member_exposure.hpp
@@ -303,6 +303,7 @@ template <typename alphabet_type_with_pseudoknot_attribute>
 //!\endcond
 struct pseudoknot_support<alphabet_type_with_pseudoknot_attribute>
 {
+    //!\brief The forwarded pseudoknot support.
     static constexpr bool value = alphabet_type_with_pseudoknot_attribute::pseudoknot_support;
 };
 //!\}

--- a/include/seqan3/alphabet/quality/concept.hpp
+++ b/include/seqan3/alphabet/quality/concept.hpp
@@ -75,6 +75,7 @@ template <typename alphabet_type>
     requires detail::internal_quality_concept<alphabet_type>
 struct underlying_phred
 {
+    //!\brief The forwarded phred type.
     using type = typename alphabet_type::phred_type;
 };
 

--- a/include/seqan3/alphabet/quality/illumina18.hpp
+++ b/include/seqan3/alphabet/quality/illumina18.hpp
@@ -48,16 +48,19 @@ namespace seqan3
  */
 struct illumina18
 {
-    //! the 3 representation types of a quality score
+    //! the PHRED representation type of a quality score
     using phred_type = int8_t;
+    //! the rank representation type of a quality score
     using rank_type = uint8_t;
+    //! the char representation type of a quality score
     using char_type = char;
 
     //! internal rank value representation
     rank_type value;
 
-    //! projection offsets of char and rank quality score
+    //! projection offset of a char quality score
     static constexpr char_type offset_char{'!'};
+    //! projection offsets of a phred quality score
     static constexpr phred_type offset_phred{0};
 
     //! implicit compatibility to inner_type

--- a/include/seqan3/core/pod_tuple.hpp
+++ b/include/seqan3/core/pod_tuple.hpp
@@ -129,6 +129,10 @@ struct pod_tuple
     //!\}
 };
 
+/*!\brief Recursion anchor for pod_tuple.
+ * \ingroup core
+ * \tparam type0 The value's type (every tuple must contain at least one type).
+ */
 template <typename type0>
 struct pod_tuple<type0>
 {


### PR DESCRIPTION
The only warning left is
seqan3/include/seqan3/range/container/concatenated_sequences.hpp:1313: warning: unable to resolve reference to `serialisation' for \ref command

as already mentioned in #127
