### PR TITLE
Alphabet refactorisation (almost last PR)

### DIFF
--- a/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
+++ b/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
@@ -193,7 +193,7 @@ namespace seqan3
 template <typename t>
 SEQAN3_CONCEPT AlignedSequence =
     std::ranges::ForwardRange<t> &&
-    Alphabet<value_type_t<t>> &&
+    Alphabet<reference_t<t>> &&
     WeaklyAssignable<reference_t<t>, gap const &> &&
     requires { typename detail::unaligned_seq_t<t>; } &&
     requires (t v, detail::unaligned_seq_t<t> unaligned)

--- a/include/seqan3/alphabet/all.hpp
+++ b/include/seqan3/alphabet/all.hpp
@@ -36,17 +36,11 @@
  * for qualities, RNA structures and alignment gaps. In addition there are templates for combining alphabet
  * types into new alphabets, and wrappers for existing data types like the canonical `char`.
  *
- * To be included into the alphabet module, an alphabet must satisfy the generic seqan3::Alphabet
- * documented below. While this only encompasses a minimum set of requirements, many of our alphabets provide
- * more features and there are more refined concepts. The inheritance diagram of seqan3::Alphabet gives
- * a detailed overview. A more basic overview of this module and it's submodules is available in the collaboration
- * diagram at the top of this page.
+ * In addition to concrete alphabet types, SeqAn provides multiple *concepts* that describe groups of alphabets
+ * by their properties and can be used to *constrain* templates so that they only work with certain alphabet types.
+ * See the \link tutorial_concepts Tutorial on Concepts \endlink for a gentle introduction to the topic.
  *
- * # The alphabet concept
- *
- * The seqan3::Alphabet defines the requirements a type needs to meet to be considered an alphabet
- * by SeqAn, or in other words: you can expect certain properties and functions to be defined on
- * all data types we call an alphabet.
+ * # The alphabet concepts
  *
  * ### Alphabet size
  *
@@ -79,25 +73,19 @@
  *
  * \snippet test/snippet/alphabet/all.cpp ambiguity
  *
- * To solve this problem, every alphabet defines two interfaces:
+ * To solve this problem, alphabets in SeqAn define two interfaces:
  *
  *   1. a **rank based interface** with
- *     * the \link seqan3::alphabet_rank_t underlying rank type \endlink able to represent this alphabet numerically;
- *       this type must be able to represent the numbers from `0` to `alphabet size - 1` (often `uint8_t`, but
- *       sometimes a larger unsigned integral type);
- *     * a \link seqan3::to_rank to_rank \endlink function to produce the numerical representation;
- *     * an \link seqan3::assign_rank_to assign_rank \endlink function to assign from the numerical
- *       representation;
+ *     * seqan3::to_rank to produce the numerical representation;
+ *     * seqan3::assign_rank_to to assign from the numerical representation;
+ *     * the numerical representation is an unsigned integral type like `size_t`; the exact type can be retrieved via
+ *       the seqan3::alphabet_rank_t.
  *   2. a **character based interface** with
- *     * the \link seqan3::alphabet_char_t underlying character type \endlink able to represent this alphabet visually
- *       (almost always `char`, but could be `char16_t` or `char32_t`, as well)
- *     * a \link seqan3::to_char to_char \endlink function to produce the visual representation;
- *     * an \link seqan3::assign_char_to assign_char \endlink function to assign from the visual
- *       representation;
- *     * a \link seqan3::char_is_valid_for char_is_valid_for \endlink function that checks whether
- *       a character value has a one-to-one mapping to an alphabet value;
- *     * an \link seqan3::assign_char_strictly_to assign_char_strict \endlink function to assign a
- *       characters while verifying its validity.
+ *     * seqan3::to_char to produce the visual representation;
+ *     * seqan3::assign_char_to to assign from the visual representation;
+ *     * seqan3::char_is_valid_for that checks whether a character value has a one-to-one mapping to an alphabet value;
+ *     * the visual representation is a character type (almost always `char`, but could be `char16_t` or `char32_t`,
+ *       as well); the exact type can be retrieved via seqan3::alphabet_char_t.
  *
  * To prevent the aforementioned ambiguity, you can neither assign from rank or char representation via `operator=`,
  * nor can you cast the alphabet to either of it's representation forms, **you need to explicitly use the
@@ -119,9 +107,36 @@
  *
  * Note, however, that literals **are not** required by the concept.
  *
- * <small>In the documentation you will also encounter seqan3::Semialphabet. It describes "one half" of an
- * alphabet and only defines the rank interface as a type requirement. It is mainly used internally and not
- * relevant to most users of SeqAn.</small>
+ * ### Different concepts
+ *
+ * All types that have valid implementations of the functions/functors described above model the concept
+ * seqan3::WritableAlphabet. This is the strongest (i.e. most refined) *general case* concept.
+ * There are more refined concepts for specific biological applications (like seqan3::NucleotideAlphabet), and there are
+ * less refined concepts that only model part of an alphabet:
+ *
+ *   * seqan3::Semialphabet and derived concepts only require the rank interface;
+ *   * seqan3::Alphabet (without `Writable*`) and derived concepts only require readability and not assignability.
+ *
+ * Typically you will use seqan3::Alphabet in "read-only" situations (e.g. `const` parameters) and
+ * seqan3::WritableAlphabet whenever the values might be changed.
+ * Semi-alphabets are less useful in application code.
+ *
+ * |                                  | seqan3::Semialphabet | seqan3::WritableSemialphabet | seqan3::Alphabet | seqan3::WritableAlphabet | Aux |
+ * |----------------------------------|:--------------------:|:----------------------------:|:----------------:|:------------------------:|:---:|
+ * | seqan3::alphabet_size_v          | ✅                    | ✅                            | ✅                | ✅                        |     |
+ * | seqan3::to_rank                  | ✅                    | ✅                            | ✅                | ✅                        |     |
+ * | seqan3::alphabet_rank_t          | ✅                    | ✅                            | ✅                | ✅                        |  🔗 |
+ * | seqan3::assign_rank_to           |                      | ✅                            |                  | ✅                        |     |
+ * | seqan3::to_char                  |                      |                              | ✅                | ✅                        |     |
+ * | seqan3::alphabet_char_t          |                      |                              | ✅                | ✅                        |  🔗 |
+ * | seqan3::assign_char_to           |                      |                              |                  | ✅                        |     |
+ * | seqan3::char_is_valid_for        |                      |                              |                  | ✅                        |     |
+ * | seqan3::assign_char_strictly_to  |                      |                              |                  | ✅                        |  🔗 |
+ *
+ * The above table shows all alphabet concepts and related functions and type traits.
+ * The entities marked as "auxiliary" provide shortcuts to the other "essential" entitities.
+ * This difference is only relevant if you want to create your own alphabet (you do not need to provide an
+ * implementation for the "auxiliary" entities, they are provided automatically).
  *
  * ### Members VS free/global functions
  *

--- a/include/seqan3/alphabet/aminoacid/aa10li.hpp
+++ b/include/seqan3/alphabet/aminoacid/aa10li.hpp
@@ -23,9 +23,11 @@ namespace seqan3
 /*!\brief The reduced Li amino acid alphabet.
  * \ingroup aminoacid
  * \implements seqan3::AminoacidAlphabet
- * \implements seqan3::detail::ConstexprAlphabet
+ * \implements seqan3::WritableAlphabet
+ * \if DEV \implements seqan3::detail::WritableConstexprAlphabet \endif
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
+ * \implements std::Regular
  *
  * \details
  * The alphabet consists of letters A, B, C, F, G, H, I, J, K, P

--- a/include/seqan3/alphabet/aminoacid/aa10murphy.hpp
+++ b/include/seqan3/alphabet/aminoacid/aa10murphy.hpp
@@ -24,9 +24,11 @@ namespace seqan3
 /*!\brief The reduced Murphy amino acid alphabet.
  * \ingroup aminoacid
  * \implements seqan3::AminoacidAlphabet
- * \implements seqan3::detail::ConstexprAlphabet
+ * \implements seqan3::WritableAlphabet
+ * \if DEV \implements seqan3::detail::WritableConstexprAlphabet \endif
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
+ * \implements std::Regular
  *
  * \details
  * The alphabet consists of letters A, B, C, F, G, H, I, K, P, S

--- a/include/seqan3/alphabet/aminoacid/aa20.hpp
+++ b/include/seqan3/alphabet/aminoacid/aa20.hpp
@@ -24,9 +24,11 @@ namespace seqan3
 /*!\brief The canonical amino acid alphabet.
  * \ingroup aminoacid
  * \implements seqan3::AminoacidAlphabet
- * \implements seqan3::detail::ConstexprAlphabet
+ * \implements seqan3::WritableAlphabet
+ * \if DEV \implements seqan3::detail::WritableConstexprAlphabet \endif
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
+ * \implements std::Regular
  *
  * \details
  * The alphabet consists of letters A, C, D, E, F, G, H, I, K, L, M, N, P, Q, R, S, T, V, W, Y

--- a/include/seqan3/alphabet/aminoacid/aa27.hpp
+++ b/include/seqan3/alphabet/aminoacid/aa27.hpp
@@ -23,9 +23,11 @@ namespace seqan3
 /*!\brief The twenty-seven letter amino acid alphabet.
  * \ingroup aminoacid
  * \implements seqan3::AminoacidAlphabet
- * \implements seqan3::detail::ConstexprAlphabet
+ * \implements seqan3::WritableAlphabet
+ * \if DEV \implements seqan3::detail::WritableConstexprAlphabet \endif
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
+ * \implements std::Regular
  *
  * \details
  * The alphabet consists of letters A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X,

--- a/include/seqan3/alphabet/aminoacid/translation.hpp
+++ b/include/seqan3/alphabet/aminoacid/translation.hpp
@@ -125,7 +125,7 @@ constexpr aa27 translate_triplet(tuple_type const & input_tuple) noexcept
 */
 template <genetic_code gc = genetic_code::CANONICAL, std::ranges::InputRange range_type>
     //!\cond
