### PR TITLE
[FEATURE] Updates different aspects of argument_parser

### DIFF
--- a/include/seqan3/argument_parser/all.hpp
+++ b/include/seqan3/argument_parser/all.hpp
@@ -65,6 +65,6 @@
  *
  * - seqan3::regex_validator
  * - seqan3::value_list_validator
- * - seqan3::integral_range_validator
+ * - seqan3::arithmetic_range_validator
  * - seqan3::file_ext_validator
  */

--- a/include/seqan3/argument_parser/argument_parser.hpp
+++ b/include/seqan3/argument_parser/argument_parser.hpp
@@ -578,6 +578,8 @@ private:
     */
     bool id_exists(std::string const & long_id)
     {
+        if (long_id.empty())
+            return false;
         return(!(used_option_ids.insert(long_id)).second);
     }
 
@@ -588,6 +590,8 @@ private:
     */
     bool id_exists(char const short_id)
     {
+        if (short_id == '\0')
+            return false;
         return(!(used_option_ids.insert(std::string(1, short_id))).second);
     }
 

--- a/include/seqan3/argument_parser/argument_parser.hpp
+++ b/include/seqan3/argument_parser/argument_parser.hpp
@@ -54,6 +54,7 @@
 #include <seqan3/argument_parser/detail/format_man.hpp>
 #include <seqan3/argument_parser/detail/format_parse.hpp>
 #include <seqan3/io/stream/concept.hpp>
+#include <seqan3/io/stream/parse_condition.hpp>
 
 namespace seqan3
 {

--- a/include/seqan3/argument_parser/argument_parser.hpp
+++ b/include/seqan3/argument_parser/argument_parser.hpp
@@ -608,7 +608,8 @@ private:
                  detail::format_ctd*/> format{detail::format_help(0)};
 
     //!\brief List of option/flag identifiers that are already used.
-    std::set<std::string> used_option_ids;
+    std::set<std::string> used_option_ids{"h", "hh", "help", "advanced-help", "export-help", "version"};
+
 };
 
 } // namespace seqan3

--- a/include/seqan3/argument_parser/argument_parser.hpp
+++ b/include/seqan3/argument_parser/argument_parser.hpp
@@ -221,6 +221,8 @@ public:
             throw parser_design_error("Option Identifier '" + std::string(1, short_id) + "' was already used before.");
         if (id_exists(long_id))
             throw parser_design_error("Option Identifier '" + long_id + "' was already used before.");
+        if (long_id.length() == 1)
+            throw parser_design_error("Long IDs must be either empty, or longer than one character.");
         if (short_id == '\0' && long_id.empty())
             throw parser_design_error("Option Identifiers cannot both be empty.");
 
@@ -249,6 +251,8 @@ public:
             throw parser_design_error("Option Identifier '" + std::string(1, short_id) + "' was already used before.");
         if (id_exists(long_id))
             throw parser_design_error("Option Identifier '" + long_id + "' was already used before.");
+        if (long_id.length() == 1)
+            throw parser_design_error("Long IDs must be either empty, or longer than one character.");
         if (short_id == '\0' && long_id.empty())
             throw parser_design_error("Option Identifiers cannot both be empty.");
 
@@ -609,7 +613,6 @@ private:
 
     //!\brief List of option/flag identifiers that are already used.
     std::set<std::string> used_option_ids{"h", "hh", "help", "advanced-help", "export-help", "version"};
-
 };
 
 } // namespace seqan3

