### PR TITLE
Cigar alphabet

### DIFF
--- a/include/seqan3/alphabet/cigar/all.hpp
+++ b/include/seqan3/alphabet/cigar/all.hpp
@@ -1,0 +1,41 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \author Joshua Kim <joshua.kim AT fu-berlin.de>
+ * \brief Meta-header for the cigar submodule; includes all headers from alphabet/cigar/.
+ */
+
+ #pragma once
+
+ #include <seqan3/alphabet/cigar/cigar_op.hpp>
+
+ /*!\defgroup cigar CIGAR
+  * \brief Contains the CIGAR operation alphabet, along with the CIGAR cartesian composition.
+  * \ingroup alphabet
+  *
+  * \par Introduction
+  *
+  * CIGAR strings are combinations of count values and CIGAR operations. This submodule has two different
+  * alphabets. One is the seqan3::cigar_op alphabet, which is a base seqan3::alphabet implementation. This
+  * contains all valid symbols contained in CIGAR strings. The other alphabet is the seqan3::cigar alphabet, which
+  * is a seqan3::cartesian_composition implementation. This combines the seqan3::cigar_op alphabet with a count value,
+  * such that one can represent an entire CIGAR string with a std::vector of seqan3::cigar values.
+  *
+  * The following table outlines the valid characters in the seqan3::cigar_op alphabet.
+  *
+  * | Letter | Description                                                                                     |
+  * |--------|-------------------------------------------------------------------------------------------------|
+  * | M      | Alignment match (can be a sequence match or mismatch, used only in basic CIGAR representations) |
+  * | I      | Insertion to the reference                                                                      |
+  * | D      | Deletion from the reference                                                                     |
+  * | N      | Skipped region from the reference                                                               |
+  * | S      | Soft clipping (clipped sequences present in SEQ)                                                |
+  * | H      | Hard clipping (clipped sequences NOT present in SEQ)                                            |
+  * | P      | Padding (silent deletion from padded reference)                                                 |
+  * | =      | Sequence match                                                                                  |
+  * | X      | Sequence mismatch                                                                               |

--- a/include/seqan3/alphabet/cigar/all.hpp
+++ b/include/seqan3/alphabet/cigar/all.hpp
@@ -2,7 +2,7 @@
 // Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
 // Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
 // This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
-// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 // -----------------------------------------------------------------------------------------------------
 
 /*!\file
@@ -20,7 +20,8 @@
   *
   * \par Introduction
   *
-  * CIGAR strings are combinations of count values and CIGAR operations. This submodule has two different
+  * CIGAR strings are combinations of count values and CIGAR operations, representing an alignment as a sequence of
+  * edit operations. This submodule has two different
   * alphabets. One is the seqan3::cigar_op alphabet, which is a base seqan3::alphabet implementation. This
   * contains all valid symbols contained in CIGAR strings. The other alphabet is the seqan3::cigar alphabet, which
   * is a seqan3::cartesian_composition implementation. This combines the seqan3::cigar_op alphabet with a count value,
@@ -39,3 +40,4 @@
   * | P      | Padding (silent deletion from padded reference)                                                 |
   * | =      | Sequence match                                                                                  |
   * | X      | Sequence mismatch                                                                               |
+  */

--- a/include/seqan3/alphabet/cigar/cigar_op.hpp
+++ b/include/seqan3/alphabet/cigar/cigar_op.hpp
@@ -93,7 +93,7 @@ protected:
             // reverse mapping for characters
             for (size_t rnk = 0u; rnk < value_size; ++rnk)
             {
-            	ret[rank_to_char[rnk] ] = rnk;
+                ret[rank_to_char[rnk] ] = rnk;
             }
 
             return ret;

