### PR TITLE
fixes some issues with view::take / view::drop / view::slice

### DIFF
--- a/doc/howto/write_a_view/solution_view.cpp
+++ b/doc/howto/write_a_view/solution_view.cpp
@@ -9,9 +9,9 @@
 using namespace seqan3;
 
 /* The iterator template */
-template <std::ranges::ForwardRange urng_t>     // CRTP derivation ↓
-struct my_iterator : seqan3::detail::inherited_iterator_base<my_iterator<urng_t>,
-                                                             std::ranges::iterator_t<urng_t>>
+template <std::ranges::ForwardRange urng_t>            // CRTP derivation ↓
+class my_iterator : public seqan3::detail::inherited_iterator_base<my_iterator<urng_t>,
+                                                                   std::ranges::iterator_t<urng_t>>
 {
 private:
     static_assert(NucleotideAlphabet<reference_t<urng_t>>,
@@ -21,9 +21,6 @@ private:
     using base_t = seqan3::detail::inherited_iterator_base<my_iterator<urng_t>,
                                                            std::ranges::iterator_t<urng_t>>;
 
-    // the CRTP in turns inherits from the actual iterator we are adapting
-    using base_base_t = std::ranges::iterator_t<urng_t>;
-
 public:
     // the member types are never imported automatically, but can be explicitly inherited:
     using typename base_t::value_type;
@@ -31,6 +28,16 @@ public:
     using typename base_t::iterator_category;
     // this member type is overwritten as we do above:
     using reference = value_type;
+
+    // define rule-of-six:
+    my_iterator() = default;
+    my_iterator(my_iterator const &) = default;
+    my_iterator(my_iterator &&) = default;
+    my_iterator & operator=(my_iterator const &) = default;
+    my_iterator & operator=(my_iterator &&) = default;
+    ~my_iterator() = default;
+    // and a constructor that takes the base_type:
+    my_iterator(base_t it) : base_t{std::move(it)} {}
 
     // we don't need to implement the ++ operators anymore!
 

--- a/include/seqan3/range/concept.hpp
+++ b/include/seqan3/range/concept.hpp
@@ -47,4 +47,18 @@ SEQAN3_CONCEPT const_iterable_concept =
     (std::ranges::RandomAccessRange<std::remove_const_t<type>>  == std::ranges::RandomAccessRange<type const>);
 //!\endcond
 
+/*!\interface seqan3::ForwardingRange<>
+ * \extends std::Range
+ * \brief Specifies a range whose iterators may outlive the range and remain valid.
+ * \see http://eel.is/c++draft/range.req
+ */
+//!\cond
+template <typename type>
+SEQAN3_CONCEPT ForwardingRange = std::ranges::Range<type> && requires (type && val)
+{
+    std::ranges::begin(std::forward<type>(val));
+    std::ranges::end(std::forward<type>(val));
+};
+//!\endcond
+
 } // namespace seqan3

--- a/include/seqan3/range/detail/inherited_iterator_base.hpp
+++ b/include/seqan3/range/detail/inherited_iterator_base.hpp
@@ -21,6 +21,10 @@
 namespace seqan3::detail
 {
 
+//!\brief An empty class type used in meta programming.
+struct empty_type
+{};
+
 /*!\brief A CRTP base template for creating iterators that inherit from other iterators.
  * \tparam derived_t The CRTP specialisation.
  * \tparam base_t    The type to inherit from; must satisfy std::Iterator.
@@ -31,6 +35,8 @@ namespace seqan3::detail
  *
  * This template enables you to inherit from another iterator and just overload those functions
  * that you wish to change.
+ *
+ * Note that many of this class's members assume that the derived type is constructible from the base type.
  *
  * ### Example
  *
@@ -43,7 +49,7 @@ namespace seqan3::detail
  * \snippet test/unit/range/detail/inherited_iterator_base_test.cpp inherited_iterator_base def
  */
 template <typename derived_t, std::Iterator base_t>
-class inherited_iterator_base : public base_t
+class inherited_iterator_base : public std::conditional_t<std::is_pointer_v<base_t>, empty_type, base_t>
 {
 public:
     /*!\name Associated types
@@ -58,31 +64,54 @@ public:
     //!\}
 
     /*!\name Constructors, destructor and assignment
+     * \brief The exception specification is explicitly "inherited" to also work for pointers as base.
      * \{
      */
-    inherited_iterator_base()                                                          = default; //!< Defaulted.
-    constexpr inherited_iterator_base(inherited_iterator_base const & rhs)             = default; //!< Defaulted.
-    constexpr inherited_iterator_base(inherited_iterator_base && rhs)                  = default; //!< Defaulted.
-    constexpr inherited_iterator_base & operator=(inherited_iterator_base const & rhs) = default; //!< Defaulted.
-    constexpr inherited_iterator_base & operator=(inherited_iterator_base && rhs)      = default; //!< Defaulted.
-    ~inherited_iterator_base()                                                         = default; //!< Defaulted.
+    constexpr inherited_iterator_base()
+        noexcept(std::is_nothrow_default_constructible_v<base_t>)                       = default; //!< Defaulted.
+    constexpr inherited_iterator_base(inherited_iterator_base const & rhs)
+        noexcept(std::is_nothrow_copy_constructible_v<base_t>)                          = default; //!< Defaulted.
+    constexpr inherited_iterator_base(inherited_iterator_base && rhs)
+        noexcept(std::is_nothrow_move_constructible_v<base_t>)                          = default; //!< Defaulted.
+    constexpr inherited_iterator_base & operator=(inherited_iterator_base const & rhs)
+        noexcept(std::is_nothrow_copy_assignable_v<base_t>)                             = default; //!< Defaulted.
+    constexpr inherited_iterator_base & operator=(inherited_iterator_base && rhs)
+        noexcept(std::is_nothrow_move_assignable_v<base_t>)                             = default; //!< Defaulted.
+    ~inherited_iterator_base()
+        noexcept(std::is_nothrow_destructible_v<base_t>)                                = default; //!< Defaulted.
 
-    inherited_iterator_base(base_t it) : base_t{it} {}
+    //!\brief Delegate to base class if inheriting from non-pointer iterator.
+    constexpr inherited_iterator_base(base_t it) noexcept(std::is_nothrow_move_constructible_v<base_t>)
+    //!\cond
+        requires !std::is_pointer_v<base_t>
+    //!\endcond
+        : base_t{std::move(it)}
+    {}
+
+    //!\brief Initialise member if deriving from pointer.
+    constexpr inherited_iterator_base(base_t it) noexcept
+    //!\cond
+        requires std::is_pointer_v<base_t>
+    //!\endcond
+        : member{std::move(it)}
+    {}
     //!\}
 
     /*!\name Comparison operators
      * \brief Unless specialised in derived_type, all operators perform base_t's operator and cast to derived_t.
      * \{
      */
-    constexpr bool operator==(derived_t const & rhs) const noexcept(noexcept(base_t{} == base_t{}))
+    constexpr bool operator==(derived_t const & rhs) const
+        noexcept(noexcept(std::declval<base_t &>() == std::declval<base_t &>()))
     //!\cond
         requires std::EqualityComparable<base_t>
     //!\endcond
     {
-        return *this_to_base() == static_cast<base_t>(rhs);
+        return *this_to_base() == *rhs.this_to_base();
     }
 
-    constexpr bool operator!=(derived_t const & rhs) const noexcept(noexcept(base_t{} == base_t{}))
+    constexpr bool operator!=(derived_t const & rhs) const
+        noexcept(noexcept(std::declval<base_t &>() == std::declval<base_t &>()))
     //!\cond
         requires std::EqualityComparable<base_t>
     //!\endcond
@@ -90,23 +119,26 @@ public:
         return !(*this == rhs);
     }
 
-    constexpr bool operator<(derived_t const & rhs) const noexcept(noexcept(base_t{} < base_t{}))
+    constexpr bool operator<(derived_t const & rhs) const
+        noexcept(noexcept(std::declval<base_t &>() < std::declval<base_t &>()))
     //!\cond
         requires std::StrictTotallyOrdered<base_t>
     //!\endcond
     {
-        return *this_to_base() < static_cast<base_t>(rhs);
+        return *this_to_base() < *rhs.this_to_base();
     }
 
-    constexpr bool operator>(derived_t const & rhs) const noexcept(noexcept(base_t{} > base_t{}))
+    constexpr bool operator>(derived_t const & rhs) const
+        noexcept(noexcept(std::declval<base_t &>() > std::declval<base_t &>()))
     //!\cond
         requires std::StrictTotallyOrdered<base_t>
     //!\endcond
     {
-        return *this_to_base() > static_cast<base_t>(rhs);
+        return *this_to_base() > *rhs.this_to_base();
     }
 
-    constexpr bool operator<=(derived_t const & rhs) const noexcept(noexcept(base_t{} < base_t{}))
+    constexpr bool operator<=(derived_t const & rhs) const
+        noexcept(noexcept(std::declval<base_t &>() > std::declval<base_t &>()))
     //!\cond
         requires std::StrictTotallyOrdered<base_t>
     //!\endcond
@@ -114,7 +146,8 @@ public:
         return !(*this > rhs);
     }
 
-    constexpr bool operator>=(derived_t const & rhs) const noexcept(noexcept(base_t{} < base_t{}))
+    constexpr bool operator>=(derived_t const & rhs) const
+        noexcept(noexcept(std::declval<base_t &>() < std::declval<base_t &>()))
     //!\cond
         requires std::StrictTotallyOrdered<base_t>
     //!\endcond
@@ -128,7 +161,7 @@ public:
      * \{
     */
     //!\brief Pre-increment, return updated iterator.
-    constexpr derived_t & operator++() noexcept(noexcept(++base_t{}))
+    constexpr derived_t & operator++() noexcept(noexcept(++std::declval<base_t &>()))
     //!\cond
         requires std::InputIterator<base_t>
     //!\endcond
@@ -138,18 +171,19 @@ public:
     }
 
     //!\brief Post-increment, return previous iterator state.
-    constexpr derived_t operator++(int) noexcept(noexcept(++base_t{}))
+    constexpr derived_t operator++(int) noexcept(noexcept(++std::declval<derived_t &>()) &&
+                                                 noexcept(derived_t(std::declval<base_t &>())))
     //!\cond
         requires std::InputIterator<base_t>
     //!\endcond
     {
-        derived_t cpy{*this};
+        derived_t cpy{*this_to_base()};
         ++(*this_derived());
         return cpy;
     }
 
     //!\brief Pre-decrement, return updated iterator.
-    constexpr derived_t & operator--() noexcept(noexcept(--base_t{}))
+    constexpr derived_t & operator--() noexcept(noexcept(--std::declval<base_t &>()))
     //!\cond
         requires std::BidirectionalIterator<base_t>
     //!\endcond
@@ -159,18 +193,19 @@ public:
     }
 
     //!\brief Post-decrement, return previous iterator state.
