### PR TITLE
[FEATURE] introduce ranges::to; remove implicit conversions

### DIFF
--- a/include/seqan3/range/view/persist.hpp
+++ b/include/seqan3/range/view/persist.hpp
@@ -140,22 +140,6 @@ public:
         return end();
     }
     //!\}
-
-    /*!\brief Convert this view into a container implicitly.
-     * \tparam container_t Type of the container to convert to; must satisfy seqan3::SequenceContainer and the
-     *                     seqan3::reference_t of both must model std::CommonReference.
-     * \returns This view converted to container_t.
-     */
-    template <SequenceContainer container_t>
-    operator container_t() const
-    //!\cond
-        requires std::CommonReference<reference_t<std::remove_reference_t<container_t>>, reference>
-    //!\endcond
-    {
-        container_t ret;
-        std::ranges::copy(begin(), end(), std::back_inserter(ret));
-        return ret;
-    }
 };
 
 //!\brief Template argument type deduction guide that strips references.

--- a/include/seqan3/range/view/take.hpp
+++ b/include/seqan3/range/view/take.hpp
@@ -430,34 +430,6 @@ public:
     {
         return target_size;
     }
-
-    /*!\brief Convert this view into a container implicitly.
-     * \tparam container_t Type of the container to convert to; must satisfy seqan3::SequenceContainer and the
-     *                     seqan3::reference_t of both must model std::CommonReference.
-     * \returns This view converted to container_t.
-     */
-    template <SequenceContainer container_t>
-    operator container_t()
-    //!\cond
-        requires std::CommonReference<reference_t<container_t>, reference>
-    //!\endcond
-    {
-        container_t ret;
-        std::ranges::copy(begin(), end(), std::back_inserter(ret));
-        return ret;
-    }
-
-    //!\overload
-    template <SequenceContainer container_t>
-    operator container_t() const
-    //!\cond
-        requires ConstIterableRange<urng_t> && std::CommonReference<reference_t<container_t>, const_reference>
-    //!\endcond
-    {
-        container_t ret;
-        std::ranges::copy(cbegin(), cend(), std::back_inserter(ret));
-        return ret;
-    }
 };
 
 //!\brief Template argument type deduction guide that strips references.

--- a/include/seqan3/range/view/take_until.hpp
+++ b/include/seqan3/range/view/take_until.hpp
@@ -470,34 +470,6 @@ public:
         return std::ranges::cend(urange);
     }
     //!\}
-
-    /*!\brief Convert this view into a container implicitly.
-     * \tparam container_t Type of the container to convert to; must model seqan3::SequenceContainer and it's
-     *                     seqan3::reference_t must model std::CommonReference with `reference`.
-     * \returns This view converted to container_t.
-     */
-    template <SequenceContainer container_t>
-    operator container_t()
-    //!\cond
-        requires std::CommonReference<reference_t<container_t>, reference>
-    //!\endcond
-    {
-        container_t ret;
-        std::ranges::copy(begin(), end(), std::back_inserter(ret));
-        return ret;
-    }
-
-    //!\overload
-    template <SequenceContainer container_t>
-    operator container_t() const
-    //!\cond
-        requires ConstIterableRange<urng_t> && std::CommonReference<reference_t<container_t>, const_reference>
-    //!\endcond
-    {
-        container_t ret;
-        std::ranges::copy(cbegin(), cend(), std::back_inserter(ret));
-        return ret;
-    }
 };
 
 //!\brief Type deduction guide that strips references.

--- a/include/seqan3/std/ranges
+++ b/include/seqan3/std/ranges
@@ -218,7 +218,13 @@ using SEQAN3_DOXYGEN_ONLY(cend =) ::ranges::cend;
 */
 template <typename urng_t>
 using view_interface = ::ranges::view_interface<urng_t>;
+
+/*!\typedef std::ranges::to
+ * \brief Alias for ranges::to.
+ */
+using SEQAN3_DOXYGEN_ONLY(to =) ::ranges::_to_::to;
 //!\}
+
 } // namespace std::ranges
 
 // -----------------------------------------------------------------------------------------------------

--- a/test/unit/range/view/view_char_to_test.cpp
+++ b/test/unit/range/view/view_char_to_test.cpp
@@ -23,16 +23,16 @@ TEST(view_char_to, basic)
     dna5_vector cmp{"ACTTTGATA"_dna5};
 
     // pipe notation
-    dna5_vector v = vec | view::char_to<dna5>;
+    dna5_vector v = vec | view::char_to<dna5> | std::ranges::to<std::vector>;
     EXPECT_EQ(cmp, v);
 
     // function notation
-    dna5_vector v2(view::char_to<dna5>(vec));
+    dna5_vector v2(view::char_to<dna5>(vec) | std::ranges::to<std::vector>);
     EXPECT_EQ(cmp, v2);
 
     // combinability
     dna5_vector cmp2{"ATAGTTTCA"_dna5};
-    dna5_vector v3 = vec | view::char_to<dna5> | std::view::reverse;
+    dna5_vector v3 = vec | view::char_to<dna5> | std::view::reverse | std::ranges::to<std::vector>;
     EXPECT_EQ(cmp2, v3);
 }
 
