### PR TITLE
[Feature] Add dna3bs alphabet

### DIFF
--- a/include/seqan3/alphabet/nucleotide/all.hpp
+++ b/include/seqan3/alphabet/nucleotide/all.hpp
@@ -16,6 +16,7 @@
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
 #include <seqan3/alphabet/nucleotide/dna15.hpp>
+#include <seqan3/alphabet/nucleotide/dna3bs.hpp>
 #include <seqan3/alphabet/nucleotide/rna4.hpp>
 #include <seqan3/alphabet/nucleotide/rna5.hpp>
 #include <seqan3/alphabet/nucleotide/rna15.hpp>
@@ -32,25 +33,25 @@
  * to represent them in a regular std::string, it makes sense to have specialised data structures in most cases.
  * This sub-module offers multiple nucleotide alphabets that can be used with regular containers and ranges.
  *
- * | Letter   | Description            |                   seqan3::dna15        |                   seqan3::dna5         |                  seqan3::dna4          |                seqan3::rna15           |                    seqan3::rna5        |                 seqan3::rna4           |
- * |:--------:|------------------------|:--------------------------------------:|:--------------------------------------:|:--------------------------------------:|:--------------------------------------:|:--------------------------------------:|:--------------------------------------:|
- * |   A      | Adenine                |                              A         |                              A         |                              A         |                              A         |                              A         |                              A         |
- * |   C      | Cytosine               |                              C         |                              C         |                              C         |                              C         |                              C         |                              C         |
- * |   G      | Guanine                |                              G         |                              G         |                              G         |                              G         |                              G         |                              G         |
- * |   T      | Thymine (DNA)          |                              T         |                              T         |                              T         | <span style="color:LightGrey">U</span> | <span style="color:LightGrey">U</span> | <span style="color:LightGrey">U</span> |
- * |   U      | Uracil (RNA)           | <span style="color:LightGrey">T</span> | <span style="color:LightGrey">T</span> | <span style="color:LightGrey">T</span> |                              U         |                              U         |                              U         |
- * |   M      | A *or* C               |                              M         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">A</span> |                              M         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">A</span> |
- * |   R      | A *or* G               |                              R         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">A</span> |                              R         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">A</span> |
- * |   W      | A *or* T               |                              W         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">A</span> |                              W         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">A</span> |
- * |   Y      | C *or* T               |                              Y         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">C</span> |                              Y         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">C</span> |
- * |   S      | C *or* G               |                              S         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">C</span> |                              S         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">C</span> |
- * |   K      | G *or* T               |                              K         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">G</span> |                              K         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">G</span> |
- * |   V      | A *or* C *or* G        |                              V         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">A</span> |                              V         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">A</span> |
- * |   H      | A *or* C *or* T        |                              H         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">A</span> |                              H         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">A</span> |
- * |   D      | A *or* G *or* T        |                              D         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">A</span> |                              D         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">A</span> |
- * |   B      | C *or* G *or* T        |                              B         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">C</span> |                              B         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">C</span> |
- * |   N      | A *or* C *or* G *or* T |                              N         |                              N         | <span style="color:LightGrey">A</span> |                              N         |                              N         | <span style="color:LightGrey">A</span> |
- * | **Size** |                        |     15                                 |      5                                 |      4                                 |     15                                 |      5                                 |      4                                 |
+ * | Letter   | Description            |                   seqan3::dna15        |                   seqan3::dna5         |                  seqan3::dna4          |                  seqan3::dna3bs          |                seqan3::rna15           |                    seqan3::rna5        |                 seqan3::rna4           |
+ * |:--------:|------------------------|:--------------------------------------:|:--------------------------------------:|:--------------------------------------:|:--------------------------------------:|:--------------------------------------:|:--------------------------------------:|:--------------------------------------:|
+ * |   A      | Adenine                |                              A         |                              A         |                              A         |                              A         |                              A         |                              A         |                              A         |
+ * |   C      | Cytosine               |                              C         |                              C         |                              C         |                              T         |                              C         |                              C         |                              C         |
+ * |   G      | Guanine                |                              G         |                              G         |                              G         |                              G         |                              G         |                              G         |                              G         |
+ * |   T      | Thymine (DNA)          |                              T         |                              T         |                              T         |                              T         | <span style="color:LightGrey">U</span> | <span style="color:LightGrey">U</span> | <span style="color:LightGrey">U</span> |
+ * |   U      | Uracil (RNA)           | <span style="color:LightGrey">T</span> | <span style="color:LightGrey">T</span> | <span style="color:LightGrey">T</span> | <span style="color:LightGrey">T</span> |                              U         |                              U         |                              U         |
+ * |   M      | A *or* C               |                              M         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">A</span> | <span style="color:LightGrey">A</span> |                              M         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">A</span> |
+ * |   R      | A *or* G               |                              R         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">A</span> | <span style="color:LightGrey">A</span> |                              R         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">A</span> |
+ * |   W      | A *or* T               |                              W         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">A</span> | <span style="color:LightGrey">A</span> |                              W         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">A</span> |
+ * |   Y      | C *or* T               |                              Y         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">T</span> | <span style="color:LightGrey">C</span> |                              Y         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">C</span> |
+ * |   S      | C *or* G               |                              S         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">T</span> | <span style="color:LightGrey">C</span> |                              S         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">C</span> |
+ * |   K      | G *or* T               |                              K         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">G</span> | <span style="color:LightGrey">G</span> |                              K         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">G</span> |
+ * |   V      | A *or* C *or* G        |                              V         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">A</span> | <span style="color:LightGrey">A</span> |                              V         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">A</span> |
+ * |   H      | A *or* C *or* T        |                              H         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">A</span> | <span style="color:LightGrey">A</span> |                              H         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">A</span> |
+ * |   D      | A *or* G *or* T        |                              D         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">A</span> | <span style="color:LightGrey">A</span> |                              D         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">A</span> |
+ * |   B      | C *or* G *or* T        |                              B         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">T</span> | <span style="color:LightGrey">C</span> |                              B         | <span style="color:LightGrey">N</span> | <span style="color:LightGrey">C</span> |
+ * |   N      | A *or* C *or* G *or* T |                              N         |                              N         | <span style="color:LightGrey">A</span> | <span style="color:LightGrey">A</span> |                              N         |                              N         | <span style="color:LightGrey">A</span> |
+ * | **Size** |                        |     15                                 |      5                                 |      3                                 |      4                                 |     15                                 |      5                                 |      4                                 |
  *
  * Keep in mind, that while we think of "the nucleotide alphabet" as consisting of four bases, there are indeed
  * more characters defined with different levels of ambiguity. Depending on your application it will make sense
