### PR TITLE
Cerealisable concept

### DIFF
--- a/include/seqan3/core/concept/cereal.hpp
+++ b/include/seqan3/core/concept/cereal.hpp
@@ -45,6 +45,7 @@
 
 #if SEQAN3_WITH_CEREAL
 #include <cereal/details/traits.hpp>
+#include <cereal/archives/binary.hpp>
 #endif
 
 namespace seqan3
@@ -127,6 +128,49 @@ concept bool cereal_text_archive_concept = std::is_base_of_v<cereal::traits::Tex
 #else
 template <typename t>
 concept bool cereal_text_archive_concept = false;
+#endif
+//!\endcond
+
+/*!\interface seqan3::cerealisable_concept <>
+ * \ingroup core
+ * \brief Is a given type serialisable with cereal?
+ *
+ * The `value_t` type satisfy the cerealisable_concept, if `value_t` can be
+ * serialised with cereal, i.e. `value_t` has a single serialisation function
+ * (`serialize`) or split load/save pair (load and save) either inside or
+ * outside of the class.
+ *
+ * \sa https://uscilab.github.io/cereal/serialization_functions.html
+ *
+ * ```
+ * #include <seqan3/core/concept/cereal.hpp>
+ * using namespace seqan3;
+ *
+ * // fundamental types are serialisable
+ * static_assert(cerealisable_concept<int>);
+ *
+ * #include <array>
+ * #include <cereal/types/array.hpp> // std::array is now serialisable
+ * static_assert(cerealisable_concept<std::array<int, 12>>);
+ *
+ * #include <seqan3/alphabet/nucleotide/dna4.hpp> // dna4 is serialisable
+ * static_assert(cerealisable_concept<dna4>);
+ * ```
+ *
+ * \attention
+ * The cereal library is an optional dependency of SeqAn, if it is not found **no types** satisfy this concept.
+ */
+//!\cond
+#if SEQAN3_WITH_CEREAL
+template <typename value_t,
+          typename input_archive_t = cereal::BinaryInputArchive,
+          typename output_archive_t = cereal::BinaryOutputArchive>
+concept bool cerealisable_concept =
+    cereal::traits::is_input_serializable<value_t, input_archive_t>::value &&
+    cereal::traits::is_output_serializable<value_t, output_archive_t>::value;
+#else
+template <typename t>
+concept bool cerealisable_concept = false;
 #endif
 //!\endcond
 

