### PR TITLE
remove ingroup MODULENAME from file documentation

### DIFF
--- a/include/seqan3/alphabet/adaptation/all.hpp
+++ b/include/seqan3/alphabet/adaptation/all.hpp
@@ -33,7 +33,6 @@
 // ============================================================================
 
 /*!\file
- * \ingroup adaptation
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  * \brief Meta-header for the adaptation submodule; includes all headers from alphabet/adaptation/.
  */

--- a/include/seqan3/alphabet/adaptation/char.hpp
+++ b/include/seqan3/alphabet/adaptation/char.hpp
@@ -33,7 +33,6 @@
 // ============================================================================
 
 /*!\file
- * \ingroup adaptation
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  * \brief Provides alphabet adaptations for standard char types.
  * \details

--- a/include/seqan3/alphabet/adaptation/concept.hpp
+++ b/include/seqan3/alphabet/adaptation/concept.hpp
@@ -33,7 +33,6 @@
 // ============================================================================
 
 /*!\file
- * \ingroup adaptation
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  * \brief Provides seqan3::char_adaptation_concept and seqan3::uint_adaptation_concept.
  */

--- a/include/seqan3/alphabet/adaptation/uint.hpp
+++ b/include/seqan3/alphabet/adaptation/uint.hpp
@@ -33,7 +33,6 @@
 // ============================================================================
 
 /*!\file
- * \ingroup adaptation
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  * \brief Provides alphabet adaptations for standard uint types.
  * \details

--- a/include/seqan3/alphabet/all.hpp
+++ b/include/seqan3/alphabet/all.hpp
@@ -33,7 +33,6 @@
 // ============================================================================
 
 /*!\file
- * \ingroup alphabet
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  * \brief Meta-header for the alphabet module.
  *

--- a/include/seqan3/alphabet/aminoacid/aa27.hpp
+++ b/include/seqan3/alphabet/aminoacid/aa27.hpp
@@ -33,7 +33,6 @@
 // ============================================================================
 
 /*!\file
- * \ingroup aminoacid
  * \author Sara Hetzel <sara.hetzel AT fu-berlin.de>
  * \brief Contains seqan3::aa27, container aliases and string literals.
  */

--- a/include/seqan3/alphabet/aminoacid/all.hpp
+++ b/include/seqan3/alphabet/aminoacid/all.hpp
@@ -33,7 +33,6 @@
 // ============================================================================
 
 /*!\file
- * \ingroup aminoacid
  * \author Sara Hetzel <sara.hetzel AT fu-berlin.de>
  * \brief Meta-header for the aminoacid submodule; includes all headers from alphabet/aminoacid/.
  */

--- a/include/seqan3/alphabet/aminoacid/translation.hpp
+++ b/include/seqan3/alphabet/aminoacid/translation.hpp
@@ -33,7 +33,6 @@
 // ============================================================================
 
 /*!\file
- * \ingroup aminoacid
  * \author Sara Hetzel <sara.hetzel AT fu-berlin.de>
  * \brief Contains functions for translating a triplet of nucleotides into an amino acid.
  */

--- a/include/seqan3/alphabet/aminoacid/translation_details.hpp
+++ b/include/seqan3/alphabet/aminoacid/translation_details.hpp
@@ -33,7 +33,6 @@
 // ============================================================================
 
 /*!\file
- * \ingroup aminoacid
  * \author Sara Hetzel <sara.hetzel AT fu-berlin.de>
  * \brief Contains translation details for nucleotide to aminoacid translation.
  */

--- a/include/seqan3/alphabet/composition/all.hpp
+++ b/include/seqan3/alphabet/composition/all.hpp
@@ -33,7 +33,6 @@
 // ============================================================================
 
 /*!\file
- * \ingroup composition
  * \author Marcel Ehrhardt <marcel.ehrhardt AT fu-berlin.de>
  * \brief Meta-header for the composition submodule; includes all headers from alphabet/composition/.
  */

