### PR TITLE
Feature/affine alignment 2

### DIFF
--- a/include/seqan3/alignment/pairwise/align_pairwise.hpp
+++ b/include/seqan3/alignment/pairwise/align_pairwise.hpp
@@ -25,7 +25,7 @@
 
 #include <seqan3/alignment/configuration/all.hpp>
 #include <seqan3/alignment/pairwise/align_result.hpp>
-#include <seqan3/alignment/pairwise/alignment_selector.hpp>
+#include <seqan3/alignment/pairwise/alignment_configurator.hpp>
 #include <seqan3/alignment/pairwise/execution/all.hpp>
 
 #include <seqan3/alphabet/gap/gapped.hpp>
@@ -46,9 +46,6 @@ template <std::ranges::InputRange sequence_t, typename alignment_config_t>
              tuple_like_concept<value_type_t<std::ranges::iterator_t<std::remove_reference_t<sequence_t>>>>
 constexpr auto align_pairwise(sequence_t && seq, alignment_config_t const & config)
 {
-    static_assert(std::tuple_size_v<value_type_t<std::ranges::iterator_t<std::remove_reference_t<sequence_t>>>> == 2,
-                  "Expects exactly two sequences for pairwise alignments.");
-
     // Wrap in persist to make the code also work with temporaries that are not views.
     auto seq_view = view::persist(std::forward<sequence_t>(seq));
     // Configure the alignment algorithm.

--- a/include/seqan3/alignment/pairwise/align_pairwise.hpp
+++ b/include/seqan3/alignment/pairwise/align_pairwise.hpp
@@ -49,12 +49,14 @@ constexpr auto align_pairwise(sequence_t && seq, alignment_config_t const & conf
     static_assert(std::tuple_size_v<value_type_t<std::ranges::iterator_t<std::remove_reference_t<sequence_t>>>> == 2,
                   "Expects exactly two sequences for pairwise alignments.");
 
-    // Make also work with temporaries.
-    auto seq_view = std::forward<sequence_t>(seq) | view::persist;
+    // Wrap in persist to make the code also work with temporaries that are not views.
+    auto seq_view = view::persist(std::forward<sequence_t>(seq));
+    // Configure the alignment algorithm.
     auto kernel = detail::alignment_configurator::configure(seq_view, config);
-
-    using exec_type = detail::alignment_executor_two_way<decltype(seq_view), decltype(kernel)>;
-    return alignment_range<exec_type>{seq_view, kernel};
+    // Create a two-way executor for the alignment.
+    detail::alignment_executor_two_way exec{std::move(seq_view), kernel};
+    // Return the range over the alignments.
+    return alignment_range{std::move(exec)};
 }
 
 template <tuple_like_concept seq_t,
@@ -65,7 +67,6 @@ constexpr auto align_pairwise(seq_t && seq, alignment_config_t && config)
     static_assert(std::tuple_size_v<std::remove_reference_t<seq_t>> == 2,
                   "Expects exactly two sequences for pairwise alignments.");
 
-    //TODO: Check the problem here.
     return align_pairwise(ranges::view::single(std::forward<seq_t>(seq)) | ranges::view::bounded,
                           std::forward<alignment_config_t>(config));
 }

--- a/include/seqan3/alignment/pairwise/align_result_selector.hpp
+++ b/include/seqan3/alignment/pairwise/align_result_selector.hpp
@@ -1,0 +1,91 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2018, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2018, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides seqan3::detail::align_result_selector.
+ * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <type_traits>
+
+#include <seqan3/alignment/configuration/align_config_result.hpp>
+#include <seqan3/alignment/matrix/alignment_coordinate.hpp>
+#include <seqan3/alphabet/gap/gapped.hpp>
+#include <seqan3/core/algorithm/configuration.hpp>
+#include <seqan3/core/metafunction/basic.hpp>
+#include <seqan3/core/metafunction/range.hpp>
+#include <seqan3/core/type_list.hpp>
+#include <seqan3/std/ranges>
+
+namespace seqan3::detail
+{
+
+/*!\brief Helper metafunction to select the alignment result type based on the configuration.
+ * \ingroup pairwise_alignment
+ * \tparam first_bach_t    The type of the first sequence.
+ * \tparam second_batch_t  The type of the second sequence.
+ * \tparam configuration_t The configuration type. Must be of type seqan3::detail::configuration
+ */
+template <std::ranges::ForwardRange first_batch_t,
+          std::ranges::ForwardRange second_batch_t,
+          typename configuration_t>
+//!\cond
+    requires is_type_specialisation_of_v<remove_cvref_t<configuration_t>, configuration>
+//!\endcond
+struct align_result_selector
+{
+    //!\brief Helper function to determine the actual result type.
+    static constexpr auto _determine()
+    {
+        using first_seq_value_type  = gapped<value_type_t<first_batch_t>>;
+        using second_seq_value_type = gapped<value_type_t<second_batch_t>>;
+        using score_type            = int32_t;
+
+        if constexpr (std::remove_reference_t<configuration_t>::template exists<align_cfg::result>())
+        {
+            if constexpr (std::Same<remove_cvref_t<decltype(get<align_cfg::result>(configuration_t{}).value)>,
+                                    with_end_position_type>)
+            {
+                return align_result_value_type<uint32_t,
+                                               score_type,
+                                               alignment_coordinate>{};
+            }
+            else if constexpr (std::Same<remove_cvref_t<decltype(get<align_cfg::result>(configuration_t{}).value)>,
+                                         with_begin_position_type>)
+            {
+                return align_result_value_type<uint32_t,
+                                               score_type,
+                                               alignment_coordinate,
+                                               alignment_coordinate>{};
+            }
+            else if constexpr (std::Same<remove_cvref_t<decltype(get<align_cfg::result>(configuration_t{}).value)>,
+                                         with_trace_type>)
+            {
+                return align_result_value_type<uint32_t,
+                                               score_type,
+                                               alignment_coordinate,
+                                               alignment_coordinate,
+                                               std::tuple<std::vector<first_seq_value_type>,
+                                                          std::vector<second_seq_value_type>>>{};
+            }
+            else
+            {
+                return align_result_value_type<uint32_t, score_type>{};
+            }
+        }
+        else
+        {
+            return align_result_value_type<uint32_t, score_type>{};
+        }
+    }
+
+    //!\brief The determined result type.
+    using type = decltype(_determine());
+};
+} // namespace seqan3::detail

--- a/include/seqan3/alignment/pairwise/align_result_selector.hpp
+++ b/include/seqan3/alignment/pairwise/align_result_selector.hpp
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------------------------------------
-// Copyright (c) 2006-2018, Knut Reinert & Freie Universität Berlin
-// Copyright (c) 2016-2018, Knut Reinert & MPI für molekulare Genetik
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
 // This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
 // shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
 // -----------------------------------------------------------------------------------------------------

--- a/include/seqan3/alignment/pairwise/alignment_algorithm.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_algorithm.hpp
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------------------------------------
-// Copyright (c) 2006-2018, Knut Reinert & Freie Universität Berlin
-// Copyright (c) 2016-2018, Knut Reinert & MPI für molekulare Genetik
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
 // This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
 // shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
 // -----------------------------------------------------------------------------------------------------

--- a/include/seqan3/alignment/pairwise/alignment_algorithm.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_algorithm.hpp
@@ -1,0 +1,199 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2018, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2018, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides seqan3::detail::alignment_algorithm.
+ * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <range/v3/algorithm/for_each.hpp>
+#include <range/v3/view/drop_exactly.hpp>
+#include <range/v3/view/zip.hpp>
+
+#include <seqan3/alignment/configuration/all.hpp>
+#include <seqan3/alignment/pairwise/policy/affine_gap_init_policy.hpp>
+#include <seqan3/alignment/pairwise/policy/affine_gap_policy.hpp>
+#include <seqan3/alignment/pairwise/policy/unbanded_dp_matrix_policy.hpp>
+#include <seqan3/alignment/pairwise/align_result_selector.hpp>
+
+#include <seqan3/alignment/scoring/gap_scheme.hpp>
+#include <seqan3/alignment/scoring/scoring_scheme_base.hpp>
+
+#include <seqan3/core/metafunction/deferred_crtp_base.hpp>
+#include <seqan3/io/stream/debug_stream.hpp>
+#include <seqan3/range/view/take_exactly.hpp>
+#include <seqan3/std/concepts>
+#include <seqan3/std/ranges>
+
+namespace seqan3::detail
+{
+
+/*!\brief The alignment algorithm type to compute standard pairwise alignment using dynamic programming.
+ * \implements std::Invocable
+ * \ingroup pairwise_alignment
+ * \tparam config_t             The configuration type; must be of type seqan3::configuration.
+ * \tparam algorithm_policies_t Template parameter pack with the policies to determine the execution of the algorithm;
+ *                              must be wrapped as seqan3::detail::deferred_crtp_base.
+ *
+ * \details
+ *
+ * ## Configuration
+ *
+ * The first template argument is the type of the alignment configuration which was used to configure the alignment
+ * algorithm type. They must be the same, otherwise it is possible that the output is not coherent with the expected
+ * result given the different configurations. The correct alignment is configured within the
+ * seqan3::detail::alignment_configurator and returned as a std::function object, which can be passed around and
+ * copied to create, for example multiple instances of the algorithm that can be executed in parallel.
+ *
+ * ## Policies
+ *
+ * This type uses multiple inheritance to configure a specific alignment computation, e.g. global or local alignments,
+ * using SIMD operations or scalar operations, computing the traceback or only the score etc.. These configurations
+ * are inherited using so-called `alignment policies`. An alignment policy is a type that implements a specific
+ * functionality through a common interface that is used by the alignment algorithm. These policies are also
+ * the customisation points of the algorithm which will be used to implement a specific behaviour. You can read more
+ * about the policies in \ref alignment_policy.
+ *
+ * Since some of the policies are augmented with traits to further refine the policy execution during the configuration,
+ * it is necessary to defer the template instantiation of the policies, which are modelled as CRTP-base classes.
+ * Therefore every added policy must be wrapped in a seqan3::detail::deferred_crtp_base class wrapper. This wrapper
+ * then is expanded during the final template instantiation of the alignment algorithm type using the corresponding
+ * template function seqan3::detail::invoke_deferred_crtp_base, which instantiates the CRTP policy types with the
+ * correct alignment algorithm type.
+ */
+template <typename config_t, typename ...algorithm_policies_t>
+class alignment_algorithm :
+    protected invoke_deferred_crtp_base<algorithm_policies_t, alignment_algorithm<algorithm_policies_t...>>...
+{
+public:
+    /*!\name Constructor, destructor and assignment
+     * \brief Defaulted all standard constructor.
+     * \{
+     */
+    constexpr alignment_algorithm()                                        = default;
+    constexpr alignment_algorithm(alignment_algorithm const &)             = default;
+    constexpr alignment_algorithm(alignment_algorithm &&)                  = default;
+    constexpr alignment_algorithm & operator=(alignment_algorithm const &) = default;
+    constexpr alignment_algorithm & operator=(alignment_algorithm &&)      = default;
+    ~alignment_algorithm()                                                 = default;
+
+    /*!\brief Constructs the algorithm with the passed configuration.
+     * \param cfg The configuration to be passed to the algorithm.
+     *
+     * \details
+     *
+     * Maintains a copy of the configuration object on the heap using a std::shared_ptr.
+     */
+    explicit constexpr alignment_algorithm(config_t const & cfg) : cfg_ptr{new config_t(cfg)}
+    {}
+    //!}
+
+    /*!\brief Invokes the actual alignment computation given two sequences.
+     * \tparam    first_batch_t  The type of the first sequence (or packed sequences); must model std::ForwardRange.
+     * \tparam    second_batch_t The type of the second sequence (or packed sequences); must model std::ForwardRange.
+     * \param[in] first_batch    The first sequence (or packed sequences).
+     * \param[in] second_batch   The second sequence (or packed sequences).
+     *
+     * \details
+     *
+     * ### Exception
+     *
+     * Strong exception guarantee.
+     *
+     * ### Thread-safety
+     *
+     * Calls to this functions in a concurrent environment are not thread safe. Instead use a copy of the alignment
+     * algorithm type.
+     *
+     * ### Complexity
+     *
+     * The code always runs in \f$ O(N^2) \f$ time and depending on the configuration requires at least \f$ O(N) \f$
+     * and at most \f$ O(N^2) \f$ space.
+     */
+    template <std::ranges::ForwardRange first_batch_t, std::ranges::ForwardRange second_batch_t>
+    auto operator()(first_batch_t const & first_batch, second_batch_t const & second_batch)
+    {
+        assert(cfg_ptr != nullptr);
+
+        // We need to allocate the score_matrix and maybe the trace_matrix.
+        this->allocate_score_matrix(first_batch, second_batch);
+
+        // Initialize cache variables to keep frequently used variables close to the CPU registers.
+        auto cache = this->make_cache(get<align_cfg::gap>(*cfg_ptr).value);
+
+        initialise_matrix(cache);
+
+        compute_matrix(first_batch, second_batch, cache);
+
+        using result_t = typename align_result_selector<first_batch_t, second_batch_t, config_t>::type;
+        result_t res{};
+
+        // Choose what needs to be computed.
+        if constexpr (config_t::template exists<align_cfg::result<detail::with_score_type>>())
+        {
+            auto last_col = this->current_column();
+            res.score = get<0>(*(std::ranges::end(last_col) - 1));
+        }
+        return align_result{res};
+    }
+
+private:
+
+    /*!\brief Initialises the first column of the dynamic programming matrix.
+     * \tparam         cache_t The cache type.
+     * \param[in,out]  cache   The cache holding hot variables.
+     */
+    template <typename cache_t>
+    void initialise_matrix(cache_t & cache)
+    {
+        auto col = this->current_column();
+
+        this->init_origin_cell(*std::ranges::begin(col), cache);
+
+        ranges::for_each(col | ranges::view::drop_exactly(1), [&cache, this](auto & cell)
+        {
+            this->init_column_cell(cell, cache);
+        });
+    }
+
+    /*!\brief Compute the alignment by iterating over the dynamic programming matrix in a column wise manner.
+     * \tparam        first_batch_t  The type of the first sequence (or packed sequences).
+     * \tparam        second_batch_t The type of the second sequence (or packed sequences).
+     * \tparam        cache_t        The type of the cache.
+     * \param[in]     first_batch    The first sequence.
+     * \param[in]     second_batch   The second sequence.
+     * \param[in,out] cache          The cache holding hot variables.
+     */
+    template <typename first_batch_t,
+              typename second_batch_t,
+              typename cache_t>
+    void compute_matrix(first_batch_t const & first_batch,
+                        second_batch_t const & second_batch,
+                        cache_t & cache)
+    {
+        auto const & score_scheme = get<align_cfg::scoring>(*cfg_ptr).value;
+        ranges::for_each(first_batch, [&, this](auto seq1_value)
+        {
+            auto col = this->current_column();
+            this->init_row_cell(*std::ranges::begin(col), cache);
+
+            auto second_batch_it = std::ranges::begin(second_batch);
+            ranges::for_each(col | ranges::view::drop_exactly(1), [&, this] (auto & cell)
+            {
+                this->compute_cell(cell, cache, score_scheme.score(seq1_value, *second_batch_it));
+                ++second_batch_it;
+            });
+        });
+    }
+
+    //!\brief The alignment configuration stored on the heap.
+    std::shared_ptr<config_t> cfg_ptr{};
+};
+
+} // namespace seqan3::detail

