### PR TITLE
[FIX] include all constraints in CPO definitions

### DIFF
--- a/include/seqan3/alphabet/nucleotide/concept.hpp
+++ b/include/seqan3/alphabet/nucleotide/concept.hpp
@@ -48,15 +48,15 @@ public:
     //!\brief Operator definition.
     template <typename nucleotide_t>
     //!\cond
-        requires requires (nucleotide_t const nucl) { { impl(priority_tag<2>{}, nucl) }; }
+        requires requires (nucleotide_t const nucl)
+        {
+            { impl(priority_tag<2>{}, nucl) };
+            requires noexcept(impl(priority_tag<2>{}, nucl));
+            requires std::Same<nucleotide_t, decltype(impl(priority_tag<2>{}, nucl))>;
+        }
     //!\endcond
-    constexpr auto operator()(nucleotide_t const nucl) const noexcept
+    constexpr nucleotide_t operator()(nucleotide_t const nucl) const noexcept
     {
-        static_assert(noexcept(impl(priority_tag<2>{}, nucl)),
-            "Only overloads that are marked noexcept are picked up by seqan3::complement().");
-        static_assert(std::Same<nucleotide_t, decltype(impl(priority_tag<2>{}, nucl))>,
-            "The return type of your complement() implementation must be 'nucleotide_t'.");
-
         return impl(priority_tag<2>{}, nucl);
     }
 };
@@ -82,13 +82,11 @@ namespace seqan3
  * It acts as a wrapper and looks for three possible implementations (in this order):
  *
  *   1. A free function `complement(your_type const a)` in the namespace of your type (or as `friend`).
- *      The function must be marked `noexcept` (`constexpr` is not required, but recommended) and the
- *      return type be `your_type`.
  *   2. A free function `complement(your_type const a)` in `namespace seqan3::custom`.
- *      The same restrictions apply as above.
  *   3. A member function called `complement()`.
- *      It must be marked `noexcept` (`constexpr` is not required, but recommended) and the return type be
- *      `your_type`.
+ *
+ * Functions are only considered for one of the above cases if they are marked `noexcept` (`constexpr` is not required,
+ * but recommended) and if the returned type is `your_type`.
  *
  * Every nucleotide alphabet type must provide one of the above.
  *


### PR DESCRIPTION
For usability reasons I chose to implement some contraints in the CPO definitions as static_asserts. This has turned out to be a mistake, because it means that checking `seqan3::Alphabet` will result in a hard error if one of the constraints are satisfied, but the static_assert fails.

I have also simplified some of the documentation.

@joergi-w Once this is merged, could you perform similar changes for quality and structure?