### PR TITLE
[FEATURE] Adds buffer_queue from google-concurrency-library.

### DIFF
--- a/include/seqan3/contrib/conqueue/buffer_queue.hpp
+++ b/include/seqan3/contrib/conqueue/buffer_queue.hpp
@@ -1,0 +1,461 @@
+// Copyright 2010 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <condition_variable>
+#include <mutex>
+
+#include <seqan3/contrib/conqueue/queue_base.hpp>
+
+namespace seqan3::contrib
+{
+
+template <typename Value>
+class buffer_queue
+{
+  public:
+    typedef Value value_type;
+
+    buffer_queue() = delete;
+    buffer_queue(const buffer_queue&) = delete;
+    explicit buffer_queue(size_t max_elems);
+    template <typename Iter>
+    buffer_queue(size_t max_elems, Iter first, Iter last);
+    buffer_queue& operator =(const buffer_queue&) = delete;
+    ~buffer_queue();
+
+//TODO(crowl): Do we want this?
+#if 0
+    generic_queue_back<value_type> back()
+        { return generic_queue_back<value_type>(this); }
+    generic_queue_front<value_type> front()
+        { return generic_queue_front<value_type>(this); }
+#endif
+
+    void close();
+    bool is_closed();
+    bool is_empty();
+
+    Value value_pop();
+    queue_op_status wait_pop(Value&);
+    queue_op_status try_pop(Value&);
+    queue_op_status nonblocking_pop(Value&);
+
+    void push(const Value& x);
+    queue_op_status wait_push(const Value& x);
+    queue_op_status try_push(const Value& x);
+    queue_op_status nonblocking_push(const Value& x);
+    void push(Value&& x);
+    queue_op_status wait_push(Value&& x);
+    queue_op_status try_push(Value&& x);
+    queue_op_status nonblocking_push(Value&& x);
+
+  private:
+    std::mutex mtx_;
+    std::condition_variable not_empty_;
+    std::condition_variable not_full_;
+    size_t waiting_full_;
+    size_t waiting_empty_;
+    Value* buffer_;
+    size_t push_index_;
+    size_t pop_index_;
+    size_t num_slots_;
+    bool closed_;
+
+    void init(size_t max_elems);
+
+    template <typename Iter>
+    void iter_init(size_t max_elems, Iter first, Iter last);
+
+    size_t next(size_t idx) { return (idx + 1) % num_slots_; }
+
+    queue_op_status try_pop_common(Value& x);
+    queue_op_status try_push_common(const Value& x);
+    queue_op_status try_push_common(Value&& x);
+
+    queue_op_status pop_from(Value& elem, size_t pdx)
+    {
+        pop_index_ = next( pdx );
+        if ( waiting_full_ > 0 ) {
+            --waiting_full_;
+            not_full_.notify_one();
+        }
+        // The change to the queue must happen before the copy/move
+        // has a chance to fail.
+        elem = std::move(buffer_[pdx]);
+        return queue_op_status::success;
+    }
+
+    void push_reindex( size_t nxt )
+    {
+        push_index_ = nxt;
+        if ( waiting_empty_ > 0 ) {
+            --waiting_empty_;
+            not_empty_.notify_one();
+        }
+    }
+
+    queue_op_status push_at(const Value& elem, size_t hdx, size_t nxt)
+    {
+        buffer_[hdx] = elem;
+        // The change to the queue must happen only after the copy succeeds.
+        push_reindex( nxt );
+        return queue_op_status::success;
+    }
+
+    queue_op_status push_at(Value&& elem, size_t hdx, size_t nxt)
+    {
+        buffer_[hdx] = std::move(elem);
+        // The change to the queue must happen only after the copy succeeds.
+        push_reindex( nxt );
+        return queue_op_status::success;
+    }
+
+};
+
+template <typename Value>
+void buffer_queue<Value>::init(size_t max_elems)
+{
+    if ( max_elems < 1 )
+        throw std::invalid_argument("number of elements must be at least one");
+}
+
+template <typename Value>
+buffer_queue<Value>::buffer_queue(size_t max_elems)
+:
+    // would rather do buffer_queue(max_elems, "")
+    waiting_full_( 0 ),
+    waiting_empty_( 0 ),
+    buffer_( new Value[max_elems+1] ),
+    push_index_( 0 ),
+    pop_index_( 0 ),
+    num_slots_( max_elems+1 ),
+    closed_( false )
+{
+    init(max_elems);
+}
+
+template <typename Value>
+template <typename Iter>
+void buffer_queue<Value>::iter_init(size_t max_elems, Iter first, Iter last)
+{
+    size_t hdx = 0;
+    for ( Iter cur = first; cur != last; ++cur ) {
+        if ( hdx >= max_elems )
+            throw std::invalid_argument("too few slots for iterator");
+        buffer_[hdx] = *cur;
+        hdx += 1; // more efficient than next(hdx)
+    }
+    push_reindex( hdx );
+}
+
+template <typename Value>
+template <typename Iter>
+buffer_queue<Value>::buffer_queue(size_t max_elems, Iter first, Iter last)
+:
+    // would rather do buffer_queue(max_elems, first, last, "")
+    waiting_full_( 0 ),
+    waiting_empty_( 0 ),
+    buffer_( new Value[max_elems+1] ),
+    push_index_( 0 ),
+    pop_index_( 0 ),
+    num_slots_( max_elems+1 ),
+    closed_( false )
+{
+    iter_init(max_elems, first, last);
+}
+
+template <typename Value>
+buffer_queue<Value>::~buffer_queue()
+{
+    delete[] buffer_;
+}
+
+template <typename Value>
+void buffer_queue<Value>::close()
+{
+    std::lock_guard<std::mutex> hold( mtx_ );
+    closed_ = true;
+    not_empty_.notify_all();
+    not_full_.notify_all();
+}
+
+template <typename Value>
+bool buffer_queue<Value>::is_closed()
+{
+    std::lock_guard<std::mutex> hold( mtx_ );
+    return closed_;
+}
+
+template <typename Value>
+bool buffer_queue<Value>::is_empty()
+{
+    std::lock_guard<std::mutex> hold( mtx_ );
+    return push_index_ == pop_index_;
+}
+
+template <typename Value>
+queue_op_status buffer_queue<Value>::try_pop_common(Value& elem)
+{
+    size_t pdx = pop_index_;
+    if ( pdx == push_index_ ) {
+        if ( closed_ )
+            return queue_op_status::closed;
+        else
+            return queue_op_status::empty;
+    }
+    return pop_from( elem, pdx );
+}
+
+template <typename Value>
+queue_op_status buffer_queue<Value>::try_pop(Value& elem)
+{
+    /* This try block is here to catch exceptions from the mutex
+       operations or from the user-defined copy assignment operator
+       in the pop_from operation. */
+    try {
+        std::lock_guard<std::mutex> hold( mtx_ );
+        return try_pop_common(elem);
+    } catch (...) {
+        close();
+        throw;
+    }
+}
+
+template <typename Value>
+queue_op_status buffer_queue<Value>::nonblocking_pop(Value& elem)
+{
+    /* This try block is here to catch exceptions from the mutex
+       operations or from the user-defined copy assignment operator
+       in the pop_from operation. */
+    try {
+        std::unique_lock<std::mutex> hold( mtx_, std::try_to_lock );
+        if ( !hold.owns_lock() ) {
+            return queue_op_status::busy;
+        }
+        return try_pop_common(elem);
+    } catch (...) {
+        close();
+        throw;
+    }
+}
+template <typename Value>
+queue_op_status buffer_queue<Value>::wait_pop(Value& elem)
+{
+    /* This try block is here to catch exceptions from the mutex
+       operations or from the user-defined copy assignment operator
+       in the pop_from operation. */
+    try {
+        std::unique_lock<std::mutex> hold( mtx_ );
+        size_t pdx;
+        for (;;) {
+            pdx = pop_index_;
+            if ( pdx != push_index_ )
+                break;
+            if ( closed_ )
+                return queue_op_status::closed;
+            ++waiting_empty_;
+            not_empty_.wait( hold );
+        }
+        return pop_from( elem, pdx );
+    } catch (...) {
+        close();
+        throw;
+    }
+}
+
+template <typename Value>
+Value buffer_queue<Value>::value_pop()
+{
+    /* This try block is here to catch exceptions from the
+       user-defined copy assignment operator. */
+    try {
+        Value elem;
+        if ( wait_pop( elem ) == queue_op_status::closed )
+            throw queue_op_status::closed;
+        return std::move(elem);
+    } catch (...) {
+        close();
+        throw;
+    }
+}
+
+template <typename Value>
+queue_op_status buffer_queue<Value>::try_push_common(const Value& elem)
+{
+    if ( closed_ )
+        return queue_op_status::closed;
+    size_t hdx = push_index_;
+    size_t nxt = next( hdx );
+    if ( nxt == pop_index_ )
+        return queue_op_status::full;
+    return push_at( elem, hdx, nxt );
+}
+
+template <typename Value>
+queue_op_status buffer_queue<Value>::try_push(const Value& elem)
+{
+    /* This try block is here to catch exceptions from the mutex
+       operations or from the user-defined copy assignment
+       operator in push_at. */
+    try {
+        std::lock_guard<std::mutex> hold( mtx_ );
+        return try_push_common(elem);
+    } catch (...) {
+        close();
+        throw;
+    }
+}
+
+template <typename Value>
+queue_op_status buffer_queue<Value>::nonblocking_push(const Value& elem)
+{
+    /* This try block is here to catch exceptions from the mutex
+       operations or from the user-defined copy assignment
+       operator in push_at. */
+    try {
+        std::unique_lock<std::mutex> hold( mtx_, std::try_to_lock );
+        if ( !hold.owns_lock() )
+            return queue_op_status::busy;
+        return try_push_common(elem);
+    } catch (...) {
+        close();
+        throw;
+    }
+}
+
+template <typename Value>
+queue_op_status buffer_queue<Value>::wait_push(const Value& elem)
+{
+    /* This try block is here to catch exceptions from the mutex
+       operations or from the user-defined copy assignment
+       operator in push_at. */
+    try {
+        std::unique_lock<std::mutex> hold( mtx_ );
+        size_t hdx;
+        size_t nxt;
+        for (;;) {
+            if ( closed_ )
+                return queue_op_status::closed;
+            hdx = push_index_;
+            nxt = next( hdx );
+            if ( nxt != pop_index_ )
+                break;
+            ++waiting_full_;
+            not_full_.wait( hold );
+        }
+        return push_at( elem, hdx, nxt );
+    } catch (...) {
+        close();
+        throw;
+    }
+}
+
+template <typename Value>
+void buffer_queue<Value>::push(const Value& elem)
+{
+    /* Only wait_push can throw, and it protects itself, so there
+       is no need to try/catch here. */
+    if ( wait_push( elem ) == queue_op_status::closed ) {
+        throw queue_op_status::closed;
+    }
+}
+
+//TODO(crowl) Refactor with non-move versions.
+
+template <typename Value>
+queue_op_status buffer_queue<Value>::try_push_common(Value&& elem)
+{
+    if ( closed_ )
+        return queue_op_status::closed;
+    size_t hdx = push_index_;
+    size_t nxt = next( hdx );
+    if ( nxt == pop_index_ )
+        return queue_op_status::full;
+    return push_at( std::move(elem), hdx, nxt );
+}
+
+
+template <typename Value>
+queue_op_status buffer_queue<Value>::try_push(Value&& elem)
+{
+    /* This try block is here to catch exceptions from the mutex
+       operations or from the user-defined copy assignment
+       operator in push_at. */
+    try {
+        std::lock_guard<std::mutex> hold( mtx_ );
+        return try_push_common(std::move(elem));
+    } catch (...) {
+        close();
+        throw;
+    }
+}
+
+template <typename Value>
+queue_op_status buffer_queue<Value>::nonblocking_push(Value&& elem)
+{
+    /* This try block is here to catch exceptions from the mutex
+       operations or from the user-defined copy assignment
+       operator in push_at. */
+    try {
+        std::unique_lock<std::mutex> hold( mtx_, std::try_to_lock );
+        if (!hold.owns_lock()) {
+            return queue_op_status::busy;
+        }
+        return try_push_common(std::move(elem));
+    } catch (...) {
+        close();
+        throw;
+    }
+}
+
+template <typename Value>
+queue_op_status buffer_queue<Value>::wait_push(Value&& elem)
+{
+    /* This try block is here to catch exceptions from the mutex
+       operations or from the user-defined copy assignment
+       operator in push_at. */
+    try {
+        std::unique_lock<std::mutex> hold( mtx_ );
+        size_t hdx;
+        size_t nxt;
+        for (;;) {
+            if ( closed_ )
+                return queue_op_status::closed;
+            hdx = push_index_;
+            nxt = next( hdx );
+            if ( nxt != pop_index_ )
+                break;
+            ++waiting_full_;
+            not_full_.wait( hold );
+        }
+        return push_at( std::move(elem), hdx, nxt );
+    } catch (...) {
+        close();
+        throw;
+    }
+}
+
+template <typename Value>
+void buffer_queue<Value>::push(Value&& elem)
+{
+    /* Only wait_push can throw, and it protects itself, so there
+       is no need to try/catch here. */
+    if ( wait_push( std::move(elem) )
+         == queue_op_status::closed )
+        throw queue_op_status::closed;
+}
+
+} // namespace seqan3::contrib

