### PR TITLE
add LEMON submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "cereal"]
 	path = cereal
 	url = https://github.com/USCiLab/cereal
+[submodule "lemon"]
+	path = lemon
+	url = https://github.com/seqan/lemon

--- a/README.md
+++ b/README.md
@@ -21,10 +21,11 @@ To include SeqAn3 in your app, you need the following:
 |                   | requirement                                          | version  | comment                                   |
 |-------------------|------------------------------------------------------|----------|-------------------------------------------|
 |**compiler**       | [GCC](http://gcc.gnu.org)                            | ≥ 7      | no other compiler is currently supported! |
-|**build system**   | [cmake](https://cmake.org)                           | ≥ 3.4    | optional, but recommended                  |
+|**build system**   | [cmake](https://cmake.org)                           | ≥ 3.4    | optional, but recommended                 |
 |**required libs**  | [SDSL](https://github.com/xxsds/sdsl-lite)           | ≥ 3      | succint datastructures                    |
 |                   | [Ranges-V3](https://github.com/ericniebler/range-v3) | == 0.3.0 | ranges and views                          |
 |**optional libs**  | [Cereal](https://github.com/USCiLab/cereal)          | ≥ 1.2.3  | serialisation                             |
+|                   | [Lemon](http://lemon.cs.elte.hu)                     | ≥ 1.3.1  | graphs, required for MSA                  |
 
 ### Developers of the library
 

--- a/build_system/seqan3-config.cmake
+++ b/build_system/seqan3-config.cmake
@@ -56,13 +56,15 @@
 #   ZLIB      -- zlib compression library
 #   BZip2     -- libbz2 compression library
 #   Cereal    -- Serialisation library
+#   Lemon     -- Graph library
 #
 # If you don't wish for these to be detected (and used), you may define SEQAN3_NO_ZLIB,
-# SEQAN3_NO_BZIP2 and SEQAN3_NO_CEREAL respectively.
+# SEQAN3_NO_BZIP2, SEQAN3_NO_CEREAL and SEQAN3_NO_LEMON respectively.
 #
 # If you wish to require the presence of ZLIB or BZip2, just check for the module before
 # finding SeqAn3, e.g. "find_package (ZLIB REQUIRED)".
 # If you wish to require the presence of CEREAL, you may define SEQAN3_CEREAL.
+# If you wish to require the presence of LEMON, you may define SEQAN3_LEMON.
 #
 # Once the search has been performed, the following variables will be set.
 #
@@ -177,6 +179,25 @@ if (SEQAN3_CEREAL)
     set (SEQAN3_DEFINITIONS ${SEQAN3_DEFINITIONS} "-DSEQAN3_WITH_CEREAL=1")
 elseif (SEQAN3_NO_CEREAL)
     set (SEQAN3_DEFINITIONS ${SEQAN3_DEFINITIONS} "-DSEQAN3_WITH_CEREAL=0")
+endif ()
+
+# Lemon is auto-detected by default, i.e. used if found, not used if not found.
+# You can optionally set a hard requirement so a build fails without Lemon,
+# or you can force-disable Lemon even if present on the system.
+option (SEQAN3_LEMON    "Require Lemon and fail if not present." OFF)
+option (SEQAN3_NO_LEMON "Don't use Lemon, even if present." OFF)
+
+if (SEQAN3_LEMON AND SEQAN3_NO_LEMON)
+    # this is always a user error, therefore we always error-out, even if SeqAn is not required
+    message (FATAL_ERROR "You may not specify SEQAN3_LEMON and SEQAN3_NO_LEMON at the same time.\n\
+                          You can specify neither (use auto-detection), or specify either to force on/off.")
+    return ()
+endif ()
+
+if (SEQAN3_LEMON)
+    set (SEQAN3_DEFINITIONS ${SEQAN3_DEFINITIONS} "-DSEQAN3_WITH_LEMON=1")
+elseif (SEQAN3_NO_LEMON)
+    set (SEQAN3_DEFINITIONS ${SEQAN3_DEFINITIONS} "-DSEQAN3_WITH_LEMON=0")
 endif ()
 
 # These two are "opt-in", because detected by CMake
@@ -345,6 +366,28 @@ if (NOT SEQAN3_NO_CEREAL)
             seqan3_config_error ("The (optional) cereal library was marked as required, but wasn't found.")
         else ()
             seqan3_config_print ("Optional dependency:        Cereal not found.")
+        endif ()
+    endif ()
+endif ()
+
+# ----------------------------------------------------------------------------
+# Lemon dependency is optional, but may set as required
+# ----------------------------------------------------------------------------
+
+if (NOT SEQAN3_NO_LEMON)
+    check_include_file_cxx (lemon/config.h _SEQAN3_HAVE_LEMON)
+
+    if (_SEQAN3_HAVE_LEMON)
+        if (SEQAN3_LEMON)
+            seqan3_config_print ("Required dependency:        Lemon found.")
+        else ()
+            seqan3_config_print ("Optional dependency:        Lemon found.")
+        endif ()
+    else ()
+        if (SEQAN3_LEMON)
+            seqan3_config_error ("The (optional) Lemon library was marked as required, but wasn't found.")
+        else ()
+            seqan3_config_print ("Optional dependency:        Lemon not found.")
         endif ()
     endif ()
 endif ()

--- a/include/seqan3/core/platform.hpp
+++ b/include/seqan3/core/platform.hpp
@@ -127,6 +127,36 @@
      */
 #endif
 
+// Lemon [optional]
+/*!\def SEQAN3_WITH_LEMON
+ * \brief Whether Lemon support is available or not.
+ * \ingroup core
+ */
+#ifndef SEQAN3_WITH_LEMON
+#   if __has_include(<lemon/config.h>)
+#       define SEQAN3_WITH_LEMON 1
+#   else
+#       define SEQAN3_WITH_LEMON 0
+#   endif
+#elif SEQAN3_WITH_LEMON != 0
+#   if !__has_include(<lemon/config.h>)
+#       error Lemon was marked as required, but not found!
+#   endif
+#endif
+#if SEQAN3_WITH_LEMON == 1
+#   define LEMON_HAVE_LONG_LONG 1
+#   define LEMON_CXX11 1
+#   if defined(__unix__) || defined(__APPLE__)
+#       define LEMON_USE_PTHREAD 1
+#       define LEMON_USE_WIN32_THREADS 0
+#       define LEMON_WIN32 0
+#   else
+#       define LEMON_USE_PTHREAD 0
+#       define LEMON_USE_WIN32_THREADS 1
+#       define LEMON_WIN32 1
+#   endif
+#endif
+
 // TODO (doesn't have a version.hpp, yet)
 
 #undef STR

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -55,7 +55,8 @@ set (CMAKE_MODULE_PATH ${SEQAN3_ROOT}/build_system ${CMAKE_MODULE_PATH})
 foreach (_PATH
          "${SEQAN3_ROOT}/range-v3/include/"
          "${SEQAN3_ROOT}/sdsl-lite/include/"
-         "${SEQAN3_ROOT}/cereal/include/")
+         "${SEQAN3_ROOT}/cereal/include/"
+         "${SEQAN3_ROOT}/lemon/include/")
     if (EXISTS ${_PATH})
         set (CMAKE_INCLUDE_PATH ${_PATH} ${CMAKE_INCLUDE_PATH})
     endif ()


### PR DESCRIPTION
According to issue #149 I add the LEMON graph library as a submodule. 
Readme files and config.h are adapted and I also started to define macros in platform.h. With the latter I need a little help - where do I get the macro values from?

I tested a little graph example within SeqAn3 and it worked on my system. I would also like to test other platforms as soon as platform.h is updated properly. 

In the SeqAn code: Do I always have to test `#ifdef SEQAN3_WITH_LEMON` before using (even including) a graph or is there a better solution? Code might get messy with all the preprocessor commands. 