### PR TITLE
Display CUPS in alignments benchmarks

### DIFF
--- a/test/include/seqan3/test/performance/sequence_generator.hpp
+++ b/test/include/seqan3/test/performance/sequence_generator.hpp
@@ -1,0 +1,65 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Contains test utilities for seqan3::simd::simd_type types.
+ * \author Marcel Ehrhardt <marcel.ehrhardt AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <random>
+
+#include <seqan3/alphabet/concept.hpp>
+#include <seqan3/test/seqan2.hpp>
+
+#ifdef SEQAN3_HAS_SEQAN2
+    #include <seqan/basic.h>
+    #include <seqan/sequence.h>
+#endif
+
+namespace seqan3::test
+{
+
+template <typename alphabet_t>
+auto generate_sequence(size_t const len = 500,
+                       size_t const variance = 0,
+                       size_t const seed = 0)
+{
+    std::mt19937 gen(seed);
+    std::uniform_int_distribution<uint8_t> dis_alpha(0, alphabet_size_v<alphabet_t> - 1);
+    std::uniform_int_distribution<size_t> dis_length(len - variance, len + variance);
+
+    std::vector<alphabet_t> sequence;
+
+    size_t length = dis_length(gen);
+    for (size_t l = 0; l < length; ++l)
+        sequence.push_back(alphabet_t{}.assign_rank(dis_alpha(gen)));
+
+    return sequence;
+}
+
+#ifdef SEQAN3_HAS_SEQAN2
+template <typename alphabet_t>
+auto generate_sequence_seqan2(size_t const len = 500,
+                              size_t const variance = 0,
+                              size_t const seed = 0)
+{
+    std::mt19937 gen(seed);
+    std::uniform_int_distribution<uint8_t> dis_alpha(0, seqan::ValueSize<alphabet_t>::VALUE - 1);
+    std::uniform_int_distribution<size_t> dis_length(len - variance, len + variance);
+
+    seqan::String<alphabet_t> sequence;
+    size_t length = dis_length(gen);
+    for (size_t l = 0; l < length; ++l)
+        appendValue(sequence, alphabet_t{dis_alpha(gen)});
+
+    return sequence;
+}
+#endif // generate seqan2 data.
+
+} // namespace seqan3::test

--- a/test/include/seqan3/test/performance/units.hpp
+++ b/test/include/seqan3/test/performance/units.hpp
@@ -14,7 +14,10 @@
 
 #include <benchmark/benchmark.h>
 
+#include <seqan3/core/concept/tuple.hpp>
+#include <seqan3/core/metafunction/range.hpp>
 #include <seqan3/core/platform.hpp>
+#include <seqan3/std/ranges>
 
 namespace seqan3::test
 {
@@ -29,6 +32,28 @@ inline benchmark::Counter bytes_per_second(size_t bytes)
     return benchmark::Counter(bytes,
                               benchmark::Counter::kIsIterationInvariantRate,
                               benchmark::Counter::OneK::kIs1024);
+}
+
+//!\brief Calculates the number of cell updates for given sequences for a specific alignment config.
+template <typename sequences_range_t>
+inline size_t pairwise_cell_updates(sequences_range_t const & sequences_range, auto && /*align_cfg*/)
+{
+    size_t matrix_cells = 0u;
+    for (auto && [seq1, seq2]: sequences_range)
+        matrix_cells += (std::ranges::size(seq1) + 1) * (std::ranges::size(seq2) + 1);
+    return matrix_cells;
+}
+
+/*!\brief This returns a counter which represents how many cell updates were done for a matrix.
+ *
+ * \param  cells The total number of cells processed of a complete benchmark run.
+ * \return       Returns a benchmark Counter which represents CUPS (cell updates per second).
+ */
+inline benchmark::Counter cell_updates_per_second(size_t cells)
+{
+    return benchmark::Counter(cells,
+                              benchmark::Counter::kIsIterationInvariantRate,
+                              benchmark::Counter::OneK::kIs1000);
 }
 
 } // namespace seqan3::test

