### PR TITLE
[fix] debug_stream_type should not be constexpr

### DIFF
--- a/include/seqan3/io/stream/debug_stream.hpp
+++ b/include/seqan3/io/stream/debug_stream.hpp
@@ -106,11 +106,11 @@ public:
      * \brief The standard functions are explicitly defaulted.
      * \{
      */
-    constexpr debug_stream_type() = default;
-    constexpr debug_stream_type(debug_stream_type const &) = default;
-    constexpr debug_stream_type(debug_stream_type &&) = default;
-    constexpr debug_stream_type & operator= (debug_stream_type const &) = default;
-    constexpr debug_stream_type & operator= (debug_stream_type &&) = default;
+    debug_stream_type() = default;
+    debug_stream_type(debug_stream_type const &) = default;
+    debug_stream_type(debug_stream_type &&) = default;
+    debug_stream_type & operator= (debug_stream_type const &) = default;
+    debug_stream_type & operator= (debug_stream_type &&) = default;
     ~debug_stream_type() = default;
 
     //!\brief Construction from an output stream.


### PR DESCRIPTION
clang complains with:
```
seqan3/include/seqan3/io/stream/debug_stream.hpp:112:5: error: defaulted definition of copy assignment operator is not constexpr
    constexpr debug_stream_type & operator= (debug_stream_type const &) = default;
    ^
seqan3/include/seqan3/io/stream/debug_stream.hpp:113:5: error: defaulted definition of move assignment operator is not constexpr
    constexpr debug_stream_type & operator= (debug_stream_type &&) = default;
    ^
```