### PR TITLE
Misc/cleanup ranges module

### DIFF
--- a/include/seqan3/alignment/scoring/aminoacid_scoring_scheme.hpp
+++ b/include/seqan3/alignment/scoring/aminoacid_scoring_scheme.hpp
@@ -18,7 +18,7 @@
 #include <seqan3/alignment/scoring/scoring_scheme_base.hpp>
 #include <seqan3/alphabet/aminoacid/aa27.hpp>
 #include <seqan3/range/shortcuts.hpp>
-#include <seqan3/std/ranges>
+#include <seqan3/std/algorithm>
 
 namespace seqan3
 {

--- a/include/seqan3/alignment/scoring/scoring_scheme_base.hpp
+++ b/include/seqan3/alignment/scoring/scoring_scheme_base.hpp
@@ -19,7 +19,7 @@
 #include <seqan3/core/concept/cereal.hpp>
 #include <seqan3/core/detail/strong_type.hpp>
 #include <seqan3/range/shortcuts.hpp>
-#include <seqan3/std/ranges>
+#include <seqan3/std/algorithm>
 
 #if SEQAN3_WITH_CEREAL
 #include <cereal/types/array.hpp>

--- a/include/seqan3/argument_parser/detail/format_base.hpp
+++ b/include/seqan3/argument_parser/detail/format_base.hpp
@@ -75,7 +75,7 @@ protected:
         if constexpr (meta::in<types, type>::value)
             return names[meta::find_index<types, type>::value];
         else
-            return detail::get_display_name_v<value_type>.string();
+            return detail::get_display_name_v<value_type>.str();
     }
 
     /*!\brief Returns the `value_type` of the input container as a string (reflection).

--- a/include/seqan3/io/alignment_file/detail.hpp
+++ b/include/seqan3/io/alignment_file/detail.hpp
@@ -18,6 +18,7 @@
 #include <seqan3/core/concept/tuple.hpp>
 #include <seqan3/range/view/single_pass_input.hpp>
 #include <seqan3/range/view/take_until.hpp>
+#include <seqan3/std/algorithm>
 #include <seqan3/std/charconv>
 #include <seqan3/std/concepts>
 #include <seqan3/std/ranges>

--- a/include/seqan3/io/alignment_file/format_sam.hpp
+++ b/include/seqan3/io/alignment_file/format_sam.hpp
@@ -37,6 +37,7 @@
 #include <seqan3/range/view/slice.hpp>
 #include <seqan3/range/view/take_until.hpp>
 #include <seqan3/range/view/to_char.hpp>
+#include <seqan3/std/algorithm>
 #include <seqan3/std/charconv>
 #include <seqan3/std/concepts>
 #include <seqan3/std/ranges>

--- a/include/seqan3/io/detail/misc.hpp
+++ b/include/seqan3/io/detail/misc.hpp
@@ -17,6 +17,7 @@
 #include <seqan3/core/metafunction/template_inspection.hpp>
 #include <seqan3/core/type_list.hpp>
 #include <seqan3/io/exception.hpp>
+#include <seqan3/std/algorithm>
 #include <seqan3/std/filesystem>
 #include <seqan3/std/iterator>
 

--- a/include/seqan3/io/sequence_file/format_embl.hpp
+++ b/include/seqan3/io/sequence_file/format_embl.hpp
@@ -32,6 +32,7 @@
 #include <seqan3/range/view/take_exactly.hpp>
 #include <seqan3/range/view/take_line.hpp>
 #include <seqan3/range/view/take_until.hpp>
+#include <seqan3/std/algorithm>
 #include <seqan3/std/charconv>
 #include <seqan3/std/ranges>
 

--- a/include/seqan3/io/sequence_file/format_fasta.hpp
+++ b/include/seqan3/io/sequence_file/format_fasta.hpp
@@ -40,6 +40,7 @@
 #include <seqan3/range/view/take_exactly.hpp>
 #include <seqan3/range/view/take_line.hpp>
 #include <seqan3/range/view/take_until.hpp>
+#include <seqan3/std/algorithm>
 #include <seqan3/std/ranges>
 
 namespace seqan3

--- a/include/seqan3/io/sequence_file/format_fastq.hpp
+++ b/include/seqan3/io/sequence_file/format_fastq.hpp
@@ -38,6 +38,7 @@
 #include <seqan3/range/view/take_exactly.hpp>
 #include <seqan3/range/view/take_line.hpp>
 #include <seqan3/range/view/take_until.hpp>
+#include <seqan3/std/algorithm>
 #include <seqan3/std/ranges>
 
 namespace seqan3

--- a/include/seqan3/io/sequence_file/format_sam.hpp
+++ b/include/seqan3/io/sequence_file/format_sam.hpp
@@ -30,6 +30,7 @@
 #include <seqan3/range/view/take_exactly.hpp>
 #include <seqan3/range/view/take_line.hpp>
 #include <seqan3/range/view/take_until.hpp>
+#include <seqan3/std/algorithm>
 #include <seqan3/std/ranges>
 
 namespace seqan3

--- a/include/seqan3/io/structure_file/format_vienna.hpp
+++ b/include/seqan3/io/structure_file/format_vienna.hpp
@@ -41,6 +41,7 @@
 #include <seqan3/range/view/take.hpp>
 #include <seqan3/range/view/take_line.hpp>
 #include <seqan3/range/view/take_until.hpp>
+#include <seqan3/std/algorithm>
 #include <seqan3/std/ranges>
 
 namespace seqan3

--- a/include/seqan3/range/container/small_vector.hpp
+++ b/include/seqan3/range/container/small_vector.hpp
@@ -24,6 +24,7 @@
 #include <seqan3/core/metafunction/template_inspection.hpp>
 #include <seqan3/range/view/repeat_n.hpp>
 #include <seqan3/range/view/take.hpp>
+#include <seqan3/std/algorithm>
 #include <seqan3/std/ranges>
 
 namespace seqan3

--- a/include/seqan3/range/decorator/gap_decorator_anchor_set.hpp
+++ b/include/seqan3/range/decorator/gap_decorator_anchor_set.hpp
@@ -24,6 +24,7 @@
 #include <seqan3/alphabet/gap/gapped.hpp>
 #include <seqan3/range/container/concept.hpp>
 #include <seqan3/range/detail/random_access_iterator.hpp>
+#include <seqan3/std/algorithm>
 #include <seqan3/std/ranges>
 
 namespace seqan3

--- a/include/seqan3/range/view/drop.hpp
+++ b/include/seqan3/range/view/drop.hpp
@@ -53,7 +53,7 @@ struct drop_fn
         // safeguard against wrong size
         if constexpr (std::ranges::SizedRange<urng_t>)
         {
-            drop_size = std::min(drop_size, std::ranges::size(urange));
+            drop_size = std::min(drop_size, static_cast<size_t>(std::ranges::size(urange)));
             new_size = std::ranges::size(urange) - drop_size;
         }
 

--- a/include/seqan3/range/view/persist.hpp
+++ b/include/seqan3/range/view/persist.hpp
@@ -22,6 +22,7 @@
 #include <seqan3/range/shortcuts.hpp>
 #include <seqan3/range/container/concept.hpp>
 #include <seqan3/range/view/detail.hpp>
+#include <seqan3/std/algorithm>
 #include <seqan3/std/concepts>
 #include <seqan3/std/ranges>
 

--- a/include/seqan3/range/view/take.hpp
+++ b/include/seqan3/range/view/take.hpp
@@ -24,6 +24,7 @@
 #include <seqan3/range/container/concept.hpp>
 #include <seqan3/range/view/detail.hpp>
 #include <seqan3/range/detail/inherited_iterator_base.hpp>
+#include <seqan3/std/algorithm>
 #include <seqan3/std/concepts>
 #include <seqan3/std/iterator>
 #include <seqan3/std/ranges>

--- a/include/seqan3/range/view/take_until.hpp
+++ b/include/seqan3/range/view/take_until.hpp
@@ -23,6 +23,7 @@
 #include <seqan3/std/concepts>
 #include <seqan3/std/ranges>
 #include <seqan3/range/container/concept.hpp>
+#include <seqan3/std/algorithm>
 #include <seqan3/std/concepts>
 #include <seqan3/std/iterator>
 #include <seqan3/std/type_traits>

--- a/include/seqan3/search/algorithm/configuration/max_error.hpp
+++ b/include/seqan3/search/algorithm/configuration/max_error.hpp
@@ -20,6 +20,7 @@
 #include <seqan3/range/view/slice.hpp>
 #include <seqan3/search/algorithm/configuration/detail.hpp>
 #include <seqan3/search/algorithm/configuration/max_error_common.hpp>
+#include <seqan3/std/algorithm>
 
 namespace seqan3::search_cfg
 {

--- a/include/seqan3/search/algorithm/configuration/max_error_rate.hpp
+++ b/include/seqan3/search/algorithm/configuration/max_error_rate.hpp
@@ -20,6 +20,7 @@
 #include <seqan3/core/algorithm/parameter_pack.hpp>
 #include <seqan3/search/algorithm/configuration/detail.hpp>
 #include <seqan3/search/algorithm/configuration/max_error_common.hpp>
+#include <seqan3/std/algorithm>
 
 namespace seqan3::search_cfg
 {

--- a/include/seqan3/search/algorithm/search.hpp
+++ b/include/seqan3/search/algorithm/search.hpp
@@ -16,6 +16,8 @@
 #include <seqan3/range/view/persist.hpp>
 #include <seqan3/search/algorithm/detail/search.hpp>
 #include <seqan3/search/fm_index/all.hpp>
+#include <seqan3/std/algorithm>
+#include <seqan3/std/ranges>
 
 namespace seqan3
 {

--- a/include/seqan3/search/fm_index/fm_index.hpp
+++ b/include/seqan3/search/fm_index/fm_index.hpp
@@ -22,6 +22,7 @@
 #include <seqan3/search/fm_index/detail/csa_alphabet_strategy.hpp>
 #include <seqan3/search/fm_index/detail/fm_index_cursor.hpp>
 #include <seqan3/search/fm_index/fm_index_cursor.hpp>
+#include <seqan3/std/algorithm>
 #include <seqan3/std/ranges>
 
 namespace seqan3

--- a/include/seqan3/std/algorithm
+++ b/include/seqan3/std/algorithm
@@ -1,0 +1,91 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Adaptations of algorithms from the Ranges TS
+ * \author René Rahn <rene.rahn AT fu-berlin.de>
+ */
+
+#pragma once
+
+/*!\defgroup algorithm algorithm
+ * \ingroup std
+ * \brief The \<algorithm\> header with additional ranges algorithm from C++20's standard library.
+ */
+
+#include <algorithm>
+
+#ifndef __cpp_lib_ranges  // If not C++20 ranges available, implement via range-v3.
+
+#include <range/v3/algorithm/copy.hpp>
+#include <range/v3/algorithm/equal.hpp>
+#include <range/v3/algorithm/fill.hpp>
+#include <range/v3/algorithm/find_if_not.hpp>
+#include <range/v3/algorithm/find_if.hpp>
+#include <range/v3/algorithm/find.hpp>
+#include <range/v3/algorithm/for_each.hpp>
+#include <range/v3/algorithm/move_backward.hpp>
+#include <range/v3/algorithm/move.hpp>
+#include <range/v3/algorithm/sort.hpp>
+
+#include <seqan3/core/platform.hpp>
+
+namespace std::ranges
+{
+
+/*!\typedef std::ranges::copy
+ * \brief Alias for ranges::copy. Copies a range of elements to a new location.
+ */
+using SEQAN3_DOXYGEN_ONLY(copy =) ::ranges::copy;
+
+/*!\typedef std::ranges::equal
+* \brief Alias for ranges::equal. Determines if two sets of elements are the same.
+*/
+using SEQAN3_DOXYGEN_ONLY(equal =) ::ranges::equal;
+
+/*!\typedef std::ranges::fill
+ * \brief Alias for ranges::fill. Assigns a value to the elements of a range.
+ */
+using SEQAN3_DOXYGEN_ONLY(fill =) ::ranges::fill;
+
+/*!\typedef std::ranges::find_if_not
+* \brief Alias for ranges::find_if_not. Returns the first element in the range for which the predicate returns false.
+*/
+using SEQAN3_DOXYGEN_ONLY(find_if_not =) ::ranges::find_if_not;
+
+/*!\typedef std::ranges::find_if
+* \brief Alias for ranges::find_if. Returns the first element in the range for which the predicate returns true.
+*/
+using SEQAN3_DOXYGEN_ONLY(find_if =) ::ranges::find_if;
+
+/*!\typedef std::ranges::find
+* \brief Alias for ranges::find. Returns the first element in the range equal to the given value.
+*/
+using SEQAN3_DOXYGEN_ONLY(find =) ::ranges::find;
+
+/*!\typedef std::ranges::for_each
+ * \brief Alias for ranges::for_each. Applies a function object to the elements of a range.
+ */
+using SEQAN3_DOXYGEN_ONLY(for_each =) ::ranges::for_each;
+
+/*!\typedef std::ranges::move_backward
+ * \brief Alias for ranges::move_backward. Moves a range of elements backward to a new location starting from the end.
+ */
+using SEQAN3_DOXYGEN_ONLY(move_backward =) ::ranges::move_backward;
+
+/*!\typedef std::ranges::move
+ * \brief Alias for ranges::move. Moves a range of elements to a new location.
+ */
+using SEQAN3_DOXYGEN_ONLY(move =) ::ranges::move;
+
+/*!\typedef std::ranges::sort
+* \brief Alias for ranges::sort. Sorts a range.
+*/
+using SEQAN3_DOXYGEN_ONLY(sort =) ::ranges::sort;
+
+} // namespace std::ranges
+#endif  // __cpp_lib_ranges

