### PR TITLE
Feature affine traceback computation for alignments

### DIFF
--- a/include/seqan3/alignment/matrix/alignment_coordinate.hpp
+++ b/include/seqan3/alignment/matrix/alignment_coordinate.hpp
@@ -15,6 +15,7 @@
 #include <type_traits>
 
 #include <seqan3/core/detail/strong_type.hpp>
+#include <seqan3/io/stream/debug_stream.hpp>
 #include <seqan3/std/concepts>
 #include <seqan3/std/iterator>
 
@@ -370,5 +371,25 @@ public:
     //!\brief The begin/end position of the alignment in the second sequence.
     SEQAN3_DOXYGEN_ONLY(size_t second_seq_pos;)
 };
+
+/*!\brief A seqan3::alignment_coordinate can be printed to the seqan3::debug_stream.
+ * \tparam    coordinate_type The alignment coordinate type.
+ * \param[in] s               The seqan3::debug_stream.
+ * \param[in] c               The alignment coordinate to print.
+ * \relates seqan3::debug_stream_type
+ *
+ * \details
+ *
+ * Prints the alignment coordinate as a tuple.
+ */
+template <typename coordinate_type>
+//!\cond
+    requires std::Same<remove_cvref_t<coordinate_type>, alignment_coordinate>
+//!\endcond
+inline debug_stream_type & operator<<(debug_stream_type & s, coordinate_type && c)
+{
+    s << std::tie(c.first_seq_pos, c.second_seq_pos);
+    return s;
+}
 
 } // namespace seqan3

--- a/include/seqan3/alignment/matrix/alignment_coordinate.hpp
+++ b/include/seqan3/alignment/matrix/alignment_coordinate.hpp
@@ -37,7 +37,7 @@ struct row_index_type : detail::strong_type<size_t, row_index_type>
     using detail::strong_type<size_t, row_index_type>::strong_type;
 };
 
-/*!\brief Represents a state to specify the implementation of the seqan3::detail::advanceable_alignment_coordinate
+/*!\brief Represents a state to specify the implementation of the seqan3::detail::advanceable_alignment_coordinate.
  * \ingroup alignment_matrix
  *
  * \details
@@ -94,21 +94,21 @@ public:
     ~advanceable_alignment_coordinate() noexcept = default;
 
     //!\brief Copy-constructs from another advanceable_alignment_coordinate with a different policy.
-    template <advanceable_alignment_coordinate_state _state>
+    template <advanceable_alignment_coordinate_state other_state>
     //!\cond
-        requires !std::Same<_state, state>
+        requires !std::Same<other_state, state>
     //!\endcond
-    constexpr advanceable_alignment_coordinate(advanceable_alignment_coordinate<_state> const & other) :
+    constexpr advanceable_alignment_coordinate(advanceable_alignment_coordinate<other_state> const & other) :
         first_seq_pos{other.first_seq_pos},
         second_seq_pos{other.second_seq_pos}
     {}
 
     //!\brief Move-constructs from another advanceable_alignment_coordinate with a different policy.
-    template <advanceable_alignment_coordinate_state _state>
+    template <advanceable_alignment_coordinate_state other_state>
     //!\cond
-        requires !std::Same<_state, state>
+        requires !std::Same<other_state, state>
     //!\endcond
-    constexpr advanceable_alignment_coordinate(advanceable_alignment_coordinate<_state> && other) :
+    constexpr advanceable_alignment_coordinate(advanceable_alignment_coordinate<other_state> && other) :
         first_seq_pos{std::move(other.first_seq_pos)},
         second_seq_pos{std::move(other.second_seq_pos)}
     {}
@@ -252,7 +252,7 @@ public:
               not available if the policy was set to seqan3::detail::advanceable_alignment_coordinate_state::none.
      */
     constexpr friend advanceable_alignment_coordinate operator+(difference_type const offset,
-                                         advanceable_alignment_coordinate const & me) noexcept
+                                                                advanceable_alignment_coordinate const & me) noexcept
     //!\cond
         requires state != advanceable_alignment_coordinate_state::none
     //!\endcond
@@ -275,11 +275,14 @@ namespace seqan3
 /*!\brief Represents the begin/end of the pairwise alignment in the respective sequences.
  * \ingroup alignment_matrix
  *
- * \details
  * \if DEV
+ * \details
  * This class only gives access to the respective positions of the sequences and is meant for
- * the user interface. For the implementation of the alignment algorithms the
- * seqan3::detail::advanceable_alignment_coordinate is used.
+ * the user interface. The additional complexity of an advanceable coorindate using the
+ * seqan3::detail::advanceable_alignment_coordinate is only necessary for the implementation of the pairwise
+ * alignment algorithm. Within in the algorithm the coordinate is used in combination with a seqan3::view::iota to
+ * keep track of the current position within the alignment matrix. For the user, however, this interface adds no
+ * benefit as they are only interested in the begin/end coordinates for the respective alignment.
  * \endif
  */
 class alignment_coordinate
@@ -305,20 +308,15 @@ public:
     ~alignment_coordinate() = default;
 
     //!\cond DEV
-    //!\brief Constructs from the seqan3::detail::advanceable_alignment_coordinate base class.
+    //!\brief Inherit the constructor from the base class.
+    using base_t::base_t;
+
+    // !\brief Constructs from the seqan3::detail::advanceable_alignment_coordinate base class.
     constexpr alignment_coordinate(base_t const & base) : base_t{base}
     {}
 
     //!\brief Constructs from the seqan3::detail::advanceable_alignment_coordinate base class.
     constexpr alignment_coordinate(base_t && base) : base_t{std::move(base)}
-    {}
-
-    /*!\brief Construction from the respective column and row indices.
-     * \param[in] c_idx The respective column index within the matrix. Of type seqan3::detail::column_index_type.
-     * \param[in] r_idx The respective row index within the matrix. Of type seqan3::detail::row_index_type.
-     */
-    constexpr alignment_coordinate(detail::column_index_type const c_idx,
-                                   detail::row_index_type const r_idx) noexcept : base_t{c_idx, r_idx}
     {}
     //!\endcond
     //!\}

--- a/include/seqan3/alignment/matrix/alignment_coordinate.hpp
+++ b/include/seqan3/alignment/matrix/alignment_coordinate.hpp
@@ -12,20 +12,363 @@
 
 #pragma once
 
-#include <seqan3/core/platform.hpp>
+#include <type_traits>
+
+#include <seqan3/core/detail/strong_type.hpp>
+#include <seqan3/std/concepts>
+#include <seqan3/std/iterator>
 
 namespace seqan3::detail
 {
-
-/*!\brief Represents the begin/end of the pairwise alignment in the respective sequences.
- * This class can for example be used to represent the coordinate where the best alignment score is located.
+/*!\brief A strong type for designated initialisation of the column index of the seqan3::detail::alignment_coordinate.
+ * \ingroup alignment_matrix
+ * \tparam index_t The type of the index; must model std::UnsignedIntegral.
  */
-struct alignment_coordinate
+template <std::UnsignedIntegral index_t>
+struct column_index_type : detail::strong_type<index_t, column_index_type<index_t>>
 {
-    //!\brief The position in the first sequence.
-    size_t seq1_pos;
-    //!\brief The position in the second sequence.
-    size_t seq2_pos;
+    //!!\brief Introduce base class constructor into this type's definition.
+    using detail::strong_type<index_t, column_index_type<index_t>>::strong_type;
 };
 
+/*!\name Type deduction guides
+ * \{
+ */
+//!\brief The default constructed element deduces to `size_t`.
+column_index_type() -> column_index_type<size_t>;
+//!\brief Deduces the position type from the constructor argument.
+template <std::UnsignedIntegral index_t>
+column_index_type(index_t const) -> column_index_type<size_t>;
+//!\}
+
+/*!\brief A strong type for designated initialisation of the row index of the seqan3::detail::alignment_coordinate.
+ * \ingroup alignment_matrix
+ * \tparam index_t The type of the index; must model std::UnsignedIntegral.
+ */
+template <std::UnsignedIntegral index_t>
+struct row_index_type : detail::strong_type<index_t, row_index_type<index_t>>
+{
+    //!!\brief Introduce base class constructor into this type's definition.
+    using detail::strong_type<index_t, row_index_type<index_t>>::strong_type;
+};
+
+/*!\name Type deduction guides
+ * \{
+ */
+//!\brief The default constructed element deduces to `size_t`.
+row_index_type() -> row_index_type<size_t>;
+//!\brief Deduces the position type from the constructor argument.
+template <std::UnsignedIntegral index_t>
+row_index_type(index_t const) -> row_index_type<size_t>;
+//!\}
+
+/*!\brief Represents a state to specify the implementation of the seqan3::detail::advanceable_alignment_coordinate
+ * \ingroup alignment_matrix
+ *
+ * \details
+ *
+ * The class seqan3::detail::alignment_coordinate can be extended with an incrementable and decrementable policy,
+ * such that it can be used as a value type inside of a iota_view. This state offers three policies: none, which
+ * leaves the functionality of seqan3::detail::alignment_coordinate untouched; column, which adds the respective
+ * functionality only for the column index and row, which adds the respective functionality only for the row index.
+ */
+enum struct advanceable_alignment_coordinate_state : uint8_t
+{
+    //!\brief The corresponding alignment coordinate will not be incrementable/decrementable.
+    none,
+    //!\brief The corresponding alignment coordinate will be incrementable/decrementable in the column index.
+    column,
+    //!\brief The corresponding alignment coordinate will be incrementable/decrementable in the row index.
+    row
+};
+
+/*!\brief Implements an internal alignment coordinate that can be used as an argument to the std::ranges::iota_view.
+ * \ingroup alignment_matrix
+ * \implements std::EqualityComparable
+ * \tparam index_t  The type of the sequence index; must model std::UnsignedIntegral.
+ * \tparam states   A non-type template flag to enable a specific advanceable policy.
+ *                  See seqan3::detail::advanceable_alignment_coordinate_state
+ *
+ * \details
+ *
+ * This class provides all members to make the `advanceable_alignment_coordinate` be usable in a std::ranges::iota_view.
+ * For the purpose of alignments modelling only incrementable and decrementable would fully suffice.
+ * Unfortunately, the current range implementation does not preserve std::ranges::BidirectionalRange properties,
+ * so we need to model the full advanceable concept in order to preserve the std::ranges::RandomAccessRange properties.
+ * This however can be relaxed if the range implementation fully complies with the current standard draft for Ranges,
+ * and increment and decrement would be enough.
+ */
+template <std::UnsignedIntegral index_t,
+          advanceable_alignment_coordinate_state state = advanceable_alignment_coordinate_state::none>
+class advanceable_alignment_coordinate
+{
+public:
+
+    //!\name Member types
+    //!\{
+    //!\brief Defines the difference type to model the std::WeaklyIncrementable concept.
+    using difference_type = std::make_signed_t<index_t>;
+    //!\}
+
+    /*!\name Constructor, destructor and assignment
+     * \{
+     */
+    constexpr advanceable_alignment_coordinate() noexcept = default;
+    constexpr advanceable_alignment_coordinate(advanceable_alignment_coordinate const &) noexcept = default;
+    constexpr advanceable_alignment_coordinate(advanceable_alignment_coordinate &&) noexcept = default;
+    constexpr advanceable_alignment_coordinate & operator=(advanceable_alignment_coordinate const &) noexcept = default;
+    constexpr advanceable_alignment_coordinate & operator=(advanceable_alignment_coordinate &&) noexcept = default;
+    ~advanceable_alignment_coordinate() noexcept = default;
+
+    //!\brief Copy-constructs from another advanceable_alignment_coordinate with a different policy.
+    template <typename _index_t, advanceable_alignment_coordinate_state _state>
+        requires std::Same<_index_t, index_t> && !std::Same<_state, state>
+    constexpr advanceable_alignment_coordinate(advanceable_alignment_coordinate<_index_t, _state> const & other) :
+        first_seq_pos{other.first_seq_pos},
+        second_seq_pos{other.second_seq_pos}
+    {}
+
+    //!\brief Move-constructs from another advanceable_alignment_coordinate with a different policy.
+    template <typename _index_t, advanceable_alignment_coordinate_state _state>
+        requires std::Same<_index_t, index_t> && !std::Same<_state, state>
+    constexpr advanceable_alignment_coordinate(advanceable_alignment_coordinate<_index_t, _state> && other) :
+        first_seq_pos{std::move(other.first_seq_pos)},
+        second_seq_pos{std::move(other.second_seq_pos)}
+    {}
+
+    /*!\brief Save construction from column and row indices.
+     * \param c_idx The respective column index within the matrix. Of type seqan3::detail::column_index_type.
+     * \param r_idx The respective row index within the matrix. Of type seqan3::detail::row_index_type.
+     */
+    constexpr advanceable_alignment_coordinate(column_index_type<index_t> const c_idx,
+                                               row_index_type<index_t> const r_idx) noexcept :
+        first_seq_pos{c_idx.get()},
+        second_seq_pos{r_idx.get()}
+    {}
+    //!\}
+
+     //!\cond
+     constexpr friend bool operator==(advanceable_alignment_coordinate const & lhs,
+                                      advanceable_alignment_coordinate const & rhs) noexcept
+     {
+         return (lhs.first_seq_pos == rhs.first_seq_pos) &&
+                (lhs.second_seq_pos == rhs.second_seq_pos);
+     }
+
+     constexpr friend bool operator!=(advanceable_alignment_coordinate const & lhs,
+                                      advanceable_alignment_coordinate const & rhs) noexcept
+     {
+         return !(lhs == rhs);
+     }
+     //!\endcond
+
+    /*!\name Member functions
+     * \brief Advances or decrements the respective column or row coordinate depending on the set policy.
+     *        These member functions are not available if the non-type template parameter `state` was set to
+     *        seqan3::detail::advanceable_alignment_coordinate_state::none.
+     * \{
+     */
+
+    constexpr advanceable_alignment_coordinate & operator++(/*pre-increment*/) noexcept
+    //!\cond
+        requires state != advanceable_alignment_coordinate_state::none
+    //!\endcond
+    {
+        if constexpr (state == advanceable_alignment_coordinate_state::column)
+            ++this->first_seq_pos;
+        else
+            ++this->second_seq_pos;
+        return *this;
+    }
+
+    constexpr advanceable_alignment_coordinate operator++(int /*post-increment*/) noexcept
+    //!\cond
+        requires state != advanceable_alignment_coordinate_state::none
+    //!\endcond
+    {
+        advanceable_alignment_coordinate tmp{*this};
+        ++(*this);
+        return tmp;
+    }
+
+    constexpr advanceable_alignment_coordinate & operator--(/*pre-decrement*/) noexcept
+    //!\cond
+        requires state != advanceable_alignment_coordinate_state::none
+    //!\endcond
+    {
+        if constexpr (state == advanceable_alignment_coordinate_state::column)
+            --this->first_seq_pos;
+        else
+            --this->second_seq_pos;
+        return *this;
+    }
+
+    constexpr advanceable_alignment_coordinate operator--(int /*post-decrement*/) noexcept
+    //!\cond
+        requires state != advanceable_alignment_coordinate_state::none
+    //!\endcond
+    {
+        advanceable_alignment_coordinate tmp{*this};
+        --(*this);
+        return tmp;
+    }
+
+    constexpr advanceable_alignment_coordinate & operator+=(difference_type const offset) noexcept
+    //!\cond
+        requires state != advanceable_alignment_coordinate_state::none
+    //!\endcond
+    {
+        if constexpr (state == advanceable_alignment_coordinate_state::column)
+            this->first_seq_pos += offset;
+        else
+            this->second_seq_pos += offset;
+        return *this;
+    }
+
+    constexpr advanceable_alignment_coordinate & operator-=(difference_type const offset) noexcept
+    //!\cond
+        requires state != advanceable_alignment_coordinate_state::none
+    //!\endcond
+    {
+        if constexpr (state == advanceable_alignment_coordinate_state::column)
+            this->first_seq_pos -= offset;
+        else
+            this->second_seq_pos -= offset;
+        return *this;
+    }
+
+    constexpr advanceable_alignment_coordinate operator+(difference_type const offset) const noexcept
+    //!\cond
+        requires state != advanceable_alignment_coordinate_state::none
+    //!\endcond
+    {
+        advanceable_alignment_coordinate tmp{*this};
+        tmp += offset;
+        return tmp;
+    }
+
+    constexpr advanceable_alignment_coordinate operator-(difference_type const offset) const noexcept
+    //!\cond
+        requires state != advanceable_alignment_coordinate_state::none
+    //!\endcond
+    {
+        advanceable_alignment_coordinate tmp{*this};
+        tmp -= offset;
+        return tmp;
+    }
+
+    constexpr difference_type operator-(advanceable_alignment_coordinate const & other) const noexcept
+    //!\cond
+        requires state != advanceable_alignment_coordinate_state::none
+    //!\endcond
+    {
+        if constexpr (state == advanceable_alignment_coordinate_state::column)
+            return this->first_seq_pos - other.first_seq_pos;
+        else
+            return this->second_seq_pos - other.second_seq_pos;
+    }
+    //!\}
+
+    //!\brief Non-member function
+    //!\{
+
+    /*!\brief Advances the respective coordinate depending on the set policy by the given offset. This function is
+              not available if the policy was set to seqan3::detail::advanceable_alignment_coordinate_state::none.
+     */
+    constexpr friend advanceable_alignment_coordinate operator+(difference_type const offset,
+                                         advanceable_alignment_coordinate const & me) noexcept
+    //!\cond
+        requires state != advanceable_alignment_coordinate_state::none
+    //!\endcond
+    {
+        return me + offset;
+    }
+    //!\}
+
+    //!\brief The begin/end position of the alignment in the first sequence.
+    index_t first_seq_pos{};
+    //!\brief The begin/end position of the alignment in the second sequence.
+    index_t second_seq_pos{};
+};
+
+/*!\name Type deduction guides
+ * \{
+ */
+advanceable_alignment_coordinate() -> advanceable_alignment_coordinate<size_t>;
+//!\brief Deduces the position type from the constructor.
+template <std::UnsignedIntegral index_t>
+advanceable_alignment_coordinate(column_index_type<index_t> const, row_index_type<index_t> const) ->
+    advanceable_alignment_coordinate<size_t>;
+//!\}
+
 } // namespace seqan3::detail
+
+namespace seqan3
+{
+
+/*!\brief Represents the begin/end of the pairwise alignment in the respective sequences.
+ * \ingroup alignment_matrix
+ *
+ * \details
+ * \if DEV
+ * This class only gives access to the respective positions of the sequences and is meant for
+ * the user interface. For the implementation of the alignment algorithms the
+ * seqan3::detail::advanceable_alignment_coordinate is used.
+ * \endif
+ */
+class alignment_coordinate
+//!\cond DEV
+    : public detail::advanceable_alignment_coordinate<size_t>
+//!\endcond
+{
+    //!\cond DEV
+    //!\brief The type of the base class.
+    using base_t = detail::advanceable_alignment_coordinate<size_t>;
+    //!\endcond
+
+public:
+
+    /*!\name Constructor, destructor and assignment
+     * \{
+     */
+    constexpr alignment_coordinate() = default;
+    constexpr alignment_coordinate(alignment_coordinate const &) = default;
+    constexpr alignment_coordinate(alignment_coordinate &&) = default;
+    constexpr alignment_coordinate & operator=(alignment_coordinate const &) = default;
+    constexpr alignment_coordinate & operator=(alignment_coordinate &&) = default;
+    ~alignment_coordinate() = default;
+
+    //!\cond DEV
+    //!\brief Constructs from the seqan3::detail::advanceable_alignment_coordinate base class.
+    constexpr alignment_coordinate(base_t const & base) : base_t{base}
+    {}
+
+    //!\brief Constructs from the seqan3::detail::advanceable_alignment_coordinate base class.
+    constexpr alignment_coordinate(base_t && base) : base_t{std::move(base)}
+    {}
+
+    /*!\brief Save construction from column and row indices.
+     * \tparam index_t The index type used to store the column and row position.
+     * \param[in] c_idx The respective column index within the matrix. Of type seqan3::detail::column_index_type.
+     * \param[in] r_idx The respective row index within the matrix. Of type seqan3::detail::row_index_type.
+     */
+    template <typename index_t>
+    constexpr alignment_coordinate(detail::column_index_type<index_t> const c_idx,
+                                   detail::row_index_type<index_t> const r_idx) noexcept :
+        base_t{c_idx, r_idx}
+    {}
+    //!\endcond
+    //!\}
+
+    //!\brief The begin/end position of the alignment in the first sequence.
+    using base_t::first_seq_pos;
+    //!\brief The begin/end position of the alignment in the second sequence.
+    using base_t::second_seq_pos;
+
+    //!\brief The begin/end position of the alignment in the first sequence.
+    SEQAN3_DOXYGEN_ONLY(size_t first_seq_pos;)
+    //!\brief The begin/end position of the alignment in the second sequence.
+    SEQAN3_DOXYGEN_ONLY(size_t second_seq_pos;)
+};
+
+} // namespace seqan3

--- a/include/seqan3/alignment/matrix/alignment_coordinate.hpp
+++ b/include/seqan3/alignment/matrix/alignment_coordinate.hpp
@@ -68,7 +68,7 @@ row_index_type(index_t const) -> row_index_type<size_t>;
  *
  * \details
  *
- * The class seqan3::detail::alignment_coordinate can be extended with an incrementable and decrementable policy,
+ * The class seqan3::detail::alignment_coordinate can be extended with an incrementable and decrementable policy
  * such that it can be used as a value type inside of a iota_view. This state offers three policies: none, which
  * leaves the functionality of seqan3::detail::alignment_coordinate untouched; column, which adds the respective
  * functionality only for the column index and row, which adds the respective functionality only for the row index.
@@ -93,11 +93,11 @@ enum struct advanceable_alignment_coordinate_state : uint8_t
  * \details
  *
  * This class provides all members to make the `advanceable_alignment_coordinate` be usable in a std::ranges::iota_view.
- * For the purpose of alignments modelling only incrementable and decrementable would fully suffice.
+ * For the purpose of alignments, modelling only incrementable and decrementable would fully suffice.
  * Unfortunately, the current range implementation does not preserve std::ranges::BidirectionalRange properties,
  * so we need to model the full advanceable concept in order to preserve the std::ranges::RandomAccessRange properties.
- * This however can be relaxed if the range implementation fully complies with the current standard draft for Ranges,
- * and increment and decrement would be enough.
+ * This, however, can be relaxed if the range implementation fully complies with the current standard draft for Ranges,
+ * as increment and decrement would be enough.
  */
 template <std::UnsignedIntegral index_t,
           advanceable_alignment_coordinate_state state = advanceable_alignment_coordinate_state::none>
@@ -137,7 +137,7 @@ public:
         second_seq_pos{std::move(other.second_seq_pos)}
     {}
 
-    /*!\brief Save construction from column and row indices.
+    /*!\brief Construction from the respective column and row indices.
      * \param c_idx The respective column index within the matrix. Of type seqan3::detail::column_index_type.
      * \param r_idx The respective row index within the matrix. Of type seqan3::detail::row_index_type.
      */
@@ -348,7 +348,7 @@ public:
     constexpr alignment_coordinate(base_t && base) : base_t{std::move(base)}
     {}
 
-    /*!\brief Save construction from column and row indices.
+    /*!\brief Construction from the respective column and row indices.
      * \tparam index_t The index type used to store the column and row position.
      * \param[in] c_idx The respective column index within the matrix. Of type seqan3::detail::column_index_type.
      * \param[in] r_idx The respective row index within the matrix. Of type seqan3::detail::row_index_type.
@@ -361,9 +361,7 @@ public:
     //!\endcond
     //!\}
 
-    //!\brief The begin/end position of the alignment in the first sequence.
     using base_t::first_seq_pos;
-    //!\brief The begin/end position of the alignment in the second sequence.
     using base_t::second_seq_pos;
 
     //!\brief The begin/end position of the alignment in the first sequence.
@@ -384,9 +382,11 @@ public:
  */
 template <typename coordinate_type>
 //!\cond
-    requires std::Same<remove_cvref_t<coordinate_type>, alignment_coordinate>
+    requires std::Same<remove_cvref_t<coordinate_type>, alignment_coordinate> ||
+             detail::is_type_specialisation_of_v<remove_cvref_t<coordinate_type>,
+                                                 detail::advanceable_alignment_coordinate>
 //!\endcond
-inline debug_stream_type & operator<<(debug_stream_type & s, coordinate_type && c)
+inline debug_stream_type & operator<<(debug_stream_type & s, coordinate_type const & c)
 {
     s << std::tie(c.first_seq_pos, c.second_seq_pos);
     return s;

--- a/include/seqan3/alignment/matrix/alignment_coordinate.hpp
+++ b/include/seqan3/alignment/matrix/alignment_coordinate.hpp
@@ -61,7 +61,7 @@ enum struct advanceable_alignment_coordinate_state : uint8_t
  * \ingroup alignment_matrix
  * \implements std::EqualityComparable
  * \tparam states   A non-type template flag to enable a specific advanceable policy.
- *                  See seqan3::detail::advanceable_alignment_coordinate_state
+ * \see seqan3::detail::advanceable_alignment_coordinate_state.
  *
  * \details
  *

--- a/include/seqan3/alignment/matrix/alignment_optimum.hpp
+++ b/include/seqan3/alignment/matrix/alignment_optimum.hpp
@@ -1,0 +1,86 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides seqan3::detail::alignment_optimum.
+ * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <type_traits>
+
+#include <seqan3/alignment/matrix/alignment_coordinate.hpp>
+#include <seqan3/core/concept/core_language.hpp>
+#include <seqan3/core/metafunction/template_inspection.hpp>
+#include <seqan3/std/concepts>
+
+namespace seqan3::detail
+{
+
+/*!\brief Stores the current optimum in the alignment algorithms.
+ * \ingroup alignment_matrix
+ * \tparam score_t The type of the tracked alignment score.
+ *
+ * \details
+ *
+ * This is an aggregate type, so the score needs to be passed before the seqan3::alignment_coordinate during
+ * construction.
+ */
+template <Arithmetic score_t>
+struct alignment_optimum
+{
+    //!\brief The optimal score.
+    score_t score{std::numeric_limits<score_t>::lowest()};
+    //!\brief The corresponding coordinate within the alignment matrix.
+    alignment_coordinate coordinate{};
+};
+
+/*!\name Type deduction guide
+ * \{
+ */
+
+alignment_optimum() -> alignment_optimum<int32_t>;
+
+template <Arithmetic score_t>
+alignment_optimum(score_t const, alignment_coordinate const) ->
+    alignment_optimum<std::remove_reference_t<score_t>>;
+//!\}
+
+/*!\brief A less than comparator for two seqan3::detail::alignment_optimum objects.
+ * \ingroup alignment_matrix
+ *
+ * \details
+ *
+ * This function object is used in std::max functions to compare two seqan3::detail::alignment_optimum objects.
+ */
+struct alignment_optimum_compare_less
+{
+
+    /*!\brief Function call operator that implements less than comparison.
+     * \tparam lhs_t The type of the left-hand side operand. Must be a type specialisation of
+     *               seqan3::detail::alignment_optimum.
+     * \tparam rhs_t The type of the right-hand side operand. Must be a type specialisation of
+     *               seqan3::detail::alignment_optimum.
+     *
+     * \param[in] lhs The left-hand side operand.
+     * \param[in] rhs The right-hand side operand.
+     *
+     * \returns bool `true` if `lhs.score < rhs.score`, otherwise `false`.
+     */
+    template <typename lhs_t, typename rhs_t>
+    //!\cond
+        requires (is_type_specialisation_of_v<lhs_t, alignment_optimum> &&
+                  is_type_specialisation_of_v<rhs_t, alignment_optimum>)
+    //!\endcond
+    constexpr bool operator()(lhs_t const & lhs, rhs_t const & rhs) const
+    {
+        return lhs.score < rhs.score;
+    }
+};
+
+} // namespace seqan3::detail

--- a/include/seqan3/alignment/matrix/alignment_optimum.hpp
+++ b/include/seqan3/alignment/matrix/alignment_optimum.hpp
@@ -22,7 +22,7 @@
 namespace seqan3::detail
 {
 
-/*!\brief Stores the current optimum in the alignment algorithms.
+/*!\brief Stores the current optimum of the alignment algorithms.
  * \ingroup alignment_matrix
  * \tparam score_t The type of the tracked alignment score.
  *
@@ -40,7 +40,7 @@ struct alignment_optimum
     alignment_coordinate coordinate{};
 };
 
-/*!\name Type deduction guide
+/*!\name Type deduction guides
  * \{
  */
 

--- a/include/seqan3/alignment/matrix/alignment_optimum.hpp
+++ b/include/seqan3/alignment/matrix/alignment_optimum.hpp
@@ -43,7 +43,7 @@ struct alignment_optimum
 /*!\name Type deduction guides
  * \{
  */
-
+//!\brief Default constructed objects deduce to `int32_t`.
 alignment_optimum() -> alignment_optimum<int32_t>;
 
 template <Arithmetic score_t>

--- a/include/seqan3/alignment/matrix/alignment_trace_algorithms.hpp
+++ b/include/seqan3/alignment/matrix/alignment_trace_algorithms.hpp
@@ -41,8 +41,8 @@ inline alignment_coordinate alignment_begin_coordinate(trace_matrix_t && matrix,
     constexpr auto D = trace_directions::diagonal;
     constexpr auto L = trace_directions::left;
     constexpr auto U = trace_directions::up;
-    size_t row = end_coordinate.seq2_pos + 1;
-    size_t col = end_coordinate.seq1_pos + 1;
+    size_t row = end_coordinate.second_seq_pos + 1;
+    size_t col = end_coordinate.first_seq_pos + 1;
 
     assert(row < matrix.rows());
     assert(col < matrix.cols());
@@ -73,7 +73,7 @@ inline alignment_coordinate alignment_begin_coordinate(trace_matrix_t && matrix,
         }
     }
 
-    return {std::max<size_t>(col, 1) - 1, std::max<size_t>(row, 1) - 1};
+    return {column_index_type{std::max<size_t>(col, 1) - 1}, row_index_type{std::max<size_t>(row, 1) - 1}};
 }
 
 /*!\brief Compute the trace from a trace matrix.
@@ -111,8 +111,8 @@ alignment_trace(database_t && database,
     constexpr auto D = trace_directions::diagonal;
     constexpr auto L = trace_directions::left;
     constexpr auto U = trace_directions::up;
-    size_t col = end_coordinate.seq1_pos + 1;
-    size_t row = end_coordinate.seq2_pos + 1;
+    size_t col = end_coordinate.first_seq_pos + 1;
+    size_t row = end_coordinate.second_seq_pos + 1;
 
     assert(row <= query.size());
     assert(col <= database.size());

--- a/include/seqan3/alignment/matrix/all.hpp
+++ b/include/seqan3/alignment/matrix/all.hpp
@@ -5,25 +5,23 @@
 // shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
 // -----------------------------------------------------------------------------------------------------
 
-//!\cond DEV
 /*!\file
  * \brief Meta-header for the \link alignment_matrix Matrix sub-module \endlink.
  * \author Marcel Ehrhardt <marcel.ehrhardt AT fu-berlin.de>
  */
-//!\endcond
 
 #pragma once
 
-//!\cond DEV
 /*!\defgroup alignment_matrix Matrix
- * \brief Provides the data structures used for representing alignments as a matrix.
+ * \brief Provides data structures for representing alignment coordinates and alignments as a matrix.
  * \ingroup alignment
  *
  * \todo Write detailed landing page.
  */
-//!\endcond
 
+#include <seqan3/alignment/matrix/alignment_coordinate.hpp>
 #include <seqan3/alignment/matrix/alignment_matrix_formatter.hpp>
+#include <seqan3/alignment/matrix/alignment_optimum.hpp>
 #include <seqan3/alignment/matrix/alignment_score_matrix.hpp>
 #include <seqan3/alignment/matrix/alignment_trace_matrix.hpp>
 #include <seqan3/alignment/matrix/matrix_concept.hpp>

--- a/include/seqan3/alignment/matrix/trace_directions.hpp
+++ b/include/seqan3/alignment/matrix/trace_directions.hpp
@@ -25,13 +25,17 @@ namespace seqan3::detail
 enum struct trace_directions : uint8_t
 {
     //!\brief No trace
-    none      = 0b0000,
+    none      = 0b00000,
     //!\brief Trace comes from the diagonal entry.
-    diagonal  = 0b0001,
+    diagonal  = 0b00001,
     //!\brief Trace comes from the above entry.
-    up        = 0b0010,
+    up        = 0b00010,
     //!\brief Trace comes from the left entry.
-    left      = 0b0100
+    left      = 0b00100,
+    //!\brief Trace comes from the above entry, while opening the gap.
+    up_open   = 0b01000,
+    //!\brief Trace comes from the left entry, while opening the gap.
+    left_open = 0b10000
 };
 
 } // namespace seqan3::detail

--- a/include/seqan3/alignment/pairwise/align_result.hpp
+++ b/include/seqan3/alignment/pairwise/align_result.hpp
@@ -117,7 +117,7 @@ private:
     //!\}
 
 public:
-    /*!\name Constructor, destructor and assignment
+    /*!\name Constructors, destructor and assignment
      * \{
      *
      * \brief Constructor to pass the alignment result traits.

--- a/include/seqan3/alignment/pairwise/alignment_algorithm.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_algorithm.hpp
@@ -346,7 +346,7 @@ private:
         });
 
         auto [cell, coordinate, trace] = *std::ranges::prev(std::ranges::end(col));
-        std::ignore = trace;
+        (void) trace;
         if constexpr (is_banded)
         {
             alignment_optimum current{get<0>(get<0>(std::move(cell))), static_cast<alignment_coordinate>(coordinate)};
@@ -379,7 +379,7 @@ private:
         ranges::for_each(first_range, [&, this](auto seq1_value)
         {
             // Move internal matrix to next column.
-            this->next_column();
+            this->go_next_column();
 
             auto col = this->current_column();
             this->init_row_cell(*std::ranges::begin(col), cache);
@@ -393,13 +393,14 @@ private:
 
             // Prepare last cell for tracking the optimum.
             auto [cell, coordinate, trace] = *std::ranges::prev(std::ranges::end(col));
-            std::ignore = trace;
+            (void) trace;
             alignment_optimum current{get<0>(std::move(cell)), static_cast<alignment_coordinate>(coordinate)};
             this->check_score_last_row(current, get<3>(cache));
         });
 
         // Prepare the last column for tracking the optimum: Only get the current score cell and the coordinate.
-        auto last_column_view = this->current_column() | ranges::view::transform([](auto && entry) {
+        auto last_column_view = this->current_column() | ranges::view::transform([](auto && entry)
+            {
             using std::get;
             return std::tuple{get<0>(std::forward<decltype(entry)>(entry)),
                               get<1>(std::forward<decltype(entry)>(entry))};
@@ -429,7 +430,7 @@ private:
 
         ranges::for_each(first_range | view::take_exactly(this->band_column_index), [&, this](auto first_range_value)
         {
-            this->next_column(); // Move to the next column.
+            this->go_next_column(); // Move to the next column.
             auto col = this->current_column();
             this->init_row_cell(*std::ranges::begin(col), cache); // initialise first row of dp matrix.
 
@@ -445,7 +446,7 @@ private:
             if (this->band_touches_last_row())  // TODO [[unlikely]]
             {
                 auto [cell, coordinate, trace] = *std::ranges::prev(std::ranges::end(col));
-                std::ignore = trace;
+                (void) trace;
                 alignment_optimum current{get<0>(get<0>(std::move(cell))),
                                           static_cast<alignment_coordinate>(coordinate)};
                 this->check_score_last_row(current, get<3>(cache));
@@ -460,7 +461,7 @@ private:
         ranges::for_each(first_range | ranges::view::drop_exactly(this->band_column_index),
         [&, this](auto first_range_value)
         {
-            this->next_column(); // Move to the next column.
+            this->go_next_column(); // Move to the next column.
             auto col = this->current_column();
 
             // Move the second_range_it to the correct position depending on the current band position.
@@ -485,7 +486,7 @@ private:
             if (this->band_touches_last_row()) // TODO [[unlikely]]
             {
                 auto [cell, coordinate, trace] = *std::ranges::prev(std::ranges::end(col));
-                std::ignore = trace;
+                (void) trace;
                 alignment_optimum current{get<0>(get<0>(std::move(cell))),
                                           static_cast<alignment_coordinate>(coordinate)};
                 this->check_score_last_row(current, get<3>(cache));

--- a/include/seqan3/alignment/pairwise/alignment_algorithm.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_algorithm.hpp
@@ -134,6 +134,10 @@ public:
     {
         assert(cfg_ptr != nullptr);
 
+        // ----------------------------------------------------------------------------
+        // Initialise dp algorithm.
+        // ----------------------------------------------------------------------------
+
         // We need to allocate the score_matrix and maybe the trace_matrix.
         this->allocate_matrix(first_range, second_range);
 
@@ -143,7 +147,15 @@ public:
 
         initialise_matrix(cache);
 
+        // ----------------------------------------------------------------------------
+        // Compute the unbanded alignment.
+        // ----------------------------------------------------------------------------
+
         compute_matrix(first_range, second_range, cache);
+
+        // ----------------------------------------------------------------------------
+        // Cleanup and prepare the alignment result.
+        // ----------------------------------------------------------------------------
 
         using result_t = typename align_result_selector<first_range_t, second_range_t, config_t>::type;
         result_t res{};
@@ -323,6 +335,7 @@ private:
     template <typename cache_t>
     void initialise_matrix(cache_t & cache)
     {
+        // Get the current dynamic programming matrix.
         auto col = this->current_column();
 
         this->init_origin_cell(*std::ranges::begin(col), cache);
@@ -552,7 +565,7 @@ private:
         using second_subrange_type = seqan3::view::subrange<decltype(it_second_seq_begin), decltype(it_second_seq_end)>;
         auto second_subrange = second_subrange_type{it_second_seq_begin, it_second_seq_end};
 
-        // Create and fill the aligned_sequence for the first sequence.
+        // Create and fill the aligned_sequence for the second sequence.
         std::vector<gapped<second_seq_value_type>> second_aligned_seq{second_subrange};
         fill_aligned_sequence(second_aligned_seq, second_gap_segments, begin_coordinate.second_seq_pos);
 

--- a/include/seqan3/alignment/pairwise/alignment_algorithm.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_algorithm.hpp
@@ -80,7 +80,7 @@ private:
     static constexpr bool is_banded = std::remove_reference_t<config_t>::template exists<align_cfg::band>();
 
 public:
-    /*!\name Constructor, destructor and assignment
+    /*!\name Constructors, destructor and assignment
      * \brief Defaulted all standard constructor.
      * \{
      */
@@ -487,6 +487,18 @@ private:
         this->check_score_last_column(last_column_view, get<3>(cache));
     }
 
+    /*!\brief Computes the traceback if requested.
+    * \tparam    first_range_t  The type of the first sequence (or packed sequences).
+    * \tparam    second_range_t The type of the second sequence (or packed sequences).
+    * \param[in] first_range    The first sequence.
+    * \param[in] second_range   The second sequence.
+    * \param[in] end_coordinate The end coordinate within the matrix where the traceback starts.
+    *
+    * \details
+    *
+    * First parses the traceback and computes the gap segments for the sequences. Then applies the gap segments
+    * to the infix of the corresponding range and return the aligned sequence.
+    */
     template <typename first_range_t, typename second_range_t>
     auto compute_traceback(first_range_t const & first_range,
                            second_range_t const & second_range,
@@ -549,7 +561,6 @@ private:
 
     //!\brief The alignment configuration stored on the heap.
     std::shared_ptr<config_t> cfg_ptr{};
-
 };
 
 } // namespace seqan3::detail

