### PR TITLE
[feature] for_each on parameter packs

### DIFF
--- a/include/seqan3/core/algorithm/all.hpp
+++ b/include/seqan3/core/algorithm/all.hpp
@@ -48,3 +48,4 @@
 #include <seqan3/core/algorithm/concept.hpp>
 #include <seqan3/core/algorithm/configuration.hpp>
 #include <seqan3/core/algorithm/deferred_config_element_base.hpp>
+#include <seqan3/core/algorithm/parameter_pack.hpp>

--- a/include/seqan3/core/algorithm/parameter_pack.hpp
+++ b/include/seqan3/core/algorithm/parameter_pack.hpp
@@ -24,8 +24,9 @@ namespace seqan3::detail
  * \param  fn               The function to call on every argument.
  * \param  args             The arguments as parameter pack.
  *
- * \details This function behaves like std::for_each but on parameter packs.
- * The invocation will be done without any loop.
+ * \details
+ *
+ * This function behaves like std::for_each but on parameter packs. The invocation will be done without any loop.
  *
  * \include test/snippet/core/algorithm/for_each_value.cpp
  */
@@ -46,8 +47,10 @@ constexpr void for_each_value(unary_function_t && fn, args_t && ...args)
  *
  * \param  fn               The function to call on every std::type_identity<type>.
  *
- * \details This function behaves like std::for_each but on types. The type will be wrapped into std::type_identity and
- * passed as argument. The invocation will be done without any loop.
+ * \details
+ *
+ * This function behaves like std::for_each but on types. The type will be wrapped into std::type_identity and passed as
+ * argument. The invocation will be done without any loop.
  *
  * \include test/snippet/core/algorithm/for_each_type.cpp
  */
@@ -70,8 +73,10 @@ constexpr void for_each_type(unary_function_t && fn)
  * \param  fn               The function to call on every std::type_identity<type>.
  * \param  type_list        The list of types, i.e. seqan3::type_list, std::tuple. [unused]
  *
- * \details This function behaves like std::for_each but on types. The type will be wrapped into std::type_identity and
- * passed as argument. The invocation will be done without any loop.
+ * \details
+ *
+ * This function behaves like std::for_each but on types. The type will be wrapped into std::type_identity and passed as
+ * argument. The invocation will be done without any loop.
  *
  * \include test/snippet/core/algorithm/for_each_type_list.cpp
  */

--- a/include/seqan3/core/algorithm/parameter_pack.hpp
+++ b/include/seqan3/core/algorithm/parameter_pack.hpp
@@ -58,8 +58,7 @@ constexpr void for_each_value(unary_function_t && fn, args_t && ...args)
  * This function behaves like std::for_each but on types. The type will be wrapped into std::type_identity and passed as
  * argument. The invocation(s) will be done without any loop.
  *
- * In contrast to `meta::for_each`, this function can handle types which are incomplete, forward declared and not
- * std::Semiregular.
+ * This function can handle types which are incomplete, forward declared and not std::Semiregular.
  *
  * \include test/snippet/core/algorithm/for_each_type.cpp
  *
@@ -89,8 +88,7 @@ constexpr void for_each_type(unary_function_t && fn)
  * This function behaves like std::for_each but on types. The type will be wrapped into std::type_identity and passed as
  * argument. The invocation(s) will be done without any loop.
  *
- * In contrast to `meta::for_each`, this function can handle types which are incomplete, forward declared and not
- * std::Semiregular.
+ * This function can handle types which are incomplete, forward declared and not std::Semiregular.
  *
  * \include test/snippet/core/algorithm/for_each_type_list.cpp
  *

--- a/include/seqan3/core/algorithm/parameter_pack.hpp
+++ b/include/seqan3/core/algorithm/parameter_pack.hpp
@@ -26,9 +26,15 @@ namespace seqan3::detail
  *
  * \details
  *
- * This function behaves like std::for_each but on parameter packs. The invocation will be done without any loop.
+ * This function behaves like std::for_each but on parameter packs. The invocation(s) will be done without any loop.
  *
  * \include test/snippet/core/algorithm/for_each_value.cpp
