### PR TITLE
[FEATURE] Add murphy aa10 alphabet

### DIFF
--- a/include/seqan3/alphabet/aminoacid/aa10murphy.hpp
+++ b/include/seqan3/alphabet/aminoacid/aa10murphy.hpp
@@ -1,0 +1,219 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \author Sara Hetzel <sara.hetzel AT fu-berlin.de>
+ * \brief Contains seqan3::aa10murphy, container aliases and string literals.
+ */
+
+#pragma once
+
+#include <vector>
+
+#include <seqan3/alphabet/aminoacid/aminoacid_base.hpp>
+#include <seqan3/alphabet/aminoacid/concept.hpp>
+#include <seqan3/io/stream/char_operations.hpp>
+
+namespace seqan3
+{
+
+/*!\brief The reduced Murphy amino acid alphabet.
+ * \ingroup aminoacid
+ * \implements seqan3::AminoacidAlphabet
+ * \implements seqan3::detail::ConstexprAlphabet
+ * \implements seqan3::TriviallyCopyable
+ * \implements seqan3::StandardLayout
+ *
+ * \details
+ * The alphabet consists of letters A, B, C, F, G, H, I, K, P, S
+ * B represents charged/polar residues (E,D,N,Q).
+ * C represents cystein and the species-specific amino acid Selenocysteine.
+ * F represents amino acids with large and mainly hydrophobic aromatic side chains (F,W,Y).
+ * I represents large hydrophobes (L,V,I,M).
+ * K represents long-chain positively charged residues (K,R) and the species-specific amino acid Pyrrolysine.
+ * S represents alcohols (S,T) and unknown.
+ * A, G, H and P do not represent any other amino acids other than themselves.
+ *
+ * This alphabet allows to reduce the aminoacid alphabet size to 10 but is still able to recognize and represent
+ * folding of all proteins. Amino acids are grouped together based on similar physical and chemical properties.
+ *
+ * *Note:* Letters which belong in the extended alphabet will be automatically converted.
+ * Terminator characters are converted to F, because the most commonly occurring stop codon in higher eukaryotes
+ * is UGA <sup>2</sup>. This is most similar to a Tryptophan which in this alphabet
+ * gets converted to Phenylalanine. Anything unknown is converted to S.
+ *
+ * |Input Letter  |Converts to    |
+ * |--------------|---------------|
+ * |D             |B<sup>1</sup>  |
+ * |E             |B<sup>1</sup>  |
+ * |J             |I<sup>1</sup>  |
+ * |L             |I<sup>1</sup>  |
+ * |M             |I<sup>1</sup>  |
+ * |N             |B<sup>1</sup>  |
+ * |O             |K<sup>1</sup>  |
+ * |Q             |B<sup>1</sup>  |
+ * |R             |K<sup>1</sup>  |
+ * |T             |S<sup>1</sup>  |
+ * |U             |C<sup>1</sup>  |
+ * |V             |I<sup>1</sup>  |
+ * |W             |F<sup>1</sup>  |
+ * |Y             |F<sup>1</sup>  |
+ * |Z             |B<sup>1</sup>  |
+ * |X (Unknown)   |S<sup>1</sup>  |
+ * |* (Terminator)|F<sup>1,2</sup>|
+ *
+ * <sup><b>1</b></sup>L. R. Murphy, A. Wallqvist, and R. M. Levy. Simplified amino acid alphabets for protein
+ * fold recognition and implications for folding. Protein Eng., 13(3):149–152, Mar 2000.\n
+ * <sup><b>2</b></sup>Trotta, E. (2016). Selective forces and mutational biases drive stop codon usage
+ * in the human genome: a comparison with sense codon usage.
+ * BMC Genomics, 17, 366. http://doi.org/10.1186/s12864-016-2692-4
+ *
+ * \snippet test/snippet/alphabet/aminoacid/aa10murphy.cpp example
+ */
+class aa10murphy : public aminoacid_base<aa10murphy, 10>
+{
+private:
+    //!\brief The base class.
+    using base_t = aminoacid_base<aa10murphy, 10>;
+
+    //!\brief Befriend seqan3::aminoacid_base.
+    friend base_t;
+    //!\cond \brief Befriend seqan3::alphabet_base.
+    friend base_t::base_t;
+    //!\endcond
+
+public:
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    constexpr aa10murphy() = default;                               //!< Defaulted.
+    constexpr aa10murphy(aa10murphy const &) = default;             //!< Defaulted.
+    constexpr aa10murphy(aa10murphy &&) = default;                  //!< Defaulted.
+    constexpr aa10murphy & operator=(aa10murphy const &) = default; //!< Defaulted.
+    constexpr aa10murphy & operator=(aa10murphy &&) = default;      //!< Defaulted.
+    ~aa10murphy() = default;                                        //!< Defaulted.
+
+    //!\brief Inherit the base class's Constructors.
+    using base_t::base_t;
+    //!\}
+
+protected:
+    //!\brief Value to char conversion table.
+    static constexpr char_type rank_to_char[value_size]
+    {
+        'A',
+        'B',
+        'C',
+        'F',
+        'G',
+        'H',
+        'I',
+        'K',
+        'P',
+        'S',
+    };
+
+    //!\brief Char to value conversion table.
+    static constexpr std::array<rank_type, 256> char_to_rank
+    {
+        [] () constexpr
+        {
+            std::array<rank_type, 256> ret{};
+
+            // initialize with UNKNOWN (std::array::fill unfortunately not constexpr)
+            for (auto & c : ret)
+                c = 9; // value of 'S', because that appears most frequently
+
+            // reverse mapping for characters and their lowercase
+            for (rank_type rnk = 0u; rnk < value_size; ++rnk)
+            {
+                ret[static_cast<rank_type>(         rank_to_char[rnk]) ] = rnk;
+                ret[static_cast<rank_type>(to_lower(rank_to_char[rnk]))] = rnk;
+            }
+
+            ret['D'] = ret['B']; ret['d'] = ret['B']; // Convert D to B (either D/N).
+            ret['E'] = ret['B']; ret['e'] = ret['B']; // Convert E to B (either D/N).
+            ret['J'] = ret['I']; ret['j'] = ret['I']; // Convert J (either I/L) to I.
+            ret['L'] = ret['I']; ret['l'] = ret['I']; // Convert L to I.
+            ret['M'] = ret['I']; ret['m'] = ret['I']; // Convert M to I.
+            ret['N'] = ret['B']; ret['n'] = ret['B']; // Convert N to B (either D/N).
+            ret['O'] = ret['K']; ret['o'] = ret['K']; // Convert Pyrrolysine to K.
+            ret['Q'] = ret['B']; ret['q'] = ret['B']; // Convert Q to B (either D/N).
+            ret['R'] = ret['K']; ret['r'] = ret['K']; // Convert R to K.
+            ret['T'] = ret['S']; ret['t'] = ret['S']; // Convert T to S.
+            ret['U'] = ret['C']; ret['u'] = ret['C']; // Convert Selenocysteine to C.
+            ret['V'] = ret['I']; ret['v'] = ret['I']; // Convert V to I.
+            ret['W'] = ret['F']; ret['w'] = ret['F']; // Convert W to F.
+            ret['X'] = ret['S']; ret['x'] = ret['S']; // Convert unknown amino acids to Serine.
+            ret['Y'] = ret['F']; ret['y'] = ret['F']; // Convert Y to F.
+            ret['Z'] = ret['B']; ret['z'] = ret['B']; // Convert Z (either E/Q) to B (either D/N).
+            ret['*'] = ret['F']; // The most common stop codon is UGA. This is most similar to a Tryptophan which in this alphabet gets converted to Phenylalanine.
+            return ret;
+        }()
+    };
+};
+
+// ------------------------------------------------------------------
+// metafunctions
+// ------------------------------------------------------------------
+
+//!\brief Helper metafunction that identifies aa10murphy as an amino acid alphabet.
+//!\ingroup aminoacid
+template <>
+struct is_aminoacid<aa10murphy> : std::true_type {};
+
+// ------------------------------------------------------------------
+// containers
+// ------------------------------------------------------------------
+
+//!\brief Alias for an std::vector of seqan3::aa10murphy.
+//!\relates aa10murphy
+using aa10murphy_vector = std::vector<aa10murphy>;
+
+// ------------------------------------------------------------------
+// literals
+// ------------------------------------------------------------------
+
+/*!\name Literals
+ * \{
+ */
+
+/*!\brief The seqan3::aa10murphy char literal.
+ * \param[in] c The character to assign.
+ * \relates seqan3::aa10murphy
+ * \returns seqan3::aa10murphy
+ */
+constexpr aa10murphy operator""_aa10murphy(char const c) noexcept
+{
+    return aa10murphy{}.assign_char(c);
+}
+
+/*!\brief The seqan3::aa10murphy  string literal.
+ * \param[in] s A pointer to the character string to assign.
+ * \param[in] n The size of the character string to assign.
+ * \relates seqan3::aa10murphy
+ * \returns seqan3::aa10murphy_vector
+ *
+ * You can use this string literal to easily assign to aa10murphy_vector:
+ *
+ * \attention
+ * All seqan3 literals are in the namespace seqan3!
+ */
+
+inline aa10murphy_vector operator""_aa10murphy(const char * s, std::size_t n)
+{
+    aa10murphy_vector r;
+    r.resize(n);
+
+    for (size_t i = 0; i < n; ++i)
+        r[i].assign_char(s[i]);
+
+    return r;
+}
+//!\}
+
+} // namespace seqan3

