### PR TITLE
Partially Revert "[FIX] travis/ubuntu16.04: gcc-7.2 bug"

### DIFF
--- a/include/seqan3/range/container/concept.hpp
+++ b/include/seqan3/range/container/concept.hpp
@@ -16,21 +16,18 @@
 #include <iterator>
 #include <type_traits>
 
-// remove if SequenceContainer_modified_by_const_iterator_bug vanished from travis
+// remove if is_basic_string is not needed anymore
 #include <string>
 
 #include <seqan3/std/iterator>
 
 // TODO:
-// * merge SequenceContainer_modified_by_const_iterator back into
-//   SequenceContainer
 // * remove is_basic_string
-// * fix test cases
 // * remove #include <string> in this file
-// once the ubuntu::ppa [1] of g++-7 has a newer update than
-// 7.2.0-1ubuntu1~16.04 (2017-08-20)
+// once the gcc bug [1] was fixed AND we require at least a gcc version which
+// contains this fix
 //
-// [1] https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/test?field.series_filter=xenial
+// [1] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=83328
 namespace seqan3::detail
 {
 //!\privatesection
@@ -51,49 +48,6 @@ struct is_basic_string<std::basic_string<value_t, traits_t, allocator_t>> : std:
 //!\attention Will be deleted once seqan3::detail::SequenceContainer_modified_by_const_iterator_bug is fixed.
 template <typename basic_string_t>
 constexpr bool is_basic_string_v = is_basic_string<basic_string_t>::value;
-
-/*!\interface seqan3::detail::SequenceContainer_modified_by_const_iterator <>
- * \brief Checks whether insert and erase can be used with const_iterator
- *
- * \attention This will be merged back into SequenceContainer once
- * seqan3::detail::SequenceContainer_modified_by_const_iterator_bug is fixed.
- */
-//!\cond
-template <typename type>
-SEQAN3_CONCEPT SequenceContainer_modified_by_const_iterator = requires (type val, type val2)
-{
-    { val.insert(val.cbegin(), val2.front())                                           } -> typename type::iterator;
-    { val.insert(val.cbegin(), typename type::value_type{})                            } -> typename type::iterator;
-    { val.insert(val.cbegin(), typename type::size_type{}, typename type::value_type{})} -> typename type::iterator;
-    { val.insert(val.cbegin(), val2.begin(), val2.end())                               } -> typename type::iterator;
-    requires is_basic_string_v<type> || requires(type val)
-    {
-        // TODO this function is not defined on strings (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=83328)
-        { val.insert(val.cbegin(), std::initializer_list<typename type::value_type>{}) } -> typename type::iterator;
-    };
-    { val.erase(val.cbegin())                                                          } -> typename type::iterator;
-    { val.erase(val.cbegin(), val.cend())                                              } -> typename type::iterator;
-
-    { val.insert(val.begin(), typename type::size_type{}, typename type::value_type{}) } -> typename type::iterator;
-    { val.insert(val.begin(), val2.begin(), val2.end())                                } -> typename type::iterator;
-};
-//!\endcond
-
-/*!\brief Workaround for a ubuntu/travis-ci exclusive bug with g++-7.2.
- *
- * seqan3::detail::SequenceContainer_modified_by_const_iterator <std::string> is
- * known to work, but ubuntu::ppa (<18.04)/travis-ci has a version of g++-7.2
- * where a bug in the STL prevents this concept to be true.
- *
- * \attention This workaround can be removed if
- * `/test/range/container/container_concept_test.cpp` is not failing on
- * ubuntu::ppa (<18.04)/travis-ci anymore. \n
- * Probably when the ppa version of gcc7 is newer than `7.2.0-1ubuntu1~16.04` (2017-08-20)
- * \sa https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/test?field.series_filter=xenial
- */
-template<typename string_t = std::string>
-constexpr bool SequenceContainer_modified_by_const_iterator_bug =
-    is_basic_string_v<string_t> && !SequenceContainer_modified_by_const_iterator<string_t>;
 
 //!\publicsection
 
@@ -204,20 +158,18 @@ SEQAN3_CONCEPT SequenceContainer = requires (type val, type val2, type const cva
     // modify container
     // TODO: how do you model this?
     // { val.emplace(typename type::const_iterator{}, ?                                   } -> typename type::iterator;
+    { val.insert(val.cbegin(), val2.front())                                           } -> typename type::iterator;
+    { val.insert(val.cbegin(), typename type::value_type{})                            } -> typename type::iterator;
+    { val.insert(val.cbegin(), typename type::size_type{}, typename type::value_type{})} -> typename type::iterator;
+    { val.insert(val.cbegin(), val2.begin(), val2.end())                               } -> typename type::iterator;
+    requires detail::is_basic_string_v<type> || requires(type val)
+    {
+        // TODO this function is not defined on strings (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=83328)
+        { val.insert(val.cbegin(), std::initializer_list<typename type::value_type>{}) } -> typename type::iterator;
+    };
 
-    { val.insert(val.begin(), val2.front())                                            } -> typename type::iterator;
-    { val.insert(val.begin(), typename type::value_type{})                             } -> typename type::iterator;
-    // because of a travis bug we can't assume typename type::iterator as return type
-    { val.insert(val.begin(), typename type::size_type{}, typename type::value_type{}) };
-    { val.insert(val.begin(), val2.begin(), val2.end())                                };
-    //TODO should return type::iterator on strings (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=83328)
-    { val.insert(val.begin(), std::initializer_list<typename type::value_type>{})      };
-    { val.erase(val.begin())                                                           } -> typename type::iterator;
-    { val.erase(val.begin(), val.end())                                                } -> typename type::iterator;
-
-    // workaround a travis bug where insert/erase can't take a const iterator, e.g. cbegin()
-    requires detail::SequenceContainer_modified_by_const_iterator_bug<type> ||
-             detail::SequenceContainer_modified_by_const_iterator<type>;
+    { val.erase(val.cbegin())                                                          } -> typename type::iterator;
+    { val.erase(val.cbegin(), val.cend())                                              } -> typename type::iterator;
 
     { val.push_back(val.front())                                                       } -> void;
     { val.push_back(typename type::value_type{})                                       } -> void;

--- a/test/unit/range/container/container_concept_test.cpp
+++ b/test/unit/range/container/container_concept_test.cpp
@@ -21,17 +21,7 @@
 
 using namespace seqan3;
 
-// if detail::SequenceContainer_modified_by_const_iterator_bug<> is false
-// test seqan3::concatenated_sequences<std::string>, otherwise
-// test seqan3::concatenated_sequences<std::vector<char>>
-using concatenated_sequences_string_t = seqan3::concatenated_sequences<
-        std::conditional_t<
-            detail::SequenceContainer_modified_by_const_iterator_bug<>,
-            std::vector<char>,
-            std::string
-      >>;
-
-TEST(Container, ForwardRange)
+TEST(range_concept, ForwardRange)
 {
     EXPECT_TRUE((std::ranges::ForwardRange<std::array<char, 2>>));
     EXPECT_TRUE((std::ranges::ForwardRange<std::list<char>>));
@@ -40,7 +30,7 @@ TEST(Container, ForwardRange)
     EXPECT_TRUE((std::ranges::ForwardRange<std::deque<char>>));
     EXPECT_TRUE((std::ranges::ForwardRange<std::string>));
 
-    EXPECT_TRUE((std::ranges::ForwardRange<concatenated_sequences_string_t>));
+    EXPECT_TRUE((std::ranges::ForwardRange<seqan3::concatenated_sequences<std::string>>));
     EXPECT_TRUE((std::ranges::ForwardRange<seqan3::concatenated_sequences<std::vector<char>>>));
 }
 
@@ -53,86 +43,20 @@ TEST(Container, Container)
     EXPECT_TRUE((seqan3::Container<std::deque<char>>));
     EXPECT_TRUE((seqan3::Container<std::string>));
 
-    EXPECT_TRUE((seqan3::Container<concatenated_sequences_string_t>));
+    EXPECT_TRUE((seqan3::Container<seqan3::concatenated_sequences<std::string>>));
     EXPECT_TRUE((seqan3::Container<seqan3::concatenated_sequences<std::vector<char>>>));
 }
 
-template <typename string_t>
-void Container_travis_bug_test()
+TEST(Container, sequence_container_former_travis_bug)
 {
-    // non const version of Container_const_travis_bug_test
+    // This tests a bug with const iterators on strings which was there in a
+    // special gcc 7.2 build (ppa) for ubuntu 14.04 and 16.04. We leave it as
+    // a regression test.
+    // see https://github.com/seqan/seqan3/pull/113/
     using namespace std::string_literals;
 
     // example code from http://en.cppreference.com/w/cpp/string/basic_string/insert
-    string_t s = "xmplr";
-    string_t r = "";
-    typename string_t::iterator it;
-
-    // insert(size_type index, size_type count, char ch)
-    r = s.insert(0, 1, 'E');
-    EXPECT_EQ("Exmplr", s);
-
-    // insert(size_type index, const char* s)
-    r = s.insert(2, "e");
-    EXPECT_EQ("Exemplr", s);
-
-    // insert(size_type index, string const& str)
-    r = s.insert(6, "a"s);
-    EXPECT_EQ("Exemplar", s);
-
-    // insert(size_type index, string const& str,
-    //     size_type index_str, size_type count)
-    r = s.insert(8, " is an example string."s, 0, 14);
-    EXPECT_EQ("Exemplar is an example", s);
-
-    // insert(const_iterator pos, char ch)
-    it = s.insert(s.begin() + s.find_first_of('n') + 1, ':');
-    EXPECT_EQ("Exemplar is an: example", s);
-
-    // insert(const_iterator pos, size_type count, char ch)
-    //TODO should return type::iterator on strings, remove if
-    // SequenceContainer_modified_by_const_iterator_bug is no issue anymore
-    // it =
-    s.insert(s.begin() + s.find_first_of(':') + 1, 2, '=');
-    EXPECT_EQ("Exemplar is an:== example", s);
-
-    // insert(const_iterator pos, InputIt first, InputIt last)
-    {
-        string_t seq = " string";
-        //TODO should return type::iterator on strings, remove if
-        // SequenceContainer_modified_by_const_iterator_bug is no issue anymore
-        // it =
-        s.insert(s.begin() + s.find_last_of('e') + 1,
-            std::begin(seq), std::end(seq));
-        EXPECT_EQ("Exemplar is an:== example string", s);
-    }
-
-    // insert(const_iterator pos, std::initializer_list<char>)
-    //TODO should return type::iterator on strings (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=83328)
-    // it =
-    s.insert(s.begin() + s.find_first_of('g') + 1, { '.' });
-    EXPECT_EQ("Exemplar is an:== example string.", s);
-}
-
-template <typename string_t>
-void Container_const_travis_bug_test()
-{
-    // travis failed on this statement
-    // concept bool SequenceContainer = requires (type val, type val2)
-    //              ^~~~~~~~~~~~~~~~
-    // /include/seqan3/range/container/concept.hpp:113:14: note:     with ‘std::basic_string<char> val’
-    // /include/seqan3/range/container/concept.hpp:113:14: note:     with ‘std::basic_string<char> val2’
-    // [...]
-    // /include/seqan3/range/container/concept.hpp:113:14: note: the required expression ‘val.erase(val.cbegin(), val.cend())’ would be ill-formed
-
-    using namespace std::string_literals;
-
-    static_assert(detail::SequenceContainer_modified_by_const_iterator<string_t>);
-    static_assert(!detail::SequenceContainer_modified_by_const_iterator_bug<string_t> && std::is_same_v<string_t, std::string>);
-    static_assert(seqan3::Container<string_t>);
-
-    // example code from http://en.cppreference.com/w/cpp/string/basic_string/insert
-    string_t s = "xmplr";
+    std::string s = "xmplr";
 
     // insert(size_type index, size_type count, char ch)
     s.insert(0, 1, 'E');
@@ -146,8 +70,7 @@ void Container_const_travis_bug_test()
     s.insert(6, "a"s);
     EXPECT_EQ("Exemplar", s);
 
-    // insert(size_type index, string const& str,
-    //     size_type index_str, size_type count)
+    // insert(size_type index, string const& str, size_type index_str, size_type count)
     s.insert(8, " is an example string."s, 0, 14);
     EXPECT_EQ("Exemplar is an example", s);
 
@@ -161,7 +84,7 @@ void Container_const_travis_bug_test()
 
     // insert(const_iterator pos, InputIt first, InputIt last)
     {
-        string_t seq = " string";
+        std::string seq = " string";
         s.insert(s.cbegin() + s.find_last_of('e') + 1,
             std::begin(seq), std::end(seq));
         EXPECT_EQ("Exemplar is an:== example string", s);
@@ -170,14 +93,6 @@ void Container_const_travis_bug_test()
     // insert(const_iterator pos, std::initializer_list<char>)
     s.insert(s.cbegin() + s.find_first_of('g') + 1, { '.' });
     EXPECT_EQ("Exemplar is an:== example string.", s);
-}
-
-TEST(Container, Container_travis_bug)
-{
-    Container_travis_bug_test<std::string>();
-
-    if constexpr(!detail::SequenceContainer_modified_by_const_iterator_bug<>)
-        Container_const_travis_bug_test<std::string>();
 }
 
 TEST(Container, SequenceContainer)
@@ -189,24 +104,8 @@ TEST(Container, SequenceContainer)
     EXPECT_TRUE((seqan3::SequenceContainer<std::deque<char>>));
     EXPECT_TRUE((seqan3::SequenceContainer<std::string>));
 
-    EXPECT_TRUE((seqan3::SequenceContainer<concatenated_sequences_string_t>));
+    EXPECT_TRUE((seqan3::SequenceContainer<seqan3::concatenated_sequences<std::string>>));
     EXPECT_TRUE((seqan3::SequenceContainer<seqan3::concatenated_sequences<std::vector<char>>>));
-}
-
-TEST(Container, SequenceContainer_modified_by_const_iterator)
-{
-    EXPECT_FALSE((seqan3::detail::SequenceContainer_modified_by_const_iterator<std::array<char, 2>>));
-    EXPECT_TRUE((seqan3::detail::SequenceContainer_modified_by_const_iterator<std::list<char>>));
-    EXPECT_FALSE((seqan3::detail::SequenceContainer_modified_by_const_iterator<std::forward_list<char>>));
-    EXPECT_TRUE((seqan3::detail::SequenceContainer_modified_by_const_iterator<std::vector<char>>));
-    EXPECT_TRUE((seqan3::detail::SequenceContainer_modified_by_const_iterator<std::deque<char>>));
-    if constexpr(!detail::SequenceContainer_modified_by_const_iterator_bug<>)
-    {
-        EXPECT_TRUE((seqan3::detail::SequenceContainer_modified_by_const_iterator<std::string>));
-    }
-
-    EXPECT_TRUE((seqan3::detail::SequenceContainer_modified_by_const_iterator<concatenated_sequences_string_t>));
-    EXPECT_TRUE((seqan3::detail::SequenceContainer_modified_by_const_iterator<seqan3::concatenated_sequences<std::vector<char>>>));
 }
 
 TEST(Container, RandomAccessContainer)
@@ -218,7 +117,7 @@ TEST(Container, RandomAccessContainer)
     EXPECT_TRUE((seqan3::RandomAccessContainer<std::deque<char>>));
     EXPECT_TRUE((seqan3::RandomAccessContainer<std::string>));
 
-    EXPECT_TRUE((seqan3::RandomAccessContainer<concatenated_sequences_string_t>));
+    EXPECT_TRUE((seqan3::RandomAccessContainer<seqan3::concatenated_sequences<std::string>>));
     EXPECT_TRUE((seqan3::RandomAccessContainer<seqan3::concatenated_sequences<std::vector<char>>>));
 }
 
@@ -231,7 +130,7 @@ TEST(Container, ReservableContainer)
     EXPECT_FALSE((seqan3::ReservableContainer<std::deque<char>>));
     EXPECT_TRUE((seqan3::ReservableContainer<std::string>));
 
-    EXPECT_TRUE((seqan3::ReservableContainer<concatenated_sequences_string_t>));
+    EXPECT_TRUE((seqan3::ReservableContainer<seqan3::concatenated_sequences<std::string>>));
     EXPECT_TRUE((seqan3::ReservableContainer<seqan3::concatenated_sequences<std::vector<char>>>));
 
     EXPECT_TRUE((seqan3::ReservableContainer<sdsl::bit_vector>));


### PR DESCRIPTION
This reverts commit 5ba75261f785259adf8b49e0cf41ce818f481e8a.

And resolves #264 

---

Edit:// this is still failing: The reason is that gcc-7 for 14.04 is compiled with disabling dual abi, see #264 for more information.

Edit:// rechecked 2019-06-05