### PR TITLE
[INTERNAL] Add default constructors explicelty to gapped composition.

### DIFF
--- a/include/seqan3/alphabet/composition/union_composition.hpp
+++ b/include/seqan3/alphabet/composition/union_composition.hpp
@@ -207,24 +207,15 @@ public:
     //!\brief The type of the alphabet when represented as a number (e.g. via \link to_rank \endlink).
     using rank_type = detail::min_viable_uint_t<value_size>;
 
-    /*!\name Default constructors
+    /*!\name Constructors, destructor and assignment
      * \{
      */
     constexpr union_composition() = default;
     constexpr union_composition(union_composition const &) = default;
     constexpr union_composition(union_composition &&) = default;
-    //!\}
+    constexpr union_composition & operator=(union_composition const &) = default;
+    constexpr union_composition & operator=(union_composition &&) = default;
 
-    /*!\name Default assignment operators
-     * \{
-     */
-    constexpr union_composition & operator= (union_composition const &) = default;
-    constexpr union_composition & operator= (union_composition &&) = default;
-    //!\}
-
-    /*!\name Conversion constructors and assignment
-     * \{
-     */
     /*!\brief Construction via a value of a composite alphabet.
      * \tparam alphabet_t One of the composite alphabet types.
      * \param  alphabet   The value of a composite alphabet that should be assigned.
@@ -305,7 +296,7 @@ public:
     //!\cond
         requires !has_alternative<alphabet_subt>() && one_composite_is<assignable_from, alphabet_subt>
     //!\endcond
-    constexpr union_composition & operator= (alphabet_subt const & subalphabet) noexcept
+    constexpr union_composition & operator=(alphabet_subt const & subalphabet) noexcept
     {
         using alphabet_t = meta::front<meta::find_if<composites, assignable_from<alphabet_subt>>>;
         alphabet_t alphabet = subalphabet;

--- a/include/seqan3/alphabet/gap/gapped.hpp
+++ b/include/seqan3/alphabet/gap/gapped.hpp
@@ -74,34 +74,6 @@ template <typename alphabet_t>
 //!\cond
     requires alphabet_concept<alphabet_t>
 //!\endcond
-struct gapped : public union_composition<alphabet_t, gap>
-{
-    using union_composition<alphabet_t, gap>::_value;
-    using union_composition<alphabet_t, gap>::value_size;
-
-    using union_composition<alphabet_t, gap>::union_composition;
-
-    using typename union_composition<alphabet_t, gap>::rank_type;
-    using typename union_composition<alphabet_t, gap>::char_type;
-
-    //!\copydoc union_composition::assign_char
-    constexpr gapped & assign_char(char_type const c) noexcept
-    {
-        // We can't just use `using union_composition<alphabet_t, gap>::assign_char;` and need to explicitly forward
-        // `assign_char`, because otherwise the return type would be `union_composition` and not `gapped`, which is
-        // required by the `alphabet_concept`.
-        union_composition<alphabet_t, gap>::assign_char(c);
-        return *this;
-    }
-
-    //!\copydoc union_composition::assign_rank
-    constexpr gapped & assign_rank(rank_type const i) /*noexcept*/
-    {
-        // TODO(marehr): mark function noexcept if assert (within union_composition) is replaced
-        // https://github.com/seqan/seqan3/issues/85
-        union_composition<alphabet_t, gap>::assign_rank(i);
-        return *this;
-    }
-};
+using gapped = union_composition<alphabet_t, gap>;
 
 } // namespace seqan3


### PR DESCRIPTION
Since missing default constructors caused trouble in the cartesian composition (PR #372) this adds them for the gapped union composition for consistency and to avoid future errors.