### PR TITLE
[FIX] Doxygen warnings in Core Module

### DIFF
--- a/include/seqan3/core/algorithm/concept.hpp
+++ b/include/seqan3/core/algorithm/concept.hpp
@@ -55,11 +55,9 @@ class config_element_base;
  * \{
  */
 /*!\var id
- * \memberof seqan3::detail::ConfigElement
  * \brief Algorithm specific static id used for internal validation checks.
  */
 /*!\var value
- * \memberof seqan3::detail::ConfigElement
  * \brief Member storing the configuration value.
  */
 //!\}

--- a/include/seqan3/core/algorithm/configuration.hpp
+++ b/include/seqan3/core/algorithm/configuration.hpp
@@ -307,12 +307,12 @@ public:
     friend constexpr auto operator|(pipeable_config_element<lhs_derived_t, lhs_value_t> && lhs,
                                     pipeable_config_element<rhs_derived_t, rhs_value_t> const & rhs);
 
-    // //!\overload
+    //!\overload
     template <typename lhs_derived_t, typename lhs_value_t, typename rhs_derived_t, typename rhs_value_t>
     friend constexpr auto operator|(pipeable_config_element<lhs_derived_t, lhs_value_t> const & lhs,
                                     pipeable_config_element<rhs_derived_t, rhs_value_t> && rhs);
 
-    // //!\overload
+    //!\overload
     template <typename lhs_derived_t, typename lhs_value_t, typename rhs_derived_t, typename rhs_value_t>
     friend constexpr auto operator|(pipeable_config_element<lhs_derived_t, lhs_value_t> const & lhs,
                                     pipeable_config_element<rhs_derived_t, rhs_value_t> const & rhs);
@@ -516,14 +516,18 @@ private:
 };
 
 /*!\name Type deduction guides
- * \relates seqan3::configuration
  * \{
  */
-//!\brief Deduces the correct configuration element type from the passed seqan3::pipeable_config_element.
+
+/*!\brief Deduces the correct configuration element type from the passed seqan3::pipeable_config_element.
+ * \relates seqan3::configuration
+ */
 template <typename derived_t, typename value_t>
 configuration(pipeable_config_element<derived_t, value_t> &&) -> configuration<remove_cvref_t<derived_t>>;
 
-//!\brief Deduces the correct configuration element type from the passed seqan3::pipeable_config_element.
+/*!\brief Deduces the correct configuration element type from the passed seqan3::pipeable_config_element.
+ * \relates seqan3::configuration
+ */
 template <typename derived_t, typename value_t>
 configuration(pipeable_config_element<derived_t, value_t> const &) -> configuration<remove_cvref_t<derived_t>>;
 //!\}
@@ -569,6 +573,7 @@ constexpr auto & get(configuration<configs_t...> & config) noexcept
     return get<pos>(config);
 }
 
+//!\overload
 template <template <typename ...> class query_t, typename ...configs_t>
 constexpr auto const & get(configuration<configs_t...> const & config) noexcept
 {
@@ -579,6 +584,7 @@ constexpr auto const & get(configuration<configs_t...> const & config) noexcept
     return get<pos>(config);
 }
 
+//!\overload
 template <template <typename ...> class query_t, typename ...configs_t>
 constexpr auto && get(configuration<configs_t...> && config) noexcept
 {
@@ -589,6 +595,7 @@ constexpr auto && get(configuration<configs_t...> && config) noexcept
     return get<pos>(std::move(config));
 }
 
+//!\overload
 template <template <typename ...> class query_t, typename ...configs_t>
 constexpr auto const && get(configuration<configs_t...> const && config) noexcept
 {
@@ -601,6 +608,7 @@ constexpr auto const && get(configuration<configs_t...> const && config) noexcep
     return std::move(get<pos>(config));
 }
 //!\}
+
 } // namespace seqan3::detail
 
 namespace std

