### PR TITLE
[FIX] Restrict PrinTo overload to objects that are streamable with our debug_stream

### DIFF
--- a/test/include/seqan3/test/pretty_printing.hpp
+++ b/test/include/seqan3/test/pretty_printing.hpp
@@ -20,8 +20,16 @@ namespace seqan3
 //!\cond DEV
 //!\brief Overload for the googletest PrintTo function that always delegates to our debug_stream.
 template <typename t>
-    requires true // tricks the compiler to consider this as more specialized than googletests generic PrintTo
+    requires requires (t const & v) { {debug_stream << v}; }
 void PrintTo (t const & v, std::ostream * out)
+{
+    debug_stream_type my_stream{*out};
+    my_stream << v;
+}
+
+template <typename t>
+    requires requires (t && v) { {debug_stream << v}; }
+void PrintTo (t && v, std::ostream * out)
 {
     debug_stream_type my_stream{*out};
     my_stream << v;

--- a/test/unit/io/stream/debug_stream_test.cpp
+++ b/test/unit/io/stream/debug_stream_test.cpp
@@ -15,6 +15,7 @@
 #include <seqan3/io/stream/debug_stream.hpp>
 #include <seqan3/range/container/bitcompressed_vector.hpp>
 #include <seqan3/range/container/concatenated_sequences.hpp>
+#include <seqan3/std/view/view_all.hpp>
 
 using namespace seqan3;
 
@@ -99,10 +100,15 @@ TEST(debug_stream, range_of_alphabet)
     o.flush();
     EXPECT_EQ(o.str(), "AGGATACAGGATACAGGATAC");
 
+    // print view
+    my_stream << view::all(d2);
+    o.flush();
+    EXPECT_EQ(o.str(), "AGGATACAGGATACAGGATACAGGATAC");
+
     concatenated_sequences<bitcompressed_vector<dna5>> const vec2 = {"ACGT"_dna5, "GAGGA"_dna5};
     my_stream << vec2;
     o.flush();
-    EXPECT_EQ(o.str(), "AGGATACAGGATACAGGATAC[ACGT,GAGGA]");
+    EXPECT_EQ(o.str(), "AGGATACAGGATACAGGATACAGGATAC[ACGT,GAGGA]");
 }
 
 TEST(debug_stream, std_endl)

--- a/test/unit/test/pretty_printing_test.cpp
+++ b/test/unit/test/pretty_printing_test.cpp
@@ -25,3 +25,25 @@ TEST(debug_stream, basic)
 
     EXPECT_EQ((testing::internal::GetCapturedStdout()), "aAGA(42,-10)");
 }
+
+namespace seqan3 {
+
+struct foo
+{
+    int f{0};
+
+    bool operator==(foo const & fo) const
+    {
+        return f == fo.f;
+    }
+};
+
+using myint = int;
+
+}
+
+TEST(debug_stream, not_printable_with_debug_stream)
+{
+    foo f1{};
+    EXPECT_EQ(f1, f1);
+}


### PR DESCRIPTION
upsi