### PR TITLE
Stream sequence alignments in multi-line representation

### DIFF
--- a/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
+++ b/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
@@ -299,7 +299,6 @@ template<tuple_like_concept alignment_t, size_t ...idx>
 void stream_alignment(debug_stream_type & stream, alignment_t const & align, std::index_sequence<idx...> const & /**/)
 {
     size_t const alignment_size = std::get<0>(align).size();
-    char const * indent = "        ";
 
     // split alignment into blocks of length 50 and loop over parts
     for (size_t begin_pos = 0; begin_pos < alignment_size; begin_pos += 50)
@@ -322,19 +321,19 @@ void stream_alignment(debug_stream_type & stream, alignment_t const & align, std
         }
 
         // write first sequence
-        stream << '\n' << indent;
+        stream << '\n' << std::setw(8) << "";
         ranges::for_each(std::get<0>(align) | ranges::view::slice(begin_pos, end_pos) | view::to_char,
                          [&stream] (char ch) { stream << ch; });
 
         auto stream_f = [&] (auto const & previous_seq, auto const & aligned_seq)
         {
             // write alignment bars
-            stream << '\n' << indent;
+            stream << '\n' << std::setw(8) << "";
             ranges::for_each(ranges::zip_view(previous_seq, aligned_seq) | ranges::view::slice(begin_pos, end_pos),
-                             [&stream] (auto ch) { stream << (std::get<0>(ch) == std::get<1>(ch) ? '|' : ' '); });
+                             [&stream] (auto && ch) { stream << (std::get<0>(ch) == std::get<1>(ch) ? '|' : ' '); });
 
             // write next sequence
-            stream << '\n' << indent;
+            stream << '\n' << std::setw(8) << "";
             ranges::for_each(aligned_seq | ranges::view::slice(begin_pos, end_pos) | view::to_char,
                              [&stream] (char ch) { stream << ch; });
         };