@@ -67,6 +68,7 @@
  *   4. if you are doing only RNA input/output, use the respective seqan3::rna* type
  *   5. to actually save space from using smaller alphabets, you need a compressed container (e.g.
  *      seqan3::bitcompressed_vector)
+ *   6. if you are working with bisulfite data use dna3bs
  *
  * ###Printing and conversion to char
  *
@@ -133,6 +135,10 @@
  * In the typical structure of DNA molecules (or double-stranded RNA), each nucleotide has a complement that it
  * pairs with. To generate the complement value of a nucleotide letter, you can call an implementation of
  * seqan3::NucleotideAlphabet::complement() on it.
+ *
+ * The only exception to this table is dna3bs alphabet as the defined complement for 'G' is also 'T' as 'C' and 'T'
+ * are treates as the same letters. However, it is in general not recommended using the complement of dna3bs but rather
+ * using the complement of another dna alphabet and afterwards transforming into dna3bs.
  *
  * For the ambiguous letters, the complement is the (possibly also ambiguous) letter representing the variant of the
  * individual complements.

--- a/include/seqan3/alphabet/nucleotide/all.hpp
+++ b/include/seqan3/alphabet/nucleotide/all.hpp
@@ -68,7 +68,7 @@
  *   4. if you are doing only RNA input/output, use the respective seqan3::rna* type
  *   5. to actually save space from using smaller alphabets, you need a compressed container (e.g.
  *      seqan3::bitcompressed_vector)
- *   6. if you are working with bisulfite data use dna3bs
+ *   6. if you are working with bisulfite data use seqan3::dna3bs
  *
  * ###Printing and conversion to char
  *
@@ -136,9 +136,9 @@
  * pairs with. To generate the complement value of a nucleotide letter, you can call an implementation of
  * seqan3::NucleotideAlphabet::complement() on it.
  *
