### PR TITLE
[MISC] Replace stream operator by std::from_chars for Integral types.

### DIFF
--- a/include/seqan3/argument_parser/detail/format_parse.hpp
+++ b/include/seqan3/argument_parser/detail/format_parse.hpp
@@ -18,6 +18,7 @@
 
 #include <seqan3/argument_parser/detail/format_base.hpp>
 #include <seqan3/std/concepts>
+#include <seqan3/std/charconv>
 
 namespace seqan3::detail
 {
@@ -323,10 +324,8 @@ private:
         value.push_back(tmp);
     }
 
-    /*!\brief Tries to cast an input string into a (integral) value and tests for overflow errors.
-     *
-     * \tparam option_t Must be stream-convertible.
-     *
+    /*!\brief Tries to cast an input string into an arithmetic value.
+     * \tparam option_t  The optiona value type; must model seqan3::Arithmetic.
      * \param[out] value Stores the casted value.
      * \param[in]  in    The input argument to be casted.
      *
@@ -335,34 +334,47 @@ private:
      *
      * \details
      *
-     * This function tests for possible overflow errors:
-     * It first casts into a signed long long int (to also catch negative values for unsigned ints)
-     * and then checks the min-max range given by numeric limits.
-     * Exception: Due to using signed long long int, this does not catch overflow errors
-     * for unsigned long int's but that kind of large a number will hopefully never be supplied
-     * via the command line..
+     * This function delegates to std::from_chars.
      */
-    template <std::Integral option_t>
+    template <Arithmetic option_t>
     //!\cond
         requires IStream<std::istringstream, option_t>
     //!\endcond
     void retrieve_value(option_t & value, std::string const & in)
     {
-        int64_t tmp;
-        std::istringstream stream{in};
-        stream >> tmp;
+        auto res = std::from_chars(&in[0], &in[in.size()], value);
 
-        if (stream.fail() || !stream.eof()) // !stream.eof() catches 13a as wrong
-            throw type_conversion_failed("Argument " + in + " could not be casted to type " +
-                                         get_type_name_as_string(value) + ".");
-
-        if (tmp > static_cast<int64_t>(std::numeric_limits<option_t>::max()) ||
-            tmp < static_cast<int64_t>(std::numeric_limits<option_t>::min()))
+        if (res.ec == std::errc::result_out_of_range)
             throw overflow_error_on_conversion("Argument " + in + " is not in integer range [" +
                                                std::to_string(std::numeric_limits<option_t>::min()) + "," +
                                                std::to_string(std::numeric_limits<option_t>::max()) + "].");
+        else if (res.ec == std::errc::invalid_argument || res.ptr != &in[in.size()])
+            throw type_conversion_failed("Argument " + in + " could not be casted to type " +
+                                         get_type_name_as_string(value) + ".");
+    }
 
