### PR TITLE
nucl16 → dna15 and rna15

### DIFF
--- a/include/seqan3/alphabet/aminoacid/translation_details.hpp
+++ b/include/seqan3/alphabet/aminoacid/translation_details.hpp
@@ -41,7 +41,7 @@
 #pragma once
 
 #include <seqan3/alphabet/nucleotide/concept.hpp>
-#include <seqan3/alphabet/nucleotide/nucl16.hpp>
+#include <seqan3/alphabet/nucleotide/dna15.hpp>
 #include <seqan3/alphabet/aminoacid/aa27.hpp>
 
 namespace seqan3::detail
@@ -49,7 +49,7 @@ namespace seqan3::detail
 /*!\brief Generic translation table for canonical genetic code.
  * \tparam nucl_type The type of input nucleotides.
  *
- * \details  All nucleotides are casted to nucl16 and the nucl16 translation table is used for translation.
+ * \details  All nucleotides are casted to dna15 and the dna15 translation table is used for translation.
  */
 template <typename nucl_type, seqan3::genetic_code gc = seqan3::genetic_code::CANONICAL, typename void_type = void>
 struct translation_table
@@ -66,14 +66,14 @@ struct translation_table
             using size_t = std::remove_const_t<decltype(alphabet_size_v<nucl_type>)>;
             for (size_t i = 0; i < alphabet_size_v<nucl_type>; ++i)
             {
-                nucl16 n1(assign_rank(nucl_type{}, i));
+                dna15 n1(assign_rank(nucl_type{}, i));
                 for (size_t j = 0; j < alphabet_size_v<nucl_type>; ++j)
                 {
-                    nucl16 n2(assign_rank(nucl_type{}, j));
+                    dna15 n2(assign_rank(nucl_type{}, j));
                     for (size_t k = 0; k < alphabet_size_v<nucl_type>; ++k)
                     {
-                        nucl16 n3(assign_rank(nucl_type{}, k));
-                        table[i][j][k] = translation_table<nucl16, gc, void_type>::VALUE[to_rank(n1)][to_rank(n2)][to_rank(n3)];
+                        dna15 n3(assign_rank(nucl_type{}, k));
+                        table[i][j][k] = translation_table<dna15, gc, void_type>::VALUE[to_rank(n1)][to_rank(n2)][to_rank(n3)];
                     }
                 }
             }
@@ -82,302 +82,269 @@ struct translation_table
     };
 };
 
-//!\brief Translation table for canonical genetic code and nucl16 alphabet.
+//!\brief Translation table for canonical genetic code and dna15 alphabet.
 template <typename void_type>