- * The only exception to this table is dna3bs alphabet as the defined complement for 'G' is also 'T' as 'C' and 'T'
- * are treates as the same letters. However, it is in general not recommended using the complement of dna3bs but rather
- * using the complement of another dna alphabet and afterwards transforming into dna3bs.
+ * The only exception to this table is the seqan3::dna3bs alphabet. The complement for 'G' is defined as 'T' since 'C' and 'T'
+ * are treated as the same letters. However, it is not recommended to use the complement of seqan3::dna3bs but rather
+ * use the complement of another dna alphabet and afterwards transform it into seqan3::dna3bs.
  *
  * For the ambiguous letters, the complement is the (possibly also ambiguous) letter representing the variant of the
  * individual complements.

--- a/include/seqan3/alphabet/nucleotide/dna3bs.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna3bs.hpp
@@ -1,0 +1,187 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \author Sara Hetzel <sara.hetzel AT fu-berlin.de>
+ * \brief Provides seqan3::dna3bs, container aliases and string literals.
+ */
+
+#pragma once
+
+#include <vector>
+
+#include <seqan3/alphabet/nucleotide/nucleotide_base.hpp>
+#include <seqan3/core/char_operations/transform.hpp>
+
+// ------------------------------------------------------------------
+// dna3bs
+// ------------------------------------------------------------------
+
+namespace seqan3
+{
+/*!\brief The three letter reduced DNA alphabet for bisulfite sequencing mode (A,G,T(=C)).
+ * \ingroup nucleotide
+ * \implements seqan3::NucleotideAlphabet
+ * \implements seqan3::WritableAlphabet
+ * \if DEV \implements seqan3::detail::WritableConstexprAlphabet \endif
+ * \implements seqan3::TriviallyCopyable
+ * \implements seqan3::StandardLayout
+ * \implements std::Regular
+ *
+ * \details
+ * Note that you can assign 'U' as a character to dna3bs and it will silently
+ * be converted to 'T'.
+ * This alphabet represents a reduced version that can be used when dealing with bisulfite-converted data.
+ * For this purpose, all Cs are converted to a T in order to allow comparison of normal sequences with
+ * bisulfite-converted sequences.
+ * For completeness this nucleotide alphabet has a complement table, however it is not recommended to use
+ * it when dealing with bisulfite data because the complement of T is ambiguous in reads from bisulfite
+ * sequencing. A 'T' can represent a true thymidine or an unmethylated 'C' that was converted into a 'T'. Therefore,
+ * it is recommended that when working with bisulfite data the reverse complement from dna4/5/15 is used prior
+ * to conversion into dna3bs in order to avoid simplifying the data by automatically setting A as the complement
+ * of C. As an example: The sequence 'ACGTGC' in dna4 would be 'ATGTGT' in dna3bs. The complement of this dna3bs
+ * sequence would be 'TATATA', however when complementing the sequence in dna4 before transforming into dna3bs,
+ * it would be 'TGTATG' which preserves more information from the original sequence.
+ *
+ * Like most alphabets, this alphabet cannot be initialised directly from its character representation.
+ * Instead initialise/assign from the character literal or use the
+ * function seqan3::dna3bs::assign_char().
+ *
+ * \include test/snippet/alphabet/nucleotide/dna3bs.cpp
+ */
+class dna3bs : public nucleotide_base<dna3bs, 3>
+{
+private:
+    //!\brief The base class.
+    using base_t = nucleotide_base<dna3bs, 3>;
+
+    //!\brief Befriend seqan3::nucleotide_base.
+    friend base_t;
+    //!\cond \brief Befriend seqan3::alphabet_base.
+    friend base_t::base_t;
+    //!\endcond
+
+public:
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    constexpr dna3bs()                            noexcept = default; //!< Defaulted.
+    constexpr dna3bs(dna3bs const &)              noexcept = default; //!< Defaulted.
+    constexpr dna3bs(dna3bs &&)                   noexcept = default; //!< Defaulted.
+    constexpr dna3bs & operator=(dna3bs const &)  noexcept = default; //!< Defaulted.
+    constexpr dna3bs & operator=(dna3bs &&)       noexcept = default; //!< Defaulted.
+    ~dna3bs()                                     noexcept = default; //!< Defaulted.
+
+    using base_t::base_t;
+
+protected:
+    //!\privatesection
+
+    //!\brief Value to char conversion table.
+    static constexpr char_type rank_to_char[alphabet_size]
+    {
+        'A',
+        'G',
+        'T'
+    };
+
+    //!\brief Char to value conversion table.
+    static constexpr std::array<rank_type, 256> char_to_rank
+    {
+        [] () constexpr
+        {
+            std::array<rank_type, 256> ret{};
+
+            // reverse mapping for characters and their lowercase
+            for (size_t rnk = 0u; rnk < alphabet_size; ++rnk)
+            {
+                ret[         rank_to_char[rnk] ] = rnk;
+                ret[to_lower(rank_to_char[rnk])] = rnk;
+            }
+
+            // set C and U equal to T
+            ret['C'] = ret['T']; ret['c'] = ret['t'];
+            ret['U'] = ret['T']; ret['u'] = ret['t'];
+
+            // iupac characters get special treatment, because there is no N
+            ret['R'] = ret['A']; ret['r'] = ret['A']; // or G
+            ret['Y'] = ret['T']; ret['y'] = ret['T']; // or T
+            ret['S'] = ret['T']; ret['s'] = ret['T']; // or G
+            ret['W'] = ret['A']; ret['w'] = ret['A']; // or T
+            ret['K'] = ret['G']; ret['k'] = ret['G']; // or T
+            ret['M'] = ret['A']; ret['m'] = ret['A']; // or T
+            ret['B'] = ret['T']; ret['b'] = ret['T']; // or G or T
+            ret['D'] = ret['A']; ret['d'] = ret['A']; // or G or T
+            ret['H'] = ret['A']; ret['h'] = ret['A']; // or C or T
+            ret['V'] = ret['A']; ret['v'] = ret['A']; // or C or G
+
+            return ret;
+        }()
+    };
+
+    //!\brief The complement table.
+    static const std::array<dna3bs, alphabet_size> complement_table;
+};
+
+// ------------------------------------------------------------------
+// containers
+// ------------------------------------------------------------------
+
+//!\brief Alias for an std::vector of seqan3::dna3bs.
+//!\relates dna3bs
+using dna3bs_vector = std::vector<dna3bs>;
+
+// ------------------------------------------------------------------
+// literals
+// ------------------------------------------------------------------
+
+/*!\name Literals
+ * \{
+ */
+
+/*!\brief The seqan3::dna3bs char literal.
+ * \relates seqan3::dna3bs
+ * \returns seqan3::dna3bs
+ */
+constexpr dna3bs operator""_dna3bs(char const c) noexcept
+{
+    return dna3bs{}.assign_char(c);
+}
+
+/*!\brief The seqan3::dna3bs string literal.
+ * \relates seqan3::dna3bs
+ * \returns seqan3::dna3bs_vector
+ *
+ * You can use this string literal to easily assign to dna3bs_vector:
+ *
+ * \include test/snippet/alphabet/nucleotide/dna3bs_literal.cpp
+ *
+ */
+inline dna3bs_vector operator""_dna3bs(char const * s, std::size_t n)
+{
+    dna3bs_vector r;
+    r.resize(n);
+
+    for (size_t i = 0; i < n; ++i)
+        r[i].assign_char(s[i]);
+
+    return r;
+}
+//!\}
+
+// ------------------------------------------------------------------
+// dna3bs (deferred definition)
+// ------------------------------------------------------------------
+
+constexpr std::array<dna3bs, dna3bs::alphabet_size> dna3bs::complement_table
+{
+    'T'_dna3bs,    // complement of 'A'_dna3bs
+    'T'_dna3bs,    // complement of 'G'_dna3bs
+    'A'_dna3bs     // complement of 'T'_dna3bs
+};
+
+} // namespace seqan3

