### PR TITLE
[fix] warnings in core tests

### DIFF
--- a/include/seqan3/core/simd/simd_algorithm.hpp
+++ b/include/seqan3/core/simd/simd_algorithm.hpp
@@ -60,7 +60,7 @@ constexpr simd_t fill_impl(typename simd_traits<simd_t>::scalar_type const scala
 template <simd_concept simd_t, typename scalar_t, scalar_t... I>
 constexpr simd_t iota_impl(scalar_t const offset, std::integer_sequence<scalar_t, I...>)
 {
-    return simd_t{(offset + I)...};
+    return simd_t{static_cast<scalar_t>(offset + I)...};
 }
 
 } // namespace seqan3::detail

--- a/test/unit/core/algorithm/configuration_test.cpp
+++ b/test/unit/core/algorithm/configuration_test.cpp
@@ -58,8 +58,8 @@ TEST(configuration, concept_check)
 
 TEST(configuration, tuple_size)
 {
-    EXPECT_EQ((std::tuple_size_v<detail::configuration<bax, bar>>), 2);
-    EXPECT_EQ((std::tuple_size<detail::configuration<bax, bar>>::value), 2);
+    EXPECT_EQ((std::tuple_size_v<detail::configuration<bax, bar>>), 2u);
+    EXPECT_EQ((std::tuple_size<detail::configuration<bax, bar>>::value), 2u);
 }
 
 TEST(configuration, tuple_element)
@@ -122,7 +122,7 @@ TEST(configuration, construction_from_tuple)
     detail::configuration cfg{std::tuple<bar, bax>{bar{}, bax{}}};
 
     using t = typename decltype(cfg)::base_type;
-    EXPECT_EQ(std::tuple_size_v<decltype(static_cast<t>(cfg))>, 2);
+    EXPECT_EQ(std::tuple_size_v<decltype(static_cast<t>(cfg))>, 2u);
 }
 
 template <size_t I>
@@ -164,9 +164,9 @@ TEST(configuration, replace_with)
 TEST(configuration, size)
 {
     detail::configuration<foo<0>> cfg{};
-    EXPECT_EQ(cfg.size(), 1);
-    EXPECT_EQ((detail::configuration<foo<1>, foo<0>>{}.size()), 2);
-    EXPECT_EQ(detail::configuration<>{}.size(), 0);
+    EXPECT_EQ(cfg.size(), 1u);
+    EXPECT_EQ((detail::configuration<foo<1>, foo<0>>{}.size()), 2u);
+    EXPECT_EQ(detail::configuration<>{}.size(), 0u);
 }
 
 struct bar_fn_impl : public detail::configuration_fn_base<bar_fn_impl>

--- a/test/unit/core/bit_manipulation_test.cpp
+++ b/test/unit/core/bit_manipulation_test.cpp
@@ -71,10 +71,10 @@ TEST(bit_manipulation, next_power_of_two)
     constexpr size_t next_power_of_two1 = next_power_of_two(1);
     constexpr size_t next_power_of_two2 = next_power_of_two(2);
     constexpr size_t next_power_of_two3 = next_power_of_two(3);