-    constexpr derived_t operator--(int) noexcept(noexcept(--base_t{}))
+    constexpr derived_t operator--(int) noexcept(noexcept(--std::declval<derived_t &>()) &&
+                                                 noexcept(derived_t{std::declval<base_t &>()}))
     //!\cond
         requires std::BidirectionalIterator<base_t>
     //!\endcond
     {
-        derived_t cpy{*this};
+        derived_t cpy{*this_to_base()};
         --(*this_derived());
         return cpy;
     }
 
     //!\brief Move iterator to the right.
-    constexpr derived_t & operator+=(difference_type const skip) noexcept(noexcept(base_t{} += skip))
+    constexpr derived_t & operator+=(difference_type const skip) noexcept(noexcept(std::declval<base_t &>() += skip))
     //!\cond
         requires std::RandomAccessIterator<base_t>
     //!\endcond
@@ -180,17 +215,19 @@ public:
     }
 
     //!\brief Return a an iterator moved to the right.
-    constexpr derived_t operator+(difference_type const skip) const noexcept(noexcept(base_t{} += skip))
+    constexpr derived_t operator+(difference_type const skip) const
+        noexcept(noexcept(std::declval<derived_t &>() += skip) && noexcept(derived_t{std::declval<base_t &>()}))
     //!\cond
         requires std::RandomAccessIterator<base_t>
     //!\endcond
     {
-        derived_t cpy{*this};
+        derived_t cpy{*this_to_base()};
         return cpy += skip;
     }
 
     //!\brief Non-member operator+ delegates to non-friend operator+.
