### PR TITLE
[INTERNAL] Prohibit calling argument_parser::parse more than once.

### DIFF
--- a/include/seqan3/argument_parser/argument_parser.hpp
+++ b/include/seqan3/argument_parser/argument_parser.hpp
@@ -367,7 +367,11 @@ public:
      */
     void parse()
     {
+        if (parse_was_called)
+            throw parser_design_error("The function parse() must only be called once!");
+
         std::visit([this] (auto & f) { f.parse(info); }, format);
+        parse_was_called = true;
     }
 
     //!\name Structuring the Help Page
@@ -483,6 +487,9 @@ public:
 //     std::future<bool> appVersionCheckFuture;
 
 private:
+    //!\brief Keeps track of whether the parse function has been called already.
+    bool parse_was_called{false};
+
     /*!\brief Initializes the seqan3::argument_parser class on construction.
      *
      * \param[in] argc     The number of command line arguments.

--- a/test/unit/argument_parser/argument_parser_design_error_test.cpp
+++ b/test/unit/argument_parser/argument_parser_design_error_test.cpp
@@ -87,3 +87,19 @@ TEST(parse_test, parser_design_error)
     parser7.add_positional_option(option_value, "desc.");
     EXPECT_THROW(parser7.parse(), parser_design_error);
 }
+
+TEST(parse_test, parse_called_twice)
+{
+    std::string option_value;
+
+    const char * argv[] = {"./argument_parser_test", "-s", "option_string"};
+    argument_parser parser("test_parser", 3, argv);
+    parser.add_option(option_value, 's', "string-option", "this is a string option.");
+
+    testing::internal::CaptureStderr();
+    EXPECT_NO_THROW(parser.parse());
+    EXPECT_TRUE((testing::internal::GetCapturedStderr()).empty());
+    EXPECT_EQ(option_value, "option_string");
+
+    EXPECT_THROW(parser.parse(), parser_design_error);
+}


### PR DESCRIPTION
This fixes #469 and will check off one issue in #471 