### PR TITLE
[fix] clang: 'auto' not allowed in function prototype

### DIFF
--- a/include/seqan3/alignment/matrix/alignment_matrix_formatter.hpp
+++ b/include/seqan3/alignment/matrix/alignment_matrix_formatter.hpp
@@ -358,7 +358,8 @@ private:
     }
 
     //!\brief Convert a matrix entry into a std::string
-    static std::string as_string(auto && entry) noexcept
+    template <typename entry_type>
+    static std::string as_string(entry_type && entry) noexcept
     {
         std::stringstream strstream;
         debug_stream_type stream{strstream};


### PR DESCRIPTION
```c++
seqan3/include/seqan3/alignment/matrix/alignment_matrix_formatter.hpp:361:34: error: 'auto' not allowed in function prototype
    static std::string as_string(auto && entry) noexcept
                                 ^~~~
```