-    constexpr friend derived_t operator+(difference_type const skip, derived_t const & it) noexcept(noexcept(base_t{} += skip))
+    constexpr friend derived_t operator+(difference_type const skip, derived_t const & it)
+        noexcept(noexcept(it + skip))
     //!\cond
         requires std::RandomAccessIterator<base_t>
     //!\endcond
@@ -199,7 +236,7 @@ public:
     }
 
     //!\brief Decrement iterator by skip.
-    constexpr derived_t & operator-=(difference_type const skip) noexcept(noexcept(base_t{} -= skip))
+    constexpr derived_t & operator-=(difference_type const skip) noexcept(noexcept(std::declval<derived_t &>() += skip))
     //!\cond
         requires std::RandomAccessIterator<base_t>
     //!\endcond
@@ -208,17 +245,19 @@ public:
     }
 
     //!\brief Return decremented copy of this iterator.
-    constexpr derived_t operator-(difference_type const skip) const noexcept(noexcept(base_t{} -= skip))
+    constexpr derived_t operator-(difference_type const skip) const
+        noexcept(noexcept(std::declval<derived_t &>() -= skip) && noexcept(derived_t(std::declval<base_t &>())))
     //!\cond
         requires std::RandomAccessIterator<base_t>
     //!\endcond
     {
-        derived_t cpy{*this};
+        derived_t cpy{*this_to_base()};
         return cpy -= skip;
     }
 
     //!\brief Non-member operator- delegates to non-friend operator-.
-    constexpr friend derived_t operator-(difference_type const skip, derived_t const & it) noexcept(noexcept(base_t{} -= skip))
+    constexpr friend derived_t operator-(difference_type const skip, derived_t const & it)
+        noexcept(noexcept(std::declval<derived_t &>() - skip))
     //!\cond
         requires std::RandomAccessIterator<base_t>
     //!\endcond
@@ -227,13 +266,14 @@ public:
     }
 
     //!\brief Return offset between this and remote iterator's position.
-    constexpr difference_type operator-(derived_t const rhs) const noexcept
+    constexpr difference_type operator-(derived_t const rhs) const
+        noexcept(noexcept(std::declval<base_t &>() - std::declval<base_t &>()))
     //!\cond
         requires std::RandomAccessIterator<base_t>
     //!\endcond
     {
-        assert(static_cast<base_t>(rhs) > *this_to_base());
-        return static_cast<difference_type>(*this_to_base() - static_cast<base_t>(rhs));
+        assert(*rhs.this_to_base() > *this_to_base());
+        return static_cast<difference_type>(*this_to_base() - *rhs.this_to_base());
     }
     //!\}
 
@@ -241,7 +281,7 @@ public:
      * \{
     */
     //!\brief Dereference operator returns element currently pointed at.
-    constexpr reference operator*() const noexcept(noexcept(*base_t{}))
+    constexpr reference operator*() const noexcept(noexcept(*std::declval<base_t &>()))
     //!\cond
         requires std::InputIterator<base_t>
     //!\endcond
@@ -250,7 +290,7 @@ public:
     }
 
     //!\brief Return pointer to this iterator.
-    constexpr pointer operator->() const noexcept(noexcept(*base_t{}))
+    constexpr pointer operator->() const noexcept(noexcept(*std::declval<base_t &>()))
     //!\cond
         requires std::InputIterator<base_t>
     //!\endcond
@@ -259,7 +299,8 @@ public:
     }
 
     //!\brief Return underlying container value currently pointed at.
-    constexpr decltype(auto) operator[](std::make_signed_t<difference_type> const n) const noexcept(noexcept(base_t{}[0]))
+    constexpr decltype(auto) operator[](std::make_signed_t<difference_type> const n) const
+        noexcept(noexcept(*std::declval<derived_t &>()) && noexcept(std::declval<derived_t &>() + 3))
     //!\cond
         requires std::RandomAccessIterator<base_t>
     //!\endcond
@@ -269,6 +310,11 @@ public:
     //!\}
 
 private:
+    //!\brief If the base is a pointer, we wrap it instead of inheriting.
+    std::conditional_t<std::is_pointer_v<base_t>, base_t, empty_type> member;
+
+    //!\brief Befriend the derived type so it can access the private members.
+    friend derived_t;
 
     //!\brief Cast this to derived type.
     derived_t * this_derived()
@@ -285,13 +331,19 @@ private:
     //!\brief Cast this to base type.
     base_t * this_to_base()
     {
-        return static_cast<base_t*>(this);
+        if constexpr (std::is_pointer_v<base_t>)
+            return &member;
+        else
+            return static_cast<base_t*>(this);
     }
 
     //!\copydoc this_to_base
     base_t const * this_to_base() const
     {
-        return static_cast<base_t const *>(this);
+        if constexpr (std::is_pointer_v<base_t>)
+            return &member;
+        else
+            return static_cast<base_t const *>(this);
     }
 };
 

--- a/include/seqan3/range/view/drop.hpp
+++ b/include/seqan3/range/view/drop.hpp
@@ -39,92 +39,60 @@ struct drop_fn
         return detail::adaptor_from_functor{*this, drop_size};
     }
 
-    /*!\brief       Call the view's constructor with the underlying view as argument.
-     * \returns     An instance of std::ranges::subrange.
+     /*!\brief Type erase if possible and forward to std::view::drop if not.
+     * \returns An instance of std::span, std::basic_string_view, std::ranges::subrange or std::ranges::drop_view.
      */