+ *
+ * \attention The order of arguments is different to std::for_each. In std::for_each the first argument is a range and
+ * the second one is a callable. Due to limitations with the ordering for parameter packs we had to change this order in
+ * the other way around.
+ *
+ * \sa https://en.cppreference.com/w/cpp/language/parameter_pack
  */
 template <typename unary_function_t, typename ...args_t>
 //!\cond
@@ -50,9 +56,11 @@ constexpr void for_each_value(unary_function_t && fn, args_t && ...args)
  * \details
  *
  * This function behaves like std::for_each but on types. The type will be wrapped into std::type_identity and passed as
- * argument. The invocation will be done without any loop.
+ * argument. The invocation(s) will be done without any loop.
  *
  * \include test/snippet/core/algorithm/for_each_type.cpp
+ *
+ * \sa seqan3::detail::for_each_value
  */
 template <typename ...types, typename unary_function_t>
 //!\cond
@@ -76,9 +84,15 @@ constexpr void for_each_type(unary_function_t && fn)
  * \details
  *
  * This function behaves like std::for_each but on types. The type will be wrapped into std::type_identity and passed as
- * argument. The invocation will be done without any loop.
+ * argument. The invocation(s) will be done without any loop.
  *
  * \include test/snippet/core/algorithm/for_each_type_list.cpp
+ *
+ * \attention The order of arguments is different to std::for_each. In std::for_each the first argument is a range and
+ * the second one is a callable. To make the interface consistent with seqan3::detail::for_each_value we change the
+ * order here, too.
+ *
+ * \sa seqan3::detail::for_each_value
  */
 template <template <typename...> typename type_list_t, typename ...args_t, typename unary_function_t>
 //!\cond

--- a/include/seqan3/core/algorithm/parameter_pack.hpp
+++ b/include/seqan3/core/algorithm/parameter_pack.hpp
@@ -1,0 +1,81 @@
+
+#pragma once
+
+#include <utility>
+
+#include <seqan3/std/concepts>
+#include <seqan3/std/type_traits>
+
+namespace seqan3::detail
+{
+
+/*!\brief Applies a function to a range of arguments.
+ * \ingroup algorithm
+ *
+ * \tparam unary_function_t The function type, like function pointers, functors and lambdas.
+ * \tparam ...args_t        The parameter pack of the arguments. (Note that each argument type can be different)
+ *
+ * \param  fn               The function to call on every argument.
+ * \param  args             The arguments as parameter pack.
+ *
+ * \details This function behaves like std::for_each but on parameter packs.
+ * The invocation will be done without any loop.
+ *
+ * \include test/snippet/core/algorithm/for_each_value.cpp
+ */
+template <typename unary_function_t, typename ...args_t>
+//!\cond
+    requires (std::Invocable<unary_function_t, args_t> && ... && true)
+//!\endcond
+constexpr void for_each_value(unary_function_t && fn, args_t && ...args)
+{
+    [[maybe_unused]] int r = (fn(std::forward<args_t>(args)), ..., 0);
+}
+
+/*!\brief Applies a function to a range of types.
+ * \ingroup algorithm
+ *
+ * \tparam ...types         The parameter pack of types.
+ * \tparam unary_function_t The function type, like function pointers, functors and lambdas.
+ *
+ * \param  fn               The function to call on every std::type_identity<type>.
+ *
+ * \details This function behaves like std::for_each but on types. The type will be wrapped into std::type_identity and
+ * passed as argument. The invocation will be done without any loop.
+ *
+ * \include test/snippet/core/algorithm/for_each_type.cpp
+ */
+template <typename ...types, typename unary_function_t>
+//!\cond
+    requires (std::Invocable<unary_function_t, std::type_identity<types>> && ... && true)
+//!\endcond
+constexpr void for_each_type(unary_function_t && fn)
+{
+    for_each_value(std::forward<unary_function_t>(fn), std::type_identity<types>{}...);
+}
+
+/*!\brief Applies a function to a range of types contained in a list.
+ * \ingroup algorithm
+ *
+ * \tparam type_list_t      The name of the list type.
+ * \tparam ...types         The parameter pack of types within a list.
+ * \tparam unary_function_t The function type, like function pointers, functors and lambdas.
+ *
+ * \param  fn               The function to call on every std::type_identity<type>.
+ * \param  type_list        The list of types, i.e. seqan3::type_list, std::tuple. [unused]
+ *
+ * \details This function behaves like std::for_each but on types. The type will be wrapped into std::type_identity and
+ * passed as argument. The invocation will be done without any loop.
+ *
+ * \include test/snippet/core/algorithm/for_each_type_list.cpp
+ */
+template <template <typename...> typename type_list_t, typename ...args_t, typename unary_function_t>
+//!\cond
+    requires (std::Invocable<unary_function_t, std::type_identity<args_t>> && ... && true)
+//!\endcond
+constexpr void for_each_type(unary_function_t && fn, type_list_t<args_t...> const & SEQAN3_DOXYGEN_ONLY(type_list))
+{
+    for_each_type<args_t...>(std::forward<unary_function_t>(fn));
+}
+
+} // namespace seqan3::detail