--- a/include/seqan3/alignment/pairwise/alignment_configurator.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_configurator.hpp
@@ -1,0 +1,189 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2018, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2018, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides seqan3::detail::alignment_selector.
+ * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <functional>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include <seqan3/alignment/configuration/all.hpp>
+#include <seqan3/alignment/pairwise/policy/all.hpp>
+#include <seqan3/alignment/pairwise/alignment_algorithm.hpp>
+#include <seqan3/alignment/pairwise/align_result_selector.hpp>
+#include <seqan3/alignment/pairwise/align_result.hpp>
+#include <seqan3/alignment/pairwise/edit_distance_unbanded.hpp>
+#include <seqan3/alphabet/gap/gapped.hpp>
+#include <seqan3/core/concept/tuple.hpp>
+#include <seqan3/core/metafunction/deferred_crtp_base.hpp>
+#include <seqan3/core/metafunction/range.hpp>
+#include <seqan3/core/metafunction/template_inspection.hpp>
+#include <seqan3/core/type_list.hpp>
+#include <seqan3/range/view/persist.hpp>
+
+namespace seqan3::detail
+{
+
+/*!\brief Provides several contracts to test when configuring the alignment algorithm.
+ * \ingroup pairwise_alignment
+ * \tparam range_type            The type of the range containing sequences to be aligned.
+ * \tparam alignment_config_type The type of the alignment configuration.
+ *
+ * \details
+ *
+ * This stateless helper class provides several contract testing functions for the alignment configuration.
+ */
+template <typename range_type,
+          typename alignment_config_type>
+struct alignment_contract
+{
+private:
+    /*!\brief Auxiliary member types
+     * \{
+     */
+    using first_seq_t  = std::tuple_element_t<0, value_type_t<std::ranges::iterator_t<range_type>>>;
+    using second_seq_t = std::tuple_element_t<1, value_type_t<std::ranges::iterator_t<range_type>>>;
+    //!\}
+
+public:
+    //!\brief Tests whether the value type of `range_type` is a tuple with exactly 2 members.
+    constexpr static bool expects_tuple_like_value_type()
+    {
+        return tuple_like_concept<alignment_config_type> &&
+               std::tuple_size_v<value_type_t<std::ranges::iterator_t<range_type>>> == 2;
+    }
+
+    //!\brief Tests whether the scoring scheme is set and can be invoked with the sequences passed.
+    constexpr static bool expects_valid_scoring_scheme()
+    {
+        if constexpr (alignment_config_type::template exists<align_cfg::scoring>())
+        {
+            using scoring_type = std::remove_reference_t<
+                                    decltype(get<align_cfg::scoring>(std::declval<alignment_config_type>()).value)
+                                 >;
+            return static_cast<bool>(scoring_scheme_concept<scoring_type, value_type_t<first_seq_t>,
+                                                                          value_type_t<second_seq_t>>);
+        }
+        else
+        {
+            return false;
+        }
+    }
+};
+
+/*!\brief Configures the alignment algorithm given the sequences and the configuration object.
+ * \ingroup pairwise_alignment
+ */
+struct alignment_configurator
+{
+    //!\brief Configure the algorithm.
+    template <std::ranges::ViewableRange sequences_t, typename config_t>
+        requires is_type_specialisation_of_v<remove_cvref_t<config_t>, configuration>
+    static constexpr auto configure(sequences_t seq_range, config_t const & cfg)
+    {
+        // ----------------------------------------------------------------------------
+        // Configure the type-erased alignment function.
+        // ----------------------------------------------------------------------------
+
+        using first_seq_t  = std::remove_reference_t<std::tuple_element_t<
+                                                        0,
+                                                        remove_cvref_t<decltype(*seqan3::begin(seq_range))>>>;
+        using second_seq_t = std::remove_reference_t<std::tuple_element_t<
+                                                        1,
+                                                        remove_cvref_t<decltype(*seqan3::begin(seq_range))>>>;
+
+        // Select the result type based on the sequences and the configuration.
+        using result_t = align_result<typename align_result_selector<first_seq_t, second_seq_t, config_t>::type>;
+        // Define the kernel type.
+        using kernel_t = std::function<result_t(first_seq_t const &, second_seq_t const &)>;
+
+
+        // ----------------------------------------------------------------------------
+        // Test some basic preconditions
+        // ----------------------------------------------------------------------------
+
+        using alignment_contract_t = alignment_contract<remove_cvref_t<sequences_t>, config_t>;
+
+        static_assert(alignment_contract_t::expects_tuple_like_value_type(),
+                      "Alignment configuration error: "
+                      "The value type of the sequence ranges must model the seqan3::detail::tuple_like_concept "
+                      "and must contain exactly 2 elements.");
+
+        static_assert(alignment_contract_t::expects_valid_scoring_scheme(),
+                      "Alignment configuration error: "
+                      "Either the scoring scheme was not configured or the given scoring scheme cannot be invoked with "
+                      "the value types of the passed sequences.");
+
+        // ----------------------------------------------------------------------------
+        // Unsupported configurations
+        // ----------------------------------------------------------------------------
+
+        if constexpr (config_t::template exists<align_cfg::band>())
+            throw std::domain_error{"Banded alignments are yet not supported."};
+
+        // ----------------------------------------------------------------------------
+        // Configure the algorithm
+        // ----------------------------------------------------------------------------
+
+        // Use default edit distance if gaps are not set.
+        auto const & gaps = cfg.template value_or<align_cfg::gap>(gap_scheme{gap_score{-1}});
+        auto const & scoring_scheme = get<align_cfg::scoring>(cfg).value;
+
+        // Check if edit distance can be used?
+        if (gaps.get_gap_open_score() == 0)
+        {
+            // TODO: Instead of relying on nucleotide scoring schemes we need to be able to determine the edit distance
+            //       option via the scheme.
+            if constexpr (is_type_specialisation_of_v<remove_cvref_t<decltype(scoring_scheme)>,
+                                                      nucleotide_scoring_scheme>)
+            {
+                if ((scoring_scheme.score('A'_dna15, 'A'_dna15) == 0) &&
+                    (scoring_scheme.score('A'_dna15, 'C'_dna15)) == -1)
+                    return configure_edit_distance<kernel_t>(cfg);
+            }
+        }
+
+        // ----------------------------------------------------------------------------
+        // Unsupported configurations
+        // ----------------------------------------------------------------------------
+
+        if constexpr (config_t::template exists<align_cfg::aligned_ends>())
+            throw std::domain_error{"Configuring the aligned ends is yet not supported."};
+
+        if constexpr (config_t::template exists<align_cfg::result<with_begin_position_type>>())
+            throw std::domain_error{"Computing the begin position is yet not supported."};
+
+        if constexpr (config_t::template exists<align_cfg::result<with_trace_type>>())
+            throw std::domain_error{"Computing the traceback is yet not supported."};
+
+        // Configure non-edit distance alignment algorithm.
+        using score_type = int;
+        using cell_type = std::pair<score_type, score_type>;
+        using dp_matrix_t = deferred_crtp_base<unbanded_dp_matrix_policy, std::allocator<cell_type>>;
+        using affine_t = deferred_crtp_base<affine_gap_policy, cell_type>;
+        using init_t = deferred_crtp_base<affine_gap_init_policy>;
+
+        return kernel_t{alignment_algorithm<config_t, dp_matrix_t, affine_t, init_t>{cfg}};
+    }
+
+private:
+
+    //!\brief Configure the edit distance algorithm.
+    template <typename kernel_t, typename config_t>
+    static constexpr auto configure_edit_distance(config_t const & cfg)
+    {
+        return kernel_t{edit_distance_wrapper<remove_cvref_t<config_t>>{cfg}};
+    }
+};
+
+} // namespace seqan3::detail

--- a/include/seqan3/alignment/pairwise/alignment_configurator.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_configurator.hpp
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------------------------------------
-// Copyright (c) 2006-2018, Knut Reinert & Freie Universität Berlin
-// Copyright (c) 2016-2018, Knut Reinert & MPI für molekulare Genetik
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
 // This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
 // shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
 // -----------------------------------------------------------------------------------------------------

--- a/include/seqan3/alignment/pairwise/alignment_selector.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_selector.hpp
@@ -18,102 +18,92 @@
 #include <vector>
 
 #include <seqan3/alignment/configuration/all.hpp>
-#include <seqan3/alignment/matrix/alignment_trace_matrix.hpp>
+#include <seqan3/alignment/pairwise/alignment_algorithm.hpp>
 #include <seqan3/alignment/pairwise/align_result.hpp>
 #include <seqan3/alignment/pairwise/edit_distance_unbanded.hpp>
+#include <seqan3/alignment/pairwise/policy/affine_gap_init_policy.hpp>
+#include <seqan3/alignment/pairwise/policy/affine_gap_policy.hpp>
+#include <seqan3/alignment/pairwise/policy/unbanded_dp_matrix_policy.hpp>
+#include <seqan3/alignment/pairwise/align_result_selector.hpp>
 #include <seqan3/alphabet/gap/gapped.hpp>
 #include <seqan3/core/concept/tuple.hpp>
+#include <seqan3/core/metafunction/deferred_crtp_base.hpp>
 #include <seqan3/core/metafunction/range.hpp>
+#include <seqan3/core/metafunction/template_inspection.hpp>
 #include <seqan3/core/type_list.hpp>
 #include <seqan3/range/view/persist.hpp>
 
 namespace seqan3::detail
 {
 
-/*!\brief Helper metafunction to determine the alignment result type based on the configuration.
- * \ingroup pairwise
- * \tparam seq1_t          The type of the first sequence.
- * \tparam seq2_t          The type of the second sequence.
- * \tparam configuration_t The configuration type. Must be of type seqan3::detail::configuration
+/*!\brief Configures the alignment kernel given the sequences and the configuration object.
+ * \ingroup pairwise_alignment
  */
-template <typename seq1_t, typename seq2_t, typename configuration_t>
-struct determine_result_type
+struct alignment_configurator
 {
-    //!\brief Helper function to determine the actual result type.
-    static constexpr auto _determine()
+    //!\brief Configure the edit distance algorithm.
+    template <typename config_t>
+    static constexpr auto configure_edit_distance(config_t const & cfg)
     {
-        using seq1_value_type = gapped<value_type_t<std::remove_reference_t<seq1_t>>>;
-        using seq2_value_type = gapped<value_type_t<std::remove_reference_t<seq2_t>>>;
-        using score_type      = int32_t;
-
-        if constexpr (std::remove_reference_t<configuration_t>::template exists<align_cfg::result>())
-        {
-            if constexpr (std::Same<remove_cvref_t<decltype(get<align_cfg::result>(configuration_t{}).value)>,
-                                    with_end_position_type>)
-                return align_result_value_type<uint32_t,
-                                               score_type,
-                                               alignment_coordinate>{};
-            else if constexpr (std::Same<remove_cvref_t<decltype(get<align_cfg::result>(configuration_t{}).value)>,
-                                         with_begin_position_type>)
-                return align_result_value_type<uint32_t,
-                                               score_type,
-                                               alignment_coordinate,
-                                               alignment_coordinate>{};
-            else if constexpr (std::Same<remove_cvref_t<decltype(get<align_cfg::result>(configuration_t{}).value)>,
-                                         with_trace_type>)
-                return align_result_value_type<uint32_t,
-                                               score_type,
-                                               alignment_coordinate,
-                                               alignment_coordinate,
-                                               std::pair<std::vector<seq1_value_type>,
-                                                         std::vector<seq2_value_type>>>{};
-            else
-                return align_result_value_type<uint32_t, score_type>{};
-        }
-        else
-        {
-            return align_result_value_type<uint32_t, score_type>{};
-        }
+        throw std::domain_error{"This branch is not yet implemented."};
     }
 
-    //!\brief The determined result type.
-    using type = align_result<decltype(_determine())>;
-};
-
-/*!\brief Selects the correct alignment algorithm based on the algorithm configuration.
- * \ingroup pairwise
- * \tparam seq_tuple_t     A tuple like object containing the two source sequences.
- *                         Must model seqan3::tuple_like_concept.
- * \tparam configuration_t The specified configuration type.
- */
-template <tuple_like_concept seq_tuple_t, typename configuration_t>
-struct alignment_selector
-{
-    //!\brief The configuration stored globally for all alignment instances.
-    configuration_t config;
-
-    //!\brief The result type of invoking the algorithm.
-    using result_type = typename determine_result_type<std::tuple_element_t<0, std::remove_reference_t<seq_tuple_t>>,
-                                                       std::tuple_element_t<1, std::remove_reference_t<seq_tuple_t>>,
-                                                       configuration_t>::type;
-
-    /*!\brief Selects the corresponding alignment algorithm based on compile time and runtime decisions.
-     * \param[in] seq The sequences as a tuple.
-     * \returns A std::function object to be called within the alignment execution.
-     *
-     * \details
-     *
-     * \todo Write detail description and explain rationale about the function object.
-     */
-    template <tuple_like_concept _seq_tuple_t>
-    auto select(_seq_tuple_t && seq)
+    //!\brief Configure the algorithm.
+    template <std::ranges::View sequences_t, typename config_t>
+        requires is_type_specialisation_of_v<remove_cvref_t<config_t>, configuration>
+    static constexpr auto configure(sequences_t SEQAN3_DOXYGEN_ONLY(seq_range), config_t const & cfg)
     {
-        //TODO Currently we only support edit_distance. We need would actually need real checks for this.
-        std::function<result_type(result_type &)> func =
-            pairwise_alignment_edit_distance_unbanded{std::get<0>(std::forward<_seq_tuple_t>(seq)) | view::persist,
-                                                      std::get<1>(std::forward<_seq_tuple_t>(seq)) | view::persist,
-                                                      config};
-        return func;
+        using first_seq_t = std::remove_reference_t<
+                                std::tuple_element_t<
+                                    0,
+                                    value_type_t<std::ranges::iterator_t<remove_cvref_t<sequences_t>>>
+                                >
+                            >;
+        using second_seq_t = std::remove_reference_t<
+                                std::tuple_element_t<
+                                    1,
+                                    value_type_t<std::ranges::iterator_t<remove_cvref_t<sequences_t>>>
+                                >
+                             >;
+
+        using result_t = align_result<typename align_result_selector<first_seq_t,
+                                                                     second_seq_t,
+                                                                     remove_cvref_t<config_t>>::type
+                                     >;
+        using kernel_t = std::function<result_t(first_seq_t const &, second_seq_t const &)>;
+
+        auto const & gaps = cfg.template value_or<align_cfg::gap>(gap_scheme{gap_score{-1}});
+        auto const & scoring_scheme =
+            cfg.template value_or<align_cfg::scoring>(nucleotide_scoring_scheme{match_score{0}, mismatch_score{-1}});
+        // Linear gaps
+        if (gaps.get_gap_open_score() == 0)
+        {
+            if constexpr (is_type_specialisation_of_v<remove_cvref_t<decltype(scoring_scheme)>,
+                                                      nucleotide_scoring_scheme>)
+            {
+                // TODO: Check if the matrix is Levenshtein distance.
+                // if ((scoring_scheme.score('A'_dna15, 'A'_dna15) == 0) &&
+                //     (scoring_scheme.score('A'_dna15, 'C'_dna15)) == -1)
+                //     return configure_edit_distance(cfg);
+                // else
+                    throw std::domain_error{"Linear gaps are not yet implemented."};
+            }
+            else // Not nucleotide_scoring_scheme
+            {
+                throw std::domain_error{"Linear gaps are not yet implemented."};
+            }
+        }
+        else // Affine gaps
+        {
+            using score_type = int;
+            using cell_type = std::pair<score_type, score_type>;
+            using dp_matrix_t = deferred_crtp_base<unbanded_dp_matrix_policy, std::allocator<cell_type>>;
+            using affine_t = deferred_crtp_base<affine_gap_policy, cell_type>;
+            using init_t = deferred_crtp_base<affine_gap_init_policy>;
+            //TODO: copies but we want to have unique_funtion to only move.
+            return kernel_t{alignment_algorithm<config_t, dp_matrix_t, affine_t, init_t>{cfg}};
+        }
     }
 };
+
 } // namespace seqan3::detail

