### PR TITLE
[FEATURE] use gap decorator as alignment return type whenever possible

### DIFF
--- a/include/seqan3/alignment/pairwise/align_pairwise.hpp
+++ b/include/seqan3/alignment/pairwise/align_pairwise.hpp
@@ -23,7 +23,6 @@
 #include <seqan3/alignment/pairwise/alignment_result.hpp>
 #include <seqan3/alignment/pairwise/alignment_configurator.hpp>
 #include <seqan3/alignment/pairwise/execution/all.hpp>
-#include <seqan3/alphabet/gap/gapped.hpp>
 #include <seqan3/core/algorithm/all.hpp>
 #include <seqan3/core/parallel/execution.hpp>
 #include <seqan3/core/type_traits/basic.hpp>

--- a/include/seqan3/alignment/pairwise/align_result_selector.hpp
+++ b/include/seqan3/alignment/pairwise/align_result_selector.hpp
@@ -20,14 +20,37 @@
 #include <seqan3/core/algorithm/configuration.hpp>
 #include <seqan3/core/type_traits/basic.hpp>
 #include <seqan3/core/type_traits/range.hpp>
+#include <seqan3/core/type_traits/transformation_trait_or.hpp>
 #include <seqan3/core/type_list.hpp>
+#include <seqan3/range/decorator/gap_decorator.hpp>
+#include <seqan3/range/view/view_all.hpp>
 #include <seqan3/std/ranges>
 
 namespace seqan3::detail
 {
 
-/*!\brief Exposes the alignment result type based on the configuration.
- * \implements seqan3::TransformationTrait
+/*!\brief A helper class to define the alignment return type.
+ * \tparam first_t  Type of the first sequence.
+ * \tparam second_t Type of the second sequence.
+ * \details
+ * The type uses the gap decorator if RandomAccessRange and SizedRange are met for both input sequences.
+ */
+template <typename first_t, typename second_t>
+struct alignment_type;
+
+//!\overload
+template <typename first_t, typename second_t>
+    requires std::ranges::RandomAccessRange<first_t> &&
+             std::ranges::SizedRange<first_t> &&
+             std::ranges::RandomAccessRange<second_t> &&
+             std::ranges::SizedRange<second_t>
+struct alignment_type<first_t, second_t>
+{
+    //!\brief The alignment type with gap decorator.
+    using type = std::tuple<gap_decorator<all_view<first_t &>>, gap_decorator<all_view<second_t &>>>;
+};
+
+/*!\brief Helper metafunction to select the alignment result type based on the configuration.
  * \ingroup pairwise_alignment
  * \tparam first_bach_t    The type of the first sequence.
  * \tparam second_range_t  The type of the second sequence.
@@ -44,8 +67,6 @@ struct align_result_selector
     //!\brief Helper function to determine the actual result type.
     static constexpr auto _determine()
     {
-        using first_seq_value_type  = gapped<value_type_t<first_range_t>>;
-        using second_seq_value_type = gapped<value_type_t<second_range_t>>;
         using score_type            = int32_t;
 
         if constexpr (std::remove_reference_t<configuration_t>::template exists<align_cfg::result>())
@@ -68,12 +89,21 @@ struct align_result_selector
             else if constexpr (std::Same<remove_cvref_t<decltype(get<align_cfg::result>(configuration_t{}).value)>,
                                          with_alignment_type>)
             {
+                // Due to an error with gcc8 we define these types beforehand.
+                using first_gapped_seq_type = gapped<value_type_t<first_range_t>>;
+                using second_gapped_seq_type = gapped<value_type_t<second_range_t>>;
+
+                // We use vectors of gapped sequence if the gap decorator cannot be used.
+                using fallback_t = std::tuple<std::vector<first_gapped_seq_type>, std::vector<second_gapped_seq_type>>;
+
+                // If the ranges are RandomAccess and Sized we can use the Gap Decorator, otherwise fallback_t.
+                using decorator_t = alignment_type<first_range_t, second_range_t>;
+
                 return alignment_result_value_type<uint32_t,
                                                    score_type,
                                                    alignment_coordinate,
                                                    alignment_coordinate,
-                                                   std::tuple<std::vector<first_seq_value_type>,
-                                                              std::vector<second_seq_value_type>>>{};
+                                                   detail::transformation_trait_or_t<decorator_t, fallback_t>>{};
             }
             else
             {
@@ -89,4 +119,5 @@ struct align_result_selector
     //!\brief The determined result type.
     using type = decltype(_determine());
 };
+
 } // namespace seqan3::detail

--- a/include/seqan3/alignment/pairwise/alignment_algorithm.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_algorithm.hpp
@@ -16,6 +16,7 @@
 #include <range/v3/view/drop_exactly.hpp>
 #include <range/v3/view/zip.hpp>
 
+#include <seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp>
 #include <seqan3/alignment/configuration/all.hpp>
 #include <seqan3/alignment/exception.hpp>
 #include <seqan3/alignment/pairwise/policy/affine_gap_init_policy.hpp>
@@ -25,9 +26,11 @@
 #include <seqan3/alignment/scoring/gap_scheme.hpp>
 #include <seqan3/alignment/scoring/scoring_scheme_base.hpp>
 
+#include <seqan3/core/concept/tuple.hpp>
 #include <seqan3/core/debug_stream.hpp>
 #include <seqan3/core/type_traits/deferred_crtp_base.hpp>
 #include <seqan3/range/view/get.hpp>
+#include <seqan3/range/view/slice.hpp>
 #include <seqan3/range/view/take_exactly.hpp>
 #include <seqan3/std/concepts>
 #include <seqan3/std/iterator>
@@ -518,59 +521,53 @@ private:
                            second_range_t & second_range,
                            alignment_coordinate back_coordinate)
     {
-        using first_seq_value_type = value_type_t<first_range_t>;
-        using second_seq_value_type = value_type_t<second_range_t>;
-
         // Parse the traceback
         auto [front_coordinate, first_gap_segments, second_gap_segments] = this->parse_traceback(back_coordinate);
 
-        auto fill_aligned_sequence = [](auto & aligned_sequence, auto & gap_segments, size_t const normalise)
+        using result_type = typename align_result_selector<first_range_t, second_range_t, config_t>::type;
+        using aligned_seq_type = decltype(result_type{}.alignment);
+
+        // If we compute the traceback the aligned sequences must be provided.
+        if constexpr (seqan3::TupleLike<aligned_seq_type>)
         {
-            assert(std::ranges::empty(gap_segments) || normalise <= gap_segments[0].position);
-
-            size_t offset = 0;
-            for (auto const & gap_elem : gap_segments)
+            auto fill_aligned_sequence = [] (auto & aligned_sequence, auto & gap_segments, size_t const normalise)
             {
-                // insert_gap(aligned_sequence, gap.position + offset, gap.size);
-                auto it = std::ranges::begin(aligned_sequence);
-                std::ranges::advance(it, (gap_elem.position - normalise) + offset);
-                aligned_sequence.insert(it, gap_elem.size, gap{});
-                offset += gap_elem.size;
-            }
-        };
+                assert(std::ranges::empty(gap_segments) || normalise <= gap_segments[0].position);
 
-        // In banded case we need to refine the back coordinate to map to the correct position within the
-        // second range.
-        if constexpr (is_banded)
-            back_coordinate = this->map_banded_coordinate_to_range_position(back_coordinate);
+                size_t offset = 0;
+                for (auto const & gap_elem : gap_segments)
+                {
+                    auto it = std::ranges::begin(aligned_sequence);
+                    std::ranges::advance(it, (gap_elem.position - normalise) + offset);
+                    insert_gap(aligned_sequence, it, gap_elem.size);
+                    offset += gap_elem.size;
+                }
+            };
 
-        // Get the subrange over the first sequence according to the front and back coordinate.
-        auto it_first_seq_begin = std::ranges::begin(first_range);
-        std::ranges::advance(it_first_seq_begin, front_coordinate.first);
-        auto it_first_seq_end = std::ranges::begin(first_range);
-        std::ranges::advance(it_first_seq_end, back_coordinate.first);
+            // In banded case we need to refine the back coordinate to map to the correct position within the
+            // second range.
+            if constexpr (is_banded)
+                back_coordinate = this->map_banded_coordinate_to_range_position(back_coordinate);
 
-        using first_subrange_type = std::ranges::subrange<decltype(it_first_seq_begin), decltype(it_first_seq_end)>;
-        auto first_subrange = first_subrange_type{it_first_seq_begin, it_first_seq_end};
+            // Get the subrange over the first sequence according to the front and back coordinate.
+            auto first_subrange = view::slice(first_range, front_coordinate.first, back_coordinate.first);
 
-        // Create and fill the aligned_sequence for the first sequence.
-        std::vector<gapped<first_seq_value_type>> first_aligned_seq{first_subrange};
-        fill_aligned_sequence(first_aligned_seq, first_gap_segments, front_coordinate.first);
+            // Get the subrange over the second sequence according to the front and back coordinate.
+            auto second_subrange = view::slice(second_range, front_coordinate.second, back_coordinate.second);
 
-        // Get the subrange over the second sequence according to the front and back coordinate.
-        auto it_second_seq_begin = std::ranges::begin(second_range);
-        std::ranges::advance(it_second_seq_begin, front_coordinate.second);
-        auto it_second_seq_end = std::ranges::begin(second_range);
-        std::ranges::advance(it_second_seq_end, back_coordinate.second);
+            // Create and fill the aligned_sequences.
+            aligned_seq_type aligned_seq;
+            assign_unaligned(std::get<0>(aligned_seq), first_subrange);
+            assign_unaligned(std::get<1>(aligned_seq), second_subrange);
+            fill_aligned_sequence(std::get<0>(aligned_seq), first_gap_segments, front_coordinate.first);
+            fill_aligned_sequence(std::get<1>(aligned_seq), second_gap_segments, front_coordinate.second);
 
-        using second_subrange_type = std::ranges::subrange<decltype(it_second_seq_begin), decltype(it_second_seq_end)>;
-        auto second_subrange = second_subrange_type{it_second_seq_begin, it_second_seq_end};
-
-        // Create and fill the aligned_sequence for the second sequence.
-        std::vector<gapped<second_seq_value_type>> second_aligned_seq{second_subrange};
-        fill_aligned_sequence(second_aligned_seq, second_gap_segments, front_coordinate.second);
-
-        return std::tuple{front_coordinate, std::tuple{first_aligned_seq, second_aligned_seq}};
+            return std::tuple{front_coordinate, aligned_seq};
+        }
+        else
+        {
+            return std::tuple{front_coordinate, std::ignore};
+        }
     }
 
     //!\brief The alignment configuration stored on the heap.

--- a/include/seqan3/alignment/pairwise/alignment_configurator.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_configurator.hpp
@@ -23,7 +23,6 @@
 #include <seqan3/alignment/pairwise/align_result_selector.hpp>
 #include <seqan3/alignment/pairwise/alignment_result.hpp>
 #include <seqan3/alignment/pairwise/edit_distance_algorithm.hpp>
-#include <seqan3/alphabet/gap/gapped.hpp>
 #include <seqan3/core/concept/tuple.hpp>
 #include <seqan3/core/type_traits/deferred_crtp_base.hpp>
 #include <seqan3/core/type_traits/range.hpp>

--- a/include/seqan3/alignment/pairwise/alignment_result.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_result.hpp
@@ -189,7 +189,7 @@ public:
     }
 
     /*!\brief Returns the actual alignment, i.e. the base pair matching.
-     * \return At least two gapped sequences, which represent the alignment.
+     * \return At least two aligned sequences, which represent the alignment.
      * \attention This function with fail the compilation, if the alignment was not requested in the alignment
      * configuration.
      */

--- a/include/seqan3/alignment/pairwise/edit_distance_unbanded.hpp
+++ b/include/seqan3/alignment/pairwise/edit_distance_unbanded.hpp
@@ -438,7 +438,12 @@ public:
 
         if constexpr (compute_sequence_alignment)
         {
-            res_vt.alignment = alignment_trace(database, query, trace_matrix(), res_vt.back_coordinate);
+            using res_type = decltype(res_vt.alignment);
+            res_vt.alignment = alignment_trace<res_type>(database,
+                                                         query,
+                                                         trace_matrix(),
+                                                         res_vt.back_coordinate,
+                                                         res_vt.front_coordinate);
         }
         return alignment_result<result_value_type>{std::move(res_vt)};
     }