--- a/include/seqan3/core/platform.hpp
+++ b/include/seqan3/core/platform.hpp
@@ -110,10 +110,16 @@
      * \brief These can be changed by apps so we used the macros instead of the values internally.
      * \{
      */
+
+     //! \brief Macro for Cereal's serialize function.
 #   define CEREAL_SERIALIZE_FUNCTION_NAME serialize
+     //! \brief Macro for Cereal's load function.
 #   define CEREAL_LOAD_FUNCTION_NAME load
+     //! \brief Macro for Cereal's save function.
 #   define CEREAL_SAVE_FUNCTION_NAME save
+     //! \brief Macro for Cereal's load_minimal function.
 #   define CEREAL_LOAD_MINIMAL_FUNCTION_NAME load_minimal
+     //! \brief Macro for Cereal's save_minimal function.
 #   define CEREAL_SAVE_MINIMAL_FUNCTION_NAME save_minimal
     /*!\}
      * \endcond

--- a/include/seqan3/core/pod_tuple.hpp
+++ b/include/seqan3/core/pod_tuple.hpp
@@ -65,7 +65,6 @@ struct pod_tuple<type0, types...>
 
     /*!\name Comparison operators
      * \{
-     * \brief Lexicographically compares the values in the tuple.
      */
 
     //!\brief Checks whether `*this` is equal to `rhs`.

--- a/include/seqan3/core/pod_tuple.hpp
+++ b/include/seqan3/core/pod_tuple.hpp
@@ -63,34 +63,42 @@ struct pod_tuple<type0, types...>
     pod_tuple<types...> _tail;
     //!\endcond
 
-    //!\name Comparison operators
-    //!\{
-    //!\brief Lexicographically compares the values in the tuple.
+    /*!\name Comparison operators
+     * \{
+     * \brief Lexicographically compares the values in the tuple.
+     */
+
+    //!\brief Test for equality.
     constexpr bool operator==(pod_tuple const & rhs) const noexcept
     {
         return std::tie(_head, _tail) == std::tie(rhs._head, rhs._tail);
     }
 
+    //!\brief Test for inequality.
     constexpr bool operator!=(pod_tuple const & rhs) const noexcept
     {
         return std::tie(_head, _tail) != std::tie(rhs._head, rhs._tail);
     }
 
+    //!\brief Test for smaller.
     constexpr bool operator<(pod_tuple const & rhs) const noexcept
     {
         return std::tie(_head, _tail) < std::tie(rhs._head, rhs._tail);
     }
 
+    //!\brief Test for larger.
     constexpr bool operator>(pod_tuple const & rhs) const noexcept
     {
         return std::tie(_head, _tail) > std::tie(rhs._head, rhs._tail);
     }
 
+    //!\brief Test for smaller or equal.
     constexpr bool operator<=(pod_tuple const & rhs) const noexcept
     {
         return std::tie(_head, _tail) <= std::tie(rhs._head, rhs._tail);
     }
 
+    //!\brief Test for larger or equal.
     constexpr bool operator>=(pod_tuple const & rhs) const noexcept
     {
         return std::tie(_head, _tail) >= std::tie(rhs._head, rhs._tail);
@@ -111,34 +119,42 @@ struct pod_tuple<type0>
     type0 _head;
     //!\endcond
 
-    //!\name Comparison operators
-    //!\{
-    //!\brief Lexicographically compares the values in the tuple.
+    /*!\name Comparison operators
+     * \brief Lexicographically compares the values in the tuple.
+     * \{
+     */
+
+    //!\brief Test for equality.
     constexpr bool operator==(pod_tuple const & rhs) const noexcept
     {
         return _head == rhs._head;
     }
 
+    //!\brief Test for inequality.
     constexpr bool operator!=(pod_tuple const & rhs) const noexcept
     {
         return _head != rhs._head;
     }
 
+    //!\brief Test for smaller.
     constexpr bool operator<(pod_tuple const & rhs) const noexcept
     {
         return _head < rhs._head;
     }
 
+    //!\brief Test for larger.
     constexpr bool operator>(pod_tuple const & rhs) const noexcept
     {
         return _head > rhs._head;
     }
 
+    //!\brief Test for smaller or equal.
     constexpr bool operator<=(pod_tuple const & rhs) const noexcept
     {
         return _head <= rhs._head;
     }
 
+    //!\brief Test for larger or equal.
     constexpr bool operator>=(pod_tuple const & rhs) const noexcept
     {
         return _head >= rhs._head;

--- a/include/seqan3/core/pod_tuple.hpp
+++ b/include/seqan3/core/pod_tuple.hpp
@@ -68,37 +68,37 @@ struct pod_tuple<type0, types...>
      * \brief Lexicographically compares the values in the tuple.
      */
 
-    //!\brief Test for equality.
+    //!\brief Checks whether `*this` is equal to `rhs`.
     constexpr bool operator==(pod_tuple const & rhs) const noexcept
     {
         return std::tie(_head, _tail) == std::tie(rhs._head, rhs._tail);
     }
 
-    //!\brief Test for inequality.
+    //!\brief Checks whether `*this` is not equal to `rhs`.
     constexpr bool operator!=(pod_tuple const & rhs) const noexcept
     {
         return std::tie(_head, _tail) != std::tie(rhs._head, rhs._tail);
     }
 
-    //!\brief Test for smaller.
+    //!\brief Checks whether `*this` is less than `rhs`.
     constexpr bool operator<(pod_tuple const & rhs) const noexcept
     {
         return std::tie(_head, _tail) < std::tie(rhs._head, rhs._tail);
     }
 
-    //!\brief Test for larger.
+    //!\brief Checks whether `*this` is greater than `rhs`.
     constexpr bool operator>(pod_tuple const & rhs) const noexcept
     {
         return std::tie(_head, _tail) > std::tie(rhs._head, rhs._tail);
     }
 
-    //!\brief Test for smaller or equal.
+    //!\brief Checks whether `*this` is less than or equal to `rhs`.
     constexpr bool operator<=(pod_tuple const & rhs) const noexcept
     {
         return std::tie(_head, _tail) <= std::tie(rhs._head, rhs._tail);
     }
 
-    //!\brief Test for larger or equal.
+    //!\brief Checks whether `*this` is greater than or equal to `rhs`.
     constexpr bool operator>=(pod_tuple const & rhs) const noexcept
     {
         return std::tie(_head, _tail) >= std::tie(rhs._head, rhs._tail);
@@ -124,37 +124,37 @@ struct pod_tuple<type0>
      * \{
      */
 
-    //!\brief Test for equality.
+    //!\brief Checks whether `*this` is equal to `rhs`.
     constexpr bool operator==(pod_tuple const & rhs) const noexcept
     {
         return _head == rhs._head;
     }
 
-    //!\brief Test for inequality.
+    //!\brief Checks whether `*this` is not equal to `rhs`.
     constexpr bool operator!=(pod_tuple const & rhs) const noexcept
     {
         return _head != rhs._head;
     }
 
-    //!\brief Test for smaller.
+    //!\brief Checks whether `*this` is less than `rhs`.
     constexpr bool operator<(pod_tuple const & rhs) const noexcept
     {
         return _head < rhs._head;
     }
 
-    //!\brief Test for larger.
+    //!\brief Checks whether `*this` is greater than `rhs`.
     constexpr bool operator>(pod_tuple const & rhs) const noexcept
     {
         return _head > rhs._head;
     }
 
-    //!\brief Test for smaller or equal.
+    //!\brief Checks whether `*this` is less than or equal to `rhs`.
     constexpr bool operator<=(pod_tuple const & rhs) const noexcept
     {
         return _head <= rhs._head;
     }
 
-    //!\brief Test for larger or equal.
+    //!\brief Checks whether `*this` is greater than or equal to `rhs`.
     constexpr bool operator>=(pod_tuple const & rhs) const noexcept
     {
         return _head >= rhs._head;

--- a/include/seqan3/core/tuple_utility.hpp
+++ b/include/seqan3/core/tuple_utility.hpp
@@ -129,10 +129,27 @@ constexpr auto tuple_split(tuple_t<ts...> && t)
  * \ingroup core
  *
  * \tparam    pivot_t A template type specifying the split position.
+ * \param[in] t       The original tuple to split.
  *
  * \returns A new tuple of tuples with the left side of the split and the right side of the split.
  *
- * \copydetails seqan3::tuple_split
+ * \details
+ *
+ * Splits a tuple into two tuples, while the element at the split position will be contained in the second tuple.
+ * Note, that the returned tuples can be empty. For this reason it is not possible to use tuple like objects,
+ * that cannot be empty, i.e. std::pair. Using such an object will emit an compiler error.
+ *
+ * ### example
+ *
+ * \snippet test/snippet/core/tuple_utility.cpp usage
+ *
+ * ### Complexity
+ *
+ * Linear in the number of elements.
+ *
+ * ### Thread safety
+ *
+ * Concurrent invocations of this functions are thread safe.
  */
 template <typename pivot_t, tuple_like_concept tuple_t>
 constexpr auto tuple_split(tuple_t && t)

--- a/include/seqan3/core/tuple_utility.hpp
+++ b/include/seqan3/core/tuple_utility.hpp
@@ -22,7 +22,10 @@
 #include <seqan3/core/metafunction/basic.hpp>
 #include <seqan3/core/metafunction/template_inspection.hpp>
 
-namespace seqan3::detail
+namespace seqan3
+{
+
+namespace detail
 {
 
 /*!\brief Helper function for seqan3::tuple_split.
@@ -62,10 +65,9 @@ constexpr auto tuple_split(tuple_t<ts...> && t, std::index_sequence<Is...> const
 {
     return tuple_t<std::tuple_element_t<beg + Is, tuple_t<ts...>>...>{std::move(std::get<beg + Is>(t))...};
 }
-} // namespace seqan3::detail
 
-namespace seqan3
-{
+} // namespace detail
+
 /*!\name Tuple utility functions
  * \brief Helper functions for tuple like objects.
  * \{
@@ -127,7 +129,6 @@ constexpr auto tuple_split(tuple_t<ts...> && t)
  * \ingroup core
  *
  * \tparam    pivot_t A template type specifying the split position.
- * \param[in] t       The original tuple to split.
  *
  * \returns A new tuple of tuples with the left side of the split and the right side of the split.
  *
@@ -171,4 +172,5 @@ constexpr auto tuple_pop_front(tuple_t && t)
     return std::get<1>(tuple_split<1>(std::forward<tuple_t>(t)));
 }
 //!\}
+
 } // namespace seqan3

--- a/include/seqan3/core/tuple_utility.hpp
+++ b/include/seqan3/core/tuple_utility.hpp
@@ -22,10 +22,7 @@
 #include <seqan3/core/metafunction/basic.hpp>
 #include <seqan3/core/metafunction/template_inspection.hpp>
 
-namespace seqan3
-{
-
-namespace detail
+namespace seqan3::detail
 {
 
 /*!\brief Helper function for seqan3::tuple_split.
@@ -66,7 +63,10 @@ constexpr auto tuple_split(tuple_t<ts...> && t, std::index_sequence<Is...> const
     return tuple_t<std::tuple_element_t<beg + Is, tuple_t<ts...>>...>{std::move(std::get<beg + Is>(t))...};
 }
 
-} // namespace detail
+} // namespace seqan3::detail
+
+namespace seqan3
+{
 
 /*!\name Tuple utility functions
  * \brief Helper functions for tuple like objects.

--- a/include/seqan3/core/tuple_utility.hpp
+++ b/include/seqan3/core/tuple_utility.hpp
@@ -62,12 +62,10 @@ constexpr auto tuple_split(tuple_t<ts...> && t, std::index_sequence<Is...> const
 {
     return tuple_t<std::tuple_element_t<beg + Is, tuple_t<ts...>>...>{std::move(std::get<beg + Is>(t))...};
 }
-
 } // namespace seqan3::detail
 
 namespace seqan3
 {
-
 /*!\name Tuple utility functions
  * \brief Helper functions for tuple like objects.
  * \{


### PR DESCRIPTION
This PR improves the SeqAn documentation in the core module and removes all 61 warnings from the doxygen build.