### PR TITLE
[FEATURE] cereal

### DIFF
--- a/doc/tutorial/read_mapper/index.md
+++ b/doc/tutorial/read_mapper/index.md
@@ -69,7 +69,7 @@ Your `main` may look like this:
 \endsolution
 
 ## Step 2 - Reading the input
-As a next step, we want to use the parsed file name to read in our reference data. This will be done 
+As a next step, we want to use the parsed file name to read in our reference data. This will be done
 using seqan3::sequence_file_input class. As a guide, you can take a look at the
 \ref tutorial_sequence_file "Sequence I/O Tutorial".
 
@@ -112,7 +112,7 @@ Now that we have the necessary sequence information, we can create an index and 
 We want to create a new function `create_index`:
 * It takes `index_path` and `storage` as parameters
 * Creates a bi_fm_index
-* Stores the bi_fm_index (you may want to `throw` if this fails)
+* Stores the bi_fm_index
 
 We also need to change:
 * `run_program` to now also call `create_index`
@@ -127,7 +127,7 @@ This is the signature of `create_index`:
 \snippet doc/tutorial/read_mapper/read_mapper_indexer_step3.cpp solution
 Here is the complete program:
 \hint
-\include doc/tutorial/read_mapper/read_mapper_indexer_step3.cpp
+\snippet doc/tutorial/read_mapper/read_mapper_indexer_step3.cpp complete
 \endhint
 \endsolution
 
@@ -191,7 +191,7 @@ This is the signature of `map_reads`:
 \snippet doc/tutorial/read_mapper/read_mapper_step2.cpp solution
 Here is the complete program:
 \hint
-\include doc/tutorial/read_mapper/read_mapper_step2.cpp
+\snippet doc/tutorial/read_mapper/read_mapper_step2.cpp complete
 \endhint
 \endsolution
 
@@ -213,7 +213,7 @@ This is the alignment config:
 \snippet doc/tutorial/read_mapper/read_mapper_step3.cpp solution
 Here is the complete program:
 \hint
-\include doc/tutorial/read_mapper/read_mapper_step3.cpp
+\snippet doc/tutorial/read_mapper/read_mapper_step3.cpp complete
 \endhint
 \endsolution
 
@@ -236,6 +236,6 @@ This is the alignment_file_output construction:
 \snippet doc/tutorial/read_mapper/read_mapper_step4.cpp solution
 Here is the complete program:
 \hint
-\include doc/tutorial/read_mapper/read_mapper_step4.cpp
+\snippet doc/tutorial/read_mapper/read_mapper_step4.cpp complete
 \endhint
 \endsolution

--- a/doc/tutorial/read_mapper/read_mapper_indexer_step3.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_indexer_step3.cpp
@@ -1,3 +1,10 @@
+#include <seqan3/core/platform.hpp>
+#if SEQAN3_WITH_CEREAL
+//![complete]
+#include <fstream>
+
+#include <cereal/archives/binary.hpp>
+
 #include <seqan3/argument_parser/all.hpp>
 #include <seqan3/io/sequence_file/input.hpp>
 #include <seqan3/io/stream/debug_stream.hpp>