--- a/include/seqan3/argument_parser/argument_parser.hpp
+++ b/include/seqan3/argument_parser/argument_parser.hpp
@@ -592,6 +592,7 @@ private:
     void verify_identifiers(char const short_id, std::string const & long_id)
     {
         auto constexpr allowed = is_alnum || is_char<'_'> || is_char<'@'>;
+
         if (id_exists(short_id))
             throw parser_design_error("Option Identifier '" + std::string(1, short_id) + "' was already used before.");
         if (id_exists(long_id))
@@ -602,11 +603,12 @@ private:
             throw parser_design_error("Option identifiers may only contain alphanumeric characters, '_', or '@'.");
         if (long_id.size() > 0 && is_char<'-'>(long_id[0]))
             throw parser_design_error("First character of long ID cannot be '-'.");
+
         std::for_each(long_id.begin(), long_id.end(), [&allowed] (char c)
-            {
-                if (!(allowed(c) || is_char<'-'>(c)))
-                    throw parser_design_error("Long identifiers may only contain alphanumeric characters, '_', '-', or '@'.");
-            });
+                      {
+                          if (!(allowed(c) || is_char<'-'>(c)))
+                              throw parser_design_error("Long identifiers may only contain alphanumeric characters, '_', '-', or '@'.");
+                      });
         if (short_id == '\0' && long_id.empty())
             throw parser_design_error("Option Identifiers cannot both be empty.");
     }

--- a/include/seqan3/argument_parser/argument_parser.hpp
+++ b/include/seqan3/argument_parser/argument_parser.hpp
@@ -202,8 +202,6 @@ public:
      * \param[in]  desc      The description of the option to be shown in the help page.
      * \param[in]  spec      Advanced option specification. see seqan3::option_spec.
      * \param[in]  validator The validator applied to the value after parsing (callable).
-     *
-     * \throws seqan3::parser_design_error
      */
     template <typename option_type, validator_concept validator_type = detail::default_validator<option_type>>
     //!\cond
