### PR TITLE
[FIX] take_view should be Sized if underlying range is Sized

### DIFF
--- a/include/seqan3/range/view/take.hpp
+++ b/include/seqan3/range/view/take.hpp
@@ -61,9 +61,6 @@ private:
     //!\brief The desired target_size.
     size_t target_size;
 
-    //!\brief The sentinel type is identical to that of the underlying range.
-    using sentinel_type = std::ranges::sentinel_t<urng_t>;
-
     //!\brief The iterator type inherits from the underlying type, but overwrites several operators.
     //!\tparam rng_t Should be `urng_t` for defining #iterator and `urng_t const` for defining #const_iterator.
     template <typename rng_t>
@@ -74,6 +71,9 @@ private:
         using base_base_t = std::ranges::iterator_t<rng_t>;
         //!\brief The CRTP wrapper type.
         using base_t      = inherited_iterator_base<iterator_type, std::ranges::iterator_t<rng_t>>;
+
+        //!\brief The sentinel type is identical to that of the underlying range.
+        using sentinel_type = std::ranges::sentinel_t<urng_t>;
 
         //!\brief The current position.
         size_t pos{};
@@ -213,7 +213,7 @@ private:
 
         //!\copydoc operator==()
         constexpr bool operator==(sentinel_type const & rhs) const
-            noexcept(!or_throw && noexcept(std::declval<base_base_t &>() == std::declval<sentinel_type &>()))
+            noexcept(!or_throw && noexcept(std::declval<base_base_t const &>() == std::declval<sentinel_type const &>()))
         {
             if (pos >= max_pos)
                 return true;
@@ -292,7 +292,7 @@ public:
     //!\brief The value_type (which equals the reference_type with any references removed).
     using value_type        = value_type_t<urng_t>;
     //!\brief The size_type is `size_t` if the view is exact, otherwise `void`.
-    using size_type         = std::conditional_t<exactly,
+    using size_type         = std::conditional_t<exactly || std::ranges::SizedRange<urng_t>,
                                                  transformation_trait_or_t<seqan3::size_type<urng_t>, size_t>,
                                                  void>;
     //!\brief A signed integer type, usually std::ptrdiff_t.
@@ -394,28 +394,31 @@ public:
      *
      * No-throw guarantee.
      */
-    constexpr sentinel_type end() noexcept
+    constexpr auto end() noexcept
     {
-        return {seqan3::end(urange)};
+        return seqan3::end(urange);
     }
 
     //!\copydoc end()
-    constexpr sentinel_type end() const noexcept
+    constexpr auto end() const noexcept
         requires ConstIterableRange<urng_t>
     {
-        return {seqan3::cend(urange)};
+        return seqan3::cend(urange);
     }
 
     //!\copydoc end()
-    constexpr sentinel_type cend() const noexcept
+    constexpr auto cend() const noexcept
         requires ConstIterableRange<urng_t>
     {
-        return {seqan3::cend(urange)};
+        return seqan3::cend(urange);
     }
     //!\}
 
-    /*!\brief Returns the number of elements in the view (only available for "exactly" specialisation!).
+    /*!\brief Returns the number of elements in the view.
      * \returns The number of elements in the view.
+     *
+     * This overload is only available if the underlying range models std::ranges::SizedRange or for
+     * specialisation that have the `exactly` template parameter set.
      *
      * ### Complexity
      *
@@ -429,6 +432,20 @@ public:
         requires exactly
     {
         return target_size;
+    }
+
+    //!\overload
+    constexpr size_type size() noexcept
+        requires (!exactly) && std::ranges::SizedRange<urng_t>
+    {
+        return std::min<size_type>(target_size, std::ranges::size(urange));
+    }
+
+    //!\overload
+    constexpr size_type size() const noexcept
+        requires (!exactly) && std::ranges::SizedRange<urng_t const>
+    {
+        return std::min<size_type>(target_size, std::ranges::size(urange));
     }
 };
 

--- a/test/unit/range/view/view_take_test.cpp
+++ b/test/unit/range/view/view_take_test.cpp
@@ -82,6 +82,18 @@ void do_concepts(adaptor_t && adaptor, bool const exactly)
     EXPECT_TRUE(ConstIterableRange<decltype(v1)>);
     EXPECT_TRUE((std::ranges::OutputRange<decltype(v1), int>));
 
+    auto v3 = vec | std::view::transform([] (auto && v) { return v; }) | adaptor;
+
+    EXPECT_TRUE(std::ranges::InputRange<decltype(v3)>);
+    EXPECT_TRUE(std::ranges::ForwardRange<decltype(v3)>);
+    EXPECT_TRUE(std::ranges::BidirectionalRange<decltype(v3)>);
+    EXPECT_TRUE(std::ranges::RandomAccessRange<decltype(v3)>);
+    EXPECT_TRUE(std::ranges::View<decltype(v3)>);
+    EXPECT_TRUE(std::ranges::SizedRange<decltype(v3)>);
+    EXPECT_FALSE(std::ranges::CommonRange<decltype(v3)>);
+    EXPECT_FALSE(ConstIterableRange<decltype(v3)>);
+    EXPECT_FALSE((std::ranges::OutputRange<decltype(v3), int>));
+
     auto v2 = vec | view::single_pass_input | adaptor;
 
     EXPECT_TRUE(std::ranges::InputRange<decltype(v2)>);


### PR DESCRIPTION
Tests for this bug(-fix) will come with @smehringer 's generic iterator tests or we will decide to remove const-iterability for view altogether.