### PR TITLE
Add --license option

### DIFF
--- a/doc/tutorial/argument_parser/index.md
+++ b/doc/tutorial/argument_parser/index.md
@@ -59,7 +59,7 @@ The argument parser checks the following restrictions and throws a seqan3::parse
 * **Short identifiers**: must be unique and consist of only a single letter that is alphanumeric characters, `_` or `@`.
 * either the short or long id may be empty but not both at the same time.
 * Only the last positional option may be a list (see [lists](#section_list_positional_options)).
-* The flag identifiers `-h`, `--help`, `--advanced-help`, `--advanced-help`, `--export-help`, `--version`, `--copyright` are predefined and cannot be specified manually or used otherwise.
+* The flag identifiers `-h`, `--help`, `-hh`, `--advanced-help`, `--export-help`, `--version`, `--license` are predefined and cannot be specified manually or used otherwise.
 * The seqan3::argument_parser::parse function may only be called once (per parser).
 
 ## Input restrictions (seqan3::parser_invalid_argument)
@@ -86,7 +86,7 @@ Currently we support the following *special requests*:
 <tr> <td> `-hh/--advanced-help` </td> <td> Prints the advanced help page to the command line (`std::cout`) </td> </tr>
 <tr> <td> `--export-help` </td> <td> Exports the help page in a different format (`std::cout`) </td> </tr>
 <tr> <td> `--version`    </td> <td> Prints the version information to the command line (`std::cout`) </td> </tr>
-<tr> <td> `--copyright`  </td> <td> Prints the copyright information to the command line (`std::cout`) </td> </tr>
+<tr> <td> `--license`  </td> <td> Prints the license information to the command line (`std::cout`) </td> </tr>
 </table>
 
 \assignment{Assignment 1}
@@ -101,13 +101,13 @@ Of course there is not much information to display yet, since we did not provide
 - **app_name**, which is already set on construction (seqan3::argument_parser_meta_data::app_name)
 - **author** (seqan3::argument_parser_meta_data::author)
 - **citation** (seqan3::argument_parser_meta_data::citation)
+- **copyright** (seqan3::argument_parser_meta_data::copyright)
 - **date** (seqan3::argument_parser_meta_data::date)
 - **description** (seqan3::argument_parser_meta_data::description)
 - **email** (seqan3::argument_parser_meta_data::email)
 - **examples** (seqan3::argument_parser_meta_data::examples)
-- **long_copyright** (seqan3::argument_parser_meta_data::long_copyright)
+- **license** (seqan3::argument_parser_meta_data::license)
 - **man_page_title** (seqan3::argument_parser_meta_data::man_page_title)
-- **short_copyright** (seqan3::argument_parser_meta_data::short_copyright)
 - **short_description** (seqan3::argument_parser_meta_data::short_description)
 - **synopsis** (seqan3::argument_parser_meta_data::synopsis)
 - **url** (seqan3::argument_parser_meta_data::url)

--- a/include/seqan3/argument_parser/argument_parser.hpp
+++ b/include/seqan3/argument_parser/argument_parser.hpp
@@ -515,9 +515,9 @@ private:
                                             "Value of --export-help must be one of [html, man, ctd]");
                 return;
             }
-            else if (arg == "--copyright")
+            else if (arg == "--license")
             {
-                format = detail::format_copyright();
+                format = detail::format_license();
                 return;
             }
         }
@@ -581,11 +581,11 @@ private:
                  detail::format_version,
                  detail::format_html,
                  detail::format_man,
-                 detail::format_copyright/*,
+                 detail::format_license/*,
                  detail::format_ctd*/> format{detail::format_help(0)};
 
     //!\brief List of option/flag identifiers that are already used.
-    std::set<std::string> used_option_ids{"h", "hh", "help", "advanced-help", "export-help", "version", "copyright"};
+    std::set<std::string> used_option_ids{"h", "hh", "help", "advanced-help", "export-help", "version", "license"};
 };
 
 } // namespace seqan3