--- a/include/seqan3/alphabet/cigar/cigar_op.hpp
+++ b/include/seqan3/alphabet/cigar/cigar_op.hpp
@@ -1,0 +1,153 @@
+// ============================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ============================================================================
+//
+// Copyright (c) 2006-2018, Knut Reinert & Freie Universitaet Berlin
+// Copyright (c) 2016-2018, Knut Reinert & MPI Molekulare Genetik
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ============================================================================
+
+/*!\file
+ * \brief Introduces the cigar_op alphabet.
+ * \author Svenja Mehringer <svenja.mehringer AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <array>
+#include <cassert>
+#include <cstdint>
+#include <type_traits>
+
+#include <seqan3/alphabet/detail/alphabet_base.hpp>
+
+// ------------------------------------------------------------------
+// cigar_op
+// ------------------------------------------------------------------
+
+namespace seqan3
+{
+
+/*!\brief The (extended) cigar operation alphabet of M,D,I,H,N,P,S,X,=.
+ * \ingroup cigar
+ *
+ * \details
+ *
+ * The CIGAR string can be either basic or extended. The only difference in the
+ * extended cigar alphabet is that aligned bases are classified as an actual
+ * match ('=') or mismatch ('X'). In contrast, the basic cigar alphabet
+ * only indicated the aligned status with an 'M', without further
+ * information if the bases are actually equal or not.
+ *
+ * The main purpose of the seqan3::cigar_op alphabet is to be used in the
+ * seqan3::cigar composition, where a cigar operation is paired with a count
+ * value.
+ *
+ * Example usage:
+ * \snippet test/snippet/alphabet/cigar/cigar_op.cpp general
+ *
+ * \note Usually you do not want to manipulate cigar elements and vectors on
+ *       your own but convert an alignment to a cigar and back. See
+ *       seqan3::get_cigar_vector for how to convert two aligned sequences into
+ *       an cigar_vector.
+ */
+class cigar_op : public alphabet_base<cigar_op, 9, char>
+{
+private:
+	//!\brief The base class.
+	using base_t = alphabet_base<cigar_op, 9, char>;
+
+	//!\cond \brief Befriend seqan3::alphabet_base.
+	friend base_t;
+	//!\endcond
+
+public:
+	/*!\name Constructors, destructor and assignment
+     * \{
+     */
+    constexpr cigar_op() noexcept : base_t{} {}
+    constexpr cigar_op(cigar_op const &) = default;
+    constexpr cigar_op(cigar_op &&) = default;
+    constexpr cigar_op & operator=(cigar_op const &) = default;
+    constexpr cigar_op & operator=(cigar_op &&) = default;
+    ~cigar_op() = default;
+    //!\}
+
+protected:
+	//!\privatesection
+
+    //!\brief Value to char conversion table.
+	static constexpr char_type rank_to_char[value_size]
+	{
+		'M',
+		'D',
+		'I',
+		'S',
+		'H',
+		'N',
+		'P',
+		'X',
+		'='
+	};
+
+	//!\brief Char to value conversion table.
+	static constexpr std::array<rank_type, 256> char_to_rank
+	{
+		[] () constexpr
+		{
+			std::array<rank_type, 256> ret{};
+
+			// reverse mapping for characters
+			for (size_t rnk = 0u; rnk < value_size; ++rnk)
+			{
+				ret[rank_to_char[rnk] ] = rnk;
+			}
+
+			return ret;
+		}()
+	};
+};
+
+// ------------------------------------------------------------------
+// literals
+// ------------------------------------------------------------------
+
+/*!\name Literals
+ * \{
+ */
+
+/*!\brief The seqan3::cigar_op char literal.
+ * \relates seqan3::cigar_op
+ * \returns seqan3::cigar_op
+ */
+cigar_op operator""_cigar_op(char const c) noexcept
+{
+    return cigar_op{}.assign_char_strict(c);
+}
+//!\}
+} // namespace seqan3

--- a/include/seqan3/alphabet/cigar/cigar_op.hpp
+++ b/include/seqan3/alphabet/cigar/cigar_op.hpp
@@ -1,48 +1,16 @@
-// ============================================================================
-//                 SeqAn - The Library for Sequence Analysis
-// ============================================================================
-//
-// Copyright (c) 2006-2018, Knut Reinert & Freie Universitaet Berlin
-// Copyright (c) 2016-2018, Knut Reinert & MPI Molekulare Genetik
-// All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-//
-//     * Redistributions of source code must retain the above copyright
-//       notice, this list of conditions and the following disclaimer.
-//     * Redistributions in binary form must reproduce the above copyright
-//       notice, this list of conditions and the following disclaimer in the
-//       documentation and/or other materials provided with the distribution.
-//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
-//       its contributors may be used to endorse or promote products derived
-//       from this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
-// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
-// DAMAGE.
-//
-// ============================================================================
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
 
 /*!\file
  * \brief Introduces the cigar_op alphabet.
- * \author Svenja Mehringer <svenja.mehringer AT fu-berlin.de>
+ * \author Joshua Kim <joshua.kim AT fu-berlin.de>
  */
 
 #pragma once
-
-#include <array>
-#include <cassert>
-#include <cstdint>
-#include <type_traits>
 
 #include <seqan3/alphabet/detail/alphabet_base.hpp>
 
@@ -69,68 +37,68 @@ namespace seqan3
  * value.
  *
  * Example usage:
