### PR TITLE
[WIP] Update concept documentation + tests for views

### DIFF
--- a/include/seqan3/range/view/char_to.hpp
+++ b/include/seqan3/range/view/char_to.hpp
@@ -37,22 +37,22 @@ namespace seqan3::view
  * This view is a **deep view:** Given a range-of-range as input (as opposed to just a range), it will apply
  * the transformation on the innermost range (instead of the outermost range).
  *
- * | range concepts and reference_t  | `urng_t` (underlying range type)      | `rrng_t` (returned range type)                     |
- * |---------------------------------|:-------------------------------------:|:--------------------------------------------------:|
- * | std::ranges::InputRange         | *required*                            | *preserved*                                        |
- * | std::ranges::ForwardRange       |                                       | *preserved*                                        |
- * | std::ranges::BidirectionalRange |                                       | *preserved*                                        |
- * | std::ranges::RandomAccessRange  |                                       | *preserved*                                        |
- * | std::ranges::ContiguousRange    |                                       | *lost*                                             |
- * |                                 |                                       |                                                    |
- * | std::ranges::ViewableRange      | *required*                            | *guaranteed*                                       |
- * | std::ranges::View               |                                       | *guaranteed*                                       |
- * | std::ranges::SizedRange         |                                       | *preserved*                                        |
- * | std::ranges::CommonRange        |                                       | *preserved*                                        |
- * | std::ranges::OutputRange        |                                       | *lost*                                             |
- * | seqan3::const_iterable_concept  |                                       | *preserved*                                        |
- * |                                 |                                       |                                                    |
- * | seqan3::reference_t             | seqan3::underlying_char_t<alphabet_t> | `alphabet_t`                                       |
+ * | range concepts and reference_t  | `urng_t` (underlying range type)      | `rrng_t` (returned range type) |
+ * |---------------------------------|:-------------------------------------:|:------------------------------:|
+ * | std::ranges::InputRange         | *required*                            | *preserved*                    |
+ * | std::ranges::ForwardRange       |                                       | *preserved*                    |
+ * | std::ranges::BidirectionalRange |                                       | *preserved*                    |
+ * | std::ranges::RandomAccessRange  |                                       | *preserved*                    |
+ * | std::ranges::ContiguousRange    |                                       | *lost*                         |
+ * |                                 |                                       |                                |
+ * | std::ranges::ViewableRange      | *required*                            | *guaranteed*                   |
+ * | std::ranges::View               |                                       | *guaranteed*                   |
+ * | std::ranges::SizedRange         |                                       | *preserved*                    |
+ * | std::ranges::CommonRange        |                                       | *preserved*                    |
+ * | std::ranges::OutputRange        |                                       | *lost*                         |
+ * | seqan3::const_iterable_concept  |                                       | *preserved*                    |
+ * |                                 |                                       |                                |
+ * | seqan3::reference_t             | seqan3::underlying_char_t<alphabet_t> | `alphabet_t`                   |
  *
  * See the \link view view submodule documentation \endlink for detailed descriptions of the view properties.
  *

--- a/include/seqan3/range/view/complement.hpp
+++ b/include/seqan3/range/view/complement.hpp
@@ -37,22 +37,22 @@ namespace seqan3::view
  * This view is a **deep view:** Given a range-of-range as input (as opposed to just a range), it will apply
  * the transformation on the innermost range (instead of the outermost range).
  *
- * | range concepts and reference_t  | `urng_t` (underlying range type)      | `rrng_t` (returned range type)                     |
- * |---------------------------------|:-------------------------------------:|:--------------------------------------------------:|
- * | std::ranges::InputRange         | *required*                            | *preserved*                                        |
- * | std::ranges::ForwardRange       |                                       | *preserved*                                        |
- * | std::ranges::BidirectionalRange |                                       | *preserved*                                        |
- * | std::ranges::RandomAccessRange  |                                       | *preserved*                                        |
- * | std::ranges::ContiguousRange    |                                       | *lost*                                             |
- * |                                 |                                       |                                                    |
- * | std::ranges::ViewableRange      | *required*                            | *guaranteed*                                       |
- * | std::ranges::View               |                                       | *guaranteed*                                       |
- * | std::ranges::SizedRange         |                                       | *preserved*                                        |
- * | std::ranges::CommonRange        |                                       | *preserved*                                        |
- * | std::ranges::OutputRange        |                                       | *lost*                                             |
- * | seqan3::const_iterable_concept  |                                       | *preserved*                                        |
- * |                                 |                                       |                                                    |
- * | seqan3::reference_t             | seqan3::NucleotideAlphabet            | std::remove_reference_t<seqan3::reference_t<urng_t>> |
+ * | range concepts and reference_t  | `urng_t` (underlying range type) | `rrng_t` (returned range type)                       |
+ * |---------------------------------|:--------------------------------:|:----------------------------------------------------:|
+ * | std::ranges::InputRange         | *required*                       | *preserved*                                          |
+ * | std::ranges::ForwardRange       |                                  | *preserved*                                          |
+ * | std::ranges::BidirectionalRange |                                  | *preserved*                                          |
+ * | std::ranges::RandomAccessRange  |                                  | *preserved*                                          |
+ * | std::ranges::ContiguousRange    |                                  | *lost*                                               |
+ * |                                 |                                  |                                                      |
+ * | std::ranges::ViewableRange      | *required*                       | *guaranteed*                                         |
+ * | std::ranges::View               |                                  | *guaranteed*                                         |
+ * | std::ranges::SizedRange         |                                  | *preserved*                                          |
+ * | std::ranges::CommonRange        |                                  | *preserved*                                          |
+ * | std::ranges::OutputRange        |                                  | *lost*                                               |
+ * | seqan3::const_iterable_concept  |                                  | *preserved*                                          |
+ * |                                 |                                  |                                                      |
+ * | seqan3::reference_t             | seqan3::NucleotideAlphabet       | std::remove_reference_t<seqan3::reference_t<urng_t>> |
  *
  * See the \link view view submodule documentation \endlink for detailed descriptions of the view properties.
  *

--- a/include/seqan3/range/view/convert.hpp
+++ b/include/seqan3/range/view/convert.hpp
@@ -32,20 +32,22 @@ namespace seqan3::view
  *
  * ### View properties
  *
- * | range concepts and reference_t  | `urng_t` (underlying range type)      | `rrng_t` (returned range type)  |
- * |---------------------------------|:-------------------------------------:|:-------------------------------:|
- * | std::ranges::InputRange         | *required*                            | *preserved*                     |
- * | std::ranges::ForwardRange       |                                       | *preserved*                     |
- * | std::ranges::BidirectionalRange |                                       | *preserved*                     |
- * | std::ranges::RandomAccessRange  |                                       | *preserved*                     |
- * |                                 |                                       |                                 |
- * | std::ranges::View               |                                       | *guaranteed*                    |
- * | std::ranges::SizedRange         |                                       | *preserved*                     |
- * | std::ranges::CommonRange        |                                       | *preserved*                     |
- * | std::ranges::OutputRange        |                                       | *lost*                          |
- * | seqan3::const_iterable_concept  |                                       | *preserved*                     |
- * |                                 |                                       |                                 |
- * | seqan3::reference_t             | seqan3::ConvertibleTo<out_t>          | `out_t`                         |
+ * | range concepts and reference_t  | `urng_t` (underlying range type) | `rrng_t` (returned range type) |
+ * |---------------------------------|:--------------------------------:|:------------------------------:|
+ * | std::ranges::InputRange         | *required*                       | *preserved*                    |
+ * | std::ranges::ForwardRange       |                                  | *preserved*                    |
+ * | std::ranges::BidirectionalRange |                                  | *preserved*                    |
+ * | std::ranges::RandomAccessRange  |                                  | *preserved*                    |
+ * | std::ranges::ContiguousRange    |                                  | *lost*                         |
+ * |                                 |                                  |                                |
+ * | std::ranges::ViewableRange      | *required*                       | *guaranteed*                   |
+ * | std::ranges::View               |                                  | *guaranteed*                   |
+ * | std::ranges::SizedRange         |                                  | *preserved*                    |
+ * | std::ranges::CommonRange        |                                  | *preserved*                    |
+ * | std::ranges::OutputRange        |                                  | *lost*                         |
+ * | seqan3::const_iterable_concept  |                                  | *preserved*                    |
+ * |                                 |                                  |                                |
+ * | seqan3::reference_t             | seqan3::ConvertibleTo<out_t>     | `out_t`                        |
  *
  * See the \link view view submodule documentation \endlink for detailed descriptions of the view properties.
  *

--- a/include/seqan3/range/view/deep.hpp
+++ b/include/seqan3/range/view/deep.hpp
@@ -53,22 +53,22 @@ namespace seqan3::view
  *
  * *For the higher dimensions* (all except the innermost ranges) the following properties hold:
  *
- * | range concepts and reference_t  | `urng_t` (underlying range type)      | `rrng_t` (returned range type)                     |
- * |---------------------------------|:-------------------------------------:|:--------------------------------------------------:|
- * | std::ranges::InputRange         | *required*                            | *preserved*                                        |
- * | std::ranges::ForwardRange       |                                       | *preserved*                                        |
- * | std::ranges::BidirectionalRange |                                       | *preserved*                                        |
- * | std::ranges::RandomAccessRange  |                                       | *preserved*                                        |
- * | std::ranges::ContiguousRange    |                                       | *lost*                                             |
- * |                                 |                                       |                                                    |
- * | std::ranges::ViewableRange      | *required*                            | *guaranteed*                                       |
- * | std::ranges::View               |                                       | *guaranteed*                                       |
- * | std::ranges::SizedRange         |                                       | *preserved*                                        |
- * | std::ranges::CommonRange        |                                       | *preserved*                                        |
- * | std::ranges::OutputRange        |                                       | *lost*                                             |
- * | seqan3::const_iterable_concept  |                                       | *preserved*                                        |
- * |                                 |                                       |                                                    |
- * | seqan3::reference_t             | std::ranges::InputRange           | std::ranges::InputRange + std::ranges::View |
+ * | range concepts and reference_t  | `urng_t` (underlying range type) | `rrng_t` (returned range type)              |
+ * |---------------------------------|:--------------------------------:|:-------------------------------------------:|
+ * | std::ranges::InputRange         | *required*                       | *preserved*                                 |
+ * | std::ranges::ForwardRange       |                                  | *preserved*                                 |
+ * | std::ranges::BidirectionalRange |                                  | *preserved*                                 |
+ * | std::ranges::RandomAccessRange  |                                  | *preserved*                                 |
+ * | std::ranges::ContiguousRange    |                                  | *lost*                                      |
+ * |                                 |                                  |                                             |
+ * | std::ranges::ViewableRange      | *required*                       | *guaranteed*                                |
+ * | std::ranges::View               |                                  | *guaranteed*                                |
+ * | std::ranges::SizedRange         |                                  | *preserved*                                 |
+ * | std::ranges::CommonRange        |                                  | *preserved*                                 |
+ * | std::ranges::OutputRange        |                                  | *lost*                                      |
+ * | seqan3::const_iterable_concept  |                                  | *preserved*                                 |
+ * |                                 |                                  |                                             |
+ * | seqan3::reference_t             | std::ranges::InputRange          | std::ranges::InputRange + std::ranges::View |
  *
  * ### Examples
  *

--- a/include/seqan3/range/view/get.hpp
+++ b/include/seqan3/range/view/get.hpp
@@ -1,4 +1,4 @@
-// -----------------------------------------------------------------------------------------------------
+ // -----------------------------------------------------------------------------------------------------
 // Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
 // Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
 // This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
@@ -33,22 +33,22 @@ namespace seqan3::view
  *
  * ### View properties
  *
