### PR TITLE
[FIX] fix short help printing.

### DIFF
--- a/include/seqan3/argument_parser/detail/format_help.hpp
+++ b/include/seqan3/argument_parser/detail/format_help.hpp
@@ -680,6 +680,8 @@ public:
      */
     void parse(argument_parser_meta_data const & parser_meta)
     {
+        meta = parser_meta;
+
         print_header();
 
         if (!parser_meta.synopsis.empty())


### PR DESCRIPTION
now prints the name and hline instead of two empty lines