### PR TITLE
[FIX] inserting and deleting gaps in an empty unaligned sequence does…

### DIFF
--- a/include/seqan3/range/decorator/gap_decorator.hpp
+++ b/include/seqan3/range/decorator/gap_decorator.hpp
@@ -423,8 +423,6 @@ public:
      */
     iterator insert_gap(iterator const it, size_type const count = 1)
     {
-        assert(ungapped_view.size());
-
         if (!count) // [[unlikely]]
             return it;
 
@@ -476,8 +474,6 @@ public:
     */
     iterator erase_gap(iterator const it)
     {
-        assert(ungapped_view.size());
-
         // check if [it, it+gap_len[ covers [first, last[
         if ((*it) != gap{}) // [[unlikely]]
             throw gap_erase_failure("The range to be erased does not correspond to a consecutive gap.");
@@ -501,8 +497,6 @@ public:
      */
     iterator erase_gap(iterator const first, iterator const last)
     {
-        assert(ungapped_view.size());
-
         size_type const pos1 = std::distance(begin(), first);
         size_type const pos2 = std::distance(begin(), last);
         set_iterator_type it = anchors.upper_bound(anchor_gap_t{pos1, bound_dummy}); // first element greater than pos1
@@ -545,7 +539,7 @@ public:
      */
     template <typename unaligned_seq_t> // generic template to use forwarding reference
     //!\cond
-        requires std::Constructible<gap_decorator, unaligned_seq_t>
+        requires std::Assignable<gap_decorator &, unaligned_seq_t>
     //!\endcond
     friend void assign_unaligned(gap_decorator & dec, unaligned_seq_t && unaligned)
     {

--- a/test/unit/range/decorator/gap_decorator_test.cpp
+++ b/test/unit/range/decorator/gap_decorator_test.cpp
@@ -25,7 +25,7 @@ using namespace seqan3;
 
 using decorator_t = gap_decorator<std::vector<dna4> const &>;
 
-const std::vector<dna4> dummy_obj{}; // dummy lvalue for type declaration of views
+std::vector<dna4> const dummy_obj{}; // dummy lvalue for type declaration of views
 using decorator_t2 = gap_decorator<
                          decltype(std::ranges::subrange<decltype(dummy_obj.begin()),
                                                  decltype(dummy_obj.begin())>{dummy_obj.begin(), dummy_obj.end()})>;


### PR DESCRIPTION
… not assert anymore.

This PR allows to insert and erase gap in debug mode. It turned out that those operations are gracefully handled by the gap_decorator and that I only needed to remove the unnecessary / misleading asserts.

Because I first wrote the test cases, I also cleaned up some of the tests in `aligned_sequence_test_template.hpp`