### PR TITLE
[FIX] fix sequence_file_output writing of SEQ_QUAL field.

### DIFF
--- a/include/seqan3/io/sequence_file/output.hpp
+++ b/include/seqan3/io/sequence_file/output.hpp
@@ -36,6 +36,7 @@
 #include <seqan3/io/sequence_file/output_format_concept.hpp>
 #include <seqan3/io/sequence_file/output_options.hpp>
 #include <seqan3/range/view/convert.hpp>
+#include <seqan3/range/view/get.hpp>
 #include <seqan3/std/ranges>
 
 namespace seqan3
@@ -823,7 +824,7 @@ protected:
     {
         static_assert(detail::decays_to_ignore_v<seq_qual_t> ||
                       (detail::decays_to_ignore_v<seq_t> && detail::decays_to_ignore_v<qual_t>),
-                  "You may not select field::SEQ_QUAL and either of field::SEQ and field::QUAL at the same time.");
+                      "You may not select field::SEQ_QUAL and either of field::SEQ and field::QUAL at the same time.");
 
         assert(!format.valueless_by_exception());
         std::visit([&] (auto & f)
@@ -832,9 +833,9 @@ protected:
             {
                 f.write(*secondary_stream,
                         options,
-                        seq_qual | view::convert<typename seq_qual_t::sequence_alphabet_type>,
+                        seq_qual | view::get<0>,
                         id,
-                        seq_qual | view::convert<typename seq_qual_t::quality_alphabet_type>);
+                        seq_qual | view::get<1>);
             }
             else
             {
@@ -866,7 +867,7 @@ protected:
         static_assert(detail::decays_to_ignore_v<reference_t<seq_quals_t>> ||
                       (detail::decays_to_ignore_v<reference_t<seqs_t>> &&
                        detail::decays_to_ignore_v<reference_t<quals_t>>),
-                  "You may not select field::SEQ_QUAL and either of field::SEQ and field::QUAL at the same time.");
+                      "You may not select field::SEQ_QUAL and either of field::SEQ and field::QUAL at the same time.");
 
         assert(!format.valueless_by_exception());
         std::visit([&] (auto & f)
@@ -878,9 +879,9 @@ protected:
                 for (auto && v : zipped)
                     f.write(*secondary_stream,
                             options,
-                            std::get<0>(v) | view::convert<typename reference_t<seq_quals_t>::sequence_alphabet_type>,
+                            std::get<0>(v) | view::get<0>,
                             std::get<1>(v),
-                            std::get<0>(v) | view::convert<typename reference_t<seq_quals_t>::quality_alphabet_type>);
+                            std::get<0>(v) | view::get<1>);
             }
             else
             {

--- a/include/seqan3/io/sequence_file/output.hpp
+++ b/include/seqan3/io/sequence_file/output.hpp
@@ -826,6 +826,10 @@ protected:
                       (detail::decays_to_ignore_v<seq_t> && detail::decays_to_ignore_v<qual_t>),
                       "You may not select field::SEQ_QUAL and either of field::SEQ and field::QUAL at the same time.");
 
+        if constexpr (!detail::decays_to_ignore_v<seq_qual_t>)
+            static_assert(detail::is_type_specialisation_of_v<value_type_t<seq_qual_t>, qualified>,
+                          "The SEQ_QUAL field must contain a range over the seqan3::qualified alphabet.");
+
         assert(!format.valueless_by_exception());
         std::visit([&] (auto & f)
         {
@@ -868,6 +872,10 @@ protected:
                       (detail::decays_to_ignore_v<reference_t<seqs_t>> &&
                        detail::decays_to_ignore_v<reference_t<quals_t>>),
                       "You may not select field::SEQ_QUAL and either of field::SEQ and field::QUAL at the same time.");
+
+        if constexpr (!detail::decays_to_ignore_v<reference_t<seq_quals_t>>)
+            static_assert(detail::is_type_specialisation_of_v<value_type_t<reference_t<seq_quals_t>>, qualified>,
+                          "The SEQ_QUAL field must contain a range over the seqan3::qualified alphabet.");
 
         assert(!format.valueless_by_exception());
         std::visit([&] (auto & f)


### PR DESCRIPTION
Caught by @joshuak94 when going through the snippets. This was never tested so it was never caught. I added tests for it.