### PR TITLE
[DOC] Larger font size for formulas

### DIFF
--- a/test/documentation/seqan3_doxygen_cfg.in
+++ b/test/documentation/seqan3_doxygen_cfg.in
@@ -43,6 +43,7 @@ TAGFILES               += "${SEQAN3_DOXYGEN_STD_TAGFILE}=http://en.cppreference.
 
 EXCLUDE_SYMBOLS        = seqan3::contrib
 
+FORMULA_FONTSIZE       = 14
 
 ## detect headers without extensions (in std module)
 EXTENSION_MAPPING      = .no_extension=C++


### PR DESCRIPTION
This PR increases the font size in the doxygen documentation for formulas. 
Currently, their size is significantly lower than the standard font. 