- * | range concepts and reference_t  | `urng_t` (underlying range type)      | `rrng_t` (returned range type)                          |
- * |---------------------------------|:-------------------------------------:|:-------------------------------------------------------:|
- * | std::ranges::InputRange         | *required*                            | *preserved*                                             |
- * | std::ranges::ForwardRange       |                                       | *preserved*                                             |
- * | std::ranges::BidirectionalRange |                                       | *preserved*                                             |
- * | std::ranges::RandomAccessRange  |                                       | *preserved*                                             |
- * | std::ranges::ContiguousRange    |                                       | *lost*                                                  |
- * |                                 |                                       |                                                         |
- * | std::ranges::ViewableRange      | *required*                            | *preserved*                                             |
- * | std::ranges::View               |                                       | *preserved*                                             |
- * | std::ranges::SizedRange         |                                       | *preserved*                                             |
- * | std::ranges::CommonRange        |                                       | *preserved*                                             |
- * | std::ranges::OutputRange        |                                       | *preserved*                                             |
- * | seqan3::const_iterable_concept  |                                       | *preserved*                                             |
- * |                                 |                                       |                                                         |
- * | seqan3::reference_t             | seqan3::tuple_like_concept            | std::tuple_element_t<index, seqan3::reference_t<urng_t>>|
+ * | range concepts and reference_t  | `urng_t` (underlying range type) | `rrng_t` (returned range type)                           |
+ * |---------------------------------|:--------------------------------:|:--------------------------------------------------------:|
+ * | std::ranges::InputRange         | *required*                       | *preserved*                                              |
+ * | std::ranges::ForwardRange       |                                  | *preserved*                                              |
+ * | std::ranges::BidirectionalRange |                                  | *preserved*                                              |
+ * | std::ranges::RandomAccessRange  |                                  | *preserved*                                              |
+ * | std::ranges::ContiguousRange    |                                  | *lost*                                                   |
+ * |                                 |                                  |                                                          |
+ * | std::ranges::ViewableRange      | *required*                       | *guaranteed*                                             |
+ * | std::ranges::View               |                                  | *guaranteed*                                             |
+ * | std::ranges::SizedRange         |                                  | *preserved*                                              |
+ * | std::ranges::CommonRange        |                                  | *preserved*                                              |
+ * | std::ranges::OutputRange        |                                  | *preserved*                                              |
+ * | seqan3::const_iterable_concept  |                                  | *preserved*                                              |
+ * |                                 |                                  |                                                          |
+ * | seqan3::reference_t             | seqan3::tuple_like_concept       | std::tuple_element_t<index, seqan3::reference_t<urng_t>> |
  *
  * See the \link view view submodule documentation \endlink for detailed descriptions of the view properties.
  *

--- a/include/seqan3/range/view/get.hpp
+++ b/include/seqan3/range/view/get.hpp
@@ -1,4 +1,4 @@
- // -----------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------
 // Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
 // Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
 // This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License

--- a/include/seqan3/range/view/kmer_hash.hpp
+++ b/include/seqan3/range/view/kmer_hash.hpp
@@ -78,22 +78,22 @@ namespace seqan3::view
      *
      * ### View properties
      *
-     * | range concepts and reference_t  | `urng_t` (underlying range type)      | `rrng_t` (returned range type)                     |
-     * |---------------------------------|:-------------------------------------:|:--------------------------------------------------:|
-     * | std::ranges::InputRange         | *required*                            | *preserved*                                        |
-     * | std::ranges::ForwardRange       | *required*                            | *preserved*                                        |
-     * | std::ranges::BidirectionalRange |                                       | *preserved*                                        |
-     * | std::ranges::RandomAccessRange  |                                       | *preserved*                                        |
-     * | std::ranges::ContiguousRange    |                                       | *lost*                                             |
-     * |                                 |                                       |                                                    |
-     * | std::ranges::ViewableRange      | *required*                            | *guaranteed*                                       |
-     * | std::ranges::View               |                                       | *guaranteed*                                       |
-     * | std::ranges::SizedRange         |                                       | *preserved*                                        |
-     * | std::ranges::CommonRange        |                                       | *preserved*                                        |
-     * | std::ranges::OutputRange        |                                       | *lost*                                             |
-     * | seqan3::const_iterable_concept  |                                       | *preserved*                                        |
-     * |                                 |                                       |                                                    |
-     * | seqan3::reference_t             | seqan3::Semialphabet                  | std::size_t                                        |
+     * | range concepts and reference_t  | `urng_t` (underlying range type) | `rrng_t` (returned range type) |
+     * |---------------------------------|:--------------------------------:|:------------------------------:|
+     * | std::ranges::InputRange         | *required*                       | *preserved*                    |
+     * | std::ranges::ForwardRange       | *required*                       | *preserved*                    |
+     * | std::ranges::BidirectionalRange |                                  | *preserved*                    |
+     * | std::ranges::RandomAccessRange  |                                  | *preserved*                    |
+     * | std::ranges::ContiguousRange    |                                  | *lost*                         |
+     * |                                 |                                  |                                |
+     * | std::ranges::ViewableRange      | *required*                       | *guaranteed*                   |
+     * | std::ranges::View               |                                  | *guaranteed*                   |
+     * | std::ranges::SizedRange         |                                  | *preserved*                    |
+     * | std::ranges::CommonRange        |                                  | *preserved*                    |
+     * | std::ranges::OutputRange        |                                  | *lost*                         |
+     * | seqan3::const_iterable_concept  |                                  | *preserved*                    |
+     * |                                 |                                  |                                |
+     * | seqan3::reference_t             | seqan3::Semialphabet             | std::size_t                    |
      *
      * See the \link view view submodule documentation \endlink for detailed descriptions of the view properties.
      *

--- a/include/seqan3/range/view/pairwise_combine.hpp
+++ b/include/seqan3/range/view/pairwise_combine.hpp
@@ -680,22 +680,22 @@ namespace seqan3::view
  *
  * ### View properties
  *
- * | range concepts and reference_t  | `urng_t` (underlying range type)      | `rrng_t` (returned range type)                                       |
- * |---------------------------------|:-------------------------------------:|:--------------------------------------------------------------------:|
- * | std::ranges::InputRange         | *required*                            | *preserved*                                                          |
- * | std::ranges::ForwardRange       | *required*                            | *preserved*                                                          |
- * | std::ranges::BidirectionalRange |                                       | *preserved*                                                          |
- * | std::ranges::RandomAccessRange  |                                       | *preserved*                                                          |
- * | std::ranges::ContiguousRange    |                                       | *lost*                                                               |
- * |                                 |                                       |                                                                      |
- * | std::ranges::ViewableRange      | *required*                            | *guaranteed*                                                         |
- * | std::ranges::View               |                                       | *guaranteed*                                                         |
- * | std::ranges::SizedRange         |                                       | *preserved*                                                          |
- * | std::ranges::CommonRange        | *required*                            | *guaranteed*                                                         |
- * | std::ranges::OutputRange        |                                       | *lost*                                                               |
- * | seqan3::const_iterable_concept  |                                       | *preserved*                                                          |
- * |                                 |                                       |                                                                      |
- * | seqan3::reference_t             |                                       | std::tuple<seqan3::reference_t<urng_t>, seqan3::reference_t<urng_t>> |
+ * | range concepts and reference_t  | `urng_t` (underlying range type) | `rrng_t` (returned range type)                                       |
+ * |---------------------------------|:--------------------------------:|:--------------------------------------------------------------------:|
+ * | std::ranges::InputRange         | *required*                       | *preserved*                                                          |
+ * | std::ranges::ForwardRange       | *required*                       | *preserved*                                                          |
+ * | std::ranges::BidirectionalRange |                                  | *preserved*                                                          |
+ * | std::ranges::RandomAccessRange  |                                  | *preserved*                                                          |
+ * | std::ranges::ContiguousRange    |                                  | *lost*                                                               |
+ * |                                 |                                  |                                                                      |
+ * | std::ranges::ViewableRange      | *required*                       | *guaranteed*                                                         |
+ * | std::ranges::View               |                                  | *guaranteed*                                                         |
+ * | std::ranges::SizedRange         |                                  | *preserved*                                                          |
+ * | std::ranges::CommonRange        | *required*                       | *guaranteed*                                                         |
+ * | std::ranges::OutputRange        |                                  | *lost*                                                               |
+ * | seqan3::const_iterable_concept  |                                  | *preserved*                                                          |
+ * |                                 |                                  |                                                                      |
+ * | seqan3::reference_t             |                                  | std::tuple<seqan3::reference_t<urng_t>, seqan3::reference_t<urng_t>> |
  *
  * See the \link view view submodule documentation \endlink for detailed descriptions of the view properties.
  *

--- a/include/seqan3/range/view/persist.hpp
+++ b/include/seqan3/range/view/persist.hpp
@@ -231,22 +231,22 @@ namespace seqan3::view
  *
  * ### View properties
  *
- * | range concepts and reference_t  | `urng_t` (underlying range type)      | `rrng_t` (returned range type)                     |
- * |---------------------------------|:-------------------------------------:|:--------------------------------------------------:|
- * | std::ranges::InputRange         | *required*                            | *preserved*                                        |
- * | std::ranges::ForwardRange       |                                       | *preserved*                                        |
- * | std::ranges::BidirectionalRange |                                       | *preserved*                                        |
- * | std::ranges::RandomAccessRange  |                                       | *preserved*                                        |
- * | std::ranges::ContiguousRange    |                                       | *preserved*                                        |
- * |                                 |                                       |                                                    |
- * | std::ranges::ViewableRange      | ***not required***                    | *guaranteed*                                       |
- * | std::ranges::View               |                                       | *guaranteed*                                       |
- * | std::ranges::SizedRange         |                                       | *preserved*                                        |
- * | std::ranges::CommonRange        |                                       | *preserved*                                        |
- * | std::ranges::OutputRange        |                                       | *preserved*                                        |
- * | seqan3::const_iterable_concept  |                                       | *preserved*                                        |
- * |                                 |                                       |                                                    |
- * | seqan3::reference_t             |                                       | seqan3::reference_t<urng_t>                        |
+ * | range concepts and reference_t  | `urng_t` (underlying range type) | `rrng_t` (returned range type) |
+ * |---------------------------------|:--------------------------------:|:------------------------------:|
+ * | std::ranges::InputRange         | *required*                       | *preserved*                    |
+ * | std::ranges::ForwardRange       |                                  | *preserved*                    |
+ * | std::ranges::BidirectionalRange |                                  | *preserved*                    |
+ * | std::ranges::RandomAccessRange  |                                  | *preserved*                    |
+ * | std::ranges::ContiguousRange    |                                  | *preserved*                    |
+ * |                                 |                                  |                                |
+ * | std::ranges::ViewableRange      | ***not required***               | *guaranteed*                   |
+ * | std::ranges::View               |                                  | *guaranteed*                   |
+ * | std::ranges::SizedRange         |                                  | *preserved*                    |
+ * | std::ranges::CommonRange        |                                  | *preserved*                    |
+ * | std::ranges::OutputRange        |                                  | *preserved*                    |
+ * | seqan3::const_iterable_concept  |                                  | *preserved*                    |
+ * |                                 |                                  |                                |
+ * | seqan3::reference_t             |                                  | seqan3::reference_t<urng_t>    |
  *
  * See the \link view view submodule documentation \endlink for detailed descriptions of the view properties.
  *

--- a/include/seqan3/range/view/rank_to.hpp
+++ b/include/seqan3/range/view/rank_to.hpp
@@ -36,22 +36,22 @@ namespace seqan3::view
  * This view is a **deep view:** Given a range-of-range as input (as opposed to just a range), it will apply
  * the transformation on the innermost range (instead of the outermost range).
  *
- * | range concepts and reference_t  | `urng_t` (underlying range type)      | `rrng_t` (returned range type)                     |
- * |---------------------------------|:-------------------------------------:|:--------------------------------------------------:|
- * | std::ranges::InputRange         | *required*                            | *preserved*                                        |
- * | std::ranges::ForwardRange       |                                       | *preserved*                                        |
- * | std::ranges::BidirectionalRange |                                       | *preserved*                                        |
- * | std::ranges::RandomAccessRange  |                                       | *preserved*                                        |
- * | std::ranges::ContiguousRange    |                                       | *lost*                                             |
- * |                                 |                                       |                                                    |
- * | std::ranges::ViewableRange      | *required*                            | *guaranteed*                                       |
- * | std::ranges::View               |                                       | *guaranteed*                                       |
- * | std::ranges::SizedRange         |                                       | *preserved*                                        |
- * | std::ranges::CommonRange        |                                       | *preserved*                                        |
- * | std::ranges::OutputRange        |                                       | *lost*                                             |
- * | seqan3::const_iterable_concept  |                                       | *preserved*                                        |
- * |                                 |                                       |                                                    |
- * | seqan3::reference_t             | seqan3::underlying_rank_t<alphabet_t> | `alphabet_t`                                       |
+ * | range concepts and reference_t  | `urng_t` (underlying range type)      | `rrng_t` (returned range type) |
+ * |---------------------------------|:-------------------------------------:|:------------------------------:|
+ * | std::ranges::InputRange         | *required*                            | *preserved*                    |
+ * | std::ranges::ForwardRange       |                                       | *preserved*                    |
+ * | std::ranges::BidirectionalRange |                                       | *preserved*                    |
+ * | std::ranges::RandomAccessRange  |                                       | *preserved*                    |
+ * | std::ranges::ContiguousRange    |                                       | *lost*                         |
+ * |                                 |                                       |                                |
+ * | std::ranges::ViewableRange      | *required*                            | *guaranteed*                   |
+ * | std::ranges::View               |                                       | *guaranteed*                   |
+ * | std::ranges::SizedRange         |                                       | *preserved*                    |
+ * | std::ranges::CommonRange        |                                       | *preserved*                    |
+ * | std::ranges::OutputRange        |                                       | *lost*                         |
+ * | seqan3::const_iterable_concept  |                                       | *preserved*                    |
+ * |                                 |                                       |                                |
+ * | seqan3::reference_t             | seqan3::underlying_rank_t<alphabet_t> | `alphabet_t`                   |
  *
  * See the \link view view submodule documentation \endlink for detailed descriptions of the view properties.
  *

