### PR TITLE
[FEATURE] Adapts the alignment algorithm to work with the aligned_ends configuration.

### DIFF
--- a/include/seqan3/alignment/pairwise/alignment_algorithm.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_algorithm.hpp
@@ -159,6 +159,8 @@ private:
         {
             this->init_column_cell(cell, cache);
         });
+
+        this->check_score_last_row(get<0>(*(seqan3::end(col) - 1)), get<3>(cache));
     }
 
     /*!\brief Compute the alignment by iterating over the dynamic programming matrix in a column wise manner.

--- a/include/seqan3/alignment/pairwise/alignment_algorithm.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_algorithm.hpp
@@ -69,7 +69,7 @@ namespace seqan3::detail
  */
 template <typename config_t, typename ...algorithm_policies_t>
 class alignment_algorithm :
-    protected invoke_deferred_crtp_base<algorithm_policies_t, alignment_algorithm<algorithm_policies_t...>>...
+    public invoke_deferred_crtp_base<algorithm_policies_t, alignment_algorithm<config_t, algorithm_policies_t...>>...
 {
 public:
     /*!\name Constructor, destructor and assignment
@@ -137,8 +137,7 @@ public:
         // Choose what needs to be computed.
         if constexpr (config_t::template exists<align_cfg::result<detail::with_score_type>>())
         {
-            auto last_col = this->current_column();
-            res.score = get<0>(*(std::ranges::end(last_col) - 1));
+            res.score = get<3>(cache);
         }
         return align_result{res};
     }
@@ -177,6 +176,7 @@ private:
                         second_batch_t const & second_batch,
                         cache_t & cache)
     {
+        using std::get;
         auto const & score_scheme = get<align_cfg::scoring>(*cfg_ptr).value;
         ranges::for_each(first_batch, [&, this](auto seq1_value)
         {
@@ -189,7 +189,9 @@ private:
                 this->compute_cell(cell, cache, score_scheme.score(seq1_value, *second_batch_it));
                 ++second_batch_it;
             });
+            this->check_score_last_row(get<0>(*(seqan3::end(col) - 1)), get<3>(cache));
         });
+        this->check_score_last_column(this->current_column(), get<3>(cache));
     }
 
     //!\brief The alignment configuration stored on the heap.

--- a/include/seqan3/alignment/pairwise/alignment_configurator.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_configurator.hpp
@@ -51,7 +51,9 @@ private:
     /*!\brief Auxiliary member types
      * \{
      */
+     //!\brief The type of the first sequence.
     using first_seq_t  = std::tuple_element_t<0, value_type_t<std::ranges::iterator_t<range_type>>>;
+    //!\brief The type of the second sequence.
     using second_seq_t = std::tuple_element_t<1, value_type_t<std::ranges::iterator_t<range_type>>>;
     //!\}
 
@@ -86,9 +88,16 @@ public:
  */
 struct alignment_configurator
 {
-    //!\brief Configure the algorithm.
-    template <std::ranges::ViewableRange sequences_t, typename config_t>
+    /*!\brief Configures the algorithm.
+     * \tparam sequences_t The range type containing the sequence pairs; must model std::ranges::ForwardRange.
+     * \tparam config_t    The alignment configuration type; must be a specialisation of seqan3::configuration.
+     * \param[in]     seq_range The range over the sequence pairs.
+     * \param[in,out] cfg       The configuration object.
+     */
+    template <std::ranges::ForwardRange sequences_t, typename config_t>
+    //!\cond
         requires is_type_specialisation_of_v<remove_cvref_t<config_t>, configuration>
+    //!\endcond
     static constexpr auto configure(sequences_t seq_range, config_t const & cfg)
     {
         // ----------------------------------------------------------------------------
@@ -104,9 +113,8 @@ struct alignment_configurator
 
         // Select the result type based on the sequences and the configuration.
         using result_t = align_result<typename align_result_selector<first_seq_t, second_seq_t, config_t>::type>;
-        // Define the kernel type.
-        using kernel_t = std::function<result_t(first_seq_t const &, second_seq_t const &)>;
-
+        // Define the function wrapper type.
+        using function_wrapper_t = std::function<result_t(first_seq_t const &, second_seq_t const &)>;
 
         // ----------------------------------------------------------------------------
         // Test some basic preconditions
@@ -149,7 +157,7 @@ struct alignment_configurator
             {
                 if ((scoring_scheme.score('A'_dna15, 'A'_dna15) == 0) &&
                     (scoring_scheme.score('A'_dna15, 'C'_dna15)) == -1)
-                    return configure_edit_distance<kernel_t>(cfg);
+                    return configure_edit_distance<function_wrapper_t>(cfg);
             }
         }
 
@@ -157,33 +165,201 @@ struct alignment_configurator
         // Unsupported configurations
         // ----------------------------------------------------------------------------
 
-        if constexpr (config_t::template exists<align_cfg::aligned_ends>())
-            throw std::domain_error{"Configuring the aligned ends is yet not supported."};
-
         if constexpr (config_t::template exists<align_cfg::result<with_begin_position_type>>())
             throw std::domain_error{"Computing the begin position is yet not supported."};
 
         if constexpr (config_t::template exists<align_cfg::result<with_trace_type>>())
             throw std::domain_error{"Computing the traceback is yet not supported."};
 
-        // Configure non-edit distance alignment algorithm.
-        using score_type = int;
-        using cell_type = std::pair<score_type, score_type>;
-        using dp_matrix_t = deferred_crtp_base<unbanded_dp_matrix_policy, std::allocator<cell_type>>;
-        using affine_t = deferred_crtp_base<affine_gap_policy, cell_type>;
-        using init_t = deferred_crtp_base<affine_gap_init_policy>;
-
-        return kernel_t{alignment_algorithm<config_t, dp_matrix_t, affine_t, init_t>{cfg}};
+        // Configure the alignment algorithm.
+        return configure_free_ends_initialisation<function_wrapper_t>(cfg);
     }
 
 private:
 
-    //!\brief Configure the edit distance algorithm.
-    template <typename kernel_t, typename config_t>
-    static constexpr auto configure_edit_distance(config_t const & cfg)
+    /*!\brief Configures the edit distance algorithm.
+     * \tparam function_wrapper_t The invocable alignment function type-erased via std::function.
+     * \tparam config_t           The alignment configuration type.
+     * \param[in] cfg             The passed configuration object.
+     */
+    template <typename function_wrapper_t, typename config_t>
+    static constexpr function_wrapper_t configure_edit_distance(config_t const & cfg)
     {
-        return kernel_t{edit_distance_wrapper<remove_cvref_t<config_t>>{cfg}};
+        return function_wrapper_t{edit_distance_wrapper<remove_cvref_t<config_t>>{cfg}};
     }
+
+    /*!\brief Configures the dynamic programming matrix initialisation accoring to seqan3::align_cfg::aligned_ends
+     *        settings.
+     * \tparam function_wrapper_t The invocable alignment function type-erased via std::function.
+     * \tparam config_t           The alignment configuration type.
+     * \param[in] cfg   The passed configuration object.
+     *
+     * \details
+     *
+     * The matrix initialisation depends on the settings for the leading gaps for the first and the second sequence
+     * within the seqan3::align_cfg::aligned_ends configuration element.
+     */
+    template <typename function_wrapper_t, typename config_t>
+    static constexpr function_wrapper_t configure_free_ends_initialisation(config_t const & cfg);
+
+    /*!\brief Configures the search space for the alignment algorithm according to seqan3::align_cfg::aligned_ends
+     *        settings.
+     * \tparam function_wrapper_t The invocable alignment function type-erased via std::function.
+     * \tparam policies_t         A template parameter pack for the already configured policy types.
+     * \tparam config_t     The alignment configuration type.
+     * \param[in] cfg       The passed configuration object.
+     *
+     * \details
+     *
+     * This option is configured in the seqan3::align_cfg::aligned_ends configuration element according to
+     * the settings for the trailing gaps of the first and the second sequence.
+     */
+    template <typename function_wrapper_t, typename ...policies_t, typename config_t>
+    static constexpr function_wrapper_t configure_free_ends_optimum_search(config_t const & cfg);
+
 };
 
