### PR TITLE
gzip and bzip2 stream

### DIFF
--- a/include/seqan3/contrib/stream/bz2_istream.hpp
+++ b/include/seqan3/contrib/stream/bz2_istream.hpp
@@ -1,0 +1,363 @@
+// bzip2stream Library License:
+// --------------------------
+//
+// The zlib/libpng License Copyright (c) 2003 Jonathan de Halleux.
+//
+// This software is provided 'as-is', without any express or implied warranty. In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose, including commercial applications, and to alter it and redistribute it freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software. If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution
+//
+// Author: Jonathan de Halleux, dehalleux@pelikhan.com, 2003
+// Altered bzip2_stream header
+// Author: Hannes Hauswedell <hannes.hauswedell@fu-berlin.de>
+
+#pragma once
+
+#ifndef SEQAN3_HAS_BZIP2
+#error "This file cannot be used when building without BZIP2-support."
+#endif
+
+#include <algorithm>
+#include <cstring>
+#include <iostream>
+#include <vector>
+
+#define BZ_NO_STDIO
+#include <bzlib.h>
+
+namespace seqan3::contrib
+{
+
+// --------------------------------------------------------------------------
+// Class basic_bz2_istreambuf
+// --------------------------------------------------------------------------
+
+const size_t BZ2_INPUT_DEFAULT_BUFFER_SIZE = 4096;
+
+template<
+    typename Elem,
+    typename Tr = std::char_traits<Elem>,
+    typename ElemA = std::allocator<Elem>,
+    typename ByteT = char,
+    typename ByteAT = std::allocator<ByteT>
+>
+class basic_bz2_istreambuf :
+    public std::basic_streambuf<Elem, Tr>
+{
+public:
+    typedef std::basic_istream<Elem, Tr>& istream_reference;
+    typedef ElemA char_allocator_type;
+    typedef ByteT byte_type;
+    typedef ByteAT byte_allocator_type;
+    typedef byte_type* byte_buffer_type;
+    typedef typename Tr::char_type char_type;
+    typedef typename Tr::int_type int_type;
+    typedef std::vector<byte_type, byte_allocator_type > byte_vector_type;
+    typedef std::vector<char_type, char_allocator_type > char_vector_type;
+
+    basic_bz2_istreambuf(
+        istream_reference istream_,
+        size_t verbosity_,
+        bool small_,
+        size_t read_buffer_size_,
+        size_t input_buffer_size_
+        );
+
+    ~basic_bz2_istreambuf();
+
+    int_type underflow();
+
+    istream_reference get_istream()        {    return m_istream;};
+    bz_stream& get_bzip2_stream()        {    return m_bzip2_stream;};
+    int get_zerr() const                {    return m_err;};
+private:
+    std::streamsize unbzip2_from_stream( char_type*, std::streamsize);
+    void put_back_from_bzip2_stream();
+    size_t fill_input_buffer();
+
+    istream_reference m_istream;
+    bz_stream m_bzip2_stream;
+    int m_err;
+    byte_vector_type m_input_buffer;
+    char_vector_type m_buffer;
+};
+
+// --------------------------------------------------------------------------
+// Class basic_bz2_istreambuf implementation
+// --------------------------------------------------------------------------
+
+template<
+    typename Elem,
+    typename Tr,
+    typename ElemA,
+    typename ByteT,
+    typename ByteAT
+>
+basic_bz2_istreambuf<
+    Elem,Tr,ElemA,ByteT,ByteAT
+    >::basic_bz2_istreambuf(
+        istream_reference istream_,
+        size_t verbosity_,
+        bool small_,
+        size_t read_buffer_size_,
+        size_t input_buffer_size_
+)
+:
+    m_istream(istream_),
+    m_input_buffer(input_buffer_size_),
+    m_buffer(read_buffer_size_)
+{
+    // setting zalloc, zfree and opaque
+    m_bzip2_stream.bzalloc=NULL;
+    m_bzip2_stream.bzfree=NULL;
+
+    m_bzip2_stream.next_in=NULL;
+    m_bzip2_stream.avail_in=0;
+    m_bzip2_stream.avail_out=0;
+    m_bzip2_stream.next_out=NULL;
+
+
+    m_err=BZ2_bzDecompressInit (
+        &m_bzip2_stream,
+        std::min(4, static_cast<int>(verbosity_)),
+        static_cast<int>(small_)
+    );
+
+    this->setg(
+        &(m_buffer[0])+4,     // beginning of putback area
+        &(m_buffer[0])+4,     // read position
+        &(m_buffer[0])+4);    // end position
+}
+
+template<
+    typename Elem,
+    typename Tr,
+    typename ElemA,
+    typename ByteT,
+    typename ByteAT
+>
+size_t basic_bz2_istreambuf<
+    Elem,Tr,ElemA,ByteT,ByteAT
+    >::fill_input_buffer()
+{
+    m_bzip2_stream.next_in=&(m_input_buffer[0]);
+    m_istream.read(
+        (char_type*)(&(m_input_buffer[0])),
+        static_cast<std::streamsize>(m_input_buffer.size()/sizeof(char_type))
+        );
+    return m_bzip2_stream.avail_in=m_istream.gcount()*sizeof(char_type);
+}
+
+template<
+    typename Elem,
+    typename Tr,
+    typename ElemA,
+    typename ByteT,
+    typename ByteAT
+>
+void basic_bz2_istreambuf<
+    Elem,Tr,ElemA,ByteT,ByteAT
+    >::put_back_from_bzip2_stream()
+{
+    if (m_bzip2_stream.avail_in==0)
+        return;
+
+    m_istream.clear( std::ios::goodbit );
+    m_istream.seekg(
+        -static_cast<int>(m_bzip2_stream.avail_in),
+        std::ios_base::cur
+        );
+
+    m_bzip2_stream.avail_in=0;
+}
+
+
+template<
+    typename Elem,
+    typename Tr,
+    typename ElemA,
+    typename ByteT,
+    typename ByteAT
+>
+basic_bz2_istreambuf<
+    Elem,Tr,ElemA,ByteT,ByteAT
+    >::~basic_bz2_istreambuf()
+{
+    BZ2_bzDecompressEnd(&m_bzip2_stream);
+}
+
+template<
+    typename Elem,
+    typename Tr,
+    typename ElemA,
+    typename ByteT,
+    typename ByteAT
+>
+typename basic_bz2_istreambuf<
+    Elem,Tr,ElemA,ByteT,ByteAT
+    >::int_type
+        basic_bz2_istreambuf<
+            Elem,Tr,ElemA,ByteT,ByteAT
+            >::underflow()
+{
+    if ( this->gptr() && ( this->gptr() < this->egptr()))
+        return * reinterpret_cast<unsigned char *>( this->gptr());
+
+    int n_putback = static_cast<int>(this->gptr() - this->eback());
+    if ( n_putback > 4)
+        n_putback = 4;
+    std::memmove(
+        &(m_buffer[0]) + (4 - n_putback),
+        this->gptr() - n_putback,
+        n_putback*sizeof(char_type)
+        );
+
+    int num = unbzip2_from_stream(
+        &(m_buffer[0])+4,
+        static_cast<std::streamsize>((m_buffer.size()-4)*sizeof(char_type))
+        );
+    if (num <= 0) // ERROR or EOF
+        return EOF;
+
+    // reset buffer pointers
+    this->setg(
+            &(m_buffer[0]) + (4 - n_putback),   // beginning of putback area
+            &(m_buffer[0]) + 4,                 // read position
+            &(m_buffer[0]) + 4 + num);          // end of buffer
+
+        // return next character
+        return* reinterpret_cast<unsigned char *>( this->gptr());
+    }
+
+
+template<
+    typename Elem,
+    typename Tr,
+    typename ElemA,
+    typename ByteT,
+    typename ByteAT
+>
+std::streamsize basic_bz2_istreambuf<
+    Elem,Tr,ElemA,ByteT,ByteAT
+    >::unbzip2_from_stream(
+        char_type* buffer_,
+        std::streamsize buffer_size_
+        )
+{
+    m_bzip2_stream.next_out=(byte_buffer_type)buffer_;
+    m_bzip2_stream.avail_out=buffer_size_*sizeof(char_type);
+    size_t count =m_bzip2_stream.avail_in;
+
+    do
+    {
+        if (m_bzip2_stream.avail_in==0)
+            count=fill_input_buffer();
+
+        if (m_bzip2_stream.avail_in)
+        {
+            m_err = BZ2_bzDecompress( &m_bzip2_stream );
+        }
+    } while (m_err==BZ_OK && m_bzip2_stream.avail_out != 0 && count != 0);
+
+    if (m_err == BZ_STREAM_END)
+        put_back_from_bzip2_stream();
+
+    return buffer_size_ - m_bzip2_stream.avail_out/sizeof(char_type);
+}
+
+// --------------------------------------------------------------------------
+// Class basic_bz2_istreambase
+// --------------------------------------------------------------------------
+
+template<
+    typename Elem,
+    typename Tr = std::char_traits<Elem>,
+    typename ElemA = std::allocator<Elem>,
+    typename ByteT = char,
+    typename ByteAT = std::allocator<ByteT>
+>
+class basic_bz2_istreambase : virtual public std::basic_ios<Elem,Tr>
+{
+public:
+    typedef std::basic_istream<Elem, Tr>& istream_reference;
+    typedef basic_bz2_istreambuf<
+        Elem,Tr,ElemA,ByteT,ByteAT> unbzip2_streambuf_type;
+
+    basic_bz2_istreambase(
+        istream_reference ostream_,
+        size_t verbosity_,
+        bool small_,
+        size_t read_buffer_size_,
+        size_t input_buffer_size_
+        )
+        : m_buf(
+            ostream_,
+            verbosity_,
+            small_,
+            read_buffer_size_,
+            input_buffer_size_
+            )
+    {
+        this->init(&m_buf );
+    };
+
+    unbzip2_streambuf_type* rdbuf() { return &m_buf; };
+
+private:
+    unbzip2_streambuf_type m_buf;
+};
+
+// --------------------------------------------------------------------------
+// Class basic_bz2_istream
+// --------------------------------------------------------------------------
+
+template<
+    typename Elem,
+    typename Tr = std::char_traits<Elem>,
+    typename ElemA = std::allocator<Elem>,
+    typename ByteT = char,
+    typename ByteAT = std::allocator<ByteT>
+>
+class basic_bz2_istream :
+    public basic_bz2_istreambase<Elem,Tr,ElemA,ByteT,ByteAT>,
+    public std::basic_istream<Elem,Tr>
+{
+public:
+    typedef basic_bz2_istreambase<
+        Elem,Tr,ElemA,ByteT,ByteAT> bzip2_istreambase_type;
+    typedef std::basic_istream<Elem,Tr> istream_type;
+    typedef istream_type& istream_reference;
+    typedef unsigned char byte_type;
+
+    basic_bz2_istream(
+        istream_reference istream_,
+        size_t verbosity_ = 0,
+        bool small_ = false,
+        size_t read_buffer_size_ = BZ2_INPUT_DEFAULT_BUFFER_SIZE,
+        size_t input_buffer_size_ = BZ2_INPUT_DEFAULT_BUFFER_SIZE
+        )
+      :
+        bzip2_istreambase_type(istream_,verbosity_, small_, read_buffer_size_, input_buffer_size_),
+        istream_type(bzip2_istreambase_type::rdbuf())
+    {};
+#ifdef _WIN32
+private:
+    void _Add_vtordisp1() { } // Required to avoid VC++ warning C4250
+    void _Add_vtordisp2() { } // Required to avoid VC++ warning C4250
+#endif
+};
+
+// --------------------------------------------------------------------------
+// typedefs
+// --------------------------------------------------------------------------
+
+typedef basic_bz2_istream<char> bz2_istream;
+typedef basic_bz2_istream<wchar_t> bz2_wistream;
+
+} // namespace seqan3::contrib