--- a/include/seqan3/core/algorithm/parameter_pack.hpp
+++ b/include/seqan3/core/algorithm/parameter_pack.hpp
@@ -1,3 +1,9 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2018, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2018, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
 
 #pragma once
 

--- a/include/seqan3/core/algorithm/parameter_pack.hpp
+++ b/include/seqan3/core/algorithm/parameter_pack.hpp
@@ -31,7 +31,7 @@ namespace seqan3::detail
  * \include test/snippet/core/algorithm/for_each_value.cpp
  *
  * \attention The order of arguments is different to std::for_each. In std::for_each the first argument is a range and
- * the second one is a callable. Due to limitations with the ordering for parameter packs we had to change this order in
+ * the second one is a callable. Due to limitations with the ordering for parameter packs the order is the other way around.
  * the other way around.
  *
  * \sa https://en.cppreference.com/w/cpp/language/parameter_pack
@@ -95,7 +95,7 @@ constexpr void for_each_type(unary_function_t && fn)
  * \include test/snippet/core/algorithm/for_each_type_list.cpp
  *
  * \attention The order of arguments is different to std::for_each. In std::for_each the first argument is a range and
- * the second one is a callable. To make the interface consistent with seqan3::detail::for_each_value we change the
+ * the second one is a callable. To make the interface consistent with seqan3::detail::for_each_value the order is changed.
  * order here, too.
  *
  * \sa seqan3::detail::for_each_value

--- a/include/seqan3/core/algorithm/parameter_pack.hpp
+++ b/include/seqan3/core/algorithm/parameter_pack.hpp
@@ -58,6 +58,9 @@ constexpr void for_each_value(unary_function_t && fn, args_t && ...args)
  * This function behaves like std::for_each but on types. The type will be wrapped into std::type_identity and passed as
  * argument. The invocation(s) will be done without any loop.
  *
+ * In contrast to `meta::for_each`, this function can handle types which are incomplete, forward declared and not
+ * std::Semiregular.
+ *
  * \include test/snippet/core/algorithm/for_each_type.cpp
  *
  * \sa seqan3::detail::for_each_value
@@ -85,6 +88,9 @@ constexpr void for_each_type(unary_function_t && fn)
  *
  * This function behaves like std::for_each but on types. The type will be wrapped into std::type_identity and passed as
  * argument. The invocation(s) will be done without any loop.
+ *
+ * In contrast to `meta::for_each`, this function can handle types which are incomplete, forward declared and not
+ * std::Semiregular.
  *
  * \include test/snippet/core/algorithm/for_each_type_list.cpp
  *

