### PR TITLE
[FEATURE] Char literals for structure alphabets

### DIFF
--- a/include/seqan3/alphabet/structure/dot_bracket3.hpp
+++ b/include/seqan3/alphabet/structure/dot_bracket3.hpp
@@ -70,7 +70,7 @@ namespace seqan3
  *```
  *
  * \par Usage
- * The following code example creates a dot_bracket3 vector, modifies it, and prints the result to stdout.
+ * The following code example creates a dot_bracket3 vector, modifies it, and prints the result to stderr.
  * \snippet test/snippet/alphabet/structure/dot_bracket3.cpp general
  */
 class dot_bracket3 : public alphabet_base<dot_bracket3, 3>
@@ -94,17 +94,6 @@ public:
     ~dot_bracket3() = default;
     //!\}
 
-    /*!\name Letter values
-     * \brief Static member "letters" that can be assigned to the alphabet or used in aggregate initialization.
-     * \details Similar to an Enum interface. *Don't worry about the `internal_type`.*
-     */
-    //!\{
-    static const dot_bracket3 UNPAIRED;
-    static const dot_bracket3 PAIR_OPEN;
-    static const dot_bracket3 PAIR_CLOSE;
-    static const dot_bracket3 UNKNOWN;
-    //!\}
-
     //!\name RNA structure properties
     //!\{
 
@@ -113,7 +102,7 @@ public:
      */
     constexpr bool is_pair_open() const noexcept
     {
-        return *this == PAIR_OPEN;
+        return this->to_char() == '(';
     }
 
     /*!\brief Check whether the character represents a leftward interaction in an RNA structure.
@@ -121,7 +110,7 @@ public:
      */
     constexpr bool is_pair_close() const noexcept
     {
-        return *this == PAIR_CLOSE;
+        return this->to_char() == ')';
     }
 
     /*!\brief Check whether the character represents an unpaired position in an RNA structure.
@@ -129,7 +118,7 @@ public:
      */
     constexpr bool is_unpaired() const noexcept
     {
-        return *this == UNPAIRED;
+        return this->to_char() == '.';
     }
 
     /*!\brief The ability of this alphabet to represent pseudoknots, i.e. crossing interactions, up to a certain depth.
@@ -171,31 +160,17 @@ protected:
     };
 };
 
-constexpr dot_bracket3 dot_bracket3::UNPAIRED   = dot_bracket3{}.assign_char('.');
-constexpr dot_bracket3 dot_bracket3::PAIR_OPEN  = dot_bracket3{}.assign_char('(');
-constexpr dot_bracket3 dot_bracket3::PAIR_CLOSE = dot_bracket3{}.assign_char(')');
-constexpr dot_bracket3 dot_bracket3::UNKNOWN    = dot_bracket3::UNPAIRED;
-
-} // namespace seqan3
-
-// ------------------------------------------------------------------
-// literals
-// ------------------------------------------------------------------
-
-namespace seqan3
-{
-
-/*!\brief dot_bracket3 literal
+/*!\name Literals
+ * \{
+ *
+ * \brief The seqan3::db3 string literal.
  * \relates seqan3::dot_bracket3
+ * \param[in] str A pointer to the character string to assign.
+ * \param[in] len The size of the character string to assign.
  * \returns std::vector<seqan3::dot_bracket3>
  *
- * You can use this string literal to easily assign to a vector of dot_bracket3 characters:
- *
- *```.cpp
- *     std::vector<dot_bracket3> foo{".(..)."_db3};
- *     std::vector<dot_bracket3> bar = ".(..)."_db3;
- *     auto bax = ".(..)."_db3;
- *```
+ * You can use this string literal to easily assign to a vector of seqan3::dot_bracket3 characters:
+ * \snippet test/snippet/alphabet/structure/dot_bracket3.cpp string_literal
  */
 inline std::vector<dot_bracket3> operator""_db3(const char * str, std::size_t len)
 {
@@ -207,5 +182,21 @@ inline std::vector<dot_bracket3> operator""_db3(const char * str, std::size_t le
 
     return vec;
 }
+
+/*!
+ * \brief The seqan3::db3 char literal.
+ * \relates seqan3::dot_bracket3
+ * \param[in] ch The character to represent as dot bracket.
+ * \returns seqan3::dot_bracket3
+ *
+ * You can use this string literal to assign a seqan3::dot_bracket3 character:
+ * \snippet test/snippet/alphabet/structure/dot_bracket3.cpp char_literal
+ */
+constexpr dot_bracket3 operator""_db3(char const ch) noexcept
+{
+    return dot_bracket3{}.assign_char(ch);
+}
+
+//!\}
 
 } // namespace seqan3

--- a/include/seqan3/alphabet/structure/dot_bracket3.hpp
+++ b/include/seqan3/alphabet/structure/dot_bracket3.hpp
@@ -102,7 +102,7 @@ public:
      */
     constexpr bool is_pair_open() const noexcept
     {
-        return this->to_char() == '(';
+        return rank == 1u;
     }
 
     /*!\brief Check whether the character represents a leftward interaction in an RNA structure.
@@ -110,7 +110,7 @@ public:
      */
     constexpr bool is_pair_close() const noexcept
     {
-        return this->to_char() == ')';
+        return rank == 2u;
     }
 
     /*!\brief Check whether the character represents an unpaired position in an RNA structure.
@@ -118,14 +118,14 @@ public:
      */
     constexpr bool is_unpaired() const noexcept
     {
-        return this->to_char() == '.';
+        return rank == 0u;
     }
 
     /*!\brief The ability of this alphabet to represent pseudoknots, i.e. crossing interactions, up to a certain depth.
      * \details It is the number of distinct pairs of interaction symbols the format supports. The value 1 denotes no
      * pseudoknot support.
      */
-    static constexpr uint8_t max_pseudoknot_depth{1};
+    static constexpr uint8_t max_pseudoknot_depth{1u};
     //!\}
 
 protected:
@@ -146,14 +146,14 @@ protected:
         {
             std::array<rank_type, 256> rank_table{};
 
-            // initialize with UNKNOWN (std::array::fill unfortunately not constexpr)
+            // initialize with unpaired (std::array::fill unfortunately not constexpr)
             for (rank_type & rnk : rank_table)
-                rnk = 0;
+                rnk = 0u;
 
             // canonical
-            rank_table['.'] = 0;
-            rank_table['('] = 1;
-            rank_table[')'] = 2;
+            rank_table['.'] = 0u;
+            rank_table['('] = 1u;
+            rank_table[')'] = 2u;
 
             return rank_table;
         } ()
@@ -177,14 +177,13 @@ inline std::vector<dot_bracket3> operator""_db3(const char * str, std::size_t le
     std::vector<dot_bracket3> vec;
     vec.resize(len);
 
-    for (size_t idx = 0u; idx < len; ++idx)
+    for (size_t idx = 0ul; idx < len; ++idx)
         vec[idx].assign_char(str[idx]);
 
     return vec;
 }
 
-/*!
- * \brief The seqan3::db3 char literal.
+/*!\brief The seqan3::db3 char literal.
  * \relates seqan3::dot_bracket3
  * \param[in] ch The character to represent as dot bracket.
  * \returns seqan3::dot_bracket3

--- a/include/seqan3/alphabet/structure/dssp9.hpp
+++ b/include/seqan3/alphabet/structure/dssp9.hpp
@@ -79,7 +79,7 @@ namespace seqan3
  * X = unknown
  *
  * \par Usage
- * The following code example creates a dssp9 vector, modifies it, and prints the result to stdout.
+ * The following code example creates a dssp9 vector, modifies it, and prints the result to stderr.
  * \snippet test/snippet/alphabet/structure/dssp9.cpp general
  */
 class dssp9 : public alphabet_base<dssp9, 9>
@@ -101,22 +101,6 @@ public:
     constexpr dssp9 & operator=(dssp9 const &) = default;
     constexpr dssp9 & operator=(dssp9 &&) = default;
     ~dssp9() = default;
-    //!\}
-
-    /*!\name Letter values
-     * \brief Static member "letters" that can be assigned to the alphabet or used in aggregate initialization.
-     * \details Similar to an Enum interface. *Don't worry about the `internal_type`.*
-     */
-    //!\{
-    static const dssp9 H;
-    static const dssp9 B;
-    static const dssp9 E;
-    static const dssp9 G;
-    static const dssp9 I;
-    static const dssp9 T;
-    static const dssp9 S;
-    static const dssp9 C;
-    static const dssp9 X;
     //!\}
 
 protected:
@@ -150,36 +134,17 @@ protected:
     };
 };
 
-constexpr dssp9 dssp9::H = dssp9{}.assign_char('H');
-constexpr dssp9 dssp9::B = dssp9{}.assign_char('B');
-constexpr dssp9 dssp9::E = dssp9{}.assign_char('E');
-constexpr dssp9 dssp9::G = dssp9{}.assign_char('G');
-constexpr dssp9 dssp9::I = dssp9{}.assign_char('I');
-constexpr dssp9 dssp9::T = dssp9{}.assign_char('T');
-constexpr dssp9 dssp9::S = dssp9{}.assign_char('S');
-constexpr dssp9 dssp9::C = dssp9{}.assign_char('C');
-constexpr dssp9 dssp9::X = dssp9{}.assign_char('X');
-
-} // namespace seqan3
-
-// ------------------------------------------------------------------
-// literals
-// ------------------------------------------------------------------
-
-namespace seqan3
-{
-
-/*!\brief dssp9 literal
+/*!\name Literals
+ * \{
+ *
+ * \brief The seqan3::dssp9 string literal.
  * \relates seqan3::dssp9
+ * \param[in] str A pointer to the character string to assign.
+ * \param[in] len The size of the character string to assign.
  * \returns std::vector<seqan3::dssp9>
  *
- * You can use this string literal to easily assign to a vector of dssp9 characters:
- *
- *```.cpp
- *     std::vector<dssp9> foo{"EHHHHT"_dssp9};
- *     std::vector<dssp9> bar = "EHHHHT"_dssp9;
- *     auto bax = "EHHHHT"_dssp9;
- *```
+ * You can use this string literal to easily assign to a vector of seqan3::dssp9 characters:
+ * \snippet test/snippet/alphabet/structure/dssp9.cpp string_literal
  */
 inline std::vector<dssp9> operator""_dssp9(const char * str, std::size_t len)
 {
@@ -191,5 +156,21 @@ inline std::vector<dssp9> operator""_dssp9(const char * str, std::size_t len)
 
     return vec;
 }
+
+/*!
+ * \brief The seqan3::dssp9 char literal.
+ * \relates seqan3::dssp9
+ * \param[in] ch The character to represent as dssp.
+ * \returns seqan3::dssp9
+ *
+ * You can use this string literal to assign a seqan3::dssp9 character:
+ * \snippet test/snippet/alphabet/structure/dssp9.cpp char_literal
+ */
+constexpr dssp9 operator""_dssp9(char const ch) noexcept
+{
+    return dssp9{}.assign_char(ch);
+}
+
+//!\}
 
 } // namespace seqan3

--- a/include/seqan3/alphabet/structure/dssp9.hpp
+++ b/include/seqan3/alphabet/structure/dssp9.hpp
@@ -121,7 +121,7 @@ protected:
 
             // initialize with X (std::array::fill unfortunately not constexpr)
             for (rank_type & rnk : ret)
-                rnk = 8;
+                rnk = 8u;
 
             // reverse mapping for characters
             for (rank_type rnk = 0u; rnk < value_size; ++rnk)
@@ -157,8 +157,7 @@ inline std::vector<dssp9> operator""_dssp9(const char * str, std::size_t len)
     return vec;
 }
 
-/*!
- * \brief The seqan3::dssp9 char literal.
+/*!\brief The seqan3::dssp9 char literal.
  * \relates seqan3::dssp9
  * \param[in] ch The character to represent as dssp.
  * \returns seqan3::dssp9

--- a/include/seqan3/alphabet/structure/wuss.hpp
+++ b/include/seqan3/alphabet/structure/wuss.hpp
@@ -75,7 +75,7 @@ namespace seqan3
  *```
  *
  * \par Usage
