### PR TITLE
[FIX, FEATURE] Add PPC Support

### DIFF
--- a/include/seqan3/contrib/stream/bgzf_stream_util.hpp
+++ b/include/seqan3/contrib/stream/bgzf_stream_util.hpp
@@ -48,13 +48,13 @@ inline static uint64_t bgzf_thread_count = std::thread::hardware_concurrency();
 
 // Special end-of-file marker defined by the BGZF compression format.
 // See: https://samtools.github.io/hts-specs/SAMv1.pdf
-static constexpr std::array<int8_t, 28> BGZF_END_OF_FILE_MARKER {{'\x1f', '\x8b', '\x08', '\x04',
-                                                                  '\x00', '\x00', '\x00', '\x00',
-                                                                  '\x00', '\xff', '\x06', '\x00',
-                                                                  '\x42', '\x43', '\x02', '\x00',
-                                                                  '\x1b', '\x00', '\x03', '\x00',
-                                                                  '\x00', '\x00', '\x00', '\x00',
-                                                                  '\x00', '\x00', '\x00', '\x00'}};
+static constexpr std::array<char, 28> BGZF_END_OF_FILE_MARKER {{'\x1f', '\x8b', '\x08', '\x04',
+                                                                '\x00', '\x00', '\x00', '\x00',
+                                                                '\x00', '\xff', '\x06', '\x00',
+                                                                '\x42', '\x43', '\x02', '\x00',
+                                                                '\x1b', '\x00', '\x03', '\x00',
+                                                                '\x00', '\x00', '\x00', '\x00',
+                                                                '\x00', '\x00', '\x00', '\x00'}};
 
 template <typename TAlgTag>
 struct CompressionContext {};