--- a/test/include/seqan3/test/seqan2.hpp
+++ b/test/include/seqan3/test/seqan2.hpp
@@ -1,0 +1,54 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Adds seqan2 to the test environment.
+ * \author Marcel Ehrhardt <marcel.ehrhardt AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <seqan3/core/platform.hpp>
+
+// SeqAn 2 [optional]
+/*!\def SEQAN3_HAS_SEQAN2
+ * \brief Whether SeqAn2 library is available or not.
+ * \ingroup test
+ */
+#if __has_include(<seqan/version.h>)
+
+#include <seqan/version.h>
+
+// Require minimum version of seqan2, see https://github.com/seqan/seqan3/issues/748
+#if SEQAN_VERSION_MAJOR == 2 && SEQAN_VERSION_MINOR >= 4
+#define SEQAN3_HAS_SEQAN2 1
+#endif
+
+#endif
+
+#ifdef SEQAN3_HAS_SEQAN2
+
+#include <seqan/basic.h>
+#include <seqan3/std/ranges>
+
+#if __cpp_lib_ranges // C++20 ranges available
+namespace std::ranges
+#else // implement via range-v3
+namespace ranges
+#endif
+{
+
+//!\brief This makes seqan iterators ranges-aware, i.e. makes them fulfil ranges::Readable which is in turn needed for
+//!ranges::InputRange.
+template <typename ...args_t>
+struct readable_traits<seqan::Iter<args_t...>>
+{
+    using value_type = typename seqan::Value<seqan::Iter<args_t...>>::Type;
+};
+
+} // namespace ranges
+#endif

--- a/test/performance/alignment/affine_alignment_benchmark.cpp
+++ b/test/performance/alignment/affine_alignment_benchmark.cpp
@@ -13,58 +13,25 @@
 #include <utility>
 #include <vector>
 
+
 #include <seqan3/alignment/pairwise/align_pairwise.hpp>
 #include <seqan3/alphabet/aminoacid/aa20.hpp>
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
-
-#if __has_include(<seqan/align.h>)
-    #define SEQAN3_HAS_SEQAN2 1
-#endif
+#include <seqan3/test/performance/units.hpp>
+#include <seqan3/test/performance/sequence_generator.hpp>
+#include <seqan3/test/seqan2.hpp>
+#include <seqan3/std/ranges>
 
 #ifdef SEQAN3_HAS_SEQAN2
     #include <seqan/align.h>
-    #include <seqan/basic.h>
-    #include <seqan/sequence.h>
 #endif
 
 using namespace seqan3;
+using namespace seqan3::test;
 
-template <typename alphabet_t>
-auto generate_sequence_seqan3(size_t const len = 500,
-                              size_t const variance = 0,
-                              size_t const seed = 0)
-{
-    std::mt19937 gen(seed);
-    std::uniform_int_distribution<uint8_t> dis_alpha(0, alphabet_size_v<alphabet_t> - 1);
-    std::uniform_int_distribution<size_t> dis_length(len - variance, len + variance);
-
-    std::vector<alphabet_t> sequence;
-
-    size_t length = dis_length(gen);
-    for (size_t l = 0; l < length; ++l)
-        sequence.push_back(alphabet_t{}.assign_rank(dis_alpha(gen)));
-
-    return sequence;
-}
-
-#ifdef SEQAN3_HAS_SEQAN2
-template <typename alphabet_t>
-auto generate_sequence_seqan2(size_t const len = 500,
-                              size_t const variance = 0,
-                              size_t const seed = 0)
-{
-    std::mt19937 gen(seed);
-    std::uniform_int_distribution<uint8_t> dis_alpha(0, seqan::ValueSize<alphabet_t>::VALUE - 1);
-    std::uniform_int_distribution<size_t> dis_length(len - variance, len + variance);
-
-    seqan::String<alphabet_t> sequence;
-    size_t length = dis_length(gen);
-    for (size_t l = 0; l < length; ++l)
-        appendValue(sequence, alphabet_t{dis_alpha(gen)});
-
-    return sequence;
-}
-#endif // generate seqan2 data.
+constexpr auto affine_cfg = align_cfg::mode{global_alignment} |
+                            align_cfg::gap{gap_scheme{gap_score{-1}, gap_open_score{-10}}} |
+                            align_cfg::scoring{nucleotide_scoring_scheme{match_score{4}, mismatch_score{-5}}};
 
 // ============================================================================
 //  affine; score; dna4; single
