### PR TITLE
[FEATURE] Adds metafunction to defer instantiation of crtp_base classes.

### DIFF
--- a/include/seqan3/core/metafunction/all.hpp
+++ b/include/seqan3/core/metafunction/all.hpp
@@ -41,6 +41,7 @@
 
 #include <seqan3/core/metafunction/pre.hpp>
 #include <seqan3/core/metafunction/basic.hpp>
+#include <seqan3/core/metafunction/deferred_crtp_base.hpp>
 #include <seqan3/core/metafunction/iterator.hpp>
 #include <seqan3/core/metafunction/range.hpp>
 #include <seqan3/core/metafunction/template_inspection.hpp>

--- a/include/seqan3/core/metafunction/deferred_crtp_base.hpp
+++ b/include/seqan3/core/metafunction/deferred_crtp_base.hpp
@@ -1,0 +1,67 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2018, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2018, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides seqan3::detail::deferred_crtp_base.
+ * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <seqan3/core/platform.hpp>
+
+namespace seqan3::detail
+{
+
+/*!\brief An invocable wrapper that defers the instantiation of a crtp_base class.
+ * \ingroup metafunction
+ * \tparam crtp_base The crtp base class to be deferred. Must be a template template parameter.
+ * \tparam args_t    A variadic template pack used to augment the `crtp_base` class.
+ *
+ * \details
+ *
+ * This metafunction wrapper allows to defer the template instantiation of crtp-base classes. This can be useful
+ * if the crtp_base class should be augmented with traits or other templates, especially when using variadic
+ * crtp_bases. The help function seqan3::detail::invoke_deferred_crtp_base can be used to instantiate the
+ * deferred crtp base with the respective derived type.
+ *
+ * ### Example
+ *
+ * The following snippet demonstrates the use of the deferred crtp base class instantiation.
+ *
+ * \include test/snippet/core/metafunction/deferred_crtp_base.cpp
+ *
+ * \see seqan3::detail::invoke_deferred_crtp_base
+ */
+template <template <typename ...> typename crtp_base, typename ...args_t>
+struct deferred_crtp_base
+{
+    /*!\brief Invokes the deferred crtp_base with the corresponding derived type.
+     * \tparam derived_t The derived type to instantiate the crtp_base with.
+     */
+    template <typename derived_t>
+    using invoke = crtp_base<derived_t, args_t...>;
+};
+
+/*!\brief Template alias to instantiate the deferred crtp base with the derived class.
+ * \ingroup metafunction
+ * \tparam deferred_crtp_base_t The deferred crtp base class.
+ * \tparam derived_t            The derived type to instantiate the crtp base class with.
+ *
+ * \details
+ *
+ * Effectively declares the type resulting from `deferred_crtp_base_t::template invoke<derived_t>`.
+ *
+ * \see seqan3::detail::deferred_crtp_base
+ */
+template <typename deferred_crtp_base_t, typename derived_t>
+//!\cond
+    requires requires { typename deferred_crtp_base_t::template invoke<derived_t>; }
+//!\endcond
+using invoke_deferred_crtp_base = typename deferred_crtp_base_t::template invoke<derived_t>;
+
+} // namespace seqan3::detail

--- a/test/snippet/core/metafunction/deferred_crtp_base.cpp
+++ b/test/snippet/core/metafunction/deferred_crtp_base.cpp
@@ -1,0 +1,51 @@
+#include <string>
+#include <type_traits>
+
+#include <seqan3/core/metafunction/deferred_crtp_base.hpp>
+
+// Defines a crtp_base class with an additional value type.
+template <typename derived_t, typename value_t>
+class base1
+{
+public:
+
+    value_t func1() const
+    {
+        return {"instance of base1"};
+    }
+};
+
+// Defines a crtp_base class with an additional value type and a parameter type.
+template <typename derived_t, typename value_t, typename parameter_t>
+class base2
+{
+public:
+
+    value_t func2(parameter_t const p) const
+    {
+        return static_cast<value_t>(p);
+    }
+};
+
+// The derived class that inherits from a variadic crtp pattern, which are augmented with additional trait types.
+// These types must be wrapped in a deferred layer, otherwise the compilation fails as incomplete types are not allowed.
+// But during the definition of the base classes, the derived class cannot be known.
+// In addition the deferred type must be invoked with the derived class using the `invoke_deferred_crtp_base` helper
+// template to instantiate the correct crtp base type.
+template <typename ...deferred_bases_t>
+class derived : public seqan3::detail::invoke_deferred_crtp_base<deferred_bases_t, derived<deferred_bases_t...>>...
+{};
+
+int main()
+{
+    // Wraps the actual classes into deferred crtp base classes.
+    // This step is necessary, since during their declaration the type of the derived class cannot be known.
+    using deferred_base1 = seqan3::detail::deferred_crtp_base<base1, std::string>;
+    using deferred_base2 = seqan3::detail::deferred_crtp_base<base2, uint8_t, uint32_t>;
+
+    // Instantiate the derived class with the deferred crtp base classes.
+    derived<deferred_base1, deferred_base2> d{};
+    // Check the inherited interfaces.
+    static_assert(std::is_same_v<decltype(d.func1()), std::string>, "Return type must be std::string");
+    static_assert(std::is_same_v<decltype(d.func2(10u)), uint8_t>, "Return type must be uint8_t");
+}

