### PR TITLE
[fix] clang: constant expression evaluates to -123 which cannot be narrowed to type 'unsigned long'

### DIFF
--- a/test/unit/std/charconv_test.cpp
+++ b/test/unit/std/charconv_test.cpp
@@ -77,7 +77,7 @@ TYPED_TEST(integral_from_char_test, negative_number)
     std::vector<char> const str{'-', '1', '2', '3'};
     auto res = std::from_chars(&str[0], &str[0] + str.size(), value);
 
-    if (std::UnsignedIntegral<TypeParam>)
+    if constexpr (std::UnsignedIntegral<TypeParam>)
     {
         EXPECT_EQ(res.ptr, &str[0]);
         EXPECT_EQ(res.ec, std::errc::invalid_argument);


### PR DESCRIPTION


```c++
/seqan3/test/unit/std/charconv_test.cpp:88:36: error: constant expression evaluates to -123 which cannot be narrowed to type 'integral_from_char_test_negative_number_Test<unsigned long>::TypeParam' (aka 'unsigned long') [-Wc++11-narrowing]
        EXPECT_EQ(value, TypeParam{-123});
                                   ^~~~
```