### PR TITLE
remove test/io/util/CMakeLists.txt

### DIFF
--- a/test/io/util/CMakeLists.txt
+++ b/test/io/util/CMakeLists.txt
@@ -1,1 +1,0 @@
-seqan3_test(output_iterator_test.cpp)


### PR DESCRIPTION
* The (empty) content from `test/io/util/CMakeLists.txt` was moved to `test/unit/io/util/CMakeLists.txt`
* The content is empty, because there is no `output_iterator_test.cpp` file
* Thus, `test/io/util/CMakeLists.txt` was deleted without any changes