-    EXPECT_EQ(next_power_of_two0, 1);
-    EXPECT_EQ(next_power_of_two1, 1);
-    EXPECT_EQ(next_power_of_two2, 2);
-    EXPECT_EQ(next_power_of_two3, 4);
+    EXPECT_EQ(next_power_of_two0, 1u);
+    EXPECT_EQ(next_power_of_two1, 1u);
+    EXPECT_EQ(next_power_of_two2, 2u);
+    EXPECT_EQ(next_power_of_two3, 4u);
 
     for (size_t power_of_two = 1; power_of_two <= (size_t{1u} << 31); power_of_two <<= 1)
     {

--- a/test/unit/core/tuple_utility_test.cpp
+++ b/test/unit/core/tuple_utility_test.cpp
@@ -92,15 +92,15 @@ TYPED_TEST(tuple_utility, detail_split)
 
     {
         auto res = detail::tuple_split<0>(t, std::make_index_sequence<0>{});
-        EXPECT_EQ(std::tuple_size_v<decltype(res)>, 0);
+        EXPECT_EQ(std::tuple_size_v<decltype(res)>, 0u);
     }
 
     {
         auto res = detail::tuple_split<2>(t, std::make_index_sequence<2>{});
-        EXPECT_EQ(std::tuple_size_v<decltype(res)>, 2);
+        EXPECT_EQ(std::tuple_size_v<decltype(res)>, 2u);
         EXPECT_TRUE((std::is_same_v<std::tuple_element_t<0, decltype(res)>, bar>));
         EXPECT_TRUE((std::is_same_v<std::tuple_element_t<1, decltype(res)>, float>));
-        EXPECT_EQ(std::get<0>(res).get(), 2);
+        EXPECT_EQ(std::get<0>(res).get(), 2u);
         EXPECT_FLOAT_EQ(std::get<1>(res), 2.1);
     }
 }
@@ -111,43 +111,43 @@ TYPED_TEST(tuple_utility, tuple_split_by_pos_lvalue)
     {
         auto res = tuple_split<0>(t);
 
-        EXPECT_EQ(std::tuple_size_v<decltype(res)>, 2);
-        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<0>(res))>>, 0);
-        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<1>(res))>>, 4);
+        EXPECT_EQ(std::tuple_size_v<decltype(res)>, 2u);
+        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<0>(res))>>, 0u);
+        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<1>(res))>>, 4u);
 
         EXPECT_EQ(std::get<0>(std::get<1>(res)), 1);
         EXPECT_EQ(std::get<1>(std::get<1>(res)), 10l);
-        EXPECT_EQ(std::get<2>(std::get<1>(res)).get(), 2);
+        EXPECT_EQ(std::get<2>(std::get<1>(res)).get(), 2u);
         EXPECT_FLOAT_EQ(std::get<3>(std::get<1>(res)), 2.1);
     }
 
     {
         auto res = tuple_split<1>(t);
 
-        EXPECT_EQ(std::tuple_size_v<decltype(res)>, 2);
-        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<0>(res))>>, 1);
-        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<1>(res))>>, 3);
+        EXPECT_EQ(std::tuple_size_v<decltype(res)>, 2u);
+        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<0>(res))>>, 1u);
+        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<1>(res))>>, 3u);
 
         EXPECT_EQ(std::get<0>(std::get<0>(res)), 1);
         EXPECT_EQ(std::get<0>(std::get<1>(res)), 10l);
-        EXPECT_EQ(std::get<1>(std::get<1>(res)).get(), 2);
+        EXPECT_EQ(std::get<1>(std::get<1>(res)).get(), 2u);
         EXPECT_FLOAT_EQ(std::get<2>(std::get<1>(res)), 2.1);
     }
 
     {
         auto res = tuple_split<3>(t);
 
-        EXPECT_EQ(std::tuple_size_v<decltype(res)>, 2);
-        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<0>(res))>>, 3);
-        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<1>(res))>>, 1);
+        EXPECT_EQ(std::tuple_size_v<decltype(res)>, 2u);
+        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<0>(res))>>, 3u);
+        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<1>(res))>>, 1u);
     }
 
     {
         auto res = tuple_split<4>(t);
 
-        EXPECT_EQ(std::tuple_size_v<decltype(res)>, 2);
-        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<0>(res))>>, 4);
-        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<1>(res))>>, 0);
+        EXPECT_EQ(std::tuple_size_v<decltype(res)>, 2u);
+        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<0>(res))>>, 4u);
+        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<1>(res))>>, 0u);
     }
 }
 
@@ -158,13 +158,13 @@ TYPED_TEST(tuple_utility, tuple_split_by_pos_const_lvalue)
     {
         auto res = tuple_split<0>(t);
 
-        EXPECT_EQ(std::tuple_size_v<decltype(res)>, 2);
-        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<0>(res))>>, 0);
-        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<1>(res))>>, 4);
+        EXPECT_EQ(std::tuple_size_v<decltype(res)>, 2u);
+        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<0>(res))>>, 0u);
+        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<1>(res))>>, 4u);
 
         EXPECT_EQ(std::get<0>(std::get<1>(res)), 1);
         EXPECT_EQ(std::get<1>(std::get<1>(res)), 10l);
