### PR TITLE
add compression and decompression support to sequence_file_*

### DIFF
--- a/include/seqan3/io/all.hpp
+++ b/include/seqan3/io/all.hpp
@@ -34,16 +34,49 @@
 
 /*!\file
  * \brief Meta-header for all IO related functionality.
+ * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  * \author René Rahn <rene.rahn AT fu-berlin.de>
  */
 
 /*!\defgroup io IO
  * \brief The IO module contains concepts, data structures and functions related to reading and writing formatted files,
  * streams, and serialisation.
+ *
+ *
+ * # Operations on characters and strings {#char_ops}
+ *
  * \todo write me!
- */
-
-/*!\page serialisation Serialisation in SeqAn3
+ *
+ *
+ * # Formatted files {#io_files}
+ *
+ * \todo write me!
+ *
+ *
+ * # Compression and decompression {#io_compression}
+ *
+ * SeqAn supports wrapping iostreams in streams that transparently compress /
+ * decompress the data sent to / read from the stream.
+ * The following compression formats are supported:
+ *
+ * | **Format** | **Extension**   | **Dependency** | **Description**                                   |
+ * |:-----------|:----------------|:----------------|:--------------------------------------------------|
+ * | GZip       | `.gz`¹          | [zlib](https://zlib.net/)        | GNU-Zip, most common format on UNIX               |
+ * | BGZF       | `.gz`, `.bgzf`² | [zlib](https://zlib.net/)        | [Blocked GZip](http://samtools.github.io/hts-specs/SAMv1.pdf), compatible extension to GZip, features parallelisation|
+ * | BZip2      | `.bz2`          | [libbz2](https://www.bzip.org)   | Stronger compression than GZip, slower to compress |
+ *
+ * <small>¹ SeqAn always assumes GZip and does not handle pure `.Z`.<br>
+ * ²Some file formats like `.bam` or `.bcf` are implicitly BGZF-compressed without showing this in the
+ * extension.</small>
+ *
+ * Whether or not a format is supported depends on whether the respective dependency was available and
+ * linked against your program (if you use CMake, this should happen automatically).
+ *
+ * Formatted files employ compression/decompression streams transparently, i.e. if the given file-extension or
+ * "magic-header" of a file suggest this, the respective stream is automatically (de-)compressed.
+ *
+ * # Serialisation {#serialisation}
+ *
  * \todo write me!
  */
 

--- a/include/seqan3/io/detail/misc_input.hpp
+++ b/include/seqan3/io/detail/misc_input.hpp
@@ -1,0 +1,137 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2018, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2018, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides various utility functions required only for input.
+ * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <iostream>
+#include <string>
+#include <tuple>
+
+#include <seqan3/core/concept/core_language.hpp>
+#ifdef SEQAN3_HAS_BZIP2
+    #include <seqan3/contrib/stream/bz2_istream.hpp>
+#endif
+#ifdef SEQAN3_HAS_ZLIB
+    #include <seqan3/contrib/stream/gz_istream.hpp>
+#endif
+#include <seqan3/std/concepts>
+#include <seqan3/std/ranges>
+
+namespace seqan3::detail
+{
+
+/*!\brief Check whether the query range is a prefix of the reference range.
+ * \param[in] reference The range that is expected to be the longer one.
+ * \param[in] query     The range that is expected to be the shorter one.
+ */
+template <std::ranges::ForwardRange ref_t, std::ranges::ForwardRange query_t>
+inline bool starts_with(ref_t && reference, query_t && query)
+//!\cond
+    requires std::EqualityComparableWith<reference_t<ref_t>, reference_t<query_t>>
+//!\endcond
+{
+    auto rit  = begin(reference);
+    auto rend = end(reference);
+
+    auto qit  = begin(query);
+    auto qend = end(query);
+
+    while (true)
+    {
+        if (qit == qend)
+            return true;
+
+        if (rit == rend)
+            return false;
+
+        if (*qit != *rit)
+            return false;
+
+        ++qit;
+        ++rit;
+    }
+}
+
+/*!\brief Depending on the magic bytes of the given stream, return a decompression stream or forward the primary stream.
+ * \param[in] primary_stream The primary (device) stream for reading.
+ * \param[in,out] filename  The associated filename; compression extensions will be stripped. [optional]
+ * \returns A pointer to the secondary stream with defaulted or NOP'ed deleter.
+ * \throws seqan3::file_open_error If the magic bytes suggest compression, but is not supported/available.
+ */
+template <char_concept char_t>
+inline auto make_secondary_istream(std::basic_istream<char_t> & primary_stream, filesystem::path & filename)
+    -> std::unique_ptr<std::basic_istream<char_t>, std::function<void(std::basic_istream<char_t>*)>>
+{
+    // don't assume ownership
+    constexpr auto stream_deleter_noop     = [] (std::basic_istream<char_t> *) {};
+    // assume ownership
+    [[maybe_unused]] constexpr auto stream_deleter_default  = [] (std::basic_istream<char_t> * ptr) { delete ptr; };
+
+    // extract "magic header"
+    std::istreambuf_iterator<char_t> it{primary_stream};
+    constexpr size_t magic_header_size = 4;
+    std::array<char, magic_header_size> magic_number;
+    for (size_t i = 0; i < magic_header_size; ++i)
+    {
+        if (it == std::istreambuf_iterator<char_t>{}) // file is smaller than 4 bytes -> not compressed, could be legal
+            return {&primary_stream, stream_deleter_noop};
+
+        magic_number[i] = *it;
+        ++it;
+    }
+
+    // restore original stream content
+    for (size_t i = 0; i < magic_header_size; ++i)
+        primary_stream.putback(magic_number[magic_header_size - 1 - i]);
+
+    std::string const extension = filename.extension().string();
+
+    // set return value appropriately
+    if (starts_with(magic_number, std::array{'\x1f', '\x8b', '\x08'})) // GZIP
+    {
+    #ifdef SEQAN3_HAS_ZLIB
+        if ((extension == ".gz") || (extension == ".bgzf"))
+            filename.replace_extension("");
+
+        return {new contrib::basic_gz_istream<char_t>{primary_stream}, stream_deleter_default};
+    #else
+        throw file_open_error{"Trying to read from a gzipped file, but no ZLIB available."};
+    #endif
+    }
+    else if (starts_with(magic_number, std::array{'\x42', '\x5a', '\x68'})) // BZip2
+    {
+    #ifdef SEQAN3_HAS_BZIP2
+        if (extension == ".bz2")
+            filename.replace_extension("");
+
+        return {new contrib::basic_bz2_istream<char_t>{primary_stream}, stream_deleter_default};
+    #else
+        throw file_open_error{"Trying to read from a bzipped file, but no libbz2 available."};
+    #endif
+    }
+    else if (starts_with(magic_number, std::array{'\x28', '\xb5', '\x2f', '\xfd'})) // ZStd
+    {
+        throw file_open_error{"Trying to read from a zst'ed file, but SeqAn does not yet support this."};
+    }
+
+    return {&primary_stream, stream_deleter_noop};
+}
+
+//!\overload
+template <char_concept char_t>
+inline auto make_secondary_istream(std::basic_istream<char_t> & primary_stream)
+{
+    filesystem::path p;
+    return make_secondary_istream(primary_stream, p);
+}
+
+} // namespace seqan3::detail