+//!\cond
+// This function returns a std::function object which can capture runtime dependent alignment algorithm types through
+// a fixed invocation interface which is already defined by the caller of this function.
+template <typename function_wrapper_t, typename config_t>
+constexpr function_wrapper_t alignment_configurator::configure_free_ends_initialisation(config_t const & cfg)
+{
+    // ----------------------------------------------------------------------------
+    // score and cell type
+    // ----------------------------------------------------------------------------
+
+    using score_type = int;
+    using cell_type = std::tuple<score_type, score_type>;
+
+    // ----------------------------------------------------------------------------
+    // dynamic programming matrix
+    // ----------------------------------------------------------------------------
+
+    using dp_matrix_t = deferred_crtp_base<unbanded_dp_matrix_policy, std::allocator<cell_type>>;
+
+    // ----------------------------------------------------------------------------
+    // affine gap kernel
+    // ----------------------------------------------------------------------------
+
+    using affine_t = deferred_crtp_base<affine_gap_policy, cell_type>;
+
+    // ----------------------------------------------------------------------------
+    // configure initialisation policy
+    // ----------------------------------------------------------------------------
+
+    // Get the value for the sequence ends configuration.
+    auto align_ends_cfg = cfg.template value_or<align_cfg::aligned_ends>(align_cfg::none_ends_free);
+    using align_ends_cfg_t = decltype(align_ends_cfg);
+
+    // This lambda augments the initialisation policy of the alignment algorithm
+    // with the aligned_ends configuration from before.
+    auto _leading_both = [&](auto first_seq, auto second_seq) constexpr
+    {
+        // Define the trait for the initialisation policy
+        struct _trait
+        {
+            using free_first_leading_t  [[maybe_unused]] = decltype(first_seq);
+            using free_second_leading_t [[maybe_unused]] = decltype(second_seq);
+        };
+
+        // Make initialisation policy a deferred CRTP base and delegate to configure the find optimum policy.
+        using init_t = deferred_crtp_base<affine_gap_init_policy, _trait>;
+        return configure_free_ends_optimum_search<function_wrapper_t, affine_t, dp_matrix_t, init_t>(cfg);
+    };
+
+    // This lambda determines the initialisation configuration for the second sequence given
+    // the leading gap property for it.
+    auto _leading_second = [&](auto first) constexpr
+    {
+        // If possible use static information.
+        if constexpr (align_ends_cfg_t::template is_static<2>())
+        {
+            return _leading_both(first, std::integral_constant<bool, align_ends_cfg_t::template get_static<2>()>{});
+        }
+        else
+        {   // Resolve correct property at runtime.
+            if (align_ends_cfg[2])
+                return _leading_both(first, std::true_type{});
+            else
+                return _leading_both(first, std::false_type{});
+        }
+    };
+
+    // Here the initialisation configuration for the first sequence is determined given
+    // the leading gap property for it.
+    // If possible use static information.
+    if constexpr (align_ends_cfg_t::template is_static<0>())
+    {
+        return _leading_second(std::integral_constant<bool, align_ends_cfg_t::template get_static<0>()>{});
+    }
+    else
+    {  // Resolve correct property at runtime.
+        if (align_ends_cfg[0])
+            return _leading_second(std::true_type{});
+        else
+            return _leading_second(std::false_type{});
+    }
+}
+//!\endcond
+
+//!\cond
+// This function returns a std::function object which can capture runtime dependent alignment algorithm types through
+// a fixed invocation interface which is already defined by the caller of this function.
+template <typename function_wrapper_t, typename ...policies_t, typename config_t>
+constexpr function_wrapper_t alignment_configurator::configure_free_ends_optimum_search(config_t const & cfg)
+{
+    // Get the value for the sequence ends configuration.
+    auto align_ends_cfg = cfg.template value_or<align_cfg::aligned_ends>(align_cfg::none_ends_free);
+    using align_ends_cfg_t = decltype(align_ends_cfg);
+
+    // This lambda augments the find optimum policy of the alignment algorithm with the
+    // respective aligned_ends configuration.
+    auto _trailing_both = [&](auto first_seq, auto second_seq) constexpr
+    {
+        struct _trait
+        {
+            using find_in_every_cell_type  [[maybe_unused]] = std::false_type;
+            using find_in_last_row_type    [[maybe_unused]] = decltype(first_seq);
+            using find_in_last_column_type [[maybe_unused]] = decltype(second_seq);
+        };
+
+        using init_t = deferred_crtp_base<find_optimum_policy, _trait>;
+        return function_wrapper_t{alignment_algorithm<config_t, policies_t..., init_t>{cfg}};
+    };
+
+    // This lambda determines the lookup configuration for the second sequence given
+    // the trailing gap property for it.
+    auto _trailing_second = [&](auto first) constexpr
+    {
+        // If possible use static information.
+        if constexpr (align_ends_cfg_t::template is_static<3>())
+        {
+            return _trailing_both(first, std::integral_constant<bool, align_ends_cfg_t::template get_static<3>()>{});
+        }
+        else
+        { // Resolve correct property at runtime.
+            if (align_ends_cfg[3])
+                return _trailing_both(first, std::true_type{});
+            else
+                return _trailing_both(first, std::false_type{});
+        }
+    };
+
+    // Here the lookup configuration for the first sequence is determined given
+    // the trailing gap property for it.
+    // If possible use static information.
+    if constexpr (align_ends_cfg_t::template is_static<1>())
+    {
+        return _trailing_second(std::integral_constant<bool, align_ends_cfg_t::template get_static<1>()>{});
+    }
+    else
+    { // Resolve correct property at runtime.
+        if (align_ends_cfg[1])
+            return _trailing_second(std::true_type{});
+        else
+            return _trailing_second(std::false_type{});
+    }
+}
+//!\endcond
 } // namespace seqan3::detail