--- a/include/seqan3/alignment/pairwise/alignment_selector.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_selector.hpp
@@ -42,10 +42,10 @@ namespace seqan3::detail
 struct alignment_configurator
 {
     //!\brief Configure the edit distance algorithm.
-    template <typename config_t>
+    template <typename kernel_t, typename config_t>
     static constexpr auto configure_edit_distance(config_t const & cfg)
     {
-        throw std::domain_error{"This branch is not yet implemented."};
+        return kernel_t{edit_distance_wrapper<remove_cvref_t<config_t>>{cfg}};
     }
 
     //!\brief Configure the algorithm.
@@ -82,10 +82,10 @@ struct alignment_configurator
                                                       nucleotide_scoring_scheme>)
             {
                 // TODO: Check if the matrix is Levenshtein distance.
-                // if ((scoring_scheme.score('A'_dna15, 'A'_dna15) == 0) &&
-                //     (scoring_scheme.score('A'_dna15, 'C'_dna15)) == -1)
-                //     return configure_edit_distance(cfg);
-                // else
+                if ((scoring_scheme.score('A'_dna15, 'A'_dna15) == 0) &&
+                    (scoring_scheme.score('A'_dna15, 'C'_dna15)) == -1)
+                    return configure_edit_distance<kernel_t>(cfg);
+                else
                     throw std::domain_error{"Linear gaps are not yet implemented."};
             }
             else // Not nucleotide_scoring_scheme

--- a/include/seqan3/alignment/pairwise/all.hpp
+++ b/include/seqan3/alignment/pairwise/all.hpp
@@ -6,7 +6,7 @@
 // -----------------------------------------------------------------------------------------------------
 
 /*!\file
- * \brief Meta-header for the \link pairwise pairwise submodule \endlink.
+ * \brief Meta-header for the \link pairwise_alignment pairwise submodule \endlink.
  * \author Rene Rahn <rene.rahn AT fu-berlin.de>
  */
 
@@ -14,11 +14,14 @@
 
 #include <seqan3/alignment/pairwise/align_pairwise.hpp>
 #include <seqan3/alignment/pairwise/align_result.hpp>
+#include <seqan3/alignment/pairwise/alignment_algorithm.hpp>
+#include <seqan3/alignment/pairwise/align_result_selector.hpp>
 #include <seqan3/alignment/pairwise/alignment_selector.hpp>
 #include <seqan3/alignment/pairwise/edit_distance_unbanded.hpp>
 #include <seqan3/alignment/pairwise/execution/all.hpp>
+#include <seqan3/alignment/pairwise/policy/all.hpp>
 
-/*!\defgroup pairwise Pairwise
+/*!\defgroup pairwise_alignment Pairwise
  * \ingroup alignment
  * \brief Provides the algorithmic components for the computation of pairwise alignments.
  */

--- a/include/seqan3/alignment/pairwise/all.hpp
+++ b/include/seqan3/alignment/pairwise/all.hpp
@@ -16,7 +16,7 @@
 #include <seqan3/alignment/pairwise/align_result.hpp>
 #include <seqan3/alignment/pairwise/alignment_algorithm.hpp>
 #include <seqan3/alignment/pairwise/align_result_selector.hpp>
-#include <seqan3/alignment/pairwise/alignment_selector.hpp>
+#include <seqan3/alignment/pairwise/alignment_configurator.hpp>
 #include <seqan3/alignment/pairwise/edit_distance_unbanded.hpp>
 #include <seqan3/alignment/pairwise/execution/all.hpp>
 #include <seqan3/alignment/pairwise/policy/all.hpp>

--- a/include/seqan3/alignment/pairwise/edit_distance_unbanded.hpp
+++ b/include/seqan3/alignment/pairwise/edit_distance_unbanded.hpp
@@ -74,7 +74,7 @@ concept edit_distance_trait_concept = requires
 };
 
 /*!\brief The default traits type for the edit distance algorithm.
- * \ingroup pairwise
+ * \ingroup pairwise_alignment
  */
 struct default_edit_distance_trait_type
 {
@@ -83,7 +83,7 @@ struct default_edit_distance_trait_type
 };
 
 /*!\brief This calculates an alignment using the edit distance and without a band.
- * \ingroup pairwise
+ * \ingroup pairwise_alignment
  * \tparam database_t     \copydoc pairwise_alignment_edit_distance_unbanded::database_type
  * \tparam query_t        \copydoc pairwise_alignment_edit_distance_unbanded::query_type
  * \tparam align_config_t The type of the alignment config.

--- a/include/seqan3/alignment/pairwise/edit_distance_unbanded.hpp
+++ b/include/seqan3/alignment/pairwise/edit_distance_unbanded.hpp
@@ -24,6 +24,7 @@
 #include <seqan3/alignment/matrix/alignment_score_matrix.hpp>
 #include <seqan3/alignment/matrix/alignment_trace_algorithms.hpp>
 #include <seqan3/alignment/matrix/alignment_trace_matrix.hpp>
+#include <seqan3/alignment/pairwise/align_result_selector.hpp>
 #include <seqan3/alignment/pairwise/align_result.hpp>
 #include <seqan3/core/algorithm/configuration.hpp>
 #include <seqan3/range/shortcuts.hpp>
@@ -578,6 +579,77 @@ template<typename database_t, typename query_t, typename config_t, typename trai
 pairwise_alignment_edit_distance_unbanded(database_t && database, query_t && query, config_t config, traits_t)
     -> pairwise_alignment_edit_distance_unbanded<database_t, query_t, config_t, traits_t>;
 //!\}
+
+// ----------------------------------------------------------------------------
+// edit_distance_wrapper
+// ----------------------------------------------------------------------------
+
+/*!\brief This type wraps the call to the seqan3::detail::pairwise_alignment_edit_distance_unbanded algorithm.
+ * \implements std::Invocable
+ * \tparam config_t The configuration type.
+ *
+ * \details
+ *
+ * This wrapper class is used to decouple the sequence types from the algorithm class type.
+ * Within the alignment configuration a std::function object with this wrapper stored is returned
+ * if an edit distance should be computed. On invocation it delegates the call to the actual implementation
+ * of the edit distance algorithm, while the interface is unified with the execution model of the pairwise alignment
+ * algorithms.
+ */
+template <typename config_t>
+class edit_distance_wrapper
+{
+public:
+    /*!\name Constructor, destructor and assignment
+     * \brief Defaulted all standard constructor.
+     * \{
+     */
+    constexpr edit_distance_wrapper() = default;
+    constexpr edit_distance_wrapper(edit_distance_wrapper const &) = default;
+    constexpr edit_distance_wrapper(edit_distance_wrapper &&) = default;
+    constexpr edit_distance_wrapper & operator=(edit_distance_wrapper const &) = default;
+    constexpr edit_distance_wrapper & operator=(edit_distance_wrapper &&) = default;
+    ~edit_distance_wrapper() = default;
+
+    /*!\brief Constructs the wrapper with the passed configuration.
+     * \param cfg The configuration to be passed to the algorithm.
+     *
+     * \details
+     *
+     * The configuration is copied once to the heap during construction and maintained by a std::shared_ptr.
+     * The configuration is not passed to the function-call-operator of this function object, in order to avoid
+     * incompatible configurations between the passed configuration and the one used during configuration of this
+     * class. Further the function object will be stored in a std::function which requires copyable objects and
+     * in parallel executions the function object must be copied as well.
+     */
+    constexpr edit_distance_wrapper(config_t const & cfg) : cfg_ptr{new config_t(cfg)}
+    {}
+    //!}
+
+    /*!\brief Invokes the actual alignment computation given two sequences.
+     * \tparam    first_batch_t  The type of the first sequence (or packed sequences); must model std::ForwardRange.
+     * \tparam    second_batch_t The type of the second sequence (or packed sequences); must model std::ForwardRange.
+     * \param[in] first_batch    The first sequence (or packed sequences).
+     * \param[in] second_batch   The second sequence (or packed sequences).
+     */
+    template <std::ranges::ForwardRange first_batch_t, std::ranges::ForwardRange second_batch_t>
+    constexpr auto operator()(first_batch_t && first_batch, second_batch_t && second_batch)
+    {
+        using result_t = typename detail::align_result_selector<remove_cvref_t<first_batch_t>,
+                                                                remove_cvref_t<second_batch_t>,
+                                                                remove_cvref_t<config_t>>::type;
+
+        pairwise_alignment_edit_distance_unbanded algo{std::forward<first_batch_t>(first_batch),
+                                                       std::forward<second_batch_t>(second_batch),
+                                                       *cfg_ptr};
+        align_result<result_t> res{};
+        return algo(res);
+    }
+
+private:
+    //!\brief The alignment configuration stored on the heap.
+    std::shared_ptr<remove_cvref_t<config_t>> cfg_ptr{};
+};
 
 //!\cond
 template<typename database_t, typename query_t, typename align_config_t, typename traits_t>

--- a/include/seqan3/alignment/pairwise/execution/alignment_executor_two_way.hpp
+++ b/include/seqan3/alignment/pairwise/execution/alignment_executor_two_way.hpp
@@ -20,6 +20,7 @@
 #include <seqan3/alignment/pairwise/execution/execution_handler_sequential.hpp>
 #include <seqan3/core/metafunction/range.hpp>
 #include <seqan3/range/shortcuts.hpp>
+#include <seqan3/range/view/single_pass_input.hpp>
 #include <seqan3/std/ranges>
 
 namespace seqan3::detail
@@ -27,36 +28,36 @@ namespace seqan3::detail
 
 /*!\brief A two way executor for pairwise alignments.
  * \ingroup execution
- * \tparam align_instance_rng_t  A bounded range over the alignment instances to compute.
- * \tparam alignment_seclector_t Selects the alignment to execute.
- * \tparam execution_handler_t   The execution handler managing the execution of the alignment instances.
+ * \tparam resource_t            The underlying range of sequence pairs to be computed; must model
+ *                               std::ranges::ViewableRange and std::ranges::InputRange.
+ * \tparam alignment_algorithm_t The alignment algorithm to be invoked on each sequence pair.
+ * \tparam execution_handler_t   The execution handler managing the execution of the alignments.
+ *
+ * \details
+ *
+ * This alignment executor provides an additional buffer over the computed alignments to allow
+ * a two-way execution flow. The alignment results can then be accessed in an order-preserving manner using the
+ * alignment_executor_two_way::bump() member function.
  */
-template <std::ranges::ViewableRange align_instance_rng_t,
+template <std::ranges::ViewableRange resource_t,
           typename alignment_algorithm_t,
           typename execution_handler_t = execution_handler_sequential>
+//!\cond
+    requires std::ranges::InputRange<std::remove_reference_t<resource_t>>
+//!\endcond
 class alignment_executor_two_way
 {
-    //!\brief Shortcut declaration for this class.
-    using this_t = alignment_executor_two_way<align_instance_rng_t, alignment_algorithm_t, execution_handler_t>;
-
-    //!\brief Grants alignment_range access to the protected/private member of this class.
-    template <typename executor_t>
-    friend class seqan3::alignment_range;
-
-    /*!\name Resource
+private:
+    /*!\name Resource types
      * \{
      */
-    //!\brief The resource type
-    using resource_type       = std::remove_reference_t<align_instance_rng_t>;
-    //!\brief The iterator over the resource.
-    using resource_iterator   = std::ranges::iterator_t<resource_type>;
-    //!\brief The sentinel over the resource.
-    using resource_sentinel   = std::ranges::sentinel_t<resource_type>;
+    //!\brief The underlying resource type.
+    using resource_type       = detail::single_pass_input_view<resource_t>;
     //!\brief The value type of the resource.
-    using resource_value_type = std::remove_reference_t<decltype(*std::declval<resource_iterator>())>;
+    using resource_value_type = value_type_t<resource_type>;
     //!\}
 
-    /*!\name Buffer
+    /*!\name Buffer types
      * \{
      */
     //!\brief The result of invoking the alignment instance.
@@ -66,66 +67,92 @@ class alignment_executor_two_way
     //!\brief The pointer type of the buffer.
     using buffer_pointer    = std::ranges::iterator_t<buffer_type>;
     //!\}
+
 public:
+
+    /*!\name Member types
+     * \{
+     */
+
     //!\brief The result type of invoking the alignment instance.
     using value_type      = buffer_value_type;
     //!\brief A reference to the alignment result.
     using reference       = std::add_lvalue_reference_t<value_type>;
     //!\brief The difference type for the buffer.
     using difference_type = typename buffer_type::difference_type;
+    //!\}
 
     /*!\name Constructors, destructor and assignment
+     * \brief The class is not copy-constructible or copy-assignable but allows move construction and assignment.
      * \{
      */
-    alignment_executor_two_way()                                               = default;
-    alignment_executor_two_way(alignment_executor_two_way const &)             = default;
-    alignment_executor_two_way(alignment_executor_two_way &&)                  = default;
-    alignment_executor_two_way & operator=(alignment_executor_two_way const &) = default;
-    alignment_executor_two_way & operator=(alignment_executor_two_way &&)      = default;
-    ~alignment_executor_two_way()                                              = default;
+    alignment_executor_two_way() = delete;
+    alignment_executor_two_way(alignment_executor_two_way const &) = delete;
+    alignment_executor_two_way(alignment_executor_two_way &&) = default;
+    alignment_executor_two_way & operator=(alignment_executor_two_way const &) = delete;
+    alignment_executor_two_way & operator=(alignment_executor_two_way && ) = default;
+    ~alignment_executor_two_way() = default;
 
     //!\brief Constructs this executor with the passed range of alignment instances.
-    alignment_executor_two_way(align_instance_rng_t _resource,
-                               alignment_algorithm_t _kernel) :
-        resource{std::forward<align_instance_rng_t>(_resource)},
-        kernel{std::forward<alignment_algorithm_t>(_kernel)},
-        resource_iter{seqan3::begin(resource)},
-        resource_end{seqan3::end(resource)}
+    alignment_executor_two_way(resource_t && resrc,
+                               alignment_algorithm_t fn) :
+        resource{view::single_pass_input(std::forward<resource_t>(resrc))},
+        kernel{fn}
     {
-        buffer.resize(1);
-        setg(seqan3::end(buffer), seqan3::end(buffer));
+        init_buffer();
     }
     //!}
-
-    //!\brief Returns a seqan3::detail::alignment_range over the invoked alignment instances.
-    alignment_range<this_t> range()
-    {
-        return alignment_range<this_t>{*this};
-    }
-
-protected:
 
     /*!\name Get area
      * \{
      */
+    /*!\brief Returns the current alignment result in the buffer and advances the buffer to the next position.
+     * \returns A std::optional that either contains a reference to the underlying value or is empty iff the
+     *          underlying resource has been completely consumed.
+     *
+     * \details
+     *
+     * If there is no available input in the result buffer anymore, this function triggers an underflow to fill
+     * the buffer with the next alignments.
+     *
+     * ### Exception
+     *
+     * Throws std::bad_function_call if the algorithm was not set.
+     */
+    std::optional<value_type> bump()
+    {
+        if (gptr == buffer_pointer{} || in_avail() == 0)
+        {
+            if (underflow() == eof)
+            {
+                return {std::nullopt};
+            }
+        }
+        return {std::move(*gptr++)};
+    }
+
     //!\brief Returns the remaining number of elements in the buffer, that are not read yet.
     constexpr size_t in_avail() const noexcept
     {
         return egptr - gptr;
     }
+    //!\}
 
-    //!\brief Returns the current alignment result in the buffer and advances the buffer get pointer.
-    std::optional<std::reference_wrapper<value_type>> bump()
+    /*!\name Miscellaneous
+     * \{
+     */
+    //!\brief Checks whether the end of the input resource was reached.
+    bool is_eof() noexcept
     {
-        if (gptr == buffer_pointer{} || gptr >= egptr)
-        {
-            if (underflow() == eof)
-            {
-                return {};
-            }
-        }
-        return {std::ref(*gptr++)};
+        return seqan3::begin(resource) == seqan3::end(resource);
     }
+    //!\}
+
+private:
+
+    /*!\name Get area
+     * \{
+     */
 
     //\brief Sets the buffer pointer.
     void setg(buffer_pointer beg, buffer_pointer end)
@@ -144,21 +171,21 @@ protected:
             return eof;
 
         // Reset the get pointer.
-        setg(begin(buffer), begin(buffer) +
-            std::min(static_cast<size_t>(resource_end - resource_iter), buffer.size()));
+        setg(seqan3::begin(buffer), seqan3::end(buffer));
 
         // Apply the alignment execution.
         // TODO: Adapt for async behavior for parallel execution handler.
-        std::transform(resource_iter, resource_iter + in_avail(), gptr,
-            [this](auto && align_instance){
-                value_type tmp;
-                auto const & [first_seq, second_seq] = align_instance;
-                exec_handler.execute(kernel, first_seq, second_seq,
-                                     [&tmp](auto && res){ tmp = std::move(res); });
-                return tmp;
-            });
-        // Advance the resource.
-        std::advance(resource_iter, in_avail());
+        size_t count = 0;
+        for (auto resource_iter = seqan3::begin(resource);
+             count < in_avail() && !is_eof(); ++count, ++resource_iter, ++gptr)
+        {
+            auto const & [first_seq, second_seq] = *resource_iter;
+            exec_handler.execute(kernel, first_seq, second_seq, [this](auto && res){ *gptr = std::move(res); });
+        }
+
+        // Update the available get position if the buffer was consumed completely.
+        setg(seqan3::begin(buffer), seqan3::begin(buffer) + count);
+
         return in_avail();
     }
     //!\}