@@ -72,19 +39,18 @@ auto generate_sequence_seqan2(size_t const len = 500,
 
 void seqan3_affine_dna4(benchmark::State & state)
 {
-    auto cfg = align_cfg::mode{global_alignment} |
-               align_cfg::gap{gap_scheme{gap_score{-1}, gap_open_score{-10}}} |
-               align_cfg::scoring{nucleotide_scoring_scheme{match_score{4}, mismatch_score{-5}}} |
-               align_cfg::result{with_score};
-
-    auto seq1 = generate_sequence_seqan3<seqan3::dna4>(500, 0, 0);
-    auto seq2 = generate_sequence_seqan3<seqan3::dna4>(500, 0, 1);
+    size_t sequence_length = 500;
+    auto seq1 = generate_sequence<seqan3::dna4>(sequence_length, 0, 0);
+    auto seq2 = generate_sequence<seqan3::dna4>(sequence_length, 0, 1);
 
     for (auto _ : state)
     {
-        auto rng = align_pairwise(std::tie(seq1, seq2), cfg);
+        auto rng = align_pairwise(std::tie(seq1, seq2), affine_cfg | align_cfg::result{with_score});
         *seqan3::begin(rng);
     }
+
+    state.counters["cells"] = pairwise_cell_updates(ranges::view::single(std::tie(seq1, seq2)), affine_cfg);
+    state.counters["CUPS"] = cell_updates_per_second(state.counters["cells"]);
 }
 
 BENCHMARK(seqan3_affine_dna4);
@@ -93,14 +59,18 @@ BENCHMARK(seqan3_affine_dna4);
 
 void seqan2_affine_dna4(benchmark::State & state)
 {
-    auto seq1 = generate_sequence_seqan2<seqan::Dna>(500, 0, 0);
-    auto seq2 = generate_sequence_seqan2<seqan::Dna>(500, 0, 1);
+    size_t sequence_length = 500;
+    auto seq1 = generate_sequence_seqan2<seqan::Dna>(sequence_length, 0, 0);
+    auto seq2 = generate_sequence_seqan2<seqan::Dna>(sequence_length, 0, 1);
 
     for (auto _ : state)
     {
         // In SeqAn2 the gap open contains already the gap extension costs, that's why we use -11 here.
         seqan::globalAlignmentScore(seq1, seq2, seqan::Score<int>{4, -5, -1, -11});
     }
+
+    state.counters["cells"] = pairwise_cell_updates(ranges::view::single(std::tie(seq1, seq2)), affine_cfg);
+    state.counters["CUPS"] = cell_updates_per_second(state.counters["cells"]);
 }
 
 BENCHMARK(seqan2_affine_dna4);
@@ -112,19 +82,18 @@ BENCHMARK(seqan2_affine_dna4);
 
 void seqan3_affine_dna4_trace(benchmark::State & state)
 {
-    auto cfg = align_cfg::mode{global_alignment} |
-               align_cfg::gap{gap_scheme{gap_score{-1}, gap_open_score{-10}}} |
-               align_cfg::scoring{nucleotide_scoring_scheme{match_score{4}, mismatch_score{-5}}} |
-               align_cfg::result{with_alignment};
-
-    auto seq1 = generate_sequence_seqan3<seqan3::dna4>(500, 0, 0);
-    auto seq2 = generate_sequence_seqan3<seqan3::dna4>(500, 0, 1);
+    size_t sequence_length = 500;
+    auto seq1 = generate_sequence<seqan3::dna4>(sequence_length, 0, 0);
+    auto seq2 = generate_sequence<seqan3::dna4>(sequence_length, 0, 1);
 
     for (auto _ : state)
     {
-        auto rng = align_pairwise(std::tie(seq1, seq2), cfg);
+        auto rng = align_pairwise(std::tie(seq1, seq2), affine_cfg | align_cfg::result{with_alignment});
         *seqan3::begin(rng);
     }
+
+    state.counters["cells"] = pairwise_cell_updates(ranges::view::single(std::tie(seq1, seq2)), affine_cfg);
+    state.counters["CUPS"] = cell_updates_per_second(state.counters["cells"]);
 }
 
 BENCHMARK(seqan3_affine_dna4_trace);
@@ -133,8 +102,9 @@ BENCHMARK(seqan3_affine_dna4_trace);
 
 void seqan2_affine_dna4_trace(benchmark::State & state)
 {
-    auto seq1 = generate_sequence_seqan2<seqan::Dna>(500, 0, 0);
-    auto seq2 = generate_sequence_seqan2<seqan::Dna>(500, 0, 1);
+    size_t sequence_length = 500;
+    auto seq1 = generate_sequence_seqan2<seqan::Dna>(sequence_length, 0, 0);
+    auto seq2 = generate_sequence_seqan2<seqan::Dna>(sequence_length, 0, 1);
 
     seqan::Gaps<decltype(seq1)> gap1{seq1};
     seqan::Gaps<decltype(seq2)> gap2{seq2};
@@ -143,6 +113,9 @@ void seqan2_affine_dna4_trace(benchmark::State & state)
         // In SeqAn2 the gap open contains already the gap extension costs, that's why we use -11 here.
         seqan::globalAlignment(gap1, gap2, seqan::Score<int>{4, -5, -1, -11});
     }
+
+    state.counters["cells"] = pairwise_cell_updates(ranges::view::single(std::tie(seq1, seq2)), affine_cfg);
+    state.counters["CUPS"] = cell_updates_per_second(state.counters["cells"]);
 }
 
 BENCHMARK(seqan2_affine_dna4_trace);