@@ -40,7 +40,7 @@ TEST(view_char_to, deep_view)
 {
     std::vector<std::string> foo{"ACGTA", "TGCAT"};
 
-    std::vector<dna5_vector> v = foo | view::char_to<dna5>;
+    std::vector<dna5_vector> v = foo | view::char_to<dna5> | std::ranges::to<std::vector<dna5_vector>>;
 
     ASSERT_EQ(size(v), 2u);
     EXPECT_TRUE((std::ranges::equal(v[0], "ACGTA"_dna5)));

--- a/test/unit/range/view/view_complement_test.cpp
+++ b/test/unit/range/view/view_complement_test.cpp
@@ -22,29 +22,29 @@ TEST(view_complement, basic)
     dna5_vector foo{"ACGTA"_dna5};
 
     // pipe notation
-    dna5_vector v = foo | view::complement;
+    dna5_vector v = foo | view::complement | std::ranges::to<std::vector>;
     EXPECT_EQ(v, "TGCAT"_dna5);
 
     // function notation
-    dna5_vector v2(view::complement(foo));
+    dna5_vector v2(view::complement(foo) | std::ranges::to<std::vector>);
     EXPECT_EQ(v2, "TGCAT"_dna5);
 
     // combinability
-    dna5_vector v3 = foo | view::complement | std::view::reverse;
+    dna5_vector v3 = foo | view::complement | std::view::reverse | std::ranges::to<std::vector>;
     EXPECT_EQ(v3, "TACGT"_dna5);
 
     dna5_vector const bar{"ACGTA"_dna5};
 
     // const pipe notation
-    dna5_vector v4 = bar | view::complement;
+    dna5_vector v4 = bar | view::complement | std::ranges::to<std::vector>;
     EXPECT_EQ(v4, "TGCAT"_dna5);
 
     // const function notation
-    dna5_vector v5(view::complement(bar));
+    dna5_vector v5(view::complement(bar) | std::ranges::to<std::vector>);
     EXPECT_EQ(v5, "TGCAT"_dna5);
 
     // const combinability
-    dna5_vector v6 = bar | view::complement | std::view::reverse;
+    dna5_vector v6 = bar | view::complement | std::view::reverse | std::ranges::to<std::vector>;
     EXPECT_EQ(v6, "TACGT"_dna5);
 }
 

--- a/test/unit/range/view/view_convert_test.cpp
+++ b/test/unit/range/view/view_convert_test.cpp
@@ -22,16 +22,16 @@ TEST(view_convert, basic)
     std::vector<bool> cmp{1, 1, 0, 1, 0, 0, 1, 1, 1};
 
     // pipe notation
-    std::vector<bool> v = vec | view::convert<bool>;
+    std::vector<bool> v = vec | view::convert<bool> | std::ranges::to<std::vector>;
     EXPECT_EQ(cmp, v);
 
     // function notation
-    std::vector<bool> v2(view::convert<bool>(vec));
+    std::vector<bool> v2(view::convert<bool>(vec) | std::ranges::to<std::vector>);
     EXPECT_EQ(cmp, v2);
 
     // combinability
     std::vector<bool> cmp2{1, 1, 1, 0, 0, 1, 0, 1, 1};
-    std::vector<bool> v3 = vec | view::convert<bool> | std::view::reverse;
+    std::vector<bool> v3 = vec | view::convert<bool> | std::view::reverse | std::ranges::to<std::vector>;
     EXPECT_EQ(cmp2, v3);
 }
 
@@ -41,16 +41,16 @@ TEST(view_convert, explicit_conversion)
     dna4_vector cmp{"ACGATAGGA"_dna4};
 
     // pipe notation
-    dna4_vector v = vec | view::convert<dna4>;
+    dna4_vector v = vec | view::convert<dna4> | std::ranges::to<std::vector>;
     EXPECT_EQ(cmp, v);
 
     // function notation
-    dna4_vector v2(view::convert<dna4>(vec));
+    dna4_vector v2(view::convert<dna4>(vec) | std::ranges::to<std::vector>);
     EXPECT_EQ(cmp, v2);
 
     // combinability
     dna4_vector cmp2{"AGGATAGCA"_dna4};
-    dna4_vector v3 = vec | view::convert<dna4> | std::view::reverse;
+    dna4_vector v3 = vec | view::convert<dna4> | std::view::reverse | std::ranges::to<std::vector>;
     EXPECT_EQ(cmp2, v3);
 }
 

--- a/test/unit/range/view/view_deep_test.cpp
+++ b/test/unit/range/view/view_deep_test.cpp
@@ -34,19 +34,19 @@ TEST(view_deep_reverse, basic)
     dna5_vector foo{"ACGTA"_dna5};
 
     // pipe notation, temporary
-    dna5_vector v0 = foo | view::deep{std::view::reverse};
+    dna5_vector v0 = foo | view::deep{std::view::reverse} | std::ranges::to<std::vector>;
     EXPECT_EQ(v0, "ATGCA"_dna5);
 
     // pipe notation
-    dna5_vector v = foo | view::deep_reverse;
+    dna5_vector v = foo | view::deep_reverse | std::ranges::to<std::vector>;
     EXPECT_EQ(v, "ATGCA"_dna5);
 
     // function notation
-    dna5_vector v2(view::deep_reverse(foo));
+    dna5_vector v2(view::deep_reverse(foo) | std::ranges::to<std::vector>);
     EXPECT_EQ(v2, "ATGCA"_dna5);
 
     // combinability
-    dna5_vector v3 = foo | view::deep_reverse | std::view::reverse;
+    dna5_vector v3 = foo | view::deep_reverse | std::view::reverse | std::ranges::to<std::vector>;
     EXPECT_EQ(v3, "ACGTA"_dna5);
 }
 
@@ -106,19 +106,19 @@ TEST(view_deep_take, basic)
     dna5_vector foo{"ACGTA"_dna5};
 
     // pipe notation, temporary
-    dna5_vector v0 = foo | view::deep{ranges::view::take}(2);
+    dna5_vector v0 = foo | view::deep{ranges::view::take}(2) | std::ranges::to<std::vector>;
     EXPECT_EQ(v0, "AC"_dna5);
 
     // pipe notation
-    dna5_vector v = foo | view::deep_take(2);
+    dna5_vector v = foo | view::deep_take(2) | std::ranges::to<std::vector>;
     EXPECT_EQ(v, "AC"_dna5);
 
     // function notation
