### PR TITLE
[MISC] Doxygen warning construction fix alphabet I

### DIFF
--- a/include/seqan3/alphabet/aminoacid/aa20.hpp
+++ b/include/seqan3/alphabet/aminoacid/aa20.hpp
@@ -72,12 +72,12 @@ public:
     /*!\name Constructors, destructor and assignment
      * \{
      */
-    constexpr aa20() : base_t{} {}
-    constexpr aa20(aa20 const &) = default;
-    constexpr aa20(aa20 &&) = default;
-    constexpr aa20 & operator=(aa20 const &) = default;
-    constexpr aa20 & operator=(aa20 &&) = default;
-    ~aa20() = default;
+    constexpr aa20() : base_t{} {}                      //!< Defaulted.
+    constexpr aa20(aa20 const &) = default;             //!< Defaulted.
+    constexpr aa20(aa20 &&) = default;                  //!< Defaulted.
+    constexpr aa20 & operator=(aa20 const &) = default; //!< Defaulted.
+    constexpr aa20 & operator=(aa20 &&) = default;      //!< Defaulted.
+    ~aa20() = default;                                  //!< Defaulted.
 
     using base_t::base_t;
     //!\}

--- a/include/seqan3/alphabet/aminoacid/aa27.hpp
+++ b/include/seqan3/alphabet/aminoacid/aa27.hpp
@@ -54,12 +54,12 @@ public:
     /*!\name Constructors, destructor and assignment
      * \{
      */
-    constexpr aa27() : base_t{} {}
-    constexpr aa27(aa27 const &) = default;
-    constexpr aa27(aa27 &&) = default;
-    constexpr aa27 & operator=(aa27 const &) = default;
-    constexpr aa27 & operator=(aa27 &&) = default;
-    ~aa27() = default;
+    constexpr aa27() : base_t{} {}                       //!< Defaulted.
+    constexpr aa27(aa27 const &) = default;              //!< Defaulted.
+    constexpr aa27(aa27 &&) = default;                   //!< Defaulted.
+    constexpr aa27 & operator=(aa27 const &) = default;  //!< Defaulted.
+    constexpr aa27 & operator=(aa27 &&) = default;       //!< Defaulted.
+    ~aa27() = default;                                   //!< Defaulted.
 
     using base_t::base_t;
     //!\}

--- a/include/seqan3/alphabet/aminoacid/aminoacid_base.hpp
+++ b/include/seqan3/alphabet/aminoacid/aminoacid_base.hpp
@@ -40,12 +40,12 @@ private:
     /*!\name Constructors, destructor and assignment
      * \{
      */
-    constexpr aminoacid_base() : base_t{} {}
-    constexpr aminoacid_base(aminoacid_base const &) = default;
-    constexpr aminoacid_base(aminoacid_base &&) = default;
-    constexpr aminoacid_base & operator=(aminoacid_base const &) = default;
-    constexpr aminoacid_base & operator=(aminoacid_base &&) = default;
-    ~aminoacid_base() = default;
+    constexpr aminoacid_base() : base_t{} {}                                 //!< Defaulted.
+    constexpr aminoacid_base(aminoacid_base const &) = default;              //!< Defaulted.
+    constexpr aminoacid_base(aminoacid_base &&) = default;                   //!< Defaulted.
+    constexpr aminoacid_base & operator=(aminoacid_base const &) = default;  //!< Defaulted.
+    constexpr aminoacid_base & operator=(aminoacid_base &&) = default;       //!< Defaulted.
+    ~aminoacid_base() = default;                                             //!< Defaulted.
     //!\}
 
     //!\brief Befriend the derived class so it can instantiate.

--- a/include/seqan3/alphabet/composition/cartesian_composition.hpp
+++ b/include/seqan3/alphabet/composition/cartesian_composition.hpp
@@ -246,12 +246,12 @@ private:
         /*!\name Constructors, destructor and assignment
          * \{
          */