- * The following code example creates a wuss vector, modifies it, and prints the result to stdout.
+ * The following code example creates a wuss vector, modifies it, and prints the result to stderr.
  * \snippet test/snippet/alphabet/structure/wuss.cpp general
  */
 template <uint8_t SIZE = 51>
@@ -109,52 +109,10 @@ public:
     ~wuss() = default;
     //!\}
 
-    /*!\name Letter values
-     * \brief Static member "letters" that can be assigned to the alphabet or used in aggregate initialization.
-     * \details Similar to an Enum interface. *Don't worry about the `internal_type`.*
-     * The pseudoknot letters are not accessible in this way, please use the string literals.
-     */
-    //!\{
-
-    //!\brief `.` not paired (insertion to known structure)
-    static this_type_deferred constexpr UNPAIRED  = this_type_deferred{}.assign_char('.');
-    //!\brief `:` not paired (external residue outside structure)
-    static this_type_deferred constexpr UNPAIRED1 = this_type_deferred{}.assign_char(':');
-    //!\brief `,` not paired (multifurcation loop)
-    static this_type_deferred constexpr UNPAIRED2 = this_type_deferred{}.assign_char(',');
-    //!\brief `-` not paired (bulge, interior loop)
-    static this_type_deferred constexpr UNPAIRED3 = this_type_deferred{}.assign_char('-');
-    //!\brief `_` not paired (hairpin loop)
-    static this_type_deferred constexpr UNPAIRED4 = this_type_deferred{}.assign_char('_');
-    //!\brief `~` not paired (due to local alignment)
-    static this_type_deferred constexpr UNPAIRED5 = this_type_deferred{}.assign_char('~');
-    //!\brief `;` not paired
-    static this_type_deferred constexpr UNPAIRED6 = this_type_deferred{}.assign_char(';');
-
-    //!\brief `<` bracket left (simple terminal stem)
-    static this_type_deferred constexpr PAIR_OPEN   = this_type_deferred{}.assign_char('<');
-    //!\brief `(` bracket left (internal helix enclosing `<>`)
-    static this_type_deferred constexpr PAIR_OPEN1  = this_type_deferred{}.assign_char('(');
-    //!\brief `[` bracket left (internal helix enclosing `()`)
-    static this_type_deferred constexpr PAIR_OPEN2  = this_type_deferred{}.assign_char('[');
-    //!\brief `{` bracket left (internal helix enclosing `[]`)
-    static this_type_deferred constexpr PAIR_OPEN3  = this_type_deferred{}.assign_char('{');
-
-    //!\brief `>` bracket right (simple terminal stem)
-    static this_type_deferred constexpr PAIR_CLOSE  = this_type_deferred{}.assign_char('>');
-    //!\brief `)` bracket right (internal helix enclosing `<>`)
-    static this_type_deferred constexpr PAIR_CLOSE1 = this_type_deferred{}.assign_char(')');
-    //!\brief `]` bracket right (internal helix enclosing `()`)
-    static this_type_deferred constexpr PAIR_CLOSE2 = this_type_deferred{}.assign_char(']');
-    //!\brief `}` bracket right (internal helix enclosing `[]`)
-    static this_type_deferred constexpr PAIR_CLOSE3 = this_type_deferred{}.assign_char('}');
-    // pseudoknots not accessible
-    //!\}
-
-    //!\name RNA structure properties
-    //!\{
-
-    /*!\brief Check whether the character represents a rightward interaction in an RNA structure.
+    /*!\name RNA structure properties
+     * \{
+     *
+     *!\brief Check whether the character represents a rightward interaction in an RNA structure.
      * \returns True if the letter represents a rightward interaction, False otherwise.
      */
     constexpr bool is_pair_open() const noexcept