-    dna5_vector v2(view::deep_take(foo, 2));
+    dna5_vector v2(view::deep_take(foo, 2) | std::ranges::to<std::vector>);
     EXPECT_EQ(v2, "AC"_dna5);
 
     // combinability
-    dna5_vector v3 = foo | view::deep_take(2) | std::view::reverse;
+    dna5_vector v3 = foo | view::deep_take(2) | std::view::reverse | std::ranges::to<std::vector>;
     EXPECT_EQ(v3, "CA"_dna5);
 }
 
@@ -151,19 +151,19 @@ TEST(view_deep_take2, basic)
     dna5_vector foo{"ACGTA"_dna5};
 
     // pipe notation, temporary
-    dna5_vector v0 = foo | view::deep{ranges::view::take(2)};
+    dna5_vector v0 = foo | view::deep{ranges::view::take(2)} | std::ranges::to<std::vector>;
     EXPECT_EQ(v0, "AC"_dna5);
 
     // pipe notation
-    dna5_vector v = foo | view::deep_take2;
+    dna5_vector v = foo | view::deep_take2 | std::ranges::to<std::vector>;
     EXPECT_EQ(v, "AC"_dna5);
 
     // function notation
-    dna5_vector v2(view::deep_take2(foo));
+    dna5_vector v2(view::deep_take2(foo) | std::ranges::to<std::vector>);
     EXPECT_EQ(v2, "AC"_dna5);
 
     // combinability
-    dna5_vector v3 = foo | view::deep_take2 | std::view::reverse;
+    dna5_vector v3 = foo | view::deep_take2 | std::view::reverse | std::ranges::to<std::vector>;
     EXPECT_EQ(v3, "CA"_dna5);
 }
 

--- a/test/unit/range/view/view_drop_test.cpp
+++ b/test/unit/range/view/view_drop_test.cpp
@@ -39,24 +39,24 @@ void do_test(adaptor_t const & adaptor, std::string const & vec)
     EXPECT_EQ("bar", std::string(v));
 
     // function notation
-    std::string v2{adaptor(vec, 3)};
+    std::string v2{adaptor(vec, 3) | std::ranges::to<std::string>};
     EXPECT_EQ("bar", v2);
 
     // combinability
     auto v3 = vec | adaptor(1) | adaptor(1) | ranges::view::unique;
     EXPECT_EQ("obar", std::string(v3));
-    std::string v3b = vec | std::view::reverse | adaptor(3) | ranges::view::unique;
+    std::string v3b = vec | std::view::reverse | adaptor(3) | ranges::view::unique | std::ranges::to<std::string>;
     EXPECT_EQ("of", v3b);
 
     // store arg
     auto a0 = adaptor(3);
     auto v4 = vec | a0;
-    EXPECT_EQ("bar", std::string(v4));
+    EXPECT_EQ("bar", std::string(v4 | std::ranges::to<std::string>));
 
     // store combined
     auto a1 = adaptor(1) | adaptor(1) | ranges::view::unique;
     auto v5 = vec | a1;
-    EXPECT_EQ("obar", std::string(v5));
+    EXPECT_EQ("obar", std::string(v5 | std::ranges::to<std::string>));
 }
 
 template <typename adaptor_t>
@@ -118,7 +118,8 @@ TEST(view_drop, underlying_is_shorter)
     EXPECT_NO_THROW(( view::drop(vec, 4) )); // no parsing
 
     std::string v;
-    EXPECT_NO_THROW(( v = vec | view::single_pass_input | view::drop(4) )); // full parsing on conversion
+    // full parsing on conversion
+    EXPECT_NO_THROW(( v = vec | view::single_pass_input | view::drop(4)  | std::ranges::to<std::string>));
     EXPECT_EQ("ar", v);
 }
 

--- a/test/unit/range/view/view_get_test.cpp
+++ b/test/unit/range/view/view_get_test.cpp
@@ -29,24 +29,24 @@ TEST(view_get, basic)
     std::vector<phred42> cmp1{phred42{0}, phred42{1}, phred42{2}, phred42{3}};
 
     //functor
-    dna4_vector functor0 = view::get<0>(qv);
-    std::vector<phred42> functor1 = view::get<1>(qv);
+    dna4_vector functor0 = view::get<0>(qv) | std::ranges::to<std::vector>;
+    std::vector<phred42> functor1 = view::get<1>(qv) | std::ranges::to<std::vector>;
     EXPECT_EQ(cmp0, functor0);
     EXPECT_EQ(cmp1, functor1);
 
     // pipe notation
-    dna4_vector pipe0 = qv | view::get<0>;
-    std::vector<phred42> pipe1 = qv | view::get<1>;
+    dna4_vector pipe0 = qv | view::get<0> | std::ranges::to<std::vector>;
+    std::vector<phred42> pipe1 = qv | view::get<1> | std::ranges::to<std::vector>;
     EXPECT_EQ(cmp0, pipe0);
     EXPECT_EQ(cmp1, pipe1);
 
     // combinability
     dna4_vector cmp2{"TGCA"_dna4};
-    dna4_vector comp = qv | view::get<0> | view::complement;
+    dna4_vector comp = qv | view::get<0> | view::complement | std::ranges::to<std::vector>;
     EXPECT_EQ(cmp2, comp);
 
     std::string cmp3{"TGCA"};
-    std::string to_char_test = comp | view::to_char;
+    std::string to_char_test = comp | view::to_char | std::ranges::to<std::string>;
     EXPECT_EQ(cmp3, to_char_test);
 
     // reference return check
@@ -66,35 +66,35 @@ TEST(view_get, advanced)
     // functor notation
     std::vector<masked<dna4>> cmp0{{'A'_dna4, mask::MASKED}, {'C'_dna4, mask::UNMASKED},
                                   {'G'_dna4, mask::MASKED}, {'T'_dna4, mask::UNMASKED}};