-    template <std::ranges::ViewableRange urng_t>
-    constexpr auto operator()(urng_t && urange, size_t drop_size) const noexcept
+    template <std::ranges::Range urng_t>
+    constexpr auto operator()(urng_t && urange, size_t drop_size) const
     {
-        auto b = std::ranges::begin(urange);
+        static_assert(std::ranges::ViewableRange<urng_t>,
+                      "The view::drop adaptor can only be passed ViewableRanges, i.e. Views or &-to-non-View.");
 
+        [[maybe_unused]] size_t new_size = -1;
+
+        // safeguard against wrong size
         if constexpr (std::ranges::SizedRange<urng_t>)
         {
             drop_size = std::min(drop_size, std::ranges::size(urange));
-            std::ranges::advance(b, drop_size);
+            new_size = std::ranges::size(urange) - drop_size;
+        }
 
-            return std::ranges::subrange<std::ranges::iterator_t<urng_t>,
-                                         std::ranges::sentinel_t<urng_t>,
-                                         std::ranges::subrange_kind::sized>
+        // string_view
+        if constexpr (is_type_specialisation_of_v<remove_cvref_t<urng_t>, std::basic_string_view>)
+        {
+            return urange.substr(drop_size);
+        }
+        // string const &
+        else if constexpr (is_type_specialisation_of_v<remove_cvref_t<urng_t>, std::basic_string> &&
+                           std::is_const_v<std::remove_reference_t<urng_t>>)
+        {
+            return std::basic_string_view{std::ranges::data(urange) + drop_size, new_size};
+        }
+        // contiguous
+        else if constexpr (ForwardingRange<urng_t> &&
+                           std::ranges::ContiguousRange<urng_t> &&
+                           std::ranges::SizedRange<urng_t>)
+        {
+            return std::span{std::ranges::data(urange) + drop_size, new_size};
+        }
+        // random_access
+        else if constexpr (ForwardingRange<urng_t> &&
+                           std::ranges::RandomAccessRange<urng_t> &&
+                           std::ranges::SizedRange<urng_t>)
+        {
+            return std::ranges::subrange<std::ranges::iterator_t<urng_t>, std::ranges::iterator_t<urng_t>>
             {
-                std::move(b),
-                std::ranges::end(urange),
-                std::ranges::size(urange) - drop_size
+                std::ranges::begin(urange) + drop_size,
+                std::ranges::begin(urange) + drop_size + new_size,
+                new_size
             };
         }
+        // std::view::drop
         else
         {
-            for (size_t i = 0; (i < drop_size) && (b != std::ranges::end(urange)); ++i, ++b);
-
-            return std::ranges::subrange<std::ranges::iterator_t<urng_t>,
-                                         std::ranges::sentinel_t<urng_t>>
-            {
-                std::move(b),
-                std::ranges::end(urange)
-            };
+            return std::forward<urng_t>(urange) | std::view::drop(drop_size);
         }
     }
-
-    /*!\brief       Overload for contiguous, sized ranges.
-     * \returns     A std::span over the input.
-     */
-    template <std::ranges::ViewableRange urng_t>
-    //!\cond
-        requires std::ranges::ContiguousRange<urng_t> && std::ranges::SizedRange<urng_t>
-    //!\endcond
-    constexpr auto operator()(urng_t && urange, size_t drop_size) const noexcept
-    {
-        drop_size = std::min(drop_size, std::ranges::size(urange));
-        return std::span{std::ranges::data(urange) + drop_size, std::ranges::size(urange) - drop_size};
-    }
-
-    /*!\brief       Overload for std::basic_string_view.
-     * \returns     A std::basic_string_view over the input.
-     */
-    template <std::ranges::ViewableRange urng_t>
-    //!\cond
-        requires std::ranges::ContiguousRange<urng_t> && std::ranges::SizedRange<urng_t> &&
-                 is_type_specialisation_of_v<std::remove_reference_t<urng_t>, std::basic_string_view>
-    //!\endcond
-    constexpr auto operator()(urng_t && urange, size_t drop_size) const noexcept
-    {
-        drop_size = std::min(drop_size, std::ranges::size(urange));
-        return urange.substr(drop_size);
-    }
-
-    /*!\brief       Overload for std::basic_string.
-     * \returns     A std::basic_string_view over the input.
-     */
-    template <typename char_t, typename traits_t, typename alloc_t>
-    constexpr std::basic_string_view<char_t, traits_t>
-    operator()(std::basic_string<char_t, traits_t, alloc_t> & urange, size_t drop_size) const noexcept
-    {
-        drop_size = std::min(drop_size, std::ranges::size(urange));
-        return {std::ranges::data(urange) + drop_size, std::ranges::size(urange) - drop_size};
-    }
-
-    //!\overload
-    template <typename char_t, typename traits_t, typename alloc_t>
-    constexpr std::basic_string_view<char_t, traits_t>
-    operator()(std::basic_string<char_t, traits_t, alloc_t> const & urange, size_t drop_size) const noexcept
-    {
-        drop_size = std::min(drop_size, std::ranges::size(urange));
-        return {std::ranges::data(urange) + drop_size, std::ranges::size(urange) - drop_size};
-    }
-
-    //!\overload
-    template <typename char_t, typename traits_t, typename alloc_t>
-    constexpr std::basic_string_view<char_t, traits_t>
-    operator()(std::basic_string<char_t, traits_t, alloc_t> const && urange, size_t drop_size) const = delete;
 };
 
 } // namespace seqan3::detail
@@ -153,32 +121,33 @@ namespace seqan3::view
  *
  * ### View properties
  *
