### PR TITLE
[HOTFIX] unbreak master; forgot to change remote for cereal

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/ericniebler/range-v3
 [submodule "cereal"]
 	path = submodules/cereal
-	url = https://github.com/USCiLab/cereal
+	url = https://github.com/h-2/cereal
 [submodule "lemon"]
 	path = submodules/lemon
 	url = https://github.com/seqan/lemon


### PR DESCRIPTION
I am not sure why we didn't detect this in travis. Is travis built without cereal in general?