### PR TITLE
[fix] make data structures defined in seqan3::detail always pretty printable (in test cases)

### DIFF
--- a/test/include/seqan3/test/pretty_printing.hpp
+++ b/test/include/seqan3/test/pretty_printing.hpp
@@ -29,3 +29,18 @@ void PrintTo (t const & v, std::ostream * out)
 //!\endcond
 
 } // namespace seqan3
+
+namespace seqan3::detail
+{
+
+//!\cond DEV
+//!\brief Overload for the googletest PrintTo function that always delegates to our debug_stream.
+template <typename t>
+    requires true // tricks the compiler to consider this as more specialized than googletests generic PrintTo
+void PrintTo (t const & v, std::ostream * out)
+{
+    ::seqan3::PrintTo(v, out);
+}
+//!\endcond
+
+} // namespace seqan3::detail

--- a/test/unit/range/view/view_pairwise_combine_test.cpp
+++ b/test/unit/range/view/view_pairwise_combine_test.cpp
@@ -124,11 +124,11 @@ TYPED_TEST(pairwise_combine_iterator_test, construction)
     iterator_t it{r.begin(), r.begin(), r.end()};
 
     const_itertor_t cit{it};
-    EXPECT_EQ(it, cit);
+    EXPECT_TRUE(it == cit);
 
     const_itertor_t cit2{};
     cit2 = it;
-    EXPECT_EQ(cit, cit2);
+    EXPECT_TRUE(cit == cit2);
 }
 
 TYPED_TEST(pairwise_combine_iterator_test, associated_types)
@@ -251,8 +251,8 @@ TYPED_TEST(pairwise_combine_iterator_test, equality)
     iterator_t it{r.begin(), r.begin(), r.end()};
 
     iterator_t it_2 = it++;
-    EXPECT_EQ(it, it);
-    EXPECT_NE(it, it_2);
+    EXPECT_TRUE(it == it);
+    EXPECT_TRUE(it != it_2);
 }
 
 TYPED_TEST(pairwise_combine_iterator_test, subscript)
@@ -387,9 +387,9 @@ TYPED_TEST(pairwise_combine_test, end)
     auto v = this->create_view();
     auto const cv{v};
 
-    EXPECT_NE(v.begin(), v.end());
-    EXPECT_NE(cv.begin(), cv.end());
-    EXPECT_NE(v.cbegin(), v.cend());
+    EXPECT_TRUE(v.begin() != v.end());
+    EXPECT_TRUE(cv.begin() != cv.end());
+    EXPECT_TRUE(v.cbegin() != v.cend());
 }
 
 TYPED_TEST(pairwise_combine_test, iterate)

--- a/test/unit/test/pretty_printing_test.cpp
+++ b/test/unit/test/pretty_printing_test.cpp
@@ -11,17 +11,100 @@
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/test/pretty_printing.hpp>
 
-using namespace seqan3;
+using seqan3::operator""_dna4;
+using namespace std::string_literals;
 
-TEST(debug_stream, basic)
+// Returns a string as gtest would print the given value.
+auto gtest_str = [](auto && v)
 {
-    testing::internal::CaptureStdout();
+    return ::testing::PrintToString(v);
+};
 
-    PrintTo('a', &std::cout);
+// Returns a string as seqan3 would print the given value.
+auto debug_str = [](auto && v)
+{
+    std::stringstream sstream{};
+    seqan3::debug_stream_type dstream{sstream};
+    dstream << v;
+    return sstream.str();
+};
 
