### PR TITLE
Feature/alignment matrix

### DIFF
--- a/include/seqan3/alignment/matrix/detail/alignment_matrix_column_major_range_base.hpp
+++ b/include/seqan3/alignment/matrix/detail/alignment_matrix_column_major_range_base.hpp
@@ -1,0 +1,513 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides seqan3::detail::alignment_matrix_column_major_range_base.
+ * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <seqan3/core/type_traits/basic.hpp>
+#include <seqan3/core/type_traits/range.hpp>
+#include <seqan3/std/iterator>
+#include <seqan3/std/ranges>
+#include <seqan3/std/span>
+
+namespace seqan3::detail
+{
+
+/*!\brief Provides a range interface for alignment matrices.
+ * \implements std::ranges::InputRange
+ * \ingroup alignment_matrix
+ * \tparam derived_t The derived type implementing the data model of the matrix (see details for more information).
+ *
+ * \details
+ *
+ * This crtp-base class provides a range based interface for alignment matrices. It generates a range of ranges, where
+ * both the outer range and the inner ranges model std::ranges::InputRange. The interface uses a column-major-order
+ * to iterate over the matrix, i.e. the outer range iterates over the columns and the inner range over the num_rows of
+ * each column. In addition, the inner range type, also referred to as `alignment-column`, must model std::ranges::View.
+ * It is a shallow wrapper around the actual column stored in the `derived_t`, who implements the corresponding data
+ * model. The current alignment-column is created within the `derived_t` when the iterator over the outer range is
+ * dereferenced. The iterator over the resulting `alignment-column` is further refined by the `derived_t` to
+ * implement the actual behavior of the underlying alignment matrix.
+ *
+ * ### Requirements of the derived type
+ *
+ * This base class requires the following functions and types defined within the derived type in order to customise the
+ * returned type over the underlying matrix.
+ *
+ *  * seqan3::detail::alignment_matrix_column_major_range_base::value_type
+ *  * seqan3::detail::alignment_matrix_column_major_range_base::alignment_column_type
+ *  * seqan3::detail::alignment_matrix_column_major_range_base::make_proxy
+ *  * seqan3::detail::alignment_matrix_column_major_range_base::initialise_column
+ *
+ * The following functions are not mandatory but can be overriden by the derived type:
+ *  * seqan3::detail::alignment_matrix_column_major_range_base::on_column_iterator_creation
+ *  * seqan3::detail::alignment_matrix_column_major_range_base::before_column_iterator_increment
+ *  * seqan3::detail::alignment_matrix_column_major_range_base::after_column_iterator_increment
+ *
+ * ### Example
+ *
+ * \include test/snippet/alignment/matrix/detail/alignment_matrix_column_major_range_base.cpp
+ */
+template <typename derived_t>
+class alignment_matrix_column_major_range_base
+{
+private:
+    //!\brief Befriend the derived type.
+    friend derived_t;
+
+    /*!\brief Represents a column within an alignment matrix.
+     * \implements std::ranges::View
+     * \implements std::ranges::InputRange
+     *
+     * \details
+     *
+     * The alignment-column depends on the `column_data_view_type` of the derived type. This type is used to
+     * alias the actual data storage of the underlying matrix implementation such that it does not own the data.
+     */
+    class alignment_column_type : public std::ranges::view_interface<alignment_column_type>
+    {
+    private:
+        //!\brief A view aliasing the actual stored data column within the underlying matrix.
+        using view_type = typename deferred_type<typename derived_t::column_data_view_type>::type;
+
+        static_assert(std::ranges::RandomAccessRange<view_type>, "Column view must support random access.");
+        static_assert(std::ranges::View<view_type>, "Column view must be a view.");
+
+        //!\brief The sentinel type of the underlying view.
+        using sentinel = std::ranges::sentinel_t<view_type>;
+
+        /*!\brief The iterator over an alignment-column.
+         * \implements std::ForwardIterator
+         *
+         * \details
+         *
+         * The iterator represents the current cell within an alignment-column. When dereferenced it
+         * calls the function `make_proxy` of the derived class to obtain a proxy value over the current matrix cell.
+         * This proxy type depends on the derived type.
+         */
+        class iterator_type
+        {
+        public:
+
+            /*!\name Associated types
+             * \{
+             */
+            //!\brief A value type dependent on the derived type.
+            using value_type = typename deferred_type<typename derived_t::value_type>::type;
+            //!\brief The reference type dependent on the derived type.
+            using reference = typename deferred_type<typename derived_t::reference>::type;
+            //!\brief Pointer type.
+            using pointer = void;
+            //!\brief Difference type.
+            using difference_type = difference_type_t<view_type>;
+            //!\brief Iterator category.
+            using iterator_category = std::forward_iterator_tag;
+            //!\}
+
+            /*!\name Constructors, destructor and assignment
+             * \{
+             */
+            constexpr iterator_type() = default; //!< Defaulted.
+            constexpr iterator_type(iterator_type const &) = default; //!< Defaulted.
+            constexpr iterator_type(iterator_type &&) = default; //!< Defaulted.
+            constexpr iterator_type & operator=(iterator_type const &) = default; //!< Defaulted.
+            constexpr iterator_type & operator=(iterator_type &&) = default; //!< Defaulted.
+            ~iterator_type() = default; //!< Defaulted.
+
+            /*!\brief Construction from the underlying alignment-column.
+             * \param host The alignment-column for this iterator.
+             */
+            explicit constexpr iterator_type(alignment_column_type & host) :
+                host_ptr{&host},
+                host_iter{host.ref.begin()}
+            {
+                host_ptr->me_ptr->on_column_iterator_creation(host_iter);
+            }
+            //!\}
+
+            /*!\name Element access
+             * \{
+             */
+            //!\brief Returns a proxy for the current alignment cell.
+            constexpr reference operator*() const noexcept
+            {
+                static_assert(std::ConvertibleTo<decltype(host_ptr->me_ptr->make_proxy(host_iter)), reference>,
+                              "The returned type of make_proxy must be convertible to the reference type.");
+                assert(host_ptr != nullptr);
+                return host_ptr->me_ptr->make_proxy(host_iter);
+            }
+            //!\}
+
+            /*!\name Arithmetic operators
+             * \{
+             */
+            //!\brief Advances the iterator by one.
+            constexpr iterator_type & operator++() noexcept
+            {
+                host_ptr->me_ptr->before_column_iterator_increment(host_iter);
+                ++host_iter;
+                host_ptr->me_ptr->after_column_iterator_increment(host_iter);
+                return *this;
+            }
+
+            //!\brief Advances the iterator and returns previous iterator.
+            constexpr iterator_type operator++(int) noexcept
+            {
+                iterator_type tmp{*this};
+                ++(*this);
+                return tmp;
+            }
+            //!\}
+
+            /*!\name Comparison operators
+             * \{
+             */
+            //!\brief Returns `true` if the host iterator reached the end, `false` otherwise.
+            constexpr bool operator==(sentinel const & rhs) const noexcept
+            {
+                return host_iter == rhs;
+            }
+
+            //!\copydoc operator==
+            friend constexpr bool operator==(sentinel const & lhs, iterator_type const & rhs) noexcept
+            {
+                return rhs == lhs;
+            }
+
+            //!\brief Returns `true` if both iterators are equal, `false` otherwise.
+            constexpr bool operator==(iterator_type const & rhs) const noexcept
+            {
+                return (host_ptr == rhs.host_ptr) && (host_iter == rhs.host_iter);
+            }
+
+            //!\brief Returns `true` if the host iterator did not reach the end, `false` otherwise.
+            constexpr bool operator!=(sentinel const & rhs) const noexcept
+            {
+                return !(*this == rhs);
+            }
+
+            //!\copydoc operator!=
+            friend constexpr bool operator!=(sentinel const & lhs, iterator_type const & rhs) noexcept
+            {
+                return rhs != lhs;
+            }
+
+            //!\brief Returns `true` if both iterators are not equal, `false` otherwise.
+            constexpr bool operator!=(iterator_type const & rhs) const noexcept
+            {
+                return !(*this == rhs);
+            }
+            //!\}
+
+        private:
+            //!\brief Pointer to the underlying alignment-column.
+            alignment_column_type * host_ptr{nullptr};
+            //!\brief Wrapped iterator over aliased matrix column.
+            std::ranges::iterator_t<view_type> host_iter{};
+        }; // class iterator_type
+
+    public:
+        /*!\name Constructors, destructor and assignment
+         * \{
+         */
+        constexpr alignment_column_type() = default; //!< Defaulted.
+        constexpr alignment_column_type(alignment_column_type const &) = default; //!< Defaulted.
+        constexpr alignment_column_type(alignment_column_type &&) = default; //!< Defaulted.
+        constexpr alignment_column_type & operator=(alignment_column_type const &) = default; //!< Defaulted.
+        constexpr alignment_column_type & operator=(alignment_column_type &&) = default; //!< Defaulted.
+        ~alignment_column_type() = default; //!< Defaulted.
+
+        /*!\brief Constructs from the derived type.
+         * \param[in] me  An instance of the derived type.
+         * \param[in] ref The underlying view referencing the current column in the matrix.
+         *
+         * \details
+         *
+         * This constructor is called by the derived type when invoking the function `initialise_column`.
+         */
+        constexpr alignment_column_type(derived_t & me, view_type ref) :
+            ref{std::move(ref)},
+            me_ptr{&me}
+        {}
+        //!\}
+
+        /*!\name Iterators
+         * \brief This column type is not const-iterable.
+         * \{
+         */
+        //!\brief Returns an iterator to the begin of the column.
+        constexpr auto begin() noexcept
+        {
+            assert(me_ptr != nullptr);
+            return iterator_type{*this};
+        }
+
+        //!\brief Deleted begin for const-qualified alignment-columns.
+        constexpr auto begin() const noexcept = delete; // Not needed by the alignment algorithm
+
+        //!\brief Deleted begin for const-qualified alignment-columns.
+        constexpr auto cbegin() const noexcept = delete;  // Not needed by the alignment algorithm
+
+        //!\brief Returns an iterator to the end of the column.
+        constexpr sentinel end() noexcept
+        {
+            return ref.end();
+        }
+
+        //!\brief Deleted end for const-qualified alignment-columns.
+        constexpr sentinel end() const noexcept = delete; // Not needed by the alignment algorithm
+
+        //!\brief Deleted end for const-qualified alignment-columns.
+        constexpr sentinel cend() const noexcept = delete; // Not needed by the alignment algorithm
+        //!\}
+
+    private:
+        //!\brief The aliased alignment-column.
+        view_type ref{};
+        //!\brief Pointer to the derived type.
+        derived_t * me_ptr{};
+    }; // class alignment_column_type
+
+    /*!\brief A column iterator over the alignment matrix.
+     * \implements std::InputIterator
+     *
+     * \details
+     *
+     * This iterator enables the iteration over the underlying alignment matrix in column-major-order.
+     * When dereferenced the iterator returns a seqan3::detail::alignment_matrix_column_major_range_base::column_type.
+     * The initialisation of the alignment-column depends on the derived type.
+     * This iterator models the std::InputIterator since in some cases the underlying semantics would only guarantee
+     * an std::InputIterator, e.g. in the one column score matrix implementation. Both the previous and the current
+     * column refer to the same data storage.
+     */
+    class iterator_type
+    {
+    public:
+        /*!\name Associated types
+         * \{
+         */
+        //!\brief The alignment-column type.
+        using value_type = alignment_column_type;
+        //!\brief A reference to the alignment-column type.
+        using reference = value_type;
+        //!\brief Pointer type.
+        using pointer = void;
+        //!\brief Difference type.
+        using difference_type = difference_type_t<alignment_column_type>;
+        //!\brief Iterator category.
+        using iterator_category = std::input_iterator_tag;
+        //!\}
+
+        /*!\name Constructors, destructor and assignment
+         * \{
+         */
+        constexpr iterator_type() = default; //!< Defaulted.
+        constexpr iterator_type(iterator_type const &) = default; //!< Defaulted.
+        constexpr iterator_type(iterator_type &&) = default; //!< Defaulted.
+        constexpr iterator_type & operator=(iterator_type const &) = default; //!< Defaulted.
+        constexpr iterator_type & operator=(iterator_type &&) = default; //!< Defaulted.
+        ~iterator_type() = default; //!< Defaulted.
+
+        /*!\brief Construction from an instance of the derived type.
+         * \param me     An instance of the derived type.
+         */
+        explicit constexpr iterator_type(derived_t & me) :
+            me_ptr{&me},
+            column_index{0}
+        {}
+        //!\}
+
+        /*!\name Element access
+         * \{
+         */
+        //!\brief Returns the current alignment-column.
+        constexpr reference operator*() const noexcept
+        {
+            static_assert(std::ConvertibleTo<decltype(me_ptr->initialise_column(column_index)), reference>,
+                          "The returned type of initialise_column must be convertible to the reference type.");
+            return me_ptr->initialise_column(column_index);
+        }
+        //!\}
+
+        /*!\name Arithmetic operators
+         * \{
+         */
+        //!\brief Increments by one.
+        constexpr iterator_type & operator++() noexcept
+        {
+            ++column_index;
+            return *this;
+        }
+
+        //!\brief Increments by one.
+        constexpr void operator++(int) noexcept
+        {
+            ++(*this);
+        }
+        //!\}
+
+        /*!\name Comparison operators
+         * \{
+         */
+        //!\brief Returns `true` if the behind-the-end column was reached, `false` otherwise.
+        constexpr bool operator==(std::ranges::default_sentinel_t const &) const noexcept
+        {
+            return column_index == me_ptr->num_cols;
+        }
+
+        //!\copydoc operator==
+        friend constexpr bool operator==(std::ranges::default_sentinel_t const & lhs, iterator_type const & rhs)
+            noexcept
+        {
+            return rhs == lhs;
+        }
+
+        //!\brief Returns `true` if the behind-the-end column was not reached, `false` otherwise.
+        constexpr bool operator!=(std::ranges::default_sentinel_t const & rhs) const noexcept
+        {
+            return !(*this == rhs);
+        }
+
+        //!\copydoc operator!=
+        friend constexpr bool operator!=(std::ranges::default_sentinel_t const & lhs, iterator_type const & rhs)
+            noexcept
+        {
+            return rhs != lhs;
+        }
+        //!\}
+
+    private:
+        //!\brief Pointer to the derived type.
+        derived_t * me_ptr;
+        //!\brief The current column index.
+        size_t column_index{};
+    }; // class iterator_type
+
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    //!\brief Defaulted.
+    constexpr alignment_matrix_column_major_range_base() = default;
+    //!\brief Defaulted.
+    constexpr alignment_matrix_column_major_range_base(alignment_matrix_column_major_range_base const &) = default;
+    //!\brief Defaulted.
+    constexpr alignment_matrix_column_major_range_base(alignment_matrix_column_major_range_base &&) = default;
+    //!\brief Defaulted.
+    constexpr alignment_matrix_column_major_range_base &
+    operator=(alignment_matrix_column_major_range_base const &) = default;
+    //!\brief Defaulted.
+    constexpr alignment_matrix_column_major_range_base &
+    operator=(alignment_matrix_column_major_range_base &&) = default;
+    //!\brief Defaulted.
+    ~alignment_matrix_column_major_range_base() = default;
+    //!\}
+
+    /*!\name Required types
+     * \brief The derived class must implement the following types.
+     * \{
+     */
+    /*!\brief The proxy type of an alignment matrix.
+     * \note This type must be defined by the derived type.
+     */
+    SEQAN3_DOXYGEN_ONLY(typedef /*IMPLEMENTATION_DEFINED*/ value_type;)
+
+    /*!\brief The view over the current alignment-column; must model std::ranges::View and std::ranges::InputRange.
+     * \note This type must be defined by the derived type.
+     */
+    SEQAN3_DOXYGEN_ONLY(typedef /*IMPLEMENTATION_DEFINED*/ column_data_view_type;)
+    //!\}
+
+    /*!\name Required interfaces
+     * \brief The derived class must implement the following methods.
+     * \{
+     */
+    /*!\brief Creates the proxy value returned when dereferencing the alignment-column-iterator.
+     * \param[in] host_iter The wrapped iterator to the actual memory storage.
+     * \returns A proxy for the current matrix position, which must be of type
+     *          seqan3::detail::alignment_matrix_column_major_range_base::value_type.
+     */
+    SEQAN3_DOXYGEN_ONLY(value_type make_proxy(iter_t host_iter) noexcept {})
+
+    /*!\brief Returns the current alignment-column at the given `column_index`.
+     * \param[in] column_index The current column position of the outer matrix iterator.
+     * \returns A view representing the current alignment-column
+     *          (seqan3::detail::alignment_matrix_column_major_range_base::alignment_column_type)
+     *
+     * \details
+     *
+     * Creates a new `seqan3::detail::alignment_matrix_column_major_range_base::alignment_column_type` initialised with
+     * the current column of the alignment matrix depending on the given `column_index`. The `alignment_column_type`
+     * stores a column view as defined by the derived class using the
+     * seqan3::detail::alignment_matrix_column_major_range_base::column_data_view_type type definition.
+     */
+    SEQAN3_DOXYGEN_ONLY(alignment_column_type initialise_column(size_t column_index) {})
+
+    /*!\brief Allows additional initialisations when calling begin on an alignment-column.
+     * \tparam iter_t The iterator type of the host iterator.
+     * \param[in] host_iter The wrapped iterator to the actual memory storage.
+     */
+    template <typename iter_t>
+    constexpr void on_column_iterator_creation(iter_t SEQAN3_DOXYGEN_ONLY(host_iter)) noexcept
+    {}
+
+    /*!\brief Allows to perform additional steps before incrementing the alignment-column-iterator.
+     * \tparam iter_t The iterator type of the host iterator.
+     * \param[in] host_iter The wrapped iterator to the actual memory storage.
+     */
+    template <typename iter_t>
+    constexpr void before_column_iterator_increment(iter_t SEQAN3_DOXYGEN_ONLY(host_iter)) noexcept
+    {}
+
+    /*!\brief Allows to perform additional steps after incrementing the alignment-column-iterator.
+     * \tparam iter_t The iterator type of the host iterator.
+     * \param[in] host_iter The wrapped iterator to the actual memory storage.
+     */
+    template <typename iter_t>
+    constexpr void after_column_iterator_increment(iter_t SEQAN3_DOXYGEN_ONLY(host_iter)) noexcept
+    {}
+    //!\}
+
+    //!\brief The type of the iterator.
+    using iterator = iterator_type;
+    //!\brief The type of sentinel.
+    using sentinel = std::ranges::default_sentinel_t;
+
+public:
+    /*!\name Iterators
+     * \brief The matrix type is not const-iterable.
+     * \{
+     */
+    //!\brief Returns an iterator to the first column of the matrix.
+    constexpr iterator begin() noexcept
+    {
+        return iterator{static_cast<derived_t &>(*this)};
+    }
+
+    //!\brief Deleted begin for const-qualified alignment matrix.
+    constexpr iterator begin() const noexcept = delete; // not needed for the alignment algorithm
+
+    //!\brief Deleted begin for const-qualified alignment matrix.
+    constexpr iterator cbegin() const noexcept = delete; // not needed for the alignment algorithm
+
+    //!\brief Returns a sentinel marking the end of the matrix.
+    constexpr sentinel end() noexcept
+    {
+        return std::ranges::default_sentinel;
+    }
+
+    //!\brief Deleted end for const-qualified alignment matrix.
+    constexpr sentinel end() const noexcept = delete; // not needed for the alignment algorithm
+
+    //!\brief Deleted end for const-qualified alignment matrix.
+    constexpr sentinel cend() const noexcept = delete; // not needed for the alignment algorithm
+    //!\}
+};
+} // namespace seqan3::detail