--- a/include/seqan3/contrib/stream/bz2_ostream.hpp
+++ b/include/seqan3/contrib/stream/bz2_ostream.hpp
@@ -1,0 +1,423 @@
+// bzip2stream Library License:
+// --------------------------
+//
+// The zlib/libpng License Copyright (c) 2003 Jonathan de Halleux.
+//
+// This software is provided 'as-is', without any express or implied warranty. In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose, including commercial applications, and to alter it and redistribute it freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software. If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution
+//
+// Author: Jonathan de Halleux, dehalleux@pelikhan.com, 2003
+// Altered bzip2_stream header
+// Author: Hannes Hauswedell <hannes.hauswedell@fu-berlin.de>
+
+#pragma once
+
+#include <algorithm>
+#include <cstring>
+#include <iostream>
+#include <vector>
+
+#ifndef SEQAN3_HAS_BZIP2
+#error "This file cannot be used when building without BZIP2-support."
+#endif
+
+#define BZ_NO_STDIO
+#include <bzlib.h>
+
+namespace seqan3::contrib
+{
+
+// --------------------------------------------------------------------------
+// Class basic_bz2_ostreambuf
+// --------------------------------------------------------------------------
+
+const size_t BZ2_OUTPUT_DEFAULT_BUFFER_SIZE = 4096;
+
+template<
+    typename Elem,
+    typename Tr = std::char_traits<Elem>,
+    typename ElemA = std::allocator<Elem>,
+    typename ByteT = char,
+    typename ByteAT = std::allocator<ByteT>
+>
+class basic_bz2_ostreambuf :
+    public std::basic_streambuf<Elem, Tr>
+{
+public:
+    typedef std::basic_streambuf< Elem, Tr > basic_streambuf_type;
+    typedef std::basic_ostream<Elem, Tr>& ostream_reference;
+    typedef ElemA char_allocator_type;
+    typedef ByteT byte_type;
+    typedef ByteAT byte_allocator_type;
+    typedef byte_type* byte_buffer_type;
+    typedef typename Tr::char_type char_type;
+    typedef typename Tr::int_type int_type;
+    typedef std::vector<byte_type, byte_allocator_type > byte_vector_type;
+    typedef std::vector<char_type, char_allocator_type > char_vector_type;
+
+    using basic_streambuf_type::epptr;
+    using basic_streambuf_type::pbase;
+    using basic_streambuf_type::pptr;
+
+    basic_bz2_ostreambuf(
+        ostream_reference ostream_,
+        size_t block_size_100k_ ,
+        size_t verbosity_ ,
+        size_t work_factor_,
+        size_t buffer_size_
+        );
+
+    ~basic_bz2_ostreambuf();
+
+    int sync ();
+    int_type overflow (int_type c);
+
+    std::streamsize flush(int flush_mode);
+    int get_zerr() const
+    {    return m_err;};
+    uint64_t get_in_size() const
+    {
+        return ((uint64_t)m_bzip2_stream.total_in_hi32 << 32)
+                + m_bzip2_stream.total_in_lo32;
+    }
+    uint64_t get_out_size() const
+    {
+        return ((uint64_t)m_bzip2_stream.total_out_hi32 << 32)
+                + m_bzip2_stream.total_out_lo32;
+    }
+private:
+    bool bzip2_to_stream( char_type*, std::streamsize);
+    size_t fill_input_buffer();
+
+    ostream_reference m_ostream;
+    bz_stream m_bzip2_stream;
+    int m_err;
+    byte_vector_type m_output_buffer;
+    char_vector_type m_buffer;
+};
+
+// --------------------------------------------------------------------------
+// Class basic_bz2_ostreambuf implementation
+// --------------------------------------------------------------------------
+
+template<
+    typename Elem,
+    typename Tr,
+    typename ElemA,
+    typename ByteT,
+    typename ByteAT
+>
+basic_bz2_ostreambuf<
+    Elem,Tr,ElemA,ByteT,ByteAT
+    >:: basic_bz2_ostreambuf(
+    ostream_reference ostream_,
+    size_t block_size_100k_,
+    size_t verbosity_,
+    size_t work_factor_,
+    size_t buffer_size_
+    )
+:
+    m_ostream(ostream_),
+    m_output_buffer(buffer_size_,0),
+    m_buffer(buffer_size_,0)
+{
+    m_bzip2_stream.bzalloc=NULL;
+    m_bzip2_stream.bzfree=NULL;
+
+    m_bzip2_stream.next_in=NULL;
+    m_bzip2_stream.avail_in=0;
+    m_bzip2_stream.avail_out=0;
+    m_bzip2_stream.next_out=NULL;
+
+    m_err=BZ2_bzCompressInit(
+        &m_bzip2_stream,
+        std::min( 9, static_cast<int>(block_size_100k_) ),
+        std::min( 4, static_cast<int>(verbosity_) ),
+        std::min( 250, static_cast<int>(work_factor_) )
+        );
+
+    this->setp( &(m_buffer[0]), &(m_buffer[m_buffer.size()-1]));
+}
+
+template<
+    typename Elem,
+    typename Tr,
+    typename ElemA,
+    typename ByteT,
+    typename ByteAT
+>
+basic_bz2_ostreambuf<
+    Elem,Tr,ElemA,ByteT,ByteAT
+    >::~basic_bz2_ostreambuf()
+{
+    flush(BZ_FINISH);
+    m_ostream.flush();
+    m_err=BZ2_bzCompressEnd(&m_bzip2_stream);
+}
+
+template<
+    typename Elem,
+    typename Tr,
+    typename ElemA,
+    typename ByteT,
+    typename ByteAT
+>
+int basic_bz2_ostreambuf<
+    Elem,Tr,ElemA,ByteT,ByteAT
+    >::sync ()
+{
+    if ( this->pptr() && this->pptr() > this->pbase())
+    {
+        int c = overflow( EOF);
+
+        if ( c == EOF)
+            return -1;
+    }
+
+    return 0;
+}
+
+template<
+    typename Elem,
+    typename Tr,
+    typename ElemA,
+    typename ByteT,
+    typename ByteAT
+>
+typename basic_bz2_ostreambuf<
+    Elem,Tr,ElemA,ByteT,ByteAT
+    >::int_type
+        basic_bz2_ostreambuf<
+            Elem,Tr,ElemA,ByteT,ByteAT
+            >::overflow (
+                typename basic_bz2_ostreambuf<
+                    Elem,Tr,ElemA,ByteT,ByteAT
+                    >::int_type c
+                )
+{
+    int w = static_cast<int>(this->pptr() - this->pbase());
+    if (c != EOF) {
+            *this->pptr() = c;
+            ++w;
+        }
+        if ( bzip2_to_stream( this->pbase(), w)) {
+            this->setp( this->pbase(), this->epptr());
+            return c;
+        } else
+            return EOF;
+}
+
+template<
+    typename Elem,
+    typename Tr,
+    typename ElemA,
+    typename ByteT,
+    typename ByteAT
+>
+bool basic_bz2_ostreambuf<
+    Elem,Tr,ElemA,ByteT,ByteAT
+    >::bzip2_to_stream(
+        typename basic_bz2_ostreambuf<
+            Elem,Tr,ElemA,ByteT,ByteAT
+            >::char_type* buffer_,
+        std::streamsize buffer_size_
+        )
+{
+    std::streamsize written_byte_size=0, total_written_byte_size = 0;
+
+    m_bzip2_stream.next_in=(byte_buffer_type)buffer_;
+    m_bzip2_stream.avail_in=buffer_size_*sizeof(char_type);
+    m_bzip2_stream.avail_out=static_cast<unsigned int>(m_output_buffer.size());
+    m_bzip2_stream.next_out=&(m_output_buffer[0]);
+    size_t remainder=0;
+
+    do
+    {
+        m_err = BZ2_bzCompress (&m_bzip2_stream, BZ_RUN );
+
+        if (m_err == BZ_RUN_OK  || m_err == BZ_STREAM_END)
+        {
+            written_byte_size= static_cast<std::streamsize>(m_output_buffer.size()) - m_bzip2_stream.avail_out;
+            total_written_byte_size+=written_byte_size;
+            // ouput buffer is full, dumping to ostream
+            m_ostream.write(
+                (const char_type*) &(m_output_buffer[0]),
+                static_cast<std::streamsize>( written_byte_size/sizeof(char_type) )
+                );
+
+            // checking if some bytes were not written.
+            if ( (remainder = written_byte_size%sizeof(char_type))!=0)
+            {
+                // copy to the beginning of the stream
+                std::memmove(
+                    &(m_output_buffer[0]),
+                    &(m_output_buffer[written_byte_size-remainder]),
+                    remainder);
+
+            }
+
+            m_bzip2_stream.avail_out=static_cast<unsigned int>(m_output_buffer.size()-remainder);
+            m_bzip2_stream.next_out=&m_output_buffer[remainder];
+        }
+    }
+    while (m_bzip2_stream.avail_in != 0 && m_err == BZ_RUN_OK);
+
+    return m_err == BZ_RUN_OK || m_err == BZ_FLUSH_OK;
+}
+
+template<
+    typename Elem,
+    typename Tr,
+    typename ElemA,
+    typename ByteT,
+    typename ByteAT
+>
+std::streamsize basic_bz2_ostreambuf<
+    Elem,Tr,ElemA,ByteT,ByteAT
+    >::flush(int flush_mode)
+{
+    std::streamsize written_byte_size=0, total_written_byte_size=0;
+
+    int const buffer_size = static_cast< int >( pptr() - pbase() ); // amount of data currently in buffer
+
+    m_bzip2_stream.next_in=(byte_buffer_type)pbase();
+    m_bzip2_stream.avail_in=static_cast< unsigned int >(buffer_size*sizeof(char_type));
+    m_bzip2_stream.avail_out=static_cast< unsigned int >(m_output_buffer.size());
+    m_bzip2_stream.next_out=&(m_output_buffer[0]);
+    size_t remainder=0;
+
+    do
+    {
+        m_err = BZ2_bzCompress (&m_bzip2_stream, flush_mode);
+        if (m_err == BZ_FINISH_OK || m_err == BZ_STREAM_END)
+        {
+            written_byte_size=
+                static_cast<std::streamsize>(m_output_buffer.size())
+                - m_bzip2_stream.avail_out;
+            total_written_byte_size+=written_byte_size;
+            // ouput buffer is full, dumping to ostream
+            m_ostream.write(
+                (const char_type*) &(m_output_buffer[0]),
+                static_cast<std::streamsize>( written_byte_size/sizeof(char_type)*sizeof(char) )
+                );
+
+            // checking if some bytes were not written.
+            if ( (remainder = written_byte_size%sizeof(char_type))!=0)
+            {
+                // copy to the beginning of the stream
+                std::memmove(
+                    &(m_output_buffer[0]),
+                    &(m_output_buffer[written_byte_size-remainder]),
+                    remainder);
+
+            }
+
+            m_bzip2_stream.avail_out=static_cast<unsigned int>(m_output_buffer.size()-remainder);
+            m_bzip2_stream.next_out=&(m_output_buffer[remainder]);
+        }
+    } while (m_err == BZ_FINISH_OK);
+
+    m_ostream.flush();
+
+    return total_written_byte_size;
+}
+
+// --------------------------------------------------------------------------
+// Class basic_bz2_ostreambase
+// --------------------------------------------------------------------------
+
+template<
+    typename Elem,
+    typename Tr = std::char_traits<Elem>,
+    typename ElemA = std::allocator<Elem>,
+    typename ByteT = char,
+    typename ByteAT = std::allocator<ByteT>
+>
+class basic_bz2_ostreambase : virtual public std::basic_ios<Elem,Tr>
+{
+public:
+    typedef std::basic_ostream<Elem, Tr>& ostream_reference;
+    typedef basic_bz2_ostreambuf<
+        Elem,Tr,ElemA,ByteT,ByteAT> bzip2_streambuf_type;
+
+    basic_bz2_ostreambase(
+        ostream_reference ostream_,
+        size_t block_size_100k_ ,
+        size_t verbosity_ ,
+        size_t work_factor_,
+        size_t buffer_size_
+        )
+        : m_buf(ostream_,block_size_100k_, verbosity_, work_factor_, buffer_size_)
+    {
+        this->init(&m_buf );
+    };
+
+    bzip2_streambuf_type* rdbuf() { return &m_buf; };
+
+private:
+    bzip2_streambuf_type m_buf;
+};
+
+// --------------------------------------------------------------------------
+// Class basic_bz2_ostream
+// --------------------------------------------------------------------------
+
+template<
+    typename Elem,
+    typename Tr = std::char_traits<Elem>,
+    typename ElemA = std::allocator<Elem>,
+    typename ByteT = char,
+    typename ByteAT = std::allocator<ByteT>
+>
+class basic_bz2_ostream :
+    public basic_bz2_ostreambase<Elem,Tr,ElemA,ByteT,ByteAT>,
+    public std::basic_ostream<Elem,Tr>
+{
+public:
+    typedef basic_bz2_ostreambase<
+        Elem,Tr,ElemA,ByteT,ByteAT> bzip2_ostreambase_type;
+    typedef std::basic_ostream<Elem,Tr> ostream_type;
+    typedef ostream_type& ostream_reference;
+
+    basic_bz2_ostream(
+        ostream_reference ostream_,
+        size_t block_size_100k_ = 9,
+        size_t verbosity_ = 0,
+        size_t work_factor_ = 30,
+        size_t buffer_size_ = BZ2_OUTPUT_DEFAULT_BUFFER_SIZE
+        )
+    :
+        bzip2_ostreambase_type(ostream_,block_size_100k_, verbosity_, work_factor_,buffer_size_),
+        ostream_type(bzip2_ostreambase_type::rdbuf())
+    {
+
+    };
+
+    basic_bz2_ostream& add_header();
+    basic_bz2_ostream& zflush()
+    {
+        this->flush(); this->rdbuf()->flush(); return *this;
+    };
+
+#ifdef _WIN32
+private:
+    void _Add_vtordisp1() { } // Required to avoid VC++ warning C4250
+    void _Add_vtordisp2() { } // Required to avoid VC++ warning C4250
+#endif
+};
+
+// --------------------------------------------------------------------------
+// Typedefs
+// --------------------------------------------------------------------------
+
+typedef basic_bz2_ostream<char>    bz2_ostream;
+typedef basic_bz2_ostream<wchar_t> bz2_wostream;
+
+} // namespace seqan3::contrib

