### PR TITLE
[fix] clang: variable is uninitialized when used here

### DIFF
--- a/test/unit/range/detail/random_access_iterator_test.cpp
+++ b/test/unit/range/detail/random_access_iterator_test.cpp
@@ -216,12 +216,12 @@ TEST_F(random_access_iterator_test_fixture, cp_destructor)
     // non-const
     using iterator_type = typename seqan3::detail::random_access_iterator<std::vector<uint8_t>>;
     iterator_type it(v_empty);
-    iterator_type * it_ptr;
+    iterator_type * it_ptr = &it;
     it_ptr->iterator_type::~iterator_type();
     // const
     using iterator_type2 = typename seqan3::detail::random_access_iterator<std::vector<uint8_t> const>;
     iterator_type2 it2(v_const_empty);
-    iterator_type2 * it_ptr2;
+    iterator_type2 * it_ptr2 = &it2;
     it_ptr2->iterator_type2::~iterator_type2();
 
 }


### PR DESCRIPTION
```c++
/seqan3/test/unit/range/detail/random_access_iterator_test.cpp:220:5: error: variable 'it_ptr' is uninitialized when used here [-Werror,-Wuninitialized]
    it_ptr->iterator_type::~iterator_type();
    ^~~~~~
/seqan3/test/unit/range/detail/random_access_iterator_test.cpp:219:27: note: initialize the variable 'it_ptr' to silence this warning
    iterator_type * it_ptr;
                          ^
                           = nullptr
/seqan3/test/unit/range/detail/random_access_iterator_test.cpp:225:5: error: variable 'it_ptr2' is uninitialized when used here [-Werror,-Wuninitialized]
    it_ptr2->iterator_type2::~iterator_type2();
    ^~~~~~~
/seqan3/test/unit/range/detail/random_access_iterator_test.cpp:224:29: note: initialize the variable 'it_ptr2' to silence this warning
    iterator_type2 * it_ptr2;
                            ^
                             = nullptr
```