### PR TITLE
Aligned_sequence_concept - add the assign_ungapped_sequence function

### DIFF
--- a/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
+++ b/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
@@ -58,41 +58,40 @@ namespace seqan3
  * \relates seqan3::aligned_sequence_concept
  * \{
  */
-/*!\fn      inline seq_type::iterator insert_gap(seq_type & seq, typename seq_type::const_iterator pos_it)
+/*!\fn      inline gapped_seq_type::iterator insert_gap(gapped_seq_type & seq, typename gapped_seq_type::const_iterator pos_it)
  * \brief   Insert a seqan3::gap into an aligned sequence.
  * \relates seqan3::aligned_sequence_concept
  *
- * \tparam        seq_type Type of the range to modify; must model
- *                         seqan3::aligned_sequence_concept.
- * \param[in,out] seq      The aligned sequence to modify.
- * \param[in]     pos_it   The iterator pointing to the position where to insert a gap.
+ * \tparam        gapped_seq_type Type of the range to modify; must model seqan3::aligned_sequence_concept.
+ * \param[in,out] seq             The aligned sequence to modify.
+ * \param[in]     pos_it          The iterator pointing to the position where to insert a gap.
  *
  * \details
  * \attention This is a concept requirement, not an actual function (however types
  *            modelling this concept will provide an implementation).
  */
-/*!\fn      inline seq_type::iterator insert_gap(seq_type & seq, typename seq_type::const_iterator pos_it, typename seq_type::size_type size)
+/*!\fn      inline gapped_seq_type::iterator insert_gap(gapped_seq_type & seq, typename gapped_seq_type::const_iterator
+ *          pos_it, typename gapped_seq_type::size_type size)
  * \brief   Insert multiple seqan3::gap into an aligned sequence.
  * \relates seqan3::aligned_sequence_concept
  *
- * \tparam        seq_type Type of the range to modify; must model
- *                         seqan3::aligned_sequence_concept.
- * \param[in,out] seq      The aligned sequence to modify.
- * \param[in]     pos_it   The iterator pointing to the position where to insert a gaps.
- * \param[in]     size     The number of gap symbols to insert (will result in a gap of length `size`).
+ * \tparam        gapped_seq_type Type of the range to modify; must model seqan3::aligned_sequence_concept.
+ * \param[in,out] seq             The aligned sequence to modify.
+ * \param[in]     pos_it          The iterator pointing to the position where to insert a gaps.
+ * \param[in]     size            The number of gap symbols to insert (will result in a gap of length `size`).
  *
  * \details
  * \attention This is a concept requirement, not an actual function (however types
  *            modelling this concept will provide an implementation).
  */
-/*!\fn      inline seq_type::iterator erase_gap(seq_type & seq, typename seq_type::const_iterator pos_it)
+/*!\fn      inline gapped_seq_type::iterator erase_gap(gapped_seq_type & seq, typename gapped_seq_type::const_iterator
+ *          pos_it)
  * \brief   Erase a seqan3::gap from an aligned sequence.
  * \relates seqan3::aligned_sequence_concept
  *
- * \tparam        seq_type Type of the range to modify; must model
- *                         seqan3::aligned_sequence_concept.
- * \param[in,out] seq      The aligned sequence to modify.
- * \param[in]     pos_it   The iterator pointing to the position where to erase a gap.
+ * \tparam        gapped_seq_type Type of the range to modify; must model seqan3::aligned_sequence_concept.
+ * \param[in,out] seq             The aligned sequence to modify.
+ * \param[in]     pos_it          The iterator pointing to the position where to erase a gap.
  *
  * \throws seqan3::gap_erase_failure if there is no seqan3::gap at \p pos_it.
  *
@@ -100,15 +99,15 @@ namespace seqan3
  * \attention This is a concept requirement, not an actual function (however types
  *            modelling this concept will provide an implementation).
  */
-/*!\fn      inline seq_type::iterator erase_gap(seq_type & seq, typename seq_type::const_iterator first, typename seq_type::const_iterator last)
+/*!\fn      inline gapped_seq_type::iterator erase_gap(gapped_seq_type & seq, typename gapped_seq_type::const_iterator
+ *          first, typename gapped_seq_type::const_iterator last)
  * \brief   Erase multiple seqan3::gap from an aligned sequence.
  * \relates seqan3::aligned_sequence_concept
  *
- * \tparam        seq_type Type of the range to modify; must model
- *                         seqan3::aligned_sequence_concept.
- * \param[in,out] seq      The aligned sequence to modify.
- * \param[in]     first    The iterator pointing to the position where to start erasing gaps.
- * \param[in]     last     The iterator pointing to the position where to stop erasing gaps.
+ * \tparam        gapped_seq_type Type of the range to modify; must model seqan3::aligned_sequence_concept.
+ * \param[in,out] seq             The aligned sequence to modify.
+ * \param[in]     first           The iterator pointing to the position where to start erasing gaps.
+ * \param[in]     last            The iterator pointing to the position where to stop erasing gaps.
  *
  * \throws seqan3::gap_erase_failure if one of the characters in [\p first, \p last) no seqan3::gap.
  *
@@ -137,19 +136,15 @@ SEQAN3_CONCEPT aligned_sequence_concept =
 // -----------------------------------------------------------------------------
 
 /*!\name Aligned sequence interface for containers
- * \brief Enables containers to model seqan3::aligned_sequence_concept if they
- * model seqan3::sequence_container_concept and have a reference type assignable
- * from seqan3::gap (e.g. std::vector<seqan3::gapped<seqan3::dna4>>).
+ * \brief Enables containers to model seqan3::aligned_sequence_concept if they model seqan3::sequence_container_concept
+ * and have a value type of the seqan3::gapped alphabet.
  * \{
  */
 /*!\brief An implementation of seqan3::aligned_sequence_concept::insert_gap for sequence containers.
- * \ingroup seqan3::aligned_sequence_concept
- * \tparam        seq_type Type of the container to modify; must model
- *                         seqan3::sequence_container_concept; the reference type
- *                         (seqan3::reference_t<seq_type>) must be assignable from
- *                         seqan3::gap.
- * \param[in,out] seq      The container to modify.
- * \param[in]     pos_it   The iterator pointing to the position where to insert a gap.
+ * \tparam        gapped_seq_type Type of the container to modify; must model seqan3::sequence_container_concept;
+ *                                The value type must be a seqan3::gapped alphabet.
+ * \param[in,out] seq             The gapped container to modify.
+ * \param[in]     pos_it          The iterator pointing to the position where to insert a gap.
  *
  *
  * \details
@@ -157,23 +152,21 @@ SEQAN3_CONCEPT aligned_sequence_concept =
  * This function delegates to the member function `insert(iterator, value)` of
  * the container.
  */
-template <sequence_container_concept seq_type>
+template <sequence_container_concept gapped_seq_type>
 //!\cond
-    requires WeaklyAssignable<reference_t<seq_type>, gap const &>
+    requires detail::is_gapped_alphabet<value_type_t<gapped_seq_type>>
 //!\endcond
-inline typename seq_type::iterator insert_gap(seq_type & seq, typename seq_type::const_iterator pos_it)
+inline typename gapped_seq_type::iterator insert_gap(gapped_seq_type & seq,
+                                                     typename gapped_seq_type::const_iterator pos_it)
 {
-    return seq.insert(pos_it, value_type_t<seq_type>{gap{}});
+    return seq.insert(pos_it, value_type_t<gapped_seq_type>{gap{}});
 }
 
 /*!\brief An implementation of seqan3::aligned_sequence_concept::insert_gap for sequence containers.
- * \ingroup seqan3::aligned_sequence_concept
- * \tparam        seq_type Type of the container to modify; must model
- *                         seqan3::sequence_container_concept; the reference type
- *                         (seqan3::reference_t<seq_type>) must be assignable from
- *                         seqan3::gap.
- * \param[in,out] seq      The container to modify.
- * \param[in]     pos_it   The iterator pointing to the position where to insert gaps.
+ * \tparam        gapped_seq_type Type of the container to modify; must model seqan3::sequence_container_concept;
+ *                                The value type must be a seqan3::gapped alphabet.
+ * \param[in,out] seq             The gapped container to modify.
+ * \param[in]     pos_it          The iterator pointing to the position where to insert gaps.
  * \param[in]     size     The number of gap symbols to insert (will result in a gap of length `size`).
  *
  * \details
@@ -181,25 +174,22 @@ inline typename seq_type::iterator insert_gap(seq_type & seq, typename seq_type:
  * This function delegates to the member function `insert(iterator, `size`, `value`)`
  * of the container.
  */
-template <sequence_container_concept seq_type>
+template <sequence_container_concept gapped_seq_type>
 //!\cond
-    requires WeaklyAssignable<reference_t<seq_type>, gap const &>
+    requires detail::is_gapped_alphabet<value_type_t<gapped_seq_type>>
 //!\endcond
-inline typename seq_type::iterator insert_gap(seq_type & seq,
-                                              typename seq_type::const_iterator pos_it,
-                                              typename seq_type::size_type size)
+inline typename gapped_seq_type::iterator insert_gap(gapped_seq_type & seq,
+                                                     typename gapped_seq_type::const_iterator pos_it,
+                                                     typename gapped_seq_type::size_type size)
 {
-    return seq.insert(pos_it, size, value_type_t<seq_type>{gap{}});
+    return seq.insert(pos_it, size, value_type_t<gapped_seq_type>{gap{}});
 }
 
 /*!\brief An implementation of seqan3::aligned_sequence_concept::erase_gap for sequence containers.
- * \ingroup seqan3::aligned_sequence_concept
- * \tparam        seq_type Type of the container to modify; must model
- *                         seqan3::sequence_container_concept; the reference type
- *                         (seqan3::reference_t<seq_type>) must be assignable from
- *                         seqan3::gap.
- * \param[in,out] seq      The container to modify.
- * \param[in]     pos_it   The iterator pointing to the position where to erase a gap.
+ * \tparam        gapped_seq_type Type of the container to modify; must model seqan3::sequence_container_concept;
+ *                                The value type must be a seqan3::gapped alphabet.
+ * \param[in,out] seq             The gapped container to modify.
+ * \param[in]     pos_it          The iterator pointing to the position where to erase a gap.
  *
  * \throws seqan3::gap_erase_failure if there is no seqan3::gap at \p pos_it.
  *
@@ -209,11 +199,12 @@ inline typename seq_type::iterator insert_gap(seq_type & seq,
  * container. Before delegating, the function checks if the position pointed to
  * by \p pos_it is an actual seqan3::gap and throws an exception if not.
  */
-template <sequence_container_concept seq_type>
+template <sequence_container_concept gapped_seq_type>
 //!\cond
-    requires WeaklyAssignable<reference_t<seq_type>, gap const &>
+    requires detail::is_gapped_alphabet<value_type_t<gapped_seq_type>>
 //!\endcond
-inline typename seq_type::iterator erase_gap(seq_type & seq, typename seq_type::const_iterator pos_it)
+inline typename gapped_seq_type::iterator erase_gap(gapped_seq_type & seq,
+                                                    typename gapped_seq_type::const_iterator pos_it)
 {
     if (*pos_it != gap{}) // [[unlikely]]
         throw gap_erase_failure("The position to be erased does not contain a gap.");
@@ -222,13 +213,10 @@ inline typename seq_type::iterator erase_gap(seq_type & seq, typename seq_type::
 }
 
 /*!\brief An implementation of seqan3::aligned_sequence_concept::erase_gap for sequence containers.
- * \ingroup seqan3::aligned_sequence_concept
- * \tparam        seq_type Type of the container to modify; must model
- *                         seqan3::sequence_container_concept; the reference type
- *                         (seqan3::reference_t<seq_type>) must be assignable from
- *                         seqan3::gap.
- * \param[in,out] seq      The container to modify.
- * \param[in]     first    The iterator pointing to the position where to start erasing gaps.
+ * \tparam        gapped_seq_type Type of the container to modify; must model seqan3::sequence_container_concept;
+ *                                The value type must be a seqan3::gapped alphabet.
+ * \param[in,out] seq             The gapped container to modify.
+ * \param[in]     first           The iterator pointing to the position where to start erasing gaps.
  * \param[in]     last     The iterator pointing to the position where to stop erasing gaps.
  *
  * \throws seqan3::gap_erase_failure if one of the characters in [\p first, \p last) no seqan3::gap.
@@ -239,13 +227,13 @@ inline typename seq_type::iterator erase_gap(seq_type & seq, typename seq_type::
  * the container. Before delegating, the function checks if the range
  * [\p first, \p last) contains only seqan3::gap symbols.
  */
-template <sequence_container_concept seq_type>
+template <sequence_container_concept gapped_seq_type>
 //!\cond
-    requires WeaklyAssignable<reference_t<seq_type>, gap const &>
+    requires detail::is_gapped_alphabet<value_type_t<gapped_seq_type>>
 //!\endcond
-inline typename seq_type::iterator erase_gap(seq_type & seq,
-                                             typename seq_type::const_iterator first,
-                                             typename seq_type::const_iterator last)
+inline typename gapped_seq_type::iterator erase_gap(gapped_seq_type & seq,
+                                                    typename gapped_seq_type::const_iterator first,
+                                                    typename gapped_seq_type::const_iterator last)
 {
     for (auto it = first; it != last; ++it)
         if (*it != gap{}) // [[unlikely]]
@@ -318,7 +306,6 @@ typename range_type::iterator erase_gap(range_type & rng,
  * \param[in] last      The iterator pointing to the position where to stop erasing gaps.
  *
  * \throws seqan3::gap_erase_failure if one of the characters in [\p first, \p last) is no seqan3::gap.
- *
  *
  * \details
  *

--- a/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
+++ b/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
@@ -91,6 +91,9 @@ using unaligned_seq_t = typename unaligned_seq<t>::type;
 // aligned_sequence_concept
 // ---------------------------------------------------------------------------------------------------------------------
 
+namespace seqan3
+{
+
 /*!\interface seqan3::aligned_sequence_concept <>
  * \extends   std::ranges::ForwardRange
  * \brief     The generic concept for an aligned sequence.
@@ -98,11 +101,6 @@ using unaligned_seq_t = typename unaligned_seq<t>::type;
  *
  * This concept describes the requirements a sequence must fulfil
  * in order to be part of the seqan3::alignment object.
- *
- * The following extended type requirements for a type `T` must hold true:
- *
- *   * seqan3::reference_t<T> must model seqan3::Alphabet.
- *   * seqan3::reference_t<T> must be assignable from seqan3::gap.
  *
  * ### Concepts and doxygen
  *
@@ -114,25 +112,25 @@ using unaligned_seq_t = typename unaligned_seq<t>::type;
  * \relates seqan3::aligned_sequence_concept
  * \{
  */
-/*!\fn      inline gapped_seq_type::iterator insert_gap(gapped_seq_type & seq, typename gapped_seq_type::const_iterator pos_it)
+/*!\fn      inline aligned_seq_t::iterator insert_gap(aligned_seq_t & aligned_seq, typename aligned_seq_t::const_iterator pos_it)
  * \brief   Insert a seqan3::gap into an aligned sequence.
  * \relates seqan3::aligned_sequence_concept
  *
- * \tparam        gapped_seq_type Type of the range to modify; must model seqan3::aligned_sequence_concept.
- * \param[in,out] seq             The aligned sequence to modify.
+ * \tparam        aligned_seq_t   Type of the range to modify; must model seqan3::aligned_sequence_concept.
+ * \param[in,out] aligned_seq     The aligned sequence to modify.
  * \param[in]     pos_it          The iterator pointing to the position where to insert a gap.
  *
  * \details
  * \attention This is a concept requirement, not an actual function (however types
  *            modelling this concept will provide an implementation).
  */
-/*!\fn      inline gapped_seq_type::iterator insert_gap(gapped_seq_type & seq, typename gapped_seq_type::const_iterator
- *          pos_it, typename gapped_seq_type::size_type size)
+/*!\fn      inline aligned_seq_t::iterator insert_gap(aligned_seq_t & aligned_seq, typename aligned_seq_t::const_iterator
+ *          pos_it, typename aligned_seq_t::size_type size)
  * \brief   Insert multiple seqan3::gap into an aligned sequence.
  * \relates seqan3::aligned_sequence_concept
  *
- * \tparam        gapped_seq_type Type of the range to modify; must model seqan3::aligned_sequence_concept.
- * \param[in,out] seq             The aligned sequence to modify.
+ * \tparam        aligned_seq_t   Type of the range to modify; must model seqan3::aligned_sequence_concept.
+ * \param[in,out] aligned_seq     The aligned sequence to modify.
  * \param[in]     pos_it          The iterator pointing to the position where to insert a gaps.
  * \param[in]     size            The number of gap symbols to insert (will result in a gap of length `size`).
  *
@@ -140,13 +138,13 @@ using unaligned_seq_t = typename unaligned_seq<t>::type;
  * \attention This is a concept requirement, not an actual function (however types
  *            modelling this concept will provide an implementation).
  */
-/*!\fn      inline gapped_seq_type::iterator erase_gap(gapped_seq_type & seq, typename gapped_seq_type::const_iterator
+/*!\fn      inline aligned_seq_t::iterator erase_gap(aligned_seq_t & aligned_seq, typename aligned_seq_t::const_iterator
  *          pos_it)
  * \brief   Erase a seqan3::gap from an aligned sequence.
  * \relates seqan3::aligned_sequence_concept
  *
- * \tparam        gapped_seq_type Type of the range to modify; must model seqan3::aligned_sequence_concept.
- * \param[in,out] seq             The aligned sequence to modify.
+ * \tparam        aligned_seq_t   Type of the range to modify; must model seqan3::aligned_sequence_concept.
+ * \param[in,out] aligned_seq     The aligned sequence to modify.
  * \param[in]     pos_it          The iterator pointing to the position where to erase a gap.
  *
  * \throws seqan3::gap_erase_failure if there is no seqan3::gap at \p pos_it.
@@ -155,19 +153,38 @@ using unaligned_seq_t = typename unaligned_seq<t>::type;
  * \attention This is a concept requirement, not an actual function (however types
  *            modelling this concept will provide an implementation).
  */
-/*!\fn      inline gapped_seq_type::iterator erase_gap(gapped_seq_type & seq, typename gapped_seq_type::const_iterator
- *          first, typename gapped_seq_type::const_iterator last)
+/*!\fn      inline aligned_seq_t::iterator erase_gap(aligned_seq_t & aligned_seq, typename aligned_seq_t::const_iterator
+ *          first, typename aligned_seq_t::const_iterator last)
  * \brief   Erase multiple seqan3::gap from an aligned sequence.
  * \relates seqan3::aligned_sequence_concept
  *
- * \tparam        gapped_seq_type Type of the range to modify; must model seqan3::aligned_sequence_concept.
- * \param[in,out] seq             The aligned sequence to modify.
+ * \tparam        aligned_seq_t   Type of the range to modify; must model seqan3::aligned_sequence_concept.
+ * \param[in,out] aligned_seq     The aligned sequence to modify.
  * \param[in]     first           The iterator pointing to the position where to start erasing gaps.
  * \param[in]     last            The iterator pointing to the position where to stop erasing gaps.
  *
  * \throws seqan3::gap_erase_failure if one of the characters in [\p first, \p last) no seqan3::gap.
  *
  * \details
+ * \attention This is a concept requirement, not an actual function (however types
+ *            modelling this concept will provide an implementation).
+ */
+/*!\fn      void assign_unaligned(aligned_seq_t & aligned_seq, unaligned_sequence_type && unaligned_seq)
+ *!\brief   Assign an ungapped sequence to a gapped sequence.
+ * \relates seqan3::aligned_sequence_concept
+ *
+ * \tparam        aligned_seq_t     Type of the container to reassign; must model seqan3::aligned_sequence_concept.
+ * \tparam        unaligned_seq_t   Type of the container to assign from; must correspond to the aligned type without
+ *                                  gap information (see details.)
+ * \param[in,out] aligned_seq       The gapped sequence container to assign to.
+ * \param[in,out] unaligned_seq     The unaligned sequence container to assign from.
+ *
+ * \details
+ *
+ * An aligned sequence has to be assignable from its unaligned counter part. For example a
+ * std::vector<seqan3::gapped<seqan3::dna4>> as well as a seqan3::gap_decorator_anchor_set<std::vector<seqan3::dna4>>
+ * can be assigned from s std::vector<seqan3::dna4> via seqan3::assign_unaligned.
+ *
  * \attention This is a concept requirement, not an actual function (however types
  *            modelling this concept will provide an implementation).
  */
@@ -178,28 +195,30 @@ SEQAN3_CONCEPT aligned_sequence_concept =
     std::ranges::ForwardRange<t> &&
     Alphabet<value_type_t<t>> &&
     WeaklyAssignable<reference_t<t>, gap const &> &&
-    requires (t v)
+    requires { typename detail::unaligned_seq_t<t>; } &&
+    requires (t v, detail::unaligned_seq_t<t> & unaligned)
     {
         { insert_gap(v, v.begin()) } -> typename t::iterator; // global functions for generic usability
         { insert_gap(v, v.begin(), 2) } -> typename t::iterator;
         { erase_gap(v, v.begin()) } -> typename t::iterator;
         { erase_gap(v, v.begin(), v.end()) } -> typename t::iterator;
+        { assign_unaligned(v, unaligned) } -> void;
     };
 //!\endcond
 
-// -----------------------------------------------------------------------------
-// Functions that make sequence containers model aligned_sequence_concept
-// -----------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------------
+// Aligned sequence interface for containers over the seqan3::gapped alphabet
+// ---------------------------------------------------------------------------------------------------------------------
 
-/*!\name Aligned sequence interface for containers
+/*!\name Aligned sequence interface for containers over the seqan3::gapped alphabet
  * \brief Enables containers to model seqan3::aligned_sequence_concept if they model seqan3::sequence_container_concept
- * and have a value type of the seqan3::gapped alphabet.
+ *        and have a value type of the seqan3::gapped alphabet.
  * \{
  */
 /*!\brief An implementation of seqan3::aligned_sequence_concept::insert_gap for sequence containers.
- * \tparam        gapped_seq_type Type of the container to modify; must model seqan3::sequence_container_concept;
+ * \tparam        aligned_seq_t   Type of the container to modify; must model seqan3::sequence_container_concept;
  *                                The value type must be a seqan3::gapped alphabet.
- * \param[in,out] seq             The gapped container to modify.
+ * \param[in,out] aligned_seq     The aligned container to modify.
  * \param[in]     pos_it          The iterator pointing to the position where to insert a gap.
  *
  *
@@ -208,43 +227,43 @@ SEQAN3_CONCEPT aligned_sequence_concept =
  * This function delegates to the member function `insert(iterator, value)` of
  * the container.
  */
-template <sequence_container_concept gapped_seq_type>
+template <sequence_container_concept aligned_seq_t>
 //!\cond
-    requires detail::is_gapped_alphabet<value_type_t<gapped_seq_type>>
+    requires detail::is_gapped_alphabet<value_type_t<aligned_seq_t>>
 //!\endcond
-inline typename gapped_seq_type::iterator insert_gap(gapped_seq_type & seq,
-                                                     typename gapped_seq_type::const_iterator pos_it)
+inline typename aligned_seq_t::iterator insert_gap(aligned_seq_t & aligned_seq,
+                                                   typename aligned_seq_t::const_iterator pos_it)
 {
-    return seq.insert(pos_it, value_type_t<gapped_seq_type>{gap{}});
+    return aligned_seq.insert(pos_it, value_type_t<aligned_seq_t>{gap{}});
 }
 
 /*!\brief An implementation of seqan3::aligned_sequence_concept::insert_gap for sequence containers.
- * \tparam        gapped_seq_type Type of the container to modify; must model seqan3::sequence_container_concept;
+ * \tparam        aligned_seq_t   Type of the container to modify; must model seqan3::sequence_container_concept;
  *                                The value type must be a seqan3::gapped alphabet.
- * \param[in,out] seq             The gapped container to modify.
+ * \param[in,out] aligned_seq     The aligned container to modify.
  * \param[in]     pos_it          The iterator pointing to the position where to insert gaps.
- * \param[in]     size     The number of gap symbols to insert (will result in a gap of length `size`).
+ * \param[in]     size            The number of gap symbols to insert (will result in a gap of length `size`).
  *
  * \details
  *
  * This function delegates to the member function `insert(iterator, `size`, `value`)`
  * of the container.
  */
-template <sequence_container_concept gapped_seq_type>
+template <sequence_container_concept aligned_seq_t>
 //!\cond
-    requires detail::is_gapped_alphabet<value_type_t<gapped_seq_type>>
+    requires detail::is_gapped_alphabet<value_type_t<aligned_seq_t>>
 //!\endcond
-inline typename gapped_seq_type::iterator insert_gap(gapped_seq_type & seq,
-                                                     typename gapped_seq_type::const_iterator pos_it,
-                                                     typename gapped_seq_type::size_type size)
+inline typename aligned_seq_t::iterator insert_gap(aligned_seq_t & aligned_seq,
+                                                   typename aligned_seq_t::const_iterator pos_it,
+                                                   typename aligned_seq_t::size_type size)
 {
-    return seq.insert(pos_it, size, value_type_t<gapped_seq_type>{gap{}});
+    return aligned_seq.insert(pos_it, size, value_type_t<aligned_seq_t>{gap{}});
 }
 
 /*!\brief An implementation of seqan3::aligned_sequence_concept::erase_gap for sequence containers.
- * \tparam        gapped_seq_type Type of the container to modify; must model seqan3::sequence_container_concept;
+ * \tparam        aligned_seq_t   Type of the container to modify; must model seqan3::sequence_container_concept;
  *                                The value type must be a seqan3::gapped alphabet.
- * \param[in,out] seq             The gapped container to modify.
+ * \param[in,out] aligned_seq     The aligned container to modify.
  * \param[in]     pos_it          The iterator pointing to the position where to erase a gap.
  *
  * \throws seqan3::gap_erase_failure if there is no seqan3::gap at \p pos_it.
@@ -255,25 +274,25 @@ inline typename gapped_seq_type::iterator insert_gap(gapped_seq_type & seq,
  * container. Before delegating, the function checks if the position pointed to
  * by \p pos_it is an actual seqan3::gap and throws an exception if not.
  */
-template <sequence_container_concept gapped_seq_type>
+template <sequence_container_concept aligned_seq_t>
 //!\cond
-    requires detail::is_gapped_alphabet<value_type_t<gapped_seq_type>>
+    requires detail::is_gapped_alphabet<value_type_t<aligned_seq_t>>
 //!\endcond
-inline typename gapped_seq_type::iterator erase_gap(gapped_seq_type & seq,
-                                                    typename gapped_seq_type::const_iterator pos_it)
+inline typename aligned_seq_t::iterator erase_gap(aligned_seq_t & aligned_seq,
+                                                  typename aligned_seq_t::const_iterator pos_it)
 {
     if (*pos_it != gap{}) // [[unlikely]]
         throw gap_erase_failure("The position to be erased does not contain a gap.");
 
-    return seq.erase(pos_it);
+    return aligned_seq.erase(pos_it);
 }
 
 /*!\brief An implementation of seqan3::aligned_sequence_concept::erase_gap for sequence containers.
- * \tparam        gapped_seq_type Type of the container to modify; must model seqan3::sequence_container_concept;
+ * \tparam        aligned_seq_t   Type of the container to modify; must model seqan3::sequence_container_concept;
  *                                The value type must be a seqan3::gapped alphabet.
- * \param[in,out] seq             The gapped container to modify.
+ * \param[in,out] aligned_seq     The aligned container to modify.
  * \param[in]     first           The iterator pointing to the position where to start erasing gaps.
- * \param[in]     last     The iterator pointing to the position where to stop erasing gaps.
+ * \param[in]     last            The iterator pointing to the position where to stop erasing gaps.
  *
  * \throws seqan3::gap_erase_failure if one of the characters in [\p first, \p last) no seqan3::gap.
  *
@@ -283,19 +302,56 @@ inline typename gapped_seq_type::iterator erase_gap(gapped_seq_type & seq,
  * the container. Before delegating, the function checks if the range
  * [\p first, \p last) contains only seqan3::gap symbols.
  */
-template <sequence_container_concept gapped_seq_type>
+template <sequence_container_concept aligned_seq_t>
 //!\cond
-    requires detail::is_gapped_alphabet<value_type_t<gapped_seq_type>>
+    requires detail::is_gapped_alphabet<value_type_t<aligned_seq_t>>
 //!\endcond
-inline typename gapped_seq_type::iterator erase_gap(gapped_seq_type & seq,
-                                                    typename gapped_seq_type::const_iterator first,
-                                                    typename gapped_seq_type::const_iterator last)
+inline typename aligned_seq_t::iterator erase_gap(aligned_seq_t & aligned_seq,
+                                                  typename aligned_seq_t::const_iterator first,
+                                                  typename aligned_seq_t::const_iterator last)
 {
     for (auto it = first; it != last; ++it)
         if (*it != gap{}) // [[unlikely]]
             throw gap_erase_failure("The range to be erased contains at least one non-gap character.");
 
-    return seq.erase(first, last);
+    return aligned_seq.erase(first, last);
+}
+
+/*!\brief An implementation of seqan3::aligned_sequence_concept::assign_unaligned_sequence for sequence containers.
+ * \tparam        aligned_seq_t     Type of the container to reassign; must model seqan3::sequence_container_concept;
+ *                                  the value type must be a seqan3::gapped alphabet.
+ * \tparam        unaligned_seq_t   Type of the container to assign from; must model std::ranges::ForwardRange;
+ * \param[in,out] aligned_seq       The gapped sequence container to assign to.
+ * \param[in,out] unaligned_seq     The unaligned sequence container to assign from.
+ *
+ * \relates seqan3::aligned_sequence_concept
+ *
+ * \details
+ *
+ * This function clears the content of the `gapped` container and reassigns the content of the `unaligned` container by
+ * using std::copy.
+ *
+ * ### Performance
+ *
+ * Linear in the size of unaligned_seq.
+ *
+ * ### Exceptions
+ *
+ * Strong exception guarantee.
+ *
+ */
+template <sequence_container_concept aligned_seq_t, std::ranges::ForwardRange unaligned_sequence_type>
+//!\cond
+    requires detail::is_gapped_alphabet<value_type_t<aligned_seq_t>> &&
+             WeaklyAssignable<reference_t<aligned_seq_t>, reference_t<unaligned_sequence_type>>
+//!\endcond
+inline void assign_unaligned(aligned_seq_t & aligned_seq, unaligned_sequence_type && unaligned_seq)
+{
+    using std::swap;
+    aligned_seq_t tmp;
+    tmp.resize(std::ranges::distance(unaligned_seq));
+    std::copy(std::ranges::begin(unaligned_seq), std::ranges::end(unaligned_seq), std::ranges::begin(tmp));
+    swap(aligned_seq, tmp);
 }
 //!\}
 

--- a/include/seqan3/alphabet/gap/gapped.hpp
+++ b/include/seqan3/alphabet/gap/gapped.hpp
@@ -42,3 +42,21 @@ template <typename alphabet_t>
 using gapped = union_composition<gap, alphabet_t>;
 
 } // namespace seqan3
+
+namespace seqan3::detail
+{
+// ---------------------------------------------------------------------------------------------------------------------
+// is_gapped_alphabet constexpr variable
+// ---------------------------------------------------------------------------------------------------------------------
+
+//!\brief Helper variable to determine if an alphabet is gapped [default: false].
+//!\ingroup gap
+template <typename t>
+constexpr bool is_gapped_alphabet = false;
+
+//!\brief Helper variable to determine if an alphabet is gapped, true for specilisations of seqan3::gapped.
+//!\ingroup gap
+template <typename t>
+constexpr bool is_gapped_alphabet<gapped<t>> = true;
+
+} // namespace seqan3::detail

--- a/include/seqan3/range/decorator/gap_decorator_anchor_set.hpp
+++ b/include/seqan3/range/decorator/gap_decorator_anchor_set.hpp
@@ -349,7 +349,7 @@ public:
     //!\}
 
     //!\brief The underlying ungapped range type.
-    using ungapped_range_type = inner_type;
+    using unaligned_seq_type = inner_type;
 
     /*!\name Constructors, destructor and assignment.
      * \{
@@ -520,6 +520,15 @@ public:
         update(it, pos2 - pos1);
 
         return iterator{*this, pos1};
+    }
+
+    /*!\brief Assigns a new sequence of type seqan3:;gap_decorator_anchor_set::unaligned_seq_type to the decorator.
+     * \param[in,out] dec       The decorator to modify.
+     * \param[in]     unaligned The unaligned sequence to assign.
+     */
+    friend void assign_unaligned(gap_decorator_anchor_set & dec, unaligned_seq_type & unaligned)
+    {
+        dec = unaligned;
     }
     //!\}
 

--- a/test/unit/alignment/aligned_sequence_test_template.hpp
+++ b/test/unit/alignment/aligned_sequence_test_template.hpp
@@ -27,6 +27,29 @@ TYPED_TEST_CASE_P(aligned_sequence);
 TYPED_TEST_P(aligned_sequence, fulfills_concept)
 {
     EXPECT_TRUE((aligned_sequence_concept<TypeParam>));
+    EXPECT_FALSE((aligned_sequence_concept<std::vector<dna4>>));
+}
+
+TYPED_TEST_P(aligned_sequence, assign_unaligned_sequence)
+{
+    using unaligned_seq_type = detail::unaligned_seq_t<TypeParam>;
+    unaligned_seq_type unaligned{};
+
+    if constexpr (sequence_container_concept<unaligned_seq_type>)
+    {
+        unaligned.resize(seq.size());
+        std::copy(seq.begin(), seq.end(), begin(unaligned));
+    }
+    else // type is view, happens for gap_decorator tests
+        unaligned = unaligned_seq_type{seq};
+
+    TypeParam aligned{};
+
+    assign_unaligned(aligned, unaligned);
+
+    EXPECT_EQ(aligned.size(), unaligned.size());
+    EXPECT_EQ(*aligned.begin(), *unaligned.begin());
+    EXPECT_EQ(*std::ranges::next(begin(aligned)), *(unaligned.begin() + 1));
 }
 
 TYPED_TEST_P(aligned_sequence, insert_one_gap)
@@ -257,6 +280,7 @@ TYPED_TEST_P(aligned_sequence, cigar_string)
 
 REGISTER_TYPED_TEST_CASE_P(aligned_sequence,
                            fulfills_concept,
+                           assign_unaligned_sequence,
                            insert_one_gap,
                            insert_multiple_gaps,
                            insert_zero_gaps,


### PR DESCRIPTION
Also adds (individual commits)

* is_gapped_alphabet helper and constrains the container functions to the ones with value type seqn3::gapped
* the ungapped sequence_type metafunction
* The assign_ungapped_sequence free function for containers over gapped alphabets.