### PR TITLE
re-activate fully virtualised builds because they have more memory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: required
 dist: trusty
 language: cpp
 


### PR DESCRIPTION
high priority because the build failures on travis are annoying as hell and our builds are too long to profit from the short boot-up-time of the containers anyway.