--- a/include/seqan3/core/char_operations/predicate_detail.hpp
+++ b/include/seqan3/core/char_operations/predicate_detail.hpp
@@ -347,16 +347,25 @@ public:
 /*!\brief Parse condition that checks if a given value is equal to `char_v`.
  * \ingroup stream
  * \implements seqan3::detail::CharPredicate
- * \tparam alphabet_t non-type template parameter with the value that should be checked against.
+ * \tparam char_v non-type template parameter with the value that should be checked against.
  */
 template <int char_v>
 struct is_char_type : public char_predicate_base<is_char_type<char_v>>
 {
     static_assert(char_v == EOF || static_cast<uint64_t>(char_v) < 256, "TODO");
 
+    //!\brief Helper function to handle char_v == EOF.
+    static constexpr auto get_string = [] ()
+    {
+        if constexpr (char_v == EOF)
+            return small_string{"EOF"};
+        else
+            return small_string{char_v};
+    };
+
     //!\brief The message representing this condition.
     static constexpr auto msg = small_string{"is_char<'"} +
-                                small_string{char_v}      +
+                                get_string()              +
                                 small_string("'>");
 
 

--- a/include/seqan3/core/platform.hpp
+++ b/include/seqan3/core/platform.hpp
@@ -186,6 +186,18 @@
 #endif
 
 // ============================================================================
+//  Architectures
+// ============================================================================
+
+// Warn if NO_WARN_X86_INTRINSICS is not set on PowerPC. See https://github.com/seqan/seqan3/pull/1157.
+#if defined(__powerpc64__)
+#   ifndef NO_WARN_X86_INTRINSICS
+#      pragma GCC warning "To use SeqAn3 on PowerPC, you may need to set -DNO_WARN_X86_INTRINSICS. \
+                           Please note that SeqAn3 is not yet optimised for PowerPC."
+#   endif
+#endif
+
+// ============================================================================
 //  Workarounds
 // ============================================================================
 

--- a/include/seqan3/io/detail/magic_header.hpp
+++ b/include/seqan3/io/detail/magic_header.hpp
@@ -22,7 +22,7 @@ namespace seqan3::detail
 //!\brief Defines a magic byte sequence to disambiguate different compression formats. Default is empty.
 //!\ingroup io
 template <typename header_tag_t>
-inline constexpr std::array<int8_t, 0> magic_header{};
+inline constexpr std::array<char, 0> magic_header{};
 
 //!\brief A tag signifying a gz compressed file.
 //!\ingroup io
@@ -37,7 +37,7 @@ struct gz_compression
  * Specialises seqan3::detail::magic_header for seqan3::detail::gz_compression.
  */
 template <>
-inline constexpr std::array<int8_t, 3> magic_header<gz_compression>{'\x1f', '\x8b', '\x08'};
+inline constexpr std::array<char, 3> magic_header<gz_compression>{'\x1f', '\x8b', '\x08'};
 
 //!\brief A tag signifying a bz2 compressed file.
 //!\ingroup io
@@ -52,7 +52,7 @@ struct bz2_compression
  * Specialises seqan3::detail::magic_header for seqan3::detail::bz2_compression.
  */
 template <>
-inline constexpr std::array<int8_t, 3> magic_header<bz2_compression>{'\x42', '\x5a', '\x68'};
+inline constexpr std::array<char, 3> magic_header<bz2_compression>{'\x42', '\x5a', '\x68'};
 
 //!\brief A tag signifying a zstd compressed file.
 //!\ingroup io
@@ -67,7 +67,7 @@ struct zstd_compression
  * Specialises seqan3::detail::magic_header for seqan3::detail::zstd_compression.
  */
 template <>
-inline constexpr std::array<int8_t, 4> magic_header<zstd_compression>{'\x28', '\xb5', '\x2f', '\xfd'};
+inline constexpr std::array<char, 4> magic_header<zstd_compression>{'\x28', '\xb5', '\x2f', '\xfd'};
 
 //!\brief A tag signifying a bgzf compressed file.
 //!\ingroup io
@@ -82,7 +82,7 @@ struct bgzf_compression
  * Specialises seqan3::detail::magic_header for seqan3::detail::bgzf_compression.
  */
 template <>
-inline constexpr std::array<int8_t, 18> magic_header<bgzf_compression>
+inline constexpr std::array<char, 18> magic_header<bgzf_compression>
 {
 //  ID1                              ID2                              CM
     magic_header<gz_compression>[0], magic_header<gz_compression>[1], magic_header<gz_compression>[2],

--- a/test/seqan3-test.cmake
+++ b/test/seqan3-test.cmake
@@ -38,7 +38,7 @@ file(MAKE_DIRECTORY ${SEQAN3_TEST_CLONE_DIR}/googletest/include/)
 # seqan3::test exposes a base set of required flags, includes, definitions and
 # libraries which are in common for **all** seqan3 tests
 add_library (seqan3_test INTERFACE)
-target_compile_options (seqan3_test INTERFACE "-pedantic"  "-Wall" "-Wextra" "-Werror")
+target_compile_options (seqan3_test INTERFACE "-pedantic"  "-Wall" "-Wextra" "-Werror" "-DNO_WARN_X86_INTRINSICS")
 target_link_libraries (seqan3_test INTERFACE "seqan3::seqan3" "pthread")
 target_include_directories (seqan3_test INTERFACE "${SEQAN3_CLONE_DIR}/test/include/")
 add_library (seqan3::test ALIAS seqan3_test)


### PR DESCRIPTION
Resolves #1096

Unit tests with GCC9 Debug and -funsigned-char work for me 
Building on ppc (Debug, GCC8) also works

---
We add `-DNO_WARN_X86_INTRINSICS` for tests to silence the following error from a system header:
```
#ifndef NO_WARN_X86_INTRINSICS
/* This header is distributed to simplify porting x86_64 code that
   makes explicit use of Intel intrinsics to powerpc64le.
   It is the user's responsibility to determine if the results are
   acceptable and make additional changes as necessary.
   Note that much code that uses Intel intrinsics can be rewritten in
   standard C or GNU C extensions, which are more portable and better
   optimized across multiple targets.

   In the specific case of X86 SSE (__m128) intrinsics, the PowerPC
   VMX/VSX ISA is a good match for vector float SIMD operations.
   However scalar float operations in vector (XMM) registers require
   the POWER8 VSX ISA (2.07) level. Also there are important
   differences for data format and placement of float scalars in the
   vector register. For PowerISA Scalar floats in FPRs (left most
   64-bits of the low 32 VSRs) is in double format, while X86_64 SSE
   uses the right most 32-bits of the XMM. These differences require
   extra steps on POWER to match the SSE scalar float semantics.

   Most SSE scalar float intrinsic operations can be performed more
   efficiently as C language float scalar operations or optimized to
   use vector SIMD operations.  We recommend this for new applications.

   Another difference is the format and details of the X86_64 MXSCR vs
   the PowerISA FPSCR / VSCR registers. We recommend applications
   replace direct access to the MXSCR with the more portable <fenv.h>
   Posix APIs. */
#error "Please read comment above.  Use -DNO_WARN_X86_INTRINSICS to disable this error."
#endif
```