--- a/include/seqan3/alignment/pairwise/policy/affine_gap_init_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/affine_gap_init_policy.hpp
@@ -14,20 +14,40 @@
 
 #include <tuple>
 
-#include <seqan3/alignment/configuration/align_config_aligned_ends.hpp>
-#include <seqan3/core/algorithm/configuration.hpp>
+#include <seqan3/core/platform.hpp>
 
 namespace seqan3::detail
 {
 
-/*!\brief Implements the Initialisation of the dynamic programming matrix with affine gaps.
+/*!\brief The default traits class for seqan3::detail::affine_gap_init_policy.
+ * \ingroup alignment_policy
+ *
+ * \details
+ *
+ * Enables the behaviour of a global alignment where both sides of the dynamic programming matrix are
+ * initialised with growing gap penalties.
+ */
+struct default_affine_init_traits
+{
+    //!\brief A std::bool_constant to enable/disable free end gaps for the leading gaps of the first sequence.
+    using free_first_leading_t  = std::false_type;
+    //!\brief A std::bool_constant to enable/disable free end gaps for the leading gaps of the second sequence.
+    using free_second_leading_t = std::false_type;
+};
+
+/*!\brief Implements the initialisation of the dynamic programming matrix with affine gaps.
  * \ingroup alignment_policy
  * \tparam derived_t   The derived alignment algorithm.
+ * \tparam traits_type The traits type to determine the initialisation rules of the dynamic programming matrix.
+ *                     Defaults to seqan3::detail::default_affine_init_traits.
  */
-template <typename derived_t>
+template <typename derived_t, typename traits_type = default_affine_init_traits>
 class affine_gap_init_policy
 {
-protected:
+private:
+
+    //!\brief Befriends the derived class to grant it access to the private members.
+    friend derived_t;
     /*!\name Constructor, destructor and assignment
      * \brief Defaulted all standard constructor.
      * \{
@@ -52,12 +72,21 @@ protected:
         using std::get;
 
         auto & [main_score, hz_score] = current_cell;
-        auto & [prev_cell, gap_open, gap_extend] = cache;
-        auto & vt_score = get<1>(prev_cell);
+        auto & vt_score = get<1>(get<0>(cache));
 
         main_score = 0;
-        hz_score = gap_open + gap_extend;
-        vt_score = gap_open + gap_extend;
+
+        // Initialise the vertical matrix cell according to the traits settings.
+        if constexpr (traits_type::free_first_leading_t::value)
+            vt_score = 0;
+        else
+            vt_score = get<1>(cache);
+
+        // Initialise the horizontal matrix cell according to the traits settings.
+        if constexpr (traits_type::free_second_leading_t::value)
+            hz_score = 0;
+        else
+            hz_score = get<1>(cache);
     }
 
     /*!\brief Initialises a cell in the first column of the dynamic programming matrix.
@@ -72,12 +101,17 @@ protected:
         using std::get;
 
         auto & [main_score, hz_score] = current_cell;
-        auto & [prev_cell, gap_open, gap_extend] = cache;
-        auto & vt_score = get<1>(prev_cell);
+        auto & vt_score = get<1>(get<0>(cache));
 
         main_score = vt_score;
-        hz_score = main_score + gap_open + gap_extend;
-        vt_score += gap_extend;
+
+        // Initialise the vertical matrix cell according to the traits settings.
+        if constexpr (traits_type::free_first_leading_t::value)
+            vt_score = 0;
+        else
+            vt_score += get<2>(cache);
+
+        hz_score = main_score + get<1>(cache);
     }
 
     /*!\brief Initialises a cell in the first row of the dynamic programming matrix.
@@ -89,14 +123,22 @@ protected:
     template <typename cell_t, typename cache_t>
     constexpr auto init_row_cell(cell_t & current_cell, cache_t & cache) const noexcept
     {
+        using std::get;
+
         auto & [main_score, hz_score] = current_cell;
-        auto & [prev_cell, gap_open, gap_extend] = cache;
-        auto & [prev_score, vt_score] = prev_cell;
+        auto & [prev_score, vt_score] = get<0>(cache);
 
         prev_score = main_score;
         main_score = hz_score;
-        hz_score += gap_extend;
-        vt_score += main_score + gap_open + gap_extend;
+
+        vt_score += main_score + get<1>(cache);
+
+        // Initialise the horizontal matrix cell according to the traits settings.
+        if constexpr (traits_type::free_second_leading_t::value)
+            hz_score = 0;
+        else
+            hz_score += get<2>(cache);
+
     }
 };
 

--- a/include/seqan3/alignment/pairwise/policy/affine_gap_init_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/affine_gap_init_policy.hpp
@@ -77,13 +77,13 @@ private:
         main_score = 0;
 
         // Initialise the vertical matrix cell according to the traits settings.
-        if constexpr (traits_type::free_first_leading_t::value)
+        if constexpr (traits_type::free_second_leading_t::value)
             vt_score = 0;
         else
             vt_score = get<1>(cache);
 
         // Initialise the horizontal matrix cell according to the traits settings.
-        if constexpr (traits_type::free_second_leading_t::value)
+        if constexpr (traits_type::free_first_leading_t::value)
             hz_score = 0;
         else
             hz_score = get<1>(cache);
@@ -106,7 +106,7 @@ private:
         main_score = vt_score;
 
         // Initialise the vertical matrix cell according to the traits settings.
-        if constexpr (traits_type::free_first_leading_t::value)
+        if constexpr (traits_type::free_second_leading_t::value)
             vt_score = 0;
         else
             vt_score += get<2>(cache);
@@ -134,7 +134,7 @@ private:
         vt_score += main_score + get<1>(cache);
 
         // Initialise the horizontal matrix cell according to the traits settings.
-        if constexpr (traits_type::free_second_leading_t::value)
+        if constexpr (traits_type::free_first_leading_t::value)
             hz_score = 0;
         else
             hz_score += get<2>(cache);

--- a/include/seqan3/alignment/pairwise/policy/all.hpp
+++ b/include/seqan3/alignment/pairwise/policy/all.hpp
@@ -16,6 +16,7 @@
 
 #include <seqan3/alignment/pairwise/policy/affine_gap_init_policy.hpp>
 #include <seqan3/alignment/pairwise/policy/affine_gap_policy.hpp>
+#include <seqan3/alignment/pairwise/policy/find_optimum_policy.hpp>
 #include <seqan3/alignment/pairwise/policy/unbanded_dp_matrix_policy.hpp>
 
 //!\cond DEV
@@ -132,5 +133,38 @@
  * ### Existing gap init policies:
  *
  *  - seqan3::detail::affine_gap_init_policy
+ *
+ * ## Find optimum policies
+ *
+ * These policies are used to define the search space of the alignment optimum.
+ *
+ * Function name             | Arguments                     | Return value                         |
+ * ------------------------- | ----------------------------- | ------------------------------------ |
+ * `check_score`             | `score const`, `optimum &`    | `void`                               |
+ * `check_score_last_row`    | `score const`, `optimum &`    | `void`                               |
+ * `check_score_last_column` | `rng_t &&`, `optimum &`       | `void`                               |
+ *
+ * - check_score:
+ *
+ *    Is called for every cell in the dynamic programming matrix. Might be a "NO-OP".
+ *    The left operand is the score of the current cell and the right operand is the current optimum that will
+ *    be updated if the current score was higher.
+ *
+ * - check_score_last_row:
+ *
+ *    Is called only for the cells in the last row of the dynamic programming matrix. Might be a NO-OP.
+ *    The left operand is the score of the current cell and the right operand is the current optimum that will
+ *    be updated if the current score was higher.
+ *
+ * - check_score_last_column:
+ *
+ *    Is called only for the cells in the last column of the dynamic programming matrix.
+ *    The left operand is the entire last column, because the algorithm's layout is column based.
+ *    This function might skip the entire range and only compare the last value (the score for the global alignment)
+ *    depending on the alignment configuration.
+ *
+ * ### Existing optimum policies:
+ *
+ *  - seqan3::detail::find_optimum_policy
  */
 //!\endcond

--- a/include/seqan3/alignment/pairwise/policy/find_optimum_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/find_optimum_policy.hpp
@@ -1,0 +1,146 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides seqan3::detail::find_optimum_policy.
+ * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <type_traits>
+
+#include <range/v3/algorithm/for_each.hpp>
+
+#include <seqan3/core/metafunction/deferred_crtp_base.hpp>
+#include <seqan3/range/shortcuts.hpp>
+#include <seqan3/std/concepts>
+#include <seqan3/std/ranges>
+
+namespace seqan3::detail
+{
+
+/*!\brief The default traits class for seqan3::detail::find_optimum_policy.
+ * \ingroup alignment_policy
+ *
+ * \details
+ *
+ * Defines the behaviour of a global alignment in which only the last cell of the dynamic programming matrix is
+ * checked for the optimum.
+ */
+struct default_find_optimum_trait
+{
+    //!\brief Disables optimum search in every cell of the dynamic programming matrix.
+    using find_in_every_cell_type  = std::false_type;
+    //!\brief Disables optimum search in the last row of the dynamic programming matrix.
+    using find_in_last_row_type    = std::false_type;
+    //!\brief Disables optimum search in the last column of the dynamic programming matrix.
+    using find_in_last_column_type = std::false_type;
+};
+
+/*!\brief A policy to determine the optimum of the dynamic programming matrix.
+ * \ingroup alignment_policy
+ * \tparam derived_t        The type of the derived class.
+ * \tparam traits_type      A traits type that determines which cells should be considered for the optimum.
+ *                          Defaults to seqan3::detail::default_find_optimum_trait.
+ *
+ * \details
+ *
+ * This class determines the matrix wide optimum. The search space can be further refined using the
+ * `traits_type` which configures the search space of the alignment matrix.
+ */
+template <typename derived_t, typename traits_type = default_find_optimum_trait>
+class find_optimum_policy
+{
+
+private:
+
+    //!\brief Befriends the derived class to grant it access to the private members.
+    friend derived_t;
+
+    /*!\name Constructor, destructor and assignment
+     * \{
+     */
+    constexpr find_optimum_policy() = default;
+    constexpr find_optimum_policy(find_optimum_policy const &) = default;
+    constexpr find_optimum_policy(find_optimum_policy &&) = default;
+    constexpr find_optimum_policy & operator=(find_optimum_policy const &) = default;
+    constexpr find_optimum_policy & operator=(find_optimum_policy &&) = default;
+    ~find_optimum_policy() = default;
+    //!}
+
+protected:
+
+    /*!\brief Checks every cell of the dynamic programming matrix.
+     * \tparam score_t The type of the score.
+     * \param[in]     val       The current value.
+     * \param[in,out] optimum   The current optimum to compare with.
+     *
+     * \details
+     *
+     * This function resolves to a "NO-OP" function if the trait for searching every cell is set to std::false_type.
+     */
+    template <typename score_t>
+    constexpr void check_score([[maybe_unused]] score_t const val,
+                               [[maybe_unused]] score_t & optimum) const noexcept
+    {
+        if constexpr (traits_type::find_in_every_cell_type::value)
+            optimum = std::max(optimum, val);
+    }
+
+    /*!\brief Checks a cell of the last row of the dynamic programming matrix.
+     * \tparam score_t The type of the score.
+     * \param[in]     val       The current value.
+     * \param[in,out] optimum   The current optimum to compare with.
+     *
+     * \details
+     *
+     * This function resolves to a "NO-OP" function if the trait for searching the last row is set to std::false_type.
+     * Due to a column based iteration layout this computes only one cell at a time. The alignment algorithm
+     * takes care of calling this function for the appropriate cells.
+     */
+    template <typename score_t>
+    constexpr void check_score_last_row([[maybe_unused]] score_t const val,
+                                        [[maybe_unused]] score_t & optimum) const noexcept
+    {
+        if constexpr (traits_type::find_in_last_row_type::value)
+            optimum = std::max(optimum, val);
+    }
+
+    /*!\brief Checks the complete last column for the optimal score.
+     * \tparam rng_t   The type of the last column; must model std::ranges::BidirectionalRange.
+     * \tparam score_t The type of the optimal score.
+     * \param[in]     rng       The last column of the dynamic programming matrix.
+     * \param[in,out] optimum   The current optimum to compare with.
+     *
+     * \details
+     *
+     * This function checks only the last element of the column (the score for the global alignment)
+     * if the trait for searching the last column is set to std::false_type.
+     * Due to a column based iteration layout the entire last column can be searched at once.
+     */
+    template <std::ranges::BidirectionalRange rng_t, typename score_t>
+    constexpr void check_score_last_column(rng_t && rng, score_t & optimum) const noexcept
+    {
+        using std::get;
+        // Only check the entire column if it was configured to search here.
+        if constexpr (traits_type::find_in_last_column_type::value)
+        {
+            ranges::for_each(rng, [&](auto && tpl)
+            {
+                optimum = std::max(optimum, get<0>(tpl));
+            });
+        }
+        else  // Only check the last cell for the global alignment.
+        {
+            auto val = get<0>(*(--seqan3::end(rng)));
+            optimum = std::max(optimum, val);
+        }
+    }
+};
+
+} // namespace seqan3::detail

--- a/include/seqan3/alignment/pairwise/policy/unbanded_dp_matrix_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/unbanded_dp_matrix_policy.hpp
@@ -30,7 +30,10 @@ namespace seqan3::detail
 template <typename derived_t, typename allocator_t>
 class unbanded_dp_matrix_policy
 {
-protected:
+private:
+
+    //!\brief Befriends the derived class to grant it access to the private members.
+    friend derived_t;
 
     /*!\name Member types
      * \{

--- a/test/unit/alignment/pairwise/fixture/global_affine_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/global_affine_unbanded.hpp
@@ -12,8 +12,8 @@
 #include <seqan3/alignment/configuration/align_config_mode.hpp>
 #include <seqan3/alignment/configuration/align_config_gap.hpp>
 #include <seqan3/alignment/configuration/align_config_scoring.hpp>
-#include <seqan3/alignment/scoring/nucleotide_scoring_scheme.hpp>
 #include <seqan3/alignment/scoring/aminoacid_scoring_scheme.hpp>
+#include <seqan3/alignment/scoring/nucleotide_scoring_scheme.hpp>
 #include <seqan3/alphabet/aminoacid/aa27.hpp>
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
@@ -78,21 +78,14 @@ static auto dna4_02 = []()
 {
     return alignment_fixture
     {
-        // score: 8 (7 insertions, 1 substitutions)
-        // alignment:
-        // AACCGGTTAACCGGTT
-        // | | | | | | | |
-        // A-C-G-T-A-C-G-TA
-        "AACCGGTTAACCGGTT"_dna4,
         "ACGTACGTA"_dna4,
-        align_config | align_cfg::scoring{nucleotide_scoring_scheme{match_score{4}, mismatch_score{-5}}}
-                     | align_cfg::aligned_ends{align_cfg::end_gaps{align_cfg::first_seq_leading{std::true_type{}},
-                                                                   align_cfg::second_seq_leading{std::true_type{}}}},
-        -7,
-        "AACCGGTTAACCG---GTT",
-        "----------ACGTACGTA",
+        "AACCGGTTAACCGGTT"_dna4,
+        align_config | align_cfg::scoring{nucleotide_scoring_scheme{match_score{4}, mismatch_score{-5}}},
+        -18,
+        "A-C-G-T-A-C-G-TA",
+        "AACCGGTTAACCGGTT",
         alignment_coordinate{0, 0},
-        alignment_coordinate{15, 8},
+        alignment_coordinate{8, 15},
         std::vector
         {
         //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T

--- a/test/unit/alignment/pairwise/fixture/global_affine_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/global_affine_unbanded.hpp
@@ -74,4 +74,54 @@ static auto dna4_01 = []()
     };
 }();
 
+static auto dna4_02 = []()
+{
+    return alignment_fixture
+    {
+        // score: 8 (7 insertions, 1 substitutions)
+        // alignment:
+        // AACCGGTTAACCGGTT
+        // | | | | | | | |
+        // A-C-G-T-A-C-G-TA
+        "AACCGGTTAACCGGTT"_dna4,
+        "ACGTACGTA"_dna4,
+        align_config | align_cfg::scoring{nucleotide_scoring_scheme{match_score{4}, mismatch_score{-5}}}
+                     | align_cfg::aligned_ends{align_cfg::end_gaps{align_cfg::first_seq_leading{std::true_type{}},
+                                                                   align_cfg::second_seq_leading{std::true_type{}}}},
+        -7,
+        "AACCGGTTAACCG---GTT",
+        "----------ACGTACGTA",
+        alignment_coordinate{0, 0},
+        alignment_coordinate{15, 8},
+        std::vector
+        {
+        //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
+        /*e*/  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16,
+        /*A*/  1,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,
+        /*C*/  2,  1,  1,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
+        /*G*/  3,  2,  2,  2,  2,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13,
+        /*T*/  4,  3,  3,  3,  3,  3,  3,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12,
+        /*A*/  5,  4,  3,  4,  4,  4,  4,  4,  4,  4,  5,  6,  7,  8,  9, 10, 11,
+        /*C*/  6,  5,  4,  3,  4,  5,  5,  5,  5,  5,  5,  5,  6,  7,  8,  9, 10,
+        /*G*/  7,  6,  5,  4,  4,  4,  5,  6,  6,  6,  6,  6,  6,  6,  7,  8,  9,
+        /*T*/  8,  7,  6,  5,  5,  5,  5,  5,  6,  7,  7,  7,  7,  7,  7,  7,  8,
+        /*A*/  9,  8,  7,  6,  6,  6,  6,  6,  6,  6,  7,  8,  8,  8,  8,  8,  8
+        },
+        std::vector
+        {
+        //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
+        /*e*/NON,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,
+        /*A*/U  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
+        /*C*/U  ,U  ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,L  ,L  ,
+        /*G*/U  ,U  ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,
+        /*T*/U  ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,
+        /*A*/U  ,DU ,D  ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
+        /*C*/U  ,U  ,U  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,
+        /*G*/U  ,U  ,U  ,U  ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,
+        /*T*/U  ,U  ,U  ,U  ,DU ,DU ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,
+        /*A*/U  ,DU ,DU ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D
+        }
+    };
+}();
+
 } // namespace seqan3::fixture::global::affine::unbanded

