### PR TITLE
[FIX] GCC8 bug workaround.

### DIFF
--- a/include/seqan3/io/alignment_file/format_sam.hpp
+++ b/include/seqan3/io/alignment_file/format_sam.hpp
@@ -632,12 +632,16 @@ public:
         else if constexpr (detail::is_type_specialisation_of_v<std::remove_reference_t<decltype(get<0>(mate))>, std::optional>)
         {
             if (get<0>(mate).has_value())
-                write_range(stream_it, (header.ref_ids())[get<0>(mate).value()]);
+                // value_or(0) instead of value() (which is equivalent here) as a
+                // workaround for a ubsan false-positive in GCC8: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90058
+                write_range(stream_it, header.ref_ids()[get<0>(mate).value_or(0)]);
             else
                 stream << '*';
         }
         else
+        {
             write_range(stream_it, get<0>(mate));
+        }
 
         stream << separator;
 


### PR DESCRIPTION
Resolves #893 

A maybe-uninitialized error only occurs on GCC-8 in release with -fsanitize=undefined
The same code works fine with GCC7 (same flags) and with GCC8 in debug (also with -fsanitize=undefined)...

The following PR is a workaround that make the error vanish.

Do not merge yet, I'll file a bug report and add a link as a commment