@@ -218,15 +216,7 @@ public:
                     option_spec const & spec = option_spec::DEFAULT,
                     validator_type validator = validator_type{}) // copy to bind rvalues
     {
-        if (id_exists(short_id))
-            throw parser_design_error("Option Identifier '" + std::string(1, short_id) + "' was already used before.");
-        if (id_exists(long_id))
-            throw parser_design_error("Option Identifier '" + long_id + "' was already used before.");
-        if (long_id.length() == 1)
-            throw parser_design_error("Long IDs must be either empty, or longer than one character.");
-        if (short_id == '\0' && long_id.empty())
-            throw parser_design_error("Option Identifiers cannot both be empty.");
-
+        verify_identifiers(short_id, long_id);
         // copy variables into the lambda because the calls are pushed to a stack
         // and the references would go out of scope.
         std::visit([=, &value] (auto & f) { f.add_option(value, short_id, long_id, desc, spec, validator); }, format);
@@ -239,8 +229,6 @@ public:
      * \param[in]  long_id  The long identifier for the flag (e.g. "integer").
      * \param[in]  desc     The description of the flag to be shown in the help page.
      * \param[in]  spec     Advanced flag specification. see seqan3::option_spec.
-     *
-     * \throws seqan3::parser_design_error
      */
     void add_flag(bool & value,
                   char const short_id,
@@ -248,15 +236,7 @@ public:
                   std::string const & desc,
                   option_spec const & spec = option_spec::DEFAULT)
     {
-        if (id_exists(short_id))
-            throw parser_design_error("Option Identifier '" + std::string(1, short_id) + "' was already used before.");
-        if (id_exists(long_id))
-            throw parser_design_error("Option Identifier '" + long_id + "' was already used before.");
-        if (long_id.length() == 1)
-            throw parser_design_error("Long IDs must be either empty, or longer than one character.");
-        if (short_id == '\0' && long_id.empty())
-            throw parser_design_error("Option Identifiers cannot both be empty.");
-
+        verify_identifiers(short_id, long_id);
         // copy variables into the lambda because the calls are pushed to a stack
         // and the references would go out of scope.
         std::visit([=, &value] (auto & f) { f.add_flag(value, short_id, long_id, desc, spec); }, format);
@@ -598,6 +578,37 @@ private:
         if (short_id == '\0')
             return false;
         return(!(used_option_ids.insert(std::string(1, short_id))).second);
+    }
+
+    /*!\brief Verifies that the short and the long identifiers are correctly formatted.
+     * \param[in] short_id The short identifier of the command line option/flag.
+     * \param[in] long_id  The long identifier of the command line option/flag.
+     * \throws seqan3::parser_design_error
+     * \details Specifically, checks that identifiers haven't been used before,
+     *          the length of long IDs is either empty or longer than one char,
+     *          the characters used in the identifiers are all valid,
+     *          and at least one of short_id or long_id is given.
+     */
+    void verify_identifiers(char const short_id, std::string const & long_id)
+    {
+        auto constexpr allowed = is_alnum || is_char<'_'> || is_char<'@'>;
+        if (id_exists(short_id))
+            throw parser_design_error("Option Identifier '" + std::string(1, short_id) + "' was already used before.");
+        if (id_exists(long_id))
+            throw parser_design_error("Option Identifier '" + long_id + "' was already used before.");
+        if (long_id.length() == 1)
+            throw parser_design_error("Long IDs must be either empty, or longer than one character.");
+        if (!allowed(short_id) && !is_char<'\0'>(short_id))
+            throw parser_design_error("Option identifiers may only contain alphanumeric characters, '_', or '@'.");
+        if (long_id.size() > 0 && is_char<'-'>(long_id[0]))
+            throw parser_design_error("First character of long ID cannot be '-'.");
+        std::for_each(long_id.begin(), long_id.end(), [&allowed] (char c)
+            {
+                if (!(allowed(c) || is_char<'-'>(c)))
+                    throw parser_design_error("Long identifiers may only contain alphanumeric characters, '_', '-', or '@'.");
+            });
+        if (short_id == '\0' && long_id.empty())
+            throw parser_design_error("Option Identifiers cannot both be empty.");
     }
 
     /*!\brief The format of the argument parser that decides the behavior when

--- a/include/seqan3/argument_parser/validators.hpp
+++ b/include/seqan3/argument_parser/validators.hpp
@@ -110,14 +110,14 @@ concept validator_concept = std::Copyable<remove_cvref_t<validator_type>> &&
 
 //!\cond
 template <typename option_value_type>
-class integral_range_validator;
+class arithmetic_range_validator;
 //!\endcond
 
 /*!\brief A validator that checks whether a number is inside a given range.
  * \ingroup argument_parser
  * \implements seqan3::validator_concept
  *
- * \tparam option_value_type Must be a (container of) integral type(s).
+ * \tparam option_value_type Must be a (container of) arithmetic type(s).
  *
  * \details
  *
@@ -127,8 +127,8 @@ class integral_range_validator;
  *
  * \snippet test/snippet/argument_parser/validators_1.cpp usage
  */
-template <std::Integral option_value_type>
-class integral_range_validator<option_value_type>
+template <arithmetic_concept option_value_type>
+class arithmetic_range_validator<option_value_type>
 {
 public:
     //!\brief The type of value that this validator invoked upon.
@@ -138,7 +138,7 @@ public:
      * \param[in] min_ Minimum set for the range to test.
      * \param[in] max_ Maximum set for the range to test.
      */
-    integral_range_validator(value_type const min_, value_type const max_) :
+    arithmetic_range_validator(value_type const min_, value_type const max_) :
         min{min_}, max{max_}
     {}
 
@@ -169,8 +169,8 @@ private:
 
 //!\cond
 template <container_concept option_value_type>
-    requires std::Integral<typename option_value_type::value_type>
-class integral_range_validator<option_value_type>
+    requires arithmetic_concept<typename option_value_type::value_type>
+class arithmetic_range_validator<option_value_type>
 {
 public:
     //!\brief Type of values that are tested by validator (container)
@@ -182,7 +182,7 @@ public:
      * \param[in] min_ Minimum set for the range to test.
      * \param[in] max_ Maximum set for the range to test.
      */
-    integral_range_validator(inner_value_type const min_,
+    arithmetic_range_validator(inner_value_type const min_,
                              inner_value_type const max_) :
         min{min_}, max{max_}
     {}

--- a/include/seqan3/argument_parser/validators.hpp
+++ b/include/seqan3/argument_parser/validators.hpp
@@ -183,7 +183,7 @@ public:
      * \param[in] max_ Maximum set for the range to test.
      */
     arithmetic_range_validator(inner_value_type const min_,
-                             inner_value_type const max_) :
+                               inner_value_type const max_) :
         min{min_}, max{max_}
     {}
 

--- a/include/seqan3/argument_parser/validators.hpp
+++ b/include/seqan3/argument_parser/validators.hpp
@@ -44,6 +44,7 @@
 
 #include <seqan3/argument_parser/auxiliary.hpp>
 #include <seqan3/argument_parser/exceptions.hpp>
+#include <seqan3/core/concept/core_language.hpp>
 #include <seqan3/core/metafunction/basic.hpp>
 #include <seqan3/io/filesystem.hpp>
 #include <seqan3/range/container/concept.hpp>

--- a/test/snippet/argument_parser/validators_1.cpp
+++ b/test/snippet/argument_parser/validators_1.cpp
@@ -7,7 +7,7 @@ int main(int argc, const char ** argv)
     seqan3::argument_parser myparser("Test", argc, argv); // initialize
 
     int myint;
-    seqan3::integral_range_validator<int> my_validator{2, 10};
+    seqan3::arithmetic_range_validator<int> my_validator{2, 10};
 
     myparser.add_option(myint,'i',"integer","Give me a number.",
                         seqan3::option_spec::DEFAULT, my_validator);

--- a/test/unit/argument_parser/argument_parser_design_error_test.cpp
+++ b/test/unit/argument_parser/argument_parser_design_error_test.cpp
@@ -104,6 +104,15 @@ TEST(parse_test, parser_design_error)
                  parser_design_error);
     EXPECT_THROW(parser9.add_flag(flag_value, 'y', "z", "long identifier is one letter"),
                  parser_design_error);
+
+    // using non-printable characters
+    argument_parser parser10("test_parser", 1, argv);
+    EXPECT_THROW(parser10.add_option(option_value, '\t', "no\n", "tab and newline don't work!"),
+                 parser_design_error);
+    EXPECT_THROW(parser10.add_flag(flag_value, 'i', "no\n", "tab and newline don't work!"),
+                 parser_design_error);
+    EXPECT_THROW(parser10.add_flag(flag_value, 'a', "-no", "can't start long_id with a hyphen"),
+                 parser_design_error);
 }
 
 TEST(parse_test, parse_called_twice)

--- a/test/unit/argument_parser/argument_parser_design_error_test.cpp
+++ b/test/unit/argument_parser/argument_parser_design_error_test.cpp
@@ -97,6 +97,13 @@ TEST(parse_test, parser_design_error)
                  "advanced-help is bad"), parser_design_error);
     EXPECT_THROW(parser8.add_option(option_value, '\0', "export-help",
                  "export-help is bad"), parser_design_error);