--- a/test/unit/alignment/pairwise/fixture/semi_global_affine_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/semi_global_affine_unbanded.hpp
@@ -1,0 +1,205 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+#pragma once
+
+#include <vector>
+
+#include <seqan3/alignment/configuration/align_config_aligned_ends.hpp>
+#include <seqan3/alignment/configuration/align_config_gap.hpp>
+#include <seqan3/alignment/configuration/align_config_mode.hpp>
+#include <seqan3/alignment/configuration/align_config_scoring.hpp>
+#include <seqan3/alignment/scoring/aminoacid_scoring_scheme.hpp>
+#include <seqan3/alignment/scoring/nucleotide_scoring_scheme.hpp>
+#include <seqan3/alphabet/aminoacid/aa27.hpp>
+#include <seqan3/alphabet/nucleotide/dna4.hpp>
+#include <seqan3/alphabet/nucleotide/dna5.hpp>
+
+#include "alignment_fixture.hpp"
+
+namespace seqan3::fixture::semi_global::affine::unbanded
+{
+
+inline constexpr auto align_config = align_cfg::mode{align_cfg::global_alignment} |
+                                     align_cfg::gap{gap_scheme{gap_score{-1}, gap_open_score{-10}}};
+
+inline constexpr auto align_config_semi_seq1 = align_config | align_cfg::aligned_ends{align_cfg::seq1_ends_free};
+inline constexpr auto align_config_semi_seq2 = align_config | align_cfg::aligned_ends{align_cfg::seq2_ends_free};
+
+static auto dna4_01 = []()
+{
+    return alignment_fixture
+    {
+        "TTTTTACGTATGTCCCCC"_dna4,
+        "ACGTAAAACGT"_dna4,
+        align_config_semi_seq1 | align_cfg::scoring{nucleotide_scoring_scheme{match_score{4}, mismatch_score{-5}}},
+        10,
+        "TTTTTACGT---ATGTCCCCC",
+        "-----ACGTAAAACGT-----",
+        alignment_coordinate{0u, 0},
+        alignment_coordinate{13u, 11},
+        std::vector
+        {
+        //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
+        /*e*/  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16,
+        /*A*/  1,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,
+        /*C*/  2,  1,  1,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
+        /*G*/  3,  2,  2,  2,  2,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13,
+        /*T*/  4,  3,  3,  3,  3,  3,  3,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12,
+        /*A*/  5,  4,  3,  4,  4,  4,  4,  4,  4,  4,  5,  6,  7,  8,  9, 10, 11,
+        /*C*/  6,  5,  4,  3,  4,  5,  5,  5,  5,  5,  5,  5,  6,  7,  8,  9, 10,
+        /*G*/  7,  6,  5,  4,  4,  4,  5,  6,  6,  6,  6,  6,  6,  6,  7,  8,  9,
+        /*T*/  8,  7,  6,  5,  5,  5,  5,  5,  6,  7,  7,  7,  7,  7,  7,  7,  8,
+        /*A*/  9,  8,  7,  6,  6,  6,  6,  6,  6,  6,  7,  8,  8,  8,  8,  8,  8
+        },
+        std::vector
+        {
+        //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
+        /*e*/NON,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,
+        /*A*/U  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
+        /*C*/U  ,U  ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,L  ,L  ,
+        /*G*/U  ,U  ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,
+        /*T*/U  ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,
+        /*A*/U  ,DU ,D  ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
+        /*C*/U  ,U  ,U  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,
+        /*G*/U  ,U  ,U  ,U  ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,
+        /*T*/U  ,U  ,U  ,U  ,DU ,DU ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,
+        /*A*/U  ,DU ,DU ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D
+        }
+    };
+}();
+
+static auto dna4_02 = []()
+{
+    return alignment_fixture
+    {
+        "ACGTAAAACGT"_dna4,
+        "TTTTTACGTATGTCCCCC"_dna4,
+        align_config_semi_seq1 | align_cfg::scoring{nucleotide_scoring_scheme{match_score{4}, mismatch_score{-5}}},
+        -13,
+        "-----ACGTA--------AAACGT",
+        "TTTTTACGTATGTCCCCC------",
+        alignment_coordinate{0u, 0},
+        alignment_coordinate{5u, 18},
+        std::vector
+        {
+        //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
+        /*e*/  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16,
+        /*A*/  1,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,
+        /*C*/  2,  1,  1,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
+        /*G*/  3,  2,  2,  2,  2,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13,
+        /*T*/  4,  3,  3,  3,  3,  3,  3,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12,
+        /*A*/  5,  4,  3,  4,  4,  4,  4,  4,  4,  4,  5,  6,  7,  8,  9, 10, 11,
+        /*C*/  6,  5,  4,  3,  4,  5,  5,  5,  5,  5,  5,  5,  6,  7,  8,  9, 10,
+        /*G*/  7,  6,  5,  4,  4,  4,  5,  6,  6,  6,  6,  6,  6,  6,  7,  8,  9,
+        /*T*/  8,  7,  6,  5,  5,  5,  5,  5,  6,  7,  7,  7,  7,  7,  7,  7,  8,
+        /*A*/  9,  8,  7,  6,  6,  6,  6,  6,  6,  6,  7,  8,  8,  8,  8,  8,  8
+        },
+        std::vector
+        {
+        //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
+        /*e*/NON,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,
+        /*A*/U  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
+        /*C*/U  ,U  ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,L  ,L  ,
+        /*G*/U  ,U  ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,
+        /*T*/U  ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,
+        /*A*/U  ,DU ,D  ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
+        /*C*/U  ,U  ,U  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,
+        /*G*/U  ,U  ,U  ,U  ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,
+        /*T*/U  ,U  ,U  ,U  ,DU ,DU ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,
+        /*A*/U  ,DU ,DU ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D
+        }
+    };
+}();
+
+static auto dna4_03 = []()
+{
+    return alignment_fixture
+    {
+        "TTTTTACGTATGTCCCCC"_dna4,
+        "ACGTAAAACGT"_dna4,
+        align_config_semi_seq2 | align_cfg::scoring{nucleotide_scoring_scheme{match_score{4}, mismatch_score{-5}}},
+        -13,
+        "-----ACGTA--------AAACGT",
+        "TTTTTACGTATGTCCCCC------",
+        alignment_coordinate{0u, 0},
+        alignment_coordinate{5u, 18},
+        std::vector
+        {
+        //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
+        /*e*/  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16,
+        /*A*/  1,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,
+        /*C*/  2,  1,  1,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
+        /*G*/  3,  2,  2,  2,  2,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13,
+        /*T*/  4,  3,  3,  3,  3,  3,  3,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12,
+        /*A*/  5,  4,  3,  4,  4,  4,  4,  4,  4,  4,  5,  6,  7,  8,  9, 10, 11,
+        /*C*/  6,  5,  4,  3,  4,  5,  5,  5,  5,  5,  5,  5,  6,  7,  8,  9, 10,
+        /*G*/  7,  6,  5,  4,  4,  4,  5,  6,  6,  6,  6,  6,  6,  6,  7,  8,  9,
+        /*T*/  8,  7,  6,  5,  5,  5,  5,  5,  6,  7,  7,  7,  7,  7,  7,  7,  8,
+        /*A*/  9,  8,  7,  6,  6,  6,  6,  6,  6,  6,  7,  8,  8,  8,  8,  8,  8
+        },
+        std::vector
+        {
+        //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
+        /*e*/NON,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,
+        /*A*/U  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
+        /*C*/U  ,U  ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,L  ,L  ,
+        /*G*/U  ,U  ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,
+        /*T*/U  ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,
+        /*A*/U  ,DU ,D  ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
+        /*C*/U  ,U  ,U  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,
+        /*G*/U  ,U  ,U  ,U  ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,
+        /*T*/U  ,U  ,U  ,U  ,DU ,DU ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,
+        /*A*/U  ,DU ,DU ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D
+        }
+    };
+}();
+
+static auto dna4_04 = []()
+{
+    return alignment_fixture
+    {
+        "ACGTAAAACGT"_dna4,
+        "TTTTTACGTATGTCCCCC"_dna4,
+        align_config_semi_seq2 | align_cfg::scoring{nucleotide_scoring_scheme{match_score{4}, mismatch_score{-5}}},
+        10,
+        "TTTTTACGT---ATGTCCCCC",
+        "-----ACGTAAAACGT-----",
+        alignment_coordinate{0u, 0},
+        alignment_coordinate{13u, 11},
+        std::vector
+        {
+        //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
+        /*e*/  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16,
+        /*A*/  1,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,
+        /*C*/  2,  1,  1,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
+        /*G*/  3,  2,  2,  2,  2,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13,
+        /*T*/  4,  3,  3,  3,  3,  3,  3,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12,
+        /*A*/  5,  4,  3,  4,  4,  4,  4,  4,  4,  4,  5,  6,  7,  8,  9, 10, 11,
+        /*C*/  6,  5,  4,  3,  4,  5,  5,  5,  5,  5,  5,  5,  6,  7,  8,  9, 10,
+        /*G*/  7,  6,  5,  4,  4,  4,  5,  6,  6,  6,  6,  6,  6,  6,  7,  8,  9,
+        /*T*/  8,  7,  6,  5,  5,  5,  5,  5,  6,  7,  7,  7,  7,  7,  7,  7,  8,
+        /*A*/  9,  8,  7,  6,  6,  6,  6,  6,  6,  6,  7,  8,  8,  8,  8,  8,  8
+        },
+        std::vector
+        {
+        //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
+        /*e*/NON,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,
+        /*A*/U  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
+        /*C*/U  ,U  ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,L  ,L  ,
+        /*G*/U  ,U  ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,
+        /*T*/U  ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,
+        /*A*/U  ,DU ,D  ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
+        /*C*/U  ,U  ,U  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,
+        /*G*/U  ,U  ,U  ,U  ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,
+        /*T*/U  ,U  ,U  ,U  ,DU ,DU ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,
+        /*A*/U  ,DU ,DU ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D
+        }
+    };
+}();
+
+} // namespace seqan3::fixture::global::affine::unbanded