-    requires NucleotideAlphabet<std::decay_t<reference_t<std::decay_t<range_type>>>>
+    requires NucleotideAlphabet<reference_t<std::decay_t<range_type>>>
     //!\endcond
 constexpr aa27 translate_triplet(range_type && input_range)
 {
@@ -159,7 +159,7 @@ constexpr aa27 translate_triplet(range_type && input_range)
 */
 template <genetic_code gc = genetic_code::CANONICAL, std::ranges::RandomAccessRange range_type>
 //!\cond
-    requires NucleotideAlphabet<std::decay_t<reference_t<std::decay_t<range_type>>>>
+    requires NucleotideAlphabet<reference_t<std::decay_t<range_type>>>
 //!\endcond
 constexpr aa27 translate_triplet(range_type && input_range)
 {

--- a/include/seqan3/alphabet/cigar/cigar_op.hpp
+++ b/include/seqan3/alphabet/cigar/cigar_op.hpp
@@ -23,6 +23,11 @@ namespace seqan3
 
 /*!\brief The (extended) cigar operation alphabet of M,D,I,H,N,P,S,X,=.
  * \ingroup cigar
+ * \implements seqan3::WritableAlphabet
+ * \if DEV \implements seqan3::detail::WritableConstexprAlphabet \endif
+ * \implements seqan3::TriviallyCopyable
+ * \implements seqan3::StandardLayout
+ * \implements std::Regular
  *
  * \details
  *

--- a/include/seqan3/alphabet/composite/alphabet_tuple_base.hpp
+++ b/include/seqan3/alphabet/composite/alphabet_tuple_base.hpp
@@ -144,18 +144,23 @@ decltype(auto) get();
 
 /*!\brief The CRTP base for a combined alphabet that contains multiple values of different alphabets at the same time.
  * \ingroup composite
- * \implements seqan3::Semialphabet
- * \implements seqan3::detail::ConstexprSemialphabet
- * \tparam first_component_type Type of the first letter; must model seqan3::Semialphabet.
- * \tparam component_types      Types of further letters (up to 4); must model seqan3::Semialphabet.
+ * \implements seqan3::WritableSemialphabet
+ * \if DEV
+ * \implements seqan3::detail::ConstexprWritableSemialphabet
+ * \tparam component_types Types of letters; must model seqan3::detail::WritableConstexprSemialphabet.
+ * \else
+ * \tparam component_types Types of letters; must model seqan3::WritableSemialphabet and all required function calls
+ * need to be callable in `constexpr`-context.
+ * \endif
  *
- * This data structure is CRTP base class for combined alphabets, where the different
- * alphabet letters exist independently as component_list, similar to a tuple.
+ *
+ * This data structure is a CRTP base class for combined alphabets, where the different
+ * alphabet letters exist independently as a components, similar to a tuple.
  *
  * Short description:
- *   * combines multiple alphabets as independent component_list, similar to a tuple;
+ *   * combines multiple alphabets as independent components, similar to a tuple;
  *   * models seqan3::tuple_like_concept, i.e. provides a get interface to its component_list;
- *   * is itself a seqan3::Semialphabet, but most derived types implement the full seqan3::Alphabet;
+ *   * is itself a seqan3::WritableSemialphabet, but most derived types implement the full seqan3::WritableAlphabet;
  *   * its alphabet size is the product of the individual sizes;
  *   * constructible, assignable and comparable with each component type and also all types that
  *     these are constructible/assignable/comparable with;
@@ -177,7 +182,8 @@ decltype(auto) get();
 template <typename derived_type,
           typename ...component_types>
 //!\cond
-    requires (detail::ConstexprSemialphabet<component_types> && ...)
+    requires (detail::WritableConstexprSemialphabet<component_types> && ...) &&
+             (!std::is_reference_v<component_types> && ...)
 //!\endcond
 class alphabet_tuple_base :
     public alphabet_base<derived_type,

--- a/include/seqan3/alphabet/composite/alphabet_variant.hpp
+++ b/include/seqan3/alphabet/composite/alphabet_variant.hpp
@@ -140,10 +140,16 @@ namespace seqan3
 
 /*!\brief A combined alphabet that can hold values of either of its alternatives.
  * \ingroup composite
- * \tparam ...alternative_types Types of possible values (at least 2); all must model seqan3::Alphabet and be
- *                              unique.
- * \implements seqan3::Alphabet
- * \implements seqan3::detail::ConstexprAlphabet
+ * \if DEV
+ * \tparam ...alternative_types Types of possible values (at least 2); all must model
+ *                              seqan3::detail::WritableConstexprAlphabet, not be references and be unique.
+ * \implements seqan3::detail::WritableConstexprAlphabet
+ * \else
+ * \tparam ...alternative_types Types of possible values (at least 2); all must model seqan3::WritableAlphabet,
+ *                              must not be references and must be unique; all required functions for
+ *                              seqan3::WritableAlphabet need to be callable in a `constexpr`-context.
+ * \endif
+ * \implements seqan3::WritableAlphabet
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
 
@@ -169,7 +175,8 @@ namespace seqan3
  */
 template <typename ...alternative_types>
 //!\cond
-    requires (detail::ConstexprAlphabet<alternative_types> && ...) &&
+    requires (detail::WritableConstexprAlphabet<alternative_types> && ...) &&
+             (!std::is_reference_v<alternative_types> && ...) &&
              (sizeof...(alternative_types) >= 2)
              //TODO same char_type
 //!\endcond

--- a/include/seqan3/alphabet/composite/detail.hpp
+++ b/include/seqan3/alphabet/composite/detail.hpp
@@ -160,7 +160,8 @@ namespace seqan3
 // forward
 template <typename ...alternative_types>
 //!\cond
-    requires (detail::ConstexprAlphabet<alternative_types> && ...) &&
+    requires (detail::WritableConstexprAlphabet<alternative_types> && ...) &&
+             (!std::is_reference_v<alternative_types> && ...) &&
              (sizeof...(alternative_types) >= 2)
              //TODO same char_type
 //!\endcond
@@ -169,7 +170,8 @@ class alphabet_variant;
 template <typename derived_type,
           typename ...component_types>
 //!\cond
-    requires (detail::ConstexprSemialphabet<component_types> && ...)
+    requires (detail::WritableConstexprSemialphabet<component_types> && ...) &&
+             (!std::is_reference_v<component_types> && ...)
 //!\endcond
 class alphabet_tuple_base;
 

--- a/include/seqan3/alphabet/detail/alphabet_proxy.hpp
+++ b/include/seqan3/alphabet/detail/alphabet_proxy.hpp
@@ -153,7 +153,7 @@ namespace seqan3
  *
  * See seqan3::bitcompressed_vector or seqan3::alphabet_tuple_base for examples of how this class is used.
  */
-template <typename derived_type, typename alphabet_type>
+template <typename derived_type, WritableSemialphabet alphabet_type>
 class alphabet_proxy : public alphabet_base<derived_type,
                                             alphabet_size_v<alphabet_type>,
                                             detail::alphabet_char_type_or_void_t<alphabet_type>>
@@ -233,26 +233,15 @@ public:
     constexpr derived_type & assign_rank(alphabet_rank_t<alphabet_type> const r) noexcept
     {
         alphabet_type tmp{};
-        using seqan3::assign_rank_to;
         assign_rank_to(r, tmp);
         return operator=(tmp);
     }
 
     constexpr derived_type & assign_char(char_type_virtual const c) noexcept
-        requires Alphabet<alphabet_type>
+        requires WritableAlphabet<alphabet_type>
     {
         alphabet_type tmp{};
-        using seqan3::assign_char_to;
         assign_char_to(c, tmp);
-        return operator=(tmp);
-    }
-
-    derived_type & assign_char_strictly(char_type_virtual const c)
-        requires Alphabet<alphabet_type>
-    {
-        alphabet_type tmp{};
-        using seqan3::assign_char_strictly_to;
-        assign_char_strictly_to(c, tmp);
         return operator=(tmp);
     }
 
@@ -273,18 +262,16 @@ public:
     //!\brief Implicit conversion to the emulated type.
     constexpr operator alphabet_type() const noexcept
     {
-        using seqan3::assign_rank_to;
         return assign_rank_to(to_rank(), alphabet_type{});
     }
 
     constexpr char_type to_char() const noexcept
         requires Alphabet<alphabet_type>
     {
-        using seqan3::to_char;
         /* (smehringer) Explicit conversion instead of static_cast:
          * See explanation in to_phred().
          */
-        return to_char(operator alphabet_type());
+        return seqan3::to_char(operator alphabet_type());
     }
 
     constexpr phred_type to_phred() const noexcept
@@ -314,8 +301,8 @@ public:
 
     //!\brief Delegate to the emulated type's validator.
     static constexpr bool char_is_valid(char_type_virtual const c) noexcept
+        requires WritableAlphabet<alphabet_type>
     {
-        using seqan3::char_is_valid_for;
         return char_is_valid_for<alphabet_type>(c);
     }
     //!\}

--- a/include/seqan3/alphabet/detail/hash.hpp
+++ b/include/seqan3/alphabet/detail/hash.hpp
@@ -23,7 +23,7 @@ namespace std
  */
 template <typename alphabet_t>
     //!\cond
-    requires seqan3::Semialphabet<seqan3::delete_const_t<alphabet_t>>
+    requires seqan3::Semialphabet<alphabet_t>
     //!\endcond
 struct hash<alphabet_t>
 {
@@ -48,7 +48,7 @@ struct hash<alphabet_t>
  */
 template <ranges::InputRange urng_t>
     //!\cond
-    requires seqan3::Semialphabet<seqan3::delete_const_t<seqan3::reference_t<urng_t>>>
+    requires seqan3::Semialphabet<seqan3::reference_t<urng_t>>
     //!\endcond
 struct hash<urng_t>
 {

--- a/include/seqan3/alphabet/gap/gap.hpp
+++ b/include/seqan3/alphabet/gap/gap.hpp
@@ -22,10 +22,11 @@ namespace seqan3
 
 /*!\brief The alphabet of a gap character '-'
  * \ingroup gap
- * \implements seqan3::Alphabet
- * \implements seqan3::detail::ConstexprAlphabet
+ * \implements seqan3::WritableAlphabet
+ * \if DEV \implements seqan3::detail::WritableConstexprAlphabet \endif
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
+ * \implements std::Regular
  *
  * The alphabet always has the same value ('-').
  *

--- a/include/seqan3/alphabet/gap/gapped.hpp
+++ b/include/seqan3/alphabet/gap/gapped.hpp
@@ -22,7 +22,7 @@ namespace seqan3
 
 /*!\brief Extends a given alphabet with a gap character.
  * \ingroup gap
- * \tparam alphabet_t Type of the letter, e.g. dna4; must satisfy seqan3::Alphabet.
+ * \tparam alphabet_t Type of the letter, e.g. dna4; must satisfy seqan3::WritableAlphabet.
  *
  * The gapped alphabet represents the variant of a given alphabet and the
  * seqan3::gap alphabet (e.g. the four letter DNA alphabet + a gap character).
@@ -37,7 +37,7 @@ namespace seqan3
  */
 template <typename alphabet_t>
 //!\cond
-    requires Alphabet<alphabet_t>
+    requires WritableAlphabet<alphabet_t>
 //!\endcond
 using gapped = alphabet_variant<gap, alphabet_t>;
 

--- a/include/seqan3/alphabet/mask/mask.hpp
+++ b/include/seqan3/alphabet/mask/mask.hpp
@@ -20,10 +20,11 @@ namespace seqan3
 {
 /*!\brief Implementation of a masked alphabet to be used for tuple composites.
  * \ingroup mask
- * \implements seqan3::Semialphabet
- * \implements seqan3::detail::ConstexprSemialphabet
+ * \implements seqan3::WritableSemialphabet
+ * \if DEV \implements seqan3::detail::ConstexprWritableSemialphabet \endif
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
+ * \implements std::Regular
  *
  * \details
  * This alphabet is not usually used directly, but instead via seqan3::masked.

--- a/include/seqan3/alphabet/mask/masked.hpp
+++ b/include/seqan3/alphabet/mask/masked.hpp
@@ -22,10 +22,11 @@ namespace seqan3
 /*!\brief Implementation of a masked composite, which extends a given alphabet
  * with a mask.
  * \ingroup mask
- * \implements seqan3::Alphabet
- * \implements seqan3::detail::ConstexprSemialphabet
+ * \implements seqan3::WritableAlphabet
+ * \if DEV \implements seqan3::detail::WritableConstexprAlphabet \endif
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
+ * \implements std::Regular
  *
  * \tparam sequence_alphabet_t Type of the first letter; must satisfy seqan3::Semialphabet.
  * \tparam mask_t Types of masked letter; must satisfy seqan3::Semialphabet, defaults to seqan3::mask.
@@ -39,7 +40,7 @@ namespace seqan3
  */
  template <typename sequence_alphabet_t>
 //!\cond
-    requires Alphabet<sequence_alphabet_t>
+    requires WritableAlphabet<sequence_alphabet_t>
 //!\endcond
 class masked : public alphabet_tuple_base<masked<sequence_alphabet_t>, sequence_alphabet_t, mask>
 {

--- a/include/seqan3/alphabet/nucleotide/concept.hpp
+++ b/include/seqan3/alphabet/nucleotide/concept.hpp
@@ -36,7 +36,7 @@ namespace seqan3
  */
 //!\cond
 template <typename type>
-SEQAN3_CONCEPT NucleotideAlphabet = Alphabet<type> && requires (type v, std::remove_reference_t<type> c)
+SEQAN3_CONCEPT NucleotideAlphabet = Alphabet<type> && requires (type v, remove_cvref_t<type> c)
 {
     requires std::Same<decltype(complement(v)), decltype(c)>;
 };

--- a/include/seqan3/alphabet/nucleotide/dna15.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna15.hpp
@@ -29,9 +29,11 @@ class rna15;
 /*!\brief The 15 letter DNA alphabet, containing all IUPAC smybols minus the gap.
  * \ingroup nucleotide
  * \implements seqan3::NucleotideAlphabet
- * \implements seqan3::detail::ConstexprAlphabet
+ * \implements seqan3::WritableAlphabet
+ * \if DEV \implements seqan3::detail::WritableConstexprAlphabet \endif
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
+ * \implements std::Regular
  *
  * \details
  * Note that you can assign 'U' as a character to dna15 and it will silently

--- a/include/seqan3/alphabet/nucleotide/dna4.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna4.hpp
@@ -29,9 +29,11 @@ class rna4;
 /*!\brief The four letter DNA alphabet of A,C,G,T.
  * \ingroup nucleotide
  * \implements seqan3::NucleotideAlphabet
- * \implements seqan3::detail::ConstexprAlphabet
+ * \implements seqan3::WritableAlphabet
+ * \if DEV \implements seqan3::detail::WritableConstexprAlphabet \endif
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
+ * \implements std::Regular
  *
  * \details
  * Note that you can assign 'U' as a character to dna4 and it will silently

--- a/include/seqan3/alphabet/nucleotide/dna5.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna5.hpp
@@ -29,9 +29,11 @@ class rna5;
 /*!\brief The five letter DNA alphabet of A,C,G,T and the unknown character N.
  * \ingroup nucleotide
  * \implements seqan3::NucleotideAlphabet
- * \implements seqan3::detail::ConstexprAlphabet
+ * \implements seqan3::WritableAlphabet
+ * \if DEV \implements seqan3::detail::WritableConstexprAlphabet \endif
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
+ * \implements std::Regular
  *
  * \details
  * Note that you can assign 'U' as a character to dna5 and it will silently

--- a/include/seqan3/alphabet/nucleotide/rna15.hpp
+++ b/include/seqan3/alphabet/nucleotide/rna15.hpp
@@ -26,9 +26,11 @@ namespace seqan3
 
 /*!\brief The 15 letter RNA alphabet, containing all IUPAC smybols minus the gap.
  * \implements seqan3::NucleotideAlphabet
- * \implements seqan3::detail::ConstexprAlphabet
+ * \implements seqan3::WritableAlphabet
+ * \if DEV \implements seqan3::detail::WritableConstexprAlphabet \endif
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
+ * \implements std::Regular
  *
  * \ingroup nucleotide
  *

--- a/include/seqan3/alphabet/nucleotide/rna4.hpp
+++ b/include/seqan3/alphabet/nucleotide/rna4.hpp
@@ -27,9 +27,11 @@ namespace seqan3
 /*!\brief The four letter RNA alphabet of A,C,G,U.
  * \ingroup nucleotide
  * \implements seqan3::NucleotideAlphabet
- * \implements seqan3::detail::ConstexprAlphabet
+ * \implements seqan3::WritableAlphabet
+ * \if DEV \implements seqan3::detail::WritableConstexprAlphabet \endif
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
+ * \implements std::Regular
  *
  * \details
  * This alphabet has the same internal representation as seqan3::dna4, the only difference is that it prints 'U' on

--- a/include/seqan3/alphabet/nucleotide/rna5.hpp
+++ b/include/seqan3/alphabet/nucleotide/rna5.hpp
@@ -27,9 +27,11 @@ namespace seqan3
 /*!\brief The five letter RNA alphabet of A,C,G,U and the unknown character N.
  * \ingroup nucleotide
  * \implements seqan3::NucleotideAlphabet
- * \implements seqan3::detail::ConstexprAlphabet
+ * \implements seqan3::WritableAlphabet
+ * \if DEV \implements seqan3::detail::WritableConstexprAlphabet \endif
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
+ * \implements std::Regular
  *
  * \details
  * This alphabet has the same internal representation as seqan3::dna5, the only difference is that it prints 'U' on

--- a/include/seqan3/alphabet/quality/phred42.hpp
+++ b/include/seqan3/alphabet/quality/phred42.hpp
@@ -23,9 +23,11 @@ namespace seqan3
 
 /*!\brief Quality type for traditional Sanger and modern Illumina Phred scores (typical range).
  * \implements seqan3::QualityAlphabet
- * \implements seqan3::detail::ConstexprAlphabet
+ * \implements seqan3::WritableAlphabet
+ * \if DEV \implements seqan3::detail::WritableConstexprAlphabet \endif
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
+ * \implements std::Regular
  *
  * \ingroup quality
  *

--- a/include/seqan3/alphabet/quality/phred63.hpp
+++ b/include/seqan3/alphabet/quality/phred63.hpp
@@ -23,9 +23,11 @@ namespace seqan3
 
 /*!\brief Quality type for traditional Sanger and modern Illumina Phred scores (full range).
  * \implements seqan3::QualityAlphabet
- * \implements seqan3::detail::ConstexprAlphabet
+ * \implements seqan3::WritableAlphabet
+ * \if DEV \implements seqan3::detail::WritableConstexprAlphabet \endif
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
+ * \implements std::Regular
  *
  * \ingroup quality
  *

--- a/include/seqan3/alphabet/quality/phred68legacy.hpp
+++ b/include/seqan3/alphabet/quality/phred68legacy.hpp
@@ -23,9 +23,11 @@ namespace seqan3
 
 /*!\brief Quality type for Solexa and deprecated Illumina formats.
  * \implements seqan3::QualityAlphabet
- * \implements seqan3::detail::ConstexprAlphabet
+ * \implements seqan3::WritableAlphabet
+ * \if DEV \implements seqan3::detail::WritableConstexprAlphabet \endif
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
+ * \implements std::Regular
  *
  * \ingroup quality
  *

--- a/include/seqan3/alphabet/quality/qualified.hpp
+++ b/include/seqan3/alphabet/quality/qualified.hpp
@@ -27,9 +27,11 @@ namespace seqan3
  * \tparam sequence_alphabet_t Type of the alphabet; must satisfy seqan3::Alphabet.
  * \tparam quality_alphabet_t  Type of the quality; must satisfy seqan3::QualityAlphabet.
  * \implements seqan3::QualityAlphabet
- * \implements seqan3::detail::ConstexprAlphabet
+ * \implements seqan3::WritableAlphabet
+ * \if DEV \implements seqan3::detail::WritableConstexprAlphabet \endif
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
+ * \implements std::Regular
  *
  *
  * This composite pairs an arbitrary alphabet with a quality alphabet, where

--- a/include/seqan3/alphabet/structure/dot_bracket3.hpp
+++ b/include/seqan3/alphabet/structure/dot_bracket3.hpp
@@ -27,9 +27,11 @@ namespace seqan3
 
 /*!\brief The three letter RNA structure alphabet of the characters ".()".
  * \implements seqan3::RnaStructureAlphabet
- * \implements seqan3::detail::ConstexprAlphabet
+ * \implements seqan3::WritableAlphabet
+ * \if DEV \implements seqan3::detail::WritableConstexprAlphabet \endif
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
+ * \implements std::Regular
  *
  * \ingroup structure
  *

--- a/include/seqan3/alphabet/structure/dssp9.hpp
+++ b/include/seqan3/alphabet/structure/dssp9.hpp
@@ -26,10 +26,12 @@ namespace seqan3
 {
 
 /*!\brief The protein structure alphabet of the characters "HGIEBTSCX".
- * \implements seqan3::Alphabet
- * \implements seqan3::detail::ConstexprAlphabet
+ * \implements seqan3::WritableAlphabet
+ * \implements seqan3::WritableAlphabet
+ * \if DEV \implements seqan3::detail::WritableConstexprAlphabet \endif
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
+ * \implements std::Regular
  *
  * \ingroup structure
  *

--- a/include/seqan3/alphabet/structure/structured_aa.hpp
+++ b/include/seqan3/alphabet/structure/structured_aa.hpp
@@ -26,12 +26,14 @@ namespace seqan3
 
 /*!\brief A seqan3::alphabet_tuple_base that joins an aminoacid alphabet with a protein structure alphabet.
  * \ingroup structure
- * \implements seqan3::Alphabet
- * \implements seqan3::detail::ConstexprAlphabet
+ * \implements seqan3::WritableAlphabet
+ * \if DEV \implements seqan3::detail::WritableConstexprAlphabet \endif
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
- * \tparam sequence_alphabet_t Type of the first aminoacid letter; must satisfy seqan3::Alphabet.
- * \tparam structure_alphabet_t Types of further structure letters; must satisfy seqan3::Alphabet.
+ * \tparam sequence_alphabet_t Type of the first aminoacid letter; must model seqan3::WritableAlphabet,
+ * seqan3::AminoacidAlphabet and satisfy the requirements on arguments by seqan3::alphabet_tuple_base.
+ * \tparam structure_alphabet_t Types of further structure letters; must model seqan3::WritableAlphabet and satisfy
+ * the requirements on arguments by seqan3::alphabet_tuple_base.
  *
  * This composite pairs an aminoacid alphabet with a structure alphabet. The rank values
  * correpsond to numeric values in the size of the composite, while the character values
@@ -46,9 +48,9 @@ namespace seqan3
  *
  * This seqan3::alphabet_tuple_base itself fulfills seqan3::Alphabet.
  */
-template <typename sequence_alphabet_t = aa27, typename structure_alphabet_t = dssp9>
+template <WritableAlphabet sequence_alphabet_t = aa27, WritableAlphabet structure_alphabet_t = dssp9>
 //!\cond
-    requires Alphabet<sequence_alphabet_t> && Alphabet<structure_alphabet_t>
+    requires (!std::is_reference_v<sequence_alphabet_t>) && (!std::is_reference_v<structure_alphabet_t>)
 //!\endcond
 class structured_aa :
     public alphabet_tuple_base<structured_aa<sequence_alphabet_t, structure_alphabet_t>,
@@ -106,13 +108,6 @@ public:
     constexpr structured_aa & assign_char(char_type const c) noexcept
     {
         seqan3::assign_char_to(c, get<0>(*this));
-        return *this;
-    }
-
-    //!\brief Strict assign from a nucleotide character. This modifies the internal sequence letter.
-    structured_aa & assign_char_strictly(char_type const c)
-    {
-        seqan3::assign_char_strictly_to(c, get<0>(*this));
         return *this;
     }
     //!\}

--- a/include/seqan3/alphabet/structure/structured_rna.hpp
+++ b/include/seqan3/alphabet/structure/structured_rna.hpp
@@ -27,11 +27,15 @@ namespace seqan3
 /*!\brief A seqan3::alphabet_tuple_base that joins a nucleotide alphabet with an RNA structure alphabet.
  * \ingroup structure
  * \implements seqan3::RnaStructureAlphabet
- * \implements seqan3::detail::ConstexprAlphabet
+ * \implements seqan3::NucleotideAlphabet
+ * \implements seqan3::WritableAlphabet
+ * \if DEV \implements seqan3::detail::WritableConstexprAlphabet \endif
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
- * \tparam sequence_alphabet_t Type of the first letter; must satisfy seqan3::NucleotideAlphabet.
- * \tparam structure_alphabet_t Types of further letters; must satisfy seqan3::RnaStructureAlphabet.
+ * \tparam sequence_alphabet_t Type of the first letter; must model seqan3::WritableAlphabet,
+ * seqan3::NucleotideAlphabet and satisfy the requirements on arguments by seqan3::alphabet_tuple_base.
+ * \tparam structure_alphabet_t Types of further letters; must model seqan3::WritableAlphabet,
+ * seqan3::RnaStructureAlphabet and satisfy the requirements on arguments by seqan3::alphabet_tuple_base.
  *
  * This composite pairs a nucleotide alphabet with a structure alphabet. The rank values
  * correpsond to numeric values in the size of the composite, while the character values
@@ -46,9 +50,9 @@ namespace seqan3
  *
  * This seqan3::alphabet_tuple_base itself models both seqan3::NucleotideAlphabet and seqan3::RnaStructureAlphabet.
  */
-template <typename sequence_alphabet_t, typename structure_alphabet_t>
+template <NucleotideAlphabet sequence_alphabet_t, RnaStructureAlphabet structure_alphabet_t>
 //!\cond
-    requires NucleotideAlphabet<sequence_alphabet_t> && RnaStructureAlphabet<structure_alphabet_t>
+    requires WritableAlphabet<sequence_alphabet_t> && WritableAlphabet<structure_alphabet_t>
 //!\endcond
 class structured_rna :
     public alphabet_tuple_base<structured_rna<sequence_alphabet_t, structure_alphabet_t>,

--- a/include/seqan3/alphabet/structure/wuss.hpp
+++ b/include/seqan3/alphabet/structure/wuss.hpp
@@ -30,9 +30,11 @@ namespace seqan3
  * \tparam SIZE The alphabet size defaults to 51 and must be an odd number in range 15..67.
  *              It determines the allowed pseudoknot depth by adding characters AaBb..Zz to the alphabet.
  * \implements seqan3::RnaStructureAlphabet
- * \implements seqan3::detail::ConstexprAlphabet
+ * \implements seqan3::WritableAlphabet
+ * \if DEV \implements seqan3::detail::WritableConstexprAlphabet \endif
  * \implements seqan3::TriviallyCopyable
  * \implements seqan3::StandardLayout
+ * \implements std::Regular
  *
  * \ingroup structure
  *

--- a/include/seqan3/core/metafunction/basic.hpp
+++ b/include/seqan3/core/metafunction/basic.hpp
@@ -23,67 +23,6 @@ namespace seqan3
 /*!\addtogroup metafunction
  * \{
  */
- // ----------------------------------------------------------------------------
- // delete_const
- // ----------------------------------------------------------------------------
-
-/*!\brief Return the input type with the topmost `const` removed [Type metafunction].
- * \tparam t The type to operate on.
- * \attention In contrast to std::remove_const, this function also removes `const` from pointers and references.
- *
- * | t                | delete_const<t>::type |
- * |------------------|-----------------------|
- * | t                | t                     |
- * | t const          | t                     |
- * | t &              | t &                   |
- * | t const &        | t &                   |
- * | t &&             | t &&                  |
- * | t const &&       | t &&                  |
- * | t *              | t                     |
- * | t const *        | t *                   |
- * | t const * const  | t const *             |
- * | t volatile       | t volatile            |
- * | t const volatile | t volatile            |
- */
-template <typename t>
-struct delete_const
-{
-    //!\brief The return type is the input type with the topmost `const` stripped.
-    using type = t;
-};
-
-//!\cond
-template <typename t>
-struct delete_const<t const>
-{
-    using type = t;
-};
-
-template <typename t>
-struct delete_const<t const *>
-{
-    using type = t *;
-};
-
-template <typename t>
-struct delete_const<t const &>
-{
-    using type = t &;
-};
-
-template <typename t>
-struct delete_const<t const &&>
-{
-    using type = t &&;
-};
-//!\endcond
-
-/*!\brief Return the input type with topmost `const` removed [Type metafunction, shortcut].
- * \tparam t The type to operate on.
- * \attention In contrast to std::remove_const, this function also removes `const` from pointers and references.
- */
-template <typename t>
-using delete_const_t = typename delete_const<t>::type;
 
 // ----------------------------------------------------------------------------
 // remove_cvref_t

--- a/include/seqan3/io/alignment_file/format_sam.hpp
+++ b/include/seqan3/io/alignment_file/format_sam.hpp
@@ -460,17 +460,17 @@ public:
         // Type Requirements (as static asserts for user friendliness)
         // ---------------------------------------------------------------------
         static_assert((std::ranges::ForwardRange<seq_type>        &&
-                      Alphabet<value_type_t<remove_cvref_t<seq_type>>>),
+                      Alphabet<reference_t<seq_type>>),
                       "The seq object must be a std::ranges::ForwardRange over "
                       "letters that model seqan3::Alphabet.");
 
         static_assert((std::ranges::ForwardRange<id_type>         &&
-                      Alphabet<value_type_t<remove_cvref_t<id_type>>>),
+                      Alphabet<reference_t<id_type>>),
                       "The id object must be a std::ranges::ForwardRange over "
                       "letters that model seqan3::Alphabet.");
 
         static_assert((std::ranges::ForwardRange<ref_seq_type>    &&
-                      Alphabet<value_type_t<remove_cvref_t<ref_seq_type>>>),
+                      Alphabet<reference_t<ref_seq_type>>),
                       "The ref_seq object must be a std::ranges::ForwardRange "
                       "over letters that model seqan3::Alphabet.");
 
@@ -493,13 +493,13 @@ public:
                       "value_type is comparable to seqan3::gap");
 
         static_assert((std::tuple_size_v<remove_cvref_t<align_type>> == 2 &&
-                       std::EqualityComparableWith<gap, value_type_t<remove_cvref_t<decltype(std::get<0>(align))>>> &&
-                       std::EqualityComparableWith<gap, value_type_t<remove_cvref_t<decltype(std::get<1>(align))>>>),
+                       std::EqualityComparableWith<gap, reference_t<decltype(std::get<0>(align))>> &&
+                       std::EqualityComparableWith<gap, reference_t<decltype(std::get<1>(align))>>),
                       "The align object must be a std::pair of two ranges whose "
                       "value_type is comparable to seqan3::gap");
 
         static_assert((std::ranges::ForwardRange<qual_type>       &&
-                       Alphabet<value_type_t<remove_cvref_t<qual_type>>>),
+                       Alphabet<reference_t<qual_type>>),
                       "The qual object must be a std::ranges::ForwardRange "
                       "over letters that model seqan3::Alphabet.");
 

