### PR TITLE
[fix] warnings in alignment tests

### DIFF
--- a/include/seqan3/alignment/matrix/alignment_trace_algorithms.hpp
+++ b/include/seqan3/alignment/matrix/alignment_trace_algorithms.hpp
@@ -65,14 +65,11 @@ namespace seqan3::detail
 inline alignment_coordinate alignment_begin_coordinate(trace_matrix_t && matrix,
                                                        alignment_coordinate const end_coordinate)
 {
-    using signed_size_t = std::make_signed_t<size_t>;
-
-    constexpr auto N = trace_directions::none;
     constexpr auto D = trace_directions::diagonal;
     constexpr auto L = trace_directions::left;
     constexpr auto U = trace_directions::up;
-    signed_size_t row = end_coordinate.seq2_pos + 1;
-    signed_size_t col = end_coordinate.seq1_pos + 1;
+    size_t row = end_coordinate.seq2_pos + 1;
+    size_t col = end_coordinate.seq1_pos + 1;
 
     assert(row < matrix.rows());
     assert(col < matrix.cols());
@@ -82,16 +79,16 @@ inline alignment_coordinate alignment_begin_coordinate(trace_matrix_t && matrix,
         trace_directions dir = matrix.at(row, col);
         if ((dir & L) == L)
         {
-            col = std::max<signed_size_t>(col - 1, 0);
+            col = std::max<size_t>(col, 1) - 1;
         }
         else if ((dir & U) == U)
         {
-            row = std::max<signed_size_t>(row - 1, 0);
+            row = std::max<size_t>(row, 1) - 1;
         }
         else if ((dir & D) == D)
         {
-            row = std::max<signed_size_t>(row - 1, 0);
-            col = std::max<signed_size_t>(col - 1, 0);
+            row = std::max<size_t>(row, 1) - 1;
+            col = std::max<size_t>(col, 1) - 1;
         }
         else
         {
@@ -103,7 +100,7 @@ inline alignment_coordinate alignment_begin_coordinate(trace_matrix_t && matrix,
         }
     }
 
-    return {std::max<signed_size_t>(col - 1, 0), std::max<signed_size_t>(row - 1, 0)};
+    return {std::max<size_t>(col, 1) - 1, std::max<size_t>(row, 1) - 1};
 }
 
 /*!\brief Compute the trace from a trace matrix.
@@ -137,14 +134,12 @@ alignment_trace(database_t && database,
                 trace_matrix_t && matrix,
                 alignment_coordinate const end_coordinate)
 {
-    using signed_size_t = std::make_signed_t<size_t>;
-
     constexpr auto N = trace_directions::none;
     constexpr auto D = trace_directions::diagonal;
     constexpr auto L = trace_directions::left;
     constexpr auto U = trace_directions::up;
-    signed_size_t col = end_coordinate.seq1_pos + 1;
-    signed_size_t row = end_coordinate.seq2_pos + 1;
+    size_t col = end_coordinate.seq1_pos + 1;
+    size_t row = end_coordinate.seq2_pos + 1;
 
     assert(row <= query.size());
     assert(col <= database.size());
@@ -162,20 +157,20 @@ alignment_trace(database_t && database,
         trace_directions dir = matrix.at(row, col);
         if ((dir & L) == L)
         {
-            col = std::max<signed_size_t>(col - 1, 0);
+            col = std::max<size_t>(col, 1) - 1;
             gapped_database.push_front(database[col]);
             gapped_query.push_front(gap::GAP);
         }
         else if ((dir & U) == U)
         {
-            row = std::max<signed_size_t>(row - 1, 0);
+            row = std::max<size_t>(row, 1) - 1;
             gapped_database.push_front(gap::GAP);
             gapped_query.push_front(query[row]);
         }
         else if ((dir & D) == D)
         {
-            row = std::max<signed_size_t>(row - 1, 0);
-            col = std::max<signed_size_t>(col - 1, 0);
+            row = std::max<size_t>(row, 1) - 1;
+            col = std::max<size_t>(col, 1) - 1;
             gapped_database.push_front(database[col]);
             gapped_query.push_front(query[row]);
         }

--- a/include/seqan3/alignment/pairwise/edit_distance_unbanded.hpp
+++ b/include/seqan3/alignment/pairwise/edit_distance_unbanded.hpp
@@ -188,7 +188,7 @@ private:
      * \{
      */
     //!\brief Which score value is considered as a hit?
-    size_t max_errors{255};
+    score_type max_errors{255};
     //!\brief The block containing the last active cell.
     size_t last_block{0};
     //!\brief A mask with a bit set on the position of the last row.
@@ -240,8 +240,8 @@ public:
         database{std::forward<database_t>(_database)},
         query{std::forward<query_t>(_query)},
         config{std::forward<align_config_t>(_config)},
-        _score{query.size()},
-        _best_score{query.size()},
+        _score{static_cast<score_type>(query.size())},
+        _best_score{static_cast<score_type>(query.size())},
         _best_score_col{ranges::begin(database)},
         database_it{ranges::begin(database)},
         database_it_end{ranges::end(database)}
@@ -249,7 +249,10 @@ public:
         static constexpr size_t alphabet_size = alphabet_size_v<query_alphabet_type>;
 
         if constexpr(use_max_errors)
+        {
             max_errors = get<align_cfg::id::max_error>(config);
+            assert(max_errors >= score_type{0});
+        }
 
         size_t block_count = (query.size() - 1 + word_size) / word_size;
         score_mask = (word_type)1 << ((query.size() - 1 + word_size) % word_size);
@@ -267,7 +270,7 @@ public:
             _best_score = _score;
         }
 
