### PR TITLE
[DOC] Add custom doxygen commands for the tutorial header, as well as assignment and solution boxes.

### DIFF
--- a/test/documentation/seqan3_doxygen_cfg.in
+++ b/test/documentation/seqan3_doxygen_cfg.in
@@ -51,3 +51,12 @@ FILE_PATTERNS          = *
 EXTRACT_PRIVATE        = ${SEQAN3_DOXYGEN_EXTRACT_PRIVATE}
 ENABLED_SECTIONS       = ${SEQAN3_DOXYGEN_ENABLED_SECTIONS}
 EXCLUDE_SYMBOLS        += ${SEQAN3_DOXYGEN_EXCLUDE_SYMBOLS}
+
+## Custom doxygen commands
+ALIASES += tutorial_head{4}="<table><tr><th>Difficulty</th><td>\1</td></tr><tr><th>Duration</th><td>\2</td></tr><tr><th>Prerequisite tutorials</th><td>\3</td></tr><tr><th>Recommended reading</th><td>\4</td></tr></table>"
+
+ALIASES += assignment{1}="\htmlonly <div class=\"alert\" style=\"padding: 10px; background-color: #dce2ef; border-left: 6px solid #2f436a;\"><h4>\1</h4>\endhtmlonly"
+ALIASES += endassignment="\htmlonly</div>\endhtmlonly"
+
+ALIASES += solution="\htmlonly <div class=\"alert\" style=\"padding: 10px; background-color: #ccff99; border-left: 6px solid #408000;\"> <details><summary><b>Solution</b></summary> \endhtmlonly"
+ALIASES += endsolution="\htmlonly </details> </div> \endhtmlonly"


### PR DESCRIPTION
For our convenience :nail_care: 

This will enable us to write
```
\tutorial_head{Easy, 30-60 min, @ref setup\, @ref setup,}
```
displaying:
![grafik](https://user-images.githubusercontent.com/7955878/52699801-e704ab00-2f76-11e9-9acf-ce36bf069781.png)

as well as 
```
\assignment{Assignment 2}

1. Extend the minimal example from assignment 1 by a function
   `void initialize_argument_parser(seqan3::argument_parser & parser)`.
2. Whithin this function, customize the parser with the following information:
   * set the author to your favourite Game of Thrones character (don't have one? really? take "Cercei")
   * set the short description to "Aggregate average US. Game of Thrones viewers by season."
   * set the version to 1.0.0
   * ... set some more if you want to
   Hint: Check out the API documentation for seqan3::argument_parser_meta_data and seqan3::argument_parser::info.
3. Try out calling `--help` again and see the results.

\endassignment
```
displaying
![grafik](https://user-images.githubusercontent.com/7955878/52699892-1adfd080-2f77-11e9-901d-f761801dbd1c.png)

and 
```
\solution

blabla
`` `cpp
    some code
`` `

\endsolution
```
displaying a collapsed soltion box
![grafik](https://user-images.githubusercontent.com/7955878/52700043-6b572e00-2f77-11e9-9669-fba79ce6910d.png)