--- a/include/seqan3/io/detail/misc_output.hpp
+++ b/include/seqan3/io/detail/misc_output.hpp
@@ -1,0 +1,76 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2018, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2018, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides various utility functions required only for output.
+ * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <iostream>
+#include <string>
+#include <tuple>
+
+#include <seqan3/core/concept/core_language.hpp>
+#ifdef SEQAN3_HAS_BZIP2
+    #include <seqan3/contrib/stream/bz2_ostream.hpp>
+#endif
+#ifdef SEQAN3_HAS_ZLIB
+    #include <seqan3/contrib/stream/gz_ostream.hpp>
+#endif
+
+namespace seqan3::detail
+{
+
+/*!\brief Depending on the given filename/extension, create a compression stream or just forward the primary stream.
+ * \param[in] primary_stream The primary (uncompressed) stream for writing.
+ * \param[in,out] filename  The associated filename; compression extensions will be stripped.
+ * \returns A pointer to the secondary stream with defaulted or NOP'ed deleter.
+ * \throws seqan3::file_open_error If a compression-extension is used, but is not supported/available.
+ */
+template<char_concept char_t>
+inline auto make_secondary_ostream(std::basic_ostream<char_t> & primary_stream, filesystem::path & filename)
+    -> std::unique_ptr<std::basic_ostream<char_t>, std::function<void(std::basic_ostream<char_t>*)>>
+{
+    // don't assume ownership
+    constexpr auto stream_deleter_noop     = [] (std::basic_ostream<char_t> *) {};
+    // assume ownership
+    [[maybe_unused]] constexpr auto stream_deleter_default  = [] (std::basic_ostream<char_t> * ptr) { delete ptr; };
+
+    std::string extension = filename.extension().string();
+
+    if ((extension == ".gz") || (extension == ".bgzf") || (extension == ".bam"))
+    {
+        //TODO: always write bgzf even when gz was requested? It's compatible and faster
+    #ifdef SEQAN3_HAS_ZLIB
+        if (extension != ".bam") // remove extension except for bam
+            filename.replace_extension("");
+
+        return {new contrib::basic_gz_ostream<char_t>{primary_stream}, stream_deleter_default};
+    #else
+        throw file_open_error{"Trying to write a gzipped file, but no ZLIB available."};
+    #endif
+    }
+    else if (extension == ".bz2")
+    {
+    #ifdef SEQAN3_HAS_BZIP2
+        filename.replace_extension("");
+        return {new contrib::basic_bz2_ostream<char_t>{primary_stream}, stream_deleter_default};
+    #else
+        throw file_open_error{"Trying to write a bzipped file, but no libbz2 available."};
+    #endif
+    }
+    else if (extension == ".zst")
+    {
+        throw file_open_error{"Trying to write a zst'ed file, but SeqAn3 does not yet support this."};
+    }
+
+    return {&primary_stream, stream_deleter_noop};
+}
+
+} // namespace seqan3::detail