--- a/include/seqan3/range/view/single_pass_input.hpp
+++ b/include/seqan3/range/view/single_pass_input.hpp
@@ -310,22 +310,22 @@ namespace seqan3::view
  * ### View properties
  *
  *
- * | range concepts and reference_t  | `urng_t` (underlying range type)      | `rrng_t` (returned range type)                     |
- * |---------------------------------|:-------------------------------------:|:--------------------------------------------------:|
- * | std::ranges::InputRange         | *required*                            | *preserved*                                        |
- * | std::ranges::ForwardRange       |                                       | *lost*                                             |
- * | std::ranges::BidirectionalRange |                                       | *lost*                                             |
- * | std::ranges::RandomAccessRange  |                                       | *lost*                                             |
- * | std::ranges::ContiguousRange    |                                       | *lost*                                             |
- * |                                 |                                       |                                                    |
- * | std::ranges::ViewableRange      | *required*                            | *guaranteed*                                       |
- * | std::ranges::View               |                                       | *guaranteed*                                       |
- * | std::ranges::SizedRange         |                                       | *lost*                                             |
- * | std::ranges::CommonRange        |                                       | *lost*                                             |
- * | std::ranges::OutputRange        |                                       | *preserved*                                        |
- * | seqan3::const_iterable_concept  |                                       | *lost*                                             |
- * |                                 |                                       |                                                    |
- * | seqan3::reference_t             |                                       | seqan3::reference_t<urng_t>                        |
+ * | range concepts and reference_t  | `urng_t` (underlying range type) | `rrng_t` (returned range type) |
+ * |---------------------------------|:--------------------------------:|:------------------------------:|
+ * | std::ranges::InputRange         | *required*                       | *preserved*                    |
+ * | std::ranges::ForwardRange       |                                  | *lost*                         |
+ * | std::ranges::BidirectionalRange |                                  | *lost*                         |
+ * | std::ranges::RandomAccessRange  |                                  | *lost*                         |
+ * | std::ranges::ContiguousRange    |                                  | *lost*                         |
+ * |                                 |                                  |                                |
+ * | std::ranges::ViewableRange      | *required*                       | *guaranteed*                   |
+ * | std::ranges::View               |                                  | *guaranteed*                   |
+ * | std::ranges::SizedRange         |                                  | *lost*                         |
+ * | std::ranges::CommonRange        |                                  | *lost*                         |
+ * | std::ranges::OutputRange        |                                  | *preserved*                    |
+ * | seqan3::const_iterable_concept  |                                  | *lost*                         |
+ * |                                 |                                  |                                |
+ * | seqan3::reference_t             |                                  | seqan3::reference_t<urng_t>    |
  *
  * See the \link view view submodule documentation \endlink for detailed descriptions of the view properties.
  *

--- a/include/seqan3/range/view/take.hpp
+++ b/include/seqan3/range/view/take.hpp
@@ -472,22 +472,22 @@ namespace seqan3::view
  *
  * ### View properties
  *
- * | range concepts and reference_t  | `urng_t` (underlying range type)      | `rrng_t` (returned range type)                     |
- * |---------------------------------|:-------------------------------------:|:--------------------------------------------------:|
- * | std::ranges::InputRange         | *required*                            | *preserved*                                        |
- * | std::ranges::ForwardRange       |                                       | *preserved*                                        |
- * | std::ranges::BidirectionalRange |                                       | *preserved*                                        |
- * | std::ranges::RandomAccessRange  |                                       | *preserved*                                        |
- * | std::ranges::ContiguousRange    |                                       | *preserved*                                        |
- * |                                 |                                       |                                                    |
- * | std::ranges::ViewableRange      | *required*                            | *guaranteed*                                       |
- * | std::ranges::View               |                                       | *guaranteed*                                       |
- * | std::ranges::SizedRange         |                                       | *lost*                                             |
- * | std::ranges::CommonRange        |                                       | *lost*                                             |
- * | std::ranges::OutputRange        |                                       | *preserved*                                        |
- * | seqan3::const_iterable_concept  |                                       | *preserved*                                        |
- * |                                 |                                       |                                                    |
- * | seqan3::reference_t             |                                       | seqan3::reference_t<urng_t>                        |
+ * | range concepts and reference_t  | `urng_t` (underlying range type) | `rrng_t` (returned range type) |
+ * |---------------------------------|:--------------------------------:|:------------------------------:|
+ * | std::ranges::InputRange         | *required*                       | *preserved*                    |
+ * | std::ranges::ForwardRange       |                                  | *preserved*                    |
+ * | std::ranges::BidirectionalRange |                                  | *preserved*                    |
+ * | std::ranges::RandomAccessRange  |                                  | *preserved*                    |
+ * | std::ranges::ContiguousRange    |                                  | *preserved*                    |
+ * |                                 |                                  |                                |
+ * | std::ranges::ViewableRange      | *required*                       | *guaranteed*                   |
+ * | std::ranges::View               |                                  | *guaranteed*                   |
+ * | std::ranges::SizedRange         |                                  | *lost*                         |
+ * | std::ranges::CommonRange        |                                  | *lost*                         |
+ * | std::ranges::OutputRange        |                                  | *preserved*                    |
+ * | seqan3::const_iterable_concept  |                                  | *preserved*                    |
+ * |                                 |                                  |                                |
+ * | seqan3::reference_t             |                                  | seqan3::reference_t<urng_t>    |
  *
  * See the \link view view submodule documentation \endlink for detailed descriptions of the view properties.
  *

--- a/include/seqan3/range/view/take_exactly.hpp
+++ b/include/seqan3/range/view/take_exactly.hpp
@@ -38,22 +38,22 @@ namespace seqan3::view
  *
  * ### View properties
  *
- * | range concepts and reference_t  | `urng_t` (underlying range type)      | `rrng_t` (returned range type)                     |
- * |---------------------------------|:-------------------------------------:|:--------------------------------------------------:|
- * | std::ranges::InputRange         | *required*                            | *preserved*                                        |
- * | std::ranges::ForwardRange       |                                       | *preserved*                                        |
- * | std::ranges::BidirectionalRange |                                       | *preserved*                                        |
- * | std::ranges::RandomAccessRange  |                                       | *preserved*                                        |
- * | std::ranges::ContiguousRange    |                                       | *preserved*                                        |
- * |                                 |                                       |                                                    |
- * | std::ranges::ViewableRange      | *required*                            | *guaranteed*                                       |
- * | std::ranges::View               |                                       | *guaranteed*                                       |
- * | std::ranges::SizedRange         |                                       | ***guaranteed***                                   |
- * | std::ranges::CommonRange        |                                       | *lost*                                             |
- * | std::ranges::OutputRange        |                                       | *preserved*                                        |
- * | seqan3::const_iterable_concept  |                                       | *preserved*                                        |
- * |                                 |                                       |                                                    |
- * | seqan3::reference_t             |                                       | seqan3::reference_t<urng_t>                        |
+ * | range concepts and reference_t  | `urng_t` (underlying range type) | `rrng_t` (returned range type) |
+ * |---------------------------------|:--------------------------------:|:------------------------------:|
+ * | std::ranges::InputRange         | *required*                       | *preserved*                    |
+ * | std::ranges::ForwardRange       |                                  | *preserved*                    |
+ * | std::ranges::BidirectionalRange |                                  | *preserved*                    |
+ * | std::ranges::RandomAccessRange  |                                  | *preserved*                    |
+ * | std::ranges::ContiguousRange    |                                  | *preserved*                    |
+ * |                                 |                                  |                                |
+ * | std::ranges::ViewableRange      | *required*                       | *guaranteed*                   |
+ * | std::ranges::View               |                                  | *guaranteed*                   |
+ * | std::ranges::SizedRange         |                                  | ***guaranteed***               |
+ * | std::ranges::CommonRange        |                                  | *lost*                         |
+ * | std::ranges::OutputRange        |                                  | *preserved*                    |
+ * | seqan3::const_iterable_concept  |                                  | *preserved*                    |
+ * |                                 |                                  |                                |
+ * | seqan3::reference_t             |                                  | seqan3::reference_t<urng_t>    |
  *
  * See the \link view view submodule documentation \endlink for detailed descriptions of the view properties.
  *

--- a/include/seqan3/range/view/take_line.hpp
+++ b/include/seqan3/range/view/take_line.hpp
@@ -401,22 +401,22 @@ namespace seqan3::view
  *
  * ### View properties
  *
- * | range concepts and reference_t  | `urng_t` (underlying range type)      | `rrng_t` (returned range type)                     |
- * |---------------------------------|:-------------------------------------:|:--------------------------------------------------:|
- * | std::ranges::InputRange         | *required*                            | *preserved*                                        |
- * | std::ranges::ForwardRange       |                                       | *preserved*                                        |
- * | std::ranges::BidirectionalRange |                                       | *preserved*                                        |
- * | std::ranges::RandomAccessRange  |                                       | *preserved*                                        |
- * | std::ranges::ContiguousRange    |                                       | *preserved*                                        |
- * |                                 |                                       |                                                    |
- * | std::ranges::ViewableRange      | *required*                            | *guaranteed*                                       |
- * | std::ranges::View               |                                       | *guaranteed*                                       |
- * | std::ranges::SizedRange         |                                       | *lost*                                             |
- * | std::ranges::CommonRange        |                                       | *lost*                                             |
- * | std::ranges::OutputRange        |                                       | *preserved*                                        |
- * | seqan3::const_iterable_concept  |                                       | *preserved*                                        |
- * |                                 |                                       |                                                    |
- * | seqan3::reference_t             | std::CommonReference<char>            | seqan3::reference_t<urng_t>                        |
+ * | range concepts and reference_t  | `urng_t` (underlying range type) | `rrng_t` (returned range type) |
+ * |---------------------------------|:--------------------------------:|:------------------------------:|
+ * | std::ranges::InputRange         | *required*                       | *preserved*                    |
+ * | std::ranges::ForwardRange       |                                  | *preserved*                    |
+ * | std::ranges::BidirectionalRange |                                  | *preserved*                    |
+ * | std::ranges::RandomAccessRange  |                                  | *preserved*                    |
+ * | std::ranges::ContiguousRange    |                                  | *preserved*                    |
+ * |                                 |                                  |                                |
+ * | std::ranges::ViewableRange      | *required*                       | *guaranteed*                   |
+ * | std::ranges::View               |                                  | *guaranteed*                   |
+ * | std::ranges::SizedRange         |                                  | *lost*                         |
+ * | std::ranges::CommonRange        |                                  | *lost*                         |
+ * | std::ranges::OutputRange        |                                  | *preserved*                    |
+ * | seqan3::const_iterable_concept  |                                  | *preserved*                    |
+ * |                                 |                                  |                                |
+ * | seqan3::reference_t             | std::CommonReference<char>       | seqan3::reference_t<urng_t>    |
  *
  * See the \link view view submodule documentation \endlink for detailed descriptions of the view properties.
  *

--- a/include/seqan3/range/view/take_until.hpp
+++ b/include/seqan3/range/view/take_until.hpp
@@ -390,22 +390,22 @@ namespace seqan3::view
  *
  * ### View properties
  *
