### PR TITLE
[Feature] affine kernel with traceback

### DIFF
--- a/include/seqan3/alignment/matrix/alignment_coordinate.hpp
+++ b/include/seqan3/alignment/matrix/alignment_coordinate.hpp
@@ -15,6 +15,7 @@
 #include <type_traits>
 
 #include <seqan3/core/detail/strong_type.hpp>
+#include <seqan3/io/stream/debug_stream.hpp>
 #include <seqan3/std/concepts>
 #include <seqan3/std/iterator>
 
@@ -370,5 +371,25 @@ public:
     //!\brief The begin/end position of the alignment in the second sequence.
     SEQAN3_DOXYGEN_ONLY(size_t second_seq_pos;)
 };
+
+/*!\brief A seqan3::alignment_coordinate can be printed to the seqan3::debug_stream.
+ * \tparam    coordinate_type The alignment coordinate type.
+ * \param[in] s               The seqan3::debug_stream.
+ * \param[in] c               The alignment coordinate to print.
+ * \relates seqan3::debug_stream_type
+ *
+ * \details
+ *
+ * Prints the alignment coordinate as a tuple.
+ */
+template <typename coordinate_type>
+//!\cond
+    requires std::Same<remove_cvref_t<coordinate_type>, alignment_coordinate>
+//!\endcond
+inline debug_stream_type & operator<<(debug_stream_type & s, coordinate_type && c)
+{
+    s << std::tie(c.first_seq_pos, c.second_seq_pos);
+    return s;
+}
 
 } // namespace seqan3

--- a/include/seqan3/alignment/matrix/alignment_coordinate.hpp
+++ b/include/seqan3/alignment/matrix/alignment_coordinate.hpp
@@ -12,20 +12,363 @@
 
 #pragma once
 
-#include <seqan3/core/platform.hpp>
+#include <type_traits>
+
+#include <seqan3/core/detail/strong_type.hpp>
+#include <seqan3/std/concepts>
+#include <seqan3/std/iterator>
 
 namespace seqan3::detail
 {
-
-/*!\brief Represents the begin/end of the pairwise alignment in the respective sequences.
- * This class can for example be used to represent the coordinate where the best alignment score is located.
+/*!\brief A strong type for designated initialisation of the column index of the seqan3::detail::alignment_coordinate.
+ * \ingroup alignment_matrix
+ * \tparam index_t The type of the index; must model std::UnsignedIntegral.
  */
-struct alignment_coordinate
+template <std::UnsignedIntegral index_t>
+struct column_index_type : detail::strong_type<index_t, column_index_type<index_t>>
 {
-    //!\brief The position in the first sequence.
-    size_t seq1_pos;
-    //!\brief The position in the second sequence.
-    size_t seq2_pos;
+    //!!\brief Introduce base class constructor into this type's definition.
+    using detail::strong_type<index_t, column_index_type<index_t>>::strong_type;
 };
 
+/*!\name Type deduction guides
+ * \{
+ */
+//!\brief The default constructed element deduces to `size_t`.
+column_index_type() -> column_index_type<size_t>;
+//!\brief Deduces the position type from the constructor argument.
+template <std::UnsignedIntegral index_t>
+column_index_type(index_t const) -> column_index_type<size_t>;
+//!\}
+
+/*!\brief A strong type for designated initialisation of the row index of the seqan3::detail::alignment_coordinate.
+ * \ingroup alignment_matrix
+ * \tparam index_t The type of the index; must model std::UnsignedIntegral.
+ */
+template <std::UnsignedIntegral index_t>
+struct row_index_type : detail::strong_type<index_t, row_index_type<index_t>>
+{
+    //!!\brief Introduce base class constructor into this type's definition.
+    using detail::strong_type<index_t, row_index_type<index_t>>::strong_type;
+};
+
+/*!\name Type deduction guides
+ * \{
+ */
+//!\brief The default constructed element deduces to `size_t`.
+row_index_type() -> row_index_type<size_t>;
+//!\brief Deduces the position type from the constructor argument.
+template <std::UnsignedIntegral index_t>
+row_index_type(index_t const) -> row_index_type<size_t>;
+//!\}
+
+/*!\brief Represents a state to specify the implementation of the seqan3::detail::advanceable_alignment_coordinate
+ * \ingroup alignment_matrix
+ *
+ * \details
+ *
+ * The class seqan3::detail::alignment_coordinate can be extended with an incrementable and decrementable policy,
+ * such that it can be used as a value type inside of a iota_view. This state offers three policies: none, which
+ * leaves the functionality of seqan3::detail::alignment_coordinate untouched; column, which adds the respective
+ * functionality only for the column index and row, which adds the respective functionality only for the row index.
+ */
+enum struct advanceable_alignment_coordinate_state : uint8_t
+{
+    //!\brief The corresponding alignment coordinate will not be incrementable/decrementable.
+    none,
+    //!\brief The corresponding alignment coordinate will be incrementable/decrementable in the column index.
+    column,
+    //!\brief The corresponding alignment coordinate will be incrementable/decrementable in the row index.
+    row
+};
+
+/*!\brief Implements an internal alignment coordinate that can be used as an argument to the std::ranges::iota_view.
+ * \ingroup alignment_matrix
+ * \implements std::EqualityComparable
+ * \tparam index_t  The type of the sequence index; must model std::UnsignedIntegral.
+ * \tparam states   A non-type template flag to enable a specific advanceable policy.
+ *                  See seqan3::detail::advanceable_alignment_coordinate_state
+ *
+ * \details
+ *
+ * This class provides all members to make the `advanceable_alignment_coordinate` be usable in a std::ranges::iota_view.
+ * For the purpose of alignments modelling only incrementable and decrementable would fully suffice.
+ * Unfortunately, the current range implementation does not preserve std::ranges::BidirectionalRange properties,
+ * so we need to model the full advanceable concept in order to preserve the std::ranges::RandomAccessRange properties.
+ * This however can be relaxed if the range implementation fully complies with the current standard draft for Ranges,
+ * and increment and decrement would be enough.
+ */
+template <std::UnsignedIntegral index_t,
+          advanceable_alignment_coordinate_state state = advanceable_alignment_coordinate_state::none>
+class advanceable_alignment_coordinate
+{
+public:
+
+    //!\name Member types
+    //!\{
+    //!\brief Defines the difference type to model the std::WeaklyIncrementable concept.
+    using difference_type = std::make_signed_t<index_t>;
+    //!\}
+
+    /*!\name Constructor, destructor and assignment
+     * \{
+     */
+    constexpr advanceable_alignment_coordinate() noexcept = default;
+    constexpr advanceable_alignment_coordinate(advanceable_alignment_coordinate const &) noexcept = default;
+    constexpr advanceable_alignment_coordinate(advanceable_alignment_coordinate &&) noexcept = default;
+    constexpr advanceable_alignment_coordinate & operator=(advanceable_alignment_coordinate const &) noexcept = default;
+    constexpr advanceable_alignment_coordinate & operator=(advanceable_alignment_coordinate &&) noexcept = default;
+    ~advanceable_alignment_coordinate() noexcept = default;
+
+    //!\brief Copy-constructs from another advanceable_alignment_coordinate with a different policy.
+    template <typename _index_t, advanceable_alignment_coordinate_state _state>
+        requires std::Same<_index_t, index_t> && !std::Same<_state, state>
+    constexpr advanceable_alignment_coordinate(advanceable_alignment_coordinate<_index_t, _state> const & other) :
+        first_seq_pos{other.first_seq_pos},
+        second_seq_pos{other.second_seq_pos}
+    {}
+
+    //!\brief Move-constructs from another advanceable_alignment_coordinate with a different policy.
+    template <typename _index_t, advanceable_alignment_coordinate_state _state>
+        requires std::Same<_index_t, index_t> && !std::Same<_state, state>
+    constexpr advanceable_alignment_coordinate(advanceable_alignment_coordinate<_index_t, _state> && other) :
+        first_seq_pos{std::move(other.first_seq_pos)},
+        second_seq_pos{std::move(other.second_seq_pos)}
+    {}
+
+    /*!\brief Save construction from column and row indices.
+     * \param c_idx The respective column index within the matrix. Of type seqan3::detail::column_index_type.
+     * \param r_idx The respective row index within the matrix. Of type seqan3::detail::row_index_type.
+     */
+    constexpr advanceable_alignment_coordinate(column_index_type<index_t> const c_idx,
+                                               row_index_type<index_t> const r_idx) noexcept :
+        first_seq_pos{c_idx.get()},
+        second_seq_pos{r_idx.get()}
+    {}
+    //!\}
+
+     //!\cond
+     constexpr friend bool operator==(advanceable_alignment_coordinate const & lhs,
+                                      advanceable_alignment_coordinate const & rhs) noexcept
+     {
+         return (lhs.first_seq_pos == rhs.first_seq_pos) &&
+                (lhs.second_seq_pos == rhs.second_seq_pos);
+     }
+
+     constexpr friend bool operator!=(advanceable_alignment_coordinate const & lhs,
+                                      advanceable_alignment_coordinate const & rhs) noexcept
+     {
+         return !(lhs == rhs);
+     }
+     //!\endcond
+
+    /*!\name Member functions
+     * \brief Advances or decrements the respective column or row coordinate depending on the set policy.
+     *        These member functions are not available if the non-type template parameter `state` was set to
+     *        seqan3::detail::advanceable_alignment_coordinate_state::none.
+     * \{
+     */
+
+    constexpr advanceable_alignment_coordinate & operator++(/*pre-increment*/) noexcept
+    //!\cond
+        requires state != advanceable_alignment_coordinate_state::none
+    //!\endcond
+    {
+        if constexpr (state == advanceable_alignment_coordinate_state::column)
+            ++this->first_seq_pos;
+        else
+            ++this->second_seq_pos;
+        return *this;
+    }
+
+    constexpr advanceable_alignment_coordinate operator++(int /*post-increment*/) noexcept
+    //!\cond
+        requires state != advanceable_alignment_coordinate_state::none
+    //!\endcond
+    {
+        advanceable_alignment_coordinate tmp{*this};
+        ++(*this);
+        return tmp;
+    }
+
+    constexpr advanceable_alignment_coordinate & operator--(/*pre-decrement*/) noexcept
+    //!\cond
+        requires state != advanceable_alignment_coordinate_state::none
+    //!\endcond
+    {
+        if constexpr (state == advanceable_alignment_coordinate_state::column)
+            --this->first_seq_pos;
+        else
+            --this->second_seq_pos;
+        return *this;
+    }
+
+    constexpr advanceable_alignment_coordinate operator--(int /*post-decrement*/) noexcept
+    //!\cond
+        requires state != advanceable_alignment_coordinate_state::none
+    //!\endcond
+    {
+        advanceable_alignment_coordinate tmp{*this};
+        --(*this);
+        return tmp;
+    }
+
+    constexpr advanceable_alignment_coordinate & operator+=(difference_type const offset) noexcept
+    //!\cond
+        requires state != advanceable_alignment_coordinate_state::none
+    //!\endcond
+    {
+        if constexpr (state == advanceable_alignment_coordinate_state::column)
+            this->first_seq_pos += offset;
+        else
+            this->second_seq_pos += offset;
+        return *this;
+    }
+
+    constexpr advanceable_alignment_coordinate & operator-=(difference_type const offset) noexcept
+    //!\cond
+        requires state != advanceable_alignment_coordinate_state::none
+    //!\endcond
+    {
+        if constexpr (state == advanceable_alignment_coordinate_state::column)
+            this->first_seq_pos -= offset;
+        else
+            this->second_seq_pos -= offset;
+        return *this;
+    }
+
+    constexpr advanceable_alignment_coordinate operator+(difference_type const offset) const noexcept
+    //!\cond
+        requires state != advanceable_alignment_coordinate_state::none
+    //!\endcond
+    {
+        advanceable_alignment_coordinate tmp{*this};
+        tmp += offset;
+        return tmp;
+    }
+
+    constexpr advanceable_alignment_coordinate operator-(difference_type const offset) const noexcept
+    //!\cond
+        requires state != advanceable_alignment_coordinate_state::none
+    //!\endcond
+    {
+        advanceable_alignment_coordinate tmp{*this};
+        tmp -= offset;
+        return tmp;
+    }
+
+    constexpr difference_type operator-(advanceable_alignment_coordinate const & other) const noexcept
+    //!\cond
+        requires state != advanceable_alignment_coordinate_state::none
+    //!\endcond
+    {
+        if constexpr (state == advanceable_alignment_coordinate_state::column)
+            return this->first_seq_pos - other.first_seq_pos;
+        else
+            return this->second_seq_pos - other.second_seq_pos;
+    }
+    //!\}
+
+    //!\brief Non-member function
+    //!\{
+
+    /*!\brief Advances the respective coordinate depending on the set policy by the given offset. This function is
+              not available if the policy was set to seqan3::detail::advanceable_alignment_coordinate_state::none.
+     */
+    constexpr friend advanceable_alignment_coordinate operator+(difference_type const offset,
+                                         advanceable_alignment_coordinate const & me) noexcept
+    //!\cond
+        requires state != advanceable_alignment_coordinate_state::none
+    //!\endcond
+    {
+        return me + offset;
+    }
+    //!\}
+
+    //!\brief The begin/end position of the alignment in the first sequence.
+    index_t first_seq_pos{};
+    //!\brief The begin/end position of the alignment in the second sequence.
+    index_t second_seq_pos{};
+};
+
+/*!\name Type deduction guides
+ * \{
+ */
+advanceable_alignment_coordinate() -> advanceable_alignment_coordinate<size_t>;
+//!\brief Deduces the position type from the constructor.
+template <std::UnsignedIntegral index_t>
+advanceable_alignment_coordinate(column_index_type<index_t> const, row_index_type<index_t> const) ->
+    advanceable_alignment_coordinate<size_t>;
+//!\}
+
 } // namespace seqan3::detail
+
+namespace seqan3
+{
+
+/*!\brief Represents the begin/end of the pairwise alignment in the respective sequences.
+ * \ingroup alignment_matrix
+ *
+ * \details
+ * \if DEV
+ * This class only gives access to the respective positions of the sequences and is meant for
+ * the user interface. For the implementation of the alignment algorithms the
+ * seqan3::detail::advanceable_alignment_coordinate is used.
+ * \endif
+ */
+class alignment_coordinate
+//!\cond DEV
+    : public detail::advanceable_alignment_coordinate<size_t>
+//!\endcond
+{
+    //!\cond DEV
+    //!\brief The type of the base class.
+    using base_t = detail::advanceable_alignment_coordinate<size_t>;
+    //!\endcond
+
+public:
+
+    /*!\name Constructor, destructor and assignment
+     * \{
+     */
+    constexpr alignment_coordinate() = default;
+    constexpr alignment_coordinate(alignment_coordinate const &) = default;
+    constexpr alignment_coordinate(alignment_coordinate &&) = default;
+    constexpr alignment_coordinate & operator=(alignment_coordinate const &) = default;
+    constexpr alignment_coordinate & operator=(alignment_coordinate &&) = default;
+    ~alignment_coordinate() = default;
+
+    //!\cond DEV
+    //!\brief Constructs from the seqan3::detail::advanceable_alignment_coordinate base class.
+    constexpr alignment_coordinate(base_t const & base) : base_t{base}
+    {}
+
+    //!\brief Constructs from the seqan3::detail::advanceable_alignment_coordinate base class.
+    constexpr alignment_coordinate(base_t && base) : base_t{std::move(base)}
+    {}
+
+    /*!\brief Save construction from column and row indices.
+     * \tparam index_t The index type used to store the column and row position.
+     * \param[in] c_idx The respective column index within the matrix. Of type seqan3::detail::column_index_type.
+     * \param[in] r_idx The respective row index within the matrix. Of type seqan3::detail::row_index_type.
+     */
+    template <typename index_t>
+    constexpr alignment_coordinate(detail::column_index_type<index_t> const c_idx,
+                                   detail::row_index_type<index_t> const r_idx) noexcept :
+        base_t{c_idx, r_idx}
+    {}
+    //!\endcond
+    //!\}
+
+    //!\brief The begin/end position of the alignment in the first sequence.
+    using base_t::first_seq_pos;
+    //!\brief The begin/end position of the alignment in the second sequence.
+    using base_t::second_seq_pos;
+
+    //!\brief The begin/end position of the alignment in the first sequence.
+    SEQAN3_DOXYGEN_ONLY(size_t first_seq_pos;)
+    //!\brief The begin/end position of the alignment in the second sequence.
+    SEQAN3_DOXYGEN_ONLY(size_t second_seq_pos;)
+};
+
+} // namespace seqan3

--- a/include/seqan3/alignment/matrix/alignment_optimum.hpp
+++ b/include/seqan3/alignment/matrix/alignment_optimum.hpp
@@ -1,0 +1,86 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides seqan3::detail::alignment_optimum.
+ * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <type_traits>
+
+#include <seqan3/alignment/matrix/alignment_coordinate.hpp>
+#include <seqan3/core/concept/core_language.hpp>
+#include <seqan3/core/metafunction/template_inspection.hpp>
+#include <seqan3/std/concepts>
+
+namespace seqan3::detail
+{
+
+/*!\brief Stores the current optimum in the alignment algorithms.
+ * \ingroup alignment_matrix
+ * \tparam score_t The type of the tracked alignment score.
+ *
+ * \details
+ *
+ * This is an aggregate type, so the score needs to be passed before the seqan3::alignment_coordinate during
+ * construction.
+ */
+template <arithmetic_concept score_t>
+struct alignment_optimum
+{
+    //!\brief The optimal score.
+    score_t score{std::numeric_limits<score_t>::lowest()};
+    //!\brief The corresponding coordinate within the alignment matrix.
+    alignment_coordinate coordinate{};
+};
+
+/*!\name Type deduction guide
+ * \{
+ */
+
+alignment_optimum() -> alignment_optimum<int32_t>;
+
+template <arithmetic_concept score_t>
+alignment_optimum(score_t const, alignment_coordinate const) ->
+    alignment_optimum<std::remove_reference_t<score_t>>;
+//!\}
+
+/*!\brief A less than comparator for two seqan3::detail::alignment_optimum objects.
+ * \ingroup alignment_matrix
+ *
+ * \details
+ *
+ * This function object is used in std::max functions to compare two seqan3::detail::alignment_optimum objects.
+ */
+struct alignment_optimum_compare_less
+{
+
+    /*!\brief Function call operator that implements less than comparison.
+     * \tparam lhs_t The type of the left-hand side operand. Must be a type specialisation of
+     *               seqan3::detail::alignment_optimum.
+     * \tparam rhs_t The type of the right-hand side operand. Must be a type specialisation of
+     *               seqan3::detail::alignment_optimum.
+     *
+     * \param[in] lhs The left-hand side operand.
+     * \param[in] rhs The right-hand side operand.
+     *
+     * \returns bool `true` if `lhs.score < rhs.score`, otherwise `false`.
+     */
+    template <typename lhs_t, typename rhs_t>
+    //!\cond
+        requires (is_type_specialisation_of_v<lhs_t, alignment_optimum> &&
+                  is_type_specialisation_of_v<rhs_t, alignment_optimum>)
+    //!\endcond
+    constexpr bool operator()(lhs_t const & lhs, rhs_t const & rhs) const
+    {
+        return lhs.score < rhs.score;
+    }
+};
+
+} // namespace seqan3::detail

--- a/include/seqan3/alignment/matrix/alignment_trace_algorithms.hpp
+++ b/include/seqan3/alignment/matrix/alignment_trace_algorithms.hpp
@@ -41,8 +41,8 @@ inline alignment_coordinate alignment_begin_coordinate(trace_matrix_t && matrix,
     constexpr auto D = trace_directions::diagonal;
     constexpr auto L = trace_directions::left;
     constexpr auto U = trace_directions::up;
-    size_t row = end_coordinate.seq2_pos + 1;
-    size_t col = end_coordinate.seq1_pos + 1;
+    size_t row = end_coordinate.second_seq_pos + 1;
+    size_t col = end_coordinate.first_seq_pos + 1;
 
     assert(row < matrix.rows());
     assert(col < matrix.cols());
@@ -73,7 +73,7 @@ inline alignment_coordinate alignment_begin_coordinate(trace_matrix_t && matrix,
         }
     }
 
-    return {std::max<size_t>(col, 1) - 1, std::max<size_t>(row, 1) - 1};
+    return {column_index_type{std::max<size_t>(col, 1) - 1}, row_index_type{std::max<size_t>(row, 1) - 1}};
 }
 
 /*!\brief Compute the trace from a trace matrix.
@@ -111,8 +111,8 @@ alignment_trace(database_t && database,
     constexpr auto D = trace_directions::diagonal;
     constexpr auto L = trace_directions::left;
     constexpr auto U = trace_directions::up;
-    size_t col = end_coordinate.seq1_pos + 1;
-    size_t row = end_coordinate.seq2_pos + 1;
+    size_t col = end_coordinate.first_seq_pos + 1;
+    size_t row = end_coordinate.second_seq_pos + 1;
 
     assert(row <= query.size());
     assert(col <= database.size());

--- a/include/seqan3/alignment/matrix/all.hpp
+++ b/include/seqan3/alignment/matrix/all.hpp
@@ -5,25 +5,23 @@
 // shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
 // -----------------------------------------------------------------------------------------------------
 
-//!\cond DEV
 /*!\file
  * \brief Meta-header for the \link alignment_matrix Matrix sub-module \endlink.
  * \author Marcel Ehrhardt <marcel.ehrhardt AT fu-berlin.de>
  */
-//!\endcond
 
 #pragma once
 
-//!\cond DEV
 /*!\defgroup alignment_matrix Matrix
- * \brief Provides the data structures used for representing alignments as a matrix.
+ * \brief Provides data structures for representing alignment coordinates and alignments as a matrix.
  * \ingroup alignment
  *
  * \todo Write detailed landing page.
  */