-        word_type vp0{~static_cast<word_type>(0)};
+        word_type vp0{static_cast<word_type>(~0)};
         word_type vn0{0};
 
         vp.resize(block_count, vp0);

--- a/include/seqan3/alignment/pairwise/execution/alignment_executor_two_way.hpp
+++ b/include/seqan3/alignment/pairwise/execution/alignment_executor_two_way.hpp
@@ -208,11 +208,11 @@ private:
     //!\brief The execution policy.
     execution_handler_t exec_handler{};
 
+    //!\brief The underlying resource containing the alignment instances.
+    align_instance_rng_t resource;  // view or lvalue ref
     //!\brief Selects the correct alignment to execute.
     alignment_selector_t selector;
 
-    //!\brief The underlying resource containing the alignment instances.
-    align_instance_rng_t resource;  // view or lvalue ref
     //!\brief Points to the current element in the resource.
     resource_iterator resource_iter{};
     //!\brief End of the resource.

--- a/include/seqan3/alignment/pairwise/execution/alignment_range.hpp
+++ b/include/seqan3/alignment/pairwise/execution/alignment_range.hpp
@@ -129,7 +129,7 @@ class alignment_range
          * \{
          */
 
-        constexpr bool operator==(std::ranges::default_sentinel const & rhs) const
+        constexpr bool operator==(std::ranges::default_sentinel const &) const
         {
             return stream_ptr->eof();
         }
@@ -183,7 +183,7 @@ public:
     ~alignment_range()                                   = default;
 
     explicit alignment_range(range_buffer_t & _range_buffer) :
-        range_buffer{&_range_buffer, [](auto ptr) { /*no-op*/ }}
+        range_buffer{&_range_buffer, [](auto) { /*no-op*/ }}
     {}
 
     // Construct from resource.

--- a/test/unit/alignment/pairwise/alignment_selector_test.cpp
+++ b/test/unit/alignment/pairwise/alignment_selector_test.cpp
@@ -61,7 +61,7 @@ TEST(alignment_selector, determine_result_type)
         auto cfg = align_cfg::edit;
         using _t = typename detail::determine_result_type<seq1_t, seq2_t, decltype(cfg)>::type;
 
-        EXPECT_EQ(std::tuple_size_v<_t>, 2);
+        EXPECT_EQ(std::tuple_size_v<_t>, 2u);
         EXPECT_TRUE((std::is_same_v<std::tuple_element_t<0, _t>, uint32_t>));
         EXPECT_TRUE((std::is_same_v<std::tuple_element_t<1, _t>, int32_t>));
     }
