### PR TITLE
[FIX] edit distance returns correct back coordinate

### DIFF
--- a/include/seqan3/alignment/matrix/alignment_trace_algorithms.hpp
+++ b/include/seqan3/alignment/matrix/alignment_trace_algorithms.hpp
@@ -44,8 +44,8 @@ inline alignment_coordinate alignment_front_coordinate(trace_matrix_t && matrix,
     constexpr auto D = trace_directions::diagonal;
     constexpr auto L = trace_directions::left;
     constexpr auto U = trace_directions::up;
-    size_t row = back_coordinate.second + 1;
-    size_t col = back_coordinate.first + 1;
+    size_t row = back_coordinate.second;
+    size_t col = back_coordinate.first;
 
     assert(row < matrix.rows());
     assert(col < matrix.cols());
@@ -112,8 +112,8 @@ inline alignment_t alignment_trace(database_t && database,
     constexpr auto D = trace_directions::diagonal;
     constexpr auto L = trace_directions::left;
     constexpr auto U = trace_directions::up;
-    size_t col = back_coordinate.first + 1;
-    size_t row = back_coordinate.second + 1;
+    size_t col = back_coordinate.first;
+    size_t row = back_coordinate.second;
 
     assert(row <= query.size());
     assert(col <= database.size());

--- a/include/seqan3/alignment/pairwise/edit_distance_unbanded.hpp
+++ b/include/seqan3/alignment/pairwise/edit_distance_unbanded.hpp
@@ -273,11 +273,11 @@ class edit_distance_unbanded_global_policy :
         _best_score = self->_score;
     }
 
-    //!\copydoc edit_distance_unbanded_semi_global_policy::_best_score_col
-    size_t best_score_column() const noexcept
+    //!\brief Returns the first component of the #back_coordinate.
+    size_t back_coordinate_first() const noexcept
     {
         derived_t const * self = static_cast<derived_t const *>(this);
-        return std::ranges::size(self->database) - 1u;
+        return std::ranges::size(self->database);
     }
     //!\}
 
@@ -309,8 +309,9 @@ public:
         if (!self->is_valid())
             return self->invalid_coordinate();
 
-        size_t col = self->best_score_column();
-        return {column_index_type{col}, row_index_type{std::ranges::size(self->query) - 1u}};
+        column_index_type const first{self->back_coordinate_first()};
+        row_index_type const second{std::ranges::size(self->query)};
+        return {first, second};
     }
     //!\}
 };
@@ -402,11 +403,11 @@ class edit_distance_unbanded_semi_global_policy :
         _best_score     = (self->_score <= _best_score) ? self->_score : _best_score;
     }
 
-    //!\copydoc edit_distance_unbanded_global_policy::best_score_column
-    size_t best_score_column() const noexcept
+    //!\copydoc edit_distance_unbanded_global_policy::back_coordinate_first
+    size_t back_coordinate_first() const noexcept
     {
         derived_t const * self = static_cast<derived_t const *>(this);
-        return std::ranges::distance(std::ranges::begin(self->database), _best_score_col);
+        return std::ranges::distance(std::ranges::begin(self->database), _best_score_col) + 1u;
     }
     //!\}
 };

