### PR TITLE
Fix alphabet_variant behaviour of from_char()

### DIFF
--- a/include/seqan3/alphabet/composite/alphabet_variant.hpp
+++ b/include/seqan3/alphabet/composite/alphabet_variant.hpp
@@ -149,7 +149,7 @@ namespace seqan3
 
  * \details
  *
- * The alphabet_variant represents the variant of two or more alternative alphabets (e.g. the
+ * The alphabet_variant represents the union of two or more alternative alphabets (e.g. the
  * four letter DNA alternative + the gap alternative). It behaves similar to a
  * [variant](https://en.cppreference.com/w/cpp/language/variant) or std::variant, but it preserves the
  * seqan3::Alphabet.
@@ -166,6 +166,28 @@ namespace seqan3
  * ### Example
  *
  * \snippet test/snippet/alphabet/composite/alphabet_variant.cpp usage
+ *
+ * ### The `char` representation of an alphabet_variant
+ *
+ * Part of the seqan3::Alphabet concept requires that the alphabet_variant provides a char representation in addition
+ * to the rank representation. For an object of seqan3::alphabet_variant, the `to_char()` member function will always
+ * return the same character as if invoked on the respective alternative.
+ * In contrast, the `assign_char()` member function might be ambiguous between the alternative alphabets in a variant.
+ *
+ * For example, assigning a '!' to seqan3::dna15 resolves to an object of rank 8 with char representation 'N' while
+ * assigning '!' to seqan3::gap always resolves to rank 0, the gap symbol itself ('-'_gap).
+ * We tackle this ambiguousness by **defaulting unknown characters to the representation of the first alternative**
+ * (e.g. `alphabet_variant<dna15, gap>{}.assign_char('!')` resolves to rank 8, representing `N`_dna15).
+ *
+ * On the other hand, two alternative alphabets might have the same char representation (e.g if
+ * you combine dna4 with dna5, 'A', 'C', 'G' and 'T' are ambiguous).
+ * We tackle this ambiguousness by **always choosing the first valid char representation** (e.g.
+ * `alphabet_variant<dna4, dna5>{}.assign_char('A')` resolves to rank 0, representing an `A`_dna4).
+ *
+ * To explicitly assign via the character representation of a specific alphabet,
+ * assign to that type first and then assign to the variant, e.g.
+ *
+ * \snippet test/snippet/alphabet/composite/alphabet_variant.cpp char_representation
  */
 template <typename ...alternative_types>
 //!\cond
@@ -504,29 +526,6 @@ protected:
         return value_to_char;
     }();
 
-    /*!\brief Compile-time generated lookup table which maps the char to rank.
-     *
-     * An map generated at compile time where the key is the char of one of the
-     * alternatives and the value is the corresponding rank over all alternatives (by
-     * conflict will default to the first).
-     *
-     */
-    static constexpr std::array char_to_rank = []() constexpr
-    {
-        constexpr size_t table_size = 1 << (sizeof(char_type) * 8);
-
-        std::array<rank_type, table_size> char_to_rank{};
-        for (size_t i = 0u; i < rank_to_char.size(); ++i)
-        {
-            using index_t = std::make_unsigned_t<char_type>;
-            rank_type & old_entry = char_to_rank[static_cast<index_t>(rank_to_char[i])];
-            bool is_new_entry = rank_to_char[0] != rank_to_char[i] && old_entry == 0;
-            if (is_new_entry)
-                old_entry = static_cast<rank_type>(i);
-        }
-        return char_to_rank;
-    }();
-
     //!\brief Converts an object of one of the given alternatives into the internal representation.
     //!\tparam index The position of `alternative_t` in the template pack `alternative_types`.
     //!\tparam alternative_t One of the alternative types.
@@ -553,6 +552,42 @@ protected:
         constexpr size_t index = meta::find_index<alternatives, alternative_t>::value;
         return rank_by_index_<index>(alternative);
     }