--- a/include/seqan3/alignment/matrix/detail/alignment_score_matrix_one_column.hpp
+++ b/include/seqan3/alignment/matrix/detail/alignment_score_matrix_one_column.hpp
@@ -1,0 +1,163 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides seqan3::detail::alignment_score_matrix_one_column.
+ * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <seqan3/alignment/matrix/detail/alignment_matrix_column_major_range_base.hpp>
+#include <seqan3/alignment/matrix/detail/alignment_score_matrix_one_column_base.hpp>
+#include <seqan3/alignment/matrix/detail/alignment_score_matrix_proxy.hpp>
+#include <seqan3/core/concept/core_language.hpp>
+#include <seqan3/core/simd/concept.hpp>
+#include <seqan3/std/iterator>
+#include <seqan3/std/ranges>
+#include <seqan3/std/span>
+
+namespace seqan3::detail
+{
+
+/*!\brief An alignment score matrix storing only a single column for the computation.
+ * \tparam score_t The type of the score; must model either seqan3::Arithmetic or seqan3::detail::Simd.
+ * \ingroup alignment_matrix
+ *
+ * \details
+ *
+ * This implementation allocates only a single column for the alignment score matrix.
+ * The matrix allows access to the underlying values through a range based interface. An iterator over the score matrix
+ * iterates in column-major-order. Dereferencing an iterator returns a view over the current matrix column.
+ * The value type is seqan3::detail::alignment_score_matrix_proxy, which gives an unified access to the respective
+ * matrix cells as needed by the standard alignment algorithm. The matrix is modelled as std::ranges::InputRange since
+ * the alignment algorithm iterates only once over the complete matrix to calculate the values.
+ */
+template <typename score_t>
+class alignment_score_matrix_one_column :
+    protected alignment_score_matrix_one_column_base<score_t>,
+    public alignment_matrix_column_major_range_base<alignment_score_matrix_one_column<score_t>>
+{
+private:
+    static_assert(Arithmetic<score_t> || Simd<score_t>,
+                  "The score type must be either an arithmetic type or a simd vector type.");
+    //!\brief The base class for data storage.
+    using matrix_base_t = alignment_score_matrix_one_column_base<score_t>;
+    //!\brief The base class for iterating over the matrix.
+    using range_base_t = alignment_matrix_column_major_range_base<alignment_score_matrix_one_column<score_t>>;
+
+    //!\brief Befriend the range base class.
+    friend range_base_t;
+
+protected:
+    using typename matrix_base_t::element_type;
+    using typename range_base_t::alignment_column_type;
+    //!\copydoc seqan3::detail::alignment_matrix_column_major_range_base::column_data_view_type
+    using column_data_view_type = std::span<element_type>;
+
+    using matrix_base_t::num_cols;
+
+public:
+    /*!\name Associated types
+     * \{
+     */
+    //!\copydoc seqan3::detail::alignment_matrix_column_major_range_base::value_type
+    using value_type = alignment_score_matrix_proxy<score_t>;
+    //!\brief Same as value type.
+    using reference = value_type;
+    //!\copydoc seqan3::detail::alignment_matrix_column_major_range_base::iterator
+    using iterator = typename range_base_t::iterator;
+    //!\copydoc seqan3::detail::alignment_matrix_column_major_range_base::sentinel
+    using sentinel = typename range_base_t::sentinel;
+    using typename matrix_base_t::size_type;
+    //!\}
+
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    //!\brief Defaulted.
+    constexpr alignment_score_matrix_one_column() = default;
+    //!\brief Defaulted.
+    constexpr alignment_score_matrix_one_column(alignment_score_matrix_one_column const &) = default;
+    //!\brief Defaulted.
+    constexpr alignment_score_matrix_one_column(alignment_score_matrix_one_column &&) = default;
+    //!\brief Defaulted.
+    constexpr alignment_score_matrix_one_column & operator=(alignment_score_matrix_one_column const &) = default;
+    //!\brief Defaulted.
+    constexpr alignment_score_matrix_one_column & operator=(alignment_score_matrix_one_column &&) = default;
+    //!\brief Defaulted.
+    ~alignment_score_matrix_one_column() = default;
+
+    /*!\brief Construction from two ranges.
+     * \tparam first_sequence_t  The first range type; must model std::ranges::ForwardRange.
+     * \tparam second_sequence_t The second range type; must model std::ranges::ForwardRange.
+     *
+     * \param[in] first         The first range.
+     * \param[in] second        The second range.
+     * \param[in] initial_value The value to initialise the matrix with. Default initialised if not specified.
+     *
+     * \details
+     *
+     * Obtains only the sizes of the passed ranges in order to allocate the score matrix. Only one column
+     * is allocated.
+     */
+    template <std::ranges::ForwardRange first_sequence_t, std::ranges::ForwardRange second_sequence_t>
+    constexpr alignment_score_matrix_one_column(first_sequence_t && first,
+                                                second_sequence_t && second,
+                                                score_t const initial_value = score_t{})
+    {
+        matrix_base_t::num_cols = static_cast<size_type>(std::ranges::distance(first) + 1);
+        matrix_base_t::num_rows = static_cast<size_type>(std::ranges::distance(second) + 1);
+        matrix_base_t::pool.resize(matrix_base_t::num_rows + 1, element_type{initial_value, initial_value});
+    }
+    //!\}
+
+private:
+    //!\copydoc seqan3::detail::alignment_matrix_column_major_range_base::initialise_column
+    constexpr alignment_column_type initialise_column(size_type const SEQAN3_DOXYGEN_ONLY(column_index)) noexcept
+    {
+        return alignment_column_type{*this, column_data_view_type{std::addressof(matrix_base_t::pool[0]),
+                                                                  matrix_base_t::num_rows}};
+    }
+
+    //!\copydoc seqan3::detail::alignment_matrix_column_major_range_base::make_proxy
+    template <std::RandomAccessIterator iter_t>
+    constexpr value_type make_proxy(iter_t host_iter) noexcept
+    {
+        return {std::get<0>(*host_iter),            // current
+                std::get<0>(matrix_base_t::cache),  // last diagonal
+                std::get<1>(*host_iter),            // last left (read)
+                std::get<1>(*host_iter),            // next left (write)
+                std::get<2>(matrix_base_t::cache)}; // last up
+    }
+
+    //!\copydoc seqan3::detail::alignment_matrix_column_major_range_base::on_column_iterator_creation
+    template <std::RandomAccessIterator iter_t>
+    constexpr void on_column_iterator_creation(iter_t host_iter) noexcept
+    {
+        // Cache the next diagonal value.
+        std::get<1>(matrix_base_t::cache) = std::get<0>(*host_iter);
+    }
+
+    //!\copydoc seqan3::detail::alignment_matrix_column_major_range_base::before_column_iterator_increment
+    template <std::RandomAccessIterator iter_t>
+    constexpr void before_column_iterator_increment(iter_t SEQAN3_DOXYGEN_ONLY(host_iter)) noexcept
+    {
+        // Update the last diagonal value.
+        std::get<0>(matrix_base_t::cache) = std::move(std::get<1>(matrix_base_t::cache));
+    }
+
+    //!\copydoc seqan3::detail::alignment_matrix_column_major_range_base::after_column_iterator_increment
+    template <std::RandomAccessIterator iter_t>
+    constexpr void after_column_iterator_increment(iter_t host_iter) noexcept
+    {
+        // Cache the next diagonal value.
+        std::get<1>(matrix_base_t::cache) = std::move(std::get<0>(*host_iter));
+    }
+};
+
+} // namespace seqan3::detail

