### PR TITLE
[FIX, TEST] Fixed cartesian and union composition comparison on compex types.

### DIFF
--- a/include/seqan3/alphabet/gap/gap.hpp
+++ b/include/seqan3/alphabet/gap/gap.hpp
@@ -70,6 +70,10 @@ struct gap
     //!\brief The type of the alphabet when represented as a number (e.g. via to_rank()).
     using rank_type = bool;
 
+    //!\cond
+    bool _bug_workaround; // See GCC Bug-Report: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=87113
+    //!\endcond
+
     /*!\name Letter values
      * \brief Static member "letters" that can be assigned to the alphabet or used in aggregate initialization.
      */

--- a/test/unit/alphabet/alphabet_test.cpp
+++ b/test/unit/alphabet/alphabet_test.cpp
@@ -62,6 +62,11 @@ using alphabet_types = ::testing::Types<dna4, dna5, dna15, rna4, rna5, rna15,
                                         union_composition<dna5, dna5>,
                                         union_composition<dna4, dna5, gap>,
                                         union_composition<char, gap>,
+                                        qualified<dna4, phred42>,
+                                        qualified<dna4, phred63>,
+                                        qualified<aa27, phred42>,
+                                        qualified<gapped<dna4>, phred42>,
+                                        gapped<qualified<dna4, phred42>>,
                                         gap,
                                         gapped<dna4>,
                                         gapped<dna15>,
@@ -294,20 +299,7 @@ class alphabet_constexpr : public ::testing::Test
 {};
 
 // add all alphabets here
-using alphabet_constexpr_types = ::testing::Types<dna4, dna5, dna15, rna4, rna5, rna15,
-                                                  /*aa27,*/
-                                                  union_composition<dna4>,
-                                                  union_composition<dna4, gap>,
-                                                  union_composition<dna4, dna5, gap>,
-                                                  char, char16_t, char32_t,
-                                                  uint8_t, uint16_t, uint32_t,
-                                                  /*gap, gapped<nucl16>, */
-                                                  dna4q,
-                                                  phred42, phred63, phred68legacy,
-                                                  dot_bracket3, dssp9, wuss<>, wuss<65>,
-                                                  structured_rna<rna5, dot_bracket3>, structured_rna<rna4, wuss51>,
-                                                  structured_aa<aa27, dssp9>,
-                                                  masked<dna5>>;
+using alphabet_constexpr_types = alphabet_types;
 
 TYPED_TEST_CASE(alphabet_constexpr, alphabet_types);
 

--- a/test/unit/alphabet/composition/CMakeLists.txt
+++ b/test/unit/alphabet/composition/CMakeLists.txt
@@ -1,3 +1,4 @@
 seqan3_test(cartesian_composition_test.cpp)
 seqan3_test(union_composition_test.cpp)
 seqan3_test(union_composition_detail_test.cpp)
+seqan3_test(composition_test.cpp)

--- a/test/unit/alphabet/composition/cartesian_composition_test.cpp
+++ b/test/unit/alphabet/composition/cartesian_composition_test.cpp
@@ -486,7 +486,6 @@ TYPED_TEST(cartesian_composition_test, custom_assignment_subtype)
     EXPECT_NE(get<0>(t1), TestFixture::value_1());
     EXPECT_NE(get<1>(t1), TestFixture::value_2());
 
-#if 0 // TODO(h-2) temporarily disabled
     t1 = TestFixture::assignable_to_value_1();
 
     EXPECT_NE(get<0>(t1), get<0>(t_d));
@@ -548,7 +547,6 @@ TYPED_TEST(cartesian_composition_test, custom_assignment_subtype)
     EXPECT_EQ(get<1>(t4), TestFixture::value_2());
     EXPECT_EQ(get<0>(t4), std::get<4>(TestFixture::values_to_cmp()));
     EXPECT_NE(get<1>(t4), std::get<5>(TestFixture::values_to_cmp()));
-#endif
 }
 
 // std::tuple_element

