### PR TITLE
[FIX] GCC8 compiler error

### DIFF
--- a/include/seqan3/range/view/persist.hpp
+++ b/include/seqan3/range/view/persist.hpp
@@ -183,11 +183,11 @@ public:
     //!\}
 
     /*!\brief Convert this view into a container implicitly.
-     * \tparam container_t Type of the container to convert to; must satisfy seqan3::container_concept and the
+     * \tparam container_t Type of the container to convert to; must satisfy seqan3::sequence_container_concept and the
      *                     seqan3::reference_t of both must model std::CommonReference.
      * \returns This view converted to container_t.
      */
-    template <container_concept container_t>
+    template <sequence_container_concept container_t>
     operator container_t()
     //!\cond
         requires std::CommonReference<reference_t<container_t>, reference>
@@ -199,7 +199,7 @@ public:
     }
 
     //!\overload
-    template <container_concept container_t>
+    template <sequence_container_concept container_t>
     operator container_t() const
     //!\cond
         requires std::CommonReference<reference_t<container_t>, reference> &&


### PR DESCRIPTION
Resolves #435 

In
https://github.com/seqan/seqan3/blob/a1f818df3cb778ae074804a889d61167194037ea/include/seqan3/range/view/persist.hpp#L190-L199
and the corresponding overload, we require the `container_concept`, but the `ranges::back_inserter(ret)` will eventually call `push_back` on something of the `container_t` type.

So, I think, we should actually require the `sequence_container_concept` (or maybe just add a requires for the `push_back` functionality?) to ensure the type provides a `push_back` function.

I did some debugging with @smehringer and we saw that apparently GCC7 resolves to `container_t = std::string` and GCC8 resolves to `container_t = std::string_view` (🤷‍♂️) - which does not provide `push_back`. 