### PR TITLE
[fix] warnings in range tests

### DIFF
--- a/test/unit/range/container/aligned_allocator_test.cpp
+++ b/test/unit/range/container/aligned_allocator_test.cpp
@@ -88,21 +88,21 @@ TEST(aligned_allocator, memory_alignment)
     int * begin = alloc.allocate(size);
     int * end   = begin + size;
 
-    EXPECT_EQ(sizeof(int), 4);
+    EXPECT_EQ(sizeof(int), 4u);
 
-    EXPECT_EQ(memory_alignment(begin, alignment), 0);
-    EXPECT_EQ(memory_alignment(end,   alignment), 8);
+    EXPECT_EQ(memory_alignment(begin, alignment), 0u);
+    EXPECT_EQ(memory_alignment(end,   alignment), 8u);
 
-    EXPECT_EQ(memory_alignment(begin + 1,  alignment), 4);
-    EXPECT_EQ(memory_alignment(begin + 2,  alignment), 8);
-    EXPECT_EQ(memory_alignment(begin + 3,  alignment), 12);
-    EXPECT_EQ(memory_alignment(begin + 4,  alignment), 0);
-    EXPECT_EQ(memory_alignment(begin + 5,  alignment), 4);
-    EXPECT_EQ(memory_alignment(begin + 6,  alignment), 8);
-    EXPECT_EQ(memory_alignment(begin + 7,  alignment), 12);
-    EXPECT_EQ(memory_alignment(begin + 8,  alignment), 0);
-    EXPECT_EQ(memory_alignment(begin + 9,  alignment), 4);
-    EXPECT_EQ(memory_alignment(begin + 10, alignment), 8);
+    EXPECT_EQ(memory_alignment(begin + 1,  alignment), 4u);
+    EXPECT_EQ(memory_alignment(begin + 2,  alignment), 8u);
+    EXPECT_EQ(memory_alignment(begin + 3,  alignment), 12u);
+    EXPECT_EQ(memory_alignment(begin + 4,  alignment), 0u);
+    EXPECT_EQ(memory_alignment(begin + 5,  alignment), 4u);
+    EXPECT_EQ(memory_alignment(begin + 6,  alignment), 8u);
+    EXPECT_EQ(memory_alignment(begin + 7,  alignment), 12u);
+    EXPECT_EQ(memory_alignment(begin + 8,  alignment), 0u);
+    EXPECT_EQ(memory_alignment(begin + 9,  alignment), 4u);
+    EXPECT_EQ(memory_alignment(begin + 10, alignment), 8u);
 
     alloc.deallocate(begin, size);
 }
@@ -117,21 +117,21 @@ TEST(aligned_allocator, in_vector)
     auto it       = begin_it;
     auto end_it   = container.end();
 
-    EXPECT_EQ(sizeof(int), 4);
+    EXPECT_EQ(sizeof(int), 4u);
 
-    EXPECT_EQ(memory_alignment(&*begin_it, alignment), 0);
-    EXPECT_EQ(memory_alignment(&*end_it,   alignment), 8);
+    EXPECT_EQ(memory_alignment(&*begin_it, alignment), 0u);
+    EXPECT_EQ(memory_alignment(&*end_it,   alignment), 8u);
 