@@ -70,7 +70,7 @@ TEST(alignment_selector, determine_result_type)
         auto cfg = align_cfg::edit | align_cfg::output<align_result_key::score>;
         using _t = typename detail::determine_result_type<seq1_t, seq2_t, decltype(cfg)>::type;
 
-        EXPECT_EQ(std::tuple_size_v<_t>, 2);
+        EXPECT_EQ(std::tuple_size_v<_t>, 2u);
         EXPECT_TRUE((std::is_same_v<std::tuple_element_t<0, _t>, uint32_t>));
         EXPECT_TRUE((std::is_same_v<std::tuple_element_t<1, _t>, int32_t>));
     }
@@ -82,7 +82,7 @@ TEST(alignment_selector, determine_result_type)
         using gapped_seq1_t = std::vector<gapped<dna4>>;
         using gapped_seq2_t = std::vector<gapped<dna4>>;
 
-        EXPECT_EQ(std::tuple_size_v<_t>, 5);
+        EXPECT_EQ(std::tuple_size_v<_t>, 5u);
         EXPECT_TRUE((std::is_same_v<std::tuple_element_t<0, _t>, uint32_t>));
         EXPECT_TRUE((std::is_same_v<std::tuple_element_t<1, _t>, int32_t>));
         EXPECT_TRUE((std::is_same_v<std::tuple_element_t<2, _t>, detail::alignment_coordinate>));


### PR DESCRIPTION
```
In file included from /seqan3/test/unit/alignment/pairwise/alignment_selector_test.cpp:35:
/seqan3-build/gcc-8-release/vendor/googletest/googletest/include/gtest/gtest.h: In instantiation of ‘testing::AssertionResult testing::internal::CmpHelperEQ(const char*, const char*, const T1&, const T2&) [with T1 = long unsigned int; T2 = int]’:
/seqan3-build/gcc-8-release/vendor/googletest/googletest/include/gtest/gtest.h:1449:23:   required from ‘static testing::AssertionResult testing::internal::EqHelper<lhs_is_null_literal>::Compare(const char*, const char*, const T1&, const T2&) [with T1 = long unsigned int; T2 = int; bool lhs_is_null_literal = false]’
/seqan3/test/unit/alignment/pairwise/alignment_selector_test.cpp:73:9:   required from here
/seqan3-build/gcc-8-release/vendor/googletest/googletest/include/gtest/gtest.h:1421:11: error: comparison of integer expressions of different signedness: ‘const long unsigned int’ and ‘const int’ [-Werror=sign-compare]
   if (lhs == rhs) {
       ~~~~^~~~~~
```

