### PR TITLE
[FIX] Doxygen warnings in Range Module

### DIFF
--- a/include/seqan3/range/container/aligned_allocator.hpp
+++ b/include/seqan3/range/container/aligned_allocator.hpp
@@ -84,6 +84,7 @@ public:
     aligned_allocator& operator=(aligned_allocator &&)      = default; //!< Defaulted.
     ~aligned_allocator()                                    = default; //!< Defaulted.
 
+    //!\brief Copy constructor with different value type.
     template <class other_value_type>
     constexpr aligned_allocator(aligned_allocator<other_value_type, alignment> const &) noexcept
     {}

--- a/include/seqan3/range/container/bitcompressed_vector.hpp
+++ b/include/seqan3/range/container/bitcompressed_vector.hpp
@@ -971,33 +971,41 @@ public:
     }
     //!\}
 
-    //!\name Comparison operators
-    //!\{
+    /*!\name Comparison operators
+     * \{
+     */
+
+    //!\brief Checks whether `*this` is equal to `rhs`.
     constexpr bool operator==(bitcompressed_vector const & rhs) const noexcept
     {
         return data == rhs.data;
     }
 
+    //!\brief Checks whether `*this` is not equal to `rhs`.
     constexpr bool operator!=(bitcompressed_vector const & rhs) const noexcept
     {
         return data != rhs.data;
     }
 
+    //!\brief Checks whether `*this` is less than `rhs`.
     constexpr bool operator<(bitcompressed_vector const & rhs) const noexcept
     {
         return data < rhs.data;
     }
 
+    //!\brief Checks whether `*this` is greater than `rhs`.
     constexpr bool operator>(bitcompressed_vector const & rhs) const noexcept
     {
         return data > rhs.data;
     }
 
+    //!\brief Checks whether `*this` is less than or equal to `rhs`.
     constexpr bool operator<=(bitcompressed_vector const & rhs) const noexcept
     {
         return data <= rhs.data;
     }
 
+    //!\brief Checks whether `*this` is greater than or equal to `rhs`.
     constexpr bool operator>=(bitcompressed_vector const & rhs) const noexcept
     {
         return data >= rhs.data;

--- a/include/seqan3/range/container/concatenated_sequences.hpp
+++ b/include/seqan3/range/container/concatenated_sequences.hpp
@@ -1236,33 +1236,41 @@ public:
     }
     //!\}
 
-    //!\name Comparison operators
-    //!\{
+    /*!\name Comparison operators
+     * \{
+     */
+
+    //!\brief Checks whether `*this` is equal to `rhs`.
     constexpr bool operator==(concatenated_sequences const & rhs) const noexcept
     {
         return data() == rhs.data();
     }
 
+    //!\brief Checks whether `*this` is not equal to `rhs`.
     constexpr bool operator!=(concatenated_sequences const & rhs) const noexcept
     {
         return data() != rhs.data();
     }
 
+    //!\brief Checks whether `*this` is less than `rhs`.
     constexpr bool operator<(concatenated_sequences const & rhs) const noexcept
     {
         return data() < rhs.data();
     }
 
+    //!\brief Checks whether `*this` is greater than `rhs`.
     constexpr bool operator>(concatenated_sequences const & rhs) const noexcept
     {
         return data() > rhs.data();
     }
 
+    //!\brief Checks whether `*this` is less than or equal to `rhs`.
     constexpr bool operator<=(concatenated_sequences const & rhs) const noexcept
     {
         return data() <= rhs.data();
     }
 
+    //!\brief Checks whether `*this` is greater than or equal to `rhs`.
     constexpr bool operator>=(concatenated_sequences const & rhs) const noexcept
     {
         return data() >= rhs.data();

--- a/include/seqan3/range/container/small_vector.hpp
+++ b/include/seqan3/range/container/small_vector.hpp
@@ -956,8 +956,10 @@ protected:
     }
 };
 
-//!\name Type deduction guides
-//!\{
+/*!\name Type deduction guides
+ * \{
+ */
+
 //!\brief Deducts the size and value type from an built-in array on construction.
 template <size_t capacity2, typename value_type>
 small_vector(const value_type (&array)[capacity2]) -> small_vector<value_type, capacity2>;