@@ -30,8 +37,11 @@ void create_index(std::filesystem::path const & index_path,
 //! [create_index]
 {
     bi_fm_index index{storage.seqs};
-    if (!index.store(index_path))
-        throw std::runtime_error{"Could not store the index"};
+    {
+        std::ofstream os{index_path, std::ios::binary};
+        cereal::BinaryOutputArchive oarchive{os};
+        oarchive(index);
+    }
 }
 
 void run_program(std::filesystem::path const & reference_path,
@@ -81,3 +91,5 @@ int main(int argc, char const ** argv)
 
     return 0;
 }
+//![complete]
+#endif //SEQAN3_WITH_CEREAL

--- a/doc/tutorial/read_mapper/read_mapper_step2.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_step2.cpp
@@ -1,3 +1,10 @@
+#include <seqan3/core/platform.hpp>
+#if SEQAN3_WITH_CEREAL
+//![complete]
+#include <fstream>
+
+#include <cereal/archives/binary.hpp>
+
 #include <seqan3/argument_parser/all.hpp>
 #include <seqan3/io/sequence_file/input.hpp>
 #include <seqan3/io/stream/debug_stream.hpp>
@@ -32,8 +39,11 @@ void map_reads(std::filesystem::path const & query_path,
 //! [map_reads]
 {
     bi_fm_index<std::vector<std::vector<dna5>>> index;
-    if (!index.load(index_path))
-        throw std::runtime_error{"Could not load index"};
+    {
+        std::ifstream is{index_path, std::ios::binary};
+        cereal::BinaryInputArchive iarchive{is};
+        iarchive(index);
+    }
 
     sequence_file_input query_in{query_path};
 
@@ -110,3 +120,5 @@ int main(int argc, char const ** argv)
 
     return 0;
 }
+//![complete]
+#endif //SEQAN3_WITH_CEREAL

--- a/doc/tutorial/read_mapper/read_mapper_step3.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_step3.cpp
@@ -1,3 +1,10 @@
+#include <seqan3/core/platform.hpp>
+#if SEQAN3_WITH_CEREAL
+//![complete]
+#include <fstream>
+
+#include <cereal/archives/binary.hpp>
+
 #include <seqan3/alignment/configuration/all.hpp>
 #include <seqan3/alignment/pairwise/align_pairwise.hpp>
 #include <seqan3/argument_parser/all.hpp>
@@ -33,8 +40,11 @@ void map_reads(std::filesystem::path const & query_path,
                uint8_t const errors)
 {
     bi_fm_index<std::vector<std::vector<dna5>>> index;
-    if (!index.load(index_path))
-        throw std::runtime_error{"Could not load index"};
+    {
+        std::ifstream is{index_path, std::ios::binary};
+        cereal::BinaryInputArchive iarchive{is};
+        iarchive(index);
+    }
 
     sequence_file_input query_in{query_path};
 
@@ -128,3 +138,5 @@ int main(int argc, char const ** argv)
 
     return 0;
 }
+//![complete]
+#endif //SEQAN3_WITH_CEREAL

--- a/doc/tutorial/read_mapper/read_mapper_step4.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_step4.cpp
@@ -1,3 +1,10 @@
+#include <seqan3/core/platform.hpp>
+#if SEQAN3_WITH_CEREAL
+//![complete]
+#include <fstream>
+
+#include <cereal/archives/binary.hpp>
+
 #include <seqan3/alignment/configuration/all.hpp>
 #include <seqan3/alignment/pairwise/align_pairwise.hpp>
 #include <seqan3/argument_parser/all.hpp>
@@ -34,8 +41,11 @@ void map_reads(std::filesystem::path const & query_path,
                uint8_t const errors)
 {
     bi_fm_index<std::vector<std::vector<dna5>>> index;
-    if (!index.load(index_path))
-        throw std::runtime_error{"Could not load index"};
+    {
+        std::ifstream is{index_path, std::ios::binary};
+        cereal::BinaryInputArchive iarchive{is};
+        iarchive(index);
+    }
 
     sequence_file_input query_in{query_path};
 
@@ -135,3 +145,5 @@ int main(int argc, char const ** argv)
 
     return 0;
 }
+//![complete]
+#endif //SEQAN3_WITH_CEREAL

--- a/doc/tutorial/search/index.md
+++ b/doc/tutorial/search/index.md
@@ -71,9 +71,7 @@ You can also index text collections (e.g. genomes with multiple chromosomes or p
 
 \snippet doc/tutorial/search/search_small_snippets.cpp text_collection
 
-The indices can also be stored and loaded from disk.<br>
-Both seqan3::fm_index::store and seqan3::fm_index::load return a `bool` indicating whether the operation was
-successful.
+The indices can also be stored and loaded from disk by using cereal.
 
 \snippet doc/tutorial/search/search_small_snippets.cpp store
 
@@ -88,15 +86,14 @@ You are given the text
 dna4_vector text{"CGCTGTCTGAAGGATGAGTGTCAGCCAGTGTAACCCGATGAGCTACCCAGTAGTCGAACTGGGCCAGACAACCCGGCGCTAATGCACTCA"_dna4};
 \endcode
 Create a seqan3::fm_index over the reference, store the index and load the index into a new seqan3::fm_index object.
-Print whether the store and load operations were successful.
+Print whether the indices are identical or differ.
 \endassignment
 
 \solution
 \snippet doc/tutorial/search/search_solution1.cpp solution
 **Expected output:**
 ```console
-Index stored successfully.
-Index loaded successfully.
+The indices are identical!
 ```
 \endsolution
 

--- a/doc/tutorial/search/search_small_snippets.cpp
+++ b/doc/tutorial/search/search_small_snippets.cpp
@@ -1,8 +1,11 @@
 #include "cleanup.hpp"
 seqan3::cleanup index_file{"index.file"};
-seqan3::cleanup index_file_tb{"index.file.tb"};
-seqan3::cleanup index_file_tbrs{"index.file.tbrs"};
-seqan3::cleanup index_file_tbss{"index.file.tbss"};
+
+#if SEQAN3_WITH_CEREAL
+#include <fstream>
+
+#include <cereal/archives/binary.hpp>
+#endif //SEQAN3_WITH_CEREAL
 
 #include <seqan3/io/stream/debug_stream.hpp>
 #include <seqan3/search/algorithm/search.hpp>
@@ -26,20 +29,34 @@ bi_fm_index bi_index{text};
 //![text_collection]
 }
 
+#if SEQAN3_WITH_CEREAL
 {
 //![store]
+#include <fstream>                                  // for writing/reading files
+
+#include <cereal/archives/binary.hpp>               // for storing/loading indices via cereal
+
 std::string text{"Garfield the fat cat without a hat."};
 fm_index index{text};
-index.store("index.file");
+{
+    std::ofstream os{"index.file", std::ios::binary};
+    cereal::BinaryOutputArchive oarchive{os};
+    oarchive(index);
+}
 //![store]
 }
 
 {
 //![load]
 fm_index<std::string> index; // we need to specify the type manually
-index.load("index.file");
+{
+    std::ifstream is{"index.file", std::ios::binary};
+    cereal::BinaryInputArchive iarchive{is};
+    iarchive(index);
+}
 //![load]
 }
+#endif //SEQAN3_WITH_CEREAL
 
 {
 //![error_search]

--- a/doc/tutorial/search/search_solution1.cpp
+++ b/doc/tutorial/search/search_solution1.cpp
@@ -1,10 +1,13 @@
+#if SEQAN3_WITH_CEREAL
+
 #include "cleanup.hpp"
 seqan3::cleanup index_file{"index.file"};
-seqan3::cleanup index_file_tb{"index.file.tb"};
-seqan3::cleanup index_file_tbrs{"index.file.tbrs"};
-seqan3::cleanup index_file_tbss{"index.file.tbss"};
 
 //![solution]
+#include <fstream>
+
+#include <cereal/archives/binary.hpp>
+
 #include <seqan3/search/fm_index/fm_index.hpp>
 
 using namespace seqan3;
@@ -14,16 +17,23 @@ int main()
     dna4_vector text{"CGCTGTCTGAAGGATGAGTGTCAGCCAGTGTAACCCGATGAGCTACCCAGTAGTCGAACTGGGCCAGACAACCCGGCGCTAATGCACTCA"_dna4};
     fm_index index{text};
 
-    if (index.store("index.file"))
-        std::cout << "Index stored successfully.\n";
-    else
-        std::cout << "Index could not be stored.\n";
+    {
+        std::ofstream os{"index.file", std::ios::binary};
+        cereal::BinaryOutputArchive oarchive{os};
+        oarchive(index);
+    }
 
     fm_index<dna4_vector> index2;
+    {
+        std::ifstream is{"index.file", std::ios::binary};
+        cereal::BinaryInputArchive iarchive{is};
+        iarchive(index2);
+    }
 
-    if (index2.load("index.file"))
-        std::cout << "Index loaded successfully.\n";
+    if (index == index2)
+        std::cout << "The indices are identical!\n";
     else
-        std::cout << "Index could not be loaded.\n";
+        std::cout << "The indices differ!\n";
 }
 //![solution]
+#endif //SEQAN3_WITH_CEREAL

--- a/include/seqan3/core/concept/cereal.hpp
+++ b/include/seqan3/core/concept/cereal.hpp
@@ -142,7 +142,9 @@ SEQAN3_CONCEPT Cerealisable =
     cereal::traits::is_input_serializable<value_t, input_archive_t>::value &&
     cereal::traits::is_output_serializable<value_t, output_archive_t>::value;
 #else
-template <typename t>
+template <typename value_t,
+          typename input_archive_t = void,
+          typename output_archive_t = void>
 SEQAN3_CONCEPT Cerealisable = false;
 #endif
 //!\endcond

--- a/include/seqan3/search/fm_index/bi_fm_index.hpp
+++ b/include/seqan3/search/fm_index/bi_fm_index.hpp
@@ -264,17 +264,37 @@ public:
         return size() == 0;
     }
 
-    // operator== not implemented by sdsl indices yet
-    // bool operator==(fm_index const & rhs) const noexcept
-    // {
-    //     return std::tie(fwd_fm, rev_fm) == std::tie(rhs.fwd_fm, rhs.rev_fm);
-    // }
+    /*!\brief Compares two indices.
+     * \returns `true` if the indices are equal, false otherwise.
+     *
+     * ### Complexity
+     *
+     * Linear.
+     *
+     * ### Exceptions
+     *
+     * No-throw guarantee.
+     */
+    bool operator==(bi_fm_index const & rhs) const noexcept
+    {
+        return std::tie(fwd_fm, rev_fm) == std::tie(rhs.fwd_fm, rhs.rev_fm);
+    }
 
-    // operator== not implemented by sdsl indices yet
-    // bool operator!=(fm_index const & rhs) const noexcept
-    // {
-    //     return !(*this == rhs);
-    // }
+    /*!\brief Compares two indices.
+     * \returns `true` if the indices are unequal, false otherwise.
+     *
+     * ### Complexity
+     *
+     * Linear.
+     *
+     * ### Exceptions
+     *
+     * No-throw guarantee.
+     */
+    bool operator!=(bi_fm_index const & rhs) const noexcept
+    {
+        return !(*this == rhs);
+    }
 
     /*!\brief Returns a seqan3::bi_fm_index_cursor on the index that can be used for searching.
      *        \if DEV
@@ -331,48 +351,20 @@ public:
        return {rev_fm};
     }
 
-    /*!\brief Loads the index from disk. Temporary function until cereal is supported.
-     *        \todo cereal
-     * \returns `true` if the index was successfully loaded from disk.
+    /*!\cond DEV
+     * \brief Serialisation support function.
+     * \tparam archive_t Type of `archive`; must satisfy seqan3::CerealArchive.
+     * \param archive The archive being serialised from/to.
      *
-     * ### Complexity
-     *
-     * Linear.
-     *
-     * ### Exceptions
-     *
-     * Strong exception guarantee.
+     * \attention These functions are never called directly, see \ref serialisation for more details.
      */
-    bool load(std::filesystem::path const & path)
+    template <CerealArchive archive_t>
+    void CEREAL_SERIALIZE_FUNCTION_NAME(archive_t & archive)
     {
-        std::filesystem::path path_fwd{path};
-        std::filesystem::path path_rev{path};
-        path_fwd += std::filesystem::path{".fwd"};
-        path_rev += std::filesystem::path{".rev"};
-        return fwd_fm.load(path_fwd) && rev_fm.load(path_rev);
+        archive(fwd_fm);
+        archive(rev_fm);
     }
-
-    /*!\brief Stores the index to disk. Temporary function until cereal is supported.
-     *        \todo cereal
-     * \returns `true` if the index was successfully stored to disk.
-     *
-     * ### Complexity
-     *
-     * Linear.
-     *
-     * ### Exceptions
-     *
-     * Strong exception guarantee.
-     */
-    bool store(std::filesystem::path const & path) const
-    {
-        std::filesystem::path path_fwd{path};
-        std::filesystem::path path_rev{path};
-        path_fwd += std::filesystem::path{".fwd"};
-        path_rev += std::filesystem::path{".rev"};
-        return fwd_fm.store(path_fwd) && rev_fm.store(path_rev);
-    }
-
+    //!\endcond
 };
 
 //!\}