@@ -182,7 +140,7 @@ public:
      *        It is the number of distinct pairs of interaction symbols the format supports: 4..30 (depends on size)
      */
     // formula: (alphabet size - 7 unpaired characters) / 2, as every bracket exists as opening/closing pair
-    static constexpr uint8_t max_pseudoknot_depth{(value_size - 7) / 2};
+    static constexpr uint8_t max_pseudoknot_depth{uint8_t{(value_size - 7) / 2}};
 
     /*!\brief Get an identifier for a pseudoknotted interaction.
      * Opening and closing brackets of the same type have the same id.
@@ -231,7 +189,7 @@ protected:
 
             // initialize with unpaired (std::array::fill unfortunately not constexpr)
             for (rank_type & rnk : rank_table)
-                rnk = 6; // ::UNPAIRED6;
+                rnk = 6;
 
             // set alphabet values
             for (rank_type rnk = 0u; rnk < value_size; ++rnk)
@@ -251,22 +209,22 @@ constexpr std::array<int8_t, SIZE> wuss<SIZE>::interaction_tab = [] () constexpr
     int cnt_open = 0;
     int cnt_close = 0;
 
-    for (rank_type rnk = UNPAIRED.to_rank();
-            rnk <= UNPAIRED6.to_rank();
+    for (rank_type rnk = wuss<SIZE>{}.assign_char('.').to_rank();
+            rnk <= wuss<SIZE>{}.assign_char(';').to_rank();
             ++rnk)
     {
         interaction_table[rnk] = 0;
     }
 
-    for (rank_type rnk = PAIR_OPEN.to_rank();
-            rnk <= PAIR_OPEN3.to_rank();
+    for (rank_type rnk = wuss<SIZE>{}.assign_char('<').to_rank();
+            rnk <= wuss<SIZE>{}.assign_char('{').to_rank();
             ++rnk)
     {
         interaction_table[rnk] = --cnt_open;
     }
 
-    for (rank_type rnk = PAIR_CLOSE.to_rank();
-            rnk <= PAIR_CLOSE3.to_rank();
+    for (rank_type rnk = wuss<SIZE>{}.assign_char('>').to_rank();
+            rnk <= wuss<SIZE>{}.assign_char('}').to_rank();
             ++rnk)
     {
         interaction_table[rnk] = ++cnt_close;
@@ -284,26 +242,17 @@ constexpr std::array<int8_t, SIZE> wuss<SIZE>::interaction_tab = [] () constexpr
 //!\brief Alias for the default type wuss51.
 typedef wuss<51> wuss51;
 
-} // namespace seqan3
-
-// ------------------------------------------------------------------
-// literals
-// ------------------------------------------------------------------
-
-namespace seqan3
-{
-
-/*!\brief wuss literal
+/*!\name Literals
+ * \{
+ *
+ * \brief The seqan3::wuss51 string literal.
  * \relates seqan3::wuss
+ * \param[in] str A pointer to the character string to assign.
+ * \param[in] len The size of the character string to assign.
  * \returns std::vector<seqan3::wuss51>
  *
- * You can use this string literal to easily assign to a vector of wuss characters:
- *
- *```.cpp
- *     std::vector<wuss<>> foo{".<..>."_wuss51};
- *     std::vector<wuss<>> bar = ".<..>."_wuss51;
- *     auto bax = ".<..>."_wuss51;
- *```
+ * You can use this string literal to easily assign to a vector of seqan3::wuss51 characters:
+ * \snippet test/snippet/alphabet/structure/wuss.cpp string_literal
  */
 inline std::vector<wuss51> operator""_wuss51(const char * str, std::size_t len)
 {
@@ -315,5 +264,22 @@ inline std::vector<wuss51> operator""_wuss51(const char * str, std::size_t len)
 
     return vec;
 }