-//!\endcond
 
+#include <seqan3/alignment/matrix/alignment_coordinate.hpp>
 #include <seqan3/alignment/matrix/alignment_matrix_formatter.hpp>
+#include <seqan3/alignment/matrix/alignment_optimum.hpp>
 #include <seqan3/alignment/matrix/alignment_score_matrix.hpp>
 #include <seqan3/alignment/matrix/alignment_trace_matrix.hpp>
 #include <seqan3/alignment/matrix/matrix_concept.hpp>

--- a/include/seqan3/alignment/matrix/trace_directions.hpp
+++ b/include/seqan3/alignment/matrix/trace_directions.hpp
@@ -25,13 +25,17 @@ namespace seqan3::detail
 enum struct trace_directions : uint8_t
 {
     //!\brief No trace
-    none      = 0b0000,
+    none      = 0b00000,
     //!\brief Trace comes from the diagonal entry.
-    diagonal  = 0b0001,
+    diagonal  = 0b00001,
     //!\brief Trace comes from the above entry.
-    up        = 0b0010,
+    up        = 0b00010,
     //!\brief Trace comes from the left entry.
-    left      = 0b0100
+    left      = 0b00100,
+    //!\brief Trace comes from the above entry, while opening the gap.
+    up_open   = 0b01000,
+    //!\brief Trace comes from the left entry, while opening the gap.
+    left_open = 0b10000
 };
 
 } // namespace seqan3::detail

--- a/include/seqan3/alignment/pairwise/alignment_algorithm.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_algorithm.hpp
@@ -159,6 +159,8 @@ private:
         {
             this->init_column_cell(cell, cache);
         });
+
+        this->check_score_last_row(get<0>(*(seqan3::end(col) - 1)), get<3>(cache));
     }
 
     /*!\brief Compute the alignment by iterating over the dynamic programming matrix in a column wise manner.

--- a/include/seqan3/alignment/pairwise/alignment_algorithm.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_algorithm.hpp
@@ -30,6 +30,7 @@
 #include <seqan3/range/view/take_exactly.hpp>
 #include <seqan3/std/concepts>
 #include <seqan3/std/ranges>
+#include <seqan3/std/view/subrange.hpp>
 
 namespace seqan3::detail
 {
@@ -135,9 +136,32 @@ public:
         result_t res{};
 
         // Choose what needs to be computed.
-        if constexpr (config_t::template exists<align_cfg::result<detail::with_score_type>>())
+        if constexpr (config_t::template exists<align_cfg::result<with_score_type>>())
         {
             res.score = get<3>(cache).score;
+        }
+        if constexpr (config_t::template exists<align_cfg::result<with_end_position_type>>())
+        {
+            res.score = get<3>(cache).score;
+            res.end_coordinate = get<3>(cache).coordinate;
+        }
+        if constexpr (config_t::template exists<align_cfg::result<with_begin_position_type>>())
+        { // At the moment we also compute the traceback even if only the begin coordinate was requested.
+          // This can be later optimised by computing the reverse alignment in a narrow band in linear memory.
+          // Especially for the SIMD version this might be more efficient.
+            res.score = get<3>(cache).score;
+            res.end_coordinate = get<3>(cache).coordinate;
+            res.begin_coordinate = get<0>(compute_traceback(first_batch,
+                                                            second_batch,
+                                                            get<3>(cache).coordinate));
+        }
+        if constexpr (config_t::template exists<align_cfg::result<with_trace_type>>())
+        {
+            res.score = get<3>(cache).score;
+            res.end_coordinate = get<3>(cache).coordinate;
+            std::tie(res.begin_coordinate, res.alignment) = compute_traceback(first_batch,
+                                                                              second_batch,
+                                                                              get<3>(cache).coordinate);
         }
         return align_result{res};
     }
@@ -161,6 +185,7 @@ private:
         });
 
         auto [cell, coordinate, trace] = *(--seqan3::end(col));
+        (void) trace; // unused in this context.
         alignment_optimum current{get<0>(std::move(cell)), static_cast<alignment_coordinate>(coordinate)};
         this->check_score_last_row(current, get<3>(cache));
     }
@@ -184,6 +209,9 @@ private:
         auto const & score_scheme = get<align_cfg::scoring>(*cfg_ptr).value;
         ranges::for_each(first_batch, [&, this](auto seq1_value)
         {
+            // Move internal matrix to next column.
+            this->next_column();
+
             auto col = this->current_column();
             this->init_row_cell(*std::ranges::begin(col), cache);
 
@@ -196,12 +224,66 @@ private:
             });
             // First construct an alignment_optimum object to make it comparable with the current optimum.
             auto [cell, coordinate, trace] = *(--seqan3::end(col));
+            (void) trace; // unused in this context.
             alignment_optimum current{get<0>(std::move(cell)), static_cast<alignment_coordinate>(coordinate)};
             this->check_score_last_row(current, get<3>(cache));
-            // Move internal matrix to next column.
-            this->next_column();
         });
         this->check_score_last_column(this->current_column(), get<3>(cache));
+    }
+
+    template <typename first_batch_t, typename second_batch_t>
+    auto compute_traceback(first_batch_t const & first_batch,
+                           second_batch_t const & second_batch,
+                           alignment_coordinate const & end_coordinate)
+    {
+        using first_seq_value_type = value_type_t<first_batch_t>;
+        using second_seq_value_type = value_type_t<second_batch_t>;
+
+        // Parse the traceback
+        auto [begin_coordinate, first_gap_segments, second_gap_segments] = this->parse_traceback(end_coordinate);
+
+        auto fill_aligned_sequence = [](auto & aligned_sequence, auto & gap_segments, size_t const normalise)
+        {
+            assert(normalise <= gap_segments[0].position);
+
+            size_t offset = 0;
+            for (auto const & gap_elem : gap_segments)
+            {
+                // insert_gap(aligned_sequence, gap.position + offset, gap.size);
+                auto it = seqan3::begin(aligned_sequence);
+                std::advance(it, (gap_elem.position - normalise) + offset);
+                aligned_sequence.insert(it, gap_elem.size, gap{});
+                offset += gap_elem.size;
+            }
+        };
+
+        // Get the subrange over the first sequence according to the begin and end coordinate.
+        auto it_first_seq_begin = seqan3::begin(first_batch);
+        std::advance(it_first_seq_begin, begin_coordinate.first_seq_pos);
+        auto it_first_seq_end = seqan3::begin(first_batch);
+        std::advance(it_first_seq_end, end_coordinate.first_seq_pos);
+
+        using first_subrange_type = seqan3::view::subrange<decltype(it_first_seq_begin), decltype(it_first_seq_end)>;
+        auto first_subrange = first_subrange_type{it_first_seq_begin, it_first_seq_end};
+
+        // Create and fill the aligned_sequence for the first sequence.
+        std::vector<gapped<first_seq_value_type>> first_aligned_seq{first_subrange};
+        fill_aligned_sequence(first_aligned_seq, first_gap_segments, begin_coordinate.first_seq_pos);
+
+        // Get the subrange over the second sequence according to the begin and end coordinate.
+        auto it_second_seq_begin = seqan3::begin(second_batch);
+        std::advance(it_second_seq_begin, begin_coordinate.second_seq_pos);
+        auto it_second_seq_end = seqan3::begin(second_batch);
+        std::advance(it_second_seq_end, end_coordinate.second_seq_pos);
+
+        using second_subrange_type = seqan3::view::subrange<decltype(it_second_seq_begin), decltype(it_second_seq_end)>;
+        auto second_subrange = second_subrange_type{it_second_seq_begin, it_second_seq_end};
+
+        // Create and fill the aligned_sequence for the first sequence.
+        std::vector<gapped<second_seq_value_type>> second_aligned_seq{second_subrange};
+        fill_aligned_sequence(second_aligned_seq, second_gap_segments, begin_coordinate.second_seq_pos);
+
+        return std::tuple{begin_coordinate, std::tuple{first_aligned_seq, second_aligned_seq}};
     }
 
     //!\brief The alignment configuration stored on the heap.

--- a/include/seqan3/alignment/pairwise/alignment_algorithm.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_algorithm.hpp
@@ -122,7 +122,7 @@ public:
         assert(cfg_ptr != nullptr);
 
         // We need to allocate the score_matrix and maybe the trace_matrix.
-        this->allocate_score_matrix(first_batch, second_batch);
+        this->allocate_matrix(first_batch, second_batch);
 
         // Initialize cache variables to keep frequently used variables close to the CPU registers.
         auto cache = this->make_cache(get<align_cfg::gap>(*cfg_ptr).value);
@@ -155,12 +155,12 @@ private:
 
         this->init_origin_cell(*std::ranges::begin(col), cache);
 
-        ranges::for_each(col | ranges::view::drop_exactly(1), [&cache, this](auto & cell)
+        ranges::for_each(col | ranges::view::drop_exactly(1), [&cache, this](auto && cell)
         {
-            this->init_column_cell(cell, cache);
+            this->init_column_cell(std::forward<decltype(cell)>(cell), cache);
         });
 
-        this->check_score_last_row(get<0>(*(seqan3::end(col) - 1)), get<3>(cache));
+        this->check_score_last_row(get<0>(get<0>(*(--seqan3::end(col)))), get<3>(cache));
     }
 
     /*!\brief Compute the alignment by iterating over the dynamic programming matrix in a column wise manner.
@@ -186,12 +186,14 @@ private:
             this->init_row_cell(*std::ranges::begin(col), cache);
 
             auto second_batch_it = std::ranges::begin(second_batch);
-            ranges::for_each(col | ranges::view::drop_exactly(1), [&, this] (auto & cell)
+            ranges::for_each(col | ranges::view::drop_exactly(1), [&, this] (auto && cell)
             {
-                this->compute_cell(cell, cache, score_scheme.score(seq1_value, *second_batch_it));
+                this->compute_cell(std::forward<decltype(cell)>(cell),
+                                   cache,
+                                   score_scheme.score(seq1_value, *second_batch_it));
                 ++second_batch_it;
             });
-            this->check_score_last_row(get<0>(*(seqan3::end(col) - 1)), get<3>(cache));
+            this->check_score_last_row(get<0>(get<0>(*(--seqan3::end(col)))), get<3>(cache));
         });
         this->check_score_last_column(this->current_column(), get<3>(cache));
     }

--- a/include/seqan3/alignment/pairwise/alignment_algorithm.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_algorithm.hpp
@@ -69,7 +69,7 @@ namespace seqan3::detail
  */
 template <typename config_t, typename ...algorithm_policies_t>
 class alignment_algorithm :
-    protected invoke_deferred_crtp_base<algorithm_policies_t, alignment_algorithm<algorithm_policies_t...>>...
+    public invoke_deferred_crtp_base<algorithm_policies_t, alignment_algorithm<config_t, algorithm_policies_t...>>...
 {
 public:
     /*!\name Constructor, destructor and assignment
@@ -137,8 +137,7 @@ public:
         // Choose what needs to be computed.
         if constexpr (config_t::template exists<align_cfg::result<detail::with_score_type>>())
         {
-            auto last_col = this->current_column();
-            res.score = get<0>(*(std::ranges::end(last_col) - 1));
+            res.score = get<3>(cache);
         }
         return align_result{res};
     }
@@ -177,6 +176,7 @@ private:
                         second_batch_t const & second_batch,
                         cache_t & cache)
     {
+        using std::get;
         auto const & score_scheme = get<align_cfg::scoring>(*cfg_ptr).value;
         ranges::for_each(first_batch, [&, this](auto seq1_value)
         {
@@ -189,7 +189,9 @@ private:
                 this->compute_cell(cell, cache, score_scheme.score(seq1_value, *second_batch_it));
                 ++second_batch_it;
             });
+            this->check_score_last_row(get<0>(*(seqan3::end(col) - 1)), get<3>(cache));
         });
+        this->check_score_last_column(this->current_column(), get<3>(cache));
     }
 
     //!\brief The alignment configuration stored on the heap.

--- a/include/seqan3/alignment/pairwise/alignment_configurator.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_configurator.hpp
@@ -228,8 +228,8 @@ alignment_configurator::configure_free_ends_initialisation(config_t const & cfg)
     // score and cell type
     // ----------------------------------------------------------------------------
 
-    using score_type = int;
-    using cell_type = std::tuple<score_type, score_type>;
+    using score_type = int32_t;
+    using cell_type = std::tuple<score_type, score_type, ignore_t>;
 
     // ----------------------------------------------------------------------------
     // dynamic programming matrix

--- a/include/seqan3/alignment/pairwise/alignment_configurator.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_configurator.hpp
@@ -51,7 +51,9 @@ private:
     /*!\brief Auxiliary member types
      * \{
      */
+     //!\brief The type of the first sequence.
     using first_seq_t  = std::tuple_element_t<0, value_type_t<std::ranges::iterator_t<range_type>>>;
+    //!\brief The type of the second sequence.
     using second_seq_t = std::tuple_element_t<1, value_type_t<std::ranges::iterator_t<range_type>>>;
     //!\}
 
@@ -86,9 +88,16 @@ public:
  */
 struct alignment_configurator
 {
-    //!\brief Configure the algorithm.
-    template <std::ranges::ViewableRange sequences_t, typename config_t>
+    /*!\brief Configures the algorithm.
+     * \tparam sequences_t The range type containing the sequence pairs; must model std::ranges::InputRange.
+     * \tparam config_t    The alignment configuration type; must be a specialisation of seqan3::configuration.
+     * \param[in]     seq_range The range over the sequence pairs.
+     * \param[in,out] cfg       The configuration object.
+     */
+    template <std::ranges::InputRange sequences_t, typename config_t>
+    //!\cond
         requires is_type_specialisation_of_v<remove_cvref_t<config_t>, configuration>
+    //!\endcond
     static constexpr auto configure(sequences_t seq_range, config_t const & cfg)
     {
         // ----------------------------------------------------------------------------
@@ -106,7 +115,6 @@ struct alignment_configurator
         using result_t = align_result<typename align_result_selector<first_seq_t, second_seq_t, config_t>::type>;
         // Define the kernel type.
         using kernel_t = std::function<result_t(first_seq_t const &, second_seq_t const &)>;
-
 
         // ----------------------------------------------------------------------------
         // Test some basic preconditions
@@ -157,33 +165,199 @@ struct alignment_configurator
         // Unsupported configurations
         // ----------------------------------------------------------------------------
 
-        if constexpr (config_t::template exists<align_cfg::aligned_ends>())
-            throw std::domain_error{"Configuring the aligned ends is yet not supported."};
-
         if constexpr (config_t::template exists<align_cfg::result<with_begin_position_type>>())
             throw std::domain_error{"Computing the begin position is yet not supported."};
 
         if constexpr (config_t::template exists<align_cfg::result<with_trace_type>>())
             throw std::domain_error{"Computing the traceback is yet not supported."};
 
-        // Configure non-edit distance alignment algorithm.
-        using score_type = int;
-        using cell_type = std::pair<score_type, score_type>;
-        using dp_matrix_t = deferred_crtp_base<unbanded_dp_matrix_policy, std::allocator<cell_type>>;
-        using affine_t = deferred_crtp_base<affine_gap_policy, cell_type>;
-        using init_t = deferred_crtp_base<affine_gap_init_policy>;
-
-        return kernel_t{alignment_algorithm<config_t, dp_matrix_t, affine_t, init_t>{cfg}};
+        // Configure the alignment algorithm.
+        return configure_free_ends_initialisation<kernel_t>(cfg);
     }
 
 private:
 
-    //!\brief Configure the edit distance algorithm.
+    /*!\brief Configures the edit distance algorithm.
+     * \tparam kernel_t The type-erased kernel to return.
+     * \tparam config_t The alignment configuration type.
+     * \param[in] cfg   The passed configuration object.
+     */
     template <typename kernel_t, typename config_t>
     static constexpr auto configure_edit_distance(config_t const & cfg)
     {
         return kernel_t{edit_distance_wrapper<remove_cvref_t<config_t>>{cfg}};
     }
+
+    /*!\brief Configures the dynamic programming matrix initialisation accoring to seqan3::align_cfg::aligned_ends
+     *        settings.
+     * \tparam kernel_t The type-erased kernel to return.
+     * \tparam config_t The alignment configuration type.
+     * \param[in] cfg   The passed configuration object.
+     *
+     * \details
+     *
+     * The matrix initialisation depends on the settings for the leading gaps for the first and the second sequence
+     * within the seqan3::align_cfg::aligned_ends configuration element.
+     */
+    template <typename kernel_t, typename config_t>
+    static constexpr auto configure_free_ends_initialisation(config_t const & cfg);
+
+    /*!\brief Configures the search space for the alignment algorithm according to seqan3::align_cfg::aligned_ends
+     *        settings.
+     * \tparam kernel_t     The type-erased kernel to return.
+     * \tparam policies_t   A template parameter pack for the already configured policy types.
+     * \tparam config_t     The alignment configuration type.
+     * \param[in] cfg       The passed configuration object.
+     *
+     * \details
+     *
+     * This option is configured in the seqan3::align_cfg::aligned_ends configuration element according to
+     * the settings for the trailing gaps of the first and the second sequence.
+     */
+    template <typename kernel_t, typename ...policies_t, typename config_t>
+    static constexpr auto configure_free_ends_optimum_search(config_t const & cfg);
+
 };
 
+//!\cond
+template <typename kernel_t, typename config_t>
+constexpr auto
+alignment_configurator::configure_free_ends_initialisation(config_t const & cfg)
+{
+    // ----------------------------------------------------------------------------
+    // score and cell type
+    // ----------------------------------------------------------------------------
+
+    using score_type = int;
+    using cell_type = std::tuple<score_type, score_type>;
+
+    // ----------------------------------------------------------------------------
+    // dynamic programming matrix
+    // ----------------------------------------------------------------------------
+
+    using dp_matrix_t = deferred_crtp_base<unbanded_dp_matrix_policy, std::allocator<cell_type>>;
+
+    // ----------------------------------------------------------------------------
+    // affine gap kernel
+    // ----------------------------------------------------------------------------
+
+    using affine_t = deferred_crtp_base<affine_gap_policy, cell_type>;
+
+    // ----------------------------------------------------------------------------
+    // configure initialisation policy
+    // ----------------------------------------------------------------------------
+
+    // Get the value for the sequence ends configuration.
+    auto align_ends_cfg = cfg.template value_or<align_cfg::aligned_ends>(align_cfg::none_ends_free);
+    using align_ends_cfg_t = decltype(align_ends_cfg);
+
+    // This lambda augments the initialisation policy of the alignment algorithm
+    // with the aligned_ends configuration from before.
+    auto _leading_both = [&](auto first_seq, auto second_seq) constexpr
+    {
+        // Define the trait for the initialisation policy
+        struct _trait
+        {
+            using free_first_leading_t  [[maybe_unused]] = decltype(first_seq);
+            using free_second_leading_t [[maybe_unused]] = decltype(second_seq);
+        };
+
+        // Make initialisation policy a deferred CRTP base and delegate to configure the find optimum policy.
+        using init_t = deferred_crtp_base<affine_gap_init_policy, _trait>;
+        return configure_free_ends_optimum_search<kernel_t, affine_t, dp_matrix_t, init_t>(cfg);
+    };
+
+    // This lambda determines the initialisation configuration for the second sequence given
+    // the leading gap property for it.
+    auto _leading_second = [&](auto first) constexpr
+    {
+        // If possible use static information.
+        if constexpr (align_ends_cfg_t::template is_static<2>())
+        {
+            return _leading_both(first, std::integral_constant<bool, align_ends_cfg_t::template get_static<2>()>{});
+        }
+        else
+        {   // Resolve correct property at runtime.
+            if (align_ends_cfg[2])
+                return _leading_both(first, std::true_type{});
+            else
+                return _leading_both(first, std::false_type{});
+        }
+    };
+
+    // Here the initialisation configuration for the first sequence is determined given
+    // the leading gap property for it.
+    // If possible use static information.
+    if constexpr (align_ends_cfg_t::template is_static<0>())
+    {
+        return _leading_second(std::integral_constant<bool, align_ends_cfg_t::template get_static<0>()>{});
+    }
+    else
+    {  // Resolve correct property at runtime.
+        if (align_ends_cfg[0])
+            return _leading_second(std::true_type{});
+        else
+            return _leading_second(std::false_type{});
+    }
+}
+//!\endcond
+
+//!\cond
+template <typename kernel_t, typename ...policies_t, typename config_t>
+constexpr auto
+alignment_configurator::configure_free_ends_optimum_search(config_t const & cfg)
+{
+    // Get the value for the sequence ends configuration.
+    auto align_ends_cfg = cfg.template value_or<align_cfg::aligned_ends>(align_cfg::none_ends_free);
+    using align_ends_cfg_t = decltype(align_ends_cfg);
+
+    // This lambda augments the find optimum policy of the alignment algorithm with the
+    // respective aligned_ends configuration.
+    auto _trailing_both = [&](auto first_seq, auto second_seq) constexpr
+    {
+        struct _trait
+        {
+            using find_in_every_cell_type  [[maybe_unused]] = std::false_type;
+            using find_in_last_row_type    [[maybe_unused]] = decltype(first_seq);
+            using find_in_last_column_type [[maybe_unused]] = decltype(second_seq);
+        };
+
+        using init_t = deferred_crtp_base<find_optimum_policy, _trait>;
+        return kernel_t{alignment_algorithm<config_t, policies_t..., init_t>{cfg}};
+    };
+
+    // This lambda determines the lookup configuration for the second sequence given
+    // the trailing gap property for it.
+    auto _trailing_second = [&](auto first) constexpr
+    {
+        // If possible use static information.
+        if constexpr (align_ends_cfg_t::template is_static<3>())
+        {
+            return _trailing_both(first, std::integral_constant<bool, align_ends_cfg_t::template get_static<3>()>{});
+        }
+        else
+        { // Resolve correct property at runtime.
+            if (align_ends_cfg[3])
+                return _trailing_both(first, std::true_type{});
+            else
+                return _trailing_both(first, std::false_type{});
+        }
+    };
+
+    // Here the lookup configuration for the first sequence is determined given
+    // the trailing gap property for it.
+    // If possible use static information.
+    if constexpr (align_ends_cfg_t::template is_static<1>())
+    {
+        return _trailing_second(std::integral_constant<bool, align_ends_cfg_t::template get_static<1>()>{});
+    }
+    else
+    { // Resolve correct property at runtime.
+        if (align_ends_cfg[1])
+            return _trailing_second(std::true_type{});
+        else
+            return _trailing_second(std::false_type{});
+    }
+}
+//!\endcond
 } // namespace seqan3::detail

