### PR TITLE
[FEATURE] add forwards for edit_distance

### DIFF
--- a/include/seqan3/alignment/pairwise/edit_distance_fwd.hpp
+++ b/include/seqan3/alignment/pairwise/edit_distance_fwd.hpp
@@ -1,0 +1,68 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Forwards for seqan3::edit_distance_unbanded related types.
+ * \author Marcel Ehrhardt <marcel.ehrhardt AT fu-berlin.de>
+*/
+
+#pragma once
+
+#include <seqan3/core/platform.hpp>
+#include <seqan3/std/concepts>
+#include <seqan3/std/ranges>
+
+namespace seqan3::detail
+{
+/*!\todo Document me
+ * \ingroup pairwise_alignment
+ */
+template <typename traits_type>
+SEQAN3_CONCEPT EditDistanceTrait = requires
+{
+    typename std::remove_reference_t<traits_type>::word_type;
+    typename std::remove_reference_t<traits_type>::is_semi_global_type;
+
+    // Must be a boolean integral constant.
+    requires std::Same<typename std::remove_reference_t<traits_type>::is_semi_global_type::value_type, bool>;
+};
+
+/*!\brief The default traits type for the edit distance algorithm.
+ * \ingroup pairwise_alignment
+ */
+struct default_edit_distance_trait_type
+{
+    //!\brief The default word type.
+    using word_type = uint64_t;
+    //!\brief Semi global alignment is disabled by default.
+    using is_semi_global_type = std::false_type;
+};
+
+//!\brief Store no state for state_t.
+template <typename state_t>
+struct empty_state
+{};
+
+//!\brief If enabled is true state_t will be added to state_type.
+template <bool enabled, typename state_t>
+using enable_state_t = std::conditional_t<enabled, state_t, empty_state<state_t>>;
+
+//!\cond
+template <std::ranges::ViewableRange database_t,
+          std::ranges::ViewableRange query_t,
+          typename align_config_t,
+          EditDistanceTrait traits_t = default_edit_distance_trait_type>
+class pairwise_alignment_edit_distance_unbanded; //forward declaration
+
+template <typename word_t, typename score_t, bool is_semi_global, bool use_max_errors>
+class edit_distance_score_matrix_full; //forward declaration
+
+template <typename word_t, bool is_semi_global, bool use_max_errors>
+class edit_distance_trace_matrix_full; //forward declaration
+//!\endcond
+
+} // namespace seqan3::detail

--- a/include/seqan3/alignment/pairwise/edit_distance_unbanded.hpp
+++ b/include/seqan3/alignment/pairwise/edit_distance_unbanded.hpp
@@ -25,6 +25,7 @@
 #include <seqan3/alignment/matrix/alignment_trace_matrix.hpp>
 #include <seqan3/alignment/pairwise/align_result_selector.hpp>
 #include <seqan3/alignment/pairwise/alignment_result.hpp>
+#include <seqan3/alignment/pairwise/edit_distance_fwd.hpp>
 #include <seqan3/core/algorithm/configuration.hpp>
 #include <seqan3/range/shortcuts.hpp>
 #include <seqan3/std/ranges>
@@ -39,30 +40,6 @@ SEQAN3_CONCEPT MaxErrors = requires (align_config_t & cfg)
 };
 //!\endcond
 
-/*!\todo Document me
- * \ingroup pairwise_alignment
- */
-template <typename traits_type>
-SEQAN3_CONCEPT EditDistanceTrait = requires
-{
-    typename std::remove_reference_t<traits_type>::word_type;
-    typename std::remove_reference_t<traits_type>::is_semi_global_type;
-
-    // Must be a boolean integral constant.
-    requires std::Same<typename std::remove_reference_t<traits_type>::is_semi_global_type::value_type, bool>;
-};
-
-/*!\brief The default traits type for the edit distance algorithm.
- * \ingroup pairwise_alignment
- */
-struct default_edit_distance_trait_type
-{
-    //!\brief The default word type.
-    using word_type = uint64_t;
-    //!\brief Semi global alignment is disabled by default.
-    using is_semi_global_type = std::false_type;
-};
-
 /*!\brief This calculates an alignment using the edit distance and without a band.
  * \ingroup pairwise_alignment
  * \tparam database_t     \copydoc pairwise_alignment_edit_distance_unbanded::database_type
@@ -72,7 +49,7 @@ struct default_edit_distance_trait_type
 template <std::ranges::ViewableRange database_t,
           std::ranges::ViewableRange query_t,
           typename align_config_t,
-          EditDistanceTrait traits_t = default_edit_distance_trait_type>
+          EditDistanceTrait traits_t>
 class pairwise_alignment_edit_distance_unbanded
 {
     /*!\name Befriended classes


### PR DESCRIPTION
Only a small PR that extracts some declarations / definitions out of a file. This is needed, because a next PR will introduce a score and trace matrix class, which need a forward declaration of  the edit distance algorithm.