+
+/*!
+ * \brief The seqan3::wuss51 char literal.
+ * \relates seqan3::wuss
+ * \param[in] ch The character to represent as wuss.
+ * \returns seqan3::wuss51
+ *
+ * You can use this string literal to assign a seqan3::wuss51 character.
+ * For different wuss alphabet sizes the `assign_char` function must be used.
+ * \snippet test/snippet/alphabet/structure/wuss.cpp char_literal
+ */
+constexpr wuss51 operator""_wuss51(char const ch) noexcept
+{
+    return wuss51{}.assign_char(ch);
+}
+
+//!\}
 
 } // namespace seqan3

--- a/test/snippet/alphabet/structure/dot_bracket3.cpp
+++ b/test/snippet/alphabet/structure/dot_bracket3.cpp
@@ -7,11 +7,26 @@ int main()
 {
 //! [general]
 // create vector
-std::vector<dot_bracket3> vec{dot_bracket3::UNPAIRED, dot_bracket3::PAIR_CLOSE, dot_bracket3::PAIR_CLOSE};
+std::vector<dot_bracket3> vec{'.'_db3, ')'_db3, ')'_db3};
 // modify and print
-vec[1] = dot_bracket3::PAIR_OPEN;
+vec[1] = '('_db3;
 for (dot_bracket3 chr : vec)
     debug_stream << to_char(chr);  // .()
 debug_stream << "\n";
 //! [general]
+
+//! [string_literal]
+std::vector<dot_bracket3> foo{".(..)."_db3};
+std::vector<dot_bracket3> bar = ".(..)."_db3;
+auto bax = ".(..)."_db3;
+//! [string_literal]
+
+//! [char_literal]
+dot_bracket3 my_letter{'('_db3};
+
+// does not work:
+// dot_bracket3 my_letter{'('}; // <- char not implicitly convertible
+
+my_letter.assign_char(')'); // <- assigns the char explicitly
+//! [char_literal]
 }

