### PR TITLE
Restructure stream handles from files to formats.

### DIFF
--- a/include/seqan3/io/alignment_file/input_format_concept.hpp
+++ b/include/seqan3/io/alignment_file/input_format_concept.hpp
@@ -12,7 +12,6 @@
 
 #pragma once
 
-#include <fstream>
 #include <string>
 #include <vector>
 
@@ -30,7 +29,7 @@ namespace seqan3::detail
 {
 
 //!\brief The alignment file input format base class.
-template <typename t>
+template <typename format_t, typename stream_char_t = char>
 class alignment_file_input_format
 {};
 
@@ -53,7 +52,6 @@ namespace seqan3
 template <typename t>
 SEQAN3_CONCEPT AlignmentFileInputFormat =
     requires (detail::alignment_file_input_format<t>                              & v,
-              std::ifstream                                                       & stream,
               alignment_file_input_options<dna5>                                  & options,
               std::vector<dna5_vector>                                            & ref_sequences,
               alignment_file_header<>                                             & header,
@@ -75,8 +73,7 @@ SEQAN3_CONCEPT AlignmentFileInputFormat =
     t::file_extensions;
     // std::Same<decltype(t::file_extensions), std::vector<std::string>>;
 
-    { v.read(stream,
-             options,
+    { v.read(options,
              ref_sequences,
              header,
              seq,
@@ -94,8 +91,7 @@ SEQAN3_CONCEPT AlignmentFileInputFormat =
              e_value,
              bit_score)};
 
-    { v.read(stream,
-             options,
+    { v.read(options,
              std::ignore,
              header,
              std::ignore,
@@ -121,14 +117,13 @@ SEQAN3_CONCEPT AlignmentFileInputFormat =
  * \{
  */
 
-/*!\fn void read(stream_type & stream, alignment_file_input_options<seq_legal_alph_type> const & options,
+/*!\fn void read(alignment_file_input_options<seq_legal_alph_type> const & options,
  *               ref_seqs_type & ref_seqs, header_type & header,
  *               seq_type & seq, qual_type & qual, id_type & id, offset_type & offset, ref_seq_type & ref_seq,
  *               ref_id_type & ref_id, ref_offset_type & ref_offset, align_type & align, flag_type & flag,
  *               mapq_type & mapq, mate_type & mate, tag_dict_type & tag_dict, e_value_type & e_value,
  *               bit_score_type & bit_score)
  * \brief Read from the specified stream and back-insert into the given field buffers.
- * \tparam stream_type        The input stream type; Must be derived from std::ostream.
  * \tparam ref_seqs_type      e.g. std::deque<ref_sequence_type> or decltype(std::ignore).
  * \tparam seq_type           Type of the seqan3::field::SEQ input (see seqan3::AlignmentFileInputTraits).
  * \tparam qual_type          Type of the seqan3::field::QUAL input (see seqan3::AlignmentFileInputTraits).
@@ -145,7 +140,6 @@ SEQAN3_CONCEPT AlignmentFileInputFormat =
  * \tparam e_value_type       Type of the seqan3::field::EVALUE input (see seqan3::AlignmentFileInputTraits).
  * \tparam bit_score_type     Type of the seqan3::field::BIT_SCORE input (see seqan3::AlignmentFileInputTraits).
  *
- * \param[in,out] stream      The input stream to read from.
  * \param[in]     options     File specific options passed to the format.
  * \param[out]    ref_seqs    The reference sequences to the corresponding alignments.
  * \param[out]    header      A pointer to the seqan3::alignment_file_header object.
@@ -169,7 +163,7 @@ SEQAN3_CONCEPT AlignmentFileInputFormat =
  * ### Additional requirements
  *
  *   * The function must also accept std::ignore as parameter for any of the fields,
- *     except stream, options and header. [This is enforced by the concept checker!]
+ *     except options and header. [This is enforced by the concept checker!]
  *   * In this case the data read for that field shall be discarded by the format.
  */
  /*!\var static inline std::vector<std::string> seqan3::AlignmentFileInputFormat::file_extensions

--- a/include/seqan3/io/alignment_file/output.hpp
+++ b/include/seqan3/io/alignment_file/output.hpp
@@ -294,7 +294,8 @@ public:
      */
     alignment_file_output(std::filesystem::path filename,
                           selected_field_ids const & SEQAN3_DOXYGEN_ONLY(fields_tag) = selected_field_ids{}) :
-        primary_stream{new std::ofstream{filename, std::ios_base::out | std::ios::binary}, stream_deleter_default}
+        primary_stream{new std::ofstream{filename, std::ios_base::out | std::ios::binary},
+                       detail::ostream_deleter_default<stream_char_type>}
     {
         // open stream
         if (!primary_stream->good())
@@ -304,7 +305,7 @@ public:
         secondary_stream = detail::make_secondary_ostream(*primary_stream, filename);
 
         // initialise format handler or throw if format is not found
-        detail::set_format(format, filename);
+        detail::set_format(format, *secondary_stream, filename);
     }
 
     /*!\brief Construct from an existing stream and with specified format.
@@ -327,9 +328,9 @@ public:
     alignment_file_output(stream_type              & stream,
                           file_format        const & SEQAN3_DOXYGEN_ONLY(format_tag),
                           selected_field_ids const & SEQAN3_DOXYGEN_ONLY(fields_tag) = selected_field_ids{}) :
-        primary_stream{&stream, stream_deleter_noop},
-        secondary_stream{&stream, stream_deleter_noop},
-        format{detail::alignment_file_output_format<file_format>{}}
+        primary_stream{&stream, detail::ostream_deleter_noop<stream_char_type>},
+        secondary_stream{&stream, detail::ostream_deleter_noop<stream_char_type>},
+        format{detail::alignment_file_output_format<file_format, stream_char_type>{*secondary_stream}}
     {
         static_assert(meta::in<valid_formats, file_format>::value,
                       "You selected a format that is not in the valid_formats of this file.");
@@ -340,9 +341,9 @@ public:
     alignment_file_output(stream_type             && stream,
                           file_format        const & SEQAN3_DOXYGEN_ONLY(format_tag),
                           selected_field_ids const & SEQAN3_DOXYGEN_ONLY(fields_tag) = selected_field_ids{}) :
-        primary_stream{new stream_type{std::move(stream)}, stream_deleter_default},
-        secondary_stream{&*primary_stream, stream_deleter_noop},
-        format{detail::alignment_file_output_format<file_format>{}}
+        primary_stream{new stream_type{std::move(stream)}, detail::ostream_deleter_default<stream_char_type>},
+        secondary_stream{&*primary_stream, detail::ostream_deleter_noop<stream_char_type>},
+        format{detail::alignment_file_output_format<file_format, stream_char_type>{*secondary_stream}}
     {
         static_assert(meta::in<valid_formats, file_format>::value,
                       "You selected a format that is not in the valid_formats of this file.");
@@ -717,21 +718,15 @@ protected:
     /*!\name Stream / file access
      * \{
      */
-    //!\brief The type of the internal stream pointers. Allows dynamically setting ownership management.
-    using stream_ptr_t = std::unique_ptr<std::basic_ostream<stream_char_type>,
-                                         std::function<void(std::basic_ostream<stream_char_type>*)>>;
-    //!\brief Stream deleter that does nothing (no ownership assumed).
-    static void stream_deleter_noop(std::basic_ostream<stream_char_type> *) {}
-    //!\brief Stream deleter with default behaviour (ownership assumed).
-    static void stream_deleter_default(std::basic_ostream<stream_char_type> * ptr) { delete ptr; }
-
     //!\brief The primary stream is the user provided stream or the file stream if constructed from filename.
-    stream_ptr_t primary_stream{nullptr, stream_deleter_noop};
+    detail::ostream_ptr_type<stream_char_type> primary_stream{nullptr, detail::ostream_deleter_noop<stream_char_type>};
     //!\brief The secondary stream is a compression layer on the primary or just points to the primary (no compression).
-    stream_ptr_t secondary_stream{nullptr, stream_deleter_noop};
+    detail::ostream_ptr_type<stream_char_type> secondary_stream{nullptr, detail::ostream_deleter_noop<stream_char_type>};
 
     //!\brief Type of the format, an std::variant over the `valid_formats`.
-    using format_type = typename detail::variant_from_tags<valid_formats, detail::alignment_file_output_format>::type;
+    using format_type = typename detail::variant_from_tags<valid_formats,
+                                                           detail::alignment_file_output_format,
+                                                           stream_char_type>::type;
 
     //!\brief The actual std::variant holding a pointer to the detected/selected format.
     format_type format;
@@ -783,11 +778,11 @@ protected:
         {
             // use header from record if explicitly given, e.g. file_output = file_input
             if constexpr (!std::Same<record_header_ptr_t, std::nullptr_t>)
-                f.write(*secondary_stream, options, *record_header_ptr, std::forward<pack_type>(remainder)...);
+                f.write(options, *record_header_ptr, std::forward<pack_type>(remainder)...);
             else if constexpr (std::Same<ref_ids_type, ref_info_not_given>)
-                f.write(*secondary_stream, options, std::ignore, std::forward<pack_type>(remainder)...);
+                f.write(options, std::ignore, std::forward<pack_type>(remainder)...);
             else
-                f.write(*secondary_stream, options, *header_ptr, std::forward<pack_type>(remainder)...);
+                f.write(options, *header_ptr, std::forward<pack_type>(remainder)...);
         }, format);
     }
 

--- a/include/seqan3/io/alignment_file/output_format_concept.hpp
+++ b/include/seqan3/io/alignment_file/output_format_concept.hpp
@@ -12,7 +12,6 @@
 
 #pragma once
 
-#include <fstream>
 #include <string>
 #include <vector>
 
@@ -29,7 +28,7 @@ namespace seqan3::detail
 {
 
 //!\brief The alignment file output format base class.
-template <typename t>
+template <typename format_type, typename stream_char_type = char>
 class alignment_file_output_format
 {};
 
@@ -53,7 +52,6 @@ namespace seqan3
 template <typename t>
 SEQAN3_CONCEPT AlignmentFileOutputFormat =
     requires (detail::alignment_file_output_format<t>                              & v,
-              std::ofstream                                                        & stream,
               alignment_file_output_options                                        & options,
               alignment_file_header<>                                              & header,
               dna5_vector                                                          & seq,
@@ -73,8 +71,7 @@ SEQAN3_CONCEPT AlignmentFileOutputFormat =
 {
     t::file_extensions;
 
-    { v.write(stream,
-              options,
+    { v.write(options,
               header,
               seq,
               qual,
@@ -100,8 +97,7 @@ SEQAN3_CONCEPT AlignmentFileOutputFormat =
  * \{
  */
 
-/*!\fn void write(stream_type                            &  stream,
-                  alignment_file_output_options const    &  options,
+/*!\fn void write(alignment_file_output_options const    &  options,
                   alignment_file_header<>                & header,
                   seq_type                               && seq,
                   qual_type                              && qual,
@@ -118,7 +114,6 @@ SEQAN3_CONCEPT AlignmentFileOutputFormat =
                   e_value_type                           && e_value,
                   bit_score_type                         && bit_score)
  * \brief Write the given fields to the specified stream.
- * \tparam stream_type      Output stream, must model seqan3::OStream with `char`.
  * \tparam seq_type         Type of the seqan3
  * \tparam id_type          Type of the seqan3
  * \tparam offset_type      Type of the seqan3
@@ -134,7 +129,6 @@ SEQAN3_CONCEPT AlignmentFileOutputFormat =
  * \tparam e_value_type     Type of the seqan3
  * \tparam bit_score_type   Type of the seqan3
  *
- * \param[in,out] stream     The output stream to write into.
  * \param[in]     options    File specific options passed to the format.
  * \param[in]     header     A pointer to the header object of the file.
  * \param[in]     seq        The data for seqan3::field::SEQ, i.e. the query sequence.

--- a/include/seqan3/io/detail/misc_output.hpp
+++ b/include/seqan3/io/detail/misc_output.hpp
@@ -46,11 +46,10 @@ inline auto make_secondary_ostream(std::basic_ostream<char_t> & primary_stream, 
 
     std::string extension = filename.extension().string();
 
-    if ((extension == ".gz") || (extension == ".bgzf") || (extension == ".bam"))
+    if ((extension == ".gz") || (extension == ".bgzf"))
     {
     #ifdef SEQAN3_HAS_ZLIB
-        if (extension != ".bam") // remove extension except for bam
-            filename.replace_extension("");
+        filename.replace_extension("");
 
         return {new contrib::basic_bgzf_ostream<char_t>{primary_stream},
                 stream_deleter_default};

--- a/include/seqan3/io/sequence_file/input.hpp
+++ b/include/seqan3/io/sequence_file/input.hpp
@@ -510,7 +510,8 @@ public:
      */
     sequence_file_input(std::filesystem::path filename,
                         selected_field_ids const & SEQAN3_DOXYGEN_ONLY(fields_tag) = selected_field_ids{}) :
-        primary_stream{new std::ifstream{filename, std::ios_base::in | std::ios::binary}, stream_deleter_default}
+        primary_stream{new std::ifstream{filename, std::ios_base::in | std::ios::binary},
+                       detail::istream_deleter_default<stream_char_type>}
     {
         if (!primary_stream->good())
             throw file_open_error{"Could not open file " + filename.string() + " for reading."};
@@ -519,7 +520,11 @@ public:
         secondary_stream = detail::make_secondary_istream(*primary_stream, filename);
 
         // initialise format handler or throw if format is not found
-        detail::set_format(format, filename);
+        detail::set_format(format, *secondary_stream, filename);
+
+        if (std::istreambuf_iterator<stream_char_type>{*secondary_stream} ==
+            std::istreambuf_iterator<stream_char_type>{})
+            at_end = true;
 
         // buffer first record
         read_next_record();
@@ -550,14 +555,19 @@ public:
     sequence_file_input(stream_t                 & stream,
                         file_format        const & SEQAN3_DOXYGEN_ONLY(format_tag),
                         selected_field_ids const & SEQAN3_DOXYGEN_ONLY(fields_tag) = selected_field_ids{}) :
-        primary_stream{&stream, stream_deleter_noop},
-        format{detail::sequence_file_input_format<file_format>{}}
+        primary_stream{&stream, detail::istream_deleter_noop<stream_char_type>}
     {
         static_assert(meta::in<valid_formats, file_format>::value,
                       "You selected a format that is not in the valid_formats of this file.");
 
         // possibly add intermediate compression stream
         secondary_stream = detail::make_secondary_istream(*primary_stream);
+
+        if (std::istreambuf_iterator<stream_char_type>{*secondary_stream} ==
+            std::istreambuf_iterator<stream_char_type>{})
+            at_end = true;
+
+        format = detail::sequence_file_input_format<file_format, stream_char_type>{*secondary_stream};
 
         // buffer first record
         read_next_record();
@@ -569,14 +579,19 @@ public:
     sequence_file_input(stream_t                && stream,
                         file_format        const & SEQAN3_DOXYGEN_ONLY(format_tag),
                         selected_field_ids const & SEQAN3_DOXYGEN_ONLY(fields_tag) = selected_field_ids{}) :
-        primary_stream{new stream_t{std::move(stream)}, stream_deleter_default},
-        format{detail::sequence_file_input_format<file_format>{}}
+        primary_stream{new stream_t{std::move(stream)}, detail::istream_deleter_default<stream_char_type>}
     {
         static_assert(meta::in<valid_formats, file_format>::value,
                       "You selected a format that is not in the valid_formats of this file.");
 
         // possibly add intermediate compression stream
         secondary_stream = detail::make_secondary_istream(*primary_stream);
+
+        if (std::istreambuf_iterator<stream_char_type>{*secondary_stream} ==
+            std::istreambuf_iterator<stream_char_type>{})
+            at_end = true;
+
+        format = detail::sequence_file_input_format<file_format, stream_char_type>{*secondary_stream};
 
         // buffer first record
         read_next_record();
@@ -712,7 +727,7 @@ public:
 
     //!\brief The options are public and its members can be set directly.
     sequence_file_input_options<typename traits_type::sequence_legal_alphabet,
-                             selected_field_ids::contains(field::SEQ_QUAL)> options;
+                                selected_field_ids::contains(field::SEQ_QUAL)> options;
 
 protected:
     //!\privatesection
@@ -728,24 +743,18 @@ protected:
     /*!\name Stream / file access
      * \{
      */
-    //!\brief The type of the internal stream pointers. Allows dynamically setting ownership management.
-    using stream_ptr_t = std::unique_ptr<std::basic_istream<stream_char_type>,
-                                         std::function<void(std::basic_istream<stream_char_type>*)>>;
-    //!\brief Stream deleter that does nothing (no ownership assumed).
-    static void stream_deleter_noop(std::basic_istream<stream_char_type> *) {}
-    //!\brief Stream deleter with default behaviour (ownership assumed).
-    static void stream_deleter_default(std::basic_istream<stream_char_type> * ptr) { delete ptr; }
-
     //!\brief The primary stream is the user provided stream or the file stream if constructed from filename.
-    stream_ptr_t primary_stream{nullptr, stream_deleter_noop};
+    detail::istream_ptr_type<stream_char_type> primary_stream{nullptr, detail::istream_deleter_noop<stream_char_type>};
     //!\brief The secondary stream is a compression layer on the primary or just points to the primary (no compression).
-    stream_ptr_t secondary_stream{nullptr, stream_deleter_noop};
+    detail::istream_ptr_type<stream_char_type> secondary_stream{nullptr, detail::istream_deleter_noop<stream_char_type>};
 
     //!\brief File is at position 1 behind the last record.
     bool at_end{false};
 
     //!\brief Type of the format, an std::variant over the `valid_formats`.
-    using format_type = typename detail::variant_from_tags<valid_formats, detail::sequence_file_input_format>::type;
+    using format_type = typename detail::variant_from_tags<valid_formats,
+                                                           detail::sequence_file_input_format,
+                                                           stream_char_type>::type;
     //!\brief The actual std::variant holding a pointer to the detected/selected format.
     format_type format;
     //!\}
@@ -756,33 +765,23 @@ protected:
         // clear the record
         record_buffer.clear();
 
-        // at end if we could not read further
-        if ((std::istreambuf_iterator<stream_char_type>{*secondary_stream} ==
-             std::istreambuf_iterator<stream_char_type>{}))
-        {
-            at_end = true;
-            return;
-        }
-
         assert(!format.valueless_by_exception());
         std::visit([&] (auto & f)
         {
             // read new record
             if constexpr (selected_field_ids::contains(field::SEQ_QUAL))
             {
-                f.read(*secondary_stream,
-                       options,
-                       detail::get_or_ignore<field::SEQ_QUAL>(record_buffer),
-                       detail::get_or_ignore<field::ID>(record_buffer),
-                       detail::get_or_ignore<field::SEQ_QUAL>(record_buffer));
+                at_end = f.read(options,
+                                detail::get_or_ignore<field::SEQ_QUAL>(record_buffer),
+                                detail::get_or_ignore<field::ID>(record_buffer),
+                                detail::get_or_ignore<field::SEQ_QUAL>(record_buffer));
             }
             else
             {
-                f.read(*secondary_stream,
-                       options,
-                       detail::get_or_ignore<field::SEQ>(record_buffer),
-                       detail::get_or_ignore<field::ID>(record_buffer),
-                       detail::get_or_ignore<field::QUAL>(record_buffer));
+                at_end = f.read(options,
+                                detail::get_or_ignore<field::SEQ>(record_buffer),
+                                detail::get_or_ignore<field::ID>(record_buffer),
+                                detail::get_or_ignore<field::QUAL>(record_buffer));
             }
         }, format);
     }

--- a/include/seqan3/io/sequence_file/input_format_concept.hpp
+++ b/include/seqan3/io/sequence_file/input_format_concept.hpp
@@ -13,7 +13,6 @@
 
 #pragma once
 
-#include <fstream>
 #include <string>
 #include <vector>
 
@@ -27,7 +26,7 @@ namespace seqan3::detail
 {
 
 //!\brief The sequence file input format base class.
-template <typename format_tag>
+template <typename format_tag, typename stream_char_type = char>
 class sequence_file_input_format
 {};
 
@@ -49,7 +48,6 @@ namespace seqan3
 //!\cond
 template <typename t>
 SEQAN3_CONCEPT SequenceFileInputFormat = requires (detail::sequence_file_input_format<t>    & v,
-                                                   std::ifstream                            & f,
                                                    sequence_file_input_options<dna5, false> & options,
                                                    dna5_vector                              & seq,
                                                    std::string                              & id,
@@ -58,9 +56,9 @@ SEQAN3_CONCEPT SequenceFileInputFormat = requires (detail::sequence_file_input_f
 {
     t::file_extensions;
 
-    { v.read(f, options, seq,         id,          qual)        } -> void;
-    { v.read(f, options, seq_qual,    id,          seq_qual)    } -> void;
-    { v.read(f, options, std::ignore, std::ignore, std::ignore) } -> void;
+    { v.read(options, seq,         id,          qual)        } -> bool;
+    { v.read(options, seq_qual,    id,          seq_qual)    } -> bool;
+    { v.read(options, std::ignore, std::ignore, std::ignore) } -> bool;
 };
 //!\endcond
 
@@ -70,17 +68,15 @@ SEQAN3_CONCEPT SequenceFileInputFormat = requires (detail::sequence_file_input_f
  * \{
  */
 
-/*!\fn void read(stream_type & stream, seqan3::sequence_file_input_options const & options, seq_type & sequence,
+/*!\fn void read(seqan3::sequence_file_input_options const & options, seq_type & sequence,
  *               id_type & id, qual_type & qualities)
  * \brief Read from the specified stream and back-insert into the given field buffers.
- * \tparam stream_type      Input stream, must satisfy seqan3::IStream with `char`.
  * \tparam seq_type         Type of the seqan3::field::SEQ input; must satisfy std::ranges::OutputRange
  * over a seqan3::Alphabet.
  * \tparam id_type          Type of the seqan3::field::ID input; must satisfy std::ranges::OutputRange
  * over a seqan3::Alphabet.
  * \tparam qual_type        Type of the seqan3::field::QUAL input; must satisfy std::ranges::OutputRange
  * over a seqan3::WritableQualityAlphabet.
- * \param[in,out] stream    The input stream to read from.
  * \param[in]     options   File specific options passed to the format.
  * \param[out]    sequence  The buffer for seqan3::field::SEQ input, i.e. the "sequence".
  * \param[out]    id        The buffer for seqan3::field::ID input, e.g. the header line in FastA.

--- a/include/seqan3/io/sequence_file/output_format_concept.hpp
+++ b/include/seqan3/io/sequence_file/output_format_concept.hpp
@@ -12,7 +12,6 @@
 
 #pragma once
 
-#include <fstream>
 #include <string>
 #include <vector>
 
@@ -26,7 +25,7 @@ namespace seqan3::detail
 {
 
 //!\brief The sequence file output format base class.
-template <typename t>
+template <typename format_tag, typename stream_char_type = char>
 class sequence_file_output_format
 {};
 
@@ -48,7 +47,6 @@ namespace seqan3
 //!\cond
 template <typename t>
 SEQAN3_CONCEPT SequenceFileOutputFormat = requires (detail::sequence_file_output_format<t> & v,
-                                                    std::ofstream                  & f,
                                                     sequence_file_output_options   & options,
                                                     dna5_vector                    & seq,
                                                     std::string                    & id,
@@ -57,9 +55,9 @@ SEQAN3_CONCEPT SequenceFileOutputFormat = requires (detail::sequence_file_output
 {
     t::file_extensions;
 
-    { v.write(f, options, seq,         id,          qual)        } -> void;
-    { v.write(f, options, std::ignore, id,          std::ignore) } -> void;
-    { v.write(f, options, std::ignore, std::ignore, std::ignore) } -> void;
+    { v.write(options, seq,         id,          qual)        } -> void;
+    { v.write(options, std::ignore, id,          std::ignore) } -> void;
+    { v.write(options, std::ignore, std::ignore, std::ignore) } -> void;
     // the last is required to be compile time valid, but should always throw at run-time.
 };
 //!\endcond
@@ -70,17 +68,15 @@ SEQAN3_CONCEPT SequenceFileOutputFormat = requires (detail::sequence_file_output
  * \{
  */
 
-/*!\fn void write(stream_type & stream, seqan3::sequence_file_output_options const & options, seq_type && sequence,
+/*!\fn void write(seqan3::sequence_file_output_options const & options, seq_type && sequence,
  *                id_type && id, qual_type && qualities)
  * \brief Write the given fields to the specified stream.
- * \tparam stream_type      Output stream, must satisfy seqan3::OStream with `char`.
  * \tparam seq_type         Type of the seqan3::field::SEQ output; must satisfy std::ranges::OutputRange
  * over a seqan3::Alphabet.
  * \tparam id_type          Type of the seqan3::field::ID output; must satisfy std::ranges::OutputRange
  * over a seqan3::Alphabet.
  * \tparam qual_type        Type of the seqan3::field::QUAL output; must satisfy std::ranges::OutputRange
  * over a seqan3::QualityAlphabet.
- * \param[in,out] stream    The output stream to write into.
  * \param[in]     options   File specific options passed to the format.
  * \param[in]     sequence  The data for seqan3::field::SEQ, i.e. the "sequence".
  * \param[in]     id        The data for seqan3::field::ID, e.g. the header line in FastA.

--- a/include/seqan3/io/structure_file/input_format_concept.hpp
+++ b/include/seqan3/io/structure_file/input_format_concept.hpp
@@ -12,7 +12,6 @@
 
 #pragma once
 
-#include <fstream>
 #include <set>
 #include <string>
 #include <utility>
@@ -28,7 +27,7 @@ namespace seqan3::detail
 {
 
 //!\brief The structure file input format base class.
-template <typename format_tag>
+template <typename format_tag, typename stream_char_type = char>
 class structure_file_input_format
 {};
 
@@ -50,7 +49,6 @@ namespace seqan3
 //!\cond
 template<typename t>
 SEQAN3_CONCEPT StructureFileInputFormat = requires(detail::structure_file_input_format<t> & v,
-                                                   std::ifstream & f,
                                                    structure_file_input_options<rna5, false> & options,
                                                    rna5_vector & seq,
                                                    std::string & id,
@@ -65,17 +63,17 @@ SEQAN3_CONCEPT StructureFileInputFormat = requires(detail::structure_file_input_
 {
     t::file_extensions;
 
-    { v.read(f, options, seq,            id,          bpp,         structure,
-                         energy,         react,       react_err,   comment,        offset)      } -> void;
+    { v.read(options, seq,            id,          bpp,         structure,
+                      energy,         react,       react_err,   comment,        offset)      } -> bool;
 
-    { v.read(f, options, seq,            id,          bpp,         std::ignore,
-                         std::ignore,    std::ignore, std::ignore, std::ignore,    std::ignore) } -> void;
+    { v.read(options, seq,            id,          bpp,         std::ignore,
+                      std::ignore,    std::ignore, std::ignore, std::ignore,    std::ignore) } -> bool;
 
-    { v.read(f, options, structured_seq, id,          std::ignore, structured_seq,
-                         energy,         std::ignore, std::ignore, std::ignore,    std::ignore) } -> void;
+    { v.read(options, structured_seq, id,          std::ignore, structured_seq,
+                      energy,         std::ignore, std::ignore, std::ignore,    std::ignore) } -> bool;
 
-    { v.read(f, options, std::ignore,    std::ignore, std::ignore, std::ignore,
-                         std::ignore,    std::ignore, std::ignore, std::ignore,    std::ignore) } -> void;
+    { v.read(options, std::ignore,    std::ignore, std::ignore, std::ignore,
+                      std::ignore,    std::ignore, std::ignore, std::ignore,    std::ignore) } -> bool;
     // the last is required to be compile time valid, but should always throw at run-time.
 };
 //!\endcond
@@ -85,8 +83,7 @@ SEQAN3_CONCEPT StructureFileInputFormat = requires(detail::structure_file_input_
  * \memberof seqan3::StructureFileInputFormat
  * \{
  */
-/*!\fn void read(stream_type & stream,
- *               structure_file_input_options<seq_legal_alph_type, structured_seq_combined> const & options,
+/*!\fn void read(structure_file_input_options<seq_legal_alph_type, structured_seq_combined> const & options,
  *               seq_type & seq,
  *               id_type & id,
  *               bpp_type & bpp,
@@ -97,7 +94,6 @@ SEQAN3_CONCEPT StructureFileInputFormat = requires(detail::structure_file_input_
  *               comment_type & comment,
  *               offset_type & offset)
  * \brief Read from the specified stream and back-insert into the given field buffers.
- * \tparam stream_type      Input stream, must satisfy seqan3::Istream with `char`.
  * \tparam seq_type         Type of the seqan3::field::SEQ input; must satisfy std::ranges::OutputRange
  * over a seqan3::Alphabet.
  * \tparam id_type          Type of the seqan3::field::ID input; must satisfy std::ranges::OutputRange
@@ -112,7 +108,6 @@ SEQAN3_CONCEPT StructureFileInputFormat = requires(detail::structure_file_input_
  * \tparam comment_type     Type of the seqan3::field::COMMENT input; must satisfy std::ranges::OutputRange
  * over a seqan3::Alphabet.
  * \tparam offset_type      Type of the seqan3::field::OFFSET input; must satisfy std::numeric_limits::is_integer.
- * \param[in,out] stream    The input stream to read from.
  * \param[in]     options   File specific options passed to the format.
  * \param[out]    seq       The buffer for seqan3::field::SEQ input, i.e. the "sequence".
  * \param[out]    id        The buffer for seqan3::field::ID input, e.g. the header line.

--- a/include/seqan3/io/structure_file/output_format_concept.hpp
+++ b/include/seqan3/io/structure_file/output_format_concept.hpp
@@ -12,7 +12,6 @@
 
 #pragma once
 
-#include <fstream>
 #include <set>
 #include <string>
 #include <vector>
@@ -26,7 +25,7 @@ namespace seqan3::detail
 {
 
 //!\brief The structure file output format base class.
-template <typename t>
+template <typename format_tag, typename stream_char_type = char>
 class structure_file_output_format
 {};
 
@@ -48,7 +47,6 @@ namespace seqan3
 //!\cond
 template <typename t>
 SEQAN3_CONCEPT StructureFileOutputFormat = requires(detail::structure_file_output_format<t> & v,
-                                                    std::ofstream & f,
                                                     structure_file_output_options & options,
                                                     rna5_vector & seq,
                                                     std::string & id,
@@ -63,14 +61,14 @@ SEQAN3_CONCEPT StructureFileOutputFormat = requires(detail::structure_file_outpu
 {
     t::file_extensions;
 
-    { v.write(f, options, seq,            id,          bpp,         structure,
-                          energy,         react,       react_err,   comment,        offset)      } -> void;
-    { v.write(f, options, seq,            id,          bpp,         std::ignore,
-                          std::ignore,    std::ignore, std::ignore, std::ignore,    std::ignore) } -> void;
-    { v.write(f, options, structured_seq, id,          std::ignore, structured_seq,
-                          energy,         std::ignore, std::ignore, std::ignore,    std::ignore) } -> void;
-    { v.write(f, options, std::ignore,    std::ignore, std::ignore, std::ignore,
-                          std::ignore,    std::ignore, std::ignore, std::ignore,    std::ignore) } -> void;
+    { v.write(options, seq,            id,          bpp,         structure,
+                       energy,         react,       react_err,   comment,        offset)      } -> void;
+    { v.write(options, seq,            id,          bpp,         std::ignore,
+                       std::ignore,    std::ignore, std::ignore, std::ignore,    std::ignore) } -> void;
+    { v.write(options, structured_seq, id,          std::ignore, structured_seq,
+                       energy,         std::ignore, std::ignore, std::ignore,    std::ignore) } -> void;
+    { v.write(options, std::ignore,    std::ignore, std::ignore, std::ignore,
+                       std::ignore,    std::ignore, std::ignore, std::ignore,    std::ignore) } -> void;
     // the last is required to be compile time valid, but should always throw at run-time.
 };
 //!\endcond
@@ -81,8 +79,7 @@ SEQAN3_CONCEPT StructureFileOutputFormat = requires(detail::structure_file_outpu
  * \{
  */
 
-/*!\fn void write(stream_type & stream,
- *                structure_file_output_options const & options,
+/*!\fn void write(structure_file_output_options const & options,
  *                seq_type && seq,
  *                id_type && id,
  *                bpp_type && bpp,
@@ -93,7 +90,6 @@ SEQAN3_CONCEPT StructureFileOutputFormat = requires(detail::structure_file_outpu
  *                comment_type && comment,
  *                offset_type && offset)
  * \brief Write the given fields to the specified stream.
- * \tparam stream_type      Output stream, must satisfy seqan3::OStream with `char`.
  * \tparam seq_type         Type of the seqan3::field::SEQ output; must satisfy std::ranges::OutputRange
  * over a seqan3::Alphabet.
  * \tparam id_type          Type of the seqan3::field::ID output; must satisfy std::ranges::OutputRange
@@ -108,7 +104,6 @@ SEQAN3_CONCEPT StructureFileOutputFormat = requires(detail::structure_file_outpu
  * \tparam comment_type     Type of the seqan3::field::COMMENT output; must satisfy std::ranges::OutputRange
  * over a seqan3::Alphabet.
  * \tparam offset_type      Type of the seqan3::field::OFFSET output; must satisfy std::numeric_limits::is_integer.
- * \param[in,out] stream    The output stream to write into.
  * \param[in]     options   File specific options passed to the format.
  * \param[in]     seq       The data for seqan3::field::SEQ output, i.e. the "sequence".
  * \param[in]     id        The data for seqan3::field::ID output, e.g. the header line.

--- a/test/performance/io/format_fasta_benchmark.cpp
+++ b/test/performance/io/format_fasta_benchmark.cpp
@@ -55,17 +55,17 @@ static std::string fasta_file = []()
 void write3(benchmark::State & state)
 {
     std::ostringstream ostream;
-    detail::sequence_file_output_format<format_fasta> format;
+    detail::sequence_file_output_format<format_fasta> format{ostream};
     sequence_file_output_options options;
 
     for (auto _ : state)
     {
         for (size_t i = 0; i < iterations_per_run; ++i)
-            format.write(ostream, options, fasta_seq, fasta_hdr, std::ignore);
+            format.write(options, fasta_seq, fasta_hdr, std::ignore);
     }
 
     ostream = std::ostringstream{};
-    format.write(ostream, options, fasta_seq, fasta_hdr, std::ignore);
+    format.write(options, fasta_seq, fasta_hdr, std::ignore);
     size_t bytes_per_run = ostream.str().size() * iterations_per_run;
     state.counters["iterations_per_run"] = iterations_per_run;
     state.counters["bytes_per_run"] = bytes_per_run;
@@ -103,11 +103,11 @@ void read3(benchmark::State & state)
 {
     std::string id;
     dna5_vector seq;
-
-    detail::sequence_file_input_format<format_fasta> format;
     sequence_file_input_options<dna5, false> options;
 
     std::istringstream istream{fasta_file};
+
+    detail::sequence_file_input_format<format_fasta> format{istream};
 
     for (auto _ : state)
     {
@@ -116,7 +116,7 @@ void read3(benchmark::State & state)
 
         for (size_t i = 0; i < iterations_per_run; ++i)
         {
-            format.read(istream, options, seq, id, std::ignore);
+            format.read(options, seq, id, std::ignore);
             id.clear();
             seq.clear();
         }

--- a/test/unit/io/alignment_file/alignment_file_output_test.cpp
+++ b/test/unit/io/alignment_file/alignment_file_output_test.cpp
@@ -519,15 +519,15 @@ read1	41	ref	1	61	1S1M1D1M1I	ref	10	300	ACGT	!##$	AS:i:2	NM:i:7
 read2	42	ref	2	62	7M1D1M1S	ref	10	300	AGGCTGNAG	!##$&'()*	xy:B:S,3,4,5
 read3	43	ref	3	63	1S1M1D1M1I1M1I1D1M1S	ref	10	300	GGAGTATA	!!*+,-./
 )";
+    std::ostringstream os{};
 
     alignment_file_input fin{std::istringstream{comp}, ref_ids, ref_seqs, format_sam{}};
-    alignment_file_output fout{std::ostringstream{}, format_sam{}};
+    alignment_file_output fout{os, format_sam{}};
 
     fin | fout;
 
-    fout.get_stream().flush();
-
-    EXPECT_EQ(reinterpret_cast<std::ostringstream &>(fout.get_stream()).str(), comp);
+    os.flush();
+    EXPECT_EQ(os.str(), comp);
 }
 
 TEST(rows, write_bam_file)
@@ -553,14 +553,15 @@ read3	43	ref	3	63	1S1M1D1M1I1M1I1D1M1S	ref	10	300	GGAGTATA	!!*+,-./
         fin | fout;
     }
 
+    std::ostringstream os{};
+
     alignment_file_input fin2{filename.get_path(), ref_ids, ref_seqs};
-    alignment_file_output fout2{std::ostringstream{}, format_sam{}};
+    alignment_file_output fout2{os, format_sam{}};
 
     fin2 | fout2;
 
-    fout2.get_stream().flush();
-
-    EXPECT_EQ(reinterpret_cast<std::ostringstream &>(fout2.get_stream()).str(), comp);
+    os.flush();
+    EXPECT_EQ(os.str(), comp);
 }
 
 TEST(rows, convert_sam_to_blast)

--- a/test/unit/io/alignment_file/format_bam_test.cpp
+++ b/test/unit/io/alignment_file/format_bam_test.cpp
@@ -15,6 +15,19 @@
 
 #include "alignment_file_format_test_template.hpp"
 
+std::string compress(std::string const & raw)
+{
+    std::ostringstream os;
+
+    {
+        contrib::bgzf_ostream bos{os};
+        bos << raw;
+    }
+
+    os.flush();
+    return os.str();
+}
+
 template <>
 struct alignment_file_read<format_bam> : public alignment_file_data
 {
@@ -26,7 +39,7 @@ struct alignment_file_read<format_bam> : public alignment_file_data
 
     using stream_type = std::istringstream;
 
-    std::string big_header_input{
+    std::string big_header_input = compress(std::string{
         '\x42', '\x41', '\x4D', '\x01', '\xB7', '\x01', '\x00', '\x00', '\x40', '\x48', '\x44', '\x09', '\x56',
         '\x4E', '\x3A', '\x31', '\x2E', '\x36', '\x09', '\x53', '\x4F', '\x3A', '\x63', '\x6F', '\x6F', '\x72',
         '\x64', '\x69', '\x6E', '\x61', '\x74', '\x65', '\x09', '\x53', '\x53', '\x3A', '\x63', '\x6F', '\x6F',
@@ -64,9 +77,9 @@ struct alignment_file_read<format_bam> : public alignment_file_data
         '\x6D', '\x65', '\x6E', '\x74', '\x0A', '\x02', '\x00', '\x00', '\x00', '\x04', '\x00', '\x00', '\x00',
         '\x72', '\x65', '\x66', '\x00', '\x3D', '\x43', '\xDB', '\x0E', '\x05', '\x00', '\x00', '\x00', '\x72',
         '\x65', '\x66', '\x32', '\x00', '\x8D', '\xED', '\x7E', '\x0E'
-    };
+    });
 
-    std::string simple_three_reads_input{
+    std::string simple_three_reads_input = compress(std::string{
         '\x42', '\x41', '\x4D', '\x01', '\x1C', '\x00', '\x00', '\x00', '\x40', '\x48', '\x44', '\x09', '\x56',
         '\x4E', '\x3A', '\x31', '\x2E', '\x36', '\x0A', '\x40', '\x53', '\x51', '\x09', '\x53', '\x4E', '\x3A',
         '\x72', '\x65', '\x66', '\x09', '\x4C', '\x4E', '\x3A', '\x33', '\x34', '\x0A', '\x01', '\x00', '\x00',
@@ -91,9 +104,9 @@ struct alignment_file_read<format_bam> : public alignment_file_data
         '\x00', '\x00', '\x00', '\x11', '\x00', '\x00', '\x00', '\x10', '\x00', '\x00', '\x00', '\x11', '\x00',
         '\x00', '\x00', '\x12', '\x00', '\x00', '\x00', '\x10', '\x00', '\x00', '\x00', '\x14', '\x00', '\x00',
         '\x00', '\x44', '\x14', '\x81', '\x81', '\x00', '\x00', '\x09', '\x0A', '\x0B', '\x0C', '\x0D', '\x0E'
-    };
+    });
 
-    std::string verbose_reads_input{
+    std::string verbose_reads_input = compress(std::string{
         '\x42', '\x41', '\x4D', '\x01', '\xA3', '\x00', '\x00', '\x00', '\x40', '\x48', '\x44', '\x09', '\x56',
         '\x4E', '\x3A', '\x31', '\x2E', '\x36', '\x09', '\x53', '\x4F', '\x3A', '\x75', '\x6E', '\x6B', '\x6E',
         '\x6F', '\x77', '\x6E', '\x09', '\x47', '\x4F', '\x3A', '\x6E', '\x6F', '\x6E', '\x65', '\x0A', '\x40',
@@ -137,9 +150,9 @@ struct alignment_file_read<format_bam> : public alignment_file_data
         '\x11', '\x00', '\x00', '\x00', '\x10', '\x00', '\x00', '\x00', '\x11', '\x00', '\x00', '\x00', '\x12',
         '\x00', '\x00', '\x00', '\x10', '\x00', '\x00', '\x00', '\x14', '\x00', '\x00', '\x00', '\x44', '\x14',
         '\x81', '\x81', '\x00', '\x00', '\x09', '\x0A', '\x0B', '\x0C', '\x0D', '\x0E'
-    };
+    });
 
-    std::string empty_input{
+    std::string empty_input = compress(std::string{
         '\x42', '\x41', '\x4D', '\x01', '\x1C', '\x00', '\x00', '\x00', '\x40', '\x48', '\x44', '\x09', '\x56',
         '\x4E', '\x3A', '\x31', '\x2E', '\x36', '\x0A', '\x40', '\x53', '\x51', '\x09', '\x53', '\x4E', '\x3A',
         '\x72', '\x65', '\x66', '\x09', '\x4C', '\x4E', '\x3A', '\x33', '\x34', '\x0A', '\x01', '\x00', '\x00',
@@ -147,9 +160,9 @@ struct alignment_file_read<format_bam> : public alignment_file_data
         '\x22', '\x00', '\x00', '\x00', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\x02',
         '\x00', '\x48', '\x12', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\xFF', '\xFF',
         '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\x00', '\x00', '\x00', '\x00', '\x2A', '\x00'
-    };
+    });
 
-    std::string empty_cigar{
+    std::string empty_cigar = compress(std::string{
         '\x42', '\x41', '\x4D', '\x01', '\x1C', '\x00', '\x00', '\x00', '\x40', '\x48', '\x44', '\x09', '\x56',
         '\x4E', '\x3A', '\x31', '\x2E', '\x36', '\x0A', '\x40', '\x53', '\x51', '\x09', '\x53', '\x4E', '\x3A',
         '\x72', '\x65', '\x66', '\x09', '\x4C', '\x4E', '\x3A', '\x33', '\x34', '\x0A', '\x01', '\x00', '\x00',
@@ -159,9 +172,9 @@ struct alignment_file_read<format_bam> : public alignment_file_data
         '\x00', '\x00', '\x09', '\x00', '\x00', '\x00', '\x2C', '\x01', '\x00', '\x00', '\x72', '\x65', '\x61',
         '\x64', '\x31', '\x00', '\x12', '\x48', '\x00', '\x02', '\x02', '\x03', '\x41', '\x53', '\x43', '\x02',
         '\x4E', '\x4D', '\x43', '\x07'
-    };
+    });
 
-    std::string unknown_ref{
+    std::string unknown_ref = compress(std::string{
         '\x42', '\x41', '\x4D', '\x01', '\x1C', '\x00', '\x00', '\x00', '\x40', '\x48', '\x44', '\x09', '\x56',
         '\x4E', '\x3A', '\x31', '\x2E', '\x36', '\x0A', '\x40', '\x53', '\x51', '\x09', '\x53', '\x4E', '\x3A',
         '\x72', '\x61', '\x66', '\x09', '\x4C', '\x4E', '\x3A', '\x33', '\x34', '\x0A', '\x01', '\x00', '\x00',
@@ -173,10 +186,10 @@ struct alignment_file_read<format_bam> : public alignment_file_data
         '\x00', '\x00', '\x10', '\x00', '\x00', '\x00', '\x11', '\x00', '\x00', '\x00', '\x12', '\x48', '\x00',
         '\x02', '\x02', '\x03', '\x61', '\x61', '\x41', '\x63', '\x41', '\x53', '\x43', '\x02', '\x66', '\x66',
         '\x66', '\x66', '\x66', '\x46', '\x40', '\x7A', '\x7A', '\x5A', '\x73', '\x74', '\x72', '\x00'
-    };
+    });
 
     /* bytes were modified to a ref id of 8448: \x00 \x00 \x21 \x00*/
-    std::string unknown_ref_header{
+    std::string unknown_ref_header = compress(std::string{
         '\x42', '\x41', '\x4D', '\x01', '\x1C', '\x00', '\x00', '\x00', '\x40', '\x48', '\x44', '\x09', '\x56',
         '\x4E', '\x3A', '\x31', '\x2E', '\x36', '\x0A', '\x40', '\x53', '\x51', '\x09', '\x53', '\x4E', '\x3A',
         '\x72', '\x65', '\x66', '\x09', '\x4C', '\x4E', '\x3A', '\x33', '\x34', '\x0A', '\x01', '\x00', '\x00',
@@ -188,9 +201,9 @@ struct alignment_file_read<format_bam> : public alignment_file_data
         '\x00', '\x00', '\x10', '\x00', '\x00', '\x00', '\x11', '\x00', '\x00', '\x00', '\x12', '\x48', '\x00',
         '\x02', '\x02', '\x03', '\x61', '\x61', '\x41', '\x63', '\x41', '\x53', '\x43', '\x02', '\x66', '\x66',
         '\x66', '\x66', '\x66', '\x46', '\x40', '\x7A', '\x7A', '\x5A', '\x73', '\x74', '\x72', '\x00', '\x0A'
-    };
+    });
 
-    std::string simple_three_reads_output{ // no hard clipping in output
+    std::string simple_three_reads_output = compress(std::string{ // no hard clipping in output
         '\x42', '\x41', '\x4D', '\x01', '\x1C', '\x00', '\x00', '\x00', '\x40', '\x48', '\x44', '\x09', '\x56',
         '\x4E', '\x3A', '\x31', '\x2E', '\x36', '\x0A', '\x40', '\x53', '\x51', '\x09', '\x53', '\x4E', '\x3A',
         '\x72', '\x65', '\x66', '\x09', '\x4C', '\x4E', '\x3A', '\x33', '\x34', '\x0A', '\x01', '\x00', '\x00',
@@ -215,11 +228,11 @@ struct alignment_file_read<format_bam> : public alignment_file_data
         '\x00', '\x00', '\x00', '\x10', '\x00', '\x00', '\x00', '\x11', '\x00', '\x00', '\x00', '\x12', '\x00',
         '\x00', '\x00', '\x10', '\x00', '\x00', '\x00', '\x14', '\x00', '\x00', '\x00', '\x44', '\x14', '\x81',
         '\x81', '\x00', '\x00', '\x09', '\x0A', '\x0B', '\x0C', '\x0D', '\x0E'
-    };
+    });
 
     std::string verbose_output{verbose_reads_input};
 
-    std::string special_output{
+    std::string special_output = compress(std::string{
         '\x42', '\x41', '\x4D', '\x01', '\x1C', '\x00', '\x00', '\x00', '\x40', '\x48', '\x44', '\x09', '\x56',
         '\x4E', '\x3A', '\x31', '\x2E', '\x36', '\x0A', '\x40', '\x53', '\x51', '\x09', '\x53', '\x4E', '\x3A',
         '\x72', '\x65', '\x66', '\x09', '\x4C', '\x4E', '\x3A', '\x33', '\x34', '\x0A', '\x01', '\x00', '\x00',
@@ -230,7 +243,7 @@ struct alignment_file_read<format_bam> : public alignment_file_data
         '\x64', '\x31', '\x00', '\x14', '\x00', '\x00', '\x00', '\x10', '\x00', '\x00', '\x00', '\x12', '\x00',
         '\x00', '\x00', '\x10', '\x00', '\x00', '\x00', '\x11', '\x00', '\x00', '\x00', '\x12', '\x48', '\x00',
         '\x02', '\x02', '\x03'
-    };
+    });
 };
 
 // ---------------------------------------------------------------------------------------------------------------------
@@ -249,7 +262,7 @@ struct bam_format : public alignment_file_data
 
 TEST_F(bam_format, wrong_magic_bytes)
 {
-    std::istringstream stream{std::string{'\x43', '\x41', '\x4D', '\x01' /*CAM\1*/}};
+    std::istringstream stream{compress(std::string{'\x43', '\x41', '\x4D', '\x01' /*CAM\1*/})};
     EXPECT_THROW((alignment_file_input{stream, format_bam{}}), format_error);
 }
 
@@ -264,7 +277,7 @@ TEST_F(bam_format, unknown_ref_in_header)
         '\x00', '\x04', '\x00', '\x00', '\x00', '\x72', '\x61', '\x66', '\x00', '\x22', '\x00', '\x00', '\x00',
     };
 
-    std::istringstream stream{unknown_ref};
+    std::istringstream stream{compress(unknown_ref)};
     EXPECT_THROW((alignment_file_input{stream, this->ref_ids, this->ref_sequences, format_bam{}}), format_error);
 }
 
@@ -279,7 +292,7 @@ TEST_F(bam_format, wrong_ref_length_in_header)
         '\x00', '\x04', '\x00', '\x00', '\x00', '\x72', '\x65', '\x66', '\x00', '\x23', '\x00', '\x00', '\x00',
     };
 
-    std::istringstream stream{wrong_ref_length};
+    std::istringstream stream{compress(wrong_ref_length)};
     EXPECT_THROW((alignment_file_input{stream, this->ref_ids, this->ref_sequences, format_bam{}}), format_error);
 }
 
@@ -301,7 +314,7 @@ TEST_F(bam_format, wrong_order_in_header)
         '\x00', '\x00', '\x00'
     };
 
-    std::istringstream stream{wrong_order};
+    std::istringstream stream{compress(wrong_order)};
     EXPECT_THROW((alignment_file_input{stream, rids, rseqs, format_bam{}}), format_error);
 }
 
@@ -324,7 +337,7 @@ TEST_F(bam_format, wrong_char_as_tag_identifier)
             '\x31', '\x4D', '\x31', '\x49', '\x00'
         };
 
-        std::istringstream stream{wrong_char_in_tag};
+        std::istringstream stream{compress(wrong_char_in_tag)};
         EXPECT_THROW((alignment_file_input{stream, this->ref_ids, this->ref_sequences, format_bam{}}), format_error);
     }
     {
@@ -344,7 +357,7 @@ TEST_F(bam_format, wrong_char_as_tag_identifier)
             '\x31', '\x4D', '\x31', '\x49', '\x00'
         };
 
-        std::istringstream stream{wrong_char_in_tag};
+        std::istringstream stream{compress(wrong_char_in_tag)};
         EXPECT_THROW((alignment_file_input{stream, this->ref_ids, this->ref_sequences, format_bam{}}), format_error);
     }
 }
@@ -368,7 +381,7 @@ TEST_F(bam_format, invalid_cigar_op)
             '\x02', '\x02', '\x03', '\x41', '\x53', '\x43', '\x02', '\x4E', '\x4D', '\x43', '\x07'
         };
 
-        std::istringstream stream{wrong_char_in_tag};
+        std::istringstream stream{compress(wrong_char_in_tag)};
         EXPECT_THROW((alignment_file_input{stream, this->ref_ids, this->ref_sequences, format_bam{}}), format_error);
     }
 }
@@ -392,7 +405,7 @@ TEST_F(bam_format, too_long_cigar_string_read)
     };
 
     {   // successful reading
-        std::istringstream stream{sam_file_with_too_long_cigar_string};
+        std::istringstream stream{compress(sam_file_with_too_long_cigar_string)};
 
         alignment_file_input fin{stream, this->ref_ids, this->ref_sequences, format_bam{}};
 
@@ -402,20 +415,20 @@ TEST_F(bam_format, too_long_cigar_string_read)
     }
 
     {   // error: sam_tag_dictionary is not read
-        std::istringstream stream{sam_file_with_too_long_cigar_string};
+        std::istringstream stream{compress(sam_file_with_too_long_cigar_string)};
 
         ASSERT_THROW((alignment_file_input{stream, format_bam{}, fields<field::ALIGNMENT>{}}), format_error);
     }
 
     {   // error: sequence is not read
-        std::istringstream stream{sam_file_with_too_long_cigar_string};
+        std::istringstream stream{compress(sam_file_with_too_long_cigar_string)};
 
         ASSERT_THROW((alignment_file_input{stream, format_bam{}, fields<field::ALIGNMENT, field::TAGS>{}}),
                      format_error);
     }
 
     {   // error no CG tag
-        std::istringstream stream{std::string{
+        std::istringstream stream{compress(std::string{
             // @HD     VN:1.0
             // @SQ     SN:ref  LN:34
             // read1   41      ref     1       61      4S3N    =       10      300     ACGT    !##$
@@ -428,7 +441,7 @@ TEST_F(bam_format, too_long_cigar_string_read)
             '\x00', '\x00', '\x09', '\x00', '\x00', '\x00', '\x2C', '\x01', '\x00', '\x00', '\x72', '\x65', '\x61',
             '\x64', '\x31', '\x00', '\x44', '\x00', '\x00', '\x00', '\x33', '\x00', '\x00', '\x00', '\x12', '\x48',
             '\x00', '\x02', '\x02', '\x03'
-        }};
+        })};
 
         ASSERT_THROW((alignment_file_input{stream, format_bam{}}), format_error);
     }
@@ -500,5 +513,5 @@ TEST_F(bam_format, too_long_cigar_string_write)
 
     os.flush();
 
-    EXPECT_TRUE(os.str() == expected); // do not use EXPECT_EQ because if this fails the output will be huge :D
+    EXPECT_TRUE(os.str() == compress(expected)); // do not use EXPECT_EQ because if this fails the output will be huge
 }

--- a/test/unit/io/sequence_file/sequence_file_format_genbank_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_format_genbank_test.cpp
@@ -86,8 +86,6 @@ ORIGIN
 )"
     };
 
-    detail::sequence_file_input_format<format_genbank> format;
-
     sequence_file_input_options<dna5, false> options;
 
     std::string id;
@@ -96,13 +94,14 @@ ORIGIN
     void do_read_test(std::string const & input)
     {
         std::stringstream istream{input};
+        detail::sequence_file_input_format<format_genbank> format{istream};
 
         for (unsigned i = 0; i < 3; ++i)
         {
             id.clear();
             seq.clear();
 
-            EXPECT_NO_THROW(( format.read(istream, options, seq, id, std::ignore) ));
+            EXPECT_NO_THROW(( format.read(options, seq, id, std::ignore) ));
             EXPECT_EQ(id, expected_ids[i]);
             EXPECT_EQ(seq, expected_seqs[i]);
             EXPECT_TRUE((ranges::equal(seq, expected_seqs[i])));
@@ -150,13 +149,14 @@ ACCESSION   ID3
 TEST_F(read, only_seq)
 {
     std::stringstream istream{input};
+    detail::sequence_file_input_format<format_genbank> format{istream};
 
     for (unsigned i = 0; i < 3; ++i)
     {
         id.clear();
         seq.clear();
 
-        EXPECT_NO_THROW( (format.read(istream, options, seq, std::ignore, std::ignore) ));
+        EXPECT_NO_THROW( (format.read(options, seq, std::ignore, std::ignore) ));
 
         EXPECT_TRUE((ranges::equal(seq, expected_seqs[i])));
     }
@@ -165,13 +165,14 @@ TEST_F(read, only_seq)
 TEST_F(read, only_id)
 {
     std::stringstream istream{input};
+    detail::sequence_file_input_format<format_genbank> format{istream};
 
     for (unsigned i = 0; i < 3; ++i)
     {
         id.clear();
         seq.clear();
 
-        EXPECT_NO_THROW( (format.read(istream, options, std::ignore, id, std::ignore) ));
+        EXPECT_NO_THROW( (format.read(options, std::ignore, id, std::ignore) ));
 
         EXPECT_TRUE((ranges::equal(id, expected_ids[i])));
     }
@@ -180,12 +181,13 @@ TEST_F(read, only_id)
 TEST_F(read, ignore_id)
 {
     std::stringstream istream{input};
+    detail::sequence_file_input_format<format_genbank> format{istream};
 
     for (unsigned i = 0; i < 3; ++i)
     {
         seq.clear();
 
-        EXPECT_NO_THROW( (format.read(istream, options, seq, std::ignore, std::ignore) ));
+        EXPECT_NO_THROW( (format.read(options, seq, std::ignore, std::ignore) ));
 
         EXPECT_TRUE((ranges::equal(seq, expected_seqs[i])));
     }
@@ -206,14 +208,16 @@ ORIGIN
     };
 
     std::stringstream istream{input};
+    detail::sequence_file_input_format<format_genbank> format{istream};
     seq.clear();
-    EXPECT_THROW( (format.read(istream, options, seq, std::ignore, std::ignore)), parse_error);
+    EXPECT_THROW( (format.read(options, seq, std::ignore, std::ignore)), parse_error);
 
 }
 
 TEST_F(read, seq_qual)
 {
     std::stringstream istream{input};
+    detail::sequence_file_input_format<format_genbank> format{istream};
     sequence_file_input_options<dna5, true> options2;
 
     std::vector<qualified<dna5, phred42>> seq_qual;
@@ -223,7 +227,7 @@ TEST_F(read, seq_qual)
         id.clear();
         seq_qual.clear();
 
-        EXPECT_NO_THROW( (format.read(istream, options2, seq_qual, id, seq_qual) ));
+        EXPECT_NO_THROW( (format.read(options2, seq_qual, id, seq_qual) ));
 
         EXPECT_TRUE((ranges::equal(id, expected_ids[i])));
         EXPECT_TRUE((ranges::equal(seq_qual | view::convert<dna5>, expected_seqs[i])));
@@ -245,7 +249,8 @@ ORIGIN
     };
 
     std::stringstream istream{input};
-    EXPECT_THROW(( format.read(istream, options, seq, id, std::ignore)), parse_error );
+    detail::sequence_file_input_format<format_genbank> format{istream};
+    EXPECT_THROW(( format.read(options, seq, id, std::ignore)), parse_error );
 }
 
 TEST_F(read, from_stream_file)
@@ -302,16 +307,16 @@ ORIGIN
 )"
     };
 
-    detail::sequence_file_output_format<format_genbank> format;
-
     sequence_file_output_options options;
 
     std::ostringstream ostream;
 
+    detail::sequence_file_output_format<format_genbank> format{ostream};
+
     void do_write_test()
     {
         for (unsigned i = 0; i < 3; ++i)
-            EXPECT_NO_THROW(( format.write(ostream, options, seqs[i], ids[i], std::ignore) ));
+            EXPECT_NO_THROW(( format.write(options, seqs[i], ids[i], std::ignore) ));
 
         ostream.flush();
     }
@@ -319,25 +324,25 @@ ORIGIN
 
 TEST_F(write, arg_handling_id_missing)
 {
-    EXPECT_THROW( (format.write(ostream, options, seqs[0], std::ignore, std::ignore)),
+    EXPECT_THROW( (format.write(options, seqs[0], std::ignore, std::ignore)),
                    std::logic_error );
 }
 
 TEST_F(write, arg_handling_id_empty)
 {
-    EXPECT_THROW( (format.write(ostream, options, seqs[0], std::string_view{""}, std::ignore)),
+    EXPECT_THROW( (format.write(options, seqs[0], std::string_view{""}, std::ignore)),
                    std::runtime_error );
 }
 
 TEST_F(write, arg_handling_seq_missing)
 {
-    EXPECT_THROW( (format.write(ostream, options, std::ignore, ids[0], std::ignore)),
+    EXPECT_THROW( (format.write(options, std::ignore, ids[0], std::ignore)),
                    std::logic_error );
 }
 
 TEST_F(write, arg_handling_seq_empty)
 {
-    EXPECT_THROW( (format.write(ostream, options, std::string_view{""}, ids[0], std::ignore)),
+    EXPECT_THROW( (format.write(options, std::string_view{""}, ids[0], std::ignore)),
                    std::runtime_error );
 }
 
@@ -356,8 +361,7 @@ TEST_F(write, seq_qual)
     });
 
     for (unsigned i = 0; i < 3; ++i)
-        EXPECT_NO_THROW(( format.write(ostream,
-                                       options,
+        EXPECT_NO_THROW(( format.write(options,
                                        seqs[i] | convert_to_qualified,
                                        ids[i],
                                        seqs[i] | convert_to_qualified) ));

--- a/test/unit/io/sequence_file/sequence_file_format_sam_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_format_sam_test.cpp
@@ -52,20 +52,21 @@ struct read_sam : public ::testing::Test
         { "!!!!!!!"_phred42 },
     };
 
-    detail::sequence_file_input_format<format_sam> format{};
     sequence_file_input_options<dna5, false> options;
     std::string id;
     dna5_vector seq;
     std::vector<phred42> qual;
+
     void do_read_test(std::string const & input)
     {
         std::stringstream istream{input};
+        detail::sequence_file_input_format<format_sam> format{istream};
         for (unsigned i = 0; i < 3; ++i)
         {
             id.clear();
             seq.clear();
             qual.clear();
-            EXPECT_NO_THROW(( format.read(istream, options, seq, id, qual) ));
+            EXPECT_NO_THROW(( format.read(options, seq, id, qual) ));
             EXPECT_EQ(seq,expected_seqs[i]);
             EXPECT_EQ(id,expected_ids[i]);
             EXPECT_EQ(qual,expected_quals[i]);
@@ -121,6 +122,7 @@ ID3 lala	0	*	0	0	*	*	0	0	ACGTTTA	!!!!!!!	TI:i:2
     };
 
     std::stringstream istream{input};
+    detail::sequence_file_input_format<format_sam> format{istream};
 
     std::vector<qualified<dna5, phred42>> seq_qual;
     sequence_file_input_options<dna5, true> options2;
@@ -130,7 +132,7 @@ ID3 lala	0	*	0	0	*	*	0	0	ACGTTTA	!!!!!!!	TI:i:2
         id.clear();
         seq_qual.clear();
 
-        format.read(istream, options2, seq_qual, id, seq_qual);
+        format.read(options2, seq_qual, id, seq_qual);
 
         EXPECT_TRUE((std::ranges::equal(id, expected_ids[i])));
         EXPECT_TRUE((std::ranges::equal(seq_qual | view::convert<dna5>, expected_seqs[i])));
@@ -162,17 +164,17 @@ ID3 lala	0	*	0	0	*	*	0	0	ACGTTTA	!!!!!!!
 )"
     };
 
-    detail::sequence_file_input_format<format_sam> format{};
     sequence_file_input_options<dna5, false> options;
     std::string id;
     dna5_vector seq;
     std::stringstream istream{input};
+    detail::sequence_file_input_format<format_sam> format{istream};
 
     for (unsigned i = 0; i < 3; ++i)
     {
         id.clear();
         seq.clear();
-        EXPECT_NO_THROW(( format.read(istream, options, seq, id, std::ignore) ));
+        EXPECT_NO_THROW(( format.read(options, seq, id, std::ignore) ));
         EXPECT_EQ(seq,expected_seqs[i]);
         EXPECT_EQ(id,expected_ids[i]);
     }
@@ -186,14 +188,14 @@ R"(ID1	0	*	0	0	*	*	0	0	ACGTTTTTTTTTTTTTTT	!##$%&'()-./++-
 )"
     };
 
-    detail::sequence_file_input_format<format_sam> format{};
     sequence_file_input_options<dna5, false> options;
     std::string id;
     dna5_vector seq;
     std::vector<phred42> qual;
     std::stringstream istream{input};
+    detail::sequence_file_input_format<format_sam> format{istream};
 
-    EXPECT_THROW((format.read(istream, options, seq, id, qual)), format_error );
+    EXPECT_THROW((format.read(options, seq, id, qual)), format_error );
 }
 
 TEST_F(read_sam, qual_too_long)
@@ -204,14 +206,14 @@ R"(ID1	0	*	0	0	*	*	0	0	ACGTTTTTTTTTTTTTTT	!##$%&'()*+,-./++-+
 )"
     };
 
-    detail::sequence_file_input_format<format_sam> format{};
     sequence_file_input_options<dna5, false> options;
     std::string id;
     dna5_vector seq;
     std::vector<phred42> qual;
     std::stringstream istream{input};
+    detail::sequence_file_input_format<format_sam> format{istream};
 
-    EXPECT_THROW((format.read(istream, options, seq, id, qual)), format_error );
+    EXPECT_THROW((format.read(options, seq, id, qual)), format_error );
 }
 
 TEST_F(read_sam, wrong_qual3)
@@ -222,14 +224,14 @@ R"(ID1	0	*	0	0	*	*	0	0	ACGTTTTTTTTTTTTTTT	!##$%&'()*a,-./++-
 )"
     };
 