--- a/include/seqan3/range/decorator/gap_decorator_anchor_set.hpp
+++ b/include/seqan3/range/decorator/gap_decorator_anchor_set.hpp
@@ -290,36 +290,43 @@ private:
          * \brief Compares iterators by virtual position.
          * \{
          */
+
+        //!\brief Checks whether `*this` is equal to `rhs`.
         constexpr friend bool operator==(gap_decorator_anchor_set_iterator const & lhs,
                                          gap_decorator_anchor_set_iterator const & rhs)
         {
             return lhs.pos == rhs.pos;
         }
 
+        //!\brief Checks whether `*this` is not equal to `rhs`.
         constexpr friend bool operator!=(gap_decorator_anchor_set_iterator const & lhs,
                                          gap_decorator_anchor_set_iterator const & rhs)
         {
             return lhs.pos != rhs.pos;
         }
 
+        //!\brief Checks whether `*this` is less than `rhs`.
         constexpr friend bool operator<(gap_decorator_anchor_set_iterator const & lhs,
                                         gap_decorator_anchor_set_iterator const & rhs)
         {
             return lhs.pos < rhs.pos;
         }
 
+        //!\brief Checks whether `*this` is greater than `rhs`.
         constexpr friend bool operator>(gap_decorator_anchor_set_iterator const & lhs,
                                         gap_decorator_anchor_set_iterator const & rhs)
         {
             return lhs.pos > rhs.pos;
         }
 
+        //!\brief Checks whether `*this` is less than or equal to `rhs`.
         constexpr friend bool operator<=(gap_decorator_anchor_set_iterator const & lhs,
                                          gap_decorator_anchor_set_iterator const & rhs)
         {
             return lhs.pos <= rhs.pos;
         }
 
+        //!\brief Checks whether `*this` is greater than or equal to `rhs`.
         constexpr friend bool operator>=(gap_decorator_anchor_set_iterator const & lhs,
                                          gap_decorator_anchor_set_iterator const & rhs)
         {
@@ -372,9 +379,11 @@ public:
 
     //!\brief Construct with the ungapped range type.
     template <typename other_range_t>
+    //!\cond
          requires !std::Same<other_range_t, gap_decorator_anchor_set> &&
                   std::Same<remove_cvref_t<other_range_t>, remove_cvref_t<inner_type>> &&
                   std::ranges::ViewableRange<other_range_t> // at end, otherwise it competes with the move ctor
+    //!\endcond
     gap_decorator_anchor_set(other_range_t && range) : ungapped_view{std::view::all(std::forward<inner_type>(range))}
     {} // TODO (@smehringer) only works for copyable views. Has to be changed once views are not required to be copyable anymore.
     // !\}
@@ -643,21 +652,25 @@ public:
     //!\}
 
     /*!\name Comparison operators
-     * \{
-     */
-    /*!\brief Compares two seqan3::gap_decorator_anchor_set 's by underlying sequence and gaps.
+     * \brief Compares two seqan3::gap_decorator_anchor_set 's by underlying sequence and gaps.
      * \param[in] lhs The left-hand side gap decorator to compare.
      * \param[in] rhs The right-hand side gap decorator to compare.
      * \returns A boolean flag indicating (in)equality of the aligned sequences.
      *
+     * \details
+     *
      * ### Complexity
+     *
      * Worst case: \f$O(n*\log k)\f$
      * Constant in case the decorators have not the same number of (consecutive) gaps.
      *
      * ### Exceptions
      *
      * No-throw guarantee. Does not modify the aligned sequences.
+     * \{
      */
+
+    //!\brief Checks whether `lhs` is equal to `rhs`.
     friend bool operator==(gap_decorator_anchor_set const & lhs, gap_decorator_anchor_set const & rhs) noexcept
     {
         if (lhs.size()  == rhs.size()  &&
@@ -670,12 +683,13 @@ public:
         return false;
     }
 
-    //!\copydoc operator==
+    //!\brief Checks whether `lhs` is not equal to `rhs`.
     friend bool operator!=(gap_decorator_anchor_set const & lhs, gap_decorator_anchor_set const & rhs) noexcept
     {
         return !(lhs == rhs);
     }
 
+    //!\brief Checks whether `lhs` is less than `rhs`.
     friend bool operator<(gap_decorator_anchor_set const & lhs, gap_decorator_anchor_set const & rhs) noexcept
     {
         auto lit = lhs.begin();
@@ -692,6 +706,7 @@ public:
         return *lit < *rit;
     }
 
+    //!\brief Checks whether `lhs` is less than or equal to `rhs`.
     friend bool operator<=(gap_decorator_anchor_set const & lhs, gap_decorator_anchor_set const & rhs) noexcept
     {
         auto lit = lhs.begin();
@@ -708,11 +723,13 @@ public:
         return *lit < *rit;
     }
 
+    //!\brief Checks whether `lhs` is greater than `rhs`.
     friend bool operator>(gap_decorator_anchor_set const & lhs, gap_decorator_anchor_set const & rhs) noexcept
     {
         return !(lhs <= rhs);
     }
 
+    //!\brief Checks whether `lhs` is greater than or equal to `rhs`.
     friend bool operator>=(gap_decorator_anchor_set const & lhs, gap_decorator_anchor_set const & rhs) noexcept
     {
         return !(lhs < rhs);

--- a/include/seqan3/range/detail/inherited_iterator_base.hpp
+++ b/include/seqan3/range/detail/inherited_iterator_base.hpp
@@ -56,10 +56,16 @@ public:
      * \brief All are derived from the base_t.
      * \{
      */
+
+    //!\brief The difference type.
     using difference_type       = typename std::iterator_traits<base_t>::difference_type;
+    //!\brief The value type.
     using value_type            = typename std::iterator_traits<base_t>::value_type;
+    //!\brief The reference type.
     using reference             = typename std::iterator_traits<base_t>::reference;
+    //!\brief The pointer type.
     using pointer               = typename std::iterator_traits<base_t>::pointer;
+    //!\brief The iterator category tag.
     using iterator_category     = iterator_tag_t<base_t>;
     //!\}
 
@@ -101,6 +107,8 @@ public:
      * \brief Unless specialised in derived_type, all operators perform base_t's operator and cast to derived_t.
      * \{
      */
+
+    //!\brief Checks whether `*this` is equal to `rhs`.
     constexpr bool operator==(derived_t const & rhs) const
         noexcept(noexcept(std::declval<base_t &>() == std::declval<base_t &>()))
     //!\cond
@@ -110,6 +118,7 @@ public:
         return *this_to_base() == *rhs.this_to_base();
     }
 
+    //!\brief Checks whether `*this` is not equal to `rhs`.
     constexpr bool operator!=(derived_t const & rhs) const
         noexcept(noexcept(std::declval<base_t &>() == std::declval<base_t &>()))
     //!\cond
@@ -119,6 +128,7 @@ public:
         return !(*this == rhs);
     }
 
+    //!\brief Checks whether `*this` is less than `rhs`.
     constexpr bool operator<(derived_t const & rhs) const
         noexcept(noexcept(std::declval<base_t &>() < std::declval<base_t &>()))
     //!\cond
@@ -128,6 +138,7 @@ public:
         return *this_to_base() < *rhs.this_to_base();
     }
 
+    //!\brief Checks whether `*this` is greater than `rhs`.
     constexpr bool operator>(derived_t const & rhs) const
         noexcept(noexcept(std::declval<base_t &>() > std::declval<base_t &>()))
     //!\cond
@@ -137,6 +148,7 @@ public:
         return *this_to_base() > *rhs.this_to_base();
     }
 
+    //!\brief Checks whether `*this` is less than or equal to `rhs`.
     constexpr bool operator<=(derived_t const & rhs) const
         noexcept(noexcept(std::declval<base_t &>() > std::declval<base_t &>()))
     //!\cond
@@ -146,6 +158,7 @@ public:
         return !(*this > rhs);
     }
 
+    //!\brief Checks whether `*this` is greater than or equal to `rhs`.
     constexpr bool operator>=(derived_t const & rhs) const
         noexcept(noexcept(std::declval<base_t &>() < std::declval<base_t &>()))
     //!\cond
@@ -214,7 +227,7 @@ public:
         return *this_derived();
     }
 