--- a/include/seqan3/argument_parser/auxiliary.hpp
+++ b/include/seqan3/argument_parser/auxiliary.hpp
@@ -80,11 +80,11 @@ struct argument_parser_meta_data // holds all meta information
     //!\brief A link to github, your website or a wiki page.
     std::string url;
     //!\brief Brief copyright (and/or license) information.
-    std::string short_copyright;
-    /*!\brief Detailed copyright information that will be displayed
-     *        when the user specifies "--copyright" on the command line.
+    std::string copyright;
+    /*!\brief Detailed license information that will be displayed
+     *        when the user specifies "--license" on the command line.
      */
-    std::string long_copyright;
+    std::string license;
     //!\brief How  users shall cite your application.
     std::string citation;
     /*!\brief The title of your man page when exported by specifying

--- a/include/seqan3/argument_parser/detail/format_help.hpp
+++ b/include/seqan3/argument_parser/detail/format_help.hpp
@@ -432,15 +432,15 @@ protected:
         std::ostream_iterator<char> out(std::cout);
 
         // Print legal stuff
-        if ((!empty(meta.short_copyright)) || (!empty(meta.long_copyright)) || (!empty(meta.citation)))
+        if ((!empty(meta.copyright)) || (!empty(meta.license)) || (!empty(meta.citation)))
         {
             std::cout << "\n" << to_text("\\fB") << "LEGAL" << to_text("\\fP") << "\n";
 
-            if (!empty(meta.short_copyright))
+            if (!empty(meta.copyright))
             {
                 std::fill_n(out, layout.leftPadding, ' ');
                 std::cout << to_text("\\fB") << meta.app_name << " Copyright: "
-                          << to_text("\\fP") << meta.short_copyright << "\n";
+                          << to_text("\\fP") << meta.copyright << "\n";
             }
             std::fill_n(out, layout.leftPadding, ' ');
             std::cout << to_text("\\fB") << "SeqAn Copyright: " << to_text("\\fP")
@@ -451,11 +451,11 @@ protected:
                 std::cout << to_text("\\fB") << "In your academic works please cite: " << to_text("\\fP")
                           << meta.citation << "\n";
             }
-            if (!empty(meta.long_copyright))
+            if (!empty(meta.license))
             {
                 std::fill_n(out, layout.leftPadding, ' ');
-                std::cout << "For full copyright and/or warranty information see " << to_text("\\fB")
-                          << "--copyright" << to_text("\\fP") << ".\n";
+                std::cout << "For full license and/or warranty information see " << to_text("\\fB")
+                          << "--license" << to_text("\\fP") << ".\n";
             }
         }
     }
@@ -767,19 +767,19 @@ public:
     }
 };
 
-/*!\brief The format that prints the copyright information to std::cout.
+/*!\brief The format that prints the license information to std::cout.
  * \ingroup argument_parser
  *
  * \details
  *
- * The copyright message printing is not done immediately, because the user cannot provide
- * meta information (e.g. long_copyright) on construction of the parser. Thus the meta information is collected
+ * The license message printing is not done immediately, because the user cannot provide
+ * meta information (e.g. long_license) on construction of the parser. Thus the meta information is collected
  * and only evaluated when calling seqan3::format_version::parse.
  */
-class format_copyright : public format_help
+class format_license : public format_help
 {
 public:
-    /*!\brief Initiates the printing of the copyright message to std::cout.
+    /*!\brief Initiates the printing of the license message to std::cout.
      * \param[in] parser_meta The meta information that are needed for a detailed version information.
      */
     void parse(argument_parser_meta_data const & parser_meta)
@@ -815,21 +815,21 @@ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
 OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 DAMAGE.)"};
 
-        strem << ranges::view::repeat_n('=', 80) << to_text("\n\\fB") << "Copyright information for "
+        strem << ranges::view::repeat_n('=', 80) << to_text("\n\\fB") << "License information for "
               << meta.app_name << ":\n" << to_text("\\fP") << ranges::view::repeat_n('-', 80) << '\n';
 