@@ -166,14 +193,14 @@ protected:
     /*!\name Miscellaneous
      * \{
      */
-    //!\brief Checks whether the end of the input resource was reached.
-    bool is_eof() const noexcept
+
+    //!\brief Initialises the underlying buffer.
+    void init_buffer()
     {
-        return resource_iter == resource_end;
+        buffer.resize(1);
+        setg(seqan3::end(buffer), seqan3::end(buffer));
     }
     //!\}
-
-private:
 
     //!\brief Indicates the end-of-stream.
     static constexpr size_t eof{-1};
@@ -182,30 +209,25 @@ private:
     execution_handler_t exec_handler{};
 
     //!\brief The underlying resource containing the alignment instances.
-    align_instance_rng_t resource;  // view or lvalue ref
+    resource_type resource{};
     //!\brief Selects the correct alignment to execute.
-    alignment_algorithm_t kernel;
-
-    //!\brief Points to the current element in the resource.
-    resource_iterator resource_iter{};
-    //!\brief End of the resource.
-    resource_sentinel resource_end{};
+    alignment_algorithm_t kernel{};
 
     //!\brief The buffer storing the alignment results.
-    buffer_type buffer;
+    buffer_type buffer{};
     //!\brief The get pointer in the buffer.
-    buffer_pointer gptr;
+    buffer_pointer gptr{};
     //!\brief The end get pointer in the buffer.
-    buffer_pointer egptr;
+    buffer_pointer egptr{};
 };
 
 /*!\name Type deduction guides
  * \relates seqan3::detail::alignment_executor_two_way
  * \{
  */
-template <std::ranges::ViewableRange resource_rng_t, typename func_t>
-alignment_executor_two_way(resource_rng_t && , func_t &&) ->
-    alignment_executor_two_way<resource_rng_t, std::remove_reference_t<func_t>, execution_handler_sequential>;
+template <typename resource_rng_t, typename func_t>
+alignment_executor_two_way(resource_rng_t &&, func_t) ->
+    alignment_executor_two_way<resource_rng_t, func_t, execution_handler_sequential>;
 
 //!\}
 } // namespace seqan3::detail

--- a/include/seqan3/alignment/pairwise/execution/alignment_executor_two_way.hpp
+++ b/include/seqan3/alignment/pairwise/execution/alignment_executor_two_way.hpp
@@ -32,12 +32,12 @@ namespace seqan3::detail
  * \tparam execution_handler_t   The execution handler managing the execution of the alignment instances.
  */
 template <std::ranges::ViewableRange align_instance_rng_t,
-          typename alignment_selector_t,
+          typename alignment_algorithm_t,
           typename execution_handler_t = execution_handler_sequential>
 class alignment_executor_two_way
 {
     //!\brief Shortcut declaration for this class.
-    using this_t = alignment_executor_two_way<align_instance_rng_t, alignment_selector_t, execution_handler_t>;
+    using this_t = alignment_executor_two_way<align_instance_rng_t, alignment_algorithm_t, execution_handler_t>;
 
     //!\brief Grants alignment_range access to the protected/private member of this class.
     template <typename executor_t>
@@ -60,7 +60,7 @@ class alignment_executor_two_way
      * \{
      */
     //!\brief The result of invoking the alignment instance.
-    using buffer_value_type = typename std::remove_reference_t<alignment_selector_t>::result_type;
+    using buffer_value_type = typename alignment_algorithm_t::result_type;
     //!\brief The internal buffer.
     using buffer_type       = std::vector<buffer_value_type>;
     //!\brief The pointer type of the buffer.
@@ -86,14 +86,14 @@ public:
 
     //!\brief Constructs this executor with the passed range of alignment instances.
     alignment_executor_two_way(align_instance_rng_t _resource,
-                               alignment_selector_t _selector) :
+                               alignment_algorithm_t _kernel) :
         resource{std::forward<align_instance_rng_t>(_resource)},
-        selector{std::forward<alignment_selector_t>(_selector)},
-        resource_iter{begin(resource)},
-        resource_end{end(resource)}
+        kernel{std::forward<alignment_algorithm_t>(_kernel)},
+        resource_iter{seqan3::begin(resource)},
+        resource_end{seqan3::end(resource)}
     {
         buffer.resize(1);
-        setg(end(buffer), end(buffer));
+        setg(seqan3::end(buffer), seqan3::end(buffer));
     }
     //!}
 
@@ -151,10 +151,10 @@ protected:
         // TODO: Adapt for async behavior for parallel execution handler.
         std::transform(resource_iter, resource_iter + in_avail(), gptr,
             [this](auto && align_instance){
-                // value_type tmp;
-                auto f = selector.select(std::forward<decltype(align_instance)>(align_instance));
                 value_type tmp;
-                exec_handler.execute(std::move(f), tmp, [&tmp](auto && res){ tmp = std::move(res); });
+                auto const & [first_seq, second_seq] = align_instance;
+                exec_handler.execute(kernel, first_seq, second_seq,
+                                     [&tmp](auto && res){ tmp = std::move(res); });
                 return tmp;
             });
         // Advance the resource.
@@ -184,7 +184,7 @@ private:
     //!\brief The underlying resource containing the alignment instances.
     align_instance_rng_t resource;  // view or lvalue ref
     //!\brief Selects the correct alignment to execute.
-    alignment_selector_t selector;
+    alignment_algorithm_t kernel;
 
     //!\brief Points to the current element in the resource.
     resource_iterator resource_iter{};
@@ -203,9 +203,9 @@ private:
  * \relates seqan3::detail::alignment_executor_two_way
  * \{
  */
-template <std::ranges::ViewableRange resource_rng_t, typename selector_t>
-alignment_executor_two_way(resource_rng_t && , selector_t &&) ->
-    alignment_executor_two_way<resource_rng_t, selector_t, execution_handler_sequential>;
+template <std::ranges::ViewableRange resource_rng_t, typename func_t>
+alignment_executor_two_way(resource_rng_t && , func_t &&) ->
+    alignment_executor_two_way<resource_rng_t, std::remove_reference_t<func_t>, execution_handler_sequential>;
 
 //!\}
 } // namespace seqan3::detail

--- a/include/seqan3/alignment/pairwise/execution/alignment_range.hpp
+++ b/include/seqan3/alignment/pairwise/execution/alignment_range.hpp
@@ -22,17 +22,18 @@ namespace seqan3
 
 /*!\brief The alignment
  * \ingroup execution
- * \tparam range_buffer_t The buffer type for the alignment stream.
+ * \tparam alignment_executor_type The buffer type for the alignment stream.
  *
  * \details
  *
  * Provides a stream-like range interface over the alignments instances that are computed in a
  * seqan3::detail::alignment_executor_two_way executor.
  */
-template <typename range_buffer_t>
+template <typename alignment_executor_type>
+//TODO requires alignment_executor_concept<alignment_executor_type>
 class alignment_range
 {
-    static_assert(!std::is_const_v<range_buffer_t>,
+    static_assert(!std::is_const_v<alignment_executor_type>,
                   "Cannot create an alignment stream over a const buffer.");
 
     //!\brief The iterator of seqan3::detail::alignment_range.
@@ -45,8 +46,6 @@ class alignment_range
         using value_type = typename alignment_range::value_type;
         //!\brief Use reference type defined by container.
         using reference = typename alignment_range::reference;
-        //!\brief Use const reference type provided by container.
-        using const_reference = std::add_const_t<reference>;
         //!\brief Pointer type is pointer of container element type.
         using pointer = std::add_pointer_t<value_type>;
         //!\brief Sets iterator category as input iterator.
@@ -55,46 +54,44 @@ class alignment_range
         /*!\name Constructors, destructor and assignment
          * \{
          */
-        iterator_type()                                  = default;
-        iterator_type(iterator_type const &)             = default;
-        iterator_type(iterator_type &&)                  = default;
-        iterator_type & operator=(iterator_type const &) = default;
-        iterator_type & operator=(iterator_type &&)      = default;
-        ~iterator_type()                                 = default;
+        constexpr iterator_type() noexcept = default;
+        constexpr iterator_type(iterator_type const &) noexcept = default;
+        constexpr iterator_type(iterator_type &&) noexcept = default;
+        constexpr iterator_type & operator=(iterator_type const &) noexcept = default;
+        constexpr iterator_type & operator=(iterator_type &&) noexcept = default;
+        ~iterator_type() = default;
 
         //!\brief Construct from alignment stream.
-        iterator_type(alignment_range & _stream) : stream_ptr(&_stream)
+        constexpr iterator_type(alignment_range & range) noexcept : range_ptr(&range)
         {}
         //!}
 
         /*!\name Read
          * \{
          */
-        reference operator*()
+        reference operator*() noexcept
         {
-            return stream_ptr->cached();
+            return range_ptr->cache;
         }
 
-        const_reference operator*() const
+        value_type const & operator*() const noexcept
         {
-            return stream_ptr->cached();
+            return range_ptr->cache;
         }
         //!\}
 
         /*!\name Increment operators
          * \{
          */
-        iterator_type & operator++(/*pre*/)
+        iterator_type & operator++(/*pre*/) noexcept
         {
-            stream_ptr->next();
+            range_ptr->next();
             return *this;
         }
 
-        iterator_type operator++(int /*post*/)
+        void operator++(int /*post*/) noexcept
         {
-            auto tmp{*this};
-            stream_ptr->next();
-            return tmp;
+            ++(*this);
         }
         //!\}
 
@@ -102,88 +99,100 @@ class alignment_range
          * \{
          */
 
-        constexpr bool operator==(std::ranges::default_sentinel const &) const
+        constexpr bool operator==(std::ranges::default_sentinel const &) const noexcept
         {
-            return stream_ptr->eof();
+            return range_ptr->eof();
         }
 
         friend constexpr bool operator==(std::ranges::default_sentinel const & lhs,
-                                         iterator_type const & rhs)
+                                         iterator_type const & rhs) noexcept
         {
             return rhs == lhs;
         }
 
-        constexpr bool operator!=(std::ranges::default_sentinel const & rhs) const
+        constexpr bool operator!=(std::ranges::default_sentinel const & rhs) const noexcept
         {
             return !(*this == rhs);
         }
 
         friend constexpr bool operator!=(std::ranges::default_sentinel const & lhs,
-                                         iterator_type const & rhs)
+                                         iterator_type const & rhs) noexcept
         {
             return rhs != lhs;
         }
         //!\}
     private:
         //!\brief Pointer to the underlying range.
-        alignment_range * stream_ptr{};
+        alignment_range * range_ptr{};
     };
 
     // Befriend the iterator with this class.
+    // TODO Check if this is necessary.
     friend class iterator_type;
 
 public:
 
     //!\brief The offset type.
-    using difference_type = typename range_buffer_t::difference_type;
+    using difference_type = typename alignment_executor_type::difference_type;
     //!\brief The alignment result type.
-    using value_type      = typename range_buffer_t::value_type;
+    using value_type      = typename alignment_executor_type::value_type;
     //!\brief The reference type.
-    using reference       = typename range_buffer_t::reference;
+    using reference       = typename alignment_executor_type::reference;
     //!\brief The iterator type.
     using iterator        = iterator_type;
+    //!\brief This range is never const-iterable. The const_iterator is always void.
+    using const_iterator  = void;
     //!\brief The sentinel type.
     using sentinel        = std::ranges::default_sentinel;
 
     /*!\name Constructors, destructor and assignment
      * \{
      */
-    alignment_range()                                    = delete;
-    alignment_range(alignment_range const &)             = default;
-    alignment_range(alignment_range &&)                  = default;
-    alignment_range & operator=(alignment_range const &) = default;
-    alignment_range & operator=(alignment_range &&)      = default;
-    ~alignment_range()                                   = default;
+    alignment_range() = default;
+    alignment_range(alignment_range const &) = delete;
+    alignment_range(alignment_range &&) = default;
+    alignment_range & operator=(alignment_range const &) = delete;
+    alignment_range & operator=(alignment_range &&) = default;
+    ~alignment_range() = default;
 
-    explicit alignment_range(range_buffer_t & _range_buffer) :
-        range_buffer{&_range_buffer, [](auto) { /*no-op*/ }}
-    {}
+    //!\brief Explicit deletion to forbid copy construction of the underlying executor.
+    explicit alignment_range(alignment_executor_type const & _alignment_executor) = delete;
 
-    // Construct from resource.
-    template <typename resource_t,
-              typename kernel_t>
-    //!\cond
-        requires std::is_constructible_v<range_buffer_t, resource_t, kernel_t>
-    //!\endcond
-    alignment_range(resource_t _range_buffer_resource,
-                    kernel_t _kernel) :
-        range_buffer{std::make_shared<range_buffer_t>(std::forward<resource_t>(_range_buffer_resource), _kernel)}
+    /*!\brief Constructs a new alignment range by taking ownership over the passed alignment buffer.
+     * \tparam _alignment_executor_type The buffer type. Must be the same type as `alignment_executor_type` when
+     *                                  references and cv-qualifiers are removed.
+     * \param[in] _alignment_executor   The buffer to take ownership from.
+     *
+     * \details
+     *
+     * Constructs a new alignment range by taking ownership over the passed alignment buffer.
+     */
+    explicit alignment_range(alignment_executor_type && _alignment_executor) :
+        alignment_executor{new alignment_executor_type{std::move(_alignment_executor)}},
+        eof_flag(false)
     {}
     //!}
 
     /*!\name Iterators
      * \{
      */
-    iterator begin()
+    constexpr iterator begin()
     {
-        next();
+        if (!eof_flag)
+            next();
         return iterator{*this};
     }
 
-    sentinel end() noexcept
+    const_iterator begin() const = delete;
+    const_iterator cbegin() const = delete;
+
+    constexpr sentinel end() noexcept
     {
         return {};
     }
+
+    constexpr sentinel end() const = delete;
+    constexpr sentinel cend() const = delete;
     //!\}
 
 protected:
@@ -192,25 +201,14 @@ protected:
     void next()
     {
         assert(!eof());
-        if (auto opt = range_buffer->bump(); opt.has_value())
-            cache = &(*opt).get();
+
+        if (!alignment_executor)
+            throw std::runtime_error{"No alignment execution buffer available."};
+
+        if (auto opt = alignment_executor->bump(); opt.has_value())
+            cache = std::move(*opt);
         else
             eof_flag = true;
-    }
-
-    //!\brief Returns the cached result.
-    // TODO make iterable in case of multiple results per alignment.
-    auto & cached() noexcept
-    {
-        assert(cache);
-        return *cache;
-    }
-
-    //!\copydoc cached()
-    auto const & cached() const noexcept
-    {
-        assert(cache);
-        return *cache;
     }
 
     //!\brief Returns whether the executor buffer reached is end.
@@ -221,11 +219,21 @@ protected:
 
 private:
     //!\brief The underlying executor buffer.
-    std::shared_ptr<range_buffer_t> range_buffer;
+    std::unique_ptr<alignment_executor_type> alignment_executor{};
     //!\brief Stores last read element.
-    value_type * cache{};
+    value_type cache{};
     //!\brief Indicates whether the stream has reached its end.
-    bool eof_flag{false};
+    bool eof_flag{true};
 };