-    detail::sequence_file_input_format<format_sam> format{};
     sequence_file_input_options<dna5, false> options;
     std::string id;
     dna5_vector seq;
     std::vector<phred42> qual;
     std::stringstream istream{input};
+    detail::sequence_file_input_format<format_sam> format{istream};
 
-    /*EXPECT_THROW(*/(format.read(istream, options, seq, id, qual))/*, unexpected_end_of_input )*/;
+    /*EXPECT_THROW(*/(format.read(options, seq, id, qual))/*, unexpected_end_of_input )*/;
 }
 
 TEST_F(read_sam, no_id)
@@ -240,12 +242,12 @@ R"(*	0	*	0	0	*	*	0	0	ACGTTTTTTTTTTTTTTT	!##$%&'()*+,-./++-
 )"
     };
 
-    detail::sequence_file_input_format<format_sam> format{};
     sequence_file_input_options<dna5, false> options;
     std::string id;
     std::stringstream istream{input};
+    detail::sequence_file_input_format<format_sam> format{istream};
 
-    EXPECT_THROW((format.read(istream, options, std::ignore, id, std::ignore)), format_error );
+    EXPECT_THROW((format.read(options, std::ignore, id, std::ignore)), format_error );
 }
 
 TEST_F(read_sam, no_seq)
