### PR TITLE
[FIX] Pressing return should default the version check.

### DIFF
--- a/include/seqan3/argument_parser/detail/version_check.hpp
+++ b/include/seqan3/argument_parser/detail/version_check.hpp
@@ -339,10 +339,11 @@ public:
 #######################################################################
 
 )";
-            char chr{};
-            std::cin >> chr;
+            std::string line{};
+            std::getline(std::cin, line);
+            line.resize(1); // ignore everything but the first char or resizes the empty string to the default
 
-            switch (chr)
+            switch (line[0])
             {
                 case 'y':
                 {


### PR DESCRIPTION
Resolve #1108 