### PR TITLE
[FIX] Doxygen warnings in I/O Module

### DIFF
--- a/include/seqan3/io/alignment_file/input.hpp
+++ b/include/seqan3/io/alignment_file/input.hpp
@@ -61,11 +61,9 @@ namespace seqan3
  * \{
  */
 /*!\typedef using sequence_alphabet
- * \memberof seqan3::AlignmentFileInputTraits
  * \brief Alphabet of the characters for the seqan3::field::SEQ; must model seqan3::Alphabet.
  */
 /*!\typedef using sequence_legal_alphabet
- * \memberof seqan3::AlignmentFileInputTraits
  * \brief Intermediate alphabet for seqan3::field::SEQ; must model seqan3::Alphabet and be convertible to
  * `sequence_alphabet`.
  *
@@ -77,30 +75,24 @@ namespace seqan3
  * character and produce an error.
  */
 /*!\typedef using sequence_container
- * \memberof seqan3::AlignmentFileInputTraits
  * \brief Type template of the seqan3::field::SEQ, a container template over `sequence_alphabet`;
  * must model seqan3::SequenceContainer.
  */
 /*!\typedef using id_alphabet
- * \memberof seqan3::AlignmentFileInputTraits
  * \brief Alphabet of the characters for the seqan3::field::ID; must model seqan3::Alphabet.
  */
 /*!\typedef using id_container
- * \memberof seqan3::AlignmentFileInputTraits
  * \brief Type template of the seqan3::field::ID, a container template over `id_alphabet`;
  * must model seqan3::SequenceContainer.
  */
 /*!\typedef using quality_alphabet
- * \memberof seqan3::AlignmentFileInputTraits
  * \brief Alphabet of the characters for the seqan3::field::QUAL; must model seqan3::QualityAlphabet.
  */
 /*!\typedef using quality_container
- * \memberof seqan3::AlignmentFileInputTraits
  * \brief Type template of the seqan3::field::QUAL, a container template over `quality_alphabet`;
  * must model seqan3::SequenceContainer.
  */
 /*!\typedef using ref_sequences
- * \memberof seqan3::AlignmentFileInputTraits
  * \brief The type of range over reference sequences; must model std::ranges::ForwardRange,
  *        the value_type mus also model std::ranges::ForwardRange, and the value type of the value type
  *        must model seqan3::Alphabet (e.g. std::vector<std::vector<dna4>>).
@@ -110,7 +102,6 @@ namespace seqan3
  *            construction.
  */
 /*!\typedef using ref_ids
- * \memberof seqan3::AlignmentFileInputTraits
  * \brief The type of range over reference sequences; must model std::ranges::ForwardRange,
  *        the value_type mus also model std::ranges::ForwardRange, and the value type of the value type
  *        must model seqan3::Alphabet (e.g. std::vector<string>).
@@ -196,20 +187,35 @@ struct alignment_file_input_default_traits
      * \brief Definitions to model seqan3::AlignmentFileInputTraits.
      * \{
      */
+
+    //!\brief The sequence alphabet is seqan3::dna5.
     using sequence_alphabet                     = dna5;
+
+    //!\brief The legal sequence alphabet for parsing is seqan3::dna15.
     using sequence_legal_alphabet               = dna15;
+
+    //!\brief The container for a sequence is std::vector.
     template <typename _sequence_alphabet>
     using sequence_container                    = std::vector<_sequence_alphabet>;
 
+    //!\brief The alphabet for an identifier string is char.
     using id_alphabet                           = char;
+
+    //!\brief The string type for an identifier is std::basic_string.
     template <typename _id_alphabet>
     using id_container                          = std::basic_string<_id_alphabet>;
 
+    //!\brief The alphabet for a quality annotation is seqan3::phred42.
     using quality_alphabet                      = phred42;
+
+    //!\brief The string type for a quality annotation is std::vector.
     template <typename _quality_alphabet>
     using quality_container                     = std::vector<_quality_alphabet>;
 
+    //!\brief The type of the reference sequences is deduced on construction.
     using ref_sequences                         = ref_sequences_t;
+
+    //!\brief The type of the reference identifiers is deduced on construction.
     using ref_ids                               = ref_ids_t;
     //!\}
 };

--- a/include/seqan3/io/alignment_file/input_format_concept.hpp
+++ b/include/seqan3/io/alignment_file/input_format_concept.hpp
@@ -118,7 +118,6 @@ SEQAN3_CONCEPT AlignmentFileInputFormat =
  *               mapq_type & mapq, mate_type & mate, tag_dict_type & tag_dict, e_value_type & e_value,
  *               bit_score_type & bit_score)
  * \brief Read from the specified stream and back-insert into the given field buffers.
- * \memberof seqan3::AlignmentFileInputFormat
  * \tparam stream_type        The input stream type; Must be derived from std::ostream.
  * \tparam ref_seqs_type      e.g. std::deque<ref_sequence_type> or decltype(std::ignore).
  * \tparam seq_type           Type of the seqan3::field::SEQ input (see seqan3::AlignmentFileInputTraits).