--- a/include/seqan3/alphabet/aminoacid/all.hpp
+++ b/include/seqan3/alphabet/aminoacid/all.hpp
@@ -11,6 +11,7 @@
  */
 #pragma once
 
+#include <seqan3/alphabet/aminoacid/aa10murphy.hpp>
 #include <seqan3/alphabet/aminoacid/aa20.hpp>
 #include <seqan3/alphabet/aminoacid/aa27.hpp>
 #include <seqan3/alphabet/aminoacid/concept.hpp>
@@ -25,7 +26,7 @@
  * \par Introduction
  * Amino acid sequences are an important part of bioinformatic data processing and used by many applications
  * and while it is possible to represent them in a regular std::string, it makes sense to have specialised data
- * structures in most cases. This sub-module offers the 27 letter aminoacid alphabet as well as a reduced version
+ * structures in most cases. This sub-module offers the 27 letter aminoacid alphabet as well as three reduced versions
  * that can be used with regular container and ranges.
  * The 27 letter amino acid alphabet contains the 20 canonical amino acids, 2 additional proteinogenic amino acids
  * (Pyrrolysine and Selenocysteine) and a termination letter (*). Additionally 4 wildcard letters are offered which
@@ -33,35 +34,35 @@
  * Leucine). See also https://en.wikipedia.org/wiki/Amino_acid for more information about the amino acid alphabet.
  *
  * \par Conversions