-        constexpr component_proxy() : base_t{}, parent{} {}
-        constexpr component_proxy(component_proxy const &) = default;
-        constexpr component_proxy(component_proxy &&) = default;
-        constexpr component_proxy & operator=(component_proxy const &) = default;
-        constexpr component_proxy & operator=(component_proxy &&) = default;
-        ~component_proxy() = default;
+        constexpr component_proxy() : base_t{}, parent{} {}                        //!< Defaulted.
+        constexpr component_proxy(component_proxy const &) = default;              //!< Defaulted.
+        constexpr component_proxy(component_proxy &&) = default;                   //!< Defaulted.
+        constexpr component_proxy & operator=(component_proxy const &) = default;  //!< Defaulted.
+        constexpr component_proxy & operator=(component_proxy &&) = default;       //!< Defaulted.
+        ~component_proxy() = default;                                              //!< Defaulted.
 
         constexpr component_proxy(alphabet_type const l, cartesian_composition & p) :
             base_t{l}, parent{&p}

--- a/include/seqan3/alphabet/composition/union_composition.hpp
+++ b/include/seqan3/alphabet/composition/union_composition.hpp
@@ -214,12 +214,12 @@ public:
     /*!\name Constructors, destructor and assignment
      * \{
      */
-    constexpr union_composition() noexcept : base_t{} {}
-    constexpr union_composition(union_composition const &) = default;
-    constexpr union_composition(union_composition &&) = default;
-    constexpr union_composition & operator=(union_composition const &) = default;
-    constexpr union_composition & operator=(union_composition &&) = default;
-    ~union_composition() = default;
+    constexpr union_composition() noexcept : base_t{} {}                           //!< Defaulted.
+    constexpr union_composition(union_composition const &) = default;              //!< Defaulted.
+    constexpr union_composition(union_composition &&) = default;                   //!< Defaulted.
+    constexpr union_composition & operator=(union_composition const &) = default;  //!< Defaulted.
+    constexpr union_composition & operator=(union_composition &&) = default;       //!< Defaulted.
+    ~union_composition() = default;                                                //!< Defaulted.
 
     /*!\brief Construction via the value of an alternative.
      * \tparam alternative_t One of the alternative types.

--- a/include/seqan3/alphabet/detail/alphabet_base.hpp
+++ b/include/seqan3/alphabet/detail/alphabet_base.hpp
@@ -69,12 +69,12 @@ public:
     /*!\name Constructors, destructor and assignment
      * \{
      */
-    constexpr alphabet_base() noexcept : rank{} {}
-    constexpr alphabet_base(alphabet_base const &) = default;
-    constexpr alphabet_base(alphabet_base &&) = default;
-    constexpr alphabet_base & operator=(alphabet_base const &) = default;
-    constexpr alphabet_base & operator=(alphabet_base &&) = default;
-    ~alphabet_base() = default;
+    constexpr alphabet_base() noexcept : rank{} {}                        //!< Defaulted.
+    constexpr alphabet_base(alphabet_base const &) = default;             //!< Defaulted.
+    constexpr alphabet_base(alphabet_base &&) = default;                  //!< Defaulted.
+    constexpr alphabet_base & operator=(alphabet_base const &) = default; //!< Defaulted.
+    constexpr alphabet_base & operator=(alphabet_base &&) = default;      //!< Defaulted.
+    ~alphabet_base() = default;                                           //!< Defaulted.
     //!\}
 
     /*!\name Read functions
@@ -302,12 +302,12 @@ public:
     /*!\name Constructors, destructor and assignment
      * \{
      */
-    constexpr alphabet_base() noexcept = default;
-    constexpr alphabet_base(alphabet_base const &) = default;
-    constexpr alphabet_base(alphabet_base &&) = default;
-    constexpr alphabet_base & operator=(alphabet_base const &) = default;
-    constexpr alphabet_base & operator=(alphabet_base &&) = default;
-    ~alphabet_base() = default;
+    constexpr alphabet_base() noexcept = default;                         //!< Defaulted.
+    constexpr alphabet_base(alphabet_base const &) = default;             //!< Defaulted.
+    constexpr alphabet_base(alphabet_base &&) = default;                  //!< Defaulted.
+    constexpr alphabet_base & operator=(alphabet_base const &) = default; //!< Defaulted.
+    constexpr alphabet_base & operator=(alphabet_base &&) = default;      //!< Defaulted.
+    ~alphabet_base() = default;                                           //!< Defaulted.
     //!\}
 
     /*!\name Read functions

--- a/include/seqan3/alphabet/detail/alphabet_proxy.hpp
+++ b/include/seqan3/alphabet/detail/alphabet_proxy.hpp
@@ -157,12 +157,12 @@ private:
     /*!\name Constructors, destructor and assignment
      * \{
      */