@@ -154,26 +127,26 @@ BENCHMARK(seqan2_affine_dna4_trace);
 
 void seqan3_affine_dna4_collection(benchmark::State & state)
 {
-    auto cfg = align_cfg::mode{global_alignment} |
-               align_cfg::gap{gap_scheme{gap_score{-1}, gap_open_score{-10}}} |
-               align_cfg::scoring{nucleotide_scoring_scheme{match_score{4}, mismatch_score{-5}}} |
-               align_cfg::result{with_score};
-
-    using sequence_t = decltype(generate_sequence_seqan3<seqan3::dna4>());
+    size_t sequence_length = 100;
+    size_t set_size = 100;
+    using sequence_t = decltype(generate_sequence<seqan3::dna4>());
 
     std::vector<std::pair<sequence_t, sequence_t>> vec;
-    for (unsigned i = 0; i < 100; ++i)
+    for (unsigned i = 0; i < set_size; ++i)
     {
-        sequence_t seq1 = generate_sequence_seqan3<seqan3::dna4>(100, 0, i);
-        sequence_t seq2 = generate_sequence_seqan3<seqan3::dna4>(100, 0, i + 100);
+        sequence_t seq1 = generate_sequence<seqan3::dna4>(sequence_length, 0, i);
+        sequence_t seq2 = generate_sequence<seqan3::dna4>(sequence_length, 0, i + set_size);
         vec.push_back(std::pair{seq1, seq2});
     }
 
     for (auto _ : state)
     {
-        for (auto && rng : align_pairwise(vec, cfg))
+        for (auto && rng : align_pairwise(vec, affine_cfg | align_cfg::result{with_score}))
             rng.score();
     }
+
+    state.counters["cells"] = pairwise_cell_updates(vec, affine_cfg);
+    state.counters["CUPS"] = cell_updates_per_second(state.counters["cells"]);
 }
 
 BENCHMARK(seqan3_affine_dna4_collection);
