### PR TITLE
[FIX] Missing return value in several *_file_out member functions.

### DIFF
--- a/include/seqan3/io/alignment_file/output.hpp
+++ b/include/seqan3/io/alignment_file/output.hpp
@@ -559,6 +559,7 @@ public:
     {
         for (auto && record : range)
             push_back(std::forward<decltype(record)>(record));
+        return *this;
     }
 
     /*!\brief            Write a range of records (or tuples) to the file.

--- a/include/seqan3/io/sequence_file/output.hpp
+++ b/include/seqan3/io/sequence_file/output.hpp
@@ -608,6 +608,7 @@ public:
     {
         for (auto && record : range)
             push_back(std::forward<decltype(record)>(record));
+        return *this;
     }
 
     /*!\brief            Write a range of records (or tuples) to the file.
@@ -721,6 +722,7 @@ public:
                       detail::range_wrap_ignore(detail::get_or_ignore<field::ID>(r)),
                       detail::range_wrap_ignore(detail::get_or_ignore<field::QUAL>(r)),
                       detail::range_wrap_ignore(detail::get_or_ignore<field::SEQ_QUAL>(r)));
+        return *this;
     }
 
     /*!\brief            Write columns (wrapped in a std::tuple) to the file.
@@ -768,6 +770,7 @@ public:
             detail::range_wrap_ignore(detail::get_or_ignore<selected_field_ids::index_of(field::ID)>(t)),
             detail::range_wrap_ignore(detail::get_or_ignore<selected_field_ids::index_of(field::QUAL)>(t)),
             detail::range_wrap_ignore(detail::get_or_ignore<selected_field_ids::index_of(field::SEQ_QUAL)>(t)));
+        return *this;
     }
     //!\}
 

--- a/include/seqan3/io/structure_file/output.hpp
+++ b/include/seqan3/io/structure_file/output.hpp
@@ -595,6 +595,7 @@ public:
     {
         for (auto && record : range)
             push_back(std::forward<decltype(record)>(record));
+        return *this;
     }
 
     /*!\brief            Write a range of records (or tuples) to the file.
@@ -714,6 +715,7 @@ public:
                       detail::range_wrap_ignore(detail::get_or_ignore<field::REACT_ERR>(r)),
                       detail::range_wrap_ignore(detail::get_or_ignore<field::COMMENT>(r)),
                       detail::range_wrap_ignore(detail::get_or_ignore<field::OFFSET>(r)));
+        return *this;
     }
 
     /*!\brief            Write columns (wrapped in a std::tuple) to the file.
@@ -768,6 +770,7 @@ public:
            detail::range_wrap_ignore(detail::get_or_ignore<selected_field_ids::index_of(field::REACT_ERR)>(t)),
            detail::range_wrap_ignore(detail::get_or_ignore<selected_field_ids::index_of(field::COMMENT)>(t)),
            detail::range_wrap_ignore(detail::get_or_ignore<selected_field_ids::index_of(field::OFFSET)>(t)));
+        return *this;
     }
     //!\}
 


### PR DESCRIPTION
Partially fixes #494 (file output).

Acknowledgements to @marehr and -fsanitizer=undefined (which would be probably good to have as a test in CI) :heart: 