-    std::vector<masked<dna4>> functor0 = view::get<0>(t);
+    std::vector<masked<dna4>> functor0 = view::get<0>(t) | std::ranges::to<std::vector>;
     EXPECT_EQ(cmp0, functor0);
 
     std::vector<phred42> cmp1{phred42{0}, phred42{1}, phred42{2}, phred42{3}};
-    std::vector<phred42> functor1 = view::get<1>(t);
+    std::vector<phred42> functor1 = view::get<1>(t) | std::ranges::to<std::vector>;
     EXPECT_EQ(cmp1, functor1);
 
     std::vector<dna4> cmp00{'A'_dna4, 'C'_dna4, 'G'_dna4, 'T'_dna4};
-    std::vector<dna4> functor00 = view::get<0>(view::get<0>(t));
+    std::vector<dna4> functor00 = view::get<0>(view::get<0>(t)) | std::ranges::to<std::vector>;
     EXPECT_EQ(cmp00, functor00);
 
     // pipe notation
-    std::vector<masked<dna4>> pipe0 = t | view::get<0>;
+    std::vector<masked<dna4>> pipe0 = t | view::get<0> | std::ranges::to<std::vector>;
     EXPECT_EQ(cmp0, pipe0);
 
-    std::vector<phred42> pipe1 = t | view::get<1>;
+    std::vector<phred42> pipe1 = t | view::get<1> | std::ranges::to<std::vector>;
     EXPECT_EQ(cmp1, pipe1);
 
-    std::vector<dna4> pipe00 = t | view::get<0> | view::get<0>;
+    std::vector<dna4> pipe00 = t | view::get<0> | view::get<0> | std::ranges::to<std::vector>;
     EXPECT_EQ(cmp00, pipe00);
 
     // combinability
     std::vector<masked<dna4>> cmprev{{'T'_dna4, mask::UNMASKED}, {'G'_dna4, mask::MASKED},
                                      {'C'_dna4, mask::UNMASKED}, {'A'_dna4, mask::MASKED}};
-    std::vector<masked<dna4>> revtest = t | view::get<0> | std::view::reverse;
+    std::vector<masked<dna4>> revtest = t | view::get<0> | std::view::reverse | std::ranges::to<std::vector>;
     EXPECT_EQ(cmprev, revtest);
 
     std::vector<dna4> cmprev2{'T'_dna4, 'G'_dna4, 'C'_dna4, 'A'_dna4};
-    std::vector<dna4> revtest2 = t | view::get<0> | view::get<0> | std::view::reverse;
+    std::vector<dna4> revtest2 = t | view::get<0> | view::get<0> | std::view::reverse | std::ranges::to<std::vector>;
     EXPECT_EQ(cmprev2, revtest2);
 
     // reference check
@@ -111,8 +111,8 @@ TEST(view_get, tuple_pair)
 
     // functor notation
     std::vector<int> cmp{0, 1, 2, 3};
-    std::vector<int> pair_func = view::get<0>(pair_test);
-    std::vector<int> tuple_func = view::get<0>(tuple_test);
+    std::vector<int> pair_func = view::get<0>(pair_test) | std::ranges::to<std::vector>;
+    std::vector<int> tuple_func = view::get<0>(tuple_test) | std::ranges::to<std::vector>;
     EXPECT_EQ(cmp, pair_func);
     EXPECT_EQ(cmp, tuple_func);
 
@@ -125,8 +125,8 @@ TEST(view_get, tuple_pair)
 
     // pipe notation
     cmp[0] = 0;
-    std::vector<int> pair_pipe = pair_test | view::get<0>;
-    std::vector<int> tuple_pipe = tuple_test | view::get<0>;
+    std::vector<int> pair_pipe = pair_test | view::get<0> | std::ranges::to<std::vector>;
+    std::vector<int> tuple_pipe = tuple_test | view::get<0> | std::ranges::to<std::vector>;
     EXPECT_EQ(cmp, pair_pipe);
     EXPECT_EQ(cmp, tuple_pipe);
 }

