### PR TITLE
[FEATURE] Improve trivial_search

### DIFF
--- a/test/unit/search/search_scheme_algorithm_test.cpp
+++ b/test/unit/search/search_scheme_algorithm_test.cpp
@@ -29,7 +29,7 @@
 using namespace seqan3;
 
 template <typename text_t>
-inline void test_search_hamming(auto it, text_t const & text, auto const & search, uint64_t const query_length,
+inline void test_search_hamming(auto index, text_t const & text, auto const & search, uint64_t const query_length,
                                 std::vector<uint8_t> const & error_distribution, time_t const seed,
                                 auto const & blocks_length, auto const & ordered_blocks_length,
                                 uint64_t const start_pos)
@@ -41,6 +41,7 @@ inline void test_search_hamming(auto it, text_t const & text, auto const & searc
 
     // Modify query s.t. it has errors matching error_distribution.
     auto query = orig_query;
+    auto it = index.begin();
     uint64_t current_blocks_length = 0;
     for (uint8_t block = 0; block < search.blocks(); ++block)
     {
@@ -133,8 +134,9 @@ inline void test_search_hamming(auto it, text_t const & text, auto const & searc
     // Find all hits using search schemes.
     detail::search_ss<false>(it, query, start_pos, start_pos + 1, 0, 0, true, search, blocks_length, error_left,
                              delegate_ss);
+    
     // Find all hits using trivial backtracking.
-    detail::search_trivial<false>(it, query, 0, error_left, delegate_trivial);
+    detail::search_trivial<false>(index, query, error_left, delegate_trivial);
 
     // Eliminate hits that we are not interested in (based on the search and chosen error distribution)
     hits_ss.erase(std::remove_if(hits_ss.begin(), hits_ss.end(), remove_predicate_ss), hits_ss.end());
@@ -203,7 +205,7 @@ inline void test_search_scheme_hamming(search_scheme_t const & search_scheme, ti
 
                     for (auto && error_distribution : error_distributions[search_id])
                     {
-                        test_search_hamming(index.begin(), text, search_scheme[search_id], query_length,
+                        test_search_hamming(index, text, search_scheme[search_id], query_length,
                                             error_distribution, seed, blocks_length, ordered_blocks_length, start_pos);
                     }
                 }


### PR DESCRIPTION
2019-03-26 16:23:30
Running ./search_benchmark
Run on (4 X 3400 MHz CPU s)
CPU Caches:
  L1 Data 32K (x2)
  L1 Instruction 32K (x2)
  L2 Unified 256K (x2)
  L3 Unified 4096K (x1)
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.


Benchmark | Time | CPU | Iterations
-- | -- | -- | --
  |   |   |  
old trivial_search |   |   |  
unidirectional_search_sim_e1/1 | 25852 ns | 25861 ns | 26683
unidirectional_search_sim_e1/2 | 278612 ns | 278715 ns | 2587
unidirectional_search_sim_e1/3 | 3190970 ns | 3192138 ns | 219
unidirectional_search_e3/1 | 3199463 ns | 3200661 ns | 217
unidirectional_search_e3/2 | 2908445 ns | 2909513 ns | 229
unidirectional_search_e3/3 | 2852047 ns | 2853116 ns | 218
  |   |   |  
modified trivial_search |   |   |  
unidirectional_search_sim_e1/1 | 30461 ns | 30460 ns | 21228
unidirectional_search_sim_e1/2 | 365720 ns | 365770 ns | 1988
unidirectional_search_sim_e1/3 | 7014972 ns | 7017075 ns | 136
unidirectional_search_e3/1 | 5574338 ns | 5576071 ns | 123
unidirectional_search_e3/2 | 5241970 ns | 5243529 ns | 127
unidirectional_search_e3/3 | 4689749 ns | 4691333 ns | 110