--- a/include/seqan3/search/fm_index/concept.hpp
+++ b/include/seqan3/search/fm_index/concept.hpp
@@ -142,9 +142,6 @@ SEQAN3_CONCEPT FmIndex = std::Semiregular<t> && requires (t index)
 
     { index.size()  } -> typename t::size_type;
     { index.empty() } -> bool;
-
-    { index.load(std::string{})  } -> bool;
-    { index.store(std::string{}) } -> bool;
 };
 //!\endcond
 /*!\name Requirements for seqan3::FmIndex

--- a/include/seqan3/search/fm_index/detail/csa_alphabet_strategy.hpp
+++ b/include/seqan3/search/fm_index/detail/csa_alphabet_strategy.hpp
@@ -162,6 +162,30 @@ namespace sdsl
             m_C.load(in);
             read_member(m_sigma, in);
         }
+
+        template <typename archive_t>
+        void CEREAL_SAVE_FUNCTION_NAME(archive_t & ar) const
+        {
+            ar(CEREAL_NVP(m_C));
+            ar(CEREAL_NVP(m_sigma));
+        }
+
+        template <typename archive_t>
+        void CEREAL_LOAD_FUNCTION_NAME(archive_t & ar)
+        {
+            ar(CEREAL_NVP(m_C));
+            ar(CEREAL_NVP(m_sigma));
+        }
+
+        bool operator==(plain_byte_alphabet const & other) const noexcept
+        {
+            return (m_C == other.m_C) && (m_sigma == other.m_sigma);
+        }
+
+        bool operator!=(plain_byte_alphabet const & other) const noexcept
+        {
+            return !(*this == other);
+        }
         //!\endcond
     };
 

--- a/include/seqan3/search/fm_index/fm_index.hpp
+++ b/include/seqan3/search/fm_index/fm_index.hpp
@@ -388,17 +388,38 @@ public:
         return size() == 0;
     }
 
-    // operator== not implemented by sdsl indices yet
-    // bool operator==(fm_index const & rhs) const noexcept
-    // {
-    //     return index == rhs.index;
-    // }
+    /*!\brief Compares two indices.
+     * \returns `true` if the indices are equal, false otherwise.
+     *
+     * ### Complexity
+     *
+     * Linear.
+     *
+     * ### Exceptions
+     *
+     * No-throw guarantee.
+     */
+    bool operator==(fm_index const & rhs) const noexcept
+    {
+        // (void) rhs;
+        return (index == rhs.index) && (text_begin == rhs.text_begin);
+    }
 
-    // operator== not implemented by sdsl indices yet
-    // bool operator!=(fm_index const & rhs) const noexcept
-    // {
-    //     return !(*this == rhs);
-    // }
+    /*!\brief Compares two indices.
+     * \returns `true` if the indices are unequal, false otherwise.
+     *
+     * ### Complexity
+     *
+     * Linear.
+     *
+     * ### Exceptions
+     *
+     * No-throw guarantee.
+     */
+    bool operator!=(fm_index const & rhs) const noexcept
+    {
+        return !(*this == rhs);
+    }
 
     /*!\brief Returns a seqan3::fm_index_cursor on the index that can be used for searching.
      *        \if DEV
@@ -419,74 +440,24 @@ public:
         return {*this};
     }
 
-    /*!\brief Loads the index from disk. Temporary function until cereal is supported.
-     *        \todo cereal
-     * \returns `true` if the index was successfully loaded from disk.
+    /*!\cond DEV
+     * \brief Serialisation support function.
+     * \tparam archive_t Type of `archive`; must satisfy seqan3::CerealArchive.
+     * \param archive The archive being serialised from/to.
      *
-     * ### Complexity
-     *
-     * Linear.
-     *
-     * ### Exceptions
-     *
-     * Strong exception guarantee.
+     * \attention These functions are never called directly, see \ref serialisation for more details.
      */
-    bool load(std::filesystem::path const & path)
+    template <CerealArchive archive_t>
+    void CEREAL_SERIALIZE_FUNCTION_NAME(archive_t & archive)
     {
-        std::filesystem::path tb_path{path};
-        std::filesystem::path tb_ss_path{path};
-        std::filesystem::path tb_rs_path{path};
-        tb_path += ".tb";
-        tb_ss_path += ".tbss";
-        tb_rs_path += ".tbrs";
-
-        sdsl_index_type tmp_index;
-        sdsl::sd_vector<> tmp_text_begin;
-        sdsl::select_support_sd<1> tmp_text_begin_ss;
-        sdsl::rank_support_sd<1> tmp_text_begin_rs;
-
-        if (sdsl::load_from_file(tmp_index, path) &&
-            sdsl::load_from_file(tmp_text_begin, tb_path) &&
-            sdsl::load_from_file(tmp_text_begin_ss, tb_ss_path) &&
-            sdsl::load_from_file(tmp_text_begin_rs, tb_rs_path))
-        {
-            std::swap(this->index, tmp_index);
-            std::swap(this->text_begin, tmp_text_begin);
-            std::swap(this->text_begin_ss, tmp_text_begin_ss);
-            std::swap(this->text_begin_rs, tmp_text_begin_rs);
-            text_begin_ss.set_vector(&text_begin);
-            text_begin_rs.set_vector(&text_begin);
-            return true;
-        }
-        return false;
+        archive(index);
+        archive(text_begin);
+        archive(text_begin_ss);
+        text_begin_ss.set_vector(&text_begin);
+        archive(text_begin_rs);
+        text_begin_rs.set_vector(&text_begin);
     }
-
-    /*!\brief Stores the index to disk. Temporary function until cereal is supported.
-     *        \todo cereal
-     * \returns `true` if the index was successfully stored to disk.
-     *
-     * ### Complexity
-     *
-     * Linear.
-     *
-     * ### Exceptions
-     *
-     * Strong exception guarantee.
-     */
-    bool store(std::filesystem::path const & path) const
-    {
-        std::filesystem::path tb_path{path};
-        std::filesystem::path tb_ss_path{path};
-        std::filesystem::path tb_rs_path{path};
-        tb_path += ".tb";
-        tb_ss_path += ".tbss";
-        tb_rs_path += ".tbrs";
-
-        return sdsl::store_to_file(index, path) &&
-               sdsl::store_to_file(text_begin, tb_path) &&
-               sdsl::store_to_file(text_begin_ss, tb_ss_path) &&
-               sdsl::store_to_file(text_begin_rs, tb_rs_path);
-    }
+    //!\endcond
 
 };
 

