### PR TITLE
Refactoring of alphabets

### DIFF
--- a/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
+++ b/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
@@ -140,7 +140,7 @@ template <typename t>
 concept aligned_sequence_concept =
     std::ranges::ForwardRange<t> &&
     alphabet_concept<value_type_t<t>> &&
-    std::Assignable<reference_t<t>, gap const &> &&
+    weakly_assignable_concept<reference_t<t>, gap const &> &&
     requires (t v)
     {
         { insert_gap(v, v.begin()) } -> typename t::iterator; // global functions for generic usability
@@ -177,7 +177,7 @@ concept aligned_sequence_concept =
  */
 template <sequence_container_concept seq_type>
 //!\cond
-    requires std::Assignable<reference_t<seq_type>, gap const &>
+    requires weakly_assignable_concept<reference_t<seq_type>, gap const &>
 //!\endcond
 inline typename seq_type::iterator insert_gap(seq_type & seq, typename seq_type::const_iterator pos_it)
 {
@@ -202,7 +202,7 @@ inline typename seq_type::iterator insert_gap(seq_type & seq, typename seq_type:
  */
 template <sequence_container_concept seq_type>
 //!\cond
-    requires std::Assignable<reference_t<seq_type>, gap const &>
+    requires weakly_assignable_concept<reference_t<seq_type>, gap const &>
 //!\endcond
 inline typename seq_type::iterator insert_gap(seq_type & seq, typename seq_type::const_iterator pos_it, typename seq_type::size_type count)
 {
@@ -229,7 +229,7 @@ inline typename seq_type::iterator insert_gap(seq_type & seq, typename seq_type:
  */
 template <sequence_container_concept seq_type>
 //!\cond
-    requires std::Assignable<reference_t<seq_type>, gap const &>
+    requires weakly_assignable_concept<reference_t<seq_type>, gap const &>
 //!\endcond
 inline typename seq_type::iterator erase_gap(seq_type & seq, typename seq_type::const_iterator pos_it)
 {
@@ -260,7 +260,7 @@ inline typename seq_type::iterator erase_gap(seq_type & seq, typename seq_type::
  */
 template <sequence_container_concept seq_type>
 //!\cond
-    requires std::Assignable<reference_t<seq_type>, gap const &>
+    requires weakly_assignable_concept<reference_t<seq_type>, gap const &>
 //!\endcond
 inline typename seq_type::iterator erase_gap(seq_type & seq, typename seq_type::const_iterator first, typename seq_type::const_iterator last)
 {

--- a/include/seqan3/alphabet/aminoacid/aa20.hpp
+++ b/include/seqan3/alphabet/aminoacid/aa20.hpp
@@ -39,12 +39,10 @@
 
 #pragma once
 
-#include <cassert>
 #include <vector>
 
-#include <seqan3/core/platform.hpp>
-#include <seqan3/alphabet/detail/convert.hpp>
-#include <seqan3/alphabet/aminoacid/concept.hpp>
+#include <seqan3/alphabet/aminoacid/aminoacid_base.hpp>
+#include <seqan3/io/stream/char_operations.hpp>
 
 namespace seqan3
 {
@@ -52,6 +50,8 @@ namespace seqan3
  * \ingroup aminoacid
  * \implements seqan3::aminoacid_concept
  * \implements seqan3::detail::constexpr_alphabet_concept
+ * \implements seqan3::trivially_copyable_concept
+ * \implements seqan3::standard_layout_concept
  *
  * \details
  * The alphabet consists of letters A, C, D, E, F, G, H, I, K, L, M, N, P, Q, R, S, T, V, W, Y
@@ -81,180 +81,35 @@ namespace seqan3
  *
  * \snippet test/snippet/alphabet/aminoacid/aa20.cpp construction
  */
-
-struct aa20
+class aa20 : public aminoacid_base<aa20, 20>
 {
-    //!\brief The type of the alphabet when converted to char (e.g. via to_char()).
-    using char_type = char;
+private:
+    //!\brief The base class.
+    using base_t = aminoacid_base<aa20, 20>;
 
-    //!\brief The type of the alphabet when represented as a number (e.g. via to_rank()).
-    using rank_type = uint8_t;
-
-
-    /*!\name Letter values
-     * \brief Static member "letters" that can be assigned to the alphabet or used in aggregate initialization.
-     * \details Similar to an Enum interface . *Don't worry about the `internal_type`.
-     */
-    //!\{
-    static const aa20 A;
-    static const aa20 B;
-    static const aa20 C;
-    static const aa20 D;
-    static const aa20 E;
-    static const aa20 F;
-    static const aa20 G;
-    static const aa20 H;
-    static const aa20 J;
-    static const aa20 I;
-    static const aa20 K;
-    static const aa20 L;
-    static const aa20 M;
-    static const aa20 N;
-    static const aa20 O;
-    static const aa20 P;
-    static const aa20 Q;
-    static const aa20 R;
-    static const aa20 S;
-    static const aa20 T;
-    static const aa20 U;
-    static const aa20 V;
-    static const aa20 W;
-    static const aa20 X;
-    static const aa20 Y;
-    static const aa20 Z;
-    static const aa20 TERMINATOR;
-    static const aa20 UNKNOWN;
-    //!\}
-
-    /*!\name Read functions
-     * \{
-     */
-    //!\brief Return the letter as a character of char_type.
-    constexpr char_type to_char() const noexcept
-    {
-        return value_to_char[static_cast<rank_type>(_value)];
-    }
-
-    //!\brief Return the letter's numeric value or rank in the alphabet.
-    constexpr rank_type to_rank() const noexcept
-    {
-        return static_cast<rank_type>(_value);
-    }
-    //!\}
-
-    /*!\name Write functions
-     * \{
-     */
-    //!\brief Assign from a character.
-    constexpr aa20 & assign_char(char_type const c) noexcept
-    {
-        using index_t = std::make_unsigned_t<char_type>;
-        _value = char_to_value[static_cast<index_t>(c)];
-        return *this;
-    }
-
-    //!\brief Assign from a numeric value.
-    constexpr aa20 & assign_rank(rank_type const c)
-    {
-        assert(c < value_size);
-        _value = static_cast<internal_type>(c);
-        return *this;
-    }
-    //!\}
-
-    //!\brief The size of the alphabet, i.e. the number of different values it can take.
-    static constexpr rank_type value_size{20};
-
-    /*!\name Conversion operators
-     * \{
-     */
-    //!\brief Explicit conversion to any other amino acid alphabet (via char representation).
-    //!\tparam other_aa_type The type to convert to; must satisfy seqan3::aminoacid_concept.
-    template <typename other_aa_type>
-    //!\cond
-        requires aminoacid_concept<other_aa_type>
+    //!\brief Befriend seqan3::aminoacid_base.
+    friend base_t;
+    //!\cond \brief Befriend seqan3::alphabet_base.
+    friend base_t::base_t;
     //!\endcond
-    explicit constexpr operator other_aa_type() const noexcept
-    {
-        return detail::convert_through_char_representation<other_aa_type, std::decay_t<decltype(*this)>>[to_rank()];
-    }
-    //!\}
 
-    //!\name Comparison operators
-    //!\{
-    constexpr bool operator==(aa20 const & rhs) const noexcept
-    {
-        return _value == rhs._value;
-    }
+public:
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    constexpr aa20() : base_t{} {}
+    constexpr aa20(aa20 const &) = default;
+    constexpr aa20(aa20 &&) = default;
+    constexpr aa20 & operator=(aa20 const &) = default;
+    constexpr aa20 & operator=(aa20 &&) = default;
+    ~aa20() = default;
 
-    constexpr bool operator!=(aa20 const & rhs) const noexcept
-    {
-        return _value != rhs._value;
-    }
-
-    constexpr bool operator<(aa20 const & rhs) const noexcept
-    {
-        return _value < rhs._value;
-    }
-
-    constexpr bool operator>(aa20 const & rhs) const noexcept
-    {
-        return _value > rhs._value;
-    }
-
-    constexpr bool operator<=(aa20 const & rhs) const noexcept
-    {
-        return _value <= rhs._value;
-    }
-
-    constexpr bool operator>=(aa20 const & rhs) const noexcept
-    {
-        return _value >= rhs._value;
-    }
+    using base_t::base_t;
     //!\}
 
 protected:
-    //!\privatesection
-    /*!\brief The internal type is a strictly typed enum.
-     *
-     * This is done to prevent aggregate initialization from numbers and/or chars.
-     * It is has the drawback that it also introduces a scope which in turn makes
-     * the static "letter values" members necessary.
-     */
-    enum struct internal_type : rank_type
-    {
-        A,
-        C,
-        D,
-        E,
-        F,
-        G,
-        H,
-        I,
-        K,
-        L,
-        M,
-        N,
-        P,
-        Q,
-        R,
-        S,
-        T,
-        V,
-        W,
-        Y,
-        B = D,
-        J = L,
-        O = L,
-        U = C,
-        X = S,
-        Z = E,
-        TERMINATOR = W,
-        UNKNOWN = S
-    };
-
     //!\brief Value to char conversion table.
-    static constexpr char_type value_to_char[value_size]
+    static constexpr char_type rank_to_char[value_size]
     {
         'A',
         'C',
@@ -279,83 +134,34 @@ protected:
     };
 
     //!\brief Char to value conversion table.
-    static constexpr std::array<internal_type, 256> char_to_value
+    static constexpr std::array<rank_type, 256> char_to_rank
     {
         [] () constexpr
         {
-            using in_t = internal_type;
-            std::array<in_t, 256> ret{};
+            std::array<rank_type, 256> ret{};
 
             // initialize with UNKNOWN (std::array::fill unfortunately not constexpr)
             for (auto & c : ret)
-                c = in_t::UNKNOWN;
+                c = 15; // value of 'S', because that appears most frequently
 
-            ret['A'] = in_t::A; ret['a'] = in_t::A;
-            ret['B'] = in_t::D; ret['b'] = in_t::D; // Convert b (either D/N) to D, since D occurs more frequently.
-            ret['C'] = in_t::C; ret['c'] = in_t::C;
-            ret['D'] = in_t::D; ret['d'] = in_t::D;
-            ret['E'] = in_t::E; ret['e'] = in_t::E;
-            ret['F'] = in_t::F; ret['f'] = in_t::F;
-            ret['G'] = in_t::G; ret['g'] = in_t::G;
-            ret['H'] = in_t::H; ret['h'] = in_t::H;
-            ret['I'] = in_t::I; ret['i'] = in_t::I;
-            ret['J'] = in_t::L; ret['j'] = in_t::L; // Convert j (either I/L) to L, since L occurs more frequently.
-            ret['K'] = in_t::K; ret['k'] = in_t::K;
-            ret['L'] = in_t::L; ret['l'] = in_t::L;
-            ret['M'] = in_t::M; ret['m'] = in_t::M;
-            ret['N'] = in_t::N; ret['n'] = in_t::N;
-            ret['O'] = in_t::L; ret['o'] = in_t::L; // Convert Pyrrolysine to lysine.
-            ret['P'] = in_t::P; ret['p'] = in_t::P;
-            ret['Q'] = in_t::Q; ret['q'] = in_t::Q;
-            ret['R'] = in_t::R; ret['r'] = in_t::R;
-            ret['S'] = in_t::S; ret['s'] = in_t::S;
-            ret['T'] = in_t::T; ret['t'] = in_t::T;
-            ret['U'] = in_t::C; ret['u'] = in_t::C; // Convert Selenocysteine to cysteine.
-            ret['V'] = in_t::V; ret['v'] = in_t::V;
-            ret['W'] = in_t::W; ret['w'] = in_t::W;
-            ret['X'] = in_t::S; ret['x'] = in_t::S; // Convert unknown amino acids to serine.
-            ret['Y'] = in_t::Y; ret['y'] = in_t::Y;
-            ret['Z'] = in_t::E; ret['z'] = in_t::E; // Convert z (either E/Q) to E, since E occurs more frequently.
-            ret['*'] = in_t::W; // The most common stop codon is UGA. This is most similar to a Tryptophan.
+            // reverse mapping for characters and their lowercase
+            for (rank_type rnk = 0u; rnk < value_size; ++rnk)
+            {
+                ret[static_cast<rank_type>(         rank_to_char[rnk]) ] = rnk;
+                ret[static_cast<rank_type>(to_lower(rank_to_char[rnk]))] = rnk;
+            }
+
+            ret['B'] = ret['D']; ret['b'] = ret['D']; // Convert b (either D/N) to D, since D occurs more frequently.
+            ret['J'] = ret['L']; ret['j'] = ret['L']; // Convert j (either I/L) to L, since L occurs more frequently.
+            ret['O'] = ret['L']; ret['o'] = ret['L']; // Convert Pyrrolysine to lysine.
+            ret['U'] = ret['C']; ret['u'] = ret['C']; // Convert Selenocysteine to cysteine.
+            ret['X'] = ret['S']; ret['x'] = ret['S']; // Convert unknown amino acids to serine.
+            ret['Z'] = ret['E']; ret['z'] = ret['E']; // Convert z (either E/Q) to E, since E occurs more frequently.
+            ret['*'] = ret['W']; // The most common stop codon is UGA. This is most similar to a Tryptophan.
             return ret;
         }()
     };
-
-public:
-    //!\privatesection
-    //!\brief The data member.
-    internal_type _value;
-    //!\publicsection
 };
-
-constexpr aa20 aa20::A{internal_type::A};
-constexpr aa20 aa20::C{internal_type::C};
-constexpr aa20 aa20::D{internal_type::D};
-constexpr aa20 aa20::E{internal_type::E};
-constexpr aa20 aa20::F{internal_type::F};
-constexpr aa20 aa20::G{internal_type::G};
-constexpr aa20 aa20::H{internal_type::H};
-constexpr aa20 aa20::I{internal_type::I};
-constexpr aa20 aa20::K{internal_type::K};
-constexpr aa20 aa20::L{internal_type::L};
-constexpr aa20 aa20::M{internal_type::M};
-constexpr aa20 aa20::N{internal_type::N};
-constexpr aa20 aa20::P{internal_type::P};
-constexpr aa20 aa20::Q{internal_type::Q};
-constexpr aa20 aa20::R{internal_type::R};
-constexpr aa20 aa20::S{internal_type::S};
-constexpr aa20 aa20::T{internal_type::T};
-constexpr aa20 aa20::V{internal_type::V};
-constexpr aa20 aa20::W{internal_type::W};
-constexpr aa20 aa20::Y{internal_type::Y};
-constexpr aa20 aa20::B{aa20::D};
-constexpr aa20 aa20::J{aa20::L};
-constexpr aa20 aa20::O{aa20::L};
-constexpr aa20 aa20::U{aa20::C};
-constexpr aa20 aa20::X{aa20::S};
-constexpr aa20 aa20::Z{aa20::E};
-constexpr aa20 aa20::TERMINATOR{aa20::W};
-constexpr aa20 aa20::UNKNOWN{aa20::S};
 
 } // namespace seqan3
 
@@ -375,7 +181,7 @@ using aa20_vector = std::vector<aa20>;
 // literals
 // ------------------------------------------------------------------
 
-namespace seqan3::literal
+namespace seqan3
 {
 
 /*!\brief aa20 literal
@@ -387,7 +193,7 @@ namespace seqan3::literal
  *\snippet test/snippet/alphabet/aminoacid/aa20.cpp literal
  *
  * \attention
- * All seqan3 literals are in the namespace seqan3::literal!
+ * All seqan3 literals are in the namespace seqan3!
  */
 
 inline aa20_vector operator""_aa20(const char * s, std::size_t n)
@@ -401,4 +207,4 @@ inline aa20_vector operator""_aa20(const char * s, std::size_t n)
     return r;
 }
 
-} // namespace seqan3::literal
+} // namespace seqan3

--- a/include/seqan3/alphabet/aminoacid/aa27.hpp
+++ b/include/seqan3/alphabet/aminoacid/aa27.hpp
@@ -39,13 +39,10 @@
 
 #pragma once
 
-#include <cassert>
-
 #include <vector>
 
-#include <seqan3/core/platform.hpp>
-#include <seqan3/alphabet/detail/convert.hpp>
-#include <seqan3/alphabet/aminoacid/concept.hpp>
+#include <seqan3/alphabet/aminoacid/aminoacid_base.hpp>
+#include <seqan3/io/stream/char_operations.hpp>
 
 namespace seqan3
 {
@@ -53,6 +50,8 @@ namespace seqan3
  * \ingroup aminoacid
  * \implements seqan3::aminoacid_concept
  * \implements seqan3::detail::constexpr_alphabet_concept
+ * \implements seqan3::trivially_copyable_concept
+ * \implements seqan3::standard_layout_concept
  *
  * \details
  * The alphabet consists of letters A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X,
@@ -65,179 +64,35 @@ namespace seqan3
  * \snippet test/snippet/alphabet/aminoacid/aa27.cpp construction
  */
 
-struct aa27
+class aa27 : public aminoacid_base<aa27, 27>
 {
-    //!\brief The type of the alphabet when converted to char (e.g. via to_char()).
-    using char_type = char;
+private:
+    //!\brief The base class.
+    using base_t = aminoacid_base<aa27, 27>;
 
-    //!\brief The type of the alphabet when represented as a number (e.g. via to_rank()).
-    using rank_type = uint8_t;
-
-
-    /*!\name Letter values
-     * \brief Static member "letters" that can be assigned to the alphabet or used in aggregate initialization.
-     * \details Similar to an Enum interface . *Don't worry about the `internal_type`.*
-     */
-    //!\{
-    static const aa27 A;
-    static const aa27 B;
-    static const aa27 C;
-    static const aa27 D;
-    static const aa27 E;
-    static const aa27 F;
-    static const aa27 G;
-    static const aa27 H;
-    static const aa27 I;
-    static const aa27 J;
-    static const aa27 K;
-    static const aa27 L;
-    static const aa27 M;
-    static const aa27 N;
-    static const aa27 O;
-    static const aa27 P;
-    static const aa27 Q;
-    static const aa27 R;
-    static const aa27 S;
-    static const aa27 T;
-    static const aa27 U;
-    static const aa27 V;
-    static const aa27 W;
-    static const aa27 X;
-    static const aa27 Y;
-    static const aa27 Z;
-    static const aa27 TERMINATOR;
-    static const aa27 UNKNOWN;
-    //!\}
-
-    /*!\name Read functions
-     * \{
-     */
-    //!\brief Return the letter as a character of char_type.
-    constexpr char_type to_char() const noexcept
-    {
-        return value_to_char[static_cast<rank_type>(_value)];
-    }
-
-    //!\brief Return the letter's numeric value or rank in the alphabet.
-    constexpr rank_type to_rank() const noexcept
-    {
-        return static_cast<rank_type>(_value);
-    }
-    //!\}
-
-    /*!\name Write functions
-     * \{
-     */
-    //!\brief Assign from a character.
-    constexpr aa27 & assign_char(char_type const c) noexcept
-    {
-        using index_t = std::make_unsigned_t<char_type>;
-        _value = char_to_value[static_cast<index_t>(c)];
-        return *this;
-    }
-
-    //!\brief Assign from a numeric value.
-    constexpr aa27 & assign_rank(rank_type const c)
-    {
-        assert(c < value_size);
-        _value = static_cast<internal_type>(c);
-        return *this;
-    }
-    //!\}
-
-    //!\brief The size of the alphabet, i.e. the number of different values it can take.
-    static constexpr rank_type value_size{27};
-
-    /*!\name Conversion operators
-     * \{
-     */
-    //!\brief Explicit conversion to any other amino acid alphabet (via char representation).
-    //!\tparam other_aa_type The type to convert to; must satisfy seqan3::aminoacid_concept.
-    template <typename other_aa_type>
-    //!\cond
-        requires aminoacid_concept<other_aa_type>
+    //!\brief Befriend seqan3::nucleotide_base.
+    friend base_t;
+    //!\cond \brief Befriend seqan3::alphabet_base.
+    friend base_t::base_t;
     //!\endcond
-    explicit constexpr operator other_aa_type() const noexcept
-    {
-        return detail::convert_through_char_representation<other_aa_type, std::decay_t<decltype(*this)>>[to_rank()];
-    }
-    //!\}
 
-    //!\name Comparison operators
-    //!\{
-    constexpr bool operator==(aa27 const & rhs) const noexcept
-    {
-        return _value == rhs._value;
-    }
+public:
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    constexpr aa27() : base_t{} {}
+    constexpr aa27(aa27 const &) = default;
+    constexpr aa27(aa27 &&) = default;
+    constexpr aa27 & operator=(aa27 const &) = default;
+    constexpr aa27 & operator=(aa27 &&) = default;
+    ~aa27() = default;
 
-    constexpr bool operator!=(aa27 const & rhs) const noexcept
-    {
-        return _value != rhs._value;
-    }
-
-    constexpr bool operator<(aa27 const & rhs) const noexcept
-    {
-        return _value < rhs._value;
-    }
-
-    constexpr bool operator>(aa27 const & rhs) const noexcept
-    {
-        return _value > rhs._value;
-    }
-
-    constexpr bool operator<=(aa27 const & rhs) const noexcept
-    {
-        return _value <= rhs._value;
-    }
-
-    constexpr bool operator>=(aa27 const & rhs) const noexcept
-    {
-        return _value >= rhs._value;
-    }
+    using base_t::base_t;
     //!\}
 
 protected:
-    //!\privatesection
-    /*!\brief The internal type is a strictly typed enum.
-     *
-     * This is done to prevent aggregate initialization from numbers and/or chars.
-     * It is has the drawback that it also introduces a scope which in turn makes
-     * the static "letter values " members necessary.
-     */
-    enum struct internal_type : rank_type
-    {
-        A,
-        B,
-        C,
-        D,
-        E,
-        F,
-        G,
-        H,
-        I,
-        J,
-        K,
-        L,
-        M,
-        N,
-        O,
-        P,
-        Q,
-        R,
-        S,
-        T,
-        U,
-        V,
-        W,
-        X,
-        Y,
-        Z,
-        TERMINATOR,
-        UNKNOWN = X
-    };
-
     //!\brief Value to char conversion table.
-    static constexpr char_type value_to_char[value_size]
+    static constexpr char_type rank_to_char[value_size]
     {
         'A',
         'B',
@@ -269,83 +124,27 @@ protected:
     };
 
     //!\brief Char to value conversion table.
-    static constexpr std::array<internal_type, 256> char_to_value
+    static constexpr std::array<rank_type, 256> char_to_rank
     {
         [] () constexpr
         {
-            using in_t = internal_type;
-            std::array<in_t, 256> ret{};
+            std::array<rank_type, 256> ret{};
 
             // initialize with UNKNOWN (std::array::fill unfortunately not constexpr)
             for (auto & c : ret)
-                c = in_t::UNKNOWN;
+                c = 23; // value of 'X'
 
-            ret['A'] = in_t::A; ret['a'] = in_t::A;
-            ret['B'] = in_t::B; ret['b'] = in_t::B;
-            ret['C'] = in_t::C; ret['c'] = in_t::C;
-            ret['D'] = in_t::D; ret['d'] = in_t::D;
-            ret['E'] = in_t::E; ret['e'] = in_t::E;
-            ret['F'] = in_t::F; ret['f'] = in_t::F;
-            ret['G'] = in_t::G; ret['g'] = in_t::G;
-            ret['H'] = in_t::H; ret['h'] = in_t::H;
-            ret['I'] = in_t::I; ret['i'] = in_t::I;
-            ret['J'] = in_t::J; ret['j'] = in_t::J;
-            ret['K'] = in_t::K; ret['k'] = in_t::K;
-            ret['L'] = in_t::L; ret['l'] = in_t::L;
-            ret['M'] = in_t::M; ret['m'] = in_t::M;
-            ret['N'] = in_t::N; ret['n'] = in_t::N;
-            ret['O'] = in_t::O; ret['o'] = in_t::O;
-            ret['P'] = in_t::P; ret['p'] = in_t::P;
-            ret['Q'] = in_t::Q; ret['q'] = in_t::Q;
-            ret['R'] = in_t::R; ret['r'] = in_t::R;
-            ret['S'] = in_t::S; ret['s'] = in_t::S;
-            ret['T'] = in_t::T; ret['t'] = in_t::T;
-            ret['U'] = in_t::U; ret['u'] = in_t::U;
-            ret['V'] = in_t::V; ret['v'] = in_t::V;
-            ret['W'] = in_t::W; ret['w'] = in_t::W;
-            ret['X'] = in_t::X; ret['x'] = in_t::X;
-            ret['Y'] = in_t::Y; ret['y'] = in_t::Y;
-            ret['Z'] = in_t::Z; ret['z'] = in_t::Z;
-            ret['*'] = in_t::TERMINATOR;
+            // reverse mapping for characters and their lowercase
+            for (rank_type rnk = 0u; rnk < value_size; ++rnk)
+            {
+                ret[static_cast<rank_type>(         rank_to_char[rnk]) ] = rnk;
+                ret[static_cast<rank_type>(to_lower(rank_to_char[rnk]))] = rnk;
+            }
+
             return ret;
         }()
     };
-
-public:
-    //!\privatesection
-    //!\brief The data member.
-    internal_type _value;
-    //!\publicsection
 };
-
-constexpr aa27 aa27::A{internal_type::A};
-constexpr aa27 aa27::B{internal_type::B};
-constexpr aa27 aa27::C{internal_type::C};
-constexpr aa27 aa27::D{internal_type::D};
-constexpr aa27 aa27::E{internal_type::E};
-constexpr aa27 aa27::F{internal_type::F};
-constexpr aa27 aa27::G{internal_type::G};
-constexpr aa27 aa27::H{internal_type::H};
-constexpr aa27 aa27::I{internal_type::I};
-constexpr aa27 aa27::J{internal_type::J};
-constexpr aa27 aa27::K{internal_type::K};
-constexpr aa27 aa27::L{internal_type::L};
-constexpr aa27 aa27::M{internal_type::M};
-constexpr aa27 aa27::N{internal_type::N};
-constexpr aa27 aa27::O{internal_type::O};
-constexpr aa27 aa27::P{internal_type::P};
-constexpr aa27 aa27::Q{internal_type::Q};
-constexpr aa27 aa27::R{internal_type::R};
-constexpr aa27 aa27::S{internal_type::S};
-constexpr aa27 aa27::T{internal_type::T};
-constexpr aa27 aa27::U{internal_type::U};
-constexpr aa27 aa27::V{internal_type::V};
-constexpr aa27 aa27::W{internal_type::W};
-constexpr aa27 aa27::X{internal_type::X};
-constexpr aa27 aa27::Y{internal_type::Y};
-constexpr aa27 aa27::Z{internal_type::Z};
-constexpr aa27 aa27::TERMINATOR{internal_type::TERMINATOR};
-constexpr aa27 aa27::UNKNOWN{aa27::X};
 
 } // namespace seqan3
 
@@ -365,7 +164,7 @@ using aa27_vector = std::vector<aa27>;
 // literals
 // ------------------------------------------------------------------
 
-namespace seqan3::literal
+namespace seqan3
 {
 
 /*!\brief aa27 literal
@@ -377,7 +176,7 @@ namespace seqan3::literal
  * \snippet test/snippet/alphabet/aminoacid/aa27.cpp literal
  *
  * \attention
- * All seqan3 literals are in the namespace seqan3::literal!
+ * All seqan3 literals are in the namespace seqan3!
  */
 
 inline aa27_vector operator""_aa27(const char * s, std::size_t n)
@@ -391,4 +190,4 @@ inline aa27_vector operator""_aa27(const char * s, std::size_t n)
     return r;
 }
 
-} // namespace seqan3::literal
+} // namespace seqan3

--- a/include/seqan3/alphabet/aminoacid/aminoacid_base.hpp
+++ b/include/seqan3/alphabet/aminoacid/aminoacid_base.hpp
@@ -1,0 +1,139 @@
+// ============================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ============================================================================
+//
+// Copyright (chr) 2006-2018, Knut Reinert & Freie Universitaet Berlin
+// Copyright (chr) 2016-2018, Knut Reinert & MPI Molekulare Genetik
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ============================================================================
+
+/*!\file
+ * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
+ * \brief Free function/metafunction wrappers for alphabets with member functions/types.
+ *
+ * This shall not need be included manually, just include `alphabet/concept.hpp`.
+ */
+
+#pragma once
+
+#include <seqan3/alphabet/detail/alphabet_base.hpp>
+#include <seqan3/alphabet/detail/convert.hpp>
+#include <seqan3/alphabet/aminoacid/concept.hpp>
+
+namespace seqan3
+{
+
+/*!\brief A CRTP-base that refines seqan3::alphabet_base and is used by the amino acids.
+ * \tparam derived_type The CRTP parameter type.
+ * \tparam size         The size of the alphabet.
+ * \tparam char_t       The character type of the alphabet (set this to `void` when defining just a
+ *                      seqan3::semi_alphabet_concept).
+ */
+template <typename derived_type, auto size, typename char_t = char>
+class aminoacid_base : public alphabet_base<derived_type, size, char_t>
+{
+private:
+    //!\brief Type of the base class.
+    using base_t = alphabet_base<derived_type, size, char_t>;
+
+    //!\brief Befriend the base class.
+    friend base_t;
+
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    constexpr aminoacid_base() : base_t{} {}
+    constexpr aminoacid_base(aminoacid_base const &) = default;
+    constexpr aminoacid_base(aminoacid_base &&) = default;
+    constexpr aminoacid_base & operator=(aminoacid_base const &) = default;
+    constexpr aminoacid_base & operator=(aminoacid_base &&) = default;
+    //!\}
+
+    //!\brief Befriend the derived class so it can instantiate.
+    friend derived_type;
+
+public:
+
+    // Import from base:
+    using typename base_t::char_type;
+    using typename base_t::rank_type;
+    using base_t::value_size;
+    using base_t::to_rank;
+
+    /*!\name Letter values
+     * \brief Static member "letters" that can be assigned to the alphabet or used in aggregate initialization.
+     * \details Similar to an Enum interface.
+     */
+    //!\{
+    static derived_type constexpr A          = assign_char(derived_type{}, 'A');
+    static derived_type constexpr B          = assign_char(derived_type{}, 'B');
+    static derived_type constexpr C          = assign_char(derived_type{}, 'C');
+    static derived_type constexpr D          = assign_char(derived_type{}, 'D');
+    static derived_type constexpr E          = assign_char(derived_type{}, 'E');
+    static derived_type constexpr F          = assign_char(derived_type{}, 'F');
+    static derived_type constexpr G          = assign_char(derived_type{}, 'G');
+    static derived_type constexpr H          = assign_char(derived_type{}, 'H');
+    static derived_type constexpr I          = assign_char(derived_type{}, 'I');
+    static derived_type constexpr J          = assign_char(derived_type{}, 'J');
+    static derived_type constexpr K          = assign_char(derived_type{}, 'K');
+    static derived_type constexpr L          = assign_char(derived_type{}, 'L');
+    static derived_type constexpr M          = assign_char(derived_type{}, 'M');
+    static derived_type constexpr N          = assign_char(derived_type{}, 'N');
+    static derived_type constexpr O          = assign_char(derived_type{}, 'O');
+    static derived_type constexpr P          = assign_char(derived_type{}, 'P');
+    static derived_type constexpr Q          = assign_char(derived_type{}, 'Q');
+    static derived_type constexpr R          = assign_char(derived_type{}, 'R');
+    static derived_type constexpr S          = assign_char(derived_type{}, 'S');
+    static derived_type constexpr T          = assign_char(derived_type{}, 'T');
+    static derived_type constexpr U          = assign_char(derived_type{}, 'U');
+    static derived_type constexpr V          = assign_char(derived_type{}, 'V');
+    static derived_type constexpr W          = assign_char(derived_type{}, 'W');
+    static derived_type constexpr X          = assign_char(derived_type{}, 'X');
+    static derived_type constexpr Y          = assign_char(derived_type{}, 'Y');
+    static derived_type constexpr Z          = assign_char(derived_type{}, 'Z');
+    static derived_type constexpr TERMINATOR = assign_char(derived_type{}, '*');
+    static derived_type constexpr UNKNOWN    = X;
+    //!\}
+
+    /*!\name Conversion operators
+     * \{
+     */
+    //!\brief Explicit conversion to any other aminoacid alphabet (via char representation).
+    //!\tparam other_aa_type The type to convert to; must satisfy seqan3::aminoacid_concept.
+    template <typename other_aa_type>
+    //!\cond
+        requires !std::Same<derived_type, other_aa_type> && aminoacid_concept<other_aa_type>
+    //!\endcond
+    explicit constexpr operator other_aa_type() const noexcept
+    {
+        return detail::convert_through_char_representation<other_aa_type, derived_type>[to_rank()];
+    }
+    //!\}
+};
+
+} // namespace seqan3

--- a/include/seqan3/alphabet/aminoacid/translation.hpp
+++ b/include/seqan3/alphabet/aminoacid/translation.hpp
@@ -52,6 +52,15 @@
 
 namespace seqan3
 {
+
+// forwards:
+class dna4;
+class dna5;
+class dna15;
+class rna4;
+class rna5;
+class rna15;
+
 /*!\brief Translate one nucleotide triplet into single amino acid (single nucleotide interface).
  * \tparam nucl_type The type of input nucleotides.
  * \param[in] n1 First nucleotide in triplet.
@@ -73,7 +82,28 @@ namespace seqan3
 template <genetic_code gc = genetic_code::CANONICAL, nucleotide_concept nucl_type>
 constexpr aa27 translate_triplet(nucl_type const & n1, nucl_type const & n2, nucl_type const & n3) noexcept
 {
-    return seqan3::detail::translation_table<nucl_type, gc>::VALUE[to_rank(n1)][to_rank(n2)][to_rank(n3)];
+    if constexpr (std::Same<nucl_type, dna4> || std::Same<nucl_type, dna5> || std::Same<nucl_type, dna15>)
+    {
+        // table exists for dna15 and is generated for dna4 and dna5 (compile time ok, because small)
+        return seqan3::detail::translation_table<nucl_type, gc>::VALUE[to_rank(n1)][to_rank(n2)][to_rank(n3)];
+    }
+    else if constexpr (std::Same<nucl_type, rna4> || std::Same<nucl_type, rna5> || std::Same<nucl_type, rna15>)
+    {
+        using rna2dna_t = std::conditional_t<std::Same<nucl_type, rna4>,  dna4,
+                          std::conditional_t<std::Same<nucl_type, rna5>,  dna5,
+                          std::conditional_t<std::Same<nucl_type, rna15>, dna15, void>>>;
+
+        // we can use dna's tables, because ranks are identical
+        return seqan3::detail::translation_table<rna2dna_t, gc>::VALUE[to_rank(n1)][to_rank(n2)][to_rank(n3)];
+    }
+    else // composites or user defined nucleotide
+    {
+        // we cast to dna15; slightly slower run-time, but lot's of compile time saved for large alphabets.
+        // (nucleotide types can be converted to dna15 by definition)
+        return seqan3::detail::translation_table<dna15, gc>::VALUE[to_rank(static_cast<dna15>(n1))]
+                                                                  [to_rank(static_cast<dna15>(n2))]
+                                                                  [to_rank(static_cast<dna15>(n3))];
+    }
 }
 
 /*!\brief Translate one nucleotide triplet into single amino acid (tuple interface).

--- a/include/seqan3/alphabet/composition/cartesian_composition.hpp
+++ b/include/seqan3/alphabet/composition/cartesian_composition.hpp
@@ -34,7 +34,7 @@
 
 /*!\file
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
- * \brief Contains cartesian_composition.
+ * \brief Provides seqan3::cartesian_composition.
  */
 
 #pragma once
@@ -45,13 +45,129 @@
 #include <meta/meta.hpp>
 
 #include <seqan3/alphabet/concept.hpp>
+#include <seqan3/alphabet/composition/detail.hpp>
+#include <seqan3/alphabet/detail/alphabet_base.hpp>
+#include <seqan3/alphabet/detail/alphabet_proxy.hpp>
 #include <seqan3/alphabet/quality/concept.hpp>
-#include <seqan3/core/pod_tuple.hpp>
+#include <seqan3/core/concept/core_language.hpp>
+#include <seqan3/core/concept/tuple.hpp>
 #include <seqan3/core/detail/int_types.hpp>
+#include <seqan3/core/metafunction/pack.hpp>
+#include <seqan3/core/metafunction/transformation_trait_or.hpp>
+#include <seqan3/core/tuple_utility.hpp>
 #include <seqan3/std/concepts>
+
+namespace seqan3::detail
+{
+
+/*!\brief Evaluates to true if one of the components of seqan3::cartesian_composition satisifes a compile-time
+ *        predicate.
+ * \tparam cartesian_t         A specialisation of seqan3::cartesian_composition.
+ * \tparam cartesian_derived_t The CRTP derived type of `cartesian_t`.
+ * \tparam fun_t               A template template that takes target_t as argument and exposes an `invoke` member type
+ *                             that evaluates some predicate and returns `std::true_type` or `std::false_type`.
+ * \tparam target_t            The type you wish to query.
+ * \ingroup composition
+ *
+ * \details
+ *
+ * To prevent recursive template and/or concept instantiation this call needs to be guarded against many exceptions.
+ * See the source file for more details.
+ */
+
+// anchor is false
+template <typename cartesian_t, typename cartesian_derived_t, template <typename> typename fun_t, typename other_t>
+inline bool constexpr one_component_is = false;
+
+//!\cond
+
+// default
+template <typename ... cartesian_comps,
+          typename cartesian_derived_t,
+          template <typename> typename fun_t,
+          typename other_t>
+inline bool constexpr one_component_is<cartesian_composition<cartesian_derived_t, cartesian_comps...>,
+                                       cartesian_derived_t,
+                                       fun_t,
+                                       other_t> =
+    !meta::empty<meta::find_if<meta::list<cartesian_comps...>, fun_t<other_t>>>::value;
+    //TODO do without meta
+
+// guard against self
+template <typename ... cartesian_comps,
+          typename cartesian_derived_t,
+          template <typename> typename fun_t>
+inline bool constexpr one_component_is<cartesian_composition<cartesian_derived_t, cartesian_comps...>,
+                                       cartesian_derived_t,
+                                       fun_t,
+                                       cartesian_composition<cartesian_derived_t, cartesian_comps...>> = false;
+
+// guard against self (derived)
+template <typename ... cartesian_comps,
+          typename cartesian_derived_t,
+          template <typename> typename fun_t>
+inline bool constexpr one_component_is<cartesian_composition<cartesian_derived_t, cartesian_comps...>,
+                                       cartesian_derived_t,
+                                       fun_t,
+                                       cartesian_derived_t> = false;
+
+// guard against types that have conversion operators to derived
+template <typename ... cartesian_comps,
+          typename cartesian_derived_t,
+          template <typename> typename fun_t,
+          typename other_t>
+    requires convertible_to_by_member_concept<other_t, cartesian_derived_t>
+inline bool constexpr one_component_is<cartesian_composition<cartesian_derived_t, cartesian_comps...>,
+                                       cartesian_derived_t,
+                                       fun_t,
+                                       other_t> = false;
+
+// guard against components
+template <typename ... cartesian_comps,
+          typename cartesian_derived_t,
+          template <typename> typename fun_t,
+          typename other_t>
+    requires type_in_pack_v<other_t, cartesian_comps...>
+//     requires meta::in<recursive_cartesian_components<cartesian_composition<cartesian_derived_t, cartesian_comps...>>::type,
+//                       other_t>::value
+inline bool constexpr one_component_is<cartesian_composition<cartesian_derived_t, cartesian_comps...>,
+                                       cartesian_derived_t,
+                                       fun_t,
+                                       other_t> = false;
+
+// during comparisons, guard against types that could be converted to self (because that is preferred)
+// (may not be done during assignment or construction because of recursiveness)
+template <typename ... cartesian_comps,
+          typename cartesian_derived_t,
+          typename other_t>
+    requires implicitly_convertible_to_concept<other_t, cartesian_derived_t>
+inline bool constexpr one_component_is<cartesian_composition<cartesian_derived_t, cartesian_comps...>,
+                                       cartesian_derived_t,
+                                       weakly_equality_comparable_with,
+                                       other_t> = false;
+template <typename ... cartesian_comps,
+          typename cartesian_derived_t,
+          typename other_t>
+    requires implicitly_convertible_to_concept<other_t, cartesian_derived_t>
+inline bool constexpr one_component_is<cartesian_composition<cartesian_derived_t, cartesian_comps...>,
+                                       cartesian_derived_t,
+                                       weakly_ordered_with,
+                                       other_t> = false;
+//!\endcond
+
+} // namespace seqan3::detail
 
 namespace seqan3
 {
+
+// forwards
+//!\cond
+template <typename t>
+decltype(auto) get();
+
+template <size_t i>
+decltype(auto) get();
+//!\endcond
 
 /*!\brief The CRTP base for a combined alphabet that contains multiple values of different alphabets at the same time.
  * \ingroup composition
@@ -61,11 +177,11 @@ namespace seqan3
  * \tparam component_types      Types of further letters (up to 4); must model seqan3::semi_alphabet_concept.
  *
  * This data structure is CRTP base class for combined alphabets, where the different
- * alphabet letters exist independently as components, similar to a tuple.
+ * alphabet letters exist independently as component_list, similar to a tuple.
  *
  * Short description:
- *   * combines multiple alphabets as independent components, similar to a tuple;
- *   * models seqan3::tuple_like_concept, i.e. provides a std::get interface to its components;
+ *   * combines multiple alphabets as independent component_list, similar to a tuple;
+ *   * models seqan3::tuple_like_concept, i.e. provides a get interface to its component_list;
  *   * is itself a seqan3::semi_alphabet_concept, but most derived types implement the full seqan3::alphabet_concept;
  *   * its alphabet size is the product of the individual sizes;
  *   * constructible, assignable and comparable with each component type and also all types that
@@ -86,104 +202,103 @@ namespace seqan3
  * \sa masked
  */
 template <typename derived_type,
-          typename first_component_type,
           typename ...component_types>
 //!\cond
-    requires detail::constexpr_semi_alphabet_concept<first_component_type> &&
-             (detail::constexpr_semi_alphabet_concept<component_types> && ...)
+    requires (detail::constexpr_semi_alphabet_concept<component_types> && ...)
 //!\endcond
-class cartesian_composition : public pod_tuple<first_component_type, component_types...>
+class cartesian_composition :
+    public alphabet_base<derived_type,
+                         (1 * ... * alphabet_size_v<component_types>),
+                         void> // no char type, because this is only semi_alphabet
 {
 private:
     //!\brief The base type of this class.
-    using base_t = pod_tuple<first_component_type, component_types...>;
+    using base_t = alphabet_base<derived_type,
+                                (1 * ... * alphabet_size_v<component_types>),
+                                void>; // no char type, because this is only semi_alphabet
 
     //!\brief A meta::list The types of each component in the composition
-    using components = meta::list<first_component_type, component_types...>;
+    using component_list = meta::list<component_types...>;
 
     //!\brief Is set to `true` if the type is contained in the type list.
     template <typename type>
     static constexpr bool is_component =
-        meta::in<components, type>::value;
+        meta::in<component_list, type>::value;
 
     //!\brief Is set to `true` if the type is uniquely contained in the type list.
     template <typename type>
     static constexpr bool is_unique_component =
         is_component<type> &&
-        (meta::find_index<components, type>::value == meta::reverse_find_index<components, type>::value);
+        (meta::find_index<component_list, type>::value == meta::reverse_find_index<component_list, type>::value);
 
-    /*!\brief 'Callable' helper class that is invokable by meta::invoke.
-      * Returns an std::true_type if the `type` is constructable from `T`.
-      */
-    template <typename T>
-    struct constructible_from
+    /*!\brief Specialisation of seqan3::alphabet_proxy that updates the rank of the cartesian_composition.
+     * \tparam alphabet_type The type of the emulated component.
+     * \tparam index         The index of the emulated component.
+     */
+    template <typename alphabet_type, size_t index>
+    class component_proxy : public alphabet_proxy<component_proxy<alphabet_type, index>, alphabet_type>
     {
-        //!\brief The returned type when invoked.
-        template <typename type>
-        using invoke = std::integral_constant<bool, std::is_constructible_v<type, T>>;
-    };
+    private:
+        //!\brief The base type.
+        using base_t = alphabet_proxy<component_proxy<alphabet_type, index>, alphabet_type>;
+        //!\brief Befriend the base type so it can call our #on_update().
+        friend base_t;
 
-    /*!\brief 'Callable' helper class that is invokable by meta::invoke.
-      * Returns an std::true_type if the `T` is implicitly convertible to `type`.
-      */
-    template <typename T>
-    struct implicitely_convertible_from
-    {
-        //!\brief The returned type when invoked.
-        template <typename type>
-        using invoke = std::integral_constant<bool, implicitly_convertible_to_concept<T, type>>;
-    };
+        //!\brief Store a pointer to the parent object so we can update it.
+        cartesian_composition *parent;
 
-    /*!\brief 'Callable' helper class that is invokable by meta::invoke.
-      * Returns an std::true_type if the `type` is assignable from `T`.
-      */
-    template <typename T>
-    struct assignable_from
-    {
-        //!\brief The returned type when invoked.
-        template <typename type>
-        using invoke = std::integral_constant<bool, std::Assignable<type, T>>;
-    };
+        //!\brief The implementation updates the rank in the parent object.
+        constexpr void on_update() noexcept
+        {
+            parent->assign_rank(
+                parent->to_rank()
+                - parent->template to_component_rank<index>() * cartesian_composition::cummulative_alph_sizes[index]
+                + to_rank() * cartesian_composition::cummulative_alph_sizes[index]);
+        }
 
-    /*!\brief 'Callable' helper class that is invokable by meta::invoke.
-      * Returns an std::true_type if the `type` is weakly equality comparable to `T`.
-      */
-    template <typename T>
-    struct weakly_equality_comparable_with
-    {
-        //!\brief The returned type when invoked.
-        template <typename type>
-        using invoke = std::integral_constant<bool, std::detail::WeaklyEqualityComparableWith<type, T>>;
-    };
+    public:
+        //Import from base type:
+        using base_t::to_rank;
+        using base_t::value_size;
+        using base_t::operator=;
 
-    /*!\brief 'Callable' helper class that is invokable by meta::invoke.
-      * Returns an std::true_type if the `type` is comparable via <,<=,>,>= to `T`.
-      */
-    template <typename T>
-    struct weakly_ordered_with
-    {
-        //!\brief The returned type when invoked.
-        template <typename type>
-        using invoke = std::integral_constant<bool, weakly_ordered_with_concept<type, T>>;
-    };
+        /*!\name Associated types
+         * \{
+         */
+        using typename base_t::rank_type;
+        using typename base_t::char_type;
+        using typename base_t::phred_type;
+        //!\}
 
-    //!\brief Is set to `true` if the one component type fulfils the FUN callable with `subtype`.
-    template <template <typename> typename FUN, typename subtype>
-    static constexpr bool one_component_is =
-         !std::is_same_v<subtype, cartesian_composition> &&
-         !std::is_same_v<subtype, derived_type> &&
-         !is_component<subtype> &&
-         !meta::empty<meta::find_if<components, FUN<subtype>>>::value;
+        /*!\name Constructors, destructor and assignment
+         * \{
+         */
+        constexpr component_proxy() : base_t{}, parent{} {}
+        constexpr component_proxy(component_proxy const &) = default;
+        constexpr component_proxy(component_proxy &&) = default;
+        constexpr component_proxy & operator=(component_proxy const &) = default;
+        constexpr component_proxy & operator=(component_proxy &&) = default;
+        ~component_proxy() = default;
+
+        constexpr component_proxy(alphabet_type const l, cartesian_composition & p) :
+            base_t{l}, parent{&p}
+        {}
+
+        // Does not inherit the base's constructor for alphabet_type so as not to cause ambiguity
+        //!\}
+    };
 
     /*!\name Constructors, destructor and assignment
      * \{
      */
-    cartesian_composition() = default;
+    constexpr cartesian_composition() : base_t{} {}
     constexpr cartesian_composition(cartesian_composition const &) = default;
     constexpr cartesian_composition(cartesian_composition &&) = default;
     constexpr cartesian_composition & operator=(cartesian_composition const &) = default;
     constexpr cartesian_composition & operator=(cartesian_composition &&) = default;
     ~cartesian_composition() = default;
+
+    using base_t::base_t;
     //!\}
 
     //!\brief befriend the derived type so that it can instantiate
@@ -191,13 +306,21 @@ private:
     friend derived_type;
 
 public:
-    //!\brief The type of value_size and `alphabet_size_v<cartesian_composition<...>>`
-    using rank_type = detail::min_viable_uint_t<(alphabet_size_v<first_component_type> * ... *
-                                                     alphabet_size_v<component_types>)>;
+    // Import from base:
+    using base_t::value_size;
+    using typename base_t::rank_type;
+    using base_t::to_rank;
+    using base_t::assign_rank;
 
-    //!\brief The product of the sizes of the individual alphabets.
-    static constexpr rank_type value_size{(alphabet_size_v<first_component_type> * ... *
-                                               alphabet_size_v<component_types>)};
+    //!\brief Export this type's components in a visible manner.
+    //!\private
+    using seqan3_cartesian_components = component_list;
+    //!\brief Export this type's components and possibly the components' components in a visible manner.
+    //!\private
+    using seqan3_recursive_cartesian_components =
+        meta::concat<component_list,
+                     detail::transformation_trait_or_t<detail::recursive_cartesian_components<component_types>,
+                                                       meta::list<>>...>;
 
     /*!\name Constructors, destructor and assignment
      * \{
@@ -207,9 +330,10 @@ public:
      *            seqan3::structure_aa).
      */
     //!\brief Construction from initialiser-list.
-    constexpr cartesian_composition(first_component_type first, component_types ... others) :
-        base_t{first, others...}
-    {}
+    constexpr cartesian_composition(component_types ... components)
+    {
+        assign_rank(rank_sum_helper(components..., std::make_index_sequence<sizeof...(component_types)>{}));
+    }
 
     /*!\brief Construction via a value of one of the components.
      * \tparam component_type Must be one uniquely contained in the type
@@ -224,7 +348,7 @@ public:
     //!\cond
         requires is_unique_component<component_type>
     //!\endcond
-    constexpr cartesian_composition(component_type const alph) : cartesian_composition{}
+    constexpr explicit cartesian_composition(component_type const alph) : cartesian_composition{}
     {
         get<component_type>(*this) = alph;
     }
@@ -244,22 +368,22 @@ public:
      */
     template <typename indirect_component_type>
     //!\cond
-       requires one_component_is<implicitely_convertible_from, indirect_component_type>
+       requires detail::one_component_is<cartesian_composition, derived_type, detail::implicitly_convertible_from, indirect_component_type>
     //!\endcond
-    constexpr cartesian_composition(indirect_component_type const alph) : cartesian_composition{}
+    constexpr explicit cartesian_composition(indirect_component_type const alph) : cartesian_composition{}
     {
-       using component_type = meta::front<meta::find_if<components, implicitely_convertible_from<indirect_component_type>>>;
+       using component_type = meta::front<meta::find_if<component_list, detail::implicitly_convertible_from<indirect_component_type>>>;
        component_type tmp(alph); // delegate construction
        get<component_type>(*this) = tmp;
     }
 
     //!\cond
     template <typename indirect_component_type>
-       requires !one_component_is<implicitely_convertible_from, indirect_component_type> &&
-                 one_component_is<constructible_from, indirect_component_type>
-    constexpr cartesian_composition(indirect_component_type const alph) : cartesian_composition{}
+       requires !detail::one_component_is<cartesian_composition, derived_type, detail::implicitly_convertible_from, indirect_component_type> &&
+                 detail::one_component_is<cartesian_composition, derived_type, detail::constructible_from, indirect_component_type>
+    constexpr explicit cartesian_composition(indirect_component_type const alph) : cartesian_composition{}
     {
-       using component_type = meta::front<meta::find_if<components, constructible_from<indirect_component_type>>>;
+       using component_type = meta::front<meta::find_if<component_list, detail::constructible_from<indirect_component_type>>>;
        component_type tmp(alph); // delegate construction
        get<component_type>(*this) = tmp;
     }
@@ -295,11 +419,11 @@ public:
      */
     template <typename indirect_component_type>
     //!\cond
-        requires one_component_is<assignable_from, indirect_component_type>
+        requires detail::one_component_is<cartesian_composition, derived_type, detail::assignable_from, indirect_component_type>
     //!\endcond
     constexpr derived_type & operator=(indirect_component_type const alph)
     {
-        using component_type = meta::front<meta::find_if<components, assignable_from<indirect_component_type>>>;
+        using component_type = meta::front<meta::find_if<component_list, detail::assignable_from<indirect_component_type>>>;
         get<component_type>(*this) = alph; // delegate assignment
         return static_cast<derived_type &>(*this);
     }
@@ -307,12 +431,12 @@ public:
     // If not assignable but implicit convertible, convert first and assign afterwards
     template <typename indirect_component_type>
     //!\cond
-        requires !one_component_is<assignable_from, indirect_component_type> &&
-                 one_component_is<implicitely_convertible_from, indirect_component_type>
+        requires !detail::one_component_is<cartesian_composition, derived_type, detail::assignable_from, indirect_component_type> &&
+                 detail::one_component_is<cartesian_composition, derived_type, detail::implicitly_convertible_from, indirect_component_type>
     //!\endcond
     constexpr derived_type & operator=(indirect_component_type const alph)
     {
-        using component_type = meta::front<meta::find_if<components, implicitely_convertible_from<indirect_component_type>>>;
+        using component_type = meta::front<meta::find_if<component_list, detail::implicitly_convertible_from<indirect_component_type>>>;
         component_type tmp(alph);
         get<component_type>(*this) = tmp;
         return static_cast<derived_type &>(*this);
@@ -321,23 +445,75 @@ public:
     //!\}
 
     /*!\name Read functions
+     * \brief All read operations are constant complexity.
      * \{
      */
-    /*!\brief Return the letter combination's numeric value (or "rank") in the alphabet composition.
-     * \par Complexity
-     * Linear in the number of alphabets.
+    /*!\brief Tuple-like access to the contained components.
+     * \tparam index Return the i-th element.
+     * \returns A proxy to the contained element that models the same alphabets concepts and supports assignment.
      */
-    constexpr rank_type to_rank() const
+    template <size_t index>
+    friend constexpr auto get(cartesian_composition & l)
     {
-        return to_rank_impl(positions);
+        static_assert(index < sizeof...(component_types), "Index out of range.");
+
+        using t = meta::at_c<component_list, index>;
+        t val{};
+
+        using seqan3::assign_rank;
+        assign_rank(val, l.to_component_rank<index>());
+
+        return component_proxy<t, index>{val, l};
     }
 
-    /*!\brief Explicit cast to a single letter. Works only if the type is unique in the type list.
-     * \par Complexity
-     * Linear in the number of alphabets.
+    /*!\copybrief get
+     * \tparam type Return the element of specified type; only available if the type is unique in the set of components.
+     * \returns A proxy to the contained element that models the same alphabets concepts and supports assignment.
      */
     template <typename type>
-    constexpr explicit operator type() const
+    friend constexpr auto get(cartesian_composition & l)
+    //!\cond
+        requires is_unique_component<type>
+    //!\endcond
+    {
+        return get<meta::find_index<component_list, type>::value>(l);
+    }
+
+    /*!\copybrief get
+     * \tparam index Return the i-th element.
+     * \returns A copy of the contained element.
+     */
+    template <size_t index>
+    friend constexpr auto get(cartesian_composition const & l)
+    {
+        static_assert(index < sizeof...(component_types), "Index out of range.");
+
+        using t = meta::at_c<component_list, index>;
+        t val{};
+
+        using seqan3::assign_rank;
+        assign_rank(val, l.to_component_rank<index>());
+
+        return val;
+    }
+
+    /*!\copybrief get
+     * \tparam type Return the element of specified type; only available if the type is unique in the set of components.
+     * \returns A copy of the contained element.
+     */
+    template <typename type>
+    friend constexpr type get(cartesian_composition const & l)
+    //!\cond
+        requires is_unique_component<type>
+    //!\endcond
+    {
+        return get<meta::find_index<component_list, type>::value>(l);
+    }
+
+    /*!\brief Implicit cast to a single letter. Works only if the type is unique in the type list.
+     */
+    template <typename type>
+    constexpr operator type() const
     //!\cond
         requires is_unique_component<type>
     //!\endcond
@@ -346,215 +522,112 @@ public:
     }
     //!\}
 
-    /*!\name Write functions
-     * \{
-     */
-    /*!\brief Assign from a numeric value.
-     * \par Complexity
-     * Linear in the number of alphabets.
-     * \par Exceptions
-     * Asserts that the parameter is smaller than value_size [only in debug mode].
-     */
-    constexpr derived_type & assign_rank(rank_type const i)
-    {
-        assert(i < value_size);
-        assign_rank_impl<0>(i);
-        return static_cast<derived_type &>(*this);
-    }
-    //!\}
-
-    // Inherit default comparators explicitly from base class
-    using base_t::operator==;
-    using base_t::operator!=;
-    using base_t::operator<;
-    using base_t::operator>;
-    using base_t::operator<=;
-    using base_t::operator>=;
-
-    /*!\name Comparison operators (against components)
-     * \brief `*this` is cast to the component type before comparison.
-     * \{
-     */
-    template <typename component_type>
-    //!\cond
-        requires is_unique_component<component_type>
-    //!\endcond
-    constexpr bool operator==(component_type const & rhs) const noexcept
-    {
-        return std::get<component_type>(*this) == rhs;
-    }
-
-    template <typename component_type>
-    //!\cond
-        requires is_unique_component<component_type>
-    //!\endcond
-    constexpr bool operator!=(component_type const & rhs) const noexcept
-    {
-        return std::get<component_type>(*this) != rhs;
-    }
-
-    template <typename component_type>
-    //!\cond
-        requires is_unique_component<component_type>
-    //!\endcond
-    constexpr bool operator<(component_type const & rhs) const noexcept
-    {
-        return std::get<component_type>(*this) < rhs;
-    }
-
-    template <typename component_type>
-    //!\cond
-        requires is_unique_component<component_type>
-    //!\endcond
-    constexpr bool operator>(component_type const & rhs) const noexcept
-    {
-        return std::get<component_type>(*this) > rhs;
-    }
-
-    template <typename component_type>
-    //!\cond
-        requires is_unique_component<component_type>
-    //!\endcond
-    constexpr bool operator<=(component_type const & rhs) const noexcept
-    {
-        return std::get<component_type>(*this) <= rhs;
-    }
-
-    template <typename component_type>
-    //!\cond
-        requires is_unique_component<component_type>
-    //!\endcond
-    constexpr bool operator>=(component_type const & rhs) const noexcept
-    {
-        return std::get<component_type>(*this) >= rhs;
-    }
-    //!\}
-
-    /*!\name Comparison operators (against indirect components)
+    /*!\name Comparison operators (against indirect component_list)
      * \brief `*this` is cast to the component type before comparison. (These overloads enable comparison for all types
      *        that a component type is comparable with).
      * \{
      */
     template <typename indirect_component_type>
-    constexpr bool operator==(indirect_component_type const rhs) const noexcept
+    constexpr bool operator==(indirect_component_type const & rhs) const noexcept
     //!\cond
-        requires one_component_is<weakly_equality_comparable_with, indirect_component_type>
+        requires detail::one_component_is<cartesian_composition, derived_type, detail::weakly_equality_comparable_with, indirect_component_type>
     //!\endcond
     {
-        using component_type = meta::front<meta::find_if<components, weakly_equality_comparable_with<indirect_component_type>>>;
+        using component_type = meta::front<meta::find_if<component_list, detail::weakly_equality_comparable_with<indirect_component_type>>>;
         return get<component_type>(*this) == rhs;
     }
 
     template <typename indirect_component_type>
     constexpr bool operator!=(indirect_component_type const & rhs) const noexcept
     //!\cond
-        requires one_component_is<weakly_equality_comparable_with, indirect_component_type>
+        requires detail::one_component_is<cartesian_composition, derived_type, detail::weakly_equality_comparable_with, indirect_component_type>
     //!\endcond
     {
-        using component_type = meta::front<meta::find_if<components, weakly_equality_comparable_with<indirect_component_type>>>;
+        using component_type = meta::front<meta::find_if<component_list, detail::weakly_equality_comparable_with<indirect_component_type>>>;
         return get<component_type>(*this) != rhs;
     }
 
     template <typename indirect_component_type>
     constexpr bool operator<(indirect_component_type const & rhs) const noexcept
     //!\cond
-        requires one_component_is<weakly_ordered_with, indirect_component_type>
+        requires detail::one_component_is<cartesian_composition, derived_type, detail::weakly_ordered_with, indirect_component_type>
     //!\endcond
     {
-        using component_type = meta::front<meta::find_if<components, weakly_ordered_with<indirect_component_type>>>;
+        using component_type = meta::front<meta::find_if<component_list, detail::weakly_ordered_with<indirect_component_type>>>;
         return get<component_type>(*this) < rhs;
     }
 
     template <typename indirect_component_type>
     constexpr bool operator>(indirect_component_type const & rhs) const noexcept
     //!\cond
-        requires one_component_is<weakly_ordered_with, indirect_component_type>
+        requires detail::one_component_is<cartesian_composition, derived_type, detail::weakly_ordered_with, indirect_component_type>
     //!\endcond
     {
-        using component_type = meta::front<meta::find_if<components, weakly_ordered_with<indirect_component_type>>>;
+        using component_type = meta::front<meta::find_if<component_list, detail::weakly_ordered_with<indirect_component_type>>>;
         return get<component_type>(*this) > rhs;
     }
 
     template <typename indirect_component_type>
     constexpr bool operator<=(indirect_component_type const & rhs) const noexcept
     //!\cond
-        requires one_component_is<weakly_ordered_with, indirect_component_type>
+        requires detail::one_component_is<cartesian_composition, derived_type, detail::weakly_ordered_with, indirect_component_type>
     //!\endcond
     {
-        using component_type = meta::front<meta::find_if<components, weakly_ordered_with<indirect_component_type>>>;
+        using component_type = meta::front<meta::find_if<component_list, detail::weakly_ordered_with<indirect_component_type>>>;
         return get<component_type>(*this) <= rhs;
     }
 
     template <typename indirect_component_type>
     constexpr bool operator>=(indirect_component_type const & rhs) const noexcept
     //!\cond
-        requires one_component_is<weakly_ordered_with, indirect_component_type>
+        requires detail::one_component_is<cartesian_composition, derived_type, detail::weakly_ordered_with, indirect_component_type>
     //!\endcond
     {
-        using component_type = meta::front<meta::find_if<components, weakly_ordered_with<indirect_component_type>>>;
+        using component_type = meta::front<meta::find_if<component_list, detail::weakly_ordered_with<indirect_component_type>>>;
         return get<component_type>(*this) >= rhs;
     }
     //!\}
 
 private:
+    //!\brief Return the rank of the i-th component.
+    template <size_t index>
+    constexpr rank_type to_component_rank() const
+    {
+        return (to_rank() / cummulative_alph_sizes[index]) % alphabet_size_v<meta::at_c<component_list, index>>;
+    }
 
-    //!\brief the cumulative alphabet size products (first, first*second, first*second*third...) are cached
-    static constexpr std::array<rank_type, sizeof...(component_types) + 1> cummulative_alph_sizes
+    //!\brief the cumulative alphabet size products are cached
+    static constexpr std::array<rank_type, component_list::size()> cummulative_alph_sizes
     {
         [] () constexpr
         {
-            std::array<rank_type, sizeof...(component_types) + 1> ret{};
-            size_t count = 0;
-            meta::for_each(meta::list<first_component_type, component_types...>{}, [&] (auto && alph) constexpr
+            // create array (1, |sigma1|, |sigma1|*|sigma2|,  ... ,  |sigma1|*...*|sigmaN|)
+            std::array<rank_type, component_list::size() + 1> ret{};
+            ret[0] = 1;
+            size_t count = 1;
+            meta::for_each(meta::reverse<component_list>{}, [&] (auto && alph) constexpr
             {
-                ret[count] = static_cast<rank_type>(
-                    alphabet_size_v<std::decay_t<decltype(alph)>> * (count > 0 ? ret[count - 1] : 1));
+                ret[count] = static_cast<rank_type>(alphabet_size_v<std::decay_t<decltype(alph)>> * ret[count - 1]);
                 ++count;
             });
 
-            return std::move(ret);
+            // reverse and strip one: (|sigma1|*...*|sigmaN-1|, ... |sigma1|*|sigma2|, |sigma1|, 1)
+            // reverse order guarantees that the first alphabet is the most significant rank contributer
+            // resulting in element-wise alphabetical ordering on comparison
+            std::array<rank_type, component_list::size()> ret2{};
+            for (size_t i = 0; i < component_list::size(); ++i)
+                ret2[i] = ret[component_list::size() - i - 1];
+
+            return ret2;
         }()
     };
 
-    //!\brief An index sequence up to the number of contained letters.
-    static constexpr auto positions = std::make_index_sequence<sizeof...(component_types)>{};
-
-    //!\brief Implementation of to_rank().
+    //!\brief For the given components, compute the combined rank.
     template <std::size_t ...idx>
-    constexpr rank_type to_rank_impl(std::index_sequence<idx...> const &) const
+    static constexpr rank_type rank_sum_helper(component_types ... components, std::index_sequence<idx...> const &)
     {
         using seqan3::to_rank;
-        if constexpr (sizeof...(idx) > 0)
-        {
-            return static_cast<rank_type>(
-                to_rank(get<0>(*this)) +
-                ((to_rank(get<idx + 1>(*this)) * cummulative_alph_sizes[idx]) + ...));
-        }
-        else
-        {
-            return to_rank(get<0>(*this));
-        }
-    }
-
-    //!\brief Implementation of assign_rank().
-    template <std::size_t j>
-    constexpr void
-    assign_rank_impl(rank_type const i)
-    {
-        using seqan3::assign_rank;
-        if constexpr (j == 0)
-        {
-            assign_rank(get<j>(*this),
-                          i % alphabet_size_v<meta::at_c<meta::list<first_component_type, component_types...>, j>>);
-        } else
-        {
-            assign_rank(get<j>(*this),
-                          (i / cummulative_alph_sizes[j - 1]) %
-                          alphabet_size_v<meta::at_c<meta::list<first_component_type, component_types...>, j>>);
-        }
-
-        if constexpr (j < sizeof...(component_types))
-            assign_rank_impl<j + 1>(i);
+        return ((to_rank(components) * cummulative_alph_sizes[idx]) + ...);
     }
 };
 
@@ -563,71 +636,92 @@ private:
  * \{
  * \brief Free function comparison operators that forward to member operators (for types != self).
  */
-template <typename component_type, typename derived_type, typename first_component_type, typename ...component_types>
+template <typename indirect_component_type, typename derived_type, typename ...component_types>
 //!\cond
-    requires detail::weakly_equality_comparable_by_members_with_concept<derived_type, component_type> &&
-             !detail::weakly_equality_comparable_by_members_with_concept<component_type, derived_type>
+    requires detail::weakly_equality_comparable_by_members_with_concept<derived_type, indirect_component_type> &&
+             !detail::weakly_equality_comparable_by_members_with_concept<indirect_component_type, derived_type>
 //!\endcond
-constexpr bool operator==(component_type const & lhs,
-                          cartesian_composition<derived_type, first_component_type, component_types...> const & rhs)
+constexpr bool operator==(indirect_component_type const & lhs,
+                          cartesian_composition<derived_type, component_types...> const & rhs)
 {
     return rhs == lhs;
 }
 
-template <typename component_type, typename derived_type, typename first_component_type, typename ...component_types>
+template <typename indirect_component_type, typename derived_type, typename ...indirect_component_types>
 //!\cond
-    requires detail::weakly_equality_comparable_by_members_with_concept<derived_type, component_type> &&
-             !detail::weakly_equality_comparable_by_members_with_concept<component_type, derived_type>
+    requires detail::weakly_equality_comparable_by_members_with_concept<derived_type, indirect_component_type> &&
+             !detail::weakly_equality_comparable_by_members_with_concept<indirect_component_type, derived_type>
 //!\endcond
-constexpr bool operator!=(component_type const & lhs,
-                          cartesian_composition<derived_type, first_component_type, component_types...> const & rhs)
+constexpr bool operator!=(indirect_component_type const & lhs,
+                          cartesian_composition<derived_type, indirect_component_types...> const & rhs)
 {
     return rhs != lhs;
 }
 
-template <typename component_type, typename derived_type, typename first_component_type, typename ...component_types>
+template <typename indirect_component_type, typename derived_type, typename ...indirect_component_types>
 //!\cond
-    requires detail::weakly_ordered_by_members_with_concept<derived_type, component_type> &&
-             !detail::weakly_ordered_by_members_with_concept<component_type, derived_type>
+    requires detail::weakly_ordered_by_members_with_concept<derived_type, indirect_component_type> &&
+             !detail::weakly_ordered_by_members_with_concept<indirect_component_type, derived_type>
 //!\endcond
-constexpr bool operator<(component_type const & lhs,
-                         cartesian_composition<derived_type, first_component_type, component_types...> const & rhs)
+constexpr bool operator<(indirect_component_type const & lhs,
+                         cartesian_composition<derived_type, indirect_component_types...> const & rhs)
 {
     return rhs > lhs;
 }
 
-template <typename component_type, typename derived_type, typename first_component_type, typename ...component_types>
+template <typename indirect_component_type, typename derived_type, typename ...indirect_component_types>
 //!\cond
-    requires detail::weakly_ordered_by_members_with_concept<derived_type, component_type> &&
-             !detail::weakly_ordered_by_members_with_concept<component_type, derived_type>
+    requires detail::weakly_ordered_by_members_with_concept<derived_type, indirect_component_type> &&
+             !detail::weakly_ordered_by_members_with_concept<indirect_component_type, derived_type>
 //!\endcond
-constexpr bool operator>(component_type const & lhs,
-                         cartesian_composition<derived_type, first_component_type, component_types...> const & rhs)
+constexpr bool operator>(indirect_component_type const & lhs,
+                         cartesian_composition<derived_type, indirect_component_types...> const & rhs)
 {
     return rhs < lhs;
 }
 
-template <typename component_type, typename derived_type, typename first_component_type, typename ...component_types>
+template <typename indirect_component_type, typename derived_type, typename ...indirect_component_types>
 //!\cond
-    requires detail::weakly_ordered_by_members_with_concept<derived_type, component_type> &&
-             !detail::weakly_ordered_by_members_with_concept<component_type, derived_type>
+    requires detail::weakly_ordered_by_members_with_concept<derived_type, indirect_component_type> &&
+             !detail::weakly_ordered_by_members_with_concept<indirect_component_type, derived_type>
 //!\endcond
-constexpr bool operator<=(component_type const & lhs,
-                          cartesian_composition<derived_type, first_component_type, component_types...> const & rhs)
+constexpr bool operator<=(indirect_component_type const & lhs,
+                          cartesian_composition<derived_type, indirect_component_types...> const & rhs)
 {
     return rhs >= lhs;
 }
 
-template <typename component_type, typename derived_type, typename first_component_type, typename ...component_types>
+template <typename indirect_component_type, typename derived_type, typename ...indirect_component_types>
 //!\cond
-    requires detail::weakly_ordered_by_members_with_concept<derived_type, component_type> &&
-             !detail::weakly_ordered_by_members_with_concept<component_type, derived_type>
+    requires detail::weakly_ordered_by_members_with_concept<derived_type, indirect_component_type> &&
+             !detail::weakly_ordered_by_members_with_concept<indirect_component_type, derived_type>
 //!\endcond
-constexpr bool operator>=(component_type const & lhs,
-                          cartesian_composition<derived_type, first_component_type, component_types...> const & rhs)
+constexpr bool operator>=(indirect_component_type const & lhs,
+                          cartesian_composition<derived_type, indirect_component_types...> const & rhs)
 {
     return rhs <= lhs;
 }
 //!\}
 
 } // namespace seqan3
+
+namespace std
+{
+
+//!\brief Obtains the type of the specified element.
+//!\relates seqan3::pod_tuple
+template <std::size_t i, seqan3::detail::cartesian_composition_concept tuple_t>
+struct tuple_element<i, tuple_t>
+{
+    //!\brief Element type.
+    using type = meta::at_c<typename tuple_t::seqan3_cartesian_components, i>;
+};
+
+//!\brief Provides access to the number of elements in a tuple as a compile-time constant expression.
+//!\relates seqan3::pod_tuple
+template <seqan3::detail::cartesian_composition_concept tuple_t>
+struct tuple_size<tuple_t> :
+    public std::integral_constant<size_t, tuple_t::seqan3_cartesian_components::size()>
+{};
+
+} // namespace std

--- a/include/seqan3/alphabet/composition/detail.hpp
+++ b/include/seqan3/alphabet/composition/detail.hpp
@@ -1,0 +1,203 @@
+// ==========================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ==========================================================================
+//
+// Copyright (c) 2006-2018, Knut Reinert, FU Berlin
+// Copyright (c) 2016-2018, Knut Reinert & MPI Molekulare Genetik
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ==========================================================================
+
+/*!\file
+ * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
+ * \brief Provides implementation detail for seqan3::union_composition and seqan3::cartesian_composition.
+ */
+
+#pragma once
+
+#include <type_traits>
+
+#include <seqan3/core/platform.hpp>
+
+namespace seqan3::detail
+{
+
+// ------------------------------------------------------------------
+// cartesian_composition_concept
+// ------------------------------------------------------------------
+
+/*!\interface seqan3::detail::cartesian_composition_concept <>
+ * \extends seqan3::semi_alphabet_concept
+ * \brief seqan3::cartesian_composition and its specialisations model this concept.
+ * \ingroup alphabet
+ *
+ * \details
+ *
+ * This concept is necessary/helpful, because CRTP-specialisations cannot be tracked via regular inheritance or
+ * specialisation mechanisms.
+ */
+//!\cond
+template <typename t>
+concept cartesian_composition_concept = requires
+{
+    typename t::seqan3_cartesian_components;
+    typename t::seqan3_recursive_cartesian_components;
+};
+//!\endcond
+
+// ------------------------------------------------------------------
+// cartesian_components
+// ------------------------------------------------------------------
+
+/*!\brief Exposes for seqan3::cartesian_composition its components as a meta::list [base template].
+ * \extends seqan3::TransformationTrait
+ * \ingroup alphabet
+ */
+template <typename t>
+struct cartesian_components;
+
+/*!\brief Exposes for seqan3::cartesian_composition its components as a meta::list
+ *        [specialisation for seqan3::cartesian_composition].
+ * \extends seqan3::TransformationTrait
+ * \ingroup alphabet
+ */
+template <cartesian_composition_concept t>
+struct cartesian_components<t>
+{
+    //!\brief The returned type.
+    using type = typename t::seqan3_cartesian_components;
+};
+
+// ------------------------------------------------------------------
+// recursive_cartesian_components
+// ------------------------------------------------------------------
+
+/*!\brief Exposes for seqan3::cartesian_composition its components and those components' components (in the case of
+ *        nested compositions) as a meta::list [base template].
+ * \extends seqan3::TransformationTrait
+ * \ingroup alphabet
+ */
+template <typename t>
+struct recursive_cartesian_components;
+
+/*!\brief Exposes for seqan3::cartesian_composition its components and those components' components (in the case of
+ *        nested compositions) as a meta::list [specialisation for seqan3::cartesian_composition].
+ * \extends seqan3::TransformationTrait
+ * \ingroup alphabet
+ */
+template <cartesian_composition_concept t>
+struct recursive_cartesian_components<t>
+{
+    //!\brief The returned type.
+    using type = typename t::seqan3_recursive_cartesian_components;
+};
+
+// ------------------------------------------------------------------
+// Callable concept helpers for meta::invoke
+// ------------------------------------------------------------------
+
+/*!\brief 'Callable' helper class that is invokable by meta::invoke.
+ * Returns an std::true_type if the `type` is constructable from `T`.
+ */
+template <typename T>
+struct constructible_from
+{
+    //!\brief The returned type when invoked.
+    template <typename type>
+    using invoke = std::integral_constant<bool, std::is_constructible_v<type, T>>;
+};
+
+/*!\brief 'Callable' helper class that is invokable by meta::invoke.
+ * Returns an std::true_type if the `T` is implicitly convertible to `type`.
+ */
+template <typename T>
+struct implicitly_convertible_from
+{
+    //!\brief The returned type when invoked.
+    template <typename type>
+    using invoke = std::integral_constant<bool, implicitly_convertible_to_concept<T, type>>;
+};
+
+/*!\brief 'Callable' helper class that is invokable by meta::invoke.
+ * Returns an std::true_type if the `type` is assignable from `T`.
+ */
+template <typename T>
+struct assignable_from
+{
+    //!\brief The returned type when invoked.
+    template <typename type>
+    using invoke = std::integral_constant<bool, weakly_assignable_concept<type, T>>;
+};
+
+/*!\brief 'Callable' helper class that is invokable by meta::invoke.
+ * Returns an std::true_type if the `type` is weakly equality comparable to `T`.
+ */
+template <typename T>
+struct weakly_equality_comparable_with
+{
+    //!\brief The returned type when invoked.
+    template <typename type>
+    using invoke = std::integral_constant<bool, std::detail::WeaklyEqualityComparableWith<type, T>>;
+};
+
+/*!\brief 'Callable' helper class that is invokable by meta::invoke.
+ * Returns an std::true_type if the `type` is comparable via <,<=,>,>= to `T`.
+ */
+template <typename T>
+struct weakly_ordered_with
+{
+    //!\brief The returned type when invoked.
+    template <typename type>
+    using invoke = std::integral_constant<bool, weakly_ordered_with_concept<type, T>>;
+};
+
+} // namespace seqan3::detail
+
+// ------------------------------------------------------------------
+// Forwards
+// ------------------------------------------------------------------
+
+namespace seqan3
+{
+
+// forward
+template <typename ...alternative_types>
+//!\cond
+    requires (detail::constexpr_alphabet_concept<alternative_types> && ...) &&
+             (sizeof...(alternative_types) >= 2)
+             //TODO same char_type
+//!\endcond
+class union_composition;
+
+template <typename derived_type,
+          typename ...component_types>
+//!\cond
+    requires (detail::constexpr_semi_alphabet_concept<component_types> && ...)
+//!\endcond
+class cartesian_composition;
+
+} // namespace seqan3

--- a/include/seqan3/alphabet/detail/alphabet_base.hpp
+++ b/include/seqan3/alphabet/detail/alphabet_base.hpp
@@ -1,0 +1,251 @@
+// ============================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ============================================================================
+//
+// Copyright (chr) 2006-2018, Knut Reinert & Freie Universitaet Berlin
+// Copyright (chr) 2016-2018, Knut Reinert & MPI Molekulare Genetik
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ============================================================================
+
+/*!\file
+ * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
+ * \brief Provides seqan3::alphabet_base.
+ */
+
+#pragma once
+
+#include <seqan3/alphabet/detail/member_exposure.hpp>
+#include <seqan3/core/detail/int_types.hpp>
+#include <seqan3/std/concepts>
+
+namespace seqan3
+{
+
+/*!\brief A CRTP-base that makes defining a custom alphabet easier.
+ * \ingroup alphabet
+ * \tparam derived_type The CRTP parameter type.
+ * \tparam size         The size of the alphabet.
+ * \tparam char_t       The character type of the alphabet (set this to `void` when defining just a
+ *                      seqan3::semi_alphabet_concept).
+ *
+ * \details
+ *
+ * You can use this class to define your own alphabet, but types are not required to be based on it to model
+ * seqan3::alphabet_concept, it is purely a way to avoid code duplication.
+ *
+ * The base class represents the alphabet value as the rank and
+ * automatically deduces the rank type from the size, it further defines all required member functions and types; the
+ * derived type needs to define only the following two tables as static member variables:
+ *
+ *   * `static std::array<char_type, value_size> constexpr rank_to_char` that defines for every possible rank value
+ *     the corresponding char value.
+ *   * `static std::array<rank_type, 256> constexpr char_to_rank` that defines for every possible character value the
+ *     corresponding rank value.
+ *
+ * ### Example
+ *
+ * This creates an alphabet called `ab` which has size two and the two letters 'A' and 'B':
+ * \snippet test/snippet/alphabet/detail/alphabet_base.cpp example
+ *
+ */
+template <typename derived_type, size_t size, typename char_t = char>
+class alphabet_base
+{
+public:
+    //TODO: this should be > 1 and there should be a different specialisation for size 1
+    static_assert(size > 0, "It does not make sense to use the base class for alphabets of size < 1.");
+
+    /*!\name Member types
+     * \{
+     */
+    //!\brief The type of the alphabet when converted to char (e.g. via to_char()).
+    using char_type = char_t;
+    //!\brief The type of the alphabet when represented as a number (e.g. via to_rank()).
+    using rank_type = detail::min_viable_uint_t<size - 1>;
+    //!\}
+
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    constexpr alphabet_base() noexcept : rank{} {}
+    constexpr alphabet_base(alphabet_base const &) = default;
+    constexpr alphabet_base(alphabet_base &&) = default;
+    constexpr alphabet_base & operator=(alphabet_base const &) = default;
+    constexpr alphabet_base & operator=(alphabet_base &&) = default;
+    ~alphabet_base() = default;
+    //!\}
+
+    /*!\name Read functions
+     * \{
+     */
+    /*!\brief Return the letter as a character of char_type.
+     *
+     * \details
+     *
+     * Satisfies the seqan3::alphabet_concept::to_char() requirement via the seqan3::to_char() wrapper.
+     *
+     * \par Complexity
+     *
+     * Constant.
+     *
+     * \par Exceptions
+     *
+     * Guaranteed not to throw.
+     */
+    constexpr char_type to_char() const noexcept
+    //!\cond
+        requires !std::Same<char_type, void>
+    //!\endcond
+    {
+        return derived_type::rank_to_char[rank];
+    }
+
+    /*!\brief Return the letter's numeric value (rank in the alphabet).
+     *
+     * \details
+     *
+     * Satisfies the seqan3::semi_alphabet_concept::to_rank() requirement via the to_rank() wrapper.
+     *
+     * \par Complexity
+     *
+     * Constant.
+     *
+     * \par Exceptions
+     *
+     * Guaranteed not to throw.
+     */
+    constexpr rank_type to_rank() const noexcept
+    {
+        return rank;
+    }
+    //!\}
+
+    /*!\name Write functions
+     * \{
+     */
+    /*!\brief Assign from a character.
+     *
+     * \details
+     *
+     * Satisfies the seqan3::alphabet_concept::assign_char() requirement via the seqan3::assign_char() wrapper.
+     *
+     * \par Complexity
+     *
+     * Constant.
+     *
+     * \par Exceptions
+     *
+     * Guaranteed not to throw.
+     */
+    constexpr derived_type & assign_char(std::conditional_t<std::Same<char_type, void>, char, char_type> const c) noexcept
+    //!\cond
+        requires !std::Same<char_type, void>
+    //!\endcond
+    {
+        using index_t = std::make_unsigned_t<char_type>;
+        rank = derived_type::char_to_rank[static_cast<index_t>(c)];
+        return static_cast<derived_type &>(*this);
+    }
+
+    /*!\brief Assign from a numeric value.
+     *
+     * \details
+     *
+     * Satisfies the seqan3::semi_alphabet_concept::assign_rank() requirement via the seqan3::assign_rank() wrapper.
+     *
+     * \par Complexity
+     *
+     * Constant.
+     *
+     * \par Exceptions
+     *
+     * Guaranteed not to throw.
+     */
+    constexpr derived_type & assign_rank(rank_type const c) noexcept
+    {
+        assert(c < value_size);
+        rank = c;
+        return static_cast<derived_type &>(*this);
+    }
+    //!\}
+
+    //!\brief The size of the alphabet, i.e. the number of different values it can take.
+    static detail::min_viable_uint_t<size> constexpr value_size = size;
+
+    //!\name Comparison operators
+    //!\{
+    friend constexpr bool operator==(derived_type const & lhs, derived_type const & rhs) noexcept
+    {
+        using seqan3::to_rank;
+        return to_rank(lhs) == to_rank(rhs);
+    }
+
+    friend constexpr bool operator!=(derived_type const & lhs, derived_type const & rhs) noexcept
+    {
+        using seqan3::to_rank;
+        return to_rank(lhs) != to_rank(rhs);
+    }
+
+    friend constexpr bool operator<(derived_type const & lhs, derived_type const & rhs) noexcept
+    {
+        using seqan3::to_rank;
+        return to_rank(lhs) < to_rank(rhs);
+    }
+
+    friend constexpr bool operator>(derived_type const & lhs, derived_type const & rhs) noexcept
+    {
+        using seqan3::to_rank;
+        return to_rank(lhs) > to_rank(rhs);
+    }
+
+    friend constexpr bool operator<=(derived_type const & lhs, derived_type const & rhs) noexcept
+    {
+        using seqan3::to_rank;
+        return to_rank(lhs) <= to_rank(rhs);
+    }
+
+    friend constexpr bool operator>=(derived_type const & lhs, derived_type const & rhs) noexcept
+    {
+        using seqan3::to_rank;
+        return to_rank(lhs) >= to_rank(rhs);
+    }
+    //!\}
+
+private:
+    //!\brief The value of the alphabet letter is stored as the rank.
+    rank_type rank;
+
+    //!\brief Expose the derived_type back to the derived_type as a dependent type to allow some obscure template
+    //!       witchery.
+    using derived_t = derived_type;
+
+    //!\brief Enable usage of the previous typedef.
+    friend derived_type;
+};
+
+} // namespace seqan3

--- a/include/seqan3/alphabet/detail/alphabet_proxy.hpp
+++ b/include/seqan3/alphabet/detail/alphabet_proxy.hpp
@@ -1,0 +1,292 @@
+// ============================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ============================================================================
+//
+// Copyright (chr) 2006-2018, Knut Reinert & Freie Universitaet Berlin
+// Copyright (chr) 2016-2018, Knut Reinert & MPI Molekulare Genetik
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ============================================================================
+
+/*!\file
+ * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
+ * \brief Free function/metafunction wrappers for alphabets with member functions/types.
+ *
+ * This shall not need be included manually, just include `alphabet/concept.hpp`.
+ */
+
+#pragma once
+
+#include <seqan3/alphabet/detail/alphabet_base.hpp>
+#include <seqan3/alphabet/nucleotide/concept.hpp>
+#include <seqan3/alphabet/quality/concept.hpp>
+#include <seqan3/core/concept/core_language.hpp>
+#include <seqan3/core/metafunction/transformation_trait_or.hpp>
+#include <seqan3/std/concepts>
+
+namespace seqan3
+{
+#if 0 // this is the alphabet_proxy I want, but GCC won't give me:
+template <typename derived_type, typename alphabet_type>
+class alphabet_proxy : public alphabet_type
+{
+public:
+    using base_t = alphabet_type;
+
+    using base_t::value_size;
+    using typename base_t::rank_type;
+    using char_type  = detail::transformation_trait_or_t<underlying_char<alphabet_type>, void>;
+    using phred_type = detail::transformation_trait_or_t<underlying_phred<alphabet_type>, void>;
+
+    using char_type_virtual  = std::conditional_t<std::Same<char_type, void>, char, char_type>;
+    using phred_type_virtual = std::conditional_t<std::Same<phred_type, void>, int8_t, phred_type>;
+
+    constexpr alphabet_proxy() : base_t{} {}
+    constexpr alphabet_proxy(alphabet_proxy const &) = default;
+    constexpr alphabet_proxy(alphabet_proxy &&) = default;
+    constexpr alphabet_proxy & operator=(alphabet_proxy const &) = default;
+    constexpr alphabet_proxy & operator=(alphabet_proxy &&) = default;
+    ~alphabet_proxy() = default;
+
+    constexpr alphabet_proxy(alphabet_type const a) :
+        base_t{a}
+    {}
+
+    constexpr alphabet_proxy & operator=(alphabet_type const & c) noexcept
+    {
+        base_t::assign_rank(seqan3::to_rank(c));
+        static_cast<derived_type &>(*this).on_update(); // <- this invokes the actual proxy behaviour!
+        return *this;
+    }
+
+    template <typename indirect_assignable_type>
+        requires std::Assignable<alphabet_type &, indirect_assignable_type>
+    constexpr alphabet_proxy & operator=(indirect_assignable_type const & c) noexcept
+    {
+        alphabet_type a{};
+        a = c;
+        return operator=(a);
+    }
+
+    constexpr alphabet_proxy & assign_char(char_type_virtual const c) noexcept
+        requires !std::Same<char_type, void>
+    {
+        alphabet_type tmp{};
+        using seqan3::assign_char;
+        assign_char(tmp, c);
+        return operator=(tmp);
+    }
+
+    constexpr alphabet_proxy & assign_rank(underlying_rank_t<alphabet_type> const r) noexcept
+    {
+        alphabet_type tmp{};
+        using seqan3::assign_rank;
+        assign_rank(tmp, r);
+        return operator=(tmp);
+    }
+
+    constexpr alphabet_proxy & assign_phred(phred_type_virtual const c) noexcept
+        requires !std::Same<phred_type, void>
+    {
+        alphabet_type tmp{};
+        using seqan3::assign_phred;
+        assign_phred(tmp, c);
+        return operator=(tmp);
+    }
+};
+#endif
+
+#if 1// this is the one that works for most things, but not all
+
+/*!\brief A CRTP-base that eases the definition of proxy types returned in place of regular alphabets.
+ * \tparam derived_type  The CRTP parameter type.
+ * \tparam alphabet_type The type of the alphabet that this proxy emulates.
+ *
+ * \details
+ *
+ * Certain containers and other data structure hold alphabet values in a non-standard way so they can convert
+ * to that alphabet when being accessed, but cannot return a reference to the held value. These data structures
+ * may instead return a *proxy* to the held value which still allows changing it (and updating the underlying data
+ * structure to reflect this).
+ *
+ * This CRTP base facilitates the definition of such proxies. Most users of SeqAn will not need to understand the
+ * details.
+ *
+ * This class ensures that the proxy itself also models seqan3::semi_alphabet_concept, seqan3::alphabet_concept,
+ * seqan3::quality_concept, seqan3::nucleotide_concept and/or seqan3::aminoacid_concept if the emulated type models
+ * these. This makes sure that function templates which accept the original, also accept the proxy. An exception
+ * are multi-layered compositions of alphabets where the proxy currently does not support access via `get`.
+ *
+ * ### Implementation notes
+ *
+ * The derived type needs to provide an `.on_update()` member function that performs the changes in the underlying
+ * data structure.
+ *
+ * See seqan3::bitcompressed_vector or seqan3::cartesian_composition for examples of how this class is used.
+ */
+template <typename derived_type, typename alphabet_type>
+class alphabet_proxy : public alphabet_base<derived_type,
+                                            alphabet_size_v<alphabet_type>,
+                                            detail::transformation_trait_or_t<underlying_char<alphabet_type>, void>>
+{
+private:
+    //!\brief Type of the base class.
+    using base_t =  alphabet_base<derived_type,
+                                  alphabet_size_v<alphabet_type>,
+                                  detail::transformation_trait_or_t<underlying_char<alphabet_type>, void>>;
+
+    //!\brief Befriend the base type.
+    friend base_t;
+
+public:
+    // Import from base:
+    using base_t::value_size;
+    using base_t::to_rank;
+
+    /*!\name Member types
+     * \{
+     */
+    using rank_type  = underlying_rank_t<alphabet_type>;
+    using char_type  = detail::transformation_trait_or_t<underlying_char<alphabet_type>, void>;
+    using phred_type = detail::transformation_trait_or_t<underlying_phred<alphabet_type>, void>;
+    //!\}
+
+private:
+    //!\brief Never used, but required for valid definitions.
+    using char_type_virtual  = std::conditional_t<std::Same<char_type, void>, char, char_type>;
+    //!\brief Never used, but required for valid definitions.
+    using phred_type_virtual = std::conditional_t<std::Same<phred_type, void>, int8_t, phred_type>;
+
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    constexpr alphabet_proxy() noexcept : base_t{} {}
+    constexpr alphabet_proxy(alphabet_proxy const &) = default;
+    constexpr alphabet_proxy(alphabet_proxy &&) = default;
+    constexpr alphabet_proxy & operator=(alphabet_proxy const &) = default;
+    constexpr alphabet_proxy & operator=(alphabet_proxy &&) = default;
+    ~alphabet_proxy() = default;
+
+    //!\brief Construction from the emulated type.
+    constexpr alphabet_proxy(alphabet_type const a) noexcept
+    {
+        base_t::assign_rank(seqan3::to_rank(a));
+    }
+
+    //!\brief Assigment from the emulated type. This function triggers the specialisation in the derived_type.
+    constexpr derived_type & operator=(alphabet_type const & c) noexcept
+    {
+        base_t::assign_rank(seqan3::to_rank(c));
+        static_cast<derived_type &>(*this).on_update(); // <- this invokes the actual proxy behaviour!
+        return static_cast<derived_type &>(*this);
+    }
+
+    //!\brief Assignment from any type that the emulated type is assignable from.
+    template <typename indirect_assignable_type>
+    constexpr derived_type & operator=(indirect_assignable_type const & c) noexcept
+        requires weakly_assignable_concept<alphabet_type, indirect_assignable_type>
+    {
+        alphabet_type a{};
+        a = c;
+        return operator=(a);
+    }
+    //!\}
+
+    //!\brief Befriend the derived type so it can instantiate.
+    friend derived_type;
+
+public:
+    /*!\name Write functions
+     * \brief All of these call the emulated type's write functions and then delegate to
+     *        the assignment operator which invokes derived behaviour.
+     * \{
+     */
+    constexpr derived_type & assign_rank(underlying_rank_t<alphabet_type> const r) noexcept
+    {
+        alphabet_type tmp{};
+        using seqan3::assign_rank;
+        assign_rank(tmp, r);
+        return operator=(tmp);
+    }
+
+    constexpr derived_type & assign_char(char_type_virtual const c) noexcept
+        requires alphabet_concept<alphabet_type>
+    {
+        alphabet_type tmp{};
+        using seqan3::assign_char;
+        assign_char(tmp, c);
+        return operator=(tmp);
+    }
+
+    constexpr derived_type & assign_phred(phred_type_virtual const c) noexcept
+        requires quality_concept<alphabet_type>
+    {
+        alphabet_type tmp{};
+        using seqan3::assign_phred;
+        assign_phred(tmp, c);
+        return operator=(tmp);
+    }
+    //!\}
+
+    /*!\name Read functions
+     * \brief All of these call the emulated type's read functions.
+     * \{
+     */
+    //!\brief Implicit conversion to the emulated type.
+    constexpr operator alphabet_type() const noexcept
+    {
+        using seqan3::assign_rank;
+        return assign_rank(alphabet_type{}, to_rank());
+    }
+
+    constexpr char_type to_char() const noexcept
+        requires alphabet_concept<alphabet_type>
+    {
+        using seqan3::to_char;
+        return to_char(static_cast<alphabet_type>(*this));
+    }
+
+    constexpr phred_type to_phred() const noexcept
+        requires quality_concept<alphabet_type>
+    {
+        using seqan3::to_phred;
+        return to_phred(static_cast<alphabet_type>(*this));
+    }
+
+#if 0 // this currently causes GCC ICE in cartesian_composition test
+    constexpr alphabet_type complement() const noexcept
+        requires nucleotide_concept<alphabet_type>
+    {
+        using seqan3::complement;
+        return complement(static_cast<alphabet_type>(*this));
+    }
+#endif
+    //!\}
+};
+
+#endif
+} // namespace seqan3

--- a/include/seqan3/alphabet/detail/convert.hpp
+++ b/include/seqan3/alphabet/detail/convert.hpp
@@ -72,23 +72,4 @@ constexpr std::array<out_t, alphabet_size_v<in_t>> convert_through_char_represen
     }()
 };
 
-/*!\brief A precomputed conversion table for two alphabets based on their phred representations.
- * \ingroup alphabet
- * \tparam out_t The type of the output, must satisfy seqan3::quality_concept.
- * \tparam in_t The type of the input, must satisfy seqan3::quality_concept.
- * \hideinitializer
- */
-template <quality_concept out_t, quality_concept in_t>
-constexpr std::array<out_t, alphabet_size_v<in_t>> convert_through_phred_representation
-{
-    [] () constexpr
-    {
-        std::array<out_t, alphabet_size_v<in_t>> ret{};
-        typename in_t::rank_type table_size = std::min<typename in_t::rank_type>(in_t::value_size, out_t::value_size);
-        for (typename in_t::rank_type i = 0; i < table_size; ++i)
-            assign_phred(ret[i], std::max<typename in_t::phred_type>(0, to_phred(assign_rank(in_t{}, i))));
-        return ret;
-    }()
-};
-
 } // namespace seqan3::detail

--- a/include/seqan3/alphabet/detail/member_exposure.hpp
+++ b/include/seqan3/alphabet/detail/member_exposure.hpp
@@ -85,8 +85,7 @@ template <typename alphabet_type_with_members>
 struct alphabet_size<alphabet_type_with_members>
 {
     //!\brief The size retrieved from the type's member.
-    static constexpr underlying_rank_t<alphabet_type_with_members> value =
-        alphabet_type_with_members::value_size;
+    static auto constexpr value = alphabet_type_with_members::value_size;
 };
 
 /*!\brief Implementation of seqan3::semi_alphabet_concept::to_rank() that delegates to a member function.
@@ -122,7 +121,7 @@ constexpr alphabet_type & assign_rank(alphabet_type & alph, underlying_rank_t<al
  * \details
  * Use this e.g. to newly create alphabet letters from rank:
  * ~~~{.cpp}
- * auto l = assign_rank(dna5{}, 1);  // l is of type dna5 and == dna5::C
+ * auto l = assign_rank(dna5{}, 1);  // l is of type dna5 and == 'C'_dna5
  * ~~~
  */
 template <typename alphabet_type>

--- a/include/seqan3/alphabet/gap/gap.hpp
+++ b/include/seqan3/alphabet/gap/gap.hpp
@@ -51,6 +51,8 @@ namespace seqan3
  * \ingroup gap
  * \implements seqan3::alphabet_concept
  * \implements seqan3::detail::constexpr_alphabet_concept
+ * \implements seqan3::trivially_copyable_concept
+ * \implements seqan3::standard_layout_concept
  *
  * The alphabet always has the same value ('-').
  *
@@ -103,10 +105,8 @@ struct gap
 
     //!\brief Assign from a numeric value (no-op, since gap has only one character).
     //!\param i not used, since gap has only one character
-    constexpr gap & assign_rank([[maybe_unused]] rank_type const i) /*noexcept*/
+    constexpr gap & assign_rank([[maybe_unused]] rank_type const i) noexcept
     {
-        // TODO(marehr): mark function noexcept if assert is replaced
-        // https://github.com/seqan/seqan3/issues/85
         assert(i == 0);
         return *this;
     }
@@ -117,32 +117,32 @@ struct gap
 
     //!\name Comparison operators
     //!\{
-    constexpr bool operator==(gap const &) const noexcept
+    friend constexpr bool operator==(gap const &, gap const &) noexcept
     {
         return true;
     }
 
-    constexpr bool operator!=(gap const &) const noexcept
+    friend constexpr bool operator!=(gap const &, gap const &) noexcept
     {
         return false;
     }
 
-    constexpr bool operator<(gap const &) const noexcept
+    friend constexpr bool operator<(gap const &, gap const &) noexcept
     {
         return false;
     }
 
-    constexpr bool operator>(gap const &) const noexcept
+    friend constexpr bool operator>(gap const &, gap const &) noexcept
     {
         return false;
     }
 
-    constexpr bool operator<=(gap const &) const noexcept
+    friend constexpr bool operator<=(gap const &, gap const &) noexcept
     {
         return true;
     }
 
-    constexpr bool operator>=(gap const &) const noexcept
+    friend constexpr bool operator>=(gap const &, gap const &) noexcept
     {
         return true;
     }

--- a/include/seqan3/alphabet/mask/mask.hpp
+++ b/include/seqan3/alphabet/mask/mask.hpp
@@ -41,6 +41,7 @@
 
 #include <cassert>
 #include <seqan3/alphabet/concept_pre.hpp>
+#include <seqan3/alphabet/detail/alphabet_base.hpp>
 
 namespace seqan3
 {
@@ -48,6 +49,8 @@ namespace seqan3
  * \ingroup mask
  * \implements seqan3::semi_alphabet_concept
  * \implements seqan3::detail::semi_constexpr_alphabet_concept
+ * \implements seqan3::trivially_copyable_concept
+ * \implements seqan3::standard_layout_concept
  *
  * \details
  * This alphabet is not usually used directly, but instead via seqan3::masked.
@@ -55,97 +58,37 @@ namespace seqan3
  *
  * \snippet test/snippet/alphabet/mask/mask.cpp general
  */
-struct mask
+class mask : public alphabet_base<mask, 2, void>
 {
-    //!\brief The type of the alphabet when represented as a number (e.g. via to_rank()).
-    using rank_type = bool;
+private:
+    //!\brief The base class.
+    using base_t = alphabet_base<mask, 2, void>;
+
+    //!\brief Befriend seqan3::alphabet_base.
+    friend base_t;
+
+public:
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    constexpr mask() : base_t{} {}
+    constexpr mask(mask const &) = default;
+    constexpr mask(mask &&) = default;
+    constexpr mask & operator=(mask const &) = default;
+    constexpr mask & operator=(mask &&) = default;
+    ~mask() = default;
+    //!\}
 
     /*!\name Boolean values
      * \brief Static member "booleans" that can be assigned to the alphabet or used in aggregate initialization.
-     * \details Similar to an Enum interface . *Don't worry about the `internal_type`.*
+     * \details Similar to an Enum interface.
      */
     //!\{
     static const mask UNMASKED;
     static const mask MASKED;
     //!\}
-
-    //!\brief The size of the alphabet, i.e. the number of different values it can take.
-    static constexpr uint8_t value_size{2};
-
-    /*!\name Read function
-     * \{
-     */
-    //!\brief Return the letter's numeric value or rank in the alphabet.
-    constexpr rank_type to_rank() const noexcept
-    {
-        return static_cast<rank_type>(_value);
-    }
-    //!\}
-
-    /*!\name Write functions
-     * \{
-     */
-    //!\brief Assign from a numeric value or true/false.
-    constexpr mask & assign_rank(rank_type const c) noexcept
-    {
-        _value = static_cast<internal_type>(c);
-        return *this;
-    }
-    //!\}
-
-    //!\name Comparison operators
-    //!\{
-    constexpr bool operator==(mask const & rhs) const noexcept
-    {
-        return _value == rhs._value;
-    }
-
-    constexpr bool operator!=(mask const & rhs) const noexcept
-    {
-        return _value != rhs._value;
-    }
-
-    constexpr bool operator<(mask const & rhs) const noexcept
-    {
-        return _value < rhs._value;
-    }
-
-    constexpr bool operator>(mask const & rhs) const noexcept
-    {
-        return _value > rhs._value;
-    }
-
-    constexpr bool operator<=(mask const & rhs) const noexcept
-    {
-        return _value <= rhs._value;
-    }
-
-    constexpr bool operator>=(mask const & rhs) const noexcept
-    {
-        return _value >= rhs._value;
-    }
-    //!\}
-protected:
-    //!\privatesection
-    /*!\brief The internal type is a strictly typed enum.
-     *
-     * This is done to prevent aggregate initialization from numbers and/or chars.
-     * It has the drawback that it also introduces a scope which in turn makes
-     * the static "letter values" members necessary.
-     */
-    enum struct internal_type : rank_type
-    {
-        UNMASKED,
-        MASKED
-    };
-
-public:
-    //!\privatesection
-    //!\brief The data member.
-    internal_type _value;
-    //!\publicsection
 };
 
-constexpr mask mask::UNMASKED{internal_type::UNMASKED};
-constexpr mask mask::MASKED{internal_type::MASKED};
+mask constexpr mask::UNMASKED{mask{}.assign_rank(0)};
+mask constexpr mask::MASKED  {mask{}.assign_rank(1)};
 } // namespace seqan3

--- a/include/seqan3/alphabet/nucleotide/all.hpp
+++ b/include/seqan3/alphabet/nucleotide/all.hpp
@@ -55,104 +55,82 @@
  * to represent them in a regular std::string, it makes sense to have specialised data structures in most cases.
  * This sub-module offers multiple nucleotide alphabets that can be used with regular containers and ranges.
  *
- * | Letter   | Description            | seqan3::dna15  | seqan3::dna5 | seqan3::dna4 | seqan3::rna15  | seqan3::rna5 | seqan3::rna4 |
- * |:--------:|------------------------|:--------------:|:------------:|:------------:|:--------------:|:------------:|:------------:|
- * |   A      | Adenine                |      ☑         |      ☑       |      ☑       |      ☑         |      ☑       |      ☑       |
- * |   C      | Cytosine               |      ☑         |      ☑       |      ☑       |      ☑         |      ☑       |      ☑       |
- * |   G      | Guanine                |      ☑         |      ☑       |      ☑       |      ☑         |      ☑       |      ☑       |
- * |   T      | Thymine (DNA)          |      ☑         |      ☑       |      ☑       |      ☐         |      ☐       |      ☐       |
- * |   U      | Uracil (RNA)           |      ☐         |      ☐       |      ☐       |      ☑         |      ☑       |      ☑       |
- * |   M      | A *or* C               |      ☑         |      ☐       |      ☐       |      ☑         |      ☐       |      ☐       |
- * |   R      | A *or* G               |      ☑         |      ☐       |      ☐       |      ☑         |      ☐       |      ☐       |
- * |   W      | A *or* T               |      ☑         |      ☐       |      ☐       |      ☑         |      ☐       |      ☐       |
- * |   Y      | C *or* T               |      ☑         |      ☐       |      ☐       |      ☑         |      ☐       |      ☐       |
- * |   S      | C *or* G               |      ☑         |      ☐       |      ☐       |      ☑         |      ☐       |      ☐       |
- * |   K      | G *or* T               |      ☑         |      ☐       |      ☐       |      ☑         |      ☐       |      ☐       |
- * |   V      | A *or* C *or* G        |      ☑         |      ☐       |      ☐       |      ☑         |      ☐       |      ☐       |
- * |   H      | A *or* C *or* T        |      ☑         |      ☐       |      ☐       |      ☑         |      ☐       |      ☐       |
- * |   D      | A *or* G *or* T        |      ☑         |      ☐       |      ☐       |      ☑         |      ☐       |      ☐       |
- * |   B      | C *or* G *or* T        |      ☑         |      ☐       |      ☐       |      ☑         |      ☐       |      ☐       |
- * |   N      | A *or* C *or* G *or* T |      ☑         |      ☑       |      ☐       |      ☑         |      ☑       |      ☐       |
- * | **Size** |                        |     15         |      5       |      4       |     15         |      5       |      4       |
+ * | Letter   | Description            |                   seqan3::dna15        |                   seqan3::dna5         |                  seqan3::dna4          |                seqan3::rna15           |                    seqan3::rna5        |                 seqan3::rna4           |
+ * |:--------:|------------------------|:--------------------------------------:|:--------------------------------------:|:--------------------------------------:|:--------------------------------------:|:--------------------------------------:|:--------------------------------------:|
+ * |   A      | Adenine                |                              A         |                              A         |                              A         |                              A         |                              A         |                              A         |
+ * |   C      | Cytosine               |                              C         |                              C         |                              C         |                              C         |                              C         |                              C         |
+ * |   G      | Guanine                |                              G         |                              G         |                              G         |                              G         |                              G         |                              G         |
+ * |   T      | Thymine (DNA)          |                              T         |                              T         |                              T         | <span style="color:LightGrey">U</span> | <span style="color:LightGrey">U</span> | <span style="color:LightGrey">U</span> |
+ * |   U      | Uracil (RNA)           | <span style="color:LightGrey">T</span> | <span style="color:LightGrey">T</span> | <span style="color:LightGrey">T</span> |                              U         |                              U         |                              U         |
+ * |   M      | A *or* C               |                              M         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">A</span> |                              M         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">A</span> |
+ * |   R      | A *or* G               |                              R         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">A</span> |                              R         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">A</span> |
+ * |   W      | A *or* T               |                              W         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">A</span> |                              W         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">A</span> |
+ * |   Y      | C *or* T               |                              Y         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">C</span> |                              Y         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">C</span> |
+ * |   S      | C *or* G               |                              S         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">C</span> |                              S         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">C</span> |
+ * |   K      | G *or* T               |                              K         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">G</span> |                              K         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">G</span> |
+ * |   V      | A *or* C *or* G        |                              V         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">A</span> |                              V         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">A</span> |
+ * |   H      | A *or* C *or* T        |                              H         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">A</span> |                              H         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">A</span> |
+ * |   D      | A *or* G *or* T        |                              D         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">A</span> |                              D         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">A</span> |
+ * |   B      | C *or* G *or* T        |                              B         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">C</span> |                              B         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">C</span> |
+ * |   N      | A *or* C *or* G *or* T |                              N         |                              N         | <span style="color:LightGrey">A</span> |                              N         |                              N         | <span style="color:LightGrey">A</span> |
+ * | **Size** |                        |     15                                 |      5                                 |      4                                 |     15                                 |      5                                 |      4                                 |
  *
  * Keep in mind, that while we think of "the nucleotide alphabet" as consisting of four bases, there are indeed
  * more characters defined with different levels of ambiguity. Depending on your application it will make sense
  * to preserve this ambiguity or to discard it to save space and/or optimise computations.
  * SeqAn offers six distinct nucleotide alphabet types to accommodate for this.
  *
- * The specialised RNA alphabets are provided for convenience, however the DNA alphabets provide a `::%U` member
- * and can handle being assigned a `'U'` character, as well. See below for the details.
+ * The specialised RNA alphabets are provided for convenience, however the DNA alphabets can handle being assigned a
+ * `'U'` character, as well. See below for the details.
  *
  * Which alphabet to chose?
  *   1. in most cases, take seqan3::dna15
  *   2. if you are memory constrained and sequence data is actually the main memory consumer, use seqan3::dna5
  *   3. if you use specialised algorithms that profit from a 2-bit representation, use seqan3::dna4
  *   4. if you are doing only RNA input/output, use the respective seqan3::rna* type
- *   5. to actually save space from using smaller alphabets, you need a compressed container (TODO link)
+ *   5. to actually save space from using smaller alphabets, you need a compressed container (e.g.
+ *      seqan3::bitcompressed_vector)
+ *
+ * \par Printing and conversion to char
+ *
+ * As with all alphabets in SeqAn3, none of the nucleotide alphabets can be directly converted to char or printed.
+ * You need to explicitly call seqan3::to_char to convert to char. The only exception is seqan3::debug_stream
+ * which does this conversion to char automatically.
+ *
+ * `T` and `U` are represented by the same rank and you cannot differentiate between them. The only difference between
+ * e.g. seqan3::dna4 and seqan3::rna4 is the output when calling to_char().
+ *
+ * \par Assignment and conversions between nucleotide types
+ *
+ *   * Nucleotide types defined here are **implicitly** convertible to each other if they have the same size
+ *     (e.g. seqan3::dna4 ↔ seqan3::rna4).
+ *   * Other nucleotide types are **explicitly** convertible to each other through their character representation.
+ *   * All ranges of nucleotide alphabets are convertible to each other via seqan3::view::convert.
+ *   * None of the nucleotide alphabets can be directly converted or assigned from `char`. You need to explicitly call
+ *     `assign_char` or use a literal (see below).
+ *
+ * When assigning from `char` or converting from a larger nucleotide alphabet to a smaller one, *loss of information*
+ * can occur since obviously some bases are not available. When converting to seqan3::dna5 or seqan3::rna5,
+ * non-canonical bases
+ * (letters other than A, C, G, T, U) are converted to `'N'` to preserve ambiguity at that position, while
+ * for seqan3::dna4 and seqan3::rna4 they are converted to the first of the possibilities they represent (because
+ * there is no letter `'N'` to represent ambiguity). See the greyed out values in the table at the top for
+ * an overview of which conversions take place.
+ *
+ * `char` values that are none of the IUPAC symbols, e.g. 'P', are always converted to the equivalent of assigning 'N',
+ * i.e. they result in 'A' for seqan3::dna4 and seqan3::rna4, and in 'N' for the other alphabets.
+ *
+ * \par Literals
+ *
+ * To avoid writing `dna4{}.assign_char('C')` every time, you may instead use the literal `'C'_dna4`.
+ * All nucleotide types defined here have character literals and also string literals which return a vector of the
+ * respective type.
  *
  * \par Concept
  *
  * The nucleotide submodule defines seqan3::nucleotide_concept which encompasses all the alphabets defined in the
- * submodule and refines seqan3::alphabet_concept.
- *
- * While it is not required by the concept, all alphabets declared in the module offer an `enum`-like interface
- * to the individual letters so you can use them as values in assignments and comparisons:
- *
- * ~~~{.cpp}
- * dna4 l{dna4::A};
- *
- * if (l == dna4::C}
- *     // ...
- * ~~~
- *
- * All alphabets define at least the letters `::%A`, `::%C`, `::%G`, `::%T`, `::%U`, `::%UNKNOWN` (although some
- * might be aliases of others).
- *
- * \par Printing and conversion to char
- *
- * | to_char()      | seqan3::dna15  | seqan3::dna5 | seqan3::dna4 | seqan3::rna15  | seqan3::rna5 | seqan3::rna4 |
- * |:--------------:|:--------------:|:------------:|:------------:|:--------------:|:------------:|:------------:|
- * | type::A        |    `'A'`       |    `'A'`     |    `'A'`     |    `'A'`       |    `'A'`     |    `'A'`     |
- * |   ...          |    ...         |    ...       |    ...       |    ...         |    ...       |    ...       |
- * | type::T        |    `'T'`       |    `'T'`     |    `'T'`     |    `'U'`       |    `'U'`     |    `'U'`     |
- * | type::U        |    `'T'`       |    `'T'`     |    `'T'`     |    `'U'`       |    `'U'`     |    `'U'`     |
- * | type::R        |    `'R'`       |     ---      |    ---       |    `'R'`       |     ---      |     ---      |
- * |   ...          |    ...         |     ---      |    ---       |    ...         |     ---      |     ---      |
- * | type::N        |    `'N'`       |    `'N'`     |    ---       |    `'N'`       |    `'N'`     |     ---      |
- * | type::UNKNOWN  |    `'N'`       |    `'N'`     |    `'A'`     |    `'N'`       |    `'N'`     |    `'A'`     |
- *
- * `T` and `U` are represented by the same rank and you cannot differentiate between them
- * (the static members `::%T` and `::%U` are synonymous). The only difference between e.g. seqan3::dna4 and
- * seqan3::rna4 is the output when calling to_char().
- *
- * \par Assignment and conversions between nucleotide types
- *
- *   * Nucleotide types are **implicitly** convertible to each other if they have the same size
- * (e.g. seqan3::dna4 ↔ seqan3::rna4).
- *   * Other nucleotide types are **explicitly** convertible to each other through their character representation.
- *   * All ranges of nucleotide alphabets are convertible to each other via seqan3::view::convert.
- *
- * | assign_char() | seqan3::dna15  | seqan3::dna5  | seqan3::dna4  | seqan3::rna15  | seqan3::rna5 | seqan3::rna4  |
- * |:-------------:|:--------------:|:-------------:|:-------------:|:--------------:|:------------:|:-------------:|
- * |   `'A'`       |   dna15::A     |  dna5::A      | dna4::A       |   rna15::A     |  rna5::A     | rna4::A       |
- * |   ...         |    ...         |    ...        | ...           |    ...         |    ...       |     ...       |
- * |   `'T'`       |   dna15::T ¹   |  dna5::T ¹    | dna4::T ¹     |   rna15::T ¹   |  rna5::T ¹   | rna4::T ¹     |
- * |   `'U'`       |   dna15::T ¹   |  dna5::T ¹    | dna4::T ¹     |   rna15::T ¹   |  rna5::T ¹   | rna4::T ¹     |
- * |   `'R'`       |   dna15::R     |  dna5::N ²    | dna4::A ³     |   rna15::R     |  rna5::N ²   | rna4::A ³     |
- * |   `'Y'`       |   dna15::Y     |  dna5::N ²    | dna4::C ³     |   rna15::Y     |  rna5::N ²   | rna4::C ³     |
- * |   ...         |    ...         |  dna5::N ²    | ... ³         |    ...         |  rna5::N ²   | ... ³         |
- * |   `'N'`       |   dna15::N     |  dna5::N ²    | dna4::A ³     |   rna15::N     |  rna5::N ²   | rna4::A ³     |
- * | e.g. `'!'`    |   dna15::N     |  dna5::N ²    | dna4::A ²     |   rna15::N     |  rna5::N ²   | rna4::A ²     |
- *
- * ¹ same as `type::U`<br>
- * ² same as `type::UNKNOWN`<br>
- * ³ the first character in the ambiguous set
- *
- * When converting from `char` or from a larger nucleotide alphabet to a smaller one, *loss of information* can occur
- * since obviously some bases are not available. When converting to seqan3::dna5 or seqan3::rna5, non-canonical bases
- * (letters other than A, C, G, T, U) are converted to `'N'` to preserve ambiguity at that position, while
- * for seqan3::dna4 and seqan3::rna4 they are converted to the first of the possibilities they represent (because
- * there is no letter `'N'` to represent ambiguity).
+ * submodule and refines seqan3::alphabet_concept. The only additional requirement is that their values can be
+ * complemented, see below.
  *
  * \par Complement
  *

--- a/include/seqan3/alphabet/nucleotide/concept.hpp
+++ b/include/seqan3/alphabet/nucleotide/concept.hpp
@@ -65,7 +65,7 @@ namespace seqan3
 template <typename type>
 concept nucleotide_concept = alphabet_concept<type> && requires (type v, std::remove_reference_t<type> c)
 {
-    requires std::Same<decltype(complement(v)),        decltype(c)>;
+    requires std::Same<decltype(complement(v)), decltype(c)>;
 };
 //!\endcond
 

--- a/include/seqan3/alphabet/nucleotide/concept.hpp
+++ b/include/seqan3/alphabet/nucleotide/concept.hpp
@@ -40,6 +40,7 @@
 #pragma once
 
 #include <seqan3/alphabet/concept.hpp>
+#include <seqan3/std/concepts>
 
 // ============================================================================
 // concept
@@ -62,11 +63,9 @@ namespace seqan3
  */
 //!\cond
 template <typename type>
-concept nucleotide_concept = requires (type v)
+concept nucleotide_concept = alphabet_concept<type> && requires (type v, std::remove_reference_t<type> c)
 {
-    requires alphabet_concept<type>;
-
-    { complement(v) } -> std::remove_reference_t<type>;
+    requires std::Same<decltype(complement(v)),        decltype(c)>;
 };
 //!\endcond
 

--- a/include/seqan3/alphabet/nucleotide/dna5.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna5.hpp
@@ -33,19 +33,16 @@
 // ============================================================================
 
 /*!\file
- * \author David Heller <david.heller AT fu-berlin.de>
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  * \brief Contains seqan3::dna5, container aliases and string literals.
  */
 
 #pragma once
 
-#include <cassert>
-
 #include <vector>
 
-#include <seqan3/alphabet/detail/convert.hpp>
-#include <seqan3/alphabet/nucleotide/concept.hpp>
+#include <seqan3/alphabet/nucleotide/nucleotide_base.hpp>
+#include <seqan3/io/stream/char_operations.hpp>
 
 // ------------------------------------------------------------------
 // dna5
@@ -54,10 +51,14 @@
 namespace seqan3
 {
 
+class rna5;
+
 /*!\brief The five letter DNA alphabet of A,C,G,T and the unknown character N.
  * \ingroup nucleotide
  * \implements seqan3::nucleotide_concept
  * \implements seqan3::detail::constexpr_alphabet_concept
+ * \implements seqan3::trivially_copyable_concept
+ * \implements seqan3::standard_layout_concept
  *
  * \details
  * Note that you can assign 'U' as a character to dna5 and it will silently
@@ -69,174 +70,74 @@ namespace seqan3
  *
  *\snippet test/snippet/alphabet/nucleotide/dna5.cpp code
  */
-
-struct dna5
+class dna5 : public nucleotide_base<dna5, 5>
 {
-    //!\copydoc seqan3::dna4::char_type
-    using char_type = char;
-    //!\copydoc seqan3::dna4::rank_type
-    using rank_type = uint8_t;
+private:
+    //!\brief The base class.
+    using base_t = nucleotide_base<dna5, 5>;
 
-    /*!\name Letter values
-     * \brief Static member "letters" that can be assigned to the alphabet or used in aggregate initialization.
-     * \details Similar to an Enum interface . *Don't worry about the `internal_type`.*
-     */
-    //!\{
-    static const dna5 A;
-    static const dna5 C;
-    static const dna5 G;
-    static const dna5 T;
-    static const dna5 N;
-    static const dna5 U;
-    static const dna5 UNKNOWN;
-    //!\}
-
-    /*!\name Read functions
-     * \{
-     */
-    //!\copydoc seqan3::dna4::to_char
-    constexpr char_type to_char() const noexcept
-    {
-        return value_to_char[static_cast<rank_type>(_value)];
-    }
-
-    //!\copydoc seqan3::dna4::to_rank
-    constexpr rank_type to_rank() const noexcept
-    {
-        return static_cast<rank_type>(_value);
-    }
-
-    //!\copydoc seqan3::dna4::complement
-    constexpr dna5 complement() const noexcept
-    {
-        return complement_table[to_rank()];
-    }
-    //!\}
-
-    /*!\name Write functions
-     * \{
-     */
-    //!\copydoc seqan3::dna4::assign_char
-    constexpr dna5 & assign_char(char_type const c) noexcept
-    {
-        using index_t = std::make_unsigned_t<char_type>;
-        _value = char_to_value[static_cast<index_t>(c)];
-        return *this;
-    }
-
-    //!\copydoc seqan3::dna4::assign_rank
-    constexpr dna5 & assign_rank(rank_type const c)
-    {
-        assert(c < value_size);
-        _value = static_cast<internal_type>(c);
-        return *this;
-    }
-    //!\}
-
-    //!\copydoc seqan3::dna4::value_size
-    static constexpr rank_type value_size{5};
-
-    /*!\name Conversion operators
-     * \{
-     */
-    //!\brief Implicit conversion between dna* and rna* of the same size.
-    //!\tparam other_nucl_type The type to convert to; must satisfy seqan3::nucleotide_concept and have the same \link value_size \endlink.
-    template <typename other_nucl_type>
-    //!\cond
-        requires nucleotide_concept<other_nucl_type> && value_size == alphabet_size_v<other_nucl_type>
+    //!\brief Befriend seqan3::nucleotide_base.
+    friend base_t;
+    //!\cond \brief Befriend seqan3::alphabet_base.
+    friend base_t::base_t;
     //!\endcond
-    constexpr operator other_nucl_type() const noexcept
-    {
-        return other_nucl_type{_value};
-    }
+    //!\brief Befriend seqan3::rna5 so it can copy #char_to_rank.
+    friend rna5;
 
-    //!\brief Explicit conversion to any other nucleotide alphabet (via char representation).
-    //!\tparam other_nucl_type The type to convert to; must satisfy seqan3::nucleotide_concept.
-    template <typename other_nucl_type>
-    //!\cond
-        requires nucleotide_concept<other_nucl_type>
-    //!\endcond
-    explicit constexpr operator other_nucl_type() const noexcept
-    {
-        return detail::convert_through_char_representation<other_nucl_type, std::decay_t<decltype(*this)>>[to_rank()];
-    }
-    //!\}
+public:
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    constexpr dna5() noexcept : base_t{} {}
+    constexpr dna5(dna5 const &) = default;
+    constexpr dna5(dna5 &&) = default;
+    constexpr dna5 & operator=(dna5 const &) = default;
+    constexpr dna5 & operator=(dna5 &&) = default;
+    ~dna5() = default;
 
-    //!\name Comparison operators
-    //!\{
-    constexpr bool operator==(dna5 const & rhs) const noexcept
-    {
-        return _value == rhs._value;
-    }
+    using base_t::base_t;
 
-    constexpr bool operator!=(dna5 const & rhs) const noexcept
+    //!\brief Allow implicit construction from dna/rna of the same size.
+    template <std::Same<rna5> t>    // Accept incomplete type
+    constexpr dna5(t const & r) noexcept
     {
-        return _value != rhs._value;
-    }
-
-    constexpr bool operator<(dna5 const & rhs) const noexcept
-    {
-        return _value < rhs._value;
-    }
-
-    constexpr bool operator>(dna5 const & rhs) const noexcept
-    {
-        return _value > rhs._value;
-    }
-
-    constexpr bool operator<=(dna5 const & rhs) const noexcept
-    {
-        return _value <= rhs._value;
-    }
-
-    constexpr bool operator>=(dna5 const & rhs) const noexcept
-    {
-        return _value >= rhs._value;
+        assign_rank(r.to_rank());
     }
     //!\}
 
 protected:
     //!\privatesection
-    //!\copydoc seqan3::dna4::internal_type
-    enum struct internal_type : rank_type
-    {
-        A,
-        C,
-        G,
-        T,
-        N,
-        U = T,
-        UNKNOWN = N
-    };
 
-    //!\copydoc seqan3::dna4::value_to_char
-    static constexpr char_type value_to_char[value_size]
+    //!\copydoc seqan3::dna4::rank_to_char
+    static constexpr char_type rank_to_char[value_size]
     {
         'A',
         'C',
         'G',
-        'T',
-        'N'
+        'N',
+        'T'
     };
 
-    //!\copydoc seqan3::dna4::char_to_value
-    static constexpr std::array<internal_type, 256> char_to_value
+    //!\copydoc seqan3::dna4::char_to_rank
+    static constexpr std::array<rank_type, 256> char_to_rank
     {
         [] () constexpr
         {
-            using in_t = internal_type;
-            std::array<in_t, 256> ret{};
+            std::array<rank_type, 256> ret{};
 
             // initialize with UNKNOWN (std::array::fill unfortunately not constexpr)
             for (auto & c : ret)
-                c = in_t::UNKNOWN;
+                c = 3; // == 'N'
 
-            // canonical
-            ret['A'] = in_t::A; ret['a'] = in_t::A;
-            ret['C'] = in_t::C; ret['c'] = in_t::C;
-            ret['G'] = in_t::G; ret['g'] = in_t::G;
-            ret['T'] = in_t::T; ret['t'] = in_t::T;
-            ret['U'] = in_t::U; ret['u'] = in_t::U;
+            // reverse mapping for characters and their lowercase
+            for (size_t rnk = 0u; rnk < value_size; ++rnk)
+            {
+                ret[         rank_to_char[rnk] ] = rnk;
+                ret[to_lower(rank_to_char[rnk])] = rnk;
+            }
+
+            // set U equal to T
+            ret['U'] = ret['T']; ret['u'] = ret['t'];
 
             // iupac characters are implicitly "UNKNOWN"
             return ret;
@@ -245,65 +146,43 @@ protected:
 
     //!\copydoc seqan3::dna4::complement_table
     static const std::array<dna5, value_size> complement_table;
-public:
-    //!\privatesection
-    //!\brief The data member.
-    internal_type _value;
-    //!\publicsection
 };
-
-constexpr dna5 dna5::A{internal_type::A};
-constexpr dna5 dna5::C{internal_type::C};
-constexpr dna5 dna5::G{internal_type::G};
-constexpr dna5 dna5::T{internal_type::T};
-constexpr dna5 dna5::N{internal_type::N};
-constexpr dna5 dna5::U{dna5::T};
-constexpr dna5 dna5::UNKNOWN{dna5::N};
-
-constexpr std::array<dna5, dna5::value_size> dna5::complement_table
-{
-    dna5::T,    // complement of dna5::A
-    dna5::G,    // complement of dna5::C
-    dna5::C,    // complement of dna5::G
-    dna5::A,    // complement of dna5::T
-    dna5::N     // complement of dna5::N
-};
-
-} // namespace seqan3
 
 // ------------------------------------------------------------------
 // containers
 // ------------------------------------------------------------------
 
-namespace seqan3
-{
-
 //!\brief Alias for an std::vector of seqan3::dna5.
 //!\relates dna5
 using dna5_vector = std::vector<dna5>;
-
-} // namespace seqan3
 
 // ------------------------------------------------------------------
 // literals
 // ------------------------------------------------------------------
 
-namespace seqan3::literal
-{
+/*!\name Literals
+ * \{
+ */
 
-/*!\brief dna5 literal
+/*!\brief The seqan3::dna5 char literal.
+ * \relates seqan3::dna5
+ * \returns seqan3::dna5
+ */
+constexpr dna5 operator""_dna5(char const c) noexcept
+{
+    return dna5{}.assign_char(c);
+}
+
+/*!\brief The seqan3::dna5 string literal.
  * \relates seqan3::dna5
  * \returns seqan3::dna5_vector
  *
  * You can use this string literal to easily assign to dna5_vector:
  *
- *\snippet test/snippet/alphabet/nucleotide/dna5.cpp operator""_dna5
+ * \snippet test/snippet/alphabet/nucleotide/dna5.cpp operator""_dna5
  *
- * \attention
- * All seqan3 literals are in the namespace seqan3::literal!
  */
-
-inline dna5_vector operator""_dna5(const char * s, std::size_t n)
+inline dna5_vector operator""_dna5(char const * s, std::size_t n)
 {
     dna5_vector r;
     r.resize(n);
@@ -313,5 +192,19 @@ inline dna5_vector operator""_dna5(const char * s, std::size_t n)
 
     return r;
 }
+//!\}
 
-} // namespace seqan3::literal
+// ------------------------------------------------------------------
+// dna5 (deferred definition)
+// ------------------------------------------------------------------
+
+constexpr std::array<dna5, dna5::value_size> dna5::complement_table
+{
+    'T'_dna5,    // complement of 'A'_dna5
+    'G'_dna5,    // complement of 'C'_dna5
+    'C'_dna5,    // complement of 'G'_dna5
+    'N'_dna5,    // complement of 'N'_dna5
+    'A'_dna5     // complement of 'T'_dna5
+};
+
+} // namespace seqan3

--- a/include/seqan3/alphabet/nucleotide/nucleotide_base.hpp
+++ b/include/seqan3/alphabet/nucleotide/nucleotide_base.hpp
@@ -1,0 +1,160 @@
+// ============================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ============================================================================
+//
+// Copyright (chr) 2006-2018, Knut Reinert & Freie Universitaet Berlin
+// Copyright (chr) 2016-2018, Knut Reinert & MPI Molekulare Genetik
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ============================================================================
+
+/*!\file
+ * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
+ * \brief Provides seqan3::nucleotide_base.
+ */
+
+#pragma once
+
+#include <seqan3/alphabet/detail/alphabet_base.hpp>
+#include <seqan3/alphabet/detail/convert.hpp>
+#include <seqan3/alphabet/nucleotide/concept.hpp>
+
+namespace seqan3
+{
+
+/*!\brief A CRTP-base that refines seqan3::alphabet_base and is used by the nucleotides.
+ * \tparam derived_type The CRTP parameter type.
+ * \tparam size         The size of the alphabet.
+ * \tparam char_t       The character type of the alphabet (set this to `void` when defining just a
+ *                      seqan3::semi_alphabet_concept).
+ */
+template <typename derived_type, auto size, typename char_t = char>
+class nucleotide_base : public alphabet_base<derived_type, size, char_t>
+{
+private:
+    //!\brief Type of the base class.
+    using base_t = alphabet_base<derived_type, size, char_t>;
+
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    constexpr nucleotide_base() : base_t{} {}
+    constexpr nucleotide_base(nucleotide_base const &) = default;
+    constexpr nucleotide_base(nucleotide_base &&) = default;
+    constexpr nucleotide_base & operator=(nucleotide_base const &) = default;
+    constexpr nucleotide_base & operator=(nucleotide_base &&) = default;
+    //!\}
+
+    //! Befriend the derived_type so it can instantiate.
+    friend derived_type;
+
+public:
+    // Import from base:
+    using typename base_t::char_type;
+    using typename base_t::rank_type;
+    using base_t::value_size;
+    using base_t::to_rank;
+
+    /*!\name Letter values
+     * \brief Static member "letters" that can be assigned to the alphabet or used in aggregate initialization.
+     * \details Similar to an Enum interface.
+     */
+    //!\{
+    static derived_type constexpr A       = assign_char(derived_type{}, 'A');
+    static derived_type constexpr B       = assign_char(derived_type{}, 'B');
+    static derived_type constexpr C       = assign_char(derived_type{}, 'C');
+    static derived_type constexpr D       = assign_char(derived_type{}, 'D');
+    static derived_type constexpr G       = assign_char(derived_type{}, 'G');
+    static derived_type constexpr H       = assign_char(derived_type{}, 'H');
+    static derived_type constexpr K       = assign_char(derived_type{}, 'K');
+    static derived_type constexpr M       = assign_char(derived_type{}, 'M');
+    static derived_type constexpr N       = assign_char(derived_type{}, 'N');
+    static derived_type constexpr R       = assign_char(derived_type{}, 'R');
+    static derived_type constexpr S       = assign_char(derived_type{}, 'S');
+    static derived_type constexpr T       = assign_char(derived_type{}, 'T');
+    static derived_type constexpr U       = assign_char(derived_type{}, 'U');
+    static derived_type constexpr V       = assign_char(derived_type{}, 'V');
+    static derived_type constexpr W       = assign_char(derived_type{}, 'W');
+    static derived_type constexpr Y       = assign_char(derived_type{}, 'Y');
+    static derived_type constexpr UNKNOWN = assign_char(derived_type{}, 'N');
+    //!\}
+
+    /*!\name Conversion operators
+     * \{
+     */
+//     //!\brief Implicit conversion between dna* and rna* of the same size.
+//     //!\tparam other_nucl_type The type to convert to; must satisfy seqan3::nucleotide_concept and have the same \link value_size \endlink.
+//     template <typename other_nucl_type>
+//     //!\cond
+//         requires !std::Same<derived_type, other_nucl_type> && nucleotide_concept<other_nucl_type> &&
+//                  value_size == alphabet_size_v<other_nucl_type>
+//     //!\endcond
+//     constexpr operator other_nucl_type() const noexcept
+//     {
+//         return other_nucl_type{}.assign_rank(to_rank());
+//     }
+
+    //!\brief Explicit conversion to any other nucleotide alphabet (via char representation).
+    //!\tparam other_nucl_type The type to convert to; must satisfy seqan3::nucleotide_concept.
+    template <typename other_nucl_type>
+    //!\cond
+        requires !std::Same<derived_type, other_nucl_type> && nucleotide_concept<other_nucl_type>
+    //!\endcond
+    explicit constexpr operator other_nucl_type() const noexcept
+    {
+        return detail::convert_through_char_representation<other_nucl_type, derived_type>[to_rank()];
+    }
+    //!\}
+
+    /*!\name Read functions
+     * \{
+     */
+
+    /*!\brief Return the complement of the letter.
+     *
+     * \details
+     *
+     * See \ref nucleotide for the actual values.
+     *
+     * Satisfies the seqan3::nucleotide_concept::complement() requirement via the seqan3::complement() wrapper.
+     *
+     * \par Complexity
+     *
+     * Constant.
+     *
+     * \par Exceptions
+     *
+     * Guaranteed not to throw.
+     */
+    constexpr derived_type complement() const noexcept
+    {
+        return derived_type::complement_table[to_rank()];
+    }
+    //!\}
+};
+
+} // namespace seqan3

--- a/include/seqan3/alphabet/quality/concept.hpp
+++ b/include/seqan3/alphabet/quality/concept.hpp
@@ -58,20 +58,24 @@ namespace seqan3
  * \{
  */
 
+template <typename alphabet_type>
+struct underlying_phred
+{};
+
 /*!\brief The internal phred type.
  * \ingroup quality
  * \tparam alphabet_type The type of alphabet. Must model the seqan3::quality_concept.
  *
  * The underlying_phred type requires the quality_concept.
  */
-template <typename alphabet_type>
+template <typename alphabet_with_member_type>
 //!\cond
-    requires requires () { typename alphabet_type::phred_type; }
+    requires requires () { typename alphabet_with_member_type::phred_type; }
 //!\endcond
-struct underlying_phred
+struct underlying_phred<alphabet_with_member_type>
 {
     //!\brief The underlying phred data type.
-    using type = typename alphabet_type::phred_type;
+    using type = typename alphabet_with_member_type::phred_type;
 };
 
 /*!\brief The internal phred type.
@@ -95,7 +99,16 @@ template <typename alphabet_type>
 //!\cond
     requires requires (alphabet_type v) { { v.assign_phred('c') }; }
 //!\endcond
-constexpr alphabet_type assign_phred(alphabet_type & chr, char const in)
+constexpr alphabet_type & assign_phred(alphabet_type & chr, char const in)
+{
+    return chr.assign_phred(in);
+}
+
+template <typename alphabet_type>
+//!\cond
+    requires requires (alphabet_type v) { { v.assign_phred('c') }; }
+//!\endcond
+constexpr alphabet_type assign_phred(alphabet_type && chr, char const in)
 {
     return chr.assign_phred(in);
 }

--- a/include/seqan3/alphabet/quality/phred42.hpp
+++ b/include/seqan3/alphabet/quality/phred42.hpp
@@ -39,11 +39,7 @@
 
 #pragma once
 
-#include <cassert>
-#include <utility>
-
-#include <seqan3/alphabet/detail/convert.hpp>
-#include <seqan3/alphabet/quality/concept.hpp>
+#include <seqan3/alphabet/quality/quality_base.hpp>
 
 // ------------------------------------------------------------------
 // phred42
@@ -55,6 +51,9 @@ namespace seqan3
 /*!\brief Quality type for traditional Sanger and modern Illumina Phred scores (typical range).
  * \implements seqan3::quality_concept
  * \implements seqan3::detail::constexpr_alphabet_concept
+ * \implements seqan3::trivially_copyable_concept
+ * \implements seqan3::standard_layout_concept
+ *
  * \ingroup quality
  *
  * \details
@@ -67,217 +66,45 @@ namespace seqan3
  *
  * \snippet test/snippet/alphabet/quality/phred42.cpp general
  */
-struct phred42
+class phred42 : public quality_base<phred42, 42>
 {
-    /*!\name Member types
-    * \{
-    */
-    //!\brief The 0-based integer representation of a quality score.
-    using rank_type = uint8_t;
+private:
+    //!\brief The base class.
+    using base_t = quality_base<phred42, 42>;
 
-    //!\brief The integer representation of a quality score assignable with =operator.
-    using phred_type = uint8_t;
+    //!\brief Befriend seqan3::quality_base.
+    friend base_t;
+    //!\cond \brief Befriend seqan3::alphabet_base.
+    friend base_t::base_t;
+    //!\endcond
 
-    //!\brief The '!'-based character representation of a quality score.
-    using char_type = char;
+public:
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    constexpr phred42() : base_t{} {}
+    constexpr phred42(phred42 const &) = default;
+    constexpr phred42(phred42 &&) = default;
+    constexpr phred42 & operator=(phred42 const &) = default;
+    constexpr phred42 & operator=(phred42 &&) = default;
+    ~phred42() = default;
+
+    //!\brief Construct from phred value.
+    constexpr phred42(phred_type const p) : base_t{p} {}
+
+    // Inherit converting constructor
+    using base_t::base_t;
     //!\}
 
-    //!\privatesection
     /*!\name Member variables.
-    * \{
-    */
-    //!\brief The internal 0-based rank value.
-    rank_type _value;
-
-    //!\brief The size of the phred score range range.
-    static constexpr rank_type value_size{42};
-
-    //!\brief Maximal phred score allowed as input. The range [42..61] is mapped to 41.
-    static constexpr rank_type max_value_size{62};
+     * \{
+     */
+    //!\brief The projection offset between phred and rank score representation.
+    static constexpr phred_type offset_phred{0};
 
     //!\brief The projection offset between char and rank score representation.
     static constexpr char_type offset_char{'!'};
     //!\}
-
-    /*!\name Read functions
-     * \{
-     */
-    /*!\brief Return the letter as a character of char_type.
-     *
-     * \details
-     *
-     * Satisfies the seqan3::alphabet_concept::to_char() requirement via the seqan3::to_char() wrapper.
-     *
-     * \par Complexity
-     *
-     * Constant.
-     *
-     * \par Exceptions
-     *
-     * Guaranteed not to throw.
-     */
-    constexpr char_type to_char() const noexcept
-    {
-        return static_cast<char_type>(_value + offset_char);
-    }
-
-    /*!\brief Return the letter's numeric phred code.
-     *
-     * \details
-     *
-     * Satisfies the seqan3::detail::quality_concept::to_phred() requirement via the seqan3::to_phred() wrapper.
-     *
-     * \par Complexity
-     *
-     * Constant.
-     *
-     * \par Exceptions
-     *
-     * Guaranteed not to throw.
-     */
-    constexpr phred_type to_phred() const noexcept
-    {
-        return _value;
-    }
-
-    /*!\brief Return the letter's rank in the quality alphabet.
-     *
-     * \details
-     *
-     * Satisfies the seqan3::semi_alphabet_concept::to_rank() requirement via the seqan3::to_rank() wrapper.
-     *
-     * \par Complexity
-     *
-     * Constant.
-     *
-     * \par Exceptions
-     *
-     * Guaranteed not to throw.
-     */
-    constexpr rank_type to_rank() const noexcept
-    {
-        return _value;
-    }
-    //!\}
-
-    /*!\name Write functions
-     * \{
-     */
-    /*!\brief Assign from a character.
-     *
-     * \details
-     *
-     * Satisfies the seqan3::alphabet_concept::assign_char() requirement via the seqan3::assign_char() wrapper.
-     *
-     * \par Complexity
-     *
-     * Constant.
-     */
-    constexpr phred42 & assign_char(char_type const c) noexcept
-    {
-        _value = char_to_value[c];
-        return *this;
-    }
-
-    /*!\brief Assign from the numeric phred value.
-     *
-     * \details
-     *
-     * Satisfies the seqan3::quality_concept::assign_phred() requirement via the seqan3::assign_rank() wrapper.
-     *
-     * \par Complexity
-     *
-     * Constant.
-     */
-    constexpr phred42 & assign_phred(phred_type const p) noexcept
-    {
-        // p >= 0 is implicitly always true
-        assert(p < max_value_size);
-        // round to largest allowed value when `p` exceeds maximal rank value
-        _value =  (p < value_size) ? p : value_size - 1;
-        return *this;
-    }
-
-    /*!\brief Assign from a the numeric rank value.
-     *
-     * \details
-     *
-     * Satisfies the seqan3::semi_alphabet_concept::assign_rank() requirement via the seqan3::assign_rank() wrapper.
-     *
-     * \par Complexity
-     *
-     * Constant.
-     *
-     * \par Exceptions
-     *
-     * Guaranteed not to throw.
-     */
-    constexpr phred42 & assign_rank(phred_type const p) noexcept
-    {
-        return assign_phred(p);
-    }
-    //!\}
-
-    //!\brief Explicit conversion to any other quality alphabet (via char representation).
-    //!\tparam other_qual_type The type to convert to; must satisfy seqan3::quality_concept.
-    //
-    template <quality_concept other_qual_type>
-    explicit constexpr operator other_qual_type() const noexcept
-    {
-        return detail::convert_through_phred_representation<other_qual_type, std::decay_t<decltype(*this)>>[to_phred()];
-    }
-    //!\}
-
-    /*!\name Comparison operators
-     * \{
-     */
-    constexpr bool operator==(const phred42 & rhs) const noexcept
-    {
-        return _value == rhs._value;
-    }
-
-    constexpr bool operator!=(const phred42 & rhs) const noexcept
-    {
-        return _value != rhs._value;
-    }
-
-    constexpr bool operator<(const phred42 & rhs) const noexcept
-    {
-        return _value < rhs._value;
-    }
-
-    constexpr bool operator>(const phred42 & rhs) const noexcept
-    {
-        return _value > rhs._value;
-    }
-
-    constexpr bool operator<=(const phred42 & rhs) const noexcept
-    {
-        return _value <= rhs._value;
-    }
-
-    constexpr bool operator>=(const phred42 & rhs) const noexcept
-    {
-        return _value >= rhs._value;
-    }
-    //!\}
-
-protected:
-    //!\privatesection
-    //!\brief Char to value conversion table.
-    static constexpr std::array<char_type, 256> char_to_value
-    {
-        [] () constexpr
-        {
-            std::array<char_type, 256> ret{};
-            for (char_type c = '!'; c <= 'J'; ++c)
-                ret[c] = c - '!';
-            // reduce ['K' .. '_']  to 'J'
-            for (char_type c = 'K'; c <= '^'; ++c)
-                ret[c] = ret['J'];
-            return ret;
-        }()
-    };
 };
 
 } // namespace seqan3

--- a/include/seqan3/alphabet/quality/phred63.hpp
+++ b/include/seqan3/alphabet/quality/phred63.hpp
@@ -39,11 +39,7 @@
 
 #pragma once
 
-#include <cassert>
-
-#include <seqan3/alphabet/detail/convert.hpp>
-#include <seqan3/alphabet/quality/concept.hpp>
-#include <seqan3/core/platform.hpp>
+#include <seqan3/alphabet/quality/quality_base.hpp>
 
 // ------------------------------------------------------------------
 // phred63
@@ -55,6 +51,9 @@ namespace seqan3
 /*!\brief Quality type for traditional Sanger and modern Illumina Phred scores (full range).
  * \implements seqan3::quality_concept
  * \implements seqan3::detail::constexpr_alphabet_concept
+ * \implements seqan3::trivially_copyable_concept
+ * \implements seqan3::standard_layout_concept
+ *
  * \ingroup quality
  *
  * \details
@@ -65,209 +64,45 @@ namespace seqan3
  *
  * \snippet test/snippet/alphabet/quality/phred63.cpp general
  */
-struct phred63
+class phred63 : public quality_base<phred63, 63>
 {
-    /*!\name Member types
-    * \{
-    */
-    //!\brief The 0-based rank representation of a quality score.
-    using rank_type = uint8_t;
+private:
+    //!\brief The base class.
+    using base_t = quality_base<phred63, 63>;
 
-    //!\brief The 0-based integer representation of a quality score assignable with =operator.
-    using phred_type = uint8_t;
+    //!\brief Befriend seqan3::quality_base.
+    friend base_t;
+    //!\cond \brief Befriend seqan3::alphabet_base.
+    friend base_t::base_t;
+    //!\endcond
 
-    //!\brief The '!'-based character representation of a quality score.
-    using char_type = char;
+public:
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    constexpr phred63() : base_t{} {}
+    constexpr phred63(phred63 const &) = default;
+    constexpr phred63(phred63 &&) = default;
+    constexpr phred63 & operator=(phred63 const &) = default;
+    constexpr phred63 & operator=(phred63 &&) = default;
+    ~phred63() = default;
+
+    //!\brief Construct from phred value.
+    constexpr phred63(phred_type const p) : base_t{p} {}
+
+    // Inherit converting constructor
+    using base_t::base_t;
     //!\}
 
-    //!\privatesection
     /*!\name Member variables.
-    * \{
-    */
-    //!\brief The internal 0-based rank value.
-    rank_type _value;
-
-    //!\brief The phred score range size for Illumina 1.8+ standard.
-    static constexpr rank_type value_size{63};
+     * \{
+     */
+    //!\brief The projection offset between phred and rank score representation.
+    static constexpr phred_type offset_phred{0};
 
     //!\brief The projection offset between char and rank score representation.
     static constexpr char_type offset_char{'!'};
     //!\}
-
-    /*!\name Read functions
-     * \{
-     */
-    /*!\brief Return the letter as a character of char_type.
-     *
-     * \details
-     *
-     * Satisfies the seqan3::alphabet_concept::to_char() requirement via the seqan3::to_char() wrapper.
-     *
-     * \par Complexity
-     *
-     * Constant.
-     *
-     * \par Exceptions
-     *
-     * Guaranteed not to throw.
-     */
-    constexpr char_type to_char() const noexcept
-    {
-        return static_cast<char_type>(_value + offset_char);
-    }
-
-    /*!\brief Return the letter's numeric phred code.
-     *
-     * \details
-     *
-     * Satisfies the seqan3::detail::quality_concept::to_phred() requirement via the seqan3::to_phred() wrapper.
-     *
-     * \par Complexity
-     *
-     * Constant.
-     *
-     * \par Exceptions
-     *
-     * Guaranteed not to throw.
-     */
-    constexpr phred_type to_phred() const noexcept
-    {
-        return _value;
-    }
-
-    /*!\brief Return the letter as a character of char_type.
-     *
-     * \details
-     *
-     * Satisfies the seqan3::alphabet_concept::to_char() requirement via the seqan3::to_char() wrapper.
-     *
-     * \par Complexity
-     *
-     * Constant.
-     *
-     * \par Exceptions
-     *
-     * Guaranteed not to throw.
-     */
-    constexpr rank_type to_rank() const noexcept
-    {
-        return _value;
-    }
-    //!\}
-
-    /*!\name Write functions
-     * \{
-     */
-     /*!\brief Assign from a character.
-      *
-      * \details
-      *
-      * Satisfies the seqan3::alphabet_concept::assign_char() requirement via the seqan3::assign_char() wrapper.
-      *
-      * \par Complexity
-      *
-      * Constant.
-      */
-    constexpr phred63 & assign_char(char_type const c) noexcept
-    {
-        _value = char_to_value[c];
-        return *this;
-    }
-
-    /*!\brief Assign from the numeric phred value.
-     *
-     * \details
-     *
-     * Satisfies the seqan3::quality_concept::assign_phred() requirement via the seqan3::assign_rank() wrapper.
-     *
-     * \par Complexity
-     *
-     * Constant.
-     */
-    constexpr phred63 & assign_phred(phred_type const p) noexcept
-    {
-        // p >= 0 is implicitly always true
-        assert(p < value_size);
-        _value = p;
-        return *this;
-    }
-
-    /*!\brief Assign from a the numeric rank value.
-     *
-     * \details
-     *
-     * Satisfies the seqan3::semi_alphabet_concept::assign_rank() requirement via the seqan3::assign_rank() wrapper.
-     *
-     * \par Complexity
-     *
-     * Constant.
-     *
-     * \par Exceptions
-     *
-     * Guaranteed not to throw.
-     */
-    constexpr phred63 & assign_rank(phred_type const p) noexcept
-    {
-        return assign_phred(p);
-    }
-    //!\}
-
-    //!\brief Explicit conversion to any other nucleotide alphabet (via char representation).
-    //!\tparam other_nucl_type The type to convert to; must model seqan3::quality_concept.
-    template <quality_concept other_qual_type>
-    explicit constexpr operator other_qual_type() const noexcept
-    {
-        return detail::convert_through_phred_representation<other_qual_type, std::decay_t<decltype(*this)>>[to_phred()];
-    }
-    //!\}
-
-    /*!\name Comparison operators.
-    * \{
-    */
-    constexpr bool operator==(const phred63 & rhs) const
-    {
-        return _value == rhs._value;
-    }
-
-    constexpr bool operator!=(const phred63 & rhs) const
-    {
-        return _value != rhs._value;
-    }
-
-    constexpr bool operator<(const phred63 & rhs) const
-    {
-        return _value < rhs._value;
-    }
-
-    constexpr bool operator>(const phred63 & rhs) const
-    {
-        return _value > rhs._value;
-    }
-
-    constexpr bool operator<=(const phred63 & rhs) const
-    {
-        return _value <= rhs._value;
-    }
-
-    constexpr bool operator>=(const phred63 & rhs) const
-    {
-        return _value >= rhs._value;
-    }
-    //!\}
-
-protected:
-    //!\privatesection
-    //!\copydoc seqan3::phred42::char_to_value
-    static constexpr std::array<char_type, 256> char_to_value
-    {
-        [] () constexpr
-        {
-            std::array<char_type, 256> ret{};
-            for (char_type c = '!'; c <= '~'; ++c)
-                ret[c] = c - offset_char;
-            return ret;
-        }()
-    };
 };
 
 } // namespace seqan3

--- a/include/seqan3/alphabet/quality/phred68legacy.hpp
+++ b/include/seqan3/alphabet/quality/phred68legacy.hpp
@@ -39,12 +39,7 @@
 
 #pragma once
 
-#include <algorithm>
-#include <cassert>
-
-#include <seqan3/alphabet/detail/convert.hpp>
-#include <seqan3/alphabet/quality/concept.hpp>
-#include <seqan3/core/platform.hpp>
+#include <seqan3/alphabet/quality/quality_base.hpp>
 
 // ------------------------------------------------------------------
 // phred68legacy
@@ -56,6 +51,9 @@ namespace seqan3
 /*!\brief Quality type for Solexa and deprecated Illumina formats.
  * \implements seqan3::quality_concept
  * \implements seqan3::detail::constexpr_alphabet_concept
+ * \implements seqan3::trivially_copyable_concept
+ * \implements seqan3::standard_layout_concept
+ *
  * \ingroup quality
  *
  * \details
@@ -66,215 +64,45 @@ namespace seqan3
  *
  * \snippet test/snippet/alphabet/quality/phred68legacy.cpp general
  */
-struct phred68legacy
+class phred68legacy : public quality_base<phred68legacy, 68>
 {
-    /*!\name Member types
-    * \{
-    */
-    //!\brief The 0-based rank representation of a quality score.
-    using rank_type = uint8_t;
+private:
+    //!\brief The base class.
+    using base_t = quality_base<phred68legacy, 68>;
 
-    //!\brief The -5-based integer representation of a quality score assignable with =operator.
-    using phred_type = int8_t;
+    //!\brief Befriend seqan3::quality_base.
+    friend base_t;
+    //!\cond \brief Befriend seqan3::alphabet_base.
+    friend base_t::base_t;
+    //!\endcond
 
-    //!\brief The ';'-based character representation of a quality score.
-    using char_type = char;
+public:
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    constexpr phred68legacy() : base_t{} {}
+    constexpr phred68legacy(phred68legacy const &) = default;
+    constexpr phred68legacy(phred68legacy &&) = default;
+    constexpr phred68legacy & operator=(phred68legacy const &) = default;
+    constexpr phred68legacy & operator=(phred68legacy &&) = default;
+    ~phred68legacy() = default;
+
+    //!\brief Construct from phred value.
+    constexpr phred68legacy(phred_type const p) : base_t{p} {}
+
+    // Inherit converting constructor
+    using base_t::base_t;
     //!\}
 
-    //!\privatesection
     /*!\name Member variables.
-    * \{
-    */
-    //!\brief The internal 0-based rank value.
-    rank_type _value;
-
-    //!\brief The phred score range size for the Solexa standard.
-    static constexpr rank_type value_size{68};
+     * \{
+     */
+    //!\brief The projection offset between phred and rank score representation.
+    static constexpr phred_type offset_phred{-5};
 
     //!\brief The projection offset between char and rank score representation.
     static constexpr char_type offset_char{';'};
-
-    //! projection offsets of a phred quality score
-    static constexpr phred_type offset_phred{-5};
     //!\}
-
-    /*!\name Read functions
-     * \{
-     */
-    /*!\brief Return the letter as a character of char_type.
-     *
-     * \details
-     *
-     * Satisfies the seqan3::alphabet_concept::to_char() requirement via the seqan3::to_char() wrapper.
-     *
-     * \par Complexity
-     *
-     * Constant.
-     *
-     * \par Exceptions
-     *
-     * Guaranteed not to throw.
-     */
-    constexpr char_type to_char() const noexcept
-    {
-        return static_cast<char_type>(_value + offset_char);
-    }
-
-    /*!\brief Return the letter's numeric phred code.
-     *
-     * \details
-     *
-     * Satisfies the seqan3::detail::quality_concept::to_phred() requirement via the seqan3::to_phred() wrapper.
-     *
-     * \par Complexity
-     *
-     * Constant.
-     *
-     * \par Exceptions
-     *
-     * Guaranteed not to throw.
-     */
-    constexpr phred_type to_phred() const noexcept
-    {
-        return _value + offset_phred;
-    }
-
-    /*!\brief Return the letter as a character of char_type.
-     *
-     * \details
-     *
-     * Satisfies the seqan3::alphabet_concept::to_char() requirement via the seqan3::to_char() wrapper.
-     *
-     * \par Complexity
-     *
-     * Constant.
-     *
-     * \par Exceptions
-     *
-     * Guaranteed not to throw.
-     */
-    constexpr rank_type to_rank() const noexcept
-    {
-        return _value;
-    }
-    //!\}
-
-    /*!\name Write functions
-     * \{
-     */
-     /*!\brief Assign from a character.
-      *
-      * \details
-      *
-      * Satisfies the seqan3::alphabet_concept::assign_char() requirement via the seqan3::assign_char() wrapper.
-      *
-      * \par Complexity
-      *
-      * Constant.
-      */
-    constexpr phred68legacy & assign_char(char_type const c) noexcept
-    {
-        _value = char_to_value[c];
-        return *this;
-    }
-
-    /*!\brief Assign from the numeric phred value.
-     *
-     * \details
-     *
-     * Satisfies the seqan3::quality_concept::assign_phred() requirement via the seqan3::assign_rank() wrapper.
-     *
-     * \par Complexity
-     *
-     * Constant.
-     */
-    constexpr phred68legacy & assign_phred(phred_type const p) noexcept
-    {
-        // p >= 0 is implicitly always true
-        assert((p >= offset_phred) && (p < value_size + offset_phred));
-        _value = p - offset_phred;
-        return *this;
-    }
-
-    /*!\brief Assign from a the numeric rank value.
-     *
-     * \details
-     *
-     * Satisfies the seqan3::semi_alphabet_concept::assign_rank() requirement via the seqan3::assign_rank() wrapper.
-     *
-     * \par Complexity
-     *
-     * Constant.
-     */
-    constexpr phred68legacy & assign_rank(rank_type const p) noexcept
-    {
-        // p implicitly always true due to unsignedness of p
-        assert(p < value_size);
-        _value = p;
-        return *this;
-    }
-    //!\}
-
-    /*!\name Conversion operators
-     * \{
-     */
-    //!\brief Explicit conversion to any other nucleotide alphabet (via char representation).
-    //!\tparam other_nucl_type The type to convert to; must satisfy seqan3::quality_concept.
-    //  phred scores below 0 will be truncated, i.e. mapped to phred64::phred_type = 0.
-    template <quality_concept other_qual_type>
-    explicit constexpr operator other_qual_type() const //noexcept
-    {
-        return detail::convert_through_phred_representation<other_qual_type, std::decay_t<decltype(*this)>>[std::max<phred_type>(0, to_phred())];
-    }
-    //!\}
-
-    /*!\name Comparison operators.
-    * \{
-    */
-    constexpr bool operator==(const phred68legacy & rhs) const
-    {
-        return this->_value == rhs._value;
-    }
-
-    constexpr bool operator!=(const phred68legacy & rhs) const
-    {
-        return this->_value != rhs._value;
-    }
-
-    constexpr bool operator<(const phred68legacy & rhs) const
-    {
-        return this->_value < rhs._value;
-    }
-
-    constexpr bool operator>(const phred68legacy & rhs) const
-    {
-        return this->_value > rhs._value;
-    }
-
-    constexpr bool operator<=(const phred68legacy & rhs) const
-    {
-        return this->_value <= rhs._value;
-    }
-
-    constexpr bool operator>=(const phred68legacy & rhs) const
-    {
-        return this->_value >= rhs._value;
-    }
-    //!\}
-
-protected:
-    //!\privatesection
-    //!\copydoc seqan3::phred42::char_to_value
-    static constexpr std::array<char_type, 256> char_to_value
-    {
-        [] () constexpr
-        {
-            std::array<char_type, 256> ret{};
-            for (char_type c = ';'; c <= '~'; ++c)
-                ret[c] = c - offset_char;
-            return ret;
-        }()
-    };
 };
 
 } // namespace seqan3

--- a/include/seqan3/alphabet/quality/qualified.hpp
+++ b/include/seqan3/alphabet/quality/qualified.hpp
@@ -55,6 +55,9 @@ namespace seqan3
  * \tparam quality_alphabet_t  Type of the quality; must satisfy seqan3::quality_concept.
  * \implements seqan3::quality_concept
  * \implements seqan3::detail::constexpr_alphabet_concept
+ * \implements seqan3::trivially_copyable_concept
+ * \implements seqan3::standard_layout_concept
+ *
  *
  * This composition pairs an arbitrary alphabet with a quality alphabet, where
  * each alphabet character is stored together with its quality score in a
@@ -102,7 +105,7 @@ public:
     /*!\name Constructors, destructor and assignment
      * \{
      */
-    qualified() = default;
+    constexpr qualified() = default;
     constexpr qualified(qualified const &) = default;
     constexpr qualified(qualified &&) = default;
     constexpr qualified & operator =(qualified const &) = default;
@@ -111,7 +114,14 @@ public:
 
     using base_type::base_type; // Inherit non-default constructors
 
-    using base_type::operator=; // Inherit non-default assignment operators
+    // Inherit operators from base
+    using base_type::operator=;
+    using base_type::operator==;
+    using base_type::operator!=;
+    using base_type::operator>=;
+    using base_type::operator<=;
+    using base_type::operator<;
+    using base_type::operator>;
 
     //!\copydoc cartesian_composition::cartesian_composition(component_type const alph)
     SEQAN3_DOXYGEN_ONLY(( constexpr qualified(component_type const alph) {} ))

--- a/include/seqan3/alphabet/quality/quality_base.hpp
+++ b/include/seqan3/alphabet/quality/quality_base.hpp
@@ -1,0 +1,195 @@
+// ============================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ============================================================================
+//
+// Copyright (c) 2006-2018, Knut Reinert & Freie Universitaet Berlin
+// Copyright (c) 2016-2018, Knut Reinert & MPI Molekulare Genetik
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ============================================================================
+
+/*!\file
+ * \author Marie Hoffmann <marie.hoffmann AT fu-berlin.de>
+ * \brief Contains seqan3::phred42 quality scores.
+ */
+
+#pragma once
+
+#include <seqan3/alphabet/detail/alphabet_base.hpp>
+#include <seqan3/alphabet/detail/convert.hpp>
+#include <seqan3/alphabet/quality/concept.hpp>
+
+namespace seqan3
+{
+
+/*!\brief A CRTP-base that refines seqan3::alphabet_base and is used by the quality alphabets.
+ * \ingroup quality
+ * \tparam derived_type The CRTP parameter type.
+ * \tparam size         The size of the alphabet.
+ */
+template <typename derived_type, auto size>
+class quality_base : public alphabet_base<derived_type, size, char>
+{
+public:
+    /*!\name Member types
+     * \{
+     */
+    //!\brief The integer representation of a quality score assignable with =operator.
+    using phred_type = int8_t;
+    //!\}
+
+private:
+    //!\brief The base type.
+    using base_t = alphabet_base<derived_type, size, char>;
+
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    constexpr quality_base() : base_t{} {}
+    constexpr quality_base(quality_base const &) = default;
+    constexpr quality_base(quality_base &&) = default;
+    constexpr quality_base & operator=(quality_base const &) = default;
+    constexpr quality_base & operator=(quality_base &&) = default;
+    ~quality_base() = default;
+
+    //!\brief Allow construction from the phred value.
+    constexpr quality_base(phred_type const p) noexcept
+    {
+        static_cast<derived_type *>(this)->assign_phred(p);
+    }
+    //!\}
+
+    //!\brief Befriend the derived_type so it can instantiate.
+    friend derived_type;
+
+public:
+    // Import from base type:
+    using base_t::value_size;
+    using base_t::to_rank;
+    using base_t::assign_rank;
+    using typename base_t::char_type;
+    using typename base_t::rank_type;
+
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    // This constructor needs to be public, because constructor templates are not inherited otherwise
+    //!\brief Allow explicit construction from any other quality type by means of the phred representation.
+    template <typename other_qual_type>
+    //!\cond
+        requires !std::Same<quality_base, other_qual_type> &&
+                 !std::Same<derived_type, other_qual_type> &&
+                 quality_concept<other_qual_type>
+    //!\endcond
+    explicit constexpr quality_base(other_qual_type const & other) noexcept
+    {
+        using seqan3::assign_phred;
+        using seqan3::to_phred;
+        assign_phred(static_cast<derived_type &>(*this), to_phred(other));
+    }
+    //!\}
+
+    /*!\name Read functions
+     * \{
+     */
+    //!\copydoc seqan3::alphabet_base::to_char
+    constexpr char_type to_char() const noexcept
+    {
+        return static_cast<char_type>(to_rank()) + derived_type::offset_char;
+    }
+
+    //!\brief Return the alphabet's value in phred representation.
+    constexpr phred_type to_phred() const noexcept
+    {
+        return static_cast<phred_type>(to_rank()) + derived_type::offset_phred;
+    }
+    //!\}
+
+    /*!\name Write functions
+     * \{
+     */
+
+    /*!\brief Assign from the numeric phred value.
+     *
+     * \details
+     *
+     * Satisfies the seqan3::quality_concept::assign_phred() requirement via the seqan3::assign_rank() wrapper.
+     *
+     * \par Complexity
+     *
+     * Constant.
+     */
+    constexpr derived_type & assign_phred(phred_type const p) noexcept
+    {
+        return assign_rank(phred_to_rank[static_cast<rank_type>(p)]);
+    }
+    //!\}
+
+protected:
+    //!\brief Phred to rank conversion table.
+    static std::array<rank_type, 256> constexpr phred_to_rank
+    {
+        [] () constexpr
+        {
+            std::array<rank_type, 256> ret{};
+
+            for (int64_t i = std::numeric_limits<phred_type>::lowest(); i <= std::numeric_limits<phred_type>::max(); ++i)
+            {
+                if (i < derived_type::offset_phred)                     // map too-small to smallest possible
+                    ret[static_cast<rank_type>(i)] = 0;
+                else if (i >= derived_type::offset_phred + value_size)  // map too-large to highest possible
+                    ret[static_cast<rank_type>(i)] = value_size - 1;
+                else                                                    // map valid range to identity
+                    ret[static_cast<rank_type>(i)] = i - derived_type::offset_phred;
+            }
+            return ret;
+        }()
+    };
+
+    //!\brief Char to rank conversion table.
+    static std::array<rank_type, 256> constexpr char_to_rank
+    {
+        [] () constexpr
+        {
+            std::array<rank_type, 256> ret{};
+
+            for (int64_t i = std::numeric_limits<char_type>::lowest(); i <= std::numeric_limits<char_type>::max(); ++i)
+            {
+                if (i < derived_type::offset_char)                     // map too-small to smallest possible
+                    ret[static_cast<rank_type>(i)] = 0;
+                else if (i >= derived_type::offset_char + value_size)  // map too-large to highest possible
+                    ret[static_cast<rank_type>(i)] = value_size - 1;
+                else                                                   // map valid range to identity
+                    ret[static_cast<rank_type>(i)] = i - derived_type::offset_char;
+            }
+
+            return ret;
+        }()
+    };
+};
+
+} // namespace seqan3

--- a/include/seqan3/alphabet/structure/dssp9.hpp
+++ b/include/seqan3/alphabet/structure/dssp9.hpp
@@ -39,10 +39,11 @@
 
 #pragma once
 
-#include <cassert>
 #include <vector>
 
 #include <seqan3/alphabet/concept.hpp>
+#include <seqan3/alphabet/detail/alphabet_base.hpp>
+#include <seqan3/io/stream/char_operations.hpp>
 
 // ------------------------------------------------------------------
 // dssp9
@@ -52,6 +53,11 @@ namespace seqan3
 {
 
 /*!\brief The protein structure alphabet of the characters "HGIEBTSCX".
+ * \implements seqan3::alphabet_concept
+ * \implements seqan3::detail::constexpr_alphabet_concept
+ * \implements seqan3::trivially_copyable_concept
+ * \implements seqan3::standard_layout_concept
+ *
  * \ingroup structure
  *
  * \details
@@ -76,13 +82,26 @@ namespace seqan3
  * The following code example creates a dssp9 vector, modifies it, and prints the result to stdout.
  * \snippet test/snippet/alphabet/structure/dssp9.cpp general
  */
-
-struct dssp9
+class dssp9 : public alphabet_base<dssp9, 9>
 {
-    //!\brief The type of the alphabet when converted to char (e.g. via to_char()).
-    using char_type = char;
-    //!\brief The type of the alphabet when represented as a number (e.g. via to_rank()).
-    using rank_type = uint8_t;
+private:
+    //!\brief The base class.
+    using base_t = alphabet_base<dssp9, 9>;
+
+    //!\brief Befriend seqan3::alphabet_base.
+    friend base_t;
+
+public:
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    constexpr dssp9() : base_t{} {}
+    constexpr dssp9(dssp9 const &) = default;
+    constexpr dssp9(dssp9 &&) = default;
+    constexpr dssp9 & operator=(dssp9 const &) = default;
+    constexpr dssp9 & operator=(dssp9 &&) = default;
+    ~dssp9() = default;
+    //!\}
 
     /*!\name Letter values
      * \brief Static member "letters" that can be assigned to the alphabet or used in aggregate initialization.
@@ -100,149 +119,46 @@ struct dssp9
     static const dssp9 X;
     //!\}
 
-    //!\name Read functions
-    //!\{
-
-    /*!\brief Get the letter as a character of char_type.
-     * \returns The character representation of this dssp9 letter.
-     */
-    constexpr char_type to_char() const noexcept
-    {
-        return value_to_char[static_cast<rank_type>(_value)];
-    }
-
-    /*!\brief Get the letter's numeric value or rank in the alphabet.
-     * \returns The numeric representation of this dssp9 letter.
-     */
-    constexpr rank_type to_rank() const noexcept
-    {
-        return static_cast<rank_type>(_value);
-    }
-    //!\}
-
-    //!\name Write functions
-    //!\{
-
-    /*!\brief Assign from a character.
-     * \param chr The character that is assigned.
-     * \returns The resulting dssp9 character.
-     */
-    constexpr dssp9 & assign_char(char_type const chr) noexcept
-    {
-        using index_t = std::make_unsigned_t<char_type>;
-        _value = char_to_value[static_cast<index_t>(chr)];
-        return *this;
-    }
-
-    /*!\brief Assign from a numeric value.
-     * \param rnk The rank value that is assigned.
-     * \returns The resulting dssp9 character.
-     */
-    constexpr dssp9 & assign_rank(rank_type const rnk)
-    {
-        assert(rnk < value_size);
-        _value = static_cast<internal_type>(rnk);
-        return *this;
-    }
-    //!\}
-
-    //!\brief The size of the alphabet, i.e. the number of different values it can take.
-    static constexpr rank_type value_size{9};
-
-    //!\name Comparison operators
-    //!\{
-    constexpr bool operator==(dssp9 const & rhs) const noexcept
-    {
-        return _value == rhs._value;
-    }
-
-    constexpr bool operator!=(dssp9 const & rhs) const noexcept
-    {
-        return _value != rhs._value;
-    }
-
-    constexpr bool operator<(dssp9 const & rhs) const noexcept
-    {
-        return _value < rhs._value;
-    }
-
-    constexpr bool operator>(dssp9 const & rhs) const noexcept
-    {
-        return _value > rhs._value;
-    }
-
-    constexpr bool operator<=(dssp9 const & rhs) const noexcept
-    {
-        return _value <= rhs._value;
-    }
-
-    constexpr bool operator>=(dssp9 const & rhs) const noexcept
-    {
-        return _value >= rhs._value;
-    }
-    //!\}
-
 protected:
     //!\privatesection
-    /*!\brief The internal type is a strictly typed enum.
-     *
-     * This is done to prevent aggregate initialization from numbers and/or chars.
-     * It is has the drawback that it also introduces a scope which in turn makes
-     * the static "letter values " members necessary.
-     */
-    enum struct internal_type : rank_type
-    {
-        H, B, E, G, I, T, S, C, X
-    };
 
     //!\brief Value-to-char conversion table.
-    static constexpr char_type value_to_char[value_size]
+    static constexpr char_type rank_to_char[value_size]
     {
         'H', 'B', 'E', 'G', 'I', 'T', 'S', 'C', 'X'
     };
 
     //!\brief Char-to-value conversion table.
-    static constexpr std::array<internal_type, 256> char_to_value
+    static constexpr std::array<rank_type, 256> char_to_rank
     {
         [] () constexpr
         {
-            std::array<internal_type, 256> rank_table{};
+            std::array<rank_type, 256> ret{};
 
             // initialize with X (std::array::fill unfortunately not constexpr)
-            for (internal_type & rnk : rank_table)
-                rnk = internal_type::X;
+            for (rank_type & rnk : ret)
+                rnk = 8;
 
-            // canonical
-            rank_table['H'] = internal_type::H;
-            rank_table['B'] = internal_type::B;
-            rank_table['E'] = internal_type::E;
-            rank_table['G'] = internal_type::G;
-            rank_table['I'] = internal_type::I;
-            rank_table['T'] = internal_type::T;
-            rank_table['S'] = internal_type::S;
-            rank_table['C'] = internal_type::C;
-            rank_table['X'] = internal_type::X;
+            // reverse mapping for characters
+            for (rank_type rnk = 0u; rnk < value_size; ++rnk)
+            {
+                ret[static_cast<rank_type>(rank_to_char[rnk])] = rnk;
+            }
 
-            return rank_table;
+            return ret;
         } ()
     };
-
-public:
-    //!\privatesection
-    //!\brief The data member.
-    internal_type _value;
-    //!\publicsection
 };
 
-constexpr dssp9 dssp9::H{internal_type::H};
-constexpr dssp9 dssp9::B{internal_type::B};
-constexpr dssp9 dssp9::E{internal_type::E};
-constexpr dssp9 dssp9::G{internal_type::G};
-constexpr dssp9 dssp9::I{internal_type::I};
-constexpr dssp9 dssp9::T{internal_type::T};
-constexpr dssp9 dssp9::S{internal_type::S};
-constexpr dssp9 dssp9::C{internal_type::C};
-constexpr dssp9 dssp9::X{internal_type::X};
+constexpr dssp9 dssp9::H = dssp9{}.assign_char('H');
+constexpr dssp9 dssp9::B = dssp9{}.assign_char('B');
+constexpr dssp9 dssp9::E = dssp9{}.assign_char('E');
+constexpr dssp9 dssp9::G = dssp9{}.assign_char('G');
+constexpr dssp9 dssp9::I = dssp9{}.assign_char('I');
+constexpr dssp9 dssp9::T = dssp9{}.assign_char('T');
+constexpr dssp9 dssp9::S = dssp9{}.assign_char('S');
+constexpr dssp9 dssp9::C = dssp9{}.assign_char('C');
+constexpr dssp9 dssp9::X = dssp9{}.assign_char('X');
 
 } // namespace seqan3
 
@@ -250,7 +166,7 @@ constexpr dssp9 dssp9::X{internal_type::X};
 // literals
 // ------------------------------------------------------------------
 
-namespace seqan3::literal
+namespace seqan3
 {
 
 /*!\brief dssp9 literal
@@ -260,14 +176,10 @@ namespace seqan3::literal
  * You can use this string literal to easily assign to a vector of dssp9 characters:
  *
  *```.cpp
- *     using namespace seqan3::literal;
  *     std::vector<dssp9> foo{"EHHHHT"_dssp9};
  *     std::vector<dssp9> bar = "EHHHHT"_dssp9;
  *     auto bax = "EHHHHT"_dssp9;
  *```
- *
- * \attention
- * All seqan3 literals are in the namespace seqan3::literal!
  */
 inline std::vector<dssp9> operator""_dssp9(const char * str, std::size_t len)
 {
@@ -280,4 +192,4 @@ inline std::vector<dssp9> operator""_dssp9(const char * str, std::size_t len)
     return vec;
 }
 
-} // namespace seqan3::literal
+} // namespace seqan3

--- a/include/seqan3/alphabet/structure/structured_aa.hpp
+++ b/include/seqan3/alphabet/structure/structured_aa.hpp
@@ -55,6 +55,8 @@ namespace seqan3
  * \ingroup structure
  * \implements seqan3::alphabet_concept
  * \implements seqan3::detail::constexpr_alphabet_concept
+ * \implements seqan3::trivially_copyable_concept
+ * \implements seqan3::standard_layout_concept
  * \tparam sequence_alphabet_t Type of the first aminoacid letter; must satisfy seqan3::alphabet_concept.
  * \tparam structure_alphabet_t Types of further structure letters; must satisfy seqan3::alphabet_concept.
  *
@@ -95,7 +97,7 @@ public:
     /*!\name Constructors, destructor and assignment
      * \{
      */
-    structured_aa() = default;
+    constexpr structured_aa() : base_type{} {}
     constexpr structured_aa(structured_aa const &) = default;
     constexpr structured_aa(structured_aa &&) = default;
     constexpr structured_aa & operator =(structured_aa const &) = default;
@@ -104,7 +106,6 @@ public:
 
     using base_type::base_type; // Inherit non-default constructors
 
-    using base_type::operator=; // Inherit non-default assignment operators
 
     //!\copydoc cartesian_composition::cartesian_composition(component_type const alph)
     SEQAN3_DOXYGEN_ONLY(( constexpr structured_aa(component_type const alph) {} ))
@@ -115,6 +116,15 @@ public:
     //!\copydoc cartesian_composition::operator=(indirect_component_type const alph)
     SEQAN3_DOXYGEN_ONLY(( constexpr structured_aa & operator=(indirect_component_type const alph) {} ))
     //!\}
+
+    // Inherit operators from base
+    using base_type::operator=;
+    using base_type::operator==;
+    using base_type::operator!=;
+    using base_type::operator>=;
+    using base_type::operator<=;
+    using base_type::operator<;
+    using base_type::operator>;
 
     /*!\name Write functions
      * \{

--- a/include/seqan3/alphabet/structure/structured_rna.hpp
+++ b/include/seqan3/alphabet/structure/structured_rna.hpp
@@ -55,6 +55,8 @@ namespace seqan3
  * \ingroup structure
  * \implements seqan3::rna_structure_concept
  * \implements seqan3::detail::constexpr_alphabet_concept
+ * \implements seqan3::trivially_copyable_concept
+ * \implements seqan3::standard_layout_concept
  * \tparam sequence_alphabet_t Type of the first letter; must satisfy seqan3::nucleotide_concept.
  * \tparam structure_alphabet_t Types of further letters; must satisfy seqan3::rna_structure_concept.
  *
@@ -95,7 +97,7 @@ public:
     /*!\name Constructors, destructor and assignment
      * \{
      */
-    structured_rna() = default;
+    constexpr structured_rna() : base_type{} {}
     constexpr structured_rna(structured_rna const &) = default;
     constexpr structured_rna(structured_rna &&) = default;
     constexpr structured_rna & operator =(structured_rna const &) = default;
@@ -103,8 +105,6 @@ public:
     ~structured_rna() = default;
 
     using base_type::base_type; // Inherit non-default constructors
-
-    using base_type::operator=; // Inherit non-default assignment operators
 
     //!\copydoc cartesian_composition::cartesian_composition(component_type const alph)
     SEQAN3_DOXYGEN_ONLY(( constexpr structured_rna(component_type const alph) {} ))
@@ -115,6 +115,15 @@ public:
     //!\copydoc cartesian_composition::operator=(indirect_component_type const alph)
     SEQAN3_DOXYGEN_ONLY(( constexpr structured_rna & operator=(indirect_component_type const alph) {} ))
     //!\}
+
+    // Inherit operators from base
+    using base_type::operator=;
+    using base_type::operator==;
+    using base_type::operator!=;
+    using base_type::operator>=;
+    using base_type::operator<=;
+    using base_type::operator<;
+    using base_type::operator>;
 
     //!\name Write functions
     //!\{

--- a/include/seqan3/core/all.hpp
+++ b/include/seqan3/core/all.hpp
@@ -66,19 +66,6 @@
  * \brief The main SeqAn3 namespace.
  */
 
-/*!\namespace seqan3::literal
- * \brief The SeqAn3 namespace for literals.
- *
- * SeqAn implements "user defined" literals in multiple places, e.g. `auto foo = "ACGTG"_dna4`. These
- * make working with small examples and tests a lot easier, but the risk of having a name collision with
- * another library is higher so follow the example of the standard library and define all our literals
- * in the namespace `seqan3::literal`.
- *
- * \attention
- * This means you cannot use them, unless you explicitly add `using namespace seqan3::literal;` (in addition
- * to `using namespace seqan3;`).
- */
-
 /*!\cond DEV
  * \namespace seqan3::detail
  * \brief The internal SeqAn3 namespace.

--- a/include/seqan3/core/concept/core_language.hpp
+++ b/include/seqan3/core/concept/core_language.hpp
@@ -79,6 +79,17 @@ concept weakly_ordered_by_members_with_concept = requires (lhs_t const & lhs, rh
     lhs.operator>=(rhs); std::Boolean<decltype(lhs.operator>=(rhs))>;
 };
 //!\endcond
+
+/*!\interface   seqan3::detail::convertible_to_by_member_concept <>
+ * \brief       Like seqan3::implicitly_convertible_to_concept, but only considers member operators of the source type.
+ */
+//!\cond
+template <typename source_t, typename target_t>
+concept convertible_to_by_member_concept = requires (source_t s)
+{
+    { s.operator target_t() } -> target_t;
+};
+//!\endcond
 //!\}
 
 } // seqan3::detail
@@ -143,6 +154,22 @@ template <typename t>
 concept floating_point_concept = arithmetic_concept<t> && std::is_floating_point_v<t>;
 //!\endcond
 
+/*!\interface   seqan3::char_concept <>
+ * \extends     std::Integral
+ * \brief       This concept encompasses exactly the types `char`, `signed char`, `unsigned char`, `wchar_t`,
+ *              `char16_t` and `char32_t`.
+ */
+//!\cond
+
+template <typename t>
+concept char_concept = std::Integral<t> &&
+                       (std::Same<t, char> || std::Same<t, unsigned char> || std::Same<t, signed char> ||
+#ifdef __cpp_char8_t
+                        std::Same<t, char8_t> ||
+#endif
+                        std::Same<t, char16_t> || std::Same<t, char32_t> || std::Same<t, wchar_t>);
+//!\endcond
+
 /*!\interface   seqan3::trivially_destructible_concept <>
  * \extends     std::Destructible
  * \brief       A type that satisfies std::is_trivially_destructible_v<t>.
@@ -171,7 +198,7 @@ concept trivially_copyable_concept = std::Copyable<t> && std::is_trivially_copya
  */
 //!\cond
 template <typename t>
-concept trivial_concept = trivially_copyable_concept<t> && trivially_destructible_concept<t>;
+concept trivial_concept = trivially_copyable_concept<t> && trivially_destructible_concept<t> && std::is_trivial_v<t>;
 //!\endcond
 
 /*!\interface   seqan3::standard_layout_concept
@@ -181,6 +208,20 @@ concept trivial_concept = trivially_copyable_concept<t> && trivially_destructibl
 //!\cond
 template <typename t>
 concept standard_layout_concept = std::is_standard_layout_v<t>;
+//!\endcond
+
+/*!\interface   seqan3::weakly_assignable_concept
+ * \brief       Resolves to std::is_assignable_v<t>.
+ * \sa          https://en.cppreference.com/w/cpp/types/is_assignable
+ *
+ * \details
+ *
+ * Note that this requires less than std::Assignable, it simply tests if the expression
+ * `std::declval<T>() = std::declval<U>()` is well-formed.
+ */
+//!\cond
+template <typename t, typename u>
+concept weakly_assignable_concept = std::is_assignable_v<t, u>;
 //!\endcond
 
 }  // namespace seqan3

--- a/include/seqan3/core/concept/tuple.hpp
+++ b/include/seqan3/core/concept/tuple.hpp
@@ -76,11 +76,14 @@ concept tuple_get_concept = requires (tuple_t & v, tuple_t const & v_c)
     requires std::tuple_size_v<tuple_t> > 0;
 
     typename std::tuple_element<0, tuple_t>::type;
-    { std::get<0>(v)              } -> typename std::tuple_element<0, tuple_t>::type &;
-    { std::get<0>(v_c)            } -> typename std::tuple_element<0, tuple_t>::type const &;
-    { std::get<0>(std::move(v))   } -> typename std::tuple_element<0, tuple_t>::type &&;
+    { get<0>(v)              } -> typename std::tuple_element<0, tuple_t>::type;
+//     requires weakly_assignable_concept<decltype(get<0>(v)), typename std::tuple_element<0, tuple_t>::type>;
+    //TODO check that the previous returns something that can be assigned to
+    // unfortunately std::Assignable requires lvalue-reference, but we want to accept xvalues too (returned proxies)
+    { get<0>(v_c)            } -> typename std::tuple_element<0, tuple_t>::type;
+    { get<0>(std::move(v))   } -> typename std::tuple_element<0, tuple_t>::type;
     // TODO: The return type for std::tuple is wrong until gcc-8.0, for gcc > 8.0 this is fixed.
-    { std::get<0>(std::move(v_c)) };// -> typename std::tuple_element<0, tuple_t>::type const &&;
+    { get<0>(std::move(v_c)) };// -> typename std::tuple_element<0, tuple_t>::type const &&;
 };
 //!\endcond
 

--- a/include/seqan3/core/detail/int_types.hpp
+++ b/include/seqan3/core/detail/int_types.hpp
@@ -37,6 +37,7 @@
 #include <type_traits>
 
 #include <seqan3/core/platform.hpp>
+#include <seqan3/std/concepts>
 
 /*!\file
  * \brief Contains metaprogramming utilities for integer types.
@@ -46,7 +47,10 @@
 namespace seqan3::detail
 {
 
-//!\cond DEV
+// ------------------------------------------------------------------
+// min_viable_uint_t
+// ------------------------------------------------------------------
+
 //!\brief Given a value, return the smallest unsigned integer that can hold it.
 template <uint64_t value>
 using min_viable_uint_t = std::conditional_t<value <= 1ull,          bool,
@@ -58,6 +62,14 @@ using min_viable_uint_t = std::conditional_t<value <= 1ull,          bool,
 //!\sa seqan3::min_viable_uint_t
 template <uint64_t value>
 constexpr auto min_viable_uint_v = static_cast<min_viable_uint_t<value>>(value);
-//!\endcond
+
+// ------------------------------------------------------------------
+// size_in_values_v
+// ------------------------------------------------------------------
+
+//!\brief Return the number of values an integral type can have, i.e. the different between min and max.
+template <std::Integral int_t>
+constexpr size_t size_in_values_v = static_cast<size_t>(std::numeric_limits<int_t>::max()) -
+                                    std::numeric_limits<int_t>::lowest();
 
 } // namespace seqan3::detail

--- a/include/seqan3/core/metafunction/pack.hpp
+++ b/include/seqan3/core/metafunction/pack.hpp
@@ -1,0 +1,44 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2018, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2018, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
+ * \brief Provides various metafunctions on a set of types, usually provided as template argument pack.
+ */
+
+#pragma once
+
+#include <type_traits>
+
+#include <seqan3/core/platform.hpp>
+
+namespace seqan3::detail
+{
+
+//!\addtogroup metafunction
+//!\{
+
+//!\brief A type trait that indicates whether the first template argument is contained in the remaining.
+template<typename target_t, typename ...pack>
+struct type_in_pack : std::false_type {};
+
+//!\cond
+template<typename target_t, typename ...pack>
+struct type_in_pack<target_t, target_t, pack...> : std::true_type {};
+
+template<typename target_t, typename pack1, typename ...pack>
+struct type_in_pack<target_t, pack1, pack...> : type_in_pack<target_t, pack...> {};
+//!\endcond
+
+//!\brief Shortcut for seqan3::detail::type_in_pack.
+//!\relates seqan3::detail::type_in_pack
+template<typename target_t, typename ...pack>
+inline bool constexpr type_in_pack_v = type_in_pack<target_t, pack...>::value;
+
+//!\}
+
+} // namespace seqan3::detail

--- a/include/seqan3/io/alignment_file/detail.hpp
+++ b/include/seqan3/io/alignment_file/detail.hpp
@@ -96,8 +96,8 @@ namespace seqan3::detail
  */
 template<typename reference_char_type, typename query_char_type>
 //!\cond
-    requires std::EqualityComparableWith<std::remove_reference_t<reference_char_type>, gap> &&
-             std::EqualityComparableWith<std::remove_reference_t<query_char_type>, gap>
+    requires std::detail::WeaklyEqualityComparableWith<reference_char_type, gap> &&
+             std::detail::WeaklyEqualityComparableWith<query_char_type, gap>
 //!\endcond
 char compare_aligned_values(reference_char_type const reference_char,
                             query_char_type const query_char,
@@ -149,8 +149,8 @@ char compare_aligned_values(reference_char_type const reference_char,
  */
 template<std::ranges::ForwardRange ref_seq_type, std::ranges::ForwardRange query_seq_type>
 //!\cond
-    requires std::EqualityComparableWith<gap, value_type_t<ref_seq_type>> &&
-             std::EqualityComparableWith<gap, value_type_t<query_seq_type>>
+    requires std::detail::WeaklyEqualityComparableWith<gap, reference_t<ref_seq_type>> &&
+             std::detail::WeaklyEqualityComparableWith<gap, reference_t<query_seq_type>>
 //!\endcond
 std::string get_cigar_string(ref_seq_type && ref_seq,
                              query_seq_type && query_seq,
@@ -251,7 +251,7 @@ std::string get_cigar_string(alignment_type && alignment,
                              uint32_t const query_end_pos = 0,
                              bool const extended_cigar = false)
 {
-    return get_cigar_string(std::get<0>(alignment), std::get<1>(alignment),
+    return get_cigar_string(get<0>(alignment), get<1>(alignment),
                             query_start_pos, query_end_pos, extended_cigar);
 }
 

--- a/include/seqan3/io/alignment_file/format_sam.hpp
+++ b/include/seqan3/io/alignment_file/format_sam.hpp
@@ -153,6 +153,7 @@ public:
     alignment_file_format_sam & operator=(alignment_file_format_sam const &) = delete;
     alignment_file_format_sam(alignment_file_format_sam &&) = default;
     alignment_file_format_sam & operator=(alignment_file_format_sam &&) = default;
+    ~alignment_file_format_sam() = default;
     //!\}
 
     //!\brief The valid file extensions for this format; note that you can modify this value.

--- a/include/seqan3/io/sequence_file/format_fasta.hpp
+++ b/include/seqan3/io/sequence_file/format_fasta.hpp
@@ -118,6 +118,7 @@ public:
     sequence_file_format_fasta & operator=(sequence_file_format_fasta const &) = delete;
     sequence_file_format_fasta(sequence_file_format_fasta &&) = default;
     sequence_file_format_fasta & operator=(sequence_file_format_fasta &&) = default;
+    ~sequence_file_format_fasta() = default;
     //!\}
 
     //!\brief The valid file extensions for this format; note that you can modify this value.

--- a/include/seqan3/io/stream/char_operations.hpp
+++ b/include/seqan3/io/stream/char_operations.hpp
@@ -1,0 +1,130 @@
+// ============================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ============================================================================
+//
+// Copyright (c) 2006-2018, Knut Reinert & Freie Universitaet Berlin
+// Copyright (c) 2016-2018, Knut Reinert & MPI Molekulare Genetik
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ============================================================================
+
+/*!\file
+ * \brief Provides utilities for modifying characters.
+ * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <array>
+#include <cmath>
+
+#include <seqan3/core/detail/int_types.hpp>
+#include <seqan3/core/concept/core_language.hpp>
+
+namespace seqan3::detail
+{
+
+//!\brief Auxiliary table for seqan3::to_lower.
+template <typename char_type>
+inline std::array<char_type, detail::size_in_values_v<char_type>> constexpr to_lower_table
+{
+    [] () constexpr
+    {
+        std::array<char_type, detail::size_in_values_v<char_type>> ret{};
+
+        for (size_t i = 0; i < detail::size_in_values_v<char_type>; ++i)
+            ret[i] = i;
+
+        for (size_t i = char_type{'A'}; i <= char_type{'Z'}; ++i)
+            ret[i] = ret[i] - char_type{'A'} + char_type{'a'};
+
+        return ret;
+    } ()
+};
+
+//!\brief Auxiliary table for seqan3::to_upper.
+template <typename char_type>
+inline std::array<char_type, detail::size_in_values_v<char_type>> constexpr to_upper_table
+{
+    [] () constexpr
+    {
+        std::array<char_type, detail::size_in_values_v<char_type>> ret{};
+
+        for (size_t i = 0; i < detail::size_in_values_v<char_type>; ++i)
+            ret[i] = i;
+
+        for (size_t i = char_type{'a'}; i <= char_type{'z'}; ++i)
+            ret[i] = ret[i] - char_type{'a'} + char_type{'A'};
+
+        return ret;
+    } ()
+};
+
+} // namespace seqan3::detail
+
+namespace seqan3
+{
+
+/*!\name Operations on characters
+ * \ingroup stream
+ * \{
+ */
+
+/*!\brief Converts 'A'-'Z' to 'a'-'z' respectively; other characters are returned as is.
+ * \tparam char_type Type of the parameter; must model seqan3::char_concept.
+ * \param c The parameter.
+ * \returns The character converted to lower case.
+ *
+ * \details
+ *
+ * In contrast to std::tolower this function is independent of locale and can be evaluated in a `constexpr` context.
+ */
+template <char_concept char_type>
+constexpr char_type to_lower(char_type const c) noexcept
+{
+    using u_t = std::make_unsigned_t<char_type>;
+    return detail::to_lower_table<char_type>[static_cast<u_t>(c)];
+}
+
+/*!\brief Converts 'a'-'z' to 'A'-'Z' respectively; other characters are returned as is.
+ * \tparam char_type Type of the parameter; must model seqan3::char_concept.
+ * \param c The parameter.
+ * \returns The character converted to upper case.
+ *
+ * \details
+ *
+ * In contrast to std::to_upper this function is independent of locale and can be evaluated in a `constexpr` context.
+ */
+template <char_concept char_type>
+constexpr char_type to_upper(char_type const c) noexcept
+{
+    using u_t = std::make_unsigned_t<char_type>;
+    return detail::to_upper_table<char_type>[static_cast<u_t>(c)];
+}
+//!\}
+
+} // namespace seqan3

--- a/include/seqan3/io/stream/debug_stream.hpp
+++ b/include/seqan3/io/stream/debug_stream.hpp
@@ -304,7 +304,7 @@ inline debug_stream_type & operator<<(debug_stream_type & s, alphabet_t const l)
  * \details
  *
  * If the element type models seqan3::alphabet_concept (and is not an unsigned integer), the range is printed
- * just as if it were a string, i.e. `std::vector<dna4>{dna4::C, dna4:G, dna4::A}` is printed as "CGA".
+ * just as if it were a string, i.e. <tt>std::vector<dna4>{'C'_dna4, 'G'_dna4, 'A'_dna4}</tt> is printed as "CGA".
  *
  * In all other cases the elements are comma separated and the range is enclosed in brackets, i.e.
  * `std::vector<int>{3, 1, 33, 7}` is printed as "[3,1,33,7]".

--- a/include/seqan3/range/view/get.hpp
+++ b/include/seqan3/range/view/get.hpp
@@ -85,12 +85,13 @@ namespace seqan3::view
  * \hideinitializer
  */
 template <size_t index>
-inline auto const get = view::transform([] (auto && in) -> auto &&
+inline auto const get = view::transform([] (auto && in) -> decltype(auto)
 {
     using std::get;
+    using seqan3::get;
     static_assert(tuple_like_concept<decltype(in)>,
                   "You may only pass ranges to view::get whose reference_t models the tuple_like_concept.");
-    return std::get<index>(in);
+    return get<index>(std::forward<decltype(in)>(in));
 });
 
 //!\}

--- a/include/seqan3/std/view/common.hpp
+++ b/include/seqan3/std/view/common.hpp
@@ -85,14 +85,14 @@ namespace seqan3::view
  *
  * ```cpp
  * dna5_vector s{"ACTNTGATAN"_dna5};
- * auto v1 = s | view::filter([](dna5 const l) { return (l != dna5::N); }); // == "ACTTGATA"_dna5
+ * auto v1 = s | view::filter([](dna5 const l) { return (l != 'N'_dna5); }); // == "ACTTGATA"_dna5
  *
  * // this won't work (as of C++17), because std::find expects begin and end to be of the same type:
- * // auto it = std::find(begin(v1), end(v1), dna5::G);
+ * // auto it = std::find(begin(v1), end(v1), 'G'_dna5);
  *
  * // this will:
  * auto v2 = v1 | view::common;
- * auto it = std::find(begin(v2), end(v2), dna5::G);
+ * auto it = std::find(begin(v2), end(v2), 'G'_dna5);
  * ```
  * \hideinitializer
  */

--- a/include/seqan3/std/view/filter.hpp
+++ b/include/seqan3/std/view/filter.hpp
@@ -87,7 +87,7 @@ namespace seqan3::view
  *
  * ```cpp
  * dna5_vector s{"ACTNTGATAN"_dna5};
- * auto v1 = s | view::filter([](dna5 const l) { return (l != dna5::N); }); // == "ACTTGATA"_dna5
+ * auto v1 = s | view::filter([](dna5 const l) { return (l != 'N'_dna5); }); // == "ACTTGATA"_dna5
  * ```
  * \hideinitializer
  */

--- a/test/snippet/alignment/matrix/alignment_matrix_formatter.cpp
+++ b/test/snippet/alignment/matrix/alignment_matrix_formatter.cpp
@@ -7,7 +7,6 @@ int main()
 {
     using namespace seqan3;
     using namespace seqan3::detail;
-    using namespace seqan3::literal;
 
     struct no_config
     {};

--- a/test/snippet/alignment/matrix/alignment_score_matrix.cpp
+++ b/test/snippet/alignment/matrix/alignment_score_matrix.cpp
@@ -12,7 +12,6 @@ int main()
 //! [code]
 using namespace seqan3;
 using namespace seqan3::detail;
-using namespace seqan3::literal;
 
 std::vector<dna4> database = "AACCGGTT"_dna4;
 std::vector<dna4> query = "ACGT"_dna4;

--- a/test/snippet/alignment/matrix/alignment_trace_matrix.cpp
+++ b/test/snippet/alignment/matrix/alignment_trace_matrix.cpp
@@ -12,7 +12,6 @@ int main()
 //! [code]
 using namespace seqan3;
 using namespace seqan3::detail;
-using namespace seqan3::literal;
 
 struct no_config
 {};

--- a/test/snippet/alignment/matrix/alignment_trace_matrix_vector.cpp
+++ b/test/snippet/alignment/matrix/alignment_trace_matrix_vector.cpp
@@ -12,7 +12,6 @@ int main()
 //! [code]
 using namespace seqan3;
 using namespace seqan3::detail;
-using namespace seqan3::literal;
 
 std::vector<dna4> database = "AACCGGTT"_dna4;
 std::vector<dna4> query = "ACGT"_dna4;

--- a/test/snippet/alignment/scoring/aminoacid_scoring_scheme.cpp
+++ b/test/snippet/alignment/scoring/aminoacid_scoring_scheme.cpp
@@ -37,7 +37,6 @@ debug_stream << "New score after editing entry: " << (int) scheme.score(aa27::T,
 
 {
 //! [score sequences]
-using namespace seqan3::literal;
 std::vector<aa27> one = "ALIGATOR"_aa27;
 std::vector<aa27> two = "ANIMATOR"_aa27;
 

--- a/test/snippet/alignment/scoring/nucleotide_scoring_scheme.cpp
+++ b/test/snippet/alignment/scoring/nucleotide_scoring_scheme.cpp
@@ -13,12 +13,12 @@ int main()
 {
 //! [two letters]
 nucleotide_scoring_scheme scheme; // hamming is default
-debug_stream << "Score between DNA5 A and G: " << (int) scheme.score(dna5::A, dna5::G) << "\n"; // == -1
-debug_stream << "Score between DNA5 A and A: " << (int) scheme.score(dna5::A, dna5::A) << "\n"; // == 0
+debug_stream << "Score between DNA5 A and G: " << (int) scheme.score('A'_dna5, 'G'_dna5) << "\n"; // == -1
+debug_stream << "Score between DNA5 A and A: " << (int) scheme.score('A'_dna5, 'A'_dna5) << "\n"; // == 0
 
 scheme.set_simple_scheme(match_score{3}, mismatch_score{-2});
-debug_stream << "Score between DNA5 A and RNA15 G: " << (int) scheme.score(dna5::A, rna15::G) << "\n"; // == -2
-debug_stream << "Score between DNA5 A and RNA15 A: " << (int) scheme.score(dna5::A, rna15::A) << "\n"; // == 3
+debug_stream << "Score between DNA5 A and RNA15 G: " << (int) scheme.score('A'_dna5, 'G'_rna15) << "\n"; // == -2
+debug_stream << "Score between DNA5 A and RNA15 A: " << (int) scheme.score('A'_dna5, 'A'_rna15) << "\n"; // == 3
 // you can score differenct nucleotides  ^
 //! [two letters]
 }
@@ -27,15 +27,14 @@ debug_stream << "Score between DNA5 A and RNA15 A: " << (int) scheme.score(dna5:
 //! [edit matrix]
 nucleotide_scoring_scheme scheme; // hamming distance is default
 debug_stream << "Score between DNA A and G before edit: "
-          << (int) scheme.score(dna15::A, dna15::G) << "\n"; // == -1
-scheme.score(dna15::A, dna15::G) = 3;
-debug_stream << "Score after editing: " << (int) scheme.score(dna15::A, dna15::G) << "\n"; // == 3
+          << (int) scheme.score('A'_dna15, 'G'_dna15) << "\n"; // == -1
+scheme.score('A'_dna15, 'G'_dna15) = 3;
+debug_stream << "Score after editing: " << (int) scheme.score('A'_dna15, 'G'_dna15) << "\n"; // == 3
 //! [edit matrix]
 }
 
 {
 //! [score sequences]
-using namespace seqan3::literal;
 std::vector<dna15> one = "AGAATA"_dna15;
 std::vector<dna15> two = "ATACTA"_dna15;
 nucleotide_scoring_scheme scheme; // hamming distance is default

--- a/test/snippet/alphabet/adaptation/uint.cpp
+++ b/test/snippet/alphabet/adaptation/uint.cpp
@@ -8,14 +8,14 @@ int main()
 
 {
 //! [assign_char]
-auto my_letter = assign_char(dna5{}, 'G');  // my_letter is of type dna5 and == dna5::G
+auto my_letter = assign_char(dna5{}, 'G');  // my_letter is of type dna5 and == 'G'_dna5
 //! [assign_char]
 (void) my_letter;
 }
 
 {
 //! [assign_rank]
-auto my_letter = assign_rank(dna5{}, 1);  // my_letter is of type dna5 and == dna5::C
+auto my_letter = assign_rank(dna5{}, 1);  // my_letter is of type dna5 and == 'C'_dna5
 //! [assign_rank]
 (void) my_letter;
 }

--- a/test/snippet/alphabet/all.cpp
+++ b/test/snippet/alphabet/all.cpp
@@ -22,7 +22,7 @@ int main()
 dna4 my_letter;
 assign_rank(my_letter, 0);       // assign an A via rank interface
 assign_char(my_letter, 'A');     // assign an A via char interface
-my_letter = dna4::A;             // some alphabets (BUT NOT ALL!) also provide an enum-like interface
+my_letter = 'A'_dna4;             // some alphabets (BUT NOT ALL!) also provide an enum-like interface
 
 debug_stream << to_char(my_letter);            // prints 'A'
 debug_stream << (unsigned)to_rank(my_letter);  // prints 0

--- a/test/snippet/alphabet/aminoacid/aa20.cpp
+++ b/test/snippet/alphabet/aminoacid/aa20.cpp
@@ -28,7 +28,6 @@ if (my_letter.to_char() == 'A')
 // aa20_vector bar = "ABFUYR";
 
 // but these do:
-using namespace seqan3::literal;
 aa20_vector foo{"ABFUYR"_aa20};
 aa20_vector bar = "ABFUYR"_aa20;
 auto bax = "ABFUYR"_aa20;

--- a/test/snippet/alphabet/aminoacid/aa27.cpp
+++ b/test/snippet/alphabet/aminoacid/aa27.cpp
@@ -27,7 +27,6 @@ if (my_letter.to_char() == 'X')
 // aa27_vector bar = "ABFUYR";
 
 // but these do:
-using namespace seqan3::literal;
 aa27_vector foo{"ABFUYR"_aa27};
 aa27_vector bar = "ABFUYR"_aa27;
 auto bax = "ABFUYR"_aa27;

--- a/test/snippet/alphabet/composition/cartesian_composition.cpp
+++ b/test/snippet/alphabet/composition/cartesian_composition.cpp
@@ -12,17 +12,17 @@ int main()
 
 {
 //! [value_construction]
-qualified<dna4, phred42> letter1{dna4::C};    // creates {dna4::C, phred42{0}}
-qualified<dna4, phred42> letter2{phred42{1}}; // creates {dna4::A, phred42{1}}
+qualified<dna4, phred42> letter1{'C'_dna4};    // creates {'C'_dna4, phred42{0}}
+qualified<dna4, phred42> letter2{phred42{1}}; // creates {'A'_dna4, phred42{1}}
 //! [value_construction]
 }
 
 {
 //! [subtype_construction]
-// The following creates {dna4::C, phre42{0}}
-qualified<dna4, phred42> letter1{dna4::C};
-// The following also creates {dna4::C, phred42{0}}, since rna4 assignable to dna4
-qualified<dna4, phred42> letter2{rna4::C};
+// The following creates {'C'_dna4, phre42{0}}
+qualified<dna4, phred42> letter1{'C'_dna4};
+// The following also creates {'C'_dna4, phred42{0}}, since rna4 assignable to dna4
+qualified<dna4, phred42> letter2{'C'_rna4};
 
 if (letter1 == letter2)
     debug_stream << "yeah\n"; // yeah
@@ -31,18 +31,18 @@ if (letter1 == letter2)
 
 {
 //! [value_assignment]
-qualified<dna4, phred42> letter1{dna4::T, phred42{1}};
+qualified<dna4, phred42> letter1{'T'_dna4, phred42{1}};
 
-letter1 = dna4::C; // yields {dna4::C, phred42{1}}
-letter1 = phred42{2}; // yields {dna4::C, phred42{2}}
+letter1 = 'C'_dna4; // yields {'C'_dna4, phred42{1}}
+letter1 = phred42{2}; // yields {'C'_dna4, phred42{2}}
 //! [value_assignment]
 }
 
 {
 //! [subtype_assignment]
-qualified<dna4, phred42> letter1{dna4::T, phred42{1}};
+qualified<dna4, phred42> letter1{'T'_dna4, phred42{1}};
 
-letter1 = rna4::C; // yields {dna4::C, phred42{1}}
+letter1 = 'C'_rna4; // yields {'C'_dna4, phred42{1}}
 //! [subtype_assignment]
 }
 

--- a/test/snippet/alphabet/composition/union_composition.cpp
+++ b/test/snippet/alphabet/composition/union_composition.cpp
@@ -9,20 +9,20 @@ int main()
 
 {
 //! [usage]
-union_composition<dna5, gap> letter{};         // implicitly dna5::A
-union_composition<dna5, gap> letter2{dna5::C}; // constructed from alternative (== dna5::C)
-union_composition<dna5, gap> letter3{rna5::U}; // constructed from type that alternative is constructable from (== dna5::T)
+union_composition<dna5, gap> letter{};         // implicitly 'A'_dna5
+union_composition<dna5, gap> letter2{'C'_dna5}; // constructed from alternative (== 'C'_dna5)
+union_composition<dna5, gap> letter3{'U'_rna5}; // constructed from type that alternative is constructable from (== 'T'_dna5)
 
-letter2.assign_char('T');                      // == dna5::T
+letter2.assign_char('T');                      // == 'T'_dna5
 letter2.assign_char('-');                      // == gap::GAP
 letter2.assign_char('K');                      // unknown characters map to the default/unknown
-                                               // character of the first alternative type (== dna5::N)
+                                               // character of the first alternative type (== 'N'_dna5)
 
 letter2 = gap::GAP;                            // assigned from alternative (== gap::GAP)
-letter2 = rna5::U;                             // assigned from type that alternative is assignable from (== dna5::T)
+letter2 = 'U'_rna5;                             // assigned from type that alternative is assignable from (== 'T'_dna5)
 
 dna5 letter4 = letter2.convert_to<dna5>();     // this works
-// gap letter5  = letter2.convert_to<gap>();   // this throws an exception, because the set value was dna5::T
+// gap letter5  = letter2.convert_to<gap>();   // this throws an exception, because the set value was 'T'_dna5
 //! [usage]
 (void) letter4;
 }
@@ -39,7 +39,7 @@ static_assert(union_t::holds_alternative<gap>(), "gap is an alternative of union
 
 {
 //! [value construction]
-union_composition<dna4, gap> letter1{dna4::C}; // or
+union_composition<dna4, gap> letter1{'C'_dna4}; // or
 union_composition<dna4, gap> letter2 = gap::GAP;
 //! [value construction]
 (void) letter1;
@@ -48,7 +48,7 @@ union_composition<dna4, gap> letter2 = gap::GAP;
 
 {
 //! [conversion]
-union_composition<dna4, gap> letter1{rna4::C};
+union_composition<dna4, gap> letter1{'C'_rna4};
 //! [conversion]
 (void) letter1;
 }
@@ -56,7 +56,7 @@ union_composition<dna4, gap> letter1{rna4::C};
 {
 //! [subtype_construction]
 union_composition<dna4, gap> letter1{};
-letter1 = rna4::C;
+letter1 = 'C'_rna4;
 //! [subtype_construction]
 }
 

--- a/test/snippet/alphabet/detail/alphabet_base.cpp
+++ b/test/snippet/alphabet/detail/alphabet_base.cpp
@@ -1,0 +1,34 @@
+#include <seqan3/alphabet/concept.hpp>
+#include <seqan3/alphabet/detail/alphabet_base.hpp>
+
+using namespace seqan3;
+
+//! [example]
+class ab : public alphabet_base<ab, 2>
+{
+private:
+    // map 0 -> A and 1 -> B
+    static std::array<char_type, value_size> constexpr rank_to_char{'A', 'B'};
+
+    // map every letter to rank zero, except Bs
+    static std::array<rank_type, 256> constexpr char_to_rank
+    {
+        // initialise with an immediately evaluated lambda expression:
+        []()
+        {
+            std::array<rank_type, 256> ret{}; // initialise all values with 0 / 'A'
+
+            // only 'b' and 'B' result in rank 1
+            ret['b'] = 1;
+            ret['B'] = 1;
+
+            return ret;
+        }()
+    };
+
+    // make the base class a friend so it can access the tables:
+    friend alphabet_base<ab, 2>;
+};
+
+static_assert(alphabet_concept<ab>);
+//! [example]

--- a/test/snippet/alphabet/gap/gapped.cpp
+++ b/test/snippet/alphabet/gap/gapped.cpp
@@ -7,7 +7,7 @@ int main()
 {
 //! [general]
 gapped<dna4> gapped_letter{};
-gapped<dna4> converted_letter{dna4::C};
+gapped<dna4> converted_letter{'C'_dna4};
 gapped<dna4> gap_letter{gap::GAP};
 // doesn't work:
 // gapped<dna4> my_letter{'A'};

--- a/test/snippet/alphabet/mask/masked.cpp
+++ b/test/snippet/alphabet/mask/masked.cpp
@@ -9,9 +9,9 @@ int main()
 {
 //! [general]
 masked<dna4> dna4_masked{};
-masked<dna4> dna4_another_masked{dna4::A, mask::UNMASKED}; // create a dna4 masked alphabet with an unmasked A
+masked<dna4> dna4_another_masked{'A'_dna4, mask::UNMASKED}; // create a dna4 masked alphabet with an unmasked A
 
-dna4_masked.assign_char('a'); // assigns a masked dna4::A
+dna4_masked.assign_char('a'); // assigns a masked 'A'_dna4
 
 if (dna4_masked.to_char() != dna4_another_masked.to_char())
     debug_stream << dna4_masked.to_char() << " is not the same as " << dna4_another_masked.to_char() << "\n";

--- a/test/snippet/alphabet/nucleotide/dna15.cpp
+++ b/test/snippet/alphabet/nucleotide/dna15.cpp
@@ -8,7 +8,7 @@ int main()
 
 {
 //! [code]
-dna15 my_letter{dna15::A};
+dna15 my_letter{'A'_dna15};
 // doesn't work:
 // dna15 my_letter{'A'};
 
@@ -27,7 +27,6 @@ if (my_letter.to_char() == 'N')
 // dna15_vector bar = "ACGTTA";
 
 // but these do:
-using namespace seqan3::literal;
 dna15_vector foo{"ACGTTA"_dna15};
 dna15_vector bar = "ACGTTA"_dna15;
 auto bax = "ACGTTA"_dna15;

--- a/test/snippet/alphabet/nucleotide/dna4.cpp
+++ b/test/snippet/alphabet/nucleotide/dna4.cpp
@@ -8,7 +8,7 @@ int main()
 
 {
 //! [code]
-dna4 my_letter{dna4::A};
+dna4 my_letter{'A'_dna4};
 // doesn't work:
 // dna4 my_letter{'A'};
 
@@ -27,7 +27,6 @@ if (my_letter.to_char() == 'A')
 // dna4_vector bar = "ACGTTA";
 
 // but these do:
-using namespace seqan3::literal;
 dna4_vector foo{"ACGTTA"_dna4};
 dna4_vector bar = "ACGTTA"_dna4;
 auto bax = "ACGTTA"_dna4;

--- a/test/snippet/alphabet/nucleotide/dna5.cpp
+++ b/test/snippet/alphabet/nucleotide/dna5.cpp
@@ -8,7 +8,7 @@ int main()
 
 {
 //! [code]
-dna5 my_letter{dna5::A};
+dna5 my_letter{'A'_dna5};
 // doesn't work:
 // dna5 my_letter{'A'};
 
@@ -27,7 +27,6 @@ if (my_letter.to_char() == 'N')
 // dna5_vector bar = "ACGTTA";
 
 // but these do:
-using namespace seqan3::literal;
 dna5_vector foo{"ACGTTA"_dna5};
 dna5_vector bar = "ACGTTA"_dna5;
 auto bax = "ACGTTA"_dna5;

--- a/test/snippet/alphabet/nucleotide/rna15.cpp
+++ b/test/snippet/alphabet/nucleotide/rna15.cpp
@@ -8,7 +8,7 @@ int main()
 
 {
 //! [code]
-rna15 my_letter{rna15::A};
+rna15 my_letter{'A'_rna15};
 // doesn't work:
 // rna15 my_letter{'A'};
 
@@ -27,7 +27,6 @@ if (my_letter.to_char() == 'N')
 // rna15_vector bar = "ACGTTA";
 
 // but these do:
-using namespace seqan3::literal;
 rna15_vector foo{"ACGTTA"_rna15};
 rna15_vector bar = "ACGTTA"_rna15;
 auto bax = "ACGTTA"_rna15;

--- a/test/snippet/alphabet/nucleotide/rna4.cpp
+++ b/test/snippet/alphabet/nucleotide/rna4.cpp
@@ -8,7 +8,7 @@ int main()
 
 {
 //! [code]
-rna4 my_letter{rna4::A};
+rna4 my_letter{'A'_rna4};
 // doesn't work:
 // rna4 my_letter{'A'};
 
@@ -27,7 +27,6 @@ if (my_letter.to_char() == 'A')
 // rna4_vector bar = "ACGTTA";
 
 // but these do:
-using namespace seqan3::literal;
 rna4_vector foo{"ACGTTA"_rna4};
 rna4_vector bar = "ACGTTA"_rna4;
 auto bax = "ACGTTA"_rna4;

--- a/test/snippet/alphabet/nucleotide/rna5.cpp
+++ b/test/snippet/alphabet/nucleotide/rna5.cpp
@@ -8,7 +8,7 @@ int main()
 
 {
 //! [code]
-rna5 my_letter{rna5::A};
+rna5 my_letter{'A'_rna5};
 // doesn't work:
 // rna5 my_letter{'A'};
 
@@ -27,7 +27,6 @@ if (my_letter.to_char() == 'N')
 // rna5_vector bar = "ACGTTA";
 
 // but these do:
-using namespace seqan3::literal;
 rna5_vector foo{"ACGTTA"_rna5};
 rna5_vector bar = "ACGTTA"_rna5;
 auto bax = "ACGTTA"_rna5;

--- a/test/snippet/alphabet/quality/qualified.cpp
+++ b/test/snippet/alphabet/quality/qualified.cpp
@@ -8,7 +8,7 @@ using namespace seqan3;
 int main()
 {
 //! [general]
-qualified<dna4, phred42> letter{dna4::A, phred42{7}};
+qualified<dna4, phred42> letter{'A'_dna4, phred42{7}};
 debug_stream << int(to_rank(letter)) << ' '
           << int(to_rank(get<0>(letter))) << ' '
           << int(to_rank(get<1>(letter))) << '\n';
@@ -26,7 +26,7 @@ debug_stream << int(to_phred(letter)) << ' '
 
 // modify via structured bindings and references:
 auto & [ seq_l, qual_l ] = letter;
-seq_l = dna4::G;
+seq_l = 'G'_dna4;
 debug_stream << to_char(letter) << '\n';
 // G
 //! [general]

--- a/test/snippet/alphabet/structure/structured_rna.cpp
+++ b/test/snippet/alphabet/structure/structured_rna.cpp
@@ -8,7 +8,7 @@ using namespace seqan3;
 int main()
 {
 //! [general]
-structured_rna<rna4, dot_bracket3> letter{rna4::G, dot_bracket3::PAIR_OPEN};
+structured_rna<rna4, dot_bracket3> letter{'G'_rna4, dot_bracket3::PAIR_OPEN};
 debug_stream << int(to_rank(letter)) << ' '
           << int(to_rank(get<0>(letter))) << ' '
           << int(to_rank(get<1>(letter))) << '\n';
@@ -21,7 +21,7 @@ debug_stream << to_char(letter) << ' '
 
 // modify via structured bindings and references:
 auto & [ seq_l, structure_l ] = letter;
-seq_l = rna4::U;
+seq_l = 'U'_rna4;
 debug_stream << to_char(letter) << '\n';
 // U
 //! [general]

--- a/test/snippet/core/detail/strong_type.cpp
+++ b/test/snippet/core/detail/strong_type.cpp
@@ -6,7 +6,6 @@
 
 using namespace seqan3;
 
-using namespace seqan3::literal;
 
 std::vector<dna4> my_range = "ACGTT"_dna4;
 

--- a/test/snippet/core/detail/strong_type_2.cpp
+++ b/test/snippet/core/detail/strong_type_2.cpp
@@ -18,7 +18,6 @@ struct window_size : detail::strong_type<unsigned, window_size>
 };
 //! [error_window]
 
-using namespace seqan3::literal;
 
 namespace seqan3::detail
 {

--- a/test/snippet/io/alignment_file/output.cpp
+++ b/test/snippet/io/alignment_file/output.cpp
@@ -3,7 +3,6 @@
 #include <iostream>
 
 using namespace seqan3;
-using namespace seqan3::literal;
 
 int main()
 {

--- a/test/snippet/io/stream/debug_stream.cpp
+++ b/test/snippet/io/stream/debug_stream.cpp
@@ -4,18 +4,17 @@
 #include <seqan3/range/view/to_rank.hpp>
 
 using namespace seqan3;
-using namespace seqan3::literal;
 
 int main()
 {
 //! [usage]
 // This does not work:
-// std::cout << dna5::C;
+// std::cout << 'C'_dna5;
 // because the alphabet needs to be converted to char explicitly:
-debug_stream << to_char(dna5::C);  // prints 'C'
+debug_stream << to_char('C'_dna5);  // prints 'C'
 
 // The debug_stream, on the other hand, does this automatically:
-debug_stream << dna5::C;        // prints 'C'
+debug_stream << 'C'_dna5;        // prints 'C'
 
 // Vectors are also not printable to debug_stream:
 std::vector<dna5> vec{"ACGT"_dna5};
@@ -50,7 +49,7 @@ debug_stream << fmtflags2::small_int_as_number << '\'' << i << "'\n";   // print
 }
 
 // this is UNDEFINED BEHAVIOUR, because the underlying stream went out-of-scope:
-//debug_stream << dna4::C;
+//debug_stream << 'C'_dna4;
 //! [set_underlying_stream]
 
 //! [set_underlying_stream2]

--- a/test/snippet/range/container/bitcompressed_vector.cpp
+++ b/test/snippet/range/container/bitcompressed_vector.cpp
@@ -2,7 +2,6 @@
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 
 using namespace seqan3;
-using namespace seqan3::literal;
 
 int main()
 {

--- a/test/snippet/range/container/concatenated_sequences.cpp
+++ b/test/snippet/range/container/concatenated_sequences.cpp
@@ -3,7 +3,6 @@
 #include <seqan3/range/container/concatenated_sequences.hpp>
 
 using namespace seqan3;
-using namespace seqan3::literal;
 
 int main()
 {
@@ -22,7 +21,7 @@ concat1 = concat2;               // you can assign from other ranges
 concat2[0] = "ATTA"_dna4;        // this works for vector of vector
 //concat1[0] = "ATTA"_dna4;      // but not on concatenated_sequences
 
-concat1[0][1] = dna4::T;         // this, however, does
+concat1[0][1] = 'T'_dna4;         // this, however, does
 debug_stream << concat1[0] << '\n'; // "ATTA"
 
 

--- a/test/snippet/range/view/complement.cpp
+++ b/test/snippet/range/view/complement.cpp
@@ -3,7 +3,6 @@
 #include <seqan3/std/view/reverse.hpp>
 
 using namespace seqan3;
-using namespace seqan3::literal;
 
 int main()
 {

--- a/test/snippet/range/view/convert.cpp
+++ b/test/snippet/range/view/convert.cpp
@@ -4,7 +4,6 @@
 #include <seqan3/std/view/reverse.hpp>
 
 using namespace seqan3;
-using namespace seqan3::literal;
 
 int main()
 {

--- a/test/snippet/range/view/deep.cpp
+++ b/test/snippet/range/view/deep.cpp
@@ -11,7 +11,6 @@ inline auto const deep_take1 = deep{view::take(1)};
 }
 
 using namespace seqan3;
-using namespace seqan3::literal;
 
 int main()
 {

--- a/test/snippet/range/view/get.cpp
+++ b/test/snippet/range/view/get.cpp
@@ -9,7 +9,7 @@ int main()
 {
 //! [usage]
 // Create a vector of dna4 quality composition alphabet.
-std::vector<dna4q> qv{{dna4::A, phred42{0}}, {dna4::C, phred42{1}}, {dna4::G, phred42{2}}, {dna4::T, phred42{3}}};
+std::vector<dna4q> qv{{'A'_dna4, phred42{0}}, {'C'_dna4, phred42{1}}, {'G'_dna4, phred42{2}}, {'T'_dna4, phred42{3}}};
 
 debug_stream << (qv | view::get<0> | view::to_char) << std::endl; // Prints [A,C,G,T]
 debug_stream << (qv | view::get<1> | view::to_char) << std::endl; // Prints [!,",#,$]

--- a/test/snippet/range/view/kmer_hash.cpp
+++ b/test/snippet/range/view/kmer_hash.cpp
@@ -4,7 +4,6 @@
 #include <seqan3/range/view/kmer_hash.hpp>
 
 using namespace seqan3;
-using namespace seqan3::literal;
 
 int main()
 {

--- a/test/snippet/range/view/persist.cpp
+++ b/test/snippet/range/view/persist.cpp
@@ -3,7 +3,6 @@
 #include <seqan3/range/view/to_char.hpp>
 
 using namespace seqan3;
-using namespace seqan3::literal;
 
 int main()
 {

--- a/test/snippet/range/view/range_view_all.cpp
+++ b/test/snippet/range/view/range_view_all.cpp
@@ -3,7 +3,6 @@
 #include <seqan3/std/view/reverse.hpp>
 
 using namespace seqan3;
-using namespace seqan3::literal;
 
 int main()
 {

--- a/test/snippet/range/view/rank_char.cpp
+++ b/test/snippet/range/view/rank_char.cpp
@@ -13,7 +13,6 @@
 
 
 using namespace seqan3;
-using namespace seqan3::literal;
 
 int main()
 {
@@ -48,8 +47,8 @@ std::vector<phred42> qvec{{0}, {7}, {5}, {3}, {7}, {4}, {30}, {16}, {23}};
 auto v3 = qvec | view::to_char;
 debug_stream << v3 << '\n'; // [!,(,&,$,(,%,?,1,8]
 
-std::vector<dna4q> qcvec{{dna4::C, phred42{0}}, {dna4::A, phred42{7}}, {dna4::G, phred42{5}}, {dna4::T, phred42{3}},
-                         {dna4::G, phred42{7}}, {dna4::A, phred42{4}}, {dna4::C, phred42{30}}, {dna4::T, phred42{16}}, {dna4::A, phred42{23}}};
+std::vector<dna4q> qcvec{{'C'_dna4, phred42{0}}, {'A'_dna4, phred42{7}}, {'G'_dna4, phred42{5}}, {'T'_dna4, phred42{3}},
+                         {'G'_dna4, phred42{7}}, {'A'_dna4, phred42{4}}, {'C'_dna4, phred42{30}}, {'T'_dna4, phred42{16}}, {'A'_dna4, phred42{23}}};
 auto v4 = qcvec | view::to_char;
 debug_stream << v4 << '\n'; // [C,A,G,T,G,A,C,T,A]
 //! [to_char]
@@ -65,8 +64,8 @@ std::vector<phred42> qvec{{0}, {7}, {5}, {3}, {7}, {4}, {30}, {16}, {23}};
 auto v3 = qvec | view::to_rank | view::convert<unsigned>;
 debug_stream << v3 << '\n'; // [0,7,5,3,7,4,30,16,23]
 
-std::vector<dna4q> qcvec{{dna4::C, phred42{0}}, {dna4::A, phred42{7}}, {dna4::G, phred42{5}}, {dna4::T, phred42{3}},
-                         {dna4::G, phred42{7}}, {dna4::A, phred42{4}}, {dna4::C, phred42{30}}, {dna4::T, phred42{16}}, {dna4::A, phred42{23}}};
+std::vector<dna4q> qcvec{{'C'_dna4, phred42{0}}, {'A'_dna4, phred42{7}}, {'G'_dna4, phred42{5}}, {'T'_dna4, phred42{3}},
+                         {'G'_dna4, phred42{7}}, {'A'_dna4, phred42{4}}, {'C'_dna4, phred42{30}}, {'T'_dna4, phred42{16}}, {'A'_dna4, phred42{23}}};
 auto v4 = qcvec | view::to_rank | view::convert<unsigned>;
 debug_stream << v4 << '\n'; // [1,28,22,15,30,16,121,67,92]
 //! [to_rank]

--- a/test/snippet/range/view/translation.cpp
+++ b/test/snippet/range/view/translation.cpp
@@ -6,7 +6,6 @@
 #include <seqan3/range/view/complement.hpp>
 
 using namespace seqan3;
-using namespace seqan3::literal;
 
 int main()
 {

--- a/test/snippet/range/view/trim.cpp
+++ b/test/snippet/range/view/trim.cpp
@@ -33,17 +33,17 @@ std::string v4 = view::trim(vec, 20u) | view::to_char;  // == "II?5"
 
 {
 //! [dna5q]
-std::vector<dna5q> vec{{dna5::A, phred42{40}}, {dna5::G, phred42{40}}, {dna5::G, phred42{30}},
-                       {dna5::A, phred42{20}}, {dna5::T, phred42{10}}};
-std::vector<dna5q> cmp{{dna5::A, phred42{40}}, {dna5::G, phred42{40}}, {dna5::G, phred42{30}},
-                       {dna5::A, phred42{20}}};
+std::vector<dna5q> vec{{'A'_dna5, phred42{40}}, {'G'_dna5, phred42{40}}, {'G'_dna5, phred42{30}},
+                       {'A'_dna5, phred42{20}}, {'T'_dna5, phred42{10}}};
+std::vector<dna5q> cmp{{'A'_dna5, phred42{40}}, {'G'_dna5, phred42{40}}, {'G'_dna5, phred42{30}},
+                       {'A'_dna5, phred42{20}}};
 
 // trim by phred_value
 auto v1 = vec | view::trim(20u);
 assert(std::vector<dna5q>(v1) == cmp);
 
 // trim by quality character; in this case the nucleotide part of the character is irrelevant
-auto v2 = vec | view::trim(dna5q{dna5::C, phred42{20}});
+auto v2 = vec | view::trim(dna5q{'C'_dna5, phred42{20}});
 assert(std::vector<dna5q>(v2) == cmp);
 
 // combinability

--- a/test/snippet/search/bi_fm_index_iterator.cpp
+++ b/test/snippet/search/bi_fm_index_iterator.cpp
@@ -3,7 +3,6 @@
 #include <seqan3/search/fm_index/all.hpp>
 
 using namespace seqan3;
-using namespace seqan3::literal;
 
 int main()
 {
@@ -42,7 +41,7 @@ it.cycle_back();                     // search the sequence "AAT"
 debug_stream << it.query() << '\n';     // outputs "AAT"
 debug_stream << it.last_char() << '\n'; // outputs 'T'
 
-it.extend_left(dna4::G);             // search the sequence "GAAT"
+it.extend_left('G'_dna4);             // search the sequence "GAAT"
 debug_stream << it.query() << '\n';     // outputs "GAAC"
 debug_stream << it.last_char() << '\n'; // outputs 'G'
 
@@ -73,7 +72,7 @@ debug_stream << uni_it.query() << '\n';     // outputs "CAA"
 // it.cycle_back();
 // debug_stream << it.last_char() << '\n';
 
-uni_it.extend_right(dna4::G);            // search the sequence "AACG"
+uni_it.extend_right('G'_dna4);            // search the sequence "AACG"
 debug_stream << uni_it.query() << '\n';     // outputs "AACG"
 debug_stream << uni_it.last_char() << '\n'; // outputs 'G'
 uni_it.cycle_back();                     // returns false since there is no sequence "AACT" in the text.
@@ -96,7 +95,7 @@ debug_stream << uni_it.query() << '\n';     // outputs "CAA"
 // it.cycle_back();
 // debug_stream << it.last_char() << '\n';
 
-uni_it.extend_right(dna4::G);            // search the sequence "CAAG"
+uni_it.extend_right('G'_dna4);            // search the sequence "CAAG"
 debug_stream << uni_it.query() << '\n';     // outputs "CAAG"
 debug_stream << uni_it.last_char() << '\n'; // outputs 'G'
 uni_it.cycle_back();                     // search the sequence "CAAT"

--- a/test/snippet/search/fm_index.cpp
+++ b/test/snippet/search/fm_index.cpp
@@ -4,7 +4,6 @@
 #include <seqan3/search/fm_index/all.hpp>
 
 using namespace seqan3;
-using namespace seqan3::literal;
 
 int main()
 {

--- a/test/snippet/search/fm_index_iterator.cpp
+++ b/test/snippet/search/fm_index_iterator.cpp
@@ -3,7 +3,6 @@
 #include <seqan3/search/fm_index/all.hpp>
 
 using namespace seqan3;
-using namespace seqan3::literal;
 
 int main()
 {

--- a/test/unit/alignment/aligned_sequence_test.cpp
+++ b/test/unit/alignment/aligned_sequence_test.cpp
@@ -105,7 +105,7 @@ TYPED_TEST(aligned_sequence_test, erase_one_gap)
 
     auto it = erase_gap(aligned_seq, aligned_seq.begin() + 1);
 
-    typename TypeParam::value_type val = dna4::C;
+    typename TypeParam::value_type val{dna4::C};
     val = dna4::C;
     EXPECT_EQ(*it, val);
     EXPECT_EQ(aligned_seq, aligned_seq_expected);
@@ -131,7 +131,7 @@ TYPED_TEST(aligned_sequence_test, erase_multiple_gaps)
 
     auto it = erase_gap(aligned_seq, aligned_seq.begin() + 1, aligned_seq.begin() + 3);
 
-    typename TypeParam::value_type val = dna4::C;
+    typename TypeParam::value_type val{dna4::C};
     val = dna4::C;
     EXPECT_EQ(*it, val);
     EXPECT_EQ(aligned_seq, aligned_seq_expected);
@@ -154,7 +154,10 @@ TYPED_TEST(aligned_sequence_test, cigar_string)
         initialize_typed_test_container(ref,  "ACGTGAT--CTG");
         initialize_typed_test_container(read, "ACGT-CGTAGTG");
 
+//         [[maybe_unused]] char c = detail::compare_aligned_values(ref[0], read[0], false);
+
         std::string expected = "4M1D2M2I3M";
+//         std::string two = detail::get_cigar_string(std::tie(ref, read));
 
         EXPECT_EQ(expected, detail::get_cigar_string(std::make_pair(ref, read)));
 

--- a/test/unit/alignment/aligned_sequence_test.cpp
+++ b/test/unit/alignment/aligned_sequence_test.cpp
@@ -39,7 +39,6 @@
 #include <seqan3/io/alignment_file/detail.hpp>
 
 using namespace seqan3;
-using namespace seqan3::literal;
 
 template <typename T>
 class aligned_sequence_test: public ::testing::Test { };
@@ -105,8 +104,8 @@ TYPED_TEST(aligned_sequence_test, erase_one_gap)
 
     auto it = erase_gap(aligned_seq, aligned_seq.begin() + 1);
 
-    typename TypeParam::value_type val{dna4::C};
-    val = dna4::C;
+    typename TypeParam::value_type val{'C'_dna4};
+    val = 'C'_dna4;
     EXPECT_EQ(*it, val);
     EXPECT_EQ(aligned_seq, aligned_seq_expected);
 
@@ -131,8 +130,8 @@ TYPED_TEST(aligned_sequence_test, erase_multiple_gaps)
 
     auto it = erase_gap(aligned_seq, aligned_seq.begin() + 1, aligned_seq.begin() + 3);
 
-    typename TypeParam::value_type val{dna4::C};
-    val = dna4::C;
+    typename TypeParam::value_type val{'C'_dna4};
+    val = 'C'_dna4;
     EXPECT_EQ(*it, val);
     EXPECT_EQ(aligned_seq, aligned_seq_expected);
 

--- a/test/unit/alignment/matrix/alignment_matrix_formatter_test.cpp
+++ b/test/unit/alignment/matrix/alignment_matrix_formatter_test.cpp
@@ -6,7 +6,6 @@
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 
 using namespace seqan3;
-using namespace seqan3::literal;
 
 struct no_config
 {};

--- a/test/unit/alignment/matrix/alignment_matrix_test.cpp
+++ b/test/unit/alignment/matrix/alignment_matrix_test.cpp
@@ -6,7 +6,6 @@
 
 using namespace seqan3;
 using namespace seqan3::detail;
-using namespace seqan3::literal;
 
 struct no_config
 {};

--- a/test/unit/alignment/pairwise/align_pairwise_test.cpp
+++ b/test/unit/alignment/pairwise/align_pairwise_test.cpp
@@ -52,7 +52,6 @@ using namespace seqan3;
 
 TEST(align_pairwise, single_rng_lvalue)
 {
-    using namespace seqan3::literal;
 
     auto seq1 = "ACGTGATG"_dna4;
     auto seq2 = "AGTGATACT"_dna4;
@@ -85,7 +84,6 @@ TEST(align_pairwise, single_rng_lvalue)
 
 TEST(align_pairwise, single_view_lvalue)
 {
-    using namespace seqan3::literal;
 
     auto seq1 = "ACGTGATG"_dna4;
     auto seq2 = "AGTGATACT"_dna4;
@@ -116,7 +114,6 @@ TEST(align_pairwise, single_view_lvalue)
 
 TEST(align_pairwise, multiple_rng_lvalue)
 {
-    using namespace seqan3::literal;
 
     auto seq1 = "ACGTGATG"_dna4;
     auto seq2 = "AGTGATACT"_dna4;

--- a/test/unit/alignment/pairwise/alignment_result_test.cpp
+++ b/test/unit/alignment/pairwise/alignment_result_test.cpp
@@ -103,7 +103,7 @@ TYPED_TEST(align_result_test, std_position_get)
 {
     using res_t = typename TestFixture::res_t;
     using seq_t = typename TestFixture::seq_t;
-    seq_t seq{dna4::A, dna4::T, gap::GAP, dna4::C, gap::GAP, gap::GAP, dna4::A};
+    seq_t seq{'A'_dna4, 'T'_dna4, gap::GAP, 'C'_dna4, gap::GAP, gap::GAP, 'A'_dna4};
 
     {
         res_t tmp{1, 0, {10, 10}, {0, 0}, {seq, seq}};
@@ -143,7 +143,7 @@ TYPED_TEST(align_result_test, seqan3_pos_get)
 {
     using res_t = typename TestFixture::res_t;
     using seq_t = typename TestFixture::seq_t;
-    seq_t seq{dna4::A, dna4::T, gap::GAP, dna4::C, gap::GAP, gap::GAP, dna4::A};
+    seq_t seq{'A'_dna4, 'T'_dna4, gap::GAP, 'C'_dna4, gap::GAP, gap::GAP, 'A'_dna4};
 
     {
         res_t tmp{1, 0, {10, 10}, {0, 0}, {seq, seq}};
@@ -183,7 +183,7 @@ TYPED_TEST(align_result_test, seqan3_enum_get)
 {
     using res_t = typename TestFixture::res_t;
     using seq_t = typename TestFixture::seq_t;
-    seq_t seq{dna4::A, dna4::T, gap::GAP, dna4::C, gap::GAP, gap::GAP, dna4::A};
+    seq_t seq{'A'_dna4, 'T'_dna4, gap::GAP, 'C'_dna4, gap::GAP, gap::GAP, 'A'_dna4};
 
     {
         res_t tmp{1, 0, {10, 10}, {0, 0}, {seq, seq}};
@@ -222,7 +222,7 @@ TYPED_TEST(align_result_test, id)
 {
     using res_t = typename TestFixture::res_t;
     using seq_t = typename TestFixture::seq_t;
-    seq_t seq{dna4::A, dna4::T, gap::GAP, dna4::C, gap::GAP, gap::GAP, dna4::A};
+    seq_t seq{'A'_dna4, 'T'_dna4, gap::GAP, 'C'_dna4, gap::GAP, gap::GAP, 'A'_dna4};
 
     res_t tmp{1, 0, {10, 10}, {0, 0}, {seq, seq}};
     EXPECT_EQ(tmp.id(), 1);
@@ -232,7 +232,7 @@ TYPED_TEST(align_result_test, score)
 {
     using res_t = typename TestFixture::res_t;
     using seq_t = typename TestFixture::seq_t;
-    seq_t seq{dna4::A, dna4::T, gap::GAP, dna4::C, gap::GAP, gap::GAP, dna4::A};
+    seq_t seq{'A'_dna4, 'T'_dna4, gap::GAP, 'C'_dna4, gap::GAP, gap::GAP, 'A'_dna4};
 
     res_t tmp{1, 0, {10, 10}, {0, 0}, {seq, seq}};
     EXPECT_EQ(tmp.score(), 0);
@@ -242,7 +242,7 @@ TYPED_TEST(align_result_test, end_coordinate)
 {
     using res_t = typename TestFixture::res_t;
     using seq_t = typename TestFixture::seq_t;
-    seq_t seq{dna4::A, dna4::T, gap::GAP, dna4::C, gap::GAP, gap::GAP, dna4::A};
+    seq_t seq{'A'_dna4, 'T'_dna4, gap::GAP, 'C'_dna4, gap::GAP, gap::GAP, 'A'_dna4};
 
     {
         res_t tmp{1, 0, {10, 10}, {0, 0}, {seq, seq}};
@@ -269,7 +269,7 @@ TYPED_TEST(align_result_test, begin_coordinate)
 {
     using res_t = typename TestFixture::res_t;
     using seq_t = typename TestFixture::seq_t;
-    seq_t seq{dna4::A, dna4::T, gap::GAP, dna4::C, gap::GAP, gap::GAP, dna4::A};
+    seq_t seq{'A'_dna4, 'T'_dna4, gap::GAP, 'C'_dna4, gap::GAP, gap::GAP, 'A'_dna4};
 
     {
         res_t tmp{1, 0, {10, 10}, {0, 0}, {seq, seq}};
@@ -296,7 +296,7 @@ TYPED_TEST(align_result_test, trace)
 {
     using res_t = typename TestFixture::res_t;
     using seq_t = typename TestFixture::seq_t;
-    seq_t seq{dna4::A, dna4::T, gap::GAP, dna4::C, gap::GAP, gap::GAP, dna4::A};
+    seq_t seq{'A'_dna4, 'T'_dna4, gap::GAP, 'C'_dna4, gap::GAP, gap::GAP, 'A'_dna4};
 
     {
         res_t tmp{1, 0, {10, 10}, {0, 0}, {seq, seq}};

--- a/test/unit/alignment/pairwise/fixture/alignment_fixture.hpp
+++ b/test/unit/alignment/pairwise/fixture/alignment_fixture.hpp
@@ -6,12 +6,11 @@
 #include <seqan3/alignment/matrix/alignment_score_matrix.hpp>
 #include <seqan3/alignment/matrix/alignment_trace_matrix.hpp>
 
-namespace seqan3::literal
+namespace seqan3
 {}
 
 namespace seqan3::fixture
 {
-using namespace seqan3::literal;
 using detail::alignment_coordinate;
 
 static constexpr auto INF = std::numeric_limits<int>::max();

--- a/test/unit/alignment/scoring_scheme_test.cpp
+++ b/test/unit/alignment/scoring_scheme_test.cpp
@@ -261,12 +261,12 @@ TYPED_TEST(generic, custom)
         EXPECT_EQ(2*2+1,    scheme.score(aa27::C, aa27::B));
     } else
     {
-        EXPECT_EQ(0*0+0,    scheme.score(dna15::A, dna15::A)); // A is 0th
-        EXPECT_EQ(0*0+2,    scheme.score(dna15::A, dna15::C)); // C is 2nd
-        EXPECT_EQ(2*2+0,    scheme.score(dna15::C, dna15::A));
-        EXPECT_EQ(3*3+3,    scheme.score(dna15::D, dna15::D)); // D is 3rd
-        EXPECT_EQ(8*8+0,    scheme.score(dna15::N, dna15::A)); // N is 8th
-        EXPECT_EQ(0*0+8,    scheme.score(dna15::A, dna15::N));
+        EXPECT_EQ(0*0+0,    scheme.score('A'_dna15, 'A'_dna15)); // A is 0th
+        EXPECT_EQ(0*0+2,    scheme.score('A'_dna15, 'C'_dna15)); // C is 2nd
+        EXPECT_EQ(2*2+0,    scheme.score('C'_dna15, 'A'_dna15));
+        EXPECT_EQ(3*3+3,    scheme.score('D'_dna15, 'D'_dna15)); // D is 3rd
+        EXPECT_EQ(8*8+0,    scheme.score('N'_dna15, 'A'_dna15)); // N is 8th
+        EXPECT_EQ(0*0+8,    scheme.score('A'_dna15, 'N'_dna15));
     }
 }
 
@@ -290,10 +290,10 @@ TYPED_TEST(generic, convertability)
         {
             using nucl_t = std::decay_t<decltype(aa)>;
 
-            EXPECT_EQ(scheme.score(aa27::C,  aa27::G),
-                      scheme.score(nucl_t::C, nucl_t::G));
-            EXPECT_EQ(scheme.score(aa27::T,  nucl_t::T),
-                      scheme.score(nucl_t::T, aa27::T));
+            EXPECT_EQ(scheme.score(aa27::C,                   aa27::G),
+                      scheme.score(nucl_t{}.assign_char('C'), nucl_t{}.assign_char('G')));
+            EXPECT_EQ(scheme.score(aa27::T,                   nucl_t{}.assign_char('T')),
+                      scheme.score(nucl_t{}.assign_char('T'), aa27::T));
         });
     } else
     {
@@ -303,17 +303,17 @@ TYPED_TEST(generic, convertability)
         {
             using nucl_t = std::decay_t<decltype(nucl)>;
 
-            EXPECT_EQ(scheme.score(dna15::C,  dna15::G),
-                      scheme.score(nucl_t::C, nucl_t::G));
-            EXPECT_EQ(scheme.score(dna15::T,  dna15::T),
-                      scheme.score(nucl_t::T, nucl_t::T));
-            EXPECT_EQ(scheme.score(dna15::A,  dna15::C),
-                      scheme.score(nucl_t::A, nucl_t::C));
+            EXPECT_EQ(scheme.score('C'_dna15,                 'G'_dna15),
+                      scheme.score(nucl_t{}.assign_char('C'), nucl_t{}.assign_char('G')));
+            EXPECT_EQ(scheme.score('T'_dna15,                 'T'_dna15),
+                      scheme.score(nucl_t{}.assign_char('T'), nucl_t{}.assign_char('T')));
+            EXPECT_EQ(scheme.score('A'_dna15,                 'C'_dna15),
+                      scheme.score(nucl_t{}.assign_char('A'), nucl_t{}.assign_char('C')));
 
-            EXPECT_EQ(scheme.score(dna15::C,  nucl_t::G),
-                      scheme.score(nucl_t::C, dna15::G));
-            EXPECT_EQ(scheme.score(dna15::C,  nucl_t::A),
-                      scheme.score(nucl_t::C, dna15::A));
+            EXPECT_EQ(scheme.score('C'_dna15,                 nucl_t{}.assign_char('G')),
+                      scheme.score(nucl_t{}.assign_char('C'), 'G'_dna15));
+            EXPECT_EQ(scheme.score('C'_dna15,                 nucl_t{}.assign_char('A')),
+                      scheme.score(nucl_t{}.assign_char('C'), 'A'_dna15));
         });
 
     }

--- a/test/unit/alphabet/aminoacid_test.cpp
+++ b/test/unit/alphabet/aminoacid_test.cpp
@@ -44,7 +44,6 @@
 #include <seqan3/alphabet/aminoacid/all.hpp>
 
 using namespace seqan3;
-using namespace seqan3::literal;
 
 template <typename T>
 class aminoacid : public ::testing::Test
@@ -244,9 +243,9 @@ TYPED_TEST(aminoacid, comparators)
 
 TEST(translation, translate_triplets)
 {
-    dna15 n1{dna15::C};
-    dna15 n2{dna15::T};
-    dna15 n3{dna15::A};
+    dna15 n1{'C'_dna15};
+    dna15 n2{'T'_dna15};
+    dna15 n3{'A'_dna15};
     aa27 c{aa27::L};
 
     // Nucleotide interface

--- a/test/unit/alphabet/composition/cartesian_composition_test.cpp
+++ b/test/unit/alphabet/composition/cartesian_composition_test.cpp
@@ -35,6 +35,7 @@
 #include <gtest/gtest.h>
 
 #include <seqan3/alphabet/all.hpp>
+#include <seqan3/core/concept/tuple.hpp>
 
 using namespace seqan3;
 
@@ -70,25 +71,25 @@ public:
     // -------------------------------------------------------------------------
     dna4 value_1()
     {
-        return dna4::G;
+        return 'G'_dna4;
     }
     rna4 assignable_to_value_1()
     {
-        return rna4::G;
+        return 'G'_rna4;
     }
     dna5 value_2()
     {
-        return dna5::G;
+        return 'G'_dna5;
     }
     rna5 assignable_to_value_2()
     {
-        return rna5::G;
+        return 'G'_rna5;
     }
     auto values_to_cmp()
     {
-        return std::make_tuple(/*low */dna4::A, dna5::A,
-                               /*mid */dna4::C, dna5::C,
-                               /*high*/dna4::T, dna5::T);
+        return std::make_tuple(/*low */'A'_dna4, 'A'_dna5,
+                               /*mid */'C'_dna4, 'C'_dna5,
+                               /*high*/'T'_dna4, 'T'_dna5);
     }
 };
 
@@ -106,11 +107,11 @@ public:
     // -------------------------------------------------------------------------
     dna4 value_1()
     {
-        return dna4::G;
+        return 'G'_dna4;
     }
     rna4 assignable_to_value_1()
     {
-        return rna4::G;
+        return 'G'_rna4;
     }
     phred42 value_2()
     {
@@ -122,9 +123,9 @@ public:
     }
     auto values_to_cmp()
     {
-        return std::make_tuple(/*low */dna4::A, phred42{1},
-                               /*mid */dna4::C, phred42{4},
-                               /*high*/dna4::T, phred42{9});
+        return std::make_tuple(/*low */'A'_dna4, phred42{1},
+                               /*mid */'C'_dna4, phred42{4},
+                               /*high*/'T'_dna4, phred42{9});
     }
 };
 
@@ -142,11 +143,11 @@ public:
     // -------------------------------------------------------------------------
     rna4 value_1()
     {
-        return rna4::G;
+        return 'G'_rna4;
     }
     dna4 assignable_to_value_1()
     {
-        return dna4::G;
+        return 'G'_dna4;
     }
     dot_bracket3 value_2()
     {
@@ -158,9 +159,9 @@ public:
     }
     auto values_to_cmp()
     {
-        return std::make_tuple(/*low */rna4::A, dot_bracket3::UNPAIRED,
-                               /*mid */rna4::C, dot_bracket3::PAIR_OPEN,
-                               /*high*/rna4::T, dot_bracket3::PAIR_CLOSE);
+        return std::make_tuple(/*low */'A'_rna4, dot_bracket3::UNPAIRED,
+                               /*mid */'C'_rna4, dot_bracket3::PAIR_OPEN,
+                               /*high*/'T'_rna4, dot_bracket3::PAIR_CLOSE);
     }
 
 };
@@ -207,6 +208,11 @@ using composition_types = ::testing::Types<test_composition<dna4, dna5>,
                                            qualified<dna4, phred42>>;
 
 TYPED_TEST_CASE(cartesian_composition_test, composition_types);
+
+TYPED_TEST(cartesian_composition_test, concept_check)
+{
+    EXPECT_TRUE(tuple_like_concept<TypeParam>);
+}
 
 // default/zero construction
 TYPED_TEST(cartesian_composition_test, ctr)
@@ -307,23 +313,11 @@ TYPED_TEST(cartesian_composition_test, get_i)
 {
     TypeParam t0 = TestFixture::instance;
 
-    static_assert(std::is_same_v<decltype(seqan3::get<0>(t0)), decltype(TestFixture::value_1()) &>);
-    static_assert(std::is_same_v<decltype(seqan3::get<1>(t0)), decltype(TestFixture::value_2()) &>);
+//     static_assert(std::is_same_v<decltype(get<0>(t0)), decltype(TestFixture::value_1()) &>);
+//     static_assert(std::is_same_v<decltype(get<1>(t0)), decltype(TestFixture::value_2()) &>);
 
-    EXPECT_EQ(seqan3::get<0>(t0), TestFixture::value_1());
-    EXPECT_EQ(seqan3::get<1>(t0), TestFixture::value_2());
-}
-
-// std::get<1>
-TYPED_TEST(cartesian_composition_test, stdget_i)
-{
-    TypeParam t0 = TestFixture::instance;
-
-    static_assert(std::is_same_v<decltype(std::get<0>(t0)), decltype(TestFixture::value_1()) &>);
-    static_assert(std::is_same_v<decltype(std::get<1>(t0)), decltype(TestFixture::value_2()) &>);
-
-    EXPECT_EQ(std::get<0>(t0), TestFixture::value_1());
-    EXPECT_EQ(std::get<1>(t0), TestFixture::value_2());
+    EXPECT_EQ(get<0>(t0), TestFixture::value_1());
+    EXPECT_EQ(get<1>(t0), TestFixture::value_2());
 }
 
 // structured bindings
@@ -344,17 +338,8 @@ TYPED_TEST(cartesian_composition_test, get_type)
 {
     TypeParam t0 = TestFixture::instance;
 
-    EXPECT_EQ(seqan3::get<decltype(TestFixture::value_1())>(t0), TestFixture::value_1());
-    EXPECT_EQ(seqan3::get<decltype(TestFixture::value_2())>(t0), TestFixture::value_2());
-}
-
-// std::get<type>
-TYPED_TEST(cartesian_composition_test, stdget_type)
-{
-    TypeParam t0 = TestFixture::instance;
-
-    EXPECT_EQ(std::get<decltype(TestFixture::value_1())>(t0), TestFixture::value_1());
-    EXPECT_EQ(std::get<decltype(TestFixture::value_2())>(t0), TestFixture::value_2());
+    EXPECT_EQ(get<decltype(TestFixture::value_1())>(t0), TestFixture::value_1());
+    EXPECT_EQ(get<decltype(TestFixture::value_2())>(t0), TestFixture::value_2());
 }
 
 // Custom constructor that assigns one type and defaults the other values

--- a/test/unit/alphabet/composition/composition_test.cpp
+++ b/test/unit/alphabet/composition/composition_test.cpp
@@ -42,8 +42,8 @@ using namespace seqan3;
 
 TEST(composition, custom_constructors)
 {
-    qualified<dna4, phred42> t11{dna4::C};
-    qualified<dna4, phred42> t12{rna4::C};
+    qualified<dna4, phred42> t11{'C'_dna4};
+    qualified<dna4, phred42> t12{'C'_rna4};
     qualified<dna4, phred42> t13{phred42{3}};
     qualified<dna4, phred42> t14{phred63{3}};
 
@@ -52,32 +52,32 @@ TEST(composition, custom_constructors)
     qualified<aa27, phred63> t22{phred63{3}};
     qualified<aa27, phred63> t23{phred42{3}};
 
-    qualified<gapped<dna4>, phred42> t31{dna4::C};
-    qualified<gapped<dna4>, phred42> t32{rna4::C};
+    qualified<gapped<dna4>, phred42> t31{'C'_dna4};
+    qualified<gapped<dna4>, phred42> t32{'C'_rna4};
     qualified<gapped<dna4>, phred42> t33{phred42{3}};
     qualified<gapped<dna4>, phred42> t34{gap::GAP};
-    qualified<gapped<dna4>, phred42> t35{gapped<dna4>(dna4::C)};
+    qualified<gapped<dna4>, phred42> t35{gapped<dna4>('C'_dna4)};
     qualified<gapped<dna4>, phred42> t36{gapped<dna4>(gap::GAP)};
     qualified<gapped<dna4>, phred42> t37{gap::GAP, phred42{3}};
 
-    gapped<qualified<dna4, phred42>> t41{dna4::C};
-    gapped<qualified<dna4, phred42>> t42{rna4::C};
+    gapped<qualified<dna4, phred42>> t41{'C'_dna4};
+    gapped<qualified<dna4, phred42>> t42{'C'_rna4};
     gapped<qualified<dna4, phred42>> t43{phred42{3}};
     gapped<qualified<dna4, phred42>> t44{gap::GAP};
-    gapped<qualified<dna4, phred42>> t45{qualified<dna4, phred42>{dna4::C, phred42{0}}};
+    gapped<qualified<dna4, phred42>> t45{qualified<dna4, phred42>{'C'_dna4, phred42{0}}};
 
-    qualified<qualified<gapped<dna4>, phred42>, phred42> t51{dna4::C};
-    qualified<qualified<gapped<dna4>, phred42>, phred42> t52{rna4::C};
+    qualified<qualified<gapped<dna4>, phred42>, phred42> t51{'C'_dna4};
+    qualified<qualified<gapped<dna4>, phred42>, phred42> t52{'C'_rna4};
     qualified<qualified<gapped<dna4>, phred42>, phred42> t53{phred42{3}};
     qualified<qualified<gapped<dna4>, phred42>, phred42> t54{gap::GAP};
-    qualified<qualified<gapped<dna4>, phred42>, phred42> t55{gapped<dna4>(dna4::C)};
+    qualified<qualified<gapped<dna4>, phred42>, phred42> t55{gapped<dna4>('C'_dna4)};
     qualified<qualified<gapped<dna4>, phred42>, phred42> t56{gapped<dna4>(gap::GAP)};
 
-    gapped<union_composition<dna4, phred42>> t61{dna4::C};
-    gapped<union_composition<dna4, phred42>> t62{rna4::C};
+    gapped<union_composition<dna4, phred42>> t61{'C'_dna4};
+    gapped<union_composition<dna4, phred42>> t62{'C'_rna4};
     gapped<union_composition<dna4, phred42>> t63{phred42{3}};
     gapped<union_composition<dna4, phred42>> t64{gap::GAP};
-    gapped<union_composition<dna4, phred42>> t65{qualified<dna4, phred42>{dna4::C, phred42{0}}};
+    gapped<union_composition<dna4, phred42>> t65{qualified<dna4, phred42>{'C'_dna4, phred42{0}}};
 
     EXPECT_EQ(t11, t12);
     EXPECT_EQ(t13, t14);
@@ -110,8 +110,8 @@ TEST(composition, custom_constructors)
 
 TEST(composition_constexpr, custom_constructor)
 {
-    constexpr qualified<dna4, phred42> t11{dna4::C};
-    constexpr qualified<dna4, phred42> t12{rna4::C};
+    constexpr qualified<dna4, phred42> t11{'C'_dna4};
+    constexpr qualified<dna4, phred42> t12{'C'_rna4};
     constexpr qualified<dna4, phred42> t13{phred42{3}};
     constexpr qualified<dna4, phred42> t14{phred63{3}};
 
@@ -119,42 +119,42 @@ TEST(composition_constexpr, custom_constructor)
     constexpr qualified<aa27, phred63> t22{phred63{3}};
     constexpr qualified<aa27, phred63> t23{phred42{3}};
 
-    constexpr qualified<gapped<dna4>, phred42> t31{dna4::C};
-    constexpr qualified<gapped<dna4>, phred42> t32{rna4::C};
+    constexpr qualified<gapped<dna4>, phred42> t31{'C'_dna4};
+    constexpr qualified<gapped<dna4>, phred42> t32{'C'_rna4};
     constexpr qualified<gapped<dna4>, phred42> t33{phred42{3}};
     constexpr qualified<gapped<dna4>, phred42> t34{gap::GAP};
-    constexpr qualified<gapped<dna4>, phred42> t35{gapped<dna4>(dna4::C)};
+    constexpr qualified<gapped<dna4>, phred42> t35{gapped<dna4>('C'_dna4)};
     constexpr qualified<gapped<dna4>, phred42> t36{gapped<dna4>(gap::GAP)};
     constexpr qualified<gapped<dna4>, phred42> t37{gap::GAP, phred42{3}};
 
-    constexpr gapped<qualified<dna4, phred42>> t41{dna4::C};
-    constexpr gapped<qualified<dna4, phred42>> t42{rna4::C};
+    constexpr gapped<qualified<dna4, phred42>> t41{'C'_dna4};
+    constexpr gapped<qualified<dna4, phred42>> t42{'C'_rna4};
     constexpr gapped<qualified<dna4, phred42>> t43{phred42{3}};
     constexpr gapped<qualified<dna4, phred42>> t44{gap::GAP};
-    constexpr gapped<qualified<dna4, phred42>> t45{qualified<dna4, phred42>{dna4::C, phred42{0}}};
+    constexpr gapped<qualified<dna4, phred42>> t45{qualified<dna4, phred42>{'C'_dna4, phred42{0}}};
 
-    constexpr qualified<qualified<gapped<dna4>, phred42>, phred42> t51{dna4::C};
-    constexpr qualified<qualified<gapped<dna4>, phred42>, phred42> t52{rna4::C};
+    constexpr qualified<qualified<gapped<dna4>, phred42>, phred42> t51{'C'_dna4};
+    constexpr qualified<qualified<gapped<dna4>, phred42>, phred42> t52{'C'_rna4};
     constexpr qualified<qualified<gapped<dna4>, phred42>, phred42> t53{phred42{3}};
     constexpr qualified<qualified<gapped<dna4>, phred42>, phred42> t54{gap::GAP};
-    constexpr qualified<qualified<gapped<dna4>, phred42>, phred42> t55{gapped<dna4>(dna4::C)};
+    constexpr qualified<qualified<gapped<dna4>, phred42>, phred42> t55{gapped<dna4>('C'_dna4)};
     constexpr qualified<qualified<gapped<dna4>, phred42>, phred42> t56{gapped<dna4>(gap::GAP)};
 
-    constexpr gapped<union_composition<dna4, phred42>> t61{dna4::C};
-    constexpr gapped<union_composition<dna4, phred42>> t62{rna4::C};
+    constexpr gapped<union_composition<dna4, phred42>> t61{'C'_dna4};
+    constexpr gapped<union_composition<dna4, phred42>> t62{'C'_rna4};
     constexpr gapped<union_composition<dna4, phred42>> t63{phred42{3}};
     constexpr gapped<union_composition<dna4, phred42>> t64{gap::GAP};
-    constexpr gapped<union_composition<dna4, phred42>> t65{qualified<dna4, phred42>{dna4::C, phred42{0}}};
+    constexpr gapped<union_composition<dna4, phred42>> t65{qualified<dna4, phred42>{'C'_dna4, phred42{0}}};
 }
 
 TEST(composition, custom_assignment)
 {
     qualified<dna4, phred42> t11{};
-    qualified<dna4, phred42> t12{dna4::C};
-    qualified<dna4, phred42> t13{dna4::C, phred42{3}};
-    t11 = dna4::C;
+    qualified<dna4, phred42> t12{'C'_dna4};
+    qualified<dna4, phred42> t13{'C'_dna4, phred42{3}};
+    t11 = 'C'_dna4;
     EXPECT_EQ(t11, t12);
-    t11 = rna4::C;
+    t11 = 'C'_rna4;
     EXPECT_EQ(t11, t12);
     t11 = phred42{3};
     EXPECT_EQ(t11, t13);
@@ -169,69 +169,69 @@ TEST(composition, custom_assignment)
     EXPECT_EQ(t21, t22);
 
     qualified<gapped<dna4>, phred42> t31{};
-    qualified<gapped<dna4>, phred42> t32{dna4::C};
-    qualified<gapped<dna4>, phred42> t33{dna4::C, phred42{3}};
+    qualified<gapped<dna4>, phred42> t32{'C'_dna4};
+    qualified<gapped<dna4>, phred42> t33{'C'_dna4, phred42{3}};
     qualified<gapped<dna4>, phred42> t34{gap::GAP, phred42{3}};
-    t31 = dna4::C;
+    t31 = 'C'_dna4;
     EXPECT_EQ(t31, t32);
-    t31 = rna4::C;
+    t31 = 'C'_rna4;
     EXPECT_EQ(t31, t32);
     t31 = phred42{3};
     EXPECT_EQ(t31, t33);
     t31 = gap::GAP;
     EXPECT_EQ(t31, t34);
-    t31 = gapped<dna4>(dna4::C);
+    t31 = gapped<dna4>('C'_dna4);
     EXPECT_EQ(t31, t33);
     t31 = gapped<dna4>(gap::GAP);
     EXPECT_EQ(t31, t34);
 
     gapped<qualified<dna4, phred42>> t41{};
-    gapped<qualified<dna4, phred42>> t42{dna4::C};
-    gapped<qualified<dna4, phred42>> t43{qualified<dna4, phred42>{dna4::C, phred42{3}}};
+    gapped<qualified<dna4, phred42>> t42{'C'_dna4};
+    gapped<qualified<dna4, phred42>> t43{qualified<dna4, phred42>{'C'_dna4, phred42{3}}};
     gapped<qualified<dna4, phred42>> t44{gap::GAP};
-    gapped<qualified<dna4, phred42>> t45{qualified<dna4, phred42>{dna4::C, phred42{0}}};
-    t41 = dna4::C;
+    gapped<qualified<dna4, phred42>> t45{qualified<dna4, phred42>{'C'_dna4, phred42{0}}};
+    t41 = 'C'_dna4;
     EXPECT_EQ(t41, t42);
-    t41 = rna4::C;
+    t41 = 'C'_rna4;
     EXPECT_EQ(t41, t42);
     t41 = phred42{3};
     // EXPECT_EQ(t41, t43); should work intuitively but does not because on assignment the qualified object is defaulted
     t41 = gap::GAP;
     EXPECT_EQ(t41, t44);
-    t41 = qualified<dna4, phred42>{dna4::C, phred42{0}};
+    t41 = qualified<dna4, phred42>{'C'_dna4, phred42{0}};
     EXPECT_EQ(t41, t45);
 
     qualified<qualified<gapped<dna4>, phred42>, phred42> t51{};
-    qualified<qualified<gapped<dna4>, phred42>, phred42> t52{dna4::C};
-    qualified<qualified<gapped<dna4>, phred42>, phred42> t53{qualified<gapped<dna4>, phred42>{dna4::C, phred42{0}}, phred42{3}};
+    qualified<qualified<gapped<dna4>, phred42>, phred42> t52{'C'_dna4};
+    qualified<qualified<gapped<dna4>, phred42>, phred42> t53{qualified<gapped<dna4>, phred42>{'C'_dna4, phred42{0}}, phred42{3}};
     qualified<qualified<gapped<dna4>, phred42>, phred42> t54{qualified<gapped<dna4>, phred42>{gap::GAP, phred42{0}}, phred42{3}};
-    t51 = dna4::C;
+    t51 = 'C'_dna4;
     EXPECT_EQ(t51, t52);
-    t51 = rna4::C;
+    t51 = 'C'_rna4;
     EXPECT_EQ(t51, t52);
     t51 = phred42{3};
     EXPECT_EQ(t51, t53);
     t51 = gap::GAP;
     EXPECT_EQ(t51, t54);
-    t51 = gapped<dna4>(dna4::C);
+    t51 = gapped<dna4>('C'_dna4);
     EXPECT_EQ(t51, t53);
     t51 = gapped<dna4>(gap::GAP);
     EXPECT_EQ(t51, t54);
 
     gapped<union_composition<dna4, phred42>> t61{};
-    gapped<union_composition<dna4, phred42>> t62{dna4::C};
+    gapped<union_composition<dna4, phred42>> t62{'C'_dna4};
     gapped<union_composition<dna4, phred42>> t63{phred42{3}};
     gapped<union_composition<dna4, phred42>> t64{gap::GAP};
-    gapped<union_composition<dna4, phred42>> t65{qualified<dna4, phred42>{dna4::C, phred42{0}}};
-    t61 = dna4::C;
+    gapped<union_composition<dna4, phred42>> t65{qualified<dna4, phred42>{'C'_dna4, phred42{0}}};
+    t61 = 'C'_dna4;
     EXPECT_EQ(t61, t62);
-    t61 = rna4::C;
+    t61 = 'C'_rna4;
     EXPECT_EQ(t61, t62);
     t61 = phred42{3};
     EXPECT_EQ(t61, t63);
     t61 = gap::GAP;
     EXPECT_EQ(t61, t64);
-    t61 = qualified<dna4, phred42>{dna4::C, phred42{0}};
+    t61 = qualified<dna4, phred42>{'C'_dna4, phred42{0}};
     EXPECT_EQ(t61, t65);
 
 }
@@ -239,8 +239,8 @@ TEST(composition, custom_assignment)
 constexpr bool do_assignment()
 {
     qualified<dna4, phred42> t11{};
-    t11 = dna4::C;
-    t11 = rna4::C;
+    t11 = 'C'_dna4;
+    t11 = 'C'_rna4;
     t11 = phred42{3};
     // t11 = phred63{3}; // does not work because of explicit conversion
 
@@ -249,33 +249,33 @@ constexpr bool do_assignment()
     t21 = phred63{3};
 
     qualified<gapped<dna4>, phred42> t31{};
-    t31 = dna4::C;
-    t31 = rna4::C;
+    t31 = 'C'_dna4;
+    t31 = 'C'_rna4;
     t31 = phred42{3};
     t31 = gap::GAP;
-    t31 = gapped<dna4>(dna4::C);
+    t31 = gapped<dna4>('C'_dna4);
     t31 = gapped<dna4>(gap::GAP);
 
     gapped<qualified<dna4, phred42>> t41{};
-    t41 = dna4::C;
-    t41 = rna4::C;
+    t41 = 'C'_dna4;
+    t41 = 'C'_rna4;
     t41 = phred42{3};
     t41 = gap::GAP;
-    t41 = qualified<dna4, phred42>{dna4::C, phred42{0}};
+    t41 = qualified<dna4, phred42>{'C'_dna4, phred42{0}};
 
     qualified<qualified<gapped<dna4>, phred42>, phred42> t51{};
-    t51 = dna4::C;
-    t51 = rna4::C;
+    t51 = 'C'_dna4;
+    t51 = 'C'_rna4;
     t51 = phred42{3};
     t51 = gap::GAP;
-    t51 = gapped<dna4>(dna4::C);
+    t51 = gapped<dna4>('C'_dna4);
     t51 = gapped<dna4>(gap::GAP);
 
     gapped<union_composition<dna4, phred42>> t61{};
-    t61 = rna4::C;
+    t61 = 'C'_rna4;
     t61 = phred42{3};
     t61 = gap::GAP;
-    t61 = qualified<dna4, phred42>{dna4::C, phred42{0}};
+    t61 = qualified<dna4, phred42>{'C'_dna4, phred42{0}};
 
     return true;
 }
@@ -287,13 +287,13 @@ TEST(composition_constexpr, custom_assignment)
 
 TEST(composition, custom_comparison)
 {
-    qualified<dna4, phred42> t11{dna4::C, phred42{3}};
-    EXPECT_EQ(t11, dna4::C);
-    EXPECT_EQ(t11, rna4::C);
+    qualified<dna4, phred42> t11{'C'_dna4, phred42{3}};
+    EXPECT_EQ(t11, 'C'_dna4);
+    EXPECT_EQ(t11, 'C'_rna4);
     EXPECT_EQ(t11, phred42{3});
 
-    EXPECT_EQ(dna4::C,    t11);
-    EXPECT_EQ(rna4::C,    t11);
+    EXPECT_EQ('C'_dna4,    t11);
+    EXPECT_EQ('C'_rna4,    t11);
     EXPECT_EQ(phred42{3}, t11);
 
     qualified<aa27, phred63> t21{aa27::K, phred63{3}};
@@ -302,61 +302,61 @@ TEST(composition, custom_comparison)
     EXPECT_EQ(aa27::K,     t21);
     EXPECT_EQ(phred63{3},  t21);
 
-    qualified<gapped<dna4>, phred42> t31{dna4::C, phred42{3}};
-    EXPECT_EQ(t31, dna4::C);
-    EXPECT_EQ(t31, rna4::C);
+    qualified<gapped<dna4>, phred42> t31{'C'_dna4, phred42{3}};
+    EXPECT_EQ(t31, 'C'_dna4);
+    EXPECT_EQ(t31, 'C'_rna4);
     EXPECT_EQ(t31, phred42{3});
     EXPECT_NE(t31, gap::GAP);
-    EXPECT_EQ(t31, gapped<dna4>(dna4::C));
+    EXPECT_EQ(t31, gapped<dna4>('C'_dna4));
 
-    EXPECT_EQ(dna4::C,                t31);
-    EXPECT_EQ(rna4::C,                t31);
+    EXPECT_EQ('C'_dna4,                t31);
+    EXPECT_EQ('C'_rna4,                t31);
     EXPECT_EQ(phred42{3},             t31);
     EXPECT_NE(gap::GAP,               t31);
-    EXPECT_EQ(gapped<dna4>(dna4::C),  t31);
+    EXPECT_EQ(gapped<dna4>('C'_dna4),  t31);
 
-    gapped<qualified<dna4, phred42>> t41{qualified<dna4, phred42>{dna4::C, phred42{3}}};
-    gapped<qualified<dna4, phred42>> t42{qualified<dna4, phred42>{dna4::C, phred42{0}}};
+    gapped<qualified<dna4, phred42>> t41{qualified<dna4, phred42>{'C'_dna4, phred42{3}}};
+    gapped<qualified<dna4, phred42>> t42{qualified<dna4, phred42>{'C'_dna4, phred42{0}}};
 
-    EXPECT_EQ(t41, (gapped<qualified<dna4, phred42>>{qualified<dna4, phred42>{dna4::C, phred42{3}}}));
-    EXPECT_EQ(t42, dna4::C);
+    EXPECT_EQ(t41, (gapped<qualified<dna4, phred42>>{qualified<dna4, phred42>{'C'_dna4, phred42{3}}}));
+    EXPECT_EQ(t42, 'C'_dna4);
     EXPECT_NE(t41, gap::GAP);
     EXPECT_NE(gap::GAP, t41);
 
-    qualified<qualified<gapped<dna4>, phred42>, phred42> t51{qualified<gapped<dna4>, phred42>{dna4::C, phred42{3}}};
-    EXPECT_EQ(t51, dna4::C);
-    EXPECT_EQ(t51, rna4::C);
+    qualified<qualified<gapped<dna4>, phred42>, phred42> t51{qualified<gapped<dna4>, phred42>{'C'_dna4, phred42{3}}};
+    EXPECT_EQ(t51, 'C'_dna4);
+    EXPECT_EQ(t51, 'C'_rna4);
     EXPECT_NE(t51, gap::GAP);
-    EXPECT_EQ(t51, gapped<dna4>(dna4::C));
+    EXPECT_EQ(t51, gapped<dna4>('C'_dna4));
     EXPECT_EQ(t51, phred42{0});
 
-    EXPECT_EQ(dna4::C,                t51);
-    EXPECT_EQ(rna4::C,                t51);
+    EXPECT_EQ('C'_dna4,                t51);
+    EXPECT_EQ('C'_rna4,                t51);
     EXPECT_EQ(phred42{0},             t51);
     EXPECT_NE(gap::GAP,               t51);
-    EXPECT_EQ(gapped<dna4>(dna4::C),  t51);
+    EXPECT_EQ(gapped<dna4>('C'_dna4),  t51);
 
-    gapped<union_composition<dna4, phred42>> t61{rna4::C};
-    EXPECT_EQ(t61, rna4::C);
-    EXPECT_EQ(t61, dna4::C);
+    gapped<union_composition<dna4, phred42>> t61{'C'_rna4};
+    EXPECT_EQ(t61, 'C'_rna4);
+    EXPECT_EQ(t61, 'C'_dna4);
     EXPECT_NE(t61, gap::GAP);
     EXPECT_NE(t61, phred42{0});
 
-    EXPECT_EQ(rna4::C,    t61);
-    EXPECT_EQ(dna4::C,    t61);
+    EXPECT_EQ('C'_rna4,    t61);
+    EXPECT_EQ('C'_dna4,    t61);
     EXPECT_NE(gap::GAP,   t61);
     EXPECT_NE(phred42{0}, t61);
 
-    EXPECT_EQ(t41, dna4::C);
-    EXPECT_EQ(t41, rna4::C);
+    EXPECT_EQ(t41, 'C'_dna4);
+    EXPECT_EQ(t41, 'C'_rna4);
     EXPECT_EQ(t41, phred42{3});
-    EXPECT_EQ(t41, (qualified<dna4, phred42>{dna4::C, phred42{3}}));
+    EXPECT_EQ(t41, (qualified<dna4, phred42>{'C'_dna4, phred42{3}}));
 
-    EXPECT_EQ(dna4::C,                                         t41);
-    EXPECT_EQ(rna4::C,                                         t41);
+    EXPECT_EQ('C'_dna4,                                         t41);
+    EXPECT_EQ('C'_rna4,                                         t41);
     EXPECT_EQ(phred42{3},                                      t41);
-    EXPECT_EQ((qualified<dna4, phred42>{dna4::C, phred42{3}}), t41);
+    EXPECT_EQ((qualified<dna4, phred42>{'C'_dna4, phred42{3}}), t41);
 
-    EXPECT_EQ(t51, (qualified<gapped<dna4>, phred42>{dna4::C, phred42{3}}));
-    EXPECT_EQ((qualified<dna4, phred42>{dna4::C, phred42{3}}), t51);
+    EXPECT_EQ(t51, (qualified<gapped<dna4>, phred42>{'C'_dna4, phred42{3}}));
+    EXPECT_EQ((qualified<dna4, phred42>{'C'_dna4, phred42{3}}), t51);
 }

--- a/test/unit/alphabet/composition/union_composition_detail_test.cpp
+++ b/test/unit/alphabet/composition/union_composition_detail_test.cpp
@@ -48,8 +48,8 @@ class detail_union_composition : public union_composition<alphabet_types...>
 {
 public:
     using union_composition<alphabet_types...>::partial_sum_sizes;
-    using union_composition<alphabet_types...>::value_to_char;
-    using union_composition<alphabet_types...>::char_to_value;
+    using union_composition<alphabet_types...>::rank_to_char;
+    using union_composition<alphabet_types...>::char_to_rank;
 };
 
 TEST(union_composition_detail_test, partial_sum_sizes)
@@ -75,76 +75,76 @@ TEST(union_composition_detail_test, partial_sum_sizes)
     EXPECT_EQ(partial_sum4[3], 10);
 }
 
-TEST(union_composition_detail_test, value_to_char)
+TEST(union_composition_detail_test, rank_to_char)
 {
-    constexpr std::array value_to_char2 = detail_union_composition<dna4, gap>::value_to_char;
-    EXPECT_EQ(value_to_char2.size(), 5u);
-    EXPECT_EQ(value_to_char2[0], 'A');
-    EXPECT_EQ(value_to_char2[1], 'C');
-    EXPECT_EQ(value_to_char2[2], 'G');
-    EXPECT_EQ(value_to_char2[3], 'T');
-    EXPECT_EQ(value_to_char2[4], '-');
+    constexpr std::array rank_to_char2 = detail_union_composition<dna4, gap>::rank_to_char;
+    EXPECT_EQ(rank_to_char2.size(), 5u);
+    EXPECT_EQ(rank_to_char2[0], 'A');
+    EXPECT_EQ(rank_to_char2[1], 'C');
+    EXPECT_EQ(rank_to_char2[2], 'G');
+    EXPECT_EQ(rank_to_char2[3], 'T');
+    EXPECT_EQ(rank_to_char2[4], '-');
 
-    constexpr std::array value_to_char3 = detail_union_composition<dna4, gap, dna5>::value_to_char;
-    EXPECT_EQ(value_to_char3.size(), 10u);
-    EXPECT_EQ(value_to_char3[0], 'A');
-    EXPECT_EQ(value_to_char3[1], 'C');
-    EXPECT_EQ(value_to_char3[2], 'G');
-    EXPECT_EQ(value_to_char3[3], 'T');
-    EXPECT_EQ(value_to_char3[4], '-');
-    EXPECT_EQ(value_to_char3[5], 'A');
-    EXPECT_EQ(value_to_char3[6], 'C');
-    EXPECT_EQ(value_to_char3[7], 'G');
-    EXPECT_EQ(value_to_char3[8], 'T');
-    EXPECT_EQ(value_to_char3[9], 'N');
+    constexpr std::array rank_to_char3 = detail_union_composition<dna4, gap, dna5>::rank_to_char;
+    EXPECT_EQ(rank_to_char3.size(), 10u);
+    EXPECT_EQ(rank_to_char3[0], 'A');
+    EXPECT_EQ(rank_to_char3[1], 'C');
+    EXPECT_EQ(rank_to_char3[2], 'G');
+    EXPECT_EQ(rank_to_char3[3], 'T');
+    EXPECT_EQ(rank_to_char3[4], '-');
+    EXPECT_EQ(rank_to_char3[5], 'A');
+    EXPECT_EQ(rank_to_char3[6], 'C');
+    EXPECT_EQ(rank_to_char3[7], 'G');
+    EXPECT_EQ(rank_to_char3[8], 'N');
+    EXPECT_EQ(rank_to_char3[9], 'T');
 
-    constexpr std::array value_to_char4 = detail_union_composition<dna5, gap, dna4>::value_to_char;
-    EXPECT_EQ(value_to_char4.size(), 10u);
-    EXPECT_EQ(value_to_char4[0], 'A');
-    EXPECT_EQ(value_to_char4[1], 'C');
-    EXPECT_EQ(value_to_char4[2], 'G');
-    EXPECT_EQ(value_to_char4[3], 'T');
-    EXPECT_EQ(value_to_char4[4], 'N');
-    EXPECT_EQ(value_to_char4[5], '-');
-    EXPECT_EQ(value_to_char4[6], 'A');
-    EXPECT_EQ(value_to_char4[7], 'C');
-    EXPECT_EQ(value_to_char4[8], 'G');
-    EXPECT_EQ(value_to_char4[9], 'T');
+    constexpr std::array rank_to_char4 = detail_union_composition<dna5, gap, dna4>::rank_to_char;
+    EXPECT_EQ(rank_to_char4.size(), 10u);
+    EXPECT_EQ(rank_to_char4[0], 'A');
+    EXPECT_EQ(rank_to_char4[1], 'C');
+    EXPECT_EQ(rank_to_char4[2], 'G');
+    EXPECT_EQ(rank_to_char4[3], 'N');
+    EXPECT_EQ(rank_to_char4[4], 'T');
+    EXPECT_EQ(rank_to_char4[5], '-');
+    EXPECT_EQ(rank_to_char4[6], 'A');
+    EXPECT_EQ(rank_to_char4[7], 'C');
+    EXPECT_EQ(rank_to_char4[8], 'G');
+    EXPECT_EQ(rank_to_char4[9], 'T');
 }
 
-TEST(union_composition_detail_test, char_to_value)
+TEST(union_composition_detail_test, char_to_rank)
 {
-    constexpr std::array char_to_value2 = detail_union_composition<dna4, gap>::char_to_value;
-    EXPECT_EQ(char_to_value2.size(), 256u);
-    EXPECT_EQ(char_to_value2['A'], 0);
-    EXPECT_EQ(char_to_value2['C'], 1);
-    EXPECT_EQ(char_to_value2['G'], 2);
-    EXPECT_EQ(char_to_value2['T'], 3);
-    EXPECT_EQ(char_to_value2['-'], 4);
+    constexpr std::array char_to_rank2 = detail_union_composition<dna4, gap>::char_to_rank;
+    EXPECT_EQ(char_to_rank2.size(), 256u);
+    EXPECT_EQ(char_to_rank2['A'], 0);
+    EXPECT_EQ(char_to_rank2['C'], 1);
+    EXPECT_EQ(char_to_rank2['G'], 2);
+    EXPECT_EQ(char_to_rank2['T'], 3);
+    EXPECT_EQ(char_to_rank2['-'], 4);
 
-    constexpr std::array char_to_value3 = detail_union_composition<dna4, gap, dna5>::char_to_value;
-    EXPECT_EQ(char_to_value3.size(), 256u);
-    EXPECT_EQ(char_to_value3['A'], 0);
-    EXPECT_EQ(char_to_value3['C'], 1);
-    EXPECT_EQ(char_to_value3['G'], 2);
-    EXPECT_EQ(char_to_value3['T'], 3);
-    EXPECT_EQ(char_to_value3['-'], 4);
-    EXPECT_EQ(char_to_value3['A'], 0);
-    EXPECT_EQ(char_to_value3['C'], 1);
-    EXPECT_EQ(char_to_value3['G'], 2);
-    EXPECT_EQ(char_to_value3['T'], 3);
-    EXPECT_EQ(char_to_value3['N'], 9);
+    constexpr std::array char_to_rank3 = detail_union_composition<dna4, gap, dna5>::char_to_rank;
+    EXPECT_EQ(char_to_rank3.size(), 256u);
+    EXPECT_EQ(char_to_rank3['A'], 0);
+    EXPECT_EQ(char_to_rank3['C'], 1);
+    EXPECT_EQ(char_to_rank3['G'], 2);
+    EXPECT_EQ(char_to_rank3['T'], 3);
+    EXPECT_EQ(char_to_rank3['-'], 4);
+    EXPECT_EQ(char_to_rank3['A'], 0);
+    EXPECT_EQ(char_to_rank3['C'], 1);
+    EXPECT_EQ(char_to_rank3['G'], 2);
+    EXPECT_EQ(char_to_rank3['N'], 8);
+    EXPECT_EQ(char_to_rank3['T'], 3);
 
-    constexpr std::array char_to_value4 = detail_union_composition<dna5, gap, dna4>::char_to_value;
-    EXPECT_EQ(char_to_value4.size(), 256u);
-    EXPECT_EQ(char_to_value4['A'], 0);
-    EXPECT_EQ(char_to_value4['C'], 1);
-    EXPECT_EQ(char_to_value4['G'], 2);
-    EXPECT_EQ(char_to_value4['T'], 3);
-    EXPECT_EQ(char_to_value4['N'], 4);
-    EXPECT_EQ(char_to_value4['-'], 5);
-    EXPECT_EQ(char_to_value4['A'], 0);
-    EXPECT_EQ(char_to_value4['C'], 1);
-    EXPECT_EQ(char_to_value4['G'], 2);
-    EXPECT_EQ(char_to_value4['T'], 3);
+    constexpr std::array char_to_rank4 = detail_union_composition<dna5, gap, dna4>::char_to_rank;
+    EXPECT_EQ(char_to_rank4.size(), 256u);
+    EXPECT_EQ(char_to_rank4['A'], 0);
+    EXPECT_EQ(char_to_rank4['C'], 1);
+    EXPECT_EQ(char_to_rank4['G'], 2);
+    EXPECT_EQ(char_to_rank4['N'], 3);
+    EXPECT_EQ(char_to_rank4['T'], 4);
+    EXPECT_EQ(char_to_rank4['-'], 5);
+    EXPECT_EQ(char_to_rank4['A'], 0);
+    EXPECT_EQ(char_to_rank4['C'], 1);
+    EXPECT_EQ(char_to_rank4['G'], 2);
+    EXPECT_EQ(char_to_rank4['T'], 4);
 }

--- a/test/unit/alphabet/composition/union_composition_test.cpp
+++ b/test/unit/alphabet/composition/union_composition_test.cpp
@@ -48,37 +48,37 @@ using namespace seqan3;
 
 TEST(union_composition_test, initialise_from_component_alphabet)
 {
-    dna5 l(rna5::A);
+    dna5 l('A'_rna5);
 
     using alphabet_t = union_composition<dna4, dna5, gap>;
     using variant_t = std::variant<dna4, dna5, gap>;
 
-    constexpr variant_t variant0{dna4::A};
-    constexpr alphabet_t letter0{dna4::A};
+    constexpr variant_t variant0{'A'_dna4};
+    constexpr alphabet_t letter0{'A'_dna4};
 
-    constexpr variant_t variant1 = dna4::C;
-    constexpr alphabet_t letter1 = dna4::C;
+    constexpr variant_t variant1 = 'C'_dna4;
+    constexpr alphabet_t letter1 = 'C'_dna4;
 
-    constexpr variant_t variant2 = {dna4::G};
-    constexpr alphabet_t letter2 = {dna4::G};
+    constexpr variant_t variant2 = {'G'_dna4};
+    constexpr alphabet_t letter2 = {'G'_dna4};
 
-    constexpr variant_t variant3 = static_cast<variant_t>(dna4::T);
-    constexpr alphabet_t letter3 = static_cast<alphabet_t>(dna4::T);
+    constexpr variant_t variant3 = static_cast<variant_t>('T'_dna4);
+    constexpr alphabet_t letter3 = static_cast<alphabet_t>('T'_dna4);
 
-    constexpr variant_t variant4 = {static_cast<variant_t>(dna5::A)};
-    constexpr alphabet_t letter4 = {static_cast<alphabet_t>(dna5::A)};
+    constexpr variant_t variant4 = {static_cast<variant_t>('A'_dna5)};
+    constexpr alphabet_t letter4 = {static_cast<alphabet_t>('A'_dna5)};
 
-    variant_t variant5{dna5::C};
-    alphabet_t letter5{dna5::C};
+    variant_t variant5{'C'_dna5};
+    alphabet_t letter5{'C'_dna5};
 
-    variant_t variant6 = dna5::G;
-    alphabet_t letter6 = dna5::G;
+    variant_t variant6 = 'G'_dna5;
+    alphabet_t letter6 = 'G'_dna5;
 
-    variant_t variant7 = {dna5::T};
-    alphabet_t letter7 = {dna5::T};
+    variant_t variant7 = {'N'_dna5};
+    alphabet_t letter7 = {'N'_dna5};
 
-    variant_t variant8 = static_cast<variant_t>(dna5::N);
-    alphabet_t letter8 = static_cast<alphabet_t>(dna5::N);
+    variant_t variant8 = static_cast<variant_t>('T'_dna5);
+    alphabet_t letter8 = static_cast<alphabet_t>('T'_dna5);
 
     variant_t variant9 = {static_cast<variant_t>(gap::GAP)};
     alphabet_t letter9 = {static_cast<alphabet_t>(gap::GAP)};
@@ -100,32 +100,32 @@ TEST(union_composition_test, initialise_from_component_alphabet_subtype)
     using alphabet_t = union_composition<dna4, dna5, gap>;
     using variant_t = std::variant<dna4, dna5, gap>;
 
-    variant_t variant0{rna4::A};
-    alphabet_t letter0{rna4::A};
+    variant_t variant0{'A'_rna4};
+    alphabet_t letter0{'A'_rna4};
 
-    variant_t variant1 = rna4::C;
-    alphabet_t letter1 = rna4::C;
+    variant_t variant1 = 'C'_rna4;
+    alphabet_t letter1 = 'C'_rna4;
 
-    variant_t variant2 = {rna4::G};
-    alphabet_t letter2 = {rna4::G};
+    variant_t variant2 = {'G'_rna4};
+    alphabet_t letter2 = {'G'_rna4};
 
-    variant_t variant3 = static_cast<variant_t>(rna4::T);
-    alphabet_t letter3 = static_cast<alphabet_t>(rna4::T);
+    variant_t variant3 = static_cast<variant_t>('T'_rna4);
+    alphabet_t letter3 = static_cast<alphabet_t>('T'_rna4);
 
-    variant_t variant4 = {static_cast<variant_t>(rna5::A)};
-    alphabet_t letter4 = {static_cast<alphabet_t>(rna5::A)};
+    variant_t variant4 = {static_cast<variant_t>('A'_rna5)};
+    alphabet_t letter4 = {static_cast<alphabet_t>('A'_rna5)};
 
-    variant_t variant5{rna5::C};
-    alphabet_t letter5{rna5::C};
+    variant_t variant5{'C'_rna5};
+    alphabet_t letter5{'C'_rna5};
 
-    variant_t variant6 = rna5::G;
-    alphabet_t letter6 = rna5::G;
+    variant_t variant6 = 'G'_rna5;
+    alphabet_t letter6 = 'G'_rna5;
 
-    variant_t variant7 = {rna5::T};
-    alphabet_t letter7 = {rna5::T};
+    variant_t variant7 = {'N'_rna5};
+    alphabet_t letter7 = {'N'_rna5};
 
-    variant_t variant8 = static_cast<variant_t>(rna5::N);
-    alphabet_t letter8 = static_cast<alphabet_t>(rna5::N);
+    variant_t variant8 = static_cast<variant_t>('T'_rna5);
+    alphabet_t letter8 = static_cast<alphabet_t>('T'_rna5);
 
     EXPECT_EQ(letter0.to_rank(), 0);
     EXPECT_EQ(letter1.to_rank(), 1);
@@ -145,38 +145,38 @@ TEST(union_composition_test, assign_from_component_alphabet)
     alphabet_t letter{};
     variant_t variant{};
 
-    variant = dna4::A;
-    letter = dna4::A;
+    variant = 'A'_dna4;
+    letter = 'A'_dna4;
     EXPECT_EQ(variant.index(), 0u);
     EXPECT_EQ(letter.to_rank(), 0);
 
-    variant = {dna4::C};
-    letter = {dna4::C};
+    variant = {'C'_dna4};
+    letter = {'C'_dna4};
     EXPECT_EQ(variant.index(), 0u);
     EXPECT_EQ(letter.to_rank(), 1);
 
-    variant = static_cast<variant_t>(dna4::G);
-    letter = static_cast<alphabet_t>(dna4::G);
+    variant = static_cast<variant_t>('G'_dna4);
+    letter = static_cast<alphabet_t>('G'_dna4);
     EXPECT_EQ(variant.index(), 0u);
     EXPECT_EQ(letter.to_rank(), 2);
 
-    variant = {static_cast<variant_t>(dna4::T)};
-    letter = {static_cast<alphabet_t>(dna4::T)};
+    variant = {static_cast<variant_t>('T'_dna4)};
+    letter = {static_cast<alphabet_t>('T'_dna4)};
     EXPECT_EQ(letter.to_rank(), 3);
 
-    letter = dna5::A;
+    letter = 'A'_dna5;
     EXPECT_EQ(letter.to_rank(), 4);
 
-    letter = dna5::C;
+    letter = 'C'_dna5;
     EXPECT_EQ(letter.to_rank(), 5);
 
-    letter = dna5::G;
+    letter = 'G'_dna5;
     EXPECT_EQ(letter.to_rank(), 6);
 
-    letter = dna5::T;
+    letter = 'N'_dna5;
     EXPECT_EQ(letter.to_rank(), 7);
 
-    letter = dna5::N;
+    letter = 'T'_dna5;
     EXPECT_EQ(letter.to_rank(), 8);
 
     letter = gap::GAP;
@@ -190,38 +190,38 @@ TEST(union_composition_test, assign_from_component_alphabet_subtype)
     alphabet_t letter{};
     variant_t variant{};
 
-    variant = rna4::A;
-    letter = rna4::A;
+    variant = 'A'_rna4;
+    letter = 'A'_rna4;
     EXPECT_EQ(variant.index(), 0u);
     EXPECT_EQ(letter.to_rank(), 0);
 
-    variant = {rna4::C};
-    letter = {rna4::C};
+    variant = {'C'_rna4};
+    letter = {'C'_rna4};
     EXPECT_EQ(variant.index(), 0u);
     EXPECT_EQ(letter.to_rank(), 1);
 
-    variant = static_cast<variant_t>(rna4::G);
-    letter = static_cast<alphabet_t>(rna4::G);
+    variant = static_cast<variant_t>('G'_rna4);
+    letter = static_cast<alphabet_t>('G'_rna4);
     EXPECT_EQ(variant.index(), 0u);
     EXPECT_EQ(letter.to_rank(), 2);
 
-    variant = {static_cast<variant_t>(rna4::T)};
-    letter = {static_cast<alphabet_t>(rna4::T)};
+    variant = {static_cast<variant_t>('T'_rna4)};
+    letter = {static_cast<alphabet_t>('T'_rna4)};
     EXPECT_EQ(letter.to_rank(), 3);
 
-    letter = rna5::A;
+    letter = 'A'_rna5;
     EXPECT_EQ(letter.to_rank(), 4);
 
-    letter = rna5::C;
+    letter = 'C'_rna5;
     EXPECT_EQ(letter.to_rank(), 5);
 
-    letter = rna5::G;
+    letter = 'G'_rna5;
     EXPECT_EQ(letter.to_rank(), 6);
 
-    letter = rna5::T;
+    letter = 'N'_rna5;
     EXPECT_EQ(letter.to_rank(), 7);
 
-    letter = rna5::N;
+    letter = 'T'_rna5;
     EXPECT_EQ(letter.to_rank(), 8);
 }
 
@@ -229,30 +229,30 @@ TEST(union_composition_test, compare_to_component_alphabet)
 {
     using alphabet_t = union_composition<dna4, dna5>;
 
-    constexpr alphabet_t letter0{dna4::G};
+    constexpr alphabet_t letter0{'G'_dna4};
 
-    EXPECT_EQ(letter0, dna4::G);
-    EXPECT_NE(letter0, dna4::A);
-    EXPECT_NE(letter0, dna5::A);
+    EXPECT_EQ(letter0, 'G'_dna4);
+    EXPECT_NE(letter0, 'A'_dna4);
+    EXPECT_NE(letter0, 'A'_dna5);
 
-    EXPECT_EQ(dna4::G, letter0);
-    EXPECT_NE(dna4::A, letter0);
-    EXPECT_NE(dna5::A, letter0);
+    EXPECT_EQ('G'_dna4, letter0);
+    EXPECT_NE('A'_dna4, letter0);
+    EXPECT_NE('A'_dna5, letter0);
 }
 
 TEST(union_composition_test, compare_to_component_alphabet_subtype)
 {
     using alphabet_t = union_composition<dna4, dna5>;
 
-    constexpr alphabet_t letter0{dna4::G};
+    constexpr alphabet_t letter0{'G'_dna4};
 
-    EXPECT_EQ(letter0, rna4::G);
-    EXPECT_NE(letter0, rna4::A);
-    EXPECT_NE(letter0, rna5::A);
+    EXPECT_EQ(letter0, 'G'_rna4);
+    EXPECT_NE(letter0, 'A'_rna4);
+    EXPECT_NE(letter0, 'A'_rna5);
 
-    EXPECT_EQ(rna4::G, letter0);
-    EXPECT_NE(rna4::A, letter0);
-    EXPECT_NE(rna5::A, letter0);
+    EXPECT_EQ('G'_rna4, letter0);
+    EXPECT_NE('A'_rna4, letter0);
+    EXPECT_NE('A'_rna5, letter0);
 }
 
 TEST(union_composition_test, fulfills_concepts)
@@ -289,7 +289,7 @@ TEST(union_composition_test, value_size)
 TEST(union_composition_test, convert_by_index)
 {
     union_composition<dna4, dna5, gap> u;
-    u = dna5::C;
+    u = 'C'_dna5;
 
     EXPECT_FALSE(u.is_alternative<0>());
     EXPECT_TRUE(u.is_alternative<1>());
@@ -300,7 +300,7 @@ TEST(union_composition_test, convert_by_index)
     EXPECT_THROW(u.convert_to<2>(), std::bad_variant_access);
 
     dna5 out = u.convert_to<1>();
-    EXPECT_EQ(out, dna5::C);
+    EXPECT_EQ(out, 'C'_dna5);
 
     u = gap::GAP;
 
@@ -311,7 +311,7 @@ TEST(union_composition_test, convert_by_index)
 TEST(union_composition_test, convert_by_type)
 {
     union_composition<dna4, dna5, gap> u;
-    u = dna5::C;
+    u = 'C'_dna5;
 
     EXPECT_FALSE(u.is_alternative<dna4>());
     EXPECT_TRUE(u.is_alternative<dna5>());
@@ -322,7 +322,7 @@ TEST(union_composition_test, convert_by_type)
     EXPECT_THROW(u.convert_to<gap>(), std::bad_variant_access);
 
     dna5 out = u.convert_to<dna5>();
-    EXPECT_EQ(out, dna5::C);
+    EXPECT_EQ(out, 'C'_dna5);
 
     u = gap::GAP;
     gap g = u.convert_unsafely_to<gap>();

--- a/test/unit/alphabet/gap/gapped_test.cpp
+++ b/test/unit/alphabet/gap/gapped_test.cpp
@@ -49,17 +49,17 @@ TEST(gapped_test, initialise_from_component_alphabet)
 {
     using alphabet_t = gapped<dna4>;
 
-    constexpr alphabet_t letter0{dna4::A};
-    constexpr alphabet_t letter1 = dna4::C;
-    constexpr alphabet_t letter2 = {dna4::G};
-    constexpr alphabet_t letter3 = static_cast<alphabet_t>(dna4::T);
+    constexpr alphabet_t letter0{'A'_dna4};
+    constexpr alphabet_t letter1 = 'C'_dna4;
+    constexpr alphabet_t letter2 = {'G'_dna4};
+    constexpr alphabet_t letter3 = static_cast<alphabet_t>('T'_dna4);
 
-    alphabet_t letter4{dna4::A};
-    alphabet_t letter5 = dna4::C;
-    alphabet_t letter6 = {dna4::G};
-    alphabet_t letter7 = static_cast<alphabet_t>(dna4::T);
+    alphabet_t letter4{'A'_dna4};
+    alphabet_t letter5 = 'C'_dna4;
+    alphabet_t letter6 = {'G'_dna4};
+    alphabet_t letter7 = static_cast<alphabet_t>('T'_dna4);
 
-    constexpr alphabet_t letter8{gap::GAP}; // letter3 = dna4::T; does not work
+    constexpr alphabet_t letter8{gap::GAP}; // letter3 = 'T'_dna4; does not work
     alphabet_t letter9{gap::GAP};
 
     EXPECT_EQ(letter0.to_rank(), 0);
@@ -79,16 +79,16 @@ TEST(gapped_test, assign_from_component_alphabet)
     using alphabet_t = gapped<dna4>;
     alphabet_t letter{};
 
-    letter = dna4::A;
+    letter = 'A'_dna4;
     EXPECT_EQ(letter.to_rank(), 0);
 
-    letter = {dna4::C}; // letter = {dna4::C}; does not work
+    letter = {'C'_dna4}; // letter = {'C'_dna4}; does not work
     EXPECT_EQ(letter.to_rank(), 1);
 
-    letter = static_cast<alphabet_t>(dna4::G);
+    letter = static_cast<alphabet_t>('G'_dna4);
     EXPECT_EQ(letter.to_rank(), 2);
 
-    letter = {static_cast<alphabet_t>(dna4::T)};
+    letter = {static_cast<alphabet_t>('T'_dna4)};
     EXPECT_EQ(letter.to_rank(), 3);
 
     letter = gap::GAP;

--- a/test/unit/alphabet/mask/masked_test.cpp
+++ b/test/unit/alphabet/mask/masked_test.cpp
@@ -62,7 +62,7 @@
  TEST(masked, aggr)
  {
     // Test on dna4.
-    [[maybe_unused]]  masked<dna4> t1{dna4::C, mask::MASKED};
+    [[maybe_unused]]  masked<dna4> t1{'C'_dna4, mask::MASKED};
 
     // Test on aa20.
     [[maybe_unused]]  masked<aa20> t2{aa20::W, mask::MASKED};
@@ -72,7 +72,7 @@
  TEST(masked, zro)
  {
     // Test on dna4.
-    masked<dna4> t1{dna4::A, mask::UNMASKED};
+    masked<dna4> t1{'A'_dna4, mask::UNMASKED};
     masked<dna4> t2{};
     EXPECT_EQ(t1, t2);
 
@@ -86,7 +86,7 @@
  TEST(masked, cp_ctr)
  {
     // Test on dna4.
-    masked<dna4> t1{dna4::C, mask::MASKED};
+    masked<dna4> t1{'C'_dna4, mask::MASKED};
     masked<dna4> t2{t1};
     masked<dna4> t3(t1);
     EXPECT_EQ(t1, t2);
@@ -104,8 +104,8 @@
  TEST(masked, mv_ctr)
  {
     // Test on dna4.
-    masked<dna4> t0{dna4::C, mask::MASKED};
-    masked<dna4> t1{dna4::C, mask::MASKED};
+    masked<dna4> t0{'C'_dna4, mask::MASKED};
+    masked<dna4> t1{'C'_dna4, mask::MASKED};
     masked<dna4> t2{std::move(t1)};
     EXPECT_EQ(t2, t0);
     masked<dna4> t3(std::move(t2));
@@ -124,7 +124,7 @@
  TEST(masked, cp_assgn)
  {
     // Test on dna4.
-    masked<dna4> t1{dna4::C, mask::MASKED};
+    masked<dna4> t1{'C'_dna4, mask::MASKED};
     masked<dna4> t2;
     masked<dna4> t3;
 
@@ -148,8 +148,8 @@
  TEST(masked, mv_assgn)
  {
     // Test on dna4.
-    masked<dna4> t0{dna4::C, mask::MASKED};
-    masked<dna4> t1{dna4::C, mask::MASKED};
+    masked<dna4> t0{'C'_dna4, mask::MASKED};
+    masked<dna4> t1{'C'_dna4, mask::MASKED};
     masked<dna4> t2;
     masked<dna4> t3;
     t2 = std::move(t1);
@@ -172,8 +172,8 @@
  TEST(masked, swap)
  {
     // Test on dna4.
-    masked<dna4> t0{dna4::C, mask::MASKED};
-    masked<dna4> t1{dna4::C, mask::MASKED};
+    masked<dna4> t0{'C'_dna4, mask::MASKED};
+    masked<dna4> t1{'C'_dna4, mask::MASKED};
     masked<dna4> t2{};
     masked<dna4> t3{};
 
@@ -196,52 +196,32 @@
  TEST(masked, get_i)
  {
     // Test on dna4.
-    masked<dna4> t0{dna4::C, mask::MASKED};
+    masked<dna4> t0{'C'_dna4, mask::MASKED};
 
-    static_assert(std::is_same_v<decltype(seqan3::get<0>(t0)), dna4 &>);
+//     static_assert(std::is_same_v<decltype(get<0>(t0)), dna4 &>);
 
-    EXPECT_EQ(seqan3::get<0>(t0), dna4::C);
-    EXPECT_EQ(seqan3::get<1>(t0), mask::MASKED);
-
-    // Test on aa20.
-    masked<aa20> t1{aa20::W, mask::MASKED};
-
-    static_assert(std::is_same_v<decltype(seqan3::get<0>(t1)), aa20 &>);
-
-    EXPECT_EQ(seqan3::get<0>(t1), aa20::W);
-    EXPECT_EQ(seqan3::get<1>(t1), mask::MASKED);
- }
-
- // std::get<1>
- TEST(masked, stdget_i)
- {
-    // Test on dna4.
-    masked<dna4> t0{dna4::C, mask::MASKED};
-
-    static_assert(std::is_same_v<decltype(std::get<0>(t0)), dna4 &>);
-
-    EXPECT_EQ(std::get<0>(t0), dna4::C);
-    EXPECT_EQ(std::get<1>(t0), mask::MASKED);
+    EXPECT_EQ(get<0>(t0), 'C'_dna4);
+    EXPECT_EQ(get<1>(t0), mask::MASKED);
 
     // Test on aa20.
     masked<aa20> t1{aa20::W, mask::MASKED};
 
-    static_assert(std::is_same_v<decltype(std::get<0>(t1)), aa20 &>);
+//     static_assert(std::is_same_v<decltype(get<0>(t1)), aa20 &>);
 
-    EXPECT_EQ(std::get<0>(t1), aa20::W);
-    EXPECT_EQ(std::get<1>(t1), mask::MASKED);
+    EXPECT_EQ(get<0>(t1), aa20::W);
+    EXPECT_EQ(get<1>(t1), mask::MASKED);
  }
 
  // structured bindings
  TEST(masked, struct_binding)
  {
     // Test on dna4.
-    masked<dna4> t0{dna4::C, mask::MASKED};
+    masked<dna4> t0{'C'_dna4, mask::MASKED};
     auto [ i, l ] = t0;
     static_assert(std::is_same_v<decltype(i), dna4>);
     static_assert(std::is_same_v<decltype(l), mask>);
 
-    EXPECT_EQ(i, dna4::C);
+    EXPECT_EQ(i, 'C'_dna4);
     // EXPECT_EQ(l, mask::MASKED);
 
     // Test on aa20.
@@ -259,28 +239,14 @@
  TEST(masked, get_type)
  {
     // Test on dna4.
-    masked<dna4> t0{dna4::C, mask::MASKED};
+    masked<dna4> t0{'C'_dna4, mask::MASKED};
 
-    EXPECT_EQ(seqan3::get<dna4>(t0), dna4::C);
-
-    // Test on aa20.
-    masked<aa20> t1{aa20::W, mask::MASKED};
-
-    EXPECT_EQ(seqan3::get<aa20>(t1), aa20::W);
- }
-
- // std::get<type>
- TEST(masked, stdget_type)
- {
-    // Test on dna4.
-    masked<dna4> t0{dna4::C, mask::MASKED};
-
-    EXPECT_EQ(std::get<dna4>(t0), dna4::C);
+    EXPECT_EQ(get<dna4>(t0), 'C'_dna4);
 
     // Test on aa20.
     masked<aa20> t1{aa20::W, mask::MASKED};
 
-    EXPECT_EQ(std::get<aa20>(t1), aa20::W);
+    EXPECT_EQ(get<aa20>(t1), aa20::W);
  }
 
  // std::tuple_element
@@ -303,7 +269,7 @@
  TEST(masked, type_deduce)
  {
     // Test on dna4.
-    masked t0{dna4::C, mask::MASKED};
+    masked t0{'C'_dna4, mask::MASKED};
     using pt = decltype(t0);
 
     static_assert(std::is_same_v<std::tuple_element_t<0, pt>, dna4>);
@@ -321,13 +287,13 @@
  TEST(masked, cast_to_element)
  {
     // Test on dna4.
-    masked<dna4> t0{dna4::C, mask::MASKED};
+    masked<dna4> t0{'C'_dna4, mask::MASKED};
 
     auto d = static_cast<dna4>(t0);
     auto q = static_cast<mask>(t0);
     static_assert(std::is_same_v<decltype(d), dna4>);
 
-    EXPECT_EQ(d, dna4::C);
+    EXPECT_EQ(d, 'C'_dna4);
     EXPECT_EQ(q, mask::MASKED);
 
     // Test on aa20.
@@ -345,9 +311,9 @@
  TEST(masked, cmp)
  {
     // Test on dna4.
-    masked<dna4> t0{dna4::C, mask::UNMASKED};
-    masked<dna4> t1{dna4::C, mask::MASKED};
-    masked<dna4> t2{dna4::G, mask::MASKED};
+    masked<dna4> t0{'C'_dna4, mask::UNMASKED};
+    masked<dna4> t1{'C'_dna4, mask::MASKED};
+    masked<dna4> t2{'G'_dna4, mask::MASKED};
 
     EXPECT_LT(t0, t1);
     EXPECT_LE(t0, t1);
@@ -407,20 +373,20 @@ TEST(masked, alphabet_size_v)
 TEST(masked, to_rank)
 {
     // Test on dna4.
-    masked<dna4> t0{dna4::C, mask::MASKED};
-    EXPECT_EQ(to_rank(std::get<0>(t0)), 1);
-    // EXPECT_EQ(to_rank(std::get<1>(t0)), 1);
+    masked<dna4> t0{'C'_dna4, mask::MASKED};
+    EXPECT_EQ(to_rank(get<0>(t0)), 1);
+    // EXPECT_EQ(to_rank(get<1>(t0)), 1);
     // EXPECT_EQ(to_rank(t0),
-    //           to_rank(std::get<0>(t0)) +
-    //           alphabet_size_v<dna4> * to_rank(std::get<1>(t0)));
+    //           to_rank(get<0>(t0)) +
+    //           alphabet_size_v<dna4> * to_rank(get<1>(t0)));
 
     // Test on aa20.
     masked<aa20> t1{aa20::A, mask::UNMASKED};
-    EXPECT_EQ(to_rank(std::get<0>(t1)), 0);
-    // EXPECT_EQ(to_rank(std::get<1>(t1)), 0);
+    EXPECT_EQ(to_rank(get<0>(t1)), 0);
+    // EXPECT_EQ(to_rank(get<1>(t1)), 0);
     // EXPECT_EQ(to_rank(t1),
-    //           to_rank(std::get<0>(t1)) +
-    //           alphabet_size_v<aa20> * to_rank(std::get<1>(t1)));
+    //           to_rank(get<0>(t1)) +
+    //           alphabet_size_v<aa20> * to_rank(get<1>(t1)));
 }
 
 TEST(masked, assign_rank)
@@ -451,19 +417,19 @@ TEST(masked, assign_rank)
 TEST(masked, to_char)
 {
     // Test on dna4.
-    masked<dna4> t0{dna4::C, mask::UNMASKED};
-    EXPECT_EQ(to_char(std::get<0>(t0)), 'C');
+    masked<dna4> t0{'C'_dna4, mask::UNMASKED};
+    EXPECT_EQ(to_char(get<0>(t0)), 'C');
     EXPECT_EQ(to_char(t0), 'C');
     t0 = mask::MASKED;
-    EXPECT_EQ(to_char(std::get<0>(t0)), 'C');
+    EXPECT_EQ(to_char(get<0>(t0)), 'C');
     EXPECT_EQ(to_char(t0), 'c');
 
     // Test on aa20.
     masked<aa20> t1{aa20::W, mask::UNMASKED};
-    EXPECT_EQ(to_char(std::get<0>(t1)), 'W');
+    EXPECT_EQ(to_char(get<0>(t1)), 'W');
     EXPECT_EQ(to_char(t1), 'W');
     t1 = mask::MASKED;
-    EXPECT_EQ(to_char(std::get<0>(t1)), 'W');
+    EXPECT_EQ(to_char(get<0>(t1)), 'W');
     EXPECT_EQ(to_char(t1), 'w');
 }
 
@@ -471,7 +437,7 @@ TEST(masked, assign_char)
 {
     // Test on dna4.
     using type = masked<dna4>;
-    type t0{dna4::C, mask::MASKED};
+    type t0{'C'_dna4, mask::MASKED};
     assign_char(t0, 'A');
     EXPECT_EQ(to_char(t0), 'A');
     assign_char(t0, 'C');

--- a/test/unit/alphabet/nucleotide_test.cpp
+++ b/test/unit/alphabet/nucleotide_test.cpp
@@ -41,7 +41,6 @@
 #include <seqan3/alphabet/nucleotide/all.hpp>
 
 using namespace seqan3;
-using namespace seqan3::literal;
 
 template <typename T>
 class nucleotide : public ::testing::Test
@@ -53,102 +52,59 @@ using nucleotide_types2 =       meta::list<dna4, dna5, dna15, rna4, rna5, rna15>
 
 TYPED_TEST_CASE(nucleotide, nucleotide_types);
 
-TYPED_TEST(nucleotide, assign_char)
+TYPED_TEST(nucleotide, assign_char_to_char)
 {
-    using t = TypeParam;
-    std::vector<char> input
-    {
-        'A', 'C', 'G', 'T', 'U', 'N',
-        'a', 'c', 'g', 't', 'u', 'n',
-        'R', 'Y', 'S', 'W', 'K', 'M', 'B', 'D', 'H', 'V',
-        'r', 'y', 's', 'w', 'k', 'm', 'b', 'd', 'h', 'v',
-        '!'
-    };
-
-    std::vector<TypeParam> cmp;
-    if constexpr (std::is_same_v<TypeParam, dna4> || std::is_same_v<TypeParam, rna4>)
-    {
-        cmp =
-        {
-            t::A, t::C, t::G, t::T, t::U, t::A,
-            t::A, t::C, t::G, t::T, t::U, t::A,
-            t::A, t::C, t::C, t::A, t::G, t::A, t::C, t::A, t::A, t::A,
-            t::A, t::C, t::C, t::A, t::G, t::A, t::C, t::A, t::A, t::A,
-            t::A
-        };
-    } else if constexpr (std::is_same_v<TypeParam, dna5> || std::is_same_v<TypeParam, rna5>)
-    {
-        cmp =
-        {
-            t::A, t::C, t::G, t::T, t::U, t::N,
-            t::A, t::C, t::G, t::T, t::U, t::N,
-            t::N, t::N, t::N, t::N, t::N, t::N, t::N, t::N, t::N, t::N,
-            t::N, t::N, t::N, t::N, t::N, t::N, t::N, t::N, t::N, t::N,
-            t::N
-        };
-    } else if constexpr (std::is_same_v<TypeParam, dna15> || std::is_same_v<TypeParam, rna15>)
-    {
-        cmp =
-        {
-            t::A, t::C, t::G, t::T, t::U, t::N,
-            t::A, t::C, t::G, t::T, t::U, t::N,
-            t::R, t::Y, t::S, t::W, t::K, t::M, t::B, t::D, t::H, t::V,
-            t::R, t::Y, t::S, t::W, t::K, t::M, t::B, t::D, t::H, t::V,
-            t::N
-        };
-    }
-
-    for (auto [ ch, cm ] : ranges::view::zip(input, cmp))
-        EXPECT_EQ((assign_char(TypeParam{}, ch)), cm);
-}
-
-TYPED_TEST(nucleotide, to_char)
-{
-    EXPECT_EQ(to_char(TypeParam::A), 'A');
-    EXPECT_EQ(to_char(TypeParam::C), 'C');
-    EXPECT_EQ(to_char(TypeParam::G), 'G');
+    EXPECT_EQ(to_char(TypeParam{}.assign_char('A')), 'A');
+    EXPECT_EQ(to_char(TypeParam{}.assign_char('C')), 'C');
+    EXPECT_EQ(to_char(TypeParam{}.assign_char('G')), 'G');
 
     if constexpr (std::is_same_v<TypeParam, rna4> ||
                   std::is_same_v<TypeParam, rna5> ||
                   std::is_same_v<TypeParam, rna15>)
     {
-        EXPECT_EQ(to_char(TypeParam::U), 'U');
-        EXPECT_EQ(to_char(TypeParam::T), 'U');
+        EXPECT_EQ(to_char(TypeParam{}.assign_char('U')), 'U');
+        EXPECT_EQ(to_char(TypeParam{}.assign_char('T')), 'U');
     }
     else if constexpr (std::is_same_v<TypeParam, dna4> ||
                        std::is_same_v<TypeParam, dna5> ||
                        std::is_same_v<TypeParam, dna15>)
     {
-        EXPECT_EQ(to_char(TypeParam::U), 'T');
-        EXPECT_EQ(to_char(TypeParam::T), 'T');
+        EXPECT_EQ(to_char(TypeParam{}.assign_char('U')), 'T');
+        EXPECT_EQ(to_char(TypeParam{}.assign_char('T')), 'T');
     }
 
     if constexpr (alphabet_size_v<TypeParam> > 5)
     {
-        EXPECT_EQ(to_char(TypeParam::R), 'R');
-        EXPECT_EQ(to_char(TypeParam::Y), 'Y');
-        EXPECT_EQ(to_char(TypeParam::S), 'S');
-        EXPECT_EQ(to_char(TypeParam::W), 'W');
-        EXPECT_EQ(to_char(TypeParam::K), 'K');
-        EXPECT_EQ(to_char(TypeParam::M), 'M');
-        EXPECT_EQ(to_char(TypeParam::B), 'B');
-        EXPECT_EQ(to_char(TypeParam::D), 'D');
-        EXPECT_EQ(to_char(TypeParam::H), 'H');
-        EXPECT_EQ(to_char(TypeParam::V), 'V');
+        EXPECT_EQ(to_char(TypeParam{}.assign_char('R')), 'R');
+        EXPECT_EQ(to_char(TypeParam{}.assign_char('Y')), 'Y');
+        EXPECT_EQ(to_char(TypeParam{}.assign_char('S')), 'S');
+        EXPECT_EQ(to_char(TypeParam{}.assign_char('W')), 'W');
+        EXPECT_EQ(to_char(TypeParam{}.assign_char('K')), 'K');
+        EXPECT_EQ(to_char(TypeParam{}.assign_char('M')), 'M');
+        EXPECT_EQ(to_char(TypeParam{}.assign_char('B')), 'B');
+        EXPECT_EQ(to_char(TypeParam{}.assign_char('D')), 'D');
+        EXPECT_EQ(to_char(TypeParam{}.assign_char('H')), 'H');
+        EXPECT_EQ(to_char(TypeParam{}.assign_char('V')), 'V');
     }
 
     if constexpr (std::is_same_v<TypeParam, dna4> || std::is_same_v<TypeParam, rna4>)
-        EXPECT_EQ(to_char(TypeParam::UNKNOWN), 'A');
+    {
+        EXPECT_EQ(to_char(TypeParam{}.assign_char('N')), 'A');
+        EXPECT_EQ(to_char(TypeParam{}.assign_char('!')), 'A');
+    }
     else
-        EXPECT_EQ(to_char(TypeParam::UNKNOWN), 'N');
+    {
+        EXPECT_EQ(to_char(TypeParam{}.assign_char('N')), 'N');
+        EXPECT_EQ(to_char(TypeParam{}.assign_char('!')), 'N');
+    }
 }
 
 TYPED_TEST(nucleotide, complement)
 {
-    EXPECT_EQ(complement(TypeParam::A), TypeParam::T);
-    EXPECT_EQ(complement(TypeParam::C), TypeParam::G);
-    EXPECT_EQ(complement(TypeParam::G), TypeParam::C);
-    EXPECT_EQ(complement(TypeParam::T), TypeParam::A);
+    EXPECT_EQ(complement(TypeParam{}.assign_char('A')), TypeParam{}.assign_char('T'));
+    EXPECT_EQ(complement(TypeParam{}.assign_char('C')), TypeParam{}.assign_char('G'));
+    EXPECT_EQ(complement(TypeParam{}.assign_char('G')), TypeParam{}.assign_char('C'));
+    EXPECT_EQ(complement(TypeParam{}.assign_char('T')), TypeParam{}.assign_char('A'));
 
     using vsize_t = std::decay_t<decltype(alphabet_size_v<TypeParam>)>;
 
@@ -181,11 +137,11 @@ TYPED_TEST(nucleotide, implicit_conversion)
                        /* must be rna15 */                                  dna15>>>>>;
 
     // construct
-    EXPECT_EQ(other_type{TypeParam::C}, other_type::C);
+    EXPECT_EQ(other_type{TypeParam{}.assign_char('C')}, other_type{}.assign_char('C'));
     // assign
     other_type l{};
-    l = TypeParam::C;
-    EXPECT_EQ(l, other_type::C);
+    l = TypeParam{}.assign_char('C');
+    EXPECT_EQ(l, other_type{}.assign_char('C'));
 }
 
 // conversion to any other nucleotide type
@@ -194,12 +150,12 @@ TYPED_TEST(nucleotide, explicit_conversion)
     meta::for_each(nucleotide_types2{}, [&] (auto && nucl) constexpr
     {
         using out_type = std::decay_t<decltype(nucl)>;
-        EXPECT_EQ(static_cast<out_type>(TypeParam::A), out_type::A);
-        EXPECT_EQ(static_cast<out_type>(TypeParam::C), out_type::C);
-        EXPECT_EQ(static_cast<out_type>(TypeParam::G), out_type::G);
-        EXPECT_EQ(static_cast<out_type>(TypeParam::T), out_type::T);
-        EXPECT_EQ(static_cast<out_type>(TypeParam::U), out_type::U);
-        EXPECT_EQ(static_cast<out_type>(TypeParam::T), out_type::U);
+        EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('A')), out_type{}.assign_char('A'));
+        EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('C')), out_type{}.assign_char('C'));
+        EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('G')), out_type{}.assign_char('G'));
+        EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('T')), out_type{}.assign_char('T'));
+        EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('U')), out_type{}.assign_char('U'));
+        EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('T')), out_type{}.assign_char('U'));
     });
 }
 
@@ -210,59 +166,59 @@ TYPED_TEST(nucleotide, explicit_conversion)
 TEST(dna4_literals, vector)
 {
     dna4_vector v;
-    v.resize(5, dna4::A);
+    v.resize(5, 'A'_dna4);
     EXPECT_EQ(v, "AAAAA"_dna4);
 
-    std::vector<dna4> w{dna4::A, dna4::C, dna4::G, dna4::T, dna4::U, dna4::UNKNOWN};
+    std::vector<dna4> w{'A'_dna4, 'C'_dna4, 'G'_dna4, 'T'_dna4, 'U'_dna4, 'N'_dna4};
     EXPECT_EQ(w, "ACGTTA"_dna4);
 }
 
 TEST(dna5_literals, vector)
 {
     dna5_vector v;
-    v.resize(5, dna5::A);
+    v.resize(5, 'A'_dna5);
     EXPECT_EQ(v, "AAAAA"_dna5);
 
-    std::vector<dna5> w{dna5::A, dna5::C, dna5::G, dna5::T, dna5::U, dna5::N, dna5::UNKNOWN};
+    std::vector<dna5> w{'A'_dna5, 'C'_dna5, 'G'_dna5, 'T'_dna5, 'U'_dna5, 'N'_dna5, 'N'_dna5};
     EXPECT_EQ(w, "ACGTTNN"_dna5);
 }
 
 TEST(dna15_literals, vector)
 {
     dna15_vector v;
-    v.resize(5, dna15::A);
+    v.resize(5, 'A'_dna15);
     EXPECT_EQ(v, "AAAAA"_dna15);
 
-    std::vector<dna15> w{dna15::A, dna15::C, dna15::G, dna15::T, dna15::U, dna15::N, dna15::UNKNOWN};
+    std::vector<dna15> w{'A'_dna15, 'C'_dna15, 'G'_dna15, 'T'_dna15, 'U'_dna15, 'N'_dna15, 'N'_dna15};
     EXPECT_EQ(w, "ACGTTNN"_dna15);
 }
 
 TEST(rna4_literals, vector)
 {
     rna4_vector v;
-    v.resize(5, rna4::A);
+    v.resize(5, 'A'_rna4);
     EXPECT_EQ(v, "AAAAA"_rna4);
 
-    std::vector<rna4> w{rna4::A, rna4::C, rna4::G, rna4::T, rna4::U, rna4::UNKNOWN};
+    std::vector<rna4> w{'A'_rna4, 'C'_rna4, 'G'_rna4, 'T'_rna4, 'U'_rna4, 'N'_rna4};
     EXPECT_EQ(w, "ACGUUA"_rna4);
 }
 
 TEST(rna5_literals, vector)
 {
     rna5_vector v;
-    v.resize(5, rna5::A);
+    v.resize(5, 'A'_rna5);
     EXPECT_EQ(v, "AAAAA"_rna5);
 
-    std::vector<rna5> w{rna5::A, rna5::C, rna5::G, rna5::T, rna5::U, rna5::N, rna5::UNKNOWN};
+    std::vector<rna5> w{'A'_rna5, 'C'_rna5, 'G'_rna5, 'T'_rna5, 'U'_rna5, 'N'_rna5, 'N'_rna5};
     EXPECT_EQ(w, "ACGUUNN"_rna5);
 }
 
 TEST(rna15_literals, vector)
 {
     rna15_vector v;
-    v.resize(5, rna15::A);
+    v.resize(5, 'A'_rna15);
     EXPECT_EQ(v, "AAAAA"_rna15);
 
-    std::vector<rna15> w{rna15::A, rna15::C, rna15::G, rna15::T, rna15::U, rna15::N, rna15::UNKNOWN};
+    std::vector<rna15> w{'A'_rna15, 'C'_rna15, 'G'_rna15, 'T'_rna15, 'U'_rna15, 'N'_rna15, 'N'_rna15};
     EXPECT_EQ(w, "ACGTTNN"_rna15);
 }

--- a/test/unit/alphabet/quality/qualified_test.cpp
+++ b/test/unit/alphabet/quality/qualified_test.cpp
@@ -77,12 +77,12 @@ TEST(qualified, alphabet_size_v)
 
 TEST(qualified, to_rank)
 {
-    qualified<dna4, phred42> t0{dna4::C, phred42{6}};
-    EXPECT_EQ(to_rank(std::get<0>(t0)), 1);
-    EXPECT_EQ(to_rank(std::get<1>(t0)), 6);
+    qualified<dna4, phred42> t0{'C'_dna4, phred42{6}};
+    EXPECT_EQ(to_rank(get<0>(t0)), 1);
+    EXPECT_EQ(to_rank(get<1>(t0)), 6);
     EXPECT_EQ(to_rank(t0),
-              to_rank(std::get<0>(t0)) +
-              alphabet_size_v<dna4> * to_rank(std::get<1>(t0)));
+              to_rank(get<1>(t0)) +
+              alphabet_size_v<phred42> * to_rank(get<0>(t0)));
 }
 
 TEST(qualified, assign_rank)
@@ -100,9 +100,9 @@ TEST(qualified, assign_rank)
 
 TEST(qualified, to_char)
 {
-    qualified<dna4, phred42> t0{dna4::C, phred42{6}};
-    EXPECT_EQ(to_char(std::get<0>(t0)), 'C');
-    EXPECT_EQ(to_char(std::get<1>(t0)), '!' + 6);
+    qualified<dna4, phred42> t0{'C'_dna4, phred42{6}};
+    EXPECT_EQ(to_char(get<0>(t0)), 'C');
+    EXPECT_EQ(to_char(get<1>(t0)), '!' + 6);
     EXPECT_EQ(to_char(t0), 'C');
 }
 
@@ -110,30 +110,30 @@ TEST(qualified, assign_char)
 {
     using type = qualified<dna4, phred42>;
 
-    type t0{dna4::C, phred42{17}};
-    char qchar = to_char(std::get<1>(t0));
+    type t0{'C'_dna4, phred42{17}};
+    char qchar = to_char(get<1>(t0));
 
     assign_char(t0, 'A');
     EXPECT_EQ(to_char(t0), 'A');
-    EXPECT_EQ(to_char(std::get<1>(t0)), qchar);
+    EXPECT_EQ(to_char(get<1>(t0)), qchar);
     assign_char(t0, 'C');
     EXPECT_EQ(to_char(t0), 'C');
-    EXPECT_EQ(to_char(std::get<1>(t0)), qchar);
+    EXPECT_EQ(to_char(get<1>(t0)), qchar);
     assign_char(t0, 'G');
     EXPECT_EQ(to_char(t0), 'G');
-    EXPECT_EQ(to_char(std::get<1>(t0)), qchar);
+    EXPECT_EQ(to_char(get<1>(t0)), qchar);
     assign_char(t0, 'T');
     EXPECT_EQ(to_char(t0), 'T');
-    EXPECT_EQ(to_char(std::get<1>(t0)), qchar);
+    EXPECT_EQ(to_char(get<1>(t0)), qchar);
     assign_char(t0, 'N');
     EXPECT_EQ(to_char(t0), 'A');
-    EXPECT_EQ(to_char(std::get<1>(t0)), qchar);
+    EXPECT_EQ(to_char(get<1>(t0)), qchar);
 }
 
 TEST(qualified, to_phred)
 {
-    qualified<dna4, phred42> t0{dna4::C, phred42{6}};
-    EXPECT_EQ(to_phred(std::get<1>(t0)), 6);
+    qualified<dna4, phred42> t0{'C'_dna4, phred42{6}};
+    EXPECT_EQ(to_phred(get<1>(t0)), 6);
     EXPECT_EQ(to_phred(t0), 6);
 }
 
@@ -141,7 +141,7 @@ TEST(qualified, assign_phred)
 {
     using type = qualified<dna4, phred42>;
 
-    type t0{dna4::C, phred42{17}};
+    type t0{'C'_dna4, phred42{17}};
     char schar = to_char(t0);
 
     assign_phred(t0, 12);
@@ -154,8 +154,8 @@ TEST(qualified, assign_phred)
 
 TEST(qualified, complement)
 {
-    qualified<dna4, phred42> t0{dna4::A, phred42{8}};
-    qualified<dna4, phred42> t0_c{(dna4::A).complement(), phred42{8}};
+    qualified<dna4, phred42> t0{'A'_dna4, phred42{8}};
+    qualified<dna4, phred42> t0_c{('A'_dna4).complement(), phred42{8}};
 
     EXPECT_EQ(t0.complement(), t0_c);
 }

--- a/test/unit/alphabet/quality_test.cpp
+++ b/test/unit/alphabet/quality_test.cpp
@@ -52,73 +52,56 @@ class quality : public ::testing::Test
 
 // add all alphabets from the quality sub module here
 using quality_types     = ::testing::Types<phred42, phred63, phred68legacy>;
+using quality_types2    =       meta::list<phred42, phred63, phred68legacy>;
 
 TYPED_TEST_CASE(quality, quality_types);
 
 // more elaborate test of assign_char and to_char, basic test is in alphabet_test.cpp
 TYPED_TEST(quality, conversion_char)
 {
-    using char_type = typename TypeParam::char_type;
-    typename TypeParam::rank_type value_size = (std::is_same_v<TypeParam, phred42>) ? phred42::max_value_size : TypeParam::value_size;
+    using c_t = typename TypeParam::char_type;
+    for (c_t i = std::numeric_limits<c_t>::lowest(); i < std::numeric_limits<c_t>::max(); ++i)
+    {
+        TypeParam v;
+        v.assign_char(i);
 
-    // phred42: ['!' .. '^'], phred63: ['!' .. '_'], phred68legacy: [';' .. '~']
-    std::vector<char_type> input_char(value_size);
-    std::iota(input_char.begin(), input_char.end(), TypeParam::offset_char);
-
-    // phred42: ['!' .. 'I', 'J' .. 'J'], phred63: =input_char, phred68legacy: =intput_char
-    std::vector<char_type> output_char = input_char;
-    if (std::is_same_v<TypeParam, phred42>)
-        std::replace_if(output_char.begin(), output_char.end(), [](char_type c){if (c > 'J') return true; return false;}, 'J');
-    for (auto [ ch, cm ] : ranges::view::zip(input_char, output_char))
-        EXPECT_EQ((assign_char(TypeParam{}, ch)).to_char(), cm);
+        if (i < TypeParam::offset_char)                                     // too small, map to valid smallest
+            EXPECT_EQ(v.to_char(), TypeParam::offset_char);
+        else if (i >= TypeParam::offset_char + TypeParam::value_size)       // too big, map to valid biggest
+            EXPECT_EQ(v.to_char(), TypeParam::offset_char + TypeParam::value_size - 1);
+        else                                                                // valid range, map to identity
+            EXPECT_EQ(v.to_char(), i);
+    }
 }
 
 // test assign_phred and to_phred
 TYPED_TEST(quality, conversion_phred)
 {
-    using phred_type = typename TypeParam::phred_type;
-    phred_type phred_offset = (std::is_same_v<TypeParam, phred68legacy>) ? phred68legacy::offset_phred : 0;
-    typename TypeParam::rank_type value_size = (std::is_same_v<TypeParam, phred42>) ? phred42::max_value_size : TypeParam::value_size;
-
-    //in:  phred42: ['!' .. '^'], phred63: ['!' .. '_'], phred68legacy: [';' .. '~']
-    std::vector<phred_type> input_phred(value_size);
-    std::iota(input_phred.begin(), input_phred.end(), phred_offset);
-
-    //out: phred42: ['!' .. 'I', 'J' .. 'J'], phred63: =input_char, phred68legacy: =intput_char
-    std::vector<phred_type> output_phred = input_phred;
-    if (std::is_same_v<TypeParam, phred42>)
-        std::replace_if(output_phred.begin(), output_phred.end(), [](phred_type pt){if (pt > 41) return true; return false;}, 41);
-
-    for (auto [ ph, pm ] : ranges::view::zip(input_phred, output_phred))
+    using p_t = typename TypeParam::phred_type;
+    for (p_t i = std::numeric_limits<p_t>::lowest(); i < std::numeric_limits<p_t>::max(); ++i)
     {
-        TypeParam p; p.assign_phred(ph);
-        EXPECT_EQ(p.to_phred(), pm);
+        TypeParam v;
+        v.assign_phred(i);
+
+        if (i < TypeParam::offset_phred)                                     // too small, map to valid smallest
+            EXPECT_EQ(v.to_phred(), TypeParam::offset_phred);
+        else if (i >= TypeParam::offset_phred + TypeParam::value_size)       // too big, map to valid biggest
+            EXPECT_EQ(v.to_phred(), TypeParam::offset_phred + TypeParam::value_size - 1);
+        else                                                                // valid range, map to identity
+            EXPECT_EQ(v.to_phred(), i);
     }
 }
 
-// more elaborate test of assign_rank and to_rank, basic test is in alphabet_test.cpp
-TYPED_TEST(quality, conversion_rank)
+// test user-defined constructor
+TYPED_TEST(quality, construction_by_phred)
 {
-    using rank_type = typename TypeParam::rank_type;
-    typename TypeParam::rank_type value_size = (std::is_same_v<TypeParam, phred42>) ? phred42::max_value_size : TypeParam::value_size;
+    TypeParam v{0};
+    EXPECT_EQ(v.to_phred(), 0);
+    EXPECT_EQ(v.to_rank(),  -TypeParam::offset_phred);
 
-    // phred42: [0 .. 61], phred63: [0 .. 62], phred68legacy: [0 .. 67]
-    std::vector<rank_type> input_rank(value_size);
-    std::iota(input_rank.begin(), input_rank.end(), 0);
-
-    // phred42: [0 .. 40, 41 .. 41], phred63: =input_rank, phred68legacy: =intput_rank
-    std::vector<rank_type> output_rank = input_rank;
-    if (std::is_same_v<TypeParam, phred42>)
-        std::replace_if(output_rank.begin(), output_rank.end(),
-            [](rank_type r){if (r >= phred42::value_size) return true; return false;},
-            phred42::value_size-1);
-
-    for (auto [ ch, cm ] : ranges::view::zip(input_rank, output_rank))
-    {
-        TypeParam t;
-        t.assign_rank(ch);
-        EXPECT_EQ(t.to_rank(), cm);
-    }
+    TypeParam v2{23};
+    EXPECT_EQ(v2.to_phred(), 23);
+    EXPECT_EQ(v2.to_rank(),  23 - TypeParam::offset_phred);
 }
 
 // ------------------------------------------------------------------
@@ -128,41 +111,18 @@ TYPED_TEST(quality, conversion_rank)
 // test provision of data type `phred_type` and phred converter.
 TYPED_TEST(quality, quality_concept)
 {
-    TypeParam p{0};
-    [[maybe_unused]] typename TypeParam::phred_type p_type = p.to_phred();
+    EXPECT_TRUE(quality_concept<TypeParam>);
+}
 
-    for (typename TypeParam::phred_type i = 0; i < TypeParam::value_size; ++i)
+TYPED_TEST(quality, explicit_conversion)
+{
+    meta::for_each(quality_types2{}, [&] (auto && qual) constexpr
     {
-        // rank and phred scores are identical for phred42 and phred63, else the offset is -5
-        typename TypeParam::phred_type offset = (!std::is_same_v<TypeParam, phred68legacy>) ? 0 : phred68legacy::offset_phred;
-        p.assign_phred(i + offset);
-        EXPECT_EQ(i + offset, p.to_phred());
-    }
-}
-
-template<typename Function, typename... Args>
-void va_for_each(Function&& fn, Args&&... args)
-{
-    using aux = int[];
-    static_cast<void>(aux
-        {
-            0, (static_cast<void>(fn(std::forward<Args>(args))), 0)...
-        });
-}
-
-TYPED_TEST(quality, implicit_conversion)
-{
-    auto convert = [](auto other) {
-        if constexpr (!std::is_same_v<TypeParam, decltype(other)>)
-        {
-            TypeParam p{0};
-            p.assign_phred(0);
-            [[maybe_unused]] decltype(other) p_other = static_cast<decltype(other)>(p);
-            EXPECT_EQ(p_other.to_phred(), typename decltype(other)::phred_type(0));
-        }
-    };
-    phred42 p42;
-    phred63 p63;
-    phred68legacy p68;
-    va_for_each(convert, p42, p63, p68);
+        using out_type = std::decay_t<decltype(qual)>;
+        EXPECT_EQ(static_cast<out_type>(TypeParam{ 0}), out_type{ 0});
+        EXPECT_EQ(static_cast<out_type>(TypeParam{ 5}), out_type{ 5});
+        EXPECT_EQ(static_cast<out_type>(TypeParam{15}), out_type{15});
+        EXPECT_EQ(static_cast<out_type>(TypeParam{20}), out_type{20});
+        EXPECT_EQ(static_cast<out_type>(TypeParam{40}), out_type{40});
+    });
 }

--- a/test/unit/alphabet/structure_test.cpp
+++ b/test/unit/alphabet/structure_test.cpp
@@ -47,7 +47,6 @@
 #include <seqan3/alphabet/structure/all.hpp>
 
 using namespace seqan3;
-using namespace seqan3::literal;
 
 template <typename T>
 class structure : public ::testing::Test
@@ -270,13 +269,13 @@ TEST(structured_rna, ctr)
 // aggregate initialization
 TEST(structured_rna, aggr)
 {
-    [[maybe_unused]]  structured_rna<rna4, dot_bracket3> t1{rna4::C, dot_bracket3::PAIR_CLOSE};
+    [[maybe_unused]]  structured_rna<rna4, dot_bracket3> t1{'C'_rna4, dot_bracket3::PAIR_CLOSE};
 }
 
 // zero initialization
 TEST(structured_rna, zro)
 {
-    structured_rna<rna4, dot_bracket3> t1{rna4::A, dot_bracket3::UNKNOWN};
+    structured_rna<rna4, dot_bracket3> t1{'A'_rna4, dot_bracket3::UNKNOWN};
     structured_rna<rna4, dot_bracket3> t2{};
 
     EXPECT_EQ(t1, t2);
@@ -285,7 +284,7 @@ TEST(structured_rna, zro)
 // copy construction
 TEST(structured_rna, cp_ctr)
 {
-    structured_rna<rna4, dot_bracket3> t1{rna4::C, dot_bracket3::PAIR_OPEN};
+    structured_rna<rna4, dot_bracket3> t1{'C'_rna4, dot_bracket3::PAIR_OPEN};
     structured_rna<rna4, dot_bracket3> t2{t1};
     structured_rna<rna4, dot_bracket3> t3(t1);
     EXPECT_EQ(t1, t2);
@@ -295,8 +294,8 @@ TEST(structured_rna, cp_ctr)
 // move construction
 TEST(structured_rna, mv_ctr)
 {
-    structured_rna<rna4, dot_bracket3> t0{rna4::C, dot_bracket3::UNPAIRED};
-    structured_rna<rna4, dot_bracket3> t1{rna4::C, dot_bracket3::UNPAIRED};
+    structured_rna<rna4, dot_bracket3> t0{'C'_rna4, dot_bracket3::UNPAIRED};
+    structured_rna<rna4, dot_bracket3> t1{'C'_rna4, dot_bracket3::UNPAIRED};
     structured_rna<rna4, dot_bracket3> t2{std::move(t1)};
     EXPECT_EQ(t2, t0);
     structured_rna<rna4, dot_bracket3> t3(std::move(t2));
@@ -306,7 +305,7 @@ TEST(structured_rna, mv_ctr)
 // copy assignment
 TEST(structured_rna, cp_assgn)
 {
-    structured_rna<rna4, dot_bracket3> t1{rna4::C, dot_bracket3::UNPAIRED};
+    structured_rna<rna4, dot_bracket3> t1{'C'_rna4, dot_bracket3::UNPAIRED};
     structured_rna<rna4, dot_bracket3> t2;
     structured_rna<rna4, dot_bracket3> t3;
 
@@ -319,8 +318,8 @@ TEST(structured_rna, cp_assgn)
 // move assignment
 TEST(structured_rna, mv_assgn)
 {
-    structured_rna<rna4, dot_bracket3> t0{rna4::C, dot_bracket3::UNPAIRED};
-    structured_rna<rna4, dot_bracket3> t1{rna4::C, dot_bracket3::UNPAIRED};
+    structured_rna<rna4, dot_bracket3> t0{'C'_rna4, dot_bracket3::UNPAIRED};
+    structured_rna<rna4, dot_bracket3> t1{'C'_rna4, dot_bracket3::UNPAIRED};
     structured_rna<rna4, dot_bracket3> t2;
     structured_rna<rna4, dot_bracket3> t3;
     t2 = std::move(t1);
@@ -332,8 +331,8 @@ TEST(structured_rna, mv_assgn)
 // swap
 TEST(structured_rna, swap)
 {
-    structured_rna<rna4, dot_bracket3> t0{rna4::C, dot_bracket3::PAIR_OPEN};
-    structured_rna<rna4, dot_bracket3> t1{rna4::C, dot_bracket3::PAIR_OPEN};
+    structured_rna<rna4, dot_bracket3> t0{'C'_rna4, dot_bracket3::PAIR_OPEN};
+    structured_rna<rna4, dot_bracket3> t1{'C'_rna4, dot_bracket3::PAIR_OPEN};
     structured_rna<rna4, dot_bracket3> t2{};
     structured_rna<rna4, dot_bracket3> t3{};
 
@@ -342,59 +341,38 @@ TEST(structured_rna, swap)
     EXPECT_EQ(t1, t3);
 }
 
-// seqan3::get<1>
+// get<1>
 TEST(structured_rna, get_i)
 {
-    structured_rna<rna4, dot_bracket3> t0{rna4::C, dot_bracket3::PAIR_OPEN};
+    structured_rna<rna4, dot_bracket3> t0{'C'_rna4, dot_bracket3::PAIR_OPEN};
 
-    static_assert(std::is_same_v<decltype(seqan3::get<0>(t0)), rna4 &>);
-    static_assert(std::is_same_v<decltype(seqan3::get<1>(t0)), dot_bracket3 &>);
+//     static_assert(std::is_same_v<decltype(get<0>(t0)), rna4 &>);
+//     static_assert(std::is_same_v<decltype(get<1>(t0)), dot_bracket3 &>);
 
-    EXPECT_EQ(seqan3::get<0>(t0), rna4::C);
-    EXPECT_EQ(seqan3::get<1>(t0), dot_bracket3{dot_bracket3::PAIR_OPEN});
-}
-
-// std::get<1>
-TEST(structured_rna, stdget_i)
-{
-    structured_rna<rna4, dot_bracket3> t0{rna4::C, dot_bracket3::UNPAIRED};
-
-    static_assert(std::is_same_v<decltype(std::get<0>(t0)), rna4 &>);
-    static_assert(std::is_same_v<decltype(std::get<1>(t0)), dot_bracket3 &>);
-
-    EXPECT_EQ(std::get<0>(t0), rna4::C);
-    EXPECT_EQ(std::get<1>(t0), dot_bracket3{dot_bracket3::UNPAIRED});
+    EXPECT_EQ(get<0>(t0), 'C'_rna4);
+    EXPECT_EQ(get<1>(t0), dot_bracket3{dot_bracket3::PAIR_OPEN});
 }
 
 // structured_rna bindings
 TEST(structured_rna, struct_binding)
 {
-    structured_rna<rna4, dot_bracket3> t0{rna4::C, dot_bracket3::PAIR_CLOSE};
+    structured_rna<rna4, dot_bracket3> t0{'C'_rna4, dot_bracket3::PAIR_CLOSE};
     auto [ i, l ] = t0;
 
     static_assert(std::is_same_v<decltype(i), rna4>);
     static_assert(std::is_same_v<decltype(l), dot_bracket3>);
 
-    EXPECT_EQ(i, rna4::C);
+    EXPECT_EQ(i, 'C'_rna4);
     EXPECT_EQ(l, dot_bracket3{dot_bracket3::PAIR_CLOSE});
 }
 
-// seqan3::get<type>
+// get<type>
 TEST(structured_rna, get_type)
 {
-    structured_rna<rna4, dot_bracket3> t0{rna4::C, dot_bracket3::PAIR_CLOSE};
+    structured_rna<rna4, dot_bracket3> t0{'C'_rna4, dot_bracket3::PAIR_CLOSE};
 
-    EXPECT_EQ(seqan3::get<rna4>(t0), rna4::C);
-    EXPECT_EQ(seqan3::get<dot_bracket3>(t0), dot_bracket3{dot_bracket3::PAIR_CLOSE});
-}
-
-// std::get<type>
-TEST(structured_rna, stdget_type)
-{
-    structured_rna<rna4, dot_bracket3> t0{rna4::C, dot_bracket3::PAIR_CLOSE};
-
-    EXPECT_EQ(std::get<rna4>(t0), rna4::C);
-    EXPECT_EQ(std::get<dot_bracket3>(t0), dot_bracket3{dot_bracket3::PAIR_CLOSE});
+    EXPECT_EQ(get<rna4>(t0), 'C'_rna4);
+    EXPECT_EQ(get<dot_bracket3>(t0), dot_bracket3{dot_bracket3::PAIR_CLOSE});
 }
 
 // std::tuple_element
@@ -410,7 +388,7 @@ TEST(structured_rna, tuple_element)
 // type deduction
 TEST(structured_rna, type_deduce)
 {
-    structured_rna t0{rna4::C, dot_bracket3{dot_bracket3::PAIR_CLOSE}};
+    structured_rna t0{'C'_rna4, dot_bracket3{dot_bracket3::PAIR_CLOSE}};
     using pt = decltype(t0);
 
     static_assert(std::is_same_v<std::tuple_element_t<0, pt>, rna4>);
@@ -421,23 +399,23 @@ TEST(structured_rna, type_deduce)
 // explicit cast to element
 TEST(structured_rna, cast_to_element)
 {
-    structured_rna<rna4, dot_bracket3> t0{rna4::C, dot_bracket3::PAIR_CLOSE};
+    structured_rna<rna4, dot_bracket3> t0{'C'_rna4, dot_bracket3::PAIR_CLOSE};
 
     auto d = static_cast<rna4>(t0);
     auto q = static_cast<dot_bracket3>(t0);
     static_assert(std::is_same_v<decltype(d), rna4>);
     static_assert(std::is_same_v<decltype(q), dot_bracket3>);
 
-    EXPECT_EQ(d, rna4::C);
+    EXPECT_EQ(d, 'C'_rna4);
     EXPECT_EQ(q, dot_bracket3{dot_bracket3::PAIR_CLOSE});
 }
 
 // comparison operators
 TEST(structured_rna, cmp)
 {
-    structured_rna<rna4, dot_bracket3> t0{rna4::C, dot_bracket3::PAIR_OPEN};
-    structured_rna<rna4, dot_bracket3> t1{rna4::C, dot_bracket3::PAIR_CLOSE};
-    structured_rna<rna4, dot_bracket3> t2{rna4::G, dot_bracket3::PAIR_CLOSE};
+    structured_rna<rna4, dot_bracket3> t0{'C'_rna4, dot_bracket3::PAIR_OPEN};
+    structured_rna<rna4, dot_bracket3> t1{'C'_rna4, dot_bracket3::PAIR_CLOSE};
+    structured_rna<rna4, dot_bracket3> t2{'G'_rna4, dot_bracket3::PAIR_CLOSE};
 
     EXPECT_LT(t0, t1);
     EXPECT_LE(t0, t1);
@@ -471,12 +449,12 @@ TEST(structured_rna, alphabet_size_v)
 // alphabet_concept: to_rank
 TEST(structured_rna, to_rank)
 {
-    structured_rna<rna4, dot_bracket3> t0{rna4::C, dot_bracket3::PAIR_CLOSE};
-    EXPECT_EQ(to_rank(std::get<0>(t0)), 1);
-    EXPECT_EQ(to_rank(std::get<1>(t0)), 2);
+    structured_rna<rna4, dot_bracket3> t0{'C'_rna4, dot_bracket3::PAIR_CLOSE};
+    EXPECT_EQ(to_rank(get<0>(t0)), 1);
+    EXPECT_EQ(to_rank(get<1>(t0)), 2);
     EXPECT_EQ(to_rank(t0),
-              to_rank(std::get<0>(t0)) +
-              alphabet_size_v<rna4> * to_rank(std::get<1>(t0)));
+              to_rank(get<1>(t0)) +
+              alphabet_size_v<dot_bracket3> * to_rank(get<0>(t0)));
 }
 
 // alphabet_concept: assign_rank
@@ -496,9 +474,9 @@ TEST(structured_rna, assign_rank)
 // alphabet_concept: to_char
 TEST(structured_rna, to_char)
 {
-    structured_rna<rna4, dot_bracket3> t0{rna4::C, dot_bracket3::PAIR_CLOSE};
-    EXPECT_EQ(to_char(std::get<0>(t0)), 'C');
-    EXPECT_EQ(to_char(std::get<1>(t0)), ')');
+    structured_rna<rna4, dot_bracket3> t0{'C'_rna4, dot_bracket3::PAIR_CLOSE};
+    EXPECT_EQ(to_char(get<0>(t0)), 'C');
+    EXPECT_EQ(to_char(get<1>(t0)), ')');
     EXPECT_EQ(to_char(t0), 'C');
 }
 
@@ -507,36 +485,36 @@ TEST(structured_rna, assign_char)
 {
     using type = structured_rna<rna4, dot_bracket3>;
 
-    type t0{rna4::C, dot_bracket3::PAIR_OPEN};
-    char qchar = to_char(std::get<1>(t0));
+    type t0{'C'_rna4, dot_bracket3::PAIR_OPEN};
+    char qchar = to_char(get<1>(t0));
 
     assign_char(t0, 'A');
     EXPECT_EQ(to_char(t0), 'A');
-    EXPECT_EQ(to_char(std::get<1>(t0)), qchar);
+    EXPECT_EQ(to_char(get<1>(t0)), qchar);
     assign_char(t0, 'C');
     EXPECT_EQ(to_char(t0), 'C');
-    EXPECT_EQ(to_char(std::get<1>(t0)), qchar);
+    EXPECT_EQ(to_char(get<1>(t0)), qchar);
     assign_char(t0, 'G');
     EXPECT_EQ(to_char(t0), 'G');
-    EXPECT_EQ(to_char(std::get<1>(t0)), qchar);
+    EXPECT_EQ(to_char(get<1>(t0)), qchar);
     assign_char(t0, 'U');
     EXPECT_EQ(to_char(t0), 'U');
-    EXPECT_EQ(to_char(std::get<1>(t0)), qchar);
+    EXPECT_EQ(to_char(get<1>(t0)), qchar);
     assign_char(t0, 'N');
     EXPECT_EQ(to_char(t0), 'A');
-    EXPECT_EQ(to_char(std::get<1>(t0)), qchar);
+    EXPECT_EQ(to_char(get<1>(t0)), qchar);
 }
 
 // nucleotide concept: complement
 TEST(structured_rna, complement)
 {
     using type = structured_rna<rna5, dot_bracket3>;
-    type tU{rna5::U, dot_bracket3::PAIR_OPEN};
-    type tG{rna5::G, dot_bracket3::PAIR_OPEN};
-    type tC{rna5::C, dot_bracket3::PAIR_OPEN};
-    type tA{rna5::A, dot_bracket3::PAIR_OPEN};
-    type tN{rna5::N, dot_bracket3::PAIR_OPEN};
-    type tt{rna5::A, dot_bracket3::PAIR_CLOSE};
+    type tU{'U'_rna5, dot_bracket3::PAIR_OPEN};
+    type tG{'G'_rna5, dot_bracket3::PAIR_OPEN};
+    type tC{'C'_rna5, dot_bracket3::PAIR_OPEN};
+    type tA{'A'_rna5, dot_bracket3::PAIR_OPEN};
+    type tN{'N'_rna5, dot_bracket3::PAIR_OPEN};
+    type tt{'A'_rna5, dot_bracket3::PAIR_CLOSE};
 
     // check whether characters are converted correctly
     EXPECT_EQ(to_char(complement(tU)), 'A');
@@ -560,9 +538,9 @@ TEST(structured_rna, complement)
 TEST(structured_rna, rna_structure_concept)
 {
     using type = structured_rna<rna5, wuss51>;
-    type t0{rna5::A, wuss51::PAIR_OPEN2};
-    type t1{rna5::N, wuss51::UNPAIRED};
-    type t2{rna5::U, wuss51::PAIR_CLOSE2};
+    type t0{'A'_rna5, wuss51::PAIR_OPEN2};
+    type t1{'N'_rna5, wuss51::UNPAIRED};
+    type t2{'U'_rna5, wuss51::PAIR_CLOSE2};
 
     EXPECT_TRUE (t0.is_pair_open());
     EXPECT_FALSE(t1.is_pair_open());
@@ -589,9 +567,9 @@ TEST(structured_rna, pseudoknot_id_without_pseudoknot_support)
 {
     using type = structured_rna<rna5, dot_bracket3>;
     EXPECT_EQ(type::max_pseudoknot_depth, 1); // format does not support pseudoknots
-    type t0{rna5::A, dot_bracket3::PAIR_OPEN};
-    type t1{rna5::N, dot_bracket3::UNPAIRED};
-    type t2{rna5::U, dot_bracket3::PAIR_CLOSE};
+    type t0{'A'_rna5, dot_bracket3::PAIR_OPEN};
+    type t1{'N'_rna5, dot_bracket3::UNPAIRED};
+    type t2{'U'_rna5, dot_bracket3::PAIR_CLOSE};
 
     EXPECT_TRUE (t0.pseudoknot_id());
     EXPECT_FALSE(t1.pseudoknot_id());
@@ -686,28 +664,16 @@ TEST(structured_aa, swap)
     EXPECT_EQ(t1, t3);
 }
 
-// seqan3::get<1>
+// get<1>
 TEST(structured_aa, get_i)
 {
     structured_aa<aa27, dssp9> t0{aa27::C, dssp9::E};
 
-    static_assert(std::is_same_v<decltype(seqan3::get<0>(t0)), aa27 &>);
-    static_assert(std::is_same_v<decltype(seqan3::get<1>(t0)), dssp9 &>);
+//     static_assert(std::is_same_v<decltype(get<0>(t0)), aa27 &>);
+//     static_assert(std::is_same_v<decltype(get<1>(t0)), dssp9 &>);
 
-    EXPECT_EQ(seqan3::get<0>(t0), aa27::C);
-    EXPECT_EQ(seqan3::get<1>(t0), dssp9::E);
-}
-
-// std::get<1>
-TEST(structured_aa, stdget_i)
-{
-    structured_aa<aa27, dssp9> t0{aa27::C, dssp9::G};
-
-    static_assert(std::is_same_v<decltype(std::get<0>(t0)), aa27 &>);
-    static_assert(std::is_same_v<decltype(std::get<1>(t0)), dssp9 &>);
-
-    EXPECT_EQ(std::get<0>(t0), aa27::C);
-    EXPECT_EQ(std::get<1>(t0), dssp9::G);
+    EXPECT_EQ(get<0>(t0), aa27::C);
+    EXPECT_EQ(get<1>(t0), dssp9::E);
 }
 
 // structured_aa bindings
@@ -723,22 +689,13 @@ TEST(structured_aa, struct_binding)
     EXPECT_EQ(l, dssp9::G);
 }
 
-// seqan3::get<type>
+// get<type>
 TEST(structured_aa, get_type)
 {
     structured_aa<aa27, dssp9> t0{aa27::C, dssp9::G};
 
-    EXPECT_EQ(seqan3::get<aa27>(t0), aa27::C);
-    EXPECT_EQ(seqan3::get<dssp9>(t0), dssp9::G);
-}
-
-// std::get<type>
-TEST(structured_aa, stdget_type)
-{
-    structured_aa<aa27, dssp9> t0{aa27::C, dssp9::G};
-
-    EXPECT_EQ(std::get<aa27>(t0), aa27::C);
-    EXPECT_EQ(std::get<dssp9>(t0), dssp9::G);
+    EXPECT_EQ(get<aa27>(t0), aa27::C);
+    EXPECT_EQ(get<dssp9>(t0), dssp9::G);
 }
 
 // std::tuple_element
@@ -816,11 +773,11 @@ TEST(structured_aa, alphabet_size_v)
 TEST(structured_aa, to_rank)
 {
     structured_aa<aa27, dssp9> t0{aa27::C, dssp9::G};
-    EXPECT_EQ(to_rank(std::get<0>(t0)), 2);
-    EXPECT_EQ(to_rank(std::get<1>(t0)), 3);
+    EXPECT_EQ(to_rank(get<0>(t0)), 2);
+    EXPECT_EQ(to_rank(get<1>(t0)), 3);
     EXPECT_EQ(to_rank(t0),
-              to_rank(std::get<0>(t0)) +
-              alphabet_size_v<aa27> * to_rank(std::get<1>(t0)));
+              to_rank(get<1>(t0)) +
+              alphabet_size_v<dssp9> * to_rank(get<0>(t0)));
 }
 
 // alphabet_concept: assign_rank
@@ -841,8 +798,8 @@ TEST(structured_aa, assign_rank)
 TEST(structured_aa, to_char)
 {
     structured_aa<aa27, dssp9> t0{aa27::C, dssp9::G};
-    EXPECT_EQ(to_char(std::get<0>(t0)), 'C');
-    EXPECT_EQ(to_char(std::get<1>(t0)), 'G');
+    EXPECT_EQ(to_char(get<0>(t0)), 'C');
+    EXPECT_EQ(to_char(get<1>(t0)), 'G');
     EXPECT_EQ(to_char(t0), 'C');
 }
 
@@ -852,21 +809,21 @@ TEST(structured_aa, assign_char)
     using type = structured_aa<aa27, dssp9>;
 
     type t0{aa27::C, dssp9::T};
-    char qchar = to_char(std::get<1>(t0));
+    char qchar = to_char(get<1>(t0));
 
     assign_char(t0, 'A');
     EXPECT_EQ(to_char(t0), 'A');
-    EXPECT_EQ(to_char(std::get<1>(t0)), qchar);
+    EXPECT_EQ(to_char(get<1>(t0)), qchar);
     assign_char(t0, 'Y');
     EXPECT_EQ(to_char(t0), 'Y');
-    EXPECT_EQ(to_char(std::get<1>(t0)), qchar);
+    EXPECT_EQ(to_char(get<1>(t0)), qchar);
     assign_char(t0, 'W');
     EXPECT_EQ(to_char(t0), 'W');
-    EXPECT_EQ(to_char(std::get<1>(t0)), qchar);
+    EXPECT_EQ(to_char(get<1>(t0)), qchar);
     assign_char(t0, 'D');
     EXPECT_EQ(to_char(t0), 'D');
-    EXPECT_EQ(to_char(std::get<1>(t0)), qchar);
+    EXPECT_EQ(to_char(get<1>(t0)), qchar);
     assign_char(t0, 'X');
     EXPECT_EQ(to_char(t0), 'X');
-    EXPECT_EQ(to_char(std::get<1>(t0)), qchar);
+    EXPECT_EQ(to_char(get<1>(t0)), qchar);
 }

--- a/test/unit/core/my_tuple.hpp
+++ b/test/unit/core/my_tuple.hpp
@@ -82,11 +82,6 @@ struct my_tuple
     }
 };
 
-} // namespace seqan3
-
-namespace std
-{
-
 template <size_t elem>
 constexpr auto & get(seqan3::my_tuple & t)
 {
@@ -131,6 +126,11 @@ constexpr auto const && get(seqan3::my_tuple const && t)
         return std::move(t.el1);
 }
 
+} // namespace seqan3
+
+namespace std
+{
+
 template <>
 struct tuple_size<seqan3::my_tuple>
 {
@@ -140,7 +140,7 @@ struct tuple_size<seqan3::my_tuple>
 template <size_t elem_no>
 struct tuple_element<elem_no, seqan3::my_tuple>
 {
-    using type = seqan3::remove_cvref_t<decltype(std::get<elem_no>(std::declval<seqan3::my_tuple>()))>;
+    using type = seqan3::remove_cvref_t<decltype(get<elem_no>(std::declval<seqan3::my_tuple>()))>;
 };
 
 } // namespace std

--- a/test/unit/io/alignment_file/alignment_file_output_test.cpp
+++ b/test/unit/io/alignment_file/alignment_file_output_test.cpp
@@ -48,7 +48,6 @@
 #include <seqan3/std/iterator>
 
 using namespace seqan3;
-using namespace seqan3::literal;
 
 std::vector<dna5_vector> seqs
 {

--- a/test/unit/io/alignment_file/format_sam_test.cpp
+++ b/test/unit/io/alignment_file/format_sam_test.cpp
@@ -46,7 +46,6 @@
 #include <seqan3/range/view/convert.hpp>
 
 using namespace seqan3;
-using namespace seqan3::literal;
 
 inline std::vector<phred42> operator""_phred42(const char * s, std::size_t n)
 {
@@ -104,12 +103,12 @@ struct alignment_data : public ::testing::Test
     };
 
     dna5_vector ref_seq = "ACTGATCGAGAGGATCTAGAGGAGATCGTAGGAC"_dna5;
-    std::vector<gapped<dna5>> ref_seq_gapped1 = {dna5::A, dna5::C, dna5::T, dna5::G};
-    std::vector<gapped<dna5>> ref_seq_gapped2 = {dna5::A, dna5::C, dna5::T, dna5::G,
-                                                dna5::A, dna5::T, dna5::C, dna5::G,
-                                                dna5::A};
-    std::vector<gapped<dna5>> ref_seq_gapped3 = {dna5::A, dna5::C, dna5::T, dna5::G,
-                                                dna5::A, dna5::T, dna5::C, dna5::G};
+    std::vector<gapped<dna5>> ref_seq_gapped1 = {'A'_dna5, 'C'_dna5, 'T'_dna5, 'G'_dna5};
+    std::vector<gapped<dna5>> ref_seq_gapped2 = {'A'_dna5, 'C'_dna5, 'T'_dna5, 'G'_dna5,
+                                                'A'_dna5, 'T'_dna5, 'C'_dna5, 'G'_dna5,
+                                                'A'_dna5};
+    std::vector<gapped<dna5>> ref_seq_gapped3 = {'A'_dna5, 'C'_dna5, 'T'_dna5, 'G'_dna5,
+                                                'A'_dna5, 'T'_dna5, 'C'_dna5, 'G'_dna5};
 
     std::string ref_id = "ref";
 
@@ -122,11 +121,11 @@ struct alignment_data : public ::testing::Test
 
     std::vector<std::pair<std::vector<gapped<dna5>>, std::vector<gapped<dna5>>>> alignments
     {
-        {ref_seq_gapped1, std::vector<gapped<dna5>>{dna5::C, gap::GAP, dna5::G, dna5::T}},
-        {ref_seq_gapped2, std::vector<gapped<dna5>>{dna5::G, dna5::G, dna5::G, dna5::C, dna5::T,
-                                                    dna5::G, dna5::N, gap::GAP, dna5::A}},
-        {ref_seq_gapped3, std::vector<gapped<dna5>>{dna5::G, gap::GAP, dna5::A, dna5::G,
-                                                    dna5::T, dna5::A, gap::GAP, dna5::T}}
+        {ref_seq_gapped1, std::vector<gapped<dna5>>{'C'_dna5, gap::GAP, 'G'_dna5, 'T'_dna5}},
+        {ref_seq_gapped2, std::vector<gapped<dna5>>{'G'_dna5, 'G'_dna5, 'G'_dna5, 'C'_dna5, 'T'_dna5,
+                                                    'G'_dna5, 'N'_dna5, gap::GAP, 'A'_dna5}},
+        {ref_seq_gapped3, std::vector<gapped<dna5>>{'G'_dna5, gap::GAP, 'A'_dna5, 'G'_dna5,
+                                                    'T'_dna5, 'A'_dna5, gap::GAP, 'T'_dna5}}
     };
 
     std::vector<unsigned> flags

--- a/test/unit/io/record_test.cpp
+++ b/test/unit/io/record_test.cpp
@@ -47,7 +47,6 @@
 #include <seqan3/range/view/to_char.hpp>
 
 using namespace seqan3;
-using namespace seqan3::literal;
 
 // ----------------------------------------------------------------------------
 // fields

--- a/test/unit/io/sequence_file/sequence_file_format_fasta_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_format_fasta_test.cpp
@@ -46,7 +46,6 @@
 #include <seqan3/range/view/convert.hpp>
 
 using namespace seqan3;
-using namespace seqan3::literal;
 
 // ----------------------------------------------------------------------------
 // general

--- a/test/unit/io/sequence_file/sequence_file_format_fastq_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_format_fastq_test.cpp
@@ -46,7 +46,6 @@
 #include <seqan3/range/view/convert.hpp>
 
 using namespace seqan3;
-using namespace seqan3::literal;
 
 //TODO remove after #256 is merged
 inline std::vector<phred42> operator""_phred42(const char * s, std::size_t n)

--- a/test/unit/io/sequence_file/sequence_file_input_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_input_test.cpp
@@ -46,7 +46,6 @@
 #include <seqan3/test/tmp_filename.hpp>
 
 using namespace seqan3;
-using namespace seqan3::literal;
 
 TEST(sequence_file_input_iterator, concepts)
 {

--- a/test/unit/io/sequence_file/sequence_file_integration_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_integration_test.cpp
@@ -44,7 +44,6 @@
 #include <seqan3/std/iterator>
 
 using namespace seqan3;
-using namespace seqan3::literal;
 
 TEST(rows, assign_sequence_files)
 {

--- a/test/unit/io/sequence_file/sequence_file_output_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_output_test.cpp
@@ -47,7 +47,6 @@
 #include <seqan3/std/iterator>
 
 using namespace seqan3;
-using namespace seqan3::literal;
 
 TEST(sequence_file_output_iterator, concepts)
 {

--- a/test/unit/io/stream/debug_stream_test.cpp
+++ b/test/unit/io/stream/debug_stream_test.cpp
@@ -44,7 +44,6 @@
 #include <seqan3/range/container/concatenated_sequences.hpp>
 
 using namespace seqan3;
-using namespace seqan3::literal;
 
 TEST(debug_stream, basic)
 {
@@ -90,16 +89,16 @@ TEST(debug_stream, alphabet)
     std::ostringstream o;
     debug_stream_type my_stream{o};
 
-    my_stream << dna4::A;
+    my_stream << 'A'_dna4;
     o.flush();
     EXPECT_EQ(o.str(), "A");
 
-    dna5 d = dna5::N;
+    dna5 d = 'N'_dna5;
     my_stream << d;
     o.flush();
     EXPECT_EQ(o.str(), "AN");
 
-    dna5 const d2 = dna5::N;
+    dna5 const d2 = 'N'_dna5;
     my_stream << d2;
     o.flush();
     EXPECT_EQ(o.str(), "ANN");

--- a/test/unit/io/stream/parse_condition_test.cpp
+++ b/test/unit/io/stream/parse_condition_test.cpp
@@ -220,7 +220,7 @@ TEST(parse_condition, is_char)
 TEST(parse_condition, is_char_msg)
 {
     using namespace seqan3;
-    EXPECT_EQ((is_char<to_char(dna4::A)>.msg.string()), "is_char<'A'>"s);
+    EXPECT_EQ((is_char<to_char('A'_dna4)>.msg.string()), "is_char<'A'>"s);
     EXPECT_EQ((is_char<'\t'>.msg.string()), "is_char<'\t'>"s);
 }
 

--- a/test/unit/io/structure_file/format_vienna_test.cpp
+++ b/test/unit/io/structure_file/format_vienna_test.cpp
@@ -55,7 +55,6 @@
 #include <seqan3/range/view/convert.hpp>
 
 using namespace seqan3;
-using namespace seqan3::literal;
 
 // ----------------------------------------------------------------------------
 // general

--- a/test/unit/io/structure_file/structure_file_input_test.cpp
+++ b/test/unit/io/structure_file/structure_file_input_test.cpp
@@ -55,7 +55,6 @@
 #include <seqan3/test/tmp_filename.hpp>
 
 using namespace seqan3;
-using namespace seqan3::literal;
 
 TEST(general, concepts)
 {

--- a/test/unit/io/structure_file/structure_file_output_test.cpp
+++ b/test/unit/io/structure_file/structure_file_output_test.cpp
@@ -59,7 +59,6 @@
 #include <seqan3/test/tmp_filename.hpp>
 
 using namespace seqan3;
-using namespace seqan3::literal;
 
 TEST(general, concepts)
 {

--- a/test/unit/range/container/container_of_container_test.cpp
+++ b/test/unit/range/container/container_of_container_test.cpp
@@ -54,7 +54,6 @@
 #endif // SEQAN3_WITH_CEREAL
 
 using namespace seqan3;
-using namespace seqan3::literal;
 
 template <typename T>
 class container_of_container : public ::testing::Test
@@ -158,7 +157,7 @@ TYPED_TEST(container_of_container, iterators)
     EXPECT_TRUE(t1.cend() == t1.end());
 
     // writability
-    (*t1.begin())[0] = dna4::T;
+    (*t1.begin())[0] = 'T'_dna4;
     EXPECT_TRUE(dna4_vector(*t1.begin())  == "TCGT"_dna4);
 }
 

--- a/test/unit/range/container/container_test.cpp
+++ b/test/unit/range/container/container_test.cpp
@@ -56,7 +56,6 @@
 #endif // SEQAN3_WITH_CEREAL
 
 using namespace seqan3;
-using namespace seqan3::literal;
 
 template <typename T>
 class container : public ::testing::Test
@@ -79,12 +78,12 @@ TYPED_TEST(container, construction)
     EXPECT_EQ(t1, t2);
 
     // initializer list
-    TypeParam t3{dna4::A, dna4::C, dna4::C, dna4::G, dna4::T};
-    TypeParam t4 = {dna4::A, dna4::C, dna4::C, dna4::G, dna4::T};
+    TypeParam t3{'A'_dna4, 'C'_dna4, 'C'_dna4, 'G'_dna4, 'T'_dna4};
+    TypeParam t4 = {'A'_dna4, 'C'_dna4, 'C'_dna4, 'G'_dna4, 'T'_dna4};
     EXPECT_EQ(t3, t4);
 
     // n * value
-    TypeParam t5{2, dna4::C};
+    TypeParam t5{2, 'C'_dna4};
 
     // from another TypeParam's sub-range
     TypeParam t6{t3.begin() + 1, t3.begin() + 3};
@@ -97,12 +96,12 @@ TYPED_TEST(container, construction)
 
 TYPED_TEST(container, assign)
 {
-    TypeParam t0{dna4::C, dna4::C};
-    TypeParam t1{dna4::A, dna4::C, dna4::C, dna4::G, dna4::T};
+    TypeParam t0{'C'_dna4, 'C'_dna4};
+    TypeParam t1{'A'_dna4, 'C'_dna4, 'C'_dna4, 'G'_dna4, 'T'_dna4};
 
     // n * value
     TypeParam t3;
-    t3.assign(2, dna4::C);
+    t3.assign(2, 'C'_dna4);
     EXPECT_EQ(t3, t0);
 
     // from another container's sub-range
@@ -112,8 +111,8 @@ TYPED_TEST(container, assign)
 
     // initializer list
     TypeParam t5, t6;
-    t5.assign({dna4::A, dna4::C, dna4::C, dna4::G, dna4::T});
-    t6 = {dna4::A, dna4::C, dna4::C, dna4::G, dna4::T};
+    t5.assign({'A'_dna4, 'C'_dna4, 'C'_dna4, 'G'_dna4, 'T'_dna4});
+    t6 = {'A'_dna4, 'C'_dna4, 'C'_dna4, 'G'_dna4, 'T'_dna4};
     EXPECT_EQ(t5, t1);
     EXPECT_EQ(t6, t1);
 
@@ -128,68 +127,68 @@ TYPED_TEST(container, assign)
 
 TYPED_TEST(container, iterators)
 {
-    TypeParam t1{dna4::A, dna4::C, dna4::C, dna4::G, dna4::T};
-    TypeParam const t2{dna4::A, dna4::C, dna4::C, dna4::G, dna4::T};
+    TypeParam t1{'A'_dna4, 'C'_dna4, 'C'_dna4, 'G'_dna4, 'T'_dna4};
+    TypeParam const t2{'A'_dna4, 'C'_dna4, 'C'_dna4, 'G'_dna4, 'T'_dna4};
 
     // begin
-    EXPECT_EQ(*t1.begin(),  dna4::A);
-    EXPECT_EQ(*t1.cbegin(), dna4::A);
-    EXPECT_EQ(*t2.begin(),  dna4::A);
-    EXPECT_EQ(*t2.cbegin(), dna4::A);
+    EXPECT_EQ(*t1.begin(),  'A'_dna4);
+    EXPECT_EQ(*t1.cbegin(), 'A'_dna4);
+    EXPECT_EQ(*t2.begin(),  'A'_dna4);
+    EXPECT_EQ(*t2.cbegin(), 'A'_dna4);
 
     // end and arithmetic
-    EXPECT_EQ(*(t1.end()  - 1), dna4::T);
-    EXPECT_EQ(*(t1.cend() - 1), dna4::T);
-    EXPECT_EQ(*(t2.end()  - 1), dna4::T);
-    EXPECT_EQ(*(t2.cend() - 1), dna4::T);
+    EXPECT_EQ(*(t1.end()  - 1), 'T'_dna4);
+    EXPECT_EQ(*(t1.cend() - 1), 'T'_dna4);
+    EXPECT_EQ(*(t2.end()  - 1), 'T'_dna4);
+    EXPECT_EQ(*(t2.cend() - 1), 'T'_dna4);
 
     // convertibility between const and non-const
     EXPECT_TRUE(t1.cend() == t1.end());
 
     // mutability
-    *t1.begin() = dna4::T;
+    *t1.begin() = 'T'_dna4;
     EXPECT_TRUE((std::ranges::equal(t1, "TCCGT"_dna4)));
 }
 
 TYPED_TEST(container, element_access)
 {
-    TypeParam t1{dna4::A, dna4::C, dna4::C, dna4::G, dna4::T};
-    TypeParam const t2{dna4::A, dna4::C, dna4::C, dna4::G, dna4::T};
+    TypeParam t1{'A'_dna4, 'C'_dna4, 'C'_dna4, 'G'_dna4, 'T'_dna4};
+    TypeParam const t2{'A'_dna4, 'C'_dna4, 'C'_dna4, 'G'_dna4, 'T'_dna4};
 
     // at
-    EXPECT_EQ(t1.at(0), dna4::A);
-    EXPECT_EQ(t2.at(0), dna4::A);
+    EXPECT_EQ(t1.at(0), 'A'_dna4);
+    EXPECT_EQ(t2.at(0), 'A'_dna4);
 
     //TODO check at's ability to throw
 
     // []
-    EXPECT_EQ(t1[0], dna4::A);
-    EXPECT_EQ(t2[0], dna4::A);
+    EXPECT_EQ(t1[0], 'A'_dna4);
+    EXPECT_EQ(t2[0], 'A'_dna4);
 
     // front
-    EXPECT_EQ(t1.front(), dna4::A);
-    EXPECT_EQ(t2.front(), dna4::A);
+    EXPECT_EQ(t1.front(), 'A'_dna4);
+    EXPECT_EQ(t2.front(), 'A'_dna4);
 
     // back
-    EXPECT_EQ(t1.back(), dna4::T);
-    EXPECT_EQ(t2.back(), dna4::T);
+    EXPECT_EQ(t1.back(), 'T'_dna4);
+    EXPECT_EQ(t2.back(), 'T'_dna4);
 
     // mutability
-    t1[0] = dna4::T;
+    t1[0] = 'T'_dna4;
     EXPECT_TRUE((std::ranges::equal(t1, "TCCGT"_dna4)));
 
-    t1.front() = dna4::C;
+    t1.front() = 'C'_dna4;
     EXPECT_TRUE((std::ranges::equal(t1, "CCCGT"_dna4)));
 
-    t1.back() = dna4::G;
+    t1.back() = 'G'_dna4;
     EXPECT_TRUE((std::ranges::equal(t1, "CCCGG"_dna4)));
 }
 
 TYPED_TEST(container, capacity)
 {
     TypeParam t0{};
-    TypeParam t1{dna4::A, dna4::C, dna4::C, dna4::G, dna4::T};
-    TypeParam const t2{dna4::A, dna4::C, dna4::C, dna4::G, dna4::T};
+    TypeParam t1{'A'_dna4, 'C'_dna4, 'C'_dna4, 'G'_dna4, 'T'_dna4};
+    TypeParam const t2{'A'_dna4, 'C'_dna4, 'C'_dna4, 'G'_dna4, 'T'_dna4};
 
     // empty
     EXPECT_TRUE(t0.empty());
@@ -226,7 +225,7 @@ TYPED_TEST(container, capacity)
 TYPED_TEST(container, clear)
 {
     TypeParam t0{};
-    TypeParam t1{dna4::A, dna4::C, dna4::C, dna4::G, dna4::T};
+    TypeParam t1{'A'_dna4, 'C'_dna4, 'C'_dna4, 'G'_dna4, 'T'_dna4};
 
     t1.clear();
     EXPECT_EQ(t0, t1);
@@ -235,22 +234,22 @@ TYPED_TEST(container, clear)
 TYPED_TEST(container, insert)
 {
     TypeParam t0{};
-    TypeParam t1{dna4::A, dna4::C, dna4::C, dna4::G, dna4::T};
+    TypeParam t1{'A'_dna4, 'C'_dna4, 'C'_dna4, 'G'_dna4, 'T'_dna4};
 
     // position, value
-    t0.insert(t0.cend(), dna4::A);
-    t0.insert(t0.cend(), dna4::C);
-    t0.insert(t0.cend(), dna4::G);
-    t0.insert(t0.cend(), dna4::T);
-    t0.insert(t0.cbegin() + 1, dna4::C);
+    t0.insert(t0.cend(), 'A'_dna4);
+    t0.insert(t0.cend(), 'C'_dna4);
+    t0.insert(t0.cend(), 'G'_dna4);
+    t0.insert(t0.cend(), 'T'_dna4);
+    t0.insert(t0.cbegin() + 1, 'C'_dna4);
     EXPECT_EQ(t0, t1);
 
     // position, n times values
     t0.clear();
-    t0.insert(t0.cend(), 2, dna4::C);
-    t0.insert(t0.cend(), 1, dna4::G);
-    t0.insert(t0.cend(), 1, dna4::T);
-    t0.insert(t0.cbegin(), 1, dna4::A);
+    t0.insert(t0.cend(), 2, 'C'_dna4);
+    t0.insert(t0.cend(), 1, 'G'_dna4);
+    t0.insert(t0.cend(), 1, 'T'_dna4);
+    t0.insert(t0.cbegin(), 1, 'A'_dna4);
     EXPECT_EQ(t0, t1);
 
     // iterator pair
@@ -263,22 +262,22 @@ TYPED_TEST(container, insert)
 
     // initializer list
     t0.clear();
-    t0.insert(t0.cend(), {dna4::A, dna4::C, dna4::G, dna4::T});
-    t0.insert(t0.cbegin() + 1, dna4::C);
+    t0.insert(t0.cend(), {'A'_dna4, 'C'_dna4, 'G'_dna4, 'T'_dna4});
+    t0.insert(t0.cbegin() + 1, 'C'_dna4);
     EXPECT_EQ(t0, t1);
 }
 
 TYPED_TEST(container, erase)
 {
-    TypeParam t1{dna4::A, dna4::C, dna4::C, dna4::G, dna4::T};
+    TypeParam t1{'A'_dna4, 'C'_dna4, 'C'_dna4, 'G'_dna4, 'T'_dna4};
 
     // one element
     t1.erase(t1.begin());
-    EXPECT_EQ(t1, (TypeParam{dna4::C, dna4::C, dna4::G, dna4::T}));
+    EXPECT_EQ(t1, (TypeParam{'C'_dna4, 'C'_dna4, 'G'_dna4, 'T'_dna4}));
 
     // range
     t1.erase(t1.begin() + 1, t1.begin() + 3);
-    EXPECT_EQ(t1, (TypeParam{dna4::C, dna4::T}));
+    EXPECT_EQ(t1, (TypeParam{'C'_dna4, 'T'_dna4}));
 }
 
 TYPED_TEST(container, push_pop)
@@ -286,14 +285,14 @@ TYPED_TEST(container, push_pop)
     TypeParam t0{};
 
     // push_back
-    t0.push_back(dna4::A);
-    EXPECT_EQ(t0,  (TypeParam{dna4::A}));
-    t0.push_back(dna4::C);
-    EXPECT_EQ(t0, (TypeParam{dna4::A, dna4::C}));
+    t0.push_back('A'_dna4);
+    EXPECT_EQ(t0,  (TypeParam{'A'_dna4}));
+    t0.push_back('C'_dna4);
+    EXPECT_EQ(t0, (TypeParam{'A'_dna4, 'C'_dna4}));
 
     // pop_back
     t0.pop_back();
-    EXPECT_EQ(t0, (TypeParam{dna4::A}));
+    EXPECT_EQ(t0, (TypeParam{'A'_dna4}));
     t0.pop_back();
     EXPECT_EQ(t0, (TypeParam{}));
 }
@@ -304,34 +303,34 @@ TYPED_TEST(container, resize)
 
     // enlarge without values
     t0.resize(3);
-    EXPECT_EQ(t0, (TypeParam{dna4::A, dna4::A, dna4::A}));
+    EXPECT_EQ(t0, (TypeParam{'A'_dna4, 'A'_dna4, 'A'_dna4}));
 
     // enlarge with value
-    t0.resize(5, dna4::C);
-    EXPECT_EQ(t0, (TypeParam{dna4::A, dna4::A, dna4::A, dna4::C, dna4::C}));
+    t0.resize(5, 'C'_dna4);
+    EXPECT_EQ(t0, (TypeParam{'A'_dna4, 'A'_dna4, 'A'_dna4, 'C'_dna4, 'C'_dna4}));
 
     // shrink with value (no effect)
-    t0.resize(4, dna4::G);
-    EXPECT_EQ(t0, (TypeParam{dna4::A, dna4::A, dna4::A, dna4::C}));
+    t0.resize(4, 'G'_dna4);
+    EXPECT_EQ(t0, (TypeParam{'A'_dna4, 'A'_dna4, 'A'_dna4, 'C'_dna4}));
 
     // shrink without value
     t0.resize(2);
-    EXPECT_EQ(t0, (TypeParam{dna4::A, dna4::A}));
+    EXPECT_EQ(t0, (TypeParam{'A'_dna4, 'A'_dna4}));
 }
 
 TYPED_TEST(container, swap)
 {
     TypeParam t0{};
-    TypeParam t1{dna4::A, dna4::C, dna4::C, dna4::G, dna4::T};
+    TypeParam t1{'A'_dna4, 'C'_dna4, 'C'_dna4, 'G'_dna4, 'T'_dna4};
 
     t0.swap(t1);
-    EXPECT_EQ(t0, (TypeParam{dna4::A, dna4::C, dna4::C, dna4::G, dna4::T}));
+    EXPECT_EQ(t0, (TypeParam{'A'_dna4, 'C'_dna4, 'C'_dna4, 'G'_dna4, 'T'_dna4}));
     EXPECT_EQ(t1, (TypeParam{}));
 }
 
 TYPED_TEST(container, streamable)
 {
-    TypeParam t1{dna4::A, dna4::C, dna4::C, dna4::G, dna4::T};
+    TypeParam t1{'A'_dna4, 'C'_dna4, 'C'_dna4, 'G'_dna4, 'T'_dna4};
 
     std::ostringstream o;
     debug_stream.set_underlying_stream(o);
@@ -371,7 +370,7 @@ void do_serialisation(TypeParam const l)
 
 TYPED_TEST(container, serialisation)
 {
-    TypeParam t1{dna4::A, dna4::C, dna4::C, dna4::G, dna4::T};
+    TypeParam t1{'A'_dna4, 'C'_dna4, 'C'_dna4, 'G'_dna4, 'T'_dna4};
 
     do_serialisation<cereal::BinaryInputArchive,         cereal::BinaryOutputArchive>        (t1);
     do_serialisation<cereal::PortableBinaryInputArchive, cereal::PortableBinaryOutputArchive>(t1);

--- a/test/unit/range/view/view_char_to_test.cpp
+++ b/test/unit/range/view/view_char_to_test.cpp
@@ -45,7 +45,6 @@
 #include <seqan3/std/view/reverse.hpp>
 
 using namespace seqan3;
-using namespace seqan3::literal;
 
 TEST(view_char_to, basic)
 {

--- a/test/unit/range/view/view_complement_test.cpp
+++ b/test/unit/range/view/view_complement_test.cpp
@@ -45,7 +45,6 @@
 #include <seqan3/std/view/reverse.hpp>
 
 using namespace seqan3;
-using namespace seqan3::literal;
 
 TEST(view_complement, basic)
 {

--- a/test/unit/range/view/view_convert_test.cpp
+++ b/test/unit/range/view/view_convert_test.cpp
@@ -43,7 +43,6 @@
 #include <seqan3/std/view/reverse.hpp>
 
 using namespace seqan3;
-using namespace seqan3::literal;
 
 TEST(view_convert, basic)
 {

--- a/test/unit/range/view/view_deep_test.cpp
+++ b/test/unit/range/view/view_deep_test.cpp
@@ -54,7 +54,6 @@ inline auto const deep_take2 = deep{ranges::view::take(2)};
 }
 
 using namespace seqan3;
-using namespace seqan3::literal;
 
 // ------------------------------------------------------------------
 // no parameters

--- a/test/unit/range/view/view_get_test.cpp
+++ b/test/unit/range/view/view_get_test.cpp
@@ -46,13 +46,12 @@
 #include <seqan3/alphabet/mask/masked.hpp>
 
 using namespace seqan3;
-using namespace seqan3::literal;
 
 TEST(view_get, basic)
 {
     // TODO remove const-ness from input vector once alphabet_proxy's complement doesnt cause ICE
-    std::vector<dna4q> const qv{{dna4::A, phred42{0}}, {dna4::C, phred42{1}}, {dna4::G, phred42{2}}, {dna4::T, phred42{3}}};
-    std::vector<dna4> cmp0{dna4::A, dna4::C, dna4::G, dna4::T};
+    std::vector<dna4q> const qv{{'A'_dna4, phred42{0}}, {'C'_dna4, phred42{1}}, {'G'_dna4, phred42{2}}, {'T'_dna4, phred42{3}}};
+    std::vector<dna4> cmp0{'A'_dna4, 'C'_dna4, 'G'_dna4, 'T'_dna4};
     std::vector<phred42> cmp1{phred42{0}, phred42{1}, phred42{2}, phred42{3}};
 
     //functor
@@ -85,14 +84,14 @@ TEST(view_get, basic)
 TEST(view_get, advanced)
 {
     // TODO remove const-ness from input vector once alphabet_proxy inherits it's alphabet
-    std::vector<qualified<masked<dna4>, phred42>> const t{{{dna4::A, mask::MASKED}, phred42{0}},
-                                                    {{dna4::C, mask::UNMASKED}, phred42{1}},
-                                                    {{dna4::G, mask::MASKED}, phred42{2}},
-                                                    {{dna4::T, mask::UNMASKED}, phred42{3}}};
+    std::vector<qualified<masked<dna4>, phred42>> const t{{{'A'_dna4, mask::MASKED}, phred42{0}},
+                                                    {{'C'_dna4, mask::UNMASKED}, phred42{1}},
+                                                    {{'G'_dna4, mask::MASKED}, phred42{2}},
+                                                    {{'T'_dna4, mask::UNMASKED}, phred42{3}}};
 
     // functor notation
-    std::vector<masked<dna4>> cmp0{{dna4::A, mask::MASKED}, {dna4::C, mask::UNMASKED},
-                                  {dna4::G, mask::MASKED}, {dna4::T, mask::UNMASKED}};
+    std::vector<masked<dna4>> cmp0{{'A'_dna4, mask::MASKED}, {'C'_dna4, mask::UNMASKED},
+                                  {'G'_dna4, mask::MASKED}, {'T'_dna4, mask::UNMASKED}};
     std::vector<masked<dna4>> functor0 = view::get<0>(t);
     EXPECT_EQ(cmp0, functor0);
 
@@ -100,7 +99,7 @@ TEST(view_get, advanced)
     std::vector<phred42> functor1 = view::get<1>(t);
     EXPECT_EQ(cmp1, functor1);
 
-    std::vector<dna4> cmp00{dna4::A, dna4::C, dna4::G, dna4::T};
+    std::vector<dna4> cmp00{'A'_dna4, 'C'_dna4, 'G'_dna4, 'T'_dna4};
     std::vector<dna4> functor00 = view::get<0>(view::get<0>(t));
     EXPECT_EQ(cmp00, functor00);
 
@@ -115,19 +114,19 @@ TEST(view_get, advanced)
     EXPECT_EQ(cmp00, pipe00);
 
     // combinability
-    std::vector<masked<dna4>> cmprev{{dna4::T, mask::UNMASKED}, {dna4::G, mask::MASKED},
-                                     {dna4::C, mask::UNMASKED}, {dna4::A, mask::MASKED}};
+    std::vector<masked<dna4>> cmprev{{'T'_dna4, mask::UNMASKED}, {'G'_dna4, mask::MASKED},
+                                     {'C'_dna4, mask::UNMASKED}, {'A'_dna4, mask::MASKED}};
     std::vector<masked<dna4>> revtest = t | view::get<0> | view::reverse;
     EXPECT_EQ(cmprev, revtest);
 
-    std::vector<dna4> cmprev2{dna4::T, dna4::G, dna4::C, dna4::A};
+    std::vector<dna4> cmprev2{'T'_dna4, 'G'_dna4, 'C'_dna4, 'A'_dna4};
     std::vector<dna4> revtest2 = t | view::get<0> | view::get<0> | view::reverse;
     EXPECT_EQ(cmprev2, revtest2);
 
     // reference check
-    functor0[0] = masked<dna4>{dna4::T, mask::UNMASKED};
-    std::vector<masked<dna4>> cmpref{{dna4::T, mask::UNMASKED}, {dna4::C, mask::UNMASKED},
-                                     {dna4::G, mask::MASKED}, {dna4::T, mask::UNMASKED}};
+    functor0[0] = masked<dna4>{'T'_dna4, mask::UNMASKED};
+    std::vector<masked<dna4>> cmpref{{'T'_dna4, mask::UNMASKED}, {'C'_dna4, mask::UNMASKED},
+                                     {'G'_dna4, mask::MASKED}, {'T'_dna4, mask::UNMASKED}};
     EXPECT_EQ(cmpref, functor0);
 }
 

--- a/test/unit/range/view/view_get_test.cpp
+++ b/test/unit/range/view/view_get_test.cpp
@@ -50,7 +50,8 @@ using namespace seqan3::literal;
 
 TEST(view_get, basic)
 {
-    std::vector<dna4q> qv{{dna4::A, phred42{0}}, {dna4::C, phred42{1}}, {dna4::G, phred42{2}}, {dna4::T, phred42{3}}};
+    // TODO remove const-ness from input vector once alphabet_proxy's complement doesnt cause ICE
+    std::vector<dna4q> const qv{{dna4::A, phred42{0}}, {dna4::C, phred42{1}}, {dna4::G, phred42{2}}, {dna4::T, phred42{3}}};
     std::vector<dna4> cmp0{dna4::A, dna4::C, dna4::G, dna4::T};
     std::vector<phred42> cmp1{phred42{0}, phred42{1}, phred42{2}, phred42{3}};
 
@@ -83,7 +84,8 @@ TEST(view_get, basic)
 
 TEST(view_get, advanced)
 {
-    std::vector<qualified<masked<dna4>, phred42>> t{{{dna4::A, mask::MASKED}, phred42{0}},
+    // TODO remove const-ness from input vector once alphabet_proxy inherits it's alphabet
+    std::vector<qualified<masked<dna4>, phred42>> const t{{{dna4::A, mask::MASKED}, phred42{0}},
                                                     {{dna4::C, mask::UNMASKED}, phred42{1}},
                                                     {{dna4::G, mask::MASKED}, phred42{2}},
                                                     {{dna4::T, mask::UNMASKED}, phred42{3}}};

--- a/test/unit/range/view/view_kmer_hash_test.cpp
+++ b/test/unit/range/view/view_kmer_hash_test.cpp
@@ -41,7 +41,6 @@
 #include <gtest/gtest.h>
 
 using namespace seqan3;
-using namespace seqan3::literal;
 
 TEST(kmer_hash, view)
 {

--- a/test/unit/range/view/view_rank_to_test.cpp
+++ b/test/unit/range/view/view_rank_to_test.cpp
@@ -43,7 +43,6 @@
 #include <seqan3/std/view/reverse.hpp>
 
 using namespace seqan3;
-using namespace seqan3::literal;
 
 TEST(view_rank_to, basic)
 {

--- a/test/unit/range/view/view_rank_to_test.cpp
+++ b/test/unit/range/view/view_rank_to_test.cpp
@@ -47,7 +47,7 @@ using namespace seqan3::literal;
 
 TEST(view_rank_to, basic)
 {
-    std::vector<unsigned> vec{0,1,3,3,3,2,0,3,0};
+    std::vector<unsigned> vec{0,1,4,4,4,2,0,4,0};
     dna5_vector cmp{"ACTTTGATA"_dna5};
 
     // pipe notation

--- a/test/unit/range/view/view_to_char_test.cpp
+++ b/test/unit/range/view/view_to_char_test.cpp
@@ -43,7 +43,6 @@
 #include <seqan3/std/view/reverse.hpp>
 
 using namespace seqan3;
-using namespace seqan3::literal;
 
 TEST(view_to_char, basic)
 {

--- a/test/unit/range/view/view_to_rank_test.cpp
+++ b/test/unit/range/view/view_to_rank_test.cpp
@@ -48,7 +48,7 @@ using namespace seqan3::literal;
 TEST(view_to_rank, basic)
 {
     dna5_vector vec{"ACTTTGATA"_dna5};
-    std::vector<unsigned> cmp{0,1,3,3,3,2,0,3,0};
+    std::vector<unsigned> cmp{0,1,4,4,4,2,0,4,0};
 
     // pipe notation
     std::vector<unsigned> v = vec | view::to_rank;
@@ -59,7 +59,7 @@ TEST(view_to_rank, basic)
     EXPECT_EQ(cmp, v2);
 
     // combinability
-    std::vector<unsigned> cmp2{0, 3, 0, 2, 3, 3, 3, 1, 0};
+    std::vector<unsigned> cmp2{0, 4, 0, 2, 4, 4, 4, 1, 0};
     std::vector<unsigned> v3 = vec | view::to_rank | view::reverse;
     EXPECT_EQ(cmp2, v3);
 }

--- a/test/unit/range/view/view_to_rank_test.cpp
+++ b/test/unit/range/view/view_to_rank_test.cpp
@@ -43,7 +43,6 @@
 #include <seqan3/std/view/reverse.hpp>
 
 using namespace seqan3;
-using namespace seqan3::literal;
 
 TEST(view_to_rank, basic)
 {

--- a/test/unit/range/view/view_translation_test.cpp
+++ b/test/unit/range/view/view_translation_test.cpp
@@ -46,15 +46,13 @@
 #include <seqan3/core/detail/reflection.hpp>
 #include <seqan3/range/concept.hpp>
 #include <seqan3/range/container/concatenated_sequences.hpp>
+#include <seqan3/range/view/char_to.hpp>
 #include <seqan3/range/view/complement.hpp>
 #include <seqan3/range/view/translation.hpp>
 #include <seqan3/std/ranges>
 
-
-
 using namespace seqan3;
-using namespace seqan3::literal;
-using namespace seqan3::view;
+// using namespace seqan3::view;
 
 template <typename T>
 class nucleotide : public ::testing::Test
@@ -67,9 +65,8 @@ TYPED_TEST_CASE(nucleotide, nucleotide_types);
 
 TYPED_TEST(nucleotide, view_translate_single)
 {
-    using t = TypeParam;
-
-    std::vector<TypeParam> vec = {t::A, t::C, t::G, t::T, t::A, t::C, t::G, t::T, t::A, t::C, t::G, t::T, t::A};
+    std::string const in{"ACGTACGTACGTA"};
+    std::vector<TypeParam> vec = in | view::char_to<TypeParam>;
     aa27_vector cmp1{"TYVR"_aa27};
     aa27_vector cmp2{"CMHA"_aa27};
 
@@ -101,9 +98,8 @@ TYPED_TEST(nucleotide, view_translate_single)
 
 TYPED_TEST(nucleotide, view_translate)
 {
-    using t = TypeParam;
-
-    std::vector<TypeParam> vec = {t::A, t::C, t::G, t::T, t::A, t::C, t::G, t::T, t::A, t::C, t::G, t::T, t::A};
+    std::string const in{"ACGTACGTACGTA"};
+    std::vector<TypeParam> vec = in | view::char_to<TypeParam>;
     std::vector<std::vector<aa27> > cmp1{{"TYVR"_aa27}};
     std::vector<std::vector<aa27> > cmp2{{"TYVR"_aa27}, {"YVRT"_aa27}};
     std::vector<std::vector<aa27> > cmp3{{"TYVR"_aa27}, {"RTYV"_aa27}, {"VRT"_aa27}};
@@ -192,9 +188,8 @@ TYPED_TEST(nucleotide, view_translate)
 
 TYPED_TEST(nucleotide, view_translate_single_container_conversion)
 {
-    using t = TypeParam;
-
-    std::vector<TypeParam> vec= {t::A, t::C, t::G, t::T, t::A, t::C, t::G, t::T, t::A, t::C, t::G, t::T, t::A};
+    std::string const in{"ACGTACGTACGTA"};
+    std::vector<TypeParam> vec = in | view::char_to<TypeParam>;
     aa27_vector cmp1{"TYVR"_aa27};
 
     // default parameter translation_frames
@@ -205,9 +200,8 @@ TYPED_TEST(nucleotide, view_translate_single_container_conversion)
 
 TYPED_TEST(nucleotide, view_translate_container_conversion)
 {
-    using t = TypeParam;
-
-    std::vector<TypeParam> vec= {t::A, t::C, t::G, t::T, t::A, t::C, t::G, t::T, t::A, t::C, t::G, t::T, t::A};
+    std::string const in{"ACGTACGTACGTA"};
+    std::vector<TypeParam> vec = in | view::char_to<TypeParam>;
     std::vector<std::vector<aa27> > cmp1{{"TYVR"_aa27}, {"RTYV"_aa27}, {"VRT"_aa27}, {"YVRT"_aa27}, {"TYVR"_aa27}, {"RTY"_aa27}};
 
     // six frame translation
@@ -223,9 +217,8 @@ TYPED_TEST(nucleotide, view_translate_container_conversion)
 
 TYPED_TEST(nucleotide, view_translate_single_concepts)
 {
-    using t = TypeParam;
-
-    std::vector<TypeParam> vec= {t::A, t::C, t::G, t::T, t::A, t::C, t::G, t::T, t::A, t::C, t::G, t::T, t::A};
+    std::string const in{"ACGTACGTACGTA"};
+    std::vector<TypeParam> vec = in | view::char_to<TypeParam>;
     EXPECT_TRUE(std::ranges::InputRange<decltype(vec)>);
     EXPECT_TRUE(std::ranges::ForwardRange<decltype(vec)>);
     EXPECT_TRUE(std::ranges::RandomAccessRange<decltype(vec)>);
@@ -243,9 +236,8 @@ TYPED_TEST(nucleotide, view_translate_single_concepts)
 
 TYPED_TEST(nucleotide, view_translate_concepts)
 {
-    using t = TypeParam;
-
-    std::vector<TypeParam> vec= {t::A, t::C, t::G, t::T, t::A, t::C, t::G, t::T, t::A, t::C, t::G, t::T, t::A};
+    std::string const in{"ACGTACGTACGTA"};
+    std::vector<TypeParam> vec = in | view::char_to<TypeParam>;
     EXPECT_TRUE(std::ranges::ForwardRange<decltype(vec)>);
     EXPECT_TRUE(std::ranges::RandomAccessRange<decltype(vec)>);
     EXPECT_TRUE(std::ranges::SizedRange<decltype(vec)>);

--- a/test/unit/range/view/view_trim_test.cpp
+++ b/test/unit/range/view/view_trim_test.cpp
@@ -71,18 +71,18 @@ TEST(view_trim, standalone)
 
 TEST(view_trim, qualified)
 {
-    std::vector<dna5q> vec{{dna5::A, phred42{40}}, {dna5::G, phred42{40}}, {dna5::G, phred42{30}},
-                           {dna5::A, phred42{20}}, {dna5::T, phred42{10}}};
-    std::vector<dna5q> cmp1{{dna5::A, phred42{40}}, {dna5::G, phred42{40}}, {dna5::G, phred42{30}},
-                            {dna5::A, phred42{20}}};
-    std::vector<dna5q> cmp2{{dna5::A, phred42{40}}, {dna5::G, phred42{40}}};
+    std::vector<dna5q> vec{{'A'_dna5, phred42{40}}, {'G'_dna5, phred42{40}}, {'G'_dna5, phred42{30}},
+                           {'A'_dna5, phred42{20}}, {'T'_dna5, phred42{10}}};
+    std::vector<dna5q> cmp1{{'A'_dna5, phred42{40}}, {'G'_dna5, phred42{40}}, {'G'_dna5, phred42{30}},
+                            {'A'_dna5, phred42{20}}};
+    std::vector<dna5q> cmp2{{'A'_dna5, phred42{40}}, {'G'_dna5, phred42{40}}};
 
     // trim by phred_value
     auto v1 = vec | view::trim(20u);
     EXPECT_EQ(std::vector<dna5q>(v1), cmp1);
 
     // trim by quality character
-    auto v2 = vec | view::trim(dna5q{dna5::C, phred42{40}});
+    auto v2 = vec | view::trim(dna5q{'C'_dna5, phred42{40}});
     EXPECT_EQ(std::vector<dna5q>(v2), cmp2);
 
     // function syntax
@@ -96,7 +96,7 @@ TEST(view_trim, qualified)
 
 TEST(view_trim, concepts)
 {
-    std::vector<dna5q> vec{{dna5::A, phred42{40}}, {dna5::G, phred42{40}}, {dna5::G, phred42{30}}, {dna5::A, phred42{20}}, {dna5::T, phred42{10}}};
+    std::vector<dna5q> vec{{'A'_dna5, phred42{40}}, {'G'_dna5, phred42{40}}, {'G'_dna5, phred42{30}}, {'A'_dna5, phred42{20}}, {'T'_dna5, phred42{10}}};
     EXPECT_TRUE(std::ranges::InputRange<decltype(vec)>);
     EXPECT_TRUE(std::ranges::ForwardRange<decltype(vec)>);
     EXPECT_TRUE(std::ranges::RandomAccessRange<decltype(vec)>);

--- a/test/unit/search/bi_fm_index_iterator_test.cpp
+++ b/test/unit/search/bi_fm_index_iterator_test.cpp
@@ -44,7 +44,6 @@
 #include <gtest/gtest.h>
 
 using namespace seqan3;
-using namespace seqan3::literal;
 
 template <typename T>
 class bi_fm_index_iterator_test : public ::testing::Test
@@ -99,25 +98,25 @@ TYPED_TEST(bi_fm_index_iterator_test, extend_char)
     typename TypeParam::index_type bi_fm{text};
 
     auto it = bi_fm.begin();
-    EXPECT_TRUE(it.extend_left(dna4::G)); // "G"
+    EXPECT_TRUE(it.extend_left('G'_dna4)); // "G"
     EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{2, 3, 6, 7, 10}));
-    EXPECT_TRUE(it.extend_left(dna4::C)); // "CG"
+    EXPECT_TRUE(it.extend_left('C'_dna4)); // "CG"
     EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{1, 9}));
-    EXPECT_FALSE(it.extend_left(dna4::C)); // "CG"
+    EXPECT_FALSE(it.extend_left('C'_dna4)); // "CG"
     EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{1, 9}));
-    EXPECT_FALSE(it.extend_left(dna4::G)); // "CG"
+    EXPECT_FALSE(it.extend_left('G'_dna4)); // "CG"
     EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{1, 9}));
-    EXPECT_FALSE(it.extend_right(dna4::T)); // "CG"
+    EXPECT_FALSE(it.extend_right('T'_dna4)); // "CG"
     EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{1, 9}));
-    EXPECT_TRUE(it.extend_right(dna4::G)); // "CGG"
+    EXPECT_TRUE(it.extend_right('G'_dna4)); // "CGG"
     EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{1}));
-    EXPECT_TRUE(it.extend_right(dna4::T)); // "CGGT"
+    EXPECT_TRUE(it.extend_right('T'_dna4)); // "CGGT"
     EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{1}));
-    EXPECT_TRUE(it.extend_right(dna4::A)); // "CGGTA"
+    EXPECT_TRUE(it.extend_right('A'_dna4)); // "CGGTA"
     EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{1}));
-    EXPECT_TRUE(it.extend_left(dna4::A)); // "ACGGTA"
+    EXPECT_TRUE(it.extend_left('A'_dna4)); // "ACGGTA"
     EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{0}));
-    EXPECT_FALSE(it.extend_left(dna4::A)); // "ACGGTA"
+    EXPECT_FALSE(it.extend_left('A'_dna4)); // "ACGGTA"
     EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{0}));
 }
 

--- a/test/unit/search/fm_index_iterator_test.cpp
+++ b/test/unit/search/fm_index_iterator_test.cpp
@@ -45,7 +45,6 @@
 #include <gtest/gtest.h>
 
 using namespace seqan3;
-using namespace seqan3::literal;
 
 struct fm_index_byte_alphabet_traits
 {
@@ -172,17 +171,17 @@ TYPED_TEST(fm_index_iterator_test, extend_right_char)
 
     // successful extend_right(char)
     TypeParam it(fm);
-    EXPECT_TRUE(it.extend_right(dna4::A));
+    EXPECT_TRUE(it.extend_right('A'_dna4));
     EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{0, 3}));
     EXPECT_EQ(it.query_length(), 1);
 
-    EXPECT_TRUE(it.extend_right(dna4::C));
+    EXPECT_TRUE(it.extend_right('C'_dna4));
     EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{0, 3}));
     EXPECT_EQ(it.query_length(), 2);
 
     // unsuccessful extend_right(char), it remains untouched
     TypeParam it_cpy = it;
-    EXPECT_FALSE(it.extend_right(dna4::C));
+    EXPECT_FALSE(it.extend_right('C'_dna4));
     EXPECT_EQ(it, it_cpy);
 }
 
@@ -194,7 +193,7 @@ TYPED_TEST(fm_index_iterator_test, extend_right_char)
 //
 //     // successful extend_right(char) using a different alphabet
 //     TypeParam it(fm);
-//     EXPECT_TRUE(it.extend_right(dna4::A));
+//     EXPECT_TRUE(it.extend_right('A'_dna4));
 //     EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{0, 3}));
 //     EXPECT_EQ(it.query_length(), 1);
 // }
@@ -222,7 +221,7 @@ TYPED_TEST(fm_index_iterator_test, extend_right_char_and_cycle)
 
     // successful extend_right() and cycle_back()
     TypeParam it(fm);
-    EXPECT_TRUE(it.extend_right(dna4::A));
+    EXPECT_TRUE(it.extend_right('A'_dna4));
     EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{0, 3, 4}));
     EXPECT_EQ(it.query_length(), 1);
 
@@ -290,7 +289,7 @@ TYPED_TEST(fm_index_iterator_test, incomplete_alphabet)
         typename TypeParam::index_type::text_type text{"ACGACG"_dna4};
         typename TypeParam::index_type fm{text};
         TypeParam it = TypeParam(fm);
-        EXPECT_FALSE(it.extend_right(dna4::T));
+        EXPECT_FALSE(it.extend_right('T'_dna4));
         EXPECT_EQ(it, TypeParam(fm));
     }
 
@@ -299,7 +298,7 @@ TYPED_TEST(fm_index_iterator_test, incomplete_alphabet)
         typename TypeParam::index_type::text_type text{"CGTCGT"_dna4};
         typename TypeParam::index_type fm{text};
         TypeParam it = TypeParam(fm);
-        EXPECT_FALSE(it.extend_right(dna4::A));
+        EXPECT_FALSE(it.extend_right('A'_dna4));
         EXPECT_EQ(it, TypeParam(fm));
     }
 
@@ -309,13 +308,13 @@ TYPED_TEST(fm_index_iterator_test, incomplete_alphabet)
         typename TypeParam::index_type::text_type text{"ATATAT"_dna4};
         typename TypeParam::index_type fm{text};
         TypeParam it = TypeParam(fm);
-        EXPECT_FALSE(it.extend_right(dna4::C));
-        EXPECT_FALSE(it.extend_right(dna4::G));
+        EXPECT_FALSE(it.extend_right('C'_dna4));
+        EXPECT_FALSE(it.extend_right('G'_dna4));
         EXPECT_FALSE(it.extend_right("ACGT"_dna4));
         EXPECT_FALSE(it.extend_right("G"_dna4));
         EXPECT_EQ(it, TypeParam(fm));
 
-        EXPECT_TRUE(it.extend_right(dna4::A));
+        EXPECT_TRUE(it.extend_right('A'_dna4));
         EXPECT_TRUE(it.cycle_back());
         EXPECT_TRUE(std::ranges::equal(it.query(), "T"_dna4));
     }

--- a/test/unit/search/fm_index_test.cpp
+++ b/test/unit/search/fm_index_test.cpp
@@ -40,7 +40,6 @@
 #include <gtest/gtest.h>
 
 using namespace seqan3;
-using namespace seqan3::literal;
 
 // TODO: EXPECT_EQ is not supported by sdsl
 

--- a/test/unit/search/search_configuration_test.cpp
+++ b/test/unit/search/search_configuration_test.cpp
@@ -39,7 +39,6 @@
 #include <gtest/gtest.h>
 
 using namespace seqan3;
-using namespace seqan3::literal;
 
 template <typename T>
 class search_configuration_test : public ::testing::Test

--- a/test/unit/search/search_test.cpp
+++ b/test/unit/search/search_test.cpp
@@ -42,7 +42,6 @@
 #include <gtest/gtest.h>
 
 using namespace seqan3;
-using namespace seqan3::literal;
 using namespace seqan3::search_cfg;
 
 template <typename T>


### PR DESCRIPTION
## major refactorisation of all alphabets

- there are now alphabet base classes that our alphabets inherit from, this reduces code duplication
- alphabets are no longer aggregate types fixing some weird issues
- our alphabets are still PODs although this is not required by the alphabet_concept anymore
- `constexpr` default construction has been fixed everywhere
- cartesian composition no longer inherits pod_tuple, but actually compresses into a single rank value
  - `gapped<dna5>` now consumes one byte, not two
  - all operations are now constant time, not linear in the number of elements
- introduction of alphabet_proxy, a generic proxy base that also models the concepts of it's emulated type
- fixed a heap of bugs I found on the way

## Reviews:

- @joshuak94 can you review the changes to the mask alphabet and gap?
- @sarahet can you review the changes regarding the amino acids? It's not much ;)
- @joergi-w can you review the changes to the structure alphabets and the dna alphabets?
- @mariehoffmann can you review the changes to the qualities?
- @smehringer @marehr Can you review rest, in particular the changes to cartesian_composition and the alphabet_proxy?

Follow-Up TODOs:
  - [ ] investigate the two ICEs
  - [ ] make union_composition require the same char_type on alternatives
  - [ ] rename `composition` module to `composite`
  - [ ] rename `cartesian_composition` to `alphabet_tuple`
  - [ ] rename `union_composition` to `alphabet_variant`
  - [ ] implement `alphabet_any`
  - [ ] switch all alphabets from enum-notation to using a char literal (only done for nucleotides)
