### PR TITLE
[FIX] fix detection of pthread on some linuxes

### DIFF
--- a/build_system/seqan3-config.cmake
+++ b/build_system/seqan3-config.cmake
@@ -363,6 +363,24 @@ else ()
 endif ()
 
 # ----------------------------------------------------------------------------
+# thread support (pthread, windows threads)
+# ----------------------------------------------------------------------------
+
+set (THREADS_PREFER_PTHREAD_FLAG TRUE)
+find_package (Threads QUIET)
+
+if (Threads_FOUND)
+    set (SEQAN3_LIBRARIES ${SEQAN3_LIBRARIES} Threads::Threads)
+    if ("${CMAKE_THREAD_LIBS_INIT}" STREQUAL "")
+        seqan3_config_print ("Thread support:             builtin.")
+    else ()
+        seqan3_config_print ("Thread support:             via ${CMAKE_THREAD_LIBS_INIT}")
+    endif ()
+else ()
+    seqan3_config_print ("Thread support:             not found.")
+endif ()
+
+# ----------------------------------------------------------------------------
 # Require Ranges and SDSL
 # ----------------------------------------------------------------------------
 


### PR DESCRIPTION
fixes #1193 #1199

It's strange that we didn't see this earlier. I know that for macOS we don't need to explicitly add it. Apparently FreeBSD also doesn't need it, but we should have seen this on Debian, or not? Maybe not all Linuxes are affected. In any case, the proposed fix is the recommended way of doing it with CMake nowadays.