### PR TITLE
[task] gap: remove unnecessary include

### DIFF
--- a/include/seqan3/alphabet/gap/gap.hpp
+++ b/include/seqan3/alphabet/gap/gap.hpp
@@ -42,7 +42,7 @@
 
 #include <cassert>
 
-#include <seqan3/alphabet/concept.hpp>
+#include <seqan3/core/platform.hpp>
 
 namespace seqan3
 {

--- a/test/snippet/alphabet/gap/gap.cpp
+++ b/test/snippet/alphabet/gap/gap.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 #include <seqan3/alphabet/gap/gap.hpp>
 
 using namespace seqan3;

--- a/test/unit/alphabet/gap/gap_test.cpp
+++ b/test/unit/alphabet/gap/gap_test.cpp
@@ -36,6 +36,7 @@
 
 #include <gtest/gtest.h>
 
+#include <seqan3/alphabet/concept.hpp>
 #include <seqan3/alphabet/gap/gap.hpp>
 
 using namespace seqan3;


### PR DESCRIPTION
The gap alphabet does not use `alphabet_concept`, so we should not include it.