- * | range concepts and reference_t  | `urng_t` (underlying range type)      | `rrng_t` (returned range type)                     |
- * |---------------------------------|:-------------------------------------:|:--------------------------------------------------:|
- * | std::ranges::InputRange         | *required*                            | *preserved*                                        |
- * | std::ranges::ForwardRange       |                                       | depends on functor (see below)                     |
- * | std::ranges::BidirectionalRange |                                       | depends on functor (see below)                     |
- * | std::ranges::RandomAccessRange  |                                       | depends on functor (see below)                     |
- * | std::ranges::ContiguousRange    |                                       | depends on functor (see below)                     |
- * |                                 |                                       |                                                    |
- * | std::ranges::ViewableRange      | *required*                            | *guaranteed*                                       |
- * | std::ranges::View               |                                       | *guaranteed*                                       |
- * | std::ranges::SizedRange         |                                       | *lost*                                             |
- * | std::ranges::CommonRange        |                                       | *lost*                                             |
- * | std::ranges::OutputRange        |                                       | *preserved*                                        |
- * | seqan3::const_iterable_concept  |                                       | depends on functor (see below)                     |
- * |                                 |                                       |                                                    |
- * | seqan3::reference_t             |                                       | seqan3::reference_t<urng_t>                        |
+ * | range concepts and reference_t  | `urng_t` (underlying range type) | `rrng_t` (returned range type) |
+ * |---------------------------------|:--------------------------------:|:------------------------------:|
+ * | std::ranges::InputRange         | *required*                       | *preserved*                    |
+ * | std::ranges::ForwardRange       |                                  | depends on functor (see below) |
+ * | std::ranges::BidirectionalRange |                                  | depends on functor (see below) |
+ * | std::ranges::RandomAccessRange  |                                  | depends on functor (see below) |
+ * | std::ranges::ContiguousRange    |                                  | depends on functor (see below) |
+ * |                                 |                                  |                                |
+ * | std::ranges::ViewableRange      | *required*                       | *guaranteed*                   |
+ * | std::ranges::View               |                                  | *guaranteed*                   |
+ * | std::ranges::SizedRange         |                                  | *lost*                         |
+ * | std::ranges::CommonRange        |                                  | *lost*                         |
+ * | std::ranges::OutputRange        |                                  | *preserved*                    |
+ * | seqan3::const_iterable_concept  |                                  | depends on functor (see below) |
+ * |                                 |                                  |                                |
+ * | seqan3::reference_t             |                                  | seqan3::reference_t<urng_t>    |
  *
  * See the \link view view submodule documentation \endlink for detailed descriptions of the view properties.
  *

--- a/include/seqan3/range/view/to_char.hpp
+++ b/include/seqan3/range/view/to_char.hpp
@@ -35,22 +35,22 @@ namespace seqan3::view
  * This view is a **deep view:** Given a range-of-range as input (as opposed to just a range), it will apply
  * the transformation on the innermost range (instead of the outermost range).
  *
- * | range concepts and reference_t  | `urng_t` (underlying range type)      | `rrng_t` (returned range type)                     |
- * |---------------------------------|:-------------------------------------:|:--------------------------------------------------:|
- * | std::ranges::InputRange         | *required*                            | *preserved*                                        |
- * | std::ranges::ForwardRange       |                                       | *preserved*                                        |
- * | std::ranges::BidirectionalRange |                                       | *preserved*                                        |
- * | std::ranges::RandomAccessRange  |                                       | *preserved*                                        |
- * | std::ranges::ContiguousRange    |                                       | *lost*                                             |
- * |                                 |                                       |                                                    |
- * | std::ranges::ViewableRange      | *required*                            | *guaranteed*                                       |
- * | std::ranges::View               |                                       | *guaranteed*                                       |
- * | std::ranges::SizedRange         |                                       | *preserved*                                        |
- * | std::ranges::CommonRange        |                                       | *preserved*                                        |
- * | std::ranges::OutputRange        |                                       | *lost*                                             |
- * | seqan3::const_iterable_concept  |                                       | *preserved*                                        |
- * |                                 |                                       |                                                    |
- * | seqan3::reference_t             | seqan3::Alphabet                      | seqan3::underlying_char_t<seqan3::value_type_t<urng_t>> |
+ * | range concepts and reference_t  | `urng_t` (underlying range type) | `rrng_t` (returned range type)                          |
+ * |---------------------------------|:--------------------------------:|:-------------------------------------------------------:|
+ * | std::ranges::InputRange         | *required*                       | *preserved*                                             |
+ * | std::ranges::ForwardRange       |                                  | *preserved*                                             |
+ * | std::ranges::BidirectionalRange |                                  | *preserved*                                             |
+ * | std::ranges::RandomAccessRange  |                                  | *preserved*                                             |
+ * | std::ranges::ContiguousRange    |                                  | *lost*                                                  |
+ * |                                 |                                  |                                                         |
+ * | std::ranges::ViewableRange      | *required*                       | *guaranteed*                                            |
+ * | std::ranges::View               |                                  | *guaranteed*                                            |
+ * | std::ranges::SizedRange         |                                  | *preserved*                                             |
+ * | std::ranges::CommonRange        |                                  | *preserved*                                             |
+ * | std::ranges::OutputRange        |                                  | *lost*                                                  |
+ * | seqan3::const_iterable_concept  |                                  | *preserved*                                             |
+ * |                                 |                                  |                                                         |
+ * | seqan3::reference_t             | seqan3::Alphabet                 | seqan3::underlying_char_t<seqan3::value_type_t<urng_t>> |
  *
  * See the \link view view submodule documentation \endlink for detailed descriptions of the view properties.
  *

--- a/include/seqan3/range/view/to_rank.hpp
+++ b/include/seqan3/range/view/to_rank.hpp
@@ -35,22 +35,22 @@ namespace seqan3::view
  * This view is a **deep view:** Given a range-of-range as input (as opposed to just a range), it will apply
  * the transformation on the innermost range (instead of the outermost range).
  *
- * | range concepts and reference_t  | `urng_t` (underlying range type)      | `rrng_t` (returned range type)                     |
- * |---------------------------------|:-------------------------------------:|:--------------------------------------------------:|
- * | std::ranges::InputRange         | *required*                            | *preserved*                                        |
- * | std::ranges::ForwardRange       |                                       | *preserved*                                        |
- * | std::ranges::BidirectionalRange |                                       | *preserved*                                        |
- * | std::ranges::RandomAccessRange  |                                       | *preserved*                                        |
- * | std::ranges::ContiguousRange    |                                       | *lost*                                             |
- * |                                 |                                       |                                                    |
- * | std::ranges::ViewableRange      | *required*                            | *guaranteed*                                       |
- * | std::ranges::View               |                                       | *guaranteed*                                       |
- * | std::ranges::SizedRange         |                                       | *preserved*                                        |
- * | std::ranges::CommonRange        |                                       | *preserved*                                        |
- * | std::ranges::OutputRange        |                                       | *lost*                                             |
- * | seqan3::const_iterable_concept  |                                       | *preserved*                                        |
- * |                                 |                                       |                                                    |
- * | seqan3::reference_t             | seqan3::Alphabet                      | seqan3::underlying_rank_t<seqan3::value_type_t<urng_t>> |
+ * | range concepts and reference_t  | `urng_t` (underlying range type) | `rrng_t` (returned range type)                          |
+ * |---------------------------------|:--------------------------------:|:-------------------------------------------------------:|
+ * | std::ranges::InputRange         | *required*                       | *preserved*                                             |
+ * | std::ranges::ForwardRange       |                                  | *preserved*                                             |
+ * | std::ranges::BidirectionalRange |                                  | *preserved*                                             |
+ * | std::ranges::RandomAccessRange  |                                  | *preserved*                                             |
+ * | std::ranges::ContiguousRange    |                                  | *lost*                                                  |
+ * |                                 |                                  |                                                         |
+ * | std::ranges::ViewableRange      | *required*                       | *guaranteed*                                            |
+ * | std::ranges::View               |                                  | *guaranteed*                                            |
+ * | std::ranges::SizedRange         |                                  | *preserved*                                             |
+ * | std::ranges::CommonRange        |                                  | *preserved*                                             |
+ * | std::ranges::OutputRange        |                                  | *lost*                                                  |
+ * | seqan3::const_iterable_concept  |                                  | *preserved*                                             |
+ * |                                 |                                  |                                                         |
+ * | seqan3::reference_t             | seqan3::Alphabet                 | seqan3::underlying_rank_t<seqan3::value_type_t<urng_t>> |
  *
  * See the \link view view submodule documentation \endlink for detailed descriptions of the view properties.
  *

--- a/include/seqan3/range/view/translation.hpp
+++ b/include/seqan3/range/view/translation.hpp
@@ -321,22 +321,22 @@ namespace seqan3::view
  *
  * ### View properties
  *
- * | range concepts and reference_t  | `urng_t` (underlying range type)      | `rrng_t` (returned range type)                     |
- * |---------------------------------|:-------------------------------------:|:--------------------------------------------------:|
- * | std::ranges::InputRange         | *required*                            | *preserved*                                        |
- * | std::ranges::ForwardRange       | *required*                            | *preserved*                                        |
- * | std::ranges::BidirectionalRange | *required*                            | *preserved*                                        |
- * | std::ranges::RandomAccessRange  | *required*                            | *preserved*                                        |
- * | std::ranges::ContiguousRange    |                                       | *lost*                                             |
- * |                                 |                                       |                                                    |
- * | std::ranges::ViewableRange      | *required*                            | *guaranteed*                                       |
- * | std::ranges::View               |                                       | *guaranteed*                                       |
- * | std::ranges::SizedRange         | *required*                            | *preserved*                                        |
- * | std::ranges::CommonRange        |                                       | *guaranteed*                                       |
- * | std::ranges::OutputRange        |                                       | *lost*                                             |
- * | seqan3::const_iterable_concept  | *required*                            | *preserved*                                        |
- * |                                 |                                       |                                                    |
- * | seqan3::reference_t             | seqan3::NucleotideAlphabet            | seqan3::aa27                                       |
+ * | range concepts and reference_t  | `urng_t` (underlying range type) | `rrng_t` (returned range type) |
+ * |---------------------------------|:--------------------------------:|:------------------------------:|
+ * | std::ranges::InputRange         | *required*                       | *preserved*                    |
+ * | std::ranges::ForwardRange       | *required*                       | *preserved*                    |
+ * | std::ranges::BidirectionalRange | *required*                       | *preserved*                    |
+ * | std::ranges::RandomAccessRange  | *required*                       | *preserved*                    |
+ * | std::ranges::ContiguousRange    |                                  | *lost*                         |
+ * |                                 |                                  |                                |
+ * | std::ranges::ViewableRange      | *required*                       | *guaranteed*                   |
+ * | std::ranges::View               |                                  | *guaranteed*                   |
+ * | std::ranges::SizedRange         | *required*                       | *preserved*                    |
+ * | std::ranges::CommonRange        |                                  | *guaranteed*                   |
+ * | std::ranges::OutputRange        |                                  | *lost*                         |
+ * | seqan3::const_iterable_concept  | *required*                       | *preserved*                    |
+ * |                                 |                                  |                                |
+ * | seqan3::reference_t             | seqan3::NucleotideAlphabet       | seqan3::aa27                   |
  *
  * * `urng_t` is the type of the range modified by this view (input).
  * * `rrng_type` is the type of the range returned by this view.
@@ -602,22 +602,22 @@ namespace seqan3::view
  *
  * ### View properties
  *
