### PR TITLE
[DOC] Adapt doxygen css for inline code.

### DIFF
--- a/test/documentation/seqan3.css
+++ b/test/documentation/seqan3.css
@@ -68,10 +68,10 @@ div.fragment {
 
 /* inline code */
 code {
-    font-size: 12pt;
-    line-height: 15px;
+    font-size: 11pt;
+    line-height: 30px;
     font-family: "Ubuntu Mono", "SFMono-Regular",source-code-pro,Menlo,Monaco,Consolas,"Roboto Mono","Droid Sans Mono","Liberation Mono",Consolas,"Courier New",Courier,monospace;
-    padding: 2px;
+    padding: 1px 0px 1px 0px;
     border-radius: 1px;
     background-color: #F6F8FA;
     border: 1px solid #F6F8FA;


### PR DESCRIPTION
@h-2 This improves the is_char table and multiple `#include ...` at the top of the file.
You may want to check out the branch and see if this also fixes stuff for FreeBSD.