### PR TITLE
Renaming

### DIFF
--- a/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
+++ b/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
@@ -45,7 +45,7 @@ namespace seqan3
  *
  * The following extended type requirements for a type `T` must hold true:
  *
- *   * seqan3::reference_t<T> must model seqan3::alphabet_concept.
+ *   * seqan3::reference_t<T> must model seqan3::Alphabet.
  *   * seqan3::reference_t<T> must be assignable from seqan3::gap.
  *
  * ### Concepts and doxygen
@@ -121,7 +121,7 @@ namespace seqan3
 template <typename t>
 SEQAN3_CONCEPT aligned_sequence_concept =
     std::ranges::ForwardRange<t> &&
-    alphabet_concept<value_type_t<t>> &&
+    Alphabet<value_type_t<t>> &&
     WeaklyAssignable<reference_t<t>, gap const &> &&
     requires (t v)
     {

--- a/include/seqan3/alignment/scoring/scoring_scheme_base.hpp
+++ b/include/seqan3/alignment/scoring/scoring_scheme_base.hpp
@@ -88,7 +88,7 @@ mismatch_score(score_type &&) -> mismatch_score<score_type>;
  *
  * This type is never used directly, instead use seqan3::nucleotide_scoring_scheme or seqan3::aminoacid_scoring_scheme.
  */
-template <typename derived_t, alphabet_concept alphabet_t, Arithmetic score_t>
+template <typename derived_t, Alphabet alphabet_t, Arithmetic score_t>
 class scoring_scheme_base
 {
 public:

--- a/include/seqan3/alignment/scoring/scoring_scheme_concept.hpp
+++ b/include/seqan3/alignment/scoring/scoring_scheme_concept.hpp
@@ -20,8 +20,8 @@ namespace seqan3
 /*!\interface seqan3::scoring_scheme_concept <>
  * \brief A concept that requires that type be able to score two letters.
  * \tparam t            The type the concept check is performed on (the putative scoring scheme).
- * \tparam alphabet_t   The type of the first letter that you wish to score; must model seqan3::alphabet_concept.
- * \tparam alphabet2_t  The type of the second letter that you wish to score; must model seqan3::alphabet_concept;
+ * \tparam alphabet_t   The type of the first letter that you wish to score; must model seqan3::Alphabet.
+ * \tparam alphabet2_t  The type of the second letter that you wish to score; must model seqan3::Alphabet;
  *                      defaults to `alphabet_t`.
  * \ingroup scoring
  *
@@ -56,7 +56,7 @@ namespace seqan3
  */
 //!\}
 //!\cond
-template <typename t, alphabet_concept alphabet_t, alphabet_concept alphabet2_t = alphabet_t>
+template <typename t, Alphabet alphabet_t, Alphabet alphabet2_t = alphabet_t>
 SEQAN3_CONCEPT scoring_scheme_concept = requires (t scheme,
                                                 alphabet_t const alph1,
                                                 alphabet2_t const alph2)

--- a/include/seqan3/alphabet/adaptation/char.hpp
+++ b/include/seqan3/alphabet/adaptation/char.hpp
@@ -10,7 +10,7 @@
  * \brief Provides alphabet adaptations for standard char types.
  * \details
  * This file provides function and metafunction overloads so that the following types
- * fulfil the seqan3::alphabet_concept:
+ * fulfil the seqan3::Alphabet:
  *   * `char`
  *   * `char16_t`
  *   * `char32_t`

--- a/include/seqan3/alphabet/adaptation/concept.hpp
+++ b/include/seqan3/alphabet/adaptation/concept.hpp
@@ -17,12 +17,12 @@
 namespace seqan3
 {
 /*!\interface seqan3::char_adaptation_concept <>
- * \extends seqan3::alphabet_concept
- * \brief A concept that covers char type adaptations for seqan3::alphabet_concept.
+ * \extends seqan3::Alphabet
+ * \brief A concept that covers char type adaptations for seqan3::Alphabet.
  * \ingroup adaptation
  *
  * \details
- * This concept introduces no formal requirements beyond those of seqan3::alphabet_concept
+ * This concept introduces no formal requirements beyond those of seqan3::Alphabet
  * and type being one of the following types:
  *
  *   * `char`
@@ -44,17 +44,17 @@ namespace seqan3
  */
 //!\cond
 template <typename type>
-SEQAN3_CONCEPT char_adaptation_concept = alphabet_concept<type> &&
+SEQAN3_CONCEPT char_adaptation_concept = Alphabet<type> &&
                                   detail::is_char_adaptation_v<type>;
 //!\endcond
 
 /*!\interface seqan3::uint_adaptation_concept <>
- * \extends seqan3::alphabet_concept
- * \brief A concept that covers uint type adaptations for seqan3::alphabet_concept.
+ * \extends seqan3::Alphabet
+ * \brief A concept that covers uint type adaptations for seqan3::Alphabet.
  * \ingroup adaptation
  *
  * \details
- * This concept introduces no formal requirements beyond those of seqan3::alphabet_concept
+ * This concept introduces no formal requirements beyond those of seqan3::Alphabet
  * and type being one of the following types:
  *
  *   * `uint8_t`
@@ -74,7 +74,7 @@ SEQAN3_CONCEPT char_adaptation_concept = alphabet_concept<type> &&
  */
 //!\cond
 template <typename type>
-SEQAN3_CONCEPT uint_adaptation_concept = alphabet_concept<type> &&
+SEQAN3_CONCEPT uint_adaptation_concept = Alphabet<type> &&
                                   detail::is_uint_adaptation_v<type>;
 //!\endcond
 

--- a/include/seqan3/alphabet/adaptation/uint.hpp
+++ b/include/seqan3/alphabet/adaptation/uint.hpp
@@ -10,7 +10,7 @@
  * \brief Provides alphabet adaptations for standard uint types.
  * \details
  * This file provides function and metafunction overloads so that the following types
- * fulfil the seqan3::alphabet_concept:
+ * fulfil the seqan3::Alphabet:
  *   * `uint8_t`
  *   * `uint16_t`
  *   * `uint32_t`

--- a/include/seqan3/alphabet/all.hpp
+++ b/include/seqan3/alphabet/all.hpp
@@ -119,7 +119,7 @@
  *
  * Note, however, that literals **are not** required by the concept.
  *
- * <small>In the documentation you will also encounter seqan3::semi_alphabet_concept. It describes "one half" of an
+ * <small>In the documentation you will also encounter seqan3::Semialphabet. It describes "one half" of an
  * alphabet and only defines the rank interface as a type requirement. It is mainly used internally and not
  * relevant to most users of SeqAn.</small>
  *

--- a/include/seqan3/alphabet/all.hpp
+++ b/include/seqan3/alphabet/all.hpp
@@ -36,15 +36,15 @@
  * for qualities, RNA structures and alignment gaps. In addition there are templates for combining alphabet
  * types into new alphabets, and wrappers for existing data types like the canonical `char`.
  *
- * To be included into the alphabet module, an alphabet must satisfy the generic seqan3::alphabet_concept
+ * To be included into the alphabet module, an alphabet must satisfy the generic seqan3::Alphabet
  * documented below. While this only encompasses a minimum set of requirements, many of our alphabets provide
- * more features and there are more refined concepts. The inheritance diagram of seqan3::alphabet_concept gives
+ * more features and there are more refined concepts. The inheritance diagram of seqan3::Alphabet gives
  * a detailed overview. A more basic overview of this module and it's submodules is available in the collaboration
  * diagram at the top of this page.
  *
  * ## The alphabet concept
  *
- * The seqan3::alphabet_concept defines the requirements a type needs to meet to be considered an alphabet
+ * The seqan3::Alphabet defines the requirements a type needs to meet to be considered an alphabet
  * by SeqAn, or in other words: you can expect certain properties and functions to be defined on
  * all data types we call an alphabet.
  *
@@ -85,18 +85,18 @@
  *     * the \link seqan3::underlying_rank underlying rank type \endlink able to represent this alphabet numerically;
  *       this type must be able to represent the numbers from `0` to `alphabet size - 1` (often `uint8_t`, but
  *       sometimes a larger unsigned integral type);
- *     * a \link seqan3::alphabet_concept::to_rank to_rank \endlink function to produce the numerical representation;
- *     * an \link seqan3::alphabet_concept::assign_rank assign_rank \endlink function to assign from the numerical
+ *     * a \link seqan3::Alphabet::to_rank to_rank \endlink function to produce the numerical representation;
+ *     * an \link seqan3::Alphabet::assign_rank assign_rank \endlink function to assign from the numerical
  *       representation;
  *   2. a **character based interface** with
  *     * the \link seqan3::underlying_char underlying character type \endlink able to represent this alphabet visually
  *       (almost always `char`, but could be `char16_t` or `char32_t`, as well)
- *     * a \link seqan3::alphabet_concept::to_char to_char \endlink function to produce the visual representation;
- *     * an \link seqan3::alphabet_concept::assign_char assign_char \endlink function to assign from the visual
+ *     * a \link seqan3::Alphabet::to_char to_char \endlink function to produce the visual representation;
+ *     * an \link seqan3::Alphabet::assign_char assign_char \endlink function to assign from the visual
  *       representation;
- *     * a \link seqan3::alphabet_concept::char_is_valid_for char_is_valid_for \endlink function that checks whether
+ *     * a \link seqan3::Alphabet::char_is_valid_for char_is_valid_for \endlink function that checks whether
  *       a character value has a one-to-one mapping to an alphabet value;
- *     * an \link seqan3::alphabet_concept::assign_char_strict assign_char_strict \endlink function to assign a
+ *     * an \link seqan3::Alphabet::assign_char_strict assign_char_strict \endlink function to assign a
  *       characters while verifying its validity.
  *
  * To prevent the aforementioned ambiguity, you can neither assign from rank or char representation via `operator=`,

--- a/include/seqan3/alphabet/aminoacid/aa20.hpp
+++ b/include/seqan3/alphabet/aminoacid/aa20.hpp
@@ -24,7 +24,7 @@ namespace seqan3
 /*!\brief The canonical amino acid alphabet.
  * \ingroup aminoacid
  * \implements seqan3::AminoacidAlphabet
- * \implements seqan3::detail::constexpr_alphabet_concept
+ * \implements seqan3::detail::ConstexprAlphabet
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
  *

--- a/include/seqan3/alphabet/aminoacid/aa27.hpp
+++ b/include/seqan3/alphabet/aminoacid/aa27.hpp
@@ -23,7 +23,7 @@ namespace seqan3
 /*!\brief The twenty-seven letter amino acid alphabet.
  * \ingroup aminoacid
  * \implements seqan3::AminoacidAlphabet
- * \implements seqan3::detail::constexpr_alphabet_concept
+ * \implements seqan3::detail::ConstexprAlphabet
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
  *

--- a/include/seqan3/alphabet/aminoacid/aminoacid_base.hpp
+++ b/include/seqan3/alphabet/aminoacid/aminoacid_base.hpp
@@ -82,7 +82,7 @@ public:
      *
      * \details
      *
-     * Models the seqan3::semi_alphabet_concept::char_is_valid_for() requirement via the seqan3::char_is_valid_for()
+     * Models the seqan3::Semialphabet::char_is_valid_for() requirement via the seqan3::char_is_valid_for()
      * wrapper.
      *
      * Behaviour specific to amino acids: True also for lower case letters that silently convert to their upper case.

--- a/include/seqan3/alphabet/aminoacid/concept.hpp
+++ b/include/seqan3/alphabet/aminoacid/concept.hpp
@@ -47,7 +47,7 @@ template <typename type>
 constexpr bool is_aminoacid_v = is_aminoacid<type>::value;
 
 /*!\interface seqan3::AminoacidAlphabet <>
- * \extends seqan3::alphabet_concept
+ * \extends seqan3::Alphabet
  * \brief A concept that indicates whether an alphabet represents amino acids.
  * \ingroup aminoacid
  *
@@ -61,7 +61,7 @@ constexpr bool is_aminoacid_v = is_aminoacid<type>::value;
  */
 //!\cond
 template <typename type>
-SEQAN3_CONCEPT AminoacidAlphabet = alphabet_concept<type> && is_aminoacid_v<remove_cvref_t<type>>;
+SEQAN3_CONCEPT AminoacidAlphabet = Alphabet<type> && is_aminoacid_v<remove_cvref_t<type>>;
 //!\endcond
 
 } // namespace seqan3

--- a/include/seqan3/alphabet/composition/cartesian_composition.hpp
+++ b/include/seqan3/alphabet/composition/cartesian_composition.hpp
@@ -155,7 +155,7 @@ decltype(auto) get();
  * Short description:
  *   * combines multiple alphabets as independent component_list, similar to a tuple;
  *   * models seqan3::tuple_like_concept, i.e. provides a get interface to its component_list;
- *   * is itself a seqan3::Semialphabet, but most derived types implement the full seqan3::alphabet_concept;
+ *   * is itself a seqan3::Semialphabet, but most derived types implement the full seqan3::Alphabet;
  *   * its alphabet size is the product of the individual sizes;
  *   * constructible, assignable and comparable with each component type and also all types that
  *     these are constructible/assignable/comparable with;

--- a/include/seqan3/alphabet/composition/cartesian_composition.hpp
+++ b/include/seqan3/alphabet/composition/cartesian_composition.hpp
@@ -144,10 +144,10 @@ decltype(auto) get();
 
 /*!\brief The CRTP base for a combined alphabet that contains multiple values of different alphabets at the same time.
  * \ingroup composition
- * \implements seqan3::semi_alphabet_concept
+ * \implements seqan3::Semialphabet
  * \implements seqan3::detail::ConstexprSemialphabet
- * \tparam first_component_type Type of the first letter; must model seqan3::semi_alphabet_concept.
- * \tparam component_types      Types of further letters (up to 4); must model seqan3::semi_alphabet_concept.
+ * \tparam first_component_type Type of the first letter; must model seqan3::Semialphabet.
+ * \tparam component_types      Types of further letters (up to 4); must model seqan3::Semialphabet.
  *
  * This data structure is CRTP base class for combined alphabets, where the different
  * alphabet letters exist independently as component_list, similar to a tuple.
@@ -155,7 +155,7 @@ decltype(auto) get();
  * Short description:
  *   * combines multiple alphabets as independent component_list, similar to a tuple;
  *   * models seqan3::tuple_like_concept, i.e. provides a get interface to its component_list;
- *   * is itself a seqan3::semi_alphabet_concept, but most derived types implement the full seqan3::alphabet_concept;
+ *   * is itself a seqan3::Semialphabet, but most derived types implement the full seqan3::alphabet_concept;
  *   * its alphabet size is the product of the individual sizes;
  *   * constructible, assignable and comparable with each component type and also all types that
  *     these are constructible/assignable/comparable with;

--- a/include/seqan3/alphabet/composition/cartesian_composition.hpp
+++ b/include/seqan3/alphabet/composition/cartesian_composition.hpp
@@ -145,7 +145,7 @@ decltype(auto) get();
 /*!\brief The CRTP base for a combined alphabet that contains multiple values of different alphabets at the same time.
  * \ingroup composition
  * \implements seqan3::semi_alphabet_concept
- * \implements seqan3::detail::constexpr_semi_alphabet_concept
+ * \implements seqan3::detail::ConstexprSemialphabet
  * \tparam first_component_type Type of the first letter; must model seqan3::semi_alphabet_concept.
  * \tparam component_types      Types of further letters (up to 4); must model seqan3::semi_alphabet_concept.
  *
@@ -177,7 +177,7 @@ decltype(auto) get();
 template <typename derived_type,
           typename ...component_types>
 //!\cond
-    requires (detail::constexpr_semi_alphabet_concept<component_types> && ...)
+    requires (detail::ConstexprSemialphabet<component_types> && ...)
 //!\endcond
 class cartesian_composition :
     public alphabet_base<derived_type,

--- a/include/seqan3/alphabet/composition/detail.hpp
+++ b/include/seqan3/alphabet/composition/detail.hpp
@@ -160,7 +160,7 @@ namespace seqan3
 // forward
 template <typename ...alternative_types>
 //!\cond
-    requires (detail::constexpr_alphabet_concept<alternative_types> && ...) &&
+    requires (detail::ConstexprAlphabet<alternative_types> && ...) &&
              (sizeof...(alternative_types) >= 2)
              //TODO same char_type
 //!\endcond

--- a/include/seqan3/alphabet/composition/detail.hpp
+++ b/include/seqan3/alphabet/composition/detail.hpp
@@ -24,7 +24,7 @@ namespace seqan3::detail
 // ------------------------------------------------------------------
 
 /*!\interface seqan3::detail::cartesian_composition_concept <>
- * \extends seqan3::semi_alphabet_concept
+ * \extends seqan3::Semialphabet
  * \brief seqan3::cartesian_composition and its specialisations model this concept.
  * \ingroup alphabet
  *

--- a/include/seqan3/alphabet/composition/detail.hpp
+++ b/include/seqan3/alphabet/composition/detail.hpp
@@ -169,7 +169,7 @@ class union_composition;
 template <typename derived_type,
           typename ...component_types>
 //!\cond
-    requires (detail::constexpr_semi_alphabet_concept<component_types> && ...)
+    requires (detail::ConstexprSemialphabet<component_types> && ...)
 //!\endcond
 class cartesian_composition;
 

--- a/include/seqan3/alphabet/composition/union_composition.hpp
+++ b/include/seqan3/alphabet/composition/union_composition.hpp
@@ -143,7 +143,7 @@ namespace seqan3
  * \tparam ...alternative_types Types of possible values (at least 2); all must model seqan3::alphabet_concept and be
  *                              unique.
  * \implements seqan3::alphabet_concept
- * \implements seqan3::detail::constexpr_alphabet_concept
+ * \implements seqan3::detail::ConstexprAlphabet
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
 
@@ -169,7 +169,7 @@ namespace seqan3
  */
 template <typename ...alternative_types>
 //!\cond
-    requires (detail::constexpr_alphabet_concept<alternative_types> && ...) &&
+    requires (detail::ConstexprAlphabet<alternative_types> && ...) &&
              (sizeof...(alternative_types) >= 2)
              //TODO same char_type
 //!\endcond

--- a/include/seqan3/alphabet/composition/union_composition.hpp
+++ b/include/seqan3/alphabet/composition/union_composition.hpp
@@ -140,9 +140,9 @@ namespace seqan3
 
 /*!\brief A combined alphabet that can hold values of either of its alternatives.
  * \ingroup composition
- * \tparam ...alternative_types Types of possible values (at least 2); all must model seqan3::alphabet_concept and be
+ * \tparam ...alternative_types Types of possible values (at least 2); all must model seqan3::Alphabet and be
  *                              unique.
- * \implements seqan3::alphabet_concept
+ * \implements seqan3::Alphabet
  * \implements seqan3::detail::ConstexprAlphabet
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
@@ -152,11 +152,11 @@ namespace seqan3
  * The union_composition represents the union of two or more alternative alphabets (e.g. the
  * four letter DNA alternative + the gap alternative). It behaves similar to a
  * [union](https://en.cppreference.com/w/cpp/language/union) or std::variant, but it preserves the
- * seqan3::alphabet_concept.
+ * seqan3::Alphabet.
  *
  * Short description:
  *   * combines multiple different alphabets in an "either-or"-fashion;
- *   * is itself a seqan3::alphabet_concept;
+ *   * is itself a seqan3::Alphabet;
  *   * its alphabet size is the sum of the individual sizes;
  *   * default initialises to the the first alternative's default (no empty state like std::variant);
  *   * constructible, assignable and (in-)equality-comparable with each alternative type and also all types that

--- a/include/seqan3/alphabet/concept.hpp
+++ b/include/seqan3/alphabet/concept.hpp
@@ -30,12 +30,12 @@ namespace seqan3
 // ------------------------------------------------------------------
 
 /*!\interface seqan3::Semialphabet <>
- * \brief The basis for seqan3::alphabet_concept, but requires only rank interface (not char).
+ * \brief The basis for seqan3::Alphabet, but requires only rank interface (not char).
  * \ingroup alphabet
  * \extends std::Regular
  * \extends std::StrictTotallyOrdered
  *
- * This concept represents "one half" of the seqan3::alphabet_concept, it requires no
+ * This concept represents "one half" of the seqan3::Alphabet, it requires no
  * `char` representation and corresponding interfaces. It is mostly used internally and
  * in the composition of alphabet types (see seqan3::cartesian_composition).
  *
@@ -85,10 +85,10 @@ SEQAN3_CONCEPT Semialphabet = std::Regular<std::remove_reference_t<t>> &&
 //!\endcond
 
 // ------------------------------------------------------------------
-// alphabet_concept
+// Alphabet
 // ------------------------------------------------------------------
 
-/*!\interface seqan3::alphabet_concept <>
+/*!\interface seqan3::Alphabet <>
  * \extends seqan3::Semialphabet
  * \brief The generic alphabet concept that covers most data types used in ranges.
  * \ingroup alphabet
@@ -100,7 +100,7 @@ SEQAN3_CONCEPT Semialphabet = std::Regular<std::remove_reference_t<t>> &&
  * the \ref alphabet module.
  *
  * For the purpose of concept checking the types `t &` and `t &&` are also considered to satisfy
- * seqan3::alphabet_concept if the type `t` satisfies it.
+ * seqan3::Alphabet if the type `t` satisfies it.
  *
  * \par Serialisation
  *
@@ -115,7 +115,7 @@ SEQAN3_CONCEPT Semialphabet = std::Regular<std::remove_reference_t<t>> &&
  */
 //!\cond
 template <typename t>
-SEQAN3_CONCEPT alphabet_concept = Semialphabet<t> && requires (t v)
+SEQAN3_CONCEPT Alphabet = Semialphabet<t> && requires (t v)
 {
     // conversion to char
     requires           noexcept(to_char(v));
@@ -226,21 +226,21 @@ SEQAN3_CONCEPT ConstexprSemialphabet = Semialphabet<t> && requires
 // ------------------------------------------------------------------
 
 /*!\interface seqan3::detail::ConstexprAlphabet <>
- * \brief A seqan3::alphabet_concept that has constexpr accessors.
+ * \brief A seqan3::Alphabet that has constexpr accessors.
  * \ingroup alphabet
  * \extends seqan3::detail::ConstexprSemialphabet
- * \extends seqan3::alphabet_concept
+ * \extends seqan3::Alphabet
  *
- * The same as seqan3::alphabet_concept, except that the following interface requirements are also required to be
+ * The same as seqan3::Alphabet, except that the following interface requirements are also required to be
  * callable in a `constexpr`-context:
  *
- *   * seqan3::alphabet_concept::to_char
- *   * seqan3::alphabet_concept::assign_char
- *   * seqan3::alphabet_concept::char_is_valid_for
+ *   * seqan3::Alphabet::to_char
+ *   * seqan3::Alphabet::assign_char
+ *   * seqan3::Alphabet::char_is_valid_for
  *
  * The only exception is:
  *
- *   * seqan3::alphabet_concept::assign_char_strict
+ *   * seqan3::Alphabet::assign_char_strict
  *
  * \par Concepts and doxygen
  *
@@ -250,7 +250,7 @@ SEQAN3_CONCEPT ConstexprSemialphabet = Semialphabet<t> && requires
 //!\cond
 template <typename t>
 SEQAN3_CONCEPT ConstexprAlphabet = ConstexprSemialphabet<t> &&
-                                     alphabet_concept<t> &&
+                                     Alphabet<t> &&
                                      requires
 {
     // currently only tests rvalue interfaces, because we have no constexpr values in this scope to get references to

--- a/include/seqan3/alphabet/concept.hpp
+++ b/include/seqan3/alphabet/concept.hpp
@@ -195,10 +195,10 @@ void CEREAL_LOAD_MINIMAL_FUNCTION_NAME(archive_t const &,
 namespace seqan3::detail
 {
 // ------------------------------------------------------------------
-// constexpr_semi_alphabet_concept
+// ConstexprSemialphabet
 // ------------------------------------------------------------------
 
-/*!\interface seqan3::detail::constexpr_semi_alphabet_concept <>
+/*!\interface seqan3::detail::ConstexprSemialphabet <>
  * \brief A seqan3::semi_alphabet_concept that has a constexpr default constructor and constexpr accessors.
  * \ingroup alphabet
  * \extends seqan3::semi_alphabet_concept
@@ -213,7 +213,7 @@ namespace seqan3::detail
  */
 //!\cond
 template <typename t>
-SEQAN3_CONCEPT constexpr_semi_alphabet_concept = semi_alphabet_concept<t> && requires
+SEQAN3_CONCEPT ConstexprSemialphabet = semi_alphabet_concept<t> && requires
 {
     // currently only tests rvalue interfaces, because we have no constexpr values in this scope to get references to
     requires SEQAN3_IS_CONSTEXPR(to_rank(std::remove_reference_t<t>{}));
@@ -228,7 +228,7 @@ SEQAN3_CONCEPT constexpr_semi_alphabet_concept = semi_alphabet_concept<t> && req
 /*!\interface seqan3::detail::constexpr_alphabet_concept <>
  * \brief A seqan3::alphabet_concept that has constexpr accessors.
  * \ingroup alphabet
- * \extends seqan3::detail::constexpr_semi_alphabet_concept
+ * \extends seqan3::detail::ConstexprSemialphabet
  * \extends seqan3::alphabet_concept
  *
  * The same as seqan3::alphabet_concept, except that the following interface requirements are also required to be
@@ -249,7 +249,7 @@ SEQAN3_CONCEPT constexpr_semi_alphabet_concept = semi_alphabet_concept<t> && req
  */
 //!\cond
 template <typename t>
-SEQAN3_CONCEPT constexpr_alphabet_concept = constexpr_semi_alphabet_concept<t> &&
+SEQAN3_CONCEPT constexpr_alphabet_concept = ConstexprSemialphabet<t> &&
                                      alphabet_concept<t> &&
                                      requires
 {

--- a/include/seqan3/alphabet/concept.hpp
+++ b/include/seqan3/alphabet/concept.hpp
@@ -222,10 +222,10 @@ SEQAN3_CONCEPT ConstexprSemialphabet = semi_alphabet_concept<t> && requires
 //!\endcond
 
 // ------------------------------------------------------------------
-// constexpr_alphabet_concept
+// ConstexprAlphabet
 // ------------------------------------------------------------------
 
-/*!\interface seqan3::detail::constexpr_alphabet_concept <>
+/*!\interface seqan3::detail::ConstexprAlphabet <>
  * \brief A seqan3::alphabet_concept that has constexpr accessors.
  * \ingroup alphabet
  * \extends seqan3::detail::ConstexprSemialphabet
@@ -249,7 +249,7 @@ SEQAN3_CONCEPT ConstexprSemialphabet = semi_alphabet_concept<t> && requires
  */
 //!\cond
 template <typename t>
-SEQAN3_CONCEPT constexpr_alphabet_concept = ConstexprSemialphabet<t> &&
+SEQAN3_CONCEPT ConstexprAlphabet = ConstexprSemialphabet<t> &&
                                      alphabet_concept<t> &&
                                      requires
 {

--- a/include/seqan3/alphabet/concept.hpp
+++ b/include/seqan3/alphabet/concept.hpp
@@ -26,10 +26,10 @@ namespace seqan3
 {
 
 // ------------------------------------------------------------------
-// semi_alphabet_concept
+// Semialphabet
 // ------------------------------------------------------------------
 
-/*!\interface seqan3::semi_alphabet_concept <>
+/*!\interface seqan3::Semialphabet <>
  * \brief The basis for seqan3::alphabet_concept, but requires only rank interface (not char).
  * \ingroup alphabet
  * \extends std::Regular
@@ -46,7 +46,7 @@ namespace seqan3
  *   * std::StrictTotallyOrdered ("has all comparison operators")
  *
  * For the purpose of concept checking the types `t &` and `t &&` are also considered to satisfy
- * seqan3::semi_alphabet_concept if the type `t` satisfies it.
+ * seqan3::Semialphabet if the type `t` satisfies it.
  *
  * It is recommended that alphabets also model seqan3::StandardLayout and seqan3::TriviallyCopyable
  * and all alphabets shipped with SeqAn3 do so.
@@ -64,7 +64,7 @@ namespace seqan3
  */
 //!\cond
 template <typename t>
-SEQAN3_CONCEPT semi_alphabet_concept = std::Regular<std::remove_reference_t<t>> &&
+SEQAN3_CONCEPT Semialphabet = std::Regular<std::remove_reference_t<t>> &&
                                 std::StrictTotallyOrdered<t> &&
                                 requires (t v)
 {
@@ -89,7 +89,7 @@ SEQAN3_CONCEPT semi_alphabet_concept = std::Regular<std::remove_reference_t<t>> 
 // ------------------------------------------------------------------
 
 /*!\interface seqan3::alphabet_concept <>
- * \extends seqan3::semi_alphabet_concept
+ * \extends seqan3::Semialphabet
  * \brief The generic alphabet concept that covers most data types used in ranges.
  * \ingroup alphabet
  *
@@ -115,7 +115,7 @@ SEQAN3_CONCEPT semi_alphabet_concept = std::Regular<std::remove_reference_t<t>> 
  */
 //!\cond
 template <typename t>
-SEQAN3_CONCEPT alphabet_concept = semi_alphabet_concept<t> && requires (t v)
+SEQAN3_CONCEPT alphabet_concept = Semialphabet<t> && requires (t v)
 {
     // conversion to char
     requires           noexcept(to_char(v));
@@ -141,25 +141,25 @@ SEQAN3_CONCEPT alphabet_concept = semi_alphabet_concept<t> && requires (t v)
 // ------------------------------------------------------------------
 
 /*!\cond DEV
- * \name Generic serialisation functions for all seqan3::semi_alphabet_concept
- * \brief All types that satisfy seqan3::semi_alphabet_concept can be serialised via Cereal.
+ * \name Generic serialisation functions for all seqan3::Semialphabet
+ * \brief All types that satisfy seqan3::Semialphabet can be serialised via Cereal.
  *
  * \{
  */
 /*!
  * \brief Save an alphabet letter to stream.
  * \tparam archive_t Must satisfy seqan3::CerealOutputArchive.
- * \tparam alphabet_t Type of l; must satisfy seqan3::semi_alphabet_concept.
+ * \tparam alphabet_t Type of l; must satisfy seqan3::Semialphabet.
  * \param l The alphabet letter.
- * \relates seqan3::semi_alphabet_concept
+ * \relates seqan3::Semialphabet
  *
  * \details
  *
- * Delegates to seqan3::semi_alphabet_concept::to_rank.
+ * Delegates to seqan3::Semialphabet::to_rank.
  *
  * \attention These functions are never called directly, see the \ref alphabet module on how to use serialisation.
  */
-template <CerealOutputArchive archive_t, semi_alphabet_concept alphabet_t>
+template <CerealOutputArchive archive_t, Semialphabet alphabet_t>
 underlying_rank_t<alphabet_t> CEREAL_SAVE_MINIMAL_FUNCTION_NAME(archive_t const &, alphabet_t const & l)
 {
     return to_rank(l);
@@ -167,14 +167,14 @@ underlying_rank_t<alphabet_t> CEREAL_SAVE_MINIMAL_FUNCTION_NAME(archive_t const 
 
 /*!\brief Restore an alphabet letter from a saved rank.
  * \tparam archive_t Must satisfy seqan3::CerealInputArchive.
- * \tparam wrapped_alphabet_t A seqan3::semi_alphabet_concept after Cereal mangles it up.
+ * \tparam wrapped_alphabet_t A seqan3::Semialphabet after Cereal mangles it up.
  * \param l The alphabet letter (cereal wrapped).
  * \param r The assigned value.
- * \relates seqan3::semi_alphabet_concept
+ * \relates seqan3::Semialphabet
  *
  * \details
  *
- * Delegates to seqan3::semi_alphabet_concept::assign_rank.
+ * Delegates to seqan3::Semialphabet::assign_rank.
  *
  * \attention These functions are never called directly, see the \ref alphabet module on how to use serialisation.
  */
@@ -182,7 +182,7 @@ template <CerealInputArchive archive_t, typename wrapped_alphabet_t>
 void CEREAL_LOAD_MINIMAL_FUNCTION_NAME(archive_t const &,
                                        wrapped_alphabet_t && l,
                                        underlying_rank_t<detail::strip_cereal_wrapper_t<wrapped_alphabet_t>> const & r)
-    requires semi_alphabet_concept<detail::strip_cereal_wrapper_t<wrapped_alphabet_t>>
+    requires Semialphabet<detail::strip_cereal_wrapper_t<wrapped_alphabet_t>>
 {
     assign_rank(static_cast<detail::strip_cereal_wrapper_t<wrapped_alphabet_t> &>(l), r);
 }
@@ -199,11 +199,11 @@ namespace seqan3::detail
 // ------------------------------------------------------------------
 
 /*!\interface seqan3::detail::ConstexprSemialphabet <>
- * \brief A seqan3::semi_alphabet_concept that has a constexpr default constructor and constexpr accessors.
+ * \brief A seqan3::Semialphabet that has a constexpr default constructor and constexpr accessors.
  * \ingroup alphabet
- * \extends seqan3::semi_alphabet_concept
+ * \extends seqan3::Semialphabet
  *
- * The same as seqan3::semi_alphabet_concept, except that all required functions are also required to be callable
+ * The same as seqan3::Semialphabet, except that all required functions are also required to be callable
  * in a `constexpr`-context.
  *
  * \par Concepts and doxygen
@@ -213,7 +213,7 @@ namespace seqan3::detail
  */
 //!\cond
 template <typename t>
-SEQAN3_CONCEPT ConstexprSemialphabet = semi_alphabet_concept<t> && requires
+SEQAN3_CONCEPT ConstexprSemialphabet = Semialphabet<t> && requires
 {
     // currently only tests rvalue interfaces, because we have no constexpr values in this scope to get references to
     requires SEQAN3_IS_CONSTEXPR(to_rank(std::remove_reference_t<t>{}));

--- a/include/seqan3/alphabet/concept_pre.hpp
+++ b/include/seqan3/alphabet/concept_pre.hpp
@@ -246,12 +246,12 @@ using underlying_char_t = typename underlying_char<alphabet_type>::type;
 //!\}
 
 // ------------------------------------------------------------------
-// seqan3::rna_structure_concept
+// seqan3::RnaStructureAlphabet
 // ------------------------------------------------------------------
 
-/*!\name Requirements for seqan3::rna_structure_concept
- * \brief You can expect these functions on all types that implement seqan3::rna_structure_concept.
- * \relates seqan3::rna_structure_concept
+/*!\name Requirements for seqan3::RnaStructureAlphabet
+ * \brief You can expect these functions on all types that implement seqan3::RnaStructureAlphabet.
+ * \relates seqan3::RnaStructureAlphabet
  * \{
  */
 /*!\brief Metafunction that indicates to what extent an alphabet can handle pseudoknots.

--- a/include/seqan3/alphabet/concept_pre.hpp
+++ b/include/seqan3/alphabet/concept_pre.hpp
@@ -32,16 +32,16 @@ namespace seqan3
 {
 
 // ------------------------------------------------------------------
-// seqan3::semi_alphabet_concept
+// seqan3::Semialphabet
 // ------------------------------------------------------------------
 
-/*!\name Requirements for seqan3::semi_alphabet_concept
- * \brief You can expect these functions on all types that implement seqan3::semi_alphabet_concept.
- * \relates seqan3::semi_alphabet_concept
+/*!\name Requirements for seqan3::Semialphabet
+ * \brief You can expect these functions on all types that implement seqan3::Semialphabet.
+ * \relates seqan3::Semialphabet
  * \{
  */
 /*!\brief The `rank_type` of the semi_alphabet. [type metafunction base template]
- * \tparam semi_alphabet_type Must satisfy seqan3::semi_alphabet_concept.
+ * \tparam semi_alphabet_type Must satisfy seqan3::Semialphabet.
  * \ingroup alphabet
  *
  * \par Helper template alias
@@ -70,7 +70,7 @@ template <typename semi_alphabet_type>
 using underlying_rank_t = typename underlying_rank<semi_alphabet_type>::type;
 
 /*!\brief The size of the alphabet. [value metafunction base template]
- * \tparam alphabet_type Must satisfy seqan3::semi_alphabet_concept.
+ * \tparam alphabet_type Must satisfy seqan3::Semialphabet.
  * \ingroup alphabet
  *
  * This is the expression to retrieve the value:
@@ -95,7 +95,7 @@ struct alphabet_size<alphabet_type &&> : alphabet_size<alphabet_type>
 {};
 
 /*!\brief The size of the alphabet. [value metafunction shortcut]
- * \tparam alphabet_type Must satisfy seqan3::semi_alphabet_concept.
+ * \tparam alphabet_type Must satisfy seqan3::Semialphabet.
  * \ingroup alphabet
  *
  * \attention Do not specialise this shortcut, instead specialise seqan3::alphabet_size.

--- a/include/seqan3/alphabet/concept_pre.hpp
+++ b/include/seqan3/alphabet/concept_pre.hpp
@@ -289,7 +289,7 @@ constexpr uint8_t max_pseudoknot_depth_v = max_pseudoknot_depth<alphabet_type>::
 } // namespace seqan3
 
 // ------------------------------------------------------------------
-// seqan3::char_adaption_concept
+// seqan3::CharAdaptationAlphabet
 // ------------------------------------------------------------------
 
 namespace seqan3::detail

--- a/include/seqan3/alphabet/concept_pre.hpp
+++ b/include/seqan3/alphabet/concept_pre.hpp
@@ -311,7 +311,7 @@ template <typename type>
 constexpr bool is_char_adaptation_v = is_char_adaptation<type>::value;
 
 // ------------------------------------------------------------------
-// seqan3::uint_adaption_concept
+// seqan3::UintAdaptionAlphabet
 // ------------------------------------------------------------------
 
 //!\brief Metafunction that indicates whether a type is a uint alphabet adaptation.

--- a/include/seqan3/alphabet/concept_pre.hpp
+++ b/include/seqan3/alphabet/concept_pre.hpp
@@ -7,7 +7,7 @@
 
 /*!\file
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
- * \brief seqan3::alphabet_concept metafunction base classes.
+ * \brief seqan3::Alphabet metafunction base classes.
  *
  * Include this file, if you implement an alphabet type with free/global function
  * and metafunction interfaces.
@@ -18,7 +18,7 @@
  * \snippet test/snippet/alphabet/concept_pre.cpp include order
  *
  * If you include `concept.hpp` before your definitions, than your type will
- * not be resolved as satisfying seqan3::alphabet_concept.
+ * not be resolved as satisfying seqan3::Alphabet.
  *
  * This is not `true` for custom alphabets implementing the interfaces as
  * member functions/variables/types.
@@ -140,17 +140,17 @@ constexpr auto alphabet_size_v = alphabet_size<alphabet_type>::value;
 //!\}
 
 // ------------------------------------------------------------------
-// seqan3::alphabet_concept
+// seqan3::Alphabet
 // ------------------------------------------------------------------
 
-/*!\name Requirements for seqan3::alphabet_concept
- * \brief You can expect these functions on all types that implement seqan3::alphabet_concept.
- * \relates seqan3::alphabet_concept
+/*!\name Requirements for seqan3::Alphabet
+ * \brief You can expect these functions on all types that implement seqan3::Alphabet.
+ * \relates seqan3::Alphabet
  * \{
  */
 
 /*!\brief The `char_type` of the alphabet. [type metafunction base template]
- * \tparam alphabet_type Must satisfy seqan3::alphabet_concept.
+ * \tparam alphabet_type Must satisfy seqan3::Alphabet.
  * \ingroup alphabet
  *
  * \par Helper template alias

--- a/include/seqan3/alphabet/detail/alphabet_base.hpp
+++ b/include/seqan3/alphabet/detail/alphabet_base.hpp
@@ -27,7 +27,7 @@ namespace seqan3
  * \tparam derived_type The CRTP parameter type.
  * \tparam size         The size of the alphabet.
  * \tparam char_t       The character type of the alphabet (set this to `void` when defining just a
- *                      seqan3::semi_alphabet_concept).
+ *                      seqan3::Semialphabet).
  *
  * \details
  *
@@ -106,7 +106,7 @@ public:
      *
      * \details
      *
-     * Satisfies the seqan3::semi_alphabet_concept::to_rank() requirement via the to_rank() wrapper.
+     * Satisfies the seqan3::Semialphabet::to_rank() requirement via the to_rank() wrapper.
      *
      * \par Complexity
      *
@@ -180,7 +180,7 @@ public:
      *
      * \details
      *
-     * Satisfies the seqan3::semi_alphabet_concept::assign_rank() requirement via the seqan3::assign_rank() wrapper.
+     * Satisfies the seqan3::Semialphabet::assign_rank() requirement via the seqan3::assign_rank() wrapper.
      *
      * \par Complexity
      *
@@ -244,7 +244,7 @@ public:
      *
      * \details
      *
-     * Models the seqan3::semi_alphabet_concept::char_is_valid_for() requirement via the seqan3::char_is_valid_for()
+     * Models the seqan3::Semialphabet::char_is_valid_for() requirement via the seqan3::char_is_valid_for()
      * wrapper.
      *
      * Default implementation: True for all character values that are reproduced by #to_char() after being assigned

--- a/include/seqan3/alphabet/detail/alphabet_base.hpp
+++ b/include/seqan3/alphabet/detail/alphabet_base.hpp
@@ -32,7 +32,7 @@ namespace seqan3
  * \details
  *
  * You can use this class to define your own alphabet, but types are not required to be based on it to model
- * seqan3::alphabet_concept, it is purely a way to avoid code duplication.
+ * seqan3::Alphabet, it is purely a way to avoid code duplication.
  *
  * The base class represents the alphabet value as the rank and
  * automatically deduces the rank type from the size, it further defines all required member functions and types; the
@@ -84,7 +84,7 @@ public:
      *
      * \details
      *
-     * Satisfies the seqan3::alphabet_concept::to_char() requirement via the seqan3::to_char() wrapper.
+     * Satisfies the seqan3::Alphabet::to_char() requirement via the seqan3::to_char() wrapper.
      *
      * \par Complexity
      *
@@ -130,7 +130,7 @@ public:
      *
      * \details
      *
-     * Satisfies the seqan3::alphabet_concept::assign_char() requirement via the seqan3::assign_char() wrapper.
+     * Satisfies the seqan3::Alphabet::assign_char() requirement via the seqan3::assign_char() wrapper.
      *
      * \par Complexity
      *
@@ -156,7 +156,7 @@ public:
      *
      * \details
      *
-     * Satisfies the seqan3::alphabet_concept::assign_char_strict() requirement via the seqan3::assign_char_strict()
+     * Satisfies the seqan3::Alphabet::assign_char_strict() requirement via the seqan3::assign_char_strict()
      * wrapper.
      *
      * ### Complexity

--- a/include/seqan3/alphabet/detail/alphabet_proxy.hpp
+++ b/include/seqan3/alphabet/detail/alphabet_proxy.hpp
@@ -109,7 +109,7 @@ public:
  * This CRTP base facilitates the definition of such proxies. Most users of SeqAn will not need to understand the
  * details.
  *
- * This class ensures that the proxy itself also models seqan3::Semialphabet, seqan3::alphabet_concept,
+ * This class ensures that the proxy itself also models seqan3::Semialphabet, seqan3::Alphabet,
  * seqan3::QualityAlphabet, seqan3::NucleotideAlphabet and/or seqan3::AminoacidAlphabet if the emulated type models
  * these. This makes sure that function templates which accept the original, also accept the proxy. An exception
  * are multi-layered compositions of alphabets where the proxy currently does not support access via `get`.
@@ -207,7 +207,7 @@ public:
     }
 
     constexpr derived_type & assign_char(char_type_virtual const c) noexcept
-        requires alphabet_concept<alphabet_type>
+        requires Alphabet<alphabet_type>
     {
         alphabet_type tmp{};
         using seqan3::assign_char;
@@ -216,7 +216,7 @@ public:
     }
 
     derived_type & assign_char_strict(char_type_virtual const c)
-        requires alphabet_concept<alphabet_type>
+        requires Alphabet<alphabet_type>
     {
         alphabet_type tmp{};
         using seqan3::assign_char_strict;
@@ -246,7 +246,7 @@ public:
     }
 
     constexpr char_type to_char() const noexcept
-        requires alphabet_concept<alphabet_type>
+        requires Alphabet<alphabet_type>
     {
         using seqan3::to_char;
         /* (smehringer) Explicit conversion instead of static_cast:

--- a/include/seqan3/alphabet/detail/alphabet_proxy.hpp
+++ b/include/seqan3/alphabet/detail/alphabet_proxy.hpp
@@ -109,7 +109,7 @@ public:
  * This CRTP base facilitates the definition of such proxies. Most users of SeqAn will not need to understand the
  * details.
  *
- * This class ensures that the proxy itself also models seqan3::semi_alphabet_concept, seqan3::alphabet_concept,
+ * This class ensures that the proxy itself also models seqan3::Semialphabet, seqan3::alphabet_concept,
  * seqan3::QualityAlphabet, seqan3::NucleotideAlphabet and/or seqan3::AminoacidAlphabet if the emulated type models
  * these. This makes sure that function templates which accept the original, also accept the proxy. An exception
  * are multi-layered compositions of alphabets where the proxy currently does not support access via `get`.

--- a/include/seqan3/alphabet/detail/convert.hpp
+++ b/include/seqan3/alphabet/detail/convert.hpp
@@ -29,11 +29,11 @@ namespace seqan3::detail
 
 /*!\brief A precomputed conversion table for two alphabets based on their char representations.
  * \ingroup alphabet
- * \tparam out_t The type of the output, must satisfy seqan3::alphabet_concept.
- * \tparam in_t The type of the input, must satisfy seqan3::alphabet_concept.
+ * \tparam out_t The type of the output, must satisfy seqan3::Alphabet.
+ * \tparam in_t The type of the input, must satisfy seqan3::Alphabet.
  * \hideinitializer
  */
-template <alphabet_concept out_t, alphabet_concept in_t>
+template <Alphabet out_t, Alphabet in_t>
 constexpr std::array<out_t, alphabet_size_v<in_t>> convert_through_char_representation
 {
     [] () constexpr

--- a/include/seqan3/alphabet/detail/hash.hpp
+++ b/include/seqan3/alphabet/detail/hash.hpp
@@ -19,14 +19,14 @@ namespace std
 {
 /*!\brief Struct for hashing a character.
  * \ingroup alphabet
- * \tparam alphabet_t The type of character to hash; Must model seqan3::semi_alphabet_concept.
+ * \tparam alphabet_t The type of character to hash; Must model seqan3::Semialphabet.
  */
-template <seqan3::semi_alphabet_concept alphabet_t>
+template <seqan3::Semialphabet alphabet_t>
 struct hash<alphabet_t>
 {
     /*!\brief Compute the hash for a character.
      * \ingroup alphabet
-     * \param[in] character The character to process. Must model seqan3::semi_alphabet_concept.
+     * \param[in] character The character to process. Must model seqan3::Semialphabet.
      *
      * \returns size_t.
      * \sa seqan3::to_rank.
@@ -41,18 +41,18 @@ struct hash<alphabet_t>
 /*!\brief Struct for hashing a range of characters.
  * \ingroup alphabet
  * \tparam urng_t The type of the range; Must model std::ranges::InputRange and the reference type of the range of the
-                  range must model seqan3::semi_alphabet_concept.
+                  range must model seqan3::Semialphabet.
  */
 template <ranges::InputRange urng_t>
     //!\cond
-    requires seqan3::semi_alphabet_concept<seqan3::reference_t<urng_t>>
+    requires seqan3::Semialphabet<seqan3::reference_t<urng_t>>
     //!\endcond
 struct hash<urng_t>
 {
     /*!\brief Compute the hash for a range of characters.
      * \ingroup alphabet
      * \param[in] range The input range to process. Must model std::ranges::InputRange and the reference type of the
-                        range of the range must model seqan3::semi_alphabet_concept.
+                        range of the range must model seqan3::Semialphabet.
      * \returns size_t.
      */
     size_t operator()(urng_t const & range) const noexcept

--- a/include/seqan3/alphabet/detail/member_exposure.hpp
+++ b/include/seqan3/alphabet/detail/member_exposure.hpp
@@ -120,12 +120,12 @@ constexpr alphabet_type assign_rank(alphabet_type && alph, underlying_rank_t<alp
 //!\}
 
 // ------------------------------------------------------------------
-// seqan3::alphabet_concept
+// seqan3::Alphabet
 // ------------------------------------------------------------------
 
-/*!\name Helpers for seqan3::alphabet_concept
+/*!\name Helpers for seqan3::Alphabet
  * \brief These functions and metafunctions expose member variables and types so that they satisfy
- * seqan3::alphabet_concept.
+ * seqan3::Alphabet.
  * \ingroup alphabet
  * \{
  */
@@ -143,7 +143,7 @@ struct underlying_char<alphabet_type_with_members>
     using type = typename alphabet_type_with_members::char_type;
 };
 
-/*!\brief Implementation of seqan3::alphabet_concept::to_char() that delegates to a member function.
+/*!\brief Implementation of seqan3::Alphabet::to_char() that delegates to a member function.
  * \tparam alphabet_type Must provide a `.to_char()` member function.
  * \param alph The alphabet letter that you wish to convert to char.
  * \returns The letter's value in the alphabet's rank type (usually `char`).
@@ -160,7 +160,7 @@ constexpr underlying_char_t<alphabet_type> to_char(alphabet_type const alph) noe
     return alph.to_char();
 }
 
-/*!\brief Implementation of seqan3::alphabet_concept::assign_char() that delegates to a member function.
+/*!\brief Implementation of seqan3::Alphabet::assign_char() that delegates to a member function.
  * \tparam alphabet_type Must provide an `.assign_char()` member function.
  * \param alph The alphabet letter that you wish to assign to.
  * \param chr The `char` value you wish to assign.
@@ -178,7 +178,7 @@ constexpr alphabet_type & assign_char(alphabet_type & alph, underlying_char_t<al
     return alph.assign_char(chr);
 }
 
-/*!\brief Implementation of seqan3::alphabet_concept::assign_char() that delegates to a member function.
+/*!\brief Implementation of seqan3::Alphabet::assign_char() that delegates to a member function.
  * \tparam alphabet_type Must provide an `.assign_char()` member function.
  * \param alph An alphabet letter temporary.
  * \param chr The `char` value you wish to assign.
@@ -201,7 +201,7 @@ constexpr alphabet_type assign_char(alphabet_type && alph, underlying_char_t<alp
     return std::move(alph.assign_char(chr));
 }
 
-/*!\brief Implementation of seqan3::alphabet_concept::char_is_valid_for() that delegates to a static member function.
+/*!\brief Implementation of seqan3::Alphabet::char_is_valid_for() that delegates to a static member function.
  * \tparam alphabet_type Must provide a `char_is_valid()` static member function.
  * \param chr The `char` value you wish to check.
  * \returns `true` or `false`.
@@ -215,7 +215,7 @@ constexpr bool char_is_valid_for(underlying_char_t<alphabet_type_with_members> c
     return std::remove_reference_t<alphabet_type_with_members>::char_is_valid(chr);
 }
 
-/*!\brief Implementation of seqan3::alphabet_concept::assign_char_strict() that delegates to a member function.
+/*!\brief Implementation of seqan3::Alphabet::assign_char_strict() that delegates to a member function.
  * \tparam alphabet_type Must provide an `.assign_char_strict()` member function.
  * \param alph The alphabet letter that you wish to assign to.
  * \param chr The `char` value you wish to assign.

--- a/include/seqan3/alphabet/detail/member_exposure.hpp
+++ b/include/seqan3/alphabet/detail/member_exposure.hpp
@@ -23,12 +23,12 @@ namespace seqan3
 {
 
 // ------------------------------------------------------------------
-// seqan3::semi_alphabet_concept
+// seqan3::Semialphabet
 // ------------------------------------------------------------------
 
-/*!\name Helpers for seqan3::semi_alphabet_concept
+/*!\name Helpers for seqan3::Semialphabet
  * \brief These functions and metafunctions expose member variables and types so that they satisfy
- * seqan3::semi_alphabet_concept.
+ * seqan3::Semialphabet.
  * \ingroup alphabet
  * \{
  */
@@ -60,7 +60,7 @@ struct alphabet_size<alphabet_type_with_members> :
                            alphabet_type_with_members::value_size>
 {};
 
-/*!\brief Implementation of seqan3::semi_alphabet_concept::to_rank() that delegates to a member function.
+/*!\brief Implementation of seqan3::Semialphabet::to_rank() that delegates to a member function.
  * \tparam alphabet_type Must provide a `.to_rank()` member function.
  * \param alph The alphabet letter that you wish to convert to rank.
  * \returns The letter's value in the alphabet's rank type (usually a `uint*_t`).
@@ -77,7 +77,7 @@ constexpr underlying_rank_t<alphabet_type> to_rank(alphabet_type const alph) noe
     return alph.to_rank();
 }
 
-/*!\brief Implementation of seqan3::semi_alphabet_concept::assign_rank() that delegates to a member function.
+/*!\brief Implementation of seqan3::Semialphabet::assign_rank() that delegates to a member function.
  * \tparam alphabet_type Must provide an `.assign_rank()` member function.
  * \param alph The alphabet letter that you wish to assign to.
  * \param rank The `rank` value you wish to assign.
@@ -95,7 +95,7 @@ constexpr alphabet_type & assign_rank(alphabet_type & alph, underlying_rank_t<al
     return alph.assign_rank(rank);
 }
 
-/*!\brief Implementation of seqan3::semi_alphabet_concept::assign_rank() that delegates to a member function.
+/*!\brief Implementation of seqan3::Semialphabet::assign_rank() that delegates to a member function.
  * \tparam alphabet_type Must provide an `.assign_rank()` member function.
  * \param alph An alphabet letter temporary.
  * \param rank The `rank` value you wish to assign.

--- a/include/seqan3/alphabet/detail/member_exposure.hpp
+++ b/include/seqan3/alphabet/detail/member_exposure.hpp
@@ -269,19 +269,19 @@ constexpr nucleotide_type complement(nucleotide_type const alph)
 //!\}
 
 // ------------------------------------------------------------------
-// seqan3::rna_structure_concept
+// seqan3::RnaStructureAlphabet
 // ------------------------------------------------------------------
 
-/*!\name Helpers for seqan3::rna_structure_concept
+/*!\name Helpers for seqan3::RnaStructureAlphabet
  * \brief These functions and metafunctions expose member variables and types so that they satisfy
- * seqan3::rna_structure_concept.
- * \relates seqan3::rna_structure_concept
+ * seqan3::RnaStructureAlphabet.
+ * \relates seqan3::RnaStructureAlphabet
  * \ingroup structure
  */
 //!\{
 
-/*!\brief Implementation of seqan3::rna_structure_concept::is_pair_open() that delegates to a member function.
- * \relates seqan3::rna_structure_concept
+/*!\brief Implementation of seqan3::RnaStructureAlphabet::is_pair_open() that delegates to a member function.
+ * \relates seqan3::RnaStructureAlphabet
  * \tparam structure_type Must provide a `.is_pair_open()` member function.
  * \param alph The alphabet letter which is checked for the pairing property.
  * \returns True if the letter represents a rightward interaction, False otherwise.
@@ -293,8 +293,8 @@ constexpr bool is_pair_open(structure_type const alph)
     return alph.is_pair_open();
 }
 
-/*!\brief Implementation of seqan3::rna_structure_concept::is_pair_close() that delegates to a member function.
- * \relates seqan3::rna_structure_concept
+/*!\brief Implementation of seqan3::RnaStructureAlphabet::is_pair_close() that delegates to a member function.
+ * \relates seqan3::RnaStructureAlphabet
  * \tparam structure_type Must provide a `.is_pair_close()` member function.
  * \param alph The alphabet letter which is checked for the pairing property.
  * \returns True if the letter represents a leftward interaction, False otherwise.
@@ -306,8 +306,8 @@ constexpr bool is_pair_close(structure_type const alph)
     return alph.is_pair_close();
 }
 
-/*!\brief Implementation of seqan3::rna_structure_concept::is_unpaired() that delegates to a member function.
- * \relates seqan3::rna_structure_concept
+/*!\brief Implementation of seqan3::RnaStructureAlphabet::is_unpaired() that delegates to a member function.
+ * \relates seqan3::RnaStructureAlphabet
  * \tparam structure_type Must provide a `.is_unpaired()` member function.
  * \param alph The alphabet letter which is checked for the pairing property.
  * \returns True if the letter represents an unpaired site, False otherwise.
@@ -320,7 +320,7 @@ constexpr bool is_unpaired(structure_type const alph)
 }
 
 /*!\brief Specialisation of seqan3::max_pseudoknot_depth that delegates to structure_type::max_pseudoknot_depth.
- * \relates seqan3::rna_structure_concept
+ * \relates seqan3::RnaStructureAlphabet
  * \tparam alphabet_type_with_pseudoknot_attribute Must provide a `static uint8_t max_pseudoknot_depth` member variable.
  */
 template <typename alphabet_type_with_pseudoknot_attribute>
@@ -334,8 +334,8 @@ struct max_pseudoknot_depth<alphabet_type_with_pseudoknot_attribute>
     static constexpr uint8_t value = alphabet_type_with_pseudoknot_attribute::max_pseudoknot_depth;
 };
 
-/*!\brief Implementation of seqan3::rna_structure_concept::pseudoknot_id() that delegates to a member function.
- * \relates seqan3::rna_structure_concept
+/*!\brief Implementation of seqan3::RnaStructureAlphabet::pseudoknot_id() that delegates to a member function.
+ * \relates seqan3::RnaStructureAlphabet
  * \tparam alphabet_type_with_pseudoknot_attribute If it supports pseudoknots, it must provide a `.pseudoknot_id()`
  * member function, otherwise it can be omitted.
  * \param alph The alphabet letter which is checked for the pseudoknot id.

--- a/include/seqan3/alphabet/exception.hpp
+++ b/include/seqan3/alphabet/exception.hpp
@@ -20,7 +20,7 @@
 namespace seqan3
 {
 
-//!\brief An exception typically thrown by seqan3::alphabet_concept::assign_char_strict.
+//!\brief An exception typically thrown by seqan3::Alphabet::assign_char_strict.
 struct invalid_char_assignment : std::runtime_error
 {
     //!\brief Constructor that takes the type name and the failed character as arguments.

--- a/include/seqan3/alphabet/gap/all.hpp
+++ b/include/seqan3/alphabet/gap/all.hpp
@@ -22,7 +22,7 @@
  * \par Introduction
  * The gap symbol (`-`) is used in alignments to represent an interruption in an alignment, usually the result of an
  * insertion or deletion. The seqan3::gap alphabet represents this (single) gap symbol and satisfies the
- * seqan3::alphabet_concept.
+ * seqan3::Alphabet.
  *
  * The main purpose of seqan3::gap is to be combined with other alphabets. This can easily be achieved by using the
  * seqan3::gapped<> template which transforms any other alphabet to be a composition of that alphabet + the gap

--- a/include/seqan3/alphabet/gap/gap.hpp
+++ b/include/seqan3/alphabet/gap/gap.hpp
@@ -22,7 +22,7 @@ namespace seqan3
 
 /*!\brief The alphabet of a gap character '-'
  * \ingroup gap
- * \implements seqan3::alphabet_concept
+ * \implements seqan3::Alphabet
  * \implements seqan3::detail::ConstexprAlphabet
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout

--- a/include/seqan3/alphabet/gap/gap.hpp
+++ b/include/seqan3/alphabet/gap/gap.hpp
@@ -23,7 +23,7 @@ namespace seqan3
 /*!\brief The alphabet of a gap character '-'
  * \ingroup gap
  * \implements seqan3::alphabet_concept
- * \implements seqan3::detail::constexpr_alphabet_concept
+ * \implements seqan3::detail::ConstexprAlphabet
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
  *

--- a/include/seqan3/alphabet/gap/gapped.hpp
+++ b/include/seqan3/alphabet/gap/gapped.hpp
@@ -22,7 +22,7 @@ namespace seqan3
 
 /*!\brief Extends a given alphabet with a gap character.
  * \ingroup gap
- * \tparam alphabet_t Type of the letter, e.g. dna4; must satisfy seqan3::alphabet_concept.
+ * \tparam alphabet_t Type of the letter, e.g. dna4; must satisfy seqan3::Alphabet.
  *
  * The gapped alphabet represents the union of a given alphabet and the
  * seqan3::gap alphabet (e.g. the four letter DNA alphabet + a gap character).
@@ -37,7 +37,7 @@ namespace seqan3
  */
 template <typename alphabet_t>
 //!\cond
-    requires alphabet_concept<alphabet_t>
+    requires Alphabet<alphabet_t>
 //!\endcond
 using gapped = union_composition<gap, alphabet_t>;
 

--- a/include/seqan3/alphabet/mask/mask.hpp
+++ b/include/seqan3/alphabet/mask/mask.hpp
@@ -21,7 +21,7 @@ namespace seqan3
 /*!\brief Implementation of a masked alphabet to be used for cartesian compositions.
  * \ingroup mask
  * \implements seqan3::Semialphabet
- * \implements seqan3::detail::SemiConstexprAlphabet
+ * \implements seqan3::detail::ConstexprSemialphabet
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
  *

--- a/include/seqan3/alphabet/mask/mask.hpp
+++ b/include/seqan3/alphabet/mask/mask.hpp
@@ -20,7 +20,7 @@ namespace seqan3
 {
 /*!\brief Implementation of a masked alphabet to be used for cartesian compositions.
  * \ingroup mask
- * \implements seqan3::semi_alphabet_concept
+ * \implements seqan3::Semialphabet
  * \implements seqan3::detail::SemiConstexprAlphabet
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout

--- a/include/seqan3/alphabet/mask/mask.hpp
+++ b/include/seqan3/alphabet/mask/mask.hpp
@@ -21,7 +21,7 @@ namespace seqan3
 /*!\brief Implementation of a masked alphabet to be used for cartesian compositions.
  * \ingroup mask
  * \implements seqan3::semi_alphabet_concept
- * \implements seqan3::detail::semi_constexpr_alphabet_concept
+ * \implements seqan3::detail::SemiConstexprAlphabet
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
  *

--- a/include/seqan3/alphabet/mask/masked.hpp
+++ b/include/seqan3/alphabet/mask/masked.hpp
@@ -27,8 +27,8 @@ namespace seqan3
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
  *
- * \tparam sequence_alphabet_t Type of the first letter; must satisfy seqan3::semi_alphabet_concept.
- * \tparam mask_t Types of masked letter; must satisfy seqan3::semi_alphabet_concept, defaults to seqan3::mask.
+ * \tparam sequence_alphabet_t Type of the first letter; must satisfy seqan3::Semialphabet.
+ * \tparam mask_t Types of masked letter; must satisfy seqan3::Semialphabet, defaults to seqan3::mask.
  *
  * \details
  * The masked composition represents a seqan3::cartesian_composition of any given alphabet with the
@@ -129,7 +129,7 @@ public:
      *
      * \details
      *
-     * Satisfies the seqan3::semi_alphabet_concept::char_is_valid_for() requirement via the seqan3::char_is_valid_for()
+     * Satisfies the seqan3::Semialphabet::char_is_valid_for() requirement via the seqan3::char_is_valid_for()
      * wrapper.
      *
      * Default implementation: True for all character values that are reproduced by #to_char() after being assigned

--- a/include/seqan3/alphabet/mask/masked.hpp
+++ b/include/seqan3/alphabet/mask/masked.hpp
@@ -23,7 +23,7 @@ namespace seqan3
  * with a mask.
  * \ingroup mask
  * \implements seqan3::Alphabet
- * \implements seqan3::detail::SemiConstexprAlphabet
+ * \implements seqan3::detail::ConstexprSemialphabet
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
  *

--- a/include/seqan3/alphabet/mask/masked.hpp
+++ b/include/seqan3/alphabet/mask/masked.hpp
@@ -22,7 +22,7 @@ namespace seqan3
 /*!\brief Implementation of a masked composition, which extends a given alphabet
  * with a mask.
  * \ingroup mask
- * \implements seqan3::alphabet_concept
+ * \implements seqan3::Alphabet
  * \implements seqan3::detail::SemiConstexprAlphabet
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
@@ -39,7 +39,7 @@ namespace seqan3
  */
  template <typename sequence_alphabet_t>
 //!\cond
-    requires alphabet_concept<sequence_alphabet_t>
+    requires Alphabet<sequence_alphabet_t>
 //!\endcond
 class masked : public cartesian_composition<masked<sequence_alphabet_t>, sequence_alphabet_t, mask>
 {

--- a/include/seqan3/alphabet/mask/masked.hpp
+++ b/include/seqan3/alphabet/mask/masked.hpp
@@ -23,7 +23,7 @@ namespace seqan3
  * with a mask.
  * \ingroup mask
  * \implements seqan3::alphabet_concept
- * \implements seqan3::detail::semi_constexpr_alphabet_concept
+ * \implements seqan3::detail::SemiConstexprAlphabet
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
  *

--- a/include/seqan3/alphabet/nucleotide/all.hpp
+++ b/include/seqan3/alphabet/nucleotide/all.hpp
@@ -104,7 +104,7 @@
  * \par Concept
  *
  * The nucleotide submodule defines seqan3::NucleotideAlphabet which encompasses all the alphabets defined in the
- * submodule and refines seqan3::alphabet_concept. The only additional requirement is that their values can be
+ * submodule and refines seqan3::Alphabet. The only additional requirement is that their values can be
  * complemented, see below.
  *
  * \par Complement

--- a/include/seqan3/alphabet/nucleotide/concept.hpp
+++ b/include/seqan3/alphabet/nucleotide/concept.hpp
@@ -23,11 +23,11 @@ namespace seqan3
 {
 
 /*!\interface seqan3::NucleotideAlphabet <>
- * \extends seqan3::alphabet_concept
+ * \extends seqan3::Alphabet
  * \brief A concept that indicates whether an alphabet represents nucleotides.
  * \ingroup nucleotide
  *
- * In addition to the requirements for seqan3::alphabet_concept, the NucleotideAlphabet introduces
+ * In addition to the requirements for seqan3::Alphabet, the NucleotideAlphabet introduces
  * a requirement for a complement function: seqan3::NucleotideAlphabet::complement.
  *
  * \par Concepts and doxygen
@@ -36,7 +36,7 @@ namespace seqan3
  */
 //!\cond
 template <typename type>
-SEQAN3_CONCEPT NucleotideAlphabet = alphabet_concept<type> && requires (type v, std::remove_reference_t<type> c)
+SEQAN3_CONCEPT NucleotideAlphabet = Alphabet<type> && requires (type v, std::remove_reference_t<type> c)
 {
     requires std::Same<decltype(complement(v)), decltype(c)>;
 };

--- a/include/seqan3/alphabet/nucleotide/dna15.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna15.hpp
@@ -29,7 +29,7 @@ class rna15;
 /*!\brief The 15 letter DNA alphabet, containing all IUPAC smybols minus the gap.
  * \ingroup nucleotide
  * \implements seqan3::NucleotideAlphabet
- * \implements seqan3::detail::constexpr_alphabet_concept
+ * \implements seqan3::detail::ConstexprAlphabet
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
  *

--- a/include/seqan3/alphabet/nucleotide/dna4.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna4.hpp
@@ -29,7 +29,7 @@ class rna4;
 /*!\brief The four letter DNA alphabet of A,C,G,T.
  * \ingroup nucleotide
  * \implements seqan3::NucleotideAlphabet
- * \implements seqan3::detail::constexpr_alphabet_concept
+ * \implements seqan3::detail::ConstexprAlphabet
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
  *

--- a/include/seqan3/alphabet/nucleotide/dna5.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna5.hpp
@@ -29,7 +29,7 @@ class rna5;
 /*!\brief The five letter DNA alphabet of A,C,G,T and the unknown character N.
  * \ingroup nucleotide
  * \implements seqan3::NucleotideAlphabet
- * \implements seqan3::detail::constexpr_alphabet_concept
+ * \implements seqan3::detail::ConstexprAlphabet
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
  *

--- a/include/seqan3/alphabet/nucleotide/nucleotide_base.hpp
+++ b/include/seqan3/alphabet/nucleotide/nucleotide_base.hpp
@@ -113,7 +113,7 @@ public:
      *
      * \details
      *
-     * Satisfies the seqan3::semi_alphabet_concept::char_is_valid_for() requirement via the seqan3::char_is_valid_for()
+     * Satisfies the seqan3::Semialphabet::char_is_valid_for() requirement via the seqan3::char_is_valid_for()
      * wrapper.
      *
      * Behaviour specific to nucleotides: True also for lower case letters that silently convert to their upper case

--- a/include/seqan3/alphabet/nucleotide/rna15.hpp
+++ b/include/seqan3/alphabet/nucleotide/rna15.hpp
@@ -26,7 +26,7 @@ namespace seqan3
 
 /*!\brief The 15 letter RNA alphabet, containing all IUPAC smybols minus the gap.
  * \implements seqan3::NucleotideAlphabet
- * \implements seqan3::detail::constexpr_alphabet_concept
+ * \implements seqan3::detail::ConstexprAlphabet
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
  *

--- a/include/seqan3/alphabet/nucleotide/rna4.hpp
+++ b/include/seqan3/alphabet/nucleotide/rna4.hpp
@@ -27,7 +27,7 @@ namespace seqan3
 /*!\brief The four letter RNA alphabet of A,C,G,U.
  * \ingroup nucleotide
  * \implements seqan3::NucleotideAlphabet
- * \implements seqan3::detail::constexpr_alphabet_concept
+ * \implements seqan3::detail::ConstexprAlphabet
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
  *

--- a/include/seqan3/alphabet/nucleotide/rna5.hpp
+++ b/include/seqan3/alphabet/nucleotide/rna5.hpp
@@ -27,7 +27,7 @@ namespace seqan3
 /*!\brief The five letter RNA alphabet of A,C,G,U and the unknown character N.
  * \ingroup nucleotide
  * \implements seqan3::NucleotideAlphabet
- * \implements seqan3::detail::constexpr_alphabet_concept
+ * \implements seqan3::detail::ConstexprAlphabet
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
  *

--- a/include/seqan3/alphabet/quality/all.hpp
+++ b/include/seqan3/alphabet/quality/all.hpp
@@ -70,7 +70,7 @@
  *
  * The quality submodule defines the seqan3::QualityAlphabet which encompasses
  * all the alphabets, defined in the submodule, and refines the
- * seqan3::alphabet_concept by providing Phred score assignment and conversion
+ * seqan3::Alphabet by providing Phred score assignment and conversion
  * operations.
  *
  * \par Assignment and Conversion

--- a/include/seqan3/alphabet/quality/concept.hpp
+++ b/include/seqan3/alphabet/quality/concept.hpp
@@ -108,11 +108,11 @@ constexpr underlying_phred_t<alphabet_type> to_phred(alphabet_type const & chr)
 // ------------------------------------------------------------------
 
 /*!\interface seqan3::QualityAlphabet <>
- * \extends seqan3::alphabet_concept
+ * \extends seqan3::Alphabet
  * \brief A concept that indicates whether an alphabet represents quality scores.
  * \ingroup quality
  *
- * In addition to the requirements for seqan3::alphabet_concept, the
+ * In addition to the requirements for seqan3::Alphabet, the
  * QualityAlphabet introduces a requirement for conversion functions from and to
  * a Phred score.
  *
@@ -125,7 +125,7 @@ constexpr underlying_phred_t<alphabet_type> to_phred(alphabet_type const & chr)
 template<typename q>
 SEQAN3_CONCEPT QualityAlphabet = requires(q quality)
 {
-    requires alphabet_concept<q>;
+    requires Alphabet<q>;
 
     { assign_phred(quality, typename q::rank_type{}) } -> q;
     { to_phred(quality) } -> const typename q::phred_type;

--- a/include/seqan3/alphabet/quality/phred42.hpp
+++ b/include/seqan3/alphabet/quality/phred42.hpp
@@ -23,7 +23,7 @@ namespace seqan3
 
 /*!\brief Quality type for traditional Sanger and modern Illumina Phred scores (typical range).
  * \implements seqan3::QualityAlphabet
- * \implements seqan3::detail::constexpr_alphabet_concept
+ * \implements seqan3::detail::ConstexprAlphabet
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
  *

--- a/include/seqan3/alphabet/quality/phred63.hpp
+++ b/include/seqan3/alphabet/quality/phred63.hpp
@@ -23,7 +23,7 @@ namespace seqan3
 
 /*!\brief Quality type for traditional Sanger and modern Illumina Phred scores (full range).
  * \implements seqan3::QualityAlphabet
- * \implements seqan3::detail::constexpr_alphabet_concept
+ * \implements seqan3::detail::ConstexprAlphabet
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
  *

--- a/include/seqan3/alphabet/quality/phred68legacy.hpp
+++ b/include/seqan3/alphabet/quality/phred68legacy.hpp
@@ -23,7 +23,7 @@ namespace seqan3
 
 /*!\brief Quality type for Solexa and deprecated Illumina formats.
  * \implements seqan3::QualityAlphabet
- * \implements seqan3::detail::constexpr_alphabet_concept
+ * \implements seqan3::detail::ConstexprAlphabet
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
  *

--- a/include/seqan3/alphabet/quality/qualified.hpp
+++ b/include/seqan3/alphabet/quality/qualified.hpp
@@ -27,7 +27,7 @@ namespace seqan3
  * \tparam sequence_alphabet_t Type of the alphabet; must satisfy seqan3::alphabet_concept.
  * \tparam quality_alphabet_t  Type of the quality; must satisfy seqan3::QualityAlphabet.
  * \implements seqan3::QualityAlphabet
- * \implements seqan3::detail::constexpr_alphabet_concept
+ * \implements seqan3::detail::ConstexprAlphabet
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
  *

--- a/include/seqan3/alphabet/quality/qualified.hpp
+++ b/include/seqan3/alphabet/quality/qualified.hpp
@@ -24,7 +24,7 @@ namespace seqan3
 
 /*!\brief Joins an arbitrary alphabet with a quality alphabet.
  * \ingroup quality
- * \tparam sequence_alphabet_t Type of the alphabet; must satisfy seqan3::alphabet_concept.
+ * \tparam sequence_alphabet_t Type of the alphabet; must satisfy seqan3::Alphabet.
  * \tparam quality_alphabet_t  Type of the quality; must satisfy seqan3::QualityAlphabet.
  * \implements seqan3::QualityAlphabet
  * \implements seqan3::detail::ConstexprAlphabet
@@ -52,9 +52,9 @@ namespace seqan3
  *
  * \snippet test/snippet/alphabet/quality/qualified.cpp general
  *
- * This seqan3::cartesian_composition itself fulfils both seqan3::alphabet_concept and seqan3::QualityAlphabet.
+ * This seqan3::cartesian_composition itself fulfils both seqan3::Alphabet and seqan3::QualityAlphabet.
  */
-template <alphabet_concept sequence_alphabet_t, QualityAlphabet quality_alphabet_t>
+template <Alphabet sequence_alphabet_t, QualityAlphabet quality_alphabet_t>
 class qualified :
     public cartesian_composition<qualified<sequence_alphabet_t, quality_alphabet_t>,
                                  sequence_alphabet_t, quality_alphabet_t>

--- a/include/seqan3/alphabet/structure/dot_bracket3.hpp
+++ b/include/seqan3/alphabet/structure/dot_bracket3.hpp
@@ -26,7 +26,7 @@ namespace seqan3
 {
 
 /*!\brief The three letter RNA structure alphabet of the characters ".()".
- * \implements seqan3::rna_structure_concept
+ * \implements seqan3::RnaStructureAlphabet
  * \implements seqan3::detail::ConstexprAlphabet
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout

--- a/include/seqan3/alphabet/structure/dot_bracket3.hpp
+++ b/include/seqan3/alphabet/structure/dot_bracket3.hpp
@@ -27,7 +27,7 @@ namespace seqan3
 
 /*!\brief The three letter RNA structure alphabet of the characters ".()".
  * \implements seqan3::rna_structure_concept
- * \implements seqan3::detail::constexpr_alphabet_concept
+ * \implements seqan3::detail::ConstexprAlphabet
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
  *

--- a/include/seqan3/alphabet/structure/dssp9.hpp
+++ b/include/seqan3/alphabet/structure/dssp9.hpp
@@ -26,7 +26,7 @@ namespace seqan3
 {
 
 /*!\brief The protein structure alphabet of the characters "HGIEBTSCX".
- * \implements seqan3::alphabet_concept
+ * \implements seqan3::Alphabet
  * \implements seqan3::detail::ConstexprAlphabet
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout

--- a/include/seqan3/alphabet/structure/dssp9.hpp
+++ b/include/seqan3/alphabet/structure/dssp9.hpp
@@ -27,7 +27,7 @@ namespace seqan3
 
 /*!\brief The protein structure alphabet of the characters "HGIEBTSCX".
  * \implements seqan3::alphabet_concept
- * \implements seqan3::detail::constexpr_alphabet_concept
+ * \implements seqan3::detail::ConstexprAlphabet
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
  *

--- a/include/seqan3/alphabet/structure/rna_structure_concept.hpp
+++ b/include/seqan3/alphabet/structure/rna_structure_concept.hpp
@@ -24,7 +24,7 @@ namespace seqan3
 {
 /*!\interface seqan3::rna_structure_concept
  * \brief A concept that indicates whether an alphabet represents RNA structure.
- * \implements alphabet_concept
+ * \implements Alphabet
  * \tparam structure_type The structure alphabet type.
  * \ingroup structure
  * \details RNA structure alphabets are required to represent interactions among RNA nucleotides.
@@ -67,7 +67,7 @@ template <typename structure_type>
 SEQAN3_CONCEPT rna_structure_concept = requires(structure_type val)
 {
     // requires fulfillment of alphabet concept
-    requires alphabet_concept<structure_type>;
+    requires Alphabet<structure_type>;
 
     // these are delegated to member functions, see file ../detail/member_exposure.hpp
     { is_pair_open(val) } -> bool;

--- a/include/seqan3/alphabet/structure/rna_structure_concept.hpp
+++ b/include/seqan3/alphabet/structure/rna_structure_concept.hpp
@@ -7,7 +7,7 @@
 
 /*!\file
  * \author Joerg Winkler <j.winkler AT fu-berlin.de>
- * \brief Provides seqan3::rna_structure_concept.
+ * \brief Provides seqan3::RnaStructureAlphabet.
  */
 
 #pragma once
@@ -22,7 +22,7 @@
 
 namespace seqan3
 {
-/*!\interface seqan3::rna_structure_concept
+/*!\interface seqan3::RnaStructureAlphabet
  * \brief A concept that indicates whether an alphabet represents RNA structure.
  * \implements Alphabet
  * \tparam structure_type The structure alphabet type.
@@ -33,38 +33,38 @@ namespace seqan3
  */
 /*!\fn bool is_pair_open(structure_type const alph)
  * \brief Check whether the given character represents a rightward interaction in an RNA structure.
- * \relates seqan3::rna_structure_concept
+ * \relates seqan3::RnaStructureAlphabet
  * \param alph The alphabet letter which is checked for the pairing property.
  * \returns True if the letter represents a rightward interaction, False otherwise.
  */
 /*!\fn bool is_pair_close(structure_type const alph)
  * \brief Check whether the given character represents a leftward interaction in an RNA structure.
- * \relates seqan3::rna_structure_concept
+ * \relates seqan3::RnaStructureAlphabet
  * \param alph The alphabet letter which is checked for the pairing property.
  * \returns True if the letter represents a leftward interaction, False otherwise.
  */
 /*!\fn bool is_unpaired(structure_type const alph)
  * \brief Check whether the given character represents an unpaired position in an RNA structure.
- * \relates seqan3::rna_structure_concept
+ * \relates seqan3::RnaStructureAlphabet
  * \param alph The alphabet letter which is checked for the pairing property.
  * \returns True if the letter represents an unpaired site, False otherwise.
  */
 /*!\fn std::optional<uint8_t> pseudoknot_id(structure_type const alph)
  * \brief Get an identifier for a pseudoknotted interaction.
- * \relates seqan3::rna_structure_concept
+ * \relates seqan3::RnaStructureAlphabet
  * \param alph The alphabet letter which is checked for the pseudoknot id.
  * \returns The pseudoknot id, if alph represents an interaction, and no value otherwise.
  * It is guaranteed to be smaller than seqan3::max_pseudoknot_depth.
  */
 /*!\struct max_pseudoknot_depth<structure_type>
  * \brief The ability of this alphabet to represent pseudoknots, i.e. crossing interactions, up to a certain depth.
- * \relates seqan3::rna_structure_concept
+ * \relates seqan3::RnaStructureAlphabet
  * \details It is the number of distinct pairs of interaction symbols the format supports. The value 1 denotes no
  * pseudoknot support; any higher number gives the maximum nestedness. Value 0 is not allowed.
  */
 //!\cond
 template <typename structure_type>
-SEQAN3_CONCEPT rna_structure_concept = requires(structure_type val)
+SEQAN3_CONCEPT RnaStructureAlphabet = requires(structure_type val)
 {
     // requires fulfillment of alphabet concept
     requires Alphabet<structure_type>;

--- a/include/seqan3/alphabet/structure/structured_aa.hpp
+++ b/include/seqan3/alphabet/structure/structured_aa.hpp
@@ -27,7 +27,7 @@ namespace seqan3
 /*!\brief A seqan3::cartesian_composition that joins an aminoacid alphabet with a protein structure alphabet.
  * \ingroup structure
  * \implements seqan3::alphabet_concept
- * \implements seqan3::detail::constexpr_alphabet_concept
+ * \implements seqan3::detail::ConstexprAlphabet
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
  * \tparam sequence_alphabet_t Type of the first aminoacid letter; must satisfy seqan3::alphabet_concept.

--- a/include/seqan3/alphabet/structure/structured_aa.hpp
+++ b/include/seqan3/alphabet/structure/structured_aa.hpp
@@ -26,12 +26,12 @@ namespace seqan3
 
 /*!\brief A seqan3::cartesian_composition that joins an aminoacid alphabet with a protein structure alphabet.
  * \ingroup structure
- * \implements seqan3::alphabet_concept
+ * \implements seqan3::Alphabet
  * \implements seqan3::detail::ConstexprAlphabet
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
- * \tparam sequence_alphabet_t Type of the first aminoacid letter; must satisfy seqan3::alphabet_concept.
- * \tparam structure_alphabet_t Types of further structure letters; must satisfy seqan3::alphabet_concept.
+ * \tparam sequence_alphabet_t Type of the first aminoacid letter; must satisfy seqan3::Alphabet.
+ * \tparam structure_alphabet_t Types of further structure letters; must satisfy seqan3::Alphabet.
  *
  * This composition pairs an aminoacid alphabet with a structure alphabet. The rank values
  * correpsond to numeric values in the size of the composition, while the character values
@@ -44,11 +44,11 @@ namespace seqan3
  *
  * \snippet test/snippet/alphabet/structure/structured_aa.cpp general
  *
- * This seqan3::cartesian_composition itself fulfills seqan3::alphabet_concept.
+ * This seqan3::cartesian_composition itself fulfills seqan3::Alphabet.
  */
 template <typename sequence_alphabet_t = aa27, typename structure_alphabet_t = dssp9>
 //!\cond
-    requires alphabet_concept<sequence_alphabet_t> && alphabet_concept<structure_alphabet_t>
+    requires Alphabet<sequence_alphabet_t> && Alphabet<structure_alphabet_t>
 //!\endcond
 class structured_aa :
     public cartesian_composition<structured_aa<sequence_alphabet_t, structure_alphabet_t>,

--- a/include/seqan3/alphabet/structure/structured_rna.hpp
+++ b/include/seqan3/alphabet/structure/structured_rna.hpp
@@ -26,12 +26,12 @@ namespace seqan3
 
 /*!\brief A seqan3::cartesian_composition that joins a nucleotide alphabet with an RNA structure alphabet.
  * \ingroup structure
- * \implements seqan3::rna_structure_concept
+ * \implements seqan3::RnaStructureAlphabet
  * \implements seqan3::detail::ConstexprAlphabet
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
  * \tparam sequence_alphabet_t Type of the first letter; must satisfy seqan3::NucleotideAlphabet.
- * \tparam structure_alphabet_t Types of further letters; must satisfy seqan3::rna_structure_concept.
+ * \tparam structure_alphabet_t Types of further letters; must satisfy seqan3::RnaStructureAlphabet.
  *
  * This composition pairs a nucleotide alphabet with a structure alphabet. The rank values
  * correpsond to numeric values in the size of the composition, while the character values
@@ -44,11 +44,11 @@ namespace seqan3
  *
  * \snippet test/snippet/alphabet/structure/structured_rna.cpp general
  *
- * This seqan3::cartesian_composition itself models both seqan3::NucleotideAlphabet and seqan3::rna_structure_concept.
+ * This seqan3::cartesian_composition itself models both seqan3::NucleotideAlphabet and seqan3::RnaStructureAlphabet.
  */
 template <typename sequence_alphabet_t, typename structure_alphabet_t>
 //!\cond
-    requires NucleotideAlphabet<sequence_alphabet_t> && rna_structure_concept<structure_alphabet_t>
+    requires NucleotideAlphabet<sequence_alphabet_t> && RnaStructureAlphabet<structure_alphabet_t>
 //!\endcond
 class structured_rna :
     public cartesian_composition<structured_rna<sequence_alphabet_t, structure_alphabet_t>,

--- a/include/seqan3/alphabet/structure/structured_rna.hpp
+++ b/include/seqan3/alphabet/structure/structured_rna.hpp
@@ -27,7 +27,7 @@ namespace seqan3
 /*!\brief A seqan3::cartesian_composition that joins a nucleotide alphabet with an RNA structure alphabet.
  * \ingroup structure
  * \implements seqan3::rna_structure_concept
- * \implements seqan3::detail::constexpr_alphabet_concept
+ * \implements seqan3::detail::ConstexprAlphabet
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
  * \tparam sequence_alphabet_t Type of the first letter; must satisfy seqan3::NucleotideAlphabet.

--- a/include/seqan3/alphabet/structure/wuss.hpp
+++ b/include/seqan3/alphabet/structure/wuss.hpp
@@ -29,7 +29,7 @@ namespace seqan3
 /*!\brief The WUSS structure alphabet of the characters `.<>:,-_~;()[]{}AaBbCcDd`...
  * \tparam SIZE The alphabet size defaults to 51 and must be an odd number in range 15..67.
  *              It determines the allowed pseudoknot depth by adding characters AaBb..Zz to the alphabet.
- * \implements seqan3::rna_structure_concept
+ * \implements seqan3::RnaStructureAlphabet
  * \implements seqan3::detail::ConstexprAlphabet
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout

--- a/include/seqan3/alphabet/structure/wuss.hpp
+++ b/include/seqan3/alphabet/structure/wuss.hpp
@@ -30,7 +30,7 @@ namespace seqan3
  * \tparam SIZE The alphabet size defaults to 51 and must be an odd number in range 15..67.
  *              It determines the allowed pseudoknot depth by adding characters AaBb..Zz to the alphabet.
  * \implements seqan3::rna_structure_concept
- * \implements seqan3::detail::constexpr_alphabet_concept
+ * \implements seqan3::detail::ConstexprAlphabet
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
  *

--- a/include/seqan3/io/alignment_file/format_sam.hpp
+++ b/include/seqan3/io/alignment_file/format_sam.hpp
@@ -186,27 +186,27 @@ public:
         // Type Requirements (as static asserts for user friendliness)
         // ---------------------------------------------------------------------
         static_assert((std::ranges::ForwardRange<seq_type>        &&
-                      alphabet_concept<value_type_t<remove_cvref_t<seq_type>>>),
+                      Alphabet<value_type_t<remove_cvref_t<seq_type>>>),
                       "The seq object must be a std::ranges::ForwardRange over "
-                      "letters that model seqan3::alphabet_concept.");
+                      "letters that model seqan3::Alphabet.");
 
         static_assert((std::ranges::ForwardRange<id_type>         &&
-                      alphabet_concept<value_type_t<remove_cvref_t<id_type>>>),
+                      Alphabet<value_type_t<remove_cvref_t<id_type>>>),
                       "The id object must be a std::ranges::ForwardRange over "
-                      "letters that model seqan3::alphabet_concept.");
+                      "letters that model seqan3::Alphabet.");
 
         static_assert(std::UnsignedIntegral<remove_cvref_t<offset_type>>,
                       "The offset object must be a std::UnsignedIntegral.");
 
         static_assert((std::ranges::ForwardRange<ref_seq_type>    &&
-                      alphabet_concept<value_type_t<remove_cvref_t<ref_seq_type>>>),
+                      Alphabet<value_type_t<remove_cvref_t<ref_seq_type>>>),
                       "The ref_seq object must be a std::ranges::ForwardRange "
-                      "over letters that model seqan3::alphabet_concept.");
+                      "over letters that model seqan3::Alphabet.");
 
         static_assert((std::ranges::ForwardRange<ref_id_type>     &&
-                      alphabet_concept<value_type_t<remove_cvref_t<ref_id_type>>>),
+                      Alphabet<value_type_t<remove_cvref_t<ref_id_type>>>),
                       "The ref_id object must be a std::ranges::ForwardRange "
-                      "over letters that model seqan3::alphabet_concept.");
+                      "over letters that model seqan3::Alphabet.");
 
         static_assert(std::Integral<remove_cvref_t<ref_offset_type>>, // -1 is given default to evaluate to 0
                       "The ref_offset object must be an std::Integral >= 0.");
@@ -231,22 +231,22 @@ public:
                       "The mapq object must be a std::UnsignedIntegral.");
 
         static_assert((std::ranges::ForwardRange<qual_type>       &&
-                       alphabet_concept<value_type_t<remove_cvref_t<qual_type>>>),
+                       Alphabet<value_type_t<remove_cvref_t<qual_type>>>),
                       "The qual object must be a std::ranges::ForwardRange "
-                      "over letters that model seqan3::alphabet_concept.");
+                      "over letters that model seqan3::Alphabet.");
 
         static_assert(tuple_like_concept<remove_cvref_t<mate_type>>,
                       "The mate object must be a std::tuple of size 3 with "
-                      "1) a std::ranges::ForwardRange with a value_type modelling seqan3::alphabet_concept, "
+                      "1) a std::ranges::ForwardRange with a value_type modelling seqan3::Alphabet, "
                       "2) an std::UnsignedIntegral, and"
                       "3) an std::UnsignedIntegral.");
 
         static_assert((std::ranges::ForwardRange<decltype(std::get<0>(mate))>                     &&
-                      alphabet_concept<value_type_t<remove_cvref_t<decltype(std::get<0>(mate))>>> &&
+                      Alphabet<value_type_t<remove_cvref_t<decltype(std::get<0>(mate))>>> &&
                       std::UnsignedIntegral<remove_cvref_t<decltype(std::get<1>(mate))>>          &&
                       std::UnsignedIntegral<remove_cvref_t<decltype(std::get<2>(mate))>>),
                       "The mate object must be a std::tuple of size 3 with "
-                      "1) a std::ranges::ForwardRange with a value_type modelling seqan3::alphabet_concept, "
+                      "1) a std::ranges::ForwardRange with a value_type modelling seqan3::Alphabet, "
                       "2) an std::UnsignedIntegral, and"
                       "3) an std::UnsignedIntegral.");
 

--- a/include/seqan3/io/sequence_file/input.hpp
+++ b/include/seqan3/io/sequence_file/input.hpp
@@ -62,21 +62,12 @@ namespace seqan3
  * \{
  */
 /*!\typedef using sequence_alphabet
-<<<<<<< HEAD
  * \memberof seqan3::SequenceFileInputTraits
- * \brief Alphabet of the characters for the seqan3::field::SEQ; must satisfy seqan3::alphabet_concept.
- */
-/*!\typedef using sequence_legal_alphabet
- * \memberof seqan3::SequenceFileInputTraits
- * \brief Intermediate alphabet for seqan3::field::SEQ; must satisfy seqan3::alphabet_concept and be convertible to
-=======
- * \memberof seqan3::sequence_file_input_traits_concept
  * \brief Alphabet of the characters for the seqan3::field::SEQ; must satisfy seqan3::Alphabet.
  */
 /*!\typedef using sequence_legal_alphabet
- * \memberof seqan3::sequence_file_input_traits_concept
+ * \memberof seqan3::SequenceFileInputTraits
  * \brief Intermediate alphabet for seqan3::field::SEQ; must satisfy seqan3::Alphabet and be convertible to
->>>>>>> [MISC] Rename alphabet_concept to Alphabet
  * `sequence_alphabet`.
  *
  * \details
@@ -97,13 +88,8 @@ namespace seqan3
  * `sequence_container`; must satisfy seqan3::sequence_container_concept.
  */
 /*!\typedef using id_alphabet
-<<<<<<< HEAD
  * \memberof seqan3::SequenceFileInputTraits
- * \brief Alphabet of the characters for the seqan3::field::ID; must satisfy seqan3::alphabet_concept.
-=======
- * \memberof seqan3::sequence_file_input_traits_concept
  * \brief Alphabet of the characters for the seqan3::field::ID; must satisfy seqan3::Alphabet.
->>>>>>> [MISC] Rename alphabet_concept to Alphabet
  */
 /*!\typedef using id_container
  * \memberof seqan3::SequenceFileInputTraits
@@ -134,15 +120,9 @@ namespace seqan3
 template <typename t>
 SEQAN3_CONCEPT SequenceFileInputTraits = requires (t v)
 {
-<<<<<<< HEAD
-    requires alphabet_concept<typename t::sequence_alphabet>;
-    requires alphabet_concept<typename t::sequence_legal_alphabet>;
-    requires ExplicitlyConvertibleTo<typename t::sequence_legal_alphabet, typename t::sequence_alphabet>;
-=======
     requires Alphabet<typename t::sequence_alphabet>;
     requires Alphabet<typename t::sequence_legal_alphabet>;
-    requires explicitly_convertible_to_concept<typename t::sequence_legal_alphabet, typename t::sequence_alphabet>;
->>>>>>> [MISC] Rename alphabet_concept to Alphabet
+    requires ExplicitlyConvertibleTo<typename t::sequence_legal_alphabet, typename t::sequence_alphabet>;
     requires sequence_container_concept<typename t::template sequence_container<typename t::sequence_alphabet>>;
     requires sequence_container_concept<typename t::template sequence_container_container<
         typename t::template sequence_container<typename t::sequence_alphabet>>>;

--- a/include/seqan3/io/sequence_file/input.hpp
+++ b/include/seqan3/io/sequence_file/input.hpp
@@ -62,12 +62,21 @@ namespace seqan3
  * \{
  */
 /*!\typedef using sequence_alphabet
+<<<<<<< HEAD
  * \memberof seqan3::SequenceFileInputTraits
  * \brief Alphabet of the characters for the seqan3::field::SEQ; must satisfy seqan3::alphabet_concept.
  */
 /*!\typedef using sequence_legal_alphabet
  * \memberof seqan3::SequenceFileInputTraits
  * \brief Intermediate alphabet for seqan3::field::SEQ; must satisfy seqan3::alphabet_concept and be convertible to
+=======
+ * \memberof seqan3::sequence_file_input_traits_concept
+ * \brief Alphabet of the characters for the seqan3::field::SEQ; must satisfy seqan3::Alphabet.
+ */
+/*!\typedef using sequence_legal_alphabet
+ * \memberof seqan3::sequence_file_input_traits_concept
+ * \brief Intermediate alphabet for seqan3::field::SEQ; must satisfy seqan3::Alphabet and be convertible to
+>>>>>>> [MISC] Rename alphabet_concept to Alphabet
  * `sequence_alphabet`.
  *
  * \details
@@ -88,8 +97,13 @@ namespace seqan3
  * `sequence_container`; must satisfy seqan3::sequence_container_concept.
  */
 /*!\typedef using id_alphabet
+<<<<<<< HEAD
  * \memberof seqan3::SequenceFileInputTraits
  * \brief Alphabet of the characters for the seqan3::field::ID; must satisfy seqan3::alphabet_concept.
+=======
+ * \memberof seqan3::sequence_file_input_traits_concept
+ * \brief Alphabet of the characters for the seqan3::field::ID; must satisfy seqan3::Alphabet.
+>>>>>>> [MISC] Rename alphabet_concept to Alphabet
  */
 /*!\typedef using id_container
  * \memberof seqan3::SequenceFileInputTraits
@@ -120,14 +134,20 @@ namespace seqan3
 template <typename t>
 SEQAN3_CONCEPT SequenceFileInputTraits = requires (t v)
 {
+<<<<<<< HEAD
     requires alphabet_concept<typename t::sequence_alphabet>;
     requires alphabet_concept<typename t::sequence_legal_alphabet>;
     requires ExplicitlyConvertibleTo<typename t::sequence_legal_alphabet, typename t::sequence_alphabet>;
+=======
+    requires Alphabet<typename t::sequence_alphabet>;
+    requires Alphabet<typename t::sequence_legal_alphabet>;
+    requires explicitly_convertible_to_concept<typename t::sequence_legal_alphabet, typename t::sequence_alphabet>;
+>>>>>>> [MISC] Rename alphabet_concept to Alphabet
     requires sequence_container_concept<typename t::template sequence_container<typename t::sequence_alphabet>>;
     requires sequence_container_concept<typename t::template sequence_container_container<
         typename t::template sequence_container<typename t::sequence_alphabet>>>;
 
-    requires alphabet_concept<typename t::id_alphabet>;
+    requires Alphabet<typename t::id_alphabet>;
     requires sequence_container_concept<typename t::template id_container<typename t::id_alphabet>>;
     requires sequence_container_concept<typename t::template id_container_container<typename t::template id_container<
         typename t::id_alphabet>>>;

--- a/include/seqan3/io/sequence_file/input_format_concept.hpp
+++ b/include/seqan3/io/sequence_file/input_format_concept.hpp
@@ -66,9 +66,9 @@ SEQAN3_CONCEPT SequenceFileInputFormat = requires (t                            
  * \memberof seqan3::SequenceFileInputFormat
  * \tparam stream_type      Input stream, must satisfy seqan3::IStream with `char`.
  * \tparam seq_type         Type of the seqan3::field::SEQ input; must satisfy std::ranges::OutputRange
- * over a seqan3::alphabet_concept.
+ * over a seqan3::Alphabet.
  * \tparam id_type          Type of the seqan3::field::ID input; must satisfy std::ranges::OutputRange
- * over a seqan3::alphabet_concept.
+ * over a seqan3::Alphabet.
  * \tparam qual_type        Type of the seqan3::field::QUAL input; must satisfy std::ranges::OutputRange
  * over a seqan3::QualityAlphabet.
  * \param[in,out] stream    The input stream to read from.

--- a/include/seqan3/io/sequence_file/output_format_concept.hpp
+++ b/include/seqan3/io/sequence_file/output_format_concept.hpp
@@ -66,9 +66,9 @@ SEQAN3_CONCEPT SequenceFileOutputFormat = requires (t                           
  * \memberof seqan3::SequenceFileOutputFormat
  * \tparam stream_type      Output stream, must satisfy seqan3::OStream with `char`.
  * \tparam seq_type         Type of the seqan3::field::SEQ output; must satisfy std::ranges::OutputRange
- * over a seqan3::alphabet_concept.
+ * over a seqan3::Alphabet.
  * \tparam id_type          Type of the seqan3::field::ID output; must satisfy std::ranges::OutputRange
- * over a seqan3::alphabet_concept.
+ * over a seqan3::Alphabet.
  * \tparam qual_type        Type of the seqan3::field::QUAL output; must satisfy std::ranges::OutputRange
  * over a seqan3::QualityAlphabet.
  * \param[in,out] stream    The output stream to write into.

--- a/include/seqan3/io/stream/debug_stream.hpp
+++ b/include/seqan3/io/stream/debug_stream.hpp
@@ -256,12 +256,12 @@ inline debug_stream_type debug_stream{};
  * \{
  */
 /*!\brief All alphabets can be printed to the seqan3::debug_stream by their char representation.
- * \tparam alphabet_t Type of the alphabet to be printed; must model seqan3::alphabet_concept.
+ * \tparam alphabet_t Type of the alphabet to be printed; must model seqan3::Alphabet.
  * \param s The seqan3::debug_stream.
  * \param l The alphabet letter.
  * \relates seqan3::debug_stream_type
  */
-template <alphabet_concept alphabet_t>
+template <Alphabet alphabet_t>
 inline debug_stream_type & operator<<(debug_stream_type & s, alphabet_t const l)
 //!\cond
     requires !OStream<std::ostream, alphabet_t>
@@ -298,7 +298,7 @@ namespace seqan3
 template <typename tuple_t>
 //!\cond
     requires !std::ranges::InputRange<tuple_t> &&
-             !alphabet_concept<remove_cvref_t<tuple_t>> && // exclude cartesian_composition
+             !Alphabet<remove_cvref_t<tuple_t>> && // exclude cartesian_composition
              tuple_like_concept<remove_cvref_t<tuple_t>>
 //!\endcond
 inline debug_stream_type & operator<<(debug_stream_type & s, tuple_t && t)
@@ -337,7 +337,7 @@ inline debug_stream_type & operator<<(debug_stream_type & s, variant_type && v)
  *
  * \details
  *
- * If the element type models seqan3::alphabet_concept (and is not an unsigned integer), the range is printed
+ * If the element type models seqan3::Alphabet (and is not an unsigned integer), the range is printed
  * just as if it were a string, i.e. <tt>std::vector<dna4>{'C'_dna4, 'G'_dna4, 'A'_dna4}</tt> is printed as "CGA".
  *
  * In all other cases the elements are comma separated and the range is enclosed in brackets, i.e.
@@ -353,7 +353,7 @@ inline debug_stream_type & operator<<(debug_stream_type & s, rng_t && r)
                std::Same<remove_cvref_t<reference_t<rng_t>>, char>)
 //!\endcond
 {
-    if constexpr (alphabet_concept<remove_cvref_t<reference_t<rng_t>>> &&
+    if constexpr (Alphabet<remove_cvref_t<reference_t<rng_t>>> &&
                   !detail::is_uint_adaptation_v<remove_cvref_t<reference_t<rng_t>>>)
     {
         for (auto && l : r)

--- a/include/seqan3/io/stream/parse_condition.hpp
+++ b/include/seqan3/io/stream/parse_condition.hpp
@@ -50,8 +50,8 @@ template <uint8_t interval_first, uint8_t interval_last>
 //!\endcond
 inline detail::is_in_interval_type<interval_first, interval_last> constexpr is_in_interval{};
 
-/*!\brief Checks whether a given letter is valid for the specified seqan3::alphabet_concept.
- * \tparam alphabet_t The alphabet to check; must model seqan3::alphabet_concept.
+/*!\brief Checks whether a given letter is valid for the specified seqan3::Alphabet.
+ * \tparam alphabet_t The alphabet to check; must model seqan3::Alphabet.
  * \ingroup stream
  *
  * \details
@@ -63,7 +63,7 @@ inline detail::is_in_interval_type<interval_first, interval_last> constexpr is_i
  * ### Example
  * \snippet test/snippet/io/stream/parse_condition.cpp is_in_alphabet
  */
-template <alphabet_concept alphabet_t>
+template <Alphabet alphabet_t>
 inline detail::is_in_alphabet_type<alphabet_t> constexpr is_in_alphabet{};
 
 /*!\brief Checks whether a given letter is the same as the template non-type argument.

--- a/include/seqan3/io/stream/parse_condition_detail.hpp
+++ b/include/seqan3/io/stream/parse_condition_detail.hpp
@@ -360,7 +360,7 @@ struct is_in_interval_type : public parse_condition_base<is_in_interval_type<int
  * \implements seqan3::detail::ParseCondition
  * \tparam alphabet_t The alphabet type. Must model seqan3::alphabet_concept.
  */
-template <detail::constexpr_alphabet_concept alphabet_t>
+template <detail::ConstexprAlphabet alphabet_t>
 struct is_in_alphabet_type : public parse_condition_base<is_in_alphabet_type<alphabet_t>>
 {
 public:

--- a/include/seqan3/io/stream/parse_condition_detail.hpp
+++ b/include/seqan3/io/stream/parse_condition_detail.hpp
@@ -357,13 +357,8 @@ struct is_in_interval_type : public parse_condition_base<is_in_interval_type<int
 
 /*!\brief Parse condition that checks if a given value is within the given alphabet `alphabet_t`.
  * \ingroup stream
-<<<<<<< HEAD
  * \implements seqan3::detail::ParseCondition
- * \tparam alphabet_t The alphabet type. Must model seqan3::alphabet_concept.
-=======
- * \implements seqan3::detail::parse_condition_concept
  * \tparam alphabet_t The alphabet type. Must model seqan3::Alphabet.
->>>>>>> [MISC] Rename alphabet_concept to Alphabet
  */
 template <detail::ConstexprAlphabet alphabet_t>
 struct is_in_alphabet_type : public parse_condition_base<is_in_alphabet_type<alphabet_t>>

--- a/include/seqan3/io/stream/parse_condition_detail.hpp
+++ b/include/seqan3/io/stream/parse_condition_detail.hpp
@@ -357,8 +357,13 @@ struct is_in_interval_type : public parse_condition_base<is_in_interval_type<int
 
 /*!\brief Parse condition that checks if a given value is within the given alphabet `alphabet_t`.
  * \ingroup stream
+<<<<<<< HEAD
  * \implements seqan3::detail::ParseCondition
  * \tparam alphabet_t The alphabet type. Must model seqan3::alphabet_concept.
+=======
+ * \implements seqan3::detail::parse_condition_concept
+ * \tparam alphabet_t The alphabet type. Must model seqan3::Alphabet.
+>>>>>>> [MISC] Rename alphabet_concept to Alphabet
  */
 template <detail::ConstexprAlphabet alphabet_t>
 struct is_in_alphabet_type : public parse_condition_base<is_in_alphabet_type<alphabet_t>>

--- a/include/seqan3/io/structure_file/detail.hpp
+++ b/include/seqan3/io/structure_file/detail.hpp
@@ -23,7 +23,7 @@ namespace seqan3::detail
  * \brief Transforms a structure annotation string into a base pair probability matrix.
  * \ingroup structure_file
  * \throws seqan3::parse_error if unpaired brackets are found in the structure annotation.
- * \tparam structure_alph_type The type of the structure alphabet; must satisfy seqan3::rna_structure_concept.
+ * \tparam structure_alph_type The type of the structure alphabet; must satisfy seqan3::RnaStructureAlphabet.
  * \tparam bpp_type            The type of the target matrix.
  * \tparam structure_type      The range type of the structure annotation.
  * \param[out] bpp             The target matrix that receives the base pair probabilities.
@@ -35,7 +35,7 @@ template <typename structure_alph_type, typename bpp_type, std::ranges::Range st
 inline
 void bpp_from_rna_structure(bpp_type & bpp, structure_type const & structure, double weight = 1.)
 {
-    if constexpr (!rna_structure_concept<structure_alph_type>)
+    if constexpr (!RnaStructureAlphabet<structure_alph_type>)
         throw parse_error{"Cannot create base pair probabilities from a structure that is not RNA structure."};
 
     bpp.clear();

--- a/include/seqan3/io/structure_file/input.hpp
+++ b/include/seqan3/io/structure_file/input.hpp
@@ -132,7 +132,7 @@ namespace seqan3
  */
 /*!\typedef using structure_alphabet
  * \memberof seqan3::structure_file_input_traits_concept
- * \brief Alphabet of the characters for the seqan3::field::STRUCTURE; must satisfy seqan3::rna_structure_concept.
+ * \brief Alphabet of the characters for the seqan3::field::STRUCTURE; must satisfy seqan3::RnaStructureAlphabet.
  */
 /*!\typedef using structure_container
  * \memberof seqan3::structure_file_input_traits_concept
@@ -249,7 +249,7 @@ SEQAN3_CONCEPT structure_file_input_traits_concept = requires(t v)
 
     // structure
     requires std::is_same_v<typename t::structure_alphabet, dssp9> // TODO(joergi-w) add aa_structure_concept
-          || rna_structure_concept<typename t::structure_alphabet>;
+          || RnaStructureAlphabet<typename t::structure_alphabet>;
     requires sequence_container_concept<typename t::template structure_container<typename t::structure_alphabet>>;
 //    requires sequence_container_concept
 //        <typename t::template structure_container_container

--- a/include/seqan3/io/structure_file/input.hpp
+++ b/include/seqan3/io/structure_file/input.hpp
@@ -201,15 +201,9 @@ SEQAN3_CONCEPT structure_file_input_traits_concept = requires(t v)
 {
     // TODO(joergi-w) The expensive concept checks are currently omitted. Check again when compiler has improved.
     // sequence
-<<<<<<< HEAD
-    requires alphabet_concept<typename t::seq_alphabet>;
-    requires alphabet_concept<typename t::seq_legal_alphabet>;
-    requires ExplicitlyConvertibleTo<typename t::seq_legal_alphabet, typename t::seq_alphabet>;
-=======
     requires Alphabet<typename t::seq_alphabet>;
     requires Alphabet<typename t::seq_legal_alphabet>;
-    requires explicitly_convertible_to_concept<typename t::seq_legal_alphabet, typename t::seq_alphabet>;
->>>>>>> [MISC] Rename alphabet_concept to Alphabet
+    requires ExplicitlyConvertibleTo<typename t::seq_legal_alphabet, typename t::seq_alphabet>;
     requires sequence_container_concept<typename t::template seq_container<typename t::seq_alphabet>>;
 //    requires sequence_container_concept
 //        <typename t::template seq_container_container

--- a/include/seqan3/io/structure_file/input.hpp
+++ b/include/seqan3/io/structure_file/input.hpp
@@ -67,11 +67,11 @@ namespace seqan3
  */
 /*!\typedef using seq_alphabet
  * \memberof seqan3::structure_file_input_traits_concept
- * \brief Alphabet of the characters for the seqan3::field::SEQ; must satisfy seqan3::alphabet_concept.
+ * \brief Alphabet of the characters for the seqan3::field::SEQ; must satisfy seqan3::Alphabet.
  */
 /*!\typedef using seq_legal_alphabet
  * \memberof seqan3::structure_file_input_traits_concept
- * \brief Intermediate alphabet for seqan3::field::SEQ; must satisfy seqan3::alphabet_concept and be convertible to
+ * \brief Intermediate alphabet for seqan3::field::SEQ; must satisfy seqan3::Alphabet and be convertible to
  * `seq_alphabet`.
  *
  * \details
@@ -93,7 +93,7 @@ namespace seqan3
  */
 /*!\typedef using id_alphabet
  * \memberof seqan3::structure_file_input_traits_concept
- * \brief Alphabet of the characters for the seqan3::field::ID; must satisfy seqan3::alphabet_concept.
+ * \brief Alphabet of the characters for the seqan3::field::ID; must satisfy seqan3::Alphabet.
  */
 /*!\typedef using id_container
  * \memberof seqan3::structure_file_input_traits_concept
@@ -173,7 +173,7 @@ namespace seqan3
  */
 /*!\typedef using comment_alphabet
  * \memberof seqan3::structure_file_input_traits_concept
- * \brief Alphabet of the characters for the seqan3::field::COMMENT; must satisfy seqan3::alphabet_concept.
+ * \brief Alphabet of the characters for the seqan3::field::COMMENT; must satisfy seqan3::Alphabet.
  */
 /*!\typedef using comment_container
  * \memberof seqan3::structure_file_input_traits_concept
@@ -201,9 +201,15 @@ SEQAN3_CONCEPT structure_file_input_traits_concept = requires(t v)
 {
     // TODO(joergi-w) The expensive concept checks are currently omitted. Check again when compiler has improved.
     // sequence
+<<<<<<< HEAD
     requires alphabet_concept<typename t::seq_alphabet>;
     requires alphabet_concept<typename t::seq_legal_alphabet>;
     requires ExplicitlyConvertibleTo<typename t::seq_legal_alphabet, typename t::seq_alphabet>;
+=======
+    requires Alphabet<typename t::seq_alphabet>;
+    requires Alphabet<typename t::seq_legal_alphabet>;
+    requires explicitly_convertible_to_concept<typename t::seq_legal_alphabet, typename t::seq_alphabet>;
+>>>>>>> [MISC] Rename alphabet_concept to Alphabet
     requires sequence_container_concept<typename t::template seq_container<typename t::seq_alphabet>>;
 //    requires sequence_container_concept
 //        <typename t::template seq_container_container
@@ -211,7 +217,7 @@ SEQAN3_CONCEPT structure_file_input_traits_concept = requires(t v)
 //                <typename t::seq_alphabet>>>;
 
     // id
-    requires alphabet_concept<typename t::id_alphabet>;
+    requires Alphabet<typename t::id_alphabet>;
     requires sequence_container_concept<typename t::template id_container<typename t::id_alphabet>>;
 //    requires sequence_container_concept
 //        <typename t::template id_container_container
@@ -279,7 +285,7 @@ SEQAN3_CONCEPT structure_file_input_traits_concept = requires(t v)
 //                <typename t::react_type>>>;
 
     // comment
-    requires alphabet_concept<typename t::comment_alphabet>;
+    requires Alphabet<typename t::comment_alphabet>;
     requires sequence_container_concept<typename t::template comment_container<typename t::comment_alphabet>>;
 //    requires sequence_container_concept
 //        <typename t::template comment_container_container

--- a/include/seqan3/io/structure_file/input_format_concept.hpp
+++ b/include/seqan3/io/structure_file/input_format_concept.hpp
@@ -95,7 +95,7 @@ SEQAN3_CONCEPT StructureFileInputFormat = requires(t & v,
  * \tparam bpp_type         Type of the seqan3::field::BPP input; must satisfy std::ranges::OutputRange
  * over a set of pair of types satisfying std::is_floating_point and std::numeric_limits::is_integer, respectively.
  * \tparam structure_type   Type of the seqan3::field::STRUCTURE input; must satisfy std::ranges::OutputRange
- * over a seqan3::rna_structure_concept.
+ * over a seqan3::RnaStructureAlphabet.
  * \tparam energy_type      Type of the seqan3::field::ENERGY input; must satisfy std::is_floating_point.
  * \tparam react_type       Type of the seqan3::field::REACT and seqan3::field::REACT_ERR input;
  * must satisfy std::is_floating_point.

--- a/include/seqan3/io/structure_file/input_format_concept.hpp
+++ b/include/seqan3/io/structure_file/input_format_concept.hpp
@@ -89,9 +89,9 @@ SEQAN3_CONCEPT StructureFileInputFormat = requires(t & v,
  * \memberof seqan3::StructureFileInputFormat
  * \tparam stream_type      Input stream, must satisfy seqan3::istream_concept with `char`.
  * \tparam seq_type         Type of the seqan3::field::SEQ input; must satisfy std::ranges::OutputRange
- * over a seqan3::alphabet_concept.
+ * over a seqan3::Alphabet.
  * \tparam id_type          Type of the seqan3::field::ID input; must satisfy std::ranges::OutputRange
- * over a seqan3::alphabet_concept.
+ * over a seqan3::Alphabet.
  * \tparam bpp_type         Type of the seqan3::field::BPP input; must satisfy std::ranges::OutputRange
  * over a set of pair of types satisfying std::is_floating_point and std::numeric_limits::is_integer, respectively.
  * \tparam structure_type   Type of the seqan3::field::STRUCTURE input; must satisfy std::ranges::OutputRange
@@ -100,7 +100,7 @@ SEQAN3_CONCEPT StructureFileInputFormat = requires(t & v,
  * \tparam react_type       Type of the seqan3::field::REACT and seqan3::field::REACT_ERR input;
  * must satisfy std::is_floating_point.
  * \tparam comment_type     Type of the seqan3::field::COMMENT input; must satisfy std::ranges::OutputRange
- * over a seqan3::alphabet_concept.
+ * over a seqan3::Alphabet.
  * \tparam offset_type      Type of the seqan3::field::OFFSET input; must satisfy std::numeric_limits::is_integer.
  * \param[in,out] stream    The input stream to read from.
  * \param[in]     options   File specific options passed to the format.

--- a/include/seqan3/io/structure_file/output_format_concept.hpp
+++ b/include/seqan3/io/structure_file/output_format_concept.hpp
@@ -92,7 +92,7 @@ SEQAN3_CONCEPT StructureFileOutputFormat = requires(t & v,
  * \tparam bpp_type         Type of the seqan3::field::BPP output; must satisfy std::ranges::OutputRange
  * over a set of pair of types satisfying std::is_floating_point and std::numeric_limits::is_integer, respectively.
  * \tparam structure_type   Type of the seqan3::field::STRUCTURE output; must satisfy std::ranges::OutputRange
- * over a seqan3::rna_structure_concept.
+ * over a seqan3::RnaStructureAlphabet.
  * \tparam energy_type      Type of the seqan3::field::ENERGY output; must satisfy std::is_floating_point.
  * \tparam react_type       Type of the seqan3::field::REACT and seqan3::field::REACT_ERR output;
  * must satisfy std::is_floating_point.

--- a/include/seqan3/io/structure_file/output_format_concept.hpp
+++ b/include/seqan3/io/structure_file/output_format_concept.hpp
@@ -86,9 +86,9 @@ SEQAN3_CONCEPT StructureFileOutputFormat = requires(t & v,
  * \memberof seqan3::StructureFileOutputFormat
  * \tparam stream_type      Output stream, must satisfy seqan3::OStream with `char`.
  * \tparam seq_type         Type of the seqan3::field::SEQ output; must satisfy std::ranges::OutputRange
- * over a seqan3::alphabet_concept.
+ * over a seqan3::Alphabet.
  * \tparam id_type          Type of the seqan3::field::ID output; must satisfy std::ranges::OutputRange
- * over a seqan3::alphabet_concept.
+ * over a seqan3::Alphabet.
  * \tparam bpp_type         Type of the seqan3::field::BPP output; must satisfy std::ranges::OutputRange
  * over a set of pair of types satisfying std::is_floating_point and std::numeric_limits::is_integer, respectively.
  * \tparam structure_type   Type of the seqan3::field::STRUCTURE output; must satisfy std::ranges::OutputRange
@@ -97,7 +97,7 @@ SEQAN3_CONCEPT StructureFileOutputFormat = requires(t & v,
  * \tparam react_type       Type of the seqan3::field::REACT and seqan3::field::REACT_ERR output;
  * must satisfy std::is_floating_point.
  * \tparam comment_type     Type of the seqan3::field::COMMENT output; must satisfy std::ranges::OutputRange
- * over a seqan3::alphabet_concept.
+ * over a seqan3::Alphabet.
  * \tparam offset_type      Type of the seqan3::field::OFFSET output; must satisfy std::numeric_limits::is_integer.
  * \param[in,out] stream    The output stream to write into.
  * \param[in]     options   File specific options passed to the format.

--- a/include/seqan3/range/container/bitcompressed_vector.hpp
+++ b/include/seqan3/range/container/bitcompressed_vector.hpp
@@ -37,7 +37,7 @@ namespace seqan3
 class debug_stream_type;
 
 /*!\brief A space-optimised version of std::vector that compresses multiple letters into a single byte.
- * \tparam alphabet_type The value type of the container, must satisfy seqan3::alphabet_concept and not be `&`.
+ * \tparam alphabet_type The value type of the container, must satisfy seqan3::Alphabet and not be `&`.
  * \implements seqan3::reservable_container_concept
  * \implements seqan3::Cerealisable
  * \ingroup container
@@ -64,7 +64,7 @@ class debug_stream_type;
  * threads at the same time **is not safe** and will lead to corruption if both values are stored in the same
  * 64bit-block, i.e. if the distance between `i` and `j` is smaller than 64 / alphabet_size.
  */
-template <alphabet_concept alphabet_type>
+template <Alphabet alphabet_type>
 //!\cond
     requires std::is_same_v<alphabet_type, std::remove_reference_t<alphabet_type>>
 //!\endcond
@@ -133,7 +133,7 @@ private:
         //!\}
     };
 
-    static_assert(alphabet_concept<reference_proxy_type>);
+    static_assert(Alphabet<reference_proxy_type>);
     //!\cond
     //NOTE(h-2): it is entirely unclear to me why we need this
     template <typename t>

--- a/include/seqan3/range/view/char_to.hpp
+++ b/include/seqan3/range/view/char_to.hpp
@@ -27,7 +27,7 @@ namespace seqan3::view
 /*!\brief               A view over an alphabet, given a range of characters.
  * \tparam urng_t       The type of the range being processed. See below for requirements. [template parameter is
  *                      omitted in pipe notation]
- * \tparam alphabet_t   The alphabet to convert to; must satisfy seqan3::alphabet_concept.
+ * \tparam alphabet_t   The alphabet to convert to; must satisfy seqan3::Alphabet.
  * \param[in] urange    The range being processed. [parameter is omitted in pipe notation]
  * \returns             A range of converted elements. See below for the properties of the returned range.
  * \ingroup view
@@ -61,12 +61,12 @@ namespace seqan3::view
  * \snippet test/snippet/range/view/rank_char.cpp char_to
  * \hideinitializer
  */
-template <alphabet_concept alphabet_type>
+template <Alphabet alphabet_type>
 inline auto const char_to = deep{view::transform([] (auto && in)
 {
     static_assert(std::is_same_v<remove_cvref_t<decltype(in)>, remove_cvref_t<underlying_char_t<alphabet_type>>>,
                     "The innermost value type must be the underlying char type of alphabet_type.");
-    // call element-wise assign_char from the alphabet_concept
+    // call element-wise assign_char from the Alphabet
     return assign_char(alphabet_type{}, in);
 })};
 

--- a/include/seqan3/range/view/kmer_hash.hpp
+++ b/include/seqan3/range/view/kmer_hash.hpp
@@ -38,13 +38,13 @@ private:
 
     /*!\brief            Call the view's constructor with the underlying view as argument.
      * \param[in] urange The input range to process. Must model std::ranges::ViewableRange and the reference type of the
-     *                   range of the range must model seqan3::semi_alphabet_concept.
+     *                   range of the range must model seqan3::Semialphabet.
      * \param[in] k      The k-mer size to construct hashes for.
      * \returns          A range of converted elements.
      */
     template <std::ranges::ViewableRange urng_t>
     //!\cond
-        requires semi_alphabet_concept<reference_t<urng_t>>
+        requires Semialphabet<reference_t<urng_t>>
     //!\endcond
     static auto impl(urng_t && urange, size_t const k)
     {
@@ -94,7 +94,7 @@ namespace seqan3::view
      * | std::ranges::OutputRange        |                                       | *lost*                                             |
      * | seqan3::const_iterable_concept  |                                       | *preserved*                                        |
      * |                                 |                                       |                                                    |
-     * | seqan3::reference_t             | seqan3::semi_alphabet_concept         | std::size_t                                        |
+     * | seqan3::reference_t             | seqan3::Semialphabet                  | std::size_t                                        |
      *
      * See the \link view view submodule documentation \endlink for detailed descriptions of the view properties.
      *

--- a/include/seqan3/range/view/rank_to.hpp
+++ b/include/seqan3/range/view/rank_to.hpp
@@ -26,7 +26,7 @@ namespace seqan3::view
 /*!\brief                A view over an alphabet, given a range of ranks.
  * \tparam urng_t       The type of the range being processed. See below for requirements. [template parameter is
  *                      omitted in pipe notation]
- * \tparam alphabet_t   The alphabet to convert to; must satisfy seqan3::alphabet_concept.
+ * \tparam alphabet_t   The alphabet to convert to; must satisfy seqan3::Alphabet.
  * \param[in] urange    The range being processed. [parameter is omitted in pipe notation]
  * \returns             A range of converted elements. See below for the properties of the returned range.
  * \ingroup view
@@ -61,7 +61,7 @@ namespace seqan3::view
  */
 template <typename alphabet_type>
 //!\cond
-    requires alphabet_concept<alphabet_type>
+    requires Alphabet<alphabet_type>
 //!\endcond
 inline auto const rank_to = deep{view::transform(
 [] (underlying_rank_t<alphabet_type> const in) -> alphabet_type

--- a/include/seqan3/range/view/to_char.hpp
+++ b/include/seqan3/range/view/to_char.hpp
@@ -50,7 +50,7 @@ namespace seqan3::view
  * | std::ranges::OutputRange        |                                       | *lost*                                             |
  * | seqan3::const_iterable_concept  |                                       | *preserved*                                        |
  * |                                 |                                       |                                                    |
- * | seqan3::reference_t             | seqan3::alphabet_concept              | seqan3::underlying_char_t<seqan3::value_type_t<urng_t>> |
+ * | seqan3::reference_t             | seqan3::Alphabet                      | seqan3::underlying_char_t<seqan3::value_type_t<urng_t>> |
  *
  * See the \link view view submodule documentation \endlink for detailed descriptions of the view properties.
  *
@@ -60,7 +60,7 @@ namespace seqan3::view
  */
 inline auto const to_char = deep{view::transform([] (auto const in) noexcept
 {
-    static_assert(alphabet_concept<remove_cvref_t<decltype(in)>>, "The value type of seqan3::view::to_char must model the seqan3::alphabet_concept.");
+    static_assert(Alphabet<remove_cvref_t<decltype(in)>>, "The value type of seqan3::view::to_char must model the seqan3::Alphabet.");
     return seqan3::to_char(in);
 })};
 

--- a/include/seqan3/range/view/to_rank.hpp
+++ b/include/seqan3/range/view/to_rank.hpp
@@ -50,7 +50,7 @@ namespace seqan3::view
  * | std::ranges::OutputRange        |                                       | *lost*                                             |
  * | seqan3::const_iterable_concept  |                                       | *preserved*                                        |
  * |                                 |                                       |                                                    |
- * | seqan3::reference_t             | seqan3::alphabet_concept              | seqan3::underlying_rank_t<seqan3::value_type_t<urng_t>> |
+ * | seqan3::reference_t             | seqan3::Alphabet                      | seqan3::underlying_rank_t<seqan3::value_type_t<urng_t>> |
  *
  * See the \link view view submodule documentation \endlink for detailed descriptions of the view properties.
  *
@@ -62,7 +62,7 @@ namespace seqan3::view
  */
 inline auto const to_rank = deep{view::transform([] (auto const in) noexcept
 {
-    static_assert(alphabet_concept<remove_cvref_t<decltype(in)>>, "The value type of seqan3::view::to_rank must model the seqan3::alphabet_concept.");
+    static_assert(Alphabet<remove_cvref_t<decltype(in)>>, "The value type of seqan3::view::to_rank must model the seqan3::Alphabet.");
     return seqan3::to_rank(in);
 })};
 

--- a/include/seqan3/search/fm_index/all.hpp
+++ b/include/seqan3/search/fm_index/all.hpp
@@ -23,7 +23,7 @@
  * library). You are able to specify the underlying implementation of the SDSL to adjust it to your needs as well as
  * choose one of the preconfigured indices that are suitable for common applications in sequence analysis.
  *
- * For technical reasons you can currently only build indices over a seqan3::alphabet_concept if its
+ * For technical reasons you can currently only build indices over a seqan3::Alphabet if its
  * seqan3::alphabet_size is smaller or equal 256.
  *
  * You can choose between unidirectional and bidirectional FM indices (which can be thought of suffix trees

--- a/include/seqan3/search/fm_index/bi_fm_index.hpp
+++ b/include/seqan3/search/fm_index/bi_fm_index.hpp
@@ -55,7 +55,7 @@ struct bi_fm_index_default_traits
  */
 template <std::ranges::RandomAccessRange text_t, BiFmIndexTraits index_traits_t = bi_fm_index_default_traits>
 //!\cond
-    requires alphabet_concept<innermost_value_type_t<text_t>> &&
+    requires Alphabet<innermost_value_type_t<text_t>> &&
              std::Same<underlying_rank_t<innermost_value_type_t<text_t>>, uint8_t>
 //!\endcond
 class bi_fm_index

--- a/include/seqan3/search/fm_index/bi_fm_index_cursor.hpp
+++ b/include/seqan3/search/fm_index/bi_fm_index_cursor.hpp
@@ -410,7 +410,7 @@ public:
      *
      * No-throw guarantee.
      */
-    template <alphabet_concept char_t>
+    template <Alphabet char_t>
     //!\cond
         requires ImplicitlyConvertibleTo<char_t, typename index_t::char_type>
     //!\endcond
@@ -452,7 +452,7 @@ public:
      *
      * No-throw guarantee.
      */
-    template <alphabet_concept char_t>
+    template <Alphabet char_t>
     //!\cond
        requires ImplicitlyConvertibleTo<char_t, typename index_t::char_type>
     //!\endcond

--- a/include/seqan3/search/fm_index/fm_index.hpp
+++ b/include/seqan3/search/fm_index/fm_index.hpp
@@ -125,7 +125,7 @@ struct fm_index_default_traits
  */
 template <std::ranges::RandomAccessRange text_t, FmIndexTraits fm_index_traits = fm_index_default_traits>
 //!\cond
-    requires alphabet_concept<innermost_value_type_t<text_t>> &&
+    requires Alphabet<innermost_value_type_t<text_t>> &&
              alphabet_size_v<innermost_value_type_t<text_t>> <= 256
 //!\endcond
 class fm_index

--- a/include/seqan3/search/fm_index/fm_index_cursor.hpp
+++ b/include/seqan3/search/fm_index/fm_index_cursor.hpp
@@ -270,7 +270,7 @@ public:
      *
      * No-throw guarantee.
      */
-    template <alphabet_concept char_t>
+    template <Alphabet char_t>
     //!\cond
         requires ImplicitlyConvertibleTo<char_t, typename index_t::char_type>
     //!\endcond

--- a/test/performance/alphabet/alphabet_benchmark.cpp
+++ b/test/performance/alphabet/alphabet_benchmark.cpp
@@ -14,7 +14,7 @@
 
 using namespace seqan3;
 
-template <alphabet_concept alphabet_t>
+template <Alphabet alphabet_t>
 static void assign_char(benchmark::State& state)
 {
     using char_t = underlying_char_t<alphabet_t>;
@@ -32,7 +32,7 @@ static void assign_char(benchmark::State& state)
     state.counters["loop_iterations"] = std::numeric_limits<char_t>::max() - std::numeric_limits<char_t>::min();
 }
 
-template <alphabet_concept alphabet_t>
+template <Alphabet alphabet_t>
 static void to_char(benchmark::State& state)
 {
     using char_t = underlying_char_t<alphabet_t>;

--- a/test/performance/alphabet/alphabet_benchmark.cpp
+++ b/test/performance/alphabet/alphabet_benchmark.cpp
@@ -50,7 +50,7 @@ static void to_char(benchmark::State& state)
     state.counters["loop_iterations"] = std::numeric_limits<char_t>::max() - std::numeric_limits<char_t>::min();
 }
 
-template <semi_alphabet_concept alphabet_t>
+template <Semialphabet alphabet_t>
 static void assign_rank(benchmark::State& state)
 {
     using rank_t_ = underlying_rank_t<alphabet_t>;
@@ -69,7 +69,7 @@ static void assign_rank(benchmark::State& state)
     state.counters["loop_iterations"] = std::numeric_limits<rank_t>::max() - std::numeric_limits<rank_t>::min();
 }
 
-template <semi_alphabet_concept alphabet_t>
+template <Semialphabet alphabet_t>
 static void to_rank(benchmark::State& state)
 {
     using rank_t_ = underlying_rank_t<alphabet_t>;

--- a/test/performance/range/container_benchmark.cpp
+++ b/test/performance/range/container_benchmark.cpp
@@ -37,7 +37,7 @@ static void push_back(benchmark::State& state)
     }
 
     state.counters["sizeof"] = sizeof(alphabet_t);
-    if constexpr (alphabet_concept<alphabet_t>)
+    if constexpr (Alphabet<alphabet_t>)
         state.counters["alph_size"] = seqan3::alphabet_size_v<alphabet_t>;
 #if 0
     state.counters["preallocated_mem"] = reserve;
@@ -134,7 +134,7 @@ static void sequential_read(benchmark::State& state)
     [[maybe_unused]] volatile alphabet_t target2 = target.back();
 
     state.counters["sizeof"] = sizeof(alphabet_t);
-    if constexpr (alphabet_concept<alphabet_t>)
+    if constexpr (Alphabet<alphabet_t>)
         state.counters["alph_size"] = seqan3::alphabet_size_v<alphabet_t>;
     state.counters["const"] = const_;
 }
@@ -223,7 +223,7 @@ static void sequential_write(benchmark::State& state)
     [[maybe_unused]] volatile alphabet_t target2 = target.back();
 
     state.counters["sizeof"] = sizeof(alphabet_t);
-    if constexpr (alphabet_concept<alphabet_t>)
+    if constexpr (Alphabet<alphabet_t>)
         state.counters["alph_size"] = seqan3::alphabet_size_v<alphabet_t>;
 }
 

--- a/test/snippet/alphabet/detail/alphabet_base.cpp
+++ b/test/snippet/alphabet/detail/alphabet_base.cpp
@@ -30,5 +30,5 @@ private:
     friend alphabet_base<ab, 2>;
 };
 
-static_assert(alphabet_concept<ab>);
+static_assert(Alphabet<ab>);
 //! [example]

--- a/test/unit/alphabet/alphabet_constexpr_test_template.hpp
+++ b/test/unit/alphabet/alphabet_constexpr_test_template.hpp
@@ -32,9 +32,9 @@ TYPED_TEST_CASE_P(alphabet_constexpr);
 
 TYPED_TEST_P(alphabet_constexpr, concept_check)
 {
-    EXPECT_TRUE(detail::constexpr_alphabet_concept<TypeParam   >);
-    EXPECT_TRUE(detail::constexpr_alphabet_concept<TypeParam & >);
-    EXPECT_TRUE(detail::constexpr_alphabet_concept<TypeParam &&>);
+    EXPECT_TRUE(detail::ConstexprAlphabet<TypeParam   >);
+    EXPECT_TRUE(detail::ConstexprAlphabet<TypeParam & >);
+    EXPECT_TRUE(detail::ConstexprAlphabet<TypeParam &&>);
 }
 
 TYPED_TEST_P(alphabet_constexpr, default_value_constructor)

--- a/test/unit/alphabet/alphabet_test_template.hpp
+++ b/test/unit/alphabet/alphabet_test_template.hpp
@@ -210,9 +210,9 @@ TYPED_TEST_P(alphabet, comparison_operators)
 
 TYPED_TEST_P(alphabet, concept_check)
 {
-    EXPECT_TRUE(alphabet_concept<TypeParam>);
-    EXPECT_TRUE(alphabet_concept<TypeParam &>);
-    EXPECT_TRUE(alphabet_concept<TypeParam &&>);
+    EXPECT_TRUE(Alphabet<TypeParam>);
+    EXPECT_TRUE(Alphabet<TypeParam &>);
+    EXPECT_TRUE(Alphabet<TypeParam &&>);
 }
 
 TYPED_TEST_P(alphabet, debug_streaming)

--- a/test/unit/alphabet/composition/union_composition_test.cpp
+++ b/test/unit/alphabet/composition/union_composition_test.cpp
@@ -236,7 +236,7 @@ TEST(union_composition_test, compare_to_component_alphabet_subtype)
 
 TEST(union_composition_test, fulfills_concepts)
 {
-    EXPECT_TRUE((alphabet_concept<union_composition<dna5, gap>>));
+    EXPECT_TRUE((Alphabet<union_composition<dna5, gap>>));
 }
 
 TEST(union_composition_test, rank_type)

--- a/test/unit/alphabet/gap/gap_test.cpp
+++ b/test/unit/alphabet/gap/gap_test.cpp
@@ -22,7 +22,7 @@ INSTANTIATE_TYPED_TEST_CASE_P(gap, alphabet_constexpr, gap);
 
 TEST(gap_test, fulfills_concept)
 {
-    EXPECT_TRUE(alphabet_concept<gap>);
+    EXPECT_TRUE(Alphabet<gap>);
 }
 
 TEST(gap_test, default_initialization)

--- a/test/unit/alphabet/mask/mask_test.cpp
+++ b/test/unit/alphabet/mask/mask_test.cpp
@@ -15,7 +15,7 @@ using namespace seqan3;
 TEST(assignment, concept_check)
 {
     EXPECT_TRUE(semi_alphabet_concept<mask>);
-    EXPECT_TRUE(detail::constexpr_semi_alphabet_concept<mask>);
+    EXPECT_TRUE(detail::ConstexprSemialphabet<mask>);
 }
 
 TEST(assignment, assign_rank)

--- a/test/unit/alphabet/mask/mask_test.cpp
+++ b/test/unit/alphabet/mask/mask_test.cpp
@@ -14,7 +14,7 @@ using namespace seqan3;
 
 TEST(assignment, concept_check)
 {
-    EXPECT_TRUE(semi_alphabet_concept<mask>);
+    EXPECT_TRUE(Semialphabet<mask>);
     EXPECT_TRUE(detail::ConstexprSemialphabet<mask>);
 }
 

--- a/test/unit/alphabet/structure/dot_bracket3_test.cpp
+++ b/test/unit/alphabet/structure/dot_bracket3_test.cpp
@@ -49,7 +49,7 @@ TEST(dot_bracket3, to_char)
 // concepts
 TEST(dot_bracket3, concept_check)
 {
-    EXPECT_TRUE(rna_structure_concept<dot_bracket3>);
+    EXPECT_TRUE(RnaStructureAlphabet<dot_bracket3>);
     EXPECT_NE(max_pseudoknot_depth_v<dot_bracket3>, 0);
 }
 

--- a/test/unit/alphabet/structure/wuss_test.cpp
+++ b/test/unit/alphabet/structure/wuss_test.cpp
@@ -66,11 +66,11 @@ TEST(wuss51, to_char)
 // concepts
 TEST(wuss51, concept_check)
 {
-    EXPECT_TRUE(rna_structure_concept<wuss51>);
+    EXPECT_TRUE(RnaStructureAlphabet<wuss51>);
     EXPECT_NE(max_pseudoknot_depth_v<wuss51>, 0);
 
-    EXPECT_TRUE(rna_structure_concept<wuss<>>);  // same as wuss51
-    EXPECT_TRUE(rna_structure_concept<wuss<67>>);
+    EXPECT_TRUE(RnaStructureAlphabet<wuss<>>);  // same as wuss51
+    EXPECT_TRUE(RnaStructureAlphabet<wuss<67>>);
 }
 
 TEST(wuss51, literals)


### PR DESCRIPTION
#520

All renamings which were necessary for file alphabet/pre_concept.hpp

Renames:
semi_constexpr_alphabet_concept -> SemiConstexprAlphabet
constexpr_semi_alphabet_concept -> ConstexprSemialphabet
constexpr_alphabet_concept -> ConstexprAlphabet
semi_alphabet_concept -> Semialphabet
alphabet_concept -> Alphabet
rna_structure_concept -> RnaStructureAlphabet
char_adaption_concept -> CharAdaptationAlphabet
uint_adaption_concept -> UintAdaptionAlphabet