@@ -493,7 +498,8 @@ public:
     {
         static_assert(compute_sequence_alignment, "alignment() can only be computed if you specify the result type "
                                                   "within your alignment config.");
-        return alignment_trace(database, query, trace_matrix(), back_coordinate());
+        using res_type = decltype(result_value_type{}.alignment);
+        return alignment_trace<res_type>(database, query, trace_matrix(), back_coordinate(), front_coordinate());
     }
 };
 

--- a/include/seqan3/range/decorator/gap_decorator.hpp
+++ b/include/seqan3/range/decorator/gap_decorator.hpp
@@ -24,6 +24,7 @@
 #include <seqan3/alphabet/gap/gapped.hpp>
 #include <seqan3/range/container/concept.hpp>
 #include <seqan3/range/detail/random_access_iterator.hpp>
+#include <seqan3/range/view/view_all.hpp>
 #include <seqan3/std/algorithm>
 #include <seqan3/std/ranges>
 
@@ -384,7 +385,7 @@ public:
                   std::Same<remove_cvref_t<other_range_t>, remove_cvref_t<inner_type>> &&
                   std::ranges::ViewableRange<other_range_t> // at end, otherwise it competes with the move ctor
     //!\endcond
-    gap_decorator(other_range_t && range) : ungapped_view{std::view::all(std::forward<inner_type>(range))}
+    gap_decorator(other_range_t && range) : ungapped_view{view::all(std::forward<inner_type>(range))}
     {} // TODO (@smehringer) only works for copyable views. Has to be changed once views are not required to be copyable anymore.
     // !\}
 
