### PR TITLE
[FIX] alignment_file/output on gcc9

### DIFF
--- a/include/seqan3/io/alignment_file/output.hpp
+++ b/include/seqan3/io/alignment_file/output.hpp
@@ -466,7 +466,8 @@ public:
                  requires { requires detail::is_type_specialisation_of_v<remove_cvref_t<record_t>, record>; }
     //!\endcond
     {
-        using default_align_t = std::pair<std::basic_string_view<gapped<char>>, std::basic_string_view<gapped<char>>>;
+        // an empty alignment type if field::ALIGNMENT is not set.
+        using default_align_t = std::pair<std::array<gapped<char>, 0>, std::array<gapped<char>, 0>>;
         using default_mate_t  = std::tuple<std::string_view, std::optional<int32_t>, int32_t>;
 
         write_record(detail::get_or<field::HEADER_PTR>(r, nullptr),
@@ -513,7 +514,8 @@ public:
         requires tuple_like_concept<tuple_t>
     //!\endcond
     {
-        using default_align_t = std::pair<std::basic_string_view<gapped<char>>, std::basic_string_view<gapped<char>>>;
+        // an empty alignment type if field::ALIGNMENT is not set.
+        using default_align_t = std::pair<std::array<gapped<char>, 0>, std::array<gapped<char>, 0>>;
         using default_mate_t  = std::tuple<std::string_view, std::optional<int32_t>, int32_t>;
 
         // index_of might return npos, but this will be handled well by get_or_ignore (and just return ignore)

--- a/test/unit/alignment/aligned_sequence_test_template.hpp
+++ b/test/unit/alignment/aligned_sequence_test_template.hpp
@@ -27,7 +27,8 @@ TYPED_TEST_CASE_P(aligned_sequence);
 TYPED_TEST_P(aligned_sequence, fulfills_concept)
 {
     EXPECT_TRUE((AlignedSequence<TypeParam>));
-    EXPECT_FALSE((AlignedSequence<std::vector<dna4>>));
+    EXPECT_FALSE((AlignedSequence<std::vector<dna4>>)); // has no gap character
+    EXPECT_FALSE((AlignedSequence<std::array<gapped<dna4>, 0>>)); // is not modifiable
 }
 
 TYPED_TEST_P(aligned_sequence, assign_unaligned_sequence)


### PR DESCRIPTION
The main problem is that std::string_view requires that the char type
fulfills std::is_trivial_v via static_assert.