-        if (!empty(meta.long_copyright))
+        if (!empty(meta.license))
         {
-            strem << to_text("\\fP") << meta.long_copyright << "\n";
+            strem << to_text("\\fP") << meta.license << "\n";
         }
-        else if (!empty(meta.short_copyright))
+        else if (!empty(meta.copyright))
         {
-            strem << to_text("\\fP") << meta.app_name << " full copyright information not available. Displaying"
-                  << " short copyright information instead:\n" << to_text("\\fP") << meta.short_copyright << "\n";
+            strem << to_text("\\fP") << meta.app_name << " full license information not available. Displaying"
+                  << " copyright information instead:\n" << to_text("\\fP") << meta.copyright << "\n";
         }
         else
         {
-            strem << to_text("\\fP") << meta.app_name << " copyright information not available.\n";
+            strem << to_text("\\fP") << meta.app_name << " copyright and license information not available.\n";
         }
 
         strem << ranges::view::repeat_n('=', 80) << to_text("\n\\fB")

--- a/include/seqan3/argument_parser/detail/format_html.hpp
+++ b/include/seqan3/argument_parser/detail/format_html.hpp
@@ -338,13 +338,13 @@ private:
         std::cout << "<br>\n";
 
         // Print legal stuff
-        if ((!meta.short_copyright.empty()) || (!meta.long_copyright.empty()) || (!meta.citation.empty()))
+        if ((!meta.copyright.empty()) || (!meta.license.empty()) || (!meta.citation.empty()))
         {
             std::cout << "<h2>Legal</h2>\n<strong>";
 
-            if (!meta.short_copyright.empty())
+            if (!meta.copyright.empty())
                 std::cout << meta.app_name << " Copyright: </strong>"
-                       << meta.short_copyright << "<br>\n<strong>";
+                       << meta.copyright << "<br>\n<strong>";
 
             std::cout << "SeqAn Copyright:</strong> 2006-2019 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.<br>\n<strong>";
 
@@ -353,8 +353,8 @@ private:
             else
                 std::cout << "</strong>";
 
-            if (!meta.long_copyright.empty())
-                std::cout << "For full copyright and/or warranty information see <tt>--copyright</tt>.\n";
+            if (!meta.license.empty())
+                std::cout << "For full license and/or warranty information see <tt>--license</tt>.\n";
         }
 
         // Print HTML boilerplate footer.

--- a/include/seqan3/argument_parser/detail/format_man.hpp
+++ b/include/seqan3/argument_parser/detail/format_man.hpp
@@ -285,20 +285,20 @@ private:
     void print_footer()
     {
         // Print legal stuff
-        if ((!empty(meta.short_copyright)) || (!empty(meta.long_copyright)) || (!empty(meta.citation)))
+        if ((!empty(meta.copyright)) || (!empty(meta.license)) || (!empty(meta.citation)))
         {
             std::cout << ".SH LEGAL\n";
 
-            if (!empty(meta.short_copyright))
-                std::cout << "\\fB" << meta.app_name << " Copyright:\\fR " << meta.short_copyright << "\n.br\n";
+            if (!empty(meta.copyright))
+                std::cout << "\\fB" << meta.app_name << " Copyright:\\fR " << meta.copyright << "\n.br\n";
 
             std::cout << "\\fBSeqAn Copyright:\\fR 2006-2015 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.\n.br\n";
 
             if (!empty(meta.citation))
                 std::cout << "\\fBIn your academic works please cite:\\fR " << meta.citation << "\n.br\n";
 
-            if (!empty(meta.long_copyright))
-                std::cout << "For full copyright and/or warranty information see \\fB--copyright\\fR.\n";
+            if (!empty(meta.license))
+                std::cout << "For full license and/or warranty information see \\fB--license\\fR.\n";
         }
     }
 

--- a/test/unit/argument_parser/detail/format_help_test.cpp
+++ b/test/unit/argument_parser/detail/format_help_test.cpp
@@ -64,13 +64,13 @@ TEST(help_page_printing, no_information)
     EXPECT_TRUE(ranges::equal((std_cout | std::view::filter(!is_space)), expected | std::view::filter(!is_space)));
 }
 