--- a/include/seqan3/std/ranges
+++ b/include/seqan3/std/ranges
@@ -22,16 +22,6 @@
 #include <range/v3/iterator/default_sentinel.hpp>
 #include <range/v3/iterator/insert_iterators.hpp>
 #include <range/v3/iterator/stream_iterators.hpp>
-#include <range/v3/algorithm/copy.hpp>
-#include <range/v3/algorithm/equal.hpp>
-#include <range/v3/algorithm/fill.hpp>
-#include <range/v3/algorithm/find_if_not.hpp>
-#include <range/v3/algorithm/find_if.hpp>
-#include <range/v3/algorithm/find.hpp>
-#include <range/v3/algorithm/for_each.hpp>
-#include <range/v3/algorithm/move_backward.hpp>
-#include <range/v3/algorithm/move.hpp>
-#include <range/v3/algorithm/sort.hpp>
 #include <range/v3/view/all.hpp>
 #include <range/v3/view/any_view.hpp>
 #include <range/v3/view/common.hpp>
@@ -200,60 +190,10 @@ using SEQAN3_DOXYGEN_ONLY(data =) ::ranges::data;
  */
 using SEQAN3_DOXYGEN_ONLY(size =) ::ranges::size;
 
-/*!\typedef std::ranges::copy
- * \brief Alias for ranges::copy. Copies a range of elements to a new location.
- */
-using SEQAN3_DOXYGEN_ONLY(copy =) ::ranges::copy;
-
-/*!\typedef std::ranges::move
- * \brief Alias for ranges::move. Moves a range of elements to a new location.
- */
-using SEQAN3_DOXYGEN_ONLY(move =) ::ranges::move;
-
-/*!\typedef std::ranges::move_backward
- * \brief Alias for ranges::move_backward. Moves a range of elements backward to a new location starting from the end.
- */
-using SEQAN3_DOXYGEN_ONLY(move_backward =) ::ranges::move_backward;
-
-/*!\typedef std::ranges::for_each
- * \brief Alias for ranges::for_each. Applies a function object to the elements of a range.
- */
-using SEQAN3_DOXYGEN_ONLY(for_each =) ::ranges::for_each;
-
-/*!\typedef std::ranges::fill
- * \brief Alias for ranges::fill. Assigns a value to the elements of a range.
- */
-using SEQAN3_DOXYGEN_ONLY(fill =) ::ranges::fill;
-
 /*!\typedef std::ranges::empty
  * \brief Alias for ranges::empty. Checks whether a range is empty.
  */
 using SEQAN3_DOXYGEN_ONLY(empty =) ::ranges::empty;
