### PR TITLE
[FIX] Also serialise support structures

### DIFF
--- a/include/seqan3/search/fm_index/fm_index.hpp
+++ b/include/seqan3/search/fm_index/fm_index.hpp
@@ -438,10 +438,29 @@ public:
      */
     bool load(std::filesystem::path const & path)
     {
-        sdsl_index_type tmp;
-        if (sdsl::load_from_file(tmp, path))
+        std::filesystem::path tb_path{path};
+        std::filesystem::path tb_ss_path{path};
+        std::filesystem::path tb_rs_path{path};
+        tb_path += ".tb";
+        tb_ss_path += ".tbss";
+        tb_rs_path += ".tbrs";
+
+        sdsl_index_type tmp_index;
+        sdsl::sd_vector<> tmp_text_begin;
+        sdsl::select_support_sd<1> tmp_text_begin_ss;
+        sdsl::rank_support_sd<1> tmp_text_begin_rs;
+
+        if (sdsl::load_from_file(tmp_index, path) &&
+            sdsl::load_from_file(tmp_text_begin, tb_path) &&
+            sdsl::load_from_file(tmp_text_begin_ss, tb_ss_path) &&
+            sdsl::load_from_file(tmp_text_begin_rs, tb_rs_path))
         {
-            std::swap(this->index, tmp);
+            std::swap(this->index, tmp_index);
+            std::swap(this->text_begin, tmp_text_begin);
+            std::swap(this->text_begin_ss, tmp_text_begin_ss);
+            std::swap(this->text_begin_rs, tmp_text_begin_rs);
+            text_begin_ss.set_vector(&text_begin);
+            text_begin_rs.set_vector(&text_begin);
             return true;
         }
         return false;
@@ -461,7 +480,17 @@ public:
      */
     bool store(std::filesystem::path const & path) const
     {
-        return sdsl::store_to_file(index, path);
+        std::filesystem::path tb_path{path};
+        std::filesystem::path tb_ss_path{path};
+        std::filesystem::path tb_rs_path{path};
+        tb_path += ".tb";
+        tb_ss_path += ".tbss";
+        tb_rs_path += ".tbrs";
+
+        return sdsl::store_to_file(index, path) &&
+               sdsl::store_to_file(text_begin, tb_path) &&
+               sdsl::store_to_file(text_begin_ss, tb_ss_path) &&
+               sdsl::store_to_file(text_begin_rs, tb_rs_path);
     }
 
 };


### PR DESCRIPTION
We also need to store/load the data structures that enable the determination of the position in a text collection

This will be hopefully soon replaced by a way shorter code with cereal