--- a/test/include/seqan3/test/cereal.hpp
+++ b/test/include/seqan3/test/cereal.hpp
@@ -1,0 +1,88 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides cereal functionality for tests.
+ * \author Enrico Seiler <enrico.seiler AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <fstream>
+
+#include <seqan3/core/concept/cereal.hpp>
+#include <seqan3/core/metafunction/basic.hpp>
+#include <seqan3/core/platform.hpp>
+#include <seqan3/test/tmp_filename.hpp>
+
+#if SEQAN3_WITH_CEREAL
+#include <cereal/archives/binary.hpp>
+#include <cereal/archives/json.hpp>
+#include <cereal/archives/portable_binary.hpp>
+#include <cereal/archives/xml.hpp>
+#include <cereal/types/vector.hpp>
+#endif // SEQAN3_WITH_CEREAL
+
+namespace seqan3
+{
+
+namespace test
+{
+//!\cond DEV
+/*!\brief Tests if an object is cerealisable.
+ * \tparam in_archive_t  Type of the cereal input archive. Must model seqan3::CerealInputArchive.
+ * \tparam out_archive_t Type of the cereal output archive. Must model seqan3::CerealOutputArchive.
+ * \tparam value_t       The type to cerealise. Must model seqan3::Cerealisable.
+ * \param l The object to cerealise.
+ */
+template <CerealInputArchive in_archive_t, CerealOutputArchive out_archive_t, typename value_t>
+//!\cond
+    requires Cerealisable<value_t, in_archive_t, out_archive_t>
+//!\endcond
+void do_cerealisation(value_t && l)
+{
+    tmp_filename filename{"cereal_test"};
+
+    {
+        std::ofstream os{filename.get_path(), std::ios::binary};
+        out_archive_t oarchive{os};
+        oarchive(l);
+    }
+
+    {
+        remove_cvref_t<value_t> in_l{};
+        std::ifstream is{filename.get_path(), std::ios::binary};
+        in_archive_t iarchive{is};
+        iarchive(in_l);
+        EXPECT_EQ(l, in_l);
+    }
+}
+
+/*!\brief Tests if an object is serialise for all cereal archive types.
+ * \tparam value_t The type to serialise.
+ * \param l The object to serialise.
+ *
+ * If cereal is **not** available, this function is a NOP.
+ * Otherwise it will call do_cerealisation() with cereal's `Binary`, `PortableBinary`, `JSON` and `XML` archives.
+ */
+template <typename value_t>
+void do_serialisation([[maybe_unused]] value_t && l)
+{
+#if SEQAN3_WITH_CEREAL
+    do_cerealisation<cereal::BinaryInputArchive,         cereal::BinaryOutputArchive>        (l);
+    do_cerealisation<cereal::PortableBinaryInputArchive, cereal::PortableBinaryOutputArchive>(l);
+    do_cerealisation<cereal::JSONInputArchive,           cereal::JSONOutputArchive>          (l);
+    do_cerealisation<cereal::XMLInputArchive,            cereal::XMLOutputArchive>           (l);
+#endif // SEQAN3_WITH_CEREAL
+}
+//!\endcond
+
+} // namespace seqan3::test
+
+} //namespace seqan3

--- a/test/unit/alignment/gap_scheme_test.cpp
+++ b/test/unit/alignment/gap_scheme_test.cpp
@@ -13,17 +13,7 @@
 
 #include <seqan3/alignment/scoring/gap_scheme.hpp>
 #include <seqan3/alignment/scoring/gap_scheme_concept.hpp>
-
-#if SEQAN3_WITH_CEREAL
-#include <seqan3/test/tmp_filename.hpp>
-
-#include <fstream>
-
-#include <cereal/archives/binary.hpp>
-#include <cereal/archives/json.hpp>
-#include <cereal/archives/portable_binary.hpp>
-#include <cereal/archives/xml.hpp>
-#endif // SEQAN3_WITH_CEREAL
+#include <seqan3/test/cereal.hpp>
 
 using namespace seqan3;
 
@@ -141,44 +131,13 @@ TEST(gap_scheme, score)
     EXPECT_EQ(scheme.score(5), -21);
 }
 
-#if SEQAN3_WITH_CEREAL
-template <typename in_archive_t, typename out_archive_t, typename TypeParam>
-void do_serialisation(TypeParam const l)
-{
-    // This makes sure the file is also deleted if an exception is thrown in one of the tests below
-    // Generate unique file name.
-    test::tmp_filename filename{"scoring_scheme_cereal_test"};
-
-    {
-        std::ofstream os{filename.get_path(), std::ios::binary};
-        out_archive_t oarchive{os};
-        oarchive(l);
-    }
-
-    {
-        TypeParam in_l{};
-        std::ifstream is{filename.get_path(), std::ios::binary};
-        in_archive_t iarchive{is};
-        iarchive(in_l);
-        EXPECT_EQ(l, in_l);
-    }
-}
-
 TEST(gap_scheme, serialisation)
 {
     gap_scheme scheme1;
+    
     scheme1.set_linear(gap_score{-3});
-
-    do_serialisation<cereal::BinaryInputArchive,         cereal::BinaryOutputArchive>        (scheme1);
-    do_serialisation<cereal::PortableBinaryInputArchive, cereal::PortableBinaryOutputArchive>(scheme1);
-    do_serialisation<cereal::JSONInputArchive,           cereal::JSONOutputArchive>          (scheme1);
-    do_serialisation<cereal::XMLInputArchive,            cereal::XMLOutputArchive>           (scheme1);
+    test::do_serialisation(scheme1);
 
     scheme1.set_affine(gap_score{-3}, gap_open_score{-6});
-
-    do_serialisation<cereal::BinaryInputArchive,         cereal::BinaryOutputArchive>        (scheme1);
-    do_serialisation<cereal::PortableBinaryInputArchive, cereal::PortableBinaryOutputArchive>(scheme1);
-    do_serialisation<cereal::JSONInputArchive,           cereal::JSONOutputArchive>          (scheme1);
-    do_serialisation<cereal::XMLInputArchive,            cereal::XMLOutputArchive>           (scheme1);
+    test::do_serialisation(scheme1);
 }
-#endif // SEQAN3_WITH_CEREAL

--- a/test/unit/alignment/scoring_scheme_test.cpp
+++ b/test/unit/alignment/scoring_scheme_test.cpp
@@ -18,17 +18,7 @@
 #include <seqan3/alphabet/nucleotide/all.hpp>
 #include <seqan3/alphabet/quality/all.hpp>
 #include <seqan3/core/type_list.hpp>
-
-#if SEQAN3_WITH_CEREAL
-#include <seqan3/test/tmp_filename.hpp>
-
-#include <fstream>
-
-#include <cereal/archives/binary.hpp>
-#include <cereal/archives/json.hpp>
-#include <cereal/archives/portable_binary.hpp>
-#include <cereal/archives/xml.hpp>
-#endif // SEQAN3_WITH_CEREAL
+#include <seqan3/test/cereal.hpp>
 
 using namespace seqan3;
 
@@ -293,47 +283,16 @@ TYPED_TEST(generic, convertability)
     }
 }
 