- * | Amino acid name            | Three letter code | One letter code | Remapped in\n seqan3::aa20      |
- * |----------------------------|-------------------|-----------------|---------------------------------|
- * |    Alanine                 | Ala               | A               | A                               |
- * |    Arginine                | Arg               | R               | R                               |
- * |    Asparagine              | Asn               | N               | N                               |
- * |    Aspartic acid           | Asp               | D               | D                               |
- * |    Cysteine                | Cys               | C               | C                               |
- * |    Tyrosine                | Tyr               | Y               | Y                               |
- * |    Glutamic acid           | Glu               | E               | E                               |
- * |    Glutamine               | Gln               | Q               | Q                               |
- * |    Glycine                 | Gly               | G               | G                               |
- * |    Histidine               | His               | H               | H                               |
- * |    Isoleucine              | Ile               | I               | I                               |
- * |    Leucine                 | leu               | L               | L                               |
- * |    Lysine                  | Lys               | K               | K                               |
- * |    Methionine              | Met               | M               | M                               |
- * |    Phenylalanine           | Phe               | F               | F                               |
- * |    Proline                 | Pro               | P               | P                               |
- * |    Serine                  | Ser               | S               | S                               |
- * |    Threonine               | Thr               | T               | T                               |
- * |    Tryptophan              | Trp               | W               | W                               |
- * |    Valine                  | Val               | V               | V                               |
- * |    Selenocysteine          | Sec               | U               | <span style="color:red">C</span>|
- * |    Pyrrolysine             | Pyl               | O               | <span style="color:red">K</span>|
- * | Asparagine or aspartic acid| Asx               | B               | <span style="color:red">D</span>|
- * | Glutamine or glutamic acid | Glx               | Z               | <span style="color:red">E</span>|
- * |    Leucine or Isoleucine   | Xle               | J               | <span style="color:red">L</span>|
- * |    Unknown                 | Xaa               | X               | <span style="color:red">S</span>|
- * |    Stop Codon              | N/A               | *               | <span style="color:red">W</span>|
+ * | Amino acid name            | Three letter code | One letter code | Remapped in\n seqan3::aa20      | Remapped in\n seqan3::aa10murphy |
+ * |----------------------------|-------------------|-----------------|---------------------------------|----------------------------------|
+ * |    Alanine                 | Ala               | A               | A                               | A                                |
+ * |    Arginine                | Arg               | R               | R                               | <span style="color:red">K</span> |
+ * |    Asparagine              | Asn               | N               | N                               | <span style="color:red">B</span> |
+ * |    Aspartic acid           | Asp               | D               | D                               | <span style="color:red">B</span> |
+ * |    Cysteine                | Cys               | C               | C                               | C                                |
+ * |    Tyrosine                | Tyr               | Y               | Y                               | <span style="color:red">F</span> |
+ * |    Glutamic acid           | Glu               | E               | E                               | <span style="color:red">B</span> |
+ * |    Glutamine               | Gln               | Q               | Q                               | <span style="color:red">B</span> |
+ * |    Glycine                 | Gly               | G               | G                               | G                                |
+ * |    Histidine               | His               | H               | H                               | H                                |
+ * |    Isoleucine              | Ile               | I               | I                               | I                                |
+ * |    Leucine                 | leu               | L               | L                               | <span style="color:red">I</span> |
+ * |    Lysine                  | Lys               | K               | K                               | K                                |
+ * |    Methionine              | Met               | M               | M                               | <span style="color:red">I</span> |
+ * |    Phenylalanine           | Phe               | F               | F                               | F                                |
+ * |    Proline                 | Pro               | P               | P                               | P                                |
+ * |    Serine                  | Ser               | S               | S                               | S                                |
+ * |    Threonine               | Thr               | T               | T                               | <span style="color:red">s</span> |
+ * |    Tryptophan              | Trp               | W               | W                               | <span style="color:red">F</span> |
+ * |    Valine                  | Val               | V               | V                               | <span style="color:red">I</span> |
+ * |    Selenocysteine          | Sec               | U               | <span style="color:red">C</span>| <span style="color:red">C</span> |
+ * |    Pyrrolysine             | Pyl               | O               | <span style="color:red">K</span>| <span style="color:red">K</span> |
+ * | Asparagine or aspartic acid| Asx               | B               | <span style="color:red">D</span>| B                                |
+ * | Glutamine or glutamic acid | Glx               | Z               | <span style="color:red">E</span>| <span style="color:red">B</span> |
+ * |    Leucine or Isoleucine   | Xle               | J               | <span style="color:red">L</span>| <span style="color:red">I</span> |
+ * |    Unknown                 | Xaa               | X               | <span style="color:red">S</span>| <span style="color:red">S</span> |
+ * |    Stop Codon              | N/A               | *               | <span style="color:red">W</span>| <span style="color:red">F</span> |
  *
  * All amino acid alphabets provide static value members (like an enum) for all amino acids in the form of the
  * one-letter representation.

