### PR TITLE
[FIX] Cast signed chars to unsigned chars.

### DIFF
--- a/include/seqan3/alphabet/aminoacid/aa27.hpp
+++ b/include/seqan3/alphabet/aminoacid/aa27.hpp
@@ -137,7 +137,8 @@ struct aa27
     //!\brief Assign from a character.
     constexpr aa27 & assign_char(char_type const c) noexcept
     {
-        _value = char_to_value[c];
+        using index_t = std::make_unsigned_t<char_type>;
+        _value = char_to_value[static_cast<index_t>(c)];
         return *this;
     }
 

--- a/include/seqan3/alphabet/nucleotide/dna15.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna15.hpp
@@ -133,7 +133,8 @@ struct dna15
     //!\copydoc seqan3::dna4::assign_char
     constexpr dna15 & assign_char(char_type const c) noexcept
     {
-        _value = char_to_value[c];
+        using index_t = std::make_unsigned_t<char_type>;
+        _value = char_to_value[static_cast<index_t>(c)];
         return *this;
     }
 

--- a/include/seqan3/alphabet/nucleotide/dna4.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna4.hpp
@@ -177,7 +177,8 @@ struct dna4
      */
     constexpr dna4 & assign_char(char_type const c) noexcept
     {
-        _value = char_to_value[c];
+        using index_t = std::make_unsigned_t<char_type>;
+        _value = char_to_value[static_cast<index_t>(c)];
         return *this;
     }
 

--- a/include/seqan3/alphabet/nucleotide/dna5.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna5.hpp
@@ -124,7 +124,8 @@ struct dna5
     //!\copydoc seqan3::dna4::assign_char
     constexpr dna5 & assign_char(char_type const c) noexcept
     {
-        _value = char_to_value[c];
+        using index_t = std::make_unsigned_t<char_type>;
+        _value = char_to_value[static_cast<index_t>(c)];
         return *this;
     }
 

--- a/include/seqan3/alphabet/nucleotide/rna15.hpp
+++ b/include/seqan3/alphabet/nucleotide/rna15.hpp
@@ -124,7 +124,8 @@ struct rna15 : public dna15
     //!\copydoc seqan3::dna4::assign_char
     constexpr rna15 & assign_char(char_type const c) noexcept
     {
-        _value = char_to_value[c];
+        using index_t = std::make_unsigned_t<char_type>;
+        _value = char_to_value[static_cast<index_t>(c)];
         return *this;
     }
 

--- a/include/seqan3/alphabet/nucleotide/rna4.hpp
+++ b/include/seqan3/alphabet/nucleotide/rna4.hpp
@@ -112,7 +112,8 @@ struct rna4 : public dna4
     //!\copydoc seqan3::dna4::assign_char
     constexpr rna4 & assign_char(char_type const c) noexcept
     {
-        _value = char_to_value[c];
+        using index_t = std::make_unsigned_t<char_type>;
+        _value = char_to_value[static_cast<index_t>(c)];
         return *this;
     }
 

--- a/include/seqan3/alphabet/nucleotide/rna5.hpp
+++ b/include/seqan3/alphabet/nucleotide/rna5.hpp
@@ -113,7 +113,8 @@ struct rna5 : public dna5
     //!\copydoc seqan3::dna4::assign_char
     constexpr rna5 & assign_char(char_type const c) noexcept
     {
-        _value = char_to_value[c];
+        using index_t = std::make_unsigned_t<char_type>;
+        _value = char_to_value[static_cast<index_t>(c)];
         return *this;
     }
 

--- a/include/seqan3/alphabet/quality/illumina18.hpp
+++ b/include/seqan3/alphabet/quality/illumina18.hpp
@@ -118,7 +118,8 @@ struct illumina18
     //! set internal value given 1-letter code
     constexpr illumina18 & assign_char(char_type const c)
     {
-        value = char_to_value[c];
+        using index_t = std::make_unsigned_t<char_type>;
+        value = char_to_value[static_cast<index_t>(c)];
         return *this;
     }
 

--- a/include/seqan3/alphabet/structure/dot_bracket3.hpp
+++ b/include/seqan3/alphabet/structure/dot_bracket3.hpp
@@ -123,7 +123,8 @@ struct dot_bracket3
      */
     constexpr dot_bracket3 & assign_char(char_type const chr) noexcept
     {
-        _value = char_to_value[chr];
+        using index_t = std::make_unsigned_t<char_type>;
+        _value = char_to_value[static_cast<index_t>(chr)];
         return *this;
     }
 

--- a/include/seqan3/alphabet/structure/dssp9.hpp
+++ b/include/seqan3/alphabet/structure/dssp9.hpp
@@ -136,7 +136,8 @@ struct dssp9
      */
     constexpr dssp9 & assign_char(char_type const chr) noexcept
     {
-        _value = char_to_value[chr];
+        using index_t = std::make_unsigned_t<char_type>;
+        _value = char_to_value[static_cast<index_t>(chr)];
         return *this;
     }
 

--- a/include/seqan3/alphabet/structure/wuss.hpp
+++ b/include/seqan3/alphabet/structure/wuss.hpp
@@ -163,7 +163,8 @@ struct wuss
      */
     constexpr wuss & assign_char(char_type const chr) noexcept
     {
-        _value = char_to_value[chr];
+        using index_t = std::make_unsigned_t<char_type>;
+        _value = char_to_value[static_cast<index_t>(chr)];
         return *this;
     }
 


### PR DESCRIPTION
Addresses issue #141 where unsigned chars are used in char_to_value. Using index_t defined as std::make_unsigned_t<char_type>, this casts the char to type index_t, resolving it to an unsigned char so that no negative values are used to index.