--- a/include/seqan3/alphabet/nucleotide/dna3bs.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna3bs.hpp
@@ -33,19 +33,18 @@ namespace seqan3
  * \implements std::Regular
  *
  * \details
- * Note that you can assign 'U' as a character to dna3bs and it will silently
- * be converted to 'T'.
  * This alphabet represents a reduced version that can be used when dealing with bisulfite-converted data.
- * For this purpose, all Cs are converted to a T in order to allow comparison of normal sequences with
+ * All 'C's are converted to a 'T' in order to allow comparison of normal sequences with
  * bisulfite-converted sequences.
- * For completeness this nucleotide alphabet has a complement table, however it is not recommended to use
+ * For completeness, this nucleotide alphabet has a complement table, however, it is not recommended to use
  * it when dealing with bisulfite data because the complement of T is ambiguous in reads from bisulfite
- * sequencing. A 'T' can represent a true thymidine or an unmethylated 'C' that was converted into a 'T'. Therefore,
- * it is recommended that when working with bisulfite data the reverse complement from dna4/5/15 is used prior
- * to conversion into dna3bs in order to avoid simplifying the data by automatically setting A as the complement
- * of C. As an example: The sequence 'ACGTGC' in dna4 would be 'ATGTGT' in dna3bs. The complement of this dna3bs
- * sequence would be 'TATATA', however when complementing the sequence in dna4 before transforming into dna3bs,
- * it would be 'TGTATG' which preserves more information from the original sequence.
+ * sequencing. A 'T' can represent a true thymidine or an unmethylated 'C' that was converted into a 'T'.
+ * Therefore, complementing a dna4bs sequence will further reduce the alphabet to only 'T' and 'A', thereby
+ * loosing all information about 'G'. When working with bisulfite data, we recommend to create the reverse
+ * complement of the dna4/5/15 range first and convert to dna3bs later. This avoids simplifying the data by automatically
+ * setting 'A' as the complement of 'C'. As an example: The sequence 'ACGTGC' in dna4 would be 'ATGTGT' in dna3bs.
+ * The complement of this dna3bs sequence would be 'TATATA', however when complementing the dna4 sequence first
+ * and afterwards transforming it into dna3bs, it would be 'TGTATG' which preserves more information from the original sequence.
  *
  * Like most alphabets, this alphabet cannot be initialised directly from its character representation.
  * Instead initialise/assign from the character literal or use the
