### PR TITLE
[MISC] Fix constructor warnings from doxygen alignment I

### DIFF
--- a/include/seqan3/alignment/band/static_band.hpp
+++ b/include/seqan3/alignment/band/static_band.hpp
@@ -71,12 +71,12 @@ public:
     /*!\name Constructors, destructor and assignment
      * \{
      */
-    constexpr static_band()                                noexcept = default;
-    constexpr static_band(static_band const &)             noexcept = default;
-    constexpr static_band(static_band &&)                  noexcept = default;
-    constexpr static_band & operator=(static_band const &) noexcept = default;
-    constexpr static_band & operator=(static_band &&)      noexcept = default;
-    ~static_band()                                         noexcept = default;
+    constexpr static_band()                                noexcept = default; //!< Defaulted
+    constexpr static_band(static_band const &)             noexcept = default; //!< Defaulted
+    constexpr static_band(static_band &&)                  noexcept = default; //!< Defaulted
+    constexpr static_band & operator=(static_band const &) noexcept = default; //!< Defaulted
+    constexpr static_band & operator=(static_band &&)      noexcept = default; //!< Defaulted
+    ~static_band()                                         noexcept = default; //!< Defaulted
 
     /*!\brief Construction from seqan3::lower_bound and seqan3::upper_bound.
      * \tparam input_value_t The input type of the lower and upper band boundaries.

--- a/include/seqan3/alignment/configuration/align_config_aligned_ends.hpp
+++ b/include/seqan3/alignment/configuration/align_config_aligned_ends.hpp
@@ -285,11 +285,11 @@ public:
             std::remove_reference_t<ends_t>::static_value), ..., 0);
     }
 
-    constexpr end_gaps(end_gaps const &)             noexcept = default;
-    constexpr end_gaps(end_gaps &&)                  noexcept = default;
-    constexpr end_gaps & operator=(end_gaps const &) noexcept = default;
-    constexpr end_gaps & operator=(end_gaps &&)      noexcept = default;
-    ~end_gaps()                                      noexcept = default;
+    constexpr end_gaps(end_gaps const &)             noexcept = default; //!< Defaulted
+    constexpr end_gaps(end_gaps &&)                  noexcept = default; //!< Defaulted
+    constexpr end_gaps & operator=(end_gaps const &) noexcept = default; //!< Defaulted
+    constexpr end_gaps & operator=(end_gaps &&)      noexcept = default; //!< Defaulted
+    ~end_gaps()                                      noexcept = default; //!< Defaulted
 
     //!\brief Construction from at least one sequence end-gap specifier.
     constexpr end_gaps(ends_t const ...args) noexcept

--- a/include/seqan3/alignment/matrix/alignment_coordinate.hpp
+++ b/include/seqan3/alignment/matrix/alignment_coordinate.hpp
@@ -86,12 +86,12 @@ public:
     /*!\name Constructors, destructor and assignment
      * \{
      */
-    constexpr advanceable_alignment_coordinate() noexcept = default;
-    constexpr advanceable_alignment_coordinate(advanceable_alignment_coordinate const &) noexcept = default;
-    constexpr advanceable_alignment_coordinate(advanceable_alignment_coordinate &&) noexcept = default;
-    constexpr advanceable_alignment_coordinate & operator=(advanceable_alignment_coordinate const &) noexcept = default;
-    constexpr advanceable_alignment_coordinate & operator=(advanceable_alignment_coordinate &&) noexcept = default;
-    ~advanceable_alignment_coordinate() noexcept = default;
+    constexpr advanceable_alignment_coordinate() noexcept = default;                                                     //!< Defaulted
+    constexpr advanceable_alignment_coordinate(advanceable_alignment_coordinate const &) noexcept = default;             //!< Defaulted
+    constexpr advanceable_alignment_coordinate(advanceable_alignment_coordinate &&) noexcept = default;                  //!< Defaulted
+    constexpr advanceable_alignment_coordinate & operator=(advanceable_alignment_coordinate const &) noexcept = default; //!< Defaulted
+    constexpr advanceable_alignment_coordinate & operator=(advanceable_alignment_coordinate &&) noexcept = default;      //!< Defaulted
+    ~advanceable_alignment_coordinate() noexcept = default;                                                              //!< Defaulted
 
     //!\brief Copy-constructs from another advanceable_alignment_coordinate with a different policy.
     template <advanceable_alignment_coordinate_state other_state>
@@ -300,12 +300,12 @@ public:
     /*!\name Constructors, destructor and assignment
      * \{
      */
-    constexpr alignment_coordinate() = default;
-    constexpr alignment_coordinate(alignment_coordinate const &) = default;
-    constexpr alignment_coordinate(alignment_coordinate &&) = default;
-    constexpr alignment_coordinate & operator=(alignment_coordinate const &) = default;
-    constexpr alignment_coordinate & operator=(alignment_coordinate &&) = default;
-    ~alignment_coordinate() = default;
+    constexpr alignment_coordinate() = default;                                         //!< Defaulted
+    constexpr alignment_coordinate(alignment_coordinate const &) = default;             //!< Defaulted
+    constexpr alignment_coordinate(alignment_coordinate &&) = default;                  //!< Defaulted
+    constexpr alignment_coordinate & operator=(alignment_coordinate const &) = default; //!< Defaulted
+    constexpr alignment_coordinate & operator=(alignment_coordinate &&) = default;      //!< Defaulted
+    ~alignment_coordinate() = default;                                                  //!< Defaulted
 
     //!\cond DEV
     //!\brief Inherit the constructor from the base class.

