### PR TITLE
[FIX] empty sequences for edit_distance

### DIFF
--- a/include/seqan3/alignment/matrix/alignment_trace_algorithms.hpp
+++ b/include/seqan3/alignment/matrix/alignment_trace_algorithms.hpp
@@ -21,7 +21,7 @@
 #include <seqan3/alignment/matrix/trace_directions.hpp>
 #include <seqan3/alphabet/gap/gapped.hpp>
 #include <seqan3/core/type_traits/range.hpp>
-#include <seqan3/range/view/view_all.hpp>
+#include <seqan3/range/view/slice.hpp>
 
 namespace seqan3::detail
 {

--- a/test/unit/alignment/matrix/debug_matrix_test.cpp
+++ b/test/unit/alignment/matrix/debug_matrix_test.cpp
@@ -23,15 +23,60 @@ struct debug_matrix_test : public ::testing::Test
 
     std::vector<bool> masking_matrix
     {
-         1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
-         1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
-         1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  0,  1,
-         1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  0,  1,
-         1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  0,  1,
-         0,  1,  1,  1,  1,  1,  1,  0,  0,  0,  1,  1,  1,  1,  1,  0,  1,
-         0,  0,  1,  1,  1,  1,  0,  0,  0,  0,  0,  1,  1,  1,  0,  0,  1,
-         0,  0,  0,  1,  1,  0,  0,  0,  0,  0,  0,  0,  1,  1,  0,  0,  1,
-         0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  1
+        1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+        1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+        1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  0,  1,
+        1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  0,  1,
+        1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  0,  1,
+        0,  1,  1,  1,  1,  1,  1,  0,  0,  0,  1,  1,  1,  1,  1,  0,  1,
+        0,  0,  1,  1,  1,  1,  0,  0,  0,  0,  0,  1,  1,  1,  0,  0,  1,
+        0,  0,  0,  1,  1,  0,  0,  0,  0,  0,  0,  0,  1,  1,  0,  0,  1,
+        0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  1
+    };
+
+    std::vector<bool> transposed_masking_matrix
+    {
+        1,  1,  1,  1,  1,  0,  0,  0,  0,
+        1,  1,  1,  1,  1,  1,  0,  0,  0,
+        1,  1,  1,  1,  1,  1,  1,  0,  0,
+        1,  1,  1,  1,  1,  1,  1,  1,  0,
+        1,  1,  1,  1,  1,  1,  1,  1,  0,
+        1,  1,  1,  1,  1,  1,  1,  0,  0,
+        1,  1,  1,  1,  1,  1,  0,  0,  0,
+        1,  1,  1,  1,  1,  0,  0,  0,  0,
+        1,  1,  1,  1,  1,  0,  0,  0,  0,
+        1,  1,  1,  1,  1,  0,  0,  0,  0,
+        1,  1,  1,  1,  1,  1,  0,  0,  0,
+        1,  1,  1,  1,  1,  1,  1,  0,  0,
+        1,  1,  1,  1,  1,  1,  1,  1,  0,
+        1,  1,  1,  1,  1,  1,  1,  1,  0,
+        1,  1,  1,  1,  1,  1,  0,  0,  0,
+        1,  1,  0,  0,  0,  0,  0,  0,  0,
+        1,  1,  1,  1,  1,  1,  1,  1,  1
+    };
+
+    std::vector<bool> masking_matrix_s9u_7u
+    {
+        1,  1,  1,  1,  1,  1,  1,
+        1,  1,  1,  1,  1,  1,  1,
+        1,  1,  1,  1,  1,  1,  1,
+        1,  1,  1,  1,  1,  1,  1,
+        1,  1,  1,  1,  1,  1,  1,
+        0,  1,  1,  1,  1,  1,  1,
+        0,  0,  1,  1,  1,  1,  0,
+        0,  0,  0,  1,  1,  0,  0,
+        0,  0,  0,  0,  0,  0,  0
+    };
+
+    std::vector<bool> transposed_masking_matrix_s7u_9u
+    {
+        1,  1,  1,  1,  1,  0,  0,  0,  0,
+        1,  1,  1,  1,  1,  1,  0,  0,  0,
+        1,  1,  1,  1,  1,  1,  1,  0,  0,
+        1,  1,  1,  1,  1,  1,  1,  1,  0,
+        1,  1,  1,  1,  1,  1,  1,  1,  0,
+        1,  1,  1,  1,  1,  1,  1,  0,  0,
+        1,  1,  1,  1,  1,  1,  0,  0,  0
     };
 
     std::vector<int> scores
@@ -108,6 +153,22 @@ struct debug_matrix_test : public ::testing::Test
            -6, -5, -4, -3, -4, -3, -4,
            -7, -6, -5, -4, -4, -4, -3,
            -8, -7, -6, -5, -5, -5, -4
+        }
+    };
+
+    row_wise_matrix<int> transposed_score_matrix_s9u_7u
+    {
+        number_rows{7u},
+        number_cols{9u},
+        std::vector
+        {
+           -0, -1, -2, -3, -4, -5, -6, -7, -8,
+           -1, -0, -1, -2, -3, -4, -5, -6, -7,
+           -2, -1, -1, -2, -3, -3, -4, -5, -6,
+           -3, -2, -1, -2, -3, -4, -3, -4, -5,
+           -4, -3, -2, -2, -3, -3, -4, -4, -5,
+           -5, -4, -3, -3, -3, -4, -3, -4, -5,
+           -6, -5, -4, -3, -4, -4, -4, -3, -4
         }
     };
 