--- a/test/snippet/alphabet/structure/dssp9.cpp
+++ b/test/snippet/alphabet/structure/dssp9.cpp
@@ -7,11 +7,27 @@ int main()
 {
 //! [general]
 // create vector
-std::vector<dssp9> vec{dssp9::E, dssp9::H, dssp9::H, dssp9::H, dssp9::T, dssp9::G};
+std::vector<dssp9> vec{'E'_dssp9, 'H'_dssp9, 'H'_dssp9, 'H'_dssp9, 'T'_dssp9, 'G'_dssp9};
 // modify and print
-vec[1] = dssp9::C;
+vec[1] = 'C'_dssp9;
 for (dssp9 chr : vec)
     debug_stream << to_char(chr);  // ECHHTG
 debug_stream << "\n";
 //! [general]
+
+//! [string_literal]
+std::vector<dssp9> foo{"EHHHHT"_dssp9};
+std::vector<dssp9> bar = "EHHHHT"_dssp9;
+auto bax = "EHHHHT"_dssp9;
+//! [string_literal]
+
+
+//! [char_literal]
+dssp9 my_letter{'I'_dssp9};
+
+// does not work:
+// dssp9 my_letter{'I'}; // <- char not implicitly convertible
+
+my_letter.assign_char('G'); // <- assigns the char explicitly
+//! [char_literal]
 }

--- a/test/snippet/alphabet/structure/structured_aa.cpp
+++ b/test/snippet/alphabet/structure/structured_aa.cpp
@@ -6,7 +6,7 @@ using namespace seqan3;
 int main()
 {
 //! [general]
-structured_aa<aa27, dssp9> letter{aa27::W, dssp9::B};
+structured_aa<aa27, dssp9> letter{aa27::W, 'B'_dssp9};
 debug_stream << int(to_rank(letter)) << ' '
           << int(to_rank(get<0>(letter))) << ' '
           << int(to_rank(get<1>(letter))) << '\n';

--- a/test/snippet/alphabet/structure/structured_rna.cpp
+++ b/test/snippet/alphabet/structure/structured_rna.cpp
@@ -8,7 +8,7 @@ using namespace seqan3;
 int main()
 {
 //! [general]
-structured_rna<rna4, dot_bracket3> letter{'G'_rna4, dot_bracket3::PAIR_OPEN};
+structured_rna<rna4, dot_bracket3> letter{'G'_rna4, '('_db3};
 debug_stream << int(to_rank(letter)) << ' '
           << int(to_rank(get<0>(letter))) << ' '
           << int(to_rank(get<1>(letter))) << '\n';

--- a/test/snippet/alphabet/structure/wuss.cpp
+++ b/test/snippet/alphabet/structure/wuss.cpp
@@ -7,11 +7,27 @@ int main()
 {
 //! [general]
 // create vector
-std::vector<wuss51> vec{wuss51::UNPAIRED, wuss51::PAIR_CLOSE, wuss51::PAIR_CLOSE};
+std::vector<wuss51> vec{'.'_wuss51, '>'_wuss51, '>'_wuss51};
 // modify and print
-vec[1] = wuss51::PAIR_OPEN;
+vec[1] = '<'_wuss51;
 for (wuss51 chr : vec)
     debug_stream << to_char(chr);  // .<>
 debug_stream << "\n";
 //! [general]
+
+//! [string_literal]
+std::vector<wuss<>> foo{".<..>."_wuss51};
+std::vector<wuss<>> bar = ".<..>."_wuss51;
+auto bax = ".<..>."_wuss51;
+//! [string_literal]
+
+//! [char_literal]
+wuss51 my_letter{'~'_wuss51};
+
+// does not work:
+// wuss51 my_letter{'~'}; // <- char not implicitly convertible
+
+// works for each wuss alphabet size:
+my_letter.assign_char('<'); // <- assigns the char explicitly
+//! [char_literal]
 }

--- a/test/unit/alphabet/composition/cartesian_composition_test.cpp
+++ b/test/unit/alphabet/composition/cartesian_composition_test.cpp
@@ -124,19 +124,18 @@ public:
     }
     dot_bracket3 value_2()
     {
-        return dot_bracket3::PAIR_OPEN;
+        return '('_db3;
     }
     dot_bracket3 assignable_to_value_2()
     {
-        return dot_bracket3::PAIR_OPEN; // replace if assignable subtype becomes available
+        return '('_db3; // replace if assignable subtype becomes available
     }
     auto values_to_cmp()
     {
-        return std::make_tuple(/*low */'A'_rna4, dot_bracket3::UNPAIRED,
-                               /*mid */'C'_rna4, dot_bracket3::PAIR_OPEN,
-                               /*high*/'T'_rna4, dot_bracket3::PAIR_CLOSE);
+        return std::make_tuple(/*low */'A'_rna4, '.'_db3,
+                               /*mid */'C'_rna4, '('_db3,
+                               /*high*/'T'_rna4, ')'_db3);
     }
-
 };
 
 template <>