--- a/test/unit/core/metafunction/CMakeLists.txt
+++ b/test/unit/core/metafunction/CMakeLists.txt
@@ -1,4 +1,5 @@
 seqan3_test(basic_test.cpp)
+seqan3_test(deferred_crtp_base_test.cpp)
 seqan3_test(transformation_trait_or_test.cpp)
 seqan3_test(function_test.cpp)
 seqan3_test(range_iterator_test.cpp)

--- a/test/unit/core/metafunction/deferred_crtp_base_test.cpp
+++ b/test/unit/core/metafunction/deferred_crtp_base_test.cpp
@@ -1,0 +1,83 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2018, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2018, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <type_traits>
+
+#include <seqan3/core/metafunction/deferred_crtp_base.hpp>
+
+using namespace seqan3;
+
+// Defines a crtp_base class with an additional value type.
+template <typename derived_t, typename value_t = std::string>
+class base1
+{
+public:
+
+    value_t func1() const
+    {
+        return {"instance of base1"};
+    }
+};
+
+// Defines a crtp_base class with an additional return type and a parameter_t.
+template <typename derived_t, typename value_t = int, typename parameter_t = int>
+class base2
+{
+public:
+
+    value_t func2(parameter_t const p) const
+    {
+        return static_cast<value_t>(p);
+    }
+};
+
+// The derived class that inherits from a variadic crtp pattern.
+template <typename ...bases_t>
+class derived : public seqan3::detail::invoke_deferred_crtp_base<bases_t, derived<bases_t...>>...
+{};
+
+TEST(deferred_crtp_base, one_base_not_augmented)
+{
+    using deferred_base1 = seqan3::detail::deferred_crtp_base<base1>;
+
+    derived<deferred_base1> d{};
+
+    EXPECT_TRUE((std::is_same_v<decltype(d.func1()), std::string>));
+}
+
+TEST(deferred_crtp_base, multiple_base_not_augmented)
+{
+    using deferred_base1 = seqan3::detail::deferred_crtp_base<base1>;
+    using deferred_base2 = seqan3::detail::deferred_crtp_base<base2>;
+
+    derived<deferred_base1, deferred_base2> d{};
+
+    EXPECT_TRUE((std::is_same_v<decltype(d.func1()), std::string>));
+    EXPECT_TRUE((std::is_same_v<decltype(d.func2(10)), int>));
+}
+
+TEST(deferred_crtp_base, one_base_augmented)
+{
+    using deferred_base1 = seqan3::detail::deferred_crtp_base<base1, std::vector<char>>;
+
+    derived<deferred_base1> d{};
+
+    EXPECT_TRUE((std::is_same_v<decltype(d.func1()), std::vector<char>>));
+}
+
+TEST(deferred_crtp_base, multiple_base_augmented)
+{
+    using deferred_base1 = seqan3::detail::deferred_crtp_base<base1, std::vector<char>>;
+    using deferred_base2 = seqan3::detail::deferred_crtp_base<base2, float, int8_t>;
+
+    derived<deferred_base1, deferred_base2> d{};
+
+    EXPECT_TRUE((std::is_same_v<decltype(d.func1()), std::vector<char>>));
+    EXPECT_TRUE((std::is_same_v<decltype(d.func2(10)), float>));
+}


### PR DESCRIPTION
This helper meta-function allows augmentation of crtp classes with traits before the derived type is known.
At the moment I will use it for the alignment configuration but I saw it as general enough to put it into core metafunction. 