--- a/include/seqan3/alignment/matrix/detail/alignment_score_matrix_one_column_banded.hpp
+++ b/include/seqan3/alignment/matrix/detail/alignment_score_matrix_one_column_banded.hpp
@@ -1,0 +1,187 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides seqan3::detail::alignment_score_matrix_one_column_banded.
+ * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <seqan3/alignment/band/static_band.hpp>
+#include <seqan3/alignment/matrix/detail/alignment_matrix_column_major_range_base.hpp>
+#include <seqan3/alignment/matrix/detail/alignment_score_matrix_one_column_base.hpp>
+#include <seqan3/alignment/matrix/detail/alignment_score_matrix_proxy.hpp>
+#include <seqan3/std/iterator>
+#include <seqan3/std/ranges>
+#include <seqan3/std/span>
+
+namespace seqan3::detail
+{
+
+/*!\brief A banded alignment score matrix storing only a single banded column for the computation.
+ * \tparam score_t The type of the score; must model either seqan3::Arithmetic or seqan3::detail::Simd.
+ * \ingroup alignment_matrix
+ *
+ * \details
+ *
+ * This implementation allocates only a single banded column for the alignment score matrix.
+ * The matrix allows access to the underlying values through a range based interface. An iterator over the score matrix
+ * iterates in column-major-order. Dereferencing an iterator returns a view over the current matrix column.
+ * The value type is seqan3::detail::alignment_score_matrix_proxy, which gives an unified access to the respective
+ * matrix cells as needed by the standard alignment algorithm. The matrix is modelled as std::ranges::InputRange since
+ * the alignment algorithm iterates only once over the complete matrix to calculate the values.
+ */
+template <typename score_t>
+class alignment_score_matrix_one_column_banded :
+    protected alignment_score_matrix_one_column_base<score_t>,
+    public alignment_matrix_column_major_range_base<alignment_score_matrix_one_column_banded<score_t>>
+{
+private:
+    //!\brief The base class for data storage.
+    using matrix_base_t = alignment_score_matrix_one_column_base<score_t>;
+    //!\brief The base class for iterating over the matrix.
+    using range_base_t = alignment_matrix_column_major_range_base<alignment_score_matrix_one_column_banded<score_t>>;
+
+    //!\brief Befriend the range base class.
+    friend range_base_t;
+
+protected:
+    using typename matrix_base_t::element_type;
+    using typename range_base_t::alignment_column_type;
+    //!\copydoc seqan3::detail::alignment_matrix_column_major_range_base::column_data_view_type
+    using column_data_view_type = std::span<element_type>;
+
+    using matrix_base_t::num_cols;
+
+public:
+    /*!\name Associated types
+     * \{
+     */
+    //!\copydoc seqan3::detail::alignment_matrix_column_major_range_base::value_type
+    using value_type = alignment_score_matrix_proxy<score_t>;
+    //!\brief Same as value type.
+    using reference = value_type;
+    //!\copydoc seqan3::detail::alignment_matrix_column_major_range_base::iterator
+    using iterator = typename range_base_t::iterator;
+    //!\copydoc seqan3::detail::alignment_matrix_column_major_range_base::sentinel
+    using sentinel = typename range_base_t::sentinel;
+    using typename matrix_base_t::size_type;
+    //!\}
+
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    //!\brief Defaulted.
+    constexpr alignment_score_matrix_one_column_banded() = default;
+    //!\brief Defaulted.
+    constexpr alignment_score_matrix_one_column_banded(alignment_score_matrix_one_column_banded const &) = default;
+    //!\brief Defaulted.
+    constexpr alignment_score_matrix_one_column_banded(alignment_score_matrix_one_column_banded &&) = default;
+    //!\brief Defaulted.
+    constexpr alignment_score_matrix_one_column_banded &
+    operator=(alignment_score_matrix_one_column_banded const &) = default;
+    //!\brief Defaulted.
+    constexpr alignment_score_matrix_one_column_banded &
+    operator=(alignment_score_matrix_one_column_banded &&) = default;
+    //!\brief Defaulted.
+    ~alignment_score_matrix_one_column_banded() = default;
+
+    /*!\brief Construction from two ranges and a band.
+     * \tparam first_sequence_t  The first range type; must model std::ranges::ForwardRange.
+     * \tparam second_sequence_t The second range type; must model std::ranges::ForwardRange.
+     *
+     * \param[in] first          The first range.
+     * \param[in] second         The second range.
+     * \param[in] band           The seqan3::static_band in which to calculate the alignment.
+     * \param[in] initial_value  The value to initialise the matrix with. Default initialised if not specified.
+     *
+     * \details
+     *
+     * Does only obtain the sizes of the passed ranges in order to allocate the score matrix. Only allocates
+     * one column of the size of the band.
+     */
+    template <std::ranges::ForwardRange first_sequence_t,
+              std::ranges::ForwardRange second_sequence_t>
+    constexpr alignment_score_matrix_one_column_banded(first_sequence_t && first,
+                                                       second_sequence_t && second,
+                                                       static_band const & band,
+                                                       score_t const initial_value = score_t{})
+    {
+        matrix_base_t::num_cols = static_cast<size_type>(std::ranges::distance(first) + 1);
+        matrix_base_t::num_rows = static_cast<size_type>(std::ranges::distance(second) + 1);
+
+        band_col_index = std::min<int32_t>(std::max<int32_t>(band.upper_bound, 0), matrix_base_t::num_cols - 1);
+        band_row_index = std::min<int32_t>(std::abs(std::min<int32_t>(band.lower_bound, 0)),
+                                           matrix_base_t::num_rows - 1);
+        band_size = band_col_index + band_row_index + 1;
+
+        // Reserve one more cell to deal with last cell in the banded column which needs only the diagonal and up cell.
+        matrix_base_t::pool.resize(band_size + 1, element_type{initial_value, initial_value});
+    }
+    //!\}
+
+private:
+    //!\brief The column index where the upper bound of the band passes through.
+    int32_t band_col_index{};
+    //!\brief The row index where the lower bound of the band passes through.
+    int32_t band_row_index{};
+    //!\brief The size of the band.
+    int32_t band_size{};
+
+    //!\copydoc seqan3::detail::alignment_matrix_column_major_range_base::initialise_column
+    constexpr alignment_column_type initialise_column(size_type const column_index) noexcept
+    {
+        int32_t slice_begin = std::max<int32_t>(0, band_col_index - column_index);
+        int32_t row_end_index = column_index - band_col_index + band_size;
+        int32_t slice_end = band_size - std::max<int32_t>(row_end_index - matrix_base_t::num_rows, 0);
+
+        assert(row_end_index >= 0);
+        assert(slice_begin >= 0);
+        assert(slice_end > 0);
+        assert(slice_begin < slice_end);
+
+        return alignment_column_type{*this, column_data_view_type{std::addressof(matrix_base_t::pool[slice_begin]),
+                                                                  std::addressof(matrix_base_t::pool[slice_end])}};
+    }
+
+    //!\copydoc seqan3::detail::alignment_matrix_column_major_range_base::make_proxy
+    template <std::RandomAccessIterator iter_t>
+    constexpr value_type make_proxy(iter_t host_iter) noexcept
+    {
+        return {std::get<0>(*host_iter),             // current
+                std::get<0>(matrix_base_t::cache),   // last diagonal
+                std::get<1>(*(host_iter + 1)),       // last left (read)
+                std::get<1>(*(host_iter)),           // next left (write)
+                std::get<1>(matrix_base_t::cache)};  // last up
+    }
+
+    //!\copydoc seqan3::detail::alignment_matrix_column_major_range_base::on_column_iterator_creation
+    template <std::RandomAccessIterator iter_t>
+    constexpr void on_column_iterator_creation(iter_t host_iter) noexcept
+    {
+        // Cache the last diagonal value.
+        std::get<0>(matrix_base_t::cache) = std::get<0>(*host_iter);
+    }
+
+    //!\copydoc seqan3::detail::alignment_matrix_column_major_range_base::before_column_iterator_increment
+    template <std::RandomAccessIterator iter_t>
+    constexpr void before_column_iterator_increment(iter_t SEQAN3_DOXYGEN_ONLY(host_iter)) noexcept
+    {
+        // noop.
+    }
+
+    //!\copydoc seqan3::detail::alignment_matrix_column_major_range_base::after_column_iterator_increment
+    template <std::RandomAccessIterator iter_t>
+    constexpr void after_column_iterator_increment(iter_t host_iter) noexcept
+    {
+        // Cache the last diagonal value.
+        std::get<0>(matrix_base_t::cache) = std::get<0>(*host_iter);
+    }
+};
+
+} // namespace seqan3::detail

--- a/include/seqan3/alignment/matrix/detail/alignment_score_matrix_one_column_base.hpp
+++ b/include/seqan3/alignment/matrix/detail/alignment_score_matrix_one_column_base.hpp
@@ -1,0 +1,61 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides seqan3::detail::alignment_score_matrix_one_column_base.
+ * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <array>
+#include <utility>
+#include <vector>
+
+#include <seqan3/core/concept/core_language.hpp>
+#include <seqan3/core/simd/concept.hpp>
+#include <seqan3/range/container/aligned_allocator.hpp>
+
+namespace seqan3::detail
+{
+
+/*!\brief A base class for alignment score matrices using only one column to compute the matrix.
+ * \tparam score_t The type of the scores.
+ * \ingroup alignment_matrix
+ *
+ * \details
+ *
+ * Manages the actual storage as a std::vector. How much memory is allocated is handled by the derived type.
+ * The `score_t` must either model the seqan3::Arithmetic or seqan3::detail::Simd vector concept.
+ */
+template <typename score_t>
+struct alignment_score_matrix_one_column_base
+{
+protected:
+    static_assert(Arithmetic<score_t> || Simd<score_t>,
+                  "Score type must either be either an arithmetic type or a simd vector type.");
+
+    //!\brief The actual element type.
+    using element_type = std::tuple<score_t, score_t>;
+    //!\brief The allocator type.
+    using allocator_type = aligned_allocator<element_type, sizeof(element_type)>;
+    //!\brief The type of the underlying storage.
+    using pool_type = std::vector<element_type, allocator_type>;
+    //!\brief The size type.
+    using size_type = size_t;
+public:
+    //!\brief The linearised memory pool storing only one column of the matrix.
+    pool_type pool{};
+    //!\brief Internal cache for the last diagonal and vertical value during the alignment computation.
+    std::array<score_t, 3> cache{};  // Third argument is used to cache next diagonal value in non-banded case.
+    //!\brief The number of columns.
+    size_type num_cols{};
+    //!\brief The number of num_rows.
+    size_type num_rows{};
+};
+
+} // namespace seqan3::detail

--- a/include/seqan3/alignment/matrix/detail/alignment_score_matrix_proxy.hpp
+++ b/include/seqan3/alignment/matrix/detail/alignment_score_matrix_proxy.hpp
@@ -1,0 +1,46 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides seqan3::detail::alignment_score_matrix_proxy.
+ * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <seqan3/core/concept/core_language.hpp>
+#include <seqan3/core/simd/concept.hpp>
+
+namespace seqan3::detail
+{
+
+/*!\brief A proxy type for a unified access to the score matrix during alignment computation.
+ * \tparam score_type The type wrapped by this proxy.
+ * \ingroup alignment_matrix
+ *
+ * \details
+ *
+ * Provides named accessors to the respective values of the score matrix during the alignment computation.
+ * The `score_type` must either model the seqan3::Arithmetic or seqan3::detail::Simd vector concept.
+ * In some cases the last value to the left is stored in a different location then the next left value that
+ * will be used in the subsequent column (e.g. in the banded alignment matrix). Accordingly the left value is
+ * split in a reference for reading, referred to as `r_left` (for reading), and a reference to the next left value
+ * on the same row, referred to as `w_left` (for writing).
+ */
+template <typename score_type>
+struct alignment_score_matrix_proxy
+{
+    static_assert(Arithmetic<score_type> || Simd<score_type>,
+                  "Value type must either be an arithmetic type or a simd vector type.");
+
+    score_type & current; //!< The current value.
+    score_type & diagonal; //!< The last diagonal value.
+    score_type & r_left; //!< The last value to the left.
+    score_type & w_left; //!< The next value to the left.
+    score_type & up; //!< The last value above.
+};
+} // namespace seqan3::detail