--- a/test/snippet/core/algorithm/for_each_type.cpp
+++ b/test/snippet/core/algorithm/for_each_type.cpp
@@ -15,19 +15,17 @@ int main()
     // };
     auto fn = [](auto id)
     {
-        using type = typename decltype(id)::type;
-
         // id is of type std::type_identity<type>
         using id_t = decltype(id);
-        static_assert(std::is_same_v<id_t, std::type_identity<type>>);
+        using type = typename id_t::type;
+
+        static_assert(std::is_same_v<id_t, std::type_identity<type>>, "id is of type std::type_identity<type>");
 
         if constexpr(std::is_same_v<type, bool>)
             debug_stream << "bool";
-
-        if constexpr(std::is_same_v<type, int>)
+        else if constexpr(std::is_same_v<type, int>)
             debug_stream << "int";
-
-        if constexpr(std::is_same_v<type, float>)
+        else if constexpr(std::is_same_v<type, float>)
             debug_stream << "float";
 
         debug_stream << ", ";

--- a/test/snippet/core/algorithm/for_each_type.cpp
+++ b/test/snippet/core/algorithm/for_each_type.cpp
@@ -1,0 +1,46 @@
+#include <iostream>
+#include <string>
+
+#include <seqan3/core/algorithm/parameter_pack.hpp>
+#include <seqan3/io/stream/debug_stream.hpp>
+
+using namespace seqan3;
+
+int main()
+{
+    // With c++20 you could also write it like this
+    // auto fn = []<typename type>(std::type_identity<type>)
+    // {
+    // ...
+    // };
+    auto fn = [](auto id)
+    {
+        using type = typename decltype(id)::type;
+
+        // id is of type std::type_identity<type>
+        using id_t = decltype(id);
+        static_assert(std::is_same_v<id_t, std::type_identity<type>>);
+
+        if constexpr(std::is_same_v<type, bool>)
+            debug_stream << "bool";
+
+        if constexpr(std::is_same_v<type, int>)
+            debug_stream << "int";
+
+        if constexpr(std::is_same_v<type, float>)
+            debug_stream << "float";
+
+        debug_stream << ", ";
+    };
+
+    // prints each type name, i.e. "int, float, bool, \n"
+    detail::for_each_type<int, float, bool>(fn);
+    debug_stream << "\n";
+
+    // is the same as explicitly writing
+    fn(std::type_identity<int>{});
+    fn(std::type_identity<float>{});
+    fn(std::type_identity<bool>{});
+    debug_stream << "\n";
+    return 0;
+}

--- a/test/snippet/core/algorithm/for_each_type.cpp
+++ b/test/snippet/core/algorithm/for_each_type.cpp
@@ -6,6 +6,13 @@
 
 using namespace seqan3;
 
+namespace incomplete
+{
+
+struct type;
+
+} // namespace incomplete
+
 int main()
 {
     // With c++20 you could also write it like this
@@ -27,18 +34,21 @@ int main()
             debug_stream << "int";
         else if constexpr(std::is_same_v<type, float>)
             debug_stream << "float";
+        else if constexpr(std::is_same_v<type, incomplete::type>)
+            debug_stream << "incomplete::type";
 
         debug_stream << ", ";
     };
 
-    // prints each type name, i.e. "int, float, bool, \n"
-    detail::for_each_type<int, float, bool>(fn);
+    // prints each type name, i.e. "int, float, bool, incomplete::type, \n"
+    detail::for_each_type<int, float, bool, incomplete::type>(fn);
     debug_stream << "\n";
 
     // is the same as explicitly writing
     fn(std::type_identity<int>{});
     fn(std::type_identity<float>{});
     fn(std::type_identity<bool>{});
+    fn(std::type_identity<incomplete::type>{});
     debug_stream << "\n";
     return 0;
 }

--- a/test/snippet/core/algorithm/for_each_type_list.cpp
+++ b/test/snippet/core/algorithm/for_each_type_list.cpp
@@ -1,0 +1,48 @@
+#include <iostream>
+#include <string>
+
+#include <seqan3/core/algorithm/parameter_pack.hpp>
+#include <seqan3/core/type_list.hpp>
+#include <seqan3/io/stream/debug_stream.hpp>
+
+using namespace seqan3;
+
+int main()
+{
+    // With c++20 you could also write it like this
+    // auto fn = []<typename type>(std::type_identity<type>)
+    // {
+    // ...
+    // };
+    auto fn = [](auto id)
+    {
+        using type = typename decltype(id)::type;
+
+        // id is of type std::type_identity<type>
+        using id_t = decltype(id);
+        static_assert(std::is_same_v<id_t, std::type_identity<type>>);
+
+        if constexpr(std::is_same_v<type, bool>)
+            debug_stream << "bool";
+
+        if constexpr(std::is_same_v<type, int>)
+            debug_stream << "int";
+
+        if constexpr(std::is_same_v<type, float>)
+            debug_stream << "float";
+
+        debug_stream << ", ";
+    };
+
+    // prints each type name, i.e. "int, float, bool, \n"
+    using types = type_list<int, float, bool>;
+    detail::for_each_type(fn, types{});
+    debug_stream << "\n";
+
+    // is the same as explicitly writing
+    fn(std::type_identity<int>{});
+    fn(std::type_identity<float>{});
+    fn(std::type_identity<bool>{});
+    debug_stream << "\n";
+    return 0;
+}