--- a/include/seqan3/alphabet/composition/cartesian_composition.hpp
+++ b/include/seqan3/alphabet/composition/cartesian_composition.hpp
@@ -33,7 +33,6 @@
 // ============================================================================
 
 /*!\file
- * \ingroup composition
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  * \brief Contains cartesian_composition.
  */

--- a/include/seqan3/alphabet/composition/union_composition.hpp
+++ b/include/seqan3/alphabet/composition/union_composition.hpp
@@ -33,7 +33,6 @@
 // ==========================================================================
 
 /*!\file
- * \ingroup composition
  * \author Marcel Ehrhardt <marcel.ehrhardt AT fu-berlin.de>
  * \author David Heller <david.heller AT fu-berlin.de>
  * \brief Contains seqan3::union_composition.

--- a/include/seqan3/alphabet/concept.hpp
+++ b/include/seqan3/alphabet/concept.hpp
@@ -33,7 +33,6 @@
 // ============================================================================
 
 /*!\file
- * \ingroup alphabet
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  * \brief Core alphabet concept and free function/metafunction wrappers.
  */

--- a/include/seqan3/alphabet/concept_pre.hpp
+++ b/include/seqan3/alphabet/concept_pre.hpp
@@ -33,7 +33,6 @@
 // ============================================================================
 
 /*!\file
- * \ingroup alphabet
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  * \brief seqan3::alphabet_concept metafunction base classes.
  *

--- a/include/seqan3/alphabet/detail/convert.hpp
+++ b/include/seqan3/alphabet/detail/convert.hpp
@@ -34,7 +34,6 @@
 
 /*!\cond DEV
  * \file
- * \ingroup alphabet
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  * \brief Provides seqan3::detail::convert_through_char_representation.
  * \endcond

--- a/include/seqan3/alphabet/detail/member_exposure.hpp
+++ b/include/seqan3/alphabet/detail/member_exposure.hpp
@@ -33,7 +33,6 @@
 // ============================================================================
 
 /*!\file
- * \ingroup alphabet
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  * \brief Free function/metafunction wrappers for alphabets with member functions/types.
  *

--- a/include/seqan3/alphabet/gap/all.hpp
+++ b/include/seqan3/alphabet/gap/all.hpp
@@ -33,7 +33,6 @@
 // ============================================================================
 
 /*!\file
- * \ingroup gap
  * \author Marcel Ehrhardt <marcel.ehrhardt AT fu-berlin.de>
  * \brief Meta-header for the gap submodule; includes all headers from alphabet/gap/.
  */

--- a/include/seqan3/alphabet/gap/gap.hpp
+++ b/include/seqan3/alphabet/gap/gap.hpp
@@ -33,7 +33,6 @@
 // ==========================================================================
 
 /*!\file
- * \ingroup gap
  * \author Marcel Ehrhardt <marcel.ehrhardt AT fu-berlin.de>
  * \author David Heller <david.heller AT fu-berlin.de>
  * \brief Contains seqan3::gap.

--- a/include/seqan3/alphabet/gap/gapped.hpp
+++ b/include/seqan3/alphabet/gap/gapped.hpp
@@ -33,7 +33,6 @@
 // ==========================================================================
 
 /*!\file
- * \ingroup gap
  * \author Marcel Ehrhardt <marcel.ehrhardt AT fu-berlin.de>
  * \author David Heller <david.heller AT fu-berlin.de>
  * \brief Contains seqan3::gapped.

--- a/include/seqan3/alphabet/nucleotide/all.hpp
+++ b/include/seqan3/alphabet/nucleotide/all.hpp
@@ -33,7 +33,6 @@
 // ============================================================================
 
 /*!\file
- * \ingroup nucleotide
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  * \brief Meta-header for the nucleotide submodule; includes all headers from alphabet/nucleotide/.
  */

