### PR TITLE
constexpr_invocable check and constexpr alphabets

### DIFF
--- a/include/seqan3/alphabet/aminoacid/aa20.hpp
+++ b/include/seqan3/alphabet/aminoacid/aa20.hpp
@@ -51,6 +51,7 @@ namespace seqan3
 /*!\brief The canonical amino acid alphabet.
  * \ingroup aminoacid
  * \implements seqan3::aminoacid_concept
+ * \implements seqan3::detail::constexpr_alphabet_concept
  *
  * \details
  * The alphabet consists of letters A, C, D, E, F, G, H, I, K, L, M, N, P, Q, R, S, T, V, W, Y

--- a/include/seqan3/alphabet/aminoacid/aa27.hpp
+++ b/include/seqan3/alphabet/aminoacid/aa27.hpp
@@ -52,6 +52,7 @@ namespace seqan3
 /*!\brief The twenty-seven letter amino acid alphabet.
  * \ingroup aminoacid
  * \implements seqan3::aminoacid_concept
+ * \implements seqan3::detail::constexpr_alphabet_concept
  *
  * \details
  * The alphabet consists of letters A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X,

--- a/include/seqan3/alphabet/composition/cartesian_composition.hpp
+++ b/include/seqan3/alphabet/composition/cartesian_composition.hpp
@@ -56,6 +56,7 @@ namespace seqan3
 /*!\brief The CRTP base for a combined alphabet that contains multiple values of different alphabets at the same time.
  * \ingroup composition
  * \implements seqan3::semi_alphabet_concept
+ * \implements seqan3::detail::constexpr_semi_alphabet_concept
  * \tparam first_component_type Type of the first letter; must model seqan3::semi_alphabet_concept.
  * \tparam component_types      Types of further letters (up to 4); must model seqan3::semi_alphabet_concept.
  *
@@ -88,7 +89,8 @@ template <typename derived_type,
           typename first_component_type,
           typename ...component_types>
 //!\cond
-    requires semi_alphabet_concept<first_component_type> && (semi_alphabet_concept<component_types> && ...)
+    requires detail::constexpr_semi_alphabet_concept<first_component_type> &&
+             (detail::constexpr_semi_alphabet_concept<component_types> && ...)
 //!\endcond
 class cartesian_composition : public pod_tuple<first_component_type, component_types...>
 {

--- a/include/seqan3/alphabet/composition/union_composition.hpp
+++ b/include/seqan3/alphabet/composition/union_composition.hpp
@@ -60,6 +60,7 @@ namespace seqan3
  * \tparam ...alternative_types Types of possible values (at least 2); all must model seqan3::alphabet_concept and be
  *                              unique.
  * \implements seqan3::alphabet_concept
+ * \implements seqan3::detail::constexpr_alphabet_concept
  *
  * \details
  *
@@ -83,7 +84,7 @@ namespace seqan3
  */
 template <typename ...alternative_types>
 //!\cond