@@ -457,6 +518,80 @@ TEST_F(score_matrix_test, transpose_matrix_rvalue)
     EXPECT_EQ(transpose_matrix.second_sequence(), second_sequence_expect);
 
     EXPECT_EQ(transpose_matrix, transposed_score_matrix);
+}
+
+TEST_F(score_matrix_test, combine_sub_transpose_operations)
+{
+    debug_matrix matrix1{score_matrix, first_sequence, second_sequence};
+    debug_matrix matrix2{score_matrix, first_sequence, second_sequence};
+    matrix1.transpose_matrix().sub_matrix(7u, 9u);
+    matrix2.sub_matrix(9u, 7u).transpose_matrix();
+
+    EXPECT_EQ(matrix1.rows(), 7u);
+    EXPECT_EQ(matrix1.cols(), 9u);
+    EXPECT_EQ(matrix2.rows(), 7u);
+    EXPECT_EQ(matrix2.cols(), 9u);
+    EXPECT_EQ(matrix1, transposed_score_matrix_s9u_7u);
+    EXPECT_EQ(matrix2, transposed_score_matrix_s9u_7u);
+    EXPECT_EQ(matrix1, matrix2);
+}
+
+TEST_F(score_matrix_test, combine_mask_transpose_operations)
+{
+    debug_matrix matrix1{score_matrix, first_sequence, second_sequence};
+    debug_matrix matrix2{score_matrix, first_sequence, second_sequence};
+    matrix1.mask_matrix(masking_matrix).sub_matrix(9u, 7u);
+    matrix2.sub_matrix(9u, 7u).mask_matrix(masking_matrix_s9u_7u);
+
+    EXPECT_EQ(matrix1.rows(), 9u);
+    EXPECT_EQ(matrix1.cols(), 7u);
+    EXPECT_EQ(matrix2.rows(), 9u);
+    EXPECT_EQ(matrix2.cols(), 7u);
+    EXPECT_EQ(matrix1, matrix2);
+}
+
+TEST_F(score_matrix_test, combine_sub_mask_transpose_operations)
+{
+    debug_matrix matrix1{score_matrix, first_sequence, second_sequence};
+    debug_matrix matrix2{score_matrix, first_sequence, second_sequence};
+    debug_matrix matrix3{score_matrix, first_sequence, second_sequence};
+    debug_matrix matrix4{score_matrix, first_sequence, second_sequence};
+    debug_matrix matrix5{score_matrix, first_sequence, second_sequence};
+    debug_matrix matrix6{score_matrix, first_sequence, second_sequence};
+    matrix1.mask_matrix(masking_matrix).transpose_matrix().sub_matrix(7u, 9u);
+    matrix2.mask_matrix(masking_matrix).sub_matrix(9u, 7u).transpose_matrix();
+    matrix3.sub_matrix(9u, 7u).mask_matrix(masking_matrix_s9u_7u).transpose_matrix();
+    matrix4.sub_matrix(9u, 7u).transpose_matrix().mask_matrix(transposed_masking_matrix_s7u_9u);
+    matrix5.transpose_matrix().sub_matrix(7u, 9u).mask_matrix(transposed_masking_matrix_s7u_9u);
+    matrix6.transpose_matrix().mask_matrix(transposed_masking_matrix).sub_matrix(7u, 9u);
+
+    EXPECT_EQ(matrix1.rows(), 7u);
+    EXPECT_EQ(matrix1.cols(), 9u);
+    EXPECT_EQ(matrix2.rows(), 7u);
+    EXPECT_EQ(matrix2.cols(), 9u);
+    EXPECT_EQ(matrix3.rows(), 7u);
+    EXPECT_EQ(matrix3.cols(), 9u);
+    EXPECT_EQ(matrix4.rows(), 7u);
+    EXPECT_EQ(matrix4.cols(), 9u);
+    EXPECT_EQ(matrix5.rows(), 7u);
+    EXPECT_EQ(matrix5.cols(), 9u);
+    EXPECT_EQ(matrix6.rows(), 7u);
+    EXPECT_EQ(matrix6.cols(), 9u);
+    EXPECT_EQ(matrix1, matrix2);
+    EXPECT_EQ(matrix1, matrix3);
+    EXPECT_EQ(matrix1, matrix4);
+    EXPECT_EQ(matrix1, matrix5);
+    EXPECT_EQ(matrix1, matrix6);
+    EXPECT_EQ(matrix2, matrix3);
+    EXPECT_EQ(matrix2, matrix4);
+    EXPECT_EQ(matrix2, matrix5);
+    EXPECT_EQ(matrix2, matrix6);
+    EXPECT_EQ(matrix3, matrix4);
+    EXPECT_EQ(matrix3, matrix5);
+    EXPECT_EQ(matrix3, matrix6);
+    EXPECT_EQ(matrix4, matrix5);
+    EXPECT_EQ(matrix4, matrix6);
+    EXPECT_EQ(matrix5, matrix6);
 }
 
 TEST_F(trace_matrix_test, other_matrix)

--- a/test/unit/alignment/pairwise/edit_distance/global_edit_distance_max_errors_unbanded_test.cpp
+++ b/test/unit/alignment/pairwise/edit_distance/global_edit_distance_max_errors_unbanded_test.cpp
@@ -8,7 +8,7 @@
 #include "../edit_distance_unbanded_test_template.hpp"
 #include "../fixture/global_edit_distance_max_errors_unbanded.hpp"
 
-using global_edit_distance_max_errors_unbanded_types
+using global_edit_distance_max_errors_unbanded_types1
     = ::testing::Types<
         global_fixture<&global::edit_distance::max_errors::unbanded::dna4_01_e255, uint8_t>,
         global_fixture<&global::edit_distance::max_errors::unbanded::dna4_01_e255, uint16_t>,
