### PR TITLE
[feature] add seqan3::detail::simd_transform

### DIFF
--- a/test/snippet/core/simd/detail/simd_transform.cpp
+++ b/test/snippet/core/simd/detail/simd_transform.cpp
@@ -1,0 +1,86 @@
+#include <seqan3/core/simd/simd.hpp>
+#include <seqan3/core/simd/simd_algorithm.hpp>
+
+int main()
+{
+{
+//! [definition]
+using simd_type = seqan3::simd::simd_type_t<uint16_t, 8>;
+using scalar_t = typename seqan3::simd::simd_traits<simd_type>::scalar_type; // same as uint16_t
+
+auto fn = [] (size_t, scalar_t ai, scalar_t bi, /*scalar_t ci, ...,*/ scalar_t zi) -> scalar_t
+{
+    return ai + bi + /*ci + ... +*/ zi;
+};
+
+simd_type a{}, b{}, /*c{}, ...,*/ z{};
+simd_type result = seqan3::detail::simd_transform<simd_type>(fn, a, b, /*c{}, ...,*/ z);
+
+// same as
+result = simd_type
+{
+    fn(0, a[0], b[0], /*c[0], ...,*/ z[0]),
+    fn(1, a[1], b[1], /*c[1], ...,*/ z[1]),
+    fn(2, a[2], b[2], /*c[2], ...,*/ z[2]),
+    // ...
+    fn(7, a[7], b[7], /*c[7], ...,*/ z[7])
+};
+result = simd_type{};
+
+for (int i = 0; i < 7; ++i)
+{
+    result[i] = fn(i, a[i], b[i], /*c[i], ...,*/ z[i]);
+}
+//! [definition]
+    static_cast<void>(result);
+}
+{
+//! [generator]
+using simd_type = seqan3::simd::simd_type_t<uint16_t, 8>;
+using scalar_t = typename seqan3::simd::simd_traits<simd_type>::scalar_type; // same as uint16_t
+
+auto iota = [i = scalar_t{0}] (size_t) mutable
+{
+    return i++;
+};
+
+simd_type result = seqan3::detail::simd_transform<simd_type>(iota);
+
+// same as
+result = simd_type
+{
+    iota(0),
+    iota(1),
+    iota(2),
+    // ...
+    iota(7)
+};
+//! [generator]
+    static_cast<void>(result);
+}
+{
+//! [binary_max]
+using simd_type = seqan3::simd::simd_type_t<uint16_t, 8>;
+
+auto max = [] (size_t, auto ai, auto bi)
+{
+    return ai > bi ? ai : bi;
+};
+
+simd_type a{}, b{};
+simd_type result = seqan3::detail::simd_transform<simd_type>(max, a, b);
+
+// same as
+result = simd_type
+{
+    max(0, a[0], b[0]),
+    max(1, a[1], b[1]),
+    max(2, a[2], b[2]),
+    // ...
+    max(7, a[7], b[7])
+};
+//! [binary_max]
+    static_cast<void>(result);
+}
+    return 0;
+}

--- a/test/unit/core/simd/detail/CMakeLists.txt
+++ b/test/unit/core/simd/detail/CMakeLists.txt
@@ -1,5 +1,4 @@
-add_subdirectories()
-
 seqan3_test(builtin_simd_test.cpp)
 seqan3_test(default_simd_backend_test.cpp)
 seqan3_test(default_simd_length_builtin_simd_test.cpp)
+seqan3_test(simd_transform_test.cpp)