-    requires (alphabet_concept<alternative_types> && ... && (sizeof...(alternative_types) >= 2))
+    requires (detail::constexpr_alphabet_concept<alternative_types> && ... && (sizeof...(alternative_types) >= 2))
 //!\endcond
 class union_composition
 {

--- a/include/seqan3/alphabet/concept.hpp
+++ b/include/seqan3/alphabet/concept.hpp
@@ -43,6 +43,7 @@
 
 #include <seqan3/core/concept/cereal.hpp>
 #include <seqan3/core/concept/core_language.hpp>
+#include <seqan3/core/metafunction/function.hpp>
 #include <seqan3/alphabet/adaptation/pre.hpp>
 #include <seqan3/alphabet/concept_pre.hpp>
 #include <seqan3/alphabet/detail/member_exposure.hpp>
@@ -204,3 +205,54 @@ void CEREAL_LOAD_MINIMAL_FUNCTION_NAME(archive_t const &,
 
 } // namespace seqan3
 
+namespace seqan3::detail
+{
+/*!\interface seqan3::detail::constexpr_semi_alphabet_concept <>
+ * \brief A seqan3::semi_alphabet_concept that has a constexpr default constructor and constexpr accessors.
+ * \ingroup alphabet
+ * \extends seqan3::semi_alphabet_concept
+ *
+ * The same as seqan3::semi_alphabet_concept, except that all required functions are also required to be
+ * `constexpr`-qualified.
+ *
+ * \par Concepts and doxygen
+ *
+ * The requirements for this concept are given as related functions and metafunctions.
+ * Types that satisfy this concept are shown as "implementing this interface".
+ */
+//!\cond
+template <typename t>
+concept constexpr_semi_alphabet_concept = semi_alphabet_concept<t> && requires
+{
+    // currently only tests rvalue interfaces, because we have no constexpr values in this scope to get references to
+    requires SEQAN3_IS_CONSTEXPR(to_rank(std::remove_reference_t<t>{}));
+    requires SEQAN3_IS_CONSTEXPR(assign_rank(std::remove_reference_t<t>{}, 0));
+};
+//!\endcond
+
+/*!\interface seqan3::detail::constexpr_alphabet_concept <>
+ * \brief A seqan3::alphabet_concept that has constexpr accessors.
+ * \ingroup alphabet
+ * \extends seqan3::detail::constexpr_semi_alphabet_concept
+ * \extends seqan3::alphabet_concept
+ *
+ * The same as seqan3::alphabet_concept, except that all required functions are also required to be
+ * `constexpr`-qualified.
+ *
+ * \par Concepts and doxygen
+ *
+ * The requirements for this concept are given as related functions and metafunctions.
+ * Types that satisfy this concept are shown as "implementing this interface".
+ */
+//!\cond
+template <typename t>
+concept constexpr_alphabet_concept = constexpr_semi_alphabet_concept<t> && requires
+{
+    // currently only tests rvalue interfaces, because we have no constexpr values in this scope to get references to
+    requires SEQAN3_IS_CONSTEXPR(to_char(std::remove_reference_t<t>{}));
+    requires SEQAN3_IS_CONSTEXPR(assign_char(std::remove_reference_t<t>{},
+                                             underlying_char_t<std::remove_reference_t<t>>{}));
+};
+//!\endcond
+
+} // namespace seqan3::detail

--- a/include/seqan3/alphabet/gap/gap.hpp
+++ b/include/seqan3/alphabet/gap/gap.hpp
@@ -50,6 +50,7 @@ namespace seqan3
 /*!\brief The alphabet of a gap character '-'
  * \ingroup gap
  * \implements seqan3::alphabet_concept
+ * \implements seqan3::detail::constexpr_alphabet_concept
  *
  * The alphabet always has the same value ('-').
  *

--- a/include/seqan3/alphabet/mask/mask.hpp
+++ b/include/seqan3/alphabet/mask/mask.hpp
@@ -47,11 +47,12 @@ namespace seqan3
 /*!\brief Implementation of a masked alphabet to be used for cartesian compositions.
  * \ingroup mask
  * \implements seqan3::semi_alphabet_concept
+ * \implements seqan3::detail::semi_constexpr_alphabet_concept
  *
  * \details
  * This alphabet is not usually used directly, but instead via seqan3::masked.
  * For more information see the \link mask Mask submodule \endlink.
- * 
+ *
  * \snippet test/snippet/alphabet/mask/mask.cpp general
  */
 struct mask

--- a/include/seqan3/alphabet/mask/masked.hpp
+++ b/include/seqan3/alphabet/mask/masked.hpp
@@ -48,6 +48,7 @@ namespace seqan3
  * with a mask.
  * \ingroup mask
  * \implements seqan3::alphabet_concept
+ * \implements seqan3::detail::semi_constexpr_alphabet_concept
  * \tparam sequence_alphabet_t Type of the first letter; must satisfy seqan3::semi_alphabet_concept.
  * \tparam mask_t Types of masked letter; must satisfy seqan3::semi_alphabet_concept, defaults to seqan3::mask.
  *

--- a/include/seqan3/alphabet/nucleotide/dna15.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna15.hpp
@@ -56,6 +56,7 @@ namespace seqan3
 /*!\brief The 15 letter DNA alphabet, containing all IUPAC smybols minus the gap.
  * \ingroup nucleotide
  * \implements seqan3::nucleotide_concept
+ * \implements seqan3::detail::constexpr_alphabet_concept
  *
  * \details
  * Note that you can assign 'U' as a character to dna15 and it will silently

--- a/include/seqan3/alphabet/nucleotide/dna4.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna4.hpp
@@ -57,6 +57,7 @@ namespace seqan3
 /*!\brief The four letter DNA alphabet of A,C,G,T.
  * \ingroup nucleotide
  * \implements seqan3::nucleotide_concept
+ * \implements seqan3::detail::constexpr_alphabet_concept
  *
  * \details
  * Note that you can assign 'U' as a character to dna4 and it will silently

--- a/include/seqan3/alphabet/nucleotide/dna5.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna5.hpp
@@ -57,6 +57,7 @@ namespace seqan3
 /*!\brief The five letter DNA alphabet of A,C,G,T and the unknown character N.
  * \ingroup nucleotide
  * \implements seqan3::nucleotide_concept
+ * \implements seqan3::detail::constexpr_alphabet_concept
  *
  * \details
  * Note that you can assign 'U' as a character to dna5 and it will silently

--- a/include/seqan3/alphabet/quality/phred42.hpp
+++ b/include/seqan3/alphabet/quality/phred42.hpp
@@ -173,9 +173,8 @@ struct phred42
      *
      * Constant.
      */
-    constexpr phred42 & assign_char(char_type const c)
+    constexpr phred42 & assign_char(char_type const c) noexcept
     {
-        assert(c >= offset_char && c < offset_char + max_value_size);
         _value = char_to_value[c];
         return *this;
     }
@@ -190,7 +189,7 @@ struct phred42
      *
      * Constant.
      */
-    constexpr phred42 & assign_phred(phred_type const p)
+    constexpr phred42 & assign_phred(phred_type const p) noexcept
     {
         // p >= 0 is implicitly always true
         assert(p < max_value_size);
@@ -213,7 +212,7 @@ struct phred42
      *
      * Guaranteed not to throw.
      */
-    constexpr phred42 & assign_rank(phred_type const p)
+    constexpr phred42 & assign_rank(phred_type const p) noexcept
     {
         return assign_phred(p);
     }
@@ -223,7 +222,7 @@ struct phred42
     //!\tparam other_qual_type The type to convert to; must satisfy seqan3::quality_concept.
     //
     template <quality_concept other_qual_type>
-    explicit constexpr operator other_qual_type() const //noexcept
+    explicit constexpr operator other_qual_type() const noexcept
     {
         return detail::convert_through_phred_representation<other_qual_type, std::decay_t<decltype(*this)>>[to_phred()];
     }

--- a/include/seqan3/alphabet/quality/phred42.hpp
+++ b/include/seqan3/alphabet/quality/phred42.hpp
@@ -54,6 +54,7 @@ namespace seqan3
 
 /*!\brief Quality type for traditional Sanger and modern Illumina Phred scores (typical range).
  * \implements seqan3::quality_concept
+ * \implements seqan3::detail::constexpr_alphabet_concept
  * \ingroup quality
  *
  * \details

--- a/include/seqan3/alphabet/quality/phred63.hpp
+++ b/include/seqan3/alphabet/quality/phred63.hpp
@@ -54,6 +54,7 @@ namespace seqan3
 
 /*!\brief Quality type for traditional Sanger and modern Illumina Phred scores (full range).
  * \implements seqan3::quality_concept
+ * \implements seqan3::detail::constexpr_alphabet_concept
  * \ingroup quality
  *
  * \details

--- a/include/seqan3/alphabet/quality/phred63.hpp
+++ b/include/seqan3/alphabet/quality/phred63.hpp
@@ -168,9 +168,8 @@ struct phred63
       *
       * Constant.
       */
-    constexpr phred63 & assign_char(char_type const c)
+    constexpr phred63 & assign_char(char_type const c) noexcept
     {
-        assert(c >= offset_char && c < offset_char + value_size);
         _value = char_to_value[c];
         return *this;
     }
@@ -185,7 +184,7 @@ struct phred63
      *
      * Constant.
      */
-    constexpr phred63 & assign_phred(phred_type const p)
+    constexpr phred63 & assign_phred(phred_type const p) noexcept
     {
         // p >= 0 is implicitly always true
         assert(p < value_size);
@@ -207,7 +206,7 @@ struct phred63
      *
      * Guaranteed not to throw.
      */
-    constexpr phred63 & assign_rank(phred_type const p)
+    constexpr phred63 & assign_rank(phred_type const p) noexcept
     {
         return assign_phred(p);
     }
@@ -216,7 +215,7 @@ struct phred63
     //!\brief Explicit conversion to any other nucleotide alphabet (via char representation).
     //!\tparam other_nucl_type The type to convert to; must model seqan3::quality_concept.
     template <quality_concept other_qual_type>
-    explicit constexpr operator other_qual_type() const //noexcept
+    explicit constexpr operator other_qual_type() const noexcept
     {
         return detail::convert_through_phred_representation<other_qual_type, std::decay_t<decltype(*this)>>[to_phred()];
     }

--- a/include/seqan3/alphabet/quality/phred68legacy.hpp
+++ b/include/seqan3/alphabet/quality/phred68legacy.hpp
@@ -55,6 +55,7 @@ namespace seqan3
 
 /*!\brief Quality type for Solexa and deprecated Illumina formats.
  * \implements seqan3::quality_concept
+ * \implements seqan3::detail::constexpr_alphabet_concept
  * \ingroup quality
  *
  * \details

--- a/include/seqan3/alphabet/quality/phred68legacy.hpp
+++ b/include/seqan3/alphabet/quality/phred68legacy.hpp
@@ -172,9 +172,8 @@ struct phred68legacy
       *
       * Constant.
       */
-    constexpr phred68legacy & assign_char(char_type const c)
+    constexpr phred68legacy & assign_char(char_type const c) noexcept
     {
-        assert(c >= offset_char && c < offset_char + value_size);
         _value = char_to_value[c];
         return *this;
     }
@@ -189,7 +188,7 @@ struct phred68legacy
      *
      * Constant.
      */
-    constexpr phred68legacy & assign_phred(phred_type const p)
+    constexpr phred68legacy & assign_phred(phred_type const p) noexcept
     {
         // p >= 0 is implicitly always true
         assert((p >= offset_phred) && (p < value_size + offset_phred));
@@ -207,7 +206,7 @@ struct phred68legacy
      *
      * Constant.
      */
-    constexpr phred68legacy & assign_rank(rank_type const p)
+    constexpr phred68legacy & assign_rank(rank_type const p) noexcept
     {
         // p implicitly always true due to unsignedness of p
         assert(p < value_size);

--- a/include/seqan3/alphabet/quality/qualified.hpp
+++ b/include/seqan3/alphabet/quality/qualified.hpp
@@ -54,6 +54,7 @@ namespace seqan3
  * \tparam sequence_alphabet_t Type of the alphabet; must satisfy seqan3::alphabet_concept.
  * \tparam quality_alphabet_t  Type of the quality; must satisfy seqan3::quality_concept.
  * \implements seqan3::quality_concept
+ * \implements seqan3::detail::constexpr_alphabet_concept
  *
  * This composition pairs an arbitrary alphabet with a quality alphabet, where
  * each alphabet character is stored together with its quality score in a

--- a/include/seqan3/alphabet/structure/dot_bracket3.hpp
+++ b/include/seqan3/alphabet/structure/dot_bracket3.hpp
@@ -53,6 +53,7 @@ namespace seqan3
 
 /*!\brief The three letter RNA structure alphabet of the characters ".()".
  * \implements seqan3::rna_structure_concept
+ * \implements seqan3::detail::constexpr_alphabet_concept
  * \ingroup structure
  *
  * \details

--- a/include/seqan3/alphabet/structure/structured_aa.hpp
+++ b/include/seqan3/alphabet/structure/structured_aa.hpp
@@ -54,6 +54,7 @@ namespace seqan3
 /*!\brief A seqan3::cartesian_composition that joins an aminoacid alphabet with a protein structure alphabet.
  * \ingroup structure
  * \implements seqan3::alphabet_concept
+ * \implements seqan3::detail::constexpr_alphabet_concept
  * \tparam sequence_alphabet_t Type of the first aminoacid letter; must satisfy seqan3::alphabet_concept.
  * \tparam structure_alphabet_t Types of further structure letters; must satisfy seqan3::alphabet_concept.
  *

--- a/include/seqan3/alphabet/structure/structured_rna.hpp
+++ b/include/seqan3/alphabet/structure/structured_rna.hpp
@@ -54,6 +54,7 @@ namespace seqan3
 /*!\brief A seqan3::cartesian_composition that joins a nucleotide alphabet with an RNA structure alphabet.
  * \ingroup structure
  * \implements seqan3::rna_structure_concept
+ * \implements seqan3::detail::constexpr_alphabet_concept
  * \tparam sequence_alphabet_t Type of the first letter; must satisfy seqan3::nucleotide_concept.
  * \tparam structure_alphabet_t Types of further letters; must satisfy seqan3::rna_structure_concept.
  *

--- a/include/seqan3/alphabet/structure/wuss.hpp
+++ b/include/seqan3/alphabet/structure/wuss.hpp
@@ -56,6 +56,7 @@ namespace seqan3
  * \tparam SIZE The alphabet size defaults to 50 and must be an odd number in range 15..67.
  *              It determines the allowed pseudoknot depth by adding characters AaBb..Zz to the alphabet.
  * \implements seqan3::rna_structure_concept
+ * \implements seqan3::detail::constexpr_alphabet_concept
  * \ingroup structure
  *
  * \details

--- a/include/seqan3/core/metafunction/function.hpp
+++ b/include/seqan3/core/metafunction/function.hpp
@@ -1,0 +1,70 @@
+// ============================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ============================================================================
+//
+// Copyright (c) 2006-2018, Knut Reinert & Freie Universitaet Berlin
+// Copyright (c) 2016-2018, Knut Reinert & MPI Molekulare Genetik
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ============================================================================
+
+/*!\file
+ * \brief Provides various metafunctions for use on functions.
+ * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <seqan3/core/platform.hpp>
+
+// ----------------------------------------------------------------------------
+// is_constexpr
+// ----------------------------------------------------------------------------
+
+namespace seqan3::detail
+{
+
+//!\brief NO-OP helper for is_constexpr
+//!\ingroup metafunction
+constexpr void is_constexpr_helper(int) {}
+
+} // namespace seqan3::detail
+
+namespace seqan3
+{
+
+/*!\brief Returns true if the expression passed to this macro can be evaluated at compile time, false otherwise.
+ * \ingroup metafunction
+ * \returns true or false.
+ */
+#if defined(__clang__) // bug: https://bugs.llvm.org//show_bug.cgi?id=15481
+#define SEQAN3_IS_CONSTEXPR(...) __builtin_constant_p( (__VA_ARGS__,0) )
+#else
+#define SEQAN3_IS_CONSTEXPR(...) noexcept(seqan3::detail::is_constexpr_helper( (__VA_ARGS__, 0) ))
+#endif
+
+} // namespace seqan3

--- a/test/unit/alphabet/alphabet_test.cpp
+++ b/test/unit/alphabet/alphabet_test.cpp
@@ -313,6 +313,11 @@ using alphabet_constexpr_types = alphabet_types;
 
 TYPED_TEST_CASE(alphabet_constexpr, alphabet_types);
 
+TYPED_TEST(alphabet_constexpr, concept_check)
+{
+    EXPECT_TRUE(detail::constexpr_alphabet_concept<TypeParam>);
+}
+
 TYPED_TEST(alphabet_constexpr, default_value_constructor)
 {
     [[maybe_unused]] constexpr TypeParam t0{};

--- a/test/unit/alphabet/mask/mask_test.cpp
+++ b/test/unit/alphabet/mask/mask_test.cpp
@@ -45,6 +45,12 @@
 
 using namespace seqan3;
 
+TEST(assignment, concept_check)
+{
+    EXPECT_TRUE(semi_alphabet_concept<mask>);
+    EXPECT_TRUE(detail::constexpr_semi_alphabet_concept<mask>);
+}
+
 TEST(assignment, assign_rank)
 {
     // l-value

--- a/test/unit/core/metafunction/CMakeLists.txt
+++ b/test/unit/core/metafunction/CMakeLists.txt
@@ -1,3 +1,4 @@
 seqan3_test(basic_test.cpp)
+seqan3_test(function_test.cpp)
 seqan3_test(range_iterator_test.cpp)
 seqan3_test(template_inspection_test.cpp)

--- a/test/unit/core/metafunction/function_test.cpp
+++ b/test/unit/core/metafunction/function_test.cpp
@@ -1,0 +1,105 @@
+// ============================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ============================================================================
+//
+// Copyright (c) 2006-2018, Knut Reinert & Freie Universitaet Berlin
+// Copyright (c) 2016-2018, Knut Reinert & MPI Molekulare Genetik
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ============================================================================
+
+#include <gtest/gtest.h>
+
+#include <seqan3/core/metafunction/function.hpp>
+
+using namespace seqan3;
+
+constexpr
+int    constexpr_nonvoid_free_fun(int i) { return i; }
+int nonconstexpr_nonvoid_free_fun(int i) { return i; }
+
+constexpr
+int constexpr_nonvoid_free_fun_const_ref(int const & i) { return i; }
+int nonconstexpr_nonvoid_free_fun_const_ref(int const & i) { return i; }
+
+constexpr
+void    constexpr_void_free_fun(int) { return; }
+void nonconstexpr_void_free_fun(int) { return; }
+
+struct constexpr_nonvoid_member_t
+{
+    int constexpr get_i(int i)
+    {
+        return i;
+    }
+};
+
+struct constexpr_void_member_t
+{
+    void constexpr get_i(int)
+    {}
+};
+
+struct nonconstexpr_nonvoid_member_t
+{
+    int get_i(int i)
+    {
+        return i;
+    }
+};
+
+struct nonconstexpr_void_member_t
+{
+    void get_i(int)
+    {}
+};
+
+TEST(metafunction, is_constexpr_invocable)
+{
+    int i = 32;
+    int constexpr j = 42;
+
+    EXPECT_TRUE((SEQAN3_IS_CONSTEXPR(constexpr_nonvoid_free_fun(3))));
+    EXPECT_TRUE((SEQAN3_IS_CONSTEXPR(constexpr_nonvoid_free_fun(j))));
+    EXPECT_TRUE((!SEQAN3_IS_CONSTEXPR(constexpr_nonvoid_free_fun(i))));
+    EXPECT_TRUE((!SEQAN3_IS_CONSTEXPR(nonconstexpr_nonvoid_free_fun(3))));
+
+    EXPECT_TRUE((SEQAN3_IS_CONSTEXPR(constexpr_nonvoid_free_fun_const_ref(static_cast<int const &>(3)))));
+    EXPECT_TRUE((SEQAN3_IS_CONSTEXPR(constexpr_nonvoid_free_fun_const_ref(j))));
+    EXPECT_TRUE((!SEQAN3_IS_CONSTEXPR(constexpr_nonvoid_free_fun_const_ref(i))));
+    EXPECT_TRUE((!SEQAN3_IS_CONSTEXPR(nonconstexpr_nonvoid_free_fun_const_ref(static_cast<int const &>(3)))));
+
+    EXPECT_TRUE((SEQAN3_IS_CONSTEXPR(constexpr_void_free_fun(3))));
+    EXPECT_TRUE((SEQAN3_IS_CONSTEXPR(constexpr_void_free_fun(j))));
+    EXPECT_TRUE((!SEQAN3_IS_CONSTEXPR(constexpr_void_free_fun(i))));
+    EXPECT_TRUE((!SEQAN3_IS_CONSTEXPR(nonconstexpr_void_free_fun(3))));
+
+    EXPECT_TRUE((SEQAN3_IS_CONSTEXPR(constexpr_nonvoid_member_t{}.get_i(3))));
+    EXPECT_TRUE((SEQAN3_IS_CONSTEXPR(constexpr_void_member_t{}.get_i(3))));
+    EXPECT_TRUE((!SEQAN3_IS_CONSTEXPR(nonconstexpr_nonvoid_member_t{}.get_i(3))));
+    EXPECT_TRUE((!SEQAN3_IS_CONSTEXPR(nonconstexpr_void_member_t{}.get_i(3))));
+}


### PR DESCRIPTION
All our alphabets are `constexpr` safe and some functionality (e.g. in the compositions) depends on this. But we require it nowhere (and it shouldnt be required in general).

Unfortunately there is no concept checking syntax for checking the constexpr'ness of a function, but I found a great hack on how to do it.

I have subsequently added constexpr concepts for alphabet and semi_alphabet and changed the requirements for the compositions. Currently these concepts reside in detail.