--- a/include/seqan3/io/alignment_file/output.hpp
+++ b/include/seqan3/io/alignment_file/output.hpp
@@ -732,8 +732,6 @@ protected:
  * \relates seqan3::alignment_file_output
  * \{
  */
-
-//!\brief Deduction of the selected fields.
 template <detail::Fields    selected_field_ids>
 alignment_file_output(std::filesystem::path &&, selected_field_ids const &)
     -> alignment_file_output<selected_field_ids,
@@ -741,7 +739,6 @@ alignment_file_output(std::filesystem::path &&, selected_field_ids const &)
                              typename alignment_file_output<>::stream_type,
                              ref_info_not_given>;
 
-//!\brief Deduction of the selected fields, the file format and the stream type.
 template <OStream<char>             stream_type,
           AlignmentFileOutputFormat file_format,
           detail::Fields            selected_field_ids>
@@ -751,7 +748,6 @@ alignment_file_output(stream_type && _stream, file_format const &, selected_fiel
                              std::remove_reference_t<stream_type>,
                              ref_info_not_given>;
 
-//!\brief Deduction of the selected fields, as well as the id and length types.
 template <detail::Fields    selected_field_ids,
           std::ranges::ForwardRange ref_ids_type,
           std::ranges::ForwardRange ref_lengths_type>
@@ -764,7 +760,6 @@ alignment_file_output(std::filesystem::path &&,
                              typename alignment_file_output<>::stream_type,
                              std::remove_reference_t<ref_ids_type>>;
 
-//!\brief Deduction of the id and length types.
 template <std::ranges::ForwardRange ref_ids_type,
           std::ranges::ForwardRange ref_lengths_type>
 alignment_file_output(std::filesystem::path &&,
@@ -775,7 +770,6 @@ alignment_file_output(std::filesystem::path &&,
                              typename alignment_file_output<>::stream_type,
                              std::remove_reference_t<ref_ids_type>>;
 
-//!\brief Deduction of the selected fields and file format, as well as the id, length and stream types.
 template <OStream<char>             stream_type,
           std::ranges::ForwardRange ref_ids_type,
           std::ranges::ForwardRange ref_lengths_type,
@@ -791,7 +785,6 @@ alignment_file_output(stream_type && _stream,
                              std::remove_reference_t<stream_type>,
                              std::remove_reference_t<ref_ids_type>>;
 
-//!\brief Deduction of the file format, as well as the id, length and stream types.
 template <OStream<char>             stream_type,
           std::ranges::ForwardRange ref_ids_type,
           std::ranges::ForwardRange ref_lengths_type,

--- a/include/seqan3/io/alignment_file/output.hpp
+++ b/include/seqan3/io/alignment_file/output.hpp
@@ -232,9 +232,14 @@ public:
      * \brief Most of the range associated types are `void` for output ranges.
      * \{
      */
+
+    //!\brief The value type (void).
     using value_type        = void;
+    //!\brief The reference type (void).
     using reference         = void;
+    //!\brief The const reference type (void).
     using const_reference   = void;
+    //!\brief The size type (void).
     using size_type         = void;
     //!\brief A signed integer type, usually std::ptrdiff_t.
     using difference_type   = std::ptrdiff_t;
@@ -727,6 +732,8 @@ protected:
  * \relates seqan3::alignment_file_output
  * \{
  */
+
+//!\brief Deduction of the selected fields.
 template <detail::Fields    selected_field_ids>
 alignment_file_output(std::filesystem::path &&, selected_field_ids const &)
     -> alignment_file_output<selected_field_ids,
@@ -734,6 +741,7 @@ alignment_file_output(std::filesystem::path &&, selected_field_ids const &)
                              typename alignment_file_output<>::stream_type,
                              ref_info_not_given>;
 
+//!\brief Deduction of the selected fields, the file format and the stream type.
 template <OStream<char>             stream_type,
           AlignmentFileOutputFormat file_format,
           detail::Fields            selected_field_ids>
@@ -743,6 +751,7 @@ alignment_file_output(stream_type && _stream, file_format const &, selected_fiel
                              std::remove_reference_t<stream_type>,
                              ref_info_not_given>;
 
+//!\brief Deduction of the selected fields, as well as the id and length types.
 template <detail::Fields    selected_field_ids,
           std::ranges::ForwardRange ref_ids_type,
           std::ranges::ForwardRange ref_lengths_type>
@@ -755,6 +764,7 @@ alignment_file_output(std::filesystem::path &&,
                              typename alignment_file_output<>::stream_type,
                              std::remove_reference_t<ref_ids_type>>;
 
+//!\brief Deduction of the id and length types.
 template <std::ranges::ForwardRange ref_ids_type,
           std::ranges::ForwardRange ref_lengths_type>
 alignment_file_output(std::filesystem::path &&,
@@ -765,6 +775,7 @@ alignment_file_output(std::filesystem::path &&,
                              typename alignment_file_output<>::stream_type,
                              std::remove_reference_t<ref_ids_type>>;
 
+//!\brief Deduction of the selected fields and file format, as well as the id, length and stream types.
 template <OStream<char>             stream_type,
           std::ranges::ForwardRange ref_ids_type,
           std::ranges::ForwardRange ref_lengths_type,
@@ -780,6 +791,7 @@ alignment_file_output(stream_type && _stream,
                              std::remove_reference_t<stream_type>,
                              std::remove_reference_t<ref_ids_type>>;
 
+//!\brief Deduction of the file format, as well as the id, length and stream types.
 template <OStream<char>             stream_type,
           std::ranges::ForwardRange ref_ids_type,
           std::ranges::ForwardRange ref_lengths_type,

--- a/include/seqan3/io/alignment_file/output_format_concept.hpp
+++ b/include/seqan3/io/alignment_file/output_format_concept.hpp
@@ -108,7 +108,6 @@ SEQAN3_CONCEPT AlignmentFileOutputFormat =
                   e_value_type                           && e_value,
                   bit_score_type                         && bit_score)
  * \brief Write the given fields to the specified stream.
- * \memberof seqan3::AlignmentFileOutputFormat
  * \tparam stream_type      Output stream, must model seqan3::OStream with `char`.
  * \tparam seq_type         Type of the seqan3
  * \tparam id_type          Type of the seqan3

--- a/include/seqan3/io/detail/ignore_output_iterator.hpp
+++ b/include/seqan3/io/detail/ignore_output_iterator.hpp
@@ -35,10 +35,16 @@ public:
      * \brief Associated types are void for output iterators, see also
      * [output iterator concept](http://en.cppreference.com/w/cpp/concept/OutputIterator).
      */
+
+    //!\brief The value type (void).
     using value_type        = void;
+    //!\brief The reference type (void).
     using reference         = void;
+    //!\brief The pointer type (void).
     using pointer           = void;
+    //!\brief A signed integer type, usually std::ptrdiff_t.
     using difference_type   = std::ptrdiff_t;
+    //!\brief The iterator category type.
     using iterator_category = std::output_iterator_tag;
     //!\}
 

--- a/include/seqan3/io/detail/in_file_iterator.hpp
+++ b/include/seqan3/io/detail/in_file_iterator.hpp
@@ -49,11 +49,18 @@ public:
      * \brief The associated types are derived from the `file_type`.
      * \{
      */
+
+    //!\brief The value type.
     using value_type        = typename file_type::value_type;
+    //!\brief The reference type.
     using reference         = typename file_type::reference;
+    //!\brief The const reference type.
     using const_reference   = typename file_type::reference;
+    //!\brief The size type.
     using size_type         = typename file_type::size_type;
+    //!\brief The difference type. A signed integer type, usually std::ptrdiff_t.
     using difference_type   = typename file_type::difference_type;
+    //!\brief The pointer type.
     using pointer           = typename file_type::value_type *;
     //!\brief Tag this class as an input iterator.
     using iterator_category = std::input_iterator_tag;
@@ -118,24 +125,29 @@ public:
      * \brief Only (in-)equality comparison of iterator with end() is supported.
      * \{
      */
+
+    //!\brief Test for equality.
     constexpr bool operator==(std::ranges::default_sentinel_t const &) const noexcept
     {
         assert(host != nullptr);
         return host->at_end;
     }
 
+    //!\brief Test for inequality.
     constexpr bool operator!=(std::ranges::default_sentinel_t const &) const noexcept
     {
         assert(host != nullptr);
         return !host->at_end;
     }
 
+    //!\brief Test for equality.
     constexpr friend bool operator==(std::ranges::default_sentinel_t const &,
                                      in_file_iterator const & it) noexcept
     {
         return (it == std::ranges::default_sentinel);
     }
 
+    //!\brief Test for inequality.
     constexpr friend bool operator!=(std::ranges::default_sentinel_t const &,
                                      in_file_iterator const & it) noexcept
     {

--- a/include/seqan3/io/detail/in_file_iterator.hpp
+++ b/include/seqan3/io/detail/in_file_iterator.hpp
@@ -126,28 +126,28 @@ public:
      * \{
      */
 
-    //!\brief Test for equality.
+    //!\brief Checks whether `*this` is equal to the sentinel.
     constexpr bool operator==(std::ranges::default_sentinel_t const &) const noexcept
     {
         assert(host != nullptr);
         return host->at_end;
     }
 
-    //!\brief Test for inequality.
+    //!\brief Checks whether `*this` is not equal to the sentinel.
     constexpr bool operator!=(std::ranges::default_sentinel_t const &) const noexcept
     {
         assert(host != nullptr);
         return !host->at_end;
     }
 
-    //!\brief Test for equality.
+    //!\brief Checks whether `it` is equal to the sentinel.
     constexpr friend bool operator==(std::ranges::default_sentinel_t const &,
                                      in_file_iterator const & it) noexcept
     {
         return (it == std::ranges::default_sentinel);
     }
 
-    //!\brief Test for inequality.
+    //!\brief Checks whether `it` is not equal to the sentinel.
     constexpr friend bool operator!=(std::ranges::default_sentinel_t const &,
                                      in_file_iterator const & it) noexcept
     {

--- a/include/seqan3/io/detail/out_file_iterator.hpp
+++ b/include/seqan3/io/detail/out_file_iterator.hpp
@@ -134,26 +134,26 @@ public:
      * \{
      */
 
-    //!\brief Test for equality.
+    //!\brief Checks whether `*this` is equal to the sentinel (always false).
     constexpr bool operator==(std::ranges::default_sentinel_t const &) const noexcept
     {
         return false;
     }
 
-    //!\brief Test for inequality.
+    //!\brief Checks whether `*this` is not equal to the sentinel (always true).
     constexpr bool operator!=(std::ranges::default_sentinel_t const &) const noexcept
     {
         return true;
     }
 
-    //!\brief Test for equality.
+    //!\brief Checks whether `it` is equal to the sentinel.
     constexpr friend bool operator==(std::ranges::default_sentinel_t const &,
                                      out_file_iterator const & it) noexcept
     {
         return (it == std::ranges::default_sentinel);
     }
 
-    //!\brief Test for inequality.
+    //!\brief Checks whether `it` is not equal to the sentinel.
     constexpr friend bool operator!=(std::ranges::default_sentinel_t const &,
                                      out_file_iterator const & it) noexcept
     {

--- a/include/seqan3/io/detail/out_file_iterator.hpp
+++ b/include/seqan3/io/detail/out_file_iterator.hpp
@@ -55,11 +55,18 @@ public:
      * \brief The associated types are `void`, see the full description.
      * \{
      */
+
+    //!\brief The value type (void).
     using value_type        = void;
+    //!\brief The reference type (void).
     using reference         = void;
+    //!\brief The const reference type (void).
     using const_reference   = void;
+    //!\brief The size type (void).
     using size_type         = void;
+    //!\brief A signed integer type, usually std::ptrdiff_t.
     using difference_type   = std::ptrdiff_t;
+    //!\brief The pointer type.
     using pointer           = void *;
     //!\brief Tag this class as an input access iterator.
     using iterator_category = std::output_iterator_tag;
@@ -126,22 +133,27 @@ public:
      * \brief This iterator never equals its sentinel.
      * \{
      */
+
+    //!\brief Test for equality.
     constexpr bool operator==(std::ranges::default_sentinel_t const &) const noexcept
     {
         return false;
     }
 
+    //!\brief Test for inequality.
     constexpr bool operator!=(std::ranges::default_sentinel_t const &) const noexcept
     {
         return true;
     }
 
+    //!\brief Test for equality.
     constexpr friend bool operator==(std::ranges::default_sentinel_t const &,
                                      out_file_iterator const & it) noexcept
     {
         return (it == std::ranges::default_sentinel);
     }
 
+    //!\brief Test for inequality.
     constexpr friend bool operator!=(std::ranges::default_sentinel_t const &,
                                      out_file_iterator const & it) noexcept
     {

--- a/include/seqan3/io/record.hpp
+++ b/include/seqan3/io/record.hpp
@@ -229,6 +229,8 @@ namespace seqan3
  * \relates seqan3::record
  * \{
  */
+
+//!\brief Free function get() for seqan3::record based on seqan3::field.
 template <field f, typename field_types, typename field_ids>
 auto & get(record<field_types, field_ids> & r)
 {
@@ -236,6 +238,7 @@ auto & get(record<field_types, field_ids> & r)
     return std::get<field_ids::index_of(f)>(r);
 }
 
+//!\overload
 template <field f, typename field_types, typename field_ids>
 auto const & get(record<field_types, field_ids> const & r)
 {
@@ -243,6 +246,7 @@ auto const & get(record<field_types, field_ids> const & r)
     return std::get<field_ids::index_of(f)>(r);
 }
 
+//!\overload
 template <field f, typename field_types, typename field_ids>
 auto && get(record<field_types, field_ids> && r)
 {
@@ -250,6 +254,7 @@ auto && get(record<field_types, field_ids> && r)
     return std::get<field_ids::index_of(f)>(std::move(r));
 }
 
+//!\overload
 template <field f, typename field_types, typename field_ids>
 auto const && get(record<field_types, field_ids> const && r)
 {

--- a/include/seqan3/io/sequence_file/input.hpp
+++ b/include/seqan3/io/sequence_file/input.hpp
@@ -64,11 +64,9 @@ namespace seqan3
  * \{
  */
 /*!\typedef using sequence_alphabet
- * \memberof seqan3::SequenceFileInputTraits
  * \brief Alphabet of the characters for the seqan3::field::SEQ; must satisfy seqan3::Alphabet.
  */
 /*!\typedef using sequence_legal_alphabet
- * \memberof seqan3::SequenceFileInputTraits
  * \brief Intermediate alphabet for seqan3::field::SEQ; must satisfy seqan3::Alphabet and be convertible to
  * `sequence_alphabet`.
  *
@@ -80,40 +78,32 @@ namespace seqan3
  * character and produce an error.
  */
 /*!\typedef using sequence_container
- * \memberof seqan3::SequenceFileInputTraits
  * \brief Type template of the seqan3::field::SEQ, a container template over `sequence_alphabet`;
  * must satisfy seqan3::SequenceContainer.
  */
 /*!\typedef using sequence_container_container
- * \memberof seqan3::SequenceFileInputTraits
  * \brief Type template of a column of seqan3::field::SEQ, a container template that can hold multiple
  * `sequence_container`; must satisfy seqan3::SequenceContainer.
  */
 /*!\typedef using id_alphabet
- * \memberof seqan3::SequenceFileInputTraits
  * \brief Alphabet of the characters for the seqan3::field::ID; must satisfy seqan3::Alphabet.
  */
 /*!\typedef using id_container
- * \memberof seqan3::SequenceFileInputTraits
  * \brief Type template of the seqan3::field::ID, a container template over `id_alphabet`;
  * must satisfy seqan3::SequenceContainer.
  */
 /*!\typedef using id_container_container
- * \memberof seqan3::SequenceFileInputTraits
  * \brief Type template of a column of seqan3::field::ID, a container template that can hold multiple
  * `id_container`; must satisfy seqan3::SequenceContainer.
  */
 /*!\typedef using quality_alphabet
- * \memberof seqan3::SequenceFileInputTraits
  * \brief Alphabet of the characters for the seqan3::field::QUAL; must satisfy seqan3::QualityAlphabet.
  */
 /*!\typedef using quality_container
- * \memberof seqan3::SequenceFileInputTraits
  * \brief Type template of the seqan3::field::QUAL, a container template over `quality_alphabet`;
  * must satisfy seqan3::SequenceContainer.
  */
 /*!\typedef using quality_container_container
- * \memberof seqan3::SequenceFileInputTraits
  * \brief Type template of a column of seqan3::field::QUAL, a container template that can hold multiple
  * `quality_container`; must satisfy seqan3::SequenceContainer.
  */
@@ -164,22 +154,40 @@ struct sequence_file_input_default_traits_dna
      * \brief Definitions to satisfy seqan3::SequenceFileInputTraits.
      * \{
      */
+
+    //!\brief The sequence alphabet is seqan3::dna5.
     using sequence_alphabet                 = dna5;
+
+    //!\brief The legal sequence alphabet for parsing is seqan3::dna15.
     using sequence_legal_alphabet           = dna15;
+
+    //!\brief The type of a DNA sequence is std::vector.
     template <typename _sequence_alphabet>
     using sequence_container                = std::vector<_sequence_alphabet>;
+
+    //!\brief The container for sequences is seqan3::concatenated_sequences.
     template <typename _sequence_container>
     using sequence_container_container      = concatenated_sequences<_sequence_container>;
 
+    //!\brief The alphabet for an identifier string is char.
     using id_alphabet                       = char;
+
+    //!\brief The string type for an identifier is std::basic_string.
     template <typename _id_alphabet>
     using id_container                      = std::basic_string<_id_alphabet>;
+
+    //!\brief The container for identifier strings is seqan3::concatenated_sequences.
     template <typename _id_container>
     using id_container_container            = concatenated_sequences<_id_container>;
 
+    //!\brief The alphabet for a quality annotation is seqan3::phred42.
     using quality_alphabet                  = phred42;
+
+    //!\brief The string type for a quality annotation is std::vector.
     template <typename _quality_alphabet>
     using quality_container                 = std::vector<_quality_alphabet>;
+
+    //!\brief The container for quality annotation strings is seqan3::concatenated_sequences.
     template <typename _quality_container>
     using quality_container_container       = concatenated_sequences<_quality_container>;
     //!\}
@@ -193,7 +201,11 @@ struct sequence_file_input_default_traits_aa : sequence_file_input_default_trait
      * \brief Definitions to satisfy seqan3::SequenceFileInputTraits.
      * \{
      */
+
+    //!\brief The sequence alphabet is seqan3::aa27.
     using sequence_alphabet = aa27;
+
+    //!\brief The legal sequence alphabet for parsing is seqan3::aa27.
     using sequence_legal_alphabet = aa27;
     //!\}
 };
@@ -800,6 +812,8 @@ protected:
  * \relates seqan3::sequence_file_input
  * \{
  */
+
+//!\brief Deduction of the selected fields, the file format and the stream type.
 template <IStream2                           stream_type,
           SequenceFileInputFormat            file_format,
           detail::Fields                     selected_field_ids>
@@ -811,6 +825,7 @@ sequence_file_input(stream_type && stream,
                            type_list<file_format>,
                            typename std::remove_reference_t<stream_type>::char_type>;
 
+//!\overload
 template <IStream2                           stream_type,
           SequenceFileInputFormat            file_format,
           detail::Fields                     selected_field_ids>

--- a/include/seqan3/io/sequence_file/input_format_concept.hpp
+++ b/include/seqan3/io/sequence_file/input_format_concept.hpp
@@ -63,7 +63,6 @@ SEQAN3_CONCEPT SequenceFileInputFormat = requires (t                            
 /*!\fn void read(stream_type & stream, seqan3::sequence_file_input_options const & options, seq_type & sequence,
  *               id_type & id, qual_type & qualities)
  * \brief Read from the specified stream and back-insert into the given field buffers.
- * \memberof seqan3::SequenceFileInputFormat
  * \tparam stream_type      Input stream, must satisfy seqan3::IStream with `char`.
  * \tparam seq_type         Type of the seqan3::field::SEQ input; must satisfy std::ranges::OutputRange
  * over a seqan3::Alphabet.

--- a/include/seqan3/io/sequence_file/output.hpp
+++ b/include/seqan3/io/sequence_file/output.hpp
@@ -203,9 +203,14 @@ public:
      * \brief Most of the range associated types are `void` for output ranges.
      * \{
      */
+
+    //!\brief The value type (void).
     using value_type        = void;
+    //!\brief The reference type (void).
     using reference         = void;
+    //!\brief The const reference type (void).
     using const_reference   = void;
+    //!\brief The size type (void).
     using size_type         = void;
     //!\brief A signed integer type, usually std::ptrdiff_t.
     using difference_type   = std::ptrdiff_t;
@@ -713,6 +718,8 @@ protected:
  * \relates seqan3::sequence_file_output
  * \{
  */
+
+//!\brief Deduction of the selected fields, the file format and the stream type.
 template <OStream2                 stream_t,
           SequenceFileOutputFormat file_format,
           detail::Fields           selected_field_ids>
@@ -723,6 +730,7 @@ sequence_file_output(stream_t &&,
                             type_list<file_format>,
                             typename std::remove_reference_t<stream_t>::char_type>;
 
+//!\overload
 template <OStream2                 stream_t,
           SequenceFileOutputFormat file_format,
           detail::Fields           selected_field_ids>

--- a/include/seqan3/io/sequence_file/output_format_concept.hpp
+++ b/include/seqan3/io/sequence_file/output_format_concept.hpp
@@ -63,7 +63,6 @@ SEQAN3_CONCEPT SequenceFileOutputFormat = requires (t                           
 /*!\fn void write(stream_type & stream, seqan3::sequence_file_output_options const & options, seq_type && sequence,
  *                id_type && id, qual_type && qualities)
  * \brief Write the given fields to the specified stream.
- * \memberof seqan3::SequenceFileOutputFormat
  * \tparam stream_type      Output stream, must satisfy seqan3::OStream with `char`.
  * \tparam seq_type         Type of the seqan3::field::SEQ output; must satisfy std::ranges::OutputRange
  * over a seqan3::Alphabet.

--- a/include/seqan3/io/stream/concept.hpp
+++ b/include/seqan3/io/stream/concept.hpp
@@ -54,7 +54,6 @@ SEQAN3_CONCEPT OStream2 = requires { typename std::remove_reference_t<stream_typ
  */
 /*!\fn      std::basic_ostream<char_type, traits_type> & operator<<(value_type val);
  * \brief   (un)-formatted output operator for the respective type on the underlying stream.
- * \relates seqan3::OStream
  * \param   val The value to write into the stream.
  * \returns A reference to a std::basic_ostream<char_type, traits_type>.
  *
@@ -67,27 +66,22 @@ SEQAN3_CONCEPT OStream2 = requires { typename std::remove_reference_t<stream_typ
  */
 
  /*!\typedef typename stream::char_type char_type
-  * \memberof seqan3::OStream
   * \brief Declares the associated char type.
   */
 
  /*!\typedef typename stream::traits_type traits_type
-  * \memberof seqan3::OStream
   * \brief Declares the associated traits type.
   */
 
  /*!\typedef typename stream::int_type int_type
-  * \memberof seqan3::OStream
   * \brief Declares the associated int type.
   */
 
  /*!\typedef typename stream::pos_type pos_type
-  * \memberof seqan3::OStream
   * \brief Declares the associated pos type.
   */
 
  /*!\typedef typename stream::off_type off_type
-  * \memberof seqan3::OStream
   * \brief Declares the associated off type.
   */
 //!\}
@@ -127,7 +121,6 @@ SEQAN3_CONCEPT IStream2 = requires { typename std::remove_reference_t<stream_typ
  */
 /*!\fn      std::basic_istream<char_type, traits_type> & operator>>(value_type val);
  * \brief   (un)-formatted input operator for the respective type on the underlying stream.
- * \relates seqan3::IStream
  * \param   val The value to read from the stream.
  * \returns A reference to a std::basic_istream<char_type, traits_type>.
  *
@@ -140,27 +133,22 @@ SEQAN3_CONCEPT IStream2 = requires { typename std::remove_reference_t<stream_typ
  */
 
  /*!\typedef typename stream::char_type char_type
-  * \memberof seqan3::IStream
   * \brief Declares the associated char type.
   */
 
  /*!\typedef typename stream::traits_type traits_type
-  * \memberof seqan3::IStream
   * \brief Declares the associated traits type.
   */
 
  /*!\typedef typename stream::int_type int_type
-  * \memberof seqan3::IStream
   * \brief Declares the associated int type.
   */
 
  /*!\typedef typename stream::pos_type pos_type
-  * \memberof seqan3::IStream
   * \brief Declares the associated pos type.
   */
 
  /*!\typedef typename stream::off_type off_type
-  * \memberof seqan3::IStream
   * \brief Declares the associated off type.
   */
 //!\}

--- a/include/seqan3/io/structure_file/input.hpp
+++ b/include/seqan3/io/structure_file/input.hpp
@@ -1117,7 +1117,6 @@ structure_file_in(stream_type && stream, file_format const &, selected_field_ids
                          type_list<file_format>,
                          typename std::remove_reference_t<stream_type>::char_type>;
 
-
 //!\overload
 template <IStream2                 stream_type,
           StructureFileInputFormat file_format,

--- a/include/seqan3/io/structure_file/input.hpp
+++ b/include/seqan3/io/structure_file/input.hpp
@@ -292,68 +292,126 @@ struct structure_file_input_default_traits_rna
      */
 
     // sequence
+
+    //!\brief The sequence alphabet is seqan3::rna5.
     using seq_alphabet                       = rna5;
+
+    //!\brief The legal sequence alphabet for parsing is seqan3::rna15.
     using seq_legal_alphabet                 = rna15;
+
+    //!\brief The type of an RNA sequence is std::vector.
     template<typename _seq_alphabet>
     using seq_container                      = std::vector<_seq_alphabet>;
+
+    //!\brief The container for sequences is seqan3::concatenated_sequences.
     template<typename _seq_container>
     using seq_container_container            = concatenated_sequences<_seq_container>;
 
     // id
+
+    //!\brief The alphabet for an identifier string is char.
     using id_alphabet                        = char;
+
+    //!\brief The string type for an identifier is std::basic_string.
     template<typename _id_alphabet>
     using id_container                       = std::basic_string<_id_alphabet>;
+
+    //!\brief The container for identifier strings is seqan3::concatenated_sequences.
     template<typename _id_container>
     using id_container_container             = concatenated_sequences<_id_container>;
 
     // base pair probability structure
+
+    //!\brief The type for a base pair probability is double.
     using bpp_prob                           = double;
+
+    //!\brief The type for the partner position of a base pair probability is size_t.
     using bpp_partner                        = size_t;
-    template<typename _bpp_prec, typename _bpp_partner>
-    using bpp_item                           = std::pair<_bpp_prec, _bpp_partner>;
+
+    //!\brief The type of a base pair item is std::pair<double, size_t>.
+    template<typename _bpp_prob, typename _bpp_partner>
+    using bpp_item                           = std::pair<_bpp_prob, _bpp_partner>;
+
+    //!\brief A queue of base pair items sorted by probability is realised with std::set.
     template<typename _bpp_item>
     using bpp_queue                          = std::set<_bpp_item>;
+
+    //!\brief A string over all bases containing the respective interaction queues is represented as std::vector.
     template<typename _bpp_queue>
     using bpp_container                      = std::vector<_bpp_queue>;
+
+    //!\brief The container for interaction strings is std::vector.
     template<typename _bpp_container>
     using bpp_container_container            = std::vector<_bpp_container>;
 
     // fixed structure
+
+    //!\brief The alphabet for a structure annotation is seqan3::phred42.
     using structure_alphabet                 = wuss51;
+
+    //!\brief The string type for a structure annotation is std::vector.
     template<typename _structure_alphabet>
     using structure_container                = std::vector<_structure_alphabet>;
+
+    //!\brief The container for structure annotation strings is seqan3::concatenated_sequences.
     template<typename _structure_container>
     using structure_container_container      = concatenated_sequences<_structure_container>;
 
     // combined sequence and structure
+
+    //!\brief The combined structured sequence alphabet is seqan3::structured_rna<seqan3::rna5, seqan3::wuss51>.
     template<typename _seq_alphabet, typename _structure_alphabet>
     using structured_seq_alphabet            = structured_rna<_seq_alphabet, _structure_alphabet>;
+
+    //!\brief The type of a structured RNA sequence is std::vector.
     template<typename _structured_seq_alphabet>
     using structured_seq_container           = std::vector<_structured_seq_alphabet>;
+
+    //!\brief The container for sequences is seqan3::concatenated_sequences.
     template<typename _structured_seq_container>
     using structured_seq_container_container = concatenated_sequences<_structured_seq_container>;
 
     // energy
+
+    //!\brief The type of the energy is std::optional<double>.
     using energy_type                        = std::optional<double>;
+
+    //!\brief The type of a container of energy values is std::vector.
     template<typename _energy_type>
     using energy_container                   = std::vector<_energy_type>;
 
     // reactivity [error]
+
+    //!\brief The type of the reactivity and reactivity error is double.
     using react_type                         = double;
+
+    //!\brief The type of a string of reactivity values is std::vector.
     template<typename _react_type>
     using react_container                    = std::vector<_react_type>;
+
+    //!\brief The type of a container of reactivity strings is std::vector.
     template<typename _react_container>
     using react_container_container          = std::vector<_react_container>;
 
     // comment
+
+    //!\brief The alphabet for a comment string is char.
     using comment_alphabet                   = char;
+
+    //!\brief The string type for a comment is std::basic_string.
     template<typename _comment_alphabet>
     using comment_container                  = std::basic_string<_comment_alphabet>;
+
+    //!\brief The container for comments is seqan3::concatenated_sequences.
     template<typename _comment_container>
     using comment_container_container        = concatenated_sequences<_comment_container>;
 
     // offset
+
+    //!\brief The type of the offset is size_t.
     using offset_type                        = size_t;
+
+    //!\brief The type of a container of offset values is std::vector.
     template<typename _offset_type>
     using offset_container                   = std::vector<_offset_type>;
     //!\}
@@ -367,9 +425,14 @@ struct structure_file_input_default_traits_aa : structure_file_input_default_tra
      * \brief Definitions to satisfy seqan3::StructureFileInputTraits.
      * \{
      */
+
+    //!\brief The sequence alphabet is seqan3::aa27.
     using seq_alphabet             = aa27;
+    //!\brief The legal sequence alphabet for parsing is seqan3::aa27.
     using seq_legal_alphabet       = aa27;
+    //!\brief The structure annotation alphabet is seqan3::dssp9.
     using structure_alphabet       = dssp9;
+    //!\brief The combined structured sequence alphabet is seqan3::structured_aa<seqan3::aa27, seqan3::dssp9>.
     template<typename _seq_alphabet, typename _structure_alphabet>
     using structured_seq_alphabet  = structured_aa<_seq_alphabet, _structure_alphabet>;
     //!\}
@@ -1043,6 +1106,8 @@ protected:
  * \relates seqan3::structure_file_in
  * \{
  */
+
+//!\brief Deduction of the selected fields, the file format and the stream type.
 template <IStream2                 stream_type,
           StructureFileInputFormat file_format,
           detail::Fields           selected_field_ids>
@@ -1052,6 +1117,8 @@ structure_file_in(stream_type && stream, file_format const &, selected_field_ids
                          type_list<file_format>,
                          typename std::remove_reference_t<stream_type>::char_type>;
 
+
+//!\overload
 template <IStream2                 stream_type,
           StructureFileInputFormat file_format,
           detail::Fields           selected_field_ids>

--- a/include/seqan3/io/structure_file/input_format_concept.hpp
+++ b/include/seqan3/io/structure_file/input_format_concept.hpp
@@ -86,7 +86,6 @@ SEQAN3_CONCEPT StructureFileInputFormat = requires(t & v,
  *               comment_type & comment,
  *               offset_type & offset)
  * \brief Read from the specified stream and back-insert into the given field buffers.
- * \memberof seqan3::StructureFileInputFormat
  * \tparam stream_type      Input stream, must satisfy seqan3::istream_concept with `char`.
  * \tparam seq_type         Type of the seqan3::field::SEQ input; must satisfy std::ranges::OutputRange
  * over a seqan3::Alphabet.

--- a/include/seqan3/io/structure_file/output.hpp
+++ b/include/seqan3/io/structure_file/output.hpp
@@ -220,9 +220,14 @@ public:
      * \brief Most of the range associated types are `void` for output ranges.
      * \{
      */
+
+    //!\brief The value type (void).
     using value_type        = void;
+    //!\brief The reference type (void).
     using reference         = void;
+    //!\brief The const reference type (void).
     using const_reference   = void;
+    //!\brief The size type (void).
     using size_type         = void;
     //!\brief A signed integer type, usually std::ptrdiff_t.
     using difference_type   = std::ptrdiff_t;
@@ -803,6 +808,8 @@ protected:
  * \relates seqan3::structure_file_out
  * \{
  */
+
+//!\brief Deduction of the selected fields, the file format and the stream type.
 template <OStream2                  stream_t,
           StructureFileOutputFormat file_format,
           detail::Fields            selected_field_ids>
@@ -811,6 +818,7 @@ structure_file_out(stream_t &&, file_format const &, selected_field_ids const &)
                           type_list<file_format>,
                           typename std::remove_reference_t<stream_t>::char_type>;
 
+//!\overload
 template <OStream2                  stream_t,
           StructureFileOutputFormat file_format,
           detail::Fields            selected_field_ids>

--- a/include/seqan3/io/structure_file/output_format_concept.hpp
+++ b/include/seqan3/io/structure_file/output_format_concept.hpp
@@ -83,7 +83,6 @@ SEQAN3_CONCEPT StructureFileOutputFormat = requires(t & v,
  *                comment_type && comment,
  *                offset_type && offset)
  * \brief Write the given fields to the specified stream.
- * \memberof seqan3::StructureFileOutputFormat
  * \tparam stream_type      Output stream, must satisfy seqan3::OStream with `char`.
  * \tparam seq_type         Type of the seqan3::field::SEQ output; must satisfy std::ranges::OutputRange
  * over a seqan3::Alphabet.


### PR DESCRIPTION
This PR improves the SeqAn documentation in the io module and removes all 383 warnings from the doxygen build.