@@ -256,12 +258,12 @@ R"(ID 1	0	*	0	0	*	*	0	0	*	!##$%&'()*+,-./++-
 )"
     };
 
-    detail::sequence_file_input_format<format_sam> format{};
     sequence_file_input_options<dna5, false> options;
     dna5_vector seq;
     std::stringstream istream{input};
+    detail::sequence_file_input_format<format_sam> format{istream};
 
-    EXPECT_THROW((format.read(istream, options, seq, std::ignore, std::ignore)), format_error );
+    EXPECT_THROW((format.read(options, seq, std::ignore, std::ignore)), format_error );
 }
 
 TEST_F(read_sam, ignore_seq)
@@ -274,17 +276,17 @@ ID3 lala	0	*	0	0	*	*	0	0	ACGTTTA	!!!!!!!
 )"
     };
 
-    detail::sequence_file_input_format<format_sam> format{};
     sequence_file_input_options<dna5, false> options;
     std::string id;
     std::vector<phred42> qual;
     std::stringstream istream{input};
+    detail::sequence_file_input_format<format_sam> format{istream};
 
     for (unsigned i = 0; i < 3; ++i)
     {
         id.clear();
         qual.clear();
-        EXPECT_NO_THROW(( format.read(istream, options, std::ignore, id, qual) ));
+        EXPECT_NO_THROW(( format.read(options, std::ignore, id, qual) ));
         EXPECT_EQ(id,expected_ids[i]);
         EXPECT_EQ(qual,expected_quals[i]);
     }