--- a/include/seqan3/alignment/matrix/detail/alignment_trace_matrix_base.hpp
+++ b/include/seqan3/alignment/matrix/detail/alignment_trace_matrix_base.hpp
@@ -1,0 +1,69 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides seqan3::detail::alignment_trace_matrix_base.
+ * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <vector>
+
+#include <seqan3/alignment/matrix/alignment_coordinate.hpp>
+#include <seqan3/alignment/matrix/trace_directions.hpp>
+#include <seqan3/core/simd/concept.hpp>
+#include <seqan3/range/container/aligned_allocator.hpp>
+
+namespace seqan3::detail
+{
+
+/*!\brief A crtp-base class for alignment traceback matrices.
+ * \tparam derived_t The derived type.
+ * \tparam trace_t   The type of the trace directions.
+ * \ingroup alignment_matrix
+ *
+ * \details
+ *
+ * Manages the actual storage as a std::vector. How much memory is allocated is handled by the derived type.
+ * The `trace_t` must be either a seqan3::detail::trace_directions enum value or a seqan3::detail::Simd vector
+ * over seqan3::detail::trace_directions.
+ */
+template <typename trace_t>
+struct alignment_trace_matrix_base
+{
+protected:
+    static_assert(std::Same<trace_t, trace_directions> || Simd<trace_t>,
+                  "Value type must either be a trace_directions object or a Simd vector.");
+
+    //!\brief The coordinate type.
+    using coordinate_type = advanceable_alignment_coordinate<advanceable_alignment_coordinate_state::row>;
+    //!\brief The actual element type.
+    using element_type = trace_t;
+    //!\brief The allocator type. Uses seqan3::aligned_allocator if storing seqan3::detail::Simd types.
+    using allocator_type = std::conditional_t<detail::Simd<trace_t>,
+                                              aligned_allocator<element_type, sizeof(element_type)>,
+                                              std::allocator<element_type>>;
+    //!\brief The type of the underlying memory pool.
+    using pool_type = std::vector<element_type, allocator_type>;
+    //!\brief The size type.
+    using size_type = size_t;
+
+public:
+    //!\brief The linearised matrix storing the trace data in column-major-order.
+    pool_type data{};
+    //!\brief Internal cache for the trace values to the left.
+    pool_type cache_left{};
+    //!\brief Internal cache for the last trace value above.
+    element_type cache_up{};
+    //!\brief The number of columns.
+    size_type num_cols{};
+    //!\brief The number of num_rows.
+    size_type num_rows{};
+};
+
+} // namespace seqan3::detail

--- a/include/seqan3/alignment/matrix/detail/alignment_trace_matrix_full.hpp
+++ b/include/seqan3/alignment/matrix/detail/alignment_trace_matrix_full.hpp
@@ -1,0 +1,173 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides seqan3::detail::alignment_trace_matrix_full.
+ * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <seqan3/alignment/matrix/detail/alignment_matrix_column_major_range_base.hpp>
+#include <seqan3/alignment/matrix/detail/alignment_trace_matrix_base.hpp>
+#include <seqan3/alignment/matrix/detail/alignment_trace_matrix_proxy.hpp>
+#include <seqan3/std/iterator>
+#include <seqan3/std/ranges>
+
+namespace seqan3::detail
+{
+
+/*!\brief An alignment traceback matrix storing the entire traceback matrix.
+ * \tparam trace_t          The type of the trace directions.
+ * \tparam coordinate_only  A boolean flag indicating if only a seqan3::alignment_coordinate should be generated.
+ * \ingroup alignment_matrix
+ *
+ * \details
+ *
+ * This implementation allocates the full traceback matrix using quadratic memory. The matrix allows access to the
+ * underlying values through a range based interface. An iterator over the traceback matrix iterates in
+ * column-major-order over the traceback matrix. Dereferencing an iterator returns a view over the current matrix
+ * column. The value type is a pair over a seqan3::alignment_coordinate and
+ * the seqan3::detail::alignment_trace_matrix_proxy, which gives a unified access to the respective matrix cells
+ * as needed by the standard alignment algorithm. The matrix is modelled as std::ranges::InputRange since the
+ * alignment algorithm iterates only once over the complete matrix to calculate the values.
+ *
+ * ### Only computing the coordinates
+ *
+ * Sometimes it is desired to only get access to the alignment coordinates. This can be achieved by setting
+ * `coordinate_only = true`. In this case no memory will be allocated and only an internal state is maintained to
+ * generate the alignment coordinates.
+ */
+template <typename trace_t, bool coordinate_only = false>
+class alignment_trace_matrix_full :
+    protected alignment_trace_matrix_base<trace_t>,
+    public alignment_matrix_column_major_range_base<alignment_trace_matrix_full<trace_t, coordinate_only>>
+{
+private:
+    static_assert(std::Same<trace_t, trace_directions> || Simd<trace_t>,
+                  "Value type must either be a trace_directions object or a Simd vector.");
+
+    //!\brief The base class for data storage.
+    using matrix_base_t = alignment_trace_matrix_base<trace_t>;
+    //!\brief The base class for iterating over the matrix.
+    using range_base_t = alignment_matrix_column_major_range_base<alignment_trace_matrix_full<trace_t, coordinate_only>>;
+
+    //!\brief Befriend the range base class.
+    friend range_base_t;
+
+protected:
+    using typename matrix_base_t::element_type;
+    using typename matrix_base_t::coordinate_type;
+    using typename range_base_t::alignment_column_type;
+    //!\brief The proxy type when accessing a traceback matrix cell.
+    using proxy_type = std::conditional_t<coordinate_only,
+                                          detail::ignore_t,
+                                          alignment_trace_matrix_proxy<trace_t>>;
+
+    //!\copydoc seqan3::detail::alignment_matrix_column_major_range_base::column_data_view_type
+    using column_data_view_type = std::conditional_t<coordinate_only,
+                                        decltype(std::view::iota(coordinate_type{}, coordinate_type{})),
+                                        decltype(std::view::zip(std::declval<std::span<element_type>>(),
+                                                                std::declval<std::span<element_type>>(),
+                                                                std::view::iota(coordinate_type{}, coordinate_type{})))>;
+
+public:
+    /*!\name Associated types
+     * \{
+     */
+    //!\copydoc seqan3::detail::alignment_matrix_column_major_range_base::value_type
+    using value_type = std::pair<coordinate_type, proxy_type>;
+    //!\brief Same as value type.
+    using reference = value_type;
+    //!\copydoc seqan3::detail::alignment_matrix_column_major_range_base::iterator
+    using iterator = typename range_base_t::iterator;
+    //!\copydoc seqan3::detail::alignment_matrix_column_major_range_base::sentinel
+    using sentinel = typename range_base_t::sentinel;
+    using typename matrix_base_t::size_type;
+    //!\}
+
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    constexpr alignment_trace_matrix_full() = default; //!< Defaulted.
+    constexpr alignment_trace_matrix_full(alignment_trace_matrix_full const &) = default; //!< Defaulted.
+    constexpr alignment_trace_matrix_full(alignment_trace_matrix_full &&) = default; //!< Defaulted.
+    constexpr alignment_trace_matrix_full & operator=(alignment_trace_matrix_full const &) = default; //!< Defaulted.
+    constexpr alignment_trace_matrix_full & operator=(alignment_trace_matrix_full &&) = default; //!< Defaulted.
+    ~alignment_trace_matrix_full() = default; //!< Defaulted.
+
+    /*!\brief Construction from two ranges.
+     * \tparam first_sequence_t  The first range type; must model std::ranges::ForwardRange.
+     * \tparam second_sequence_t The second range type; must model std::ranges::ForwardRange.
+     *
+     * \param[in] first  The first range.
+     * \param[in] second The second range.
+     * \param[in] initial_value The value to initialise the matrix with. Default initialised if not specified.
+     *
+     * \details
+     *
+     * Obtains the sizes of the passed ranges in order to allocate the traceback matrix.
+     * If `coordinate_only` is set to `true`, nothing will be allocated.
+     */
+    template <std::ranges::ForwardRange first_sequence_t, std::ranges::ForwardRange second_sequence_t>
+    constexpr alignment_trace_matrix_full(first_sequence_t && first,
+                                          second_sequence_t && second,
+                                          [[maybe_unused]] trace_t const initial_value = trace_t{})
+    {
+        matrix_base_t::num_cols = static_cast<size_type>(std::ranges::distance(first) + 1);
+        matrix_base_t::num_rows = static_cast<size_type>(std::ranges::distance(second) + 1);
+
+        if constexpr (!coordinate_only)
+        {
+            matrix_base_t::data.resize(matrix_base_t::num_rows * matrix_base_t::num_cols);
+            matrix_base_t::cache_left.resize(matrix_base_t::num_rows, initial_value);
+        }
+    }
+    //!\}
+
+private:
+    //!\copydoc seqan3::detail::alignment_matrix_column_major_range_base::initialise_column
+    constexpr alignment_column_type initialise_column(size_type const column_index) noexcept
+    {
+        coordinate_type row_begin{column_index_type{column_index}, row_index_type{0u}};
+        coordinate_type row_end{column_index_type{column_index}, row_index_type{matrix_base_t::num_rows}};
+        if constexpr (coordinate_only)
+        {
+            return alignment_column_type{*this, column_data_view_type{std::view::iota(std::move(row_begin),
+                                                                                      std::move(row_end))}};
+        }
+        else
+        {
+            size_type index = matrix_base_t::num_rows * column_index;
+            auto col = std::view::zip(std::span<element_type>{std::addressof(matrix_base_t::data[index]),
+                                                              matrix_base_t::num_rows},
+                                      std::span<element_type>{matrix_base_t::cache_left},
+                                      std::view::iota(std::move(row_begin), std::move(row_end)));
+            return alignment_column_type{*this, column_data_view_type{col}};
+        }
+    }
+
+    //!\copydoc seqan3::detail::alignment_matrix_column_major_range_base::make_proxy
+    template <std::RandomAccessIterator iter_t>
+    constexpr value_type make_proxy(iter_t host_iter) noexcept
+    {
+        if constexpr (coordinate_only)
+        {
+            return {*host_iter, std::ignore};
+        }
+        else
+        {
+            return {std::get<2>(*host_iter),
+                    proxy_type{std::get<0>(*host_iter),
+                               std::get<1>(*host_iter),
+                               std::get<1>(*host_iter),
+                               matrix_base_t::cache_up}};
+        }
+    }
+};
+
+} // namespace seqan3::detail