- * \snippet test/snippet/alphabet/cigar/cigar_op.cpp general
+ * \include test/snippet/alphabet/cigar/cigar_op.cpp
  *
  * \note Usually you do not want to manipulate cigar elements and vectors on
  *       your own but convert an alignment to a cigar and back. See
  *       seqan3::get_cigar_vector for how to convert two aligned sequences into
- *       an cigar_vector.
+ *       a cigar_vector.
  */
 class cigar_op : public alphabet_base<cigar_op, 9, char>
 {
 private:
-	//!\brief The base class.
-	using base_t = alphabet_base<cigar_op, 9, char>;
+    //!\brief The base class.
+    using base_t = alphabet_base<cigar_op, 9, char>;
 
-	//!\cond \brief Befriend seqan3::alphabet_base.
-	friend base_t;
-	//!\endcond
+    //!\cond \brief Befriend seqan3::alphabet_base.
+    friend base_t;
+    //!\endcond
 
 public:
-	/*!\name Constructors, destructor and assignment
+    /*!\name Constructors, destructor and assignment
      * \{
      */
-    constexpr cigar_op() noexcept : base_t{} {}
-    constexpr cigar_op(cigar_op const &) = default;
-    constexpr cigar_op(cigar_op &&) = default;
-    constexpr cigar_op & operator=(cigar_op const &) = default;
-    constexpr cigar_op & operator=(cigar_op &&) = default;
-    ~cigar_op() = default;
+    constexpr cigar_op()                             noexcept = default; //!< Defaulted.
+    constexpr cigar_op(cigar_op const &)             noexcept = default; //!< Defaulted.
+    constexpr cigar_op(cigar_op &&)                  noexcept = default; //!< Defaulted.
+    constexpr cigar_op & operator=(cigar_op const &) noexcept = default; //!< Defaulted.
+    constexpr cigar_op & operator=(cigar_op &&)      noexcept = default; //!< Defaulted.
+    ~cigar_op()                                      noexcept = default; //!< Defaulted.
     //!\}
 
 protected:
-	//!\privatesection
+    //!\privatesection
 
     //!\brief Value to char conversion table.
-	static constexpr char_type rank_to_char[value_size]
-	{
-		'M',
-		'D',
-		'I',
-		'S',
-		'H',
-		'N',
-		'P',
-		'X',
-		'='
-	};
+    static constexpr char_type rank_to_char[value_size]
+    {
+        'M',
+        'D',
+        'I',
+        'S',
+        'H',
+        'N',
+        'P',
+        'X',
+        '='
+    };
 
-	//!\brief Char to value conversion table.
-	static constexpr std::array<rank_type, 256> char_to_rank
-	{
-		[] () constexpr
-		{
-			std::array<rank_type, 256> ret{};
+    //!\brief Char to value conversion table.
+    static constexpr std::array<rank_type, 256> char_to_rank
+    {
+        [] () constexpr
+        {
+            std::array<rank_type, 256> ret{};
 
-			// reverse mapping for characters
-			for (size_t rnk = 0u; rnk < value_size; ++rnk)
-			{
-				ret[rank_to_char[rnk] ] = rnk;
-			}
+            // reverse mapping for characters
+            for (size_t rnk = 0u; rnk < value_size; ++rnk)
+            {
+            	ret[rank_to_char[rnk] ] = rnk;
+            }
 
-			return ret;
-		}()
-	};
+            return ret;
+        }()
+    };
 };
 
 // ------------------------------------------------------------------
@@ -145,9 +113,9 @@ protected:
  * \relates seqan3::cigar_op
  * \returns seqan3::cigar_op
  */
-cigar_op operator""_cigar_op(char const c) noexcept
+inline cigar_op operator""_cigar_op(char const c) noexcept
 {
-    return cigar_op{}.assign_char_strict(c);
+    return cigar_op{}.assign_char_strictly(c);
 }
 //!\}
 } // namespace seqan3

--- a/test/snippet/alphabet/cigar/cigar_op.cpp
+++ b/test/snippet/alphabet/cigar/cigar_op.cpp
@@ -1,27 +1,13 @@
 #include <seqan3/alphabet/cigar/cigar_op.hpp>
+#include <seqan3/io/stream/debug_stream.hpp>
 