-#if SEQAN3_WITH_CEREAL
-template <typename in_archive_t, typename out_archive_t, typename TypeParam>
-void do_serialisation(TypeParam const l)
-{
-    // This makes sure the file is also deleted if an exception is thrown in one of the tests below
-    // Generate unique file name.
-    test::tmp_filename filename{"scoring_scheme_cereal_test"};
-
-    {
-        std::ofstream os{filename.get_path(), std::ios::binary};
-        out_archive_t oarchive{os};
-        oarchive(l);
-    }
-
-    {
-        TypeParam in_l{};
-        std::ifstream is{filename.get_path(), std::ios::binary};
-        in_archive_t iarchive{is};
-        iarchive(in_l);
-        EXPECT_EQ(l, in_l);
-    }
-}
-
 TYPED_TEST(generic, serialisation)
 {
     TypeParam scheme1;
-    scheme1.set_hamming_distance();
 
-    do_serialisation<cereal::BinaryInputArchive,         cereal::BinaryOutputArchive>        (scheme1);
-    do_serialisation<cereal::PortableBinaryInputArchive, cereal::PortableBinaryOutputArchive>(scheme1);
-    do_serialisation<cereal::JSONInputArchive,           cereal::JSONOutputArchive>          (scheme1);
-    do_serialisation<cereal::XMLInputArchive,            cereal::XMLOutputArchive>           (scheme1);
+    scheme1.set_hamming_distance();
+    test::do_serialisation(scheme1);
 
     scheme1.set_simple_scheme(match_score{11}, mismatch_score{-7});
-
-    do_serialisation<cereal::BinaryInputArchive,         cereal::BinaryOutputArchive>        (scheme1);
-    do_serialisation<cereal::PortableBinaryInputArchive, cereal::PortableBinaryOutputArchive>(scheme1);
-    do_serialisation<cereal::JSONInputArchive,           cereal::JSONOutputArchive>          (scheme1);
-    do_serialisation<cereal::XMLInputArchive,            cereal::XMLOutputArchive>           (scheme1);
+    test::do_serialisation(scheme1);
 }
-#endif // SEQAN3_WITH_CEREAL
 
 // ------------------------------------------------------------------
 // aminoacid test

--- a/test/unit/alphabet/alphabet_test_template.hpp
+++ b/test/unit/alphabet/alphabet_test_template.hpp
@@ -12,19 +12,8 @@
 #include <seqan3/alphabet/concept.hpp>
 #include <seqan3/alphabet/exception.hpp>
 #include <seqan3/io/stream/debug_stream.hpp>
+#include <seqan3/test/cereal.hpp>
 #include <seqan3/test/pretty_printing.hpp>
-
-#if SEQAN3_WITH_CEREAL
-#include <seqan3/test/tmp_filename.hpp>
-
-#include <fstream>
-
-#include <cereal/archives/binary.hpp>
-#include <cereal/archives/portable_binary.hpp>
-#include <cereal/archives/json.hpp>
-#include <cereal/archives/xml.hpp>
-#include <cereal/types/vector.hpp>
-#endif // SEQAN3_WITH_CEREAL
 
 using namespace seqan3;
 
@@ -284,50 +273,18 @@ TYPED_TEST_P(alphabet, hash)
     }
 }
 
-#if SEQAN3_WITH_CEREAL
-template <typename in_archive_t, typename out_archive_t, typename TypeParam>
-void do_serialisation(TypeParam const l, std::vector<TypeParam> const & vec)
-{
-    // Generate unique file name.
-    test::tmp_filename filename{"alphabet_cereal_test"};
-    {
-        std::ofstream os{filename.get_path(), std::ios::binary};
-        out_archive_t oarchive{os};
-        oarchive(l);
-        oarchive(vec);
-    }
-
-    {
-        TypeParam in_l{};
-        std::vector<TypeParam> in_vec;
-
-        std::ifstream is{filename.get_path(), std::ios::binary};
-        in_archive_t iarchive{is};
-        iarchive(in_l);
-        iarchive(in_vec);
-        EXPECT_EQ(l, in_l);
-        EXPECT_EQ(vec, in_vec);
-    }
-}
-#endif // SEQAN3_WITH_CEREAL
-
 TYPED_TEST_P(alphabet, serialisation)
 {
-#if SEQAN3_WITH_CEREAL
     TypeParam letter;
 
     assign_rank(letter, 1 % alphabet_size_v<TypeParam>);
+    test::do_serialisation(letter);
 
     std::vector<TypeParam> vec;
     vec.resize(10);
     for (unsigned i = 0; i < 10; ++i)
         assign_rank(vec[i], i % alphabet_size_v<TypeParam>);
-
-    do_serialisation<cereal::BinaryInputArchive,         cereal::BinaryOutputArchive>(letter, vec);
-    do_serialisation<cereal::PortableBinaryInputArchive, cereal::PortableBinaryOutputArchive>(letter, vec);
-    do_serialisation<cereal::JSONInputArchive,           cereal::JSONOutputArchive>(letter, vec);
-    do_serialisation<cereal::XMLInputArchive,            cereal::XMLOutputArchive>(letter, vec);
-#endif // SEQAN3_WITH_CEREAL
+    test::do_serialisation(vec);
 }
 
 REGISTER_TYPED_TEST_CASE_P(alphabet, alphabet_size, default_value_constructor, global_assign_rank, global_to_rank,

--- a/test/unit/range/container/container_of_container_test.cpp
+++ b/test/unit/range/container/container_of_container_test.cpp
@@ -13,18 +13,8 @@
 #include <seqan3/io/stream/debug_stream.hpp>
 #include <seqan3/range/container/all.hpp>
 #include <seqan3/range/view/to_char.hpp>
-
-#if SEQAN3_WITH_CEREAL
-#include <seqan3/test/tmp_filename.hpp>
-
-#include <fstream>
-
-#include <cereal/archives/binary.hpp>
-#include <cereal/archives/portable_binary.hpp>
-#include <cereal/archives/json.hpp>
-#include <cereal/archives/xml.hpp>
-#include <cereal/types/vector.hpp>
-#endif // SEQAN3_WITH_CEREAL
+#include <seqan3/test/cereal.hpp>
+#include <seqan3/test/pretty_printing.hpp>
 
 using namespace seqan3;
 
@@ -52,27 +42,26 @@ TYPED_TEST(container_of_container, construction)
 {
     TypeParam t1;
     TypeParam t2{};
-//     EXPECT_EQ(t1, t2); // doesnt work because of conflict between ranges and gtest
-    EXPECT_TRUE(t1 == t2);
+    EXPECT_EQ(t1, t2);
 
     // initializer list
     TypeParam t3{"ACGT"_dna4, "ACGT"_dna4, "GAGGA"_dna4};
     TypeParam t4 = {"ACGT"_dna4, "ACGT"_dna4, "GAGGA"_dna4};
-    EXPECT_TRUE(t3 == t4);
+    EXPECT_EQ(t3, t4);
 
     // n * value
     TypeParam t5{2, "ACGT"_dna4};
     // from another TypeParam's sub-range
     TypeParam t6{t3.begin(), t3.begin() + 2};
-    EXPECT_TRUE(t5 == t6);
+    EXPECT_EQ(t5, t6);
 
     std::vector<std::vector<dna4>> other_vector{"ACGT"_dna4, "ACGT"_dna4, "GAGGA"_dna4};
     // direct from another container-of-container
     TypeParam t7{other_vector};
     // from another container-of-container's sub-range
     TypeParam t8{other_vector.cbegin(), other_vector.cend()};
-    EXPECT_TRUE(t3 == t7);
-    EXPECT_TRUE(t7 == t8);
+    EXPECT_EQ(t3, t7);
+    EXPECT_EQ(t7, t8);
 }
 
 TYPED_TEST(container_of_container, assign)
@@ -84,19 +73,19 @@ TYPED_TEST(container_of_container, assign)
     // n * value
     TypeParam t3;
     t3.assign(2, "ACGT"_dna4);
-    EXPECT_TRUE(t3 == t2);
+    EXPECT_EQ(t3, t2);
 
     // from another container-of-container's sub-range
     TypeParam t4;
     t4.assign(other_vector.cbegin(), other_vector.cend());
-    EXPECT_TRUE(t4 == t1);
+    EXPECT_EQ(t4, t1);
 
     // initializer list
     TypeParam t5, t6;
     t5.assign({"ACGT"_dna4, "ACGT"_dna4, "GAGGA"_dna4});
     t6 = {"ACGT"_dna4, "ACGT"_dna4, "GAGGA"_dna4};
-    EXPECT_TRUE(t5 == t1);
-    EXPECT_TRUE(t6 == t1);
+    EXPECT_EQ(t5, t1);
+    EXPECT_EQ(t6, t1);
 
     // direct from another container-of-container
     if constexpr (std::is_same_v<TypeParam, concatenated_sequences<std::vector<dna4>>>)
@@ -104,8 +93,8 @@ TYPED_TEST(container_of_container, assign)
         TypeParam t7, t8;
         t7.assign(other_vector);
         t8 = other_vector;
-        EXPECT_TRUE(t7 == t1);
-        EXPECT_TRUE(t8 == t1);
+        EXPECT_EQ(t7, t1);
+        EXPECT_EQ(t8, t1);
     }
 }
 