--- a/include/seqan3/alignment/matrix/detail/alignment_trace_matrix_full_banded.hpp
+++ b/include/seqan3/alignment/matrix/detail/alignment_trace_matrix_full_banded.hpp
@@ -1,0 +1,208 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides seqan3::detail::alignment_trace_matrix_full_banded.
+ * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <seqan3/alignment/band/static_band.hpp>
+#include <seqan3/alignment/matrix/detail/alignment_matrix_column_major_range_base.hpp>
+#include <seqan3/alignment/matrix/detail/alignment_trace_matrix_base.hpp>
+#include <seqan3/alignment/matrix/detail/alignment_trace_matrix_proxy.hpp>
+#include <seqan3/std/iterator>
+#include <seqan3/std/ranges>
+
+namespace seqan3::detail
+{
+
+/*!\brief An alignment traceback matrix storing the entire banded traceback matrix.
+ * \tparam trace_t          The type of the trace directions.
+ * \tparam coordinate_only  A boolean flag indicating if only a seqan3::alignment_coordinate should be generated.
+ * \ingroup alignment_matrix
+ *
+ * \details
+ *
+ * This implementation allocates the full banded traceback matrix using `k*m` memory, where `k` is the band size and
+ * `m` the number of columns to store. The matrix allows access to the
+ * underlying values through a range based interface. An iterator over the traceback matrix iterates in
+ * column-major-order over the traceback matrix. Dereferencing an iterator returns a slice over the current matrix
+ * column. The value type is a pair over a seqan3::alignment_coordinate and
+ * the seqan3::detail::alignment_trace_matrix_proxy, which gives a unified access to the respective matrix cells
+ * as needed by the standard alignment algorithm. The matrix is modelled as std::ranges::InputRange since the
+ * alignment algorithm iterates only once over the complete matrix to calculate the values.
+ *
+ * ### Only computing the coordinates
+ *
+ * Sometimes it is desired to only get access to the alignment coordinates. This can be achieved by setting
+ * `coordinate_only = true`. In this case no memory will be allocated and only an internal state is maintained to
+ * generate the alignment coordinates. The coordinates are relative to the banded matrix, i.e. they do not represent the
+ * corresponding row indices of the actual (unbanded) matrix.
+ */
+template <typename trace_t, bool coordinate_only = false>
+class alignment_trace_matrix_full_banded :
+    protected alignment_trace_matrix_base<trace_t>,
+    public alignment_matrix_column_major_range_base<alignment_trace_matrix_full_banded<trace_t, coordinate_only>>
+{
+private:
+    static_assert(std::Same<trace_t, trace_directions> || Simd<trace_t>,
+                  "Value type must either be a trace_directions object or a Simd vector.");
+
+    //!\brief The base class for data storage.
+    using matrix_base_t = alignment_trace_matrix_base<trace_t>;
+    //!\brief The base class for iterating over the matrix.
+    using range_base_t = alignment_matrix_column_major_range_base<alignment_trace_matrix_full_banded<trace_t,
+                                                                                                coordinate_only>>;
+    //!\brief Befriend the range base class.
+    friend range_base_t;
+
+protected:
+    using typename matrix_base_t::element_type;
+    using typename matrix_base_t::coordinate_type;
+    using typename range_base_t::alignment_column_type;
+    //!\brief The proxy type when accessing a traceback matrix cell.
+    using proxy_type = std::conditional_t<coordinate_only,
+                                          detail::ignore_t,
+                                          alignment_trace_matrix_proxy<trace_t>>;
+    //!\copydoc alignment_matrix_column_major_range_base::column_data_view_type
+    using column_data_view_type = std::conditional_t<coordinate_only,
+                                        decltype(std::view::iota(coordinate_type{}, coordinate_type{})),
+                                        decltype(std::view::zip(std::declval<std::span<element_type>>(),
+                                                                std::declval<std::span<element_type>>(),
+                                                                std::view::iota(coordinate_type{}, coordinate_type{})))>;
+
+public:
+    /*!\name Associated types
+     * \{
+     */
+    //!\copydoc seqan3::detail::alignment_matrix_column_major_range_base::value_type
+    using value_type = std::pair<coordinate_type, proxy_type>;
+    //!\brief Same as value type.
+    using reference = value_type;
+    //!\copydoc seqan3::detail::alignment_matrix_column_major_range_base::iterator
+    using iterator = typename range_base_t::iterator;
+    //!\copydoc seqan3::detail::alignment_matrix_column_major_range_base::sentinel
+    using sentinel = typename range_base_t::sentinel;
+    using typename matrix_base_t::size_type;
+    //!\}
+
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+     //!\brief Defaulted.
+    constexpr alignment_trace_matrix_full_banded() = default;
+     //!\brief Defaulted.
+    constexpr alignment_trace_matrix_full_banded(alignment_trace_matrix_full_banded const &) = default;
+     //!\brief Defaulted.
+    constexpr alignment_trace_matrix_full_banded(alignment_trace_matrix_full_banded &&) = default;
+     //!\brief Defaulted.
+    constexpr alignment_trace_matrix_full_banded & operator=(alignment_trace_matrix_full_banded const &) = default;
+     //!\brief Defaulted.
+    constexpr alignment_trace_matrix_full_banded & operator=(alignment_trace_matrix_full_banded &&) = default;
+     //!\brief Defaulted.
+    ~alignment_trace_matrix_full_banded() = default;
+
+    /*!\brief Construction from two ranges and a band.
+     * \tparam first_sequence_t  The first range type; must model std::ranges::ForwardRange.
+     * \tparam second_sequence_t The second range type; must model std::ranges::ForwardRange.
+     *
+     * \param[in] first         The first range.
+     * \param[in] second        The second range.
+     * \param[in] band          The seqan3::static_band in which to calculate the alignment.
+     * \param[in] initial_value The value to initialise the matrix with. Default initialised if not specified.
+     *
+     * \details
+     *
+     * Obtains the sizes of the passed ranges in order to allocate the traceback matrix. Only allocates
+     * memory to store the banded matrix.
+     * If `coordinate_only` is set to `true`, nothing will be allocated.
+     */
+    template <std::ranges::ForwardRange first_sequence_t, std::ranges::ForwardRange second_sequence_t>
+    constexpr alignment_trace_matrix_full_banded(first_sequence_t && first,
+                                                 second_sequence_t && second,
+                                                 static_band const & band,
+                                                 [[maybe_unused]] trace_t const initial_value = trace_t{})
+    {
+        matrix_base_t::num_cols = static_cast<size_type>(std::ranges::distance(first) + 1);
+        matrix_base_t::num_rows = static_cast<size_type>(std::ranges::distance(second) + 1);
+
+        band_col_index = std::min<int32_t>(std::max<int32_t>(band.upper_bound, 0), matrix_base_t::num_cols - 1);
+        band_row_index = std::min<int32_t>(std::abs(std::min<int32_t>(band.lower_bound, 0)), matrix_base_t::num_rows - 1);
+        band_size = band_col_index + band_row_index + 1;
+
+        // Reserve one more cell to deal with last cell in the banded column which needs only the diagonal and up cell.
+        if constexpr (!coordinate_only)
+        {
+            matrix_base_t::data.resize(matrix_base_t::num_cols * band_size);
+            matrix_base_t::cache_left.resize(band_size, initial_value);
+        }
+    }
+    //!\}
+
+private:
+    //!\brief The column index where the upper bound of the band passes through.
+    int32_t band_col_index{};
+    //!\brief The row index where the lower bound of the band passes through.
+    int32_t band_row_index{};
+    //!\brief The size of the band.
+    int32_t band_size{};
+
+    //!\copydoc seqan3::detail::alignment_matrix_column_major_range_base::initialise_column
+    constexpr alignment_column_type initialise_column(size_type const column_index) noexcept
+    {
+        int32_t slice_begin = std::max<int32_t>(0, band_col_index - column_index);
+        int32_t row_end_index = column_index - band_col_index + band_size;
+        int32_t slice_end = band_size - std::max<int32_t>(row_end_index - matrix_base_t::num_rows, 0);
+
+        assert(row_end_index >= 0);
+        assert(slice_begin >= 0);
+        assert(slice_end > 0);
+        assert(slice_begin < slice_end);
+
+        coordinate_type row_begin{column_index_type{column_index}, row_index_type{static_cast<size_type>(slice_begin)}};
+        coordinate_type row_end{column_index_type{column_index}, row_index_type{static_cast<size_type>(slice_end)}};
+        if constexpr (coordinate_only)
+        {
+            return alignment_column_type{*this, column_data_view_type{std::view::iota(std::move(row_begin),
+                                                                                      std::move(row_end))}};
+        }
+        else
+        {
+            size_type base_index = band_size * column_index;
+
+            // We need to jump to the offset.
+            auto col = std::view::zip(
+                            std::span<element_type>{std::addressof(matrix_base_t::data[base_index + slice_begin]),
+                                                    std::addressof(matrix_base_t::data[base_index + slice_end])},
+                            std::span<element_type>{std::addressof(matrix_base_t::cache_left[slice_begin]),
+                                                    std::addressof(matrix_base_t::cache_left[slice_end])},
+                            std::view::iota(std::move(row_begin), std::move(row_end)));
+            return alignment_column_type{*this, column_data_view_type{std::move(col)}};
+        }
+    }
+
+    //!\copydoc seqan3::detail::alignment_matrix_column_major_range_base::make_proxy
+    template <std::RandomAccessIterator iter_t>
+    constexpr value_type make_proxy(iter_t host_iter) noexcept
+    {
+        if constexpr (coordinate_only)
+        {
+            return {*host_iter, std::ignore};
+        }
+        else
+        {
+            return {std::get<2>(*host_iter), proxy_type{std::get<0>(*host_iter),
+                                                        std::get<1>(*(host_iter + 1)),
+                                                        std::get<1>(*host_iter),
+                                                        matrix_base_t::cache_up}};
+        }
+    }
+};
+
+} // namespace seqan3::detail

--- a/include/seqan3/alignment/matrix/detail/alignment_trace_matrix_proxy.hpp
+++ b/include/seqan3/alignment/matrix/detail/alignment_trace_matrix_proxy.hpp
@@ -1,0 +1,44 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides seqan3::detail::alignment_trace_matrix_proxy.
+ * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <seqan3/alignment/matrix/trace_directions.hpp>
+#include <seqan3/core/simd/concept.hpp>
+#include <seqan3/std/concepts>
+
+namespace seqan3::detail
+{
+
+/*!\brief A proxy type for a unified access to the traceback matrix during alignment computation.
+ * \tparam trace_type The type wrapped by this proxy.
+ * \ingroup alignment_matrix
+ *
+ * \details
+ *
+ * Provides named accessors to the respective values of the traceback matrix during the alignment computation.
+ * The `trace_type` must be either a seqan3::detail::trace_directions value or a seqan3::detail::Simd vector
+ * over seqan3::detail::trace_directions.
+ */
+template <typename trace_type>
+struct alignment_trace_matrix_proxy
+{
+    static_assert(std::Same<trace_type, trace_directions> || Simd<trace_type>,
+                  "Value type must either be a trace_directions object or a Simd vector.");
+
+    trace_type & current; //!< Reference to the current element.
+    trace_type & left_r; //!< Reference to the element to the left.
+    trace_type & left_w; //!< Reference to the next element to the left.
+    trace_type & up; //!< Reference to the element above.
+};
+
+} // namespace seqan3::detail

--- a/include/seqan3/alignment/matrix/detail/all.hpp
+++ b/include/seqan3/alignment/matrix/detail/all.hpp
@@ -1,0 +1,22 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Meta-header for the detail block of the \link alignment_matrix Matrix sub-module \endlink.
+ * \author René Rahn <rene.rahn AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <seqan3/alignment/matrix/detail/alignment_matrix_column_major_range_base.hpp>
+#include <seqan3/alignment/matrix/detail/alignment_score_matrix_one_column_banded.hpp>
+#include <seqan3/alignment/matrix/detail/alignment_score_matrix_one_column_base.hpp>
+#include <seqan3/alignment/matrix/detail/alignment_score_matrix_one_column.hpp>
+#include <seqan3/alignment/matrix/detail/alignment_score_matrix_proxy.hpp>
+#include <seqan3/alignment/matrix/detail/alignment_trace_matrix_full_banded.hpp>
+#include <seqan3/alignment/matrix/detail/alignment_trace_matrix_full.hpp>
+#include <seqan3/alignment/matrix/detail/alignment_trace_matrix_proxy.hpp>

--- a/include/seqan3/std/algorithm
+++ b/include/seqan3/std/algorithm
@@ -32,6 +32,7 @@
 #include <range/v3/algorithm/move_backward.hpp>
 #include <range/v3/algorithm/move.hpp>
 #include <range/v3/algorithm/sort.hpp>
+#include <range/v3/algorithm/transform.hpp>
 
 #include <seqan3/core/platform.hpp>
 
@@ -92,6 +93,11 @@ using SEQAN3_DOXYGEN_ONLY(move =) ::ranges::move;
 * \brief Alias for ranges::sort. Sorts a range.
 */
 using SEQAN3_DOXYGEN_ONLY(sort =) ::ranges::sort;
+
+/*!\typedef std::ranges::transform
+* \brief Alias for ranges::transform. Transforms a range.
+*/
+using SEQAN3_DOXYGEN_ONLY(transform =) ::ranges::transform;
 
 } // namespace std::ranges
 #endif  // __cpp_lib_ranges

--- a/test/snippet/alignment/matrix/detail/alignment_matrix_column_major_range_base.cpp
+++ b/test/snippet/alignment/matrix/detail/alignment_matrix_column_major_range_base.cpp
@@ -1,0 +1,74 @@
+#include <vector>
+
+#include <seqan3/alignment/matrix/detail/alignment_matrix_column_major_range_base.hpp>
+#include <seqan3/core/debug_stream.hpp>
+#include <seqan3/std/span>
+
+using namespace seqan3;
+using namespace seqan3::detail;
+
+class my_matrix : public alignment_matrix_column_major_range_base<my_matrix>
+{
+public:
+
+    // Alias the base class
+    using base_t = alignment_matrix_column_major_range_base<my_matrix>;
+
+    // Inherit the alignment column type defined in the base class. This type is returned in initialise_column.
+    using typename base_t::alignment_column_type;
+
+    // The following types are required by the base type since they cannot be inferred within the base.
+
+    using column_data_view_type = std::span<int>;  //This type is the underlying view over the actual memory location.
+    using value_type = int; // The actual value type.
+    using reference = int &; // The actual reference type.
+
+    my_matrix() = default;
+    my_matrix(my_matrix const &) = default;
+    my_matrix(my_matrix &&) = default;
+    my_matrix & operator=(my_matrix const &) = default;
+    my_matrix & operator=(my_matrix &&) = default;
+    ~my_matrix() = default;
+
+    my_matrix(size_t const num_rows, size_t const num_cols) :
+        num_rows{num_rows},
+        num_cols{num_cols}
+    {
+        data.resize(num_rows * num_cols);
+    }
+
+private:
+
+    std::vector<int> data{};
+    size_t num_rows{};
+    size_t num_cols{};
+
+    //Required for the base class. Initialises the current column given the column index.
+    alignment_column_type initialise_column(size_t const column_index) noexcept
+    {
+        return alignment_column_type{*this,
+                                     column_data_view_type{std::addressof(data[num_rows * column_index]), num_rows}};
+    }
+
+    //Required for the base class. Initialises the proxy for the current iterator over the current column.
+    template <std::RandomAccessIterator iter_t>
+    constexpr reference make_proxy(iter_t iter) noexcept
+    {
+        return *iter;
+    }
+};
+
+int main()
+{
+    my_matrix matrix{3, 5};
+
+    // Fill the matrix with
+    int val = 0;
+    for (auto col : matrix) // Iterate over the columns
+        for (auto & cell : col) // Iterate over the cells in one column.
+            cell = val++;
+
+    // Print the matrix column by column
+    for (auto col : matrix)
+        debug_stream << col << "\n";
+}

--- a/test/unit/alignment/matrix/CMakeLists.txt
+++ b/test/unit/alignment/matrix/CMakeLists.txt
@@ -6,3 +6,5 @@ seqan3_test(debug_stream_debug_matrix_test.cpp)
 seqan3_test(debug_stream_trace_directions_test.cpp)
 seqan3_test(edit_distance_score_matrix_full_test.cpp)
 seqan3_test(edit_distance_trace_matrix_full_test.cpp)
