### PR TITLE
[FIX] in DP alignment: keep old optimum if current cell score is equal

### DIFF
--- a/include/seqan3/alignment/pairwise/policy/find_optimum_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/find_optimum_policy.hpp
@@ -92,7 +92,7 @@ protected:
     {
         if constexpr (traits_type::find_in_every_cell_type::value)
         {
-            optimum = std::max(current, optimum, alignment_optimum_compare_less{});
+            optimum = std::max(optimum, current, alignment_optimum_compare_less{}); // if equal => optimum
         }
 
     }
@@ -113,7 +113,7 @@ protected:
                                         [[maybe_unused]] alignment_optimum<score_t> & optimum) const noexcept
     {
         if constexpr (traits_type::find_in_last_row_type::value)
-            optimum = std::max(current, optimum, alignment_optimum_compare_less{});
+            optimum = std::max(optimum, current, alignment_optimum_compare_less{});  // if equal => optimum
     }
 
     /*!\brief Checks the complete last column for the optimal score.
@@ -138,19 +138,19 @@ protected:
         {
             ranges::for_each(rng, [&](auto && entry)
             {
-                optimum = std::max(alignment_optimum<score_t>{get<0>(get<0>(entry)),
+                optimum = std::max(optimum,
+                                   alignment_optimum<score_t>{get<0>(get<0>(entry)),
                                                               static_cast<alignment_coordinate>(get<1>(entry))},
-                                   optimum,
-                                   alignment_optimum_compare_less{});
+                                   alignment_optimum_compare_less{});  // if equal => optimum
             });
         }
         else  // Only check the last cell for the global alignment.
         {
             auto && last = *std::ranges::prev(std::ranges::end(rng));
-            optimum = std::max(alignment_optimum<score_t>{get<0>(get<0>(last)),
+            optimum = std::max(optimum,
+                               alignment_optimum<score_t>{get<0>(get<0>(last)),
                                                           static_cast<alignment_coordinate>(get<1>(last))},
-                               optimum,
-                               alignment_optimum_compare_less{});
+                               alignment_optimum_compare_less{});  // if equal => optimum
         }
     }
 


### PR DESCRIPTION
I found an example where local alignments are extended too long, because the optimal score appeared again later and the algorithm chose the long version. This PR fixes this behaviour, such that always the shorter alignment is returned.