@@ -77,6 +76,7 @@ public:
     ~dna3bs()                                     noexcept = default; //!< Defaulted.
 
     using base_t::base_t;
+    //!\}
 
 protected:
     //!\privatesection
@@ -108,16 +108,16 @@ protected:
             ret['U'] = ret['T']; ret['u'] = ret['t'];
 
             // iupac characters get special treatment, because there is no N
-            ret['R'] = ret['A']; ret['r'] = ret['A']; // or G
-            ret['Y'] = ret['T']; ret['y'] = ret['T']; // or T
-            ret['S'] = ret['T']; ret['s'] = ret['T']; // or G
-            ret['W'] = ret['A']; ret['w'] = ret['A']; // or T
-            ret['K'] = ret['G']; ret['k'] = ret['G']; // or T
-            ret['M'] = ret['A']; ret['m'] = ret['A']; // or T
-            ret['B'] = ret['T']; ret['b'] = ret['T']; // or G or T
-            ret['D'] = ret['A']; ret['d'] = ret['A']; // or G or T
-            ret['H'] = ret['A']; ret['h'] = ret['A']; // or C or T
-            ret['V'] = ret['A']; ret['v'] = ret['A']; // or C or G
+            ret['R'] = ret['A']; ret['r'] = ret['A']; // A or G becomes A
+            ret['Y'] = ret['T']; ret['y'] = ret['T']; // C or T becomes T
+            ret['S'] = ret['T']; ret['s'] = ret['T']; // C or G becomes T
+            ret['W'] = ret['A']; ret['w'] = ret['A']; // A or T becomes A
+            ret['K'] = ret['G']; ret['k'] = ret['G']; // G or T becomes G
+            ret['M'] = ret['A']; ret['m'] = ret['A']; // A or C becomes A
+            ret['B'] = ret['T']; ret['b'] = ret['T']; // C or G or T becomes T
+            ret['D'] = ret['A']; ret['d'] = ret['A']; // A or G or T becomes A
+            ret['H'] = ret['A']; ret['h'] = ret['A']; // A or C or T becomes A
+            ret['V'] = ret['A']; ret['v'] = ret['A']; // A or C or G  becomes A
 
             return ret;
         }()