+
+add_subdirectories()

--- a/test/unit/alignment/matrix/detail/CMakeLists.txt
+++ b/test/unit/alignment/matrix/detail/CMakeLists.txt
@@ -1,1 +1,3 @@
 seqan3_test (alignment_matrix_column_major_range_test.cpp)
+seqan3_test (alignment_score_matrix_one_column_banded_test.cpp)
+seqan3_test (alignment_score_matrix_one_column_test.cpp)

--- a/test/unit/alignment/matrix/detail/CMakeLists.txt
+++ b/test/unit/alignment/matrix/detail/CMakeLists.txt
@@ -1,0 +1,1 @@
+seqan3_test (alignment_matrix_column_major_range_test.cpp)

--- a/test/unit/alignment/matrix/detail/CMakeLists.txt
+++ b/test/unit/alignment/matrix/detail/CMakeLists.txt
@@ -1,3 +1,5 @@
 seqan3_test (alignment_matrix_column_major_range_test.cpp)
 seqan3_test (alignment_score_matrix_one_column_banded_test.cpp)
 seqan3_test (alignment_score_matrix_one_column_test.cpp)
+seqan3_test (alignment_trace_matrix_full_banded_test.cpp)
+seqan3_test (alignment_trace_matrix_full_test.cpp)

--- a/test/unit/alignment/matrix/detail/alignment_matrix_base_test_template.hpp
+++ b/test/unit/alignment/matrix/detail/alignment_matrix_base_test_template.hpp
@@ -1,0 +1,133 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <seqan3/alignment/band/static_band.hpp>
+
+using namespace seqan3;
+using namespace seqan3::detail;
+
+template <typename t>
+struct alignment_matrix_base_test : public ::testing::Test
+{
+    using matrix_t = std::tuple_element_t<0, t>;
+    static constexpr bool is_banded = std::tuple_element_t<1, t>::value;
+
+    alignment_matrix_base_test()
+    {
+        if constexpr (is_banded)
+            test_range = matrix_t{first, second, static_band{lower_bound{-2}, upper_bound{2}}};
+        else
+            test_range = matrix_t{first, second};
+    }
+
+    std::string first{"abba"};
+    std::string second{"baba"};
+    matrix_t test_range{};
+};
+
+TYPED_TEST_CASE_P(alignment_matrix_base_test);
+
+TYPED_TEST_P(alignment_matrix_base_test, range_concepts)
+{
+    using outer_it = std::ranges::iterator_t<typename TestFixture::matrix_t>;
+    using column_t = value_type_t<outer_it>;
+    using inner_it = std::ranges::iterator_t<column_t>;
+
+    EXPECT_TRUE(std::ranges::InputRange<typename TestFixture::matrix_t>);
+    EXPECT_TRUE(std::InputIterator<outer_it>);
+    EXPECT_TRUE(std::InputIterator<inner_it>);
+    EXPECT_TRUE(std::ranges::InputRange<column_t>);
+    EXPECT_TRUE(std::ranges::View<column_t>);
+}
+
+TYPED_TEST_P(alignment_matrix_base_test, begin_end)
+{
+    auto it = this->test_range.begin();
+    auto col = *it;
+    auto col_it = col.begin();
+
+    EXPECT_NE(col_it, col.end());
+    EXPECT_NE(it, this->test_range.end());
+}
+
+TYPED_TEST_P(alignment_matrix_base_test, basic_construction)
+{
+    using matrix_type = typename TestFixture::matrix_t;
+
+    EXPECT_TRUE(std::is_default_constructible_v<matrix_type>);
+    EXPECT_TRUE(std::is_copy_constructible_v<matrix_type>);
+    EXPECT_TRUE(std::is_move_constructible_v<matrix_type>);
+    EXPECT_TRUE(std::is_copy_assignable_v<matrix_type>);
+    EXPECT_TRUE(std::is_move_assignable_v<matrix_type>);
+    EXPECT_TRUE(std::is_destructible_v<matrix_type>);
+}
+
+template <typename matrix_t>
+void test_matrix_iteration(matrix_t test_range, int32_t const expected_col_count, int32_t const expected_row_count)
+{
+    int32_t col_count = 0;
+    int32_t row_count = 0;
+    for (auto col : test_range)
+    {
+        for ([[maybe_unused]] auto cell : col)
+            ++row_count;
+
+        ++col_count;
+    }
+    EXPECT_EQ(col_count, expected_col_count);
+    EXPECT_EQ(row_count, expected_row_count);
+}
+
+TYPED_TEST_P(alignment_matrix_base_test, empty_row)
+{
+    using matrix_type = typename TestFixture::matrix_t;
+
+    if constexpr (TestFixture::is_banded)
+    {
+        static_band band{lower_bound{-2}, upper_bound{4}};
+        test_matrix_iteration(matrix_type{this->first, std::string{""}, band}, 5, 5);
+    }
+    else
+    {
+        test_matrix_iteration(matrix_type{this->first, std::string{""}}, 5, 5);
+    }
+}
+
+TYPED_TEST_P(alignment_matrix_base_test, empty_col)
+{
+    using matrix_type = typename TestFixture::matrix_t;
+
+    if constexpr (TestFixture::is_banded)
+    {
+        static_band band{lower_bound{-2}, upper_bound{2}};
+        test_matrix_iteration(matrix_type{std::string{""}, this->second, band}, 1, 3);
+    }
+    else
+    {
+        test_matrix_iteration(matrix_type{std::string{""}, this->second}, 1, 5);
+    }
+}
+
+TYPED_TEST_P(alignment_matrix_base_test, empty_col_row)
+{
+    using matrix_type = typename TestFixture::matrix_t;
+
+    if constexpr (TestFixture::is_banded)
+    {
+        static_band band{lower_bound{0}, upper_bound{2}};
+        test_matrix_iteration(matrix_type{std::string{""}, std::string{""}, band}, 1, 1);
+    }
+    else
+    {
+        test_matrix_iteration(matrix_type{std::string{""}, std::string{""}}, 1, 1);
+    }
+}
+
+REGISTER_TYPED_TEST_CASE_P(alignment_matrix_base_test, range_concepts, begin_end, basic_construction, empty_row,
+                           empty_col, empty_col_row);

--- a/test/unit/alignment/matrix/detail/alignment_matrix_column_major_range_test.cpp
+++ b/test/unit/alignment/matrix/detail/alignment_matrix_column_major_range_test.cpp
@@ -1,0 +1,164 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include <seqan3/alignment/matrix/detail/alignment_matrix_column_major_range_base.hpp>
+
+using namespace seqan3;
+using namespace seqan3::detail;
+
+class test_matrix : public alignment_matrix_column_major_range_base<test_matrix>
+{
+public:
+
+    using base_t = alignment_matrix_column_major_range_base<test_matrix>;
+
+    using element_type = int;
+    using alignment_column_type = typename base_t::alignment_column_type;
+    using column_data_view_type = std::span<element_type>;
+
+    struct proxy_type
+    {
+        element_type & value;
+    };
+
+    using value_type = proxy_type;
+    using reference = proxy_type;
+
+    test_matrix() = default;
+    test_matrix(test_matrix const &) = default;
+    test_matrix(test_matrix &&) = default;
+    test_matrix & operator=(test_matrix const &) = default;
+    test_matrix & operator=(test_matrix &&) = default;
+    ~test_matrix() = default;
+
+    std::vector<element_type> data{};
+    size_t num_cols{};
+    size_t num_rows{};
+    size_t num_create{};
+    size_t num_pre{};
+    size_t num_post{};
+
+    alignment_column_type initialise_column(size_t const column_index) noexcept
+    {
+        return alignment_column_type{*this,
+                                     column_data_view_type{std::addressof(data[num_rows * column_index]), num_rows}};
+    }
+
+    template <std::RandomAccessIterator iter_t>
+    constexpr reference make_proxy(iter_t iter) noexcept
+    {
+        return {*iter};
+    }
+
+    template <std::RandomAccessIterator iter_t>
+    constexpr void on_column_iterator_creation(iter_t) noexcept
+    {
+        ++num_create;
+    }
+
+    template <std::RandomAccessIterator iter_t>
+    constexpr void before_column_iterator_increment(iter_t ) noexcept
+    {
+        ++num_pre;
+    }
+
+    template <std::RandomAccessIterator iter_t>
+    constexpr void after_column_iterator_increment(iter_t ) noexcept
+    {
+        ++num_post;
+    }
+};
+
+class alignment_matrix_column_major_range_base_test : public ::testing::Test
+{
+protected:
+
+    alignment_matrix_column_major_range_base_test()
+    {
+        matrix.num_cols = 4;
+        matrix.num_rows = 5;
+        matrix.data.resize(matrix.num_cols * matrix.num_rows);
+
+        int k = 0;
+        for (unsigned i = 0; i < matrix.num_cols; ++i)
+            for (unsigned j = 0; j < matrix.num_rows; ++j, ++k)
+                matrix.data[i * matrix.num_rows + j] = k;
+    }
+
+    test_matrix matrix{};
+};
+
+TEST(alignment_matrix_column_major_range_base, concepts)
+{
+    using outer_it = std::ranges::iterator_t<test_matrix>;
+    using column_t = value_type_t<outer_it>;
+    using inner_it = std::ranges::iterator_t<column_t>;
+
+    EXPECT_TRUE(std::ranges::InputRange<test_matrix>);
+    EXPECT_TRUE(std::InputIterator<outer_it>);
+    EXPECT_TRUE(std::InputIterator<inner_it>);
+    EXPECT_TRUE(std::ranges::InputRange<column_t>);
+    EXPECT_TRUE(std::ranges::View<column_t>);
+}
+
+TEST_F(alignment_matrix_column_major_range_base_test, begin_end)
+{
+    auto it = matrix.begin();
+    auto col = *it;
+    auto col_it = col.begin();
+    EXPECT_EQ((*col_it).value, 0);
+    EXPECT_NE(col_it, col.end());
+    EXPECT_NE(it, matrix.end());
+}
+
+TEST_F(alignment_matrix_column_major_range_base_test, iterate_columns)
+{
+    size_t count = 0;
+    for (auto it = matrix.begin(); it != matrix.end(); ++it, ++count);
+    EXPECT_EQ(count, 4u);
+}
+
+TEST_F(alignment_matrix_column_major_range_base_test, iterate_num_rows)
+{
+    auto it = matrix.begin();
+    auto col = *it;
+    size_t count = 0;
+    for (auto it = col.begin(); it != col.end(); ++it, ++count);
+    EXPECT_EQ(count, 5u);
+}
+
+TEST_F(alignment_matrix_column_major_range_base_test, iterate_matrix)
+{
+    auto mat_it = matrix.begin();
+    auto col = *mat_it;
+    int cmp = 0;
+    for (auto it = col.begin(); it != col.end(); ++it, ++cmp)
+        EXPECT_EQ((*it).value, cmp);
+
+    ++mat_it;
+    col = *mat_it;
+    for (auto it = col.begin(); it != col.end(); ++it, ++cmp)
+        EXPECT_EQ((*it).value, cmp);
+
+    ++mat_it;
+    col = *mat_it;
+    for (auto it = col.begin(); it != col.end(); ++it, ++cmp)
+        EXPECT_EQ((*it).value, cmp);
+
+    ++mat_it;
+    col = *mat_it;
+    for (auto it = col.begin(); it != col.end(); ++it, ++cmp)
+        EXPECT_EQ((*it).value, cmp);
+
+    EXPECT_EQ(matrix.num_create, 4u);
+    EXPECT_EQ(matrix.num_pre, 20u);
+    EXPECT_EQ(matrix.num_post, 20u);
+}

--- a/test/unit/alignment/matrix/detail/alignment_score_matrix_one_column_banded_test.cpp
+++ b/test/unit/alignment/matrix/detail/alignment_score_matrix_one_column_banded_test.cpp
@@ -12,7 +12,9 @@
 
 #include <seqan3/alignment/matrix/detail/alignment_score_matrix_one_column_banded.hpp>
 
-#include "alignment_score_matrix_test_template.hpp"
+#include "alignment_matrix_base_test_template.hpp"
+#include "simulated_alignment_test_template.hpp"
+#include "../../../range/iterator_test_template.hpp"
 
 using namespace seqan3;
 
@@ -41,5 +43,67 @@ struct alignment_score_matrix_one_column_banded_test
 };
 
 INSTANTIATE_TYPED_TEST_CASE_P(one_column_banded,
-                              alignment_score_matrix_test,
+                              simulated_alignment_test,
                               alignment_score_matrix_one_column_banded_test<int32_t>);