--- a/include/seqan3/contrib/conqueue/queue_base.hpp
+++ b/include/seqan3/contrib/conqueue/queue_base.hpp
@@ -1,0 +1,672 @@
+// Copyright 2011 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <atomic>
+#include <iostream>
+#include <iterator>
+#include <stddef.h>
+
+#include <seqan3/core/platform.hpp>
+
+namespace seqan3::contrib
+{
+
+template <typename Queue>
+class queue_back_iter
+:
+    public std::iterator<std::output_iterator_tag, void, void, void, void>
+{
+  public:
+    typedef typename Queue::value_type value_type;
+
+    queue_back_iter(Queue& q) : q_(&q) { }
+    queue_back_iter() : q_(static_cast<Queue*>(NULL)) { }
+
+    queue_back_iter& operator *() { return *this; }
+    queue_back_iter& operator ++() { return *this; }
+    queue_back_iter& operator ++(int) { return *this; }
+    queue_back_iter& operator =(const value_type& value);
+
+    bool operator ==(const queue_back_iter& y) { return q_ == y.q_; }
+    bool operator !=(const queue_back_iter& y) { return q_ != y.q_; }
+
+  private:
+    Queue* q_;
+};
+
+template <typename Queue>
+class queue_front_iter
+:
+    public std::iterator<std::input_iterator_tag, void, void, void, void>
+{
+  public:
+    typedef typename Queue::value_type value_type;
+
+    class value
+    {
+      public:
+        value(value_type v) : v_(v) { }
+        value_type operator *() const { return v_; }
+      private:
+        value_type v_;
+    };
+
+    queue_front_iter(Queue& q) : q_(&q) { if ( q_ ) next(); }
+    queue_front_iter() : q_(static_cast<Queue*>(NULL)) { }
+
+    const value_type& operator *() const { return v_; }
+    const value_type* operator ->() const { return &v_; }
+    queue_front_iter& operator ++() { next(); return *this; }
+    value operator ++(int) { value t = v_; next(); return t; }
+
+    bool operator ==(const queue_front_iter& y)
+    { return q_ == y.q_; }
+    bool operator !=(const queue_front_iter& y)
+    { return q_ != y.q_; }
+
+  private:
+    void next();
+
+    Queue* q_;
+    value_type v_;
+};
+
+enum class queue_op_status
+{
+    success = 0,
+    empty,
+    full,
+    closed,
+    busy
+};
+
+#if 0
+template <typename Value>
+class queue_common
+{
+  public:
+    typedef Value& reference;
+    typedef const Value& const_reference;
+    typedef Value value_type;
+
+    virtual void close() = 0;
+    virtual bool is_closed() = 0;
+    virtual bool is_empty() = 0;
+
+  protected:
+    virtual ~queue_common();
+};
+
+template <typename Value>
+queue_common<Value>::~queue_common() = default;
+#endif
+
+template <typename Queue>
+class generic_queue_back
+{
+  public:
+    typedef typename Queue::value_type value_type;
+    typedef value_type& reference;
+    typedef const value_type& const_reference;
+
+    typedef queue_back_iter<generic_queue_back> iterator;
+    typedef const queue_back_iter<generic_queue_back> const_iterator;
+
+    //FIX generic_queue_back() = default;
+    generic_queue_back(Queue& queue) : queue_(&queue) { }
+    generic_queue_back(Queue* queue) : queue_(queue) { }
+    generic_queue_back(const generic_queue_back& other)
+        = default;
+    generic_queue_back& operator =(const generic_queue_back& other)
+        = default;
+
+    void close() { queue_->close(); }
+    bool is_closed() { return queue_->is_closed(); }
+    bool is_empty() { return queue_->is_empty(); }
+
+    iterator begin() { return iterator(*this); }
+    iterator end() { return iterator(); }
+    const iterator cbegin() { return const_iterator(*this); }
+    const iterator cend() { return const_iterator(); }
+
+    void push(const value_type& x)
+        { queue_->push(x); }
+    queue_op_status wait_push(const value_type& x)
+        { return queue_->wait_push(x); }
+    queue_op_status try_push(const value_type& x)
+        { return queue_->try_push(x); }
+    queue_op_status nonblocking_push(const value_type& x)
+        { return queue_->nonblocking_push(x); }
+    void push(value_type&& x)
+        { queue_->push( std::move(x) ); }
+    queue_op_status wait_push(value_type&& x)
+        { return queue_->wait_push( std::move(x) ); }
+    queue_op_status try_push(value_type&& x)
+        { return queue_->try_push( std::move(x) ); }
+    queue_op_status nonblocking_push(value_type&& x)
+        { return queue_->nonblocking_push( std::move(x) ); }
+
+    bool has_queue() { return queue_ != NULL; }
+
+  protected:
+    Queue* queue_;
+};
+
+template <typename Queue>
+class generic_queue_front
+{
+  public:
+    typedef typename Queue::value_type value_type;
+    typedef value_type& reference;
+    typedef const value_type& const_reference;
+
+    typedef queue_front_iter<generic_queue_front> iterator;
+    typedef queue_front_iter<generic_queue_front> const_iterator;
+
+    //FIX generic_queue_front() = default;
+    generic_queue_front(Queue& queue) : queue_(&queue) { }
+    generic_queue_front(Queue* queue) : queue_(queue) { }
+    generic_queue_front(const generic_queue_front& other)
+        = default;
+    generic_queue_front& operator =(const generic_queue_front& other)
+        = default;
+
+    void close() { queue_->close(); }
+    bool is_closed() { return queue_->is_closed(); }
+    bool is_empty() { return queue_->is_empty(); }
+
+    iterator begin() { return iterator(*this); }
+    iterator end() { return iterator(); }
+    const iterator cbegin() { return const_iterator(*this); }
+    const iterator cend() { return const_iterator(); }
+
+    value_type value_pop()
+        { return queue_->value_pop(); }
+    queue_op_status wait_pop(value_type& x)
+        { return queue_->wait_pop(x); }
+    queue_op_status try_pop(value_type& x)
+        { return queue_->try_pop(x); }
+    queue_op_status nonblocking_pop(value_type& x)
+        { return queue_->nonblocking_pop(x); }
+
+    bool has_queue() { return queue_ != NULL; }
+
+  protected:
+    Queue* queue_;
+};
+
+template <typename Queue>
+queue_back_iter<Queue>&
+queue_back_iter<Queue>::operator =(const value_type& value)
+{
+    queue_op_status s = q_->wait_push(value);
+    if ( s != queue_op_status::success ) {
+        q_ = NULL;
+        throw s;
+    }
+    return *this;
+}
+
+template <typename Queue>
+void
+queue_front_iter<Queue>::next()
+{
+    queue_op_status s = q_->wait_pop(v_);
+    if ( s == queue_op_status::closed )
+        q_ = NULL;
+}
+
+template <typename Value>
+class queue_base
+{
+  public:
+    typedef Value value_type;
+    typedef value_type& reference;
+    typedef const value_type& const_reference;
+
+    virtual ~queue_base() { }
+
+    virtual void close() = 0;
+    virtual bool is_closed() = 0;
+    virtual bool is_empty() = 0;
+
+    virtual void push(const Value& x) = 0;
+    virtual queue_op_status wait_push(const Value& x) = 0;
+    virtual queue_op_status try_push(const Value& x) = 0;
+    virtual queue_op_status nonblocking_push(const Value& x) = 0;
+
+    virtual void push(Value&& x) = 0;
+    virtual queue_op_status wait_push(Value&& x) = 0;
+    virtual queue_op_status try_push(Value&& x) = 0;
+    virtual queue_op_status nonblocking_push(Value&& x) = 0;
+
+    virtual Value value_pop() = 0;
+    virtual queue_op_status wait_pop(Value&) = 0;
+    virtual queue_op_status try_pop(Value&) = 0;
+    virtual queue_op_status nonblocking_pop(Value&) = 0;
+};
+
+//TODO(crowl): Use template aliases for queue_back and queue_front?
+
+template <typename Value>
+class queue_back
+: public generic_queue_back< queue_base<Value> >
+{
+  public:
+    queue_back() = default;
+    queue_back(queue_base<Value>& queue)
+        : generic_queue_back< queue_base<Value> >(queue) { }
+    queue_back(queue_base<Value>* queue)
+        : generic_queue_back< queue_base<Value> >(queue) { }
+    queue_back(const queue_back<Value>& other)
+        : generic_queue_back< queue_base<Value> >(other.queue_) { }
+};
+
+template <typename Value>
+class queue_front
+: public generic_queue_front< queue_base<Value> >
+{
+  public:
+    queue_front() = default;
+    queue_front(queue_base<Value>& queue)
+        : generic_queue_front< queue_base<Value> >(queue) { }
+    queue_front(queue_base<Value>* queue)
+        : generic_queue_front< queue_base<Value> >(queue) { }
+    queue_front(const queue_front<Value>& other)
+        : generic_queue_front< queue_base<Value> >(other.queue_) { }
+};
+
+template <typename Queue>
+class queue_wrapper
+:
+    public virtual queue_base <typename Queue::value_type>
+{
+    Queue* ptr;
+
+  public:
+    typedef typename Queue::value_type value_type;
+    typedef value_type& reference;
+    typedef const value_type& const_reference;
+
+    queue_wrapper(Queue* arg)
+    : ptr(arg)
+    { }
+
+    queue_wrapper(Queue& arg)
+    : ptr(&arg)
+    { }
+
+    virtual ~queue_wrapper()
+    { }
+
+    virtual void close()
+    { ptr->close(); }
+
+    virtual bool is_closed()
+    { return ptr->is_closed(); }
+
+    virtual bool is_empty()
+    { return ptr->is_empty(); }
+
+    virtual void push(const value_type& x)
+    { ptr->push(x); }
+
+    virtual queue_op_status wait_push(const value_type& x)
+    { return ptr->wait_push(x); }
+
+    virtual queue_op_status try_push(const value_type& x)
+    { return ptr->try_push(x); }
+
+    virtual queue_op_status nonblocking_push(const value_type& x)
+    { return ptr->nonblocking_push(x); }
+
+    virtual void push(value_type&& x)
+    { ptr->push(std::move(x)); }
+
+    virtual queue_op_status wait_push(value_type&& x)
+    { return ptr->wait_push(std::move(x)); }
+
+    virtual queue_op_status try_push(value_type&& x)
+    { return ptr->try_push(std::move(x)); }
+
+    virtual queue_op_status nonblocking_push(value_type&& x)
+    { return ptr->nonblocking_push(std::move(x)); }
+
+    virtual value_type value_pop()
+    { return ptr->value_pop(); }
+
+    virtual queue_op_status wait_pop(value_type& x)
+    { return ptr->wait_pop(x); }
+
+    virtual queue_op_status try_pop(value_type& x)
+    { return ptr->try_pop(x); }
+
+    virtual queue_op_status nonblocking_pop(value_type& x)
+    { return ptr->nonblocking_pop(x); }
+
+    queue_back<value_type> back()
+    { return queue_back<value_type>(this); }
+
+    queue_front<value_type> front()
+    { return queue_front<value_type>(this); }
+};
+
+template <typename Value>
+class queue_counted
+:
+    public queue_base<Value>
+{
+  public:
+    queue_counted() : bk_(0), ft_(0) { }
+    virtual ~queue_counted() { }
+
+    void inc_back() { bk_++; }
+    void inc_front() { ft_++; }
+    bool dec_back() { return --bk_ == 0; }
+    bool dec_front() { return --ft_ == 0; }
+    bool no_back() { return bk_ == 0; }
+    bool no_front() { return ft_ == 0; }
+
+  private:
+    std::atomic<int> bk_;
+    std::atomic<int> ft_;
+};
+
+template <typename Value>
+class shared_queue_back
+{
+  public:
+    typedef Value value_type;
+    typedef value_type& reference;
+    typedef const value_type& const_reference;
+
+    typedef queue_back_iter<shared_queue_back> iterator;
+    typedef const queue_back_iter<shared_queue_back> const_iterator;
+
+    //FIX shared_queue_back()
+    //FIX     : queue_(NULL) { }
+    shared_queue_back(queue_counted<value_type>* queue)
+        : queue_(queue) { queue->inc_back(); }
+    shared_queue_back(const shared_queue_back& other)
+        : queue_(other.queue_) { queue_->inc_back(); }
+    shared_queue_back(shared_queue_back&& other)
+        : queue_(other.queue_) { other.queue_ = NULL; }
+
+  private:
+    void release()
+    {
+        if ( queue_ != NULL && queue_->dec_back() ) {
+            queue_->close();
+            if ( queue_->no_front() ) {
+                delete queue_;
+            }
+        }
+    }
+
+  public:
+    ~shared_queue_back() { release(); }
+
+    shared_queue_back& operator =(const shared_queue_back& other)
+    {
+        if ( this != &other ) {
+            release();
+            queue_ = other->queue_;
+            if ( queue_ != NULL )
+                queue_->inc_back();
+        }
+        return *this;
+    }
+    shared_queue_back& operator =(shared_queue_back&& other)
+    {
+        if ( this != &other ) {
+            release();
+            queue_ = other->queue_;
+            other->queue_ == NULL;
+        }
+        return *this;
+    }
+
+    void close() { queue_->close(); }
+    bool is_closed() { return queue_->is_closed(); }
+    bool is_empty() { return queue_->is_empty(); }
+
+    iterator begin() { return iterator(*this); }
+    iterator end() { return iterator(); }
+    const iterator cbegin() { return const_iterator(*this); }
+    const iterator cend() { return const_iterator(); }
+
+    void push(const value_type& x)
+        { queue_->push(x); }
+    queue_op_status wait_push(const value_type& x)
+        { return queue_->wait_push(x); }
+    queue_op_status try_push(const value_type& x)
+        { return queue_->try_push(x); }
+    queue_op_status nonblocking_push(const value_type& x)
+        { return queue_->nonblocking_push(x); }
+    void push(value_type&& x)
+        { queue_->push( std::move(x) ); }
+    queue_op_status wait_push(value_type&& x)
+        { return queue_->wait_push( std::move(x) ); }
+    queue_op_status try_push(value_type&& x)
+        { return queue_->try_push( std::move(x) ); }
+    queue_op_status nonblocking_push(value_type&& x)
+        { return queue_->nonblocking_push( std::move(x) ); }
+
+  private:
+    queue_counted<value_type>* queue_;
+};
+
+template <typename Value>
+class shared_queue_front
+{
+  public:
+    typedef Value value_type;
+    typedef value_type& reference;
+    typedef const value_type& const_reference;
+
+    typedef queue_front_iter<shared_queue_front> iterator;
+    typedef queue_front_iter<shared_queue_front> const_iterator;
+
+    //FIX shared_queue_front()
+    //FIX     : queue_(NULL) { }
+    shared_queue_front(queue_counted<value_type>* queue)
+        : queue_(queue) { queue->inc_front(); }
+    shared_queue_front(const shared_queue_front& other)
+        : queue_(other.queue_) { queue_->inc_front(); }
+    shared_queue_front(shared_queue_front&& other)
+        : queue_(other.queue_) { other.queue_ = NULL; }
+
+  private:
+    void release()
+    {
+        if ( queue_ != NULL && queue_->dec_front() ) {
+            queue_->close();
+            if ( queue_->no_back() ) {
+                delete queue_;
+            }
+        }
+    }
+
+  public:
+    ~shared_queue_front() { release(); }
+
+    shared_queue_front& operator =(const shared_queue_front& other)
+    {
+        if ( this != &other ) {
+            release();
+            queue_ = other->queue_;
+            if ( queue_ != NULL )
+                queue_->inc_front();
+        }
+        return *this;
+    }
+
+    shared_queue_front& operator =(shared_queue_front&& other)
+    {
+        if ( this != &other ) {
+            release();
+            queue_ = other->queue_;
+            other->queue_ = NULL;
+        }
+        return *this;
+    }
+
+    void close() { queue_->close(); }
+    bool is_closed() { return queue_->is_closed(); }
+    bool is_empty() { return queue_->is_empty(); }
+
+    iterator begin() { return iterator(*this); }
+    iterator end() { return iterator(); }
+    const iterator cbegin() { return const_iterator(*this); }
+    const iterator cend() { return const_iterator(); }
+
+    value_type value_pop()
+        { return queue_->value_pop(); }
+    queue_op_status wait_pop(value_type& x)
+        { return queue_->wait_pop(x); }
+    queue_op_status try_pop(value_type& x)
+        { return queue_->try_pop(x); }
+    queue_op_status nonblocking_pop(value_type& x)
+        { return queue_->nonblocking_pop(x); }
+
+  private:
+    queue_counted<value_type>* queue_;
+};
+
+template <typename Queue>
+class queue_owner
+:
+    public queue_counted <typename Queue::value_type>
+{
+    Queue* ptr;
+
+  public:
+    typedef typename Queue::value_type value_type;
+    typedef value_type& reference;
+    typedef const value_type& const_reference;
+
+    queue_owner(const queue_owner&) = delete;
+    queue_owner(Queue* arg) : ptr(arg) { }
+
+    virtual ~queue_owner() { delete ptr; }
+
+    queue_back<value_type> back()
+        { return queue_back<value_type>(this); }
+    queue_front<value_type> front()
+        { return queue_front<value_type>(this); }
+
+    virtual void close() { ptr->close(); }
+    virtual bool is_closed() { return ptr->is_closed(); }
+    virtual bool is_empty() { return ptr->is_empty(); }
+
+    virtual void push(const value_type& x)
+        { ptr->push(x); }
+    virtual queue_op_status wait_push(const value_type& x)
+        { return ptr->wait_push(x); }
+    virtual queue_op_status try_push(const value_type& x)
+        { return ptr->try_push(x); }
+    virtual queue_op_status nonblocking_push(const value_type& x)
+        { return ptr->nonblocking_push(x); }
+
+    virtual void push(value_type&& x)
+        { ptr->push(std::move(x)); }
+    virtual queue_op_status wait_push(value_type&& x)
+        { return ptr->wait_push(std::move(x)); }
+    virtual queue_op_status try_push(value_type&& x)
+        { return ptr->try_push(std::move(x)); }
+    virtual queue_op_status nonblocking_push(value_type&& x)
+        { return ptr->nonblocking_push(std::move(x)); }
+
+    virtual value_type value_pop()
+        { return ptr->value_pop(); }
+    virtual queue_op_status wait_pop(value_type& x)
+        { return ptr->wait_pop(x); }
+    virtual queue_op_status try_pop(value_type& x)
+        { return ptr->try_pop(x); }
+    virtual queue_op_status nonblocking_pop(value_type& x)
+        { return ptr->nonblocking_pop(x); }
+};
+
+
+template <typename Queue>
+class queue_object
+:
+    public queue_counted <typename Queue::value_type>
+{
+    Queue obj_;
+
+  public:
+    typedef typename Queue::value_type value_type;
+    typedef value_type& reference;
+    typedef const value_type& const_reference;
+
+    queue_object(const queue_object&) = delete;
+    template <typename ... Args>
+    queue_object(Args ... args) : obj_(args...) { }
+
+    virtual ~queue_object() { }
+
+    operator queue_back<value_type>() //TODO(crowl) Really?
+        { return queue_back<value_type>(this); }
+    queue_back<value_type> back()
+        { return queue_back<value_type>(this); }
+    queue_front<value_type> front()
+        { return queue_front<value_type>(this); }
+
+    virtual void close() { obj_.close(); }
+    virtual bool is_closed() { return obj_.is_closed(); }
+    virtual bool is_empty() { return obj_.is_empty(); }
+
+    virtual void push(const value_type& x)
+        { obj_.push(x); }
+    virtual queue_op_status wait_push(const value_type& x)
+        { return obj_.wait_push(x); }
+    virtual queue_op_status try_push(const value_type& x)
+        { return obj_.try_push(x); }
+    virtual queue_op_status nonblocking_push(const value_type& x)
+        { return obj_.nonblocking_push(x); }
+
+    virtual void push(value_type&& x)
+        { obj_.push(std::move(x)); }
+    virtual queue_op_status wait_push(value_type&& x)
+        { return obj_.wait_push(std::move(x)); }
+    virtual queue_op_status try_push(value_type&& x)
+        { return obj_.try_push(std::move(x)); }
+    virtual queue_op_status nonblocking_push(value_type&& x)
+        { return obj_.nonblocking_push(std::move(x)); }
+
+    virtual value_type value_pop()
+        { return obj_.value_pop(); }
+    virtual queue_op_status wait_pop(value_type& x)
+        { return obj_.wait_pop(x); }
+    virtual queue_op_status try_pop(value_type& x)
+        { return obj_.try_pop(x); }
+    virtual queue_op_status nonblocking_pop(value_type& x)
+        { return obj_.nonblocking_pop(x); }
+};
+
+template <typename Queue, typename ... Args>
+std::pair< shared_queue_back<typename Queue::value_type>,
+           shared_queue_front<typename Queue::value_type> >
+share_queue_ends(Args ... args)
+{
+  typedef typename Queue::value_type elemtype;
+  auto  q =  new queue_object<Queue>(args...) ;
+  return std::make_pair(shared_queue_back<elemtype>(q),
+                        shared_queue_front<elemtype>(q));
+}
+
+} // namespace seqan3::contrib

