### PR TITLE
[MISC,FEATURE] Allow char* searches in string indices

### DIFF
--- a/include/seqan3/search/algorithm/configuration/max_error.hpp
+++ b/include/seqan3/search/algorithm/configuration/max_error.hpp
@@ -13,8 +13,6 @@
 
 #pragma once
 
-#include <range/v3/algorithm/fill.hpp>
-#include <range/v3/algorithm/for_each.hpp>
 #include <range/v3/numeric/accumulate.hpp>
 
 #include <seqan3/core/algorithm/pipeable_config_element.hpp>
@@ -109,7 +107,7 @@ public:
         // Only total is set so we set all other errors to the total limit.
         if constexpr (((std::remove_reference_t<errors_t>::_id() == 0) || ...) && sizeof...(errors) == 1)
         {
-            ranges::fill(base_t::value | view::slice(1, 4), base_t::value[0]);
+            std::ranges::fill(base_t::value | view::slice(1, 4), base_t::value[0]);
         } // otherwise if total is not set but any other field is set than use total as the sum of all set errors.
         else if constexpr (!((std::remove_reference_t<errors_t>::_id() == 0) || ...) && sizeof...(errors) > 0)
         {

--- a/include/seqan3/search/algorithm/configuration/max_error_rate.hpp
+++ b/include/seqan3/search/algorithm/configuration/max_error_rate.hpp
@@ -13,8 +13,6 @@
 
 #pragma once
 
-#include <range/v3/algorithm/fill.hpp>
-#include <range/v3/algorithm/for_each.hpp>
 #include <range/v3/numeric/accumulate.hpp>
 #include <range/v3/view/slice.hpp>
 
@@ -110,7 +108,7 @@ public:
         }, std::forward<errors_t>(errors)...);
 
         // check correct values.