```
In file included from /seqan3/include/seqan3/alignment/pairwise/execution/alignment_executor_two_way.hpp:46,
                 from /seqan3/test/unit/alignment/pairwise/execution/alignment_executor_two_way_test.cpp:43:
/seqan3/include/seqan3/alignment/pairwise/execution/alignment_range.hpp: In instantiation of ‘seqan3::alignment_range<range_buffer_t>::alignment_range(range_buffer_t&) [with range_buffer_t = seqan3::detail::alignment_executor_two_way<std::vector<foo>&, foo_selector, seqan3::detail::execution_handler_sequential>]::<lambda(auto:1)> [with auto:1 = seqan3::detail::alignment_executor_two_way<std::vector<foo>&, foo_selector, seqan3::detail::execution_handler_sequential>*]’:
/usr/include/c++/8.2.1/type_traits:2283:26:   required by substitution of ‘template<class _Fn, class ... _Args> static std::__result_of_success<decltype (declval<_Fn>()((declval<_Args>)()...)), std::__invoke_other> std::__result_of_other_impl::_S_test(int) [with _Fn = seqan3::alignment_range<range_buffer_t>::alignment_range(range_buffer_t&) [with range_buffer_t = seqan3::detail::alignment_executor_two_way<std::vector<foo>&, foo_selector, seqan3::detail::execution_handler_sequential>]::<lambda(auto:1)>&; _Args = {seqan3::detail::alignment_executor_two_way<std::vector<foo, std::allocator<foo> >&, foo_selector, seqan3::detail::execution_handler_sequential>*&}]’
/usr/include/c++/8.2.1/type_traits:2294:55:   required from ‘struct std::__result_of_impl<false, false, seqan3::alignment_range<range_buffer_t>::alignment_range(range_buffer_t&) [with range_buffer_t = seqan3::detail::alignment_executor_two_way<std::vector<foo>&, foo_selector, seqan3::detail::execution_handler_sequential>]::<lambda(auto:1)>&, seqan3::detail::alignment_executor_two_way<std::vector<foo, std::allocator<foo> >&, foo_selector, seqan3::detail::execution_handler_sequential>*&>’
/usr/include/c++/8.2.1/type_traits:2617:12:   recursively required by substitution of ‘template<class _Result, class _Ret> struct std::__is_invocable_impl<_Result, _Ret, std::__void_t<typename _Result::type> > [with _Result = std::__invoke_result<seqan3::alignment_range<range_buffer_t>::alignment_range(range_buffer_t&) [with range_buffer_t = seqan3::detail::alignment_executor_two_way<std::vector<foo>&, foo_selector, seqan3::detail::execution_handler_sequential>]::<lambda(auto:1)>&, seqan3::detail::alignment_executor_two_way<std::vector<foo, std::allocator<foo> >&, foo_selector, seqan3::detail::execution_handler_sequential>*&>; _Ret = void]’
/usr/include/c++/8.2.1/type_traits:2617:12:   required from ‘struct std::__is_invocable<seqan3::alignment_range<range_buffer_t>::alignment_range(range_buffer_t&) [with range_buffer_t = seqan3::detail::alignment_executor_two_way<std::vector<foo>&, foo_selector, seqan3::detail::execution_handler_sequential>]::<lambda(auto:1)>&, seqan3::detail::alignment_executor_two_way<std::vector<foo, std::allocator<foo> >&, foo_selector, seqan3::detail::execution_handler_sequential>*&>’
/usr/include/c++/8.2.1/bits/shared_ptr_base.h:1114:40:   required from ‘std::__shared_ptr<_Tp, _Lp>::__shared_ptr(_Yp*, _Deleter) [with _Yp = seqan3::detail::alignment_executor_two_way<std::vector<foo>&, foo_selector, seqan3::detail::execution_handler_sequential>; _Deleter = seqan3::alignment_range<range_buffer_t>::alignment_range(range_buffer_t&) [with range_buffer_t = seqan3::detail::alignment_executor_two_way<std::vector<foo>&, foo_selector, seqan3::detail::execution_handler_sequential>]::<lambda(auto:1)>; <template-parameter-2-3> = void; _Tp = seqan3::detail::alignment_executor_two_way<std::vector<foo>&, foo_selector, seqan3::detail::execution_handler_sequential>; __gnu_cxx::_Lock_policy _Lp = (__gnu_cxx::_Lock_policy)2]’
/usr/include/c++/8.2.1/bits/shared_ptr.h:157:48:   required from ‘std::shared_ptr<_Tp>::shared_ptr(_Yp*, _Deleter) [with _Yp = seqan3::detail::alignment_executor_two_way<std::vector<foo>&, foo_selector, seqan3::detail::execution_handler_sequential>; _Deleter = seqan3::alignment_range<range_buffer_t>::alignment_range(range_buffer_t&) [with range_buffer_t = seqan3::detail::alignment_executor_two_way<std::vector<foo>&, foo_selector, seqan3::detail::execution_handler_sequential>]::<lambda(auto:1)>; <template-parameter-2-3> = void; _Tp = seqan3::detail::alignment_executor_two_way<std::vector<foo>&, foo_selector, seqan3::detail::execution_handler_sequential>]’
/seqan3/include/seqan3/alignment/pairwise/execution/alignment_range.hpp:186:64:   required from ‘seqan3::alignment_range<range_buffer_t>::alignment_range(range_buffer_t&) [with range_buffer_t = seqan3::detail::alignment_executor_two_way<std::vector<foo>&, foo_selector, seqan3::detail::execution_handler_sequential>]’
/seqan3/include/seqan3/alignment/pairwise/execution/alignment_executor_two_way.hpp:130:45:   required from ‘seqan3::alignment_range<seqan3::detail::alignment_executor_two_way<align_instance_rng_t, alignment_selector_t, execution_handler_t> > seqan3::detail::alignment_executor_two_way<align_instance_rng_t, alignment_selector_t, execution_handler_t>::range() [with align_instance_rng_t = std::vector<foo>&; alignment_selector_t = foo_selector; execution_handler_t = seqan3::detail::execution_handler_sequential]’
/seqan3/test/unit/alignment/pairwise/execution/alignment_executor_two_way_test.cpp:77:32:   required from here
/seqan3/include/seqan3/alignment/pairwise/execution/alignment_range.hpp:186:46: error: unused parameter ‘ptr’ [-Werror=unused-parameter]
         range_buffer{&_range_buffer, [](auto ptr) { /*no-op*/ }}
                                         ~~~~~^~~
```