- * | range concepts and reference_t  | `urng_t` (underlying range type)      | `rrng_t` (returned range type)                     |
- * |---------------------------------|:-------------------------------------:|:--------------------------------------------------:|
- * | std::ranges::InputRange         | *required*                            | *preserved*                                        |
- * | std::ranges::ForwardRange       | *required*                            | *preserved*                                        |
- * | std::ranges::BidirectionalRange | *required*                            | *preserved*                                        |
- * | std::ranges::RandomAccessRange  | *required*                            | *preserved*                                        |
- * | std::ranges::ContiguousRange    |                                       | *lost*                                             |
- * |                                 |                                       |                                                    |
- * | std::ranges::ViewableRange      | *required*                            | *guaranteed*                                       |
- * | std::ranges::View               |                                       | *guaranteed*                                       |
- * | std::ranges::SizedRange         | *required*                            | *preserved*                                        |
- * | std::ranges::CommonRange        |                                       | *guaranteed*                                       |
- * | std::ranges::OutputRange        |                                       | *lost*                                             |
- * | seqan3::const_iterable_concept  | *required*                            | *preserved*                                        |
- * |                                 |                                       |                                                    |
- * | seqan3::reference_t             | seqan3::NucleotideAlphabet            | std::ranges::View && std::ranges::RandomAccessRange && std::ranges::SizedRange |
+ * | range concepts and reference_t  | `urng_t` (underlying range type) | `rrng_t` (returned range type)                                                 |
+ * |---------------------------------|:--------------------------------:|:------------------------------------------------------------------------------:|
+ * | std::ranges::InputRange         | *required*                       | *preserved*                                                                    |
+ * | std::ranges::ForwardRange       | *required*                       | *preserved*                                                                    |
+ * | std::ranges::BidirectionalRange | *required*                       | *preserved*                                                                    |
+ * | std::ranges::RandomAccessRange  | *required*                       | *preserved*                                                                    |
+ * | std::ranges::ContiguousRange    |                                  | *lost*                                                                         |
+ * |                                 |                                  |                                                                                |
+ * | std::ranges::ViewableRange      | *required*                       | *guaranteed*                                                                   |
+ * | std::ranges::View               |                                  | *guaranteed*                                                                   |
+ * | std::ranges::SizedRange         | *required*                       | *preserved*                                                                    |
+ * | std::ranges::CommonRange        |                                  | *guaranteed*                                                                   |
+ * | std::ranges::OutputRange        |                                  | *lost*                                                                         |
+ * | seqan3::const_iterable_concept  | *required*                       | *preserved*                                                                    |
+ * |                                 |                                  |                                                                                |
+ * | seqan3::reference_t             | seqan3::NucleotideAlphabet       | std::ranges::View && std::ranges::RandomAccessRange && std::ranges::SizedRange |
  *
  * * `urng_t` is the type of the range modified by this view (input).
  * * `rrng_type` is the type of the range returned by this view.

--- a/include/seqan3/range/view/trim.hpp
+++ b/include/seqan3/range/view/trim.hpp
@@ -162,20 +162,22 @@ namespace seqan3::view
  * This view is a **deep view:** Given a range-of-range as input (as opposed to just a range), it will apply
  * the transformation on the innermost range (instead of the outermost range).
  *
- * | range concepts and reference_t  | `urng_t` (underlying range type)      | `rrng_t` (returned range type)  |
- * |---------------------------------|:-------------------------------------:|:-------------------------------:|
- * | std::ranges::InputRange         | *required*                            | *preserved*                     |
- * | std::ranges::ForwardRange       |                                       | *preserved*                     |
- * | std::ranges::BidirectionalRange |                                       | *preserved*                     |
- * | std::ranges::RandomAccessRange  |                                       | *preserved*                     |
- * |                                 |                                       |                                 |
- * | std::ranges::View               |                                       | *guaranteed*                    |
- * | std::ranges::SizedRange         |                                       | *lost*                          |
- * | std::ranges::CommonRange        |                                       | *lost*                          |
- * | std::ranges::OutputRange        |                                       | *preserved*                     |
- * | seqan3::const_iterable_concept  |                                       | *preserved*                     |
- * |                                 |                                       |                                 |
- * | seqan3::reference_t             | seqan3::QualityAlphabet               | seqan3::reference_t<urng_t>     |
+ * | range concepts and reference_t  | `urng_t` (underlying range type) | `rrng_t` (returned range type) |
+ * |---------------------------------|:--------------------------------:|:------------------------------:|
+ * | std::ranges::InputRange         | *required*                       | *preserved*                    |
+ * | std::ranges::ForwardRange       |                                  | *preserved*                    |
+ * | std::ranges::BidirectionalRange |                                  | *preserved*                    |
+ * | std::ranges::RandomAccessRange  |                                  | *preserved*                    |
+ * | std::ranges::ContiguousRange    |                                  | *preserved*                    |
+ * |                                 |                                  |                                |
+ * | std::ranges::ViewableRange      | *required*                       | *guaranteed*                   |
+ * | std::ranges::View               |                                  | *guaranteed*                   |
+ * | std::ranges::SizedRange         |                                  | *lost*                         |
+ * | std::ranges::CommonRange        |                                  | *lost*                         |
+ * | std::ranges::OutputRange        |                                  | *preserved*                    |
+ * | seqan3::const_iterable_concept  |                                  | *preserved*                    |
+ * |                                 |                                  |                                |
+ * | seqan3::reference_t             | seqan3::QualityAlphabet          | seqan3::reference_t<urng_t>    |
  *
  * See the \link view view submodule documentation \endlink for detailed descriptions of the view properties.
  *

--- a/test/unit/range/view/view_char_to_test.cpp
+++ b/test/unit/range/view/view_char_to_test.cpp
@@ -16,6 +16,8 @@
 #include <seqan3/range/view/char_to.hpp>
 #include <seqan3/std/ranges>
 
+#include "view_concept_check.hpp"
+
 using namespace seqan3;
 
 TEST(view_char_to, basic)
@@ -50,26 +52,14 @@ TEST(view_char_to, deep_view)
 
 TEST(view_char_to, concepts)
 {
+    using namespace seqan3::test;
+    
     std::string vec{"ACTTTGATA"};
-    EXPECT_TRUE(std::ranges::InputRange<decltype(vec)>);
-    EXPECT_TRUE(std::ranges::ForwardRange<decltype(vec)>);
-    EXPECT_TRUE(std::ranges::BidirectionalRange<decltype(vec)>);
-    EXPECT_TRUE(std::ranges::RandomAccessRange<decltype(vec)>);
-    EXPECT_FALSE(std::ranges::View<decltype(vec)>);
-    EXPECT_TRUE(std::ranges::SizedRange<decltype(vec)>);
-    EXPECT_TRUE(std::ranges::CommonRange<decltype(vec)>);
-    EXPECT_TRUE(const_iterable_concept<decltype(vec)>);
-    EXPECT_TRUE((std::ranges::OutputRange<decltype(vec), char>));
-
     auto v1 = vec | view::char_to<dna5>;
-    EXPECT_TRUE(std::ranges::InputRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::ForwardRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::BidirectionalRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::RandomAccessRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::View<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::SizedRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::CommonRange<decltype(v1)>);
-    EXPECT_TRUE(const_iterable_concept<decltype(v1)>);
-    EXPECT_FALSE((std::ranges::OutputRange<decltype(v1), dna5>));
-    EXPECT_FALSE((std::ranges::OutputRange<decltype(v1), char>));
+
+    EXPECT_TRUE((preserved<decltype(vec), decltype(v1)>({Input, Forward, Bidirectional, RandomAccess, Sized, Common, 
+                                                         ConstIterable})));
+    EXPECT_TRUE((guaranteed<decltype(vec), decltype(v1)>({View, Viewable})));
+    EXPECT_TRUE((weak_guaranteed<decltype(v1)>({Viewable})));
+    EXPECT_TRUE((lost<decltype(vec), decltype(v1)>({Contiguous, Output})));
 }

--- a/test/unit/range/view/view_complement_test.cpp
+++ b/test/unit/range/view/view_complement_test.cpp
@@ -16,6 +16,8 @@
 #include <seqan3/range/view/complement.hpp>
 #include <seqan3/std/ranges>
 
+#include "view_concept_check.hpp"
+
 using namespace seqan3;
 
 TEST(view_complement, basic)
@@ -48,26 +50,13 @@ TEST(view_complement, deep_view)
 
 TEST(view_complement, concepts)
 {
+    using namespace seqan3::test;
     dna5_vector vec{"ACGTA"_dna5};
-    EXPECT_TRUE(std::ranges::InputRange<decltype(vec)>);
-    EXPECT_TRUE(std::ranges::ForwardRange<decltype(vec)>);
-    EXPECT_TRUE(std::ranges::BidirectionalRange<decltype(vec)>);
-    EXPECT_TRUE(std::ranges::RandomAccessRange<decltype(vec)>);
-    EXPECT_FALSE(std::ranges::View<decltype(vec)>);
-    EXPECT_TRUE(std::ranges::SizedRange<decltype(vec)>);
-    EXPECT_TRUE(std::ranges::CommonRange<decltype(vec)>);
-    EXPECT_TRUE(const_iterable_concept<decltype(vec)>);
-    EXPECT_TRUE((std::ranges::OutputRange<decltype(vec), dna5>));
-
     auto v1 = vec | view::complement;
-    EXPECT_TRUE(std::ranges::InputRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::ForwardRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::BidirectionalRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::RandomAccessRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::View<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::SizedRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::CommonRange<decltype(v1)>);
-    EXPECT_TRUE(const_iterable_concept<decltype(v1)>);
-    EXPECT_FALSE((std::ranges::OutputRange<decltype(v1), dna5>));
-    EXPECT_FALSE((std::ranges::OutputRange<decltype(v1), char>));
+
+    EXPECT_TRUE((preserved<decltype(vec), decltype(v1)>({Input, Forward, Bidirectional, RandomAccess, Sized, Common, 
+                                                         ConstIterable})));
+    EXPECT_TRUE((guaranteed<decltype(vec), decltype(v1)>({View})));
+    EXPECT_TRUE(weak_guaranteed<decltype(v1)>({Viewable}));
+    EXPECT_TRUE((lost<decltype(vec), decltype(v1)>({Contiguous, Output})));
 }