@@ -298,12 +300,12 @@ R"(ID 1	0	*	0	0	*	*	0	0	ACGTTTTT?TTTTTTTTT	!##$%&'()*+,-./++-
 )"
     };
 
-    detail::sequence_file_input_format<format_sam> format{};
     sequence_file_input_options<dna5, false> options;
     dna5_vector seq;
     std::stringstream istream{input};
+    detail::sequence_file_input_format<format_sam> format{istream};
 
-    EXPECT_THROW((format.read(istream, options, seq, std::ignore, std::ignore)), format_error );
+    EXPECT_THROW((format.read(options, seq, std::ignore, std::ignore)), format_error );
 }
 
 TEST_F(read_sam, from_stream_file)
@@ -375,36 +377,38 @@ struct write : public ::testing::Test
         { "!##$&'()*+,-./+)*+,-)*+,-)*+,-)*+,BDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDBDDEBDBEEBEBE"_phred42 },
         { "!!*+,-./+*+,-./+!!FF!!"_phred42 },
     };
-    detail::sequence_file_output_format<format_sam> format;
     sequence_file_output_options options;
     std::ostringstream ostream;
+    detail::sequence_file_output_format<format_sam> format{ostream};
+
     void do_write_test()
     {
         for (unsigned i = 0; i < 3; ++i)
-            EXPECT_NO_THROW(( format.write(ostream, options, seqs[i], ids[i], quals[i]) ));
+            EXPECT_NO_THROW(( format.write(options, seqs[i], ids[i], quals[i]) ));
         ostream.flush();
     }
