### PR TITLE
remove one line from documentation

### DIFF
--- a/include/seqan3/alphabet/nucleotide/rna15.hpp
+++ b/include/seqan3/alphabet/nucleotide/rna15.hpp
@@ -57,7 +57,6 @@ namespace seqan3
 
 /*!\brief The 15 letter RNA alphabet, containing all IUPAC smybols minus the gap.
  * \ingroup nucleotide
- * \implements seqan3::nucleotide_concept
  *
  * \details
  * This alphabet inherits from seqan3::dna15 and is guaranteed to have the same internal representation of


### PR DESCRIPTION
rna15 is already marked as implementing nucleotide_concept because it inherits from dna15. Removing this explicit "implem,ents" removes a double link in the inheritance graph and brings it inline with rna4 and rna5