--- a/test/unit/range/view/view_concept_check.hpp
+++ b/test/unit/range/view/view_concept_check.hpp
@@ -1,0 +1,295 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \author Tobias Loka <LokaT AT rki.de>
+ * \brief Provides functions to test the fulfillment of range concepts.
+ */
+
+#include <gtest/gtest.h>
+
+#include <seqan3/io/stream/debug_stream.hpp>
+#include <seqan3/std/ranges>
+
+using namespace seqan3;
+
+namespace seqan3::test 
+{
+
+//!\brief Enum for the different types of range concepts.
+enum ConceptType : uint8_t
+{
+    Input,
+    Forward,
+    Bidirectional,
+    RandomAccess,
+    Contiguous,
+    Viewable,
+    View,
+    Sized,
+    Common,
+    Output,
+    ConstIterable
+};
+
+/*!\brief Convert a ConceptType object to std::string for output.
+ * \tparam conc The range concept to convert to string as seqan3::test::ConceptType object.
+ * \return The concept type as std::string.
+ *
+ *\details
+ * 
+ * The return string is not a 1:1 conversion of the enum type name but rather the full name
+ * of the range concept it stands for.
+ */
+std::string to_string(ConceptType const conc)
+{
+    switch(conc)
+    {
+        case Input:
+            return "InputRange";
+        case Forward:
+            return "ForwardRange";
+        case Bidirectional:
+            return "BidirectionalRange";
+        case RandomAccess:
+            return "RandomAccessRange";
+        case Contiguous:
+            return "ContiguousRange";
+        case Viewable:
+            return "ViewableRange";
+        case View:
+            return "View";
+        case Sized:
+            return "SizedRange";
+        case Common:
+            return "CommonRange";
+        case Output:
+            return "OutputRange";
+        case ConstIterable:
+            return "const_iterable_concept";
+        default:
+            return "Undefined";
+    }
+}
+
+/*!\brief Expression to check the fulfillment of a range concept.
+ * \tparam conc    The range concept to check as seqan3::test::ConceptType object.
+ * \return True if TYPE fulfills conc. False if not.
+ * \throws std::logic_error    Throws logic error if the concept type given (concept) is unknown.
+ *
+ * ### Example
+ * using namespace seqan3::test;
+ * std::string vec{"HelloWorld"};
+ * EXPECT_TRUE(fulfilled<decltype(vec)>(ConceptType::Input));
+ */
+template<typename TYPE>
+constexpr bool fulfilled(ConceptType const conc)
+{
+    switch (conc)
+    {
+        case Input:
+            return std::ranges::InputRange<TYPE>;
+        case Forward:
+            return std::ranges::ForwardRange<TYPE>;
+        case Bidirectional:
+            return std::ranges::BidirectionalRange<TYPE>;
+        case RandomAccess:
+            return std::ranges::RandomAccessRange<TYPE>;
+        case Contiguous:
+            return std::ranges::ContiguousRange<TYPE>;
+        case Viewable:
+            return std::ranges::ViewableRange<TYPE>;
+        case View:
+            return std::ranges::View<TYPE>;
+        case Sized:
+            return std::ranges::SizedRange<TYPE>;
+        case Common:
+            return std::ranges::CommonRange<TYPE>;
+        case Output:
+            return std::ranges::OutputRange<TYPE, typename seqan3::value_type<TYPE>::type>;
+        case ConstIterable:
+            return const_iterable_concept<TYPE>;
+        default:
+            throw std::logic_error("Unexpected ConceptType in view_concept_check::fulfilled(...).");
+    }
+}
+
+/*!\brief Checks if the fulfillment of a concept is preserved from IN_TYPE to OUT_TYPE.
+ * \tparam concepts    A list of range concepts to check as seqan3::test::ConceptType object.
+ * \return True if fulfillment of conc is preserved from IN_TYPE to OUT_TYPE. False if not.
+ *
+ * ### Example
+ * using namespace seqan3::test;
+ * std::string vec{"HelloWorld"};
+ * auto view = vec | std::view::reverse;
+ * EXPECT_TRUE((preserved<decltype(vec),decltype(view)>({Input, Forward}))); //double brackets required
+ *
+ *\details
+ *
+ * This function is designed for use inside EXPECT_TRUE(...). Using other test scenarios (e.g., EXPECT_FALSE)
+ * can lead to unintended command line output via debug_stream.
+ */
+template<std::ranges::Range IN_TYPE, typename OUT_TYPE>
+constexpr bool preserved(std::initializer_list<ConceptType> const & concepts)
+{
+    bool success = true;
+    auto it = concepts.begin();
+    for (; it != concepts.end(); ++it)
+    {
+        if(fulfilled<IN_TYPE>(*it) != fulfilled<OUT_TYPE>(*it))
+        {
+            debug_stream << "Preserved check of concept '" << to_string(*it) << "' failed:\n" 
+                         << " IN_TYPE: " << fulfilled<IN_TYPE>(*it) << '\n'
+                         << "OUT_TYPE: " << fulfilled<OUT_TYPE>(*it) << '\n'
+                         << "are expected to be equal.\n";
+            success = false;
+        }
+    }
+    return success;
+}
+
+/*!\brief Checks if the fulfillment of a concept is lost from IN_TYPE to OUT_TYPE.
+ * \tparam concepts    A list of range concepts to check as seqan3::test::ConceptType object.
+ * \return True if fulfillment of conc is lost from IN_TYPE to OUT_TYPE. False if not.
+ *
+ * ### Example
+ * using namespace seqan3::test;
+ * std::string vec{"HelloWorld"};
+ * auto view = vec | std::view::reverse;
+ * EXPECT_TRUE((lost<decltype(vec), decltype(view)>({Contiguous}))); // double brackets required
+ *
+ * \details
+ *
+ * The lost function checks a real loss, i.e. true for IN_TYPE and false for OUT_TYPE. 
+ * You can use weak_lost(...) function to only check false for OUT_TYPE.
+ * This function is designed for use inside EXPECT_TRUE(...). Using other test scenarios (e.g., EXPECT_FALSE)
+ * can lead to unintended command line output via debug_stream.
+ */
+template<std::ranges::Range IN_TYPE, typename OUT_TYPE>
+constexpr bool lost(std::initializer_list<ConceptType> const & concepts)
+{
+    bool success = true;
+    auto it = concepts.begin();
+    for (; it != concepts.end(); ++it)
+    {
+        if(!fulfilled<IN_TYPE>(*it) || fulfilled<OUT_TYPE>(*it))
+        {
+            debug_stream << "Lost check of concept '" << to_string(*it) << "' failed:\n" 
+                         << " IN_TYPE: " << fulfilled<IN_TYPE>(*it) << " (expected true)" << '\n'
+                         << "OUT_TYPE: " << fulfilled<OUT_TYPE>(*it) << " (expected false)" <<'\n';
+            success = false;
+        }
+    }
+    return success;
+}
+
+/*!\brief Checks weakly if the fulfillment of a concept is lost from IN_TYPE to OUT_TYPE.
+ * \tparam concepts    A list of range concepts to check as seqan3::test::ConceptType object.
+ * \return True if fulfillment of conc is (weakly) lost in OUT_TYPE. False if not.
+
+ *
+ * ### Example
+ * using namespace seqan3::test;
+ * std::string vec{"HelloWorld"};
+ * auto view = vec | std::view::reverse;
+ * EXPECT_TRUE(weak_lost<decltype(view)>({Contiguous}));
+ *
+ * \details
+ *
+ * The lost function weakly checks a loss, i.e. only false for OUT__TYPE. 
+ * You can use lost(...) function to check true for IN_TYPE and false for OUT_TYPE.
+ * This function is designed for use inside EXPECT_TRUE(...). Using other test scenarios (e.g., EXPECT_FALSE)
+ * can lead to unintended command line output via debug_stream.
+ */
+template<typename OUT_TYPE>
+constexpr bool weak_lost(std::initializer_list<ConceptType> const & concepts)
+{
+    bool success = true;
+    auto it = concepts.begin();
+    for (; it != concepts.end(); ++it)
+    {
+        if(fulfilled<OUT_TYPE>(*it))
+        {
+            debug_stream << "Weak lost check of concept '" << to_string(*it) << "' failed:\n" 
+                         << "OUT_TYPE: " << fulfilled<OUT_TYPE>(*it) << " (expected false)" <<'\n';
+            success = false;
+        }
+    }
+    return success;
+}
+
+/*!\brief Checks if the fulfillment of a concept is guaranteed from IN_TYPE to OUT_TYPE.
+ * \tparam concepts    A list of range concepts to check as seqan3::test::ConceptType object.
+ * \return True if fulfillment of conc is guaranteed in OUT_TYPE. False if not.
+ *
+ * ### Example
+ * using namespace seqan3::test;
+ * std::string vec{"HelloWorld"};
+ * auto view = vec | std::view::reverse;
+ * // This EXPECT_TRUE will fail, as InputRange concept is fulfilled by IN_TYPE.
+ * // For this setup, you would have to use weak_guaranteed(...) function instead.
+ * EXPECT_TRUE((guaranteed<decltype(vec),decltype(view)>({Input}))); // double brackets required
+ *
+ * \details
+ *
+ * The lost function checks a real guarantee, i.e. false for IN_TYPE and true for OUT_TYPE. 
+ * You can use weak_guarantee(...) function to only check true for OUT_TYPE.
+ * This function is designed for use inside EXPECT_TRUE(...). Using other test scenarios (e.g., EXPECT_FALSE)
+ * can lead to unintended command line output via debug_stream.
+ */
+template<typename IN_TYPE, typename OUT_TYPE>
+constexpr bool guaranteed(std::initializer_list<ConceptType> const & concepts)
+{
+    bool success = true;
+    auto it = concepts.begin();
+    for (; it != concepts.end(); ++it)
+    {
+        if(fulfilled<IN_TYPE>(*it) || !fulfilled<OUT_TYPE>(*it))
+        {
+            debug_stream << "Guaranteed check of concept '" << to_string(*it) << "' failed:\n" 
+                         << " IN_TYPE: " << fulfilled<IN_TYPE>(*it) << " (expected false)" << '\n'
+                         << "OUT_TYPE: " << fulfilled<OUT_TYPE>(*it) << " (expected true)" <<'\n';
+            success = false;
+        }
+    }
+    return success;
+}
+
+/*!\brief Checks weakly if the fulfillment of a concept is lost from IN_TYPE to OUT_TYPE.
+ * \tparam concepts    A list of range concepts to check as seqan3::test::ConceptType object.
+ * \return True if fulfillment of conc is (weakly) guaranteed in OUT_TYPE. False if not.
+ *
+ * ### Example
+ * using namespace seqan3::test;
+ * std::string vec{"HelloWorld"};
+ * auto view = vec | std::view::reverse;
+ * EXPECT_TRUE(weak_guaranteed<decltype(view)>({Input}));
+ *
+ * \details
+ *
+ * The weak_guaranteed(...) function weakly checks a guarantee, i.e. only true for OUT_TYPE. 
+ * You can use guaranteed(...) function to check true for IN_TYPE and true for OUT_TYPE.
+ * This function is designed for use inside EXPECT_TRUE(...). Using other test scenarios (e.g., EXPECT_FALSE)
+ * can lead to unintended command line output via debug_stream.
+ */
+template<typename OUT_TYPE>
+constexpr bool weak_guaranteed(std::initializer_list<ConceptType> const & concepts)
+{
+    bool success = true;
+    auto it = concepts.begin();
+    for (; it != concepts.end(); ++it)
+    {
+        if(!fulfilled<OUT_TYPE>(*it))
+        {
+            debug_stream << "Weak guaranteed check of concept '" << to_string(*it) << "' failed:\n" 
+                         << "OUT_TYPE: " << fulfilled<OUT_TYPE>(*it) << " (expected true)" <<'\n';
+            success = false;
+        }
+    }
+    return success;
+}
+}

--- a/test/unit/range/view/view_convert_test.cpp
+++ b/test/unit/range/view/view_convert_test.cpp
@@ -14,6 +14,8 @@
 #include <seqan3/range/view/convert.hpp>
 #include <seqan3/std/ranges>
 
+#include "view_concept_check.hpp"
+
 using namespace seqan3;
 
 TEST(view_convert, basic)
@@ -56,26 +58,13 @@ TEST(view_convert, explicit_conversion)
 
 TEST(view_convert, concepts)
 {
+    using namespace seqan3::test;
     dna5_vector vec{"ACGNTNGGN"_dna5};
-    EXPECT_TRUE(std::ranges::InputRange<decltype(vec)>);
-    EXPECT_TRUE(std::ranges::ForwardRange<decltype(vec)>);
-    EXPECT_TRUE(std::ranges::BidirectionalRange<decltype(vec)>);
-    EXPECT_TRUE(std::ranges::RandomAccessRange<decltype(vec)>);
-    EXPECT_FALSE(std::ranges::View<decltype(vec)>);
-    EXPECT_TRUE(std::ranges::SizedRange<decltype(vec)>);
-    EXPECT_TRUE(std::ranges::CommonRange<decltype(vec)>);
-    EXPECT_TRUE(const_iterable_concept<decltype(vec)>);
-    EXPECT_TRUE((std::ranges::OutputRange<decltype(vec), dna5>));
-
     auto v1 = vec | view::convert<dna4>;
-    EXPECT_TRUE(std::ranges::InputRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::ForwardRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::BidirectionalRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::RandomAccessRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::View<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::SizedRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::CommonRange<decltype(v1)>);
-    EXPECT_TRUE(const_iterable_concept<decltype(v1)>);
-    EXPECT_FALSE((std::ranges::OutputRange<decltype(v1), dna5>));
-    EXPECT_FALSE((std::ranges::OutputRange<decltype(v1), dna4>));
+    
+    EXPECT_TRUE((preserved<decltype(vec), decltype(v1)>({Input, Forward, Bidirectional, RandomAccess, Sized, Common, 
+                                                         ConstIterable})));
+    EXPECT_TRUE((guaranteed<decltype(vec), decltype(v1)>({View})));
+    EXPECT_TRUE(weak_guaranteed<decltype(v1)>({Viewable}));
+    EXPECT_TRUE((lost<decltype(vec), decltype(v1)>({Contiguous, Output})));
 }

--- a/test/unit/range/view/view_deep_test.cpp
+++ b/test/unit/range/view/view_deep_test.cpp
@@ -18,6 +18,8 @@
 #include <seqan3/range/view/to_char.hpp>
 #include <seqan3/std/ranges>
 