--- a/include/seqan3/alignment/matrix/alignment_coordinate.hpp
+++ b/include/seqan3/alignment/matrix/alignment_coordinate.hpp
@@ -86,12 +86,15 @@ public:
     /*!\name Constructors, destructor and assignment
      * \{
      */
-    constexpr advanceable_alignment_coordinate() noexcept = default;                                                     //!< Defaulted
-    constexpr advanceable_alignment_coordinate(advanceable_alignment_coordinate const &) noexcept = default;             //!< Defaulted
-    constexpr advanceable_alignment_coordinate(advanceable_alignment_coordinate &&) noexcept = default;                  //!< Defaulted
-    constexpr advanceable_alignment_coordinate & operator=(advanceable_alignment_coordinate const &) noexcept = default; //!< Defaulted
-    constexpr advanceable_alignment_coordinate & operator=(advanceable_alignment_coordinate &&) noexcept = default;      //!< Defaulted
-    ~advanceable_alignment_coordinate() noexcept = default;                                                              //!< Defaulted
+    constexpr advanceable_alignment_coordinate() noexcept = default;                                    //!< Defaulted
+    //!\brief Defaulted
+    constexpr advanceable_alignment_coordinate(advanceable_alignment_coordinate const &) noexcept = default;
+    constexpr advanceable_alignment_coordinate(advanceable_alignment_coordinate &&) noexcept = default; //!< Defaulted
+    //!\brief Defaulted
+    constexpr advanceable_alignment_coordinate & operator=(advanceable_alignment_coordinate const &) noexcept = default;
+    //!\brief Defaulted
+    constexpr advanceable_alignment_coordinate & operator=(advanceable_alignment_coordinate &&) noexcept = default;
+    ~advanceable_alignment_coordinate() noexcept = default;                                             //!< Defaulted
 
     //!\brief Copy-constructs from another advanceable_alignment_coordinate with a different policy.
     template <advanceable_alignment_coordinate_state other_state>

--- a/include/seqan3/alignment/matrix/alignment_matrix_formatter.hpp
+++ b/include/seqan3/alignment/matrix/alignment_matrix_formatter.hpp
@@ -194,15 +194,15 @@ public:
     alignment_matrix_format symbols;
 
     /*!\name Constructors, destructor and assignment
-     * The copy-constructor, move-constructor, copy-assignment, move-assignment,
-     * and destructor are implicitly defined.
      * \{
      */
-     alignment_matrix_formatter() = delete;
-     alignment_matrix_formatter(alignment_matrix_formatter const &) = default;
-     alignment_matrix_formatter(alignment_matrix_formatter &&) = default;
-     alignment_matrix_formatter & operator=(alignment_matrix_formatter const &) = default;
-     alignment_matrix_formatter & operator=(alignment_matrix_formatter &&) = default;
+     alignment_matrix_formatter() = delete;                                                //!< Matrix taken as ref.
+     alignment_matrix_formatter(alignment_matrix_formatter const &) = default;             //!< Defaulted
+     alignment_matrix_formatter(alignment_matrix_formatter &&) = default;                  //!< Defaulted
+     alignment_matrix_formatter & operator=(alignment_matrix_formatter const &) = default; //!< Defaulted
+     alignment_matrix_formatter & operator=(alignment_matrix_formatter &&) = default;      //!< Defaulted
+     ~alignment_matrix_formatter() = default;                                              //!< Defaulted
+
     /*!\brief Construct the matrix out of the *entries*, the *rows*,
      *        and the *cols*.
      * \param _matrix  \copydoc matrix

--- a/include/seqan3/alignment/matrix/alignment_trace_matrix.hpp
+++ b/include/seqan3/alignment/matrix/alignment_trace_matrix.hpp
@@ -90,15 +90,14 @@ public:
     using entry_type = trace_directions;
 
     /*!\name Constructors, destructor and assignment
-     * The copy-constructor, move-constructor, copy-assignment, move-assignment,
-     * and destructor are implicitly defined.
      * \{
      */
-     alignment_trace_matrix() = default;
-     alignment_trace_matrix(alignment_trace_matrix const &) = default;
-     alignment_trace_matrix(alignment_trace_matrix &&) = default;
-     alignment_trace_matrix & operator=(alignment_trace_matrix const &) = default;
-     alignment_trace_matrix & operator=(alignment_trace_matrix &&) = default;
+     alignment_trace_matrix() = default;                                           //!< Defaulted
+     alignment_trace_matrix(alignment_trace_matrix const &) = default;             //!< Defaulted
+     alignment_trace_matrix(alignment_trace_matrix &&) = default;                  //!< Defaulted
+     alignment_trace_matrix & operator=(alignment_trace_matrix const &) = default; //!< Defaulted
+     alignment_trace_matrix & operator=(alignment_trace_matrix &&) = default;      //!< Defaulted
+     ~alignment_trace_matrix() = default;                                          //!< Defaulted
 
     /*!\brief Construct the trace matrix by using a score_matrix.
      * \param database     The database sequence.

--- a/include/seqan3/alignment/matrix/row_wise_matrix.hpp
+++ b/include/seqan3/alignment/matrix/row_wise_matrix.hpp
@@ -37,15 +37,14 @@ public:
     using entry_type = entry_t;
 
     /*!\name Constructors, destructor and assignment
-     * The copy-constructor, move-constructor, copy-assignment, move-assignment,
-     * and destructor are implicitly defined.
      * \{
      */