@@ -33,8 +33,11 @@ using global_edit_distance_max_errors_unbanded_types
         global_fixture<&global::edit_distance::max_errors::unbanded::dna4_01T_e255, uint8_t>,
         global_fixture<&global::edit_distance::max_errors::unbanded::dna4_01T_e255, uint16_t>,
         global_fixture<&global::edit_distance::max_errors::unbanded::dna4_01T_e255, uint32_t>,
-        global_fixture<&global::edit_distance::max_errors::unbanded::dna4_01T_e255, uint64_t>,
+        global_fixture<&global::edit_distance::max_errors::unbanded::dna4_01T_e255, uint64_t>
+    >;
 
+using global_edit_distance_max_errors_unbanded_types2
+    = ::testing::Types<
         global_fixture<&global::edit_distance::max_errors::unbanded::dna4_02_e255, uint8_t>,
         global_fixture<&global::edit_distance::max_errors::unbanded::dna4_02_e255, uint16_t>,
         global_fixture<&global::edit_distance::max_errors::unbanded::dna4_02_e255, uint32_t>,
@@ -55,6 +58,31 @@ using global_edit_distance_max_errors_unbanded_types
         global_fixture<&global::edit_distance::max_errors::unbanded::dna4_02_s10u_15u_e7, uint32_t>,
         global_fixture<&global::edit_distance::max_errors::unbanded::dna4_02_s10u_15u_e7, uint64_t>,
 
+        global_fixture<&global::edit_distance::max_errors::unbanded::dna4_02_s1u_15u_e255, uint8_t>,
+        global_fixture<&global::edit_distance::max_errors::unbanded::dna4_02_s1u_15u_e255, uint16_t>,
+        global_fixture<&global::edit_distance::max_errors::unbanded::dna4_02_s1u_15u_e255, uint32_t>,
+        global_fixture<&global::edit_distance::max_errors::unbanded::dna4_02_s1u_15u_e255, uint64_t>,
+
+        global_fixture<&global::edit_distance::max_errors::unbanded::dna4_02_s1u_15u_e5, uint8_t>,
+        global_fixture<&global::edit_distance::max_errors::unbanded::dna4_02_s1u_15u_e5, uint16_t>,
+        global_fixture<&global::edit_distance::max_errors::unbanded::dna4_02_s1u_15u_e5, uint32_t>,
+        global_fixture<&global::edit_distance::max_errors::unbanded::dna4_02_s1u_15u_e5, uint64_t>,
+
+        global_fixture<&global::edit_distance::max_errors::unbanded::dna4_02T_s15u_1u_e255, uint8_t>,
+        global_fixture<&global::edit_distance::max_errors::unbanded::dna4_02T_s15u_1u_e255, uint16_t>,
+        global_fixture<&global::edit_distance::max_errors::unbanded::dna4_02T_s15u_1u_e255, uint32_t>,
+        global_fixture<&global::edit_distance::max_errors::unbanded::dna4_02T_s15u_1u_e255, uint64_t>,
+
+        global_fixture<&global::edit_distance::max_errors::unbanded::dna4_02T_s15u_1u_e5, uint8_t>,
+        global_fixture<&global::edit_distance::max_errors::unbanded::dna4_02T_s15u_1u_e5, uint16_t>,
+        global_fixture<&global::edit_distance::max_errors::unbanded::dna4_02T_s15u_1u_e5, uint32_t>,
+        global_fixture<&global::edit_distance::max_errors::unbanded::dna4_02T_s15u_1u_e5, uint64_t>,
+
+        global_fixture<&global::edit_distance::max_errors::unbanded::dna4_03_e255, uint8_t>,
+        global_fixture<&global::edit_distance::max_errors::unbanded::dna4_03_e255, uint16_t>,
+        global_fixture<&global::edit_distance::max_errors::unbanded::dna4_03_e255, uint32_t>,
+        global_fixture<&global::edit_distance::max_errors::unbanded::dna4_03_e255, uint64_t>,
+
         global_fixture<&global::edit_distance::max_errors::unbanded::aa27_01_e255, uint8_t>,
         global_fixture<&global::edit_distance::max_errors::unbanded::aa27_01_e255, uint16_t>,
         global_fixture<&global::edit_distance::max_errors::unbanded::aa27_01_e255, uint32_t>,
@@ -66,4 +94,5 @@ using global_edit_distance_max_errors_unbanded_types
         global_fixture<&global::edit_distance::max_errors::unbanded::aa27_01T_e255, uint64_t>
     >;
 
-INSTANTIATE_TYPED_TEST_CASE_P(global, edit_distance_unbanded_test, global_edit_distance_max_errors_unbanded_types);
+INSTANTIATE_TYPED_TEST_CASE_P(global1, edit_distance_unbanded_test, global_edit_distance_max_errors_unbanded_types1);
+INSTANTIATE_TYPED_TEST_CASE_P(global2, edit_distance_unbanded_test, global_edit_distance_max_errors_unbanded_types2);

--- a/test/unit/alignment/pairwise/edit_distance/global_edit_distance_unbanded_test.cpp
+++ b/test/unit/alignment/pairwise/edit_distance/global_edit_distance_unbanded_test.cpp
@@ -35,6 +35,21 @@ using global_edit_distance_unbanded_types
         global_fixture<&global::edit_distance::unbanded::dna4_02_s3u_15u, uint32_t>,
         global_fixture<&global::edit_distance::unbanded::dna4_02_s3u_15u, uint64_t>,
 
