### PR TITLE
Rename concepts core language

### DIFF
--- a/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
+++ b/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
@@ -122,7 +122,7 @@ template <typename t>
 SEQAN3_CONCEPT aligned_sequence_concept =
     std::ranges::ForwardRange<t> &&
     alphabet_concept<value_type_t<t>> &&
-    weakly_assignable_concept<reference_t<t>, gap const &> &&
+    WeaklyAssignable<reference_t<t>, gap const &> &&
     requires (t v)
     {
         { insert_gap(v, v.begin()) } -> typename t::iterator; // global functions for generic usability
@@ -159,7 +159,7 @@ SEQAN3_CONCEPT aligned_sequence_concept =
  */
 template <sequence_container_concept seq_type>
 //!\cond
-    requires weakly_assignable_concept<reference_t<seq_type>, gap const &>
+    requires WeaklyAssignable<reference_t<seq_type>, gap const &>
 //!\endcond
 inline typename seq_type::iterator insert_gap(seq_type & seq, typename seq_type::const_iterator pos_it)
 {
@@ -184,7 +184,7 @@ inline typename seq_type::iterator insert_gap(seq_type & seq, typename seq_type:
  */
 template <sequence_container_concept seq_type>
 //!\cond
-    requires weakly_assignable_concept<reference_t<seq_type>, gap const &>
+    requires WeaklyAssignable<reference_t<seq_type>, gap const &>
 //!\endcond
 inline typename seq_type::iterator insert_gap(seq_type & seq,
                                               typename seq_type::const_iterator pos_it,
@@ -213,7 +213,7 @@ inline typename seq_type::iterator insert_gap(seq_type & seq,
  */
 template <sequence_container_concept seq_type>
 //!\cond
-    requires weakly_assignable_concept<reference_t<seq_type>, gap const &>
+    requires WeaklyAssignable<reference_t<seq_type>, gap const &>
 //!\endcond
 inline typename seq_type::iterator erase_gap(seq_type & seq, typename seq_type::const_iterator pos_it)
 {
@@ -244,7 +244,7 @@ inline typename seq_type::iterator erase_gap(seq_type & seq, typename seq_type::
  */
 template <sequence_container_concept seq_type>
 //!\cond
-    requires weakly_assignable_concept<reference_t<seq_type>, gap const &>
+    requires WeaklyAssignable<reference_t<seq_type>, gap const &>
 //!\endcond
 inline typename seq_type::iterator erase_gap(seq_type & seq,
                                              typename seq_type::const_iterator first,

--- a/include/seqan3/alignment/band/static_band.hpp
+++ b/include/seqan3/alignment/band/static_band.hpp
@@ -22,9 +22,9 @@ namespace seqan3
 /*!\brief Type for a lower boundary.
  * \todo Put into core module. This might be useful in other places as well.
  * \ingroup alignment_band
- * \tparam value_t The underlying type of the lower bound; must model seqan3::arithmetic_concept.
+ * \tparam value_t The underlying type of the lower bound; must model seqan3::Arithmetic.
  */
-template <seqan3::arithmetic_concept value_t>
+template <seqan3::Arithmetic value_t>
 struct lower_bound : detail::strong_type<value_t, lower_bound<value_t>>
 {
     //!\brief Inheriting constructors from base class.
@@ -34,9 +34,9 @@ struct lower_bound : detail::strong_type<value_t, lower_bound<value_t>>
 /*!\brief Type for an upper boundary.
  * \todo Put into core module. This might be useful in other places as well.
  * \ingroup alignment_band
- * \tparam value_t The underlying type of the upper bound; must model seqan3::arithmetic_concept.
+ * \tparam value_t The underlying type of the upper bound; must model seqan3::Arithmetic.
  */
-template <seqan3::arithmetic_concept value_t>
+template <seqan3::Arithmetic value_t>
 struct upper_bound : detail::strong_type<value_t, upper_bound<value_t>>
 {
     //!\brief Inheriting constructors from base class.
@@ -49,16 +49,16 @@ struct upper_bound : detail::strong_type<value_t, upper_bound<value_t>>
  */
 /*!\brief Deduces the underlying lower boundary type.
  * \relates seqan3::lower_bound
- * \tparam value_t The underlying type of the lower bound; must model seqan3::arithmetic_concept.
+ * \tparam value_t The underlying type of the lower bound; must model seqan3::Arithmetic.
  */
-template <seqan3::arithmetic_concept value_t>
+template <seqan3::Arithmetic value_t>
 lower_bound(value_t) -> lower_bound<value_t>;
 
 /*!\brief Deduces the underlying upper boundary type.
  * \relates seqan3::upper_bound
- * \tparam value_t The underlying type of the upper bound; must model seqan3::arithmetic_concept.
+ * \tparam value_t The underlying type of the upper bound; must model seqan3::Arithmetic.
  */
-template <seqan3::arithmetic_concept value_t>
+template <seqan3::Arithmetic value_t>
 upper_bound(value_t) -> upper_bound<value_t>;
 //!\}
 

--- a/include/seqan3/alignment/scoring/aminoacid_scoring_scheme.hpp
+++ b/include/seqan3/alignment/scoring/aminoacid_scoring_scheme.hpp
@@ -79,7 +79,7 @@ enum class aminoacid_similarity_matrix
  * Score two sequences:
  * \snippet test/snippet/alignment/scoring/aminoacid_scoring_scheme.cpp score sequences
  */
-template <arithmetic_concept score_type = int8_t>
+template <Arithmetic score_type = int8_t>
 class aminoacid_scoring_scheme : public scoring_scheme_base<aminoacid_scoring_scheme<score_type>, aa27, score_type>
 {
 private:
@@ -104,7 +104,7 @@ public:
     SEQAN3_DOXYGEN_ONLY(( constexpr aminoacid_scoring_scheme() noexcept {} ))
     //!\copydoc scoring_scheme_base::scoring_scheme_base(match_score<score_arg_t> const ms, mismatch_score<score_arg_t> const mms)
     SEQAN3_DOXYGEN_ONLY((
-      template <arithmetic_concept score_arg_t>
+      template <Arithmetic score_arg_t>
       constexpr aminoacid_scoring_scheme(match_score<score_arg_t> const ms, mismatch_score<score_arg_t> const mms) {}
     ))
     //!\copydoc scoring_scheme_base::scoring_scheme_base(matrix_type const & _matrix)
@@ -292,11 +292,11 @@ aminoacid_scoring_scheme() -> aminoacid_scoring_scheme<int8_t>;
 /*!\brief Attention: This guide does not actually deduce from the underlying type, but always defaults to `int8_t`.
  * To use a larger type, specify the template argument manually.
  */
-template <arithmetic_concept score_arg_type>
+template <Arithmetic score_arg_type>
 aminoacid_scoring_scheme(match_score<score_arg_type>,
                          mismatch_score<score_arg_type>) -> aminoacid_scoring_scheme<int8_t>;
 
-template <arithmetic_concept score_arg_type>
+template <Arithmetic score_arg_type>
 aminoacid_scoring_scheme(std::array<std::array<score_arg_type, 27>, 27>) -> aminoacid_scoring_scheme<score_arg_type>;
 
 aminoacid_scoring_scheme(aminoacid_similarity_matrix) -> aminoacid_scoring_scheme<int8_t>;

--- a/include/seqan3/alignment/scoring/gap_scheme.hpp
+++ b/include/seqan3/alignment/scoring/gap_scheme.hpp
@@ -253,14 +253,14 @@ gap_scheme() -> gap_scheme<int8_t>;
  * for floating point types.
  * To use a larger type, specify the template argument manually.
  */
-template <floating_point_concept score_arg_type>
+template <FloatingPoint score_arg_type>
 gap_scheme(gap_score<score_arg_type>, gap_open_score<score_arg_type>) -> gap_scheme<float>;
 
 /*!\brief Attention: This guide does not actually deduce from the underlying type, but always defaults to `float`
  * for floating point types.
  * To use a larger type, specify the template argument manually.
  */
-template <floating_point_concept score_arg_type>
+template <FloatingPoint score_arg_type>
 gap_scheme(gap_score<score_arg_type>) -> gap_scheme<float>;
 
 /*!\brief Attention: This guide does not actually deduce from the underlying type, but always defaults to `int8_t`

--- a/include/seqan3/alignment/scoring/gap_scheme.hpp
+++ b/include/seqan3/alignment/scoring/gap_scheme.hpp
@@ -30,7 +30,7 @@ namespace seqan3
  * \ingroup scoring
  * \see seqan3::gap_scheme
  */
-template <arithmetic_concept score_type>
+template <Arithmetic score_type>
 struct gap_score : detail::strong_type<score_type, gap_score<score_type>, detail::strong_type_skill::convert>
 {
      using detail::strong_type<score_type, gap_score<score_type>, detail::strong_type_skill::convert>::strong_type;
@@ -40,7 +40,7 @@ struct gap_score : detail::strong_type<score_type, gap_score<score_type>, detail
  * \relates seqan3::gap_score
  * \{
  */
-template <arithmetic_concept score_type>
+template <Arithmetic score_type>
 gap_score(score_type &&) -> gap_score<score_type>;
 //!\}
 
@@ -54,7 +54,7 @@ gap_score(score_type &&) -> gap_score<score_type>;
  * \ingroup scoring
  * \see seqan3::gap_scheme
  */
-template <arithmetic_concept score_type>
+template <Arithmetic score_type>
 struct gap_open_score : detail::strong_type<score_type, gap_open_score<score_type>, detail::strong_type_skill::convert>
 {
      using detail::strong_type<score_type, gap_open_score<score_type>, detail::strong_type_skill::convert>::strong_type;
@@ -64,7 +64,7 @@ struct gap_open_score : detail::strong_type<score_type, gap_open_score<score_typ
  * \relates seqan3::gap_open_score
  * \{
  */
-template <arithmetic_concept score_type>
+template <Arithmetic score_type>
 gap_open_score(score_type &&) -> gap_open_score<score_type>;
 //!\}
 
@@ -76,7 +76,7 @@ gap_open_score(score_type &&) -> gap_open_score<score_type>;
  * \tparam score_type Type of the score values saved internally.
  * \ingroup scoring
  */
-template <arithmetic_concept score_t = int8_t>
+template <Arithmetic score_t = int8_t>
 class gap_scheme
 {
 public:
@@ -101,7 +101,7 @@ public:
     /*!\brief Constructor for the Affine gap costs model (delegates to set_affine()).
      * \copydetails set_affine()
      */
-    template <arithmetic_concept score_arg_t>
+    template <Arithmetic score_arg_t>
     constexpr gap_scheme(gap_score<score_arg_t> const g, gap_open_score<score_arg_t> const go)
     {
         set_affine(g, go);
@@ -110,7 +110,7 @@ public:
     /*!\brief Constructor for the Linear gap costs model (delegates to set_linear()).
      * \copydetails set_linear()
      */
-    template <arithmetic_concept score_arg_t>
+    template <Arithmetic score_arg_t>
     constexpr gap_scheme(gap_score<score_arg_t> const g)
     {
         set_linear(g);
@@ -134,7 +134,7 @@ public:
      * formula was `(n-1) * g + go`.
      *
      */
-    template <arithmetic_concept score_arg_t>
+    template <Arithmetic score_arg_t>
     constexpr void set_affine(gap_score<score_arg_t> const g, gap_open_score<score_arg_t> const go)
     {
         std::conditional_t<std::Integral<score_t>, int64_t, double> i_g = static_cast<score_arg_t>(g);
@@ -162,7 +162,7 @@ public:
      * The score for a sequence of `n` gap characters is computed as `n * g`. This is the same as the affine model
      * with a gap open score of `0`.
      */
-    template <arithmetic_concept score_arg_t>
+    template <Arithmetic score_arg_t>
     constexpr void set_linear(gap_score<score_arg_t> const g)
     {
         set_affine(g, gap_open_score<score_arg_t>{0});
@@ -267,14 +267,14 @@ gap_scheme(gap_score<score_arg_type>) -> gap_scheme<float>;
  * for integer types.
  * To use a larger type, specify the template argument manually.
  */
-template <arithmetic_concept score_arg_type>
+template <Arithmetic score_arg_type>
 gap_scheme(gap_score<score_arg_type>, gap_open_score<score_arg_type>) -> gap_scheme<int8_t>;
 
 /*!\brief Attention: This guide does not actually deduce from the underlying type, but always defaults to `int8_t`
  * for integer types.
  * To use a larger type, specify the template argument manually.
  */
-template <arithmetic_concept score_arg_type>
+template <Arithmetic score_arg_type>
 gap_scheme(gap_score<score_arg_type>) -> gap_scheme<int8_t>;
 //!\}
 

--- a/include/seqan3/alignment/scoring/nucleotide_scoring_scheme.hpp
+++ b/include/seqan3/alignment/scoring/nucleotide_scoring_scheme.hpp
@@ -40,7 +40,7 @@ namespace seqan3
  * Score two sequences:
  * \snippet test/snippet/alignment/scoring/nucleotide_scoring_scheme.cpp score sequences
  */
-template <arithmetic_concept score_type = int8_t>
+template <Arithmetic score_type = int8_t>
 class nucleotide_scoring_scheme : public scoring_scheme_base<nucleotide_scoring_scheme<score_type>, dna15, score_type>
 {
 private:
@@ -55,7 +55,7 @@ public:
     SEQAN3_DOXYGEN_ONLY(( constexpr nucleotide_scoring_scheme() noexcept {} ))
     //!\copydoc scoring_scheme_base::scoring_scheme_base(match_score<score_arg_t> const ms, mismatch_score<score_arg_t> const mms)
     SEQAN3_DOXYGEN_ONLY((
-      template <arithmetic_concept score_arg_t>
+      template <Arithmetic score_arg_t>
       constexpr nucleotide_scoring_scheme(match_score<score_arg_t> const ms, mismatch_score<score_arg_t> const mms) {}
     ))
     //!\copydoc scoring_scheme_base::scoring_scheme_base(matrix_type const & _matrix)
@@ -76,11 +76,11 @@ nucleotide_scoring_scheme() -> nucleotide_scoring_scheme<int8_t>;
 /*!\brief Attention: This guide does not actually deduce from the underlying type, but always defaults to `int8_t`.
  * To use a larger type, specify the template argument manually.
  */
-template <arithmetic_concept score_arg_type>
+template <Arithmetic score_arg_type>
 nucleotide_scoring_scheme(match_score<score_arg_type>,
                           mismatch_score<score_arg_type>) -> nucleotide_scoring_scheme<int8_t>;
 
-template <arithmetic_concept score_arg_type>
+template <Arithmetic score_arg_type>
 nucleotide_scoring_scheme(std::array<std::array<score_arg_type, 15>, 15>) -> nucleotide_scoring_scheme<score_arg_type>;
 //!\}
 

--- a/include/seqan3/alignment/scoring/scoring_scheme_base.hpp
+++ b/include/seqan3/alignment/scoring/scoring_scheme_base.hpp
@@ -37,7 +37,7 @@ namespace seqan3
  * \ingroup scoring
  * \see scoring_scheme_base::set_simple_scheme
  */
-template <arithmetic_concept score_type>
+template <Arithmetic score_type>
 struct match_score : detail::strong_type<score_type, match_score<score_type>, detail::strong_type_skill::convert>
 {
      using detail::strong_type<score_type, match_score<score_type>, detail::strong_type_skill::convert>::strong_type;
@@ -47,7 +47,7 @@ struct match_score : detail::strong_type<score_type, match_score<score_type>, de
  * \relates seqan3::match_score
  * \{
  */
-template <arithmetic_concept score_type>
+template <Arithmetic score_type>
 match_score(score_type &&) -> match_score<score_type>;
 //!\}
 
@@ -60,7 +60,7 @@ match_score(score_type &&) -> match_score<score_type>;
  * \ingroup scoring
  * \see scoring_scheme_base::set_simple_scheme
  */
-template <arithmetic_concept score_type>
+template <Arithmetic score_type>
 struct mismatch_score : detail::strong_type<score_type, mismatch_score<score_type>, detail::strong_type_skill::convert>
 {
      using detail::strong_type<score_type, mismatch_score<score_type>, detail::strong_type_skill::convert>::strong_type;
@@ -70,7 +70,7 @@ struct mismatch_score : detail::strong_type<score_type, mismatch_score<score_typ
  * \relates seqan3::mismatch_score
  * \{
  */
-template <arithmetic_concept score_type>
+template <Arithmetic score_type>
 mismatch_score(score_type &&) -> mismatch_score<score_type>;
 //!\}
 
@@ -88,7 +88,7 @@ mismatch_score(score_type &&) -> mismatch_score<score_type>;
  *
  * This type is never used directly, instead use seqan3::nucleotide_scoring_scheme or seqan3::aminoacid_scoring_scheme.
  */
-template <typename derived_t, alphabet_concept alphabet_t, arithmetic_concept score_t>
+template <typename derived_t, alphabet_concept alphabet_t, Arithmetic score_t>
 class scoring_scheme_base
 {
 public:
@@ -134,7 +134,7 @@ private:
     /*!\brief Constructor for the simple scheme (delegates to set_simple_scheme()).
      * \copydetails set_simple_scheme()
      */
-    template <arithmetic_concept score_arg_t>
+    template <Arithmetic score_arg_t>
     constexpr scoring_scheme_base(match_score<score_arg_t> const ms, mismatch_score<score_arg_t> const mms)
     {
         set_simple_scheme(ms, mms);
@@ -165,7 +165,7 @@ public:
      * \param[in] mms Mismatches shall be given this value (of type seqan3::mismatch_score).
      * \throws std::invalid_argument Thrown if you pass a value that is to large/low to be represented by `score_t`.
      */
-    template <arithmetic_concept score_arg_t>
+    template <Arithmetic score_arg_t>
     constexpr void set_simple_scheme(match_score<score_arg_t> const ms, mismatch_score<score_arg_t> const mms)
     {
         std::conditional_t<std::Integral<score_t>, int64_t, double> i_ms = static_cast<score_arg_t>(ms);

--- a/include/seqan3/alignment/scoring/scoring_scheme_base.hpp
+++ b/include/seqan3/alignment/scoring/scoring_scheme_base.hpp
@@ -203,16 +203,15 @@ public:
      * \param[in] alph2   The second letter to score.
      * \return The score of the two letters in the current scheme.
      */
-    template <explicitly_convertible_to_concept<alphabet_t> alph1_t,
-              explicitly_convertible_to_concept<alphabet_t> alph2_t>
+    template <ExplicitlyConvertibleTo<alphabet_t> alph1_t,
+              ExplicitlyConvertibleTo<alphabet_t> alph2_t>
     constexpr score_t & score(alph1_t const alph1, alph2_t const alph2) noexcept
     {
         return matrix[to_rank(static_cast<alphabet_t>(alph1))][to_rank(static_cast<alphabet_t>(alph2))];
     }
 
     //!\copydoc score
-    template <explicitly_convertible_to_concept<alphabet_t> alph1_t,
-              explicitly_convertible_to_concept<alphabet_t> alph2_t>
+    template <ExplicitlyConvertibleTo<alphabet_t> alph1_t, ExplicitlyConvertibleTo<alphabet_t> alph2_t>
     constexpr score_t score(alph1_t const alph1, alph2_t const alph2) const noexcept
     {
         return matrix[to_rank(static_cast<alphabet_t>(alph1))][to_rank(static_cast<alphabet_t>(alph2))];

--- a/include/seqan3/alignment/scoring/scoring_scheme_concept.hpp
+++ b/include/seqan3/alignment/scoring/scoring_scheme_concept.hpp
@@ -37,7 +37,7 @@ namespace seqan3
  * \{
  */
 /*!\typedef     typedef IMPLEMENTATION_DEFINED score_type;
- * \brief       The type returned by seqan3::scoring_scheme_concept::score(), usually a seqan3::arithmetic_concept.
+ * \brief       The type returned by seqan3::scoring_scheme_concept::score(), usually a seqan3::Arithmetic.
  * \memberof seqan3::scoring_scheme_concept
  *
  * \details

--- a/include/seqan3/alphabet/aminoacid/aa20.hpp
+++ b/include/seqan3/alphabet/aminoacid/aa20.hpp
@@ -26,7 +26,7 @@ namespace seqan3
  * \implements seqan3::AminoacidAlphabet
  * \implements seqan3::detail::constexpr_alphabet_concept
  * \implements seqan3::TriviallyCopyable
- * \implements seqan3::standard_layout_concept
+ * \implements seqan3::StandardLayout
  *
  * \details
  * The alphabet consists of letters A, C, D, E, F, G, H, I, K, L, M, N, P, Q, R, S, T, V, W, Y

--- a/include/seqan3/alphabet/aminoacid/aa20.hpp
+++ b/include/seqan3/alphabet/aminoacid/aa20.hpp
@@ -25,7 +25,7 @@ namespace seqan3
  * \ingroup aminoacid
  * \implements seqan3::AminoacidAlphabet
  * \implements seqan3::detail::constexpr_alphabet_concept
- * \implements seqan3::trivially_copyable_concept
+ * \implements seqan3::TriviallyCopyable
  * \implements seqan3::standard_layout_concept
  *
  * \details

--- a/include/seqan3/alphabet/aminoacid/aa27.hpp
+++ b/include/seqan3/alphabet/aminoacid/aa27.hpp
@@ -25,7 +25,7 @@ namespace seqan3
  * \implements seqan3::AminoacidAlphabet
  * \implements seqan3::detail::constexpr_alphabet_concept
  * \implements seqan3::TriviallyCopyable
- * \implements seqan3::standard_layout_concept
+ * \implements seqan3::StandardLayout
  *
  * \details
  * The alphabet consists of letters A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X,

--- a/include/seqan3/alphabet/aminoacid/aa27.hpp
+++ b/include/seqan3/alphabet/aminoacid/aa27.hpp
@@ -24,7 +24,7 @@ namespace seqan3
  * \ingroup aminoacid
  * \implements seqan3::AminoacidAlphabet
  * \implements seqan3::detail::constexpr_alphabet_concept
- * \implements seqan3::trivially_copyable_concept
+ * \implements seqan3::TriviallyCopyable
  * \implements seqan3::standard_layout_concept
  *
  * \details

--- a/include/seqan3/alphabet/composition/cartesian_composition.hpp
+++ b/include/seqan3/alphabet/composition/cartesian_composition.hpp
@@ -89,7 +89,7 @@ template <typename ... cartesian_comps,
           typename cartesian_derived_t,
           template <typename> typename fun_t,
           typename other_t>
-    requires convertible_to_by_member_concept<other_t, cartesian_derived_t>
+    requires ConvertibleToByMember<other_t, cartesian_derived_t>
 inline bool constexpr one_component_is<cartesian_composition<cartesian_derived_t, cartesian_comps...>,
                                        cartesian_derived_t,
                                        fun_t,

--- a/include/seqan3/alphabet/composition/cartesian_composition.hpp
+++ b/include/seqan3/alphabet/composition/cartesian_composition.hpp
@@ -633,8 +633,8 @@ constexpr bool operator!=(indirect_component_type const & lhs,
 
 template <typename indirect_component_type, typename derived_type, typename ...indirect_component_types>
 //!\cond
-    requires detail::weakly_ordered_by_members_with_concept<derived_type, indirect_component_type> &&
-             !detail::weakly_ordered_by_members_with_concept<indirect_component_type, derived_type>
+    requires detail::WeaklyOrderedByMembersWith<derived_type, indirect_component_type> &&
+             !detail::WeaklyOrderedByMembersWith<indirect_component_type, derived_type>
 //!\endcond
 constexpr bool operator<(indirect_component_type const & lhs,
                          cartesian_composition<derived_type, indirect_component_types...> const & rhs) noexcept
@@ -644,8 +644,8 @@ constexpr bool operator<(indirect_component_type const & lhs,
 
 template <typename indirect_component_type, typename derived_type, typename ...indirect_component_types>
 //!\cond
-    requires detail::weakly_ordered_by_members_with_concept<derived_type, indirect_component_type> &&
-             !detail::weakly_ordered_by_members_with_concept<indirect_component_type, derived_type>
+    requires detail::WeaklyOrderedByMembersWith<derived_type, indirect_component_type> &&
+             !detail::WeaklyOrderedByMembersWith<indirect_component_type, derived_type>
 //!\endcond
 constexpr bool operator>(indirect_component_type const & lhs,
                          cartesian_composition<derived_type, indirect_component_types...> const & rhs) noexcept
@@ -655,8 +655,8 @@ constexpr bool operator>(indirect_component_type const & lhs,
 
 template <typename indirect_component_type, typename derived_type, typename ...indirect_component_types>
 //!\cond
-    requires detail::weakly_ordered_by_members_with_concept<derived_type, indirect_component_type> &&
-             !detail::weakly_ordered_by_members_with_concept<indirect_component_type, derived_type>
+    requires detail::WeaklyOrderedByMembersWith<derived_type, indirect_component_type> &&
+             !detail::WeaklyOrderedByMembersWith<indirect_component_type, derived_type>
 //!\endcond
 constexpr bool operator<=(indirect_component_type const & lhs,
                           cartesian_composition<derived_type, indirect_component_types...> const & rhs) noexcept
@@ -666,8 +666,8 @@ constexpr bool operator<=(indirect_component_type const & lhs,
 
 template <typename indirect_component_type, typename derived_type, typename ...indirect_component_types>
 //!\cond
-    requires detail::weakly_ordered_by_members_with_concept<derived_type, indirect_component_type> &&
-             !detail::weakly_ordered_by_members_with_concept<indirect_component_type, derived_type>
+    requires detail::WeaklyOrderedByMembersWith<derived_type, indirect_component_type> &&
+             !detail::WeaklyOrderedByMembersWith<indirect_component_type, derived_type>
 //!\endcond
 constexpr bool operator>=(indirect_component_type const & lhs,
                           cartesian_composition<derived_type, indirect_component_types...> const & rhs) noexcept

--- a/include/seqan3/alphabet/composition/cartesian_composition.hpp
+++ b/include/seqan3/alphabet/composition/cartesian_composition.hpp
@@ -113,7 +113,7 @@ inline bool constexpr one_component_is<cartesian_composition<cartesian_derived_t
 template <typename ... cartesian_comps,
           typename cartesian_derived_t,
           typename other_t>
-    requires implicitly_convertible_to_concept<other_t, cartesian_derived_t>
+    requires ImplicitlyConvertibleTo<other_t, cartesian_derived_t>
 inline bool constexpr one_component_is<cartesian_composition<cartesian_derived_t, cartesian_comps...>,
                                        cartesian_derived_t,
                                        weakly_equality_comparable_with,
@@ -121,7 +121,7 @@ inline bool constexpr one_component_is<cartesian_composition<cartesian_derived_t
 template <typename ... cartesian_comps,
           typename cartesian_derived_t,
           typename other_t>
-    requires implicitly_convertible_to_concept<other_t, cartesian_derived_t>
+    requires ImplicitlyConvertibleTo<other_t, cartesian_derived_t>
 inline bool constexpr one_component_is<cartesian_composition<cartesian_derived_t, cartesian_comps...>,
                                        cartesian_derived_t,
                                        weakly_ordered_with,

--- a/include/seqan3/alphabet/composition/cartesian_composition.hpp
+++ b/include/seqan3/alphabet/composition/cartesian_composition.hpp
@@ -611,8 +611,8 @@ private:
  */
 template <typename indirect_component_type, typename derived_type, typename ...component_types>
 //!\cond
-    requires detail::weakly_equality_comparable_by_members_with_concept<derived_type, indirect_component_type> &&
-             !detail::weakly_equality_comparable_by_members_with_concept<indirect_component_type, derived_type>
+    requires detail::WeaklyEqualityComparableByMembersWith<derived_type, indirect_component_type> &&
+             !detail::WeaklyEqualityComparableByMembersWith<indirect_component_type, derived_type>
 //!\endcond
 constexpr bool operator==(indirect_component_type const & lhs,
                           cartesian_composition<derived_type, component_types...> const & rhs) noexcept
@@ -622,8 +622,8 @@ constexpr bool operator==(indirect_component_type const & lhs,
 
 template <typename indirect_component_type, typename derived_type, typename ...indirect_component_types>
 //!\cond
-    requires detail::weakly_equality_comparable_by_members_with_concept<derived_type, indirect_component_type> &&
-             !detail::weakly_equality_comparable_by_members_with_concept<indirect_component_type, derived_type>
+    requires detail::WeaklyEqualityComparableByMembersWith<derived_type, indirect_component_type> &&
+             !detail::WeaklyEqualityComparableByMembersWith<indirect_component_type, derived_type>
 //!\endcond
 constexpr bool operator!=(indirect_component_type const & lhs,
                           cartesian_composition<derived_type, indirect_component_types...> const & rhs) noexcept

--- a/include/seqan3/alphabet/composition/detail.hpp
+++ b/include/seqan3/alphabet/composition/detail.hpp
@@ -145,7 +145,7 @@ struct weakly_ordered_with
 {
     //!\brief The returned type when invoked.
     template <typename type>
-    using invoke = std::integral_constant<bool, weakly_ordered_with_concept<type, T>>;
+    using invoke = std::integral_constant<bool, WeaklyOrderedWith<type, T>>;
 };
 
 } // namespace seqan3::detail

--- a/include/seqan3/alphabet/composition/detail.hpp
+++ b/include/seqan3/alphabet/composition/detail.hpp
@@ -123,7 +123,7 @@ struct assignable_from
 {
     //!\brief The returned type when invoked.
     template <typename type>
-    using invoke = std::integral_constant<bool, weakly_assignable_concept<type, T>>;
+    using invoke = std::integral_constant<bool, WeaklyAssignable<type, T>>;
 };
 
 /*!\brief 'Callable' helper class that is invokable by meta::invoke.

--- a/include/seqan3/alphabet/composition/detail.hpp
+++ b/include/seqan3/alphabet/composition/detail.hpp
@@ -112,7 +112,7 @@ struct implicitly_convertible_from
 {
     //!\brief The returned type when invoked.
     template <typename type>
-    using invoke = std::integral_constant<bool, implicitly_convertible_to_concept<T, type>>;
+    using invoke = std::integral_constant<bool, ImplicitlyConvertibleTo<T, type>>;
 };
 
 /*!\brief 'Callable' helper class that is invokable by meta::invoke.

--- a/include/seqan3/alphabet/composition/union_composition.hpp
+++ b/include/seqan3/alphabet/composition/union_composition.hpp
@@ -77,7 +77,7 @@ inline bool constexpr one_alternative_is<union_composition<alternatives...>,
 template <typename ... alternatives,
           template <typename> typename fun_t,
           typename target_t>
-    requires convertible_to_by_member_concept<target_t, union_composition<alternatives...>>
+    requires ConvertibleToByMember<target_t, union_composition<alternatives...>>
 inline bool constexpr one_alternative_is<union_composition<alternatives...>,
                                          fun_t,
                                          target_t> = false;

--- a/include/seqan3/alphabet/composition/union_composition.hpp
+++ b/include/seqan3/alphabet/composition/union_composition.hpp
@@ -145,7 +145,7 @@ namespace seqan3
  * \implements seqan3::alphabet_concept
  * \implements seqan3::detail::constexpr_alphabet_concept
  * \implements seqan3::TriviallyCopyable
- * \implements seqan3::standard_layout_concept
+ * \implements seqan3::StandardLayout
 
  * \details
  *

--- a/include/seqan3/alphabet/composition/union_composition.hpp
+++ b/include/seqan3/alphabet/composition/union_composition.hpp
@@ -144,7 +144,7 @@ namespace seqan3
  *                              unique.
  * \implements seqan3::alphabet_concept
  * \implements seqan3::detail::constexpr_alphabet_concept
- * \implements seqan3::trivially_copyable_concept
+ * \implements seqan3::TriviallyCopyable
  * \implements seqan3::standard_layout_concept
 
  * \details

--- a/include/seqan3/alphabet/composition/union_composition.hpp
+++ b/include/seqan3/alphabet/composition/union_composition.hpp
@@ -563,8 +563,8 @@ protected:
 template <typename lhs_t, typename ...alternative_types>
 constexpr bool operator==(lhs_t const & lhs, union_composition<alternative_types...> const & rhs) noexcept
 //!\cond
-    requires detail::weakly_equality_comparable_by_members_with_concept<union_composition<alternative_types...>, lhs_t> &&
-             !detail::weakly_equality_comparable_by_members_with_concept<lhs_t, union_composition<alternative_types...>>
+    requires detail::WeaklyEqualityComparableByMembersWith<union_composition<alternative_types...>, lhs_t> &&
+             !detail::WeaklyEqualityComparableByMembersWith<lhs_t, union_composition<alternative_types...>>
 //!\endcond
 {
     return rhs == lhs;
@@ -573,8 +573,8 @@ constexpr bool operator==(lhs_t const & lhs, union_composition<alternative_types
 template <typename lhs_t, typename ...alternative_types>
 constexpr bool operator!=(lhs_t const & lhs, union_composition<alternative_types...> const & rhs) noexcept
 //!\cond
-    requires detail::weakly_equality_comparable_by_members_with_concept<union_composition<alternative_types...>, lhs_t> &&
-             !detail::weakly_equality_comparable_by_members_with_concept<lhs_t, union_composition<alternative_types...>>
+    requires detail::WeaklyEqualityComparableByMembersWith<union_composition<alternative_types...>, lhs_t> &&
+             !detail::WeaklyEqualityComparableByMembersWith<lhs_t, union_composition<alternative_types...>>
 //!\endcond
 {
     return rhs != lhs;

--- a/include/seqan3/alphabet/concept.hpp
+++ b/include/seqan3/alphabet/concept.hpp
@@ -48,7 +48,7 @@ namespace seqan3
  * For the purpose of concept checking the types `t &` and `t &&` are also considered to satisfy
  * seqan3::semi_alphabet_concept if the type `t` satisfies it.
  *
- * It is recommended that alphabets also model seqan3::standard_layout_concept and seqan3::trivially_copyable_concept
+ * It is recommended that alphabets also model seqan3::standard_layout_concept and seqan3::TriviallyCopyable
  * and all alphabets shipped with SeqAn3 do so.
  *
  * \par Serialisation

--- a/include/seqan3/alphabet/concept.hpp
+++ b/include/seqan3/alphabet/concept.hpp
@@ -48,7 +48,7 @@ namespace seqan3
  * For the purpose of concept checking the types `t &` and `t &&` are also considered to satisfy
  * seqan3::semi_alphabet_concept if the type `t` satisfies it.
  *
- * It is recommended that alphabets also model seqan3::standard_layout_concept and seqan3::TriviallyCopyable
+ * It is recommended that alphabets also model seqan3::StandardLayout and seqan3::TriviallyCopyable
  * and all alphabets shipped with SeqAn3 do so.
  *
  * \par Serialisation

--- a/include/seqan3/alphabet/detail/alphabet_proxy.hpp
+++ b/include/seqan3/alphabet/detail/alphabet_proxy.hpp
@@ -181,7 +181,7 @@ private:
     //!\brief Assignment from any type that the emulated type is assignable from.
     template <typename indirect_assignable_type>
     constexpr derived_type & operator=(indirect_assignable_type const & c) noexcept
-        requires weakly_assignable_concept<alphabet_type, indirect_assignable_type>
+        requires WeaklyAssignable<alphabet_type, indirect_assignable_type>
     {
         alphabet_type a{};
         a = c;

--- a/include/seqan3/alphabet/gap/gap.hpp
+++ b/include/seqan3/alphabet/gap/gap.hpp
@@ -25,7 +25,7 @@ namespace seqan3
  * \implements seqan3::alphabet_concept
  * \implements seqan3::detail::constexpr_alphabet_concept
  * \implements seqan3::TriviallyCopyable
- * \implements seqan3::standard_layout_concept
+ * \implements seqan3::StandardLayout
  *
  * The alphabet always has the same value ('-').
  *

--- a/include/seqan3/alphabet/gap/gap.hpp
+++ b/include/seqan3/alphabet/gap/gap.hpp
@@ -24,7 +24,7 @@ namespace seqan3
  * \ingroup gap
  * \implements seqan3::alphabet_concept
  * \implements seqan3::detail::constexpr_alphabet_concept
- * \implements seqan3::trivially_copyable_concept
+ * \implements seqan3::TriviallyCopyable
  * \implements seqan3::standard_layout_concept
  *
  * The alphabet always has the same value ('-').

--- a/include/seqan3/alphabet/mask/mask.hpp
+++ b/include/seqan3/alphabet/mask/mask.hpp
@@ -22,7 +22,7 @@ namespace seqan3
  * \ingroup mask
  * \implements seqan3::semi_alphabet_concept
  * \implements seqan3::detail::semi_constexpr_alphabet_concept
- * \implements seqan3::trivially_copyable_concept
+ * \implements seqan3::TriviallyCopyable
  * \implements seqan3::standard_layout_concept
  *
  * \details

--- a/include/seqan3/alphabet/mask/mask.hpp
+++ b/include/seqan3/alphabet/mask/mask.hpp
@@ -23,7 +23,7 @@ namespace seqan3
  * \implements seqan3::semi_alphabet_concept
  * \implements seqan3::detail::semi_constexpr_alphabet_concept
  * \implements seqan3::TriviallyCopyable
- * \implements seqan3::standard_layout_concept
+ * \implements seqan3::StandardLayout
  *
  * \details
  * This alphabet is not usually used directly, but instead via seqan3::masked.

--- a/include/seqan3/alphabet/mask/masked.hpp
+++ b/include/seqan3/alphabet/mask/masked.hpp
@@ -25,7 +25,7 @@ namespace seqan3
  * \implements seqan3::alphabet_concept
  * \implements seqan3::detail::semi_constexpr_alphabet_concept
  * \implements seqan3::TriviallyCopyable
- * \implements seqan3::standard_layout_concept
+ * \implements seqan3::StandardLayout
  *
  * \tparam sequence_alphabet_t Type of the first letter; must satisfy seqan3::semi_alphabet_concept.
  * \tparam mask_t Types of masked letter; must satisfy seqan3::semi_alphabet_concept, defaults to seqan3::mask.

--- a/include/seqan3/alphabet/mask/masked.hpp
+++ b/include/seqan3/alphabet/mask/masked.hpp
@@ -24,7 +24,7 @@ namespace seqan3
  * \ingroup mask
  * \implements seqan3::alphabet_concept
  * \implements seqan3::detail::semi_constexpr_alphabet_concept
- * \implements seqan3::trivially_copyable_concept
+ * \implements seqan3::TriviallyCopyable
  * \implements seqan3::standard_layout_concept
  *
  * \tparam sequence_alphabet_t Type of the first letter; must satisfy seqan3::semi_alphabet_concept.

--- a/include/seqan3/alphabet/nucleotide/dna15.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna15.hpp
@@ -31,7 +31,7 @@ class rna15;
  * \implements seqan3::NucleotideAlphabet
  * \implements seqan3::detail::constexpr_alphabet_concept
  * \implements seqan3::TriviallyCopyable
- * \implements seqan3::standard_layout_concept
+ * \implements seqan3::StandardLayout
  *
  * \details
  * Note that you can assign 'U' as a character to dna15 and it will silently

--- a/include/seqan3/alphabet/nucleotide/dna15.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna15.hpp
@@ -30,7 +30,7 @@ class rna15;
  * \ingroup nucleotide
  * \implements seqan3::NucleotideAlphabet
  * \implements seqan3::detail::constexpr_alphabet_concept
- * \implements seqan3::trivially_copyable_concept
+ * \implements seqan3::TriviallyCopyable
  * \implements seqan3::standard_layout_concept
  *
  * \details

--- a/include/seqan3/alphabet/nucleotide/dna4.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna4.hpp
@@ -30,7 +30,7 @@ class rna4;
  * \ingroup nucleotide
  * \implements seqan3::NucleotideAlphabet
  * \implements seqan3::detail::constexpr_alphabet_concept
- * \implements seqan3::trivially_copyable_concept
+ * \implements seqan3::TriviallyCopyable
  * \implements seqan3::standard_layout_concept
  *
  * \details

--- a/include/seqan3/alphabet/nucleotide/dna4.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna4.hpp
@@ -31,7 +31,7 @@ class rna4;
  * \implements seqan3::NucleotideAlphabet
  * \implements seqan3::detail::constexpr_alphabet_concept
  * \implements seqan3::TriviallyCopyable
- * \implements seqan3::standard_layout_concept
+ * \implements seqan3::StandardLayout
  *
  * \details
  * Note that you can assign 'U' as a character to dna4 and it will silently

--- a/include/seqan3/alphabet/nucleotide/dna5.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna5.hpp
@@ -31,7 +31,7 @@ class rna5;
  * \implements seqan3::NucleotideAlphabet
  * \implements seqan3::detail::constexpr_alphabet_concept
  * \implements seqan3::TriviallyCopyable
- * \implements seqan3::standard_layout_concept
+ * \implements seqan3::StandardLayout
  *
  * \details
  * Note that you can assign 'U' as a character to dna5 and it will silently

--- a/include/seqan3/alphabet/nucleotide/dna5.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna5.hpp
@@ -30,7 +30,7 @@ class rna5;
  * \ingroup nucleotide
  * \implements seqan3::NucleotideAlphabet
  * \implements seqan3::detail::constexpr_alphabet_concept
- * \implements seqan3::trivially_copyable_concept
+ * \implements seqan3::TriviallyCopyable
  * \implements seqan3::standard_layout_concept
  *
  * \details

--- a/include/seqan3/alphabet/nucleotide/rna15.hpp
+++ b/include/seqan3/alphabet/nucleotide/rna15.hpp
@@ -27,7 +27,7 @@ namespace seqan3
 /*!\brief The 15 letter RNA alphabet, containing all IUPAC smybols minus the gap.
  * \implements seqan3::NucleotideAlphabet
  * \implements seqan3::detail::constexpr_alphabet_concept
- * \implements seqan3::trivially_copyable_concept
+ * \implements seqan3::TriviallyCopyable
  * \implements seqan3::standard_layout_concept
  *
  * \ingroup nucleotide

--- a/include/seqan3/alphabet/nucleotide/rna15.hpp
+++ b/include/seqan3/alphabet/nucleotide/rna15.hpp
@@ -28,7 +28,7 @@ namespace seqan3
  * \implements seqan3::NucleotideAlphabet
  * \implements seqan3::detail::constexpr_alphabet_concept
  * \implements seqan3::TriviallyCopyable
- * \implements seqan3::standard_layout_concept
+ * \implements seqan3::StandardLayout
  *
  * \ingroup nucleotide
  *

--- a/include/seqan3/alphabet/nucleotide/rna4.hpp
+++ b/include/seqan3/alphabet/nucleotide/rna4.hpp
@@ -29,7 +29,7 @@ namespace seqan3
  * \implements seqan3::NucleotideAlphabet
  * \implements seqan3::detail::constexpr_alphabet_concept
  * \implements seqan3::TriviallyCopyable
- * \implements seqan3::standard_layout_concept
+ * \implements seqan3::StandardLayout
  *
  * \details
  * This alphabet has the same internal representation as seqan3::dna4, the only difference is that it prints 'U' on

--- a/include/seqan3/alphabet/nucleotide/rna4.hpp
+++ b/include/seqan3/alphabet/nucleotide/rna4.hpp
@@ -28,7 +28,7 @@ namespace seqan3
  * \ingroup nucleotide
  * \implements seqan3::NucleotideAlphabet
  * \implements seqan3::detail::constexpr_alphabet_concept
- * \implements seqan3::trivially_copyable_concept
+ * \implements seqan3::TriviallyCopyable
  * \implements seqan3::standard_layout_concept
  *
  * \details

--- a/include/seqan3/alphabet/nucleotide/rna5.hpp
+++ b/include/seqan3/alphabet/nucleotide/rna5.hpp
@@ -28,7 +28,7 @@ namespace seqan3
  * \ingroup nucleotide
  * \implements seqan3::NucleotideAlphabet
  * \implements seqan3::detail::constexpr_alphabet_concept
- * \implements seqan3::trivially_copyable_concept
+ * \implements seqan3::TriviallyCopyable
  * \implements seqan3::standard_layout_concept
  *
  * \details

--- a/include/seqan3/alphabet/nucleotide/rna5.hpp
+++ b/include/seqan3/alphabet/nucleotide/rna5.hpp
@@ -29,7 +29,7 @@ namespace seqan3
  * \implements seqan3::NucleotideAlphabet
  * \implements seqan3::detail::constexpr_alphabet_concept
  * \implements seqan3::TriviallyCopyable
- * \implements seqan3::standard_layout_concept
+ * \implements seqan3::StandardLayout
  *
  * \details
  * This alphabet has the same internal representation as seqan3::dna5, the only difference is that it prints 'U' on

--- a/include/seqan3/alphabet/quality/phred42.hpp
+++ b/include/seqan3/alphabet/quality/phred42.hpp
@@ -24,7 +24,7 @@ namespace seqan3
 /*!\brief Quality type for traditional Sanger and modern Illumina Phred scores (typical range).
  * \implements seqan3::QualityAlphabet
  * \implements seqan3::detail::constexpr_alphabet_concept
- * \implements seqan3::trivially_copyable_concept
+ * \implements seqan3::TriviallyCopyable
  * \implements seqan3::standard_layout_concept
  *
  * \ingroup quality

--- a/include/seqan3/alphabet/quality/phred42.hpp
+++ b/include/seqan3/alphabet/quality/phred42.hpp
@@ -25,7 +25,7 @@ namespace seqan3
  * \implements seqan3::QualityAlphabet
  * \implements seqan3::detail::constexpr_alphabet_concept
  * \implements seqan3::TriviallyCopyable
- * \implements seqan3::standard_layout_concept
+ * \implements seqan3::StandardLayout
  *
  * \ingroup quality
  *

--- a/include/seqan3/alphabet/quality/phred63.hpp
+++ b/include/seqan3/alphabet/quality/phred63.hpp
@@ -24,7 +24,7 @@ namespace seqan3
 /*!\brief Quality type for traditional Sanger and modern Illumina Phred scores (full range).
  * \implements seqan3::QualityAlphabet
  * \implements seqan3::detail::constexpr_alphabet_concept
- * \implements seqan3::trivially_copyable_concept
+ * \implements seqan3::TriviallyCopyable
  * \implements seqan3::standard_layout_concept
  *
  * \ingroup quality

--- a/include/seqan3/alphabet/quality/phred63.hpp
+++ b/include/seqan3/alphabet/quality/phred63.hpp
@@ -25,7 +25,7 @@ namespace seqan3
  * \implements seqan3::QualityAlphabet
  * \implements seqan3::detail::constexpr_alphabet_concept
  * \implements seqan3::TriviallyCopyable
- * \implements seqan3::standard_layout_concept
+ * \implements seqan3::StandardLayout
  *
  * \ingroup quality
  *

--- a/include/seqan3/alphabet/quality/phred68legacy.hpp
+++ b/include/seqan3/alphabet/quality/phred68legacy.hpp
@@ -24,7 +24,7 @@ namespace seqan3
 /*!\brief Quality type for Solexa and deprecated Illumina formats.
  * \implements seqan3::QualityAlphabet
  * \implements seqan3::detail::constexpr_alphabet_concept
- * \implements seqan3::trivially_copyable_concept
+ * \implements seqan3::TriviallyCopyable
  * \implements seqan3::standard_layout_concept
  *
  * \ingroup quality

--- a/include/seqan3/alphabet/quality/phred68legacy.hpp
+++ b/include/seqan3/alphabet/quality/phred68legacy.hpp
@@ -25,7 +25,7 @@ namespace seqan3
  * \implements seqan3::QualityAlphabet
  * \implements seqan3::detail::constexpr_alphabet_concept
  * \implements seqan3::TriviallyCopyable
- * \implements seqan3::standard_layout_concept
+ * \implements seqan3::StandardLayout
  *
  * \ingroup quality
  *

--- a/include/seqan3/alphabet/quality/qualified.hpp
+++ b/include/seqan3/alphabet/quality/qualified.hpp
@@ -28,7 +28,7 @@ namespace seqan3
  * \tparam quality_alphabet_t  Type of the quality; must satisfy seqan3::QualityAlphabet.
  * \implements seqan3::QualityAlphabet
  * \implements seqan3::detail::constexpr_alphabet_concept
- * \implements seqan3::trivially_copyable_concept
+ * \implements seqan3::TriviallyCopyable
  * \implements seqan3::standard_layout_concept
  *
  *

--- a/include/seqan3/alphabet/quality/qualified.hpp
+++ b/include/seqan3/alphabet/quality/qualified.hpp
@@ -29,7 +29,7 @@ namespace seqan3
  * \implements seqan3::QualityAlphabet
  * \implements seqan3::detail::constexpr_alphabet_concept
  * \implements seqan3::TriviallyCopyable
- * \implements seqan3::standard_layout_concept
+ * \implements seqan3::StandardLayout
  *
  *
  * This composition pairs an arbitrary alphabet with a quality alphabet, where

--- a/include/seqan3/alphabet/structure/dot_bracket3.hpp
+++ b/include/seqan3/alphabet/structure/dot_bracket3.hpp
@@ -29,7 +29,7 @@ namespace seqan3
  * \implements seqan3::rna_structure_concept
  * \implements seqan3::detail::constexpr_alphabet_concept
  * \implements seqan3::TriviallyCopyable
- * \implements seqan3::standard_layout_concept
+ * \implements seqan3::StandardLayout
  *
  * \ingroup structure
  *

--- a/include/seqan3/alphabet/structure/dot_bracket3.hpp
+++ b/include/seqan3/alphabet/structure/dot_bracket3.hpp
@@ -28,7 +28,7 @@ namespace seqan3
 /*!\brief The three letter RNA structure alphabet of the characters ".()".
  * \implements seqan3::rna_structure_concept
  * \implements seqan3::detail::constexpr_alphabet_concept
- * \implements seqan3::trivially_copyable_concept
+ * \implements seqan3::TriviallyCopyable
  * \implements seqan3::standard_layout_concept
  *
  * \ingroup structure

--- a/include/seqan3/alphabet/structure/dssp9.hpp
+++ b/include/seqan3/alphabet/structure/dssp9.hpp
@@ -28,7 +28,7 @@ namespace seqan3
 /*!\brief The protein structure alphabet of the characters "HGIEBTSCX".
  * \implements seqan3::alphabet_concept
  * \implements seqan3::detail::constexpr_alphabet_concept
- * \implements seqan3::trivially_copyable_concept
+ * \implements seqan3::TriviallyCopyable
  * \implements seqan3::standard_layout_concept
  *
  * \ingroup structure

--- a/include/seqan3/alphabet/structure/dssp9.hpp
+++ b/include/seqan3/alphabet/structure/dssp9.hpp
@@ -29,7 +29,7 @@ namespace seqan3
  * \implements seqan3::alphabet_concept
  * \implements seqan3::detail::constexpr_alphabet_concept
  * \implements seqan3::TriviallyCopyable
- * \implements seqan3::standard_layout_concept
+ * \implements seqan3::StandardLayout
  *
  * \ingroup structure
  *

--- a/include/seqan3/alphabet/structure/structured_aa.hpp
+++ b/include/seqan3/alphabet/structure/structured_aa.hpp
@@ -29,7 +29,7 @@ namespace seqan3
  * \implements seqan3::alphabet_concept
  * \implements seqan3::detail::constexpr_alphabet_concept
  * \implements seqan3::TriviallyCopyable
- * \implements seqan3::standard_layout_concept
+ * \implements seqan3::StandardLayout
  * \tparam sequence_alphabet_t Type of the first aminoacid letter; must satisfy seqan3::alphabet_concept.
  * \tparam structure_alphabet_t Types of further structure letters; must satisfy seqan3::alphabet_concept.
  *

--- a/include/seqan3/alphabet/structure/structured_aa.hpp
+++ b/include/seqan3/alphabet/structure/structured_aa.hpp
@@ -28,7 +28,7 @@ namespace seqan3
  * \ingroup structure
  * \implements seqan3::alphabet_concept
  * \implements seqan3::detail::constexpr_alphabet_concept
- * \implements seqan3::trivially_copyable_concept
+ * \implements seqan3::TriviallyCopyable
  * \implements seqan3::standard_layout_concept
  * \tparam sequence_alphabet_t Type of the first aminoacid letter; must satisfy seqan3::alphabet_concept.
  * \tparam structure_alphabet_t Types of further structure letters; must satisfy seqan3::alphabet_concept.

--- a/include/seqan3/alphabet/structure/structured_rna.hpp
+++ b/include/seqan3/alphabet/structure/structured_rna.hpp
@@ -28,7 +28,7 @@ namespace seqan3
  * \ingroup structure
  * \implements seqan3::rna_structure_concept
  * \implements seqan3::detail::constexpr_alphabet_concept
- * \implements seqan3::trivially_copyable_concept
+ * \implements seqan3::TriviallyCopyable
  * \implements seqan3::standard_layout_concept
  * \tparam sequence_alphabet_t Type of the first letter; must satisfy seqan3::NucleotideAlphabet.
  * \tparam structure_alphabet_t Types of further letters; must satisfy seqan3::rna_structure_concept.

--- a/include/seqan3/alphabet/structure/structured_rna.hpp
+++ b/include/seqan3/alphabet/structure/structured_rna.hpp
@@ -29,7 +29,7 @@ namespace seqan3
  * \implements seqan3::rna_structure_concept
  * \implements seqan3::detail::constexpr_alphabet_concept
  * \implements seqan3::TriviallyCopyable
- * \implements seqan3::standard_layout_concept
+ * \implements seqan3::StandardLayout
  * \tparam sequence_alphabet_t Type of the first letter; must satisfy seqan3::NucleotideAlphabet.
  * \tparam structure_alphabet_t Types of further letters; must satisfy seqan3::rna_structure_concept.
  *

--- a/include/seqan3/alphabet/structure/wuss.hpp
+++ b/include/seqan3/alphabet/structure/wuss.hpp
@@ -32,7 +32,7 @@ namespace seqan3
  * \implements seqan3::rna_structure_concept
  * \implements seqan3::detail::constexpr_alphabet_concept
  * \implements seqan3::TriviallyCopyable
- * \implements seqan3::standard_layout_concept
+ * \implements seqan3::StandardLayout
  *
  * \ingroup structure
  *

--- a/include/seqan3/alphabet/structure/wuss.hpp
+++ b/include/seqan3/alphabet/structure/wuss.hpp
@@ -31,7 +31,7 @@ namespace seqan3
  *              It determines the allowed pseudoknot depth by adding characters AaBb..Zz to the alphabet.
  * \implements seqan3::rna_structure_concept
  * \implements seqan3::detail::constexpr_alphabet_concept
- * \implements seqan3::trivially_copyable_concept
+ * \implements seqan3::TriviallyCopyable
  * \implements seqan3::standard_layout_concept
  *
  * \ingroup structure

--- a/include/seqan3/argument_parser/validators.hpp
+++ b/include/seqan3/argument_parser/validators.hpp
@@ -101,7 +101,7 @@ class arithmetic_range_validator;
  *
  * \snippet test/snippet/argument_parser/validators_1.cpp usage
  */
-template <arithmetic_concept option_value_type>
+template <Arithmetic option_value_type>
 class arithmetic_range_validator<option_value_type>
 {
 public:
@@ -143,7 +143,7 @@ private:
 
 //!\cond
 template <container_concept option_value_type>
-    requires arithmetic_concept<typename option_value_type::value_type>
+    requires Arithmetic<typename option_value_type::value_type>
 class arithmetic_range_validator<option_value_type>
 {
 public:

--- a/include/seqan3/core/concept/core_language.hpp
+++ b/include/seqan3/core/concept/core_language.hpp
@@ -36,12 +36,12 @@ SEQAN3_CONCEPT weakly_equality_comparable_by_members_with_concept = requires (lh
     lhs.operator!=(rhs); std::Boolean<decltype(lhs.operator!=(rhs))>;
 };
 //!\endcond
-/*!\interface   seqan3::detail::weakly_ordered_by_members_with_concept <>
+/*!\interface   seqan3::detail::WeaklyOrderedByMembersWith <>
  * \brief       Like seqan3::weakly_ordered_with_concept, but considers only member operators of the LHS.
  */
 //!\cond
 template <typename lhs_t, typename rhs_t>
-SEQAN3_CONCEPT weakly_ordered_by_members_with_concept = requires (lhs_t const & lhs, rhs_t const & rhs)
+SEQAN3_CONCEPT WeaklyOrderedByMembersWith = requires (lhs_t const & lhs, rhs_t const & rhs)
 {
     lhs.operator< (rhs); std::Boolean<decltype(lhs.operator< (rhs))>;
     lhs.operator> (rhs); std::Boolean<decltype(lhs.operator> (rhs))>;

--- a/include/seqan3/core/concept/core_language.hpp
+++ b/include/seqan3/core/concept/core_language.hpp
@@ -171,13 +171,13 @@ template <typename t>
 SEQAN3_CONCEPT trivial_concept = TriviallyCopyable<t> && TriviallyDestructible<t> && std::is_trivial_v<t>;
 //!\endcond
 
-/*!\interface   seqan3::standard_layout_concept
+/*!\interface   seqan3::StandardLayout
  * \brief       Resolves to std::is_standard_layout_v<t>.
  * \sa          http://en.cppreference.com/w/cpp/concept/StandardLayoutType
  */
 //!\cond
 template <typename t>
-SEQAN3_CONCEPT standard_layout_concept = std::is_standard_layout_v<t>;
+SEQAN3_CONCEPT StandardLayout = std::is_standard_layout_v<t>;
 //!\endcond
 
 /*!\interface   seqan3::weakly_assignable_concept

--- a/include/seqan3/core/concept/core_language.hpp
+++ b/include/seqan3/core/concept/core_language.hpp
@@ -97,12 +97,12 @@ template <typename t, typename u>
 SEQAN3_CONCEPT ImplicitlyConvertibleTo = std::is_convertible_v<t, u>;
 //!\endcond
 
-/*!\interface   seqan3::explicitly_convertible_to_concept <>
+/*!\interface   seqan3::ExplicitlyConvertibleTo <>
  * \brief       Resolves to `std::ranges::ExplicitlyConvertibleTo<type1, type2>()`.
  */
 //!\cond
 template <typename t, typename u>
-SEQAN3_CONCEPT explicitly_convertible_to_concept = requires (t vt) { { static_cast<u>(vt)}; };
+SEQAN3_CONCEPT ExplicitlyConvertibleTo = requires (t vt) { { static_cast<u>(vt)}; };
 //!\endcond
 
 /*!\interface   seqan3::arithmetic_concept <>

--- a/include/seqan3/core/concept/core_language.hpp
+++ b/include/seqan3/core/concept/core_language.hpp
@@ -37,7 +37,7 @@ SEQAN3_CONCEPT weakly_equality_comparable_by_members_with_concept = requires (lh
 };
 //!\endcond
 /*!\interface   seqan3::detail::WeaklyOrderedByMembersWith <>
- * \brief       Like seqan3::weakly_ordered_with_concept, but considers only member operators of the LHS.
+ * \brief       Like seqan3::WeaklyOrderedWith, but considers only member operators of the LHS.
  */
 //!\cond
 template <typename lhs_t, typename rhs_t>
@@ -71,7 +71,7 @@ namespace seqan3
  * \{
  */
 
-/*!\interface   seqan3::weakly_ordered_with_concept <>
+/*!\interface   seqan3::WeaklyOrderedWith <>
  * \tparam t1   The first type to compare.
  * \tparam t2   The second type to compare.
  * \brief       Requires the two operands to be comparable with `==` and `!=` in both directions.
@@ -79,7 +79,7 @@ namespace seqan3
  */
 //!\cond
 template <typename t1, typename t2>
-SEQAN3_CONCEPT weakly_ordered_with_concept = requires (std::remove_reference_t<t1> const & v1,
+SEQAN3_CONCEPT WeaklyOrderedWith = requires (std::remove_reference_t<t1> const & v1,
                                                      std::remove_reference_t<t2> const & v2)
 {
     { v1 <  v2 } -> bool &&;

--- a/include/seqan3/core/concept/core_language.hpp
+++ b/include/seqan3/core/concept/core_language.hpp
@@ -160,7 +160,7 @@ template <typename t>
 SEQAN3_CONCEPT TriviallyCopyable = std::Copyable<t> && std::is_trivially_copyable_v<t>;
 //!\endcond
 
-/*!\interface   seqan3::trivial_concept
+/*!\interface   seqan3::Trivial
  * \brief       A type that satisfies seqan3::TriviallyCopyable and seqan3::TriviallyDestructible.
  * \extends     seqan3::TriviallyCopyable
  * \extends     seqan3::TriviallyDestructible
@@ -168,7 +168,7 @@ SEQAN3_CONCEPT TriviallyCopyable = std::Copyable<t> && std::is_trivially_copyabl
  */
 //!\cond
 template <typename t>
-SEQAN3_CONCEPT trivial_concept = TriviallyCopyable<t> && TriviallyDestructible<t> && std::is_trivial_v<t>;
+SEQAN3_CONCEPT Trivial = TriviallyCopyable<t> && TriviallyDestructible<t> && std::is_trivial_v<t>;
 //!\endcond
 
 /*!\interface   seqan3::StandardLayout

--- a/include/seqan3/core/concept/core_language.hpp
+++ b/include/seqan3/core/concept/core_language.hpp
@@ -180,7 +180,7 @@ template <typename t>
 SEQAN3_CONCEPT StandardLayout = std::is_standard_layout_v<t>;
 //!\endcond
 
-/*!\interface   seqan3::weakly_assignable_concept
+/*!\interface   seqan3::WeaklyAssignable
  * \brief       Resolves to std::is_assignable_v<t>.
  * \sa          https://en.cppreference.com/w/cpp/types/is_assignable
  *
@@ -191,7 +191,7 @@ SEQAN3_CONCEPT StandardLayout = std::is_standard_layout_v<t>;
  */
 //!\cond
 template <typename t, typename u>
-SEQAN3_CONCEPT weakly_assignable_concept = std::is_assignable_v<t, u>;
+SEQAN3_CONCEPT WeaklyAssignable = std::is_assignable_v<t, u>;
 //!\endcond
 
 }  // namespace seqan3

--- a/include/seqan3/core/concept/core_language.hpp
+++ b/include/seqan3/core/concept/core_language.hpp
@@ -150,25 +150,25 @@ template <typename t>
 SEQAN3_CONCEPT TriviallyDestructible = std::Destructible<t> && std::is_trivially_destructible_v<t>;
 //!\endcond
 
-/*!\interface   seqan3::trivially_copyable_concept
+/*!\interface   seqan3::TriviallyCopyable
  * \brief       A type that satisfies std::is_trivially_copyable_v<t>.
  * \extends     std::Copyable
  * \sa          http://en.cppreference.com/w/cpp/types/is_trivially_copyable
  */
 //!\cond
 template <typename t>
-SEQAN3_CONCEPT trivially_copyable_concept = std::Copyable<t> && std::is_trivially_copyable_v<t>;
+SEQAN3_CONCEPT TriviallyCopyable = std::Copyable<t> && std::is_trivially_copyable_v<t>;
 //!\endcond
 
 /*!\interface   seqan3::trivial_concept
- * \brief       A type that satisfies seqan3::trivially_copyable_concept and seqan3::TriviallyDestructible.
- * \extends     seqan3::trivially_copyable_concept
+ * \brief       A type that satisfies seqan3::TriviallyCopyable and seqan3::TriviallyDestructible.
+ * \extends     seqan3::TriviallyCopyable
  * \extends     seqan3::TriviallyDestructible
  * \sa          http://en.cppreference.com/w/cpp/experimental/ranges/concepts/Copyable
  */
 //!\cond
 template <typename t>
-SEQAN3_CONCEPT trivial_concept = trivially_copyable_concept<t> && TriviallyDestructible<t> && std::is_trivial_v<t>;
+SEQAN3_CONCEPT trivial_concept = TriviallyCopyable<t> && TriviallyDestructible<t> && std::is_trivial_v<t>;
 //!\endcond
 
 /*!\interface   seqan3::standard_layout_concept

--- a/include/seqan3/core/concept/core_language.hpp
+++ b/include/seqan3/core/concept/core_language.hpp
@@ -140,14 +140,14 @@ SEQAN3_CONCEPT char_concept = std::Integral<t> &&
                         std::Same<t, char16_t> || std::Same<t, char32_t> || std::Same<t, wchar_t>);
 //!\endcond
 
-/*!\interface   seqan3::trivially_destructible_concept <>
+/*!\interface   seqan3::TriviallyDestructible <>
  * \extends     std::Destructible
  * \brief       A type that satisfies std::is_trivially_destructible_v<t>.
  * \sa          http://en.cppreference.com/w/cpp/types/is_destructible
  */
 //!\cond
 template <typename t>
-SEQAN3_CONCEPT trivially_destructible_concept = std::Destructible<t> && std::is_trivially_destructible_v<t>;
+SEQAN3_CONCEPT TriviallyDestructible = std::Destructible<t> && std::is_trivially_destructible_v<t>;
 //!\endcond
 
 /*!\interface   seqan3::trivially_copyable_concept
@@ -161,14 +161,14 @@ SEQAN3_CONCEPT trivially_copyable_concept = std::Copyable<t> && std::is_triviall
 //!\endcond
 
 /*!\interface   seqan3::trivial_concept
- * \brief       A type that satisfies seqan3::trivially_copyable_concept and seqan3::trivially_destructible_concept.
+ * \brief       A type that satisfies seqan3::trivially_copyable_concept and seqan3::TriviallyDestructible.
  * \extends     seqan3::trivially_copyable_concept
- * \extends     seqan3::trivially_destructible_concept
+ * \extends     seqan3::TriviallyDestructible
  * \sa          http://en.cppreference.com/w/cpp/experimental/ranges/concepts/Copyable
  */
 //!\cond
 template <typename t>
-SEQAN3_CONCEPT trivial_concept = trivially_copyable_concept<t> && trivially_destructible_concept<t> && std::is_trivial_v<t>;
+SEQAN3_CONCEPT trivial_concept = trivially_copyable_concept<t> && TriviallyDestructible<t> && std::is_trivial_v<t>;
 //!\endcond
 
 /*!\interface   seqan3::standard_layout_concept

--- a/include/seqan3/core/concept/core_language.hpp
+++ b/include/seqan3/core/concept/core_language.hpp
@@ -25,12 +25,12 @@ namespace seqan3::detail
  * \{
  */
 
-/*!\interface   seqan3::detail::weakly_equality_comparable_by_members_with_concept <>
+/*!\interface   seqan3::detail::WeaklyEqualityComparableByMembersWith <>
  * \brief       Like std::detail::WeaklyEqualityComparableWith, but considers only member operators of the LHS.
  */
 //!\cond
 template <typename lhs_t, typename rhs_t>
-SEQAN3_CONCEPT weakly_equality_comparable_by_members_with_concept = requires (lhs_t const & lhs, rhs_t const & rhs)
+SEQAN3_CONCEPT WeaklyEqualityComparableByMembersWith = requires (lhs_t const & lhs, rhs_t const & rhs)
 {
     lhs.operator==(rhs); std::Boolean<decltype(lhs.operator==(rhs))>;
     lhs.operator!=(rhs); std::Boolean<decltype(lhs.operator!=(rhs))>;

--- a/include/seqan3/core/concept/core_language.hpp
+++ b/include/seqan3/core/concept/core_language.hpp
@@ -51,7 +51,7 @@ SEQAN3_CONCEPT WeaklyOrderedByMembersWith = requires (lhs_t const & lhs, rhs_t c
 //!\endcond
 
 /*!\interface   seqan3::detail::convertible_to_by_member_concept <>
- * \brief       Like seqan3::implicitly_convertible_to_concept, but only considers member operators of the source type.
+ * \brief       Like seqan3::ImplicitlyConvertibleTo, but only considers member operators of the source type.
  */
 //!\cond
 template <typename source_t, typename target_t>
@@ -89,12 +89,12 @@ SEQAN3_CONCEPT weakly_ordered_with_concept = requires (std::remove_reference_t<t
 };
 //!\endcond
 
-/*!\interface   seqan3::implicitly_convertible_to_concept <>
+/*!\interface   seqan3::ImplicitlyConvertibleTo <>
  * \brief       Resolves to `std::ranges::ImplicitlyConvertibleTo<type1, type2>()`.
  */
 //!\cond
 template <typename t, typename u>
-SEQAN3_CONCEPT implicitly_convertible_to_concept = std::is_convertible_v<t, u>;
+SEQAN3_CONCEPT ImplicitlyConvertibleTo = std::is_convertible_v<t, u>;
 //!\endcond
 
 /*!\interface   seqan3::explicitly_convertible_to_concept <>

--- a/include/seqan3/core/concept/core_language.hpp
+++ b/include/seqan3/core/concept/core_language.hpp
@@ -105,23 +105,23 @@ template <typename t, typename u>
 SEQAN3_CONCEPT ExplicitlyConvertibleTo = requires (t vt) { { static_cast<u>(vt)}; };
 //!\endcond
 
-/*!\interface   seqan3::arithmetic_concept <>
+/*!\interface   seqan3::Arithmetic <>
  * \brief       A type that satisfies std::is_arithmetic_v<t>.
  * \sa          http://en.cppreference.com/w/cpp/types/is_arithmetic
  */
 //!\cond
 template <typename t>
-SEQAN3_CONCEPT arithmetic_concept = std::is_arithmetic_v<t>;
+SEQAN3_CONCEPT Arithmetic = std::is_arithmetic_v<t>;
 //!\endcond
 
 /*!\interface   seqan3::floating_point_concept <>
- * \extends     seqan3::arithmetic_concept
+ * \extends     seqan3::Arithmetic
  * \brief       An arithmetic type that also satisfies std::is_floating_point_v<t>.
  * \sa          http://en.cppreference.com/w/cpp/types/is_floating_point
  */
 //!\cond
 template <typename t>
-SEQAN3_CONCEPT floating_point_concept = arithmetic_concept<t> && std::is_floating_point_v<t>;
+SEQAN3_CONCEPT FloatingPoint = arithmetic_concept<t> && std::is_floating_point_v<t>;
 //!\endcond
 
 /*!\interface   seqan3::char_concept <>

--- a/include/seqan3/core/concept/core_language.hpp
+++ b/include/seqan3/core/concept/core_language.hpp
@@ -50,12 +50,12 @@ SEQAN3_CONCEPT WeaklyOrderedByMembersWith = requires (lhs_t const & lhs, rhs_t c
 };
 //!\endcond
 
-/*!\interface   seqan3::detail::convertible_to_by_member_concept <>
+/*!\interface   seqan3::detail::ConvertibleToByMember <>
  * \brief       Like seqan3::ImplicitlyConvertibleTo, but only considers member operators of the source type.
  */
 //!\cond
 template <typename source_t, typename target_t>
-SEQAN3_CONCEPT convertible_to_by_member_concept = requires (source_t s)
+SEQAN3_CONCEPT ConvertibleToByMember = requires (source_t s)
 {
     { s.operator target_t() } -> target_t;
 };

--- a/include/seqan3/core/concept/core_language.hpp
+++ b/include/seqan3/core/concept/core_language.hpp
@@ -114,14 +114,14 @@ template <typename t>
 SEQAN3_CONCEPT Arithmetic = std::is_arithmetic_v<t>;
 //!\endcond
 
-/*!\interface   seqan3::floating_point_concept <>
+/*!\interface   seqan3::FloatingPoint <>
  * \extends     seqan3::Arithmetic
  * \brief       An arithmetic type that also satisfies std::is_floating_point_v<t>.
  * \sa          http://en.cppreference.com/w/cpp/types/is_floating_point
  */
 //!\cond
 template <typename t>
-SEQAN3_CONCEPT FloatingPoint = arithmetic_concept<t> && std::is_floating_point_v<t>;
+SEQAN3_CONCEPT FloatingPoint = Arithmetic<t> && std::is_floating_point_v<t>;
 //!\endcond
 
 /*!\interface   seqan3::char_concept <>

--- a/include/seqan3/core/concept/tuple.hpp
+++ b/include/seqan3/core/concept/tuple.hpp
@@ -50,7 +50,7 @@ SEQAN3_CONCEPT tuple_get_concept = requires (tuple_t & v, tuple_t const & v_c)
 
     typename std::tuple_element<0, tuple_t>::type;
     { get<0>(v)              } -> typename std::tuple_element<0, tuple_t>::type;
-//     requires weakly_assignable_concept<decltype(get<0>(v)), typename std::tuple_element<0, tuple_t>::type>;
+//     requires WeaklyAssignable<decltype(get<0>(v)), typename std::tuple_element<0, tuple_t>::type>;
     //TODO check that the previous returns something that can be assigned to
     // unfortunately std::Assignable requires lvalue-reference, but we want to accept xvalues too (returned proxies)
     { get<0>(v_c)            } -> typename std::tuple_element<0, tuple_t>::type;

--- a/include/seqan3/io/sequence_file/input.hpp
+++ b/include/seqan3/io/sequence_file/input.hpp
@@ -122,7 +122,7 @@ SEQAN3_CONCEPT sequence_file_input_traits_concept = requires (t v)
 {
     requires alphabet_concept<typename t::sequence_alphabet>;
     requires alphabet_concept<typename t::sequence_legal_alphabet>;
-    requires explicitly_convertible_to_concept<typename t::sequence_legal_alphabet, typename t::sequence_alphabet>;
+    requires ExplicitlyConvertibleTo<typename t::sequence_legal_alphabet, typename t::sequence_alphabet>;
     requires sequence_container_concept<typename t::template sequence_container<typename t::sequence_alphabet>>;
     requires sequence_container_concept<typename t::template sequence_container_container<
         typename t::template sequence_container<typename t::sequence_alphabet>>>;

--- a/include/seqan3/io/structure_file/input.hpp
+++ b/include/seqan3/io/structure_file/input.hpp
@@ -202,7 +202,7 @@ SEQAN3_CONCEPT structure_file_input_traits_concept = requires(t v)
     // sequence
     requires alphabet_concept<typename t::seq_alphabet>;
     requires alphabet_concept<typename t::seq_legal_alphabet>;
-    requires explicitly_convertible_to_concept<typename t::seq_legal_alphabet, typename t::seq_alphabet>;
+    requires ExplicitlyConvertibleTo<typename t::seq_legal_alphabet, typename t::seq_alphabet>;
     requires sequence_container_concept<typename t::template seq_container<typename t::seq_alphabet>>;
 //    requires sequence_container_concept
 //        <typename t::template seq_container_container

--- a/include/seqan3/range/view/convert.hpp
+++ b/include/seqan3/range/view/convert.hpp
@@ -61,7 +61,7 @@ namespace seqan3::view
 template <typename out_t>
 auto const convert = view::transform([] (auto const & in) -> out_t
 {
-    if constexpr (implicitly_convertible_to_concept<std::remove_reference_t<decltype(in)>, out_t>)
+    if constexpr (ImplicitlyConvertibleTo<std::remove_reference_t<decltype(in)>, out_t>)
         return in;
     else
         return static_cast<out_t>(in);

--- a/include/seqan3/range/view/convert.hpp
+++ b/include/seqan3/range/view/convert.hpp
@@ -45,7 +45,7 @@ namespace seqan3::view
  * | std::ranges::OutputRange        |                                       | *lost*                          |
  * | seqan3::const_iterable_concept  |                                       | *preserved*                     |
  * |                                 |                                       |                                 |
- * | seqan3::reference_t             | seqan3::convertible_to_concept<out_t> | `out_t`                         |
+ * | seqan3::reference_t             | seqan3::ConvertibleTo<out_t>          | `out_t`                         |
  *
  * See the \link view view submodule documentation \endlink for detailed descriptions of the view properties.
  *

--- a/include/seqan3/search/algorithm/configuration/max_error_common.hpp
+++ b/include/seqan3/search/algorithm/configuration/max_error_common.hpp
@@ -25,7 +25,7 @@ namespace seqan3::search_cfg
  */
 template <typename value_t>
 //!\cond
-    requires arithmetic_concept<value_t>
+    requires Arithmetic<value_t>
 //!\endcond
 struct total : detail::strong_type<value_t, total<value_t>, detail::strong_type_skill::convert>
 {
@@ -57,7 +57,7 @@ total(value_t) -> total<double>;
  */
 template <typename value_t>
 //!\cond
-    requires arithmetic_concept<value_t>
+    requires Arithmetic<value_t>
 //!\endcond
 struct substitution : detail::strong_type<value_t, substitution<value_t>, detail::strong_type_skill::convert>
 {
@@ -88,7 +88,7 @@ substitution(value_t) -> substitution<double>;
  */
 template <typename value_t>
 //!\cond
-    requires arithmetic_concept<value_t>
+    requires Arithmetic<value_t>
 //!\endcond
 struct insertion : detail::strong_type<value_t, insertion<value_t>, detail::strong_type_skill::convert>
 {
@@ -119,7 +119,7 @@ insertion(value_t) -> insertion<double>;
  */
 template <typename value_t>
 //!\cond
-    requires arithmetic_concept<value_t>
+    requires Arithmetic<value_t>
 //!\endcond
 struct deletion : detail::strong_type<value_t, deletion<value_t>, detail::strong_type_skill::convert>
 {

--- a/include/seqan3/search/algorithm/configuration/max_error_common.hpp
+++ b/include/seqan3/search/algorithm/configuration/max_error_common.hpp
@@ -45,7 +45,7 @@ total(value_t) -> total<uint8_t>;
 
 template <typename value_t>
 //!\cond
-    requires floating_point_concept<value_t>
+    requires FloatingPoint<value_t>
 //!\endcond
 total(value_t) -> total<double>;
 //!\}
@@ -77,7 +77,7 @@ substitution(value_t) -> substitution<uint8_t>;
 
 template <typename value_t>
 //!\cond
-    requires floating_point_concept<value_t>
+    requires FloatingPoint<value_t>
 //!\endcond
 substitution(value_t) -> substitution<double>;
 //!\}
@@ -108,7 +108,7 @@ insertion(value_t) -> insertion<uint8_t>;
 
 template <typename value_t>
 //!\cond
-    requires floating_point_concept<value_t>
+    requires FloatingPoint<value_t>
 //!\endcond
 insertion(value_t) -> insertion<double>;
 //!\}
@@ -139,7 +139,7 @@ deletion(value_t) -> deletion<uint8_t>;
 
 template <typename value_t>
 //!\cond
-    requires floating_point_concept<value_t>
+    requires FloatingPoint<value_t>
 //!\endcond
 deletion(value_t) -> deletion<double>;
 //!\}

--- a/include/seqan3/search/fm_index/bi_fm_index_cursor.hpp
+++ b/include/seqan3/search/fm_index/bi_fm_index_cursor.hpp
@@ -412,7 +412,7 @@ public:
      */
     template <alphabet_concept char_t>
     //!\cond
-        requires implicitly_convertible_to_concept<char_t, typename index_t::char_type>
+        requires ImplicitlyConvertibleTo<char_t, typename index_t::char_type>
     //!\endcond
     bool extend_right(char_t const c) noexcept
     {
@@ -454,7 +454,7 @@ public:
      */
     template <alphabet_concept char_t>
     //!\cond
-       requires implicitly_convertible_to_concept<char_t, typename index_t::char_type>
+       requires ImplicitlyConvertibleTo<char_t, typename index_t::char_type>
     //!\endcond
     bool extend_left(char_t const c) noexcept
     {
@@ -498,7 +498,7 @@ public:
      */
     template <std::ranges::RandomAccessRange seq_t>
     //!\cond
-        requires implicitly_convertible_to_concept<innermost_value_type_t<seq_t>, typename index_t::char_type>
+        requires ImplicitlyConvertibleTo<innermost_value_type_t<seq_t>, typename index_t::char_type>
     //!\endcond
     bool extend_right(seq_t && seq) noexcept
     {
@@ -561,7 +561,7 @@ public:
      */
     template <std::ranges::RandomAccessRange seq_t>
     //!\cond
-       requires implicitly_convertible_to_concept<innermost_value_type_t<seq_t>, typename index_t::char_type>
+       requires ImplicitlyConvertibleTo<innermost_value_type_t<seq_t>, typename index_t::char_type>
     //!\endcond
     bool extend_left(seq_t && seq) noexcept
     {

--- a/include/seqan3/search/fm_index/fm_index_cursor.hpp
+++ b/include/seqan3/search/fm_index/fm_index_cursor.hpp
@@ -272,7 +272,7 @@ public:
      */
     template <alphabet_concept char_t>
     //!\cond
-        requires implicitly_convertible_to_concept<char_t, typename index_t::char_type>
+        requires ImplicitlyConvertibleTo<char_t, typename index_t::char_type>
     //!\endcond
     bool extend_right(char_t const c) noexcept
     {
@@ -310,7 +310,7 @@ public:
      */
     template <std::ranges::RandomAccessRange seq_t>
     //!\cond
-        requires implicitly_convertible_to_concept<innermost_value_type_t<seq_t>, typename index_t::char_type>
+        requires ImplicitlyConvertibleTo<innermost_value_type_t<seq_t>, typename index_t::char_type>
     //!\endcond
     bool extend_right(seq_t && seq) noexcept
     {

--- a/include/seqan3/std/charconv
+++ b/include/seqan3/std/charconv
@@ -244,7 +244,7 @@ inline std::from_chars_result from_chars(char const * first, char const * last, 
  *
  * \sa https://en.cppreference.com/w/cpp/utility/from_chars
  */
-template <seqan3::floating_point_concept floating_point_type>
+template <seqan3::FloatingPoint floating_point_type>
 inline std::from_chars_result from_chars(char const * first,
                                          char const * last,
                                          floating_point_type & value,

--- a/include/seqan3/std/charconv_detail.hpp
+++ b/include/seqan3/std/charconv_detail.hpp
@@ -682,7 +682,7 @@ inline std::from_chars_result from_chars_integral(char const * first, char const
 //!\endcond
 
 //!\brief Delegates to functions strto[d/f/ld] for floating point value extraction.
-template <seqan3::floating_point_concept value_type>
+template <seqan3::FloatingPoint value_type>
 inline std::from_chars_result from_chars_floating_point(char const * first,
                                                         char const * last,
                                                         value_type & value,

--- a/test/unit/std/concept/core_language_test.cpp
+++ b/test/unit/std/concept/core_language_test.cpp
@@ -35,11 +35,11 @@ TEST(ImplicitlyConvertibleTo, basic)
     EXPECT_TRUE((!ImplicitlyConvertibleTo<type_a, type_c>));
 }
 
-TEST(explicitly_convertible_to_concept, basic)
+TEST(ExplicitlyConvertibleTo, basic)
 {
-    EXPECT_TRUE((explicitly_convertible_to_concept<type_b, type_c>));
-    EXPECT_TRUE((!explicitly_convertible_to_concept<type_c, type_b>));
-    EXPECT_TRUE((explicitly_convertible_to_concept<type_a, type_c>));
+    EXPECT_TRUE((ExplicitlyConvertibleTo<type_b, type_c>));
+    EXPECT_TRUE((!ExplicitlyConvertibleTo<type_c, type_b>));
+    EXPECT_TRUE((ExplicitlyConvertibleTo<type_a, type_c>));
 }
 
 TEST(core_language_concepts, ConvertibleTo)

--- a/test/unit/std/concept/core_language_test.cpp
+++ b/test/unit/std/concept/core_language_test.cpp
@@ -28,11 +28,11 @@ TEST(core_language_concepts, DerivedFrom)
     EXPECT_TRUE((!std::DerivedFrom<type_a, type_b>));
 }
 
-TEST(implicitly_convertible_to_concept, basic)
+TEST(ImplicitlyConvertibleTo, basic)
 {
-    EXPECT_TRUE((implicitly_convertible_to_concept<type_b, type_c>));
-    EXPECT_TRUE((!implicitly_convertible_to_concept<type_c, type_b>));
-    EXPECT_TRUE((!implicitly_convertible_to_concept<type_a, type_c>));
+    EXPECT_TRUE((ImplicitlyConvertibleTo<type_b, type_c>));
+    EXPECT_TRUE((!ImplicitlyConvertibleTo<type_c, type_b>));
+    EXPECT_TRUE((!ImplicitlyConvertibleTo<type_a, type_c>));
 }
 
 TEST(explicitly_convertible_to_concept, basic)


### PR DESCRIPTION
#520

All renamings which were necessary for file core/concept/core_language.hpp

Renames:

weakly_equality_comparable_by_members_with_concept -> WeaklyEqualityComparableByMembersWith
weakly_ordered_by_members_with_concept -> WeaklyOrderedByMembersWith
implicitly_convertible_to_concept -> ImplicitlyConvertibleTo
explicitly_convertible_to_concept -> ExplicitlyConvertibleTo
convertible_to_concept -> ConvertibleTo
arithmetic_concept -> Arithmetic
floating_point_concept -> FloatingPoint
trivially_destructible_concept -> TriviallyDestructible
trivially_copyable_concept -> TriviallyCopyable
standard_layout_concept -> StandardLayout
trivial_concept -> Trivial
weakly_assignable_concept -> WeaklyAssignable
weakly_ordered_with_concept -> WeaklyOrderedWith
convertible_to_by_member_concept -> ConvertibleToByMember