### PR TITLE
[FIX] Fixes construction of end_gaps from lvalues.

### DIFF
--- a/doc/tutorial/pairwise_alignment/index.md
+++ b/doc/tutorial/pairwise_alignment/index.md
@@ -161,7 +161,7 @@ The result can be finally examined using the seqan3::align_result class.
 There is also a shortcut for computing the edit distance for two sequences. The edit distance is a special metric
 to count the number of edit operations between two sequences. It can be solved with a fast bit-vector algorithm.
 To compute the edit-distance you can use the shortcut seqan3::align_cfg::edit. This only works for nucleotide
-sequences. It can be further refined using seqan3::align_cfg::end_gaps::first_ends_free and the
+sequences. It can be further refined using seqan3::align_cfg::end_gaps::free_ends_first and the
 seqan3::align_cfg::max_error configuration.
 
 \todo Compute all pairwise edit operations of the sequences and filter out every alignment with a score higher than 5

--- a/doc/tutorial/pairwise_alignment/index.md
+++ b/doc/tutorial/pairwise_alignment/index.md
@@ -161,7 +161,7 @@ The result can be finally examined using the seqan3::align_result class.
 There is also a shortcut for computing the edit distance for two sequences. The edit distance is a special metric
 to count the number of edit operations between two sequences. It can be solved with a fast bit-vector algorithm.
 To compute the edit-distance you can use the shortcut seqan3::align_cfg::edit. This only works for nucleotide
-sequences. It can be further refined using seqan3::align_cfg::end_gaps::seq1_ends_free and the
+sequences. It can be further refined using seqan3::align_cfg::end_gaps::first_ends_free and the
 seqan3::align_cfg::max_error configuration.
 
 \todo Compute all pairwise edit operations of the sequences and filter out every alignment with a score higher than 5

--- a/doc/tutorial/pairwise_alignment/pa_assignment_2_solution.cpp
+++ b/doc/tutorial/pairwise_alignment/pa_assignment_2_solution.cpp
@@ -28,7 +28,7 @@ int main()
     // Configure the alignment kernel.
     auto config = align_cfg::mode{align_cfg::global_alignment} |
                   align_cfg::scoring{nucleotide_scoring_scheme{}} |
-                  align_cfg::aligned_ends{align_cfg::seq2_ends_free};
+                  align_cfg::aligned_ends{seq2_ends_free};
 
     for (auto const & res : align_pairwise(source, config))
         debug_stream << "Score: " << res.get_score() << '\n';

--- a/doc/tutorial/pairwise_alignment/pa_assignment_2_solution.cpp
+++ b/doc/tutorial/pairwise_alignment/pa_assignment_2_solution.cpp
@@ -28,7 +28,7 @@ int main()
     // Configure the alignment kernel.
     auto config = align_cfg::mode{align_cfg::global_alignment} |
                   align_cfg::scoring{nucleotide_scoring_scheme{}} |
-                  align_cfg::aligned_ends{second_ends_free};
+                  align_cfg::aligned_ends{free_ends_second};
 
     for (auto const & res : align_pairwise(source, config))
         debug_stream << "Score: " << res.get_score() << '\n';

--- a/doc/tutorial/pairwise_alignment/pa_assignment_2_solution.cpp
+++ b/doc/tutorial/pairwise_alignment/pa_assignment_2_solution.cpp
@@ -28,7 +28,7 @@ int main()
     // Configure the alignment kernel.
     auto config = align_cfg::mode{align_cfg::global_alignment} |
                   align_cfg::scoring{nucleotide_scoring_scheme{}} |
-                  align_cfg::aligned_ends{seq2_ends_free};
+                  align_cfg::aligned_ends{second_ends_free};
 
     for (auto const & res : align_pairwise(source, config))
         debug_stream << "Score: " << res.get_score() << '\n';

--- a/doc/tutorial/pairwise_alignment/pa_assignment_3_solution.cpp
+++ b/doc/tutorial/pairwise_alignment/pa_assignment_3_solution.cpp
@@ -29,7 +29,7 @@ int main()
     // Configure the alignment kernel.
     auto config = align_cfg::mode{align_cfg::global_alignment} |
                   align_cfg::scoring{aminoacid_scoring_scheme{aminoacid_similarity_matrix::BLOSUM62}} |
-                  align_cfg::aligned_ends{seq2_ends_free};
+                  align_cfg::aligned_ends{second_ends_free};
 
     for (auto const & res : align_pairwise(source, config))
         debug_stream << "Score: " << res.get_score() << '\n';

--- a/doc/tutorial/pairwise_alignment/pa_assignment_3_solution.cpp
+++ b/doc/tutorial/pairwise_alignment/pa_assignment_3_solution.cpp
@@ -29,7 +29,7 @@ int main()
     // Configure the alignment kernel.
     auto config = align_cfg::mode{align_cfg::global_alignment} |
                   align_cfg::scoring{aminoacid_scoring_scheme{aminoacid_similarity_matrix::BLOSUM62}} |
-                  align_cfg::aligned_ends{second_ends_free};
+                  align_cfg::aligned_ends{free_ends_second};
 
     for (auto const & res : align_pairwise(source, config))
         debug_stream << "Score: " << res.get_score() << '\n';

--- a/doc/tutorial/pairwise_alignment/pa_assignment_3_solution.cpp
+++ b/doc/tutorial/pairwise_alignment/pa_assignment_3_solution.cpp
@@ -29,7 +29,7 @@ int main()
     // Configure the alignment kernel.
     auto config = align_cfg::mode{align_cfg::global_alignment} |
                   align_cfg::scoring{aminoacid_scoring_scheme{aminoacid_similarity_matrix::BLOSUM62}} |
-                  align_cfg::aligned_ends{align_cfg::seq2_ends_free};
+                  align_cfg::aligned_ends{seq2_ends_free};
 
     for (auto const & res : align_pairwise(source, config))
         debug_stream << "Score: " << res.get_score() << '\n';