+#include "view_concept_check.hpp"
+
 namespace seqan3::view
 {
 inline auto const deep_reverse = deep{std::view::reverse};
@@ -65,38 +67,27 @@ TEST(view_deep_reverse, deep)
 
 TEST(view_deep_reverse, concepts)
 {
+
+    using namespace seqan3::test;
     std::vector<dna5_vector> vec{"ACGTA"_dna5, "TGCAT"_dna5};
-    EXPECT_TRUE(std::ranges::InputRange<decltype(vec)>);
-    EXPECT_TRUE(std::ranges::ForwardRange<decltype(vec)>);
-    EXPECT_TRUE(std::ranges::BidirectionalRange<decltype(vec)>);
-    EXPECT_TRUE(std::ranges::RandomAccessRange<decltype(vec)>);
-    EXPECT_FALSE(std::ranges::View<decltype(vec)>);
-    EXPECT_TRUE(std::ranges::SizedRange<decltype(vec)>);
-    EXPECT_TRUE(std::ranges::CommonRange<decltype(vec)>);
-    EXPECT_TRUE(const_iterable_concept<decltype(vec)>);
-    EXPECT_TRUE((std::ranges::OutputRange<decltype(vec), dna5_vector>));
-
     auto v1 = vec | view::deep_reverse;
-    EXPECT_TRUE(std::ranges::InputRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::ForwardRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::BidirectionalRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::RandomAccessRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::View<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::SizedRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::CommonRange<decltype(v1)>);
-    EXPECT_TRUE(const_iterable_concept<decltype(v1)>);
-    EXPECT_FALSE((std::ranges::OutputRange<decltype(v1), dna5_vector>)); // view temporary returned in deep case
-
     auto v_elem = v1[0];
-    EXPECT_TRUE(std::ranges::InputRange<decltype(v_elem)>);
-    EXPECT_TRUE(std::ranges::ForwardRange<decltype(v_elem)>);
-    EXPECT_TRUE(std::ranges::BidirectionalRange<decltype(v_elem)>);
-    EXPECT_TRUE(std::ranges::RandomAccessRange<decltype(v_elem)>);
-    EXPECT_TRUE(std::ranges::View<decltype(v_elem)>);
-    EXPECT_TRUE(std::ranges::SizedRange<decltype(v_elem)>);
-    EXPECT_TRUE(std::ranges::CommonRange<decltype(v_elem)>);
-    EXPECT_TRUE(const_iterable_concept<decltype(v_elem)>);
-    EXPECT_TRUE((std::ranges::OutputRange<decltype(v_elem), dna5>));
+
+    // --- View ---
+
+    EXPECT_TRUE((preserved<decltype(vec), decltype(v1)>({Input, Forward, Bidirectional, RandomAccess, Sized, Common, 
+                                                         ConstIterable})));
+    EXPECT_TRUE((guaranteed<decltype(vec), decltype(v1)>({View})));
+    EXPECT_TRUE(weak_guaranteed<decltype(v1)>({Viewable}));
+    EXPECT_TRUE((lost<decltype(vec), decltype(v1)>({Contiguous, Output})));
+
+    // --- Underlying element ---
+
+    EXPECT_TRUE((preserved<decltype(vec), decltype(v_elem)>({Input, Forward, Bidirectional, RandomAccess, Sized, Common, 
+                                                         Output, ConstIterable})));
+    EXPECT_TRUE((guaranteed<decltype(vec), decltype(v_elem)>({View})));
+    EXPECT_TRUE(weak_guaranteed<decltype(v_elem)>({Viewable}));
+    EXPECT_TRUE((lost<decltype(vec), decltype(v_elem)>({Contiguous})));
 }
 
 // ------------------------------------------------------------------

--- a/test/unit/range/view/view_get_test.cpp
+++ b/test/unit/range/view/view_get_test.cpp
@@ -19,6 +19,8 @@
 #include <seqan3/range/view/complement.hpp>
 #include <seqan3/std/ranges>
 
+#include "view_concept_check.hpp"
+
 using namespace seqan3;
 
 TEST(view_get, basic)
@@ -133,28 +135,15 @@ TEST(view_get, tuple_pair)
 
 TEST(view_get, concepts)
 {
+    using namespace seqan3::test;
     std::vector<std::tuple<int, int>> vec{{0, 1}, {0, 1}, {0, 1}, {0, 1}, {0, 1}};
-    EXPECT_TRUE(std::ranges::InputRange<decltype(vec)>);
-    EXPECT_TRUE(std::ranges::ForwardRange<decltype(vec)>);
-    EXPECT_TRUE(std::ranges::BidirectionalRange<decltype(vec)>);
-    EXPECT_TRUE(std::ranges::RandomAccessRange<decltype(vec)>);
-    EXPECT_FALSE(std::ranges::View<decltype(vec)>);
-    EXPECT_TRUE(std::ranges::SizedRange<decltype(vec)>);
-    EXPECT_TRUE(std::ranges::CommonRange<decltype(vec)>);
-    EXPECT_TRUE(const_iterable_concept<decltype(vec)>);
-    EXPECT_TRUE((std::ranges::OutputRange<decltype(vec), std::tuple<int, int>>));
-
     auto v1 = vec | view::get<0>;
-    EXPECT_TRUE(std::ranges::InputRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::ForwardRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::BidirectionalRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::RandomAccessRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::View<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::SizedRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::CommonRange<decltype(v1)>);
-    EXPECT_TRUE(const_iterable_concept<decltype(v1)>);
-    EXPECT_FALSE((std::ranges::OutputRange<decltype(v1), std::tuple<int, int>>));
-    EXPECT_TRUE((std::ranges::OutputRange<decltype(v1), int>));
+
+    EXPECT_TRUE((preserved<decltype(vec), decltype(v1)>({Input, Forward, Bidirectional, RandomAccess, Sized, Common, 
+                                                         Output, ConstIterable})));
+    EXPECT_TRUE((guaranteed<decltype(vec), decltype(v1)>({View})));
+    EXPECT_TRUE(weak_guaranteed<decltype(v1)>({Viewable}));
+    EXPECT_TRUE((lost<decltype(vec), decltype(v1)>({Contiguous})));
 }
 
 // https://github.com/seqan/seqan3/issues/745

--- a/test/unit/range/view/view_kmer_hash_test.cpp
+++ b/test/unit/range/view/view_kmer_hash_test.cpp
@@ -5,13 +5,16 @@
 // shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
 // -----------------------------------------------------------------------------------------------------
 
+#include <gtest/gtest.h>
+
 #include <type_traits>
 
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
+#include <seqan3/range/concept.hpp>
 #include <seqan3/range/container/bitcompressed_vector.hpp>
 #include <seqan3/range/view/kmer_hash.hpp>
 
-#include <gtest/gtest.h>
+#include "view_concept_check.hpp"
 
 using namespace seqan3;
 
@@ -41,4 +44,17 @@ TEST(kmer_hash, view)
         std::vector<size_t> expected{6,27,44,50,9};
         EXPECT_EQ(expected, hashes);
     }
+}
+
+TEST(kmer_hash, concepts)
+{
+    using namespace seqan3::test;
+    std::vector<dna4> vec{"ACGTG"_dna4};
+    auto v1 = vec | view::kmer_hash(3);
+
+    EXPECT_TRUE((preserved<decltype(vec), decltype(v1)>({Input, Forward, Bidirectional, RandomAccess, Sized, Common, 
+                                                         ConstIterable})));
+    EXPECT_TRUE((guaranteed<decltype(vec), decltype(v1)>({View})));
+    EXPECT_TRUE(weak_guaranteed<decltype(v1)>({Viewable}));
+    EXPECT_TRUE((lost<decltype(vec), decltype(v1)>({Contiguous, Output})));
 }

--- a/test/unit/range/view/view_persist_test.cpp
+++ b/test/unit/range/view/view_persist_test.cpp
@@ -12,11 +12,14 @@
 #include <range/v3/algorithm/copy.hpp>
 #include <range/v3/view/unique.hpp>
 
+#include <seqan3/core/metafunction/pre.hpp>
 #include <seqan3/io/stream/parse_condition.hpp>
 #include <seqan3/range/view/persist.hpp>
 #include <seqan3/range/concept.hpp>
 #include <seqan3/std/concepts>
 #include <seqan3/std/ranges>
+
+#include "view_concept_check.hpp"
 
 using namespace seqan3;
 
@@ -79,26 +82,11 @@ TEST(view_persist, const_)
 
 TEST(view_persist, concepts)
 {
-    std::string vec{"foobar"};
-    EXPECT_TRUE(std::ranges::InputRange<decltype(std::string{"foo"})>);
-    EXPECT_TRUE(std::ranges::ForwardRange<decltype(std::string{"foo"})>);
-    EXPECT_TRUE(std::ranges::BidirectionalRange<decltype(std::string{"foo"})>);
-    EXPECT_TRUE(std::ranges::RandomAccessRange<decltype(std::string{"foo"})>);
-    EXPECT_FALSE(std::ranges::View<decltype(std::string{"foo"})>);
-    EXPECT_TRUE(std::ranges::SizedRange<decltype(std::string{"foo"})>);
-    EXPECT_TRUE(std::ranges::CommonRange<decltype(std::string{"foo"})>);
-    EXPECT_TRUE(const_iterable_concept<decltype(std::string{"foo"})>);
-    EXPECT_TRUE((std::ranges::OutputRange<decltype(std::string{"foo"}), char>));
-
+    using namespace seqan3::test;
     auto v1 = std::string{"foo"} | view::persist;
 
-    EXPECT_TRUE(std::ranges::InputRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::ForwardRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::BidirectionalRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::RandomAccessRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::View<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::SizedRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::CommonRange<decltype(v1)>);
-    EXPECT_TRUE(const_iterable_concept<decltype(v1)>);
-    EXPECT_TRUE((std::ranges::OutputRange<decltype(v1), char>));
+    EXPECT_TRUE((preserved<std::string, decltype(v1)>({Input, Forward, Bidirectional, RandomAccess, Contiguous, Sized, 
+                                                         Common, Output, ConstIterable})));
+    EXPECT_TRUE((guaranteed<std::string, decltype(v1)>({View, Viewable})));
+    EXPECT_TRUE((weak_guaranteed<decltype(v1)>({Viewable})));
 }

--- a/test/unit/range/view/view_rank_to_test.cpp
+++ b/test/unit/range/view/view_rank_to_test.cpp
@@ -14,6 +14,8 @@
 #include <seqan3/range/concept.hpp>
 #include <seqan3/std/ranges>
 
+#include "view_concept_check.hpp"
+
 using namespace seqan3;
 
 TEST(view_rank_to, basic)
@@ -37,26 +39,12 @@ TEST(view_rank_to, basic)
 
 TEST(view_rank_to, concepts)
 {
+    using namespace seqan3::test;
     std::vector<unsigned> vec{0,1,3,3,3,2,0,3,0};
-    EXPECT_TRUE(std::ranges::InputRange<decltype(vec)>);
-    EXPECT_TRUE(std::ranges::ForwardRange<decltype(vec)>);
-    EXPECT_TRUE(std::ranges::BidirectionalRange<decltype(vec)>);
-    EXPECT_TRUE(std::ranges::RandomAccessRange<decltype(vec)>);
-    EXPECT_FALSE(std::ranges::View<decltype(vec)>);
-    EXPECT_TRUE(std::ranges::SizedRange<decltype(vec)>);
-    EXPECT_TRUE(std::ranges::CommonRange<decltype(vec)>);
-    EXPECT_TRUE(const_iterable_concept<decltype(vec)>);
-    EXPECT_TRUE((std::ranges::OutputRange<decltype(vec), unsigned>));
-
     auto v1 = vec | view::rank_to<dna5>;
-    EXPECT_TRUE(std::ranges::InputRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::ForwardRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::BidirectionalRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::RandomAccessRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::View<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::SizedRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::CommonRange<decltype(v1)>);
-    EXPECT_TRUE(const_iterable_concept<decltype(v1)>);
-    EXPECT_FALSE((std::ranges::OutputRange<decltype(v1), dna5>));
-    EXPECT_FALSE((std::ranges::OutputRange<decltype(v1), unsigned>));
+
+    EXPECT_TRUE((preserved<decltype(vec), decltype(v1)>({Input, Forward, Bidirectional, RandomAccess, Sized, Common, 
+                                                         ConstIterable})));
+    EXPECT_TRUE((guaranteed<decltype(vec), decltype(v1)>({View, Viewable})));
+    EXPECT_TRUE((lost<decltype(vec), decltype(v1)>({Contiguous, Output})));
 }

--- a/test/unit/range/view/view_to_char_test.cpp
+++ b/test/unit/range/view/view_to_char_test.cpp
@@ -14,6 +14,8 @@
 #include <seqan3/range/view/to_char.hpp>
 #include <seqan3/std/ranges>
 
+#include "view_concept_check.hpp"
+
 using namespace seqan3;
 
 TEST(view_to_char, basic)
