### PR TITLE
[fix] cmake uses -isystem and not -I for seqan3 include path

### DIFF
--- a/build_system/seqan3-config.cmake
+++ b/build_system/seqan3-config.cmake
@@ -170,9 +170,9 @@ find_path (SEQAN3_CLONE_DIR NAMES build_system/seqan3-config.cmake HINTS "${CMAK
 if (SEQAN3_CLONE_DIR)
     message (STATUS "  Detected as running from a repository checkout…")
 
-    if (NOT SEQAN3_BASEDIR AND IS_DIRECTORY "${SEQAN3_CLONE_DIR}/include")
+    if (NOT SEQAN3_INCLUDE_DIR AND IS_DIRECTORY "${SEQAN3_CLONE_DIR}/include")
         message (STATUS "  …adding SeqAn3 include:     ${SEQAN3_CLONE_DIR}/include")
-        set (SEQAN3_BASEDIR "${SEQAN3_CLONE_DIR}/include")
+        set (SEQAN3_INCLUDE_DIR "${SEQAN3_CLONE_DIR}/include")
     endif ()
 
     if (EXISTS "${SEQAN3_CLONE_DIR}/submodules")
@@ -180,7 +180,7 @@ if (SEQAN3_CLONE_DIR)
         foreach (submodule ${submodules})
             if (IS_DIRECTORY ${submodule})
                 message (STATUS "  …adding submodule include:  ${submodule}")
-                set (SEQAN3_INCLUDE_DIRS ${submodule} ${SEQAN3_INCLUDE_DIRS})
+                set (SEQAN3_DEPENDENCY_INCLUDE_DIRS ${submodule} ${SEQAN3_DEPENDENCY_INCLUDE_DIRS})
             endif ()
         endforeach ()
     endif ()
@@ -190,15 +190,15 @@ endif ()
 # Find SeqAn3 include path
 # ----------------------------------------------------------------------------
 
-if (NOT SEQAN3_BASEDIR)
-    find_path (SEQAN3_BASEDIR "seqan3/version.hpp" HINTS ${SEQAN3_INCLUDE_DIRS})
+if (NOT SEQAN3_INCLUDE_DIR)
+    find_path (SEQAN3_INCLUDE_DIR "seqan3/version.hpp" HINTS ${SEQAN3_DEPENDENCY_INCLUDE_DIRS})
 endif ()
 
-mark_as_advanced (SEQAN3_BASEDIR)
+mark_as_advanced (SEQAN3_INCLUDE_DIR)
 
 # find include directory
-if (SEQAN3_BASEDIR)
-    seqan3_config_print ("SeqAn3 include dir found:   ${SEQAN3_BASEDIR}")
+if (SEQAN3_INCLUDE_DIR)
+    seqan3_config_print ("SeqAn3 include dir found:   ${SEQAN3_INCLUDE_DIR}")
 else ()
     seqan3_config_error ("SeqAn3 include directory could not be found.")
 endif ()
@@ -210,7 +210,7 @@ endif ()
 # deactivate messages in check_*
 set (CMAKE_REQUIRED_QUIET       1)
 # use global variables in Check* calls
-set (CMAKE_REQUIRED_INCLUDES    ${CMAKE_INCLUDE_PATH} ${SEQAN3_BASEDIR} ${SEQAN3_INCLUDE_DIRS})
+set (CMAKE_REQUIRED_INCLUDES    ${CMAKE_INCLUDE_PATH} ${SEQAN3_INCLUDE_DIR} ${SEQAN3_DEPENDENCY_INCLUDE_DIRS})
 set (CMAKE_REQUIRED_FLAGS       ${CMAKE_CXX_FLAGS})
 
 # ----------------------------------------------------------------------------
@@ -459,7 +459,7 @@ endif ()
 
 if (ZLIB_FOUND)
     set (SEQAN3_LIBRARIES         ${SEQAN3_LIBRARIES}         ${ZLIB_LIBRARIES})
-    set (SEQAN3_INCLUDE_DIRS      ${SEQAN3_INCLUDE_DIRS}      ${ZLIB_INCLUDE_DIRS})
+    set (SEQAN3_DEPENDENCY_INCLUDE_DIRS      ${SEQAN3_DEPENDENCY_INCLUDE_DIRS}      ${ZLIB_INCLUDE_DIRS})
     set (SEQAN3_DEFINITIONS       ${SEQAN3_DEFINITIONS}       "-DSEQAN3_HAS_ZLIB=1")
     seqan3_config_print ("Optional dependency:        ZLIB-${ZLIB_VERSION_STRING} found.")
 else ()
@@ -484,7 +484,7 @@ endif ()
 
 if (BZIP2_FOUND)
     set (SEQAN3_LIBRARIES         ${SEQAN3_LIBRARIES}         ${BZIP2_LIBRARIES})
-    set (SEQAN3_INCLUDE_DIRS      ${SEQAN3_INCLUDE_DIRS}      ${BZIP2_INCLUDE_DIRS})
+    set (SEQAN3_DEPENDENCY_INCLUDE_DIRS      ${SEQAN3_DEPENDENCY_INCLUDE_DIRS}      ${BZIP2_INCLUDE_DIRS})
     set (SEQAN3_DEFINITIONS       ${SEQAN3_DEFINITIONS}       "-DSEQAN3_HAS_BZIP2=1")
     seqan3_config_print ("Optional dependency:        BZip2-${BZIP2_VERSION_STRING} found.")
 else ()
@@ -527,7 +527,7 @@ endif ()
 # Find SeqAn3 version.hpp and extract version
 # ----------------------------------------------------------------------------
 
-set (_SEQAN3_VERSION_HPP "${SEQAN3_BASEDIR}/seqan3/version.hpp")
+set (_SEQAN3_VERSION_HPP "${SEQAN3_INCLUDE_DIR}/seqan3/version.hpp")
 set (_SEQAN3_VERSION_IDS MAJOR MINOR PATCH)
 
 # set to 0.0.0 ny default
@@ -578,7 +578,7 @@ try_compile (SEQAN3_PLATFORM_TEST
              ${CMAKE_BINARY_DIR}
              ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/src.cxx
              CMAKE_FLAGS         "-DCOMPILE_DEFINITIONS:STRING=${CMAKE_CXX_FLAGS} ${SEQAN3_CXX_FLAGS}"
-                                 "-DINCLUDE_DIRECTORIES:STRING=${CMAKE_INCLUDE_PATH};${SEQAN3_BASEDIR};${SEQAN3_INCLUDE_DIRS}"
+                                 "-DINCLUDE_DIRECTORIES:STRING=${CMAKE_INCLUDE_PATH};${SEQAN3_INCLUDE_DIR};${SEQAN3_DEPENDENCY_INCLUDE_DIRS}"
              COMPILE_DEFINITIONS ${SEQAN3_DEFINITIONS}
              LINK_LIBRARIES      ${SEQAN3_LIBRARIES}
              OUTPUT_VARIABLE     SEQAN3_PLATFORM_TEST_OUTPUT)
@@ -603,7 +603,7 @@ set (SeqAn3_FOUND TRUE)
 # ----------------------------------------------------------------------------
 
 if (NOT ${FIND_NAME}_FIND_QUIETLY)
-    message (STATUS "${ColourBold}Found SeqAn3:${ColourReset} ${SEQAN3_BASEDIR}/seqan3 (found version \"${SEQAN3_VERSION_STRING}\")")
+    message (STATUS "${ColourBold}Found SeqAn3:${ColourReset} ${SEQAN3_INCLUDE_DIR}/seqan3 (found version \"${SEQAN3_VERSION_STRING}\")")
 endif ()
 
 separate_arguments (SEQAN3_CXX_FLAGS_LIST UNIX_COMMAND "${SEQAN3_CXX_FLAGS}")
@@ -613,14 +613,14 @@ target_compile_definitions (seqan3_seqan3 INTERFACE ${SEQAN3_DEFINITIONS})
 target_compile_options (seqan3_seqan3 INTERFACE ${SEQAN3_CXX_FLAGS_LIST})
 target_link_libraries (seqan3_seqan3 INTERFACE "${SEQAN3_LIBRARIES}")
 # include seqan3/include/ as -I, because seqan3 should never produce warnings.
-target_include_directories (seqan3_seqan3 INTERFACE "${SEQAN3_BASEDIR}")
+target_include_directories (seqan3_seqan3 INTERFACE "${SEQAN3_INCLUDE_DIR}")
 # include everything except seqan3/include/ as -isystem, i.e.
 # a system header which suppresses warnings of external libraries.
-target_include_directories (seqan3_seqan3 SYSTEM INTERFACE "${SEQAN3_INCLUDE_DIRS}")
+target_include_directories (seqan3_seqan3 SYSTEM INTERFACE "${SEQAN3_DEPENDENCY_INCLUDE_DIRS}")
 add_library (seqan3::seqan3 ALIAS seqan3_seqan3)
 
-# propagate SEQAN3_BASEDIR into SEQAN3_INCLUDE_DIRS
-set (SEQAN3_INCLUDE_DIRS ${SEQAN3_BASEDIR} ${SEQAN3_INCLUDE_DIRS})
+# propagate SEQAN3_INCLUDE_DIR into SEQAN3_INCLUDE_DIRS
+set (SEQAN3_INCLUDE_DIRS ${SEQAN3_INCLUDE_DIR} ${SEQAN3_DEPENDENCY_INCLUDE_DIRS})
 
 if (SEQAN3_FIND_DEBUG)
   message ("Result for ${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt")
@@ -628,7 +628,7 @@ if (SEQAN3_FIND_DEBUG)
   message ("  CMAKE_BUILD_TYPE            ${CMAKE_BUILD_TYPE}")
   message ("  CMAKE_SOURCE_DIR            ${CMAKE_SOURCE_DIR}")
   message ("  CMAKE_INCLUDE_PATH          ${CMAKE_INCLUDE_PATH}")
-  message ("  SEQAN3_BASEDIR              ${SEQAN3_BASEDIR}")
+  message ("  SEQAN3_INCLUDE_DIR          ${SEQAN3_INCLUDE_DIR}")
   message ("")
   message ("  ${FIND_NAME}_FOUND                ${${FIND_NAME}_FOUND}")
   message ("  SEQAN3_HAS_ZLIB             ${ZLIB_FOUND}")

--- a/include/seqan3/search/algorithm/detail/search.hpp
+++ b/include/seqan3/search/algorithm/detail/search.hpp
@@ -73,15 +73,16 @@ inline auto search_single(index_t const & index, query_t & query, configuration_
 {
     // retrieve error numbers / rates
     detail::search_param max_error{0, 0, 0, 0};
-    auto & [total, subs, ins, del] = max_error;
     if constexpr (contains<search_cfg::id::max_error>(cfg))
     {
+        auto & [total, subs, ins, del] = max_error;
         std::tie(total, subs, ins, del) = get<search_cfg::id::max_error>(cfg);
     }
     else if constexpr (contains<search_cfg::id::max_error_rate>(cfg))
     {
         // NOTE: Casting doubles rounds towards zero (i.e. floor for positive numbers). Thus, given a rate of
         // 10% and a read length of 101 the max number of errors is correctly casted from 10.1 errors to 10
+        auto & [total, subs, ins, del] = max_error;
         std::tie(total, subs, ins, del) = std::apply([& query] (auto && ... args)
             {
                 return std::tuple{(args * query.size())...};

--- a/include/seqan3/search/fm_index/bi_fm_index_iterator.hpp
+++ b/include/seqan3/search/fm_index/bi_fm_index_iterator.hpp
@@ -293,8 +293,8 @@ public:
         assert(index != nullptr);
         // equal SA interval implies equal parent node information (or both are root nodes)
         assert(!(fwd_lb == rhs.fwd_lb && fwd_rb == rhs.fwd_rb && depth == rhs.depth) ||
-               depth == 0 ||
-               parent_lb == rhs.parent_lb && parent_rb == rhs.parent_rb && _last_char == rhs._last_char);
+               (depth == 0) ||
+               (parent_lb == rhs.parent_lb && parent_rb == rhs.parent_rb && _last_char == rhs._last_char));
 
         return std::tie(fwd_lb, fwd_rb, depth) == std::tie(rhs.fwd_lb, rhs.fwd_rb, rhs.depth);
     }

--- a/test/seqan3-test.cmake
+++ b/test/seqan3-test.cmake
@@ -177,7 +177,10 @@ macro (seqan3_require_test)
         gtest_project
         PREFIX gtest_project
         GIT_REPOSITORY "https://github.com/google/googletest.git"
-        GIT_TAG "release-1.8.1"
+        # we currently have warnings that were introduced in
+        # 03867b5389516a0f185af52672cf5472fa0c159c, which are still available
+        # in "release-1.8.1", see https://github.com/google/googletest/issues/1419
+        GIT_TAG "52f8183e7f3620cf03f321a2624eb0d4f7649f4c"
         SOURCE_DIR "${SEQAN3_TEST_CLONE_DIR}"
         CMAKE_ARGS "${gtest_project_args}"
         UPDATE_DISCONNECTED yes

--- a/test/seqan3-test.cmake
+++ b/test/seqan3-test.cmake
@@ -64,35 +64,39 @@ file(MAKE_DIRECTORY ${SEQAN3_TEST_CLONE_DIR}/googlemock/include/)
 
 # seqan3::test exposes a base set of required flags, includes, definitions and
 # libraries which are in common for **all** seqan3 tests
-add_library (seqan3::test INTERFACE IMPORTED)
-set_property (TARGET seqan3::test APPEND PROPERTY INTERFACE_COMPILE_OPTIONS "-pedantic"  "-Wall" "-Wextra" "-Werror")
-set_property (TARGET seqan3::test APPEND PROPERTY INTERFACE_LINK_LIBRARIES "seqan3::seqan3" "pthread")
-set_property (TARGET seqan3::test APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${SEQAN3_CLONE_DIR}/test/include/")
+add_library (seqan3_test INTERFACE)
+target_compile_options (seqan3_test INTERFACE "-pedantic"  "-Wall" "-Wextra" "-Werror")
+target_link_libraries (seqan3_test INTERFACE "seqan3::seqan3" "pthread")
+target_include_directories (seqan3_test INTERFACE "${SEQAN3_CLONE_DIR}/test/include/")
+add_library (seqan3::test ALIAS seqan3_test)
 
 # seqan3::test::performance specifies required flags, includes and libraries
 # needed for performance test cases in seqan3/test/performance
-add_library (seqan3::test::performance INTERFACE IMPORTED)
-set_property (TARGET seqan3::test::performance APPEND PROPERTY INTERFACE_LINK_LIBRARIES "seqan3::test" "gbenchmark")
-set_property (TARGET seqan3::test::performance APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${SEQAN3_BENCHMARK_CLONE_DIR}/include/")
+add_library (seqan3_test_performance INTERFACE)
+target_link_libraries (seqan3_test_performance INTERFACE "seqan3::test" "gbenchmark")
+target_include_directories (seqan3_test_performance INTERFACE "${SEQAN3_BENCHMARK_CLONE_DIR}/include/")
+add_library (seqan3::test::performance ALIAS seqan3_test_performance)
 
 # seqan3::test::unit specifies required flags, includes and libraries
 # needed for unit test cases in seqan3/test/unit
-add_library (seqan3::test::unit INTERFACE IMPORTED)
-set_property (TARGET seqan3::test::unit APPEND PROPERTY INTERFACE_LINK_LIBRARIES "seqan3::test" "gtest_main" "gtest")
-set_property (TARGET seqan3::test::unit
-              APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES  "${SEQAN3_TEST_CLONE_DIR}/googletest/include/"
-                                                             "${SEQAN3_TEST_CLONE_DIR}/googlemock/include/")
+add_library (seqan3_test_unit INTERFACE)
+target_link_libraries (seqan3_test_unit INTERFACE "seqan3::test" "gtest_main" "gtest")
+target_include_directories (seqan3_test_unit INTERFACE "${SEQAN3_TEST_CLONE_DIR}/googletest/include/"
+                                                       "${SEQAN3_TEST_CLONE_DIR}/googlemock/include/")
+add_library (seqan3::test::unit ALIAS seqan3_test_unit)
 
 # seqan3::test::coverage specifies required flags, includes and libraries
 # needed for coverage test cases in seqan3/test/coverage
-add_library (seqan3::test::coverage INTERFACE IMPORTED)
-set_property (TARGET seqan3::test::coverage APPEND PROPERTY INTERFACE_COMPILE_OPTIONS "--coverage" "-fprofile-arcs" "-ftest-coverage")
-set_property (TARGET seqan3::test::coverage APPEND PROPERTY INTERFACE_LINK_LIBRARIES "seqan3::test::unit" "gcov")
+add_library (seqan3_test_coverage INTERFACE)
+target_compile_options (seqan3_test_coverage INTERFACE "--coverage" "-fprofile-arcs" "-ftest-coverage")
+target_link_libraries (seqan3_test_coverage INTERFACE "seqan3::test::unit" "gcov")
+add_library (seqan3::test::coverage ALIAS seqan3_test_coverage)
 
 # seqan3::test::header specifies required flags, includes and libraries
 # needed for header test cases in seqan3/test/header
-add_library (seqan3::test::header INTERFACE IMPORTED)
-set_property (TARGET seqan3::test::header APPEND PROPERTY INTERFACE_LINK_LIBRARIES "seqan3::test::unit")
+add_library (seqan3_test_header INTERFACE)
+target_link_libraries (seqan3_test_header INTERFACE "seqan3::test::unit")
+add_library (seqan3::test::header ALIAS seqan3_test_header)
 
 # ----------------------------------------------------------------------------
 # Commonly shared options for external projects.


### PR DESCRIPTION
We observed the problem that warnings weren't triggered in our tests.

After some investigation, we figured out that seqan3 was included as `-isystem` in the unit tests.

After some more digging, I found out that this is due to using `add_library(name INTERFACE IMPORTED)`.

This PR changes the cmake script in such a way that seqan3 will always be included via `-I`, but our external dependencies will be still included as system libraries, i.e. `-isystem`.

This resolves #606.

-----

This PR only makes the changes in cmake, the following PRs fix the code:

* ~#616~ 
* ~#617~
* ~#618~
* ~#619~ 
* ~#627~
* ~#628~
* ~#629~