### PR TITLE
[FEATURE] Adds magic_header to disambiguate compression streams.

### DIFF
--- a/include/seqan3/io/detail/magic_header.hpp
+++ b/include/seqan3/io/detail/magic_header.hpp
@@ -82,7 +82,7 @@ struct bgzf_compression
  * Specialises seqan3::detail::magic_header for seqan3::detail::bgzf_compression.
  */
 template <>
-inline constexpr std::array<int8_t, 18 > magic_header<bgzf_compression>
+inline constexpr std::array<int8_t, 18> magic_header<bgzf_compression>
 {
 //  ID1                              ID2                              CM
     magic_header<gz_compression>[0], magic_header<gz_compression>[1], magic_header<gz_compression>[2],

--- a/include/seqan3/io/detail/magic_header.hpp
+++ b/include/seqan3/io/detail/magic_header.hpp
@@ -1,0 +1,95 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides seqan3::detail::magic_header.
+ * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <array>
+
+#include <seqan3/core/platform.hpp>
+
+namespace seqan3::detail
+{
+
+//!\brief Defines a magic byte sequence to disambiguate different compression formats. Default is empty.
+//!\ingroup io
+template <typename header_tag_t>
+inline constexpr std::array<int8_t, 0> magic_header{};
+
+//!\brief A tag signifying a gz compressed file.
+//!\ingroup io
+struct gz_compression
+{};
+
+/*!\brief The magic byte sequence to disambiguate gz compressed files.
+ * \ingroup io
+ *
+ * \details
+ *
+ * Specialises seqan3::detail::magic_header for seqan3::detail::gz_compression.
+ */
+template <>
+inline constexpr std::array<int8_t, 3> magic_header<gz_compression>{'\x1f', '\x8b', '\x08'};
+
+//!\brief A tag signifying a bz2 compressed file.
+//!\ingroup io
+struct bz2_compression
+{};
+
+/*!\brief The magic byte sequence to disambiguate bz2 compressed files.
+ * \ingroup io
+ *
+ * \details
+ *
+ * Specialises seqan3::detail::magic_header for seqan3::detail::bz2_compression.
+ */
+template <>
+inline constexpr std::array<int8_t, 3> magic_header<bz2_compression>{'\x42', '\x5a', '\x68'};
+
+//!\brief A tag signifying a zstd compressed file.
+//!\ingroup io
+struct zstd_compression
+{};
+
+/*!\brief The magic byte sequence to disambiguate zstd compressed files.
+ * \ingroup io
+ *
+ * \details
+ *
+ * Specialises seqan3::detail::magic_header for seqan3::detail::zstd_compression.
+ */
+template <>
+inline constexpr std::array<int8_t, 4> magic_header<zstd_compression>{'\x28', '\xb5', '\x2f', '\xfd'};
+
+//!\brief A tag signifying a bgzf compressed file.
+//!\ingroup io
+struct bgzf_compression
+{};
+
+/*!\brief The magic byte sequence to disambiguate bgzf compressed files.
+ * \ingroup io
+ *
+ * \details
+ *
+ * Specialises seqan3::detail::magic_header for seqan3::detail::bgzf_compression.
+ */
+template <>
+inline constexpr std::array<int8_t, 18 > magic_header<bgzf_compression>
+{
+//  ID1                              ID2                              CM
+    magic_header<gz_compression>[0], magic_header<gz_compression>[1], magic_header<gz_compression>[2],
+//  FLG     [MTIME                       ]  XFL     OS      [XLEN        ]
+    '\x04', '\x00', '\x00', '\x00', '\x00', '\x00', '\xff', '\x06', '\x00',
+//  B       C       [SLEN        ]  [BSIZE       ]
+    '\x42', '\x43', '\x02', '\x00', '\x00', '\x00'
+};
+
+} // namespace seqan3::detail

--- a/include/seqan3/io/detail/misc_input.hpp
+++ b/include/seqan3/io/detail/misc_input.hpp
@@ -23,6 +23,7 @@
 #ifdef SEQAN3_HAS_ZLIB
     #include <seqan3/contrib/stream/gz_istream.hpp>
 #endif
+#include <seqan3/io/detail/magic_header.hpp>
 #include <seqan3/std/concepts>
 #include <seqan3/std/filesystem>
 #include <seqan3/std/ranges>
@@ -97,7 +98,7 @@ inline auto make_secondary_istream(std::basic_istream<char_t> & primary_stream, 
     std::string const extension = filename.extension().string();
 
     // set return value appropriately
-    if (starts_with(magic_number, std::array{'\x1f', '\x8b', '\x08'})) // GZIP
+    if (starts_with(magic_number, magic_header<gz_compression>)) // GZIP
     {
     #ifdef SEQAN3_HAS_ZLIB
         if ((extension == ".gz") || (extension == ".bgzf"))
@@ -108,7 +109,7 @@ inline auto make_secondary_istream(std::basic_istream<char_t> & primary_stream, 
         throw file_open_error{"Trying to read from a gzipped file, but no ZLIB available."};
     #endif
     }
-    else if (starts_with(magic_number, std::array{'\x42', '\x5a', '\x68'})) // BZip2
+    else if (starts_with(magic_number, magic_header<bz2_compression>)) // BZip2
     {
     #ifdef SEQAN3_HAS_BZIP2
         if (extension == ".bz2")
@@ -119,7 +120,7 @@ inline auto make_secondary_istream(std::basic_istream<char_t> & primary_stream, 
         throw file_open_error{"Trying to read from a bzipped file, but no libbz2 available."};
     #endif
     }
-    else if (starts_with(magic_number, std::array{'\x28', '\xb5', '\x2f', '\xfd'})) // ZStd
+    else if (starts_with(magic_number, magic_header<zstd_compression>)) // ZStd
     {
         throw file_open_error{"Trying to read from a zst'ed file, but SeqAn does not yet support this."};
     }


### PR DESCRIPTION
This adds magic header variables for our compression streams. The main reason why we need this is that we need to access the bgzf header at multiple places. Hence, it is safer to bring it into a global variable. Since it would be weird to have this only for bgzf_compression but not the others, I decided to add it for all compression formats. 