### PR TITLE
[FIX] Index and Search

### DIFF
--- a/include/seqan3/search/fm_index/concept.hpp
+++ b/include/seqan3/search/fm_index/concept.hpp
@@ -16,9 +16,9 @@
 
 #include <sdsl/suffix_arrays.hpp>
 
-#include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/core/metafunction/range.hpp>
 #include <seqan3/range/concept.hpp>
+#include <seqan3/range/container/concept.hpp>
 
 namespace seqan3::detail
 {
@@ -129,10 +129,12 @@ SEQAN3_CONCEPT FmIndex = std::Semiregular<t> && requires (t index)
     typename t::size_type;
     typename t::cursor_type;
 
+    requires sequence_container_concept<typename t::text_type>;
+
     // NOTE: circular dependency
     // requires FmIndexCursor<typename t::cursor_type>;
 
-    requires requires (t index, std::vector<value_type_t<typename t::text_type>> const text)
+    requires requires (t index, typename t::text_type const text)
     {
         { t(text) };
         { index.construct(text) } -> void;

--- a/test/unit/search/CMakeLists.txt
+++ b/test/unit/search/CMakeLists.txt
@@ -2,7 +2,8 @@ add_subdirectories()
 
 seqan3_test (sdsl_index_test.cpp)
 
+seqan3_test (search_collection_test.cpp)
 seqan3_test (search_configuration_test.cpp)
-seqan3_test (search_scheme_test.cpp)
 seqan3_test (search_scheme_algorithm_test.cpp)
+seqan3_test (search_scheme_test.cpp)
 seqan3_test (search_test.cpp)

--- a/test/unit/search/fm_index/bi_fm_index_dna4_test.cpp
+++ b/test/unit/search/fm_index/bi_fm_index_dna4_test.cpp
@@ -10,3 +10,14 @@
 
 INSTANTIATE_TYPED_TEST_CASE_P(dna4, fm_index_test, bi_fm_index<std::vector<dna4>>);
 INSTANTIATE_TYPED_TEST_CASE_P(dna4_collection, fm_index_collection_test, bi_fm_index<std::vector<std::vector<dna4>>>);
+
+TEST(fm_index_test, additional_concepts)
+{
+    EXPECT_TRUE(BiFmIndexTraits<bi_fm_index_default_traits>);
+    EXPECT_TRUE(BiFmIndex<bi_fm_index<std::string>>);
+}
+
+TEST(fm_index_collection_test, additional_concepts)
+{
+    EXPECT_TRUE(BiFmIndex<bi_fm_index<std::vector<std::string>>>);
+}

--- a/test/unit/search/fm_index/fm_index_collection_test_template.hpp
+++ b/test/unit/search/fm_index/fm_index_collection_test_template.hpp
@@ -7,6 +7,7 @@
 
 #include <type_traits>
 
+#include <seqan3/core/metafunction/template_inspection.hpp>
 #include <seqan3/search/fm_index/all.hpp>
 #include <seqan3/test/tmp_filename.hpp>
 
@@ -103,8 +104,10 @@ TYPED_TEST_P(fm_index_collection_test, serialization)
 TYPED_TEST_P(fm_index_collection_test, concept_check)
 {
     EXPECT_TRUE(FmIndex<TypeParam>);
-    EXPECT_TRUE(FmIndexTraits<fm_index_default_traits>);
-    EXPECT_TRUE(BiFmIndexTraits<bi_fm_index_default_traits>);
+    if constexpr (detail::is_type_specialisation_of_v<TypeParam, bi_fm_index>)
+    {
+        EXPECT_TRUE(BiFmIndex<TypeParam>);
+    }
 }
 
 TYPED_TEST_P(fm_index_collection_test, empty_text)

--- a/test/unit/search/fm_index/fm_index_dna4_test.cpp
+++ b/test/unit/search/fm_index/fm_index_dna4_test.cpp
@@ -10,3 +10,14 @@
 
 INSTANTIATE_TYPED_TEST_CASE_P(dna4, fm_index_test, fm_index<std::vector<dna4>>);
 INSTANTIATE_TYPED_TEST_CASE_P(dna4_collection, fm_index_collection_test, fm_index<std::vector<std::vector<dna4>>>);
+
+TEST(fm_index_test, additional_concepts)
+{
+    EXPECT_TRUE(FmIndexTraits<fm_index_default_traits>);
+    EXPECT_TRUE(FmIndex<fm_index<std::string>>);
+}
+
+TEST(fm_index_collection_test, additional_concepts)
+{
+    EXPECT_TRUE(FmIndex<fm_index<std::vector<std::string>>>);
+}

--- a/test/unit/search/fm_index/fm_index_test_template.hpp
+++ b/test/unit/search/fm_index/fm_index_test_template.hpp
@@ -7,6 +7,7 @@
 
 #include <type_traits>
 
+#include <seqan3/core/metafunction/template_inspection.hpp>
 #include <seqan3/search/fm_index/all.hpp>
 #include <seqan3/test/tmp_filename.hpp>
 
@@ -101,8 +102,10 @@ TYPED_TEST_P(fm_index_test, serialization)
 TYPED_TEST_P(fm_index_test, concept_check)
 {
     EXPECT_TRUE(FmIndex<TypeParam>);
-    EXPECT_TRUE(FmIndexTraits<fm_index_default_traits>);
-    EXPECT_TRUE(BiFmIndexTraits<bi_fm_index_default_traits>);
+    if constexpr (detail::is_type_specialisation_of_v<TypeParam, bi_fm_index>)
+    {
+        EXPECT_TRUE(BiFmIndex<TypeParam>);
+    }
 }
 
 TYPED_TEST_P(fm_index_test, empty_text)

--- a/test/unit/search/search_collection_test.cpp
+++ b/test/unit/search/search_collection_test.cpp
@@ -1,0 +1,112 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+#include <algorithm>
+#include <type_traits>
+
+#include "helper.hpp"
+
+#include <seqan3/search/algorithm/all.hpp>
+
+#include <gtest/gtest.h>
+
+using namespace seqan3;
+using namespace seqan3::search_cfg;
+
+template <typename T>
+class search_test : public ::testing::Test
+{
+public:
+    std::vector<std::vector<dna4>> text{"ACGTACGTACGT"_dna4, "ACGTACGTACGT"_dna4};
+    T index{text};
+};
+
+using fm_index_types = ::testing::Types<fm_index<std::vector<std::vector<dna4>>>,
+                                        bi_fm_index<std::vector<std::vector<dna4>>>>;
+
+TYPED_TEST_CASE(search_test, fm_index_types);
+
+TYPED_TEST(search_test, error_free)
+{
+    using result_t = std::pair<typename TypeParam::size_type, typename TypeParam::size_type>;
+    using hits_result_t = std::vector<result_t>;
+
+    {
+        // successful and unsuccesful exact search without cfg
+        EXPECT_EQ(uniquify(search(this->index, "ACGT"_dna4)), (hits_result_t{{0, 0}, {0, 4}, {0, 8},
+                                                                             {1, 0}, {1, 4}, {1, 8}}));
+        EXPECT_EQ(uniquify(search(this->index, "ACGG"_dna4)), (hits_result_t{}));
+    }
+
+    {
+        // successful and unsuccesful exact search with empty cfg
+        configuration const cfg;
+        EXPECT_EQ(uniquify(search(this->index, "ACGT"_dna4, cfg)), (hits_result_t{{0, 0}, {0, 4}, {0, 8},
+                                                                                  {1, 0}, {1, 4}, {1, 8}}));
+        EXPECT_EQ(uniquify(search(this->index, "ACGG"_dna4, cfg)), (hits_result_t{}));
+    }
+
+    {
+        // successful and unsuccesful exact search using empty max_total_error
+        configuration const cfg = max_error{};
+        EXPECT_EQ(uniquify(search(this->index, "ACGT"_dna4, cfg)), (hits_result_t{{0, 0}, {0, 4}, {0, 8},
+                                                                                  {1, 0}, {1, 4}, {1, 8}}));
+        EXPECT_EQ(uniquify(search(this->index, "ACGG"_dna4, cfg)), (hits_result_t{}));
+    }
+
+    {
+        // successful and unsuccesful exact search using short version of max_total_error
+        configuration const cfg = max_error{total{0}};
+        EXPECT_EQ(uniquify(search(this->index, "ACGT"_dna4, cfg)), (hits_result_t{{0, 0}, {0, 4}, {0, 8},
+                                                                                  {1, 0}, {1, 4}, {1, 8}}));
+        EXPECT_EQ(uniquify(search(this->index, "ACGG"_dna4, cfg)), (hits_result_t{}));
+    }
+
+    {
+        // successful and unsuccesful exact search using max_total_error
+        configuration const cfg = max_error{total{0}, substitution{0}, insertion{0}, deletion{0}};
+        EXPECT_EQ(uniquify(search(this->index, "ACGT"_dna4, cfg)), (hits_result_t{{0, 0}, {0, 4}, {0, 8},
+                                                                                  {1, 0}, {1, 4}, {1, 8}}));
+        EXPECT_EQ(uniquify(search(this->index, "ACGG"_dna4, cfg)), (hits_result_t{}));
+    }
+
+    {
+        // successful and unsuccesful exact search using empty max_total_error_rate
+        configuration const cfg = max_error_rate{};
+        EXPECT_EQ(uniquify(search(this->index, "ACGT"_dna4, cfg)), (hits_result_t{{0, 0}, {0, 4}, {0, 8},
+                                                                                  {1, 0}, {1, 4}, {1, 8}}));
+        EXPECT_EQ(uniquify(search(this->index, "ACGG"_dna4, cfg)), (hits_result_t{}));
+    }
+
+    {
+        // successful and unsuccesful exact search using short version of max_total_error_rate
+        configuration const cfg = max_error_rate{total{.0}};
+        EXPECT_EQ(uniquify(search(this->index, "ACGT"_dna4, cfg)), (hits_result_t{{0, 0}, {0, 4}, {0, 8},
+                                                                                  {1, 0}, {1, 4}, {1, 8}}));
+        EXPECT_EQ(uniquify(search(this->index, "ACGG"_dna4, cfg)), (hits_result_t{}));
+    }
+
+    {
+        // successful and unsuccesful exact search using max_total_error_rate
+        configuration const cfg = max_error_rate{total{.0}, substitution{.0}, insertion{.0}, deletion{.0}};
+        EXPECT_EQ(uniquify(search(this->index, "ACGT"_dna4, cfg)), (hits_result_t{{0, 0}, {0, 4}, {0, 8},
+                                                                                  {1, 0}, {1, 4}, {1, 8}}));
+        EXPECT_EQ(uniquify(search(this->index, "ACGG"_dna4, cfg)), (hits_result_t{}));
+    }
+}
+
+TYPED_TEST(search_test, multiple_queries)
+{
+    using result_t = std::vector<std::pair<typename TypeParam::size_type, typename TypeParam::size_type>>;
+    using hits_result_t = std::vector<result_t>;
+    std::vector<std::vector<dna4>> const queries{{"GG"_dna4, "ACGTACGTACGT"_dna4, "ACGTA"_dna4}};
+
+    configuration const cfg = max_error_rate{total{.0}, substitution{.0}, insertion{.0}, deletion{.0}};
+    EXPECT_EQ(uniquify(search(this->index, queries, cfg)), (hits_result_t{{},
+                                                                          {{0, 0}, {1, 0}},
+                                                                          {{0, 0}, {0, 4}, {1, 0}, {1, 4}}}));
+}


### PR DESCRIPTION
- Indices do not work on `std::string`, but they should (adapt concept to check that the text is a sequence container)
- Search does not work for text collections (define type of results as `size_t` or `std::pair<size_t, size_t>` depending on whether the index is built over a single text or text collection)

Todo:

- [x] Add tests