--- a/include/seqan3/core/concept/cereal.hpp
+++ b/include/seqan3/core/concept/cereal.hpp
@@ -133,7 +133,7 @@ concept bool cereal_text_archive_concept = false;
 
 /*!\interface seqan3::cerealisable_concept <>
  * \ingroup core
- * \brief Is a given type serialisable with cereal?
+ * \brief Specifies the requirements for types that are serialisable via Cereal.
  *
  * The `value_t` type satisfy the cerealisable_concept, if `value_t` can be
  * serialised with cereal, i.e. `value_t` has a single serialisation function

--- a/test/unit/core/concept/CMakeLists.txt
+++ b/test/unit/core/concept/CMakeLists.txt
@@ -1,0 +1,1 @@
+seqan3_test (cereal_test.cpp)

--- a/test/unit/core/concept/cereal_test.cpp
+++ b/test/unit/core/concept/cereal_test.cpp
@@ -1,0 +1,70 @@
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <vector>
+
+#include <seqan3/core/concept/cereal.hpp>
+
+#if SEQAN3_WITH_CEREAL
+#include <cereal/archives/xml.hpp>
+#include <cereal/archives/json.hpp>
+#include <cereal/archives/binary.hpp>
+#include <cereal/archives/portable_binary.hpp>
+
+#include <cereal/types/array.hpp>
+#endif
+
+using namespace seqan3;
+
+#if SEQAN3_WITH_CEREAL
+
+TEST(cereal, cereal_output_archive_concept)
+{
+    EXPECT_TRUE((cereal_output_archive_concept<cereal::XMLOutputArchive>));
+    EXPECT_TRUE((cereal_output_archive_concept<cereal::JSONOutputArchive>));
+    EXPECT_TRUE((cereal_output_archive_concept<cereal::BinaryOutputArchive>));
+    EXPECT_TRUE((cereal_output_archive_concept<cereal::PortableBinaryOutputArchive>));
+    EXPECT_FALSE((cereal_output_archive_concept<cereal::XMLInputArchive>));
+    EXPECT_FALSE((cereal_output_archive_concept<cereal::JSONInputArchive>));
+    EXPECT_FALSE((cereal_output_archive_concept<cereal::BinaryInputArchive>));
+    EXPECT_FALSE((cereal_output_archive_concept<cereal::PortableBinaryInputArchive>));
+}
+
+TEST(cereal, cereal_input_archive_concept)
+{
+    EXPECT_FALSE((cereal_input_archive_concept<cereal::XMLOutputArchive>));
+    EXPECT_FALSE((cereal_input_archive_concept<cereal::JSONOutputArchive>));
+    EXPECT_FALSE((cereal_input_archive_concept<cereal::BinaryOutputArchive>));
+    EXPECT_FALSE((cereal_input_archive_concept<cereal::PortableBinaryOutputArchive>));
+    EXPECT_TRUE((cereal_input_archive_concept<cereal::XMLInputArchive>));
+    EXPECT_TRUE((cereal_input_archive_concept<cereal::JSONInputArchive>));
+    EXPECT_TRUE((cereal_input_archive_concept<cereal::BinaryInputArchive>));
+    EXPECT_TRUE((cereal_input_archive_concept<cereal::PortableBinaryInputArchive>));
+}
+
+TEST(cereal, cereal_archive_concept)
+{
+    EXPECT_TRUE((cereal_archive_concept<cereal::XMLOutputArchive>));
+    EXPECT_TRUE((cereal_archive_concept<cereal::JSONOutputArchive>));
+    EXPECT_TRUE((cereal_archive_concept<cereal::BinaryOutputArchive>));
+    EXPECT_TRUE((cereal_archive_concept<cereal::PortableBinaryOutputArchive>));
+    EXPECT_TRUE((cereal_archive_concept<cereal::XMLInputArchive>));
+    EXPECT_TRUE((cereal_archive_concept<cereal::JSONInputArchive>));
+    EXPECT_TRUE((cereal_archive_concept<cereal::BinaryInputArchive>));
+    EXPECT_TRUE((cereal_archive_concept<cereal::PortableBinaryInputArchive>));
+}
+
+TEST(cereal, cereal_text_archive_concept)
+{
+    EXPECT_TRUE((cereal_text_archive_concept<cereal::XMLOutputArchive>));
+    EXPECT_TRUE((cereal_text_archive_concept<cereal::JSONOutputArchive>));
+    EXPECT_FALSE((cereal_text_archive_concept<cereal::BinaryOutputArchive>));
+    EXPECT_FALSE((cereal_text_archive_concept<cereal::PortableBinaryOutputArchive>));
+    EXPECT_TRUE((cereal_text_archive_concept<cereal::XMLInputArchive>));
+    EXPECT_TRUE((cereal_text_archive_concept<cereal::JSONInputArchive>));
+    EXPECT_FALSE((cereal_text_archive_concept<cereal::BinaryInputArchive>));
+    EXPECT_FALSE((cereal_text_archive_concept<cereal::PortableBinaryInputArchive>));
+}
+
+#endif

--- a/test/unit/core/concept/cereal_test.cpp
+++ b/test/unit/core/concept/cereal_test.cpp
@@ -67,4 +67,23 @@ TEST(cereal, cereal_text_archive_concept)
     EXPECT_FALSE((cereal_text_archive_concept<cereal::PortableBinaryInputArchive>));
 }
 
+struct my_struct{};
+
+TEST(cereal, cerealisable_concept)
+{
+    EXPECT_TRUE((cerealisable_concept<int>));
+    EXPECT_TRUE((cerealisable_concept<float>));
+
+    // my_struct does not define any serialise functions
+    EXPECT_FALSE((cerealisable_concept<my_struct>));
+
+    // will be true, since <cereal/types/array.hpp> is included
+    EXPECT_TRUE((cerealisable_concept<std::array<int, 10>>));
+    // is false, because <cereal/types/vector.hpp> is not included
+    EXPECT_FALSE((cerealisable_concept<std::vector<int>>));
+
+    // recursive containers of cerealisable value types work
+    EXPECT_TRUE((cerealisable_concept<std::array<std::array<int, 10>, 10>>));
+}
+
 #endif


### PR DESCRIPTION
:new:  test cases for /include/core/concept/cereal.hpp

:new: seqan3::cerealisable_concept

> This concept checks whether a given type is serialisable with cereal.