--- a/doc/tutorial/read_mapper/read_mapper_step3.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_step3.cpp
@@ -43,7 +43,7 @@ void map_reads(std::filesystem::path const & query_path,
 
 //! [alignment_config]
     configuration const align_config = align_cfg::edit |
-                                       align_cfg::aligned_ends{align_cfg::seq1_ends_free} |
+                                       align_cfg::aligned_ends{seq1_ends_free} |
                                        align_cfg::result{align_cfg::with_trace};
 //! [alignment_config]
 

--- a/doc/tutorial/read_mapper/read_mapper_step3.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_step3.cpp
@@ -43,7 +43,7 @@ void map_reads(std::filesystem::path const & query_path,
 
 //! [alignment_config]
     configuration const align_config = align_cfg::edit |
-                                       align_cfg::aligned_ends{seq1_ends_free} |
+                                       align_cfg::aligned_ends{first_ends_free} |
                                        align_cfg::result{align_cfg::with_trace};
 //! [alignment_config]
 

--- a/doc/tutorial/read_mapper/read_mapper_step3.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_step3.cpp
@@ -43,7 +43,7 @@ void map_reads(std::filesystem::path const & query_path,
 
 //! [alignment_config]
     configuration const align_config = align_cfg::edit |
-                                       align_cfg::aligned_ends{first_ends_free} |
+                                       align_cfg::aligned_ends{free_ends_first} |
                                        align_cfg::result{align_cfg::with_trace};
 //! [alignment_config]
 

--- a/doc/tutorial/read_mapper/read_mapper_step4.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_step4.cpp
@@ -53,7 +53,7 @@ void map_reads(std::filesystem::path const & query_path,
                                         search_cfg::mode{search_cfg::all_best};
 
     configuration const align_config = align_cfg::edit |
-                                       align_cfg::aligned_ends{seq1_ends_free} |
+                                       align_cfg::aligned_ends{first_ends_free} |
                                        align_cfg::result{align_cfg::with_trace};
 
     for (auto & [query, id, qual] : query_in)

--- a/doc/tutorial/read_mapper/read_mapper_step4.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_step4.cpp
@@ -53,7 +53,7 @@ void map_reads(std::filesystem::path const & query_path,
                                         search_cfg::mode{search_cfg::all_best};
 
     configuration const align_config = align_cfg::edit |
-                                       align_cfg::aligned_ends{first_ends_free} |
+                                       align_cfg::aligned_ends{free_ends_first} |
                                        align_cfg::result{align_cfg::with_trace};
 
     for (auto & [query, id, qual] : query_in)

--- a/doc/tutorial/read_mapper/read_mapper_step4.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_step4.cpp
@@ -53,7 +53,7 @@ void map_reads(std::filesystem::path const & query_path,
                                         search_cfg::mode{search_cfg::all_best};
 
     configuration const align_config = align_cfg::edit |
-                                       align_cfg::aligned_ends{align_cfg::seq1_ends_free} |
+                                       align_cfg::aligned_ends{seq1_ends_free} |
                                        align_cfg::result{align_cfg::with_trace};
 
     for (auto & [query, id, qual] : query_in)

--- a/doc/tutorial/search/search_solution5.cpp
+++ b/doc/tutorial/search/search_solution5.cpp
@@ -17,7 +17,7 @@ void run_text_single()
     configuration const search_config = search_cfg::max_error{search_cfg::total{1}} |
                                         search_cfg::mode{search_cfg::all_best};
     configuration const align_config = align_cfg::edit |
-                                       align_cfg::aligned_ends{align_cfg::seq1_ends_free} |
+                                       align_cfg::aligned_ends{seq1_ends_free} |
                                        align_cfg::result{align_cfg::with_trace};
 
     auto results = search(index, query, search_config);
@@ -54,7 +54,7 @@ void run_text_collection()
     configuration const search_config = search_cfg::max_error{search_cfg::total{1}} |
                                         search_cfg::mode{search_cfg::all_best};
     configuration const align_config = align_cfg::edit |
-                                       align_cfg::aligned_ends{align_cfg::seq1_ends_free} |
+                                       align_cfg::aligned_ends{seq1_ends_free} |
                                        align_cfg::result{align_cfg::with_trace};
 
     auto results = search(index, query, search_config);

--- a/doc/tutorial/search/search_solution5.cpp
+++ b/doc/tutorial/search/search_solution5.cpp
@@ -17,7 +17,7 @@ void run_text_single()
     configuration const search_config = search_cfg::max_error{search_cfg::total{1}} |
                                         search_cfg::mode{search_cfg::all_best};
     configuration const align_config = align_cfg::edit |
-                                       align_cfg::aligned_ends{seq1_ends_free} |
+                                       align_cfg::aligned_ends{first_ends_free} |
                                        align_cfg::result{align_cfg::with_trace};
 
     auto results = search(index, query, search_config);
@@ -54,7 +54,7 @@ void run_text_collection()
     configuration const search_config = search_cfg::max_error{search_cfg::total{1}} |
                                         search_cfg::mode{search_cfg::all_best};
     configuration const align_config = align_cfg::edit |
-                                       align_cfg::aligned_ends{seq1_ends_free} |
+                                       align_cfg::aligned_ends{first_ends_free} |
                                        align_cfg::result{align_cfg::with_trace};
 
     auto results = search(index, query, search_config);

--- a/doc/tutorial/search/search_solution5.cpp
+++ b/doc/tutorial/search/search_solution5.cpp
@@ -17,7 +17,7 @@ void run_text_single()
     configuration const search_config = search_cfg::max_error{search_cfg::total{1}} |
                                         search_cfg::mode{search_cfg::all_best};
     configuration const align_config = align_cfg::edit |
-                                       align_cfg::aligned_ends{first_ends_free} |
+                                       align_cfg::aligned_ends{free_ends_first} |
                                        align_cfg::result{align_cfg::with_trace};
 
     auto results = search(index, query, search_config);
@@ -54,7 +54,7 @@ void run_text_collection()
     configuration const search_config = search_cfg::max_error{search_cfg::total{1}} |
                                         search_cfg::mode{search_cfg::all_best};
     configuration const align_config = align_cfg::edit |
-                                       align_cfg::aligned_ends{first_ends_free} |
+                                       align_cfg::aligned_ends{free_ends_first} |
                                        align_cfg::result{align_cfg::with_trace};
 
     auto results = search(index, query, search_config);

--- a/include/seqan3/alignment/configuration/align_config_aligned_ends.hpp
+++ b/include/seqan3/alignment/configuration/align_config_aligned_ends.hpp
@@ -85,7 +85,7 @@ public:
  * Using a `bool` allows to dynamically set the value if the option is only known at runtime. If the option is
  * already known at compile time the static version will be the preferred option.
  *
- * \see seqan3::first_seq_trailing
+ * \see seqan3::back_end_first
  * \see seqan3::second_seq_leading
  * \see seqan3::second_seq_trailing
  */
@@ -107,10 +107,10 @@ front_end_first(value_t) -> front_end_first<value_t>;
 //!\}
 
 // ----------------------------------------------------------------------------
-// first_seq_trailing
+// back_end_first
 // ----------------------------------------------------------------------------
 
-/*!\brief The penalty configuration for a aligning the back of the first sequence with a gap.
+/*!\brief The penalty configuration for aligning the back of the first sequence with a gap.
  * \ingroup alignment_configuration
  * \tparam value_t The type of the value to be wrapped. Can be of type std::true_type, std::false_type or bool.
  *
@@ -121,7 +121,7 @@ front_end_first(value_t) -> front_end_first<value_t>;
  * \see second_seq_trailing
  */
 template <typename value_t>
-struct first_seq_trailing : public sequence_end_gap_specifier_base<value_t>
+struct back_end_first : public sequence_end_gap_specifier_base<value_t>
 {
     //!\privatesection
     //!\brief An internal id to allow consistency checks with other gap specifiers.
@@ -129,12 +129,12 @@ struct first_seq_trailing : public sequence_end_gap_specifier_base<value_t>
 };
 
 /*!\name Type deduction guides
- * \relates seqan3::first_seq_trailing
+ * \relates seqan3::back_end_first
  * \{
  */
 //!\brief Deduces the template argument from the type of the wrapped value.
 template <typename value_t>
-first_seq_trailing(value_t) -> first_seq_trailing<value_t>;
+back_end_first(value_t) -> back_end_first<value_t>;
 //!\}
 
 // ----------------------------------------------------------------------------
@@ -148,7 +148,7 @@ first_seq_trailing(value_t) -> first_seq_trailing<value_t>;
  * \copydetails seqan3::front_end_first
  *
  * \see front_end_first
- * \see first_seq_trailing
+ * \see back_end_first
  * \see second_seq_trailing
  */
 template <typename value_t>
@@ -179,7 +179,7 @@ second_seq_leading(value_t) -> second_seq_leading<value_t>;
  * \copydetails seqan3::front_end_first
  *
  * \see front_end_first
- * \see first_seq_trailing
+ * \see back_end_first
  * \see second_seq_leading
  */
 template <typename value_t>
@@ -210,7 +210,7 @@ second_seq_trailing(value_t) -> second_seq_trailing<value_t>;
  * \details
  *
  * A wrapper for providing ordered access to the end-gap specifiers independent of the input order.
- * The possible input types can be: seqan3::front_end_first, seqan3::first_seq_trailing,
+ * The possible input types can be: seqan3::front_end_first, seqan3::back_end_first,
  * seqan3::second_seq_leading and seqan3::second_seq_trailing.
  * The types in the parameter pack `ends_t` are deduced by the corresponding constructor argument.
  * If a specifier is not set it will default to `false` and thus the respective end-gap will be penalised in the
@@ -237,7 +237,7 @@ second_seq_trailing(value_t) -> second_seq_trailing<value_t>;
  * algorithm.
  *
  * \see seqan3::front_end_first
- * \see seqan3::first_seq_trailing
+ * \see seqan3::back_end_first
  * \see seqan3::second_seq_leading
  * \see seqan3::second_seq_trailing
  */
@@ -245,7 +245,7 @@ template <typename ...ends_t>
 //!\cond
     requires sizeof...(ends_t) <= 4 &&
              ((detail::is_type_specialisation_of_v<ends_t, front_end_first> ||
-               detail::is_type_specialisation_of_v<ends_t, first_seq_trailing> ||
+               detail::is_type_specialisation_of_v<ends_t, back_end_first> ||
                detail::is_type_specialisation_of_v<ends_t, second_seq_leading>  ||
                detail::is_type_specialisation_of_v<ends_t, second_seq_trailing>) && ...)
 //!\endcond
@@ -312,7 +312,7 @@ public:
      *
      * The sequence end-gap specifier are stored in an ordered fashion. The following position mapping will be used
      * to access the respective values:
-     * seqan3::front_end_first &rarr; 0; seqan3::first_seq_trailing &rarr; 1;
+     * seqan3::front_end_first &rarr; 0; seqan3::back_end_first &rarr; 1;
      * seqan3::second_seq_leading &rarr; 2; seqan3::second_seq_trailing &rarr; 3.
      *
      * \returns `true` if the respective sequence end-gap is set to be free, `false` otherwise.
@@ -330,7 +330,7 @@ public:
      *
      * The sequence end-gap specifier are stored in an ordered fashion. The following position mapping will be used
      * to access the respective values:
-     * seqan3::front_end_first &rarr; 0; seqan3::first_seq_trailing &rarr; 1;
+     * seqan3::front_end_first &rarr; 0; seqan3::back_end_first &rarr; 1;
      * seqan3::second_seq_leading &rarr; 2; seqan3::second_seq_trailing &rarr; 3.
      *
      * \returns `true` if the respective sequence end-gap is set to be free, `false` otherwise.
@@ -433,7 +433,7 @@ end_gaps(ends_t const & ...) -> end_gaps<ends_t...>;
  * ```
  */
 inline constexpr end_gaps all_ends_free{front_end_first<std::true_type>{},
-                                        first_seq_trailing<std::true_type>{},
+                                        back_end_first<std::true_type>{},
                                         second_seq_leading<std::true_type>{},
                                         second_seq_trailing<std::true_type>{}};
 
@@ -455,7 +455,7 @@ inline constexpr end_gaps all_ends_free{front_end_first<std::true_type>{},
  * ```
  */
 inline constexpr end_gaps none_ends_free{front_end_first<std::false_type>{},
-                                         first_seq_trailing<std::false_type>{},
+                                         back_end_first<std::false_type>{},
                                          second_seq_leading<std::false_type>{},
                                          second_seq_trailing<std::false_type>{}};
 
@@ -478,7 +478,7 @@ inline constexpr end_gaps none_ends_free{front_end_first<std::false_type>{},
  * ```
  */
 inline constexpr end_gaps seq1_ends_free{front_end_first<std::true_type>{},
-                                         first_seq_trailing<std::true_type>{},
+                                         back_end_first<std::true_type>{},
                                          second_seq_leading<std::false_type>{},
                                          second_seq_trailing<std::false_type>{}};
 
@@ -501,7 +501,7 @@ inline constexpr end_gaps seq1_ends_free{front_end_first<std::true_type>{},
  * ```
  */
 inline constexpr end_gaps seq2_ends_free{front_end_first<std::false_type>{},
-                                         first_seq_trailing<std::false_type>{},
+                                         back_end_first<std::false_type>{},
                                          second_seq_leading<std::true_type>{},
                                          second_seq_trailing<std::true_type>{}};
 //!\}

--- a/include/seqan3/alignment/configuration/align_config_aligned_ends.hpp
+++ b/include/seqan3/alignment/configuration/align_config_aligned_ends.hpp
@@ -22,7 +22,7 @@
 #include <seqan3/core/algorithm/pipeable_config_element.hpp>
 #include <seqan3/core/algorithm/parameter_pack.hpp>
 
-namespace seqan3::align_cfg
+namespace seqan3
 {
 
 /*!\brief A mixin class which can maintain a static or a dynamic bool state.
@@ -34,7 +34,7 @@ namespace seqan3::align_cfg
  * \details
  *
  * This mixin base class provides an optional pattern regarding the static state of the represented value.
- * If the mixin is constructed from an std::integral_constant it will hold an static state of the wrapped value.
+ * If the mixin is constructed from an std::integral_constant, it will hold an static state of the wrapped value.
  * In the other case, when constructing it from a boolean, the state of the value will be dynamic.
  */
 template <typename value_t,
@@ -85,9 +85,9 @@ public:
  * Using a `bool` allows to dynamically set the value if the option is only known at runtime. If the option is
  * already known at compile time the static version will be the preferred option.
  *
- * \see first_seq_trailing
- * \see second_seq_leading
- * \see second_seq_trailing
+ * \see seqan3::first_seq_trailing
+ * \see seqan3::second_seq_leading
+ * \see seqan3::second_seq_trailing
  */
 template <typename value_t>
 struct first_seq_leading : public seq_end_gap_base<value_t>
@@ -98,7 +98,7 @@ struct first_seq_leading : public seq_end_gap_base<value_t>
 };
 
 /*!\name Type deduction guides
- * \relates seqan3::align_cfg::first_seq_leading
+ * \relates seqan3::first_seq_leading
  * \{
  */
 //!\brief Deduces the template argument from the type of the wrapped value.
@@ -114,7 +114,7 @@ first_seq_leading(value_t) -> first_seq_leading<value_t>;
  * \ingroup alignment_configuration
  * \tparam value_t The type of the value to be wrapped. Can be of type std::true_type, std::false_type or bool.
  *
- * \copydetails seqan3::align_cfg::first_seq_leading
+ * \copydetails seqan3::first_seq_leading
  *
  * \see first_seq_leading
  * \see second_seq_leading
@@ -129,7 +129,7 @@ struct first_seq_trailing : public seq_end_gap_base<value_t>
 };
 
 /*!\name Type deduction guides
- * \relates seqan3::align_cfg::first_seq_trailing
+ * \relates seqan3::first_seq_trailing
  * \{
  */
 //!\brief Deduces the template argument from the type of the wrapped value.
@@ -145,7 +145,7 @@ first_seq_trailing(value_t) -> first_seq_trailing<value_t>;
  * \ingroup alignment_configuration
  * \tparam value_t The type of the value to be wrapped. Can be of type std::true_type, std::false_type or bool.
  *
- * \copydetails seqan3::align_cfg::first_seq_leading
+ * \copydetails seqan3::first_seq_leading
  *
  * \see first_seq_leading
  * \see first_seq_trailing
@@ -160,7 +160,7 @@ struct second_seq_leading : public seq_end_gap_base<value_t>
 };
 
 /*!\name Type deduction guides
- * \relates seqan3::align_cfg::second_seq_leading
+ * \relates seqan3::second_seq_leading
  * \{
  */
 //!\brief Deduces the template argument from the type of the wrapped value.
@@ -176,7 +176,7 @@ second_seq_leading(value_t) -> second_seq_leading<value_t>;
  * \ingroup alignment_configuration
  * \tparam value_t The type of the value to be wrapped. Can be of type std::true_type, std::false_type or bool.
  *
- * \copydetails seqan3::align_cfg::first_seq_leading
+ * \copydetails seqan3::first_seq_leading
  *
  * \see first_seq_leading
  * \see first_seq_trailing
@@ -191,7 +191,7 @@ struct second_seq_trailing : public seq_end_gap_base<value_t>
 };
 
 /*!\name Type deduction guides
- * \relates seqan3::align_cfg::second_seq_trailing
+ * \relates seqan3::second_seq_trailing
  * \{
  */
 //!\brief Deduces the template argument from the type of the wrapped value.
@@ -210,8 +210,8 @@ second_seq_trailing(value_t) -> second_seq_trailing<value_t>;
  * \details
  *
  * A wrapper for providing ordered access to the end-gap specifiers independent of the input order.
- * The possible input types can be: seqan3::align_cfg::first_seq_leading, seqan3::align_cfg::first_seq_trailing,
- * seqan3::align_cfg::second_seq_leading and seqan3::align_cfg::second_seq_trailing.
+ * The possible input types can be: seqan3::first_seq_leading, seqan3::first_seq_trailing,
+ * seqan3::second_seq_leading and seqan3::second_seq_trailing.
  * The types in the parameter pack `ends_t` are deduced by the corresponding constructor argument.
  * If a specifier is not set it will default to `false` and thus the respective end-gap will be penalised in the
  * pairwise alignment.
@@ -236,10 +236,10 @@ second_seq_trailing(value_t) -> second_seq_trailing<value_t>;
  * the alignment algorithm since the runtime information need to be translated into static information for the alignment
  * algorithm.
  *
- * \see seqan3::align_cfg::first_seq_leading
- * \see seqan3::align_cfg::first_seq_trailing
- * \see seqan3::align_cfg::second_seq_leading
- * \see seqan3::align_cfg::second_seq_trailing
+ * \see seqan3::first_seq_leading
+ * \see seqan3::first_seq_trailing
+ * \see seqan3::second_seq_leading
+ * \see seqan3::second_seq_trailing
  */
 template <typename ...ends_t>
 //!\cond
@@ -312,8 +312,8 @@ public:
      *
      * The sequence end-gap specifier are stored in an ordered fashion. The following position mapping will be used
      * to access the respective values:
-     * seqan3::align_cfg::first_seq_leading &rarr; 0; seqan3::align_cfg::first_seq_trailing &rarr; 1;
-     * seqan3::align_cfg::second_seq_leading &rarr; 2; seqan3::align_cfg::second_seq_trailing &rarr; 3.
+     * seqan3::first_seq_leading &rarr; 0; seqan3::first_seq_trailing &rarr; 1;
+     * seqan3::second_seq_leading &rarr; 2; seqan3::second_seq_trailing &rarr; 3.
      *
      * \returns `true` if the respective sequence end-gap is set to be free, `false` otherwise.
      */
@@ -330,8 +330,8 @@ public:
      *
      * The sequence end-gap specifier are stored in an ordered fashion. The following position mapping will be used
      * to access the respective values:
-     * seqan3::align_cfg::first_seq_leading &rarr; 0; seqan3::align_cfg::first_seq_trailing &rarr; 1;
-     * seqan3::align_cfg::second_seq_leading &rarr; 2; seqan3::align_cfg::second_seq_trailing &rarr; 3.
+     * seqan3::first_seq_leading &rarr; 0; seqan3::first_seq_trailing &rarr; 1;
+     * seqan3::second_seq_leading &rarr; 2; seqan3::second_seq_trailing &rarr; 3.
      *
      * \returns `true` if the respective sequence end-gap is set to be free, `false` otherwise.
      */
@@ -398,60 +398,13 @@ private:
 };
 
 /*!\name Type deduction guides
- * \relates seqan3::align_cfg::end_gaps
+ * \relates seqan3::end_gaps
  * \{
  */
 
 //!\brief Deduces the end-gap specifier from the constructor arguments.
 template <typename ... ends_t>
 end_gaps(ends_t const & ...) -> end_gaps<ends_t...>;
-
-//!\}
-
-// ----------------------------------------------------------------------------
-// aligned_ends
-// ----------------------------------------------------------------------------
-
-/*!\brief The configuration for aligned sequence ends.
- * \ingroup alignment_configuration
- * \tparam end_gaps_t The type of the end-gaps. Must be of type seqan3::align_cfg::end_gaps.
- *
- * \details
- *
- * This configuration element configures the aligned ends to further refine the global alignment algorithm.
- * Particularly, the ends of the alignment can be penalised with gap costs or not. For example, the semi-global
- * alignment does not penalise the leading and trailing gaps of one sequence while it does for the other sequence.
- *
- * The class is instantiated with an object of seqan3::align_cfg::end_gaps. The user can configure each of the
- * gap specifier separately, such that it allows for maximal flexibility to configure the alignment algorithm.
- * However, there are also predefined \ref predefined_end_gap_configurations "configurations", which should be
- * preferred whenever possible.
- *
- * If this configuration element is not specified for the alignment algorithm, it will automatically default to
- * \ref seqan3::align_cfg::end_gaps::none_ends_free "none_ends_free", which computes a global alignment.
- *
- * ### Example
- *
- * \snippet snippet/alignment/configuration/align_cfg_aligned_ends_example.cpp aligned_ends
- */
-template <typename end_gaps_t>
-//!\cond
-    requires detail::is_type_specialisation_of_v<end_gaps_t, end_gaps>
-//!\endcond
-struct aligned_ends : public pipeable_config_element<aligned_ends<end_gaps_t>, end_gaps_t>
-{
-    //!\privatesection
-    //!\brief Internal id to check for consistent configuration settings.
-    static constexpr detail::align_config_id id{detail::align_config_id::aligned_ends};
-};
-
-/*!\name Type deduction guides
- * \relates seqan3::align_cfg::aligned_ends
- * \{
- */
-//!\brief Deduces the end-gaps object type from the constructor argument.
-template <typename end_gaps_t>
-aligned_ends(end_gaps_t) -> aligned_ends<std::remove_reference_t<end_gaps_t>>;
 //!\}
 
 // ----------------------------------------------------------------------------
@@ -461,7 +414,7 @@ aligned_ends(end_gaps_t) -> aligned_ends<std::remove_reference_t<end_gaps_t>>;
 /*!\name Predefined end-gaps configurations
  * \anchor predefined_end_gap_configurations
  * \brief These variables are pre-configured end-gaps that are frequently used in pairwise sequence alignments.
- * \relates seqan3::align_cfg::end_gaps
+ * \relates seqan3::end_gaps
  * \{
  */
 
@@ -553,3 +506,54 @@ inline constexpr end_gaps seq2_ends_free{first_seq_leading<std::false_type>{},
                                          second_seq_trailing<std::true_type>{}};
 //!\}
 } // namespace seqan3
+
+namespace seqan3::align_cfg
+{
+
+// ----------------------------------------------------------------------------
+// aligned_ends
+// ----------------------------------------------------------------------------
+
+/*!\brief The configuration for aligned sequence ends.
+ * \ingroup alignment_configuration
+ * \tparam end_gaps_t The type of the end-gaps. Must be of type seqan3::end_gaps.
+ *
+ * \details
+ *
+ * This configuration element configures the aligned ends to further refine the global alignment algorithm.
+ * Particularly, the ends of the alignment can be penalised with gap costs or not. For example, the semi-global
+ * alignment does not penalise the leading and trailing gaps of one sequence while it does for the other sequence.
+ *
+ * The class is instantiated with an object of seqan3::end_gaps. The user can configure each of the
+ * gap specifier separately, such that it allows for maximal flexibility to configure the alignment algorithm.
+ * However, there are also predefined \ref predefined_end_gap_configurations "configurations", which should be
+ * preferred whenever possible.
+ *
+ * If this configuration element is not specified for the alignment algorithm, it will automatically default to
+ * \ref seqan3::end_gaps::none_ends_free "none_ends_free", which computes a global alignment.
+ *
+ * ### Example
+ *
+ * \snippet snippet/alignment/configuration/align_cfg_aligned_ends_example.cpp aligned_ends
+ */
+template <typename end_gaps_t>
+//!\cond
+    requires detail::is_type_specialisation_of_v<end_gaps_t, end_gaps>
+//!\endcond
+struct aligned_ends : public pipeable_config_element<aligned_ends<end_gaps_t>, end_gaps_t>
+{
+    //!\privatesection
+    //!\brief Internal id to check for consistent configuration settings.
+    static constexpr detail::align_config_id id{detail::align_config_id::aligned_ends};
+};
+
+/*!\name Type deduction guides
+ * \relates seqan3::align_cfg::aligned_ends
+ * \{
+ */
+//!\brief Deduces the end-gaps object type from the constructor argument.
+template <typename end_gaps_t>
+aligned_ends(end_gaps_t) -> aligned_ends<std::remove_reference_t<end_gaps_t>>;
+//!\}
+
+} // namespace seqan3::align_cfg

--- a/include/seqan3/alignment/configuration/align_config_aligned_ends.hpp
+++ b/include/seqan3/alignment/configuration/align_config_aligned_ends.hpp
@@ -408,7 +408,7 @@ end_gaps(ends_t const & ...) -> end_gaps<ends_t...>;
 //!\}
 
 // ----------------------------------------------------------------------------
-// all_ends_free
+// free_ends_all
 // ----------------------------------------------------------------------------
 
 /*!\name Predefined end-gaps configurations
@@ -432,13 +432,13 @@ end_gaps(ends_t const & ...) -> end_gaps<ends_t...>;
  * TTTTTACGTA------
  * ```
  */
-inline constexpr end_gaps all_ends_free{front_end_first<std::true_type>{},
+inline constexpr end_gaps free_ends_all{front_end_first<std::true_type>{},
                                         back_end_first<std::true_type>{},
                                         front_end_second<std::true_type>{},
                                         back_end_second<std::true_type>{}};
 
 // ----------------------------------------------------------------------------
-// none_ends_free
+// free_ends_none
 // ----------------------------------------------------------------------------
 
 /*!\brief All ends are penalised.
@@ -454,13 +454,13 @@ inline constexpr end_gaps all_ends_free{front_end_first<std::true_type>{},
  * AAAACGTATAGACCGT
  * ```
  */
-inline constexpr end_gaps none_ends_free{front_end_first<std::false_type>{},
+inline constexpr end_gaps free_ends_none{front_end_first<std::false_type>{},
                                          back_end_first<std::false_type>{},
                                          front_end_second<std::false_type>{},
                                          back_end_second<std::false_type>{}};
 
 // ----------------------------------------------------------------------------
-// first_ends_free
+// free_ends_first
 // ----------------------------------------------------------------------------
 
 /*!\brief Ends of the first sequence are free.
@@ -477,13 +477,13 @@ inline constexpr end_gaps none_ends_free{front_end_first<std::false_type>{},
  * -----ACGTAAAACGT-----
  * ```
  */
-inline constexpr end_gaps first_ends_free{front_end_first<std::true_type>{},
+inline constexpr end_gaps free_ends_first{front_end_first<std::true_type>{},
                                           back_end_first<std::true_type>{},
                                           front_end_second<std::false_type>{},
                                           back_end_second<std::false_type>{}};
 
 // ----------------------------------------------------------------------------
-// second_ends_free
+// free_ends_second
 // ----------------------------------------------------------------------------
 
 /*!\brief Ends for the second sequence are free.
@@ -500,7 +500,7 @@ inline constexpr end_gaps first_ends_free{front_end_first<std::true_type>{},
  * TTTTTACGT---ATGTCCCCC
  * ```
  */
-inline constexpr end_gaps second_ends_free{front_end_first<std::false_type>{},
+inline constexpr end_gaps free_ends_second{front_end_first<std::false_type>{},
                                            back_end_first<std::false_type>{},
                                            front_end_second<std::true_type>{},
                                            back_end_second<std::true_type>{}};
@@ -516,7 +516,7 @@ namespace seqan3::align_cfg
 
 /*!\brief The configuration for aligned sequence ends.
  * \ingroup alignment_configuration
- * \tparam end_gaps_t The type of the end-gaps. Must be of type seqan3::end_gaps.
+ * \tparam end_gaps_t The type of the end-gaps. Must be a specialisation of seqan3::end_gaps.
  *
  * \details
  *
@@ -530,7 +530,7 @@ namespace seqan3::align_cfg
  * preferred whenever possible.
  *
  * If this configuration element is not specified for the alignment algorithm, it will automatically default to
- * \ref seqan3::end_gaps::none_ends_free "none_ends_free" which computes a global alignment.
+ * \ref seqan3::end_gaps::free_ends_none "free_ends_none" which computes a global alignment.
  *
  * ### Example
  *

--- a/include/seqan3/alignment/configuration/align_config_aligned_ends.hpp
+++ b/include/seqan3/alignment/configuration/align_config_aligned_ends.hpp
@@ -292,13 +292,13 @@ public:
     ~end_gaps()                                      noexcept = default;
 
     //!\brief Construction from at least one sequence end-gap specifier.
-    constexpr end_gaps(ends_t && ...args) noexcept
+    constexpr end_gaps(ends_t const ...args) noexcept
         requires sizeof...(ends_t) > 0
     {
         detail::for_each_value([this](auto e)
         {
             values[remove_cvref_t<decltype(e)>::id()] = e();
-        }, std::forward<ends_t>(args)...);
+        }, args...);
     }
     //\!}
 
@@ -404,7 +404,7 @@ private:
 
 //!\brief Deduces the end-gap specifier from the constructor arguments.
 template <typename ... ends_t>
-end_gaps(ends_t && ...) -> end_gaps<std::remove_reference_t<ends_t>...>;
+end_gaps(ends_t const & ...) -> end_gaps<ends_t...>;
 
 //!\}
 

--- a/include/seqan3/alignment/configuration/align_config_aligned_ends.hpp
+++ b/include/seqan3/alignment/configuration/align_config_aligned_ends.hpp
@@ -483,7 +483,7 @@ inline constexpr end_gaps first_ends_free{front_end_first<std::true_type>{},
                                           back_end_second<std::false_type>{}};
 
 // ----------------------------------------------------------------------------
-// seq2_ends_free
+// second_ends_free
 // ----------------------------------------------------------------------------
 
 /*!\brief Ends for the second sequence are free.
@@ -500,10 +500,10 @@ inline constexpr end_gaps first_ends_free{front_end_first<std::true_type>{},
  * TTTTTACGT---ATGTCCCCC
  * ```
  */
-inline constexpr end_gaps seq2_ends_free{front_end_first<std::false_type>{},
-                                         back_end_first<std::false_type>{},
-                                         front_end_second<std::true_type>{},
-                                         back_end_second<std::true_type>{}};
+inline constexpr end_gaps second_ends_free{front_end_first<std::false_type>{},
+                                           back_end_first<std::false_type>{},
+                                           front_end_second<std::true_type>{},
+                                           back_end_second<std::true_type>{}};
 //!\}
 } // namespace seqan3
 
@@ -525,12 +525,12 @@ namespace seqan3::align_cfg
  * alignment does not penalise the leading and trailing gaps of one sequence while it does for the other sequence.
  *
  * The class is instantiated with an object of seqan3::end_gaps. The user can configure each of the
- * gap specifier separately, such that it allows for maximal flexibility to configure the alignment algorithm.
- * However, there are also predefined \ref predefined_end_gap_configurations "configurations", which should be
+ * gap specifier separately allowing for maximal flexibility when configuring the alignment algorithm.
+ * However, there are also predefined \ref predefined_end_gap_configurations "configurations" which should be
  * preferred whenever possible.
  *
  * If this configuration element is not specified for the alignment algorithm, it will automatically default to
- * \ref seqan3::end_gaps::none_ends_free "none_ends_free", which computes a global alignment.
+ * \ref seqan3::end_gaps::none_ends_free "none_ends_free" which computes a global alignment.
  *
  * ### Example
  *

--- a/include/seqan3/alignment/configuration/align_config_aligned_ends.hpp
+++ b/include/seqan3/alignment/configuration/align_config_aligned_ends.hpp
@@ -86,7 +86,7 @@ public:
  * already known at compile time the static version will be the preferred option.
  *
  * \see seqan3::back_end_first
- * \see seqan3::second_seq_leading
+ * \see seqan3::front_end_second
  * \see seqan3::second_seq_trailing
  */
 template <typename value_t>
@@ -117,7 +117,7 @@ front_end_first(value_t) -> front_end_first<value_t>;
  * \copydetails seqan3::front_end_first
  *
  * \see front_end_first
- * \see second_seq_leading
+ * \see front_end_second
  * \see second_seq_trailing
  */
 template <typename value_t>
@@ -138,10 +138,10 @@ back_end_first(value_t) -> back_end_first<value_t>;
 //!\}
 
 // ----------------------------------------------------------------------------
-// second_seq_leading
+// front_end_second
 // ----------------------------------------------------------------------------
 
-/*!\brief The penalty configuration for a aligning the front of the second sequence with a gap.
+/*!\brief The penalty configuration for aligning the front of the second sequence with a gap.
  * \ingroup alignment_configuration
  * \tparam value_t The type of the value to be wrapped. Can be of type std::true_type, std::false_type or bool.
  *
@@ -152,7 +152,7 @@ back_end_first(value_t) -> back_end_first<value_t>;
  * \see second_seq_trailing
  */
 template <typename value_t>
-struct second_seq_leading : public sequence_end_gap_specifier_base<value_t>
+struct front_end_second : public sequence_end_gap_specifier_base<value_t>
 {
     //!\privatesection
     //!\brief An internal id to allow consistency checks with other gap specifiers.
@@ -160,12 +160,12 @@ struct second_seq_leading : public sequence_end_gap_specifier_base<value_t>
 };
 
 /*!\name Type deduction guides
- * \relates seqan3::second_seq_leading
+ * \relates seqan3::front_end_second
  * \{
  */
 //!\brief Deduces the template argument from the type of the wrapped value.
 template <typename value_t>
-second_seq_leading(value_t) -> second_seq_leading<value_t>;
+front_end_second(value_t) -> front_end_second<value_t>;
 //!\}
 
 // ----------------------------------------------------------------------------
@@ -180,7 +180,7 @@ second_seq_leading(value_t) -> second_seq_leading<value_t>;
  *
  * \see front_end_first
  * \see back_end_first
- * \see second_seq_leading
+ * \see front_end_second
  */
 template <typename value_t>
 struct second_seq_trailing : public sequence_end_gap_specifier_base<value_t>
@@ -211,7 +211,7 @@ second_seq_trailing(value_t) -> second_seq_trailing<value_t>;
  *
  * A wrapper for providing ordered access to the end-gap specifiers independent of the input order.
  * The possible input types can be: seqan3::front_end_first, seqan3::back_end_first,
- * seqan3::second_seq_leading and seqan3::second_seq_trailing.
+ * seqan3::front_end_second and seqan3::second_seq_trailing.
  * The types in the parameter pack `ends_t` are deduced by the corresponding constructor argument.
  * If a specifier is not set it will default to `false` and thus the respective end-gap will be penalised in the
  * pairwise alignment.
@@ -238,7 +238,7 @@ second_seq_trailing(value_t) -> second_seq_trailing<value_t>;
  *
  * \see seqan3::front_end_first
  * \see seqan3::back_end_first
- * \see seqan3::second_seq_leading
+ * \see seqan3::front_end_second
  * \see seqan3::second_seq_trailing
  */
 template <typename ...ends_t>
@@ -246,7 +246,7 @@ template <typename ...ends_t>
     requires sizeof...(ends_t) <= 4 &&
              ((detail::is_type_specialisation_of_v<ends_t, front_end_first> ||
                detail::is_type_specialisation_of_v<ends_t, back_end_first> ||
-               detail::is_type_specialisation_of_v<ends_t, second_seq_leading>  ||
+               detail::is_type_specialisation_of_v<ends_t, front_end_second>  ||
                detail::is_type_specialisation_of_v<ends_t, second_seq_trailing>) && ...)
 //!\endcond
 class end_gaps
@@ -313,7 +313,7 @@ public:
      * The sequence end-gap specifier are stored in an ordered fashion. The following position mapping will be used
      * to access the respective values:
      * seqan3::front_end_first &rarr; 0; seqan3::back_end_first &rarr; 1;
-     * seqan3::second_seq_leading &rarr; 2; seqan3::second_seq_trailing &rarr; 3.
+     * seqan3::front_end_second &rarr; 2; seqan3::second_seq_trailing &rarr; 3.
      *
      * \returns `true` if the respective sequence end-gap is set to be free, `false` otherwise.
      */
@@ -331,7 +331,7 @@ public:
      * The sequence end-gap specifier are stored in an ordered fashion. The following position mapping will be used
      * to access the respective values:
      * seqan3::front_end_first &rarr; 0; seqan3::back_end_first &rarr; 1;
-     * seqan3::second_seq_leading &rarr; 2; seqan3::second_seq_trailing &rarr; 3.
+     * seqan3::front_end_second &rarr; 2; seqan3::second_seq_trailing &rarr; 3.
      *
      * \returns `true` if the respective sequence end-gap is set to be free, `false` otherwise.
      */
@@ -434,7 +434,7 @@ end_gaps(ends_t const & ...) -> end_gaps<ends_t...>;
  */
 inline constexpr end_gaps all_ends_free{front_end_first<std::true_type>{},
                                         back_end_first<std::true_type>{},
-                                        second_seq_leading<std::true_type>{},
+                                        front_end_second<std::true_type>{},
                                         second_seq_trailing<std::true_type>{}};
 
 // ----------------------------------------------------------------------------
@@ -456,7 +456,7 @@ inline constexpr end_gaps all_ends_free{front_end_first<std::true_type>{},
  */
 inline constexpr end_gaps none_ends_free{front_end_first<std::false_type>{},
                                          back_end_first<std::false_type>{},
-                                         second_seq_leading<std::false_type>{},
+                                         front_end_second<std::false_type>{},
                                          second_seq_trailing<std::false_type>{}};
 
 // ----------------------------------------------------------------------------
@@ -479,7 +479,7 @@ inline constexpr end_gaps none_ends_free{front_end_first<std::false_type>{},
  */
 inline constexpr end_gaps seq1_ends_free{front_end_first<std::true_type>{},
                                          back_end_first<std::true_type>{},
-                                         second_seq_leading<std::false_type>{},
+                                         front_end_second<std::false_type>{},
                                          second_seq_trailing<std::false_type>{}};
 
 // ----------------------------------------------------------------------------
@@ -502,7 +502,7 @@ inline constexpr end_gaps seq1_ends_free{front_end_first<std::true_type>{},
  */
 inline constexpr end_gaps seq2_ends_free{front_end_first<std::false_type>{},
                                          back_end_first<std::false_type>{},
-                                         second_seq_leading<std::true_type>{},
+                                         front_end_second<std::true_type>{},
                                          second_seq_trailing<std::true_type>{}};
 //!\}
 } // namespace seqan3

--- a/include/seqan3/alignment/configuration/align_config_aligned_ends.hpp
+++ b/include/seqan3/alignment/configuration/align_config_aligned_ends.hpp
@@ -69,7 +69,7 @@ public:
 };
 
 // ----------------------------------------------------------------------------
-// first_seq_leading
+// front_end_first
 // ----------------------------------------------------------------------------
 
 /*!\brief The penalty configuration for aligning the front of the first sequence with a gap.
@@ -90,7 +90,7 @@ public:
  * \see seqan3::second_seq_trailing
  */
 template <typename value_t>
-struct first_seq_leading : public sequence_end_gap_specifier_base<value_t>
+struct front_end_first : public sequence_end_gap_specifier_base<value_t>
 {
     //!\privatesection
     //!\brief An internal id to allow consistency checks with other gap specifiers.
@@ -98,12 +98,12 @@ struct first_seq_leading : public sequence_end_gap_specifier_base<value_t>
 };
 
 /*!\name Type deduction guides
- * \relates seqan3::first_seq_leading
+ * \relates seqan3::front_end_first
  * \{
  */
 //!\brief Deduces the template argument from the type of the wrapped value.
 template <typename value_t>
-first_seq_leading(value_t) -> first_seq_leading<value_t>;
+front_end_first(value_t) -> front_end_first<value_t>;
 //!\}
 
 // ----------------------------------------------------------------------------
@@ -114,9 +114,9 @@ first_seq_leading(value_t) -> first_seq_leading<value_t>;
  * \ingroup alignment_configuration
  * \tparam value_t The type of the value to be wrapped. Can be of type std::true_type, std::false_type or bool.
  *
- * \copydetails seqan3::first_seq_leading
+ * \copydetails seqan3::front_end_first
  *
- * \see first_seq_leading
+ * \see front_end_first
  * \see second_seq_leading
  * \see second_seq_trailing
  */
@@ -145,9 +145,9 @@ first_seq_trailing(value_t) -> first_seq_trailing<value_t>;
  * \ingroup alignment_configuration
  * \tparam value_t The type of the value to be wrapped. Can be of type std::true_type, std::false_type or bool.
  *
- * \copydetails seqan3::first_seq_leading
+ * \copydetails seqan3::front_end_first
  *
- * \see first_seq_leading
+ * \see front_end_first
  * \see first_seq_trailing
  * \see second_seq_trailing
  */
@@ -176,9 +176,9 @@ second_seq_leading(value_t) -> second_seq_leading<value_t>;
  * \ingroup alignment_configuration
  * \tparam value_t The type of the value to be wrapped. Can be of type std::true_type, std::false_type or bool.
  *
- * \copydetails seqan3::first_seq_leading
+ * \copydetails seqan3::front_end_first
  *
- * \see first_seq_leading
+ * \see front_end_first
  * \see first_seq_trailing
  * \see second_seq_leading
  */
@@ -210,7 +210,7 @@ second_seq_trailing(value_t) -> second_seq_trailing<value_t>;
  * \details
  *
  * A wrapper for providing ordered access to the end-gap specifiers independent of the input order.
- * The possible input types can be: seqan3::first_seq_leading, seqan3::first_seq_trailing,
+ * The possible input types can be: seqan3::front_end_first, seqan3::first_seq_trailing,
  * seqan3::second_seq_leading and seqan3::second_seq_trailing.
  * The types in the parameter pack `ends_t` are deduced by the corresponding constructor argument.
  * If a specifier is not set it will default to `false` and thus the respective end-gap will be penalised in the
@@ -236,7 +236,7 @@ second_seq_trailing(value_t) -> second_seq_trailing<value_t>;
  * the alignment algorithm since the runtime information need to be translated into static information for the alignment
  * algorithm.
  *
- * \see seqan3::first_seq_leading
+ * \see seqan3::front_end_first
  * \see seqan3::first_seq_trailing
  * \see seqan3::second_seq_leading
  * \see seqan3::second_seq_trailing
@@ -244,7 +244,7 @@ second_seq_trailing(value_t) -> second_seq_trailing<value_t>;
 template <typename ...ends_t>
 //!\cond
     requires sizeof...(ends_t) <= 4 &&
-             ((detail::is_type_specialisation_of_v<ends_t, first_seq_leading> ||
+             ((detail::is_type_specialisation_of_v<ends_t, front_end_first> ||
                detail::is_type_specialisation_of_v<ends_t, first_seq_trailing> ||
                detail::is_type_specialisation_of_v<ends_t, second_seq_leading>  ||
                detail::is_type_specialisation_of_v<ends_t, second_seq_trailing>) && ...)
@@ -312,7 +312,7 @@ public:
      *
      * The sequence end-gap specifier are stored in an ordered fashion. The following position mapping will be used
      * to access the respective values:
-     * seqan3::first_seq_leading &rarr; 0; seqan3::first_seq_trailing &rarr; 1;
+     * seqan3::front_end_first &rarr; 0; seqan3::first_seq_trailing &rarr; 1;
      * seqan3::second_seq_leading &rarr; 2; seqan3::second_seq_trailing &rarr; 3.
      *
      * \returns `true` if the respective sequence end-gap is set to be free, `false` otherwise.
@@ -330,7 +330,7 @@ public:
      *
      * The sequence end-gap specifier are stored in an ordered fashion. The following position mapping will be used
      * to access the respective values:
-     * seqan3::first_seq_leading &rarr; 0; seqan3::first_seq_trailing &rarr; 1;
+     * seqan3::front_end_first &rarr; 0; seqan3::first_seq_trailing &rarr; 1;
      * seqan3::second_seq_leading &rarr; 2; seqan3::second_seq_trailing &rarr; 3.
      *
      * \returns `true` if the respective sequence end-gap is set to be free, `false` otherwise.
@@ -432,7 +432,7 @@ end_gaps(ends_t const & ...) -> end_gaps<ends_t...>;
  * TTTTTACGTA------
  * ```
  */
-inline constexpr end_gaps all_ends_free{first_seq_leading<std::true_type>{},
+inline constexpr end_gaps all_ends_free{front_end_first<std::true_type>{},
                                         first_seq_trailing<std::true_type>{},
                                         second_seq_leading<std::true_type>{},
                                         second_seq_trailing<std::true_type>{}};
@@ -454,7 +454,7 @@ inline constexpr end_gaps all_ends_free{first_seq_leading<std::true_type>{},
  * AAAACGTATAGACCGT
  * ```
  */
-inline constexpr end_gaps none_ends_free{first_seq_leading<std::false_type>{},
+inline constexpr end_gaps none_ends_free{front_end_first<std::false_type>{},
                                          first_seq_trailing<std::false_type>{},
                                          second_seq_leading<std::false_type>{},
                                          second_seq_trailing<std::false_type>{}};
@@ -477,7 +477,7 @@ inline constexpr end_gaps none_ends_free{first_seq_leading<std::false_type>{},
  * -----ACGTAAAACGT-----
  * ```
  */
-inline constexpr end_gaps seq1_ends_free{first_seq_leading<std::true_type>{},
+inline constexpr end_gaps seq1_ends_free{front_end_first<std::true_type>{},
                                          first_seq_trailing<std::true_type>{},
                                          second_seq_leading<std::false_type>{},
                                          second_seq_trailing<std::false_type>{}};
@@ -500,7 +500,7 @@ inline constexpr end_gaps seq1_ends_free{first_seq_leading<std::true_type>{},
  * TTTTTACGT---ATGTCCCCC
  * ```
  */
-inline constexpr end_gaps seq2_ends_free{first_seq_leading<std::false_type>{},
+inline constexpr end_gaps seq2_ends_free{front_end_first<std::false_type>{},
                                          first_seq_trailing<std::false_type>{},
                                          second_seq_leading<std::true_type>{},
                                          second_seq_trailing<std::true_type>{}};

--- a/include/seqan3/alignment/configuration/align_config_aligned_ends.hpp
+++ b/include/seqan3/alignment/configuration/align_config_aligned_ends.hpp
@@ -87,7 +87,7 @@ public:
  *
  * \see seqan3::back_end_first
  * \see seqan3::front_end_second
- * \see seqan3::second_seq_trailing
+ * \see seqan3::back_end_second
  */
 template <typename value_t>
 struct front_end_first : public sequence_end_gap_specifier_base<value_t>
@@ -118,7 +118,7 @@ front_end_first(value_t) -> front_end_first<value_t>;
  *
  * \see front_end_first
  * \see front_end_second
- * \see second_seq_trailing
+ * \see back_end_second
  */
 template <typename value_t>
 struct back_end_first : public sequence_end_gap_specifier_base<value_t>
@@ -149,7 +149,7 @@ back_end_first(value_t) -> back_end_first<value_t>;
  *
  * \see front_end_first
  * \see back_end_first
- * \see second_seq_trailing
+ * \see back_end_second
  */
 template <typename value_t>
 struct front_end_second : public sequence_end_gap_specifier_base<value_t>
@@ -169,10 +169,10 @@ front_end_second(value_t) -> front_end_second<value_t>;
 //!\}
 
 // ----------------------------------------------------------------------------
-// second_seq_trailing
+// back_end_second
 // ----------------------------------------------------------------------------
 
-/*!\brief The penalty configuration for a aligning the back of the second sequence with a gap.
+/*!\brief The penalty configuration for aligning the back of the second sequence with a gap.
  * \ingroup alignment_configuration
  * \tparam value_t The type of the value to be wrapped. Can be of type std::true_type, std::false_type or bool.
  *
@@ -183,7 +183,7 @@ front_end_second(value_t) -> front_end_second<value_t>;
  * \see front_end_second
  */
 template <typename value_t>
-struct second_seq_trailing : public sequence_end_gap_specifier_base<value_t>
+struct back_end_second : public sequence_end_gap_specifier_base<value_t>
 {
     //!\privatesection
     //!\brief An internal id to allow consistency checks with other gap specifiers.
@@ -191,12 +191,12 @@ struct second_seq_trailing : public sequence_end_gap_specifier_base<value_t>
 };
 
 /*!\name Type deduction guides
- * \relates seqan3::second_seq_trailing
+ * \relates seqan3::back_end_second
  * \{
  */
 //!\brief Deduces the template argument from the type of the wrapped value.
 template <typename value_t>
-second_seq_trailing(value_t) -> second_seq_trailing<value_t>;
+back_end_second(value_t) -> back_end_second<value_t>;
 //!\}
 
 // ----------------------------------------------------------------------------
@@ -211,7 +211,7 @@ second_seq_trailing(value_t) -> second_seq_trailing<value_t>;
  *
  * A wrapper for providing ordered access to the end-gap specifiers independent of the input order.
  * The possible input types can be: seqan3::front_end_first, seqan3::back_end_first,
- * seqan3::front_end_second and seqan3::second_seq_trailing.
+ * seqan3::front_end_second and seqan3::back_end_second.
  * The types in the parameter pack `ends_t` are deduced by the corresponding constructor argument.
  * If a specifier is not set it will default to `false` and thus the respective end-gap will be penalised in the
  * pairwise alignment.
@@ -239,7 +239,7 @@ second_seq_trailing(value_t) -> second_seq_trailing<value_t>;
  * \see seqan3::front_end_first
  * \see seqan3::back_end_first
  * \see seqan3::front_end_second
- * \see seqan3::second_seq_trailing
+ * \see seqan3::back_end_second
  */
 template <typename ...ends_t>
 //!\cond
@@ -247,7 +247,7 @@ template <typename ...ends_t>
              ((detail::is_type_specialisation_of_v<ends_t, front_end_first> ||
                detail::is_type_specialisation_of_v<ends_t, back_end_first> ||
                detail::is_type_specialisation_of_v<ends_t, front_end_second>  ||
-               detail::is_type_specialisation_of_v<ends_t, second_seq_trailing>) && ...)
+               detail::is_type_specialisation_of_v<ends_t, back_end_second>) && ...)
 //!\endcond
 class end_gaps
 {
@@ -313,7 +313,7 @@ public:
      * The sequence end-gap specifier are stored in an ordered fashion. The following position mapping will be used
      * to access the respective values:
      * seqan3::front_end_first &rarr; 0; seqan3::back_end_first &rarr; 1;
-     * seqan3::front_end_second &rarr; 2; seqan3::second_seq_trailing &rarr; 3.
+     * seqan3::front_end_second &rarr; 2; seqan3::back_end_second &rarr; 3.
      *
      * \returns `true` if the respective sequence end-gap is set to be free, `false` otherwise.
      */
@@ -331,7 +331,7 @@ public:
      * The sequence end-gap specifier are stored in an ordered fashion. The following position mapping will be used
      * to access the respective values:
      * seqan3::front_end_first &rarr; 0; seqan3::back_end_first &rarr; 1;
-     * seqan3::front_end_second &rarr; 2; seqan3::second_seq_trailing &rarr; 3.
+     * seqan3::front_end_second &rarr; 2; seqan3::back_end_second &rarr; 3.
      *
      * \returns `true` if the respective sequence end-gap is set to be free, `false` otherwise.
      */
@@ -435,7 +435,7 @@ end_gaps(ends_t const & ...) -> end_gaps<ends_t...>;
 inline constexpr end_gaps all_ends_free{front_end_first<std::true_type>{},
                                         back_end_first<std::true_type>{},
                                         front_end_second<std::true_type>{},
-                                        second_seq_trailing<std::true_type>{}};
+                                        back_end_second<std::true_type>{}};
 
 // ----------------------------------------------------------------------------
 // none_ends_free
@@ -457,7 +457,7 @@ inline constexpr end_gaps all_ends_free{front_end_first<std::true_type>{},
 inline constexpr end_gaps none_ends_free{front_end_first<std::false_type>{},
                                          back_end_first<std::false_type>{},
                                          front_end_second<std::false_type>{},
-                                         second_seq_trailing<std::false_type>{}};
+                                         back_end_second<std::false_type>{}};
 
 // ----------------------------------------------------------------------------
 // seq1_ends_free
@@ -480,7 +480,7 @@ inline constexpr end_gaps none_ends_free{front_end_first<std::false_type>{},
 inline constexpr end_gaps seq1_ends_free{front_end_first<std::true_type>{},
                                          back_end_first<std::true_type>{},
                                          front_end_second<std::false_type>{},
-                                         second_seq_trailing<std::false_type>{}};
+                                         back_end_second<std::false_type>{}};
 
 // ----------------------------------------------------------------------------
 // seq2_ends_free
@@ -503,7 +503,7 @@ inline constexpr end_gaps seq1_ends_free{front_end_first<std::true_type>{},
 inline constexpr end_gaps seq2_ends_free{front_end_first<std::false_type>{},
                                          back_end_first<std::false_type>{},
                                          front_end_second<std::true_type>{},
-                                         second_seq_trailing<std::true_type>{}};
+                                         back_end_second<std::true_type>{}};
 //!\}
 } // namespace seqan3
 

--- a/include/seqan3/alignment/configuration/align_config_aligned_ends.hpp
+++ b/include/seqan3/alignment/configuration/align_config_aligned_ends.hpp
@@ -43,7 +43,7 @@ template <typename value_t,
 //!\cond
     requires std::Same<value_t, std::true_type> || std::Same<value_t, std::false_type> || std::Same<value_t, bool>
 //!\endcond
-struct seq_end_gap_base
+struct sequence_end_gap_specifier_base
 {
 protected:
 
@@ -90,7 +90,7 @@ public:
  * \see seqan3::second_seq_trailing
  */
 template <typename value_t>
-struct first_seq_leading : public seq_end_gap_base<value_t>
+struct first_seq_leading : public sequence_end_gap_specifier_base<value_t>
 {
     //!\privatesection
     //!\brief An internal id to allow consistency checks with other gap specifiers.
@@ -121,7 +121,7 @@ first_seq_leading(value_t) -> first_seq_leading<value_t>;
  * \see second_seq_trailing
  */
 template <typename value_t>
-struct first_seq_trailing : public seq_end_gap_base<value_t>
+struct first_seq_trailing : public sequence_end_gap_specifier_base<value_t>
 {
     //!\privatesection
     //!\brief An internal id to allow consistency checks with other gap specifiers.
@@ -152,7 +152,7 @@ first_seq_trailing(value_t) -> first_seq_trailing<value_t>;
  * \see second_seq_trailing
  */
 template <typename value_t>
-struct second_seq_leading : public seq_end_gap_base<value_t>
+struct second_seq_leading : public sequence_end_gap_specifier_base<value_t>
 {
     //!\privatesection
     //!\brief An internal id to allow consistency checks with other gap specifiers.
@@ -183,7 +183,7 @@ second_seq_leading(value_t) -> second_seq_leading<value_t>;
  * \see second_seq_leading
  */
 template <typename value_t>
-struct second_seq_trailing : public seq_end_gap_base<value_t>
+struct second_seq_trailing : public sequence_end_gap_specifier_base<value_t>
 {
     //!\privatesection
     //!\brief An internal id to allow consistency checks with other gap specifiers.

--- a/include/seqan3/alignment/configuration/align_config_aligned_ends.hpp
+++ b/include/seqan3/alignment/configuration/align_config_aligned_ends.hpp
@@ -460,7 +460,7 @@ inline constexpr end_gaps none_ends_free{front_end_first<std::false_type>{},
                                          back_end_second<std::false_type>{}};
 
 // ----------------------------------------------------------------------------
-// seq1_ends_free
+// first_ends_free
 // ----------------------------------------------------------------------------
 
 /*!\brief Ends of the first sequence are free.
@@ -477,10 +477,10 @@ inline constexpr end_gaps none_ends_free{front_end_first<std::false_type>{},
  * -----ACGTAAAACGT-----
  * ```
  */
-inline constexpr end_gaps seq1_ends_free{front_end_first<std::true_type>{},
-                                         back_end_first<std::true_type>{},
-                                         front_end_second<std::false_type>{},
-                                         back_end_second<std::false_type>{}};
+inline constexpr end_gaps first_ends_free{front_end_first<std::true_type>{},
+                                          back_end_first<std::true_type>{},
+                                          front_end_second<std::false_type>{},
+                                          back_end_second<std::false_type>{}};
 
 // ----------------------------------------------------------------------------
 // seq2_ends_free

--- a/include/seqan3/alignment/configuration/align_config_edit.hpp
+++ b/include/seqan3/alignment/configuration/align_config_edit.hpp
@@ -37,7 +37,7 @@ namespace seqan3::align_cfg
  * Under the hood SeqAn uses a [fast bit-vector algorithm](https://dl.acm.org/citation.cfm?id=316550) to compute the
  * edit distance whenever possible. This depends on the final alignment configuration. Currently, the fast
  * edit distance algorithm is only triggered for \ref seqan3::align_cfg::global_alignment "global alignments" and
- * \ref seqan3::align_cfg::end_gaps::first_ends_free "semi-global alignments" with free ends in the first sequence.
+ * \ref seqan3::end_gaps::first_ends_free "semi-global alignments" with free ends in the first sequence.
  *
  * \snippet test/snippet/alignment/configuration/align_cfg_edit_example.cpp semi_global
  *

--- a/include/seqan3/alignment/configuration/align_config_edit.hpp
+++ b/include/seqan3/alignment/configuration/align_config_edit.hpp
@@ -37,7 +37,7 @@ namespace seqan3::align_cfg
  * Under the hood SeqAn uses a [fast bit-vector algorithm](https://dl.acm.org/citation.cfm?id=316550) to compute the
  * edit distance whenever possible. This depends on the final alignment configuration. Currently, the fast
  * edit distance algorithm is only triggered for \ref seqan3::align_cfg::global_alignment "global alignments" and
- * \ref seqan3::align_cfg::end_gaps::seq1_ends_free "semi-global alignments" with free ends in the first sequence.
+ * \ref seqan3::align_cfg::end_gaps::first_ends_free "semi-global alignments" with free ends in the first sequence.
  *
  * \snippet test/snippet/alignment/configuration/align_cfg_edit_example.cpp semi_global
  *

--- a/include/seqan3/alignment/configuration/align_config_edit.hpp
+++ b/include/seqan3/alignment/configuration/align_config_edit.hpp
@@ -37,7 +37,7 @@ namespace seqan3::align_cfg
  * Under the hood SeqAn uses a [fast bit-vector algorithm](https://dl.acm.org/citation.cfm?id=316550) to compute the
  * edit distance whenever possible. This depends on the final alignment configuration. Currently, the fast
  * edit distance algorithm is only triggered for \ref seqan3::align_cfg::global_alignment "global alignments" and
- * \ref seqan3::end_gaps::first_ends_free "semi-global alignments" with free ends in the first sequence.
+ * \ref seqan3::end_gaps::free_ends_first "semi-global alignments" with free ends in the first sequence.
  *
  * \snippet test/snippet/alignment/configuration/align_cfg_edit_example.cpp semi_global
  *

--- a/include/seqan3/alignment/pairwise/alignment_configurator.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_configurator.hpp
@@ -257,7 +257,7 @@ public:
             // Use default edit distance if gaps are not set.
             auto const & gaps = cfg.template value_or<align_cfg::gap>(gap_scheme{gap_score{-1}});
             auto const & scoring_scheme = get<align_cfg::scoring>(cfg).value;
-            auto align_ends_cfg = cfg.template value_or<align_cfg::aligned_ends>(align_cfg::none_ends_free);
+            auto align_ends_cfg = cfg.template value_or<align_cfg::aligned_ends>(none_ends_free);
 
             // Only use edit distance if ...
             if (gaps.get_gap_open_score() == 0 &&  // gap open score is not set,
@@ -310,7 +310,7 @@ private:
         // ----------------------------------------------------------------------------
 
         // Get the value for the sequence ends configuration.
-        auto align_ends_cfg = cfg.template value_or<align_cfg::aligned_ends>(align_cfg::none_ends_free);
+        auto align_ends_cfg = cfg.template value_or<align_cfg::aligned_ends>(none_ends_free);
         using align_ends_cfg_t = remove_cvref_t<decltype(align_ends_cfg)>;
 
         auto configure_edit_traits = [&](auto is_semi_global)
@@ -435,7 +435,7 @@ constexpr function_wrapper_t alignment_configurator::configure_free_ends_initial
     // ----------------------------------------------------------------------------
 
     // Get the value for the sequence ends configuration.
-    auto align_ends_cfg = cfg.template value_or<align_cfg::aligned_ends>(align_cfg::none_ends_free);
+    auto align_ends_cfg = cfg.template value_or<align_cfg::aligned_ends>(none_ends_free);
     using align_ends_cfg_t = decltype(align_ends_cfg);
 
     // This lambda augments the initialisation policy of the alignment algorithm
@@ -497,7 +497,7 @@ template <typename function_wrapper_t, typename ...policies_t, typename config_t
 constexpr function_wrapper_t alignment_configurator::configure_free_ends_optimum_search(config_t const & cfg)
 {
     // Get the value for the sequence ends configuration.
-    auto align_ends_cfg = cfg.template value_or<align_cfg::aligned_ends>(align_cfg::none_ends_free);
+    auto align_ends_cfg = cfg.template value_or<align_cfg::aligned_ends>(none_ends_free);
     using align_ends_cfg_t = decltype(align_ends_cfg);
 
     // This lambda augments the find optimum policy of the alignment algorithm with the

--- a/include/seqan3/alignment/pairwise/alignment_configurator.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_configurator.hpp
@@ -257,7 +257,7 @@ public:
             // Use default edit distance if gaps are not set.
             auto const & gaps = cfg.template value_or<align_cfg::gap>(gap_scheme{gap_score{-1}});
             auto const & scoring_scheme = get<align_cfg::scoring>(cfg).value;
-            auto align_ends_cfg = cfg.template value_or<align_cfg::aligned_ends>(none_ends_free);
+            auto align_ends_cfg = cfg.template value_or<align_cfg::aligned_ends>(free_ends_none);
 
             // Only use edit distance if ...
             if (gaps.get_gap_open_score() == 0 &&  // gap open score is not set,
@@ -310,7 +310,7 @@ private:
         // ----------------------------------------------------------------------------
 
         // Get the value for the sequence ends configuration.
-        auto align_ends_cfg = cfg.template value_or<align_cfg::aligned_ends>(none_ends_free);
+        auto align_ends_cfg = cfg.template value_or<align_cfg::aligned_ends>(free_ends_none);
         using align_ends_cfg_t = remove_cvref_t<decltype(align_ends_cfg)>;
 
         auto configure_edit_traits = [&](auto is_semi_global)
@@ -435,7 +435,7 @@ constexpr function_wrapper_t alignment_configurator::configure_free_ends_initial
     // ----------------------------------------------------------------------------
 
     // Get the value for the sequence ends configuration.
-    auto align_ends_cfg = cfg.template value_or<align_cfg::aligned_ends>(none_ends_free);
+    auto align_ends_cfg = cfg.template value_or<align_cfg::aligned_ends>(free_ends_none);
     using align_ends_cfg_t = decltype(align_ends_cfg);
 
     // This lambda augments the initialisation policy of the alignment algorithm
@@ -497,7 +497,7 @@ template <typename function_wrapper_t, typename ...policies_t, typename config_t
 constexpr function_wrapper_t alignment_configurator::configure_free_ends_optimum_search(config_t const & cfg)
 {
     // Get the value for the sequence ends configuration.
-    auto align_ends_cfg = cfg.template value_or<align_cfg::aligned_ends>(none_ends_free);
+    auto align_ends_cfg = cfg.template value_or<align_cfg::aligned_ends>(free_ends_none);
     using align_ends_cfg_t = decltype(align_ends_cfg);
 
     // This lambda augments the find optimum policy of the alignment algorithm with the

--- a/test/snippet/alignment/configuration/align_cfg_aligned_ends_example.cpp
+++ b/test/snippet/alignment/configuration/align_cfg_aligned_ends_example.cpp
@@ -8,9 +8,9 @@ int main()
     using namespace seqan3;
 
     // Create an end_gaps object with one user defined static value and one user defined non-static value.
-    end_gaps eg{first_seq_leading{std::true_type{}}, second_seq_leading{true}};
+    end_gaps eg{front_end_first{std::true_type{}}, second_seq_leading{true}};
 
-    // Check if the first_seq_leading parameter contains static information.
+    // Check if the front_end_first parameter contains static information.
     if constexpr (decltype(eg)::is_static<0>())
     {
         debug_stream << "The leading gaps of the first sequence are static and the value is: " <<
@@ -49,7 +49,7 @@ int main()
     align_cfg::aligned_ends semi_seq2{seq2_ends_free};
 
     // Custom settings.
-    align_cfg::aligned_ends custom{end_gaps{first_seq_leading{std::true_type{}}, second_seq_leading{std::true_type{}}}};
+    align_cfg::aligned_ends custom{end_gaps{front_end_first{std::true_type{}}, second_seq_leading{std::true_type{}}}};
 //! [aligned_ends]
 
     (void) overlap;

--- a/test/snippet/alignment/configuration/align_cfg_aligned_ends_example.cpp
+++ b/test/snippet/alignment/configuration/align_cfg_aligned_ends_example.cpp
@@ -37,16 +37,16 @@ int main()
     using namespace seqan3;
 
     // Setup for overlap alignment.
-    align_cfg::aligned_ends overlap{all_ends_free};
+    align_cfg::aligned_ends overlap{free_ends_all};
 
     // Setup for global alignment.
-    align_cfg::aligned_ends global{none_ends_free};
+    align_cfg::aligned_ends global{free_ends_none};
 
     // Setup for semi-global alignment with free-end gaps in the first sequence.
-    align_cfg::aligned_ends semi_seq1{first_ends_free};
+    align_cfg::aligned_ends semi_seq1{free_ends_first};
 
     // Setup for semi-global alignment with free-end gaps in the second sequence.
-    align_cfg::aligned_ends semi_seq2{second_ends_free};
+    align_cfg::aligned_ends semi_seq2{free_ends_second};
 
     // Custom settings.
     align_cfg::aligned_ends custom{end_gaps{front_end_first{std::true_type{}}, front_end_second{std::true_type{}}}};

--- a/test/snippet/alignment/configuration/align_cfg_aligned_ends_example.cpp
+++ b/test/snippet/alignment/configuration/align_cfg_aligned_ends_example.cpp
@@ -8,7 +8,7 @@ int main()
     using namespace seqan3;
 
     // Create an end_gaps object with one user defined static value and one user defined non-static value.
-    end_gaps eg{front_end_first{std::true_type{}}, second_seq_leading{true}};
+    end_gaps eg{front_end_first{std::true_type{}}, front_end_second{true}};
 
     // Check if the front_end_first parameter contains static information.
     if constexpr (decltype(eg)::is_static<0>())
@@ -49,7 +49,7 @@ int main()
     align_cfg::aligned_ends semi_seq2{seq2_ends_free};
 
     // Custom settings.
-    align_cfg::aligned_ends custom{end_gaps{front_end_first{std::true_type{}}, second_seq_leading{std::true_type{}}}};
+    align_cfg::aligned_ends custom{end_gaps{front_end_first{std::true_type{}}, front_end_second{std::true_type{}}}};
 //! [aligned_ends]
 
     (void) overlap;

--- a/test/snippet/alignment/configuration/align_cfg_aligned_ends_example.cpp
+++ b/test/snippet/alignment/configuration/align_cfg_aligned_ends_example.cpp
@@ -46,7 +46,7 @@ int main()
     align_cfg::aligned_ends semi_seq1{first_ends_free};
 
     // Setup for semi-global alignment with free-end gaps in the second sequence.
-    align_cfg::aligned_ends semi_seq2{seq2_ends_free};
+    align_cfg::aligned_ends semi_seq2{second_ends_free};
 
     // Custom settings.
     align_cfg::aligned_ends custom{end_gaps{front_end_first{std::true_type{}}, front_end_second{std::true_type{}}}};

--- a/test/snippet/alignment/configuration/align_cfg_aligned_ends_example.cpp
+++ b/test/snippet/alignment/configuration/align_cfg_aligned_ends_example.cpp
@@ -8,8 +8,7 @@ int main()
     using namespace seqan3;
 
     // Create an end_gaps object with one user defined static value and one user defined non-static value.
-    align_cfg::end_gaps eg{align_cfg::first_seq_leading{std::true_type{}},
-                           align_cfg::second_seq_leading{true}};
+    end_gaps eg{first_seq_leading{std::true_type{}}, second_seq_leading{true}};
 
     // Check if the first_seq_leading parameter contains static information.
     if constexpr (decltype(eg)::is_static<0>())
@@ -38,20 +37,19 @@ int main()
     using namespace seqan3;
 
     // Setup for overlap alignment.
-    align_cfg::aligned_ends overlap{align_cfg::all_ends_free};
+    align_cfg::aligned_ends overlap{all_ends_free};
 
     // Setup for global alignment.
-    align_cfg::aligned_ends global{align_cfg::none_ends_free};
+    align_cfg::aligned_ends global{none_ends_free};
 
     // Setup for semi-global alignment with free-end gaps in the first sequence.
-    align_cfg::aligned_ends semi_seq1{align_cfg::seq1_ends_free};
+    align_cfg::aligned_ends semi_seq1{seq1_ends_free};
 
     // Setup for semi-global alignment with free-end gaps in the second sequence.
-    align_cfg::aligned_ends semi_seq2{align_cfg::seq2_ends_free};
+    align_cfg::aligned_ends semi_seq2{seq2_ends_free};
 
     // Custom settings.
-    align_cfg::aligned_ends custom{align_cfg::end_gaps{align_cfg::first_seq_leading{std::true_type{}},
-                                                       align_cfg::second_seq_leading{std::true_type{}}}};
+    align_cfg::aligned_ends custom{end_gaps{first_seq_leading{std::true_type{}}, second_seq_leading{std::true_type{}}}};
 //! [aligned_ends]
 
     (void) overlap;

--- a/test/snippet/alignment/configuration/align_cfg_aligned_ends_example.cpp
+++ b/test/snippet/alignment/configuration/align_cfg_aligned_ends_example.cpp
@@ -43,7 +43,7 @@ int main()
     align_cfg::aligned_ends global{none_ends_free};
 
     // Setup for semi-global alignment with free-end gaps in the first sequence.
-    align_cfg::aligned_ends semi_seq1{seq1_ends_free};
+    align_cfg::aligned_ends semi_seq1{first_ends_free};
 
     // Setup for semi-global alignment with free-end gaps in the second sequence.
     align_cfg::aligned_ends semi_seq2{seq2_ends_free};

--- a/test/snippet/alignment/configuration/align_cfg_edit_example.cpp
+++ b/test/snippet/alignment/configuration/align_cfg_edit_example.cpp
@@ -9,7 +9,7 @@ int main()
     using namespace seqan3;
 
     // Computes semi global edit distance using fast-bit vector algorithm.
-    auto cfg_fast = align_cfg::edit | align_cfg::aligned_ends{seq1_ends_free};
+    auto cfg_fast = align_cfg::edit | align_cfg::aligned_ends{first_ends_free};
 
     // Computes semi global edit distance using slower standard pairwise algorithm.
     auto cfg_slow = align_cfg::edit | align_cfg::aligned_ends{seq2_ends_free};

--- a/test/snippet/alignment/configuration/align_cfg_edit_example.cpp
+++ b/test/snippet/alignment/configuration/align_cfg_edit_example.cpp
@@ -9,10 +9,10 @@ int main()
     using namespace seqan3;
 
     // Computes semi global edit distance using fast-bit vector algorithm.
-    auto cfg_fast = align_cfg::edit | align_cfg::aligned_ends{first_ends_free};
+    auto cfg_fast = align_cfg::edit | align_cfg::aligned_ends{free_ends_first};
 
     // Computes semi global edit distance using slower standard pairwise algorithm.
-    auto cfg_slow = align_cfg::edit | align_cfg::aligned_ends{second_ends_free};
+    auto cfg_slow = align_cfg::edit | align_cfg::aligned_ends{free_ends_second};
 //! [semi_global]
     (void) cfg_fast;
     (void) cfg_slow;

--- a/test/snippet/alignment/configuration/align_cfg_edit_example.cpp
+++ b/test/snippet/alignment/configuration/align_cfg_edit_example.cpp
@@ -12,7 +12,7 @@ int main()
     auto cfg_fast = align_cfg::edit | align_cfg::aligned_ends{first_ends_free};
 
     // Computes semi global edit distance using slower standard pairwise algorithm.
-    auto cfg_slow = align_cfg::edit | align_cfg::aligned_ends{seq2_ends_free};
+    auto cfg_slow = align_cfg::edit | align_cfg::aligned_ends{second_ends_free};
 //! [semi_global]
     (void) cfg_fast;
     (void) cfg_slow;

--- a/test/snippet/alignment/configuration/align_cfg_edit_example.cpp
+++ b/test/snippet/alignment/configuration/align_cfg_edit_example.cpp
@@ -9,10 +9,10 @@ int main()
     using namespace seqan3;
 
     // Computes semi global edit distance using fast-bit vector algorithm.
-    auto cfg_fast = align_cfg::edit | align_cfg::aligned_ends{align_cfg::seq1_ends_free};
+    auto cfg_fast = align_cfg::edit | align_cfg::aligned_ends{seq1_ends_free};
 
     // Computes semi global edit distance using slower standard pairwise algorithm.
-    auto cfg_slow = align_cfg::edit | align_cfg::aligned_ends{align_cfg::seq2_ends_free};
+    auto cfg_slow = align_cfg::edit | align_cfg::aligned_ends{seq2_ends_free};
 //! [semi_global]
     (void) cfg_fast;
     (void) cfg_slow;

--- a/test/unit/alignment/configuration/align_config_aligned_ends_test.cpp
+++ b/test/unit/alignment/configuration/align_config_aligned_ends_test.cpp
@@ -300,41 +300,41 @@ TEST(end_gaps, static_access)
     EXPECT_EQ(eg[2], false);
 }
 
-TEST(end_gaps, all_ends_free)
+TEST(end_gaps, free_ends_all)
 {
     using test = end_gaps<front_end_first<std::true_type>,
                           back_end_first<std::true_type>,
                           front_end_second<std::true_type>,
                           back_end_second<std::true_type>>;
-    EXPECT_EQ((std::is_same_v<std::remove_const_t<decltype(all_ends_free)>, test>), true);
+    EXPECT_EQ((std::is_same_v<std::remove_const_t<decltype(free_ends_all)>, test>), true);
 }
 
-TEST(end_gaps, none_ends_free)
+TEST(end_gaps, free_ends_none)
 {
     using test = end_gaps<front_end_first<std::false_type>,
                           back_end_first<std::false_type>,
                           front_end_second<std::false_type>,
                           back_end_second<std::false_type>>;
 
-    EXPECT_EQ((std::is_same_v<std::remove_const_t<decltype(none_ends_free)>, test>), true);
+    EXPECT_EQ((std::is_same_v<std::remove_const_t<decltype(free_ends_none)>, test>), true);
 }
 
-TEST(end_gaps, first_ends_free)
+TEST(end_gaps, free_ends_first)
 {
     using test = end_gaps<front_end_first<std::true_type>,
                           back_end_first<std::true_type>,
                           front_end_second<std::false_type>,
                           back_end_second<std::false_type>>;
-    EXPECT_EQ((std::is_same_v<std::remove_const_t<decltype(first_ends_free)>, test>), true);
+    EXPECT_EQ((std::is_same_v<std::remove_const_t<decltype(free_ends_first)>, test>), true);
 }
 
-TEST(end_gaps, second_ends_free)
+TEST(end_gaps, free_ends_second)
 {
     using test = end_gaps<front_end_first<std::false_type>,
                           back_end_first<std::false_type>,
                           front_end_second<std::true_type>,
                           back_end_second<std::true_type>>;
-    EXPECT_EQ((std::is_same_v<std::remove_const_t<decltype(second_ends_free)>, test>), true);
+    EXPECT_EQ((std::is_same_v<std::remove_const_t<decltype(free_ends_second)>, test>), true);
 }
 
 TEST(align_cfg_aligned_ends, is_aggregate)
@@ -344,7 +344,7 @@ TEST(align_cfg_aligned_ends, is_aggregate)
 
 TEST(align_cfg_aligned_ends, id)
 {
-    align_cfg::aligned_ends cfg{all_ends_free};
+    align_cfg::aligned_ends cfg{free_ends_all};
 
     EXPECT_EQ(static_cast<uint8_t>(decltype(cfg)::id),
               static_cast<uint8_t>(detail::align_config_id::aligned_ends));
@@ -352,7 +352,7 @@ TEST(align_cfg_aligned_ends, id)
 
 TEST(align_cfg_aligned_ends, value)
 {
-    align_cfg::aligned_ends cfg{first_ends_free};
+    align_cfg::aligned_ends cfg{free_ends_first};
     using type = decltype(cfg.value);
 
     using test = end_gaps<front_end_first<std::true_type>,
@@ -376,7 +376,7 @@ TEST(align_cfg_aligned_ends, value)
 TEST(align_cfg_aligned_ends, configuration)
 {
     {
-        align_cfg::aligned_ends elem{all_ends_free};
+        align_cfg::aligned_ends elem{free_ends_all};
         configuration cfg{elem};
 
         EXPECT_EQ((get<align_cfg::aligned_ends>(cfg).value[0]), true);
@@ -386,7 +386,7 @@ TEST(align_cfg_aligned_ends, configuration)
     }
 
     {
-        configuration cfg{align_cfg::aligned_ends{all_ends_free}};
+        configuration cfg{align_cfg::aligned_ends{free_ends_all}};
 
         EXPECT_EQ((get<align_cfg::aligned_ends>(cfg).value[0]), true);
         EXPECT_EQ((get<align_cfg::aligned_ends>(cfg).value[1]), true);

--- a/test/unit/alignment/configuration/align_config_aligned_ends_test.cpp
+++ b/test/unit/alignment/configuration/align_config_aligned_ends_test.cpp
@@ -328,13 +328,13 @@ TEST(end_gaps, first_ends_free)
     EXPECT_EQ((std::is_same_v<std::remove_const_t<decltype(first_ends_free)>, test>), true);
 }
 
-TEST(end_gaps, seq2_ends_free)
+TEST(end_gaps, second_ends_free)
 {
     using test = end_gaps<front_end_first<std::false_type>,
                           back_end_first<std::false_type>,
                           front_end_second<std::true_type>,
                           back_end_second<std::true_type>>;
-    EXPECT_EQ((std::is_same_v<std::remove_const_t<decltype(seq2_ends_free)>, test>), true);
+    EXPECT_EQ((std::is_same_v<std::remove_const_t<decltype(second_ends_free)>, test>), true);
 }
 
 TEST(align_cfg_aligned_ends, is_aggregate)

--- a/test/unit/alignment/configuration/align_config_aligned_ends_test.cpp
+++ b/test/unit/alignment/configuration/align_config_aligned_ends_test.cpp
@@ -319,13 +319,13 @@ TEST(end_gaps, none_ends_free)
     EXPECT_EQ((std::is_same_v<std::remove_const_t<decltype(none_ends_free)>, test>), true);
 }
 
-TEST(end_gaps, seq1_ends_free)
+TEST(end_gaps, first_ends_free)
 {
     using test = end_gaps<front_end_first<std::true_type>,
                           back_end_first<std::true_type>,
                           front_end_second<std::false_type>,
                           back_end_second<std::false_type>>;
-    EXPECT_EQ((std::is_same_v<std::remove_const_t<decltype(seq1_ends_free)>, test>), true);
+    EXPECT_EQ((std::is_same_v<std::remove_const_t<decltype(first_ends_free)>, test>), true);
 }
 
 TEST(end_gaps, seq2_ends_free)
@@ -352,7 +352,7 @@ TEST(align_cfg_aligned_ends, id)
 
 TEST(align_cfg_aligned_ends, value)
 {
-    align_cfg::aligned_ends cfg{seq1_ends_free};
+    align_cfg::aligned_ends cfg{first_ends_free};
     using type = decltype(cfg.value);
 
     using test = end_gaps<front_end_first<std::true_type>,

--- a/test/unit/alignment/configuration/align_config_aligned_ends_test.cpp
+++ b/test/unit/alignment/configuration/align_config_aligned_ends_test.cpp
@@ -39,8 +39,8 @@ private:
     }
 };
 
-using static_end_gap_types = ::testing::Types<first_seq_leading<std::true_type>,
-                                              first_seq_leading<std::false_type>,
+using static_end_gap_types = ::testing::Types<front_end_first<std::true_type>,
+                                              front_end_first<std::false_type>,
                                               first_seq_trailing<std::true_type>,
                                               first_seq_trailing<std::false_type>,
                                               second_seq_leading<std::true_type>,
@@ -54,7 +54,7 @@ template <typename type>
 class dynamic_end_gap_test : public ::testing::Test
 {};
 
-using dynamic_end_gap_types = ::testing::Types<first_seq_leading<bool>,
+using dynamic_end_gap_types = ::testing::Types<front_end_first<bool>,
                                                first_seq_trailing<bool>,
                                                second_seq_leading<bool>,
                                                second_seq_trailing<bool>>;
@@ -67,20 +67,20 @@ TEST(sequence_end_gap_specifier_base, aggregate)
     EXPECT_TRUE((std::is_aggregate_v<dummy_gap<bool>>));
 }
 
-TEST(first_seq_leading, deduction)
+TEST(front_end_first, deduction)
 {
     { // static
-        first_seq_leading tmp{std::true_type{}};
-        EXPECT_EQ((std::is_same_v<decltype(tmp), first_seq_leading<std::true_type>>), true);
-        first_seq_leading tmp2{std::false_type{}};
-        EXPECT_EQ((std::is_same_v<decltype(tmp2), first_seq_leading<std::false_type>>), true);
+        front_end_first tmp{std::true_type{}};
+        EXPECT_EQ((std::is_same_v<decltype(tmp), front_end_first<std::true_type>>), true);
+        front_end_first tmp2{std::false_type{}};
+        EXPECT_EQ((std::is_same_v<decltype(tmp2), front_end_first<std::false_type>>), true);
     }
 
     { // dynamic
-        first_seq_leading tmp{true};
-        EXPECT_EQ((std::is_same_v<decltype(tmp), first_seq_leading<bool>>), true);
-        first_seq_leading tmp2{false};
-        EXPECT_EQ((std::is_same_v<decltype(tmp2), first_seq_leading<bool>>), true);
+        front_end_first tmp{true};
+        EXPECT_EQ((std::is_same_v<decltype(tmp), front_end_first<bool>>), true);
+        front_end_first tmp2{false};
+        EXPECT_EQ((std::is_same_v<decltype(tmp2), front_end_first<bool>>), true);
     }
 }
 
@@ -174,44 +174,44 @@ TEST(end_gaps, construction)
     }
 
     { // one element
-        EXPECT_TRUE((std::is_nothrow_default_constructible_v<end_gaps<first_seq_leading<std::true_type>>>));
-        EXPECT_TRUE((std::is_nothrow_copy_constructible_v<end_gaps<first_seq_leading<std::true_type>>>));
-        EXPECT_TRUE((std::is_nothrow_move_constructible_v<end_gaps<first_seq_leading<std::true_type>>>));
-        EXPECT_TRUE((std::is_nothrow_copy_assignable_v<end_gaps<first_seq_leading<std::true_type>>>));
-        EXPECT_TRUE((std::is_nothrow_move_assignable_v<end_gaps<first_seq_leading<std::true_type>>>));
+        EXPECT_TRUE((std::is_nothrow_default_constructible_v<end_gaps<front_end_first<std::true_type>>>));
+        EXPECT_TRUE((std::is_nothrow_copy_constructible_v<end_gaps<front_end_first<std::true_type>>>));
+        EXPECT_TRUE((std::is_nothrow_move_constructible_v<end_gaps<front_end_first<std::true_type>>>));
+        EXPECT_TRUE((std::is_nothrow_copy_assignable_v<end_gaps<front_end_first<std::true_type>>>));
+        EXPECT_TRUE((std::is_nothrow_move_assignable_v<end_gaps<front_end_first<std::true_type>>>));
 
-        EXPECT_TRUE((std::is_nothrow_constructible_v<end_gaps<first_seq_leading<std::true_type>>>));
+        EXPECT_TRUE((std::is_nothrow_constructible_v<end_gaps<front_end_first<std::true_type>>>));
     }
 
     { // four elements
-        EXPECT_TRUE((std::is_nothrow_default_constructible_v<end_gaps<first_seq_leading<std::true_type>,
+        EXPECT_TRUE((std::is_nothrow_default_constructible_v<end_gaps<front_end_first<std::true_type>,
                                                                       second_seq_leading<bool>,
                                                                       first_seq_trailing<std::false_type>,
                                                                       second_seq_trailing<bool>>>));
-        EXPECT_TRUE((std::is_nothrow_copy_constructible_v<end_gaps<first_seq_leading<std::true_type>,
+        EXPECT_TRUE((std::is_nothrow_copy_constructible_v<end_gaps<front_end_first<std::true_type>,
                                                                    second_seq_leading<bool>,
                                                                    first_seq_trailing<std::false_type>,
                                                                    second_seq_trailing<bool>>>));
-        EXPECT_TRUE((std::is_nothrow_move_constructible_v<end_gaps<first_seq_leading<std::true_type>,
+        EXPECT_TRUE((std::is_nothrow_move_constructible_v<end_gaps<front_end_first<std::true_type>,
                                                                    second_seq_leading<bool>,
                                                                    first_seq_trailing<std::false_type>,
                                                                    second_seq_trailing<bool>>>));
-        EXPECT_TRUE((std::is_nothrow_copy_assignable_v<end_gaps<first_seq_leading<std::true_type>,
+        EXPECT_TRUE((std::is_nothrow_copy_assignable_v<end_gaps<front_end_first<std::true_type>,
                                                                 second_seq_leading<bool>,
                                                                 first_seq_trailing<std::false_type>,
                                                                 second_seq_trailing<bool>>>));
-        EXPECT_TRUE((std::is_nothrow_move_assignable_v<end_gaps<first_seq_leading<std::true_type>,
+        EXPECT_TRUE((std::is_nothrow_move_assignable_v<end_gaps<front_end_first<std::true_type>,
                                                                 second_seq_leading<bool>,
                                                                 first_seq_trailing<std::false_type>,
                                                                 second_seq_trailing<bool>>>));
-        EXPECT_TRUE((std::is_nothrow_constructible_v<end_gaps<first_seq_leading<std::true_type>,
+        EXPECT_TRUE((std::is_nothrow_constructible_v<end_gaps<front_end_first<std::true_type>,
                                                               second_seq_leading<bool>,
                                                               first_seq_trailing<std::false_type>,
                                                               second_seq_trailing<bool>>>));
     }
 
     { // from lvalue
-        first_seq_leading fsl{std::true_type{}};
+        front_end_first fsl{std::true_type{}};
         EXPECT_TRUE(end_gaps{fsl}[0]);
     }
 }
@@ -230,8 +230,8 @@ TEST(end_gaps, deduction)
     }
 
     { // multiple elements
-        end_gaps eg{second_seq_trailing{true}, first_seq_leading{std::true_type{}}, second_seq_leading{std::false_type{}}};
-        using foo = end_gaps<second_seq_trailing<bool>, first_seq_leading<std::true_type>, second_seq_leading<std::false_type>>;
+        end_gaps eg{second_seq_trailing{true}, front_end_first{std::true_type{}}, second_seq_leading{std::false_type{}}};
+        using foo = end_gaps<second_seq_trailing<bool>, front_end_first<std::true_type>, second_seq_leading<std::false_type>>;
         EXPECT_EQ((std::is_same_v<decltype(eg), foo>), true);
     }
 }
@@ -248,7 +248,7 @@ TEST(end_gaps, access)
     }
 
     { // custom
-        end_gaps eg{second_seq_trailing{true}, first_seq_leading{std::true_type{}}, second_seq_leading{std::false_type{}}};
+        end_gaps eg{second_seq_trailing{true}, front_end_first{std::true_type{}}, second_seq_leading{std::false_type{}}};
 
         EXPECT_EQ(eg[0], true);
         EXPECT_EQ(eg[1], false);
@@ -273,7 +273,7 @@ TEST(end_gaps, static_query)
     }
 
     { // custom
-        end_gaps eg{second_seq_trailing{true}, first_seq_leading{std::true_type{}}, second_seq_leading{std::false_type{}}};
+        end_gaps eg{second_seq_trailing{true}, front_end_first{std::true_type{}}, second_seq_leading{std::false_type{}}};
 
         constexpr bool seq1_l = decltype(eg)::is_static<0>();
         constexpr bool seq1_t = decltype(eg)::is_static<1>();
@@ -289,7 +289,7 @@ TEST(end_gaps, static_query)
 
 TEST(end_gaps, static_access)
 {
-    end_gaps eg{second_seq_trailing{true}, first_seq_leading{std::true_type{}}, second_seq_leading{std::false_type{}}};
+    end_gaps eg{second_seq_trailing{true}, front_end_first{std::true_type{}}, second_seq_leading{std::false_type{}}};
 
     constexpr bool seq1_l = decltype(eg)::get_static<0>();
     constexpr bool seq2_l = decltype(eg)::get_static<2>();
@@ -302,7 +302,7 @@ TEST(end_gaps, static_access)
 
 TEST(end_gaps, all_ends_free)
 {
-    using test = end_gaps<first_seq_leading<std::true_type>,
+    using test = end_gaps<front_end_first<std::true_type>,
                           first_seq_trailing<std::true_type>,
                           second_seq_leading<std::true_type>,
                           second_seq_trailing<std::true_type>>;
@@ -311,7 +311,7 @@ TEST(end_gaps, all_ends_free)
 
 TEST(end_gaps, none_ends_free)
 {
-    using test = end_gaps<first_seq_leading<std::false_type>,
+    using test = end_gaps<front_end_first<std::false_type>,
                           first_seq_trailing<std::false_type>,
                           second_seq_leading<std::false_type>,
                           second_seq_trailing<std::false_type>>;
@@ -321,7 +321,7 @@ TEST(end_gaps, none_ends_free)
 
 TEST(end_gaps, seq1_ends_free)
 {
-    using test = end_gaps<first_seq_leading<std::true_type>,
+    using test = end_gaps<front_end_first<std::true_type>,
                           first_seq_trailing<std::true_type>,
                           second_seq_leading<std::false_type>,
                           second_seq_trailing<std::false_type>>;
@@ -330,7 +330,7 @@ TEST(end_gaps, seq1_ends_free)
 
 TEST(end_gaps, seq2_ends_free)
 {
-    using test = end_gaps<first_seq_leading<std::false_type>,
+    using test = end_gaps<front_end_first<std::false_type>,
                           first_seq_trailing<std::false_type>,
                           second_seq_leading<std::true_type>,
                           second_seq_trailing<std::true_type>>;
@@ -355,7 +355,7 @@ TEST(align_cfg_aligned_ends, value)
     align_cfg::aligned_ends cfg{seq1_ends_free};
     using type = decltype(cfg.value);
 
-    using test = end_gaps<first_seq_leading<std::true_type>,
+    using test = end_gaps<front_end_first<std::true_type>,
                           first_seq_trailing<std::true_type>,
                           second_seq_leading<std::false_type>,
                           second_seq_trailing<std::false_type>>;

--- a/test/unit/alignment/configuration/align_config_aligned_ends_test.cpp
+++ b/test/unit/alignment/configuration/align_config_aligned_ends_test.cpp
@@ -209,6 +209,11 @@ TEST(end_gaps, construction)
                                                               first_seq_trailing<std::false_type>,
                                                               second_seq_trailing<bool>>>));
     }
+
+    { // from lvalue
+        first_seq_leading fsl{std::true_type{}};
+        EXPECT_TRUE(end_gaps{fsl}[0]);
+    }
 }
 
 TEST(end_gaps, deduction)

--- a/test/unit/alignment/configuration/align_config_aligned_ends_test.cpp
+++ b/test/unit/alignment/configuration/align_config_aligned_ends_test.cpp
@@ -43,8 +43,8 @@ using static_end_gap_types = ::testing::Types<front_end_first<std::true_type>,
                                               front_end_first<std::false_type>,
                                               back_end_first<std::true_type>,
                                               back_end_first<std::false_type>,
-                                              second_seq_leading<std::true_type>,
-                                              second_seq_leading<std::false_type>,
+                                              front_end_second<std::true_type>,
+                                              front_end_second<std::false_type>,
                                               second_seq_trailing<std::true_type>,
                                               second_seq_trailing<std::false_type>>;
 
@@ -56,7 +56,7 @@ class dynamic_end_gap_test : public ::testing::Test
 
 using dynamic_end_gap_types = ::testing::Types<front_end_first<bool>,
                                                back_end_first<bool>,
-                                               second_seq_leading<bool>,
+                                               front_end_second<bool>,
                                                second_seq_trailing<bool>>;
 
 TYPED_TEST_CASE(dynamic_end_gap_test, dynamic_end_gap_types);
@@ -101,20 +101,20 @@ TEST(back_end_first, deduction)
     }
 }
 
-TEST(second_seq_leading, deduction)
+TEST(front_end_second, deduction)
 {
     { // static
-        second_seq_leading tmp{std::true_type{}};
-        EXPECT_EQ((std::is_same_v<decltype(tmp), second_seq_leading<std::true_type>>), true);
-        second_seq_leading tmp2{std::false_type{}};
-        EXPECT_EQ((std::is_same_v<decltype(tmp2), second_seq_leading<std::false_type>>), true);
+        front_end_second tmp{std::true_type{}};
+        EXPECT_EQ((std::is_same_v<decltype(tmp), front_end_second<std::true_type>>), true);
+        front_end_second tmp2{std::false_type{}};
+        EXPECT_EQ((std::is_same_v<decltype(tmp2), front_end_second<std::false_type>>), true);
     }
 
     { // dynamic
-        second_seq_leading tmp{true};
-        EXPECT_EQ((std::is_same_v<decltype(tmp), second_seq_leading<bool>>), true);
-        second_seq_leading tmp2{false};
-        EXPECT_EQ((std::is_same_v<decltype(tmp2), second_seq_leading<bool>>), true);
+        front_end_second tmp{true};
+        EXPECT_EQ((std::is_same_v<decltype(tmp), front_end_second<bool>>), true);
+        front_end_second tmp2{false};
+        EXPECT_EQ((std::is_same_v<decltype(tmp2), front_end_second<bool>>), true);
     }
 }
 
@@ -185,27 +185,27 @@ TEST(end_gaps, construction)
 
     { // four elements
         EXPECT_TRUE((std::is_nothrow_default_constructible_v<end_gaps<front_end_first<std::true_type>,
-                                                                      second_seq_leading<bool>,
+                                                                      front_end_second<bool>,
                                                                       back_end_first<std::false_type>,
                                                                       second_seq_trailing<bool>>>));
         EXPECT_TRUE((std::is_nothrow_copy_constructible_v<end_gaps<front_end_first<std::true_type>,
-                                                                   second_seq_leading<bool>,
+                                                                   front_end_second<bool>,
                                                                    back_end_first<std::false_type>,
                                                                    second_seq_trailing<bool>>>));
         EXPECT_TRUE((std::is_nothrow_move_constructible_v<end_gaps<front_end_first<std::true_type>,
-                                                                   second_seq_leading<bool>,
+                                                                   front_end_second<bool>,
                                                                    back_end_first<std::false_type>,
                                                                    second_seq_trailing<bool>>>));
         EXPECT_TRUE((std::is_nothrow_copy_assignable_v<end_gaps<front_end_first<std::true_type>,
-                                                                second_seq_leading<bool>,
+                                                                front_end_second<bool>,
                                                                 back_end_first<std::false_type>,
                                                                 second_seq_trailing<bool>>>));
         EXPECT_TRUE((std::is_nothrow_move_assignable_v<end_gaps<front_end_first<std::true_type>,
-                                                                second_seq_leading<bool>,
+                                                                front_end_second<bool>,
                                                                 back_end_first<std::false_type>,
                                                                 second_seq_trailing<bool>>>));
         EXPECT_TRUE((std::is_nothrow_constructible_v<end_gaps<front_end_first<std::true_type>,
-                                                              second_seq_leading<bool>,
+                                                              front_end_second<bool>,
                                                               back_end_first<std::false_type>,
                                                               second_seq_trailing<bool>>>));
     }
@@ -230,8 +230,8 @@ TEST(end_gaps, deduction)
     }
 
     { // multiple elements
-        end_gaps eg{second_seq_trailing{true}, front_end_first{std::true_type{}}, second_seq_leading{std::false_type{}}};
-        using foo = end_gaps<second_seq_trailing<bool>, front_end_first<std::true_type>, second_seq_leading<std::false_type>>;
+        end_gaps eg{second_seq_trailing{true}, front_end_first{std::true_type{}}, front_end_second{std::false_type{}}};
+        using foo = end_gaps<second_seq_trailing<bool>, front_end_first<std::true_type>, front_end_second<std::false_type>>;
         EXPECT_EQ((std::is_same_v<decltype(eg), foo>), true);
     }
 }
@@ -248,7 +248,7 @@ TEST(end_gaps, access)
     }
 
     { // custom
-        end_gaps eg{second_seq_trailing{true}, front_end_first{std::true_type{}}, second_seq_leading{std::false_type{}}};
+        end_gaps eg{second_seq_trailing{true}, front_end_first{std::true_type{}}, front_end_second{std::false_type{}}};
 
         EXPECT_EQ(eg[0], true);
         EXPECT_EQ(eg[1], false);
@@ -273,7 +273,7 @@ TEST(end_gaps, static_query)
     }
 
     { // custom
-        end_gaps eg{second_seq_trailing{true}, front_end_first{std::true_type{}}, second_seq_leading{std::false_type{}}};
+        end_gaps eg{second_seq_trailing{true}, front_end_first{std::true_type{}}, front_end_second{std::false_type{}}};
 
         constexpr bool seq1_l = decltype(eg)::is_static<0>();
         constexpr bool seq1_t = decltype(eg)::is_static<1>();
@@ -289,7 +289,7 @@ TEST(end_gaps, static_query)
 
 TEST(end_gaps, static_access)
 {
-    end_gaps eg{second_seq_trailing{true}, front_end_first{std::true_type{}}, second_seq_leading{std::false_type{}}};
+    end_gaps eg{second_seq_trailing{true}, front_end_first{std::true_type{}}, front_end_second{std::false_type{}}};
 
     constexpr bool seq1_l = decltype(eg)::get_static<0>();
     constexpr bool seq2_l = decltype(eg)::get_static<2>();
@@ -304,7 +304,7 @@ TEST(end_gaps, all_ends_free)
 {
     using test = end_gaps<front_end_first<std::true_type>,
                           back_end_first<std::true_type>,
-                          second_seq_leading<std::true_type>,
+                          front_end_second<std::true_type>,
                           second_seq_trailing<std::true_type>>;
     EXPECT_EQ((std::is_same_v<std::remove_const_t<decltype(all_ends_free)>, test>), true);
 }
@@ -313,7 +313,7 @@ TEST(end_gaps, none_ends_free)
 {
     using test = end_gaps<front_end_first<std::false_type>,
                           back_end_first<std::false_type>,
-                          second_seq_leading<std::false_type>,
+                          front_end_second<std::false_type>,
                           second_seq_trailing<std::false_type>>;
 
     EXPECT_EQ((std::is_same_v<std::remove_const_t<decltype(none_ends_free)>, test>), true);
@@ -323,7 +323,7 @@ TEST(end_gaps, seq1_ends_free)
 {
     using test = end_gaps<front_end_first<std::true_type>,
                           back_end_first<std::true_type>,
-                          second_seq_leading<std::false_type>,
+                          front_end_second<std::false_type>,
                           second_seq_trailing<std::false_type>>;
     EXPECT_EQ((std::is_same_v<std::remove_const_t<decltype(seq1_ends_free)>, test>), true);
 }
@@ -332,7 +332,7 @@ TEST(end_gaps, seq2_ends_free)
 {
     using test = end_gaps<front_end_first<std::false_type>,
                           back_end_first<std::false_type>,
-                          second_seq_leading<std::true_type>,
+                          front_end_second<std::true_type>,
                           second_seq_trailing<std::true_type>>;
     EXPECT_EQ((std::is_same_v<std::remove_const_t<decltype(seq2_ends_free)>, test>), true);
 }
@@ -357,7 +357,7 @@ TEST(align_cfg_aligned_ends, value)
 
     using test = end_gaps<front_end_first<std::true_type>,
                           back_end_first<std::true_type>,
-                          second_seq_leading<std::false_type>,
+                          front_end_second<std::false_type>,
                           second_seq_trailing<std::false_type>>;
 
     EXPECT_EQ((std::is_same_v<type, test>), true);

--- a/test/unit/alignment/configuration/align_config_aligned_ends_test.cpp
+++ b/test/unit/alignment/configuration/align_config_aligned_ends_test.cpp
@@ -19,7 +19,7 @@ using namespace seqan3;
 using namespace seqan3::align_cfg;
 
 template <typename value_t>
-struct dummy_gap : seq_end_gap_base<value_t>
+struct dummy_gap : sequence_end_gap_specifier_base<value_t>
 {};
 
 template <typename type>
@@ -61,7 +61,7 @@ using dynamic_end_gap_types = ::testing::Types<first_seq_leading<bool>,
 
 TYPED_TEST_CASE(dynamic_end_gap_test, dynamic_end_gap_types);
 
-TEST(seq_end_gap_base, aggregate)
+TEST(sequence_end_gap_specifier_base, aggregate)
 {
     EXPECT_TRUE((std::is_aggregate_v<dummy_gap<std::true_type>>));
     EXPECT_TRUE((std::is_aggregate_v<dummy_gap<bool>>));

--- a/test/unit/alignment/configuration/align_config_aligned_ends_test.cpp
+++ b/test/unit/alignment/configuration/align_config_aligned_ends_test.cpp
@@ -41,8 +41,8 @@ private:
 
 using static_end_gap_types = ::testing::Types<front_end_first<std::true_type>,
                                               front_end_first<std::false_type>,
-                                              first_seq_trailing<std::true_type>,
-                                              first_seq_trailing<std::false_type>,
+                                              back_end_first<std::true_type>,
+                                              back_end_first<std::false_type>,
                                               second_seq_leading<std::true_type>,
                                               second_seq_leading<std::false_type>,
                                               second_seq_trailing<std::true_type>,
@@ -55,7 +55,7 @@ class dynamic_end_gap_test : public ::testing::Test
 {};
 
 using dynamic_end_gap_types = ::testing::Types<front_end_first<bool>,
-                                               first_seq_trailing<bool>,
+                                               back_end_first<bool>,
                                                second_seq_leading<bool>,
                                                second_seq_trailing<bool>>;
 
@@ -84,20 +84,20 @@ TEST(front_end_first, deduction)
     }
 }
 
-TEST(first_seq_trailing, deduction)
+TEST(back_end_first, deduction)
 {
     { // static
-        first_seq_trailing tmp{std::true_type{}};
-        EXPECT_EQ((std::is_same_v<decltype(tmp), first_seq_trailing<std::true_type>>), true);
-        first_seq_trailing tmp2{std::false_type{}};
-        EXPECT_EQ((std::is_same_v<decltype(tmp2), first_seq_trailing<std::false_type>>), true);
+        back_end_first tmp{std::true_type{}};
+        EXPECT_EQ((std::is_same_v<decltype(tmp), back_end_first<std::true_type>>), true);
+        back_end_first tmp2{std::false_type{}};
+        EXPECT_EQ((std::is_same_v<decltype(tmp2), back_end_first<std::false_type>>), true);
     }
 
     { // dynamic
-        first_seq_trailing tmp{true};
-        EXPECT_EQ((std::is_same_v<decltype(tmp), first_seq_trailing<bool>>), true);
-        first_seq_trailing tmp2{false};
-        EXPECT_EQ((std::is_same_v<decltype(tmp2), first_seq_trailing<bool>>), true);
+        back_end_first tmp{true};
+        EXPECT_EQ((std::is_same_v<decltype(tmp), back_end_first<bool>>), true);
+        back_end_first tmp2{false};
+        EXPECT_EQ((std::is_same_v<decltype(tmp2), back_end_first<bool>>), true);
     }
 }
 
@@ -186,27 +186,27 @@ TEST(end_gaps, construction)
     { // four elements
         EXPECT_TRUE((std::is_nothrow_default_constructible_v<end_gaps<front_end_first<std::true_type>,
                                                                       second_seq_leading<bool>,
-                                                                      first_seq_trailing<std::false_type>,
+                                                                      back_end_first<std::false_type>,
                                                                       second_seq_trailing<bool>>>));
         EXPECT_TRUE((std::is_nothrow_copy_constructible_v<end_gaps<front_end_first<std::true_type>,
                                                                    second_seq_leading<bool>,
-                                                                   first_seq_trailing<std::false_type>,
+                                                                   back_end_first<std::false_type>,
                                                                    second_seq_trailing<bool>>>));
         EXPECT_TRUE((std::is_nothrow_move_constructible_v<end_gaps<front_end_first<std::true_type>,
                                                                    second_seq_leading<bool>,
-                                                                   first_seq_trailing<std::false_type>,
+                                                                   back_end_first<std::false_type>,
                                                                    second_seq_trailing<bool>>>));
         EXPECT_TRUE((std::is_nothrow_copy_assignable_v<end_gaps<front_end_first<std::true_type>,
                                                                 second_seq_leading<bool>,
-                                                                first_seq_trailing<std::false_type>,
+                                                                back_end_first<std::false_type>,
                                                                 second_seq_trailing<bool>>>));
         EXPECT_TRUE((std::is_nothrow_move_assignable_v<end_gaps<front_end_first<std::true_type>,
                                                                 second_seq_leading<bool>,
-                                                                first_seq_trailing<std::false_type>,
+                                                                back_end_first<std::false_type>,
                                                                 second_seq_trailing<bool>>>));
         EXPECT_TRUE((std::is_nothrow_constructible_v<end_gaps<front_end_first<std::true_type>,
                                                               second_seq_leading<bool>,
-                                                              first_seq_trailing<std::false_type>,
+                                                              back_end_first<std::false_type>,
                                                               second_seq_trailing<bool>>>));
     }
 
@@ -303,7 +303,7 @@ TEST(end_gaps, static_access)
 TEST(end_gaps, all_ends_free)
 {
     using test = end_gaps<front_end_first<std::true_type>,
-                          first_seq_trailing<std::true_type>,
+                          back_end_first<std::true_type>,
                           second_seq_leading<std::true_type>,
                           second_seq_trailing<std::true_type>>;
     EXPECT_EQ((std::is_same_v<std::remove_const_t<decltype(all_ends_free)>, test>), true);
@@ -312,7 +312,7 @@ TEST(end_gaps, all_ends_free)
 TEST(end_gaps, none_ends_free)
 {
     using test = end_gaps<front_end_first<std::false_type>,
-                          first_seq_trailing<std::false_type>,
+                          back_end_first<std::false_type>,
                           second_seq_leading<std::false_type>,
                           second_seq_trailing<std::false_type>>;
 
@@ -322,7 +322,7 @@ TEST(end_gaps, none_ends_free)
 TEST(end_gaps, seq1_ends_free)
 {
     using test = end_gaps<front_end_first<std::true_type>,
-                          first_seq_trailing<std::true_type>,
+                          back_end_first<std::true_type>,
                           second_seq_leading<std::false_type>,
                           second_seq_trailing<std::false_type>>;
     EXPECT_EQ((std::is_same_v<std::remove_const_t<decltype(seq1_ends_free)>, test>), true);
@@ -331,7 +331,7 @@ TEST(end_gaps, seq1_ends_free)
 TEST(end_gaps, seq2_ends_free)
 {
     using test = end_gaps<front_end_first<std::false_type>,
-                          first_seq_trailing<std::false_type>,
+                          back_end_first<std::false_type>,
                           second_seq_leading<std::true_type>,
                           second_seq_trailing<std::true_type>>;
     EXPECT_EQ((std::is_same_v<std::remove_const_t<decltype(seq2_ends_free)>, test>), true);
@@ -356,7 +356,7 @@ TEST(align_cfg_aligned_ends, value)
     using type = decltype(cfg.value);
 
     using test = end_gaps<front_end_first<std::true_type>,
-                          first_seq_trailing<std::true_type>,
+                          back_end_first<std::true_type>,
                           second_seq_leading<std::false_type>,
                           second_seq_trailing<std::false_type>>;
 

--- a/test/unit/alignment/configuration/align_config_aligned_ends_test.cpp
+++ b/test/unit/alignment/configuration/align_config_aligned_ends_test.cpp
@@ -45,8 +45,8 @@ using static_end_gap_types = ::testing::Types<front_end_first<std::true_type>,
                                               back_end_first<std::false_type>,
                                               front_end_second<std::true_type>,
                                               front_end_second<std::false_type>,
-                                              second_seq_trailing<std::true_type>,
-                                              second_seq_trailing<std::false_type>>;
+                                              back_end_second<std::true_type>,
+                                              back_end_second<std::false_type>>;
 
 TYPED_TEST_CASE(static_end_gap_test, static_end_gap_types);
 
@@ -57,7 +57,7 @@ class dynamic_end_gap_test : public ::testing::Test
 using dynamic_end_gap_types = ::testing::Types<front_end_first<bool>,
                                                back_end_first<bool>,
                                                front_end_second<bool>,
-                                               second_seq_trailing<bool>>;
+                                               back_end_second<bool>>;
 
 TYPED_TEST_CASE(dynamic_end_gap_test, dynamic_end_gap_types);
 
@@ -118,20 +118,20 @@ TEST(front_end_second, deduction)
     }
 }
 
-TEST(second_seq_trailing, deduction)
+TEST(back_end_second, deduction)
 {
     { // static
-        second_seq_trailing tmp{std::true_type{}};
-        EXPECT_EQ((std::is_same_v<decltype(tmp), second_seq_trailing<std::true_type>>), true);
-        second_seq_trailing tmp2{std::false_type{}};
-        EXPECT_EQ((std::is_same_v<decltype(tmp2), second_seq_trailing<std::false_type>>), true);
+        back_end_second tmp{std::true_type{}};
+        EXPECT_EQ((std::is_same_v<decltype(tmp), back_end_second<std::true_type>>), true);
+        back_end_second tmp2{std::false_type{}};
+        EXPECT_EQ((std::is_same_v<decltype(tmp2), back_end_second<std::false_type>>), true);
     }
 
     { // dynamic
-        second_seq_trailing tmp{true};
-        EXPECT_EQ((std::is_same_v<decltype(tmp), second_seq_trailing<bool>>), true);
-        second_seq_trailing tmp2{false};
-        EXPECT_EQ((std::is_same_v<decltype(tmp2), second_seq_trailing<bool>>), true);
+        back_end_second tmp{true};
+        EXPECT_EQ((std::is_same_v<decltype(tmp), back_end_second<bool>>), true);
+        back_end_second tmp2{false};
+        EXPECT_EQ((std::is_same_v<decltype(tmp2), back_end_second<bool>>), true);
     }
 }
 
@@ -187,27 +187,27 @@ TEST(end_gaps, construction)
         EXPECT_TRUE((std::is_nothrow_default_constructible_v<end_gaps<front_end_first<std::true_type>,
                                                                       front_end_second<bool>,
                                                                       back_end_first<std::false_type>,
-                                                                      second_seq_trailing<bool>>>));
+                                                                      back_end_second<bool>>>));
         EXPECT_TRUE((std::is_nothrow_copy_constructible_v<end_gaps<front_end_first<std::true_type>,
                                                                    front_end_second<bool>,
                                                                    back_end_first<std::false_type>,
-                                                                   second_seq_trailing<bool>>>));
+                                                                   back_end_second<bool>>>));
         EXPECT_TRUE((std::is_nothrow_move_constructible_v<end_gaps<front_end_first<std::true_type>,
                                                                    front_end_second<bool>,
                                                                    back_end_first<std::false_type>,
-                                                                   second_seq_trailing<bool>>>));
+                                                                   back_end_second<bool>>>));
         EXPECT_TRUE((std::is_nothrow_copy_assignable_v<end_gaps<front_end_first<std::true_type>,
                                                                 front_end_second<bool>,
                                                                 back_end_first<std::false_type>,
-                                                                second_seq_trailing<bool>>>));
+                                                                back_end_second<bool>>>));
         EXPECT_TRUE((std::is_nothrow_move_assignable_v<end_gaps<front_end_first<std::true_type>,
                                                                 front_end_second<bool>,
                                                                 back_end_first<std::false_type>,
-                                                                second_seq_trailing<bool>>>));
+                                                                back_end_second<bool>>>));
         EXPECT_TRUE((std::is_nothrow_constructible_v<end_gaps<front_end_first<std::true_type>,
                                                               front_end_second<bool>,
                                                               back_end_first<std::false_type>,
-                                                              second_seq_trailing<bool>>>));
+                                                              back_end_second<bool>>>));
     }
 
     { // from lvalue
@@ -224,14 +224,14 @@ TEST(end_gaps, deduction)
     }
 
     { // one element
-        end_gaps eg{second_seq_trailing{true}};
-        using foo = end_gaps<second_seq_trailing<bool>>;
+        end_gaps eg{back_end_second{true}};
+        using foo = end_gaps<back_end_second<bool>>;
         EXPECT_EQ((std::is_same_v<decltype(eg), foo>), true);
     }
 
     { // multiple elements
-        end_gaps eg{second_seq_trailing{true}, front_end_first{std::true_type{}}, front_end_second{std::false_type{}}};
-        using foo = end_gaps<second_seq_trailing<bool>, front_end_first<std::true_type>, front_end_second<std::false_type>>;
+        end_gaps eg{back_end_second{true}, front_end_first{std::true_type{}}, front_end_second{std::false_type{}}};
+        using foo = end_gaps<back_end_second<bool>, front_end_first<std::true_type>, front_end_second<std::false_type>>;
         EXPECT_EQ((std::is_same_v<decltype(eg), foo>), true);
     }
 }
@@ -248,7 +248,7 @@ TEST(end_gaps, access)
     }
 
     { // custom
-        end_gaps eg{second_seq_trailing{true}, front_end_first{std::true_type{}}, front_end_second{std::false_type{}}};
+        end_gaps eg{back_end_second{true}, front_end_first{std::true_type{}}, front_end_second{std::false_type{}}};
 
         EXPECT_EQ(eg[0], true);
         EXPECT_EQ(eg[1], false);
@@ -273,7 +273,7 @@ TEST(end_gaps, static_query)
     }
 
     { // custom
-        end_gaps eg{second_seq_trailing{true}, front_end_first{std::true_type{}}, front_end_second{std::false_type{}}};
+        end_gaps eg{back_end_second{true}, front_end_first{std::true_type{}}, front_end_second{std::false_type{}}};
 
         constexpr bool seq1_l = decltype(eg)::is_static<0>();
         constexpr bool seq1_t = decltype(eg)::is_static<1>();
@@ -289,7 +289,7 @@ TEST(end_gaps, static_query)
 
 TEST(end_gaps, static_access)
 {
-    end_gaps eg{second_seq_trailing{true}, front_end_first{std::true_type{}}, front_end_second{std::false_type{}}};
+    end_gaps eg{back_end_second{true}, front_end_first{std::true_type{}}, front_end_second{std::false_type{}}};
 
     constexpr bool seq1_l = decltype(eg)::get_static<0>();
     constexpr bool seq2_l = decltype(eg)::get_static<2>();
@@ -305,7 +305,7 @@ TEST(end_gaps, all_ends_free)
     using test = end_gaps<front_end_first<std::true_type>,
                           back_end_first<std::true_type>,
                           front_end_second<std::true_type>,
-                          second_seq_trailing<std::true_type>>;
+                          back_end_second<std::true_type>>;
     EXPECT_EQ((std::is_same_v<std::remove_const_t<decltype(all_ends_free)>, test>), true);
 }
 
@@ -314,7 +314,7 @@ TEST(end_gaps, none_ends_free)
     using test = end_gaps<front_end_first<std::false_type>,
                           back_end_first<std::false_type>,
                           front_end_second<std::false_type>,
-                          second_seq_trailing<std::false_type>>;
+                          back_end_second<std::false_type>>;
 
     EXPECT_EQ((std::is_same_v<std::remove_const_t<decltype(none_ends_free)>, test>), true);
 }
@@ -324,7 +324,7 @@ TEST(end_gaps, seq1_ends_free)
     using test = end_gaps<front_end_first<std::true_type>,
                           back_end_first<std::true_type>,
                           front_end_second<std::false_type>,
-                          second_seq_trailing<std::false_type>>;
+                          back_end_second<std::false_type>>;
     EXPECT_EQ((std::is_same_v<std::remove_const_t<decltype(seq1_ends_free)>, test>), true);
 }
 
@@ -333,7 +333,7 @@ TEST(end_gaps, seq2_ends_free)
     using test = end_gaps<front_end_first<std::false_type>,
                           back_end_first<std::false_type>,
                           front_end_second<std::true_type>,
-                          second_seq_trailing<std::true_type>>;
+                          back_end_second<std::true_type>>;
     EXPECT_EQ((std::is_same_v<std::remove_const_t<decltype(seq2_ends_free)>, test>), true);
 }
 
@@ -358,7 +358,7 @@ TEST(align_cfg_aligned_ends, value)
     using test = end_gaps<front_end_first<std::true_type>,
                           back_end_first<std::true_type>,
                           front_end_second<std::false_type>,
-                          second_seq_trailing<std::false_type>>;
+                          back_end_second<std::false_type>>;
 
     EXPECT_EQ((std::is_same_v<type, test>), true);
 

--- a/test/unit/alignment/configuration/align_config_common_test.cpp
+++ b/test/unit/alignment/configuration/align_config_common_test.cpp
@@ -19,7 +19,7 @@ template <typename T>
 class alignment_configuration_test : public ::testing::Test
 {};
 
-using test_types = ::testing::Types<align_cfg::aligned_ends<std::remove_const_t<decltype(align_cfg::all_ends_free)>>,
+using test_types = ::testing::Types<align_cfg::aligned_ends<std::remove_const_t<decltype(all_ends_free)>>,
                                     align_cfg::band<static_band>,
                                     align_cfg::gap<gap_scheme<>>,
                                     align_cfg::max_error,

--- a/test/unit/alignment/configuration/align_config_common_test.cpp
+++ b/test/unit/alignment/configuration/align_config_common_test.cpp
@@ -19,7 +19,7 @@ template <typename T>
 class alignment_configuration_test : public ::testing::Test
 {};
 
-using test_types = ::testing::Types<align_cfg::aligned_ends<std::remove_const_t<decltype(all_ends_free)>>,
+using test_types = ::testing::Types<align_cfg::aligned_ends<std::remove_const_t<decltype(free_ends_all)>>,
                                     align_cfg::band<static_band>,
                                     align_cfg::gap<gap_scheme<>>,
                                     align_cfg::max_error,

--- a/test/unit/alignment/pairwise/alignment_configurator_test.cpp
+++ b/test/unit/alignment/pairwise/alignment_configurator_test.cpp
@@ -53,7 +53,7 @@ TEST(alignment_configurator, configure_edit_trace)
 
 TEST(alignment_configurator, configure_edit_semi)
 {
-    EXPECT_TRUE(run_test(align_cfg::edit | align_cfg::aligned_ends{seq1_ends_free}));
+    EXPECT_TRUE(run_test(align_cfg::edit | align_cfg::aligned_ends{first_ends_free}));
 }
 
 TEST(alignment_configurator, configure_edit_banded)

--- a/test/unit/alignment/pairwise/alignment_configurator_test.cpp
+++ b/test/unit/alignment/pairwise/alignment_configurator_test.cpp
@@ -53,7 +53,7 @@ TEST(alignment_configurator, configure_edit_trace)
 
 TEST(alignment_configurator, configure_edit_semi)
 {
-    EXPECT_TRUE(run_test(align_cfg::edit | align_cfg::aligned_ends{first_ends_free}));
+    EXPECT_TRUE(run_test(align_cfg::edit | align_cfg::aligned_ends{free_ends_first}));
 }
 
 TEST(alignment_configurator, configure_edit_banded)
@@ -160,7 +160,7 @@ TEST(alignment_configurator, configure_affine_global_semi)
     auto cfg = align_cfg::mode{align_cfg::global_alignment} |
                align_cfg::scoring{nucleotide_scoring_scheme{}} |
                align_cfg::gap{gap_scheme{gap_score{-1}, gap_open_score{-10}}} |
-               align_cfg::aligned_ends{all_ends_free};
+               align_cfg::aligned_ends{free_ends_all};
 
     EXPECT_TRUE(run_test(cfg));
 }

--- a/test/unit/alignment/pairwise/alignment_configurator_test.cpp
+++ b/test/unit/alignment/pairwise/alignment_configurator_test.cpp
@@ -53,7 +53,7 @@ TEST(alignment_configurator, configure_edit_trace)
 
 TEST(alignment_configurator, configure_edit_semi)
 {
-    EXPECT_TRUE(run_test(align_cfg::edit | align_cfg::aligned_ends{align_cfg::seq1_ends_free}));
+    EXPECT_TRUE(run_test(align_cfg::edit | align_cfg::aligned_ends{seq1_ends_free}));
 }
 
 TEST(alignment_configurator, configure_edit_banded)
@@ -160,7 +160,7 @@ TEST(alignment_configurator, configure_affine_global_semi)
     auto cfg = align_cfg::mode{align_cfg::global_alignment} |
                align_cfg::scoring{nucleotide_scoring_scheme{}} |
                align_cfg::gap{gap_scheme{gap_score{-1}, gap_open_score{-10}}} |
-               align_cfg::aligned_ends{align_cfg::all_ends_free};
+               align_cfg::aligned_ends{all_ends_free};
 
     EXPECT_TRUE(run_test(cfg));
 }

--- a/test/unit/alignment/pairwise/fixture/semi_global_affine_banded.hpp
+++ b/test/unit/alignment/pairwise/fixture/semi_global_affine_banded.hpp
@@ -29,8 +29,8 @@ inline constexpr auto align_config = align_cfg::mode{align_cfg::global_alignment
                                      align_cfg::gap{gap_scheme{gap_score{-1}, gap_open_score{-10}}} |
                                      align_cfg::band{static_band{lower_bound{-4}, upper_bound{8}}};
 
-inline constexpr auto align_config_semi_seq1 = align_config | align_cfg::aligned_ends{align_cfg::seq1_ends_free};
-inline constexpr auto align_config_semi_seq2 = align_config | align_cfg::aligned_ends{align_cfg::seq2_ends_free};
+inline constexpr auto align_config_semi_seq1 = align_config | align_cfg::aligned_ends{seq1_ends_free};
+inline constexpr auto align_config_semi_seq2 = align_config | align_cfg::aligned_ends{seq2_ends_free};
 
 static auto dna4_semi_seq1_a = []()
 {

--- a/test/unit/alignment/pairwise/fixture/semi_global_affine_banded.hpp
+++ b/test/unit/alignment/pairwise/fixture/semi_global_affine_banded.hpp
@@ -29,7 +29,7 @@ inline constexpr auto align_config = align_cfg::mode{align_cfg::global_alignment
                                      align_cfg::gap{gap_scheme{gap_score{-1}, gap_open_score{-10}}} |
                                      align_cfg::band{static_band{lower_bound{-4}, upper_bound{8}}};
 
-inline constexpr auto align_config_semi_seq1 = align_config | align_cfg::aligned_ends{seq1_ends_free};
+inline constexpr auto align_config_semi_seq1 = align_config | align_cfg::aligned_ends{first_ends_free};
 inline constexpr auto align_config_semi_seq2 = align_config | align_cfg::aligned_ends{seq2_ends_free};
 
 static auto dna4_semi_seq1_a = []()

--- a/test/unit/alignment/pairwise/fixture/semi_global_affine_banded.hpp
+++ b/test/unit/alignment/pairwise/fixture/semi_global_affine_banded.hpp
@@ -30,7 +30,7 @@ inline constexpr auto align_config = align_cfg::mode{align_cfg::global_alignment
                                      align_cfg::band{static_band{lower_bound{-4}, upper_bound{8}}};
 
 inline constexpr auto align_config_semi_seq1 = align_config | align_cfg::aligned_ends{first_ends_free};
-inline constexpr auto align_config_semi_seq2 = align_config | align_cfg::aligned_ends{seq2_ends_free};
+inline constexpr auto align_config_semi_seq2 = align_config | align_cfg::aligned_ends{second_ends_free};
 
 static auto dna4_semi_seq1_a = []()
 {

--- a/test/unit/alignment/pairwise/fixture/semi_global_affine_banded.hpp
+++ b/test/unit/alignment/pairwise/fixture/semi_global_affine_banded.hpp
@@ -29,8 +29,8 @@ inline constexpr auto align_config = align_cfg::mode{align_cfg::global_alignment
                                      align_cfg::gap{gap_scheme{gap_score{-1}, gap_open_score{-10}}} |
                                      align_cfg::band{static_band{lower_bound{-4}, upper_bound{8}}};
 
-inline constexpr auto align_config_semi_seq1 = align_config | align_cfg::aligned_ends{first_ends_free};
-inline constexpr auto align_config_semi_seq2 = align_config | align_cfg::aligned_ends{second_ends_free};
+inline constexpr auto align_config_semi_seq1 = align_config | align_cfg::aligned_ends{free_ends_first};
+inline constexpr auto align_config_semi_seq2 = align_config | align_cfg::aligned_ends{free_ends_second};
 
 static auto dna4_semi_seq1_a = []()
 {

--- a/test/unit/alignment/pairwise/fixture/semi_global_affine_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/semi_global_affine_unbanded.hpp
@@ -27,7 +27,7 @@ namespace seqan3::test::alignment::fixture::semi_global::affine::unbanded
 inline constexpr auto align_config = align_cfg::mode{align_cfg::global_alignment} |
                                      align_cfg::gap{gap_scheme{gap_score{-1}, gap_open_score{-10}}};
 
-inline constexpr auto align_config_semi_seq1 = align_config | align_cfg::aligned_ends{seq1_ends_free};
+inline constexpr auto align_config_semi_seq1 = align_config | align_cfg::aligned_ends{first_ends_free};
 inline constexpr auto align_config_semi_seq2 = align_config | align_cfg::aligned_ends{seq2_ends_free};
 
 static auto dna4_01 = []()

--- a/test/unit/alignment/pairwise/fixture/semi_global_affine_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/semi_global_affine_unbanded.hpp
@@ -27,8 +27,8 @@ namespace seqan3::test::alignment::fixture::semi_global::affine::unbanded
 inline constexpr auto align_config = align_cfg::mode{align_cfg::global_alignment} |
                                      align_cfg::gap{gap_scheme{gap_score{-1}, gap_open_score{-10}}};
 
-inline constexpr auto align_config_semi_seq1 = align_config | align_cfg::aligned_ends{first_ends_free};
-inline constexpr auto align_config_semi_seq2 = align_config | align_cfg::aligned_ends{second_ends_free};
+inline constexpr auto align_config_semi_seq1 = align_config | align_cfg::aligned_ends{free_ends_first};
+inline constexpr auto align_config_semi_seq2 = align_config | align_cfg::aligned_ends{free_ends_second};
 
 static auto dna4_01 = []()
 {

--- a/test/unit/alignment/pairwise/fixture/semi_global_affine_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/semi_global_affine_unbanded.hpp
@@ -27,8 +27,8 @@ namespace seqan3::test::alignment::fixture::semi_global::affine::unbanded
 inline constexpr auto align_config = align_cfg::mode{align_cfg::global_alignment} |
                                      align_cfg::gap{gap_scheme{gap_score{-1}, gap_open_score{-10}}};
 
-inline constexpr auto align_config_semi_seq1 = align_config | align_cfg::aligned_ends{align_cfg::seq1_ends_free};
-inline constexpr auto align_config_semi_seq2 = align_config | align_cfg::aligned_ends{align_cfg::seq2_ends_free};
+inline constexpr auto align_config_semi_seq1 = align_config | align_cfg::aligned_ends{seq1_ends_free};
+inline constexpr auto align_config_semi_seq2 = align_config | align_cfg::aligned_ends{seq2_ends_free};
 
 static auto dna4_01 = []()
 {

--- a/test/unit/alignment/pairwise/fixture/semi_global_affine_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/semi_global_affine_unbanded.hpp
@@ -28,7 +28,7 @@ inline constexpr auto align_config = align_cfg::mode{align_cfg::global_alignment
                                      align_cfg::gap{gap_scheme{gap_score{-1}, gap_open_score{-10}}};
 
 inline constexpr auto align_config_semi_seq1 = align_config | align_cfg::aligned_ends{first_ends_free};
-inline constexpr auto align_config_semi_seq2 = align_config | align_cfg::aligned_ends{seq2_ends_free};
+inline constexpr auto align_config_semi_seq2 = align_config | align_cfg::aligned_ends{second_ends_free};
 
 static auto dna4_01 = []()
 {

--- a/test/unit/alignment/pairwise/fixture/semi_global_edit_distance_max_errors_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/semi_global_edit_distance_max_errors_unbanded.hpp
@@ -15,7 +15,7 @@ namespace seqan3::test::alignment::fixture::semi_global::edit_distance::max_erro
 {
 
 inline constexpr auto align_config = align_cfg::edit |
-                                     align_cfg::aligned_ends{first_ends_free} |
+                                     align_cfg::aligned_ends{free_ends_first} |
                                      align_cfg::max_error{255};
 
 static auto dna4_01_e255 = []()

--- a/test/unit/alignment/pairwise/fixture/semi_global_edit_distance_max_errors_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/semi_global_edit_distance_max_errors_unbanded.hpp
@@ -15,7 +15,7 @@ namespace seqan3::test::alignment::fixture::semi_global::edit_distance::max_erro
 {
 
 inline constexpr auto align_config = align_cfg::edit |
-                                     align_cfg::aligned_ends{align_cfg::seq1_ends_free} |
+                                     align_cfg::aligned_ends{seq1_ends_free} |
                                      align_cfg::max_error{255};
 
 static auto dna4_01_e255 = []()

--- a/test/unit/alignment/pairwise/fixture/semi_global_edit_distance_max_errors_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/semi_global_edit_distance_max_errors_unbanded.hpp
@@ -15,7 +15,7 @@ namespace seqan3::test::alignment::fixture::semi_global::edit_distance::max_erro
 {
 
 inline constexpr auto align_config = align_cfg::edit |
-                                     align_cfg::aligned_ends{seq1_ends_free} |
+                                     align_cfg::aligned_ends{first_ends_free} |
                                      align_cfg::max_error{255};
 
 static auto dna4_01_e255 = []()

--- a/test/unit/alignment/pairwise/fixture/semi_global_edit_distance_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/semi_global_edit_distance_unbanded.hpp
@@ -13,7 +13,7 @@
 namespace seqan3::test::alignment::fixture::semi_global::edit_distance::unbanded
 {
 
-inline constexpr auto align_config = align_cfg::edit | align_cfg::aligned_ends{first_ends_free};
+inline constexpr auto align_config = align_cfg::edit | align_cfg::aligned_ends{free_ends_first};
 
 static auto dna4_01 = []()
 {

--- a/test/unit/alignment/pairwise/fixture/semi_global_edit_distance_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/semi_global_edit_distance_unbanded.hpp
@@ -13,7 +13,7 @@
 namespace seqan3::test::alignment::fixture::semi_global::edit_distance::unbanded
 {
 
-inline constexpr auto align_config = align_cfg::edit | align_cfg::aligned_ends{seq1_ends_free};
+inline constexpr auto align_config = align_cfg::edit | align_cfg::aligned_ends{first_ends_free};
 
 static auto dna4_01 = []()
 {

--- a/test/unit/alignment/pairwise/fixture/semi_global_edit_distance_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/semi_global_edit_distance_unbanded.hpp
@@ -13,7 +13,7 @@
 namespace seqan3::test::alignment::fixture::semi_global::edit_distance::unbanded
 {
 
-inline constexpr auto align_config = align_cfg::edit | align_cfg::aligned_ends{align_cfg::seq1_ends_free};
+inline constexpr auto align_config = align_cfg::edit | align_cfg::aligned_ends{seq1_ends_free};
 
 static auto dna4_01 = []()
 {


### PR DESCRIPTION
Before construction of the end_gaps from lvalues of the end gap specified was not working because of explicit rvalue semantics in the constructor.

Also renames the end gap specifiers and the predefined end gap values to be more consistent with the general naming scheme of the alignment module.