-    PrintTo("AGA"_dna4, &std::cout);
+TEST(pretty_printing, gtest_output)
+{
+    // warning: these outputs can change due to changes in gtest
+    EXPECT_EQ(gtest_str('a'), "'a' (97, 0x61)"s);
+    EXPECT_EQ(debug_str('a'), "a"s);
 
-    PrintTo(std::make_tuple<int, int>(42, -10), &std::cout);
+    EXPECT_EQ(gtest_str(std::make_tuple<int, int>(42, -10)), "(42, -10)"s);
+    EXPECT_EQ(debug_str(std::make_tuple<int, int>(42, -10)), "(42,-10)"s);
 
-    EXPECT_EQ((testing::internal::GetCapturedStdout()), "aAGA(42,-10)");
+    EXPECT_EQ(gtest_str(std::vector<std::vector<int>>{{0,1}, {2,3}, {1,2}, {0}}),
+              "{ { 0, 1 }, { 2, 3 }, { 1, 2 }, { 0 } }"s);
+    EXPECT_EQ(debug_str(std::vector<std::vector<int>>{{0,1}, {2,3}, {1,2}, {0}}),
+              "[[0,1],[2,3],[1,2],[0]]"s);
+}
+
+TEST(pretty_printing, seqan3_output)
+{
+    // seqan3 types should always produce the same result
+    EXPECT_EQ(gtest_str('G'_dna4), "G"s);
+    EXPECT_EQ(debug_str('G'_dna4), "G"s);
+    EXPECT_EQ('G'_dna4, 'G'_dna4); // change value to test
+
+    EXPECT_EQ(gtest_str("ACGTCGA"_dna4), "ACGTCGA"s);
+    EXPECT_EQ(debug_str("ACGTCGA"_dna4), "ACGTCGA"s);
+    EXPECT_EQ("ACGTCGA"_dna4, "ACGTCGA"_dna4); // change value to test
+
+    std::vector dna_set1{"AC"_dna4, "GT"_dna4, "CG"_dna4, "A"_dna4};
+    std::vector dna_set2{"AC"_dna4, "GT"_dna4, "CG"_dna4, "A"_dna4};
+    EXPECT_EQ(gtest_str(dna_set1), "[AC,GT,CG,A]"s);
+    EXPECT_EQ(debug_str(dna_set1), "[AC,GT,CG,A]"s);
+    EXPECT_EQ(dna_set1, dna_set2); // change value to test
+
+    std::vector dna_sets1{std::vector{"AC"_dna4, "GT"_dna4}, std::vector{"CG"_dna4, "A"_dna4}};
+    std::vector dna_sets2{std::vector{"AC"_dna4, "GT"_dna4}, std::vector{"CG"_dna4, "A"_dna4}};
+    EXPECT_EQ(gtest_str(dna_sets1), "[[AC,GT],[CG,A]]"s);
+    EXPECT_EQ(debug_str(dna_sets1), "[[AC,GT],[CG,A]]"s);
+    EXPECT_EQ(dna_sets1, dna_sets2); // change value to test
+}
+
+namespace seqan3::detail
+{
+
+struct my_type
+{
+    std::string str;
+
+    bool operator==(my_type const & other) const
+    {
+        return str == other.str;
+    }
+
+    bool operator!=(my_type const & other) const
+    {
+        return str != other.str;
+    }
+};
+
+} // namespace seqan3::detail
+
+namespace seqan3
+{
+
+template <typename my_type>
+    requires std::Same<std::decay_t<my_type>, detail::my_type>
+inline debug_stream_type & operator<<(debug_stream_type & s, my_type && m)
+{
+    s << m.str;
+    return s;
+}
+
+} // namespace seqan3
+
+TEST(pretty_printing, seqan3_detail_output)
+{
+    // seqan3 types should always produce the same result
+    EXPECT_EQ(gtest_str(seqan3::detail::my_type{"HALLO"s}), "HALLO"s);
+    EXPECT_EQ(debug_str(seqan3::detail::my_type{"HALLO"s}), "HALLO"s);
+    EXPECT_EQ(seqan3::detail::my_type{"HALLO"}, seqan3::detail::my_type{"HALLO"}); // change value to test
 }


### PR DESCRIPTION
I had the problem that defined types in `seqan3::detail` did not use the correct debug_stream overload if they appeared on the right hand side in 

```c++
EXPECT_EQ(seqan3::detail::my_struct{}, seqan3::detail::my_struct{});
```

The left hand side of `EXPECT_EQ` printed fine.

Putting `PrintTo` into the detail namespace solved the problem for me.