### PR TITLE
[FIX] make view::take consume also at the very beginning.

### DIFF
--- a/include/seqan3/range/view/take_until.hpp
+++ b/include/seqan3/range/view/take_until.hpp
@@ -235,17 +235,18 @@ private:
         //!\brief Defaulted.
         ~iterator_type_consume_input()                                                             = default;
 
-        //!\brief Constructor that delegates to the CRTP layer.
-        iterator_type_consume_input(base_base_t it) noexcept(noexcept(base_t{it})) :
-            base_t{std::move(it)}
-        {}
-
         //!\brief Constructor that delegates to the CRTP layer and initialises the callable.
         iterator_type_consume_input(base_base_t it,
                                     fun_ref_t _fun,
                                     sentinel_type sen) noexcept(noexcept(base_t{it})) :
             base_t{std::move(it)}, fun{_fun}, stored_end{std::move(sen)}
-        {}
+        {
+            if ((*this->this_to_base() != stored_end) && fun(**this))
+            {
+                at_end_gracefully = true;
+                ++(*this);
+            }
+        }
         //!\}
 
         /*!\name Associated types

--- a/test/unit/range/view/view_take_line_test.cpp
+++ b/test/unit/range/view/view_take_line_test.cpp
@@ -109,6 +109,15 @@ TEST(view_take_line, no_eol)
     EXPECT_EQ("foo", v);
 }
 
+TEST(view_take_line, eol_at_first_position)
+{
+    using sbt = std::istreambuf_iterator<char>;
+    std::istringstream vec{"\n\nfoo"};
+    auto stream_view = std::ranges::subrange<decltype(sbt{vec}), decltype(sbt{})> {sbt{vec}, sbt{}};
+    EXPECT_EQ("", std::string(stream_view | view::take_line));
+    EXPECT_EQ("foo", std::string(stream_view | view::take_line));
+}
+
 TEST(view_take_line, concepts)
 {
     do_concepts(view::take_line);


### PR DESCRIPTION
Resolves #950