### PR TITLE
[FIX] Fix from_chars for float 

### DIFF
--- a/test/unit/std/charconv_test.cpp
+++ b/test/unit/std/charconv_test.cpp
@@ -69,6 +69,16 @@ TYPED_TEST(integral_from_char_test, postive_number)
         EXPECT_EQ(res.ptr, &str[0] + str.size());
         EXPECT_EQ(res.ec, std::errc{});
     }
+
+    // Read only up to a certain point
+    {
+        std::vector<char> const str{'0', '2', '3', '4', '5', '6'};
+        auto res = std::from_chars(&str[0], &str[0] + 3, value);
+
+        EXPECT_EQ(value, TypeParam{23});
+        EXPECT_EQ(res.ptr, &str[0] + 3);
+        EXPECT_EQ(res.ec, std::errc{});
+    }
 }
 
 TYPED_TEST(integral_from_char_test, negative_number)
@@ -258,11 +268,6 @@ using real_types = ::testing::Types<float, double, long double>;
 
 TYPED_TEST_CASE(from_char_real_test, real_types);
 
-bool double_equals(double a, double b, double epsilon = 0.00001)
-{
-    return std::abs(a - b) < epsilon;
-}
-
 TYPED_TEST(from_char_real_test, real_numbers)
 {
     std::setlocale(LC_NUMERIC, "C");
@@ -270,104 +275,127 @@ TYPED_TEST(from_char_real_test, real_numbers)
         TypeParam val{};
         std::string str = "1234";
         auto res = std::from_chars(&str[0], &str[0] + str.size(), val);
-        EXPECT_EQ(val, TypeParam{1234});
+        EXPECT_FLOAT_EQ(val, TypeParam{1234});
         EXPECT_EQ(res.ec, std::errc{});
+        EXPECT_EQ(res.ptr, &str[0] + str.size());
     }
 
     {
         TypeParam val{};
         std::string str = "1.2e3";
         auto res = std::from_chars(&str[0], &str[0] + str.size(), val);
-        EXPECT_EQ(val, TypeParam{1200});
+        EXPECT_FLOAT_EQ(val, TypeParam{1200});
         EXPECT_EQ(res.ec, std::errc{});
+        EXPECT_EQ(res.ptr, &str[0] + str.size());
     }
 
     {
         TypeParam val{};
         std::string str = "1.2e-3";
         auto res = std::from_chars(&str[0], &str[0] + str.size(), val);
-        EXPECT_TRUE(double_equals(val, TypeParam{0.0012}));
+        EXPECT_FLOAT_EQ(val, TypeParam{0.0012});
         EXPECT_EQ(res.ec, std::errc{});
+        EXPECT_EQ(res.ptr, &str[0] + str.size());
     }
 
     {
         TypeParam val{};
         std::string str = "1.e2";
         auto res = std::from_chars(&str[0], &str[0] + str.size(), val);
-        EXPECT_EQ(val, TypeParam{100});
+        EXPECT_FLOAT_EQ(val, TypeParam{100});
         EXPECT_EQ(res.ec, std::errc{});
+        EXPECT_EQ(res.ptr, &str[0] + str.size());
     }
 
     {
         TypeParam val{};
         std::string str = "1.";
         auto res = std::from_chars(&str[0], &str[0] + str.size(), val);
-        EXPECT_EQ(val, TypeParam{1});
+        EXPECT_FLOAT_EQ(val, TypeParam{1});
         EXPECT_EQ(res.ec, std::errc{});
+        EXPECT_EQ(res.ptr, &str[0] + str.size());
     }
 
     {
         TypeParam val{};
         std::string str = ".2e3";
         auto res = std::from_chars(&str[0], &str[0] + str.size(), val);
-        EXPECT_EQ(val, TypeParam{200});
+        EXPECT_FLOAT_EQ(val, TypeParam{200});
         EXPECT_EQ(res.ec, std::errc{});
+        EXPECT_EQ(res.ptr, &str[0] + str.size());
     }
 
     {
         TypeParam val{};
         std::string str = "2e3";
         auto res = std::from_chars(&str[0], &str[0] + str.size(), val);
-        EXPECT_EQ(val, TypeParam{2000});
+        EXPECT_FLOAT_EQ(val, TypeParam{2000});
         EXPECT_EQ(res.ec, std::errc{});
+        EXPECT_EQ(res.ptr, &str[0] + str.size());
     }
 
     {
         TypeParam val{};
         std::string str = "2";
         auto res = std::from_chars(&str[0], &str[0] + str.size(), val);
-        EXPECT_EQ(val, TypeParam{2});
+        EXPECT_FLOAT_EQ(val, TypeParam{2});
         EXPECT_EQ(res.ec, std::errc{});
+        EXPECT_EQ(res.ptr, &str[0] + str.size());
     }
 
     {
         TypeParam val{};
         std::string str = "4em";
         auto res = std::from_chars(&str[0], &str[0] + str.size(), val);
-        EXPECT_EQ(val, TypeParam{4});
+        EXPECT_FLOAT_EQ(val, TypeParam{4});
         EXPECT_EQ(res.ec, std::errc{});
+        EXPECT_EQ(res.ptr, &str[0] + str.size());
     }
 
     {
         TypeParam val{};
         std::string str = "-1.2e3";
         auto res = std::from_chars(&str[0], &str[0] + str.size(), val);
-        EXPECT_EQ(val, TypeParam{-1200});
+        EXPECT_FLOAT_EQ(val, TypeParam{-1200});
         EXPECT_EQ(res.ec, std::errc{});
+        EXPECT_EQ(res.ptr, &str[0] + str.size());
     }
 
     {
         TypeParam val{42};
         std::string str = "-.3";
         auto res = std::from_chars(&str[0], &str[0] + str.size(), val);
-        EXPECT_TRUE(double_equals(val, TypeParam{-0.3}));
+        EXPECT_FLOAT_EQ(val, TypeParam{-0.3});
         EXPECT_EQ(res.ec, std::errc{});
+        EXPECT_EQ(res.ptr, &str[0] + str.size());
     }
 
     {
         TypeParam val{42};
         std::string str = "1.2e";
         auto res = std::from_chars(&str[0], &str[0] + str.size(), val);
-        EXPECT_TRUE(double_equals(val, TypeParam{1.2}));
+        EXPECT_FLOAT_EQ(val, TypeParam{1.2});
         EXPECT_EQ(res.ec, std::errc{});
+        EXPECT_EQ(res.ptr, &str[0] + str.size());
     }
 
     {
         TypeParam val{42};
         std::string str = "0.0";
         auto res = std::from_chars(&str[0], &str[0] + str.size(), val);
-        EXPECT_EQ(val, TypeParam{0});
+        EXPECT_FLOAT_EQ(val, TypeParam{0});
         EXPECT_EQ(res.ec, std::errc{});
+        EXPECT_EQ(res.ptr, &str[0] + str.size());
+    }
+
+    // Read only until a certain position
+    {
+        TypeParam val{42};
+        std::string str = "3.194357";
+        auto res = std::from_chars(&str[0], &str[0] + 4, val);
+        EXPECT_FLOAT_EQ(val, TypeParam{3.19});
+        EXPECT_EQ(res.ec, std::errc{});
+        EXPECT_EQ(res.ptr, &str[0] + 4);
     }
 }
 