--- a/include/seqan3/contrib/stream/gz_istream.hpp
+++ b/include/seqan3/contrib/stream/gz_istream.hpp
@@ -1,0 +1,338 @@
+// zipstream Library License:
+// --------------------------
+//
+// The zlib/libpng License Copyright (c) 2003 Jonathan de Halleux.
+//
+// This software is provided 'as-is', without any express or implied warranty. In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose, including commercial applications, and to alter it and redistribute it freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software. If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution
+//
+// Altered zipstream library header
+// Author: Jonathan de Halleux, dehalleux@pelikhan.com, 2003
+// Author: David Weese <david.weese@fu-berlin.de>
+// Author: Enrico Siragusa <enrico.siragusa@fu-berlin.de>
+// Author: Hannes Hauswedell <hannes.hauswedell@fu-berlin.de>
+
+#pragma once
+
+#include <iostream>
+#include <cstring>
+#include <vector>
+
+#ifndef SEQAN3_HAS_ZLIB
+#error "This file cannot be used when building without ZLIB-support."
+#endif
+
+#include <zlib.h>
+
+namespace seqan3::contrib
+{
+
+// Default gzip buffer size, change this to suite your needs.
+const size_t GZ_INPUT_DEFAULT_BUFFER_SIZE = 921600;
+
+// --------------------------------------------------------------------------
+// Class basic_gz_istreambuf
+// --------------------------------------------------------------------------
+// A stream decorator that takes compressed input and unzips it to a istream.
+// The class wraps up the deflate method of the zlib library 1.1.4 http://www.gzip.org/zlib/
+
+template <typename Elem,
+          typename Tr = std::char_traits<Elem>,
+          typename ElemA = std::allocator<Elem>,
+          typename ByteT = unsigned char,
+          typename ByteAT = std::allocator<ByteT>
+          >
+class basic_gz_istreambuf :
+    public std::basic_streambuf<Elem, Tr>
+{
+public:
+    typedef std::basic_istream<Elem, Tr> &              istream_reference;
+    typedef ElemA                                       char_allocator_type;
+    typedef ByteT                                       byte_type;
+    typedef ByteAT                                      byte_allocator_type;
+    typedef byte_type *                                 byte_buffer_type;
+    typedef Tr                                          traits_type;
+    typedef typename Tr::char_type                      char_type;
+    typedef typename Tr::int_type                       int_type;
+    typedef std::vector<byte_type, byte_allocator_type> byte_vector_type;
+    typedef std::vector<char_type, char_allocator_type> char_vector_type;
+
+    // Construct a unzip stream
+    // More info on the following parameters can be found in the zlib documentation.
+    basic_gz_istreambuf(istream_reference istream_,
+                          size_t window_size_,
+                          size_t read_buffer_size_,
+                          size_t input_buffer_size_);
+
+    ~basic_gz_istreambuf();
+
+    int_type underflow();
+
+    // returns the compressed input istream
+    istream_reference get_istream()  { return m_istream; }
+    // returns the zlib stream structure
+    z_stream & get_zip_stream()      { return m_zip_stream; }
+
+private:
+    void put_back_from_zip_stream();
+    std::streamsize unzip_from_stream(char_type *, std::streamsize);
+    size_t fill_input_buffer();
+
+    istream_reference m_istream;
+    z_stream m_zip_stream;
+    int m_err;
+    byte_vector_type m_input_buffer;
+    char_vector_type m_buffer;
+};
+
+// --------------------------------------------------------------------------
+// Class basic_gz_istreambuf implementation
+// --------------------------------------------------------------------------
+
+template <typename Elem,
+          typename Tr,
+          typename ElemA,
+          typename ByteT,
+          typename ByteAT>
+basic_gz_istreambuf<Elem, Tr, ElemA, ByteT, ByteAT>::basic_gz_istreambuf(
+    istream_reference istream_,
+    size_t window_size_,
+    size_t read_buffer_size_,
+    size_t input_buffer_size_
+    ) :
+    m_istream(istream_),
+    m_input_buffer(input_buffer_size_),
+    m_buffer(read_buffer_size_)
+{
+    // setting zalloc, zfree and opaque
+    m_zip_stream.zalloc = (alloc_func)0;
+    m_zip_stream.zfree = (free_func)0;
+
+    m_zip_stream.next_in = NULL;
+    m_zip_stream.avail_in = 0;
+    m_zip_stream.avail_out = 0;
+    m_zip_stream.next_out = NULL;
+
+    m_err = inflateInit2(&m_zip_stream, static_cast<int>(window_size_));
+
+    this->setg(&(m_buffer[0]) + 4,  // beginning of putback area
+               &(m_buffer[0]) + 4,  // read position
+               &(m_buffer[0]) + 4); // end position
+}
+
+template <typename Elem,
+          typename Tr,
+          typename ElemA,
+          typename ByteT,
+          typename ByteAT>
+basic_gz_istreambuf<Elem, Tr, ElemA, ByteT, ByteAT>::~basic_gz_istreambuf()
+{
+    inflateEnd(&m_zip_stream);
+}
+
+template <typename Elem,
+          typename Tr,
+          typename ElemA,
+          typename ByteT,
+          typename ByteAT>
+typename basic_gz_istreambuf<Elem, Tr, ElemA, ByteT, ByteAT>::int_type
+basic_gz_istreambuf<Elem, Tr, ElemA, ByteT, ByteAT>::underflow()
+{
+    if (this->gptr() && (this->gptr() < this->egptr()))
+        return *reinterpret_cast<unsigned char *>(this->gptr());
+
+    int n_putback = static_cast<int>(this->gptr() - this->eback());
+    if (n_putback > 4)
+        n_putback = 4;
+
+    std::memmove(&(m_buffer[0]) + (4 - n_putback), this->gptr() - n_putback, n_putback * sizeof(char_type));
+
+    int num = unzip_from_stream(&(m_buffer[0]) + 4,
+                                static_cast<std::streamsize>((m_buffer.size() - 4) * sizeof(char_type)));
+
+    if (num <= 0)     // ERROR or EOF
+        return traits_type::eof();
+
+    // reset buffer pointers
+    this->setg(&(m_buffer[0]) + (4 - n_putback),         // beginning of putback area
+               &(m_buffer[0]) + 4,                       // read position
+               &(m_buffer[0]) + 4 + num);                // end of buffer
+
+    // return next character
+    return *reinterpret_cast<unsigned char *>(this->gptr());
+}
+
+template <typename Elem,
+          typename Tr,
+          typename ElemA,
+          typename ByteT,
+          typename ByteAT>
+std::streamsize basic_gz_istreambuf<Elem, Tr, ElemA, ByteT, ByteAT>::unzip_from_stream(
+    char_type * buffer_,
+    std::streamsize buffer_size_)
+{
+    m_zip_stream.next_out = (byte_buffer_type)buffer_;
+    m_zip_stream.avail_out = static_cast<uInt>(buffer_size_ * sizeof(char_type));
+    size_t count = m_zip_stream.avail_in;
+
+    do
+    {
+        if (m_zip_stream.avail_in == 0)
+            count = fill_input_buffer();
+
+        if (m_zip_stream.avail_in)
+            m_err = inflate(&m_zip_stream, Z_SYNC_FLUSH);
+
+        if (m_err == Z_STREAM_END)
+            inflateReset(&m_zip_stream);
+        else if (m_err < 0)
+            break;
+    }
+    while (m_zip_stream.avail_out > 0 && count > 0);
+
+    std::streamsize n_read = buffer_size_ - m_zip_stream.avail_out / sizeof(char_type);
+
+    // check if it is the end
+    if (m_zip_stream.avail_out > 0 && m_err == Z_STREAM_END)
+        put_back_from_zip_stream();
+
+    return n_read;
+}
+
+template <typename Elem,
+          typename Tr,
+          typename ElemA,
+          typename ByteT,
+          typename ByteAT>
+size_t basic_gz_istreambuf<Elem, Tr, ElemA, ByteT, ByteAT>::fill_input_buffer()
+{
+    m_zip_stream.next_in = &(m_input_buffer[0]);
+    m_istream.read((char_type *)(&(m_input_buffer[0])),
+                   static_cast<std::streamsize>(m_input_buffer.size() / sizeof(char_type)));
+    return m_zip_stream.avail_in = m_istream.gcount() * sizeof(char_type);
+}
+
+template <typename Elem,
+          typename Tr,
+          typename ElemA,
+          typename ByteT,
+          typename ByteAT>
+void basic_gz_istreambuf<Elem, Tr, ElemA, ByteT, ByteAT>::put_back_from_zip_stream()
+{
+    if (m_zip_stream.avail_in == 0)
+        return;
+
+    m_istream.clear(std::ios::goodbit);
+    m_istream.seekg(-static_cast<int>(m_zip_stream.avail_in), std::ios_base::cur);
+
+    m_zip_stream.avail_in = 0;
+}
+
+// --------------------------------------------------------------------------
+// Class basic_gz_istreambase
+// --------------------------------------------------------------------------
+// Base class for unzip istreams
+// Contains a basic_gz_istreambuf.
+
+template <typename Elem,
+          typename Tr = std::char_traits<Elem>,
+          typename ElemA = std::allocator<Elem>,
+          typename ByteT = unsigned char,
+          typename ByteAT = std::allocator<ByteT>
+          >
+class basic_gz_istreambase :
+    virtual public std::basic_ios<Elem, Tr>
+{
+public:
+    typedef std::basic_istream<Elem, Tr> &                        istream_reference;
+    typedef basic_gz_istreambuf<Elem, Tr, ElemA, ByteT, ByteAT> unzip_streambuf_type;
+
+    basic_gz_istreambase(istream_reference ostream_,
+                          size_t window_size_,
+                          size_t read_buffer_size_,
+                          size_t input_buffer_size_) :
+        m_buf(ostream_, window_size_, read_buffer_size_, input_buffer_size_)
+    {
+        this->init(&m_buf);
+    }
+
+    // returns the underlying unzip istream object
+    unzip_streambuf_type * rdbuf() { return &m_buf; }
+
+private:
+    unzip_streambuf_type m_buf;
+};
+
+// --------------------------------------------------------------------------
+// Class basic_gz_istream
+// --------------------------------------------------------------------------
+// A zipper istream
+//
+// This class is a istream decorator that behaves 'almost' like any other ostream.
+// At construction, it takes any istream that shall be used to input of the compressed data.
+//
+// Simlpe example:
+//
+// // create a stream on zip string
+// istringstream istringstream_( ostringstream_.str());
+// // create unzipper istream
+// zip_istream unzipper( istringstream_);
+// // read and unzip
+// unzipper>>f_r>>d_r>>ui_r>>ul_r>>us_r>>c_r>>dum_r;
+
+template <typename Elem,
+          typename Tr = std::char_traits<Elem>,
+          typename ElemA = std::allocator<Elem>,
+          typename ByteT = unsigned char,
+          typename ByteAT = std::allocator<ByteT>
+          >
+class basic_gz_istream :
+    public basic_gz_istreambase<Elem, Tr, ElemA, ByteT, ByteAT>,
+    public std::basic_istream<Elem, Tr>
+{
+public:
+    typedef basic_gz_istreambase<Elem, Tr, ElemA, ByteT, ByteAT> zip_istreambase_type;
+    typedef std::basic_istream<Elem, Tr>                          istream_type;
+    typedef istream_type &                                        istream_reference;
+    typedef ByteT                                                 byte_type;
+    typedef Tr                                                    traits_type;
+
+    // Construct a unzipper stream
+    //
+    // istream_ input buffer
+    // window_size_
+    // read_buffer_size_
+    // input_buffer_size_
+
+    basic_gz_istream(istream_reference istream_,
+                      size_t window_size_ = 31, // 15 (size) + 16 (gzip header)
+                      size_t read_buffer_size_ = GZ_INPUT_DEFAULT_BUFFER_SIZE,
+                      size_t input_buffer_size_ = GZ_INPUT_DEFAULT_BUFFER_SIZE) :
+        zip_istreambase_type(istream_, window_size_, read_buffer_size_, input_buffer_size_),
+        istream_type(this->rdbuf())
+    {}
+
+#ifdef _WIN32
+private:
+    void _Add_vtordisp1() {}  // Required to avoid VC++ warning C4250
+    void _Add_vtordisp2() {}  // Required to avoid VC++ warning C4250
+#endif
+};
+
+// ===========================================================================
+// Typedefs
+// ===========================================================================
+
+// A typedef for basic_gz_istream<char>
+typedef basic_gz_istream<char>     gz_istream;
+// A typedef for basic_gz_istream<wchart>
+typedef basic_gz_istream<wchar_t>  gz_wistream;
+
+} // namespace seqan3::contrib