+
+    // using one-letter long identifiers.
+    argument_parser parser9("test_parser", 1, argv);
+    EXPECT_THROW(parser9.add_option(option_value, 'y', "z", "long identifier is one letter"),
+                 parser_design_error);
+    EXPECT_THROW(parser9.add_flag(flag_value, 'y', "z", "long identifier is one letter"),
+                 parser_design_error);
 }
 
 TEST(parse_test, parse_called_twice)

--- a/test/unit/argument_parser/argument_parser_design_error_test.cpp
+++ b/test/unit/argument_parser/argument_parser_design_error_test.cpp
@@ -86,6 +86,17 @@ TEST(parse_test, parser_design_error)
     parser7.add_positional_option(vec, "oh oh list not at the end.");
     parser7.add_positional_option(option_value, "desc.");
     EXPECT_THROW(parser7.parse(), parser_design_error);
+
+    // using h, help, advanced-help, and export-help
+    argument_parser parser8("test_parser", 1, argv);
+    EXPECT_THROW(parser8.add_option(option_value, 'h', "", "-h is bad."),
+                 parser_design_error);
+    EXPECT_THROW(parser8.add_option(option_value, '\0', "help", "help is bad."),
+                 parser_design_error);
+    EXPECT_THROW(parser8.add_option(option_value, '\0', "advanced-help",
+                 "advanced-help is bad"), parser_design_error);
+    EXPECT_THROW(parser8.add_option(option_value, '\0', "export-help",
+                 "export-help is bad"), parser_design_error);
 }
 
 TEST(parse_test, parse_called_twice)

