### PR TITLE
Print tuple_like objects to debug_stream

### DIFF
--- a/test/unit/io/stream/debug_stream_test.cpp
+++ b/test/unit/io/stream/debug_stream_test.cpp
@@ -153,3 +153,24 @@ TEST(debug_stream, path)
     o.flush();
     EXPECT_EQ(o.str(), "\"my/path/my_file.txt\"");
 }
+
+TEST(debug_stream, tuple)
+{
+    std::ostringstream o;
+    debug_stream_type my_stream{o};
+
+    std::tuple<size_t, std::string> t0{32, "dummy"};
+    my_stream << t0;
+    o.flush();
+    EXPECT_EQ(o.str(), "(32,dummy)");
+
+    std::tuple<size_t> t1{32};
+    my_stream << t1;
+    o.flush();
+    EXPECT_EQ(o.str(), "(32,dummy)(32)");
+
+    std::tuple<size_t, std::pair<size_t, size_t>> t2{2, {3,2}};
+    my_stream << t2;
+    o.flush();
+    EXPECT_EQ(o.str(), "(32,dummy)(32)(2,(3,2))");
+}


### PR DESCRIPTION
This adds printing for objects that fulfil the `tuple_like_concept`.

Open questions:

- Where to put the code and/or the `detail` namespace?
- ~~Any way to avoid const and non-const overload? The member function for `operator<<` is templatized and it won't resolve to `tuple_t const` if `tuple_t` is used in the function call.~~ done
- ~~Currently breaks some alphabet tests and the `simd_debug_stream_test` because of ambiguous overloads (the debug_stream for simd creates an `std::array` which then also fulfils the `tuple_like_concept`)~~

- <details><summary>Additional requirements (click me)</summary><p>
   We could add:

   ```cpp
   template <typename ...elems>
   inline bool constexpr all_streamable = false;

   template <typename T>
   concept debug_streamable =
   requires (T t)
   {
       debug_stream << t;
   };

   template <typename ...elems>
   inline bool constexpr all_streamable<type_list<elems...>> = (debug_streamable<elems> && ...);
   ```

   And then require `requires all_streamable<detail::tuple_type_list_t<tuple_t>>`.

</p></details>
<br>