### PR TITLE
[FIX] Include platform.hpp in span.hpp

### DIFF
--- a/include/seqan3/std/span.hpp
+++ b/include/seqan3/std/span.hpp
@@ -22,6 +22,8 @@
 #include <iterator>     // for iterators
 #include <type_traits>  // for remove_cv, etc
 
+#include <seqan3/core/platform.hpp>
+
 #if __has_include(<span>)
 #include <span>
 #else


### PR DESCRIPTION
Fixes

```
[ 28%] Building CXX object CMakeFiles/seqan3_header_seqan3_std_span_2.dir/header_test_src/seqan3_std_span_2.cpp.o
/home/travis/build/seqan/seqan3-build/header_test_src/seqan3_std_span_2.cpp:7:2: error: #error "Your header file is missing #include<seqan3/core/platform.hpp>"
 #error "Your header file is missing #include<seqan3/core/platform.hpp>"
  ^~~~~
CMakeFiles/seqan3_header_seqan3_std_span_2.dir/build.make:62: recipe for target 'CMakeFiles/seqan3_header_seqan3_std_span_2.dir/header_test_src/seqan3_std_span_2.cpp.o' failed
make[2]: *** [CMakeFiles/seqan3_header_seqan3_std_span_2.dir/header_test_src/seqan3_std_span_2.cpp.o] Error 1
make[2]: Target 'CMakeFiles/seqan3_header_seqan3_std_span_2.dir/build' not remade because of errors.
CMakeFiles/Makefile2:9132: recipe for target 'CMakeFiles/seqan3_header_seqan3_std_span_2.dir/all' failed
make[1]: *** [CMakeFiles/seqan3_header_seqan3_std_span_2.dir/all] Error 2
```