+
+using test_type = std::pair<detail::alignment_score_matrix_one_column_banded<int32_t>, std::true_type>;
+
+INSTANTIATE_TYPED_TEST_CASE_P(one_column_banded,
+                              alignment_matrix_base_test,
+                              test_type);
+
+//-----------------------------------------------------------------------------
+// Test outer iterator
+//-----------------------------------------------------------------------------
+struct outer_iterator
+{};
+
+template <>
+struct iterator_fixture<outer_iterator> : alignment_matrix_base_test<test_type>
+{
+    using base_t = alignment_matrix_base_test<test_type>;
+
+    using iterator_tag = std::input_iterator_tag;
+    static constexpr bool const_iterable = false;
+
+    using base_t::test_range;
+    std::vector<int> expected_range{0, 0, 0, 0, 0};
+
+    template <typename lhs_t, typename rhs_t>
+    static void expect_eq(lhs_t lhs, rhs_t rhs)
+    {
+        EXPECT_EQ((*lhs.begin()).current, rhs);
+    }
+};
+
+INSTANTIATE_TYPED_TEST_CASE_P(banded_score_matrix_outer_iterator,
+                              iterator_fixture,
+                              outer_iterator);
+
+//-----------------------------------------------------------------------------
+// Test inner iterator
+//-----------------------------------------------------------------------------
+struct inner_iterator
+{};
+
+template <>
+struct iterator_fixture<inner_iterator> : alignment_matrix_base_test<test_type>
+{
+    using base_t = alignment_matrix_base_test<test_type>;
+
+    using iterator_tag = std::forward_iterator_tag;
+    static constexpr bool const_iterable = false;
+
+    decltype(*base_t::test_range.begin()) test_range = *base_t::test_range.begin();
+    std::vector<int> expected_range{0, 0, 0};
+
+    template <typename lhs_t, typename rhs_t>
+    static void expect_eq(lhs_t lhs, rhs_t rhs)
+    {
+        EXPECT_EQ(lhs.current, rhs);
+    }
+};
+
+INSTANTIATE_TYPED_TEST_CASE_P(banded_score_matrix_inner_iterator,
+                              iterator_fixture,
+                              inner_iterator);

--- a/test/unit/alignment/matrix/detail/alignment_score_matrix_one_column_banded_test.cpp
+++ b/test/unit/alignment/matrix/detail/alignment_score_matrix_one_column_banded_test.cpp
@@ -1,0 +1,45 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <vector>
+#include <string>
+
+#include <seqan3/alignment/matrix/detail/alignment_score_matrix_one_column_banded.hpp>
+
+#include "alignment_score_matrix_test_template.hpp"
+
+using namespace seqan3;
+
+template <typename t>
+struct alignment_score_matrix_one_column_banded_test
+{
+    using matrix_t = detail::alignment_score_matrix_one_column_banded<t>;
+    using score_type = t;
+
+    alignment_score_matrix_one_column_banded_test() = default;
+    alignment_score_matrix_one_column_banded_test(std::string f, std::string s) :
+        matrix{matrix_t{f, s, static_band{lower_bound{-2}, upper_bound{2}}, -100}}
+    {}
+
+    // Banded matrix. We write only partial columns to the result.
+    // The remaining part is therefor 0.
+    std::vector<t> gold_matrix{  0, -1, -2,
+                                -1, -1, -1, -2,
+                                -2, -1, -2, -1, -2,
+                                    -2, -2, -2, -2,
+                                        -2, -3, -2,
+                                 0, 0, 0, 0, 0, 0};
+
+    matrix_t matrix{};
+    size_t last_init_column = 2;
+};
+
+INSTANTIATE_TYPED_TEST_CASE_P(one_column_banded,
+                              alignment_score_matrix_test,
+                              alignment_score_matrix_one_column_banded_test<int32_t>);

--- a/test/unit/alignment/matrix/detail/alignment_score_matrix_one_column_test.cpp
+++ b/test/unit/alignment/matrix/detail/alignment_score_matrix_one_column_test.cpp
@@ -12,7 +12,9 @@
 
 #include <seqan3/alignment/matrix/detail/alignment_score_matrix_one_column.hpp>
 
-#include "alignment_score_matrix_test_template.hpp"
+#include "alignment_matrix_base_test_template.hpp"
+#include "simulated_alignment_test_template.hpp"
+#include "../../../range/iterator_test_template.hpp"
 
 using namespace seqan3;
 
@@ -37,5 +39,67 @@ struct alignment_score_matrix_one_column_test
 };
 
 INSTANTIATE_TYPED_TEST_CASE_P(one_column,
-                              alignment_score_matrix_test,
+                              simulated_alignment_test,
                               alignment_score_matrix_one_column_test<int32_t>);
+
+using test_type = std::pair<detail::alignment_score_matrix_one_column<int32_t>, std::false_type>;
+
+INSTANTIATE_TYPED_TEST_CASE_P(one_column,
+                              alignment_matrix_base_test,
+                              test_type);
+
+//-----------------------------------------------------------------------------
+// Test outer iterator
+//-----------------------------------------------------------------------------
+struct outer_iterator
+{};
+
+template <>
+struct iterator_fixture<outer_iterator> : alignment_matrix_base_test<test_type>
+{
+    using base_t = alignment_matrix_base_test<test_type>;
+
+    using iterator_tag = std::input_iterator_tag;
+    static constexpr bool const_iterable = false;
+
+    using base_t::test_range;
+    std::vector<int> expected_range{0, 0, 0, 0, 0};
+
+    template <typename lhs_t, typename rhs_t>
+    static void expect_eq(lhs_t lhs, rhs_t rhs)
+    {
+        EXPECT_EQ((*lhs.begin()).current, rhs);
+    }
+};
+
+INSTANTIATE_TYPED_TEST_CASE_P(score_matrix_outer_iterator,
+                              iterator_fixture,
+                              outer_iterator);
+
+//-----------------------------------------------------------------------------
+// Test inner iterator
+//-----------------------------------------------------------------------------
+struct inner_iterator
+{};
+
+template <>
+struct iterator_fixture<inner_iterator> : alignment_matrix_base_test<test_type>
+{
+    using base_t = alignment_matrix_base_test<test_type>;
+
+    using iterator_tag = std::forward_iterator_tag;
+    static constexpr bool const_iterable = false;
+
+    decltype(*base_t::test_range.begin()) test_range = *base_t::test_range.begin();
+    std::vector<int> expected_range{0, 0, 0, 0, 0};
+
+    template <typename lhs_t, typename rhs_t>
+    static void expect_eq(lhs_t lhs, rhs_t rhs)
+    {
+        EXPECT_EQ(lhs.current, rhs);
+    }
+};
+
+INSTANTIATE_TYPED_TEST_CASE_P(score_matrix_inner_iterator,
+                              iterator_fixture,
+                              inner_iterator);

--- a/test/unit/alignment/matrix/detail/alignment_score_matrix_one_column_test.cpp
+++ b/test/unit/alignment/matrix/detail/alignment_score_matrix_one_column_test.cpp
@@ -1,0 +1,41 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include <seqan3/alignment/matrix/detail/alignment_score_matrix_one_column.hpp>
+
+#include "alignment_score_matrix_test_template.hpp"
+
+using namespace seqan3;
+
+template <typename t>
+struct alignment_score_matrix_one_column_test
+{
+    using matrix_t = detail::alignment_score_matrix_one_column<t>;
+    using score_type = t;
+
+    alignment_score_matrix_one_column_test() = default;
+    alignment_score_matrix_one_column_test(std::string f, std::string s) : matrix{matrix_t{f, s, -100}}
+    {}
+
+    std::vector<t> gold_matrix{  0, -1, -2, -3, -4,
+                                -1, -1, -1, -2, -3,
+                                -2, -1, -2, -1, -2,
+                                -3, -2, -2, -2, -2,
+                                -4, -3, -2, -3, -2};
+
+    matrix_t matrix{};
+    size_t last_init_column = 4;
+};
+
+INSTANTIATE_TYPED_TEST_CASE_P(one_column,
+                              alignment_score_matrix_test,
+                              alignment_score_matrix_one_column_test<int32_t>);

--- a/test/unit/alignment/matrix/detail/alignment_score_matrix_test_template.hpp
+++ b/test/unit/alignment/matrix/detail/alignment_score_matrix_test_template.hpp
@@ -1,0 +1,177 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <seqan3/std/algorithm>
+
+template <typename t>
+struct alignment_score_matrix_test : public ::testing::Test
+{
+    using score_type = typename t::score_type;
+
+    score_type match = 0;
+    score_type mismatch = -1;
+    score_type gap = -1;
+
+    std::string first{"abba"};
+    std::string second{"baba"};
+
+    t test_data{first, second};
+
+    auto & matrix()
+    {
+        return test_data.matrix;
+    };
+
+    auto & gold_matrix()
+    {
+        return test_data.gold_matrix;
+    }
+
+    auto last_init_column()
+    {
+        return test_data.last_init_column;
+    }
+};
+
+TYPED_TEST_CASE_P(alignment_score_matrix_test);
+
+using namespace seqan3;
+using namespace seqan3::detail;
+
+TYPED_TEST_P(alignment_score_matrix_test, range_concepts)
+{
+    using matrix_type = std::remove_reference_t<decltype(this->matrix())>;
+
+    using outer_it = std::ranges::iterator_t<matrix_type>;
+    using column_t = value_type_t<outer_it>;
+    using inner_it = std::ranges::iterator_t<column_t>;
+
+    EXPECT_TRUE(std::ranges::InputRange<matrix_type>);
+    EXPECT_TRUE(std::InputIterator<outer_it>);
+    EXPECT_TRUE(std::InputIterator<inner_it>);
+    EXPECT_TRUE(std::ranges::InputRange<column_t>);
+    EXPECT_TRUE(std::ranges::View<column_t>);
+}
+
+TYPED_TEST_P(alignment_score_matrix_test, begin_end)
+{
+    auto it = this->matrix().begin();
+    auto col = *it;
+    auto col_it = col.begin();
+
+    EXPECT_NE(col_it, col.end());
+    EXPECT_NE(it, this->matrix().end());
+}
+
+TYPED_TEST_P(alignment_score_matrix_test, basic_construction)
+{
+    using matrix_type = std::remove_reference_t<decltype(this->matrix())>;
+
+    EXPECT_TRUE(std::is_default_constructible_v<matrix_type>);
+    EXPECT_TRUE(std::is_copy_constructible_v<matrix_type>);
+    EXPECT_TRUE(std::is_move_constructible_v<matrix_type>);
+    EXPECT_TRUE(std::is_copy_assignable_v<matrix_type>);
+    EXPECT_TRUE(std::is_move_assignable_v<matrix_type>);
+}
+
+TYPED_TEST_P(alignment_score_matrix_test, simulated_alignment)
+{
+    std::vector<typename TypeParam::score_type> cmp_matrix{};
+    cmp_matrix.resize(this->gold_matrix().size());
+    auto cmp_it = cmp_matrix.begin();
+
+    // ----------------------------------------------------------------------------
+    // Initialise the first column
+    // ----------------------------------------------------------------------------
+
+    auto mat_it = this->matrix().begin();
+    auto col = *mat_it;
+    auto col_it = col.begin();;
+    (*col_it).current = 0;
+    (*col_it).up = this->gap;
+    (*col_it).w_left = this->gap;
+    ++col_it;
+    size_t step = 0;
+
+    for (; col_it != col.end(); ++col_it, ++step)
+    {
+        (*col_it).current = (*col_it).up;
+        (*col_it).up += this->gap;
+        (*col_it).w_left = (*col_it).current + this->gap;
+    }
+
+    // dump the computed column.
+    cmp_it = std::ranges::transform(col, cmp_it, [] (auto proxy) { return proxy.current; }).out;
+
+    // ----------------------------------------------------------------------------
+    // Compute all columns where the first cell is at the top of the matrix
+    // ----------------------------------------------------------------------------
+
+    // The inner kernel as lambda to reduce duplicate code.
+    auto inner_kernel = [this] (auto col_it, auto const first_idx, auto const second_idx)
+    {
+        auto proxy = *col_it;
+        auto & [current, diagonal, r_left, w_left, up] = proxy;
+        current = ((this->first[first_idx] == this->second[second_idx]) ? this->match : this->mismatch) + diagonal;
+        current = std::max(current, std::max(r_left, up));
+        up = current + this->gap;
+        w_left = current + this->gap;
+    };
+
+    unsigned first_idx = 0;
+    // Go to next column.
+    ++mat_it;
+    size_t col_id = 0;
+    for (; col_id < this->last_init_column(); ++mat_it, ++first_idx, ++col_id)
+    {
+        unsigned second_idx = 0;
+        col = *mat_it;
+        auto col_it = col.begin();
+        (*col_it).current = (*col_it).r_left;
+        (*col_it).up = (*col_it).current + this->gap;
+        (*col_it).w_left = (*col_it).r_left + this->gap;
+        ++col_it;
+
+        for (; col_it != col.end(); ++col_it, ++second_idx)
+            inner_kernel(col_it, first_idx, second_idx);
+
+        // dump the computed column.
+        cmp_it = std::ranges::transform(col, cmp_it, [] (auto proxy) { return proxy.current; }).out;
+    }
+
+    // ----------------------------------------------------------------------------
+    // In banded case compute all columns starting in the middle of the matrix.
+    // ----------------------------------------------------------------------------
+
+    for (; col_id < this->first.size(); ++mat_it, ++first_idx, ++col_id)
+    {
+        unsigned second_idx = col_id - 2; // get correct index of second sequence.
+        col = *mat_it;
+        auto col_it = col.begin();
+        auto proxy = *col_it;
+        auto & [current, diagonal, r_left, w_left, up] = proxy;
+        current = ((this->first[first_idx] == this->second[second_idx]) ? this->match : this->mismatch) + diagonal;
+        current = std::max(current, r_left);
+        up = current + this->gap;
+        w_left = current + this->gap;
+        ++col_it;
+        ++second_idx;
+
+        for (; col_it != col.end(); ++col_it, ++second_idx)
+            inner_kernel(col_it, first_idx, second_idx);
+
+        // dump the computed column.
+        cmp_it = std::ranges::transform(col, cmp_it, [] (auto proxy) { return proxy.current; }).out;
+    }
+
+    EXPECT_TRUE(std::equal(cmp_matrix.begin(), cmp_matrix.end(), this->gold_matrix().begin()));
+}
+
+REGISTER_TYPED_TEST_CASE_P(alignment_score_matrix_test,
+                           range_concepts, begin_end, basic_construction, simulated_alignment);