--- a/include/seqan3/io/sequence_file/format_fasta.hpp
+++ b/include/seqan3/io/sequence_file/format_fasta.hpp
@@ -144,10 +144,11 @@ public:
               id_type                                                                & id,
               qual_type                                                              & SEQAN3_DOXYGEN_ONLY(qualities))
     {
-        auto stream_view = view::subrange<decltype(std::istreambuf_iterator<char>{stream}),
-                                          decltype(std::istreambuf_iterator<char>{})>
-                            {std::istreambuf_iterator<char>{stream},
-                             std::istreambuf_iterator<char>{}};
+        using stream_char_t = typename stream_type::char_type;
+        auto stream_view = view::subrange<decltype(std::istreambuf_iterator<stream_char_t>{stream}),
+                                          decltype(std::istreambuf_iterator<stream_char_t>{})>
+                            {std::istreambuf_iterator<stream_char_t>{stream},
+                             std::istreambuf_iterator<stream_char_t>{}};
         // ID
         read_id(stream_view, options, id);
 
@@ -155,7 +156,7 @@ public:
         read_seq(stream_view, options, sequence);
 
         // make sure "buffer at end" implies "stream at end"
-        if ((std::istreambuf_iterator<char>{stream} == std::istreambuf_iterator<char>{}) &&
+        if ((std::istreambuf_iterator<stream_char_t>{stream} == std::istreambuf_iterator<stream_char_t>{}) &&
             (!stream.eof()))
         {
             stream.get(); // triggers error in stream and sets eof

--- a/include/seqan3/io/sequence_file/format_fastq.hpp
+++ b/include/seqan3/io/sequence_file/format_fastq.hpp
@@ -136,10 +136,11 @@ public:
               id_type                                                                & id,
               qual_type                                                              & qualities)
     {
-        auto stream_view = view::subrange<decltype(std::istreambuf_iterator<char>{stream}),
-                                          decltype(std::istreambuf_iterator<char>{})>
-                            {std::istreambuf_iterator<char>{stream},
-                             std::istreambuf_iterator<char>{}};
+        using stream_char_t = typename stream_type::char_type;
+        auto stream_view = view::subrange<decltype(std::istreambuf_iterator<stream_char_t>{stream}),
+                                          decltype(std::istreambuf_iterator<stream_char_t>{})>
+                            {std::istreambuf_iterator<stream_char_t>{stream},
+                             std::istreambuf_iterator<stream_char_t>{}};
 
         auto stream_it = begin(stream_view);
 
@@ -239,7 +240,7 @@ public:
         }
 
         // make sure "buffer at end" implies "stream at end"
-        if ((std::istreambuf_iterator<char>{stream} == std::istreambuf_iterator<char>{}) &&
+        if ((std::istreambuf_iterator<stream_char_t>{stream} == std::istreambuf_iterator<stream_char_t>{}) &&
             (!stream.eof()))
         {
             stream.get(); // triggers error in stream and sets eof

--- a/include/seqan3/io/stream/concept.hpp
+++ b/include/seqan3/io/stream/concept.hpp
@@ -58,17 +58,22 @@ namespace seqan3
  */
 //!\cond
 template <typename stream_type, typename value_type>
-concept ostream_concept = std::is_base_of_v<std::ios_base, stream_type> &&
+concept ostream_concept = std::is_base_of_v<std::ios_base, std::remove_reference_t<stream_type>> &&
                                requires (stream_type & os, value_type & val)
 {
-    typename stream_type::char_type;
-    typename stream_type::traits_type;
-    typename stream_type::int_type;
-    typename stream_type::pos_type;
-    typename stream_type::off_type;
+    typename std::remove_reference_t<stream_type>::char_type;
+    typename std::remove_reference_t<stream_type>::traits_type;
+    typename std::remove_reference_t<stream_type>::int_type;
+    typename std::remove_reference_t<stream_type>::pos_type;
+    typename std::remove_reference_t<stream_type>::off_type;
 
-    { os << val } -> std::basic_ostream<typename stream_type::char_type, typename stream_type::traits_type> &;
+    { os << val } -> std::basic_ostream<typename std::remove_reference_t<stream_type>::char_type,
+                                        typename std::remove_reference_t<stream_type>::traits_type> &;
 };
+
+template <typename stream_type>
+concept ostream_concept2 = requires { typename std::remove_reference_t<stream_type>::char_type; } &&
+                           ostream_concept<stream_type, typename std::remove_reference_t<stream_type>::char_type>;
 //!\endcond
 
 /*!\name Requirements for seqan3::ostream_concept
@@ -126,17 +131,22 @@ concept ostream_concept = std::is_base_of_v<std::ios_base, stream_type> &&
  */
 //!\cond
 template <typename stream_type, typename value_type>
-concept istream_concept = std::is_base_of_v<std::ios_base, stream_type> &&
-                               requires (stream_type & os, value_type & val)
+concept istream_concept = std::is_base_of_v<std::ios_base, std::remove_reference_t<stream_type>> &&
+                               requires (stream_type & is, value_type & val)
 {
-    typename stream_type::char_type;
-    typename stream_type::traits_type;
-    typename stream_type::int_type;
-    typename stream_type::pos_type;
-    typename stream_type::off_type;
+    typename std::remove_reference_t<stream_type>::char_type;
+    typename std::remove_reference_t<stream_type>::traits_type;
+    typename std::remove_reference_t<stream_type>::int_type;
+    typename std::remove_reference_t<stream_type>::pos_type;
+    typename std::remove_reference_t<stream_type>::off_type;
 
-    { os >> val } -> std::basic_istream<typename stream_type::char_type, typename stream_type::traits_type> &;
+    { is >> val } -> std::basic_istream<typename std::remove_reference_t<stream_type>::char_type,
+                                        typename std::remove_reference_t<stream_type>::traits_type> &;
 };
+
+template <typename stream_type>
+concept istream_concept2 = requires { typename std::remove_reference_t<stream_type>::char_type; } &&
+                           istream_concept<stream_type, typename std::remove_reference_t<stream_type>::char_type>;
 //!\endcond
 
 /*!\name Requirements for seqan3::istream_concept
@@ -197,6 +207,7 @@ concept istream_concept = std::is_base_of_v<std::ios_base, stream_type> &&
 template <typename stream_type, typename value_type>
 concept stream_concept = ostream_concept<stream_type, value_type> &&
                               istream_concept<stream_type, value_type>;
+
 //!\endcond
 
 } // namespace seqan3

--- a/include/seqan3/io/stream/parse_condition_detail.hpp
+++ b/include/seqan3/io/stream/parse_condition_detail.hpp
@@ -172,7 +172,6 @@ concept parse_condition_concept = requires
 // ----------------------------------------------------------------------------
 
 /*!\brief Returns a printable value for the given character `c`.
- * \tparam char_type The type of the character.
  * \param[in] c The character to be represented as printable string.
  * \return    a std::string containing a printable version of the given character `c`.
  *
@@ -193,8 +192,7 @@ concept parse_condition_concept = requires
  *
  * Thread-safe.
  */
-template <typename char_type>
-inline std::string make_printable(char_type const c)
+inline std::string make_printable(char const c)
 {
     switch (c)
     {

--- a/test/unit/io/sequence_file/sequence_file_input_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_input_test.cpp
@@ -133,9 +133,9 @@ TEST_F(sequence_file_input_f, construct_by_filename)
         }
 
         EXPECT_NO_THROW(( sequence_file_input<sequence_file_input_default_traits_dna,
-                                           fields<field::SEQ>,
-                                           type_list<sequence_file_format_fasta>,
-                                           std::ifstream>{filename.get_path(), fields<field::SEQ>{}} ));
+                                             fields<field::SEQ>,
+                                             type_list<sequence_file_format_fasta>,
+                                             char>{filename.get_path(), fields<field::SEQ>{}} ));
     }
 }
 
@@ -143,19 +143,19 @@ TEST_F(sequence_file_input_f, construct_from_stream)
 {
     /* stream + format_tag */
     EXPECT_NO_THROW(( sequence_file_input<sequence_file_input_default_traits_dna,
-                                       fields<field::SEQ, field::ID, field::QUAL>,
-                                       type_list<sequence_file_format_fasta>,
-                                       std::istringstream>{std::istringstream{input},
-                                                           sequence_file_format_fasta{}} ));
+                                         fields<field::SEQ, field::ID, field::QUAL>,
+                                         type_list<sequence_file_format_fasta>,
+                                         char>{std::istringstream{input},
+                                               sequence_file_format_fasta{}} ));
 
 
     /* stream + format_tag + fields */
     EXPECT_NO_THROW(( sequence_file_input<sequence_file_input_default_traits_dna,
-                                       fields<field::SEQ, field::ID, field::QUAL>,
-                                       type_list<sequence_file_format_fasta>,
-                                       std::istringstream>{std::istringstream{input},
-                                                           sequence_file_format_fasta{},
-                                                           fields<field::SEQ, field::ID, field::QUAL>{}} ));
+                                          fields<field::SEQ, field::ID, field::QUAL>,
+                                          type_list<sequence_file_format_fasta>,
+                                          char>{std::istringstream{input},
+                                                sequence_file_format_fasta{},
+                                                fields<field::SEQ, field::ID, field::QUAL>{}} ));
 }
 
 TEST_F(sequence_file_input_f, default_template_args_and_deduction_guides)