--- a/test/snippet/alphabet/aminoacid/aa10murphy.cpp
+++ b/test/snippet/alphabet/aminoacid/aa10murphy.cpp
@@ -1,0 +1,29 @@
+//! [example]
+#include <seqan3/alphabet/aminoacid/aa27.hpp>
+#include <seqan3/alphabet/aminoacid/aa10murphy.hpp>
+#include <seqan3/io/stream/debug_stream.hpp>
+#include <seqan3/range/view/convert.hpp>
+
+using seqan3::operator""_aa10murphy;
+using seqan3::operator""_aa27;
+
+int main()
+{
+    // Construction of aa10murphy amino acids from character
+    seqan3::aa10murphy my_letter{'A'_aa10murphy};
+
+    my_letter.assign_char('C');
+    my_letter.assign_char('?'); // all unknown characters are converted to 'S'_aa10murphy implicitly
+
+    if (my_letter.to_char() == 'S')
+        seqan3::debug_stream << "yeah\n"; // "yeah";
+
+    // Convert aa27 alphabet to aa10_murphy
+    seqan3::aa27_vector v1{"AVRSTXOUB"_aa27};
+    auto v2 = v1 | seqan3::view::convert<seqan3::aa10murphy>; // AIKSSSKCB
+
+    seqan3::debug_stream << v2 << "\n";
+
+    return 0;
+}
+//! [example]

--- a/test/unit/alphabet/aminoacid/CMakeLists.txt
+++ b/test/unit/alphabet/aminoacid/CMakeLists.txt
@@ -1,4 +1,5 @@
 seqan3_test(aa20_test.cpp)
 seqan3_test(aa27_test.cpp)