--- a/test/unit/range/view/view_kmer_hash_test.cpp
+++ b/test/unit/range/view/view_kmer_hash_test.cpp
@@ -19,25 +19,25 @@ TEST(kmer_hash, view)
 {
     {
         std::vector<dna4> text{"AAAAA"_dna4};
-        std::vector<size_t> hashes = text | view::kmer_hash(3);
+        std::vector<size_t> hashes = text | view::kmer_hash(3) | std::ranges::to<std::vector>;
         std::vector<size_t> expected{0,0,0};
         EXPECT_EQ(expected, hashes);
     }
     {
         std::vector<dna4> text{"ACGTAGC"_dna4};
-        std::vector<size_t> hashes = text | view::kmer_hash(3);
+        std::vector<size_t> hashes = text | view::kmer_hash(3) | std::ranges::to<std::vector>;
         std::vector<size_t> expected{6,27,44,50,9};
         EXPECT_EQ(expected, hashes);
     }
     {
         std::vector<dna4> text{"AC"_dna4};
-        std::vector<size_t> hashes = text | view::kmer_hash(3);
+        std::vector<size_t> hashes = text | view::kmer_hash(3) | std::ranges::to<std::vector>;
         std::vector<size_t> expected{};
         EXPECT_EQ(expected, hashes);
     }
     {
         bitcompressed_vector<dna4> text{"ACGTAGC"_dna4};
-        std::vector<size_t> hashes = text | view::kmer_hash(3);
+        std::vector<size_t> hashes = text | view::kmer_hash(3) | std::ranges::to<std::vector>;
         std::vector<size_t> expected{6,27,44,50,9};
         EXPECT_EQ(expected, hashes);
     }
@@ -47,25 +47,25 @@ TEST(kmer_hash, const_view)
 {
     {
         std::vector<dna4> const text{"AAAAA"_dna4};
-        std::vector<size_t> hashes = text | view::kmer_hash(3);
+        std::vector<size_t> hashes = text | view::kmer_hash(3) | std::ranges::to<std::vector>;
         std::vector<size_t> expected{0,0,0};
         EXPECT_EQ(expected, hashes);
     }
     {
         std::vector<dna4> const text{"ACGTAGC"_dna4};
-        std::vector<size_t> hashes = text | view::kmer_hash(3);
+        std::vector<size_t> hashes = text | view::kmer_hash(3) | std::ranges::to<std::vector>;
         std::vector<size_t> expected{6,27,44,50,9};
         EXPECT_EQ(expected, hashes);
     }
     {
         std::vector<dna4> const text{"AC"_dna4};
-        std::vector<size_t> hashes = text | view::kmer_hash(3);
+        std::vector<size_t> hashes = text | view::kmer_hash(3) | std::ranges::to<std::vector>;
         std::vector<size_t> expected{};
         EXPECT_EQ(expected, hashes);
     }
     {
         bitcompressed_vector<dna4> const text{"ACGTAGC"_dna4};
-        std::vector<size_t> hashes = text | view::kmer_hash(3);
+        std::vector<size_t> hashes = text | view::kmer_hash(3) | std::ranges::to<std::vector>;
         std::vector<size_t> expected{6,27,44,50,9};
         EXPECT_EQ(expected, hashes);
     }

--- a/test/unit/range/view/view_persist_test.cpp
+++ b/test/unit/range/view/view_persist_test.cpp
@@ -33,13 +33,13 @@ TEST(view_persist, delegate_to_view_all)
     EXPECT_EQ("foo", std::string{v});
 
     // function notation
-    std::string v2 = view::persist(vec);
+    std::string v2 = view::persist(vec) | std::ranges::to<std::string>;
     EXPECT_EQ("foo", v2);
 
     // combinability
     auto v3 = vec | view::persist | ranges::view::unique;
     EXPECT_EQ("fo", std::string{v3});
-    std::string v3b = vec | std::view::reverse | view::persist | ranges::view::unique;
+    std::string v3b = vec | std::view::reverse | view::persist | ranges::view::unique | std::ranges::to<std::string>;
     EXPECT_EQ("of", v3b);
 
     // store combined
@@ -55,13 +55,17 @@ TEST(view_persist, wrap_temporary)
     EXPECT_EQ("foo", std::string(v));
 
     // function notation
-    std::string v2 = view::persist(std::string{"foo"});
+    std::string v2 = view::persist(std::string{"foo"}) | std::ranges::to<std::string>;
     EXPECT_EQ("foo", v2);
 
     // combinability
     auto v3 = std::string{"foo"} | view::persist | ranges::view::unique;
     EXPECT_EQ("fo", std::string(v3));
-    std::string v3b = std::string{"foo"} | view::persist | std::view::filter(is_char<'o'>) | ranges::view::unique;
+    std::string v3b = std::string{"foo"}
+                    | view::persist
+                    | std::view::filter(is_char<'o'>)
+                    | ranges::view::unique
+                    | std::ranges::to<std::string>;
     EXPECT_EQ("o", v3b);
 }
 

--- a/test/unit/range/view/view_rank_to_test.cpp
+++ b/test/unit/range/view/view_rank_to_test.cpp
@@ -22,16 +22,16 @@ TEST(view_rank_to, basic)
     dna5_vector cmp{"ACTTTGATA"_dna5};
 
     // pipe notation
-    dna5_vector v = vec | view::rank_to<dna5>;
+    dna5_vector v = vec | view::rank_to<dna5> | std::ranges::to<std::vector>;
     EXPECT_EQ(cmp, v);
 
     // function notation
-    dna5_vector v2(view::rank_to<dna5>(vec));
+    dna5_vector v2(view::rank_to<dna5>(vec) | std::ranges::to<std::vector>);
     EXPECT_EQ(cmp, v2);
 
     // combinability
     dna5_vector cmp2{"ATAGTTTCA"_dna5};
-    dna5_vector v3 = vec | view::rank_to<dna5> | std::view::reverse;
+    dna5_vector v3 = vec | view::rank_to<dna5> | std::view::reverse | std::ranges::to<std::vector>;
     EXPECT_EQ(cmp2, v3);
 }
 

--- a/test/unit/range/view/view_slice_test.cpp
+++ b/test/unit/range/view/view_slice_test.cpp
@@ -35,32 +35,32 @@ void do_test(adaptor_t const & adaptor, std::string const & vec)
 {
     // pipe notation
     auto v = vec | adaptor(1, 4);
-    EXPECT_EQ("oob", std::string(v));
+    EXPECT_EQ("oob", v | std::ranges::to<std::string>);
 
     // function notation
-    std::string v2{adaptor(vec, 1, 4)};
+    std::string v2{adaptor(vec, 1, 4) | std::ranges::to<std::string>};
     EXPECT_EQ("oob", v2);
 
     // combinability
     auto v3 = vec | adaptor(0, 4) | adaptor(1, 3) | ranges::view::unique;
-    EXPECT_EQ("o", std::string(v3));
-    std::string v3b = vec | std::view::reverse | adaptor(1, 4) | ranges::view::unique;
+    EXPECT_EQ("o", v3 | std::ranges::to<std::string>);
+    std::string v3b = vec | std::view::reverse | adaptor(1, 4) | ranges::view::unique | std::ranges::to<std::string>;
     EXPECT_EQ("abo", v3b);
 
     // store arg
     auto a0 = adaptor(1, 4);
     auto v4 = vec | a0;
-    EXPECT_EQ("oob", std::string(v4));
+    EXPECT_EQ("oob", v4 | std::ranges::to<std::string>);
 
     // store combined
     auto a1 = adaptor(0, 4) | adaptor(1, 3) | ranges::view::unique;
     auto v5 = vec | a1;
-    EXPECT_EQ("o", std::string(v5));
+    EXPECT_EQ("o", v5 | std::ranges::to<std::string>);
 
     // store combined in middle
     auto a2 = std::view::reverse | adaptor(1, 4) | ranges::view::unique;
     auto v6 = vec | a2;
-    EXPECT_EQ("abo", std::string(v6));
+    EXPECT_EQ("abo", v6 | std::ranges::to<std::string>);
 }
 
 template <typename adaptor_t>