-    EXPECT_EQ(memory_alignment(&*(++it), alignment), 4);
-    EXPECT_EQ(memory_alignment(&*(++it), alignment), 8);
-    EXPECT_EQ(memory_alignment(&*(++it), alignment), 12);
-    EXPECT_EQ(memory_alignment(&*(++it), alignment), 0);
-    EXPECT_EQ(memory_alignment(&*(++it), alignment), 4);
-    EXPECT_EQ(memory_alignment(&*(++it), alignment), 8);
-    EXPECT_EQ(memory_alignment(&*(++it), alignment), 12);
-    EXPECT_EQ(memory_alignment(&*(++it), alignment), 0);
-    EXPECT_EQ(memory_alignment(&*(++it), alignment), 4);
-    EXPECT_EQ(memory_alignment(&*(++it), alignment), 8);
+    EXPECT_EQ(memory_alignment(&*(++it), alignment), 4u);
+    EXPECT_EQ(memory_alignment(&*(++it), alignment), 8u);
+    EXPECT_EQ(memory_alignment(&*(++it), alignment), 12u);
+    EXPECT_EQ(memory_alignment(&*(++it), alignment), 0u);
+    EXPECT_EQ(memory_alignment(&*(++it), alignment), 4u);
+    EXPECT_EQ(memory_alignment(&*(++it), alignment), 8u);
+    EXPECT_EQ(memory_alignment(&*(++it), alignment), 12u);
+    EXPECT_EQ(memory_alignment(&*(++it), alignment), 0u);
+    EXPECT_EQ(memory_alignment(&*(++it), alignment), 4u);
+    EXPECT_EQ(memory_alignment(&*(++it), alignment), 8u);
 }
 
 TEST(aligned_allocator, in_deque)
@@ -144,21 +144,21 @@ TEST(aligned_allocator, in_deque)
     auto it       = begin_it;
     auto end_it   = container.end();
 
-    EXPECT_EQ(sizeof(int), 4);
+    EXPECT_EQ(sizeof(int), 4u);
 
-    EXPECT_EQ(memory_alignment(&*begin_it, alignment), 0);
-    EXPECT_EQ(memory_alignment(&*end_it,   alignment), 8);
+    EXPECT_EQ(memory_alignment(&*begin_it, alignment), 0u);
+    EXPECT_EQ(memory_alignment(&*end_it,   alignment), 8u);
 
-    EXPECT_EQ(memory_alignment(&*(++it), alignment), 4);
-    EXPECT_EQ(memory_alignment(&*(++it), alignment), 8);
-    EXPECT_EQ(memory_alignment(&*(++it), alignment), 12);
-    EXPECT_EQ(memory_alignment(&*(++it), alignment), 0);
-    EXPECT_EQ(memory_alignment(&*(++it), alignment), 4);
-    EXPECT_EQ(memory_alignment(&*(++it), alignment), 8);
-    EXPECT_EQ(memory_alignment(&*(++it), alignment), 12);
-    EXPECT_EQ(memory_alignment(&*(++it), alignment), 0);
-    EXPECT_EQ(memory_alignment(&*(++it), alignment), 4);
-    EXPECT_EQ(memory_alignment(&*(++it), alignment), 8);
+    EXPECT_EQ(memory_alignment(&*(++it), alignment), 4u);
+    EXPECT_EQ(memory_alignment(&*(++it), alignment), 8u);
+    EXPECT_EQ(memory_alignment(&*(++it), alignment), 12u);
+    EXPECT_EQ(memory_alignment(&*(++it), alignment), 0u);
+    EXPECT_EQ(memory_alignment(&*(++it), alignment), 4u);
+    EXPECT_EQ(memory_alignment(&*(++it), alignment), 8u);
+    EXPECT_EQ(memory_alignment(&*(++it), alignment), 12u);
+    EXPECT_EQ(memory_alignment(&*(++it), alignment), 0u);
+    EXPECT_EQ(memory_alignment(&*(++it), alignment), 4u);
+    EXPECT_EQ(memory_alignment(&*(++it), alignment), 8u);
 }
 
 TEST(aligned_allocator, in_list)
@@ -171,21 +171,21 @@ TEST(aligned_allocator, in_list)
     auto it       = begin_it;
     auto end_it   = container.end();
 
-    EXPECT_EQ(sizeof(int), 4);
+    EXPECT_EQ(sizeof(int), 4u);
 
-    EXPECT_EQ(memory_alignment(&*begin_it, alignment), 0);
-    EXPECT_EQ(memory_alignment(&*end_it,   alignment), 0);
+    EXPECT_EQ(memory_alignment(&*begin_it, alignment), 0u);
+    EXPECT_EQ(memory_alignment(&*end_it,   alignment), 0u);
 