-using namespace seqan3;
+using seqan3::operator""_cigar_op;
 
 int main()
 {
-//! [general]
 // Initialze an seqan3::cigar_op:
-cigar_op match{'M'_cigar_op};
+seqan3::cigar_op match{'M'_cigar_op};
 
-// Usually you want to use the cigar_op directly in a cigar element
-// cigar my_cigar_elem1{match, 20u};
-
-// you print cigar_op and cigar values:
-std::cout << match.to_char() << std::endl;          // M
-// std::cout << my_cigar_elem1 << std::endl; // 20M
-
-// You can also make your own cigar_vector and print it
-// cigar my_cigar_elem2{cigar_op::D, 5u};
-// cigar my_cigar_elem3{cigar_op::M, 10u};
-//
-// cigar_vector my_cigar_vector{my_cigar_elem1, my_cigar_elem2, my_cigar_elem3};
-//
-// std::cout << my_cigar_vector << std::endl; // 20M5D10M
-// }
-//! [general]
+// you can print cigar_op values:
+seqan3::debug_stream << match << std::endl;          // M
 }

--- a/test/snippet/alphabet/cigar/cigar_op.cpp
+++ b/test/snippet/alphabet/cigar/cigar_op.cpp
@@ -1,0 +1,27 @@
+#include <seqan3/alphabet/cigar/cigar_op.hpp>
+
+using namespace seqan3;
+
+int main()
+{
+//! [general]
+// Initialze an seqan3::cigar_op:
+cigar_op match{'M'_cigar_op};
+
+// Usually you want to use the cigar_op directly in a cigar element
+// cigar my_cigar_elem1{match, 20u};
+
+// you print cigar_op and cigar values:
+std::cout << match.to_char() << std::endl;          // M
+// std::cout << my_cigar_elem1 << std::endl; // 20M
+
+// You can also make your own cigar_vector and print it
+// cigar my_cigar_elem2{cigar_op::D, 5u};
+// cigar my_cigar_elem3{cigar_op::M, 10u};
+//
+// cigar_vector my_cigar_vector{my_cigar_elem1, my_cigar_elem2, my_cigar_elem3};
+//
+// std::cout << my_cigar_vector << std::endl; // 20M5D10M
+// }
+//! [general]
+}

--- a/test/unit/alphabet/cigar/CMakeLists.txt
+++ b/test/unit/alphabet/cigar/CMakeLists.txt
@@ -1,0 +1,1 @@
+seqan3_test(cigar_op_test.cpp)

--- a/test/unit/alphabet/cigar/cigar_op_test.cpp
+++ b/test/unit/alphabet/cigar/cigar_op_test.cpp
@@ -1,0 +1,44 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+#include "../alphabet_test_template.hpp"
+#include "../alphabet_constexpr_test_template.hpp"
+#include <seqan3/alphabet/cigar/cigar_op.hpp>
+
+INSTANTIATE_TYPED_TEST_CASE_P(cigar_op, alphabet, cigar_op);
+INSTANTIATE_TYPED_TEST_CASE_P(cigar_op, alphabet_constexpr, cigar_op);
+
+TEST(cigar_op, to_char_assign_char)
+{
+	EXPECT_EQ(to_char(cigar_op{}.assign_char('M')), 'M');
+	EXPECT_EQ(to_char(cigar_op{}.assign_char('D')), 'D');
+	EXPECT_EQ(to_char(cigar_op{}.assign_char('I')), 'I');
+	EXPECT_EQ(to_char(cigar_op{}.assign_char('S')), 'S');
+	EXPECT_EQ(to_char(cigar_op{}.assign_char('H')), 'H');
+	EXPECT_EQ(to_char(cigar_op{}.assign_char('N')), 'N');
+	EXPECT_EQ(to_char(cigar_op{}.assign_char('P')), 'P');
+	EXPECT_EQ(to_char(cigar_op{}.assign_char('X')), 'X');
+	EXPECT_EQ(to_char(cigar_op{}.assign_char('=')), '=');
+}
+
+TEST(cigar_op, char_literal)
+{
+	EXPECT_EQ(to_char(cigar_op{'M'_cigar_op}), 'M');
+	EXPECT_EQ(to_char(cigar_op{'D'_cigar_op}), 'D');
+	EXPECT_EQ(to_char(cigar_op{'I'_cigar_op}), 'I');
+	EXPECT_EQ(to_char(cigar_op{'S'_cigar_op}), 'S');
+	EXPECT_EQ(to_char(cigar_op{'H'_cigar_op}), 'H');
+	EXPECT_EQ(to_char(cigar_op{'N'_cigar_op}), 'N');
+	EXPECT_EQ(to_char(cigar_op{'P'_cigar_op}), 'P');
+	EXPECT_EQ(to_char(cigar_op{'X'_cigar_op}), 'X');
+	EXPECT_EQ(to_char(cigar_op{'='_cigar_op}), '=');
+}
+
+TEST(cigar_op, assign_char_strict)
+{
+	EXPECT_THROW(cigar_op{}.assign_char_strict('A'), invalid_char_assignment);
+}