@@ -122,7 +122,8 @@ TEST(view_slice, underlying_is_shorter)
     EXPECT_NO_THROW(( view::slice(vec, 1, 4) )); // no parsing
 
     std::string v;
-    EXPECT_NO_THROW(( v = vec | view::single_pass_input | view::slice(1, 4) )); // full parsing on conversion
+    // full parsing on conversion
+    EXPECT_NO_THROW(( v = vec | view::single_pass_input | view::slice(1, 4) | std::ranges::to<std::string> ));
     EXPECT_EQ("oob", v);
 }
 

--- a/test/unit/range/view/view_take_line_test.cpp
+++ b/test/unit/range/view/view_take_line_test.cpp
@@ -29,22 +29,22 @@ void do_test(adaptor_t const & adaptor, std::string const & vec)
 {
     // pipe notation
     auto v = vec | adaptor;
-    EXPECT_EQ("foo", std::string(v));
+    EXPECT_EQ("foo", v | std::ranges::to<std::string>);
 
     // function notation
-    std::string v2(adaptor(vec));
+    std::string v2(adaptor(vec) | std::ranges::to<std::string>);
     EXPECT_EQ("foo", v2);
 
     // combinability
     auto v3 = vec | adaptor | ranges::view::unique;
-    EXPECT_EQ("fo", std::string(v3));
-    std::string v3b = vec | std::view::reverse | adaptor | ranges::view::unique;
+    EXPECT_EQ("fo", v3 | std::ranges::to<std::string>);
+    std::string v3b = vec | std::view::reverse | adaptor | ranges::view::unique | std::ranges::to<std::string>;
     EXPECT_EQ("rab", v3b);
 
     // consuming behaviour
     auto v4 = vec | view::single_pass_input;
     auto v5 = std::move(v4) | adaptor;
-    EXPECT_EQ("foo", std::string(v5));
+    EXPECT_EQ("foo", v5 | std::ranges::to<std::string>);
     EXPECT_EQ('b', *begin(v5)); // not newline
 }
 
@@ -114,8 +114,8 @@ TEST(view_take_line, eol_at_first_position)
     using sbt = std::istreambuf_iterator<char>;
     std::istringstream vec{"\n\nfoo"};
     auto stream_view = std::ranges::subrange<decltype(sbt{vec}), decltype(sbt{})> {sbt{vec}, sbt{}};
-    EXPECT_EQ("", std::string(stream_view | view::take_line));
-    EXPECT_EQ("foo", std::string(stream_view | view::take_line));
+    EXPECT_EQ("", stream_view | view::take_line | std::ranges::to<std::string>);
+    EXPECT_EQ("foo", stream_view | view::take_line | std::ranges::to<std::string>);
 }
 
 TEST(view_take_line, concepts)

--- a/test/unit/range/view/view_take_test.cpp
+++ b/test/unit/range/view/view_take_test.cpp
@@ -36,20 +36,20 @@ void do_test(adaptor_t const & adaptor, std::string const & vec)
 {
     // pipe notation
     auto v = vec | adaptor(3);
-    EXPECT_EQ("foo", std::string(v));
+    EXPECT_EQ("foo", v | std::ranges::to<std::string>);
 
     // iterators (code coverage)
     EXPECT_EQ(v.begin(), v.begin());
     EXPECT_NE(v.begin(), v.end());
 
     // function notation
-    std::string v2{adaptor(vec, 3)};
+    std::string v2{adaptor(vec, 3) | std::ranges::to<std::string>};
     EXPECT_EQ("foo", v2);
 
     // combinability
     auto v3 = vec | adaptor(3) | adaptor(3) | ranges::view::unique;
-    EXPECT_EQ("fo", std::string(v3));
-    std::string v3b = vec | std::view::reverse | adaptor(3) | ranges::view::unique;
+    EXPECT_EQ("fo", v3 | std::ranges::to<std::string>);
+    std::string v3b = vec | std::view::reverse | adaptor(3) | ranges::view::unique | std::ranges::to<std::string>;
     EXPECT_EQ("rab", v3b);
 
     // comparability against self
@@ -115,7 +115,8 @@ TEST(view_take, underlying_is_shorter)
     EXPECT_NO_THROW(( view::take(vec, 4) )); // no parsing
 
     std::string v;
-    EXPECT_NO_THROW(( v = vec | view::single_pass_input | view::take(4) )); // full parsing on conversion
+    // full parsing on conversion
+    EXPECT_NO_THROW(( v = vec | view::single_pass_input | view::take(4) | std::ranges::to<std::string>));
     EXPECT_EQ("foo", v);
 }
 

