### PR TITLE
[fix] warnings in io tests

### DIFF
--- a/include/seqan3/io/stream/parse_condition_detail.hpp
+++ b/include/seqan3/io/stream/parse_condition_detail.hpp
@@ -291,7 +291,7 @@ public:
         requires sizeof(value_t) != 1
     {
         return (static_cast<std::make_unsigned_t<value_t>>(val) < 256) ? operator()(static_cast<uint8_t>(val)) :
-               (val == EOF)                                            ? derived_t::data[256]                  : false;
+               (static_cast<decltype(EOF)>(val) == EOF)                ? derived_t::data[256]                  : false;
     }
     //!\}
 

--- a/test/unit/io/structure_file/format_vienna_test.cpp
+++ b/test/unit/io/structure_file/format_vienna_test.cpp
@@ -135,7 +135,7 @@ struct read : public ::testing::Test
         auto interaction_sets = bpp | ranges::view::remove_if([] (auto & set) { return set.size() != 1; });
         for (auto & iset : interaction_sets)
         {
-            EXPECT_EQ(iset.size(), 1);
+            EXPECT_EQ(iset.size(), 1u);
             EXPECT_EQ(iset.begin()->second, bpp_comp[cnt++]);
             EXPECT_FLOAT_EQ(iset.begin()->first, 1.0f);
         }


### PR DESCRIPTION
```
In file included from /seqan3/test/unit/io/structure_file/format_vienna_test.cpp:40:
/seqan3-build/gcc-8-release/vendor/googletest/googletest/include/gtest/gtest.h: In instantiation of ‘testing::AssertionResult testing::internal::CmpHelperEQ(const char*, const char*, const T1&, const T2&) [with T1 = long unsigned int; T2 = int]’:
/seqan3-build/gcc-8-release/vendor/googletest/googletest/include/gtest/gtest.h:1449:23:   required from ‘static testing::AssertionResult testing::internal::EqHelper<lhs_is_null_literal>::Compare(const char*, const char*, const T1&, const T2&) [with T1 = long unsigned int; T2 = int; bool lhs_is_null_literal = false]’
/seqan3/test/unit/io/structure_file/format_vienna_test.cpp:138:13:   required from here
/seqan3-build/gcc-8-release/vendor/googletest/googletest/include/gtest/gtest.h:1421:11: error: comparison of integer expressions of different signedness: ‘const long unsigned int’ and ‘const int’ [-Werror=sign-compare]
   if (lhs == rhs) {
       ~~~~^~~~~~
```

```
In file included from /seqan3/test/unit/io/structure_file/format_vienna_test.cpp:40:
/seqan3-build/gcc-8-release/vendor/googletest/googletest/include/gtest/gtest.h: In instantiation of ‘testing::AssertionResult testing::internal::CmpHelperEQ(const char*, const char*, const T1&, const T2&) [with T1 = long unsigned int; T2 = int]’:
/seqan3-build/gcc-8-release/vendor/googletest/googletest/include/gtest/gtest.h:1449:23:   required from ‘static testing::AssertionResult testing::internal::EqHelper<lhs_is_null_literal>::Compare(const char*, const char*, const T1&, const T2&) [with T1 = long unsigned int; T2 = int; bool lhs_is_null_literal = false]’
/seqan3/test/unit/io/structure_file/format_vienna_test.cpp:138:13:   required from here
/seqan3-build/gcc-8-release/vendor/googletest/googletest/include/gtest/gtest.h:1421:11: error: comparison of integer expressions of different signedness: ‘const long unsigned int’ and ‘const int’ [-Werror=sign-compare]
   if (lhs == rhs) {
       ~~~~^~~~~~
```