### PR TITLE
[fix] documentation test should preserve newlines

### DIFF
--- a/test/documentation/CMakeLists.txt
+++ b/test/documentation/CMakeLists.txt
@@ -26,7 +26,7 @@ enable_testing()
 
 set (SEQAN3_DOXYGEN_TEST_SCRIPT "
     output=\$(${DOXYGEN_EXECUTABLE} 2>&1 > /dev/null);
-    echo \$output;
+    echo \"\$output\";
     test -z \"\$output\"")
 
 if (SEQAN3_USER_DOC)


### PR DESCRIPTION
This small fix makes the difference between

```c++
/seqan3/include/seqan3/core/metafunction/template_inspection.hpp:48: warning: explicit link request to 'testing::Types' could not be resolved /seqan3/include/seqan3/core/metafunction/template_inspection.hpp:48: warning: explicit link request to 'testing::Types' could not be resolved /seqan3/include/seqan3/core/metafunction/template_inspection.hpp:48: warning: explicit link request to 'testing::Types' could not be resolved /seqan3/include/seqan3/core/metafunction/template_inspection.hpp:48: warning: explicit link request to 'testing::Types' could not be resolved /seqan3/include/seqan3/core/metafunction/template_inspection.hpp:50: warning: Found unknown command `\detail' /seqan3/include/seqan3/core/metafunction/template_inspection.hpp:54: warning: explicit link request to 'testing::internal::None' could not be resolved /seqan3/include/seqan3/core/metafunction/template_inspection.hpp:55: warning: explicit link request to 'testing::Types<int>' could not be resolved /seqan3/include/seqan3/core/metafunction/template_inspection.hpp:55: warning: explicit link request to 'testing::internal::None' could not be resolved /seqan3/include/seqan3/core/metafunction/template_inspection.hpp:55: warning: explicit link request to 'testing::internal::None' could not be resolved /seqan3/include/seqan3/core/metafunction/template_inspection.hpp:56: warning: explicit link request to 'testing::internal::None' could not be resolved /seqan3/include/seqan3/core/metafunction/template_inspection.hpp:60: warning: included file test/snippet/core/testing_list.cpp is not found. Check your EXAMPLE_PATH /seqan3/include/seqan3/core/metafunction/template_inspection.hpp:48: warning: explicit link request to 'testing::Types' could not be resolved
```

and 

```c++
/seqan3/include/seqan3/core/metafunction/template_inspection.hpp:48: warning: explicit link request to 'testing::Types' could not be resolved
/seqan3/include/seqan3/core/metafunction/template_inspection.hpp:48: warning: explicit link request to 'testing::Types' could not be resolved
/seqan3/include/seqan3/core/metafunction/template_inspection.hpp:48: warning: explicit link request to 'testing::Types' could not be resolved
/seqan3/include/seqan3/core/metafunction/template_inspection.hpp:48: warning: explicit link request to 'testing::Types' could not be resolved
/seqan3/include/seqan3/core/metafunction/template_inspection.hpp:50: warning: Found unknown command `\detail'
/seqan3/include/seqan3/core/metafunction/template_inspection.hpp:54: warning: explicit link request to 'testing::internal::None' could not be resolved
/seqan3/include/seqan3/core/metafunction/template_inspection.hpp:55: warning: explicit link request to 'testing::Types<int>' could not be resolved
/seqan3/include/seqan3/core/metafunction/template_inspection.hpp:55: warning: explicit link request to 'testing::internal::None' could not be resolved
/seqan3/include/seqan3/core/metafunction/template_inspection.hpp:55: warning: explicit link request to 'testing::internal::None' could not be resolved
/seqan3/include/seqan3/core/metafunction/template_inspection.hpp:56: warning: explicit link request to 'testing::internal::None' could not be resolved
/seqan3/include/seqan3/core/metafunction/template_inspection.hpp:60: warning: included file test/snippet/core/testing_list.cpp is not found. Check your EXAMPLE_PATH
/seqan3/include/seqan3/core/metafunction/template_inspection.hpp:48: warning: explicit link request to 'testing::Types' could not be resolved
```