### PR TITLE
[INTERNAL, TEST] Remove static_assert from alphabet code

### DIFF
--- a/include/seqan3/alphabet/adaptation/all.hpp
+++ b/include/seqan3/alphabet/adaptation/all.hpp
@@ -46,13 +46,3 @@
  * \brief Contains alphabet adaptions of some standard char and uint types.
  * \ingroup alphabet
  */
-
-#ifndef NDEBUG
-#include <seqan3/alphabet/concept.hpp>
-static_assert(seqan3::char_adaptation_concept<char>);
-static_assert(seqan3::char_adaptation_concept<char16_t>);
-static_assert(seqan3::char_adaptation_concept<char32_t>);
-static_assert(seqan3::uint_adaptation_concept<uint8_t>);
-static_assert(seqan3::uint_adaptation_concept<uint16_t>);
-static_assert(seqan3::uint_adaptation_concept<uint32_t>);
-#endif

--- a/include/seqan3/alphabet/aminoacid/aa27.hpp
+++ b/include/seqan3/alphabet/aminoacid/aa27.hpp
@@ -341,13 +341,6 @@ constexpr aa27 aa27::UNKNOWN{aa27::X};
 
 } // namespace seqan3
 
-#ifndef NDEBUGs
-
-#include <seqan3/alphabet/concept.hpp>
-
-static_assert(seqan3::alphabet_concept<seqan3::aa27>);
-#endif
-
 // ------------------------------------------------------------------
 // containers
 // ------------------------------------------------------------------

--- a/include/seqan3/alphabet/composition/union_composition.hpp
+++ b/include/seqan3/alphabet/composition/union_composition.hpp
@@ -497,8 +497,3 @@ protected:
 };
 
 } // namespace seqan3
-
-#ifndef NDEBUG
-#include <seqan3/alphabet/nucleotide/dna5.hpp>
-static_assert(seqan3::alphabet_concept<seqan3::union_composition<seqan3::dna5, seqan3::dna5>>);
-#endif

--- a/include/seqan3/alphabet/gap/gap.hpp
+++ b/include/seqan3/alphabet/gap/gap.hpp
@@ -154,8 +154,4 @@ struct gap
 
 constexpr gap gap::GAP{};
 
-#ifndef NDEBUG
-static_assert(alphabet_concept<gap>);
-#endif
-
 }

--- a/include/seqan3/alphabet/gap/gapped.hpp
+++ b/include/seqan3/alphabet/gap/gapped.hpp
@@ -105,8 +105,3 @@ struct gapped : public union_composition<alphabet_t, gap>
 };
 
 } // namespace seqan3
-
-#ifndef NDEBUG
-#include <seqan3/alphabet/nucleotide/dna4.hpp>
-static_assert(seqan3::alphabet_concept<seqan3::gapped<seqan3::dna4>>);
-#endif

--- a/include/seqan3/alphabet/nucleotide/dna4.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna4.hpp
@@ -356,11 +356,6 @@ constexpr std::array<dna4, dna4::value_size> dna4::complement_table
 
 } // namespace seqan3
 
-#ifndef NDEBUG
-static_assert(seqan3::alphabet_concept<seqan3::dna4>);
-static_assert(seqan3::nucleotide_concept<seqan3::dna4>);
-#endif
-
 // ------------------------------------------------------------------
 // containers
 // ------------------------------------------------------------------

--- a/include/seqan3/alphabet/nucleotide/dna5.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna5.hpp
@@ -277,11 +277,6 @@ constexpr std::array<dna5, dna5::value_size> dna5::complement_table
 
 } // namespace seqan3
 
-#ifndef NDEBUG
-static_assert(seqan3::alphabet_concept<seqan3::dna5>);
-static_assert(seqan3::nucleotide_concept<seqan3::dna5>);
-#endif
-
 // ------------------------------------------------------------------
 // containers
 // ------------------------------------------------------------------

--- a/include/seqan3/alphabet/nucleotide/nucl16.hpp
+++ b/include/seqan3/alphabet/nucleotide/nucl16.hpp
@@ -329,11 +329,6 @@ constexpr std::array<nucl16, nucl16::value_size> nucl16::complement_table
 
 } // namespace seqan3
 
