### PR TITLE
Rename Core Concepts

### DIFF
--- a/include/seqan3/alignment/scoring/gap_scheme.hpp
+++ b/include/seqan3/alignment/scoring/gap_scheme.hpp
@@ -223,12 +223,12 @@ public:
 
     /*!\cond DEV
      * \brief Serialisation support function.
-     * \tparam archive_t Type of `archive`; must satisfy seqan3::cereal_archive_concept.
+     * \tparam archive_t Type of `archive`; must satisfy seqan3::CerealArchive.
      * \param  archive   The archive being serialised from/to.
      *
      * \attention These functions are never called directly, see \ref serialisation for more details.
      */
-    template <cereal_archive_concept archive_t>
+    template <CerealArchive archive_t>
     void CEREAL_SERIALIZE_FUNCTION_NAME(archive_t & archive)
     {
         archive(gap);

--- a/include/seqan3/alignment/scoring/scoring_scheme_base.hpp
+++ b/include/seqan3/alignment/scoring/scoring_scheme_base.hpp
@@ -234,12 +234,12 @@ public:
 
     /*!\cond DEV
      * \brief Serialisation support function.
-     * \tparam archive_t Type of `archive`; must satisfy seqan3::cereal_archive_concept.
+     * \tparam archive_t Type of `archive`; must satisfy seqan3::CerealArchive.
      * \param  archive   The archive being serialised from/to.
      *
      * \attention These functions are never called directly, see \ref serialisation for more details.
      */
-    template <cereal_archive_concept archive_t>
+    template <CerealArchive archive_t>
     void CEREAL_SERIALIZE_FUNCTION_NAME(archive_t & archive)
     {
         archive(matrix);

--- a/include/seqan3/alphabet/concept.hpp
+++ b/include/seqan3/alphabet/concept.hpp
@@ -148,7 +148,7 @@ SEQAN3_CONCEPT alphabet_concept = semi_alphabet_concept<t> && requires (t v)
  */
 /*!
  * \brief Save an alphabet letter to stream.
- * \tparam archive_t Must satisfy seqan3::cereal_output_archive_concept.
+ * \tparam archive_t Must satisfy seqan3::CerealOutputArchive.
  * \tparam alphabet_t Type of l; must satisfy seqan3::semi_alphabet_concept.
  * \param l The alphabet letter.
  * \relates seqan3::semi_alphabet_concept
@@ -159,7 +159,7 @@ SEQAN3_CONCEPT alphabet_concept = semi_alphabet_concept<t> && requires (t v)
  *
  * \attention These functions are never called directly, see the \ref alphabet module on how to use serialisation.
  */
-template <cereal_output_archive_concept archive_t, semi_alphabet_concept alphabet_t>
+template <CerealOutputArchive archive_t, semi_alphabet_concept alphabet_t>
 underlying_rank_t<alphabet_t> CEREAL_SAVE_MINIMAL_FUNCTION_NAME(archive_t const &, alphabet_t const & l)
 {
     return to_rank(l);

--- a/include/seqan3/alphabet/concept.hpp
+++ b/include/seqan3/alphabet/concept.hpp
@@ -166,7 +166,7 @@ underlying_rank_t<alphabet_t> CEREAL_SAVE_MINIMAL_FUNCTION_NAME(archive_t const 
 }
 
 /*!\brief Restore an alphabet letter from a saved rank.
- * \tparam archive_t Must satisfy seqan3::cereal_input_archive_concept.
+ * \tparam archive_t Must satisfy seqan3::CerealInputArchive.
  * \tparam wrapped_alphabet_t A seqan3::semi_alphabet_concept after Cereal mangles it up.
  * \param l The alphabet letter (cereal wrapped).
  * \param r The assigned value.
@@ -178,7 +178,7 @@ underlying_rank_t<alphabet_t> CEREAL_SAVE_MINIMAL_FUNCTION_NAME(archive_t const 
  *
  * \attention These functions are never called directly, see the \ref alphabet module on how to use serialisation.
  */
-template <cereal_input_archive_concept archive_t, typename wrapped_alphabet_t>
+template <CerealInputArchive archive_t, typename wrapped_alphabet_t>
 void CEREAL_LOAD_MINIMAL_FUNCTION_NAME(archive_t const &,
                                        wrapped_alphabet_t && l,
                                        underlying_rank_t<detail::strip_cereal_wrapper_t<wrapped_alphabet_t>> const & r)

--- a/include/seqan3/core/algorithm/all.hpp
+++ b/include/seqan3/core/algorithm/all.hpp
@@ -26,7 +26,7 @@
  * ### Usage
  *
  * The basis of any algorithm configuration are configuration elements. These are objects that handle a specific
- * setting and must satisfy the seqan3::detail::config_element_concept. The following snippet demonstrates a
+ * setting and must satisfy the seqan3::detail::ConfigElement. The following snippet demonstrates a
  * basic setup for such configuration elements.
  *
  * \snippet test/snippet/core/algorithm/configuration.cpp configuration_setup

--- a/include/seqan3/core/algorithm/concept.hpp
+++ b/include/seqan3/core/algorithm/concept.hpp
@@ -33,7 +33,7 @@ namespace seqan3::detail
 {
 
 // ----------------------------------------------------------------------------
-// Concept config_element_concept
+// Concept ConfigElement
 // ----------------------------------------------------------------------------
 
 //!\cond
@@ -41,7 +41,7 @@ template <typename derived_t>
 class config_element_base;
 //!\endcond
 
-/*!\interface seqan3::detail::config_element_concept <>
+/*!\interface seqan3::detail::ConfigElement <>
  * \brief Concept for an algorithm configuration.
  * \ingroup algorithm
  *
@@ -49,23 +49,23 @@ class config_element_base;
  * \implements seqan3::pipeable_config_element
  */
 
-/*!\name Requirements for seqan3::detail::config_element_concept
- * \relates seqan3::detail::config_element_concept
- * \brief   You can expect this member on all types that satisfy seqan3::detail::config_element_concept.
+/*!\name Requirements for seqan3::detail::ConfigElement
+ * \relates seqan3::detail::ConfigElement
+ * \brief   You can expect this member on all types that satisfy seqan3::detail::ConfigElement.
  * \{
  */
 /*!\var id
- * \memberof seqan3::detail::config_element_concept
+ * \memberof seqan3::detail::ConfigElement
  * \brief Algorithm specific static id used for internal validation checks.
  */
 /*!\var value
- * \memberof seqan3::detail::config_element_concept
+ * \memberof seqan3::detail::ConfigElement
  * \brief Member storing the configuration value.
  */
 //!\}
 //!\cond
 template <typename config_t>
-SEQAN3_CONCEPT config_element_concept = std::Semiregular<std::remove_reference_t<config_t>> &&
+SEQAN3_CONCEPT ConfigElement = std::Semiregular<std::remove_reference_t<config_t>> &&
 requires (config_t c)
 {
     { std::remove_reference_t<config_t>::id };

--- a/include/seqan3/core/algorithm/configuration.hpp
+++ b/include/seqan3/core/algorithm/configuration.hpp
@@ -30,7 +30,7 @@ namespace seqan3
 
 //!\cond
 // Forward declaration for friend declaration definitions below.
-template <detail::config_element_concept ... configs_t>
+template <detail::ConfigElement ... configs_t>
 class configuration;
 
 template <typename lhs_derived_t, typename lhs_value_t, typename rhs_derived_t, typename rhs_value_t>
@@ -70,7 +70,7 @@ constexpr auto operator|(pipeable_config_element<lhs_derived_t, lhs_value_t> con
  * \ingroup algorithm
  *
  * \tparam configs_t Template parameter pack containing all configuration elements; Must model
- *                   seqan3::detail::config_element_concept
+ *                   seqan3::detail::ConfigElement
  *
  * \details
  *
@@ -78,11 +78,11 @@ constexpr auto operator|(pipeable_config_element<lhs_derived_t, lhs_value_t> con
  * configurations for a specific algorithm. It extends the standard tuple interface with some useful functions to modify
  * and query the user configurations.
  */
-template <detail::config_element_concept ... configs_t>
+template <detail::ConfigElement ... configs_t>
 class configuration : public std::tuple<configs_t...>
 {
     //!\brief Friend declaration for other instances of the configuration.
-    template <detail::config_element_concept ... _configs_t>
+    template <detail::ConfigElement ... _configs_t>
     friend class configuration;
 public:
     //!\privatesection
@@ -446,7 +446,7 @@ private:
      *
      * Strong exception guarantee.
      */
-    template <detail::config_element_concept config_element_t>
+    template <detail::ConfigElement config_element_t>
     constexpr auto push_back(config_element_t elem) const &
     {
         static_assert(detail::is_configuration_valid_v<remove_cvref_t<config_element_t>,
@@ -460,7 +460,7 @@ private:
     }
 
     //!\copydoc push_back
-    template <detail::config_element_concept config_element_t>
+    template <detail::ConfigElement config_element_t>
     constexpr auto push_back(config_element_t elem) &&
     {
         static_assert(detail::is_configuration_valid_v<remove_cvref_t<config_element_t>,
@@ -570,7 +570,7 @@ namespace std
 /*!\brief Returns the number of elements stored in seqan3::detail::configuration.
  * \ingroup algorithm
  */
-template <seqan3::detail::config_element_concept ... configs_t>
+template <seqan3::detail::ConfigElement ... configs_t>
 struct tuple_size<seqan3::configuration<configs_t...>>
 {
     //!\brief The number of elements.
@@ -580,7 +580,7 @@ struct tuple_size<seqan3::configuration<configs_t...>>
 /*!\brief Returns the type of the element at the specified position within seqan3::configuration.
  * \ingroup algorithm
  */
-template <size_t pos, seqan3::detail::config_element_concept ... configs_t>
+template <size_t pos, seqan3::detail::ConfigElement ... configs_t>
 struct tuple_element<pos, seqan3::configuration<configs_t...>>
 {
     //!\brief The type of the config at position `pos`

--- a/include/seqan3/core/algorithm/configuration_utility.hpp
+++ b/include/seqan3/core/algorithm/configuration_utility.hpp
@@ -52,7 +52,7 @@ inline constexpr std::array<std::array<void, 0>, 0> compatibility_table;
  *
  * \see seqan3::detail::is_configuration_valid_v
  */
-template <config_element_concept query_t, config_element_concept ... compare_types>
+template <ConfigElement query_t, ConfigElement ... compare_types>
 struct is_configuration_valid :
     public std::conditional_t<
         (std::is_same_v<remove_cvref_t<decltype(query_t::id)>, remove_cvref_t<decltype(compare_types::id)>> && ...) &&

--- a/include/seqan3/core/concept/cereal.hpp
+++ b/include/seqan3/core/concept/cereal.hpp
@@ -24,7 +24,7 @@
 namespace seqan3
 {
 
-/*!\interface seqan3::cereal_output_archive_concept <>
+/*!\interface seqan3::CerealOutputArchive <>
  * \brief All output archives of the Cereal library satisfy this.
  * \extends seqan3::CerealArchive
  * \ingroup core
@@ -38,10 +38,10 @@ namespace seqan3
 //!\cond
 #if SEQAN3_WITH_CEREAL
 template <typename t>
-SEQAN3_CONCEPT cereal_output_archive_concept = std::is_base_of_v<cereal::detail::OutputArchiveBase, t>;
+SEQAN3_CONCEPT CerealOutputArchive = std::is_base_of_v<cereal::detail::OutputArchiveBase, t>;
 #else
 template <typename t>
-SEQAN3_CONCEPT cereal_output_archive_concept = false;
+SEQAN3_CONCEPT CerealOutputArchive = false;
 #endif
 //!\endcond
 
@@ -76,7 +76,7 @@ SEQAN3_CONCEPT cereal_input_archive_concept = false;
 //!\cond
 #if SEQAN3_WITH_CEREAL
 template <typename t>
-SEQAN3_CONCEPT CerealArchive = cereal_output_archive_concept<t> || cereal_input_archive_concept<t>;
+SEQAN3_CONCEPT CerealArchive = CerealOutputArchive<t> || cereal_input_archive_concept<t>;
 #else
 template <typename t>
 SEQAN3_CONCEPT CerealArchive = false;

--- a/include/seqan3/core/concept/cereal.hpp
+++ b/include/seqan3/core/concept/cereal.hpp
@@ -45,7 +45,7 @@ SEQAN3_CONCEPT CerealOutputArchive = false;
 #endif
 //!\endcond
 
-/*!\interface seqan3::cereal_input_archive_concept <>
+/*!\interface seqan3::CerealInputArchive <>
  * \brief All input archives of the Cereal library satisfy this.
  * \extends seqan3::CerealArchive
  * \ingroup core
@@ -59,10 +59,10 @@ SEQAN3_CONCEPT CerealOutputArchive = false;
 //!\cond
 #if SEQAN3_WITH_CEREAL
 template <typename t>
-SEQAN3_CONCEPT cereal_input_archive_concept = std::is_base_of_v<cereal::detail::InputArchiveBase, t>;
+SEQAN3_CONCEPT CerealInputArchive = std::is_base_of_v<cereal::detail::InputArchiveBase, t>;
 #else
 template <typename t>
-SEQAN3_CONCEPT cereal_input_archive_concept = false;
+SEQAN3_CONCEPT CerealInputArchive = false;
 #endif
 //!\endcond
 
@@ -76,7 +76,7 @@ SEQAN3_CONCEPT cereal_input_archive_concept = false;
 //!\cond
 #if SEQAN3_WITH_CEREAL
 template <typename t>
-SEQAN3_CONCEPT CerealArchive = CerealOutputArchive<t> || cereal_input_archive_concept<t>;
+SEQAN3_CONCEPT CerealArchive = CerealOutputArchive<t> || CerealInputArchive<t>;
 #else
 template <typename t>
 SEQAN3_CONCEPT CerealArchive = false;

--- a/include/seqan3/core/concept/cereal.hpp
+++ b/include/seqan3/core/concept/cereal.hpp
@@ -104,11 +104,11 @@ SEQAN3_CONCEPT cereal_text_archive_concept = false;
 #endif
 //!\endcond
 
-/*!\interface seqan3::cerealisable_concept <>
+/*!\interface seqan3::Cerealisable <>
  * \ingroup core
  * \brief Specifies the requirements for types that are serialisable via Cereal.
  *
- * The `value_t` type satisfy the cerealisable_concept, if `value_t` can be
+ * The `value_t` type satisfy the Cerealisable, if `value_t` can be
  * serialised with cereal, i.e. `value_t` has a single serialisation function
  * (`serialize`) or split load/save pair (load and save) either inside or
  * outside of the class.
@@ -120,14 +120,14 @@ SEQAN3_CONCEPT cereal_text_archive_concept = false;
  * using namespace seqan3;
  *
  * // fundamental types are serialisable
- * static_assert(cerealisable_concept<int>);
+ * static_assert(Cerealisable<int>);
  *
  * #include <array>
  * #include <cereal/types/array.hpp> // std::array is now serialisable
- * static_assert(cerealisable_concept<std::array<int, 12>>);
+ * static_assert(Cerealisable<std::array<int, 12>>);
  *
  * #include <seqan3/alphabet/nucleotide/dna4.hpp> // dna4 is serialisable
- * static_assert(cerealisable_concept<dna4>);
+ * static_assert(Cerealisable<dna4>);
  * ```
  *
  * \attention
@@ -138,12 +138,12 @@ SEQAN3_CONCEPT cereal_text_archive_concept = false;
 template <typename value_t,
           typename input_archive_t = cereal::BinaryInputArchive,
           typename output_archive_t = cereal::BinaryOutputArchive>
-SEQAN3_CONCEPT cerealisable_concept =
+SEQAN3_CONCEPT Cerealisable =
     cereal::traits::is_input_serializable<value_t, input_archive_t>::value &&
     cereal::traits::is_output_serializable<value_t, output_archive_t>::value;
 #else
 template <typename t>
-SEQAN3_CONCEPT cerealisable_concept = false;
+SEQAN3_CONCEPT Cerealisable = false;
 #endif
 //!\endcond
 

--- a/include/seqan3/core/concept/cereal.hpp
+++ b/include/seqan3/core/concept/cereal.hpp
@@ -26,7 +26,7 @@ namespace seqan3
 
 /*!\interface seqan3::cereal_output_archive_concept <>
  * \brief All output archives of the Cereal library satisfy this.
- * \extends seqan3::cereal_archive_concept
+ * \extends seqan3::CerealArchive
  * \ingroup core
  *
  * This includes cereal::BinaryOutputArchive, cereal::PortableBinaryOutputArchive, cereal::JSONOutputArchive,
@@ -47,7 +47,7 @@ SEQAN3_CONCEPT cereal_output_archive_concept = false;
 
 /*!\interface seqan3::cereal_input_archive_concept <>
  * \brief All input archives of the Cereal library satisfy this.
- * \extends seqan3::cereal_archive_concept
+ * \extends seqan3::CerealArchive
  * \ingroup core
  *
  * This includes cereal::BinaryInputArchive, cereal::PortableBinaryInputArchive, cereal::JSONInputArchive,
@@ -66,7 +66,7 @@ SEQAN3_CONCEPT cereal_input_archive_concept = false;
 #endif
 //!\endcond
 
-/*!\interface seqan3::cereal_archive_concept <>
+/*!\interface seqan3::CerealArchive <>
  * \brief All archives of the Cereal library satisfy this.
  * \ingroup core
  *
@@ -76,16 +76,16 @@ SEQAN3_CONCEPT cereal_input_archive_concept = false;
 //!\cond
 #if SEQAN3_WITH_CEREAL
 template <typename t>
-SEQAN3_CONCEPT cereal_archive_concept = cereal_output_archive_concept<t> || cereal_input_archive_concept<t>;
+SEQAN3_CONCEPT CerealArchive = cereal_output_archive_concept<t> || cereal_input_archive_concept<t>;
 #else
 template <typename t>
-SEQAN3_CONCEPT cereal_archive_concept = false;
+SEQAN3_CONCEPT CerealArchive = false;
 #endif
 //!\endcond
 
 /*!\interface seqan3::cereal_text_archive_concept <>
  * \brief All text archives of the Cereal library satisfy this.
- * \extends seqan3::cereal_archive_concept
+ * \extends seqan3::CerealArchive
  * \ingroup core
  *
  * This includes cereal::JSONOutputArchive, cereal::XMLOutputArchive, cereal::JSONInputArchive,

--- a/include/seqan3/range/container/bitcompressed_vector.hpp
+++ b/include/seqan3/range/container/bitcompressed_vector.hpp
@@ -40,7 +40,7 @@ class debug_stream_type;
 /*!\brief A space-optimised version of std::vector that compresses multiple letters into a single byte.
  * \tparam alphabet_type The value type of the container, must satisfy seqan3::alphabet_concept and not be `&`.
  * \implements seqan3::reservable_container_concept
- * \implements seqan3::cerealisable_concept
+ * \implements seqan3::Cerealisable
  * \ingroup container
  *
  * This class template behaves just like std::vector<alphabet_type> but has an internal representation where

--- a/include/seqan3/range/container/bitcompressed_vector.hpp
+++ b/include/seqan3/range/container/bitcompressed_vector.hpp
@@ -1007,12 +1007,12 @@ public:
 
     /*!\cond DEV
      * \brief Serialisation support function.
-     * \tparam archive_t Type of `archive`; must satisfy seqan3::cereal_archive_concept.
+     * \tparam archive_t Type of `archive`; must satisfy seqan3::CerealArchive.
      * \param archive The archive being serialised from/to.
      *
      * \attention These functions are never called directly, see \ref serialisation for more details.
      */
-    template <cereal_archive_concept archive_t>
+    template <CerealArchive archive_t>
     void CEREAL_SERIALIZE_FUNCTION_NAME(archive_t & archive)
     {
         archive(data); //TODO: data not yet serialisable

--- a/include/seqan3/range/container/concatenated_sequences.hpp
+++ b/include/seqan3/range/container/concatenated_sequences.hpp
@@ -1270,12 +1270,12 @@ public:
 
     /*!\cond DEV
      * \brief Serialisation support function.
-     * \tparam archive_t Type of `archive`; must satisfy seqan3::cereal_archive_concept.
+     * \tparam archive_t Type of `archive`; must satisfy seqan3::CerealArchive.
      * \param archive The archive being serialised from/to.
      *
      * \attention These functions are never called directly, see \ref serialisation for more details.
      */
-    template <cereal_archive_concept archive_t>
+    template <CerealArchive archive_t>
     void CEREAL_SERIALIZE_FUNCTION_NAME(archive_t & archive)
     {
         archive(data_values, data_delimiters);

--- a/test/unit/alignment/configuration/align_config_band_test.cpp
+++ b/test/unit/alignment/configuration/align_config_band_test.cpp
@@ -14,9 +14,9 @@
 
 using namespace seqan3;
 
-TEST(align_config_band, config_element_concept)
+TEST(align_config_band, ConfigElement)
 {
-    EXPECT_TRUE((detail::config_element_concept<align_cfg::band<static_band>>));
+    EXPECT_TRUE((detail::ConfigElement<align_cfg::band<static_band>>));
 }
 
 TEST(align_config_band, configuration)

--- a/test/unit/alignment/configuration/align_config_common_test.cpp
+++ b/test/unit/alignment/configuration/align_config_common_test.cpp
@@ -53,9 +53,9 @@ TEST(alignment_configuration_test, number_of_configs)
     EXPECT_EQ(static_cast<uint8_t>(detail::align_config_id::SIZE), 7);
 }
 
-TYPED_TEST(alignment_configuration_test, config_element_concept)
+TYPED_TEST(alignment_configuration_test, ConfigElement)
 {
-    EXPECT_TRUE((detail::config_element_concept<TypeParam>));
+    EXPECT_TRUE((detail::ConfigElement<TypeParam>));
 }
 
 TYPED_TEST(alignment_configuration_test, configuration_exists)

--- a/test/unit/alignment/configuration/align_config_gap_test.cpp
+++ b/test/unit/alignment/configuration/align_config_gap_test.cpp
@@ -14,9 +14,9 @@
 
 using namespace seqan3;
 
-TEST(align_config_gap, config_element_concept)
+TEST(align_config_gap, ConfigElement)
 {
-    EXPECT_TRUE((detail::config_element_concept<align_cfg::gap<gap_scheme<>>>));
+    EXPECT_TRUE((detail::ConfigElement<align_cfg::gap<gap_scheme<>>>));
 }
 
 TEST(align_config_gap, configuration)

--- a/test/unit/alignment/configuration/align_config_max_error_test.cpp
+++ b/test/unit/alignment/configuration/align_config_max_error_test.cpp
@@ -15,9 +15,9 @@
 
 using namespace seqan3;
 
-TEST(align_config_max_error, config_element_concept)
+TEST(align_config_max_error, ConfigElement)
 {
-    EXPECT_TRUE((detail::config_element_concept<align_cfg::max_error>));
+    EXPECT_TRUE((detail::ConfigElement<align_cfg::max_error>));
 }
 
 TEST(align_config_max_error, configuration)

--- a/test/unit/alignment/configuration/align_config_mode_test.cpp
+++ b/test/unit/alignment/configuration/align_config_mode_test.cpp
@@ -21,9 +21,9 @@ struct align_cfg_mode_test : public ::testing::Test
 using test_types = ::testing::Types<detail::global_alignment_type>;
 TYPED_TEST_CASE(align_cfg_mode_test, test_types);
 
-TYPED_TEST(align_cfg_mode_test, config_element_concept)
+TYPED_TEST(align_cfg_mode_test, ConfigElement)
 {
-    EXPECT_EQ(detail::config_element_concept<align_cfg::mode<TypeParam>>, true);
+    EXPECT_EQ(detail::ConfigElement<align_cfg::mode<TypeParam>>, true);
 }
 
 TYPED_TEST(align_cfg_mode_test, configuration)

--- a/test/unit/alignment/configuration/align_config_result_test.cpp
+++ b/test/unit/alignment/configuration/align_config_result_test.cpp
@@ -27,9 +27,9 @@ using test_types = ::testing::Types<detail::with_score_type,
 
 TYPED_TEST_CASE(align_cfg_result_test, test_types);
 
-TEST(align_config_max_error, config_element_concept)
+TEST(align_config_max_error, ConfigElement)
 {
-    EXPECT_TRUE((detail::config_element_concept<align_cfg::result<detail::with_score_type>>));
+    EXPECT_TRUE((detail::ConfigElement<align_cfg::result<detail::with_score_type>>));
 }
 
 template <typename type>

--- a/test/unit/alignment/configuration/align_config_scoring_test.cpp
+++ b/test/unit/alignment/configuration/align_config_scoring_test.cpp
@@ -28,10 +28,10 @@ using test_types = ::testing::Types<std::tuple<aminoacid_scoring_scheme<int8_t>,
                                     std::tuple<nucleotide_scoring_scheme<int8_t>, dna15>>;
 TYPED_TEST_CASE(align_confg_scoring_test, test_types);
 
-TYPED_TEST(align_confg_scoring_test, config_element_concept)
+TYPED_TEST(align_confg_scoring_test, ConfigElement)
 {
     using scheme_t = typename TestFixture::scheme_t;
-    EXPECT_TRUE((detail::config_element_concept<align_cfg::scoring<scheme_t>>));
+    EXPECT_TRUE((detail::ConfigElement<align_cfg::scoring<scheme_t>>));
 }
 
 TYPED_TEST(align_confg_scoring_test, configuration)

--- a/test/unit/core/algorithm/configuration_test.cpp
+++ b/test/unit/core/algorithm/configuration_test.cpp
@@ -17,8 +17,8 @@ using namespace seqan3;
 
 TEST(configuration, concept_check)
 {
-    EXPECT_TRUE(detail::config_element_concept<bar>);
-    EXPECT_FALSE(detail::config_element_concept<int>);
+    EXPECT_TRUE(detail::ConfigElement<bar>);
+    EXPECT_FALSE(detail::ConfigElement<int>);
 
     EXPECT_TRUE((tuple_like_concept<configuration<bax, bar>>));
 }

--- a/test/unit/core/concept/cereal_test.cpp
+++ b/test/unit/core/concept/cereal_test.cpp
@@ -31,16 +31,16 @@ TEST(cereal, CerealOutputArchive)
     EXPECT_FALSE((CerealOutputArchive<cereal::PortableBinaryInputArchive>));
 }
 
-TEST(cereal, cereal_input_archive_concept)
+TEST(cereal, CerealInputArchive)
 {
-    EXPECT_FALSE((cereal_input_archive_concept<cereal::XMLOutputArchive>));
-    EXPECT_FALSE((cereal_input_archive_concept<cereal::JSONOutputArchive>));
-    EXPECT_FALSE((cereal_input_archive_concept<cereal::BinaryOutputArchive>));
-    EXPECT_FALSE((cereal_input_archive_concept<cereal::PortableBinaryOutputArchive>));
-    EXPECT_TRUE((cereal_input_archive_concept<cereal::XMLInputArchive>));
-    EXPECT_TRUE((cereal_input_archive_concept<cereal::JSONInputArchive>));
-    EXPECT_TRUE((cereal_input_archive_concept<cereal::BinaryInputArchive>));
-    EXPECT_TRUE((cereal_input_archive_concept<cereal::PortableBinaryInputArchive>));
+    EXPECT_FALSE((CerealInputArchive<cereal::XMLOutputArchive>));
+    EXPECT_FALSE((CerealInputArchive<cereal::JSONOutputArchive>));
+    EXPECT_FALSE((CerealInputArchive<cereal::BinaryOutputArchive>));
+    EXPECT_FALSE((CerealInputArchive<cereal::PortableBinaryOutputArchive>));
+    EXPECT_TRUE((CerealInputArchive<cereal::XMLInputArchive>));
+    EXPECT_TRUE((CerealInputArchive<cereal::JSONInputArchive>));
+    EXPECT_TRUE((CerealInputArchive<cereal::BinaryInputArchive>));
+    EXPECT_TRUE((CerealInputArchive<cereal::PortableBinaryInputArchive>));
 }
 
 TEST(cereal, CerealArchive)

--- a/test/unit/core/concept/cereal_test.cpp
+++ b/test/unit/core/concept/cereal_test.cpp
@@ -43,16 +43,16 @@ TEST(cereal, cereal_input_archive_concept)
     EXPECT_TRUE((cereal_input_archive_concept<cereal::PortableBinaryInputArchive>));
 }
 
-TEST(cereal, cereal_archive_concept)
+TEST(cereal, CerealArchive)
 {
-    EXPECT_TRUE((cereal_archive_concept<cereal::XMLOutputArchive>));
-    EXPECT_TRUE((cereal_archive_concept<cereal::JSONOutputArchive>));
-    EXPECT_TRUE((cereal_archive_concept<cereal::BinaryOutputArchive>));
-    EXPECT_TRUE((cereal_archive_concept<cereal::PortableBinaryOutputArchive>));
-    EXPECT_TRUE((cereal_archive_concept<cereal::XMLInputArchive>));
-    EXPECT_TRUE((cereal_archive_concept<cereal::JSONInputArchive>));
-    EXPECT_TRUE((cereal_archive_concept<cereal::BinaryInputArchive>));
-    EXPECT_TRUE((cereal_archive_concept<cereal::PortableBinaryInputArchive>));
+    EXPECT_TRUE((CerealArchive<cereal::XMLOutputArchive>));
+    EXPECT_TRUE((CerealArchive<cereal::JSONOutputArchive>));
+    EXPECT_TRUE((CerealArchive<cereal::BinaryOutputArchive>));
+    EXPECT_TRUE((CerealArchive<cereal::PortableBinaryOutputArchive>));
+    EXPECT_TRUE((CerealArchive<cereal::XMLInputArchive>));
+    EXPECT_TRUE((CerealArchive<cereal::JSONInputArchive>));
+    EXPECT_TRUE((CerealArchive<cereal::BinaryInputArchive>));
+    EXPECT_TRUE((CerealArchive<cereal::PortableBinaryInputArchive>));
 }
 
 TEST(cereal, cereal_text_archive_concept)

--- a/test/unit/core/concept/cereal_test.cpp
+++ b/test/unit/core/concept/cereal_test.cpp
@@ -19,16 +19,16 @@ using namespace seqan3;
 
 #if SEQAN3_WITH_CEREAL
 
-TEST(cereal, cereal_output_archive_concept)
+TEST(cereal, CerealOutputArchive)
 {
-    EXPECT_TRUE((cereal_output_archive_concept<cereal::XMLOutputArchive>));
-    EXPECT_TRUE((cereal_output_archive_concept<cereal::JSONOutputArchive>));
-    EXPECT_TRUE((cereal_output_archive_concept<cereal::BinaryOutputArchive>));
-    EXPECT_TRUE((cereal_output_archive_concept<cereal::PortableBinaryOutputArchive>));
-    EXPECT_FALSE((cereal_output_archive_concept<cereal::XMLInputArchive>));
-    EXPECT_FALSE((cereal_output_archive_concept<cereal::JSONInputArchive>));
-    EXPECT_FALSE((cereal_output_archive_concept<cereal::BinaryInputArchive>));
-    EXPECT_FALSE((cereal_output_archive_concept<cereal::PortableBinaryInputArchive>));
+    EXPECT_TRUE((CerealOutputArchive<cereal::XMLOutputArchive>));
+    EXPECT_TRUE((CerealOutputArchive<cereal::JSONOutputArchive>));
+    EXPECT_TRUE((CerealOutputArchive<cereal::BinaryOutputArchive>));
+    EXPECT_TRUE((CerealOutputArchive<cereal::PortableBinaryOutputArchive>));
+    EXPECT_FALSE((CerealOutputArchive<cereal::XMLInputArchive>));
+    EXPECT_FALSE((CerealOutputArchive<cereal::JSONInputArchive>));
+    EXPECT_FALSE((CerealOutputArchive<cereal::BinaryInputArchive>));
+    EXPECT_FALSE((CerealOutputArchive<cereal::PortableBinaryInputArchive>));
 }
 
 TEST(cereal, cereal_input_archive_concept)

--- a/test/unit/core/concept/cereal_test.cpp
+++ b/test/unit/core/concept/cereal_test.cpp
@@ -69,21 +69,21 @@ TEST(cereal, cereal_text_archive_concept)
 
 struct my_struct{};
 
-TEST(cereal, cerealisable_concept)
+TEST(cereal, Cerealisable)
 {
-    EXPECT_TRUE((cerealisable_concept<int>));
-    EXPECT_TRUE((cerealisable_concept<float>));
+    EXPECT_TRUE((Cerealisable<int>));
+    EXPECT_TRUE((Cerealisable<float>));
 
     // my_struct does not define any serialise functions
-    EXPECT_FALSE((cerealisable_concept<my_struct>));
+    EXPECT_FALSE((Cerealisable<my_struct>));
 
     // will be true, since <cereal/types/array.hpp> is included
-    EXPECT_TRUE((cerealisable_concept<std::array<int, 10>>));
+    EXPECT_TRUE((Cerealisable<std::array<int, 10>>));
     // is false, because <cereal/types/vector.hpp> is not included
-    EXPECT_FALSE((cerealisable_concept<std::vector<int>>));
+    EXPECT_FALSE((Cerealisable<std::vector<int>>));
 
     // recursive containers of cerealisable value types work
-    EXPECT_TRUE((cerealisable_concept<std::array<std::array<int, 10>, 10>>));
+    EXPECT_TRUE((Cerealisable<std::array<std::array<int, 10>, 10>>));
 }
 
 #endif

--- a/test/unit/search/search_configuration_test.cpp
+++ b/test/unit/search/search_configuration_test.cpp
@@ -42,9 +42,9 @@ TEST(search_configuration_test, symmetric_configuration)
     }
 }
 
-TYPED_TEST(search_configuration_test, config_element_concept)
+TYPED_TEST(search_configuration_test, ConfigElement)
 {
-    EXPECT_TRUE((detail::config_element_concept<TypeParam>));
+    EXPECT_TRUE((detail::ConfigElement<TypeParam>));
 }
 
 TYPED_TEST(search_configuration_test, configuration_exists)


### PR DESCRIPTION
#520

Some renamings for core.

Renames:

config_element_concept -> ConfigElement
cereal_archive_concept -> CerealArchive
cereal_output_archive_concept-> CerealOutputArchive
cereal_input_archive_concept -> CerealInputArchive
cerealisable_concept -> Cerealisable