### PR TITLE
argument_parser no longer uses app_name for synopsis.

### DIFF
--- a/include/seqan3/argument_parser/auxiliary.hpp
+++ b/include/seqan3/argument_parser/auxiliary.hpp
@@ -99,7 +99,9 @@ struct argument_parser_meta_data // holds all meta information
      *        is separated by a new line.
      */
     std::vector<std::string> description;
-    //!\brief Add lines of usage to the synopsis section of the help page (e.g. "[OPTIONS] FILE1 FILE1").
+    /*!\brief Add lines of usage to the synopsis section of the help page (e.g. 
+     *        "./my_read_mapper [OPTIONS] FILE1 FILE1").
+     */
     std::vector<std::string> synopsis;
     /*!\brief Provide some examples on how to use your tool and what standard
      *        parameters might be appropriate in different cases (e.g.

--- a/include/seqan3/argument_parser/detail/format_help.hpp
+++ b/include/seqan3/argument_parser/detail/format_help.hpp
@@ -309,9 +309,8 @@ protected:
         for (unsigned i = 0; i < meta.synopsis.size(); ++i)
         {
             std::string text = "\\fB";
-            text.append(meta.app_name);
-            text.append("\\fP ");
             text.append(meta.synopsis[i]);
+            text.insert(text.find_first_of(" \t"), "\\fP");
 
             print_line(text, false);
         }

--- a/include/seqan3/argument_parser/detail/format_html.hpp
+++ b/include/seqan3/argument_parser/detail/format_html.hpp
@@ -115,7 +115,7 @@ public:
         print_header();
 
         print_section("Synopsis");
-        _print_synopsis();
+        print_synopsis();
 
         if (!meta.description.empty())
         {
@@ -232,14 +232,13 @@ private:
     }
 
     //!\brief Prints a help page synopsis in HTML format section to std::cout.
-    void _print_synopsis()
+    void print_synopsis()
     {
         for (unsigned i = 0; i < meta.synopsis.size(); ++i)
         {
             std::string text = "\\fB";
-            text.append(meta.app_name);
-            text.append("\\fP ");
             text.append(meta.synopsis[i]);
+            text.insert(text.find_first_of(" \t"), "\\fP");
 
             print_line(text, false);
         }

--- a/include/seqan3/argument_parser/detail/format_man.hpp
+++ b/include/seqan3/argument_parser/detail/format_man.hpp
@@ -211,9 +211,8 @@ private:
         for (unsigned i = 0; i < meta.synopsis.size(); ++i)
         {
             std::string text = "\\fB";
-            text.append(meta.app_name);
-            text.append("\\fP ");
             text.append(meta.synopsis[i]);
+            text.insert(text.find_first_of(" \t"), "\\fP");
 
             print_line(text, false);
         }

--- a/test/unit/argument_parser/detail/format_help_test.cpp
+++ b/test/unit/argument_parser/detail/format_help_test.cpp
@@ -37,13 +37,13 @@ TEST(help_page_printing, short_help)
 {
     // Empty call with no options given. For detail::format_short_help
     argument_parser parser0("empty_options", 1, argv0);
-    parser0.info.synopsis.push_back("synopsis");
+    parser0.info.synopsis.push_back("./some_binary_name synopsis");
     testing::internal::CaptureStdout();
     EXPECT_EXIT(parser0.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
     std_cout = testing::internal::GetCapturedStdout();
     expected = "empty_options"
                "============="
-               "empty_options synopsis"
+               "./some_binary_name synopsis"
                "Try -h or --help for more information.";
     EXPECT_TRUE(ranges::equal((std_cout | std::view::filter(!is_space)), expected | std::view::filter(!is_space)));
 }
@@ -199,8 +199,8 @@ TEST(help_page_printing, full_information)
 {
     // Add synopsis, description, short description, positional option, option, flag, and example.
     argument_parser parser6("full", 2, argv1);
-    parser6.info.synopsis.push_back("synopsis");
-    parser6.info.synopsis.push_back("synopsis2");
+    parser6.info.synopsis.push_back("./some_binary_name synopsis");
+    parser6.info.synopsis.push_back("./some_binary_name synopsis2");
     parser6.info.description.push_back("description");
     parser6.info.description.push_back("description2");
     parser6.info.short_description = "so short";
@@ -215,8 +215,8 @@ TEST(help_page_printing, full_information)
     expected = "full - so short"
                "==============="
                "SYNOPSIS"
-               "full synopsis"
-               "full synopsis2"
+               "./some_binary_name synopsis"
+               "./some_binary_name synopsis2"
                "DESCRIPTION"
                "description"
                "description2"

--- a/test/unit/argument_parser/detail/format_html_test.cpp
+++ b/test/unit/argument_parser/detail/format_html_test.cpp
@@ -51,8 +51,8 @@ TEST(html_test, html)
 
    // Full html help page.
    argument_parser parser1("program_full_options", 3, argv0);
-   parser1.info.synopsis.push_back("synopsis");
-   parser1.info.synopsis.push_back("synopsis2");
+   parser1.info.synopsis.push_back("./some_binary_name synopsis");
+   parser1.info.synopsis.push_back("./some_binary_name synopsis2");
    parser1.info.description.push_back("description");
    parser1.info.description.push_back("description2");
    parser1.info.short_description = "short description";
@@ -82,9 +82,9 @@ TEST(html_test, html)
                           "<div>short description</div>"
                           "<h2>Synopsis</h2>"
                           "<p>"
-                          "<strong>program_full_options</strong> synopsis"
+                          "<strong>./some_binary_name</strong> synopsis"
                           "<br />"
-                          "<strong>program_full_options</strong> synopsis2"
+                          "<strong>./some_binary_name</strong> synopsis2"
                           "<br />"
                           "</p>"
                           "<h2>Description</h2>"


### PR DESCRIPTION
Instead, the name of the binary has to be set manually in the synopsis definition.
This is necessary for a distinction between app name and binary name which are usually different.
For printing on command line, man or HTML, the first word of the synopsis (detected by the first ' ' or '\t') is still displayed in bold font.