--- a/include/seqan3/io/alignment_file/input.hpp
+++ b/include/seqan3/io/alignment_file/input.hpp
@@ -125,13 +125,13 @@ template <typename t>
 SEQAN3_CONCEPT AlignmentFileInputTraits = requires (t v)
 {
     // field::SEQ
-    requires Alphabet<typename t::sequence_alphabet>;
-    requires Alphabet<typename t::sequence_legal_alphabet>;
+    requires WritableAlphabet<typename t::sequence_alphabet>;
+    requires WritableAlphabet<typename t::sequence_legal_alphabet>;
     requires ExplicitlyConvertibleTo<typename t::sequence_legal_alphabet, typename t::sequence_alphabet>;
     requires SequenceContainer<typename t::template sequence_container<typename t::sequence_alphabet>>;
 
     // field::ID
-    requires Alphabet<typename t::id_alphabet>;
+    requires WritableAlphabet<typename t::id_alphabet>;
     requires SequenceContainer<typename t::template id_container<typename t::id_alphabet>>;
 
     // field::QUAL
@@ -142,12 +142,14 @@ SEQAN3_CONCEPT AlignmentFileInputTraits = requires (t v)
     // either ref_info_not_given or a range over ranges over Alphabet (e.g. std::vector<dna4_vector>)
     requires std::Same<typename t::ref_sequences, ref_info_not_given> ||
          (std::ranges::ForwardRange<typename t::ref_sequences> &&
-         std::ranges::ForwardRange<detail::transformation_trait_or_t<value_type<typename t::ref_sequences>, dna4_vector>> &&
-         Alphabet<value_type_t<detail::transformation_trait_or_t<value_type<typename t::ref_sequences>, dna4_vector>>>);
+         std::ranges::ForwardRange<detail::transformation_trait_or_t<reference<typename t::ref_sequences>, dna4_vector>> &&
+         Alphabet<reference_t<detail::transformation_trait_or_t<reference<typename t::ref_sequences>, dna4_vector>>>);
 
     // field::REF_ID
