### PR TITLE
[DOC,FIX] Search module with doxygen 1.8.15

### DIFF
--- a/include/seqan3/search/algorithm/configuration/max_error.hpp
+++ b/include/seqan3/search/algorithm/configuration/max_error.hpp
@@ -80,12 +80,12 @@ public:
      * \brief Defaulted all standard constructor.
      * \{
      */
-    constexpr max_error()                              noexcept = default;
-    constexpr max_error(max_error const &)             noexcept = default;
-    constexpr max_error(max_error &&)                  noexcept = default;
-    constexpr max_error & operator=(max_error const &) noexcept = default;
-    constexpr max_error & operator=(max_error &&)      noexcept = default;
-    ~max_error()                                       noexcept = default;
+    constexpr max_error()                              noexcept = default; //!< Default constructor.
+    constexpr max_error(max_error const &)             noexcept = default; //!< Copy constructor.
+    constexpr max_error(max_error &&)                  noexcept = default; //!< Move constructor.
+    constexpr max_error & operator=(max_error const &) noexcept = default; //!< Copy assignment.
+    constexpr max_error & operator=(max_error &&)      noexcept = default; //!< Move assignment.
+    ~max_error()                                       noexcept = default; //!< Destructor.
 
     /*!\brief Constructs the object from a set of error specifiers.
      * \tparam    errors_t A template parameter pack with the error types.

--- a/include/seqan3/search/algorithm/configuration/max_error_common.hpp
+++ b/include/seqan3/search/algorithm/configuration/max_error_common.hpp
@@ -40,9 +40,11 @@ struct total : detail::strong_type<value_t, total<value_t>, detail::strong_type_
  * \relates seqan3::search_cfg::total
  * \{
  */
+//! \brief Deduces to `uint8_t` for all types modelling std::Integral.
 template <std::Integral value_t>
 total(value_t) -> total<uint8_t>;
 
+//! \brief Deduces to `double` for all types modelling seqan3::FloatingPoint.
 template <typename value_t>
 //!\cond
     requires FloatingPoint<value_t>
@@ -72,9 +74,11 @@ struct substitution : detail::strong_type<value_t, substitution<value_t>, detail
  * \relates seqan3::search_cfg::substitution
  * \{
  */
+//! \brief Deduces to `uint8_t` for all types modelling std::Integral.
 template <std::Integral value_t>
 substitution(value_t) -> substitution<uint8_t>;
 
+//! \brief Deduces to `double` for all types modelling seqan3::FloatingPoint.
 template <typename value_t>
 //!\cond
     requires FloatingPoint<value_t>
@@ -103,9 +107,11 @@ struct insertion : detail::strong_type<value_t, insertion<value_t>, detail::stro
  * \relates seqan3::search_cfg::total
  * \{
  */
+//! \brief Deduces to `uint8_t` for all types modelling std::Integral.
 template <std::Integral value_t>
 insertion(value_t) -> insertion<uint8_t>;
 
+//! \brief Deduces to `double` for all types modelling seqan3::FloatingPoint.
 template <typename value_t>
 //!\cond
     requires FloatingPoint<value_t>
@@ -134,9 +140,11 @@ struct deletion : detail::strong_type<value_t, deletion<value_t>, detail::strong
  * \relates seqan3::search_cfg::deletion
  * \{
  */
+//! \brief Deduces to `uint8_t` for Integral types.
 template <std::Integral value_t>
 deletion(value_t) -> deletion<uint8_t>;
 
+//! \brief Deduces to `double` for all types modelling seqan3::FloatingPoint.
 template <typename value_t>
 //!\cond
     requires FloatingPoint<value_t>

--- a/include/seqan3/search/algorithm/configuration/max_error_rate.hpp
+++ b/include/seqan3/search/algorithm/configuration/max_error_rate.hpp
@@ -83,12 +83,12 @@ public:
      * \brief Defaulted all standard constructor.
      * \{
      */
-    constexpr max_error_rate()                                   noexcept = default;
-    constexpr max_error_rate(max_error_rate const &)             noexcept = default;
-    constexpr max_error_rate(max_error_rate &&)                  noexcept = default;
-    constexpr max_error_rate & operator=(max_error_rate const &) noexcept = default;
-    constexpr max_error_rate & operator=(max_error_rate &&)      noexcept = default;
-    ~max_error_rate()                                            noexcept = default;
+    constexpr max_error_rate()                                   noexcept = default; //!< Default constructor.
+    constexpr max_error_rate(max_error_rate const &)             noexcept = default; //!< Copy constructor.
+    constexpr max_error_rate(max_error_rate &&)                  noexcept = default; //!< Move constructor.
+    constexpr max_error_rate & operator=(max_error_rate const &) noexcept = default; //!< Copy assignment.
+    constexpr max_error_rate & operator=(max_error_rate &&)      noexcept = default; //!< Move assignment.
+    ~max_error_rate()                                            noexcept = default; //!< Destructor.
 
     /*!\brief Constructs the object from a set of error specifiers.
      * \tparam    errors_t A template parameter pack with the error types.

--- a/include/seqan3/search/fm_index/bi_fm_index.hpp
+++ b/include/seqan3/search/fm_index/bi_fm_index.hpp
@@ -157,12 +157,12 @@ public:
     /*!\name Constructors, destructor and assignment
      * \{
      */
-    bi_fm_index() = default;
-    bi_fm_index(bi_fm_index const &) = default;
-    bi_fm_index & operator=(bi_fm_index const &) = default;
-    bi_fm_index(bi_fm_index &&) = default;
-    bi_fm_index & operator=(bi_fm_index &&) = default;
-    ~bi_fm_index() = default;
+    bi_fm_index() = default;                                //!< Default constructor.
+    bi_fm_index(bi_fm_index const &) = default;             //!< Copy constructor.
+    bi_fm_index & operator=(bi_fm_index const &) = default; //!< Copy assignment.
+    bi_fm_index(bi_fm_index &&) = default;                  //!< Move constructor.
+    bi_fm_index & operator=(bi_fm_index &&) = default;      //!< Move assignment.
+    ~bi_fm_index() = default;                               //!< Destructor.
 
     /*!\brief Constructor that immediately constructs the index given a range.
      *        The range cannot be an rvalue (i.e. a temporary object) and has to be non-empty.

--- a/include/seqan3/search/fm_index/bi_fm_index_cursor.hpp
+++ b/include/seqan3/search/fm_index/bi_fm_index_cursor.hpp
@@ -244,12 +244,14 @@ public:
     //!\brief Default constructor. Accessing member functions on a default constructed object is undefined behavior.
     //        Default construction is necessary to make this class semi-regular and e.g., to allow construction of
     //        std::array of cursors.
-    bi_fm_index_cursor() noexcept = default;
-    bi_fm_index_cursor(bi_fm_index_cursor const &) noexcept = default;
-    bi_fm_index_cursor & operator=(bi_fm_index_cursor const &) noexcept = default;
-    bi_fm_index_cursor(bi_fm_index_cursor &&) noexcept = default;
-    bi_fm_index_cursor & operator=(bi_fm_index_cursor &&) noexcept = default;
+    bi_fm_index_cursor() noexcept = default;                                       //!< Default constructor.
+    bi_fm_index_cursor(bi_fm_index_cursor const &) noexcept = default;             //!< Copy constructor.
+    bi_fm_index_cursor & operator=(bi_fm_index_cursor const &) noexcept = default; //!< Copy assignment.
+    bi_fm_index_cursor(bi_fm_index_cursor &&) noexcept = default;                  //!< Move constructor.
+    bi_fm_index_cursor & operator=(bi_fm_index_cursor &&) noexcept = default;      //!< Move assignment.
+    ~bi_fm_index_cursor() = default;                                               //!< Destructor.
 
+    //! \brief Construct from given index.
     bi_fm_index_cursor(index_t const & _index) noexcept : index(&_index),
                                                           fwd_lb(0), fwd_rb(_index.size() - 1),
                                                           rev_lb(0), rev_rb(_index.size() - 1),

--- a/include/seqan3/search/fm_index/concept.hpp
+++ b/include/seqan3/search/fm_index/concept.hpp
@@ -62,7 +62,6 @@ SEQAN3_CONCEPT SdslIndex = requires (t sdsl_index)
  * \{
  *
  * \typedef typename t::size_type size_type
- * \memberof seqan3::detail::SdslIndex
  * \brief Type for representing the size of the indexed text.
  *
  * \todo Write me.
@@ -105,7 +104,6 @@ SEQAN3_CONCEPT FmIndexTraits = requires (t v)
  * \{
  *
  * \typedef typename t::sdsl_index_type sdsl_index_type
- * \memberof seqan3::FmIndexTraits
  * \brief Declares the type of the underlying SDSL index. Must satisfy the seqan3::detail::SdslIndex.
  *
  * \}
@@ -155,19 +153,15 @@ SEQAN3_CONCEPT FmIndex = std::Semiregular<t> && requires (t index)
  * \{
  *
  * \typedef typename t::text_type text_type
- * \memberof seqan3::FmIndex
  * \brief Type of the indexed text.
  *
  * \typedef typename t::char_type char_type
- * \memberof seqan3::FmIndex
  * \brief Type of the underlying character of text_type.
  *
  * \typedef typename t::size_type size_type
- * \memberof seqan3::FmIndex
  * \brief Type for representing the size of the indexed text.
  *
  * \typedef typename t::cursor_type cursor_type
- * \memberof seqan3::FmIndex
  * \brief Type of the unidirectional FM index cursor.
  *
  * \todo Write me!
@@ -221,11 +215,9 @@ SEQAN3_CONCEPT FmIndexCursor = std::Semiregular<t> && requires (t cur)
  * \{
  *
  * \typedef typename t::index_type index_type
- * \memberof seqan3::FmIndexCursor
  * \brief Type of the underlying SeqAn FM index (not the underlying SDSL index).
  *
  * \typedef typename t::size_type size_type
- * \memberof seqan3::FmIndexCursor
  * \brief Type for representing the size of the indexed text.
  *
  * \todo Write me!
@@ -259,12 +251,10 @@ SEQAN3_CONCEPT BiFmIndexTraits = requires (t v)
  * \{
  *
  * \typedef typename t::fm_index_traits fm_index_traits
- * \memberof seqan3::BiFmIndexTraits
  * \brief Declares the type of the underlying unidirectional FM index on the original text.
  *        Must satisfy seqan3::FmIndexTraits.
  *
  * \typedef typename t::rev_fm_index_traits rev_fm_index_traits
- * \memberof seqan3::BiFmIndexTraits
  * \brief Declares the type of the underlying unidirectional FM index on the reversed text.
  *        Must satisfy seqan3::FmIndexTraits.
  *
@@ -301,15 +291,12 @@ SEQAN3_CONCEPT BiFmIndex = FmIndex<t> && requires (t index)
  * \{
  *
  * \typedef typename t::cursor_type cursor_type
- * \memberof seqan3::BiFmIndex
  * \brief Type of the bidirectional FM index cursor.
  *
  * \typedef typename t::fwd_cursor_type fwd_cursor_type
- * \memberof seqan3::BiFmIndex
  * \brief Type of the unidirectional FM index cursor based on the unidirectional FM index on the original text.
  *
  * \typedef typename t::rev_cursor_type rev_cursor_type
- * \memberof seqan3::BiFmIndex
  * \brief Type of the unidirectional FM index cursor based on the unidirectional FM index on the reversed text.
  *
  * \todo Write me!
@@ -352,11 +339,9 @@ SEQAN3_CONCEPT BiFmIndexCursor = FmIndexCursor<t> && requires (t cur)
  * \{
  *
  * \typedef typename t::index_type index_type
- * \memberof seqan3::BiFmIndexCursor
  * \brief Type of the underlying SeqAn FM index (not the underlying SDSL index).
  *
  * \typedef typename t::size_type size_type
- * \memberof seqan3::BiFmIndexCursor
  * \brief Type for representing the size of the indexed text.
  *
  * \todo Write me!

--- a/include/seqan3/search/fm_index/fm_index.hpp
+++ b/include/seqan3/search/fm_index/fm_index.hpp
@@ -188,12 +188,12 @@ public:
     /*!\name Constructors, destructor and assignment
      * \{
      */
-    fm_index() = default;
-    fm_index(fm_index const &) = default;
-    fm_index & operator=(fm_index const &) = default;
-    fm_index(fm_index &&) = default;
-    fm_index & operator=(fm_index &&) = default;
-    ~fm_index() = default;
+    fm_index() = default;                             //!< Default constructor.
+    fm_index(fm_index const &) = default;             //!< Copy constructor.
+    fm_index & operator=(fm_index const &) = default; //!< Copy assignment.
+    fm_index(fm_index &&) = default;                  //!< Move constructor.
+    fm_index & operator=(fm_index &&) = default;      //!< Move assignment.
+    ~fm_index() = default;                            //!< Destructor.
 
     /*!\brief Constructor that immediately constructs the index given a range.
               The range cannot be an rvalue (i.e. a temporary object) and has to be non-empty.

--- a/include/seqan3/search/fm_index/fm_index_cursor.hpp
+++ b/include/seqan3/search/fm_index/fm_index_cursor.hpp
@@ -163,12 +163,14 @@ public:
     //!\brief Default constructor. Accessing member functions on a default constructed object is undefined behavior.
     //        Default construction is necessary to make this class semi-regular and e.g., to allow construction of
     //        std::array of iterators.
-    fm_index_cursor() noexcept = default;
-    fm_index_cursor(fm_index_cursor const &) noexcept = default;
-    fm_index_cursor & operator=(fm_index_cursor const &) noexcept = default;
-    fm_index_cursor(fm_index_cursor &&) noexcept = default;
-    fm_index_cursor & operator=(fm_index_cursor &&) noexcept = default;
+    fm_index_cursor() noexcept = default;                                    //!< Default constructor.
+    fm_index_cursor(fm_index_cursor const &) noexcept = default;             //!< Copy constructor.
+    fm_index_cursor & operator=(fm_index_cursor const &) noexcept = default; //!< Copy assignment.
+    fm_index_cursor(fm_index_cursor &&) noexcept = default;                  //!< Move constructor.
+    fm_index_cursor & operator=(fm_index_cursor &&) noexcept = default;      //!< Move assignment.
+    ~fm_index_cursor() = default;                                            //!< Destructor.
 
+    //! \brief Construct from given index.
     fm_index_cursor(index_t const & _index) noexcept : index(&_index), node({0, _index.index.size() - 1, 0, 0}),
                                                        sigma(_index.index.sigma - is_collection)
     {}


### PR DESCRIPTION
This would fix all the warnings for the search module.

* How do we want to document the rule of six? Inline? Or an extra line per element?
* Any special way we want to document type deduction guides? Or do we want to exclude them from the docs?