--- a/test/unit/range/view/view_take_until_test.cpp
+++ b/test/unit/range/view/view_take_until_test.cpp
@@ -29,22 +29,22 @@ void do_test(adaptor_t const & adaptor, fun_t && fun, std::string const & vec)
 {
     // pipe notation
     auto v = vec | adaptor(fun);
-    EXPECT_EQ("foo", std::string(v));
+    EXPECT_EQ("foo", v  | std::ranges::to<std::string>);
 
     // function notation
-    std::string v2 = adaptor(vec, fun);
+    std::string v2 = adaptor(vec, fun) | std::ranges::to<std::string>;
     EXPECT_EQ("foo", v2);
 
     // combinability
     auto v3 = vec | adaptor(fun) | ranges::view::unique;
-    EXPECT_EQ("fo", std::string(v3));
-    std::string v3b = vec | std::view::reverse | adaptor(fun) | ranges::view::unique;
+    EXPECT_EQ("fo", v3  | std::ranges::to<std::string>);
+    std::string v3b = vec | std::view::reverse | adaptor(fun) | ranges::view::unique | std::ranges::to<std::string>;
     EXPECT_EQ("rab", v3b);
 
     // pointer as iterator
     std::span s{std::ranges::data(vec), vec.size()};
     auto v4 = s | adaptor(fun);
-    EXPECT_EQ("foo", std::string(v4));
+    EXPECT_EQ("foo", v4 | std::ranges::to<std::string>);
 
     // comparability against self
     EXPECT_TRUE(std::ranges::equal(v,v));
@@ -102,7 +102,7 @@ TEST(view_take_until, functor_fail)
 {
     std::string vec{"foo"};
     std::string v;
-    EXPECT_NO_THROW(( v = vec | view::take_until([] (char c) { return c == '\n'; }) ));
+    EXPECT_NO_THROW(( v = vec | view::take_until([] (char c) { return c == '\n'; }) | std::ranges::to<std::string> ));
     EXPECT_EQ("foo", v);
 }
 
@@ -128,7 +128,8 @@ TEST(view_take_until_or_throw, unix_eol)
 TEST(view_take_until_or_throw, functor_fail)
 {
     std::string vec{"foo"};
-    EXPECT_THROW(std::string v = vec | view::take_until_or_throw([] (char c) { return c == '\n'; }),
+    EXPECT_THROW(std::string v = vec | view::take_until_or_throw([] (char c) { return c == '\n'; })
+                                     | std::ranges::to<std::string>,
                  unexpected_end_of_input);
 }
 

--- a/test/unit/range/view/view_to_char_test.cpp
+++ b/test/unit/range/view/view_to_char_test.cpp
@@ -22,16 +22,16 @@ TEST(view_to_char, basic)
     std::string cmp{"ACTTTGATA"};
 
     // pipe notation
-    std::string v = vec | view::to_char;
+    std::string v = vec | view::to_char | std::ranges::to<std::string>;
     EXPECT_EQ(cmp, v);
 
     // function notation
-    std::string v2(view::to_char(vec));
+    std::string v2(view::to_char(vec) | std::ranges::to<std::string>);
     EXPECT_EQ(cmp, v2);
 
     // combinability
     std::string cmp2{"ATAGTTTCA"};
-    std::string v3 = vec | view::to_char | std::view::reverse;
+    std::string v3 = vec | view::to_char | std::view::reverse | std::ranges::to<std::string>;
     EXPECT_EQ(cmp2, v3);
 }
 

--- a/test/unit/range/view/view_to_lower_test.cpp
+++ b/test/unit/range/view/view_to_lower_test.cpp
@@ -23,11 +23,11 @@ TEST(view_to_lower, basic)
     std::string cmp {"iamadnastring"};
 
     // pipe notation string
-    std::string s(input_string | view::to_lower);
+    std::string s(input_string | view::to_lower | std::ranges::to<std::string>);
     EXPECT_EQ(cmp, s);
 
     // custom conversion operator
-    std::string s2(view::to_lower(input_string));
+    std::string s2(view::to_lower(input_string) | std::ranges::to<std::string>);
     EXPECT_EQ(cmp, s2);
 }
 
@@ -40,11 +40,11 @@ TEST(view_to_lower, combinability)
     std::string cmp2{"aggcgt"};
 
    // output combinability
-    std::string s(input_string | view::to_lower | std::view::reverse);
+    std::string s(input_string | view::to_lower | std::view::reverse | std::ranges::to<std::string>);
     EXPECT_EQ(cmp, s);
 
     // input combinability
-    std::string s2(dna_vec | view::to_char | view::to_lower);
+    std::string s2(dna_vec | view::to_char | view::to_lower | std::ranges::to<std::string>);
     EXPECT_EQ(cmp2, s2);
 }
 
@@ -53,7 +53,7 @@ TEST(view_to_lower, deep)
     std::vector<std::string> input_vec{"IAmADnaString", "IAmAProteinString"};
     std::vector<std::string> cmp{"iamadnastring", "iamaproteinstring"};
 
-    std::vector<std::string> s(input_vec | view::to_lower);
+    std::vector<std::string> s(input_vec | view::to_lower | std::ranges::to<std::vector<std::string>>);
     EXPECT_EQ(cmp, s);
 }
 

--- a/test/unit/range/view/view_to_rank_test.cpp
+++ b/test/unit/range/view/view_to_rank_test.cpp
@@ -19,19 +19,19 @@ using namespace seqan3;
 TEST(view_to_rank, basic)
 {
     dna5_vector vec{"ACTTTGATA"_dna5};
-    std::vector<unsigned> cmp{0,1,4,4,4,2,0,4,0};
+    std::vector<uint8_t> cmp{0,1,4,4,4,2,0,4,0};
 
     // pipe notation
-    std::vector<unsigned> v = vec | view::to_rank;
+    std::vector<uint8_t> v = vec | view::to_rank | std::ranges::to<std::vector>;
     EXPECT_EQ(cmp, v);
 
     // function notation
-    std::vector<unsigned> v2(view::to_rank(vec));
+    std::vector<uint8_t> v2(view::to_rank(vec) | std::ranges::to<std::vector>);
     EXPECT_EQ(cmp, v2);
 
     // combinability
-    std::vector<unsigned> cmp2{0, 4, 0, 2, 4, 4, 4, 1, 0};
-    std::vector<unsigned> v3 = vec | view::to_rank | std::view::reverse;
+    std::vector<uint8_t> cmp2{0, 4, 0, 2, 4, 4, 4, 1, 0};
+    std::vector<uint8_t> v3 = vec | view::to_rank | std::view::reverse | std::ranges::to<std::vector>;
     EXPECT_EQ(cmp2, v3);
 }
 