--- a/test/unit/alphabet/composition/composition_test.cpp
+++ b/test/unit/alphabet/composition/composition_test.cpp
@@ -1,0 +1,376 @@
+// ============================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ============================================================================
+//
+// Copyright (c) 2006-2018, Knut Reinert & Freie Universitaet Berlin
+// Copyright (c) 2016-2018, Knut Reinert & MPI Molekulare Genetik
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ============================================================================
+
+#include <gtest/gtest.h>
+
+#include <seqan3/alphabet/all.hpp>
+
+using namespace seqan3;
+
+// Some haessllihckeiten-tests
+
+TEST(composition, custom_constructors)
+{
+    qualified<dna4, phred42> t11{dna4::C};
+    qualified<dna4, phred42> t12{rna4::C};
+    qualified<dna4, phred42> t13{phred42{3}};
+    qualified<dna4, phred42> t14{phred63{3}};
+
+    qualified<aa27, phred63> t20{aa27::K, phred63{}};
+    qualified<aa27, phred63> t21{aa27::K};
+    qualified<aa27, phred63> t22{phred63{3}};
+    qualified<aa27, phred63> t23{phred42{3}};
+
+    qualified<gapped<dna4>, phred42> t31{dna4::C};
+    qualified<gapped<dna4>, phred42> t32{rna4::C};
+    qualified<gapped<dna4>, phred42> t33{phred42{3}};
+    qualified<gapped<dna4>, phred42> t34{gap::GAP};
+    qualified<gapped<dna4>, phred42> t35{gapped<dna4>(dna4::C)};
+    qualified<gapped<dna4>, phred42> t36{gapped<dna4>(gap::GAP)};
+    qualified<gapped<dna4>, phred42> t37{gap::GAP, phred42{3}};
+
+    gapped<qualified<dna4, phred42>> t41{dna4::C};
+    gapped<qualified<dna4, phred42>> t42{rna4::C};
+    gapped<qualified<dna4, phred42>> t43{phred42{3}};
+    gapped<qualified<dna4, phred42>> t44{gap::GAP};
+    gapped<qualified<dna4, phred42>> t45{qualified<dna4, phred42>{dna4::C, phred42{0}}};
+
+    qualified<qualified<gapped<dna4>, phred42>, phred42> t51{dna4::C};
+    qualified<qualified<gapped<dna4>, phred42>, phred42> t52{rna4::C};
+    qualified<qualified<gapped<dna4>, phred42>, phred42> t53{phred42{3}};
+    qualified<qualified<gapped<dna4>, phred42>, phred42> t54{gap::GAP};
+    qualified<qualified<gapped<dna4>, phred42>, phred42> t55{gapped<dna4>(dna4::C)};
+    qualified<qualified<gapped<dna4>, phred42>, phred42> t56{gapped<dna4>(gap::GAP)};
+
+    gapped<union_composition<dna4, phred42>> t61{dna4::C};
+    gapped<union_composition<dna4, phred42>> t62{rna4::C};
+    gapped<union_composition<dna4, phred42>> t63{phred42{3}};
+    gapped<union_composition<dna4, phred42>> t64{gap::GAP};
+    gapped<union_composition<dna4, phred42>> t65{qualified<dna4, phred42>{dna4::C, phred42{0}}};
+
+    EXPECT_EQ(t11, t12);
+    EXPECT_EQ(t13, t14);
+
+    EXPECT_EQ(t20, t21);
+    EXPECT_EQ(t22, t23);
+
+    EXPECT_EQ(t31, t32);
+    EXPECT_NE(t31, t33);
+    EXPECT_NE(t31, t34);
+    EXPECT_EQ(t31, t35);
+    EXPECT_EQ(t34, t36);
+
+    EXPECT_EQ(t41, t42);
+    EXPECT_NE(t41, t43);
+    EXPECT_NE(t41, t44);
+    EXPECT_EQ(t41, t45);
+
+    EXPECT_EQ(t51, t52);
+    EXPECT_NE(t51, t53);
+    EXPECT_NE(t51, t54);
+    EXPECT_EQ(t51, t55);
+    EXPECT_EQ(t54, t56);
+
+    EXPECT_EQ(t61, t62);
+    EXPECT_NE(t61, t63);
+    EXPECT_NE(t61, t64);
+    EXPECT_EQ(t61, t65);
+}
+
+TEST(composition_constexpr, custom_constructor)
+{
+    constexpr qualified<dna4, phred42> t11{dna4::C};
+    constexpr qualified<dna4, phred42> t12{rna4::C};
+    constexpr qualified<dna4, phred42> t13{phred42{3}};
+    constexpr qualified<dna4, phred42> t14{phred63{3}};
+
+    constexpr qualified<aa27, phred63> t21{aa27::K};
+    constexpr qualified<aa27, phred63> t22{phred63{3}};
+    constexpr qualified<aa27, phred63> t23{phred42{3}};
+
+    constexpr qualified<gapped<dna4>, phred42> t31{dna4::C};
+    constexpr qualified<gapped<dna4>, phred42> t32{rna4::C};
+    constexpr qualified<gapped<dna4>, phred42> t33{phred42{3}};
+    constexpr qualified<gapped<dna4>, phred42> t34{gap::GAP};
+    constexpr qualified<gapped<dna4>, phred42> t35{gapped<dna4>(dna4::C)};
+    constexpr qualified<gapped<dna4>, phred42> t36{gapped<dna4>(gap::GAP)};
+    constexpr qualified<gapped<dna4>, phred42> t37{gap::GAP, phred42{3}};
+
+    constexpr gapped<qualified<dna4, phred42>> t41{dna4::C};
+    constexpr gapped<qualified<dna4, phred42>> t42{rna4::C};
+    constexpr gapped<qualified<dna4, phred42>> t43{phred42{3}};
+    constexpr gapped<qualified<dna4, phred42>> t44{gap::GAP};
+    constexpr gapped<qualified<dna4, phred42>> t45{qualified<dna4, phred42>{dna4::C, phred42{0}}};
+
+    constexpr qualified<qualified<gapped<dna4>, phred42>, phred42> t51{dna4::C};
+    constexpr qualified<qualified<gapped<dna4>, phred42>, phred42> t52{rna4::C};
+    constexpr qualified<qualified<gapped<dna4>, phred42>, phred42> t53{phred42{3}};
+    constexpr qualified<qualified<gapped<dna4>, phred42>, phred42> t54{gap::GAP};
+    constexpr qualified<qualified<gapped<dna4>, phred42>, phred42> t55{gapped<dna4>(dna4::C)};
+    constexpr qualified<qualified<gapped<dna4>, phred42>, phred42> t56{gapped<dna4>(gap::GAP)};
+
+    constexpr gapped<union_composition<dna4, phred42>> t61{dna4::C};
+    constexpr gapped<union_composition<dna4, phred42>> t62{rna4::C};
+    constexpr gapped<union_composition<dna4, phred42>> t63{phred42{3}};
+    constexpr gapped<union_composition<dna4, phred42>> t64{gap::GAP};
+    constexpr gapped<union_composition<dna4, phred42>> t65{qualified<dna4, phred42>{dna4::C, phred42{0}}};
+}
+
+TEST(composition, custom_assignment)
+{
+    qualified<dna4, phred42> t11{};
+    qualified<dna4, phred42> t12{dna4::C};
+    qualified<dna4, phred42> t13{dna4::C, phred42{3}};
+    t11 = dna4::C;
+    EXPECT_EQ(t11, t12);
+    t11 = rna4::C;
+    EXPECT_EQ(t11, t12);
+    t11 = phred42{3};
+    EXPECT_EQ(t11, t13);
+    // t11 = phred63{3}; // does not work because of explicit conversion
+
+    qualified<aa27, phred63> t20{aa27::K, phred63{}};
+    qualified<aa27, phred63> t21{};
+    qualified<aa27, phred63> t22{aa27::K, phred63{3}};
+    t21 = aa27::K;
+    EXPECT_EQ(t20, t21);
+    t21 = phred63{3};
+    EXPECT_EQ(t21, t22);
+
+    qualified<gapped<dna4>, phred42> t31{};
+    qualified<gapped<dna4>, phred42> t32{dna4::C};
+    qualified<gapped<dna4>, phred42> t33{dna4::C, phred42{3}};
+    qualified<gapped<dna4>, phred42> t34{gap::GAP, phred42{3}};
+    t31 = dna4::C;
+    EXPECT_EQ(t31, t32);
+    t31 = rna4::C;
+    EXPECT_EQ(t31, t32);
+    t31 = phred42{3};
+    EXPECT_EQ(t31, t33);
+    t31 = gap::GAP;
+    EXPECT_EQ(t31, t34);
+    t31 = gapped<dna4>(dna4::C);
+    EXPECT_EQ(t31, t33);
+    t31 = gapped<dna4>(gap::GAP);
+    EXPECT_EQ(t31, t34);
+
+    gapped<qualified<dna4, phred42>> t41{};
+    gapped<qualified<dna4, phred42>> t42{dna4::C};
+    gapped<qualified<dna4, phred42>> t43{qualified<dna4, phred42>{dna4::C, phred42{3}}};
+    gapped<qualified<dna4, phred42>> t44{gap::GAP};
+    gapped<qualified<dna4, phred42>> t45{qualified<dna4, phred42>{dna4::C, phred42{0}}};
+    t41 = dna4::C;
+    EXPECT_EQ(t41, t42);
+    t41 = rna4::C;
+    EXPECT_EQ(t41, t42);
+    t41 = phred42{3};
+    // EXPECT_EQ(t41, t43); should work intuitively but does not because on assignment the qualified object is defaulted
+    t41 = gap::GAP;
+    EXPECT_EQ(t41, t44);
+    t41 = qualified<dna4, phred42>{dna4::C, phred42{0}};
+    EXPECT_EQ(t41, t45);
+
+    qualified<qualified<gapped<dna4>, phred42>, phred42> t51{};
+    qualified<qualified<gapped<dna4>, phred42>, phred42> t52{dna4::C};
+    qualified<qualified<gapped<dna4>, phred42>, phred42> t53{qualified<gapped<dna4>, phred42>{dna4::C, phred42{0}}, phred42{3}};
+    qualified<qualified<gapped<dna4>, phred42>, phred42> t54{qualified<gapped<dna4>, phred42>{gap::GAP, phred42{0}}, phred42{3}};
+    t51 = dna4::C;
+    EXPECT_EQ(t51, t52);
+    t51 = rna4::C;
+    EXPECT_EQ(t51, t52);
+    t51 = phred42{3};
+    EXPECT_EQ(t51, t53);
+    t51 = gap::GAP;
+    EXPECT_EQ(t51, t54);
+    t51 = gapped<dna4>(dna4::C);
+    EXPECT_EQ(t51, t53);
+    t51 = gapped<dna4>(gap::GAP);
+    EXPECT_EQ(t51, t54);
+
+    gapped<union_composition<dna4, phred42>> t61{};
+    gapped<union_composition<dna4, phred42>> t62{dna4::C};
+    gapped<union_composition<dna4, phred42>> t63{phred42{3}};
+    gapped<union_composition<dna4, phred42>> t64{gap::GAP};
+    gapped<union_composition<dna4, phred42>> t65{qualified<dna4, phred42>{dna4::C, phred42{0}}};
+    t61 = dna4::C;
+    EXPECT_EQ(t61, t62);
+    t61 = rna4::C;
+    EXPECT_EQ(t61, t62);
+    t61 = phred42{3};
+    EXPECT_EQ(t61, t63);
+    t61 = gap::GAP;
+    EXPECT_EQ(t61, t64);
+    t61 = qualified<dna4, phred42>{dna4::C, phred42{0}};
+    EXPECT_EQ(t61, t65);
+
+}
+
+constexpr bool do_assignment()
+{
+    qualified<dna4, phred42> t11{};
+    t11 = dna4::C;
+    t11 = rna4::C;
+    t11 = phred42{3};
+    // t11 = phred63{3}; // does not work because of explicit conversion
+
+    qualified<aa27, phred63> t21{};
+    t21 = aa27::K;
+    t21 = phred63{3};
+
+    qualified<gapped<dna4>, phred42> t31{};
+    t31 = dna4::C;
+    t31 = rna4::C;
+    t31 = phred42{3};
+    t31 = gap::GAP;
+    t31 = gapped<dna4>(dna4::C);
+    t31 = gapped<dna4>(gap::GAP);
+
+    gapped<qualified<dna4, phred42>> t41{};
+    t41 = dna4::C;
+    t41 = rna4::C;
+    t41 = phred42{3};
+    t41 = gap::GAP;
+    t41 = qualified<dna4, phred42>{dna4::C, phred42{0}};
+
+    qualified<qualified<gapped<dna4>, phred42>, phred42> t51{};
+    t51 = dna4::C;
+    t51 = rna4::C;
+    t51 = phred42{3};
+    t51 = gap::GAP;
+    t51 = gapped<dna4>(dna4::C);
+    t51 = gapped<dna4>(gap::GAP);
+
+    gapped<union_composition<dna4, phred42>> t61{};
+    t61 = rna4::C;
+    t61 = phred42{3};
+    t61 = gap::GAP;
+    t61 = qualified<dna4, phred42>{dna4::C, phred42{0}};
+
+    return true;
+}
+
+TEST(composition_constexpr, custom_assignment)
+{
+    [[maybe_unused]] constexpr bool foo = do_assignment();
+}
+
+TEST(composition, custom_ccomparison)
+{
+    qualified<dna4, phred42> t11{dna4::C, phred42{3}};
+    EXPECT_EQ(t11, dna4::C);
+    EXPECT_EQ(t11, rna4::C);
+    EXPECT_EQ(t11, phred42{3});
+
+    EXPECT_EQ(dna4::C,    t11);
+    EXPECT_EQ(rna4::C,    t11);
+    EXPECT_EQ(phred42{3}, t11);
+
+    qualified<aa27, phred63> t21{aa27::K, phred63{3}};
+    EXPECT_EQ(t21, aa27::K);
+    EXPECT_EQ(t21, phred63{3});
+    EXPECT_EQ(aa27::K,     t21);
+    EXPECT_EQ(phred63{3},  t21);
+
+    qualified<gapped<dna4>, phred42> t31{dna4::C, phred42{3}};
+    EXPECT_EQ(t31, dna4::C);
+    EXPECT_EQ(t31, rna4::C);
+    EXPECT_EQ(t31, phred42{3});
+    EXPECT_NE(t31, gap::GAP);
+    EXPECT_EQ(t31, gapped<dna4>(dna4::C));
+
+    EXPECT_EQ(dna4::C,                t31);
+    EXPECT_EQ(rna4::C,                t31);
+    EXPECT_EQ(phred42{3},             t31);
+    EXPECT_NE(gap::GAP,               t31);
+    EXPECT_EQ(gapped<dna4>(dna4::C),  t31);
+
+    gapped<qualified<dna4, phred42>> t41{qualified<dna4, phred42>{dna4::C, phred42{3}}};
+    gapped<qualified<dna4, phred42>> t42{qualified<dna4, phred42>{dna4::C, phred42{0}}};
+
+    EXPECT_EQ(t41, (gapped<qualified<dna4, phred42>>{qualified<dna4, phred42>{dna4::C, phred42{3}}}));
+    EXPECT_EQ(t42, dna4::C);
+    EXPECT_NE(t41, gap::GAP);
+    EXPECT_NE(gap::GAP, t41);
+
+    qualified<qualified<gapped<dna4>, phred42>, phred42> t51{qualified<gapped<dna4>, phred42>{dna4::C, phred42{3}}};
+    EXPECT_EQ(t51, dna4::C);
+    EXPECT_EQ(t51, rna4::C);
+    EXPECT_NE(t51, gap::GAP);
+    EXPECT_EQ(t51, gapped<dna4>(dna4::C));
+    EXPECT_EQ(t51, phred42{0});
+
+    EXPECT_EQ(dna4::C,                t51);
+    EXPECT_EQ(rna4::C,                t51);
+    EXPECT_EQ(phred42{0},             t51);
+    EXPECT_NE(gap::GAP,               t51);
+    EXPECT_EQ(gapped<dna4>(dna4::C),  t51);
+
+    gapped<union_composition<dna4, phred42>> t61{rna4::C};
+    EXPECT_EQ(t61, rna4::C);
+    EXPECT_EQ(t61, dna4::C);
+    EXPECT_NE(t61, gap::GAP);
+    EXPECT_NE(t61, phred42{0});
+
+    EXPECT_EQ(rna4::C,    t61);
+    EXPECT_EQ(dna4::C,    t61);
+    EXPECT_NE(gap::GAP,   t61);
+    EXPECT_NE(phred42{0}, t61);
+
+    // TODO Comparisons that should work but currently do not
+    // ======================================================
+
+    // Consider t41 with type gapped<qualified<dna4, phred42>>
+    // -------------------------------------------------------
+    // the following builds but does not compare correctly because
+    // the union composition does not delegate to the operator of
+    // the underlying type but implicitly casts the value with
+    // results in a different rank.
+    //
+    // EXPECT_EQ(t41, dna4::C);
+    // EXPECT_EQ(t41, rna4::C);
+    // EXPECT_EQ(t41, phred42{3});
+    // EXPECT_EQ(t41, (qualified<dna4, phred42>{dna4::C, phred42{3}}));
+
+    // EXPECT_EQ(dna4::C,                                         t41);
+    // EXPECT_EQ(rna4::C,                                         t41);
+    // EXPECT_EQ(phred42{3},                                      t41);
+    // EXPECT_EQ((qualified<dna4, phred42>{dna4::C, phred42{3}}), t41);
+
+    // Consider t51 with type qualified<qualified<gapped<dna4>, phred42>, phred42>
+    // -----------------------------------------------------------
+    // The following does not compile because of ambiguous operators.
+    //
+    // EXPECT_EQ(t51, (qualified<gapped<dna4>, phred42>{dna4::C, phred42{3}}));
+    // EXPECT_EQ((qualified<dna4, phred42>{dna4::C, phred42{3}}), t51);
+}


### PR DESCRIPTION
… the only important change is the change of:  friend comparison operator -> free functions.
And the GCC bug workaround in gap.hpp