### PR TITLE
[fix] clang: use source-level subsumption

### DIFF
--- a/include/seqan3/core/metafunction/range.hpp
+++ b/include/seqan3/core/metafunction/range.hpp
@@ -231,7 +231,9 @@ using innermost_value_type_t = typename innermost_value_type<t>::type;
  * returns.
  */
 template <typename t>
+//!\cond
     requires detail::has_value_type<t>
+//!\endcond
 constexpr size_t dimension_v = 1;
 
 //!\cond

--- a/include/seqan3/core/metafunction/range.hpp
+++ b/include/seqan3/core/metafunction/range.hpp
@@ -231,13 +231,8 @@ using innermost_value_type_t = typename innermost_value_type<t>::type;
  * returns.
  */
 template <typename t>
-constexpr size_t dimension_v = 0;
-
-template <typename t>
-//!\cond
     requires detail::has_value_type<t>
-//!\endcond
-constexpr size_t dimension_v<t> = 1;
+constexpr size_t dimension_v = 1;
 
 //!\cond
 template <typename t>

--- a/include/seqan3/core/metafunction/range.hpp
+++ b/include/seqan3/core/metafunction/range.hpp
@@ -241,10 +241,7 @@ constexpr size_t dimension_v<t> = 1;
 
 //!\cond
 template <typename t>
-    requires detail::has_value_type<t> && requires
-    {
-        typename value_type_t<remove_cvref_t<value_type_t<remove_cvref_t<t>>>>;
-    }
+    requires detail::has_value_type<t> && detail::has_value_type<value_type_t<remove_cvref_t<t>>>
 constexpr size_t dimension_v<t> = dimension_v<value_type_t<remove_cvref_t<t>>> + 1;
 //!\endcond
 

--- a/include/seqan3/core/metafunction/range.hpp
+++ b/include/seqan3/core/metafunction/range.hpp
@@ -190,11 +190,10 @@ struct size_type<rng_t>
  * Attention, this metafunction implicitly removes cv-qualifiers on the all value_types except the one returned.
  */
 template <typename t>
-struct innermost_value_type;
-
-template <typename t>
+//!\cond
     requires detail::has_value_type<t>
-struct innermost_value_type<t>
+//!\endcond
+struct innermost_value_type
 {
     //!\brief The return type (recursion not shown).
     using type = value_type_t<remove_cvref_t<t>>;
@@ -202,10 +201,7 @@ struct innermost_value_type<t>
 
 //!\cond
 template <typename t>
-    requires detail::has_value_type<t> && requires
-    {
-        typename value_type_t<remove_cvref_t<value_type_t<remove_cvref_t<t>>>>;
-    }
+    requires detail::has_value_type<t> && detail::has_value_type<value_type_t<remove_cvref_t<t>>>
 struct innermost_value_type<t>
 {
     using type = typename innermost_value_type<value_type_t<remove_cvref_t<t>>>::type;


### PR DESCRIPTION
fixes #524; a problem with normalization of constaints