-    constexpr alphabet_proxy() noexcept : base_t{} {}
-    constexpr alphabet_proxy(alphabet_proxy const &) = default;
-    constexpr alphabet_proxy(alphabet_proxy &&) = default;
-    constexpr alphabet_proxy & operator=(alphabet_proxy const &) = default;
-    constexpr alphabet_proxy & operator=(alphabet_proxy &&) = default;
-    ~alphabet_proxy() = default;
+    constexpr alphabet_proxy() noexcept : base_t{} {}                       //!< Defaulted.
+    constexpr alphabet_proxy(alphabet_proxy const &) = default;             //!< Defaulted.
+    constexpr alphabet_proxy(alphabet_proxy &&) = default;                  //!< Defaulted.
+    constexpr alphabet_proxy & operator=(alphabet_proxy const &) = default; //!< Defaulted.
+    constexpr alphabet_proxy & operator=(alphabet_proxy &&) = default;      //!< Defaulted.
+    ~alphabet_proxy() = default;                                            //!< Defaulted.
 
     //!\brief Construction from the emulated type.
     constexpr alphabet_proxy(alphabet_type const a) noexcept

--- a/include/seqan3/alphabet/gap/gap.hpp
+++ b/include/seqan3/alphabet/gap/gap.hpp
@@ -48,12 +48,12 @@ public:
     /*!\name Constructors, destructor and assignment
      * \{
      */
-    constexpr gap() noexcept : base_t{} {}
-    constexpr gap(gap const &) = default;
-    constexpr gap(gap &&) = default;
-    constexpr gap & operator=(gap const &) = default;
-    constexpr gap & operator=(gap &&) = default;
-    ~gap() = default;
+    constexpr gap() noexcept : base_t{} {}            //!< Defaulted.
+    constexpr gap(gap const &) = default;             //!< Defaulted.
+    constexpr gap(gap &&) = default;                  //!< Defaulted.
+    constexpr gap & operator=(gap const &) = default; //!< Defaulted.
+    constexpr gap & operator=(gap &&) = default;      //!< Defaulted.
+    ~gap() = default;                                 //!< Defaulted.
 
     using base_t::base_t;
     //!\}

--- a/include/seqan3/alphabet/mask/mask.hpp
+++ b/include/seqan3/alphabet/mask/mask.hpp
@@ -44,12 +44,12 @@ public:
     /*!\name Constructors, destructor and assignment
      * \{
      */
-    constexpr mask() : base_t{} {}
-    constexpr mask(mask const &) = default;
-    constexpr mask(mask &&) = default;
-    constexpr mask & operator=(mask const &) = default;
-    constexpr mask & operator=(mask &&) = default;
-    ~mask() = default;
+    constexpr mask() : base_t{} {}                      //!< Defaulted.
+    constexpr mask(mask const &) = default;             //!< Defaulted.
+    constexpr mask(mask &&) = default;                  //!< Defaulted.
+    constexpr mask & operator=(mask const &) = default; //!< Defaulted.
+    constexpr mask & operator=(mask &&) = default;      //!< Defaulted.
+    ~mask() = default;                                  //!< Defaulted.
     //!\}
 
     /*!\name Boolean values

--- a/include/seqan3/alphabet/mask/masked.hpp
+++ b/include/seqan3/alphabet/mask/masked.hpp
@@ -59,12 +59,12 @@ public:
     /*!\name Constructors, destructor and assignment
      * \{
      */
-    constexpr masked() : base_type{} {}
-    constexpr masked(masked const &) = default;
-    constexpr masked(masked &&) = default;
-    constexpr masked & operator =(masked const &) = default;
-    constexpr masked & operator =(masked &&) = default;
-    ~masked() = default;
+    constexpr masked() : base_type{} {}                      //!< Defaulted.
+    constexpr masked(masked const &) = default;              //!< Defaulted.
+    constexpr masked(masked &&) = default;                   //!< Defaulted.
+    constexpr masked & operator =(masked const &) = default; //!< Defaulted.
+    constexpr masked & operator =(masked &&) = default;      //!< Defaulted.
+    ~masked() = default;                                     //!< Defaulted.
 
     using base_type::base_type; // Inherit non-default constructors
 


### PR DESCRIPTION
Fixes for doxygen warning due to uncommented default construction in alphabet part I.
There are some empty constructors, I commented them with empty, hope that is okay.