### PR TITLE
[fix] some warnings in alignment tests

### DIFF
--- a/include/seqan3/alignment/configuration/align_config_max_error.hpp
+++ b/include/seqan3/alignment/configuration/align_config_max_error.hpp
@@ -73,7 +73,7 @@ struct align_config_max_error_adaptor : public configuration_fn_base<align_confi
     //!\cond
         requires is_algorithm_configuration_v<remove_cvref_t<configuration_t>>
     //!\endcond
-    constexpr auto invoke(configuration_t && cfg, int32_t const err) const
+    constexpr auto invoke(configuration_t && cfg, uint32_t const err) const
     {
         static_assert(is_valid_alignment_configuration_v<align_cfg::id::max_error, remove_cvref_t<configuration_t>>,
                       SEQAN3_INVALID_CONFIG(align_cfg::id::max_error));

--- a/test/unit/alignment/configuration/align_config_max_error_test.cpp
+++ b/test/unit/alignment/configuration/align_config_max_error_test.cpp
@@ -80,7 +80,7 @@ TEST(align_config_max_error, get_by_enum)
     detail::configuration cfg = align_cfg::max_error(10);
     auto const c_cfg = detail::configuration{align_cfg::max_error(10)};
 
-    EXPECT_EQ(get<align_cfg::id::max_error>(cfg), 10);
+    EXPECT_EQ(get<align_cfg::id::max_error>(cfg), 10u);
     EXPECT_TRUE((std::is_same_v<decltype(get<align_cfg::id::max_error>(cfg)),
                                 uint32_t &>));
 

--- a/test/unit/alignment/matrix/alignment_matrix_formatter_test.cpp
+++ b/test/unit/alignment/matrix/alignment_matrix_formatter_test.cpp
@@ -61,55 +61,55 @@ using typename seqan3::detail::matrix_formatter_test;
 
 TEST_F(matrix_formatter_test, unicode_str_length)
 {
-    EXPECT_EQ(unicode_str_length(" "), 1);
-    EXPECT_EQ(unicode_str_length(";"), 1);
-    EXPECT_EQ(unicode_str_length(""), 0);
-    EXPECT_EQ(unicode_str_length("N"), 1);
-    EXPECT_EQ(unicode_str_length("D"), 1);
-    EXPECT_EQ(unicode_str_length("U"), 1);
-    EXPECT_EQ(unicode_str_length("DU"), 2);
-    EXPECT_EQ(unicode_str_length("L"), 1);
-    EXPECT_EQ(unicode_str_length("DL"), 2);
-    EXPECT_EQ(unicode_str_length("UL"), 2);
-    EXPECT_EQ(unicode_str_length("DUL"), 3);
-    EXPECT_EQ(unicode_str_length("|"), 1);
-    EXPECT_EQ(unicode_str_length("-"), 1);
-    EXPECT_EQ(unicode_str_length("/"), 1);
-    EXPECT_EQ(unicode_str_length("INF"), 3);
+    EXPECT_EQ(unicode_str_length(" "), 1u);
+    EXPECT_EQ(unicode_str_length(";"), 1u);
+    EXPECT_EQ(unicode_str_length(""), 0u);
+    EXPECT_EQ(unicode_str_length("N"), 1u);
+    EXPECT_EQ(unicode_str_length("D"), 1u);
+    EXPECT_EQ(unicode_str_length("U"), 1u);
+    EXPECT_EQ(unicode_str_length("DU"), 2u);
+    EXPECT_EQ(unicode_str_length("L"), 1u);
+    EXPECT_EQ(unicode_str_length("DL"), 2u);
+    EXPECT_EQ(unicode_str_length("UL"), 2u);
+    EXPECT_EQ(unicode_str_length("DUL"), 3u);
+    EXPECT_EQ(unicode_str_length("|"), 1u);
+    EXPECT_EQ(unicode_str_length("-"), 1u);
+    EXPECT_EQ(unicode_str_length("/"), 1u);
+    EXPECT_EQ(unicode_str_length("INF"), 3u);
 
-    EXPECT_EQ(unicode_str_length(u8"ε"), 1);
-    EXPECT_EQ(unicode_str_length(u8"║"), 1);
-    EXPECT_EQ(unicode_str_length(u8"═"), 1);
-    EXPECT_EQ(unicode_str_length(u8"╬"), 1);
-    EXPECT_EQ(unicode_str_length(u8"∞"), 1);
+    EXPECT_EQ(unicode_str_length(u8"ε"), 1u);
+    EXPECT_EQ(unicode_str_length(u8"║"), 1u);
+    EXPECT_EQ(unicode_str_length(u8"═"), 1u);
+    EXPECT_EQ(unicode_str_length(u8"╬"), 1u);
+    EXPECT_EQ(unicode_str_length(u8"∞"), 1u);
 
-    EXPECT_EQ(unicode_str_length(u8"█"), 1);
-    EXPECT_EQ(unicode_str_length(u8"▘"), 1);
-    EXPECT_EQ(unicode_str_length(u8"▝"), 1);
-    EXPECT_EQ(unicode_str_length(u8"▀"), 1);
-    EXPECT_EQ(unicode_str_length(u8"▖"), 1);
-    EXPECT_EQ(unicode_str_length(u8"▌"), 1);
-    EXPECT_EQ(unicode_str_length(u8"▞"), 1);
-    EXPECT_EQ(unicode_str_length(u8"▛"), 1);
-    EXPECT_EQ(unicode_str_length(u8"∞"), 1);
+    EXPECT_EQ(unicode_str_length(u8"█"), 1u);
+    EXPECT_EQ(unicode_str_length(u8"▘"), 1u);
+    EXPECT_EQ(unicode_str_length(u8"▝"), 1u);
+    EXPECT_EQ(unicode_str_length(u8"▀"), 1u);
+    EXPECT_EQ(unicode_str_length(u8"▖"), 1u);
+    EXPECT_EQ(unicode_str_length(u8"▌"), 1u);
+    EXPECT_EQ(unicode_str_length(u8"▞"), 1u);
+    EXPECT_EQ(unicode_str_length(u8"▛"), 1u);
+    EXPECT_EQ(unicode_str_length(u8"∞"), 1u);
 
-    EXPECT_EQ(unicode_str_length(u8"⠀"), 1);
-    EXPECT_EQ(unicode_str_length(u8"⠁"), 1);
-    EXPECT_EQ(unicode_str_length(u8"⠈"), 1);
-    EXPECT_EQ(unicode_str_length(u8"⠉"), 1);
-    EXPECT_EQ(unicode_str_length(u8"⠄"), 1);
-    EXPECT_EQ(unicode_str_length(u8"⠅"), 1);
-    EXPECT_EQ(unicode_str_length(u8"⠌"), 1);
-    EXPECT_EQ(unicode_str_length(u8"⠍"), 1);
+    EXPECT_EQ(unicode_str_length(u8"⠀"), 1u);
+    EXPECT_EQ(unicode_str_length(u8"⠁"), 1u);
+    EXPECT_EQ(unicode_str_length(u8"⠈"), 1u);
+    EXPECT_EQ(unicode_str_length(u8"⠉"), 1u);
+    EXPECT_EQ(unicode_str_length(u8"⠄"), 1u);
+    EXPECT_EQ(unicode_str_length(u8"⠅"), 1u);
+    EXPECT_EQ(unicode_str_length(u8"⠌"), 1u);
+    EXPECT_EQ(unicode_str_length(u8"⠍"), 1u);
 
-    EXPECT_EQ(unicode_str_length(u8"↺"), 1);
-    EXPECT_EQ(unicode_str_length(u8"↖"), 1);
-    EXPECT_EQ(unicode_str_length(u8"↑"), 1);
-    EXPECT_EQ(unicode_str_length(u8"↖↑"), 2);
-    EXPECT_EQ(unicode_str_length(u8"←"), 1);
-    EXPECT_EQ(unicode_str_length(u8"↖←"), 2);
-    EXPECT_EQ(unicode_str_length(u8"↑←"), 2);
-    EXPECT_EQ(unicode_str_length(u8"↖↑←"), 3);
+    EXPECT_EQ(unicode_str_length(u8"↺"), 1u);
+    EXPECT_EQ(unicode_str_length(u8"↖"), 1u);
+    EXPECT_EQ(unicode_str_length(u8"↑"), 1u);
+    EXPECT_EQ(unicode_str_length(u8"↖↑"), 2u);
+    EXPECT_EQ(unicode_str_length(u8"←"), 1u);
+    EXPECT_EQ(unicode_str_length(u8"↖←"), 2u);
+    EXPECT_EQ(unicode_str_length(u8"↑←"), 2u);
+    EXPECT_EQ(unicode_str_length(u8"↖↑←"), 3u);
 }
 
 TEST_F(matrix_formatter_test, score_matrix_ascii)

--- a/test/unit/alignment/pairwise/alignment_result_test.cpp
+++ b/test/unit/alignment/pairwise/alignment_result_test.cpp
@@ -96,7 +96,7 @@ TYPED_TEST(align_result_test, tuple_element)
 TYPED_TEST(align_result_test, tuple_size)
 {
     using res_t = typename TestFixture::res_t;
-    EXPECT_EQ(std::tuple_size_v<res_t>, 5);
+    EXPECT_EQ(std::tuple_size_v<res_t>, 5u);
 }
 
 TYPED_TEST(align_result_test, std_position_get)
@@ -106,32 +106,32 @@ TYPED_TEST(align_result_test, std_position_get)
     seq_t seq{'A'_dna4, 'T'_dna4, gap::GAP, 'C'_dna4, gap::GAP, gap::GAP, 'A'_dna4};
 
     {
-        res_t tmp{1, 0, {10, 10}, {0, 0}, {seq, seq}};
-        EXPECT_EQ(std::get<0>(tmp), 1);
+        res_t tmp{1u, 0, {10u, 10u}, {0u, 0u}, {seq, seq}};
+        EXPECT_EQ(std::get<0>(tmp), 1u);
         EXPECT_EQ(std::string{std::get<0>(std::get<4>(tmp)) | view::to_char}, std::string{"AT-C--A"});
         EXPECT_TRUE((std::is_same_v<decltype(std::get<0>(tmp)), typename TestFixture::id_t &>));
     }
 
     {
-        res_t const tmp{res_t{1, 0, {10, 10}, {0, 0}, {seq, seq}}};
-        EXPECT_EQ(std::get<0>(tmp), 1);
+        res_t const tmp{res_t{1u, 0, {10u, 10u}, {0u, 0u}, {seq, seq}}};
+        EXPECT_EQ(std::get<0>(tmp), 1u);
         EXPECT_EQ(std::string{std::get<0>(std::get<4>(tmp)) | view::to_char}, std::string{"AT-C--A"});
         EXPECT_TRUE((std::is_same_v<decltype(std::get<0>(tmp)), typename TestFixture::id_t const &>));
     }
 
     {
-        res_t tmp{1, 0, {10, 10}, {0, 0}, {seq, seq}};
-        EXPECT_EQ(std::get<0>(std::move(tmp)), 1);
-        res_t tmp2{1, 0, {10, 10}, {0, 0}, {seq, seq}};
+        res_t tmp{1u, 0, {10u, 10u}, {0u, 0u}, {seq, seq}};
+        EXPECT_EQ(std::get<0>(std::move(tmp)), 1u);
+        res_t tmp2{1u, 0, {10u, 10u}, {0u, 0u}, {seq, seq}};
         EXPECT_EQ(std::string{view::persist(std::get<0>(std::get<4>(std::move(tmp2)))) | view::to_char},
                   std::string{"AT-C--A"});
         EXPECT_TRUE((std::is_same_v<decltype(std::get<0>(std::move(tmp))), typename TestFixture::id_t &&>));
     }
 
     {
-        res_t const tmp{res_t{1, 0, {10, 10}, {0, 0}, {seq, seq}}};
-        EXPECT_EQ(std::get<0>(std::move(tmp)), 1);
-        res_t const tmp2{res_t{1, 0, {10, 10}, {0, 0}, {seq, seq}}};
+        res_t const tmp{res_t{1u, 0, {10u, 10u}, {0u, 0u}, {seq, seq}}};
+        EXPECT_EQ(std::get<0>(std::move(tmp)), 1u);
+        res_t const tmp2{res_t{1u, 0, {10u, 10u}, {0u, 0u}, {seq, seq}}};
         EXPECT_EQ(std::string{view::persist(std::get<0>(std::get<4>(std::move(tmp2)))) | view::to_char},
                   std::string{"AT-C--A"});
         // TODO: enable if gcc-7 is fixed.
@@ -146,32 +146,32 @@ TYPED_TEST(align_result_test, seqan3_pos_get)
     seq_t seq{'A'_dna4, 'T'_dna4, gap::GAP, 'C'_dna4, gap::GAP, gap::GAP, 'A'_dna4};
 
     {
-        res_t tmp{1, 0, {10, 10}, {0, 0}, {seq, seq}};
-        EXPECT_EQ(get<0>(tmp), 1);
+        res_t tmp{1u, 0, {10u, 10u}, {0u, 0u}, {seq, seq}};
+        EXPECT_EQ(get<0>(tmp), 1u);
         EXPECT_EQ(std::string{std::get<0>(get<4>(tmp)) | view::to_char}, std::string{"AT-C--A"});
         EXPECT_TRUE((std::is_same_v<decltype(get<0>(tmp)), typename TestFixture::id_t &>));
     }
 
     {
-        res_t const tmp{res_t{1, 0, {10, 10}, {0, 0}, {seq, seq}}};
-        EXPECT_EQ(get<0>(tmp), 1);
+        res_t const tmp{res_t{1u, 0, {10u, 10u}, {0u, 0u}, {seq, seq}}};
+        EXPECT_EQ(get<0>(tmp), 1u);
         EXPECT_EQ(std::string{std::get<0>(get<4>(tmp)) | view::to_char}, std::string{"AT-C--A"});
         EXPECT_TRUE((std::is_same_v<decltype(get<0>(tmp)), typename TestFixture::id_t const &>));
     }
 
     {
-        res_t tmp{1, 0, {10, 10}, {0, 0}, {seq, seq}};
-        EXPECT_EQ(get<0>(std::move(tmp)), 1);
-        res_t tmp2{1, 0, {10, 10}, {0, 0}, {seq, seq}};
+        res_t tmp{1u, 0, {10u, 10u}, {0u, 0u}, {seq, seq}};
+        EXPECT_EQ(get<0>(std::move(tmp)), 1u);
+        res_t tmp2{1u, 0, {10u, 10u}, {0u, 0u}, {seq, seq}};
         EXPECT_EQ(std::string{view::persist(std::get<0>(get<4>(std::move(tmp2)))) | view::to_char},
                   std::string{"AT-C--A"});
         EXPECT_TRUE((std::is_same_v<decltype(get<0>(std::move(tmp))), typename TestFixture::id_t &&>));
     }
 
     {
-        res_t const tmp{res_t{1, 0, {10, 10}, {0, 0}, {seq, seq}}};
-        EXPECT_EQ(get<0>(std::move(tmp)), 1);
-        res_t const tmp2{res_t{1, 0, {10, 10}, {0, 0}, {seq, seq}}};
+        res_t const tmp{res_t{1u, 0, {10u, 10u}, {0u, 0u}, {seq, seq}}};
+        EXPECT_EQ(get<0>(std::move(tmp)), 1u);
+        res_t const tmp2{res_t{1u, 0, {10u, 10u}, {0u, 0u}, {seq, seq}}};
         EXPECT_EQ(std::string{view::persist(std::get<0>(get<4>(std::move(tmp2)))) | view::to_char},
                   std::string{"AT-C--A"});
         // TODO: enable if gcc-7 is fixed.
@@ -186,32 +186,32 @@ TYPED_TEST(align_result_test, seqan3_enum_get)
     seq_t seq{'A'_dna4, 'T'_dna4, gap::GAP, 'C'_dna4, gap::GAP, gap::GAP, 'A'_dna4};
 
     {
-        res_t tmp{1, 0, {10, 10}, {0, 0}, {seq, seq}};
-        EXPECT_EQ(get<align_result_key::id>(tmp), 1);
+        res_t tmp{1u, 0, {10u, 10u}, {0u, 0u}, {seq, seq}};
+        EXPECT_EQ(get<align_result_key::id>(tmp), 1u);
         EXPECT_EQ(std::string{std::get<0>(get<align_result_key::trace>(tmp)) | view::to_char}, std::string{"AT-C--A"});
         EXPECT_TRUE((std::is_same_v<decltype(get<align_result_key::id>(tmp)), typename TestFixture::id_t &>));
     }
 
     {
-        res_t const tmp{res_t{1, 0, {10, 10}, {0, 0}, {seq, seq}}};
-        EXPECT_EQ(get<align_result_key::id>(tmp), 1);
+        res_t const tmp{res_t{1u, 0, {10u, 10u}, {0u, 0u}, {seq, seq}}};
+        EXPECT_EQ(get<align_result_key::id>(tmp), 1u);
         EXPECT_EQ(std::string{std::get<0>(get<align_result_key::trace>(tmp)) | view::to_char}, std::string{"AT-C--A"});
         EXPECT_TRUE((std::is_same_v<decltype(get<align_result_key::id>(tmp)), typename TestFixture::id_t const &>));
     }
 
     {
-        res_t tmp{1, 0, {10, 10}, {0, 0}, {seq, seq}};
-        EXPECT_EQ(get<align_result_key::id>(std::move(tmp)), 1);
-        res_t tmp2{1, 0, {10, 10}, {0, 0}, {seq, seq}};
+        res_t tmp{1u, 0, {10u, 10u}, {0u, 0u}, {seq, seq}};
+        EXPECT_EQ(get<align_result_key::id>(std::move(tmp)), 1u);
+        res_t tmp2{1u, 0, {10u, 10u}, {0u, 0u}, {seq, seq}};
         EXPECT_EQ(std::string{view::persist(std::get<0>(get<align_result_key::trace>(std::move(tmp2)))) | view::to_char},
                   std::string{"AT-C--A"});
         EXPECT_TRUE((std::is_same_v<decltype(get<align_result_key::id>(std::move(tmp))), typename TestFixture::id_t &&>));
     }
 
     {
-        res_t const tmp{res_t{1, 0, {10, 10}, {0, 0}, {seq, seq}}};
-        EXPECT_EQ(get<align_result_key::id>(std::move(tmp)), 1);
-        res_t const tmp2{res_t{1, 0, {10, 10}, {0, 0}, {seq, seq}}};
+        res_t const tmp{res_t{1u, 0, {10u, 10u}, {0u, 0u}, {seq, seq}}};
+        EXPECT_EQ(get<align_result_key::id>(std::move(tmp)), 1u);
+        res_t const tmp2{res_t{1u, 0, {10u, 10u}, {0u, 0u}, {seq, seq}}};
         EXPECT_EQ(std::string{view::persist(std::get<0>(get<align_result_key::trace>(std::move(tmp2)))) | view::to_char},
                   std::string{"AT-C--A"});
         EXPECT_TRUE((std::is_same_v<decltype(get<align_result_key::id>(std::move(tmp))), typename TestFixture::id_t const &&>));
@@ -224,8 +224,8 @@ TYPED_TEST(align_result_test, id)
     using seq_t = typename TestFixture::seq_t;
     seq_t seq{'A'_dna4, 'T'_dna4, gap::GAP, 'C'_dna4, gap::GAP, gap::GAP, 'A'_dna4};
 
-    res_t tmp{1, 0, {10, 10}, {0, 0}, {seq, seq}};
-    EXPECT_EQ(tmp.id(), 1);
+    res_t tmp{1u, 0, {10u, 10u}, {0u, 0u}, {seq, seq}};
+    EXPECT_EQ(tmp.id(), 1u);
 }
 
 TYPED_TEST(align_result_test, score)
@@ -234,7 +234,7 @@ TYPED_TEST(align_result_test, score)
     using seq_t = typename TestFixture::seq_t;
     seq_t seq{'A'_dna4, 'T'_dna4, gap::GAP, 'C'_dna4, gap::GAP, gap::GAP, 'A'_dna4};
 
-    res_t tmp{1, 0, {10, 10}, {0, 0}, {seq, seq}};
+    res_t tmp{1u, 0, {10u, 10u}, {0u, 0u}, {seq, seq}};
     EXPECT_EQ(tmp.score(), 0);
 }
 
@@ -245,14 +245,14 @@ TYPED_TEST(align_result_test, end_coordinate)
     seq_t seq{'A'_dna4, 'T'_dna4, gap::GAP, 'C'_dna4, gap::GAP, gap::GAP, 'A'_dna4};
 
     {
-        res_t tmp{1, 0, {10, 10}, {0, 0}, {seq, seq}};
+        res_t tmp{1u, 0, {10u, 10u}, {0u, 0u}, {seq, seq}};
         EXPECT_EQ(tmp.end_coordinate(), (std::pair{10lu, 10lu}));
         EXPECT_TRUE((std::is_same_v<decltype(tmp.end_coordinate()),
                                     std::pair<size_t, size_t> const &>));
     }
 
     {
-        res_t tmp{1, 0, {10, 10}, {0, 0}, {seq, seq}};
+        res_t tmp{1u, 0, {10u, 10u}, {0u, 0u}, {seq, seq}};
         EXPECT_TRUE(std::move(tmp).end_coordinate() == (std::pair{10lu, 10lu}));
         EXPECT_TRUE((std::is_same_v<decltype(std::move(tmp).end_coordinate()),
                                     std::pair<size_t, size_t> const &&>));
@@ -272,14 +272,14 @@ TYPED_TEST(align_result_test, begin_coordinate)
     seq_t seq{'A'_dna4, 'T'_dna4, gap::GAP, 'C'_dna4, gap::GAP, gap::GAP, 'A'_dna4};
 
     {
-        res_t tmp{1, 0, {10, 10}, {0, 0}, {seq, seq}};
+        res_t tmp{1u, 0, {10u, 10u}, {0u, 0u}, {seq, seq}};
         EXPECT_EQ(tmp.begin_coordinate(), (std::pair{0lu, 0lu}));
         EXPECT_TRUE((std::is_same_v<decltype(tmp.begin_coordinate()),
                                     std::pair<size_t, size_t> const &>));
     }
 
     {
-        res_t tmp{1, 0, {10, 10}, {0, 0}, {seq, seq}};
+        res_t tmp{1u, 0, {10u, 10u}, {0u, 0u}, {seq, seq}};
         EXPECT_TRUE(std::move(tmp).begin_coordinate() == (std::pair{0lu, 0lu}));
         EXPECT_TRUE((std::is_same_v<decltype(std::move(tmp).begin_coordinate()),
                                     std::pair<size_t, size_t> const &&>));
@@ -299,14 +299,14 @@ TYPED_TEST(align_result_test, trace)
     seq_t seq{'A'_dna4, 'T'_dna4, gap::GAP, 'C'_dna4, gap::GAP, gap::GAP, 'A'_dna4};
 
     {
-        res_t tmp{1, 0, {10, 10}, {0, 0}, {seq, seq}};
+        res_t tmp{1u, 0, {10u, 10u}, {0u, 0u}, {seq, seq}};
         EXPECT_EQ(tmp.trace(), (std::tuple{seq, seq}));
         EXPECT_TRUE((std::is_same_v<decltype(tmp.trace()),
                                     std::tuple<seq_t, seq_t> const &>));
     }
 
     {
-        res_t tmp{1, 0, {10, 10}, {0, 0}, {seq, seq}};
+        res_t tmp{1u, 0, {10u, 10u}, {0u, 0u}, {seq, seq}};
         EXPECT_TRUE(std::move(tmp).trace() == (std::tuple{seq, seq}));
         EXPECT_TRUE((std::is_same_v<decltype(std::move(tmp).trace()),
                                     std::tuple<seq_t, seq_t> const &&>));


### PR DESCRIPTION
Part of #607, fixes mainly `signed` != `unsigned` warnings.