+seqan3_test(aa10murphy_test.cpp)
 seqan3_test(aminoacid_conversion_integration_test.cpp)
 seqan3_test(aminoacid_translation_integration_test.cpp)

--- a/test/unit/alphabet/aminoacid/aa10murphy_test.cpp
+++ b/test/unit/alphabet/aminoacid/aa10murphy_test.cpp
@@ -1,0 +1,124 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+#include <range/v3/view/zip.hpp>
+
+#include "../alphabet_test_template.hpp"
+#include "../alphabet_constexpr_test_template.hpp"
+#include "aminoacid_test_template.hpp"
+
+#include <seqan3/alphabet/aminoacid/aa10murphy.hpp>
+
+INSTANTIATE_TYPED_TEST_CASE_P(aa10murphy, alphabet, aa10murphy);
+INSTANTIATE_TYPED_TEST_CASE_P(aa10murphy, alphabet_constexpr, aa10murphy);
+INSTANTIATE_TYPED_TEST_CASE_P(aa10murphy, aminoacid, aa10murphy);
+
+TEST(aa10murphy, assign_char)
+{
+    std::vector<char> chars
+    {
+        'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+        'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+        'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+        'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+        '*', '!'
+    };
+
+    std::vector<aa10murphy> alphabets
+    {
+        'A'_aa10murphy, 'B'_aa10murphy, 'C'_aa10murphy, 'B'_aa10murphy, 'B'_aa10murphy, 'F'_aa10murphy, 'G'_aa10murphy,
+        'H'_aa10murphy, 'I'_aa10murphy, 'I'_aa10murphy, 'K'_aa10murphy, 'I'_aa10murphy, 'I'_aa10murphy,
+        'A'_aa10murphy, 'B'_aa10murphy, 'C'_aa10murphy, 'B'_aa10murphy, 'B'_aa10murphy, 'F'_aa10murphy, 'G'_aa10murphy,
+        'H'_aa10murphy, 'I'_aa10murphy, 'I'_aa10murphy, 'K'_aa10murphy, 'I'_aa10murphy, 'I'_aa10murphy,
+        'B'_aa10murphy, 'K'_aa10murphy, 'P'_aa10murphy, 'B'_aa10murphy, 'K'_aa10murphy, 'S'_aa10murphy, 'S'_aa10murphy,
+        'C'_aa10murphy, 'I'_aa10murphy, 'F'_aa10murphy, 'S'_aa10murphy, 'F'_aa10murphy, 'B'_aa10murphy,
+        'B'_aa10murphy, 'K'_aa10murphy, 'P'_aa10murphy, 'B'_aa10murphy, 'K'_aa10murphy, 'S'_aa10murphy, 'S'_aa10murphy,
+        'C'_aa10murphy, 'I'_aa10murphy, 'F'_aa10murphy, 'S'_aa10murphy, 'F'_aa10murphy, 'B'_aa10murphy,
+        'F'_aa10murphy, 'S'_aa10murphy
+    };
+
+    for (auto [ chr, alp ] : std::view::zip(chars, alphabets))
+        EXPECT_EQ((assign_char(aa10murphy{}, chr)), alp);
+}
+
+TEST(aa10murphy, to_char)
+{
+    std::vector<char> chars
+    {
+        'A', 'C', 'B', 'B', 'F', 'G', 'H', 'I', 'K', 'I', 'I', 'B', 'P',
+        'B', 'K', 'S', 'S', 'I', 'F', 'F', 'B', 'I', 'K', 'C', 'S', 'B'
+    };
+
+    std::vector<aa10murphy> alphabets
+    {
+        'A'_aa10murphy, 'C'_aa10murphy, 'D'_aa10murphy, 'E'_aa10murphy, 'F'_aa10murphy, 'G'_aa10murphy, 'H'_aa10murphy,
+        'I'_aa10murphy, 'K'_aa10murphy, 'L'_aa10murphy, 'M'_aa10murphy, 'N'_aa10murphy, 'P'_aa10murphy,
+        'Q'_aa10murphy, 'R'_aa10murphy, 'S'_aa10murphy, 'T'_aa10murphy, 'V'_aa10murphy, 'W'_aa10murphy, 'Y'_aa10murphy,
+        'B'_aa10murphy, 'J'_aa10murphy, 'O'_aa10murphy, 'U'_aa10murphy, 'X'_aa10murphy, 'Z'_aa10murphy
+    };
+
+    for (auto [ chr, alp ] : std::view::zip(chars, alphabets))
+        EXPECT_EQ(to_char(alp), chr);
+}
+
+// ------------------------------------------------------------------
+// literals
+// ------------------------------------------------------------------
+
+TEST(literals, char_literal)
+{
+    EXPECT_EQ(to_char('A'_aa10murphy), 'A');
+    EXPECT_EQ(to_char('B'_aa10murphy), 'B');
+    EXPECT_EQ(to_char('C'_aa10murphy), 'C');
+    EXPECT_EQ(to_char('F'_aa10murphy), 'F');
+    EXPECT_EQ(to_char('G'_aa10murphy), 'G');
+    EXPECT_EQ(to_char('H'_aa10murphy), 'H');
+    EXPECT_EQ(to_char('I'_aa10murphy), 'I');
+    EXPECT_EQ(to_char('K'_aa10murphy), 'K');
+    EXPECT_EQ(to_char('P'_aa10murphy), 'P');
+    EXPECT_EQ(to_char('S'_aa10murphy), 'S');
+
+    EXPECT_EQ(to_char('*'_aa10murphy), 'F');
+    EXPECT_EQ(to_char('!'_aa10murphy), 'S');
+}
+
+TEST(literals, vector)
+{
+    aa10murphy_vector v20;
+    v20.resize(5, 'D'_aa10murphy);
+    EXPECT_EQ(v20, "BBBBB"_aa10murphy);
+
+    std::vector<aa10murphy> w20{'A'_aa10murphy, 'D'_aa10murphy, 'J'_aa10murphy, 'O'_aa10murphy, 'U'_aa10murphy, 'X'_aa10murphy, 'R'_aa10murphy, '!'_aa10murphy,
+                          '*'_aa10murphy, '*'_aa10murphy};
+    EXPECT_EQ(w20, "ABIKCSKSF*"_aa10murphy);
+}
+
+TEST(aa10murphy, char_is_valid)
+{
+    constexpr auto aa27_validator = (is_alpha || is_char<'*'>);
+
+    for (char c : std::view::iota(std::numeric_limits<char>::min(), std::numeric_limits<char>::max()))
+    {
+        bool expect = false;
+        switch (c)
+        {
+            case 'D': case 'E': case 'J': case 'L': case 'M': case 'N': case 'O':
+            case 'Q': case 'R': case 'T': case 'U': case 'V': case 'W': case 'X':
+            case 'Y': case 'Z':
+            case 'd': case 'e': case 'j': case 'l': case 'm': case 'n': case 'o':
+            case 'q': case 'r': case 't': case 'u': case 'v': case 'w': case 'x':
+            case 'y': case 'z':
+            case '*':
+                break;
+            default:
+                expect = aa27_validator(c);
+                break;
+        }
+
+        EXPECT_EQ(aa10murphy::char_is_valid(c), expect);
+    }
+}