--- a/test/snippet/core/algorithm/for_each_type_list.cpp
+++ b/test/snippet/core/algorithm/for_each_type_list.cpp
@@ -16,19 +16,17 @@ int main()
     // };
     auto fn = [](auto id)
     {
-        using type = typename decltype(id)::type;
-
         // id is of type std::type_identity<type>
         using id_t = decltype(id);
-        static_assert(std::is_same_v<id_t, std::type_identity<type>>);
+        using type = typename id_t::type;
+
+        static_assert(std::is_same_v<id_t, std::type_identity<type>>, "id is of type std::type_identity<type>");
 
         if constexpr(std::is_same_v<type, bool>)
             debug_stream << "bool";
-
-        if constexpr(std::is_same_v<type, int>)
+        else if constexpr(std::is_same_v<type, int>)
             debug_stream << "int";
-
-        if constexpr(std::is_same_v<type, float>)
+        else if constexpr(std::is_same_v<type, float>)
             debug_stream << "float";
 
         debug_stream << ", ";

--- a/test/snippet/core/algorithm/for_each_type_list.cpp
+++ b/test/snippet/core/algorithm/for_each_type_list.cpp
@@ -7,6 +7,13 @@
 
 using namespace seqan3;
 
+namespace incomplete
+{
+
+struct type;
+
+} // namespace incomplete
+
 int main()
 {
     // With c++20 you could also write it like this
@@ -28,12 +35,14 @@ int main()
             debug_stream << "int";
         else if constexpr(std::is_same_v<type, float>)
             debug_stream << "float";
+        else if constexpr(std::is_same_v<type, incomplete::type>)
+            debug_stream << "incomplete::type";
 
         debug_stream << ", ";
     };
 
-    // prints each type name, i.e. "int, float, bool, \n"
-    using types = type_list<int, float, bool>;
+    // prints each type name, i.e. "int, float, bool, incomplete::type, \n"
+    using types = type_list<int, float, bool, incomplete::type>;
     detail::for_each_type(fn, types{});
     debug_stream << "\n";
 
@@ -41,6 +50,7 @@ int main()
     fn(std::type_identity<int>{});
     fn(std::type_identity<float>{});
     fn(std::type_identity<bool>{});
+    fn(std::type_identity<incomplete::type>{});
     debug_stream << "\n";
     return 0;
 }

--- a/test/snippet/core/algorithm/for_each_value.cpp
+++ b/test/snippet/core/algorithm/for_each_value.cpp
@@ -1,0 +1,27 @@
+#include <iostream>
+#include <string>
+
+#include <seqan3/core/algorithm/parameter_pack.hpp>
+#include <seqan3/io/stream/debug_stream.hpp>
+
+using namespace seqan3;
+
+int main()
+{
+    auto fn = [](auto && a)
+    {
+        debug_stream << a;
+    };
+
+    // prints each argument, i.e. "0, 1, 2, 3\n"
+    detail::for_each_value(fn, 0, ", ", 1.0, ", ", std::string{"2, 3"}, '\n');
+
+    // is the same as explicitly writing
+    fn(0);
+    fn(", ");
+    fn(1.0);
+    fn(", ");
+    fn(std::string{"2, 3"});
+    fn('\n');
+    return 0;
+}

--- a/test/unit/core/algorithm/CMakeLists.txt
+++ b/test/unit/core/algorithm/CMakeLists.txt
@@ -1,2 +1,3 @@
 seqan3_test (configuration_test.cpp)
 seqan3_test (deferred_config_element_base_test.cpp)
+seqan3_test (parameter_pack_test.cpp)

