### PR TITLE
[MISC] Fix doxygen warnings for default construction argument parser

### DIFF
--- a/include/seqan3/argument_parser/argument_parser.hpp
+++ b/include/seqan3/argument_parser/argument_parser.hpp
@@ -128,15 +128,13 @@ class argument_parser
 {
 public:
     /*!\name Constructors, destructor and assignment
-     * \brief All standard constructors are explicitly defaulted except the
-     *        default constructor which is deleted.
      * \{
      */
-    argument_parser() = delete;
-    argument_parser(argument_parser const &) = default;
-    argument_parser & operator=(argument_parser const &) = default;
-    argument_parser(argument_parser &&) = default;
-    argument_parser & operator=(argument_parser &&) = default;
+    argument_parser() = delete;                                     //!< Deleted.
+    argument_parser(argument_parser const &) = default;             //!< Defaulted.
+    argument_parser & operator=(argument_parser const &) = default; //!< Defaulted.
+    argument_parser(argument_parser &&) = default;                  //!< Defaulted.
+    argument_parser & operator=(argument_parser &&) = default;      //!< Defaulted.
 
     /*!\brief Initializes an argument_parser object from the command line arguments.
      *

--- a/include/seqan3/argument_parser/detail/format_parse.hpp
+++ b/include/seqan3/argument_parser/detail/format_parse.hpp
@@ -51,14 +51,13 @@ class format_parse : public format_base
 {
 public:
     /*!\name Constructors, destructor and assignment
-     * \brief The (default) constructors.
      * \{
      */
-    format_parse() = delete;
-    format_parse(format_parse const & pf) = default;
-    format_parse & operator=(format_parse const & pf) = default;
-    format_parse(format_parse &&) = default;
-    format_parse & operator=(format_parse &&) = default;
+    format_parse() = delete;                                     //!< Deleted.
+    format_parse(format_parse const & pf) = default;             //!< Defaulted.
+    format_parse & operator=(format_parse const & pf) = default; //!< Defaulted.
+    format_parse(format_parse &&) = default;                     //!< Defaulted.
+    format_parse & operator=(format_parse &&) = default;         //!< Defaulted.
 
     /*!\brief The constructor of the parse format.
      * \param[in] argc_ The number of command line arguments.

--- a/include/seqan3/argument_parser/validators.hpp
+++ b/include/seqan3/argument_parser/validators.hpp
@@ -258,7 +258,7 @@ public:
     /*!\brief Constructing from a vector.
      * \param[in] v The vector of valid file extensions to test (e.g. {"fa", "fasta"}).
      * \param[in] c Case sensitivity flag. Set true for case sensitivity. Default: false (case insensitive).
-     *              
+     *
      * For case insensitivity, everything is converted to lower case characters.
      */
     file_ext_validator(std::vector<std::string> const & v, bool const c = false) :
@@ -270,7 +270,7 @@ public:
     /*!\brief Constructing from an initializer_list.
      * \param[in] v The initializer_list of valid file extensions to test (e.g. {"fa", "fasta"}).
      * \param[in] c Case sensitivity flag. Set true for case sensitivity. Default: false (case insensitive).
-     *              
+     *
      * For case insensitivity, everything is converted to lower case characters.
      */
     file_ext_validator(std::initializer_list<std::string> const & v, bool const c = false) :
@@ -494,12 +494,11 @@ public:
     /*!\name Constructors, destructor and assignment
      * \{
      */
-    //!\brief The default constructor is explicitly deleted.
-    validator_chain_adaptor() = delete;
-    validator_chain_adaptor(validator_chain_adaptor const & pf) = default;
-    validator_chain_adaptor & operator=(validator_chain_adaptor const & pf) = default;
-    validator_chain_adaptor(validator_chain_adaptor &&) = default;
-    validator_chain_adaptor & operator=(validator_chain_adaptor &&) = default;
+    validator_chain_adaptor() = delete;                                                //!< Deleted.
+    validator_chain_adaptor(validator_chain_adaptor const & pf) = default;             //!< Defaulted.
+    validator_chain_adaptor & operator=(validator_chain_adaptor const & pf) = default; //!< Defaulted.
+    validator_chain_adaptor(validator_chain_adaptor &&) = default;                     //!< Defaulted.
+    validator_chain_adaptor & operator=(validator_chain_adaptor &&) = default;         //!< Defaulted.
 
     /*!\brief Constructing from two validators.
      * \param[in] vali1_ Some validator to be chained to vali2_.


### PR DESCRIPTION
Missing default comments in argument parser. For deletions, I just added Deleted, if a more specific comment is wanted please tell me what kind of comment in a code review.