--- a/test/unit/alignment/matrix/detail/alignment_trace_matrix_full_banded_test.cpp
+++ b/test/unit/alignment/matrix/detail/alignment_trace_matrix_full_banded_test.cpp
@@ -1,0 +1,112 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <type_traits>
+#include <utility>
+
+#include <seqan3/alignment/matrix/detail/alignment_trace_matrix_full_banded.hpp>
+#include <seqan3/alignment/matrix/trace_directions.hpp>
+
+#include "alignment_matrix_base_test_template.hpp"
+#include "../../../range/iterator_test_template.hpp"
+
+using namespace seqan3;
+
+using trace_matrix_t = std::pair<detail::alignment_trace_matrix_full_banded<trace_directions>, std::true_type>;
+using coo_matrix_t = std::pair<detail::alignment_trace_matrix_full_banded<trace_directions, true>, std::true_type>;
+
+using testing_types = ::testing::Types<trace_matrix_t, coo_matrix_t>;
+INSTANTIATE_TYPED_TEST_CASE_P(full_matrix_banded,
+                              alignment_matrix_base_test,
+                              testing_types);
+
+//-----------------------------------------------------------------------------
+// Test outer iterator
+//-----------------------------------------------------------------------------
+template <typename test_type>
+struct outer_iterator
+{};
+
+template <typename test_type>
+struct iterator_fixture<outer_iterator<test_type>> : alignment_matrix_base_test<test_type>
+{
+    static constexpr trace_directions N = trace_directions::none;
+
+    using base_t = alignment_matrix_base_test<test_type>;
+    using iterator_tag = std::input_iterator_tag;
+    static constexpr bool const_iterable = false;
+
+    using base_t::test_range;
+    std::vector<std::pair<std::pair<size_t, size_t>, trace_directions>> expected_range{{{2, 0}, N},
+                                                                                       {{1, 1}, N},
+                                                                                       {{0, 2}, N},
+                                                                                       {{0, 3}, N},
+                                                                                       {{0, 4}, N}};
+
+    template <typename lhs_t, typename rhs_t>
+    static void test(lhs_t lhs, rhs_t rhs)
+    {
+        auto [coo, trace] = lhs;
+        EXPECT_EQ(coo.second, std::get<0>(std::get<0>(rhs)));
+        EXPECT_EQ(coo.first, std::get<1>(std::get<0>(rhs)));
+
+        if constexpr (std::is_same_v<std::tuple_element_t<0, test_type>,
+                                     detail::alignment_trace_matrix_full_banded<trace_directions>>)
+        {
+            EXPECT_EQ(trace.current, std::get<1>(rhs));
+        }
+    }
+
+    template <typename lhs_t, typename rhs_t>
+    static void expect_eq(lhs_t lhs, rhs_t rhs)
+    {
+        test(*lhs.begin(), rhs);
+    }
+};
+
+using testing_types_outer = ::testing::Types<outer_iterator<trace_matrix_t>, outer_iterator<coo_matrix_t>>;
+
+INSTANTIATE_TYPED_TEST_CASE_P(banded_trace_matrix_outer_iterator,
+                              iterator_fixture,
+                              testing_types_outer);
+
+//-----------------------------------------------------------------------------
+// Test inner iterator
+//-----------------------------------------------------------------------------
+template <typename test_type>
+struct inner_iterator
+{};
+
+template <typename test_type>
+struct iterator_fixture<inner_iterator<test_type>> : iterator_fixture<outer_iterator<test_type>>
+{
+    static constexpr trace_directions N = trace_directions::none;
+
+    using base_t = iterator_fixture<outer_iterator<test_type>>;
+
+    using iterator_tag = std::forward_iterator_tag;
+    static constexpr bool const_iterable = false;
+
+    decltype(*base_t::test_range.begin()) test_range = *base_t::test_range.begin();
+    std::vector<std::pair<std::pair<size_t, size_t>, trace_directions>> expected_range{{{2, 0}, base_t::N},
+                                                                                       {{3, 0}, base_t::N},
+                                                                                       {{4, 0}, base_t::N}};
+
+    template <typename lhs_t, typename rhs_t>
+    static void expect_eq(lhs_t lhs, rhs_t rhs)
+    {
+        base_t::test(lhs, rhs);
+    }
+};
+
+using testing_types_inner = ::testing::Types<inner_iterator<trace_matrix_t>, inner_iterator<coo_matrix_t>>;
+
+INSTANTIATE_TYPED_TEST_CASE_P(banded_trace_matrix_inner_iterator,
+                              iterator_fixture,
+                              testing_types_inner);

--- a/test/unit/alignment/matrix/detail/alignment_trace_matrix_full_test.cpp
+++ b/test/unit/alignment/matrix/detail/alignment_trace_matrix_full_test.cpp
@@ -1,0 +1,113 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <type_traits>
+#include <utility>
+
+#include <seqan3/alignment/matrix/detail/alignment_trace_matrix_full.hpp>
+#include <seqan3/alignment/matrix/trace_directions.hpp>
+
+#include "alignment_matrix_base_test_template.hpp"
+#include "../../../range/iterator_test_template.hpp"
+
+using namespace seqan3;
+
+using trace_matrix_t = std::pair<detail::alignment_trace_matrix_full<trace_directions>, std::false_type>;
+using coo_matrix_t = std::pair<detail::alignment_trace_matrix_full<trace_directions, true>, std::false_type>;
+
+using testing_types = ::testing::Types<trace_matrix_t, coo_matrix_t>;
+
+INSTANTIATE_TYPED_TEST_CASE_P(full_matrix,
+                              alignment_matrix_base_test,
+                              testing_types);
+
+//-----------------------------------------------------------------------------
+// Test outer iterator
+//-----------------------------------------------------------------------------
+template <typename test_type>
+struct outer_iterator
+{};
+
+template <typename test_type>
+struct iterator_fixture<outer_iterator<test_type>> : alignment_matrix_base_test<test_type>
+{
+    static constexpr trace_directions N = trace_directions::none;
+
+    using base_t = alignment_matrix_base_test<test_type>;
+    using iterator_tag = std::input_iterator_tag;
+    static constexpr bool const_iterable = false;
+
+    using base_t::test_range;
+    std::vector<std::pair<std::pair<size_t, size_t>, trace_directions>> expected_range{{{0, 0}, N},
+                                                                                       {{0, 1}, N},
+                                                                                       {{0, 2}, N},
+                                                                                       {{0, 3}, N},
+                                                                                       {{0, 4}, N}};
+
+    template <typename lhs_t, typename rhs_t>
+    static void test(lhs_t lhs, rhs_t rhs)
+    {
+        auto [coo, trace] = lhs;
+        EXPECT_EQ(coo.second, std::get<0>(std::get<0>(rhs)));
+        EXPECT_EQ(coo.first, std::get<1>(std::get<0>(rhs)));
+
+        if constexpr (std::is_same_v<std::tuple_element_t<0, test_type>,
+                                     detail::alignment_trace_matrix_full<trace_directions>>)
+        {
+            EXPECT_EQ(trace.current, std::get<1>(rhs));
+        }
+    }
+
+    template <typename lhs_t, typename rhs_t>
+    static void expect_eq(lhs_t lhs, rhs_t rhs)
+    {
+        test(*lhs.begin(), rhs);
+    }
+};
+
+using testing_types_outer = ::testing::Types<outer_iterator<trace_matrix_t>, outer_iterator<coo_matrix_t>>;
+
+INSTANTIATE_TYPED_TEST_CASE_P(trace_matrix_outer_iterator,
+                              iterator_fixture,
+                              testing_types_outer);
+
+//-----------------------------------------------------------------------------
+// Test inner iterator
+//-----------------------------------------------------------------------------
+template <typename test_type>
+struct inner_iterator
+{};
+
+template <typename test_type>
+struct iterator_fixture<inner_iterator<test_type>> : iterator_fixture<outer_iterator<test_type>>
+{
+    using base_t = iterator_fixture<outer_iterator<test_type>>;
+
+    using iterator_tag = std::forward_iterator_tag;
+    static constexpr bool const_iterable = false;
+
+    decltype(*base_t::test_range.begin()) test_range = *base_t::test_range.begin();
+    std::vector<std::pair<std::pair<size_t, size_t>, trace_directions>> expected_range{{{0, 0}, base_t::N},
+                                                                                       {{1, 0}, base_t::N},
+                                                                                       {{2, 0}, base_t::N},
+                                                                                       {{3, 0}, base_t::N},
+                                                                                       {{4, 0}, base_t::N}};
+
+    template <typename lhs_t, typename rhs_t>
+    static void expect_eq(lhs_t lhs, rhs_t rhs)
+    {
+        base_t::test(lhs, rhs);
+    }
+};
+
+using testing_types_inner = ::testing::Types<inner_iterator<trace_matrix_t>, inner_iterator<coo_matrix_t>>;
+
+INSTANTIATE_TYPED_TEST_CASE_P(trace_matrix_inner_iterator,
+                              iterator_fixture,
+                              testing_types_inner);

--- a/test/unit/alignment/matrix/detail/simulated_alignment_test_template.hpp
+++ b/test/unit/alignment/matrix/detail/simulated_alignment_test_template.hpp
@@ -10,7 +10,7 @@
 #include <seqan3/std/algorithm>
 
 template <typename t>
-struct alignment_score_matrix_test : public ::testing::Test
+struct simulated_alignment_test : public ::testing::Test
 {
     using score_type = typename t::score_type;
 
@@ -39,48 +39,12 @@ struct alignment_score_matrix_test : public ::testing::Test
     }
 };
 
-TYPED_TEST_CASE_P(alignment_score_matrix_test);
+TYPED_TEST_CASE_P(simulated_alignment_test);
 
 using namespace seqan3;
 using namespace seqan3::detail;
 
-TYPED_TEST_P(alignment_score_matrix_test, range_concepts)
-{
-    using matrix_type = std::remove_reference_t<decltype(this->matrix())>;
-
-    using outer_it = std::ranges::iterator_t<matrix_type>;
-    using column_t = value_type_t<outer_it>;
-    using inner_it = std::ranges::iterator_t<column_t>;
-
-    EXPECT_TRUE(std::ranges::InputRange<matrix_type>);
-    EXPECT_TRUE(std::InputIterator<outer_it>);
-    EXPECT_TRUE(std::InputIterator<inner_it>);
-    EXPECT_TRUE(std::ranges::InputRange<column_t>);
-    EXPECT_TRUE(std::ranges::View<column_t>);
-}
-
-TYPED_TEST_P(alignment_score_matrix_test, begin_end)
-{
-    auto it = this->matrix().begin();
-    auto col = *it;
-    auto col_it = col.begin();
-
-    EXPECT_NE(col_it, col.end());
-    EXPECT_NE(it, this->matrix().end());
-}
-
-TYPED_TEST_P(alignment_score_matrix_test, basic_construction)
-{
-    using matrix_type = std::remove_reference_t<decltype(this->matrix())>;
-
-    EXPECT_TRUE(std::is_default_constructible_v<matrix_type>);
-    EXPECT_TRUE(std::is_copy_constructible_v<matrix_type>);
-    EXPECT_TRUE(std::is_move_constructible_v<matrix_type>);
-    EXPECT_TRUE(std::is_copy_assignable_v<matrix_type>);
-    EXPECT_TRUE(std::is_move_assignable_v<matrix_type>);
-}
-
-TYPED_TEST_P(alignment_score_matrix_test, simulated_alignment)
+TYPED_TEST_P(simulated_alignment_test, linear_alignment)
 {
     std::vector<typename TypeParam::score_type> cmp_matrix{};
     cmp_matrix.resize(this->gold_matrix().size());
@@ -173,5 +137,4 @@ TYPED_TEST_P(alignment_score_matrix_test, simulated_alignment)
     EXPECT_TRUE(std::equal(cmp_matrix.begin(), cmp_matrix.end(), this->gold_matrix().begin()));
 }
 
-REGISTER_TYPED_TEST_CASE_P(alignment_score_matrix_test,
-                           range_concepts, begin_end, basic_construction, simulated_alignment);
+REGISTER_TYPED_TEST_CASE_P(simulated_alignment_test, linear_alignment);


### PR DESCRIPTION
Adds alignment matrices that give a unified access to the cells required by the standard alignment algorithm. I only had some testing of the basic functionality. The tests will follow soon.

Fixes #1104

### Todo 
- [x] tests

### Note

I will not update the alignment policies yet. I need first the traceback iterator interface. When this works, then I can adapt and reduce the policies. 