### PR TITLE
[FIX] Fixes template inspection for non template source types.

### DIFF
--- a/include/seqan3/core/metafunction/template_inspection.hpp
+++ b/include/seqan3/core/metafunction/template_inspection.hpp
@@ -170,7 +170,8 @@ using transfer_template_vargs_onto_t = typename transfer_template_vargs_onto<sou
  * \tparam source_type      The source type.
  * \tparam target_template  The type template you wish to compare against (must take only types as template arguments).
  * \ingroup metafunction
- * \see seqan3::detail::is_value_specialisation_of_v
+ * \see seqan3::detail::is_value_specialisation_of
+ * \see seqan3::detail::is_type_specialisation_of_v
  *
  * \details
  *
@@ -186,8 +187,17 @@ using transfer_template_vargs_onto_t = typename transfer_template_vargs_onto<sou
  * ```
  */
 template <typename source_t, template <typename ...> typename target_template>
-constexpr bool is_type_specialisation_of_v =
-    std::is_same_v<source_t, transfer_template_args_onto_t<source_t, target_template>>;
+struct is_type_specialisation_of :
+    std::is_same<source_t, transfer_template_args_onto_t<source_t, target_template>>
+{};
+
+/*!\brief Helper variable template for seqan3::detail::is_type_specialisation_of.
+ * \tparam source_type      The source type.
+ * \tparam target_template  The type template you wish to compare against (must take only types as template arguments).
+ * \ingroup metafunction
+ */
+template <typename source_t, template <typename ...> typename target_template>
+inline constexpr bool is_type_specialisation_of_v = is_type_specialisation_of<source_t, target_template>::value;
 
 // ----------------------------------------------------------------------------
 // is_value_specialisation_of_v
@@ -198,10 +208,20 @@ constexpr bool is_type_specialisation_of_v =
  * \tparam target_template  The type template you wish to compare against (must take only non-types as template
  * arguments).
  * \ingroup metafunction
- * \see seqan3::detail::is_type_specialisation_of_v
+ * \see seqan3::detail::is_type_specialisation_of
+ * \see seqan3::detail::is_value_specialisation_of_v
  */
 template <typename source_t, template <auto ...> typename target_template>
-constexpr bool is_value_specialisation_of_v =
-    std::is_same_v<source_t, transfer_template_vargs_onto_t<source_t, target_template>>;
+struct is_value_specialisation_of :
+    std::is_same<source_t, transfer_template_vargs_onto_t<source_t, target_template>>
+{};
+
+/*!\brief Helper variable template for seqan3::detail::is_value_specialisation_of.
+ * \tparam source_type      The source type.
+ * \tparam target_template  The type template you wish to compare against (must take only types as template arguments).
+ * \ingroup metafunction
+ */
+template <typename source_t, template <auto ...> typename target_template>
+inline constexpr bool is_value_specialisation_of_v = is_value_specialisation_of<source_t, target_template>::value;
 
 } // namespace seqan3::detail

--- a/include/seqan3/core/metafunction/template_inspection.hpp
+++ b/include/seqan3/core/metafunction/template_inspection.hpp
@@ -65,6 +65,7 @@ namespace seqan3::detail
  * This metafunction works for templates that have **only type-arguments**. See
  * seqan3::detail::transfer_template_vargs_onto for a metafunction that transfers non-type arguments. There is
  * no metafunction that can handle a combination of type and non-type arguments.
+ * If the `source_type` is a not a template class, e.g. an `int`, the return type defaults to `void`.
  *
  * ### Example
  *
@@ -75,7 +76,11 @@ namespace seqan3::detail
  * ```
  */
 template <typename source_type, template <typename ...> typename target_template>
-struct transfer_template_args_onto;
+struct transfer_template_args_onto
+{
+    //!\brief The return type: set to void for non template types.
+    using type = void;
+};
 
 /*!\brief Type metafunction that extracts a type template's **type** arguments and specialises another template
  * with them [metafunction definition].
@@ -120,10 +125,15 @@ using transfer_template_args_onto_t = typename transfer_template_args_onto<sourc
  * This metafunction works for templates that have **only non-type-arguments**. See
  * seqan3::detail::transfer_template_args_onto for a metafunction that transfers type arguments. There is
  * no metafunction that can handle a combination of type and non-type arguments.
+ * If the `source_type` is a not a template class, e.g. an `int`, the return type defaults to `void`.
  */
 
 template <typename source_type, template <auto ...> typename target_template>
-struct transfer_template_vargs_onto;
+struct transfer_template_vargs_onto
+{
+    //!\brief The return type: set to void for non template types.
+    using type = void;
+};
 
 /*!\brief Type metafunction that extracts a type template's **non-type** arguments and specialises another template
  * with them [metafunction definition].

--- a/test/unit/core/metafunction/template_inspection_test.cpp
+++ b/test/unit/core/metafunction/template_inspection_test.cpp
@@ -52,6 +52,13 @@ TEST(template_inspect, transfer_template_args_onto_t)
     EXPECT_TRUE((std::is_same_v<t, std::tuple<int, char, double>>));
 }
 
+TEST(template_inspect, is_type_specialisation_of_v)
+{
+    using tl = type_list<int, char, double>;
+    EXPECT_TRUE((detail::is_type_specialisation_of_v<tl, type_list>));
+    EXPECT_FALSE((detail::is_type_specialisation_of_v<int, type_list>));
+}
+
 template <int i, char c>
 struct t1 {};
 
@@ -73,4 +80,12 @@ TEST(template_inspect, transfer_template_vargs_onto_t)
     using ta2 = detail::transfer_template_vargs_onto_t<tl, t2>;
     EXPECT_EQ(1,   ta2::i);
     EXPECT_EQ('a', ta2::c);
+}
+
+TEST(template_inspect, is_value_specialisation_of_v)
+{
+    using tl = t1<1, 'a'>;
+
+    EXPECT_TRUE((detail::is_value_specialisation_of_v<tl, t1>));
+    EXPECT_FALSE((detail::is_value_specialisation_of_v<int, t1>));
 }

--- a/test/unit/core/metafunction/template_inspection_test.cpp
+++ b/test/unit/core/metafunction/template_inspection_test.cpp
@@ -52,6 +52,13 @@ TEST(template_inspect, transfer_template_args_onto_t)
     EXPECT_TRUE((std::is_same_v<t, std::tuple<int, char, double>>));
 }
 
+TEST(template_inspect, is_type_specialisation_of)
+{
+    using tl = type_list<int, char, double>;
+    EXPECT_TRUE((detail::is_type_specialisation_of<tl, type_list>::value));
+    EXPECT_FALSE((detail::is_type_specialisation_of<int, type_list>::value));
+}
+
 TEST(template_inspect, is_type_specialisation_of_v)
 {
     using tl = type_list<int, char, double>;
@@ -80,6 +87,14 @@ TEST(template_inspect, transfer_template_vargs_onto_t)
     using ta2 = detail::transfer_template_vargs_onto_t<tl, t2>;
     EXPECT_EQ(1,   ta2::i);
     EXPECT_EQ('a', ta2::c);
+}
+
+TEST(template_inspect, is_value_specialisation_of)
+{
+    using tl = t1<1, 'a'>;
+
+    EXPECT_TRUE((detail::is_value_specialisation_of<tl, t1>::value));
+    EXPECT_FALSE((detail::is_value_specialisation_of<int, t1>::value));
 }
 
 TEST(template_inspect, is_value_specialisation_of_v)


### PR DESCRIPTION
Fixes the following issue: 
When using our template inspection with non-template types the compiler will emit an error, rather than having a negative result. 