-        EXPECT_EQ(std::get<2>(std::get<1>(res)).get(), 2);
+        EXPECT_EQ(std::get<2>(std::get<1>(res)).get(), 2u);
         EXPECT_FLOAT_EQ(std::get<3>(std::get<1>(res)), 2.1);
     }
 }
@@ -174,13 +174,13 @@ TYPED_TEST(tuple_utility, tuple_split_by_pos_rvalue)
     {
         auto res = tuple_split<0>(TypeParam{1, 10l, bar{2}, 2.1});
 
-        EXPECT_EQ(std::tuple_size_v<decltype(res)>, 2);
-        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<0>(res))>>, 0);
-        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<1>(res))>>, 4);
+        EXPECT_EQ(std::tuple_size_v<decltype(res)>, 2u);
+        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<0>(res))>>, 0u);
+        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<1>(res))>>, 4u);
 
         EXPECT_EQ(std::get<0>(std::get<1>(res)), 1);
         EXPECT_EQ(std::get<1>(std::get<1>(res)), 10l);
-        EXPECT_EQ(std::get<2>(std::get<1>(res)).get(), 2);
+        EXPECT_EQ(std::get<2>(std::get<1>(res)).get(), 2u);
         EXPECT_FLOAT_EQ(std::get<3>(std::get<1>(res)), 2.1);
     }
 }
@@ -192,13 +192,13 @@ TYPED_TEST(tuple_utility, tuple_split_by_pos_const_rvalue)
         EXPECT_TRUE((std::is_same_v<decltype(t), TypeParam const>));
         auto res = tuple_split<0>(std::move(t));
 
-        EXPECT_EQ(std::tuple_size_v<decltype(res)>, 2);
-        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<0>(res))>>, 0);
-        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<1>(res))>>, 4);
+        EXPECT_EQ(std::tuple_size_v<decltype(res)>, 2u);
+        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<0>(res))>>, 0u);
+        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<1>(res))>>, 4u);
 
         EXPECT_EQ(std::get<0>(std::get<1>(res)), 1);
         EXPECT_EQ(std::get<1>(std::get<1>(res)), 10l);
-        EXPECT_EQ(std::get<2>(std::get<1>(res)).get(), 2);
+        EXPECT_EQ(std::get<2>(std::get<1>(res)).get(), 2u);
         EXPECT_FLOAT_EQ(std::get<3>(std::get<1>(res)), 2.1);
     }
 }
@@ -209,35 +209,35 @@ TYPED_TEST(tuple_utility, tuple_split_by_type_lvalue)
     {
         auto res = tuple_split<int>(t);
 
-        EXPECT_EQ(std::tuple_size_v<decltype(res)>, 2);
-        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<0>(res))>>, 0);
-        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<1>(res))>>, 4);
+        EXPECT_EQ(std::tuple_size_v<decltype(res)>, 2u);
+        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<0>(res))>>, 0u);
+        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<1>(res))>>, 4u);
 
         EXPECT_EQ(std::get<0>(std::get<1>(res)), 1);
         EXPECT_EQ(std::get<1>(std::get<1>(res)), 10l);
-        EXPECT_EQ(std::get<2>(std::get<1>(res)).get(), 2);
+        EXPECT_EQ(std::get<2>(std::get<1>(res)).get(), 2u);
         EXPECT_FLOAT_EQ(std::get<3>(std::get<1>(res)), 2.1);
     }
 
     {
         auto res = tuple_split<long int>(t);
 
-        EXPECT_EQ(std::tuple_size_v<decltype(res)>, 2);
-        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<0>(res))>>, 1);
-        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<1>(res))>>, 3);
+        EXPECT_EQ(std::tuple_size_v<decltype(res)>, 2u);
+        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<0>(res))>>, 1u);
+        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<1>(res))>>, 3u);
 
         EXPECT_EQ(std::get<0>(std::get<0>(res)), 1);
         EXPECT_EQ(std::get<0>(std::get<1>(res)), 10l);
