### PR TITLE
[INTERNAL] make the metafunctions not redirect to range-v3 metafunctions

### DIFF
--- a/include/seqan3/core/metafunction/iterator.hpp
+++ b/include/seqan3/core/metafunction/iterator.hpp
@@ -39,6 +39,7 @@
 
 #pragma once
 
+#include <iterator>
 #include <type_traits>
 
 #include <range/v3/utility/iterator_traits.hpp>
@@ -65,7 +66,7 @@ template <std::InputIterator it_t>
 struct value_type<it_t>
 {
     //!\brief Return the member type as return type.
-    using type = ranges::value_type_t<it_t>;
+    using type = typename std::iterator_traits<std::remove_reference_t<it_t>>::value_type;
 };
 
 // see specialisation for ranges in core/metafunction/range.hpp
@@ -81,7 +82,7 @@ template <std::InputIterator it_t>
 struct reference<it_t>
 {
     //!\brief Return the member type as return type.
-    using type = ranges::reference_t<it_t>;
+    using type = typename std::iterator_traits<std::remove_reference_t<it_t>>::reference;
 };
 
 // see specialisation for ranges in core/metafunction/range.hpp
@@ -97,7 +98,7 @@ template <std::InputIterator it_t>
 struct rvalue_reference<it_t>
 {
     //!\brief Return the member type as return type.
-    using type = ranges::rvalue_reference_t<it_t>;
+    using type = decltype(ranges::iter_move(std::declval<it_t &>()));
 };
 
 // see specialisation for ranges in core/metafunction/range.hpp
@@ -119,7 +120,7 @@ template <std::WeaklyIncrementable it_t>
 struct difference_type<it_t>
 {
     //!\brief Return the member type as return type.
-    using type = ranges::difference_type_t<it_t>;
+    using type = typename std::iterator_traits<std::remove_reference_t<it_t>>::difference_type;
 };
 
 // see specialisation for ranges in core/metafunction/range.hpp
@@ -135,7 +136,7 @@ template <std::WeaklyIncrementable it_t>
 struct size_type<it_t>
 {
     //!\brief Return the member type as return type.
-    using type = ranges::size_type_t<it_t>;
+    using type = std::make_unsigned_t<difference_type_t<it_t>>;
 };
 
 // see specialisation for ranges in core/metafunction/range.hpp

--- a/include/seqan3/core/metafunction/range.hpp
+++ b/include/seqan3/core/metafunction/range.hpp
@@ -71,7 +71,7 @@ namespace seqan3
  * \tparam t The type to operate on.
  */
 template <std::ranges::Range rng_t>
-using iterator_t = ranges::iterator_t<rng_t>;
+using iterator_t = decltype(ranges::begin(std::declval<rng_t &>()));
 
 // ----------------------------------------------------------------------------
 // sentinel
@@ -81,7 +81,7 @@ using iterator_t = ranges::iterator_t<rng_t>;
  * \tparam t The type to operate on.
  */
 template <std::ranges::Range rng_t>
-using sentinel_t = ranges::sentinel_t<rng_t>;
+using sentinel_t = decltype(ranges::end(std::declval<rng_t &>()));
 
 // ----------------------------------------------------------------------------
 // value_type
@@ -181,8 +181,8 @@ template <std::ranges::SizedRange rng_t>
 //!\endcond
 struct size_type<rng_t>
 {
-    //!\brief Return the size_type member definition from the queried type's iterator.
-    using type = size_type_t<iterator_t<rng_t>>;
+    //!\brief Return the size_type as returned by the size function.
+    using type = decltype(ranges::size(std::declval<rng_t &>()));
 };
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
minor changes to not make these depend on range-v3 counterparts. They do however depend on ranges::begin, ranges::end, ranges::size and ranges::iter_move which should be available in our `std` module.