### PR TITLE
[FIXES-#764] bitcompressed_vector's reference type should always be a proxy

### DIFF
--- a/include/seqan3/alphabet/detail/alphabet_proxy.hpp
+++ b/include/seqan3/alphabet/detail/alphabet_proxy.hpp
@@ -241,6 +241,16 @@ public:
         return assign_rank_to(to_rank(), alphabet_type{});
     }
 
+    //!\brief Implicit conversion to types that the emulated type is convertible to.
+    template <typename other_t>
+    //!\cond
+        requires std::ConvertibleTo<alphabet_type, other_t>
+    //!\endcond
+    constexpr operator other_t() const noexcept
+    {
+        return operator alphabet_type();
+    }
+
     constexpr auto to_char() const noexcept
         requires Alphabet<alphabet_type>
     {
@@ -280,6 +290,48 @@ public:
         requires WritableAlphabet<alphabet_type>
     {
         return char_is_valid_for<alphabet_type>(c);
+    }
+    //!\}
+
+    /*!\name Comparison operators
+     * \brief These are only required if the emulated type allows comparison with types it is not convertible to,
+     *        e.g. seqan3::alphabet_variant.
+     * \{
+     */
+    //!\brief Allow (in-)equality comparison with types that the emulated type is comparable with.
+    template <typename t>
+    friend constexpr auto operator==(derived_type const lhs, t const rhs) noexcept
+        -> std::enable_if_t<!std::Same<derived_type, t> && std::detail::WeaklyEqualityComparableWith<alphabet_type, t>,
+                            bool>
+    {
+        return (static_cast<alphabet_type>(lhs) == rhs);
+    }
+
+    //!\brief Allow (in-)equality comparison with types that the emulated type is comparable with.
+    template <typename t>
+    friend constexpr auto operator==(t const lhs, derived_type const rhs) noexcept
+        -> std::enable_if_t<!std::Same<derived_type, t> && std::detail::WeaklyEqualityComparableWith<alphabet_type, t>,
+                            bool>
+    {
+        return (rhs == lhs);
+    }
+
+    //!\brief Allow (in-)equality comparison with types that the emulated type is comparable with.
+    template <typename t>
+    friend constexpr auto operator!=(derived_type const lhs, t const rhs) noexcept
+        -> std::enable_if_t<!std::Same<derived_type, t> && std::detail::WeaklyEqualityComparableWith<alphabet_type, t>,
+                            bool>
+    {
+        return !(lhs == rhs);
+    }
+
+    //!\brief Allow (in-)equality comparison with types that the emulated type is comparable with.
+    template <typename t>
+    friend constexpr auto operator!=(t const lhs, derived_type const rhs) noexcept
+        -> std::enable_if_t<!std::Same<derived_type, t> && std::detail::WeaklyEqualityComparableWith<alphabet_type, t>,
+                            bool>
+    {
+        return (rhs != lhs);
     }
     //!\}
 };

--- a/include/seqan3/alphabet/nucleotide/rna4.hpp
+++ b/include/seqan3/alphabet/nucleotide/rna4.hpp
@@ -70,6 +70,9 @@ public:
 
     //!\brief Allow implicit construction from dna/rna of the same size.
     constexpr rna4(dna4 const & r) noexcept
+#if SEQAN3_WORKAROUND_GCC_90897
+        requires true
+#endif
     {
         assign_rank(r.to_rank());
     }

--- a/include/seqan3/core/platform.hpp
+++ b/include/seqan3/core/platform.hpp
@@ -194,6 +194,15 @@
 #   endif
 #endif
 
+//!\brief See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90897
+#ifndef SEQAN3_WORKAROUND_GCC_90897
+#   if defined(__GNUC__) && (__GNUC__ == 8)
+#       define SEQAN3_WORKAROUND_GCC_90897 1
+#   else
+#       define SEQAN3_WORKAROUND_GCC_90897 0
+#   endif
+#endif
+
 // ============================================================================
 //  Backmatter
 // ============================================================================

