### PR TITLE
forbid conversion operators into the type itself

### DIFF
--- a/include/seqan3/alphabet/aminoacid/aa20.hpp
+++ b/include/seqan3/alphabet/aminoacid/aa20.hpp
@@ -172,7 +172,7 @@ struct aa20
     //!\tparam other_aa_type The type to convert to; must satisfy seqan3::aminoacid_concept.
     template <typename other_aa_type>
     //!\cond
-        requires aminoacid_concept<other_aa_type>
+        requires !std::Same<aa20, other_aa_type> && aminoacid_concept<other_aa_type>
     //!\endcond
     explicit constexpr operator other_aa_type() const noexcept
     {

--- a/include/seqan3/alphabet/aminoacid/aa27.hpp
+++ b/include/seqan3/alphabet/aminoacid/aa27.hpp
@@ -155,7 +155,7 @@ struct aa27
     //!\tparam other_aa_type The type to convert to; must satisfy seqan3::aminoacid_concept.
     template <typename other_aa_type>
     //!\cond
-        requires aminoacid_concept<other_aa_type>
+        requires !std::Same<aa27, other_aa_type> && aminoacid_concept<other_aa_type>
     //!\endcond
     explicit constexpr operator other_aa_type() const noexcept
     {

--- a/include/seqan3/alphabet/nucleotide/dna15.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna15.hpp
@@ -152,7 +152,7 @@ struct dna15
     //!\tparam other_nucl_type The type to convert to; must satisfy seqan3::nucleotide_concept and have the same \link value_size \endlink.
     template <typename other_nucl_type>
     //!\cond
-        requires nucleotide_concept<other_nucl_type> && value_size == alphabet_size_v<other_nucl_type>
+        requires !std::Same<dna15, other_nucl_type> && nucleotide_concept<other_nucl_type> && value_size == alphabet_size_v<other_nucl_type>
     //!\endcond
     constexpr operator other_nucl_type() const noexcept
     {
@@ -163,7 +163,7 @@ struct dna15
     //!\tparam other_nucl_type The type to convert to; must satisfy seqan3::nucleotide_concept.
     template <typename other_nucl_type>
     //!\cond
-        requires nucleotide_concept<other_nucl_type>
+        requires !std::Same<dna15, other_nucl_type> && nucleotide_concept<other_nucl_type>
     //!\endcond
     explicit constexpr operator other_nucl_type() const noexcept
     {

--- a/include/seqan3/alphabet/nucleotide/dna4.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna4.hpp
@@ -209,7 +209,7 @@ struct dna4
     //!\tparam other_nucl_type The type to convert to; must satisfy seqan3::nucleotide_concept and have the same \link value_size \endlink.
     template <typename other_nucl_type>
     //!\cond
-        requires nucleotide_concept<other_nucl_type> && value_size == alphabet_size_v<other_nucl_type>
+        requires !std::Same<dna4, other_nucl_type> && nucleotide_concept<other_nucl_type> && value_size == alphabet_size_v<other_nucl_type>
     //!\endcond
     constexpr operator other_nucl_type() const noexcept
     {
@@ -220,7 +220,7 @@ struct dna4
     //!\tparam other_nucl_type The type to convert to; must satisfy seqan3::nucleotide_concept.
     template <typename other_nucl_type>
     //!\cond
-        requires nucleotide_concept<other_nucl_type>
+        requires !std::Same<dna4, other_nucl_type> && nucleotide_concept<other_nucl_type>
     //!\endcond
     explicit constexpr operator other_nucl_type() const noexcept
     {

--- a/include/seqan3/alphabet/nucleotide/dna5.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna5.hpp
@@ -143,7 +143,7 @@ struct dna5
     //!\tparam other_nucl_type The type to convert to; must satisfy seqan3::nucleotide_concept and have the same \link value_size \endlink.
     template <typename other_nucl_type>
     //!\cond
-        requires nucleotide_concept<other_nucl_type> && value_size == alphabet_size_v<other_nucl_type>
+        requires !std::Same<dna5, other_nucl_type> && nucleotide_concept<other_nucl_type> && value_size == alphabet_size_v<other_nucl_type>
     //!\endcond
     constexpr operator other_nucl_type() const noexcept
     {
@@ -154,7 +154,7 @@ struct dna5
     //!\tparam other_nucl_type The type to convert to; must satisfy seqan3::nucleotide_concept.
     template <typename other_nucl_type>
     //!\cond
-        requires nucleotide_concept<other_nucl_type>
+        requires !std::Same<dna5, other_nucl_type> && nucleotide_concept<other_nucl_type>
     //!\endcond
     explicit constexpr operator other_nucl_type() const noexcept
     {

--- a/include/seqan3/alphabet/nucleotide/rna15.hpp
+++ b/include/seqan3/alphabet/nucleotide/rna15.hpp
@@ -139,7 +139,7 @@ struct rna15 : public dna15
     //!\tparam other_nucl_type The type to convert to; must satisfy seqan3::nucleotide_concept and have the same \link value_size \endlink.
     template <typename other_nucl_type>
     //!\cond
-        requires nucleotide_concept<other_nucl_type> && value_size == alphabet_size_v<other_nucl_type>
+        requires !std::Same<rna15, other_nucl_type> && nucleotide_concept<other_nucl_type> && value_size == alphabet_size_v<other_nucl_type>
     //!\endcond
     constexpr operator other_nucl_type() const noexcept
     {
@@ -150,7 +150,7 @@ struct rna15 : public dna15
     //!\tparam other_nucl_type The type to convert to; must satisfy seqan3::nucleotide_concept.
     template <typename other_nucl_type>
     //!\cond
-        requires nucleotide_concept<other_nucl_type>
+        requires !std::Same<rna15, other_nucl_type> && nucleotide_concept<other_nucl_type>
     //!\endcond
     explicit constexpr operator other_nucl_type() const noexcept
     {

--- a/include/seqan3/alphabet/nucleotide/rna4.hpp
+++ b/include/seqan3/alphabet/nucleotide/rna4.hpp
@@ -127,7 +127,7 @@ struct rna4 : public dna4
     //!\tparam other_nucl_type The type to convert to; must satisfy seqan3::nucleotide_concept and have the same \link value_size \endlink.
     template <typename other_nucl_type>
     //!\cond
-        requires nucleotide_concept<other_nucl_type> && value_size == alphabet_size_v<other_nucl_type>
+        requires !std::Same<rna4, other_nucl_type> && nucleotide_concept<other_nucl_type> && value_size == alphabet_size_v<other_nucl_type>
     //!\endcond
     constexpr operator other_nucl_type() const noexcept
     {
@@ -138,7 +138,7 @@ struct rna4 : public dna4
     //!\tparam other_nucl_type The type to convert to; must satisfy seqan3::nucleotide_concept.
     template <typename other_nucl_type>
     //!\cond
-        requires nucleotide_concept<other_nucl_type>
+        requires !std::Same<rna4, other_nucl_type> && nucleotide_concept<other_nucl_type>
     //!\endcond
     explicit constexpr operator other_nucl_type() const noexcept
     {

--- a/include/seqan3/alphabet/nucleotide/rna5.hpp
+++ b/include/seqan3/alphabet/nucleotide/rna5.hpp
@@ -128,7 +128,7 @@ struct rna5 : public dna5
     //!\tparam other_nucl_type The type to convert to; must satisfy seqan3::nucleotide_concept and have the same \link value_size \endlink.
     template <typename other_nucl_type>
     //!\cond
-        requires nucleotide_concept<other_nucl_type> && value_size == alphabet_size_v<other_nucl_type>
+        requires !std::Same<rna5, other_nucl_type> && nucleotide_concept<other_nucl_type> && value_size == alphabet_size_v<other_nucl_type>
     //!\endcond
     constexpr operator other_nucl_type() const noexcept
     {
@@ -139,7 +139,7 @@ struct rna5 : public dna5
     //!\tparam other_nucl_type The type to convert to; must satisfy seqan3::nucleotide_concept.
     template <typename other_nucl_type>
     //!\cond
-        requires nucleotide_concept<other_nucl_type>
+        requires !std::Same<rna5, other_nucl_type> && nucleotide_concept<other_nucl_type>
     //!\endcond
     explicit constexpr operator other_nucl_type() const noexcept
     {

--- a/include/seqan3/alphabet/quality/phred42.hpp
+++ b/include/seqan3/alphabet/quality/phred42.hpp
@@ -44,6 +44,7 @@
 
 #include <seqan3/alphabet/detail/convert.hpp>
 #include <seqan3/alphabet/quality/concept.hpp>
+#include <seqan3/std/concepts>
 
 // ------------------------------------------------------------------
 // phred42
@@ -221,7 +222,10 @@ struct phred42
     //!\brief Explicit conversion to any other quality alphabet (via char representation).
     //!\tparam other_qual_type The type to convert to; must satisfy seqan3::quality_concept.
     //
-    template <quality_concept other_qual_type>
+    template <typename other_qual_type>
+    //!\cond
+        requires !std::Same<phred42, other_qual_type> && quality_concept<other_qual_type>
+    //!\endcond
     explicit constexpr operator other_qual_type() const noexcept
     {
         return detail::convert_through_phred_representation<other_qual_type, std::decay_t<decltype(*this)>>[to_phred()];

--- a/include/seqan3/alphabet/quality/phred63.hpp
+++ b/include/seqan3/alphabet/quality/phred63.hpp
@@ -44,6 +44,7 @@
 #include <seqan3/alphabet/detail/convert.hpp>
 #include <seqan3/alphabet/quality/concept.hpp>
 #include <seqan3/core/platform.hpp>
+#include <seqan3/std/concepts>
 
 // ------------------------------------------------------------------
 // phred63
@@ -214,7 +215,10 @@ struct phred63
 
     //!\brief Explicit conversion to any other nucleotide alphabet (via char representation).
     //!\tparam other_nucl_type The type to convert to; must model seqan3::quality_concept.
-    template <quality_concept other_qual_type>
+    template <typename other_qual_type>
+    //!\cond
+        requires !std::Same<phred63, other_qual_type> && quality_concept<other_qual_type>
+    //!\endcond
     explicit constexpr operator other_qual_type() const noexcept
     {
         return detail::convert_through_phred_representation<other_qual_type, std::decay_t<decltype(*this)>>[to_phred()];

--- a/include/seqan3/alphabet/quality/phred68legacy.hpp
+++ b/include/seqan3/alphabet/quality/phred68legacy.hpp
@@ -45,6 +45,7 @@
 #include <seqan3/alphabet/detail/convert.hpp>
 #include <seqan3/alphabet/quality/concept.hpp>
 #include <seqan3/core/platform.hpp>
+#include <seqan3/std/concepts>
 
 // ------------------------------------------------------------------
 // phred68legacy
@@ -221,7 +222,10 @@ struct phred68legacy
     //!\brief Explicit conversion to any other nucleotide alphabet (via char representation).
     //!\tparam other_nucl_type The type to convert to; must satisfy seqan3::quality_concept.
     //  phred scores below 0 will be truncated, i.e. mapped to phred64::phred_type = 0.
-    template <quality_concept other_qual_type>
+    template <typename other_qual_type>
+    //!\cond
+        requires !std::Same<phred68legacy, other_qual_type> && quality_concept<other_qual_type>
+    //!\endcond
     explicit constexpr operator other_qual_type() const //noexcept
     {
         return detail::convert_through_phred_representation<other_qual_type, std::decay_t<decltype(*this)>>[std::max<phred_type>(0, to_phred())];


### PR DESCRIPTION
This is the main reason why clang seg faults. (There are still some other major defects, like memory leaks, (new) seg faults and other stuff).


saarraz/clang-concepts/issues/12