### PR TITLE
[INTERNAL] argument_parser now accepts also non-const char **.

### DIFF
--- a/include/seqan3/argument_parser/argument_parser.hpp
+++ b/include/seqan3/argument_parser/argument_parser.hpp
@@ -166,7 +166,7 @@ public:
      * \param[in] argc     The number of command line arguments.
      * \param[in] argv     The command line arguments to parse.
      */
-    argument_parser(std::string const app_name, int const argc, const char ** argv)
+    argument_parser(std::string const app_name, int const argc, char const * const * const  argv)
     {
         info.app_name = std::move(app_name);
         init(argc, argv);
@@ -502,7 +502,7 @@ private:
      * If `-export-help` is specified with a value other than html/man or ctd
      * a parser_invalid_argument is thrown.
      */
-    void init(int const argc, const char ** argv)
+    void init(int const argc, char const * const * const  argv)
     {
         if (argc <= 1) // no arguments provided
         {

--- a/include/seqan3/argument_parser/detail/format_parse.hpp
+++ b/include/seqan3/argument_parser/detail/format_parse.hpp
@@ -90,7 +90,7 @@ public:
      * \param[in] argc_ The number of command line arguments.
      * \param[in] argv_ The command line arguments to parse.
      */
-    format_parse(int const argc_, const char ** argv_) :
+    format_parse(int const argc_, char const * const * const  argv_) :
         argc(argc_ - 1)
     {
         init(argc_, argv_);
@@ -209,7 +209,7 @@ private:
      * Adds all command line arguments to the member format_parse::argv,
      * but splits all values (options) containing an equality sign.
      */
-    void init(int argc_, const char ** argv_)
+    void init(int argc_, char const * const * const  argv_)
     {
         argv.resize(argc_ - 1); // -1 because of the binary name
 

--- a/test/snippet/argument_parser/argument_parser_1.cpp
+++ b/test/snippet/argument_parser/argument_parser_1.cpp
@@ -1,7 +1,7 @@
 //! [usage]
 #include <seqan3/argument_parser/all.hpp>
 
-int main(int argc, const char ** argv)
+int main(int argc, char ** argv)
 {
     seqan3::argument_parser myparser("Grade-Average", argc, argv); // initialize
 

--- a/test/snippet/argument_parser/argument_parser_2.cpp
+++ b/test/snippet/argument_parser/argument_parser_2.cpp
@@ -1,7 +1,7 @@
 //! [usage]
 #include <seqan3/argument_parser/all.hpp>
 
-int main(int argc, const char ** argv)
+int main(int argc, char ** argv)
 {
     seqan3::argument_parser myparser("The-Age-App", argc, argv); // initialize
 

--- a/test/snippet/argument_parser/argument_parser_3.cpp
+++ b/test/snippet/argument_parser/argument_parser_3.cpp
@@ -1,7 +1,7 @@
 //! [usage]
 #include <seqan3/argument_parser/all.hpp>
 
-int main(int argc, const char ** argv)
+int main(int argc, char ** argv)
 {
     seqan3::argument_parser myparser("Penguin_Parade", argc, argv); // initialize
 

--- a/test/unit/argument_parser/format_parse_test.cpp
+++ b/test/unit/argument_parser/format_parse_test.cpp
@@ -710,3 +710,55 @@ TEST(parse_test, required_option_missing)
 
     EXPECT_THROW(parser.parse(), required_option_missing);
 }
+
+TEST(parse_test, argv_const_combinations)
+{
+    bool flag_value{false};
+
+    char arg1[]{"./argument_parser"};
+    char arg2[]{"-f"};
+    char * argv[] = {arg1, arg2};
+
+    // all const*
+    char const * const * const argv_all_const{argv};
+    argument_parser parser("test_parser", 2, argv_all_const);
+    parser.add_flag(flag_value, 'f', "flag", "this is a flag.");
+
+    EXPECT_NO_THROW(parser.parse());
+    EXPECT_TRUE(flag_value);
+
+    // none const
+    flag_value = false;
+    parser = argument_parser("test_parser", 2, argv);
+    parser.add_flag(flag_value, 'f', "flag", "this is a flag.");
+
+    EXPECT_NO_THROW(parser.parse());
+    EXPECT_TRUE(flag_value);
+
+    // const 1
+    flag_value = false;
+    char const * argv_const1[] = {"./argument_parser_test", "-f"};
+    parser = argument_parser("test_parser", 2, argv_const1);
+    parser.add_flag(flag_value, 'f', "flag", "this is a flag.");
+
+    EXPECT_NO_THROW(parser.parse());
+    EXPECT_TRUE(flag_value);
+
+    // const 2
+    flag_value = false;
+    char * const argv_const2[] = {arg1, arg2};
+    parser = argument_parser("test_parser", 2, argv_const2);
+    parser.add_flag(flag_value, 'f', "flag", "this is a flag.");
+
+    EXPECT_NO_THROW(parser.parse());
+    EXPECT_TRUE(flag_value);
+
+    // const 12
+    flag_value = false;
+    char const * const argv_const12[] = {arg1, arg2};
+    parser = argument_parser("test_parser", 2, argv_const12);
+    parser.add_flag(flag_value, 'f', "flag", "this is a flag.");
+
+    EXPECT_NO_THROW(parser.parse());
+    EXPECT_TRUE(flag_value);
+}


### PR DESCRIPTION
It is indirectly tested in the snippets that now mirror the "usual" main function parameters.

Fixes #388 and can be checked off in #471 after merging.