--- a/include/seqan3/alphabet/nucleotide/concept.hpp
+++ b/include/seqan3/alphabet/nucleotide/concept.hpp
@@ -33,7 +33,6 @@
 // ============================================================================
 
 /*!\file
- * \ingroup nucleotide
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  * \brief Provides seqan3::nucleotide_concept.
  */

--- a/include/seqan3/alphabet/nucleotide/dna15.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna15.hpp
@@ -33,7 +33,6 @@
 // ============================================================================
 
 /*!\file
- * \ingroup nucleotide
  * \author Sara Hetzel <sara.hetzel AT fu-berlin.de>
  * \brief Contains seqan3::dna15, container aliases and string literals.
  */

--- a/include/seqan3/alphabet/nucleotide/dna4.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna4.hpp
@@ -33,7 +33,6 @@
 // ============================================================================
 
 /*!\file
- * \ingroup nucleotide
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  * \brief Contains seqan3::dna4, container aliases and string literals.
  */

--- a/include/seqan3/alphabet/nucleotide/dna5.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna5.hpp
@@ -33,7 +33,6 @@
 // ============================================================================
 
 /*!\file
- * \ingroup nucleotide
  * \author David Heller <david.heller AT fu-berlin.de>
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  * \brief Contains seqan3::dna5, container aliases and string literals.

--- a/include/seqan3/alphabet/nucleotide/rna15.hpp
+++ b/include/seqan3/alphabet/nucleotide/rna15.hpp
@@ -33,7 +33,6 @@
 // ============================================================================
 
 /*!\file
- * \ingroup nucleotide
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  * \brief Provides seqan3::rna15, container aliases and string literals.
  */

--- a/include/seqan3/alphabet/nucleotide/rna4.hpp
+++ b/include/seqan3/alphabet/nucleotide/rna4.hpp
@@ -33,7 +33,6 @@
 // ============================================================================
 
 /*!\file
- * \ingroup nucleotide
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  * \brief Contains seqan3::rna4, container aliases and string literals.
  */

--- a/include/seqan3/alphabet/nucleotide/rna5.hpp
+++ b/include/seqan3/alphabet/nucleotide/rna5.hpp
@@ -33,7 +33,6 @@
 // ============================================================================
 
 /*!\file
- * \ingroup nucleotide
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  * \brief Contains seqan3::rna5, container aliases and string literals.
  */

--- a/include/seqan3/alphabet/quality/aliases.hpp
+++ b/include/seqan3/alphabet/quality/aliases.hpp
@@ -33,7 +33,6 @@
 // ============================================================================
 
 /*!\file
- * \ingroup alphabet
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  * \brief Contains aliases for quality_composition.
  */

--- a/include/seqan3/alphabet/quality/all.hpp
+++ b/include/seqan3/alphabet/quality/all.hpp
@@ -40,7 +40,6 @@
 #include <seqan3/alphabet/quality/illumina18.hpp>
 
 /*!\file
- * \ingroup alphabet
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  * \brief Meta-header that includes all headers from alphabet/quality/
  */

--- a/include/seqan3/alphabet/quality/quality_composition.hpp
+++ b/include/seqan3/alphabet/quality/quality_composition.hpp
@@ -33,7 +33,6 @@
 // ============================================================================
 
 /*!\file
- * \ingroup alphabet
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  * \brief Contains quality alphabet compositions.
  */

--- a/include/seqan3/alphabet/structure/all.hpp
+++ b/include/seqan3/alphabet/structure/all.hpp
@@ -37,6 +37,7 @@
  * \brief Meta-header for the structure module. It includes all headers from alphabet/structure/.
  *
  * \defgroup structure Structure
+ * \ingroup alphabet
  * \brief The structure module contains alphabets for RNA and protein structure.
  * \details The following alphabets are currently supported in SeqAn. Please see the format's page for more details.
  *

--- a/include/seqan3/alphabet/structure/all.hpp
+++ b/include/seqan3/alphabet/structure/all.hpp
@@ -37,7 +37,6 @@
  * \brief Meta-header for the structure module. It includes all headers from alphabet/structure/.
  *
  * \defgroup structure Structure
