### PR TITLE
[FEATURE?] Only one build per branch concurrently

### DIFF
--- a/.jenkinsfile
+++ b/.jenkinsfile
@@ -4,9 +4,11 @@ import hudson.triggers.TimerTrigger;
 // Global properties
 // ============================================================================
 
+// Only one build at a time for each branch/PR
 // Start build every night between 1:00-4:59
 // Keep only last 10 builds
 properties([
+    disableConcurrentBuilds(),
     pipelineTriggers(
         [cron(env.BRANCH_NAME == 'master' ? 'H H(1-4) * * *' : '')]
     ),


### PR DESCRIPTION
Hopefully fixes daily crashes of the Docker server.

Alternative is to cancel the old running job:
https://stackoverflow.com/questions/46041579/jenkins-pipeline-milestone-not-cancelling-previous-ongoing-build/48956042#48956042