--- a/include/seqan3/alignment/pairwise/edit_distance_unbanded.hpp
+++ b/include/seqan3/alignment/pairwise/edit_distance_unbanded.hpp
@@ -483,7 +483,7 @@ public:
         if constexpr(is_semi_global)
             col = std::distance(begin(database), _best_score_col);
 
-        return {col, query.size() - 1};
+        return {column_index_type{col}, row_index_type{query.size() - 1}};
     }
 
     //!\brief Return the alignment, i.e. the actual base pair matching.

--- a/include/seqan3/alignment/pairwise/policy/affine_gap_init_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/affine_gap_init_policy.hpp
@@ -14,7 +14,7 @@
 
 #include <tuple>
 
-#include <seqan3/core/platform.hpp>
+#include <seqan3/alignment/matrix/trace_directions.hpp>
 
 namespace seqan3::detail
 {
@@ -71,24 +71,37 @@ private:
     {
         using std::get;
 
-        auto & [main_score, hz_score] = get<0>(current_cell);
+        auto & [main_score, hz_score, hz_trace]       = get<0>(current_cell);
         auto & [prev_cell, gap_open, gap_extend, opt] = cache;
         auto & vt_score = get<1>(prev_cell);
         (void) opt;  // prevent compiler warning.
 
         main_score = 0;
+        get<2>(current_cell) = trace_directions::none; // store the trace direction
 
         // Initialise the vertical matrix cell according to the traits settings.
         if constexpr (traits_type::free_second_leading_t::value)
+        {
             vt_score = 0;
+            get<2>(prev_cell) = trace_directions::none;  // cache vertical trace
+        }
         else
+        {
             vt_score = gap_open;
+            get<2>(prev_cell) = trace_directions::up_open; // cache vertical trace
+        }
 
         // Initialise the horizontal matrix cell according to the traits settings.
         if constexpr (traits_type::free_first_leading_t::value)
+        {
             hz_score = 0;
+            hz_trace = trace_directions::none; // cache horizontal trace
+        }
         else
+        {
             hz_score = gap_open;
+            hz_trace = trace_directions::left_open; // cache horizontal trace
+        }
     }
 
     /*!\brief Initialises a cell in the first column of the dynamic programming matrix.
@@ -102,20 +115,28 @@ private:
     {
         using std::get;
 
-        auto & [main_score, hz_score] = get<0>(current_cell);
+        auto & [main_score, hz_score, hz_trace]       = get<0>(current_cell);
         auto & [prev_cell, gap_open, gap_extend, opt] = cache;
         auto & vt_score = get<1>(prev_cell);
         (void) opt;  // prevent compiler warning.
 
         main_score = vt_score;
+        get<2>(current_cell) = get<2>(prev_cell); // store the trace direction
 
         // Initialise the vertical matrix cell according to the traits settings.
         if constexpr (traits_type::free_second_leading_t::value)
+        {
             vt_score = 0;
+            get<2>(prev_cell) = trace_directions::none; // cache vertical trace
+        }
         else
+        {
             vt_score += gap_extend;
+            get<2>(prev_cell) = trace_directions::up; // cache vertical trace
+        }
 
         hz_score = main_score + gap_open;
+        hz_trace = trace_directions::none;  // cache horizontal trace
     }
 
     /*!\brief Initialises a cell in the first row of the dynamic programming matrix.
@@ -129,22 +150,28 @@ private:
     {
         using std::get;
 
-        auto & [main_score, hz_score] = get<0>(current_cell);
+        auto & [main_score, hz_score, hz_trace]       = get<0>(current_cell);
         auto & [prev_cell, gap_open, gap_extend, opt] = cache;
-        auto & [prev_score, vt_score] = prev_cell;
+        auto & [prev_score, vt_score, vt_trace]       = prev_cell;
         (void) opt;  // prevent compiler warning.
 
         prev_score = main_score;
         main_score = hz_score;
+        get<2>(current_cell) = hz_trace; // store the trace direction
 
         vt_score += main_score + gap_open;
-
+        vt_trace = trace_directions::none; // cache vertical trace
         // Initialise the horizontal matrix cell according to the traits settings.
         if constexpr (traits_type::free_first_leading_t::value)
+        {
             hz_score = 0;
+            hz_trace = trace_directions::none;
+        }
         else
+        {
             hz_score += gap_extend;
-
+            hz_trace = trace_directions::left;
+        }
     }
 };
 

--- a/include/seqan3/alignment/pairwise/policy/affine_gap_init_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/affine_gap_init_policy.hpp
@@ -79,16 +79,16 @@ private:
         main_score = 0;
 
         // Initialise the vertical matrix cell according to the traits settings.
-        if constexpr (traits_type::free_first_leading_t::value)
+        if constexpr (traits_type::free_second_leading_t::value)
             vt_score = 0;
         else
-            vt_score = gap_open + gap_extend;
+            vt_score = gap_open;
 
         // Initialise the horizontal matrix cell according to the traits settings.
-        if constexpr (traits_type::free_second_leading_t::value)
+        if constexpr (traits_type::free_first_leading_t::value)
             hz_score = 0;
         else
-            hz_score = gap_open + gap_extend;
+            hz_score = gap_open;
     }
 
     /*!\brief Initialises a cell in the first column of the dynamic programming matrix.
@@ -110,12 +110,12 @@ private:
         main_score = vt_score;
 
         // Initialise the vertical matrix cell according to the traits settings.
-        if constexpr (traits_type::free_first_leading_t::value)
+        if constexpr (traits_type::free_second_leading_t::value)
             vt_score = 0;
         else
             vt_score += gap_extend;
 
-        hz_score = main_score + gap_open + gap_extend;
+        hz_score = main_score + gap_open;
     }
 
     /*!\brief Initialises a cell in the first row of the dynamic programming matrix.
@@ -135,10 +135,10 @@ private:
         prev_score = main_score;
         main_score = hz_score;
 
-        vt_score += main_score + gap_open + gap_extend;
+        vt_score += main_score + gap_open;
 
         // Initialise the horizontal matrix cell according to the traits settings.
-        if constexpr (traits_type::free_second_leading_t::value)
+        if constexpr (traits_type::free_first_leading_t::value)
             hz_score = 0;
         else
             hz_score += gap_extend;

--- a/include/seqan3/alignment/pairwise/policy/affine_gap_init_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/affine_gap_init_policy.hpp
@@ -58,7 +58,7 @@ private:
     constexpr affine_gap_init_policy & operator=(affine_gap_init_policy const &) noexcept = default;
     constexpr affine_gap_init_policy & operator=(affine_gap_init_policy &&) noexcept = default;
     ~affine_gap_init_policy() noexcept = default;
-    //!}
+    //!\}
 
     /*!\brief Initialises the origin of the dynamic programming matrix.
      * \tparam        cell_t       The underlying cell type.
@@ -71,10 +71,9 @@ private:
     {
         using std::get;
 
-        auto & [main_score, hz_score, hz_trace]       = get<0>(current_cell);
-        auto & [prev_cell, gap_open, gap_extend, opt] = cache;
+        auto & [main_score, hz_score, hz_trace] = get<0>(current_cell);
+        auto & prev_cell = get<0>(cache);
         auto & vt_score = get<1>(prev_cell);
-        (void) opt;  // prevent compiler warning.
 
         main_score = 0;
         get<2>(current_cell) = trace_directions::none; // store the trace direction
@@ -87,7 +86,7 @@ private:
         }
         else
         {
-            vt_score = gap_open;
+            vt_score = get<1>(cache);
             get<2>(prev_cell) = trace_directions::up_open; // cache vertical trace
         }
 
@@ -99,7 +98,7 @@ private:
         }
         else
         {
-            hz_score = gap_open;
+            hz_score = get<1>(cache);
             hz_trace = trace_directions::left_open; // cache horizontal trace
         }
     }
@@ -115,10 +114,9 @@ private:
     {
         using std::get;
 
-        auto & [main_score, hz_score, hz_trace]       = get<0>(current_cell);
-        auto & [prev_cell, gap_open, gap_extend, opt] = cache;
+        auto & [main_score, hz_score, hz_trace] = get<0>(current_cell);
+        auto & prev_cell = get<0>(cache);
         auto & vt_score = get<1>(prev_cell);
-        (void) opt;  // prevent compiler warning.
 
         main_score = vt_score;
         get<2>(current_cell) = get<2>(prev_cell); // store the trace direction
@@ -131,12 +129,12 @@ private:
         }
         else
         {
-            vt_score += gap_extend;
+            vt_score += get<2>(cache);
             get<2>(prev_cell) = trace_directions::up; // cache vertical trace
         }
 
-        hz_score = main_score + gap_open;
-        hz_trace = trace_directions::none;  // cache horizontal trace
+        hz_score = main_score + get<1>(cache);
+        hz_trace = trace_directions::left_open;  // cache horizontal trace
     }
 
     /*!\brief Initialises a cell in the first row of the dynamic programming matrix.
@@ -150,17 +148,16 @@ private:
     {
         using std::get;
 
-        auto & [main_score, hz_score, hz_trace]       = get<0>(current_cell);
-        auto & [prev_cell, gap_open, gap_extend, opt] = cache;
-        auto & [prev_score, vt_score, vt_trace]       = prev_cell;
-        (void) opt;  // prevent compiler warning.
+        auto & [main_score, hz_score, hz_trace] = get<0>(current_cell);
+        auto & prev_cell = get<0>(cache);
+        auto & [prev_score, vt_score, vt_trace] = prev_cell;
 
         prev_score = main_score;
         main_score = hz_score;
         get<2>(current_cell) = hz_trace; // store the trace direction
 
-        vt_score += main_score + gap_open;
-        vt_trace = trace_directions::none; // cache vertical trace
+        vt_score += main_score + get<1>(cache);
+        vt_trace = trace_directions::up_open; // cache vertical trace
         // Initialise the horizontal matrix cell according to the traits settings.
         if constexpr (traits_type::free_first_leading_t::value)
         {
@@ -169,7 +166,7 @@ private:
         }
         else
         {
-            hz_score += gap_extend;
+            hz_score += get<2>(cache);
             hz_trace = trace_directions::left;
         }
     }

--- a/include/seqan3/alignment/pairwise/policy/affine_gap_init_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/affine_gap_init_policy.hpp
@@ -67,11 +67,11 @@ private:
      * \param[in,out] cache        The cache storing hot helper variables.
      */
     template <typename cell_t, typename cache_t>
-    constexpr auto init_origin_cell(cell_t & current_cell, cache_t & cache) const noexcept
+    constexpr auto init_origin_cell(cell_t && current_cell, cache_t & cache) const noexcept
     {
         using std::get;
 
-        auto & [main_score, hz_score] = current_cell;
+        auto & [main_score, hz_score] = get<0>(current_cell);
         auto & [prev_cell, gap_open, gap_extend, opt] = cache;
         auto & vt_score = get<1>(prev_cell);
         (void) opt;  // prevent compiler warning.
@@ -98,11 +98,11 @@ private:
      * \param[in,out] cache        The cache storing hot helper variables.
      */
     template <typename cell_t, typename cache_t>
-    constexpr auto init_column_cell(cell_t & current_cell, cache_t & cache) const noexcept
+    constexpr auto init_column_cell(cell_t && current_cell, cache_t & cache) const noexcept
     {
         using std::get;
 
-        auto & [main_score, hz_score] = current_cell;
+        auto & [main_score, hz_score] = get<0>(current_cell);
         auto & [prev_cell, gap_open, gap_extend, opt] = cache;
         auto & vt_score = get<1>(prev_cell);
         (void) opt;  // prevent compiler warning.
@@ -125,9 +125,11 @@ private:
      * \param[in,out] cache        The cache storing hot helper variables.
      */
     template <typename cell_t, typename cache_t>
-    constexpr auto init_row_cell(cell_t & current_cell, cache_t & cache) const noexcept
+    constexpr auto init_row_cell(cell_t && current_cell, cache_t & cache) const noexcept
     {
-        auto & [main_score, hz_score] = current_cell;
+        using std::get;
+
+        auto & [main_score, hz_score] = get<0>(current_cell);
         auto & [prev_cell, gap_open, gap_extend, opt] = cache;
         auto & [prev_score, vt_score] = prev_cell;
         (void) opt;  // prevent compiler warning.

--- a/include/seqan3/alignment/pairwise/policy/affine_gap_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/affine_gap_policy.hpp
@@ -64,12 +64,14 @@ private:
      * \param[in]     score           The score of comparing the respective letters of the first and the second sequence.
      */
     template <typename score_cell_type, typename cache_t>
-    constexpr void compute_cell(score_cell_type & current_cell,
+    constexpr void compute_cell(score_cell_type && current_cell,
                                 cache_t & cache,
                                 score_t const score) const noexcept
     {
+        using std::get;
+
         // Unpack the cached variables.
-        auto & [main_score, hz_score] = current_cell;
+        auto & [main_score, hz_score] = get<0>(current_cell);
         auto & [prev_cell, gap_open, gap_extend, opt] = cache;
         auto & [prev_score, vt_score] = prev_cell;
 

--- a/include/seqan3/alignment/pairwise/policy/affine_gap_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/affine_gap_policy.hpp
@@ -55,7 +55,7 @@ private:
     constexpr affine_gap_policy & operator=(affine_gap_policy const &) noexcept = default;
     constexpr affine_gap_policy & operator=(affine_gap_policy &&)      noexcept = default;
     ~affine_gap_policy()                                               noexcept = default;
-    //!}
+    //!\}
 
     /*!\brief Computes the score of the current cell.
      * \tparam  matrix_entry_type The type of the current cell.
@@ -93,9 +93,9 @@ private:
         else  // Compute any traceback
         {
             tmp = (tmp < vt_score) ? (trace_value = vt_trace, vt_score)
-                                   : (trace_value = trace_directions::diagonal, tmp);
+                                   : (trace_value = trace_directions::diagonal | vt_trace, tmp);
             tmp = (tmp < hz_score) ? (trace_value = hz_trace, hz_score)
-                                   : tmp;
+                                   : (trace_value |= hz_trace, tmp);
         }
         // Cache the current main score for the next diagonal computation and update the current score.
         prev_score = main_score;
@@ -118,8 +118,8 @@ private:
         {
             vt_score = (vt_score < tmp) ? (vt_trace = trace_directions::up_open, tmp)
                                         : (vt_trace = trace_directions::up, vt_score);
-            hz_score = (hz_score < tmp) ? (hz_trace = trace_directions::up_open, tmp)
-                                        : (hz_trace = trace_directions::up, hz_score);
+            hz_score = (hz_score < tmp) ? (hz_trace = trace_directions::left_open, tmp)
+                                        : (hz_trace = trace_directions::left, hz_score);
         }
     }
 

--- a/include/seqan3/alignment/pairwise/policy/affine_gap_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/affine_gap_policy.hpp
@@ -15,7 +15,7 @@
 #include <limits>
 #include <tuple>
 
-#include <seqan3/core/platform.hpp>
+#include <seqan3/alignment/matrix/alignment_optimum.hpp>
 
 namespace seqan3::detail
 {
@@ -56,22 +56,23 @@ private:
     ~affine_gap_policy()                                               noexcept = default;
     //!}
 
-    /*!\brief Computes the score for current cell.
-     * \tparam        score_cell_type The type of the current cell.
-     * \tparam        cache_t         The type of the cache.
-     * \param[in,out] current_cell    The current cell in the dynamic programming matrix.
-     * \param[in,out] cache           The cache storing hot helper variables.
-     * \param[in]     score           The score of comparing the respective letters of the first and the second sequence.
+    /*!\brief Computes the score of the current cell.
+     * \tparam  matrix_entry_type The type of the current cell.
+     * \tparam  cache_type        The type of the cache.
+     * \param[in,out] current_cell The current cell in the dynamic programming matrix.
+     * \param[in,out] cache        The cache storing hot helper variables.
+     * \param[in]     score        The score of comparing the respective letters of the first and the second sequence.
      */
-    template <typename score_cell_type, typename cache_t>
-    constexpr void compute_cell(score_cell_type && current_cell,
+    template <typename matrix_entry_type, typename cache_t>
+    constexpr void compute_cell(matrix_entry_type && current_cell,
                                 cache_t & cache,
                                 score_t const score) const noexcept
     {
         using std::get;
 
         // Unpack the cached variables.
-        auto & [main_score, hz_score] = get<0>(current_cell);
+        auto & [score_entry, coordinate, trace_entry] = current_cell;
+        auto & [main_score, hz_score] = score_entry;
         auto & [prev_cell, gap_open, gap_extend, opt] = cache;
         auto & [prev_score, vt_score] = prev_cell;
 
@@ -84,7 +85,8 @@ private:
         prev_score = main_score;
         main_score = tmp;
         // Check if this was the optimum. Possibly a noop.
-        static_cast<derived_t const &>(*this).check_score(tmp, opt);
+        static_cast<derived_t const &>(*this).check_score(
+                alignment_optimum{tmp, static_cast<alignment_coordinate>(coordinate)}, opt);
         tmp += gap_open;
         vt_score += gap_extend;
         hz_score += gap_extend;
@@ -100,10 +102,12 @@ private:
     template <typename gap_scheme_t>
     constexpr auto make_cache(gap_scheme_t && scheme) const noexcept
     {
+        alignment_optimum opt{std::numeric_limits<score_t>::lowest(),
+                              alignment_coordinate{column_index_type{0u}, row_index_type{0u}}};
         return std::tuple{cell_t{},
                           static_cast<score_t>(scheme.get_gap_open_score() + scheme.get_gap_score()),
                           static_cast<score_t>(scheme.get_gap_score()),
-                          score_t{std::numeric_limits<score_t>::lowest()}};
+                          std::move(opt)};
     }
 };
 

--- a/include/seqan3/alignment/pairwise/policy/all.hpp
+++ b/include/seqan3/alignment/pairwise/policy/all.hpp
@@ -79,6 +79,7 @@
  * ### Existing matrix policies:
  *
  *  - seqan3::detail::unbanded_dp_matrix_policy
+ *  - seqan3::detail::unbanded_score_trace_dp_matrix_policy
  *
  * ## Gap policies
  *

--- a/include/seqan3/alignment/pairwise/policy/all.hpp
+++ b/include/seqan3/alignment/pairwise/policy/all.hpp
@@ -16,6 +16,7 @@
 
 #include <seqan3/alignment/pairwise/policy/affine_gap_init_policy.hpp>
 #include <seqan3/alignment/pairwise/policy/affine_gap_policy.hpp>
+#include <seqan3/alignment/pairwise/policy/find_optimum_policy.hpp>
 #include <seqan3/alignment/pairwise/policy/unbanded_dp_matrix_policy.hpp>
 
 //!\cond DEV
@@ -132,5 +133,38 @@
  * ### Existing gap init policies:
  *
  *  - seqan3::detail::affine_gap_init_policy
+ *
+ * ## Find optimum policies
+ *
+ * These policies are used to define the search space of the alignment optimum.
+ *
+ * Function name             | Arguments                     | Return value                         |
+ * ------------------------- | ----------------------------- | ------------------------------------ |
+ * `check_score`             | `score const`, `optimum &`    | `void`                               |
+ * `check_score_last_row`    | `score const`, `optimum &`    | `void`                               |
+ * `check_score_last_column` | `rng_t &&`, `optimum &`       | `void`                               |
+ *
+ * - check_score:
+ *
+ *    Is called for every cell in the dynamic programming matrix. Might be a "NO-OP".
+ *    The left operand is the score of the current cell and the right operand is the current optimum that will
+ *    be updated if the current score was higher.
+ *
+ * - check_score_last_row:
+ *
+ *    Is called only for the cells in the last row of the dynamic programming matrix. Might be a NO-OP.
+ *    The left operand is the score of the current cell and the right operand is the current optimum that will
+ *    be updated if the current score was higher.
+ *
+ * - check_score_last_column:
+ *
+ *    Is called only for the cells in the last column of the dynamic programming matrix.
+ *    The left operand is the entire last column, because the algorithm's layout is column based.
+ *    This function might skip the entire range and only compare the last value (the score for the global alignment)
+ *    depending on the alignment configuration.
+ *
+ * ### Existing optimum policies:
+ *
+ *  - seqan3::detail::find_optimum_policy
  */
 //!\endcond

--- a/include/seqan3/alignment/pairwise/policy/all.hpp
+++ b/include/seqan3/alignment/pairwise/policy/all.hpp
@@ -18,6 +18,7 @@
 #include <seqan3/alignment/pairwise/policy/affine_gap_policy.hpp>
 #include <seqan3/alignment/pairwise/policy/find_optimum_policy.hpp>
 #include <seqan3/alignment/pairwise/policy/unbanded_dp_matrix_policy.hpp>
+#include <seqan3/alignment/pairwise/policy/unbanded_score_trace_dp_matrix_policy.hpp>
 
 //!\cond DEV
 /*!\defgroup alignment_policy Alignment policies
@@ -54,11 +55,12 @@
  * These policies maintain the alignment matrix in their own state.
  * The following table shows the functions that are required by the seqan3::detail::alignment_algorithm.
  *
- * Function name     | Arguments | Return value                         |
- * ----------------- | --------- | ------------------------------------ |
- * `allocate_matrix` | &Oslash;  | `void`                               |
- * `current_column`  | &Oslash;  | *implementation defined* - see below |
- * `next_column`     | &Oslash;  | `void`                               |
+ * Function name     | Arguments               | Return value                                                                 |
+ * ----------------- | ----------------------- | ---------------------------------------------------------------------------- |
+ * `allocate_matrix` | &Oslash;                | `void`                                                                       |
+ * `current_column`  | &Oslash;                | *implementation defined* - see below                                         |
+ * `next_column`     | &Oslash;                | `void`                                                                       |
+ * `parse_traceback` | `alignment_coordinate`  | `tuple<alignment_coordinate, tuple<deque<gap_segment>, deque<gap_segment>>>` |
  *
  * - allocate_matrix:
  *
@@ -75,6 +77,13 @@
  * - next_column:
  *
  *     Is called at the end of a column computation and moves internal matrix pointers to the next column.
+ *
+ * - parse_traceback:
+ *
+ *     This function is only required if the alignment is requested. It gets the coordinate where the traceback
+ *     should be started and returns a tuple with the begin coordinate and the two iterable ranges containing
+ *     seqan3::detail::gap_segment s. These gap segments store the gaps within the first sequence and the second
+ *     sequence respectively.
  *
  * ### Existing matrix policies:
  *

--- a/include/seqan3/alignment/pairwise/policy/find_optimum_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/find_optimum_policy.hpp
@@ -35,8 +35,11 @@ namespace seqan3::detail
  */
 struct default_find_optimum_trait
 {
+    //!\brief Disables lookup of the optimal score in every cell.
     using find_in_every_cell_type  = std::false_type;
+    //!\brief Disables lookup of the optimal score in the last row.
     using find_in_last_row_type    = std::false_type;
+    //!\brief Disables lookup of the optimal score in the last column.
     using find_in_last_column_type = std::false_type;
 };
 
@@ -69,7 +72,7 @@ private:
     constexpr find_optimum_policy & operator=(find_optimum_policy const &) = default;
     constexpr find_optimum_policy & operator=(find_optimum_policy &&) = default;
     ~find_optimum_policy() = default;
-    //!}
+    //!\}
 
 protected:
 

--- a/include/seqan3/alignment/pairwise/policy/find_optimum_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/find_optimum_policy.hpp
@@ -1,0 +1,143 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides seqan3::detail::find_optimum_policy.
+ * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <type_traits>
+
+#include <range/v3/algorithm/for_each.hpp>
+
+#include <seqan3/core/metafunction/deferred_crtp_base.hpp>
+#include <seqan3/range/shortcuts.hpp>
+#include <seqan3/std/concepts>
+#include <seqan3/std/ranges>
+
+namespace seqan3::detail
+{
+
+/*!\brief The default traits class for seqan3::detail::find_optimum_policy.
+ * \ingroup alignment_policy
+ *
+ * \details
+ *
+ * Defines the behaviour of a global alignment in which only the last cell of the dynamic programming matrix is
+ * checked for the optimum.
+ */
+struct default_find_optimum_trait
+{
+    using find_in_every_cell_type  = std::false_type;
+    using find_in_last_row_type    = std::false_type;
+    using find_in_last_column_type = std::false_type;
+};
+
+/*!\brief A policy to determine the optimum of the dynamic programming matrix.
+ * \ingroup alignment_policy
+ * \tparam derived_t        The type of the derived class.
+ * \tparam traits_type      A traits type that determines which cells should be considered for the optimum.
+ *                          Defaults to seqan3::detail::default_find_optimum_trait.
+ *
+ * \details
+ *
+ * This class determines the matrix wide optimum. The search space can be further refined using the
+ * `traits_type` which configures the search space of the alignment matrix.
+ */
+template <typename derived_t, typename traits_type = default_find_optimum_trait>
+class find_optimum_policy
+{
+
+private:
+
+    //!\brief Befriends the derived class to grant it access to the private members.
+    friend derived_t;
+
+    /*!\name Constructor, destructor and assignment
+     * \{
+     */
+    constexpr find_optimum_policy() = default;
+    constexpr find_optimum_policy(find_optimum_policy const &) = default;
+    constexpr find_optimum_policy(find_optimum_policy &&) = default;
+    constexpr find_optimum_policy & operator=(find_optimum_policy const &) = default;
+    constexpr find_optimum_policy & operator=(find_optimum_policy &&) = default;
+    ~find_optimum_policy() = default;
+    //!}
+
+protected:
+
+    /*!\brief Checks every cell of the dynamic programming matrix.
+     * \tparam score_t The type of the score.
+     * \param[in]     val       The current value.
+     * \param[in,out] optimum   The current optimum to compare with.
+     *
+     * \details
+     *
+     * This function resolves to a "NO-OP" function if the trait for searching every cell is set to std::false_type.
+     */
+    template <typename score_t>
+    constexpr void check_score([[maybe_unused]] score_t const val,
+                               [[maybe_unused]] score_t & optimum) const noexcept
+    {
+        if constexpr (traits_type::find_in_every_cell_type::value)
+            optimum = std::max(optimum, val);
+    }
+
+    /*!\brief Checks a cell of the last row of the dynamic programming matrix.
+     * \tparam score_t The type of the score.
+     * \param[in]     val       The current value.
+     * \param[in,out] optimum   The current optimum to compare with.
+     *
+     * \details
+     *
+     * This function resolves to a "NO-OP" function if the trait for searching the last row is set to std::false_type.
+     * Due to a column based iteration layout this computes only one cell at a time. The alignment algorithm
+     * takes care of calling this function for the appropriate cells.
+     */
+    template <typename score_t>
+    constexpr void check_score_last_row([[maybe_unused]] score_t const val,
+                                        [[maybe_unused]] score_t & optimum) const noexcept
+    {
+        if constexpr (traits_type::find_in_last_row_type::value)
+            optimum = std::max(optimum, val);
+    }
+
+    /*!\brief Checks the complete last column for the optimal score.
+     * \tparam rng_t   The type of the last column; must model std::ranges::BidirectionalRange.
+     * \tparam score_t The type of the optimal score.
+     * \param[in]     rng       The last column of the dynamic programming matrix.
+     * \param[in,out] optimum   The current optimum to compare with.
+     *
+     * \details
+     *
+     * This function checks only the last element of the column (the score for the global alignment)
+     * if the trait for searching the last column is set to std::false_type.
+     * Due to a column based iteration layout the entire last column can be searched at once.
+     */
+    template <std::ranges::BidirectionalRange rng_t, typename score_t>
+    constexpr void check_score_last_column(rng_t && rng, score_t & optimum) const noexcept
+    {
+        using std::get;
+        // Only check the entire column if it was configured to search here.
+        if constexpr (traits_type::find_in_last_column_type::value)
+        {
+            ranges::for_each(rng, [&](auto && tpl)
+            {
+                optimum = std::max(optimum, get<0>(tpl));
+            });
+        }
+        else  // Only check the last cell for the global alignment.
+        {
+            auto val = get<0>(*(--seqan3::end(rng)));
+            optimum = std::max(optimum, val);
+        }
+    }
+};
+
+} // namespace seqan3::detail

--- a/include/seqan3/alignment/pairwise/policy/find_optimum_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/find_optimum_policy.hpp
@@ -129,12 +129,12 @@ protected:
         {
             ranges::for_each(rng, [&](auto && tpl)
             {
-                optimum = std::max(optimum, get<0>(tpl));
+                optimum = std::max(optimum, get<0>(get<0>(tpl)));
             });
         }
         else  // Only check the last cell for the global alignment.
         {
-            auto val = get<0>(*(--seqan3::end(rng)));
+            auto val = get<0>(get<0>(*(--seqan3::end(rng))));
             optimum = std::max(optimum, val);
         }
     }

--- a/include/seqan3/alignment/pairwise/policy/unbanded_dp_matrix_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/unbanded_dp_matrix_policy.hpp
@@ -16,9 +16,11 @@
 #include <tuple>
 
 #include <range/v3/view/bounded.hpp>
+#include <range/v3/view/iota.hpp>
 #include <range/v3/view/repeat_n.hpp>
 #include <range/v3/view/zip.hpp>
 
+#include <seqan3/alignment/matrix/alignment_coordinate.hpp>
 #include <seqan3/core/metafunction/range.hpp>
 #include <seqan3/range/shortcuts.hpp>
 #include <seqan3/std/span.hpp>
@@ -77,14 +79,20 @@ private:
     //!\brief Returns the current column of the alignment matrix.
     auto current_column()
     {
+        advanceable_alignment_coordinate<size_t, advanceable_alignment_coordinate_state::row>
+            col_begin{column_index_type{current_column_index}, row_index_type{0u}};
+        advanceable_alignment_coordinate<size_t, advanceable_alignment_coordinate_state::row>
+            col_end{column_index_type{current_column_index}, row_index_type{dimension_second_batch}};
+
         return ranges::view::zip(std::span{score_matrix},
+                                 ranges::view::iota(col_begin, col_end),
                                  ranges::view::repeat_n(std::ignore, dimension_second_batch) | ranges::view::bounded);
     }
 
     //!\brief Moves internal matrix pointer to the next column.
     constexpr void next_column()
     {
-        // noop
+        ++current_column_index;
     }
 
     //!\brief The data container.
@@ -93,5 +101,7 @@ private:
     size_t dimension_first_batch  = 0;
     //!\brief Caches the size of the vertical dimension (number of rows).
     size_t dimension_second_batch = 0;
+    //!\brief The index of the active column.
+    size_t current_column_index = 0;
 };
 } // namespace seqan3::detail

--- a/include/seqan3/alignment/pairwise/policy/unbanded_dp_matrix_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/unbanded_dp_matrix_policy.hpp
@@ -58,7 +58,7 @@ private:
      * \tparam first_batch_t   The type of the first sequence (or packed sequences).
      * \tparam second_batch_t  The type of the second sequence (or packed sequences).
      * \param[in] first_batch  The first sequence (or packed sequences).
-     * \param[in] second_batch The first sequence (or packed sequences).
+     * \param[in] second_batch The second sequence (or packed sequences).
      */
     template <typename first_batch_t, typename second_batch_t>
     void allocate_score_matrix(first_batch_t && first_batch, second_batch_t && second_batch)

--- a/include/seqan3/alignment/pairwise/policy/unbanded_dp_matrix_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/unbanded_dp_matrix_policy.hpp
@@ -58,7 +58,7 @@ private:
     constexpr unbanded_dp_matrix_policy & operator=(unbanded_dp_matrix_policy const &) = default;
     constexpr unbanded_dp_matrix_policy & operator=(unbanded_dp_matrix_policy &&)      = default;
     ~unbanded_dp_matrix_policy()                                                       = default;
-    //!}
+    //!\}
 
     /*!\brief Allocates the memory for the dynamic programming matrix given the two sequences.
      * \tparam first_batch_t   The type of the first sequence (or packed sequences).

--- a/include/seqan3/alignment/pairwise/policy/unbanded_dp_matrix_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/unbanded_dp_matrix_policy.hpp
@@ -30,7 +30,10 @@ namespace seqan3::detail
 template <typename derived_t, typename allocator_t>
 class unbanded_dp_matrix_policy
 {
-protected:
+private:
+
+    //!\brief Befriends the derived class to grant it access to the private members.
+    friend derived_t;
 
     /*!\name Member types
      * \{

--- a/include/seqan3/alignment/pairwise/policy/unbanded_score_trace_dp_matrix_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/unbanded_score_trace_dp_matrix_policy.hpp
@@ -1,0 +1,108 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides seqan3::detail::unbanded_score_trace_dp_matrix.
+ * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <range/v3/view/zip.hpp>
+
+#include <seqan3/alignment/matrix/trace_directions.hpp>
+#include <seqan3/alignment/pairwise/policy/unbanded_dp_matrix_policy.hpp>
+#include <seqan3/std/span.hpp>
+
+namespace seqan3::detail
+{
+/*!\brief Manages the allocation and provision of an unbanded dynamic programming matrix.
+ * \ingroup alignment_policy
+ * \tparam derived_t   The derived alignment algorithm.
+ * \tparam score_allocator_t The allocator type used for allocating the score matrix.
+ * \tparam trace_allocator_t The allocator type used for allocating the trace matrix.
+ */
+template <typename derived_t, typename score_allocator_t, typename trace_allocator_t>
+class unbanded_score_trace_dp_matrix_policy :
+    public unbanded_dp_matrix_policy<unbanded_score_trace_dp_matrix_policy<derived_t,
+                                                                           score_allocator_t,
+                                                                           trace_allocator_t>,
+                                     score_allocator_t>
+{
+private:
+
+    //!\brief The base type
+    using base_t = unbanded_dp_matrix_policy<unbanded_score_trace_dp_matrix_policy<derived_t,
+                                                                                   score_allocator_t,
+                                                                                   trace_allocator_t>,
+                                             score_allocator_t>;
+
+    //!\brief Befriends the derived class to grant it access to the private members.
+    friend derived_t;
+    //!\brief Make dimension_first_batch visible in this class.
+    using base_t::dimension_first_batch;
+    //!\brief Make dimension_second_batch visible in this class.
+    using base_t::dimension_second_batch;
+    //!\brief Make score_matrix visible in this class.
+    using base_t::score_matrix;
+
+    /*!\name Member types
+     * \{
+     */
+    //!\brief The underlying cell type of the dynamic programming matrix.
+    using cell_type  = typename score_allocator_t::value_type;
+    using trace_type = typename trace_allocator_t::value_type;
+    //!\}
+
+    /*!\name Constructor, destructor and assignment
+     * \{
+     */
+    constexpr unbanded_score_trace_dp_matrix_policy() = default;
+    constexpr unbanded_score_trace_dp_matrix_policy(unbanded_score_trace_dp_matrix_policy const &) = default;
+    constexpr unbanded_score_trace_dp_matrix_policy(unbanded_score_trace_dp_matrix_policy &&) = default;
+    constexpr unbanded_score_trace_dp_matrix_policy & operator=(unbanded_score_trace_dp_matrix_policy const &) = default;
+    constexpr unbanded_score_trace_dp_matrix_policy & operator=(unbanded_score_trace_dp_matrix_policy &&) = default;
+    ~unbanded_score_trace_dp_matrix_policy() = default;
+    //!}
+
+    /*!\brief Allocates the memory for the dynamic programming matrix given the two sequences.
+     * \tparam first_batch_t   The type of the first sequence (or packed sequences).
+     * \tparam second_batch_t  The type of the second sequence (or packed sequences).
+     * \param[in] first_batch  The first sequence (or packed sequences).
+     * \param[in] second_batch The second sequence (or packed sequences).
+     */
+    template <typename first_batch_t, typename second_batch_t>
+    constexpr void allocate_matrix(first_batch_t && first_batch, second_batch_t && second_batch)
+    {
+        dimension_first_batch = seqan3::size(std::forward<first_batch_t>(first_batch)) + 1;
+        dimension_second_batch = seqan3::size(std::forward<second_batch_t>(second_batch)) + 1;
+
+        // We use only one column to compute the score.
+        score_matrix.resize(dimension_second_batch);
+        // We use the full matrix to store the trace direction.
+        trace_matrix.resize(dimension_first_batch * dimension_second_batch);
+        trace_matrix_iter = trace_matrix.begin();
+    }
+
+    //!\brief Returns the current column of the alignment matrix.
+    constexpr auto current_column()
+    {
+        return ranges::view::zip(std::span{score_matrix}, std::span{&(*trace_matrix_iter), dimension_second_batch});
+    }
+
+    //!\brief Moves internal matrix pointer to the next column.
+    constexpr void next_column() noexcept
+    {
+        trace_matrix_iter += dimension_second_batch;
+    }
+
+    //!\brief The data container.
+    std::vector<trace_type, trace_allocator_t> trace_matrix{};
+    //!\brief The current iterator in the trace matrix.
+    typename std::vector<trace_type, trace_allocator_t>::iterator trace_matrix_iter{};
+};
+} // namespace seqan3::detail

--- a/include/seqan3/alignment/pairwise/policy/unbanded_score_trace_dp_matrix_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/unbanded_score_trace_dp_matrix_policy.hpp
@@ -12,15 +12,32 @@
 
 #pragma once
 
+#include <deque>
+
 #include <range/v3/view/iota.hpp>
+#include <range/v3/view/reverse.hpp>
 #include <range/v3/view/zip.hpp>
 
 #include <seqan3/alignment/matrix/alignment_coordinate.hpp>
+#include <seqan3/alignment/matrix/trace_directions.hpp>
 #include <seqan3/alignment/pairwise/policy/unbanded_dp_matrix_policy.hpp>
+#include <seqan3/range/view/persist.hpp>
 #include <seqan3/std/span.hpp>
 
 namespace seqan3::detail
 {
+
+/*!\brief Stores information about a contiguous gap.
+ * \ingroup alignment_policy
+ */
+struct gap_segment
+{
+    //!\brief The position in the sequence where to insert the gap; (inserted before the position).
+    size_t position;
+    //!\brief The size of the gap.
+    size_t size;
+};
+
 /*!\brief Manages the allocation and provision of an unbanded dynamic programming matrix.
  * \ingroup alignment_policy
  * \tparam derived_t   The derived alignment algorithm.
@@ -70,7 +87,7 @@ private:
     constexpr unbanded_score_trace_dp_matrix_policy & operator=(unbanded_score_trace_dp_matrix_policy const &) = default;
     constexpr unbanded_score_trace_dp_matrix_policy & operator=(unbanded_score_trace_dp_matrix_policy &&) = default;
     ~unbanded_score_trace_dp_matrix_policy() = default;
-    //!}
+    //!\}
 
     /*!\brief Allocates the memory for the dynamic programming matrix given the two sequences.
      * \tparam first_batch_t   The type of the first sequence (or packed sequences).
@@ -81,8 +98,8 @@ private:
     template <typename first_batch_t, typename second_batch_t>
     constexpr void allocate_matrix(first_batch_t && first_batch, second_batch_t && second_batch)
     {
-        dimension_first_batch = seqan3::size(std::forward<first_batch_t>(first_batch)) + 1;
-        dimension_second_batch = seqan3::size(std::forward<second_batch_t>(second_batch)) + 1;
+        dimension_first_batch = seqan3::size(first_batch) + 1;
+        dimension_second_batch = seqan3::size(second_batch) + 1;
         current_column_index = 0;
         // We use only one column to compute the score.
         score_matrix.resize(dimension_second_batch);
@@ -108,7 +125,115 @@ private:
     constexpr void next_column() noexcept
     {
         ++current_column_index;
-        trace_matrix_iter += dimension_second_batch;
+        std::advance(trace_matrix_iter, dimension_second_batch);
+    }
+
+    /*!\brief Parses the traceback starting from the given coordinate.
+     * \param end_coordinate The coordinate from where to start the traceback.
+     *
+     * \returns A tuple containing the begin coordinate and a tuple with all seqan3::detail::gap_segment s for the
+     *          first sequence and the second sequence.
+     */
+    constexpr auto parse_traceback(alignment_coordinate const & end_coordinate)
+    {
+        // Store the trace segments.
+        std::deque<gap_segment> first_segments{};
+        std::deque<gap_segment> second_segments{};
+
+        // Put the iterator to the position where the traceback starts.
+        auto direction_iter = seqan3::begin(trace_matrix);
+        std::advance(direction_iter, end_coordinate.first_seq_pos * dimension_second_batch +
+                                     end_coordinate.second_seq_pos);
+
+        // Parse the trace until interrupt.
+        while (*direction_iter != trace_directions::none)
+        {
+            // parse until end of diagonal run
+            while (static_cast<bool>(*direction_iter & trace_directions::diagonal))
+            {
+                std::advance(direction_iter, -dimension_second_batch - 1);
+            }
+
+            // parse vertical gap -> record gap in first_segments (will be translated into gap of first sequence)
+            if (static_cast<bool>(*direction_iter & trace_directions::up) ||
+                static_cast<bool>(*direction_iter & trace_directions::up_open))
+            {
+                // Get the current column index (note the column based layout)
+                size_t pos = std::distance(seqan3::begin(trace_matrix), direction_iter) / dimension_second_batch;
+                gap_segment gap{pos, 0u};
+
+                // Follow gap until open signal is detected.
+                while (!static_cast<bool>(*direction_iter & trace_directions::up_open))
+                {
+                    --direction_iter;
+                    ++gap.size;
+                }
+                // explicitly follow opening gap
+                --direction_iter;
+                ++gap.size;
+                // record the gap
+                first_segments.push_front(std::move(gap));
+                continue;
+            }
+            // parse horizontal gap -> record gap in second_segments (will be translated into gap of second sequence)
+            if (static_cast<bool>(*direction_iter & trace_directions::left) ||
+                static_cast<bool>(*direction_iter & trace_directions::left_open))
+            {
+                // Get the current row index (note the column based layout)
+                size_t pos = std::distance(seqan3::begin(trace_matrix), direction_iter) % dimension_second_batch;
+                gap_segment gap{pos, 0u};
+
+                // Follow gap until open signal is detected.
+                while (!static_cast<bool>(*direction_iter & trace_directions::left_open))
+                {
+                    std::advance(direction_iter, -dimension_second_batch);
+                    ++gap.size;
+                }
+                // explicitly follow opening gap
+                std::advance(direction_iter, -dimension_second_batch);
+                ++gap.size;
+                second_segments.push_front(std::move(gap));
+            }
+        }
+
+        // Get begin coordinate.
+        auto c = column_index_type{std::distance(seqan3::begin(trace_matrix), direction_iter) / dimension_second_batch};
+        auto r = row_index_type{std::distance(seqan3::begin(trace_matrix), direction_iter) % dimension_second_batch};
+
+        return std::tuple{alignment_coordinate{column_index_type{std::move(c)}, row_index_type{std::move(r)}},
+                          first_segments,
+                          second_segments};
+    }
+
+    //!\brief Prints the trace matrix; for debugging only.
+    void print_trace_matrix()
+    {
+        auto printable = [](trace_directions dir)
+        {
+            std::string seq{};
+            if (dir == trace_directions::none)
+                seq.append("0");
+            if ((dir & trace_directions::diagonal) == trace_directions::diagonal)
+                seq.append("\\");
+            if ((dir & trace_directions::up) == trace_directions::up)
+                seq.append("|");
+            if ((dir & trace_directions::up_open) == trace_directions::up_open)
+                seq.append("^");
+            if ((dir & trace_directions::left) == trace_directions::left)
+                seq.append("-");
+            if ((dir & trace_directions::left_open) == trace_directions::left_open)
+                seq.append("<");
+            return seq;
+        };
+
+        for (size_t row = 0; row < dimension_second_batch; ++row)
+        {
+            for (size_t col = 0; col < dimension_first_batch; ++col)
+            {
+                debug_stream << printable(trace_matrix[col * dimension_second_batch + row]) << " ";
+            }
+            debug_stream << "\n";
+        }
     }
 
     //!\brief The data container.

--- a/test/unit/alignment/matrix/CMakeLists.txt
+++ b/test/unit/alignment/matrix/CMakeLists.txt
@@ -1,2 +1,4 @@
+seqan3_test(alignment_coordinate_test.cpp)
 seqan3_test(alignment_matrix_test.cpp)
 seqan3_test(alignment_matrix_formatter_test.cpp)
+seqan3_test(alignment_optimum_test.cpp)

--- a/test/unit/alignment/matrix/alignment_coordinate_test.cpp
+++ b/test/unit/alignment/matrix/alignment_coordinate_test.cpp
@@ -1,0 +1,338 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <type_traits>
+
+#include <range/v3/view/iota.hpp>
+
+#include <seqan3/alignment/matrix/alignment_coordinate.hpp>
+#include <seqan3/range/shortcuts.hpp>
+#include <seqan3/std/concepts>
+#include <seqan3/std/iterator>
+
+using namespace seqan3;
+
+TEST(advanceable_alignment_coordinate, column_index_type)
+{
+    detail::column_index_type ci{1u};
+    EXPECT_EQ(ci.get(), static_cast<size_t>(1));
+}
+
+TEST(advanceable_alignment_coordinate, row_index_type)
+{
+    detail::row_index_type ri{1u};
+    EXPECT_EQ(ri.get(), static_cast<size_t>(1));
+}
+
+TEST(advanceable_alignment_coordinate, construction)
+{
+    EXPECT_TRUE(std::is_default_constructible<detail::advanceable_alignment_coordinate<size_t>>::value);
+    EXPECT_TRUE(std::is_copy_constructible<detail::advanceable_alignment_coordinate<size_t>>::value);
+    EXPECT_TRUE(std::is_copy_assignable<detail::advanceable_alignment_coordinate<size_t>>::value);
+    EXPECT_TRUE(std::is_move_constructible<detail::advanceable_alignment_coordinate<size_t>>::value);
+    EXPECT_TRUE(std::is_move_assignable<detail::advanceable_alignment_coordinate<size_t>>::value);
+    EXPECT_TRUE(std::is_destructible<detail::advanceable_alignment_coordinate<size_t>>::value);
+}
+
+TEST(advanceable_alignment_coordinate, construction_with_different_state)
+{
+    detail::advanceable_alignment_coordinate<size_t, detail::advanceable_alignment_coordinate_state::row>
+        ro{detail::column_index_type{2u}, detail::row_index_type{3u}};
+
+    detail::advanceable_alignment_coordinate<size_t,
+        detail::advanceable_alignment_coordinate_state::none> no{ro};
+
+    EXPECT_EQ(no.first_seq_pos, static_cast<size_t>(2));
+    EXPECT_EQ(no.second_seq_pos, static_cast<size_t>(3));
+}
+
+TEST(advanceable_alignment_coordinate, type_deduction)
+{
+    detail::advanceable_alignment_coordinate def_co{};
+    EXPECT_TRUE((std::is_same_v<decltype(def_co),
+                    detail::advanceable_alignment_coordinate<size_t,
+                        detail::advanceable_alignment_coordinate_state::none>>));
+
+    detail::advanceable_alignment_coordinate co{detail::column_index_type{2u}, detail::row_index_type{3u}};
+    EXPECT_TRUE((std::is_same_v<decltype(co),
+                    detail::advanceable_alignment_coordinate<size_t,
+                        detail::advanceable_alignment_coordinate_state::none>>));
+}
+
+TEST(advanceable_alignment_coordinate, access)
+{
+    detail::advanceable_alignment_coordinate def_co{};
+    EXPECT_EQ(def_co.first_seq_pos, static_cast<size_t>(0));
+    EXPECT_EQ(def_co.second_seq_pos, static_cast<size_t>(0));
+
+    detail::advanceable_alignment_coordinate co{detail::column_index_type{2u}, detail::row_index_type{3u}};
+    EXPECT_EQ(co.first_seq_pos, static_cast<size_t>(2));
+    EXPECT_EQ(co.second_seq_pos, static_cast<size_t>(3));
+}
+
+TEST(advanceable_alignment_coordinate, weakly_equality_comparable_concept)
+{
+    using not_incrementable =
+        detail::advanceable_alignment_coordinate<size_t,
+            detail::advanceable_alignment_coordinate_state::none>;
+    using row_incrementable =
+        detail::advanceable_alignment_coordinate<size_t,
+            detail::advanceable_alignment_coordinate_state::row>;
+    using column_incrementable =
+        detail::advanceable_alignment_coordinate<size_t,
+            detail::advanceable_alignment_coordinate_state::column>;
+
+    EXPECT_TRUE(std::EqualityComparable<not_incrementable>);
+    EXPECT_TRUE(std::EqualityComparable<row_incrementable>);
+    EXPECT_TRUE(std::EqualityComparable<column_incrementable>);
+}
+
+TEST(advanceable_alignment_coordinate, equality)
+{
+    using test_type =
+        detail::advanceable_alignment_coordinate<size_t,
+            detail::advanceable_alignment_coordinate_state::none>;
+
+    test_type t1{detail::column_index_type{10u}, detail::row_index_type{5u}};
+    test_type t2{detail::column_index_type{5u}, detail::row_index_type{5u}};
+    test_type t3{detail::column_index_type{10u}, detail::row_index_type{10u}};
+
+    EXPECT_TRUE(t1 == t1);
+    EXPECT_FALSE(t2 == t1);
+    EXPECT_FALSE(t1 == t3);
+    EXPECT_FALSE(t2 == t3);
+}
+
+TEST(advanceable_alignment_coordinate, inequality)
+{
+    using test_type =
+        detail::advanceable_alignment_coordinate<size_t,
+            detail::advanceable_alignment_coordinate_state::none>;
+
+    test_type t1{detail::column_index_type{10u}, detail::row_index_type{5u}};
+    test_type t2{detail::column_index_type{5u}, detail::row_index_type{5u}};
+    test_type t3{detail::column_index_type{10u}, detail::row_index_type{10u}};
+
+    EXPECT_FALSE(t1 != t1);
+    EXPECT_TRUE(t2 != t1);
+    EXPECT_TRUE(t1 != t3);
+    EXPECT_TRUE(t2 != t3);
+}
+
+TEST(advanceable_alignment_coordinate, incremental_concept)
+{
+    using not_incrementable =
+        detail::advanceable_alignment_coordinate<size_t,
+            detail::advanceable_alignment_coordinate_state::none>;
+    using row_incrementable =
+        detail::advanceable_alignment_coordinate<size_t,
+            detail::advanceable_alignment_coordinate_state::row>;
+    using column_incrementable =
+        detail::advanceable_alignment_coordinate<size_t,
+            detail::advanceable_alignment_coordinate_state::column>;
+
+    EXPECT_FALSE(std::WeaklyIncrementable<not_incrementable>);
+    EXPECT_TRUE(std::WeaklyIncrementable<row_incrementable>);
+    EXPECT_TRUE(std::WeaklyIncrementable<column_incrementable>);
+}
+
+TEST(advanceable_alignment_coordinate, increment_row)
+{
+    using row_incrementable =
+        detail::advanceable_alignment_coordinate<size_t,
+            detail::advanceable_alignment_coordinate_state::row>;
+
+    row_incrementable co{detail::column_index_type{0u}, detail::row_index_type{0u}};
+    co = ++co;
+    EXPECT_EQ(co.first_seq_pos, 0u);
+    EXPECT_EQ(co.second_seq_pos, 1u);
+    auto co_tmp = co++;
+    EXPECT_EQ(co_tmp.first_seq_pos, 0u);
+    EXPECT_EQ(co_tmp.second_seq_pos, 1u);
+    EXPECT_EQ(co.first_seq_pos, 0u);
+    EXPECT_EQ(co.second_seq_pos, 2u);
+    co += 4;
+    EXPECT_EQ(co.first_seq_pos, 0u);
+    EXPECT_EQ(co.second_seq_pos, 6u);
+}
+
+TEST(advanceable_alignment_coordinate, increment_col)
+{
+    using col_incrementable =
+        detail::advanceable_alignment_coordinate<size_t,
+            detail::advanceable_alignment_coordinate_state::column>;
+
+    col_incrementable co{detail::column_index_type{0u}, detail::row_index_type{0u}};
+    co = ++co;
+    EXPECT_EQ(co.first_seq_pos, 1u);
+    EXPECT_EQ(co.second_seq_pos, 0u);
+    auto co_tmp = co++;
+    EXPECT_EQ(co_tmp.first_seq_pos, 1u);
+    EXPECT_EQ(co_tmp.second_seq_pos, 0u);
+    EXPECT_EQ(co.first_seq_pos, 2u);
+    EXPECT_EQ(co.second_seq_pos, 0u);
+    co += 4;
+    EXPECT_EQ(co.first_seq_pos, 6u);
+    EXPECT_EQ(co.second_seq_pos, 0u);
+}
+
+TEST(advanceable_alignment_coordinate, decrement_row)
+{
+    using row_incrementable =
+        detail::advanceable_alignment_coordinate<size_t,
+            detail::advanceable_alignment_coordinate_state::row>;
+
+    row_incrementable co{detail::column_index_type{0u}, detail::row_index_type{0u}};
+    co += 4;
+    auto co_tmp = co--;
+    EXPECT_EQ(co_tmp.first_seq_pos, 0u);
+    EXPECT_EQ(co_tmp.second_seq_pos, 4u);
+    EXPECT_EQ(co.first_seq_pos, 0u);
+    EXPECT_EQ(co.second_seq_pos, 3u);
+
+    co = --co;
+    EXPECT_EQ(co.first_seq_pos, 0u);
+    EXPECT_EQ(co.second_seq_pos, 2u);
+
+    co -= 2;
+    EXPECT_EQ(co.first_seq_pos, 0u);
+    EXPECT_EQ(co.second_seq_pos, 0u);
+}
+
+TEST(advanceable_alignment_coordinate, decrement_col)
+{
+    using col_incrementable =
+        detail::advanceable_alignment_coordinate<size_t,
+            detail::advanceable_alignment_coordinate_state::column>;
+
+    col_incrementable co{detail::column_index_type{0u}, detail::row_index_type{0u}};
+    co += 4;
+    auto co_tmp = co--;
+    EXPECT_EQ(co_tmp.first_seq_pos, 4u);
+    EXPECT_EQ(co_tmp.second_seq_pos, 0u);
+    EXPECT_EQ(co.first_seq_pos, 3u);
+    EXPECT_EQ(co.second_seq_pos, 0u);
+
+    co = --co;
+    EXPECT_EQ(co.first_seq_pos, 2u);
+    EXPECT_EQ(co.second_seq_pos, 0u);
+
+    co -= 2;
+    EXPECT_EQ(co.first_seq_pos, 0u);
+    EXPECT_EQ(co.second_seq_pos, 0u);
+}
+
+TEST(advanceable_alignment_coordinate, advance_row)
+{
+    using row_incrementable =
+        detail::advanceable_alignment_coordinate<size_t,
+            detail::advanceable_alignment_coordinate_state::row>;
+
+    row_incrementable co{detail::column_index_type{0u}, detail::row_index_type{0u}};
+
+    co = co + 4;
+    EXPECT_EQ(co.first_seq_pos, 0u);
+    EXPECT_EQ(co.second_seq_pos, 4u);
+
+    co = 4 + co;
+    EXPECT_EQ(co.first_seq_pos, 0u);
+    EXPECT_EQ(co.second_seq_pos, 8u);
+}
+
+TEST(advanceable_alignment_coordinate, advance_col)
+{
+    using col_incrementable =
+        detail::advanceable_alignment_coordinate<size_t,
+            detail::advanceable_alignment_coordinate_state::column>;
+
+    col_incrementable co{detail::column_index_type{0u}, detail::row_index_type{0u}};
+    co = co + 4;
+    EXPECT_EQ(co.first_seq_pos, 4u);
+    EXPECT_EQ(co.second_seq_pos, 0u);
+
+    co = 4 + co;
+    EXPECT_EQ(co.first_seq_pos, 8u);
+    EXPECT_EQ(co.second_seq_pos, 0u);
+}
+
+TEST(advanceable_alignment_coordinate, iota_column_index)
+{
+    using col_incrementable =
+        detail::advanceable_alignment_coordinate<size_t,
+            detail::advanceable_alignment_coordinate_state::column>;
+
+    col_incrementable co_begin{detail::column_index_type{0u}, detail::row_index_type{0u}};
+    col_incrementable co_end{detail::column_index_type{5u}, detail::row_index_type{0u}};
+    auto v = ranges::view::iota(co_begin, co_end);
+
+    EXPECT_TRUE((std::Same<decltype(v.begin()), decltype(v.end())>));
+    EXPECT_EQ((*(--v.end())).first_seq_pos, 4u);
+
+    size_t test = 0u;
+    for (auto coordinate : v)
+        EXPECT_EQ(coordinate.first_seq_pos, test++);
+}
+
+TEST(advanceable_alignment_coordinate, iota_row_index)
+{
+    using row_incrementable =
+        detail::advanceable_alignment_coordinate<size_t,
+            detail::advanceable_alignment_coordinate_state::row>;
+
+    row_incrementable co_begin{detail::column_index_type{0u}, detail::row_index_type{0u}};
+    row_incrementable co_end{detail::column_index_type{0u}, detail::row_index_type{5u}};
+    auto v = ranges::view::iota(co_begin, co_end);
+
+    EXPECT_TRUE((std::Same<decltype(v.begin()), decltype(v.end())>));
+    EXPECT_EQ((*(--v.end())).second_seq_pos, 4u);
+
+    size_t test = 0u;
+    for (auto coordinate : v)
+        EXPECT_EQ(coordinate.second_seq_pos, test++);
+}
+
+TEST(alignment_coordinate, basic)
+{
+    EXPECT_TRUE(std::is_default_constructible<alignment_coordinate>::value);
+    EXPECT_TRUE(std::is_copy_constructible<alignment_coordinate>::value);
+    EXPECT_TRUE(std::is_copy_assignable<alignment_coordinate>::value);
+    EXPECT_TRUE(std::is_move_constructible<alignment_coordinate>::value);
+    EXPECT_TRUE(std::is_move_assignable<alignment_coordinate>::value);
+    EXPECT_TRUE(std::is_destructible<alignment_coordinate>::value);
+
+    using not_incrementable =
+        detail::advanceable_alignment_coordinate<size_t,
+            detail::advanceable_alignment_coordinate_state::none>;
+    using row_incrementable =
+        detail::advanceable_alignment_coordinate<size_t,
+            detail::advanceable_alignment_coordinate_state::row>;
+    using col_incrementable =
+        detail::advanceable_alignment_coordinate<size_t,
+            detail::advanceable_alignment_coordinate_state::column>;
+
+    not_incrementable co_not{detail::column_index_type{10u}, detail::row_index_type{5u}};
+    col_incrementable co_col{detail::column_index_type{10u}, detail::row_index_type{5u}};
+    row_incrementable co_row{detail::column_index_type{10u}, detail::row_index_type{5u}};
+
+    alignment_coordinate test1{co_not};
+    EXPECT_EQ(test1.first_seq_pos, 10u);
+    EXPECT_EQ(test1.second_seq_pos, 5u);
+
+    alignment_coordinate test2{co_col};
+    EXPECT_EQ(test2.first_seq_pos, 10u);
+    EXPECT_EQ(test2.second_seq_pos, 5u);
+
+    alignment_coordinate test3{co_row};
+    EXPECT_EQ(test3.first_seq_pos, 10u);
+    EXPECT_EQ(test3.second_seq_pos, 5u);
+
+    alignment_coordinate test4{detail::column_index_type{10u}, detail::row_index_type{5u}};
+    EXPECT_EQ(test4.first_seq_pos, 10u);
+    EXPECT_EQ(test4.second_seq_pos, 5u);
+}

--- a/test/unit/alignment/matrix/alignment_optimum_test.cpp
+++ b/test/unit/alignment/matrix/alignment_optimum_test.cpp
@@ -1,0 +1,75 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <type_traits>
+
+#include <seqan3/alignment/matrix/alignment_optimum.hpp>
+
+using namespace seqan3;
+
+TEST(alignment_optimum, construction)
+{
+    EXPECT_TRUE((std::is_default_constructible<detail::alignment_optimum<int32_t>>::value));
+    EXPECT_TRUE((std::is_copy_constructible<detail::alignment_optimum<int32_t>>::value));
+    EXPECT_TRUE((std::is_copy_assignable<detail::alignment_optimum<int32_t>>::value));
+    EXPECT_TRUE((std::is_move_constructible<detail::alignment_optimum<int32_t>>::value));
+    EXPECT_TRUE((std::is_move_assignable<detail::alignment_optimum<int32_t>>::value));
+    EXPECT_TRUE((std::is_destructible<detail::alignment_optimum<int32_t>>::value));
+}
+
+TEST(alignment_optimum, type_deduction)
+{
+    detail::alignment_optimum def_ao{};
+    EXPECT_TRUE((std::is_same_v<decltype(def_ao), detail::alignment_optimum<int32_t>>));
+
+    alignment_coordinate coordinate{};
+    coordinate.first_seq_pos = 2u;
+    coordinate.second_seq_pos = 3u;
+    detail::alignment_optimum ao{10, coordinate};
+    EXPECT_TRUE((std::is_same_v<decltype(ao), detail::alignment_optimum<int32_t>>));
+}
+
+TEST(alignment_optimum, access)
+{
+    detail::alignment_optimum def_ao{};
+
+    EXPECT_EQ(def_ao.score, std::numeric_limits<int32_t>::lowest());
+    EXPECT_EQ(static_cast<size_t>(def_ao.coordinate.first_seq_pos), static_cast<size_t>(0));
+    EXPECT_EQ(static_cast<size_t>(def_ao.coordinate.second_seq_pos), static_cast<size_t>(0));
+
+    alignment_coordinate coordinate{};
+    coordinate.first_seq_pos = 2u;
+    coordinate.second_seq_pos = 3u;
+    detail::alignment_optimum ao{10, coordinate};
+    EXPECT_EQ(ao.score, 10);
+    EXPECT_EQ(static_cast<size_t>(ao.coordinate.first_seq_pos), static_cast<size_t>(2));
+    EXPECT_EQ(static_cast<size_t>(ao.coordinate.second_seq_pos), static_cast<size_t>(3));
+}
+
+TEST(alignment_optimum, max)
+{
+    detail::alignment_optimum def_ao{};
+
+    EXPECT_EQ(def_ao.score, std::numeric_limits<int32_t>::lowest());
+    EXPECT_EQ(static_cast<size_t>(def_ao.coordinate.first_seq_pos), static_cast<size_t>(0));
+    EXPECT_EQ(static_cast<size_t>(def_ao.coordinate.second_seq_pos), static_cast<size_t>(0));
+
+    alignment_coordinate coordinate{};
+    coordinate.first_seq_pos = 2u;
+    coordinate.second_seq_pos = 3u;
+    detail::alignment_optimum ao{10, coordinate};
+    EXPECT_EQ(ao.score, 10);
+    EXPECT_EQ(static_cast<size_t>(ao.coordinate.first_seq_pos), static_cast<size_t>(2));
+    EXPECT_EQ(static_cast<size_t>(ao.coordinate.second_seq_pos), static_cast<size_t>(3));
+
+    auto val = std::max(def_ao, ao, detail::alignment_optimum_compare_less{});
+    EXPECT_EQ(ao.score, 10);
+    EXPECT_EQ(static_cast<size_t>(val.coordinate.first_seq_pos), static_cast<size_t>(2));
+    EXPECT_EQ(static_cast<size_t>(val.coordinate.second_seq_pos), static_cast<size_t>(3));
+}

--- a/test/unit/alignment/pairwise/align_pairwise_test.cpp
+++ b/test/unit/alignment/pairwise/align_pairwise_test.cpp
@@ -44,8 +44,8 @@ TEST(align_pairwise, single_rng_lvalue)
         for (auto && res : align_pairwise(p, cfg))
         {
             EXPECT_EQ(res.get_score(), -4);
-            auto [cmp1, cmp2] = res.get_end_coordinate();
-            EXPECT_EQ((std::tie(cmp1, cmp2)), (std::tuple{7, 8}));
+            EXPECT_EQ(res.get_end_coordinate().first_seq_pos, 7u);
+            EXPECT_EQ(res.get_end_coordinate().second_seq_pos, 8u);
             auto && [gap1, gap2] = res.get_alignment();
             EXPECT_EQ(std::string{gap1 | view::to_char}, "ACGTGATG--");
             EXPECT_EQ(std::string{gap2 | view::to_char}, "A-GTGATACT");

--- a/test/unit/alignment/pairwise/align_result_selector_test.cpp
+++ b/test/unit/alignment/pairwise/align_result_selector_test.cpp
@@ -59,9 +59,9 @@ TEST(alignment_selector, align_result_selector)
         EXPECT_TRUE((std::is_same_v<decltype(std::declval<_t>().get_id()), uint32_t>));
         EXPECT_TRUE((std::is_same_v<decltype(std::declval<_t>().get_score()), int32_t>));
         EXPECT_TRUE((std::is_same_v<decltype(std::declval<_t>().get_end_coordinate()),
-                                    detail::alignment_coordinate const &>));
+                                    alignment_coordinate const &>));
         EXPECT_TRUE((std::is_same_v<decltype(std::declval<_t>().get_begin_coordinate()),
-                                    detail::alignment_coordinate const &>));
+                                    alignment_coordinate const &>));
         EXPECT_TRUE((std::is_same_v<decltype(std::declval<_t>().get_alignment()),
                                     std::tuple<gapped_seq1_t, gapped_seq2_t> const &>));
     }