+        global_fixture<&global::edit_distance::unbanded::dna4_02_s1u_15u, uint8_t>,
+        global_fixture<&global::edit_distance::unbanded::dna4_02_s1u_15u, uint16_t>,
+        global_fixture<&global::edit_distance::unbanded::dna4_02_s1u_15u, uint32_t>,
+        global_fixture<&global::edit_distance::unbanded::dna4_02_s1u_15u, uint64_t>,
+
+        global_fixture<&global::edit_distance::unbanded::dna4_02T_s15u_1u, uint8_t>,
+        global_fixture<&global::edit_distance::unbanded::dna4_02T_s15u_1u, uint16_t>,
+        global_fixture<&global::edit_distance::unbanded::dna4_02T_s15u_1u, uint32_t>,
+        global_fixture<&global::edit_distance::unbanded::dna4_02T_s15u_1u, uint64_t>,
+
+        global_fixture<&global::edit_distance::unbanded::dna4_03, uint8_t>,
+        global_fixture<&global::edit_distance::unbanded::dna4_03, uint16_t>,
+        global_fixture<&global::edit_distance::unbanded::dna4_03, uint32_t>,
+        global_fixture<&global::edit_distance::unbanded::dna4_03, uint64_t>,
+
         global_fixture<&global::edit_distance::unbanded::aa27_01, uint8_t>,
         global_fixture<&global::edit_distance::unbanded::aa27_01, uint16_t>,
         global_fixture<&global::edit_distance::unbanded::aa27_01, uint32_t>,

--- a/test/unit/alignment/pairwise/edit_distance/semi_global_edit_distance_max_errors_unbanded_test.cpp
+++ b/test/unit/alignment/pairwise/edit_distance/semi_global_edit_distance_max_errors_unbanded_test.cpp
@@ -8,17 +8,12 @@
 #include "../edit_distance_unbanded_test_template.hpp"
 #include "../fixture/semi_global_edit_distance_max_errors_unbanded.hpp"
 
-using semi_global_edit_distance_max_errors_unbanded_types
+using semi_global_edit_distance_max_errors_unbanded_types1
     = ::testing::Types<
         semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_01_e255, uint8_t>,
         semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_01_e255, uint16_t>,
         semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_01_e255, uint32_t>,
         semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_01_e255, uint64_t>,
-
-        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_01T_e255, uint8_t>,
-        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_01T_e255, uint16_t>,
-        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_01T_e255, uint32_t>,
-        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_01T_e255, uint64_t>,
 
         semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_01_e5, uint8_t>,
         semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_01_e5, uint16_t>,
@@ -30,11 +25,77 @@ using semi_global_edit_distance_max_errors_unbanded_types
         semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_01_e2, uint32_t>,
         semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_01_e2, uint64_t>,
 
+        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_01T_e255, uint8_t>,
+        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_01T_e255, uint16_t>,
+        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_01T_e255, uint32_t>,
+        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_01T_e255, uint64_t>
+        >;
+
+using semi_global_edit_distance_max_errors_unbanded_types2
+    = ::testing::Types<
         semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_02_e255, uint8_t>,
         semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_02_e255, uint16_t>,
         semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_02_e255, uint32_t>,
         semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_02_e255, uint64_t>,
 
+        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_02_s10u_15u_e255, uint8_t>,
+        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_02_s10u_15u_e255, uint16_t>,
+        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_02_s10u_15u_e255, uint32_t>,
+        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_02_s10u_15u_e255, uint64_t>,
+
+        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_02_s10u_15u_e4, uint8_t>,
+        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_02_s10u_15u_e4, uint16_t>,
+        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_02_s10u_15u_e4, uint32_t>,
+        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_02_s10u_15u_e4, uint64_t>,
+
+        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_02_s10u_15u_e3, uint8_t>,
+        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_02_s10u_15u_e3, uint16_t>,
+        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_02_s10u_15u_e3, uint32_t>,
+        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_02_s10u_15u_e3, uint64_t>,
+
+        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_02_s3u_15u_e255, uint8_t>,
+        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_02_s3u_15u_e255, uint16_t>,
+        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_02_s3u_15u_e255, uint32_t>,
+        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_02_s3u_15u_e255, uint64_t>,
+
+        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_02_s3u_15u_e0, uint8_t>,
+        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_02_s3u_15u_e0, uint16_t>,
+        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_02_s3u_15u_e0, uint32_t>,
+        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_02_s3u_15u_e0, uint64_t>,
+
+        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_02_s1u_15u_e255, uint8_t>,
+        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_02_s1u_15u_e255, uint16_t>,
+        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_02_s1u_15u_e255, uint32_t>,
+        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_02_s1u_15u_e255, uint64_t>,
+
+        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_02_s1u_15u_e0, uint8_t>,
+        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_02_s1u_15u_e0, uint16_t>,
+        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_02_s1u_15u_e0, uint32_t>,
+        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_02_s1u_15u_e0, uint64_t>,
+
+        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_01T_s17u_1u_e255, uint8_t>,
+        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_01T_s17u_1u_e255, uint16_t>,
+        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_01T_s17u_1u_e255, uint32_t>,
+        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_01T_s17u_1u_e255, uint64_t>,
+
+        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_01T_s17u_1u_e5, uint8_t>,
+        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_01T_s17u_1u_e5, uint16_t>,
+        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_01T_s17u_1u_e5, uint32_t>,
+        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_01T_s17u_1u_e5, uint64_t>,
+
+        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_03_e255, uint8_t>,
+        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_03_e255, uint16_t>,
+        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_03_e255, uint32_t>,
+        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_03_e255, uint64_t>,
+
+        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_03_e0, uint8_t>,
+        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_03_e0, uint16_t>,
+        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_03_e0, uint32_t>,
+        semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::dna4_03_e0, uint64_t>
+    >;
+
+using semi_global_edit_distance_max_errors_unbanded_types3
+    = ::testing::Types<
         semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::aa27_01_e255, uint8_t>,
         semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::aa27_01_e255, uint16_t>,
         semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::aa27_01_e255, uint32_t>,