@@ -115,23 +104,23 @@ TYPED_TEST(container_of_container, iterators)
     TypeParam const t2{"ACGT"_dna4, "ACGT"_dna4, "GAGGA"_dna4};
 
     // begin
-    EXPECT_TRUE(dna4_vector(*t1.begin())  == "ACGT"_dna4);
-    EXPECT_TRUE(dna4_vector(*t1.cbegin()) == "ACGT"_dna4);
-    EXPECT_TRUE(dna4_vector(*t2.begin())  == "ACGT"_dna4);
-    EXPECT_TRUE(dna4_vector(*t2.cbegin()) == "ACGT"_dna4);
+    EXPECT_EQ(dna4_vector(*t1.begin()), "ACGT"_dna4);
+    EXPECT_EQ(dna4_vector(*t1.cbegin()), "ACGT"_dna4);
+    EXPECT_EQ(dna4_vector(*t2.begin()), "ACGT"_dna4);
+    EXPECT_EQ(dna4_vector(*t2.cbegin()), "ACGT"_dna4);
 
     // end and arithmetic
-    EXPECT_TRUE(dna4_vector(*(t1.end()  - 1)) == "GAGGA"_dna4);
-    EXPECT_TRUE(dna4_vector(*(t1.cend() - 1)) == "GAGGA"_dna4);
-    EXPECT_TRUE(dna4_vector(*(t2.end()  - 1)) == "GAGGA"_dna4);
-    EXPECT_TRUE(dna4_vector(*(t2.cend() - 1)) == "GAGGA"_dna4);
+    EXPECT_EQ(dna4_vector(*(t1.end()  - 1)), "GAGGA"_dna4);
+    EXPECT_EQ(dna4_vector(*(t1.cend() - 1)), "GAGGA"_dna4);
+    EXPECT_EQ(dna4_vector(*(t2.end()  - 1)), "GAGGA"_dna4);
+    EXPECT_EQ(dna4_vector(*(t2.cend() - 1)), "GAGGA"_dna4);
 
     // convertibility between const and non-const
     EXPECT_TRUE(t1.cend() == t1.end());
 
     // writability
     (*t1.begin())[0] = 'T'_dna4;
-    EXPECT_TRUE(dna4_vector(*t1.begin())  == "TCGT"_dna4);
+    EXPECT_EQ(dna4_vector(*t1.begin()), "TCGT"_dna4);
 }
 
 TYPED_TEST(container_of_container, element_access)
@@ -140,34 +129,34 @@ TYPED_TEST(container_of_container, element_access)
     TypeParam const t2{"ACGT"_dna4, "ACGT"_dna4, "GAGGA"_dna4};
 
     // at
-    EXPECT_TRUE(dna4_vector(t1.at(0)) == "ACGT"_dna4);
-    EXPECT_TRUE(dna4_vector(t2.at(0)) == "ACGT"_dna4);
+    EXPECT_EQ(dna4_vector(t1.at(0)), "ACGT"_dna4);
+    EXPECT_EQ(dna4_vector(t2.at(0)), "ACGT"_dna4);
     //TODO once we have throwing assert, check at's ability to throw
 
     // []
-    EXPECT_TRUE(dna4_vector(t1[0])    == "ACGT"_dna4);
-    EXPECT_TRUE(dna4_vector(t2[0])    == "ACGT"_dna4);
+    EXPECT_EQ(dna4_vector(t1[0]), "ACGT"_dna4);
+    EXPECT_EQ(dna4_vector(t2[0]), "ACGT"_dna4);
 
     // front
-    EXPECT_TRUE(dna4_vector(t1.front()) == "ACGT"_dna4);
-    EXPECT_TRUE(dna4_vector(t2.front()) == "ACGT"_dna4);
+    EXPECT_EQ(dna4_vector(t1.front()), "ACGT"_dna4);
+    EXPECT_EQ(dna4_vector(t2.front()), "ACGT"_dna4);
 
     // back
-    EXPECT_TRUE(dna4_vector(t1.back()) == "GAGGA"_dna4);
-    EXPECT_TRUE(dna4_vector(t2.back()) == "GAGGA"_dna4);
+    EXPECT_EQ(dna4_vector(t1.back()), "GAGGA"_dna4);
+    EXPECT_EQ(dna4_vector(t2.back()), "GAGGA"_dna4);
 
     if constexpr (std::is_same_v<TypeParam, concatenated_sequences<std::vector<dna4>>>)
     {
         using size_type = typename TypeParam::size_type;
         // concat
-        EXPECT_TRUE(dna4_vector(t1.concat()) == "ACGTACGTGAGGA"_dna4);
-        EXPECT_TRUE(dna4_vector(t2.concat()) == "ACGTACGTGAGGA"_dna4);
+        EXPECT_EQ(dna4_vector(t1.concat()), "ACGTACGTGAGGA"_dna4);
+        EXPECT_EQ(dna4_vector(t2.concat()), "ACGTACGTGAGGA"_dna4);
 
         // data
-        EXPECT_TRUE(std::get<0>(t1.data()) == "ACGTACGTGAGGA"_dna4);
-        EXPECT_TRUE(std::get<0>(t2.data()) == "ACGTACGTGAGGA"_dna4);
-        EXPECT_TRUE((std::get<1>(t1.data()) == std::vector<size_type>{0, 4, 8, 13}));
-        EXPECT_TRUE((std::get<1>(t2.data()) == std::vector<size_type>{0, 4, 8, 13}));
+        EXPECT_EQ(std::get<0>(t1.data()), "ACGTACGTGAGGA"_dna4);
+        EXPECT_EQ(std::get<0>(t2.data()), "ACGTACGTGAGGA"_dna4);
+        EXPECT_EQ(std::get<1>(t1.data()), (std::vector<size_type>{0, 4, 8, 13}));
+        EXPECT_EQ(std::get<1>(t2.data()), (std::vector<size_type>{0, 4, 8, 13}));
     }
 
 }
@@ -234,7 +223,7 @@ TYPED_TEST(container_of_container, clear)
     TypeParam t1{"ACGT"_dna4, "ACGT"_dna4, "GAGGA"_dna4};
 
     t1.clear();
-    EXPECT_TRUE(t0 == t1);
+    EXPECT_EQ(t0, t1);
 }
 
 TYPED_TEST(container_of_container, insert)
@@ -246,7 +235,7 @@ TYPED_TEST(container_of_container, insert)
     t0.insert(t0.cend(), "ACGT"_dna4);
     t0.insert(t0.cend(), "GAGGA"_dna4);
     t0.insert(t0.cbegin() + 1, "ACGT"_dna4);
-    EXPECT_TRUE(t0 == t1);
+    EXPECT_EQ(t0, t1);
 
     // position, n times values
     t0.clear();
@@ -254,7 +243,7 @@ TYPED_TEST(container_of_container, insert)
     t0.insert(t0.cend(), 2, "ACGT"_dna4);
     t0.insert(t0.cend(), 1, "GAGGA"_dna4);
     t0.insert(t0.cbegin(), 1, "GAGGA"_dna4);