-    requires Alphabet<value_type_t<value_type_t<typename t::ref_ids>>>;
-    requires std::ranges::ForwardRange<value_type_t<typename t::ref_ids>>;
+    requires Alphabet<reference_t<reference_t<typename t::ref_ids>>> &&
+             (!std::Same<typename t::ref_sequences, ref_info_not_given> ||
+              WritableAlphabet<reference_t<reference_t<typename t::ref_ids>>>);
+    requires std::ranges::ForwardRange<reference_t<typename t::ref_ids>>;
     requires std::ranges::ForwardRange<typename t::ref_ids>;
 
     // field::OFFSET is fixed to int32_t

--- a/include/seqan3/io/sequence_file/format_sam.hpp
+++ b/include/seqan3/io/sequence_file/format_sam.hpp
@@ -237,7 +237,7 @@ public:
     {
         if constexpr (!(detail::decays_to_ignore_v<seq_type>))
         {
-            static_assert(std::ranges::ForwardRange<seq_type> && Alphabet<value_type_t<seq_type>>,
+            static_assert(std::ranges::ForwardRange<seq_type> && Alphabet<reference_t<seq_type>>,
                           "The sequence must model std::ranges::ForwardRange and its value type must model "
                           "seqan3::Alphabet.");
         }

--- a/include/seqan3/io/sequence_file/input.hpp
+++ b/include/seqan3/io/sequence_file/input.hpp
@@ -122,14 +122,14 @@ namespace seqan3
 template <typename t>
 SEQAN3_CONCEPT SequenceFileInputTraits = requires (t v)
 {
-    requires Alphabet<typename t::sequence_alphabet>;
-    requires Alphabet<typename t::sequence_legal_alphabet>;
+    requires WritableAlphabet<typename t::sequence_alphabet>;
+    requires WritableAlphabet<typename t::sequence_legal_alphabet>;
     requires ExplicitlyConvertibleTo<typename t::sequence_legal_alphabet, typename t::sequence_alphabet>;
     requires SequenceContainer<typename t::template sequence_container<typename t::sequence_alphabet>>;
     requires SequenceContainer<typename t::template sequence_container_container<
         typename t::template sequence_container<typename t::sequence_alphabet>>>;
 
-    requires Alphabet<typename t::id_alphabet>;
+    requires WritableAlphabet<typename t::id_alphabet>;
     requires SequenceContainer<typename t::template id_container<typename t::id_alphabet>>;
     requires SequenceContainer<typename t::template id_container_container<typename t::template id_container<
         typename t::id_alphabet>>>;

--- a/include/seqan3/io/stream/debug_stream.hpp
+++ b/include/seqan3/io/stream/debug_stream.hpp
@@ -298,7 +298,7 @@ namespace seqan3
 template <typename tuple_t>
 //!\cond
     requires !std::ranges::InputRange<tuple_t> &&
-             !Alphabet<remove_cvref_t<tuple_t>> && // exclude alphabet_tuple_base
+             !Alphabet<tuple_t> && // exclude alphabet_tuple_base
              tuple_like_concept<remove_cvref_t<tuple_t>>
 //!\endcond
 inline debug_stream_type & operator<<(debug_stream_type & s, tuple_t && t)
@@ -374,7 +374,7 @@ inline debug_stream_type & operator<<(debug_stream_type & s, rng_t && r)
                std::Same<remove_cvref_t<reference_t<rng_t>>, char>)
 //!\endcond
 {
-    if constexpr (Alphabet<remove_cvref_t<reference_t<rng_t>>> &&
+    if constexpr (Alphabet<reference_t<rng_t>> &&
                   !detail::is_uint_adaptation_v<remove_cvref_t<reference_t<rng_t>>>)
     {
         for (auto && l : r)

--- a/include/seqan3/io/structure_file/input.hpp
+++ b/include/seqan3/io/structure_file/input.hpp
@@ -176,8 +176,8 @@ SEQAN3_CONCEPT StructureFileInputTraits = requires(t v)
 {
     // TODO(joergi-w) The expensive concept checks are currently omitted. Check again when compiler has improved.
     // sequence
-    requires Alphabet<typename t::seq_alphabet>;
-    requires Alphabet<typename t::seq_legal_alphabet>;
+    requires WritableAlphabet<typename t::seq_alphabet>;
+    requires WritableAlphabet<typename t::seq_legal_alphabet>;
     requires ExplicitlyConvertibleTo<typename t::seq_legal_alphabet, typename t::seq_alphabet>;
     requires SequenceContainer<typename t::template seq_container<typename t::seq_alphabet>>;
 //    requires SequenceContainer
@@ -186,7 +186,7 @@ SEQAN3_CONCEPT StructureFileInputTraits = requires(t v)
 //                <typename t::seq_alphabet>>>;
 
     // id
-    requires Alphabet<typename t::id_alphabet>;
+    requires WritableAlphabet<typename t::id_alphabet>;
     requires SequenceContainer<typename t::template id_container<typename t::id_alphabet>>;
 //    requires SequenceContainer
 //        <typename t::template id_container_container
@@ -254,7 +254,7 @@ SEQAN3_CONCEPT StructureFileInputTraits = requires(t v)
 //                <typename t::react_type>>>;
 
     // comment
-    requires Alphabet<typename t::comment_alphabet>;
+    requires WritableAlphabet<typename t::comment_alphabet>;
     requires SequenceContainer<typename t::template comment_container<typename t::comment_alphabet>>;
 //    requires SequenceContainer
 //        <typename t::template comment_container_container

--- a/include/seqan3/range/container/bitcompressed_vector.hpp
+++ b/include/seqan3/range/container/bitcompressed_vector.hpp
@@ -131,7 +131,7 @@ private:
         //!\}
     };
 
-    static_assert(Alphabet<reference_proxy_type>);
+    static_assert(WritableAlphabet<reference_proxy_type>);
     //!\cond
     //NOTE(h-2): it is entirely unclear to me why we need this
     template <typename t>

--- a/include/seqan3/range/view/complement.hpp
+++ b/include/seqan3/range/view/complement.hpp
@@ -62,13 +62,12 @@ namespace seqan3::view
  * \hideinitializer
  */
 
-inline auto const complement = deep{std::view::transform([] (auto && in)
+inline auto const complement = deep{std::view::transform([] (auto const in)
 {
-    static_assert(NucleotideAlphabet<delete_const_t<decltype(in)>>,
+    static_assert(NucleotideAlphabet<decltype(in)>,
                   "The innermost value type must satisfy the NucleotideAlphabet.");
     // call element-wise complement from the NucleotideAlphabet
-    using seqan3::complement;
-    return complement(in);
+    return seqan3::complement(in);
 })};
 
 //!\}

--- a/include/seqan3/range/view/kmer_hash.hpp
+++ b/include/seqan3/range/view/kmer_hash.hpp
@@ -43,7 +43,7 @@ struct kmer_hash_fn
      */
     template <std::ranges::ViewableRange urng_t>
     //!\cond
-        requires Semialphabet<delete_const_t<reference_t<urng_t>>>
+        requires Semialphabet<reference_t<urng_t>>
     //!\endcond
     constexpr auto operator()(urng_t && urange, size_t const k) const noexcept
     {

--- a/include/seqan3/range/view/rank_to.hpp
+++ b/include/seqan3/range/view/rank_to.hpp
@@ -26,7 +26,7 @@ namespace seqan3::view
 /*!\brief                A view over an alphabet, given a range of ranks.
  * \tparam urng_t       The type of the range being processed. See below for requirements. [template parameter is
  *                      omitted in pipe notation]
- * \tparam alphabet_t   The alphabet to convert to; must satisfy seqan3::Alphabet.
+ * \tparam alphabet_t   The alphabet to convert to; must satisfy seqan3::WritableSemialphabet.
  * \param[in] urange    The range being processed. [parameter is omitted in pipe notation]
  * \returns             A range of converted elements. See below for the properties of the returned range.
  * \ingroup view
@@ -61,7 +61,7 @@ namespace seqan3::view
  */
 template <typename alphabet_type>
 //!\cond
-    requires Alphabet<alphabet_type>
+    requires WritableSemialphabet<alphabet_type>
 //!\endcond
 inline auto const rank_to = deep{std::view::transform(
 [] (alphabet_rank_t<alphabet_type> const in) -> alphabet_type

--- a/include/seqan3/range/view/to_rank.hpp
+++ b/include/seqan3/range/view/to_rank.hpp
@@ -62,7 +62,8 @@ namespace seqan3::view
  */
 inline auto const to_rank = deep{std::view::transform([] (auto const in) noexcept
 {
-    static_assert(Alphabet<remove_cvref_t<decltype(in)>>, "The value type of seqan3::view::to_rank must model the seqan3::Alphabet.");
+    static_assert(Semialphabet<decltype(in)>,
+                  "The value type of seqan3::view::to_rank must model the seqan3::Alphabet.");
     return seqan3::to_rank(in);
 })};
 

--- a/include/seqan3/range/view/translation.hpp
+++ b/include/seqan3/range/view/translation.hpp
@@ -39,7 +39,7 @@ template <typename urng_t>
 //!\cond
     requires std::ranges::SizedRange<urng_t> &&
              std::ranges::RandomAccessRange<urng_t> &&
-             NucleotideAlphabet<std::decay_t<reference_t<std::decay_t<urng_t>>>>
+             NucleotideAlphabet<reference_t<urng_t>>
 //!\endcond
 class view_translate;
 
@@ -47,7 +47,7 @@ template <typename urng_t>
 //!\cond
     requires std::ranges::SizedRange<urng_t> &&
              std::ranges::RandomAccessRange<urng_t> &&
-             NucleotideAlphabet<std::decay_t<reference_t<std::decay_t<urng_t>>>>
+             NucleotideAlphabet<reference_t<urng_t>>
 //!\endcond
 class view_translate_single;
 
@@ -148,7 +148,7 @@ template <typename urng_t>
 //!\cond
     requires std::ranges::SizedRange<urng_t> &&
              std::ranges::RandomAccessRange<urng_t> &&
-             NucleotideAlphabet<std::decay_t<reference_t<std::decay_t<urng_t>>>>
+             NucleotideAlphabet<reference_t<urng_t>>
 //!\endcond
 class view_translate_single
 {
@@ -370,7 +370,7 @@ template <typename urng_t>
 //!\cond
     requires std::ranges::SizedRange<urng_t> &&
              std::ranges::RandomAccessRange<urng_t> &&
-             NucleotideAlphabet<std::decay_t<reference_t<std::decay_t<urng_t>>>>
+             NucleotideAlphabet<reference_t<urng_t>>
 //!\endcond
 view_translate_single(urng_t &&, translation_frames const) -> view_translate_single<urng_t>;
 
@@ -379,7 +379,7 @@ template <typename urng_t>
 //!\cond
     requires std::ranges::SizedRange<urng_t> &&
              std::ranges::RandomAccessRange<urng_t> &&
-             NucleotideAlphabet<std::decay_t<reference_t<std::decay_t<urng_t>>>>
+             NucleotideAlphabet<reference_t<urng_t>>
 //!\endcond
 view_translate_single(urng_t &&) -> view_translate_single<urng_t>;
 
@@ -459,7 +459,7 @@ template <typename urng_t>
 //!\cond
     requires std::ranges::SizedRange<urng_t> &&
              std::ranges::RandomAccessRange<urng_t> &&
-             NucleotideAlphabet<std::decay_t<reference_t<std::decay_t<urng_t>>>>
+             NucleotideAlphabet<reference_t<urng_t>>
 //!\endcond
 class view_translate
 {
@@ -658,7 +658,7 @@ template <typename urng_t>
 //!\cond
     requires std::ranges::SizedRange<urng_t> &&
              std::ranges::RandomAccessRange<urng_t> &&
-             NucleotideAlphabet<std::decay_t<reference_t<std::decay_t<urng_t>>>>
+             NucleotideAlphabet<reference_t<urng_t>>
 //!\endcond
 view_translate(urng_t &&, translation_frames const = translation_frames{}) -> view_translate<urng_t>;
 

--- a/include/seqan3/search/fm_index/bi_fm_index.hpp
+++ b/include/seqan3/search/fm_index/bi_fm_index.hpp
@@ -55,7 +55,7 @@ struct bi_fm_index_default_traits
  */
 template <std::ranges::RandomAccessRange text_t, BiFmIndexTraits index_traits_t = bi_fm_index_default_traits>
 //!\cond
-    requires Alphabet<innermost_value_type_t<text_t>> &&
+    requires Semialphabet<innermost_value_type_t<text_t>> &&
              std::Same<alphabet_rank_t<innermost_value_type_t<text_t>>, uint8_t>
 //!\endcond
 class bi_fm_index

--- a/include/seqan3/search/fm_index/fm_index.hpp
+++ b/include/seqan3/search/fm_index/fm_index.hpp
@@ -121,7 +121,7 @@ struct fm_index_default_traits
  */
 template <std::ranges::RandomAccessRange text_t, FmIndexTraits fm_index_traits = fm_index_default_traits>
 //!\cond
-    requires Alphabet<innermost_value_type_t<text_t>> &&
+    requires Semialphabet<innermost_value_type_t<text_t>> &&
              alphabet_size_v<innermost_value_type_t<text_t>> <= 256
 //!\endcond
 class fm_index

--- a/test/unit/alphabet/CMakeLists.txt
+++ b/test/unit/alphabet/CMakeLists.txt
@@ -1,3 +1,6 @@
 add_subdirectories()
+seqan3_test(alphabet_cereal_test.cpp)
+seqan3_test(alphabet_debug_stream_test.cpp)
+seqan3_test(alphabet_hash_test.cpp)
 seqan3_test(custom_alphabet_test.cpp)
 seqan3_test(custom_alphabet2_test.cpp)

--- a/test/unit/alphabet/alphabet_cereal_test.cpp
+++ b/test/unit/alphabet/alphabet_cereal_test.cpp
@@ -1,0 +1,38 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <seqan3/alphabet/gap/gapped.hpp>
+#include <seqan3/alphabet/nucleotide/dna4.hpp>
+#include <seqan3/alphabet/quality/phred42.hpp>
+#include <seqan3/alphabet/quality/qualified.hpp>
+#include <seqan3/test/cereal.hpp>
+
+using namespace seqan3;
+
+template <typename T>
+class alphabet_cereal : public ::testing::Test
+{};
+
+using test_types = ::testing::Types<dna4, qualified<dna4, phred42>, gapped<dna4>>;
+
+TYPED_TEST_CASE(alphabet_cereal, test_types);
+
+TYPED_TEST(alphabet_cereal, serialisation)
+{
+    TypeParam letter;
+
+    assign_rank_to(1 % alphabet_size_v<TypeParam>, letter);
+    test::do_serialisation(letter);
+
+    std::vector<TypeParam> vec;
+    vec.resize(10);
+    for (unsigned i = 0; i < 10; ++i)
+        assign_rank_to(i % alphabet_size_v<TypeParam>, vec[i]);
+    test::do_serialisation(vec);
+}

--- a/test/unit/alphabet/alphabet_constexpr_test_template.hpp
+++ b/test/unit/alphabet/alphabet_constexpr_test_template.hpp
@@ -34,7 +34,15 @@ TYPED_TEST_P(alphabet_constexpr, concept_check)
 {
     EXPECT_TRUE(detail::ConstexprAlphabet<TypeParam   >);
     EXPECT_TRUE(detail::ConstexprAlphabet<TypeParam & >);
-    EXPECT_TRUE(detail::ConstexprAlphabet<TypeParam &&>);
+
+    EXPECT_TRUE(detail::ConstexprAlphabet<TypeParam const   >);
+    EXPECT_TRUE(detail::ConstexprAlphabet<TypeParam const & >);
+
+    EXPECT_TRUE(detail::WritableConstexprAlphabet<TypeParam   >);
+    EXPECT_TRUE(detail::WritableConstexprAlphabet<TypeParam & >);
+
+    EXPECT_FALSE(detail::WritableConstexprAlphabet<TypeParam const   >);
+    EXPECT_FALSE(detail::WritableConstexprAlphabet<TypeParam const & >);
 }
 
 TYPED_TEST_P(alphabet_constexpr, default_value_constructor)

--- a/test/unit/alphabet/alphabet_debug_stream_test.cpp
+++ b/test/unit/alphabet/alphabet_debug_stream_test.cpp
@@ -1,0 +1,37 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <seqan3/alphabet/gap/gapped.hpp>
+#include <seqan3/alphabet/nucleotide/dna4.hpp>
+#include <seqan3/alphabet/quality/phred42.hpp>
+#include <seqan3/alphabet/quality/qualified.hpp>
+#include <seqan3/io/stream/debug_stream.hpp>
+
+using namespace seqan3;
+
+template <typename T>
+class alphabet_debug_stream : public ::testing::Test
+{};
+
+using test_types = ::testing::Types<dna4, qualified<dna4, phred42>, gapped<dna4>>;
+
+TYPED_TEST_CASE(alphabet_debug_stream, test_types);
+
+TYPED_TEST(alphabet_debug_stream, debug_streaming)
+{
+    std::ostringstream o;
+    debug_stream_type my_stream{o};
+
+    TypeParam val{'C'_dna4};
+    my_stream << val;
+
+    o.flush();
+    EXPECT_EQ(o.str().size(), 1u);
+    EXPECT_EQ(to_char(o.str()[0]), 'C');
+}

--- a/test/unit/alphabet/alphabet_hash_test.cpp
+++ b/test/unit/alphabet/alphabet_hash_test.cpp
@@ -1,0 +1,81 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <seqan3/alphabet/gap/gapped.hpp>
+#include <seqan3/alphabet/nucleotide/dna4.hpp>
+#include <seqan3/alphabet/quality/phred42.hpp>
+#include <seqan3/alphabet/quality/qualified.hpp>
+
+using namespace seqan3;
+
+template <typename T>
+class alphabet_hashing : public ::testing::Test
+{};
+
+using test_types = ::testing::Types<dna4, qualified<dna4, phred42>, gapped<dna4>>;
+
+TYPED_TEST_CASE(alphabet_hashing, test_types);
+
+TYPED_TEST(alphabet_hashing, hash)
+{
+    {
+        TypeParam t0{};
+        std::hash<TypeParam> h{};
+        if constexpr (std::Same<TypeParam, char>)
+        {
+            for (size_t i = 0; i < alphabet_size_v<TypeParam>/2; ++i)
+            {
+                assign_rank_to(i, t0);
+                ASSERT_EQ(h(t0), i);
+            }
+        }
+        else
+        {
+            for (size_t i = 0; i < alphabet_size_v<TypeParam>; ++i)
+            {
+                assign_rank_to(i, t0);
+                ASSERT_EQ(h(t0), i);
+            }
+        }
+    }
+    {
+        std::vector<TypeParam> text;
+        text.reserve(4);
+        for (size_t i = 0; i < 4; ++i)
+        {
+            text.push_back(assign_rank_to(0, TypeParam{}));
+        }
+        std::hash<decltype(text)> h{};
+        ASSERT_EQ(h(text), 0u);
+    }
+    {
+        std::hash<TypeParam const> h{};
+        if constexpr (std::Same<TypeParam, char>)
+        {
+            for (size_t i = 0; i < alphabet_size_v<TypeParam>/2; ++i)
+            {
+                TypeParam const t0 = assign_rank_to(i, TypeParam{});
+                ASSERT_EQ(h(t0), i);
+            }
+        }
+        else
+        {
+            for (size_t i = 0; i < alphabet_size_v<TypeParam>; ++i)
+            {
+                TypeParam const t0 = assign_rank_to(i, TypeParam{});
+                ASSERT_EQ(h(t0), i);
+            }
+        }
+    }
+    {
+        std::vector<TypeParam> const text(4, assign_rank_to(0, TypeParam{}));
+        std::hash<decltype(text)> h{};
+        ASSERT_EQ(h(text), 0u);
+    }
+}

--- a/test/unit/alphabet/alphabet_test_template.hpp
+++ b/test/unit/alphabet/alphabet_test_template.hpp
@@ -7,13 +7,10 @@
 
 #include <gtest/gtest.h>
 
-#include <range/v3/view/iota.hpp>
-
 #include <seqan3/alphabet/concept.hpp>
 #include <seqan3/alphabet/exception.hpp>
-#include <seqan3/io/stream/debug_stream.hpp>
-#include <seqan3/test/cereal.hpp>
 #include <seqan3/test/pretty_printing.hpp>
+#include <seqan3/std/ranges>
 
 using namespace seqan3;
 
@@ -199,95 +196,31 @@ TYPED_TEST_P(alphabet, comparison_operators)
 
 TYPED_TEST_P(alphabet, concept_check)
 {
+    EXPECT_TRUE(Semialphabet<TypeParam>);
+    EXPECT_TRUE(Semialphabet<TypeParam &>);
+
+    EXPECT_TRUE(WritableSemialphabet<TypeParam>);
+    EXPECT_TRUE(WritableSemialphabet<TypeParam &>);
+
+    EXPECT_TRUE(Semialphabet<TypeParam const>);
+    EXPECT_TRUE(Semialphabet<TypeParam const &>);
+
+    EXPECT_FALSE(WritableSemialphabet<TypeParam const>);
+    EXPECT_FALSE(WritableSemialphabet<TypeParam const &>);
+
     EXPECT_TRUE(Alphabet<TypeParam>);
     EXPECT_TRUE(Alphabet<TypeParam &>);
-    EXPECT_TRUE(Alphabet<TypeParam &&>);
-}
 
-TYPED_TEST_P(alphabet, debug_streaming)
-{
-    std::ostringstream o;
-    debug_stream_type my_stream{o};
+    EXPECT_TRUE(WritableAlphabet<TypeParam>);
+    EXPECT_TRUE(WritableAlphabet<TypeParam &>);
 
-    my_stream << TypeParam{};
+    EXPECT_TRUE(Alphabet<TypeParam const>);
+    EXPECT_TRUE(Alphabet<TypeParam const &>);
 
-    o.flush();
-    EXPECT_EQ(o.str().size(), 1u);
-}
-
-TYPED_TEST_P(alphabet, hash)
-{
-    {
-        TypeParam t0{};
-        std::hash<TypeParam> h{};
-        if constexpr (std::Same<TypeParam, char>)
-        {
-            for (size_t i = 0; i < alphabet_size_v<TypeParam>/2; ++i)
-            {
-                assign_rank_to(i, t0);
-                ASSERT_EQ(h(t0), i);
-            }
-        }
-        else
-        {
-            for (size_t i = 0; i < alphabet_size_v<TypeParam>; ++i)
-            {
-                assign_rank_to(i, t0);
-                ASSERT_EQ(h(t0), i);
-            }
-        }
-    }
-    {
-        std::vector<TypeParam> text;
-        text.reserve(4);
-        for (size_t i = 0; i < 4; ++i)
-        {
-            text.push_back(assign_rank_to(0, TypeParam{}));
-        }
-        std::hash<decltype(text)> h{};
-        ASSERT_EQ(h(text), 0u);
-    }
-    {
-        std::hash<TypeParam const> h{};
-        if constexpr (std::Same<TypeParam, char>)
-        {
-            for (size_t i = 0; i < alphabet_size_v<TypeParam>/2; ++i)
-            {
-                TypeParam const t0 = assign_rank_to(i, TypeParam{});
-                ASSERT_EQ(h(t0), i);
-            }
-        }
-        else
-        {
-            for (size_t i = 0; i < alphabet_size_v<TypeParam>; ++i)
-            {
-                TypeParam const t0 = assign_rank_to(i, TypeParam{});
-                ASSERT_EQ(h(t0), i);
-            }
-        }
-    }
-    {
-        std::vector<TypeParam> const text(4, assign_rank_to(0, TypeParam{}));
-        std::hash<decltype(text)> h{};
-        ASSERT_EQ(h(text), 0u);
-    }
-}
-
-TYPED_TEST_P(alphabet, serialisation)
-{
-    TypeParam letter;
-
-    assign_rank_to(1 % alphabet_size_v<TypeParam>, letter);
-    test::do_serialisation(letter);
-
-    std::vector<TypeParam> vec;
-    vec.resize(10);
-    for (unsigned i = 0; i < 10; ++i)
-        assign_rank_to(i % alphabet_size_v<TypeParam>, vec[i]);
-    test::do_serialisation(vec);
+    EXPECT_FALSE(WritableAlphabet<TypeParam const>);
+    EXPECT_FALSE(WritableAlphabet<TypeParam const &>);
 }
 
 REGISTER_TYPED_TEST_CASE_P(alphabet, alphabet_size, default_value_constructor, global_assign_rank, global_to_rank,
     copy_constructor, move_constructor, copy_assignment, move_assignment, swap, global_assign_char, global_to_char,
-    global_char_is_valid_for, global_assign_char_strict, comparison_operators, concept_check, debug_streaming, hash,
-    serialisation);
+    global_char_is_valid_for, global_assign_char_strict, comparison_operators, concept_check);

--- a/test/unit/core/metafunction/basic_test.cpp
+++ b/test/unit/core/metafunction/basic_test.cpp
@@ -36,19 +36,3 @@ TEST(metafunction, remove_cvref_t)
     EXPECT_FALSE((std::is_same_v<int*, remove_cvref_t<int[3]>>));   // type stays same
     // the last example would be true for std::decay_t
 }
-
-TEST(metafunction, delete_const_t)
-{
-    EXPECT_TRUE((std::is_same_v<int, 		 delete_const_t<int>>));
-    EXPECT_TRUE((std::is_same_v<int, 		 delete_const_t<int const>>));
-    EXPECT_TRUE((std::is_same_v<int volatile, 	 delete_const_t<int volatile>>));
-    EXPECT_TRUE((std::is_same_v<int &, 		 delete_const_t<int &>>));
-    EXPECT_TRUE((std::is_same_v<int &&, 	 delete_const_t<int &&>>));
-    EXPECT_TRUE((std::is_same_v<int &, 		 delete_const_t<int const &>>));
-    EXPECT_TRUE((std::is_same_v<int &&, 	 delete_const_t<int const &&>>));
-    EXPECT_TRUE((std::is_same_v<int volatile &&, delete_const_t<int const volatile &&>>));
-    EXPECT_TRUE((std::is_same_v<int *, 		 delete_const_t<int *>>));
-    EXPECT_TRUE((std::is_same_v<int *, 		 delete_const_t<int const *>>));
-    EXPECT_TRUE((std::is_same_v<int volatile *,  delete_const_t<int const volatile *>>));
-    EXPECT_TRUE((std::is_same_v<char const *, 	 delete_const_t<char const * const>>));
-}


### PR DESCRIPTION
This PR splits the alphabet concepts into readable and writable. It also does some drive-by fixes to here and there and improves the documentation.

~~A notable change is that we now require `std::is_trivially_copyable` for our alphabets which currently breaks the bitcompressed vector, I still need to investigate that.~~

@joergi-w  Can you give this a review? Once everything is merged and settled down you will have to change this for the structure alphabets, too, I am afraid!