--- a/include/seqan3/contrib/stream/gz_ostream.hpp
+++ b/include/seqan3/contrib/stream/gz_ostream.hpp
@@ -1,0 +1,452 @@
+// zipstream Library License:
+// --------------------------
+//
+// The zlib/libpng License Copyright (c) 2003 Jonathan de Halleux.
+//
+// This software is provided 'as-is', without any express or implied warranty. In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose, including commercial applications, and to alter it and redistribute it freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software. If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution
+//
+// Altered zipstream library header
+// Author: Jonathan de Halleux, dehalleux@pelikhan.com, 2003
+// Author: David Weese <david.weese@fu-berlin.de>
+// Author: Enrico Siragusa <enrico.siragusa@fu-berlin.de>
+// Author: Hannes Hauswedell <hannes.hauswedell@fu-berlin.de>
+
+#pragma once
+
+#ifndef SEQAN3_HAS_ZLIB
+#error "This file cannot be used when building without ZLIB-support."
+#endif
+
+#include <iostream>
+#include <cstring>
+#include <vector>
+
+#include <zlib.h>
+
+namespace seqan3::contrib
+{
+
+// Default gzip buffer size, change this to suite your needs.
+const size_t GZ_OUTPUT_DEFAULT_BUFFER_SIZE = 921600;
+
+// --------------------------------------------------------------------------
+// Enum EStrategy
+// --------------------------------------------------------------------------
+// Compression strategy, see zlib doc.
+
+enum EStrategy
+{
+    StrategyFiltered = 1,
+    StrategyHuffmanOnly = 2,
+    DefaultStrategy = 0
+};
+
+// --------------------------------------------------------------------------
+// Class basic_gz_ostreambuf
+// --------------------------------------------------------------------------
+// A stream decorator that takes raw input and zips it to a ostream.
+// The class wraps up the inflate method of the zlib library 1.1.4 http://www.gzip.org/zlib/
+
+template <typename Elem,
+          typename Tr = std::char_traits<Elem>,
+          typename ElemA = std::allocator<Elem>,
+          typename ByteT = unsigned char,
+          typename ByteAT = std::allocator<ByteT>
+          >
+class basic_gz_ostreambuf :
+    public std::basic_streambuf<Elem, Tr>
+{
+public:
+    typedef std::basic_ostream<Elem, Tr> &              ostream_reference;
+    typedef ElemA                                       char_allocator_type;
+    typedef ByteT                                       byte_type;
+    typedef ByteAT                                      byte_allocator_type;
+    typedef byte_type *                                 byte_buffer_type;
+    typedef Tr                                          traits_type;
+    typedef typename Tr::char_type                      char_type;
+    typedef typename Tr::int_type                       int_type;
+    typedef std::vector<byte_type, byte_allocator_type> byte_vector_type;
+    typedef std::vector<char_type, char_allocator_type> char_vector_type;
+
+    // Construct a zip stream
+    // More info on the following parameters can be found in the zlib documentation.
+    basic_gz_ostreambuf(ostream_reference ostream_,
+                        size_t level_,
+                        EStrategy strategy_,
+                        size_t window_size_,
+                        size_t memory_level_,
+                        size_t buffer_size_);
+
+    ~basic_gz_ostreambuf();
+
+    int sync();
+    int_type overflow(int_type c);
+
+    // flushes the zip buffer and output buffer.
+    // This method should be called at the end of the compression.
+    // Calling flush multiple times, will lower the compression ratio.
+    std::streamsize flush();
+
+    // flushes the zip buffer and output buffer and finalize the zip stream
+    // This method should be called at the end of the compression.
+    std::streamsize flush_finalize();
+
+
+private:
+    bool zip_to_stream(char_type *, std::streamsize);
+    size_t fill_input_buffer();
+    // flush the zip buffer using a particular mode and flush output buffer
+    std::streamsize flush(int flush_mode);
+
+    ostream_reference m_ostream;
+    z_stream m_zip_stream;
+    int m_err;
+    byte_vector_type m_output_buffer;
+    char_vector_type m_buffer;
+};
+
+// --------------------------------------------------------------------------
+// Class basic_gz_ostreambuf implementation
+// --------------------------------------------------------------------------
+
+template <typename Elem,
+          typename Tr,
+          typename ElemA,
+          typename ByteT,
+          typename ByteAT>
+basic_gz_ostreambuf<Elem, Tr, ElemA, ByteT, ByteAT>::basic_gz_ostreambuf(
+    ostream_reference ostream_,
+    size_t level_,
+    EStrategy strategy_,
+    size_t window_size_,
+    size_t memory_level_,
+    size_t buffer_size_
+    ) :
+    m_ostream(ostream_),
+    m_output_buffer(buffer_size_, 0),
+    m_buffer(buffer_size_, 0)
+{
+    m_zip_stream.zalloc = (alloc_func)0;
+    m_zip_stream.zfree = (free_func)0;
+
+    m_zip_stream.next_in = NULL;
+    m_zip_stream.avail_in = 0;
+    m_zip_stream.avail_out = 0;
+    m_zip_stream.next_out = NULL;
+
+    m_err = deflateInit2(
+        &m_zip_stream,
+        std::min(9, static_cast<int>(level_)),
+        Z_DEFLATED,
+        static_cast<int>(window_size_),
+        std::min(9, static_cast<int>(memory_level_)),
+        static_cast<int>(strategy_)
+        );
+
+    this->setp(&(m_buffer[0]), &(m_buffer[m_buffer.size() - 1]));
+}
+
+template <typename Elem,
+          typename Tr,
+          typename ElemA,
+          typename ByteT,
+          typename ByteAT>
+basic_gz_ostreambuf<Elem, Tr, ElemA, ByteT, ByteAT>::~basic_gz_ostreambuf()
+{
+    flush_finalize();
+    m_ostream.flush();
+    m_err = deflateEnd(&m_zip_stream);
+}
+
+template <typename Elem,
+          typename Tr,
+          typename ElemA,
+          typename ByteT,
+          typename ByteAT>
+int basic_gz_ostreambuf<Elem, Tr, ElemA, ByteT, ByteAT>::sync()
+{
+    if (this->pptr() && this->pptr() > this->pbase())
+    {
+        if (traits_type::eq_int_type(overflow(traits_type::eof()), traits_type::eof()))
+            return -1;
+    }
+
+    return 0;
+}
+
+template <typename Elem,
+          typename Tr,
+          typename ElemA,
+          typename ByteT,
+          typename ByteAT>
+typename basic_gz_ostreambuf<Elem, Tr, ElemA, ByteT, ByteAT>::int_type
+basic_gz_ostreambuf<Elem, Tr, ElemA, ByteT, ByteAT>::overflow(
+    typename basic_gz_ostreambuf<Elem, Tr, ElemA, ByteT, ByteAT>::int_type c)
+{
+    int w = static_cast<int>(this->pptr() - this->pbase());
+
+    if (!traits_type::eq_int_type(c, traits_type::eof()))
+    {
+        *this->pptr() = c;
+        ++w;
+    }
+
+    if (zip_to_stream(this->pbase(), w))
+    {
+        this->setp(this->pbase(), this->epptr() - 1);
+        return c;
+    }
+    else
+    {
+        return traits_type::eof();
+    }
+}
+
+template <typename Elem,
+          typename Tr,
+          typename ElemA,
+          typename ByteT,
+          typename ByteAT>
+bool basic_gz_ostreambuf<Elem, Tr, ElemA, ByteT, ByteAT>::zip_to_stream(
+    typename basic_gz_ostreambuf<Elem, Tr, ElemA, ByteT, ByteAT>::char_type * buffer_,
+    std::streamsize buffer_size_)
+{
+    std::streamsize written_byte_size = 0, total_written_byte_size = 0;
+
+    m_zip_stream.next_in = (byte_buffer_type)buffer_;
+    m_zip_stream.avail_in = static_cast<uInt>(buffer_size_ * sizeof(char_type));
+    m_zip_stream.avail_out = static_cast<uInt>(m_output_buffer.size());
+    m_zip_stream.next_out = &(m_output_buffer[0]);
+    size_t remainder = 0;
+
+    do
+    {
+        m_err = deflate(&m_zip_stream, 0);
+
+        if (m_err == Z_OK  || m_err == Z_STREAM_END)
+        {
+            written_byte_size = static_cast<std::streamsize>(m_output_buffer.size()) - m_zip_stream.avail_out;
+            total_written_byte_size += written_byte_size;
+
+            // ouput buffer is full, dumping to ostream
+            m_ostream.write((const char_type *) &(m_output_buffer[0]),
+                            static_cast<std::streamsize>(written_byte_size / sizeof(char_type)));
+
+            // checking if some bytes were not written.
+            if ((remainder = written_byte_size % sizeof(char_type)) != 0)
+            {
+                // copy to the beginning of the stream
+                std::memmove(&(m_output_buffer[0]),
+                             &(m_output_buffer[written_byte_size - remainder]),
+                             remainder);
+            }
+
+            m_zip_stream.avail_out = static_cast<uInt>(m_output_buffer.size() - remainder);
+            m_zip_stream.next_out = &m_output_buffer[remainder];
+        }
+    }
+    while (m_zip_stream.avail_in != 0 && m_err == Z_OK);
+
+    return m_err == Z_OK;
+}
+
+template <typename Elem,
+          typename Tr,
+          typename ElemA,
+          typename ByteT,
+          typename ByteAT>
+std::streamsize basic_gz_ostreambuf<Elem, Tr, ElemA, ByteT, ByteAT>::flush(int flush_mode)
+{
+    int const buffer_size = static_cast<int>(this->pptr() - this->pbase()); // amount of data currently in buffer
+
+    std::streamsize written_byte_size = 0, total_written_byte_size = 0;
+
+    m_zip_stream.next_in = (byte_buffer_type) this->pbase();
+    m_zip_stream.avail_in = static_cast<uInt>(buffer_size * sizeof(char_type));
+    m_zip_stream.avail_out = static_cast<uInt>(m_output_buffer.size());
+    m_zip_stream.next_out = &(m_output_buffer[0]);
+    size_t remainder = 0;
+
+    do
+    {
+        m_err = deflate(&m_zip_stream, flush_mode);
+        if (m_err == Z_OK || m_err == Z_STREAM_END)
+        {
+            written_byte_size = static_cast<std::streamsize>(m_output_buffer.size()) - m_zip_stream.avail_out;
+            total_written_byte_size += written_byte_size;
+
+            // ouput buffer is full, dumping to ostream
+            m_ostream.write((const char_type *) &(m_output_buffer[0]),
+                            static_cast<std::streamsize>(written_byte_size / sizeof(char_type) * sizeof(byte_type)));
+
+            // checking if some bytes were not written.
+            if ((remainder = written_byte_size % sizeof(char_type)) != 0)
+            {
+                // copy to the beginning of the stream
+                std::memmove(&(m_output_buffer[0]),
+                             &(m_output_buffer[written_byte_size - remainder]),
+                             remainder);
+            }
+
+            m_zip_stream.avail_out = static_cast<uInt>(m_output_buffer.size() - remainder);
+            m_zip_stream.next_out = &m_output_buffer[remainder];
+        }
+    }
+    while (m_err == Z_OK);
+
+    m_ostream.flush();
+
+    return total_written_byte_size;
+}
+
+template <typename Elem,
+          typename Tr,
+          typename ElemA,
+          typename ByteT,
+          typename ByteAT>
+std::streamsize basic_gz_ostreambuf<Elem, Tr, ElemA, ByteT, ByteAT>::flush()
+{
+    return flush(Z_SYNC_FLUSH);
+}
+
+template <typename Elem,
+          typename Tr,
+          typename ElemA,
+          typename ByteT,
+          typename ByteAT>
+std::streamsize basic_gz_ostreambuf<Elem, Tr, ElemA, ByteT, ByteAT>::flush_finalize()
+{
+    return flush(Z_FINISH);
+}
+
+// --------------------------------------------------------------------------
+// Class basic_gz_ostreambase
+// --------------------------------------------------------------------------
+// Base class for zip ostreams.
+// Contains a basic_gz_ostreambuf.
+
+template <typename Elem,
+          typename Tr = std::char_traits<Elem>,
+          typename ElemA = std::allocator<Elem>,
+          typename ByteT = unsigned char,
+          typename ByteAT = std::allocator<ByteT>
+          >
+class basic_gz_ostreambase :
+    virtual public std::basic_ios<Elem, Tr>
+{
+public:
+    typedef std::basic_ostream<Elem, Tr> &                      ostream_reference;
+    typedef basic_gz_ostreambuf<Elem, Tr, ElemA, ByteT, ByteAT> zip_streambuf_type;
+
+    // Construct a zip stream
+    // More info on the following parameters can be found in the zlib documentation.
+    basic_gz_ostreambase(ostream_reference ostream_,
+                          size_t level_,
+                          EStrategy strategy_,
+                          size_t window_size_,
+                          size_t memory_level_,
+                          size_t buffer_size_) :
+        m_buf(ostream_, level_, strategy_, window_size_, memory_level_, buffer_size_)
+    {
+        this->init(&m_buf);
+    }
+
+    // returns the underlying zip ostream object
+    zip_streambuf_type * rdbuf() { return &m_buf; }
+
+private:
+    zip_streambuf_type m_buf;
+};
+
+// --------------------------------------------------------------------------
+// Class basic_gz_ostream
+// --------------------------------------------------------------------------
+// A zipper ostream
+//
+// This class is a ostream decorator that behaves 'almost' like any other ostream.
+// At construction, it takes any ostream that shall be used to output of the compressed data.
+// When finished, you need to call the special method zflush or call the destructor
+// to flush all the intermidiate streams.
+//
+// Example:
+//
+// // creating the target zip string, could be a fstream
+// ostringstream ostringstream_;
+// // creating the zip layer
+// zip_ostream zipper(ostringstream_);
+// // writing data
+// zipper<<f<<" "<<d<<" "<<ui<<" "<<ul<<" "<<us<<" "<<c<<" "<<dum;
+// // zip ostream needs special flushing...
+// zipper.zflush();
+
+template <typename Elem,
+          typename Tr = std::char_traits<Elem>,
+          typename ElemA = std::allocator<Elem>,
+          typename ByteT = unsigned char,
+          typename ByteAT = std::allocator<ByteT>
+          >
+class basic_gz_ostream :
+    public basic_gz_ostreambase<Elem, Tr, ElemA, ByteT, ByteAT>,
+    public std::basic_ostream<Elem, Tr>
+{
+public:
+    typedef basic_gz_ostreambase<Elem, Tr, ElemA, ByteT, ByteAT> zip_ostreambase_type;
+    typedef std::basic_ostream<Elem, Tr>                          ostream_type;
+    typedef ostream_type &                                        ostream_reference;
+
+    // Constructs a zipper ostream decorator
+    //
+    // ostream_ ostream where the compressed output is written
+    // is_gzip_ true if gzip header and footer have to be added
+    // level_ level of compression 0, bad and fast, 9, good and slower,
+    // strategy_ compression strategy
+    // window_size_ see zlib doc
+    // memory_level_ see zlib doc
+    // buffer_size_ the buffer size used to zip data
+
+    basic_gz_ostream(ostream_reference ostream_,
+                      size_t level_ = Z_DEFAULT_COMPRESSION,
+                      EStrategy strategy_ = DefaultStrategy,
+                      size_t window_size_ = 31, // 15 (size) + 16 (gzip header)
+                      size_t memory_level_ = 8,
+                      size_t buffer_size_ = GZ_OUTPUT_DEFAULT_BUFFER_SIZE) :
+        zip_ostreambase_type(ostream_, level_, strategy_, window_size_, memory_level_, buffer_size_),
+        ostream_type(this->rdbuf())
+    {}
+
+    ~basic_gz_ostream()
+    {
+        this->flush(); this->rdbuf()->flush_finalize();
+    }
+
+    // flush inner buffer and zipper buffer
+    basic_gz_ostream<Elem, Tr> & zflush()
+    {
+        this->flush(); this->rdbuf()->flush(); return *this;
+    }
+
+#ifdef _WIN32
+private:
+    void _Add_vtordisp1() {}  // Required to avoid VC++ warning C4250
+    void _Add_vtordisp2() {}  // Required to avoid VC++ warning C4250
+#endif
+};
+
+// ===========================================================================
+// Typedefs
+// ===========================================================================
+
+// A typedef for basic_gz_ostream<char>
+typedef basic_gz_ostream<char>     gz_ostream;
+// A typedef for basic_gz_ostream<wchar_t>
+typedef basic_gz_ostream<wchar_t>  gz_wostream;
+
+} // namespace seqan3::contrib