-    EXPECT_TRUE(t0 == t1);
+    EXPECT_EQ(t0, t1);
 
     // iterator pair
     t0.clear();
@@ -263,14 +252,14 @@ TYPED_TEST(container_of_container, insert)
 
     t0.insert(t0.cend(),   t1.cend() - 1, t1.cend());
     t0.insert(t0.cbegin(), t1.cend() - 1, t1.cend());
-    EXPECT_TRUE(t0 == t1);
+    EXPECT_EQ(t0, t1);
 
     // initializer list
     t0.clear();
     t1 = {"ACGT"_dna4, "ACGT"_dna4, "GAGGA"_dna4};
     t0.insert(t0.cend(), {"ACGT"_dna4, "GAGGA"_dna4});
     t0.insert(t0.cbegin() + 1, "ACGT"_dna4);
-    EXPECT_TRUE(t0 == t1);
+    EXPECT_EQ(t0, t1);
 }
 
 TYPED_TEST(container_of_container, erase)
@@ -279,12 +268,12 @@ TYPED_TEST(container_of_container, erase)
 
     // one element
     t1.erase(t1.begin());
-    EXPECT_TRUE((t1 == TypeParam{"ACGT"_dna4, "GAGGA"_dna4}));
+    EXPECT_EQ(t1, (TypeParam{"ACGT"_dna4, "GAGGA"_dna4}));
 
     // range
     t1 = {"GAGGA"_dna4, "ACGT"_dna4, "ACGT"_dna4, "GAGGA"_dna4};
     t1.erase(t1.begin() + 1, t1.begin() + 3);
-    EXPECT_TRUE((t1 == TypeParam{"GAGGA"_dna4, "GAGGA"_dna4}));
+    EXPECT_EQ(t1, (TypeParam{"GAGGA"_dna4, "GAGGA"_dna4}));
 }
 
 TYPED_TEST(container_of_container, push_pop)
@@ -293,15 +282,15 @@ TYPED_TEST(container_of_container, push_pop)
 
     // push_back
     t0.push_back("ACGT"_dna4);
-    EXPECT_TRUE((t0 == TypeParam{"ACGT"_dna4}));
+    EXPECT_EQ(t0, (TypeParam{"ACGT"_dna4}));
     t0.push_back("GAGGA"_dna4);
-    EXPECT_TRUE((t0 == TypeParam{"ACGT"_dna4, "GAGGA"_dna4}));
+    EXPECT_EQ(t0, (TypeParam{"ACGT"_dna4, "GAGGA"_dna4}));
 
     // pop_back
     t0.pop_back();
-    EXPECT_TRUE(t0 == TypeParam{"ACGT"_dna4});
+    EXPECT_EQ(t0, (TypeParam{"ACGT"_dna4}));
     t0.pop_back();
-    EXPECT_TRUE(t0 == TypeParam{});
+    EXPECT_EQ(t0, TypeParam{});
 }
 
 TYPED_TEST(container_of_container, resize)
@@ -310,19 +299,19 @@ TYPED_TEST(container_of_container, resize)
 
     // enlarge without values
     t0.resize(3);
-    EXPECT_TRUE((t0 == TypeParam{{}, {}, {}}));
+    EXPECT_EQ(t0,( TypeParam{{}, {}, {}}));
 
     // enlarge with value
     t0.resize(5, "ACGT"_dna4);
-    EXPECT_TRUE((t0 == TypeParam{{}, {}, {}, "ACGT"_dna4, "ACGT"_dna4}));
+    EXPECT_EQ(t0, (TypeParam{{}, {}, {}, "ACGT"_dna4, "ACGT"_dna4}));
 
     // shrink with value
     t0.resize(4, "ACGT"_dna4);
-    EXPECT_TRUE((t0 == TypeParam{{}, {}, {}, "ACGT"_dna4}));
+    EXPECT_EQ(t0, (TypeParam{{}, {}, {}, "ACGT"_dna4}));
 
     // shrink without value
     t0.resize(2);
-    EXPECT_TRUE((t0 == TypeParam{{}, {}}));
+    EXPECT_EQ(t0, (TypeParam{{}, {}}));
 }
 
 TYPED_TEST(container_of_container, swap)
@@ -331,8 +320,8 @@ TYPED_TEST(container_of_container, swap)
     TypeParam t1{"ACGT"_dna4, "ACGT"_dna4, "GAGGA"_dna4};
 
     t0.swap(t1);
-    EXPECT_TRUE((t0 == TypeParam{"ACGT"_dna4, "ACGT"_dna4, "GAGGA"_dna4}));
-    EXPECT_TRUE((t1 == TypeParam{}));
+    EXPECT_EQ(t0, (TypeParam{"ACGT"_dna4, "ACGT"_dna4, "GAGGA"_dna4}));
+    EXPECT_EQ(t1, TypeParam{});
 }
 
 TYPED_TEST(container_of_container, streamable)
@@ -353,38 +342,8 @@ TYPED_TEST(container_of_container, streamable)
     EXPECT_EQ(o.str(), "[], [ACGT,ACGT,GAGGA]");
 }
 
-#if SEQAN3_WITH_CEREAL
-template <typename in_archive_t, typename out_archive_t, typename TypeParam>
-void do_serialisation(TypeParam const l)
-{
-    // This makes sure the file is also deleted if an exception is thrown in one of the tests below
-    // Generate unique file name.
-    test::tmp_filename filename{"container_cereal_test"};
-    {
-        std::ofstream os{filename.get_path(), std::ios::binary};
-        out_archive_t oarchive{os};
-        oarchive(l);
-    }
-
-    {
-        TypeParam in_l{};
-        std::ifstream is{filename.get_path(), std::ios::binary};
-        in_archive_t iarchive{is};
-        iarchive(in_l);
-        EXPECT_TRUE(l == in_l);
-    }
-}
-
 TYPED_TEST(container_of_container, serialisation)
 {
-    if constexpr (!std::Same<TypeParam, concatenated_sequences<bitcompressed_vector<dna4>>>) // not serialisable, yet
-    {
-        TypeParam t1{"ACGT"_dna4, "ACGT"_dna4, "GAGGA"_dna4};
-
-        do_serialisation<cereal::BinaryInputArchive,         cereal::BinaryOutputArchive>        (t1);
-        do_serialisation<cereal::PortableBinaryInputArchive, cereal::PortableBinaryOutputArchive>(t1);
-        do_serialisation<cereal::JSONInputArchive,           cereal::JSONOutputArchive>          (t1);
-        do_serialisation<cereal::XMLInputArchive,            cereal::XMLOutputArchive>           (t1);
-    }
+    TypeParam t1{"ACGT"_dna4, "ACGT"_dna4, "GAGGA"_dna4};
+    test::do_serialisation(t1);
 }
-#endif // SEQAN3_WITH_CEREAL

--- a/test/unit/range/container/container_test.cpp
+++ b/test/unit/range/container/container_test.cpp
@@ -15,18 +15,7 @@
 #include <seqan3/io/stream/debug_stream.hpp>
 #include <seqan3/range/container/all.hpp>
 #include <seqan3/range/view/convert.hpp>
-
-#if SEQAN3_WITH_CEREAL
-#include <seqan3/test/tmp_filename.hpp>
-
-#include <fstream>
-
-#include <cereal/archives/binary.hpp>
-#include <cereal/archives/portable_binary.hpp>
-#include <cereal/archives/json.hpp>
-#include <cereal/archives/xml.hpp>
-#include <cereal/types/vector.hpp>
-#endif // SEQAN3_WITH_CEREAL
+#include <seqan3/test/cereal.hpp>
 
 using namespace seqan3;
 