@@ -163,7 +163,7 @@ TEST_F(sequence_file_input_f, default_template_args_and_deduction_guides)
     using comp0 = sequence_file_input_default_traits_dna;
     using comp1 = fields<field::SEQ, field::ID, field::QUAL>;
     using comp2 = type_list<sequence_file_format_fasta, sequence_file_format_fastq>;
-    using comp3 = std::ifstream;
+    using comp3 = char;
 
     /* default template args */
     {
@@ -171,7 +171,7 @@ TEST_F(sequence_file_input_f, default_template_args_and_deduction_guides)
         EXPECT_TRUE((std::is_same_v<typename t::traits_type,        comp0>));
         EXPECT_TRUE((std::is_same_v<typename t::selected_field_ids, comp1>));
         EXPECT_TRUE((std::is_same_v<typename t::valid_formats,      comp2>));
-        EXPECT_TRUE((std::is_same_v<typename t::stream_type,        comp3>));
+        EXPECT_TRUE((std::is_same_v<typename t::stream_char_type,   comp3>));
     }
 
     /* guided filename constructor */
@@ -189,7 +189,7 @@ TEST_F(sequence_file_input_f, default_template_args_and_deduction_guides)
         EXPECT_TRUE((std::is_same_v<typename t::traits_type,        comp0>));
         EXPECT_TRUE((std::is_same_v<typename t::selected_field_ids, comp1>));
         EXPECT_TRUE((std::is_same_v<typename t::valid_formats,      comp2>));
-        EXPECT_TRUE((std::is_same_v<typename t::stream_type,        comp3>));
+        EXPECT_TRUE((std::is_same_v<typename t::stream_char_type,   comp3>));
     }
 
     /* guided filename constructor + custom fields */
@@ -207,10 +207,23 @@ TEST_F(sequence_file_input_f, default_template_args_and_deduction_guides)
         EXPECT_TRUE((std::is_same_v<typename t::traits_type,        comp0>));
         EXPECT_TRUE((std::is_same_v<typename t::selected_field_ids, fields<field::SEQ>>));                   // changed
         EXPECT_TRUE((std::is_same_v<typename t::valid_formats,      comp2>));
-        EXPECT_TRUE((std::is_same_v<typename t::stream_type,        comp3>));
+        EXPECT_TRUE((std::is_same_v<typename t::stream_char_type,   comp3>));
     }
 
     /* guided stream constructor */