--- a/test/documentation/seqan3_doxygen_cfg.in
+++ b/test/documentation/seqan3_doxygen_cfg.in
@@ -32,6 +32,9 @@ PREDEFINED             = "CEREAL_SERIALIZE_FUNCTION_NAME=serialize" \
                          "SEQAN3_DOXYGEN_ONLY(x)= x" \
                          "${SEQAN3_DOXYGEN_PREDEFINED_NDEBUG}"
 
+EXCLUDE_SYMBOLS        = seqan3::contrib
+
+
 ## detect headers without extensions (in std module)
 EXTENSION_MAPPING      = .no_extension=C++
 FILE_PATTERNS          = *
@@ -39,4 +42,4 @@ FILE_PATTERNS          = *
 ## Developer VS user mode
 EXTRACT_PRIVATE        = ${SEQAN3_DOXYGEN_EXTRACT_PRIVATE}
 ENABLED_SECTIONS       = ${SEQAN3_DOXYGEN_ENABLED_SECTIONS}
-EXCLUDE_SYMBOLS        = ${SEQAN3_DOXYGEN_EXCLUDE_SYMBOLS}
+EXCLUDE_SYMBOLS        += ${SEQAN3_DOXYGEN_EXCLUDE_SYMBOLS}

--- a/test/performance/io/CMakeLists.txt
+++ b/test/performance/io/CMakeLists.txt
@@ -1,2 +1,3 @@
-
+seqan3_benchmark(stream_input_benchmark.cpp)
+seqan3_benchmark(stream_output_benchmark.cpp)
 seqan3_benchmark(parse_condition_benchmark.cpp)