- * | range concepts and reference_t  | `urng_t` (underlying range type)      | `rrng_t` (returned range type)                     |
- * |---------------------------------|:-------------------------------------:|:--------------------------------------------------:|
- * | std::ranges::InputRange         | *required*                            | *preserved*                                        |
- * | std::ranges::ForwardRange       |                                       | *preserved*                                        |
- * | std::ranges::BidirectionalRange |                                       | *preserved*                                        |
- * | std::ranges::RandomAccessRange  |                                       | *preserved*                                        |
- * | std::ranges::ContiguousRange    |                                       | *preserved*                                        |
- * |                                 |                                       |                                                    |
- * | std::ranges::ViewableRange      | *required*                            | *guaranteed*                                       |
- * | std::ranges::View               |                                       | *guaranteed*                                       |
- * | std::ranges::SizedRange         |                                       | *preserved*                                        |
- * | std::ranges::CommonRange        |                                       | *preserved*                                        |
- * | std::ranges::OutputRange        |                                       | *preserved* unless `urng_t` is std::basic_string   |
- * | seqan3::const_iterable_concept  |                                       | *preserved*                                        |
- * |                                 |                                       |                                                    |
- * | seqan3::reference_t             |                                       | seqan3::reference_t<urng_t>                        |
+ * | range concepts and reference_t  | `urng_t` (underlying range type)   | `rrng_t` (returned range type)  |
+ * |---------------------------------|:----------------------------------:|:-------------------------------:|
+ * | std::ranges::InputRange         | *required*                         | *preserved*                     |
+ * | std::ranges::ForwardRange       |                                    | *preserved*                     |
+ * | std::ranges::BidirectionalRange |                                    | *preserved*                     |
+ * | std::ranges::RandomAccessRange  |                                    | *preserved*                     |
+ * | std::ranges::ContiguousRange    |                                    | *preserved*                     |
+ * |                                 |                                    |                                 |
+ * | std::ranges::ViewableRange      | *required*                         | *guaranteed*                    |
+ * | std::ranges::View               |                                    | *guaranteed*                    |
+ * | std::ranges::SizedRange         |                                    | *preserved*                     |
+ * | std::ranges::CommonRange        |                                    | *preserved*                     |
+ * | std::ranges::OutputRange        |                                    | *preserved*                     |
+ * | seqan3::const_iterable_concept  |                                    | *preserved*                     |
+ * |                                 |                                    |                                 |
+ * | seqan3::reference_t             |                                    | seqan3::reference_t<urng_t>     |
  *
  * See the \link view view submodule documentation \endlink for detailed descriptions of the view properties.
  *
  * ### Return type
  *
- * | `urng_t` (underlying range type)                          | `rrng_t` (returned range type)                     |
- * |:---------------------------------------------------------:|:--------------------------------------------------:|
- * | std::basic_string *or* std::basic_string_view             | std::basic_string_view                             |
- * | std::ranges::SizedRange && std::ranges::ContiguousRange   | std::span                                          |
- * | *else*                                                    | std::ranges::subrange                              |
+ * | `urng_t` (underlying range type)                                                       | `rrng_t` (returned range type)  |
+ * |:--------------------------------------------------------------------------------------:|:-------------------------------:|
+ * | `std::basic_string const &` *or* `std::basic_string_view`                              | `std::basic_string_view`        |
+ * | `seqan3::ForwardingRange && std::ranges::SizedRange && std::ranges::ContiguousRange`   | `std::span`                     |
+ * | `seqan3::ForwardingRange && std::ranges::SizedRange && std::ranges::RandomAccessRange` | `std::ranges::subrange`         |
+ * | *else*                                                                                 | *implementation defined type*   |
  *
  * The adaptor is different from std::view::drop in that it performs type erasure for some underlying ranges.
  * It returns exactly the type specified above.

--- a/include/seqan3/range/view/slice.hpp
+++ b/include/seqan3/range/view/slice.hpp
@@ -89,22 +89,22 @@ namespace seqan3::view
  *
  * ### View properties
  *
- * | range concepts and reference_t  | `urng_t` (underlying range type)      | `rrng_t` (returned range type)                     |
- * |---------------------------------|:-------------------------------------:|:--------------------------------------------------:|
- * | std::ranges::InputRange         | *required*                            | *preserved*                                        |
- * | std::ranges::ForwardRange       |                                       | *preserved*                                        |
- * | std::ranges::BidirectionalRange |                                       | *preserved*                                        |
- * | std::ranges::RandomAccessRange  |                                       | *preserved*                                        |
- * | std::ranges::ContiguousRange    |                                       | *preserved*                                        |
- * |                                 |                                       |                                                    |
- * | std::ranges::ViewableRange      | *required*                            | *guaranteed*                                       |
- * | std::ranges::View               |                                       | *guaranteed*                                       |
- * | std::ranges::SizedRange         |                                       | *preserved*                                        |
- * | std::ranges::CommonRange        |                                       | *preserved*                                        |
- * | std::ranges::OutputRange        |                                       | *preserved* unless `urng_t` is std::basic_string   |
- * | seqan3::const_iterable_concept  |                                       | *preserved*                                        |
- * |                                 |                                       |                                                    |
- * | seqan3::reference_t             |                                       | seqan3::reference_t<urng_t>                        |
+ * | range concepts and reference_t  | `urng_t` (underlying range type)  | `rrng_t` (returned range type)  |
+ * |---------------------------------|:---------------------------------:|:-------------------------------:|
+ * | std::ranges::InputRange         | *required*                        | *preserved*                     |
+ * | std::ranges::ForwardRange       |                                   | *preserved*                     |
+ * | std::ranges::BidirectionalRange |                                   | *preserved*                     |
+ * | std::ranges::RandomAccessRange  |                                   | *preserved*                     |
+ * | std::ranges::ContiguousRange    |                                   | *preserved*                     |
+ * |                                 |                                   |                                 |
+ * | std::ranges::ViewableRange      | *required*                        | *guaranteed*                    |
+ * | std::ranges::View               |                                   | *guaranteed*                    |
+ * | std::ranges::SizedRange         |                                   | *preserved*                     |
+ * | std::ranges::CommonRange        |                                   | *preserved*                     |
+ * | std::ranges::OutputRange        |                                   | *preserved*                     |
+ * | seqan3::const_iterable_concept  |                                   | *preserved*                     |
+ * |                                 |                                   |                                 |
+ * | seqan3::reference_t             |                                   | seqan3::reference_t<urng_t>     |
  *
  * See the \link view view submodule documentation \endlink for detailed descriptions of the view properties.
  *