--- a/test/unit/core/algorithm/parameter_pack_test.cpp
+++ b/test/unit/core/algorithm/parameter_pack_test.cpp
@@ -1,0 +1,198 @@
+// ============================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ============================================================================
+//
+// Copyright (c) 2006-2018, Knut Reinert & Freie Universitaet Berlin
+// Copyright (c) 2016-2018, Knut Reinert & MPI Molekulare Genetik
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ============================================================================
+
+#include <gtest/gtest.h>
+
+#include <seqan3/alphabet/nucleotide/dna4.hpp>
+#include <seqan3/core/algorithm/parameter_pack.hpp>
+#include <seqan3/core/type_list.hpp>
+#include <seqan3/io/stream/debug_stream.hpp>
+
+using namespace seqan3;
+
+TEST(parameter_pack, for_each_value)
+{
+    int i = 0;
+    auto fn = [&i](int arg)
+    {
+        EXPECT_EQ(i, arg);
+        ++i;
+    };
+
+    detail::for_each_value(fn);
+    EXPECT_EQ(i, 0);
+    detail::for_each_value(fn, 0);
+    EXPECT_EQ(i, 1);
+    detail::for_each_value(fn, 1, 2);
+    EXPECT_EQ(i, 3);
+    detail::for_each_value(fn, 3, 4, 5);
+    EXPECT_EQ(i, 6);
+}
+
+TEST(parameter_pack, for_each_value2)
+{
+    std::stringstream s{};
+    debug_stream_type stream{s};
+
+    auto fn = [&stream](auto && arg)
+    {
+        stream << arg << ";";
+    };
+
+    detail::for_each_value(fn);
+    detail::for_each_value(fn, 0);
+    detail::for_each_value(fn, 1.0, '2');
+    detail::for_each_value(fn, "3;4", -5, 'C'_dna4);
+
+    EXPECT_EQ(s.str(), "0;1;2;3;4;-5;C;");
+}
+
+TEST(parameter_pack, for_each_type)
+{
+    std::stringstream s{};
+    debug_stream_type stream{s};
+
+    auto fn = [&stream](auto id)
+    {
+        using type = typename decltype(id)::type;
+
+        // id is of type std::type_identity<type>
+        using id_t = decltype(id);
+        static_assert(std::is_same_v<id_t, std::type_identity<type>>);
+
+        if constexpr (std::is_same_v<type, bool>)
+            stream << type{0} << ";";
+        if constexpr (std::is_same_v<type, uint8_t>)
+            stream << type{1} << ";";
+        if constexpr (std::is_same_v<type, int8_t>)
+            stream << type{-1} << ";";
+        if constexpr (std::is_same_v<type, uint16_t>)
+            stream << type{2} << ";";
+        if constexpr (std::is_same_v<type, int16_t>)
+            stream << type{-2} << ";";
+        if constexpr (std::is_same_v<type, uint32_t>)
+            stream << type{3} << ";";
+        if constexpr (std::is_same_v<type, int32_t>)
+            stream << type{-3} << ";";
+        if constexpr (std::is_same_v<type, uint64_t>)
+            stream << type{4} << ";";
+        if constexpr (std::is_same_v<type, int64_t>)
+            stream << type{-4} << ";";
+    };
+
+    detail::for_each_type<bool, uint8_t, int8_t, uint16_t, int16_t,
+                          uint32_t, int32_t, uint64_t, int64_t>(fn);
+
+    EXPECT_EQ(s.str(), "0;1;-1;2;-2;3;-3;4;-4;");
+}
+
+TEST(type_list, for_each_type)
+{
+    std::stringstream s{};
+    debug_stream_type stream{s};
+
+    auto fn = [&stream](auto id)
+    {
+        using type = typename decltype(id)::type;
+
+        // id is of type std::type_identity<type>
+        using id_t = decltype(id);
+        static_assert(std::is_same_v<id_t, std::type_identity<type>>);
+
+        if constexpr (std::is_same_v<type, bool>)
+            stream << type{0} << ";";
+        if constexpr (std::is_same_v<type, uint8_t>)
+            stream << type{1} << ";";
+        if constexpr (std::is_same_v<type, int8_t>)
+            stream << type{-1} << ";";
+        if constexpr (std::is_same_v<type, uint16_t>)
+            stream << type{2} << ";";
+        if constexpr (std::is_same_v<type, int16_t>)
+            stream << type{-2} << ";";
+        if constexpr (std::is_same_v<type, uint32_t>)
+            stream << type{3} << ";";
+        if constexpr (std::is_same_v<type, int32_t>)
+            stream << type{-3} << ";";
+        if constexpr (std::is_same_v<type, uint64_t>)
+            stream << type{4} << ";";
+        if constexpr (std::is_same_v<type, int64_t>)
+            stream << type{-4} << ";";
+    };
+
+    using types = type_list<bool, uint8_t, int8_t, uint16_t, int16_t,
+                            uint32_t, int32_t, uint64_t, int64_t>;
+    detail::for_each_type(fn, types{});
+
+    EXPECT_EQ(s.str(), "0;1;-1;2;-2;3;-3;4;-4;");
+}
+
+TEST(tuple, for_each_type)
+{
+    std::stringstream s{};
+    debug_stream_type stream{s};
+
+    auto fn = [&stream](auto id)
+    {
+        using type = typename decltype(id)::type;
+
+        // id is of type std::type_identity<type>
+        using id_t = decltype(id);
+        static_assert(std::is_same_v<id_t, std::type_identity<type>>);
+
+        if constexpr (std::is_same_v<type, bool>)
+            stream << type{0} << ";";
+        if constexpr (std::is_same_v<type, uint8_t>)
+            stream << type{1} << ";";
+        if constexpr (std::is_same_v<type, int8_t>)
+            stream << type{-1} << ";";
+        if constexpr (std::is_same_v<type, uint16_t>)
+            stream << type{2} << ";";
+        if constexpr (std::is_same_v<type, int16_t>)
+            stream << type{-2} << ";";
+        if constexpr (std::is_same_v<type, uint32_t>)
+            stream << type{3} << ";";
+        if constexpr (std::is_same_v<type, int32_t>)
+            stream << type{-3} << ";";
+        if constexpr (std::is_same_v<type, uint64_t>)
+            stream << type{4} << ";";
+        if constexpr (std::is_same_v<type, int64_t>)
+            stream << type{-4} << ";";
+    };
+
+    using tuple = std::tuple<bool, uint8_t, int8_t, uint16_t, int16_t,
+                             uint32_t, int32_t, uint64_t, int64_t>;
+    detail::for_each_type(fn, tuple{});
+
+    EXPECT_EQ(s.str(), "0;1;-1;2;-2;3;-3;4;-4;");
+}