+    {
+        std::istringstream ext{input};
+        sequence_file_input fin{ext, sequence_file_format_fasta{}};
+
+        using t = decltype(fin);
+        EXPECT_TRUE((std::is_same_v<typename t::traits_type,        comp0>));
+        EXPECT_TRUE((std::is_same_v<typename t::selected_field_ids, comp1>));
+        EXPECT_TRUE((std::is_same_v<typename t::valid_formats,      type_list<sequence_file_format_fasta,
+                                                                              sequence_file_format_fastq>>));// changed
+        EXPECT_TRUE((std::is_same_v<typename t::stream_char_type,   comp3>));
+    }
+
+    /* guided stream temporary constructor */
     {
         sequence_file_input fin{std::istringstream{input}, sequence_file_format_fasta{}};
 
@@ -219,18 +232,32 @@ TEST_F(sequence_file_input_f, default_template_args_and_deduction_guides)
         EXPECT_TRUE((std::is_same_v<typename t::selected_field_ids, comp1>));
         EXPECT_TRUE((std::is_same_v<typename t::valid_formats,      type_list<sequence_file_format_fasta,
                                                                               sequence_file_format_fastq>>));// changed
-        EXPECT_TRUE((std::is_same_v<typename t::stream_type,        std::istringstream>));                   // changed
+        EXPECT_TRUE((std::is_same_v<typename t::stream_char_type,   comp3>));
     }
 
-    /* guided stream constructor + custom fields */
+    /* guided stream constructor + custom fields + different stream char type */
     {
-        sequence_file_input fin{std::istringstream{input}, sequence_file_format_fasta{}, fields<field::SEQ>{}};
+        auto winput = input | view::convert<wchar_t>;
+        std::wistringstream ext{winput};
+        sequence_file_input fin{ext, sequence_file_format_fasta{}, fields<field::SEQ>{}};
 
         using t = decltype(fin);
         EXPECT_TRUE((std::is_same_v<typename t::traits_type,        comp0>));
         EXPECT_TRUE((std::is_same_v<typename t::selected_field_ids, fields<field::SEQ>>));                   // changed
         EXPECT_TRUE((std::is_same_v<typename t::valid_formats,      type_list<sequence_file_format_fasta>>));// changed
-        EXPECT_TRUE((std::is_same_v<typename t::stream_type,        std::istringstream>));                   // changed
+        EXPECT_TRUE((std::is_same_v<typename t::stream_char_type,   wchar_t>));                              // changed
+    }
+
+    /* guided stream temporary constructor + custom fields + different stream char type */
+    {
+        auto winput = input | view::convert<wchar_t>;
+        sequence_file_input fin{std::wistringstream{winput}, sequence_file_format_fasta{}, fields<field::SEQ>{}};
+
+        using t = decltype(fin);
+        EXPECT_TRUE((std::is_same_v<typename t::traits_type,        comp0>));
+        EXPECT_TRUE((std::is_same_v<typename t::selected_field_ids, fields<field::SEQ>>));                   // changed
+        EXPECT_TRUE((std::is_same_v<typename t::valid_formats,      type_list<sequence_file_format_fasta>>));// changed
+        EXPECT_TRUE((std::is_same_v<typename t::stream_char_type,   wchar_t>));                              // changed
     }
 }
 
@@ -378,3 +405,91 @@ TEST_F(sequence_file_input_f, column_reading_decomposed_temporary)
         EXPECT_TRUE(empty(quals[i]));
     }
 }