@@ -113,15 +113,16 @@ namespace seqan3::view
  * If `begin_pos` is larger than the size of the underlying range an empty range is returned.
  * If `end_pos` is larger than the size of the underlying range less elements are returned.
  *
- * If `end_pos < begin_pos` and exception of type std::invalid_argument is thrown.
+ * If `end_pos < begin_pos` an exception of type std::invalid_argument is thrown.
  *
  * ### Return type
  *
- * | `urng_t` (underlying range type)                          | `rrng_t` (returned range type)                     |
- * |:---------------------------------------------------------:|:--------------------------------------------------:|
- * | std::basic_string *or* std::basic_string_view             | std::basic_string_view                             |
- * | std::ranges::SizedRange && std::ranges::ContiguousRange   | std::span                                          |
- * | *else*                                                    | std::ranges::subrange                              |
+ * | `urng_t` (underlying range type)                                                       | `rrng_t` (returned range type)  |
+ * |:--------------------------------------------------------------------------------------:|:-------------------------------:|
+ * | `std::basic_string const &` *or* `std::basic_string_view`                              | `std::basic_string_view`        |
+ * | `seqan3::ForwardingRange && std::ranges::SizedRange && std::ranges::ContiguousRange`   | `std::span`                     |
+ * | `seqan3::ForwardingRange && std::ranges::SizedRange && std::ranges::RandomAccessRange` | `std::ranges::subrange`         |
+ * | *else*                                                                                 | *implementation defined type*   |
  *
  * The adaptor returns exactly the type specified above.
  *

--- a/include/seqan3/range/view/view_all.hpp
+++ b/include/seqan3/range/view/view_all.hpp
@@ -14,6 +14,7 @@
 
 #include <string_view>
 
+#include <seqan3/core/metafunction/template_inspection.hpp>
 #include <seqan3/range/concept.hpp>
 #include <seqan3/range/view/detail.hpp>
 #include <seqan3/std/concepts>
@@ -43,61 +44,50 @@ private:
     //!\brief Befriend the base class so it can call impl().
     friend base_t;
 
-    /*!\brief       Overload for std::basic_string.
-     * \returns     A std::basic_string_view over the input.
+    /*!\brief Type erase if possible and delegate to std::view::all otherwise.
+     * \returns An instance of std::span, std::basic_string_view, std::ranges::subrange or std::view::all's return type.
      */
-    template <typename char_t, typename traits_t, typename allocator_t>
-    static auto impl(std::basic_string<char_t, traits_t, allocator_t> const & urange)
+    template <std::ranges::Range urng_t>
+    static constexpr auto impl(urng_t && urange)
     {
-        return std::basic_string_view<char_t, traits_t>{urange};
-    }
+        static_assert(std::ranges::ViewableRange<urng_t>,
+                      "The view::all adaptor can only be passed ViewableRanges, i.e. Views or &-to-non-View.");
 
-    //!\overload
-    template <typename char_t, typename traits_t, typename allocator_t>
-    static auto impl(std::basic_string<char_t, traits_t, allocator_t> & urange)
-    {
-        return std::basic_string_view<char_t, traits_t>{urange};
-    }
-
-    //!\overload
-    template <typename char_t, typename traits_t, typename allocator_t>
-    static auto impl(std::basic_string<char_t, traits_t, allocator_t> const && urange) = delete;
-
-    /*!\brief       Overload for contiguous, sized ranges that aren't views.
-     * \returns     A std::span over the input.
-     */
-    template <std::ranges::ViewableRange urng_t>
-        requires !std::ranges::View<std::remove_reference_t<urng_t>> && // views are copied/moved by std::view::all
-                 std::ranges::ContiguousRange<urng_t> &&
-                 std::ranges::SizedRange<urng_t>
-    static auto impl(urng_t && urange)
-    {
-        return std::span{std::ranges::data(urange), std::ranges::size(urange)};
-    }
-
-    /*!\brief       Overload for random-access, sized ranges that aren't views.
-     * \returns     A std::ranges::subrange over the input.
-     */
-    template <std::ranges::ViewableRange urng_t>
-        requires !std::ranges::View<std::remove_reference_t<urng_t>> && // views are copied/moved by std::view::all
-                 std::ranges::RandomAccessRange<urng_t> &&
-                 std::ranges::SizedRange<urng_t>
-    static auto impl(urng_t && urange)
-    {
-        return std::ranges::subrange<std::ranges::iterator_t<urng_t>, std::ranges::sentinel_t<urng_t>>
+        // views are always passed as-is
+        if constexpr (std::ranges::View<remove_cvref_t<urng_t>>)
         {
-            std::ranges::begin(urange),
-            std::ranges::end(urange)
-        };
-    }
-
-    /*!\brief       Overload for the most generic case.
-     * \returns     The parameter forwarded to std::view::all.
-     */
-    template <std::ranges::ViewableRange urng_t>
-    static auto impl(urng_t && urange)
-    {
-        return std::view::all(std::forward<urng_t>(urange));
+            return std::view::all(std::forward<urng_t>(urange));
+        }
+        // string const &
+        else if constexpr (is_type_specialisation_of_v<remove_cvref_t<urng_t>, std::basic_string> &&
+                           std::is_const_v<std::remove_reference_t<urng_t>>)
+        {
+            return std::basic_string_view{std::ranges::data(urange), std::ranges::size(urange)};
+        }
+        // contiguous
+        else if constexpr (ForwardingRange<urng_t> &&
+                           std::ranges::ContiguousRange<urng_t> &&
+                           std::ranges::SizedRange<urng_t>)
+        {
+            return std::span{std::ranges::data(urange), std::ranges::size(urange)};
+        }
+        // random_access
+        else if constexpr (ForwardingRange<urng_t> &&
+                           std::ranges::RandomAccessRange<urng_t> &&
+                           std::ranges::SizedRange<urng_t>)
+        {
+            return std::ranges::subrange<std::ranges::iterator_t<urng_t>, std::ranges::iterator_t<urng_t>>
+            {
+                std::ranges::begin(urange),
+                std::ranges::begin(urange) + std::ranges::size(urange),
+                std::ranges::size(urange)
+            };
+        }
+        // pass to std::view::all (will return ref-view)
+        else
+        {
+            return std::view::all(std::forward<urng_t>(urange));
+        }
     }
 };
 