+
     void do_write_test_no_qual()
     {
         for (unsigned i = 0; i < 3; ++i)
-            EXPECT_NO_THROW(( format.write(ostream, options, seqs[i], ids[i],""_phred42) ));
+            EXPECT_NO_THROW(( format.write(options, seqs[i], ids[i],""_phred42) ));
         ostream.flush();
     }
 };
 
 TEST_F(write, arg_handling_id_missing)
 {
-    EXPECT_NO_THROW( (format.write(ostream, options, seqs[0], std::ignore, quals[0])));
+    EXPECT_NO_THROW( (format.write(options, seqs[0], std::ignore, quals[0])));
 }
 
 TEST_F(write, arg_handling_seq_missing)
 {
-    EXPECT_NO_THROW( (format.write(ostream, options, std::ignore, ids[0], quals[0])));
+    EXPECT_NO_THROW( (format.write(options, std::ignore, ids[0], quals[0])));
 }
 
 TEST_F(write, arg_handling_qual_missing)
 {
-    EXPECT_NO_THROW( (format.write(ostream, options, seqs[0], ids[0], std::ignore)));
+    EXPECT_NO_THROW( (format.write(options, seqs[0], ids[0], std::ignore)));
 }
 
 TEST_F(write, default_options)


### PR DESCRIPTION
Blocked by ~#1160~ 
Blocked by ~#1184~ 

Moves the stream handle from the file to the format
and for alignment SAM removes all usage of `operator<<()` in favour of working directly on the ostreambuf_iterator.