+
+// ----------------------------------------------------------------------------
+// decompression
+// ----------------------------------------------------------------------------
+
+template <typename fixture_t, typename input_file_t>
+void decompression_impl(fixture_t & fix, input_file_t & fin)
+{
+    size_t counter = 0;
+    for (auto & rec : fin)
+    {
+        EXPECT_TRUE((std::ranges::equal(get<field::SEQ>(rec), fix.seq_comp[counter])));
+        EXPECT_TRUE((std::ranges::equal(get<field::ID>(rec),  fix.id_comp[counter])));
+        EXPECT_TRUE(empty(get<field::QUAL>(rec)));
+
+        counter++;
+    }
+
+    EXPECT_EQ(counter, 3u);
+}
+
+#ifdef SEQAN3_HAS_ZLIB
+std::string input_gz
+{
+    '\x1F','\x8B','\x08','\x00','\x33','\xBF','\x13','\x5C','\x00','\x03','\xB3','\x53','\x08','\x71','\x0D','\x0E',
+    '\x51','\x30','\xE4','\x72','\x74','\x76','\x0F','\xE1','\xB2','\x0B','\x49','\x2D','\x2E','\x31','\xE2','\x72',
+    '\x74','\x77','\x77','\x0E','\x71','\xF7','\xE3','\xB2','\x53','\x00','\xF1','\x8D','\xB9','\xDC','\xDD','\x1D',
+    '\xDD','\x43','\x1C','\x43','\x1C','\x1D','\x43','\x50','\x21','\x17','\x00','\xEF','\x24','\xC2','\xE9','\x3E',
+    '\x00','\x00','\x00',
+};
+
+TEST_F(sequence_file_input_f, decompression_by_filename_gz)
+{
+    test::tmp_filename filename{"sequence_file_output_test.fasta.gz"};
+
+    {
+        std::ofstream of{filename.get_path(), std::ios::binary};
+
+        std::copy(begin(input_gz), end(input_gz), std::ostreambuf_iterator<char>{of});
+    }
+
+    sequence_file_input fin{filename.get_path()};
+
+    decompression_impl(*this, fin);
+}
+
+TEST_F(sequence_file_input_f, decompression_by_stream_gz)
+{
+    sequence_file_input fin{std::istringstream{input_gz}, sequence_file_format_fasta{}};
+
+    decompression_impl(*this, fin);
+}
+#endif
+
+#ifdef SEQAN3_HAS_BZIP2
+std::string input_bz2
+{
+    '\x42','\x5A','\x68','\x39','\x31','\x41','\x59','\x26','\x53','\x59','\x8D','\xD7','\xE7','\xD6','\x00','\x00',
+    '\x06','\x5F','\x80','\x00','\x10','\x40','\x00','\x38','\x01','\x2A','\x81','\x0C','\x00','\x02','\x00','\x0C',
+    '\x00','\x20','\x00','\x54','\x44','\x34','\xC0','\x00','\x4A','\x9B','\x44','\x68','\x9E','\x48','\x5D','\x34',
+    '\x67','\x4F','\x24','\xFC','\x6F','\x10','\xC5','\xA0','\x3C','\x12','\x61','\xDD','\xE9','\x45','\xA5','\xD4',
+    '\x26','\x31','\xBC','\xF1','\x49','\x61','\x81','\xA2','\xEE','\x48','\xA7','\x0A','\x12','\x11','\xBA','\xFC',
+    '\xFA','\xC0'
+};
+
+TEST_F(sequence_file_input_f, decompression_by_filename_bz2)
+{
+    test::tmp_filename filename{"sequence_file_output_test.fasta.bz2"};
+
+    {
+        std::ofstream of{filename.get_path(), std::ios::binary};
+
+        std::copy(begin(input_bz2), end(input_bz2), std::ostreambuf_iterator<char>{of});
+    }
+
+    sequence_file_input fin{filename.get_path()};
+
+    decompression_impl(*this, fin);
+}
+
+TEST_F(sequence_file_input_f, decompression_by_stream_bz2)
+{
+    sequence_file_input fin{std::istringstream{input_bz2}, sequence_file_format_fasta{}};
+
+    decompression_impl(*this, fin);
+}
+#endif
+

--- a/test/unit/io/sequence_file/sequence_file_integration_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_integration_test.cpp
@@ -74,7 +74,7 @@ TEST(rows, assign_sequence_files)
     fout = fin;
 
     fout.get_stream().flush();
-    EXPECT_EQ(fout.get_stream().str(), output_comp);
+    EXPECT_EQ(reinterpret_cast<std::ostringstream&>(fout.get_stream()).str(), output_comp);
 }
 
 TEST(integration, assign_sequence_file_pipes)
@@ -98,7 +98,7 @@ TEST(integration, assign_sequence_file_pipes)
                 sequence_file_output{std::ostringstream{}, sequence_file_format_fasta{}};
 
     fout.get_stream().flush();
-    EXPECT_EQ(fout.get_stream().str(), input);
+    EXPECT_EQ(reinterpret_cast<std::ostringstream&>(fout.get_stream()).str(), input);
 }
 
 TEST(integration, view)
@@ -132,7 +132,7 @@ TEST(integration, view)
               | sequence_file_output{std::ostringstream{}, sequence_file_format_fasta{}};
 
     fout.get_stream().flush();
-    EXPECT_EQ(fout.get_stream().str(), output);
+    EXPECT_EQ(reinterpret_cast<std::ostringstream&>(fout.get_stream()).str(), output);
 }
 
 TEST(integration, convert_fastq_to_fasta)
@@ -160,5 +160,5 @@ TEST(integration, convert_fastq_to_fasta)
     auto fout = sequence_file_input{std::istringstream{fastq_in}, sequence_file_format_fastq{}} |
                 sequence_file_output{std::ostringstream{}, sequence_file_format_fasta{}};
     fout.get_stream().flush();
-    EXPECT_EQ(fout.get_stream().str(), fasta_out);
+    EXPECT_EQ(reinterpret_cast<std::ostringstream&>(fout.get_stream()).str(), fasta_out);
 }

--- a/test/unit/io/sequence_file/sequence_file_output_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_output_test.cpp
@@ -115,8 +115,7 @@ TEST(general, construct_by_filename)
     {
         test::tmp_filename filename{"sequence_file_output_constructor.fasta"};
         EXPECT_NO_THROW(( sequence_file_output<fields<field::SEQ>,
-                                            type_list<sequence_file_format_fasta>,
-                                            std::ofstream>{filename.get_path(), fields<field::SEQ>{}} ));
+                                            type_list<sequence_file_format_fasta>>{filename.get_path(), fields<field::SEQ>{}} ));
     }
 }
 