@@ -182,14 +155,16 @@ BENCHMARK(seqan3_affine_dna4_collection);
 
 void seqan2_affine_dna4_collection(benchmark::State & state)
 {
+    size_t sequence_length = 100;
+    size_t set_size = 100;
     using sequence_t = decltype(generate_sequence_seqan2<seqan::Dna>());
 
     seqan::StringSet<sequence_t> vec1;
     seqan::StringSet<sequence_t> vec2;
-    for (unsigned i = 0; i < 100; ++i)
+    for (unsigned i = 0; i < set_size; ++i)
     {
-        sequence_t seq1 = generate_sequence_seqan2<seqan::Dna>(100, 0, i);
-        sequence_t seq2 = generate_sequence_seqan2<seqan::Dna>(100, 0, i + 100);
+        sequence_t seq1 = generate_sequence_seqan2<seqan::Dna>(sequence_length, 0, i);
+        sequence_t seq2 = generate_sequence_seqan2<seqan::Dna>(sequence_length, 0, i + set_size);
         appendValue(vec1, seq1);
         appendValue(vec2, seq2);
     }
@@ -199,6 +174,9 @@ void seqan2_affine_dna4_collection(benchmark::State & state)
         // In SeqAn2 the gap open contains already the gap extension costs, that's why we use -11 here.
         seqan::globalAlignmentScore(vec1, vec2, seqan::Score<int>{4, -5, -1, -11});
     }
+
+    state.counters["cells"] = pairwise_cell_updates(ranges::view::zip(vec1, vec2), affine_cfg);
+    state.counters["CUPS"] = cell_updates_per_second(state.counters["cells"]);
 }
 
 BENCHMARK(seqan2_affine_dna4_collection);
@@ -210,26 +188,26 @@ BENCHMARK(seqan2_affine_dna4_collection);
 
 void seqan3_affine_dna4_trace_collection(benchmark::State & state)
 {
-    auto cfg = align_cfg::mode{global_alignment} |
-               align_cfg::gap{gap_scheme{gap_score{-1}, gap_open_score{-10}}} |
-               align_cfg::scoring{nucleotide_scoring_scheme{match_score{4}, mismatch_score{-5}}} |
-               align_cfg::result{with_alignment};
-
-    using sequence_t = decltype(generate_sequence_seqan3<seqan3::dna4>());
+    size_t sequence_length = 100;
+    size_t set_size = 100;
+    using sequence_t = decltype(generate_sequence<seqan3::dna4>());
 
     std::vector<std::pair<sequence_t, sequence_t>> vec;
-    for (unsigned i = 0; i < 100; ++i)
+    for (unsigned i = 0; i < set_size; ++i)
     {
-        sequence_t seq1 = generate_sequence_seqan3<seqan3::dna4>(100, 0, i);
-        sequence_t seq2 = generate_sequence_seqan3<seqan3::dna4>(100, 0, i + 100);
+        sequence_t seq1 = generate_sequence<seqan3::dna4>(sequence_length, 0, i);
+        sequence_t seq2 = generate_sequence<seqan3::dna4>(sequence_length, 0, i + set_size);
         vec.push_back(std::pair{seq1, seq2});
     }
 
     for (auto _ : state)
     {
-        for (auto && rng : align_pairwise(vec, cfg))
+        for (auto && rng : align_pairwise(vec, affine_cfg | align_cfg::result{with_alignment}))
             rng.score();
     }
+
+    state.counters["cells"] = pairwise_cell_updates(vec, affine_cfg);
+    state.counters["CUPS"] = cell_updates_per_second(state.counters["cells"]);
 }
 
 BENCHMARK(seqan3_affine_dna4_trace_collection);