-     row_wise_matrix() = default;
-     row_wise_matrix(row_wise_matrix const &) = default;
-     row_wise_matrix(row_wise_matrix &&) = default;
-     row_wise_matrix & operator=(row_wise_matrix const &) = default;
-     row_wise_matrix & operator=(row_wise_matrix &&) = default;
+     row_wise_matrix() = default;                                    //!< Defaulted
+     row_wise_matrix(row_wise_matrix const &) = default;             //!< Defaulted
+     row_wise_matrix(row_wise_matrix &&) = default;                  //!< Defaulted
+     row_wise_matrix & operator=(row_wise_matrix const &) = default; //!< Defaulted
+     row_wise_matrix & operator=(row_wise_matrix &&) = default;      //!< Defaulted
+     ~row_wise_matrix() = default;                                   //!< Defaulted
     /*!\brief Construct the matrix out of the *entries*, the *rows*,
      *        and the *cols*.
      * \param entries The entry values as a flat std::vector <#entry_type>.

--- a/include/seqan3/alignment/pairwise/execution/alignment_executor_two_way.hpp
+++ b/include/seqan3/alignment/pairwise/execution/alignment_executor_two_way.hpp
@@ -87,10 +87,10 @@ public:
      * \brief The class is not copy-constructible or copy-assignable but allows move construction and assignment.
      * \{
      */
-    alignment_executor_two_way() = delete;                                               //!< Deleted
-    alignment_executor_two_way(alignment_executor_two_way const &) = delete;             //!< Deleted
+    alignment_executor_two_way() = delete;                                               //!< This is a move-only type.
+    alignment_executor_two_way(alignment_executor_two_way const &) = delete;             //!< This is a move-only type.
     alignment_executor_two_way(alignment_executor_two_way &&) = default;                 //!< Defaulted
-    alignment_executor_two_way & operator=(alignment_executor_two_way const &) = delete; //!< Deleted
+    alignment_executor_two_way & operator=(alignment_executor_two_way const &) = delete; //!< This is a move-only type.
     alignment_executor_two_way & operator=(alignment_executor_two_way && ) = default;    //!< Defaulted
     ~alignment_executor_two_way() = default;                                             //!< Defaulted
 

--- a/include/seqan3/alignment/pairwise/execution/alignment_executor_two_way.hpp
+++ b/include/seqan3/alignment/pairwise/execution/alignment_executor_two_way.hpp
@@ -89,10 +89,10 @@ public:
      */
     alignment_executor_two_way() = delete;
     alignment_executor_two_way(alignment_executor_two_way const &) = delete;
-    alignment_executor_two_way(alignment_executor_two_way &&) = default;
+    alignment_executor_two_way(alignment_executor_two_way &&) = default;              //!< Defaulted
     alignment_executor_two_way & operator=(alignment_executor_two_way const &) = delete;