-        ranges::for_each(base_t::value, [](auto error_elem)
+        std::ranges::for_each(base_t::value, [](auto error_elem)
         {
             if (0.0 > error_elem  || error_elem > 1.0)
                 throw std::invalid_argument("Error rates must be between 0 and 1.");
@@ -119,7 +117,7 @@ public:
         // Only total is set so we set all other errors to the total limit.
         if constexpr (((std::remove_reference_t<errors_t>::_id() == 0) || ...) && sizeof...(errors) == 1)
         {
-            ranges::fill(base_t::value | view::slice(1, 4), base_t::value[0]);
+            std::ranges::fill(base_t::value | view::slice(1, 4), base_t::value[0]);
         } // otherwise if total is not set but any other field is set than use total as the sum of all set errors.
         else if constexpr (!((std::remove_reference_t<errors_t>::_id() == 0) || ...) && sizeof...(errors) > 0)
         {

--- a/include/seqan3/search/algorithm/detail/search.hpp
+++ b/include/seqan3/search/algorithm/detail/search.hpp
@@ -62,7 +62,7 @@ inline auto search_single(index_t const & index, query_t & query, configuration_
         auto & [total, subs, ins, del] = max_error;
         std::tie(total, subs, ins, del) = std::apply([& query] (auto && ... args)
             {
-                return std::tuple{(args * query.size())...};
+                return std::tuple{(args * std::ranges::size(query))...};
             }, get<search_cfg::max_error_rate>(cfg).value);
     }
 

--- a/include/seqan3/search/algorithm/detail/search_scheme_algorithm.hpp
+++ b/include/seqan3/search/algorithm/detail/search_scheme_algorithm.hpp
@@ -341,8 +341,8 @@ inline bool search_ss_children(cursor_t cur, query_t & query,
             // No deletion at the beginning of the leftmost block.
             // No deletion at the end of the rightmost block.
             if (error_left.deletion > 0 &&
-                !(go_right && (rb == 1 || rb == query.size() + 1)) &&
-                !(!go_right && (lb == 0 || lb == query.size())))
+                !(go_right && (rb == 1 || rb == std::ranges::size(query) + 1)) &&
+                !(!go_right && (lb == 0 || lb == std::ranges::size(query))))
             {
                 search_param error_left3{error_left};
                 error_left3.total--;
@@ -370,7 +370,7 @@ inline bool search_ss(cursor_t cur, query_t & query,
     uint8_t const min_error_left_in_block = std::max(search.l[block_id] - errors_spent, 0); // NOTE: changed
 
     // Done.
-    if (min_error_left_in_block == 0 && lb == 0 && rb == query.size() + 1)
+    if (min_error_left_in_block == 0 && lb == 0 && rb == std::ranges::size(query) + 1)
     {
         delegate(cur);
         return true;
@@ -459,7 +459,7 @@ inline void search_ss(index_t const & index, query_t & query, search_param const
                       search_scheme_t const & search_scheme, delegate_t && delegate)
 {
     // retrieve cumulative block lengths and starting position
-    auto const block_info = search_scheme_block_info(search_scheme, query.size());
+    auto const block_info = search_scheme_block_info(search_scheme, std::ranges::size(query));
 
     for (uint8_t search_id = 0; search_id < search_scheme.size(); ++search_id)
     {

--- a/include/seqan3/search/algorithm/detail/search_trivial.hpp
+++ b/include/seqan3/search/algorithm/detail/search_trivial.hpp
@@ -15,10 +15,9 @@
 
 #include <type_traits>
 
-#include <range/v3/view/drop_exactly.hpp>
-
 #include <seqan3/range/concept.hpp>
 #include <seqan3/search/algorithm/detail/search_common.hpp>
+#include <seqan3/std/ranges>
 
 namespace seqan3::detail
 {
@@ -52,10 +51,10 @@ inline bool search_trivial(cursor_t cur, query_t & query, typename cursor_t::siz
                            search_param const error_left, delegate_t && delegate) noexcept(noexcept(delegate))
 {
     // Exact case (end of query sequence or no errors left)
-    if (query_pos == query.size() || error_left.total == 0)
+    if (query_pos == std::ranges::size(query) || error_left.total == 0)
     {
         // If not at end of query sequence, try searching the remaining suffix without any errors.
-        if (query_pos == query.size() || cur.extend_right(ranges::view::drop_exactly(query, query_pos)))
+        if (query_pos == std::ranges::size(query) || cur.extend_right(std::view::drop(query, query_pos)))
         {
             delegate(cur);
             return true;

--- a/include/seqan3/search/algorithm/search.hpp
+++ b/include/seqan3/search/algorithm/search.hpp
@@ -55,6 +55,9 @@ template <FmIndex index_t, typename queries_t, typename configuration_t>
 //!\endcond
 inline auto search(index_t const & index, queries_t && queries, configuration_t const & cfg)
 {
+    static_assert(ImplicitlyConvertibleTo<innermost_value_type_t<queries_t>, typename index_t::char_type>,
+                  "The alphabets of index and query are not compatible.");
+
     using cfg_t = remove_cvref_t<configuration_t>;
 
     if constexpr (cfg_t::template exists<search_cfg::max_error>())
@@ -95,6 +98,25 @@ inline auto search(index_t const & index, queries_t && queries, configuration_t 
     }
 }
 
+//! \overload
+template <FmIndex index_t, typename configuration_t>
+inline auto search(index_t const & index, char const * const queries, configuration_t const & cfg)
+{
+    return search(index, std::string_view{queries}, cfg);
+}
+
+//! \overload
+template <FmIndex index_t, typename configuration_t>
+inline auto search(index_t const & index,
+                   std::initializer_list<char const * const> const & queries,
+                   configuration_t const & cfg)
+{
+    std::vector<std::string_view> query;
+    query.reserve(std::ranges::size(queries));
+    std::ranges::for_each(queries, [&query] (char const * const q) { query.push_back(std::string_view{q}); });
+    return search(index, query, cfg);
+}
+
 /*!\brief Search a query or a range of queries in an index.
  *        It will not allow for any errors and will output all matches as positions in the text.
  * \tparam index_t    Must model seqan3::FmIndex.
@@ -119,6 +141,9 @@ template <FmIndex index_t, typename queries_t>
 //!\endcond
 inline auto search(index_t const & index, queries_t && queries)
 {
+    static_assert(ImplicitlyConvertibleTo<innermost_value_type_t<queries_t>, typename index_t::char_type>,
+                  "The alphabets of index and query are not compatible.");
+
     configuration const default_cfg = search_cfg::max_error{search_cfg::total{0},
                                                             search_cfg::substitution{0},
                                                             search_cfg::insertion{0},
@@ -126,6 +151,23 @@ inline auto search(index_t const & index, queries_t && queries)
                                             | search_cfg::output{search_cfg::text_position}
                                             | search_cfg::mode{search_cfg::all};
     return search(index, queries, default_cfg);
+}
+
+//! \overload
+template <FmIndex index_t>
+inline auto search(index_t const & index, char const * const queries)
+{
+    return search(index, std::string_view{queries});
+}
+
+//! \overload
+template <FmIndex index_t>
+inline auto search(index_t const & index, std::initializer_list<char const * const> const & queries)
+{
+    std::vector<std::string_view> query;
+    query.reserve(std::ranges::size(queries));
+    std::ranges::for_each(queries, [&query] (char const * const q) { query.push_back(std::string_view{q}); });
+    return search(index, query);
 }
 
 //!\}

--- a/include/seqan3/search/fm_index/bi_fm_index_cursor.hpp
+++ b/include/seqan3/search/fm_index/bi_fm_index_cursor.hpp
@@ -16,7 +16,6 @@
 
 #include <sdsl/suffix_trees.hpp>
 
-#include <range/v3/view/iota.hpp>
 #include <range/v3/view/slice.hpp>
 
 #include <seqan3/alphabet/all.hpp>
@@ -504,8 +503,8 @@ public:
     {
         assert(index != nullptr);
 
-        auto first = seq.begin();
-        auto last = seq.end();
+        auto first = std::ranges::begin(seq);
+        auto last = std::ranges::end(seq);
 
     #ifndef NDEBUG
         fwd_cursor_last_used = (first != last); // only if seq was not empty
@@ -568,8 +567,8 @@ public:
         assert(index != nullptr);
 
         auto rev_seq = std::view::reverse(seq);
-        auto first = rev_seq.begin();
-        auto last = rev_seq.end();
+        auto first = std::ranges::begin(rev_seq);
+        auto last = std::ranges::end(rev_seq);
 
     #ifndef NDEBUG
         if (first != last) // only if seq was not empty

--- a/include/seqan3/search/fm_index/fm_index.hpp
+++ b/include/seqan3/search/fm_index/fm_index.hpp
@@ -14,9 +14,6 @@
 
 #include <sdsl/suffix_trees.hpp>
 
-#include <range/v3/algorithm/copy.hpp>
-#include <range/v3/view/join.hpp>
-
 #include <seqan3/core/metafunction/range.hpp>
 #include <seqan3/std/filesystem>
 #include <seqan3/range/shortcuts.hpp>

--- a/include/seqan3/search/fm_index/fm_index_cursor.hpp
+++ b/include/seqan3/search/fm_index/fm_index_cursor.hpp
@@ -17,8 +17,6 @@
 
 #include <sdsl/suffix_trees.hpp>
 
-#include <range/v3/view/iota.hpp>
-#include <range/v3/view/join.hpp>
 #include <range/v3/view/slice.hpp>
 
 #include <seqan3/alphabet/all.hpp>
@@ -313,9 +311,8 @@ public:
     //!\endcond
     bool extend_right(seq_t && seq) noexcept
     {
-        auto first = seq.begin();
-        auto last = seq.end();
-
+        auto first = std::ranges::begin(seq);
+        auto last = std::ranges::end(seq);
         assert(index != nullptr); // range must not be empty!
 
         size_type _lb = node.lb, _rb = node.rb;

--- a/include/seqan3/std/ranges
+++ b/include/seqan3/std/ranges
@@ -24,6 +24,8 @@
 #include <range/v3/iterator/stream_iterators.hpp>
 #include <range/v3/algorithm/copy.hpp>
 #include <range/v3/algorithm/equal.hpp>
+#include <range/v3/algorithm/fill.hpp>
+#include <range/v3/algorithm/for_each.hpp>
 #include <range/v3/algorithm/sort.hpp>
 #include <range/v3/view/all.hpp>
 #include <range/v3/view/any_view.hpp>
@@ -196,6 +198,16 @@ using SEQAN3_DOXYGEN_ONLY(size =) ::ranges::size;
  * \brief Alias for ranges::copy. Copies a range of elements to a new location.
  */
 using SEQAN3_DOXYGEN_ONLY(copy =) ::ranges::copy;
+
+/*!\typedef std::ranges::for_each
+ * \brief Alias for ranges::for_each. Applies a function object to the elements of a range.
+ */
+using SEQAN3_DOXYGEN_ONLY(for_each =) ::ranges::for_each;
+
+/*!\typedef std::ranges::fill
+ * \brief Alias for ranges::fill. Assigns a value to the elements of a range.
+ */
+using SEQAN3_DOXYGEN_ONLY(fill =) ::ranges::fill;
 
 /*!\typedef std::ranges::empty
  * \brief Alias for ranges::empty. Checks whether a range is empty.


### PR DESCRIPTION
* Removes deprecated includes
* Switches to range version of `size`, `begin`, `end`
* Adds static_assert to check for compatibility of index and query alphabet (60 lines of trace with a meaningful message in the beginning vs. 600 lines with no clear message)
* Adds overloads for `char const * const` and `std::initializer<char const * const>` that allow searches on string indices for, e.g., `"query"` or `{"query1", "query2"}`
* Adds tests for the overloads