### PR TITLE
[fix] clang: 'matrix_formatter_test' defined as a struct here but previously declared as a class

### DIFF
--- a/include/seqan3/alignment/matrix/alignment_matrix_formatter.hpp
+++ b/include/seqan3/alignment/matrix/alignment_matrix_formatter.hpp
@@ -391,7 +391,7 @@ private:
     }
 
     //!\brief Befriend test case
-    friend class matrix_formatter_test;
+    friend struct matrix_formatter_test;
 };
 
 /*!\name Type deduction guides


### PR DESCRIPTION
```c++
/seqan3/test/unit/alignment/matrix/alignment_matrix_formatter_test.cpp:16:1: error: 'matrix_formatter_test' defined as a struct here but previously declared as a class [-Werror,-Wmismatched-tags]
struct matrix_formatter_test : public ::testing::Test
^
/seqan3/include/seqan3/alignment/matrix/alignment_matrix_formatter.hpp:395:12: note: did you mean struct here?
    friend class matrix_formatter_test;
           ^
```