@@ -125,35 +115,35 @@ namespace seqan3::view
  *
  * ### View properties
  *
- * | range concepts and reference_t  | `urng_t` (underlying range type)      | `rrng_t` (returned range type)                     |
- * |---------------------------------|:-------------------------------------:|:--------------------------------------------------:|
- * | std::ranges::InputRange         | *required*                            | *preserved*                                        |
- * | std::ranges::ForwardRange       |                                       | *preserved*                                        |
- * | std::ranges::BidirectionalRange |                                       | *preserved*                                        |
- * | std::ranges::RandomAccessRange  |                                       | *preserved*                                        |
- * | std::ranges::ContiguousRange    |                                       | *preserved*                                        |
- * |                                 |                                       |                                                    |
- * | std::ranges::ViewableRange      | *required*                            | *guaranteed*                                       |
- * | std::ranges::View               |                                       | *guaranteed*                                       |
- * | std::ranges::SizedRange         |                                       | *preserved*                                        |
- * | std::ranges::CommonRange        |                                       | *preserved*                                        |
- * | std::ranges::OutputRange        |                                       | *preserved* unless `urng_t` is std::basic_string   |
- * | seqan3::const_iterable_concept  |                                       | *preserved*                                        |
- * |                                 |                                       |                                                    |
- * | seqan3::reference_t             |                                       | seqan3::reference_t<urng_t>                        |
+ * | range concepts and reference_t  | `urng_t` (underlying range type)  | `rrng_t` (returned range type)  |
+ * |---------------------------------|:---------------------------------:|:-------------------------------:|
+ * | std::ranges::InputRange         | *required*                        | *preserved*                     |
+ * | std::ranges::ForwardRange       |                                   | *preserved*                     |
+ * | std::ranges::BidirectionalRange |                                   | *preserved*                     |
+ * | std::ranges::RandomAccessRange  |                                   | *preserved*                     |
+ * | std::ranges::ContiguousRange    |                                   | *preserved*                     |
+ * |                                 |                                   |                                 |
+ * | std::ranges::ViewableRange      | *required*                        | *guaranteed*                    |
+ * | std::ranges::View               |                                   | *guaranteed*                    |
+ * | std::ranges::SizedRange         |                                   | *preserved*                     |
+ * | std::ranges::CommonRange        |                                   | *preserved*                     |
+ * | std::ranges::OutputRange        |                                   | *preserved*                     |
+ * | seqan3::const_iterable_concept  |                                   | *preserved*                     |
+ * |                                 |                                   |                                 |
+ * | seqan3::reference_t             |                                   | seqan3::reference_t<urng_t>     |
  *
  * See the \link view view submodule documentation \endlink for detailed descriptions of the view properties.
  *
  * ### Return type
  *
- * | `urng_t` (underlying range type)                          | `rrng_t` (returned range type)                     |
- * |:---------------------------------------------------------:|:--------------------------------------------------:|
- * | std::basic_string *or* std::basic_string_view             | std::basic_string_view                             |
- * | std::ranges::SizedRange && std::ranges::ContiguousRange   | std::span                                          |
- * | std::ranges::SizedRange && std::ranges::RandomAccessRange | std::ranges::subrange                              |
- * | *else*                                                    | *implementation defined type*                      |
+ * | `urng_t` (underlying range type)                                                       | `rrng_t` (returned range type)  |
+ * |:--------------------------------------------------------------------------------------:|:-------------------------------:|
+ * | `std::basic_string const &` *or* `std::basic_string_view`                              | `std::basic_string_view`        |
+ * | `seqan3::ForwardingRange && std::ranges::SizedRange && std::ranges::ContiguousRange`   | `std::span`                     |
+ * | `seqan3::ForwardingRange && std::ranges::SizedRange && std::ranges::RandomAccessRange` | `std::ranges::subrange`         |
+ * | *else*                                                                                 | *implementation defined type*   |
  *
- * This adaptor is different from std::view::all in that it performs type erasure for some underlying ranges.
+ * This adaptor is different from std::view::take in that it performs type erasure for some underlying ranges.
  * It returns exactly the type specified above.
  *
  * ### Example

