### PR TITLE
Rename io

### DIFF
--- a/include/seqan3/argument_parser/argument_parser.hpp
+++ b/include/seqan3/argument_parser/argument_parser.hpp
@@ -177,9 +177,9 @@ public:
      */
     template <typename option_type, validator_concept validator_type = detail::default_validator<option_type>>
     //!\cond
-        requires (istream_concept<std::istringstream, option_type> ||
-                  istream_concept<std::istringstream, typename option_type::value_type>) &&
-                 std::is_same_v<typename validator_type::value_type, option_type>
+        requires (IStream<std::istringstream, option_type> ||
+                  IStream<std::istringstream, typename option_type::value_type>) &&
+                  std::is_same_v<typename validator_type::value_type, option_type>
     //!\endcond
     void add_option(option_type & value,
                     char const short_id,
@@ -236,9 +236,9 @@ public:
      */
     template <typename option_type, validator_concept validator_type = detail::default_validator<option_type>>
     //!\cond
-        requires (istream_concept<std::istringstream, option_type> ||
-                  istream_concept<std::istringstream, typename option_type::value_type>) &&
-                 std::is_same_v<typename validator_type::value_type, option_type>
+        requires (IStream<std::istringstream, option_type> ||
+                  IStream<std::istringstream, typename option_type::value_type>) &&
+                  std::is_same_v<typename validator_type::value_type, option_type>
     //!\endcond
     void add_positional_option(option_type & value,
                                std::string const & desc,

--- a/include/seqan3/argument_parser/auxiliary.hpp
+++ b/include/seqan3/argument_parser/auxiliary.hpp
@@ -118,7 +118,7 @@ namespace detail
  */
 template <typename ...value_type>
 //!\cond
-requires (ostream_concept<std::iostream, std::remove_reference_t<value_type>> && ...)
+requires (OStream<std::iostream, std::remove_reference_t<value_type>> && ...)
 //!\endcond
 std::string to_string(value_type && ...values)
 {

--- a/include/seqan3/argument_parser/detail/format_parse.hpp
+++ b/include/seqan3/argument_parser/detail/format_parse.hpp
@@ -275,7 +275,7 @@ private:
 
     /*!\brief Tries to cast an input string into a value.
      *
-     * \tparam option_t Must satisfy the seqan3::istream_concept.
+     * \tparam option_t Must satisfy the seqan3::IStream.
      *
      * \param[out] value Stores the casted value.
      * \param[in]  in    The input argument to be casted.
@@ -284,7 +284,7 @@ private:
      */
     template <typename option_t>
     //!\cond
-        requires istream_concept<std::istringstream, option_t>
+        requires IStream<std::istringstream, option_t>
     //!\endcond
     void retrieve_value(option_t & value, std::string const & in)
     {
@@ -306,14 +306,14 @@ private:
     /*!\brief Appends a casted value to its container.
      *
      * \tparam container_option_t Must satisfy the seqan3::sequence_container_concept and
-     *                            its value_type must satisfy the seqan3::istream_concept
+     *                            its value_type must satisfy the seqan3::IStream
      *
      * \param[out] value Container that stores the casted value.
      * \param[in]  in    The input argument to be casted.
      */
     template <sequence_container_concept container_option_t>
     //!\cond
-        requires istream_concept<std::istringstream, typename container_option_t::value_type>
+        requires IStream<std::istringstream, typename container_option_t::value_type>
     //!\cond
     void retrieve_value(container_option_t & value, std::string const & in)
     {
@@ -344,7 +344,7 @@ private:
      */
     template <std::Integral option_t>
     //!\cond
-        requires istream_concept<std::istringstream, option_t>
+        requires IStream<std::istringstream, option_t>
     //!\endcond
     void retrieve_value(option_t & value, std::string const & in)
     {

--- a/include/seqan3/io/alignment_file/format_sam.hpp
+++ b/include/seqan3/io/alignment_file/format_sam.hpp
@@ -135,7 +135,7 @@ public:
         { "sam" },
     };
 
-    //!\copydoc alignment_file_output_format_concept::write
+    //!\copydoc AlignmentFileOutputFormat::write
     template <typename stream_type,
               typename seq_type,
               typename id_type,

--- a/include/seqan3/io/alignment_file/output.hpp
+++ b/include/seqan3/io/alignment_file/output.hpp
@@ -199,7 +199,7 @@ template <detail::fields_concept selected_field_ids_ =
                      field::EVALUE,
                      field::BIT_SCORE,
                      field::HEADER_PTR>,
-          detail::type_list_of_alignment_file_output_formats_concept valid_formats_ =
+          detail::TypeListOfAlignmentFileOutputFormats valid_formats_ =
               type_list<alignment_file_format_sam/*,
                         alignment_file_format_bam,
                         alignment_file_format_blast_tabular*/>,

--- a/include/seqan3/io/alignment_file/output.hpp
+++ b/include/seqan3/io/alignment_file/output.hpp
@@ -46,7 +46,7 @@ namespace seqan3
  * \tparam selected_field_ids   A seqan3::fields type with the list and order of
  *                              fields IDs; only relevant if these can't be deduced.
  * \tparam valid_formats        A seqan3::type_list of the selectable formats (each
- *                              must model seqan3::alignment_file_output_format_concept).
+ *                              must model seqan3::AlignmentFileOutputFormat).
  * \tparam stream_type          The type of the stream, must model seqan3::ostream_concept.
  *
  * \details
@@ -313,14 +313,14 @@ public:
     }
 
     /*!\brief Construct from an existing stream and with specified format.
-     * \tparam file_format   The format of the file in the stream, must satisfy seqan3::alignment_file_output_format_concept.
+     * \tparam file_format   The format of the file in the stream, must satisfy seqan3::AlignmentFileOutputFormat.
      * \param[in] _stream    The stream to operate on (this must be std::move'd in!).
      * \param[in] format_tag The file format tag.
      * \param[in] fields_tag A seqan3::fields tag. [optional]
      *
      * \details
      */
-    template <alignment_file_output_format_concept file_format>
+    template <AlignmentFileOutputFormat file_format>
     alignment_file_output(stream_type             && _stream,
                           file_format        const & SEQAN3_DOXYGEN_ONLY(format_tag),
                           selected_field_ids const & SEQAN3_DOXYGEN_ONLY(fields_tag) = selected_field_ids{}) :
@@ -675,7 +675,7 @@ protected:
  * \{
  */
 template <ostream_concept<char>             stream_type,
-          alignment_file_output_format_concept file_format,
+          AlignmentFileOutputFormat file_format,
           detail::fields_concept            selected_field_ids>
 alignment_file_output(stream_type && _stream, file_format const &, selected_field_ids const &)
     -> alignment_file_output<selected_field_ids,

--- a/include/seqan3/io/alignment_file/output.hpp
+++ b/include/seqan3/io/alignment_file/output.hpp
@@ -47,7 +47,7 @@ namespace seqan3
  *                              fields IDs; only relevant if these can't be deduced.
  * \tparam valid_formats        A seqan3::type_list of the selectable formats (each
  *                              must model seqan3::AlignmentFileOutputFormat).
- * \tparam stream_type          The type of the stream, must model seqan3::ostream_concept.
+ * \tparam stream_type          The type of the stream, must model seqan3::OStream.
  *
  * \details
  *
@@ -203,7 +203,7 @@ template <detail::fields_concept selected_field_ids_ =
               type_list<alignment_file_format_sam/*,
                         alignment_file_format_bam,
                         alignment_file_format_blast_tabular*/>,
-          ostream_concept<char> stream_type_ = std::ofstream>
+          OStream<char> stream_type_ = std::ofstream>
 class alignment_file_output
 {
 public:
@@ -674,7 +674,7 @@ protected:
  * \relates seqan3::alignment_file_output
  * \{
  */
-template <ostream_concept<char>             stream_type,
+template <OStream<char>             stream_type,
           AlignmentFileOutputFormat file_format,
           detail::fields_concept            selected_field_ids>
 alignment_file_output(stream_type && _stream, file_format const &, selected_field_ids const &)

--- a/include/seqan3/io/alignment_file/output_format_concept.hpp
+++ b/include/seqan3/io/alignment_file/output_format_concept.hpp
@@ -6,7 +6,7 @@
 // -----------------------------------------------------------------------------------------------------
 
 /*!\file
- * \brief Provides seqan3::alignment_file_output_format_concept and auxiliary classes.
+ * \brief Provides seqan3::AlignmentFileOutputFormat and auxiliary classes.
  * \author Svenja Mehringer <avenja.mehringer AT fu-berlin.de>
  */
 
@@ -28,7 +28,7 @@
 namespace seqan3
 {
 
-/*!\interface seqan3::alignment_file_output_format_concept <>
+/*!\interface seqan3::AlignmentFileOutputFormat <>
  * \brief The generic concept for alignment file out formats.
  * \ingroup alignment_file
  *
@@ -41,7 +41,7 @@ namespace seqan3
  */
 //!\cond
 template <typename t>
-SEQAN3_CONCEPT alignment_file_output_format_concept =
+SEQAN3_CONCEPT AlignmentFileOutputFormat =
     requires (t                                                               & v,
               std::ofstream                                                   & stream,
               alignment_file_output_options                                   & options,
@@ -84,9 +84,9 @@ SEQAN3_CONCEPT alignment_file_output_format_concept =
 };
 //!\endcond
 
-/*!\name Requirements for seqan3::alignment_file_output_format_concept
- * \brief You can expect these **members** on all types that implement seqan3::alignment_file_output_format_concept.
- * \memberof seqan3::alignment_file_output_format_concept
+/*!\name Requirements for seqan3::AlignmentFileOutputFormat
+ * \brief You can expect these **members** on all types that implement seqan3::AlignmentFileOutputFormat.
+ * \memberof seqan3::AlignmentFileOutputFormat
  * \{
  */
 
@@ -108,7 +108,7 @@ SEQAN3_CONCEPT alignment_file_output_format_concept =
                   e_value_type                           && e_value,
                   bit_score_type                         && bit_score)
  * \brief Write the given fields to the specified stream.
- * \memberof seqan3::alignment_file_output_format_concept
+ * \memberof seqan3::AlignmentFileOutputFormat
  * \tparam stream_type      Output stream, must model seqan3::ostream_concept with `char`.
  * \tparam seq_type         Type of the seqan3
  * \tparam id_type          Type of the seqan3
@@ -144,7 +144,7 @@ SEQAN3_CONCEPT alignment_file_output_format_concept =
  * \param[in]     bit_score  The data for seqan3::field::, e.g. the bit score of the alignment (BLAST).
  *
  */
-/*!\var static inline std::vector<std::string> seqan3::alignment_file_output_format_concept::file_extensions
+/*!\var static inline std::vector<std::string> seqan3::AlignmentFileOutputFormat::file_extensions
  * \brief The format type is required to provide a vector of all supported file extensions.
  */
 
@@ -156,7 +156,7 @@ namespace seqan3::detail
 {
 
 /*!\brief Auxiliary value metafuncton that checks whether a type is a seqan3::type_list and all types meet
- * seqan3::alignment_file_output_format_concept [default is false].
+ * seqan3::AlignmentFileOutputFormat [default is false].
  * \ingroup core
  * \see seqan3::type_list_of_alignment_file_output_formats_concept
  */
@@ -164,13 +164,13 @@ template <typename t>
 constexpr bool is_type_list_of_alignment_file_output_formats_v = false;
 
 /*!\brief Auxiliary value metafuncton that checks whether a type is a seqan3::type_list and all types meet
- * seqan3::alignment_file_output_format_concept [overload].
+ * seqan3::AlignmentFileOutputFormat [overload].
  * \ingroup core
  * \see seqan3::type_list_of_alignment_file_output_formats_concept
  */
 template <typename ... ts>
 constexpr bool is_type_list_of_alignment_file_output_formats_v<type_list<ts...>>
-                = (alignment_file_output_format_concept<ts> && ...);
+                = (AlignmentFileOutputFormat<ts> && ...);
 
 /*!\brief Auxiliary concept that checks whether a type is a seqan3::type_list and all types meet
  * seqan3::alignment_file_format_concept.

--- a/include/seqan3/io/alignment_file/output_format_concept.hpp
+++ b/include/seqan3/io/alignment_file/output_format_concept.hpp
@@ -109,7 +109,7 @@ SEQAN3_CONCEPT AlignmentFileOutputFormat =
                   bit_score_type                         && bit_score)
  * \brief Write the given fields to the specified stream.
  * \memberof seqan3::AlignmentFileOutputFormat
- * \tparam stream_type      Output stream, must model seqan3::ostream_concept with `char`.
+ * \tparam stream_type      Output stream, must model seqan3::OStream with `char`.
  * \tparam seq_type         Type of the seqan3
  * \tparam id_type          Type of the seqan3
  * \tparam offset_type      Type of the seqan3

--- a/include/seqan3/io/alignment_file/output_format_concept.hpp
+++ b/include/seqan3/io/alignment_file/output_format_concept.hpp
@@ -158,7 +158,7 @@ namespace seqan3::detail
 /*!\brief Auxiliary value metafuncton that checks whether a type is a seqan3::type_list and all types meet
  * seqan3::AlignmentFileOutputFormat [default is false].
  * \ingroup core
- * \see seqan3::type_list_of_alignment_file_output_formats_concept
+ * \see seqan3::TypeListOfAlignmentFileOutputFormats
  */
 template <typename t>
 constexpr bool is_type_list_of_alignment_file_output_formats_v = false;
@@ -166,7 +166,7 @@ constexpr bool is_type_list_of_alignment_file_output_formats_v = false;
 /*!\brief Auxiliary value metafuncton that checks whether a type is a seqan3::type_list and all types meet
  * seqan3::AlignmentFileOutputFormat [overload].
  * \ingroup core
- * \see seqan3::type_list_of_alignment_file_output_formats_concept
+ * \see seqan3::TypeListOfAlignmentFileOutputFormats
  */
 template <typename ... ts>
 constexpr bool is_type_list_of_alignment_file_output_formats_v<type_list<ts...>>
@@ -178,5 +178,5 @@ constexpr bool is_type_list_of_alignment_file_output_formats_v<type_list<ts...>>
  * \see seqan3::is_type_list_of_alignment_file_formats_v
  */
 template <typename t>
-SEQAN3_CONCEPT type_list_of_alignment_file_output_formats_concept = is_type_list_of_alignment_file_output_formats_v<t>;
+SEQAN3_CONCEPT TypeListOfAlignmentFileOutputFormats = is_type_list_of_alignment_file_output_formats_v<t>;
 } // namespace seqan3::detail

--- a/include/seqan3/io/sequence_file/format_fasta.hpp
+++ b/include/seqan3/io/sequence_file/format_fasta.hpp
@@ -48,7 +48,7 @@ namespace seqan3
 {
 /*!\brief       The FastA format.
  * \implements  sequence_file_input_format_concept
- * \implements  sequence_file_output_format_concept
+ * \implements  SequenceFileOutputFormat
  * \ingroup     sequence
  *
  * \details
@@ -135,7 +135,7 @@ public:
         }
     }
 
-    //!\copydoc sequence_file_output_format_concept::write
+    //!\copydoc SequenceFileOutputFormat::write
     template <typename stream_type,     // constraints checked by file
               typename seq_type,        // other constraints checked inside function
               typename id_type,

--- a/include/seqan3/io/sequence_file/format_fasta.hpp
+++ b/include/seqan3/io/sequence_file/format_fasta.hpp
@@ -47,7 +47,7 @@
 namespace seqan3
 {
 /*!\brief       The FastA format.
- * \implements  sequence_file_input_format_concept
+ * \implements  SequenceFileInputFormat
  * \implements  SequenceFileOutputFormat
  * \ingroup     sequence
  *
@@ -104,7 +104,7 @@ public:
         { "frn"   },
     };
 
-    //!\copydoc sequence_file_input_format_concept::read
+    //!\copydoc SequenceFileInputFormat::read
     template <typename stream_type,     // constraints checked by file
               typename seq_legal_alph_type, bool seq_qual_combined,
               typename seq_type,        // other constraints checked inside function

--- a/include/seqan3/io/sequence_file/format_fastq.hpp
+++ b/include/seqan3/io/sequence_file/format_fastq.hpp
@@ -45,7 +45,7 @@
 namespace seqan3
 {
 /*!\brief       The FastQ format.
- * \implements  sequence_file_format_concept
+ * \implements  SequenceFileFormat
  * \ingroup     sequence
  *
  * \details

--- a/include/seqan3/io/sequence_file/format_fastq.hpp
+++ b/include/seqan3/io/sequence_file/format_fastq.hpp
@@ -96,7 +96,7 @@ public:
         { "fq"    }
     };
 
-    //!\copydoc sequence_file_input_format_concept::read
+    //!\copydoc SequenceFileInputFormat::read
     template <typename stream_type,     // constraints checked by file
               typename seq_legal_alph_type, bool seq_qual_combined,
               typename seq_type,        // other constraints checked inside function

--- a/include/seqan3/io/sequence_file/format_fastq.hpp
+++ b/include/seqan3/io/sequence_file/format_fastq.hpp
@@ -65,7 +65,7 @@ namespace seqan3
  *
  * All documented encodings for the quality string are supported (see the article above), but they are **not detected**
  * from the file. Instead, when reading the file, you have to set the respective alphabet via a traits type (see
- * seqan3::sequence_file_input_traits_concept and the quality submodule \todo link).
+ * seqan3::SequenceFileInputTraits and the quality submodule \todo link).
  *
  * ### Implementation notes
  *

--- a/include/seqan3/io/sequence_file/format_fastq.hpp
+++ b/include/seqan3/io/sequence_file/format_fastq.hpp
@@ -219,7 +219,7 @@ public:
         }
     }
 
-    //!\copydoc sequence_file_output_format_concept::write
+    //!\copydoc SequenceFileOutputFormat::write
     template <typename stream_type,     // constraints checked by file
               typename seq_type,        // other constraints checked inside function
               typename id_type,

--- a/include/seqan3/io/sequence_file/input.hpp
+++ b/include/seqan3/io/sequence_file/input.hpp
@@ -118,7 +118,7 @@ namespace seqan3
 //!\}
 //!\cond
 template <typename t>
-concept SequenceFileInputTraits = requires (t v)
+SEQAN3_CONCEPT SequenceFileInputTraits = requires (t v)
 {
     requires alphabet_concept<typename t::sequence_alphabet>;
     requires alphabet_concept<typename t::sequence_legal_alphabet>;
@@ -434,14 +434,14 @@ struct sequence_file_input_default_traits_aa : sequence_file_input_default_trait
  */
 
 template <
-    SequenceFileInputTraits                       traits_type_        = sequence_file_input_default_traits_dna,
-    detail::fields_concept                                   selected_field_ids_ = fields<field::SEQ,
+    SequenceFileInputTraits                    traits_type_        = sequence_file_input_default_traits_dna,
+    detail::fields_concept                     selected_field_ids_ = fields<field::SEQ,
                                                                                           field::ID,
                                                                                           field::QUAL>,
     detail::TypeListOfSequenceFileInputFormats valid_formats_      = type_list<sequence_file_format_fasta,
                                                                                              sequence_file_format_fastq
                                                                                              /*, ...*/>,
-    char_concept                                             stream_char_type_   = char>
+    char_concept                               stream_char_type_   = char>
 class sequence_file_input
 {
 public:
@@ -914,13 +914,8 @@ protected:
  * \relates seqan3::sequence_file_input
  * \{
  */
-<<<<<<< HEAD
-template <istream_concept2                   stream_type,
-          SequenceFileInputFormat file_format,
-=======
 template <IStream2                           stream_type,
           SequenceFileInputFormat            file_format,
->>>>>>> b7da21f... [MISC] Rename istream_concept -> IStream
           detail::fields_concept             selected_field_ids>
 sequence_file_input(stream_type && stream,
                     file_format const &,
@@ -951,10 +946,10 @@ sequence_file_input(stream_type & stream,
 namespace std
 {
 //!\brief std::tuple_size overload for column-like access. [metafunction specialisation for seqan3::sequence_file_input]
-template <seqan3::SequenceFileInputTraits                       traits_type,
-          seqan3::detail::fields_concept                                selected_field_ids,
+template <seqan3::SequenceFileInputTraits                    traits_type,
+          seqan3::detail::fields_concept                     selected_field_ids,
           seqan3::detail::TypeListOfSequenceFileInputFormats valid_formats,
-          seqan3::char_concept                                             stream_char_t>
+          seqan3::char_concept                               stream_char_t>
 struct tuple_size<seqan3::sequence_file_input<traits_type, selected_field_ids, valid_formats, stream_char_t>>
 {
     //!\brief The value equals the number of selected fields in the file.
@@ -962,11 +957,11 @@ struct tuple_size<seqan3::sequence_file_input<traits_type, selected_field_ids, v
 };
 
 //!\brief std::tuple_element overload for column-like access. [metafunction specialisation for seqan3::sequence_file_input]
-template <size_t                                                        elem_no,
-          seqan3::SequenceFileInputTraits                       traits_type,
-          seqan3::detail::fields_concept                                selected_field_ids,
+template <size_t                                             elem_no,
+          seqan3::SequenceFileInputTraits                    traits_type,
+          seqan3::detail::fields_concept                     selected_field_ids,
           seqan3::detail::TypeListOfSequenceFileInputFormats valid_formats,
-          seqan3::char_concept                                             stream_char_t>
+          seqan3::char_concept                               stream_char_t>
 struct tuple_element<elem_no, seqan3::sequence_file_input<traits_type, selected_field_ids, valid_formats, stream_char_t>>
     : tuple_element<elem_no, typename seqan3::sequence_file_input<traits_type,
                                                                selected_field_ids,

--- a/include/seqan3/io/sequence_file/input.hpp
+++ b/include/seqan3/io/sequence_file/input.hpp
@@ -438,9 +438,9 @@ template <
     detail::fields_concept                                   selected_field_ids_ = fields<field::SEQ,
                                                                                           field::ID,
                                                                                           field::QUAL>,
-    detail::type_list_of_sequence_file_input_formats_concept valid_formats_      = type_list<sequence_file_format_fasta,
-                                                                                          sequence_file_format_fastq
-                                                                                         /*, ...*/>,
+    detail::TypeListOfSequenceFileInputFormats valid_formats_      = type_list<sequence_file_format_fasta,
+                                                                                             sequence_file_format_fastq
+                                                                                             /*, ...*/>,
     char_concept                                             stream_char_type_   = char>
 class sequence_file_input
 {
@@ -948,7 +948,7 @@ namespace std
 //!\brief std::tuple_size overload for column-like access. [metafunction specialisation for seqan3::sequence_file_input]
 template <seqan3::sequence_file_input_traits_concept                       traits_type,
           seqan3::detail::fields_concept                                selected_field_ids,
-          seqan3::detail::type_list_of_sequence_file_input_formats_concept valid_formats,
+          seqan3::detail::TypeListOfSequenceFileInputFormats valid_formats,
           seqan3::char_concept                                             stream_char_t>
 struct tuple_size<seqan3::sequence_file_input<traits_type, selected_field_ids, valid_formats, stream_char_t>>
 {
@@ -960,7 +960,7 @@ struct tuple_size<seqan3::sequence_file_input<traits_type, selected_field_ids, v
 template <size_t                                                        elem_no,
           seqan3::sequence_file_input_traits_concept                       traits_type,
           seqan3::detail::fields_concept                                selected_field_ids,
-          seqan3::detail::type_list_of_sequence_file_input_formats_concept valid_formats,
+          seqan3::detail::TypeListOfSequenceFileInputFormats valid_formats,
           seqan3::char_concept                                             stream_char_t>
 struct tuple_element<elem_no, seqan3::sequence_file_input<traits_type, selected_field_ids, valid_formats, stream_char_t>>
     : tuple_element<elem_no, typename seqan3::sequence_file_input<traits_type,

--- a/include/seqan3/io/sequence_file/input.hpp
+++ b/include/seqan3/io/sequence_file/input.hpp
@@ -625,7 +625,7 @@ public:
      * it is detected as being compressed.
      * See the section on \link io_compression compression and decompression \endlink for more information.
      */
-    template <istream_concept2 stream_t,
+    template <IStream2 stream_t,
               SequenceFileInputFormat file_format>
     sequence_file_input(stream_t                 & stream,
                         file_format        const & SEQAN3_DOXYGEN_ONLY(format_tag),
@@ -644,7 +644,7 @@ public:
     }
 
     //!\overload
-    template <istream_concept2 stream_t,
+    template <IStream2 stream_t,
               SequenceFileInputFormat file_format>
     sequence_file_input(stream_t                && stream,
                         file_format        const & SEQAN3_DOXYGEN_ONLY(format_tag),
@@ -914,8 +914,13 @@ protected:
  * \relates seqan3::sequence_file_input
  * \{
  */
+<<<<<<< HEAD
 template <istream_concept2                   stream_type,
           SequenceFileInputFormat file_format,
+=======
+template <IStream2                           stream_type,
+          SequenceFileInputFormat            file_format,
+>>>>>>> b7da21f... [MISC] Rename istream_concept -> IStream
           detail::fields_concept             selected_field_ids>
 sequence_file_input(stream_type && stream,
                     file_format const &,
@@ -925,8 +930,8 @@ sequence_file_input(stream_type && stream,
                            type_list<file_format>,
                            typename std::remove_reference_t<stream_type>::char_type>;
 
-template <istream_concept2                   stream_type,
-          SequenceFileInputFormat file_format,
+template <IStream2                           stream_type,
+          SequenceFileInputFormat            file_format,
           detail::fields_concept             selected_field_ids>
 sequence_file_input(stream_type & stream,
                     file_format const &,

--- a/include/seqan3/io/sequence_file/input.hpp
+++ b/include/seqan3/io/sequence_file/input.hpp
@@ -219,7 +219,7 @@ struct sequence_file_input_default_traits_aa : sequence_file_input_default_trait
  * \tparam selected_field_ids   A seqan3::fields type with the list and order of desired record entries; all fields
  * must be in seqan3::sequence_file_input::field_ids.
  * \tparam valid_formats        A seqan3::type_list of the selectable formats (each must meet
- * seqan3::sequence_file_input_format_concept).
+ * seqan3::SequenceFileInputFormat).
  * \tparam stream_char_type     The type of the underlying stream device(s); must model seqan3::char_concept.
  * \details
  *
@@ -612,7 +612,7 @@ public:
      */
 
     /*!\brief Construct from an existing stream and with specified format.
-     * \tparam file_format   The format of the file in the stream, must satisfy seqan3::sequence_file_input_format_concept.
+     * \tparam file_format   The format of the file in the stream, must satisfy seqan3::SequenceFileInputFormat.
      * \param[in] stream     The stream to operate on; must be derived of std::basic_istream.
      * \param[in] format_tag The file format tag.
      * \param[in] fields_tag A seqan3::fields tag. [optional]
@@ -626,7 +626,7 @@ public:
      * See the section on \link io_compression compression and decompression \endlink for more information.
      */
     template <istream_concept2 stream_t,
-              sequence_file_input_format_concept file_format>
+              SequenceFileInputFormat file_format>
     sequence_file_input(stream_t                 & stream,
                         file_format        const & SEQAN3_DOXYGEN_ONLY(format_tag),
                         selected_field_ids const & SEQAN3_DOXYGEN_ONLY(fields_tag) = selected_field_ids{}) :
@@ -645,7 +645,7 @@ public:
 
     //!\overload
     template <istream_concept2 stream_t,
-              sequence_file_input_format_concept file_format>
+              SequenceFileInputFormat file_format>
     sequence_file_input(stream_t                && stream,
                         file_format        const & SEQAN3_DOXYGEN_ONLY(format_tag),
                         selected_field_ids const & SEQAN3_DOXYGEN_ONLY(fields_tag) = selected_field_ids{}) :
@@ -860,7 +860,7 @@ protected:
         }
 
         assert(!format.valueless_by_exception());
-        std::visit([&] (sequence_file_input_format_concept & f)
+        std::visit([&] (SequenceFileInputFormat & f)
         {
             // read new record
             if constexpr (selected_field_ids::contains(field::SEQ_QUAL))
@@ -915,7 +915,7 @@ protected:
  * \{
  */
 template <istream_concept2                   stream_type,
-          sequence_file_input_format_concept file_format,
+          SequenceFileInputFormat file_format,
           detail::fields_concept             selected_field_ids>
 sequence_file_input(stream_type && stream,
                     file_format const &,
@@ -926,7 +926,7 @@ sequence_file_input(stream_type && stream,
                            typename std::remove_reference_t<stream_type>::char_type>;
 
 template <istream_concept2                   stream_type,
-          sequence_file_input_format_concept file_format,
+          SequenceFileInputFormat file_format,
           detail::fields_concept             selected_field_ids>
 sequence_file_input(stream_type & stream,
                     file_format const &,

--- a/include/seqan3/io/sequence_file/input.hpp
+++ b/include/seqan3/io/sequence_file/input.hpp
@@ -42,16 +42,16 @@ namespace seqan3
 {
 
 // ----------------------------------------------------------------------------
-// sequence_file_input_traits_concept
+// SequenceFileInputTraits
 // ----------------------------------------------------------------------------
 
-/*!\interface seqan3::sequence_file_input_traits_concept <>
+/*!\interface seqan3::SequenceFileInputTraits <>
  * \brief The requirements a traits_type for seqan3::sequence_file_input must meet.
  * \ingroup sequence
  */
-/*!\name Requirements for seqan3::sequence_file_input_traits_concept
- * \brief You can expect these **member types** of all types that satisfy seqan3::sequence_file_input_traits_concept.
- * \memberof seqan3::sequence_file_input_traits_concept
+/*!\name Requirements for seqan3::SequenceFileInputTraits
+ * \brief You can expect these **member types** of all types that satisfy seqan3::SequenceFileInputTraits.
+ * \memberof seqan3::SequenceFileInputTraits
  *
  * \details
  *
@@ -62,11 +62,11 @@ namespace seqan3
  * \{
  */
 /*!\typedef using sequence_alphabet
- * \memberof seqan3::sequence_file_input_traits_concept
+ * \memberof seqan3::SequenceFileInputTraits
  * \brief Alphabet of the characters for the seqan3::field::SEQ; must satisfy seqan3::alphabet_concept.
  */
 /*!\typedef using sequence_legal_alphabet
- * \memberof seqan3::sequence_file_input_traits_concept
+ * \memberof seqan3::SequenceFileInputTraits
  * \brief Intermediate alphabet for seqan3::field::SEQ; must satisfy seqan3::alphabet_concept and be convertible to
  * `sequence_alphabet`.
  *
@@ -78,47 +78,47 @@ namespace seqan3
  * character and produce an error.
  */
 /*!\typedef using sequence_container
- * \memberof seqan3::sequence_file_input_traits_concept
+ * \memberof seqan3::SequenceFileInputTraits
  * \brief Type template of the seqan3::field::SEQ, a container template over `sequence_alphabet`;
  * must satisfy seqan3::sequence_container_concept.
  */
 /*!\typedef using sequence_container_container
- * \memberof seqan3::sequence_file_input_traits_concept
+ * \memberof seqan3::SequenceFileInputTraits
  * \brief Type template of a column of seqan3::field::SEQ, a container template that can hold multiple
  * `sequence_container`; must satisfy seqan3::sequence_container_concept.
  */
 /*!\typedef using id_alphabet
- * \memberof seqan3::sequence_file_input_traits_concept
+ * \memberof seqan3::SequenceFileInputTraits
  * \brief Alphabet of the characters for the seqan3::field::ID; must satisfy seqan3::alphabet_concept.
  */
 /*!\typedef using id_container
- * \memberof seqan3::sequence_file_input_traits_concept
+ * \memberof seqan3::SequenceFileInputTraits
  * \brief Type template of the seqan3::field::ID, a container template over `id_alphabet`;
  * must satisfy seqan3::sequence_container_concept.
  */
 /*!\typedef using id_container_container
- * \memberof seqan3::sequence_file_input_traits_concept
+ * \memberof seqan3::SequenceFileInputTraits
  * \brief Type template of a column of seqan3::field::ID, a container template that can hold multiple
  * `id_container`; must satisfy seqan3::sequence_container_concept.
  */
 /*!\typedef using quality_alphabet
- * \memberof seqan3::sequence_file_input_traits_concept
+ * \memberof seqan3::SequenceFileInputTraits
  * \brief Alphabet of the characters for the seqan3::field::QUAL; must satisfy seqan3::QualityAlphabet.
  */
 /*!\typedef using quality_container
- * \memberof seqan3::sequence_file_input_traits_concept
+ * \memberof seqan3::SequenceFileInputTraits
  * \brief Type template of the seqan3::field::QUAL, a container template over `quality_alphabet`;
  * must satisfy seqan3::sequence_container_concept.
  */
 /*!\typedef using quality_container_container
- * \memberof seqan3::sequence_file_input_traits_concept
+ * \memberof seqan3::SequenceFileInputTraits
  * \brief Type template of a column of seqan3::field::QUAL, a container template that can hold multiple
  * `quality_container`; must satisfy seqan3::sequence_container_concept.
  */
 //!\}
 //!\cond
 template <typename t>
-SEQAN3_CONCEPT sequence_file_input_traits_concept = requires (t v)
+concept SequenceFileInputTraits = requires (t v)
 {
     requires alphabet_concept<typename t::sequence_alphabet>;
     requires alphabet_concept<typename t::sequence_legal_alphabet>;
@@ -144,7 +144,7 @@ SEQAN3_CONCEPT sequence_file_input_traits_concept = requires (t v)
 // ----------------------------------------------------------------------------
 
 /*!\brief The default traits for seqan3::sequence_file_input
- * \implements sequence_file_input_traits_concept
+ * \implements SequenceFileInputTraits
  * \ingroup sequence
  *
  * \details
@@ -171,7 +171,7 @@ SEQAN3_CONCEPT sequence_file_input_traits_concept = requires (t v)
 struct sequence_file_input_default_traits_dna
 {
     /*!\name Member types
-     * \brief Definitions to satisfy seqan3::sequence_file_input_traits_concept.
+     * \brief Definitions to satisfy seqan3::SequenceFileInputTraits.
      * \{
      */
     using sequence_alphabet                 = dna5;
@@ -200,7 +200,7 @@ struct sequence_file_input_default_traits_dna
 struct sequence_file_input_default_traits_aa : sequence_file_input_default_traits_dna
 {
     /*!\name Member types
-     * \brief Definitions to satisfy seqan3::sequence_file_input_traits_concept.
+     * \brief Definitions to satisfy seqan3::SequenceFileInputTraits.
      * \{
      */
     using sequence_alphabet = aa27;
@@ -215,7 +215,7 @@ struct sequence_file_input_default_traits_aa : sequence_file_input_default_trait
 /*!\brief A class for reading sequence files, e.g. FASTA, FASTQ ...
  * \ingroup sequence
  * \tparam traits_type          An auxiliary type that defines certain member types and constants, must satisfy
- * seqan3::sequence_file_input_traits_concept.
+ * seqan3::SequenceFileInputTraits.
  * \tparam selected_field_ids   A seqan3::fields type with the list and order of desired record entries; all fields
  * must be in seqan3::sequence_file_input::field_ids.
  * \tparam valid_formats        A seqan3::type_list of the selectable formats (each must meet
@@ -426,7 +426,7 @@ struct sequence_file_input_default_traits_aa : sequence_file_input_default_trait
  *
  * Note that for this to make sense, your storage data types need to be identical to the corresponding column types
  * of the file. If you require different column types you can specify you own traits, see
- * seqan3::sequence_file_input_traits_concept.
+ * seqan3::SequenceFileInputTraits.
  *
  * ### Formats
  *
@@ -434,7 +434,7 @@ struct sequence_file_input_default_traits_aa : sequence_file_input_default_trait
  */
 
 template <
-    sequence_file_input_traits_concept                       traits_type_        = sequence_file_input_default_traits_dna,
+    SequenceFileInputTraits                       traits_type_        = sequence_file_input_default_traits_dna,
     detail::fields_concept                                   selected_field_ids_ = fields<field::SEQ,
                                                                                           field::ID,
                                                                                           field::QUAL>,
@@ -946,7 +946,7 @@ sequence_file_input(stream_type & stream,
 namespace std
 {
 //!\brief std::tuple_size overload for column-like access. [metafunction specialisation for seqan3::sequence_file_input]
-template <seqan3::sequence_file_input_traits_concept                       traits_type,
+template <seqan3::SequenceFileInputTraits                       traits_type,
           seqan3::detail::fields_concept                                selected_field_ids,
           seqan3::detail::TypeListOfSequenceFileInputFormats valid_formats,
           seqan3::char_concept                                             stream_char_t>
@@ -958,7 +958,7 @@ struct tuple_size<seqan3::sequence_file_input<traits_type, selected_field_ids, v
 
 //!\brief std::tuple_element overload for column-like access. [metafunction specialisation for seqan3::sequence_file_input]
 template <size_t                                                        elem_no,
-          seqan3::sequence_file_input_traits_concept                       traits_type,
+          seqan3::SequenceFileInputTraits                       traits_type,
           seqan3::detail::fields_concept                                selected_field_ids,
           seqan3::detail::TypeListOfSequenceFileInputFormats valid_formats,
           seqan3::char_concept                                             stream_char_t>

--- a/include/seqan3/io/sequence_file/input_format_concept.hpp
+++ b/include/seqan3/io/sequence_file/input_format_concept.hpp
@@ -6,7 +6,7 @@
 // -----------------------------------------------------------------------------------------------------
 
 /*!\file
- * \brief Provides seqan3::sequence_file_input_format_concept and auxiliary classes.
+ * \brief Provides seqan3::SequenceFileInputFormat and auxiliary classes.
  * \author Jörg Winkler <j.winkler AT fu-berlin.de>
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  */
@@ -26,7 +26,7 @@
 namespace seqan3
 {
 
-/*!\interface seqan3::sequence_file_input_format_concept <>
+/*!\interface seqan3::SequenceFileInputFormat <>
  * \brief The generic concept for sequence file in formats.
  * \ingroup sequence
  *
@@ -38,7 +38,7 @@ namespace seqan3
  */
 //!\cond
 template <typename t>
-SEQAN3_CONCEPT sequence_file_input_format_concept = requires (t                                     & v,
+SEQAN3_CONCEPT SequenceFileInputFormat = requires (t                                     & v,
                                                          std::ifstream                         & f,
                                                          sequence_file_input_options<dna5, false> & options,
                                                          dna5_vector                           & seq,
@@ -54,16 +54,16 @@ SEQAN3_CONCEPT sequence_file_input_format_concept = requires (t                 
 };
 //!\endcond
 
-/*!\name Requirements for seqan3::sequence_file_input_format_concept
- * \brief You can expect these **members** on all types that implement seqan3::sequence_file_input_format_concept.
- * \memberof seqan3::sequence_file_input_format_concept
+/*!\name Requirements for seqan3::SequenceFileInputFormat
+ * \brief You can expect these **members** on all types that implement seqan3::SequenceFileInputFormat.
+ * \memberof seqan3::SequenceFileInputFormat
  * \{
  */
 
 /*!\fn void read(stream_type & stream, seqan3::sequence_file_input_options const & options, seq_type & sequence,
  *               id_type & id, qual_type & qualities)
  * \brief Read from the specified stream and back-insert into the given field buffers.
- * \memberof seqan3::sequence_file_input_format_concept
+ * \memberof seqan3::SequenceFileInputFormat
  * \tparam stream_type      Input stream, must satisfy seqan3::istream_concept with `char`.
  * \tparam seq_type         Type of the seqan3::field::SEQ input; must satisfy std::ranges::OutputRange
  * over a seqan3::alphabet_concept.
@@ -89,7 +89,7 @@ SEQAN3_CONCEPT sequence_file_input_format_concept = requires (t                 
  *     a specialisation of seqan3::qualified and the second template parameter to
  *     seqan3::sequence_file_input_options must be set to true.
  */
- /*!\var static inline std::vector<std::string> seqan3::sequence_file_input_format_concept::file_extensions
+ /*!\var static inline std::vector<std::string> seqan3::SequenceFileInputFormat::file_extensions
  * \brief The format type is required to provide a vector of all supported file extensions.
  */
 //!\}
@@ -100,7 +100,7 @@ namespace seqan3::detail
 {
 
 /*!\brief Auxiliary value metafuncton that checks whether a type is a seqan3::type_list and all types meet
- * seqan3::sequence_file_input_format_concept [default is false].
+ * seqan3::SequenceFileInputFormat [default is false].
  * \ingroup core
  * \see seqan3::type_list_of_sequence_file_input_formats_concept
  */
@@ -108,16 +108,16 @@ template <typename t>
 constexpr bool is_type_list_of_sequence_file_input_formats_v = false;
 
 /*!\brief Auxiliary value metafuncton that checks whether a type is a seqan3::type_list and all types meet
- * seqan3::sequence_file_input_format_concept [overload].
+ * seqan3::SequenceFileInputFormat [overload].
  * \ingroup core
   * \see seqan3::type_list_of_sequence_file_input_formats_concept
  */
 template <typename ... ts>
 constexpr bool is_type_list_of_sequence_file_input_formats_v<type_list<ts...>> =
-    (sequence_file_input_format_concept<ts> && ...);
+    (SequenceFileInputFormat<ts> && ...);
 
 /*!\brief Auxiliary concept that checks whether a type is a seqan3::type_list and all types meet
- *        seqan3::sequence_file_input_format_concept.
+ *        seqan3::SequenceFileInputFormat.
  * \ingroup core
  * \see seqan3::is_type_list_of_sequence_file_formats_v
  */

--- a/include/seqan3/io/sequence_file/input_format_concept.hpp
+++ b/include/seqan3/io/sequence_file/input_format_concept.hpp
@@ -38,13 +38,13 @@ namespace seqan3
  */
 //!\cond
 template <typename t>
-SEQAN3_CONCEPT SequenceFileInputFormat = requires (t                                     & v,
-                                                         std::ifstream                         & f,
-                                                         sequence_file_input_options<dna5, false> & options,
-                                                         dna5_vector                           & seq,
-                                                         std::string                           & id,
-                                                         std::vector<phred42>                  & qual,
-                                                         std::vector<dna5q>                    & seq_qual)
+SEQAN3_CONCEPT SequenceFileInputFormat = requires (t                                        & v,
+                                                   std::ifstream                            & f,
+                                                   sequence_file_input_options<dna5, false> & options,
+                                                   dna5_vector                              & seq,
+                                                   std::string                              & id,
+                                                   std::vector<phred42>                     & qual,
+                                                   std::vector<dna5q>                       & seq_qual)
 {
     t::file_extensions;
 
@@ -123,5 +123,4 @@ constexpr bool is_type_list_of_sequence_file_input_formats_v<type_list<ts...>> =
  */
 template <typename t>
 SEQAN3_CONCEPT TypeListOfSequenceFileInputFormats = is_type_list_of_sequence_file_input_formats_v<t>;
-
 } // namespace seqan3::detail

--- a/include/seqan3/io/sequence_file/input_format_concept.hpp
+++ b/include/seqan3/io/sequence_file/input_format_concept.hpp
@@ -102,7 +102,7 @@ namespace seqan3::detail
 /*!\brief Auxiliary value metafuncton that checks whether a type is a seqan3::type_list and all types meet
  * seqan3::SequenceFileInputFormat [default is false].
  * \ingroup core
- * \see seqan3::type_list_of_sequence_file_input_formats_concept
+ * \see seqan3::TypeListOfSequenceFileInputFormats
  */
 template <typename t>
 constexpr bool is_type_list_of_sequence_file_input_formats_v = false;
@@ -110,7 +110,7 @@ constexpr bool is_type_list_of_sequence_file_input_formats_v = false;
 /*!\brief Auxiliary value metafuncton that checks whether a type is a seqan3::type_list and all types meet
  * seqan3::SequenceFileInputFormat [overload].
  * \ingroup core
-  * \see seqan3::type_list_of_sequence_file_input_formats_concept
+  * \see seqan3::TypeListOfSequenceFileInputFormats
  */
 template <typename ... ts>
 constexpr bool is_type_list_of_sequence_file_input_formats_v<type_list<ts...>> =
@@ -122,6 +122,6 @@ constexpr bool is_type_list_of_sequence_file_input_formats_v<type_list<ts...>> =
  * \see seqan3::is_type_list_of_sequence_file_formats_v
  */
 template <typename t>
-SEQAN3_CONCEPT type_list_of_sequence_file_input_formats_concept = is_type_list_of_sequence_file_input_formats_v<t>;
+SEQAN3_CONCEPT TypeListOfSequenceFileInputFormats = is_type_list_of_sequence_file_input_formats_v<t>;
 
 } // namespace seqan3::detail

--- a/include/seqan3/io/sequence_file/input_format_concept.hpp
+++ b/include/seqan3/io/sequence_file/input_format_concept.hpp
@@ -64,7 +64,7 @@ SEQAN3_CONCEPT SequenceFileInputFormat = requires (t                            
  *               id_type & id, qual_type & qualities)
  * \brief Read from the specified stream and back-insert into the given field buffers.
  * \memberof seqan3::SequenceFileInputFormat
- * \tparam stream_type      Input stream, must satisfy seqan3::istream_concept with `char`.
+ * \tparam stream_type      Input stream, must satisfy seqan3::IStream with `char`.
  * \tparam seq_type         Type of the seqan3::field::SEQ input; must satisfy std::ranges::OutputRange
  * over a seqan3::alphabet_concept.
  * \tparam id_type          Type of the seqan3::field::ID input; must satisfy std::ranges::OutputRange

--- a/include/seqan3/io/sequence_file/output.hpp
+++ b/include/seqan3/io/sequence_file/output.hpp
@@ -51,7 +51,7 @@ namespace seqan3
  * \tparam selected_field_ids   A seqan3::fields type with the list and order of fields IDs; only relevant if these
  * can't be deduced.
  * \tparam valid_formats        A seqan3::type_list of the selectable formats (each must meet
- * seqan3::sequence_file_output_format_concept).
+ * seqan3::SequenceFileOutputFormat).
  * \tparam stream_char_type     The type of the underlying stream device(s); must model seqan3::char_concept.
  * \details
  *
@@ -342,7 +342,7 @@ public:
     }
 
     /*!\brief Construct from an existing stream and with specified format.
-     * \tparam file_format   The format of the file in the stream, must satisfy seqan3::sequence_file_output_format_concept.
+     * \tparam file_format   The format of the file in the stream, must satisfy seqan3::SequenceFileOutputFormat.
      * \param[in,out] stream The stream to write to, must be derived of std::basic_ostream<stream_char_t>.
      * \param[in] format_tag The file format tag.
      * \param[in] fields_tag A seqan3::fields tag. [optional]
@@ -357,7 +357,7 @@ public:
      * See the section on \link io_compression compression and decompression \endlink for more information.
      */
     template <ostream_concept2 stream_t,
-              sequence_file_output_format_concept file_format>
+              SequenceFileOutputFormat file_format>
     sequence_file_output(stream_t                 & stream,
                          file_format        const & SEQAN3_DOXYGEN_ONLY(format_tag),
                          selected_field_ids const & SEQAN3_DOXYGEN_ONLY(fields_tag) = selected_field_ids{}) :
@@ -371,7 +371,7 @@ public:
 
     //!\overload
     template <ostream_concept2 stream_t,
-              sequence_file_output_format_concept file_format>
+              SequenceFileOutputFormat file_format>
     sequence_file_output(stream_t                && stream,
                          file_format        const & SEQAN3_DOXYGEN_ONLY(format_tag),
                          selected_field_ids const & SEQAN3_DOXYGEN_ONLY(fields_tag) = selected_field_ids{}) :
@@ -910,7 +910,7 @@ protected:
  * \{
  */
 template <ostream_concept2                     stream_t,
-          sequence_file_output_format_concept file_format,
+          SequenceFileOutputFormat file_format,
           detail::fields_concept              selected_field_ids>
 sequence_file_output(stream_t &&,
                      file_format const &,
@@ -920,7 +920,7 @@ sequence_file_output(stream_t &&,
                             typename std::remove_reference_t<stream_t>::char_type>;
 
 template <ostream_concept2                     stream_t,
-          sequence_file_output_format_concept file_format,
+          SequenceFileOutputFormat file_format,
           detail::fields_concept              selected_field_ids>
 sequence_file_output(stream_t &,
                      file_format const &,

--- a/include/seqan3/io/sequence_file/output.hpp
+++ b/include/seqan3/io/sequence_file/output.hpp
@@ -909,9 +909,9 @@ protected:
  * \relates seqan3::sequence_file_output
  * \{
  */
-template <OStream2                            stream_t,
-          SequenceFileOutputFormat            file_format,
-          detail::fields_concept              selected_field_ids>
+template <OStream2                 stream_t,
+          SequenceFileOutputFormat file_format,
+          detail::fields_concept   selected_field_ids>
 sequence_file_output(stream_t &&,
                      file_format const &,
                      selected_field_ids const &)
@@ -919,9 +919,9 @@ sequence_file_output(stream_t &&,
                             type_list<file_format>,
                             typename std::remove_reference_t<stream_t>::char_type>;
 
-template <OStream2                             stream_t,
-          SequenceFileOutputFormat            file_format,
-          detail::fields_concept              selected_field_ids>
+template <OStream2                 stream_t,
+          SequenceFileOutputFormat file_format,
+          detail::fields_concept   selected_field_ids>
 sequence_file_output(stream_t &,
                      file_format const &,
                      selected_field_ids const &)

--- a/include/seqan3/io/sequence_file/output.hpp
+++ b/include/seqan3/io/sequence_file/output.hpp
@@ -356,7 +356,7 @@ public:
      * want compression.
      * See the section on \link io_compression compression and decompression \endlink for more information.
      */
-    template <ostream_concept2 stream_t,
+    template <OStream2 stream_t,
               SequenceFileOutputFormat file_format>
     sequence_file_output(stream_t                 & stream,
                          file_format        const & SEQAN3_DOXYGEN_ONLY(format_tag),
@@ -370,7 +370,7 @@ public:
     }
 
     //!\overload
-    template <ostream_concept2 stream_t,
+    template <OStream2 stream_t,
               SequenceFileOutputFormat file_format>
     sequence_file_output(stream_t                && stream,
                          file_format        const & SEQAN3_DOXYGEN_ONLY(format_tag),
@@ -909,8 +909,8 @@ protected:
  * \relates seqan3::sequence_file_output
  * \{
  */
-template <ostream_concept2                     stream_t,
-          SequenceFileOutputFormat file_format,
+template <OStream2                            stream_t,
+          SequenceFileOutputFormat            file_format,
           detail::fields_concept              selected_field_ids>
 sequence_file_output(stream_t &&,
                      file_format const &,
@@ -919,8 +919,8 @@ sequence_file_output(stream_t &&,
                             type_list<file_format>,
                             typename std::remove_reference_t<stream_t>::char_type>;
 
-template <ostream_concept2                     stream_t,
-          SequenceFileOutputFormat file_format,
+template <OStream2                             stream_t,
+          SequenceFileOutputFormat            file_format,
           detail::fields_concept              selected_field_ids>
 sequence_file_output(stream_t &,
                      file_format const &,

--- a/include/seqan3/io/sequence_file/output.hpp
+++ b/include/seqan3/io/sequence_file/output.hpp
@@ -239,7 +239,7 @@ namespace seqan3
  */
 
 template <detail::fields_concept selected_field_ids_ = fields<field::SEQ, field::ID, field::QUAL>,
-          detail::type_list_of_sequence_file_output_formats_concept valid_formats_ =
+          detail::TypeListOfSequenceFileOutputFormats valid_formats_ =
               type_list<sequence_file_format_fasta, sequence_file_format_fastq>,
           char_concept stream_char_type_ = char>
 class sequence_file_output

--- a/include/seqan3/io/sequence_file/output_format_concept.hpp
+++ b/include/seqan3/io/sequence_file/output_format_concept.hpp
@@ -64,7 +64,7 @@ SEQAN3_CONCEPT SequenceFileOutputFormat = requires (t                         & 
  *                id_type && id, qual_type && qualities)
  * \brief Write the given fields to the specified stream.
  * \memberof seqan3::SequenceFileOutputFormat
- * \tparam stream_type      Output stream, must satisfy seqan3::ostream_concept with `char`.
+ * \tparam stream_type      Output stream, must satisfy seqan3::OStream with `char`.
  * \tparam seq_type         Type of the seqan3::field::SEQ output; must satisfy std::ranges::OutputRange
  * over a seqan3::alphabet_concept.
  * \tparam id_type          Type of the seqan3::field::ID output; must satisfy std::ranges::OutputRange

--- a/include/seqan3/io/sequence_file/output_format_concept.hpp
+++ b/include/seqan3/io/sequence_file/output_format_concept.hpp
@@ -25,7 +25,7 @@
 namespace seqan3
 {
 
-/*!\interface seqan3::sequence_file_output_format_concept <>
+/*!\interface seqan3::SequenceFileOutputFormat <>
  * \brief The generic concept for sequence file out formats.
  * \ingroup sequence
  *
@@ -37,7 +37,7 @@ namespace seqan3
  */
 //!\cond
 template <typename t>
-SEQAN3_CONCEPT sequence_file_output_format_concept = requires (t                         & v,
+SEQAN3_CONCEPT SequenceFileOutputFormat = requires (t                         & v,
                                                           std::ofstream             & f,
                                                           sequence_file_output_options & options,
                                                           dna5_vector               & seq,
@@ -54,16 +54,16 @@ SEQAN3_CONCEPT sequence_file_output_format_concept = requires (t                
 };
 //!\endcond
 
-/*!\name Requirements for seqan3::sequence_file_output_format_concept
- * \brief You can expect these **members** on all types that implement seqan3::sequence_file_output_format_concept.
- * \memberof seqan3::sequence_file_output_format_concept
+/*!\name Requirements for seqan3::SequenceFileOutputFormat
+ * \brief You can expect these **members** on all types that implement seqan3::SequenceFileOutputFormat.
+ * \memberof seqan3::SequenceFileOutputFormat
  * \{
  */
 
 /*!\fn void write(stream_type & stream, seqan3::sequence_file_output_options const & options, seq_type && sequence,
  *                id_type && id, qual_type && qualities)
  * \brief Write the given fields to the specified stream.
- * \memberof seqan3::sequence_file_output_format_concept
+ * \memberof seqan3::SequenceFileOutputFormat
  * \tparam stream_type      Output stream, must satisfy seqan3::ostream_concept with `char`.
  * \tparam seq_type         Type of the seqan3::field::SEQ output; must satisfy std::ranges::OutputRange
  * over a seqan3::alphabet_concept.
@@ -86,7 +86,7 @@ SEQAN3_CONCEPT sequence_file_output_format_concept = requires (t                
  *   * The format does not handle seqan3::field::SEQ_QUAL, instead seqan3::sequence_file_output splits it into two views
  *     and passes it to the format as if they were separate.
  */
-/*!\var static inline std::vector<std::string> seqan3::sequence_file_output_format_concept::file_extensions
+/*!\var static inline std::vector<std::string> seqan3::SequenceFileOutputFormat::file_extensions
  * \brief The format type is required to provide a vector of all supported file extensions.
  */
 
@@ -98,7 +98,7 @@ namespace seqan3::detail
 {
 
 /*!\brief Auxiliary value metafuncton that checks whether a type is a seqan3::type_list and all types meet
- * seqan3::sequence_file_output_format_concept [default is false].
+ * seqan3::SequenceFileOutputFormat [default is false].
  * \ingroup core
  * \see seqan3::type_list_of_sequence_file_output_formats_concept
  */
@@ -106,13 +106,13 @@ template <typename t>
 constexpr bool is_type_list_of_sequence_file_output_formats_v = false;
 
 /*!\brief Auxiliary value metafuncton that checks whether a type is a seqan3::type_list and all types meet
- * seqan3::sequence_file_output_format_concept [overload].
+ * seqan3::SequenceFileOutputFormat [overload].
  * \ingroup core
   * \see seqan3::type_list_of_sequence_file_output_formats_concept
  */
 template <typename ... ts>
 constexpr bool is_type_list_of_sequence_file_output_formats_v<type_list<ts...>> =
-    (sequence_file_output_format_concept<ts> && ...);
+    (SequenceFileOutputFormat<ts> && ...);
 
 /*!\brief Auxiliary concept that checks whether a type is a seqan3::type_list and all types meet seqan3::sequence_file_format_concept.
  * \ingroup core

--- a/include/seqan3/io/sequence_file/output_format_concept.hpp
+++ b/include/seqan3/io/sequence_file/output_format_concept.hpp
@@ -6,7 +6,7 @@
 // -----------------------------------------------------------------------------------------------------
 
 /*!\file
- * \brief Provides seqan3::sequence_file_format_out_concept and auxiliary classes.
+ * \brief Provides seqan3::SequenceFileFormatOut and auxiliary classes.
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  */
 

--- a/include/seqan3/io/sequence_file/output_format_concept.hpp
+++ b/include/seqan3/io/sequence_file/output_format_concept.hpp
@@ -100,7 +100,7 @@ namespace seqan3::detail
 /*!\brief Auxiliary value metafuncton that checks whether a type is a seqan3::type_list and all types meet
  * seqan3::SequenceFileOutputFormat [default is false].
  * \ingroup core
- * \see seqan3::type_list_of_sequence_file_output_formats_concept
+ * \see seqan3::TypeListOfSequenceFileOutputFormats
  */
 template <typename t>
 constexpr bool is_type_list_of_sequence_file_output_formats_v = false;
@@ -108,7 +108,7 @@ constexpr bool is_type_list_of_sequence_file_output_formats_v = false;
 /*!\brief Auxiliary value metafuncton that checks whether a type is a seqan3::type_list and all types meet
  * seqan3::SequenceFileOutputFormat [overload].
  * \ingroup core
-  * \see seqan3::type_list_of_sequence_file_output_formats_concept
+  * \see seqan3::TypeListOfSequenceFileOutputFormats
  */
 template <typename ... ts>
 constexpr bool is_type_list_of_sequence_file_output_formats_v<type_list<ts...>> =
@@ -119,5 +119,5 @@ constexpr bool is_type_list_of_sequence_file_output_formats_v<type_list<ts...>> 
  * \see seqan3::is_type_list_of_sequence_file_formats_v
  */
 template <typename t>
-SEQAN3_CONCEPT type_list_of_sequence_file_output_formats_concept = is_type_list_of_sequence_file_output_formats_v<t>;
+SEQAN3_CONCEPT TypeListOfSequenceFileOutputFormats = is_type_list_of_sequence_file_output_formats_v<t>;
 } // namespace seqan3::detail

--- a/include/seqan3/io/sequence_file/output_format_concept.hpp
+++ b/include/seqan3/io/sequence_file/output_format_concept.hpp
@@ -114,7 +114,7 @@ template <typename ... ts>
 constexpr bool is_type_list_of_sequence_file_output_formats_v<type_list<ts...>> =
     (SequenceFileOutputFormat<ts> && ...);
 
-/*!\brief Auxiliary concept that checks whether a type is a seqan3::type_list and all types meet seqan3::sequence_file_format_concept.
+/*!\brief Auxiliary concept that checks whether a type is a seqan3::type_list and all types meet seqan3::SequenceFileFormat.
  * \ingroup core
  * \see seqan3::is_type_list_of_sequence_file_formats_v
  */

--- a/include/seqan3/io/sequence_file/output_format_concept.hpp
+++ b/include/seqan3/io/sequence_file/output_format_concept.hpp
@@ -37,13 +37,13 @@ namespace seqan3
  */
 //!\cond
 template <typename t>
-SEQAN3_CONCEPT SequenceFileOutputFormat = requires (t                         & v,
-                                                          std::ofstream             & f,
-                                                          sequence_file_output_options & options,
-                                                          dna5_vector               & seq,
-                                                          std::string               & id,
-                                                          std::vector<phred42>   & qual,
-                                                          std::vector<dna5q>        & seq_qual)
+SEQAN3_CONCEPT SequenceFileOutputFormat = requires (t                            & v,
+                                                    std::ofstream                & f,
+                                                    sequence_file_output_options & options,
+                                                    dna5_vector                  & seq,
+                                                    std::string                  & id,
+                                                    std::vector<phred42>         & qual,
+                                                    std::vector<dna5q>           & seq_qual)
 {
     t::file_extensions;
 

--- a/include/seqan3/io/stream/concept.hpp
+++ b/include/seqan3/io/stream/concept.hpp
@@ -94,7 +94,7 @@ SEQAN3_CONCEPT OStream2 = requires { typename std::remove_reference_t<stream_typ
   */
 //!\}
 
-/*!\interface seqan3::istream_concept <>
+/*!\interface seqan3::IStream <>
  * \ingroup stream
  * \brief Concept for input streams.
  *
@@ -104,8 +104,8 @@ SEQAN3_CONCEPT OStream2 = requires { typename std::remove_reference_t<stream_typ
  */
 //!\cond
 template <typename stream_type, typename value_type>
-SEQAN3_CONCEPT istream_concept = std::is_base_of_v<std::ios_base, std::remove_reference_t<stream_type>> &&
-                               requires (stream_type & is, value_type & val)
+SEQAN3_CONCEPT IStream = std::is_base_of_v<std::ios_base, std::remove_reference_t<stream_type>> &&
+                         requires (stream_type & is, value_type & val)
 {
     typename std::remove_reference_t<stream_type>::char_type;
     typename std::remove_reference_t<stream_type>::traits_type;
@@ -118,18 +118,18 @@ SEQAN3_CONCEPT istream_concept = std::is_base_of_v<std::ios_base, std::remove_re
 };
 
 template <typename stream_type>
-SEQAN3_CONCEPT istream_concept2 = requires { typename std::remove_reference_t<stream_type>::char_type; } &&
-                           istream_concept<stream_type, typename std::remove_reference_t<stream_type>::char_type>;
+SEQAN3_CONCEPT IStream2 = requires { typename std::remove_reference_t<stream_type>::char_type; } &&
+                          IStream<stream_type, typename std::remove_reference_t<stream_type>::char_type>;
 //!\endcond
 
-/*!\name Requirements for seqan3::istream_concept
- * \relates seqan3::istream_concept
- * \brief You can expect these member types and the free function on all types that satisfy seqan3::istream_concept.
+/*!\name Requirements for seqan3::IStream
+ * \relates seqan3::IStream
+ * \brief You can expect these member types and the free function on all types that satisfy seqan3::IStream.
  * \{
  */
 /*!\fn      std::basic_istream<char_type, traits_type> & operator>>(value_type val);
  * \brief   (un)-formatted input operator for the respective type on the underlying stream.
- * \relates seqan3::istream_concept
+ * \relates seqan3::IStream
  * \param   val The value to read from the stream.
  * \returns A reference to a std::basic_istream<char_type, traits_type>.
  *
@@ -142,33 +142,33 @@ SEQAN3_CONCEPT istream_concept2 = requires { typename std::remove_reference_t<st
  */
 
  /*!\typedef typename stream::char_type char_type
-  * \memberof seqan3::istream_concept
+  * \memberof seqan3::IStream
   * \brief Declares the associated char type.
   */
 
  /*!\typedef typename stream::traits_type traits_type
-  * \memberof seqan3::istream_concept
+  * \memberof seqan3::IStream
   * \brief Declares the associated traits type.
   */
 
  /*!\typedef typename stream::int_type int_type
-  * \memberof seqan3::istream_concept
+  * \memberof seqan3::IStream
   * \brief Declares the associated int type.
   */
 
  /*!\typedef typename stream::pos_type pos_type
-  * \memberof seqan3::istream_concept
+  * \memberof seqan3::IStream
   * \brief Declares the associated pos type.
   */
 
  /*!\typedef typename stream::off_type off_type
-  * \memberof seqan3::istream_concept
+  * \memberof seqan3::IStream
   * \brief Declares the associated off type.
   */
 //!\}
 
 /*!\interface seqan3::stream_concept <>
- * \extends seqan3::istream_concept
+ * \extends seqan3::IStream
  * \extends seqan3::OStream
  * \brief Concept for i/o streams permitting both directions.
  * \ingroup stream
@@ -179,7 +179,7 @@ SEQAN3_CONCEPT istream_concept2 = requires { typename std::remove_reference_t<st
 //!\cond
 template <typename stream_type, typename value_type>
 SEQAN3_CONCEPT Stream = OStream<stream_type, value_type> &&
-                        istream_concept<stream_type, value_type>;
+                        IStream<stream_type, value_type>;
 
 //!\endcond
 

--- a/include/seqan3/io/stream/concept.hpp
+++ b/include/seqan3/io/stream/concept.hpp
@@ -167,7 +167,7 @@ SEQAN3_CONCEPT IStream2 = requires { typename std::remove_reference_t<stream_typ
   */
 //!\}
 
-/*!\interface seqan3::stream_concept <>
+/*!\interface seqan3::Stream <>
  * \extends seqan3::IStream
  * \extends seqan3::OStream
  * \brief Concept for i/o streams permitting both directions.

--- a/include/seqan3/io/stream/concept.hpp
+++ b/include/seqan3/io/stream/concept.hpp
@@ -21,7 +21,7 @@
 
 namespace seqan3
 {
-/*!\interface seqan3::ostream_concept <>
+/*!\interface seqan3::OStream <>
  * \ingroup stream
  * \brief Concept for output streams.
  *
@@ -31,8 +31,8 @@ namespace seqan3
  */
 //!\cond
 template <typename stream_type, typename value_type>
-SEQAN3_CONCEPT ostream_concept = std::is_base_of_v<std::ios_base, std::remove_reference_t<stream_type>> &&
-                               requires (stream_type & os, value_type & val)
+SEQAN3_CONCEPT OStream = std::is_base_of_v<std::ios_base, std::remove_reference_t<stream_type>> &&
+                         requires (stream_type & os, value_type & val)
 {
     typename std::remove_reference_t<stream_type>::char_type;
     typename std::remove_reference_t<stream_type>::traits_type;
@@ -45,18 +45,18 @@ SEQAN3_CONCEPT ostream_concept = std::is_base_of_v<std::ios_base, std::remove_re
 };
 
 template <typename stream_type>
-SEQAN3_CONCEPT ostream_concept2 = requires { typename std::remove_reference_t<stream_type>::char_type; } &&
-                           ostream_concept<stream_type, typename std::remove_reference_t<stream_type>::char_type>;
+SEQAN3_CONCEPT OStream2 = requires { typename std::remove_reference_t<stream_type>::char_type; } &&
+                          OStream<stream_type, typename std::remove_reference_t<stream_type>::char_type>;
 //!\endcond
 
-/*!\name Requirements for seqan3::ostream_concept
- * \relates seqan3::ostream_concept
- * \brief You can expect these member types and the free function on all types that satisfy seqan3::ostream_concept.
+/*!\name Requirements for seqan3::OStream
+ * \relates seqan3::OStream
+ * \brief You can expect these member types and the free function on all types that satisfy seqan3::OStream.
  * \{
  */
 /*!\fn      std::basic_ostream<char_type, traits_type> & operator<<(value_type val);
  * \brief   (un)-formatted output operator for the respective type on the underlying stream.
- * \relates seqan3::ostream_concept
+ * \relates seqan3::OStream
  * \param   val The value to write into the stream.
  * \returns A reference to a std::basic_ostream<char_type, traits_type>.
  *
@@ -69,27 +69,27 @@ SEQAN3_CONCEPT ostream_concept2 = requires { typename std::remove_reference_t<st
  */
 
  /*!\typedef typename stream::char_type char_type
-  * \memberof seqan3::ostream_concept
+  * \memberof seqan3::OStream
   * \brief Declares the associated char type.
   */
 
  /*!\typedef typename stream::traits_type traits_type
-  * \memberof seqan3::ostream_concept
+  * \memberof seqan3::OStream
   * \brief Declares the associated traits type.
   */
 
  /*!\typedef typename stream::int_type int_type
-  * \memberof seqan3::ostream_concept
+  * \memberof seqan3::OStream
   * \brief Declares the associated int type.
   */
 
  /*!\typedef typename stream::pos_type pos_type
-  * \memberof seqan3::ostream_concept
+  * \memberof seqan3::OStream
   * \brief Declares the associated pos type.
   */
 
  /*!\typedef typename stream::off_type off_type
-  * \memberof seqan3::ostream_concept
+  * \memberof seqan3::OStream
   * \brief Declares the associated off type.
   */
 //!\}
@@ -169,7 +169,7 @@ SEQAN3_CONCEPT istream_concept2 = requires { typename std::remove_reference_t<st
 
 /*!\interface seqan3::stream_concept <>
  * \extends seqan3::istream_concept
- * \extends seqan3::ostream_concept
+ * \extends seqan3::OStream
  * \brief Concept for i/o streams permitting both directions.
  * \ingroup stream
  *
@@ -178,8 +178,8 @@ SEQAN3_CONCEPT istream_concept2 = requires { typename std::remove_reference_t<st
  */
 //!\cond
 template <typename stream_type, typename value_type>
-SEQAN3_CONCEPT stream_concept = ostream_concept<stream_type, value_type> &&
-                              istream_concept<stream_type, value_type>;
+SEQAN3_CONCEPT Stream = OStream<stream_type, value_type> &&
+                        istream_concept<stream_type, value_type>;
 
 //!\endcond
 

--- a/include/seqan3/io/stream/debug_stream.hpp
+++ b/include/seqan3/io/stream/debug_stream.hpp
@@ -73,7 +73,7 @@ constexpr bool add_enum_bitwise_operators<fmtflags2> = true;
  *
  * See seqan3::fmtflags2 for more details.
  *
- * \attention This class does not yet model seqan3::ostream_concept fully, \todo implement.
+ * \attention This class does not yet model seqan3::OStream fully, \todo implement.
  */
 class debug_stream_type
 {
@@ -264,7 +264,7 @@ inline debug_stream_type debug_stream{};
 template <alphabet_concept alphabet_t>
 inline debug_stream_type & operator<<(debug_stream_type & s, alphabet_t const l)
 //!\cond
-    requires !ostream_concept<std::ostream, alphabet_t>
+    requires !OStream<std::ostream, alphabet_t>
 //!\endcond
 {
     return s << to_char(l);

--- a/include/seqan3/io/stream/parse_condition_detail.hpp
+++ b/include/seqan3/io/stream/parse_condition_detail.hpp
@@ -121,7 +121,7 @@ SEQAN3_CONCEPT ParseCondition = requires
 //!\endcond
 
 /*!\name Requirements for seqan3::detail::ParseCondition
- * \brief You can expect the variable and the predicate function on all types that satisfy seqan3::ostream_concept.
+ * \brief You can expect the variable and the predicate function on all types that satisfy seqan3::OStream.
  * \{
  */
 /*!\fn      bool operator()(char_type c);

--- a/include/seqan3/io/stream/parse_condition_detail.hpp
+++ b/include/seqan3/io/stream/parse_condition_detail.hpp
@@ -87,7 +87,7 @@ inline constexpr_string constexpr condition_message_v
 };
 
 // ----------------------------------------------------------------------------
-// parse_condition_concept
+// ParseCondition
 // ----------------------------------------------------------------------------
 
 //!\cond
@@ -95,7 +95,7 @@ template <typename condition_t>
 class parse_condition_base;
 //!\endcond
 
-/*!\interface seqan3::detail::parse_condition_concept <>
+/*!\interface seqan3::detail::ParseCondition <>
  * \brief An internal concept to check if an object fulfills the requirements of a seqan3::detail::parse_condition.
  * \ingroup stream
  *
@@ -106,7 +106,7 @@ class parse_condition_base;
  */
 //!\cond
 template <typename condition_t>
-SEQAN3_CONCEPT parse_condition_concept = requires
+SEQAN3_CONCEPT ParseCondition = requires
 {
     requires std::Predicate<std::remove_reference_t<condition_t>, char>;
     requires std::is_base_of_v<parse_condition_base<remove_cvref_t<condition_t>>,
@@ -120,13 +120,13 @@ SEQAN3_CONCEPT parse_condition_concept = requires
 };
 //!\endcond
 
-/*!\name Requirements for seqan3::detail::parse_condition_concept
+/*!\name Requirements for seqan3::detail::ParseCondition
  * \brief You can expect the variable and the predicate function on all types that satisfy seqan3::ostream_concept.
  * \{
  */
 /*!\fn      bool operator()(char_type c);
  * \brief   Predicate function to test if `c` satisfies the given condition.
- * \memberof seqan3::detail::parse_condition_concept
+ * \memberof seqan3::detail::ParseCondition
  * \param   c The character to be tested.
  * \returns `true` on success, `false` otherwise.
  *
@@ -135,7 +135,7 @@ SEQAN3_CONCEPT parse_condition_concept = requires
  */
 
 /*!\var static constexpr auto msg
- * \memberof seqan3::detail::parse_condition_concept
+ * \memberof seqan3::detail::ParseCondition
  * \brief Defines the condition msg. The type is deduced from the constant expression in the definition of the variable.
  */
 //!\}
@@ -192,11 +192,11 @@ inline std::string make_printable(char const c)
 // ----------------------------------------------------------------------------
 
 //!\cond
-template <parse_condition_concept... condition_ts>
+template <ParseCondition... condition_ts>
     requires sizeof...(condition_ts) >= 2
 struct parse_condition_combiner;
 
-template <parse_condition_concept condition_t>
+template <ParseCondition condition_t>
 struct parse_condition_negator;
 //!\endcond
 
@@ -204,7 +204,7 @@ struct parse_condition_negator;
  *        parse conditions to add logical disjunction and negation operator.
  * \ingroup stream
  * \tparam derived_t The parse condition type to be extended with the logical operators.
- *                   Must model seqan3::detail::parse_condition_concept.
+ *                   Must model seqan3::detail::ParseCondition.
  */
 template <typename derived_t>
 struct parse_condition_base
@@ -216,8 +216,8 @@ struct parse_condition_base
      * \brief Adds logical operators to allow logical disjunction, conjunction and negation on parse conditions.
      * \{
      */
-    //!\brief Combines the result of two seqan3::detail::parse_condition_concept via logical disjunction.
-    template <parse_condition_concept rhs_t>
+    //!\brief Combines the result of two seqan3::detail::ParseCondition via logical disjunction.
+    template <ParseCondition rhs_t>
     constexpr auto operator||(rhs_t const &) const
     {
         return parse_condition_combiner<derived_t, rhs_t>{};
@@ -265,12 +265,12 @@ struct parse_condition_base
 // ----------------------------------------------------------------------------
 
 /*!\brief Logical disjunction operator for parse conditions.
- * \implements seqan3::detail::parse_condition_concept
+ * \implements seqan3::detail::ParseCondition
  * \tparam condition_ts Template parameter pack over all parse condition types. Must contain at least 2 template parameters.
- *                      Must model seqan3::detail::parse_condition_concept.
+ *                      Must model seqan3::detail::ParseCondition.
  * \ingroup stream
  */
-template <parse_condition_concept... condition_ts>
+template <ParseCondition... condition_ts>
 //!\cond
     requires sizeof...(condition_ts) >= 2
 //!\endcond
@@ -289,12 +289,12 @@ struct parse_condition_combiner : public parse_condition_base<parse_condition_co
 };
 
 /*!\brief Logical not operator for a parse condition.
- * \implements seqan3::detail::parse_condition_concept
+ * \implements seqan3::detail::ParseCondition
  * \tparam condition_t Template parameter to apply the not-operator for.
- *                     Must model seqan3::detail::parse_condition_concept.
+ *                     Must model seqan3::detail::ParseCondition.
  * \ingroup stream
  */
-template <parse_condition_concept condition_t>
+template <ParseCondition condition_t>
 struct parse_condition_negator : public parse_condition_base<parse_condition_negator<condition_t>>
 {
     //!\brief The message representing the negation of the associated condition.
@@ -315,7 +315,7 @@ struct parse_condition_negator : public parse_condition_base<parse_condition_neg
 
 /*!\brief Parse condition that checks if a given value is in the range of `rng_beg` and `interval_last`.
  * \ingroup stream
- * \implements seqan3::detail::parse_condition_concept
+ * \implements seqan3::detail::ParseCondition
  * \tparam interval_first non-type template parameter denoting the begin of the allowed range.
  *                        Must be less than or equal to `interval_last`.
  * \tparam interval_last non-type template parameter denoting the end of the allowed range.
@@ -357,7 +357,7 @@ struct is_in_interval_type : public parse_condition_base<is_in_interval_type<int
 
 /*!\brief Parse condition that checks if a given value is within the given alphabet `alphabet_t`.
  * \ingroup stream
- * \implements seqan3::detail::parse_condition_concept
+ * \implements seqan3::detail::ParseCondition
  * \tparam alphabet_t The alphabet type. Must model seqan3::alphabet_concept.
  */
 template <detail::constexpr_alphabet_concept alphabet_t>
@@ -392,7 +392,7 @@ public:
 
 /*!\brief Parse condition that checks if a given value is equal to `char_v`.
  * \ingroup stream
- * \implements seqan3::detail::parse_condition_concept
+ * \implements seqan3::detail::ParseCondition
  * \tparam alphabet_t non-type template parameter with the value that should be checked against.
  */
 template <int char_v>

--- a/include/seqan3/io/structure_file/format_vienna.hpp
+++ b/include/seqan3/io/structure_file/format_vienna.hpp
@@ -48,7 +48,7 @@
 namespace seqan3
 {
 /*!\brief       The Vienna format (dot bracket notation) for RNA sequences with secondary structure.
- * \implements  seqan3::structure_file_input_format_concept
+ * \implements  seqan3::StructureFileInputFormat
  * \implements  seqan3::StructureFileOutputFormat
  * \ingroup     structure_file
  *
@@ -105,7 +105,7 @@ public:
         { "fa" }
     };
 
-    //!\copydoc seqan3::structure_file_input_format_concept::read
+    //!\copydoc seqan3::StructureFileInputFormat::read
     template <typename stream_type,     // constraints checked by file
               typename seq_legal_alph_type,
               bool     structured_seq_combined,

--- a/include/seqan3/io/structure_file/format_vienna.hpp
+++ b/include/seqan3/io/structure_file/format_vienna.hpp
@@ -49,7 +49,7 @@ namespace seqan3
 {
 /*!\brief       The Vienna format (dot bracket notation) for RNA sequences with secondary structure.
  * \implements  seqan3::structure_file_input_format_concept
- * \implements  seqan3::structure_file_output_format_concept
+ * \implements  seqan3::StructureFileOutputFormat
  * \ingroup     structure_file
  *
  * \details
@@ -261,7 +261,7 @@ public:
         }
     }
 
-    //!\copydoc seqan3::structure_file_output_format_concept::write
+    //!\copydoc seqan3::StructureFileOutputFormat::write
     template <typename stream_type,     // constraints checked by file
               typename seq_type,        // other constraints checked inside function
               typename id_type,

--- a/include/seqan3/io/structure_file/input.hpp
+++ b/include/seqan3/io/structure_file/input.hpp
@@ -411,7 +411,7 @@ struct structure_file_input_default_traits_aa : structure_file_input_default_tra
  *                            must be in seqan3::structure_file_in::field_ids.
  * \tparam valid_formats      A seqan3::type_list of the selectable formats (each must meet
  *                            seqan3::StructureFileInputFormat).
- * \tparam stream_type        The type of the stream, must satisfy seqan3::istream_concept.
+ * \tparam stream_type        The type of the stream, must satisfy seqan3::IStream.
  * \details
  *
  * ### Introduction
@@ -639,7 +639,7 @@ template<structure_file_input_traits_concept traits_type_ = structure_file_input
          detail::fields_concept selected_field_ids_ = fields<field::SEQ, field::ID, field::STRUCTURE>,
          detail::TypeListOfStructureFileInputFormats valid_formats_
              = type_list<structure_file_format_vienna>,
-         istream_concept<char> stream_type_ = std::ifstream>
+         IStream<char> stream_type_ = std::ifstream>
 class structure_file_in
 {
 public:
@@ -1148,7 +1148,7 @@ protected:
  * \relates seqan3::structure_file_in
  * \{
  */
-template <istream_concept<char> stream_type,
+template <IStream<char> stream_type,
           StructureFileInputFormat file_format,
           detail::fields_concept selected_field_ids>
 structure_file_in(stream_type && _stream, file_format const &, selected_field_ids const &)
@@ -1172,7 +1172,7 @@ namespace std
 template<seqan3::structure_file_input_traits_concept traits_type,
          seqan3::detail::fields_concept selected_field_ids,
          seqan3::detail::TypeListOfStructureFileInputFormats valid_formats,
-         seqan3::istream_concept<char> stream_type>
+         seqan3::IStream<char> stream_type>
 struct tuple_size<seqan3::structure_file_in<traits_type, selected_field_ids, valid_formats, stream_type>>
 {
     //!\brief The value equals the number of selected fields in the file.
@@ -1186,7 +1186,7 @@ template<size_t elem_no,
          seqan3::structure_file_input_traits_concept traits_type,
          seqan3::detail::fields_concept selected_field_ids,
          seqan3::detail::TypeListOfStructureFileInputFormats valid_formats,
-         seqan3::istream_concept<char> stream_type>
+         seqan3::IStream<char> stream_type>
 struct tuple_element<elem_no, seqan3::structure_file_in<traits_type, selected_field_ids, valid_formats, stream_type>>
     : tuple_element<elem_no, typename seqan3::structure_file_in<traits_type,
                                                                 selected_field_ids,

--- a/include/seqan3/io/structure_file/input.hpp
+++ b/include/seqan3/io/structure_file/input.hpp
@@ -637,7 +637,7 @@ struct structure_file_input_default_traits_aa : structure_file_input_default_tra
  */
 template<structure_file_input_traits_concept traits_type_ = structure_file_input_default_traits_rna,
          detail::fields_concept selected_field_ids_ = fields<field::SEQ, field::ID, field::STRUCTURE>,
-         detail::type_list_of_structure_file_input_formats_concept valid_formats_
+         detail::TypeListOfStructureFileInputFormats valid_formats_
              = type_list<structure_file_format_vienna>,
          istream_concept<char> stream_type_ = std::ifstream>
 class structure_file_in
@@ -1171,7 +1171,7 @@ namespace std
  */
 template<seqan3::structure_file_input_traits_concept traits_type,
          seqan3::detail::fields_concept selected_field_ids,
-         seqan3::detail::type_list_of_structure_file_input_formats_concept valid_formats,
+         seqan3::detail::TypeListOfStructureFileInputFormats valid_formats,
          seqan3::istream_concept<char> stream_type>
 struct tuple_size<seqan3::structure_file_in<traits_type, selected_field_ids, valid_formats, stream_type>>
 {
@@ -1185,7 +1185,7 @@ struct tuple_size<seqan3::structure_file_in<traits_type, selected_field_ids, val
 template<size_t elem_no,
          seqan3::structure_file_input_traits_concept traits_type,
          seqan3::detail::fields_concept selected_field_ids,
-         seqan3::detail::type_list_of_structure_file_input_formats_concept valid_formats,
+         seqan3::detail::TypeListOfStructureFileInputFormats valid_formats,
          seqan3::istream_concept<char> stream_type>
 struct tuple_element<elem_no, seqan3::structure_file_in<traits_type, selected_field_ids, valid_formats, stream_type>>
     : tuple_element<elem_no, typename seqan3::structure_file_in<traits_type,

--- a/include/seqan3/io/structure_file/input.hpp
+++ b/include/seqan3/io/structure_file/input.hpp
@@ -410,7 +410,7 @@ struct structure_file_input_default_traits_aa : structure_file_input_default_tra
  * \tparam selected_field_ids A seqan3::fields type with the list and order of desired record entries; all fields
  *                            must be in seqan3::structure_file_in::field_ids.
  * \tparam valid_formats      A seqan3::type_list of the selectable formats (each must meet
- *                            seqan3::structure_file_input_format_concept).
+ *                            seqan3::StructureFileInputFormat).
  * \tparam stream_type        The type of the stream, must satisfy seqan3::istream_concept.
  * \details
  *
@@ -855,12 +855,12 @@ public:
 
     /*!\brief Construct from an existing stream and with specified format.
      * \tparam file_format The format of the file in the stream, must satisfy
-     * seqan3::structure_file_input_format_concept.
+     * seqan3::StructureFileInputFormat.
      * \param[in] _stream The stream to operate on (this must be std::move'd in!).
      * \param[in] format_tag The file format tag.
      * \param[in] fields_tag A seqan3::fields tag. [optional]
      */
-    template<structure_file_input_format_concept file_format>
+    template<StructureFileInputFormat file_format>
     structure_file_in(stream_type && _stream,
                       file_format const & SEQAN3_DOXYGEN_ONLY(format_tag),
                       selected_field_ids const & SEQAN3_DOXYGEN_ONLY(fields_tag) = selected_field_ids{}) :
@@ -1060,7 +1060,7 @@ protected:
         }
 
         assert(!format.valueless_by_exception());
-        std::visit([&] (structure_file_input_format_concept & f)
+        std::visit([&] (StructureFileInputFormat & f)
         {
             // read new record
             if constexpr (selected_field_ids::contains(field::STRUCTURED_SEQ))
@@ -1149,7 +1149,7 @@ protected:
  * \{
  */
 template <istream_concept<char> stream_type,
-          structure_file_input_format_concept file_format,
+          StructureFileInputFormat file_format,
           detail::fields_concept selected_field_ids>
 structure_file_in(stream_type && _stream, file_format const &, selected_field_ids const &)
     -> structure_file_in<typename structure_file_in<>::traits_type,       // actually use the default

--- a/include/seqan3/io/structure_file/input_format_concept.hpp
+++ b/include/seqan3/io/structure_file/input_format_concept.hpp
@@ -6,7 +6,7 @@
 // -----------------------------------------------------------------------------------------------------
 
 /*!\file
- * \brief Provides seqan3::structure_file_input_format_concept.
+ * \brief Provides seqan3::StructureFileInputFormat.
  * \author Jörg Winkler <j.winkler AT fu-berlin.de>
  */
 
@@ -26,7 +26,7 @@
 
 namespace seqan3
 {
-/*!\interface seqan3::structure_file_input_format_concept <>
+/*!\interface seqan3::StructureFileInputFormat <>
  * \brief The generic concept for structure file in formats.
  * \ingroup structure_file
  *
@@ -38,7 +38,7 @@ namespace seqan3
  */
 //!\cond
 template<typename t>
-SEQAN3_CONCEPT structure_file_input_format_concept = requires(t & v,
+SEQAN3_CONCEPT StructureFileInputFormat = requires(t & v,
                                                             std::ifstream & f,
                                                             structure_file_input_options<rna5, false> & options,
                                                             rna5_vector & seq,
@@ -69,9 +69,9 @@ SEQAN3_CONCEPT structure_file_input_format_concept = requires(t & v,
 };
 //!\endcond
 
-/*!\name Requirements for seqan3::structure_file_input_format_concept
- * \brief You can expect these **members** on all types that implement seqan3::structure_file_input_format_concept.
- * \memberof seqan3::structure_file_input_format_concept
+/*!\name Requirements for seqan3::StructureFileInputFormat
+ * \brief You can expect these **members** on all types that implement seqan3::StructureFileInputFormat.
+ * \memberof seqan3::StructureFileInputFormat
  * \{
  */
 /*!\fn void read(stream_type & stream,
@@ -86,7 +86,7 @@ SEQAN3_CONCEPT structure_file_input_format_concept = requires(t & v,
  *               comment_type & comment,
  *               offset_type & offset)
  * \brief Read from the specified stream and back-insert into the given field buffers.
- * \memberof seqan3::structure_file_input_format_concept
+ * \memberof seqan3::StructureFileInputFormat
  * \tparam stream_type      Input stream, must satisfy seqan3::istream_concept with `char`.
  * \tparam seq_type         Type of the seqan3::field::SEQ input; must satisfy std::ranges::OutputRange
  * over a seqan3::alphabet_concept.
@@ -126,7 +126,7 @@ SEQAN3_CONCEPT structure_file_input_format_concept = requires(t & v,
  *     a specialisation of seqan3::structured_rna and the second template parameter to
  *     seqan3::structure_file_input_options must be set to true.
  */
- /*!\var static inline std::vector<std::string> seqan3::structure_file_input_format_concept::file_extensions
+ /*!\var static inline std::vector<std::string> seqan3::StructureFileInputFormat::file_extensions
  * \brief The format type is required to provide a vector of all supported file extensions.
  */
 //!\}
@@ -145,16 +145,16 @@ template<typename t>
 constexpr bool is_type_list_of_structure_file_input_formats_v = false;
 
 /*!\brief Auxiliary value metafuncton that checks whether a type is a seqan3::type_list and all types meet
- * seqan3::structure_file_input_format_concept [overload].
+ * seqan3::StructureFileInputFormat [overload].
  * \ingroup core
  * \see seqan3::type_list_of_structure_file_input_formats_concept
  */
 template<typename ... ts>
 constexpr bool is_type_list_of_structure_file_input_formats_v<type_list<ts...>>
-                = (structure_file_input_format_concept<ts> && ...);
+                = (StructureFileInputFormat<ts> && ...);
 
 /*!\brief Auxiliary concept that checks whether a type is a seqan3::type_list and all types meet
- * seqan3::structure_file_input_format_concept.
+ * seqan3::StructureFileInputFormat.
  * \ingroup core
  * \see seqan3::is_type_list_of_structure_file_formats_v
  */

--- a/include/seqan3/io/structure_file/input_format_concept.hpp
+++ b/include/seqan3/io/structure_file/input_format_concept.hpp
@@ -39,18 +39,18 @@ namespace seqan3
 //!\cond
 template<typename t>
 SEQAN3_CONCEPT StructureFileInputFormat = requires(t & v,
-                                                            std::ifstream & f,
-                                                            structure_file_input_options<rna5, false> & options,
-                                                            rna5_vector & seq,
-                                                            std::string & id,
-                                                            std::vector<std::set<std::pair<double, size_t>>> & bpp,
-                                                            std::vector<wuss51> & structure,
-                                                            std::vector<structured_rna<rna5, wuss51>> & structured_seq,
-                                                            double energy,
-                                                            double react,
-                                                            double react_err,
-                                                            std::string & comment,
-                                                            size_t offset)
+                                                   std::ifstream & f,
+                                                   structure_file_input_options<rna5, false> & options,
+                                                   rna5_vector & seq,
+                                                   std::string & id,
+                                                   std::vector<std::set<std::pair<double, size_t>>> & bpp,
+                                                   std::vector<wuss51> & structure,
+                                                   std::vector<structured_rna<rna5, wuss51>> & structured_seq,
+                                                   double energy,
+                                                   double react,
+                                                   double react_err,
+                                                   std::string & comment,
+                                                   size_t offset)
 {
     t::file_extensions;
 

--- a/include/seqan3/io/structure_file/input_format_concept.hpp
+++ b/include/seqan3/io/structure_file/input_format_concept.hpp
@@ -139,7 +139,7 @@ namespace seqan3::detail
 /*!\brief Auxiliary value metafuncton that checks whether a type is a seqan3::type_list and all types meet
  * seqan3::structure_file_format_concept [default is false].
  * \ingroup core
- * \see seqan3::type_list_of_structure_file_input_formats_concept
+ * \see seqan3::TypeListOfStructureFileInputFormats
  */
 template<typename t>
 constexpr bool is_type_list_of_structure_file_input_formats_v = false;
@@ -147,7 +147,7 @@ constexpr bool is_type_list_of_structure_file_input_formats_v = false;
 /*!\brief Auxiliary value metafuncton that checks whether a type is a seqan3::type_list and all types meet
  * seqan3::StructureFileInputFormat [overload].
  * \ingroup core
- * \see seqan3::type_list_of_structure_file_input_formats_concept
+ * \see seqan3::TypeListOfStructureFileInputFormats
  */
 template<typename ... ts>
 constexpr bool is_type_list_of_structure_file_input_formats_v<type_list<ts...>>
@@ -159,6 +159,5 @@ constexpr bool is_type_list_of_structure_file_input_formats_v<type_list<ts...>>
  * \see seqan3::is_type_list_of_structure_file_formats_v
  */
 template<typename t>
-SEQAN3_CONCEPT type_list_of_structure_file_input_formats_concept = is_type_list_of_structure_file_input_formats_v<t>;
-
+SEQAN3_CONCEPT TypeListOfStructureFileInputFormats = is_type_list_of_structure_file_input_formats_v<t>;
 } // namespace seqan3::detail

--- a/include/seqan3/io/structure_file/output.hpp
+++ b/include/seqan3/io/structure_file/output.hpp
@@ -51,7 +51,7 @@ namespace seqan3
  * \tparam selected_field_ids A seqan3::fields type with the list and order of fields IDs; only relevant if these
  *                            can't be deduced.
  * \tparam valid_formats      A seqan3::type_list of the selectable formats (each must meet
- *                            seqan3::structure_file_output_format_concept).
+ *                            seqan3::StructureFileOutputFormat).
  * \tparam stream_type        The type of the stream, must satisfy seqan3::ostream_concept.
  * \details
  *
@@ -354,12 +354,12 @@ public:
 
     /*!\brief Construct from an existing stream and with specified format.
      * \tparam file_format The format of the file in the stream, must satisfy
-     * seqan3::structure_file_output_format_concept.
+     * seqan3::StructureFileOutputFormat.
      * \param[in] _stream  The stream to operate on (this must be std::move'd in!).
      * \param[in] format_tag The file format tag.
      * \param[in] fields_tag A seqan3::fields tag. [optional]
      */
-    template <structure_file_output_format_concept file_format>
+    template <StructureFileOutputFormat file_format>
     structure_file_out(stream_type             && _stream,
                       file_format        const & SEQAN3_DOXYGEN_ONLY(format_tag),
                       selected_field_ids const & SEQAN3_DOXYGEN_ONLY(fields_tag) = selected_field_ids{}) :
@@ -915,7 +915,7 @@ protected:
  * \{
  */
 template <ostream_concept<char>                stream_type,
-          structure_file_output_format_concept file_format,
+          StructureFileOutputFormat file_format,
           detail::fields_concept               selected_field_ids>
 structure_file_out(stream_type && _stream, file_format const &, selected_field_ids const &)
     -> structure_file_out<selected_field_ids,

--- a/include/seqan3/io/structure_file/output.hpp
+++ b/include/seqan3/io/structure_file/output.hpp
@@ -52,7 +52,7 @@ namespace seqan3
  *                            can't be deduced.
  * \tparam valid_formats      A seqan3::type_list of the selectable formats (each must meet
  *                            seqan3::StructureFileOutputFormat).
- * \tparam stream_type        The type of the stream, must satisfy seqan3::ostream_concept.
+ * \tparam stream_type        The type of the stream, must satisfy seqan3::OStream.
  * \details
  *
  * ### Introduction
@@ -251,7 +251,7 @@ namespace seqan3
 template <detail::fields_concept selected_field_ids_ = fields<field::SEQ, field::ID, field::STRUCTURE>,
           detail::TypeListOfStructureFileOutputFormats valid_formats_
               = type_list<structure_file_format_vienna>,
-          ostream_concept<char> stream_type_ = std::ofstream>
+          OStream<char> stream_type_ = std::ofstream>
 class structure_file_out
 {
 public:
@@ -914,8 +914,8 @@ protected:
  * \relates seqan3::structure_file_out
  * \{
  */
-template <ostream_concept<char>                stream_type,
-          StructureFileOutputFormat file_format,
+template <OStream<char>                        stream_type,
+          StructureFileOutputFormat            file_format,
           detail::fields_concept               selected_field_ids>
 structure_file_out(stream_type && _stream, file_format const &, selected_field_ids const &)
     -> structure_file_out<selected_field_ids,

--- a/include/seqan3/io/structure_file/output.hpp
+++ b/include/seqan3/io/structure_file/output.hpp
@@ -249,7 +249,7 @@ namespace seqan3
  */
 
 template <detail::fields_concept selected_field_ids_ = fields<field::SEQ, field::ID, field::STRUCTURE>,
-          detail::type_list_of_structure_file_output_formats_concept valid_formats_
+          detail::TypeListOfStructureFileOutputFormats valid_formats_
               = type_list<structure_file_format_vienna>,
           ostream_concept<char> stream_type_ = std::ofstream>
 class structure_file_out

--- a/include/seqan3/io/structure_file/output.hpp
+++ b/include/seqan3/io/structure_file/output.hpp
@@ -914,9 +914,9 @@ protected:
  * \relates seqan3::structure_file_out
  * \{
  */
-template <OStream<char>                        stream_type,
-          StructureFileOutputFormat            file_format,
-          detail::fields_concept               selected_field_ids>
+template <OStream<char>             stream_type,
+          StructureFileOutputFormat file_format,
+          detail::fields_concept    selected_field_ids>
 structure_file_out(stream_type && _stream, file_format const &, selected_field_ids const &)
     -> structure_file_out<selected_field_ids,
                          type_list<file_format>,

--- a/include/seqan3/io/structure_file/output_format_concept.hpp
+++ b/include/seqan3/io/structure_file/output_format_concept.hpp
@@ -6,7 +6,7 @@
 // -----------------------------------------------------------------------------------------------------
 
 /*!\file
- * \brief Provides seqan3::structure_file_output_format_concept and auxiliary classes.
+ * \brief Provides seqan3::StructureFileOutputFormat and auxiliary classes.
  * \author Jörg Winkler <j.winkler AT fu-berlin.de>
  */
 
@@ -25,7 +25,7 @@
 namespace seqan3
 {
 
-/*!\interface seqan3::structure_file_output_format_concept <>
+/*!\interface seqan3::StructureFileOutputFormat <>
  * \brief The generic concept for sequence file out formats.
  * \ingroup structure_file
  *
@@ -37,7 +37,7 @@ namespace seqan3
  */
 //!\cond
 template <typename t>
-SEQAN3_CONCEPT structure_file_output_format_concept = requires(t & v,
+SEQAN3_CONCEPT StructureFileOutputFormat = requires(t & v,
                                                              std::ofstream & f,
                                                              structure_file_output_options & options,
                                                              rna5_vector & seq,
@@ -65,9 +65,9 @@ SEQAN3_CONCEPT structure_file_output_format_concept = requires(t & v,
 };
 //!\endcond
 
-/*!\name Requirements for seqan3::structure_file_output_format_concept
- * \brief You can expect these **members** on all types that implement seqan3::structure_file_output_format_concept.
- * \memberof seqan3::structure_file_output_format_concept
+/*!\name Requirements for seqan3::StructureFileOutputFormat
+ * \brief You can expect these **members** on all types that implement seqan3::StructureFileOutputFormat.
+ * \memberof seqan3::StructureFileOutputFormat
  * \{
  */
 
@@ -83,7 +83,7 @@ SEQAN3_CONCEPT structure_file_output_format_concept = requires(t & v,
  *                comment_type && comment,
  *                offset_type && offset)
  * \brief Write the given fields to the specified stream.
- * \memberof seqan3::structure_file_output_format_concept
+ * \memberof seqan3::StructureFileOutputFormat
  * \tparam stream_type      Output stream, must satisfy seqan3::ostream_concept with `char`.
  * \tparam seq_type         Type of the seqan3::field::SEQ output; must satisfy std::ranges::OutputRange
  * over a seqan3::alphabet_concept.
@@ -120,7 +120,7 @@ SEQAN3_CONCEPT structure_file_output_format_concept = requires(t & v,
  *   * The format does not handle seqan3::field::STRUCTURED_SEQ, instead seqan3::structure_file_out splits it into
  * two views and passes it to the format as if they were separate.
  */
-/*!\var static inline std::vector<std::string> seqan3::structure_file_output_format_concept::file_extensions
+/*!\var static inline std::vector<std::string> seqan3::StructureFileOutputFormat::file_extensions
  * \brief The format type is required to provide a vector of all supported file extensions.
  */
 
@@ -132,7 +132,7 @@ namespace seqan3::detail
 {
 
 /*!\brief Auxiliary value metafuncton that checks whether a type is a seqan3::type_list and all types meet
- * seqan3::structure_file_output_format_concept [default is false].
+ * seqan3::StructureFileOutputFormat [default is false].
  * \ingroup core
  * \see seqan3::type_list_of_structure_file_output_formats_concept
  */
@@ -140,13 +140,13 @@ template <typename t>
 constexpr bool is_type_list_of_structure_file_output_formats_v = false;
 
 /*!\brief Auxiliary value metafuncton that checks whether a type is a seqan3::type_list and all types meet
- * seqan3::structure_file_output_format_concept [overload].
+ * seqan3::StructureFileOutputFormat [overload].
  * \ingroup core
  * \see seqan3::type_list_of_structure_file_output_formats_concept
  */
 template <typename ... ts>
 constexpr bool is_type_list_of_structure_file_output_formats_v<type_list<ts...>>
-                = (structure_file_output_format_concept<ts> && ...);
+                = (StructureFileOutputFormat<ts> && ...);
 
 /*!\brief Auxiliary concept that checks whether a type is a seqan3::type_list and all types meet
  * seqan3::structure_file_format_concept.

--- a/include/seqan3/io/structure_file/output_format_concept.hpp
+++ b/include/seqan3/io/structure_file/output_format_concept.hpp
@@ -134,7 +134,7 @@ namespace seqan3::detail
 /*!\brief Auxiliary value metafuncton that checks whether a type is a seqan3::type_list and all types meet
  * seqan3::StructureFileOutputFormat [default is false].
  * \ingroup core
- * \see seqan3::type_list_of_structure_file_output_formats_concept
+ * \see seqan3::TypeListOfStructureFileOutputFormats
  */
 template <typename t>
 constexpr bool is_type_list_of_structure_file_output_formats_v = false;
@@ -142,7 +142,7 @@ constexpr bool is_type_list_of_structure_file_output_formats_v = false;
 /*!\brief Auxiliary value metafuncton that checks whether a type is a seqan3::type_list and all types meet
  * seqan3::StructureFileOutputFormat [overload].
  * \ingroup core
- * \see seqan3::type_list_of_structure_file_output_formats_concept
+ * \see seqan3::TypeListOfStructureFileOutputFormats
  */
 template <typename ... ts>
 constexpr bool is_type_list_of_structure_file_output_formats_v<type_list<ts...>>
@@ -154,5 +154,5 @@ constexpr bool is_type_list_of_structure_file_output_formats_v<type_list<ts...>>
  * \see seqan3::is_type_list_of_structure_file_formats_v
  */
 template <typename t>
-SEQAN3_CONCEPT type_list_of_structure_file_output_formats_concept = is_type_list_of_structure_file_output_formats_v<t>;
+SEQAN3_CONCEPT TypeListOfStructureFileOutputFormats = is_type_list_of_structure_file_output_formats_v<t>;
 } // namespace seqan3::detail

--- a/include/seqan3/io/structure_file/output_format_concept.hpp
+++ b/include/seqan3/io/structure_file/output_format_concept.hpp
@@ -38,18 +38,18 @@ namespace seqan3
 //!\cond
 template <typename t>
 SEQAN3_CONCEPT StructureFileOutputFormat = requires(t & v,
-                                                             std::ofstream & f,
-                                                             structure_file_output_options & options,
-                                                             rna5_vector & seq,
-                                                             std::string & id,
-                                                             std::vector<std::set<std::pair<double, size_t>>> & bpp,
-                                                             std::vector<wuss51> & structure,
-                                                             std::vector<structured_rna<rna5, wuss51>> & structured_seq,
-                                                             double energy,
-                                                             double react,
-                                                             double react_err,
-                                                             std::string & comment,
-                                                             size_t offset)
+                                                    std::ofstream & f,
+                                                    structure_file_output_options & options,
+                                                    rna5_vector & seq,
+                                                    std::string & id,
+                                                    std::vector<std::set<std::pair<double, size_t>>> & bpp,
+                                                    std::vector<wuss51> & structure,
+                                                    std::vector<structured_rna<rna5, wuss51>> & structured_seq,
+                                                    double energy,
+                                                    double react,
+                                                    double react_err,
+                                                    std::string & comment,
+                                                    size_t offset)
 {
     t::file_extensions;
 

--- a/include/seqan3/io/structure_file/output_format_concept.hpp
+++ b/include/seqan3/io/structure_file/output_format_concept.hpp
@@ -84,7 +84,7 @@ SEQAN3_CONCEPT StructureFileOutputFormat = requires(t & v,
  *                offset_type && offset)
  * \brief Write the given fields to the specified stream.
  * \memberof seqan3::StructureFileOutputFormat
- * \tparam stream_type      Output stream, must satisfy seqan3::ostream_concept with `char`.
+ * \tparam stream_type      Output stream, must satisfy seqan3::OStream with `char`.
  * \tparam seq_type         Type of the seqan3::field::SEQ output; must satisfy std::ranges::OutputRange
  * over a seqan3::alphabet_concept.
  * \tparam id_type          Type of the seqan3::field::ID output; must satisfy std::ranges::OutputRange

--- a/test/unit/io/alignment_file/format_sam_test.cpp
+++ b/test/unit/io/alignment_file/format_sam_test.cpp
@@ -27,7 +27,7 @@ using namespace seqan3;
 TEST(general, concepts)
 {
     // EXPECT_TRUE((alignment_file_in_format_concept<alignment_file_format_sam>));
-    EXPECT_TRUE((alignment_file_output_format_concept<alignment_file_format_sam>));
+    EXPECT_TRUE((AlignmentFileOutputFormat<alignment_file_format_sam>));
 }
 
 // ----------------------------------------------------------------------------

--- a/test/unit/io/concept_test.cpp
+++ b/test/unit/io/concept_test.cpp
@@ -56,21 +56,21 @@ TEST(io, istream_concept)
     EXPECT_FALSE((istream_concept<std::string, char>));
 }
 
-TEST(io, ostream_concept)
+TEST(io, OStream)
 {
-    EXPECT_FALSE((ostream_concept<std::istream, char>));
-    EXPECT_TRUE((ostream_concept<std::ostream, char>));
-    EXPECT_TRUE((ostream_concept<std::iostream, char>));
-    EXPECT_FALSE((ostream_concept<std::ifstream, char>));
-    EXPECT_TRUE((ostream_concept<std::ofstream, char>));
-    EXPECT_TRUE((ostream_concept<std::fstream, char>));
-    EXPECT_FALSE((ostream_concept<std::istringstream, char>));
-    EXPECT_TRUE((ostream_concept<std::ostringstream, char>));
-    EXPECT_TRUE((ostream_concept<std::stringstream, char>));
-    EXPECT_FALSE((ostream_concept<std::vector<char>, char>));
-    EXPECT_FALSE((ostream_concept<std::vector<char>, char>));
-    EXPECT_FALSE((ostream_concept<std::vector<char>, char>));
-    EXPECT_FALSE((ostream_concept<std::string, char>));
-    EXPECT_FALSE((ostream_concept<std::string, char>));
-    EXPECT_FALSE((ostream_concept<std::string, char>));
+    EXPECT_FALSE((OStream<std::istream, char>));
+    EXPECT_TRUE((OStream<std::ostream, char>));
+    EXPECT_TRUE((OStream<std::iostream, char>));
+    EXPECT_FALSE((OStream<std::ifstream, char>));
+    EXPECT_TRUE((OStream<std::ofstream, char>));
+    EXPECT_TRUE((OStream<std::fstream, char>));
+    EXPECT_FALSE((OStream<std::istringstream, char>));
+    EXPECT_TRUE((OStream<std::ostringstream, char>));
+    EXPECT_TRUE((OStream<std::stringstream, char>));
+    EXPECT_FALSE((OStream<std::vector<char>, char>));
+    EXPECT_FALSE((OStream<std::vector<char>, char>));
+    EXPECT_FALSE((OStream<std::vector<char>, char>));
+    EXPECT_FALSE((OStream<std::string, char>));
+    EXPECT_FALSE((OStream<std::string, char>));
+    EXPECT_FALSE((OStream<std::string, char>));
 }

--- a/test/unit/io/concept_test.cpp
+++ b/test/unit/io/concept_test.cpp
@@ -37,23 +37,23 @@ TEST(io, Stream)
     EXPECT_FALSE((Stream<std::string, char>));
 }
 
-TEST(io, istream_concept)
+TEST(io, IStream)
 {
-    EXPECT_TRUE((istream_concept<std::istream, char>));
-    EXPECT_FALSE((istream_concept<std::ostream, char>));
-    EXPECT_TRUE((istream_concept<std::iostream, char>));
-    EXPECT_TRUE((istream_concept<std::ifstream, char>));
-    EXPECT_FALSE((istream_concept<std::ofstream, char>));
-    EXPECT_TRUE((istream_concept<std::fstream, char>));
-    EXPECT_TRUE((istream_concept<std::istringstream, char>));
-    EXPECT_FALSE((istream_concept<std::ostringstream, char>));
-    EXPECT_TRUE((istream_concept<std::stringstream, char>));
-    EXPECT_FALSE((istream_concept<std::vector<char>, char>));
-    EXPECT_FALSE((istream_concept<std::vector<char>, char>));
-    EXPECT_FALSE((istream_concept<std::vector<char>, char>));
-    EXPECT_FALSE((istream_concept<std::string, char>));
-    EXPECT_FALSE((istream_concept<std::string, char>));
-    EXPECT_FALSE((istream_concept<std::string, char>));
+    EXPECT_TRUE((IStream<std::istream, char>));
+    EXPECT_FALSE((IStream<std::ostream, char>));
+    EXPECT_TRUE((IStream<std::iostream, char>));
+    EXPECT_TRUE((IStream<std::ifstream, char>));
+    EXPECT_FALSE((IStream<std::ofstream, char>));
+    EXPECT_TRUE((IStream<std::fstream, char>));
+    EXPECT_TRUE((IStream<std::istringstream, char>));
+    EXPECT_FALSE((IStream<std::ostringstream, char>));
+    EXPECT_TRUE((IStream<std::stringstream, char>));
+    EXPECT_FALSE((IStream<std::vector<char>, char>));
+    EXPECT_FALSE((IStream<std::vector<char>, char>));
+    EXPECT_FALSE((IStream<std::vector<char>, char>));
+    EXPECT_FALSE((IStream<std::string, char>));
+    EXPECT_FALSE((IStream<std::string, char>));
+    EXPECT_FALSE((IStream<std::string, char>));
 }
 
 TEST(io, OStream)

--- a/test/unit/io/concept_test.cpp
+++ b/test/unit/io/concept_test.cpp
@@ -18,23 +18,23 @@
 
 using namespace seqan3;
 
-TEST(io, stream_concept)
+TEST(io, Stream)
 {
-    EXPECT_FALSE((stream_concept<std::istream, char>));
-    EXPECT_FALSE((stream_concept<std::ostream, char>));
-    EXPECT_TRUE((stream_concept<std::iostream, char>));
-    EXPECT_FALSE((stream_concept<std::ifstream, char>));
-    EXPECT_FALSE((stream_concept<std::ofstream, char>));
-    EXPECT_TRUE((stream_concept<std::fstream, char>));
-    EXPECT_FALSE((stream_concept<std::istringstream, char>));
-    EXPECT_FALSE((stream_concept<std::ostringstream, char>));
-    EXPECT_TRUE((stream_concept<std::stringstream, char>));
-    EXPECT_FALSE((stream_concept<std::vector<char>, char>));
-    EXPECT_FALSE((stream_concept<std::vector<char>, char>));
-    EXPECT_FALSE((stream_concept<std::vector<char>, char>));
-    EXPECT_FALSE((stream_concept<std::string, char>));
-    EXPECT_FALSE((stream_concept<std::string, char>));
-    EXPECT_FALSE((stream_concept<std::string, char>));
+    EXPECT_FALSE((Stream<std::istream, char>));
+    EXPECT_FALSE((Stream<std::ostream, char>));
+    EXPECT_TRUE((Stream<std::iostream, char>));
+    EXPECT_FALSE((Stream<std::ifstream, char>));
+    EXPECT_FALSE((Stream<std::ofstream, char>));
+    EXPECT_TRUE((Stream<std::fstream, char>));
+    EXPECT_FALSE((Stream<std::istringstream, char>));
+    EXPECT_FALSE((Stream<std::ostringstream, char>));
+    EXPECT_TRUE((Stream<std::stringstream, char>));
+    EXPECT_FALSE((Stream<std::vector<char>, char>));
+    EXPECT_FALSE((Stream<std::vector<char>, char>));
+    EXPECT_FALSE((Stream<std::vector<char>, char>));
+    EXPECT_FALSE((Stream<std::string, char>));
+    EXPECT_FALSE((Stream<std::string, char>));
+    EXPECT_FALSE((Stream<std::string, char>));
 }
 
 TEST(io, istream_concept)

--- a/test/unit/io/sequence_file/sequence_file_format_fasta_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_format_fasta_test.cpp
@@ -13,7 +13,7 @@
 #include <range/v3/view/transform.hpp>
 
 #include <seqan3/alphabet/quality/all.hpp>
-#include <seqan3/io/sequence_file/InputFormat.hpp>
+#include <seqan3/io/sequence_file/input_format_concept.hpp>
 #include <seqan3/io/sequence_file/output_format_concept.hpp>
 #include <seqan3/io/sequence_file/format_fasta.hpp>
 #include <seqan3/range/view/convert.hpp>

--- a/test/unit/io/sequence_file/sequence_file_format_fasta_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_format_fasta_test.cpp
@@ -27,7 +27,7 @@ using namespace seqan3;
 TEST(general, concepts)
 {
     EXPECT_TRUE((sequence_file_input_format_concept<sequence_file_format_fasta>));
-    EXPECT_TRUE((sequence_file_output_format_concept<sequence_file_format_fasta>));
+    EXPECT_TRUE((SequenceFileOutputFormat<sequence_file_format_fasta>));
 }
 
 // ----------------------------------------------------------------------------

--- a/test/unit/io/sequence_file/sequence_file_format_fasta_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_format_fasta_test.cpp
@@ -13,7 +13,7 @@
 #include <range/v3/view/transform.hpp>
 
 #include <seqan3/alphabet/quality/all.hpp>
-#include <seqan3/io/sequence_file/input_format_concept.hpp>
+#include <seqan3/io/sequence_file/InputFormat.hpp>
 #include <seqan3/io/sequence_file/output_format_concept.hpp>
 #include <seqan3/io/sequence_file/format_fasta.hpp>
 #include <seqan3/range/view/convert.hpp>

--- a/test/unit/io/sequence_file/sequence_file_format_fasta_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_format_fasta_test.cpp
@@ -26,7 +26,7 @@ using namespace seqan3;
 
 TEST(general, concepts)
 {
-    EXPECT_TRUE((sequence_file_input_format_concept<sequence_file_format_fasta>));
+    EXPECT_TRUE((SequenceFileInputFormat<sequence_file_format_fasta>));
     EXPECT_TRUE((SequenceFileOutputFormat<sequence_file_format_fasta>));
 }
 

--- a/test/unit/io/sequence_file/sequence_file_format_fastq_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_format_fastq_test.cpp
@@ -27,7 +27,7 @@ using namespace seqan3;
 TEST(general, concepts)
 {
     EXPECT_TRUE((sequence_file_input_format_concept<sequence_file_format_fastq>));
-    EXPECT_TRUE((sequence_file_output_format_concept<sequence_file_format_fastq>));
+    EXPECT_TRUE((SequenceFileOutputFormat<sequence_file_format_fastq>));
 }
 
 // ----------------------------------------------------------------------------

--- a/test/unit/io/sequence_file/sequence_file_format_fastq_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_format_fastq_test.cpp
@@ -13,7 +13,7 @@
 #include <range/v3/view/transform.hpp>
 
 #include <seqan3/alphabet/quality/all.hpp>
-#include <seqan3/io/sequence_file/InputFormat.hpp>
+#include <seqan3/io/sequence_file/input_format_concept.hpp>
 #include <seqan3/io/sequence_file/output_format_concept.hpp>
 #include <seqan3/io/sequence_file/format_fastq.hpp>
 #include <seqan3/range/view/convert.hpp>

--- a/test/unit/io/sequence_file/sequence_file_format_fastq_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_format_fastq_test.cpp
@@ -13,7 +13,7 @@
 #include <range/v3/view/transform.hpp>
 
 #include <seqan3/alphabet/quality/all.hpp>
-#include <seqan3/io/sequence_file/input_format_concept.hpp>
+#include <seqan3/io/sequence_file/InputFormat.hpp>
 #include <seqan3/io/sequence_file/output_format_concept.hpp>
 #include <seqan3/io/sequence_file/format_fastq.hpp>
 #include <seqan3/range/view/convert.hpp>

--- a/test/unit/io/sequence_file/sequence_file_format_fastq_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_format_fastq_test.cpp
@@ -26,7 +26,7 @@ using namespace seqan3;
 
 TEST(general, concepts)
 {
-    EXPECT_TRUE((sequence_file_input_format_concept<sequence_file_format_fastq>));
+    EXPECT_TRUE((SequenceFileInputFormat<sequence_file_format_fastq>));
     EXPECT_TRUE((SequenceFileOutputFormat<sequence_file_format_fastq>));
 }
 

--- a/test/unit/io/stream/istream_test_template.hpp
+++ b/test/unit/io/stream/istream_test_template.hpp
@@ -27,7 +27,7 @@ TYPED_TEST_CASE_P(istream);
 
 TYPED_TEST_P(istream, concept_check)
 {
-    EXPECT_TRUE((istream_concept<TypeParam, char>));
+    EXPECT_TRUE((IStream<TypeParam, char>));
 }
 
 TYPED_TEST_P(istream, input)

--- a/test/unit/io/stream/ostream_test_template.hpp
+++ b/test/unit/io/stream/ostream_test_template.hpp
@@ -27,7 +27,7 @@ TYPED_TEST_CASE_P(ostream);
 
 TYPED_TEST_P(ostream, concept_check)
 {
-    EXPECT_TRUE((ostream_concept<TypeParam, char>));
+    EXPECT_TRUE((OStream<TypeParam, char>));
 }
 
 TYPED_TEST_P(ostream, output)

--- a/test/unit/io/stream/parse_condition_test.cpp
+++ b/test/unit/io/stream/parse_condition_test.cpp
@@ -49,25 +49,25 @@ TEST(parse_condition, parse_condition_msg)
     EXPECT_EQ(foo<'o'>::msg.string(), "foo_o"s);
 }
 
-TEST(parse_condition, parse_condition_concept)
+TEST(parse_condition, ParseCondition)
 {
     using namespace seqan3;
 
-    EXPECT_TRUE(detail::parse_condition_concept<decltype(is_in_alphabet<dna4>)>);
-    EXPECT_TRUE(detail::parse_condition_concept<decltype(is_char<to_char('A'_aa27)>)>);
-    EXPECT_TRUE((detail::parse_condition_concept<decltype(is_in_interval<'a','z'>)>));
-    EXPECT_TRUE(detail::parse_condition_concept<decltype(is_space)>);
-    EXPECT_TRUE(detail::parse_condition_concept<decltype(is_blank)>);
-    EXPECT_TRUE(detail::parse_condition_concept<decltype(is_graph)>);
-    EXPECT_TRUE(detail::parse_condition_concept<decltype(is_alpha)>);
-    EXPECT_TRUE(detail::parse_condition_concept<decltype(is_digit)>);
-    EXPECT_TRUE(detail::parse_condition_concept<decltype(is_alnum)>);
+    EXPECT_TRUE(detail::ParseCondition<decltype(is_in_alphabet<dna4>)>);
+    EXPECT_TRUE(detail::ParseCondition<decltype(is_char<to_char('A'_aa27)>)>);
+    EXPECT_TRUE((detail::ParseCondition<decltype(is_in_interval<'a','z'>)>));
+    EXPECT_TRUE(detail::ParseCondition<decltype(is_space)>);
+    EXPECT_TRUE(detail::ParseCondition<decltype(is_blank)>);
+    EXPECT_TRUE(detail::ParseCondition<decltype(is_graph)>);
+    EXPECT_TRUE(detail::ParseCondition<decltype(is_alpha)>);
+    EXPECT_TRUE(detail::ParseCondition<decltype(is_digit)>);
+    EXPECT_TRUE(detail::ParseCondition<decltype(is_alnum)>);
     // TODO(rrahn): Direct call in concept caused ICE.
     auto val = ((!is_space || is_alpha) || is_digit);
-    EXPECT_TRUE(detail::parse_condition_concept<decltype(val)>);
-    EXPECT_TRUE(detail::parse_condition_concept<foo<' '>>);
-    EXPECT_FALSE(detail::parse_condition_concept<bar>);
-    EXPECT_FALSE(detail::parse_condition_concept<int>);
+    EXPECT_TRUE(detail::ParseCondition<decltype(val)>);
+    EXPECT_TRUE(detail::ParseCondition<foo<' '>>);
+    EXPECT_FALSE(detail::ParseCondition<bar>);
+    EXPECT_FALSE(detail::ParseCondition<int>);
 }
 
 TEST(parse_condition, parse_condition_combiner)

--- a/test/unit/io/structure_file/format_vienna_test.cpp
+++ b/test/unit/io/structure_file/format_vienna_test.cpp
@@ -18,7 +18,7 @@
 #include <seqan3/alphabet/structure/dot_bracket3.hpp>
 #include <seqan3/alphabet/structure/structured_rna.hpp>
 #include <seqan3/io/structure_file/format_vienna.hpp>
-#include <seqan3/io/structure_file/InputFormat.hpp>
+#include <seqan3/io/structure_file/input_format_concept.hpp>
 #include <seqan3/io/structure_file/output_format_concept.hpp>
 #include <seqan3/range/view/convert.hpp>
 

--- a/test/unit/io/structure_file/format_vienna_test.cpp
+++ b/test/unit/io/structure_file/format_vienna_test.cpp
@@ -30,7 +30,7 @@ using namespace seqan3;
 
 TEST(general, concepts)
 {
-    EXPECT_TRUE((structure_file_input_format_concept<structure_file_format_vienna>));
+    EXPECT_TRUE((StructureFileInputFormat<structure_file_format_vienna>));
     EXPECT_TRUE((StructureFileOutputFormat<structure_file_format_vienna>));
 }
 

--- a/test/unit/io/structure_file/format_vienna_test.cpp
+++ b/test/unit/io/structure_file/format_vienna_test.cpp
@@ -18,7 +18,7 @@
 #include <seqan3/alphabet/structure/dot_bracket3.hpp>
 #include <seqan3/alphabet/structure/structured_rna.hpp>
 #include <seqan3/io/structure_file/format_vienna.hpp>
-#include <seqan3/io/structure_file/input_format_concept.hpp>
+#include <seqan3/io/structure_file/InputFormat.hpp>
 #include <seqan3/io/structure_file/output_format_concept.hpp>
 #include <seqan3/range/view/convert.hpp>
 

--- a/test/unit/io/structure_file/format_vienna_test.cpp
+++ b/test/unit/io/structure_file/format_vienna_test.cpp
@@ -31,7 +31,7 @@ using namespace seqan3;
 TEST(general, concepts)
 {
     EXPECT_TRUE((structure_file_input_format_concept<structure_file_format_vienna>));
-    EXPECT_TRUE((structure_file_output_format_concept<structure_file_format_vienna>));
+    EXPECT_TRUE((StructureFileOutputFormat<structure_file_format_vienna>));
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
#520 

Alle renamings for IO.

sequence_file_output_format_concept -> SequenceFileOutputFormat
alignment_file_output_format_concept -> AlignmentFileOutputFormat
structure_file_output_format_concept -> StructureFileOutputFormat
output_format_concept-> OutputFormat
sequence_file_InputFormat -> SequenceFileInputFormat
structure_file_InputFormat -> StructureFileInputFormat
input_format_concept-> InputFormat
ostream_concept -> Ostream
istream_concept -> Istream
stream_concept -> Stream
type_list_of_structure_file_output_formats_concept -> TypeListOfStructureFileOutputFormats
type_list_of_structure_file_input_formats_concept -> TypeListOfStructureFileInputFormats
type_list_of_sequence_file_output_formats_concept ->TypeListOfSequenceFileOutputFormats
type_list_of_sequence_file_input_formats_concept ->TypeListOfSequenceFileInputFormats
type_list_of_alignment_file_output_formats_concept ->TypeListOfAlignmentFileOutputFormats
sequence_file_format_concept -> SequenceFileFormat
sequence_file_input_traits_concept -> SequenceFileInputTraits
sequence_file_format_out_concept -> SequenceFileFormatOut
parse_condition_concept -> ParseCondition