@@ -238,23 +216,24 @@ BENCHMARK(seqan3_affine_dna4_trace_collection);
 
 void seqan2_affine_dna4_trace_collection(benchmark::State & state)
 {
+    size_t sequence_length = 100;
+    size_t set_size = 100;
     using sequence_t = decltype(generate_sequence_seqan2<seqan::Dna>());
 
     seqan::StringSet<sequence_t> vec1;
     seqan::StringSet<sequence_t> vec2;
-    for (unsigned i = 0; i < 100; ++i)
+    for (unsigned i = 0; i < set_size; ++i)
     {
-        sequence_t seq1 = generate_sequence_seqan2<seqan::Dna>(100, 0, i);
-        sequence_t seq2 = generate_sequence_seqan2<seqan::Dna>(100, 0, i + 100);
+        sequence_t seq1 = generate_sequence_seqan2<seqan::Dna>(sequence_length, 0, i);
+        sequence_t seq2 = generate_sequence_seqan2<seqan::Dna>(sequence_length, 0, i + set_size);
         appendValue(vec1, seq1);
         appendValue(vec2, seq2);
     }
 
-
     seqan::StringSet<seqan::Gaps<sequence_t>> gap1;
     seqan::StringSet<seqan::Gaps<sequence_t>> gap2;
 
-    for (unsigned i = 0; i < 100; ++i)
+    for (unsigned i = 0; i < set_size; ++i)
     {
         appendValue(gap1, seqan::Gaps<sequence_t>{vec1[i]});
         appendValue(gap2, seqan::Gaps<sequence_t>{vec2[i]});
@@ -265,6 +244,9 @@ void seqan2_affine_dna4_trace_collection(benchmark::State & state)
         // In SeqAn2 the gap open contains already the gap extension costs, that's why we use -11 here.
         seqan::globalAlignment(gap1, gap2, seqan::Score<int>{4, -5, -1, -11});
     }
+
+    state.counters["cells"] = pairwise_cell_updates(ranges::view::zip(vec1, vec2), affine_cfg);
+    state.counters["CUPS"] = cell_updates_per_second(state.counters["cells"]);
 }
 
 BENCHMARK(seqan2_affine_dna4_trace_collection);

--- a/test/unit/test/CMakeLists.txt
+++ b/test/unit/test/CMakeLists.txt
@@ -1,2 +1,3 @@
-seqan3_test(tmp_filename_test.cpp)
 seqan3_test(pretty_printing_test.cpp)
+seqan3_test(seqan2_test.cpp)
+seqan3_test(tmp_filename_test.cpp)

