### PR TITLE
[FIX] 3 minor changes in alignment IO

### DIFF
--- a/include/seqan3/alphabet/detail/convert.hpp
+++ b/include/seqan3/alphabet/detail/convert.hpp
@@ -39,7 +39,8 @@ constexpr std::array<out_t, alphabet_size<in_t>> convert_through_char_representa
     [] () constexpr
     {
         std::array<out_t, alphabet_size<in_t>> ret{};
-        for (typename in_t::rank_type i = 0; i < alphabet_size<in_t>; ++i)
+        // for (decltype(alphabet_size<in_t>) i = 0; ...) causes indefinite compilation :(
+        for (auto i = decltype(alphabet_size<in_t>){0}; i < alphabet_size<in_t>; ++i)
             assign_char_to(to_char(assign_rank_to(i, in_t{})), ret[i]);
         return ret;
     }()

--- a/include/seqan3/io/alignment_file/format_bam.hpp
+++ b/include/seqan3/io/alignment_file/format_bam.hpp
@@ -836,7 +836,7 @@ public:
                 /* block_size  */ 0,  // will be initialised right after
                 /* refID       */ -1, // will be initialised right after
                 /* pos         */ ref_offset.value_or(-1),
-                /* l_read_name */ std::max<uint8_t>(std::ranges::distance(id) + 1, 2) /* empty id is repr. by '*\0' */,
+                /* l_read_name */ std::max<uint8_t>(std::min<size_t>(std::ranges::distance(id) + 1, 255), 2),
                 /* mapq        */ mapq,
                 /* bin         */ reg2bin(ref_offset.value_or(-1), std::ranges::distance(get<1>(align))),
                 /* n_cigar_op  */ static_cast<uint16_t>(cigar.size()),
@@ -918,7 +918,7 @@ public:
             if (std::ranges::distance(id) == 0) // empty id is represented as * for backward compatibility
                 stream_it = '*';
             else
-                std::ranges::copy_n(std::ranges::begin(id), std::ranges::distance(id), stream_it); // write read id
+                std::ranges::copy_n(std::ranges::begin(id), core.l_read_name - 1, stream_it); // write read id
             stream_it = '\0';
 
             // write cigar

--- a/include/seqan3/io/alignment_file/format_bam.hpp
+++ b/include/seqan3/io/alignment_file/format_bam.hpp
@@ -836,7 +836,7 @@ public:
                 /* block_size  */ 0,  // will be initialised right after
                 /* refID       */ -1, // will be initialised right after
                 /* pos         */ ref_offset.value_or(-1),
-                /* l_read_name */ static_cast<uint8_t>(std::ranges::distance(id) + 1),
+                /* l_read_name */ std::max<uint8_t>(std::ranges::distance(id) + 1, 2) /* empty id is repr. by '*\0' */,
                 /* mapq        */ mapq,
                 /* bin         */ reg2bin(ref_offset.value_or(-1), std::ranges::distance(get<1>(align))),
                 /* n_cigar_op  */ static_cast<uint16_t>(cigar.size()),
@@ -915,7 +915,10 @@ public:
 
             std::ranges::copy_n(reinterpret_cast<char *>(&core), sizeof(core), stream_it);  // write core
 
-            std::ranges::copy_n(std::ranges::begin(id), std::ranges::distance(id), stream_it); // write read id
+            if (std::ranges::distance(id) == 0) // empty id is represented as * for backward compatibility
+                stream_it = '*';
+            else
+                std::ranges::copy_n(std::ranges::begin(id), std::ranges::distance(id), stream_it); // write read id
             stream_it = '\0';
 
             // write cigar

--- a/include/seqan3/io/alignment_file/format_sam.hpp
+++ b/include/seqan3/io/alignment_file/format_sam.hpp
@@ -988,7 +988,9 @@ public:
               typename align_type,
               typename qual_type,
               typename mate_type,