@@ -46,4 +107,6 @@ using semi_global_edit_distance_max_errors_unbanded_types
         semi_global_fixture<&semi_global::edit_distance::max_errors::unbanded::aa27_01T_e255, uint64_t>
     >;
 
-INSTANTIATE_TYPED_TEST_CASE_P(global, edit_distance_unbanded_test, semi_global_edit_distance_max_errors_unbanded_types);
+INSTANTIATE_TYPED_TEST_CASE_P(semi_global_max_errors1, edit_distance_unbanded_test, semi_global_edit_distance_max_errors_unbanded_types1);
+INSTANTIATE_TYPED_TEST_CASE_P(semi_global_max_errors2, edit_distance_unbanded_test, semi_global_edit_distance_max_errors_unbanded_types2);
+INSTANTIATE_TYPED_TEST_CASE_P(semi_global_max_errors3, edit_distance_unbanded_test, semi_global_edit_distance_max_errors_unbanded_types3);

--- a/test/unit/alignment/pairwise/edit_distance/semi_global_edit_distance_unbanded_test.cpp
+++ b/test/unit/alignment/pairwise/edit_distance/semi_global_edit_distance_unbanded_test.cpp
@@ -35,6 +35,21 @@ using semi_global_edit_distance_unbanded_types
         semi_global_fixture<&semi_global::edit_distance::unbanded::dna4_02_s3u_15u, uint32_t>,
         semi_global_fixture<&semi_global::edit_distance::unbanded::dna4_02_s3u_15u, uint64_t>,
 
+        semi_global_fixture<&semi_global::edit_distance::unbanded::dna4_02_s1u_15u, uint8_t>,
+        semi_global_fixture<&semi_global::edit_distance::unbanded::dna4_02_s1u_15u, uint16_t>,
+        semi_global_fixture<&semi_global::edit_distance::unbanded::dna4_02_s1u_15u, uint32_t>,
+        semi_global_fixture<&semi_global::edit_distance::unbanded::dna4_02_s1u_15u, uint64_t>,
+
+        semi_global_fixture<&semi_global::edit_distance::unbanded::dna4_01T_s17u_1u, uint8_t>,
+        semi_global_fixture<&semi_global::edit_distance::unbanded::dna4_01T_s17u_1u, uint16_t>,
+        semi_global_fixture<&semi_global::edit_distance::unbanded::dna4_01T_s17u_1u, uint32_t>,
+        semi_global_fixture<&semi_global::edit_distance::unbanded::dna4_01T_s17u_1u, uint64_t>,
+
+        semi_global_fixture<&semi_global::edit_distance::unbanded::dna4_03, uint8_t>,
+        semi_global_fixture<&semi_global::edit_distance::unbanded::dna4_03, uint16_t>,
+        semi_global_fixture<&semi_global::edit_distance::unbanded::dna4_03, uint32_t>,
+        semi_global_fixture<&semi_global::edit_distance::unbanded::dna4_03, uint64_t>,
+
         semi_global_fixture<&semi_global::edit_distance::unbanded::aa27_01, uint8_t>,
         semi_global_fixture<&semi_global::edit_distance::unbanded::aa27_01, uint16_t>,
         semi_global_fixture<&semi_global::edit_distance::unbanded::aa27_01, uint32_t>,

--- a/test/unit/alignment/pairwise/fixture/global_edit_distance_max_errors_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/global_edit_distance_max_errors_unbanded.hpp
@@ -278,6 +278,130 @@ static auto dna4_02_s10u_15u_e7 = []()
     };
 }();
 
