### PR TITLE
Fix/small string and take

### DIFF
--- a/include/seqan3/range/container/small_string.hpp
+++ b/include/seqan3/range/container/small_string.hpp
@@ -228,6 +228,33 @@ public:
         sz = count;
         data_[sz] = '\0';
     }
+
+    /*!\brief Removes specified elements from the container.
+     * \param   index Remove the elements starting at `index`. Defaults to `0`.
+     * \param   count The number of elements to remove. Defaults to `max_size()`.
+     * \returns `*this`
+     *
+     * Invalidates iterators and references at or after the point of the erase, including the end() iterator.
+     *
+     * The iterator `pos` must be valid and dereferenceable. Thus the end() iterator (which is valid, but is not
+     * dereferencable) cannot be used as a value for pos.
+     *
+     * ### Complexity
+     *
+     * Linear in size().
+     *
+     * ### Exceptions
+     *
+     * No-throw guarantee.
+     */
+    constexpr small_string & erase(size_type index = 0, size_type count = max_size()) noexcept
+    {
+        assert(index <= this->size());
+
+        iterator it = this->begin() + index;
+        base_t::erase(it, it + std::min<size_type>(count, this->size() - index));
+        return *this;
+    }
     //!\}
 
     /*!\name Concatenation

--- a/include/seqan3/range/view/take.hpp
+++ b/include/seqan3/range/view/take.hpp
@@ -260,7 +260,9 @@ public:
     //!\brief The value_type (which equals the reference_type with any references removed).
     using value_type        = value_type_t<urng_t>;
     //!\brief The size_type is `size_t` if the view is exact, otherwise `void`.
-    using size_type         = std::conditional_t<exactly, size_t, void>;
+    using size_type         = std::conditional_t<exactly,
+                                                 transformation_trait_or_t<seqan3::size_type<urng_t>, size_t>,
+                                                 void>;
     //!\brief A signed integer type, usually std::ptrdiff_t.
     using difference_type   = difference_type_t<urng_t>;
     //!\brief The iterator type of this view (a random access iterator).

--- a/test/unit/core/metafunction/range_iterator_test.cpp
+++ b/test/unit/core/metafunction/range_iterator_test.cpp
@@ -58,8 +58,8 @@ void expect_same_types()
     constexpr bool val = std::is_same_v<meta::at_c<list1, pos>, meta::at_c<list2, pos>>;
     if constexpr (!val)
     {
-        std::cerr << "\'" << detail::get_display_name_v<meta::at_c<list1, pos>> << "\' not equal to \'"
-                  << detail::get_display_name_v<meta::at_c<list2, pos>> << "\' \n";
+        std::cerr << "pos: " << pos << " \'" << detail::get_display_name_v<meta::at_c<list1, pos>>
+                  << "\' not equal to \'" << detail::get_display_name_v<meta::at_c<list2, pos>> << "\' \n";
     }
     EXPECT_TRUE(val);
 
@@ -208,17 +208,13 @@ TEST(range_and_iterator, size_type_)
                                  size_type_t<foreign_iterator>,                    // iterator2
                                  size_type_t<decltype(v)>>;                        // range, no member
 
-    // see above
-    using view_int_size_t = std::conditional_t<sizeof(std::size_t) == 8,
-                                               std::uint_fast64_t,
-                                               std::uint_fast32_t>;
     using comp_list = meta::list<size_t,
                                  size_t,
                                  size_t,
                                  size_t,
                                  size_t,
                                  size_t,
-                                 view_int_size_t>;
+                                 size_t>;
 
     expect_same_types<type_list, comp_list>();
 }

--- a/test/unit/range/container/small_string_test.cpp
+++ b/test/unit/range/container/small_string_test.cpp
@@ -338,3 +338,39 @@ TEST(small_string, compile_time_fill)
     constexpr bool cmp = fill_small_string(small_string<4>{}, 'x') == small_string{"xxxx"};
     EXPECT_TRUE(cmp);
 }
+
+TEST(small_string, output)
+{
+    small_string em{"hello"};
+    std::ostringstream os;
+    os << em;
+    EXPECT_EQ(os.str(), "hello"s);
+}
+
+TEST(small_string, input)
+{
+    { // Until whitespace
+        small_string<50> em{"test"};
+        std::istringstream is{"hello test"};
+        is >> em;
+        EXPECT_EQ(em.str(), "hello"s);
+    }
+
+    { // Exceed capacity
+        small_string<5> em{"test"};
+        std::istringstream is{"hellotest"};
+        is >> em;
+        EXPECT_EQ(em.str(), "hello"s);
+
+        std::string remaining{};
+        is >> remaining;
+        EXPECT_EQ(remaining, "test"s);
+    }
+
+    { // eof before capacity reached
+        small_string<50> em{""};
+        std::istringstream is{"hellotest"};
+        is >> em;
+        EXPECT_EQ(em.str(), "hellotest"s);
+    }
+}

--- a/test/unit/range/container/small_string_test.cpp
+++ b/test/unit/range/container/small_string_test.cpp
@@ -111,6 +111,29 @@ TEST(small_string, implicit_conversion)
     EXPECT_EQ(str, "hello"s);  // explicit
 }
 
+constexpr bool erase_test()
+{
+    small_string em{"hello"};
+    em.erase();
+    bool res = em.empty();
+
+    small_string em1{"hello"};
+    em1.erase(2);
+    res = res && (em1 == small_string<5>{"he"});
+
+    small_string em2{"hello"};
+    em2.erase(2, 2);
+    res = res && (em2 == small_string<5>{"heo"});
+
+    return res;
+}
+
+TEST(small_string, erase)
+{
+    constexpr bool res = erase_test();
+    EXPECT_TRUE(res);
+}
+
 TEST(small_string, concat)
 {
     {


### PR DESCRIPTION
Yesterday while building all tests of the library for mac I spotted an error in the range iterator test. It caused an error when printing the small_string to std::cerr. Since the small_string should mimic the string interface I added overloads for the formatted input and output. Thereby, I saw that string has an additional erase interface which I added as well. 
Then while investigating the error, I updated the size type of the take view to use the size type of the underlying range if applicable. Still the test was wrong, because the size type in the test changed no matter what you would do. .