### PR TITLE
[fix] clang: 'decltype(auto)' cannot be combined with other type specifiers

### DIFF
--- a/include/seqan3/io/detail/record.hpp
+++ b/include/seqan3/io/detail/record.hpp
@@ -199,7 +199,7 @@ auto const & get_or_ignore(std::tuple<types...> const & t)
  */
 //!\brief Access an element in a std::tuple or seqan3::record; return or_value if not contained.
 template <field f, typename field_types, typename field_ids, typename or_type>
-auto get_or(record<field_types, field_ids> & r, or_type && or_value)
+decltype(auto) get_or(record<field_types, field_ids> & r, or_type && or_value)
 {
     if constexpr (field_ids::contains(f))
         return std::get<field_ids::index_of(f)>(r);
@@ -209,7 +209,7 @@ auto get_or(record<field_types, field_ids> & r, or_type && or_value)
 
 //!\copydoc seqan3::detail::get_or
 template <field f, typename field_types, typename field_ids, typename or_type>
-auto const get_or(record<field_types, field_ids> const & r, or_type && or_value)
+decltype(auto) get_or(record<field_types, field_ids> const & r, or_type && or_value)
 {
     if constexpr (field_ids::contains(f))
         return std::get<field_ids::index_of(f)>(r);
@@ -219,7 +219,7 @@ auto const get_or(record<field_types, field_ids> const & r, or_type && or_value)
 
 //!\copydoc seqan3::detail::get_or
 template <size_t i, typename or_type, typename ... types>
-auto get_or(std::tuple<types...> & t, or_type && or_value)
+decltype(auto) get_or(std::tuple<types...> & t, or_type && or_value)
 {
     if constexpr (i < sizeof...(types))
         return std::get<i>(t);
@@ -229,7 +229,7 @@ auto get_or(std::tuple<types...> & t, or_type && or_value)
 
 //!\copydoc seqan3::detail::get_or
 template <size_t i, typename or_type, typename ... types>
-auto const get_or(std::tuple<types...> const & t, or_type && or_value)
+decltype(auto) get_or(std::tuple<types...> const & t, or_type && or_value)
 {
     if constexpr (i < sizeof...(types))
         return std::get<i>(t);

--- a/include/seqan3/io/detail/record.hpp
+++ b/include/seqan3/io/detail/record.hpp
@@ -199,7 +199,7 @@ auto const & get_or_ignore(std::tuple<types...> const & t)
  */
 //!\brief Access an element in a std::tuple or seqan3::record; return or_value if not contained.
 template <field f, typename field_types, typename field_ids, typename or_type>
-decltype(auto) get_or(record<field_types, field_ids> & r, or_type && or_value)
+auto get_or(record<field_types, field_ids> & r, or_type && or_value)
 {
     if constexpr (field_ids::contains(f))
         return std::get<field_ids::index_of(f)>(r);
@@ -209,7 +209,7 @@ decltype(auto) get_or(record<field_types, field_ids> & r, or_type && or_value)
 
 //!\copydoc seqan3::detail::get_or
 template <field f, typename field_types, typename field_ids, typename or_type>
-decltype(auto) const get_or(record<field_types, field_ids> const & r, or_type && or_value)
+auto const get_or(record<field_types, field_ids> const & r, or_type && or_value)
 {
     if constexpr (field_ids::contains(f))
         return std::get<field_ids::index_of(f)>(r);
@@ -219,7 +219,7 @@ decltype(auto) const get_or(record<field_types, field_ids> const & r, or_type &&
 
 //!\copydoc seqan3::detail::get_or
 template <size_t i, typename or_type, typename ... types>
-decltype(auto) get_or(std::tuple<types...> & t, or_type && or_value)
+auto get_or(std::tuple<types...> & t, or_type && or_value)
 {
     if constexpr (i < sizeof...(types))
         return std::get<i>(t);
@@ -229,7 +229,7 @@ decltype(auto) get_or(std::tuple<types...> & t, or_type && or_value)
 
 //!\copydoc seqan3::detail::get_or
 template <size_t i, typename or_type, typename ... types>
-decltype(auto) const get_or(std::tuple<types...> const & t, or_type && or_value)
+auto const get_or(std::tuple<types...> const & t, or_type && or_value)
 {
     if constexpr (i < sizeof...(types))
         return std::get<i>(t);


### PR DESCRIPTION
```
/seqan3/include/seqan3/io/detail/record.hpp:212:1: error: 'decltype(auto)' cannot be combined with other type specifiers
decltype(auto) const get_or(record<field_types, field_ids> const & r, or_type && or_value)
^
```

See https://stackoverflow.com/questions/27766601/why-cannot-form-reference-to-decltypeauto/27766740#27766740