### PR TITLE
[fix] warnings in alphabet tests

### DIFF
--- a/test/unit/alphabet/adaptation/char_test.cpp
+++ b/test/unit/alphabet/adaptation/char_test.cpp
@@ -72,15 +72,9 @@ TYPED_TEST(char_adaptation, to_rank)
     TypeParam l{'A'};
     EXPECT_TRUE((std::is_same_v<decltype(to_rank(l)), underlying_rank_t<TypeParam>>));
     EXPECT_TRUE((std::is_same_v<decltype(to_rank(TypeParam{'A'})), underlying_rank_t<TypeParam>>));
-    if constexpr (std::is_unsigned_v<TypeParam>)
-    {
-        unsigned char cmp{'A'};
-        EXPECT_EQ(to_rank(TypeParam{65}), cmp);
-    }
-    else
-    {
-        EXPECT_EQ(to_rank(TypeParam{65}), 'A');
-    }
+
+    unsigned char cmp{'A'};
+    EXPECT_EQ(to_rank(TypeParam{65}), cmp);
 }
 
 TYPED_TEST(char_adaptation, assign_rank)

--- a/test/unit/alphabet/alphabet_test_template.hpp
+++ b/test/unit/alphabet/alphabet_test_template.hpp
@@ -206,7 +206,7 @@ TYPED_TEST_P(alphabet, debug_streaming)
     debug_stream << TypeParam{};
 
     o.flush();
-    EXPECT_EQ(o.str().size(), 1);
+    EXPECT_EQ(o.str().size(), 1u);
 }
 
 TYPED_TEST_P(alphabet, hash)
@@ -239,7 +239,7 @@ TYPED_TEST_P(alphabet, hash)
             text.push_back(assign_rank(TypeParam{}, 0));
         }
         std::hash<decltype(text)> h{};
-        ASSERT_EQ(h(text), 0);
+        ASSERT_EQ(h(text), 0u);
     }
 }
 


### PR DESCRIPTION
Part of #607, fixes mainly `signed` != `unsigned` warnings. 