--- a/test/unit/alphabet/composition/cartesian_composition_test.cpp
+++ b/test/unit/alphabet/composition/cartesian_composition_test.cpp
@@ -160,17 +160,17 @@ public:
     }
     dssp9 value_2()
     {
-        return dssp9::I;
+        return 'I'_dssp9;
     }
     dssp9 assignable_to_value_2()
     {
-        return dssp9::I; // replace if assignable subtype becomes available
+        return 'I'_dssp9; // replace if assignable subtype becomes available
     }
     auto values_to_cmp()
     {
-        return std::make_tuple(/*low */aa27::A, dssp9::H,
-                               /*mid */aa27::P, dssp9::I,
-                               /*high*/aa27::Z, dssp9::X);
+        return std::make_tuple(/*low */aa27::A, 'H'_dssp9,
+                               /*mid */aa27::P, 'I'_dssp9,
+                               /*high*/aa27::Z, 'X'_dssp9);
     }
 };
 

--- a/test/unit/alphabet/structure/dot_bracket3_test.cpp
+++ b/test/unit/alphabet/structure/dot_bracket3_test.cpp
@@ -60,8 +60,7 @@ TEST(dot_bracket3, literals)
     vec1.resize(5, '('_db3);
     EXPECT_EQ(vec1, "((((("_db3);
 
-    std::vector<dot_bracket3> vec2{'.'_db3, '('_db3, '('_db3,
-                                   ')'_db3, ')'_db3, '.'_db3};
+    std::vector<dot_bracket3> vec2{'.'_db3, '('_db3, '('_db3, ')'_db3, ')'_db3, '.'_db3};
     EXPECT_EQ(vec2, ".(())."_db3);
 }
 