--- a/test/unit/test/seqan2_test.cpp
+++ b/test/unit/test/seqan2_test.cpp
@@ -1,0 +1,122 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <seqan3/core/concept/tuple.hpp>
+#include <seqan3/core/metafunction/iterator.hpp>
+#include <seqan3/core/metafunction/range.hpp>
+#include <seqan3/test/seqan2.hpp>
+#include <seqan3/std/ranges>
+
+// Note: this file will only test regressions encountered with seqan2 compatibility and has no claim to be complete
+
+#ifdef SEQAN3_HAS_SEQAN2
+#include <seqan/sequence.h>
+
+template <typename T>
+class seqan2_container : public ::testing::Test
+{};
+
+using seqan2_container_types = ::testing::Types<seqan::String<int>, seqan::StringSet<int>>;
+TYPED_TEST_CASE(seqan2_container, seqan2_container_types);
+
+template <typename container_t>
+container_t construct_iota(int n)
+{
+    container_t container{};
+
+    for (int i = 0; i < n; ++i)
+        seqan::appendValue(container, i);
+
+    return container;
+}
+
+TYPED_TEST(seqan2_container, std_ranges_size)
+{
+    using container_t = TypeParam;
+    container_t container = construct_iota<container_t>(5u);
+
+    EXPECT_EQ(5u, std::ranges::size(container));
+}
+
+TYPED_TEST(seqan2_container, std_ranges_begin_end)
+{
+    using container_t = TypeParam;
+    container_t container = construct_iota<container_t>(5u);
+
+    auto it = std::ranges::begin(container);
+    auto it_end = std::ranges::end(container);
+
+    EXPECT_TRUE((std::Same<decltype(it), decltype(seqan::begin(container))>));
+    EXPECT_TRUE((std::Same<decltype(it_end), decltype(seqan::end(container))>));
+
+    for (int i = 0; it != it_end; ++it, ++i)
+    {
+        EXPECT_EQ(i, *it);
+    }
+}
+
+TYPED_TEST(seqan2_container, std_ranges_iterator)
+{
+    using container_t = TypeParam;
+    using iterator_t = decltype(std::ranges::begin(std::declval<container_t &>()));
+    using const_iterator_t = decltype(std::ranges::begin(std::declval<container_t const &>()));
+
+    EXPECT_TRUE((std::Same<std::ranges::iterator_t<container_t>, iterator_t>));
+    EXPECT_TRUE((std::Same<std::ranges::iterator_t<container_t &>, iterator_t>));
+    EXPECT_TRUE((std::Same<std::ranges::iterator_t<container_t const>, const_iterator_t>));
+    EXPECT_TRUE((std::Same<std::ranges::iterator_t<container_t const &>, const_iterator_t>));
+}
+
+TYPED_TEST(seqan2_container, std_iterator_traits)
+{
+    using container_t = TypeParam;
+    using iterator_t = std::ranges::iterator_t<container_t>;
+    using value_type = typename std::iterator_traits<iterator_t>::value_type;
+    EXPECT_TRUE((std::Same<value_type, int>));
+}
+
+TYPED_TEST(seqan2_container, std_iterator)
+{
+    using container_t = TypeParam;
+    using iterator_t = std::ranges::iterator_t<container_t>;
+    EXPECT_FALSE(std::Iterator<container_t>);
+    EXPECT_TRUE(std::Iterator<iterator_t>);
+}
+
+template <typename range_t>
+SEQAN3_CONCEPT SeqAn2Range = requires(range_t range)
+{
+    {seqan::begin(range)} -> std::ranges::iterator_t<range_t>;
+    {seqan::end(range)} -> std::ranges::iterator_t<range_t>;
+};
+
+TYPED_TEST(seqan2_container, seqan_range_concept)
+{
+    using container_t = TypeParam;
+    using iterator_t = std::ranges::iterator_t<container_t>;
+    EXPECT_TRUE(SeqAn2Range<container_t>);
+    EXPECT_FALSE(SeqAn2Range<iterator_t>);
+}
+
+TYPED_TEST(seqan2_container, std_ranges_range)
+{
+    using container_t = TypeParam;
+    using iterator_t = std::ranges::iterator_t<container_t>;
+    EXPECT_TRUE(std::ranges::Range<container_t>);
+    EXPECT_FALSE(std::ranges::Range<iterator_t>);
+}
+
+TYPED_TEST(seqan2_container, seqan3_value_type)
+{
+    using container_t = TypeParam;
+    using value_type = seqan3::value_type_t<container_t>;
+    EXPECT_TRUE((std::Same<value_type, int>));
+}
+
+#endif


### PR DESCRIPTION
This PR
* introduces CUPS unit for alignment benchmark
  ```
    2019-02-20 03:19:45
    Running ./affine_alignment_benchmark
    Run on (8 X 3900 MHz CPU s)
    CPU Caches:
      L1 Data 32K (x4)
      L1 Instruction 32K (x4)
      L2 Unified 256K (x4)
      L3 Unified 8192K (x1)
    Load Average: 1.97, 1.91, 1.75
    ***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
    ----------------------------------------------------------------------------------------
    Benchmark                              Time             CPU   Iterations UserCounters...
    ----------------------------------------------------------------------------------------
    seqan3_affine_dna4                547784 ns       545909 ns         1122 CUPS=459.786M/s cells=251.001k
    seqan2_affine_dna4                543044 ns       541903 ns         1284 CUPS=463.185M/s cells=251.001k
    seqan3_affine_dna4_collection    2196457 ns      2191458 ns          321 CUPS=465.489M/s cells=1020.1k
    seqan2_affine_dna4_collection     279064 ns       278199 ns         2434 CUPS=3.66679G/s cells=1020.1k
  ```
* adds method to calculate total cell updates per run
* splits some commonly used utility for alignment benchmarks into own files (for a later PR where myers gets an alignment benchmark and reuses functions)
* adds a compatibility layer for seqan2 in test cases (might solve #748).