### PR TITLE
add GCC9 support, update range-v3 to 1.0-beta

### DIFF
--- a/include/seqan3/alignment/pairwise/align_pairwise.hpp
+++ b/include/seqan3/alignment/pairwise/align_pairwise.hpp
@@ -19,8 +19,6 @@
 
 #include <meta/meta.hpp>
 
-#include <range/v3/view/bounded.hpp>
-#include <range/v3/view/transform.hpp>
 #include <range/v3/view/single.hpp>
 
 #include <seqan3/alignment/configuration/all.hpp>
@@ -36,6 +34,7 @@
 
 #include <seqan3/std/concepts>
 #include <seqan3/std/ranges>
+#include <seqan3/std/view/common.hpp>
 
 namespace seqan3
 {
@@ -64,7 +63,7 @@ constexpr auto align_pairwise(seq_t && seq, alignment_config_t && config)
     static_assert(std::tuple_size_v<std::remove_reference_t<seq_t>> == 2,
                   "Expects exactly two sequences for pairwise alignments.");
 
-    return align_pairwise(ranges::view::single(std::forward<seq_t>(seq)) | ranges::view::bounded,
+    return align_pairwise(ranges::view::single(std::forward<seq_t>(seq)) | view::common,
                           std::forward<alignment_config_t>(config));
 }
 //!\endcond

--- a/include/seqan3/alignment/pairwise/edit_distance_unbanded.hpp
+++ b/include/seqan3/alignment/pairwise/edit_distance_unbanded.hpp
@@ -17,7 +17,6 @@
 #include <utility>
 
 #include <range/v3/algorithm/copy.hpp>
-#include <range/v3/utility/iterator.hpp>
 
 #include <seqan3/alignment/configuration/all.hpp>
 #include <seqan3/alignment/matrix/alignment_coordinate.hpp>

--- a/include/seqan3/alignment/pairwise/execution/alignment_range.hpp
+++ b/include/seqan3/alignment/pairwise/execution/alignment_range.hpp
@@ -12,8 +12,6 @@
 
 #pragma once
 
-#include <range/v3/utility/iterator.hpp>
-
 #include <seqan3/std/concepts>
 #include <seqan3/std/ranges>
 
@@ -99,23 +97,23 @@ class alignment_range
          * \{
          */
 
-        constexpr bool operator==(std::ranges::default_sentinel const &) const noexcept
+        constexpr bool operator==(std::ranges::default_sentinel_t const &) const noexcept
         {
             return range_ptr->eof();
         }
 
-        friend constexpr bool operator==(std::ranges::default_sentinel const & lhs,
+        friend constexpr bool operator==(std::ranges::default_sentinel_t const & lhs,
                                          iterator_type const & rhs) noexcept
         {
             return rhs == lhs;
         }
 
-        constexpr bool operator!=(std::ranges::default_sentinel const & rhs) const noexcept
+        constexpr bool operator!=(std::ranges::default_sentinel_t const & rhs) const noexcept
         {
             return !(*this == rhs);
         }
 
-        friend constexpr bool operator!=(std::ranges::default_sentinel const & lhs,
+        friend constexpr bool operator!=(std::ranges::default_sentinel_t const & lhs,
                                          iterator_type const & rhs) noexcept
         {
             return rhs != lhs;
@@ -143,7 +141,7 @@ public:
     //!\brief This range is never const-iterable. The const_iterator is always void.
     using const_iterator  = void;
     //!\brief The sentinel type.
-    using sentinel        = std::ranges::default_sentinel;
+    using sentinel        = std::ranges::default_sentinel_t;
 
     /*!\name Constructors, destructor and assignment
      * \{

--- a/include/seqan3/argument_parser/detail/format_help.hpp
+++ b/include/seqan3/argument_parser/detail/format_help.hpp
@@ -79,7 +79,7 @@ public:
                     option_spec const & spec,
                     validator_type && validator)
     {
-        parser_set_up_calls.push_back([=, &value]()
+        parser_set_up_calls.push_back([this, &value, short_id, long_id, desc, spec, validator]()
         {
             if (!(spec & option_spec::HIDDEN) && (!(spec & option_spec::ADVANCED) || show_advanced_options))
                 print_list_item(prep_id_for_help(short_id, long_id) + " " + option_type_and_list_info(value),
@@ -100,7 +100,7 @@ public:
                   std::string const & desc,
                   option_spec const & spec)
     {
-        parser_set_up_calls.push_back([=] ()
+        parser_set_up_calls.push_back([this, short_id, long_id, desc, spec] ()
         {
             if (!(spec & option_spec::HIDDEN) && (!(spec & option_spec::ADVANCED) || show_advanced_options))
                 print_list_item(prep_id_for_help(short_id, long_id), desc);
@@ -121,7 +121,7 @@ public:
                                std::string const & desc,
                                validator_type & validator)
     {
-        positional_option_calls.push_back([=, &value]()
+        positional_option_calls.push_back([this, &value, desc, validator] ()
         {
             ++positional_option_count;
             std::string key{"\\fBARGUMENT-" + std::to_string(positional_option_count) + "\\fP " + option_type_and_list_info(value)};
@@ -184,7 +184,7 @@ public:
      */
     void add_section(std::string const & title)
     {
-        parser_set_up_calls.push_back([=] ()
+        parser_set_up_calls.push_back([this, title] ()
         {
             print_section(title);
         });
@@ -195,7 +195,7 @@ public:
      */
     void add_subsection(std::string const & title)
     {
-        parser_set_up_calls.push_back([=] ()
+        parser_set_up_calls.push_back([this, title] ()
         {
             print_subsection(title);
         });
@@ -207,7 +207,7 @@ public:
      */
     void add_line(std::string const & text, bool line_is_paragraph)
     {
-        parser_set_up_calls.push_back([=] ()
+        parser_set_up_calls.push_back([this, text, line_is_paragraph] ()
         {
             print_line(text, line_is_paragraph);
         });
@@ -219,7 +219,7 @@ public:
      */
     void add_list_item(std::string const & key, std::string const & desc)
     {
-        parser_set_up_calls.push_back([=] ()
+        parser_set_up_calls.push_back([this, key, desc] ()
         {
             print_list_item(key, desc);
         });
@@ -699,7 +699,7 @@ public:
                     option_spec const & spec,
                     validator_type && validator)
     {
-        parser_set_up_calls.push_back([=, &value]()
+        parser_set_up_calls.push_back([this, &value, short_id, long_id, desc, spec, validator]()
         {
             if (!(spec & option_spec::HIDDEN) && (!(spec & option_spec::ADVANCED) || show_advanced_options))
                 print_list_item(prep_id_for_help(short_id, long_id) + " " + option_type_and_list_info(value),
@@ -722,7 +722,7 @@ public:
                   std::string const & desc,
                   option_spec const & spec)
     {
-        parser_set_up_calls.push_back([=, &value] ()
+        parser_set_up_calls.push_back([this, &value, short_id, long_id, desc, spec] ()
         {
             if (!(spec & option_spec::HIDDEN) && (!(spec & option_spec::ADVANCED) || show_advanced_options))
                 print_list_item(prep_id_for_help(short_id, long_id), desc);
@@ -743,7 +743,7 @@ public:
                                std::string const & desc,
                                validator_type && validator)
     {
-        positional_option_calls.push_back([=, &value]()
+        positional_option_calls.push_back([this, &value, desc, validator]()
         {
             ++positional_option_count;
             std::string key{"\\fBARGUMENT " + std::to_string(positional_option_count) + "\\fP " + option_type_and_list_info(value)};

--- a/include/seqan3/argument_parser/detail/format_html.hpp
+++ b/include/seqan3/argument_parser/detail/format_html.hpp
@@ -54,7 +54,7 @@ public:
                     option_spec const & spec,
                     validator_type && validator)
     {
-        parser_set_up_calls.push_back([=, &value]()
+        parser_set_up_calls.push_back([this, &value, short_id, long_id, desc, spec, validator] ()
         {
             if (!(spec & option_spec::HIDDEN) && (!(spec & option_spec::ADVANCED)))
                 print_list_item(prep_id_for_help(short_id, long_id) + " " + option_type_and_list_info(value),
@@ -75,7 +75,7 @@ public:
                   std::string const & desc,
                   option_spec const & spec)
     {
-        parser_set_up_calls.push_back([=] ()
+        parser_set_up_calls.push_back([this, short_id, long_id, desc, spec] ()
         {
             if (!(spec & option_spec::HIDDEN) && (!(spec & option_spec::ADVANCED)))
                 print_list_item(prep_id_for_help(short_id, long_id), desc);
@@ -98,7 +98,7 @@ public:
     {
         ++positional_option_count;
 
-        positional_option_calls.push_back([=, &value]()
+        positional_option_calls.push_back([this, &value, desc, validator] ()
         {
             std::string key{"\\fBARGUMENT " + std::to_string(positional_option_count) + "\\fP " + option_type_and_list_info(value)};
             print_list_item(key, (desc + " " + validator.get_help_page_message()));
@@ -150,7 +150,7 @@ public:
      */
     void add_section(std::string const & title)
     {
-        parser_set_up_calls.push_back([=] ()
+        parser_set_up_calls.push_back([this, title] ()
         {
             print_section(title);
         });
@@ -160,7 +160,7 @@ public:
      */
     void add_subsection(std::string const & title)
     {
-        parser_set_up_calls.push_back([=] ()
+        parser_set_up_calls.push_back([this, title] ()
         {
             print_subsection(title);
         });
@@ -173,7 +173,7 @@ public:
      */
     void add_line(std::string const & text, bool const line_is_paragraph)
     {
-        parser_set_up_calls.push_back([=] ()
+        parser_set_up_calls.push_back([this, text, line_is_paragraph] ()
         {
             print_line(text, line_is_paragraph);
         });
@@ -186,7 +186,7 @@ public:
      */
     void add_list_item(std::string const & key, std::string const & description)
     {
-        parser_set_up_calls.push_back([=] ()
+        parser_set_up_calls.push_back([this, key, description] ()
         {
             print_list_item(key, description);
         });

--- a/include/seqan3/argument_parser/detail/format_man.hpp
+++ b/include/seqan3/argument_parser/detail/format_man.hpp
@@ -52,7 +52,7 @@ public:
                     option_spec const & spec,
                     validator_type && validator)
     {
-        parser_set_up_calls.push_back([=, &value]()
+        parser_set_up_calls.push_back([this, &value, short_id, long_id, desc, spec, validator] ()
         {
             if (!(spec & option_spec::HIDDEN) && (!(spec & option_spec::ADVANCED)))
                 print_list_item(prep_id_for_help(short_id, long_id) + " " + option_type_and_list_info(value),
@@ -73,7 +73,7 @@ public:
                   std::string const & desc,
                   option_spec const & spec)
     {
-        parser_set_up_calls.push_back([=] ()
+        parser_set_up_calls.push_back([this, short_id, long_id, desc, spec] ()
         {
             if (!(spec & option_spec::HIDDEN) && (!(spec & option_spec::ADVANCED)))
                 print_list_item(prep_id_for_help(short_id, long_id), desc);
@@ -94,7 +94,7 @@ public:
     {
         ++positional_option_count;
 
-        positional_option_calls.push_back([=, &value]()
+        positional_option_calls.push_back([this, &value, desc, validator] ()
         {
             std::string key{"\\fBARGUMENT-" + std::to_string(positional_option_count) +
                             "\\fP " + option_type_and_list_info(value)};

--- a/include/seqan3/argument_parser/detail/format_parse.hpp
+++ b/include/seqan3/argument_parser/detail/format_parse.hpp
@@ -93,7 +93,7 @@ public:
                     option_spec const & spec,
                     validator_type && validator)
     {
-        option_calls.push_back([=, &value]()
+        option_calls.push_back([this, &value, short_id, long_id, spec, validator]()
         {
             get_option(value, short_id, long_id, spec, validator);
         });
@@ -113,7 +113,7 @@ public:
                   std::string const & /*desc*/,
                   option_spec const & /*spec*/)
     {
-        flag_calls.push_back([=, &value]()
+        flag_calls.push_back([this, &value, short_id, long_id]()
         {
             get_flag(value, short_id, long_id);
         });
@@ -134,7 +134,7 @@ public:
                                std::string const & /*desc*/,
                                validator_type && validator)
     {
-        positional_option_calls.push_back([=, &value]()
+        positional_option_calls.push_back([this, &value, validator]()
         {
             get_positional_option(value, validator);
         });

--- a/include/seqan3/core/concept/core_language.hpp
+++ b/include/seqan3/core/concept/core_language.hpp
@@ -14,9 +14,6 @@
 
 #include <type_traits>
 
-#include <range/v3/range_concepts.hpp>
-#include <range/v3/utility/functional.hpp>
-
 #include <seqan3/core/platform.hpp>
 #include <seqan3/std/concepts>
 #include <seqan3/std/ranges>

--- a/include/seqan3/core/metafunction/basic.hpp
+++ b/include/seqan3/core/metafunction/basic.hpp
@@ -12,10 +12,8 @@
 
 #pragma once
 
+#include <tuple>
 #include <type_traits>
-
-#include <range/v3/utility/iterator_traits.hpp>
-#include <range/v3/range_traits.hpp>
 
 #include <seqan3/core/platform.hpp>
 

--- a/include/seqan3/core/metafunction/iterator.hpp
+++ b/include/seqan3/core/metafunction/iterator.hpp
@@ -15,8 +15,6 @@
 #include <iterator>
 #include <type_traits>
 
-#include <range/v3/utility/iterator_traits.hpp>
-
 #include <seqan3/core/platform.hpp>
 #include <seqan3/core/metafunction/pre.hpp>
 #include <seqan3/std/iterator>

--- a/include/seqan3/core/metafunction/range.hpp
+++ b/include/seqan3/core/metafunction/range.hpp
@@ -14,9 +14,6 @@
 
 #include <type_traits>
 
-#include <range/v3/utility/iterator_traits.hpp>
-#include <range/v3/range_traits.hpp>
-
 #include <seqan3/core/platform.hpp>
 #include <seqan3/core/metafunction/pre.hpp>
 #include <seqan3/core/metafunction/basic.hpp>

--- a/include/seqan3/core/platform.hpp
+++ b/include/seqan3/core/platform.hpp
@@ -29,6 +29,10 @@
 #   error "This is not a C++ compiler."
 #endif
 
+#if __has_include(<version>)
+#   include <version>
+#endif
+
 // C++ Concepts [required]
 #ifdef __cpp_concepts
 #   if __cpp_concepts == 201507 // GCC and Concepts TS

--- a/include/seqan3/io/alignment_file/output.hpp
+++ b/include/seqan3/io/alignment_file/output.hpp
@@ -262,7 +262,7 @@ public:
     //!\brief The const iterator type is void, because files are not const-iterable.
     using const_iterator    = void;
     //!\brief The type returned by end().
-    using sentinel          = std::ranges::default_sentinel;
+    using sentinel          = std::ranges::default_sentinel_t;
     //!\}
 
     /*!\name Constructors, destructor and assignment

--- a/include/seqan3/io/detail/in_file_iterator.hpp
+++ b/include/seqan3/io/detail/in_file_iterator.hpp
@@ -36,7 +36,7 @@ namespace seqan3::detail
  * previous iterators are always invalid (all iterators point to the current position in single-pass
  * ranges).
  *
- * This iterator may be compared against std::ranges::default_sentinel, this check delegates to
+ * This iterator may be compared against std::ranges::default_sentinel_t, this check delegates to
  * calling the `eof()` member function on the file's stream.
  */
 template <typename file_type>
@@ -118,28 +118,28 @@ public:
      * \brief Only (in-)equality comparison of iterator with end() is supported.
      * \{
      */
-    constexpr bool operator==(std::ranges::default_sentinel const &) const noexcept
+    constexpr bool operator==(std::ranges::default_sentinel_t const &) const noexcept
     {
         assert(host != nullptr);
         return host->at_end;
     }
 
-    constexpr bool operator!=(std::ranges::default_sentinel const &) const noexcept
+    constexpr bool operator!=(std::ranges::default_sentinel_t const &) const noexcept
     {
         assert(host != nullptr);
         return !host->at_end;
     }
 
-    constexpr friend bool operator==(std::ranges::default_sentinel const &,
+    constexpr friend bool operator==(std::ranges::default_sentinel_t const &,
                                      in_file_iterator const & it) noexcept
     {
-        return (it == std::ranges::default_sentinel{});
+        return (it == std::ranges::default_sentinel);
     }
 
-    constexpr friend bool operator!=(std::ranges::default_sentinel const &,
+    constexpr friend bool operator!=(std::ranges::default_sentinel_t const &,
                                      in_file_iterator const & it) noexcept
     {
-        return (it != std::ranges::default_sentinel{});
+        return (it != std::ranges::default_sentinel);
     }
     //!\}
 

--- a/include/seqan3/io/detail/misc_input.hpp
+++ b/include/seqan3/io/detail/misc_input.hpp
@@ -100,7 +100,7 @@ inline auto make_secondary_istream(std::basic_istream<char_t> & primary_stream, 
     {
     #ifdef SEQAN3_HAS_ZLIB
         if ((extension == ".gz") || (extension == ".bgzf"))
-            filename.replace_extension("");
+            filename.replace_extension();
 
         return {new contrib::basic_gz_istream<char_t>{primary_stream}, stream_deleter_default};
     #else
@@ -111,7 +111,7 @@ inline auto make_secondary_istream(std::basic_istream<char_t> & primary_stream, 
     {
     #ifdef SEQAN3_HAS_BZIP2
         if (extension == ".bz2")
-            filename.replace_extension("");
+            filename.replace_extension();
 
         return {new contrib::basic_bz2_istream<char_t>{primary_stream}, stream_deleter_default};
     #else

--- a/include/seqan3/io/detail/out_file_iterator.hpp
+++ b/include/seqan3/io/detail/out_file_iterator.hpp
@@ -126,26 +126,26 @@ public:
      * \brief This iterator never equals its sentinel.
      * \{
      */
-    constexpr bool operator==(std::ranges::default_sentinel const &) const noexcept
+    constexpr bool operator==(std::ranges::default_sentinel_t const &) const noexcept
     {
         return false;
     }
 
-    constexpr bool operator!=(std::ranges::default_sentinel const &) const noexcept
+    constexpr bool operator!=(std::ranges::default_sentinel_t const &) const noexcept
     {
         return true;
     }
 
-    constexpr friend bool operator==(std::ranges::default_sentinel const &,
+    constexpr friend bool operator==(std::ranges::default_sentinel_t const &,
                                      out_file_iterator const & it) noexcept
     {
-        return (it == std::ranges::default_sentinel{});
+        return (it == std::ranges::default_sentinel);
     }
 
-    constexpr friend bool operator!=(std::ranges::default_sentinel const &,
+    constexpr friend bool operator!=(std::ranges::default_sentinel_t const &,
                                      out_file_iterator const & it) noexcept
     {
-        return (it != std::ranges::default_sentinel{});
+        return (it != std::ranges::default_sentinel);
     }
     //!\}
 

--- a/include/seqan3/io/sequence_file/format_fasta.hpp
+++ b/include/seqan3/io/sequence_file/format_fasta.hpp
@@ -18,7 +18,6 @@
 #include <vector>
 
 #include <range/v3/algorithm/copy.hpp>
-#include <range/v3/utility/iterator.hpp>
 #include <range/v3/view/chunk.hpp>
 #include <range/v3/view/drop_while.hpp>
 #include <range/v3/view/join.hpp>

--- a/include/seqan3/io/sequence_file/format_fastq.hpp
+++ b/include/seqan3/io/sequence_file/format_fastq.hpp
@@ -18,7 +18,6 @@
 #include <vector>
 
 #include <range/v3/algorithm/copy.hpp>
-#include <range/v3/utility/iterator.hpp>
 #include <range/v3/view/chunk.hpp>
 #include <range/v3/view/join.hpp>
 #include <range/v3/view/remove_if.hpp>

--- a/include/seqan3/io/sequence_file/input.hpp
+++ b/include/seqan3/io/sequence_file/input.hpp
@@ -553,7 +553,7 @@ public:
     //!\brief The const iterator type is void, because files are not const-iterable.
     using const_iterator    = void;
     //!\brief The type returned by end().
-    using sentinel          = std::ranges::default_sentinel;
+    using sentinel          = std::ranges::default_sentinel_t;
     //!\}
 
     /*!\name Constructors, destructor and assignment

--- a/include/seqan3/io/sequence_file/output.hpp
+++ b/include/seqan3/io/sequence_file/output.hpp
@@ -293,7 +293,7 @@ public:
     //!\brief The const iterator type is void, because files are not const-iterable.
     using const_iterator    = void;
     //!\brief The type returned by end().
-    using sentinel          = std::ranges::default_sentinel;
+    using sentinel          = std::ranges::default_sentinel_t;
     //!\}
 
     /*!\name Constructors, destructor and assignment

--- a/include/seqan3/io/stream/concept.hpp
+++ b/include/seqan3/io/stream/concept.hpp
@@ -15,7 +15,7 @@
 #include <ios>
 #include <type_traits>
 
-#include <range/v3/utility/associated_types.hpp>
+#include <range/v3/iterator/associated_types.hpp>
 
 #include <seqan3/core/platform.hpp>
 

--- a/include/seqan3/io/stream/parse_condition_detail.hpp
+++ b/include/seqan3/io/stream/parse_condition_detail.hpp
@@ -52,7 +52,7 @@ public:
         for (size_t i = 0; i < N; ++i)
             rhs[i] = rhs[i] || base_t::operator[](i);
 
-        return std::move(rhs);
+        return rhs;
     }
     //!\brief Return a new bitset with all bits flipped.
     constexpr constexpr_pseudo_bitset operator~() const noexcept

--- a/include/seqan3/io/structure_file/format_vienna.hpp
+++ b/include/seqan3/io/structure_file/format_vienna.hpp
@@ -21,7 +21,6 @@
 #include <vector>
 
 #include <range/v3/algorithm/copy.hpp>
-#include <range/v3/utility/iterator.hpp>
 #include <range/v3/view/chunk.hpp>
 #include <range/v3/view/drop_while.hpp>
 #include <range/v3/view/join.hpp>

--- a/include/seqan3/io/structure_file/input.hpp
+++ b/include/seqan3/io/structure_file/input.hpp
@@ -789,7 +789,7 @@ public:
     //!\brief The const iterator type is void, because files are not const-iterable.
     using const_iterator  = void;
     //!\brief The type returned by end().
-    using sentinel        = std::ranges::default_sentinel;
+    using sentinel        = std::ranges::default_sentinel_t;
     //!\}
 
     /*!\name Constructors, destructor and assignment

--- a/include/seqan3/io/structure_file/output.hpp
+++ b/include/seqan3/io/structure_file/output.hpp
@@ -312,7 +312,7 @@ public:
     //!\brief The const iterator type is void, because files are not const-iterable.
     using const_iterator    = void;
     //!\brief The type returned by end().
-    using sentinel          = std::ranges::default_sentinel;
+    using sentinel          = std::ranges::default_sentinel_t;
     //!\}
 
     /*!\name Constructors, destructor and assignment

--- a/include/seqan3/range/container/bitcompressed_vector.hpp
+++ b/include/seqan3/range/container/bitcompressed_vector.hpp
@@ -14,8 +14,6 @@
 
 #include <type_traits>
 
-#include <range/v3/iterator_range.hpp>
-
 #include <sdsl/int_vector.hpp>
 
 #include <seqan3/alphabet/detail/alphabet_proxy.hpp>

--- a/include/seqan3/range/container/bitcompressed_vector.hpp
+++ b/include/seqan3/range/container/bitcompressed_vector.hpp
@@ -30,6 +30,7 @@
 #include <seqan3/std/concepts>
 #include <seqan3/std/iterator>
 #include <seqan3/std/ranges>
+#include <seqan3/std/view/subrange.hpp>
 
 namespace seqan3
 {
@@ -118,7 +119,7 @@ private:
          * \brief All are explicitly defaulted.
          * \{
          */
-        constexpr reference_proxy_type() noexcept : base_t{} {}
+        constexpr reference_proxy_type() noexcept : base_t{}, internal_proxy{} {}
         constexpr reference_proxy_type(reference_proxy_type const &) = default;
         constexpr reference_proxy_type(reference_proxy_type &&) = default;
         constexpr reference_proxy_type & operator=(reference_proxy_type const &) = default;
@@ -755,7 +756,9 @@ public:
     {
         auto const pos_as_num = std::distance(cbegin(), pos);
 
-        auto v = std::ranges::iterator_range{begin_it, end_it} | seqan3::view::convert<value_type> | seqan3::view::to_rank;
+        auto v = view::subrange<begin_iterator_type, end_iterator_type>{begin_it, end_it}
+               | view::convert<value_type>
+               | view::to_rank;
         data.insert(data.begin() + pos_as_num, seqan3::begin(v), seqan3::end(v));
 
         return begin() + pos_as_num;

--- a/include/seqan3/range/container/concatenated_sequences.hpp
+++ b/include/seqan3/range/container/concatenated_sequences.hpp
@@ -28,6 +28,7 @@
 #include <seqan3/std/iterator>
 #include <seqan3/std/ranges>
 #include <seqan3/std/view/common.hpp>
+#include <seqan3/std/view/subrange.hpp>
 
 #if SEQAN3_WITH_CEREAL
 #include <cereal/types/vector.hpp>
@@ -971,7 +972,9 @@ public:
         if (last - first == 0)
             return begin() + pos_as_num;
 
-        auto const ilist = std::ranges::make_iterator_range(first, last, std::distance(first, last));
+        auto const ilist = view::subrange<begin_iterator_type, end_iterator_type>(first,
+                                                                                  last,
+                                                                                  std::distance(first, last));
 
         data_delimiters.reserve(data_values.size() + ilist.size());
         data_delimiters.insert(data_delimiters.begin() + pos_as_num,

--- a/include/seqan3/range/container/concept.hpp
+++ b/include/seqan3/range/container/concept.hpp
@@ -150,7 +150,7 @@ SEQAN3_CONCEPT container_concept = requires (type val, type val2, type const cva
     { type{}          } -> type;   // default constructor
     { type{type{}}    } -> type;   // copy/move constructor
     { val = val2      } -> type &; // assignment
-    { (&val)->~type() } -> void;   // destructor
+    { (&val)->~type() };           // destructor
 
     { val.begin()     } -> typename type::iterator;
     { val.end()       } -> typename type::iterator;

--- a/include/seqan3/range/detail/inherited_iterator_base.hpp
+++ b/include/seqan3/range/detail/inherited_iterator_base.hpp
@@ -15,10 +15,6 @@
 #include <cassert>
 #include <type_traits>
 
-#include <range/v3/utility/iterator_traits.hpp>
-#include <range/v3/range_traits.hpp>
-
-#include <seqan3/std/ranges>
 #include <seqan3/std/iterator>
 
 namespace seqan3::detail

--- a/include/seqan3/range/detail/random_access_iterator.hpp
+++ b/include/seqan3/range/detail/random_access_iterator.hpp
@@ -15,9 +15,6 @@
 #include <cassert>
 #include <type_traits>
 
-#include <range/v3/utility/iterator_traits.hpp>
-#include <range/v3/range_traits.hpp>
-
 #include <seqan3/std/iterator>
 
 namespace seqan3::detail

--- a/include/seqan3/range/view/persist.hpp
+++ b/include/seqan3/range/view/persist.hpp
@@ -149,7 +149,7 @@ public:
     template <sequence_container_concept container_t>
     operator container_t() const
     //!\cond
-        requires std::CommonReference<reference_t<container_t>, reference> && const_iterable_concept<urng_t>
+        requires std::CommonReference<reference_t<std::remove_reference_t<container_t>>, reference>
     //!\endcond
     {
         container_t ret;

--- a/include/seqan3/range/view/take.hpp
+++ b/include/seqan3/range/view/take.hpp
@@ -176,6 +176,7 @@ private:
          * \{
          */
         bool operator==(iterator_type const & rhs) const noexcept(!or_throw)
+            requires std::ForwardIterator<base_base_t>
         {
             return static_cast<base_base_t>(*this) == static_cast<base_base_t>(rhs);
         }
@@ -209,6 +210,7 @@ private:
         }
 
         bool operator!=(iterator_type const & rhs) const noexcept(!or_throw)
+            requires std::ForwardIterator<base_base_t>
         {
             return static_cast<base_base_t>(*this) != static_cast<base_base_t>(rhs);
         }

--- a/include/seqan3/range/view/take_line.hpp
+++ b/include/seqan3/range/view/take_line.hpp
@@ -141,6 +141,7 @@ private:
          * \{
          */
         bool operator==(iterator_type const & rhs) const noexcept(!require_eol)
+            requires std::ForwardIterator<base_base_t>
         {
             return static_cast<base_base_t>(*this) == static_cast<base_base_t>(rhs);
         }
@@ -176,6 +177,7 @@ private:
         }
 
         bool operator!=(iterator_type const & rhs) const noexcept(!require_eol)
+            requires std::ForwardIterator<base_base_t>
         {
             return static_cast<base_base_t>(*this) != static_cast<base_base_t>(rhs);
         }

--- a/include/seqan3/range/view/take_until.hpp
+++ b/include/seqan3/range/view/take_until.hpp
@@ -129,6 +129,7 @@ private:
          * \{
          */
         bool operator==(iterator_type const & rhs) const noexcept(!or_throw)
+            requires std::ForwardIterator<base_base_t>
         {
             return static_cast<base_base_t>(*this) == static_cast<base_base_t>(rhs);
         }
@@ -157,6 +158,7 @@ private:
         }
 
         bool operator!=(iterator_type const & rhs) const noexcept(!or_throw)
+            requires std::ForwardIterator<base_base_t>
         {
             return static_cast<base_base_t>(*this) != static_cast<base_base_t>(rhs);
         }

--- a/include/seqan3/range/view/to_char.hpp
+++ b/include/seqan3/range/view/to_char.hpp
@@ -58,7 +58,7 @@ namespace seqan3::view
  * \snippet test/snippet/range/view/rank_char.cpp to_char
  * \hideinitializer
  */
-inline auto const to_char = deep{view::transform([] (auto const in)
+inline auto const to_char = deep{view::transform([] (auto const in) noexcept
 {
     static_assert(alphabet_concept<remove_cvref_t<decltype(in)>>, "The value type of seqan3::view::to_char must model the seqan3::alphabet_concept.");
     return seqan3::to_char(in);

--- a/include/seqan3/range/view/to_rank.hpp
+++ b/include/seqan3/range/view/to_rank.hpp
@@ -60,7 +60,7 @@ namespace seqan3::view
  * often implemented as `unsigned char` and thus will not be printed as a number by default.
  * \hideinitializer
  */
-inline auto const to_rank = deep{view::transform([] (auto const in)
+inline auto const to_rank = deep{view::transform([] (auto const in) noexcept
 {
     static_assert(alphabet_concept<remove_cvref_t<decltype(in)>>, "The value type of seqan3::view::to_rank must model the seqan3::alphabet_concept.");
     return seqan3::to_rank(in);

--- a/include/seqan3/std/concepts
+++ b/include/seqan3/std/concepts
@@ -12,7 +12,9 @@
 
 #pragma once
 
-#if __has_include(<concepts>) // C++20 concepts available
+#include <seqan3/core/platform.hpp>
+
+#ifdef __cpp_lib_concepts        // C++20 ranges available
 #include <concepts>
 #else                         // use range-v3 to emulate
 
@@ -21,7 +23,6 @@
 
 #include <range/v3/utility/common_type.hpp>
 
-#include <seqan3/core/platform.hpp>
 #include <seqan3/core/metafunction/basic.hpp>
 
 /*!\defgroup std std

--- a/include/seqan3/std/iterator
+++ b/include/seqan3/std/iterator
@@ -16,7 +16,8 @@
 
 #ifndef __cpp_lib_ranges
 
-#include <range/v3/utility/iterator.hpp>
+#include <range/v3/iterator/insert_iterators.hpp>
+#include <range/v3/iterator/stream_iterators.hpp>
 
 #include <seqan3/std/concepts>
 
@@ -135,7 +136,8 @@ constexpr auto back_inserter(container_t & container)
  */
 //!\cond
 template <typename t>
-SEQAN3_CONCEPT Readable = static_cast<bool>(::ranges::Readable<t>());
+SEQAN3_CONCEPT Readable = ::ranges::Readable<t>;
+
 //!\endcond
 
 /*!\interface std::Writable <>
@@ -145,7 +147,7 @@ SEQAN3_CONCEPT Readable = static_cast<bool>(::ranges::Readable<t>());
  */
 //!\cond
 template <typename out, typename t>
-SEQAN3_CONCEPT Writable = static_cast<bool>(::ranges::Writable<out, t>());
+SEQAN3_CONCEPT Writable = ::ranges::Writable<out, t>;
 //!\endcond
 
 /*!\interface std::WeaklyIncrementable <>
@@ -177,7 +179,7 @@ SEQAN3_CONCEPT WeaklyIncrementable = Semiregular<t> &&
  */
 //!\cond
 template <typename i>
-SEQAN3_CONCEPT Incrementable = Regular<i> && WeaklyIncrementable<i> && static_cast<bool>(::ranges::Incrementable<i>());
+SEQAN3_CONCEPT Incrementable = Regular<i> && WeaklyIncrementable<i> && ::ranges::Incrementable<i>;
 //!\endcond
 
 /*!\interface std::Iterator <>
@@ -188,7 +190,7 @@ SEQAN3_CONCEPT Incrementable = Regular<i> && WeaklyIncrementable<i> && static_ca
  */
 //!\cond
 template <typename i>
-SEQAN3_CONCEPT Iterator = WeaklyIncrementable<i> && static_cast<bool>(::ranges::Iterator<i>());
+SEQAN3_CONCEPT Iterator = WeaklyIncrementable<i> && ::ranges::Iterator<i>;
 //!\endcond
 
 /*!\interface std::Sentinel <>
@@ -200,7 +202,7 @@ SEQAN3_CONCEPT Iterator = WeaklyIncrementable<i> && static_cast<bool>(::ranges::
  */
 //!\cond
 template <typename s, typename i>
-SEQAN3_CONCEPT Sentinel = Semiregular<s> && Iterator<i> && static_cast<bool>(::ranges::Sentinel<s, i>());
+SEQAN3_CONCEPT Sentinel = Semiregular<s> && Iterator<i> && ::ranges::Sentinel<s, i>;
 //!\endcond
 
 /*!\interface std::SizedSentinel <>
@@ -211,7 +213,7 @@ SEQAN3_CONCEPT Sentinel = Semiregular<s> && Iterator<i> && static_cast<bool>(::r
  */
 //!\cond
 template <typename s, typename i>
-SEQAN3_CONCEPT SizedSentinel = Sentinel<s, i> && static_cast<bool>(::ranges::SizedSentinel<s, i>());
+SEQAN3_CONCEPT SizedSentinel = Sentinel<s, i> && ::ranges::SizedSentinel<s, i>;
 //!\endcond
 
 /*!\interface std::OutputIterator <>
@@ -224,7 +226,7 @@ SEQAN3_CONCEPT SizedSentinel = Sentinel<s, i> && static_cast<bool>(::ranges::Siz
  */
 //!\cond
 template <typename out, typename t>
-SEQAN3_CONCEPT OutputIterator = Iterator<out> && Writable<out, t> && static_cast<bool>(::ranges::OutputIterator<out, t>());
+SEQAN3_CONCEPT OutputIterator = Iterator<out> && Writable<out, t> && ::ranges::OutputIterator<out, t>;
 //!\endcond
 
 /*!\interface std::InputIterator <>
@@ -236,7 +238,7 @@ SEQAN3_CONCEPT OutputIterator = Iterator<out> && Writable<out, t> && static_cast
  */
 //!\cond
 template <typename i>
-SEQAN3_CONCEPT InputIterator = Iterator<i> && Readable<i> && static_cast<bool>(::ranges::InputIterator<i>());
+SEQAN3_CONCEPT InputIterator = Iterator<i> && Readable<i> && ::ranges::InputIterator<i>;
 //!\endcond
 
 /*!\interface std::ForwardIterator <>
@@ -252,7 +254,7 @@ template <typename i>
 SEQAN3_CONCEPT ForwardIterator = InputIterator<i> &&
                                Incrementable<i> &&
                                Sentinel<i, i> &&
-                               static_cast<bool>(::ranges::ForwardIterator<i>());
+                               ::ranges::ForwardIterator<i>;
 //!\endcond
 
 /*!\interface std::BidirectionalIterator <>
@@ -263,7 +265,7 @@ SEQAN3_CONCEPT ForwardIterator = InputIterator<i> &&
  */
 //!\cond
 template <typename i>
-SEQAN3_CONCEPT BidirectionalIterator = ForwardIterator<i> && static_cast<bool>(::ranges::BidirectionalIterator<i>());
+SEQAN3_CONCEPT BidirectionalIterator = ForwardIterator<i> && ::ranges::BidirectionalIterator<i>;
 //!\endcond
 
 /*!\interface std::RandomAccessIterator <>
@@ -280,7 +282,7 @@ template <typename i>
 SEQAN3_CONCEPT RandomAccessIterator = BidirectionalIterator<i> &&
                                     StrictTotallyOrdered<i> &&
                                     SizedSentinel<i, i> &&
-                                    static_cast<bool>(::ranges::RandomAccessIterator<i>());
+                                    ::ranges::RandomAccessIterator<i>;
 //!\endcond
 
 //!\} // Iterator Concepts.

--- a/include/seqan3/std/ranges
+++ b/include/seqan3/std/ranges
@@ -12,19 +12,20 @@
 
 #pragma once
 
-#if __has_include(<ranges>) // C++20 ranges available
+#include <seqan3/core/platform.hpp>
+
+#if __cpp_lib_ranges // C++20 ranges available
 #include <ranges>
 #else // implement via range-v3
 
-#include <range/v3/range_concepts.hpp>
-#include <range/v3/empty.hpp>
-#include <range/v3/iterator_range.hpp>
+#include <range/v3/range/concepts.hpp>
+#include <range/v3/iterator/default_sentinel.hpp>
+#include <range/v3/iterator/insert_iterators.hpp>
+#include <range/v3/iterator/stream_iterators.hpp>
 #include <range/v3/algorithm/copy.hpp>
 #include <range/v3/algorithm/equal.hpp>
 #include <range/v3/view/any_view.hpp>
 #include <range/v3/view/reverse.hpp>
-
-#include <seqan3/core/platform.hpp>
 
 /*!\defgroup ranges ranges
  * \ingroup std
@@ -43,7 +44,7 @@ namespace std::ranges
  */
 //!\cond
 template <typename type>
-SEQAN3_CONCEPT Range = (bool)::ranges::Range<type>();
+SEQAN3_CONCEPT Range = ::ranges::Range<type>;
 //!\endcond
 
 /*!\interface std::ranges::SizedRange <>
@@ -53,7 +54,7 @@ SEQAN3_CONCEPT Range = (bool)::ranges::Range<type>();
  */
 //!\cond
 template <typename type>
-SEQAN3_CONCEPT SizedRange = Range<type> && (bool)::ranges::SizedRange<type>();
+SEQAN3_CONCEPT SizedRange = Range<type> && ::ranges::SizedRange<type>;
 //!\endcond
 
 /*!\interface std::ranges::CommonRange  <>
@@ -63,7 +64,7 @@ SEQAN3_CONCEPT SizedRange = Range<type> && (bool)::ranges::SizedRange<type>();
  */
 //!\cond
 template <typename type>
-SEQAN3_CONCEPT CommonRange = Range<type> && (bool)::ranges::BoundedRange<type>();
+SEQAN3_CONCEPT CommonRange = Range<type> && ::ranges::CommonRange<type>;
 //!\endcond
 
 /*!\interface std::ranges::OutputRange <>
@@ -74,7 +75,7 @@ SEQAN3_CONCEPT CommonRange = Range<type> && (bool)::ranges::BoundedRange<type>()
  */
 //!\cond
 template <typename type, typename out_type>
-SEQAN3_CONCEPT OutputRange = Range<type> && (bool)::ranges::OutputRange<type, out_type>();
+SEQAN3_CONCEPT OutputRange = Range<type> && ::ranges::OutputRange<type, out_type>;
 //!\endcond
 
 /*!\interface std::ranges::InputRange <>
@@ -85,7 +86,7 @@ SEQAN3_CONCEPT OutputRange = Range<type> && (bool)::ranges::OutputRange<type, ou
  */
 //!\cond
 template <typename type>
-SEQAN3_CONCEPT InputRange = Range<type> && (bool)::ranges::InputRange<type>();
+SEQAN3_CONCEPT InputRange = Range<type> && ::ranges::InputRange<type>;
 //!\endcond
 
 /*!\interface std::ranges::ForwardRange <>
@@ -96,7 +97,7 @@ SEQAN3_CONCEPT InputRange = Range<type> && (bool)::ranges::InputRange<type>();
  */
 //!\cond
 template <typename type>
-SEQAN3_CONCEPT ForwardRange = InputRange<type> && (bool)::ranges::ForwardRange<type>();
+SEQAN3_CONCEPT ForwardRange = InputRange<type> && ::ranges::ForwardRange<type>;
 //!\endcond
 
 /*!\interface std::ranges::BidirectionalRange <>
@@ -107,7 +108,7 @@ SEQAN3_CONCEPT ForwardRange = InputRange<type> && (bool)::ranges::ForwardRange<t
  */
 //!\cond
 template <typename type>
-SEQAN3_CONCEPT BidirectionalRange = ForwardRange<type> && (bool)::ranges::BidirectionalRange<type>();
+SEQAN3_CONCEPT BidirectionalRange = ForwardRange<type> && ::ranges::BidirectionalRange<type>;
 //!\endcond
 
 /*!\interface std::ranges::RandomAccessRange <>
@@ -118,7 +119,7 @@ SEQAN3_CONCEPT BidirectionalRange = ForwardRange<type> && (bool)::ranges::Bidire
  */
 //!\cond
 template <typename type>
-SEQAN3_CONCEPT RandomAccessRange = BidirectionalRange<type> && (bool)::ranges::RandomAccessRange<type>();
+SEQAN3_CONCEPT RandomAccessRange = BidirectionalRange<type> && ::ranges::RandomAccessRange<type>;
 //!\endcond
 
 /*!\interface std::ranges::ContiguousRange <>
@@ -127,7 +128,7 @@ SEQAN3_CONCEPT RandomAccessRange = BidirectionalRange<type> && (bool)::ranges::R
  */
 //!\cond
 template <typename type>
-SEQAN3_CONCEPT ContiguousRange = RandomAccessRange<type> && (bool)::ranges::ContiguousRange<type>();
+SEQAN3_CONCEPT ContiguousRange = RandomAccessRange<type> && ::ranges::ContiguousRange<type>;
 //!\endcond
 
 /*!\interface std::ranges::View <>
@@ -139,7 +140,7 @@ SEQAN3_CONCEPT ContiguousRange = RandomAccessRange<type> && (bool)::ranges::Cont
  */
 //!\cond
 template <typename type>
-SEQAN3_CONCEPT View = Range<type> && (bool)::ranges::View<type>();
+SEQAN3_CONCEPT View = Range<type> && ::ranges::View<type>;
 //!\endcond
 
 /*!\interface std::ranges::ViewableRange <>
@@ -183,9 +184,14 @@ using SEQAN3_DOXYGEN_ONLY(empty =) ::ranges::empty;
 using SEQAN3_DOXYGEN_ONLY(equal =) ::ranges::equal;
 
 /*!\typedef std::ranges::default_sentinel
-* \brief Alias for ranges::default_sentinel. Empty sentinel type for use with iterator types that know the bound of their range.
+* \brief Alias for ranges::default_sentinel. Empty sentinel object for use with iterators that know the bound of their range.
 */
 using SEQAN3_DOXYGEN_ONLY(default_sentinel =) ::ranges::default_sentinel;
+
+/*!\typedef std::ranges::default_sentinel_t
+* \brief Alias for ranges::default_sentinel_t. Type of ranges::default_sentinel.
+*/
+using SEQAN3_DOXYGEN_ONLY(default_sentinel_t =) ::ranges::default_sentinel_t;
 
 /*!\typedef std::ranges::sentinel_t
 * \brief Alias for ranges::sentinel_t. Obtains the sentinel type of a range.
@@ -202,16 +208,6 @@ using SEQAN3_DOXYGEN_ONLY(iterator_t =) ::ranges::iterator_t;
 */
 using SEQAN3_DOXYGEN_ONLY(ostreambuf_iterator =) ::ranges::ostreambuf_iterator;
 
-/*!\typedef std::ranges::iterator_range
-* \brief Alias for ranges::iterator_range. Iterator adaptor for a Range type.
-*/
-using SEQAN3_DOXYGEN_ONLY(iterator_range =) ::ranges::iterator_range;
-
-/*!\typedef std::ranges::make_iterator_range
-* \brief Alias for ranges::make_iterator_range. Makes the iterator adaptor.
-*/
-using SEQAN3_DOXYGEN_ONLY(make_iterator_range =) ::ranges::make_iterator_range;
-
 /*!\typedef std::ranges::cbegin
 * \brief Alias for ranges::cbegin. Returns an iterator to the beginning of a range.
 */
@@ -221,11 +217,6 @@ using SEQAN3_DOXYGEN_ONLY(cbegin =) ::ranges::cbegin;
 * \brief Alias for ranges::cend. Returns an iterator to the end of a range.
 */
 using SEQAN3_DOXYGEN_ONLY(cend =) ::ranges::cend;
-
-/*!\typedef std::ranges::istream_range
-* \brief Alias for ranges::istream_range. Istream adaptor for a Range type.
-*/
-using SEQAN3_DOXYGEN_ONLY(istream_range =) ::ranges::istream_range;
 
 /*!\typedef std::ranges::ostream_iterator
 * \brief Alias for ranges::ostream_iterator. Ostream adaptor for a Range type.

--- a/include/seqan3/std/type_traits
+++ b/include/seqan3/std/type_traits
@@ -14,8 +14,6 @@
 
 #include <type_traits>
 
-#if __cplusplus <= 201810L // TODO feature_test_macro if available
-
 namespace std
 {
 
@@ -29,11 +27,17 @@ namespace std
  * \ingroup type_traits
  */
 template <typename t>
-struct type_identity
+struct type_identity;
+
+//!\cond
+template <typename t>
+    requires true
+struct type_identity<t>
 {
     //!\brief The return type (which is the argument).
     using type = t;
 };
+//!\endcond
 
 //!\brief A shortcut for std::type_identity.
 //!\ingroup type_traits
@@ -41,5 +45,3 @@ template <typename t>
 using type_identity_t = typename type_identity<t>::type;
 
 } // namespace std
-
-#endif // C++17

--- a/include/seqan3/std/view/common.hpp
+++ b/include/seqan3/std/view/common.hpp
@@ -12,7 +12,7 @@
 
 #pragma once
 
-#include <range/v3/view/bounded.hpp>
+#include <range/v3/view/common.hpp>
 
 #include <seqan3/std/iterator>
 
@@ -69,6 +69,6 @@ namespace seqan3::view
  * ```
  * \hideinitializer
  */
-inline constexpr auto common = ranges::view::bounded;
+inline constexpr auto common = ranges::view::common;
 
 } // namespace seqan3::view

--- a/include/seqan3/std/view/subrange.hpp
+++ b/include/seqan3/std/view/subrange.hpp
@@ -12,7 +12,7 @@
 
 #pragma once
 
-#include <range/v3/iterator_range.hpp>
+#include <range/v3/view/subrange.hpp>
 
 #include <seqan3/std/iterator>
 #include <seqan3/std/ranges>
@@ -66,7 +66,7 @@ namespace seqan3::view
  * \hideinitializer
  */
 template <std::Iterator it_t, std::Sentinel<it_t> sen_t>
-using subrange = std::ranges::iterator_range<it_t, sen_t>;
+using subrange = ::ranges::subrange<it_t, sen_t>;
 //TODO change to ranges::subrange once that has arrived
 
 } // namespace seqan3::view

--- a/test/header/CMakeLists.txt
+++ b/test/header/CMakeLists.txt
@@ -103,7 +103,9 @@ seqan3_require_test ()
 
 seqan3_header_test (seqan3 "${SEQAN3_CLONE_DIR}/include")
 seqan3_header_test (seqan3_test "${SEQAN3_CLONE_DIR}/test/include")
-seqan3_header_test (range-v3 "${SEQAN3_CLONE_DIR}/submodules/range-v3/include")
+
+# contains deprecated headers that produce an error when included
+# seqan3_header_test (range-v3 "${SEQAN3_CLONE_DIR}/submodules/range-v3/include")
 
 # not self-contained headers; error: extra ‘;’ [-Werror=pedantic]
 # seqan3_header_test (lemon "${SEQAN3_CLONE_DIR}/submodules/lemon/include")

--- a/test/unit/alignment/pairwise/align_pairwise_test.cpp
+++ b/test/unit/alignment/pairwise/align_pairwise_test.cpp
@@ -18,6 +18,7 @@
 #include <seqan3/alphabet/nucleotide/all.hpp>
 #include <seqan3/core/concept/tuple.hpp>
 #include <seqan3/range/view/to_char.hpp>
+#include <seqan3/std/view/common.hpp>
 
 #include <range/v3/view/generate_n.hpp>
 
@@ -60,7 +61,7 @@ TEST(align_pairwise, single_view_lvalue)
     auto seq2 = "AGTGATACT"_dna4;
 
     // auto p = std::make_pair(seq1, seq2);
-    auto v = ranges::view::single(std::tie(seq1, seq2)) | ranges::view::bounded;
+    auto v = ranges::view::single(std::tie(seq1, seq2)) | view::common;
 
     {  // the score
         configuration cfg = align_cfg::edit | align_cfg::result{align_cfg::with_score};

--- a/test/unit/io/detail/in_file_iterator_test.cpp
+++ b/test/unit/io/detail/in_file_iterator_test.cpp
@@ -97,11 +97,11 @@ TEST(in_file_iterator, comparison)
     it_t it{f};
 
     // not at end
-    EXPECT_FALSE(it == std::ranges::default_sentinel{});
+    EXPECT_FALSE(it == std::ranges::default_sentinel);
 
     // consume the entire range
     ++it; ++it; ++it; ++it; ++it; ++it; ++it;
 
     // at end
-    EXPECT_TRUE(it == std::ranges::default_sentinel{});
+    EXPECT_TRUE(it == std::ranges::default_sentinel);
 }

--- a/test/unit/io/detail/out_file_iterator_test.cpp
+++ b/test/unit/io/detail/out_file_iterator_test.cpp
@@ -83,5 +83,5 @@ TEST(out_file_iterator, comparison)
     it_t it{fake_file};
 
     // never at end
-    EXPECT_FALSE(it == std::ranges::default_sentinel{});
+    EXPECT_FALSE(it == std::ranges::default_sentinel);
 }

--- a/test/unit/io/stream/parse_condition_test.cpp
+++ b/test/unit/io/stream/parse_condition_test.cpp
@@ -22,7 +22,7 @@ struct foo : seqan3::detail::parse_condition_base<foo<char_v>>
 
     using base_t = seqan3::detail::parse_condition_base<foo<char_v>>;
 
-    static auto constexpr data = [&] () { typename base_t::data_t d{}; d[char_v] = true; return d; }();
+    static auto constexpr data = [] () { typename base_t::data_t d{}; d[char_v] = true; return d; }();
 };
 
 template <char char_v>

--- a/test/unit/io/structure_file/structure_file_input_test.cpp
+++ b/test/unit/io/structure_file/structure_file_input_test.cpp
@@ -48,7 +48,7 @@ struct structure_file_input_class : public ::testing::Test
             std::ofstream filecreator{filename.get_path(), std::ios::out | std::ios::binary};
             filecreator << contents; // must contain at least one record
         }
-        return std::move(filename);
+        return filename;
     }
 };
 

--- a/test/unit/range/view/view_single_pass_input_test.cpp
+++ b/test/unit/range/view/view_single_pass_input_test.cpp
@@ -36,11 +36,11 @@ class single_pass_input : public ::testing::Test
         {
             return rng_type{1, 2, 3, 4, 5};
         }
-        else if constexpr (std::is_same_v<std::remove_cv_t<rng_type>, std::ranges::istream_range<char>>)
+        else if constexpr (std::is_same_v<std::remove_cv_t<rng_type>, ranges::istream_view<char>>)
         {
             return std::istringstream{"12345"};
         }
-        else /*(std::is_same_v<rng_type, std::ranges::istream_range<int>>)*/
+        else if constexpr (std::is_same_v<rng_type, ranges::istream_view<int>>)
         {
             return std::istringstream{"1 2 3 4 5"};
         }
@@ -55,8 +55,8 @@ public:
 using underlying_range_types = ::testing::Types<std::vector<char>,
                                                 std::vector<int>,
                                                 std::vector<char> const,
-                                                std::ranges::istream_range<char>,
-                                                std::ranges::istream_range<int>>;
+                                                ranges::istream_view<char>,
+                                                ranges::istream_view<int>>;
 
 TYPED_TEST_CASE(single_pass_input, underlying_range_types);
 

--- a/test/unit/range/view/view_take_line_test.cpp
+++ b/test/unit/range/view/view_take_line_test.cpp
@@ -10,15 +10,12 @@
 #include <gtest/gtest.h>
 
 #include <range/v3/algorithm/copy.hpp>
-#include <range/v3/view/take_while.hpp> //DEBUG
-#include <range/v3/view/unique.hpp> //DEBUG
+#include <range/v3/view/unique.hpp>
 
 #include <seqan3/range/shortcuts.hpp>
 #include <seqan3/range/view/take_line.hpp>
 #include <seqan3/range/view/single_pass_input.hpp>
 #include <seqan3/std/ranges>
-#include <seqan3/std/iterator> //DEBUG
-#include <seqan3/core/detail/reflection.hpp> //DEBUG
 #include <seqan3/range/view/to_char.hpp>
 #include <seqan3/std/view/reverse.hpp>
 #include <seqan3/std/view/common.hpp>

--- a/test/unit/search/fm_index_cursor/fm_index_cursor_collection_test_template.hpp
+++ b/test/unit/search/fm_index_cursor/fm_index_cursor_collection_test_template.hpp
@@ -59,7 +59,7 @@ TYPED_TEST_P(fm_index_cursor_collection_test, ctr)
     EXPECT_EQ(it0.locate().size(), fm.size());
 
     // default construction (does not initialize the cursor)
-    TypeParam it1;
+    [[maybe_unused]] TypeParam it1;
 
     // copy construction
     TypeParam it2{it0};

--- a/test/unit/search/fm_index_cursor/fm_index_cursor_test_template.hpp
+++ b/test/unit/search/fm_index_cursor/fm_index_cursor_test_template.hpp
@@ -59,7 +59,7 @@ TYPED_TEST_P(fm_index_cursor_test, ctr)
     EXPECT_EQ(it0.locate().size(), fm.size());
 
     // default construction (does not initialize the cursor)
-    TypeParam it1;
+    [[maybe_unused]] TypeParam it1;
 
     // copy construction
     TypeParam it2{it0};


### PR DESCRIPTION
Please review, but do not merge, yet. I recommend reviewing commit-by-commit.

We need to have the blockers fixed, before we can merge this (everything builds locally with applied patches in range-v3 and sdsl).

Blockers (GCC7 and GCC8):
  * ~~ericniebler/range-v3#1023~~
  * ~~xxsds/sdsl-lite#57~~
  * ~~xxsds/sdsl-lite#58~~

Blockers (GCC9, fixes available in next snapshot):
  * ~~ericniebler/range-v3#1011~~
  * ~~https://gcc.gnu.org/bugzilla/show_bug.cgi?id=89089~~
  * ~~https://gcc.gnu.org/bugzilla/show_bug.cgi?id=89117~~
