### PR TITLE
Testing with MSys64-MinGW-gcc8.3

### DIFF
--- a/test/include/seqan3/test/tmp_filename.hpp
+++ b/test/include/seqan3/test/tmp_filename.hpp
@@ -17,6 +17,9 @@
 // TODO(rrahn): At support for Windows platforms, when we support it.
 #if defined(__APPLE__)
 #include <unistd.h>
+#elif defined(_WIN32)
+#include <cstring>
+#include <io.h>
 #else  // other unix systems
 #include <stdlib.h>
 #endif
@@ -27,6 +30,18 @@ namespace seqan3
 {
 namespace test
 {
+#if defined(_WIN32)
+inline char * mkdtemp(char * template_name)
+{
+    if (_mktemp_s(template_name, strlen(template_name) + 1))
+        return nullptr;
+
+    if (std::filesystem::create_directories(template_name))
+        return template_name;
+
+    return nullptr;
+}
+#endif
 
 /// \cond
 /*!\brief Creates and maintains a std::filesystem::path to a temporary file.

--- a/test/unit/argument_parser/format_parse_validators_test.cpp
+++ b/test/unit/argument_parser/format_parse_validators_test.cpp
@@ -113,22 +113,22 @@ TEST(validator_test, input_file)
         std::filesystem::path file_in_path;
 
         // option
-        std::filesystem::path path = tmp_name.get_path();
+        std::string const & path = tmp_name.get_path().string();
         const char * argv[] = {"./argument_parser_test", "-i", path.c_str()};
         argument_parser parser{"test_parser", 3, argv, false};
         parser.add_option(file_in_path, 'i', "int-option", "desc",
                           option_spec::DEFAULT, input_file_validator{formats});
 
         EXPECT_NO_THROW(parser.parse());
-        EXPECT_EQ(file_in_path.string(), path.string());
+        EXPECT_EQ(file_in_path.string(), path);
     }
 
     { // file list.
         std::vector<std::filesystem::path> input_files;
 
         // option
-        std::filesystem::path path = tmp_name.get_path();
-        std::filesystem::path path_2 = tmp_name_2.get_path();
+        std::string const & path = tmp_name.get_path().string();
+        std::string const & path_2 = tmp_name_2.get_path().string();
 
         const char * argv[] = {"./argument_parser_test", path.c_str(), path_2.c_str()};
         argument_parser parser{"test_parser", 3, argv, false};
@@ -136,8 +136,8 @@ TEST(validator_test, input_file)
 
         EXPECT_NO_THROW(parser.parse());
         EXPECT_EQ(input_files.size(), 2u);
-        EXPECT_EQ(input_files[0].string(), path.string());
-        EXPECT_EQ(input_files[1].string(), path_2.string());
+        EXPECT_EQ(input_files[0].string(), path);
+        EXPECT_EQ(input_files[1].string(), path_2);
     }
 
     { // get help page message
@@ -210,22 +210,22 @@ TEST(validator_test, output_file)
         std::filesystem::path file_out_path;
 
         // option
-        std::filesystem::path path = tmp_name.get_path();
+        std::string const & path = tmp_name.get_path().string();
         const char * argv[] = {"./argument_parser_test", "-o", path.c_str()};
         argument_parser parser{"test_parser", 3, argv, false};
         parser.add_option(file_out_path, 'o', "out-option", "desc",
                           option_spec::DEFAULT, output_file_validator{formats});
 
         EXPECT_NO_THROW(parser.parse());
-        EXPECT_EQ(file_out_path.string(), path.string());
+        EXPECT_EQ(file_out_path.string(), path);
     }
 
     { // file list.
         std::vector<std::filesystem::path> output_files;
 
         // option
-        std::filesystem::path path = tmp_name.get_path();
-        std::filesystem::path path_3 = tmp_name_3.get_path();
+        std::string const & path = tmp_name.get_path().string();
+        std::string const & path_3 = tmp_name_3.get_path().string();
 
         const char * argv[] = {"./argument_parser_test", path.c_str(), path_3.c_str()};
         argument_parser parser{"test_parser", 3, argv, false};
@@ -233,8 +233,8 @@ TEST(validator_test, output_file)
 
         EXPECT_NO_THROW(parser.parse());
         EXPECT_EQ(output_files.size(), 2u);
-        EXPECT_EQ(output_files[0].string(), path.string());
-        EXPECT_EQ(output_files[1].string(), path_3.string());
+        EXPECT_EQ(output_files[0].string(), path);
+        EXPECT_EQ(output_files[1].string(), path_3);
     }
 
     // get help page message
@@ -289,13 +289,14 @@ TEST(validator_test, input_directory)
             std::filesystem::path dir_in_path;
 
             // option
-            const char * argv[] = {"./argument_parser_test", "-i", p.c_str()};
+            std::string const & path = p.string();
+            const char * argv[] = {"./argument_parser_test", "-i", path.c_str()};
             argument_parser parser{"test_parser", 3, argv, false};
             parser.add_option(dir_in_path, 'i', "input-option", "desc",
                               option_spec::DEFAULT, input_directory_validator{});
 
             EXPECT_NO_THROW(parser.parse());
-            EXPECT_EQ(p.string(), dir_in_path.string());
+            EXPECT_EQ(path, dir_in_path.string());
         }
     }
 
@@ -335,13 +336,14 @@ TEST(validator_test, output_directory)
         std::filesystem::path dir_out_path;
 
         // option
-        const char * argv[] = {"./argument_parser_test", "-o", p.c_str()};
+        std::string const & path = p.string();
+        const char * argv[] = {"./argument_parser_test", "-o", path.c_str()};
         argument_parser parser{"test_parser", 3, argv, false};
         parser.add_option(dir_out_path, 'o', "output-option", "desc",
                           option_spec::DEFAULT, output_directory_validator{});
 
         EXPECT_NO_THROW(parser.parse());
-        EXPECT_EQ(p.string(), dir_out_path.string());
+        EXPECT_EQ(path, dir_out_path.string());
     }
 
     {
@@ -940,7 +942,8 @@ TEST(validator_test, chaining_validators)
 
     // option
     {
-        const char * argv[] = {"./argument_parser_test", "-s", tmp_name.get_path().c_str()};
+        std::string const & path = tmp_name.get_path().string();
+        const char * argv[] = {"./argument_parser_test", "-s", path.c_str()};
         argument_parser parser{"test_parser", 3, argv, false};
         parser.add_option(option_value, 's', "string-option", "desc",
                           option_spec::DEFAULT, absolute_path_validator | my_file_ext_validator);
@@ -948,11 +951,11 @@ TEST(validator_test, chaining_validators)
         testing::internal::CaptureStderr();
         EXPECT_NO_THROW(parser.parse());
         EXPECT_TRUE((testing::internal::GetCapturedStderr()).empty());
-        EXPECT_EQ(option_value, tmp_name.get_path().string());
+        EXPECT_EQ(option_value, path);
     }
 
     {
-        auto rel_path = tmp_name.get_path().relative_path();
+        auto rel_path = tmp_name.get_path().relative_path().string();
         const char * argv[] = {"./argument_parser_test", "-s", rel_path.c_str()};
         argument_parser parser{"test_parser", 3, argv, false};
         parser.add_option(option_value, 's', "string-option", "desc",
@@ -962,8 +965,8 @@ TEST(validator_test, chaining_validators)
     }
 
     {
-
-        const char * argv[] = {"./argument_parser_test", "-s", invalid_extension.c_str()};
+        std::string const & path = invalid_extension.string();
+        const char * argv[] = {"./argument_parser_test", "-s", path.c_str()};
         argument_parser parser{"test_parser", 3, argv, false};
         parser.add_option(option_value, 's', "string-option", "desc",
                           option_spec::DEFAULT, absolute_path_validator | my_file_ext_validator);
@@ -973,7 +976,8 @@ TEST(validator_test, chaining_validators)
 
     // with temporary validators
     {
-        const char * argv[] = {"./argument_parser_test", "-s", tmp_name.get_path().c_str()};
+        std::string const & path = tmp_name.get_path().string();
+        const char * argv[] = {"./argument_parser_test", "-s", path.c_str()};
         argument_parser parser{"test_parser", 3, argv, false};
         parser.add_option(option_value, 's', "string-option", "desc",
                           option_spec::DEFAULT,
@@ -983,12 +987,13 @@ TEST(validator_test, chaining_validators)
         testing::internal::CaptureStderr();
         EXPECT_NO_THROW(parser.parse());
         EXPECT_TRUE((testing::internal::GetCapturedStderr()).empty());
-        EXPECT_EQ(option_value, tmp_name.get_path().string());
+        EXPECT_EQ(option_value, path);
     }
 
     // three validators
     {
-        const char * argv[] = {"./argument_parser_test", "-s", tmp_name.get_path().c_str()};
+        std::string const & path = tmp_name.get_path().string();
+        const char * argv[] = {"./argument_parser_test", "-s", path.c_str()};
         argument_parser parser{"test_parser", 3, argv, false};
         parser.add_option(option_value, 's', "string-option", "desc",
                           option_spec::DEFAULT,
@@ -999,7 +1004,7 @@ TEST(validator_test, chaining_validators)
         testing::internal::CaptureStderr();
         EXPECT_NO_THROW(parser.parse());
         EXPECT_TRUE((testing::internal::GetCapturedStderr()).empty());
-        EXPECT_EQ(option_value, tmp_name.get_path().string());
+        EXPECT_EQ(option_value, path);
     }
 
     // help page message
@@ -1031,7 +1036,8 @@ TEST(validator_test, chaining_validators)
     // chaining with a container option value type
     {
         std::vector<std::string> option_list_value{};
-        const char * argv[] = {"./argument_parser_test", "-s", tmp_name.get_path().c_str()};
+        std::string const & path = tmp_name.get_path().string();
+        const char * argv[] = {"./argument_parser_test", "-s", path.c_str()};
         argument_parser parser{"test_parser", 3, argv, false};
         parser.add_option(option_list_value, 's', "string-option", "desc",
                           option_spec::DEFAULT,
@@ -1040,6 +1046,6 @@ TEST(validator_test, chaining_validators)
         testing::internal::CaptureStderr();
         EXPECT_NO_THROW(parser.parse());
         EXPECT_TRUE((testing::internal::GetCapturedStderr()).empty());
-        EXPECT_EQ(option_list_value[0], tmp_name.get_path().string());
+        EXPECT_EQ(option_list_value[0], path);
     }
 }


### PR DESCRIPTION
MSys64-MinGW-gcc8.3 comes with a working filesystem. No more need of Boost (https://github.com/seqan/seqan3/pull/515).

Still some problems: 
```
template <typename T>
class istream : public ::testing::Test
{};

inline std::string const uncompressed{"The quick brown fox jumps over the lazy dog"};

TYPED_TEST_CASE_P(istream);

TYPED_TEST_P(istream, concept_check)
{
    EXPECT_TRUE((IStream<TypeParam, char>));
}
```
produce:
```
[ 44%] Built target gz_ostream_test
[ 44%] Building CXX object core/CMakeFiles/tuple_utility_test.dir/tuple_utility_test.cpp.obj
In file included from C:/Prog/ExtLib/cmake-seqan3-unit-build-release/vendor/googletest/googletest/include/gtest/gtest.h:67,
                 from C:\Prog\ExtLib\seqan3\test\unit\contrib\stream\gz_istream_test.cpp:8:
C:/Prog/ExtLib/cmake-seqan3-unit-build-release/vendor/googletest/googletest/include/gtest/gtest-typed-test.h:228:35: error: expected template-name before '<' token
   class TestName : public CaseName<gtest_TypeParam_> { \
                                   ^
C:/Prog/ExtLib/seqan3/test/unit/io/stream/istream_test_template.hpp:29:1: note: in expansion of macro 'TYPED_TEST_P'
 TYPED_TEST_P(IStream, concept_check)
 ^~~~~~~~~~~~
```
and with `aligned_alloc` in range: 
```
[100%] Building CXX object range/container/CMakeFiles/aligned_allocator_test.dir/aligned_allocator_test.cpp.obj
In file included from C:\Prog\ExtLib\seqan3\test\unit\range\container\aligned_allocator_test.cpp:10:
C:/Prog/ExtLib/seqan3/include/seqan3/range/container/aligned_allocator.hpp: In member function 'seqan3::aligned_allocator<value_t, alignment_v>::value_type* seqan3::aligned_allocator<value_t, alignment_v>::allocate(seqan3::aligned_allocator<value_t, alignment_v>::size_type)':
C:/Prog/ExtLib/seqan3/include/seqan3/range/container/aligned_allocator.hpp:122:48: error: 'aligned_alloc' is not a member of 'std'
         if (auto p = static_cast<pointer>(std::aligned_alloc(alignment, n * sizeof(value_type))))
                                                ^~~~~~~~~~~~~
											
```	