+
+/*!\name Type deduction guide
+ * \relates seqan3::alignment_range
+ * \{
+ */
+
+//!\brief Deduces from the passed alignment_executor_type
+template <typename alignment_executor_type>
+alignment_range(alignment_executor_type &&) -> alignment_range<std::remove_reference_t<alignment_executor_type>>;
+//!}
 
 } // namespace seqan3

--- a/include/seqan3/alignment/pairwise/execution/alignment_range.hpp
+++ b/include/seqan3/alignment/pairwise/execution/alignment_range.hpp
@@ -161,13 +161,13 @@ public:
 
     // Construct from resource.
     template <typename resource_t,
-              typename selector_t>
+              typename kernel_t>
     //!\cond
-        requires std::is_constructible_v<range_buffer_t, resource_t, selector_t>
+        requires std::is_constructible_v<range_buffer_t, resource_t, kernel_t>
     //!\endcond
-    explicit alignment_range(resource_t _range_buffer_resource,
-                             selector_t _selector) :
-        range_buffer{std::make_shared<range_buffer_t>(std::forward<resource_t>(_range_buffer_resource), _selector)}
+    alignment_range(resource_t _range_buffer_resource,
+                    kernel_t _kernel) :
+        range_buffer{std::make_shared<range_buffer_t>(std::forward<resource_t>(_range_buffer_resource), _kernel)}
     {}
     //!}
 

--- a/include/seqan3/alignment/pairwise/execution/execution_handler_sequential.hpp
+++ b/include/seqan3/alignment/pairwise/execution/execution_handler_sequential.hpp
@@ -25,27 +25,18 @@ namespace seqan3::detail
 class execution_handler_sequential
 {
 public:
-    /*!\name Constructors, destructor and assignment
-     * \{
-     */
-    execution_handler_sequential()                                                 = default;
-    execution_handler_sequential(execution_handler_sequential const &)             = default;
-    execution_handler_sequential(execution_handler_sequential &&)                  = default;
-    execution_handler_sequential & operator=(execution_handler_sequential const &) = default;
-    execution_handler_sequential & operator=(execution_handler_sequential &&)      = default;
-    ~execution_handler_sequential()                                                = default;
-    //!}
 
     /*!\name Execution
      * \{
      */
     //!\brief Invokes the passed alignment instance in a blocking manner.
-    template <typename func_result_t>
-    void execute(std::function<func_result_t(func_result_t &)> func,
-                 func_result_t & res,
-                 std::function<void(decltype(func(res)))> delegate)
+    template <typename func_result_t, typename first_batch_t, typename second_batch_t>
+    void execute(std::function<func_result_t(first_batch_t const &, second_batch_t const &)> func,
+                  first_batch_t const & first_batch,
+                  second_batch_t const & second_batch,
+                  std::function<void(decltype(func(first_batch, second_batch)))> delegate)
     {
-        delegate(func(res));
+        delegate(func(first_batch, second_batch));
     }
     //!\}
 };

--- a/include/seqan3/alignment/pairwise/execution/execution_handler_sequential.hpp
+++ b/include/seqan3/alignment/pairwise/execution/execution_handler_sequential.hpp
@@ -22,7 +22,7 @@ namespace seqan3::detail
 /*!\brief Handles the sequential execution of alignments.
  * \ingroup execution
  */
-class execution_handler_sequential
+struct execution_handler_sequential
 {
 public:
 
@@ -32,9 +32,9 @@ public:
     //!\brief Invokes the passed alignment instance in a blocking manner.
     template <typename func_result_t, typename first_batch_t, typename second_batch_t>
     void execute(std::function<func_result_t(first_batch_t const &, second_batch_t const &)> func,
-                  first_batch_t const & first_batch,
-                  second_batch_t const & second_batch,
-                  std::function<void(decltype(func(first_batch, second_batch)))> delegate)
+                 first_batch_t const & first_batch,
+                 second_batch_t const & second_batch,
+                 std::function<void(decltype(func(first_batch, second_batch)))> delegate)
     {
         delegate(func(first_batch, second_batch));
     }

--- a/include/seqan3/alignment/pairwise/policy/affine_gap_init_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/affine_gap_init_policy.hpp
@@ -1,0 +1,103 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2018, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2018, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides seqan3::detail::affine_gap_init_policy.
+ * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <tuple>
+
+#include <seqan3/alignment/configuration/align_config_aligned_ends.hpp>
+#include <seqan3/core/algorithm/configuration.hpp>
+
+namespace seqan3::detail
+{
+
+/*!\brief Implements the Initialisation of the dynamic programming matrix with affine gaps.
+ * \ingroup alignment_policy
+ * \tparam derived_t   The derived alignment algorithm.
+ */
+template <typename derived_t>
+class affine_gap_init_policy
+{
+protected:
+    /*!\name Constructor, destructor and assignment
+     * \brief Defaulted all standard constructor.
+     * \{
+     */
+    constexpr affine_gap_init_policy() noexcept = default;
+    constexpr affine_gap_init_policy(affine_gap_init_policy const &) noexcept = default;
+    constexpr affine_gap_init_policy(affine_gap_init_policy &&) noexcept = default;
+    constexpr affine_gap_init_policy & operator=(affine_gap_init_policy const &) noexcept = default;
+    constexpr affine_gap_init_policy & operator=(affine_gap_init_policy &&) noexcept = default;
+    ~affine_gap_init_policy() noexcept = default;
+    //!}
+
+    /*!\brief Initialises the origin of the dynamic programming matrix.
+     * \tparam        cell_t       The underlying cell type.
+     * \tparam        cache_t      The type of the cache.
+     * \param[in,out] current_cell The current cell in the dynamic programming matrix.
+     * \param[in,out] cache        The cache storing hot helper variables.
+     */
+    template <typename cell_t, typename cache_t>
+    constexpr auto init_origin_cell(cell_t & current_cell, cache_t & cache) const noexcept
+    {
+        using std::get;
+
+        auto & [main_score, hz_score] = current_cell;
+        auto & [prev_cell, gap_open, gap_extend] = cache;
+        auto & vt_score = get<1>(prev_cell);
+
+        main_score = 0;
+        hz_score = gap_open + gap_extend;
+        vt_score = gap_open + gap_extend;
+    }
+
+    /*!\brief Initialises a cell in the first column of the dynamic programming matrix.
+     * \tparam        cell_t       The underlying cell type.
+     * \tparam        cache_t      The type of the cache.
+     * \param[in,out] current_cell The current cell in the dynamic programming matrix.
+     * \param[in,out] cache        The cache storing hot helper variables.
+     */
+    template <typename cell_t, typename cache_t>
+    constexpr auto init_column_cell(cell_t & current_cell, cache_t & cache) const noexcept
+    {
+        using std::get;
+
+        auto & [main_score, hz_score] = current_cell;
+        auto & [prev_cell, gap_open, gap_extend] = cache;
+        auto & vt_score = get<1>(prev_cell);
+
+        main_score = vt_score;
+        hz_score = main_score + gap_open + gap_extend;
+        vt_score += gap_extend;
+    }
+
+    /*!\brief Initialises a cell in the first row of the dynamic programming matrix.
+     * \tparam        cell_t       The underlying cell type.
+     * \tparam        cache_t      The type of the cache.
+     * \param[in,out] current_cell The current cell in the dynamic programming matrix.
+     * \param[in,out] cache        The cache storing hot helper variables.
+     */
+    template <typename cell_t, typename cache_t>
+    constexpr auto init_row_cell(cell_t & current_cell, cache_t & cache) const noexcept
+    {
+        auto & [main_score, hz_score] = current_cell;
+        auto & [prev_cell, gap_open, gap_extend] = cache;
+        auto & [prev_score, vt_score] = prev_cell;
+
+        prev_score = main_score;
+        main_score = hz_score;
+        hz_score += gap_extend;
+        vt_score += main_score + gap_open + gap_extend;
+    }
+};
+
+} // namespace seqan3::detail

--- a/include/seqan3/alignment/pairwise/policy/affine_gap_init_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/affine_gap_init_policy.hpp
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------------------------------------
-// Copyright (c) 2006-2018, Knut Reinert & Freie Universität Berlin
-// Copyright (c) 2016-2018, Knut Reinert & MPI für molekulare Genetik
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
 // This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
 // shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
 // -----------------------------------------------------------------------------------------------------

--- a/include/seqan3/alignment/pairwise/policy/affine_gap_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/affine_gap_policy.hpp
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------------------------------------
-// Copyright (c) 2006-2018, Knut Reinert & Freie Universität Berlin
-// Copyright (c) 2016-2018, Knut Reinert & MPI für molekulare Genetik
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
 // This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
 // shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
 // -----------------------------------------------------------------------------------------------------

--- a/include/seqan3/alignment/pairwise/policy/affine_gap_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/affine_gap_policy.hpp
@@ -1,0 +1,103 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2018, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2018, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides seqan3::detail::affine_gap_policy.
+ * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <tuple>
+#include <type_traits>
+
+#include <seqan3/core/metafunction/basic.hpp>
+#include <seqan3/core/metafunction/range.hpp>
+#include <seqan3/std/concepts>
+
+namespace seqan3::detail
+{
+
+// ----------------------------------------------------------------------------
+// affine_gap_policy
+// ----------------------------------------------------------------------------
+
+/*!\brief The hot kernel implementation using affine gaps.
+ * \ingroup alignment_policy
+ * \tparam derived_t   The derived alignment algorithm.
+ * \tparam cell_t      The cell type of the dynamic programming matrix.
+ */
+template <typename derived_t, typename cell_t>
+class affine_gap_policy
+{
+protected:
+    /*!\name Member types
+     * \{
+     */
+    //!\brief The underlying score type.
+    using score_t = std::tuple_element_t<0, cell_t>;
+    //!\}
+
+    /*!\name Constructor, destructor and assignment
+     * \brief Defaulted all standard constructor.
+     * \{
+     */
+    constexpr affine_gap_policy()                                      noexcept = default;
+    constexpr affine_gap_policy(affine_gap_policy const &)             noexcept = default;
+    constexpr affine_gap_policy(affine_gap_policy &&)                  noexcept = default;
+    constexpr affine_gap_policy & operator=(affine_gap_policy const &) noexcept = default;
+    constexpr affine_gap_policy & operator=(affine_gap_policy &&)      noexcept = default;
+    ~affine_gap_policy()                                               noexcept = default;
+    //!}
+
+    /*!\brief Computes the score for current cell.
+     * \tparam        score_cell_type The type of the current cell.
+     * \tparam        cache_t         The type of the cache.
+     * \param[in,out] current_cell    The current cell in the dynamic programming matrix.
+     * \param[in,out] cache           The cache storing hot helper variables.
+     * \param[in]     score           The score of comparing the respective letters of the first and the second sequence.
+     */
+    template <typename score_cell_type, typename cache_t>
+    constexpr void compute_cell(score_cell_type & current_cell,
+                                cache_t & cache,
+                                score_t const score) const noexcept
+    {
+        // Unpack the cached variables.
+        auto & [main_score, hz_score] = current_cell;
+        auto & [prev_cell, gap_open, gap_extend] = cache;
+        auto & [prev_score, vt_score] = prev_cell;
+
+        //TODO For the local alignment we might be able to use GCC overlow builtin arithmetics, which
+        // allows us to check if overflow/underflow would happen. Not sure, if this helps with the performance though.
+        // (see https://gcc.gnu.org/onlinedocs/gcc/Integer-Overflow-Builtins.html)
+        score_t tmp = prev_score + score;
+        tmp = std::max(tmp, vt_score);
+        tmp = std::max(tmp, hz_score);
+        prev_score = main_score;
+        main_score = tmp;
+        tmp += gap_open;
+        vt_score += gap_extend;
+        hz_score += gap_extend;
+        vt_score = std::max(vt_score, tmp);
+        hz_score = std::max(hz_score, tmp);
+    }
+
+    /*!\brief Creates the cache used for affine gap computation.
+     * \tparam    gap_scheme_t The type of the gap scheme.
+     * \param[in] scheme       The configured gap scheme.
+     * \returns The created cache.
+     */
+    template <typename gap_scheme_t>
+    constexpr auto make_cache(gap_scheme_t && scheme) const noexcept
+    {
+        return std::tuple{cell_t{},
+                          static_cast<score_t>(scheme.get_gap_open_score() + scheme.get_gap_score()),
+                          static_cast<score_t>(scheme.get_gap_score())};
+    }
+};
+
+} // namespace seqan3::detail