--- a/test/unit/core/simd/detail/simd_transform_test.cpp
+++ b/test/unit/core/simd/detail/simd_transform_test.cpp
@@ -1,0 +1,189 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2018, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2018, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <seqan3/core/simd/simd.hpp>
+#include <seqan3/core/simd/simd_algorithm.hpp>
+#include <seqan3/test/simd_utility.hpp>
+
+#include <algorithm>
+#include <numeric>
+#include <iostream>
+
+using namespace seqan3;
+
+template <typename simd_t>
+simd_t transform_iota(int offset)
+{
+    return detail::simd_transform<simd_t>([offset] (size_t const i)
+    {
+        return offset + i;
+    });
+}
+
+template <simd_concept simd_t>
+constexpr simd_t transform_iota_constexpr(int offset)
+{
+    return detail::simd_transform_constexpr<simd_t>([offset] (size_t const i)
+    {
+        return offset + i;
+    });
+}
+
+TEST(simd_transform_constexpr, nullary_iota)
+{
+    using simd_type = simd_type_t<int16_t, 8>;
+    constexpr size_t length = simd_traits<simd_type>::length;
+
+    constexpr simd_type result = transform_iota_constexpr<simd_type>(4);
+
+    simd_type expect{};
+    for (size_t i = 0; i < length; ++i)
+        expect[i] = 4 + i;
+
+    SIMD_EQ(result, expect);
+}
+
+#ifndef __clang__
+TEST(simd_transform_constexpr, unary_add)
+{
+    using simd_type = simd_type_t<int16_t, 8>;
+    constexpr size_t length = simd_traits<simd_type>::length;
+
+    constexpr simd_type four_iota = transform_iota_constexpr<simd_type>(4);
+    constexpr simd_type result = detail::simd_transform_constexpr<simd_type>([] (size_t, auto four_iota_i)
+    {
+        return four_iota_i + 6;
+    }, four_iota);
+
+    simd_type expect{};
+    for (size_t i = 0; i < length; ++i)
+        expect[i] = i + 4 + 6;
+
+    SIMD_EQ(result, expect);
+}
+
+TEST(simd_transform_constexpr, binary_multiply)
+{
+    using simd_type = simd_type_t<int16_t, 8>;
+    constexpr size_t length = simd_traits<simd_type>::length;
+
+    constexpr simd_type four_iota = transform_iota_constexpr<simd_type>(4);
+    constexpr simd_type two_iota = transform_iota_constexpr<simd_type>(2);
+    constexpr simd_type result = detail::simd_transform_constexpr<simd_type>([] (size_t, auto four_iota_i, auto two_iota_i)
+    {
+        return four_iota_i * two_iota_i;
+    }, four_iota, two_iota);
+
+    simd_type expect{};
+    for (size_t i = 0; i < length; ++i)
+        expect[i] = (i + 4) * (i + 2);
+
+    SIMD_EQ(result, expect);
+}
+
+TEST(simd_transform_constexpr, ternary_blend)
+{
+    using simd_type = simd_type_t<int16_t, 8>;
+    using mask_type = typename simd_traits<simd_type>::mask_type;
+    constexpr size_t length = simd_traits<simd_type>::length;
+
+    constexpr simd_type four_iota = transform_iota_constexpr<simd_type>(4);
+    constexpr simd_type two_iota = transform_iota_constexpr<simd_type>(2);
+    constexpr mask_type mask = detail::simd_transform_constexpr<mask_type>([] (size_t i)
+    {
+        return (i % 3);
+    });
+
+    constexpr simd_type result = detail::simd_transform_constexpr<simd_type>([] (size_t, auto four_iota_i, auto two_iota_i, auto mask_i)
+    {
+        return mask_i ? four_iota_i : two_iota_i;
+    }, four_iota, two_iota, mask);
+
+    simd_type expect{};
+    for (size_t i = 0; i < length; ++i)
+        expect[i] = (i % 3) ? (i + 4) : (i + 2);
+
+    SIMD_EQ(result, expect);
+}
+#endif
+
+TEST(simd_transform, nullary_iota)
+{
+    using simd_type = simd_type_t<int16_t, 8>;
+    constexpr size_t length = simd_traits<simd_type>::length;
+
+    simd_type result = transform_iota<simd_type>(4);
+    simd_type expect{};
+    for (size_t i = 0; i < length; ++i)
+        expect[i] = 4 + i;
+
+    SIMD_EQ(result, expect);
+}
+
+TEST(simd_transform, unary_add)
+{
+    using simd_type = simd_type_t<int16_t, 8>;
+    constexpr size_t length = simd_traits<simd_type>::length;
+
+    simd_type four_iota = transform_iota<simd_type>(4);
+    simd_type result = detail::simd_transform<simd_type>([] (size_t, auto four_iota_i)
+    {
+        return four_iota_i + 6;
+    }, four_iota);
+
+    simd_type expect{};
+    for (size_t i = 0; i < length; ++i)
+        expect[i] = i + 4 + 6;
+
+    SIMD_EQ(result, expect);
+}
+
+TEST(simd_transform, binary_multiply)
+{
+    using simd_type = simd_type_t<int16_t, 8>;
+    constexpr size_t length = simd_traits<simd_type>::length;
+
+    simd_type four_iota = transform_iota<simd_type>(4);
+    simd_type two_iota = transform_iota<simd_type>(2);
+    simd_type result = detail::simd_transform<simd_type>([] (size_t, auto four_iota_i, auto two_iota_i)
+    {
+        return four_iota_i * two_iota_i;
+    }, four_iota, two_iota);
+
+    simd_type expect{};
+    for (size_t i = 0; i < length; ++i)
+        expect[i] = (i + 4) * (i + 2);
+
+    SIMD_EQ(result, expect);
+}
+
+TEST(simd_transform, ternary_blend)
+{
+    using simd_type = simd_type_t<int16_t, 8>;
+    using mask_type = typename simd_traits<simd_type>::mask_type;
+    constexpr size_t length = simd_traits<simd_type>::length;
+
+    simd_type four_iota = transform_iota<simd_type>(4);
+    simd_type two_iota = transform_iota<simd_type>(2);
+    mask_type mask = detail::simd_transform<mask_type>([] (size_t i)
+    {
+        return (i % 3);
+    });
+
+    simd_type result = detail::simd_transform<simd_type>([] (size_t, auto four_iota_i, auto two_iota_i, auto mask_i)
+    {
+        return mask_i ? four_iota_i : two_iota_i;
+    }, four_iota, two_iota, mask);
+
+    simd_type expect{};
+    for (size_t i = 0; i < length; ++i)
+        expect[i] = (i % 3) ? (i + 4) : (i + 2);
+
+    SIMD_EQ(result, expect);
+}