--- a/test/snippet/alphabet/nucleotide/dna3bs.cpp
+++ b/test/snippet/alphabet/nucleotide/dna3bs.cpp
@@ -1,0 +1,19 @@
+#include <seqan3/alphabet/nucleotide/dna3bs.hpp>
+#include <seqan3/core/debug_stream.hpp>
+
+int main()
+{
+    using seqan3::operator""_dna3bs;
+
+    seqan3::dna3bs my_letter{'A'_dna3bs};
+
+    my_letter.assign_char('C'); // all C will be converted to T.
+    if (my_letter.to_char() == 'T')
+        seqan3::debug_stream << "yeah\n"; // "yeah";
+
+    my_letter.assign_char('F'); // unknown characters are implicitly converted to A.
+    if (my_letter.to_char() == 'A')
+        seqan3::debug_stream << "yeah\n"; // "yeah";
+
+    return 0;
+}

--- a/test/snippet/alphabet/nucleotide/dna3bs_literal.cpp
+++ b/test/snippet/alphabet/nucleotide/dna3bs_literal.cpp
@@ -1,0 +1,17 @@
+#include <seqan3/alphabet/nucleotide/dna3bs.hpp>
+#include <seqan3/core/debug_stream.hpp>
+
+int main()
+{
+    using seqan3::operator""_dna3bs;
+
+    seqan3::dna3bs_vector foo{"ACGTTA"_dna3bs}; // ATGTTA
+    seqan3::dna3bs_vector bar = "ATGTTA"_dna3bs;
+
+    if (foo == bar)
+        seqan3::debug_stream << "yeah\n"; // "yeah";
+
+    auto bax = "ACGTTA"_dna3bs;
+
+    return 0;
+}

--- a/test/unit/alphabet/nucleotide/CMakeLists.txt
+++ b/test/unit/alphabet/nucleotide/CMakeLists.txt
@@ -1,6 +1,7 @@
 seqan3_test(dna4_test.cpp)
 seqan3_test(dna5_test.cpp)
 seqan3_test(dna15_test.cpp)
+seqan3_test(dna3bs_test.cpp)
 seqan3_test(rna4_test.cpp)
 seqan3_test(rna5_test.cpp)
 seqan3_test(rna15_test.cpp)