-        value = static_cast<option_t>(tmp);
+    /*!\brief Tries to cast an input string into boleand value.
+     * \param[out] value Stores the casted value.
+     * \param[in]  in    The input argument to be casted.
+     *
+     * \throws seqan3::type_conversion_failed
+     *
+     * \details
+     *
+     * This function delegates to std::from_chars.
+     */
+    void retrieve_value(bool & value, std::string const & in)
+    {
+        if (in == "0")
+            value = false;
+        else if (in == "1")
+            value = true;
+        else if (in == "true")
+            value = true;
+        else if (in == "false")
+            value = false;
+        else
+            throw type_conversion_failed("Argument '" + in + "' could not be casted to boolean.");
     }
 
     /*!\brief Handles value retrieval for options based on different kev value pairs.

--- a/include/seqan3/std/charconv_detail.hpp
+++ b/include/seqan3/std/charconv_detail.hpp
@@ -773,6 +773,8 @@ inline std::from_chars_result from_chars_floating_point(char const * first,
         tmp = strtold(start, &end);
     }
 
+    last = first + (end - start);
+
     if (errno == ERANGE)
     {
         return {last, std::errc::result_out_of_range};

--- a/test/unit/argument_parser/format_parse_test.cpp
+++ b/test/unit/argument_parser/format_parse_test.cpp
@@ -410,23 +410,41 @@ TEST(parse_type_test, parse_success_bool_option)
     bool option_value;
     bool positional_value;
 
-    const char * argv[] = {"./argument_parser_test", "-b", "1", "0"};
-    argument_parser parser("test_parser", 4, argv);
-    parser.add_option(option_value, 'b', "bool-option", "this is a bool option.");
-    parser.add_positional_option(positional_value, "this is a bool positional.");
+    // numbers 0 and 1
+    {
+        const char * argv[] = {"./argument_parser_test", "-b", "1", "0"};
+        argument_parser parser("test_parser", 4, argv);
+        parser.add_option(option_value, 'b', "bool-option", "this is a bool option.");
+        parser.add_positional_option(positional_value, "this is a bool positional.");
 
-    testing::internal::CaptureStderr();
-    EXPECT_NO_THROW(parser.parse());
+        testing::internal::CaptureStderr();
+        EXPECT_NO_THROW(parser.parse());
 
-    EXPECT_TRUE((testing::internal::GetCapturedStderr()).empty());
-    EXPECT_EQ(option_value, true);
-    EXPECT_EQ(positional_value, false);
+        EXPECT_TRUE((testing::internal::GetCapturedStderr()).empty());
+        EXPECT_EQ(option_value, true);
+        EXPECT_EQ(positional_value, false);
+    }
+
+    // true and false
+    {
+        const char * argv[] = {"./argument_parser_test", "-b", "true", "false"};
+        argument_parser parser("test_parser", 4, argv);
+        parser.add_option(option_value, 'b', "bool-option", "this is a bool option.");
+        parser.add_positional_option(positional_value, "this is a bool positional.");
+
+        testing::internal::CaptureStderr();
+        EXPECT_NO_THROW(parser.parse());
+
+        EXPECT_TRUE((testing::internal::GetCapturedStderr()).empty());
+        EXPECT_EQ(option_value, true);
+        EXPECT_EQ(positional_value, false);
+    }
 }
 
 TEST(parse_type_test, parse_success_int_option)
 {
     int option_value;
-    int positional_value;
+    size_t positional_value;
 
     const char * argv[] = {"./argument_parser_test", "-i", "-2", "278"};
     argument_parser parser("test_parser", 4, argv);
@@ -438,7 +456,7 @@ TEST(parse_type_test, parse_success_int_option)
 
     EXPECT_TRUE((testing::internal::GetCapturedStderr()).empty());
     EXPECT_EQ(option_value, -2);
-    EXPECT_EQ(positional_value, 278);
+    EXPECT_EQ(positional_value, 278u);
 }
 
 TEST(parse_type_test, parse_success_double_option)
@@ -455,8 +473,8 @@ TEST(parse_type_test, parse_success_double_option)
     EXPECT_NO_THROW(parser.parse());
 
     EXPECT_TRUE((testing::internal::GetCapturedStderr()).empty());
-    EXPECT_EQ(option_value, 12.457);
-    EXPECT_EQ(positional_value, 0.123);
+    EXPECT_FLOAT_EQ(option_value, 12.457);
+    EXPECT_FLOAT_EQ(positional_value, 0.123);
 
     // double expression with e
     const char * argv2[] = {"./argument_parser_test", "-d", "6.0221418e23"};
@@ -467,8 +485,8 @@ TEST(parse_type_test, parse_success_double_option)
     EXPECT_NO_THROW(parser2.parse());
 
     EXPECT_TRUE((testing::internal::GetCapturedStderr()).empty());
-    EXPECT_EQ(option_value, 6.0221418e23);
-    EXPECT_EQ(positional_value, 0.123);
+    EXPECT_FLOAT_EQ(option_value, 6.0221418e23);
+    EXPECT_FLOAT_EQ(positional_value, 0.123);
 
 }
 

--- a/test/unit/argument_parser/format_parse_validators_test.cpp
+++ b/test/unit/argument_parser/format_parse_validators_test.cpp
@@ -181,7 +181,7 @@ TEST(validator_test, arithmetic_range_validator_success)
     testing::internal::CaptureStderr();
     EXPECT_NO_THROW(parser8.parse());
     EXPECT_TRUE((testing::internal::GetCapturedStderr()).empty());
-    EXPECT_EQ(double_option_value, 10.9);
+    EXPECT_FLOAT_EQ(double_option_value, 10.9);
 }
 
 TEST(validator_test, arithmetic_range_validator_error)

--- a/test/unit/std/charconv_test.cpp
+++ b/test/unit/std/charconv_test.cpp
@@ -322,7 +322,7 @@ TYPED_TEST(from_char_real_test, real_numbers)
         auto res = std::from_chars(&str[0], &str[0] + str.size(), val);
         EXPECT_FLOAT_EQ(val, TypeParam{4});
         EXPECT_EQ(res.ec, std::errc{});
-        EXPECT_EQ(res.ptr, &str[0] + str.size());
+        EXPECT_EQ(res.ptr, &str[0] + 1);
     }
 
     {
@@ -349,7 +349,7 @@ TYPED_TEST(from_char_real_test, real_numbers)
         auto res = std::from_chars(&str[0], &str[0] + str.size(), val);
         EXPECT_FLOAT_EQ(val, TypeParam{1.2});
         EXPECT_EQ(res.ec, std::errc{});
-        EXPECT_EQ(res.ptr, &str[0] + str.size());
+        EXPECT_EQ(res.ptr, &str[0] + 3);
     }
 
     {
@@ -366,6 +366,16 @@ TYPED_TEST(from_char_real_test, real_numbers)
         TypeParam val{42};
         std::string str = "3.194357";
         auto res = std::from_chars(&str[0], &str[0] + 4, val);
+        EXPECT_FLOAT_EQ(val, TypeParam{3.19});
+        EXPECT_EQ(res.ec, std::errc{});
+        EXPECT_EQ(res.ptr, &str[0] + 4);
+    }
+
+    // Partial Parsing
+    {
+        TypeParam val{42};
+        std::string str = "3.19abc";
+        auto res = std::from_chars(&str[0], &str[0] + str.size(), val);
         EXPECT_FLOAT_EQ(val, TypeParam{3.19});
         EXPECT_EQ(res.ec, std::errc{});
         EXPECT_EQ(res.ptr, &str[0] + 4);
@@ -438,7 +448,7 @@ TYPED_TEST(from_char_real_test, nan_value)
 
     {
         TypeParam val{};
-        std::string str = "nan(...)";
+        std::string str = "nan(abc)";
         auto res = std::from_chars(&str[0], &str[0] + str.size(), val);
         EXPECT_TRUE(std::isnan(val));
         EXPECT_EQ(res.ec, std::errc{});
@@ -447,7 +457,7 @@ TYPED_TEST(from_char_real_test, nan_value)
 
     {
         TypeParam val{};
-        std::string str = "NAN(...)";
+        std::string str = "NAN(abc)";
         auto res = std::from_chars(&str[0], &str[0] + str.size(), val);
         EXPECT_TRUE(std::isnan(val));
         EXPECT_EQ(res.ec, std::errc{});


### PR DESCRIPTION
long overdue and also has better handling for "out of range" errors.