--- a/include/seqan3/alignment/pairwise/policy/all.hpp
+++ b/include/seqan3/alignment/pairwise/policy/all.hpp
@@ -1,0 +1,136 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2018, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2018, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+//!\cond DEV
+/*!\file
+ * \brief Meta-header for the \link alignment_policy alignment policy submodule \endlink.
+ * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ */
+//!\endcond
+
+#pragma once
+
+#include <seqan3/alignment/pairwise/policy/affine_gap_init_policy.hpp>
+#include <seqan3/alignment/pairwise/policy/affine_gap_policy.hpp>
+#include <seqan3/alignment/pairwise/policy/unbanded_dp_matrix_policy.hpp>
+
+//!\cond DEV
+/*!\defgroup alignment_policy Alignment policies
+ * \ingroup pairwise_alignment
+ * \brief Provides policies for the alignment algorithm.
+ *
+ * ## Introduction
+ *
+ * The standard pairwise alignment algorithm in SeqAn is implemented in many variations. It supports the standard
+ * algorithms such as the global, local, and semi-global alignment using different kinds of scoring matrices for
+ * nucleotide or amino acid alphabets. It further allows for computing only the score or the begin and end positions
+ * or even the traceback. In addition, the algorithms can be executed in highly parallel environments using SIMD
+ * (Single Instruction Multiple Data) vectorisation and multi-threading. The combination of all of these variations
+ * leads to a huge number of different implementations of the same algorithm. Hence it is desirable to reduce the
+ * code duplication in order to increase maintenance and extension of the alignment algorithms in the future. To
+ * achieve this the alignment algorithm type is specialised with alignment policies.
+ *
+ * ### Policy state
+ *
+ * Policies can have an internal state to manage some additional variables. However, be careful with using
+ * non-stateless policies, as they can affect the internal memory layout which can result in performance regressions.
+ * The state of a policy should therefore be carefully tested with benchmarks.
+ *
+ * ### Customisation point
+ *
+ * An alignment policy serves as a customisation point to the alignment algorithm which has to implement a specific
+ * set of functions that are called by the actual seqan3::detail::alignment_algorithm type. These policies further
+ * separate logical units of the alignment algorithm, i.e. the initialisation, the computation, and the memory
+ * allocation of the alignment matrix.
+ *
+ * ## Matrix policies
+ *
+ * Matrix policies are used to allocate and to provide an iterable interface to the alignment matrix.
+ * These policies maintain the alignment matrix in their own state.
+ * The following table shows the functions that are required by the seqan3::detail::alignment_algorithm.
+ *
+ * Function name     | Arguments | Return value                         |
+ * ----------------- | --------- | ------------------------------------ |
+ * `allocate_matrix` | &Oslash;  | `void`                               |
+ * `current_column`  | &Oslash;  | *implementation defined* - see below |
+ * `next_column`     | &Oslash;  | `void`                               |
+ *
+ * - allocate_matrix:
+ *
+ *    Is called at the beginning of the alignment algorithm and allocates the memory for the alignment matrix and
+ *    possibly resets some internal matrix pointers.
+ *
+ * - current_column:
+ *
+ *     Returns the current column to be computed. The return type can be any type that supports structured bindings,
+ *     where the first parameter is at least a std::ranges::ForwardRange over the score matrix and the second argument
+ *     is at least a std::ranges::ForwardRange over the traceback matrix or std::ignore if the traceback shall not
+ *     be computed.
+ *
+ * - next_column:
+ *
+ *     Is called at the end of a column computation and moves internal matrix pointers to the next column.
+ *
+ * ### Existing matrix policies:
+ *
+ *  - seqan3::detail::unbanded_dp_matrix_policy
+ *
+ * ## Gap policies
+ *
+ * Gap policies are used to initialise and to compute the cells within the alignment matrix.
+ * The gap policies are further divided into a policy initialising the matrix and computing the cells.
+ * The following table shows the functions that need to be implemented by a gap policy.
+ *
+ * Function name     | Arguments                              | Return value                         |
+ * ----------------- | -------------------------------------- | ------------------------------------ |
+ * `compute_cell`    | `cell &&`, `cache &`, `score const &`  | `void`                               |
+ * `make_cache`      | `gap_scheme const &`                   | alignment_algorithm_cache            |
+ *
+ * - compute_cell:
+ *
+ *    This function implements the kernel that computes the score and, if enabled, the traceback direction.
+ *    It gets as an input the dereferenced value of the scoring matrix (see above), the current alignment algorithm
+ *    cache and the score of comparing two letter of the used alphabet using the passed scoring scheme.
+ *
+ * - make_cache:
+ *
+ *     Initialises and returns the cache used in the alignment algorithm. It must return a type that allows structured
+ *     bindings, with the first argument being of the same type as the allocator value type used in the matrix policy,
+ *     the second argument being the costs for gap opening + gap and the third argument being the costs for a gap.
+ *
+ * ### Existing gap policies:
+ *
+ *  - seqan3::detail::affine_gap_policy
+ *
+ * The following table displays requirements for the corresponding gap intialisation policy:
+ *
+ * Function name      | Arguments                        | Return value                         |
+ * ------------------ | -------------------------------- | ------------------------------------ |
+ * `init_origin_cell` | `cell &&`, `cache &`             | `void`                               |
+ * `init_column_cell` | `cell &&`, `cache &`             | `void`                               |
+ * `init_row_cell`    | `cell &&`, `cache &`             | `void`                               |
+ *
+ * - init_origin_cell:
+ *
+ *     Implements the initialisation of the matrix origin \f$ (M(0,0)) \f$. This function gets the current cell
+ *     dereferenced from the score matrix and the alignment algorithm cache.
+ *
+ * - init_column_cell:
+ *
+ *     Implements the initialisation of the cells in the first row of the matrix \f$ (M(i,0)) \f$.
+ *     This function gets the current cell dereferenced from the score matrix and the alignment algorithm cache.
+ *
+ * - init_row_cell:
+ *
+ *     Implements the initialisation of the cells in the first column of the matrix \f$ (M(0,j)) \f$.
+ *     This function gets the current cell dereferenced from the score matrix and the alignment algorithm cache.
+ *
+ * ### Existing gap init policies:
+ *
+ *  - seqan3::detail::affine_gap_init_policy
+ */
+//!\endcond

--- a/include/seqan3/alignment/pairwise/policy/all.hpp
+++ b/include/seqan3/alignment/pairwise/policy/all.hpp
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------------------------------------
-// Copyright (c) 2006-2018, Knut Reinert & Freie Universität Berlin
-// Copyright (c) 2016-2018, Knut Reinert & MPI für molekulare Genetik
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
 // This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
 // shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
 // -----------------------------------------------------------------------------------------------------

--- a/include/seqan3/alignment/pairwise/policy/unbanded_dp_matrix_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/unbanded_dp_matrix_policy.hpp
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------------------------------------
-// Copyright (c) 2006-2018, Knut Reinert & Freie Universität Berlin
-// Copyright (c) 2016-2018, Knut Reinert & MPI für molekulare Genetik
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
 // This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
 // shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
 // -----------------------------------------------------------------------------------------------------

--- a/include/seqan3/alignment/pairwise/policy/unbanded_dp_matrix_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/unbanded_dp_matrix_policy.hpp
@@ -1,0 +1,84 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2018, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2018, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides seqan3::detail::unbanded_dp_matrix_policy.
+ * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <vector>
+#include <utility>
+
+#include <seqan3/core/metafunction/range.hpp>
+#include <seqan3/std/view/subrange.hpp>
+#include <seqan3/std/ranges>
+
+namespace seqan3::detail
+{
+
+/*!\brief Manages the allocation and provision of an unbanded dynamic programming matrix.
+ * \ingroup alignment_policy
+ * \tparam derived_t   The derived alignment algorithm.
+ * \tparam allocator_t The allocator type used for allocating the dynamic programming matrix.
+ */
+template <typename derived_t, typename allocator_t>
+class unbanded_dp_matrix_policy
+{
+protected:
+
+    /*!\name Member types
+     * \{
+     */
+    //!\brief The underlying cell type of the dynamic programming matrix.
+    using cell_type = typename allocator_t::value_type;
+    //!\}
+
+    /*!\name Constructor, destructor and assignment
+     * \brief Defaulted all standard constructor.
+     * \{
+     */
+    constexpr unbanded_dp_matrix_policy()                                              = default;
+    constexpr unbanded_dp_matrix_policy(unbanded_dp_matrix_policy const &)             = default;
+    constexpr unbanded_dp_matrix_policy(unbanded_dp_matrix_policy &&)                  = default;
+    constexpr unbanded_dp_matrix_policy & operator=(unbanded_dp_matrix_policy const &) = default;
+    constexpr unbanded_dp_matrix_policy & operator=(unbanded_dp_matrix_policy &&)      = default;
+    ~unbanded_dp_matrix_policy()                                                       = default;
+    //!}
+
+    /*!\brief Allocates the memory for the dynamic programming matrix given the two sequences.
+     * \tparam first_batch_t   The type of the first sequence (or packed sequences).
+     * \tparam second_batch_t  The type of the second sequence (or packed sequences).
+     * \param[in] first_batch  The first sequence (or packed sequences).
+     * \param[in] second_batch The first sequence (or packed sequences).
+     */
+    template <typename first_batch_t, typename second_batch_t>
+    void allocate_score_matrix(first_batch_t && first_batch, second_batch_t && second_batch)
+    {
+        dimension_first_batch = std::ranges::size(first_batch);
+        dimension_second_batch = std::ranges::size(second_batch);
+
+        // We use only one column to compute the score.
+        score_matrix.resize(dimension_second_batch + 1);
+    }
+
+    //!\brief Returns the current column of the alignment matrix.
+    auto current_column()
+    {
+        using iter_t = std::ranges::iterator_t<decltype(score_matrix)>;
+        return view::subrange<iter_t, iter_t>{std::ranges::begin(score_matrix), std::ranges::end(score_matrix)};
+    }
+
+    //!\brief The data container.
+    std::vector<cell_type, allocator_t> score_matrix{};
+    //!\brief Caches the size of the horizontal dimension (number of columns).
+    size_t dimension_first_batch  = 0;
+    //!\brief Caches the size of the vertical dimension (number of rows).
+    size_t dimension_second_batch = 0;
+};
+} // namespace seqan3::detail

--- a/include/seqan3/range/view/single_pass_input.hpp
+++ b/include/seqan3/range/view/single_pass_input.hpp
@@ -55,7 +55,7 @@ private:
         //!\brief The underlying range.
         urng_t             urng;
         //!\brief The cached iterator of the underlying range.
-        urng_iterator_type cached_urng_iter{};
+        urng_iterator_type cached_urng_iter{seqan3::begin(urng)};
     };
 
     //!\brief Shared pointer of the data model.
@@ -92,7 +92,7 @@ public:
 
     //!\brief Construction from the underlying view.
     single_pass_input_view(urng_t && urng) :
-        view_state_ptr{new view_state{std::forward<urng_t>(urng), seqan3::begin(urng)}}
+        view_state_ptr{new view_state{std::forward<urng_t>(urng)}}
     {}
     //!\}
 
@@ -120,7 +120,9 @@ public:
     //!\brief Returns a sentinel.
     sentinel end()
     {
-        return {seqan3::end(view_state_ptr->urng)};
+        if (view_state_ptr != nullptr)
+            return {seqan3::end(view_state_ptr->urng)};
+        return sentinel{};
     }
 
     //!\brief Const version of end is deleted, since the underlying view_state must be mutable.
@@ -243,7 +245,9 @@ public:
     //!\brief Compares iterator with sentinel.
     constexpr bool operator==(sentinel_type const & s) const noexcept
     {
-        return cached() == s;
+        if (view_ptr->view_state_ptr != nullptr)
+            return cached() == s;
+        return true;
     }
 
     //!\copydoc operator==

--- a/test/unit/alignment/pairwise/CMakeLists.txt
+++ b/test/unit/alignment/pairwise/CMakeLists.txt
@@ -1,6 +1,7 @@
 seqan3_test(align_pairwise_test.cpp)
 seqan3_test(align_result_test.cpp)
-seqan3_test(alignment_selector_test.cpp)
+seqan3_test(align_result_selector_test.cpp)
 seqan3_test(edit_distance_unbanded_test.cpp)
+seqan3_test(global_affine_unbanded_test.cpp)
 
 add_subdirectories()

--- a/test/unit/alignment/pairwise/align_pairwise_test.cpp
+++ b/test/unit/alignment/pairwise/align_pairwise_test.cpp
@@ -33,23 +33,25 @@ TEST(align_pairwise, single_rng_lvalue)
 
     {  // the score
         configuration cfg = align_cfg::edit | align_cfg::result{align_cfg::with_score};
-        for (auto && res : align_pairwise(p, cfg))
-        {
-            EXPECT_EQ(res.get_score(), -4);
-        }
+        EXPECT_THROW(align_pairwise(p, cfg), std::domain_error);
+        // for (auto && res : align_pairwise(p, cfg))
+        // {
+        //     EXPECT_EQ(res.score(), -4);
+        // }
     }
 
     {  // the trace
         configuration cfg = align_cfg::edit | align_cfg::result{align_cfg::with_trace};
-        for (auto && res : align_pairwise(p, cfg))
-        {
-            EXPECT_EQ(res.get_score(), -4);
-            auto [cmp1, cmp2] = res.get_end_coordinate();
-            EXPECT_EQ((std::tie(cmp1, cmp2)), (std::tuple{7, 8}));
-            auto && [gap1, gap2] = res.get_alignment();
-            EXPECT_EQ(std::string{gap1 | view::to_char}, "ACGTGATG--");
-            EXPECT_EQ(std::string{gap2 | view::to_char}, "A-GTGATACT");
-        }
+        EXPECT_THROW(align_pairwise(p, cfg), std::domain_error);
+        // for (auto && res : align_pairwise(p, cfg))
+        // {
+        //     EXPECT_EQ(res.score(), -4);
+        //     auto [cmp1, cmp2] = res.end_coordinate();
+        //     EXPECT_EQ((std::tie(cmp1, cmp2)), (std::tuple{7, 8}));
+        //     auto && [gap1, gap2] = res.trace();
+        //     EXPECT_EQ(std::string{gap1 | view::to_char}, "ACGTGATG--");
+        //     EXPECT_EQ(std::string{gap2 | view::to_char}, "A-GTGATACT");
+        // }
     }
 }
 