--- a/test/unit/argument_parser/format_parse_test.cpp
+++ b/test/unit/argument_parser/format_parse_test.cpp
@@ -762,3 +762,28 @@ TEST(parse_test, argv_const_combinations)
     EXPECT_NO_THROW(parser.parse());
     EXPECT_TRUE(flag_value);
 }
+
+TEST(parse_test, multiple_empty_options)
+{
+    int option_value;
+
+    {
+        const char * argv[]{"./empty_long", "-s=1"};
+        argument_parser parser("empty_long", 2, argv);
+        parser.add_option(option_value, 'i', "", "no long");
+        parser.add_option(option_value, 's', "", "no long");
+
+        EXPECT_NO_THROW(parser.parse());
+        EXPECT_EQ(1, option_value);
+    }
+
+    {
+        const char * argv[]{"./empty_short", "--long=2"};
+        argument_parser parser("empty_short", 2, argv);
+        parser.add_option(option_value, '\0', "longi", "no short");
+        parser.add_option(option_value, '\0', "long", "no short");
+
+        EXPECT_NO_THROW(parser.parse());
+        EXPECT_EQ(2, option_value);
+    }
+}

--- a/test/unit/argument_parser/format_parse_validators_test.cpp
+++ b/test/unit/argument_parser/format_parse_validators_test.cpp
@@ -55,12 +55,12 @@ TEST(validator_test, fullfill_concept)
     EXPECT_TRUE(validator_concept<detail::default_validator<int> const>);
     EXPECT_TRUE(validator_concept<detail::default_validator<int> &>);
 
-    EXPECT_TRUE(validator_concept<integral_range_validator<int>>);
+    EXPECT_TRUE(validator_concept<arithmetic_range_validator<int>>);
     EXPECT_TRUE(validator_concept<value_list_validator<int>>);
     EXPECT_TRUE(validator_concept<regex_validator<std::string>>);
     EXPECT_TRUE(validator_concept<regex_validator<std::vector<std::string>>>);
     EXPECT_TRUE(validator_concept<detail::default_validator<std::vector<int>>>);
-    EXPECT_TRUE(validator_concept<integral_range_validator<std::vector<int>>>);
+    EXPECT_TRUE(validator_concept<arithmetic_range_validator<std::vector<int>>>);
     EXPECT_TRUE(validator_concept<value_list_validator<std::vector<int>>>);
     EXPECT_TRUE(validator_concept<file_ext_validator>);
     EXPECT_TRUE(validator_concept<file_existance_validator>);
@@ -105,7 +105,7 @@ TEST(validator_test, file_exists)
     EXPECT_NO_THROW(parser.parse());
 }
 
-TEST(validator_test, integral_range_validator_success)
+TEST(validator_test, arithmetic_range_validator_success)
 {
     int option_value;
     std::vector<int> option_vector;
@@ -114,7 +114,7 @@ TEST(validator_test, integral_range_validator_success)
     const char * argv[] = {"./argument_parser_test", "-i", "10"};
     argument_parser parser("test_parser", 3, argv);
     parser.add_option(option_value, 'i', "int-option", "desc",
-                      option_spec::DEFAULT, integral_range_validator<int>(1,20));
+                      option_spec::DEFAULT, arithmetic_range_validator<int>(1,20));
 
     testing::internal::CaptureStderr();
     EXPECT_NO_THROW(parser.parse());