-    //!\brief Return a an iterator moved to the right.
+    //!\brief Returns an iterator which is advanced by `skip` positions.
     constexpr derived_t operator+(difference_type const skip) const
         noexcept(noexcept(std::declval<derived_t &>() += skip) && noexcept(derived_t{std::declval<base_t &>()}))
     //!\cond

--- a/include/seqan3/range/detail/misc.hpp
+++ b/include/seqan3/range/detail/misc.hpp
@@ -35,7 +35,6 @@ constexpr void consume(rng_t && rng)
 /*!\brief Iterate over a range (NO-OP for forward ranges).
  * \ingroup range
  * \tparam rng_t Type of the range; must satisfy std::ranges::ForwardRange.
- * \param rng The range.
  */
 template <std::ranges::ForwardRange rng_t>
 constexpr void consume(rng_t &&)

--- a/include/seqan3/range/detail/random_access_iterator.hpp
+++ b/include/seqan3/range/detail/random_access_iterator.hpp
@@ -116,6 +116,8 @@ public:
      * specialised in derived type.
      * \{
      */
+
+    //!\brief Checks whether `*this` is equal to `rhs`.
     template <typename range_type2>
     //!\cond
         requires std::is_same_v<std::remove_const_t<range_type>, std::remove_const_t<range_type2>>
@@ -125,6 +127,7 @@ public:
         return pos == rhs.pos;
     }
 