-    EXPECT_EQ(memory_alignment(&*(++it), alignment), 0);
-    EXPECT_EQ(memory_alignment(&*(++it), alignment), 0);
-    EXPECT_EQ(memory_alignment(&*(++it), alignment), 0);
-    EXPECT_EQ(memory_alignment(&*(++it), alignment), 0);
-    EXPECT_EQ(memory_alignment(&*(++it), alignment), 0);
-    EXPECT_EQ(memory_alignment(&*(++it), alignment), 0);
-    EXPECT_EQ(memory_alignment(&*(++it), alignment), 0);
-    EXPECT_EQ(memory_alignment(&*(++it), alignment), 0);
-    EXPECT_EQ(memory_alignment(&*(++it), alignment), 0);
-    EXPECT_EQ(memory_alignment(&*(++it), alignment), 0);
+    EXPECT_EQ(memory_alignment(&*(++it), alignment), 0u);
+    EXPECT_EQ(memory_alignment(&*(++it), alignment), 0u);
+    EXPECT_EQ(memory_alignment(&*(++it), alignment), 0u);
+    EXPECT_EQ(memory_alignment(&*(++it), alignment), 0u);
+    EXPECT_EQ(memory_alignment(&*(++it), alignment), 0u);
+    EXPECT_EQ(memory_alignment(&*(++it), alignment), 0u);
+    EXPECT_EQ(memory_alignment(&*(++it), alignment), 0u);
+    EXPECT_EQ(memory_alignment(&*(++it), alignment), 0u);
+    EXPECT_EQ(memory_alignment(&*(++it), alignment), 0u);
+    EXPECT_EQ(memory_alignment(&*(++it), alignment), 0u);
 }
 
 TEST(aligned_allocator, in_map)
@@ -202,17 +202,17 @@ TEST(aligned_allocator, in_map)
     auto begin_it = container.begin();
     auto it       = begin_it;
 
-    EXPECT_EQ(sizeof(int), 4);
+    EXPECT_EQ(sizeof(int), 4u);
 
-    EXPECT_EQ(memory_alignment(&*begin_it, alignment), 0);
+    EXPECT_EQ(memory_alignment(&*begin_it, alignment), 0u);
 
-    EXPECT_EQ(memory_alignment(&*(++it), alignment), 0);
-    EXPECT_EQ(memory_alignment(&*(++it), alignment), 0);
-    EXPECT_EQ(memory_alignment(&*(++it), alignment), 0);
-    EXPECT_EQ(memory_alignment(&*(++it), alignment), 0);
-    EXPECT_EQ(memory_alignment(&*(++it), alignment), 0);
-    EXPECT_EQ(memory_alignment(&*(++it), alignment), 0);
-    EXPECT_EQ(memory_alignment(&*(++it), alignment), 0);
-    EXPECT_EQ(memory_alignment(&*(++it), alignment), 0);
-    EXPECT_EQ(memory_alignment(&*(++it), alignment), 0);
+    EXPECT_EQ(memory_alignment(&*(++it), alignment), 0u);
+    EXPECT_EQ(memory_alignment(&*(++it), alignment), 0u);
+    EXPECT_EQ(memory_alignment(&*(++it), alignment), 0u);
+    EXPECT_EQ(memory_alignment(&*(++it), alignment), 0u);
+    EXPECT_EQ(memory_alignment(&*(++it), alignment), 0u);
+    EXPECT_EQ(memory_alignment(&*(++it), alignment), 0u);
+    EXPECT_EQ(memory_alignment(&*(++it), alignment), 0u);
+    EXPECT_EQ(memory_alignment(&*(++it), alignment), 0u);
+    EXPECT_EQ(memory_alignment(&*(++it), alignment), 0u);
 }

--- a/test/unit/range/view/view_char_to_test.cpp
+++ b/test/unit/range/view/view_char_to_test.cpp
@@ -71,7 +71,7 @@ TEST(view_char_to, deep_view)
 
     std::vector<dna5_vector> v = foo | view::char_to<dna5>;
 