+
+    /*!\brief Compile-time generated lookup table which maps the char to rank.
+     *
+     * An map generated at compile time where the key is the char of one of the
+     * alternatives and the value is the corresponding rank over all alternatives (by
+     * conflict will default to the first).
+     *
+     */
+    static constexpr std::array char_to_rank = []() constexpr
+    {
+        constexpr size_t table_size = 1 << (sizeof(char_type) * 8);
+
+        std::array<rank_type, table_size> char_to_rank{};
+
+        for (size_t i = 0u; i < table_size; ++i)
+        {
+            char_type chr = static_cast<char_type>(i);
+            bool there_was_no_valid_representation{true};
+
+            meta::for_each(alternatives{}, [&] (auto && alt)
+            {
+                using alt_type = remove_cvref_t<decltype(alt)>;
+
+                if (there_was_no_valid_representation && char_is_valid_for<alt_type>(chr))
+                {
+                    there_was_no_valid_representation = false;
+                    char_to_rank[i] = rank_by_type_(assign_char_to(chr, alt_type{}));
+                }
+            });
+
+            if (there_was_no_valid_representation)
+                char_to_rank[i] = rank_by_type_(assign_char_to(chr, meta::front<alternatives>{}));
+        }
+
+        return char_to_rank;
+    }();
 };
 
 /*!\name Comparison operators

--- a/include/seqan3/alphabet/gap/gapped.hpp
+++ b/include/seqan3/alphabet/gap/gapped.hpp
@@ -39,7 +39,7 @@ template <typename alphabet_t>
 //!\cond
     requires Alphabet<alphabet_t>
 //!\endcond
-using gapped = alphabet_variant<gap, alphabet_t>;
+using gapped = alphabet_variant<alphabet_t, gap>;
 
 } // namespace seqan3
 

--- a/test/snippet/alphabet/composite/alphabet_variant.cpp
+++ b/test/snippet/alphabet/composite/alphabet_variant.cpp
@@ -28,6 +28,14 @@ dna5 letter4 = letter2.convert_to<dna5>();      // this works
 }
 
 {
+//! [char_representation]
+alphabet_variant<dna4, dna5> var;
+var.assign_char('A');             // will be in the "dna4-state"
+var = 'A'_dna5;                   // will be in the "dna5-state"
+//! [char_representation]
+}
+
+{
 //! [holds_alternative]
 using variant_t = alphabet_variant<dna5, gap>;
 

--- a/test/unit/alphabet/gap/gapped_test.cpp
+++ b/test/unit/alphabet/gap/gapped_test.cpp
@@ -42,16 +42,16 @@ TEST(gapped_test, initialise_from_component_alphabet)
     constexpr alphabet_t letter8{gap{}}; // letter3 = 'T'_dna4; does not work
     alphabet_t letter9{gap{}};
 
-    EXPECT_EQ(letter0.to_rank(), 1);
-    EXPECT_EQ(letter1.to_rank(), 2);
-    EXPECT_EQ(letter2.to_rank(), 3);
-    EXPECT_EQ(letter3.to_rank(), 4);
-    EXPECT_EQ(letter4.to_rank(), 1);
-    EXPECT_EQ(letter5.to_rank(), 2);
-    EXPECT_EQ(letter6.to_rank(), 3);
-    EXPECT_EQ(letter7.to_rank(), 4);
-    EXPECT_EQ(letter8.to_rank(), 0);
-    EXPECT_EQ(letter9.to_rank(), 0);
+    EXPECT_EQ(letter0.to_rank(), 0);
+    EXPECT_EQ(letter1.to_rank(), 1);
+    EXPECT_EQ(letter2.to_rank(), 2);
+    EXPECT_EQ(letter3.to_rank(), 3);
+    EXPECT_EQ(letter4.to_rank(), 0);
+    EXPECT_EQ(letter5.to_rank(), 1);
+    EXPECT_EQ(letter6.to_rank(), 2);
+    EXPECT_EQ(letter7.to_rank(), 3);
+    EXPECT_EQ(letter8.to_rank(), 4);
+    EXPECT_EQ(letter9.to_rank(), 4);
 }
 
 TEST(gapped_test, assign_from_component_alphabet)
@@ -60,19 +60,19 @@ TEST(gapped_test, assign_from_component_alphabet)
     alphabet_t letter{};
 
     letter = gap{};
-    EXPECT_EQ(letter.to_rank(), 0);
+    EXPECT_EQ(letter.to_rank(), 4);
 
     letter = 'A'_dna4;
-    EXPECT_EQ(letter.to_rank(), 1);
+    EXPECT_EQ(letter.to_rank(), 0);
 
     letter = {'C'_dna4}; // letter = {'C'_dna4}; does not work
-    EXPECT_EQ(letter.to_rank(), 2);
+    EXPECT_EQ(letter.to_rank(), 1);
 
     letter = static_cast<alphabet_t>('G'_dna4);
-    EXPECT_EQ(letter.to_rank(), 3);
+    EXPECT_EQ(letter.to_rank(), 2);
 
     letter = {static_cast<alphabet_t>('T'_dna4)};
-    EXPECT_EQ(letter.to_rank(), 4);
+    EXPECT_EQ(letter.to_rank(), 3);
 }
 
 TEST(gapped_test, fulfills_concepts)

--- a/test/unit/range/decorator/gap_decorator_anchor_set_test.cpp
+++ b/test/unit/range/decorator/gap_decorator_anchor_set_test.cpp
@@ -211,10 +211,10 @@ TEST(gap_decorator_anchor_set, comparison)
     insert_gap(dec2, dec2.begin(), 1);
 
     EXPECT_NE(dec, dec2); // ACTG-- vs -ACTG--
-    EXPECT_LT(dec2, dec);
-    EXPECT_LE(dec2, dec);
-    EXPECT_GT(dec, dec2);
-    EXPECT_GE(dec, dec2);
+    EXPECT_GT(dec2, dec);
+    EXPECT_GE(dec2, dec);
+    EXPECT_LT(dec, dec2);
+    EXPECT_LE(dec, dec2);
 
     std::vector<dna4> v2{"TCTG"_dna4};
     gap_decorator_anchor_set decNE{v2};


### PR DESCRIPTION
The current behaviour of the alphabet variant for assigning characters was to only query the `rank_to_char` table and leave all other characters to rank 0. Ambiguous character representations were resolved to the first alphabet.

This caused unintuitive behaviour for e.g. `gapped<dna15>`: assigning an unknown character resolved to `gap` (which resolves to `N` for dna15 otherwise) and `a` is treated as an unknown character although it is usually converted to the uppercase character for the other nucleotides.

This PR fixes this behaviour by using the rank_to_char behaviour of the first alphabet.
