### PR TITLE
Comparison seqan2 and seqan3 for fasta I/O

### DIFF
--- a/test/performance/io/CMakeLists.txt
+++ b/test/performance/io/CMakeLists.txt
@@ -1,3 +1,4 @@
 seqan3_benchmark(stream_input_benchmark.cpp)
 seqan3_benchmark(stream_output_benchmark.cpp)
 seqan3_benchmark(parse_condition_benchmark.cpp)
+seqan3_benchmark(format_fasta_benchmark.cpp)

--- a/test/performance/io/format_fasta_benchmark.cpp
+++ b/test/performance/io/format_fasta_benchmark.cpp
@@ -1,0 +1,112 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+#if __has_include(<seqan/seq_io.h>)
+    #include <seqan/seq_io.h>
+#endif
+
+#include <algorithm>
+#include <cctype>
+#include <cstring>
+
+#include <benchmark/benchmark.h>
+
+#include <range/v3/algorithm/equal.hpp>
+#include <range/v3/view/transform.hpp>
+
+#include <seqan3/alphabet/quality/all.hpp>
+#include <seqan3/io/sequence_file/input.hpp>
+#include <seqan3/io/sequence_file/input_format_concept.hpp>
+#include <seqan3/io/sequence_file/output.hpp>
+#include <seqan3/io/sequence_file/output_format_concept.hpp>
+#include <seqan3/io/sequence_file/format_fasta.hpp>
+#include <seqan3/range/view/convert.hpp>
+
+#include <sstream>
+
+using namespace seqan3;
+
+void write3(benchmark::State & state)
+{
+    std::ostringstream ostream;
+    sequence_file_format_fasta format;
+    sequence_file_output_options options;
+    std::string id{"seq"};
+    dna5_vector seq{"ACTAGACTAGCTACGATCAGCTACGATCAGCTACGA"_dna5};
+
+    for (auto _ : state)
+    {
+        format.write(ostream, options, seq, id, std::ignore);
+    }
+}
+
+BENCHMARK(write3);
+
+#if __has_include(<seqan/seq_io.h>)
+
+void write2(benchmark::State & state)
+{
+    std::ostringstream outStream;
+    seqan::CharString meta = "seq";
+    seqan::Dna5String seq = "ACTAGACTAGCTACGATCAGCTACGATCAGCTACGA";
+
+    for (auto _ : state)
+    {
+        seqan::writeRecord(outStream, meta, seq, seqan::Fasta());
+    }
+}
+
+BENCHMARK(write2);
+#endif
+
+void read3(benchmark::State & state)
+{
+    std::string dummy_file{};
+    for (size_t idx = 0; idx < 10000000; idx++)
+        dummy_file += ">seq\nACTAGACTAGCTACGATCAGCTACGATCAGCTACGA\n";
+    std::istringstream istream{dummy_file};
+    sequence_file_format_fasta format;
+    sequence_file_input_options<dna5, false> options;
+    std::string id;
+    dna5_vector seq;
+    for (auto _ : state)
+    {
+        format.read(istream, options, seq, id, std::ignore);
+	    id.clear();
+	    seq.clear();
+    }
+}
+BENCHMARK(read3);
+
+#if __has_include(<seqan/seq_io.h>)
+
+#include <fstream>
+
+void read2(benchmark::State & state)
+{
+    seqan::CharString meta;
+    seqan::Dna5String seq;
+    std::string dummy_file{};
+    for (size_t idx = 0; idx < 10000000; idx++)
+        dummy_file += ">seq\nACTAGACTAGCTACGATCAGCTACGATCAGCTACGA\n";
+    std::istringstream istream{dummy_file};
+
+    seqan::VirtualStream<char, seqan::Input> comp;
+    open(comp, istream);
+    auto it = seqan::directionIterator(comp, seqan::Input());
+
+    for (auto _ : state)
+    {
+        readRecord(meta, seq,  it, seqan::Fasta{});
+        clear(meta);
+        clear(seq);
+    }
+}
+BENCHMARK(read2);
+#endif
+
+BENCHMARK_MAIN();


### PR DESCRIPTION
As you can see in the benchmark, I compare reading and writing of fasta files in seqan2 and seqan3. The results for the same input are (write2 and read2 are referring to seqan2):

write 31715 ns 31715 ns 19368
write2 506 ns 506 ns 1361641
read 38040 ns 38039 ns 18167
read2 2368 ns 2367 ns 300955

So, it looks like seqan3 is slower.