### PR TITLE
[FIX] track changes in google testing framework

### DIFF
--- a/test/performance/example/example_benchmark.cpp
+++ b/test/performance/example/example_benchmark.cpp
@@ -53,7 +53,7 @@ static void memcpy_benchmark(benchmark::State& state) {
         memcpy(dst, src, size);
 
     int64_t bytes = int64_t(state.iterations()) * int64_t(size);
-    state.SetBytesProcessed(bytes);
+    state.counters["bytes_processed"] = bytes;
     delete[] src;
     delete[] dst;
 }
@@ -68,7 +68,7 @@ static void copy_benchmark(benchmark::State& state) {
         std::copy_n(src, size, dst);
 
     int64_t bytes = int64_t(state.iterations()) * int64_t(size);
-    state.SetBytesProcessed(bytes);
+    state.counters["bytes_processed"] = bytes;
     delete[] src;
     delete[] dst;
 }


### PR DESCRIPTION
Recent travis and jenkings builds have been failing with:
```cpp
/home/travis/build/seqan/seqan3/test/performance/example/example_benchmark.cpp:56:34: error: ‘void benchmark::State::SetBytesProcessed(int64_t)’ is deprecated: The SetItemsProcessed()/items_processed()/SetBytesProcessed()/bytes_processed() will be removed in a future release. Please use custom user counters. [-Werror=deprecated-declarations]
     state.SetBytesProcessed(bytes);
                                  ^
In file included from /home/travis/build/seqan/seqan3/test/performance/example/example_benchmark.cpp:38:0:
/home/travis/build/seqan/seqan3-build/vendor/benchmark/include/benchmark/benchmark.h:549:8: note: declared here
   void SetBytesProcessed(int64_t bytes) { bytes_processed_ = bytes; }
        ^~~~~~~~~~~~~~~~~
```

This PR fixes the behaviour.

@marehr Can you have quick look at it?