-        EXPECT_EQ(std::get<1>(std::get<1>(res)).get(), 2);
+        EXPECT_EQ(std::get<1>(std::get<1>(res)).get(), 2u);
         EXPECT_FLOAT_EQ(std::get<2>(std::get<1>(res)), 2.1);
     }
 
     {
         auto res = tuple_split<float>(t);
 
-        EXPECT_EQ(std::tuple_size_v<decltype(res)>, 2);
-        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<0>(res))>>, 3);
-        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<1>(res))>>, 1);
+        EXPECT_EQ(std::tuple_size_v<decltype(res)>, 2u);
+        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<0>(res))>>, 3u);
+        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<1>(res))>>, 1u);
     }
 }
 
@@ -248,13 +248,13 @@ TYPED_TEST(tuple_utility, tuple_split_by_type_const_lvalue)
     {
         auto res = tuple_split<int>(t);
 
-        EXPECT_EQ(std::tuple_size_v<decltype(res)>, 2);
-        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<0>(res))>>, 0);
-        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<1>(res))>>, 4);
+        EXPECT_EQ(std::tuple_size_v<decltype(res)>, 2u);
+        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<0>(res))>>, 0u);
+        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<1>(res))>>, 4u);
 
         EXPECT_EQ(std::get<0>(std::get<1>(res)), 1);
         EXPECT_EQ(std::get<1>(std::get<1>(res)), 10l);
-        EXPECT_EQ(std::get<2>(std::get<1>(res)).get(), 2);
+        EXPECT_EQ(std::get<2>(std::get<1>(res)).get(), 2u);
         EXPECT_FLOAT_EQ(std::get<3>(std::get<1>(res)), 2.1);
     }
 }
@@ -264,13 +264,13 @@ TYPED_TEST(tuple_utility, tuple_split_by_type_rvalue)
     {
         auto res = tuple_split<int>(TypeParam{1, 10l, bar{2}, 2.1});
 
-        EXPECT_EQ(std::tuple_size_v<decltype(res)>, 2);
-        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<0>(res))>>, 0);
-        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<1>(res))>>, 4);
+        EXPECT_EQ(std::tuple_size_v<decltype(res)>, 2u);
+        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<0>(res))>>, 0u);
+        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<1>(res))>>, 4u);
 
         EXPECT_EQ(std::get<0>(std::get<1>(res)), 1);
         EXPECT_EQ(std::get<1>(std::get<1>(res)), 10l);
-        EXPECT_EQ(std::get<2>(std::get<1>(res)).get(), 2);
+        EXPECT_EQ(std::get<2>(std::get<1>(res)).get(), 2u);
         EXPECT_FLOAT_EQ(std::get<3>(std::get<1>(res)), 2.1);
     }
 }
@@ -282,13 +282,13 @@ TYPED_TEST(tuple_utility, tuple_split_by_type_const_rvalue)
         EXPECT_TRUE((std::is_same_v<decltype(t), TypeParam const>));
         auto res = tuple_split<int>(std::move(t));
 
-        EXPECT_EQ(std::tuple_size_v<decltype(res)>, 2);
-        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<0>(res))>>, 0);
-        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<1>(res))>>, 4);
+        EXPECT_EQ(std::tuple_size_v<decltype(res)>, 2u);
+        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<0>(res))>>, 0u);
+        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(std::get<1>(res))>>, 4u);
 
         EXPECT_EQ(std::get<0>(std::get<1>(res)), 1);
         EXPECT_EQ(std::get<1>(std::get<1>(res)), 10l);
-        EXPECT_EQ(std::get<2>(std::get<1>(res)).get(), 2);
+        EXPECT_EQ(std::get<2>(std::get<1>(res)).get(), 2u);
         EXPECT_FLOAT_EQ(std::get<3>(std::get<1>(res)), 2.1);
     }
 }
