### PR TITLE
Renaming2 

### DIFF
--- a/include/seqan3/alphabet/aminoacid/aa20.hpp
+++ b/include/seqan3/alphabet/aminoacid/aa20.hpp
@@ -23,7 +23,7 @@ namespace seqan3
 
 /*!\brief The canonical amino acid alphabet.
  * \ingroup aminoacid
- * \implements seqan3::aminoacid_concept
+ * \implements seqan3::AminoacidAlphabet
  * \implements seqan3::detail::constexpr_alphabet_concept
  * \implements seqan3::trivially_copyable_concept
  * \implements seqan3::standard_layout_concept

--- a/include/seqan3/alphabet/aminoacid/aa27.hpp
+++ b/include/seqan3/alphabet/aminoacid/aa27.hpp
@@ -22,7 +22,7 @@ namespace seqan3
 {
 /*!\brief The twenty-seven letter amino acid alphabet.
  * \ingroup aminoacid
- * \implements seqan3::aminoacid_concept
+ * \implements seqan3::AminoacidAlphabet
  * \implements seqan3::detail::constexpr_alphabet_concept
  * \implements seqan3::trivially_copyable_concept
  * \implements seqan3::standard_layout_concept

--- a/include/seqan3/alphabet/aminoacid/aminoacid_base.hpp
+++ b/include/seqan3/alphabet/aminoacid/aminoacid_base.hpp
@@ -68,7 +68,7 @@ public:
     //!\cond
         requires !std::Same<aminoacid_base, other_aa_type> &&
                  !std::Same<derived_type, other_aa_type> &&
-                 aminoacid_concept<other_aa_type>
+                 AminoacidAlphabet<other_aa_type>
     //!\endcond
     explicit constexpr aminoacid_base(other_aa_type const & other) noexcept
     {

--- a/include/seqan3/alphabet/aminoacid/concept.hpp
+++ b/include/seqan3/alphabet/aminoacid/concept.hpp
@@ -7,7 +7,7 @@
 
 /*!\file
  * \author Joshua Kim <joshua.kim AT fu-berlin.de>
- * \brief Provides seqan3::aminoacid_concept.
+ * \brief Provides seqan3::AminoacidAlphabet.
  */
 
 #pragma once
@@ -46,7 +46,7 @@ struct is_aminoacid : std::false_type {};
 template <typename type>
 constexpr bool is_aminoacid_v = is_aminoacid<type>::value;
 
-/*!\interface seqan3::aminoacid_concept <>
+/*!\interface seqan3::AminoacidAlphabet <>
  * \extends seqan3::alphabet_concept
  * \brief A concept that indicates whether an alphabet represents amino acids.
  * \ingroup aminoacid
@@ -61,7 +61,7 @@ constexpr bool is_aminoacid_v = is_aminoacid<type>::value;
  */
 //!\cond
 template <typename type>
-SEQAN3_CONCEPT aminoacid_concept = alphabet_concept<type> && is_aminoacid_v<remove_cvref_t<type>>;
+SEQAN3_CONCEPT AminoacidAlphabet = alphabet_concept<type> && is_aminoacid_v<remove_cvref_t<type>>;
 //!\endcond
 
 } // namespace seqan3

--- a/include/seqan3/alphabet/aminoacid/translation.hpp
+++ b/include/seqan3/alphabet/aminoacid/translation.hpp
@@ -52,7 +52,7 @@ class rna15;
  *
  * No-throw guarantee.
 */