@@ -538,7 +539,7 @@ public:
         return iterator{*this, pos1};
     }
 
-    /*!\brief Assigns a new sequence of type seqan3:;gap_decorator::unaligned_seq_type to the decorator.
+    /*!\brief Assigns a new sequence of type seqan3::gap_decorator::unaligned_seq_type to the decorator.
      * \param[in,out] dec       The decorator to modify.
      * \param[in]     unaligned The unaligned sequence to assign.
      */
@@ -811,7 +812,7 @@ private:
     }
 
     //!\brief Stores a (copy of a) view to the ungapped, underlying sequence.
-    decltype(std::view::all(std::declval<inner_type &&>())) ungapped_view{};
+    decltype(view::all(std::declval<inner_type &&>())) ungapped_view{};
 
     //!\brief Set storing the anchor gaps.
     anchor_set_type anchors{};

--- a/test/unit/alignment/pairwise/align_result_selector_test.cpp
+++ b/test/unit/alignment/pairwise/align_result_selector_test.cpp
@@ -25,10 +25,11 @@
 #include <seqan3/core/concept/tuple.hpp>
 #include <seqan3/range/view/persist.hpp>
 #include <seqan3/range/view/to_char.hpp>
+#include <seqan3/range/view/view_all.hpp>
 
 using namespace seqan3;
 
