### PR TITLE
[INFRA] Enable header tests for search module

### DIFF
--- a/include/seqan3/search/algorithm/configuration/max_error_rate.hpp
+++ b/include/seqan3/search/algorithm/configuration/max_error_rate.hpp
@@ -14,10 +14,10 @@
 #pragma once
 
 #include <range/v3/numeric/accumulate.hpp>
-#include <range/v3/view/slice.hpp>
 
 #include <seqan3/core/algorithm/pipeable_config_element.hpp>
 #include <seqan3/core/algorithm/parameter_pack.hpp>
+#include <seqan3/range/view/slice.hpp>
 #include <seqan3/search/algorithm/configuration/detail.hpp>
 #include <seqan3/search/algorithm/configuration/max_error_common.hpp>
 #include <seqan3/std/algorithm>

--- a/test/header/CMakeLists.txt
+++ b/test/header/CMakeLists.txt
@@ -41,7 +41,7 @@ macro (seqan3_header_test component header_base_path)
     seqan3_test_files (header_files "${header_base_path}" "*.hpp;*.h")
 
     # filter out headers which are implementation detail
-    list (FILTER header_files EXCLUDE REGEX "detail|/bits/|search")
+    list (FILTER header_files EXCLUDE REGEX "detail|/bits/")
 
     file (WRITE "${PROJECT_BINARY_DIR}/${target}.cpp" "")
     add_executable (${target} ${PROJECT_BINARY_DIR}/${target}.cpp)


### PR DESCRIPTION
<s>**Blocked by** https://github.com/xxsds/sdsl-lite/pull/66</s>

Now that the SDSL passes the header tests, we can re-enable the header tests for the search module.