+    //!\brief Checks whether `*this` is not equal to `rhs`.
     template <typename range_type2>
     //!\cond
         requires std::is_same_v<std::remove_const_t<range_type>, std::remove_const_t<range_type2>>
@@ -134,6 +137,7 @@ public:
         return !(*this == rhs);
     }
 
+    //!\brief Checks whether `*this` is less than `rhs`.
     template <typename range_type2>
     //!\cond
         requires std::is_same_v<std::remove_const_t<range_type>, std::remove_const_t<range_type2>>
@@ -143,6 +147,7 @@ public:
         return static_cast<bool>(pos < rhs.pos);
     }
 
+    //!\brief Checks whether `*this` is greater than `rhs`.
     template <typename range_type2>
     //!\cond
         requires std::is_same_v<std::remove_const_t<range_type>, std::remove_const_t<range_type2>>
@@ -152,6 +157,7 @@ public:
         return pos > rhs.pos;
     }
 
+    //!\brief Checks whether `*this` is less than or equal to `rhs`.
     template <typename range_type2>
     //!\cond
         requires std::is_same_v<std::remove_const_t<range_type>, std::remove_const_t<range_type2>>
@@ -161,6 +167,7 @@ public:
         return pos <= rhs.pos;
     }
 
+    //!\brief Checks whether `*this` is greater than or equal to `rhs`.
     template <typename range_type2>
     //!\cond
         requires std::is_same_v<std::remove_const_t<range_type>, std::remove_const_t<range_type2>>

--- a/include/seqan3/range/view/pairwise_combine.hpp
+++ b/include/seqan3/range/view/pairwise_combine.hpp
@@ -77,10 +77,16 @@ private:
         /*!\name Associated types
          * \{
          */
+
+        //!\brief The difference type.
         using difference_type   = std::ptrdiff_t;
+        //!\brief The value type.
         using value_type        = std::tuple<underlying_val_t, underlying_val_t>;
+        //!\brief The reference type.
         using reference         = std::tuple<underlying_ref_t, underlying_ref_t>;
+        //!\brief The pointer type.
         using pointer           = void;
+        //!\brief The iterator category tag.
         using iterator_category = iterator_tag_t<underlying_iterator_type>;
         //!\}
 
@@ -289,6 +295,8 @@ private:
         //NOTE: The comparison operators should be implemented as friends, but due to a bug in gcc friend function
         // cannot yet be constrained. To avoid unexpected errors with the comparison all operators are implemented as
         // direct members and not as friends.
+
+        //!\brief Checks whether `*this` is equal to `rhs`.
         template <typename other_range_type>
         //!\cond
             requires std::EqualityComparableWith<underlying_iterator_type, std::ranges::iterator_t<other_range_type>> &&
@@ -300,6 +308,7 @@ private:
             return std::tie(first_it, second_it) == std::tie(rhs.first_it, rhs.second_it);
         }
 
+        //!\brief Checks whether `*this` is not equal to `rhs`.
         template <typename other_range_type>
         //!\cond
             requires std::EqualityComparableWith<underlying_iterator_type, std::ranges::iterator_t<other_range_type>> &&