--- a/test/unit/core/algorithm/parameter_pack_test.cpp
+++ b/test/unit/core/algorithm/parameter_pack_test.cpp
@@ -1,36 +1,9 @@
-// ============================================================================
-//                 SeqAn - The Library for Sequence Analysis
-// ============================================================================
-//
-// Copyright (c) 2006-2018, Knut Reinert & Freie Universitaet Berlin
-// Copyright (c) 2016-2018, Knut Reinert & MPI Molekulare Genetik
-// All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-//
-//     * Redistributions of source code must retain the above copyright
-//       notice, this list of conditions and the following disclaimer.
-//     * Redistributions in binary form must reproduce the above copyright
-//       notice, this list of conditions and the following disclaimer in the
-//       documentation and/or other materials provided with the distribution.
-//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
-//       its contributors may be used to endorse or promote products derived
-//       from this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
-// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
-// DAMAGE.
-//
-// ============================================================================
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2018, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2018, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
 
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
Allow applying a function to each argument of a parameter pack.

An example:

```c++
#include <iostream>
#include <string>

#include <seqan3/core/algorithm/parameter_pack.hpp>
#include <seqan3/io/stream/debug_stream.hpp>

using namespace seqan3;

int main()
{
    auto fn = [](auto && a)
    {
        debug_stream << a;
    };

    // prints each argument, i.e. "0, 1, 2, 3\n"
    detail::parameter_pack_for_each(fn, 0, ", ", 1.0, ", ", std::string{"2, 3"}, '\n');

    // is the same as explicitly writing
    fn(0);
    fn(", ");
    fn(1.0);
    fn(", ");
    fn(std::string{"2, 3"});
    fn('\n');
    return 0;
}
```