@@ -125,7 +125,7 @@ TEST(validator_test, integral_range_validator_success)
     const char * argv2[] = {"./argument_parser_test", "-i", "-10"};
     argument_parser parser2("test_parser", 3, argv2);
     parser2.add_option(option_value, 'i', "int-option", "desc",
-                       option_spec::DEFAULT, integral_range_validator<int>(-20,20));
+                       option_spec::DEFAULT, arithmetic_range_validator<int>(-20,20));
 
     testing::internal::CaptureStderr();
     EXPECT_NO_THROW(parser2.parse());
@@ -135,7 +135,7 @@ TEST(validator_test, integral_range_validator_success)
     // positional option
     const char * argv3[] = {"./argument_parser_test", "10"};
     argument_parser parser3("test_parser", 2, argv3);
-    parser3.add_positional_option(option_value, "desc", integral_range_validator<int>(1,20));
+    parser3.add_positional_option(option_value, "desc", arithmetic_range_validator<int>(1,20));
 
     testing::internal::CaptureStderr();
     EXPECT_NO_THROW(parser3.parse());
@@ -145,7 +145,7 @@ TEST(validator_test, integral_range_validator_success)
     // positional option - negative values
     const char * argv4[] = {"./argument_parser_test", "--", "-10"};
     argument_parser parser4("test_parser", 3, argv4);
-    parser4.add_positional_option(option_value, "desc", integral_range_validator<int>(-20,20));
+    parser4.add_positional_option(option_value, "desc", arithmetic_range_validator<int>(-20,20));
 
     testing::internal::CaptureStderr();
     EXPECT_NO_THROW(parser4.parse());
@@ -156,7 +156,7 @@ TEST(validator_test, integral_range_validator_success)
     const char * argv5[] = {"./argument_parser_test", "-i", "-10", "-i", "48"};
     argument_parser parser5("test_parser", 5, argv5);
     parser5.add_option(option_vector, 'i', "int-option", "desc",
-                       option_spec::DEFAULT, integral_range_validator<std::vector<int>>(-50,50));
+                       option_spec::DEFAULT, arithmetic_range_validator<std::vector<int>>(-50,50));
 
     testing::internal::CaptureStderr();
     EXPECT_NO_THROW(parser5.parse());
@@ -168,7 +168,7 @@ TEST(validator_test, integral_range_validator_success)
     option_vector.clear();
     const char * argv6[] = {"./argument_parser_test", "--", "-10", "1"};
     argument_parser parser6("test_parser", 4, argv6);
-    parser6.add_positional_option(option_vector, "desc", integral_range_validator<std::vector<int>>(-20,20));
+    parser6.add_positional_option(option_vector, "desc", arithmetic_range_validator<std::vector<int>>(-20,20));
 
     testing::internal::CaptureStderr();
     EXPECT_NO_THROW(parser6.parse());
@@ -180,7 +180,7 @@ TEST(validator_test, integral_range_validator_success)
     option_vector.clear();
     const char * argv7[] = {"./argument_parser_test", "-h"};
     argument_parser parser7("test_parser", 2, argv7);
-    parser7.add_positional_option(option_vector, "desc", integral_range_validator<std::vector<int>>(-20,20));
+    parser7.add_positional_option(option_vector, "desc", arithmetic_range_validator<std::vector<int>>(-20,20));
 
 
     testing::internal::CaptureStdout();
@@ -197,9 +197,21 @@ TEST(validator_test, integral_range_validator_success)
                            "    SeqAn version: ") + seqan3_version;
     EXPECT_TRUE(ranges::equal((stdout   | ranges::view::remove_if(is_space)),
                                expected | ranges::view::remove_if(is_space)));
+
+    // option - double value
+    double double_option_value;
+    const char * argv8[] = {"./argument_parser_test", "-i", "10.9"};
+    argument_parser parser8("test_parser", 3, argv8);
+    parser8.add_option(double_option_value, 'i', "double-option", "desc",
+                       option_spec::DEFAULT, arithmetic_range_validator<double>(1, 20));
+
+    testing::internal::CaptureStderr();
+    EXPECT_NO_THROW(parser8.parse());
+    EXPECT_TRUE((testing::internal::GetCapturedStderr()).empty());
+    EXPECT_EQ(double_option_value, 10.9);
 }
 