--- a/include/seqan3/range/container/bitcompressed_vector.hpp
+++ b/include/seqan3/range/container/bitcompressed_vector.hpp
@@ -90,16 +90,8 @@ private:
         //!\brief Befriend the base type so it can call our #on_update().
         friend base_t;
 
-        //!\brief For certain sizes sdsl::int_vector doesn't return a proxy and sdsl::int_vector_reference
-        //!       would be invalid; ranges::semiregular_t triggers this so we workaround here.
-        static uint8_t constexpr safe_bits_per_letter = (bits_per_letter ==  8 ||
-                                                         bits_per_letter == 16 ||
-                                                         bits_per_letter == 32) ? 64 : bits_per_letter;
-
-        //!\brief Type of the the internal proxy
-        using internal_proxy_type = sdsl::int_vector_reference<sdsl::int_vector<safe_bits_per_letter>>;
         //!\brief The proxy of the underlying data type; wrapped in semiregular_t, because it isn't semiregular itself.
-        ranges::semiregular_t<internal_proxy_type> internal_proxy;
+        ranges::semiregular_t<reference_t<data_type>> internal_proxy;
 
         //!\brief Update the sdsl-proxy.
         constexpr void on_update() noexcept
@@ -122,7 +114,7 @@ private:
         ~reference_proxy_type()                                                  noexcept = default; //!< Defaulted.
 
         //!\brief Initialise from internal proxy type.
-        reference_proxy_type(internal_proxy_type const & internal) noexcept :
+        reference_proxy_type(reference_t<data_type> const & internal) noexcept :
             internal_proxy{internal}
         {
             static_cast<base_t &>(*this).assign_rank(internal);
@@ -145,9 +137,7 @@ public:
     //!\brief Equals the alphabet_type.
     using value_type        = alphabet_type;
     //!\brief A proxy type that enables assignment, if the underlying data structure also provides a proxy.
-    using reference         = std::conditional_t<std::is_lvalue_reference_v<reference_t<data_type>>,
-                                                 reference_t<data_type>,
-                                                 reference_proxy_type>;
+    using reference         = reference_proxy_type;
     //!\brief Equals the alphabet_type / value_type.
     using const_reference   = alphabet_type;
     //!\brief The iterator type of this container (a random access iterator).

--- a/test/unit/range/container/container_concept_test.cpp
+++ b/test/unit/range/container/container_concept_test.cpp
@@ -16,7 +16,11 @@
 
 #include <sdsl/int_vector.hpp>
 
+#include <seqan3/alphabet/nucleotide/dna4.hpp>
+#include <seqan3/alphabet/quality/phred42.hpp>
+#include <seqan3/alphabet/quality/qualified.hpp>
 #include <seqan3/range/container/concatenated_sequences.hpp>
+#include <seqan3/range/container/bitcompressed_vector.hpp>
 #include <seqan3/range/container/concept.hpp>
 
 using namespace seqan3;
@@ -32,6 +36,8 @@ TEST(range_concept, ForwardRange)
 
     EXPECT_TRUE((std::ranges::ForwardRange<seqan3::concatenated_sequences<std::string>>));
     EXPECT_TRUE((std::ranges::ForwardRange<seqan3::concatenated_sequences<std::vector<char>>>));
+    EXPECT_TRUE((std::ranges::ForwardRange<bitcompressed_vector<dna4>>));
+    EXPECT_TRUE((std::ranges::ForwardRange<bitcompressed_vector<qualified<dna4, phred42>>>));
 }
 
 TEST(Container, Container)
@@ -137,6 +143,8 @@ TEST(Container, ReservableContainer)
     EXPECT_TRUE((seqan3::ReservableContainer<sdsl::int_vector<>>));
     EXPECT_TRUE((seqan3::ReservableContainer<sdsl::int_vector<13>>));
     EXPECT_TRUE((seqan3::ReservableContainer<sdsl::int_vector<64>>));
+    EXPECT_TRUE((seqan3::ReservableContainer<bitcompressed_vector<dna4>>));
+    EXPECT_TRUE((seqan3::ReservableContainer<bitcompressed_vector<qualified<dna4, phred42>>>));
 }
 
 /* Check the SDSL containers */


### PR DESCRIPTION
fixes #764 

added a fix to #679 as well