-    ASSERT_EQ(size(v), 2);
+    ASSERT_EQ(size(v), 2u);
     EXPECT_TRUE((std::ranges::equal(v[0], "ACGTA"_dna5)));
     EXPECT_TRUE((std::ranges::equal(v[1], "TGCAT"_dna5)));
 }

--- a/test/unit/range/view/view_complement_test.cpp
+++ b/test/unit/range/view/view_complement_test.cpp
@@ -69,7 +69,7 @@ TEST(view_complement, deep_view)
 
     auto v = foo | view::complement;
 
-    ASSERT_EQ(size(v), 2);
+    ASSERT_EQ(size(v), 2u);
     EXPECT_TRUE((std::ranges::equal(v[0], "TGCAT"_dna5)));
     EXPECT_TRUE((std::ranges::equal(v[1], "ACGTA"_dna5)));
 }

--- a/test/unit/range/view/view_deep_test.cpp
+++ b/test/unit/range/view/view_deep_test.cpp
@@ -86,7 +86,7 @@ TEST(view_deep_reverse, deep)
 
     auto v = foo | view::deep_reverse;
 
-    ASSERT_EQ(size(v), 2);
+    ASSERT_EQ(size(v), 2u);
     EXPECT_TRUE((std::ranges::equal(v[0], "ATGCA"_dna5)));
     EXPECT_TRUE((std::ranges::equal(v[1], "TACGT"_dna5)));
 }
@@ -158,7 +158,7 @@ TEST(view_deep_take, deep)
 
     auto v = foo | view::deep_take(2);
 
-    ASSERT_EQ(size(v), 3);
+    ASSERT_EQ(size(v), 3u);
     EXPECT_TRUE((std::ranges::equal(v[0], "AC"_dna5)));
     EXPECT_TRUE((std::ranges::equal(v[1], "TG"_dna5)));
     EXPECT_TRUE((std::ranges::equal(v[2], "NN"_dna5)));
@@ -166,7 +166,7 @@ TEST(view_deep_take, deep)
     int i = 2;
     auto v2 = foo | view::deep_take(i);
 
-    ASSERT_EQ(size(v2), 3);
+    ASSERT_EQ(size(v2), 3u);
     EXPECT_TRUE((std::ranges::equal(v2[0], "AC"_dna5)));
     EXPECT_TRUE((std::ranges::equal(v2[1], "TG"_dna5)));
     EXPECT_TRUE((std::ranges::equal(v2[2], "NN"_dna5)));
@@ -203,7 +203,7 @@ TEST(view_deep_take2, deep)
 
     auto v = foo | view::deep_take2;
 
-    ASSERT_EQ(size(v), 3);
+    ASSERT_EQ(size(v), 3u);
     EXPECT_TRUE((std::ranges::equal(v[0], "AC"_dna5)));
     EXPECT_TRUE((std::ranges::equal(v[1], "TG"_dna5)));
     EXPECT_TRUE((std::ranges::equal(v[2], "NN"_dna5)));

--- a/test/unit/range/view/view_take_test.cpp
+++ b/test/unit/range/view/view_take_test.cpp
@@ -160,7 +160,7 @@ TEST(view_take_exactly, underlying_is_shorter)
     EXPECT_EQ("foo", v);
 
     auto v2 = vec | view::single_pass_input | view::take_exactly(4);
-    EXPECT_EQ(size(v2), 4); // here be dragons
+    EXPECT_EQ(size(v2), 4u); // here be dragons
 }
 
 // ============================================================================
@@ -187,4 +187,3 @@ TEST(view_take_exactly_or_throw, underlying_is_shorter)
     EXPECT_THROW(( v = vec | view::single_pass_input | view::take_exactly_or_throw(4)),
                    unexpected_end_of_input); // full parsing on conversion, throw on conversion
 }
-


### PR DESCRIPTION
Part of #607, fixes mainly `signed` != `unsigned` warnings.