@@ -124,15 +123,13 @@ TEST(general, construct_from_stream)
 {
     /* stream + format_tag */
     EXPECT_NO_THROW(( sequence_file_output<fields<field::SEQ, field::ID, field::QUAL>,
-                                        type_list<sequence_file_format_fasta>,
-                                        std::ostringstream>{std::ostringstream{},
+                                           type_list<sequence_file_format_fasta>>{std::ostringstream{},
                                                             sequence_file_format_fasta{}} ));
 
 
     /* stream + format_tag + fields */
     EXPECT_NO_THROW(( sequence_file_output<fields<field::SEQ, field::ID, field::QUAL>,
-                                        type_list<sequence_file_format_fasta>,
-                                        std::ostringstream>{std::ostringstream{},
+                                        type_list<sequence_file_format_fasta>>{std::ostringstream{},
                                                             sequence_file_format_fasta{},
                                                             fields<field::SEQ, field::ID, field::QUAL>{}} ));
 }
@@ -141,14 +138,14 @@ TEST(general, default_template_args_and_deduction_guides)
 {
     using comp1 = fields<field::SEQ, field::ID, field::QUAL>;
     using comp2 = type_list<sequence_file_format_fasta, sequence_file_format_fastq>;
-    using comp3 = std::ofstream;
+    using comp3 = char;
 
     /* default template args */
     {
         using t = sequence_file_output<>;
         EXPECT_TRUE((std::is_same_v<typename t::selected_field_ids, comp1>));
         EXPECT_TRUE((std::is_same_v<typename t::valid_formats,      comp2>));
-        EXPECT_TRUE((std::is_same_v<typename t::stream_type,        comp3>));
+        EXPECT_TRUE((std::is_same_v<typename t::stream_char_type,   comp3>));
     }
 
     /* guided filename constructor */
@@ -160,7 +157,7 @@ TEST(general, default_template_args_and_deduction_guides)
         using t = decltype(fout);
         EXPECT_TRUE((std::is_same_v<typename t::selected_field_ids, comp1>));
         EXPECT_TRUE((std::is_same_v<typename t::valid_formats,      comp2>));
-        EXPECT_TRUE((std::is_same_v<typename t::stream_type,        comp3>));
+        EXPECT_TRUE((std::is_same_v<typename t::stream_char_type,   comp3>));
     }
 
     /* guided filename constructor + custom fields */
@@ -172,10 +169,22 @@ TEST(general, default_template_args_and_deduction_guides)
         using t = decltype(fout);
         EXPECT_TRUE((std::is_same_v<typename t::selected_field_ids, fields<field::SEQ>>));                   // changed
         EXPECT_TRUE((std::is_same_v<typename t::valid_formats,      comp2>));
-        EXPECT_TRUE((std::is_same_v<typename t::stream_type,        comp3>));
+        EXPECT_TRUE((std::is_same_v<typename t::stream_char_type,   comp3>));
     }
 
     /* guided stream constructor */
+    {
+        std::ostringstream ext{};
+        sequence_file_output fout{ext, sequence_file_format_fasta{}};
+
+        using t = decltype(fout);
+        EXPECT_TRUE((std::is_same_v<typename t::selected_field_ids, comp1>));
+        EXPECT_TRUE((std::is_same_v<typename t::valid_formats,      type_list<sequence_file_format_fasta,
+                                                                              sequence_file_format_fastq>>));// changed
+        EXPECT_TRUE((std::is_same_v<typename t::stream_char_type,   comp3>));
+    }
+
+    /* guided stream temporary constructor */
     {
         sequence_file_output fout{std::ostringstream{}, sequence_file_format_fasta{}};
 
@@ -183,17 +192,28 @@ TEST(general, default_template_args_and_deduction_guides)
         EXPECT_TRUE((std::is_same_v<typename t::selected_field_ids, comp1>));
         EXPECT_TRUE((std::is_same_v<typename t::valid_formats,      type_list<sequence_file_format_fasta,
                                                                               sequence_file_format_fastq>>));// changed
-        EXPECT_TRUE((std::is_same_v<typename t::stream_type,        std::ostringstream>));                   // changed
+        EXPECT_TRUE((std::is_same_v<typename t::stream_char_type,   comp3>));
     }
 
-    /* guided stream constructor + custom fields */
+    /* guided stream constructor + custom fields + different stream_char_type */
     {
-        sequence_file_output fout{std::ostringstream{}, sequence_file_format_fasta{}, fields<field::SEQ>{}};
+        std::wostringstream ext{};
+        sequence_file_output fout{ext, sequence_file_format_fasta{}, fields<field::SEQ>{}};
 
         using t = decltype(fout);
         EXPECT_TRUE((std::is_same_v<typename t::selected_field_ids, fields<field::SEQ>>));                   // changed
         EXPECT_TRUE((std::is_same_v<typename t::valid_formats,      type_list<sequence_file_format_fasta>>));// changed
-        EXPECT_TRUE((std::is_same_v<typename t::stream_type,        std::ostringstream>));                   // changed
+        EXPECT_TRUE((std::is_same_v<typename t::stream_char_type,   wchar_t>));                              // changed
+    }
+
+    /* guided stream temporary constructor + custom fields + different stream_char_type */
+    {
+        sequence_file_output fout{std::wostringstream{}, sequence_file_format_fasta{}, fields<field::SEQ>{}};
+
+        using t = decltype(fout);
+        EXPECT_TRUE((std::is_same_v<typename t::selected_field_ids, fields<field::SEQ>>));                   // changed
+        EXPECT_TRUE((std::is_same_v<typename t::valid_formats,      type_list<sequence_file_format_fasta>>));// changed
+        EXPECT_TRUE((std::is_same_v<typename t::stream_char_type,   wchar_t>));                              // changed
     }
 }
 
@@ -211,7 +231,7 @@ void row_wise_impl(fn_t fn)
         fn(fout, i);
 
     fout.get_stream().flush();
-    EXPECT_EQ(fout.get_stream().str(), output_comp);
+    EXPECT_EQ(reinterpret_cast<std::ostringstream&>(fout.get_stream()).str(), output_comp);
 }
 
 template <typename source_t>
@@ -223,7 +243,7 @@ void assign_impl(source_t && source)
     fout = source;
 
     fout.get_stream().flush();
