### PR TITLE
Generalize fm index concept

### DIFF
--- a/include/seqan3/search/fm_index/concept.hpp
+++ b/include/seqan3/search/fm_index/concept.hpp
@@ -159,7 +159,7 @@ concept fm_index_concept = std::Semiregular<t> && requires (t index)
     // NOTE: circular dependency
     // requires fm_index_iterator_concept<typename t::iterator_type>;
 
-    requires requires (t index, std::vector<dna4> const text)
+    requires requires (t index, std::vector<typename t::char_type> const text)
     {
         { t(text) };
         { index.construct(text) } -> void;

--- a/test/unit/search/fm_index_test.cpp
+++ b/test/unit/search/fm_index_test.cpp
@@ -134,8 +134,10 @@ TYPED_TEST(fm_index_test, serialization)
 TEST(fm_index_test, concepts)
 {
     EXPECT_TRUE(fm_index_concept<fm_index<std::vector<dna4>>>);
+    EXPECT_TRUE(fm_index_concept<fm_index<std::vector<dna5>>>);
     EXPECT_TRUE(fm_index_traits_concept<fm_index_default_traits>);
 
     EXPECT_TRUE(bi_fm_index_concept<bi_fm_index<std::vector<dna4>>>);
+    EXPECT_TRUE(bi_fm_index_concept<bi_fm_index<std::vector<dna5>>>);
     EXPECT_TRUE(bi_fm_index_traits_concept<bi_fm_index_default_traits>);
 }


### PR DESCRIPTION
The fm_index concept tests for 
https://github.com/seqan/seqan3/blob/41b42cc5d45c544a427ed079af957ad4366ea9e6/include/seqan3/search/fm_index/concept.hpp#L162

We should actually check for the underlying `char_type` instead of `dna4` .

And since we only test the concepts for `dna4`, the concept tests will pass ...