@@ -64,20 +66,23 @@ TEST(align_pairwise, single_view_lvalue)
 
     {  // the score
         configuration cfg = align_cfg::edit | align_cfg::result{align_cfg::with_score};
-        for (auto && res : align_pairwise(v, cfg))
-        {
-            EXPECT_EQ(res.get_score(), -4);
-        }
+        EXPECT_THROW(align_pairwise(v, cfg), std::domain_error);
+        // for (auto && res : align_pairwise(v, cfg))
+        // {
+        //      EXPECT_EQ(res.score(), -4);
+        // }
     }
     {  // the trace
         configuration cfg = align_cfg::edit | align_cfg::result{align_cfg::with_trace};
-        for (auto && res : align_pairwise(v, cfg))
-        {
-            EXPECT_EQ(res.get_score(), -4);
-            auto && [gap1, gap2] = res.get_alignment();
-            EXPECT_EQ(std::string{gap1 | view::to_char}, "ACGTGATG--");
-            EXPECT_EQ(std::string{gap2 | view::to_char}, "A-GTGATACT");
-        }
+
+        EXPECT_THROW(align_pairwise(v, cfg), std::domain_error);
+        // for (auto && res : align_pairwise(v, cfg))
+        // {
+        //     EXPECT_EQ(res.score(), -4);
+        //     auto && [gap1, gap2] = res.trace();
+        //     EXPECT_EQ(std::string{gap1 | view::to_char}, "ACGTGATG--");
+        //     EXPECT_EQ(std::string{gap2 | view::to_char}, "A-GTGATACT");
+        // }
     }
 }
 
@@ -91,11 +96,12 @@ TEST(align_pairwise, multiple_rng_lvalue)
     std::vector<decltype(p)> vec{10, p};
 
     configuration cfg = align_cfg::edit | align_cfg::result{align_cfg::with_trace};
-    for (auto && res : align_pairwise(vec, cfg))
-    {
-        EXPECT_EQ(res.get_score(), -4);
-        auto && [gap1, gap2] = res.get_alignment();
-        EXPECT_EQ(std::string{gap1 | view::to_char}, "ACGTGATG--");
-        EXPECT_EQ(std::string{gap2 | view::to_char}, "A-GTGATACT");
-    }
+    EXPECT_THROW(align_pairwise(vec, cfg), std::domain_error);
+    // for (auto && res : align_pairwise(vec, cfg))
+    // {
+    //     EXPECT_EQ(res.score(), -4);
+    //     auto && [gap1, gap2] = res.trace();
+    //     EXPECT_EQ(std::string{gap1 | view::to_char}, "ACGTGATG--");
+    //     EXPECT_EQ(std::string{gap2 | view::to_char}, "A-GTGATACT");
+    // }
 }

--- a/test/unit/alignment/pairwise/align_pairwise_test.cpp
+++ b/test/unit/alignment/pairwise/align_pairwise_test.cpp
@@ -33,25 +33,23 @@ TEST(align_pairwise, single_rng_lvalue)
 
     {  // the score
         configuration cfg = align_cfg::edit | align_cfg::result{align_cfg::with_score};
-        EXPECT_THROW(align_pairwise(p, cfg), std::domain_error);
-        // for (auto && res : align_pairwise(p, cfg))
-        // {
-        //     EXPECT_EQ(res.score(), -4);
-        // }
+        for (auto && res : align_pairwise(p, cfg))
+        {
+            EXPECT_EQ(res.get_score(), -4);
+        }
     }
 
     {  // the trace
         configuration cfg = align_cfg::edit | align_cfg::result{align_cfg::with_trace};
-        EXPECT_THROW(align_pairwise(p, cfg), std::domain_error);
-        // for (auto && res : align_pairwise(p, cfg))
-        // {
-        //     EXPECT_EQ(res.score(), -4);
-        //     auto [cmp1, cmp2] = res.end_coordinate();
-        //     EXPECT_EQ((std::tie(cmp1, cmp2)), (std::tuple{7, 8}));
-        //     auto && [gap1, gap2] = res.trace();
-        //     EXPECT_EQ(std::string{gap1 | view::to_char}, "ACGTGATG--");
-        //     EXPECT_EQ(std::string{gap2 | view::to_char}, "A-GTGATACT");
-        // }
+        for (auto && res : align_pairwise(p, cfg))
+        {
+            EXPECT_EQ(res.get_score(), -4);
+            auto [cmp1, cmp2] = res.get_end_coordinate();
+            EXPECT_EQ((std::tie(cmp1, cmp2)), (std::tuple{7, 8}));
+            auto && [gap1, gap2] = res.get_alignment();
+            EXPECT_EQ(std::string{gap1 | view::to_char}, "ACGTGATG--");
+            EXPECT_EQ(std::string{gap2 | view::to_char}, "A-GTGATACT");
+        }
     }
 }
 
@@ -66,23 +64,21 @@ TEST(align_pairwise, single_view_lvalue)
 
     {  // the score
         configuration cfg = align_cfg::edit | align_cfg::result{align_cfg::with_score};
-        EXPECT_THROW(align_pairwise(v, cfg), std::domain_error);
-        // for (auto && res : align_pairwise(v, cfg))
-        // {
-        //      EXPECT_EQ(res.score(), -4);
-        // }
+        for (auto && res : align_pairwise(v, cfg))
+        {
+             EXPECT_EQ(res.get_score(), -4);
+        }
     }
     {  // the trace
         configuration cfg = align_cfg::edit | align_cfg::result{align_cfg::with_trace};
 
-        EXPECT_THROW(align_pairwise(v, cfg), std::domain_error);
-        // for (auto && res : align_pairwise(v, cfg))
-        // {
-        //     EXPECT_EQ(res.score(), -4);
-        //     auto && [gap1, gap2] = res.trace();
-        //     EXPECT_EQ(std::string{gap1 | view::to_char}, "ACGTGATG--");
-        //     EXPECT_EQ(std::string{gap2 | view::to_char}, "A-GTGATACT");
-        // }
+        for (auto && res : align_pairwise(v, cfg))
+        {
+            EXPECT_EQ(res.get_score(), -4);
+            auto && [gap1, gap2] = res.get_alignment();
+            EXPECT_EQ(std::string{gap1 | view::to_char}, "ACGTGATG--");
+            EXPECT_EQ(std::string{gap2 | view::to_char}, "A-GTGATACT");
+        }
     }
 }
 
@@ -96,12 +92,11 @@ TEST(align_pairwise, multiple_rng_lvalue)
     std::vector<decltype(p)> vec{10, p};
 
     configuration cfg = align_cfg::edit | align_cfg::result{align_cfg::with_trace};
-    EXPECT_THROW(align_pairwise(vec, cfg), std::domain_error);
-    // for (auto && res : align_pairwise(vec, cfg))
-    // {
-    //     EXPECT_EQ(res.score(), -4);
-    //     auto && [gap1, gap2] = res.trace();
-    //     EXPECT_EQ(std::string{gap1 | view::to_char}, "ACGTGATG--");
-    //     EXPECT_EQ(std::string{gap2 | view::to_char}, "A-GTGATACT");
-    // }
+    for (auto && res : align_pairwise(vec, cfg))
+    {
+        EXPECT_EQ(res.get_score(), -4);
+        auto && [gap1, gap2] = res.get_alignment();
+        EXPECT_EQ(std::string{gap1 | view::to_char}, "ACGTGATG--");
+        EXPECT_EQ(std::string{gap2 | view::to_char}, "A-GTGATACT");
+    }
 }

--- a/test/unit/alignment/pairwise/align_result_selector_test.cpp
+++ b/test/unit/alignment/pairwise/align_result_selector_test.cpp
@@ -19,7 +19,7 @@
 
 #include <seqan3/alignment/configuration/all.hpp>
 #include <seqan3/alignment/configuration/align_config_result.hpp>
-#include <seqan3/alignment/pairwise/alignment_selector.hpp>
+#include <seqan3/alignment/pairwise/alignment_configurator.hpp>
 #include <seqan3/alphabet/gap/gapped.hpp>
 #include <seqan3/alphabet/nucleotide/all.hpp>
 #include <seqan3/core/concept/tuple.hpp>

--- a/test/unit/alignment/pairwise/align_result_selector_test.cpp
+++ b/test/unit/alignment/pairwise/align_result_selector_test.cpp
@@ -14,7 +14,10 @@
 
 #include <meta/meta.hpp>
 
-#include <seqan3/alignment/configuration/align_config_edit.hpp>
+#include <range/v3/view/bounded.hpp>
+#include <range/v3/view/single.hpp>
+
+#include <seqan3/alignment/configuration/all.hpp>
 #include <seqan3/alignment/configuration/align_config_result.hpp>
 #include <seqan3/alignment/pairwise/alignment_selector.hpp>
 #include <seqan3/alphabet/gap/gapped.hpp>
@@ -25,14 +28,14 @@
 
 using namespace seqan3;
 
-TEST(alignment_selector, determine_result_type)
+TEST(alignment_selector, align_result_selector)
 {
     using seq1_t = std::vector<dna4>;
     using seq2_t = std::list<dna4>;
 
     { // test case I
         auto cfg = align_cfg::edit;
-        using _t = typename detail::determine_result_type<seq1_t, seq2_t, decltype(cfg)>::type;
+        using _t = align_result<typename detail::align_result_selector<seq1_t, seq2_t, decltype(cfg)>::type>;
 
         EXPECT_TRUE((std::is_same_v<decltype(std::declval<_t>().get_id()), uint32_t>));
         EXPECT_TRUE((std::is_same_v<decltype(std::declval<_t>().get_score()), int32_t>));
@@ -40,7 +43,7 @@ TEST(alignment_selector, determine_result_type)
 
     { // test case II
         auto cfg = align_cfg::edit | align_cfg::result{align_cfg::with_score};
-        using _t = typename detail::determine_result_type<seq1_t, seq2_t, decltype(cfg)>::type;
+        using _t = align_result<typename detail::align_result_selector<seq1_t, seq2_t, decltype(cfg)>::type>;
 
         EXPECT_TRUE((std::is_same_v<decltype(std::declval<_t>().get_id()), uint32_t>));
         EXPECT_TRUE((std::is_same_v<decltype(std::declval<_t>().get_score()), int32_t>));
@@ -48,7 +51,7 @@ TEST(alignment_selector, determine_result_type)
 
     { // test case III
         auto cfg = align_cfg::edit | align_cfg::result{align_cfg::with_trace};
-        using _t = typename detail::determine_result_type<seq1_t, seq2_t, decltype(cfg)>::type;
+        using _t = align_result<typename detail::align_result_selector<seq1_t, seq2_t, decltype(cfg)>::type>;
 
         using gapped_seq1_t = std::vector<gapped<dna4>>;
         using gapped_seq2_t = std::vector<gapped<dna4>>;
@@ -60,25 +63,6 @@ TEST(alignment_selector, determine_result_type)
         EXPECT_TRUE((std::is_same_v<decltype(std::declval<_t>().get_begin_coordinate()),
                                     detail::alignment_coordinate const &>));
         EXPECT_TRUE((std::is_same_v<decltype(std::declval<_t>().get_alignment()),
-                                    std::pair<gapped_seq1_t, gapped_seq2_t> const &>));
-    }
-}
-
-TEST(alignment_selector, select)
-{
-    using seq1_t = std::vector<dna4>;
-    using seq2_t = std::vector<dna4>;
-    using seq_t = std::pair<seq1_t, seq2_t>;
-
-    { // test case I
-        auto cfg = align_cfg::edit;
-        using _t = detail::alignment_selector<seq_t, decltype(cfg)>;
-
-        using res_t = typename detail::determine_result_type<seq1_t, seq2_t, decltype(cfg)>::type;
-
-        seq_t s{};
-        EXPECT_TRUE((std::is_same_v<res_t, typename _t::result_type>));
-        EXPECT_TRUE((std::is_same_v<decltype(_t{cfg}.select(s)),
-                                    std::function<res_t(res_t &)>>));
+                                    std::tuple<gapped_seq1_t, gapped_seq2_t> const &>));
     }
 }

--- a/test/unit/alignment/pairwise/execution/CMakeLists.txt
+++ b/test/unit/alignment/pairwise/execution/CMakeLists.txt
@@ -1,1 +1,2 @@
 seqan3_test(alignment_executor_two_way_test.cpp)
+seqan3_test(alignment_range_test.cpp)

--- a/test/unit/alignment/pairwise/execution/alignment_executor_two_way_test.cpp
+++ b/test/unit/alignment/pairwise/execution/alignment_executor_two_way_test.cpp
@@ -19,11 +19,9 @@ using namespace seqan3;
 
 struct foo
 {
-    int i;
-
-    std::string operator()(std::string & /*ignore*/) const
+    std::string operator()(int const & id) const
     {
-        return std::string{"my_test_"} + std::to_string(i);
+        return std::string{"foo_"} + std::to_string(id);
     }
 };
 
@@ -40,16 +38,23 @@ struct foo_selector
 };
 
 //TODO: Currently we only do a generic integration test. We need to add more testing in the end.
-TEST(alignment_excecutor_two_way, stream_integration)
+TEST(alignment_excecutor_two_way, execution)
 {
-    std::vector<foo> resource_rng{foo{0}, foo{1}, foo{2}, foo{3}, foo{4}, foo{0}, foo{1}, foo{2}, foo{3}, foo{4}};
+    std::vector<std::pair<foo, int>> resource_rng{{foo{}, 0}, {foo{}, 1}, {foo{}, 2}, {foo{}, 3}, {foo{}, 4},
+                                                  {foo{}, 0}, {foo{}, 1}, {foo{}, 2}, {foo{}, 3}, {foo{}, 4}};
 
-    detail::alignment_executor_two_way exec{resource_rng, foo_selector{}};
+    std::function<std::string(foo const &, int const &)> f =
+        [](foo const & fn, int const & id)
+        {
+            return fn(id);
+        };
+
+    detail::alignment_executor_two_way exec{resource_rng, f};
 
     int c = 0;
     for (auto res : exec.range())
     {
-        std::string test = "my_test_" + std::to_string(c % 5);
+        std::string test = "foo_" + std::to_string(c % 5);
         EXPECT_EQ(test, res);
         ++c;
     }

--- a/test/unit/alignment/pairwise/execution/alignment_executor_two_way_test.cpp
+++ b/test/unit/alignment/pairwise/execution/alignment_executor_two_way_test.cpp
@@ -9,53 +9,113 @@
 
 #include <string>
 
-#include <range/v3/view/bounded.hpp>
+#include <range/v3/algorithm/for_each.hpp>
 #include <range/v3/view/single.hpp>
-#include <range/v3/view/transform.hpp>
+#include <range/v3/view/zip.hpp>
 
 #include <seqan3/alignment/pairwise/execution/alignment_executor_two_way.hpp>
+#include <seqan3/range/view/persist.hpp>
+
+struct dummy_alignment
+{
+
+    template <typename first_seq_t, typename second_seq_t>
+    constexpr auto operator()(first_seq_t && first_seq, second_seq_t && second_seq) const
+    {
+        size_t count = 0;
+        ranges::for_each(ranges::view::zip(first_seq, second_seq), [&](auto && tpl)
+        {
+            auto && [v1, v2] = tpl;
+            if (v1 == v2)
+                ++count;
+        });
+        return count;
+    }
+};
+
+// Some globally defined test types
+inline static std::tuple single{std::string{"AACGTACGT"}, std::string{"ATCGTCCGT"}};
+inline static std::vector<decltype(single)> collection{5, single};
+inline static std::function<size_t(std::string const &, std::string const &)> fn{dummy_alignment{}};
 
 using namespace seqan3;
 
-struct foo
+TEST(alignment_executor_two_way, construction)
 {
-    std::string operator()(int const & id) const
-    {
-        return std::string{"foo_"} + std::to_string(id);
-    }
-};
+    using type = detail::alignment_executor_two_way<std::add_lvalue_reference_t<decltype(collection)>, decltype(fn)>;
 
-struct foo_selector
+    EXPECT_FALSE(std::is_default_constructible_v<type>);
+    EXPECT_FALSE(std::is_copy_constructible_v<type>);
+    EXPECT_TRUE(std::is_move_constructible_v<type>);
+    EXPECT_FALSE(std::is_copy_assignable_v<type>);
+    EXPECT_TRUE(std::is_move_assignable_v<type>);
+}
+
+TEST(alignment_executor_two_way, is_eof)
 {
-    using result_type = std::string;
+    using type = detail::alignment_executor_two_way<std::add_lvalue_reference_t<decltype(collection)>, decltype(fn)>;
+    type exec{collection, fn};
+    EXPECT_FALSE(exec.is_eof());
+}
 
