### PR TITLE
[FIX] Fixes scoring scheme matrix size type.

### DIFF
--- a/include/seqan3/alignment/scoring/scoring_scheme_base.hpp
+++ b/include/seqan3/alignment/scoring/scoring_scheme_base.hpp
@@ -125,7 +125,7 @@ public:
     //!\brief Type of the score values.
     using score_type = score_t;
     //!\brief Size type that can hold the dimension of the matrix (i.e. size of the alphabet).
-    using matrix_size_type = uint8_t;
+    using matrix_size_type = std::remove_const_t<decltype(alphabet_size_v<alphabet_t>)>;
     //!\}
 
     //!\brief Size of the matrix dimensions (i.e. size of the alphabet).


### PR DESCRIPTION
Some minor fix for scoring schemes.
Currntly the size type for the scoring scheme matrix is fixed to uint8_t, which won't work for char alphabets. 
To make it generic the matrix size type should be dependent to the size type that can hold the size of the alphabet. While char adaptions already exposed a type in the alphabet_size value meta function, the other alphabets did not. 
This fix adds the type alias for the alphabet_size value meta function.