### PR TITLE
Adjustment to style guide (space before &)

### DIFF
--- a/test/performance/core/bit_manipulation_benchmark.cpp
+++ b/test/performance/core/bit_manipulation_benchmark.cpp
@@ -12,7 +12,7 @@
 #include <seqan3/core/bit_manipulation.hpp>
 
 template <typename size_type>
-static void is_power_of_two_popcount(benchmark::State& state) {
+static void is_power_of_two_popcount(benchmark::State & state) {
     std::srand(0);
     size_type n = 0;
     for (auto _ : state)
@@ -32,7 +32,7 @@ BENCHMARK_TEMPLATE(is_power_of_two_popcount, unsigned);
 BENCHMARK_TEMPLATE(is_power_of_two_popcount, unsigned long);
 BENCHMARK_TEMPLATE(is_power_of_two_popcount, unsigned long long);
 
-static void is_power_of_two_arithmetic(benchmark::State& state) {
+static void is_power_of_two_arithmetic(benchmark::State & state) {
     std::srand(0);
     size_t n = 0;
     for (auto _ : state)
@@ -43,7 +43,7 @@ static void is_power_of_two_arithmetic(benchmark::State& state) {
 }
 BENCHMARK(is_power_of_two_arithmetic);
 
-static void is_power_of_two_seqan3(benchmark::State& state) {
+static void is_power_of_two_seqan3(benchmark::State & state) {
     std::srand(0);
     size_t n = 0;
     for (auto _ : state)
@@ -54,7 +54,7 @@ static void is_power_of_two_seqan3(benchmark::State& state) {
 }
 BENCHMARK(is_power_of_two_seqan3);
 
-static void next_power_of_two_seqan3(benchmark::State& state) {
+static void next_power_of_two_seqan3(benchmark::State & state) {
     std::srand(0);
     size_t n = 0;
     for (auto _ : state)

--- a/test/performance/core/char_operations/char_predicate_benchmark.cpp
+++ b/test/performance/core/char_operations/char_predicate_benchmark.cpp
@@ -18,7 +18,7 @@ using namespace seqan3;
 constexpr std::array<char, 1 << 20> arr{};
 
 template <bool stl>
-static void simple(benchmark::State& state)
+static void simple(benchmark::State & state)
 {
     size_t sum = 0;
     size_t i = 0;
@@ -40,7 +40,7 @@ BENCHMARK_TEMPLATE(simple, true);
 BENCHMARK_TEMPLATE(simple, false);
 
 template <bool stl>
-static void combined(benchmark::State& state)
+static void combined(benchmark::State & state)
 {
     size_t sum = 0;
     size_t i = 0;

--- a/test/performance/example/example_benchmark.cpp
+++ b/test/performance/example/example_benchmark.cpp
@@ -14,13 +14,13 @@
 
 using namespace seqan3::test;
 
-static void vector_copy_benchmark(benchmark::State& state) {
+static void vector_copy_benchmark(benchmark::State & state) {
     std::vector<int> x = {15, 13, 12, 10};
     for (auto _ : state)
         std::vector<int> copy{x};
 }
 
-static void memcpy_benchmark(benchmark::State& state) {
+static void memcpy_benchmark(benchmark::State & state) {
     unsigned size = state.range(0);
     char* src = new char[size];
     char* dst = new char[size];
@@ -34,7 +34,7 @@ static void memcpy_benchmark(benchmark::State& state) {
     delete[] dst;
 }
 
-static void copy_benchmark(benchmark::State& state) {
+static void copy_benchmark(benchmark::State & state) {
     unsigned size = state.range(0);
     char* src = new char[size];
     char* dst = new char[size];

--- a/test/performance/range/gap_decorator_seq_write_benchmark.cpp
+++ b/test/performance/range/gap_decorator_seq_write_benchmark.cpp
@@ -27,7 +27,7 @@ using namespace seqan3;
 //  insert left to right
 // ============================================================================
 template <typename gap_decorator_t, bool gapped_flag>
-void insert_left2right(benchmark::State& state)
+void insert_left2right(benchmark::State & state)
 {
     unsigned int seq_len = state.range(0);
     using size_type = typename gap_decorator_t::size_type;

--- a/test/performance/range/views/view_all_benchmark.cpp
+++ b/test/performance/range/views/view_all_benchmark.cpp
@@ -21,7 +21,7 @@ using namespace seqan3;
 // ============================================================================
 
 template <typename container_t, typename adaptor_t>
-void sequential_read(benchmark::State& state)
+void sequential_read(benchmark::State & state)
 {
     container_t c;
     c.resize(1'000'000);

--- a/test/performance/range/views/view_drop_benchmark.cpp
+++ b/test/performance/range/views/view_drop_benchmark.cpp
@@ -24,7 +24,7 @@ using namespace seqan3;
 // ============================================================================
 
 template <typename container_t, typename adaptor_t, bool single_pass = false>
-void sequential_read(benchmark::State& state)
+void sequential_read(benchmark::State & state)
 {
     container_t c;
     c.resize(1'000'000);

--- a/test/performance/range/views/view_drop_view_take_benchmark.cpp
+++ b/test/performance/range/views/view_drop_view_take_benchmark.cpp
@@ -23,7 +23,7 @@ using namespace seqan3;
 // THIS FILE IMPLICITLY TESTS seqan3::views::slice, because that is just drop piped into take
 
 template <typename container_t, typename drop_t, typename take_t, bool single_pass = false>
-void sequential_read(benchmark::State& state)
+void sequential_read(benchmark::State & state)
 {
     container_t c;
     c.resize(1'003'000);

--- a/test/performance/range/views/view_take_until_benchmark.cpp
+++ b/test/performance/range/views/view_take_until_benchmark.cpp
@@ -24,7 +24,7 @@ using namespace seqan3;
 // ============================================================================
 
 template <typename container_t, typename adaptor_t, bool invert, bool single_pass = false, bool one_adapt = false>
-void sequential_read(benchmark::State& state)
+void sequential_read(benchmark::State & state)
 {
     container_t c;
     c.resize(1'000'000);


### PR DESCRIPTION
Through copy-paste `State&` instead of `State &` is found in many benchmarks.