--- a/test/unit/alphabet/aminoacid/aminoacid_conversion_integration_test.cpp
+++ b/test/unit/alphabet/aminoacid/aminoacid_conversion_integration_test.cpp
@@ -18,7 +18,7 @@ template <typename T>
 class aminoacid_conversion : public ::testing::Test
 {};
 
-using aminoacid_types = type_list<aa20, aa27>; // needed for some tests
+using aminoacid_types = type_list<aa10murphy, aa20, aa27>; // needed for some tests
 using aminoacid_gtest_types = detail::transfer_template_args_onto_t<aminoacid_types, ::testing::Types>;
 
 TYPED_TEST_CASE(aminoacid_conversion, aminoacid_gtest_types);
@@ -31,26 +31,27 @@ TYPED_TEST(aminoacid_conversion, explicit_conversion)
         using out_type = std::decay_t<decltype(aa)>;
         EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('A')), out_type{}.assign_char('A'));
         EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('C')), out_type{}.assign_char('C'));
-        EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('D')), out_type{}.assign_char('D'));
-        EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('E')), out_type{}.assign_char('E'));
         EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('F')), out_type{}.assign_char('F'));
         EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('G')), out_type{}.assign_char('G'));
         EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('H')), out_type{}.assign_char('H'));
         EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('I')), out_type{}.assign_char('I'));
         EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('K')), out_type{}.assign_char('K'));