+static auto dna4_02_s1u_15u_e255 = []()
+{
+    return alignment_fixture
+    {
+        // score: 14 (14 deletetions)
+        // alignment:
+        // AACCGGTAAACCGG
+        //
+        // --------------
+        "AACCGGTAAACCGG"_dna4,
+        ""_dna4,
+        align_cfg::edit | align_cfg::max_error{255},
+        -14,
+        "AACCGGTAAACCGG",
+        "--------------",
+        dna4_02_s1u_15u.front_coordinate,
+        dna4_02_s1u_15u.back_coordinate,
+        dna4_02_s1u_15u.score_vector,
+        dna4_02_s1u_15u.trace_vector
+    };
+}();
+
+static auto dna4_02_s1u_15u_e5 = []()
+{
+    std::vector<bool> masking_matrix
+    {
+    //    e, A, A, C, C, G, G, T, A, A, A, C, C, G, G
+    /*e*/ 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+    };
+
+    return alignment_fixture
+    {
+        // score is inf and has no alignment
+        "AACCGGTAAACCGG"_dna4,
+        ""_dna4,
+        align_cfg::edit | align_cfg::max_error{5},
+        INF,
+        "",
+        "",
+        alignment_coordinate{column_index_type{14u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{14u}, row_index_type{0u}},
+        dna4_02_s1u_15u.score_matrix().mask_matrix(masking_matrix),
+        dna4_02_s1u_15u.trace_matrix().mask_matrix(masking_matrix)
+    };
+}();
+
+static auto dna4_02T_s15u_1u_e255 = []()
+{
+    return alignment_fixture
+    {
+        // score: 14 (14 insertions)
+        // alignment:
+        // --------------
+        //
+        // AACCGGTAAACCGG
+        ""_dna4,
+        "AACCGGTAAACCGG"_dna4,
+        align_cfg::edit | align_cfg::max_error{255},
+        -14,
+        "--------------",
+        "AACCGGTAAACCGG",
+        dna4_02T_s15u_1u.front_coordinate,
+        dna4_02T_s15u_1u.back_coordinate,
+        dna4_02T_s15u_1u.score_vector,
+        dna4_02T_s15u_1u.trace_vector
+    };
+}();
+
+static auto dna4_02T_s15u_1u_e5 = []()
+{
+    std::vector<bool> masking_matrix
+    {
+    //    e,
+    /*e*/ 1,
+    /*A*/ 1,
+    /*A*/ 1,
+    /*C*/ 1,
+    /*C*/ 1,
+    /*G*/ 1,
+    /*G*/ 0,
+    /*T*/ 0,
+    /*A*/ 0,
+    /*A*/ 0,
+    /*A*/ 0,
+    /*C*/ 0,
+    /*C*/ 0,
+    /*G*/ 0,
+    /*G*/ 0,
+    };
+
+    return alignment_fixture
+    {
+        // score is inf and has no alignment
+        ""_dna4,
+        "AACCGGTAAACCGG"_dna4,
+        align_cfg::edit | align_cfg::max_error{5},
+        INF,
+        "",
+        "",
+        alignment_coordinate{column_index_type{0u}, row_index_type{14u}},
+        alignment_coordinate{column_index_type{0u}, row_index_type{14u}},
+        dna4_02T_s15u_1u.score_matrix().mask_matrix(masking_matrix),
+        dna4_02T_s15u_1u.trace_matrix().mask_matrix(masking_matrix)
+    };
+}();
+
+static auto dna4_03_e255 = []()
+{
+    return alignment_fixture
+    {
+        // score: 0
+        ""_dna4,
+        ""_dna4,
+        align_cfg::edit | align_cfg::max_error{255},
+        -0,
+        "",
+        "",
+        dna4_03.front_coordinate,
+        dna4_03.back_coordinate,
+        dna4_03.score_vector,
+        dna4_03.trace_vector
+    };
+}();
+
 static auto aa27_01_e255 = []()
 {
     return alignment_fixture

--- a/test/unit/alignment/pairwise/fixture/global_edit_distance_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/global_edit_distance_unbanded.hpp
@@ -165,7 +165,7 @@ static auto dna4_02_s3u_15u = []()
 {
     return alignment_fixture
     {
-        // score: 14 (14 insertions)
+        // score: 12 (12 insertions)
         // alignment:
         // AACCGGTAAACCGG
         // | |
@@ -180,6 +180,68 @@ static auto dna4_02_s3u_15u = []()
         alignment_coordinate{column_index_type{14u}, row_index_type{2u}},
         dna4_02.score_matrix().sub_matrix(3u, 15u),
         dna4_02.trace_matrix().sub_matrix(3u, 15u)
+    };
+}();
+
+static auto dna4_02_s1u_15u = []()
+{
+    return alignment_fixture
+    {
+        // score: 14 (14 deletetions)
+        // alignment:
+        // AACCGGTAAACCGG
+        //
+        // --------------
+        "AACCGGTAAACCGG"_dna4,
+        ""_dna4,
+        align_cfg::edit,
+        -14,
+        "AACCGGTAAACCGG",
+        "--------------",
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{14u}, row_index_type{0u}},
+        dna4_02.score_matrix().sub_matrix(1u, 15u),
+        dna4_02.trace_matrix().sub_matrix(1u, 15u)
+    };
+}();
+
+static auto dna4_02T_s15u_1u = []()
+{
+    return alignment_fixture
+    {
+        // score: 14 (14 insertions)
+        // alignment:
+        // --------------
+        //
+        // AACCGGTAAACCGG
+        ""_dna4,
+        "AACCGGTAAACCGG"_dna4,
+        align_cfg::edit,
+        -14,
+        "--------------",
+        "AACCGGTAAACCGG",
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{0u}, row_index_type{14u}},
+        dna4_02.score_matrix().transpose_matrix().sub_matrix(15u, 1u),
+        dna4_02.trace_matrix().transpose_matrix().sub_matrix(15u, 1u)
+    };
+}();
+
+static auto dna4_03 = []()
+{
+    return alignment_fixture
+    {
+        // score: 0
+        ""_dna4,
+        ""_dna4,
+        align_cfg::edit,
+        -0,
+        "",
+        "",
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        std::vector<int>{0},
+        std::vector<detail::trace_directions>{NON}
     };
 }();
 

--- a/test/unit/alignment/pairwise/fixture/semi_global_edit_distance_max_errors_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/semi_global_edit_distance_max_errors_unbanded.hpp
@@ -140,6 +140,279 @@ static auto dna4_02_e255 = []()
     };
 }();
 
