### PR TITLE
[FIX] On GCC9 it is not possibly to guarantee to create a valueless variant.

### DIFF
--- a/test/unit/io/stream/debug_stream_test.cpp
+++ b/test/unit/io/stream/debug_stream_test.cpp
@@ -148,11 +148,6 @@ TEST(debug_stream, tuple)
     EXPECT_EQ(o.str(), "(32,dummy)(32)(2,(3,2))");
 }
 
-struct make_variant_valueless_helper
-{
-    operator int() { throw 42; }
-};
-
 TEST(debug_stream, variant)
 {
     std::ostringstream o;
@@ -180,20 +175,6 @@ TEST(debug_stream, variant)
     my_stream << std::variant<double, std::string>{std::string{"tmp"}};
     o.flush();
     EXPECT_EQ(o.str(), "3.3foobar4.2tmp");
-
-    /*valueless*/
-    std::variant<double, int> v3;
-
-    try
-    {
-        v3.emplace<1>(make_variant_valueless_helper()); // v may be valueless
-    }
-    catch (int e)
-    {}
-
-    my_stream << v3;
-    o.flush();
-    EXPECT_EQ(o.str(), "3.3foobar4.2tmp<VALUELESS_VARIANT>");
 }
 
 TEST(debug_stream, optional)


### PR DESCRIPTION
At least I did not manage to do it :grimacing: 

Resolves #894 

cppreference says

> A variant may become valueless in the following situations:
 >*   (guaranteed) an exception is thrown during the move initialization of the contained value from the temporary in copy assignment
 >*   (guaranteed) an exception is thrown during the move initialization of the contained value during move assignment
> *   (optionally) an exception is thrown when initializing the contained value during a type-changing assignment
> *   (optionally) an exception is thrown when initializing the contained value during a type-changing emplace 

I tried this, which from my understanding models the first "guaranteed to be valueless" but it isn't. Did I do somehting wrong?

```cpp
struct make_variant_valueless_helper
{
    make_variant_valueless_helper() = default;
    make_variant_valueless_helper(make_variant_valueless_helper &&) { throw 42; } // move constructor throws
    make_variant_valueless_helper & operator=(make_variant_valueless_helper &&) { throw 42; } // move assignment throws

    friend auto & operator<<(std::ostream & ss, make_variant_valueless_helper &)
    {
        ss << "make_variant_valueless_helper";
        return ss;
    }
};
//...
    std::variant<make_variant_valueless_helper, int> v3;

    try
    {
        v3 = std::variant<make_variant_valueless_helper, int>{make_variant_valueless_helper{}};
    }
    catch (int e)
    {}

    my_stream << v3; // should print "<VALUELESS_BY_EXCEPTION>" but does not
```