@@ -311,6 +320,7 @@ private:
             return !(*this == rhs);
         }
 
+        //!\brief Checks whether `*this` is less than `rhs`.
         template <typename other_range_type>
         //!\cond
             requires std::StrictTotallyOrderedWith<underlying_iterator_type,
@@ -323,6 +333,7 @@ private:
             return std::tie(first_it, second_it) < std::tie(rhs.first_it, rhs.second_it);
         }
 
+        //!\brief Checks whether `*this` is greater than `rhs`.
         template <typename other_range_type>
         //!\cond
             requires std::StrictTotallyOrderedWith<underlying_iterator_type,
@@ -336,6 +347,7 @@ private:
             return std::tie(first_it, second_it) > std::tie(rhs.first_it, rhs.second_it);
         }
 
+        //!\brief Checks whether `*this` is less than or equal to `rhs`.
         template <typename other_range_type>
         //!\cond
             requires std::StrictTotallyOrderedWith<underlying_iterator_type,
@@ -348,6 +360,7 @@ private:
             return std::tie(first_it, second_it) <= std::tie(rhs.first_it, rhs.second_it);
         }
 
+        //!\brief Checks whether `*this` is greater than or equal to `rhs`.
         template <typename other_range_type>
         //!\cond
             requires std::StrictTotallyOrderedWith<underlying_iterator_type,
@@ -420,8 +433,10 @@ private:
 
 public:
 
-    //!\name Associated types
-    //!\{
+    /*!\name Associated types
+     * \{
+     */
+
     //!\brief The iterator type.
     using iterator          = iterator_type<underlying_range_type>;
     //!\brief The const iterator type. Evaluates to void if the underlying range is not const iterable.

--- a/include/seqan3/range/view/repeat.hpp
+++ b/include/seqan3/range/view/repeat.hpp
@@ -267,6 +267,7 @@ public:
         return *single_value.begin();
     }
 
+    //!\copydoc operator[]()
     constexpr reference operator[](difference_type const SEQAN3_DOXYGEN_ONLY(n)) noexcept
     {
         return *single_value.begin();

--- a/include/seqan3/range/view/take.hpp
+++ b/include/seqan3/range/view/take.hpp
@@ -230,7 +230,7 @@ private:
             return rhs == lhs;
         }
 
-        //!\brief Checks whether `*this` is equal to `rhs`.
+        //!\brief Checks whether `*this` is not equal to `rhs`.
         constexpr bool operator!=(sentinel_type const & rhs) const
             noexcept(noexcept(std::declval<iterator_type &>() == rhs))
         {

--- a/include/seqan3/range/view/take.hpp
+++ b/include/seqan3/range/view/take.hpp
@@ -108,10 +108,16 @@ private:
          * \brief All are derived from the base_base_t.
          * \{
          */
+
+        //!\brief The difference type.
         using difference_type       = typename std::iterator_traits<base_base_t>::difference_type;
+        //!\brief The value type.
         using value_type            = typename std::iterator_traits<base_base_t>::value_type;
+        //!\brief The reference type.
         using reference             = typename std::iterator_traits<base_base_t>::reference;
+        //!\brief The pointer type.
         using pointer               = typename std::iterator_traits<base_base_t>::pointer;
+        //!\brief The iterator category tag.
         using iterator_category     = iterator_tag_t<base_base_t>;
         //!\}
 
@@ -119,6 +125,8 @@ private:
          * \brief seqan3::detail::inherited_iterator_base operators are used unless specialised here.
          * \{
          */
+
+        //!\brief Increments the iterator by one.
         constexpr iterator_type & operator++() noexcept(noexcept(++std::declval<base_t &>()))
         {
             base_t::operator++();
@@ -126,6 +134,7 @@ private:
             return *this;
         }
 
+        //!\brief Returns an iterator incremented by one.
         constexpr iterator_type operator++(int) noexcept(noexcept(++std::declval<iterator_type &>()) &&
                                                std::is_nothrow_copy_constructible_v<iterator_type>)
         {
@@ -134,6 +143,7 @@ private:
             return cpy;
         }
 
+        //!\brief Decrements the iterator by one.
         constexpr iterator_type & operator--() noexcept(noexcept(--std::declval<base_base_t &>()))
         //!\cond
             requires std::BidirectionalIterator<base_base_t>
@@ -144,6 +154,7 @@ private:
             return *this;
         }
 
+        //!\brief Returns an iterator decremented by one.
         constexpr iterator_type operator--(int) noexcept(noexcept(--std::declval<iterator_type &>()) &&
                                                std::is_nothrow_copy_constructible_v<iterator_type>)
         //!\cond
@@ -155,6 +166,7 @@ private:
             return cpy;
         }
 
+        //!\brief Advances the iterator by skip positions.
         constexpr iterator_type & operator+=(difference_type const skip) noexcept(noexcept(std::declval<base_t &>() += skip))
         //!\cond
             requires std::RandomAccessIterator<base_base_t>
@@ -165,6 +177,7 @@ private:
             return *this;
         }
 
