### PR TITLE
[fix] clang: defaulted definition of copy assignment operator is not constexpr

### DIFF
--- a/test/unit/range/detail/inherited_iterator_base_test.cpp
+++ b/test/unit/range/detail/inherited_iterator_base_test.cpp
@@ -54,10 +54,10 @@ private:
 
 public:
     skip_odd_numbers_it() = default;
-    constexpr skip_odd_numbers_it(skip_odd_numbers_it const & rhs) = default;
-    constexpr skip_odd_numbers_it(skip_odd_numbers_it && rhs) = default;
-    constexpr skip_odd_numbers_it & operator=(skip_odd_numbers_it const & rhs) = default;
-    constexpr skip_odd_numbers_it & operator=(skip_odd_numbers_it && rhs) = default;
+    skip_odd_numbers_it(skip_odd_numbers_it const & rhs) = default;
+    skip_odd_numbers_it(skip_odd_numbers_it && rhs) = default;
+    skip_odd_numbers_it & operator=(skip_odd_numbers_it const & rhs) = default;
+    skip_odd_numbers_it & operator=(skip_odd_numbers_it && rhs) = default;
     ~skip_odd_numbers_it() = default;
 
     skip_odd_numbers_it(base_base_t it) : base_t{it} {}


### PR DESCRIPTION
```c++
/seqan3/test/unit/range/detail/inherited_iterator_base_test.cpp:59:5: error: defaulted definition of copy assignment operator is not constexpr
    constexpr skip_odd_numbers_it & operator=(skip_odd_numbers_it const & rhs) = default;
    ^
```