--- a/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
+++ b/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
@@ -310,11 +310,11 @@ void stream_alignment(debug_stream_type & stream, alignment_t const & align, std
             stream << '\n';
 
         stream << std::setw(7) << begin_pos << ' ';
-        for (size_t rel_pos = 1; rel_pos <= (end_pos - 1) % 50 + 1; ++rel_pos)
+        for (size_t pos = begin_pos + 1; pos <= end_pos; ++pos)
         {
-            if (rel_pos % 10 == 0)
+            if (pos % 10 == 0)
                 stream << ':';
-            else if (rel_pos % 5 == 0)
+            else if (pos % 5 == 0)
                 stream << '.';
             else
                 stream << ' ';

--- a/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
+++ b/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
@@ -106,7 +106,7 @@ namespace seqan3
  *                         seqan3::aligned_sequence_concept.
  * \param[in,out] seq      The aligned sequence to modify.
  * \param[in]     pos_it   The iterator pointing to the position where to insert a gaps.
- * \param[in]     size     The number of gaps to insert.
+ * \param[in]     size     The number of gap symbols to insert (will result in a gap of length size).
  *
  * \details
  * \attention This is a concept requirement, not an actual function (however types
@@ -200,7 +200,7 @@ inline typename seq_type::iterator insert_gap(seq_type & seq, typename seq_type:
  *                         seqan3::gap.
  * \param[in,out] seq      The container to modify.
  * \param[in]     pos_it   The iterator pointing to the position where to insert gaps.
- * \param[in]     size     The number of gaps to insert.
+ * \param[in]     size     The number of gap symbols to insert (will result in a gap of length size).
  *
  * \relates seqan3::aligned_sequence_concept
  *
@@ -288,8 +288,7 @@ inline typename seq_type::iterator erase_gap(seq_type & seq,
 namespace detail
 {
 
-/*!
- * \brief               Create the formatted alignment output and add it to the provided debug_stream.
+/*!\brief               Create the formatted alignment output and add it to the provided debug_stream.
  * \ingroup             aligned_sequence
  * \tparam alignment_t  The type of the alignment, must satisfy tuple_like_concept.
  * \tparam idx          An index sequence.
@@ -344,15 +343,13 @@ void stream_alignment(debug_stream_type & stream, alignment_t const & align, std
     }
 }
 
-/*!
- * \brief True, if each type satisfies aligned_sequence_concept; false otherwise.
+/*!\brief True, if each type satisfies aligned_sequence_concept; false otherwise.
  * \tparam elems The pack of types to be tested.
  */
 template <typename ...elems>
 inline bool constexpr all_satisfy_aligned_seq = false;
 
-/*!
- * \brief True, if each type satisfies aligned_sequence_concept; false otherwise.
+/*!\brief True, if each type satisfies aligned_sequence_concept; false otherwise.
  * \tparam elems The pack of types to be tested.
  */
 template <typename ...elems>
@@ -360,8 +357,7 @@ inline bool constexpr all_satisfy_aligned_seq<type_list<elems...>> = (aligned_se
 
 } // namespace detail
 
-/*!
- * \brief Streaming operator for alignments, which are represented as tuples of aligned sequences.
+/*!\brief Streaming operator for alignments, which are represented as tuples of aligned sequences.
  * \tparam tuple_t  The alignment type, must satisfy tuple_like_concept and its size must be at least 2.
  * \param stream    The target stream for the formatted output.
  * \param alignment The alignment that shall be formatted. All sequences must be equally long.

--- a/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
+++ b/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
@@ -289,16 +289,17 @@ namespace detail
 {
 
 /*!
- * Create the formatted alignment output and add it to the provided debug_stream.
+ * \brief               Create the formatted alignment output and add it to the provided debug_stream.
  * \tparam alignment_t  The type of the alignment, must satisfy tuple_like_concept.
  * \tparam idx          An index sequence.
- * \param stream        The output stream that receives the formatted alignment.
- * \param align         The alignment that shall be streamed.
+ * \param[in] stream    The output stream that receives the formatted alignment.
+ * \param[in] align     The alignment that shall be streamed.
  */
 template<tuple_like_concept alignment_t, size_t ...idx>
 void stream_alignment(debug_stream_type & stream, alignment_t const & align, std::index_sequence<idx...> const & /**/)
 {
     size_t const alignment_length = std::get<0>(align).size();
+    char const * indent = "        ";
 
     // split alignment into blocks of length 50 and loop over parts
     for (size_t used_length = 0; used_length < alignment_length; used_length += 50)
@@ -319,7 +320,6 @@ void stream_alignment(debug_stream_type & stream, alignment_t const & align, std
         }
 
         // write sequences
-        const char * indent = "        ";
         stream << std::endl << indent;
         size_t const col_end = std::min(used_length + 50, alignment_length);
         ranges::for_each(std::get<0>(align) | ranges::view::slice(used_length, col_end) | view::to_char,
@@ -370,7 +370,9 @@ inline bool constexpr all_satisfy_aligned_seq<type_list<elems...>> = (aligned_se
  * \return          The given stream to which the alignment representation is appended.
  */
 template <tuple_like_concept tuple_t>
-requires all_satisfy_aligned_seq<detail::tuple_type_list_t<tuple_t>>
+//!\cond
+    requires all_satisfy_aligned_seq<detail::tuple_type_list_t<tuple_t>>
+//!\endcond
 inline debug_stream_type & operator<<(debug_stream_type & stream, tuple_t const & alignment)
 {
     static_assert(std::tuple_size_v<tuple_t> >= 2, "An alignment requires at least two sequences.");

--- a/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
+++ b/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
@@ -106,7 +106,7 @@ namespace seqan3
  *                         seqan3::aligned_sequence_concept.
  * \param[in,out] seq      The aligned sequence to modify.
  * \param[in]     pos_it   The iterator pointing to the position where to insert a gaps.
- * \param[in]     size     The number of gap symbols to insert (will result in a gap of length size).
+ * \param[in]     size     The number of gap symbols to insert (will result in a gap of length `size`).
  *
  * \details
  * \attention This is a concept requirement, not an actual function (however types
@@ -200,13 +200,13 @@ inline typename seq_type::iterator insert_gap(seq_type & seq, typename seq_type:
  *                         seqan3::gap.
  * \param[in,out] seq      The container to modify.
  * \param[in]     pos_it   The iterator pointing to the position where to insert gaps.
- * \param[in]     size     The number of gap symbols to insert (will result in a gap of length size).
+ * \param[in]     size     The number of gap symbols to insert (will result in a gap of length `size`).
  *
  * \relates seqan3::aligned_sequence_concept
  *
  * \details
  *
- * This function delegates to the member function `insert(iterator, size, value)`
+ * This function delegates to the member function `insert(iterator, `size`, `value`)`
  * of the container.
  */
 template <sequence_container_concept seq_type>
@@ -298,7 +298,8 @@ namespace detail
 template<tuple_like_concept alignment_t, size_t ...idx>
 void stream_alignment(debug_stream_type & stream, alignment_t const & align, std::index_sequence<idx...> const & /**/)
 {
-    size_t const alignment_size = std::get<0>(align).size();
+    using std::get;
+    size_t const alignment_size = get<0>(align).size();
 
     // split alignment into blocks of length 50 and loop over parts
     for (size_t begin_pos = 0; begin_pos < alignment_size; begin_pos += 50)
@@ -322,7 +323,7 @@ void stream_alignment(debug_stream_type & stream, alignment_t const & align, std
 
         // write first sequence
         stream << '\n' << std::setw(8) << "";
-        ranges::for_each(std::get<0>(align) | ranges::view::slice(begin_pos, end_pos) | view::to_char,
+        ranges::for_each(get<0>(align) | ranges::view::slice(begin_pos, end_pos) | view::to_char,
                          [&stream] (char ch) { stream << ch; });
 
         auto stream_f = [&] (auto const & previous_seq, auto const & aligned_seq)
@@ -330,14 +331,14 @@ void stream_alignment(debug_stream_type & stream, alignment_t const & align, std
             // write alignment bars
             stream << '\n' << std::setw(8) << "";
             ranges::for_each(ranges::zip_view(previous_seq, aligned_seq) | ranges::view::slice(begin_pos, end_pos),
-                             [&stream] (auto && ch) { stream << (std::get<0>(ch) == std::get<1>(ch) ? '|' : ' '); });
+                             [&stream] (auto && ch) { stream << (get<0>(ch) == get<1>(ch) ? '|' : ' '); });
 
             // write next sequence
             stream << '\n' << std::setw(8) << "";
             ranges::for_each(aligned_seq | ranges::view::slice(begin_pos, end_pos) | view::to_char,
                              [&stream] (char ch) { stream << ch; });
         };
-        (stream_f(std::get<idx>(align), std::get<idx + 1>(align)), ...);
+        (stream_f(get<idx>(align), get<idx + 1>(align)), ...);
         stream << '\n';
     }
 }

--- a/test/unit/alignment/aligned_sequence_test.cpp
+++ b/test/unit/alignment/aligned_sequence_test.cpp
@@ -37,6 +37,9 @@
 #include <seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp>
 #include <seqan3/alphabet/all.hpp>
 #include <seqan3/io/alignment_file/detail.hpp>
+#include <seqan3/io/stream/debug_stream.hpp>
+#include <seqan3/range/view/persist.hpp>
+#include <seqan3/range/view/convert.hpp>
 
 using namespace seqan3;
 
@@ -203,4 +206,68 @@ TYPED_TEST(aligned_sequence_test, cigar_string)
         EXPECT_EQ(expected1, detail::get_cigar_string(std::make_pair(ref, read), 0, 0, true));
         EXPECT_EQ(expected2, detail::get_cigar_string(std::make_pair(ref, read), 5, 60, true));
     }
+}
+
+TEST(aligned_sequence_stream, tuple)
+{
+    std::string const expected
+    {
+        "      0     .    :    .    :    .    :    .    :    .    :\n"
+        "        GCGGGTCACTGAGGGCTGGGATGAGGACGGCCACCACTTCGAGGAGTCCC\n"
+        "            | ||      |        |  |       |   |||   |    |\n"
+        "        CTACGGCAGAAGAAGACATCCGAAAAAGCTGACACCTCTCGCCTACAAGC\n"
+        "        ||||||||||||||||||||| || |||||||||||||||||||||||||\n"
+        "        CTACGGCAGAAGAAGACATCCCAAGAAGCTGACACCTCTCGCCTACAAGC\n"
+        "\n"
+        "     50     .    :    .    :    .    :    .    :    .    :\n"
+        "        TTCACTACGAGGGCAGGGCCGTGGACATCACCACGTCAGACAGGGACAAG\n"
+        "            |            || | | | | |     | |   | |     | \n"
+        "        AGTTCATACCTAATGTCGCGGAGAAGACCTTAGGGGCCAGCGGCAGATAC\n"
+        "        |||| |||||||||||||||||||||||||||||||||||||||||||||\n"
+        "        AGTTTATACCTAATGTCGCGGAGAAGACCTTAGGGGCCAGCGGCAGATAC\n"
+        "\n"
+        "    100     .    :    .    :    .    :    .    :\n"
+        "        AGCAAGTACGGCACCCTGTCCAGACTGGCGGTGGAAGCTG\n"
+        "               |    || |          |    |  |||   \n"
+        "        GAGGGCAAGATAACGCGCAATTCGGAGAGATTTAAAGAAC\n"
+        "        ||||||||||| ||||||||||||||||||||||||||||\n"
+        "        GAGGGCAAGATCACGCGCAATTCGGAGAGATTTAAAGAAC\n"
+    };
+
+    std::tuple<std::vector<gapped<dna4>>, std::vector<gapped<dna4>>, std::vector<gapped<dna4>>> const alignment
+    {
+        "GCGGGTCACTGAGGGCTGGGATGAGGACGGCCACCACTTCGAGGAGTCCCTTCACTACGAGGGCAGGGCCGTGGACATCACCACGTCAGACAGGGACAAGAGCAAGTA"
+        "CGGCACCCTGTCCAGACTGGCGGTGGAAGCTG"_dna4 | view::persist | view::convert<gapped<dna4>>,
+        "CTACGGCAGAAGAAGACATCCGAAAAAGCTGACACCTCTCGCCTACAAGCAGTTCATACCTAATGTCGCGGAGAAGACCTTAGGGGCCAGCGGCAGATACGAGGGCAA"
+        "GATAACGCGCAATTCGGAGAGATTTAAAGAAC"_dna4 | view::persist | view::convert<gapped<dna4>>,
+        "CTACGGCAGAAGAAGACATCCCAAGAAGCTGACACCTCTCGCCTACAAGCAGTTTATACCTAATGTCGCGGAGAAGACCTTAGGGGCCAGCGGCAGATACGAGGGCAA"
+        "GATCACGCGCAATTCGGAGAGATTTAAAGAAC"_dna4 | view::persist | view::convert<gapped<dna4>>
+    };
+
+    std::ostringstream oss;
+    debug_stream_type stream{oss};
+    stream << alignment;
+    EXPECT_EQ(expected, oss.str());
+}
+
+TEST(aligned_sequence_stream, pair_of_different_types)
+{
+    std::string const expected
+    {
+        "      0     . \n"
+        "        CUUC-G\n"
+        "        ||   |\n"
+        "        CU-NGG\n"
+    };
+
+    std::pair<std::vector<gapped<rna4>>, std::vector<gapped<rna5>>> const alignment
+    {
+        {'C'_rna4, 'U'_rna4, 'U'_rna4, 'C'_rna4, gap::GAP, 'G'_rna4},
+        {'C'_rna5, 'U'_rna5, gap::GAP, 'N'_rna5, 'G'_rna5, 'G'_rna5}
+    };
+
+    std::ostringstream oss;
+    debug_stream_type stream{oss};
+    stream << alignment;
+    EXPECT_EQ(expected, oss.str());
 }

--- a/test/unit/alignment/aligned_sequence_test.cpp
+++ b/test/unit/alignment/aligned_sequence_test.cpp
@@ -208,7 +208,7 @@ TYPED_TEST(aligned_sequence_test, cigar_string)
     }
 }
 
-TEST(aligned_sequence_stream, tuple)
+TEST(aligned_sequence_stream, multi_without_gaps)
 {
     std::string const expected
     {
@@ -250,7 +250,7 @@ TEST(aligned_sequence_stream, tuple)
     EXPECT_EQ(expected, oss.str());
 }
 
-TEST(aligned_sequence_stream, pair_of_different_types)
+TEST(aligned_sequence_stream, pair_with_gaps)
 {
     std::string const expected
     {


### PR DESCRIPTION
This PR adds debug_stream's `operator<<` for alignments, which are represented as tuple or pair of aligned sequences. Should I add support for std::vector of aligned sequences as well? 

Due to our file output policy of not checking user variables before printing, the output may be corrupted, if the sequences do not have equal length. 

The documentation of how to use zip_view as a column iterator for alignments will come in a separate PR. 

replaces PR #233 and #20 