--- a/test/unit/alphabet/cigar/cigar_op_test.cpp
+++ b/test/unit/alphabet/cigar/cigar_op_test.cpp
@@ -40,5 +40,5 @@ TEST(cigar_op, char_literal)
 
 TEST(cigar_op, assign_char_strict)
 {
-	EXPECT_THROW(cigar_op{}.assign_char_strict('A'), invalid_char_assignment);
+	EXPECT_THROW(cigar_op{}.assign_char_strictly('A'), invalid_char_assignment);
 }

--- a/test/unit/alphabet/cigar/cigar_op_test.cpp
+++ b/test/unit/alphabet/cigar/cigar_op_test.cpp
@@ -2,8 +2,10 @@
 // Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
 // Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
 // This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
-// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 // -----------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
 
 #include "../alphabet_test_template.hpp"
 #include "../alphabet_constexpr_test_template.hpp"
@@ -14,31 +16,24 @@ INSTANTIATE_TYPED_TEST_CASE_P(cigar_op, alphabet_constexpr, cigar_op);
 
 TEST(cigar_op, to_char_assign_char)
 {
-	EXPECT_EQ(to_char(cigar_op{}.assign_char('M')), 'M');
-	EXPECT_EQ(to_char(cigar_op{}.assign_char('D')), 'D');
-	EXPECT_EQ(to_char(cigar_op{}.assign_char('I')), 'I');
-	EXPECT_EQ(to_char(cigar_op{}.assign_char('S')), 'S');
-	EXPECT_EQ(to_char(cigar_op{}.assign_char('H')), 'H');
-	EXPECT_EQ(to_char(cigar_op{}.assign_char('N')), 'N');
-	EXPECT_EQ(to_char(cigar_op{}.assign_char('P')), 'P');
-	EXPECT_EQ(to_char(cigar_op{}.assign_char('X')), 'X');
-	EXPECT_EQ(to_char(cigar_op{}.assign_char('=')), '=');
+    for (char chr : std::string{"MDISHNPX="})
+        EXPECT_EQ(to_char(cigar_op{}.assign_char(chr)), chr);
 }
 
 TEST(cigar_op, char_literal)
 {
-	EXPECT_EQ(to_char(cigar_op{'M'_cigar_op}), 'M');
-	EXPECT_EQ(to_char(cigar_op{'D'_cigar_op}), 'D');
-	EXPECT_EQ(to_char(cigar_op{'I'_cigar_op}), 'I');
-	EXPECT_EQ(to_char(cigar_op{'S'_cigar_op}), 'S');
-	EXPECT_EQ(to_char(cigar_op{'H'_cigar_op}), 'H');
-	EXPECT_EQ(to_char(cigar_op{'N'_cigar_op}), 'N');
-	EXPECT_EQ(to_char(cigar_op{'P'_cigar_op}), 'P');
-	EXPECT_EQ(to_char(cigar_op{'X'_cigar_op}), 'X');
-	EXPECT_EQ(to_char(cigar_op{'='_cigar_op}), '=');
+    EXPECT_EQ(to_char(cigar_op{'M'_cigar_op}), 'M');
+    EXPECT_EQ(to_char(cigar_op{'D'_cigar_op}), 'D');
+    EXPECT_EQ(to_char(cigar_op{'I'_cigar_op}), 'I');
+    EXPECT_EQ(to_char(cigar_op{'S'_cigar_op}), 'S');
+    EXPECT_EQ(to_char(cigar_op{'H'_cigar_op}), 'H');
+    EXPECT_EQ(to_char(cigar_op{'N'_cigar_op}), 'N');
+    EXPECT_EQ(to_char(cigar_op{'P'_cigar_op}), 'P');
+    EXPECT_EQ(to_char(cigar_op{'X'_cigar_op}), 'X');
+    EXPECT_EQ(to_char(cigar_op{'='_cigar_op}), '=');
 }
 
 TEST(cigar_op, assign_char_strict)
 {
-	EXPECT_THROW(cigar_op{}.assign_char_strictly('A'), invalid_char_assignment);
+    EXPECT_THROW(cigar_op{}.assign_char_strictly('A'), invalid_char_assignment);
 }


### PR DESCRIPTION
Adds the cigar alphabet, starting with cigar_op.

Fixes #887