-TEST(alignment_selector, align_result_selector)
+TEST(alignment_selector, align_result_selector_with_list)
 {
     using seq1_t = std::vector<dna4>;
     using seq2_t = std::list<dna4>;
@@ -65,4 +66,23 @@ TEST(alignment_selector, align_result_selector)
         EXPECT_TRUE((std::is_same_v<decltype(std::declval<_t>().alignment()),
                                     std::tuple<gapped_seq1_t, gapped_seq2_t> const &>));
     }
+}
+
+TEST(alignment_selector, align_result_selector_with_vector)
+{
+    using seq_t = std::vector<dna4>;
+
+    auto cfg = align_cfg::edit | align_cfg::result{with_alignment};
+    using _t = alignment_result<typename detail::align_result_selector<seq_t, seq_t, decltype(cfg)>::type>;
+
+    using gapped_seq_t = gap_decorator<all_view<std::vector<dna4> &>>;
+
+    EXPECT_TRUE((std::is_same_v<decltype(std::declval<_t>().id()), uint32_t>));
+    EXPECT_TRUE((std::is_same_v<decltype(std::declval<_t>().score()), int32_t>));
+    EXPECT_TRUE((std::is_same_v<decltype(std::declval<_t>().back_coordinate()),
+                                alignment_coordinate const &>));
+    EXPECT_TRUE((std::is_same_v<decltype(std::declval<_t>().front_coordinate()),
+                                alignment_coordinate const &>));
+    EXPECT_TRUE((std::is_same_v<decltype(std::declval<_t>().alignment()),
+                                std::tuple<gapped_seq_t, gapped_seq_t> const &>));
 }

--- a/test/unit/alphabet/gap/gapped_test.cpp
+++ b/test/unit/alphabet/gap/gapped_test.cpp
@@ -9,6 +9,9 @@
 
 #include <gtest/gtest.h>
 
+#include <vector>
+
+#include <seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp>
 #include <seqan3/alphabet/gap/gapped.hpp>
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/alphabet/nucleotide/dna15.hpp>
@@ -80,4 +83,5 @@ TEST(gapped_test, fulfills_concepts)
     using alphabet_t = gapped<dna4>;
     EXPECT_TRUE((std::is_trivially_copyable_v<alphabet_t>));
     EXPECT_TRUE((std::is_standard_layout_v<alphabet_t>));
+    EXPECT_TRUE((AlignedSequence<std::vector<alphabet_t>>));
 }

--- a/test/unit/range/decorator/gap_decorator_test.cpp
+++ b/test/unit/range/decorator/gap_decorator_test.cpp
@@ -79,6 +79,8 @@ TYPED_TEST(gap_decorator_f, concept_checks)
     EXPECT_FALSE((ranges::enable_view<TypeParam &>));
 
     EXPECT_FALSE((std::ranges::View<TypeParam>));
+
+    EXPECT_TRUE((AlignedSequence<TypeParam>));
 }
 
 TYPED_TEST(gap_decorator_f, construction_general)


### PR DESCRIPTION
To prevent copies for the returned alignment, we now use the gap decorator to store only the positions of the gaps. This is possible if the input sequences model `SizedRange` and `RandomAccessRange`. If these requirements are not met, we instead copy the sequences into vectors of gapped sequence (as before).

Fixes #888