-#ifndef NDEBUG
-static_assert(seqan3::alphabet_concept<seqan3::nucl16>);
-static_assert(seqan3::nucleotide_concept<seqan3::nucl16>);
-#endif
-
 // ------------------------------------------------------------------
 // containers
 // ------------------------------------------------------------------

--- a/include/seqan3/alphabet/nucleotide/rna4.hpp
+++ b/include/seqan3/alphabet/nucleotide/rna4.hpp
@@ -173,11 +173,6 @@ constexpr rna4 rna4::UNKNOWN{rna4::A};
 
 } // namespace seqan3
 
-#ifndef NDEBUG
-static_assert(seqan3::alphabet_concept<seqan3::rna4>);
-static_assert(seqan3::nucleotide_concept<seqan3::rna4>);
-#endif
-
 // ------------------------------------------------------------------
 // containers
 // ------------------------------------------------------------------

--- a/include/seqan3/alphabet/nucleotide/rna5.hpp
+++ b/include/seqan3/alphabet/nucleotide/rna5.hpp
@@ -176,11 +176,6 @@ constexpr rna5 rna5::UNKNOWN{rna5::N};
 
 } // namespace seqan3
 
-#ifndef NDEBUG
-static_assert(seqan3::alphabet_concept<seqan3::rna5>);
-static_assert(seqan3::nucleotide_concept<seqan3::rna5>);
-#endif
-
 // ------------------------------------------------------------------
 // containers
 // ------------------------------------------------------------------

--- a/include/seqan3/alphabet/quality/aliases.hpp
+++ b/include/seqan3/alphabet/quality/aliases.hpp
@@ -73,8 +73,3 @@ using rna5q = quality_composition<rna5, illumina18>;
 using nucl16q = quality_composition<nucl16, illumina18>;
 
 } // namespace seqan3
-
-#ifndef NDEBUG
-static_assert(seqan3::nucleotide_concept<seqan3::dna4q>);
-static_assert(sizeof(seqan3::dna4q) == sizeof(seqan3::dna4) + sizeof(seqan3::illumina18));
-#endif

--- a/include/seqan3/alphabet/quality/illumina18.hpp
+++ b/include/seqan3/alphabet/quality/illumina18.hpp
@@ -171,11 +171,3 @@ protected:
 };
 
 } // namespace seqan3
-
-#ifndef NDEBUG
-#include <seqan3/alphabet/concept.hpp>
-#include <seqan3/alphabet/quality/concept.hpp>
-static_assert(seqan3::alphabet_concept<seqan3::illumina18>);
-static_assert(seqan3::quality_concept<seqan3::illumina18>);
-static_assert(seqan3::detail::internal_quality_concept<seqan3::illumina18>);
-#endif

--- a/include/seqan3/alphabet/quality/quality_composition.hpp
+++ b/include/seqan3/alphabet/quality/quality_composition.hpp
@@ -176,10 +176,3 @@ quality_composition(sequence_alphabet_type &&, quality_alphabet_type &&)
     -> quality_composition<std::decay_t<sequence_alphabet_type>, std::decay_t<quality_alphabet_type>>;
 
 } // namespace seqan3
-
-#ifndef NDEBUG
-#include <seqan3/alphabet/nucleotide/dna4.hpp>
-#include <seqan3/alphabet/quality/illumina18.hpp>
-static_assert(seqan3::nucleotide_concept<seqan3::quality_composition<seqan3::dna4, seqan3::illumina18>>);
-static_assert(seqan3::quality_concept<seqan3::quality_composition<seqan3::dna4, seqan3::illumina18>>);
-#endif

--- a/include/seqan3/alphabet/structure/dot_bracket3.hpp
+++ b/include/seqan3/alphabet/structure/dot_bracket3.hpp
@@ -266,11 +266,6 @@ constexpr dot_bracket3 dot_bracket3::UNKNOWN{internal_type::UNKNOWN};
 
 } // namespace seqan3
 
-#ifndef NDEBUG
-static_assert(seqan3::alphabet_concept<seqan3::dot_bracket3>);
-static_assert(seqan3::rna_structure_concept<seqan3::dot_bracket3>);
-#endif
-
 // ------------------------------------------------------------------
 // literals
 // ------------------------------------------------------------------

