### PR TITLE
[FIX] ambigious constructors of specialised inherited_iterator_base

### DIFF
--- a/include/seqan3/range/view/persist.hpp
+++ b/include/seqan3/range/view/persist.hpp
@@ -46,7 +46,6 @@
 #include <seqan3/io/exception.hpp>
 #include <seqan3/range/concept.hpp>
 #include <seqan3/range/container/concept.hpp>
-#include <seqan3/range/detail/inherited_iterator_base.hpp>
 #include <seqan3/range/view/detail.hpp>
 #include <seqan3/std/concepts>
 #include <seqan3/std/view/view_all.hpp>

--- a/include/seqan3/range/view/take.hpp
+++ b/include/seqan3/range/view/take.hpp
@@ -111,7 +111,7 @@ private:
         ~iterator_type() = default;
 
         //!\brief Constructor that delegates to the CRTP layer.
-        iterator_type(base_base_t it) :
+        iterator_type(base_base_t const & it) :
             base_t{it}
         {}
 

--- a/include/seqan3/range/view/take_line.hpp
+++ b/include/seqan3/range/view/take_line.hpp
@@ -105,7 +105,7 @@ private:
         ~iterator_type() = default;
 
         //!\brief Constructor that delegates to the CRTP layer.
-        iterator_type(base_base_t it) : base_t{it} {}
+        iterator_type(base_base_t const & it) : base_t{it} {}
         //!\}
 
         /*!\name Associated types

--- a/include/seqan3/range/view/take_until.hpp
+++ b/include/seqan3/range/view/take_until.hpp
@@ -123,7 +123,7 @@ private:
         ~iterator_type() = default;
 
         //!\brief Constructor that delegates to the CRTP layer.
-        iterator_type(base_base_t it) :
+        iterator_type(base_base_t const & it) :
             base_t{it}
         {}
 

--- a/test/unit/range/view/view_take_test.cpp
+++ b/test/unit/range/view/view_take_test.cpp
@@ -67,7 +67,7 @@ void do_test(adaptor_t const & adaptor, std::string const & vec)
     EXPECT_EQ("foo", v2);
 
     // combinability
-    auto v3 = vec | adaptor(3) | ranges::view::unique;
+    auto v3 = vec | adaptor(3) | adaptor(3) | ranges::view::unique;
     EXPECT_EQ("fo", std::string(v3));
     std::string v3b = vec | view::reverse | adaptor(3) | ranges::view::unique;
     EXPECT_EQ("rab", v3b);


### PR DESCRIPTION
Fixes a bug that prevented multiple instances of `view::take`, `view::take_until` and `view::take_line` (and their `_or_throw` versions to be chained.

The problem was found by @joshuak94 but I don't think there was an issue.