@@ -37,26 +39,13 @@ TEST(view_to_char, basic)
 
 TEST(view_to_char, concepts)
 {
+    using namespace seqan3::test;
     dna5_vector vec{"ACTTTGATA"_dna5};
-    EXPECT_TRUE(std::ranges::InputRange<decltype(vec)>);
-    EXPECT_TRUE(std::ranges::ForwardRange<decltype(vec)>);
-    EXPECT_TRUE(std::ranges::BidirectionalRange<decltype(vec)>);
-    EXPECT_TRUE(std::ranges::RandomAccessRange<decltype(vec)>);
-    EXPECT_FALSE(std::ranges::View<decltype(vec)>);
-    EXPECT_TRUE(std::ranges::SizedRange<decltype(vec)>);
-    EXPECT_TRUE(std::ranges::CommonRange<decltype(vec)>);
-    EXPECT_TRUE(const_iterable_concept<decltype(vec)>);
-    EXPECT_TRUE((std::ranges::OutputRange<decltype(vec), dna5>));
-
     auto v1 = vec | view::to_char;
-    EXPECT_TRUE(std::ranges::InputRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::ForwardRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::BidirectionalRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::RandomAccessRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::View<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::SizedRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::CommonRange<decltype(v1)>);
-    EXPECT_TRUE(const_iterable_concept<decltype(v1)>);
-    EXPECT_FALSE((std::ranges::OutputRange<decltype(v1), dna5>));
-    EXPECT_FALSE((std::ranges::OutputRange<decltype(v1), char>));
+
+    EXPECT_TRUE((preserved<decltype(vec), decltype(v1)>({Input, Forward, Bidirectional, RandomAccess, Sized, Common, 
+                                                         ConstIterable})));
+    EXPECT_TRUE((guaranteed<decltype(vec), decltype(v1)>({View})));
+    EXPECT_TRUE(weak_guaranteed<decltype(v1)>({Viewable}));
+    EXPECT_TRUE((lost<decltype(vec), decltype(v1)>({Contiguous, Output})));
 }

--- a/test/unit/range/view/view_to_rank_test.cpp
+++ b/test/unit/range/view/view_to_rank_test.cpp
@@ -14,6 +14,8 @@
 #include <seqan3/range/view/to_rank.hpp>
 #include <seqan3/std/ranges>
 
+#include "view_concept_check.hpp"
+
 using namespace seqan3;
 
 TEST(view_to_rank, basic)
@@ -37,26 +39,13 @@ TEST(view_to_rank, basic)
 
 TEST(view_to_rank, concepts)
 {
+    using namespace seqan3::test;
     dna5_vector vec{"ACTTTGATA"_dna5};
-    EXPECT_TRUE(std::ranges::InputRange<decltype(vec)>);
-    EXPECT_TRUE(std::ranges::ForwardRange<decltype(vec)>);
-    EXPECT_TRUE(std::ranges::BidirectionalRange<decltype(vec)>);
-    EXPECT_TRUE(std::ranges::RandomAccessRange<decltype(vec)>);
-    EXPECT_FALSE(std::ranges::View<decltype(vec)>);
-    EXPECT_TRUE(std::ranges::SizedRange<decltype(vec)>);
-    EXPECT_TRUE(std::ranges::CommonRange<decltype(vec)>);
-    EXPECT_TRUE(const_iterable_concept<decltype(vec)>);
-    EXPECT_TRUE((std::ranges::OutputRange<decltype(vec), dna5>));
-
     auto v1 = vec | view::to_rank;
-    EXPECT_TRUE(std::ranges::InputRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::ForwardRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::BidirectionalRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::RandomAccessRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::View<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::SizedRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::CommonRange<decltype(v1)>);
-    EXPECT_TRUE(const_iterable_concept<decltype(v1)>);
-    EXPECT_FALSE((std::ranges::OutputRange<decltype(v1), dna5>));
-    EXPECT_FALSE((std::ranges::OutputRange<decltype(v1), unsigned>));
+
+    EXPECT_TRUE((preserved<decltype(vec), decltype(v1)>({Input, Forward, Bidirectional, RandomAccess, Sized, Common, 
+                                                         ConstIterable})));
+    EXPECT_TRUE((guaranteed<decltype(vec), decltype(v1)>({View})));
+    EXPECT_TRUE(weak_guaranteed<decltype(v1)>({Viewable}));
+    EXPECT_TRUE((lost<decltype(vec), decltype(v1)>({Contiguous, Output})));
 }

--- a/test/unit/range/view/view_translation_test.cpp
+++ b/test/unit/range/view/view_translation_test.cpp
@@ -24,6 +24,8 @@
 #include <seqan3/range/view/translation.hpp>
 #include <seqan3/std/ranges>
 
+#include "view_concept_check.hpp"
+
 using namespace seqan3;
 // using namespace seqan3::view;
 
@@ -190,41 +192,29 @@ TYPED_TEST(nucleotide, view_translate_container_conversion)
 
 TYPED_TEST(nucleotide, view_translate_single_concepts)
 {
+    using namespace seqan3::test;
     std::string const in{"ACGTACGTACGTA"};
     std::vector<TypeParam> vec = in | view::char_to<TypeParam>;
-    EXPECT_TRUE(std::ranges::InputRange<decltype(vec)>);
-    EXPECT_TRUE(std::ranges::ForwardRange<decltype(vec)>);
-    EXPECT_TRUE(std::ranges::RandomAccessRange<decltype(vec)>);
-    EXPECT_TRUE(std::ranges::SizedRange<decltype(vec)>);
-
     auto v1 = vec | view::translate_single(translation_frames::FWD_FRAME_0);
-    EXPECT_TRUE(std::ranges::InputRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::ForwardRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::RandomAccessRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::SizedRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::View<decltype(v1)>);
-    EXPECT_TRUE((std::is_same_v<aa27, value_type_t<decltype(v1)>>));
-    EXPECT_TRUE((std::is_same_v<aa27, reference_t<decltype(v1)>>));
+
+    EXPECT_TRUE((preserved<decltype(vec), decltype(v1)>({Input, Forward, Bidirectional, RandomAccess, Sized,
+                                                         ConstIterable})));
+    EXPECT_TRUE((guaranteed<decltype(vec), decltype(v1)>({View})));
+    EXPECT_TRUE(weak_guaranteed<decltype(v1)>({Viewable, Common}));
+    EXPECT_TRUE((lost<decltype(vec), decltype(v1)>({Contiguous, Output})));
 }
 
 TYPED_TEST(nucleotide, view_translate_concepts)
 {
+    using namespace seqan3::test;
+
     std::string const in{"ACGTACGTACGTA"};
     std::vector<TypeParam> vec = in | view::char_to<TypeParam>;
-    EXPECT_TRUE(std::ranges::ForwardRange<decltype(vec)>);
-    EXPECT_TRUE(std::ranges::RandomAccessRange<decltype(vec)>);
-    EXPECT_TRUE(std::ranges::SizedRange<decltype(vec)>);
-
     auto v1 = vec | view::translate(translation_frames::FWD_REV_0);
-    EXPECT_TRUE(std::ranges::InputRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::ForwardRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::RandomAccessRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::SizedRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::View<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::RandomAccessRange<value_type_t<decltype(v1)>>);
-    EXPECT_TRUE(std::ranges::SizedRange<value_type_t<decltype(v1)>>);
-    EXPECT_TRUE(std::ranges::View<value_type_t<decltype(v1)>>);
-    EXPECT_TRUE(std::ranges::RandomAccessRange<reference_t<decltype(v1)>>);
-    EXPECT_TRUE(std::ranges::SizedRange<reference_t<decltype(v1)>>);
-    EXPECT_TRUE(std::ranges::View<reference_t<decltype(v1)>>);
+
+    EXPECT_TRUE((preserved<decltype(vec), decltype(v1)>({Input, Forward, Bidirectional, RandomAccess, Sized,
+                                                         ConstIterable})));
+    EXPECT_TRUE((guaranteed<decltype(vec), decltype(v1)>({View})));
+    EXPECT_TRUE(weak_guaranteed<decltype(v1)>({Viewable, Common}));
+    EXPECT_TRUE((lost<decltype(vec), decltype(v1)>({Contiguous, Output})));
 }

--- a/test/unit/range/view/view_trim_test.cpp
+++ b/test/unit/range/view/view_trim_test.cpp
@@ -15,6 +15,8 @@
 #include <seqan3/range/view/trim.hpp>
 #include <seqan3/std/ranges>
 
+#include "view_concept_check.hpp"
+
 using namespace seqan3;
 using namespace seqan3::view;
 
@@ -68,19 +70,14 @@ TEST(view_trim, qualified)
 
 TEST(view_trim, concepts)
 {
+    using namespace seqan3::test;
     std::vector<dna5q> vec{{'A'_dna5, phred42{40}}, {'G'_dna5, phred42{40}}, {'G'_dna5, phred42{30}}, {'A'_dna5, phred42{20}}, {'T'_dna5, phred42{10}}};
-    EXPECT_TRUE(std::ranges::InputRange<decltype(vec)>);
-    EXPECT_TRUE(std::ranges::ForwardRange<decltype(vec)>);
-    EXPECT_TRUE(std::ranges::RandomAccessRange<decltype(vec)>);
-    EXPECT_TRUE(std::ranges::CommonRange<decltype(vec)>);
-    EXPECT_TRUE((std::ranges::OutputRange<decltype(vec), dna5q>));
-    EXPECT_TRUE(std::ranges::SizedRange<decltype(vec)>);
-
     auto v1 = vec | view::trim(20u);
-    EXPECT_TRUE(std::ranges::InputRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::ForwardRange<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::RandomAccessRange<decltype(v1)>);
-    EXPECT_FALSE(std::ranges::CommonRange<decltype(v1)>);
-    EXPECT_TRUE((std::ranges::OutputRange<decltype(v1), dna5q>));
-    EXPECT_TRUE(!std::ranges::SizedRange<decltype(v1)>);
+
+    //TODO Contiguous should be preserved, but isn't
+    EXPECT_TRUE((preserved<decltype(vec), decltype(v1)>(
+        {Input, Forward, Bidirectional, RandomAccess/*, Contiguous*/, Output, ConstIterable})));
+    EXPECT_TRUE((guaranteed<decltype(vec), decltype(v1)>({View})));
+    EXPECT_TRUE(weak_guaranteed<decltype(v1)>({Viewable}));
+    EXPECT_TRUE((lost<decltype(vec), decltype(v1)>({Sized, Common})));
 }


### PR DESCRIPTION
Content of this PR
---

I introduced a new test structure to test the concepts for all views that didn't look too complicated for me to touch. The new structure should give a more intuitive overview of preservance/guarantee/loss.
Thereby, I also added missing tests for ViewableRange and ContiguousRange.

The test structure
---

I created an enum for all different range concepts.
Using that enum, it is now possible to check for fulfillment, preserving, guarantee or loss via functions using initialization lists:

```c++
// Example for preserved, other types (fulfill, guarantee, loss) work in a similar way
using namespace seqan3::test;
std::string vec{"HelloWorld"};
auto view = vec | std::view::reverse;
EXPECT_TRUE((preserved<decltype(vec),decltype(view)>({Input, Forward})));
```
For lost and guaranteed concepts that cannot be properly tested for the input range, there are functions weak_lost(...) and weak_guaranteed(...) that only test the correct output type.

If `EXPECT_TRUE` fails, the error message gives a combined output of the underlying test functions and the GoogleTest output which would look like this:
```
Preserved check of concept 'OutputRange' failed:
 IN_TYPE: 1
OUT_TYPE: 0
are expected to be equal.
/home/lokat/workspace/seqan3-fork/test/unit/range/view/view_complement_test.cpp:58: Failure
Value of: (preserved<decltype(vec), decltype(v1)>({Input, Forward, Bidirectional, RandomAccess, Sized, Common, ConstIterable, Output}))
  Actual: false
Expected: true
```

With this combintion of output, it is ensured to get all necessary information about what failed (which was actually not too trivial to achieve): The concept type, which expectations were not fulfilled and the original line where the FAIL() occured.

The following views are already included and using the new functions:

- char_to
- complement
- convert
- deep
- get
- kmer_hash
- persist
- to_char
- to_rank
- translation
- trim

The following tests remain unchanged:

- pairwise_combine
- single_pass_input
- take
- take_line
- take_until

Issues
---

- `view_trim_test.cpp`: ContiguousRange is not preserved (test fails when uncommented)

WIP
---

- The remaining tests should be updated before merging PR.
- Test range type of input and output?