@@ -379,6 +407,7 @@ TYPED_TEST(from_char_real_test, infinity_value)
         auto res = std::from_chars(&str[0], &str[0] + str.size(), val);
         EXPECT_EQ(val, std::numeric_limits<TypeParam>::infinity());
         EXPECT_EQ(res.ec, std::errc{});
+        EXPECT_EQ(res.ptr, &str[0] + str.size());
     }
 
     {
@@ -387,6 +416,7 @@ TYPED_TEST(from_char_real_test, infinity_value)
         auto res = std::from_chars(&str[0], &str[0] + str.size(), val);
         EXPECT_EQ(val, std::numeric_limits<TypeParam>::infinity());
         EXPECT_EQ(res.ec, std::errc{});
+        EXPECT_EQ(res.ptr, &str[0] + str.size());
     }
 
     {
@@ -395,6 +425,7 @@ TYPED_TEST(from_char_real_test, infinity_value)
         auto res = std::from_chars(&str[0], &str[0] + str.size(), val);
         EXPECT_EQ(val, std::numeric_limits<TypeParam>::infinity());
         EXPECT_EQ(res.ec, std::errc{});
+        EXPECT_EQ(res.ptr, &str[0] + str.size());
     }
 
     {
@@ -403,6 +434,7 @@ TYPED_TEST(from_char_real_test, infinity_value)
         auto res = std::from_chars(&str[0], &str[0] + str.size(), val);
         EXPECT_EQ(val, std::numeric_limits<TypeParam>::infinity());
         EXPECT_EQ(res.ec, std::errc{});
+        EXPECT_EQ(res.ptr, &str[0] + str.size());
     }
 
 }
@@ -419,6 +451,7 @@ TYPED_TEST(from_char_real_test, nan_value)
         auto res = std::from_chars(&str[0], &str[0] + str.size(), val);
         EXPECT_TRUE(std::isnan(val));
         EXPECT_EQ(res.ec, std::errc{});
+        EXPECT_EQ(res.ptr, &str[0] + str.size());
     }
 
     {
@@ -427,6 +460,7 @@ TYPED_TEST(from_char_real_test, nan_value)
         auto res = std::from_chars(&str[0], &str[0] + str.size(), val);
         EXPECT_TRUE(std::isnan(val));
         EXPECT_EQ(res.ec, std::errc{});
+        EXPECT_EQ(res.ptr, &str[0] + str.size());
     }
 
     {
@@ -435,6 +469,7 @@ TYPED_TEST(from_char_real_test, nan_value)
         auto res = std::from_chars(&str[0], &str[0] + str.size(), val);
         EXPECT_TRUE(std::isnan(val));
         EXPECT_EQ(res.ec, std::errc{});
+        EXPECT_EQ(res.ptr, &str[0] + str.size());
     }
 
     {
@@ -443,6 +478,7 @@ TYPED_TEST(from_char_real_test, nan_value)
         auto res = std::from_chars(&str[0], &str[0] + str.size(), val);
         EXPECT_TRUE(std::isnan(val));
         EXPECT_EQ(res.ec, std::errc{});
+        EXPECT_EQ(res.ptr, &str[0] + str.size());
     }
 }
 
@@ -452,7 +488,7 @@ TYPED_TEST(from_char_real_test, non_valid_strings)
         TypeParam val{42};
         std::string str = "e3";
         auto res = std::from_chars(&str[0], &str[0] + str.size(), val);
-        EXPECT_EQ(val, TypeParam{42});
+        EXPECT_FLOAT_EQ(val, TypeParam{42});
         EXPECT_EQ(res.ec, std::errc::invalid_argument);
     }
 
@@ -460,7 +496,7 @@ TYPED_TEST(from_char_real_test, non_valid_strings)
         TypeParam val{42};
         std::string str = "+1.2e3";
         auto res = std::from_chars(&str[0], &str[0] + str.size(), val);
-        EXPECT_EQ(val, TypeParam{42});
+        EXPECT_FLOAT_EQ(val, TypeParam{42});
         EXPECT_EQ(res.ec, std::errc::invalid_argument);
     }
 }


### PR DESCRIPTION
Treat the second parameter as the end of the sequence to parse.