--- a/test/performance/io/stream_input_benchmark.cpp
+++ b/test/performance/io/stream_input_benchmark.cpp
@@ -1,0 +1,249 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2018, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2018, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+#include <benchmark/benchmark.h>
+
+#include <iostream>
+#include <memory>
+#include <sstream>
+
+#ifdef SEQAN3_HAS_ZLIB
+    #include <seqan3/contrib/stream/gz_istream.hpp>
+    #include <seqan3/contrib/stream/gz_ostream.hpp>
+#endif
+
+// only benchmark BZIP2 if explicitly requested, because slow setup
+#if !defined(SEQAN3_BENCH_BZIP2) && defined(SEQAN3_HAS_BZIP2)
+    #undef SEQAN3_HAS_BZIP2
+#endif
+
+#ifdef SEQAN3_HAS_BZIP2
+    #include <seqan3/contrib/stream/bz2_istream.hpp>
+    #include <seqan3/contrib/stream/bz2_ostream.hpp>
+#endif
+
+// SEQAN2
+#if __has_include(<seqan/stream.h>)
+    #define SEQAN3_HAS_SEQAN2 1
+
+    #ifdef SEQAN3_HAS_ZLIB
+        #define SEQAN_HAS_ZLIB 1
+    #endif
+
+    #ifdef SEQAN3_HAS_BZIP2
+        #define SEQAN_HAS_BZIP2 1
+    #endif
+
+    #include <seqan/stream.h>
+#endif
+
+using namespace seqan3;
+
+std::string input
+{
+    [] ()
+    {
+        std::string line{"The quick brown fox jumps over the lazy dog"};
+        std::string ret;
+        for (size_t i = 0; i < 10'000'000; ++i)
+            ret += line;
+        return ret;
+    } ()
+};
+
+template <typename t>
+std::string const input_comp;
+
+#ifdef SEQAN3_HAS_SEQAN2
+template <>
+std::string const & input_comp<seqan::Nothing> = input;
+#endif
+
+#ifdef SEQAN3_HAS_ZLIB
+template <>
+std::string const input_comp<contrib::gz_istream>
+{
+    [] ()
+    {
+        std::ostringstream ret;
+        contrib::gz_ostream os{ret};
+        std::copy(input.begin(), input.end(), std::ostreambuf_iterator<char>(os));
+        return ret.str();
+    } ()
+};
+#ifdef SEQAN3_HAS_SEQAN2
+template <>
+std::string const & input_comp<seqan::GZFile> = input_comp<contrib::gz_istream>;
+#endif
+#endif
+
+#ifdef SEQAN3_HAS_BZIP2
+template <>
+std::string const input_comp<contrib::bz2_istream>
+{
+    [] ()
+    {
+        std::ostringstream ret;
+        contrib::bz2_ostream os{ret};
+        std::copy(input.begin(), input.end(), std::ostreambuf_iterator<char>(os));
+        return ret.str();
+    } ()
+};
+#ifdef SEQAN3_HAS_SEQAN2
+template <>
+std::string const & input_comp<seqan::BZ2File> = input_comp<contrib::bz2_istream>;
+#endif
+#endif
+
+// ============================================================================
+//  plain benchmark of ostringstream
+// ============================================================================
+
+void uncompressed(benchmark::State & state)
+{
+    std::istringstream s{input};
+
+    std::istreambuf_iterator<char> it{s};
+
+    size_t i = 0;
+    for (auto _ : state)
+    {
+        i += *it;
+        ++it;
+    }
+
+    [[maybe_unused]] volatile size_t j = i;
+}
+
+BENCHMARK(uncompressed);
+
+// ============================================================================
+//  compression applied
+// ============================================================================
+
+template <typename compressed_istream_t>
+void compressed(benchmark::State & state)
+{
+    std::istringstream s{input_comp<compressed_istream_t>};
+    compressed_istream_t comp{s};
+    std::istreambuf_iterator<char> it{comp};
+
+    size_t i = 0;
+    for (auto _ : state)
+    {
+        i += *it;
+        ++it;
+    }
+
+    [[maybe_unused]] volatile size_t j = i;
+}
+
+#ifdef SEQAN3_HAS_ZLIB
+BENCHMARK_TEMPLATE(compressed, contrib::gz_istream);
+#endif
+
+#ifdef SEQAN3_HAS_BZIP2
+BENCHMARK_TEMPLATE(compressed, contrib::bz2_istream);
+#endif
+
+// ============================================================================
+//  compression applied, but stuffed into plain istream
+// ============================================================================
+
+template <typename compressed_istream_t>
+void compressed_type_erased(benchmark::State & state)
+{
+    std::istringstream s{input_comp<compressed_istream_t>};
+    std::unique_ptr<std::istream> comp{new compressed_istream_t{s}};
+    std::istreambuf_iterator<char> it{*comp};
+
+    size_t i = 0;
+    for (auto _ : state)
+    {
+        i += *it;
+        ++it;
+    }
+
+    [[maybe_unused]] volatile size_t j = i;
+}
+
+#ifdef SEQAN3_HAS_ZLIB
+BENCHMARK_TEMPLATE(compressed_type_erased, contrib::gz_istream);
+#endif
+#ifdef SEQAN3_HAS_BZIP2
+BENCHMARK_TEMPLATE(compressed_type_erased, contrib::bz2_istream);
+#endif
+
+// ============================================================================
+//  compression applied, but stuffed into plain istream, also stringstream erased
+// ============================================================================
+
+template <typename compressed_istream_t>
+void compressed_type_erased2(benchmark::State & state)
+{
+    std::unique_ptr<std::istream> s{new std::istringstream{input_comp<compressed_istream_t>}};
+    std::unique_ptr<std::istream> comp{new compressed_istream_t{*s}};
+    std::istreambuf_iterator<char> it{*comp};
+
+    size_t i = 0;
+    for (auto _ : state)
+    {
+        i += *it;
+        ++it;
+    }
+
+    [[maybe_unused]] volatile size_t j = i;
+}
+
+#ifdef SEQAN3_HAS_ZLIB
+BENCHMARK_TEMPLATE(compressed_type_erased2, contrib::gz_istream);
+#endif
+#ifdef SEQAN3_HAS_BZIP2
+BENCHMARK_TEMPLATE(compressed_type_erased2, contrib::bz2_istream);
+#endif
+
+// ============================================================================
+//  seqan2 virtual stream
+// ============================================================================
+
+#ifdef SEQAN3_HAS_SEQAN2
+template <typename compression_type>
+void seqan2_compressed(benchmark::State & state)
+{
+    std::istringstream s{input_comp<compression_type>};
+    seqan::VirtualStream<char, seqan::Input> comp;
+    compression_type tag;
+    open(comp, s, tag);
+
+    auto it = seqan::directionIterator(comp, seqan::Input());
+
+    size_t i = 0;
+    for (auto _ : state)
+    {
+        i += *it;
+        ++it;
+    }
+
+    [[maybe_unused]] volatile size_t j = i;
+}
+BENCHMARK_TEMPLATE(seqan2_compressed, seqan::Nothing);
+
+#ifdef SEQAN_HAS_ZLIB
+BENCHMARK_TEMPLATE(seqan2_compressed, seqan::GZFile);
+// BENCHMARK_TEMPLATE(seqan2_compressed, seqan::BgzfFile);
+#endif
+#ifdef SEQAN_HAS_BZIP2
+BENCHMARK_TEMPLATE(seqan2_compressed, seqan::BZ2File);
+#endif
+
+#endif // SEQAN3_HAS_SEQAN2
+
+// ============================================================================
+//  instantiate tests
+// ============================================================================
+
+BENCHMARK_MAIN();

