### PR TITLE
[FEATURE] iterator_tag_t

### DIFF
--- a/include/seqan3/core/metafunction/iterator.hpp
+++ b/include/seqan3/core/metafunction/iterator.hpp
@@ -113,6 +113,110 @@ struct size_type<it_t>
 
 // see specialisation for ranges in core/metafunction/range.hpp
 
+// ----------------------------------------------------------------------------
+// iterator_tag
+// ----------------------------------------------------------------------------
+
+/*!\brief Type metafunction that deduces the
+ * [iterator_category](https://en.cppreference.com/w/cpp/iterator/iterator_tags) from the modelled
+ * concept [Type metafunction].
+ * \tparam it_t The type to operate on.
+ *
+ * <table>
+ *   <tr>
+ *     <th>Modelled concept</th>
+ *     <th>iterator_tag<it_t>::type</th>
+ *   </tr>
+ *   <tr>
+ *     <td>\ref std::InputIterator "std::InputIterator<it_t>"</td>
+ *     <td>std::input_iterator_tag</td>
+ *   </tr>
+ *   <tr>
+ *     <td>\ref std::InputIterator "!std::InputIterator<it_t>" &amp;&amp;
+ *         \ref std::OutputIterator "std::OutputIterator<it_t, value_type<it_t>>"</td>
+ *     <td>std::output_iterator_tag</td>
+ *   </tr>
+ *   <tr>
+ *     <td>\ref std::ForwardIterator "std::ForwardIterator<it_t>"</td>
+ *     <td>std::forward_iterator_tag</td>
+ *   </tr>
+ *   <tr>
+ *     <td>\ref std::BidirectionalIterator "std::BidirectionalIterator<it_t>"</td>
+ *     <td>std::bidirectional_iterator_tag</td>
+ *   </tr>
+ *   <tr>
+ *     <td>\ref std::RandomAccessIterator "std::RandomAccessIterator<it_t>"</td>
+ *     <td>std::random_access_iterator_tag</td>
+ *   </tr>
+ * </table>
+ *
+ * \attention
+ * If [std::iterator_traits<it_t>::iterator_category](https://en.cppreference.com/w/cpp/iterator/iterator_traits)
+ * is defined for a type `it_t`, this metafunction acts as an alias for it.
+ * If it is not defined and no concepts are modelled, iterator_tag<it_t>::type is not defined.
+ */
+template <typename it_t>
+struct iterator_tag
+{
+SEQAN3_DOXYGEN_ONLY(
+    //!\brief The [iterator_category](https://en.cppreference.com/w/cpp/iterator/iterator_tags).
+    using type = iterator_category;
+)
+};
+
+//!\cond
+template <typename it_t>
+    requires requires { typename std::iterator_traits<it_t>::iterator_category; }
+struct iterator_tag<it_t>
+{
+    using type = typename std::iterator_traits<it_t>::iterator_category;
+};
+
+template <std::InputIterator it_t>
+    requires !requires { typename std::iterator_traits<it_t>::iterator_category; }
+struct iterator_tag<it_t>
+{
+    using type = std::input_iterator_tag;
+};
+
+template <typename it_t>
+    requires !std::InputIterator<it_t> && std::OutputIterator<it_t, value_type_t<it_t>> &&
+             !requires { typename std::iterator_traits<it_t>::iterator_category; }
+struct iterator_tag<it_t>
+{
+    using type = std::output_iterator_tag;
+};
+
+template <std::ForwardIterator it_t>
+    requires !requires { typename std::iterator_traits<it_t>::iterator_category; }
+struct iterator_tag<it_t>
+{
+    using type = std::forward_iterator_tag;
+};
+
+template <std::BidirectionalIterator it_t>
+    requires !requires { typename std::iterator_traits<it_t>::iterator_category; }
+struct iterator_tag<it_t>
+{
+    using type = std::bidirectional_iterator_tag;
+};
+
+template <std::RandomAccessIterator it_t>
+    requires !requires { typename std::iterator_traits<it_t>::iterator_category; }
+struct iterator_tag<it_t>
+{
+    using type = std::random_access_iterator_tag;
+};
+//!\endcond
+
+/*!\brief Return the `iterator_category` type of the input type [Type metafunction, shortcut].
+ * \tparam it_t The type to operate on.
+ */
+template <typename it_t>
+//!\cond
+    requires requires { typename iterator_tag<it_t>::type; }
+//!\endcond
+using iterator_tag_t = typename iterator_tag<it_t>::type;
 //!\}
 
 } // namespace seqan3