--- a/test/unit/contrib/conqueue/CMakeLists.txt
+++ b/test/unit/contrib/conqueue/CMakeLists.txt
@@ -1,0 +1,1 @@
+seqan3_test(buffer_queue_test.cpp)

--- a/test/unit/contrib/conqueue/buffer_queue_test.cpp
+++ b/test/unit/contrib/conqueue/buffer_queue_test.cpp
@@ -1,0 +1,100 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <numeric>
+#include <thread>
+
+#include <seqan3/contrib/conqueue/buffer_queue.hpp>
+#include <seqan3/std/ranges>
+
+using namespace seqan3;
+
+void test_buffer_queue(size_t num_producer, size_t num_consumer)
+{
+    constexpr size_t size_v = 10000;
+    contrib::buffer_queue<uint32_t> queue{100};
+
+    std::atomic<uint32_t> cnt{0};
+
+    // Define the producer section
+    auto produce = [&]()
+    {
+        while (true)
+        {
+            // Load atomic
+            uint32_t intermediate = cnt.fetch_add(1);
+
+            if (intermediate >= size_v)
+                return;
+
+            // wait semantics
+            contrib::queue_op_status status = queue.wait_push(intermediate);
+            if (status != contrib::queue_op_status::success)
+                return;
+        }
+    };
+
+    // Define the consumer section
+    std::atomic<uint32_t> sum{0};
+    auto consume = [&]() mutable
+    {
+        uint32_t i = 0;
+        while (queue.wait_pop(i) != contrib::queue_op_status::closed)
+            sum.fetch_add(i, std::memory_order_relaxed);
+    };
+
+    // Create producer pool
+    std::vector<std::thread> producer_pool;
+    for (size_t n = 0; n < num_producer; ++n)
+        producer_pool.emplace_back(produce);
+
+    // Create consumer pool
+    std::vector<std::thread> consumer_pool;
+    for (size_t n = 0; n < num_consumer; ++n)
+        consumer_pool.emplace_back(consume);
+
+
+    for (auto & t : producer_pool)
+    {
+        if (t.joinable())
+            t.join();
+    }
+    // Notify queue that no more work is going to be added.
+    queue.close();
+
+    for (auto & t : consumer_pool)
+    {
+        if (t.joinable())
+            t.join();
+    }
+
+    auto v = std::view::iota(0, size_v) | std::view::common;
+    EXPECT_EQ(sum.load(), (std::accumulate(v.begin(), v.end(), 0u)));
+}
+
+TEST(buffer_queue, single_producer_single_consumer)
+{
+    test_buffer_queue(1, 1);
+}
+
+TEST(buffer_queue, single_producer_multiple_consumer)
+{
+    test_buffer_queue(1, 4);
+}
+
+TEST(buffer_queue, multiple_producer_single_consumer)
+{
+    test_buffer_queue(4, 1);
+}
+
+TEST(buffer_queue, multiple_producer_multiple_consumer)
+{
+    test_buffer_queue(4, 4);
+}


### PR DESCRIPTION
This queue is an excerpt from the google concurrency library and implements the interface as proposed by [P0260R3](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p0260r3.html)

It is not clear if we can use this. We first need a license change of the library. Might be that we have to port our old queue from SeqAn2 and adapt the interface to use the proposal interface.