--- a/include/seqan3/alphabet/structure/dssp9.hpp
+++ b/include/seqan3/alphabet/structure/dssp9.hpp
@@ -254,10 +254,6 @@ constexpr dssp9 dssp9::X{internal_type::X};
 
 } // namespace seqan3
 
-#ifndef NDEBUG
-static_assert(seqan3::alphabet_concept<seqan3::dssp9>);
-#endif
-
 // ------------------------------------------------------------------
 // literals
 // ------------------------------------------------------------------

--- a/include/seqan3/alphabet/structure/structured_aa.hpp
+++ b/include/seqan3/alphabet/structure/structured_aa.hpp
@@ -147,9 +147,3 @@ structured_aa(sequence_alphabet_type &&, structure_alphabet_type &&)
     -> structured_aa<std::decay_t<sequence_alphabet_type>, std::decay_t<structure_alphabet_type>>;
 
 } // namespace seqan3
-
-#ifndef NDEBUG
-#include <seqan3/alphabet/aminoacid/aa27.hpp>
-#include <seqan3/alphabet/structure/dssp9.hpp>
-static_assert(seqan3::alphabet_concept<seqan3::structured_aa<seqan3::aa27, seqan3::dssp9>>);
-#endif

--- a/include/seqan3/alphabet/structure/structured_rna.hpp
+++ b/include/seqan3/alphabet/structure/structured_rna.hpp
@@ -192,11 +192,3 @@ structured_rna(sequence_alphabet_type &&, structure_alphabet_type &&)
     -> structured_rna<std::decay_t<sequence_alphabet_type>, std::decay_t<structure_alphabet_type>>;
 
 } // namespace seqan3
-
-#ifndef NDEBUG
-#include <seqan3/alphabet/nucleotide/rna5.hpp>
-#include <seqan3/alphabet/structure/wuss.hpp>
-static_assert(seqan3::alphabet_concept<seqan3::structured_rna<seqan3::rna5, seqan3::wuss51>>);
-static_assert(seqan3::nucleotide_concept<seqan3::structured_rna<seqan3::rna5, seqan3::wuss51>>);
-static_assert(seqan3::rna_structure_concept<seqan3::structured_rna<seqan3::rna5, seqan3::wuss51>>);
-#endif

--- a/include/seqan3/alphabet/structure/wuss.hpp
+++ b/include/seqan3/alphabet/structure/wuss.hpp
@@ -398,11 +398,6 @@ typedef wuss<51> wuss51;
 
 } // namespace seqan3
 
-#ifndef NDEBUG
-static_assert(seqan3::alphabet_concept<seqan3::wuss<>>);
-static_assert(seqan3::rna_structure_concept<seqan3::wuss<>>);
-#endif
-
 // ------------------------------------------------------------------
 // literals
 // ------------------------------------------------------------------

--- a/test/alphabet/alphabet_test.cpp
+++ b/test/alphabet/alphabet_test.cpp
@@ -59,8 +59,9 @@ using alphabet_types = ::testing::Types<dna4, dna5, rna4, rna5, nucl16,
                                         aa27,
                                         union_composition<dna4>,
                                         union_composition<dna4, gap>,
+                                        union_composition<dna5, dna5>,
                                         union_composition<dna4, dna5, gap>,
-                                        /*gap, */
+                                        /*gap,*/
                                         gapped<dna4>,
                                         gapped<nucl16>,
                                         gapped<illumina18>,

--- a/test/alphabet/quality/illumina18_test.cpp
+++ b/test/alphabet/quality/illumina18_test.cpp
@@ -178,3 +178,9 @@ TEST(illumina18_cmp, cmp)
     EXPECT_GE(illu3, illu2);
     EXPECT_GT(illu3, illu2);
 }
+
+TEST(illumina18, quality_concept)
+{
+    EXPECT_TRUE(quality_concept<illumina18>);
+    EXPECT_TRUE(seqan3::detail::internal_quality_concept<illumina18>);
+}


### PR DESCRIPTION
See #145 

As it seems, all static asserts are already tested.
For adaptation, quality_composition and structured_aa we might want to refactor some tests:
- e.g. alphabet_concept gets tested by testing the single conditions instead of ``EXPECT_TRUE(alphabet_concept<TypeParam>);`` or something similar
- Not all types get tested, e.g. in quality_composition