### PR TITLE
 [fix] clang: unused variables 

### DIFF
--- a/test/unit/range/container/aligned_allocator_test.cpp
+++ b/test/unit/range/container/aligned_allocator_test.cpp
@@ -65,13 +65,13 @@ TEST(aligned_allocator, standard_construction)
 
 TEST(aligned_allocator, constexpr_constructor)
 {
-    constexpr aligned_allocator<int, 16> alloc{};
+    [[maybe_unused]] constexpr aligned_allocator<int, 16> alloc{};
 }
 
 TEST(aligned_allocator, conversion_constructor)
 {
     aligned_allocator<int, 16> int_alloc{};
-    aligned_allocator<float, 16> float_alloc{int_alloc};
+    [[maybe_unused]] aligned_allocator<float, 16> float_alloc{int_alloc};
 }
 
 size_t memory_alignment(void * value, size_t alignment)

--- a/test/unit/range/detail/random_access_iterator_test.cpp
+++ b/test/unit/range/detail/random_access_iterator_test.cpp
@@ -79,8 +79,8 @@ TEST(random_access_iterator_test, concept_checks)
 // default constructor
 TEST(random_access_iterator_test, default_constructor)
 {
-    seqan3::detail::random_access_iterator<std::vector<uint8_t>> it;
-    seqan3::detail::random_access_iterator<std::vector<uint8_t> const> it2;
+    [[maybe_unused]] seqan3::detail::random_access_iterator<std::vector<uint8_t>> it;
+    [[maybe_unused]] seqan3::detail::random_access_iterator<std::vector<uint8_t> const> it2;
 }
 
 // constructor with empty container reference
@@ -125,10 +125,10 @@ TEST_F(random_access_iterator_test_fixture, cp_constructor1)
 {
     // non-const container
     seqan3::detail::random_access_iterator<std::vector<uint8_t>> it_base(v_empty);
-    seqan3::detail::random_access_iterator<std::vector<uint8_t>> it_derivate(it_base);
+    [[maybe_unused]] seqan3::detail::random_access_iterator<std::vector<uint8_t>> it_derivate(it_base);
     // const container
     seqan3::detail::random_access_iterator<std::vector<uint8_t> const> it_base2(v_const_empty);
-    seqan3::detail::random_access_iterator<std::vector<uint8_t> const> it_derivate2(it_base2);
+    [[maybe_unused]] seqan3::detail::random_access_iterator<std::vector<uint8_t> const> it_derivate2(it_base2);
 }
 
 // copy constructor with non-empty container reference


### PR DESCRIPTION
```c++
/seqan3/test/unit/range/detail/random_access_iterator_test.cpp:82:66: error: unused variable 'it' [-Werror,-Wunused-variable]
    seqan3::detail::random_access_iterator<std::vector<uint8_t>> it;
                                                                 ^
/seqan3/test/unit/range/detail/random_access_iterator_test.cpp:83:72: error: unused variable 'it2' [-Werror,-Wunused-variable]
    seqan3::detail::random_access_iterator<std::vector<uint8_t> const> it2;
                                                                       ^
/seqan3/test/unit/range/detail/random_access_iterator_test.cpp:128:66: error: unused variable 'it_derivate' [-Werror,-Wunused-variable]
    seqan3::detail::random_access_iterator<std::vector<uint8_t>> it_derivate(it_base);
                                                                 ^
/seqan3/test/unit/range/detail/random_access_iterator_test.cpp:131:72: error: unused variable 'it_derivate2' [-Werror,-Wunused-variable]
    seqan3::detail::random_access_iterator<std::vector<uint8_t> const> it_derivate2(it_base2);
                                                                       ^
```

```c++
seqan3/test/unit/range/container/aligned_allocator_test.cpp:68:42: error: unused variable 'alloc' [-Werror,-Wunused-variable]
    constexpr aligned_allocator<int, 16> alloc{};
                                         ^
seqan3/test/unit/range/container/aligned_allocator_test.cpp:74:34: error: unused variable 'float_alloc' [-Werror,-Wunused-variable]
    aligned_allocator<float, 16> float_alloc{int_alloc};
                                 ^
```