--- a/test/unit/core/simd/simd_algorithm_test.cpp
+++ b/test/unit/core/simd/simd_algorithm_test.cpp
@@ -46,11 +46,11 @@ TEST(simd_algorithm, fill)
 {
     using simd_type = simd_type_t<int16_t, 8>;
 
-    simd_type expect{};
-    for (size_t i = 0; i < simd_traits<simd_type>::length; ++i)
-        expect[i] = 4;
-
-    constexpr simd_type result = fill<simd_type>(4);
+    constexpr simd_type result = simd::fill<simd_type>(4);
+    simd_type expect = detail::simd_transform<simd_type>([](size_t)
+    {
+        return 4;
+    });
     SIMD_EQ(result, expect);
 }
 
@@ -58,10 +58,22 @@ TEST(simd_algorithm, iota)
 {
     using simd_type = simd_type_t<int16_t, 8>;
 
-    simd_type expect{};
-    for (size_t i = 0; i < simd_traits<simd_type>::length; ++i)
-        expect[i] = i;
+    constexpr simd_type result = simd::iota<simd_type>(0);
+    simd_type expect = detail::simd_transform<simd_type>([i = 0](size_t) mutable
+    {
+        return i++;
+    });
+    SIMD_EQ(result, expect);
+}
 
-    constexpr simd_type result = iota<simd_type>(0);
+TEST(simd_algorithm, iota_with_offset)
+{
+    using simd_type = simd_type_t<int16_t, 8>;
+
+    constexpr simd_type result = simd::iota<simd_type>(5);
+    simd_type expect = detail::simd_transform<simd_type>([](size_t i)
+    {
+        return 5 + i;
+    });
     SIMD_EQ(result, expect);
 }


### PR DESCRIPTION
This introduces `seqan3::detail::simd_transform`, which will help in testing and auto-vectorizing simd instructions.

```c++
using simd_type = seqan3::simd::simd_type_t<uint16_t, 8>;
using scalar_t = typename seqan3::simd::simd_traits<simd_type>::scalar_type; // same as uint16_t

auto iota = [i = scalar_t{0}] (size_t) mutable
{
    return i++;
};

simd_type result = seqan3::detail::simd_transform<simd_type>(iota);

// same as
result = simd_type
{
    iota(0),
    iota(1),
    iota(2),
    // ...
    iota(7)
};
```