--- a/test/performance/io/stream_output_benchmark.cpp
+++ b/test/performance/io/stream_output_benchmark.cpp
@@ -1,0 +1,164 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2018, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2018, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+#include <benchmark/benchmark.h>
+
+#include <iostream>
+#include <memory>
+#include <sstream>
+
+#ifdef SEQAN3_HAS_ZLIB
+    #include <seqan3/contrib/stream/gz_ostream.hpp>
+#endif
+
+#ifdef SEQAN3_HAS_BZIP2
+    #include <seqan3/contrib/stream/bz2_ostream.hpp>
+#endif
+
+// SEQAN2
+#if __has_include(<seqan/stream.h>)
+    #define SEQAN3_HAS_SEQAN2 1
+
+    #ifdef SEQAN3_HAS_ZLIB
+        #define SEQAN_HAS_ZLIB 1
+    #endif
+
+    #ifdef SEQAN3_HAS_BZIP2
+        #define SEQAN_HAS_BZIP2 1
+    #endif
+
+    #include <seqan/stream.h>
+#endif
+
+using namespace seqan3;
+
+// ============================================================================
+//  plain benchmark of ostringstream
+// ============================================================================
+
+void uncompressed(benchmark::State & state)
+{
+    std::ostringstream os;
+
+    std::ostreambuf_iterator<char> oit{os};
+
+    size_t i = 0;
+    for (auto _ : state)
+        oit = static_cast<char>(i++ % 128);
+}
+BENCHMARK(uncompressed);
+
+// ============================================================================
+//  compression applied
+// ============================================================================
+
+template <typename compressed_ostream_t>
+void compressed(benchmark::State & state)
+{
+    std::ostringstream os;
+
+    compressed_ostream_t ogzf{os};
+
+    std::ostreambuf_iterator<char> oit{ogzf};
+
+    size_t i = 0;
+    for (auto _ : state)
+        oit = static_cast<char>(i++ % 128);
+}
+
+#ifdef SEQAN3_HAS_ZLIB
+BENCHMARK_TEMPLATE(compressed, contrib::gz_ostream);
+#endif
+#ifdef SEQAN3_HAS_BZIP2
+BENCHMARK_TEMPLATE(compressed, contrib::bz2_ostream);
+#endif
+
+// ============================================================================
+//  compression applied, but stuffed into plain ostream
+// ============================================================================
+
+template <typename compressed_ostream_t>
+void compressed_type_erased(benchmark::State & state)
+{
+    std::ostringstream os;
+
+    std::unique_ptr<std::ostream> ogzf{new compressed_ostream_t{os}};
+
+    std::ostreambuf_iterator<char> oit{*ogzf};
+
+    size_t i = 0;
+    for (auto _ : state)
+        oit = static_cast<char>(i++ % 128);
+}
+
+#ifdef SEQAN3_HAS_ZLIB
+BENCHMARK_TEMPLATE(compressed_type_erased, contrib::gz_ostream);
+#endif
+#ifdef SEQAN3_HAS_BZIP2
+BENCHMARK_TEMPLATE(compressed_type_erased, contrib::bz2_ostream);
+#endif
+
+// ============================================================================
+//  compression applied, but stuffed into plain ostream, also stringstream erased
+// ============================================================================
+
+template <typename compressed_ostream_t>
+void compressed_type_erased2(benchmark::State & state)
+{
+    std::unique_ptr<std::ostream> os{new std::ostringstream{}};
+
+    std::unique_ptr<std::ostream> ogzf{new compressed_ostream_t{*os}};
+
+    std::ostreambuf_iterator<char> oit{*ogzf};
+
+    size_t i = 0;
+    for (auto _ : state)
+        oit = static_cast<char>(i++ % 128);
+}
+
+#ifdef SEQAN3_HAS_ZLIB
+BENCHMARK_TEMPLATE(compressed_type_erased2, contrib::gz_ostream);
+#endif
+#ifdef SEQAN3_HAS_BZIP2
+BENCHMARK_TEMPLATE(compressed_type_erased2, contrib::bz2_ostream);
+#endif
+
+// ============================================================================
+//  seqan2 virtual stream
+// ============================================================================
+
+#ifdef SEQAN3_HAS_SEQAN2
+template <typename compression_type>
+void seqan2_compressed(benchmark::State & state)
+{
+    std::ostringstream os;
+
+    seqan::VirtualStream<char, seqan::Output> ogzf;
+    compression_type tag;
+    open(ogzf, os, tag);
+
+    size_t i = 0;
+    for (auto _ : state)
+        write(ogzf, static_cast<char>(i++ % 128));
+}
+BENCHMARK_TEMPLATE(seqan2_compressed, seqan::Nothing);
+
+#ifdef SEQAN_HAS_ZLIB
+BENCHMARK_TEMPLATE(seqan2_compressed, seqan::GZFile);
+BENCHMARK_TEMPLATE(seqan2_compressed, seqan::BgzfFile);
+#endif
+#ifdef SEQAN_HAS_BZIP2
+BENCHMARK_TEMPLATE(seqan2_compressed, seqan::BZ2File);
+#endif
+
+#endif // SEQAN3_HAS_SEQAN2
+
+// ============================================================================
+//  instantiate tests
+// ============================================================================
+
+BENCHMARK_MAIN();

--- a/test/unit/contrib/CMakeLists.txt
+++ b/test/unit/contrib/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectories()

--- a/test/unit/contrib/stream/CMakeLists.txt
+++ b/test/unit/contrib/stream/CMakeLists.txt
@@ -1,0 +1,9 @@
+if (BZIP2_FOUND)
+    seqan3_test(bz2_istream_test.cpp)
+    seqan3_test(bz2_ostream_test.cpp)
+endif ()
+
+if (ZLIB_FOUND)
+    seqan3_test(gz_istream_test.cpp)
+    seqan3_test(gz_ostream_test.cpp)
+endif ()

--- a/test/unit/contrib/stream/bz2_istream_test.cpp
+++ b/test/unit/contrib/stream/bz2_istream_test.cpp
@@ -1,0 +1,32 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2018, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2018, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <seqan3/contrib/stream/bz2_istream.hpp>
+
+#include "../../io/stream/istream_test_template.hpp"
+
+using namespace seqan3;
+
+template <>
+class istream<contrib::bz2_istream> : public ::testing::Test
+{
+public:
+    static inline std::string compressed
+    {
+        '\x42','\x5A','\x68','\x39','\x31','\x41','\x59','\x26','\x53','\x59','\x45','\x9D','\xEE','\x61','\x00','\x00',
+        '\x04','\x13','\x80','\x40','\x00','\x04','\x00','\x3F','\xFF','\xFF','\xF0','\x20','\x00','\x31','\x46','\x86',
+        '\x80','\x00','\x00','\x31','\xE9','\xA9','\xA6','\x4C','\x86','\x11','\xB4','\x6D','\x47','\x62','\x62','\x08',
+        '\x49','\xED','\x7A','\xA1','\x53','\x65','\x65','\xB1','\x25','\xE3','\xE2','\x60','\xB1','\xF8','\x98','\x39',
+        '\xDD','\x4C','\x09','\x6F','\x9C','\xE8','\x5D','\xC9','\x14','\xE1','\x42','\x41','\x16','\x77','\xB9','\x84',
+    };
+};
+
+using test_types = ::testing::Types<contrib::bz2_istream>;
+
+INSTANTIATE_TYPED_TEST_CASE_P(contrib_streams, istream, test_types);