-              typename tag_dict_type>
+              typename tag_dict_type,
+              typename e_value_type,
+              typename bit_score_type>
     void write(stream_type                            &  stream,
                alignment_file_output_options const    &  options,
                header_type                            && header,
@@ -1004,8 +1006,8 @@ public:
                uint8_t                                   mapq,
                mate_type                              && mate,
                tag_dict_type                          && tag_dict,
-               double                                    SEQAN3_DOXYGEN_ONLY(e_value),
-               double                                    SEQAN3_DOXYGEN_ONLY(bit_score))
+               e_value_type                           && SEQAN3_DOXYGEN_ONLY(e_value),
+               bit_score_type                         && SEQAN3_DOXYGEN_ONLY(bit_score))
     {
         /* Note the following general things:
          *
@@ -1032,11 +1034,6 @@ public:
                       Alphabet<reference_t<id_type>>),
                       "The id object must be a std::ranges::ForwardRange over "
                       "letters that model seqan3::Alphabet.");
-
-        static_assert((std::ranges::ForwardRange<ref_seq_type>    &&
-                      Alphabet<reference_t<ref_seq_type>>),
-                      "The ref_seq object must be a std::ranges::ForwardRange "
-                      "over letters that model seqan3::Alphabet.");
 
         if constexpr (!detail::decays_to_ignore_v<ref_id_type>)
         {

--- a/include/seqan3/io/alignment_file/header.hpp
+++ b/include/seqan3/io/alignment_file/header.hpp
@@ -16,8 +16,11 @@
 #include <unordered_map>
 #include <vector>
 
+#include <seqan3/alphabet/concept.hpp>
+#include <seqan3/alphabet/detail/hash.hpp>
 #include <seqan3/core/type_traits/pre.hpp>
 #include <seqan3/io/alignment_file/detail.hpp>
+#include <seqan3/range/view/view_all.hpp>
 #include <seqan3/std/ranges>
 
 namespace seqan3
@@ -88,7 +91,9 @@ private:
     //!\brief Stream deleter with default behaviour (ownership assumed).
     static void ref_ids_deleter_default(ref_ids_type * ptr) { delete ptr; }
     //!\brief The key's type of ref_dict.
-    using key_type = std::ranges::all_view<reference_t<ref_ids_type>>;
+    using key_type = std::conditional_t<std::ranges::ContiguousRange<reference_t<ref_ids_type>>,
+                        std::span<innermost_value_type_t<ref_ids_type> const>,
+                        all_view<reference_t<ref_ids_type>>>;
     //!\brief The pointer to reference ids information (non-owning if reference information is given).
     ref_ids_ptr_t ref_ids_ptr{new ref_ids_type{}, ref_ids_deleter_default};
 

--- a/include/seqan3/io/alignment_file/input.hpp
+++ b/include/seqan3/io/alignment_file/input.hpp
@@ -78,11 +78,8 @@ namespace seqan3
  * \brief Type template of the seqan3::field::SEQ, a container template over `sequence_alphabet`;
  * must model seqan3::SequenceContainer.
  */
-/*!\typedef using id_alphabet
- * \brief Alphabet of the characters for the seqan3::field::ID; must model seqan3::Alphabet.
- */
 /*!\typedef using id_container
- * \brief Type template of the seqan3::field::ID, a container template over `id_alphabet`;
+ * \brief Type template of the seqan3::field::ID, a container template over `char`;
  * must model seqan3::SequenceContainer.
  */
 /*!\typedef using quality_alphabet
@@ -122,8 +119,7 @@ SEQAN3_CONCEPT AlignmentFileInputTraits = requires (t v)
     requires SequenceContainer<typename t::template sequence_container<typename t::sequence_alphabet>>;
 
     // field::ID
-    requires WritableAlphabet<typename t::id_alphabet>;
-    requires SequenceContainer<typename t::template id_container<typename t::id_alphabet>>;
+    requires SequenceContainer<typename t::template id_container<char>>;
 
     // field::QUAL
     requires WritableQualityAlphabet<typename t::quality_alphabet>;
@@ -199,9 +195,6 @@ struct alignment_file_input_default_traits
     //!\brief The container for a sequence is std::vector.
     template <typename _sequence_alphabet>
     using sequence_container                    = std::vector<_sequence_alphabet>;
-
-    //!\brief The alphabet for an identifier string is char.
-    using id_alphabet                           = char;
 
     //!\brief The string type for an identifier is std::basic_string.
     template <typename _id_alphabet>
@@ -417,8 +410,7 @@ public:
     using sequence_type            = typename traits_type::template sequence_container<
                                          typename traits_type::sequence_alphabet>;
     //!\brief The type of field::ID (default std::string by default).
-    using id_type                  = typename traits_type::template id_container<
-                                         typename traits_type::id_alphabet>;
+    using id_type                  = typename traits_type::template id_container<char>;
     //!\brief The type of field::OFFSET is fixed to int32_t.
     using offset_type              = int32_t;
     /*!\brief The type of field::REF_SEQ (default depends on construction).

--- a/test/unit/io/alignment_file/alignment_file_format_test_template.hpp
+++ b/test/unit/io/alignment_file/alignment_file_format_test_template.hpp
@@ -461,6 +461,29 @@ TYPED_TEST_P(alignment_file_write, output_concept)
     EXPECT_TRUE((AlignmentFileOutputFormat<TypeParam>));
 }
 
+TYPED_TEST_P(alignment_file_write, write_empty_members)
+{
+    detail::alignment_file_output_format<TypeParam> format;
+
+    std::ostringstream ostream;
+    {
+        alignment_file_header header{std::vector<std::string>{this->ref_id}};
+        header.ref_id_info.push_back({this->ref_seq.size(), ""});
+        header.ref_dict[this->ref_id] = 0;
+
+        using default_align_t = std::pair<std::span<gapped<char>>, std::span<gapped<char>>>;
+        using default_mate_t  = std::tuple<std::string_view, std::optional<int32_t>, int32_t>;
+
+        ASSERT_NO_THROW(format.write(ostream, output_options, header, std::string_view{}, std::string_view{},
+                                     std::string_view{}, 0, std::string_view{}, std::string_view{},
+                                     std::optional<int32_t>{std::nullopt}, default_align_t{}, 0, 0,
+                                     default_mate_t{}, sam_tag_dictionary{}, 0, 0));
+    }
+
+    ostream.flush();
+    EXPECT_EQ(ostream.str(), this->empty_input);
+}
+
 TYPED_TEST_P(alignment_file_write, default_options_all_members_specified)
 {
     detail::alignment_file_output_format<TypeParam> format;
@@ -636,6 +659,7 @@ REGISTER_TYPED_TEST_CASE_P(alignment_file_read,
                            format_error_ref_id_not_in_reference_information);
 
 REGISTER_TYPED_TEST_CASE_P(alignment_file_write,
+                           write_empty_members,
                            output_concept,
                            default_options_all_members_specified,
                            write_ref_id_with_different_types,

--- a/test/unit/io/alignment_file/format_bam_test.cpp
+++ b/test/unit/io/alignment_file/format_bam_test.cpp
@@ -146,7 +146,7 @@ struct alignment_file_read<format_bam> : public alignment_file_data
         '\x00', '\x04', '\x00', '\x00', '\x00', '\x72', '\x65', '\x66', '\x00', '\x22', '\x00', '\x00', '\x00',
         '\x22', '\x00', '\x00', '\x00', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\x02',
         '\x00', '\x48', '\x12', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\xFF', '\xFF',
-        '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\x00', '\x00', '\x00', '\x00', '\x2A', '\x00', '\x0A'
+        '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\x00', '\x00', '\x00', '\x00', '\x2A', '\x00'
     };
 
     std::string empty_cigar{

--- a/test/unit/io/alignment_file/format_sam_test.cpp
+++ b/test/unit/io/alignment_file/format_sam_test.cpp
@@ -54,7 +54,7 @@ read3	43	ref	3	63	1S1M1D1M1I1M1I1D1M1S	=	10	300	GGAGTATA	!!*+,-./
                                                                              "\tbf:B:f,3.5,0.1,43.8\n"
         "read3\t43\tref\t3\t63\t1S1M1D1M1I1M1I1D1M1S\tref\t10\t300\tGGAGTATA\t!!*+,-./\n"};
 
-    std::string empty_input{"*\t0\t*\t0\t0\t*\t*\t0\t0\t*\t*\n"};
+    std::string empty_input{"@HD\tVN:1.6\n@SQ\tSN:ref\tLN:34\n*\t0\t*\t0\t0\t*\t*\t0\t0\t*\t*\n"};
 
     std::string empty_cigar{"read1\t41\tref\t1\t61\t*\tref\t10\t300\tACGT\t!##$\n"};
 


### PR DESCRIPTION
1. BAM needs to write `*\0` for empty read ids (not `\0` like right now, which did not impede our files since they are equivalent but for samtools those are not equivalent)

2. SAM should not have requirements on types it does not use. (This way you could also pass std::ignore to the file)

3. The read id alphabet should not be modifiable by the traits object since there is no use case other than `char` (container is modifiable) and char is required by BAM. (Is this an API break?)