### PR TITLE
Concept renaming missing II

### DIFF
--- a/include/seqan3/core/concept/cereal.hpp
+++ b/include/seqan3/core/concept/cereal.hpp
@@ -83,7 +83,7 @@ SEQAN3_CONCEPT CerealArchive = false;
 #endif
 //!\endcond
 
-/*!\interface seqan3::cereal_text_archive_concept <>
+/*!\interface seqan3::CerealTextArchive <>
  * \brief All text archives of the Cereal library satisfy this.
  * \extends seqan3::CerealArchive
  * \ingroup core
@@ -97,10 +97,10 @@ SEQAN3_CONCEPT CerealArchive = false;
 //!\cond
 #if SEQAN3_WITH_CEREAL
 template <typename t>
-SEQAN3_CONCEPT cereal_text_archive_concept = std::is_base_of_v<cereal::traits::TextArchive, t>;
+SEQAN3_CONCEPT CerealTextArchive = std::is_base_of_v<cereal::traits::TextArchive, t>;
 #else
 template <typename t>
-SEQAN3_CONCEPT cereal_text_archive_concept = false;
+SEQAN3_CONCEPT CerealTextArchive = false;
 #endif
 //!\endcond
 

--- a/include/seqan3/core/simd/concept.hpp
+++ b/include/seqan3/core/simd/concept.hpp
@@ -6,7 +6,7 @@
 // -----------------------------------------------------------------------------------------------------
 
 /*!\file
- * \brief Contains seqan3::simd::simd_concept
+ * \brief Contains seqan3::simd::Simd
  * \author Marcel Ehrhardt <marcel.ehrhardt AT fu-berlin.de>
  */
 