- * \ingroup alphabet
  * \brief The structure module contains alphabets for RNA and protein structure.
  * \details The following alphabets are currently supported in SeqAn. Please see the format's page for more details.
  *

--- a/include/seqan3/alphabet/structure/all.hpp
+++ b/include/seqan3/alphabet/structure/all.hpp
@@ -33,7 +33,6 @@
 // ============================================================================
 
 /*!\file
- * \ingroup structure
  * \author Joerg Winkler <j.winkler AT fu-berlin.de>
  * \brief Meta-header for the structure module. It includes all headers from alphabet/structure/.
  *

--- a/include/seqan3/alphabet/structure/dot_bracket3.hpp
+++ b/include/seqan3/alphabet/structure/dot_bracket3.hpp
@@ -33,7 +33,6 @@
 // ============================================================================
 
 /*!\file
- * \ingroup structure
  * \author Joerg Winkler <j.winkler AT fu-berlin.de>
  * \brief Contains the dot bracket format for RNA structure.
  */

--- a/include/seqan3/alphabet/structure/dssp9.hpp
+++ b/include/seqan3/alphabet/structure/dssp9.hpp
@@ -33,7 +33,6 @@
 // ============================================================================
 
 /*!\file
- * \ingroup structure
  * \author Joerg Winkler <j.winkler AT fu-berlin.de>
  * \brief Contains the dssp format for protein structure.
  */

--- a/include/seqan3/alphabet/structure/rna_structure_concept.hpp
+++ b/include/seqan3/alphabet/structure/rna_structure_concept.hpp
@@ -33,7 +33,6 @@
 // ============================================================================
 
 /*!\file
- * \ingroup structure
  * \author Joerg Winkler <j.winkler AT fu-berlin.de>
  * \brief Provides seqan3::rna_structure_concept.
  */

--- a/include/seqan3/alphabet/structure/structured_aa.hpp
+++ b/include/seqan3/alphabet/structure/structured_aa.hpp
@@ -33,7 +33,6 @@
 // ============================================================================
 
 /*!\file
- * \ingroup structure
  * \author Joerg Winkler <j.winkler AT fu-berlin.de>
  * \brief Contains the composition of aminoacid with structure alphabets.
  */

--- a/include/seqan3/alphabet/structure/structured_rna.hpp
+++ b/include/seqan3/alphabet/structure/structured_rna.hpp
@@ -33,7 +33,6 @@
 // ============================================================================
 
 /*!\file
- * \ingroup structure
  * \author Joerg Winkler <j.winkler AT fu-berlin.de>
  * \brief Contains the composition of nucleotide with structure alphabets.
  */

--- a/include/seqan3/alphabet/structure/wuss.hpp
+++ b/include/seqan3/alphabet/structure/wuss.hpp
@@ -33,7 +33,6 @@
 // ============================================================================
 
 /*!\file
- * \ingroup structure
  * \author Joerg Winkler <j.winkler AT fu-berlin.de>
  * \brief Contains the WUSS format for RNA structure.
  */

--- a/include/seqan3/core/all.hpp
+++ b/include/seqan3/core/all.hpp
@@ -33,7 +33,6 @@
 // ============================================================================
 
 /*!\file
- * \ingroup core
  * \brief Meta-header for the \link core core module \endlink.
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  * \author Rene Rahn <rene.rahn AT fu-berlin.de>

--- a/include/seqan3/core/concept/cereal.hpp
+++ b/include/seqan3/core/concept/cereal.hpp
@@ -34,7 +34,6 @@
 
 /*!\file
  * \brief Adaptions of concepts from the Cereal library.
- * \ingroup core
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  */
 

--- a/include/seqan3/core/concept/core.hpp
+++ b/include/seqan3/core/concept/core.hpp
@@ -34,7 +34,6 @@
 
 /*!\file
  * \brief Adaptions of core concepts from the Ranges TS.
- * \ingroup core
  * \author Rene Rahn <rene.rahn AT fu-berlin.de>
  */
 

