### PR TITLE
[FIX] #262: gcc8 fails to compile reflection_test.cpp

### DIFF
--- a/include/seqan3/core/detail/reflection.hpp
+++ b/include/seqan3/core/detail/reflection.hpp
@@ -61,7 +61,7 @@ struct get_display_name_size
 {
 private:
     //!\brief Helper function to extract the size of the display name.
-    static constexpr auto get_size = [] ()
+    static constexpr auto get_size()
     {
         // __PRETTY_FUNCTION__ exposes the signature of the class including the name of the template instance as
         // a static const char[]. The following code, extracts the part that displays the template name.
@@ -142,7 +142,7 @@ struct get_display_name
 {
 private:
     //!\brief Helper function to get the display name.
-    static constexpr auto get_display_name_fn = [] () constexpr
+    static constexpr auto get_display_name_fn()
     {
         // Use a helper function to extract the size of the requested type.
         constexpr_string<get_display_name_size_v<type>> tmp{};

--- a/test/unit/core/detail/reflection_test.cpp
+++ b/test/unit/core/detail/reflection_test.cpp
@@ -48,16 +48,18 @@ struct bar
 } // namespace foo
 
 // Some types to test if reflection works.
-using reflection_types = ::testing::Types<char, char16_t, char32_t,
+using reflection_types = ::testing::Types<char, char16_t, char32_t, short,
                                           short int, unsigned int, double, const char *,
-                                          foo::bar<char>, foo::bar<foo::bar<char, double>>>;
+                                          foo::bar<char>, foo::bar<foo::bar<char, double>>,
+                                          foo::bar<foo::bar<char, short *>>>;
 
 template <typename param_type>
 class reflection : public ::testing::Test
 {
     // The corresponding list of names that should be generated. Must have the same order as `reflection_types`.
-    inline static const std::vector names{"char", "char16_t", "char32_t", "short int", "unsigned int", "double",
-                                          "const char*", "foo::bar<char>", "foo::bar<foo::bar<char, double> >"};
+    inline static const std::vector names{"char", "char16_t", "char32_t", "short int", "short int", "unsigned int", "double",
+                                          "const char*", "foo::bar<char>", "foo::bar<foo::bar<char, double> >",
+                                          "foo::bar<foo::bar<char, short int*> >"};
 
     // Helper function to obtain the index of the current type `param_type` within the list of `reflection_types`.
     template <typename ...rem_types>
@@ -83,7 +85,44 @@ public:
 
 TYPED_TEST_CASE(reflection, reflection_types);
 
+TYPED_TEST(reflection, size)
+{
+    EXPECT_EQ(detail::get_display_name_size_v<TypeParam>, this->expected_name().size());
+}
+
 TYPED_TEST(reflection, name)
 {
     EXPECT_EQ(detail::get_display_name_v<TypeParam>.string(), this->expected_name());
+}
+
+namespace seqan3::detail
+{
+template <typename type>
+struct pretty_function
+{
+    static auto to_string()
+    {
+        return std::string{__PRETTY_FUNCTION__};
+    }
+};
+} // namespace seqan3::detail
+
+// NOTE: This does not test a seqan3 library feature, but the underlying magic
+// of how seqan3::detail::get_display_name_v works. This is needed, because
+// __PRETTY_FUNCTION__ has vendor specific output which is not standardised.
+TEST(pretty_function, to_string)
+{
+    std::string int_name = seqan3::detail::pretty_function<int>::to_string();
+#if defined(__clang__)
+    EXPECT_EQ(int_name, "static auto seqan3::detail::pretty_function<int>::to_string() [type = int]");
+#elif defined(__GNUC__)
+    EXPECT_EQ(int_name, "static auto seqan3::detail::pretty_function<type>::to_string() [with type = int]");
+#endif
+
+    std::string foo_bar_char_name = seqan3::detail::pretty_function<foo::bar<char>>::to_string();
+#if defined(__clang__)
+    EXPECT_EQ(foo_bar_char_name, "static auto seqan3::detail::pretty_function<foo::bar<char> >::to_string() [type = foo::bar<char>]");
+#elif defined(__GNUC__)
+    EXPECT_EQ(foo_bar_char_name, "static auto seqan3::detail::pretty_function<type>::to_string() [with type = foo::bar<char>]");
+#endif
 }


### PR DESCRIPTION
As you can see, gcc-8 changed the output of `__PRETTY_FUNCTION__`.

The `[with type = int]` part is now missing; therefore, `get_size()` skipped over all characters until after `\0`

resolves #262 