+static auto dna4_02_s10u_15u_e255 = []()
+{
+    return alignment_fixture
+    {
+        // score: 4 (3 deletions, 1 insertion)
+        // alignment:
+        // AAC---CGGTAAAC---CGGTT
+        //  ||   || ||
+        // -ACGTACG-TA-----------
+        "AACCGGTAAACCGG"_dna4,
+        "ACGTACGTA"_dna4,
+        align_cfg::edit | align_cfg::max_error{255} | align_cfg::aligned_ends{free_ends_first},
+        -4,
+        "AC---CGGTA",
+        "ACGTACG-TA",
+        dna4_02_s10u_15u.front_coordinate,
+        dna4_02_s10u_15u.back_coordinate,
+        dna4_02_s10u_15u.score_vector,
+        dna4_02_s10u_15u.trace_vector
+    };
+}();
+
+static auto dna4_02_s10u_15u_e4 = []()
+{
+    std::vector<bool> masking_matrix
+    {
+    //    e, A, A, C, C, G, G, T, A, A, A, C, C, G, G
+    /*e*/ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    /*A*/ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    /*C*/ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    /*G*/ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    /*T*/ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    /*A*/ 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    /*C*/ 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    /*G*/ 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    /*T*/ 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0, 1, 1,
+    /*A*/ 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+    };
+
+    return alignment_fixture
+    {
+        // score: INF no alignment
+        "AACCGGTAAACCGG"_dna4,
+        "ACGTACGTA"_dna4,
+        align_cfg::edit | align_cfg::max_error{4} | align_cfg::aligned_ends{free_ends_first},
+        -4,
+        "AC---CGGTA",
+        "ACGTACG-TA",
+        dna4_02_s10u_15u.front_coordinate,
+        dna4_02_s10u_15u.back_coordinate,
+        dna4_02_s10u_15u.score_matrix().mask_matrix(masking_matrix),
+        dna4_02_s10u_15u.trace_matrix().mask_matrix(masking_matrix)
+    };
+}();
+
+static auto dna4_02_s10u_15u_e3 = []()
+{
+    std::vector<bool> masking_matrix
+    {
+    //    e, A, A, C, C, G, G, T, A, A, A, C, C, G, G
+    /*e*/ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    /*A*/ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    /*C*/ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    /*G*/ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    /*T*/ 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    /*A*/ 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    /*C*/ 0, 0, 0, 1, 1, 1, 0, 0, 1, 1, 0, 1, 1, 1, 0,
+    /*G*/ 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0,
+    /*T*/ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    /*A*/ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+    };
+
+    return alignment_fixture
+    {
+        // score: INF no alignment
+        "AACCGGTAAACCGG"_dna4,
+        "ACGTACGTA"_dna4,
+        align_cfg::edit | align_cfg::max_error{3} | align_cfg::aligned_ends{free_ends_first},
+        INF,
+        "",
+        "",
+        alignment_coordinate{column_index_type{14u}, row_index_type{9u}},
+        alignment_coordinate{column_index_type{14u}, row_index_type{9u}},
+        dna4_02_s10u_15u.score_matrix().mask_matrix(masking_matrix),
+        dna4_02_s10u_15u.trace_matrix().mask_matrix(masking_matrix)
+    };
+}();
+
+static auto dna4_02_s3u_15u_e255 = []()
+{
+    return alignment_fixture
+    {
+        // score: 0 (0 deletions, 0 insertion)
+        // alignment:
+        // AACCGGTAAACCGGTT
+        //          ||
+        // ---------AC-----
+        "AACCGGTAAACCGG"_dna4,
+        "AC"_dna4,
+        align_cfg::edit | align_cfg::max_error{255} | align_cfg::aligned_ends{free_ends_first},
+        -0,
+        "AC",
+        "AC",
+        dna4_02_s3u_15u.front_coordinate,
+        dna4_02_s3u_15u.back_coordinate,
+        dna4_02_s3u_15u.score_vector,
+        dna4_02_s3u_15u.trace_vector
+    };
+}();
+
+static auto dna4_02_s3u_15u_e0 = []()
+{
+    std::vector<bool> masking_matrix
+    {
+    //    e, A, A, C, C, G, G, T, A, A, A, C, C, G, G
+    /*e*/ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    /*A*/ 0, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0,
+    /*C*/ 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
+    };
+
+    return alignment_fixture
+    {
+        // score: 0 (0 deletions, 0 insertion)
+        // alignment:
+        // AACCGGTAAACCGGTT
+        //          ||
+        // ---------AC-----
+        "AACCGGTAAACCGG"_dna4,
+        "AC"_dna4,
+        align_cfg::edit | align_cfg::max_error{0} | align_cfg::aligned_ends{free_ends_first},
+        -0,
+        "AC",
+        "AC",
+        dna4_02_s3u_15u.front_coordinate,
+        dna4_02_s3u_15u.back_coordinate,
+        dna4_02_s3u_15u.score_matrix().mask_matrix(masking_matrix),
+        dna4_02_s3u_15u.trace_matrix().mask_matrix(masking_matrix)
+    };
+}();
+
+static auto dna4_02_s1u_15u_e255 = []()
+{
+    return alignment_fixture
+    {
+        // score: 0 - empty alignment
+        "AACCGGTAAACCGG"_dna4,
+        ""_dna4,
+        align_cfg::edit | align_cfg::max_error{255} | align_cfg::aligned_ends{free_ends_first},
+        -0,
+        "",
+        "",
+        dna4_02_s1u_15u.front_coordinate,
+        dna4_02_s1u_15u.back_coordinate,
+        dna4_02_s1u_15u.score_vector,
+        dna4_02_s1u_15u.trace_vector
+    };
+}();
+
+static auto dna4_02_s1u_15u_e0 = []()
+{
+    return alignment_fixture
+    {
+        // score: 0 - empty alignment
+        "AACCGGTAAACCGG"_dna4,
+        ""_dna4,
+        align_cfg::edit | align_cfg::max_error{0} | align_cfg::aligned_ends{free_ends_first},
+        -0,
+        "",
+        "",
+        dna4_02_s1u_15u.front_coordinate,
+        dna4_02_s1u_15u.back_coordinate,
+        dna4_02_s1u_15u.score_vector,
+        dna4_02_s1u_15u.trace_vector
+    };
+}();
+
+static auto dna4_01T_s17u_1u_e255 = []()
+{
+    return alignment_fixture
+    {
+        // score: 16 (16 insertions)
+        // alignment:
+        // ----------------
+        //
+        // AACCGGTTAACCGGTT
+        ""_dna4,
+        "AACCGGTTAACCGGTT"_dna4,
+        align_cfg::edit | align_cfg::max_error{255} | align_cfg::aligned_ends{free_ends_first},
+        -16,
+        "----------------",
+        "AACCGGTTAACCGGTT",
+        dna4_01T_s17u_1u.front_coordinate,
+        dna4_01T_s17u_1u.back_coordinate,
+        dna4_01T_s17u_1u.score_vector,
+        dna4_01T_s17u_1u.trace_vector
+    };
+}();
+
+static auto dna4_01T_s17u_1u_e5 = []()
+{
+    std::vector<bool> masking_matrix
+    {
+    //    e,
+    /*e*/ 1,
+    /*A*/ 1,
+    /*A*/ 1,
+    /*C*/ 1,
+    /*C*/ 1,
+    /*G*/ 1,
+    /*G*/ 0,
+    /*T*/ 0,
+    /*T*/ 0,
+    /*A*/ 0,
+    /*A*/ 0,
+    /*C*/ 0,
+    /*C*/ 0,
+    /*G*/ 0,
+    /*G*/ 0,
+    /*T*/ 0,
+    /*T*/ 0,
+    };
+    return alignment_fixture
+    {
+        // score: INF - empty alignment
+        ""_dna4,
+        "AACCGGTTAACCGGTT"_dna4,
+        align_cfg::edit | align_cfg::max_error{5} | align_cfg::aligned_ends{free_ends_first},
+        INF,
+        "",
+        "",
+        alignment_coordinate{column_index_type{0u}, row_index_type{16u}},
+        alignment_coordinate{column_index_type{0u}, row_index_type{16u}},
+        dna4_01T_s17u_1u.score_matrix().mask_matrix(masking_matrix),
+        dna4_01T_s17u_1u.trace_matrix().mask_matrix(masking_matrix)
+    };
+}();
+
+static auto dna4_03_e255 = []()
+{
+    return alignment_fixture
+    {
+        // score: 0
+        ""_dna4,
+        ""_dna4,
+        align_cfg::edit | align_cfg::max_error{255} | align_cfg::aligned_ends{free_ends_first},
+        -0,
+        "",
+        "",
+        dna4_03.front_coordinate,
+        dna4_03.back_coordinate,
+        dna4_03.score_vector,
+        dna4_03.trace_vector
+    };
+}();
+
+static auto dna4_03_e0 = []()
+{
+    return alignment_fixture
+    {
+        // score: 0
+        ""_dna4,
+        ""_dna4,
+        align_cfg::edit | align_cfg::max_error{0} | align_cfg::aligned_ends{free_ends_first},
+        -0,
+        "",
+        "",
+        dna4_03.front_coordinate,
+        dna4_03.back_coordinate,
+        dna4_03.score_vector,
+        dna4_03.trace_vector
+    };
+}();
+
 static auto aa27_01_e255 = []()
 {
     return alignment_fixture

--- a/test/unit/alignment/pairwise/fixture/semi_global_edit_distance_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/semi_global_edit_distance_unbanded.hpp
@@ -214,13 +214,71 @@ static auto dna4_02_s3u_15u = []()
         "AACCGGTAAACCGG"_dna4,
         "AC"_dna4,
         align_cfg::edit | align_cfg::aligned_ends{free_ends_first},
-        0,
+        -0,
         "AC",
         "AC",
         alignment_coordinate{column_index_type{9u}, row_index_type{0u}},
         alignment_coordinate{column_index_type{11u}, row_index_type{2u}},
         dna4_02.score_matrix().sub_matrix(3u, 15u),
         dna4_02.trace_matrix().sub_matrix(3u, 15u)
+    };
+}();
+
+static auto dna4_02_s1u_15u = []()
+{
+    return alignment_fixture
+    {
+        // score: 0 - empty alignment
+        "AACCGGTAAACCGG"_dna4,
+        ""_dna4,
+        align_cfg::edit | align_cfg::aligned_ends{free_ends_first},
+        -0,
+        "",
+        "",
+        alignment_coordinate{column_index_type{14u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{14u}, row_index_type{0u}},
+        dna4_02.score_matrix().sub_matrix(1u, 15u),
+        dna4_02.trace_matrix().sub_matrix(1u, 15u)
+    };
+}();
+
+static auto dna4_01T_s17u_1u = []()
+{
+    return alignment_fixture
+    {
+        // score: 16 (16 insertions)
+        // alignment:
+        // ----------------
+        //
+        // AACCGGTTAACCGGTT
+        ""_dna4,
+        "AACCGGTTAACCGGTT"_dna4,
+        align_cfg::edit | align_cfg::aligned_ends{free_ends_first},
+        -16,
+        "----------------",
+        "AACCGGTTAACCGGTT",
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{0u}, row_index_type{16u}},
+        dna4_01T.score_matrix().sub_matrix(17u, 1u),
+        dna4_01T.trace_matrix().sub_matrix(17u, 1u)
+    };
+}();
+
+static auto dna4_03 = []()
+{
+    return alignment_fixture
+    {
+        // score: 0
+        ""_dna4,
+        ""_dna4,
+        align_cfg::edit | align_cfg::aligned_ends{free_ends_first},
+        -0,
+        "",
+        "",
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        std::vector<int>{0},
+        std::vector<detail::trace_directions>{NON}
     };
 }();
 


### PR DESCRIPTION
This PR will fix
* don't seg-fault on empty sequences (resolves #1111)
* Fixes and tests some bugs with debug_matrix where you can't combine transformation-operations.