--- a/test/unit/alignment/pairwise/edit_distance_unbanded_test.cpp
+++ b/test/unit/alignment/pairwise/edit_distance_unbanded_test.cpp
@@ -212,10 +212,10 @@ TYPED_TEST_P(edit_distance_unbanded, trace_matrix)
 
     EXPECT_EQ(trace_matrix.cols(), database.size()+1);
     EXPECT_EQ(trace_matrix.rows(), query.size()+1);
-    EXPECT_EQ(begin_coordinate.seq1_pos, fixture.begin_coordinate.seq1_pos);
-    EXPECT_EQ(begin_coordinate.seq2_pos, fixture.begin_coordinate.seq2_pos);
-    EXPECT_EQ(end_coordinate.seq1_pos, fixture.end_coordinate.seq1_pos);
-    EXPECT_EQ(end_coordinate.seq2_pos, fixture.end_coordinate.seq2_pos);
+    EXPECT_EQ(begin_coordinate.first_seq_pos, fixture.begin_coordinate.first_seq_pos);
+    EXPECT_EQ(begin_coordinate.second_seq_pos, fixture.begin_coordinate.second_seq_pos);
+    EXPECT_EQ(end_coordinate.first_seq_pos, fixture.end_coordinate.first_seq_pos);
+    EXPECT_EQ(end_coordinate.second_seq_pos, fixture.end_coordinate.second_seq_pos);
     EXPECT_EQ(trace_matrix, fixture.trace_matrix);
     EXPECT_EQ(alignment.score(), fixture.score);
 

