### PR TITLE
[FIX] minor fixes to view::persist

### DIFF
--- a/include/seqan3/range/view/persist.hpp
+++ b/include/seqan3/range/view/persist.hpp
@@ -84,8 +84,8 @@ public:
      */
     //!\brief The reference_type.
     using reference         = reference_t<urng_t>;
-    //!\brief The const_reference type is equal to the reference type if the underlying range is const-iterable.
-    using const_reference   = std::conditional_t<const_iterable_concept<urng_t>, reference, void>;
+    //!\brief The const_reference type is equal to the reference type.
+    using const_reference   = reference;
     //!\brief The value_type (which equals the reference_type with any references removed).
     using value_type        = value_type_t<urng_t>;
     //!\brief If the underliying range is Sized, this resolves to range_type::size_type, otherwise void.
@@ -94,8 +94,8 @@ public:
     using difference_type   = difference_type_t<urng_t>;
     //!\brief The iterator type of this view (a random access iterator).
     using iterator          = std::ranges::iterator_t<urng_t>;
-    //!\brief The const_iterator type is equal to the iterator type if the underlying range is const-iterable.
-    using const_iterator    = std::conditional_t<const_iterable_concept<urng_t>, iterator, void>;
+    //!\brief The const_iterator type is equal to the iterator type.
+    using const_iterator    = iterator;
     //!\}
 
     /*!\name Constructors, destructor and assignment
@@ -132,23 +132,15 @@ public:
      *
      * No-throw guarantee.
      */
-    iterator begin() noexcept
-    {
-        return seqan3::begin(*urange);
-    }
-
-    //!\copydoc begin()
     const_iterator begin() const noexcept
-        requires const_iterable_concept<urng_t>
     {
         return seqan3::begin(*urange);
     }
 
     //!\copydoc begin()
     const_iterator cbegin() const noexcept
-        requires const_iterable_concept<urng_t>
     {
-        return seqan3::begin(*urange);
+        return begin();
     }
 
     /*!\brief Returns an iterator to the element following the last element of the range.
@@ -164,23 +156,15 @@ public:
      *
      * No-throw guarantee.
      */
-    auto end() noexcept
-    {
-        return seqan3::end(*urange);
-    }
-
-    //!\copydoc end()
     auto end() const noexcept
-        requires const_iterable_concept<urng_t>
     {
         return seqan3::end(*urange);
     }
 
     //!\copydoc end()
     auto cend() const noexcept
-        requires const_iterable_concept<urng_t>
     {
-        return seqan3::end(*urange);
+        return end();
     }
     //!\}
 
@@ -189,18 +173,6 @@ public:
      *                     seqan3::reference_t of both must model std::CommonReference.
      * \returns This view converted to container_t.
      */
-    template <sequence_container_concept container_t>
-    operator container_t()
-    //!\cond
-        requires std::CommonReference<reference_t<container_t>, reference>
-    //!\endcond
-    {
-        container_t ret;
-        std::ranges::copy(begin(), end(), std::back_inserter(ret));
-        return ret;
-    }
-
-    //!\overload
     template <sequence_container_concept container_t>
     operator container_t() const
     //!\cond
@@ -216,7 +188,7 @@ public:
 //!\brief Template argument type deduction guide that strips references.
 //!\relates seqan3::detail::view_persist
 template <typename urng_t>
-view_persist(urng_t const &) -> view_persist<std::remove_reference_t<urng_t>>;
+view_persist(urng_t &&) -> view_persist<std::remove_reference_t<urng_t>>;
 
 // ============================================================================
 //  persist_fn (adaptor definition)


### PR DESCRIPTION
Since we are always delegating to the underlying range's non-const iterator/sentinel, we don't need to check for const-iterability.