-    template <typename task_t>
-    auto select(task_t && t)
-    {
-        std::function<result_type(result_type &)> f = t;
-        return f;
-    }
-};
-
-//TODO: Currently we only do a generic integration test. We need to add more testing in the end.
-TEST(alignment_excecutor_two_way, execution)
+TEST(alignment_executor_two_way, type_deduction)
 {
-    std::vector<std::pair<foo, int>> resource_rng{{foo{}, 0}, {foo{}, 1}, {foo{}, 2}, {foo{}, 3}, {foo{}, 4},
-                                                  {foo{}, 0}, {foo{}, 1}, {foo{}, 2}, {foo{}, 3}, {foo{}, 4}};
+    detail::alignment_executor_two_way exec{collection, fn};
+    EXPECT_FALSE(exec.is_eof());
+}
 
-    std::function<std::string(foo const &, int const &)> f =
-        [](foo const & fn, int const & id)
-        {
-            return fn(id);
-        };
+TEST(alignment_executor_two_way, bump)
+{
+    detail::alignment_executor_two_way exec{collection, fn};
+    EXPECT_EQ(exec.bump(), 7u);
+    EXPECT_EQ(exec.bump(), 7u);
+    EXPECT_EQ(exec.bump(), 7u);
+    EXPECT_EQ(exec.bump(), 7u);
+    EXPECT_EQ(exec.bump(), 7u);
+    EXPECT_FALSE(static_cast<bool>(exec.bump()));
+}
 
-    detail::alignment_executor_two_way exec{resource_rng, f};
+TEST(alignment_executor_two_way, in_avail)
+{
+    detail::alignment_executor_two_way exec{collection, fn};
+    EXPECT_EQ(exec.in_avail(), 0u);
+    EXPECT_EQ(exec.bump(), 7u);
+    EXPECT_EQ(exec.in_avail(), 0u);
+}
 
-    int c = 0;
-    for (auto res : exec.range())
-    {
-        std::string test = "foo_" + std::to_string(c % 5);
-        EXPECT_EQ(test, res);
-        ++c;
-    }
+TEST(alignment_executor_two_way, lvalue_single_view)
+{
+    auto v = ranges::view::single(single);
+    detail::alignment_executor_two_way exec{v, fn};
+    EXPECT_EQ(exec.bump(), 7u);
+    EXPECT_FALSE(static_cast<bool>(exec.bump()));
+}
+
+TEST(alignment_executor_two_way, rvalue_single_view)
+{
+    detail::alignment_executor_two_way exec{ranges::view::single(single), fn};
+    EXPECT_EQ(exec.bump(), 7u);
+    EXPECT_FALSE(static_cast<bool>(exec.bump()));
+}
+
+TEST(alignment_executor_two_way, lvalue_collection)
+{
+    detail::alignment_executor_two_way exec{collection, fn};
+    EXPECT_EQ(exec.bump(), 7u);
+    EXPECT_EQ(exec.bump(), 7u);
+    EXPECT_EQ(exec.bump(), 7u);
+    EXPECT_EQ(exec.bump(), 7u);
+    EXPECT_EQ(exec.bump(), 7u);
+    EXPECT_FALSE(static_cast<bool>(exec.bump()));
+}
+
+TEST(alignment_executor_two_way, rvalue_collection_view)
+{
+    detail::alignment_executor_two_way exec{collection | view::persist, fn};
+    EXPECT_EQ(exec.bump(), 7u);
+    EXPECT_EQ(exec.bump(), 7u);
+    EXPECT_EQ(exec.bump(), 7u);
+    EXPECT_EQ(exec.bump(), 7u);
+    EXPECT_EQ(exec.bump(), 7u);
+    EXPECT_FALSE(static_cast<bool>(exec.bump()));
 }

--- a/test/unit/alignment/pairwise/execution/alignment_range_test.cpp
+++ b/test/unit/alignment/pairwise/execution/alignment_range_test.cpp
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------------------------------------
-// Copyright (c) 2006-2018, Knut Reinert & Freie Universität Berlin
-// Copyright (c) 2016-2018, Knut Reinert & MPI für molekulare Genetik
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
 // This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
 // shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
 // -----------------------------------------------------------------------------------------------------

--- a/test/unit/alignment/pairwise/execution/alignment_range_test.cpp
+++ b/test/unit/alignment/pairwise/execution/alignment_range_test.cpp
@@ -1,0 +1,99 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2018, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2018, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <optional>
+
+#include <range/v3/view/iota.hpp>
+
+#include <seqan3/alignment/pairwise/execution/alignment_range.hpp>
+#include <seqan3/range/view/single_pass_input.hpp>
+#include <seqan3/range/shortcuts.hpp>
+
+using namespace seqan3;
+
+struct dummy_executor
+{
+
+    using value_type      = size_t;
+    using reference       = value_type;
+    using difference_type = std::ptrdiff_t;
+
+    std::optional<size_t> bump()
+    {
+        auto it = begin(generator);
+        if (it == end(generator))
+        {
+            return {};
+        }
+        else
+        {
+            std::optional<size_t> opt{*it};
+            ++it;
+            return opt;
+        }
+    }
+
+private:
+
+    detail::single_pass_input_view<decltype(ranges::view::iota(0u, 10u))> generator{ranges::view::iota(0u, 10u)};
+};
+
+TEST(alignment_range, concept_test)
+{
+    EXPECT_TRUE(std::ranges::InputRange<alignment_range<dummy_executor>>);
+    EXPECT_FALSE(std::ranges::ForwardRange<alignment_range<dummy_executor>>);
+}
+
+TEST(alignment_range, construction)
+{
+    EXPECT_TRUE(std::is_default_constructible_v<alignment_range<dummy_executor>>);
+    EXPECT_FALSE(std::is_copy_constructible_v<alignment_range<dummy_executor>>);
+    EXPECT_TRUE(std::is_move_constructible_v<alignment_range<dummy_executor>>);
+    EXPECT_FALSE(std::is_copy_assignable_v<alignment_range<dummy_executor>>);
+    EXPECT_TRUE(std::is_move_assignable_v<alignment_range<dummy_executor>>);
+
+    EXPECT_TRUE((std::is_constructible_v<alignment_range<dummy_executor>, dummy_executor>));
+}
+
+TEST(alignment_range, type_deduction)
+{
+    alignment_range rng{dummy_executor{}};
+    EXPECT_TRUE((std::is_same_v<decltype(rng), alignment_range<dummy_executor>>));
+}
+
+TEST(alignment_range, begin)
+{
+    alignment_range rng{dummy_executor{}};
+    auto it = rng.begin();
+    EXPECT_EQ(*it, 0u);
+}
+
+TEST(alignment_range, end)
+{
+    alignment_range rng{dummy_executor{}};
+    auto it = rng.end();
+    EXPECT_FALSE(it == begin(rng));
+    EXPECT_FALSE(begin(rng) == it);
+}
+
+TEST(alignment_range, iterable)
+{
+    alignment_range rng{dummy_executor{}};
+    size_t sum = 0;
+    for (size_t res : rng)
+        sum += res;
+
+    EXPECT_EQ(sum, 45u);
+}
+
+TEST(alignment_range, default_construction)
+{
+    alignment_range<dummy_executor> rng{};
+    EXPECT_TRUE(begin(rng) == end(rng));
+}

--- a/test/unit/alignment/pairwise/fixture/global_affine_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/global_affine_unbanded.hpp
@@ -1,0 +1,77 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2018, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2018, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+#pragma once
+
+#include <vector>
+
+#include <seqan3/alignment/configuration/align_config_mode.hpp>
+#include <seqan3/alignment/configuration/align_config_gap.hpp>
+#include <seqan3/alignment/configuration/align_config_scoring.hpp>
+#include <seqan3/alignment/scoring/nucleotide_scoring_scheme.hpp>
+#include <seqan3/alignment/scoring/aminoacid_scoring_scheme.hpp>
+#include <seqan3/alphabet/aminoacid/aa27.hpp>
+#include <seqan3/alphabet/nucleotide/dna4.hpp>
+#include <seqan3/alphabet/nucleotide/dna5.hpp>
+
+#include "alignment_fixture.hpp"
+
+namespace seqan3::fixture::global::affine::unbanded
+{
+
+inline constexpr auto align_config = align_cfg::mode{align_cfg::global_alignment} |
+                                     align_cfg::gap{gap_scheme{gap_score{-1}, gap_open_score{-10}}};
+
+static auto dna4_01 = []()
+{
+    return alignment_fixture
+    {
+        // score: 8 (7 insertions, 1 substitutions)
+        // alignment:
+        // AACCGGTTAACCGGTT
+        // | | | | | | | |
+        // A-C-G-T-A-C-G-TA
+        "AACCGGTTAACCGGTT"_dna4,
+        "ACGTACGTA"_dna4,
+        align_config | align_cfg::scoring{nucleotide_scoring_scheme{match_score{4}, mismatch_score{-5}}},
+        -18,
+        "AACCGGTTAACCGGTT",
+        "A-C-G-T-A-C-G-TA",
+        alignment_coordinate{0, 0},
+        alignment_coordinate{15, 8},
+        std::vector
+        {
+        //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
+        /*e*/  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16,
+        /*A*/  1,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,
+        /*C*/  2,  1,  1,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
+        /*G*/  3,  2,  2,  2,  2,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13,
+        /*T*/  4,  3,  3,  3,  3,  3,  3,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12,
+        /*A*/  5,  4,  3,  4,  4,  4,  4,  4,  4,  4,  5,  6,  7,  8,  9, 10, 11,
+        /*C*/  6,  5,  4,  3,  4,  5,  5,  5,  5,  5,  5,  5,  6,  7,  8,  9, 10,
+        /*G*/  7,  6,  5,  4,  4,  4,  5,  6,  6,  6,  6,  6,  6,  6,  7,  8,  9,
+        /*T*/  8,  7,  6,  5,  5,  5,  5,  5,  6,  7,  7,  7,  7,  7,  7,  7,  8,
+        /*A*/  9,  8,  7,  6,  6,  6,  6,  6,  6,  6,  7,  8,  8,  8,  8,  8,  8
+        },
+        std::vector
+        {
+        //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
+        /*e*/NON,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,
+        /*A*/U  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
+        /*C*/U  ,U  ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,L  ,L  ,
+        /*G*/U  ,U  ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,
+        /*T*/U  ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,
+        /*A*/U  ,DU ,D  ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
+        /*C*/U  ,U  ,U  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,
+        /*G*/U  ,U  ,U  ,U  ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,
+        /*T*/U  ,U  ,U  ,U  ,DU ,DU ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,
+        /*A*/U  ,DU ,DU ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D
+        }
+    };
+}();
+
+} // namespace seqan3::fixture::global::affine::unbanded

--- a/test/unit/alignment/pairwise/fixture/global_affine_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/global_affine_unbanded.hpp
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------------------------------------
-// Copyright (c) 2006-2018, Knut Reinert & Freie Universität Berlin
-// Copyright (c) 2016-2018, Knut Reinert & MPI für molekulare Genetik
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
 // This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
 // shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
 // -----------------------------------------------------------------------------------------------------

--- a/test/unit/alignment/pairwise/global_affine_unbanded_test.cpp
+++ b/test/unit/alignment/pairwise/global_affine_unbanded_test.cpp
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------------------------------------
-// Copyright (c) 2006-2018, Knut Reinert & Freie Universität Berlin
-// Copyright (c) 2016-2018, Knut Reinert & MPI für molekulare Genetik
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
 // This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
 // shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
 // -----------------------------------------------------------------------------------------------------

--- a/test/unit/alignment/pairwise/global_affine_unbanded_test.cpp
+++ b/test/unit/alignment/pairwise/global_affine_unbanded_test.cpp
@@ -1,0 +1,61 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2018, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2018, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+
+#include <seqan3/alignment/matrix/alignment_score_matrix.hpp>
+#include <seqan3/alignment/matrix/alignment_trace_matrix.hpp>
+#include <seqan3/alignment/pairwise/align_pairwise.hpp>
+
+#include <seqan3/range/view/to_char.hpp>
+
+#include "fixture/global_affine_unbanded.hpp"
+
+using namespace seqan3;
+using namespace seqan3::detail;
+using namespace seqan3::fixture;
+
+template <auto _fixture>
+struct param : public ::testing::Test
+{
+    auto fixture() -> decltype(alignment_fixture{*_fixture}) const &
+    {
+        return *_fixture;
+    }
+};
+
+template <typename param_t>
+class global_affine_unbanded : public param_t
+{};
+
+TYPED_TEST_CASE_P(global_affine_unbanded);
+
+using global_affine_unbanded_types
+    = ::testing::Types<
+        param<&global::affine::unbanded::dna4_01>
+    >;
+
+TYPED_TEST_P(global_affine_unbanded, score)
+{
+    auto const & fixture = this->fixture();
+    // We only compute the score.
+    auto align_cfg = fixture.config | align_cfg::result{align_cfg::with_score};
+
+    std::vector database = fixture.sequence1;
+    std::vector query = fixture.sequence2;
+
+    // TODO Make test work with ranges.
+    auto alignment = align_pairwise(std::pair{database, query}, align_cfg);
+
+    EXPECT_EQ((*std::ranges::begin(alignment)).get_score(), fixture.score);
+}
+
+REGISTER_TYPED_TEST_CASE_P(global_affine_unbanded, score);
+
+// work around a bug that you can't specify more than 50 template arguments to ::testing::types
+INSTANTIATE_TYPED_TEST_CASE_P(global, global_affine_unbanded, global_affine_unbanded_types);

--- a/test/unit/range/view/view_single_pass_input_test.cpp
+++ b/test/unit/range/view/view_single_pass_input_test.cpp
@@ -117,6 +117,12 @@ TYPED_TEST(single_pass_input, view_end)
     EXPECT_TRUE((std::is_same_v<decltype(view.end()), sentinel_type>));
 }
 
+TYPED_TEST(single_pass_input, default_construction)
+{
+    detail::single_pass_input_view<std::add_lvalue_reference_t<TypeParam>> v{};
+    EXPECT_TRUE(seqan3::begin(v) == seqan3::end(v));
+}
+
 TYPED_TEST(single_pass_input, view_iterate)
 {
     TypeParam p{this->data};


### PR DESCRIPTION
Depends on:
* #668 

Supersedes #636 

Implements the first version of an affine alignment kernel that computes the score.
It refines the alignment range and the two-way executor to be move only as they are dealing with a resource. Some small fixes of the single input pass view to allow default construction of it.
Refines the algorithm configuration to check pre conditions and throw if a configuration setting is yet not supported.