### PR TITLE
edit_distance now computes begin position

### DIFF
--- a/include/seqan3/alignment/matrix/alignment_trace_matrix.hpp
+++ b/include/seqan3/alignment/matrix/alignment_trace_matrix.hpp
@@ -46,8 +46,7 @@
 #include <seqan3/alignment/matrix/alignment_score_matrix.hpp>
 #include <seqan3/alphabet/gap/gapped.hpp>
 #include <seqan3/core/add_enum_bitwise_operators.hpp>
-#include <seqan3/core/metafunction/basic.hpp>
-#include <seqan3/core/metafunction/iterator.hpp>
+#include <seqan3/core/metafunction/range.hpp>
 
 namespace seqan3::detail
 {

--- a/include/seqan3/alignment/matrix/alignment_trace_matrix.hpp
+++ b/include/seqan3/alignment/matrix/alignment_trace_matrix.hpp
@@ -157,13 +157,17 @@ alignment_begin_coordinate(trace_matrix_t && matrix, alignment_coordinate const 
 
 /*!\brief Compute the trace from a trace matrix.
  * \ingroup alignment_matrix
- * \tparam    database_t           The type of the database sequence.
- * \tparam    query_t              The type of the query sequence.
- * \tparam    trace_matrix_t       The type of the trace matrix.
- * \param[in] database             The database sequence.
- * \param[in] query                The query sequence.
- * \param[in] matrix               The trace matrix.
- * \param[in] end_coordinate       Where the trace in the matrix ends.
+ * \tparam    database_t                 The type of the database sequence.
+ * \tparam    query_t                    The type of the query sequence.
+ * \tparam    trace_matrix_t             The type of the trace matrix.
+ * \cond DEV
+ * \tparam    gapped_database_alphabet_t The alphabet type of the gapped database sequence.
+ * \tparam    gapped_query_alphabet_t    The alphabet type of the gapped query sequence.
+ * \endcond
+ * \param[in] database                   The database sequence.
+ * \param[in] query                      The query sequence.
+ * \param[in] matrix                     The trace matrix.
+ * \param[in] end_coordinate             Where the trace in the matrix ends.
  */
 template <
     typename database_t,
@@ -176,11 +180,10 @@ template <
              std::Same<typename remove_cvref_t<trace_matrix_t>::entry_type, trace_directions>
 //!\endcond
 inline std::pair<std::vector<gapped_database_alphabet_t>, std::vector<gapped_query_alphabet_t>>
-alignment_trace(
-    database_t && database,
-    query_t && query,
-    trace_matrix_t && matrix,
-    alignment_coordinate const end_coordinate)
+alignment_trace(database_t && database,
+                query_t && query,
+                trace_matrix_t && matrix,
+                alignment_coordinate const end_coordinate)
 {
     using signed_size_t = std::make_signed_t<size_t>;
 

--- a/include/seqan3/alignment/matrix/alignment_trace_matrix.hpp
+++ b/include/seqan3/alignment/matrix/alignment_trace_matrix.hpp
@@ -105,7 +105,7 @@ struct alignment_coordinate
  * \tparam    trace_matrix_t The type of the trace matrix.
  * \param[in] matrix         The trace matrix.
  * \param[in] end_coordinate Where the trace in the matrix ends.
- * \return Returns the begin coordinate.
+ * \returns Returns the begin coordinate.
  */
  template <typename trace_matrix_t>
  //!\cond
@@ -169,7 +169,7 @@ inline alignment_coordinate alignment_begin_coordinate(trace_matrix_t && matrix,
  * \param[in] query                      The query sequence.
  * \param[in] matrix                     The trace matrix.
  * \param[in] end_coordinate             Where the trace in the matrix ends.
- * \return Returns a seqan3::aligned_sequence.
+ * \returns Returns a seqan3::aligned_sequence.
  */
 template <
     typename database_t,

--- a/include/seqan3/alignment/matrix/alignment_trace_matrix.hpp
+++ b/include/seqan3/alignment/matrix/alignment_trace_matrix.hpp
@@ -39,11 +39,12 @@
 
 #pragma once
 
-#include <list>
-#include <seqan3/alphabet/gap/gapped.hpp>
+#include <deque>
+#include <vector>
 
 #include <seqan3/alignment/matrix/matrix_concept.hpp>
 #include <seqan3/alignment/matrix/alignment_score_matrix.hpp>
+#include <seqan3/alphabet/gap/gapped.hpp>
 #include <seqan3/core/add_enum_bitwise_operators.hpp>
 #include <seqan3/core/metafunction/basic.hpp>
 
@@ -98,64 +99,128 @@ struct alignment_coordinate
     size_t seq2_pos;
 };
 
-/*!\brief Compute the trace from a trace matrix
+/*!\brief Compute the begin coordinate.
  * \ingroup alignment_matrix
- * \tparam    database_t     The type of the database sequence.
- * \tparam    query_t        The type of the query sequence.
  * \tparam    trace_matrix_t The type of the trace matrix.
- * \param[in] database       The database sequence.
- * \param[in] query          The query sequence.
  * \param[in] matrix         The trace matrix.
  * \param[in] end_coordinate Where the trace in the matrix ends.
+ */
+ template <typename trace_matrix_t>
+ //!\cond
+     requires matrix_concept<remove_cvref_t<trace_matrix_t>> &&
+              std::Same<typename remove_cvref_t<trace_matrix_t>::entry_type, trace_directions>
+ //!\endcond
+inline alignment_coordinate
+alignment_begin_coordinate(trace_matrix_t && matrix, alignment_coordinate const end_coordinate)
+{
+    using signed_size_t = std::make_signed_t<size_t>;
+
+    constexpr auto N = trace_directions::none;
+    constexpr auto D = trace_directions::diagonal;
+    constexpr auto L = trace_directions::left;
+    constexpr auto U = trace_directions::up;
+    signed_size_t row = end_coordinate.seq2_pos + 1;
+    signed_size_t col = end_coordinate.seq1_pos + 1;
+
+    assert(row < matrix.rows());
+    assert(col < matrix.cols());
+
+    while(true)
+    {
+        trace_directions dir = matrix.at(row, col);
+        if ((dir & L) == L)
+        {
+            col = std::max<signed_size_t>(col - 1, 0);
+        }
+        else if ((dir & U) == U)
+        {
+            row = std::max<signed_size_t>(row - 1, 0);
+        }
+        else if ((dir & D) == D)
+        {
+            row = std::max<signed_size_t>(row - 1, 0);
+            col = std::max<signed_size_t>(col - 1, 0);
+        }
+        else
+        {
+            if (row == 0 || col == 0)
+                break;
+            throw std::logic_error{"Trace not found"};
+        }
+    }
+    return
+    {
+        std::max<signed_size_t>(col - 1, 0),
+        std::max<signed_size_t>(row - 1, 0)
+    };
+}
+
+/*!\brief Compute the trace from a trace matrix.
+ * \ingroup alignment_matrix
+ * \tparam    database_t           The type of the database sequence.
+ * \tparam    query_t              The type of the query sequence.
+ * \tparam    trace_matrix_t       The type of the trace matrix.
+ * \param[in] database             The database sequence.
+ * \param[in] query                The query sequence.
+ * \param[in] matrix               The trace matrix.
+ * \param[in] end_coordinate       Where the trace in the matrix ends.
  */
 template <
     typename database_t,
     typename query_t,
     typename trace_matrix_t,
-    typename gapped_database_t = gapped<std::decay_t<decltype(std::declval<database_t>()[0])>>,
-    typename gapped_query_t = gapped<std::decay_t<decltype(std::declval<query_t>()[0])>>>
+    typename gapped_database_alphabet_t = gapped<std::decay_t<decltype(std::declval<database_t>()[0])>>,
+    typename gapped_query_alphabet_t = gapped<std::decay_t<decltype(std::declval<query_t>()[0])>>>
 //!\cond
     requires matrix_concept<remove_cvref_t<trace_matrix_t>> &&
              std::Same<typename remove_cvref_t<trace_matrix_t>::entry_type, trace_directions>
 //!\endcond
-inline std::pair<std::list<gapped_database_t>, std::list<gapped_query_t>>
-alignment_trace(database_t && database, query_t && query, trace_matrix_t && matrix, alignment_coordinate const end_coordinate)
+inline std::pair<std::vector<gapped_database_alphabet_t>, std::vector<gapped_query_alphabet_t>>
+alignment_trace(
+    database_t && database,
+    query_t && query,
+    trace_matrix_t && matrix,
+    alignment_coordinate const end_coordinate)
 {
+    using signed_size_t = std::make_signed_t<size_t>;
+
     constexpr auto N = trace_directions::none;
     constexpr auto D = trace_directions::diagonal;
     constexpr auto L = trace_directions::left;
     constexpr auto U = trace_directions::up;
-    size_t col = end_coordinate.seq1_pos + 1;
-    size_t row = end_coordinate.seq2_pos + 1;
+    signed_size_t col = end_coordinate.seq1_pos + 1;
+    signed_size_t row = end_coordinate.seq2_pos + 1;
 
-    assert(col <= database.size());
     assert(row <= query.size());
+    assert(col <= database.size());
+    assert(row < matrix.rows());
+    assert(col < matrix.cols());
 
-    std::list<gapped_database_t> gapped_database{};
-    std::list<gapped_query_t> gapped_query{};
+    std::deque<gapped_database_alphabet_t> gapped_database{};
+    std::deque<gapped_query_alphabet_t> gapped_query{};
 
     if (matrix.at(0, 0) != N)
-        throw std::runtime_error{"End trace must be NONE"};
+        throw std::logic_error{"End trace must be NONE"};
 
-    while(row >= 0 && col >= 0)
+    while(true)
     {
         trace_directions dir = matrix.at(row, col);
         if ((dir & L) == L)
         {
-            col = std::max<int>(col - 1, 0);
+            col = std::max<signed_size_t>(col - 1, 0);
             gapped_database.push_front(database[col]);
             gapped_query.push_front(gap::GAP);
         }
         else if ((dir & U) == U)
         {
-            row = std::max<int>(row - 1, 0);
+            row = std::max<signed_size_t>(row - 1, 0);
             gapped_database.push_front(gap::GAP);
             gapped_query.push_front(query[row]);
         }
         else if ((dir & D) == D)
         {
-            row = std::max<int>(row - 1, 0);
-            col = std::max<int>(col - 1, 0);
+            row = std::max<signed_size_t>(row - 1, 0);
+            col = std::max<signed_size_t>(col - 1, 0);
             gapped_database.push_front(database[col]);
             gapped_query.push_front(query[row]);
         }
@@ -163,10 +228,16 @@ alignment_trace(database_t && database, query_t && query, trace_matrix_t && matr
         {
             if (row == 0 || col == 0)
                 break;
-            throw std::runtime_error{"Trace not found"};
+            throw std::logic_error{"Trace not found"};
         }
+
     }
-    return {gapped_database, gapped_query};
+
+    return
+    {
+        {std::begin(gapped_database), std::end(gapped_database)},
+        {std::begin(gapped_query), std::end(gapped_query)}
+    };
 }
 
 /*!\brief A trace matrix represented in a one-dimensional std::vector

--- a/include/seqan3/alignment/matrix/alignment_trace_matrix.hpp
+++ b/include/seqan3/alignment/matrix/alignment_trace_matrix.hpp
@@ -145,17 +145,15 @@ inline alignment_coordinate alignment_begin_coordinate(trace_matrix_t && matrix,
         }
         else
         {
-            if (row == 0 || col == 0)
-                break;
-            throw std::logic_error{"Trace not found"};
+#ifndef NDEBUG
+            if (!(row == 0 || col == 0))
+                throw std::logic_error{"Unkown seqan3::trace_direction in an inner cell of the trace matrix."};
+#endif
+            break;
         }
     }
 
-    return
-    {
-        std::max<signed_size_t>(col - 1, 0),
-        std::max<signed_size_t>(row - 1, 0)
-    };
+    return {std::max<signed_size_t>(col - 1, 0), std::max<signed_size_t>(row - 1, 0)};
 }
 
 /*!\brief Compute the trace from a trace matrix.
@@ -233,9 +231,11 @@ alignment_trace(database_t && database,
         }
         else
         {
-            if (row == 0 || col == 0)
-                break;
-            throw std::logic_error{"Trace not found"};
+#ifndef NDEBUG
+            if (!(row == 0 || col == 0))
+                throw std::logic_error{"Unkown seqan3::trace_direction in an inner cell of the trace matrix."};
+#endif
+            break;
         }
 
     }

--- a/include/seqan3/alignment/matrix/alignment_trace_matrix.hpp
+++ b/include/seqan3/alignment/matrix/alignment_trace_matrix.hpp
@@ -110,8 +110,8 @@ struct alignment_coordinate
      requires matrix_concept<remove_cvref_t<trace_matrix_t>> &&
               std::Same<typename remove_cvref_t<trace_matrix_t>::entry_type, trace_directions>
  //!\endcond
-inline alignment_coordinate
-alignment_begin_coordinate(trace_matrix_t && matrix, alignment_coordinate const end_coordinate)
+inline alignment_coordinate alignment_begin_coordinate(trace_matrix_t && matrix,
+                                                       alignment_coordinate const end_coordinate)
 {
     using signed_size_t = std::make_signed_t<size_t>;
 
@@ -125,7 +125,7 @@ alignment_begin_coordinate(trace_matrix_t && matrix, alignment_coordinate const 
     assert(row < matrix.rows());
     assert(col < matrix.cols());
 
-    while(true)
+    while (true)
     {
         trace_directions dir = matrix.at(row, col);
         if ((dir & L) == L)
@@ -205,7 +205,7 @@ alignment_trace(database_t && database,
     if (matrix.at(0, 0) != N)
         throw std::logic_error{"End trace must be NONE"};
 
-    while(true)
+    while (true)
     {
         trace_directions dir = matrix.at(row, col);
         if ((dir & L) == L)

--- a/include/seqan3/alignment/matrix/alignment_trace_matrix.hpp
+++ b/include/seqan3/alignment/matrix/alignment_trace_matrix.hpp
@@ -47,6 +47,7 @@
 #include <seqan3/alphabet/gap/gapped.hpp>
 #include <seqan3/core/add_enum_bitwise_operators.hpp>
 #include <seqan3/core/metafunction/basic.hpp>
+#include <seqan3/core/metafunction/iterator.hpp>
 
 namespace seqan3::detail
 {
@@ -104,6 +105,7 @@ struct alignment_coordinate
  * \tparam    trace_matrix_t The type of the trace matrix.
  * \param[in] matrix         The trace matrix.
  * \param[in] end_coordinate Where the trace in the matrix ends.
+ * \return Returns the begin coordinate.
  */
  template <typename trace_matrix_t>
  //!\cond
@@ -148,6 +150,7 @@ inline alignment_coordinate alignment_begin_coordinate(trace_matrix_t && matrix,
             throw std::logic_error{"Trace not found"};
         }
     }
+
     return
     {
         std::max<signed_size_t>(col - 1, 0),
@@ -168,13 +171,14 @@ inline alignment_coordinate alignment_begin_coordinate(trace_matrix_t && matrix,
  * \param[in] query                      The query sequence.
  * \param[in] matrix                     The trace matrix.
  * \param[in] end_coordinate             Where the trace in the matrix ends.
+ * \return Returns a seqan3::aligned_sequence.
  */
 template <
     typename database_t,
     typename query_t,
     typename trace_matrix_t,
-    typename gapped_database_alphabet_t = gapped<std::decay_t<decltype(std::declval<database_t>()[0])>>,
-    typename gapped_query_alphabet_t = gapped<std::decay_t<decltype(std::declval<query_t>()[0])>>>
+    typename gapped_database_alphabet_t = gapped<value_type_t<database_t>>,
+    typename gapped_query_alphabet_t = gapped<value_type_t<query_t>>>
 //!\cond
     requires matrix_concept<remove_cvref_t<trace_matrix_t>> &&
              std::Same<typename remove_cvref_t<trace_matrix_t>::entry_type, trace_directions>

--- a/include/seqan3/alignment/pairwise/edit_distance_unbanded.hpp
+++ b/include/seqan3/alignment/pairwise/edit_distance_unbanded.hpp
@@ -430,20 +430,23 @@ public:
         {
             get<align_result_key::score>(res) = score();
         }
+
+        alignment_coordinate end;
         if constexpr (std::tuple_size_v<result_type> >= 3)
         {
-            get<align_result_key::end>(res) = end_coordinate();
+            end = end_coordinate();
+            get<align_result_key::end>(res) = end;
         }
-        // if constexpr (std::tuple_size_v<result_type> >= 4)
-        // { TODO
-        //     throw std::invalid_argument{"The current output setting is not supported!"};
-        // }
-        if constexpr (std::tuple_size_v<result_type> == 5)
+
+        [[maybe_unused]] alignment_trace_matrix matrix = trace_matrix();
+        if constexpr (std::tuple_size_v<result_type> >= 4)
         {
-            auto && [seq1_trace, seq2_trace] = alignment_trace(database, query, trace_matrix(), end_coordinate());
-            auto & [in1, in2] = get<align_result_key::trace>(res);
-            ranges::copy(seq1_trace, ranges::back_inserter(in1));
-            ranges::copy(seq2_trace, ranges::back_inserter(in2));
+            get<align_result_key::begin>(res) = alignment_begin_coordinate(matrix, end);
+        }
+
+        if constexpr (std::tuple_size_v<result_type> >= 5)
+        {
+            get<align_result_key::trace>(res) = alignment_trace(database, query, matrix, end);
         }
         return res;
     }
@@ -464,6 +467,13 @@ public:
     trace_matrix_type trace_matrix() const noexcept
     {
         return trace_matrix_type{*this};
+    }
+
+    //!\brief Return the begin position of the alignment
+    alignment_coordinate begin_coordinate() const noexcept
+    {
+        alignment_coordinate end = end_coordinate();
+        return alignment_begin_coordinate(trace_matrix(), end);
     }
 
     //!\brief Return the end position of the alignment

--- a/include/seqan3/alignment/pairwise/edit_distance_unbanded.hpp
+++ b/include/seqan3/alignment/pairwise/edit_distance_unbanded.hpp
@@ -431,22 +431,20 @@ public:
             get<align_result_key::score>(res) = score();
         }
 
-        alignment_coordinate end;
         if constexpr (std::tuple_size_v<result_type> >= 3)
         {
-            end = end_coordinate();
-            get<align_result_key::end>(res) = end;
+            get<align_result_key::end>(res) = end_coordinate();
         }
 
         [[maybe_unused]] alignment_trace_matrix matrix = trace_matrix();
         if constexpr (std::tuple_size_v<result_type> >= 4)
         {
-            get<align_result_key::begin>(res) = alignment_begin_coordinate(matrix, end);
+            get<align_result_key::begin>(res) = alignment_begin_coordinate(matrix, get<align_result_key::end>(res));
         }
 
         if constexpr (std::tuple_size_v<result_type> >= 5)
         {
-            get<align_result_key::trace>(res) = alignment_trace(database, query, matrix, end);
+            get<align_result_key::trace>(res) = alignment_trace(database, query, matrix, get<align_result_key::end>(res));
         }
         return res;
     }

--- a/test/unit/alignment/pairwise/edit_distance_unbanded_test.cpp
+++ b/test/unit/alignment/pairwise/edit_distance_unbanded_test.cpp
@@ -207,10 +207,13 @@ TYPED_TEST_P(edit_distance_unbanded, trace_matrix)
 
     auto alignment = edit_distance<word_type>(database, query, align_cfg);
     auto trace_matrix = alignment.trace_matrix();
+    auto begin_coordinate = alignment.begin_coordinate();
     auto end_coordinate = alignment.end_coordinate();
 
     EXPECT_EQ(trace_matrix.cols(), database.size()+1);
     EXPECT_EQ(trace_matrix.rows(), query.size()+1);
+    EXPECT_EQ(begin_coordinate.seq1_pos, fixture.begin_coordinate.seq1_pos);
+    EXPECT_EQ(begin_coordinate.seq2_pos, fixture.begin_coordinate.seq2_pos);
     EXPECT_EQ(end_coordinate.seq1_pos, fixture.end_coordinate.seq1_pos);
     EXPECT_EQ(end_coordinate.seq2_pos, fixture.end_coordinate.seq2_pos);
     EXPECT_EQ(trace_matrix, fixture.trace_matrix);

--- a/test/unit/alignment/pairwise/fixture/alignment_fixture.hpp
+++ b/test/unit/alignment/pairwise/fixture/alignment_fixture.hpp
@@ -36,6 +36,7 @@ struct alignment_fixture
         score_t _score,
         std::string _gapped_sequence1,
         std::string _gapped_sequence2,
+        alignment_coordinate _begin_coordinate,
         alignment_coordinate _end_coordinate,
         std::vector<score_t> _score_vector,
         std::vector<trace_t> _trace_vector
@@ -45,6 +46,7 @@ struct alignment_fixture
         score{_score},
         gapped_sequence1{_gapped_sequence1},
         gapped_sequence2{_gapped_sequence2},
+        begin_coordinate{_begin_coordinate},
         end_coordinate{_end_coordinate},
         score_matrix{std::move(_score_vector), sequence2.size()+1, sequence1.size()+1},
         trace_matrix{std::move(_trace_vector), sequence2.size()+1, sequence1.size()+1}
@@ -60,6 +62,7 @@ struct alignment_fixture
     std::string gapped_sequence1;
     std::string gapped_sequence2;
 
+    alignment_coordinate begin_coordinate;
     alignment_coordinate end_coordinate;
     score_matrix_t score_matrix;
     trace_matrix_t trace_matrix;
@@ -74,6 +77,7 @@ alignment_fixture(
     score_t _score,
     std::string _gapped_sequence1,
     std::string _gapped_sequence2,
+    alignment_coordinate _begin_coordinate,
     alignment_coordinate _end_coordinate,
     std::vector<score_t> _score_vector,
     std::vector<trace_t> _trace_vector

--- a/test/unit/alignment/pairwise/fixture/global_edit_distance_max_errors_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/global_edit_distance_max_errors_unbanded.hpp
@@ -30,6 +30,7 @@ static auto dna4_01_e255 = []()
         -8,
         "AACCGGTTAACCGGTT",
         "A-C-G-T-A-C-G-TA",
+        alignment_coordinate{0, 0},
         alignment_coordinate{15, 8},
         std::vector
         {
@@ -77,6 +78,7 @@ static auto dna4_01T_e255 = []()
         -8,
         "A-C-G-T-A-C-G-TA",
         "AACCGGTTAACCGGTT",
+        alignment_coordinate{0, 0},
         alignment_coordinate{8, 15},
         std::vector
         {
@@ -138,6 +140,7 @@ static auto dna4_02_e255 = []()
         -8,
         "AACCGGTAAACCGGTT",
         "A-C-G-TA--C-G-TA",
+        alignment_coordinate{0, 0},
         alignment_coordinate{15, 8},
         std::vector
         {
@@ -185,6 +188,7 @@ static auto aa27_01_e255 = []()
         -8,
         "UUWWRRIIUUWWRRII",
         "U-W-R-I-U-W-R-IU",
+        alignment_coordinate{0, 0},
         alignment_coordinate{15, 8},
         std::vector
         {
@@ -232,6 +236,7 @@ static auto aa27_01T_e255 = []()
         -8,
         "U-W-R-I-U-W-R-IU",
         "UUWWRRIIUUWWRRII",
+        alignment_coordinate{0, 0},
         alignment_coordinate{8, 15},
         std::vector
         {

--- a/test/unit/alignment/pairwise/fixture/global_edit_distance_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/global_edit_distance_unbanded.hpp
@@ -27,6 +27,7 @@ static auto dna4_01 = []()
         -8,
         "AACCGGTTAACCGGTT",
         "A-C-G-T-A-C-G-TA",
+        alignment_coordinate{0, 0},
         alignment_coordinate{15, 8},
         std::vector
         {
@@ -74,6 +75,7 @@ static auto dna4_01T = []()
         -8,
         "A-C-G-T-A-C-G-TA",
         "AACCGGTTAACCGGTT",
+        alignment_coordinate{0, 0},
         alignment_coordinate{8, 15},
         std::vector
         {
@@ -135,6 +137,7 @@ static auto dna4_02 = []()
         -8,
         "AACCGGTAAACCGGTT",
         "A-C-G-TA--C-G-TA",
+        alignment_coordinate{0, 0},
         alignment_coordinate{15, 8},
         std::vector
         {
@@ -182,6 +185,7 @@ static auto aa27_01 = []()
         -8,
         "UUWWRRIIUUWWRRII",
         "U-W-R-I-U-W-R-IU",
+        alignment_coordinate{0, 0},
         alignment_coordinate{15, 8},
         std::vector
         {
@@ -229,6 +233,7 @@ static auto aa27_01T = []()
         -8,
         "U-W-R-I-U-W-R-IU",
         "UUWWRRIIUUWWRRII",
+        alignment_coordinate{0, 0},
         alignment_coordinate{8, 15},
         std::vector
         {

--- a/test/unit/alignment/pairwise/fixture/semi_global_edit_distance_max_errors_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/semi_global_edit_distance_max_errors_unbanded.hpp
@@ -33,6 +33,7 @@ static auto dna4_01_e255 = []()
         -5,
         "AC---CGGTT",
         "ACGTACG-TA",
+        alignment_coordinate{8, 0},
         alignment_coordinate{15, 8},
         std::vector
         {
@@ -80,6 +81,7 @@ static auto dna4_01T_e255 = []()
         -8,
         "A-C-G-T-A-C-G-TA",
         "AACCGGTTAACCGGTT",
+        alignment_coordinate{0, 0},
         alignment_coordinate{8, 15},
         std::vector
         {
@@ -141,6 +143,7 @@ static auto dna4_02_e255 = []()
         -4,
         "AC---CGGTA",
         "ACGTACG-TA",
+        alignment_coordinate{0, 0},
         alignment_coordinate{7, 8},
         std::vector
         {
@@ -188,6 +191,7 @@ static auto aa27_01_e255 = []()
         -5,
         "UW---WRRII",
         "UWRIUWR-IU",
+        alignment_coordinate{8, 0},
         alignment_coordinate{15, 8},
         std::vector
         {
@@ -235,6 +239,7 @@ static auto aa27_01T_e255 = []()
         -8,
         "U-W-R-I-U-W-R-IU",
         "UUWWRRIIUUWWRRII",
+        alignment_coordinate{0, 0},
         alignment_coordinate{8, 15},
         std::vector
         {

--- a/test/unit/alignment/pairwise/fixture/semi_global_edit_distance_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/semi_global_edit_distance_unbanded.hpp
@@ -30,6 +30,7 @@ static auto dna4_01 = []()
         -5,
         "AC---CGGTT",
         "ACGTACG-TA",
+        alignment_coordinate{8, 0},
         alignment_coordinate{15, 8},
         std::vector
         {
@@ -77,6 +78,7 @@ static auto dna4_01T = []()
         -8,
         "A-C-G-T-A-C-G-TA",
         "AACCGGTTAACCGGTT",
+        alignment_coordinate{0, 0},
         alignment_coordinate{8, 15},
         std::vector
         {
@@ -138,6 +140,7 @@ static auto dna4_02 = []()
         -4,
         "AC---CGGTA",
         "ACGTACG-TA",
+        alignment_coordinate{0, 0},
         alignment_coordinate{7, 8},
         std::vector
         {
@@ -185,6 +188,7 @@ static auto aa27_01 = []()
         -5,
         "UW---WRRII",
         "UWRIUWR-IU",
+        alignment_coordinate{8, 0},
         alignment_coordinate{15, 8},
         std::vector
         {
@@ -232,6 +236,7 @@ static auto aa27_01T = []()
         -8,
         "U-W-R-I-U-W-R-IU",
         "UUWWRRIIUUWWRRII",
+        alignment_coordinate{0, 0},
         alignment_coordinate{8, 15},
         std::vector
         {


### PR DESCRIPTION
Changes:
* computes begin_position
* `edit_distance{}(result_type)` supports now all `result_type` modes and properly sets the return values
* `align_result` expects now the `alignment_coordinate` type
* `alignment_trace` won't use `lists` anymore