### PR TITLE
[DOC,FIX] escape double dash

### DIFF
--- a/include/seqan3/argument_parser/argument_parser.hpp
+++ b/include/seqan3/argument_parser/argument_parser.hpp
@@ -258,7 +258,7 @@ public:
      * \throws seqan3::option_declared_multiple_times if an option that is not a list was declared multiple times.
      * \throws seqan3::overflow_error_on_conversion if the numeric argument would cause an overflow error when
      *                                              converted into the expected type.
-     * \throws seqan3::parser_interruption on special user request (e.g. --help or --version).
+     * \throws seqan3::parser_interruption on special user request (e.g. \--help or \--version).
      * \throws seqan3::parser_invalid_argument if the user provided wrong arguments.
      * \throws seqan3::required_option_missing if the user did not provide a required option.
      * \throws seqan3::too_many_arguments if the command line call contained more arguments than expected.
@@ -275,13 +275,13 @@ public:
      * The parser behaves differently when the given command line (`argv`)
      * contains the following keywords (in order of checking) :
      *
-     * - **-h/--help** Prints the help page and throws
+     * - **-h/\--help** Prints the help page and throws
      *                 a seqan3::parser_interruption.
-     * - **-hh/--advanced-help** Prints the help page including advanced options
+     * - **-hh/\--advanced-help** Prints the help page including advanced options
      *                           and throws a seqan3::parser_interruption.
-     * - **--version** Prints the version information and throws
+     * - <b>\--version</b> Prints the version information and throws
      *                 a seqan3::parser_interruption.
-     * - **--export-help [format]** Prints the application description in the
+     * - <b>\--export-help [format]</b> Prints the application description in the
      *                              given format (html/man/ctd) and throws a
      *                              seqan3::parser_interruption.
      *
@@ -468,16 +468,16 @@ private:
      *
      * - **no arguments** If no arguments are provided on the commandline, the
      *                    seqan3::detail::format_short_help is set.
-     * - **-h/--help** sets the format to seqan3::detail::format_help
-     * - **-hh/--advanced-help** sets the format to seqan3::detail::format_help
+     * - **-h/\--help** sets the format to seqan3::detail::format_help
+     * - **-hh/\--advanced-help** sets the format to seqan3::detail::format_help
      *                           and show_advanced_options to `true`.
-     * - **--version** sets the format to seqan3::detail::format_version.
-     * - **-export-help html** sets the format to seqan3::detail::format_html.
-     * - **-export-help man** sets the format to seqan3::detail::format_man.
-     * - **-export-help ctd** sets the format to seqan3::detail::format_ctd.
+     * - <b>\--version</b> sets the format to seqan3::detail::format_version.
+     * - <b>\--export-help html</b> sets the format to seqan3::detail::format_html.
+     * - <b>\--export-help man</b> sets the format to seqan3::detail::format_man.
+     * - <b>\--export-help ctd</b> sets the format to seqan3::detail::format_ctd.
      * - else the format is that to seqan3::detail::format_parse
      *
-     * If `-export-help` is specified with a value other than html/man or ctd
+     * If `--export-help` is specified with a value other than html/man or ctd
      * a parser_invalid_argument is thrown.
      */
     void init(int const argc, char const * const * const  argv)

--- a/include/seqan3/argument_parser/detail/format_base.hpp
+++ b/include/seqan3/argument_parser/detail/format_base.hpp
@@ -120,7 +120,7 @@ protected:
      * \param[in] long_id  The long identifier of the option/flag.
      * \returns The name of the short and long id, prepended with (double)dash.
      *
-     * \details  e.g. "-i,--integer","-i", or "--integer".
+     * \details  e.g. "-i,--integer", "-i", or "--integer".
      */
     static std::string prep_id_for_help(char const short_id, std::string const & long_id)
     {

--- a/include/seqan3/argument_parser/detail/format_parse.hpp
+++ b/include/seqan3/argument_parser/detail/format_parse.hpp
@@ -721,7 +721,7 @@ private:
     std::vector<std::string> argv;
     //!\brief Number of command line arguments.
     int argc;
-    //!\brief Artificial end of argv if -- was seen.
+    //!\brief Artificial end of argv if \-- was seen.
     std::vector<std::string>::iterator end_of_options_it;
 };
 

--- a/include/seqan3/argument_parser/exceptions.hpp
+++ b/include/seqan3/argument_parser/exceptions.hpp
@@ -149,11 +149,11 @@ public:
  *
  * Behavior that triggers a parser interruption:
  *
- * - **--version** Prints the version information.
- * - **--copyright** Prints the copyright information.
- * - **-h/--help** Prints the help page (excluding advanced options).
- * - **-hh/--advanced-help** Prints the help page including advanced options.
- * - **--export-help [format]** Prints the help page information in the
+ * - <b>\--version</b> Prints the version information.
+ * - <b>\--copyright</b> Prints the copyright information.
+ * - **-h/\--help** Prints the help page (excluding advanced options).
+ * - **-hh/\--advanced-help** Prints the help page including advanced options.
+ * - <b>\--export-help [format]</b> Prints the help page information in the
  *                              given format (html/man/ctd).
  */
 class parser_interruption : public std::exception


### PR DESCRIPTION
From

![image](https://user-images.githubusercontent.com/12967715/52974333-71a73900-33c1-11e9-908b-d8b5b8d10dc5.png)

To
![image](https://user-images.githubusercontent.com/12967715/52974336-75d35680-33c1-11e9-90c2-15b88741ccd0.png)

`--export-help` was wrongly documented in one place. 
We need `<b><\b>` tags in a few places since `**\--something**` is not parsed correctly.
