### PR TITLE
[FIX] argument parsing of option with empty long identifier.

### DIFF
--- a/include/seqan3/argument_parser/argument_parser.hpp
+++ b/include/seqan3/argument_parser/argument_parser.hpp
@@ -521,27 +521,16 @@ private:
     }
 
     /*!\brief Checks whether the long identifier has already been used before.
-    * \param[in] long_id The long identifier of the command line option/flag.
+    * \param[in] id The long identifier of the command line option/flag.
     * \returns `true` if an option or flag with the long identifier exists or `false`
     *          otherwise.
     */
-    bool id_exists(std::string const & long_id)
+    template <typename id_type>
+    bool id_exists(id_type const & id)
     {
-        if (long_id.empty())
+        if (detail::format_parse::is_empty_id(id))
             return false;
-        return(!(used_option_ids.insert(long_id)).second);
-    }
-
-    /*!\brief Checks whether the short identifier has already been used before.
-    * \param[in] short_id The short identifier of the command line option/flag.
-    * \returns `true` if an option or flag with the identifier exists or `false`
-    *          otherwise.
-    */
-    bool id_exists(char const short_id)
-    {
-        if (short_id == '\0')
-            return false;
-        return(!(used_option_ids.insert(std::string(1, short_id))).second);
+        return (!(used_option_ids.insert(std::string({id}))).second);
     }
 
     /*!\brief Verifies that the short and the long identifiers are correctly formatted.
@@ -573,7 +562,7 @@ private:
                           if (!(allowed(c) || is_char<'-'>(c)))
                               throw parser_design_error("Long identifiers may only contain alphanumeric characters, '_', '-', or '@'.");
                       });
-        if (short_id == '\0' && long_id.empty())
+        if (detail::format_parse::is_empty_id(short_id) && detail::format_parse::is_empty_id(long_id))
             throw parser_design_error("Option Identifiers cannot both be empty.");
     }
 

--- a/include/seqan3/argument_parser/detail/format_parse.hpp
+++ b/include/seqan3/argument_parser/detail/format_parse.hpp
@@ -173,6 +173,16 @@ public:
     void add_list_item(std::string const &, std::string const &) {}
     //!\endcond
 
+    //!\brief Checks whether \p id is empty.
+    template <typename id_type>
+    static bool is_empty_id(id_type const & id)
+    {
+        if constexpr (std::Same<remove_cvref_t<id_type>, std::string>)
+            return id.empty();
+        else // char
+            return is_char<'\0'>(id);
+    }
+
 private:
     /*!\brief Initializes the format_parse on construction.
      *
@@ -224,7 +234,10 @@ private:
     template <typename id_type>
     std::vector<std::string>::iterator find_option_id(std::vector<std::string>::iterator const begin_it, id_type const & id)
     {
-        return(std::find_if(begin_it, end_of_options_it,
+        if (is_empty_id(id))
+            return end_of_options_it;
+
+        return (std::find_if(begin_it, end_of_options_it,
             [&] (const std::string & v)
             {
                 size_t id_size{(prepend_dash(id)).size()};

--- a/test/unit/argument_parser/format_parse_test.cpp
+++ b/test/unit/argument_parser/format_parse_test.cpp
@@ -769,6 +769,15 @@ TEST(parse_test, multiple_empty_options)
     }
 
     {
+        const char * argv[]{"./empty_long", "-s=1", "--unknown"};
+        argument_parser parser("empty_long", 3, argv);
+        parser.add_option(option_value, 'i', "", "no long");
+        parser.add_option(option_value, 's', "", "no long");
+
+        EXPECT_THROW(parser.parse(), unknown_option);
+    }
+
+    {
         const char * argv[]{"./empty_short", "--long=2"};
         argument_parser parser("empty_short", 2, argv);
         parser.add_option(option_value, '\0', "longi", "no short");


### PR DESCRIPTION
The test I added formerly would throw a `cast_conversion` error because it would recognize `--` as the long identifier for the `i` option and then parse `unknown` as the option value.