### PR TITLE
[FIX] out-of-range in random access benchmarks

### DIFF
--- a/test/performance/range/view/view_drop_benchmark.cpp
+++ b/test/performance/range/view/view_drop_benchmark.cpp
@@ -106,7 +106,7 @@ void random_access(benchmark::State & state)
     std::vector<size_t> access_positions;
     access_positions.resize(1'000'000);
     std::mt19937 gen(42);
-    std::uniform_int_distribution<size_t> dis(0, 1'000'000);
+    std::uniform_int_distribution<size_t> dis(0, 1'000'000 - 1);
 
     for (size_t i = 0; i < 1'000'000; ++i)
         access_positions[i] = dis(gen);

--- a/test/performance/range/view/view_drop_view_take_benchmark.cpp
+++ b/test/performance/range/view/view_drop_view_take_benchmark.cpp
@@ -106,7 +106,7 @@ void random_access(benchmark::State & state)
     std::vector<size_t> access_positions;
     access_positions.resize(1'000'000);
     std::mt19937 gen(42);
-    std::uniform_int_distribution<size_t> dis(0, 1'000'000);
+    std::uniform_int_distribution<size_t> dis(0, 998'000 - 1);
 
     for (size_t i = 0; i < 1'000'000; ++i)
         access_positions[i] = dis(gen);

--- a/test/performance/range/view/view_take_benchmark.cpp
+++ b/test/performance/range/view/view_take_benchmark.cpp
@@ -122,7 +122,7 @@ void random_access(benchmark::State & state)
     std::vector<size_t> access_positions;
     access_positions.resize(1'000'000);
     std::mt19937 gen(42);
-    std::uniform_int_distribution<size_t> dis(0, 1'000'000);
+    std::uniform_int_distribution<size_t> dis(0, 1'000'000 - 1);
 
     for (size_t i = 0; i < 1'000'000; ++i)
         access_positions[i] = dis(gen);


### PR DESCRIPTION
I broke the documentation debug nightly builds yesterday 🏆 