-    EXPECT_EQ(fout.get_stream().str(), output_comp);
+    EXPECT_EQ(reinterpret_cast<std::ostringstream&>(fout.get_stream()).str(), output_comp);
 }
 
 // ----------------------------------------------------------------------------
@@ -349,7 +369,7 @@ TEST(row, different_fields_in_record_and_file)
         "AGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGG\n"
         "CTGNAGGCTGN\n"
     };
-    EXPECT_EQ(fout.get_stream().str(), expected_out);
+    EXPECT_EQ(reinterpret_cast<std::ostringstream&>(fout.get_stream()).str(), expected_out);
 }
 
 // ----------------------------------------------------------------------------
@@ -405,3 +425,109 @@ TEST(columns, assign_tuple_of_columns)
 {
     assign_impl(std::tie(seqs, ids));
 }
+
+// ----------------------------------------------------------------------------
+// compression
+// ----------------------------------------------------------------------------
+
+void compression_by_filename_impl(test::tmp_filename & filename, std::string_view const expected)
+{
+    {
+        sequence_file_output fout{filename.get_path()};
+        fout.options.fasta_letters_per_line = 0;
+
+        for (size_t i = 0; i < 3; ++i)
+        {
+            record<type_list<dna5_vector, std::string>, fields<field::SEQ, field::ID>> r{seqs[i], ids[i]};
+
+            fout.push_back(r);
+        }
+
+    }
+
+    std::string buffer;
+
+    {
+        std::ifstream fi{filename.get_path(), std::ios::binary};
+
+        buffer = std::string{std::istreambuf_iterator<char>{fi}, std::istreambuf_iterator<char>{}};
+    }
+
+    EXPECT_EQ(buffer, expected);
+}
+
+template <typename comp_stream_t>
+void compression_by_stream_impl(comp_stream_t & stream)
+{
+    sequence_file_output fout{stream, sequence_file_format_fasta{}};
+    fout.options.fasta_letters_per_line = 0;
+
+    for (size_t i = 0; i < 3; ++i)
+    {
+        record<type_list<dna5_vector, std::string>, fields<field::SEQ, field::ID>> r{seqs[i], ids[i]};
+
+        fout.push_back(r);
+    }
+}
+
+#ifdef SEQAN3_HAS_ZLIB
+std::string expected_gz
+{
+    '\x1F','\x8B','\x08','\x00','\x00','\x00','\x00','\x00','\x00','\x03','\xB3','\x53','\x08','\x71','\x0D','\x0E',
+    '\x51','\x30','\xE4','\x72','\x74','\x76','\x0F','\xE1','\xB2','\x53','\x08','\x49','\x2D','\x2E','\x31','\xE2',
+    '\x72','\x74','\x77','\x77','\x0E','\x71','\xF7','\xA3','\x05','\x05','\xB5','\xC3','\x98','\xCB','\xDD','\xDD',
+    '\xD1','\x3D','\xC4','\x31','\xC4','\xD1','\x31','\x04','\x15','\x72','\x01','\x00','\x27','\xAD','\xB4','\xE9',
+    '\x93','\x00','\x00','\x00'
+};
+
+TEST(compression, by_filename_gz)
+{
+    test::tmp_filename filename{"sequence_file_output_test.fasta.gz"};
+
+    compression_by_filename_impl(filename, expected_gz);
+}
+
+TEST(compression, by_stream_gz)
+{
+    std::ostringstream out;
+
+    {
+        contrib::gz_ostream compout{out};
+        compression_by_stream_impl(compout);
+    }
+
+    EXPECT_EQ(out.str(), expected_gz);
+}
+#endif
+
+#ifdef SEQAN3_HAS_BZIP2
+std::string expected_bz2
+{
+    '\x42','\x5A','\x68','\x39','\x31','\x41','\x59','\x26','\x53','\x59','\xB4','\x68','\xEA','\xE3','\x00','\x00',
+    '\x06','\xDF','\x80','\x00','\x10','\x40','\x00','\x38','\x01','\x2A','\x81','\x0C','\x00','\x02','\x00','\x0C',
+    '\x00','\x20','\x00','\x50','\xA6','\x00','\x09','\xA0','\x8A','\x10','\x9A','\x32','\x34','\xD9','\xAB','\x5F',
+    '\x16','\xE9','\xEB','\x86','\x5B','\x46','\x41','\x8D','\xD0','\x1E','\x12','\x8C','\xC0','\xB5','\x48','\xD2',
+    '\x3A','\x9B','\x23','\xB9','\x9F','\x64','\x98','\x1E','\xEE','\x8C','\x18','\x3E','\x38','\x7E','\x2E','\xE4',
+    '\x8A','\x70','\xA1','\x21','\x68','\xD1','\xD5','\xC6'
+};
+
+TEST(compression, by_filename_bz2)
+{
+    test::tmp_filename filename{"sequence_file_output_test.fasta.bz2"};
+
+
+    compression_by_filename_impl(filename, expected_bz2);
+}
+
+TEST(compression, by_stream_bz2)
+{
+    std::ostringstream out;
+
+    {
+        contrib::bz2_ostream compout{out};
+        compression_by_stream_impl(compout);
+    }
+
+    EXPECT_EQ(out.str(), expected_bz2);
+}
+#endif


### PR DESCRIPTION
resolves #611 
~~blocked by #610 (new commits begin at [MISC] ...)~~

----

In addition to the planned changes this also makes sequence_file cope with streams that have other char-types than `char`, like `wchar_t`.

@rrahn I have added some single-arguments concepts to the stream_concepts and we can discuss what to do about it long-term.