@@ -58,5 +58,5 @@ TEST(view_to_rank, concepts)
     EXPECT_TRUE(std::ranges::CommonRange<decltype(v1)>);
     EXPECT_TRUE(ConstIterableRange<decltype(v1)>);
     EXPECT_FALSE((std::ranges::OutputRange<decltype(v1), dna5>));
-    EXPECT_FALSE((std::ranges::OutputRange<decltype(v1), unsigned>));
+    EXPECT_FALSE((std::ranges::OutputRange<decltype(v1), uint8_t>));
 }

--- a/test/unit/range/view/view_to_upper_test.cpp
+++ b/test/unit/range/view/view_to_upper_test.cpp
@@ -23,11 +23,11 @@ TEST(view_to_upper, basic)
     std::string cmp {"IAMADNASTRING"};
 
     // pipe notation string
-    std::string s(input_string | view::to_upper);
+    std::string s(input_string | view::to_upper | std::ranges::to<std::string>);
     EXPECT_EQ(cmp, s);
 
     // custom conversion operator
-    std::string s2(view::to_upper(input_string));
+    std::string s2(view::to_upper(input_string) | std::ranges::to<std::string>);
     EXPECT_EQ(cmp, s2);
 }
 
@@ -40,11 +40,11 @@ TEST(view_to_upper, combinability)
     std::string cmp2{"AGGCGT"};
 
    // output combinability
-    std::string s(input_string | view::to_upper | std::view::reverse);
+    std::string s(input_string | view::to_upper | std::view::reverse | std::ranges::to<std::string>);
     EXPECT_EQ(cmp, s);
 
     // input combinability
-    std::string s2(dna_vec | view::to_char | view::to_upper);
+    std::string s2(dna_vec | view::to_char | view::to_upper | std::ranges::to<std::string>);
     EXPECT_EQ(cmp2, s2);
 }
 
@@ -53,7 +53,7 @@ TEST(view_to_upper, deep)
     std::vector<std::string> input_vec{"IAmADnaString", "IAmAProteinString"};
     std::vector<std::string> cmp{"IAMADNASTRING", "IAMAPROTEINSTRING"};
 
-    std::vector<std::string> s(input_vec | view::to_upper);
+    std::vector<std::string> s(input_vec | view::to_upper | std::ranges::to<std::vector<std::string>>);
     EXPECT_EQ(cmp, s);
 }
 

--- a/test/unit/range/view/view_translation_test.cpp
+++ b/test/unit/range/view/view_translation_test.cpp
@@ -37,7 +37,7 @@ TYPED_TEST_CASE(nucleotide, nucleotide_types);
 TYPED_TEST(nucleotide, view_translate_single)
 {
     std::string const in{"ACGTACGTACGTA"};
-    std::vector<TypeParam> vec = in | view::char_to<TypeParam>;
+    std::vector<TypeParam> vec = in | view::char_to<TypeParam> | std::ranges::to<std::vector>;
     aa27_vector cmp1{"TYVR"_aa27};
     aa27_vector cmp2{"CMHA"_aa27};
 

--- a/test/unit/range/view/view_trim_test.cpp
+++ b/test/unit/range/view/view_trim_test.cpp
@@ -26,18 +26,18 @@ TEST(view_trim, standalone)
 
     // trim by phred_value
     auto v1 = vec | view::trim(20u);                        // == ['I','I','?','5']
-    EXPECT_EQ(std::vector<phred42>(v1), cmp1);
+    EXPECT_EQ(v1 | std::ranges::to<std::vector>, cmp1);
 
     // trim by quality character
     auto v2 = vec | view::trim(phred42{40});             // == ['I','I']
-    EXPECT_EQ(std::vector<phred42>(v2), cmp2);
+    EXPECT_EQ(v2 | std::ranges::to<std::vector>, cmp2);
 
     // function syntax
     auto v3 = view::trim(vec, 20u);                         // == ['I','I','?','5']
-    EXPECT_EQ(std::vector<phred42>(v3), cmp1);
+    EXPECT_EQ(v3 | std::ranges::to<std::vector>, cmp1);
 
     // combinability
-    std::string v4 = view::trim(vec, 20u) | view::to_char;  // == "II?5"
+    std::string v4 = view::trim(vec, 20u) | view::to_char | std::ranges::to<std::string>;  // == "II?5"
     EXPECT_EQ("II?5", v4);
 }
 
@@ -51,15 +51,15 @@ TEST(view_trim, qualified)
 
     // trim by phred_value
     auto v1 = vec | view::trim(20u);
-    EXPECT_EQ(std::vector<dna5q>(v1), cmp1);
+    EXPECT_EQ(v1 | std::ranges::to<std::vector>, cmp1);
 
     // trim by quality character
     auto v2 = vec | view::trim(dna5q{'C'_dna5, phred42{40}});
-    EXPECT_EQ(std::vector<dna5q>(v2), cmp2);
+    EXPECT_EQ(v2 | std::ranges::to<std::vector>, cmp2);
 
     // function syntax
     auto v3 = view::trim(vec, 20u);
-    EXPECT_EQ(std::vector<dna5q>(v3), cmp1);
+    EXPECT_EQ(v3 | std::ranges::to<std::vector>, cmp1);
 
     // combinability
     std::string v4 = view::trim(vec, 20u) | view::to_char;


### PR DESCRIPTION
fixes #915 

Since the views from the range library are still implicitly convertible, I might have missed a case or two, but we can fix that when upstream changes or we have a C++20 implementation to test against.

None of our views are implicitly convertible anymore.