### PR TITLE
[fix] clang: incomplete type 'seqan3::detail::is_char_type<-1>' used in type trait expression

### DIFF
--- a/include/seqan3/io/stream/parse_condition_detail.hpp
+++ b/include/seqan3/io/stream/parse_condition_detail.hpp
@@ -300,7 +300,6 @@ public:
      */
     //!\brief Returns the message representing this condition as std::string.
     std::string message() const
-        requires parse_condition_concept<derived_t>
     {
         return derived_t::msg.string();
     }


### PR DESCRIPTION
clang can't use requires in a CRTP base class if the condition in the requires involves the derived class which is not fully defined yet.

Tries to define `is_char_type` (still incomplete) -> tries to define `parse_condition_base<is_char_type>` (still incomplete) -> tries to define `message` (still incomplete) which has a requires on `is_char_type` (circular dependency on a still incomplete type).

```c++
In file included from /seqan3/test/unit/io/stream/parse_condition_test.cpp:35:
In file included from /seqan3-build/clang-6-concepts/vendor/googletest/googletest/include/gtest/gtest.h:55:
In file included from /usr/lib64/gcc/x86_64-pc-linux-gnu/8.2.1/../../../../include/c++/8.2.1/ostream:38:
In file included from /usr/lib64/gcc/x86_64-pc-linux-gnu/8.2.1/../../../../include/c++/8.2.1/ios:39:
In file included from /usr/lib64/gcc/x86_64-pc-linux-gnu/8.2.1/../../../../include/c++/8.2.1/exception:144:
In file included from /usr/lib64/gcc/x86_64-pc-linux-gnu/8.2.1/../../../../include/c++/8.2.1/bits/nested_exception.h:40:
In file included from /usr/lib64/gcc/x86_64-pc-linux-gnu/8.2.1/../../../../include/c++/8.2.1/bits/move.h:55:
/usr/lib64/gcc/x86_64-pc-linux-gnu/8.2.1/../../../../include/c++/8.2.1/type_traits:1338:66: error: incomplete type 'seqan3::detail::is_char_type<-1>' used in type trait expression
    : public integral_constant<bool, __is_base_of(_Base, _Derived)>
                                                                 ^
/usr/lib64/gcc/x86_64-pc-linux-gnu/8.2.1/../../../../include/c++/8.2.1/type_traits:2905:40: note: in instantiation of template class 'std::is_base_of<seqan3::detail::parse_condition_base<seqan3::detail::is_char_type<-1> >, seqan3::detail::is_char_type<-1> >' requested here
  inline constexpr bool is_base_of_v = is_base_of<_Base, _Derived>::value;
                                       ^
/seqan3/include/seqan3/io/stream/parse_condition_detail.hpp:139:19: note: in instantiation of variable template specialization 'std::is_base_of_v<seqan3::detail::parse_condition_base<seqan3::detail::is_char_type<-1> >, seqan3::detail::is_char_type<-1> >' requested here
    requires std::is_base_of_v<parse_condition_base<remove_cvref_t<condition_t>>,
                  ^
/seqan3/include/seqan3/io/stream/parse_condition_detail.hpp:139:14: note: in instantiation of requirement here
    requires std::is_base_of_v<parse_condition_base<remove_cvref_t<condition_t>>,
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/seqan3/include/seqan3/io/stream/parse_condition_detail.hpp:139:14: note: while checking the satisfaction of nested requirement requested here
    requires std::is_base_of_v<parse_condition_base<remove_cvref_t<condition_t>>,
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/seqan3/include/seqan3/io/stream/parse_condition_detail.hpp:136:35: note: while substituting template arguments into constraint expression here
concept parse_condition_concept = requires
                                  ^~~~~~~~
/seqan3/include/seqan3/io/stream/parse_condition_detail.hpp:303:18: note: while checking the satisfaction of concept 'parse_condition_concept<seqan3::detail::is_char_type<-1> >' requested here
        requires parse_condition_concept<derived_t>
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/seqan3/include/seqan3/io/stream/parse_condition_detail.hpp:461:30: note: in instantiation of template class 'seqan3::detail::parse_condition_base<seqan3::detail::is_char_type<-1> >' requested here
struct is_char_type : public parse_condition_base<is_char_type<char_v>>
                             ^
/seqan3/include/seqan3/io/stream/parse_condition.hpp:108:47: note: in instantiation of template class 'seqan3::detail::is_char_type<-1>' requested here
inline detail::is_char_type<char_v> constexpr is_char;
                                              ^
/seqan3/include/seqan3/io/stream/parse_condition.hpp:120:32: note: in instantiation of variable template specialization 'seqan3::is_char' requested here
inline auto constexpr is_eof = is_char<EOF>;
                               ^
/seqan3/include/seqan3/io/stream/parse_condition_detail.hpp:461:8: note: definition of 'seqan3::detail::is_char_type<-1>' is not complete until the closing '}'
struct is_char_type : public parse_condition_base<is_char_type<char_v>>
       ^
```