### PR TITLE
[FIX] empty sequence files are valid files that result into an empty range.

### DIFF
--- a/include/seqan3/io/sequence_file/format_fasta.hpp
+++ b/include/seqan3/io/sequence_file/format_fasta.hpp
@@ -124,13 +124,6 @@ public:
 
         // Sequence
         read_seq(stream_view, options, sequence);
-
-        // make sure "buffer at end" implies "stream at end"
-        if ((std::istreambuf_iterator<stream_char_t>{stream} == std::istreambuf_iterator<stream_char_t>{}) &&
-            (!stream.eof()))
-        {
-            stream.get(); // triggers error in stream and sets eof
-        }
     }
 
     //!\copydoc SequenceFileOutputFormat::write

--- a/include/seqan3/io/sequence_file/format_fastq.hpp
+++ b/include/seqan3/io/sequence_file/format_fastq.hpp
@@ -208,13 +208,6 @@ public:
         {
             detail::consume(qview);
         }
-
-        // make sure "buffer at end" implies "stream at end"
-        if ((std::istreambuf_iterator<stream_char_t>{stream} == std::istreambuf_iterator<stream_char_t>{}) &&
-            (!stream.eof()))
-        {
-            stream.get(); // triggers error in stream and sets eof
-        }
     }
 
     //!\copydoc SequenceFileOutputFormat::write

--- a/include/seqan3/io/sequence_file/input.hpp
+++ b/include/seqan3/io/sequence_file/input.hpp
@@ -730,14 +730,12 @@ protected:
     //!\brief Tell the format to move to the next record and update the buffer.
     void read_next_record()
     {
-        if (at_end)
-            return;
-
         // clear the record
         record_buffer.clear();
 
         // at end if we could not read further
-        if (secondary_stream->eof())
+        if ((std::istreambuf_iterator<stream_char_type>{*secondary_stream} ==
+             std::istreambuf_iterator<stream_char_type>{}))
         {
             at_end = true;
             return;

--- a/include/seqan3/io/structure_file/format_vienna.hpp
+++ b/include/seqan3/io/structure_file/format_vienna.hpp
@@ -250,12 +250,6 @@ public:
             detail::consume(stream_view | view::take_line);
         }
         detail::consume(stream_view | view::take_until(!is_space));
-
-        // make sure "buffer at end" implies "stream at end"
-        if ((stream_it_t{stream} == stream_it_t{}) && (!stream.eof()))
-        {
-            stream.get(); // triggers error in stream and sets eof
-        }
     }
 
     //!\copydoc seqan3::StructureFileOutputFormat::write

--- a/include/seqan3/io/structure_file/input.hpp
+++ b/include/seqan3/io/structure_file/input.hpp
@@ -968,14 +968,12 @@ protected:
     //!\brief Tell the format to move to the next record and update the buffer.
     void read_next_record()
     {
-        if (at_end)
-            return;
-
         // clear the record
         record_buffer.clear();
 
         // at end if we could not read further
-        if (secondary_stream->eof())
+        if ((std::istreambuf_iterator<stream_char_type>{*secondary_stream} ==
+             std::istreambuf_iterator<stream_char_type>{}))
         {
             at_end = true;
             return;

--- a/test/unit/io/sequence_file/sequence_file_input_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_input_test.cpp
@@ -74,7 +74,6 @@ TEST_F(sequence_file_input_f, construct_by_filename)
 
         {
             std::ofstream filecreator{filename.get_path(), std::ios::out | std::ios::binary};
-            filecreator << "> ID\nACGT\n"; // must contain at least one record
         }
 
         EXPECT_NO_THROW( sequence_file_input<>{filename.get_path()} );
@@ -102,7 +101,6 @@ TEST_F(sequence_file_input_f, construct_by_filename)
 
         {
             std::ofstream filecreator{filename.get_path(), std::ios::out | std::ios::binary};
-            filecreator << "> ID\nACGT\n"; // must contain at least one record
         }
 
         EXPECT_NO_THROW(( sequence_file_input<sequence_file_input_default_traits_dna,
@@ -153,7 +151,6 @@ TEST_F(sequence_file_input_f, default_template_args_and_deduction_guides)
 
         {
             std::ofstream filecreator{filename.get_path(), std::ios::out | std::ios::binary};
-            filecreator << "> ID\nACGT\n"; // must contain at least one record
         }
 
         sequence_file_input fin{filename.get_path()};
@@ -171,7 +168,6 @@ TEST_F(sequence_file_input_f, default_template_args_and_deduction_guides)
 
         {
             std::ofstream filecreator{filename.get_path(), std::ios::out | std::ios::binary};
-            filecreator << "> ID\nACGT\n"; // must contain at least one record
         }
 
         sequence_file_input fin{filename.get_path(), fields<field::SEQ>{}};
@@ -232,6 +228,23 @@ TEST_F(sequence_file_input_f, default_template_args_and_deduction_guides)
         EXPECT_TRUE((std::is_same_v<typename t::valid_formats,      type_list<sequence_file_format_fasta>>));// changed
         EXPECT_TRUE((std::is_same_v<typename t::stream_char_type,   wchar_t>));                              // changed
     }
+}
+
+TEST_F(sequence_file_input_f, empty_file)
+{
+    test::tmp_filename filename{"empty.fasta"};
+    std::ofstream filecreator{filename.get_path(), std::ios::out | std::ios::binary};
+
+    sequence_file_input fin{filename.get_path()};
+
+    EXPECT_EQ(fin.begin(), fin.end());
+}
+
+TEST_F(sequence_file_input_f, empty_stream)
+{
+    sequence_file_input fin{std::istringstream{std::string{}}, sequence_file_format_fasta{}};
+
+    EXPECT_EQ(fin.begin(), fin.end());
 }
 
 TEST_F(sequence_file_input_f, record_reading)
@@ -430,6 +443,19 @@ TEST_F(sequence_file_input_f, decompression_by_stream_gz)
 
     decompression_impl(*this, fin);
 }
+
+TEST_F(sequence_file_input_f, read_empty_gz_file)
+{
+    std::string empty_zipped_file
+    {
+        '\x1f', '\x8b', '\x08', '\x08', '\x5a', '\x07', '\x98', '\x5c',
+        '\x00', '\x03', '\x66', '\x6f', '\x6f', '\x00', '\x03', '\x00',
+        '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00'
+    };
+    sequence_file_input fin{std::istringstream{empty_zipped_file}, sequence_file_format_fasta{}};
+
+    EXPECT_TRUE(fin.begin() == fin.end());
+}
 #endif
 
 #ifdef SEQAN3_HAS_BZIP2
@@ -463,6 +489,17 @@ TEST_F(sequence_file_input_f, decompression_by_stream_bz2)
     sequence_file_input fin{std::istringstream{input_bz2}, sequence_file_format_fasta{}};
 
     decompression_impl(*this, fin);
+}
+
+TEST_F(sequence_file_input_f, read_empty_bz2_file)
+{
+    std::string empty_zipped_file
+    {
+        '\x42', '\x5a', '\x68', '\x39', '\x17', '\x72', '\x45', '\x38', '\x50', '\x90', '\x00', '\x00', '\x00', '\x00'
+    };
+    sequence_file_input fin{std::istringstream{empty_zipped_file}, sequence_file_format_fasta{}};
+
+    EXPECT_TRUE(fin.begin() == fin.end());
 }
 #endif
 


### PR DESCRIPTION
Resolves #823 