```
In file included from /seqan3/test/unit/alignment/pairwise/edit_distance_unbanded_test.cpp:6:
/seqan3/include/seqan3/alignment/pairwise/edit_distance_unbanded.hpp: In instantiation of ‘seqan3::detail::pairwise_alignment_edit_distance_unbanded<database_t, query_t, align_config_t, traits_t>::pairwise_alignment_edit_distance_unbanded(database_t&&, query_t&&, align_config_t) [with database_t = std::vector<seqan3::dna4>&; query_t = std::vector<seqan3::dna4>&; align_config_t = seqan3::detail::configuration<seqan3::detail::align_config_gap<seqan3::gap_scheme<signed char> >, seqan3::detail::align_config_score<seqan3::nucleotide_scoring_scheme<signed char> >, seqan3::detail::align_config_global>&; traits_t = test_traits_type<unsigned char>]’:
/seqan3/test/unit/alignment/pairwise/edit_distance_unbanded_test.cpp:161:10:   required from ‘auto edit_distance(database_t&&, query_t&&, align_cfg_t&&) [with word_type = unsigned char; database_t = std::vector<seqan3::dna4>&; query_t = std::vector<seqan3::dna4>&; align_cfg_t = seqan3::detail::configuration<seqan3::detail::align_config_gap<seqan3::gap_scheme<signed char> >, seqan3::detail::align_config_score<seqan3::nucleotide_scoring_scheme<signed char> >, seqan3::detail::align_config_global>&]’
/seqan3/test/unit/alignment/pairwise/edit_distance_unbanded_test.cpp:190:46:   required from ‘void gtest_case_edit_distance_unbanded_::score_matrix<gtest_TypeParam_>::TestBody() [with gtest_TypeParam_ = param<(& seqan3::fixture::global::edit_distance::unbanded::dna4_02), unsigned char>]’
/seqan3/test/unit/alignment/pairwise/edit_distance_unbanded_test.cpp:181:1:   required from here
/seqan3/include/seqan3/alignment/pairwise/edit_distance_unbanded.hpp:270:19: error: narrowing conversion of ‘-1’ from ‘int’ to ‘seqan3::detail::pairwise_alignment_edit_distance_unbanded<std::vector<seqan3::dna4>&, std::vector<seqan3::dna4>&, seqan3::detail::configuration<seqan3::detail::align_config_gap<seqan3::gap_scheme<signed char> >, seqan3::detail::align_config_score<seqan3::nucleotide_scoring_scheme<signed char> >, seqan3::detail::align_config_global>&, test_traits_type<unsigned char> >::word_type’ {aka ‘unsigned char’} inside { } [-Wnarrowing]
         word_type vp0{~word_type{0}};
                   ^~~
```