--- a/include/seqan3/search/algorithm/detail/search_trivial.hpp
+++ b/include/seqan3/search/algorithm/detail/search_trivial.hpp
@@ -54,7 +54,7 @@ inline bool search_trivial(cursor_t cur, query_t & query, typename cursor_t::siz
     if (query_pos == std::ranges::size(query) || error_left.total == 0)
     {
         // If not at end of query sequence, try searching the remaining suffix without any errors.
-        if (query_pos == std::ranges::size(query) || cur.extend_right(std::view::drop(query, query_pos)))
+        if (query_pos == std::ranges::size(query) || cur.extend_right(view::drop(query, query_pos)))
         {
             delegate(cur);
             return true;

--- a/include/seqan3/search/fm_index/bi_fm_index_cursor.hpp
+++ b/include/seqan3/search/fm_index/bi_fm_index_cursor.hpp
@@ -16,10 +16,9 @@
 
 #include <sdsl/suffix_trees.hpp>
 
-#include <range/v3/view/slice.hpp>
-
 #include <seqan3/alphabet/all.hpp>
 #include <seqan3/core/metafunction/range.hpp>
+#include <seqan3/range/view/slice.hpp>
 #include <seqan3/search/fm_index/bi_fm_index.hpp>
 #include <seqan3/std/ranges>
 
@@ -867,7 +866,7 @@ public:
         assert(index != nullptr && index->text != nullptr);
 
         size_type const query_begin = offset() - index->fwd_fm.index[fwd_lb];
-        return *index->text | ranges::view::slice(query_begin, query_begin + query_length());
+        return *index->text | view::slice(query_begin, query_begin + query_length());
     }
 
     //!\overload
@@ -880,7 +879,7 @@ public:
 
         size_type const loc = offset() - index->fwd_fm.index[fwd_lb];
         size_type const query_begin = loc - index->fwd_fm.text_begin_rs.rank(loc + 1) + 1; // Substract delimiters
-        return *index->text | std::view::join | ranges::view::slice(query_begin, query_begin + query_length());
+        return *index->text | std::view::join | view::slice(query_begin, query_begin + query_length());
     }
 
     //!\copydoc query()

--- a/include/seqan3/search/fm_index/fm_index_cursor.hpp
+++ b/include/seqan3/search/fm_index/fm_index_cursor.hpp
@@ -21,6 +21,7 @@
 
 #include <seqan3/alphabet/all.hpp>
 #include <seqan3/core/metafunction/range.hpp>
+#include <seqan3/range/view/slice.hpp>
 #include <seqan3/search/fm_index/detail/csa_alphabet_strategy.hpp>
 #include <seqan3/search/fm_index/detail/fm_index_cursor.hpp>
 #include <seqan3/search/fm_index/fm_index.hpp>
@@ -455,7 +456,7 @@ public:
         assert(index != nullptr && index->text != nullptr);
 
         size_type const query_begin = offset() - index->index[node.lb];
-        return *index->text | ranges::view::slice(query_begin, query_begin + query_length());
+        return *index->text | view::slice(query_begin, query_begin + query_length());
     }
 
     //!\overload
@@ -468,7 +469,7 @@ public:
 
         size_type const loc = offset() - index->index[node.lb];
         size_type const query_begin = loc - index->text_begin_rs.rank(loc + 1) + 1; // Substract delimiters
-        return *index->text | std::view::join | ranges::view::slice(query_begin, query_begin + query_length());
+        return *index->text | std::view::join | view::slice(query_begin, query_begin + query_length());
     }
 
     //!\copydoc query()

--- a/include/seqan3/std/span
+++ b/include/seqan3/std/span
@@ -226,6 +226,9 @@ public:
     span<byte, span_extent * sizeof(element_type)> as_writeable_bytes() const noexcept
     { return {reinterpret_cast<byte *>(data()), size_bytes()}; }
 
+    friend constexpr iterator begin(span s) noexcept { return s.begin(); }
+    friend constexpr iterator end(span s) noexcept { return s.end(); }
+
 private:
     pointer data_;
 
@@ -380,6 +383,9 @@ public:
 
     span<byte, dynamic_extent> as_writeable_bytes() const noexcept
     { return {reinterpret_cast<byte *>(data()), size_bytes()}; }
+
+    friend constexpr iterator begin(span s) noexcept { return s.begin(); }
+    friend constexpr iterator end(span s) noexcept { return s.end(); }
 
 private:
     pointer    data_;

--- a/test/unit/range/view/view_all_test.cpp
+++ b/test/unit/range/view/view_all_test.cpp
@@ -30,7 +30,7 @@ TEST(view_all, string_overload)
 
         auto v = view::all(urange);
 
-        EXPECT_TRUE((std::Same<decltype(v), std::string_view>));
+        EXPECT_FALSE((std::Same<decltype(v), std::string_view>)); // only returns string_view for string const
         EXPECT_TRUE((std::ranges::equal(v, urange)));
     }
 

--- a/test/unit/range/view/view_slice_test.cpp
+++ b/test/unit/range/view/view_slice_test.cpp
@@ -97,7 +97,7 @@ void do_concepts(adaptor_t && adaptor, bool const exactly)
     EXPECT_TRUE(std::ranges::View<decltype(v2)>);
     EXPECT_EQ(std::ranges::SizedRange<decltype(v2)>, exactly);
     EXPECT_FALSE(std::ranges::CommonRange<decltype(v2)>);
-    EXPECT_TRUE(const_iterable_concept<decltype(v2)>);          // resolves subrange
+    EXPECT_FALSE(const_iterable_concept<decltype(v2)>);
     EXPECT_TRUE((std::ranges::OutputRange<decltype(v2), int>));
 }
 
@@ -128,7 +128,7 @@ TEST(view_slice, underlying_is_shorter)
 TEST(view_slice, type_erasure)
 {
     {   // string overload
-        std::string urange{"foobar"};
+        std::string const urange{"foobar"};
 
         auto v = view::slice(urange, 1, 4);
 

--- a/test/unit/range/view/view_take_until_test.cpp
+++ b/test/unit/range/view/view_take_until_test.cpp
@@ -16,6 +16,7 @@
 #include <seqan3/range/view/single_pass_input.hpp>
 #include <seqan3/range/view/to_char.hpp>
 #include <seqan3/std/ranges>
+#include <seqan3/std/span>
 
 using namespace seqan3;
 
@@ -39,6 +40,14 @@ void do_test(adaptor_t const & adaptor, fun_t && fun, std::string const & vec)
     EXPECT_EQ("fo", std::string(v3));
     std::string v3b = vec | std::view::reverse | adaptor(fun) | ranges::view::unique;
     EXPECT_EQ("rab", v3b);
+
+    // pointer as iterator
+    std::span s{std::ranges::data(vec), vec.size()};
+    auto v4 = s | adaptor(fun);
+    EXPECT_EQ("foo", std::string(v4));
+
+    // comparability against self
+    EXPECT_TRUE(std::ranges::equal(v,v));
 }
 
 template <typename adaptor_t>


### PR DESCRIPTION
supersedes #852 

fixes:
  * view::drop and view::take only return sub-ranges on ForwardingRanges
  * our inherited_iterator_base can now inherit from iterators that are actually pointers (by wrapping them instead of inheriting from them)
  * switch more code to use our view::slice instead of ranges::view::slice