+        //!\brief Advances the iterator by -skip positions.
         constexpr iterator_type & operator-=(difference_type const skip) noexcept(noexcept(std::declval<base_t &>() -= skip))
         //!\cond
             requires std::RandomAccessIterator<base_base_t>
@@ -180,6 +193,8 @@ private:
          * \brief We define comparison against self and against the sentinel.
          * \{
          */
+
+        //!\brief Checks whether `*this` is equal to `rhs`.
         constexpr bool operator==(iterator_type const & rhs) const
             noexcept(!or_throw && noexcept(std::declval<base_base_t &>() == std::declval<base_base_t &>()))
         //!\cond
@@ -189,6 +204,7 @@ private:
             return *base_t::this_to_base() == *rhs.this_to_base();
         }
 
+        //!\copydoc operator==()
         constexpr bool operator==(sentinel_type const & rhs) const
             noexcept(!or_throw && noexcept(std::declval<base_base_t &>() == std::declval<sentinel_type &>()))
         {
@@ -208,17 +224,20 @@ private:
             }
         }
 
+        //!\brief Checks whether `lhs` is equal to `rhs`.
         constexpr friend bool operator==(sentinel_type const & lhs, iterator_type const & rhs) noexcept(noexcept(rhs == lhs))
         {
             return rhs == lhs;
         }
 
+        //!\brief Checks whether `*this` is equal to `rhs`.
         constexpr bool operator!=(sentinel_type const & rhs) const
             noexcept(noexcept(std::declval<iterator_type &>() == rhs))
         {
             return !(*this == rhs);
         }
 
+        //!\copydoc operator!=()
         constexpr bool operator!=(iterator_type const & rhs) const
             noexcept(noexcept(std::declval<iterator_type &>() == rhs))
         //!\cond
@@ -228,6 +247,7 @@ private:
             return !(*this == rhs);
         }
 
+        //!\brief Checks whether `lhs` is not equal to `rhs`.
         constexpr friend bool operator!=(sentinel_type const & lhs, iterator_type const & rhs) noexcept(noexcept(rhs != lhs))
         {
             return rhs != lhs;
@@ -237,6 +257,11 @@ private:
         /*!\name Reference/Dereference operators
          * \brief seqan3::detail::inherited_iterator_base operators are used unless specialised here.
          * \{
+         */
+
+        /*!\brief Accesses an element by index.
+         * \param n Position relative to current location.
+         * \return A reference to the element at relative location.
          */
         constexpr reference operator[](std::make_unsigned_t<difference_type> const n) const
             noexcept(noexcept(std::declval<base_base_t &>()[0]))

--- a/include/seqan3/range/view/take_until.hpp
+++ b/include/seqan3/range/view/take_until.hpp
@@ -119,10 +119,16 @@ private:
          * \brief All are derived from the base_base_t.
          * \{
          */
+
+        //!\brief The difference type.
         using difference_type       = typename std::iterator_traits<base_base_t>::difference_type;
+        //!\brief The value type.
         using value_type            = typename std::iterator_traits<base_base_t>::value_type;
+        //!\brief The reference type.
         using reference             = typename std::iterator_traits<base_base_t>::reference;
+        //!\brief The pointer type.
         using pointer               = typename std::iterator_traits<base_base_t>::pointer;
+        //!\brief The iterator category tag.
         using iterator_category     = iterator_tag_t<base_base_t>;
         //!\}
 


### PR DESCRIPTION
This PR improves the SeqAn documentation in the range module and removes all 134 warnings from the doxygen build.