```
In file included from /seqan3/test/unit/alignment/pairwise/edit_distance_unbanded_test.cpp:6:
/seqan3/include/seqan3/alignment/pairwise/edit_distance_unbanded.hpp: In instantiation of ‘bool seqan3::detail::pairwise_alignment_edit_distance_unbanded<database_t, query_t, align_config_t, traits_t>::small_patterns() [with database_t = std::vector<seqan3::aa27>&; query_t = std::vector<seqan3::aa27>&; align_config_t = seqan3::detail::configuration<seqan3::detail::align_config_max_error, seqan3::detail::align_config_gap<seqan3::gap_scheme<signed char> >, seqan3::detail::align_config_score<seqan3::nucleotide_scoring_scheme<signed char> >, seqan3::detail::align_config_global>&; traits_t = test_traits_type<short unsigned int>]’:
/seqan3/include/seqan3/alignment/pairwise/edit_distance_unbanded.hpp:414:13:   required from ‘void seqan3::detail::pairwise_alignment_edit_distance_unbanded<database_t, query_t, align_config_t, traits_t>::_compute() [with database_t = std::vector<seqan3::aa27>&; query_t = std::vector<seqan3::aa27>&; align_config_t = seqan3::detail::configuration<seqan3::detail::align_config_max_error, seqan3::detail::align_config_gap<seqan3::gap_scheme<signed char> >, seqan3::detail::align_config_score<seqan3::nucleotide_scoring_scheme<signed char> >, seqan3::detail::align_config_global>&; traits_t = test_traits_type<short unsigned int>]’
/seqan3/include/seqan3/alignment/pairwise/edit_distance_unbanded.hpp:431:9:   required from ‘result_type& seqan3::detail::pairwise_alignment_edit_distance_unbanded<database_t, query_t, align_config_t, traits_t>::operator()(result_type&) [with result_type = std::tuple<>; database_t = std::vector<seqan3::aa27>&; query_t = std::vector<seqan3::aa27>&; align_config_t = seqan3::detail::configuration<seqan3::detail::align_config_max_error, seqan3::detail::align_config_gap<seqan3::gap_scheme<signed char> >, seqan3::detail::align_config_score<seqan3::nucleotide_scoring_scheme<signed char> >, seqan3::detail::align_config_global>&; traits_t = test_traits_type<short unsigned int>]’
/seqan3/test/unit/alignment/pairwise/edit_distance_unbanded_test.cpp:164:14:   required from ‘auto edit_distance(database_t&&, query_t&&, align_cfg_t&&) [with word_type = short unsigned int; database_t = std::vector<seqan3::aa27>&; query_t = std::vector<seqan3::aa27>&; align_cfg_t = seqan3::detail::configuration<seqan3::detail::align_config_max_error, seqan3::detail::align_config_gap<seqan3::gap_scheme<signed char> >, seqan3::detail::align_config_score<seqan3::nucleotide_scoring_scheme<signed char> >, seqan3::detail::align_config_global>&]’
/seqan3/test/unit/alignment/pairwise/edit_distance_unbanded_test.cpp:236:46:   required from ‘void gtest_case_edit_distance_unbanded_::trace<gtest_TypeParam_>::TestBody() [with gtest_TypeParam_ = param<(& seqan3::fixture::global::edit_distance::max_errors::unbanded::aa27_01T_e255), short unsigned int>]’
/seqan3/test/unit/alignment/pairwise/edit_distance_unbanded_test.cpp:227:1:   required from here
/seqan3/include/seqan3/alignment/pairwise/edit_distance_unbanded.hpp:510:24: error: comparison of integer expressions of different signedness: ‘seqan3::detail::pairwise_alignment_edit_distance_unbanded<std::vector<seqan3::aa27>&, std::vector<seqan3::aa27>&, seqan3::detail::configuration<seqan3::detail::align_config_max_error, seqan3::detail::align_config_gap<seqan3::gap_scheme<signed char> >, seqan3::detail::align_config_score<seqan3::nucleotide_scoring_scheme<signed char> >, seqan3::detail::align_config_global>&, test_traits_type<short unsigned int> >::score_type’ {aka ‘int’} and ‘size_t’ {aka ‘long unsigned int’} [-Werror=sign-compare]
             if (_score <= max_errors && on_hit())
                 ~~~~~~~^~~~~~~~~~~~~
```