### PR TITLE
[FIX,TEST] Ignore OS flag in gzip compression

### DIFF
--- a/test/unit/io/sequence_file/sequence_file_output_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_output_test.cpp
@@ -475,7 +475,9 @@ void compression_by_filename_impl(test::tmp_filename & filename, std::string_vie
         buffer = std::string{std::istreambuf_iterator<char>{fi}, std::istreambuf_iterator<char>{}};
     }
 
-    EXPECT_EQ(buffer, expected);
+    // Ignore the OS flag
+    EXPECT_EQ(buffer.substr(0,9), expected.substr(0,9));
+    EXPECT_EQ(buffer.substr(11), expected.substr(11));
 }
 
 template <typename comp_stream_t>
@@ -518,7 +520,10 @@ TEST(compression, by_stream_gz)
         compression_by_stream_impl(compout);
     }
 
-    EXPECT_EQ(out.str(), expected_gz);
+    // Ignore the OS flag
+    std::string buffer(out.str());
+    EXPECT_EQ(buffer.substr(0,9), expected_gz.substr(0,9));
+    EXPECT_EQ(buffer.substr(11), expected_gz.substr(11));
 }
 #endif
 

--- a/test/unit/io/stream/ostream_test_template.hpp
+++ b/test/unit/io/stream/ostream_test_template.hpp
@@ -44,7 +44,9 @@ TYPED_TEST_P(ostream, output)
     std::ifstream fi{filename.get_path(), std::ios::binary};
     std::string buffer{std::istreambuf_iterator<char>{fi}, std::istreambuf_iterator<char>{}};
 
-    EXPECT_EQ(buffer, TestFixture::compressed);
+    // Ignore the OS flag
+    EXPECT_EQ(buffer.substr(0,9), TestFixture::compressed.substr(0,9));
+    EXPECT_EQ(buffer.substr(11), TestFixture::compressed.substr(11));
 }
 
 TYPED_TEST_P(ostream, output_type_erased)
@@ -62,7 +64,9 @@ TYPED_TEST_P(ostream, output_type_erased)
     std::ifstream fi{filename.get_path(), std::ios::binary};
     std::string buffer{std::istreambuf_iterator<char>{fi}, std::istreambuf_iterator<char>{}};
 
-    EXPECT_EQ(buffer, TestFixture::compressed);
+    // Ignore the OS flag
+    EXPECT_EQ(buffer.substr(0,9), TestFixture::compressed.substr(0,9));
+    EXPECT_EQ(buffer.substr(11), TestFixture::compressed.substr(11));
 }
 
 REGISTER_TYPED_TEST_CASE_P(ostream, concept_check, output, output_type_erased);

--- a/test/unit/io/structure_file/structure_file_output_test.cpp
+++ b/test/unit/io/structure_file/structure_file_output_test.cpp
@@ -435,7 +435,9 @@ struct structure_file_output_compression : public structure_file_output_write
             std::ifstream fi{filename.get_path(), std::ios::binary};
             buffer = std::string{std::istreambuf_iterator<char>{fi}, std::istreambuf_iterator<char>{}};
         }
-        EXPECT_EQ(buffer, expected);
+        // Ignore the OS flag
+        EXPECT_EQ(buffer.substr(0,9), expected.substr(0,9));
+        EXPECT_EQ(buffer.substr(11), expected.substr(11));
     }
 
     template<typename comp_stream_t>
@@ -481,7 +483,10 @@ TEST_F(structure_file_output_compression, by_stream_gz)
         contrib::gz_ostream compout{out};
         compression_by_stream_impl(compout);
     }
-    EXPECT_EQ(out.str(), expected_gz);
+    // Ignore the OS flag
+    std::string buffer(out.str());
+    EXPECT_EQ(buffer.substr(0,9), expected_gz.substr(0,9));
+    EXPECT_EQ(buffer.substr(11), expected_gz.substr(11));
 }
 #endif
 


### PR DESCRIPTION
Resolves #723 
With this PR the unit tests do not fail anymore on my machine (mac).

I don't like checking the substrings in, e.g., `compression_by_filename_impl` for both gzip and bz2 compression since it is not necessary for bz2.
@h-2 Any preferred way to fix this?