### PR TITLE
[INTERNAL] add SEQAN3_CONCEPT macro to handle TS vs C++20 concepts

### DIFF
--- a/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
+++ b/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
@@ -119,7 +119,7 @@ namespace seqan3
 //!\}
 //!\cond
 template <typename t>
-concept aligned_sequence_concept =
+SEQAN3_CONCEPT aligned_sequence_concept =
     std::ranges::ForwardRange<t> &&
     alphabet_concept<value_type_t<t>> &&
     weakly_assignable_concept<reference_t<t>, gap const &> &&

--- a/include/seqan3/alignment/matrix/matrix_concept.hpp
+++ b/include/seqan3/alignment/matrix/matrix_concept.hpp
@@ -31,7 +31,7 @@ namespace seqan3::detail
 */
 //!\cond
 template <typename matrix_t>
-concept matrix_concept = requires(matrix_t m)
+SEQAN3_CONCEPT matrix_concept = requires(matrix_t m)
 {
 //!\endcond
     /*!\typedef typedef IMPLEMENTATION_DEFINED entry_type;

--- a/include/seqan3/alignment/pairwise/edit_distance_unbanded.hpp
+++ b/include/seqan3/alignment/pairwise/edit_distance_unbanded.hpp
@@ -34,7 +34,7 @@ namespace seqan3::detail
 {
 //!\cond
 template <typename align_config_t>
-concept semi_global_config_concept =
+SEQAN3_CONCEPT semi_global_config_concept =
     std::remove_reference_t<align_config_t>::template exists<align_cfg::aligned_ends>() &&
 requires (align_config_t & cfg)
 {
@@ -53,13 +53,13 @@ requires (align_config_t & cfg)
 };
 
 template <typename align_config_t>
-concept global_config_concept = requires (align_config_t & cfg)
+SEQAN3_CONCEPT global_config_concept = requires (align_config_t & cfg)
 {
     requires cfg.template exists<align_cfg::mode<detail::global_alignment_type>>();
 };
 
 template <typename align_config_t>
-concept max_errors_concept = requires (align_config_t & cfg)
+SEQAN3_CONCEPT max_errors_concept = requires (align_config_t & cfg)
 {
     requires cfg.template exists<align_cfg::max_error>();
 };
@@ -69,7 +69,7 @@ concept max_errors_concept = requires (align_config_t & cfg)
  * \ingroup pairwise
  */
 template <typename traits_type>
-concept edit_distance_trait_concept = requires
+SEQAN3_CONCEPT edit_distance_trait_concept = requires
 {
     typename std::remove_reference_t<traits_type>::word_type;
 };

--- a/include/seqan3/alignment/scoring/gap_scheme_concept.hpp
+++ b/include/seqan3/alignment/scoring/gap_scheme_concept.hpp
@@ -46,7 +46,7 @@ namespace seqan3
 //!\}
 //!\cond
 template <typename t>
-concept gap_scheme_concept = requires (t scheme, size_t num)
+SEQAN3_CONCEPT gap_scheme_concept = requires (t scheme, size_t num)
 {
     { scheme.score(num) } -> ptrdiff_t;
 };

--- a/include/seqan3/alignment/scoring/scoring_scheme_concept.hpp
+++ b/include/seqan3/alignment/scoring/scoring_scheme_concept.hpp
@@ -57,7 +57,7 @@ namespace seqan3
 //!\}
 //!\cond
 template <typename t, alphabet_concept alphabet_t, alphabet_concept alphabet2_t = alphabet_t>
-concept scoring_scheme_concept = requires (t scheme,
+SEQAN3_CONCEPT scoring_scheme_concept = requires (t scheme,
                                                 alphabet_t const alph1,
                                                 alphabet2_t const alph2)
 {

--- a/include/seqan3/alphabet/adaptation/concept.hpp
+++ b/include/seqan3/alphabet/adaptation/concept.hpp
@@ -44,7 +44,7 @@ namespace seqan3
  */
 //!\cond
 template <typename type>
-concept char_adaptation_concept = alphabet_concept<type> &&
+SEQAN3_CONCEPT char_adaptation_concept = alphabet_concept<type> &&
                                   detail::is_char_adaptation_v<type>;
 //!\endcond
 
@@ -74,7 +74,7 @@ concept char_adaptation_concept = alphabet_concept<type> &&
  */
 //!\cond
 template <typename type>
-concept uint_adaptation_concept = alphabet_concept<type> &&
+SEQAN3_CONCEPT uint_adaptation_concept = alphabet_concept<type> &&
                                   detail::is_uint_adaptation_v<type>;
 //!\endcond
 

--- a/include/seqan3/alphabet/aminoacid/concept.hpp
+++ b/include/seqan3/alphabet/aminoacid/concept.hpp
@@ -61,7 +61,7 @@ constexpr bool is_aminoacid_v = is_aminoacid<type>::value;
  */
 //!\cond
 template <typename type>
-concept aminoacid_concept = alphabet_concept<type> && is_aminoacid_v<remove_cvref_t<type>>;
+SEQAN3_CONCEPT aminoacid_concept = alphabet_concept<type> && is_aminoacid_v<remove_cvref_t<type>>;
 //!\endcond
 
 } // namespace seqan3

--- a/include/seqan3/alphabet/composition/detail.hpp
+++ b/include/seqan3/alphabet/composition/detail.hpp
@@ -35,7 +35,7 @@ namespace seqan3::detail
  */
 //!\cond
 template <typename t>
-concept cartesian_composition_concept = requires
+SEQAN3_CONCEPT cartesian_composition_concept = requires
 {
     typename t::seqan3_cartesian_components;
     typename t::seqan3_recursive_cartesian_components;

--- a/include/seqan3/alphabet/concept.hpp
+++ b/include/seqan3/alphabet/concept.hpp
@@ -64,7 +64,7 @@ namespace seqan3
  */
 //!\cond
 template <typename t>
-concept semi_alphabet_concept = std::Regular<std::remove_reference_t<t>> &&
+SEQAN3_CONCEPT semi_alphabet_concept = std::Regular<std::remove_reference_t<t>> &&
                                 std::StrictTotallyOrdered<t> &&
                                 requires (t v)
 {
@@ -115,7 +115,7 @@ concept semi_alphabet_concept = std::Regular<std::remove_reference_t<t>> &&
  */
 //!\cond
 template <typename t>
-concept alphabet_concept = semi_alphabet_concept<t> && requires (t v)
+SEQAN3_CONCEPT alphabet_concept = semi_alphabet_concept<t> && requires (t v)
 {
     // conversion to char
     requires           noexcept(to_char(v));
@@ -213,7 +213,7 @@ namespace seqan3::detail
  */
 //!\cond
 template <typename t>
-concept constexpr_semi_alphabet_concept = semi_alphabet_concept<t> && requires
+SEQAN3_CONCEPT constexpr_semi_alphabet_concept = semi_alphabet_concept<t> && requires
 {
     // currently only tests rvalue interfaces, because we have no constexpr values in this scope to get references to
     requires SEQAN3_IS_CONSTEXPR(to_rank(std::remove_reference_t<t>{}));
@@ -249,7 +249,7 @@ concept constexpr_semi_alphabet_concept = semi_alphabet_concept<t> && requires
  */
 //!\cond
 template <typename t>
-concept constexpr_alphabet_concept = constexpr_semi_alphabet_concept<t> &&
+SEQAN3_CONCEPT constexpr_alphabet_concept = constexpr_semi_alphabet_concept<t> &&
                                      alphabet_concept<t> &&
                                      requires
 {

--- a/include/seqan3/alphabet/nucleotide/concept.hpp
+++ b/include/seqan3/alphabet/nucleotide/concept.hpp
@@ -36,7 +36,7 @@ namespace seqan3
  */
 //!\cond
 template <typename type>
-concept nucleotide_concept = alphabet_concept<type> && requires (type v, std::remove_reference_t<type> c)
+SEQAN3_CONCEPT nucleotide_concept = alphabet_concept<type> && requires (type v, std::remove_reference_t<type> c)
 {
     requires std::Same<decltype(complement(v)), decltype(c)>;
 };

--- a/include/seqan3/alphabet/quality/concept.hpp
+++ b/include/seqan3/alphabet/quality/concept.hpp
@@ -123,7 +123,7 @@ constexpr underlying_phred_t<alphabet_type> to_phred(alphabet_type const & chr)
  */
 //!\cond
 template<typename q>
-concept quality_concept = requires(q quality)
+SEQAN3_CONCEPT quality_concept = requires(q quality)
 {
     requires alphabet_concept<q>;
 

--- a/include/seqan3/alphabet/structure/rna_structure_concept.hpp
+++ b/include/seqan3/alphabet/structure/rna_structure_concept.hpp
@@ -64,7 +64,7 @@ namespace seqan3
  */
 //!\cond
 template <typename structure_type>
-concept rna_structure_concept = requires(structure_type val)
+SEQAN3_CONCEPT rna_structure_concept = requires(structure_type val)
 {
     // requires fulfillment of alphabet concept
     requires alphabet_concept<structure_type>;

--- a/include/seqan3/argument_parser/validators.hpp
+++ b/include/seqan3/argument_parser/validators.hpp
@@ -71,7 +71,7 @@ namespace seqan3
 //!\}
 //!\cond
 template <typename validator_type>
-concept validator_concept = std::Copyable<remove_cvref_t<validator_type>> &&
+SEQAN3_CONCEPT validator_concept = std::Copyable<remove_cvref_t<validator_type>> &&
                             requires(validator_type validator,
                                      typename std::remove_reference_t<validator_type>::value_type value)
 {

--- a/include/seqan3/core/algorithm/concept.hpp
+++ b/include/seqan3/core/algorithm/concept.hpp
@@ -65,7 +65,7 @@ class config_element_base;
 //!\}
 //!\cond
 template <typename config_t>
-concept config_element_concept = std::Semiregular<std::remove_reference_t<config_t>> &&
+SEQAN3_CONCEPT config_element_concept = std::Semiregular<std::remove_reference_t<config_t>> &&
 requires (config_t c)
 {
     { std::remove_reference_t<config_t>::id };

--- a/include/seqan3/core/concept/cereal.hpp
+++ b/include/seqan3/core/concept/cereal.hpp
@@ -38,10 +38,10 @@ namespace seqan3
 //!\cond
 #if SEQAN3_WITH_CEREAL
 template <typename t>
-concept cereal_output_archive_concept = std::is_base_of_v<cereal::detail::OutputArchiveBase, t>;
+SEQAN3_CONCEPT cereal_output_archive_concept = std::is_base_of_v<cereal::detail::OutputArchiveBase, t>;
 #else
 template <typename t>
-concept cereal_output_archive_concept = false;
+SEQAN3_CONCEPT cereal_output_archive_concept = false;
 #endif
 //!\endcond
 
@@ -59,10 +59,10 @@ concept cereal_output_archive_concept = false;
 //!\cond
 #if SEQAN3_WITH_CEREAL
 template <typename t>
-concept cereal_input_archive_concept = std::is_base_of_v<cereal::detail::InputArchiveBase, t>;
+SEQAN3_CONCEPT cereal_input_archive_concept = std::is_base_of_v<cereal::detail::InputArchiveBase, t>;
 #else
 template <typename t>
-concept cereal_input_archive_concept = false;
+SEQAN3_CONCEPT cereal_input_archive_concept = false;
 #endif
 //!\endcond
 
@@ -76,10 +76,10 @@ concept cereal_input_archive_concept = false;
 //!\cond
 #if SEQAN3_WITH_CEREAL
 template <typename t>
-concept cereal_archive_concept = cereal_output_archive_concept<t> || cereal_input_archive_concept<t>;
+SEQAN3_CONCEPT cereal_archive_concept = cereal_output_archive_concept<t> || cereal_input_archive_concept<t>;
 #else
 template <typename t>
-concept cereal_archive_concept = false;
+SEQAN3_CONCEPT cereal_archive_concept = false;
 #endif
 //!\endcond
 
@@ -97,10 +97,10 @@ concept cereal_archive_concept = false;
 //!\cond
 #if SEQAN3_WITH_CEREAL
 template <typename t>
-concept cereal_text_archive_concept = std::is_base_of_v<cereal::traits::TextArchive, t>;
+SEQAN3_CONCEPT cereal_text_archive_concept = std::is_base_of_v<cereal::traits::TextArchive, t>;
 #else
 template <typename t>
-concept cereal_text_archive_concept = false;
+SEQAN3_CONCEPT cereal_text_archive_concept = false;
 #endif
 //!\endcond
 
@@ -138,12 +138,12 @@ concept cereal_text_archive_concept = false;
 template <typename value_t,
           typename input_archive_t = cereal::BinaryInputArchive,
           typename output_archive_t = cereal::BinaryOutputArchive>
-concept cerealisable_concept =
+SEQAN3_CONCEPT cerealisable_concept =
     cereal::traits::is_input_serializable<value_t, input_archive_t>::value &&
     cereal::traits::is_output_serializable<value_t, output_archive_t>::value;
 #else
 template <typename t>
-concept cerealisable_concept = false;
+SEQAN3_CONCEPT cerealisable_concept = false;
 #endif
 //!\endcond
 

--- a/include/seqan3/core/concept/core_language.hpp
+++ b/include/seqan3/core/concept/core_language.hpp
@@ -33,7 +33,7 @@ namespace seqan3::detail
  */
 //!\cond
 template <typename lhs_t, typename rhs_t>
-concept weakly_equality_comparable_by_members_with_concept = requires (lhs_t const & lhs, rhs_t const & rhs)
+SEQAN3_CONCEPT weakly_equality_comparable_by_members_with_concept = requires (lhs_t const & lhs, rhs_t const & rhs)
 {
     lhs.operator==(rhs); std::Boolean<decltype(lhs.operator==(rhs))>;
     lhs.operator!=(rhs); std::Boolean<decltype(lhs.operator!=(rhs))>;
@@ -44,7 +44,7 @@ concept weakly_equality_comparable_by_members_with_concept = requires (lhs_t con
  */
 //!\cond
 template <typename lhs_t, typename rhs_t>
-concept weakly_ordered_by_members_with_concept = requires (lhs_t const & lhs, rhs_t const & rhs)
+SEQAN3_CONCEPT weakly_ordered_by_members_with_concept = requires (lhs_t const & lhs, rhs_t const & rhs)
 {
     lhs.operator< (rhs); std::Boolean<decltype(lhs.operator< (rhs))>;
     lhs.operator> (rhs); std::Boolean<decltype(lhs.operator> (rhs))>;
@@ -58,7 +58,7 @@ concept weakly_ordered_by_members_with_concept = requires (lhs_t const & lhs, rh
  */
 //!\cond
 template <typename source_t, typename target_t>
-concept convertible_to_by_member_concept = requires (source_t s)
+SEQAN3_CONCEPT convertible_to_by_member_concept = requires (source_t s)
 {
     { s.operator target_t() } -> target_t;
 };
@@ -82,7 +82,7 @@ namespace seqan3
  */
 //!\cond
 template <typename t1, typename t2>
-concept weakly_ordered_with_concept = requires (std::remove_reference_t<t1> const & v1,
+SEQAN3_CONCEPT weakly_ordered_with_concept = requires (std::remove_reference_t<t1> const & v1,
                                                      std::remove_reference_t<t2> const & v2)
 {
     { v1 <  v2 } -> bool &&;
@@ -97,7 +97,7 @@ concept weakly_ordered_with_concept = requires (std::remove_reference_t<t1> cons
  */
 //!\cond
 template <typename t, typename u>
-concept implicitly_convertible_to_concept = std::is_convertible_v<t, u>;
+SEQAN3_CONCEPT implicitly_convertible_to_concept = std::is_convertible_v<t, u>;
 //!\endcond
 
 /*!\interface   seqan3::explicitly_convertible_to_concept <>
@@ -105,7 +105,7 @@ concept implicitly_convertible_to_concept = std::is_convertible_v<t, u>;
  */
 //!\cond
 template <typename t, typename u>
-concept explicitly_convertible_to_concept = requires (t vt) { { static_cast<u>(vt)}; };
+SEQAN3_CONCEPT explicitly_convertible_to_concept = requires (t vt) { { static_cast<u>(vt)}; };
 //!\endcond
 
 /*!\interface   seqan3::arithmetic_concept <>
@@ -114,7 +114,7 @@ concept explicitly_convertible_to_concept = requires (t vt) { { static_cast<u>(v
  */
 //!\cond
 template <typename t>
-concept arithmetic_concept = std::is_arithmetic_v<t>;
+SEQAN3_CONCEPT arithmetic_concept = std::is_arithmetic_v<t>;
 //!\endcond
 
 /*!\interface   seqan3::floating_point_concept <>
@@ -124,7 +124,7 @@ concept arithmetic_concept = std::is_arithmetic_v<t>;
  */
 //!\cond
 template <typename t>
-concept floating_point_concept = arithmetic_concept<t> && std::is_floating_point_v<t>;
+SEQAN3_CONCEPT floating_point_concept = arithmetic_concept<t> && std::is_floating_point_v<t>;
 //!\endcond
 
 /*!\interface   seqan3::char_concept <>
@@ -135,7 +135,7 @@ concept floating_point_concept = arithmetic_concept<t> && std::is_floating_point
 //!\cond
 
 template <typename t>
-concept char_concept = std::Integral<t> &&
+SEQAN3_CONCEPT char_concept = std::Integral<t> &&
                        (std::Same<t, char> || std::Same<t, unsigned char> || std::Same<t, signed char> ||
 #ifdef __cpp_char8_t
                         std::Same<t, char8_t> ||
@@ -150,7 +150,7 @@ concept char_concept = std::Integral<t> &&
  */
 //!\cond
 template <typename t>
-concept trivially_destructible_concept = std::Destructible<t> && std::is_trivially_destructible_v<t>;
+SEQAN3_CONCEPT trivially_destructible_concept = std::Destructible<t> && std::is_trivially_destructible_v<t>;
 //!\endcond
 
 /*!\interface   seqan3::trivially_copyable_concept
@@ -160,7 +160,7 @@ concept trivially_destructible_concept = std::Destructible<t> && std::is_trivial
  */
 //!\cond
 template <typename t>
-concept trivially_copyable_concept = std::Copyable<t> && std::is_trivially_copyable_v<t>;
+SEQAN3_CONCEPT trivially_copyable_concept = std::Copyable<t> && std::is_trivially_copyable_v<t>;
 //!\endcond
 
 /*!\interface   seqan3::trivial_concept
@@ -171,7 +171,7 @@ concept trivially_copyable_concept = std::Copyable<t> && std::is_trivially_copya
  */
 //!\cond
 template <typename t>
-concept trivial_concept = trivially_copyable_concept<t> && trivially_destructible_concept<t> && std::is_trivial_v<t>;
+SEQAN3_CONCEPT trivial_concept = trivially_copyable_concept<t> && trivially_destructible_concept<t> && std::is_trivial_v<t>;
 //!\endcond
 
 /*!\interface   seqan3::standard_layout_concept
@@ -180,7 +180,7 @@ concept trivial_concept = trivially_copyable_concept<t> && trivially_destructibl
  */
 //!\cond
 template <typename t>
-concept standard_layout_concept = std::is_standard_layout_v<t>;
+SEQAN3_CONCEPT standard_layout_concept = std::is_standard_layout_v<t>;
 //!\endcond
 
 /*!\interface   seqan3::weakly_assignable_concept
@@ -194,7 +194,7 @@ concept standard_layout_concept = std::is_standard_layout_v<t>;
  */
 //!\cond
 template <typename t, typename u>
-concept weakly_assignable_concept = std::is_assignable_v<t, u>;
+SEQAN3_CONCEPT weakly_assignable_concept = std::is_assignable_v<t, u>;
 //!\endcond
 
 }  // namespace seqan3

--- a/include/seqan3/core/concept/tuple.hpp
+++ b/include/seqan3/core/concept/tuple.hpp
@@ -31,7 +31,7 @@ namespace seqan3::detail
  */
 //!\cond
 template <typename tuple_t>
-concept tuple_size_concept = requires (tuple_t v)
+SEQAN3_CONCEPT tuple_size_concept = requires (tuple_t v)
 {
     { std::tuple_size<tuple_t>::value } -> size_t;
 };
@@ -44,7 +44,7 @@ concept tuple_size_concept = requires (tuple_t v)
  */
 //!\cond
 template <typename tuple_t>
-concept tuple_get_concept = requires (tuple_t & v, tuple_t const & v_c)
+SEQAN3_CONCEPT tuple_get_concept = requires (tuple_t & v, tuple_t const & v_c)
 {
     requires std::tuple_size_v<tuple_t> > 0;
 
@@ -168,7 +168,7 @@ namespace seqan3
 //!\}
 //!\cond
 template <typename t>
-concept tuple_like_concept = detail::tuple_size_concept<std::remove_reference_t<t>> && requires(t v)
+SEQAN3_CONCEPT tuple_like_concept = detail::tuple_size_concept<std::remove_reference_t<t>> && requires(t v)
 {
     typename detail::tuple_type_list<remove_cvref_t<t>>::type;
 

--- a/include/seqan3/core/metafunction/range.hpp
+++ b/include/seqan3/core/metafunction/range.hpp
@@ -35,7 +35,7 @@ namespace seqan3::detail
 
 //!\cond
 template <typename t>
-concept has_value_type = requires { typename value_type_t<remove_cvref_t<t>>; };
+SEQAN3_CONCEPT has_value_type = requires { typename value_type_t<remove_cvref_t<t>>; };
 //!\endcond
 
 } // namespace seqan3::detail
@@ -230,7 +230,7 @@ constexpr size_t dimension_v<t> = dimension_v<value_type_t<remove_cvref_t<t>>> +
  */
 //!\cond
 template <typename t1, typename t2>
-concept compatible_concept = requires (t1, t2)
+SEQAN3_CONCEPT compatible_concept = requires (t1, t2)
 {
     requires (dimension_v<t1> == dimension_v<t2>);
 

--- a/include/seqan3/core/platform.hpp
+++ b/include/seqan3/core/platform.hpp
@@ -29,15 +29,16 @@
 #   error "This is not a C++ compiler."
 #endif
 
-// Concepts TS [required]
+// C++ Concepts [required]
 #ifdef __cpp_concepts
 #   if __cpp_concepts == 201507 // GCC and Concepts TS
-#       define concept concept bool
+#       define SEQAN3_CONCEPT concept bool
 #   else
         static_assert(__cpp_concepts >= 201507, "Your compiler supports Concepts, but the support is not recent enough.");
+#       define SEQAN3_CONCEPT concept
 #   endif
 #else
-#   error "SeqAn3 requires the Concepts TS, make sure that you have set -fconcepts (not all compilers support this)."
+#   error "SeqAn3 requires C++ Concepts, either vie the TS (flag: -fconcepts) or via C++20 (flag: -std=c++2a / -std=c++20)."
 #endif
 
 // SeqAn [required]

--- a/include/seqan3/core/simd/concept.hpp
+++ b/include/seqan3/core/simd/concept.hpp
@@ -34,7 +34,7 @@ inline namespace simd
  */
 //!\cond
 template <typename simd_t>
-concept simd_concept = requires (simd_t a, simd_t b)
+SEQAN3_CONCEPT simd_concept = requires (simd_t a, simd_t b)
 {
     typename simd_traits<simd_t>::scalar_type;
     typename simd_traits<simd_t>::mask_type;

--- a/include/seqan3/core/type_list.hpp
+++ b/include/seqan3/core/type_list.hpp
@@ -35,6 +35,6 @@ namespace seqan3::detail
  * \ingroup core
  */
 template <typename t>
-concept type_list_concept = is_type_specialisation_of_v<t, type_list>;
+SEQAN3_CONCEPT type_list_concept = is_type_specialisation_of_v<t, type_list>;
 
 } // namespace seqan3::detail

--- a/include/seqan3/io/alignment_file/output_format_concept.hpp
+++ b/include/seqan3/io/alignment_file/output_format_concept.hpp
@@ -41,7 +41,7 @@ namespace seqan3
  */
 //!\cond
 template <typename t>
-concept alignment_file_output_format_concept =
+SEQAN3_CONCEPT alignment_file_output_format_concept =
     requires (t                                                               & v,
               std::ofstream                                                   & stream,
               alignment_file_output_options                                   & options,
@@ -178,5 +178,5 @@ constexpr bool is_type_list_of_alignment_file_output_formats_v<type_list<ts...>>
  * \see seqan3::is_type_list_of_alignment_file_formats_v
  */
 template <typename t>
-concept type_list_of_alignment_file_output_formats_concept = is_type_list_of_alignment_file_output_formats_v<t>;
+SEQAN3_CONCEPT type_list_of_alignment_file_output_formats_concept = is_type_list_of_alignment_file_output_formats_v<t>;
 } // namespace seqan3::detail

--- a/include/seqan3/io/detail/record.hpp
+++ b/include/seqan3/io/detail/record.hpp
@@ -32,7 +32,7 @@ namespace seqan3::detail
  * \relates seqan3::fields
  */
 template <typename t>
-concept fields_concept = is_value_specialisation_of_v<t, fields>;
+SEQAN3_CONCEPT fields_concept = is_value_specialisation_of_v<t, fields>;
 
 // ----------------------------------------------------------------------------
 // select_types_with_ids

--- a/include/seqan3/io/sequence_file/input.hpp
+++ b/include/seqan3/io/sequence_file/input.hpp
@@ -118,7 +118,7 @@ namespace seqan3
 //!\}
 //!\cond
 template <typename t>
-concept sequence_file_input_traits_concept = requires (t v)
+SEQAN3_CONCEPT sequence_file_input_traits_concept = requires (t v)
 {
     requires alphabet_concept<typename t::sequence_alphabet>;
     requires alphabet_concept<typename t::sequence_legal_alphabet>;

--- a/include/seqan3/io/sequence_file/input_format_concept.hpp
+++ b/include/seqan3/io/sequence_file/input_format_concept.hpp
@@ -38,7 +38,7 @@ namespace seqan3
  */
 //!\cond
 template <typename t>
-concept sequence_file_input_format_concept = requires (t                                     & v,
+SEQAN3_CONCEPT sequence_file_input_format_concept = requires (t                                     & v,
                                                          std::ifstream                         & f,
                                                          sequence_file_input_options<dna5, false> & options,
                                                          dna5_vector                           & seq,
@@ -122,6 +122,6 @@ constexpr bool is_type_list_of_sequence_file_input_formats_v<type_list<ts...>> =
  * \see seqan3::is_type_list_of_sequence_file_formats_v
  */
 template <typename t>
-concept type_list_of_sequence_file_input_formats_concept = is_type_list_of_sequence_file_input_formats_v<t>;
+SEQAN3_CONCEPT type_list_of_sequence_file_input_formats_concept = is_type_list_of_sequence_file_input_formats_v<t>;
 
 } // namespace seqan3::detail

--- a/include/seqan3/io/sequence_file/output_format_concept.hpp
+++ b/include/seqan3/io/sequence_file/output_format_concept.hpp
@@ -37,7 +37,7 @@ namespace seqan3
  */
 //!\cond
 template <typename t>
-concept sequence_file_output_format_concept = requires (t                         & v,
+SEQAN3_CONCEPT sequence_file_output_format_concept = requires (t                         & v,
                                                           std::ofstream             & f,
                                                           sequence_file_output_options & options,
                                                           dna5_vector               & seq,
@@ -119,5 +119,5 @@ constexpr bool is_type_list_of_sequence_file_output_formats_v<type_list<ts...>> 
  * \see seqan3::is_type_list_of_sequence_file_formats_v
  */
 template <typename t>
-concept type_list_of_sequence_file_output_formats_concept = is_type_list_of_sequence_file_output_formats_v<t>;
+SEQAN3_CONCEPT type_list_of_sequence_file_output_formats_concept = is_type_list_of_sequence_file_output_formats_v<t>;
 } // namespace seqan3::detail

--- a/include/seqan3/io/stream/concept.hpp
+++ b/include/seqan3/io/stream/concept.hpp
@@ -31,7 +31,7 @@ namespace seqan3
  */
 //!\cond
 template <typename stream_type, typename value_type>
-concept ostream_concept = std::is_base_of_v<std::ios_base, std::remove_reference_t<stream_type>> &&
+SEQAN3_CONCEPT ostream_concept = std::is_base_of_v<std::ios_base, std::remove_reference_t<stream_type>> &&
                                requires (stream_type & os, value_type & val)
 {
     typename std::remove_reference_t<stream_type>::char_type;
@@ -45,7 +45,7 @@ concept ostream_concept = std::is_base_of_v<std::ios_base, std::remove_reference
 };
 
 template <typename stream_type>
-concept ostream_concept2 = requires { typename std::remove_reference_t<stream_type>::char_type; } &&
+SEQAN3_CONCEPT ostream_concept2 = requires { typename std::remove_reference_t<stream_type>::char_type; } &&
                            ostream_concept<stream_type, typename std::remove_reference_t<stream_type>::char_type>;
 //!\endcond
 
@@ -104,7 +104,7 @@ concept ostream_concept2 = requires { typename std::remove_reference_t<stream_ty
  */
 //!\cond
 template <typename stream_type, typename value_type>
-concept istream_concept = std::is_base_of_v<std::ios_base, std::remove_reference_t<stream_type>> &&
+SEQAN3_CONCEPT istream_concept = std::is_base_of_v<std::ios_base, std::remove_reference_t<stream_type>> &&
                                requires (stream_type & is, value_type & val)
 {
     typename std::remove_reference_t<stream_type>::char_type;
@@ -118,7 +118,7 @@ concept istream_concept = std::is_base_of_v<std::ios_base, std::remove_reference
 };
 
 template <typename stream_type>
-concept istream_concept2 = requires { typename std::remove_reference_t<stream_type>::char_type; } &&
+SEQAN3_CONCEPT istream_concept2 = requires { typename std::remove_reference_t<stream_type>::char_type; } &&
                            istream_concept<stream_type, typename std::remove_reference_t<stream_type>::char_type>;
 //!\endcond
 
@@ -178,7 +178,7 @@ concept istream_concept2 = requires { typename std::remove_reference_t<stream_ty
  */
 //!\cond
 template <typename stream_type, typename value_type>
-concept stream_concept = ostream_concept<stream_type, value_type> &&
+SEQAN3_CONCEPT stream_concept = ostream_concept<stream_type, value_type> &&
                               istream_concept<stream_type, value_type>;
 
 //!\endcond

--- a/include/seqan3/io/stream/parse_condition_detail.hpp
+++ b/include/seqan3/io/stream/parse_condition_detail.hpp
@@ -106,7 +106,7 @@ class parse_condition_base;
  */
 //!\cond
 template <typename condition_t>
-concept parse_condition_concept = requires
+SEQAN3_CONCEPT parse_condition_concept = requires
 {
     requires std::Predicate<std::remove_reference_t<condition_t>, char>;
     requires std::is_base_of_v<parse_condition_base<remove_cvref_t<condition_t>>,

--- a/include/seqan3/io/structure_file/input.hpp
+++ b/include/seqan3/io/structure_file/input.hpp
@@ -196,7 +196,7 @@ namespace seqan3
 //!\}
 //!\cond
 template<typename t>
-concept structure_file_input_traits_concept = requires(t v)
+SEQAN3_CONCEPT structure_file_input_traits_concept = requires(t v)
 {
     // TODO(joergi-w) The expensive concept checks are currently omitted. Check again when compiler has improved.
     // sequence

--- a/include/seqan3/io/structure_file/input_format_concept.hpp
+++ b/include/seqan3/io/structure_file/input_format_concept.hpp
@@ -38,7 +38,7 @@ namespace seqan3
  */
 //!\cond
 template<typename t>
-concept structure_file_input_format_concept = requires(t & v,
+SEQAN3_CONCEPT structure_file_input_format_concept = requires(t & v,
                                                             std::ifstream & f,
                                                             structure_file_input_options<rna5, false> & options,
                                                             rna5_vector & seq,
@@ -159,6 +159,6 @@ constexpr bool is_type_list_of_structure_file_input_formats_v<type_list<ts...>>
  * \see seqan3::is_type_list_of_structure_file_formats_v
  */
 template<typename t>
-concept type_list_of_structure_file_input_formats_concept = is_type_list_of_structure_file_input_formats_v<t>;
+SEQAN3_CONCEPT type_list_of_structure_file_input_formats_concept = is_type_list_of_structure_file_input_formats_v<t>;
 
 } // namespace seqan3::detail

--- a/include/seqan3/io/structure_file/output_format_concept.hpp
+++ b/include/seqan3/io/structure_file/output_format_concept.hpp
@@ -37,7 +37,7 @@ namespace seqan3
  */
 //!\cond
 template <typename t>
-concept structure_file_output_format_concept = requires(t & v,
+SEQAN3_CONCEPT structure_file_output_format_concept = requires(t & v,
                                                              std::ofstream & f,
                                                              structure_file_output_options & options,
                                                              rna5_vector & seq,
@@ -154,5 +154,5 @@ constexpr bool is_type_list_of_structure_file_output_formats_v<type_list<ts...>>
  * \see seqan3::is_type_list_of_structure_file_formats_v
  */
 template <typename t>
-concept type_list_of_structure_file_output_formats_concept = is_type_list_of_structure_file_output_formats_v<t>;
+SEQAN3_CONCEPT type_list_of_structure_file_output_formats_concept = is_type_list_of_structure_file_output_formats_v<t>;
 } // namespace seqan3::detail

--- a/include/seqan3/range/concept.hpp
+++ b/include/seqan3/range/concept.hpp
@@ -39,7 +39,7 @@ namespace seqan3
  */
 //!\cond
 template <typename type>
-concept const_iterable_concept =
+SEQAN3_CONCEPT const_iterable_concept =
     std::ranges::InputRange<std::remove_const_t<type>> &&
     std::ranges::InputRange<type const> &&
     (std::ranges::ForwardRange<std::remove_const_t<type>>       == std::ranges::ForwardRange<type const>) &&

--- a/include/seqan3/range/container/concept.hpp
+++ b/include/seqan3/range/container/concept.hpp
@@ -60,7 +60,7 @@ constexpr bool is_basic_string_v = is_basic_string<basic_string_t>::value;
  */
 //!\cond
 template <typename type>
-concept sequence_container_concept_modified_by_const_iterator = requires (type val, type val2)
+SEQAN3_CONCEPT sequence_container_concept_modified_by_const_iterator = requires (type val, type val2)
 {
     { val.insert(val.cbegin(), val2.front())                                           } -> typename type::iterator;
     { val.insert(val.cbegin(), typename type::value_type{})                            } -> typename type::iterator;
@@ -121,7 +121,7 @@ namespace seqan3
  */
 //!\cond
 template <typename type>
-concept container_concept = requires (type val, type val2, type const cval, typename type::iterator it)
+SEQAN3_CONCEPT container_concept = requires (type val, type val2, type const cval, typename type::iterator it)
 {
     // member types
     typename type::value_type;
@@ -186,7 +186,7 @@ concept container_concept = requires (type val, type val2, type const cval, type
  */
 //!\cond
 template <typename type>
-concept sequence_container_concept = requires (type val, type val2, type const cval)
+SEQAN3_CONCEPT sequence_container_concept = requires (type val, type val2, type const cval)
 {
     requires container_concept<type>;
 
@@ -250,7 +250,7 @@ concept sequence_container_concept = requires (type val, type val2, type const c
  */
 //!\cond
 template <typename type>
-concept random_access_container_concept = requires (type val)
+SEQAN3_CONCEPT random_access_container_concept = requires (type val)
 {
     requires sequence_container_concept<type>;
 
@@ -276,7 +276,7 @@ concept random_access_container_concept = requires (type val)
  */
 //!\cond
 template <typename type>
-concept reservable_container_concept = requires (type val)
+SEQAN3_CONCEPT reservable_container_concept = requires (type val)
 {
     requires random_access_container_concept<type>;
 

--- a/include/seqan3/search/fm_index/concept.hpp
+++ b/include/seqan3/search/fm_index/concept.hpp
@@ -36,7 +36,7 @@ namespace seqan3::detail
  */
 //!\cond
 template <typename t>
-concept SdslIndex = requires (t sdsl_index)
+SEQAN3_CONCEPT SdslIndex = requires (t sdsl_index)
 {
     typename t::size_type;
 
@@ -92,7 +92,7 @@ namespace seqan3
  */
 //!\cond
 template <typename t>
-concept FmIndexTraits = requires (t v)
+SEQAN3_CONCEPT FmIndexTraits = requires (t v)
 {
     typename t::sdsl_index_type;
 
@@ -122,7 +122,7 @@ concept FmIndexTraits = requires (t v)
  */
 //!\cond
 template <typename t>
-concept FmIndex = std::Semiregular<t> && requires (t index)
+SEQAN3_CONCEPT FmIndex = std::Semiregular<t> && requires (t index)
 {
     typename t::text_type;
     typename t::char_type;
@@ -184,7 +184,7 @@ concept FmIndex = std::Semiregular<t> && requires (t index)
  */
 //!\cond
 template <typename t>
-concept FmIndexCursor = std::Semiregular<t> && requires (t cur)
+SEQAN3_CONCEPT FmIndexCursor = std::Semiregular<t> && requires (t cur)
 {
     typename t::index_type;
     typename t::size_type;
@@ -242,7 +242,7 @@ concept FmIndexCursor = std::Semiregular<t> && requires (t cur)
  */
 //!\cond
 template <typename t>
-concept BiFmIndexTraits = requires (t v)
+SEQAN3_CONCEPT BiFmIndexTraits = requires (t v)
 {
     requires FmIndexTraits<typename t::fm_index_traits>;
     requires FmIndexTraits<typename t::rev_fm_index_traits>;
@@ -280,7 +280,7 @@ concept BiFmIndexTraits = requires (t v)
  */
 //!\cond
 template <typename t>
-concept BiFmIndex = FmIndex<t> && requires (t index)
+SEQAN3_CONCEPT BiFmIndex = FmIndex<t> && requires (t index)
 {
     typename t::cursor_type; // already required by FmIndex but has a different documentation
     typename t::fwd_cursor_type;
@@ -326,7 +326,7 @@ concept BiFmIndex = FmIndex<t> && requires (t index)
  */
 //!\cond
 template <typename t>
-concept BiFmIndexCursor = FmIndexCursor<t> && requires (t cur)
+SEQAN3_CONCEPT BiFmIndexCursor = FmIndexCursor<t> && requires (t cur)
 {
     requires BiFmIndex<typename t::index_type>;
 

--- a/include/seqan3/std/concepts
+++ b/include/seqan3/std/concepts
@@ -50,7 +50,7 @@ namespace std
  */
 //!\cond
 template <class T, class U>
-concept Same = std::is_same_v<T, U>;
+SEQAN3_CONCEPT Same = std::is_same_v<T, U>;
 //!\endcond
 
 /*!\interface std::DerivedFrom <>
@@ -60,7 +60,7 @@ concept Same = std::is_same_v<T, U>;
  */
 //!\cond
 template <class Derived, class Base >
-concept DerivedFrom =
+SEQAN3_CONCEPT DerivedFrom =
     std::is_base_of_v<Base, Derived> &&
     std::is_convertible_v<const volatile Derived*, const volatile Base*>;
 //!\endcond
@@ -73,7 +73,7 @@ concept DerivedFrom =
  */
 //!\cond
 template <class From, class To>
-concept ConvertibleTo =
+SEQAN3_CONCEPT ConvertibleTo =
     std::is_convertible_v<From, To> &&
     requires(From (&f)())
     {
@@ -88,7 +88,7 @@ concept ConvertibleTo =
  */
 //!\cond
 template <class T, class U >
-concept CommonReference =
+SEQAN3_CONCEPT CommonReference =
   Same<::ranges::common_reference_t<T, U>, ::ranges::common_reference_t<U, T>> &&
   ConvertibleTo<T, ::ranges::common_reference_t<T, U>> &&
   ConvertibleTo<U, ::ranges::common_reference_t<T, U>>;
@@ -101,7 +101,7 @@ concept CommonReference =
  */
 //!\cond
 template <class T, class U>
-concept Common =
+SEQAN3_CONCEPT Common =
     Same<::ranges::common_type_t<T, U>, ::ranges::common_type_t<U, T>> &&
     ConvertibleTo<T, ::ranges::common_type_t<T, U>> &&
     ConvertibleTo<U, ::ranges::common_type_t<T, U>> &&
@@ -117,7 +117,7 @@ concept Common =
  */
 //!\cond
 template <class T>
-concept Integral = std::is_arithmetic_v<T> && std::is_integral_v<T>;
+SEQAN3_CONCEPT Integral = std::is_arithmetic_v<T> && std::is_integral_v<T>;
 //!\endcond
 
 /*!\interface std::SignedIntegral
@@ -128,7 +128,7 @@ concept Integral = std::is_arithmetic_v<T> && std::is_integral_v<T>;
  */
 //!\cond
 template <class T>
-concept SignedIntegral = Integral<T> && std::is_signed_v<T>;
+SEQAN3_CONCEPT SignedIntegral = Integral<T> && std::is_signed_v<T>;
 //!\endcond
 
 /*!\interface std::UnsignedIntegral
@@ -139,7 +139,7 @@ concept SignedIntegral = Integral<T> && std::is_signed_v<T>;
  */
 //!\cond
 template <class T>
-concept UnsignedIntegral = Integral<T> && !SignedIntegral<T>;
+SEQAN3_CONCEPT UnsignedIntegral = Integral<T> && !SignedIntegral<T>;
 //!\endcond
 
 /*!\interface std::Assignable <>
@@ -159,7 +159,7 @@ concept UnsignedIntegral = Integral<T> && !SignedIntegral<T>;
  */
 //!\cond
 template <class LHS, class RHS>
-concept Assignable =
+SEQAN3_CONCEPT Assignable =
     std::is_lvalue_reference_v<LHS> &&
     CommonReference<std::remove_reference_t<LHS> const &, std::remove_reference_t<RHS> const&> &&
     requires(LHS lhs, RHS&& rhs)
@@ -186,7 +186,7 @@ concept Assignable =
 //!\}
 //!\cond
 template <class T>
-concept Swappable = std::is_swappable_v<T>;
+SEQAN3_CONCEPT Swappable = std::is_swappable_v<T>;
 //!\endcond
 
 /*!\interface std::SwappableWith <>
@@ -196,7 +196,7 @@ concept Swappable = std::is_swappable_v<T>;
  */
 //!\cond
 template <class T, class U>
-concept SwappableWith =
+SEQAN3_CONCEPT SwappableWith =
     std::is_swappable_with_v<T, T> &&
     std::is_swappable_with_v<U, U> &&
     CommonReference<std::remove_reference_t<T> const &, std::remove_reference_t<U> const &> &&
@@ -211,7 +211,7 @@ concept SwappableWith =
  */
 //!\cond
 template < class T >
-concept Destructible = std::is_nothrow_destructible_v<T>;
+SEQAN3_CONCEPT Destructible = std::is_nothrow_destructible_v<T>;
 //!\endcond
 
 /*!\interface   std::Constructible <>
@@ -222,7 +222,7 @@ concept Destructible = std::is_nothrow_destructible_v<T>;
  */
 //!\cond
 template < class T, class... Args >
-concept Constructible = Destructible<T> && std::is_constructible_v<T, Args...>;
+SEQAN3_CONCEPT Constructible = Destructible<T> && std::is_constructible_v<T, Args...>;
 //!\endcond
 
 /*!\interface   std::DefaultConstructible <>
@@ -233,7 +233,7 @@ concept Constructible = Destructible<T> && std::is_constructible_v<T, Args...>;
  */
 //!\cond
 template < class T >
-concept DefaultConstructible = Constructible<T>;
+SEQAN3_CONCEPT DefaultConstructible = Constructible<T>;
 //!\endcond
 
 /*!\interface   std::MoveConstructible <>
@@ -246,7 +246,7 @@ concept DefaultConstructible = Constructible<T>;
  */
 //!\cond
 template< class T >
-concept MoveConstructible = Constructible<T, T> && ConvertibleTo<T, T>;
+SEQAN3_CONCEPT MoveConstructible = Constructible<T, T> && ConvertibleTo<T, T>;
 //!\endcond
 
 /*!\interface   std::CopyConstructible <>
@@ -259,7 +259,7 @@ concept MoveConstructible = Constructible<T, T> && ConvertibleTo<T, T>;
  */
 //!\cond
 template <class T>
-concept CopyConstructible =
+SEQAN3_CONCEPT CopyConstructible =
   MoveConstructible<T> &&
   Constructible<T, T&>       && ConvertibleTo<T&, T> &&
   Constructible<T, const T&> && ConvertibleTo<const T&, T> &&
@@ -281,7 +281,7 @@ concept CopyConstructible =
  */
 //!\cond
 template < class T >
-concept Movable = std::is_object_v<T> && MoveConstructible<T> && Assignable<T&, T> && Swappable<T>;
+SEQAN3_CONCEPT Movable = std::is_object_v<T> && MoveConstructible<T> && Assignable<T&, T> && Swappable<T>;
 //!\endcond
 
 // ============================================================================
@@ -295,7 +295,7 @@ concept Movable = std::is_object_v<T> && MoveConstructible<T> && Assignable<T&, 
  */
 //!\cond
 template <class B>
-concept Boolean =
+SEQAN3_CONCEPT Boolean =
     Movable<seqan3::remove_cvref_t<B>> &&
     requires(std::remove_reference_t<B> const & b1,
              std::remove_reference_t<B> const & b2, bool const a)
@@ -330,7 +330,7 @@ namespace std::detail
  */
 //!\cond
 template <class T, class U>
-concept WeaklyEqualityComparableWith =
+SEQAN3_CONCEPT WeaklyEqualityComparableWith =
     requires(std::remove_reference_t<T> const & t,
              std::remove_reference_t<U> const & u)
     {
@@ -371,7 +371,7 @@ namespace std
 //!\}
 //!\cond
 template < class T >
-concept EqualityComparable = detail::WeaklyEqualityComparableWith<T, T>;
+SEQAN3_CONCEPT EqualityComparable = detail::WeaklyEqualityComparableWith<T, T>;
 //!\endcond
 
 /*!\interface   std::EqualityComparableWith <>
@@ -384,7 +384,7 @@ concept EqualityComparable = detail::WeaklyEqualityComparableWith<T, T>;
  */
 //!\cond
 template <class T, class U>
-concept EqualityComparableWith =
+SEQAN3_CONCEPT EqualityComparableWith =
     EqualityComparable<T> &&
     EqualityComparable<U> &&
     CommonReference<std::remove_reference_t<T> const &, std::remove_reference_t<U> const &> &&
@@ -428,7 +428,7 @@ concept EqualityComparableWith =
 //!\}
 //!\cond
 template <class T>
-concept StrictTotallyOrdered =
+SEQAN3_CONCEPT StrictTotallyOrdered =
     EqualityComparable<T> &&
     requires(std::remove_reference_t<T> const & a,
              std::remove_reference_t<T> const & b)
@@ -449,7 +449,7 @@ concept StrictTotallyOrdered =
  */
 //!\cond
 template <class T, class U>
-concept StrictTotallyOrderedWith =
+SEQAN3_CONCEPT StrictTotallyOrderedWith =
     StrictTotallyOrdered<T> &&
     StrictTotallyOrdered<U> &&
     CommonReference<std::remove_reference_t<T> const &, std::remove_reference_t<U> const &> &&
@@ -483,7 +483,7 @@ concept StrictTotallyOrderedWith =
  */
 //!\cond
 template <class T>
-concept Copyable = CopyConstructible<T> && Movable<T> && Assignable<T&, const T&>;
+SEQAN3_CONCEPT Copyable = CopyConstructible<T> && Movable<T> && Assignable<T&, const T&>;
 //!\endcond
 
 /*!\interface   std::Semiregular
@@ -494,7 +494,7 @@ concept Copyable = CopyConstructible<T> && Movable<T> && Assignable<T&, const T&
  */
 //!\cond
 template <class T>
-concept Semiregular = Copyable<T> && DefaultConstructible<T>;
+SEQAN3_CONCEPT Semiregular = Copyable<T> && DefaultConstructible<T>;
 //!\endcond
 
 /*!\interface   std::Regular
@@ -505,7 +505,7 @@ concept Semiregular = Copyable<T> && DefaultConstructible<T>;
  */
 //!\cond
 template <class T>
-concept Regular = Semiregular<T> && EqualityComparable<T>;
+SEQAN3_CONCEPT Regular = Semiregular<T> && EqualityComparable<T>;
 //!\endcond
 
 // ============================================================================
@@ -518,7 +518,7 @@ concept Regular = Semiregular<T> && EqualityComparable<T>;
  */
 //!\cond
 template< class F, class... Args >
-concept Invocable =
+SEQAN3_CONCEPT Invocable =
     requires(F&& f, Args&&... args)
     {
         std::invoke(std::forward<F>(f), std::forward<Args>(args)...);
@@ -534,7 +534,7 @@ concept Invocable =
  */
 //!\cond
 template< class F, class... Args >
-concept RegularInvocable = Invocable<F, Args...>;
+SEQAN3_CONCEPT RegularInvocable = Invocable<F, Args...>;
 //!\endcond
 
 /*!\interface   std::Predicate <>
@@ -544,7 +544,7 @@ concept RegularInvocable = Invocable<F, Args...>;
  */
 //!\cond
 template < class F, class... Args >
-concept Predicate = RegularInvocable<F, Args...> && Boolean<std::invoke_result_t<F, Args...>>;
+SEQAN3_CONCEPT Predicate = RegularInvocable<F, Args...> && Boolean<std::invoke_result_t<F, Args...>>;
 //!\endcond
 
 /*!\interface   std::Relation <>
@@ -555,7 +555,7 @@ concept Predicate = RegularInvocable<F, Args...> && Boolean<std::invoke_result_t
  */
 //!\cond
 template <class R, class T, class U>
-concept Relation =
+SEQAN3_CONCEPT Relation =
     Predicate<R, T, T> &&
     Predicate<R, U, U> &&
     CommonReference<std::remove_reference_t<T> const &, std::remove_reference_t<U> const &> &&
@@ -574,7 +574,7 @@ concept Relation =
  */
 //!\cond
 template < class R, class T, class U >
-concept StrictWeakOrder = Relation<R, T, U>;
+SEQAN3_CONCEPT StrictWeakOrder = Relation<R, T, U>;
 //!\endcond
 //!\}
 

--- a/include/seqan3/std/iterator
+++ b/include/seqan3/std/iterator
@@ -135,7 +135,7 @@ constexpr auto back_inserter(container_t & container)
  */
 //!\cond
 template <typename t>
-concept Readable = static_cast<bool>(::ranges::Readable<t>());
+SEQAN3_CONCEPT Readable = static_cast<bool>(::ranges::Readable<t>());
 //!\endcond
 
 /*!\interface std::Writable <>
@@ -145,7 +145,7 @@ concept Readable = static_cast<bool>(::ranges::Readable<t>());
  */
 //!\cond
 template <typename out, typename t>
-concept Writable = static_cast<bool>(::ranges::Writable<out, t>());
+SEQAN3_CONCEPT Writable = static_cast<bool>(::ranges::Writable<out, t>());
 //!\endcond
 
 /*!\interface std::WeaklyIncrementable <>
@@ -157,7 +157,7 @@ concept Writable = static_cast<bool>(::ranges::Writable<out, t>());
  */
 //!\cond
 template <typename t>
-concept WeaklyIncrementable = Semiregular<t> &&
+SEQAN3_CONCEPT WeaklyIncrementable = Semiregular<t> &&
                                    requires (t v)
 {
     typename iter_difference_t<std::remove_reference_t<t>>;
@@ -177,7 +177,7 @@ concept WeaklyIncrementable = Semiregular<t> &&
  */
 //!\cond
 template <typename i>
-concept Incrementable = Regular<i> && WeaklyIncrementable<i> && static_cast<bool>(::ranges::Incrementable<i>());
+SEQAN3_CONCEPT Incrementable = Regular<i> && WeaklyIncrementable<i> && static_cast<bool>(::ranges::Incrementable<i>());
 //!\endcond
 
 /*!\interface std::Iterator <>
@@ -188,7 +188,7 @@ concept Incrementable = Regular<i> && WeaklyIncrementable<i> && static_cast<bool
  */
 //!\cond
 template <typename i>
-concept Iterator = WeaklyIncrementable<i> && static_cast<bool>(::ranges::Iterator<i>());
+SEQAN3_CONCEPT Iterator = WeaklyIncrementable<i> && static_cast<bool>(::ranges::Iterator<i>());
 //!\endcond
 
 /*!\interface std::Sentinel <>
@@ -200,7 +200,7 @@ concept Iterator = WeaklyIncrementable<i> && static_cast<bool>(::ranges::Iterato
  */
 //!\cond
 template <typename s, typename i>
-concept Sentinel = Semiregular<s> && Iterator<i> && static_cast<bool>(::ranges::Sentinel<s, i>());
+SEQAN3_CONCEPT Sentinel = Semiregular<s> && Iterator<i> && static_cast<bool>(::ranges::Sentinel<s, i>());
 //!\endcond
 
 /*!\interface std::SizedSentinel <>
@@ -211,7 +211,7 @@ concept Sentinel = Semiregular<s> && Iterator<i> && static_cast<bool>(::ranges::
  */
 //!\cond
 template <typename s, typename i>
-concept SizedSentinel = Sentinel<s, i> && static_cast<bool>(::ranges::SizedSentinel<s, i>());
+SEQAN3_CONCEPT SizedSentinel = Sentinel<s, i> && static_cast<bool>(::ranges::SizedSentinel<s, i>());
 //!\endcond
 
 /*!\interface std::OutputIterator <>
@@ -224,7 +224,7 @@ concept SizedSentinel = Sentinel<s, i> && static_cast<bool>(::ranges::SizedSenti
  */
 //!\cond
 template <typename out, typename t>
-concept OutputIterator = Iterator<out> && Writable<out, t> && static_cast<bool>(::ranges::OutputIterator<out, t>());
+SEQAN3_CONCEPT OutputIterator = Iterator<out> && Writable<out, t> && static_cast<bool>(::ranges::OutputIterator<out, t>());
 //!\endcond
 
 /*!\interface std::InputIterator <>
@@ -236,7 +236,7 @@ concept OutputIterator = Iterator<out> && Writable<out, t> && static_cast<bool>(
  */
 //!\cond
 template <typename i>
-concept InputIterator = Iterator<i> && Readable<i> && static_cast<bool>(::ranges::InputIterator<i>());
+SEQAN3_CONCEPT InputIterator = Iterator<i> && Readable<i> && static_cast<bool>(::ranges::InputIterator<i>());
 //!\endcond
 
 /*!\interface std::ForwardIterator <>
@@ -249,7 +249,7 @@ concept InputIterator = Iterator<i> && Readable<i> && static_cast<bool>(::ranges
  */
 //!\cond
 template <typename i>
-concept ForwardIterator = InputIterator<i> &&
+SEQAN3_CONCEPT ForwardIterator = InputIterator<i> &&
                                Incrementable<i> &&
                                Sentinel<i, i> &&
                                static_cast<bool>(::ranges::ForwardIterator<i>());
@@ -263,7 +263,7 @@ concept ForwardIterator = InputIterator<i> &&
  */
 //!\cond
 template <typename i>
-concept BidirectionalIterator = ForwardIterator<i> && static_cast<bool>(::ranges::BidirectionalIterator<i>());
+SEQAN3_CONCEPT BidirectionalIterator = ForwardIterator<i> && static_cast<bool>(::ranges::BidirectionalIterator<i>());
 //!\endcond
 
 /*!\interface std::RandomAccessIterator <>
@@ -277,7 +277,7 @@ concept BidirectionalIterator = ForwardIterator<i> && static_cast<bool>(::ranges
  */
 //!\cond
 template <typename i>
-concept RandomAccessIterator = BidirectionalIterator<i> &&
+SEQAN3_CONCEPT RandomAccessIterator = BidirectionalIterator<i> &&
                                     StrictTotallyOrdered<i> &&
                                     SizedSentinel<i, i> &&
                                     static_cast<bool>(::ranges::RandomAccessIterator<i>());

--- a/include/seqan3/std/ranges
+++ b/include/seqan3/std/ranges
@@ -43,7 +43,7 @@ namespace std::ranges
  */
 //!\cond
 template <typename type>
-concept Range = (bool)::ranges::Range<type>();
+SEQAN3_CONCEPT Range = (bool)::ranges::Range<type>();
 //!\endcond
 
 /*!\interface std::ranges::SizedRange <>
@@ -53,7 +53,7 @@ concept Range = (bool)::ranges::Range<type>();
  */
 //!\cond
 template <typename type>
-concept SizedRange = Range<type> && (bool)::ranges::SizedRange<type>();
+SEQAN3_CONCEPT SizedRange = Range<type> && (bool)::ranges::SizedRange<type>();
 //!\endcond
 
 /*!\interface std::ranges::CommonRange  <>
@@ -63,7 +63,7 @@ concept SizedRange = Range<type> && (bool)::ranges::SizedRange<type>();
  */
 //!\cond
 template <typename type>
-concept CommonRange = Range<type> && (bool)::ranges::BoundedRange<type>();
+SEQAN3_CONCEPT CommonRange = Range<type> && (bool)::ranges::BoundedRange<type>();
 //!\endcond
 
 /*!\interface std::ranges::OutputRange <>
@@ -74,7 +74,7 @@ concept CommonRange = Range<type> && (bool)::ranges::BoundedRange<type>();
  */
 //!\cond
 template <typename type, typename out_type>
-concept OutputRange = Range<type> && (bool)::ranges::OutputRange<type, out_type>();
+SEQAN3_CONCEPT OutputRange = Range<type> && (bool)::ranges::OutputRange<type, out_type>();
 //!\endcond
 
 /*!\interface std::ranges::InputRange <>
@@ -85,7 +85,7 @@ concept OutputRange = Range<type> && (bool)::ranges::OutputRange<type, out_type>
  */
 //!\cond
 template <typename type>
-concept InputRange = Range<type> && (bool)::ranges::InputRange<type>();
+SEQAN3_CONCEPT InputRange = Range<type> && (bool)::ranges::InputRange<type>();
 //!\endcond
 
 /*!\interface std::ranges::ForwardRange <>
@@ -96,7 +96,7 @@ concept InputRange = Range<type> && (bool)::ranges::InputRange<type>();
  */
 //!\cond
 template <typename type>
-concept ForwardRange = InputRange<type> && (bool)::ranges::ForwardRange<type>();
+SEQAN3_CONCEPT ForwardRange = InputRange<type> && (bool)::ranges::ForwardRange<type>();
 //!\endcond
 
 /*!\interface std::ranges::BidirectionalRange <>
@@ -107,7 +107,7 @@ concept ForwardRange = InputRange<type> && (bool)::ranges::ForwardRange<type>();
  */
 //!\cond
 template <typename type>
-concept BidirectionalRange = ForwardRange<type> && (bool)::ranges::BidirectionalRange<type>();
+SEQAN3_CONCEPT BidirectionalRange = ForwardRange<type> && (bool)::ranges::BidirectionalRange<type>();
 //!\endcond
 
 /*!\interface std::ranges::RandomAccessRange <>
@@ -118,7 +118,7 @@ concept BidirectionalRange = ForwardRange<type> && (bool)::ranges::Bidirectional
  */
 //!\cond
 template <typename type>
-concept RandomAccessRange = BidirectionalRange<type> && (bool)::ranges::RandomAccessRange<type>();
+SEQAN3_CONCEPT RandomAccessRange = BidirectionalRange<type> && (bool)::ranges::RandomAccessRange<type>();
 //!\endcond
 
 /*!\interface std::ranges::ContiguousRange <>
@@ -127,7 +127,7 @@ concept RandomAccessRange = BidirectionalRange<type> && (bool)::ranges::RandomAc
  */
 //!\cond
 template <typename type>
-concept ContiguousRange = RandomAccessRange<type> && (bool)::ranges::ContiguousRange<type>();
+SEQAN3_CONCEPT ContiguousRange = RandomAccessRange<type> && (bool)::ranges::ContiguousRange<type>();
 //!\endcond
 
 /*!\interface std::ranges::View <>
@@ -139,7 +139,7 @@ concept ContiguousRange = RandomAccessRange<type> && (bool)::ranges::ContiguousR
  */
 //!\cond
 template <typename type>
-concept View = Range<type> && (bool)::ranges::View<type>();
+SEQAN3_CONCEPT View = Range<type> && (bool)::ranges::View<type>();
 //!\endcond
 
 /*!\interface std::ranges::ViewableRange <>
@@ -149,7 +149,7 @@ concept View = Range<type> && (bool)::ranges::View<type>();
  */
 //!\cond
 template <typename type>
-concept ViewableRange = Range<type> && (std::is_lvalue_reference_v<type> || View<type>);
+SEQAN3_CONCEPT ViewableRange = Range<type> && (std::is_lvalue_reference_v<type> || View<type>);
 //!\endcond
 
 /*!\typedef std::ranges::begin;


### PR DESCRIPTION
This is a prerequisite for updating to the new ranges branch which is prerequisite for having GCC9 support.