-TEST(help_page_printing, with_short_copyright)
+TEST(help_page_printing, with_copyright)
 {
-    // Again, but with short copyright, long copyright, and citation.
-    argument_parser short_copy("test_parser", 2, argv1);
-    short_copy.info.short_copyright = "short";
+    // Again, but with copyright, license, and citation.
+    argument_parser copyright("test_parser", 2, argv1);
+    copyright.info.copyright = "copyright";
     testing::internal::CaptureStdout();
-    EXPECT_EXIT(short_copy.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
+    EXPECT_EXIT(copyright.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
     std_cout = testing::internal::GetCapturedStdout();
     expected = "test_parser"
                "==========="
@@ -79,17 +79,17 @@ TEST(help_page_printing, with_short_copyright)
                "test_parser version:"
                "SeqAn version: " + version_str +
                "LEGAL"
-               "test_parser Copyright: short"
+               "test_parser Copyright: copyright"
                "SeqAn Copyright: 2006-2015 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.";
     EXPECT_TRUE(ranges::equal((std_cout | std::view::filter(!is_space)), expected | std::view::filter(!is_space)));
 }
 
-TEST(help_page_printing, with_long_copyright)
+TEST(help_page_printing, with_license)
 {
-    argument_parser long_copy("test_parser", 2, argv1);
-    long_copy.info.long_copyright = "long";
+    argument_parser license("test_parser", 2, argv1);
+    license.info.license = "license";
     testing::internal::CaptureStdout();
-    EXPECT_EXIT(long_copy.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
+    EXPECT_EXIT(license.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
     std_cout = testing::internal::GetCapturedStdout();
     expected = "test_parser"
                "==========="
@@ -99,7 +99,7 @@ TEST(help_page_printing, with_long_copyright)
                "SeqAn version: " + version_str +
                "LEGAL"
                "SeqAn Copyright: 2006-2015 Knut Reinert, FU-Berlin; released under the 3-clause BSDL."
-               "For full copyright and/or warranty information see --copyright.";
+               "For full license and/or warranty information see --license.";
     EXPECT_TRUE(ranges::equal((std_cout | std::view::filter(!is_space)), expected | std::view::filter(!is_space)));
 }
 
@@ -238,26 +238,26 @@ TEST(help_page_printing, full_information)
     EXPECT_TRUE(ranges::equal((std_cout | std::view::filter(!is_space)), expected | std::view::filter(!is_space)));
 }
 
-TEST(help_page_printing, copyright)
+TEST(help_page_printing, license)
 {
-    // Tests the --copyright call.
-    const char * argvCopyright[] = {"./copyright", "--copyright"};
-    argument_parser copyright("myApp", 2, argvCopyright);
+    // Tests the --license call.
+    const char * argvLicense[] = {"./copyright", "--license"};
+    argument_parser license("myApp", 2, argvLicense);
 
     std::ifstream license_file{std::string{{SEQAN_INCLUDE_DIR}} + "/../LICENSE"};
     std::string license_string{(std::istreambuf_iterator<char>(license_file)),
                                 std::istreambuf_iterator<char>()};
 
-    // Test --copyright with empty short and long copyright info.
+    // Test --license with empty copyright and license info.
     {
         testing::internal::CaptureStdout();
-        EXPECT_EXIT(copyright.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
+        EXPECT_EXIT(license.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
         std_cout = testing::internal::GetCapturedStdout();
 
         expected = "================================================================================\n"
-                   "Copyright information for myApp:\n"
+                   "License information for myApp:\n"
                    "--------------------------------------------------------------------------------\n"
-                   "myApp copyright information not available.\n"
+                   "myApp copyright and license information not available.\n"
                    "================================================================================\n"
                    "This program contains SeqAn3 code licensed under the following terms:\n"
                    "--------------------------------------------------------------------------------\n"
@@ -266,19 +266,19 @@ TEST(help_page_printing, copyright)
         EXPECT_EQ(std_cout, expected);
     }
 
-    // Test --copyright with a non-empty short copyright and an empty long copyright.
-    copyright.info.short_copyright = "short copyright line 1\nshort copyright line 2";
+    // Test --copyright with a non-empty copyright and an empty license.
+    license.info.copyright = "copyright line 1\ncopyright line 2";
     {
         testing::internal::CaptureStdout();
-        EXPECT_EXIT(copyright.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
+        EXPECT_EXIT(license.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
         std_cout = testing::internal::GetCapturedStdout();
 
         expected = "================================================================================\n"
-                   "Copyright information for myApp:\n"
+                   "License information for myApp:\n"
                    "--------------------------------------------------------------------------------\n"
-                   "myApp full copyright information not available. Displaying short copyright information instead:\n"
-                   "short copyright line 1\n"
-                   "short copyright line 2\n"
+                   "myApp full license information not available. Displaying copyright information instead:\n"
+                   "copyright line 1\n"
+                   "copyright line 2\n"
                    "================================================================================\n"
                    "This program contains SeqAn3 code licensed under the following terms:\n"
                    "--------------------------------------------------------------------------------\n"
@@ -287,18 +287,18 @@ TEST(help_page_printing, copyright)
         EXPECT_EQ(std_cout, expected);
     }
 
-    // Test --copyright with a non-empty short copyright and a non-empty long copyright.
-    copyright.info.long_copyright = "long copyright line 1\nlong copyright line 2";
+    // Test --license with a non-empty copyright and a non-empty license.
+    license.info.license = "license line 1\nlicense line 2";
     {
         testing::internal::CaptureStdout();
-        EXPECT_EXIT(copyright.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
+        EXPECT_EXIT(license.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
         std_cout = testing::internal::GetCapturedStdout();
 
         expected = "================================================================================\n"
-                   "Copyright information for myApp:\n"
+                   "License information for myApp:\n"
                    "--------------------------------------------------------------------------------\n"
-                   "long copyright line 1\n"
-                   "long copyright line 2\n"
+                   "license line 1\n"
+                   "license line 2\n"
                    "================================================================================\n"
                    "This program contains SeqAn3 code licensed under the following terms:\n"
                    "--------------------------------------------------------------------------------\n"

--- a/test/unit/argument_parser/detail/format_html_test.cpp
+++ b/test/unit/argument_parser/detail/format_html_test.cpp
@@ -57,8 +57,8 @@ TEST(html_test, html)
    parser1.info.description.push_back("description2");
    parser1.info.short_description = "short description";
    parser1.info.url = "www.seqan.de";
-   parser1.info.short_copyright = "short copyright";
-   parser1.info.long_copyright = "long_copyright";
+   parser1.info.copyright = "copyright";
+   parser1.info.license = "license";
    parser1.info.citation = "citation";
    parser1.add_option(option_value, 'i', "int", "this is a int option.");
    parser1.add_option(option_value, 'j', "jint", "this is a int option.");
@@ -120,10 +120,10 @@ TEST(html_test, html)
                           "www.seqan.de<br>"
                           "<br>"
                           "<h2>Legal</h2>"
-                          "<strong>program_full_options Copyright: </strong>short copyright<br>"
+                          "<strong>program_full_options Copyright: </strong>copyright<br>"
                           "<strong>SeqAn Copyright:</strong> 2006-2019 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.<br>"
                           "<strong>In your academic works please cite:</strong> citation<br>"
-                          "For full copyright and/or warranty information see <tt>--copyright</tt>."
+                          "For full license and/or warranty information see <tt>--license</tt>."
                           "</body></html>");
    EXPECT_TRUE(ranges::equal((my_stdout   | std::view::filter(!is_space)),
                               expected | ranges::view::remove_if(is_space)));


### PR DESCRIPTION
Print copyright information with `--license` in addition to `--copyright`.
Resolves #862 