### PR TITLE
performance units in benchmarks

### DIFF
--- a/test/header/CMakeLists.txt
+++ b/test/header/CMakeLists.txt
@@ -61,6 +61,7 @@ macro (seqan3_header_test component header_base_path)
 #include <${header}>
 #include <${header}>
 #include <gtest/gtest.h>
+#include <benchmark/benchmark.h>
 TEST(${header_test_name_safe}) {}")
             # test that seqan3 headers include platform.hpp
             if ("${component}" MATCHES "seqan3")
@@ -72,11 +73,15 @@ TEST(${header_test_name_safe}) {}")
 
             add_library (${header_target} OBJECT "${header_target_source}")
             # NOTE: a simple target_link_libraries (${header_target} seqan3::test::header)
-            # is not possible for OBJECT libraries
-            target_compile_options (${header_target} PRIVATE $<TARGET_PROPERTY:seqan3::test::header,INTERFACE_COMPILE_OPTIONS>)
-            target_compile_definitions (${header_target} PRIVATE $<TARGET_PROPERTY:seqan3::test::header,INTERFACE_COMPILE_DEFINITIONS>)
-            target_include_directories (${header_target} PRIVATE $<TARGET_PROPERTY:seqan3::test::header,INTERFACE_INCLUDE_DIRECTORIES>)
-            add_dependencies (${header_target} gtest)
+            # is not possible for OBJECT libraries before cmake 3.12
+            if (CMAKE_VERSION VERSION_LESS 3.12)
+                target_compile_options (${header_target} PRIVATE $<TARGET_PROPERTY:seqan3::test::header,INTERFACE_COMPILE_OPTIONS>)
+                target_compile_definitions (${header_target} PRIVATE $<TARGET_PROPERTY:seqan3::test::header,INTERFACE_COMPILE_DEFINITIONS>)
+                target_include_directories (${header_target} PRIVATE $<TARGET_PROPERTY:seqan3::test::header,INTERFACE_INCLUDE_DIRECTORIES>)
+                target_link_libraries (${header_target} PRIVATE $<TARGET_PROPERTY:seqan3::test::header,INTERFACE_LINK_LIBRARIES>)
+            else ()
+                target_link_libraries (${header_target} seqan3::test::header)
+            endif ()
 
             target_sources (${target} PRIVATE $<TARGET_OBJECTS:${header_target}>)
         endforeach ()
@@ -92,6 +97,7 @@ TEST(${header_test_name_safe}) {}")
 endmacro ()
 
 seqan3_require_ccache ()
+seqan3_require_benchmark ()
 seqan3_require_test ()
 
 seqan3_header_test (seqan3 "${SEQAN3_CLONE_DIR}/include")

--- a/test/include/seqan3/test/performance/units.hpp
+++ b/test/include/seqan3/test/performance/units.hpp
@@ -19,8 +19,7 @@
 namespace seqan3::test
 {
 
-/**
- * This returns a counter which represents how many bytes were processed per second.
+/*!\brief This returns a counter which represents how many bytes were processed per second.
  *
  * \param  bytes The total number of bytes processed of a complete benchmark run.
  * \return       Returns a benchmark Counter which represents bytes/s.

--- a/test/include/seqan3/test/performance/units.hpp
+++ b/test/include/seqan3/test/performance/units.hpp
@@ -1,0 +1,35 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Contains predefined custom units for google benchmark.
+ * \author Marcel Ehrhardt <marcel.ehrhardt AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <benchmark/benchmark.h>
+
+#include <seqan3/core/platform.hpp>
+
+namespace seqan3::test
+{
+
+/**
+ * This returns a counter which represents how many bytes were processed per second.
+ *
+ * \param  bytes The total number of bytes processed of a complete benchmark run.
+ * \return       Returns a benchmark Counter which represents bytes/s.
+ */
+inline benchmark::Counter bytes_per_second(size_t bytes)
+{
+    return benchmark::Counter(bytes,
+                              benchmark::Counter::kIsIterationInvariantRate,
+                              benchmark::Counter::OneK::kIs1024);
+}
+
+} // namespace seqan3::test

--- a/test/performance/example/example_benchmark.cpp
+++ b/test/performance/example/example_benchmark.cpp
@@ -10,6 +10,10 @@
 
 #include <benchmark/benchmark.h>
 
+#include <seqan3/test/performance/units.hpp>
+
+using namespace seqan3::test;
+
 static void vector_copy_benchmark(benchmark::State& state) {
     std::vector<int> x = {15, 13, 12, 10};
     for (auto _ : state)
@@ -25,8 +29,7 @@ static void memcpy_benchmark(benchmark::State& state) {
     for (auto _ : state)
         memcpy(dst, src, size);
 
-    int64_t bytes = int64_t(state.iterations()) * int64_t(size);
-    state.counters["bytes_processed"] = bytes;
+    state.counters["bytes_per_second"] = bytes_per_second(size);
     delete[] src;
     delete[] dst;
 }
@@ -40,8 +43,7 @@ static void copy_benchmark(benchmark::State& state) {
     for (auto _ : state)
         std::copy_n(src, size, dst);
 
-    int64_t bytes = int64_t(state.iterations()) * int64_t(size);
-    state.counters["bytes_processed"] = bytes;
+    state.counters["bytes_per_second"] = bytes_per_second(size);
     delete[] src;
     delete[] dst;
 }

--- a/test/seqan3-test.cmake
+++ b/test/seqan3-test.cmake
@@ -76,6 +76,7 @@ add_library (seqan3::test::coverage ALIAS seqan3_test_coverage)
 # needed for header test cases in seqan3/test/header
 add_library (seqan3_test_header INTERFACE)
 target_link_libraries (seqan3_test_header INTERFACE "seqan3::test::unit")
+target_link_libraries (seqan3_test_header INTERFACE "seqan3::test::performance")
 add_library (seqan3::test::header ALIAS seqan3_test_header)
 
 # ----------------------------------------------------------------------------

--- a/test/seqan3-test.cmake
+++ b/test/seqan3-test.cmake
@@ -177,7 +177,7 @@ macro (seqan3_require_benchmark)
         gbenchmark_project
         PREFIX gbenchmark_project
         GIT_REPOSITORY "https://github.com/google/benchmark.git"
-        GIT_TAG "v1.4.1"
+        GIT_TAG "b8ca0c42179b7b5d656494e61dda8b861057122f"
         SOURCE_DIR "${SEQAN3_BENCHMARK_CLONE_DIR}"
         CMAKE_ARGS "${gbenchmark_project_args}"
         UPDATE_DISCONNECTED yes


### PR DESCRIPTION
This introduces convenient functions to represent common measurable units in google/benchmark.

An example is bytes/s, which is introduced in this PR.  We introduce this, because SetBytesProcessed was marked as deprecated in favour for a more general benchmark::Counter approach. (see https://github.com/google/benchmark/pull/654)

In a later PR I will introduce CUPS (cell updates per second) for alignment benchmarks as another common benchmark unit.