@@ -319,35 +308,8 @@ TYPED_TEST(container, streamable)
     EXPECT_EQ(o.str(), "ACCGT");
 }
 
-#if 0 // SEQAN3_WITH_CEREAL
-template <typename in_archive_t, typename out_archive_t, typename TypeParam>
-void do_serialisation(TypeParam const l)
-{
-    // This makes sure the file is also deleted if an exception is thrown in one of the tests below
-    // Generate unique file name.
-    test::tmp_file_name filename{"container_cereal_test"};
-    {
-        std::ofstream os{filename.get_path(), std::ios::binary};
-        out_archive_t oarchive{os};
-        oarchive(l);
-    }
-
-    {
-        TypeParam in_l{};
-        std::ifstream is{filename.get_path(), std::ios::binary};
-        in_archive_t iarchive{is};
-        iarchive(in_l);
-        EXPECT_EQ(l, in_l);
-    }
-}
-
 TYPED_TEST(container, serialisation)
 {
     TypeParam t1{'A'_dna4, 'C'_dna4, 'C'_dna4, 'G'_dna4, 'T'_dna4};
-
-    do_serialisation<cereal::BinaryInputArchive,         cereal::BinaryOutputArchive>        (t1);
-    do_serialisation<cereal::PortableBinaryInputArchive, cereal::PortableBinaryOutputArchive>(t1);
-    do_serialisation<cereal::JSONInputArchive,           cereal::JSONOutputArchive>          (t1);
-    do_serialisation<cereal::XMLInputArchive,            cereal::XMLOutputArchive>           (t1);
+    test::do_serialisation(t1);
 }
-#endif // SEQAN3_WITH_CEREAL

--- a/test/unit/search/fm_index/fm_index_collection_test_template.hpp
+++ b/test/unit/search/fm_index/fm_index_collection_test_template.hpp
@@ -5,13 +5,13 @@
 // shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
 // -----------------------------------------------------------------------------------------------------
 
+#include <gtest/gtest.h>
+
 #include <type_traits>
 
 #include <seqan3/core/metafunction/template_inspection.hpp>
 #include <seqan3/search/fm_index/all.hpp>
-#include <seqan3/test/tmp_filename.hpp>
-
-#include <gtest/gtest.h>
+#include <seqan3/test/cereal.hpp>
 
 using namespace seqan3;
 
@@ -23,7 +23,7 @@ TYPED_TEST_CASE_P(fm_index_collection_test);
 
 TYPED_TEST_P(fm_index_collection_test, ctr)
 {
-    typedef value_type_t<typename TypeParam::text_type> inner_text_type;
+    using inner_text_type = value_type_t<typename TypeParam::text_type>;
     typename TypeParam::text_type text{inner_text_type(10), inner_text_type(10)}; // initialized with smallest char
 
     // default/zero construction
@@ -32,28 +32,28 @@ TYPED_TEST_P(fm_index_collection_test, ctr)
 
     // copy construction
     TypeParam fm1{fm0};
-    EXPECT_EQ(fm0.size(), fm1.size());
+    EXPECT_EQ(fm0, fm1);
 
     // copy assignment
     TypeParam fm2 = fm0;
-    EXPECT_EQ(fm0.size(), fm2.size());
+    EXPECT_EQ(fm0, fm2);
 
     // move construction
-    TypeParam fm3{std::move(fm0)};
-    EXPECT_EQ(fm0.size(), fm3.size());
+    TypeParam fm3{std::move(fm1)};
+    EXPECT_EQ(fm0, fm3);
 
     // move assigment
-    TypeParam fm4 = std::move(fm0);
-    EXPECT_EQ(fm0.size(), fm4.size());
+    TypeParam fm4 = std::move(fm2);
+    EXPECT_EQ(fm0, fm4);
 
     // container contructor
     TypeParam fm5{text};
-    EXPECT_EQ(fm0.size(), fm5.size());
+    EXPECT_EQ(fm0, fm5);
 }
 
 TYPED_TEST_P(fm_index_collection_test, swap)
 {
-    typedef value_type_t<typename TypeParam::text_type> inner_text_type;
+    using inner_text_type = value_type_t<typename TypeParam::text_type>;
     typename TypeParam::text_type textA{inner_text_type(10), inner_text_type(10)};
     typename TypeParam::text_type textB{inner_text_type(20), inner_text_type(20)};
 
@@ -62,15 +62,15 @@ TYPED_TEST_P(fm_index_collection_test, swap)
     TypeParam fm2{fm0};
     TypeParam fm3{fm1};
 
-    EXPECT_EQ(fm0.size(), fm2.size());
-    EXPECT_EQ(fm1.size(), fm3.size());
-    EXPECT_NE(fm0.size(), fm1.size());
+    EXPECT_EQ(fm0, fm2);
+    EXPECT_EQ(fm1, fm3);
+    EXPECT_NE(fm0, fm1);
 
     std::swap(fm1, fm2);
 
-    EXPECT_EQ(fm0.size(), fm1.size());
-    EXPECT_EQ(fm2.size(), fm3.size());
-    EXPECT_NE(fm0.size(), fm2.size());
+    EXPECT_EQ(fm0, fm1);
+    EXPECT_EQ(fm2, fm3);
+    EXPECT_NE(fm0, fm2);
 }
 
 TYPED_TEST_P(fm_index_collection_test, size)
@@ -78,27 +78,10 @@ TYPED_TEST_P(fm_index_collection_test, size)
     TypeParam fm;
     EXPECT_TRUE(fm.empty());
 
-    typedef value_type_t<typename TypeParam::text_type> inner_text_type;
+    using inner_text_type = value_type_t<typename TypeParam::text_type>;
     typename TypeParam::text_type text{inner_text_type(4), inner_text_type(4)};
     fm.construct(text);
     EXPECT_EQ(fm.size(), 10u); // including a sentinel character and a delimiter
-}
-
-TYPED_TEST_P(fm_index_collection_test, serialization)
-{
-    typedef value_type_t<typename TypeParam::text_type> inner_text_type;
-    typename TypeParam::text_type text{inner_text_type(4), inner_text_type(4)};
-    TypeParam fm0{text};
-
-    test::tmp_filename filename{"fm_index"};
-    auto const & path = filename.get_path();
-
-    EXPECT_TRUE(fm0.store(path));
-
-    TypeParam fm1{};
-    EXPECT_TRUE(fm1.load(path));
-
-    EXPECT_EQ(fm1.size(), 10u);
 }
 
 TYPED_TEST_P(fm_index_collection_test, concept_check)
@@ -122,4 +105,13 @@ TYPED_TEST_P(fm_index_collection_test, empty_text)
     }
 }
 
-REGISTER_TYPED_TEST_CASE_P(fm_index_collection_test, ctr, swap, size, serialization, concept_check, empty_text);
+TYPED_TEST_P(fm_index_collection_test, serialisation)
+{
+    using inner_text_type = value_type_t<typename TypeParam::text_type>;
+    typename TypeParam::text_type text{inner_text_type(4), inner_text_type(12)};
+
+    TypeParam fm{text};
+    test::do_serialisation(fm);
+}
+
+REGISTER_TYPED_TEST_CASE_P(fm_index_collection_test, ctr, swap, size, serialisation, concept_check, empty_text);


### PR DESCRIPTION
Adds cereal support (and equality comparison) for SDSL data structures.

* Adds a test header for cereal tests
* Enables tests for containers using cereal (bitcompressed_vector)
* Enables serialisation via cereal for FM-Index
* Removes `load`/`store` function from FM-Index and FM-Index concept


**TODO**
* Would be nice to have a cereal tutorial or dedicated page on the documentation (other PR)