--- a/test/unit/alignment/pairwise/global_affine_unbanded_test.cpp
+++ b/test/unit/alignment/pairwise/global_affine_unbanded_test.cpp
@@ -15,6 +15,7 @@
 #include <seqan3/range/view/to_char.hpp>
 
 #include "fixture/global_affine_unbanded.hpp"
+#include "fixture/semi_global_affine_unbanded.hpp"
 
 using namespace seqan3;
 using namespace seqan3::detail;
@@ -41,6 +42,14 @@ using global_affine_unbanded_types
         param<&global::affine::unbanded::dna4_02>
     >;
 
+using semi_global_affine_unbanded_types
+    = ::testing::Types<
+        param<&semi_global::affine::unbanded::dna4_01>,
+        param<&semi_global::affine::unbanded::dna4_02>,
+        param<&semi_global::affine::unbanded::dna4_03>,
+        param<&semi_global::affine::unbanded::dna4_04>
+    >;
+
 TYPED_TEST_P(global_affine_unbanded, score)
 {
     auto const & fixture = this->fixture();
@@ -58,5 +67,5 @@ TYPED_TEST_P(global_affine_unbanded, score)
 
 REGISTER_TYPED_TEST_CASE_P(global_affine_unbanded, score);
 
-// work around a bug that you can't specify more than 50 template arguments to ::testing::types
 INSTANTIATE_TYPED_TEST_CASE_P(global, global_affine_unbanded, global_affine_unbanded_types);
+INSTANTIATE_TYPED_TEST_CASE_P(semi_global, global_affine_unbanded, semi_global_affine_unbanded_types);

--- a/test/unit/alignment/pairwise/global_affine_unbanded_test.cpp
+++ b/test/unit/alignment/pairwise/global_affine_unbanded_test.cpp
@@ -37,7 +37,8 @@ TYPED_TEST_CASE_P(global_affine_unbanded);
 
 using global_affine_unbanded_types
     = ::testing::Types<
-        param<&global::affine::unbanded::dna4_01>
+        param<&global::affine::unbanded::dna4_01>,
+        param<&global::affine::unbanded::dna4_02>
     >;
 
 TYPED_TEST_P(global_affine_unbanded, score)


### PR DESCRIPTION
 Supersedes #674 

### Detail
* Adapts the configurator to reslolve the aligned_ends configuration.
* Adds a traits class to the affine_gap_init_policy to select the proper initiailisation.
* Implements a find_optimum_policy which tracks the optimal score depending on the aligned_ends configuration.
* Adapts the alignment algorithm to check for the optimal score.
* Fixes the CRTP-Base class pattern using private member and befirending the derived class.
* Fixes the CRTP-Base class declaration.
* Fixes some minor warnings.
* Updates documentation of the classes.