--- a/include/seqan3/core/concept/core_detail.hpp
+++ b/include/seqan3/core/concept/core_detail.hpp
@@ -38,7 +38,6 @@
 
 /*!\file
  * \brief Testing the core library concepts.
- * \ingroup core
  * \author Rene Rahn <rene.rahn AT fu-berlin.de>
  */
 

--- a/include/seqan3/core/concept/iterator.hpp
+++ b/include/seqan3/core/concept/iterator.hpp
@@ -34,7 +34,6 @@
 
 /*!\file
  * \brief Adaptions of Iterator concepts from the Ranges TS.
- * \ingroup core
  * \author Rene Rahn <rene.rahn AT fu-berlin.de>
  */
 

--- a/include/seqan3/core/concept/iterator_detail.hpp
+++ b/include/seqan3/core/concept/iterator_detail.hpp
@@ -38,7 +38,6 @@
 
 /*! \file
  *  \brief Testing the iterator concepts.
- *  \ingroup core
  *  \author Rene Rahn <rene.rahn AT fu-berlin.de>
  */
 

--- a/include/seqan3/core/detail/int_types.hpp
+++ b/include/seqan3/core/detail/int_types.hpp
@@ -41,7 +41,6 @@
 /*!\file
  * \brief Contains metaprogramming utilities for integer types.
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
- * \ingroup core
  */
 
 namespace seqan3::detail

--- a/include/seqan3/core/platform.hpp
+++ b/include/seqan3/core/platform.hpp
@@ -41,7 +41,6 @@
 /*!\file
  * \brief Contains platform and dependency checks.
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
- * \ingroup core
  */
 
 // macro cruft

--- a/include/seqan3/core/pod_tuple.hpp
+++ b/include/seqan3/core/pod_tuple.hpp
@@ -33,7 +33,6 @@
 // ============================================================================
 
 /*!\file
- * \ingroup core
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  * \brief Contains seqan3::pod_tuple
  */

--- a/include/seqan3/range/action/all.hpp
+++ b/include/seqan3/range/action/all.hpp
@@ -33,7 +33,6 @@
 // ============================================================================
 
 /*!\file
- * \ingroup action
  * \brief Meta-header for the \link action action submodule \endlink.
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  */

--- a/include/seqan3/range/all.hpp
+++ b/include/seqan3/range/all.hpp
@@ -33,7 +33,6 @@
 // ============================================================================
 
 /*!\file
- * \ingroup range
  * \brief Meta-header for the \link range range module \endlink.
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  */

--- a/include/seqan3/range/concept.hpp
+++ b/include/seqan3/range/concept.hpp
@@ -34,7 +34,6 @@
 
 /*!\file
  * \brief Adaptations of concepts from the Ranges TS
- * \ingroup range
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  */
 

--- a/include/seqan3/range/container/all.hpp
+++ b/include/seqan3/range/container/all.hpp
@@ -33,7 +33,6 @@
 // ============================================================================
 
 /*!\file
- * \ingroup container
  * \brief Meta-header for the \link container container submodule \endlink.
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  */

--- a/include/seqan3/range/container/concatenated_sequences.hpp
+++ b/include/seqan3/range/container/concatenated_sequences.hpp
@@ -34,7 +34,6 @@
 
 /*!\file
  * \brief Provides seqan3::concatenated_sequences.
- * \ingroup container
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  */
 

--- a/include/seqan3/range/container/concept.hpp
+++ b/include/seqan3/range/container/concept.hpp
@@ -34,7 +34,6 @@
 
 /*!\file
  * \brief Adaptations of concepts from the standard library.
- * \ingroup container
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  */
 