--- a/include/seqan3/range/detail/inherited_iterator_base.hpp
+++ b/include/seqan3/range/detail/inherited_iterator_base.hpp
@@ -15,6 +15,7 @@
 #include <cassert>
 #include <type_traits>
 
+#include <seqan3/core/metafunction/iterator.hpp>
 #include <seqan3/std/iterator>
 
 namespace seqan3::detail
@@ -53,7 +54,7 @@ public:
     using value_type            = typename std::iterator_traits<base_t>::value_type;
     using reference             = typename std::iterator_traits<base_t>::reference;
     using pointer               = typename std::iterator_traits<base_t>::pointer;
-    using iterator_category     = typename std::iterator_traits<base_t>::iterator_category;
+    using iterator_category     = iterator_tag_t<base_t>;
     //!\}
 
     /*!\name Constructors, destructor and assignment

--- a/include/seqan3/range/view/pairwise_combine.hpp
+++ b/include/seqan3/range/view/pairwise_combine.hpp
@@ -81,7 +81,7 @@ private:
         using value_type        = std::tuple<underlying_val_t, underlying_val_t>;
         using reference         = std::tuple<underlying_ref_t, underlying_ref_t>;
         using pointer           = void;
-        using iterator_category = typename std::iterator_traits<underlying_iterator_type>::iterator_category;
+        using iterator_category = iterator_tag_t<underlying_iterator_type>;
         //!\}
 
         /*!\name Constructors, destructor and assignment

--- a/include/seqan3/range/view/take.hpp
+++ b/include/seqan3/range/view/take.hpp
@@ -109,7 +109,7 @@ private:
         using value_type            = typename std::iterator_traits<base_base_t>::value_type;
         using reference             = typename std::iterator_traits<base_base_t>::reference;
         using pointer               = typename std::iterator_traits<base_base_t>::pointer;
-        using iterator_category     = typename std::iterator_traits<base_base_t>::iterator_category;
+        using iterator_category     = iterator_tag_t<base_base_t>;
         //!\}
 
         /*!\name Arithmetic operators

--- a/include/seqan3/range/view/take_line.hpp
+++ b/include/seqan3/range/view/take_line.hpp
@@ -96,7 +96,7 @@ private:
         using value_type            = typename std::iterator_traits<base_base_t>::value_type;
         using reference             = typename std::iterator_traits<base_base_t>::reference;
         using pointer               = typename std::iterator_traits<base_base_t>::pointer;
-        using iterator_category     = typename std::iterator_traits<base_base_t>::iterator_category;
+        using iterator_category     = iterator_tag_t<base_base_t>;
         //!\}
 
         /*!\name Arithmetic operators

--- a/include/seqan3/range/view/take_until.hpp
+++ b/include/seqan3/range/view/take_until.hpp
@@ -121,7 +121,7 @@ private:
         using value_type            = typename std::iterator_traits<base_base_t>::value_type;
         using reference             = typename std::iterator_traits<base_base_t>::reference;
         using pointer               = typename std::iterator_traits<base_base_t>::pointer;
-        using iterator_category     = typename std::iterator_traits<base_base_t>::iterator_category;
+        using iterator_category     = iterator_tag_t<base_base_t>;
         //!\}
 
         /*!\name Comparison operators


### PR DESCRIPTION
Resolves #791 

This adds a `iterator_tag_t` metafunction that returns the correct iterator_tag depending on the modelled concept.

This can be used instead of `std::iterator_traits<it_t>::iterator_category` and allows us to use our views (which expect a `iterator_category` and now can automatically deduce it with `iterator_tag_t`) in combination with views from the range library that do not set the `iterator_tag` iff concept support is detected (this is a C++20 behaviour).