-
-/*!\typedef std::ranges::equal
-* \brief Alias for ranges::equal. Determines if two sets of elements are the same.
-*/
-using SEQAN3_DOXYGEN_ONLY(equal =) ::ranges::equal;
-
-/*!\typedef std::ranges::sort
-* \brief Alias for ranges::sort. Sorts a range.
-*/
-using SEQAN3_DOXYGEN_ONLY(sort =) ::ranges::sort;
-
-/*!\typedef std::ranges::find
-* \brief Alias for ranges::find. Returns the first element in the range equal to the given value.
-*/
-using SEQAN3_DOXYGEN_ONLY(find =) ::ranges::find;
-
-/*!\typedef std::ranges::find_if
-* \brief Alias for ranges::find_if. Returns the first element in the range for which the predicate returns true.
-*/
-using SEQAN3_DOXYGEN_ONLY(find_if =) ::ranges::find_if;
-
-/*!\typedef std::ranges::find_if_not
-* \brief Alias for ranges::find_if_not. Returns the first element in the range for which the predicate returns false.
-*/
-using SEQAN3_DOXYGEN_ONLY(find_if_not =) ::ranges::find_if_not;
 
 /*!\typedef std::ranges::default_sentinel
 * \brief Alias for ranges::default_sentinel. Empty sentinel object for use with iterators that know the bound of their range.

--- a/test/snippet/io/alignment_file/alignment_file_input.cpp
+++ b/test/snippet/io/alignment_file/alignment_file_input.cpp
@@ -6,6 +6,7 @@
 #include <seqan3/range/view/persist.hpp>
 #include <seqan3/range/view/single_pass_input.hpp>
 #include <seqan3/range/view/take_until.hpp>
+#include <seqan3/std/algorithm>
 #include <seqan3/std/ranges>
 
 struct write_file_dummy_struct

--- a/test/unit/io/alignment_file/alignment_file_input_test.cpp
+++ b/test/unit/io/alignment_file/alignment_file_input_test.cpp
@@ -13,6 +13,7 @@
 #include <seqan3/io/alignment_file/input.hpp>
 #include <seqan3/range/view/convert.hpp>
 #include <seqan3/range/view/to_char.hpp>
+#include <seqan3/std/algorithm>
 #include <seqan3/std/iterator>
 #include <seqan3/std/ranges>
 #include <seqan3/test/tmp_filename.hpp>

--- a/test/unit/io/record_test.cpp
+++ b/test/unit/io/record_test.cpp
@@ -9,8 +9,6 @@
 
 #include <gtest/gtest.h>
 
-#include <range/v3/algorithm/equal.hpp>
-
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/alphabet/quality/phred42.hpp>
 #include <seqan3/io/record.hpp>
@@ -18,6 +16,7 @@
 #include <seqan3/core/concept/tuple.hpp>
 #include <seqan3/core/detail/reflection.hpp>
 #include <seqan3/range/view/to_char.hpp>
+#include <seqan3/std/algorithm>
 
 using namespace seqan3;
 

--- a/test/unit/io/sequence_file/sequence_file_format_embl_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_format_embl_test.cpp
@@ -15,6 +15,7 @@
 #include <seqan3/io/sequence_file/output.hpp>
 #include <seqan3/io/sequence_file/output_format_concept.hpp>
 #include <seqan3/io/sequence_file/format_embl.hpp>
+#include <seqan3/std/algorithm>
 #include <seqan3/test/pretty_printing.hpp>
 
 using namespace seqan3;

--- a/test/unit/io/sequence_file/sequence_file_format_fasta_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_format_fasta_test.cpp
@@ -9,14 +9,13 @@
 
 #include <gtest/gtest.h>
 
-#include <range/v3/algorithm/equal.hpp>
-#include <range/v3/view/transform.hpp>
-
 #include <seqan3/alphabet/quality/all.hpp>
 #include <seqan3/io/sequence_file/input_format_concept.hpp>
 #include <seqan3/io/sequence_file/output_format_concept.hpp>
 #include <seqan3/io/sequence_file/format_fasta.hpp>
 #include <seqan3/range/view/convert.hpp>
+#include <seqan3/std/algorithm>
+#include <seqan3/std/ranges>
 
 using namespace seqan3;
 

--- a/test/unit/io/sequence_file/sequence_file_format_fastq_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_format_fastq_test.cpp
@@ -9,14 +9,13 @@
 
 #include <gtest/gtest.h>
 
-#include <range/v3/algorithm/equal.hpp>
-#include <range/v3/view/transform.hpp>
-
 #include <seqan3/alphabet/quality/all.hpp>
 #include <seqan3/io/sequence_file/input_format_concept.hpp>
 #include <seqan3/io/sequence_file/output_format_concept.hpp>
 #include <seqan3/io/sequence_file/format_fastq.hpp>
 #include <seqan3/range/view/convert.hpp>
+#include <seqan3/std/algorithm>
+#include <seqan3/std/ranges>
 
 using namespace seqan3;
 

--- a/test/unit/io/sequence_file/sequence_file_format_sam_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_format_sam_test.cpp
@@ -15,6 +15,7 @@
 #include <seqan3/io/sequence_file/input_format_concept.hpp>
 #include <seqan3/io/sequence_file/output.hpp>
 #include <seqan3/io/sequence_file/output_format_concept.hpp>
+#include <seqan3/std/algorithm>
 #include <seqan3/test/pretty_printing.hpp>
 
 using namespace seqan3;

--- a/test/unit/io/sequence_file/sequence_file_input_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_input_test.cpp
@@ -9,11 +9,10 @@
 
 #include <gtest/gtest.h>
 
-#include <range/v3/view/zip.hpp>
-
 #include <seqan3/io/sequence_file/input.hpp>
 #include <seqan3/range/view/convert.hpp>
 #include <seqan3/range/view/to_char.hpp>
+#include <seqan3/std/algorithm>
 #include <seqan3/std/iterator>
 #include <seqan3/std/ranges>
 #include <seqan3/test/tmp_filename.hpp>

--- a/test/unit/io/structure_file/format_vienna_test.cpp
+++ b/test/unit/io/structure_file/format_vienna_test.cpp
@@ -12,8 +12,6 @@
 
 #include <gtest/gtest.h>
 
-#include <range/v3/algorithm/equal.hpp>
-
 #include <seqan3/alphabet/nucleotide/rna4.hpp>
 #include <seqan3/alphabet/structure/dot_bracket3.hpp>
 #include <seqan3/alphabet/structure/structured_rna.hpp>
@@ -21,6 +19,7 @@
 #include <seqan3/io/structure_file/input_format_concept.hpp>
 #include <seqan3/io/structure_file/output_format_concept.hpp>
 #include <seqan3/range/view/convert.hpp>
+#include <seqan3/std/algorithm>
 
 using namespace seqan3;
 

--- a/test/unit/io/structure_file/structure_file_input_test.cpp
+++ b/test/unit/io/structure_file/structure_file_input_test.cpp
@@ -11,14 +11,12 @@
 
 #include <gtest/gtest.h>
 
-#include <range/v3/view/zip.hpp>
-#include <range/v3/view/filter.hpp>
-#include <range/v3/algorithm/for_each.hpp>
 #include <range/v3/view/map.hpp>
 
 #include <seqan3/alphabet/nucleotide/rna4.hpp>
 #include <seqan3/io/structure_file/input.hpp>
 #include <seqan3/range/view/convert.hpp>
+#include <seqan3/std/algorithm>
 #include <seqan3/std/iterator>
 #include <seqan3/std/ranges>
 #include <seqan3/test/tmp_filename.hpp>

--- a/test/unit/range/container/container_test.cpp
+++ b/test/unit/range/container/container_test.cpp
@@ -15,6 +15,7 @@
 #include <seqan3/io/stream/debug_stream.hpp>
 #include <seqan3/range/container/all.hpp>
 #include <seqan3/range/view/convert.hpp>
+#include <seqan3/std/algorithm>
 #include <seqan3/test/cereal.hpp>
 #include <seqan3/test/pretty_printing.hpp>
 

--- a/test/unit/range/view/view_all_test.cpp
+++ b/test/unit/range/view/view_all_test.cpp
@@ -15,6 +15,7 @@
 
 #include <seqan3/range/view/view_all.hpp>
 #include <seqan3/std/concepts>
+#include <seqan3/std/algorithm>
 #include <seqan3/std/ranges>
 
 using namespace seqan3;

--- a/test/unit/range/view/view_char_to_test.cpp
+++ b/test/unit/range/view/view_char_to_test.cpp
@@ -9,11 +9,10 @@
 
 #include <gtest/gtest.h>
 
-#include <range/v3/algorithm/equal.hpp>
-
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
 #include <seqan3/range/concept.hpp>
 #include <seqan3/range/view/char_to.hpp>
+#include <seqan3/std/algorithm>
 #include <seqan3/std/ranges>
 
 using namespace seqan3;

--- a/test/unit/range/view/view_complement_test.cpp
+++ b/test/unit/range/view/view_complement_test.cpp
@@ -12,6 +12,7 @@
 #include <seqan3/alphabet/nucleotide/all.hpp>
 #include <seqan3/range/concept.hpp>
 #include <seqan3/range/view/complement.hpp>
+#include <seqan3/std/algorithm>
 #include <seqan3/std/ranges>
 
 using namespace seqan3;

--- a/test/unit/range/view/view_deep_test.cpp
+++ b/test/unit/range/view/view_deep_test.cpp
@@ -9,13 +9,11 @@
 
 #include <gtest/gtest.h>
 
-#include <range/v3/algorithm/equal.hpp>
-#include <range/v3/view/take.hpp>
-
 #include <seqan3/alphabet/nucleotide/all.hpp>
 #include <seqan3/range/concept.hpp>
 #include <seqan3/range/view/deep.hpp>
 #include <seqan3/range/view/to_char.hpp>
+#include <seqan3/std/algorithm>
 #include <seqan3/std/ranges>
 
 namespace seqan3::view

--- a/test/unit/range/view/view_drop_test.cpp
+++ b/test/unit/range/view/view_drop_test.cpp
@@ -21,6 +21,7 @@
 #include <seqan3/range/concept.hpp>
 #include <seqan3/range/container/concept.hpp>
 #include <seqan3/range/view/to_char.hpp>
+#include <seqan3/std/algorithm>
 #include <seqan3/std/concepts>
 #include <seqan3/std/ranges>
 

--- a/test/unit/range/view/view_repeat_n_test.cpp
+++ b/test/unit/range/view/view_repeat_n_test.cpp
@@ -14,6 +14,7 @@
 #include <seqan3/range/view/repeat_n.hpp>
 #include <seqan3/range/view/take.hpp>
 #include <seqan3/range/view/take_exactly.hpp>
+#include <seqan3/std/algorithm>
 #include <seqan3/std/ranges>
 
 using namespace seqan3;

--- a/test/unit/range/view/view_repeat_test.cpp
+++ b/test/unit/range/view/view_repeat_test.cpp
@@ -14,6 +14,7 @@
 #include <seqan3/range/view/repeat.hpp>
 #include <seqan3/range/view/take.hpp>
 #include <seqan3/range/view/take_exactly.hpp>
+#include <seqan3/std/algorithm>
 #include <seqan3/std/ranges>
 
 using namespace seqan3;

--- a/test/unit/range/view/view_slice_test.cpp
+++ b/test/unit/range/view/view_slice_test.cpp
@@ -20,6 +20,7 @@
 #include <seqan3/range/concept.hpp>
 #include <seqan3/range/container/concept.hpp>
 #include <seqan3/range/view/to_char.hpp>
+#include <seqan3/std/algorithm>
 #include <seqan3/std/concepts>
 #include <seqan3/std/ranges>
 

--- a/test/unit/range/view/view_take_test.cpp
+++ b/test/unit/range/view/view_take_test.cpp
@@ -13,7 +13,6 @@
 
 #include <gtest/gtest.h>
 
-#include <range/v3/algorithm/copy.hpp>
 #include <range/v3/view/unique.hpp>
 
 #include <seqan3/range/view/take.hpp>
@@ -22,6 +21,7 @@
 #include <seqan3/range/concept.hpp>
 #include <seqan3/range/container/concept.hpp>
 #include <seqan3/range/view/to_char.hpp>
+#include <seqan3/std/algorithm>
 #include <seqan3/std/concepts>
 #include <seqan3/std/ranges>
 

--- a/test/unit/range/view/view_take_until_test.cpp
+++ b/test/unit/range/view/view_take_until_test.cpp
@@ -9,12 +9,12 @@
 
 #include <gtest/gtest.h>
 
-#include <range/v3/algorithm/copy.hpp>
 #include <range/v3/view/unique.hpp>
 
 #include <seqan3/range/view/take_until.hpp>
 #include <seqan3/range/view/single_pass_input.hpp>
 #include <seqan3/range/view/to_char.hpp>
+#include <seqan3/std/algorithm>
 #include <seqan3/std/ranges>
 #include <seqan3/std/span>
 

--- a/test/unit/range/view/view_translation_test.cpp
+++ b/test/unit/range/view/view_translation_test.cpp
@@ -11,9 +11,6 @@
 #include <string>
 #include <vector>
 
-#include <range/v3/view/take.hpp>
-#include <range/v3/algorithm/equal.hpp>
-
 #include <seqan3/alphabet/nucleotide/all.hpp>
 #include <seqan3/alphabet/aminoacid/aa27.hpp>
 #include <seqan3/core/detail/reflection.hpp>
@@ -22,6 +19,7 @@
 #include <seqan3/range/view/char_to.hpp>
 #include <seqan3/range/view/complement.hpp>
 #include <seqan3/range/view/translation.hpp>
+#include <seqan3/std/algorithm>
 #include <seqan3/std/ranges>
 
 using namespace seqan3;

--- a/test/unit/search/fm_index_cursor/bi_fm_index_cursor_collection_test_template.hpp
+++ b/test/unit/search/fm_index_cursor/bi_fm_index_cursor_collection_test_template.hpp
@@ -9,10 +9,9 @@
 
 #include "../helper.hpp"
 
-#include <range/v3/algorithm/equal.hpp>
-
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/search/fm_index/bi_fm_index_cursor.hpp>
+#include <seqan3/std/algorithm>
 
 #include <gtest/gtest.h>
 

--- a/test/unit/search/fm_index_cursor/bi_fm_index_cursor_test_template.hpp
+++ b/test/unit/search/fm_index_cursor/bi_fm_index_cursor_test_template.hpp
@@ -9,10 +9,9 @@
 
 #include "../helper.hpp"
 
-#include <range/v3/algorithm/equal.hpp>
-
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/search/fm_index/bi_fm_index_cursor.hpp>
+#include <seqan3/std/algorithm>
 
 #include <gtest/gtest.h>
 

--- a/test/unit/search/fm_index_cursor/fm_index_cursor_collection_test_template.hpp
+++ b/test/unit/search/fm_index_cursor/fm_index_cursor_collection_test_template.hpp
@@ -9,11 +9,9 @@
 
 #include "../helper.hpp"
 
-#include <range/v3/algorithm/equal.hpp>
-
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/search/fm_index/all.hpp>
-
+#include <seqan3/std/algorithm>
 
 #include <gtest/gtest.h>
 

--- a/test/unit/search/fm_index_cursor/fm_index_cursor_test_template.hpp
+++ b/test/unit/search/fm_index_cursor/fm_index_cursor_test_template.hpp
@@ -9,11 +9,9 @@
 
 #include "../helper.hpp"
 
-#include <range/v3/algorithm/equal.hpp>
-
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/search/fm_index/all.hpp>
-
+#include <seqan3/std/algorithm>
 
 #include <gtest/gtest.h>
 

--- a/test/unit/std/ranges/find_test.cpp
+++ b/test/unit/std/ranges/find_test.cpp
@@ -9,7 +9,7 @@
 
 #include <vector>
 
-#include <seqan3/std/ranges>
+#include <seqan3/std/algorithm>
 
 TEST(general, find)
 {

--- a/test/unit/std/ranges/move_test.cpp
+++ b/test/unit/std/ranges/move_test.cpp
@@ -9,7 +9,7 @@
 
 #include <vector>
 
-#include <seqan3/std/ranges>
+#include <seqan3/std/algorithm>
 
 TEST(general, move)
 {


### PR DESCRIPTION
Moves the ranges algorithms to the algorithm include.

Fixes a bug with format_parse_base 
Fixes a bug with drop_view closure object on macos.