--- a/test/unit/alignment/pairwise/fixture/alignment_fixture.hpp
+++ b/test/unit/alignment/pairwise/fixture/alignment_fixture.hpp
@@ -3,6 +3,7 @@
 
 #include <limits>
 
+#include <seqan3/alignment/matrix/alignment_coordinate.hpp>
 #include <seqan3/alignment/matrix/alignment_score_matrix.hpp>
 #include <seqan3/alignment/matrix/alignment_trace_matrix.hpp>
 
@@ -11,7 +12,7 @@ namespace seqan3
 
 namespace seqan3::fixture
 {
-using detail::alignment_coordinate;
+// using seqan3::alignment_coordinate;
 
 static constexpr auto INF = std::numeric_limits<int>::max();
 

--- a/test/unit/alignment/pairwise/fixture/global_affine_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/global_affine_unbanded.hpp
@@ -42,10 +42,10 @@ static auto dna4_01 = []()
         "ACGTACGTA"_dna4,
         align_config | align_cfg::scoring{nucleotide_scoring_scheme{match_score{4}, mismatch_score{-5}}},
         -18,
-        "AACCGGTTAACCGGTT",
-        "A-C-G-T-A-C-G-TA",
+        "AACCGGTTAACCG---GTT",
+        "A----------CGTACGTA",
         alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
-        alignment_coordinate{column_index_type{15u}, row_index_type{8u}},
+        alignment_coordinate{column_index_type{16u}, row_index_type{9u}},
         std::vector
         {
         //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
@@ -88,10 +88,10 @@ static auto dna4_02 = []()
         "AACCGGTTAACCGGTT"_dna4,
         align_config | align_cfg::scoring{nucleotide_scoring_scheme{match_score{4}, mismatch_score{-5}}},
         -18,
-        "A-C-G-T-A-C-G-TA",
-        "AACCGGTTAACCGGTT",
+        "ACGTAC----------GTA",
+        "A---ACCGGTTAACCGGTT",
         alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
-        alignment_coordinate{column_index_type{8u}, row_index_type{15u}},
+        alignment_coordinate{column_index_type{9u}, row_index_type{16u}},
         std::vector
         {
         //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T

--- a/test/unit/alignment/pairwise/fixture/global_affine_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/global_affine_unbanded.hpp
@@ -12,8 +12,8 @@
 #include <seqan3/alignment/configuration/align_config_mode.hpp>
 #include <seqan3/alignment/configuration/align_config_gap.hpp>
 #include <seqan3/alignment/configuration/align_config_scoring.hpp>
-#include <seqan3/alignment/scoring/nucleotide_scoring_scheme.hpp>
 #include <seqan3/alignment/scoring/aminoacid_scoring_scheme.hpp>
+#include <seqan3/alignment/scoring/nucleotide_scoring_scheme.hpp>
 #include <seqan3/alphabet/aminoacid/aa27.hpp>
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
@@ -78,21 +78,14 @@ static auto dna4_02 = []()
 {
     return alignment_fixture
     {
-        // score: 8 (7 insertions, 1 substitutions)
-        // alignment:
-        // AACCGGTTAACCGGTT
-        // | | | | | | | |
-        // A-C-G-T-A-C-G-TA
-        "AACCGGTTAACCGGTT"_dna4,
         "ACGTACGTA"_dna4,
-        align_config | align_cfg::scoring{nucleotide_scoring_scheme{match_score{4}, mismatch_score{-5}}}
-                     | align_cfg::aligned_ends{align_cfg::end_gaps{align_cfg::first_seq_leading{std::true_type{}},
-                                                                   align_cfg::second_seq_leading{std::true_type{}}}},
-        -7,
-        "AACCGGTTAACCG---GTT",
-        "----------ACGTACGTA",
+        "AACCGGTTAACCGGTT"_dna4,
+        align_config | align_cfg::scoring{nucleotide_scoring_scheme{match_score{4}, mismatch_score{-5}}},
+        -18,
+        "A-C-G-T-A-C-G-TA",
+        "AACCGGTTAACCGGTT",
         alignment_coordinate{0, 0},
-        alignment_coordinate{15, 8},
+        alignment_coordinate{8, 15},
         std::vector
         {
         //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T

--- a/test/unit/alignment/pairwise/fixture/global_affine_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/global_affine_unbanded.hpp
@@ -28,6 +28,9 @@ inline constexpr auto align_config = align_cfg::mode{align_cfg::global_alignment
 
 static auto dna4_01 = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         // score: 8 (7 insertions, 1 substitutions)
@@ -41,8 +44,8 @@ static auto dna4_01 = []()
         -18,
         "AACCGGTTAACCGGTT",
         "A-C-G-T-A-C-G-TA",
-        alignment_coordinate{0, 0},
-        alignment_coordinate{15, 8},
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{15u}, row_index_type{8u}},
         std::vector
         {
         //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
@@ -76,6 +79,9 @@ static auto dna4_01 = []()
 
 static auto dna4_02 = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         "ACGTACGTA"_dna4,
@@ -84,8 +90,8 @@ static auto dna4_02 = []()
         -18,
         "A-C-G-T-A-C-G-TA",
         "AACCGGTTAACCGGTT",
-        alignment_coordinate{0, 0},
-        alignment_coordinate{8, 15},
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{8u}, row_index_type{15u}},
         std::vector
         {
         //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T

--- a/test/unit/alignment/pairwise/fixture/global_affine_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/global_affine_unbanded.hpp
@@ -74,4 +74,54 @@ static auto dna4_01 = []()
     };
 }();
 
+static auto dna4_02 = []()
+{
+    return alignment_fixture
+    {
+        // score: 8 (7 insertions, 1 substitutions)
+        // alignment:
+        // AACCGGTTAACCGGTT
+        // | | | | | | | |
+        // A-C-G-T-A-C-G-TA
+        "AACCGGTTAACCGGTT"_dna4,
+        "ACGTACGTA"_dna4,
+        align_config | align_cfg::scoring{nucleotide_scoring_scheme{match_score{4}, mismatch_score{-5}}}
+                     | align_cfg::aligned_ends{align_cfg::end_gaps{align_cfg::first_seq_leading{std::true_type{}},
+                                                                   align_cfg::second_seq_leading{std::true_type{}}}},
+        -7,
+        "AACCGGTTAACCG---GTT",
+        "----------ACGTACGTA",
+        alignment_coordinate{0, 0},
+        alignment_coordinate{15, 8},
+        std::vector
+        {
+        //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
+        /*e*/  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16,
+        /*A*/  1,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,
+        /*C*/  2,  1,  1,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
+        /*G*/  3,  2,  2,  2,  2,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13,
+        /*T*/  4,  3,  3,  3,  3,  3,  3,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12,
+        /*A*/  5,  4,  3,  4,  4,  4,  4,  4,  4,  4,  5,  6,  7,  8,  9, 10, 11,
+        /*C*/  6,  5,  4,  3,  4,  5,  5,  5,  5,  5,  5,  5,  6,  7,  8,  9, 10,
+        /*G*/  7,  6,  5,  4,  4,  4,  5,  6,  6,  6,  6,  6,  6,  6,  7,  8,  9,
+        /*T*/  8,  7,  6,  5,  5,  5,  5,  5,  6,  7,  7,  7,  7,  7,  7,  7,  8,
+        /*A*/  9,  8,  7,  6,  6,  6,  6,  6,  6,  6,  7,  8,  8,  8,  8,  8,  8
+        },
+        std::vector
+        {
+        //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
+        /*e*/NON,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,
+        /*A*/U  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
+        /*C*/U  ,U  ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,L  ,L  ,
+        /*G*/U  ,U  ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,
+        /*T*/U  ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,
+        /*A*/U  ,DU ,D  ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
+        /*C*/U  ,U  ,U  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,
+        /*G*/U  ,U  ,U  ,U  ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,
+        /*T*/U  ,U  ,U  ,U  ,DU ,DU ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,
+        /*A*/U  ,DU ,DU ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D
+        }
+    };
+}();
+
 } // namespace seqan3::fixture::global::affine::unbanded

--- a/test/unit/alignment/pairwise/fixture/global_edit_distance_max_errors_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/global_edit_distance_max_errors_unbanded.hpp
@@ -17,6 +17,9 @@ inline constexpr auto align_config = align_cfg::edit | align_cfg::max_error{255}
 
 static auto dna4_01_e255 = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         // score: 8 (7 insertions, 1 substitutions)
@@ -30,8 +33,8 @@ static auto dna4_01_e255 = []()
         -8,
         "AACCGGTTAACCGGTT",
         "A-C-G-T-A-C-G-TA",
-        alignment_coordinate{0, 0},
-        alignment_coordinate{15, 8},
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{15u}, row_index_type{8u}},
         std::vector
         {
         //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
@@ -65,6 +68,9 @@ static auto dna4_01_e255 = []()
 
 static auto dna4_01T_e255 = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         // score: 8 (7 insertions, 1 substitutions)
@@ -78,8 +84,8 @@ static auto dna4_01T_e255 = []()
         -8,
         "A-C-G-T-A-C-G-TA",
         "AACCGGTTAACCGGTT",
-        alignment_coordinate{0, 0},
-        alignment_coordinate{8, 15},
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{8u}, row_index_type{15u}},
         std::vector
         {
         //     e,  A,  C,  G,  T,  A,  C,  G,  T,  A
@@ -127,6 +133,9 @@ static auto dna4_01T_e255 = []()
 
 static auto dna4_02_e255 = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         // score: 8 (7 insertions, 1 substitutions)
@@ -140,8 +149,8 @@ static auto dna4_02_e255 = []()
         -8,
         "AACCGGTAAACCGGTT",
         "A-C-G-TA--C-G-TA",
-        alignment_coordinate{0, 0},
-        alignment_coordinate{15, 8},
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{15u}, row_index_type{8u}},
         std::vector
         {
         //     e,  A,  A,  C,  C,  G,  G,  T,  A,  A,  A,  C,  C,  G,  G,  T,  T,
@@ -175,6 +184,9 @@ static auto dna4_02_e255 = []()
 
 static auto aa27_01_e255 = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         // score: 8 (7 insertions, 1 substitutions)
@@ -188,8 +200,8 @@ static auto aa27_01_e255 = []()
         -8,
         "UUWWRRIIUUWWRRII",
         "U-W-R-I-U-W-R-IU",
-        alignment_coordinate{0, 0},
-        alignment_coordinate{15, 8},
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{15u}, row_index_type{8u}},
         std::vector
         {
         //     e,  U,  U,  W,  W,  R,  R,  I,  I,  U,  U,  W,  W,  R,  R,  I,  I
@@ -223,6 +235,9 @@ static auto aa27_01_e255 = []()
 
 static auto aa27_01T_e255 = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         // score: 8 (7 insertions, 1 substitutions)
@@ -236,8 +251,8 @@ static auto aa27_01T_e255 = []()
         -8,
         "U-W-R-I-U-W-R-IU",
         "UUWWRRIIUUWWRRII",
-        alignment_coordinate{0, 0},
-        alignment_coordinate{8, 15},
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{8u}, row_index_type{15u}},
         std::vector
         {
         //     e,  U,  W,  R,  I,  U,  W,  R,  I,  U

--- a/test/unit/alignment/pairwise/fixture/global_edit_distance_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/global_edit_distance_unbanded.hpp
@@ -14,6 +14,9 @@ namespace seqan3::fixture::global::edit_distance::unbanded
 
 static auto dna4_01 = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         // score: 8 (7 insertions, 1 substitutions)
@@ -27,8 +30,8 @@ static auto dna4_01 = []()
         -8,
         "AACCGGTTAACCGGTT",
         "A-C-G-T-A-C-G-TA",
-        alignment_coordinate{0, 0},
-        alignment_coordinate{15, 8},
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{15u}, row_index_type{8u}},
         std::vector
         {
         //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
@@ -62,6 +65,9 @@ static auto dna4_01 = []()
 
 static auto dna4_01T = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         // score: 8 (7 insertions, 1 substitutions)
@@ -75,8 +81,8 @@ static auto dna4_01T = []()
         -8,
         "A-C-G-T-A-C-G-TA",
         "AACCGGTTAACCGGTT",
-        alignment_coordinate{0, 0},
-        alignment_coordinate{8, 15},
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{8u}, row_index_type{15u}},
         std::vector
         {
         //     e,  A,  C,  G,  T,  A,  C,  G,  T,  A
@@ -124,6 +130,9 @@ static auto dna4_01T = []()
 
 static auto dna4_02 = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         // score: 8 (7 insertions, 1 substitutions)
@@ -137,8 +146,8 @@ static auto dna4_02 = []()
         -8,
         "AACCGGTAAACCGGTT",
         "A-C-G-TA--C-G-TA",
-        alignment_coordinate{0, 0},
-        alignment_coordinate{15, 8},
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{15u}, row_index_type{8u}},
         std::vector
         {
         //     e,  A,  A,  C,  C,  G,  G,  T,  A,  A,  A,  C,  C,  G,  G,  T,  T,
@@ -172,6 +181,9 @@ static auto dna4_02 = []()
 
 static auto aa27_01 = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         // score: 8 (7 insertions, 1 substitutions)
@@ -185,8 +197,8 @@ static auto aa27_01 = []()
         -8,
         "UUWWRRIIUUWWRRII",
         "U-W-R-I-U-W-R-IU",
-        alignment_coordinate{0, 0},
-        alignment_coordinate{15, 8},
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{15u}, row_index_type{8u}},
         std::vector
         {
         //     e,  U,  U,  W,  W,  R,  R,  I,  I,  U,  U,  W,  W,  R,  R,  I,  I
@@ -220,6 +232,9 @@ static auto aa27_01 = []()
 
 static auto aa27_01T = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         // score: 8 (7 insertions, 1 substitutions)
@@ -233,8 +248,8 @@ static auto aa27_01T = []()
         -8,
         "U-W-R-I-U-W-R-IU",
         "UUWWRRIIUUWWRRII",
-        alignment_coordinate{0, 0},
-        alignment_coordinate{8, 15},
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{8u}, row_index_type{15u}},
         std::vector
         {
         //     e,  U,  W,  R,  I,  U,  W,  R,  I,  U

--- a/test/unit/alignment/pairwise/fixture/semi_global_affine_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/semi_global_affine_unbanded.hpp
@@ -1,0 +1,205 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+#pragma once
+
+#include <vector>
+
+#include <seqan3/alignment/configuration/align_config_aligned_ends.hpp>
+#include <seqan3/alignment/configuration/align_config_gap.hpp>
+#include <seqan3/alignment/configuration/align_config_mode.hpp>
+#include <seqan3/alignment/configuration/align_config_scoring.hpp>
+#include <seqan3/alignment/scoring/aminoacid_scoring_scheme.hpp>
+#include <seqan3/alignment/scoring/nucleotide_scoring_scheme.hpp>
+#include <seqan3/alphabet/aminoacid/aa27.hpp>
+#include <seqan3/alphabet/nucleotide/dna4.hpp>
+#include <seqan3/alphabet/nucleotide/dna5.hpp>
+
+#include "alignment_fixture.hpp"
+
+namespace seqan3::fixture::semi_global::affine::unbanded
+{
+
+inline constexpr auto align_config = align_cfg::mode{align_cfg::global_alignment} |
+                                     align_cfg::gap{gap_scheme{gap_score{-1}, gap_open_score{-10}}};
+
+inline constexpr auto align_config_semi_seq1 = align_config | align_cfg::aligned_ends{align_cfg::seq1_ends_free};
+inline constexpr auto align_config_semi_seq2 = align_config | align_cfg::aligned_ends{align_cfg::seq2_ends_free};
+
+static auto dna4_01 = []()
+{
+    return alignment_fixture
+    {
+        "TTTTTACGTATGTCCCCC"_dna4,
+        "ACGTAAAACGT"_dna4,
+        align_config_semi_seq1 | align_cfg::scoring{nucleotide_scoring_scheme{match_score{4}, mismatch_score{-5}}},
+        10,
+        "TTTTTACGT---ATGTCCCCC",
+        "-----ACGTAAAACGT-----",
+        alignment_coordinate{0u, 0},
+        alignment_coordinate{13u, 11},
+        std::vector
+        {
+        //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
+        /*e*/  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16,
+        /*A*/  1,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,
+        /*C*/  2,  1,  1,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
+        /*G*/  3,  2,  2,  2,  2,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13,
+        /*T*/  4,  3,  3,  3,  3,  3,  3,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12,
+        /*A*/  5,  4,  3,  4,  4,  4,  4,  4,  4,  4,  5,  6,  7,  8,  9, 10, 11,
+        /*C*/  6,  5,  4,  3,  4,  5,  5,  5,  5,  5,  5,  5,  6,  7,  8,  9, 10,
+        /*G*/  7,  6,  5,  4,  4,  4,  5,  6,  6,  6,  6,  6,  6,  6,  7,  8,  9,
+        /*T*/  8,  7,  6,  5,  5,  5,  5,  5,  6,  7,  7,  7,  7,  7,  7,  7,  8,
+        /*A*/  9,  8,  7,  6,  6,  6,  6,  6,  6,  6,  7,  8,  8,  8,  8,  8,  8
+        },
+        std::vector
+        {
+        //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
+        /*e*/NON,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,
+        /*A*/U  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
+        /*C*/U  ,U  ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,L  ,L  ,
+        /*G*/U  ,U  ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,
+        /*T*/U  ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,
+        /*A*/U  ,DU ,D  ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
+        /*C*/U  ,U  ,U  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,
+        /*G*/U  ,U  ,U  ,U  ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,
+        /*T*/U  ,U  ,U  ,U  ,DU ,DU ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,
+        /*A*/U  ,DU ,DU ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D
+        }
+    };
+}();
+
+static auto dna4_02 = []()
+{
+    return alignment_fixture
+    {
+        "ACGTAAAACGT"_dna4,
+        "TTTTTACGTATGTCCCCC"_dna4,
+        align_config_semi_seq1 | align_cfg::scoring{nucleotide_scoring_scheme{match_score{4}, mismatch_score{-5}}},
+        -13,
+        "-----ACGTA--------AAACGT",
+        "TTTTTACGTATGTCCCCC------",
+        alignment_coordinate{0u, 0},
+        alignment_coordinate{5u, 18},
+        std::vector
+        {
+        //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
+        /*e*/  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16,
+        /*A*/  1,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,
+        /*C*/  2,  1,  1,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
+        /*G*/  3,  2,  2,  2,  2,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13,
+        /*T*/  4,  3,  3,  3,  3,  3,  3,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12,
+        /*A*/  5,  4,  3,  4,  4,  4,  4,  4,  4,  4,  5,  6,  7,  8,  9, 10, 11,
+        /*C*/  6,  5,  4,  3,  4,  5,  5,  5,  5,  5,  5,  5,  6,  7,  8,  9, 10,
+        /*G*/  7,  6,  5,  4,  4,  4,  5,  6,  6,  6,  6,  6,  6,  6,  7,  8,  9,
+        /*T*/  8,  7,  6,  5,  5,  5,  5,  5,  6,  7,  7,  7,  7,  7,  7,  7,  8,
+        /*A*/  9,  8,  7,  6,  6,  6,  6,  6,  6,  6,  7,  8,  8,  8,  8,  8,  8
+        },
+        std::vector
+        {
+        //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
+        /*e*/NON,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,
+        /*A*/U  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
+        /*C*/U  ,U  ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,L  ,L  ,
+        /*G*/U  ,U  ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,
+        /*T*/U  ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,
+        /*A*/U  ,DU ,D  ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
+        /*C*/U  ,U  ,U  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,
+        /*G*/U  ,U  ,U  ,U  ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,
+        /*T*/U  ,U  ,U  ,U  ,DU ,DU ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,
+        /*A*/U  ,DU ,DU ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D
+        }
+    };
+}();
+
+static auto dna4_03 = []()
+{
+    return alignment_fixture
+    {
+        "TTTTTACGTATGTCCCCC"_dna4,
+        "ACGTAAAACGT"_dna4,
+        align_config_semi_seq2 | align_cfg::scoring{nucleotide_scoring_scheme{match_score{4}, mismatch_score{-5}}},
+        -13,
+        "-----ACGTA--------AAACGT",
+        "TTTTTACGTATGTCCCCC------",
+        alignment_coordinate{0u, 0},
+        alignment_coordinate{5u, 18},
+        std::vector
+        {
+        //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
+        /*e*/  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16,
+        /*A*/  1,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,
+        /*C*/  2,  1,  1,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
+        /*G*/  3,  2,  2,  2,  2,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13,
+        /*T*/  4,  3,  3,  3,  3,  3,  3,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12,
+        /*A*/  5,  4,  3,  4,  4,  4,  4,  4,  4,  4,  5,  6,  7,  8,  9, 10, 11,
+        /*C*/  6,  5,  4,  3,  4,  5,  5,  5,  5,  5,  5,  5,  6,  7,  8,  9, 10,
+        /*G*/  7,  6,  5,  4,  4,  4,  5,  6,  6,  6,  6,  6,  6,  6,  7,  8,  9,
+        /*T*/  8,  7,  6,  5,  5,  5,  5,  5,  6,  7,  7,  7,  7,  7,  7,  7,  8,
+        /*A*/  9,  8,  7,  6,  6,  6,  6,  6,  6,  6,  7,  8,  8,  8,  8,  8,  8
+        },
+        std::vector
+        {
+        //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
+        /*e*/NON,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,
+        /*A*/U  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
+        /*C*/U  ,U  ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,L  ,L  ,
+        /*G*/U  ,U  ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,
+        /*T*/U  ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,
+        /*A*/U  ,DU ,D  ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
+        /*C*/U  ,U  ,U  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,
+        /*G*/U  ,U  ,U  ,U  ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,
+        /*T*/U  ,U  ,U  ,U  ,DU ,DU ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,
+        /*A*/U  ,DU ,DU ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D
+        }
+    };
+}();
+
+static auto dna4_04 = []()
+{
+    return alignment_fixture
+    {
+        "ACGTAAAACGT"_dna4,
+        "TTTTTACGTATGTCCCCC"_dna4,
+        align_config_semi_seq2 | align_cfg::scoring{nucleotide_scoring_scheme{match_score{4}, mismatch_score{-5}}},
+        10,
+        "TTTTTACGT---ATGTCCCCC",
+        "-----ACGTAAAACGT-----",
+        alignment_coordinate{0u, 0},
+        alignment_coordinate{13u, 11},
+        std::vector
+        {
+        //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
+        /*e*/  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16,
+        /*A*/  1,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,
+        /*C*/  2,  1,  1,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
+        /*G*/  3,  2,  2,  2,  2,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13,
+        /*T*/  4,  3,  3,  3,  3,  3,  3,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12,
+        /*A*/  5,  4,  3,  4,  4,  4,  4,  4,  4,  4,  5,  6,  7,  8,  9, 10, 11,
+        /*C*/  6,  5,  4,  3,  4,  5,  5,  5,  5,  5,  5,  5,  6,  7,  8,  9, 10,
+        /*G*/  7,  6,  5,  4,  4,  4,  5,  6,  6,  6,  6,  6,  6,  6,  7,  8,  9,
+        /*T*/  8,  7,  6,  5,  5,  5,  5,  5,  6,  7,  7,  7,  7,  7,  7,  7,  8,
+        /*A*/  9,  8,  7,  6,  6,  6,  6,  6,  6,  6,  7,  8,  8,  8,  8,  8,  8
+        },
+        std::vector
+        {
+        //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
+        /*e*/NON,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,
+        /*A*/U  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
+        /*C*/U  ,U  ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,L  ,L  ,
+        /*G*/U  ,U  ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,
+        /*T*/U  ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,
+        /*A*/U  ,DU ,D  ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
+        /*C*/U  ,U  ,U  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,
+        /*G*/U  ,U  ,U  ,U  ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,
+        /*T*/U  ,U  ,U  ,U  ,DU ,DU ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,
+        /*A*/U  ,DU ,DU ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D
+        }
+    };
+}();
+
+} // namespace seqan3::fixture::global::affine::unbanded

--- a/test/unit/alignment/pairwise/fixture/semi_global_affine_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/semi_global_affine_unbanded.hpp
@@ -41,9 +41,9 @@ static auto dna4_01 = []()
         "ACGTAAAACGT"_dna4,
         align_config_semi_seq1 | align_cfg::scoring{nucleotide_scoring_scheme{match_score{4}, mismatch_score{-5}}},
         10,
-        "TTTTTACGT---ATGTCCCCC",
-        "-----ACGTAAAACGT-----",
-        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        "ACGT---ATGT",
+        "ACGTAAAACGT",
+        alignment_coordinate{column_index_type{5u}, row_index_type{0u}},
         alignment_coordinate{column_index_type{13u}, row_index_type{11u}},
         std::vector
         {
@@ -87,8 +87,8 @@ static auto dna4_02 = []()
         "TTTTTACGTATGTCCCCC"_dna4,
         align_config_semi_seq1 | align_cfg::scoring{nucleotide_scoring_scheme{match_score{4}, mismatch_score{-5}}},
         -13,
-        "-----ACGTA--------AAACGT",
-        "TTTTTACGTATGTCCCCC------",
+        "-----ACGTA--------",
+        "TTTTTACGTATGTCCCCC",
         alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
         alignment_coordinate{column_index_type{5u}, row_index_type{18u}},
         std::vector
@@ -133,10 +133,10 @@ static auto dna4_03 = []()
         "ACGTAAAACGT"_dna4,
         align_config_semi_seq2 | align_cfg::scoring{nucleotide_scoring_scheme{match_score{4}, mismatch_score{-5}}},
         -13,
-        "-----ACGTA--------AAACGT",
-        "TTTTTACGTATGTCCCCC------",
+        "TTTTTACGTATGTCCCCC",
+        "-----ACGTA--------",
         alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
-        alignment_coordinate{column_index_type{5u}, row_index_type{18u}},
+        alignment_coordinate{column_index_type{18u}, row_index_type{5u}},
         std::vector
         {
         //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
@@ -172,17 +172,17 @@ static auto dna4_04 = []()
 {
     using detail::column_index_type;
     using detail::row_index_type;
-    
+
     return alignment_fixture
     {
         "ACGTAAAACGT"_dna4,
         "TTTTTACGTATGTCCCCC"_dna4,
         align_config_semi_seq2 | align_cfg::scoring{nucleotide_scoring_scheme{match_score{4}, mismatch_score{-5}}},
         10,
-        "TTTTTACGT---ATGTCCCCC",
-        "-----ACGTAAAACGT-----",
-        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
-        alignment_coordinate{column_index_type{13u}, row_index_type{11u}},
+        "ACGTAAAACGT",
+        "ACGT---ATGT",
+        alignment_coordinate{column_index_type{0u}, row_index_type{5u}},
+        alignment_coordinate{column_index_type{11u}, row_index_type{13u}},
         std::vector
         {
         //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T

--- a/test/unit/alignment/pairwise/fixture/semi_global_affine_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/semi_global_affine_unbanded.hpp
@@ -32,6 +32,9 @@ inline constexpr auto align_config_semi_seq2 = align_config | align_cfg::aligned
 
 static auto dna4_01 = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         "TTTTTACGTATGTCCCCC"_dna4,
@@ -40,8 +43,8 @@ static auto dna4_01 = []()
         10,
         "TTTTTACGT---ATGTCCCCC",
         "-----ACGTAAAACGT-----",
-        alignment_coordinate{0u, 0},
-        alignment_coordinate{13u, 11},
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{13u}, row_index_type{11u}},
         std::vector
         {
         //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
@@ -75,6 +78,9 @@ static auto dna4_01 = []()
 
 static auto dna4_02 = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         "ACGTAAAACGT"_dna4,
@@ -83,8 +89,8 @@ static auto dna4_02 = []()
         -13,
         "-----ACGTA--------AAACGT",
         "TTTTTACGTATGTCCCCC------",
-        alignment_coordinate{0u, 0},
-        alignment_coordinate{5u, 18},
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{5u}, row_index_type{18u}},
         std::vector
         {
         //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
@@ -118,6 +124,9 @@ static auto dna4_02 = []()
 
 static auto dna4_03 = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         "TTTTTACGTATGTCCCCC"_dna4,
@@ -126,8 +135,8 @@ static auto dna4_03 = []()
         -13,
         "-----ACGTA--------AAACGT",
         "TTTTTACGTATGTCCCCC------",
-        alignment_coordinate{0u, 0},
-        alignment_coordinate{5u, 18},
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{5u}, row_index_type{18u}},
         std::vector
         {
         //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
@@ -161,6 +170,9 @@ static auto dna4_03 = []()
 
 static auto dna4_04 = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+    
     return alignment_fixture
     {
         "ACGTAAAACGT"_dna4,
@@ -169,8 +181,8 @@ static auto dna4_04 = []()
         10,
         "TTTTTACGT---ATGTCCCCC",
         "-----ACGTAAAACGT-----",
-        alignment_coordinate{0u, 0},
-        alignment_coordinate{13u, 11},
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{13u}, row_index_type{11u}},
         std::vector
         {
         //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T

--- a/test/unit/alignment/pairwise/fixture/semi_global_edit_distance_max_errors_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/semi_global_edit_distance_max_errors_unbanded.hpp
@@ -20,6 +20,9 @@ inline constexpr auto align_config = align_cfg::edit |
 
 static auto dna4_01_e255 = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         // score: 5 (3 deletions, 1 insertion, 1 substitutions)
@@ -33,8 +36,8 @@ static auto dna4_01_e255 = []()
         -5,
         "AC---CGGTT",
         "ACGTACG-TA",
-        alignment_coordinate{8, 0},
-        alignment_coordinate{15, 8},
+        alignment_coordinate{column_index_type{8u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{15u}, row_index_type{8u}},
         std::vector
         {
         //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
@@ -68,6 +71,9 @@ static auto dna4_01_e255 = []()
 
 static auto dna4_01T_e255 = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         // score: 8 (7 insertions, 1 substitutions)
@@ -81,8 +87,8 @@ static auto dna4_01T_e255 = []()
         -8,
         "A-C-G-T-A-C-G-TA",
         "AACCGGTTAACCGGTT",
-        alignment_coordinate{0, 0},
-        alignment_coordinate{8, 15},
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{8u}, row_index_type{15u}},
         std::vector
         {
         //     e,  A,  C,  G,  T,  A,  C,  G,  T,  A
@@ -130,6 +136,9 @@ static auto dna4_01T_e255 = []()
 
 static auto dna4_02_e255 = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         // score: 4 (3 deletions, 1 insertion)
@@ -143,8 +152,8 @@ static auto dna4_02_e255 = []()
         -4,
         "AC---CGGTA",
         "ACGTACG-TA",
-        alignment_coordinate{0, 0},
-        alignment_coordinate{7, 8},
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{7u}, row_index_type{8u}},
         std::vector
         {
         //     e,  A,  A,  C,  C,  G,  G,  T,  A,  A,  A,  C,  C,  G,  G,  T,  T,
@@ -178,6 +187,9 @@ static auto dna4_02_e255 = []()
 
 static auto aa27_01_e255 = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         // score: 5 (3 deletions, 1 insertion, 1 substitutions)
@@ -191,8 +203,8 @@ static auto aa27_01_e255 = []()
         -5,
         "UW---WRRII",
         "UWRIUWR-IU",
-        alignment_coordinate{8, 0},
-        alignment_coordinate{15, 8},
+        alignment_coordinate{column_index_type{8u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{15u}, row_index_type{8u}},
         std::vector
         {
         //     e,  U,  U,  W,  W,  R,  R,  I,  I,  U,  U,  W,  W,  R,  R,  I,  I
@@ -226,6 +238,9 @@ static auto aa27_01_e255 = []()
 
 static auto aa27_01T_e255 = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         // score: 8 (7 insertions, 1 substitutions)
@@ -239,8 +254,8 @@ static auto aa27_01T_e255 = []()
         -8,
         "U-W-R-I-U-W-R-IU",
         "UUWWRRIIUUWWRRII",
-        alignment_coordinate{0, 0},
-        alignment_coordinate{8, 15},
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{8u}, row_index_type{15u}},
         std::vector
         {
         //     e,  U,  W,  R,  I,  U,  W,  R,  I,  U

--- a/test/unit/alignment/pairwise/fixture/semi_global_edit_distance_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/semi_global_edit_distance_unbanded.hpp
@@ -17,6 +17,9 @@ inline constexpr auto align_config = align_cfg::edit | align_cfg::aligned_ends{a
 
 static auto dna4_01 = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         // score: 5 (3 deletions, 1 insertion, 1 substitutions)
@@ -30,8 +33,8 @@ static auto dna4_01 = []()
         -5,
         "AC---CGGTT",
         "ACGTACG-TA",
-        alignment_coordinate{8, 0},
-        alignment_coordinate{15, 8},
+        alignment_coordinate{column_index_type{8u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{15u}, row_index_type{8u}},
         std::vector
         {
         //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
@@ -65,6 +68,9 @@ static auto dna4_01 = []()
 
 static auto dna4_01T = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         // score: 8 (7 insertions, 1 substitutions)
@@ -78,8 +84,8 @@ static auto dna4_01T = []()
         -8,
         "A-C-G-T-A-C-G-TA",
         "AACCGGTTAACCGGTT",
-        alignment_coordinate{0, 0},
-        alignment_coordinate{8, 15},
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{8u}, row_index_type{15u}},
         std::vector
         {
         //     e,  A,  C,  G,  T,  A,  C,  G,  T,  A
@@ -127,6 +133,9 @@ static auto dna4_01T = []()
 
 static auto dna4_02 = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         // score: 4 (3 deletions, 1 insertion)
@@ -140,8 +149,8 @@ static auto dna4_02 = []()
         -4,
         "AC---CGGTA",
         "ACGTACG-TA",
-        alignment_coordinate{0, 0},
-        alignment_coordinate{7, 8},
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{7u}, row_index_type{8u}},
         std::vector
         {
         //     e,  A,  A,  C,  C,  G,  G,  T,  A,  A,  A,  C,  C,  G,  G,  T,  T,
@@ -175,6 +184,9 @@ static auto dna4_02 = []()
 
 static auto aa27_01 = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         // score: 5 (3 deletions, 1 insertion, 1 substitutions)
@@ -188,8 +200,8 @@ static auto aa27_01 = []()
         -5,
         "UW---WRRII",
         "UWRIUWR-IU",
-        alignment_coordinate{8, 0},
-        alignment_coordinate{15, 8},
+        alignment_coordinate{column_index_type{8u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{15u}, row_index_type{8u}},
         std::vector
         {
         //     e,  U,  U,  W,  W,  R,  R,  I,  I,  U,  U,  W,  W,  R,  R,  I,  I
@@ -223,6 +235,9 @@ static auto aa27_01 = []()
 
 static auto aa27_01T = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         // score: 8 (7 insertions, 1 substitutions)
@@ -236,8 +251,8 @@ static auto aa27_01T = []()
         -8,
         "U-W-R-I-U-W-R-IU",
         "UUWWRRIIUUWWRRII",
-        alignment_coordinate{0, 0},
-        alignment_coordinate{8, 15},
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{8u}, row_index_type{15u}},
         std::vector
         {
         //     e,  U,  W,  R,  I,  U,  W,  R,  I,  U

--- a/test/unit/alignment/pairwise/global_affine_unbanded_test.cpp
+++ b/test/unit/alignment/pairwise/global_affine_unbanded_test.cpp
@@ -53,19 +53,66 @@ using semi_global_affine_unbanded_types
 TYPED_TEST_P(global_affine_unbanded, score)
 {
     auto const & fixture = this->fixture();
-    // We only compute the score.
     auto align_cfg = fixture.config | align_cfg::result{align_cfg::with_score};
 
     std::vector database = fixture.sequence1;
     std::vector query = fixture.sequence2;
 
-    // TODO Make test work with ranges.
     auto alignment = align_pairwise(std::pair{database, query}, align_cfg);
 
     EXPECT_EQ((*std::ranges::begin(alignment)).get_score(), fixture.score);
 }
 
-REGISTER_TYPED_TEST_CASE_P(global_affine_unbanded, score);
+TYPED_TEST_P(global_affine_unbanded, end_position)
+{
+    auto const & fixture = this->fixture();
+    auto align_cfg = fixture.config | align_cfg::result{align_cfg::with_end_position};
+
+    std::vector database = fixture.sequence1;
+    std::vector query = fixture.sequence2;
+
+    auto alignment = align_pairwise(std::pair{database, query}, align_cfg);
+
+    auto res = *std::ranges::begin(alignment);
+    EXPECT_EQ(res.get_score(), fixture.score);
+    EXPECT_EQ(res.get_end_coordinate(), fixture.end_coordinate);
+}
+
+TYPED_TEST_P(global_affine_unbanded, begin_position)
+{
+    auto const & fixture = this->fixture();
+    auto align_cfg = fixture.config | align_cfg::result{align_cfg::with_begin_position};
+
+    std::vector database = fixture.sequence1;
+    std::vector query = fixture.sequence2;
+
+    auto alignment = align_pairwise(std::pair{database, query}, align_cfg);
+
+    auto res = *std::ranges::begin(alignment);
+    EXPECT_EQ(res.get_score(), fixture.score);
+    EXPECT_EQ(res.get_begin_coordinate(), fixture.begin_coordinate);
+    EXPECT_EQ(res.get_end_coordinate(), fixture.end_coordinate);
+}
+
+TYPED_TEST_P(global_affine_unbanded, trace)
+{
+    auto const & fixture = this->fixture();
+    auto align_cfg = fixture.config | align_cfg::result{align_cfg::with_trace};
+
+    std::vector database = fixture.sequence1;
+    std::vector query = fixture.sequence2;
+
+    auto alignment = align_pairwise(std::pair{database, query}, align_cfg);
+
+    auto res = *std::ranges::begin(alignment);
+    EXPECT_EQ(res.get_score(), fixture.score);
+    EXPECT_EQ(res.get_begin_coordinate(), fixture.begin_coordinate);
+    EXPECT_EQ(res.get_end_coordinate(), fixture.end_coordinate);
+    EXPECT_TRUE(ranges::equal(get<0>(res.get_alignment()) | view::to_char, fixture.gapped_sequence1));
+    EXPECT_TRUE(ranges::equal(get<1>(res.get_alignment()) | view::to_char, fixture.gapped_sequence2));
+}
+
+REGISTER_TYPED_TEST_CASE_P(global_affine_unbanded, score, end_position, begin_position, trace);
 
 INSTANTIATE_TYPED_TEST_CASE_P(global, global_affine_unbanded, global_affine_unbanded_types);
 INSTANTIATE_TYPED_TEST_CASE_P(semi_global, global_affine_unbanded, semi_global_affine_unbanded_types);

--- a/test/unit/alignment/pairwise/global_affine_unbanded_test.cpp
+++ b/test/unit/alignment/pairwise/global_affine_unbanded_test.cpp
@@ -15,6 +15,7 @@
 #include <seqan3/range/view/to_char.hpp>
 
 #include "fixture/global_affine_unbanded.hpp"
+#include "fixture/semi_global_affine_unbanded.hpp"
 
 using namespace seqan3;
 using namespace seqan3::detail;
@@ -41,6 +42,14 @@ using global_affine_unbanded_types
         param<&global::affine::unbanded::dna4_02>
     >;
 
+using semi_global_affine_unbanded_types
+    = ::testing::Types<
+        param<&semi_global::affine::unbanded::dna4_01>,
+        param<&semi_global::affine::unbanded::dna4_02>,
+        param<&semi_global::affine::unbanded::dna4_03>,
+        param<&semi_global::affine::unbanded::dna4_04>
+    >;
+
 TYPED_TEST_P(global_affine_unbanded, score)
 {
     auto const & fixture = this->fixture();
@@ -58,5 +67,5 @@ TYPED_TEST_P(global_affine_unbanded, score)
 
 REGISTER_TYPED_TEST_CASE_P(global_affine_unbanded, score);
 
-// work around a bug that you can't specify more than 50 template arguments to ::testing::types
 INSTANTIATE_TYPED_TEST_CASE_P(global, global_affine_unbanded, global_affine_unbanded_types);
+INSTANTIATE_TYPED_TEST_CASE_P(semi_global, global_affine_unbanded, semi_global_affine_unbanded_types);

--- a/test/unit/alignment/pairwise/global_affine_unbanded_test.cpp
+++ b/test/unit/alignment/pairwise/global_affine_unbanded_test.cpp
@@ -37,7 +37,8 @@ TYPED_TEST_CASE_P(global_affine_unbanded);
 
 using global_affine_unbanded_types
     = ::testing::Types<
-        param<&global::affine::unbanded::dna4_01>
+        param<&global::affine::unbanded::dna4_01>,
+        param<&global::affine::unbanded::dna4_02>
     >;
 
 TYPED_TEST_P(global_affine_unbanded, score)

--- a/test/unit/alignment/pairwise/policy/CMakeLists.txt
+++ b/test/unit/alignment/pairwise/policy/CMakeLists.txt
@@ -1,0 +1,1 @@
+seqan3_test(unbanded_score_trace_dp_matrix_policy_test.cpp)

--- a/test/unit/alignment/pairwise/policy/CMakeLists.txt
+++ b/test/unit/alignment/pairwise/policy/CMakeLists.txt
@@ -1,1 +1,2 @@
+seqan3_test(unbanded_score_dp_matrix_policy_test.cpp)
 seqan3_test(unbanded_score_trace_dp_matrix_policy_test.cpp)

--- a/test/unit/alignment/pairwise/policy/unbanded_score_dp_matrix_policy_test.cpp
+++ b/test/unit/alignment/pairwise/policy/unbanded_score_dp_matrix_policy_test.cpp
@@ -1,0 +1,150 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2018, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2018, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include <range/v3/view/bounded.hpp>
+
+#include <seqan3/alignment/pairwise/policy/unbanded_dp_matrix_policy.hpp>
+#include <seqan3/core/metafunction/basic.hpp>
+#include <seqan3/core/metafunction/template_inspection.hpp>
+#include <seqan3/std/iterator>
+#include <seqan3/std/ranges>
+
+template <typename score_alloc_t>
+struct policy_mock :
+    public seqan3::detail::unbanded_dp_matrix_policy<policy_mock<score_alloc_t>, score_alloc_t>
+{
+public:
+
+    using base_t = seqan3::detail::unbanded_dp_matrix_policy<policy_mock<score_alloc_t>, score_alloc_t>;
+
+    using base_t::base_t;
+
+    using base_t::allocate_matrix;
+    using base_t::current_column;
+    using base_t::next_column;
+
+    using base_t::dimension_first_batch;
+    using base_t::dimension_second_batch;
+    using base_t::score_matrix;
+
+};
+
+template <typename alloc_type>
+struct unbanded_score_matrix_test : public ::testing::Test
+{
+    using score_alloc_t = std::allocator<alloc_type>;
+
+    auto fixture()
+    {
+        return policy_mock<score_alloc_t>{};
+    }
+};
+
+using test_types = std::tuple<int32_t, int32_t>;
+TYPED_TEST_CASE(unbanded_score_matrix_test, ::testing::Types<test_types>);
+
+TYPED_TEST(unbanded_score_matrix_test, constructor)
+{
+    using mock_t = decltype(this->fixture());
+
+    EXPECT_TRUE(std::is_default_constructible_v<mock_t>);
+    EXPECT_TRUE(std::is_copy_constructible_v<mock_t>);
+    EXPECT_TRUE(std::is_move_constructible_v<mock_t>);
+    EXPECT_TRUE(std::is_copy_assignable_v<mock_t>);
+    EXPECT_TRUE(std::is_move_assignable_v<mock_t>);
+    EXPECT_TRUE(std::is_destructible_v<mock_t>);
+}
+
+TYPED_TEST(unbanded_score_matrix_test, allocate_matrix)
+{
+    std::string seq1{"garfieldthecat"};
+    std::string seq2{"garfieldthefatcat"};
+
+    auto mock = this->fixture();
+
+    mock.allocate_matrix(seq1, seq2);
+
+    EXPECT_EQ(mock.dimension_first_batch, seq1.size() + 1);
+    EXPECT_EQ(mock.dimension_second_batch, seq2.size() + 1);
+    EXPECT_EQ(mock.score_matrix.size(), seq2.size() + 1);
+}
+
+TYPED_TEST(unbanded_score_matrix_test, current_column)
+{
+    std::string seq1{"garfieldthecat"};
+    std::string seq2{"garfieldthefatcat"};
+
+    auto mock = this->fixture();
+
+    mock.allocate_matrix(seq1, seq2);
+
+    auto zip_view = mock.current_column();
+
+    EXPECT_EQ(seqan3::size(zip_view), seq2.size() + 1);
+    EXPECT_TRUE((std::is_same_v<std::remove_reference_t<decltype(std::get<0>(zip_view[0]))>, TypeParam>));
+    EXPECT_TRUE(seqan3::detail::decays_to_ignore_v<std::remove_reference_t<decltype(std::get<1>(zip_view[0]))>>);
+}
+
+TYPED_TEST(unbanded_score_matrix_test, next_column)
+{
+    std::string seq1{"garfieldthecat"};
+    std::string seq2{"garfieldthefatcat"};
+
+    auto mock = this->fixture();
+
+    mock.allocate_matrix(seq1, seq2);
+
+    // Get the active column
+    auto zip_view = mock.current_column();
+    for (auto && entry : zip_view)
+    {
+        std::get<0>(entry) = std::tuple{10, -10};
+        std::get<1>(entry) = 1;
+    }
+
+    // Go to next active column and check if active column has moved.
+    mock.next_column();
+    auto zip_view_2 = mock.current_column();
+    for (auto const entry : zip_view_2)
+    {
+        EXPECT_TRUE((std::get<0>(entry) == std::tuple{10, -10}));
+        EXPECT_TRUE(seqan3::detail::decays_to_ignore_v<std::remove_reference_t<decltype(std::get<1>(entry))>>);
+    }
+}
+
+#include <seqan3/io/stream/debug_stream.hpp>
+
+TYPED_TEST(unbanded_score_matrix_test, test_concepts)
+{
+    auto mock = this->fixture();
+
+    // Get the active column
+    auto zip_view = mock.current_column();
+
+    EXPECT_TRUE(std::ranges::InputRange<decltype(zip_view)>);
+    EXPECT_TRUE(std::ranges::ForwardRange<decltype(zip_view)>);
+    EXPECT_TRUE(std::ranges::BidirectionalRange<decltype(zip_view)>);
+    EXPECT_TRUE(std::ranges::RandomAccessRange<decltype(zip_view)>);
+    EXPECT_TRUE(std::ranges::SizedRange<decltype(zip_view)>);
+
+    auto it = seqan3::begin(zip_view);
+
+    EXPECT_TRUE(std::InputIterator<decltype(it)>);
+    EXPECT_TRUE(std::ForwardIterator<decltype(it)>);
+    EXPECT_TRUE(std::BidirectionalIterator<decltype(it)>);
+    EXPECT_TRUE(std::RandomAccessIterator<decltype(it)>);
+
+    auto it_e = seqan3::end(zip_view);
+    EXPECT_TRUE(std::InputIterator<decltype(it_e)>);
+    EXPECT_TRUE(std::ForwardIterator<decltype(it_e)>);
+    EXPECT_TRUE(std::BidirectionalIterator<decltype(it_e)>);
+    EXPECT_TRUE(std::RandomAccessIterator<decltype(it_e)>);
+}

--- a/test/unit/alignment/pairwise/policy/unbanded_score_dp_matrix_policy_test.cpp
+++ b/test/unit/alignment/pairwise/policy/unbanded_score_dp_matrix_policy_test.cpp
@@ -27,13 +27,16 @@ public:
 
     using base_t::base_t;
 
+    // Expose member function for testing
     using base_t::allocate_matrix;
     using base_t::current_column;
     using base_t::next_column;
 
+    // Expose member variables for testing
     using base_t::dimension_first_batch;
     using base_t::dimension_second_batch;
     using base_t::score_matrix;
+    using base_t::current_column_index;
 
 };
 
@@ -90,7 +93,7 @@ TYPED_TEST(unbanded_score_matrix_test, current_column)
 
     EXPECT_EQ(seqan3::size(zip_view), seq2.size() + 1);
     EXPECT_TRUE((std::is_same_v<std::remove_reference_t<decltype(std::get<0>(zip_view[0]))>, TypeParam>));
-    EXPECT_TRUE(seqan3::detail::decays_to_ignore_v<std::remove_reference_t<decltype(std::get<1>(zip_view[0]))>>);
+    EXPECT_TRUE(seqan3::detail::decays_to_ignore_v<std::remove_reference_t<decltype(std::get<2>(zip_view[0]))>>);
 }
 
 TYPED_TEST(unbanded_score_matrix_test, next_column)
@@ -107,20 +110,22 @@ TYPED_TEST(unbanded_score_matrix_test, next_column)
     for (auto && entry : zip_view)
     {
         std::get<0>(entry) = std::tuple{10, -10};
-        std::get<1>(entry) = 1;
+        std::get<2>(entry) = 1;
     }
 
+    EXPECT_EQ(mock.current_column_index, 0u);
     // Go to next active column and check if active column has moved.
     mock.next_column();
     auto zip_view_2 = mock.current_column();
+    size_t row_index = 0;
     for (auto const entry : zip_view_2)
     {
         EXPECT_TRUE((std::get<0>(entry) == std::tuple{10, -10}));
-        EXPECT_TRUE(seqan3::detail::decays_to_ignore_v<std::remove_reference_t<decltype(std::get<1>(entry))>>);
+        EXPECT_EQ(std::get<1>(entry).first_seq_pos, 1u);
+        EXPECT_EQ(std::get<1>(entry).second_seq_pos, row_index++);
+        EXPECT_TRUE(seqan3::detail::decays_to_ignore_v<std::remove_reference_t<decltype(std::get<2>(entry))>>);
     }
 }
-
-#include <seqan3/io/stream/debug_stream.hpp>
 
 TYPED_TEST(unbanded_score_matrix_test, test_concepts)
 {
@@ -129,22 +134,12 @@ TYPED_TEST(unbanded_score_matrix_test, test_concepts)
     // Get the active column
     auto zip_view = mock.current_column();
 
-    EXPECT_TRUE(std::ranges::InputRange<decltype(zip_view)>);
-    EXPECT_TRUE(std::ranges::ForwardRange<decltype(zip_view)>);
     EXPECT_TRUE(std::ranges::BidirectionalRange<decltype(zip_view)>);
-    EXPECT_TRUE(std::ranges::RandomAccessRange<decltype(zip_view)>);
     EXPECT_TRUE(std::ranges::SizedRange<decltype(zip_view)>);
 
     auto it = seqan3::begin(zip_view);
-
-    EXPECT_TRUE(std::InputIterator<decltype(it)>);
-    EXPECT_TRUE(std::ForwardIterator<decltype(it)>);
     EXPECT_TRUE(std::BidirectionalIterator<decltype(it)>);
-    EXPECT_TRUE(std::RandomAccessIterator<decltype(it)>);
 
     auto it_e = seqan3::end(zip_view);
-    EXPECT_TRUE(std::InputIterator<decltype(it_e)>);
-    EXPECT_TRUE(std::ForwardIterator<decltype(it_e)>);
     EXPECT_TRUE(std::BidirectionalIterator<decltype(it_e)>);
-    EXPECT_TRUE(std::RandomAccessIterator<decltype(it_e)>);
 }

--- a/test/unit/alignment/pairwise/policy/unbanded_score_trace_dp_matrix_policy_test.cpp
+++ b/test/unit/alignment/pairwise/policy/unbanded_score_trace_dp_matrix_policy_test.cpp
@@ -9,6 +9,7 @@
 
 #include <memory>
 
+#include <seqan3/alignment/matrix/trace_directions.hpp>
 #include <seqan3/alignment/pairwise/policy/unbanded_score_trace_dp_matrix_policy.hpp>
 #include <seqan3/core/metafunction/range.hpp>
 #include <seqan3/core/metafunction/template_inspection.hpp>
@@ -27,12 +28,15 @@ public:
 
     using base_t::base_t;
 
+    // Make member functions available for testing
     using base_t::allocate_matrix;
     using base_t::current_column;
     using base_t::next_column;
 
+    // Make member variables available for testing
     using base_t::dimension_first_batch;
     using base_t::dimension_second_batch;
+    using base_t::current_column_index;
     using base_t::score_matrix;
     using base_t::trace_matrix;
 };
@@ -94,7 +98,9 @@ TYPED_TEST(unbanded_score_trace_test, current_column)
     EXPECT_EQ(seqan3::size(zip_view), seq2.size() + 1);
 
     using value_t = seqan3::value_type_t<decltype(zip_view)>;
-    EXPECT_EQ(std::tuple_size_v<value_t>, 2u);
+    EXPECT_EQ(std::tuple_size_v<value_t>, 3u);
+    EXPECT_TRUE(std::ranges::SizedRange<decltype(zip_view)>);
+    EXPECT_TRUE(std::ranges::BidirectionalRange<decltype(zip_view)>);
 }
 
 TYPED_TEST(unbanded_score_trace_test, next_column)
@@ -111,25 +117,33 @@ TYPED_TEST(unbanded_score_trace_test, next_column)
     for (auto && entry : zip_view)
     {
         std::get<0>(entry) = std::tuple{10, -10};
-        std::get<1>(entry) = seqan3::detail::trace_directions::diagonal;
+        std::get<2>(entry) = seqan3::detail::trace_directions::diagonal;
     }
 
     // Get the same active column again
     auto zip_view_2 = mock.current_column();
+    size_t row_index = 0u;
     for (auto const entry : zip_view_2)
     {
         EXPECT_TRUE((std::get<0>(entry) == std::tuple{10, -10}));
-        EXPECT_TRUE((std::get<1>(entry) == seqan3::detail::trace_directions::diagonal));
+        EXPECT_EQ(std::get<1>(entry).first_seq_pos,  0u);
+        EXPECT_EQ(std::get<1>(entry).second_seq_pos,  row_index++);
+        EXPECT_TRUE((std::get<2>(entry) == seqan3::detail::trace_directions::diagonal));
     }
+
+    EXPECT_EQ(mock.current_column_index, 0u);
 
     // Go to next active column and check if active column has moved.
     mock.next_column();
     auto zip_view_3 = mock.current_column();
 
+    row_index = 0;
     for (auto const entry : zip_view_3)
     {
         EXPECT_TRUE((std::get<0>(entry) == std::tuple{10, -10}));
-        EXPECT_TRUE((std::get<1>(entry) == seqan3::detail::trace_directions::none));
+        EXPECT_EQ(std::get<1>(entry).first_seq_pos,  1u);
+        EXPECT_EQ(std::get<1>(entry).second_seq_pos,  row_index++);
+        EXPECT_TRUE((std::get<2>(entry) == seqan3::detail::trace_directions::none));
     }
 
     EXPECT_EQ(seqan3::size(zip_view_3), seq2.size() + 1);

--- a/test/unit/alignment/pairwise/policy/unbanded_score_trace_dp_matrix_policy_test.cpp
+++ b/test/unit/alignment/pairwise/policy/unbanded_score_trace_dp_matrix_policy_test.cpp
@@ -1,0 +1,136 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include <seqan3/alignment/pairwise/policy/unbanded_score_trace_dp_matrix_policy.hpp>
+#include <seqan3/core/metafunction/range.hpp>
+#include <seqan3/core/metafunction/template_inspection.hpp>
+
+template <typename score_alloc_t, typename trace_alloc_t>
+struct policy_mock :
+    public seqan3::detail::unbanded_score_trace_dp_matrix_policy<policy_mock<score_alloc_t, trace_alloc_t>,
+                                                                 score_alloc_t,
+                                                                 trace_alloc_t>
+{
+public:
+
+    using base_t = seqan3::detail::unbanded_score_trace_dp_matrix_policy<policy_mock<score_alloc_t, trace_alloc_t>,
+                                                                         score_alloc_t,
+                                                                         trace_alloc_t>;
+
+    using base_t::base_t;
+
+    using base_t::allocate_matrix;
+    using base_t::current_column;
+    using base_t::next_column;
+
+    using base_t::dimension_first_batch;
+    using base_t::dimension_second_batch;
+    using base_t::score_matrix;
+    using base_t::trace_matrix;
+};
+
+template <typename alloc_types>
+struct unbanded_score_trace_test : public ::testing::Test
+{
+    using score_alloc_t = std::allocator<std::tuple_element_t<0, alloc_types>>;
+    using trace_alloc_t = std::allocator<std::tuple_element_t<1, alloc_types>>;
+
+    auto fixture()
+    {
+        return policy_mock<score_alloc_t, trace_alloc_t>{};
+    }
+};
+
+using test_type = std::tuple<std::tuple<int32_t, int32_t>, seqan3::detail::trace_directions>;
+
+TYPED_TEST_CASE(unbanded_score_trace_test, ::testing::Types<test_type>);
+
+TYPED_TEST(unbanded_score_trace_test, constructor)
+{
+    using mock_t = decltype(this->fixture());
+
+    EXPECT_TRUE(std::is_default_constructible_v<mock_t>);
+    EXPECT_TRUE(std::is_copy_constructible_v<mock_t>);
+    EXPECT_TRUE(std::is_move_constructible_v<mock_t>);
+    EXPECT_TRUE(std::is_copy_assignable_v<mock_t>);
+    EXPECT_TRUE(std::is_move_assignable_v<mock_t>);
+    EXPECT_TRUE(std::is_destructible_v<mock_t>);
+}
+
+TYPED_TEST(unbanded_score_trace_test, allocate_matrix)
+{
+    std::string seq1{"garfieldthecat"};
+    std::string seq2{"garfieldthefatcat"};
+
+    auto mock = this->fixture();
+
+    mock.allocate_matrix(seq1, seq2);
+
+    EXPECT_EQ(mock.dimension_first_batch, seq1.size() + 1);
+    EXPECT_EQ(mock.dimension_second_batch, seq2.size() + 1);
+    EXPECT_EQ(mock.score_matrix.size(), seq2.size() + 1);
+    EXPECT_EQ(mock.trace_matrix.size(), (seq1.size() + 1) * (seq2.size() + 1));
+}
+
+TYPED_TEST(unbanded_score_trace_test, current_column)
+{
+    std::string seq1{"garfieldthecat"};
+    std::string seq2{"garfieldthefatcat"};
+
+    auto mock = this->fixture();
+
+    mock.allocate_matrix(seq1, seq2);
+
+    auto zip_view = mock.current_column();
+
+    EXPECT_EQ(seqan3::size(zip_view), seq2.size() + 1);
+
+    using value_t = seqan3::value_type_t<decltype(zip_view)>;
+    EXPECT_EQ(std::tuple_size_v<value_t>, 2u);
+}
+
+TYPED_TEST(unbanded_score_trace_test, next_column)
+{
+    std::string seq1{"garfieldthecat"};
+    std::string seq2{"garfieldthefatcat"};
+
+    auto mock = this->fixture();
+
+    mock.allocate_matrix(seq1, seq2);
+
+    // Get the active column
+    auto zip_view = mock.current_column();
+    for (auto && entry : zip_view)
+    {
+        std::get<0>(entry) = std::tuple{10, -10};
+        std::get<1>(entry) = seqan3::detail::trace_directions::diagonal;
+    }
+
+    // Get the same active column again
+    auto zip_view_2 = mock.current_column();
+    for (auto const entry : zip_view_2)
+    {
+        EXPECT_TRUE((std::get<0>(entry) == std::tuple{10, -10}));
+        EXPECT_TRUE((std::get<1>(entry) == seqan3::detail::trace_directions::diagonal));
+    }
+
+    // Go to next active column and check if active column has moved.
+    mock.next_column();
+    auto zip_view_3 = mock.current_column();
+
+    for (auto const entry : zip_view_3)
+    {
+        EXPECT_TRUE((std::get<0>(entry) == std::tuple{10, -10}));
+        EXPECT_TRUE((std::get<1>(entry) == seqan3::detail::trace_directions::none));
+    }
+
+    EXPECT_EQ(seqan3::size(zip_view_3), seq2.size() + 1);
+}


### PR DESCRIPTION
Supersedes #675 

Blocked  by #686 

Implements the traceback for generating the alignment.
Here are some benchmarks 
gcc9
```console
---------------------------------------------------------------------------
Benchmark                                    Time           CPU Iterations
---------------------------------------------------------------------------
seqan3_affine_dna4                      806558 ns     804354 ns        802
seqan2_affine_dna4                      722358 ns     715522 ns       1028
seqan3_affine_dna4_trace               3057949 ns    3054982 ns        223
seqan2_affine_dna4_trace               2710810 ns    2707381 ns        247
seqan3_affine_dna4_collection          3282436 ns    3278531 ns        209
seqan2_affine_dna4_collection          3055412 ns    3051580 ns        226
seqan3_affine_dna4_trace_collection   12665911 ns   12656358 ns         53
seqan2_affine_dna4_trace_collection   11679496 ns   11672161 ns         56
```

gcc8

```console
---------------------------------------------------------------------------
Benchmark                                    Time           CPU Iterations
---------------------------------------------------------------------------
seqan3_affine_dna4                      703024 ns     702296 ns        890
seqan2_affine_dna4                      673800 ns     673459 ns        947
seqan3_affine_dna4_trace               3170673 ns    3170121 ns        214
seqan2_affine_dna4_trace               2779336 ns    2777941 ns        253
seqan3_affine_dna4_collection          3243861 ns    3241996 ns        224
seqan2_affine_dna4_collection          3635063 ns    3632989 ns        190
seqan3_affine_dna4_trace_collection   13125700 ns   13119235 ns         51
seqan2_affine_dna4_trace_collection   11904751 ns   11895446 ns         56
```
The traceback in seqan3 is slower than in seqan2. 
This performance regression must be analysed to see where it comes from.

gcc7
```console
---------------------------------------------------------------------------
Benchmark                                    Time           CPU Iterations
---------------------------------------------------------------------------
seqan3_affine_dna4                      607930 ns     600999 ns       1007
seqan2_affine_dna4                      606012 ns     599308 ns       1021
seqan3_affine_dna4_trace               2873277 ns    2872426 ns        235
seqan2_affine_dna4_trace               2659906 ns    2659506 ns        245
seqan3_affine_dna4_collection          2452780 ns    2452078 ns        283
seqan2_affine_dna4_collection          2554415 ns    2553559 ns        263
seqan3_affine_dna4_trace_collection   11975804 ns   11972429 ns         56
seqan2_affine_dna4_trace_collection   11661372 ns   11655714 ns         56
```