-TEST(validator_test, integral_range_validator_error)
+TEST(validator_test, arithmetic_range_validator_error)
 {
     int option_value;
     std::vector<int> option_vector;
@@ -208,7 +220,7 @@ TEST(validator_test, integral_range_validator_error)
     const char * argv[] = {"./argument_parser_test", "-i", "30"};
     argument_parser parser("test_parser", 3, argv);
     parser.add_option(option_value, 'i', "int-option", "desc",
-                      option_spec::DEFAULT, integral_range_validator<int>(1,20));
+                      option_spec::DEFAULT, arithmetic_range_validator<int>(1,20));
 
     EXPECT_THROW(parser.parse(), validation_failed);
 
@@ -216,21 +228,21 @@ TEST(validator_test, integral_range_validator_error)
     const char * argv2[] = {"./argument_parser_test", "-i", "-21"};
     argument_parser parser2("test_parser", 3, argv2);
     parser2.add_option(option_value, 'i', "int-option", "desc",
-                       option_spec::DEFAULT, integral_range_validator<int>(-20,20));
+                       option_spec::DEFAULT, arithmetic_range_validator<int>(-20,20));
 
     EXPECT_THROW(parser2.parse(), validation_failed);
 
     // positional option - above max
     const char * argv3[] = {"./argument_parser_test", "30"};
     argument_parser parser3("test_parser", 2, argv3);
-    parser3.add_positional_option(option_value, "desc", integral_range_validator<int>(1,20));
+    parser3.add_positional_option(option_value, "desc", arithmetic_range_validator<int>(1,20));
 
     EXPECT_THROW(parser3.parse(), validation_failed);
 
     // positional option - below min
     const char * argv4[] = {"./argument_parser_test", "--", "-21"};
     argument_parser parser4("test_parser", 3, argv4);
-    parser4.add_positional_option(option_value, "desc", integral_range_validator<int>(-20,20));
+    parser4.add_positional_option(option_value, "desc", arithmetic_range_validator<int>(-20,20));
 
     EXPECT_THROW(parser4.parse(), validation_failed);
 
@@ -238,7 +250,7 @@ TEST(validator_test, integral_range_validator_error)
     const char * argv5[] = {"./argument_parser_test", "-i", "-100"};
     argument_parser parser5("test_parser", 3, argv5);
     parser5.add_option(option_vector, 'i', "int-option", "desc",
-                       option_spec::DEFAULT, integral_range_validator<std::vector<int>>(-50,50));
+                       option_spec::DEFAULT, arithmetic_range_validator<std::vector<int>>(-50,50));
 
     EXPECT_THROW(parser5.parse(), validation_failed);
 
@@ -246,9 +258,18 @@ TEST(validator_test, integral_range_validator_error)
     option_vector.clear();
     const char * argv6[] = {"./argument_parser_test", "--", "-10", "100"};
     argument_parser parser6("test_parser", 4, argv6);
-    parser6.add_positional_option(option_vector, "desc", integral_range_validator<std::vector<int>>(-20,20));
+    parser6.add_positional_option(option_vector, "desc", arithmetic_range_validator<std::vector<int>>(-20,20));
 
     EXPECT_THROW(parser6.parse(), validation_failed);
+
+    // option - double value
+    double double_option_value;
+    const char * argv7[] = {"./argument_parser_test", "-i", "0.9"};
+    argument_parser parser7("test_parser", 3, argv7);
+    parser7.add_option(double_option_value, 'i', "double-option", "desc",
+                       option_spec::DEFAULT, arithmetic_range_validator<double>(1, 20));
+
+    EXPECT_THROW(parser7.parse(), validation_failed);
 }
 
 TEST(validator_test, value_list_validator_success)


### PR DESCRIPTION
1. Update integral_range_validator to arithmetic_range_validator, so that non-integer types (double, etc.) can still be validated. Also updates the snippet, and adds test cases for successful and unsuccessful uses of double.