@@ -20,7 +20,7 @@
 namespace seqan3::detail
 {
 //!\cond
-// NOTE: this definition should be used for seqan3::simd_concept, but gcc has a bug that it will not fail silently if
+// NOTE: this definition should be used for seqan3::Simd, but gcc has a bug that it will not fail silently if
 // simd_t is a pointer to a incomplete type. Furthermore the is_pointer_v should prevent those cases by checking the type
 // beforehand, but for some reasons the short-circuit semantic of `&&` does not work in this case and gcc still evaluates
 // the requires clause which in turn triggers the error.
@@ -29,7 +29,7 @@ namespace seqan3::detail
 //     error: invalid use of incomplete type ‘struct incomplete::template_type<int>’
 //          requires std::Same<decltype(a - b), simd_t>;
 template <typename simd_t>
-SEQAN3_CONCEPT simd_concept = requires (simd_t a, simd_t b)
+SEQAN3_CONCEPT Simd = requires (simd_t a, simd_t b)
 {
     typename simd_traits<simd_t>::scalar_type;
     typename simd_traits<simd_t>::mask_type;
@@ -70,22 +70,22 @@ namespace seqan3
 inline namespace simd
 {
 
-/*!\interface seqan3::simd::simd_concept <>
+/*!\interface seqan3::simd::Simd <>
  * \brief The generic simd concept.
  * \ingroup simd
  *
  * \details
  *
- * seqan3::simd::simd_concept checks whether a given type is a simd type. One of the prerequisites is
+ * seqan3::simd::Simd checks whether a given type is a simd type. One of the prerequisites is
  * that seqan3::simd::simd_traits is defined for this type.
  *
  * \if DEV
- * \todo Simplify concept to the seqan3::detail::simd_concept once gcc bug is fixed
+ * \todo Simplify concept to the seqan3::detail::Simd once gcc bug is fixed
  * \endif
  */
 //!\cond
 template <typename simd_t>
-SEQAN3_CONCEPT simd_concept = !std::is_pointer_v<std::decay_t<simd_t>> && detail::simd_concept<simd_t>;
+SEQAN3_CONCEPT Simd = !std::is_pointer_v<std::decay_t<simd_t>> && detail::Simd<simd_t>;
 //!\endcond
 
 } // inline namespace simd

--- a/include/seqan3/core/simd/simd_algorithm.hpp
+++ b/include/seqan3/core/simd/simd_algorithm.hpp
@@ -22,7 +22,7 @@ namespace seqan3::detail
 
 //!\brief Helper function for seqan3::simd::fill.
 //!\ingroup simd
-template <simd_concept simd_t, size_t... I>
+template <Simd simd_t, size_t... I>
 constexpr simd_t fill_impl(typename simd_traits<simd_t>::scalar_type const scalar, std::index_sequence<I...>)
 {
     return simd_t{((void)I, scalar)...};
@@ -30,7 +30,7 @@ constexpr simd_t fill_impl(typename simd_traits<simd_t>::scalar_type const scala
 
 //!\brief Helper function for seqan3::simd::iota.
 //!\ingroup simd
-template <simd_concept simd_t, typename scalar_t, scalar_t... I>
+template <Simd simd_t, typename scalar_t, scalar_t... I>
 constexpr simd_t iota_impl(scalar_t const offset, std::integer_sequence<scalar_t, I...>)
 {
     return simd_t{static_cast<scalar_t>(offset + I)...};
@@ -45,7 +45,7 @@ inline namespace simd
 {
 
 /*!\brief Fills a seqan3::simd::simd_type vector with a scalar value.
- * \tparam    simd_t The simd type which satisfies seqan3::simd::simd_concept.
+ * \tparam    simd_t The simd type which satisfies seqan3::simd::Simd.
  * \param[in] scalar The scalar value to fill the seqan3::simd::simd_type vector.
  * \ingroup simd
  *
@@ -53,7 +53,7 @@ inline namespace simd
  *
  * \include test/snippet/core/simd/fill.cpp
  */
-template <simd_concept simd_t>
+template <Simd simd_t>
 constexpr simd_t fill(typename simd_traits<simd_t>::scalar_type const scalar)
 {
     constexpr size_t length = simd_traits<simd_t>::length;
@@ -61,7 +61,7 @@ constexpr simd_t fill(typename simd_traits<simd_t>::scalar_type const scalar)
 }
 
 /*!\brief Fills a seqan3::simd::simd_type vector with the scalar values offset, offset+1, offset+2, ...
- * \tparam    simd_t The simd type which satisfies seqan3::simd::simd_concept.
+ * \tparam    simd_t The simd type which satisfies seqan3::simd::Simd.
  * \param[in] offset The scalar offset to fill the seqan3::simd::simd_type vector.
  * \ingroup simd
  *
@@ -69,7 +69,7 @@ constexpr simd_t fill(typename simd_traits<simd_t>::scalar_type const scalar)
  *
  * \include test/snippet/core/simd/iota.cpp
  */
-template <simd_concept simd_t>
+template <Simd simd_t>
 constexpr simd_t iota(typename simd_traits<simd_t>::scalar_type const offset)
 {
     constexpr size_t length = simd_traits<simd_t>::length;

--- a/include/seqan3/core/simd/simd_debug_stream.hpp
+++ b/include/seqan3/core/simd/simd_debug_stream.hpp
@@ -24,7 +24,7 @@ namespace seqan3
  */
 template <typename simd_t>
 //!\cond
-    requires simd::simd_concept<remove_cvref_t<simd_t>>
+    requires simd::Simd<remove_cvref_t<simd_t>>
 //!\endcond
 inline debug_stream_type & operator<<(debug_stream_type & s, simd_t && simd)
 {

--- a/include/seqan3/core/simd/simd_traits.hpp
+++ b/include/seqan3/core/simd/simd_traits.hpp
@@ -39,24 +39,24 @@ struct simd_traits
 #if SEQAN3_DOXYGEN_ONLY(1)0
 {
     /*!\brief The underlying type of a simd vector (is not defined if *simd_t*
-     * does not satisfy *seqan3::simd::Simd*)
+     * does not model *seqan3::simd::Simd*)
      */
     using scalar_type = IMPLEMENTATION_DEFINED;
     /*!\brief The number of packed values in a simd vector (is not defined if
-     * *simd_t* does not satisfy *seqan3::simd::Simd*)
+     * *simd_t* does not model *seqan3::simd::Simd*)
      */
     static constexpr auto length = IMPLEMENTATION_DEFINED;
     /*!\brief The maximum number of packable values in a simd vector, if the
      * underlying type would be *[u]int8_t* (is not defined if *simd_t* does not
-     * satisfy *seqan3::simd::Simd*)
+     * model *seqan3::simd::Simd*)
      */
     static constexpr auto max_length = IMPLEMENTATION_DEFINED;
     /*!\brief The type returned by comparison operators (is not defined if
-     * *simd_t* does not satisfy *seqan3::simd::Simd*)
+     * *simd_t* does not model *seqan3::simd::Simd*)
      */
     using mask_type = IMPLEMENTATION_DEFINED;
     /*!\brief The type used to define how to swizzle a simd vector (is not
-     * defined if *simd_t* does not satisfy *seqan3::simd::Simd*)
+     * defined if *simd_t* does not model *seqan3::simd::Simd*)
      */
     using swizzle_type = IMPLEMENTATION_DEFINED;
 }

--- a/include/seqan3/core/simd/simd_traits.hpp
+++ b/include/seqan3/core/simd/simd_traits.hpp
@@ -23,7 +23,7 @@ inline namespace simd
 /*!\brief seqan3::simd::simd_traits is the trait class that provides uniform interface
  * to the properties of simd_t types.
  * \ingroup simd
- * \tparam simd_t The simd type that satisfies seqan3::simd::simd_concept.
+ * \tparam simd_t The simd type that satisfies seqan3::simd::Simd.
  *
  * The class defines the following member variables and types:
  * * scalar_type - the underlying type of a simd vector
@@ -39,24 +39,24 @@ struct simd_traits
 #if SEQAN3_DOXYGEN_ONLY(1)0
 {
     /*!\brief The underlying type of a simd vector (is not defined if *simd_t*
-     * does not satisfy *seqan3::simd::simd_concept*)
+     * does not satisfy *seqan3::simd::Simd*)
      */
     using scalar_type = IMPLEMENTATION_DEFINED;
     /*!\brief The number of packed values in a simd vector (is not defined if
-     * *simd_t* does not satisfy *seqan3::simd::simd_concept*)
+     * *simd_t* does not satisfy *seqan3::simd::Simd*)
      */
     static constexpr auto length = IMPLEMENTATION_DEFINED;
     /*!\brief The maximum number of packable values in a simd vector, if the
      * underlying type would be *[u]int8_t* (is not defined if *simd_t* does not
-     * satisfy *seqan3::simd::simd_concept*)
+     * satisfy *seqan3::simd::Simd*)
      */
     static constexpr auto max_length = IMPLEMENTATION_DEFINED;
     /*!\brief The type returned by comparison operators (is not defined if
-     * *simd_t* does not satisfy *seqan3::simd::simd_concept*)
+     * *simd_t* does not satisfy *seqan3::simd::Simd*)
      */
     using mask_type = IMPLEMENTATION_DEFINED;
     /*!\brief The type used to define how to swizzle a simd vector (is not
-     * defined if *simd_t* does not satisfy *seqan3::simd::simd_concept*)
+     * defined if *simd_t* does not satisfy *seqan3::simd::Simd*)
      */
     using swizzle_type = IMPLEMENTATION_DEFINED;
 }

--- a/include/seqan3/core/type_list.hpp
+++ b/include/seqan3/core/type_list.hpp
@@ -35,6 +35,6 @@ namespace seqan3::detail
  * \ingroup core
  */
 template <typename t>
-SEQAN3_CONCEPT type_list_concept = is_type_specialisation_of_v<t, type_list>;
+SEQAN3_CONCEPT TypeList = is_type_specialisation_of_v<t, type_list>;
 
 } // namespace seqan3::detail

--- a/include/seqan3/io/alignment_file/input.hpp
+++ b/include/seqan3/io/alignment_file/input.hpp
@@ -359,7 +359,7 @@ struct alignment_file_input_default_traits
  */
 template <
     AlignmentFileInputTraits                     traits_type_        = alignment_file_input_default_traits<>,
-    detail::fields_concept                       selected_field_ids_ = fields<field::SEQ,
+    detail::Fields                               selected_field_ids_ = fields<field::SEQ,
                                                                               field::ID,
                                                                               field::OFFSET,
                                                                               field::REF_SEQ,
@@ -977,7 +977,7 @@ protected:
 //!\brief Deduce selected fields, file_format and stream char type, default the rest.
 template <IStream2                 stream_type,
           AlignmentFileInputFormat file_format,
-          detail::fields_concept   selected_field_ids>
+          detail::Fields           selected_field_ids>
 alignment_file_input(stream_type && stream,
                      file_format const &,
                      selected_field_ids const &)
@@ -989,7 +989,7 @@ alignment_file_input(stream_type && stream,
 //!\brief Deduce selected fields, file_format and stream char type, default the rest.
 template <IStream2                 stream_type,
           AlignmentFileInputFormat file_format,
-          detail::fields_concept   selected_field_ids>
+          detail::Fields           selected_field_ids>
 alignment_file_input(stream_type & stream,
                      file_format const &,
                      selected_field_ids const &)
@@ -1001,7 +1001,7 @@ alignment_file_input(stream_type & stream,
 //!\brief Deduce selected fields, ref_sequences_t and ref_ids_t, default the rest.
 template <std::ranges::ForwardRange           ref_ids_t,
           std::ranges::ForwardRange           ref_sequences_t,
-          detail::fields_concept              selected_field_ids>
+          detail::Fields                      selected_field_ids>
 alignment_file_input(std::filesystem::path path,
                      ref_ids_t &,
                      ref_sequences_t &,
@@ -1029,7 +1029,7 @@ template <IStream2                  stream_type,
           std::ranges::ForwardRange ref_ids_t,
           std::ranges::ForwardRange ref_sequences_t,
           AlignmentFileInputFormat  file_format,
-          detail::fields_concept    selected_field_ids>
+          detail::Fields            selected_field_ids>
 alignment_file_input(stream_type && stream,
                      ref_ids_t &,
                      ref_sequences_t &,
@@ -1046,7 +1046,7 @@ template <IStream2                  stream_type,
           std::ranges::ForwardRange ref_ids_t,
           std::ranges::ForwardRange ref_sequences_t,
           AlignmentFileInputFormat  file_format,
-          detail::fields_concept    selected_field_ids>
+          detail::Fields            selected_field_ids>
 alignment_file_input(stream_type & stream,
                      ref_ids_t &,
                      ref_sequences_t &,
@@ -1099,7 +1099,7 @@ namespace std
 {
 //!\brief std::tuple_size overload for column-like access. [metafunction specialisation for seqan3::alignment_file_input]
 template <seqan3::AlignmentFileInputTraits                    traits_type,
-          seqan3::detail::fields_concept                      selected_field_ids,
+          seqan3::detail::Fields                              selected_field_ids,
           seqan3::detail::TypeListOfAlignmentFileInputFormats valid_formats,
           seqan3::char_concept                                stream_char_t>
 struct tuple_size<seqan3::alignment_file_input<traits_type, selected_field_ids, valid_formats, stream_char_t>>
@@ -1111,7 +1111,7 @@ struct tuple_size<seqan3::alignment_file_input<traits_type, selected_field_ids, 
 //!\brief std::tuple_element overload for column-like access. [metafunction specialisation for seqan3::alignment_file_input]
 template <size_t                                              elem_no,
           seqan3::AlignmentFileInputTraits                    traits_type,
-          seqan3::detail::fields_concept                      selected_field_ids,
+          seqan3::detail::Fields                              selected_field_ids,
           seqan3::detail::TypeListOfAlignmentFileInputFormats valid_formats,
           seqan3::char_concept                                stream_char_t>
 struct tuple_element<elem_no, seqan3::alignment_file_input<traits_type, selected_field_ids, valid_formats, stream_char_t>>

--- a/include/seqan3/io/alignment_file/input.hpp
+++ b/include/seqan3/io/alignment_file/input.hpp
@@ -226,7 +226,7 @@ struct alignment_file_input_default_traits
  *                              must be in seqan3::alignment_file_input::field_ids.
  * \tparam valid_formats        A seqan3::type_list of the selectable formats (each must meet
  *                              seqan3::AlignmentFileInputFormat).
- * \tparam stream_char_type     The type of the underlying stream device(s); must model seqan3::char_concept.
+ * \tparam stream_char_type     The type of the underlying stream device(s); must model std::Integral.
  *
  * \details
  *
@@ -375,7 +375,7 @@ template <
                                                                               field::BIT_SCORE,
                                                                               field::HEADER_PTR>,
     detail::TypeListOfAlignmentFileInputFormats  valid_formats_ = type_list<alignment_file_format_sam>,
-    char_concept                                 stream_char_type_ = char>
+    std::Integral                                stream_char_type_ = char>
 class alignment_file_input
 {
 public:
@@ -1101,7 +1101,7 @@ namespace std
 template <seqan3::AlignmentFileInputTraits                    traits_type,
           seqan3::detail::Fields                              selected_field_ids,
           seqan3::detail::TypeListOfAlignmentFileInputFormats valid_formats,
-          seqan3::char_concept                                stream_char_t>
+          std::Integral                                       stream_char_t>
 struct tuple_size<seqan3::alignment_file_input<traits_type, selected_field_ids, valid_formats, stream_char_t>>
 {
     //!\brief The value equals the number of selected fields in the file.
@@ -1113,7 +1113,7 @@ template <size_t                                              elem_no,
           seqan3::AlignmentFileInputTraits                    traits_type,
           seqan3::detail::Fields                              selected_field_ids,
           seqan3::detail::TypeListOfAlignmentFileInputFormats valid_formats,
-          seqan3::char_concept                                stream_char_t>
+          std::Integral                                       stream_char_t>
 struct tuple_element<elem_no, seqan3::alignment_file_input<traits_type, selected_field_ids, valid_formats, stream_char_t>>
     : tuple_element<elem_no, typename seqan3::alignment_file_input<traits_type,
                                                                selected_field_ids,

--- a/include/seqan3/io/alignment_file/output.hpp
+++ b/include/seqan3/io/alignment_file/output.hpp
@@ -164,7 +164,7 @@ namespace seqan3
  *
  * \sa seqan3::alignment_file_format_sam
  */
-template <detail::fields_concept selected_field_ids_ =
+template <detail::Fields selected_field_ids_ =
               fields<field::SEQ,
                      field::ID,
                      field::OFFSET,
@@ -727,7 +727,7 @@ protected:
  * \relates seqan3::alignment_file_output
  * \{
  */
-template <detail::fields_concept    selected_field_ids>
+template <detail::Fields    selected_field_ids>
 alignment_file_output(std::filesystem::path &&, selected_field_ids const &)
     -> alignment_file_output<selected_field_ids,
                              typename alignment_file_output<>::valid_formats,
@@ -736,14 +736,14 @@ alignment_file_output(std::filesystem::path &&, selected_field_ids const &)
 
 template <OStream<char>             stream_type,
           AlignmentFileOutputFormat file_format,
-          detail::fields_concept    selected_field_ids>
+          detail::Fields            selected_field_ids>
 alignment_file_output(stream_type && _stream, file_format const &, selected_field_ids const &)
     -> alignment_file_output<selected_field_ids,
                              type_list<file_format>,
                              std::remove_reference_t<stream_type>,
                              ref_info_not_given>;
 
-template <detail::fields_concept    selected_field_ids,
+template <detail::Fields    selected_field_ids,
           std::ranges::ForwardRange ref_ids_type,
           std::ranges::ForwardRange ref_lengths_type>
 alignment_file_output(std::filesystem::path &&,
@@ -769,7 +769,7 @@ template <OStream<char>             stream_type,
           std::ranges::ForwardRange ref_ids_type,
           std::ranges::ForwardRange ref_lengths_type,
           AlignmentFileOutputFormat file_format,
-          detail::fields_concept    selected_field_ids>
+          detail::Fields            selected_field_ids>
 alignment_file_output(stream_type && _stream,
                       ref_ids_type &&,
                       ref_lengths_type &&,

--- a/include/seqan3/io/detail/record.hpp
+++ b/include/seqan3/io/detail/record.hpp
@@ -24,7 +24,7 @@ namespace seqan3::detail
 {
 
 // ----------------------------------------------------------------------------
-// fields_concept
+// Fields
 // ----------------------------------------------------------------------------
 
 /*!\brief Auxiliary concept that checks whether a type is a specialisation of seqan3::fields.
@@ -32,7 +32,7 @@ namespace seqan3::detail
  * \relates seqan3::fields
  */
 template <typename t>
-SEQAN3_CONCEPT fields_concept = is_value_specialisation_of_v<t, fields>;
+SEQAN3_CONCEPT Fields = is_value_specialisation_of_v<t, fields>;
 
 // ----------------------------------------------------------------------------
 // select_types_with_ids

--- a/include/seqan3/io/sequence_file/input.hpp
+++ b/include/seqan3/io/sequence_file/input.hpp
@@ -334,7 +334,7 @@ struct sequence_file_input_default_traits_aa : sequence_file_input_default_trait
 
 template <
     SequenceFileInputTraits                    traits_type_        = sequence_file_input_default_traits_dna,
-    detail::fields_concept                     selected_field_ids_ = fields<field::SEQ,
+    detail::Fields                             selected_field_ids_ = fields<field::SEQ,
                                                                             field::ID,
                                                                             field::QUAL>,
     detail::TypeListOfSequenceFileInputFormats valid_formats_      = type_list<sequence_file_format_embl,
@@ -802,7 +802,7 @@ protected:
  */
 template <IStream2                           stream_type,
           SequenceFileInputFormat            file_format,
-          detail::fields_concept             selected_field_ids>
+          detail::Fields                     selected_field_ids>
 sequence_file_input(stream_type && stream,
                     file_format const &,
                     selected_field_ids const &)
@@ -813,7 +813,7 @@ sequence_file_input(stream_type && stream,
 
 template <IStream2                           stream_type,
           SequenceFileInputFormat            file_format,
-          detail::fields_concept             selected_field_ids>
+          detail::Fields                     selected_field_ids>
 sequence_file_input(stream_type & stream,
                     file_format const &,
                     selected_field_ids const &)
@@ -833,7 +833,7 @@ namespace std
 {
 //!\brief std::tuple_size overload for column-like access. [metafunction specialisation for seqan3::sequence_file_input]
 template <seqan3::SequenceFileInputTraits                    traits_type,
-          seqan3::detail::fields_concept                     selected_field_ids,
+          seqan3::detail::Fields                             selected_field_ids,
           seqan3::detail::TypeListOfSequenceFileInputFormats valid_formats,
           seqan3::char_concept                               stream_char_t>
 struct tuple_size<seqan3::sequence_file_input<traits_type, selected_field_ids, valid_formats, stream_char_t>>
@@ -845,7 +845,7 @@ struct tuple_size<seqan3::sequence_file_input<traits_type, selected_field_ids, v
 //!\brief std::tuple_element overload for column-like access. [metafunction specialisation for seqan3::sequence_file_input]
 template <size_t                                             elem_no,
           seqan3::SequenceFileInputTraits                    traits_type,
-          seqan3::detail::fields_concept                     selected_field_ids,
+          seqan3::detail::Fields                             selected_field_ids,
           seqan3::detail::TypeListOfSequenceFileInputFormats valid_formats,
           seqan3::char_concept                               stream_char_t>
 struct tuple_element<elem_no, seqan3::sequence_file_input<traits_type, selected_field_ids, valid_formats, stream_char_t>>

--- a/include/seqan3/io/sequence_file/output.hpp
+++ b/include/seqan3/io/sequence_file/output.hpp
@@ -158,7 +158,7 @@ namespace seqan3
  * TODO give overview of formats, once they are all implemented
  */
 
-template <detail::fields_concept selected_field_ids_ = fields<field::SEQ, field::ID, field::QUAL>,
+template <detail::Fields selected_field_ids_ = fields<field::SEQ, field::ID, field::QUAL>,
           detail::TypeListOfSequenceFileOutputFormats valid_formats_ =
               type_list<sequence_file_format_embl, sequence_file_format_fasta, sequence_file_format_fastq,
                         sequence_file_format_sam>,
@@ -715,7 +715,7 @@ protected:
  */
 template <OStream2                 stream_t,
           SequenceFileOutputFormat file_format,
-          detail::fields_concept   selected_field_ids>
+          detail::Fields           selected_field_ids>
 sequence_file_output(stream_t &&,
                      file_format const &,
                      selected_field_ids const &)
@@ -725,7 +725,7 @@ sequence_file_output(stream_t &&,
 
 template <OStream2                 stream_t,
           SequenceFileOutputFormat file_format,
-          detail::fields_concept   selected_field_ids>
+          detail::Fields           selected_field_ids>
 sequence_file_output(stream_t &,
                      file_format const &,
                      selected_field_ids const &)

--- a/include/seqan3/io/structure_file/input.hpp
+++ b/include/seqan3/io/structure_file/input.hpp
@@ -544,7 +544,7 @@ struct structure_file_input_default_traits_aa : structure_file_input_default_tra
  * Currently, the only implemented format is seqan3::structure_file_format_vienna. More formats will follow soon.
  */
 template<StructureFileInputTraits traits_type_ = structure_file_input_default_traits_rna,
-         detail::fields_concept selected_field_ids_ = fields<field::SEQ, field::ID, field::STRUCTURE>,
+         detail::Fields selected_field_ids_ = fields<field::SEQ, field::ID, field::STRUCTURE>,
          detail::TypeListOfStructureFileInputFormats valid_formats_
              = type_list<structure_file_format_vienna>,
          char_concept stream_char_type_ = char>
@@ -1068,18 +1068,18 @@ protected:
  * \relates seqan3::structure_file_in
  * \{
  */
-template <IStream2 stream_type,
+template <IStream2                 stream_type,
           StructureFileInputFormat file_format,
-          detail::fields_concept selected_field_ids>
+          detail::Fields           selected_field_ids>
 structure_file_in(stream_type && stream, file_format const &, selected_field_ids const &)
     -> structure_file_in<typename structure_file_in<>::traits_type,       // actually use the default
                          selected_field_ids,
                          type_list<file_format>,
                          typename std::remove_reference_t<stream_type>::char_type>;
 
-template <IStream2 stream_type,
+template <IStream2                 stream_type,
           StructureFileInputFormat file_format,
-          detail::fields_concept selected_field_ids>
+          detail::Fields           selected_field_ids>
 structure_file_in(stream_type & stream, file_format const &, selected_field_ids const &)
     -> structure_file_in<typename structure_file_in<>::traits_type,       // actually use the default
                          selected_field_ids,
@@ -1098,10 +1098,10 @@ namespace std
 /*!\brief std::tuple_size overload for column-like access.
  * [metafunction specialisation for seqan3::structure_file_in]
  */
-template<seqan3::StructureFileInputTraits traits_type,
-         seqan3::detail::fields_concept selected_field_ids,
+template<seqan3::StructureFileInputTraits                    traits_type,
+         seqan3::detail::Fields                              selected_field_ids,
          seqan3::detail::TypeListOfStructureFileInputFormats valid_formats,
-         seqan3::char_concept stream_char_t>
+         seqan3::char_concept                                stream_char_t>
 struct tuple_size<seqan3::structure_file_in<traits_type, selected_field_ids, valid_formats, stream_char_t>>
 {
     //!\brief The value equals the number of selected fields in the file.
@@ -1111,11 +1111,11 @@ struct tuple_size<seqan3::structure_file_in<traits_type, selected_field_ids, val
 /*!\brief std::tuple_element overload for column-like access.
  * [metafunction specialisation for seqan3::structure_file_in]
  */
-template<size_t elem_no,
-         seqan3::StructureFileInputTraits traits_type,
-         seqan3::detail::fields_concept selected_field_ids,
+template<size_t                                              elem_no,
+         seqan3::StructureFileInputTraits                    traits_type,
+         seqan3::detail::Fields                              selected_field_ids,
          seqan3::detail::TypeListOfStructureFileInputFormats valid_formats,
-         seqan3::char_concept stream_char_t>
+         seqan3::char_concept                                stream_char_t>
 struct tuple_element<elem_no, seqan3::structure_file_in<traits_type, selected_field_ids, valid_formats, stream_char_t>>
     : tuple_element<elem_no, typename seqan3::structure_file_in<traits_type,
                                                                 selected_field_ids,

--- a/include/seqan3/io/structure_file/input.hpp
+++ b/include/seqan3/io/structure_file/input.hpp
@@ -66,11 +66,9 @@ namespace seqan3
  * \{
  */
 /*!\typedef using seq_alphabet
- * \memberof seqan3::StructureFileInputTraits
  * \brief Alphabet of the characters for the seqan3::field::SEQ; must satisfy seqan3::Alphabet.
  */
 /*!\typedef using seq_legal_alphabet
- * \memberof seqan3::StructureFileInputTraits
  * \brief Intermediate alphabet for seqan3::field::SEQ; must satisfy seqan3::Alphabet and be convertible to
  * `seq_alphabet`.
  *
@@ -82,115 +80,92 @@ namespace seqan3
  * character and produce an error.
  */
 /*!\typedef using seq_container
- * \memberof seqan3::StructureFileInputTraits
  * \brief Type template of the seqan3::field::SEQ, a container template over `seq_alphabet`;
  * must satisfy seqan3::SequenceContainer.
  */
 /*!\typedef using seq_container_container
- * \memberof seqan3::StructureFileInputTraits
  * \brief Type template of a column of seqan3::field::SEQ, a container template that can hold multiple
  * `seq_container`; must satisfy seqan3::SequenceContainer.
  */
 /*!\typedef using id_alphabet
- * \memberof seqan3::StructureFileInputTraits
  * \brief Alphabet of the characters for the seqan3::field::ID; must satisfy seqan3::Alphabet.
  */
 /*!\typedef using id_container
- * \memberof seqan3::StructureFileInputTraits
  * \brief Type template of the seqan3::field::ID, a container template over `id_alphabet`;
  * must satisfy seqan3::SequenceContainer.
  */
 /*!\typedef using id_container_container
- * \memberof seqan3::StructureFileInputTraits
  * \brief Type template of a column of seqan3::field::ID, a container template that can hold multiple
  * `id_container`; must satisfy seqan3::SequenceContainer.
  */
 /*!\typedef using bpp_prob
- * \memberof seqan3::StructureFileInputTraits
  * \brief Data type for the base pair probabilities in seqan3::field::BPP; must satisfy std::is_floating_point.
  */
 /*!\typedef using bpp_partner
- * \memberof seqan3::StructureFileInputTraits
  * \brief Data type for the partner index of an interaction in seqan3::field::BPP; must satisfy
  * std::numeric_limits::is_integer.
  */
 /*!\typedef using bpp_queue
- * \memberof seqan3::StructureFileInputTraits
  * \brief A container template representing a set of interactions of type bpp_item,
  * which are (comparable) tuples of `bpp_prob` and `bpp_partner`;
  * must satisfy seqan3::Container and must provide an std::emplace(bpp_prob, bpp_partner) function.
  */
 /*!\typedef using bpp_container
- * \memberof seqan3::StructureFileInputTraits
  * \brief Type template of the seqan3::field::BPP, a container template over a set (bpp_queue) of interactions;
  * must satisfy seqan3::SequenceContainer.
  */
 /*!\typedef using bpp_container_container
- * \memberof seqan3::StructureFileInputTraits
  * \brief Type template of a column of seqan3::field::BPP, a container template that can hold multiple
  * `bpp_container`; must satisfy seqan3::SequenceContainer.
  */
 /*!\typedef using structure_alphabet
- * \memberof seqan3::StructureFileInputTraits
  * \brief Alphabet of the characters for the seqan3::field::STRUCTURE; must satisfy seqan3::RnaStructureAlphabet.
  */
 /*!\typedef using structure_container
- * \memberof seqan3::StructureFileInputTraits
  * \brief Type template of the seqan3::field::STRUCTURE, a container template over `structure_alphabet`;
  * must satisfy seqan3::SequenceContainer.
  */
 /*!\typedef using structure_container_container
- * \memberof seqan3::StructureFileInputTraits
  * \brief Type template of a column of seqan3::field::STRUCTURE, a container template that can hold multiple
  * `structure_container`; must satisfy seqan3::SequenceContainer.
  */
 /*!\typedef using energy_type
- * \memberof seqan3::StructureFileInputTraits
  * \brief Type template of the seqan3::field::ENERGY; must be std::optional of a type satisfying std::is_floating_point.
  * \details
  * If the file record contains an energy, the value can be obtained through dereference or std::optional::value.
  * Otherwise, operator bool or std::optional::has_value return false.
  */
 /*!\typedef using energy_container
- * \memberof seqan3::StructureFileInputTraits
  * \brief Type template of a column of seqan3::field::ENERGY, a container template that can hold multiple `energy_type`;
  * must satisfy seqan3::SequenceContainer.
  */
 /*!\typedef using react_type
- * \memberof seqan3::StructureFileInputTraits
  * \brief Data type for the reactivity and reactivity error in seqan3::field::REACT and seqan3::field::REACT_ERR,
  * respectively; must satisfy std::is_floating_point.
  */
 /*!\typedef using react_container
- * \memberof seqan3::StructureFileInputTraits
  * \brief Type template of the seqan3::field::REACT and seqan3::field::REACT_ERR, a container template over
  * `react_type`; must satisfy seqan3::SequenceContainer.
  */
 /*!\typedef using react_container_container
- * \memberof seqan3::StructureFileInputTraits
  * \brief Type template of a column of seqan3::field::REACT and seqan3::field::REACT_ERR, a container template that
  * can hold multiple `react_container`; must satisfy seqan3::SequenceContainer.
  */
 /*!\typedef using comment_alphabet
- * \memberof seqan3::StructureFileInputTraits
  * \brief Alphabet of the characters for the seqan3::field::COMMENT; must satisfy seqan3::Alphabet.
  */
 /*!\typedef using comment_container
- * \memberof seqan3::StructureFileInputTraits
  * \brief Type template of the seqan3::field::COMMENT, a container template over `comment_alphabet`;
  * must satisfy seqan3::SequenceContainer.
  */
 /*!\typedef using comment_container_container
- * \memberof seqan3::StructureFileInputTraits
  * \brief Type template of a column of seqan3::field::COMMENT, a container template that can hold multiple
  * `comment_container`; must satisfy seqan3::SequenceContainer.
  */
 /*!\typedef using offset_type
- * \memberof seqan3::StructureFileInputTraits
  * \brief Type template of the seqan3::field::OFFSET; must statisfy std::numeric_limits::is_integer.
  */
 /*!\typedef using offset_container
- * \memberof seqan3::StructureFileInputTraits
  * \brief Type template of a column of seqan3::field::OFFSET, a container template that can hold multiple `offset_type`;
  * must satisfy seqan3::SequenceContainer.
  */

--- a/include/seqan3/io/structure_file/input.hpp
+++ b/include/seqan3/io/structure_file/input.hpp
@@ -45,16 +45,16 @@
 namespace seqan3
 {
 // ----------------------------------------------------------------------------
-// structure_file_input_traits_concept
+// StructureFileInputTraits
 // ----------------------------------------------------------------------------
 
-/*!\interface seqan3::structure_file_input_traits_concept <>
+/*!\interface seqan3::StructureFileInputTraits <>
  * \brief The requirements a traits_type for seqan3::structure_file_in must meet.
  * \ingroup structure_file
  */
-/*!\name Requirements for seqan3::structure_file_input_traits_concept
- * \brief You can expect these **member types** of all types that satisfy seqan3::structure_file_input_traits_concept.
- * \memberof seqan3::structure_file_input_traits_concept
+/*!\name Requirements for seqan3::StructureFileInputTraits
+ * \brief You can expect these **member types** of all types that satisfy seqan3::StructureFileInputTraits.
+ * \memberof seqan3::StructureFileInputTraits
  *
  * \details
  *
@@ -66,11 +66,11 @@ namespace seqan3
  * \{
  */
 /*!\typedef using seq_alphabet
- * \memberof seqan3::structure_file_input_traits_concept
+ * \memberof seqan3::StructureFileInputTraits
  * \brief Alphabet of the characters for the seqan3::field::SEQ; must satisfy seqan3::Alphabet.
  */
 /*!\typedef using seq_legal_alphabet
- * \memberof seqan3::structure_file_input_traits_concept
+ * \memberof seqan3::StructureFileInputTraits
  * \brief Intermediate alphabet for seqan3::field::SEQ; must satisfy seqan3::Alphabet and be convertible to
  * `seq_alphabet`.
  *
@@ -82,122 +82,122 @@ namespace seqan3
  * character and produce an error.
  */
 /*!\typedef using seq_container
- * \memberof seqan3::structure_file_input_traits_concept
+ * \memberof seqan3::StructureFileInputTraits
  * \brief Type template of the seqan3::field::SEQ, a container template over `seq_alphabet`;
  * must satisfy seqan3::SequenceContainer.
  */
 /*!\typedef using seq_container_container
- * \memberof seqan3::structure_file_input_traits_concept
+ * \memberof seqan3::StructureFileInputTraits
  * \brief Type template of a column of seqan3::field::SEQ, a container template that can hold multiple
  * `seq_container`; must satisfy seqan3::SequenceContainer.
  */
 /*!\typedef using id_alphabet
- * \memberof seqan3::structure_file_input_traits_concept
+ * \memberof seqan3::StructureFileInputTraits
  * \brief Alphabet of the characters for the seqan3::field::ID; must satisfy seqan3::Alphabet.
  */
 /*!\typedef using id_container
- * \memberof seqan3::structure_file_input_traits_concept
+ * \memberof seqan3::StructureFileInputTraits
  * \brief Type template of the seqan3::field::ID, a container template over `id_alphabet`;
  * must satisfy seqan3::SequenceContainer.
  */
 /*!\typedef using id_container_container
- * \memberof seqan3::structure_file_input_traits_concept
+ * \memberof seqan3::StructureFileInputTraits
  * \brief Type template of a column of seqan3::field::ID, a container template that can hold multiple
  * `id_container`; must satisfy seqan3::SequenceContainer.
  */
 /*!\typedef using bpp_prob
- * \memberof seqan3::structure_file_input_traits_concept
+ * \memberof seqan3::StructureFileInputTraits
  * \brief Data type for the base pair probabilities in seqan3::field::BPP; must satisfy std::is_floating_point.
  */
 /*!\typedef using bpp_partner
- * \memberof seqan3::structure_file_input_traits_concept
+ * \memberof seqan3::StructureFileInputTraits
  * \brief Data type for the partner index of an interaction in seqan3::field::BPP; must satisfy
  * std::numeric_limits::is_integer.
  */
 /*!\typedef using bpp_queue
- * \memberof seqan3::structure_file_input_traits_concept
+ * \memberof seqan3::StructureFileInputTraits
  * \brief A container template representing a set of interactions of type bpp_item,
  * which are (comparable) tuples of `bpp_prob` and `bpp_partner`;
  * must satisfy seqan3::Container and must provide an std::emplace(bpp_prob, bpp_partner) function.
  */
 /*!\typedef using bpp_container
- * \memberof seqan3::structure_file_input_traits_concept
+ * \memberof seqan3::StructureFileInputTraits
  * \brief Type template of the seqan3::field::BPP, a container template over a set (bpp_queue) of interactions;
  * must satisfy seqan3::SequenceContainer.
  */
 /*!\typedef using bpp_container_container
- * \memberof seqan3::structure_file_input_traits_concept
+ * \memberof seqan3::StructureFileInputTraits
  * \brief Type template of a column of seqan3::field::BPP, a container template that can hold multiple
  * `bpp_container`; must satisfy seqan3::SequenceContainer.
  */
 /*!\typedef using structure_alphabet
- * \memberof seqan3::structure_file_input_traits_concept
+ * \memberof seqan3::StructureFileInputTraits
  * \brief Alphabet of the characters for the seqan3::field::STRUCTURE; must satisfy seqan3::RnaStructureAlphabet.
  */
 /*!\typedef using structure_container
- * \memberof seqan3::structure_file_input_traits_concept
+ * \memberof seqan3::StructureFileInputTraits
  * \brief Type template of the seqan3::field::STRUCTURE, a container template over `structure_alphabet`;
  * must satisfy seqan3::SequenceContainer.
  */
 /*!\typedef using structure_container_container
- * \memberof seqan3::structure_file_input_traits_concept
+ * \memberof seqan3::StructureFileInputTraits
  * \brief Type template of a column of seqan3::field::STRUCTURE, a container template that can hold multiple
  * `structure_container`; must satisfy seqan3::SequenceContainer.
  */
 /*!\typedef using energy_type
- * \memberof seqan3::structure_file_input_traits_concept
+ * \memberof seqan3::StructureFileInputTraits
  * \brief Type template of the seqan3::field::ENERGY; must be std::optional of a type satisfying std::is_floating_point.
  * \details
  * If the file record contains an energy, the value can be obtained through dereference or std::optional::value.
  * Otherwise, operator bool or std::optional::has_value return false.
  */
 /*!\typedef using energy_container
- * \memberof seqan3::structure_file_input_traits_concept
+ * \memberof seqan3::StructureFileInputTraits
  * \brief Type template of a column of seqan3::field::ENERGY, a container template that can hold multiple `energy_type`;
  * must satisfy seqan3::SequenceContainer.
  */
 /*!\typedef using react_type
- * \memberof seqan3::structure_file_input_traits_concept
+ * \memberof seqan3::StructureFileInputTraits
  * \brief Data type for the reactivity and reactivity error in seqan3::field::REACT and seqan3::field::REACT_ERR,
  * respectively; must satisfy std::is_floating_point.
  */
 /*!\typedef using react_container
- * \memberof seqan3::structure_file_input_traits_concept
+ * \memberof seqan3::StructureFileInputTraits
  * \brief Type template of the seqan3::field::REACT and seqan3::field::REACT_ERR, a container template over
  * `react_type`; must satisfy seqan3::SequenceContainer.
  */
 /*!\typedef using react_container_container
- * \memberof seqan3::structure_file_input_traits_concept
+ * \memberof seqan3::StructureFileInputTraits
  * \brief Type template of a column of seqan3::field::REACT and seqan3::field::REACT_ERR, a container template that
  * can hold multiple `react_container`; must satisfy seqan3::SequenceContainer.
  */
 /*!\typedef using comment_alphabet
- * \memberof seqan3::structure_file_input_traits_concept
+ * \memberof seqan3::StructureFileInputTraits
  * \brief Alphabet of the characters for the seqan3::field::COMMENT; must satisfy seqan3::Alphabet.
  */
 /*!\typedef using comment_container
- * \memberof seqan3::structure_file_input_traits_concept
+ * \memberof seqan3::StructureFileInputTraits
  * \brief Type template of the seqan3::field::COMMENT, a container template over `comment_alphabet`;
  * must satisfy seqan3::SequenceContainer.
  */
 /*!\typedef using comment_container_container
- * \memberof seqan3::structure_file_input_traits_concept
+ * \memberof seqan3::StructureFileInputTraits
  * \brief Type template of a column of seqan3::field::COMMENT, a container template that can hold multiple
  * `comment_container`; must satisfy seqan3::SequenceContainer.
  */
 /*!\typedef using offset_type
- * \memberof seqan3::structure_file_input_traits_concept
+ * \memberof seqan3::StructureFileInputTraits
  * \brief Type template of the seqan3::field::OFFSET; must statisfy std::numeric_limits::is_integer.
  */
 /*!\typedef using offset_container
- * \memberof seqan3::structure_file_input_traits_concept
+ * \memberof seqan3::StructureFileInputTraits
  * \brief Type template of a column of seqan3::field::OFFSET, a container template that can hold multiple `offset_type`;
  * must satisfy seqan3::SequenceContainer.
  */
 //!\}
 //!\cond
 template<typename t>
-SEQAN3_CONCEPT structure_file_input_traits_concept = requires(t v)
+SEQAN3_CONCEPT StructureFileInputTraits = requires(t v)
 {
     // TODO(joergi-w) The expensive concept checks are currently omitted. Check again when compiler has improved.
     // sequence
@@ -297,7 +297,7 @@ SEQAN3_CONCEPT structure_file_input_traits_concept = requires(t v)
 // ----------------------------------------------------------------------------
 
 /*!\brief The default traits for seqan3::structure_file_in
- * \implements structure_file_input_traits_concept
+ * \implements StructureFileInputTraits
  * \ingroup structure_file
  *
  * \details
@@ -312,7 +312,7 @@ SEQAN3_CONCEPT structure_file_input_traits_concept = requires(t v)
 struct structure_file_input_default_traits_rna
 {
     /*!\name Member types
-     * \brief Definitions to satisfy seqan3::structure_file_input_traits_concept.
+     * \brief Definitions to satisfy seqan3::StructureFileInputTraits.
      * \{
      */
 
@@ -389,7 +389,7 @@ struct structure_file_input_default_traits_rna
 struct structure_file_input_default_traits_aa : structure_file_input_default_traits_rna
 {
     /*!\name Member types
-     * \brief Definitions to satisfy seqan3::structure_file_input_traits_concept.
+     * \brief Definitions to satisfy seqan3::StructureFileInputTraits.
      * \{
      */
     using seq_alphabet             = aa27;
@@ -407,7 +407,7 @@ struct structure_file_input_default_traits_aa : structure_file_input_default_tra
 /*!\brief A class for reading structured sequence files, e.g. Stockholm, Connect, Vienna, ViennaRNA bpp matrix ...
  * \ingroup structure_file
  * \tparam traits_type        An auxiliary type that defines certain member types and constants, must satisfy
- *                            seqan3::structure_file_input_traits_concept.
+ *                            seqan3::StructureFileInputTraits.
  * \tparam selected_field_ids A seqan3::fields type with the list and order of desired record entries; all fields
  *                            must be in seqan3::structure_file_in::field_ids.
  * \tparam valid_formats      A seqan3::type_list of the selectable formats (each must meet
@@ -537,13 +537,13 @@ struct structure_file_input_default_traits_aa : structure_file_input_default_tra
  *
  * Note that for this to make sense, your storage data types need to be identical to the corresponding column types
  * of the file. If you require different column types you can specify you own traits, see
- * seqan3::structure_file_input_traits_concept.
+ * seqan3::StructureFileInputTraits.
  *
  * ### Formats
  *
  * Currently, the only implemented format is seqan3::structure_file_format_vienna. More formats will follow soon.
  */
-template<structure_file_input_traits_concept traits_type_ = structure_file_input_default_traits_rna,
+template<StructureFileInputTraits traits_type_ = structure_file_input_default_traits_rna,
          detail::fields_concept selected_field_ids_ = fields<field::SEQ, field::ID, field::STRUCTURE>,
          detail::TypeListOfStructureFileInputFormats valid_formats_
              = type_list<structure_file_format_vienna>,
@@ -1098,7 +1098,7 @@ namespace std
 /*!\brief std::tuple_size overload for column-like access.
  * [metafunction specialisation for seqan3::structure_file_in]
  */
-template<seqan3::structure_file_input_traits_concept traits_type,
+template<seqan3::StructureFileInputTraits traits_type,
          seqan3::detail::fields_concept selected_field_ids,
          seqan3::detail::TypeListOfStructureFileInputFormats valid_formats,
          seqan3::char_concept stream_char_t>
@@ -1112,7 +1112,7 @@ struct tuple_size<seqan3::structure_file_in<traits_type, selected_field_ids, val
  * [metafunction specialisation for seqan3::structure_file_in]
  */
 template<size_t elem_no,
-         seqan3::structure_file_input_traits_concept traits_type,
+         seqan3::StructureFileInputTraits traits_type,
          seqan3::detail::fields_concept selected_field_ids,
          seqan3::detail::TypeListOfStructureFileInputFormats valid_formats,
          seqan3::char_concept stream_char_t>

--- a/include/seqan3/io/structure_file/output.hpp
+++ b/include/seqan3/io/structure_file/output.hpp
@@ -167,7 +167,7 @@ namespace seqan3
  * Currently, the only implemented format is seqan3::structure_file_format_vienna. More formats will follow soon.
  */
 
-template <detail::fields_concept selected_field_ids_ = fields<field::SEQ, field::ID, field::STRUCTURE>,
+template <detail::Fields selected_field_ids_ = fields<field::SEQ, field::ID, field::STRUCTURE>,
           detail::TypeListOfStructureFileOutputFormats valid_formats_
               = type_list<structure_file_format_vienna>,
           char_concept stream_char_type_ = char>
@@ -803,17 +803,17 @@ protected:
  * \relates seqan3::structure_file_out
  * \{
  */
-template <OStream2 stream_t,
+template <OStream2                  stream_t,
           StructureFileOutputFormat file_format,
-          detail::fields_concept selected_field_ids>
+          detail::Fields            selected_field_ids>
 structure_file_out(stream_t &&, file_format const &, selected_field_ids const &)
     -> structure_file_out<selected_field_ids,
                           type_list<file_format>,
                           typename std::remove_reference_t<stream_t>::char_type>;
 
-template <OStream2 stream_t,
+template <OStream2                  stream_t,
           StructureFileOutputFormat file_format,
-          detail::fields_concept selected_field_ids>
+          detail::Fields            selected_field_ids>
 structure_file_out(stream_t &, file_format const &, selected_field_ids const &)
     -> structure_file_out<selected_field_ids,
                           type_list<file_format>,

--- a/test/include/seqan3/test/simd_utility.hpp
+++ b/test/include/seqan3/test/simd_utility.hpp
@@ -31,8 +31,8 @@
  */
 #define SIMD_EQ(...) do { \
     auto [left, right] = std::make_tuple(__VA_ARGS__); \
-    static_assert(seqan3::simd::simd_concept<decltype(left)>, "The left argument of SIMD_EQ is not a simd_type"); \
-    static_assert(seqan3::simd::simd_concept<decltype(right)>, "The right argument of SIMD_EQ is not a simd_type"); \
+    static_assert(seqan3::simd::Simd<decltype(left)>, "The left argument of SIMD_EQ is not a simd_type"); \
+    static_assert(seqan3::simd::Simd<decltype(right)>, "The right argument of SIMD_EQ is not a simd_type"); \
     static_assert(std::is_same_v<decltype(left), decltype(right)>, "The left and right argument of SIMD_EQ don't have the same type."); \
     using _simd_traits_t = seqan3::simd::simd_traits<decltype(left)>; \
     std::vector<typename _simd_traits_t::scalar_type> left_simd(_simd_traits_t::length), right_simd(_simd_traits_t::length); \

--- a/test/unit/core/concept/cereal_test.cpp
+++ b/test/unit/core/concept/cereal_test.cpp
@@ -61,16 +61,16 @@ TEST(cereal, CerealArchive)
     EXPECT_TRUE((CerealArchive<cereal::PortableBinaryInputArchive>));
 }
 
-TEST(cereal, cereal_text_archive_concept)
+TEST(cereal, CerealTextArchive)
 {
-    EXPECT_TRUE((cereal_text_archive_concept<cereal::XMLOutputArchive>));
-    EXPECT_TRUE((cereal_text_archive_concept<cereal::JSONOutputArchive>));
-    EXPECT_FALSE((cereal_text_archive_concept<cereal::BinaryOutputArchive>));
-    EXPECT_FALSE((cereal_text_archive_concept<cereal::PortableBinaryOutputArchive>));
-    EXPECT_TRUE((cereal_text_archive_concept<cereal::XMLInputArchive>));
-    EXPECT_TRUE((cereal_text_archive_concept<cereal::JSONInputArchive>));
-    EXPECT_FALSE((cereal_text_archive_concept<cereal::BinaryInputArchive>));
-    EXPECT_FALSE((cereal_text_archive_concept<cereal::PortableBinaryInputArchive>));
+    EXPECT_TRUE((CerealTextArchive<cereal::XMLOutputArchive>));
+    EXPECT_TRUE((CerealTextArchive<cereal::JSONOutputArchive>));
+    EXPECT_FALSE((CerealTextArchive<cereal::BinaryOutputArchive>));
+    EXPECT_FALSE((CerealTextArchive<cereal::PortableBinaryOutputArchive>));
+    EXPECT_TRUE((CerealTextArchive<cereal::XMLInputArchive>));
+    EXPECT_TRUE((CerealTextArchive<cereal::JSONInputArchive>));
+    EXPECT_FALSE((CerealTextArchive<cereal::BinaryInputArchive>));
+    EXPECT_FALSE((CerealTextArchive<cereal::PortableBinaryInputArchive>));
 }
 
 struct my_struct{};

--- a/test/unit/core/simd/detail/builtin_simd_test.cpp
+++ b/test/unit/core/simd/detail/builtin_simd_test.cpp
@@ -187,28 +187,28 @@ TEST(builtin_simd, default_simd_max_length)
 #endif
 }
 
-TEST(builtin_simd, simd_concept)
+TEST(builtin_simd, Simd)
 {
-    EXPECT_FALSE(simd_concept<short>);
-    EXPECT_FALSE(simd_concept<int>);
-    EXPECT_FALSE(simd_concept<incomplete::type>);
-    EXPECT_FALSE(simd_concept<incomplete::template_type<int>>);
+    EXPECT_FALSE(Simd<short>);
+    EXPECT_FALSE(Simd<int>);
+    EXPECT_FALSE(Simd<incomplete::type>);
+    EXPECT_FALSE(Simd<incomplete::template_type<int>>);
 
-    auto fails_simd_concept = [](auto id)
+    auto fails_Simd = [](auto id)
     {
         using type = typename decltype(id)::type;
-        EXPECT_FALSE(simd_concept<type>);
+        EXPECT_FALSE(Simd<type>);
     };
 
-    detail::for_each_type(fails_simd_concept, subscript_types<short>{});
-    detail::for_each_type(fails_simd_concept, subscript_types<int>{});
-    detail::for_each_type(fails_simd_concept, subscript_types<incomplete::type>{});
-    detail::for_each_type(fails_simd_concept, subscript_types<incomplete::template_type<int>>{});
+    detail::for_each_type(fails_Simd, subscript_types<short>{});
+    detail::for_each_type(fails_Simd, subscript_types<int>{});
+    detail::for_each_type(fails_Simd, subscript_types<incomplete::type>{});
+    detail::for_each_type(fails_Simd, subscript_types<incomplete::template_type<int>>{});
 
-    EXPECT_TRUE(simd_concept<int16x8_t>);
-    EXPECT_TRUE(simd_concept<int32x4_t>);
-    EXPECT_TRUE(simd_concept<int64x2_t>);
-    EXPECT_TRUE(simd_concept<uint16x16_t>);
-    EXPECT_TRUE(simd_concept<uint32x8_t>);
-    EXPECT_TRUE(simd_concept<uint64x4_t>);
+    EXPECT_TRUE(Simd<int16x8_t>);
+    EXPECT_TRUE(Simd<int32x4_t>);
+    EXPECT_TRUE(Simd<int64x2_t>);
+    EXPECT_TRUE(Simd<uint16x16_t>);
+    EXPECT_TRUE(Simd<uint32x8_t>);
+    EXPECT_TRUE(Simd<uint64x4_t>);
 }

--- a/test/unit/core/simd/simd_test.cpp
+++ b/test/unit/core/simd/simd_test.cpp
@@ -56,32 +56,32 @@ TEST(simd, standard_construction)
     EXPECT_TRUE((std::is_nothrow_swappable_v<int16x_t>));
 }
 
-template <simd_concept simd_t>
+template <Simd simd_t>
 void construct_test(simd_t & simd, typename simd_traits<simd_t>::scalar_type a, std::integral_constant<size_t, 1>)
 {
     simd = simd_t{a};
 }
 
-template <simd_concept simd_t>
+template <Simd simd_t>
 void construct_test(simd_t & simd, typename simd_traits<simd_t>::scalar_type a, std::integral_constant<size_t, 8>)
 {
     simd = simd_t{a, a, a, a, a, a, a, a};
 }
 
-template <simd_concept simd_t>
+template <Simd simd_t>
 void construct_test(simd_t & simd, typename simd_traits<simd_t>::scalar_type a, std::integral_constant<size_t, 16>)
 {
     simd = simd_t{a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a};
 }
 
-template <simd_concept simd_t>
+template <Simd simd_t>
 void construct_test(simd_t & simd, typename simd_traits<simd_t>::scalar_type a, std::integral_constant<size_t, 32>)
 {
     simd = simd_t{a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a,
                   a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a};
 }
 
-template <simd_concept simd_t>
+template <Simd simd_t>
 void construct_test(simd_t & simd, typename simd_traits<simd_t>::scalar_type a, std::integral_constant<size_t, 64>)
 {
     simd = simd_t{a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a,


### PR DESCRIPTION
Some concepts which I forgot to change before.

structure_file_input_traits_concept -> StructureFileInputTraits
fields_concept -> Fields
cereal_text_archive_concept -> CerealTextArchive
type_list_concept -> TypeList
simd_concept -> Simd