### PR TITLE
[FIX] Fixes template inspection for enum values.

### DIFF
--- a/include/seqan3/core/metafunction/template_inspection.hpp
+++ b/include/seqan3/core/metafunction/template_inspection.hpp
@@ -147,8 +147,24 @@ template <template <auto ...> typename source_template,
           auto ... source_varg_types>
 struct transfer_template_vargs_onto<source_template<source_varg_types...>, target_template>
 {
+    /*!\brief Returns the target type.
+     * \tparam target The target type substituted with the vargs from `source_template`.
+     * \tparam args   vargs from the `source_template`.
+     * \returns The target type substituted with the vargs from `source_template` if the expression `target<args...>`
+     *          is not ill-formed, otherwise `void`.
+     */
+    template <template <auto ...> typename target,
+              auto ... args,
+              typename = decltype(target<args...>{})>
+    static constexpr target<args...> if_valid_expression(int *);
+
+    //!\overload
+    template <template <auto ...> typename target,
+              auto ... args>
+    static constexpr void if_valid_expression(...);
+
     //!\brief The return type: the target type specialised by the unpacked types in the list.
-    using type = target_template<source_varg_types...>;
+    using type = decltype(if_valid_expression<target_template, source_varg_types...>(nullptr));
 };
 
 /*!\brief Type metafunction shortcut for seqan3::detail::transfer_template_vargs_onto.

--- a/test/unit/core/metafunction/template_inspection_test.cpp
+++ b/test/unit/core/metafunction/template_inspection_test.cpp
@@ -76,6 +76,40 @@ struct t2
     static constexpr auto c = _c;
 };
 
+enum struct e1
+{
+    foo
+};
+
+template <e1 v>
+struct foo
+{};
+
+enum struct e2
+{
+    bar
+};
+
+template <e2 v>
+struct bar
+{};
+
+template <e2 v>
+struct bar2
+{};
+
+TEST(template_inspect, transfer_template_vargs_onto_enum)
+{
+    using ta = detail::transfer_template_vargs_onto<bar<e2::bar>, foo>::type;
+    EXPECT_TRUE((std::is_same_v<ta, void>));
+
+    using ta2 = detail::transfer_template_vargs_onto<bar<e2::bar>, bar>::type;
+    EXPECT_TRUE((std::is_same_v<ta2, bar<e2::bar>>));
+
+    using ta3 = detail::transfer_template_vargs_onto<bar<e2::bar>, bar2>::type;
+    EXPECT_TRUE((std::is_same_v<ta3, bar2<e2::bar>>));
+}
+
 TEST(template_inspect, transfer_template_vargs_onto_t)
 {
     using tl = t1<1, 'a'>;


### PR DESCRIPTION
If one tries to use transfer_template_vargs_onto for two different types with two different enum values, the compiler will emit a hard error. 
This is problematic if one wants to use the is_specialization metafunction, as it does not compile. 
The fix, uses the SFINAE trick to check if the expression actually is valid and if not evaluates to void. 