-    alignment_executor_two_way & operator=(alignment_executor_two_way && ) = default;
-    ~alignment_executor_two_way() = default;
+    alignment_executor_two_way & operator=(alignment_executor_two_way && ) = default; //!< Defaulted
+    ~alignment_executor_two_way() = default;                                          //!< Defaulted
 
     //!\brief Constructs this executor with the passed range of alignment instances.
     alignment_executor_two_way(resource_t && resrc,

--- a/include/seqan3/alignment/pairwise/execution/alignment_executor_two_way.hpp
+++ b/include/seqan3/alignment/pairwise/execution/alignment_executor_two_way.hpp
@@ -87,12 +87,12 @@ public:
      * \brief The class is not copy-constructible or copy-assignable but allows move construction and assignment.
      * \{
      */
-    alignment_executor_two_way() = delete;
-    alignment_executor_two_way(alignment_executor_two_way const &) = delete;
-    alignment_executor_two_way(alignment_executor_two_way &&) = default;              //!< Defaulted
-    alignment_executor_two_way & operator=(alignment_executor_two_way const &) = delete;
-    alignment_executor_two_way & operator=(alignment_executor_two_way && ) = default; //!< Defaulted
-    ~alignment_executor_two_way() = default;                                          //!< Defaulted
+    alignment_executor_two_way() = delete;                                               //!< Deleted
+    alignment_executor_two_way(alignment_executor_two_way const &) = delete;             //!< Deleted
+    alignment_executor_two_way(alignment_executor_two_way &&) = default;                 //!< Defaulted
+    alignment_executor_two_way & operator=(alignment_executor_two_way const &) = delete; //!< Deleted
+    alignment_executor_two_way & operator=(alignment_executor_two_way && ) = default;    //!< Defaulted
+    ~alignment_executor_two_way() = default;                                             //!< Defaulted
 
     //!\brief Constructs this executor with the passed range of alignment instances.
     alignment_executor_two_way(resource_t && resrc,

--- a/include/seqan3/alignment/pairwise/execution/alignment_range.hpp
+++ b/include/seqan3/alignment/pairwise/execution/alignment_range.hpp
@@ -23,6 +23,7 @@ namespace seqan3
  * \tparam alignment_executor_type The buffer type for the alignment stream.
  *
  * \details
+ * \attention This class considers moveable-only ranges.
  *
  * Provides a stream-like range interface over the alignments instances that are computed in a
  * seqan3::detail::alignment_executor_two_way executor.
@@ -52,12 +53,12 @@ class alignment_range
         /*!\name Constructors, destructor and assignment
          * \{
          */
-        constexpr iterator_type() noexcept = default;
-        constexpr iterator_type(iterator_type const &) noexcept = default;
-        constexpr iterator_type(iterator_type &&) noexcept = default;
-        constexpr iterator_type & operator=(iterator_type const &) noexcept = default;
-        constexpr iterator_type & operator=(iterator_type &&) noexcept = default;
-        ~iterator_type() = default;
+        constexpr iterator_type() noexcept = default;                                  //!< Defaulted
+        constexpr iterator_type(iterator_type const &) noexcept = default;             //!< Defaulted
+        constexpr iterator_type(iterator_type &&) noexcept = default;                  //!< Defaulted
+        constexpr iterator_type & operator=(iterator_type const &) noexcept = default; //!< Defaulted
+        constexpr iterator_type & operator=(iterator_type &&) noexcept = default;      //!< Defaulted
+        ~iterator_type() = default;                                                    //!< Defaulted
 
         //!\brief Construct from alignment stream.
         constexpr iterator_type(alignment_range & range) noexcept : range_ptr(&range)
@@ -141,12 +142,12 @@ public:
     /*!\name Constructors, destructor and assignment
      * \{
      */
-    alignment_range() = default;
-    alignment_range(alignment_range const &) = delete;
-    alignment_range(alignment_range &&) = default;
-    alignment_range & operator=(alignment_range const &) = delete;
-    alignment_range & operator=(alignment_range &&) = default;
-    ~alignment_range() = default;
+    alignment_range() = default;                                   //!< Defaulted
+    alignment_range(alignment_range const &) = delete;             //!< Deleted
+    alignment_range(alignment_range &&) = default;                 //!< Defaulted
+    alignment_range & operator=(alignment_range const &) = delete; //!< Deleted
+    alignment_range & operator=(alignment_range &&) = default;     //!< Defaulted
+    ~alignment_range() = default;                                  //!< Defaulted
 
     //!\brief Explicit deletion to forbid copy construction of the underlying executor.
     explicit alignment_range(alignment_executor_type const & _alignment_executor) = delete;

--- a/include/seqan3/alignment/pairwise/execution/alignment_range.hpp
+++ b/include/seqan3/alignment/pairwise/execution/alignment_range.hpp
@@ -143,9 +143,9 @@ public:
      * \{
      */
     alignment_range() = default;                                   //!< Defaulted
-    alignment_range(alignment_range const &) = delete;             //!< Deleted
+    alignment_range(alignment_range const &) = delete;             //!< This is a move-only type.
     alignment_range(alignment_range &&) = default;                 //!< Defaulted
-    alignment_range & operator=(alignment_range const &) = delete; //!< Deleted
+    alignment_range & operator=(alignment_range const &) = delete; //!< This is a move-only type.
     alignment_range & operator=(alignment_range &&) = default;     //!< Defaulted
     ~alignment_range() = default;                                  //!< Defaulted
 

--- a/include/seqan3/alignment/pairwise/policy/affine_gap_banded_init_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/affine_gap_banded_init_policy.hpp
@@ -43,12 +43,14 @@ private:
      * \brief Defaulted all standard constructor.
      * \{
      */
-    constexpr affine_gap_banded_init_policy() noexcept = default;                                                  //!< Defaulted
-    constexpr affine_gap_banded_init_policy(affine_gap_banded_init_policy const &) noexcept = default;             //!< Defaulted
-    constexpr affine_gap_banded_init_policy(affine_gap_banded_init_policy &&) noexcept = default;                  //!< Defaulted
-    constexpr affine_gap_banded_init_policy & operator=(affine_gap_banded_init_policy const &) noexcept = default; //!< Defaulted
-    constexpr affine_gap_banded_init_policy & operator=(affine_gap_banded_init_policy &&) noexcept = default;      //!< Defaulted
-    ~affine_gap_banded_init_policy() noexcept = default;                                                           //!< Defaulted
+    constexpr affine_gap_banded_init_policy() noexcept = default;                                      //!< Defaulted
+    constexpr affine_gap_banded_init_policy(affine_gap_banded_init_policy const &) noexcept = default; //!< Defaulted
+    constexpr affine_gap_banded_init_policy(affine_gap_banded_init_policy &&) noexcept = default;      //!< Defaulted
+    //!\brief Defaulted
+    constexpr affine_gap_banded_init_policy & operator=(affine_gap_banded_init_policy const &) noexcept = default;
+    //!\brief Defaulted
+    constexpr affine_gap_banded_init_policy & operator=(affine_gap_banded_init_policy &&) noexcept = default;
+    ~affine_gap_banded_init_policy() noexcept = default;                                               //!< Defaulted
     //!\}
 
     /*!\brief Initialises the origin of the dynamic programming matrix.

--- a/include/seqan3/alignment/pairwise/policy/affine_gap_banded_init_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/affine_gap_banded_init_policy.hpp
@@ -43,12 +43,12 @@ private:
      * \brief Defaulted all standard constructor.
      * \{
      */
-    constexpr affine_gap_banded_init_policy() noexcept = default;
-    constexpr affine_gap_banded_init_policy(affine_gap_banded_init_policy const &) noexcept = default;
-    constexpr affine_gap_banded_init_policy(affine_gap_banded_init_policy &&) noexcept = default;
-    constexpr affine_gap_banded_init_policy & operator=(affine_gap_banded_init_policy const &) noexcept = default;
-    constexpr affine_gap_banded_init_policy & operator=(affine_gap_banded_init_policy &&) noexcept = default;
-    ~affine_gap_banded_init_policy() noexcept = default;
+    constexpr affine_gap_banded_init_policy() noexcept = default;                                                  //!< Defaulted
+    constexpr affine_gap_banded_init_policy(affine_gap_banded_init_policy const &) noexcept = default;             //!< Defaulted
+    constexpr affine_gap_banded_init_policy(affine_gap_banded_init_policy &&) noexcept = default;                  //!< Defaulted
+    constexpr affine_gap_banded_init_policy & operator=(affine_gap_banded_init_policy const &) noexcept = default; //!< Defaulted
+    constexpr affine_gap_banded_init_policy & operator=(affine_gap_banded_init_policy &&) noexcept = default;      //!< Defaulted
+    ~affine_gap_banded_init_policy() noexcept = default;                                                           //!< Defaulted
     //!\}
 
     /*!\brief Initialises the origin of the dynamic programming matrix.

--- a/include/seqan3/alignment/pairwise/policy/affine_gap_banded_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/affine_gap_banded_policy.hpp
@@ -50,12 +50,12 @@ private:
      * \brief Defaulted all standard constructor.
      * \{
      */
-    constexpr affine_gap_banded_policy() noexcept = default;
-    constexpr affine_gap_banded_policy(affine_gap_banded_policy const &) noexcept = default;
-    constexpr affine_gap_banded_policy(affine_gap_banded_policy &&) noexcept = default;
-    constexpr affine_gap_banded_policy & operator=(affine_gap_banded_policy const &) noexcept = default;
-    constexpr affine_gap_banded_policy & operator=(affine_gap_banded_policy &&) noexcept = default;
-    ~affine_gap_banded_policy() noexcept = default;
+    constexpr affine_gap_banded_policy() noexcept = default;                                             //!< Defaulted
+    constexpr affine_gap_banded_policy(affine_gap_banded_policy const &) noexcept = default;             //!< Defaulted
+    constexpr affine_gap_banded_policy(affine_gap_banded_policy &&) noexcept = default;                  //!< Defaulted
+    constexpr affine_gap_banded_policy & operator=(affine_gap_banded_policy const &) noexcept = default; //!< Defaulted
+    constexpr affine_gap_banded_policy & operator=(affine_gap_banded_policy &&) noexcept = default;      //!< Defaulted
+    ~affine_gap_banded_policy() noexcept = default;                                                      //!< Defaulted
     //!\}
 
     /*!\brief Computes the score for current cell.

--- a/include/seqan3/alignment/pairwise/policy/affine_gap_init_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/affine_gap_init_policy.hpp
@@ -52,12 +52,12 @@ private:
      * \brief Defaulted all standard constructor.
      * \{
      */
-    constexpr affine_gap_init_policy() noexcept = default;
-    constexpr affine_gap_init_policy(affine_gap_init_policy const &) noexcept = default;
-    constexpr affine_gap_init_policy(affine_gap_init_policy &&) noexcept = default;
-    constexpr affine_gap_init_policy & operator=(affine_gap_init_policy const &) noexcept = default;
-    constexpr affine_gap_init_policy & operator=(affine_gap_init_policy &&) noexcept = default;
-    ~affine_gap_init_policy() noexcept = default;
+    constexpr affine_gap_init_policy() noexcept = default;                                           //!< Defaulted
+    constexpr affine_gap_init_policy(affine_gap_init_policy const &) noexcept = default;             //!< Defaulted
+    constexpr affine_gap_init_policy(affine_gap_init_policy &&) noexcept = default;                  //!< Defaulted
+    constexpr affine_gap_init_policy & operator=(affine_gap_init_policy const &) noexcept = default; //!< Defaulted
+    constexpr affine_gap_init_policy & operator=(affine_gap_init_policy &&) noexcept = default;      //!< Defaulted
+    ~affine_gap_init_policy() noexcept = default;                                                    //!< Defaulted
     //!\}
 
     /*!\brief Initialises the origin of the dynamic programming matrix.

--- a/include/seqan3/alignment/pairwise/policy/affine_gap_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/affine_gap_policy.hpp
@@ -49,12 +49,12 @@ private:
      * \brief Defaulted all standard constructor.
      * \{
      */
-    constexpr affine_gap_policy() noexcept = default;
-    constexpr affine_gap_policy(affine_gap_policy const &) noexcept = default;
-    constexpr affine_gap_policy(affine_gap_policy &&) noexcept = default;
-    constexpr affine_gap_policy & operator=(affine_gap_policy const &) noexcept = default;
-    constexpr affine_gap_policy & operator=(affine_gap_policy &&) noexcept = default;
-    ~affine_gap_policy() noexcept = default;
+    constexpr affine_gap_policy() noexcept = default;                                      //!< Defaulted
+    constexpr affine_gap_policy(affine_gap_policy const &) noexcept = default;             //!< Defaulted
+    constexpr affine_gap_policy(affine_gap_policy &&) noexcept = default;                  //!< Defaulted
+    constexpr affine_gap_policy & operator=(affine_gap_policy const &) noexcept = default; //!< Defaulted
+    constexpr affine_gap_policy & operator=(affine_gap_policy &&) noexcept = default;      //!< Defaulted
+    ~affine_gap_policy() noexcept = default;                                               //!< Defaulted
     //!\}
 
     /*!\brief Computes the score of the current cell.

--- a/include/seqan3/alignment/pairwise/policy/banded_score_dp_matrix_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/banded_score_dp_matrix_policy.hpp
@@ -61,12 +61,12 @@ private:
     /*!\name Constructors, destructor and assignment
      * \{
      */
-    constexpr banded_score_dp_matrix_policy() = default;
-    constexpr banded_score_dp_matrix_policy(banded_score_dp_matrix_policy const &) = default;
-    constexpr banded_score_dp_matrix_policy(banded_score_dp_matrix_policy &&) = default;
-    constexpr banded_score_dp_matrix_policy & operator=(banded_score_dp_matrix_policy const &) = default;
-    constexpr banded_score_dp_matrix_policy & operator=(banded_score_dp_matrix_policy &&) = default;
-    ~banded_score_dp_matrix_policy() = default;
+    constexpr banded_score_dp_matrix_policy() = default;                                                  //!< Defaulted
+    constexpr banded_score_dp_matrix_policy(banded_score_dp_matrix_policy const &) = default;             //!< Defaulted
+    constexpr banded_score_dp_matrix_policy(banded_score_dp_matrix_policy &&) = default;                  //!< Defaulted
+    constexpr banded_score_dp_matrix_policy & operator=(banded_score_dp_matrix_policy const &) = default; //!< Defaulted
+    constexpr banded_score_dp_matrix_policy & operator=(banded_score_dp_matrix_policy &&) = default;      //!< Defaulted
+    ~banded_score_dp_matrix_policy() = default;                                                           //!< Defaulted
     //!\}
 
 public:

--- a/include/seqan3/alignment/pairwise/policy/banded_score_trace_dp_matrix_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/banded_score_trace_dp_matrix_policy.hpp
@@ -81,12 +81,14 @@ private:
     /*!\name Constructors, destructor and assignment
      * \{
      */
-    constexpr banded_score_trace_dp_matrix_policy() = default;                                                        //!< Defaulted
-    constexpr banded_score_trace_dp_matrix_policy(banded_score_trace_dp_matrix_policy const &) = default;             //!< Defaulted
-    constexpr banded_score_trace_dp_matrix_policy(banded_score_trace_dp_matrix_policy &&) = default;                  //!< Defaulted
-    constexpr banded_score_trace_dp_matrix_policy & operator=(banded_score_trace_dp_matrix_policy const &) = default; //!< Defaulted
-    constexpr banded_score_trace_dp_matrix_policy & operator=(banded_score_trace_dp_matrix_policy &&) = default;      //!< Defaulted
-    ~banded_score_trace_dp_matrix_policy() = default;                                                                 //!< Defaulted
+    constexpr banded_score_trace_dp_matrix_policy() = default;                                            //!< Defaulted
+    constexpr banded_score_trace_dp_matrix_policy(banded_score_trace_dp_matrix_policy const &) = default; //!< Defaulted
+    constexpr banded_score_trace_dp_matrix_policy(banded_score_trace_dp_matrix_policy &&) = default;      //!< Defaulted
+    //!\brief Defaulted
+    constexpr banded_score_trace_dp_matrix_policy & operator=(banded_score_trace_dp_matrix_policy const &) = default;
+    //!\brief Defaulted 
+    constexpr banded_score_trace_dp_matrix_policy & operator=(banded_score_trace_dp_matrix_policy &&) = default;
+    ~banded_score_trace_dp_matrix_policy() = default;                                                     //!< Defaulted
     //!\}
 
     /*!\brief Allocates the memory for the dynamic programming matrix given the two sequences.

--- a/include/seqan3/alignment/pairwise/policy/banded_score_trace_dp_matrix_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/banded_score_trace_dp_matrix_policy.hpp
@@ -81,12 +81,12 @@ private:
     /*!\name Constructors, destructor and assignment
      * \{
      */
-    constexpr banded_score_trace_dp_matrix_policy() = default;
-    constexpr banded_score_trace_dp_matrix_policy(banded_score_trace_dp_matrix_policy const &) = default;
-    constexpr banded_score_trace_dp_matrix_policy(banded_score_trace_dp_matrix_policy &&) = default;
-    constexpr banded_score_trace_dp_matrix_policy & operator=(banded_score_trace_dp_matrix_policy const &) = default;
-    constexpr banded_score_trace_dp_matrix_policy & operator=(banded_score_trace_dp_matrix_policy &&) = default;
-    ~banded_score_trace_dp_matrix_policy() = default;
+    constexpr banded_score_trace_dp_matrix_policy() = default;                                                        //!< Defaulted
+    constexpr banded_score_trace_dp_matrix_policy(banded_score_trace_dp_matrix_policy const &) = default;             //!< Defaulted
+    constexpr banded_score_trace_dp_matrix_policy(banded_score_trace_dp_matrix_policy &&) = default;                  //!< Defaulted
+    constexpr banded_score_trace_dp_matrix_policy & operator=(banded_score_trace_dp_matrix_policy const &) = default; //!< Defaulted
+    constexpr banded_score_trace_dp_matrix_policy & operator=(banded_score_trace_dp_matrix_policy &&) = default;      //!< Defaulted
+    ~banded_score_trace_dp_matrix_policy() = default;                                                                 //!< Defaulted
     //!\}
 
     /*!\brief Allocates the memory for the dynamic programming matrix given the two sequences.

--- a/include/seqan3/alignment/pairwise/policy/find_optimum_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/find_optimum_policy.hpp
@@ -67,12 +67,12 @@ private:
     /*!\name Constructors, destructor and assignment
      * \{
      */
-    constexpr find_optimum_policy() = default;
-    constexpr find_optimum_policy(find_optimum_policy const &) = default;
-    constexpr find_optimum_policy(find_optimum_policy &&) = default;
-    constexpr find_optimum_policy & operator=(find_optimum_policy const &) = default;
-    constexpr find_optimum_policy & operator=(find_optimum_policy &&) = default;
-    ~find_optimum_policy() = default;
+    constexpr find_optimum_policy() = default;                                        //!< Defaulted
+    constexpr find_optimum_policy(find_optimum_policy const &) = default;             //!< Defaulted
+    constexpr find_optimum_policy(find_optimum_policy &&) = default;                  //!< Defaulted
+    constexpr find_optimum_policy & operator=(find_optimum_policy const &) = default; //!< Defaulted
+    constexpr find_optimum_policy & operator=(find_optimum_policy &&) = default;      //!< Defaulted
+    ~find_optimum_policy() = default;                                                 //!< Defaulted
     //!\}
 
 protected:

--- a/include/seqan3/alignment/pairwise/policy/unbanded_score_dp_matrix_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/unbanded_score_dp_matrix_policy.hpp
@@ -55,12 +55,12 @@ private:
      * \brief Defaulted all standard constructor.
      * \{
      */
-    constexpr unbanded_score_dp_matrix_policy() = default;
-    constexpr unbanded_score_dp_matrix_policy(unbanded_score_dp_matrix_policy const &) = default;
-    constexpr unbanded_score_dp_matrix_policy(unbanded_score_dp_matrix_policy &&) = default;
-    constexpr unbanded_score_dp_matrix_policy & operator=(unbanded_score_dp_matrix_policy const &) = default;
-    constexpr unbanded_score_dp_matrix_policy & operator=(unbanded_score_dp_matrix_policy &&) = default;
-    ~unbanded_score_dp_matrix_policy() = default;
+    constexpr unbanded_score_dp_matrix_policy() = default;                                                    //!< Defaulted
+    constexpr unbanded_score_dp_matrix_policy(unbanded_score_dp_matrix_policy const &) = default;             //!< Defaulted
+    constexpr unbanded_score_dp_matrix_policy(unbanded_score_dp_matrix_policy &&) = default;                  //!< Defaulted
+    constexpr unbanded_score_dp_matrix_policy & operator=(unbanded_score_dp_matrix_policy const &) = default; //!< Defaulted
+    constexpr unbanded_score_dp_matrix_policy & operator=(unbanded_score_dp_matrix_policy &&) = default;      //!< Defaulted
+    ~unbanded_score_dp_matrix_policy() = default;                                                             //!< Defaulted
     //!\}
 
     /*!\brief Allocates the memory for the dynamic programming matrix given the two sequences.

--- a/include/seqan3/alignment/pairwise/policy/unbanded_score_dp_matrix_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/unbanded_score_dp_matrix_policy.hpp
@@ -55,12 +55,13 @@ private:
      * \brief Defaulted all standard constructor.
      * \{
      */
-    constexpr unbanded_score_dp_matrix_policy() = default;                                                    //!< Defaulted
-    constexpr unbanded_score_dp_matrix_policy(unbanded_score_dp_matrix_policy const &) = default;             //!< Defaulted
-    constexpr unbanded_score_dp_matrix_policy(unbanded_score_dp_matrix_policy &&) = default;                  //!< Defaulted
-    constexpr unbanded_score_dp_matrix_policy & operator=(unbanded_score_dp_matrix_policy const &) = default; //!< Defaulted
-    constexpr unbanded_score_dp_matrix_policy & operator=(unbanded_score_dp_matrix_policy &&) = default;      //!< Defaulted
-    ~unbanded_score_dp_matrix_policy() = default;                                                             //!< Defaulted
+    constexpr unbanded_score_dp_matrix_policy() = default;                                               //!< Defaulted
+    constexpr unbanded_score_dp_matrix_policy(unbanded_score_dp_matrix_policy const &) = default;        //!< Defaulted
+    constexpr unbanded_score_dp_matrix_policy(unbanded_score_dp_matrix_policy &&) = default;             //!< Defaulted
+    //!\brief Defaulted
+    constexpr unbanded_score_dp_matrix_policy & operator=(unbanded_score_dp_matrix_policy const &) = default;
+    constexpr unbanded_score_dp_matrix_policy & operator=(unbanded_score_dp_matrix_policy &&) = default; //!< Defaulted
+    ~unbanded_score_dp_matrix_policy() = default;                                                        //!< Defaulted
     //!\}
 
     /*!\brief Allocates the memory for the dynamic programming matrix given the two sequences.

--- a/include/seqan3/alignment/pairwise/policy/unbanded_score_trace_dp_matrix_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/unbanded_score_trace_dp_matrix_policy.hpp
@@ -92,12 +92,12 @@ private:
     /*!\name Constructors, destructor and assignment
      * \{
      */
-    constexpr unbanded_score_trace_dp_matrix_policy() = default;
-    constexpr unbanded_score_trace_dp_matrix_policy(unbanded_score_trace_dp_matrix_policy const &) = default;
-    constexpr unbanded_score_trace_dp_matrix_policy(unbanded_score_trace_dp_matrix_policy &&) = default;
-    constexpr unbanded_score_trace_dp_matrix_policy & operator=(unbanded_score_trace_dp_matrix_policy const &) = default;
-    constexpr unbanded_score_trace_dp_matrix_policy & operator=(unbanded_score_trace_dp_matrix_policy &&) = default;
-    ~unbanded_score_trace_dp_matrix_policy() = default;
+    constexpr unbanded_score_trace_dp_matrix_policy() = default;                                                          //!< Defaulted
+    constexpr unbanded_score_trace_dp_matrix_policy(unbanded_score_trace_dp_matrix_policy const &) = default;             //!< Defaulted
+    constexpr unbanded_score_trace_dp_matrix_policy(unbanded_score_trace_dp_matrix_policy &&) = default;                  //!< Defaulted
+    constexpr unbanded_score_trace_dp_matrix_policy & operator=(unbanded_score_trace_dp_matrix_policy const &) = default; //!< Defaulted
+    constexpr unbanded_score_trace_dp_matrix_policy & operator=(unbanded_score_trace_dp_matrix_policy &&) = default;      //!< Defaulted
+    ~unbanded_score_trace_dp_matrix_policy() = default;                                                                   //!< Defaulted
     //!\}
 
     /*!\brief Allocates the memory for the dynamic programming matrix given the two sequences.

--- a/include/seqan3/alignment/pairwise/policy/unbanded_score_trace_dp_matrix_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/unbanded_score_trace_dp_matrix_policy.hpp
@@ -92,12 +92,15 @@ private:
     /*!\name Constructors, destructor and assignment
      * \{
      */
-    constexpr unbanded_score_trace_dp_matrix_policy() = default;                                                          //!< Defaulted
-    constexpr unbanded_score_trace_dp_matrix_policy(unbanded_score_trace_dp_matrix_policy const &) = default;             //!< Defaulted
-    constexpr unbanded_score_trace_dp_matrix_policy(unbanded_score_trace_dp_matrix_policy &&) = default;                  //!< Defaulted
-    constexpr unbanded_score_trace_dp_matrix_policy & operator=(unbanded_score_trace_dp_matrix_policy const &) = default; //!< Defaulted
-    constexpr unbanded_score_trace_dp_matrix_policy & operator=(unbanded_score_trace_dp_matrix_policy &&) = default;      //!< Defaulted
-    ~unbanded_score_trace_dp_matrix_policy() = default;                                                                   //!< Defaulted
+    constexpr unbanded_score_trace_dp_matrix_policy() = default;                                         //!< Defaulted
+    //!\brief Defaulted
+    constexpr unbanded_score_trace_dp_matrix_policy(unbanded_score_trace_dp_matrix_policy const &) = default;
+    constexpr unbanded_score_trace_dp_matrix_policy(unbanded_score_trace_dp_matrix_policy &&) = default; //!< Defaulted
+    //!\brief Defaulted
+    constexpr unbanded_score_trace_dp_matrix_policy & operator=(unbanded_score_trace_dp_matrix_policy const &) = default;
+    //!\brief Defaulted
+    constexpr unbanded_score_trace_dp_matrix_policy & operator=(unbanded_score_trace_dp_matrix_policy &&) = default;
+    ~unbanded_score_trace_dp_matrix_policy() = default;                                                  //!< Defaulted
     //!\}
 
     /*!\brief Allocates the memory for the dynamic programming matrix given the two sequences.


### PR DESCRIPTION
Fix doxygen warnings due to constructor comments for alignment, part I. 