-struct translation_table<nucl16, seqan3::genetic_code::CANONICAL, void_type>
+struct translation_table<dna15, seqan3::genetic_code::CANONICAL, void_type>
 {
     //!\brief Holds the translation table for canonical genetic code and nucl16 alphabet.
-    static constexpr aa27 VALUE[nucl16::value_size][nucl16::value_size][nucl16::value_size]
+    static constexpr aa27 VALUE[dna15::value_size][dna15::value_size][dna15::value_size]
     {
         { // a??
-            // a,               b,       c,       d,       g,                h,       k,       m,       n,       r,                s,       t,       u,       v,       w,       y
-            { aa27::K,          aa27::X, aa27::N, aa27::X, aa27::K,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::K,          aa27::X, aa27::N, aa27::N, aa27::X, aa27::X, aa27::N }, // aa?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ab?
-            { aa27::T,          aa27::T, aa27::T, aa27::T, aa27::T,          aa27::T, aa27::T, aa27::T, aa27::T, aa27::T,          aa27::T, aa27::T, aa27::T, aa27::T, aa27::T, aa27::T }, // ac?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ad?
-            { aa27::R,          aa27::X, aa27::S, aa27::X, aa27::R,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::R,          aa27::X, aa27::S, aa27::S, aa27::X, aa27::X, aa27::S }, // ag?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ah?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ak?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // am?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // an?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ar?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // as?
-            { aa27::I,          aa27::X, aa27::I, aa27::X, aa27::M,          aa27::I, aa27::X, aa27::I, aa27::X, aa27::X,          aa27::X, aa27::I, aa27::I, aa27::X, aa27::I, aa27::I }, // at?
-            { aa27::I,          aa27::X, aa27::I, aa27::X, aa27::M,          aa27::I, aa27::X, aa27::I, aa27::X, aa27::X,          aa27::X, aa27::I, aa27::I, aa27::X, aa27::I, aa27::I }, // au?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // av?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // aw?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }  // ay?
+            // a,               b,       c,       d,       g,                h,       k,       m,       n,       r,                s,       t,       v,       w,       y
+            { aa27::K,          aa27::X, aa27::N, aa27::X, aa27::K,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::K,          aa27::X, aa27::N, aa27::X, aa27::X, aa27::N }, // aa?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ab?
+            { aa27::T,          aa27::T, aa27::T, aa27::T, aa27::T,          aa27::T, aa27::T, aa27::T, aa27::T, aa27::T,          aa27::T, aa27::T, aa27::T, aa27::T, aa27::T }, // ac?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ad?
+            { aa27::R,          aa27::X, aa27::S, aa27::X, aa27::R,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::R,          aa27::X, aa27::S, aa27::X, aa27::X, aa27::S }, // ag?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ah?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ak?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // am?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // an?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ar?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // as?
+            { aa27::I,          aa27::X, aa27::I, aa27::X, aa27::M,          aa27::I, aa27::X, aa27::I, aa27::X, aa27::X,          aa27::X, aa27::I, aa27::X, aa27::I, aa27::I }, // at?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // av?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // aw?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }  // ay?
     }, { // b??
-            // a,               b,       c,       d,       g,                h,       k,       m,       n,       r,                s,       t,       u,       v,       w,       y
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ba?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // bb?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // bc?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // bd?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // bg?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // bh?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // bk?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // bm?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // bn?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // br?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // bs?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // bt?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // bu?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // bv?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // bw?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }  // by?
+            // a,               b,       c,       d,       g,                h,       k,       m,       n,       r,                s,       t,       v,       w,       y
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ba?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // bb?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // bc?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // bd?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // bg?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // bh?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // bk?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // bm?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // bn?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // br?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // bs?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // bt?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // bv?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // bw?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }  // by?
         }, { // c??
-            // a,               b,       c,       d,       g,                h,       k,       m,       n,       r,                s,       t,       u,       v,       w,       y
-            { aa27::Q,          aa27::X, aa27::H, aa27::X, aa27::Q,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::Q,          aa27::X, aa27::H, aa27::H, aa27::X, aa27::X, aa27::H }, // ca?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // cb?
-            { aa27::P,          aa27::P, aa27::P, aa27::P, aa27::P,          aa27::P, aa27::P, aa27::P, aa27::P, aa27::P,          aa27::P, aa27::P, aa27::P, aa27::P, aa27::P, aa27::P }, // cc?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // cd?
-            { aa27::R,          aa27::R, aa27::R, aa27::R, aa27::R,          aa27::R, aa27::R, aa27::R, aa27::R, aa27::R,          aa27::R, aa27::R, aa27::R, aa27::R, aa27::R, aa27::R }, // cg?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ch?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ck?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // cm?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // cn?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // cr?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // cs?
-            { aa27::L,          aa27::L, aa27::L, aa27::L, aa27::L,          aa27::L, aa27::L, aa27::L, aa27::L, aa27::L,          aa27::L, aa27::L, aa27::L, aa27::L, aa27::L, aa27::L }, // ct?
-            { aa27::L,          aa27::L, aa27::L, aa27::L, aa27::L,          aa27::L, aa27::L, aa27::L, aa27::L, aa27::L,          aa27::L, aa27::L, aa27::L, aa27::L, aa27::L, aa27::L }, // cu?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // cv?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // cw?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }  // cy?
+            // a,               b,       c,       d,       g,                h,       k,       m,       n,       r,                s,       t,       v,       w,       y
+            { aa27::Q,          aa27::X, aa27::H, aa27::X, aa27::Q,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::Q,          aa27::X, aa27::H, aa27::X, aa27::X, aa27::H }, // ca?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // cb?
+            { aa27::P,          aa27::P, aa27::P, aa27::P, aa27::P,          aa27::P, aa27::P, aa27::P, aa27::P, aa27::P,          aa27::P, aa27::P, aa27::P, aa27::P, aa27::P }, // cc?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // cd?
+            { aa27::R,          aa27::R, aa27::R, aa27::R, aa27::R,          aa27::R, aa27::R, aa27::R, aa27::R, aa27::R,          aa27::R, aa27::R, aa27::R, aa27::R, aa27::R }, // cg?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ch?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ck?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // cm?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // cn?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // cr?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // cs?
+            { aa27::L,          aa27::L, aa27::L, aa27::L, aa27::L,          aa27::L, aa27::L, aa27::L, aa27::L, aa27::L,          aa27::L, aa27::L, aa27::L, aa27::L, aa27::L }, // ct?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // cv?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // cw?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }  // cy?
         }, { // d??
-            // a,               b,       c,       d,       g,                h,       k,       m,       n,       r,                s,       t,       u,       v,       w,       y
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // da?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // db?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // dc?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // dd?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // dg?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // dh?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // dk?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // dm?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // dn?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // dr?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ds?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // dt?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // du?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // dv?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // dw?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }  // dy?
+            // a,               b,       c,       d,       g,                h,       k,       m,       n,       r,                s,       t,       v,       w,       y
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // da?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // db?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // dc?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // dd?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // dg?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // dh?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // dk?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // dm?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // dn?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // dr?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ds?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // dt?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // dv?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // dw?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }  // dy?
 
         }, { // g??
-            // a,               b,       c,       d,       g,                h,       k,       m,       n,       r,                s,       t,       u,       v,       w,       y
-            { aa27::E,          aa27::X, aa27::D, aa27::X, aa27::E,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::E,          aa27::X, aa27::D, aa27::D, aa27::X, aa27::X, aa27::D }, // ga?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // gb?
-            { aa27::A,          aa27::A, aa27::A, aa27::A, aa27::A,          aa27::A, aa27::A, aa27::A, aa27::A, aa27::A,          aa27::A, aa27::A, aa27::A, aa27::A, aa27::A, aa27::A }, // gc?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // gd?
-            { aa27::G,          aa27::G, aa27::G, aa27::G, aa27::G,          aa27::G, aa27::G, aa27::G, aa27::G, aa27::G,          aa27::G, aa27::G, aa27::G, aa27::G, aa27::G, aa27::G }, // gg?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // gh?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // gk?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // gm?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // gn?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // gr?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // gs?
-            { aa27::V,          aa27::V, aa27::V, aa27::V, aa27::V,          aa27::V, aa27::V, aa27::V, aa27::V, aa27::V,          aa27::V, aa27::V, aa27::V, aa27::V, aa27::V, aa27::V }, // gt?
-            { aa27::V,          aa27::V, aa27::V, aa27::V, aa27::V,          aa27::V, aa27::V, aa27::V, aa27::V, aa27::V,          aa27::V, aa27::V, aa27::V, aa27::V, aa27::V, aa27::V }, // gu?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // gv?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // gw?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }  // gy?
+            // a,               b,       c,       d,       g,                h,       k,       m,       n,       r,                s,       t,       v,       w,       y
+            { aa27::E,          aa27::X, aa27::D, aa27::X, aa27::E,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::E,          aa27::X, aa27::D, aa27::X, aa27::X, aa27::D }, // ga?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // gb?
+            { aa27::A,          aa27::A, aa27::A, aa27::A, aa27::A,          aa27::A, aa27::A, aa27::A, aa27::A, aa27::A,          aa27::A, aa27::A, aa27::A, aa27::A, aa27::A }, // gc?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // gd?
+            { aa27::G,          aa27::G, aa27::G, aa27::G, aa27::G,          aa27::G, aa27::G, aa27::G, aa27::G, aa27::G,          aa27::G, aa27::G, aa27::G, aa27::G, aa27::G }, // gg?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // gh?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // gk?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // gm?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // gn?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // gr?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // gs?
+            { aa27::V,          aa27::V, aa27::V, aa27::V, aa27::V,          aa27::V, aa27::V, aa27::V, aa27::V, aa27::V,          aa27::V, aa27::V, aa27::V, aa27::V, aa27::V }, // gt?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // gv?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // gw?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }  // gy?
         }, { // h??
-            // a,               b,       c,       d,       g,                h,       k,       m,       n,       r,                s,       t,       u,       v,       w,       y
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ha?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // hb?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // hc?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // hd?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // hg?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // hh?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // hk?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // hm?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // hn?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // hr?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // hs?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ht?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // hu?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // hv?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // hw?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }  // hy?
+            // a,               b,       c,       d,       g,                h,       k,       m,       n,       r,                s,       t,       v,       w,       y
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ha?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // hb?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // hc?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // hd?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // hg?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // hh?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // hk?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // hm?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // hn?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // hr?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // hs?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ht?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // hv?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // hw?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }  // hy?
 
         }, { // k??
-            // a,               b,       c,       d,       g,                h,       k,       m,       n,       r,                s,       t,       u,       v,       w,       y
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ka?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // kb?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // kc?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // kd?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // kg?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // kh?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // kk?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // km?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // kn?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // kr?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ks?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // kt?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ku?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // kv?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // kw?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }  // ky?
+            // a,               b,       c,       d,       g,                h,       k,       m,       n,       r,                s,       t,       v,       w,       y
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ka?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // kb?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // kc?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // kd?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // kg?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // kh?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // kk?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // km?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // kn?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // kr?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ks?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // kt?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // kv?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // kw?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }  // ky?
 
         }, { // m??
-            // a,               b,       c,       d,       g,                h,       k,       m,       n,       r,                s,       t,       u,       v,       w,       y
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ma?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // mb?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // mc?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // md?
-            { aa27::R,          aa27::X, aa27::X, aa27::X, aa27::R,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::R,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // mg?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // mh?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // mk?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // mm?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // mn?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // mr?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ms?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // mt?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // mu?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // mv?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // mw?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }  // my?
+            // a,               b,       c,       d,       g,                h,       k,       m,       n,       r,                s,       t,       v,       w,       y
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ma?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // mb?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // mc?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // md?
+            { aa27::R,          aa27::X, aa27::X, aa27::X, aa27::R,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::R,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // mg?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // mh?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // mk?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // mm?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // mn?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // mr?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ms?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // mt?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // mv?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // mw?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }  // my?
 
 
         }, { // n??
-            // a,               b,       c,       d,       g,                h,       k,       m,       n,       r,                s,       t,       u,       v,       w,       y
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // nb?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // nc?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // nd?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ng?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // nh?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // nk?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // nm?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // nn?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // nr?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ns?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // nt?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // nu?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // nv?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // nw?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }  // ny?
+            // a,               b,       c,       d,       g,                h,       k,       m,       n,       r,                s,       t,       v,       w,       y
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // nb?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // nc?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // nd?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ng?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // nh?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // nk?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // nm?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // nn?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // nr?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ns?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // nt?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // nv?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // nw?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }  // ny?
         }, { // r??
-            // a,               b,       c,       d,       g,                h,       k,       m,       n,       r,                s,       t,       u,       v,       w,       y
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // rb?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // rc?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // rd?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // rg?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // rh?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // rk?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // rm?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // rn?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // rr?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // rs?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // rt?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ru?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // rv?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // rw?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }  // ry?
+            // a,               b,       c,       d,       g,                h,       k,       m,       n,       r,                s,       t,       v,       w,       y
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // rb?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // rc?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // rd?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // rg?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // rh?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // rk?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // rm?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // rn?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // rr?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // rs?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // rt?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // rv?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // rw?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }  // ry?
         }, { // s??
-            // a,               b,       c,       d,       g,                h,       k,       m,       n,       r,                s,       t,       u,       v,       w,       y
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // sb?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // sc?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // sd?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // sg?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // sh?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // sk?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // sm?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // sn?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // sr?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ss?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // st?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // su?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // sv?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // sw?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }  // sy?
+            // a,               b,       c,       d,       g,                h,       k,       m,       n,       r,                s,       t,       v,       w,       y
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // sb?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // sc?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // sd?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // sg?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // sh?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // sk?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // sm?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // sn?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // sr?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ss?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // st?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // sv?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // sw?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }  // sy?
         }, { // t??
-            // a,               b,       c,       d,       g,                h,       k,       m,       n,       r,                s,       t,       u,       v,       w,       y
-            { aa27::TERMINATOR, aa27::X, aa27::Y, aa27::X, aa27::TERMINATOR, aa27::X, aa27::X, aa27::X, aa27::X, aa27::TERMINATOR, aa27::X, aa27::Y, aa27::Y, aa27::X, aa27::X, aa27::Y }, // ta?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // tb?
-            { aa27::S,          aa27::S, aa27::S, aa27::S, aa27::S,          aa27::S, aa27::S, aa27::S, aa27::S, aa27::S,          aa27::S, aa27::S, aa27::S, aa27::S, aa27::S, aa27::S }, // tc?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // td?
-            { aa27::TERMINATOR, aa27::X, aa27::C, aa27::X, aa27::W,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::C, aa27::C, aa27::X, aa27::C }, // tg?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // th?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // tk?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // tm?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // tn?
-            { aa27::TERMINATOR, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // tr?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ts?
-            { aa27::L,          aa27::X, aa27::F, aa27::X, aa27::X,          aa27::L, aa27::X, aa27::X, aa27::X, aa27::L,          aa27::X, aa27::F, aa27::F, aa27::X, aa27::X, aa27::F }, // tt?
-            { aa27::L,          aa27::X, aa27::F, aa27::X, aa27::X,          aa27::L, aa27::X, aa27::X, aa27::X, aa27::L,          aa27::X, aa27::F, aa27::F, aa27::X, aa27::X, aa27::F }, // tu?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // tv?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // tw?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }  // ty?
-        }, { // u??
-            // a,               b,       c,       d,       g,                h,       k,       m,       n,       r,                s,       t,       u,       v,       w,       y
-            { aa27::TERMINATOR, aa27::X, aa27::Y, aa27::X, aa27::TERMINATOR, aa27::X, aa27::X, aa27::X, aa27::X, aa27::TERMINATOR, aa27::X, aa27::Y, aa27::Y, aa27::X, aa27::X, aa27::Y }, // ua?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ub?
-            { aa27::S,          aa27::S, aa27::S, aa27::S, aa27::S,          aa27::S, aa27::S, aa27::S, aa27::S, aa27::S,          aa27::S, aa27::S, aa27::S, aa27::S, aa27::S, aa27::S }, // uc?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ud?
-            { aa27::TERMINATOR, aa27::X, aa27::C, aa27::X, aa27::W,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::C, aa27::C, aa27::X, aa27::C }, // ug?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // uh?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // uk?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // um?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // un?
-            { aa27::TERMINATOR, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ur?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // us?
-            { aa27::L,          aa27::X, aa27::F, aa27::X, aa27::X,          aa27::L, aa27::X, aa27::X, aa27::X, aa27::L,          aa27::X, aa27::F, aa27::F, aa27::X, aa27::X, aa27::F }, // ut?
-            { aa27::L,          aa27::X, aa27::F, aa27::X, aa27::X,          aa27::L, aa27::X, aa27::X, aa27::X, aa27::L,          aa27::X, aa27::F, aa27::F, aa27::X, aa27::X, aa27::F }, // uu?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // uv?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // uw?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }  // uy?
+            // a,               b,       c,       d,       g,                h,       k,       m,       n,       r,                s,       t,       v,       w,       y
+            { aa27::TERMINATOR, aa27::X, aa27::Y, aa27::X, aa27::TERMINATOR, aa27::X, aa27::X, aa27::X, aa27::X, aa27::TERMINATOR, aa27::X, aa27::Y, aa27::X, aa27::X, aa27::Y }, // ta?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // tb?
+            { aa27::S,          aa27::S, aa27::S, aa27::S, aa27::S,          aa27::S, aa27::S, aa27::S, aa27::S, aa27::S,          aa27::S, aa27::S, aa27::S, aa27::S, aa27::S }, // tc?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // td?
+            { aa27::TERMINATOR, aa27::X, aa27::C, aa27::X, aa27::W,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::C, aa27::X, aa27::C }, // tg?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // th?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // tk?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // tm?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // tn?
+            { aa27::TERMINATOR, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // tr?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ts?
+            { aa27::L,          aa27::X, aa27::F, aa27::X, aa27::X,          aa27::L, aa27::X, aa27::X, aa27::X, aa27::L,          aa27::X, aa27::F, aa27::X, aa27::X, aa27::F }, // tt?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // tv?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // tw?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }  // ty?
         }, { // v??
-            // a,               b,       c,       d,       g,                h,       k,       m,       n,       r,                s,       t,       u,       v,       w,       y
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // va?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // vb?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // vc?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // vd?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // vg?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // vh?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // vk?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // vm?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // vn?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // vr?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // vs?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // vt?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // vu?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // vv?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // vw?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }  // vy?
+            // a,               b,       c,       d,       g,                h,       k,       m,       n,       r,                s,       t,       v,       w,       y
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // va?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // vb?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // vc?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // vd?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // vg?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // vh?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // vk?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // vm?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // vn?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // vr?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // vs?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // vt?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // vv?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // vw?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }  // vy?
         }, { // w??
-            // a,               b,       c,       d,       g,                h,       k,       m,       n,       r,                s,       t,       u,       v,       w,       y
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // wa?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // wb?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // wc?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // wd?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // wg?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // wh?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // wk?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // wm?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // wn?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // wr?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ws?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // wt?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // wu?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // wv?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ww?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }  // wy?
+            // a,               b,       c,       d,       g,                h,       k,       m,       n,       r,                s,       t,       v,       w,       y
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // wa?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // wb?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // wc?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // wd?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // wg?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // wh?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // wk?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // wm?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // wn?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // wr?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ws?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // wt?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // wv?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ww?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }  // wy?
         }, { // y??
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ya?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // yb?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // yc?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // yd?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // yg?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // yh?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // yk?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ym?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // yn?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // yr?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ys?
-            { aa27::L,          aa27::X, aa27::X, aa27::X, aa27::L,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::L,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // yt?
-            { aa27::L,          aa27::X, aa27::X, aa27::X, aa27::L,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::L,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // yu?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // yv?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // yw?
-            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }  // yy?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ya?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // yb?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // yc?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // yd?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // yg?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // yh?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // yk?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ym?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // yn?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // yr?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // ys?
+            { aa27::L,          aa27::X, aa27::X, aa27::X, aa27::L,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::L,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // yt?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // yv?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }, // yw?
+            { aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X,          aa27::X, aa27::X, aa27::X, aa27::X, aa27::X }  // yy?
         }
     };
 };

--- a/include/seqan3/alphabet/nucleotide/all.hpp
+++ b/include/seqan3/alphabet/nucleotide/all.hpp
@@ -41,7 +41,7 @@
 #include <seqan3/alphabet/nucleotide/concept.hpp>
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
-#include <seqan3/alphabet/nucleotide/nucl16.hpp>
+#include <seqan3/alphabet/nucleotide/dna15.hpp>
 #include <seqan3/alphabet/nucleotide/rna4.hpp>
 #include <seqan3/alphabet/nucleotide/rna5.hpp>
 
@@ -53,43 +53,41 @@
  *
  * Nucleotide sequences are at the core of most bioinformatic data processing and while it is possible
  * to represent them in a regular std::string, it makes sense to have specialised data structures in most cases.
- * This sub-module offers multiple nucleotide alphabets that can be used with regular container and ranges.
+ * This sub-module offers multiple nucleotide alphabets that can be used with regular containers and ranges.
  *
- * | Letter   | Description            | seqan3::nucl16 | seqan3::dna5 | seqan3::dna4 | seqan3::rna5 | seqan3::rna4 |
- * |:--------:|------------------------|:--------------:|:------------:|:------------:|:------------:|:------------:|
- * |   A      | Adenine                |      ☑         |      ☑       |      ☑       |      ☑       |      ☑       |
- * |   C      | Cytosine               |      ☑         |      ☑       |      ☑       |      ☑       |      ☑       |
- * |   G      | Guanine                |      ☑         |      ☑       |      ☑       |      ☑       |      ☑       |
- * |   T      | Thymine (DNA)          |      ☑         |      ☑       |      ☑       |      ☐       |      ☐       |
- * |   U      | Uracil (RNA)           |      ☑         |      ☐       |      ☐       |      ☑       |      ☑       |
- * |   M      | A *or* C               |      ☑         |      ☐       |      ☐       |      ☐       |      ☐       |
- * |   R      | A *or* G               |      ☑         |      ☐       |      ☐       |      ☐       |      ☐       |
- * |   W      | A *or* T               |      ☑         |      ☐       |      ☐       |      ☐       |      ☐       |
- * |   Y      | C *or* T               |      ☑         |      ☐       |      ☐       |      ☐       |      ☐       |
- * |   S      | C *or* G               |      ☑         |      ☐       |      ☐       |      ☐       |      ☐       |
- * |   K      | G *or* T               |      ☑         |      ☐       |      ☐       |      ☐       |      ☐       |
- * |   V      | A *or* C *or* G        |      ☑         |      ☐       |      ☐       |      ☐       |      ☐       |
- * |   H      | A *or* C *or* T        |      ☑         |      ☐       |      ☐       |      ☐       |      ☐       |
- * |   D      | A *or* G *or* T        |      ☑         |      ☐       |      ☐       |      ☐       |      ☐       |
- * |   B      | C *or* G *or* T        |      ☑         |      ☐       |      ☐       |      ☐       |      ☐       |
- * |   N      | A *or* C *or* G *or* T |      ☑         |      ☑       |      ☐       |      ☑       |      ☐       |
- * | **Size** |                        |     16         |      5       |      4       |      5       |      4       |
+ * | Letter   | Description            | seqan3::dna15  | seqan3::dna5 | seqan3::dna4 | seqan3::rna15  | seqan3::rna5 | seqan3::rna4 |
+ * |:--------:|------------------------|:--------------:|:------------:|:------------:|:--------------:|:------------:|:------------:|
+ * |   A      | Adenine                |      ☑         |      ☑       |      ☑       |      ☑         |      ☑       |      ☑       |
+ * |   C      | Cytosine               |      ☑         |      ☑       |      ☑       |      ☑         |      ☑       |      ☑       |
+ * |   G      | Guanine                |      ☑         |      ☑       |      ☑       |      ☑         |      ☑       |      ☑       |
+ * |   T      | Thymine (DNA)          |      ☑         |      ☑       |      ☑       |      ☐         |      ☐       |      ☐       |
+ * |   U      | Uracil (RNA)           |      ☐         |      ☐       |      ☐       |      ☑         |      ☑       |      ☑       |
+ * |   M      | A *or* C               |      ☑         |      ☐       |      ☐       |      ☑         |      ☐       |      ☐       |
+ * |   R      | A *or* G               |      ☑         |      ☐       |      ☐       |      ☑         |      ☐       |      ☐       |
+ * |   W      | A *or* T               |      ☑         |      ☐       |      ☐       |      ☑         |      ☐       |      ☐       |
+ * |   Y      | C *or* T               |      ☑         |      ☐       |      ☐       |      ☑         |      ☐       |      ☐       |
+ * |   S      | C *or* G               |      ☑         |      ☐       |      ☐       |      ☑         |      ☐       |      ☐       |
+ * |   K      | G *or* T               |      ☑         |      ☐       |      ☐       |      ☑         |      ☐       |      ☐       |
+ * |   V      | A *or* C *or* G        |      ☑         |      ☐       |      ☐       |      ☑         |      ☐       |      ☐       |
+ * |   H      | A *or* C *or* T        |      ☑         |      ☐       |      ☐       |      ☑         |      ☐       |      ☐       |
+ * |   D      | A *or* G *or* T        |      ☑         |      ☐       |      ☐       |      ☑         |      ☐       |      ☐       |
+ * |   B      | C *or* G *or* T        |      ☑         |      ☐       |      ☐       |      ☑         |      ☐       |      ☐       |
+ * |   N      | A *or* C *or* G *or* T |      ☑         |      ☑       |      ☐       |      ☑         |      ☑       |      ☐       |
+ * | **Size** |                        |     15         |      5       |      4       |     15         |      5       |      4       |
  *
  * Keep in mind, that while we think of "the nucleotide alphabet" as consisting of four bases, there are indeed
  * more characters defined with different levels of ambiguity. Depending on your application it will make sense
  * to preserve this ambiguity or to discard it to save space and/or optimise computations.
- * SeqAn offers five distinct nucleotide alphabet types to accommodate for this.
- *
- * For seqan3::nucl16 there are also the following aliases (typedefs): `dna16, rna16, dna, rna`
+ * SeqAn offers six distinct nucleotide alphabet types to accommodate for this.
  *
  * The specialised RNA alphabets are provided for convenience, however the DNA alphabets provide a `::%U` member
- * and can handle being assigned and `'U'` character, as well. See below for the details.
+ * and can handle being assigned a `'U'` character, as well. See below for the details.
  *
  * Which alphabet to chose?
- *   1. in most cases, take seqan3::nucl16
+ *   1. in most cases, take seqan3::dna15
  *   2. if you are memory constrained and sequence data is actually the main memory consumer, use seqan3::dna5
  *   3. if you use specialised algorithms that profit from a 2-bit representation, use seqan3::dna4
- *   4. if 2. or 3. and you are doing only RNA input/output, use seqan3::rna5 or seqan3::rna4
+ *   4. if you are doing only RNA input/output, use the respective seqan3::rna* type
  *   5. to actually save space from using smaller alphabets, you need a compressed container (TODO link)
  *
  * \par Concept
@@ -112,48 +110,47 @@
  *
  * \par Printing and conversion to char
  *
+ * | to_char()      | seqan3::dna15  | seqan3::dna5 | seqan3::dna4 | seqan3::rna15  | seqan3::rna5 | seqan3::rna4 |
+ * |:--------------:|:--------------:|:------------:|:------------:|:--------------:|:------------:|:------------:|
+ * | type::A        |    `'A'`       |    `'A'`     |    `'A'`     |    `'A'`       |    `'A'`     |    `'A'`     |
+ * |   ...          |    ...         |    ...       |    ...       |    ...         |    ...       |    ...       |
+ * | type::T        |    `'T'`       |    `'T'`     |    `'T'`     |    `'U'`       |    `'U'`     |    `'U'`     |
+ * | type::U        |    `'T'`       |    `'T'`     |    `'T'`     |    `'U'`       |    `'U'`     |    `'U'`     |
+ * | type::R        |    `'R'`       |     ---      |    ---       |    `'R'`       |     ---      |     ---      |
+ * |   ...          |    ...         |     ---      |    ---       |    ...         |     ---      |     ---      |
+ * | type::N        |    `'N'`       |    `'N'`     |    ---       |    `'N'`       |    `'N'`     |     ---      |
+ * | type::UNKNOWN  |    `'N'`       |    `'N'`     |    `'A'`     |    `'N'`       |    `'N'`     |    `'A'`     |
  *
- * | to_char()      | seqan3::nucl16 | seqan3::dna5 | seqan3::dna4 | seqan3::rna5 | seqan3::rna4 |
- * |:--------------:|:--------------:|:------------:|:------------:|:------------:|:------------:|
- * | type::A        |    `'A'`       |    `'A'`     |    `'A'`     |    `'A'`     |    `'A'`     |
- * |   ...          |    ...         |    ...       |    ...       |    ...       |    ...       |
- * | type::T        |    `'T'`       |    `'T'`     |    `'T'`     |    `'U'`     |    `'U'`     |
- * | type::U        |    `'U'`       |    `'T'`     |    `'T'`     |    `'U'`     |    `'U'`     |
- * | type::R        |    `'R'`       |     ---      |    ---       |     ---      |     ---      |
- * |   ...          |    ...         |     ---      |    ---       |     ---      |     ---      |
- * | type::N        |    `'N'`       |    `'N'`     |    ---       |    `'N'`     |     ---      |
- * | type::UNKNOWN  |    `'N'`       |    `'N'`     |    `'A'`     |    `'N'`     |    `'A'`     |
- *
- * In the smaller alphabets `T` and `U` are represented by the same rank and you cannot differentiate between them
+ * `T` and `U` are represented by the same rank and you cannot differentiate between them
  * (the static members `::%T` and `::%U` are synonymous). The only difference between e.g. seqan3::dna4 and
  * seqan3::rna4 is the output when calling to_char().
  *
- * \par Assignment and Conversion
+ * \par Assignment and conversions between nucleotide types
  *
- *   * seqan3::dna4 ↔ seqan3::rna4, as well as seqan3::dna5 ↔ seqan3::rna5 are directly assignable to each other.
- *   * All nucleotide alphabets are convertible to each other, as well as from their `char` and rank types via
- *     seqan3::convert(), although the behaviour depends on the type, see below.
+ *   * Nucleotide types are **implicitly** convertible to each other if they have the same size
+ * (e.g. seqan3::dna4 ↔ seqan3::rna4).
+ *   * Other nucleotide types are **explicitly** convertible to each other through their character representation.
  *   * All ranges of nucleotide alphabets are convertible to each other via seqan3::view::convert.
  *
- * | assign_char() | seqan3::nucl16 | seqan3::dna5  | seqan3::dna4  | seqan3::rna5 | seqan3::rna4  |
- * |:-------------:|:--------------:|:-------------:|:-------------:|:------------:|:-------------:|
- * |   `'A'`       |  nucl16::A     |  dna5::A      | dna4::A       |  rna5::A     | rna4::A       |
- * |   ...         |    ...         |    ...        | ...           |    ...       |     ...       |
- * |   `'T'`       |  nucl16::T     |  dna5::T ¹    | dna4::T ¹     |  rna5::T ¹   | rna4::T ¹     |
- * |   `'U'`       |  nucl16::U     |  dna5::T ¹    | dna4::T ¹     |  rna5::T ¹   | rna4::T ¹     |
- * |   `'R'`       |  nucl16::R     |  dna5::N ²    | dna4::A ³     |  rna5::N ²   | rna4::A ³     |
- * |   `'Y'`       |  nucl16::Y     |  dna5::N ²    | dna4::C ³     |  rna5::N ²   | rna4::C ³     |
- * |   ...         |    ...         |  dna5::N ²    | ... ³         |  rna5::N ²   | ... ³         |
- * |   `'N'`       |  nucl16::N     |  dna5::N ²    | dna4::A ³     |  rna5::N ²   | rna4::A ³     |
- * | e.g. `'!'`    |  nucl16::N     |  dna5::N ²    | dna4::A ²     |  rna5::N ²   | rna4::A ²     |
+ * | assign_char() | seqan3::dna15  | seqan3::dna5  | seqan3::dna4  | seqan3::rna15  | seqan3::rna5 | seqan3::rna4  |
+ * |:-------------:|:--------------:|:-------------:|:-------------:|:--------------:|:------------:|:-------------:|
+ * |   `'A'`       |   dna15::A     |  dna5::A      | dna4::A       |   rna15::A     |  rna5::A     | rna4::A       |
+ * |   ...         |    ...         |    ...        | ...           |    ...         |    ...       |     ...       |
+ * |   `'T'`       |   dna15::T ¹   |  dna5::T ¹    | dna4::T ¹     |   rna15::T ¹   |  rna5::T ¹   | rna4::T ¹     |
+ * |   `'U'`       |   dna15::T ¹   |  dna5::T ¹    | dna4::T ¹     |   rna15::T ¹   |  rna5::T ¹   | rna4::T ¹     |
+ * |   `'R'`       |   dna15::R     |  dna5::N ²    | dna4::A ³     |   rna15::R     |  rna5::N ²   | rna4::A ³     |
+ * |   `'Y'`       |   dna15::Y     |  dna5::N ²    | dna4::C ³     |   rna15::Y     |  rna5::N ²   | rna4::C ³     |
+ * |   ...         |    ...         |  dna5::N ²    | ... ³         |    ...         |  rna5::N ²   | ... ³         |
+ * |   `'N'`       |   dna15::N     |  dna5::N ²    | dna4::A ³     |   rna15::N     |  rna5::N ²   | rna4::A ³     |
+ * | e.g. `'!'`    |   dna15::N     |  dna5::N ²    | dna4::A ²     |   rna15::N     |  rna5::N ²   | rna4::A ²     |
  *
  * ¹ same as `type::U`<br>
  * ² same as `type::UNKNOWN`<br>
  * ³ the first character in the ambiguous set
  *
- * When converting from `char` or a larger nucleotide alphabet to smaller one, *loss of information* can occur since
- * obviously some bases are not available. When converting to seqan3::dna5 or seqan3::rna5, non-canonical
- * bases (letters other than A, C, G, T, U) are converted to `'N'` to preserve ambiguity at that position, while
+ * When converting from `char` or from a larger nucleotide alphabet to a smaller one, *loss of information* can occur
+ * since obviously some bases are not available. When converting to seqan3::dna5 or seqan3::rna5, non-canonical bases
+ * (letters other than A, C, G, T, U) are converted to `'N'` to preserve ambiguity at that position, while
  * for seqan3::dna4 and seqan3::rna4 they are converted to the first of the possibilities they represent (because
  * there is no letter `'N'` to represent ambiguity).
  *

--- a/include/seqan3/alphabet/nucleotide/all.hpp
+++ b/include/seqan3/alphabet/nucleotide/all.hpp
@@ -44,6 +44,7 @@
 #include <seqan3/alphabet/nucleotide/dna15.hpp>
 #include <seqan3/alphabet/nucleotide/rna4.hpp>
 #include <seqan3/alphabet/nucleotide/rna5.hpp>
+#include <seqan3/alphabet/nucleotide/rna15.hpp>
 
 /*!\defgroup nucleotide Nucleotide
  * \brief Contains the different DNA and RNA alphabet types.

--- a/include/seqan3/alphabet/nucleotide/dna15.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna15.hpp
@@ -35,7 +35,7 @@
 /*!\file
  * \ingroup nucleotide
  * \author Sara Hetzel <sara.hetzel AT fu-berlin.de>
- * \brief Contains seqan3::nucl16, container aliases and string literals.
+ * \brief Contains seqan3::dna15, container aliases and string literals.
  */
 
 #pragma once
@@ -49,24 +49,24 @@
 #include <seqan3/alphabet/nucleotide/concept.hpp>
 
 // ------------------------------------------------------------------
-// nucl16
+// dna15
 // ------------------------------------------------------------------
 
 namespace seqan3
 {
 
-/*!\brief The 16 letter DNA alphabet, containing all IUPAC smybols.
+/*!\brief The 15 letter DNA alphabet, containing all IUPAC smybols minus the gap.
  * \ingroup nucleotide
  * \implements seqan3::nucleotide_concept
  *
  * \details
- * Note that in contrast to seqan3::dna4, seqan3::rna4, seqan3::dna5 and seqan3::rna5
- * the letters 'T' and 'U' are distinct values in this alphabet.
+ * Note that you can assign 'U' as a character to dna15 and it will silently
+ * be converted to 'T'.
  *
  *~~~~~~~~~~~~~~~{.cpp}
- *     nucl16 my_letter{nucl16::A};
+ *     dna15 my_letter{dna15::A};
  *     // doesn't work:
- *     // nucl16 my_letter{'A'};
+ *     // dna15 my_letter{'A'};
  *
  *     my_letter.assign_char('C'); // <- this does!
  *
@@ -76,7 +76,7 @@ namespace seqan3
  *~~~~~~~~~~~~~~~
  */
 
-struct nucl16
+struct dna15
 {
     //!\copydoc seqan3::dna4::char_type
     using char_type = char;
@@ -88,23 +88,23 @@ struct nucl16
      * \details Similar to an Enum interface . *Don't worry about the `internal_type`.*
      */
     //!\{
-    static const nucl16 A;
-    static const nucl16 B;
-    static const nucl16 C;
-    static const nucl16 D;
-    static const nucl16 G;
-    static const nucl16 H;
-    static const nucl16 K;
-    static const nucl16 M;
-    static const nucl16 N;
-    static const nucl16 R;
-    static const nucl16 S;
-    static const nucl16 T;
-    static const nucl16 U;
-    static const nucl16 V;
-    static const nucl16 W;
-    static const nucl16 Y;
-    static const nucl16 UNKNOWN;
+    static const dna15 A;
+    static const dna15 B;
+    static const dna15 C;
+    static const dna15 D;
+    static const dna15 G;
+    static const dna15 H;
+    static const dna15 K;
+    static const dna15 M;
+    static const dna15 N;
+    static const dna15 R;
+    static const dna15 S;
+    static const dna15 T;
+    static const dna15 U;
+    static const dna15 V;
+    static const dna15 W;
+    static const dna15 Y;
+    static const dna15 UNKNOWN;
     //!\}
 
     /*!\name Read functions
@@ -123,7 +123,7 @@ struct nucl16
     }
 
     //!\copydoc seqan3::dna4::complement
-    constexpr nucl16 complement() const noexcept
+    constexpr dna15 complement() const noexcept
     {
         return complement_table[to_rank()];
     }
@@ -133,14 +133,14 @@ struct nucl16
      * \{
      */
     //!\copydoc seqan3::dna4::assign_char
-    constexpr nucl16 & assign_char(char_type const c) noexcept
+    constexpr dna15 & assign_char(char_type const c) noexcept
     {
         _value = char_to_value[c];
         return *this;
     }
 
     //!\copydoc seqan3::dna4::assign_rank
-    constexpr nucl16 & assign_rank(rank_type const c)
+    constexpr dna15 & assign_rank(rank_type const c)
     {
         assert(c < value_size);
         _value = static_cast<internal_type>(c);
@@ -149,7 +149,7 @@ struct nucl16
     //!\}
 
     //!\copydoc seqan3::dna4::value_size
-    static constexpr rank_type value_size{16};
+    static constexpr rank_type value_size{15};
 
     /*!\name Conversion operators
      * \{
@@ -168,32 +168,32 @@ struct nucl16
 
     //!\name Comparison operators
     //!\{
-    constexpr bool operator==(nucl16 const & rhs) const noexcept
+    constexpr bool operator==(dna15 const & rhs) const noexcept
     {
         return _value == rhs._value;
     }
 
-    constexpr bool operator!=(nucl16 const & rhs) const noexcept
+    constexpr bool operator!=(dna15 const & rhs) const noexcept
     {
         return _value != rhs._value;
     }
 
-    constexpr bool operator<(nucl16 const & rhs) const noexcept
+    constexpr bool operator<(dna15 const & rhs) const noexcept
     {
         return _value < rhs._value;
     }
 
-    constexpr bool operator>(nucl16 const & rhs) const noexcept
+    constexpr bool operator>(dna15 const & rhs) const noexcept
     {
         return _value > rhs._value;
     }
 
-    constexpr bool operator<=(nucl16 const & rhs) const noexcept
+    constexpr bool operator<=(dna15 const & rhs) const noexcept
     {
         return _value <= rhs._value;
     }
 
-    constexpr bool operator>=(nucl16 const & rhs) const noexcept
+    constexpr bool operator>=(dna15 const & rhs) const noexcept
     {
         return _value >= rhs._value;
     }
@@ -216,7 +216,7 @@ protected:
         R,
         S,
         T,
-        U,
+        U = T,
         V,
         W,
         Y,
@@ -238,7 +238,6 @@ protected:
         'R',
         'S',
         'T',
-        'U',
         'V',
         'W',
         'Y'
@@ -280,7 +279,7 @@ protected:
     };
 
     //!\copydoc seqan3::dna4::complement_table
-    static const std::array<nucl16, value_size> complement_table;
+    static const std::array<dna15, value_size> complement_table;
 
 public:
     //!\privatesection
@@ -289,42 +288,41 @@ public:
     //!\publicsection
 };
 
-constexpr nucl16 nucl16::A{internal_type::A};
-constexpr nucl16 nucl16::B{internal_type::B};
-constexpr nucl16 nucl16::C{internal_type::C};
-constexpr nucl16 nucl16::D{internal_type::D};
-constexpr nucl16 nucl16::G{internal_type::G};
-constexpr nucl16 nucl16::H{internal_type::H};
-constexpr nucl16 nucl16::K{internal_type::K};
-constexpr nucl16 nucl16::M{internal_type::M};
-constexpr nucl16 nucl16::N{internal_type::N};
-constexpr nucl16 nucl16::R{internal_type::R};
-constexpr nucl16 nucl16::S{internal_type::S};
-constexpr nucl16 nucl16::T{internal_type::T};
-constexpr nucl16 nucl16::U{internal_type::U};
-constexpr nucl16 nucl16::V{internal_type::V};
-constexpr nucl16 nucl16::W{internal_type::W};
-constexpr nucl16 nucl16::Y{internal_type::Y};
-constexpr nucl16 nucl16::UNKNOWN{nucl16::N};
+constexpr dna15 dna15::A{internal_type::A};
+constexpr dna15 dna15::B{internal_type::B};
+constexpr dna15 dna15::C{internal_type::C};
+constexpr dna15 dna15::D{internal_type::D};
+constexpr dna15 dna15::G{internal_type::G};
+constexpr dna15 dna15::H{internal_type::H};
+constexpr dna15 dna15::K{internal_type::K};
+constexpr dna15 dna15::M{internal_type::M};
+constexpr dna15 dna15::N{internal_type::N};
+constexpr dna15 dna15::R{internal_type::R};
+constexpr dna15 dna15::S{internal_type::S};
+constexpr dna15 dna15::T{internal_type::T};
+constexpr dna15 dna15::U{dna15::T};
+constexpr dna15 dna15::V{internal_type::V};
+constexpr dna15 dna15::W{internal_type::W};
+constexpr dna15 dna15::Y{internal_type::Y};
+constexpr dna15 dna15::UNKNOWN{dna15::N};
 
-constexpr std::array<nucl16, nucl16::value_size> nucl16::complement_table
+constexpr std::array<dna15, dna15::value_size> dna15::complement_table
 {
-    nucl16::T,    // complement of nucl16::A
-    nucl16::V,    // complement of nucl16::B
-    nucl16::G,    // complement of nucl16::C
-    nucl16::H,    // complement of nucl16::D
-    nucl16::C,    // complement of nucl16::G
-    nucl16::D,    // complement of nucl16::H
-    nucl16::M,    // complement of nucl16::K
-    nucl16::K,    // complement of nucl16::M
-    nucl16::N,    // complement of nucl16::N
-    nucl16::Y,    // complement of nucl16::R
-    nucl16::S,    // complement of nucl16::S
-    nucl16::A,    // complement of nucl16::T
-    nucl16::A,    // complement of nucl16::U
-    nucl16::B,    // complement of nucl16::V
-    nucl16::W,    // complement of nucl16::W
-    nucl16::R     // complement of nucl16::Y
+    dna15::T,    // complement of dna15::A
+    dna15::V,    // complement of dna15::B
+    dna15::G,    // complement of dna15::C
+    dna15::H,    // complement of dna15::D
+    dna15::C,    // complement of dna15::G
+    dna15::D,    // complement of dna15::H
+    dna15::M,    // complement of dna15::K
+    dna15::K,    // complement of dna15::M
+    dna15::N,    // complement of dna15::N
+    dna15::Y,    // complement of dna15::R
+    dna15::S,    // complement of dna15::S
+    dna15::A,    // complement of dna15::T
+    dna15::B,    // complement of dna15::V
+    dna15::W,    // complement of dna15::W
+    dna15::R     // complement of dna15::Y
 };
 
 } // namespace seqan3
@@ -335,42 +333,10 @@ constexpr std::array<nucl16, nucl16::value_size> nucl16::complement_table
 
 namespace seqan3
 {
-    /*!\name Alphabet aliases
-     * \{
-     * \brief Other names (typedefs) for seqan3::nucl16
-     * \relates nucl16
-     */
-    using dna16 = nucl16;
-    using rna16 = nucl16;
-    using dna = nucl16;
-    using rna = nucl16;
-    //!\}
 
-} // namespace seqan3
-
-
-// ------------------------------------------------------------------
-// containers
-// ------------------------------------------------------------------
-
-namespace seqan3
-{
-
-//!\brief Alias for an std::vector of seqan3::nucl16.
-//!\relates nucl16
-using nucl16_vector = std::vector<nucl16>;
-
-
-/*!\brief Alias for an std::basic_string of seqan3::nucl16.
- * \relates nucl16
- *
- * \attention
- * Note that we recommend using seqan3::nucl16_vector instead of nucl16_string in almost all situations.
- * While the C++ style operations on the string are well supported, you should not access the internal c-string
- * and should not use C-Style operations on it, e.g. the `char_traits::strlen` function will not return the
- * correct length of the string (while the `.size()` returns the correct value).
- */
-using nucl16_string = std::basic_string<nucl16, std::char_traits<nucl16>>;
+//!\brief Alias for an std::vector of seqan3::dna15.
+//!\relates dna15
+using dna15_vector = std::vector<dna15>;
 
 } // namespace seqan3
 
@@ -381,66 +347,31 @@ using nucl16_string = std::basic_string<nucl16, std::char_traits<nucl16>>;
 namespace seqan3::literal
 {
 
-/*!\brief nucl16 literal
- * \relates seqan3::nucl16
- * \returns seqan3::nucl16_vector
+/*!\brief dna15 literal
+ * \relates seqan3::dna15
+ * \returns seqan3::dna15_vector
  *
- * You can use this string literal to easily assign to nucl16_vector:
+ * You can use this string literal to easily assign to dna15_vector:
  *
  *~~~~~~~~~~~~~~~{.cpp}
  *     // these don't work:
- *     // nucl16_vector foo{"ACGTTA"};
- *     // nucl16_vector bar = "ACGTTA";
+ *     // dna15_vector foo{"ACGTTA"};
+ *     // dna15_vector bar = "ACGTTA";
  *
  *     // but these do:
  *     using namespace seqan3::literal;
- *     nucl16_vector foo{"ACGTTA"_nucl16};
- *     nucl16_vector bar = "ACGTTA"_nucl16;
- *     auto bax = "ACGTTA"_nucl16;
+ *     dna15_vector foo{"ACGTTA"_dna15};
+ *     dna15_vector bar = "ACGTTA"_dna15;
+ *     auto bax = "ACGTTA"_dna15;
  *~~~~~~~~~~~~~~~
  *
  * \attention
  * All seqan3 literals are in the namespace seqan3::literal!
  */
 
-inline nucl16_vector operator""_nucl16(const char * s, std::size_t n)
+inline dna15_vector operator""_dna15(const char * s, std::size_t n)
 {
-    nucl16_vector r;
-    r.resize(n);
-
-    for (size_t i = 0; i < n; ++i)
-        r[i].assign_char(s[i]);
-
-    return r;
-}
-
-/*!\brief nucl16 string literal
- * \relates seqan3::nucl16
- * \returns seqan3::nucl16_string
- *
- * You can use this string literal to easily assign to nucl16_vector:
- *
- *~~~~~~~~~~~~~~~{.cpp}
- *     // these don't work:
- *     // nucl16_string foo{"ACGTTA"};
- *     // nucl16_string bar = "ACGTTA";
- *
- *     // but these do:
- *     using namespace seqan3::literal;
- *     nucl16_string foo{"ACGTTA"_nucl16s};
- *     nucl16_string bar = "ACGTTA"_nucl16s;
- *     auto bax = "ACGTTA"_nucl16s;
- *~~~~~~~~~~~~~~~
- *
- * Please note the limitations of seqan3::nucl16_string and consider using the \link operator""_nucl16 \endlink instead.
- *
- * \attention
- * All seqan3 literals are in the namespace seqan3::literal!
- */
-
-inline nucl16_string operator""_nucl16s(const char * s, std::size_t n)
-{
-    nucl16_string r;
+    dna15_vector r;
     r.resize(n);
 
     for (size_t i = 0; i < n; ++i)
@@ -450,4 +381,3 @@ inline nucl16_string operator""_nucl16s(const char * s, std::size_t n)
 }
 
 } // namespace seqan3::literal
-

--- a/include/seqan3/alphabet/nucleotide/dna15.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna15.hpp
@@ -154,6 +154,17 @@ struct dna15
     /*!\name Conversion operators
      * \{
      */
+    //!\brief Implicit conversion between dna* and rna* of the same size.
+    //!\tparam other_nucl_type The type to convert to; must satisfy seqan3::nucleotide_concept and have the same \link value_size \endlink.
+    template <typename other_nucl_type>
+    //!\cond
+        requires nucleotide_concept<other_nucl_type> && value_size == alphabet_size_v<other_nucl_type>
+    //!\endcond
+    constexpr operator other_nucl_type() const noexcept
+    {
+        return other_nucl_type{_value};
+    }
+
     //!\brief Explicit conversion to any other nucleotide alphabet (via char representation).
     //!\tparam other_nucl_type The type to convert to; must satisfy seqan3::nucleotide_concept.
     template <typename other_nucl_type>

--- a/include/seqan3/alphabet/nucleotide/rna15.hpp
+++ b/include/seqan3/alphabet/nucleotide/rna15.hpp
@@ -1,0 +1,264 @@
+// ============================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ============================================================================
+//
+// Copyright (c) 2006-2017, Knut Reinert & Freie Universitaet Berlin
+// Copyright (c) 2016-2017, Knut Reinert & MPI Molekulare Genetik
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ============================================================================
+
+/*!\file
+ * \ingroup nucleotide
+ * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
+ * \brief Provides seqan3::rna15, container aliases and string literals.
+ */
+
+#pragma once
+
+#include <cassert>
+
+#include <string>
+#include <vector>
+
+#include <seqan3/alphabet/detail/convert.hpp>
+#include <seqan3/alphabet/nucleotide/concept.hpp>
+#include <seqan3/alphabet/nucleotide/dna15.hpp>
+
+// ------------------------------------------------------------------
+// rna15
+// ------------------------------------------------------------------
+
+namespace seqan3
+{
+
+/*!\brief The 15 letter RNA alphabet, containing all IUPAC smybols minus the gap.
+ * \ingroup nucleotide
+ * \implements seqan3::nucleotide_concept
+ *
+ * \details
+ * This alphabet inherits from seqan3::dna15 and is guaranteed to have the same internal representation of
+ * data. The only difference is that it prints 'U' on character conversion instead of 'T'. You can implicitly
+ * convert between values of seqan3::dna15 and seqan3::rna15.
+ *
+ *~~~~~~~~~~~~~~~{.cpp}
+ *     rna15 my_letter{rna15::A};
+ *     // doesn't work:
+ *     // rna15 my_letter{'A'};
+ *
+ *     my_letter.assign_char('C'); // <- this does!
+ *
+ *     my_letter.assign_char('F'); // converted to N internally
+ *     if (my_letter.to_char() == 'N')
+ *        std::cout << "yeah\n"; // "yeah";
+ *~~~~~~~~~~~~~~~
+ */
+
+struct rna15 : public dna15
+{
+    /*!\name Letter values
+     * \brief Static member "letters" that can be assigned to the alphabet or used in aggregate initialization.
+     * \details Similar to an Enum interface . *Don't worry about the `internal_type`.*
+     */
+    //!\{
+    static const rna15 A;
+    static const rna15 B;
+    static const rna15 C;
+    static const rna15 D;
+    static const rna15 G;
+    static const rna15 H;
+    static const rna15 K;
+    static const rna15 M;
+    static const rna15 N;
+    static const rna15 R;
+    static const rna15 S;
+    static const rna15 T;
+    static const rna15 U;
+    static const rna15 V;
+    static const rna15 W;
+    static const rna15 Y;
+    static const rna15 UNKNOWN;
+    //!\}
+
+    /*!\name Read functions
+     * \{
+     */
+    //!\copydoc seqan3::dna4::to_char
+    constexpr char_type to_char() const noexcept
+    {
+        return value_to_char[static_cast<rank_type>(_value)];
+    }
+
+    //!\copydoc seqan3::dna4::complement
+    constexpr rna15 complement() const noexcept
+    {
+        return dna15::complement();
+    }
+    //!\}
+
+    /*!\name Write functions
+     * \{
+     */
+    //!\copydoc seqan3::dna4::assign_char
+    constexpr rna15 & assign_char(char_type const c) noexcept
+    {
+        _value = char_to_value[c];
+        return *this;
+    }
+
+    //!\copydoc seqan3::dna4::assign_rank
+    constexpr rna15 & assign_rank(rank_type const c)
+    {
+        assert(c < value_size);
+        _value = static_cast<internal_type>(c);
+        return *this;
+    }
+    //!\}
+
+    /*!\name Conversion operators
+     * \{
+     */
+    //!\brief Implicit conversion between dna* and rna* of the same size.
+    //!\tparam other_nucl_type The type to convert to; must satisfy seqan3::nucleotide_concept and have the same \link value_size \endlink.
+    template <typename other_nucl_type>
+    //!\cond
+        requires nucleotide_concept<other_nucl_type> && value_size == alphabet_size_v<other_nucl_type>
+    //!\endcond
+    constexpr operator other_nucl_type() const noexcept
+    {
+        return other_nucl_type{_value};
+    }
+
+    //!\brief Explicit conversion to any other nucleotide alphabet (via char representation).
+    //!\tparam other_nucl_type The type to convert to; must satisfy seqan3::nucleotide_concept.
+    template <typename other_nucl_type>
+    //!\cond
+        requires nucleotide_concept<other_nucl_type>
+    //!\endcond
+    explicit constexpr operator other_nucl_type() const noexcept
+    {
+        return detail::convert_through_char_representation<other_nucl_type, std::decay_t<decltype(*this)>>[to_rank()];
+    }
+    //!\}
+
+protected:
+    //!\privatesection
+    //!\copydoc seqan3::dna4::value_to_char
+    static constexpr char_type value_to_char[value_size]
+    {
+        'A',
+        'B',
+        'C',
+        'D',
+        'G',
+        'H',
+        'K',
+        'M',
+        'N',
+        'R',
+        'S',
+        'U',
+        'V',
+        'W',
+        'Y'
+    };
+};
+
+constexpr rna15 rna15::A{internal_type::A};
+constexpr rna15 rna15::B{internal_type::B};
+constexpr rna15 rna15::C{internal_type::C};
+constexpr rna15 rna15::D{internal_type::D};
+constexpr rna15 rna15::G{internal_type::G};
+constexpr rna15 rna15::H{internal_type::H};
+constexpr rna15 rna15::K{internal_type::K};
+constexpr rna15 rna15::M{internal_type::M};
+constexpr rna15 rna15::N{internal_type::N};
+constexpr rna15 rna15::R{internal_type::R};
+constexpr rna15 rna15::S{internal_type::S};
+constexpr rna15 rna15::U{internal_type::U};
+constexpr rna15 rna15::T{rna15::U};
+constexpr rna15 rna15::V{internal_type::V};
+constexpr rna15 rna15::W{internal_type::W};
+constexpr rna15 rna15::Y{internal_type::Y};
+constexpr rna15 rna15::UNKNOWN{rna15::N};
+
+} // namespace seqan3
+
+// ------------------------------------------------------------------
+// containers
+// ------------------------------------------------------------------
+
+namespace seqan3
+{
+
+//!\brief Alias for an std::vector of seqan3::rna15.
+//!\relates rna15
+using rna15_vector = std::vector<rna15>;
+
+} // namespace seqan3
+
+// ------------------------------------------------------------------
+// literals
+// ------------------------------------------------------------------
+
+namespace seqan3::literal
+{
+
+/*!\brief rna15 literal
+ * \relates seqan3::rna15
+ * \returns seqan3::rna15_vector
+ *
+ * You can use this string literal to easily assign to rna15_vector:
+ *
+ *~~~~~~~~~~~~~~~{.cpp}
+ *     // these don't work:
+ *     // rna15_vector foo{"ACGTTA"};
+ *     // rna15_vector bar = "ACGTTA";
+ *
+ *     // but these do:
+ *     using namespace seqan3::literal;
+ *     rna15_vector foo{"ACGTTA"_rna15};
+ *     rna15_vector bar = "ACGTTA"_rna15;
+ *     auto bax = "ACGTTA"_rna15;
+ *~~~~~~~~~~~~~~~
+ *
+ * \attention
+ * All seqan3 literals are in the namespace seqan3::literal!
+ */
+
+inline rna15_vector operator""_rna15(const char * s, std::size_t n)
+{
+    rna15_vector r;
+    r.resize(n);
+
+    for (size_t i = 0; i < n; ++i)
+        r[i].assign_char(s[i]);
+
+    return r;
+}
+
+} // namespace seqan3::literal

--- a/include/seqan3/alphabet/quality/aliases.hpp
+++ b/include/seqan3/alphabet/quality/aliases.hpp
@@ -48,11 +48,7 @@
 #include <seqan3/alphabet/quality/quality_composition.hpp>
 #include <seqan3/alphabet/quality/concept.hpp>
 #include <seqan3/alphabet/quality/illumina18.hpp>
-#include <seqan3/alphabet/nucleotide/dna4.hpp>
-#include <seqan3/alphabet/nucleotide/dna5.hpp>
-#include <seqan3/alphabet/nucleotide/rna4.hpp>
-#include <seqan3/alphabet/nucleotide/rna5.hpp>
-#include <seqan3/alphabet/nucleotide/nucl16.hpp>
+#include <seqan3/alphabet/nucleotide/all.hpp>
 
 namespace seqan3
 {
@@ -69,7 +65,10 @@ using rna4q = quality_composition<rna4, illumina18>;
 //!\brief An alphabet that stores a seqan3::rna5 letter and an seqan3::illumina18 letter at each position.
 using rna5q = quality_composition<rna5, illumina18>;
 
-//!\brief An alphabet that stores a seqan3::nucl16 letter and an seqan3::illumina18 letter at each position.
-using nucl16q = quality_composition<nucl16, illumina18>;
+//!\brief An alphabet that stores a seqan3::dna15 letter and an seqan3::illumina18 letter at each position.
+using dna15q = quality_composition<dna15, illumina18>;
+
+//!\brief An alphabet that stores a seqan3::rna15 letter and an seqan3::illumina18 letter at each position.
+using rna15q = quality_composition<rna15, illumina18>;
 
 } // namespace seqan3

--- a/include/seqan3/range/view/convert.hpp
+++ b/include/seqan3/range/view/convert.hpp
@@ -81,9 +81,9 @@ namespace seqan3::view
  *   auto v3 = vec | view::convert<bool> | ranges::view::reverse; // == [1, 1, 1, 0, 0, 1, 0, 1, 1];
  * ```
  *
- * Convert from seqan3::nucl16 to seqan3::dna5:
+ * Convert from seqan3::dna15 to seqan3::dna5:
  * ```cpp
- *   nucl16_vector vec2{"ACYGTN"_nucl16};
+ *   dna15_vector vec2{"ACYGTN"_dna15};
  *   auto v4 = vec2 | view::convert<dna5>; // == "ACNGTN"_dna5
  * ```
  * \hideinitializer

--- a/test/alphabet/alphabet_test.cpp
+++ b/test/alphabet/alphabet_test.cpp
@@ -55,7 +55,7 @@ class alphabet : public ::testing::Test
 {};
 
 // add all alphabets here
-using alphabet_types = ::testing::Types<dna4, dna5, rna4, rna5, nucl16,
+using alphabet_types = ::testing::Types<dna4, dna5, dna15, rna4, rna5, rna15,
                                         aa27,
                                         union_composition<dna4>,
                                         union_composition<dna4, gap>,
@@ -63,7 +63,7 @@ using alphabet_types = ::testing::Types<dna4, dna5, rna4, rna5, nucl16,
                                         union_composition<dna4, dna5, gap>,
                                         /*gap,*/
                                         gapped<dna4>,
-                                        gapped<nucl16>,
+                                        gapped<dna15>,
                                         gapped<illumina18>,
                                         char, char16_t, // char32_t, too slow
                                         uint8_t, uint16_t, // uint32_t, too slow
@@ -285,7 +285,7 @@ class alphabet_constexpr : public ::testing::Test
 {};
 
 // add all alphabets here
-using alphabet_constexpr_types = ::testing::Types<dna4, dna5, rna4, rna5, nucl16,
+using alphabet_constexpr_types = ::testing::Types<dna4, dna5, dna15, rna4, rna5, rna15,
                                                   /*aa27,*/
                                                   union_composition<dna4>,
                                                   union_composition<dna4, gap>,

--- a/test/alphabet/aminoacid_test.cpp
+++ b/test/alphabet/aminoacid_test.cpp
@@ -151,13 +151,13 @@ TEST(aa27_literals, string)
 
 TEST(translation, translate_triplets)
 {
-    nucl16 n1{nucl16::C};
-    nucl16 n2{nucl16::T};
-    nucl16 n3{nucl16::A};
+    dna15 n1{dna15::C};
+    dna15 n2{dna15::T};
+    dna15 n3{dna15::A};
     aa27 c{aa27::L};
 
     // Nucleotide interface
-    aa27 t1{translate_triplet<genetic_code::CANONICAL, nucl16>(n1, n2, n3)};
+    aa27 t1{translate_triplet<genetic_code::CANONICAL, dna15>(n1, n2, n3)};
 
     EXPECT_EQ(t1, c);
 

--- a/test/alphabet/nucleotide_test.cpp
+++ b/test/alphabet/nucleotide_test.cpp
@@ -48,8 +48,8 @@ class nucleotide : public ::testing::Test
 {};
 
 // add all alphabets from the nucleotide sub module here
-using nucleotide_types  = ::testing::Types<dna4, dna5, rna4, rna5, dna15>;
-using nucleotide_types2 =       meta::list<dna4, dna5, rna4, rna5, dna15>; // needed for some tests
+using nucleotide_types  = ::testing::Types<dna4, dna5, dna15, rna4, rna5, rna15>;
+using nucleotide_types2 =       meta::list<dna4, dna5, dna15, rna4, rna5, rna15>; // needed for some tests
 
 TYPED_TEST_CASE(nucleotide, nucleotide_types);
 
@@ -86,7 +86,7 @@ TYPED_TEST(nucleotide, assign_char)
             t::N, t::N, t::N, t::N, t::N, t::N, t::N, t::N, t::N, t::N,
             t::N
         };
-    } else if constexpr (std::is_same_v<TypeParam, dna15>)
+    } else if constexpr (std::is_same_v<TypeParam, dna15> || std::is_same_v<TypeParam, rna15>)
     {
         cmp =
         {
@@ -109,15 +109,15 @@ TYPED_TEST(nucleotide, to_char)
     EXPECT_EQ(to_char(TypeParam::G), 'G');
 
     if constexpr (std::is_same_v<TypeParam, rna4> ||
-                  std::is_same_v<TypeParam, rna5>)
-//                   std::is_same_v<TypeParam, rna15>)
+                  std::is_same_v<TypeParam, rna5> ||
+                  std::is_same_v<TypeParam, rna15>)
     {
         EXPECT_EQ(to_char(TypeParam::U), 'U');
         EXPECT_EQ(to_char(TypeParam::T), 'U');
     }
     else if constexpr (std::is_same_v<TypeParam, dna4> ||
                        std::is_same_v<TypeParam, dna5> ||
-                       std::is_same_v<TypeParam, dna5>)
+                       std::is_same_v<TypeParam, dna15>)
     {
         EXPECT_EQ(to_char(TypeParam::U), 'T');
         EXPECT_EQ(to_char(TypeParam::T), 'T');
@@ -179,19 +179,19 @@ TYPED_TEST(nucleotide, concept)
 // conversion to rna/dna of same size
 TYPED_TEST(nucleotide, implicit_conversion)
 {
-    using complement_type = std::conditional_t<std::is_same_v<TypeParam, rna4>, dna4,
-                            std::conditional_t<std::is_same_v<TypeParam, dna4>, rna4,
-                            std::conditional_t<std::is_same_v<TypeParam, rna5>, dna5,
-                            std::conditional_t<std::is_same_v<TypeParam, dna5>, rna5, void>>>>;
-    if constexpr (!std::is_same_v<complement_type, void>)
-    {
-        // construct
-        EXPECT_EQ(complement_type{TypeParam::C}, complement_type::C);
-        // assign
-        complement_type l{};
-        l = TypeParam::C;
-        EXPECT_EQ(l, complement_type::C);
-    }
+    using other_type = std::conditional_t<std::is_same_v<TypeParam, rna4>,  dna4,
+                       std::conditional_t<std::is_same_v<TypeParam, dna4>,  rna4,
+                       std::conditional_t<std::is_same_v<TypeParam, rna5>,  dna5,
+                       std::conditional_t<std::is_same_v<TypeParam, dna5>,  rna5,
+                       std::conditional_t<std::is_same_v<TypeParam, dna15>, rna15,
+                       /* must be rna15 */                                  dna15>>>>>;
+
+    // construct
+    EXPECT_EQ(other_type{TypeParam::C}, other_type::C);
+    // assign
+    other_type l{};
+    l = TypeParam::C;
+    EXPECT_EQ(l, other_type::C);
 }
 
 // conversion to any other nucleotide type
@@ -203,6 +203,9 @@ TYPED_TEST(nucleotide, explicit_conversion)
         EXPECT_EQ(static_cast<out_type>(TypeParam::A), out_type::A);
         EXPECT_EQ(static_cast<out_type>(TypeParam::C), out_type::C);
         EXPECT_EQ(static_cast<out_type>(TypeParam::G), out_type::G);
+        EXPECT_EQ(static_cast<out_type>(TypeParam::T), out_type::T);
+        EXPECT_EQ(static_cast<out_type>(TypeParam::U), out_type::U);
+        EXPECT_EQ(static_cast<out_type>(TypeParam::T), out_type::U);
     });
 }
 
@@ -251,6 +254,16 @@ TEST(dna5_literals, basic_string)
     EXPECT_EQ(w, "ACGTTNN"_dna5s);
 }
 
+TEST(dna15_literals, vector)
+{
+    dna15_vector v;
+    v.resize(5, dna15::A);
+    EXPECT_EQ(v, "AAAAA"_dna15);
+
+    std::vector<dna15> w{dna15::A, dna15::C, dna15::G, dna15::T, dna15::U, dna15::N, dna15::UNKNOWN};
+    EXPECT_EQ(w, "ACGTTNN"_dna15);
+}
+
 TEST(rna4_literals, vector)
 {
     rna4_vector v;
@@ -292,12 +305,12 @@ TEST(rna5_literals, basic_string)
     EXPECT_EQ(w, "ACGUUNN"_rna5s);
 }
 
-TEST(dna15_literals, vector)
+TEST(rna15_literals, vector)
 {
-    dna15_vector v;
-    v.resize(5, dna15::A);
-    EXPECT_EQ(v, "AAAAA"_dna15);
+    rna15_vector v;
+    v.resize(5, rna15::A);
+    EXPECT_EQ(v, "AAAAA"_rna15);
 
-    std::vector<dna15> w{dna15::A, dna15::C, dna15::G, dna15::T, dna15::U, dna15::N, dna15::UNKNOWN};
-    EXPECT_EQ(w, "ACGTTNN"_dna15);
+    std::vector<rna15> w{rna15::A, rna15::C, rna15::G, rna15::T, rna15::U, rna15::N, rna15::UNKNOWN};
+    EXPECT_EQ(w, "ACGTTNN"_rna15);
 }

--- a/test/alphabet/nucleotide_test.cpp
+++ b/test/alphabet/nucleotide_test.cpp
@@ -48,8 +48,8 @@ class nucleotide : public ::testing::Test
 {};
 
 // add all alphabets from the nucleotide sub module here
-using nucleotide_types  = ::testing::Types<dna4, dna5, rna4, rna5, nucl16>;
-using nucleotide_types2 =       meta::list<dna4, dna5, rna4, rna5, nucl16>; // needed for some tests
+using nucleotide_types  = ::testing::Types<dna4, dna5, rna4, rna5, dna15>;
+using nucleotide_types2 =       meta::list<dna4, dna5, rna4, rna5, dna15>; // needed for some tests
 
 TYPED_TEST_CASE(nucleotide, nucleotide_types);
 
@@ -86,7 +86,7 @@ TYPED_TEST(nucleotide, assign_char)
             t::N, t::N, t::N, t::N, t::N, t::N, t::N, t::N, t::N, t::N,
             t::N
         };
-    } else if constexpr (std::is_same_v<TypeParam, nucl16>)
+    } else if constexpr (std::is_same_v<TypeParam, dna15>)
     {
         cmp =
         {
@@ -108,20 +108,23 @@ TYPED_TEST(nucleotide, to_char)
     EXPECT_EQ(to_char(TypeParam::C), 'C');
     EXPECT_EQ(to_char(TypeParam::G), 'G');
 
-    if constexpr (std::is_same_v<TypeParam, rna4> || std::is_same_v<TypeParam, rna5>)
+    if constexpr (std::is_same_v<TypeParam, rna4> ||
+                  std::is_same_v<TypeParam, rna5>)
+//                   std::is_same_v<TypeParam, rna15>)
     {
         EXPECT_EQ(to_char(TypeParam::U), 'U');
         EXPECT_EQ(to_char(TypeParam::T), 'U');
     }
-    else if constexpr (std::is_same_v<TypeParam, dna4> || std::is_same_v<TypeParam, dna5>)
+    else if constexpr (std::is_same_v<TypeParam, dna4> ||
+                       std::is_same_v<TypeParam, dna5> ||
+                       std::is_same_v<TypeParam, dna5>)
     {
         EXPECT_EQ(to_char(TypeParam::U), 'T');
         EXPECT_EQ(to_char(TypeParam::T), 'T');
-    } else
-    {
-        EXPECT_EQ(to_char(TypeParam::U), 'U');
-        EXPECT_EQ(to_char(TypeParam::T), 'T');
+    }
 
+    if constexpr (alphabet_size_v<TypeParam> > 5)
+    {
         EXPECT_EQ(to_char(TypeParam::R), 'R');
         EXPECT_EQ(to_char(TypeParam::Y), 'Y');
         EXPECT_EQ(to_char(TypeParam::S), 'S');
@@ -153,16 +156,7 @@ TYPED_TEST(nucleotide, complement)
     {
         TypeParam c = assign_rank(TypeParam{}, i);
 
-        if constexpr (std::is_same_v<TypeParam, nucl16>)
-        {
-            if (c == nucl16::U)
-                EXPECT_EQ(complement(complement(c)), nucl16::T);
-            else
-                EXPECT_EQ(complement(complement(c)), c);
-        } else
-        {
-            EXPECT_EQ(complement(complement(c)), c);
-        }
+        EXPECT_EQ(complement(complement(c)), c);
     }
 }
 
@@ -298,23 +292,12 @@ TEST(rna5_literals, basic_string)
     EXPECT_EQ(w, "ACGUUNN"_rna5s);
 }
 
-TEST(nucl16_literals, vector)
+TEST(dna15_literals, vector)
 {
-    nucl16_vector v;
-    v.resize(5, nucl16::A);
-    EXPECT_EQ(v, "AAAAA"_nucl16);
+    dna15_vector v;
+    v.resize(5, dna15::A);
+    EXPECT_EQ(v, "AAAAA"_dna15);
 
-    std::vector<nucl16> w{nucl16::A, nucl16::C, nucl16::G, nucl16::T, nucl16::U, nucl16::N, nucl16::UNKNOWN};
-    EXPECT_EQ(w, "ACGTUNN"_nucl16);
-}
-
-TEST(nucl16_literals, basic_string)
-{
-    nucl16_string v;
-    v.resize(5, nucl16::A);
-    EXPECT_EQ(v, "AAAAA"_nucl16s);
-
-    std::basic_string<nucl16, std::char_traits<nucl16>> w{nucl16::A, nucl16::C, nucl16::G, nucl16::T, nucl16::U,
-                                                          nucl16::N, nucl16::UNKNOWN};
-    EXPECT_EQ(w, "ACGTUNN"_nucl16s);
+    std::vector<dna15> w{dna15::A, dna15::C, dna15::G, dna15::T, dna15::U, dna15::N, dna15::UNKNOWN};
+    EXPECT_EQ(w, "ACGTTNN"_dna15);
 }


### PR DESCRIPTION
replace the nucl16 alphabet (with distinct T and U values) with dan15 and rna15. This removes ambiguity on conversions and creates consistency with the other dna and rna alphabets.