### PR TITLE
[FEATURE] Enable chaining of validators.

### DIFF
--- a/include/seqan3/argument_parser/validators.hpp
+++ b/include/seqan3/argument_parser/validators.hpp
@@ -61,14 +61,48 @@ namespace seqan3
  * The requirements for this concept are given as related functions and metafunctions.
  * Types that satisfy this concept are shown as "implementing this interface".
  */
+/*!\name Requirements for seqan3::validator_concept
+ * \brief You can expect these (meta-)functions on all types that implement seqan3::validator_concept.
+ * \{
+ */
+/*!\typedef     using value_type
+ * \brief       The type of value on which the validator is called on.
+ * \relates     seqan3::validator_concept
+ *
+ * \details
+ * \attention This is a concept requirement, not an actual typedef (however types satisfying this concept
+ * will provide an implementation).
+ */
+/*!\fn              void operator()(value_type const & cmp) const
+ * \brief           Validates the value 'cmp' and throws a seqan3::validation_error on failure.
+ * \tparam          value_type The type of the value to be validated.
+ * \param[in,out]   cmp The value to be validated.
+ * \relates         seqan3::validator_concept
+ * \throws          seqan3::validation_error if value 'cmp' does not pass validation.
+ *
+ * \details
+ * \attention This is a concept requirement, not an actual function (however types satisfying this concept
+ * will provide an implementation).
+ */
+/*!\fn              std::string get_help_page_message() const
+ * \brief           Returns a message that can be appended to the (positional) options help page info.
+ * \relates         seqan3::validator_concept
+ * \returns         A string that contains information on the performed validation.
+ *
+ * \details
+ * \attention This is a concept requirement, not an actual function (however types satisfying this concept
+ * will provide an implementation).
+ */
+//!\}
 //!\cond
 template <typename validator_type>
-concept validator_concept = std::Invocable<validator_type, typename validator_type::value_type> &&
-                                 requires(validator_type validator,
-                                          typename validator_type::value_type value)
+concept validator_concept = std::Copyable<remove_cvref_t<validator_type>> &&
+                            requires(validator_type validator,
+                                     typename std::remove_reference_t<validator_type>::value_type value)
 {
-    typename validator_type::value_type;
+    typename std::remove_reference_t<validator_type>::value_type;
 
+    { validator(value) } -> void;
     { validator.get_help_page_message() } -> std::string;
 };
 //!\endcond
@@ -80,6 +114,7 @@ class integral_range_validator;
 
 /*!\brief A validator that checks whether a number is inside a given range.
  * \ingroup argument_parser
+ * \implements seqan3::validator_concept
  *
  * \tparam option_value_type Must be a (container of) integral type(s).
  *
@@ -182,6 +217,7 @@ private:
 
 /*!\brief A validator that checks whether a value is inside a list of valid values.
  * \ingroup argument_parser
+ * \implements seqan3::validator_concept
  *
  * \details
  *
@@ -236,6 +272,7 @@ private:
 
 /*!\brief A validator that checks if each value in a container appears in a list of valid values.
  * \ingroup argument_parser
+ * \implements seqan3::validator_concept
  * \extends seqan3::value_list_validator
  *
  * \tparam option_value_type The container type. Must satisfy the seqan3::container_concept.
@@ -294,6 +331,7 @@ private:
 
 /*!\brief A validator that checks if a filenames has one of the valid extensions.
  * \ingroup argument_parser
+ * \implements seqan3::validator_concept
  *
  * \details
  *
@@ -399,6 +437,7 @@ class regex_validator;
 
 /*!\brief A validator that checks if a matches a regular expression pattern.
  * \ingroup argument_parser
+ * \implements seqan3::validator_concept
  *
  * \details
  *
@@ -450,6 +489,7 @@ private:
 
 /*!\brief A validator that checks if each value in a container satisfies a regex expression.
  * \ingroup argument_parser
+ * \implements seqan3::validator_concept
  * \extends seqan3::regex_validator
  */
 template <>
@@ -500,6 +540,7 @@ namespace detail
 
 /*!\brief Validator that always returns true.
  * \ingroup argument_parser
+ * \implements seqan3::validator_concept
  *
  * \details
  *
@@ -512,11 +553,9 @@ struct default_validator
     //!\brief Type of values that are tested by validator
     using value_type = option_value_type;
 
-    //!\brief Value cmp always passes validation.
-    bool operator()(option_value_type const & /*cmp*/) const noexcept
-    {
-        return true;
-    }
+    //!\brief Value cmp always passes validation because the operator never throws.
+    void operator()(option_value_type const & /*cmp*/) const noexcept
+    {}
 
     //!\brief Since no validation is happening the help message is empty.
     std::string get_help_page_message() const

--- a/test/snippet/argument_parser/validators_chaining.cpp
+++ b/test/snippet/argument_parser/validators_chaining.cpp
@@ -1,0 +1,33 @@
+#include <seqan3/argument_parser/all.hpp>
+
+int main(int argc, const char ** argv)
+{
+    seqan3::argument_parser myparser("Test", argc, argv); // initialize
+
+    std::string file_name;
+
+    seqan3::regex_validator<std::string> absolute_path_validator("(/[^/]+)+/.*\\.[^/\\.]+$");
+    seqan3::file_ext_validator my_file_ext_validator({"sa", "so"});
+
+    myparser.add_option(file_name, 'f', "file","Give me a file name/path.",
+                        seqan3::option_spec::DEFAULT, absolute_path_validator | my_file_ext_validator);
+
+    // an exception will be thrown if the user specifies a file name
+    // that is not an absolute path or does not have one of the file extension [sa,so]
+    try
+    {
+        myparser.parse();
+    }
+    catch (seqan3::parser_invalid_argument const & ext) // the user did something wrong
+    {
+        std::cerr << "[PARSER ERROR] " << ext.what() << "\n"; // customize your error message
+        return -1;
+    }
+    catch (seqan3::parser_interruption const &) // expected behaviour on special requests (e.g. `--help`)
+    {
+        return 0;
+    }
+
+    std::cout << "filename given by user passed validation: " << file_name << "\n";
+    return 0;
+}

--- a/test/unit/argument_parser/format_parse_validators_test.cpp
+++ b/test/unit/argument_parser/format_parse_validators_test.cpp
@@ -44,7 +44,12 @@ using namespace seqan3;
 
 TEST(validator_test, fullfill_concept)
 {
+    EXPECT_FALSE(validator_concept<int>);
+
     EXPECT_TRUE(validator_concept<detail::default_validator<int>>);
+    EXPECT_TRUE(validator_concept<detail::default_validator<int> const>);
+    EXPECT_TRUE(validator_concept<detail::default_validator<int> &>);
+
     EXPECT_TRUE(validator_concept<integral_range_validator<int>>);
     EXPECT_TRUE(validator_concept<value_list_validator<int>>);
     EXPECT_TRUE(validator_concept<regex_validator<std::string>>);


### PR DESCRIPTION
Fixes #192 

You can now do this

```
parser.add_option(..., validator1 | validator2);
```