--- a/test/unit/alignment/pairwise/align_pairwise_test.cpp
+++ b/test/unit/alignment/pairwise/align_pairwise_test.cpp
@@ -64,8 +64,8 @@ TYPED_TEST(align_pairwise_test, single_pair)
         {
             EXPECT_EQ(res.id(), idx++);
             EXPECT_EQ(res.score(), -4);
-            EXPECT_EQ(res.back_coordinate().first, 7u);
-            EXPECT_EQ(res.back_coordinate().second, 8u);
+            EXPECT_EQ(res.back_coordinate().first, 8u);
+            EXPECT_EQ(res.back_coordinate().second, 9u);
             auto && [gap1, gap2] = res.alignment();
             EXPECT_EQ(std::string{gap1 | view::to_char}, "ACGTGATG--");
             EXPECT_EQ(std::string{gap2 | view::to_char}, "A-GTGATACT");
@@ -75,7 +75,6 @@ TYPED_TEST(align_pairwise_test, single_pair)
 
 TYPED_TEST(align_pairwise_test, single_view)
 {
-
     auto seq1 = "ACGTGATG"_dna4;
     auto seq2 = "AGTGATACT"_dna4;
 
@@ -103,7 +102,6 @@ TYPED_TEST(align_pairwise_test, single_view)
 
 TYPED_TEST(align_pairwise_test, collection)
 {
-
     auto seq1 = "ACGTGATG"_dna4;
     auto seq2 = "AGTGATACT"_dna4;
 

--- a/test/unit/alignment/pairwise/fixture/global_edit_distance_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/global_edit_distance_unbanded.hpp
@@ -37,7 +37,7 @@ static auto dna4_01 = []()
         "AACCGGTTAACCGGTT",
         "A-C-G-T-A-C-G-TA",
         alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
-        alignment_coordinate{column_index_type{15u}, row_index_type{8u}},
+        alignment_coordinate{column_index_type{16u}, row_index_type{9u}},
         std::vector
         {
         //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
@@ -85,7 +85,7 @@ static auto dna4_01T = []()
         "A-C-G-T-A-C-G-TA",
         "AACCGGTTAACCGGTT",
         alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
-        alignment_coordinate{column_index_type{8u}, row_index_type{15u}},
+        alignment_coordinate{column_index_type{9u}, row_index_type{16u}},
         dna4_01.score_matrix().transpose_matrix(),
         dna4_01.trace_matrix().transpose_matrix()
     };
@@ -107,7 +107,7 @@ static auto dna4_02 = []()
         "AACCGGTAAACCGGTT",
         "A-C-G-TA--C-G-TA",
         alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
-        alignment_coordinate{column_index_type{15u}, row_index_type{8u}},
+        alignment_coordinate{column_index_type{16u}, row_index_type{9u}},
         std::vector
         {
         //     e,  A,  A,  C,  C,  G,  G,  T,  A,  A,  A,  C,  C,  G,  G,  T,  T,
@@ -155,7 +155,7 @@ static auto dna4_02_s10u_15u = []()
         "AACCGGTAAACCGG-",
         "A-C-G-TA--C-GTA",
         alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
-        alignment_coordinate{column_index_type{13u}, row_index_type{8u}},
+        alignment_coordinate{column_index_type{14u}, row_index_type{9u}},
         dna4_02.score_matrix().sub_matrix(10u, 15u),
         dna4_02.trace_matrix().sub_matrix(10u, 15u)
     };
@@ -177,7 +177,7 @@ static auto dna4_02_s3u_15u = []()
         "AACCGGTAAACCGG",
         "A-C-----------",
         alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
-        alignment_coordinate{column_index_type{13u}, row_index_type{1u}},
+        alignment_coordinate{column_index_type{14u}, row_index_type{2u}},
         dna4_02.score_matrix().sub_matrix(3u, 15u),
         dna4_02.trace_matrix().sub_matrix(3u, 15u)
     };
@@ -199,7 +199,7 @@ static auto aa27_01 = []()
         "UUWWRRIIUUWWRRII",
         "U-W-R-I-U-W-R-IU",
         alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
-        alignment_coordinate{column_index_type{15u}, row_index_type{8u}},
+        alignment_coordinate{column_index_type{16u}, row_index_type{9u}},
         std::vector
         {
         //     e,  U,  U,  W,  W,  R,  R,  I,  I,  U,  U,  W,  W,  R,  R,  I,  I
@@ -247,7 +247,7 @@ static auto aa27_01T = []()
         "U-W-R-I-U-W-R-IU",
         "UUWWRRIIUUWWRRII",
         alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
-        alignment_coordinate{column_index_type{8u}, row_index_type{15u}},
+        alignment_coordinate{column_index_type{9u}, row_index_type{16u}},
         aa27_01.score_matrix().transpose_matrix(),
         aa27_01.trace_matrix().transpose_matrix()
     };

--- a/test/unit/alignment/pairwise/fixture/semi_global_edit_distance_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/semi_global_edit_distance_unbanded.hpp
@@ -38,7 +38,7 @@ static auto dna4_01 = []()
         "AC---CGGTT",
         "ACGTACG-TA",
         alignment_coordinate{column_index_type{9u}, row_index_type{0u}},
-        alignment_coordinate{column_index_type{15u}, row_index_type{8u}},
+        alignment_coordinate{column_index_type{16u}, row_index_type{9u}},
         std::vector
         {
         //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
@@ -86,7 +86,7 @@ static auto dna4_01T = []()
         "A-C-G-T-A-C-G-TA",
         "AACCGGTTAACCGGTT",
         alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
-        alignment_coordinate{column_index_type{8u}, row_index_type{15u}},
+        alignment_coordinate{column_index_type{9u}, row_index_type{16u}},
         std::vector
         {
         //     e,  A,  C,  G,  T,  A,  C,  G,  T,  A
@@ -148,7 +148,7 @@ static auto dna4_02 = []()
         "AC---CGGTA",
         "ACGTACG-TA",
         alignment_coordinate{column_index_type{1u}, row_index_type{0u}},
-        alignment_coordinate{column_index_type{7u}, row_index_type{8u}},
+        alignment_coordinate{column_index_type{8u}, row_index_type{9u}},
         std::vector
         {
         //     e,  A,  A,  C,  C,  G,  G,  T,  A,  A,  A,  C,  C,  G,  G,  T,  T,
@@ -196,7 +196,7 @@ static auto dna4_02_s10u_15u = []()
         "AC---CGGTA",
         "ACGTACG-TA",
         alignment_coordinate{column_index_type{1u}, row_index_type{0u}},
-        alignment_coordinate{column_index_type{7u}, row_index_type{8u}},
+        alignment_coordinate{column_index_type{8u}, row_index_type{9u}},
         dna4_02.score_matrix().sub_matrix(10u, 15u),
         dna4_02.trace_matrix().sub_matrix(10u, 15u)
     };
@@ -218,7 +218,7 @@ static auto dna4_02_s3u_15u = []()
         "AC",
         "AC",
         alignment_coordinate{column_index_type{9u}, row_index_type{0u}},
-        alignment_coordinate{column_index_type{10u}, row_index_type{1u}},
+        alignment_coordinate{column_index_type{11u}, row_index_type{2u}},
         dna4_02.score_matrix().sub_matrix(3u, 15u),
         dna4_02.trace_matrix().sub_matrix(3u, 15u)
     };
@@ -240,7 +240,7 @@ static auto aa27_01 = []()
         "UW---WRRII",
         "UWRIUWR-IU",
         alignment_coordinate{column_index_type{9u}, row_index_type{0u}},
-        alignment_coordinate{column_index_type{15u}, row_index_type{8u}},
+        alignment_coordinate{column_index_type{16u}, row_index_type{9u}},
         std::vector
         {
         //     e,  U,  U,  W,  W,  R,  R,  I,  I,  U,  U,  W,  W,  R,  R,  I,  I
@@ -288,7 +288,7 @@ static auto aa27_01T = []()
         "U-W-R-I-U-W-R-IU",
         "UUWWRRIIUUWWRRII",
         alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
-        alignment_coordinate{column_index_type{8u}, row_index_type{15u}},
+        alignment_coordinate{column_index_type{9u}, row_index_type{16u}},
         std::vector
         {
         //     e,  U,  W,  R,  I,  U,  W,  R,  I,  U


### PR DESCRIPTION
@rrahn I already talked this over with you, that the general pairwise algorithm returns non-inclusive `back_coordinate`s and that the edit distance returns inclusive `back_coordinate`s.

It is desirable to have non-inclusive back coordinates and inclusive front coordinates, because with that one can express empty intervals. This PR makes `back_coordinate`s non-inclusive and resolves a discrepancy between the general and edit alignment algorithm.

As an example for non-inclusive:
https://github.com/seqan/seqan3/blob/81a1cb9f7ec99d1f87b88213bc959bb5b81f416a/test/unit/alignment/pairwise/fixture/global_affine_banded.hpp#L48-L58

And an example for inclusive:
https://github.com/seqan/seqan3/blob/81a1cb9f7ec99d1f87b88213bc959bb5b81f416a/test/unit/alignment/pairwise/fixture/global_edit_distance_unbanded.hpp#L26-L40