@@ -298,15 +298,15 @@ TYPED_TEST(tuple_utility, tuple_pop_front_lvalue)
     TypeParam t{1, 10l, bar{2}, 2.1};
     auto res = tuple_pop_front(t);
 
-    EXPECT_EQ(std::tuple_size_v<decltype(res)>, 3);
+    EXPECT_EQ(std::tuple_size_v<decltype(res)>, 3u);
 
     EXPECT_EQ(std::get<0>(res), 10l);
-    EXPECT_EQ(std::get<1>(res).get(), 2);
+    EXPECT_EQ(std::get<1>(res).get(), 2u);
     EXPECT_FLOAT_EQ(std::get<2>(res), 2.1);
 
     auto res2 = tuple_pop_front(tuple_pop_front(tuple_pop_front(res)));
 
-    EXPECT_EQ(std::tuple_size_v<decltype(res2)>, 0);
+    EXPECT_EQ(std::tuple_size_v<decltype(res2)>, 0u);
 }
 
 TYPED_TEST(tuple_utility, tuple_pop_front_const_lvalue)
@@ -314,10 +314,10 @@ TYPED_TEST(tuple_utility, tuple_pop_front_const_lvalue)
     TypeParam const t{TypeParam{1, 10l, bar{2}, 2.1}};
     auto res = tuple_pop_front(t);
 
-    EXPECT_EQ(std::tuple_size_v<decltype(res)>, 3);
+    EXPECT_EQ(std::tuple_size_v<decltype(res)>, 3u);
 
     EXPECT_EQ(std::get<0>(res), 10l);
-    EXPECT_EQ(std::get<1>(res).get(), 2);
+    EXPECT_EQ(std::get<1>(res).get(), 2u);
     EXPECT_FLOAT_EQ(std::get<2>(res), 2.1);
 }
 
@@ -326,10 +326,10 @@ TYPED_TEST(tuple_utility, tuple_pop_front_rvalue)
     TypeParam t{1, 10l, bar{2}, 2.1};
     auto res = tuple_pop_front(std::move(t));
 
-    EXPECT_EQ(std::tuple_size_v<decltype(res)>, 3);
+    EXPECT_EQ(std::tuple_size_v<decltype(res)>, 3u);
 
     EXPECT_EQ(std::get<0>(res), 10l);
-    EXPECT_EQ(std::get<1>(res).get(), 2);
+    EXPECT_EQ(std::get<1>(res).get(), 2u);
     EXPECT_FLOAT_EQ(std::get<2>(res), 2.1);
 }
 
@@ -338,10 +338,10 @@ TYPED_TEST(tuple_utility, tuple_pop_front_const_rvalue)
     TypeParam const t{TypeParam{1, 10l, bar{2}, 2.1}};
     auto res = tuple_pop_front(std::move(t));
 
-    EXPECT_EQ(std::tuple_size_v<decltype(res)>, 3);
+    EXPECT_EQ(std::tuple_size_v<decltype(res)>, 3u);
 
     EXPECT_EQ(std::get<0>(res), 10l);
-    EXPECT_EQ(std::get<1>(res).get(), 2);
+    EXPECT_EQ(std::get<1>(res).get(), 2u);
     EXPECT_FLOAT_EQ(std::get<2>(res), 2.1);
 }
 
@@ -351,8 +351,8 @@ TYPED_TEST(tuple_utility, tuple_split_and_pop)
     {
         auto [left, right] = tuple_split<float>(t);
 
-        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(left)>>, 0);
-        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(right)>>, 1);
+        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(left)>>, 0u);
+        EXPECT_EQ(std::tuple_size_v<std::remove_reference_t<decltype(right)>>, 1u);
 
         using left_t = detail::transfer_template_args_onto_t<remove_cvref_t<decltype(left)>, type_list>;
         using right_t = detail::transfer_template_args_onto_t<remove_cvref_t<decltype(tuple_pop_front(right))>, type_list>;


### PR DESCRIPTION
Part of #607, fixes mainly `signed` != `unsigned` warnings. 