--- a/test/unit/contrib/stream/bz2_ostream_test.cpp
+++ b/test/unit/contrib/stream/bz2_ostream_test.cpp
@@ -1,0 +1,32 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2018, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2018, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <seqan3/contrib/stream/bz2_ostream.hpp>
+
+#include "../../io/stream/ostream_test_template.hpp"
+
+using namespace seqan3;
+
+template <>
+class ostream<contrib::bz2_ostream> : public ::testing::Test
+{
+public:
+    static inline std::string compressed
+    {
+        '\x42','\x5A','\x68','\x39','\x31','\x41','\x59','\x26','\x53','\x59','\x45','\x9D','\xEE','\x61','\x00','\x00',
+        '\x04','\x13','\x80','\x40','\x00','\x04','\x00','\x3F','\xFF','\xFF','\xF0','\x20','\x00','\x31','\x46','\x86',
+        '\x80','\x00','\x00','\x31','\xE9','\xA9','\xA6','\x4C','\x86','\x11','\xB4','\x6D','\x47','\x62','\x62','\x08',
+        '\x49','\xED','\x7A','\xA1','\x53','\x65','\x65','\xB1','\x25','\xE3','\xE2','\x60','\xB1','\xF8','\x98','\x39',
+        '\xDD','\x4C','\x09','\x6F','\x9C','\xE8','\x5D','\xC9','\x14','\xE1','\x42','\x41','\x16','\x77','\xB9','\x84',
+    };
+};
+
+using test_types = ::testing::Types<contrib::bz2_ostream>;
+
+INSTANTIATE_TYPED_TEST_CASE_P(contrib_streams, ostream, test_types);

--- a/test/unit/contrib/stream/gz_istream_test.cpp
+++ b/test/unit/contrib/stream/gz_istream_test.cpp
@@ -1,0 +1,31 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2018, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2018, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <seqan3/contrib/stream/gz_istream.hpp>
+
+#include "../../io/stream/istream_test_template.hpp"
+
+using namespace seqan3;
+
+template <>
+class istream<contrib::gz_istream> : public ::testing::Test
+{
+public:
+    static inline std::string compressed
+    {
+        '\x1f','\x8b','\x08','\x00','\x00','\x00','\x00','\x00','\x00','\x03','\x0b','\xc9','\x48','\x55','\x28','\x2c',
+        '\xcd','\x4c','\xce','\x56','\x48','\x2a','\xca','\x2f','\xcf','\x53','\x48','\xcb','\xaf','\x50','\xc8','\x2a',
+        '\xcd','\x2d','\x28','\x56','\xc8','\x2f','\x4b','\x2d','\x52','\x28','\x01','\x4a','\xe7','\x24','\x56','\x55',
+        '\x2a','\xa4','\xe4','\xa7','\x03','\x00','\x39','\xa3','\x4f','\x41','\x2b','\x00','\x00','\x00'
+    };
+};
+
+using test_types = ::testing::Types<contrib::gz_istream>;
+
+INSTANTIATE_TYPED_TEST_CASE_P(contrib_streams, istream, test_types);

--- a/test/unit/contrib/stream/gz_ostream_test.cpp
+++ b/test/unit/contrib/stream/gz_ostream_test.cpp
@@ -1,0 +1,31 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2018, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2018, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <seqan3/contrib/stream/gz_ostream.hpp>
+
+#include "../../io/stream/ostream_test_template.hpp"
+
+using namespace seqan3;
+
+template <>
+class ostream<contrib::gz_ostream> : public ::testing::Test
+{
+public:
+    static inline std::string compressed
+    {
+        '\x1f','\x8b','\x08','\x00','\x00','\x00','\x00','\x00','\x00','\x03','\x0b','\xc9','\x48','\x55','\x28','\x2c',
+        '\xcd','\x4c','\xce','\x56','\x48','\x2a','\xca','\x2f','\xcf','\x53','\x48','\xcb','\xaf','\x50','\xc8','\x2a',
+        '\xcd','\x2d','\x28','\x56','\xc8','\x2f','\x4b','\x2d','\x52','\x28','\x01','\x4a','\xe7','\x24','\x56','\x55',
+        '\x2a','\xa4','\xe4','\xa7','\x03','\x00','\x39','\xa3','\x4f','\x41','\x2b','\x00','\x00','\x00'
+    };
+};
+
+using test_types = ::testing::Types<contrib::gz_ostream>;
+
+INSTANTIATE_TYPED_TEST_CASE_P(contrib_streams, ostream, test_types);

--- a/test/unit/io/stream/istream_test_template.hpp
+++ b/test/unit/io/stream/istream_test_template.hpp
@@ -1,0 +1,67 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2018, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2018, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms fi the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <fstream>
+#include <iostream>
+#include <string>
+
+#include <seqan3/io/stream/concept.hpp>
+
+#include <seqan3/test/tmp_filename.hpp>
+
+using namespace seqan3;
+
+template <typename T>
+class istream : public ::testing::Test
+{};
+
+inline std::string const uncompressed{"The quick brown fox jumps over the lazy dog"};
+
+TYPED_TEST_CASE_P(istream);
+
+TYPED_TEST_P(istream, concept_check)
+{
+    EXPECT_TRUE((istream_concept<TypeParam, char>));
+}
+
+TYPED_TEST_P(istream, input)
+{
+    test::tmp_filename filename{"istream_test"};
+
+    {
+        std::ofstream fi{filename.get_path()};
+
+        fi << TestFixture::compressed;
+    }
+
+    std::ifstream fi{filename.get_path(), std::ios::binary};
+    TypeParam comp{fi};
+    std::string buffer{std::istreambuf_iterator<char>{comp}, std::istreambuf_iterator<char>{}};
+
+    EXPECT_EQ(buffer, uncompressed);
+}
+
+TYPED_TEST_P(istream, input_type_erased)
+{
+    test::tmp_filename filename{"istream_test"};
+
+    {
+        std::ofstream fi{filename.get_path()};
+
+        fi << TestFixture::compressed;
+    }
+
+    std::ifstream fi{filename.get_path(), std::ios::binary};
+    std::unique_ptr<std::istream> comp{new TypeParam{fi}};
+    std::string buffer{std::istreambuf_iterator<char>{*comp}, std::istreambuf_iterator<char>{}};
+
+    EXPECT_EQ(buffer, uncompressed);
+}
+
+REGISTER_TYPED_TEST_CASE_P(istream, concept_check, input, input_type_erased);

--- a/test/unit/io/stream/ostream_test_template.hpp
+++ b/test/unit/io/stream/ostream_test_template.hpp
@@ -1,0 +1,68 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2018, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2018, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <fstream>
+#include <iostream>
+#include <string>
+
+#include <seqan3/io/stream/concept.hpp>
+
+#include <seqan3/test/tmp_filename.hpp>
+
+using namespace seqan3;
+
+template <typename T>
+class ostream : public ::testing::Test
+{};
+
+inline std::string const uncompressed{"The quick brown fox jumps over the lazy dog"};
+
+TYPED_TEST_CASE_P(ostream);
+
+TYPED_TEST_P(ostream, concept_check)
+{
+    EXPECT_TRUE((ostream_concept<TypeParam, char>));
+}
+
+TYPED_TEST_P(ostream, output)
+{
+    test::tmp_filename filename{"ostream_test"};
+
+    {
+        std::ofstream of{filename.get_path()};
+        TypeParam ogzf{of};
+
+        ogzf << uncompressed << std::flush;
+    }
+
+    std::ifstream fi{filename.get_path(), std::ios::binary};
+    std::string buffer{std::istreambuf_iterator<char>{fi}, std::istreambuf_iterator<char>{}};
+
+    EXPECT_EQ(buffer, TestFixture::compressed);
+}
+
+TYPED_TEST_P(ostream, output_type_erased)
+{
+    test::tmp_filename filename{"ostream_test"};
+
+    {
+        std::ofstream of{filename.get_path()};
+
+        std::unique_ptr<std::ostream> ogzf{new TypeParam{of}};
+
+        *ogzf << uncompressed << std::flush;
+    }
+
+    std::ifstream fi{filename.get_path(), std::ios::binary};
+    std::string buffer{std::istreambuf_iterator<char>{fi}, std::istreambuf_iterator<char>{}};
+
+    EXPECT_EQ(buffer, TestFixture::compressed);
+}
+
+REGISTER_TYPED_TEST_CASE_P(ostream, concept_check, output, output_type_erased);


### PR DESCRIPTION
resolves #610 

no bgzf for now, because it has additional requirements
not tied into any of the files, yet

Benchmarks have high variance on my system, but here is one:

### ostream
```
-------------------------------------------------------------------------------------
Benchmark                                              Time           CPU Iterations
-------------------------------------------------------------------------------------
uncompressed                                           6 ns          6 ns  144466035
compressed<contrib::gz_ostream>                        8 ns          8 ns   90665658
compressed<contrib::bz2_ostream>                     529 ns        520 ns    1807077
compressed_type_erased<contrib::gz_ostream>            8 ns          8 ns   92377217
compressed_type_erased<contrib::bz2_ostream>         583 ns        576 ns    1000000
compressed_type_erased2<contrib::gz_ostream>           8 ns          8 ns   91140686
compressed_type_erased2<contrib::bz2_ostream>        405 ns        400 ns    2322257
seqan2_compressed<seqan::Nothing>                     14 ns         14 ns   59982816
seqan2_compressed<seqan::GZFile>                      24 ns         23 ns   51139189
seqan2_compressed<seqan::BgzfFile>                     9 ns          9 ns   78701854
seqan2_compressed<seqan::BZ2File>                    568 ns        561 ns    1889330

```

Take-home:
* doing type-erasure the way I proposed is basically free
* seqan2's virtual streams incur a noticeable penalty
* bzip2 is soo slow

### istream 
```
------------------------------------------------------------------------------------
Benchmark                                             Time           CPU Iterations
------------------------------------------------------------------------------------
uncompressed                                          2 ns          2 ns  341142583
compressed<contrib::gz_istream>                       3 ns          3 ns  207857710
compressed_type_erased<contrib::gz_istream>           3 ns          3 ns  207806119
compressed_type_erased2<contrib::gz_istream>          4 ns          4 ns  170516471
seqan2_compressed<seqan::Nothing>                     6 ns          6 ns  119800598
seqan2_compressed<seqan::GZFile>                     10 ns         10 ns   92157975
```
Same thing here (BZip2 bench not run by default, because the setup is so expensive – need to build a a sufficiently large buffer to read from and compression is very slow compared with decompression)