--- a/test/unit/alphabet/nucleotide/dna3bs_test.cpp
+++ b/test/unit/alphabet/nucleotide/dna3bs_test.cpp
@@ -1,0 +1,98 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+#include <seqan3/alphabet/concept.hpp>
+#include <seqan3/alphabet/nucleotide/dna3bs.hpp>
+#include <seqan3/core/char_operations/predicate.hpp>
+
+#include "../alphabet_test_template.hpp"
+#include "../alphabet_constexpr_test_template.hpp"
+
+INSTANTIATE_TYPED_TEST_CASE_P(dna3bs, alphabet, dna3bs);
+INSTANTIATE_TYPED_TEST_CASE_P(dna3bs, alphabet_constexpr, dna3bs);
+
+TEST(dna3bs, concept_check)
+{
+    EXPECT_TRUE(NucleotideAlphabet<dna3bs>);
+    EXPECT_TRUE(NucleotideAlphabet<dna3bs &>);
+    EXPECT_TRUE(NucleotideAlphabet<dna3bs const>);
+    EXPECT_TRUE(NucleotideAlphabet<dna3bs const &>);
+}
+
+TEST(dna3bs, global_complement)
+{
+    EXPECT_EQ(complement(dna3bs{}.assign_char('A')), dna3bs{}.assign_char('T'));
+    EXPECT_EQ(complement(dna3bs{}.assign_char('C')), dna3bs{}.assign_char('A'));
+    EXPECT_EQ(complement(dna3bs{}.assign_char('G')), dna3bs{}.assign_char('T'));
+    EXPECT_EQ(complement(dna3bs{}.assign_char('T')), dna3bs{}.assign_char('A'));
+}
+
+TEST(dna3bs, to_char_assign_char)
+{
+    EXPECT_EQ(to_char(dna3bs{}.assign_char('A')), 'A');
+    EXPECT_EQ(to_char(dna3bs{}.assign_char('C')), 'T');
+    EXPECT_EQ(to_char(dna3bs{}.assign_char('G')), 'G');
+
+    EXPECT_EQ(to_char(dna3bs{}.assign_char('U')), 'T');
+    EXPECT_EQ(to_char(dna3bs{}.assign_char('T')), 'T');
+
+    EXPECT_EQ(to_char(dna3bs{}.assign_char('R')), 'A');
+    EXPECT_EQ(to_char(dna3bs{}.assign_char('Y')), 'T');
+    EXPECT_EQ(to_char(dna3bs{}.assign_char('S')), 'T');
+    EXPECT_EQ(to_char(dna3bs{}.assign_char('W')), 'A');
+    EXPECT_EQ(to_char(dna3bs{}.assign_char('K')), 'G');
+    EXPECT_EQ(to_char(dna3bs{}.assign_char('M')), 'A');
+    EXPECT_EQ(to_char(dna3bs{}.assign_char('B')), 'T');
+    EXPECT_EQ(to_char(dna3bs{}.assign_char('D')), 'A');
+    EXPECT_EQ(to_char(dna3bs{}.assign_char('H')), 'A');
+    EXPECT_EQ(to_char(dna3bs{}.assign_char('V')), 'A');
+
+    EXPECT_EQ(to_char(dna3bs{}.assign_char('N')), 'A');
+    EXPECT_EQ(to_char(dna3bs{}.assign_char('!')), 'A');
+}
+
+TEST(dna3bs, char_literal)
+{
+    EXPECT_EQ(to_char('A'_dna3bs), 'A');
+    EXPECT_EQ(to_char('C'_dna3bs), 'T');
+    EXPECT_EQ(to_char('G'_dna3bs), 'G');
+
+    EXPECT_EQ(to_char('U'_dna3bs), 'T');
+    EXPECT_EQ(to_char('T'_dna3bs), 'T');
+
+    EXPECT_EQ(to_char('R'_dna3bs), 'A');
+    EXPECT_EQ(to_char('Y'_dna3bs), 'T');
+    EXPECT_EQ(to_char('S'_dna3bs), 'T');
+    EXPECT_EQ(to_char('W'_dna3bs), 'A');
+    EXPECT_EQ(to_char('K'_dna3bs), 'G');
+    EXPECT_EQ(to_char('M'_dna3bs), 'A');
+    EXPECT_EQ(to_char('B'_dna3bs), 'T');
+    EXPECT_EQ(to_char('D'_dna3bs), 'A');
+    EXPECT_EQ(to_char('H'_dna3bs), 'A');
+    EXPECT_EQ(to_char('V'_dna3bs), 'A');
+
+    EXPECT_EQ(to_char('N'_dna3bs), 'A');
+    EXPECT_EQ(to_char('!'_dna3bs), 'A');
+}
+
+TEST(dna3bs, string_literal)
+{
+    dna3bs_vector v;
+    v.resize(5, 'A'_dna3bs);
+    EXPECT_EQ(v, "AAAAA"_dna3bs);
+
+    std::vector<dna3bs> w{'A'_dna3bs, 'C'_dna3bs, 'G'_dna3bs, 'T'_dna3bs, 'U'_dna3bs, 'N'_dna3bs};
+    EXPECT_EQ(w, "ATGTTA"_dna3bs);
+}
+
+TEST(dna3bs, char_is_valid)
+{
+    constexpr auto validator = is_char<'A'> || is_char<'G'> || is_char<'T'> || is_char<'U'>
+                            || is_char<'a'> || is_char<'g'> || is_char<'t'> || is_char<'u'>;
+    for (char c : std::view::iota(std::numeric_limits<char>::min(), std::numeric_limits<char>::max()))
+        EXPECT_EQ(dna3bs::char_is_valid(c), validator(c));
+}


### PR DESCRIPTION
This PR introduces the reduced nucleotide alphabet dna3bs that can be used when working with bisulfite converted data. The alphabet has only three letters (A, G and T) where every C gets treated as a T.
This produces of course ambiguities when thinking about the complement. Practically, it is anyways not recommended to use the complement of this alphabet (as explained in the docs). However, for completeness and in order to fulfill the nucleotide concept we introduced a complement here were T is the complement of both A and G.