--- a/include/seqan3/alignment/pairwise/alignment_algorithm.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_algorithm.hpp
@@ -226,7 +226,7 @@ public:
         static_assert(std::is_signed_v<diff_type>,  "Only signed types can be used to test the band parameters.");
 
         if (static_cast<diff_type>(band.lower_bound) >
-            std::ranges::distance(seqan3::begin(first_range), seqan3::end(first_range)))
+            std::ranges::distance(std::ranges::begin(first_range), std::ranges::end(first_range)))
         {
             throw invalid_alignment_configuration
             {
@@ -235,7 +235,7 @@ public:
         }
 
         if (static_cast<diff_type>(std::abs(band.upper_bound)) >
-            std::ranges::distance(seqan3::begin(second_range), seqan3::end(second_range)))
+            std::ranges::distance(std::ranges::begin(second_range), std::ranges::end(second_range)))
         {
             throw invalid_alignment_configuration
             {
@@ -325,14 +325,14 @@ private:
     {
         auto col = this->current_column();
 
-        this->init_origin_cell(*seqan3::begin(col), cache);
+        this->init_origin_cell(*std::ranges::begin(col), cache);
 
         ranges::for_each(col | ranges::view::drop_exactly(1), [&cache, this](auto && cell)
         {
             this->init_column_cell(std::forward<decltype(cell)>(cell), cache);
         });
 
-        auto [cell, coordinate, trace] = *std::ranges::prev(seqan3::end(col));
+        auto [cell, coordinate, trace] = *std::ranges::prev(std::ranges::end(col));
         std::ignore = trace;
         if constexpr (is_banded)
         {
@@ -369,7 +369,7 @@ private:
             this->next_column();
 
             auto col = this->current_column();
-            this->init_row_cell(*seqan3::begin(col), cache);
+            this->init_row_cell(*std::ranges::begin(col), cache);
 
             auto second_range_it = std::ranges::begin(second_range);
             ranges::for_each(col | ranges::view::drop_exactly(1), [&, this] (auto && cell)
@@ -379,7 +379,7 @@ private:
             });
 
             // Prepare last cell for tracking the optimum.
-            auto [cell, coordinate, trace] = *std::ranges::prev(seqan3::end(col));
+            auto [cell, coordinate, trace] = *std::ranges::prev(std::ranges::end(col));
             std::ignore = trace;
             alignment_optimum current{get<0>(std::move(cell)), static_cast<alignment_coordinate>(coordinate)};
             this->check_score_last_row(current, get<3>(cache));
@@ -418,9 +418,9 @@ private:
         {
             this->next_column(); // Move to the next column.
             auto col = this->current_column();
-            this->init_row_cell(*seqan3::begin(col), cache); // initialise first row of dp matrix.
+            this->init_row_cell(*std::ranges::begin(col), cache); // initialise first row of dp matrix.
 
-            auto second_range_it = seqan3::begin(second_range);
+            auto second_range_it = std::ranges::begin(second_range);
             ranges::for_each(col | ranges::view::drop_exactly(1), [&, this] (auto && cell)
             {
                 this->compute_cell(std::forward<decltype(cell)>(cell),
@@ -431,7 +431,7 @@ private:
 
             if (this->band_touches_last_row())  // TODO [[unlikely]]
             {
-                auto [cell, coordinate, trace] = *std::ranges::prev(seqan3::end(col));
+                auto [cell, coordinate, trace] = *std::ranges::prev(std::ranges::end(col));
                 std::ignore = trace;
                 alignment_optimum current{get<0>(get<0>(std::move(cell))),
                                           static_cast<alignment_coordinate>(coordinate)};
@@ -452,7 +452,7 @@ private:
 
             // Move the second_range_it to the correct position depending on the current band position.
             auto second_range_it = std::ranges::begin(second_range);
-            std::advance(second_range_it, this->second_range_begin_offset());
+            std::ranges::advance(second_range_it, this->second_range_begin_offset());
 
             // Initialise the first cell of the current band.
             this->compute_first_band_cell(*std::ranges::begin(col),
@@ -471,7 +471,7 @@ private:
 
             if (this->band_touches_last_row()) // TODO [[unlikely]]
             {
-                auto [cell, coordinate, trace] = *std::ranges::prev(seqan3::end(col));
+                auto [cell, coordinate, trace] = *std::ranges::prev(std::ranges::end(col));
                 std::ignore = trace;
                 alignment_optimum current{get<0>(get<0>(std::move(cell))),
                                           static_cast<alignment_coordinate>(coordinate)};
@@ -518,8 +518,8 @@ private:
             for (auto const & gap_elem : gap_segments)
             {
                 // insert_gap(aligned_sequence, gap.position + offset, gap.size);
-                auto it = seqan3::begin(aligned_sequence);
-                std::advance(it, (gap_elem.position - normalise) + offset);
+                auto it = std::ranges::begin(aligned_sequence);
+                std::ranges::advance(it, (gap_elem.position - normalise) + offset);
                 aligned_sequence.insert(it, gap_elem.size, gap{});
                 offset += gap_elem.size;
             }
@@ -531,10 +531,10 @@ private:
             end_coordinate = this->map_banded_coordinate_to_range_position(end_coordinate);
 
         // Get the subrange over the first sequence according to the begin and end coordinate.
-        auto it_first_seq_begin = seqan3::begin(first_range);
-        std::advance(it_first_seq_begin, begin_coordinate.first_seq_pos);
-        auto it_first_seq_end = seqan3::begin(first_range);
-        std::advance(it_first_seq_end, end_coordinate.first_seq_pos);
+        auto it_first_seq_begin = std::ranges::begin(first_range);
+        std::ranges::advance(it_first_seq_begin, begin_coordinate.first_seq_pos);
+        auto it_first_seq_end = std::ranges::begin(first_range);
+        std::ranges::advance(it_first_seq_end, end_coordinate.first_seq_pos);
 
         using first_subrange_type = seqan3::view::subrange<decltype(it_first_seq_begin), decltype(it_first_seq_end)>;
         auto first_subrange = first_subrange_type{it_first_seq_begin, it_first_seq_end};
@@ -544,10 +544,10 @@ private:
         fill_aligned_sequence(first_aligned_seq, first_gap_segments, begin_coordinate.first_seq_pos);
 
         // Get the subrange over the second sequence according to the begin and end coordinate.
-        auto it_second_seq_begin = seqan3::begin(second_range);
-        std::advance(it_second_seq_begin, begin_coordinate.second_seq_pos);
-        auto it_second_seq_end = seqan3::begin(second_range);
-        std::advance(it_second_seq_end, end_coordinate.second_seq_pos);
+        auto it_second_seq_begin = std::ranges::begin(second_range);
+        std::ranges::advance(it_second_seq_begin, begin_coordinate.second_seq_pos);
+        auto it_second_seq_end = std::ranges::begin(second_range);
+        std::ranges::advance(it_second_seq_end, end_coordinate.second_seq_pos);
 
         using second_subrange_type = seqan3::view::subrange<decltype(it_second_seq_begin), decltype(it_second_seq_end)>;
         auto second_subrange = second_subrange_type{it_second_seq_begin, it_second_seq_end};

--- a/include/seqan3/alignment/pairwise/alignment_algorithm.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_algorithm.hpp
@@ -129,7 +129,7 @@ public:
      * and at most \f$ O(N^2) \f$ space.
      */
     template <std::ranges::ForwardRange first_range_t, std::ranges::ForwardRange second_range_t>
-    auto operator()(first_range_t const & first_range, second_range_t const & second_range)
+    auto operator()(first_range_t && first_range, second_range_t && second_range)
         requires !is_banded
     {
         assert(cfg_ptr != nullptr);
@@ -207,7 +207,7 @@ public:
      * and at most \f$ O(N*k) \f$ space.
      */
     template <std::ranges::ForwardRange first_range_t, std::ranges::ForwardRange second_range_t>
-    auto operator()(first_range_t const & first_range, second_range_t const & second_range)
+    auto operator()(first_range_t && first_range, second_range_t && second_range)
         requires is_banded
     {
         assert(cfg_ptr != nullptr);
@@ -357,8 +357,8 @@ private:
     template <typename first_range_t,
               typename second_range_t,
               typename cache_t>
-    void compute_matrix(first_range_t const & first_range,
-                        second_range_t const & second_range,
+    void compute_matrix(first_range_t & first_range,
+                        second_range_t & second_range,
                         cache_t & cache)
     {
         using std::get;
@@ -405,8 +405,8 @@ private:
     template <typename first_range_t,
               typename second_range_t,
               typename cache_t>
-    void compute_banded_matrix(first_range_t const & first_range,
-                               second_range_t const & second_range,
+    void compute_banded_matrix(first_range_t & first_range,
+                               second_range_t & second_range,
                                cache_t & cache)
     {
         auto const & score_scheme = get<align_cfg::scoring>(*cfg_ptr).value;
@@ -500,8 +500,8 @@ private:
     * to the infix of the corresponding range and return the aligned sequence.
     */
     template <typename first_range_t, typename second_range_t>
-    auto compute_traceback(first_range_t const & first_range,
-                           second_range_t const & second_range,
+    auto compute_traceback(first_range_t & first_range,
+                           second_range_t & second_range,
                            alignment_coordinate end_coordinate)
     {
         using first_seq_value_type = value_type_t<first_range_t>;

--- a/include/seqan3/alignment/pairwise/alignment_algorithm.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_algorithm.hpp
@@ -20,7 +20,7 @@
 #include <seqan3/alignment/exception.hpp>
 #include <seqan3/alignment/pairwise/policy/affine_gap_init_policy.hpp>
 #include <seqan3/alignment/pairwise/policy/affine_gap_policy.hpp>
-#include <seqan3/alignment/pairwise/policy/unbanded_dp_matrix_policy.hpp>
+#include <seqan3/alignment/pairwise/policy/unbanded_score_dp_matrix_policy.hpp>
 #include <seqan3/alignment/pairwise/align_result_selector.hpp>
 #include <seqan3/alignment/scoring/gap_scheme.hpp>
 #include <seqan3/alignment/scoring/scoring_scheme_base.hpp>

--- a/include/seqan3/alignment/pairwise/alignment_configurator.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_configurator.hpp
@@ -109,7 +109,7 @@ private:
                 if constexpr (config_t::template exists<align_cfg::band>())
                     return deferred_crtp_base<banded_score_dp_matrix_policy, score_allocator_t>{};
                 else
-                    return deferred_crtp_base<unbanded_dp_matrix_policy, score_allocator_t>{};
+                    return deferred_crtp_base<unbanded_score_dp_matrix_policy, score_allocator_t>{};
             }
             else
             {  // requested traceback

--- a/include/seqan3/alignment/pairwise/alignment_configurator.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_configurator.hpp
@@ -185,30 +185,43 @@ public:
     /*!\brief Configures the algorithm.
      * \tparam sequences_t The range type containing the sequence pairs; must model std::ranges::ForwardRange.
      * \tparam config_t    The alignment configuration type; must be a specialisation of seqan3::configuration.
-     * \param[in]     seq_range The range over the sequence pairs.
+     * \param[in]     seq_range The range over the sequences; The value type must model seqan3::tuple_like_concept.
      * \param[in,out] cfg       The configuration object.
+     *
+     * \returns std::function wrapper of the configured alignment algorithm.
+     *
+     * \details
+     *
+     * This function reads the seqan3::configuration object and generates the corresponding alignment algorithm type.
+     * During this process some runtime configurations are converted to static configurations if required. The return
+     * type is a std::function which is generated in the following way:
+     *
+     * \snippet snippet/alignment/pairwise/alignment_configurator.cpp result
+     *
+     * The arguments to the function object are two ranges, which always need to be passed as lvalue references.
+     * Note that even if they are not passed as const lvalue reference (which is not possible, since not all views are
+     * const-iterable), they are not modified within the alignment algorithm.
      */
     template <std::ranges::ForwardRange sequences_t, typename config_t>
     //!\cond
-        requires is_type_specialisation_of_v<remove_cvref_t<config_t>, configuration>
+        requires tuple_like_concept<value_type_t<std::remove_reference_t<sequences_t>>> && 
+                 is_type_specialisation_of_v<remove_cvref_t<config_t>, configuration>
     //!\endcond
-    static constexpr auto configure(sequences_t seq_range, config_t const & cfg)
+    static constexpr auto configure(sequences_t && SEQAN3_DOXYGEN_ONLY(seq_range), config_t const & cfg)
     {
         // ----------------------------------------------------------------------------
         // Configure the type-erased alignment function.
         // ----------------------------------------------------------------------------
 
-        using first_seq_t  = std::remove_reference_t<std::tuple_element_t<
-                                                        0,
-                                                        remove_cvref_t<decltype(*seqan3::begin(seq_range))>>>;
-        using second_seq_t = std::remove_reference_t<std::tuple_element_t<
-                                                        1,
-                                                        remove_cvref_t<decltype(*seqan3::begin(seq_range))>>>;
+        using first_seq_t = std::tuple_element_t<0, value_type_t<std::remove_reference_t<sequences_t>>>;
+        using second_seq_t = std::tuple_element_t<1, value_type_t<std::remove_reference_t<sequences_t>>>;
 
         // Select the result type based on the sequences and the configuration.
-        using result_t = align_result<typename align_result_selector<first_seq_t, second_seq_t, config_t>::type>;
+        using result_t = align_result<typename align_result_selector<std::remove_reference_t<first_seq_t>,
+                                                                     std::remove_reference_t<second_seq_t>,
+                                                                     config_t>::type>;
         // Define the function wrapper type.
-        using function_wrapper_t = std::function<result_t(first_seq_t const &, second_seq_t const &)>;
+        using function_wrapper_t = std::function<result_t(first_seq_t &, second_seq_t &)>;
 
         // ----------------------------------------------------------------------------
         // Test some basic preconditions

--- a/include/seqan3/alignment/pairwise/alignment_configurator.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_configurator.hpp
@@ -113,9 +113,18 @@ private:
             }
             else
             {  // requested traceback
-                return deferred_crtp_base<unbanded_score_trace_dp_matrix_policy,
-                                          score_allocator_t,
-                                          trace_allocator_t>{};
+                if constexpr (config_t::template exists<align_cfg::band>())
+                {
+                    return deferred_crtp_base<banded_score_trace_dp_matrix_policy,
+                                              score_allocator_t,
+                                              trace_allocator_t>{};
+                }
+                else
+                {
+                    return deferred_crtp_base<unbanded_score_trace_dp_matrix_policy,
+                                              score_allocator_t,
+                                              trace_allocator_t>{};
+                }
             }
         }
 
@@ -328,10 +337,6 @@ constexpr function_wrapper_t alignment_configurator::configure_free_ends_initial
     // ----------------------------------------------------------------------------
     // dynamic programming matrix
     // ----------------------------------------------------------------------------
-
-    if constexpr (!std::is_same_v<trace_type, ignore_t> &&
-                   config_t::template exists<align_cfg::band>())
-        throw invalid_alignment_configuration{"Computing traceback for banded alignments is yet not supported."};
 
     using dp_matrix_t = typename select_matrix_policy<config_t,
                                                       std::allocator<cell_type>,

--- a/include/seqan3/alignment/pairwise/alignment_configurator.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_configurator.hpp
@@ -307,8 +307,8 @@ constexpr function_wrapper_t alignment_configurator::configure_free_ends_initial
     // score and cell type
     // ----------------------------------------------------------------------------
 
-    using score_type = int;
-    using cell_type = std::tuple<score_type, score_type>;
+    using score_type = int32_t;
+    using cell_type = std::tuple<score_type, score_type, ignore_t>;
 
     // ----------------------------------------------------------------------------
     // dynamic programming matrix

--- a/include/seqan3/alignment/pairwise/edit_distance_unbanded.hpp
+++ b/include/seqan3/alignment/pairwise/edit_distance_unbanded.hpp
@@ -480,7 +480,7 @@ public:
     {
         size_t col = database.size() - 1;
         if constexpr(is_semi_global)
-            col = std::distance(begin(database), _best_score_col);
+            col = std::ranges::distance(begin(database), _best_score_col);
 
         return {column_index_type{col}, row_index_type{query.size() - 1}};
     }

--- a/include/seqan3/alignment/pairwise/edit_distance_unbanded.hpp
+++ b/include/seqan3/alignment/pairwise/edit_distance_unbanded.hpp
@@ -599,7 +599,7 @@ template <typename config_t>
 class edit_distance_wrapper
 {
 public:
-    /*!\name Constructor, destructor and assignment
+    /*!\name Constructors, destructor and assignment
      * \brief Defaulted all standard constructor.
      * \{
      */

--- a/include/seqan3/alignment/pairwise/edit_distance_unbanded.hpp
+++ b/include/seqan3/alignment/pairwise/edit_distance_unbanded.hpp
@@ -638,9 +638,7 @@ public:
                                                                 remove_cvref_t<second_range_t>,
                                                                 remove_cvref_t<config_t>>::type;
 
-        pairwise_alignment_edit_distance_unbanded algo{std::forward<first_range_t>(first_range),
-                                                       std::forward<second_range_t>(second_range),
-                                                       *cfg_ptr};
+        pairwise_alignment_edit_distance_unbanded algo{first_range, second_range, *cfg_ptr};
         align_result<result_t> res{};
         return algo(res);
     }

--- a/include/seqan3/alignment/pairwise/edit_distance_unbanded.hpp
+++ b/include/seqan3/alignment/pairwise/edit_distance_unbanded.hpp
@@ -482,7 +482,7 @@ public:
         if constexpr(is_semi_global)
             col = std::distance(begin(database), _best_score_col);
 
-        return {col, query.size() - 1};
+        return {column_index_type{col}, row_index_type{query.size() - 1}};
     }
 
     //!\brief Return the alignment, i.e. the actual base pair matching.

--- a/include/seqan3/alignment/pairwise/execution/alignment_executor_two_way.hpp
+++ b/include/seqan3/alignment/pairwise/execution/alignment_executor_two_way.hpp
@@ -144,7 +144,7 @@ public:
     //!\brief Checks whether the end of the input resource was reached.
     bool is_eof() noexcept
     {
-        return seqan3::begin(resource) == seqan3::end(resource);
+        return std::ranges::begin(resource) == std::ranges::end(resource);
     }
     //!\}
 
@@ -171,12 +171,12 @@ private:
             return eof;
 
         // Reset the get pointer.
-        setg(seqan3::begin(buffer), seqan3::end(buffer));
+        setg(std::ranges::begin(buffer), std::ranges::end(buffer));
 
         // Apply the alignment execution.
         // TODO: Adapt for async behavior for parallel execution handler.
         size_t count = 0;
-        for (auto resource_iter = seqan3::begin(resource);
+        for (auto resource_iter = std::ranges::begin(resource);
              count < in_avail() && !is_eof(); ++count, ++resource_iter, ++gptr)
         {
             auto && [first_seq, second_seq] = *resource_iter;
@@ -184,7 +184,7 @@ private:
         }
 
         // Update the available get position if the buffer was consumed completely.
-        setg(seqan3::begin(buffer), seqan3::begin(buffer) + count);
+        setg(std::ranges::begin(buffer), std::ranges::begin(buffer) + count);
 
         return in_avail();
     }
@@ -198,7 +198,7 @@ private:
     void init_buffer()
     {
         buffer.resize(1);
-        setg(seqan3::end(buffer), seqan3::end(buffer));
+        setg(std::ranges::end(buffer), std::ranges::end(buffer));
     }
     //!\}
 

--- a/include/seqan3/alignment/pairwise/execution/alignment_executor_two_way.hpp
+++ b/include/seqan3/alignment/pairwise/execution/alignment_executor_two_way.hpp
@@ -179,7 +179,7 @@ private:
         for (auto resource_iter = seqan3::begin(resource);
              count < in_avail() && !is_eof(); ++count, ++resource_iter, ++gptr)
         {
-            auto const & [first_seq, second_seq] = *resource_iter;
+            auto && [first_seq, second_seq] = *resource_iter;
             exec_handler.execute(kernel, first_seq, second_seq, [this](auto && res){ *gptr = std::move(res); });
         }
 

--- a/include/seqan3/alignment/pairwise/execution/execution_handler_sequential.hpp
+++ b/include/seqan3/alignment/pairwise/execution/execution_handler_sequential.hpp
@@ -34,11 +34,11 @@ public:
      * \tparam fn_type           The callable that needs to be invoked; must model std::Invocable with first_range_type
      *                           and second_range_type.
      * \tparam first_range_type  The type of the first range.
-     * \tparam second_range_type The type of the first range.
+     * \tparam second_range_type The type of the second range.
      * \tparam delegate_type     The type of the callable invoked on the std::invoke_result of `fn_type`; must model
      *                           std::Invocable.
      *
-     * \param[in] fn_type      The callable calling the alignment algorithm.
+     * \param[in] func         The callable invoking the alignment algorithm.
      * \param[in] first_range  The first range.
      * \param[in] second_range The second range.
      * \param[in] delegate     The callable invoked with the result of the alignment.

--- a/include/seqan3/alignment/pairwise/execution/execution_handler_sequential.hpp
+++ b/include/seqan3/alignment/pairwise/execution/execution_handler_sequential.hpp
@@ -15,6 +15,7 @@
 #include <functional>
 
 #include <seqan3/core/platform.hpp>
+#include <seqan3/std/concepts>
 
 namespace seqan3::detail
 {
@@ -29,14 +30,30 @@ public:
     /*!\name Execution
      * \{
      */
-    //!\brief Invokes the passed alignment instance in a blocking manner.
-    template <typename func_result_t, typename first_range_t, typename second_range_t>
-    void execute(std::function<func_result_t(first_range_t const &, second_range_t const &)> func,
-                 first_range_t const & first_range,
-                 second_range_t const & second_range,
-                 std::function<void(decltype(func(first_range, second_range)))> delegate)
+    /*!\brief Invokes the passed alignment instance in a blocking manner.
+     * \tparam fn_type           The callable that needs to be invoked; must model std::Invocable with first_range_type
+     *                           and second_range_type.
+     * \tparam first_range_type  The type of the first range.
+     * \tparam second_range_type The type of the first range.
+     * \tparam delegate_type     The type of the callable invoked on the std::invoke_result of `fn_type`; must model
+     *                           std::Invocable.
+     *
+     * \param[in] fn_type      The callable calling the alignment algorithm.
+     * \param[in] first_range  The first range.
+     * \param[in] second_range The second range.
+     * \param[in] delegate     The callable invoked with the result of the alignment.
+     */
+    template <typename fn_type, typename first_range_type, typename second_range_type, typename delegate_type>
+    //!\cond
+        requires std::Invocable<fn_type, first_range_type, second_range_type> &&
+                 std::Invocable<delegate_type, std::invoke_result_t<fn_type, first_range_type, second_range_type>>
+    //!\endcond
+    void execute(fn_type && func,
+                 first_range_type && first_range,
+                 second_range_type && second_range,
+                 delegate_type && delegate)
     {
-        delegate(func(first_range, second_range));
+        delegate(func(std::forward<first_range_type>(first_range), std::forward<second_range_type>(second_range)));
     }
     //!\}
 };

--- a/include/seqan3/alignment/pairwise/policy/affine_gap_banded_init_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/affine_gap_banded_init_policy.hpp
@@ -143,12 +143,12 @@ private:
         auto & trace_value = get<2>(current_cell);  // the trace value to store.
         auto & main_score = get<0>(current_entry);  // current_entry stores current score to be updated.
         auto & hz_trace = get<2>(current_entry); // store trace for the next horizontal computation.
-        auto const & hz_score = get<1>(next_entry);  // next_entry stores last horizontal value (shifted by one).
-        auto const & prev_hz_trace = get<1>(next_entry);  // next_entry stores last horizontal value (shifted by one).
+        auto const & prev_hz_score = get<1>(next_entry);  // get the previous horizontal score.
+        auto const & prev_hz_trace = get<2>(next_entry);  // get the previous horizontal trace.
         auto & vt_score = get<1>(get<0>(cache));
         auto & vt_trace = get<2>(get<0>(cache));
 
-        main_score = hz_score;
+        main_score = prev_hz_score;
         trace_value = prev_hz_trace;
         vt_score += main_score + get<1>(cache); // gap opening cost
         vt_trace = trace_directions::up_open;
@@ -161,7 +161,7 @@ private:
         }
         else
         {
-            get<1>(current_entry) = hz_score + get<2>(cache);
+            get<1>(current_entry) = prev_hz_score + get<2>(cache);
             hz_trace = trace_directions::left;
         }
     }

--- a/include/seqan3/alignment/pairwise/policy/affine_gap_banded_init_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/affine_gap_banded_init_policy.hpp
@@ -62,7 +62,8 @@ private:
     {
         using std::get;
 
-        auto & [main_score, hz_score] = get<0>(current_cell);
+        // Call get twice since the banded score column is a zipped range and we need to access the main column.
+        auto & [main_score, hz_score] = get<0>(get<0>(current_cell));
         auto & vt_score = get<1>(get<0>(cache));
 
         main_score = 0;
@@ -91,7 +92,8 @@ private:
     {
         using std::get;
 
-        auto & [main_score, hz_score] = get<0>(current_cell);
+        // Call get twice since the banded score column is a zipped range and we need to access the main column.
+        auto & [main_score, hz_score] = get<0>(get<0>(current_cell));
         auto & vt_score = get<1>(get<0>(cache));
 
         main_score = vt_score;
@@ -114,7 +116,7 @@ private:
     template <typename cell_t, typename cache_t>
     constexpr auto init_row_cell(cell_t && current_cell, cache_t & cache) const noexcept
     {
-        auto & [current_entry, next_entry] = current_cell; // Split into current entry and next entry.
+        auto & [current_entry, next_entry] = get<0>(current_cell); // Split into current entry and next entry.
         auto & main_score = get<0>(current_entry);  // current_entry stores current score to be updated.
         auto & hz_score = get<1>(next_entry);  // next_entry stores last horizontal value (shifted by one).
         auto & vt_score = get<1>(get<0>(cache));

--- a/include/seqan3/alignment/pairwise/policy/affine_gap_banded_init_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/affine_gap_banded_init_policy.hpp
@@ -39,7 +39,7 @@ private:
     //!\brief Befriends the derived type.
     friend derived_t;
 
-    /*!\name Constructor, destructor and assignment
+    /*!\name Constructors, destructor and assignment
      * \brief Defaulted all standard constructor.
      * \{
      */

--- a/include/seqan3/alignment/pairwise/policy/affine_gap_banded_init_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/affine_gap_banded_init_policy.hpp
@@ -132,7 +132,7 @@ private:
     }
 
     /*!\brief Balances the total score based on the band parameters and the alignment configuration.
-     * \tparam        score_type       The type of the score to update.
+     * \tparam        optimum_type     The type of the optimum to update.
      * \tparam        band_type        The type of the band.
      * \tparam        gap_scheme_type  The type of the gap_scheme.
      * \param[in,out] total  The total score to update.
@@ -144,20 +144,20 @@ private:
      * Depending on the band position and the alignment configuration updates the total score
      * of the alignment. It adds the score for initialising the matrix with a gap until the begin of the band.
      */
-    template <typename score_type, typename band_type, typename gap_scheme_type>
-    constexpr void balance_leading_gaps(score_type & total,
+    template <typename optimum_type, typename band_type, typename gap_scheme_type>
+    constexpr void balance_leading_gaps(optimum_type & total,
                                         band_type const & band,
                                         gap_scheme_type const & scheme) const noexcept
     {
         if constexpr (!traits_type::free_second_leading_t::value)
         {  // Band starts inside of second sequence.
             if (0 > band.upper_bound)
-                total += scheme.score(std::abs(band.upper_bound));
+                total.score += scheme.score(std::abs(band.upper_bound));
         }
         if constexpr (!traits_type::free_first_leading_t::value)
         { // Band starts inside of first sequence.
             if (band.lower_bound > 0)
-                total += scheme.score(band.lower_bound);
+                total.score += scheme.score(band.lower_bound);
         }
     }
 };

--- a/include/seqan3/alignment/pairwise/policy/affine_gap_banded_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/affine_gap_banded_policy.hpp
@@ -72,7 +72,7 @@ private:
     {
         using std::get;
         // Unpack the cached variables.
-        auto & [current_entry, next_entry] = current_cell;
+        auto & [current_entry, next_entry] = get<0>(current_cell);
         auto & [main_score, hz_score] = current_entry;
         auto const & prev_hz_score = get<1>(next_entry);
         auto & [prev_cell, gap_open, gap_extend, opt] = cache;
@@ -106,7 +106,7 @@ private:
     {
         using std::get;
         // Unpack the cached variables.
-        auto & [current_entry, next_entry] = current_cell;
+        auto & [current_entry, next_entry] = get<0>(current_cell);
         auto & main_score = get<0>(current_entry);
         auto const & prev_hz_score = get<1>(next_entry);
         auto & vt_score = get<1>(get<0>(cache));

--- a/include/seqan3/alignment/pairwise/policy/affine_gap_banded_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/affine_gap_banded_policy.hpp
@@ -79,7 +79,7 @@ private:
         auto & [prev_cell, gap_open, gap_extend, opt] = cache;
         auto & [tmp, vt_score, vt_trace] = prev_cell;
 
-        std::ignore = prev_main_score;
+        (void) prev_main_score;
 
         //TODO For the local alignment we might be able to use GCC overlow builtin arithmetics, which
         // allows us to check if overflow/underflow would happen. Not sure, if this helps with the performance though.
@@ -142,7 +142,7 @@ private:
         auto const & prev_hz_trace = get<2>(next_entry);
         auto & [tmp, vt_score, vt_trace] = get<0>(cache);
 
-        std::ignore = tmp;
+        (void) tmp;
 
         // Compute the diagonal score and the compare with the previous horizontal value.
         main_score += score;

--- a/include/seqan3/alignment/pairwise/policy/affine_gap_banded_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/affine_gap_banded_policy.hpp
@@ -94,9 +94,9 @@ private:
         else  // Compute any traceback
         {
             main_score = (main_score < vt_score) ? (trace_value = vt_trace, vt_score)
-                                   : (trace_value = trace_directions::diagonal, main_score);
+                                                 : (trace_value = trace_directions::diagonal | vt_trace, main_score);
             main_score = (main_score < prev_hz_score) ? (trace_value = prev_hz_trace, prev_hz_score)
-                                   : main_score;
+                                                      : (trace_value |= prev_hz_trace, main_score);
         }
 
         // Check if this was the optimum. Possibly a noop.

--- a/include/seqan3/alignment/pairwise/policy/affine_gap_banded_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/affine_gap_banded_policy.hpp
@@ -75,11 +75,11 @@ private:
         auto & [score_entry, coordinate, trace_value] = current_cell;
         auto & [current_entry, next_entry] = score_entry;
         auto & [main_score, hz_score, hz_trace] = current_entry;
-        auto const & [_ignore, prev_hz_score, prev_hz_trace]= next_entry;
+        auto const & [prev_main_score, prev_hz_score, prev_hz_trace]= next_entry;
         auto & [prev_cell, gap_open, gap_extend, opt] = cache;
         auto & [tmp, vt_score, vt_trace] = prev_cell;
 
-        std::ignore = _ignore;
+        std::ignore = prev_main_score;
 
         //TODO For the local alignment we might be able to use GCC overlow builtin arithmetics, which
         // allows us to check if overflow/underflow would happen. Not sure, if this helps with the performance though.

--- a/include/seqan3/alignment/pairwise/policy/affine_gap_banded_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/affine_gap_banded_policy.hpp
@@ -46,7 +46,7 @@ private:
     //!\brief Import this typename into class scope.
     using score_t = typename base_t::score_t;
 
-    /*!\name Constructor, destructor and assignment
+    /*!\name Constructors, destructor and assignment
      * \brief Defaulted all standard constructor.
      * \{
      */

--- a/include/seqan3/alignment/pairwise/policy/affine_gap_banded_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/affine_gap_banded_policy.hpp
@@ -85,7 +85,8 @@ private:
         main_score = std::max(main_score, vt_score);
         main_score = std::max(main_score, prev_hz_score);
         // Check if this was the optimum. Possibly a noop.
-        static_cast<derived_type const &>(*this).check_score(main_score, opt);
+        static_cast<derived_type const &>(*this).check_score(
+            alignment_optimum{main_score, static_cast<alignment_coordinate>(get<1>(current_cell))}, opt);
 
         tmp = main_score + gap_open;
         vt_score = std::max(vt_score + gap_extend, tmp);
@@ -115,7 +116,8 @@ private:
         main_score += score;
         main_score = std::max(main_score, prev_hz_score);
         // Check if this was the optimum. Possibly a noop.
-        static_cast<derived_type const &>(*this).check_score(main_score, get<3>(cache));
+        static_cast<derived_type const &>(*this).check_score(
+                alignment_optimum{main_score, static_cast<alignment_coordinate>(get<1>(current_cell))}, get<3>(cache));
         // At the top of the band we can not come from up but only diagonal or left, so the next vertical must be a
         // gap open.
         vt_score = main_score + get<1>(cache);  // add gap open cost

--- a/include/seqan3/alignment/pairwise/policy/affine_gap_init_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/affine_gap_init_policy.hpp
@@ -48,7 +48,7 @@ private:
 
     //!\brief Befriends the derived class to grant it access to the private members.
     friend derived_t;
-    /*!\name Constructor, destructor and assignment
+    /*!\name Constructors, destructor and assignment
      * \brief Defaulted all standard constructor.
      * \{
      */

--- a/include/seqan3/alignment/pairwise/policy/affine_gap_init_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/affine_gap_init_policy.hpp
@@ -67,11 +67,11 @@ private:
      * \param[in,out] cache        The cache storing hot helper variables.
      */
     template <typename cell_t, typename cache_t>
-    constexpr auto init_origin_cell(cell_t & current_cell, cache_t & cache) const noexcept
+    constexpr auto init_origin_cell(cell_t && current_cell, cache_t & cache) const noexcept
     {
         using std::get;
 
-        auto & [main_score, hz_score] = current_cell;
+        auto & [main_score, hz_score] = get<0>(current_cell);
         auto & vt_score = get<1>(get<0>(cache));
 
         main_score = 0;
@@ -96,11 +96,11 @@ private:
      * \param[in,out] cache        The cache storing hot helper variables.
      */
     template <typename cell_t, typename cache_t>
-    constexpr auto init_column_cell(cell_t & current_cell, cache_t & cache) const noexcept
+    constexpr auto init_column_cell(cell_t && current_cell, cache_t & cache) const noexcept
     {
         using std::get;
 
-        auto & [main_score, hz_score] = current_cell;
+        auto & [main_score, hz_score] = get<0>(current_cell);
         auto & vt_score = get<1>(get<0>(cache));
 
         main_score = vt_score;
@@ -121,11 +121,11 @@ private:
      * \param[in,out] cache        The cache storing hot helper variables.
      */
     template <typename cell_t, typename cache_t>
-    constexpr auto init_row_cell(cell_t & current_cell, cache_t & cache) const noexcept
+    constexpr auto init_row_cell(cell_t && current_cell, cache_t & cache) const noexcept
     {
         using std::get;
 
-        auto & [main_score, hz_score] = current_cell;
+        auto & [main_score, hz_score] = get<0>(current_cell);
         auto & [prev_score, vt_score] = get<0>(cache);
 
         prev_score = main_score;

--- a/include/seqan3/alignment/pairwise/policy/affine_gap_init_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/affine_gap_init_policy.hpp
@@ -14,7 +14,7 @@
 
 #include <tuple>
 
-#include <seqan3/core/platform.hpp>
+#include <seqan3/alignment/matrix/trace_directions.hpp>
 
 namespace seqan3::detail
 {
@@ -71,22 +71,36 @@ private:
     {
         using std::get;
 
-        auto & [main_score, hz_score] = get<0>(current_cell);
-        auto & vt_score = get<1>(get<0>(cache));
+        auto & [main_score, hz_score, hz_trace] = get<0>(current_cell);
+        auto & prev_cell = get<0>(cache);
+        auto & vt_score = get<1>(prev_cell);
 
         main_score = 0;
+        get<2>(current_cell) = trace_directions::none; // store the trace direction
 
         // Initialise the vertical matrix cell according to the traits settings.
         if constexpr (traits_type::free_second_leading_t::value)
+        {
             vt_score = 0;
+            get<2>(prev_cell) = trace_directions::none;  // cache vertical trace
+        }
         else
+        {
             vt_score = get<1>(cache);
+            get<2>(prev_cell) = trace_directions::up_open; // cache vertical trace
+        }
 
         // Initialise the horizontal matrix cell according to the traits settings.
         if constexpr (traits_type::free_first_leading_t::value)
+        {
             hz_score = 0;
+            hz_trace = trace_directions::none; // cache horizontal trace
+        }
         else
+        {
             hz_score = get<1>(cache);
+            hz_trace = trace_directions::left_open; // cache horizontal trace
+        }
     }
 
     /*!\brief Initialises a cell in the first column of the dynamic programming matrix.
@@ -100,18 +114,27 @@ private:
     {
         using std::get;
 
-        auto & [main_score, hz_score] = get<0>(current_cell);
-        auto & vt_score = get<1>(get<0>(cache));
+        auto & [main_score, hz_score, hz_trace] = get<0>(current_cell);
+        auto & prev_cell = get<0>(cache);
+        auto & vt_score = get<1>(prev_cell);
 
         main_score = vt_score;
+        get<2>(current_cell) = get<2>(prev_cell); // store the trace direction
 
         // Initialise the vertical matrix cell according to the traits settings.
         if constexpr (traits_type::free_second_leading_t::value)
+        {
             vt_score = 0;
+            get<2>(prev_cell) = trace_directions::none; // cache vertical trace
+        }
         else
+        {
             vt_score += get<2>(cache);
+            get<2>(prev_cell) = trace_directions::up; // cache vertical trace
+        }
 
         hz_score = main_score + get<1>(cache);
+        hz_trace = trace_directions::none;  // cache horizontal trace
     }
 
     /*!\brief Initialises a cell in the first row of the dynamic programming matrix.
@@ -125,20 +148,26 @@ private:
     {
         using std::get;
 
-        auto & [main_score, hz_score] = get<0>(current_cell);
-        auto & [prev_score, vt_score] = get<0>(cache);
+        auto & [main_score, hz_score, hz_trace] = get<0>(current_cell);
+        auto & [prev_score, vt_score, vt_trace] = get<0>(cache);
 
         prev_score = main_score;
         main_score = hz_score;
+        get<2>(current_cell) = hz_trace; // store the trace direction
 
         vt_score += main_score + get<1>(cache);
-
+        vt_trace = trace_directions::none; // cache vertical trace
         // Initialise the horizontal matrix cell according to the traits settings.
         if constexpr (traits_type::free_first_leading_t::value)
+        {
             hz_score = 0;
+            hz_trace = trace_directions::none;
+        }
         else
+        {
             hz_score += get<2>(cache);
-
+            hz_trace = trace_directions::left;
+        }
     }
 };
 

--- a/include/seqan3/alignment/pairwise/policy/affine_gap_init_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/affine_gap_init_policy.hpp
@@ -134,7 +134,7 @@ private:
         }
 
         hz_score = main_score + get<1>(cache);
-        hz_trace = trace_directions::none;  // cache horizontal trace
+        hz_trace = trace_directions::left_open;  // cache horizontal trace
     }
 
     /*!\brief Initialises a cell in the first row of the dynamic programming matrix.
@@ -156,7 +156,7 @@ private:
         get<2>(current_cell) = hz_trace; // store the trace direction
 
         vt_score += main_score + get<1>(cache);
-        vt_trace = trace_directions::none; // cache vertical trace
+        vt_trace = trace_directions::up_open; // cache vertical trace
         // Initialise the horizontal matrix cell according to the traits settings.
         if constexpr (traits_type::free_first_leading_t::value)
         {

--- a/include/seqan3/alignment/pairwise/policy/affine_gap_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/affine_gap_policy.hpp
@@ -64,12 +64,14 @@ private:
      * \param[in]     score           The score of comparing the respective letters of the first and the second sequence.
      */
     template <typename score_cell_type, typename cache_t>
-    constexpr void compute_cell(score_cell_type & current_cell,
+    constexpr void compute_cell(score_cell_type && current_cell,
                                 cache_t & cache,
                                 score_t const score) const noexcept
     {
+        using std::get;
+
         // Unpack the cached variables.
-        auto & [main_score, hz_score] = current_cell;
+        auto & [main_score, hz_score] = get<0>(current_cell);
         auto & [prev_cell, gap_open, gap_extend, opt] = cache;
         auto & [prev_score, vt_score] = prev_cell;
 

--- a/include/seqan3/alignment/pairwise/policy/affine_gap_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/affine_gap_policy.hpp
@@ -16,6 +16,7 @@
 #include <tuple>
 
 #include <seqan3/alignment/matrix/alignment_optimum.hpp>
+#include <seqan3/alignment/matrix/trace_directions.hpp>
 
 namespace seqan3::detail
 {
@@ -71,29 +72,55 @@ private:
         using std::get;
 
         // Unpack the cached variables.
-        auto & [score_entry, coordinate, trace_entry] = current_cell;
-        auto & [main_score, hz_score] = score_entry;
+        auto & [score_entry, coordinate, trace_value] = current_cell;
+        auto & [main_score, hz_score, hz_trace]       = score_entry;
         auto & [prev_cell, gap_open, gap_extend, opt] = cache;
-        auto & [prev_score, vt_score] = prev_cell;
+        auto & [prev_score, vt_score, vt_trace]       = prev_cell;
 
-        std::ignore = trace_entry;
-
-        //TODO For the local alignment we might be able to use GCC overlow builtin arithmetics, which
+        //TODO For the local alignment we might be able to use GCC overflow builtin arithmetics, which
         // allows us to check if overflow/underflow would happen. Not sure, if this helps with the performance though.
         // (see https://gcc.gnu.org/onlinedocs/gcc/Integer-Overflow-Builtins.html)
+
+        // Precompute the diagonal score.
         score_t tmp = prev_score + score;
-        tmp = std::max(tmp, vt_score);
-        tmp = std::max(tmp, hz_score);
+
+        // Compute where the max comes from.
+        if constexpr (decays_to_ignore_v<decltype(trace_value)>) // Don't compute a traceback
+        {
+            tmp = (tmp < vt_score) ? vt_score : tmp;
+            tmp = (tmp < hz_score) ? hz_score : tmp;
+        }
+        else  // Compute any traceback
+        {
+            tmp = (tmp < vt_score) ? (trace_value = vt_trace, vt_score)
+                                   : (trace_value = trace_directions::diagonal, tmp);
+            tmp = (tmp < hz_score) ? (trace_value = hz_trace, hz_score)
+                                   : tmp;
+        }
+        // Cache the current main score for the next diagonal computation and update the current score.
         prev_score = main_score;
         main_score = tmp;
         // Check if this was the optimum. Possibly a noop.
         static_cast<derived_t const &>(*this).check_score(
                 alignment_optimum{tmp, static_cast<alignment_coordinate>(coordinate)}, opt);
+
+        // Prepare horizontal and vertical score for next column.
         tmp += gap_open;
         vt_score += gap_extend;
         hz_score += gap_extend;
-        vt_score = std::max(vt_score, tmp);
-        hz_score = std::max(hz_score, tmp);
+
+        if constexpr (decays_to_ignore_v<decltype(trace_value)>)
+        {
+            vt_score = (vt_score < tmp) ? tmp : vt_score;
+            hz_score = (hz_score < tmp) ? tmp : hz_score;
+        }
+        else
+        {
+            vt_score = (vt_score < tmp) ? (vt_trace = trace_directions::up_open, tmp)
+                                        : (vt_trace = trace_directions::up, vt_score);
+            hz_score = (hz_score < tmp) ? (hz_trace = trace_directions::up_open, tmp)
+                                        : (hz_trace = trace_directions::up, hz_score);
+        }
     }
 
     /*!\brief Creates the cache used for affine gap computation.

--- a/include/seqan3/alignment/pairwise/policy/affine_gap_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/affine_gap_policy.hpp
@@ -45,7 +45,7 @@ private:
     using score_t = std::tuple_element_t<0, cell_t>;
     //!\}
 
-    /*!\name Constructor, destructor and assignment
+    /*!\name Constructors, destructor and assignment
      * \brief Defaulted all standard constructor.
      * \{
      */

--- a/include/seqan3/alignment/pairwise/policy/affine_gap_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/affine_gap_policy.hpp
@@ -93,9 +93,9 @@ private:
         else  // Compute any traceback
         {
             tmp = (tmp < vt_score) ? (trace_value = vt_trace, vt_score)
-                                   : (trace_value = trace_directions::diagonal, tmp);
+                                   : (trace_value = trace_directions::diagonal | vt_trace, tmp);
             tmp = (tmp < hz_score) ? (trace_value = hz_trace, hz_score)
-                                   : tmp;
+                                   : (trace_value |= hz_trace, tmp);
         }
         // Cache the current main score for the next diagonal computation and update the current score.
         prev_score = main_score;
@@ -118,8 +118,8 @@ private:
         {
             vt_score = (vt_score < tmp) ? (vt_trace = trace_directions::up_open, tmp)
                                         : (vt_trace = trace_directions::up, vt_score);
-            hz_score = (hz_score < tmp) ? (hz_trace = trace_directions::up_open, tmp)
-                                        : (hz_trace = trace_directions::up, hz_score);
+            hz_score = (hz_score < tmp) ? (hz_trace = trace_directions::left_open, tmp)
+                                        : (hz_trace = trace_directions::left, hz_score);
         }
     }
 

--- a/include/seqan3/alignment/pairwise/policy/all.hpp
+++ b/include/seqan3/alignment/pairwise/policy/all.hpp
@@ -63,7 +63,7 @@
  * ----------------- | ----------------------- | ---------------------------------------------------------------------------- |
  * `allocate_matrix` | &Oslash;                | `void`                                                                       |
  * `current_column`  | &Oslash;                | *implementation defined* - see below                                         |
- * `next_column`     | &Oslash;                | `void`                                                                       |
+ * `go_next_column`  | &Oslash;                | `void`                                                                       |
  * `parse_traceback` | `alignment_coordinate`  | `tuple<alignment_coordinate, tuple<deque<gap_segment>, deque<gap_segment>>>` |
  *
  * - allocate_matrix:
@@ -78,7 +78,7 @@
  *     is at least a std::ranges::ForwardRange over the traceback matrix or std::ignore if the traceback shall not
  *     be computed.
  *
- * - next_column:
+ * - go_next_column:
  *
  *     Is called at the end of a column computation and moves internal matrix pointers to the next column.
  *

--- a/include/seqan3/alignment/pairwise/policy/all.hpp
+++ b/include/seqan3/alignment/pairwise/policy/all.hpp
@@ -19,6 +19,7 @@
 #include <seqan3/alignment/pairwise/policy/affine_gap_init_policy.hpp>
 #include <seqan3/alignment/pairwise/policy/affine_gap_policy.hpp>
 #include <seqan3/alignment/pairwise/policy/banded_score_dp_matrix_policy.hpp>
+#include <seqan3/alignment/pairwise/policy/banded_score_trace_dp_matrix_policy.hpp>
 #include <seqan3/alignment/pairwise/policy/find_optimum_policy.hpp>
 #include <seqan3/alignment/pairwise/policy/unbanded_dp_matrix_policy.hpp>
 #include <seqan3/alignment/pairwise/policy/unbanded_score_trace_dp_matrix_policy.hpp>

--- a/include/seqan3/alignment/pairwise/policy/all.hpp
+++ b/include/seqan3/alignment/pairwise/policy/all.hpp
@@ -21,7 +21,7 @@
 #include <seqan3/alignment/pairwise/policy/banded_score_dp_matrix_policy.hpp>
 #include <seqan3/alignment/pairwise/policy/banded_score_trace_dp_matrix_policy.hpp>
 #include <seqan3/alignment/pairwise/policy/find_optimum_policy.hpp>
-#include <seqan3/alignment/pairwise/policy/unbanded_dp_matrix_policy.hpp>
+#include <seqan3/alignment/pairwise/policy/unbanded_score_dp_matrix_policy.hpp>
 #include <seqan3/alignment/pairwise/policy/unbanded_score_trace_dp_matrix_policy.hpp>
 
 //!\cond DEV
@@ -91,7 +91,7 @@
  *
  * ### Existing matrix policies:
  *
- *  - seqan3::detail::unbanded_dp_matrix_policy
+ *  - seqan3::detail::unbanded_score_dp_matrix_policy
  *  - seqan3::detail::unbanded_score_trace_dp_matrix_policy
  *
  * # Gap policies

--- a/include/seqan3/alignment/pairwise/policy/all.hpp
+++ b/include/seqan3/alignment/pairwise/policy/all.hpp
@@ -58,11 +58,12 @@
  * These policies maintain the alignment matrix in their own state.
  * The following table shows the functions that are required by the seqan3::detail::alignment_algorithm.
  *
- * Function name     | Arguments | Return value                         |
- * ----------------- | --------- | ------------------------------------ |
- * `allocate_matrix` | &Oslash;  | `void`                               |
- * `current_column`  | &Oslash;  | *implementation defined* - see below |
- * `next_column`     | &Oslash;  | `void`                               |
+ * Function name     | Arguments               | Return value                                                                 |
+ * ----------------- | ----------------------- | ---------------------------------------------------------------------------- |
+ * `allocate_matrix` | &Oslash;                | `void`                                                                       |
+ * `current_column`  | &Oslash;                | *implementation defined* - see below                                         |
+ * `next_column`     | &Oslash;                | `void`                                                                       |
+ * `parse_traceback` | `alignment_coordinate`  | `tuple<alignment_coordinate, tuple<deque<gap_segment>, deque<gap_segment>>>` |
  *
  * - allocate_matrix:
  *
@@ -79,6 +80,13 @@
  * - next_column:
  *
  *     Is called at the end of a column computation and moves internal matrix pointers to the next column.
+ *
+ * - parse_traceback:
+ *
+ *     This function is only required if the alignment is requested. It gets the coordinate where the traceback
+ *     should be started and returns a tuple with the begin coordinate and the two iterable ranges containing
+ *     seqan3::detail::gap_segment s. These gap segments store the gaps within the first sequence and the second
+ *     sequence respectively.
  *
  * ### Existing matrix policies:
  *

--- a/include/seqan3/alignment/pairwise/policy/all.hpp
+++ b/include/seqan3/alignment/pairwise/policy/all.hpp
@@ -21,6 +21,7 @@
 #include <seqan3/alignment/pairwise/policy/banded_score_dp_matrix_policy.hpp>
 #include <seqan3/alignment/pairwise/policy/find_optimum_policy.hpp>
 #include <seqan3/alignment/pairwise/policy/unbanded_dp_matrix_policy.hpp>
+#include <seqan3/alignment/pairwise/policy/unbanded_score_trace_dp_matrix_policy.hpp>
 
 //!\cond DEV
 /*!\defgroup alignment_policy Alignment policies
@@ -82,6 +83,7 @@
  * ### Existing matrix policies:
  *
  *  - seqan3::detail::unbanded_dp_matrix_policy
+ *  - seqan3::detail::unbanded_score_trace_dp_matrix_policy
  *
  * # Gap policies
  *

--- a/include/seqan3/alignment/pairwise/policy/banded_score_dp_matrix_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/banded_score_dp_matrix_policy.hpp
@@ -61,7 +61,7 @@ private:
     static constexpr std::tuple_element_t<0, cell_type> INF =
         std::numeric_limits<std::tuple_element_t<0, cell_type>>::lowest() / 2;
 
-    /*!\name Constructor, destructor and assignment
+    /*!\name Constructors, destructor and assignment
      * \{
      */
     constexpr banded_score_dp_matrix_policy() = default;

--- a/include/seqan3/alignment/pairwise/policy/banded_score_dp_matrix_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/banded_score_dp_matrix_policy.hpp
@@ -15,6 +15,7 @@
 #include <limits>
 #include <memory>
 
+#include <range/v3/view/repeat_n.hpp>
 #include <range/v3/view/slice.hpp>
 #include <range/v3/view/zip.hpp>
 
@@ -22,6 +23,7 @@
 #include <seqan3/range/shortcuts.hpp>
 #include <seqan3/std/ranges>
 #include <seqan3/std/span.hpp>
+#include <seqan3/std/view/common.hpp>
 
 namespace seqan3::detail
 {
@@ -100,9 +102,12 @@ public:
     //!\brief Returns the current column of the alignment matrix.
     constexpr auto current_column() noexcept
     {
+        auto span = current_band_size();
         // Return zip view over current column and current column shifted by one to access the previous horizontal.
-        return ranges::view::zip(std::span{std::addressof(*current_matrix_iter), current_band_size()},
-                                 std::span{std::addressof(*(current_matrix_iter + 1)), current_band_size()});
+        auto zip_score = ranges::view::zip(std::span{std::addressof(*current_matrix_iter), span},
+                                           std::span{std::addressof(*(current_matrix_iter + 1)), span});
+        return ranges::view::zip(std::move(zip_score),
+                                 ranges::view::repeat_n(std::ignore, span) | view::common);
     }
 
     //!\brief Moves internal matrix pointer to the next column.

--- a/include/seqan3/alignment/pairwise/policy/banded_score_dp_matrix_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/banded_score_dp_matrix_policy.hpp
@@ -22,7 +22,7 @@
 
 #include <seqan3/alignment/matrix/alignment_coordinate.hpp>
 #include <seqan3/alignment/matrix/trace_directions.hpp>
-#include <seqan3/alignment/pairwise/policy/unbanded_dp_matrix_policy.hpp>
+#include <seqan3/alignment/pairwise/policy/unbanded_score_dp_matrix_policy.hpp>
 #include <seqan3/range/shortcuts.hpp>
 #include <seqan3/std/ranges>
 #include <seqan3/std/span.hpp>
@@ -38,12 +38,12 @@ namespace seqan3::detail
  */
 template <typename derived_t, typename allocator_type>
 class banded_score_dp_matrix_policy :
-    public unbanded_dp_matrix_policy<banded_score_dp_matrix_policy<derived_t, allocator_type>,  allocator_type>
+    public unbanded_score_dp_matrix_policy<banded_score_dp_matrix_policy<derived_t, allocator_type>,  allocator_type>
 {
 private:
 
     //!\brief The type of the base.
-    using base_t = unbanded_dp_matrix_policy<banded_score_dp_matrix_policy<derived_t, allocator_type>,  allocator_type>;
+    using base_t = unbanded_score_dp_matrix_policy<banded_score_dp_matrix_policy<derived_t, allocator_type>,  allocator_type>;
 
     //!\brief Befriend CRTP derived type.
     friend derived_t;

--- a/include/seqan3/alignment/pairwise/policy/banded_score_dp_matrix_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/banded_score_dp_matrix_policy.hpp
@@ -132,10 +132,10 @@ public:
     }
 
     //!\brief Moves internal matrix pointer to the next column.
-    constexpr void next_column() noexcept
+    constexpr void go_next_column() noexcept
     {
         // Update the current_column_index.
-        base_t::next_column();
+        base_t::go_next_column();
         // Still in the initialisation phase and need to update the current matrix iterator until begin is reached.
         if (current_matrix_iter != std::ranges::begin(score_matrix))
             --current_matrix_iter;
@@ -229,12 +229,13 @@ public:
      */
     constexpr auto map_banded_coordinate_to_range_position(alignment_coordinate coordinate) const noexcept
     {
+        using as_int_t = std::make_signed_t<decltype(coordinate.first_seq_pos)>;
         // Refine the row coordinate to match the original sequence coordinates since the first position of the
         // trace matrix is shifted by the value of the band_column_index, i.e. the upper bound of the band.
         //
         // case 1: ends in column before the band_column_index: subtract the offset from the actual row coordinate.
         // case 2: ends in column after the band_column_index: add the offset to the actual row coordinate.
-        coordinate.second_seq_pos += static_cast<int32_t>(coordinate.first_seq_pos - band_column_index);
+        coordinate.second_seq_pos += static_cast<as_int_t>(coordinate.first_seq_pos - band_column_index);
         return coordinate;
     }
 

--- a/include/seqan3/alignment/pairwise/policy/banded_score_dp_matrix_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/banded_score_dp_matrix_policy.hpp
@@ -21,6 +21,7 @@
 #include <range/v3/view/zip.hpp>
 
 #include <seqan3/alignment/matrix/alignment_coordinate.hpp>
+#include <seqan3/alignment/matrix/trace_directions.hpp>
 #include <seqan3/alignment/pairwise/policy/unbanded_dp_matrix_policy.hpp>
 #include <seqan3/range/shortcuts.hpp>
 #include <seqan3/std/ranges>
@@ -95,7 +96,12 @@ public:
 
         // Reserve one more cell to deal with last cell in the banded column which needs only the diagonal and up cell.
         // TODO: introduce specific named cell types with initialisation values.
-        score_matrix.resize(band_column_index + band_row_index + 2, cell_type{INF, INF});
+        score_matrix.resize(band_column_index + band_row_index + 2);
+
+        using std::get;
+        get<0>(score_matrix.back()) = INF;
+        get<1>(score_matrix.back()) = INF;
+        get<2>(score_matrix.back()) = trace_directions::none;
         current_column_index = 0;
         // Position the iterator to the right offset within the band.
         current_matrix_iter = seqan3::begin(score_matrix) + band_column_index;

--- a/include/seqan3/alignment/pairwise/policy/banded_score_dp_matrix_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/banded_score_dp_matrix_policy.hpp
@@ -85,8 +85,8 @@ public:
     template <typename first_range_t, typename second_range_t, typename band_t>
     constexpr void allocate_matrix(first_range_t & first_range, second_range_t & second_range, band_t const & band)
     {
-        dimension_first_range  = std::distance(seqan3::begin(first_range), seqan3::end(first_range)) + 1;
-        dimension_second_range = std::distance(seqan3::begin(second_range), seqan3::end(second_range)) + 1;
+        dimension_first_range  = std::ranges::distance(std::ranges::begin(first_range), std::ranges::end(first_range)) + 1;
+        dimension_second_range = std::ranges::distance(std::ranges::begin(second_range), std::ranges::end(second_range)) + 1;
 
         // If upper_bound is negative, set it to 0 and trim the second sequences accordingly.
         band_column_index = std::max(static_cast<uint_fast32_t>(band.upper_bound), static_cast<uint_fast32_t>(0));
@@ -106,7 +106,7 @@ public:
         get<2>(score_matrix.back()) = trace_directions::none;
         current_column_index = 0;
         // Position the iterator to the right offset within the band.
-        current_matrix_iter = seqan3::begin(score_matrix) + band_column_index;
+        current_matrix_iter = std::ranges::begin(score_matrix) + band_column_index;
     }
 
     //!\brief Returns the current column of the alignment matrix.
@@ -116,11 +116,11 @@ public:
 
         assert(span > 0u);  // The span must always be greater than 0.
 
-        advanceable_alignment_coordinate<size_t, advanceable_alignment_coordinate_state::row>
+        advanceable_alignment_coordinate<advanceable_alignment_coordinate_state::row>
             col_begin{column_index_type{current_column_index},
-                      row_index_type{static_cast<size_t>(std::ranges::distance(seqan3::begin(score_matrix),
+                      row_index_type{static_cast<size_t>(std::ranges::distance(std::ranges::begin(score_matrix),
                                                                                current_matrix_iter))}};
-        advanceable_alignment_coordinate<size_t, advanceable_alignment_coordinate_state::row>
+        advanceable_alignment_coordinate<advanceable_alignment_coordinate_state::row>
             col_end{column_index_type{current_column_index}, row_index_type{col_begin.second_seq_pos + span}};
 
         // Return zip view over current column and current column shifted by one to access the previous horizontal.
@@ -137,7 +137,7 @@ public:
         // Update the current_column_index.
         base_t::next_column();
         // Still in the initialisation phase and need to update the current matrix iterator until begin is reached.
-        if (current_matrix_iter != seqan3::begin(score_matrix))
+        if (current_matrix_iter != std::ranges::begin(score_matrix))
             --current_matrix_iter;
     }
 
@@ -153,11 +153,11 @@ public:
         // than the first term in the equation above.
         assert(remaining_column_size > 0);
 
-        using const_iter = typename score_matrix_type::const_iterator;
+        // using const_iter = typename score_matrix_type::const_iterator;
         // The current band size is the min of the remaining column size and the size of the current span of the band.
         return std::min(static_cast<uint_fast32_t>(remaining_column_size),
                         static_cast<uint_fast32_t>(
-                                std::distance<const_iter>(current_matrix_iter, seqan3::end(score_matrix)) - 1));
+                                std::ranges::distance(current_matrix_iter, std::ranges::end(score_matrix)) - 1));
     }
 
     /*!\brief Computes the begin offset of the second_range within the vertical dimension of banded matrix.
@@ -204,8 +204,8 @@ public:
     {
         using band_type = decltype(band.lower_bound);
 
-        band_type dimension_first = std::distance(seqan3::begin(first_range), seqan3::end(first_range));
-        band_type dimension_second = std::distance(seqan3::begin(second_range), seqan3::end(second_range));
+        band_type dimension_first = std::ranges::distance(std::ranges::begin(first_range), std::ranges::end(first_range));
+        band_type dimension_second = std::ranges::distance(std::ranges::begin(second_range), std::ranges::end(second_range));
 
         auto trim_first_range = [&]() constexpr
         {

--- a/include/seqan3/alignment/pairwise/policy/banded_score_dp_matrix_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/banded_score_dp_matrix_policy.hpp
@@ -83,7 +83,7 @@ public:
      * \param[in] band         The band.
      */
     template <typename first_range_t, typename second_range_t, typename band_t>
-    constexpr void allocate_matrix(first_range_t && first_range, second_range_t && second_range, band_t const & band)
+    constexpr void allocate_matrix(first_range_t & first_range, second_range_t & second_range, band_t const & band)
     {
         dimension_first_range  = std::distance(seqan3::begin(first_range), seqan3::end(first_range)) + 1;
         dimension_second_range = std::distance(seqan3::begin(second_range), seqan3::end(second_range)) + 1;
@@ -198,8 +198,8 @@ public:
     * sequences are trimmed, such that the band starts in the origin and ends in the sink.
     */
     template <typename first_range_t, typename second_range_t, typename band_t>
-    constexpr auto trim_sequences(first_range_t && first_range,
-                                  second_range_t && second_range,
+    constexpr auto trim_sequences(first_range_t & first_range,
+                                  second_range_t & second_range,
                                   band_t const & band) const noexcept
     {
         using band_type = decltype(band.lower_bound);
@@ -211,14 +211,14 @@ public:
         {
             size_t begin_pos = std::max(band.lower_bound - 1, static_cast<band_type>(0));
             size_t end_pos = std::min(band.upper_bound + dimension_second, dimension_first);
-            return std::forward<first_range_t>(first_range) | ranges::view::slice(begin_pos, end_pos);
+            return first_range | ranges::view::slice(begin_pos, end_pos);
         };
 
         auto trim_second_range = [&]() constexpr
         {
             size_t begin_pos = std::abs(std::min(band.upper_bound + 1, static_cast<band_type>(0)));
             size_t end_pos = std::min(dimension_first - band.lower_bound, dimension_second);
-            return std::forward<second_range_t>(second_range) | ranges::view::slice(begin_pos, end_pos);
+            return second_range | ranges::view::slice(begin_pos, end_pos);
         };
 
         return std::tuple{trim_first_range(), trim_second_range()};

--- a/include/seqan3/alignment/pairwise/policy/banded_score_trace_dp_matrix_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/banded_score_trace_dp_matrix_policy.hpp
@@ -131,9 +131,9 @@ private:
     }
 
     //!\brief Moves internal matrix pointer to the next column.
-    constexpr void next_column() noexcept
+    constexpr void go_next_column() noexcept
     {
-        base_t::next_column();
+        base_t::go_next_column();
         // Move trace back pointer to begin of next column
         trace_matrix_iter = std::ranges::begin(trace_matrix) + band_size * current_column_index;
         // As long as we shift the band towards the band_column_index, jump to the correct begin.

--- a/include/seqan3/alignment/pairwise/policy/banded_score_trace_dp_matrix_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/banded_score_trace_dp_matrix_policy.hpp
@@ -115,11 +115,11 @@ private:
 
         // The begin coordinate in the current column begins at it - begin(matrix).
         // The end coordinate ends at it - begin(matrix) + current_band_size
-        advanceable_alignment_coordinate<size_t, advanceable_alignment_coordinate_state::row>
+        advanceable_alignment_coordinate<advanceable_alignment_coordinate_state::row>
             col_begin{column_index_type{current_column_index},
                       row_index_type{static_cast<size_t>(std::ranges::distance(std::ranges::begin(score_matrix),
                                                                                current_matrix_iter))}};
-        advanceable_alignment_coordinate<size_t, advanceable_alignment_coordinate_state::row>
+        advanceable_alignment_coordinate<advanceable_alignment_coordinate_state::row>
             col_end{column_index_type{current_column_index}, row_index_type{col_begin.second_seq_pos + span}};
 
         // Return zip view over current column and current column shifted by one to access the previous horizontal.
@@ -155,7 +155,7 @@ private:
 
         // Put the iterator to the position where the traceback starts.
         auto direction_iter = std::ranges::begin(trace_matrix);
-        std::advance(direction_iter, end_coordinate.first_seq_pos * band_size +
+        std::ranges::advance(direction_iter, end_coordinate.first_seq_pos * band_size +
                                      end_coordinate.second_seq_pos);
 
         // Parse the trace until interrupt.
@@ -217,7 +217,7 @@ private:
                                            band_size)};
         auto r = row_index_type{
                 static_cast<uint_fast32_t>(std::ranges::distance(std::ranges::begin(trace_matrix), direction_iter) %
-                                        band_size)};
+                                           band_size)};
 
         // Validate correct coordinates.
         auto begin_coordinate = map_banded_coordinate_to_range_position(

--- a/include/seqan3/alignment/pairwise/policy/banded_score_trace_dp_matrix_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/banded_score_trace_dp_matrix_policy.hpp
@@ -68,7 +68,6 @@ private:
     /*!\name Member types
      * \{
      */
-    //!\brief The underlying cell type of the dynamic programming matrix.
     //!\brief The underlying cell type of the scoring matrix.
     using cell_type = typename score_allocator_t::value_type;
     //!\brief The underlying cell type of the trace matrix.
@@ -79,7 +78,7 @@ private:
     using trace_matrix_type = std::vector<trace_type, trace_allocator_t>;
     //!\}
 
-    /*!\name Constructor, destructor and assignment
+    /*!\name Constructors, destructor and assignment
      * \{
      */
     constexpr banded_score_trace_dp_matrix_policy() = default;
@@ -88,13 +87,15 @@ private:
     constexpr banded_score_trace_dp_matrix_policy & operator=(banded_score_trace_dp_matrix_policy const &) = default;
     constexpr banded_score_trace_dp_matrix_policy & operator=(banded_score_trace_dp_matrix_policy &&) = default;
     ~banded_score_trace_dp_matrix_policy() = default;
-    //!}
+    //!\}
 
     /*!\brief Allocates the memory for the dynamic programming matrix given the two sequences.
      * \tparam first_range_t   The type of the first sequence (or packed sequences).
      * \tparam second_range_t  The type of the second sequence (or packed sequences).
+     * \tparam band_t          The type of the band object.
      * \param[in] first_range  The first sequence (or packed sequences).
      * \param[in] second_range The second sequence (or packed sequences).
+     * \param[in] band         The band object.
      */
     template <typename first_range_t, typename second_range_t, typename band_t>
     constexpr void allocate_matrix(first_range_t && first_range, second_range_t && second_range, band_t const & band)

--- a/include/seqan3/alignment/pairwise/policy/banded_score_trace_dp_matrix_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/banded_score_trace_dp_matrix_policy.hpp
@@ -1,0 +1,144 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides seqan3::detail::unbanded_score_trace_dp_matrix.
+ * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <range/v3/view/iota.hpp>
+#include <range/v3/view/zip.hpp>
+
+#include <seqan3/alignment/matrix/alignment_coordinate.hpp>
+#include <seqan3/alignment/pairwise/policy/banded_score_dp_matrix_policy.hpp>
+#include <seqan3/std/span.hpp>
+
+namespace seqan3::detail
+{
+/*!\brief Manages the allocation and provision of an unbanded dynamic programming matrix.
+ * \ingroup alignment_policy
+ * \tparam derived_t   The derived alignment algorithm.
+ * \tparam score_allocator_t The allocator type used for allocating the score matrix.
+ * \tparam trace_allocator_t The allocator type used for allocating the trace matrix.
+ */
+template <typename derived_t, typename score_allocator_t, typename trace_allocator_t>
+class banded_score_trace_dp_matrix_policy :
+    public banded_score_dp_matrix_policy<banded_score_trace_dp_matrix_policy<derived_t,
+                                                                             score_allocator_t,
+                                                                             trace_allocator_t>,
+                                         score_allocator_t>
+{
+private:
+
+    //!\brief The base type
+    using base_t = banded_score_dp_matrix_policy<banded_score_trace_dp_matrix_policy<derived_t,
+                                                                                     score_allocator_t,
+                                                                                     trace_allocator_t>,
+                                                 score_allocator_t>;
+
+    //!\brief Befriends the derived class to grant it access to the private members.
+    friend derived_t;
+
+    // Import members from base class.
+    using base_t::score_matrix;
+    using base_t::dimension_first_range;
+    using base_t::dimension_second_range;
+    using base_t::current_column_index;
+    using base_t::current_matrix_iter;
+    using base_t::band_column_index;
+    using base_t::band_row_index;
+
+    // Import member functions from base class
+    using base_t::current_band_size;
+    using base_t::second_range_begin_offset;
+    using base_t::band_touches_last_row;
+    using base_t::trim_sequences;
+
+    /*!\name Member types
+     * \{
+     */
+    //!\brief The underlying cell type of the dynamic programming matrix.
+    //!\brief The underlying cell type of the scoring matrix.
+    using cell_type = typename score_allocator_t::value_type;
+    //!\brief The underlying cell type of the trace matrix.
+    using trace_type = typename trace_allocator_t::value_type;
+    //!\brief The type of the score matrix.
+    using score_matrix_type = std::vector<cell_type, score_allocator_t>;
+    //!\brief The type of the trace matrix.
+    using trace_matrix_type = std::vector<trace_type, trace_allocator_t>;
+    //!\}
+
+    /*!\name Constructor, destructor and assignment
+     * \{
+     */
+    constexpr banded_score_trace_dp_matrix_policy() = default;
+    constexpr banded_score_trace_dp_matrix_policy(banded_score_trace_dp_matrix_policy const &) = default;
+    constexpr banded_score_trace_dp_matrix_policy(banded_score_trace_dp_matrix_policy &&) = default;
+    constexpr banded_score_trace_dp_matrix_policy & operator=(banded_score_trace_dp_matrix_policy const &) = default;
+    constexpr banded_score_trace_dp_matrix_policy & operator=(banded_score_trace_dp_matrix_policy &&) = default;
+    ~banded_score_trace_dp_matrix_policy() = default;
+    //!}
+
+    /*!\brief Allocates the memory for the dynamic programming matrix given the two sequences.
+     * \tparam first_range_t   The type of the first sequence (or packed sequences).
+     * \tparam second_range_t  The type of the second sequence (or packed sequences).
+     * \param[in] first_range  The first sequence (or packed sequences).
+     * \param[in] second_range The second sequence (or packed sequences).
+     */
+    template <typename first_range_t, typename second_range_t, typename band_t>
+    constexpr void allocate_matrix(first_range_t && first_range, second_range_t && second_range, band_t const & band)
+    {
+        base_t::allocate_matrix(first_range, second_range, band);
+
+        // Allocate the k-banded score matrix for the trace matrix and set the matrix iterator to the first position
+        // within the matrix.
+        band_dimension = band_column_index + band_row_index + 1;
+        trace_matrix.resize(band_dimension * dimension_first_range);
+        trace_matrix_iter = seqan3::begin(trace_matrix) + band_column_index;
+    }
+
+    //!\brief Returns the current column of the alignment matrix.
+    constexpr auto current_column() noexcept
+    {
+        auto span = base_t::current_band_size();
+
+        assert(span > 0u);  // The span must always be greater than 0.
+
+        // The begin coordinate in the current column begins at it - begin(matrix).
+        // The end coordinate ends at it - begin(matrix) + current_band_size
+        advanceable_alignment_coordinate<size_t, advanceable_alignment_coordinate_state::row>
+            col_begin{column_index_type{current_column_index},
+                      row_index_type{static_cast<size_t>(std::ranges::distance(seqan3::begin(score_matrix),
+                                                                               current_matrix_iter))}};
+        advanceable_alignment_coordinate<size_t, advanceable_alignment_coordinate_state::row>
+            col_end{column_index_type{current_column_index}, row_index_type{col_begin.second_seq_pos + span}};
+
+        // Return zip view over current column and current column shifted by one to access the previous horizontal.
+        auto zip_score = ranges::view::zip(std::span{std::addressof(*current_matrix_iter), span},
+                                           std::span{std::addressof(*(current_matrix_iter + 1)), span});
+        return ranges::view::zip(std::move(zip_score),
+                                 ranges::view::iota(col_begin, col_end),
+                                 std::span{std::addressof(*trace_matrix_iter), span});
+    }
+
+    //!\brief Moves internal matrix pointer to the next column.
+    constexpr void next_column() noexcept
+    {
+        base_t::next_column();
+        trace_matrix_iter += band_dimension - ((current_matrix_iter != seqan3::begin(score_matrix)) ? 1 : 0);
+    }
+
+    //!\brief The data container.
+    trace_matrix_type trace_matrix{};
+    //!\brief The current iterator in the trace matrix.
+    typename std::ranges::iterator_t<trace_matrix_type> trace_matrix_iter{};
+    //!\brief The full dimension of the band.
+    uint_fast32_t band_dimension{};
+};
+} // namespace seqan3::detail

--- a/include/seqan3/alignment/pairwise/policy/banded_score_trace_dp_matrix_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/banded_score_trace_dp_matrix_policy.hpp
@@ -98,7 +98,7 @@ private:
      * \param[in] band         The band object.
      */
     template <typename first_range_t, typename second_range_t, typename band_t>
-    constexpr void allocate_matrix(first_range_t && first_range, second_range_t && second_range, band_t const & band)
+    constexpr void allocate_matrix(first_range_t & first_range, second_range_t & second_range, band_t const & band)
     {
         base_t::allocate_matrix(first_range, second_range, band);
 

--- a/include/seqan3/alignment/pairwise/policy/find_optimum_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/find_optimum_policy.hpp
@@ -16,11 +16,14 @@
 
 #include <range/v3/algorithm/for_each.hpp>
 
+#include <seqan3/alignment/matrix/alignment_optimum.hpp>
 #include <seqan3/core/metafunction/deferred_crtp_base.hpp>
 #include <seqan3/range/shortcuts.hpp>
 #include <seqan3/std/concepts>
 #include <seqan3/std/iterator>
 #include <seqan3/std/ranges>
+
+#include <seqan3/io/stream/debug_stream.hpp>
 
 namespace seqan3::detail
 {
@@ -78,7 +81,7 @@ protected:
 
     /*!\brief Checks every cell of the dynamic programming matrix.
      * \tparam score_t The type of the score.
-     * \param[in]     val       The current value.
+     * \param[in]     current   The current value.
      * \param[in,out] optimum   The current optimum to compare with.
      *
      * \details
@@ -86,16 +89,19 @@ protected:
      * This function resolves to a "NO-OP" function if the trait for searching every cell is set to std::false_type.
      */
     template <typename score_t>
-    constexpr void check_score([[maybe_unused]] score_t const val,
-                               [[maybe_unused]] score_t & optimum) const noexcept
+    constexpr void check_score([[maybe_unused]] alignment_optimum<score_t> const & current,
+                               [[maybe_unused]] alignment_optimum<score_t> & optimum) const noexcept
     {
         if constexpr (traits_type::find_in_every_cell_type::value)
-            optimum = std::max(optimum, val);
+        {
+            optimum = std::max(current, optimum, alignment_optimum_compare_less{});
+        }
+
     }
 
     /*!\brief Checks a cell of the last row of the dynamic programming matrix.
      * \tparam score_t The type of the score.
-     * \param[in]     val       The current value.
+     * \param[in]     current   The current value.
      * \param[in,out] optimum   The current optimum to compare with.
      *
      * \details
@@ -105,11 +111,11 @@ protected:
      * takes care of calling this function for the appropriate cells.
      */
     template <typename score_t>
-    constexpr void check_score_last_row([[maybe_unused]] score_t const val,
-                                        [[maybe_unused]] score_t & optimum) const noexcept
+    constexpr void check_score_last_row([[maybe_unused]] alignment_optimum<score_t> const & current,
+                                        [[maybe_unused]] alignment_optimum<score_t> & optimum) const noexcept
     {
         if constexpr (traits_type::find_in_last_row_type::value)
-            optimum = std::max(optimum, val);
+            optimum = std::max(current, optimum, alignment_optimum_compare_less{});
     }
 
     /*!\brief Checks the complete last column for the optimal score.
@@ -125,26 +131,33 @@ protected:
      * Due to a column based iteration layout the entire last column can be searched at once.
      */
     template <std::ranges::BidirectionalRange rng_t, typename score_t>
-    constexpr void check_score_last_column(rng_t && rng, score_t & optimum) const noexcept
+    constexpr void check_score_last_column(rng_t const & rng,
+                                           alignment_optimum<score_t> & optimum) const noexcept
     {
         using std::get;
         // Only check the entire column if it was configured to search here.
         if constexpr (traits_type::find_in_last_column_type::value)
         {
-            ranges::for_each(rng, [&](auto && tpl)
+            ranges::for_each(rng, [&](auto && entry)
             {
-                optimum = std::max(optimum, get<0>(tpl));
+                optimum = std::max(alignment_optimum<score_t>{get<0>(get<0>(entry)),
+                                                              static_cast<alignment_coordinate>(get<1>(entry))},
+                                   optimum,
+                                   alignment_optimum_compare_less{});
             });
         }
         else  // Only check the last cell for the global alignment.
         {
-            auto val = get<0>(*std::ranges::prev(seqan3::end(rng)));
-            optimum = std::max(optimum, val);
+            auto && last = *std::ranges::prev(seqan3::end(rng));
+            optimum = std::max(alignment_optimum<score_t>{get<0>(get<0>(last)),
+                                                          static_cast<alignment_coordinate>(get<1>(last))},
+                               optimum,
+                               alignment_optimum_compare_less{});
         }
     }
 
     /*!\brief Balances the total score of the alignment depending on the band settings and the alignment configuration.
-     * \tparam score_type      The type of the score.
+     * \tparam optimum_type    The type of the matrix optimum.
      * \tparam dimension_type  The type of the matrix dimensions.
      * \tparam band_type       The type of the band.
      * \tparam gap_scheme_type The type of the gap_scheme.
@@ -154,11 +167,11 @@ protected:
      * \param[in]     band             The band.
      * \param[in]     scheme           The gap scheme to get the score for the trailing gap.
      */
-    template <typename score_type,
+    template <typename optimum_type,
               typename dimension_type,
               typename band_type,
               typename gap_scheme_type>
-    constexpr void balance_trailing_gaps([[maybe_unused]] score_type & total,
+    constexpr void balance_trailing_gaps([[maybe_unused]] optimum_type & total,
                                          [[maybe_unused]] dimension_type const dimension_first,
                                          [[maybe_unused]] dimension_type const dimension_second,
                                          [[maybe_unused]] band_type const & band,
@@ -174,7 +187,7 @@ protected:
                                              static_cast<cmp_int_type>(dimension_first));
 
             assert(gap_size >= 0);
-            total += scheme.score(gap_size);
+            total.score += scheme.score(gap_size);
         }
 
         // Only balance score if max is not searched in entire last column.
@@ -186,7 +199,7 @@ protected:
                                              static_cast<cmp_int_type>(dimension_second));
 
             assert(gap_size >= 0);
-            total += scheme.score(gap_size);
+            total.score += scheme.score(gap_size);
         }
     }
 };

--- a/include/seqan3/alignment/pairwise/policy/find_optimum_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/find_optimum_policy.hpp
@@ -23,8 +23,6 @@
 #include <seqan3/std/iterator>
 #include <seqan3/std/ranges>
 
-#include <seqan3/io/stream/debug_stream.hpp>
-
 namespace seqan3::detail
 {
 
@@ -66,7 +64,7 @@ private:
     //!\brief Befriends the derived class to grant it access to the private members.
     friend derived_t;
 
-    /*!\name Constructor, destructor and assignment
+    /*!\name Constructors, destructor and assignment
      * \{
      */
     constexpr find_optimum_policy() = default;
@@ -162,8 +160,8 @@ protected:
      * \tparam band_type       The type of the band.
      * \tparam gap_scheme_type The type of the gap_scheme.
      * \param[in,out] total            The total score to be updated.
-     * \param[in]     dimension_first  The horizontal matrix dimension.
-     * \param[in]     dimension_second The vertical matrix dimension.
+     * \param[in]     dimension_first  The matrix dimension in horizontal direction (size of first range + 1).
+     * \param[in]     dimension_second The matrix dimension in vertical direction (size of second range + 1).
      * \param[in]     band             The band.
      * \param[in]     scheme           The gap scheme to get the score for the trailing gap.
      */

--- a/include/seqan3/alignment/pairwise/policy/find_optimum_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/find_optimum_policy.hpp
@@ -146,7 +146,7 @@ protected:
         }
         else  // Only check the last cell for the global alignment.
         {
-            auto && last = *std::ranges::prev(seqan3::end(rng));
+            auto && last = *std::ranges::prev(std::ranges::end(rng));
             optimum = std::max(alignment_optimum<score_t>{get<0>(get<0>(last)),
                                                           static_cast<alignment_coordinate>(get<1>(last))},
                                optimum,

--- a/include/seqan3/alignment/pairwise/policy/unbanded_dp_matrix_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/unbanded_dp_matrix_policy.hpp
@@ -15,10 +15,12 @@
 #include <vector>
 #include <tuple>
 
+#include <range/v3/view/iota.hpp>
 #include <range/v3/view/repeat_n.hpp>
 #include <range/v3/view/transform.hpp>
 #include <range/v3/view/zip.hpp>
 
+#include <seqan3/alignment/matrix/alignment_coordinate.hpp>
 #include <seqan3/core/metafunction/range.hpp>
 #include <seqan3/range/shortcuts.hpp>
 #include <seqan3/std/span.hpp>
@@ -82,7 +84,13 @@ private:
     //!\brief Returns the current column of the alignment matrix.
     constexpr auto current_column() noexcept
     {
+        advanceable_alignment_coordinate<size_t, advanceable_alignment_coordinate_state::row>
+            col_begin{column_index_type{current_column_index}, row_index_type{0u}};
+        advanceable_alignment_coordinate<size_t, advanceable_alignment_coordinate_state::row>
+            col_end{column_index_type{current_column_index}, row_index_type{dimension_second_range}};
+
         return ranges::view::zip(std::span{score_matrix},
+                                 ranges::view::iota(col_begin, col_end),
                                  ranges::view::repeat_n(std::ignore, dimension_second_range) | view::common);
     }
 

--- a/include/seqan3/alignment/pairwise/policy/unbanded_dp_matrix_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/unbanded_dp_matrix_policy.hpp
@@ -51,7 +51,7 @@ private:
     using score_matrix_type = std::vector<cell_type, allocator_t>;
     //!\}
 
-    /*!\name Constructor, destructor and assignment
+    /*!\name Constructors, destructor and assignment
      * \brief Defaulted all standard constructor.
      * \{
      */

--- a/include/seqan3/alignment/pairwise/policy/unbanded_score_dp_matrix_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/unbanded_score_dp_matrix_policy.hpp
@@ -84,9 +84,9 @@ private:
     //!\brief Returns the current column of the alignment matrix.
     constexpr auto current_column() noexcept
     {
-        advanceable_alignment_coordinate<size_t, advanceable_alignment_coordinate_state::row>
+        advanceable_alignment_coordinate<advanceable_alignment_coordinate_state::row>
             col_begin{column_index_type{current_column_index}, row_index_type{0u}};
-        advanceable_alignment_coordinate<size_t, advanceable_alignment_coordinate_state::row>
+        advanceable_alignment_coordinate<advanceable_alignment_coordinate_state::row>
             col_end{column_index_type{current_column_index}, row_index_type{dimension_second_range}};
 
         return ranges::view::zip(std::span{score_matrix},

--- a/include/seqan3/alignment/pairwise/policy/unbanded_score_dp_matrix_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/unbanded_score_dp_matrix_policy.hpp
@@ -95,7 +95,7 @@ private:
     }
 
     //!\brief Moves internal matrix pointer to the next column.
-    constexpr void next_column() noexcept
+    constexpr void go_next_column() noexcept
     {
         ++current_column_index;
     }

--- a/include/seqan3/alignment/pairwise/policy/unbanded_score_dp_matrix_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/unbanded_score_dp_matrix_policy.hpp
@@ -70,7 +70,7 @@ private:
      * \param[in] second_range The first sequence (or packed sequences).
      */
     template <typename first_range_t, typename second_range_t>
-    constexpr void allocate_matrix(first_range_t && first_range, second_range_t && second_range)
+    constexpr void allocate_matrix(first_range_t & first_range, second_range_t & second_range)
     {
         dimension_first_range = std::ranges::distance(first_range) + 1;
         dimension_second_range = std::ranges::distance(second_range) + 1;

--- a/include/seqan3/alignment/pairwise/policy/unbanded_score_dp_matrix_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/unbanded_score_dp_matrix_policy.hpp
@@ -6,7 +6,7 @@
 // -----------------------------------------------------------------------------------------------------
 
 /*!\file
- * \brief Provides seqan3::detail::unbanded_dp_matrix_policy.
+ * \brief Provides seqan3::detail::unbanded_score_dp_matrix_policy.
  * \author Rene Rahn <rene.rahn AT fu-berlin.de>
  */
 
@@ -35,7 +35,7 @@ namespace seqan3::detail
  * \tparam allocator_t The allocator type used for allocating the dynamic programming matrix.
  */
 template <typename derived_t, typename allocator_t>
-class unbanded_dp_matrix_policy
+class unbanded_score_dp_matrix_policy
 {
 private:
 
@@ -55,12 +55,12 @@ private:
      * \brief Defaulted all standard constructor.
      * \{
      */
-    constexpr unbanded_dp_matrix_policy()                                              = default;
-    constexpr unbanded_dp_matrix_policy(unbanded_dp_matrix_policy const &)             = default;
-    constexpr unbanded_dp_matrix_policy(unbanded_dp_matrix_policy &&)                  = default;
-    constexpr unbanded_dp_matrix_policy & operator=(unbanded_dp_matrix_policy const &) = default;
-    constexpr unbanded_dp_matrix_policy & operator=(unbanded_dp_matrix_policy &&)      = default;
-    ~unbanded_dp_matrix_policy()                                                       = default;
+    constexpr unbanded_score_dp_matrix_policy() = default;
+    constexpr unbanded_score_dp_matrix_policy(unbanded_score_dp_matrix_policy const &) = default;
+    constexpr unbanded_score_dp_matrix_policy(unbanded_score_dp_matrix_policy &&) = default;
+    constexpr unbanded_score_dp_matrix_policy & operator=(unbanded_score_dp_matrix_policy const &) = default;
+    constexpr unbanded_score_dp_matrix_policy & operator=(unbanded_score_dp_matrix_policy &&) = default;
+    ~unbanded_score_dp_matrix_policy() = default;
     //!\}
 
     /*!\brief Allocates the memory for the dynamic programming matrix given the two sequences.

--- a/include/seqan3/alignment/pairwise/policy/unbanded_score_trace_dp_matrix_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/unbanded_score_trace_dp_matrix_policy.hpp
@@ -130,9 +130,9 @@ private:
     }
 
     //!\brief Moves internal matrix pointer to the next column.
-    constexpr void next_column() noexcept
+    constexpr void go_next_column() noexcept
     {
-        base_t::next_column();
+        base_t::go_next_column();
         trace_matrix_iter += dimension_second_range;
     }
 

--- a/include/seqan3/alignment/pairwise/policy/unbanded_score_trace_dp_matrix_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/unbanded_score_trace_dp_matrix_policy.hpp
@@ -107,7 +107,7 @@ private:
      * \param[in] second_range The second sequence (or packed sequences).
      */
     template <typename first_range_t, typename second_range_t>
-    constexpr void allocate_matrix(first_range_t && first_range, second_range_t && second_range)
+    constexpr void allocate_matrix(first_range_t & first_range, second_range_t & second_range)
     {
         base_t::allocate_matrix(first_range, second_range);
 

--- a/include/seqan3/alignment/pairwise/policy/unbanded_score_trace_dp_matrix_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/unbanded_score_trace_dp_matrix_policy.hpp
@@ -1,0 +1,114 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides seqan3::detail::unbanded_score_trace_dp_matrix.
+ * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <range/v3/view/zip.hpp>
+
+#include <seqan3/alignment/matrix/trace_directions.hpp>
+#include <seqan3/alignment/pairwise/policy/unbanded_dp_matrix_policy.hpp>
+#include <seqan3/std/span.hpp>
+
+namespace seqan3::detail
+{
+/*!\brief Manages the allocation and provision of an unbanded dynamic programming matrix.
+ * \ingroup alignment_policy
+ * \tparam derived_t   The derived alignment algorithm.
+ * \tparam score_allocator_t The allocator type used for allocating the score matrix.
+ * \tparam trace_allocator_t The allocator type used for allocating the trace matrix.
+ */
+template <typename derived_t, typename score_allocator_t, typename trace_allocator_t>
+class unbanded_score_trace_dp_matrix_policy :
+    public unbanded_dp_matrix_policy<unbanded_score_trace_dp_matrix_policy<derived_t,
+                                                                           score_allocator_t,
+                                                                           trace_allocator_t>,
+                                     score_allocator_t>
+{
+private:
+
+    //!\brief The base type
+    using base_t = unbanded_dp_matrix_policy<unbanded_score_trace_dp_matrix_policy<derived_t,
+                                                                                   score_allocator_t,
+                                                                                   trace_allocator_t>,
+                                             score_allocator_t>;
+
+    //!\brief Befriends the derived class to grant it access to the private members.
+    friend derived_t;
+    //!\brief Make dimension_first_range visible in this class.
+    using base_t::dimension_first_range;
+    //!\brief Make dimension_second_range visible in this class.
+    using base_t::dimension_second_range;
+    //!\brief Make score_matrix visible in this class.
+    using base_t::score_matrix;
+
+    /*!\name Member types
+     * \{
+     */
+    //!\brief The underlying cell type of the dynamic programming matrix.
+    //!\brief The underlying cell type of the scoring matrix.
+    using cell_type = typename score_allocator_t::value_type;
+    //!\brief The underlying cell type of the trace matrix.
+    using trace_type = typename trace_allocator_t::value_type;
+    //!\brief The type of the score matrix.
+    using score_matrix_type = std::vector<cell_type, score_allocator_t>;
+    //!\brief The type of the trace matrix.
+    using trace_matrix_type = std::vector<trace_type, trace_allocator_t>;
+    //!\}
+
+    /*!\name Constructor, destructor and assignment
+     * \{
+     */
+    constexpr unbanded_score_trace_dp_matrix_policy() = default;
+    constexpr unbanded_score_trace_dp_matrix_policy(unbanded_score_trace_dp_matrix_policy const &) = default;
+    constexpr unbanded_score_trace_dp_matrix_policy(unbanded_score_trace_dp_matrix_policy &&) = default;
+    constexpr unbanded_score_trace_dp_matrix_policy & operator=(unbanded_score_trace_dp_matrix_policy const &) = default;
+    constexpr unbanded_score_trace_dp_matrix_policy & operator=(unbanded_score_trace_dp_matrix_policy &&) = default;
+    ~unbanded_score_trace_dp_matrix_policy() = default;
+    //!}
+
+    /*!\brief Allocates the memory for the dynamic programming matrix given the two sequences.
+     * \tparam first_range_t   The type of the first sequence (or packed sequences).
+     * \tparam second_range_t  The type of the second sequence (or packed sequences).
+     * \param[in] first_range  The first sequence (or packed sequences).
+     * \param[in] second_range The second sequence (or packed sequences).
+     */
+    template <typename first_range_t, typename second_range_t>
+    constexpr void allocate_matrix(first_range_t && first_range, second_range_t && second_range)
+    {
+        dimension_first_range = seqan3::size(std::forward<first_range_t>(first_range)) + 1;
+        dimension_second_range = seqan3::size(std::forward<second_range_t>(second_range)) + 1;
+
+        // We use only one column to compute the score.
+        score_matrix.resize(dimension_second_range);
+        // We use the full matrix to store the trace direction.
+        trace_matrix.resize(dimension_first_range * dimension_second_range);
+        trace_matrix_iter = trace_matrix.begin();
+    }
+
+    //!\brief Returns the current column of the alignment matrix.
+    constexpr auto current_column()
+    {
+        return ranges::view::zip(std::span{score_matrix}, std::span{&(*trace_matrix_iter), dimension_second_range});
+    }
+
+    //!\brief Moves internal matrix pointer to the next column.
+    constexpr void next_column() noexcept
+    {
+        trace_matrix_iter += dimension_second_range;
+    }
+
+    //!\brief The data container.
+    trace_matrix_type trace_matrix{};
+    //!\brief The current iterator in the trace matrix.
+    typename trace_matrix_type::iterator trace_matrix_iter{};
+};
+} // namespace seqan3::detail

--- a/include/seqan3/alignment/pairwise/policy/unbanded_score_trace_dp_matrix_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/unbanded_score_trace_dp_matrix_policy.hpp
@@ -20,7 +20,7 @@
 
 #include <seqan3/alignment/matrix/alignment_coordinate.hpp>
 #include <seqan3/alignment/matrix/trace_directions.hpp>
-#include <seqan3/alignment/pairwise/policy/unbanded_dp_matrix_policy.hpp>
+#include <seqan3/alignment/pairwise/policy/unbanded_score_dp_matrix_policy.hpp>
 #include <seqan3/range/view/persist.hpp>
 #include <seqan3/std/span.hpp>
 
@@ -51,18 +51,18 @@ struct gap_segment
  */
 template <typename derived_t, typename score_allocator_t, typename trace_allocator_t>
 class unbanded_score_trace_dp_matrix_policy :
-    public unbanded_dp_matrix_policy<unbanded_score_trace_dp_matrix_policy<derived_t,
-                                                                           score_allocator_t,
-                                                                           trace_allocator_t>,
-                                     score_allocator_t>
+    public unbanded_score_dp_matrix_policy<unbanded_score_trace_dp_matrix_policy<derived_t,
+                                                                                 score_allocator_t,
+                                                                                 trace_allocator_t>,
+                                           score_allocator_t>
 {
 private:
 
     //!\brief The base type
-    using base_t = unbanded_dp_matrix_policy<unbanded_score_trace_dp_matrix_policy<derived_t,
-                                                                                   score_allocator_t,
-                                                                                   trace_allocator_t>,
-                                             score_allocator_t>;
+    using base_t = unbanded_score_dp_matrix_policy<unbanded_score_trace_dp_matrix_policy<derived_t,
+                                                                                         score_allocator_t,
+                                                                                         trace_allocator_t>,
+                                                   score_allocator_t>;
 
     //!\brief Befriends the derived class to grant it access to the private members.
     friend derived_t;

--- a/include/seqan3/alignment/pairwise/policy/unbanded_score_trace_dp_matrix_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/unbanded_score_trace_dp_matrix_policy.hpp
@@ -119,14 +119,14 @@ private:
     //!\brief Returns the current column of the alignment matrix.
     constexpr auto current_column()
     {
-        advanceable_alignment_coordinate<size_t, advanceable_alignment_coordinate_state::row>
+        advanceable_alignment_coordinate<advanceable_alignment_coordinate_state::row>
             col_begin{column_index_type{current_column_index}, row_index_type{0u}};
-        advanceable_alignment_coordinate<size_t, advanceable_alignment_coordinate_state::row>
+        advanceable_alignment_coordinate<advanceable_alignment_coordinate_state::row>
             col_end{column_index_type{current_column_index}, row_index_type{dimension_second_range}};
 
         return ranges::view::zip(std::span{score_matrix},
                                  ranges::view::iota(col_begin, col_end),
-                                 std::span{&(*trace_matrix_iter), dimension_second_range});
+                                 std::span{std::addressof(*trace_matrix_iter), dimension_second_range});
     }
 
     //!\brief Moves internal matrix pointer to the next column.
@@ -149,9 +149,9 @@ private:
         std::deque<gap_segment> second_segments{};
 
         // Put the iterator to the position where the traceback starts.
-        auto direction_iter = seqan3::begin(trace_matrix);
-        std::advance(direction_iter, end_coordinate.first_seq_pos * dimension_second_range +
-                                     end_coordinate.second_seq_pos);
+        auto direction_iter = std::ranges::begin(trace_matrix);
+        std::ranges::advance(direction_iter,
+                             end_coordinate.first_seq_pos * dimension_second_range + end_coordinate.second_seq_pos);
 
         // Parse the trace until interrupt.
         while (*direction_iter != trace_directions::none)
@@ -167,7 +167,7 @@ private:
                 static_cast<bool>(*direction_iter & trace_directions::up_open))
             {
                 // Get the current column index (note the column based layout)
-                size_t pos = std::ranges::distance(seqan3::begin(trace_matrix), direction_iter) /
+                size_t pos = std::ranges::distance(std::ranges::begin(trace_matrix), direction_iter) /
                              dimension_second_range;
                 gap_segment gap{pos, 0u};
 
@@ -189,7 +189,7 @@ private:
                 static_cast<bool>(*direction_iter & trace_directions::left_open))
             {
                 // Get the current row index (note the column based layout)
-                size_t pos = std::ranges::distance(seqan3::begin(trace_matrix), direction_iter) %
+                size_t pos = std::ranges::distance(std::ranges::begin(trace_matrix), direction_iter) %
                              dimension_second_range;
                 gap_segment gap{pos, 0u};
 
@@ -207,9 +207,9 @@ private:
         }
 
         // Get begin coordinate.
-        auto c = column_index_type{std::ranges::distance(seqan3::begin(trace_matrix), direction_iter) /
+        auto c = column_index_type{std::ranges::distance(std::ranges::begin(trace_matrix), direction_iter) /
                                    dimension_second_range};
-        auto r = row_index_type{std::ranges::distance(seqan3::begin(trace_matrix), direction_iter) %
+        auto r = row_index_type{std::ranges::distance(std::ranges::begin(trace_matrix), direction_iter) %
                                 dimension_second_range};
 
         return std::tuple{alignment_coordinate{column_index_type{std::move(c)}, row_index_type{std::move(r)}},

--- a/include/seqan3/alignment/pairwise/policy/unbanded_score_trace_dp_matrix_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/unbanded_score_trace_dp_matrix_policy.hpp
@@ -12,9 +12,10 @@
 
 #pragma once
 
+#include <range/v3/view/iota.hpp>
 #include <range/v3/view/zip.hpp>
 
-#include <seqan3/alignment/matrix/trace_directions.hpp>
+#include <seqan3/alignment/matrix/alignment_coordinate.hpp>
 #include <seqan3/alignment/pairwise/policy/unbanded_dp_matrix_policy.hpp>
 #include <seqan3/std/span.hpp>
 
@@ -49,6 +50,8 @@ private:
     using base_t::dimension_second_range;
     //!\brief Make score_matrix visible in this class.
     using base_t::score_matrix;
+    //!\brief Make current_column_index visible in this class.
+    using base_t::current_column_index;
 
     /*!\name Member types
      * \{
@@ -84,9 +87,7 @@ private:
     template <typename first_range_t, typename second_range_t>
     constexpr void allocate_matrix(first_range_t && first_range, second_range_t && second_range)
     {
-        dimension_first_range = seqan3::size(std::forward<first_range_t>(first_range)) + 1;
-        dimension_second_range = seqan3::size(std::forward<second_range_t>(second_range)) + 1;
-
+        base_t::allocate_matrix(first_range, second_range);
         // We use only one column to compute the score.
         score_matrix.resize(dimension_second_range);
         // We use the full matrix to store the trace direction.
@@ -97,12 +98,20 @@ private:
     //!\brief Returns the current column of the alignment matrix.
     constexpr auto current_column()
     {
-        return ranges::view::zip(std::span{score_matrix}, std::span{&(*trace_matrix_iter), dimension_second_range});
+        advanceable_alignment_coordinate<size_t, advanceable_alignment_coordinate_state::row>
+            col_begin{column_index_type{current_column_index}, row_index_type{0u}};
+        advanceable_alignment_coordinate<size_t, advanceable_alignment_coordinate_state::row>
+            col_end{column_index_type{current_column_index}, row_index_type{dimension_second_range}};
+
+        return ranges::view::zip(std::span{score_matrix},
+                                 ranges::view::iota(col_begin, col_end),
+                                 std::span{&(*trace_matrix_iter), dimension_second_range});
     }
 
     //!\brief Moves internal matrix pointer to the next column.
     constexpr void next_column() noexcept
     {
+        base_t::next_column();
         trace_matrix_iter += dimension_second_range;
     }
 

--- a/include/seqan3/alignment/pairwise/policy/unbanded_score_trace_dp_matrix_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/unbanded_score_trace_dp_matrix_policy.hpp
@@ -12,15 +12,32 @@
 
 #pragma once
 
+#include <deque>
+
 #include <range/v3/view/iota.hpp>
+#include <range/v3/view/reverse.hpp>
 #include <range/v3/view/zip.hpp>
 
 #include <seqan3/alignment/matrix/alignment_coordinate.hpp>
+#include <seqan3/alignment/matrix/trace_directions.hpp>
 #include <seqan3/alignment/pairwise/policy/unbanded_dp_matrix_policy.hpp>
+#include <seqan3/range/view/persist.hpp>
 #include <seqan3/std/span.hpp>
 
 namespace seqan3::detail
 {
+
+/*!\brief Stores information about a contiguous gap.
+ * \ingroup alignment_policy
+ */
+struct gap_segment
+{
+    //!\brief The position in the sequence where to insert the gap; (inserted before the position).
+    size_t position;
+    //!\brief The size of the gap.
+    size_t size;
+};
+
 /*!\brief Manages the allocation and provision of an unbanded dynamic programming matrix.
  * \ingroup alignment_policy
  * \tparam derived_t   The derived alignment algorithm.
@@ -76,7 +93,7 @@ private:
     constexpr unbanded_score_trace_dp_matrix_policy & operator=(unbanded_score_trace_dp_matrix_policy const &) = default;
     constexpr unbanded_score_trace_dp_matrix_policy & operator=(unbanded_score_trace_dp_matrix_policy &&) = default;
     ~unbanded_score_trace_dp_matrix_policy() = default;
-    //!}
+    //!\}
 
     /*!\brief Allocates the memory for the dynamic programming matrix given the two sequences.
      * \tparam first_range_t   The type of the first sequence (or packed sequences).
@@ -88,8 +105,7 @@ private:
     constexpr void allocate_matrix(first_range_t && first_range, second_range_t && second_range)
     {
         base_t::allocate_matrix(first_range, second_range);
-        // We use only one column to compute the score.
-        score_matrix.resize(dimension_second_range);
+
         // We use the full matrix to store the trace direction.
         trace_matrix.resize(dimension_first_range * dimension_second_range);
         trace_matrix_iter = trace_matrix.begin();
@@ -115,9 +131,121 @@ private:
         trace_matrix_iter += dimension_second_range;
     }
 
+    /*!\brief Parses the traceback starting from the given coordinate.
+     * \param end_coordinate The coordinate from where to start the traceback.
+     *
+     * \returns A tuple containing the begin coordinate and a tuple with all seqan3::detail::gap_segment s for the
+     *          first sequence and the second sequence.
+     */
+    constexpr auto parse_traceback(alignment_coordinate const & end_coordinate)
+    {
+        // Store the trace segments.
+        std::deque<gap_segment> first_segments{};
+        std::deque<gap_segment> second_segments{};
+
+        // Put the iterator to the position where the traceback starts.
+        auto direction_iter = seqan3::begin(trace_matrix);
+        std::advance(direction_iter, end_coordinate.first_seq_pos * dimension_second_range +
+                                     end_coordinate.second_seq_pos);
+
+        // Parse the trace until interrupt.
+        while (*direction_iter != trace_directions::none)
+        {
+            // parse until end of diagonal run
+            while (static_cast<bool>(*direction_iter & trace_directions::diagonal))
+            {
+                std::ranges::advance(direction_iter, -dimension_second_range - 1);
+            }
+
+            // parse vertical gap -> record gap in first_segments (will be translated into gap of first sequence)
+            if (static_cast<bool>(*direction_iter & trace_directions::up) ||
+                static_cast<bool>(*direction_iter & trace_directions::up_open))
+            {
+                // Get the current column index (note the column based layout)
+                size_t pos = std::ranges::distance(seqan3::begin(trace_matrix), direction_iter) /
+                             dimension_second_range;
+                gap_segment gap{pos, 0u};
+
+                // Follow gap until open signal is detected.
+                while (!static_cast<bool>(*direction_iter & trace_directions::up_open))
+                {
+                    --direction_iter;
+                    ++gap.size;
+                }
+                // explicitly follow opening gap
+                --direction_iter;
+                ++gap.size;
+                // record the gap
+                first_segments.push_front(std::move(gap));
+                continue;
+            }
+            // parse horizontal gap -> record gap in second_segments (will be translated into gap of second sequence)
+            if (static_cast<bool>(*direction_iter & trace_directions::left) ||
+                static_cast<bool>(*direction_iter & trace_directions::left_open))
+            {
+                // Get the current row index (note the column based layout)
+                size_t pos = std::ranges::distance(seqan3::begin(trace_matrix), direction_iter) %
+                             dimension_second_range;
+                gap_segment gap{pos, 0u};
+
+                // Follow gap until open signal is detected.
+                while (!static_cast<bool>(*direction_iter & trace_directions::left_open))
+                {
+                    std::ranges::advance(direction_iter, -dimension_second_range);
+                    ++gap.size;
+                }
+                // explicitly follow opening gap
+                std::ranges::advance(direction_iter, -dimension_second_range);
+                ++gap.size;
+                second_segments.push_front(std::move(gap));
+            }
+        }
+
+        // Get begin coordinate.
+        auto c = column_index_type{std::ranges::distance(seqan3::begin(trace_matrix), direction_iter) /
+                                   dimension_second_range};
+        auto r = row_index_type{std::ranges::distance(seqan3::begin(trace_matrix), direction_iter) %
+                                dimension_second_range};
+
+        return std::tuple{alignment_coordinate{column_index_type{std::move(c)}, row_index_type{std::move(r)}},
+                          first_segments,
+                          second_segments};
+    }
+
+    //!\brief Helper function to print the trace matrix; for debugging only.
+    void print_trace_matrix()
+    {
+        auto printable = [](trace_directions dir)
+        {
+            std::string seq{};
+            if (dir == trace_directions::none)
+                seq.append("0");
+            if ((dir & trace_directions::diagonal) == trace_directions::diagonal)
+                seq.append("\\");
+            if ((dir & trace_directions::up) == trace_directions::up)
+                seq.append("|");
+            if ((dir & trace_directions::up_open) == trace_directions::up_open)
+                seq.append("^");
+            if ((dir & trace_directions::left) == trace_directions::left)
+                seq.append("-");
+            if ((dir & trace_directions::left_open) == trace_directions::left_open)
+                seq.append("<");
+            return seq;
+        };
+
+        for (size_t row = 0; row < dimension_second_range; ++row)
+        {
+            for (size_t col = 0; col < dimension_first_range; ++col)
+            {
+                debug_stream << printable(trace_matrix[col * dimension_second_range + row]) << " ";
+            }
+            debug_stream << "\n";
+        }
+    }
+
     //!\brief The data container.
     trace_matrix_type trace_matrix{};
     //!\brief The current iterator in the trace matrix.
-    typename trace_matrix_type::iterator trace_matrix_iter{};
+    std::ranges::iterator_t<trace_matrix_type> trace_matrix_iter{};
 };
 } // namespace seqan3::detail

--- a/include/seqan3/alignment/pairwise/policy/unbanded_score_trace_dp_matrix_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/unbanded_score_trace_dp_matrix_policy.hpp
@@ -43,6 +43,11 @@ struct gap_segment
  * \tparam derived_t   The derived alignment algorithm.
  * \tparam score_allocator_t The allocator type used for allocating the score matrix.
  * \tparam trace_allocator_t The allocator type used for allocating the trace matrix.
+ *
+ * \details
+ *
+ * Internally manages two vectors for the scoring matrix and the traceback matrix for the
+ * banded dynamic programming matrix.
  */
 template <typename derived_t, typename score_allocator_t, typename trace_allocator_t>
 class unbanded_score_trace_dp_matrix_policy :
@@ -84,7 +89,7 @@ private:
     using trace_matrix_type = std::vector<trace_type, trace_allocator_t>;
     //!\}
 
-    /*!\name Constructor, destructor and assignment
+    /*!\name Constructors, destructor and assignment
      * \{
      */
     constexpr unbanded_score_trace_dp_matrix_policy() = default;

--- a/test/performance/alignment/affine_alignment_benchmark.cpp
+++ b/test/performance/alignment/affine_alignment_benchmark.cpp
@@ -107,7 +107,49 @@ BENCHMARK(seqan2_affine_dna4);
 #endif // SEQAN3_HAS_SEQAN2
 
 // ============================================================================
-//  affine; score; dna4; set
+//  affine; trace; dna4; single
+// ============================================================================
+
+void seqan3_affine_dna4_trace(benchmark::State & state)
+{
+    auto cfg = align_cfg::mode{align_cfg::global_alignment} |
+               align_cfg::gap{gap_scheme{gap_score{-1}, gap_open_score{-10}}} |
+               align_cfg::scoring{nucleotide_scoring_scheme{match_score{4}, mismatch_score{-5}}} |
+               align_cfg::result{align_cfg::with_trace};
+
+    auto seq1 = generate_sequence_seqan3<seqan3::dna4>(500, 0, 0);
+    auto seq2 = generate_sequence_seqan3<seqan3::dna4>(500, 0, 1);
+
+    for (auto _ : state)
+    {
+        auto rng = align_pairwise(std::tie(seq1, seq2), cfg);
+        *seqan3::begin(rng);
+    }
+}
+
+BENCHMARK(seqan3_affine_dna4_trace);
+
+#ifdef SEQAN3_HAS_SEQAN2
+
+void seqan2_affine_dna4_trace(benchmark::State & state)
+{
+    auto seq1 = generate_sequence_seqan2<seqan::Dna>(500, 0, 0);
+    auto seq2 = generate_sequence_seqan2<seqan::Dna>(500, 0, 1);
+
+    seqan::Gaps<decltype(seq1)> gap1{seq1};
+    seqan::Gaps<decltype(seq2)> gap2{seq2};
+    for (auto _ : state)
+    {
+        // In SeqAn2 the gap open contains already the gap extension costs, that's why we use -11 here.
+        seqan::globalAlignment(gap1, gap2, seqan::Score<int>{4, -5, -1, -11});
+    }
+}
+
+BENCHMARK(seqan2_affine_dna4_trace);
+#endif // SEQAN3_HAS_SEQAN2
+
+// ============================================================================
+//  affine; score; dna4; collection
 // ============================================================================
 
 void seqan3_affine_dna4_collection(benchmark::State & state)
@@ -160,6 +202,72 @@ void seqan2_affine_dna4_collection(benchmark::State & state)
 }
 
 BENCHMARK(seqan2_affine_dna4_collection);
+#endif // SEQAN3_HAS_SEQAN2
+
+// ============================================================================
+//  affine; trace; dna4; collection
+// ============================================================================
+
+void seqan3_affine_dna4_trace_collection(benchmark::State & state)
+{
+    auto cfg = align_cfg::mode{align_cfg::global_alignment} |
+               align_cfg::gap{gap_scheme{gap_score{-1}, gap_open_score{-10}}} |
+               align_cfg::scoring{nucleotide_scoring_scheme{match_score{4}, mismatch_score{-5}}} |
+               align_cfg::result{align_cfg::with_trace};
+
+    using sequence_t = decltype(generate_sequence_seqan3<seqan3::dna4>());
+
+    std::vector<std::pair<sequence_t, sequence_t>> vec;
+    for (unsigned i = 0; i < 100; ++i)
+    {
+        sequence_t seq1 = generate_sequence_seqan3<seqan3::dna4>(100, 0, i);
+        sequence_t seq2 = generate_sequence_seqan3<seqan3::dna4>(100, 0, i + 100);
+        vec.push_back(std::pair{seq1, seq2});
+    }
+
+    for (auto _ : state)
+    {
+        for (auto && rng : align_pairwise(vec, cfg))
+            rng.get_score();
+    }
+}
+
+BENCHMARK(seqan3_affine_dna4_trace_collection);
+
+#ifdef SEQAN3_HAS_SEQAN2
+
+void seqan2_affine_dna4_trace_collection(benchmark::State & state)
+{
+    using sequence_t = decltype(generate_sequence_seqan2<seqan::Dna>());
+
+    seqan::StringSet<sequence_t> vec1;
+    seqan::StringSet<sequence_t> vec2;
+    for (unsigned i = 0; i < 100; ++i)
+    {
+        sequence_t seq1 = generate_sequence_seqan2<seqan::Dna>(100, 0, i);
+        sequence_t seq2 = generate_sequence_seqan2<seqan::Dna>(100, 0, i + 100);
+        appendValue(vec1, seq1);
+        appendValue(vec2, seq2);
+    }
+
+
+    seqan::StringSet<seqan::Gaps<sequence_t>> gap1;
+    seqan::StringSet<seqan::Gaps<sequence_t>> gap2;
+
+    for (unsigned i = 0; i < 100; ++i)
+    {
+        appendValue(gap1, seqan::Gaps<sequence_t>{vec1[i]});
+        appendValue(gap2, seqan::Gaps<sequence_t>{vec2[i]});
+    }
+
+    for (auto _ : state)
+    {
+        // In SeqAn2 the gap open contains already the gap extension costs, that's why we use -11 here.
+        seqan::globalAlignment(gap1, gap2, seqan::Score<int>{4, -5, -1, -11});
+    }
+}
+
+BENCHMARK(seqan2_affine_dna4_trace_collection);
 #endif // SEQAN3_HAS_SEQAN2
 
 // ============================================================================

--- a/test/snippet/alignment/pairwise/alignment_configurator.cpp
+++ b/test/snippet/alignment/pairwise/alignment_configurator.cpp
@@ -1,0 +1,24 @@
+#include <seqan3/alignment/pairwise/alignment_configurator.hpp>
+
+using namespace seqan3;
+using namespace seqan3::detail;
+
+int main()
+{
+    using sequences_t = std::vector<std::pair<std::string, std::string>>;
+    using config_t = decltype(align_cfg::edit);
+
+//! [result]
+    using first_seq_t = std::tuple_element_t<0, value_type_t<std::remove_reference_t<sequences_t>>>;
+    using second_seq_t = std::tuple_element_t<1, value_type_t<std::remove_reference_t<sequences_t>>>;
+
+    // Select the result type based on the sequences and the configuration.
+    using result_t = align_result<typename align_result_selector<std::remove_reference_t<first_seq_t>,
+                                                                 std::remove_reference_t<second_seq_t>,
+                                                                 config_t>::type>;
+    // Define the function wrapper type.
+    using function_wrapper_t = std::function<result_t(first_seq_t &, second_seq_t &)>;
+//! [result]
+
+    static_assert(is_type_specialisation_of_v<function_wrapper_t, std::function>);
+}

--- a/test/unit/alignment/matrix/CMakeLists.txt
+++ b/test/unit/alignment/matrix/CMakeLists.txt
@@ -1,2 +1,4 @@
+seqan3_test(alignment_coordinate_test.cpp)
 seqan3_test(alignment_matrix_test.cpp)
 seqan3_test(alignment_matrix_formatter_test.cpp)
+seqan3_test(alignment_optimum_test.cpp)

--- a/test/unit/alignment/matrix/alignment_coordinate_test.cpp
+++ b/test/unit/alignment/matrix/alignment_coordinate_test.cpp
@@ -32,21 +32,20 @@ TEST(advanceable_alignment_coordinate, row_index_type)
 
 TEST(advanceable_alignment_coordinate, construction)
 {
-    EXPECT_TRUE(std::is_default_constructible<detail::advanceable_alignment_coordinate<size_t>>::value);
-    EXPECT_TRUE(std::is_copy_constructible<detail::advanceable_alignment_coordinate<size_t>>::value);
-    EXPECT_TRUE(std::is_copy_assignable<detail::advanceable_alignment_coordinate<size_t>>::value);
-    EXPECT_TRUE(std::is_move_constructible<detail::advanceable_alignment_coordinate<size_t>>::value);
-    EXPECT_TRUE(std::is_move_assignable<detail::advanceable_alignment_coordinate<size_t>>::value);
-    EXPECT_TRUE(std::is_destructible<detail::advanceable_alignment_coordinate<size_t>>::value);
+    EXPECT_TRUE(std::is_default_constructible<detail::advanceable_alignment_coordinate<>>::value);
+    EXPECT_TRUE(std::is_copy_constructible<detail::advanceable_alignment_coordinate<>>::value);
+    EXPECT_TRUE(std::is_copy_assignable<detail::advanceable_alignment_coordinate<>>::value);
+    EXPECT_TRUE(std::is_move_constructible<detail::advanceable_alignment_coordinate<>>::value);
+    EXPECT_TRUE(std::is_move_assignable<detail::advanceable_alignment_coordinate<>>::value);
+    EXPECT_TRUE(std::is_destructible<detail::advanceable_alignment_coordinate<>>::value);
 }
 
 TEST(advanceable_alignment_coordinate, construction_with_different_state)
 {
-    detail::advanceable_alignment_coordinate<size_t, detail::advanceable_alignment_coordinate_state::row>
+    detail::advanceable_alignment_coordinate<detail::advanceable_alignment_coordinate_state::row>
         ro{detail::column_index_type{2u}, detail::row_index_type{3u}};
 
-    detail::advanceable_alignment_coordinate<size_t,
-        detail::advanceable_alignment_coordinate_state::none> no{ro};
+    detail::advanceable_alignment_coordinate<detail::advanceable_alignment_coordinate_state::none> no{ro};
 
     EXPECT_EQ(no.first_seq_pos, static_cast<size_t>(2));
     EXPECT_EQ(no.second_seq_pos, static_cast<size_t>(3));
@@ -56,13 +55,11 @@ TEST(advanceable_alignment_coordinate, type_deduction)
 {
     detail::advanceable_alignment_coordinate def_co{};
     EXPECT_TRUE((std::is_same_v<decltype(def_co),
-                    detail::advanceable_alignment_coordinate<size_t,
-                        detail::advanceable_alignment_coordinate_state::none>>));
+                    detail::advanceable_alignment_coordinate<detail::advanceable_alignment_coordinate_state::none>>));
 
     detail::advanceable_alignment_coordinate co{detail::column_index_type{2u}, detail::row_index_type{3u}};
     EXPECT_TRUE((std::is_same_v<decltype(co),
-                    detail::advanceable_alignment_coordinate<size_t,
-                        detail::advanceable_alignment_coordinate_state::none>>));
+                    detail::advanceable_alignment_coordinate<detail::advanceable_alignment_coordinate_state::none>>));
 }
 
 TEST(advanceable_alignment_coordinate, access)
@@ -79,14 +76,11 @@ TEST(advanceable_alignment_coordinate, access)
 TEST(advanceable_alignment_coordinate, weakly_equality_comparable_concept)
 {
     using not_incrementable =
-        detail::advanceable_alignment_coordinate<size_t,
-            detail::advanceable_alignment_coordinate_state::none>;
+        detail::advanceable_alignment_coordinate<detail::advanceable_alignment_coordinate_state::none>;
     using row_incrementable =
-        detail::advanceable_alignment_coordinate<size_t,
-            detail::advanceable_alignment_coordinate_state::row>;
+        detail::advanceable_alignment_coordinate<detail::advanceable_alignment_coordinate_state::row>;
     using column_incrementable =
-        detail::advanceable_alignment_coordinate<size_t,
-            detail::advanceable_alignment_coordinate_state::column>;
+        detail::advanceable_alignment_coordinate<detail::advanceable_alignment_coordinate_state::column>;
 
     EXPECT_TRUE(std::EqualityComparable<not_incrementable>);
     EXPECT_TRUE(std::EqualityComparable<row_incrementable>);
@@ -96,8 +90,7 @@ TEST(advanceable_alignment_coordinate, weakly_equality_comparable_concept)
 TEST(advanceable_alignment_coordinate, equality)
 {
     using test_type =
-        detail::advanceable_alignment_coordinate<size_t,
-            detail::advanceable_alignment_coordinate_state::none>;
+        detail::advanceable_alignment_coordinate<detail::advanceable_alignment_coordinate_state::none>;
 
     test_type t1{detail::column_index_type{10u}, detail::row_index_type{5u}};
     test_type t2{detail::column_index_type{5u}, detail::row_index_type{5u}};
@@ -112,8 +105,7 @@ TEST(advanceable_alignment_coordinate, equality)
 TEST(advanceable_alignment_coordinate, inequality)
 {
     using test_type =
-        detail::advanceable_alignment_coordinate<size_t,
-            detail::advanceable_alignment_coordinate_state::none>;
+        detail::advanceable_alignment_coordinate<detail::advanceable_alignment_coordinate_state::none>;
 
     test_type t1{detail::column_index_type{10u}, detail::row_index_type{5u}};
     test_type t2{detail::column_index_type{5u}, detail::row_index_type{5u}};
@@ -128,14 +120,11 @@ TEST(advanceable_alignment_coordinate, inequality)
 TEST(advanceable_alignment_coordinate, incremental_concept)
 {
     using not_incrementable =
-        detail::advanceable_alignment_coordinate<size_t,
-            detail::advanceable_alignment_coordinate_state::none>;
+        detail::advanceable_alignment_coordinate<detail::advanceable_alignment_coordinate_state::none>;
     using row_incrementable =
-        detail::advanceable_alignment_coordinate<size_t,
-            detail::advanceable_alignment_coordinate_state::row>;
+        detail::advanceable_alignment_coordinate<detail::advanceable_alignment_coordinate_state::row>;
     using column_incrementable =
-        detail::advanceable_alignment_coordinate<size_t,
-            detail::advanceable_alignment_coordinate_state::column>;
+        detail::advanceable_alignment_coordinate<detail::advanceable_alignment_coordinate_state::column>;
 
     EXPECT_FALSE(std::WeaklyIncrementable<not_incrementable>);
     EXPECT_TRUE(std::WeaklyIncrementable<row_incrementable>);
@@ -145,8 +134,7 @@ TEST(advanceable_alignment_coordinate, incremental_concept)
 TEST(advanceable_alignment_coordinate, increment_row)
 {
     using row_incrementable =
-        detail::advanceable_alignment_coordinate<size_t,
-            detail::advanceable_alignment_coordinate_state::row>;
+        detail::advanceable_alignment_coordinate<detail::advanceable_alignment_coordinate_state::row>;
 
     row_incrementable co{detail::column_index_type{0u}, detail::row_index_type{0u}};
     co = ++co;
@@ -165,8 +153,7 @@ TEST(advanceable_alignment_coordinate, increment_row)
 TEST(advanceable_alignment_coordinate, increment_col)
 {
     using col_incrementable =
-        detail::advanceable_alignment_coordinate<size_t,
-            detail::advanceable_alignment_coordinate_state::column>;
+        detail::advanceable_alignment_coordinate<detail::advanceable_alignment_coordinate_state::column>;
 
     col_incrementable co{detail::column_index_type{0u}, detail::row_index_type{0u}};
     co = ++co;
@@ -185,8 +172,7 @@ TEST(advanceable_alignment_coordinate, increment_col)
 TEST(advanceable_alignment_coordinate, decrement_row)
 {
     using row_incrementable =
-        detail::advanceable_alignment_coordinate<size_t,
-            detail::advanceable_alignment_coordinate_state::row>;
+        detail::advanceable_alignment_coordinate<detail::advanceable_alignment_coordinate_state::row>;
 
     row_incrementable co{detail::column_index_type{0u}, detail::row_index_type{0u}};
     co += 4;
@@ -208,8 +194,7 @@ TEST(advanceable_alignment_coordinate, decrement_row)
 TEST(advanceable_alignment_coordinate, decrement_col)
 {
     using col_incrementable =
-        detail::advanceable_alignment_coordinate<size_t,
-            detail::advanceable_alignment_coordinate_state::column>;
+        detail::advanceable_alignment_coordinate<detail::advanceable_alignment_coordinate_state::column>;
 
     col_incrementable co{detail::column_index_type{0u}, detail::row_index_type{0u}};
     co += 4;
@@ -231,8 +216,7 @@ TEST(advanceable_alignment_coordinate, decrement_col)
 TEST(advanceable_alignment_coordinate, advance_row)
 {
     using row_incrementable =
-        detail::advanceable_alignment_coordinate<size_t,
-            detail::advanceable_alignment_coordinate_state::row>;
+        detail::advanceable_alignment_coordinate<detail::advanceable_alignment_coordinate_state::row>;
 
     row_incrementable co{detail::column_index_type{0u}, detail::row_index_type{0u}};
 
@@ -248,8 +232,7 @@ TEST(advanceable_alignment_coordinate, advance_row)
 TEST(advanceable_alignment_coordinate, advance_col)
 {
     using col_incrementable =
-        detail::advanceable_alignment_coordinate<size_t,
-            detail::advanceable_alignment_coordinate_state::column>;
+        detail::advanceable_alignment_coordinate<detail::advanceable_alignment_coordinate_state::column>;
 
     col_incrementable co{detail::column_index_type{0u}, detail::row_index_type{0u}};
     co = co + 4;
@@ -264,8 +247,7 @@ TEST(advanceable_alignment_coordinate, advance_col)
 TEST(advanceable_alignment_coordinate, iota_column_index)
 {
     using col_incrementable =
-        detail::advanceable_alignment_coordinate<size_t,
-            detail::advanceable_alignment_coordinate_state::column>;
+        detail::advanceable_alignment_coordinate<detail::advanceable_alignment_coordinate_state::column>;
 
     col_incrementable co_begin{detail::column_index_type{0u}, detail::row_index_type{0u}};
     col_incrementable co_end{detail::column_index_type{5u}, detail::row_index_type{0u}};
@@ -282,8 +264,7 @@ TEST(advanceable_alignment_coordinate, iota_column_index)
 TEST(advanceable_alignment_coordinate, iota_row_index)
 {
     using row_incrementable =
-        detail::advanceable_alignment_coordinate<size_t,
-            detail::advanceable_alignment_coordinate_state::row>;
+        detail::advanceable_alignment_coordinate<detail::advanceable_alignment_coordinate_state::row>;
 
     row_incrementable co_begin{detail::column_index_type{0u}, detail::row_index_type{0u}};
     row_incrementable co_end{detail::column_index_type{0u}, detail::row_index_type{5u}};
@@ -307,14 +288,11 @@ TEST(alignment_coordinate, basic)
     EXPECT_TRUE(std::is_destructible<alignment_coordinate>::value);
 
     using not_incrementable =
-        detail::advanceable_alignment_coordinate<size_t,
-            detail::advanceable_alignment_coordinate_state::none>;
+        detail::advanceable_alignment_coordinate<detail::advanceable_alignment_coordinate_state::none>;
     using row_incrementable =
-        detail::advanceable_alignment_coordinate<size_t,
-            detail::advanceable_alignment_coordinate_state::row>;
+        detail::advanceable_alignment_coordinate<detail::advanceable_alignment_coordinate_state::row>;
     using col_incrementable =
-        detail::advanceable_alignment_coordinate<size_t,
-            detail::advanceable_alignment_coordinate_state::column>;
+        detail::advanceable_alignment_coordinate<detail::advanceable_alignment_coordinate_state::column>;
 
     not_incrementable co_not{detail::column_index_type{10u}, detail::row_index_type{5u}};
     col_incrementable co_col{detail::column_index_type{10u}, detail::row_index_type{5u}};

--- a/test/unit/alignment/matrix/alignment_coordinate_test.cpp
+++ b/test/unit/alignment/matrix/alignment_coordinate_test.cpp
@@ -1,0 +1,338 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <type_traits>
+
+#include <range/v3/view/iota.hpp>
+
+#include <seqan3/alignment/matrix/alignment_coordinate.hpp>
+#include <seqan3/range/shortcuts.hpp>
+#include <seqan3/std/concepts>
+#include <seqan3/std/iterator>
+
+using namespace seqan3;
+
+TEST(advanceable_alignment_coordinate, column_index_type)
+{
+    detail::column_index_type ci{1u};
+    EXPECT_EQ(ci.get(), static_cast<size_t>(1));
+}
+
+TEST(advanceable_alignment_coordinate, row_index_type)
+{
+    detail::row_index_type ri{1u};
+    EXPECT_EQ(ri.get(), static_cast<size_t>(1));
+}
+
+TEST(advanceable_alignment_coordinate, construction)
+{
+    EXPECT_TRUE(std::is_default_constructible<detail::advanceable_alignment_coordinate<size_t>>::value);
+    EXPECT_TRUE(std::is_copy_constructible<detail::advanceable_alignment_coordinate<size_t>>::value);
+    EXPECT_TRUE(std::is_copy_assignable<detail::advanceable_alignment_coordinate<size_t>>::value);
+    EXPECT_TRUE(std::is_move_constructible<detail::advanceable_alignment_coordinate<size_t>>::value);
+    EXPECT_TRUE(std::is_move_assignable<detail::advanceable_alignment_coordinate<size_t>>::value);
+    EXPECT_TRUE(std::is_destructible<detail::advanceable_alignment_coordinate<size_t>>::value);
+}
+
+TEST(advanceable_alignment_coordinate, construction_with_different_state)
+{
+    detail::advanceable_alignment_coordinate<size_t, detail::advanceable_alignment_coordinate_state::row>
+        ro{detail::column_index_type{2u}, detail::row_index_type{3u}};
+
+    detail::advanceable_alignment_coordinate<size_t,
+        detail::advanceable_alignment_coordinate_state::none> no{ro};
+
+    EXPECT_EQ(no.first_seq_pos, static_cast<size_t>(2));
+    EXPECT_EQ(no.second_seq_pos, static_cast<size_t>(3));
+}
+
+TEST(advanceable_alignment_coordinate, type_deduction)
+{
+    detail::advanceable_alignment_coordinate def_co{};
+    EXPECT_TRUE((std::is_same_v<decltype(def_co),
+                    detail::advanceable_alignment_coordinate<size_t,
+                        detail::advanceable_alignment_coordinate_state::none>>));
+
+    detail::advanceable_alignment_coordinate co{detail::column_index_type{2u}, detail::row_index_type{3u}};
+    EXPECT_TRUE((std::is_same_v<decltype(co),
+                    detail::advanceable_alignment_coordinate<size_t,
+                        detail::advanceable_alignment_coordinate_state::none>>));
+}
+
+TEST(advanceable_alignment_coordinate, access)
+{
+    detail::advanceable_alignment_coordinate def_co{};
+    EXPECT_EQ(def_co.first_seq_pos, static_cast<size_t>(0));
+    EXPECT_EQ(def_co.second_seq_pos, static_cast<size_t>(0));
+
+    detail::advanceable_alignment_coordinate co{detail::column_index_type{2u}, detail::row_index_type{3u}};
+    EXPECT_EQ(co.first_seq_pos, static_cast<size_t>(2));
+    EXPECT_EQ(co.second_seq_pos, static_cast<size_t>(3));
+}
+
+TEST(advanceable_alignment_coordinate, weakly_equality_comparable_concept)
+{
+    using not_incrementable =
+        detail::advanceable_alignment_coordinate<size_t,
+            detail::advanceable_alignment_coordinate_state::none>;
+    using row_incrementable =
+        detail::advanceable_alignment_coordinate<size_t,
+            detail::advanceable_alignment_coordinate_state::row>;
+    using column_incrementable =
+        detail::advanceable_alignment_coordinate<size_t,
+            detail::advanceable_alignment_coordinate_state::column>;
+
+    EXPECT_TRUE(std::EqualityComparable<not_incrementable>);
+    EXPECT_TRUE(std::EqualityComparable<row_incrementable>);
+    EXPECT_TRUE(std::EqualityComparable<column_incrementable>);
+}
+
+TEST(advanceable_alignment_coordinate, equality)
+{
+    using test_type =
+        detail::advanceable_alignment_coordinate<size_t,
+            detail::advanceable_alignment_coordinate_state::none>;
+
+    test_type t1{detail::column_index_type{10u}, detail::row_index_type{5u}};
+    test_type t2{detail::column_index_type{5u}, detail::row_index_type{5u}};
+    test_type t3{detail::column_index_type{10u}, detail::row_index_type{10u}};
+
+    EXPECT_TRUE(t1 == t1);
+    EXPECT_FALSE(t2 == t1);
+    EXPECT_FALSE(t1 == t3);
+    EXPECT_FALSE(t2 == t3);
+}
+
+TEST(advanceable_alignment_coordinate, inequality)
+{
+    using test_type =
+        detail::advanceable_alignment_coordinate<size_t,
+            detail::advanceable_alignment_coordinate_state::none>;
+
+    test_type t1{detail::column_index_type{10u}, detail::row_index_type{5u}};
+    test_type t2{detail::column_index_type{5u}, detail::row_index_type{5u}};
+    test_type t3{detail::column_index_type{10u}, detail::row_index_type{10u}};
+
+    EXPECT_FALSE(t1 != t1);
+    EXPECT_TRUE(t2 != t1);
+    EXPECT_TRUE(t1 != t3);
+    EXPECT_TRUE(t2 != t3);
+}
+
+TEST(advanceable_alignment_coordinate, incremental_concept)
+{
+    using not_incrementable =
+        detail::advanceable_alignment_coordinate<size_t,
+            detail::advanceable_alignment_coordinate_state::none>;
+    using row_incrementable =
+        detail::advanceable_alignment_coordinate<size_t,
+            detail::advanceable_alignment_coordinate_state::row>;
+    using column_incrementable =
+        detail::advanceable_alignment_coordinate<size_t,
+            detail::advanceable_alignment_coordinate_state::column>;
+
+    EXPECT_FALSE(std::WeaklyIncrementable<not_incrementable>);
+    EXPECT_TRUE(std::WeaklyIncrementable<row_incrementable>);
+    EXPECT_TRUE(std::WeaklyIncrementable<column_incrementable>);
+}
+
+TEST(advanceable_alignment_coordinate, increment_row)
+{
+    using row_incrementable =
+        detail::advanceable_alignment_coordinate<size_t,
+            detail::advanceable_alignment_coordinate_state::row>;
+
+    row_incrementable co{detail::column_index_type{0u}, detail::row_index_type{0u}};
+    co = ++co;
+    EXPECT_EQ(co.first_seq_pos, 0u);
+    EXPECT_EQ(co.second_seq_pos, 1u);
+    auto co_tmp = co++;
+    EXPECT_EQ(co_tmp.first_seq_pos, 0u);
+    EXPECT_EQ(co_tmp.second_seq_pos, 1u);
+    EXPECT_EQ(co.first_seq_pos, 0u);
+    EXPECT_EQ(co.second_seq_pos, 2u);
+    co += 4;
+    EXPECT_EQ(co.first_seq_pos, 0u);
+    EXPECT_EQ(co.second_seq_pos, 6u);
+}
+
+TEST(advanceable_alignment_coordinate, increment_col)
+{
+    using col_incrementable =
+        detail::advanceable_alignment_coordinate<size_t,
+            detail::advanceable_alignment_coordinate_state::column>;
+
+    col_incrementable co{detail::column_index_type{0u}, detail::row_index_type{0u}};
+    co = ++co;
+    EXPECT_EQ(co.first_seq_pos, 1u);
+    EXPECT_EQ(co.second_seq_pos, 0u);
+    auto co_tmp = co++;
+    EXPECT_EQ(co_tmp.first_seq_pos, 1u);
+    EXPECT_EQ(co_tmp.second_seq_pos, 0u);
+    EXPECT_EQ(co.first_seq_pos, 2u);
+    EXPECT_EQ(co.second_seq_pos, 0u);
+    co += 4;
+    EXPECT_EQ(co.first_seq_pos, 6u);
+    EXPECT_EQ(co.second_seq_pos, 0u);
+}
+
+TEST(advanceable_alignment_coordinate, decrement_row)
+{
+    using row_incrementable =
+        detail::advanceable_alignment_coordinate<size_t,
+            detail::advanceable_alignment_coordinate_state::row>;
+
+    row_incrementable co{detail::column_index_type{0u}, detail::row_index_type{0u}};
+    co += 4;
+    auto co_tmp = co--;
+    EXPECT_EQ(co_tmp.first_seq_pos, 0u);
+    EXPECT_EQ(co_tmp.second_seq_pos, 4u);
+    EXPECT_EQ(co.first_seq_pos, 0u);
+    EXPECT_EQ(co.second_seq_pos, 3u);
+
+    co = --co;
+    EXPECT_EQ(co.first_seq_pos, 0u);
+    EXPECT_EQ(co.second_seq_pos, 2u);
+
+    co -= 2;
+    EXPECT_EQ(co.first_seq_pos, 0u);
+    EXPECT_EQ(co.second_seq_pos, 0u);
+}
+
+TEST(advanceable_alignment_coordinate, decrement_col)
+{
+    using col_incrementable =
+        detail::advanceable_alignment_coordinate<size_t,
+            detail::advanceable_alignment_coordinate_state::column>;
+
+    col_incrementable co{detail::column_index_type{0u}, detail::row_index_type{0u}};
+    co += 4;
+    auto co_tmp = co--;
+    EXPECT_EQ(co_tmp.first_seq_pos, 4u);
+    EXPECT_EQ(co_tmp.second_seq_pos, 0u);
+    EXPECT_EQ(co.first_seq_pos, 3u);
+    EXPECT_EQ(co.second_seq_pos, 0u);
+
+    co = --co;
+    EXPECT_EQ(co.first_seq_pos, 2u);
+    EXPECT_EQ(co.second_seq_pos, 0u);
+
+    co -= 2;
+    EXPECT_EQ(co.first_seq_pos, 0u);
+    EXPECT_EQ(co.second_seq_pos, 0u);
+}
+
+TEST(advanceable_alignment_coordinate, advance_row)
+{
+    using row_incrementable =
+        detail::advanceable_alignment_coordinate<size_t,
+            detail::advanceable_alignment_coordinate_state::row>;
+
+    row_incrementable co{detail::column_index_type{0u}, detail::row_index_type{0u}};
+
+    co = co + 4;
+    EXPECT_EQ(co.first_seq_pos, 0u);
+    EXPECT_EQ(co.second_seq_pos, 4u);
+
+    co = 4 + co;
+    EXPECT_EQ(co.first_seq_pos, 0u);
+    EXPECT_EQ(co.second_seq_pos, 8u);
+}
+
+TEST(advanceable_alignment_coordinate, advance_col)
+{
+    using col_incrementable =
+        detail::advanceable_alignment_coordinate<size_t,
+            detail::advanceable_alignment_coordinate_state::column>;
+
+    col_incrementable co{detail::column_index_type{0u}, detail::row_index_type{0u}};
+    co = co + 4;
+    EXPECT_EQ(co.first_seq_pos, 4u);
+    EXPECT_EQ(co.second_seq_pos, 0u);
+
+    co = 4 + co;
+    EXPECT_EQ(co.first_seq_pos, 8u);
+    EXPECT_EQ(co.second_seq_pos, 0u);
+}
+
+TEST(advanceable_alignment_coordinate, iota_column_index)
+{
+    using col_incrementable =
+        detail::advanceable_alignment_coordinate<size_t,
+            detail::advanceable_alignment_coordinate_state::column>;
+
+    col_incrementable co_begin{detail::column_index_type{0u}, detail::row_index_type{0u}};
+    col_incrementable co_end{detail::column_index_type{5u}, detail::row_index_type{0u}};
+    auto v = ranges::view::iota(co_begin, co_end);
+
+    EXPECT_TRUE((std::Same<decltype(v.begin()), decltype(v.end())>));
+    EXPECT_EQ((*(--v.end())).first_seq_pos, 4u);
+
+    size_t test = 0u;
+    for (auto coordinate : v)
+        EXPECT_EQ(coordinate.first_seq_pos, test++);
+}
+
+TEST(advanceable_alignment_coordinate, iota_row_index)
+{
+    using row_incrementable =
+        detail::advanceable_alignment_coordinate<size_t,
+            detail::advanceable_alignment_coordinate_state::row>;
+
+    row_incrementable co_begin{detail::column_index_type{0u}, detail::row_index_type{0u}};
+    row_incrementable co_end{detail::column_index_type{0u}, detail::row_index_type{5u}};
+    auto v = ranges::view::iota(co_begin, co_end);
+
+    EXPECT_TRUE((std::Same<decltype(v.begin()), decltype(v.end())>));
+    EXPECT_EQ((*(--v.end())).second_seq_pos, 4u);
+
+    size_t test = 0u;
+    for (auto coordinate : v)
+        EXPECT_EQ(coordinate.second_seq_pos, test++);
+}
+
+TEST(alignment_coordinate, basic)
+{
+    EXPECT_TRUE(std::is_default_constructible<alignment_coordinate>::value);
+    EXPECT_TRUE(std::is_copy_constructible<alignment_coordinate>::value);
+    EXPECT_TRUE(std::is_copy_assignable<alignment_coordinate>::value);
+    EXPECT_TRUE(std::is_move_constructible<alignment_coordinate>::value);
+    EXPECT_TRUE(std::is_move_assignable<alignment_coordinate>::value);
+    EXPECT_TRUE(std::is_destructible<alignment_coordinate>::value);
+
+    using not_incrementable =
+        detail::advanceable_alignment_coordinate<size_t,
+            detail::advanceable_alignment_coordinate_state::none>;
+    using row_incrementable =
+        detail::advanceable_alignment_coordinate<size_t,
+            detail::advanceable_alignment_coordinate_state::row>;
+    using col_incrementable =
+        detail::advanceable_alignment_coordinate<size_t,
+            detail::advanceable_alignment_coordinate_state::column>;
+
+    not_incrementable co_not{detail::column_index_type{10u}, detail::row_index_type{5u}};
+    col_incrementable co_col{detail::column_index_type{10u}, detail::row_index_type{5u}};
+    row_incrementable co_row{detail::column_index_type{10u}, detail::row_index_type{5u}};
+
+    alignment_coordinate test1{co_not};
+    EXPECT_EQ(test1.first_seq_pos, 10u);
+    EXPECT_EQ(test1.second_seq_pos, 5u);
+
+    alignment_coordinate test2{co_col};
+    EXPECT_EQ(test2.first_seq_pos, 10u);
+    EXPECT_EQ(test2.second_seq_pos, 5u);
+
+    alignment_coordinate test3{co_row};
+    EXPECT_EQ(test3.first_seq_pos, 10u);
+    EXPECT_EQ(test3.second_seq_pos, 5u);
+
+    alignment_coordinate test4{detail::column_index_type{10u}, detail::row_index_type{5u}};
+    EXPECT_EQ(test4.first_seq_pos, 10u);
+    EXPECT_EQ(test4.second_seq_pos, 5u);
+}

--- a/test/unit/alignment/matrix/alignment_optimum_test.cpp
+++ b/test/unit/alignment/matrix/alignment_optimum_test.cpp
@@ -1,0 +1,75 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <type_traits>
+
+#include <seqan3/alignment/matrix/alignment_optimum.hpp>
+
+using namespace seqan3;
+
+TEST(alignment_optimum, construction)
+{
+    EXPECT_TRUE((std::is_default_constructible<detail::alignment_optimum<int32_t>>::value));
+    EXPECT_TRUE((std::is_copy_constructible<detail::alignment_optimum<int32_t>>::value));
+    EXPECT_TRUE((std::is_copy_assignable<detail::alignment_optimum<int32_t>>::value));
+    EXPECT_TRUE((std::is_move_constructible<detail::alignment_optimum<int32_t>>::value));
+    EXPECT_TRUE((std::is_move_assignable<detail::alignment_optimum<int32_t>>::value));
+    EXPECT_TRUE((std::is_destructible<detail::alignment_optimum<int32_t>>::value));
+}
+
+TEST(alignment_optimum, type_deduction)
+{
+    detail::alignment_optimum def_ao{};
+    EXPECT_TRUE((std::is_same_v<decltype(def_ao), detail::alignment_optimum<int32_t>>));
+
+    alignment_coordinate coordinate{};
+    coordinate.first_seq_pos = 2u;
+    coordinate.second_seq_pos = 3u;
+    detail::alignment_optimum ao{10, coordinate};
+    EXPECT_TRUE((std::is_same_v<decltype(ao), detail::alignment_optimum<int32_t>>));
+}
+
+TEST(alignment_optimum, access)
+{
+    detail::alignment_optimum def_ao{};
+
+    EXPECT_EQ(def_ao.score, std::numeric_limits<int32_t>::lowest());
+    EXPECT_EQ(static_cast<size_t>(def_ao.coordinate.first_seq_pos), static_cast<size_t>(0));
+    EXPECT_EQ(static_cast<size_t>(def_ao.coordinate.second_seq_pos), static_cast<size_t>(0));
+
+    alignment_coordinate coordinate{};
+    coordinate.first_seq_pos = 2u;
+    coordinate.second_seq_pos = 3u;
+    detail::alignment_optimum ao{10, coordinate};
+    EXPECT_EQ(ao.score, 10);
+    EXPECT_EQ(static_cast<size_t>(ao.coordinate.first_seq_pos), static_cast<size_t>(2));
+    EXPECT_EQ(static_cast<size_t>(ao.coordinate.second_seq_pos), static_cast<size_t>(3));
+}
+
+TEST(alignment_optimum, max)
+{
+    detail::alignment_optimum def_ao{};
+
+    EXPECT_EQ(def_ao.score, std::numeric_limits<int32_t>::lowest());
+    EXPECT_EQ(static_cast<size_t>(def_ao.coordinate.first_seq_pos), static_cast<size_t>(0));
+    EXPECT_EQ(static_cast<size_t>(def_ao.coordinate.second_seq_pos), static_cast<size_t>(0));
+
+    alignment_coordinate coordinate{};
+    coordinate.first_seq_pos = 2u;
+    coordinate.second_seq_pos = 3u;
+    detail::alignment_optimum ao{10, coordinate};
+    EXPECT_EQ(ao.score, 10);
+    EXPECT_EQ(static_cast<size_t>(ao.coordinate.first_seq_pos), static_cast<size_t>(2));
+    EXPECT_EQ(static_cast<size_t>(ao.coordinate.second_seq_pos), static_cast<size_t>(3));
+
+    auto val = std::max(def_ao, ao, detail::alignment_optimum_compare_less{});
+    EXPECT_EQ(ao.score, 10);
+    EXPECT_EQ(static_cast<size_t>(val.coordinate.first_seq_pos), static_cast<size_t>(2));
+    EXPECT_EQ(static_cast<size_t>(val.coordinate.second_seq_pos), static_cast<size_t>(3));
+}

--- a/test/unit/alignment/pairwise/align_pairwise_test.cpp
+++ b/test/unit/alignment/pairwise/align_pairwise_test.cpp
@@ -45,8 +45,8 @@ TEST(align_pairwise, single_rng_lvalue)
         for (auto && res : align_pairwise(p, cfg))
         {
             EXPECT_EQ(res.get_score(), -4);
-            auto [cmp1, cmp2] = res.get_end_coordinate();
-            EXPECT_EQ((std::tie(cmp1, cmp2)), (std::tuple{7, 8}));
+            EXPECT_EQ(res.get_end_coordinate().first_seq_pos, 7u);
+            EXPECT_EQ(res.get_end_coordinate().second_seq_pos, 8u);
             auto && [gap1, gap2] = res.get_alignment();
             EXPECT_EQ(std::string{gap1 | view::to_char}, "ACGTGATG--");
             EXPECT_EQ(std::string{gap2 | view::to_char}, "A-GTGATACT");

--- a/test/unit/alignment/pairwise/align_result_selector_test.cpp
+++ b/test/unit/alignment/pairwise/align_result_selector_test.cpp
@@ -59,9 +59,9 @@ TEST(alignment_selector, align_result_selector)
         EXPECT_TRUE((std::is_same_v<decltype(std::declval<_t>().get_id()), uint32_t>));
         EXPECT_TRUE((std::is_same_v<decltype(std::declval<_t>().get_score()), int32_t>));
         EXPECT_TRUE((std::is_same_v<decltype(std::declval<_t>().get_end_coordinate()),
-                                    detail::alignment_coordinate const &>));
+                                    alignment_coordinate const &>));
         EXPECT_TRUE((std::is_same_v<decltype(std::declval<_t>().get_begin_coordinate()),
-                                    detail::alignment_coordinate const &>));
+                                    alignment_coordinate const &>));
         EXPECT_TRUE((std::is_same_v<decltype(std::declval<_t>().get_alignment()),
                                     std::tuple<gapped_seq1_t, gapped_seq2_t> const &>));
     }

--- a/test/unit/alignment/pairwise/alignment_configurator_test.cpp
+++ b/test/unit/alignment/pairwise/alignment_configurator_test.cpp
@@ -26,7 +26,7 @@ bool run_test(config_t const & cfg)
 {
     auto r = setup();
     auto fn = detail::alignment_configurator::configure(r, cfg);
-    auto && [seq1, seq2] = *seqan3::begin(r);
+    auto && [seq1, seq2] = *std::ranges::begin(r);
 
     return fn(seq1, seq2).get_score() == 0;
 }

--- a/test/unit/alignment/pairwise/alignment_configurator_test.cpp
+++ b/test/unit/alignment/pairwise/alignment_configurator_test.cpp
@@ -125,21 +125,21 @@ TEST(alignment_configurator, configure_affine_global_banded)
     }
 }
 
-// TEST(alignment_configurator, configure_affine_global_banded_with_trace)
-// {
-//     auto cfg = align_cfg::mode{align_cfg::global_alignment} |
-//                align_cfg::gap{gap_scheme{gap_score{-1}, gap_open_score{-10}}} |
-//                align_cfg::scoring{nucleotide_scoring_scheme{}} |
-//                align_cfg::band{static_band{lower_bound{-1}, upper_bound{1}}};
-//
-//     auto cfg_trace = cfg | align_cfg::result{align_cfg::with_trace};
-//     auto cfg_begin = cfg | align_cfg::result{align_cfg::with_begin_position};
-//     auto cfg_end = cfg | align_cfg::result{align_cfg::with_end_position};
-//
-//     EXPECT_TRUE(run_test(cfg_end));
-//     EXPECT_THROW(run_test(cfg_trace), invalid_alignment_configuration);
-//     EXPECT_THROW(run_test(cfg_begin), invalid_alignment_configuration);
-// }
+TEST(alignment_configurator, configure_affine_global_banded_with_trace)
+{
+    auto cfg = align_cfg::mode{align_cfg::global_alignment} |
+               align_cfg::gap{gap_scheme{gap_score{-1}, gap_open_score{-10}}} |
+               align_cfg::scoring{nucleotide_scoring_scheme{}} |
+               align_cfg::band{static_band{lower_bound{-1}, upper_bound{1}}};
+
+    auto cfg_trace = cfg | align_cfg::result{align_cfg::with_trace};
+    auto cfg_begin = cfg | align_cfg::result{align_cfg::with_begin_position};
+    auto cfg_end = cfg | align_cfg::result{align_cfg::with_end_position};
+
+    EXPECT_TRUE(run_test(cfg_end));
+    EXPECT_TRUE(run_test(cfg_trace));
+    EXPECT_TRUE(run_test(cfg_begin));
+}
 
 TEST(alignment_configurator, configure_affine_global_semi)
 {

--- a/test/unit/alignment/pairwise/alignment_configurator_test.cpp
+++ b/test/unit/alignment/pairwise/alignment_configurator_test.cpp
@@ -18,7 +18,7 @@ using namespace seqan3;
 auto setup()
 {
     auto data = std::tuple{"ACGT"_dna4, "ACGT"_dna4};
-    return ranges::view::single(std::move(data)) | view::persist;
+    return ranges::view::single(std::move(data));
 }
 
 template <typename config_t>
@@ -26,7 +26,7 @@ bool run_test(config_t const & cfg)
 {
     auto r = setup();
     auto fn = detail::alignment_configurator::configure(r, cfg);
-    auto [seq1, seq2] = *seqan3::begin(r);
+    auto && [seq1, seq2] = *seqan3::begin(r);
 
     return fn(seq1, seq2).get_score() == 0;
 }

--- a/test/unit/alignment/pairwise/edit_distance_unbanded_test.cpp
+++ b/test/unit/alignment/pairwise/edit_distance_unbanded_test.cpp
@@ -220,8 +220,8 @@ TYPED_TEST_P(edit_distance_unbanded, trace_matrix)
     EXPECT_EQ(alignment.score(), fixture.score);
 
     auto && [gapped_database, gapped_query] = alignment.alignment();
-    EXPECT_EQ(std::string{gapped_database | view::to_char}, fixture.gapped_sequence1);
-    EXPECT_EQ(std::string{gapped_query | view::to_char}, fixture.gapped_sequence2);
+    EXPECT_EQ(std::string{gapped_database | view::to_char}, fixture.aligned_sequence1);
+    EXPECT_EQ(std::string{gapped_query | view::to_char}, fixture.aligned_sequence2);
 }
 
 TYPED_TEST_P(edit_distance_unbanded, trace)
@@ -236,8 +236,8 @@ TYPED_TEST_P(edit_distance_unbanded, trace)
     auto alignment = edit_distance<word_type>(database, query, align_cfg);
 
     auto && [gapped_database, gapped_query] = alignment.alignment();
-    EXPECT_EQ(std::string{gapped_database | view::to_char}, fixture.gapped_sequence1);
-    EXPECT_EQ(std::string{gapped_query | view::to_char}, fixture.gapped_sequence2);
+    EXPECT_EQ(std::string{gapped_database | view::to_char}, fixture.aligned_sequence1);
+    EXPECT_EQ(std::string{gapped_query | view::to_char}, fixture.aligned_sequence2);
 }
 
 REGISTER_TYPED_TEST_CASE_P(edit_distance_unbanded, score, score_matrix, trace_matrix, trace);

--- a/test/unit/alignment/pairwise/edit_distance_unbanded_test.cpp
+++ b/test/unit/alignment/pairwise/edit_distance_unbanded_test.cpp
@@ -212,10 +212,10 @@ TYPED_TEST_P(edit_distance_unbanded, trace_matrix)
 
     EXPECT_EQ(trace_matrix.cols(), database.size()+1);
     EXPECT_EQ(trace_matrix.rows(), query.size()+1);
-    EXPECT_EQ(begin_coordinate.seq1_pos, fixture.begin_coordinate.seq1_pos);
-    EXPECT_EQ(begin_coordinate.seq2_pos, fixture.begin_coordinate.seq2_pos);
-    EXPECT_EQ(end_coordinate.seq1_pos, fixture.end_coordinate.seq1_pos);
-    EXPECT_EQ(end_coordinate.seq2_pos, fixture.end_coordinate.seq2_pos);
+    EXPECT_EQ(begin_coordinate.first_seq_pos, fixture.begin_coordinate.first_seq_pos);
+    EXPECT_EQ(begin_coordinate.second_seq_pos, fixture.begin_coordinate.second_seq_pos);
+    EXPECT_EQ(end_coordinate.first_seq_pos, fixture.end_coordinate.first_seq_pos);
+    EXPECT_EQ(end_coordinate.second_seq_pos, fixture.end_coordinate.second_seq_pos);
     EXPECT_EQ(trace_matrix, fixture.trace_matrix);
     EXPECT_EQ(alignment.score(), fixture.score);
 

--- a/test/unit/alignment/pairwise/execution/alignment_executor_two_way_test.cpp
+++ b/test/unit/alignment/pairwise/execution/alignment_executor_two_way_test.cpp
@@ -15,6 +15,7 @@
 
 #include <seqan3/alignment/pairwise/execution/alignment_executor_two_way.hpp>
 #include <seqan3/range/view/persist.hpp>
+#include <seqan3/test/pretty_printing.hpp>
 
 struct dummy_alignment
 {
@@ -36,7 +37,7 @@ struct dummy_alignment
 // Some globally defined test types
 inline static std::tuple single{std::string{"AACGTACGT"}, std::string{"ATCGTCCGT"}};
 inline static std::vector<decltype(single)> collection{5, single};
-inline static std::function<size_t(std::string const &, std::string const &)> fn{dummy_alignment{}};
+inline static std::function<size_t(std::string &, std::string &)> fn{dummy_alignment{}};
 
 using namespace seqan3;
 
@@ -67,11 +68,12 @@ TEST(alignment_executor_two_way, type_deduction)
 TEST(alignment_executor_two_way, bump)
 {
     detail::alignment_executor_two_way exec{collection, fn};
-    EXPECT_EQ(exec.bump(), 7u);
-    EXPECT_EQ(exec.bump(), 7u);
-    EXPECT_EQ(exec.bump(), 7u);
-    EXPECT_EQ(exec.bump(), 7u);
-    EXPECT_EQ(exec.bump(), 7u);
+
+    EXPECT_EQ(exec.bump().value(), 7u);
+    EXPECT_EQ(exec.bump().value(), 7u);
+    EXPECT_EQ(exec.bump().value(), 7u);
+    EXPECT_EQ(exec.bump().value(), 7u);
+    EXPECT_EQ(exec.bump().value(), 7u);
     EXPECT_FALSE(static_cast<bool>(exec.bump()));
 }
 
@@ -79,7 +81,7 @@ TEST(alignment_executor_two_way, in_avail)
 {
     detail::alignment_executor_two_way exec{collection, fn};
     EXPECT_EQ(exec.in_avail(), 0u);
-    EXPECT_EQ(exec.bump(), 7u);
+    EXPECT_EQ(exec.bump().value(), 7u);
     EXPECT_EQ(exec.in_avail(), 0u);
 }
 
@@ -87,35 +89,35 @@ TEST(alignment_executor_two_way, lvalue_single_view)
 {
     auto v = ranges::view::single(single);
     detail::alignment_executor_two_way exec{v, fn};
-    EXPECT_EQ(exec.bump(), 7u);
+    EXPECT_EQ(exec.bump().value(), 7u);
     EXPECT_FALSE(static_cast<bool>(exec.bump()));
 }
 
 TEST(alignment_executor_two_way, rvalue_single_view)
 {
     detail::alignment_executor_two_way exec{ranges::view::single(single), fn};
-    EXPECT_EQ(exec.bump(), 7u);
+    EXPECT_EQ(exec.bump().value(), 7u);
     EXPECT_FALSE(static_cast<bool>(exec.bump()));
 }
 
 TEST(alignment_executor_two_way, lvalue_collection)
 {
     detail::alignment_executor_two_way exec{collection, fn};
-    EXPECT_EQ(exec.bump(), 7u);
-    EXPECT_EQ(exec.bump(), 7u);
-    EXPECT_EQ(exec.bump(), 7u);
-    EXPECT_EQ(exec.bump(), 7u);
-    EXPECT_EQ(exec.bump(), 7u);
+    EXPECT_EQ(exec.bump().value(), 7u);
+    EXPECT_EQ(exec.bump().value(), 7u);
+    EXPECT_EQ(exec.bump().value(), 7u);
+    EXPECT_EQ(exec.bump().value(), 7u);
+    EXPECT_EQ(exec.bump().value(), 7u);
     EXPECT_FALSE(static_cast<bool>(exec.bump()));
 }
 
 TEST(alignment_executor_two_way, rvalue_collection_view)
 {
     detail::alignment_executor_two_way exec{collection | view::persist, fn};
-    EXPECT_EQ(exec.bump(), 7u);
-    EXPECT_EQ(exec.bump(), 7u);
-    EXPECT_EQ(exec.bump(), 7u);
-    EXPECT_EQ(exec.bump(), 7u);
-    EXPECT_EQ(exec.bump(), 7u);
+    EXPECT_EQ(exec.bump().value(), 7u);
+    EXPECT_EQ(exec.bump().value(), 7u);
+    EXPECT_EQ(exec.bump().value(), 7u);
+    EXPECT_EQ(exec.bump().value(), 7u);
+    EXPECT_EQ(exec.bump().value(), 7u);
     EXPECT_FALSE(static_cast<bool>(exec.bump()));
 }

--- a/test/unit/alignment/pairwise/fixture/alignment_fixture.hpp
+++ b/test/unit/alignment/pairwise/fixture/alignment_fixture.hpp
@@ -3,6 +3,7 @@
 
 #include <limits>
 
+#include <seqan3/alignment/matrix/alignment_coordinate.hpp>
 #include <seqan3/alignment/matrix/alignment_score_matrix.hpp>
 #include <seqan3/alignment/matrix/alignment_trace_matrix.hpp>
 
@@ -11,8 +12,6 @@ namespace seqan3
 
 namespace seqan3::test::alignment::fixture
 {
-
-using detail::alignment_coordinate;
 
 static constexpr auto INF = std::numeric_limits<int>::max();
 

--- a/test/unit/alignment/pairwise/fixture/alignment_fixture.hpp
+++ b/test/unit/alignment/pairwise/fixture/alignment_fixture.hpp
@@ -6,6 +6,7 @@
 #include <seqan3/alignment/matrix/alignment_coordinate.hpp>
 #include <seqan3/alignment/matrix/alignment_score_matrix.hpp>
 #include <seqan3/alignment/matrix/alignment_trace_matrix.hpp>
+#include <seqan3/alignment/matrix/trace_directions.hpp>
 
 namespace seqan3
 {}
@@ -24,34 +25,56 @@ static constexpr auto UL = U | L;
 static constexpr auto DL = D | L;
 static constexpr auto DUL = D | U | L;
 
-template <typename sequence1_t, typename sequence2_t, typename config_t,
-          typename score_t, typename score_matrix_t, typename trace_matrix_t>
+template <typename sequence1_t,
+          typename sequence2_t,
+          typename config_t,
+          typename score_t,
+          typename score_matrix_t,
+          typename trace_matrix_t>
 struct alignment_fixture
 {
     template <typename trace_t>
-    alignment_fixture(
-        sequence1_t && _sequence1,
-        sequence2_t && _sequence2,
-        config_t _config,
-        score_t _score,
-        std::string _gapped_sequence1,
-        std::string _gapped_sequence2,
-        alignment_coordinate _begin_coordinate,
-        alignment_coordinate _end_coordinate,
-        std::vector<score_t> _score_vector,
-        std::vector<trace_t> _trace_vector
-    ) : sequence1{_sequence1},
+    alignment_fixture(sequence1_t && _sequence1,
+                      sequence2_t && _sequence2,
+                      config_t _config,
+                      score_t _score,
+                      std::string _aligned_sequence1,
+                      std::string _aligned_sequence2,
+                      alignment_coordinate _begin_coordinate,
+                      alignment_coordinate _end_coordinate,
+                      std::vector<score_t> _score_vector,
+                      std::vector<trace_t> _trace_vector) :
+        sequence1{_sequence1},
         sequence2{_sequence2},
         config{_config},
         score{_score},
-        gapped_sequence1{_gapped_sequence1},
-        gapped_sequence2{_gapped_sequence2},
+        aligned_sequence1{_aligned_sequence1},
+        aligned_sequence2{_aligned_sequence2},
         begin_coordinate{_begin_coordinate},
         end_coordinate{_end_coordinate},
         score_matrix{std::move(_score_vector), sequence2.size()+1, sequence1.size()+1},
         trace_matrix{std::move(_trace_vector), sequence2.size()+1, sequence1.size()+1}
-    {
-    }
+    {}
+
+    alignment_fixture(sequence1_t && _sequence1,
+                      sequence2_t && _sequence2,
+                      config_t _config,
+                      score_t _score,
+                      std::string _aligned_sequence1,
+                      std::string _aligned_sequence2,
+                      alignment_coordinate _begin_coordinate,
+                      alignment_coordinate _end_coordinate) :
+        alignment_fixture(std::forward<sequence1_t>(_sequence1),
+                          std::forward<sequence2_t>(_sequence2),
+                          _config,
+                          _score,
+                          _aligned_sequence1,
+                          _aligned_sequence2,
+                          _begin_coordinate,
+                          _end_coordinate,
+                          std::vector<score_t>{},
+                          std::vector<detail::trace_directions>{})
+    {}
 
     sequence1_t sequence1;
     sequence2_t sequence2;
@@ -59,36 +82,47 @@ struct alignment_fixture
     config_t config;
 
     score_t score;
-    std::string gapped_sequence1;
-    std::string gapped_sequence2;
+    std::string aligned_sequence1;
+    std::string aligned_sequence2;
 
     alignment_coordinate begin_coordinate;
     alignment_coordinate end_coordinate;
     score_matrix_t score_matrix;
     trace_matrix_t trace_matrix;
-
 };
 
 template <typename sequence1_t, typename sequence2_t, typename config_t, typename score_t, typename trace_t>
-alignment_fixture(
-    sequence1_t && _sequence1,
-    sequence2_t && _sequence2,
-    config_t _config,
-    score_t _score,
-    std::string _gapped_sequence1,
-    std::string _gapped_sequence2,
-    alignment_coordinate _begin_coordinate,
-    alignment_coordinate _end_coordinate,
-    std::vector<score_t> _score_vector,
-    std::vector<trace_t> _trace_vector
-)
--> alignment_fixture<
-    sequence1_t,
-    sequence2_t,
-    config_t,
-    score_t,
-    detail::alignment_score_matrix<std::vector<score_t>>,
-    detail::alignment_trace_matrix<std::vector<trace_t>>
->;
+alignment_fixture(sequence1_t && _sequence1,
+                  sequence2_t && _sequence2,
+                  config_t _config,
+                  score_t _score,
+                  std::string _aligned_sequence1,
+                  std::string _aligned_sequence2,
+                  alignment_coordinate _begin_coordinate,
+                  alignment_coordinate _end_coordinate,
+                  std::vector<score_t> _score_vector,
+                  std::vector<trace_t> _trace_vector)
+-> alignment_fixture<sequence1_t,
+                     sequence2_t,
+                     config_t,
+                     score_t,
+                     detail::alignment_score_matrix<std::vector<score_t>>,
+                     detail::alignment_trace_matrix<std::vector<trace_t>>>;
+
+template <typename sequence1_t, typename sequence2_t, typename config_t, typename score_t>
+alignment_fixture(sequence1_t && _sequence1,
+                  sequence2_t && _sequence2,
+                  config_t _config,
+                  score_t _score,
+                  std::string _aligned_sequence1,
+                  std::string _aligned_sequence2,
+                  alignment_coordinate _begin_coordinate,
+                  alignment_coordinate _end_coordinate)
+-> alignment_fixture<sequence1_t,
+                     sequence2_t,
+                     config_t,
+                     score_t,
+                     detail::alignment_score_matrix<std::vector<score_t>>,
+                     detail::alignment_trace_matrix<std::vector<detail::trace_directions>>>;
 
 } // namespace seqan3::test::alignment::fixture

--- a/test/unit/alignment/pairwise/fixture/global_affine_banded.hpp
+++ b/test/unit/alignment/pairwise/fixture/global_affine_banded.hpp
@@ -50,35 +50,7 @@ static auto dna4_01 = []()
         "A---ACCGGTTAACCGGTT",
         "ACGTAC----------GTA",
         alignment_coordinate{detail::column_index_type{0u}, detail::row_index_type{0u}},
-        alignment_coordinate{detail::column_index_type{15u}, detail::row_index_type{8u}},
-        std::vector
-        {
-        //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
-        /*e*/  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16,
-        /*A*/  1,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,
-        /*C*/  2,  1,  1,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
-        /*G*/  3,  2,  2,  2,  2,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13,
-        /*T*/  4,  3,  3,  3,  3,  3,  3,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12,
-        /*A*/  5,  4,  3,  4,  4,  4,  4,  4,  4,  4,  5,  6,  7,  8,  9, 10, 11,
-        /*C*/  6,  5,  4,  3,  4,  5,  5,  5,  5,  5,  5,  5,  6,  7,  8,  9, 10,
-        /*G*/  7,  6,  5,  4,  4,  4,  5,  6,  6,  6,  6,  6,  6,  6,  7,  8,  9,
-        /*T*/  8,  7,  6,  5,  5,  5,  5,  5,  6,  7,  7,  7,  7,  7,  7,  7,  8,
-        /*A*/  9,  8,  7,  6,  6,  6,  6,  6,  6,  6,  7,  8,  8,  8,  8,  8,  8
-        },
-        std::vector
-        {
-        //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
-        /*e*/NON,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,
-        /*A*/U  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
-        /*C*/U  ,U  ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,L  ,L  ,
-        /*G*/U  ,U  ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,
-        /*T*/U  ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,
-        /*A*/U  ,DU ,D  ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
-        /*C*/U  ,U  ,U  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,
-        /*G*/U  ,U  ,U  ,U  ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,
-        /*T*/U  ,U  ,U  ,U  ,DU ,DU ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,
-        /*A*/U  ,DU ,DU ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D
-        }
+        alignment_coordinate{detail::column_index_type{16u}, detail::row_index_type{9u}}
     };
 }();
 

--- a/test/unit/alignment/pairwise/fixture/global_affine_banded.hpp
+++ b/test/unit/alignment/pairwise/fixture/global_affine_banded.hpp
@@ -49,8 +49,8 @@ static auto dna4_01 = []()
         -18,
         "A---ACCGGTTAACCGGTT",
         "ACGTAC----------GTA",
-        alignment_coordinate{0, 0},
-        alignment_coordinate{15, 8},
+        alignment_coordinate{detail::column_index_type{0u}, detail::row_index_type{0u}},
+        alignment_coordinate{detail::column_index_type{15u}, detail::row_index_type{8u}},
         std::vector
         {
         //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T

--- a/test/unit/alignment/pairwise/fixture/global_affine_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/global_affine_unbanded.hpp
@@ -42,10 +42,10 @@ static auto dna4_01 = []()
         "ACGTACGTA"_dna4,
         align_config | align_cfg::scoring{nucleotide_scoring_scheme{match_score{4}, mismatch_score{-5}}},
         -18,
-        "AACCGGTTAACCGGTT",
-        "A-C-G-T-A-C-G-TA",
+        "AACCGGTTAACCG---GTT",
+        "A----------CGTACGTA",
         alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
-        alignment_coordinate{column_index_type{15u}, row_index_type{8u}},
+        alignment_coordinate{column_index_type{16u}, row_index_type{9u}},
         std::vector
         {
         //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
@@ -88,10 +88,10 @@ static auto dna4_02 = []()
         "AACCGGTTAACCGGTT"_dna4,
         align_config | align_cfg::scoring{nucleotide_scoring_scheme{match_score{4}, mismatch_score{-5}}},
         -18,
-        "A-C-G-T-A-C-G-TA",
-        "AACCGGTTAACCGGTT",
+        "ACGTAC----------GTA",
+        "A---ACCGGTTAACCGGTT",
         alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
-        alignment_coordinate{column_index_type{8u}, row_index_type{15u}},
+        alignment_coordinate{column_index_type{9u}, row_index_type{16u}},
         std::vector
         {
         //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T

--- a/test/unit/alignment/pairwise/fixture/global_affine_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/global_affine_unbanded.hpp
@@ -28,6 +28,9 @@ inline constexpr auto align_config = align_cfg::mode{align_cfg::global_alignment
 
 static auto dna4_01 = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         // score: 8 (7 insertions, 1 substitutions)
@@ -41,8 +44,8 @@ static auto dna4_01 = []()
         -18,
         "AACCGGTTAACCGGTT",
         "A-C-G-T-A-C-G-TA",
-        alignment_coordinate{0, 0},
-        alignment_coordinate{15, 8},
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{15u}, row_index_type{8u}},
         std::vector
         {
         //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
@@ -76,6 +79,9 @@ static auto dna4_01 = []()
 
 static auto dna4_02 = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         "ACGTACGTA"_dna4,
@@ -84,8 +90,8 @@ static auto dna4_02 = []()
         -18,
         "A-C-G-T-A-C-G-TA",
         "AACCGGTTAACCGGTT",
-        alignment_coordinate{0, 0},
-        alignment_coordinate{8, 15},
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{8u}, row_index_type{15u}},
         std::vector
         {
         //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T

--- a/test/unit/alignment/pairwise/fixture/global_edit_distance_max_errors_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/global_edit_distance_max_errors_unbanded.hpp
@@ -17,6 +17,9 @@ inline constexpr auto align_config = align_cfg::edit | align_cfg::max_error{255}
 
 static auto dna4_01_e255 = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         // score: 8 (7 insertions, 1 substitutions)
@@ -30,8 +33,8 @@ static auto dna4_01_e255 = []()
         -8,
         "AACCGGTTAACCGGTT",
         "A-C-G-T-A-C-G-TA",
-        alignment_coordinate{0, 0},
-        alignment_coordinate{15, 8},
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{15u}, row_index_type{8u}},
         std::vector
         {
         //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
@@ -65,6 +68,9 @@ static auto dna4_01_e255 = []()
 
 static auto dna4_01T_e255 = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         // score: 8 (7 insertions, 1 substitutions)
@@ -78,8 +84,8 @@ static auto dna4_01T_e255 = []()
         -8,
         "A-C-G-T-A-C-G-TA",
         "AACCGGTTAACCGGTT",
-        alignment_coordinate{0, 0},
-        alignment_coordinate{8, 15},
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{8u}, row_index_type{15u}},
         std::vector
         {
         //     e,  A,  C,  G,  T,  A,  C,  G,  T,  A
@@ -127,6 +133,9 @@ static auto dna4_01T_e255 = []()
 
 static auto dna4_02_e255 = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         // score: 8 (7 insertions, 1 substitutions)
@@ -140,8 +149,8 @@ static auto dna4_02_e255 = []()
         -8,
         "AACCGGTAAACCGGTT",
         "A-C-G-TA--C-G-TA",
-        alignment_coordinate{0, 0},
-        alignment_coordinate{15, 8},
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{15u}, row_index_type{8u}},
         std::vector
         {
         //     e,  A,  A,  C,  C,  G,  G,  T,  A,  A,  A,  C,  C,  G,  G,  T,  T,
@@ -175,6 +184,9 @@ static auto dna4_02_e255 = []()
 
 static auto aa27_01_e255 = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         // score: 8 (7 insertions, 1 substitutions)
@@ -188,8 +200,8 @@ static auto aa27_01_e255 = []()
         -8,
         "UUWWRRIIUUWWRRII",
         "U-W-R-I-U-W-R-IU",
-        alignment_coordinate{0, 0},
-        alignment_coordinate{15, 8},
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{15u}, row_index_type{8u}},
         std::vector
         {
         //     e,  U,  U,  W,  W,  R,  R,  I,  I,  U,  U,  W,  W,  R,  R,  I,  I
@@ -223,6 +235,9 @@ static auto aa27_01_e255 = []()
 
 static auto aa27_01T_e255 = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         // score: 8 (7 insertions, 1 substitutions)
@@ -236,8 +251,8 @@ static auto aa27_01T_e255 = []()
         -8,
         "U-W-R-I-U-W-R-IU",
         "UUWWRRIIUUWWRRII",
-        alignment_coordinate{0, 0},
-        alignment_coordinate{8, 15},
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{8u}, row_index_type{15u}},
         std::vector
         {
         //     e,  U,  W,  R,  I,  U,  W,  R,  I,  U

--- a/test/unit/alignment/pairwise/fixture/global_edit_distance_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/global_edit_distance_unbanded.hpp
@@ -14,6 +14,9 @@ namespace seqan3::test::alignment::fixture::global::edit_distance::unbanded
 
 static auto dna4_01 = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         // score: 8 (7 insertions, 1 substitutions)
@@ -27,8 +30,8 @@ static auto dna4_01 = []()
         -8,
         "AACCGGTTAACCGGTT",
         "A-C-G-T-A-C-G-TA",
-        alignment_coordinate{0, 0},
-        alignment_coordinate{15, 8},
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{15u}, row_index_type{8u}},
         std::vector
         {
         //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
@@ -62,6 +65,9 @@ static auto dna4_01 = []()
 
 static auto dna4_01T = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         // score: 8 (7 insertions, 1 substitutions)
@@ -75,8 +81,8 @@ static auto dna4_01T = []()
         -8,
         "A-C-G-T-A-C-G-TA",
         "AACCGGTTAACCGGTT",
-        alignment_coordinate{0, 0},
-        alignment_coordinate{8, 15},
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{8u}, row_index_type{15u}},
         std::vector
         {
         //     e,  A,  C,  G,  T,  A,  C,  G,  T,  A
@@ -124,6 +130,9 @@ static auto dna4_01T = []()
 
 static auto dna4_02 = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         // score: 8 (7 insertions, 1 substitutions)
@@ -137,8 +146,8 @@ static auto dna4_02 = []()
         -8,
         "AACCGGTAAACCGGTT",
         "A-C-G-TA--C-G-TA",
-        alignment_coordinate{0, 0},
-        alignment_coordinate{15, 8},
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{15u}, row_index_type{8u}},
         std::vector
         {
         //     e,  A,  A,  C,  C,  G,  G,  T,  A,  A,  A,  C,  C,  G,  G,  T,  T,
@@ -172,6 +181,9 @@ static auto dna4_02 = []()
 
 static auto aa27_01 = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         // score: 8 (7 insertions, 1 substitutions)
@@ -185,8 +197,8 @@ static auto aa27_01 = []()
         -8,
         "UUWWRRIIUUWWRRII",
         "U-W-R-I-U-W-R-IU",
-        alignment_coordinate{0, 0},
-        alignment_coordinate{15, 8},
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{15u}, row_index_type{8u}},
         std::vector
         {
         //     e,  U,  U,  W,  W,  R,  R,  I,  I,  U,  U,  W,  W,  R,  R,  I,  I
@@ -220,6 +232,9 @@ static auto aa27_01 = []()
 
 static auto aa27_01T = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         // score: 8 (7 insertions, 1 substitutions)
@@ -233,8 +248,8 @@ static auto aa27_01T = []()
         -8,
         "U-W-R-I-U-W-R-IU",
         "UUWWRRIIUUWWRRII",
-        alignment_coordinate{0, 0},
-        alignment_coordinate{8, 15},
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{8u}, row_index_type{15u}},
         std::vector
         {
         //     e,  U,  W,  R,  I,  U,  W,  R,  I,  U

--- a/test/unit/alignment/pairwise/fixture/semi_global_affine_banded.hpp
+++ b/test/unit/alignment/pairwise/fixture/semi_global_affine_banded.hpp
@@ -42,8 +42,8 @@ static auto dna4_01 = []()
         10,
         "TTTTTACGT---ATGTCCCCC",
         "-----ACGTAAAACGT-----",
-        alignment_coordinate{0u, 0},
-        alignment_coordinate{13u, 11},
+        alignment_coordinate{detail::column_index_type{0u}, detail::row_index_type{0u}},
+        alignment_coordinate{detail::column_index_type{13u}, detail::row_index_type{11u}},
         std::vector
         {
         //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
@@ -85,8 +85,8 @@ static auto dna4_02 = []()
         -13,
         "-----ACGTA--------AAACGT",
         "TTTTTACGTATGTCCCCC------",
-        alignment_coordinate{0u, 0},
-        alignment_coordinate{5u, 18},
+        alignment_coordinate{detail::column_index_type{0u}, detail::row_index_type{0u}},
+        alignment_coordinate{detail::column_index_type{5u}, detail::row_index_type{18u}},
         std::vector
         {
         //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
@@ -128,8 +128,8 @@ static auto dna4_03 = []()
         -13,
         "-----ACGTA--------AAACGT",
         "TTTTTACGTATGTCCCCC------",
-        alignment_coordinate{0u, 0},
-        alignment_coordinate{5u, 18},
+        alignment_coordinate{detail::column_index_type{0u}, detail::row_index_type{0u}},
+        alignment_coordinate{detail::column_index_type{5u}, detail::row_index_type{18u}},
         std::vector
         {
         //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
@@ -171,8 +171,8 @@ static auto dna4_04 = []()
         10,
         "TTTTTACGT---ATGTCCCCC",
         "-----ACGTAAAACGT-----",
-        alignment_coordinate{0u, 0},
-        alignment_coordinate{13u, 11},
+        alignment_coordinate{detail::column_index_type{0u}, detail::row_index_type{0u}},
+        alignment_coordinate{detail::column_index_type{13u}, detail::row_index_type{11u}},
         std::vector
         {
         //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T

--- a/test/unit/alignment/pairwise/fixture/semi_global_affine_banded.hpp
+++ b/test/unit/alignment/pairwise/fixture/semi_global_affine_banded.hpp
@@ -32,7 +32,7 @@ inline constexpr auto align_config = align_cfg::mode{align_cfg::global_alignment
 inline constexpr auto align_config_semi_seq1 = align_config | align_cfg::aligned_ends{align_cfg::seq1_ends_free};
 inline constexpr auto align_config_semi_seq2 = align_config | align_cfg::aligned_ends{align_cfg::seq2_ends_free};
 
-static auto dna4_01 = []()
+static auto dna4_semi_seq1_a = []()
 {
     return alignment_fixture
     {
@@ -40,167 +40,58 @@ static auto dna4_01 = []()
         "ACGTAAAACGT"_dna4,
         align_config_semi_seq1 | align_cfg::scoring{nucleotide_scoring_scheme{match_score{4}, mismatch_score{-5}}},
         10,
-        "TTTTTACGT---ATGTCCCCC",
-        "-----ACGTAAAACGT-----",
-        alignment_coordinate{detail::column_index_type{0u}, detail::row_index_type{0u}},
-        alignment_coordinate{detail::column_index_type{13u}, detail::row_index_type{11u}},
-        std::vector
-        {
-        //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
-        /*e*/  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16,
-        /*A*/  1,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,
-        /*C*/  2,  1,  1,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
-        /*G*/  3,  2,  2,  2,  2,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13,
-        /*T*/  4,  3,  3,  3,  3,  3,  3,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12,
-        /*A*/  5,  4,  3,  4,  4,  4,  4,  4,  4,  4,  5,  6,  7,  8,  9, 10, 11,
-        /*C*/  6,  5,  4,  3,  4,  5,  5,  5,  5,  5,  5,  5,  6,  7,  8,  9, 10,
-        /*G*/  7,  6,  5,  4,  4,  4,  5,  6,  6,  6,  6,  6,  6,  6,  7,  8,  9,
-        /*T*/  8,  7,  6,  5,  5,  5,  5,  5,  6,  7,  7,  7,  7,  7,  7,  7,  8,
-        /*A*/  9,  8,  7,  6,  6,  6,  6,  6,  6,  6,  7,  8,  8,  8,  8,  8,  8
-        },
-        std::vector
-        {
-        //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
-        /*e*/NON,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,
-        /*A*/U  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
-        /*C*/U  ,U  ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,L  ,L  ,
-        /*G*/U  ,U  ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,
-        /*T*/U  ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,
-        /*A*/U  ,DU ,D  ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
-        /*C*/U  ,U  ,U  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,
-        /*G*/U  ,U  ,U  ,U  ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,
-        /*T*/U  ,U  ,U  ,U  ,DU ,DU ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,
-        /*A*/U  ,DU ,DU ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D
-        }
+        "ACGT---ATGT",
+        "ACGTAAAACGT",
+        alignment_coordinate{detail::column_index_type{5u}, detail::row_index_type{0u}},
+        alignment_coordinate{detail::column_index_type{13u}, detail::row_index_type{11u}}
     };
 }();
 
-static auto dna4_02 = []()
-{
-    return alignment_fixture
-    {
-        "ACGTAAAACGT"_dna4,
-        "TTTTTACGTATGTCCCCC"_dna4,
-        align_config_semi_seq1 | align_cfg::scoring{nucleotide_scoring_scheme{match_score{4}, mismatch_score{-5}}},
-        -13,
-        "-----ACGTA--------AAACGT",
-        "TTTTTACGTATGTCCCCC------",
-        alignment_coordinate{detail::column_index_type{0u}, detail::row_index_type{0u}},
-        alignment_coordinate{detail::column_index_type{5u}, detail::row_index_type{18u}},
-        std::vector
-        {
-        //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
-        /*e*/  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16,
-        /*A*/  1,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,
-        /*C*/  2,  1,  1,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
-        /*G*/  3,  2,  2,  2,  2,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13,
-        /*T*/  4,  3,  3,  3,  3,  3,  3,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12,
-        /*A*/  5,  4,  3,  4,  4,  4,  4,  4,  4,  4,  5,  6,  7,  8,  9, 10, 11,
-        /*C*/  6,  5,  4,  3,  4,  5,  5,  5,  5,  5,  5,  5,  6,  7,  8,  9, 10,
-        /*G*/  7,  6,  5,  4,  4,  4,  5,  6,  6,  6,  6,  6,  6,  6,  7,  8,  9,
-        /*T*/  8,  7,  6,  5,  5,  5,  5,  5,  6,  7,  7,  7,  7,  7,  7,  7,  8,
-        /*A*/  9,  8,  7,  6,  6,  6,  6,  6,  6,  6,  7,  8,  8,  8,  8,  8,  8
-        },
-        std::vector
-        {
-        //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
-        /*e*/NON,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,
-        /*A*/U  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
-        /*C*/U  ,U  ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,L  ,L  ,
-        /*G*/U  ,U  ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,
-        /*T*/U  ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,
-        /*A*/U  ,DU ,D  ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
-        /*C*/U  ,U  ,U  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,
-        /*G*/U  ,U  ,U  ,U  ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,
-        /*T*/U  ,U  ,U  ,U  ,DU ,DU ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,
-        /*A*/U  ,DU ,DU ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D
-        }
-    };
-}();
+// TODO: Fix the computation of the trailing gap, which depends on whether the score in the last cell
+// was a gap or not (the gap must be extended in this case.) -> or throw invalid_alignment_configuration if
+// the score cannot be computed.
+// static auto dna4_semi_seq1_b = []()
+// {
+//     return alignment_fixture
+//     {
+//         "ACGTAAAACGT"_dna4,
+//         "TTTTTACGTATGTCCCCC"_dna4,
+//         align_config_semi_seq1 | align_cfg::scoring{nucleotide_scoring_scheme{match_score{4}, mismatch_score{-5}}},
+//         -13,
+//         "-----ACGTA--------AAACGT",
+//         "TTTTTACGTATGTCCCCC------",
+//         alignment_coordinate{detail::column_index_type{0u}, detail::row_index_type{0u}},
+//         alignment_coordinate{detail::column_index_type{5u}, detail::row_index_type{18u}}
+//     };
+// }();
 
-static auto dna4_03 = []()
+static auto dna4_semi_seq2_a = []()
 {
     return alignment_fixture
     {
         "TTTTTACGTATGTCCCCC"_dna4,
         "ACGTAAAACGT"_dna4,
         align_config_semi_seq2 | align_cfg::scoring{nucleotide_scoring_scheme{match_score{4}, mismatch_score{-5}}},
-        -13,
-        "-----ACGTA--------AAACGT",
-        "TTTTTACGTATGTCCCCC------",
-        alignment_coordinate{detail::column_index_type{0u}, detail::row_index_type{0u}},
-        alignment_coordinate{detail::column_index_type{5u}, detail::row_index_type{18u}},
-        std::vector
-        {
-        //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
-        /*e*/  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16,
-        /*A*/  1,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,
-        /*C*/  2,  1,  1,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
-        /*G*/  3,  2,  2,  2,  2,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13,
-        /*T*/  4,  3,  3,  3,  3,  3,  3,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12,
-        /*A*/  5,  4,  3,  4,  4,  4,  4,  4,  4,  4,  5,  6,  7,  8,  9, 10, 11,
-        /*C*/  6,  5,  4,  3,  4,  5,  5,  5,  5,  5,  5,  5,  6,  7,  8,  9, 10,
-        /*G*/  7,  6,  5,  4,  4,  4,  5,  6,  6,  6,  6,  6,  6,  6,  7,  8,  9,
-        /*T*/  8,  7,  6,  5,  5,  5,  5,  5,  6,  7,  7,  7,  7,  7,  7,  7,  8,
-        /*A*/  9,  8,  7,  6,  6,  6,  6,  6,  6,  6,  7,  8,  8,  8,  8,  8,  8
-        },
-        std::vector
-        {
-        //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
-        /*e*/NON,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,
-        /*A*/U  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
-        /*C*/U  ,U  ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,L  ,L  ,
-        /*G*/U  ,U  ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,
-        /*T*/U  ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,
-        /*A*/U  ,DU ,D  ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
-        /*C*/U  ,U  ,U  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,
-        /*G*/U  ,U  ,U  ,U  ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,
-        /*T*/U  ,U  ,U  ,U  ,DU ,DU ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,
-        /*A*/U  ,DU ,DU ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D
-        }
+        -19,
+        "TTTTTACGTATGTCCCCC",
+        "GTAAAACGT---------",
+        alignment_coordinate{detail::column_index_type{0u}, detail::row_index_type{2u}},
+        alignment_coordinate{detail::column_index_type{18u}, detail::row_index_type{11u}}
     };
 }();
 
-static auto dna4_04 = []()
+static auto dna4_semi_seq2_b = []()
 {
     return alignment_fixture
     {
         "ACGTAAAACGT"_dna4,
         "TTTTTACGTATGTCCCCC"_dna4,
         align_config_semi_seq2 | align_cfg::scoring{nucleotide_scoring_scheme{match_score{4}, mismatch_score{-5}}},
-        10,
-        "TTTTTACGT---ATGTCCCCC",
-        "-----ACGTAAAACGT-----",
-        alignment_coordinate{detail::column_index_type{0u}, detail::row_index_type{0u}},
-        alignment_coordinate{detail::column_index_type{13u}, detail::row_index_type{11u}},
-        std::vector
-        {
-        //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
-        /*e*/  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16,
-        /*A*/  1,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,
-        /*C*/  2,  1,  1,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
-        /*G*/  3,  2,  2,  2,  2,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13,
-        /*T*/  4,  3,  3,  3,  3,  3,  3,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12,
-        /*A*/  5,  4,  3,  4,  4,  4,  4,  4,  4,  4,  5,  6,  7,  8,  9, 10, 11,
-        /*C*/  6,  5,  4,  3,  4,  5,  5,  5,  5,  5,  5,  5,  6,  7,  8,  9, 10,
-        /*G*/  7,  6,  5,  4,  4,  4,  5,  6,  6,  6,  6,  6,  6,  6,  7,  8,  9,
-        /*T*/  8,  7,  6,  5,  5,  5,  5,  5,  6,  7,  7,  7,  7,  7,  7,  7,  8,
-        /*A*/  9,  8,  7,  6,  6,  6,  6,  6,  6,  6,  7,  8,  8,  8,  8,  8,  8
-        },
-        std::vector
-        {
-        //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
-        /*e*/NON,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,
-        /*A*/U  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
-        /*C*/U  ,U  ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,L  ,L  ,
-        /*G*/U  ,U  ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,
-        /*T*/U  ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,
-        /*A*/U  ,DU ,D  ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
-        /*C*/U  ,U  ,U  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,
-        /*G*/U  ,U  ,U  ,U  ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,
-        /*T*/U  ,U  ,U  ,U  ,DU ,DU ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,
-        /*A*/U  ,DU ,DU ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D
-        }
+        -5,
+        "ACGTAAAACGT",
+        "------TACGT",
+        alignment_coordinate{detail::column_index_type{0u}, detail::row_index_type{4u}},
+        alignment_coordinate{detail::column_index_type{11u}, detail::row_index_type{9u}}
     };
 }();
 

--- a/test/unit/alignment/pairwise/fixture/semi_global_affine_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/semi_global_affine_unbanded.hpp
@@ -41,9 +41,9 @@ static auto dna4_01 = []()
         "ACGTAAAACGT"_dna4,
         align_config_semi_seq1 | align_cfg::scoring{nucleotide_scoring_scheme{match_score{4}, mismatch_score{-5}}},
         10,
-        "TTTTTACGT---ATGTCCCCC",
-        "-----ACGTAAAACGT-----",
-        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        "ACGT---ATGT",
+        "ACGTAAAACGT",
+        alignment_coordinate{column_index_type{5u}, row_index_type{0u}},
         alignment_coordinate{column_index_type{13u}, row_index_type{11u}},
         std::vector
         {
@@ -87,8 +87,8 @@ static auto dna4_02 = []()
         "TTTTTACGTATGTCCCCC"_dna4,
         align_config_semi_seq1 | align_cfg::scoring{nucleotide_scoring_scheme{match_score{4}, mismatch_score{-5}}},
         -13,
-        "-----ACGTA--------AAACGT",
-        "TTTTTACGTATGTCCCCC------",
+        "-----ACGTA--------",
+        "TTTTTACGTATGTCCCCC",
         alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
         alignment_coordinate{column_index_type{5u}, row_index_type{18u}},
         std::vector
@@ -133,10 +133,10 @@ static auto dna4_03 = []()
         "ACGTAAAACGT"_dna4,
         align_config_semi_seq2 | align_cfg::scoring{nucleotide_scoring_scheme{match_score{4}, mismatch_score{-5}}},
         -13,
-        "-----ACGTA--------AAACGT",
-        "TTTTTACGTATGTCCCCC------",
+        "TTTTTACGTATGTCCCCC",
+        "-----ACGTA--------",
         alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
-        alignment_coordinate{column_index_type{5u}, row_index_type{18u}},
+        alignment_coordinate{column_index_type{18u}, row_index_type{5u}},
         std::vector
         {
         //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
@@ -172,17 +172,17 @@ static auto dna4_04 = []()
 {
     using detail::column_index_type;
     using detail::row_index_type;
-    
+
     return alignment_fixture
     {
         "ACGTAAAACGT"_dna4,
         "TTTTTACGTATGTCCCCC"_dna4,
         align_config_semi_seq2 | align_cfg::scoring{nucleotide_scoring_scheme{match_score{4}, mismatch_score{-5}}},
         10,
-        "TTTTTACGT---ATGTCCCCC",
-        "-----ACGTAAAACGT-----",
-        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
-        alignment_coordinate{column_index_type{13u}, row_index_type{11u}},
+        "ACGTAAAACGT",
+        "ACGT---ATGT",
+        alignment_coordinate{column_index_type{0u}, row_index_type{5u}},
+        alignment_coordinate{column_index_type{11u}, row_index_type{13u}},
         std::vector
         {
         //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T

--- a/test/unit/alignment/pairwise/fixture/semi_global_affine_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/semi_global_affine_unbanded.hpp
@@ -32,6 +32,9 @@ inline constexpr auto align_config_semi_seq2 = align_config | align_cfg::aligned
 
 static auto dna4_01 = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         "TTTTTACGTATGTCCCCC"_dna4,
@@ -40,8 +43,8 @@ static auto dna4_01 = []()
         10,
         "TTTTTACGT---ATGTCCCCC",
         "-----ACGTAAAACGT-----",
-        alignment_coordinate{0u, 0},
-        alignment_coordinate{13u, 11},
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{13u}, row_index_type{11u}},
         std::vector
         {
         //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
@@ -75,6 +78,9 @@ static auto dna4_01 = []()
 
 static auto dna4_02 = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         "ACGTAAAACGT"_dna4,
@@ -83,8 +89,8 @@ static auto dna4_02 = []()
         -13,
         "-----ACGTA--------AAACGT",
         "TTTTTACGTATGTCCCCC------",
-        alignment_coordinate{0u, 0},
-        alignment_coordinate{5u, 18},
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{5u}, row_index_type{18u}},
         std::vector
         {
         //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
@@ -118,6 +124,9 @@ static auto dna4_02 = []()
 
 static auto dna4_03 = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         "TTTTTACGTATGTCCCCC"_dna4,
@@ -126,8 +135,8 @@ static auto dna4_03 = []()
         -13,
         "-----ACGTA--------AAACGT",
         "TTTTTACGTATGTCCCCC------",
-        alignment_coordinate{0u, 0},
-        alignment_coordinate{5u, 18},
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{5u}, row_index_type{18u}},
         std::vector
         {
         //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
@@ -161,6 +170,9 @@ static auto dna4_03 = []()
 
 static auto dna4_04 = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+    
     return alignment_fixture
     {
         "ACGTAAAACGT"_dna4,
@@ -169,8 +181,8 @@ static auto dna4_04 = []()
         10,
         "TTTTTACGT---ATGTCCCCC",
         "-----ACGTAAAACGT-----",
-        alignment_coordinate{0u, 0},
-        alignment_coordinate{13u, 11},
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{13u}, row_index_type{11u}},
         std::vector
         {
         //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T

--- a/test/unit/alignment/pairwise/fixture/semi_global_edit_distance_max_errors_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/semi_global_edit_distance_max_errors_unbanded.hpp
@@ -20,6 +20,9 @@ inline constexpr auto align_config = align_cfg::edit |
 
 static auto dna4_01_e255 = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         // score: 5 (3 deletions, 1 insertion, 1 substitutions)
@@ -33,8 +36,8 @@ static auto dna4_01_e255 = []()
         -5,
         "AC---CGGTT",
         "ACGTACG-TA",
-        alignment_coordinate{8, 0},
-        alignment_coordinate{15, 8},
+        alignment_coordinate{column_index_type{8u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{15u}, row_index_type{8u}},
         std::vector
         {
         //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
@@ -68,6 +71,9 @@ static auto dna4_01_e255 = []()
 
 static auto dna4_01T_e255 = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         // score: 8 (7 insertions, 1 substitutions)
@@ -81,8 +87,8 @@ static auto dna4_01T_e255 = []()
         -8,
         "A-C-G-T-A-C-G-TA",
         "AACCGGTTAACCGGTT",
-        alignment_coordinate{0, 0},
-        alignment_coordinate{8, 15},
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{8u}, row_index_type{15u}},
         std::vector
         {
         //     e,  A,  C,  G,  T,  A,  C,  G,  T,  A
@@ -130,6 +136,9 @@ static auto dna4_01T_e255 = []()
 
 static auto dna4_02_e255 = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         // score: 4 (3 deletions, 1 insertion)
@@ -143,8 +152,8 @@ static auto dna4_02_e255 = []()
         -4,
         "AC---CGGTA",
         "ACGTACG-TA",
-        alignment_coordinate{0, 0},
-        alignment_coordinate{7, 8},
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{7u}, row_index_type{8u}},
         std::vector
         {
         //     e,  A,  A,  C,  C,  G,  G,  T,  A,  A,  A,  C,  C,  G,  G,  T,  T,
@@ -178,6 +187,9 @@ static auto dna4_02_e255 = []()
 
 static auto aa27_01_e255 = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         // score: 5 (3 deletions, 1 insertion, 1 substitutions)
@@ -191,8 +203,8 @@ static auto aa27_01_e255 = []()
         -5,
         "UW---WRRII",
         "UWRIUWR-IU",
-        alignment_coordinate{8, 0},
-        alignment_coordinate{15, 8},
+        alignment_coordinate{column_index_type{8u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{15u}, row_index_type{8u}},
         std::vector
         {
         //     e,  U,  U,  W,  W,  R,  R,  I,  I,  U,  U,  W,  W,  R,  R,  I,  I
@@ -226,6 +238,9 @@ static auto aa27_01_e255 = []()
 
 static auto aa27_01T_e255 = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         // score: 8 (7 insertions, 1 substitutions)
@@ -239,8 +254,8 @@ static auto aa27_01T_e255 = []()
         -8,
         "U-W-R-I-U-W-R-IU",
         "UUWWRRIIUUWWRRII",
-        alignment_coordinate{0, 0},
-        alignment_coordinate{8, 15},
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{8u}, row_index_type{15u}},
         std::vector
         {
         //     e,  U,  W,  R,  I,  U,  W,  R,  I,  U

--- a/test/unit/alignment/pairwise/fixture/semi_global_edit_distance_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/semi_global_edit_distance_unbanded.hpp
@@ -17,6 +17,9 @@ inline constexpr auto align_config = align_cfg::edit | align_cfg::aligned_ends{a
 
 static auto dna4_01 = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         // score: 5 (3 deletions, 1 insertion, 1 substitutions)
@@ -30,8 +33,8 @@ static auto dna4_01 = []()
         -5,
         "AC---CGGTT",
         "ACGTACG-TA",
-        alignment_coordinate{8, 0},
-        alignment_coordinate{15, 8},
+        alignment_coordinate{column_index_type{8u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{15u}, row_index_type{8u}},
         std::vector
         {
         //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
@@ -65,6 +68,9 @@ static auto dna4_01 = []()
 
 static auto dna4_01T = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         // score: 8 (7 insertions, 1 substitutions)
@@ -78,8 +84,8 @@ static auto dna4_01T = []()
         -8,
         "A-C-G-T-A-C-G-TA",
         "AACCGGTTAACCGGTT",
-        alignment_coordinate{0, 0},
-        alignment_coordinate{8, 15},
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{8u}, row_index_type{15u}},
         std::vector
         {
         //     e,  A,  C,  G,  T,  A,  C,  G,  T,  A
@@ -127,6 +133,9 @@ static auto dna4_01T = []()
 
 static auto dna4_02 = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         // score: 4 (3 deletions, 1 insertion)
@@ -140,8 +149,8 @@ static auto dna4_02 = []()
         -4,
         "AC---CGGTA",
         "ACGTACG-TA",
-        alignment_coordinate{0, 0},
-        alignment_coordinate{7, 8},
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{7u}, row_index_type{8u}},
         std::vector
         {
         //     e,  A,  A,  C,  C,  G,  G,  T,  A,  A,  A,  C,  C,  G,  G,  T,  T,
@@ -175,6 +184,9 @@ static auto dna4_02 = []()
 
 static auto aa27_01 = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         // score: 5 (3 deletions, 1 insertion, 1 substitutions)
@@ -188,8 +200,8 @@ static auto aa27_01 = []()
         -5,
         "UW---WRRII",
         "UWRIUWR-IU",
-        alignment_coordinate{8, 0},
-        alignment_coordinate{15, 8},
+        alignment_coordinate{column_index_type{8u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{15u}, row_index_type{8u}},
         std::vector
         {
         //     e,  U,  U,  W,  W,  R,  R,  I,  I,  U,  U,  W,  W,  R,  R,  I,  I
@@ -223,6 +235,9 @@ static auto aa27_01 = []()
 
 static auto aa27_01T = []()
 {
+    using detail::column_index_type;
+    using detail::row_index_type;
+
     return alignment_fixture
     {
         // score: 8 (7 insertions, 1 substitutions)
@@ -236,8 +251,8 @@ static auto aa27_01T = []()
         -8,
         "U-W-R-I-U-W-R-IU",
         "UUWWRRIIUUWWRRII",
-        alignment_coordinate{0, 0},
-        alignment_coordinate{8, 15},
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{8u}, row_index_type{15u}},
         std::vector
         {
         //     e,  U,  W,  R,  I,  U,  W,  R,  I,  U

--- a/test/unit/alignment/pairwise/global_affine_banded_test.cpp
+++ b/test/unit/alignment/pairwise/global_affine_banded_test.cpp
@@ -43,7 +43,10 @@ using global_affine_banded_types
 
 using semi_global_affine_banded_types
     = ::testing::Types<
-        param<&semi_global::affine::banded::dna4_01>
+        param<&semi_global::affine::banded::dna4_semi_seq1_a>,
+        //param<&semi_global::affine::banded::dna4_semi_seq1_b>,
+        param<&semi_global::affine::banded::dna4_semi_seq2_a>,
+        param<&semi_global::affine::banded::dna4_semi_seq2_b>
     >;
 
 TYPED_TEST_P(global_affine_banded, score)
@@ -61,7 +64,58 @@ TYPED_TEST_P(global_affine_banded, score)
     EXPECT_EQ((*std::ranges::begin(alignment)).get_score(), fixture.score);
 }
 
-REGISTER_TYPED_TEST_CASE_P(global_affine_banded, score);
+TYPED_TEST_P(global_affine_banded, end_position)
+{
+    auto const & fixture = this->fixture();
+    auto align_cfg = fixture.config | align_cfg::result{align_cfg::with_end_position};
+
+    std::vector database = fixture.sequence1;
+    std::vector query = fixture.sequence2;
+
+    auto alignment = align_pairwise(std::pair{database, query}, align_cfg);
+
+    auto res = *std::ranges::begin(alignment);
+    EXPECT_EQ(res.get_score(), fixture.score);
+
+    EXPECT_EQ(res.get_end_coordinate(), fixture.end_coordinate);
+}
+
+TYPED_TEST_P(global_affine_banded, begin_position)
+{
+    auto const & fixture = this->fixture();
+    auto align_cfg = fixture.config | align_cfg::result{align_cfg::with_begin_position};
+
+    std::vector database = fixture.sequence1;
+    std::vector query = fixture.sequence2;
+
+    auto alignment = align_pairwise(std::pair{database, query}, align_cfg);
+
+    auto res = *std::ranges::begin(alignment);
+    EXPECT_EQ(res.get_score(), fixture.score);
+
+    EXPECT_EQ(res.get_begin_coordinate(), fixture.begin_coordinate);
+    EXPECT_EQ(res.get_end_coordinate(), fixture.end_coordinate);
+}
+
+TYPED_TEST_P(global_affine_banded, trace)
+{
+    auto const & fixture = this->fixture();
+    auto align_cfg = fixture.config | align_cfg::result{align_cfg::with_trace};
+
+    std::vector database = fixture.sequence1;
+    std::vector query = fixture.sequence2;
+
+    auto alignment = align_pairwise(std::pair{database, query}, align_cfg);
+
+    auto res = *std::ranges::begin(alignment);
+    EXPECT_EQ(res.get_score(), fixture.score);
+    EXPECT_EQ(res.get_begin_coordinate(), fixture.begin_coordinate);
+    EXPECT_EQ(res.get_end_coordinate(), fixture.end_coordinate);
+    EXPECT_TRUE(ranges::equal(get<0>(res.get_alignment()) | view::to_char, fixture.aligned_sequence1));
+    EXPECT_TRUE(ranges::equal(get<1>(res.get_alignment()) | view::to_char, fixture.aligned_sequence2));
+}
+
+REGISTER_TYPED_TEST_CASE_P(global_affine_banded, score, end_position, begin_position, trace);
 
 // work around a bug that you can't specify more than 50 template arguments to ::testing::types
 INSTANTIATE_TYPED_TEST_CASE_P(global, global_affine_banded, global_affine_banded_types);

--- a/test/unit/alignment/pairwise/global_affine_unbanded_test.cpp
+++ b/test/unit/alignment/pairwise/global_affine_unbanded_test.cpp
@@ -53,19 +53,66 @@ using semi_global_affine_unbanded_types
 TYPED_TEST_P(global_affine_unbanded, score)
 {
     auto const & fixture = this->fixture();
-    // We only compute the score.
     auto align_cfg = fixture.config | align_cfg::result{align_cfg::with_score};
 
     std::vector database = fixture.sequence1;
     std::vector query = fixture.sequence2;
 
-    // TODO Make test work with ranges.
     auto alignment = align_pairwise(std::pair{database, query}, align_cfg);
 
     EXPECT_EQ((*std::ranges::begin(alignment)).get_score(), fixture.score);
 }
 
-REGISTER_TYPED_TEST_CASE_P(global_affine_unbanded, score);
+TYPED_TEST_P(global_affine_unbanded, end_position)
+{
+    auto const & fixture = this->fixture();
+    auto align_cfg = fixture.config | align_cfg::result{align_cfg::with_end_position};
+
+    std::vector database = fixture.sequence1;
+    std::vector query = fixture.sequence2;
+
+    auto alignment = align_pairwise(std::pair{database, query}, align_cfg);
+
+    auto res = *std::ranges::begin(alignment);
+    EXPECT_EQ(res.get_score(), fixture.score);
+    EXPECT_EQ(res.get_end_coordinate(), fixture.end_coordinate);
+}
+
+TYPED_TEST_P(global_affine_unbanded, begin_position)
+{
+    auto const & fixture = this->fixture();
+    auto align_cfg = fixture.config | align_cfg::result{align_cfg::with_begin_position};
+
+    std::vector database = fixture.sequence1;
+    std::vector query = fixture.sequence2;
+
+    auto alignment = align_pairwise(std::pair{database, query}, align_cfg);
+
+    auto res = *std::ranges::begin(alignment);
+    EXPECT_EQ(res.get_score(), fixture.score);
+    EXPECT_EQ(res.get_begin_coordinate(), fixture.begin_coordinate);
+    EXPECT_EQ(res.get_end_coordinate(), fixture.end_coordinate);
+}
+
+TYPED_TEST_P(global_affine_unbanded, trace)
+{
+    auto const & fixture = this->fixture();
+    auto align_cfg = fixture.config | align_cfg::result{align_cfg::with_trace};
+
+    std::vector database = fixture.sequence1;
+    std::vector query = fixture.sequence2;
+
+    auto alignment = align_pairwise(std::pair{database, query}, align_cfg);
+
+    auto res = *std::ranges::begin(alignment);
+    EXPECT_EQ(res.get_score(), fixture.score);
+    EXPECT_EQ(res.get_begin_coordinate(), fixture.begin_coordinate);
+    EXPECT_EQ(res.get_end_coordinate(), fixture.end_coordinate);
+    EXPECT_TRUE(ranges::equal(get<0>(res.get_alignment()) | view::to_char, fixture.gapped_sequence1));
+    EXPECT_TRUE(ranges::equal(get<1>(res.get_alignment()) | view::to_char, fixture.gapped_sequence2));
+}
+
+REGISTER_TYPED_TEST_CASE_P(global_affine_unbanded, score, end_position, begin_position, trace);
 
 INSTANTIATE_TYPED_TEST_CASE_P(global, global_affine_unbanded, global_affine_unbanded_types);
 INSTANTIATE_TYPED_TEST_CASE_P(semi_global, global_affine_unbanded, semi_global_affine_unbanded_types);

--- a/test/unit/alignment/pairwise/global_affine_unbanded_test.cpp
+++ b/test/unit/alignment/pairwise/global_affine_unbanded_test.cpp
@@ -108,8 +108,8 @@ TYPED_TEST_P(global_affine_unbanded, trace)
     EXPECT_EQ(res.get_score(), fixture.score);
     EXPECT_EQ(res.get_begin_coordinate(), fixture.begin_coordinate);
     EXPECT_EQ(res.get_end_coordinate(), fixture.end_coordinate);
-    EXPECT_TRUE(ranges::equal(get<0>(res.get_alignment()) | view::to_char, fixture.gapped_sequence1));
-    EXPECT_TRUE(ranges::equal(get<1>(res.get_alignment()) | view::to_char, fixture.gapped_sequence2));
+    EXPECT_TRUE(ranges::equal(get<0>(res.get_alignment()) | view::to_char, fixture.aligned_sequence1));
+    EXPECT_TRUE(ranges::equal(get<1>(res.get_alignment()) | view::to_char, fixture.aligned_sequence2));
 }
 
 REGISTER_TYPED_TEST_CASE_P(global_affine_unbanded, score, end_position, begin_position, trace);

--- a/test/unit/alignment/pairwise/policy/CMakeLists.txt
+++ b/test/unit/alignment/pairwise/policy/CMakeLists.txt
@@ -1,3 +1,4 @@
 seqan3_test (affine_gap_banded_init_policy_test.cpp)
 seqan3_test (affine_gap_banded_policy_test.cpp)
 seqan3_test (banded_score_dp_matrix_policy_test.cpp)
+seqan3_test (unbanded_score_trace_dp_matrix_policy_test.cpp)

--- a/test/unit/alignment/pairwise/policy/CMakeLists.txt
+++ b/test/unit/alignment/pairwise/policy/CMakeLists.txt
@@ -1,4 +1,5 @@
 seqan3_test (affine_gap_banded_init_policy_test.cpp)
 seqan3_test (affine_gap_banded_policy_test.cpp)
 seqan3_test (banded_score_dp_matrix_policy_test.cpp)
+seqan3_test (unbanded_score_dp_matrix_policy_test.cpp)
 seqan3_test (unbanded_score_trace_dp_matrix_policy_test.cpp)

--- a/test/unit/alignment/pairwise/policy/affine_gap_banded_init_policy_test.cpp
+++ b/test/unit/alignment/pairwise/policy/affine_gap_banded_init_policy_test.cpp
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 
 #include <seqan3/alignment/band/static_band.hpp>
+#include <seqan3/alignment/matrix/alignment_coordinate.hpp>
 #include <seqan3/alignment/matrix/alignment_optimum.hpp>
 #include <seqan3/alignment/pairwise/policy/affine_gap_banded_init_policy.hpp>
 #include <seqan3/alignment/scoring/gap_scheme.hpp>
@@ -36,48 +37,63 @@ TEST(affine_gap_banded_init_policy, construction)
 
 TEST(affine_gap_banded_init_policy, init_origin_cell)
 {
-    std::tuple cell{std::tuple{0, 0}, std::tuple{0, 0}};
-    std::tuple cache{std::tuple{0, 0}, -10, -1};
+    std::tuple cell{std::tuple{0, 0, std::ignore}, std::tuple{0, 0, std::ignore}};
+    std::tuple cache{std::tuple{0, 0, std::ignore}, -10, -1};
 
     affine_gap_banded_init_policy_mock mock{};
 
-    mock.init_origin_cell(std::make_tuple(std::ref(cell), std::ignore), cache);
+    mock.init_origin_cell(std::make_tuple(std::ref(cell), seqan3::alignment_coordinate{}, std::ignore), cache);
 
-    EXPECT_EQ(std::get<0>(cell), (std::tuple{0, -10}));
-    EXPECT_EQ(std::get<1>(cell), (std::tuple{0, 0}));
-    EXPECT_EQ(std::get<0>(cache), (std::tuple{0, -10}));
+    int first;
+    int second;
+    std::tie(first, second, std::ignore) = std::get<0>(cell);
+    EXPECT_EQ((std::tie(first, second)), (std::tuple{0, -10}));
+    std::tie(first, second, std::ignore) = std::get<1>(cell);
+    EXPECT_EQ((std::tie(first, second)), (std::tuple{0, 0}));
+    std::tie(first, second, std::ignore) = std::get<0>(cache);
+    EXPECT_EQ((std::tie(first, second)), (std::tuple{0, -10}));
     EXPECT_EQ(std::get<1>(cache), -10);
     EXPECT_EQ(std::get<2>(cache), -1);
 }
 
 TEST(affine_gap_banded_init_policy, init_column_cell)
 {
-    std::tuple cell{std::tuple{0, -10}, std::tuple{0, 0}};
-    std::tuple cache{std::tuple{0, -10}, -10, -1};
+    std::tuple cell{std::tuple{0, -10, std::ignore}, std::tuple{0, 0, std::ignore}};
+    std::tuple cache{std::tuple{0, -10, std::ignore}, -10, -1};
 
     affine_gap_banded_init_policy_mock mock{};
 
-    mock.init_column_cell(std::make_tuple(std::ref(cell), std::ignore), cache);
+    mock.init_column_cell(std::make_tuple(std::ref(cell), seqan3::alignment_coordinate{}, std::ignore), cache);
 
-    EXPECT_EQ(std::get<0>(cell), (std::tuple{-10, -20}));
-    EXPECT_EQ(std::get<1>(cell), (std::tuple{0, 0}));
-    EXPECT_EQ(std::get<0>(cache), (std::tuple{0, -11}));
+    int first;
+    int second;
+    std::tie(first, second, std::ignore) = std::get<0>(cell);
+    EXPECT_EQ((std::tie(first, second)), (std::tuple{-10, -20}));
+    std::tie(first, second, std::ignore) = std::get<1>(cell);
+    EXPECT_EQ((std::tie(first, second)), (std::tuple{0, 0}));
+    std::tie(first, second, std::ignore) = std::get<0>(cache);
+    EXPECT_EQ((std::tie(first, second)), (std::tuple{0, -11}));
     EXPECT_EQ(std::get<1>(cache), -10);
     EXPECT_EQ(std::get<2>(cache), -1);
 }
 
 TEST(affine_gap_banded_init_policy, init_row_cell)
 {
-    std::tuple cell{std::tuple{0, 0}, std::tuple{0, -10}};
-    std::tuple cache{std::tuple{0, 0}, -10, -1};
+    std::tuple cell{std::tuple{0, 0, std::ignore}, std::tuple{0, -10, std::ignore}};
+    std::tuple cache{std::tuple{0, 0, std::ignore}, -10, -1};
 
     affine_gap_banded_init_policy_mock mock{};
 
-    mock.init_row_cell(std::make_tuple(std::ref(cell), std::ignore), cache);
-
-    EXPECT_EQ(std::get<0>(cell), (std::tuple{-10, -11}));
-    EXPECT_EQ(std::get<1>(cell), (std::tuple{0, -10}));
-    EXPECT_EQ(std::get<0>(cache), (std::tuple{0, -20}));
+    mock.init_row_cell(std::make_tuple(std::ref(cell), seqan3::alignment_coordinate{}, std::ignore), cache);
+    
+    int first;
+    int second;
+    std::tie(first, second, std::ignore) = std::get<0>(cell);
+    EXPECT_EQ((std::tie(first, second)), (std::tuple{-10, -11}));
+    std::tie(first, second, std::ignore) = std::get<1>(cell);
+    EXPECT_EQ((std::tie(first, second)), (std::tuple{0, -10}));
+    std::tie(first, second, std::ignore) = std::get<0>(cache);
+    EXPECT_EQ((std::tie(first, second)), (std::tuple{0, -20}));
     EXPECT_EQ(std::get<1>(cache), -10);
     EXPECT_EQ(std::get<2>(cache), -1);
 }

--- a/test/unit/alignment/pairwise/policy/affine_gap_banded_init_policy_test.cpp
+++ b/test/unit/alignment/pairwise/policy/affine_gap_banded_init_policy_test.cpp
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 
 #include <seqan3/alignment/band/static_band.hpp>
+#include <seqan3/alignment/matrix/alignment_optimum.hpp>
 #include <seqan3/alignment/pairwise/policy/affine_gap_banded_init_policy.hpp>
 #include <seqan3/alignment/scoring/gap_scheme.hpp>
 
@@ -89,21 +90,22 @@ TEST(affine_gap_banded_init_policy, balance_leading_gaps)
     static_band band{lower_bound{-3}, upper_bound{3}};
     gap_scheme scheme{gap_score{-1}, gap_open_score{-10}};
     affine_gap_banded_init_policy_mock mock{};
-    //
-    int total = 0;
+
+    detail::alignment_optimum<int> total;
+    total.score = 0;
 
     mock.balance_leading_gaps(total, band, scheme);
-    EXPECT_EQ(total, 0);
+    EXPECT_EQ(total.score, 0);
 
     band.lower_bound = -4;
     band.upper_bound = -3;
 
     mock.balance_leading_gaps(total, band, scheme);
-    EXPECT_EQ(total, -13);
+    EXPECT_EQ(total.score, -13);
 
     band.lower_bound = 4;
     band.upper_bound = 10;
 
     mock.balance_leading_gaps(total, band, scheme);
-    EXPECT_EQ(total, -27);
+    EXPECT_EQ(total.score, -27);
 }

--- a/test/unit/alignment/pairwise/policy/affine_gap_banded_init_policy_test.cpp
+++ b/test/unit/alignment/pairwise/policy/affine_gap_banded_init_policy_test.cpp
@@ -40,7 +40,7 @@ TEST(affine_gap_banded_init_policy, init_origin_cell)
 
     affine_gap_banded_init_policy_mock mock{};
 
-    mock.init_origin_cell(cell, cache);
+    mock.init_origin_cell(std::make_tuple(std::ref(cell), std::ignore), cache);
 
     EXPECT_EQ(std::get<0>(cell), (std::tuple{0, -10}));
     EXPECT_EQ(std::get<1>(cell), (std::tuple{0, 0}));
@@ -56,7 +56,7 @@ TEST(affine_gap_banded_init_policy, init_column_cell)
 
     affine_gap_banded_init_policy_mock mock{};
 
-    mock.init_column_cell(cell, cache);
+    mock.init_column_cell(std::make_tuple(std::ref(cell), std::ignore), cache);
 
     EXPECT_EQ(std::get<0>(cell), (std::tuple{-10, -20}));
     EXPECT_EQ(std::get<1>(cell), (std::tuple{0, 0}));
@@ -72,7 +72,7 @@ TEST(affine_gap_banded_init_policy, init_row_cell)
 
     affine_gap_banded_init_policy_mock mock{};
 
-    mock.init_row_cell(cell, cache);
+    mock.init_row_cell(std::make_tuple(std::ref(cell), std::ignore), cache);
 
     EXPECT_EQ(std::get<0>(cell), (std::tuple{-10, -11}));
     EXPECT_EQ(std::get<1>(cell), (std::tuple{0, -10}));

--- a/test/unit/alignment/pairwise/policy/affine_gap_banded_policy_test.cpp
+++ b/test/unit/alignment/pairwise/policy/affine_gap_banded_policy_test.cpp
@@ -74,7 +74,7 @@ TEST(affine_gap_banded_policy, compute_first_band_cell)
 
     {  // max from diagonal
         std::tuple cell{std::tuple{0, -10}, std::tuple{-11, -20}};
-        mock.compute_first_band_cell(cell, cache, 5);
+        mock.compute_first_band_cell(std::make_tuple(std::ref(cell), std::ignore), cache, 5);
 
         EXPECT_EQ(std::get<0>(cell), (std::tuple{5, -10}));
         EXPECT_EQ(std::get<1>(cell), (std::tuple{-11, -20}));
@@ -85,7 +85,7 @@ TEST(affine_gap_banded_policy, compute_first_band_cell)
 
     {  // max from horizontal
         std::tuple cell{std::tuple{0, -10}, std::tuple{-11, -20}};
-        mock.compute_first_band_cell(cell, cache, -25);
+        mock.compute_first_band_cell(std::make_tuple(std::ref(cell), std::ignore), cache, -25);
 
         EXPECT_EQ(std::get<0>(cell), (std::tuple{-20, -10}));
         EXPECT_EQ(std::get<1>(cell), (std::tuple{-11, -20}));
@@ -97,7 +97,7 @@ TEST(affine_gap_banded_policy, compute_first_band_cell)
     {  // max from vertical - ignored in the computation.
         std::get<0>(cache) = std::tuple{0, 10};
         std::tuple cell{std::tuple{0, -10}, std::tuple{-11, -20}};
-        mock.compute_first_band_cell(cell, cache, -10);
+        mock.compute_first_band_cell(std::make_tuple(std::ref(cell), std::ignore), cache, -10);
 
         EXPECT_EQ(std::get<0>(cell), (std::tuple{-10, -10}));
         EXPECT_EQ(std::get<1>(cell), (std::tuple{-11, -20}));
@@ -117,7 +117,7 @@ TEST(affine_gap_banded_policy, compute_cell)
     { // max from diagonal
         std::get<0>(cache) = std::tuple{0, -4};
         std::tuple cell{std::tuple{0, -10}, std::tuple{-11, -20}};
-        mock.compute_cell(cell, cache, 5);
+        mock.compute_cell(std::make_tuple(std::ref(cell), std::ignore), cache, 5);
 
         EXPECT_EQ(std::get<0>(cell), (std::tuple{5, -6}));
         EXPECT_EQ(std::get<1>(cell), (std::tuple{-11, -20}));
@@ -129,7 +129,7 @@ TEST(affine_gap_banded_policy, compute_cell)
     { // max from horizontal
         std::get<0>(cache) = std::tuple{0, -15};
         std::tuple cell{std::tuple{0, -10}, std::tuple{-11, -3}};
-        mock.compute_cell(cell, cache, -10);
+        mock.compute_cell(std::make_tuple(std::ref(cell), std::ignore), cache, -10);
 
         EXPECT_EQ(std::get<0>(cell), (std::tuple{-3, -4}));
         EXPECT_EQ(std::get<1>(cell), (std::tuple{-11, -3}));
@@ -141,7 +141,7 @@ TEST(affine_gap_banded_policy, compute_cell)
     {  // max from vertical
         std::get<0>(cache) = std::tuple{0, -3};
         std::tuple cell{std::tuple{0, -10}, std::tuple{-11, -4}};
-        mock.compute_cell(cell, cache, -10);
+        mock.compute_cell(std::make_tuple(std::ref(cell), std::ignore), cache, -10);
 
         EXPECT_EQ(std::get<0>(cell), (std::tuple{-3, -5}));
         EXPECT_EQ(std::get<1>(cell), (std::tuple{-11, -4}));

--- a/test/unit/alignment/pairwise/policy/affine_gap_banded_policy_test.cpp
+++ b/test/unit/alignment/pairwise/policy/affine_gap_banded_policy_test.cpp
@@ -15,7 +15,8 @@ struct check_score_mock
 public:
 
     template <typename score_t>
-    constexpr void check_score(score_t const &, score_t const &) const noexcept
+    constexpr void check_score(seqan3::detail::alignment_optimum<score_t> const &,
+                               seqan3::detail::alignment_optimum<score_t> const &) const noexcept
     {}
 };
 
@@ -59,7 +60,7 @@ TEST(affine_gap_banded_policy, make_cache)
     EXPECT_TRUE((std::is_same_v<cell_t, std::tuple<int, int>>));
     EXPECT_TRUE((std::is_same_v<gap_open_t, int>));
     EXPECT_TRUE((std::is_same_v<gap_extension_t, int>));
-    EXPECT_TRUE((std::is_same_v<optimum_t, int>));
+    EXPECT_TRUE((std::is_same_v<optimum_t, seqan3::detail::alignment_optimum<int>>));
 
     EXPECT_EQ(std::get<1>(cache), -11);
     EXPECT_EQ(std::get<2>(cache), -1);
@@ -67,14 +68,20 @@ TEST(affine_gap_banded_policy, make_cache)
 
 TEST(affine_gap_banded_policy, compute_first_band_cell)
 {
+    using namespace seqan3;
+    using namespace seqan3::detail;
+
     affine_gap_banded_policy_mock<std::tuple<int, int>> mock{};
 
-    seqan3::gap_scheme scheme{seqan3::gap_score{-1}, seqan3::gap_open_score{-10}};
+    gap_scheme scheme{gap_score{-1}, gap_open_score{-10}};
     auto cache = mock.make_cache(scheme);
 
     {  // max from diagonal
         std::tuple cell{std::tuple{0, -10}, std::tuple{-11, -20}};
-        mock.compute_first_band_cell(std::make_tuple(std::ref(cell), std::ignore), cache, 5);
+        mock.compute_first_band_cell(std::make_tuple(std::ref(cell),
+                                                     alignment_coordinate{column_index_type{3u}, row_index_type{5u}},
+                                                     std::ignore),
+                                     cache, 5);
 
         EXPECT_EQ(std::get<0>(cell), (std::tuple{5, -10}));
         EXPECT_EQ(std::get<1>(cell), (std::tuple{-11, -20}));
@@ -85,7 +92,11 @@ TEST(affine_gap_banded_policy, compute_first_band_cell)
 
     {  // max from horizontal
         std::tuple cell{std::tuple{0, -10}, std::tuple{-11, -20}};
-        mock.compute_first_band_cell(std::make_tuple(std::ref(cell), std::ignore), cache, -25);
+        mock.compute_first_band_cell(std::make_tuple(std::ref(cell),
+                                                     alignment_coordinate{column_index_type{3u}, row_index_type{5u}},
+                                                     std::ignore),
+                                     cache,
+                                     -25);
 
         EXPECT_EQ(std::get<0>(cell), (std::tuple{-20, -10}));
         EXPECT_EQ(std::get<1>(cell), (std::tuple{-11, -20}));
@@ -97,7 +108,11 @@ TEST(affine_gap_banded_policy, compute_first_band_cell)
     {  // max from vertical - ignored in the computation.
         std::get<0>(cache) = std::tuple{0, 10};
         std::tuple cell{std::tuple{0, -10}, std::tuple{-11, -20}};
-        mock.compute_first_band_cell(std::make_tuple(std::ref(cell), std::ignore), cache, -10);
+        mock.compute_first_band_cell(std::make_tuple(std::ref(cell),
+                                                     alignment_coordinate{column_index_type{3u}, row_index_type{5u}},
+                                                     std::ignore),
+                                     cache,
+                                     -10);
 
         EXPECT_EQ(std::get<0>(cell), (std::tuple{-10, -10}));
         EXPECT_EQ(std::get<1>(cell), (std::tuple{-11, -20}));
@@ -109,15 +124,22 @@ TEST(affine_gap_banded_policy, compute_first_band_cell)
 
 TEST(affine_gap_banded_policy, compute_cell)
 {
+    using namespace seqan3;
+    using namespace seqan3::detail;
+
     affine_gap_banded_policy_mock<std::tuple<int, int>> mock{};
 
-    seqan3::gap_scheme scheme{seqan3::gap_score{-1}, seqan3::gap_open_score{-10}};
+    gap_scheme scheme{gap_score{-1}, gap_open_score{-10}};
     auto cache = mock.make_cache(scheme);
 
     { // max from diagonal
         std::get<0>(cache) = std::tuple{0, -4};
         std::tuple cell{std::tuple{0, -10}, std::tuple{-11, -20}};
-        mock.compute_cell(std::make_tuple(std::ref(cell), std::ignore), cache, 5);
+        mock.compute_cell(std::make_tuple(std::ref(cell),
+                                          alignment_coordinate{column_index_type{3u}, row_index_type{5u}},
+                                          std::ignore),
+                          cache,
+                          5);
 
         EXPECT_EQ(std::get<0>(cell), (std::tuple{5, -6}));
         EXPECT_EQ(std::get<1>(cell), (std::tuple{-11, -20}));
@@ -129,7 +151,11 @@ TEST(affine_gap_banded_policy, compute_cell)
     { // max from horizontal
         std::get<0>(cache) = std::tuple{0, -15};
         std::tuple cell{std::tuple{0, -10}, std::tuple{-11, -3}};
-        mock.compute_cell(std::make_tuple(std::ref(cell), std::ignore), cache, -10);
+        mock.compute_cell(std::make_tuple(std::ref(cell),
+                                          alignment_coordinate{column_index_type{3u}, row_index_type{5u}},
+                                          std::ignore),
+                          cache,
+                          -10);
 
         EXPECT_EQ(std::get<0>(cell), (std::tuple{-3, -4}));
         EXPECT_EQ(std::get<1>(cell), (std::tuple{-11, -3}));
@@ -141,7 +167,11 @@ TEST(affine_gap_banded_policy, compute_cell)
     {  // max from vertical
         std::get<0>(cache) = std::tuple{0, -3};
         std::tuple cell{std::tuple{0, -10}, std::tuple{-11, -4}};
-        mock.compute_cell(std::make_tuple(std::ref(cell), std::ignore), cache, -10);
+        mock.compute_cell(std::make_tuple(std::ref(cell),
+                                          alignment_coordinate{column_index_type{3u}, row_index_type{5u}},
+                                          std::ignore),
+                          cache,
+                          -10);
 
         EXPECT_EQ(std::get<0>(cell), (std::tuple{-3, -5}));
         EXPECT_EQ(std::get<1>(cell), (std::tuple{-11, -4}));

--- a/test/unit/alignment/pairwise/policy/affine_gap_banded_policy_test.cpp
+++ b/test/unit/alignment/pairwise/policy/affine_gap_banded_policy_test.cpp
@@ -35,17 +35,17 @@ public:
 
 TEST(affine_gap_banded_policy, construction)
 {
-    EXPECT_TRUE((std::is_default_constructible_v<affine_gap_banded_policy_mock<std::tuple<int, int>>>));
-    EXPECT_TRUE((std::is_copy_constructible_v<affine_gap_banded_policy_mock<std::tuple<int, int>>>));
-    EXPECT_TRUE((std::is_move_constructible_v<affine_gap_banded_policy_mock<std::tuple<int, int>>>));
-    EXPECT_TRUE((std::is_copy_assignable_v<affine_gap_banded_policy_mock<std::tuple<int, int>>>));
-    EXPECT_TRUE((std::is_move_assignable_v<affine_gap_banded_policy_mock<std::tuple<int, int>>>));
-    EXPECT_TRUE((std::is_destructible_v<affine_gap_banded_policy_mock<std::tuple<int, int>>>));
+    EXPECT_TRUE((std::is_default_constructible_v<affine_gap_banded_policy_mock<std::tuple<int, int, seqan3::detail::ignore_t>>>));
+    EXPECT_TRUE((std::is_copy_constructible_v<affine_gap_banded_policy_mock<std::tuple<int, int, seqan3::detail::ignore_t>>>));
+    EXPECT_TRUE((std::is_move_constructible_v<affine_gap_banded_policy_mock<std::tuple<int, int, seqan3::detail::ignore_t>>>));
+    EXPECT_TRUE((std::is_copy_assignable_v<affine_gap_banded_policy_mock<std::tuple<int, int, seqan3::detail::ignore_t>>>));
+    EXPECT_TRUE((std::is_move_assignable_v<affine_gap_banded_policy_mock<std::tuple<int, int, seqan3::detail::ignore_t>>>));
+    EXPECT_TRUE((std::is_destructible_v<affine_gap_banded_policy_mock<std::tuple<int, int, seqan3::detail::ignore_t>>>));
 }
 
 TEST(affine_gap_banded_policy, make_cache)
 {
-    affine_gap_banded_policy_mock<std::tuple<int, int>> mock{};
+    affine_gap_banded_policy_mock<std::tuple<int, int, seqan3::detail::ignore_t>> mock{};
 
     seqan3::gap_scheme scheme{seqan3::gap_score{-1}, seqan3::gap_open_score{-10}};
     auto cache = mock.make_cache(scheme);
@@ -57,7 +57,7 @@ TEST(affine_gap_banded_policy, make_cache)
     using gap_extension_t = std::tuple_element_t<2, decltype(cache)>;
     using optimum_t = std::tuple_element_t<3, decltype(cache)>;
 
-    EXPECT_TRUE((std::is_same_v<cell_t, std::tuple<int, int>>));
+    EXPECT_TRUE((std::is_same_v<cell_t, std::tuple<int, int, seqan3::detail::ignore_t>>));
     EXPECT_TRUE((std::is_same_v<gap_open_t, int>));
     EXPECT_TRUE((std::is_same_v<gap_extension_t, int>));
     EXPECT_TRUE((std::is_same_v<optimum_t, seqan3::detail::alignment_optimum<int>>));
@@ -71,52 +71,67 @@ TEST(affine_gap_banded_policy, compute_first_band_cell)
     using namespace seqan3;
     using namespace seqan3::detail;
 
-    affine_gap_banded_policy_mock<std::tuple<int, int>> mock{};
+    affine_gap_banded_policy_mock<std::tuple<int, int, seqan3::detail::ignore_t>> mock{};
 
     gap_scheme scheme{gap_score{-1}, gap_open_score{-10}};
     auto cache = mock.make_cache(scheme);
 
     {  // max from diagonal
-        std::tuple cell{std::tuple{0, -10}, std::tuple{-11, -20}};
+        std::tuple cell{std::tuple{0, -10, std::ignore}, std::tuple{-11, -20, std::ignore}};
         mock.compute_first_band_cell(std::make_tuple(std::ref(cell),
                                                      alignment_coordinate{column_index_type{3u}, row_index_type{5u}},
                                                      std::ignore),
                                      cache, 5);
 
-        EXPECT_EQ(std::get<0>(cell), (std::tuple{5, -10}));
-        EXPECT_EQ(std::get<1>(cell), (std::tuple{-11, -20}));
-        EXPECT_EQ(std::get<0>(cache), (std::tuple{0, -6}));
+        int first;
+        int second;
+        std::tie(first, second, std::ignore) = std::get<0>(cell);
+        EXPECT_EQ((std::tie(first, second)), (std::tuple{5, -10}));
+        std::tie(first, second, std::ignore) = std::get<1>(cell);
+        EXPECT_EQ((std::tie(first, second)), (std::tuple{-11, -20}));
+        std::tie(first, second, std::ignore) = std::get<0>(cache);
+        EXPECT_EQ((std::tie(first, second)), (std::tuple{0, -6}));
         EXPECT_EQ(std::get<1>(cache), -11);
         EXPECT_EQ(std::get<2>(cache), -1);
     }
 
     {  // max from horizontal
-        std::tuple cell{std::tuple{0, -10}, std::tuple{-11, -20}};
+        std::tuple cell{std::tuple{0, -10, std::ignore}, std::tuple{-11, -20, std::ignore}};
         mock.compute_first_band_cell(std::make_tuple(std::ref(cell),
                                                      alignment_coordinate{column_index_type{3u}, row_index_type{5u}},
                                                      std::ignore),
                                      cache,
                                      -25);
 
-        EXPECT_EQ(std::get<0>(cell), (std::tuple{-20, -10}));
-        EXPECT_EQ(std::get<1>(cell), (std::tuple{-11, -20}));
-        EXPECT_EQ(std::get<0>(cache), (std::tuple{0, -31}));
+        int first;
+        int second;
+        std::tie(first, second, std::ignore) = std::get<0>(cell);
+        EXPECT_EQ((std::tie(first, second)), (std::tuple{-20, -10}));
+        std::tie(first, second, std::ignore) = std::get<1>(cell);
+        EXPECT_EQ((std::tie(first, second)), (std::tuple{-11, -20}));
+        std::tie(first, second, std::ignore) = std::get<0>(cache);
+        EXPECT_EQ((std::tie(first, second)), (std::tuple{0, -31}));
         EXPECT_EQ(std::get<1>(cache), -11);
         EXPECT_EQ(std::get<2>(cache), -1);
     }
 
     {  // max from vertical - ignored in the computation.
-        std::get<0>(cache) = std::tuple{0, 10};
-        std::tuple cell{std::tuple{0, -10}, std::tuple{-11, -20}};
+        std::get<0>(cache) = std::tuple{0, 10, std::ignore};
+        std::tuple cell{std::tuple{0, -10, std::ignore}, std::tuple{-11, -20, std::ignore}};
         mock.compute_first_band_cell(std::make_tuple(std::ref(cell),
                                                      alignment_coordinate{column_index_type{3u}, row_index_type{5u}},
                                                      std::ignore),
                                      cache,
                                      -10);
 
-        EXPECT_EQ(std::get<0>(cell), (std::tuple{-10, -10}));
-        EXPECT_EQ(std::get<1>(cell), (std::tuple{-11, -20}));
-        EXPECT_EQ(std::get<0>(cache), (std::tuple{0, -21}));
+        int first;
+        int second;
+        std::tie(first, second, std::ignore) = std::get<0>(cell);
+        EXPECT_EQ((std::tie(first, second)), (std::tuple{-10, -10}));
+        std::tie(first, second, std::ignore) = std::get<1>(cell);
+        EXPECT_EQ((std::tie(first, second)), (std::tuple{-11, -20}));
+        std::tie(first, second, std::ignore) = std::get<0>(cache);
+        EXPECT_EQ((std::tie(first, second)), (std::tuple{0, -21}));
         EXPECT_EQ(std::get<1>(cache), -11);
         EXPECT_EQ(std::get<2>(cache), -1);
     }
@@ -127,55 +142,69 @@ TEST(affine_gap_banded_policy, compute_cell)
     using namespace seqan3;
     using namespace seqan3::detail;
 
-    affine_gap_banded_policy_mock<std::tuple<int, int>> mock{};
+    affine_gap_banded_policy_mock<std::tuple<int, int, seqan3::detail::ignore_t>> mock{};
 
     gap_scheme scheme{gap_score{-1}, gap_open_score{-10}};
     auto cache = mock.make_cache(scheme);
 
     { // max from diagonal
-        std::get<0>(cache) = std::tuple{0, -4};
-        std::tuple cell{std::tuple{0, -10}, std::tuple{-11, -20}};
+        std::get<0>(cache) = std::tuple{0, -4, std::ignore};
+        std::tuple cell{std::tuple{0, -10, std::ignore}, std::tuple{-11, -20, std::ignore}};
         mock.compute_cell(std::make_tuple(std::ref(cell),
                                           alignment_coordinate{column_index_type{3u}, row_index_type{5u}},
                                           std::ignore),
                           cache,
                           5);
-
-        EXPECT_EQ(std::get<0>(cell), (std::tuple{5, -6}));
-        EXPECT_EQ(std::get<1>(cell), (std::tuple{-11, -20}));
-        EXPECT_EQ(std::get<0>(cache), (std::tuple{-6, -5}));
+        int first;
+        int second;
+        std::tie(first, second, std::ignore) = std::get<0>(cell);
+        EXPECT_EQ((std::tie(first, second)), (std::tuple{5, -6}));
+        std::tie(first, second, std::ignore) = std::get<1>(cell);
+        EXPECT_EQ((std::tie(first, second)), (std::tuple{-11, -20}));
+        std::tie(first, second, std::ignore) = std::get<0>(cache);
+        EXPECT_EQ((std::tie(first, second)), (std::tuple{-6, -5}));
         EXPECT_EQ(std::get<1>(cache), -11);
         EXPECT_EQ(std::get<2>(cache), -1);
     }
 
     { // max from horizontal
-        std::get<0>(cache) = std::tuple{0, -15};
-        std::tuple cell{std::tuple{0, -10}, std::tuple{-11, -3}};
+        std::get<0>(cache) = std::tuple{0, -15, std::ignore};
+        std::tuple cell{std::tuple{0, -10, std::ignore}, std::tuple{-11, -3, std::ignore}};
         mock.compute_cell(std::make_tuple(std::ref(cell),
                                           alignment_coordinate{column_index_type{3u}, row_index_type{5u}},
                                           std::ignore),
                           cache,
                           -10);
 
-        EXPECT_EQ(std::get<0>(cell), (std::tuple{-3, -4}));
-        EXPECT_EQ(std::get<1>(cell), (std::tuple{-11, -3}));
-        EXPECT_EQ(std::get<0>(cache), (std::tuple{-14, -14}));
+        int first;
+        int second;
+        std::tie(first, second, std::ignore) = std::get<0>(cell);
+        EXPECT_EQ((std::tie(first, second)), (std::tuple{-3, -4}));
+        std::tie(first, second, std::ignore) = std::get<1>(cell);
+        EXPECT_EQ((std::tie(first, second)), (std::tuple{-11, -3}));
+        std::tie(first, second, std::ignore) = std::get<0>(cache);
+        EXPECT_EQ((std::tie(first, second)), (std::tuple{-14, -14}));
         EXPECT_EQ(std::get<1>(cache), -11);
         EXPECT_EQ(std::get<2>(cache), -1);
     }
 
     {  // max from vertical
-        std::get<0>(cache) = std::tuple{0, -3};
-        std::tuple cell{std::tuple{0, -10}, std::tuple{-11, -4}};
+        std::get<0>(cache) = std::tuple{0, -3, std::ignore};
+        std::tuple cell{std::tuple{0, -10, std::ignore}, std::tuple{-11, -4, std::ignore}};
         mock.compute_cell(std::make_tuple(std::ref(cell),
                                           alignment_coordinate{column_index_type{3u}, row_index_type{5u}},
                                           std::ignore),
                           cache,
                           -10);
 
-        EXPECT_EQ(std::get<0>(cell), (std::tuple{-3, -5}));
-        EXPECT_EQ(std::get<1>(cell), (std::tuple{-11, -4}));
-        EXPECT_EQ(std::get<0>(cache), (std::tuple{-14, -4}));
+        int first;
+        int second;
+        std::tie(first, second, std::ignore) = std::get<0>(cell);
+        EXPECT_EQ((std::tie(first, second)), (std::tuple{-3, -5}));
+        std::tie(first, second, std::ignore) = std::get<1>(cell);
+        EXPECT_EQ((std::tie(first, second)), (std::tuple{-11, -4}));
+        std::tie(first, second, std::ignore) = std::get<0>(cache);
+        EXPECT_EQ((std::tie(first, second)), (std::tuple{-14, -4}));
         EXPECT_EQ(std::get<1>(cache), -11);
         EXPECT_EQ(std::get<2>(cache), -1);
     }

--- a/test/unit/alignment/pairwise/policy/banded_score_dp_matrix_policy_test.cpp
+++ b/test/unit/alignment/pairwise/policy/banded_score_dp_matrix_policy_test.cpp
@@ -41,7 +41,7 @@ public:
     // Member functions
     using base_t::second_range_begin_offset;
     using base_t::current_band_size;
-    using base_t::next_column;
+    using base_t::go_next_column;
     using base_t::current_column;
     using base_t::allocate_matrix;
 };
@@ -86,29 +86,29 @@ TEST(banded_score_dp_matrix_policy, allocate_matrix)
     EXPECT_EQ(std::get<1>(last_cell), decltype(mock)::INF);
 }
 
-TEST(banded_score_dp_matrix_policy, next_column)
+TEST(banded_score_dp_matrix_policy, go_next_column)
 {
     auto mock = mock_factory();
 
     EXPECT_EQ(mock.current_column_index, 0u);
     EXPECT_NE(mock.current_matrix_iter, std::ranges::begin(mock.score_matrix));
 
-    mock.next_column();
+    mock.go_next_column();
     EXPECT_EQ(mock.current_column_index, 1u);
     EXPECT_NE(mock.current_matrix_iter, std::ranges::begin(mock.score_matrix));
-    mock.next_column();
+    mock.go_next_column();
     EXPECT_EQ(mock.current_column_index, 2u);
     EXPECT_NE(mock.current_matrix_iter, std::ranges::begin(mock.score_matrix));
-    mock.next_column();
+    mock.go_next_column();
     EXPECT_EQ(mock.current_column_index, 3u);
     EXPECT_NE(mock.current_matrix_iter, std::ranges::begin(mock.score_matrix));
-    mock.next_column();
+    mock.go_next_column();
     EXPECT_EQ(mock.current_column_index, 4u);
     EXPECT_NE(mock.current_matrix_iter, std::ranges::begin(mock.score_matrix));
-    mock.next_column();
+    mock.go_next_column();
     EXPECT_EQ(mock.current_column_index, 5u);
     EXPECT_EQ(mock.current_matrix_iter, std::ranges::begin(mock.score_matrix));
-    mock.next_column();
+    mock.go_next_column();
     EXPECT_EQ(mock.current_column_index, 6u);
     EXPECT_EQ(mock.current_matrix_iter, std::ranges::begin(mock.score_matrix));
 }
@@ -124,7 +124,7 @@ TEST(banded_score_dp_matrix_policy, current_band_size)
     {
         // Band increases by one as long as it is
         EXPECT_EQ(mock.current_band_size(), 8 + s);
-        mock.next_column();
+        mock.go_next_column();
     }
 
     // After that the band size does not change until the end of second range is reached.
@@ -132,7 +132,7 @@ TEST(banded_score_dp_matrix_policy, current_band_size)
     {
         // Band increases by one as long as it is
         EXPECT_EQ(mock.current_band_size(), 13u);
-        mock.next_column();
+        mock.go_next_column();
     }
 
     // When the band reaches the end it will be decreased by one
@@ -140,7 +140,7 @@ TEST(banded_score_dp_matrix_policy, current_band_size)
     {
         // Band increases by one as long as it is
         EXPECT_EQ(mock.current_band_size(), 13 - (s - 10u));
-        mock.next_column();
+        mock.go_next_column();
     }
 }
 
@@ -179,14 +179,14 @@ TEST(banded_score_dp_matrix_policy, second_range_begin_offset)
 
     // move to the first column behind the band position in first row.
     for (unsigned i = 0u; i < 6; ++i)
-        mock.next_column();
+        mock.go_next_column();
 
     EXPECT_EQ(mock.second_range_begin_offset(), 0u);
-    mock.next_column();
+    mock.go_next_column();
     EXPECT_EQ(mock.second_range_begin_offset(), 1u);
-    mock.next_column();
+    mock.go_next_column();
     EXPECT_EQ(mock.second_range_begin_offset(), 2u);
-    mock.next_column();
+    mock.go_next_column();
     EXPECT_EQ(mock.second_range_begin_offset(), 3u);
 }
 
@@ -199,13 +199,13 @@ TEST(banded_score_dp_matrix_policy, band_touches_last_row)
     for (unsigned i = 0; i < 10u; ++i)
     {
         EXPECT_FALSE(mock.band_touches_last_row());
-        mock.next_column();
+        mock.go_next_column();
     }
 
     for (unsigned i = 10; i < 14u; ++i)
     {
         EXPECT_TRUE(mock.band_touches_last_row());
-        mock.next_column();
+        mock.go_next_column();
     }
 }
 

--- a/test/unit/alignment/pairwise/policy/banded_score_dp_matrix_policy_test.cpp
+++ b/test/unit/alignment/pairwise/policy/banded_score_dp_matrix_policy_test.cpp
@@ -149,19 +149,22 @@ TEST(banded_score_dp_matrix_policy, current_column)
 
     auto mock = mock_factory();
 
-    auto col = mock.current_column();
+    auto col = mock.current_column() | detail::view_get_score_column;
+
     EXPECT_EQ(std::tuple_size_v<value_type_t<decltype(col)>>, 2u);
     EXPECT_EQ(seqan3::size(col), 4u);
 
     // Writing into the first value means writing into the second value
-    for (auto tpl : col)
-        std::get<0>(tpl) = std::tuple{-1, -1};
+    for (auto && tpl : col)
+    {
+        std::get<0>(std::forward<decltype(tpl)>(tpl)) = std::tuple{-1, -1};
+    }
 
-    for (auto tpl : col | view::take_exactly(3u))
-        EXPECT_EQ(std::get<1>(tpl), (std::tuple{-1, -1}));
+    for (auto && tpl : col | view::take_exactly(3u))
+        EXPECT_EQ(std::get<1>(std::forward<decltype(tpl)>(tpl)), (std::tuple{-1, -1}));
 
-
-    EXPECT_EQ(std::get<1>(*(--seqan3::end(col))), (std::tuple{decltype(mock)::INF, decltype(mock)::INF}));
+    EXPECT_EQ(std::get<1>(*std::ranges::prev(seqan3::end(col))),
+              (std::tuple{decltype(mock)::INF, decltype(mock)::INF}));
 }
 
 TEST(banded_score_dp_matrix_policy, second_range_begin_offset)

--- a/test/unit/alignment/pairwise/policy/banded_score_dp_matrix_policy_test.cpp
+++ b/test/unit/alignment/pairwise/policy/banded_score_dp_matrix_policy_test.cpp
@@ -79,9 +79,9 @@ TEST(banded_score_dp_matrix_policy, allocate_matrix)
     EXPECT_EQ(mock.dimension_second_range, 18u);
     EXPECT_EQ(mock.band_column_index, 5u);
     EXPECT_EQ(mock.band_row_index, 3u);
-    EXPECT_NE(mock.current_matrix_iter, seqan3::begin(mock.score_matrix));
+    EXPECT_NE(mock.current_matrix_iter, std::ranges::begin(mock.score_matrix));
 
-    auto last_cell = *std::ranges::prev(seqan3::end(mock.score_matrix));
+    auto last_cell = *std::ranges::prev(std::ranges::end(mock.score_matrix));
     EXPECT_EQ(std::get<0>(last_cell), decltype(mock)::INF);
     EXPECT_EQ(std::get<1>(last_cell), decltype(mock)::INF);
 }
@@ -91,26 +91,26 @@ TEST(banded_score_dp_matrix_policy, next_column)
     auto mock = mock_factory();
 
     EXPECT_EQ(mock.current_column_index, 0u);
-    EXPECT_NE(mock.current_matrix_iter, seqan3::begin(mock.score_matrix));
+    EXPECT_NE(mock.current_matrix_iter, std::ranges::begin(mock.score_matrix));
 
     mock.next_column();
     EXPECT_EQ(mock.current_column_index, 1u);
-    EXPECT_NE(mock.current_matrix_iter, seqan3::begin(mock.score_matrix));
+    EXPECT_NE(mock.current_matrix_iter, std::ranges::begin(mock.score_matrix));
     mock.next_column();
     EXPECT_EQ(mock.current_column_index, 2u);
-    EXPECT_NE(mock.current_matrix_iter, seqan3::begin(mock.score_matrix));
+    EXPECT_NE(mock.current_matrix_iter, std::ranges::begin(mock.score_matrix));
     mock.next_column();
     EXPECT_EQ(mock.current_column_index, 3u);
-    EXPECT_NE(mock.current_matrix_iter, seqan3::begin(mock.score_matrix));
+    EXPECT_NE(mock.current_matrix_iter, std::ranges::begin(mock.score_matrix));
     mock.next_column();
     EXPECT_EQ(mock.current_column_index, 4u);
-    EXPECT_NE(mock.current_matrix_iter, seqan3::begin(mock.score_matrix));
+    EXPECT_NE(mock.current_matrix_iter, std::ranges::begin(mock.score_matrix));
     mock.next_column();
     EXPECT_EQ(mock.current_column_index, 5u);
-    EXPECT_EQ(mock.current_matrix_iter, seqan3::begin(mock.score_matrix));
+    EXPECT_EQ(mock.current_matrix_iter, std::ranges::begin(mock.score_matrix));
     mock.next_column();
     EXPECT_EQ(mock.current_column_index, 6u);
-    EXPECT_EQ(mock.current_matrix_iter, seqan3::begin(mock.score_matrix));
+    EXPECT_EQ(mock.current_matrix_iter, std::ranges::begin(mock.score_matrix));
 }
 
 TEST(banded_score_dp_matrix_policy, current_band_size)
@@ -153,7 +153,7 @@ TEST(banded_score_dp_matrix_policy, current_column)
     auto col = mock.current_column() | detail::view_get_score_column;
 
     EXPECT_EQ(std::tuple_size_v<value_type_t<decltype(col)>>, 2u);
-    EXPECT_EQ(seqan3::size(col), 4u);
+    EXPECT_EQ(std::ranges::size(col), 4u);
 
     // Writing into the first value means writing into the second value
     for (auto && tpl : col)
@@ -169,8 +169,8 @@ TEST(banded_score_dp_matrix_policy, current_column)
         EXPECT_EQ((std::tie(first, second)), (std::tuple{-1, -1}));
     }
 
-    EXPECT_EQ(std::get<0>(std::get<1>(*std::ranges::prev(seqan3::end(col)))), decltype(mock)::INF);
-    EXPECT_EQ(std::get<1>(std::get<1>(*std::ranges::prev(seqan3::end(col)))), decltype(mock)::INF);
+    EXPECT_EQ(std::get<0>(std::get<1>(*std::ranges::prev(std::ranges::end(col)))), decltype(mock)::INF);
+    EXPECT_EQ(std::get<1>(std::get<1>(*std::ranges::prev(std::ranges::end(col)))), decltype(mock)::INF);
 }
 
 TEST(banded_score_dp_matrix_policy, second_range_begin_offset)
@@ -224,7 +224,7 @@ TEST(banded_score_dp_matrix_policy, trim_sequences)
         auto [t_seq1, t_seq2] = mock.trim_sequences(seq1, seq2, band);
         EXPECT_TRUE(ranges::equal(t_seq1, seq1));
         EXPECT_TRUE(ranges::equal(t_seq2, seq2));
-        EXPECT_EQ(seqan3::size(t_seq1), seqan3::size(t_seq2));
+        EXPECT_EQ(std::ranges::size(t_seq1), std::ranges::size(t_seq2));
     }
 
     {

--- a/test/unit/alignment/pairwise/policy/unbanded_score_dp_matrix_policy_test.cpp
+++ b/test/unit/alignment/pairwise/policy/unbanded_score_dp_matrix_policy_test.cpp
@@ -1,0 +1,150 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2018, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2018, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include <range/v3/view/bounded.hpp>
+
+#include <seqan3/alignment/pairwise/policy/unbanded_dp_matrix_policy.hpp>
+#include <seqan3/core/metafunction/basic.hpp>
+#include <seqan3/core/metafunction/template_inspection.hpp>
+#include <seqan3/std/iterator>
+#include <seqan3/std/ranges>
+
+template <typename score_alloc_t>
+struct policy_mock :
+    public seqan3::detail::unbanded_dp_matrix_policy<policy_mock<score_alloc_t>, score_alloc_t>
+{
+public:
+
+    using base_t = seqan3::detail::unbanded_dp_matrix_policy<policy_mock<score_alloc_t>, score_alloc_t>;
+
+    using base_t::base_t;
+
+    using base_t::allocate_matrix;
+    using base_t::current_column;
+    using base_t::next_column;
+
+    using base_t::dimension_first_range;
+    using base_t::dimension_second_range;
+    using base_t::score_matrix;
+
+};
+
+template <typename alloc_type>
+struct unbanded_score_matrix_test : public ::testing::Test
+{
+    using score_alloc_t = std::allocator<alloc_type>;
+
+    auto fixture()
+    {
+        return policy_mock<score_alloc_t>{};
+    }
+};
+
+using test_types = std::tuple<int32_t, int32_t>;
+TYPED_TEST_CASE(unbanded_score_matrix_test, ::testing::Types<test_types>);
+
+TYPED_TEST(unbanded_score_matrix_test, constructor)
+{
+    using mock_t = decltype(this->fixture());
+
+    EXPECT_TRUE(std::is_default_constructible_v<mock_t>);
+    EXPECT_TRUE(std::is_copy_constructible_v<mock_t>);
+    EXPECT_TRUE(std::is_move_constructible_v<mock_t>);
+    EXPECT_TRUE(std::is_copy_assignable_v<mock_t>);
+    EXPECT_TRUE(std::is_move_assignable_v<mock_t>);
+    EXPECT_TRUE(std::is_destructible_v<mock_t>);
+}
+
+TYPED_TEST(unbanded_score_matrix_test, allocate_matrix)
+{
+    std::string seq1{"garfieldthecat"};
+    std::string seq2{"garfieldthefatcat"};
+
+    auto mock = this->fixture();
+
+    mock.allocate_matrix(seq1, seq2);
+
+    EXPECT_EQ(mock.dimension_first_range, seq1.size() + 1);
+    EXPECT_EQ(mock.dimension_second_range, seq2.size() + 1);
+    EXPECT_EQ(mock.score_matrix.size(), seq2.size() + 1);
+}
+
+TYPED_TEST(unbanded_score_matrix_test, current_column)
+{
+    std::string seq1{"garfieldthecat"};
+    std::string seq2{"garfieldthefatcat"};
+
+    auto mock = this->fixture();
+
+    mock.allocate_matrix(seq1, seq2);
+
+    auto zip_view = mock.current_column();
+
+    EXPECT_EQ(seqan3::size(zip_view), seq2.size() + 1);
+    EXPECT_TRUE((std::is_same_v<std::remove_reference_t<decltype(std::get<0>(zip_view[0]))>, TypeParam>));
+    EXPECT_TRUE(seqan3::detail::decays_to_ignore_v<std::remove_reference_t<decltype(std::get<1>(zip_view[0]))>>);
+}
+
+TYPED_TEST(unbanded_score_matrix_test, next_column)
+{
+    std::string seq1{"garfieldthecat"};
+    std::string seq2{"garfieldthefatcat"};
+
+    auto mock = this->fixture();
+
+    mock.allocate_matrix(seq1, seq2);
+
+    // Get the active column
+    auto zip_view = mock.current_column();
+    for (auto && entry : zip_view)
+    {
+        std::get<0>(entry) = std::tuple{10, -10};
+        std::get<1>(entry) = 1;
+    }
+
+    // Go to next active column and check if active column has moved.
+    mock.next_column();
+    auto zip_view_2 = mock.current_column();
+    for (auto const entry : zip_view_2)
+    {
+        EXPECT_TRUE((std::get<0>(entry) == std::tuple{10, -10}));
+        EXPECT_TRUE(seqan3::detail::decays_to_ignore_v<std::remove_reference_t<decltype(std::get<1>(entry))>>);
+    }
+}
+
+#include <seqan3/io/stream/debug_stream.hpp>
+
+TYPED_TEST(unbanded_score_matrix_test, test_concepts)
+{
+    auto mock = this->fixture();
+
+    // Get the active column
+    auto zip_view = mock.current_column();
+
+    EXPECT_TRUE(std::ranges::InputRange<decltype(zip_view)>);
+    EXPECT_TRUE(std::ranges::ForwardRange<decltype(zip_view)>);
+    EXPECT_TRUE(std::ranges::BidirectionalRange<decltype(zip_view)>);
+    EXPECT_TRUE(std::ranges::RandomAccessRange<decltype(zip_view)>);
+    EXPECT_TRUE(std::ranges::SizedRange<decltype(zip_view)>);
+
+    auto it = seqan3::begin(zip_view);
+
+    EXPECT_TRUE(std::InputIterator<decltype(it)>);
+    EXPECT_TRUE(std::ForwardIterator<decltype(it)>);
+    EXPECT_TRUE(std::BidirectionalIterator<decltype(it)>);
+    EXPECT_TRUE(std::RandomAccessIterator<decltype(it)>);
+
+    auto it_e = seqan3::end(zip_view);
+    EXPECT_TRUE(std::InputIterator<decltype(it_e)>);
+    EXPECT_TRUE(std::ForwardIterator<decltype(it_e)>);
+    EXPECT_TRUE(std::BidirectionalIterator<decltype(it_e)>);
+    EXPECT_TRUE(std::RandomAccessIterator<decltype(it_e)>);
+}

--- a/test/unit/alignment/pairwise/policy/unbanded_score_dp_matrix_policy_test.cpp
+++ b/test/unit/alignment/pairwise/policy/unbanded_score_dp_matrix_policy_test.cpp
@@ -90,7 +90,7 @@ TYPED_TEST(unbanded_score_matrix_test, current_column)
 
     auto zip_view = mock.current_column();
 
-    EXPECT_EQ(seqan3::size(zip_view), seq2.size() + 1);
+    EXPECT_EQ(std::ranges::size(zip_view), seq2.size() + 1);
     EXPECT_TRUE((std::is_same_v<std::remove_reference_t<decltype(std::get<0>(zip_view[0]))>, TypeParam>));
     EXPECT_TRUE(seqan3::detail::decays_to_ignore_v<std::remove_reference_t<decltype(std::get<2>(zip_view[0]))>>);
 }
@@ -136,9 +136,9 @@ TYPED_TEST(unbanded_score_matrix_test, test_concepts)
     EXPECT_TRUE(std::ranges::BidirectionalRange<decltype(zip_view)>);
     EXPECT_TRUE(std::ranges::SizedRange<decltype(zip_view)>);
 
-    auto it = seqan3::begin(zip_view);
+    auto it = std::ranges::begin(zip_view);
     EXPECT_TRUE(std::BidirectionalIterator<decltype(it)>);
 
-    auto it_e = seqan3::end(zip_view);
+    auto it_e = std::ranges::end(zip_view);
     EXPECT_TRUE(std::BidirectionalIterator<decltype(it_e)>);
 }

--- a/test/unit/alignment/pairwise/policy/unbanded_score_dp_matrix_policy_test.cpp
+++ b/test/unit/alignment/pairwise/policy/unbanded_score_dp_matrix_policy_test.cpp
@@ -11,7 +11,7 @@
 
 #include <range/v3/view/bounded.hpp>
 
-#include <seqan3/alignment/pairwise/policy/unbanded_dp_matrix_policy.hpp>
+#include <seqan3/alignment/pairwise/policy/unbanded_score_dp_matrix_policy.hpp>
 #include <seqan3/core/metafunction/basic.hpp>
 #include <seqan3/core/metafunction/template_inspection.hpp>
 #include <seqan3/std/iterator>
@@ -19,11 +19,11 @@
 
 template <typename score_alloc_t>
 struct policy_mock :
-    public seqan3::detail::unbanded_dp_matrix_policy<policy_mock<score_alloc_t>, score_alloc_t>
+    public seqan3::detail::unbanded_score_dp_matrix_policy<policy_mock<score_alloc_t>, score_alloc_t>
 {
 public:
 
-    using base_t = seqan3::detail::unbanded_dp_matrix_policy<policy_mock<score_alloc_t>, score_alloc_t>;
+    using base_t = seqan3::detail::unbanded_score_dp_matrix_policy<policy_mock<score_alloc_t>, score_alloc_t>;
 
     using base_t::base_t;
 

--- a/test/unit/alignment/pairwise/policy/unbanded_score_dp_matrix_policy_test.cpp
+++ b/test/unit/alignment/pairwise/policy/unbanded_score_dp_matrix_policy_test.cpp
@@ -30,7 +30,7 @@ public:
     // Expose member function for testing
     using base_t::allocate_matrix;
     using base_t::current_column;
-    using base_t::next_column;
+    using base_t::go_next_column;
 
     using base_t::dimension_first_range;
     using base_t::dimension_second_range;
@@ -95,7 +95,7 @@ TYPED_TEST(unbanded_score_matrix_test, current_column)
     EXPECT_TRUE(seqan3::detail::decays_to_ignore_v<std::remove_reference_t<decltype(std::get<2>(zip_view[0]))>>);
 }
 
-TYPED_TEST(unbanded_score_matrix_test, next_column)
+TYPED_TEST(unbanded_score_matrix_test, go_next_column)
 {
     std::string seq1{"garfieldthecat"};
     std::string seq2{"garfieldthefatcat"};
@@ -114,7 +114,7 @@ TYPED_TEST(unbanded_score_matrix_test, next_column)
 
     EXPECT_EQ(mock.current_column_index, 0u);
     // Go to next active column and check if active column has moved.
-    mock.next_column();
+    mock.go_next_column();
     auto zip_view_2 = mock.current_column();
     size_t row_index = 0;
     for (auto const entry : zip_view_2)

--- a/test/unit/alignment/pairwise/policy/unbanded_score_trace_dp_matrix_policy_test.cpp
+++ b/test/unit/alignment/pairwise/policy/unbanded_score_trace_dp_matrix_policy_test.cpp
@@ -52,9 +52,9 @@ struct unbanded_score_trace_test : public ::testing::Test
     }
 };
 
-using test_type = std::tuple<std::tuple<int32_t, int32_t>, seqan3::detail::trace_directions>;
+using test_type = ::testing::Types<std::tuple<std::tuple<int32_t, int32_t>, seqan3::detail::trace_directions>>;
 
-TYPED_TEST_CASE(unbanded_score_trace_test, ::testing::Types<test_type>);
+TYPED_TEST_CASE(unbanded_score_trace_test, test_type);
 
 TYPED_TEST(unbanded_score_trace_test, constructor)
 {
@@ -111,7 +111,7 @@ TYPED_TEST(unbanded_score_trace_test, next_column)
 
     mock.allocate_matrix(seq1, seq2);
 
-    // Get the active column
+    // Assign to the active column
     auto zip_view = mock.current_column();
     for (auto && entry : zip_view)
     {

--- a/test/unit/alignment/pairwise/policy/unbanded_score_trace_dp_matrix_policy_test.cpp
+++ b/test/unit/alignment/pairwise/policy/unbanded_score_trace_dp_matrix_policy_test.cpp
@@ -31,7 +31,7 @@ public:
     // Make member functions available for testing
     using base_t::allocate_matrix;
     using base_t::current_column;
-    using base_t::next_column;
+    using base_t::go_next_column;
 
     using base_t::dimension_first_range;
     using base_t::dimension_second_range;
@@ -102,7 +102,7 @@ TYPED_TEST(unbanded_score_trace_test, current_column)
     EXPECT_TRUE(std::ranges::BidirectionalRange<decltype(zip_view)>);
 }
 
-TYPED_TEST(unbanded_score_trace_test, next_column)
+TYPED_TEST(unbanded_score_trace_test, go_next_column)
 {
     std::string seq1{"garfieldthecat"};
     std::string seq2{"garfieldthefatcat"};
@@ -133,7 +133,7 @@ TYPED_TEST(unbanded_score_trace_test, next_column)
     EXPECT_EQ(mock.current_column_index, 0u);
 
     // Go to next active column and check if active column has moved.
-    mock.next_column();
+    mock.go_next_column();
     auto zip_view_3 = mock.current_column();
 
     row_index = 0;

--- a/test/unit/alignment/pairwise/policy/unbanded_score_trace_dp_matrix_policy_test.cpp
+++ b/test/unit/alignment/pairwise/policy/unbanded_score_trace_dp_matrix_policy_test.cpp
@@ -1,0 +1,136 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include <seqan3/alignment/pairwise/policy/unbanded_score_trace_dp_matrix_policy.hpp>
+#include <seqan3/core/metafunction/range.hpp>
+#include <seqan3/core/metafunction/template_inspection.hpp>
+
+template <typename score_alloc_t, typename trace_alloc_t>
+struct policy_mock :
+    public seqan3::detail::unbanded_score_trace_dp_matrix_policy<policy_mock<score_alloc_t, trace_alloc_t>,
+                                                                 score_alloc_t,
+                                                                 trace_alloc_t>
+{
+public:
+
+    using base_t = seqan3::detail::unbanded_score_trace_dp_matrix_policy<policy_mock<score_alloc_t, trace_alloc_t>,
+                                                                         score_alloc_t,
+                                                                         trace_alloc_t>;
+
+    using base_t::base_t;
+
+    using base_t::allocate_matrix;
+    using base_t::current_column;
+    using base_t::next_column;
+
+    using base_t::dimension_first_range;
+    using base_t::dimension_second_range;
+    using base_t::score_matrix;
+    using base_t::trace_matrix;
+};
+
+template <typename alloc_types>
+struct unbanded_score_trace_test : public ::testing::Test
+{
+    using score_alloc_t = std::allocator<std::tuple_element_t<0, alloc_types>>;
+    using trace_alloc_t = std::allocator<std::tuple_element_t<1, alloc_types>>;
+
+    auto fixture()
+    {
+        return policy_mock<score_alloc_t, trace_alloc_t>{};
+    }
+};
+
+using test_type = std::tuple<std::tuple<int32_t, int32_t>, seqan3::detail::trace_directions>;
+
+TYPED_TEST_CASE(unbanded_score_trace_test, ::testing::Types<test_type>);
+
+TYPED_TEST(unbanded_score_trace_test, constructor)
+{
+    using mock_t = decltype(this->fixture());
+
+    EXPECT_TRUE(std::is_default_constructible_v<mock_t>);
+    EXPECT_TRUE(std::is_copy_constructible_v<mock_t>);
+    EXPECT_TRUE(std::is_move_constructible_v<mock_t>);
+    EXPECT_TRUE(std::is_copy_assignable_v<mock_t>);
+    EXPECT_TRUE(std::is_move_assignable_v<mock_t>);
+    EXPECT_TRUE(std::is_destructible_v<mock_t>);
+}
+
+TYPED_TEST(unbanded_score_trace_test, allocate_matrix)
+{
+    std::string seq1{"garfieldthecat"};
+    std::string seq2{"garfieldthefatcat"};
+
+    auto mock = this->fixture();
+
+    mock.allocate_matrix(seq1, seq2);
+
+    EXPECT_EQ(mock.dimension_first_range, seq1.size() + 1);
+    EXPECT_EQ(mock.dimension_second_range, seq2.size() + 1);
+    EXPECT_EQ(mock.score_matrix.size(), seq2.size() + 1);
+    EXPECT_EQ(mock.trace_matrix.size(), (seq1.size() + 1) * (seq2.size() + 1));
+}
+
+TYPED_TEST(unbanded_score_trace_test, current_column)
+{
+    std::string seq1{"garfieldthecat"};
+    std::string seq2{"garfieldthefatcat"};
+
+    auto mock = this->fixture();
+
+    mock.allocate_matrix(seq1, seq2);
+
+    auto zip_view = mock.current_column();
+
+    EXPECT_EQ(seqan3::size(zip_view), seq2.size() + 1);
+
+    using value_t = seqan3::value_type_t<decltype(zip_view)>;
+    EXPECT_EQ(std::tuple_size_v<value_t>, 2u);
+}
+
+TYPED_TEST(unbanded_score_trace_test, next_column)
+{
+    std::string seq1{"garfieldthecat"};
+    std::string seq2{"garfieldthefatcat"};
+
+    auto mock = this->fixture();
+
+    mock.allocate_matrix(seq1, seq2);
+
+    // Get the active column
+    auto zip_view = mock.current_column();
+    for (auto && entry : zip_view)
+    {
+        std::get<0>(entry) = std::tuple{10, -10};
+        std::get<1>(entry) = seqan3::detail::trace_directions::diagonal;
+    }
+
+    // Get the same active column again
+    auto zip_view_2 = mock.current_column();
+    for (auto const entry : zip_view_2)
+    {
+        EXPECT_TRUE((std::get<0>(entry) == std::tuple{10, -10}));
+        EXPECT_TRUE((std::get<1>(entry) == seqan3::detail::trace_directions::diagonal));
+    }
+
+    // Go to next active column and check if active column has moved.
+    mock.next_column();
+    auto zip_view_3 = mock.current_column();
+
+    for (auto const entry : zip_view_3)
+    {
+        EXPECT_TRUE((std::get<0>(entry) == std::tuple{10, -10}));
+        EXPECT_TRUE((std::get<1>(entry) == seqan3::detail::trace_directions::none));
+    }
+
+    EXPECT_EQ(seqan3::size(zip_view_3), seq2.size() + 1);
+}

--- a/test/unit/alignment/pairwise/policy/unbanded_score_trace_dp_matrix_policy_test.cpp
+++ b/test/unit/alignment/pairwise/policy/unbanded_score_trace_dp_matrix_policy_test.cpp
@@ -94,7 +94,7 @@ TYPED_TEST(unbanded_score_trace_test, current_column)
 
     auto zip_view = mock.current_column();
 
-    EXPECT_EQ(seqan3::size(zip_view), seq2.size() + 1);
+    EXPECT_EQ(std::ranges::size(zip_view), seq2.size() + 1);
 
     using value_t = seqan3::value_type_t<decltype(zip_view)>;
     EXPECT_EQ(std::tuple_size_v<value_t>, 3u);
@@ -145,5 +145,5 @@ TYPED_TEST(unbanded_score_trace_test, next_column)
         EXPECT_TRUE((std::get<2>(entry) == seqan3::detail::trace_directions::none));
     }
 
-    EXPECT_EQ(seqan3::size(zip_view_3), seq2.size() + 1);
+    EXPECT_EQ(std::ranges::size(zip_view_3), seq2.size() + 1);
 }


### PR DESCRIPTION
Implements the traceback computation for the banded and unbanded alignment case.

Superseeds #691 

Fixes #661 

This PR adds the traceback computation for the banded and unbanded case. There are still some open tasks that are all documented in the alignment module project. But this will handle ~99% of the normal alignment cases and is everything we need for the tutorials. 

Updated performance results for gcc-7

```console
---------------------------------------------------------------------------
Benchmark                                    Time           CPU Iterations
---------------------------------------------------------------------------
seqan3_affine_dna4                      578966 ns     578363 ns       1043
seqan2_affine_dna4                      581657 ns     581027 ns       1153
seqan3_affine_dna4_trace               2841675 ns    2837551 ns        243
seqan2_affine_dna4_trace               2560076 ns    2555956 ns        274
seqan3_affine_dna4_collection          2360674 ns    2357736 ns        295
seqan2_affine_dna4_collection          2512771 ns    2507039 ns        280
seqan3_affine_dna4_trace_collection   11702101 ns   11680847 ns         59
seqan2_affine_dna4_trace_collection   11049155 ns   11032645 ns         62
```