--- a/include/seqan3/range/detail/random_access_iterator.hpp
+++ b/include/seqan3/range/detail/random_access_iterator.hpp
@@ -35,7 +35,6 @@
 /*!\file
  * \brief Provides the seqan3::detail::random_access_iterator class.
  * \author Marie Hoffmann <marie.hoffmann AT fu-berlin.de>
- * \ingroup range
  */
 
 #pragma once

--- a/include/seqan3/range/metafunction.hpp
+++ b/include/seqan3/range/metafunction.hpp
@@ -35,7 +35,6 @@
 /*!\file
  * \brief Provides various metafunctions used by the range module.
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
- * \ingroup range
  */
 
 #pragma once

--- a/include/seqan3/range/view/all.hpp
+++ b/include/seqan3/range/view/all.hpp
@@ -33,7 +33,6 @@
 // ============================================================================
 
 /*!\file
- * \ingroup view
  * \brief Meta-header for the \link view view submodule \endlink.
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  */

--- a/include/seqan3/range/view/char_to.hpp
+++ b/include/seqan3/range/view/char_to.hpp
@@ -33,7 +33,6 @@
 // ============================================================================
 
 /*!\file
- * \ingroup view
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  * \brief Provides seqan3::view::char_to.
  */

--- a/include/seqan3/range/view/complement.hpp
+++ b/include/seqan3/range/view/complement.hpp
@@ -33,7 +33,6 @@
 // ============================================================================
 
 /*!\file
- * \ingroup view
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  * \brief Provides seqan3::view::complement.
  */

--- a/include/seqan3/range/view/concept.hpp
+++ b/include/seqan3/range/view/concept.hpp
@@ -34,7 +34,6 @@
 
 /*!\file
  * \brief Adaptation of the view concept from the Ranges TS.
- * \ingroup view
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  */
 

--- a/include/seqan3/range/view/convert.hpp
+++ b/include/seqan3/range/view/convert.hpp
@@ -33,7 +33,6 @@
 // ============================================================================
 
 /*!\file
- * \ingroup view
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  * \brief Provides seqan3::view::convert.
  */

--- a/include/seqan3/range/view/rank_to.hpp
+++ b/include/seqan3/range/view/rank_to.hpp
@@ -33,7 +33,6 @@
 // ============================================================================
 
 /*!\file
- * \ingroup view
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  * \brief Provides seqan3::view::rank_to.
  */

--- a/include/seqan3/range/view/to_char.hpp
+++ b/include/seqan3/range/view/to_char.hpp
@@ -33,7 +33,6 @@
 // ============================================================================
 
 /*!\file
- * \ingroup view
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  * \brief Provides seqan3::view::to_char.
  */

--- a/include/seqan3/range/view/to_rank.hpp
+++ b/include/seqan3/range/view/to_rank.hpp
@@ -33,7 +33,6 @@
 // ============================================================================
 
 /*!\file
- * \ingroup view
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  * \brief Provides seqan3::view::to_rank.
  */

--- a/include/seqan3/range/view/translation.hpp
+++ b/include/seqan3/range/view/translation.hpp
@@ -33,7 +33,6 @@
 // ============================================================================
 
 /*!\file
- * \ingroup view
  * \author Sara Hetzel <sara.hetzel AT fu-berlin.de>
  * \brief Provides seqan3::view::translate, seqan3::view::translate_single and seqan3::view::translate_frames.
  */

--- a/include/seqan3/range/view/trim.hpp
+++ b/include/seqan3/range/view/trim.hpp
@@ -33,7 +33,6 @@
 // ============================================================================
 
 /*!\file
- * \ingroup view
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  * \brief Provides seqan3::view::trim.
  */

--- a/test/alphabet/structure_test.cpp
+++ b/test/alphabet/structure_test.cpp
@@ -33,7 +33,6 @@
 // ============================================================================
 
 /*!\file
- * \ingroup alphabet
  * \author Joerg Winkler <j.winkler AT fu-berlin.de>
  * \brief Tests for the structure alphabets.
  */


### PR DESCRIPTION
#160 

Removing \ingroup command only if it has a preceding \file command.