-        EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('L')), out_type{}.assign_char('L'));
-        EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('M')), out_type{}.assign_char('M'));
-        EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('N')), out_type{}.assign_char('N'));
         EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('P')), out_type{}.assign_char('P'));
-        EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('Q')), out_type{}.assign_char('Q'));
-        EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('R')), out_type{}.assign_char('R'));
         EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('S')), out_type{}.assign_char('S'));
-        EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('T')), out_type{}.assign_char('T'));
-        EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('V')), out_type{}.assign_char('V'));
-        EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('W')), out_type{}.assign_char('W'));
-        EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('Y')), out_type{}.assign_char('Y'));
+
         if (std::is_same_v<TypeParam, aa27>)
         {
+            EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('D')), out_type{}.assign_char('D'));
+            EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('E')), out_type{}.assign_char('E'));
+            EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('L')), out_type{}.assign_char('L'));
+            EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('M')), out_type{}.assign_char('M'));
+            EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('N')), out_type{}.assign_char('N'));
+            EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('Q')), out_type{}.assign_char('Q'));
+            EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('R')), out_type{}.assign_char('R'));
+            EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('T')), out_type{}.assign_char('T'));
+            EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('V')), out_type{}.assign_char('V'));
+            EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('W')), out_type{}.assign_char('W'));
+            EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('Y')), out_type{}.assign_char('Y'));
             EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('B')), out_type{}.assign_char('B'));
             EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('J')), out_type{}.assign_char('J'));
             EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('O')), out_type{}.assign_char('O'));
@@ -62,6 +63,17 @@ TYPED_TEST(aminoacid_conversion, explicit_conversion)
         }
         else if (std::is_same_v<TypeParam, aa20>)
         {
+            EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('D')), out_type{}.assign_char('D'));
+            EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('E')), out_type{}.assign_char('E'));
+            EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('L')), out_type{}.assign_char('L'));
+            EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('M')), out_type{}.assign_char('M'));
+            EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('N')), out_type{}.assign_char('N'));
+            EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('Q')), out_type{}.assign_char('Q'));
+            EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('R')), out_type{}.assign_char('R'));
+            EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('T')), out_type{}.assign_char('T'));
+            EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('V')), out_type{}.assign_char('V'));
+            EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('W')), out_type{}.assign_char('W'));
+            EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('Y')), out_type{}.assign_char('Y'));
             EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('B')), out_type{}.assign_char('D'));
             EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('J')), out_type{}.assign_char('L'));
             EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('O')), out_type{}.assign_char('L'));
@@ -69,6 +81,27 @@ TYPED_TEST(aminoacid_conversion, explicit_conversion)
             EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('X')), out_type{}.assign_char('S'));
             EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('Z')), out_type{}.assign_char('E'));
             EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('*')), out_type{}.assign_char('W'));
+            EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('!')), out_type{}.assign_char('S'));
+        }
+        else if (std::is_same_v<TypeParam, aa10murphy>)
+        {
+            EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('D')), out_type{}.assign_char('B'));
+            EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('E')), out_type{}.assign_char('B'));
+            EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('J')), out_type{}.assign_char('I'));
+            EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('L')), out_type{}.assign_char('I'));
+            EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('M')), out_type{}.assign_char('I'));
+            EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('N')), out_type{}.assign_char('B'));
+            EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('O')), out_type{}.assign_char('K'));
+            EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('Q')), out_type{}.assign_char('B'));
+            EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('R')), out_type{}.assign_char('K'));
+            EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('T')), out_type{}.assign_char('S'));
+            EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('U')), out_type{}.assign_char('C'));
+            EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('V')), out_type{}.assign_char('I'));
+            EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('W')), out_type{}.assign_char('F'));
+            EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('X')), out_type{}.assign_char('S'));
+            EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('Y')), out_type{}.assign_char('F'));
+            EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('Z')), out_type{}.assign_char('B'));
+            EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('*')), out_type{}.assign_char('F'));
             EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('!')), out_type{}.assign_char('S'));
         }
     });


### PR DESCRIPTION
The documentation could still be improved, I guess. Could you maybe take a closer look here and we can then discuss what information needs to be provided for the usage of this alphabet (especially when it comes to the grouping of amino acids and why)?

Besides, I was not sure about the initialization amino acid and whether it is the same as for aa20, so maybe we check this again as well.