--- a/test/unit/alphabet/structure/dot_bracket3_test.cpp
+++ b/test/unit/alphabet/structure/dot_bracket3_test.cpp
@@ -18,7 +18,6 @@ INSTANTIATE_TYPED_TEST_CASE_P(dot_bracket3, alphabet_constexpr, dot_bracket3);
 // assign_char functions
 TEST(dot_bracket3, assign_char)
 {
-    using t = dot_bracket3;
     std::vector<char> input
     {
         '.', '(', ')',
@@ -29,10 +28,10 @@ TEST(dot_bracket3, assign_char)
 
     std::vector<dot_bracket3> cmp
     {
-        t::UNPAIRED, t::PAIR_OPEN, t::PAIR_CLOSE,
-        t::UNKNOWN, t::UNKNOWN, t::UNKNOWN, t::UNKNOWN, t::UNKNOWN, t::UNKNOWN,
-        t::UNKNOWN, t::UNKNOWN, t::UNKNOWN, t::UNKNOWN, t::UNKNOWN, t::UNKNOWN,
-        t::UNKNOWN, t::UNKNOWN, t::UNKNOWN, t::UNKNOWN, t::UNKNOWN, t::UNKNOWN, t::UNKNOWN
+        '.'_db3, '('_db3, ')'_db3,
+        '.'_db3, '.'_db3, '.'_db3, '.'_db3, '.'_db3, '.'_db3,
+        '.'_db3, '.'_db3, '.'_db3, '.'_db3, '.'_db3, '.'_db3,
+        '.'_db3, '.'_db3, '.'_db3, '.'_db3, '.'_db3, '.'_db3, '.'_db3
     };
 
     for (auto [ ch, cm ] : ranges::view::zip(input, cmp))
@@ -42,10 +41,9 @@ TEST(dot_bracket3, assign_char)
 // to_char functions
 TEST(dot_bracket3, to_char)
 {
-    EXPECT_EQ(to_char(dot_bracket3::UNPAIRED), '.');
-    EXPECT_EQ(to_char(dot_bracket3::PAIR_OPEN), '(');
-    EXPECT_EQ(to_char(dot_bracket3::PAIR_CLOSE), ')');
-    EXPECT_EQ(to_char(dot_bracket3::UNKNOWN), '.');
+    EXPECT_EQ(to_char('.'_db3), '.');
+    EXPECT_EQ(to_char('('_db3), '(');
+    EXPECT_EQ(to_char(')'_db3), ')');
 }
 
 // concepts
@@ -59,19 +57,19 @@ TEST(dot_bracket3, literals)
 {
 
     std::vector<dot_bracket3> vec1;
-    vec1.resize(5, dot_bracket3::PAIR_OPEN);
+    vec1.resize(5, '('_db3);
     EXPECT_EQ(vec1, "((((("_db3);
 
-    std::vector<dot_bracket3> vec2{dot_bracket3::UNPAIRED, dot_bracket3::PAIR_OPEN, dot_bracket3::PAIR_OPEN,
-                                   dot_bracket3::PAIR_CLOSE, dot_bracket3::PAIR_CLOSE, dot_bracket3::UNKNOWN};
+    std::vector<dot_bracket3> vec2{'.'_db3, '('_db3, '('_db3,
+                                   ')'_db3, ')'_db3, '.'_db3};
     EXPECT_EQ(vec2, ".(())."_db3);
 }
 
 TEST(dot_bracket3, dot_bracket3)
 {
     EXPECT_EQ(dot_bracket3::max_pseudoknot_depth, 1);
-    EXPECT_TRUE(dot_bracket3::UNPAIRED.is_unpaired());
-    EXPECT_TRUE(dot_bracket3::PAIR_OPEN.is_pair_open());
-    EXPECT_TRUE(dot_bracket3::PAIR_CLOSE.is_pair_close());
-    EXPECT_TRUE(dot_bracket3::UNKNOWN.is_unpaired());
+    EXPECT_TRUE('.'_db3.is_unpaired());
+    EXPECT_TRUE('('_db3.is_pair_open());
+    EXPECT_TRUE(')'_db3.is_pair_close());
+    EXPECT_TRUE('.'_db3.is_unpaired());
 }

--- a/test/unit/alphabet/structure/dssp9_test.cpp
+++ b/test/unit/alphabet/structure/dssp9_test.cpp
@@ -18,7 +18,6 @@ INSTANTIATE_TYPED_TEST_CASE_P(dssp9, alphabet_constexpr, dssp9);
 // assign_char functions
 TEST(dssp9, assign_char)
 {
-    using t = dssp9;
     std::vector<char> input
     {
         '.', '(', ')',
@@ -29,9 +28,10 @@ TEST(dssp9, assign_char)
 
     std::vector<dssp9> cmp
     {
-        t::X, t::X, t::X,
-        t::X, t::X, t::X, t::X, t::X, t::X, t::X, t::X, t::X, t::X, t::X, t::X,
-        t::H, t::B, t::E, t::G, t::I, t::T, t::S
+        'X'_dssp9, 'X'_dssp9, 'X'_dssp9,
+        'X'_dssp9, 'X'_dssp9, 'X'_dssp9, 'X'_dssp9, 'X'_dssp9, 'X'_dssp9,
+        'X'_dssp9, 'X'_dssp9, 'X'_dssp9, 'X'_dssp9, 'X'_dssp9, 'X'_dssp9,
+        'H'_dssp9, 'B'_dssp9, 'E'_dssp9, 'G'_dssp9, 'I'_dssp9, 'T'_dssp9, 'S'_dssp9
     };
 
     for (auto [ ch, cm ] : ranges::view::zip(input, cmp))
@@ -41,24 +41,24 @@ TEST(dssp9, assign_char)
 // to_char functions
 TEST(dssp9, to_char)
 {
-    EXPECT_EQ(to_char(dssp9::H), 'H');
-    EXPECT_EQ(to_char(dssp9::B), 'B');
-    EXPECT_EQ(to_char(dssp9::E), 'E');
-    EXPECT_EQ(to_char(dssp9::G), 'G');
-    EXPECT_EQ(to_char(dssp9::I), 'I');
-    EXPECT_EQ(to_char(dssp9::T), 'T');
-    EXPECT_EQ(to_char(dssp9::S), 'S');
-    EXPECT_EQ(to_char(dssp9::C), 'C');
-    EXPECT_EQ(to_char(dssp9::X), 'X');
+    EXPECT_EQ(to_char('H'_dssp9), 'H');
+    EXPECT_EQ(to_char('B'_dssp9), 'B');
+    EXPECT_EQ(to_char('E'_dssp9), 'E');
+    EXPECT_EQ(to_char('G'_dssp9), 'G');
+    EXPECT_EQ(to_char('I'_dssp9), 'I');
+    EXPECT_EQ(to_char('T'_dssp9), 'T');
+    EXPECT_EQ(to_char('S'_dssp9), 'S');
+    EXPECT_EQ(to_char('C'_dssp9), 'C');
+    EXPECT_EQ(to_char('X'_dssp9), 'X');
 }
 
 TEST(dssp9, literals)
 {
 
     std::vector<dssp9> vec1;
-    vec1.resize(5, dssp9::H);
+    vec1.resize(5, 'H'_dssp9);
     EXPECT_EQ(vec1, "HHHHH"_dssp9);
 
-    std::vector<dssp9> vec2{dssp9::E, dssp9::H, dssp9::H, dssp9::H, dssp9::T, dssp9::G};
+    std::vector<dssp9> vec2{'E'_dssp9, 'H'_dssp9, 'H'_dssp9, 'H'_dssp9, 'T'_dssp9, 'G'_dssp9};
     EXPECT_EQ(vec2, "EHHHTG"_dssp9);
 }

--- a/test/unit/alphabet/structure/wuss51_test.cpp
+++ b/test/unit/alphabet/structure/wuss51_test.cpp
@@ -23,7 +23,6 @@ INSTANTIATE_TYPED_TEST_CASE_P(wuss67, alphabet_constexpr, wuss<67>);
 // assign_char functions
 TEST(wuss51, assign_char)
 {
-
     std::vector<char> input
     {
         '.', '(', ')',
@@ -84,9 +83,8 @@ TEST(wuss51, literals)
     EXPECT_EQ(vec2, ".<<>>."_wuss51);
 }
 
-TEST(wuss51, wuss51)
+TEST(wuss51, structure_properties)
 {
-
     EXPECT_EQ(wuss51::max_pseudoknot_depth, 22);
     std::vector<wuss51> vec = ".:,-_~;<>()[]{}AaBbCcDd"_wuss51;
     for (unsigned idx = 0; idx <= 6; ++idx)

--- a/test/unit/alphabet/structure/wuss51_test.cpp
+++ b/test/unit/alphabet/structure/wuss51_test.cpp
@@ -15,12 +15,15 @@
 
 INSTANTIATE_TYPED_TEST_CASE_P(wuss51, alphabet, wuss51);
 INSTANTIATE_TYPED_TEST_CASE_P(wuss51, alphabet_constexpr, wuss51);
+INSTANTIATE_TYPED_TEST_CASE_P(wuss15, alphabet, wuss<15>);
+INSTANTIATE_TYPED_TEST_CASE_P(wuss15, alphabet_constexpr, wuss<15>);
+INSTANTIATE_TYPED_TEST_CASE_P(wuss67, alphabet, wuss<67>);
+INSTANTIATE_TYPED_TEST_CASE_P(wuss67, alphabet_constexpr, wuss<67>);
 
 // assign_char functions
 TEST(wuss51, assign_char)
 {
 
-    using t = wuss51;
     std::vector<char> input
     {
         '.', '(', ')',
@@ -31,16 +34,10 @@ TEST(wuss51, assign_char)
 
     std::vector<wuss51> cmp
     {
-        t::UNPAIRED, t::PAIR_OPEN1, t::PAIR_CLOSE1,
-        t::UNPAIRED1, t::UNPAIRED2, t::UNPAIRED3, t::UNPAIRED4, t::UNPAIRED5, t::UNPAIRED6,
-        t::PAIR_OPEN, t::PAIR_CLOSE, t::PAIR_OPEN2, t::PAIR_CLOSE2, t::PAIR_OPEN3, t::PAIR_CLOSE3,
-        "H"_wuss51.front(),
-        "B"_wuss51.front(),
-        "E"_wuss51.front(),
-        "G"_wuss51.front(),
-        "I"_wuss51.front(),
-        "T"_wuss51.front(),
-        "S"_wuss51.front()
+        '.'_wuss51, '('_wuss51, ')'_wuss51,
+        ':'_wuss51, ','_wuss51, '-'_wuss51, '_'_wuss51, '~'_wuss51, ';'_wuss51,
+        '<'_wuss51, '>'_wuss51, '['_wuss51, ']'_wuss51, '{'_wuss51, '}'_wuss51,
+        'H'_wuss51, 'B'_wuss51, 'E'_wuss51, 'G'_wuss51, 'I'_wuss51, 'T'_wuss51, 'S'_wuss51
     };
 
     for (auto [ ch, cm ] : ranges::view::zip(input, cmp))
@@ -50,21 +47,21 @@ TEST(wuss51, assign_char)
 // to_char functions
 TEST(wuss51, to_char)
 {
-    EXPECT_EQ(to_char(wuss51::UNPAIRED), '.');
-    EXPECT_EQ(to_char(wuss51::UNPAIRED1), ':');
-    EXPECT_EQ(to_char(wuss51::UNPAIRED2), ',');
-    EXPECT_EQ(to_char(wuss51::UNPAIRED3), '-');
-    EXPECT_EQ(to_char(wuss51::UNPAIRED4), '_');
-    EXPECT_EQ(to_char(wuss51::UNPAIRED5), '~');
-    EXPECT_EQ(to_char(wuss51::UNPAIRED6), ';');
-    EXPECT_EQ(to_char(wuss51::PAIR_OPEN), '<');
-    EXPECT_EQ(to_char(wuss51::PAIR_CLOSE), '>');
-    EXPECT_EQ(to_char(wuss51::PAIR_OPEN1), '(');
-    EXPECT_EQ(to_char(wuss51::PAIR_CLOSE1), ')');
-    EXPECT_EQ(to_char(wuss51::PAIR_OPEN2), '[');
-    EXPECT_EQ(to_char(wuss51::PAIR_CLOSE2), ']');
-    EXPECT_EQ(to_char(wuss51::PAIR_OPEN3), '{');
-    EXPECT_EQ(to_char(wuss51::PAIR_CLOSE3), '}');
+    EXPECT_EQ(to_char('.'_wuss51), '.');
+    EXPECT_EQ(to_char(':'_wuss51), ':');
+    EXPECT_EQ(to_char(','_wuss51), ',');
+    EXPECT_EQ(to_char('-'_wuss51), '-');
+    EXPECT_EQ(to_char('_'_wuss51), '_');
+    EXPECT_EQ(to_char('~'_wuss51), '~');
+    EXPECT_EQ(to_char(';'_wuss51), ';');
+    EXPECT_EQ(to_char('<'_wuss51), '<');
+    EXPECT_EQ(to_char('>'_wuss51), '>');
+    EXPECT_EQ(to_char('('_wuss51), '(');
+    EXPECT_EQ(to_char(')'_wuss51), ')');
+    EXPECT_EQ(to_char('['_wuss51), '[');
+    EXPECT_EQ(to_char(']'_wuss51), ']');
+    EXPECT_EQ(to_char('{'_wuss51), '{');
+    EXPECT_EQ(to_char('}'_wuss51), '}');
 }
 
 // concepts
@@ -79,13 +76,11 @@ TEST(wuss51, concept_check)
 
 TEST(wuss51, literals)
 {
-
     std::vector<wuss51> vec1;
-    vec1.resize(5, wuss51::PAIR_OPEN);
+    vec1.resize(5, '<'_wuss51);
     EXPECT_EQ(vec1, "<<<<<"_wuss51);
 
-    std::vector<wuss51> vec2{wuss51::UNPAIRED, wuss51::PAIR_OPEN, wuss51::PAIR_OPEN,
-                             wuss51::PAIR_CLOSE, wuss51::PAIR_CLOSE, wuss51::UNPAIRED};
+    std::vector<wuss51> vec2{'.'_wuss51, '<'_wuss51, '<'_wuss51, '>'_wuss51, '>'_wuss51, '.'_wuss51};
     EXPECT_EQ(vec2, ".<<>>."_wuss51);
 }
 


### PR DESCRIPTION
Adds char literals to the following alphabets and removes the enum interface.
- [x] dot bracket
- [x] dssp
- [x] wuss

solves #644 