-template <genetic_code gc = genetic_code::CANONICAL, nucleotide_concept nucl_type>
+template <genetic_code gc = genetic_code::CANONICAL, NucleotideAlphabet nucl_type>
 constexpr aa27 translate_triplet(nucl_type const & n1, nucl_type const & n2, nucl_type const & n3) noexcept
 {
     if constexpr (std::Same<nucl_type, dna4> || std::Same<nucl_type, dna5> || std::Same<nucl_type, dna15>)
@@ -98,9 +98,9 @@ constexpr aa27 translate_triplet(nucl_type const & n1, nucl_type const & n2, nuc
 template <genetic_code gc = genetic_code::CANONICAL, typename tuple_type>
 //!\cond
     requires std::tuple_size<tuple_type>::value == 3 &&
-             nucleotide_concept<std::tuple_element_t<0, tuple_type>> &&
-             nucleotide_concept<std::tuple_element_t<1, tuple_type>> &&
-             nucleotide_concept<std::tuple_element_t<2, tuple_type>>
+             NucleotideAlphabet<std::tuple_element_t<0, tuple_type>> &&
+             NucleotideAlphabet<std::tuple_element_t<1, tuple_type>> &&
+             NucleotideAlphabet<std::tuple_element_t<2, tuple_type>>
 //!\endcond
 constexpr aa27 translate_triplet(tuple_type const & input_tuple) noexcept
 {
@@ -125,7 +125,7 @@ constexpr aa27 translate_triplet(tuple_type const & input_tuple) noexcept
 */
 template <genetic_code gc = genetic_code::CANONICAL, std::ranges::InputRange range_type>
     //!\cond
-    requires nucleotide_concept<std::decay_t<reference_t<std::decay_t<range_type>>>>
+    requires NucleotideAlphabet<std::decay_t<reference_t<std::decay_t<range_type>>>>
     //!\endcond
 constexpr aa27 translate_triplet(range_type && input_range)
 {
@@ -159,7 +159,7 @@ constexpr aa27 translate_triplet(range_type && input_range)
 */
 template <genetic_code gc = genetic_code::CANONICAL, std::ranges::RandomAccessRange range_type>
 //!\cond
-    requires nucleotide_concept<std::decay_t<reference_t<std::decay_t<range_type>>>>
+    requires NucleotideAlphabet<std::decay_t<reference_t<std::decay_t<range_type>>>>
 //!\endcond
 constexpr aa27 translate_triplet(range_type && input_range)
 {

--- a/include/seqan3/alphabet/detail/alphabet_proxy.hpp
+++ b/include/seqan3/alphabet/detail/alphabet_proxy.hpp
@@ -110,7 +110,7 @@ public:
  * details.
  *
  * This class ensures that the proxy itself also models seqan3::semi_alphabet_concept, seqan3::alphabet_concept,
- * seqan3::quality_concept, seqan3::nucleotide_concept and/or seqan3::AminoacidAlphabet if the emulated type models
+ * seqan3::quality_concept, seqan3::NucleotideAlphabet and/or seqan3::AminoacidAlphabet if the emulated type models
  * these. This makes sure that function templates which accept the original, also accept the proxy. An exception
  * are multi-layered compositions of alphabets where the proxy currently does not support access via `get`.
  *
@@ -261,7 +261,7 @@ public:
 
 #if 0 // this currently causes GCC ICE in cartesian_composition test
     constexpr alphabet_type complement() const noexcept
-        requires nucleotide_concept<alphabet_type>
+        requires NucleotideAlphabet<alphabet_type>
     {
         using seqan3::complement;
         return complement(static_cast<alphabet_type>(*this));

--- a/include/seqan3/alphabet/detail/alphabet_proxy.hpp
+++ b/include/seqan3/alphabet/detail/alphabet_proxy.hpp
@@ -110,7 +110,7 @@ public:
  * details.
  *
  * This class ensures that the proxy itself also models seqan3::semi_alphabet_concept, seqan3::alphabet_concept,
- * seqan3::quality_concept, seqan3::nucleotide_concept and/or seqan3::aminoacid_concept if the emulated type models
+ * seqan3::quality_concept, seqan3::nucleotide_concept and/or seqan3::AminoacidAlphabet if the emulated type models
  * these. This makes sure that function templates which accept the original, also accept the proxy. An exception
  * are multi-layered compositions of alphabets where the proxy currently does not support access via `get`.
  *

--- a/include/seqan3/alphabet/detail/alphabet_proxy.hpp
+++ b/include/seqan3/alphabet/detail/alphabet_proxy.hpp
@@ -110,7 +110,7 @@ public:
  * details.
  *
  * This class ensures that the proxy itself also models seqan3::semi_alphabet_concept, seqan3::alphabet_concept,
- * seqan3::quality_concept, seqan3::NucleotideAlphabet and/or seqan3::AminoacidAlphabet if the emulated type models
+ * seqan3::QualityAlphabet, seqan3::NucleotideAlphabet and/or seqan3::AminoacidAlphabet if the emulated type models
  * these. This makes sure that function templates which accept the original, also accept the proxy. An exception
  * are multi-layered compositions of alphabets where the proxy currently does not support access via `get`.
  *
@@ -225,7 +225,7 @@ public:
     }
 
     constexpr derived_type & assign_phred(phred_type_virtual const c) noexcept
-        requires quality_concept<alphabet_type>
+        requires QualityAlphabet<alphabet_type>
     {
         alphabet_type tmp{};
         using seqan3::assign_phred;
@@ -253,7 +253,7 @@ public:
     }
 
     constexpr phred_type to_phred() const noexcept
-        requires quality_concept<alphabet_type>
+        requires QualityAlphabet<alphabet_type>
     {
         using seqan3::to_phred;
         return to_phred(static_cast<alphabet_type>(*this));

--- a/include/seqan3/alphabet/detail/member_exposure.hpp
+++ b/include/seqan3/alphabet/detail/member_exposure.hpp
@@ -245,17 +245,17 @@ constexpr alphabet_type_with_members assign_char_strict(alphabet_type_with_membe
 //!\}
 
 // ------------------------------------------------------------------
-// seqan3::nucleotide_concept
+// seqan3::NucleotideAlphabet
 // ------------------------------------------------------------------
 
-/*!\name Helpers for seqan3::nucleotide_concept
+/*!\name Helpers for seqan3::NucleotideAlphabet
  * \brief These functions and metafunctions expose member variables and types so that they satisfy
- * seqan3::nucleotide_concept.
+ * seqan3::NucleotideAlphabet.
  * \ingroup nucleotide
  * \{
  */
 
-/*!\brief Implementation of seqan3::nucleotide_concept::complement() that delegates to a member function.
+/*!\brief Implementation of seqan3::NucleotideAlphabet::complement() that delegates to a member function.
  * \tparam nucleotide_type Must provide a `.complement()` member function.
  * \param alph The alphabet letter for whom you wish to receive the complement.
  * \returns The letter's complement, e.g. 'T' for 'A'.

--- a/include/seqan3/alphabet/nucleotide/all.hpp
+++ b/include/seqan3/alphabet/nucleotide/all.hpp
@@ -103,7 +103,7 @@
  *
  * \par Concept
  *
- * The nucleotide submodule defines seqan3::nucleotide_concept which encompasses all the alphabets defined in the
+ * The nucleotide submodule defines seqan3::NucleotideAlphabet which encompasses all the alphabets defined in the
  * submodule and refines seqan3::alphabet_concept. The only additional requirement is that their values can be
  * complemented, see below.
  *
@@ -130,7 +130,7 @@
  *
  * In the typical structure of DNA molecules (or double-stranded RNA), each nucleotide has a complement that it
  * pairs with. To generate the complement value of a nucleotide letter, you can call an implementation of
- * seqan3::nucleotide_concept::complement() on it.
+ * seqan3::NucleotideAlphabet::complement() on it.
  *
  * For the ambiguous letters, the complement is the (possibly also ambiguous) letter representing the union of the
  * individual complements.

--- a/include/seqan3/alphabet/nucleotide/concept.hpp
+++ b/include/seqan3/alphabet/nucleotide/concept.hpp
@@ -7,7 +7,7 @@
 
 /*!\file
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
- * \brief Provides seqan3::nucleotide_concept.
+ * \brief Provides seqan3::NucleotideAlphabet.
  */
 
 #pragma once
@@ -22,13 +22,13 @@
 namespace seqan3
 {
 
-/*!\interface seqan3::nucleotide_concept <>
+/*!\interface seqan3::NucleotideAlphabet <>
  * \extends seqan3::alphabet_concept
  * \brief A concept that indicates whether an alphabet represents nucleotides.
  * \ingroup nucleotide
  *
- * In addition to the requirements for seqan3::alphabet_concept, the nucleotide_concept introduces
- * a requirement for a complement function: seqan3::nucleotide_concept::complement.
+ * In addition to the requirements for seqan3::alphabet_concept, the NucleotideAlphabet introduces
+ * a requirement for a complement function: seqan3::NucleotideAlphabet::complement.
  *
  * \par Concepts and doxygen
  * The requirements for this concept are given as related functions and metafunctions.
@@ -36,19 +36,19 @@ namespace seqan3
  */
 //!\cond
 template <typename type>
-SEQAN3_CONCEPT nucleotide_concept = alphabet_concept<type> && requires (type v, std::remove_reference_t<type> c)
+SEQAN3_CONCEPT NucleotideAlphabet = alphabet_concept<type> && requires (type v, std::remove_reference_t<type> c)
 {
     requires std::Same<decltype(complement(v)), decltype(c)>;
 };
 //!\endcond
 
-/*!\name Requirements for seqan3::nucleotide_concept
- * \brief You can expect these functions on all types that implement seqan3::nucleotide_concept.
+/*!\name Requirements for seqan3::NucleotideAlphabet
+ * \brief You can expect these functions on all types that implement seqan3::NucleotideAlphabet.
  * \{
  */
 /*!\fn nucleotide_type seqan3::complement(nucleotide_type const alph)
  * \brief Returns the alphabet letter's complement value.
- * \relates seqan3::nucleotide_concept
+ * \relates seqan3::NucleotideAlphabet
  * \param alph The alphabet letter for whom you wish to receive the complement.
  * \returns The letter's complement, e.g. 'T' for 'A'.
  * \details

--- a/include/seqan3/alphabet/nucleotide/dna15.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna15.hpp
@@ -28,7 +28,7 @@ class rna15;
 
 /*!\brief The 15 letter DNA alphabet, containing all IUPAC smybols minus the gap.
  * \ingroup nucleotide
- * \implements seqan3::nucleotide_concept
+ * \implements seqan3::NucleotideAlphabet
  * \implements seqan3::detail::constexpr_alphabet_concept
  * \implements seqan3::trivially_copyable_concept
  * \implements seqan3::standard_layout_concept

--- a/include/seqan3/alphabet/nucleotide/dna4.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna4.hpp
@@ -28,7 +28,7 @@ class rna4;
 
 /*!\brief The four letter DNA alphabet of A,C,G,T.
  * \ingroup nucleotide
- * \implements seqan3::nucleotide_concept
+ * \implements seqan3::NucleotideAlphabet
  * \implements seqan3::detail::constexpr_alphabet_concept
  * \implements seqan3::trivially_copyable_concept
  * \implements seqan3::standard_layout_concept

--- a/include/seqan3/alphabet/nucleotide/dna5.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna5.hpp
@@ -28,7 +28,7 @@ class rna5;
 
 /*!\brief The five letter DNA alphabet of A,C,G,T and the unknown character N.
  * \ingroup nucleotide
- * \implements seqan3::nucleotide_concept
+ * \implements seqan3::NucleotideAlphabet
  * \implements seqan3::detail::constexpr_alphabet_concept
  * \implements seqan3::trivially_copyable_concept
  * \implements seqan3::standard_layout_concept

--- a/include/seqan3/alphabet/nucleotide/nucleotide_base.hpp
+++ b/include/seqan3/alphabet/nucleotide/nucleotide_base.hpp
@@ -28,7 +28,7 @@ namespace seqan3
  * \details
  *
  * You can use this class to define your own nucleotide alphabet, but types are not required to be based on it to model
- * seqan3::nucleotide_concept, it is purely a way to avoid code duplication.
+ * seqan3::NucleotideAlphabet, it is purely a way to avoid code duplication.
  *
  * In addition to the requirements of seqan3::alphabet_base, the derived type needs to define the following static
  * member variable (can be private):
@@ -73,7 +73,7 @@ public:
     //!\cond
         requires !std::Same<nucleotide_base, other_nucl_type> &&
                  !std::Same<derived_type, other_nucl_type> &&
-                 nucleotide_concept<other_nucl_type>
+                 NucleotideAlphabet<other_nucl_type>
     //!\endcond
     explicit constexpr nucleotide_base(other_nucl_type const & other) noexcept
     {
@@ -93,7 +93,7 @@ public:
      *
      * See \ref nucleotide for the actual values.
      *
-     * Satisfies the seqan3::nucleotide_concept::complement() requirement via the seqan3::complement() wrapper.
+     * Satisfies the seqan3::NucleotideAlphabet::complement() requirement via the seqan3::complement() wrapper.
      *
      * \par Complexity
      *

--- a/include/seqan3/alphabet/nucleotide/rna15.hpp
+++ b/include/seqan3/alphabet/nucleotide/rna15.hpp
@@ -25,7 +25,7 @@ namespace seqan3
 {
 
 /*!\brief The 15 letter RNA alphabet, containing all IUPAC smybols minus the gap.
- * \implements seqan3::nucleotide_concept
+ * \implements seqan3::NucleotideAlphabet
  * \implements seqan3::detail::constexpr_alphabet_concept
  * \implements seqan3::trivially_copyable_concept
  * \implements seqan3::standard_layout_concept

--- a/include/seqan3/alphabet/nucleotide/rna4.hpp
+++ b/include/seqan3/alphabet/nucleotide/rna4.hpp
@@ -26,7 +26,7 @@ namespace seqan3
 
 /*!\brief The four letter RNA alphabet of A,C,G,U.
  * \ingroup nucleotide
- * \implements seqan3::nucleotide_concept
+ * \implements seqan3::NucleotideAlphabet
  * \implements seqan3::detail::constexpr_alphabet_concept
  * \implements seqan3::trivially_copyable_concept
  * \implements seqan3::standard_layout_concept

--- a/include/seqan3/alphabet/nucleotide/rna5.hpp
+++ b/include/seqan3/alphabet/nucleotide/rna5.hpp
@@ -26,7 +26,7 @@ namespace seqan3
 
 /*!\brief The five letter RNA alphabet of A,C,G,U and the unknown character N.
  * \ingroup nucleotide
- * \implements seqan3::nucleotide_concept
+ * \implements seqan3::NucleotideAlphabet
  * \implements seqan3::detail::constexpr_alphabet_concept
  * \implements seqan3::trivially_copyable_concept
  * \implements seqan3::standard_layout_concept

--- a/include/seqan3/alphabet/quality/all.hpp
+++ b/include/seqan3/alphabet/quality/all.hpp
@@ -68,7 +68,7 @@
  *
  * \par Concept
  *
- * The quality submodule defines the seqan3::quality_concept which encompasses
+ * The quality submodule defines the seqan3::QualityAlphabet which encompasses
  * all the alphabets, defined in the submodule, and refines the
  * seqan3::alphabet_concept by providing Phred score assignment and conversion
  * operations.

--- a/include/seqan3/alphabet/quality/concept.hpp
+++ b/include/seqan3/alphabet/quality/concept.hpp
@@ -21,12 +21,12 @@ namespace seqan3
 {
 
 // ------------------------------------------------------------------
-// Member exposure for the seqan3::quality_concept
+// Member exposure for the seqan3::QualityAlphabet
 // ------------------------------------------------------------------
 
-/*!\name Helpers for seqan3::quality_concept
+/*!\name Helpers for seqan3::QualityAlphabet
  * \brief These functions and metafunctions expose member variables and types so
- * that the type can model the seqan3::quality_concept.
+ * that the type can model the seqan3::QualityAlphabet.
  * \ingroup quality
  * \{
  */
@@ -37,9 +37,9 @@ struct underlying_phred
 
 /*!\brief The internal phred type.
  * \ingroup quality
- * \tparam alphabet_type The type of alphabet. Must model the seqan3::quality_concept.
+ * \tparam alphabet_type The type of alphabet. Must model the seqan3::QualityAlphabet.
  *
- * The underlying_phred type requires the quality_concept.
+ * The underlying_phred type requires the QualityAlphabet.
  */
 template <typename alphabet_with_member_type>
 //!\cond
@@ -53,20 +53,20 @@ struct underlying_phred<alphabet_with_member_type>
 
 /*!\brief The internal phred type.
  * \ingroup quality
- * \tparam alphabet_type The type of alphabet. Must model the seqan3::quality_concept.
+ * \tparam alphabet_type The type of alphabet. Must model the seqan3::QualityAlphabet.
  *
- * The underlying_phred type requires the quality_concept.
+ * The underlying_phred type requires the QualityAlphabet.
  */
 template <typename alphabet_type>
 using underlying_phred_t = typename underlying_phred<alphabet_type>::type;
 
 /*!\brief The public setter function of a phred score.
  * \ingroup quality
- * \tparam    alphabet_type The type of alphabet. Must model the seqan3::quality_concept.
+ * \tparam    alphabet_type The type of alphabet. Must model the seqan3::QualityAlphabet.
  * \param[in] chr           The quality value to assign a score.
  * \param[in] in            The character to representing the phred score.
  *
- * The underlying_phred type requires the quality_concept.
+ * The underlying_phred type requires the QualityAlphabet.
  */
 template <typename alphabet_type>
 //!\cond
@@ -88,10 +88,10 @@ constexpr alphabet_type assign_phred(alphabet_type && chr, char const in)
 
 /*!\brief The public getter function for the phred representation of a score.
  * \ingroup quality
- * \tparam    alphabet_type The type of alphabet. Must model the seqan3::quality_concept.
+ * \tparam    alphabet_type The type of alphabet. Must model the seqan3::QualityAlphabet.
  * \param[in] chr           The quality value to convert into the phred score.
  *
- * The underlying_phred type requires the quality_concept.
+ * The underlying_phred type requires the QualityAlphabet.
  */
 template <typename alphabet_type>
 //!\cond
@@ -104,16 +104,16 @@ constexpr underlying_phred_t<alphabet_type> to_phred(alphabet_type const & chr)
 //\}
 
 // ------------------------------------------------------------------
-// seqan3::quality_concept
+// seqan3::QualityAlphabet
 // ------------------------------------------------------------------
 
-/*!\interface seqan3::quality_concept <>
+/*!\interface seqan3::QualityAlphabet <>
  * \extends seqan3::alphabet_concept
  * \brief A concept that indicates whether an alphabet represents quality scores.
  * \ingroup quality
  *
  * In addition to the requirements for seqan3::alphabet_concept, the
- * quality_concept introduces a requirement for conversion functions from and to
+ * QualityAlphabet introduces a requirement for conversion functions from and to
  * a Phred score.
  *
  * \par Concepts and doxygen
@@ -123,7 +123,7 @@ constexpr underlying_phred_t<alphabet_type> to_phred(alphabet_type const & chr)
  */
 //!\cond
 template<typename q>
-SEQAN3_CONCEPT quality_concept = requires(q quality)
+SEQAN3_CONCEPT QualityAlphabet = requires(q quality)
 {
     requires alphabet_concept<q>;
 

--- a/include/seqan3/alphabet/quality/phred42.hpp
+++ b/include/seqan3/alphabet/quality/phred42.hpp
@@ -22,7 +22,7 @@ namespace seqan3
 {
 
 /*!\brief Quality type for traditional Sanger and modern Illumina Phred scores (typical range).
- * \implements seqan3::quality_concept
+ * \implements seqan3::QualityAlphabet
  * \implements seqan3::detail::constexpr_alphabet_concept
  * \implements seqan3::trivially_copyable_concept
  * \implements seqan3::standard_layout_concept

--- a/include/seqan3/alphabet/quality/phred63.hpp
+++ b/include/seqan3/alphabet/quality/phred63.hpp
@@ -22,7 +22,7 @@ namespace seqan3
 {
 
 /*!\brief Quality type for traditional Sanger and modern Illumina Phred scores (full range).
- * \implements seqan3::quality_concept
+ * \implements seqan3::QualityAlphabet
  * \implements seqan3::detail::constexpr_alphabet_concept
  * \implements seqan3::trivially_copyable_concept
  * \implements seqan3::standard_layout_concept

--- a/include/seqan3/alphabet/quality/phred68legacy.hpp
+++ b/include/seqan3/alphabet/quality/phred68legacy.hpp
@@ -22,7 +22,7 @@ namespace seqan3
 {
 
 /*!\brief Quality type for Solexa and deprecated Illumina formats.
- * \implements seqan3::quality_concept
+ * \implements seqan3::QualityAlphabet
  * \implements seqan3::detail::constexpr_alphabet_concept
  * \implements seqan3::trivially_copyable_concept
  * \implements seqan3::standard_layout_concept

--- a/include/seqan3/alphabet/quality/qualified.hpp
+++ b/include/seqan3/alphabet/quality/qualified.hpp
@@ -25,8 +25,8 @@ namespace seqan3
 /*!\brief Joins an arbitrary alphabet with a quality alphabet.
  * \ingroup quality
  * \tparam sequence_alphabet_t Type of the alphabet; must satisfy seqan3::alphabet_concept.
- * \tparam quality_alphabet_t  Type of the quality; must satisfy seqan3::quality_concept.
- * \implements seqan3::quality_concept
+ * \tparam quality_alphabet_t  Type of the quality; must satisfy seqan3::QualityAlphabet.
+ * \implements seqan3::QualityAlphabet
  * \implements seqan3::detail::constexpr_alphabet_concept
  * \implements seqan3::trivially_copyable_concept
  * \implements seqan3::standard_layout_concept
@@ -52,9 +52,9 @@ namespace seqan3
  *
  * \snippet test/snippet/alphabet/quality/qualified.cpp general
  *
- * This seqan3::cartesian_composition itself fulfils both seqan3::alphabet_concept and seqan3::quality_concept.
+ * This seqan3::cartesian_composition itself fulfils both seqan3::alphabet_concept and seqan3::QualityAlphabet.
  */
-template <alphabet_concept sequence_alphabet_t, quality_concept quality_alphabet_t>
+template <alphabet_concept sequence_alphabet_t, QualityAlphabet quality_alphabet_t>
 class qualified :
     public cartesian_composition<qualified<sequence_alphabet_t, quality_alphabet_t>,
                                  sequence_alphabet_t, quality_alphabet_t>

--- a/include/seqan3/alphabet/quality/qualified.hpp
+++ b/include/seqan3/alphabet/quality/qualified.hpp
@@ -148,10 +148,10 @@ public:
 
     /*!\brief Return a qualified where the quality is preserved, but the sequence letter is complemented.
      * \sa seqan3::complement
-     * \sa seqan3::nucleotide_concept::complement
+     * \sa seqan3::NucleotideAlphabet::complement
      */
     constexpr qualified complement() const noexcept
-        requires nucleotide_concept<sequence_alphabet_t>
+        requires NucleotideAlphabet<sequence_alphabet_t>
     {
         using seqan3::complement;
         return qualified{complement(get<0>(*this)), get<1>(*this)};

--- a/include/seqan3/alphabet/quality/quality_base.hpp
+++ b/include/seqan3/alphabet/quality/quality_base.hpp
@@ -76,7 +76,7 @@ public:
     //!\cond
         requires !std::Same<quality_base, other_qual_type> &&
                  !std::Same<derived_type, other_qual_type> &&
-                 quality_concept<other_qual_type>
+                 QualityAlphabet<other_qual_type>
     //!\endcond
     explicit constexpr quality_base(other_qual_type const & other) noexcept
     {
@@ -110,7 +110,7 @@ public:
      *
      * \details
      *
-     * Satisfies the seqan3::quality_concept::assign_phred() requirement via the seqan3::assign_rank() wrapper.
+     * Satisfies the seqan3::QualityAlphabet::assign_phred() requirement via the seqan3::assign_rank() wrapper.
      *
      * \par Complexity
      *

--- a/include/seqan3/alphabet/structure/structured_rna.hpp
+++ b/include/seqan3/alphabet/structure/structured_rna.hpp
@@ -30,7 +30,7 @@ namespace seqan3
  * \implements seqan3::detail::constexpr_alphabet_concept
  * \implements seqan3::trivially_copyable_concept
  * \implements seqan3::standard_layout_concept
- * \tparam sequence_alphabet_t Type of the first letter; must satisfy seqan3::nucleotide_concept.
+ * \tparam sequence_alphabet_t Type of the first letter; must satisfy seqan3::NucleotideAlphabet.
  * \tparam structure_alphabet_t Types of further letters; must satisfy seqan3::rna_structure_concept.
  *
  * This composition pairs a nucleotide alphabet with a structure alphabet. The rank values
@@ -44,11 +44,11 @@ namespace seqan3
  *
  * \snippet test/snippet/alphabet/structure/structured_rna.cpp general
  *
- * This seqan3::cartesian_composition itself models both seqan3::nucleotide_concept and seqan3::rna_structure_concept.
+ * This seqan3::cartesian_composition itself models both seqan3::NucleotideAlphabet and seqan3::rna_structure_concept.
  */
 template <typename sequence_alphabet_t, typename structure_alphabet_t>
 //!\cond
-    requires nucleotide_concept<sequence_alphabet_t> && rna_structure_concept<structure_alphabet_t>
+    requires NucleotideAlphabet<sequence_alphabet_t> && rna_structure_concept<structure_alphabet_t>
 //!\endcond
 class structured_rna :
     public cartesian_composition<structured_rna<sequence_alphabet_t, structure_alphabet_t>,
@@ -127,7 +127,7 @@ public:
     /*!\brief Return a structured_rna where the sequence letter is converted to its complement.
      * \details
      * See \ref nucleotide for the actual values.
-     * Satisfies the seqan3::nucleotide_concept::complement() requirement via the seqan3::complement() wrapper.
+     * Satisfies the seqan3::NucleotideAlphabet::complement() requirement via the seqan3::complement() wrapper.
      * The structure letter is not modified.
      * \par Complexity
      * Constant.

--- a/include/seqan3/io/sequence_file/input.hpp
+++ b/include/seqan3/io/sequence_file/input.hpp
@@ -103,7 +103,7 @@ namespace seqan3
  */
 /*!\typedef using quality_alphabet
  * \memberof seqan3::sequence_file_input_traits_concept
- * \brief Alphabet of the characters for the seqan3::field::QUAL; must satisfy seqan3::quality_concept.
+ * \brief Alphabet of the characters for the seqan3::field::QUAL; must satisfy seqan3::QualityAlphabet.
  */
 /*!\typedef using quality_container
  * \memberof seqan3::sequence_file_input_traits_concept
@@ -132,7 +132,7 @@ SEQAN3_CONCEPT sequence_file_input_traits_concept = requires (t v)
     requires sequence_container_concept<typename t::template id_container_container<typename t::template id_container<
         typename t::id_alphabet>>>;
 
-    requires quality_concept<typename t::quality_alphabet>;
+    requires QualityAlphabet<typename t::quality_alphabet>;
     requires sequence_container_concept<typename t::template quality_container<typename t::quality_alphabet>>;
     requires sequence_container_concept<typename t::template quality_container_container<
         typename t::template quality_container<typename t::quality_alphabet>>>;

--- a/include/seqan3/io/sequence_file/input_format_concept.hpp
+++ b/include/seqan3/io/sequence_file/input_format_concept.hpp
@@ -70,7 +70,7 @@ SEQAN3_CONCEPT sequence_file_input_format_concept = requires (t                 
  * \tparam id_type          Type of the seqan3::field::ID input; must satisfy std::ranges::OutputRange
  * over a seqan3::alphabet_concept.
  * \tparam qual_type        Type of the seqan3::field::QUAL input; must satisfy std::ranges::OutputRange
- * over a seqan3::quality_concept.
+ * over a seqan3::QualityAlphabet.
  * \param[in,out] stream    The input stream to read from.
  * \param[in]     options   File specific options passed to the format.
  * \param[out]    sequence  The buffer for seqan3::field::SEQ input, i.e. the "sequence".

--- a/include/seqan3/io/sequence_file/output_format_concept.hpp
+++ b/include/seqan3/io/sequence_file/output_format_concept.hpp
@@ -70,7 +70,7 @@ SEQAN3_CONCEPT sequence_file_output_format_concept = requires (t                
  * \tparam id_type          Type of the seqan3::field::ID output; must satisfy std::ranges::OutputRange
  * over a seqan3::alphabet_concept.
  * \tparam qual_type        Type of the seqan3::field::QUAL output; must satisfy std::ranges::OutputRange
- * over a seqan3::quality_concept.
+ * over a seqan3::QualityAlphabet.
  * \param[in,out] stream    The output stream to write into.
  * \param[in]     options   File specific options passed to the format.
  * \param[in]     sequence  The data for seqan3::field::SEQ, i.e. the "sequence".

--- a/include/seqan3/range/view/all.hpp
+++ b/include/seqan3/range/view/all.hpp
@@ -152,7 +152,7 @@
  * (since dereferencing an iterator or calling operator[] returns the reference type). The reference type may or may
  * not actually contain a `&` (see below). For many SeqAn specific views additional concept requirements are defined
  * for the input range's reference type, e.g. seqan3::view::complement can only operate on ranges whose elements are
- * nucleotides (meet seqan3::nucleotide_concept_check). In some case the type may even be a specific type or the result
+ * nucleotides (meet seqan3::NucleotideAlphabet_check). In some case the type may even be a specific type or the result
  * of a metafunction.
  *
  * **Returned range's reference type:** Conversely certain views make guarantees on the concepts satisfied by the

--- a/include/seqan3/range/view/complement.hpp
+++ b/include/seqan3/range/view/complement.hpp
@@ -30,7 +30,7 @@ namespace seqan3::view
  * \returns             A range of converted elements. See below for the properties of the returned range.
  * \ingroup view
  *
- * Calls seqan3::nucleotide_concept::complement() on every element of the input range.
+ * Calls seqan3::NucleotideAlphabet::complement() on every element of the input range.
  *
  * ### View properties
  *
@@ -52,7 +52,7 @@ namespace seqan3::view
  * | std::ranges::OutputRange        |                                       | *lost*                                             |
  * | seqan3::const_iterable_concept  |                                       | *preserved*                                        |
  * |                                 |                                       |                                                    |
- * | seqan3::reference_t             | seqan3::nucleotide_concept            | std::remove_reference_t<seqan3::reference_t<urng_t>> |
+ * | seqan3::reference_t             | seqan3::NucleotideAlphabet            | std::remove_reference_t<seqan3::reference_t<urng_t>> |
  *
  * See the \link view view submodule documentation \endlink for detailed descriptions of the view properties.
  *
@@ -64,9 +64,9 @@ namespace seqan3::view
 
 inline auto const complement = deep{view::transform([] (auto && in)
 {
-    static_assert(nucleotide_concept<std::remove_const_t<decltype(in)>>,
-                  "The innermost value type must satisfy the nucleotide_concept.");
-    // call element-wise complement from the nucleotide_concept
+    static_assert(NucleotideAlphabet<std::remove_const_t<decltype(in)>>,
+                  "The innermost value type must satisfy the NucleotideAlphabet.");
+    // call element-wise complement from the NucleotideAlphabet
     using seqan3::complement;
     return complement(in);
 })};

--- a/include/seqan3/range/view/translation.hpp
+++ b/include/seqan3/range/view/translation.hpp
@@ -65,7 +65,7 @@ template <typename urng_t>
 //!\cond
     requires std::ranges::SizedRange<urng_t> &&
              std::ranges::RandomAccessRange<urng_t> &&
-             nucleotide_concept<std::decay_t<reference_t<std::decay_t<urng_t>>>>
+             NucleotideAlphabet<std::decay_t<reference_t<std::decay_t<urng_t>>>>
 //!\endcond
 class view_translate_single
 {
@@ -286,7 +286,7 @@ template <typename urng_t>
 //!\cond
     requires std::ranges::SizedRange<urng_t> &&
              std::ranges::RandomAccessRange<urng_t> &&
-             nucleotide_concept<std::decay_t<reference_t<std::decay_t<urng_t>>>>
+             NucleotideAlphabet<std::decay_t<reference_t<std::decay_t<urng_t>>>>
 //!\endcond
 view_translate_single(urng_t &&, translation_frames const) -> view_translate_single<urng_t>;
 
@@ -295,7 +295,7 @@ template <typename urng_t>
 //!\cond
     requires std::ranges::SizedRange<urng_t> &&
              std::ranges::RandomAccessRange<urng_t> &&
-             nucleotide_concept<std::decay_t<reference_t<std::decay_t<urng_t>>>>
+             NucleotideAlphabet<std::decay_t<reference_t<std::decay_t<urng_t>>>>
 //!\endcond
 view_translate_single(urng_t &&) -> view_translate_single<urng_t>;
 
@@ -336,7 +336,7 @@ namespace seqan3::view
  * | std::ranges::OutputRange        |                                       | *lost*                                             |
  * | seqan3::const_iterable_concept  | *required*                            | *preserved*                                        |
  * |                                 |                                       |                                                    |
- * | seqan3::reference_t             | seqan3::nucleotide_concept            | seqan3::aa27                                       |
+ * | seqan3::reference_t             | seqan3::NucleotideAlphabet            | seqan3::aa27                                       |
  *
  * * `urng_t` is the type of the range modified by this view (input).
  * * `rrng_type` is the type of the range returned by this view.
@@ -368,7 +368,7 @@ template <typename urng_t>
 //!\cond
     requires std::ranges::SizedRange<urng_t> &&
              std::ranges::RandomAccessRange<urng_t> &&
-             nucleotide_concept<std::decay_t<reference_t<std::decay_t<urng_t>>>>
+             NucleotideAlphabet<std::decay_t<reference_t<std::decay_t<urng_t>>>>
 //!\endcond
 class view_translate
 {
@@ -567,7 +567,7 @@ template <typename urng_t>
 //!\cond
     requires std::ranges::SizedRange<urng_t> &&
              std::ranges::RandomAccessRange<urng_t> &&
-             nucleotide_concept<std::decay_t<reference_t<std::decay_t<urng_t>>>>
+             NucleotideAlphabet<std::decay_t<reference_t<std::decay_t<urng_t>>>>
 //!\endcond
 view_translate(urng_t &&, translation_frames const) -> view_translate<urng_t>;
 
@@ -576,7 +576,7 @@ template <typename urng_t>
 //!\cond
     requires std::ranges::SizedRange<urng_t> &&
              std::ranges::RandomAccessRange<urng_t> &&
-             nucleotide_concept<std::decay_t<reference_t<std::decay_t<urng_t>>>>
+             NucleotideAlphabet<std::decay_t<reference_t<std::decay_t<urng_t>>>>
 //!\endcond
 view_translate(urng_t &&) -> view_translate<urng_t>;
 
@@ -617,7 +617,7 @@ namespace seqan3::view
  * | std::ranges::OutputRange        |                                       | *lost*                                             |
  * | seqan3::const_iterable_concept  | *required*                            | *preserved*                                        |
  * |                                 |                                       |                                                    |
- * | seqan3::reference_t             | seqan3::nucleotide_concept            | std::ranges::View && std::ranges::RandomAccessRange && std::ranges::SizedRange |
+ * | seqan3::reference_t             | seqan3::NucleotideAlphabet            | std::ranges::View && std::ranges::RandomAccessRange && std::ranges::SizedRange |
  *
  * * `urng_t` is the type of the range modified by this view (input).
  * * `rrng_type` is the type of the range returned by this view.

--- a/include/seqan3/range/view/trim.hpp
+++ b/include/seqan3/range/view/trim.hpp
@@ -38,7 +38,7 @@ struct trim_fn
     auto operator()(irng_t && irange,
                     underlying_phred_t<value_type_t<std::decay_t<irng_t>>> const threshold) const
     //!\cond
-        requires std::ranges::InputRange<irng_t> && quality_concept<value_type_t<std::decay_t<irng_t>>>
+        requires std::ranges::InputRange<irng_t> && QualityAlphabet<value_type_t<std::decay_t<irng_t>>>
     //!\endcond
     {
         return ranges::view::take_while(std::forward<irng_t>(irange), [threshold] (auto && value)
@@ -56,14 +56,14 @@ struct trim_fn
     auto operator()(irng_t && irange,
                     std::decay_t<value_type_t<std::decay_t<irng_t>>> const threshold) const
     //!\cond
-        requires std::ranges::InputRange<irng_t> && quality_concept<value_type_t<std::decay_t<irng_t>>>
+        requires std::ranges::InputRange<irng_t> && QualityAlphabet<value_type_t<std::decay_t<irng_t>>>
     //!\endcond
     {
         return (*this)(std::forward<irng_t>(irange), to_phred(threshold));
     }
 
     /*!\brief A functor that behaves like a named version of std::bind around seqan3::detail::trim_fn::operator().
-     * \tparam threshold_t Must be an integral type or satisfy the seqan3::quality_concept.
+     * \tparam threshold_t Must be an integral type or satisfy the seqan3::QualityAlphabet.
      *
      * \details
      *
@@ -95,7 +95,7 @@ struct trim_fn
     };
 
     /*!\brief Range-less interface for use with the pipe notation.
-     * \tparam threshold_t Must be an integral type or satisfy the seqan3::quality_concept.
+     * \tparam threshold_t Must be an integral type or satisfy the seqan3::QualityAlphabet.
      * \param threshold The minimum quality given by a value of the range's value type.
      *
      * \details
@@ -105,7 +105,7 @@ struct trim_fn
     template <typename threshold_t>
     delegate<threshold_t> operator()(threshold_t const threshold) const
     //!\cond
-        requires std::is_integral_v<std::decay_t<threshold_t>> || quality_concept<std::decay_t<threshold_t>>
+        requires std::is_integral_v<std::decay_t<threshold_t>> || QualityAlphabet<std::decay_t<threshold_t>>
     //!\endcond
     {
         return delegate<threshold_t>{threshold, *this};
@@ -122,7 +122,7 @@ struct trim_fn
     template <typename irng_t,
               typename threshold_t>
     //!\cond
-        requires std::ranges::InputRange<irng_t> && quality_concept<value_type_t<std::decay_t<irng_t>>> &&
+        requires std::ranges::InputRange<irng_t> && QualityAlphabet<value_type_t<std::decay_t<irng_t>>> &&
                  (std::is_same_v<std::decay_t<threshold_t>,
                                  std::decay_t<value_type_t<std::decay_t<irng_t>>>> ||
                   std::is_convertible_v<std::decay_t<threshold_t>,
@@ -144,7 +144,7 @@ namespace seqan3::view
  * \{
  */
 
-/*!\brief               A view that does quality-threshold trimming on a range of seqan3::quality_concept.
+/*!\brief               A view that does quality-threshold trimming on a range of seqan3::QualityAlphabet.
  * \tparam urng_t       The type of the range being processed. See below for requirements.
  * \tparam threshold_t  Either seqan3::value_type_t<urng_t> or
  *                      seqan3::underlying_phred_t<seqan3::value_type_t<urng_t>>.
@@ -175,7 +175,7 @@ namespace seqan3::view
  * | std::ranges::OutputRange        |                                       | *preserved*                     |
  * | seqan3::const_iterable_concept  |                                       | *preserved*                     |
  * |                                 |                                       |                                 |
- * | seqan3::reference_t             | seqan3::quality_concept               | seqan3::reference_t<urng_t>     |
+ * | seqan3::reference_t             | seqan3::QualityAlphabet               | seqan3::reference_t<urng_t>     |
  *
  * See the \link view view submodule documentation \endlink for detailed descriptions of the view properties.
  *

--- a/test/unit/alphabet/aminoacid/aminoacid_test_template.hpp
+++ b/test/unit/alphabet/aminoacid/aminoacid_test_template.hpp
@@ -23,8 +23,8 @@ TYPED_TEST_CASE_P(aminoacid);
 
 TYPED_TEST_P(aminoacid, concept_check)
 {
-    EXPECT_TRUE(aminoacid_concept<TypeParam>);
-    EXPECT_TRUE(aminoacid_concept<TypeParam &>);
+    EXPECT_TRUE(AminoacidAlphabet<TypeParam>);
+    EXPECT_TRUE(AminoacidAlphabet<TypeParam &>);
 }
 
 // ------------------------------------------------------------------

--- a/test/unit/alphabet/nucleotide/nucleotide_test_template.hpp
+++ b/test/unit/alphabet/nucleotide/nucleotide_test_template.hpp
@@ -42,8 +42,8 @@ TYPED_TEST_P(nucleotide, global_complement)
 
 TYPED_TEST_P(nucleotide, concept_check)
 {
-    EXPECT_TRUE(nucleotide_concept<TypeParam>);
-    EXPECT_TRUE(nucleotide_concept<TypeParam &>);
+    EXPECT_TRUE(NucleotideAlphabet<TypeParam>);
+    EXPECT_TRUE(NucleotideAlphabet<TypeParam &>);
 }
 
 REGISTER_TYPED_TEST_CASE_P(nucleotide, global_complement, concept_check);

--- a/test/unit/alphabet/quality/phred_test_template.hpp
+++ b/test/unit/alphabet/quality/phred_test_template.hpp
@@ -68,7 +68,7 @@ TYPED_TEST_P(phred, conversion_rank)
 // test provision of data type `phred_type` and phred converter.
 TYPED_TEST_P(phred, concept_check)
 {
-    EXPECT_TRUE(quality_concept<TypeParam>);
+    EXPECT_TRUE(QualityAlphabet<TypeParam>);
 }
 
 REGISTER_TYPED_TEST_CASE_P(phred, conversion_char, conversion_phred, conversion_rank, concept_check);


### PR DESCRIPTION
#520

All renamings which were necessary for other concepts in alphabets besides the one in this PR #621.

Renames:
aminoacid_concept -> AminoacidAlphabet
nucleotide_concept -> NucleotideAlphabet
quality_concept -> Quality (Edit: QualityAlphabet)