### PR TITLE
[FEATURE] our own meta library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog {#about_changelog}
+
+[TOC]
+
+This changelog contains a top-level entry for each release with sections on new features, API changes and notable
+bug-fixes (not all bug-fixes will be listed).
+See the documentation on [api stability](http://docs.seqan.de/seqan/3-master-user/about_api.html) to learn about
+when API changes are allowed.
+
+<!--
+The following API changes should be documented as such:
+  * a previously experimental interface now being marked as stable
+  * an interface being removed
+  * syntactical changes to an interface (e.g. renaming or reordering of files, functions, parameters)
+  * semantical changes to an interface (e.g. a function's result is now always one larger) [DANGEROUS!]
+
+If possible, provide tooling that performs the changes, e.g. a shell-script.
+-->
+
+# 3.0.1
+
+## New features
+
+* Traits for "metaprogramming" with `seqan3::type_list` and type packs have been added.
+
+## API changes
+
+### The `type_list` header has moved
+
+If you included `<seqan3/core/type_list.hpp>` you need to change the path to `<seqan3/core/type_list/type_list.hpp>`.
+
+## Notable Bug-fixes
+
+# 3.0.0 ("Escala")
+
+Initial release of SeqAn3.

--- a/include/seqan3/alignment/pairwise/align_result_selector.hpp
+++ b/include/seqan3/alignment/pairwise/align_result_selector.hpp
@@ -21,7 +21,7 @@
 #include <seqan3/core/type_traits/basic.hpp>
 #include <seqan3/core/type_traits/range.hpp>
 #include <seqan3/core/type_traits/transformation_trait_or.hpp>
-#include <seqan3/core/type_list.hpp>
+#include <seqan3/core/type_list/type_list.hpp>
 #include <seqan3/range/decorator/gap_decorator.hpp>
 #include <seqan3/range/view/view_all.hpp>
 #include <seqan3/std/ranges>

--- a/include/seqan3/alignment/pairwise/alignment_configurator.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_configurator.hpp
@@ -27,7 +27,7 @@
 #include <seqan3/core/type_traits/deferred_crtp_base.hpp>
 #include <seqan3/core/type_traits/range.hpp>
 #include <seqan3/core/type_traits/template_inspection.hpp>
-#include <seqan3/core/type_list.hpp>
+#include <seqan3/core/type_list/type_list.hpp>
 #include <seqan3/range/view/view_all.hpp>
 
 namespace seqan3::detail

--- a/include/seqan3/core/algorithm/configuration.hpp
+++ b/include/seqan3/core/algorithm/configuration.hpp
@@ -22,7 +22,7 @@
 #include <seqan3/core/type_traits/basic.hpp>
 #include <seqan3/core/type_traits/template_inspection.hpp>
 #include <seqan3/core/tuple_utility.hpp>
-#include <seqan3/core/type_list.hpp>
+#include <seqan3/core/type_list/type_list.hpp>
 #include <seqan3/std/concepts>
 
 namespace seqan3

--- a/include/seqan3/core/algorithm/configuration_utility.hpp
+++ b/include/seqan3/core/algorithm/configuration_utility.hpp
@@ -18,7 +18,7 @@
 #include <meta/meta.hpp>
 
 #include <seqan3/core/algorithm/concept.hpp>
-#include <seqan3/core/type_list.hpp>
+#include <seqan3/core/type_list/type_list.hpp>
 #include <seqan3/core/concept/tuple.hpp>
 
 namespace seqan3::detail

--- a/include/seqan3/core/all.hpp
+++ b/include/seqan3/core/all.hpp
@@ -26,7 +26,7 @@
 #include <seqan3/core/platform.hpp>
 #include <seqan3/core/pod_tuple.hpp>
 #include <seqan3/core/tuple_utility.hpp>
-#include <seqan3/core/type_list.hpp>
+#include <seqan3/core/type_list/type_list.hpp>
 
 /*!\defgroup core Core
  * \brief Provides core functionality used by multiple modules.

--- a/include/seqan3/core/concept/tuple.hpp
+++ b/include/seqan3/core/concept/tuple.hpp
@@ -17,7 +17,7 @@
 
 #include <seqan3/core/type_traits/basic.hpp>
 #include <seqan3/core/type_traits/template_inspection.hpp>
-#include <seqan3/core/type_list.hpp>
+#include <seqan3/core/type_list/type_list.hpp>
 #include <seqan3/core/pod_tuple.hpp>
 #include <seqan3/std/concepts>
 

--- a/include/seqan3/core/tuple_utility.hpp
+++ b/include/seqan3/core/tuple_utility.hpp
@@ -18,7 +18,7 @@
 
 #include <seqan3/core/concept/tuple.hpp>
 #include <seqan3/core/pod_tuple.hpp>
-#include <seqan3/core/type_list.hpp>
+#include <seqan3/core/type_list/type_list.hpp>
 #include <seqan3/core/type_traits/basic.hpp>
 #include <seqan3/core/type_traits/template_inspection.hpp>
 

--- a/include/seqan3/core/type_list.hpp
+++ b/include/seqan3/core/type_list.hpp
@@ -7,7 +7,7 @@
 
 /*!\file
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
- * \brief Provides seqan3::type_list and auxiliary type traits.
+ * \brief Provides seqan3::type_list.
  */
 
 #pragma once
@@ -18,6 +18,10 @@
 
 namespace seqan3
 {
+
+// ----------------------------------------------------------------------------
+// type_list class
+// ----------------------------------------------------------------------------
 
 /*!\brief Type that contains multiple types, an alias for
  * [meta::list](https://ericniebler.github.io/range-v3/structmeta_1_1list.html).
@@ -30,6 +34,10 @@ using type_list = meta::list<types...>;
 
 namespace seqan3::detail
 {
+
+// ----------------------------------------------------------------------------
+// TypeList concept
+// ----------------------------------------------------------------------------
 
 /*!\brief Auxiliary concept that checks whether a type is a specialisation of seqan3::type_list.
  * \ingroup core

--- a/include/seqan3/core/type_list/all.hpp
+++ b/include/seqan3/core/type_list/all.hpp
@@ -1,0 +1,36 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
+ * \brief Provides seqan3::type_list and metaprogramming utilities.
+ */
+
+#pragma once
+
+#include <seqan3/core/type_list/type_list.hpp>
+#include <seqan3/core/type_list/traits.hpp>
+
+/*!\defgroup type_list Type List
+ * \brief Provides seqan3::type_list and metaprogramming utilities for working on type lists and type packs.
+ * \ingroup core
+ *
+ * \details
+ *
+ * All traits are defined in the header `<seqan3/core/type_list/traits.hpp>`.
+ *
+ */
+
+/*!\namespace seqan3::pack_traits
+ * \brief Namespace containing traits for working on type packs.
+ * \ingroup type_list
+ */
+
+/*!\namespace seqan3::list_traits
+ * \brief Namespace containing traits for working on seqan3::type_list.
+ * \ingroup type_list
+ */

--- a/include/seqan3/core/type_list/traits.hpp
+++ b/include/seqan3/core/type_list/traits.hpp
@@ -1,0 +1,552 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
+ * \brief Provides traits for seqan3::type_list.
+ */
+
+#pragma once
+
+#include <seqan3/core/type_list.hpp>
+
+// ----------------------------------------------------------------------------
+// seqan3::pack_traits::detail
+// ----------------------------------------------------------------------------
+
+namespace seqan3::pack_traits::detail
+{
+
+/*!\brief Implementation for seqan3::pack_traits::at.
+ * \tparam idx      The index.
+ * \tparam head_t   Currently viewed pack_t element.
+ * \tparam tail_t   Rest of the type pack.
+ * \ingroup type_list
+ */
+template <ptrdiff_t idx, typename head_t, typename ...tail_t>
+auto at()
+{
+    if constexpr (idx == 0)
+        return std::type_identity<head_t>{};
+    else if constexpr (idx > 0)
+#if __clang__
+        return std::type_identity<__type_pack_element<idx - 1, tail_t...>>;
+#else
+        return at<idx - 1, tail_t...>();
+#endif // __clang__
+    else
+        return at<sizeof...(tail_t) + 1 + idx, head_t, tail_t...>();
+}
+
+/*!\brief Implementation for seqan3::pack_traits::front.
+ * \tparam head_t   Currently viewed pack_t element.
+ * \tparam tail_t   Rest of the type pack.
+ * \ingroup type_list
+ */
+template <typename head_t, typename ...tail_t>
+std::type_identity<head_t> front();
+
+/*!\brief Implementation for seqan3::pack_traits::drop_front.
+ * \tparam head_t   Currently viewed pack_t element.
+ * \tparam tail_t   Rest of the type pack.
+ * \ingroup type_list
+ */
+template <typename head_t, typename ...tail_t>
+type_list<tail_t...> drop_front();
+
+} // namespace seqan3::pack_traits::detail
+
+// ----------------------------------------------------------------------------
+// seqan3::pack_traits
+// ----------------------------------------------------------------------------
+
+namespace seqan3::pack_traits
+{
+
+/*!\name Type pack traits (return a value)
+ * \{
+ */
+
+/*!\brief The size of a type pack.
+ * \tparam pack_t The type pack.
+ * \returns `sizeof...(pack_t)`
+ * \ingroup type_list
+ *
+ * \details
+ *
+ * ### (Compile-time) Complexity
+ *
+ * Constant
+ */
+template <typename ...pack_t>
+inline constexpr size_t size = sizeof...(pack_t);
+
+//!\}
+
+/*!\name Type pack traits (return a single type)
+ * \{
+ */
+
+/*!\brief Return the type at given index from the type pack.
+ * \tparam idx    The index; must be smaller than the size of the pack.
+ * \tparam pack_t The type pack.
+ * \ingroup type_list
+ *
+ * \details
+ *
+ * Negative indexes are supported (e.g. `at<-1, int, double, bool &>` is `bool &`).
+ *
+ * ### (Compile-time) Complexity
+ *
+ * Equal to `idx` (linear).
+ */
+template <ptrdiff_t idx, typename ...pack_t>
+//!\cond
+    requires (idx >= 0 && idx < sizeof...(pack_t)) ||
+             (-idx <= sizeof...(pack_t))
+//!\endcond
+using at = typename decltype(detail::at<idx, pack_t...>())::type;
+
+/*!\brief Return the first type from the type pack.
+ * \tparam pack_t The type pack.
+ * \ingroup type_list
+ *
+ * \details
+ *
+ * ### (Compile-time) Complexity
+ *
+ * Constant.
+ */
+template <typename ...pack_t>
+//!\cond
+    requires (sizeof...(pack_t) > 0)
+//!\endcond
+using front = typename decltype(detail::front<pack_t...>())::type;
+
+/*!\brief Return the last type from the type pack.
+ * \tparam pack_t The type pack.
+ * \ingroup type_list
+ *
+ * \details
+ *
+ * ### (Compile-time) Complexity
+ *
+ * Constant.
+ */
+template <typename ...pack_t>
+//!\cond
+    requires (sizeof...(pack_t) > 0)
+//!\endcond
+using back = typename decltype((std::type_identity<pack_t>{}, ...))::type; // use comma operator
+
+//!\}
+
+/*!\name Type pack traits (return a type list)
+ * \{
+ */
+
+/*!\brief Return a seqan3::type_list of all the types in the type pack, except the first.
+ * \tparam pack_t The type pack.
+ * \ingroup type_list
+ *
+ * \details
+ *
+ * ### (Compile-time) Complexity
+ *
+ * Constant.
+ */
+template <typename ...pack_t>
+//!\cond
+    requires (sizeof...(pack_t) > 0)
+//!\endcond
+using drop_front = typename decltype(detail::drop_front<pack_t...>())::type;
+
+//!\}
+
+} // namespace seqan3::pack_traits
+
+// ----------------------------------------------------------------------------
+// seqan3::list_traits
+// ----------------------------------------------------------------------------
+
+namespace seqan3::list_traits::detail
+{
+
+/*!\brief Implementation for seqan3::list_traits::at.
+ * \tparam idx      The index.
+ * \tparam pack_t   Types in the type list.
+ * \ingroup type_list
+ */
+template <ptrdiff_t idx, typename ...pack_t>
+std::type_identity<seqan3::pack_traits::at<idx, pack_t...>> at(type_list<pack_t...>);
+
+/*!\brief Implementation for seqan3::list_traits::front.
+ * \tparam pack_t   Types in the type list.
+ * \ingroup type_list
+ */
+template <typename ...pack_t>
+std::type_identity<seqan3::pack_traits::front<pack_t...>> front(type_list<pack_t...>);
+
+/*!\brief Implementation for seqan3::list_traits::back.
+ * \tparam pack_t   Types in the type list.
+ * \ingroup type_list
+ */
+template <typename ...pack_t>
+std::type_identity<seqan3::pack_traits::back<pack_t...>> back(type_list<pack_t...>);
+
+/*!\brief Implementation for seqan3::list_traits::concat.
+ * \tparam pack1_t   Types in the first type list.
+ * \tparam pack2_t   Types in the second type list.
+ * \ingroup type_list
+ */
+template <typename ...pack1_t,
+          typename ...pack2_t>
+type_list<pack1_t..., pack2_t...> concat(type_list<pack1_t...>, type_list<pack2_t...>);
+
+/*!\brief Implementation for seqan3::list_traits::drop_front.
+ * \tparam pack_t   Types in the type list.
+ * \ingroup type_list
+ */
+template <typename ...pack_t>
+seqan3::pack_traits::drop_front<pack_t...> drop_front(type_list<pack_t...>);
+
+/*!\brief Implementation for take, drop, take_last and drop_last in seqan3::list_traits.
+ * \tparam idx       The index after which to split.
+ * \tparam pack1_t   Types in the first type list.
+ * \tparam head_t    Head of the second type list.
+ * \tparam pack2_t   Rest of the second type list.
+ * \ingroup type_list
+ */
+template <ptrdiff_t idx,
+          typename ...pack1_t,
+          typename head_t, typename ...pack2_t>
+auto split_after(type_list<pack1_t...>, type_list<head_t, pack2_t...>)
+{
+    if constexpr (idx == sizeof...(pack2_t) + 1)
+        return std::pair<type_list<pack1_t..., head_t, pack2_t...>, type_list<>>{};
+    else if constexpr (idx == 0)
+        return std::pair<type_list<pack1_t...>, type_list<head_t, pack2_t...>>{};
+    else
+        return split_after<idx - 1>(type_list<pack1_t..., head_t>{}, type_list<pack2_t...>{});
+}
+
+} // namespace seqan3::list_traits::detail
+
+// ----------------------------------------------------------------------------
+// seqan3::list_traits
+// ----------------------------------------------------------------------------
+
+//TODO think about whether the TypeList concept check is expensive and necessary
+
+//!\brief Namespace containing traits for working on seqan3::type_list.
+namespace seqan3::list_traits
+{
+
+//!\cond
+template <seqan3::detail::TypeList list_t>
+inline constexpr size_t size = 0;
+//!\endcond
+
+/*!\name Type list traits (return a value)
+ * \{
+ */
+
+/*!\brief The size of a type list.
+ * \tparam pack_t Types in the list.
+ * \returns `sizeof...(pack_t)`
+ * \ingroup type_list
+ *
+ * \details
+ *
+ * ### (Compile-time) Complexity
+ *
+ * Constant
+ */
+template <typename ...pack_t>
+inline constexpr size_t size<type_list<pack_t...>> = sizeof...(pack_t);
+
+//!\}
+
+/*!\name Type list traits (return a single type)
+ * \{
+ */
+
+/*!\brief Return the type at given index from the type list.
+ * \tparam idx    The index; must be smaller than the size of the type list.
+ * \tparam list_t The type_list.
+ * \ingroup type_list
+ *
+ * \details
+ *
+ * Negative indexes are supported (e.g. `at<-1, type_list<int, double, bool &>>` is `bool &`).
+ *
+ * ### (Compile-time) Complexity
+ *
+ * Equal to `idx` (linear).
+ */
+template <ptrdiff_t idx, seqan3::detail::TypeList list_t>
+//!\cond
+    requires (idx >= 0 && idx < size<list_t>) || (-idx <= size<list_t>)
+//!\endcond
+using at = typename decltype(detail::at<idx>(list_t{}))::type;
+
+/*!\brief Return the first type from the type list.
+ * \tparam list_t The type list.
+ * \ingroup type_list
+ *
+ * \details
+ *
+ * ### (Compile-time) Complexity
+ *
+ * Constant.
+ */
+template <seqan3::detail::TypeList list_t>
+//!\cond
+    requires (size<list_t> > 0)
+//!\endcond
+using front = typename decltype(detail::front(list_t{}))::type;
+
+/*!\brief Return the last type from the type list.
+ * \tparam list_t The type list.
+ * \ingroup type_list
+ *
+ * \details
+ *
+ * ### (Compile-time) Complexity
+ *
+ * Constant.
+ */
+template <seqan3::detail::TypeList list_t>
+//!\cond
+    requires (size<list_t> > 0)
+//!\endcond
+using back = typename decltype(detail::back(list_t{}))::type;
+
+//!\}
+
+/*!\name Type list traits (return a type list)
+ * \{
+ */
+
+/*!\brief Join two seqan3::type_list s into one.
+ * \tparam list1_t The first (input) type list.
+ * \tparam list2_t The second (input) type list.
+ * \ingroup type_list
+ *
+ * \details
+ *
+ * ### (Compile-time) Complexity
+ *
+ * Constant.
+ */
+template <seqan3::detail::TypeList list1_t, seqan3::detail::TypeList list2_t>
+using concat = decltype(detail::concat(list1_t{}, list2_t{}));
+
+/*!\brief Return a seqan3::type_list of all the types in the type list, except the first.
+ * \tparam list_t The (input) type list.
+ * \ingroup type_list
+ *
+ * \details
+ *
+ * ### (Compile-time) Complexity
+ *
+ * Constant.
+ */
+template <seqan3::detail::TypeList list_t>
+//!\cond
+    requires (size<list_t> > 0)
+//!\endcond
+using drop_front = decltype(detail::drop_front(list_t{}));
+
+/*!\brief Return a seqan3::type_list of the first `n` types in the input type list.
+ * \tparam n        The target size; must be >= 0 and <= the size of the input type list.
+ * \tparam list_t   The (input) type list.
+ * \ingroup type_list
+ *
+ * \details
+ *
+ * ### (Compile-time) Complexity
+ *
+ * Equal to `n` (linear).
+ */
+template <ptrdiff_t n, seqan3::detail::TypeList list_t>
+//!\cond
+    requires (n >= 0 && n <= size<list_t>)
+//!\endcond
+using take = typename decltype(detail::split_after<n>(type_list<>{}, list_t{}))::first_type;
+
+/*!\brief Return a seqan3::type_list of the types in the input type list, except the first `n`.
+ * \tparam n        The amount to drop; must be >= 0 and <= the size of the input type list.
+ * \tparam list_t   The (input) type list.
+ * \ingroup type_list
+ *
+ * \details
+ *
+ * ### (Compile-time) Complexity
+ *
+ * Equal to `n` (linear).
+ */
+template <ptrdiff_t n, seqan3::detail::TypeList list_t>
+//!\cond
+    requires (n >= 0 && n <= size<list_t>)
+//!\endcond
+using drop = typename decltype(detail::split_after<n>(type_list<>{}, list_t{}))::second_type;
+
+/*!\brief Return a seqan3::type_list of the last `n` types in the input type list.
+ * \tparam n        The target size; must be >= 0 and <= the size of the input type list.
+ * \tparam list_t   The (input) type list.
+ * \ingroup type_list
+ *
+ * \details
+ *
+ * ### (Compile-time) Complexity
+ *
+ * Equal to `size<list_t> - n` (linear).
+ */
+template <ptrdiff_t n, seqan3::detail::TypeList list_t>
+//!\cond
+    requires (n >= 0 && n <= size<list_t>)
+//!\endcond
+using take_last = drop<size<list_t> - n, list_t>;
+
+/*!\brief Return a seqan3::type_list of the types the input type list, except the last `n`.
+ * \tparam n        The amount to drop; must be >= 0 and <= the size of the input type list.
+ * \tparam list_t   The (input) type list.
+ * \ingroup type_list
+ *
+ * \details
+ *
+ * ### (Compile-time) Complexity
+ *
+ * Equal to `size<list_t> - n` (linear).
+ */
+template <ptrdiff_t n, seqan3::detail::TypeList list_t>
+//!\cond
+    requires (n >= 0 && n <= size<list_t>)
+//!\endcond
+using drop_last = take<size<list_t> - n, list_t>;
+
+/*!\brief Split a seqan3::type_list into two parts returned as a pair of seqan3::type_list.
+ * \tparam n        The number of elements after which to split; must be >= 0 and <= the size of the input type list.
+ * \tparam list_t   The (input) type list.
+ * \ingroup type_list
+ *
+ * \details
+ *
+ * ### (Compile-time) Complexity
+ *
+ * Equal to `n` (linear).
+ */
+template <ptrdiff_t n, seqan3::detail::TypeList list_t>
+//!\cond
+    requires (n >= 0 && n <= size<list_t>)
+//!\endcond
+using split_after = decltype(detail::split_after<n>(type_list<>{}, list_t{}));
+
+//!\}
+
+} // namespace seqan3::list_traits
+
+// ----------------------------------------------------------------------------
+// seqan3::pack_traits that depend on list_traits
+// ----------------------------------------------------------------------------
+
+namespace seqan3::pack_traits
+{
+
+/*!\name Type pack traits (return a type list)
+ * \{
+ */
+
+/*!\brief Return a seqan3::type_list of the first `n` types in the type pack.
+ * \tparam n        The target size; must be >= 0 and <= the size of the type pack.
+ * \tparam pack_t   The type pack.
+ * \ingroup type_list
+ *
+ * \details
+ *
+ * ### (Compile-time) Complexity
+ *
+ * Equal to `n` (linear).
+ */
+template <ptrdiff_t n, typename ...pack_t>
+//!\cond
+    requires (n >= 0 && n <= sizeof...(pack_t))
+//!\endcond
+using take = seqan3::list_traits::take<n, type_list<pack_t...>>;
+
+/*!\brief Return a seqan3::type_list of the types in the type pack, except the first `n`.
+ * \tparam n        The amount to drop; must be >= 0 and <= the size of the type pack.
+ * \tparam pack_t   The type pack.
+ * \ingroup type_list
+ *
+ * \details
+ *
+ * ### (Compile-time) Complexity
+ *
+ * Equal to `n` (linear).
+ */
+template <ptrdiff_t n, typename ...pack_t>
+//!\cond
+    requires (n >= 0 && n <= sizeof...(pack_t))
+//!\endcond
+using drop = seqan3::list_traits::drop<n, type_list<pack_t...>>;
+
+/*!\brief Return a seqan3::type_list of the last `n` types in the type pack.
+ * \tparam n        The target size; must be >= 0 and <= the size of the type pack.
+ * \tparam pack_t   The type pack.
+ * \ingroup type_list
+ *
+ * \details
+ *
+ * ### (Compile-time) Complexity
+ *
+ * Equal to `sizeof...(pack_t) - n` (linear).
+ */
+template <ptrdiff_t n, typename ...pack_t>
+//!\cond
+    requires (n >= 0 && n <= sizeof...(pack_t))
+//!\endcond
+using take_last = seqan3::list_traits::take_last<n, type_list<pack_t...>>;
+
+/*!\brief Return a seqan3::type_list of the types the type pack, except the last `n`.
+ * \tparam n        The amount to drop; must be >= 0 and <= the size of the type pack.
+ * \tparam pack_t   The type pack.
+ * \ingroup type_list
+ *
+ * \details
+ *
+ * ### (Compile-time) Complexity
+ *
+ * Equal to `sizeof...(pack_t) - n (linear).
+ */
+template <ptrdiff_t n, typename ...pack_t>
+//!\cond
+    requires (n >= 0 && n <= sizeof...(pack_t))
+//!\endcond
+using drop_last = seqan3::list_traits::drop_last<n, type_list<pack_t...>>;
+
+/*!\brief Split a type pack into two parts returned as a pair of seqan3::type_list.
+ * \tparam n        The number of elements after which to split; must be >= 0 and <= the size of the type pack.
+ * \tparam pack_t   The type pack.
+ * \ingroup type_list
+ *
+ * \details
+ *
+ * ### (Compile-time) Complexity
+ *
+ * Equal to `n` (linear).
+ */
+template <ptrdiff_t n, typename ...pack_t>
+//!\cond
+    requires (n >= 0 && n <= sizeof...(pack_t))
+//!\endcond
+using split_after = seqan3::list_traits::split_after<n, type_list<pack_t...>>;
+
+//!\}
+
+} // namespace seqan3::pack_traits

--- a/include/seqan3/core/type_list/traits.hpp
+++ b/include/seqan3/core/type_list/traits.hpp
@@ -12,7 +12,7 @@
 
 #pragma once
 
-#include <seqan3/core/type_list.hpp>
+#include <seqan3/core/type_list/type_list.hpp>
 
 // ----------------------------------------------------------------------------
 // seqan3::pack_traits::detail

--- a/include/seqan3/core/type_list/type_list.hpp
+++ b/include/seqan3/core/type_list/type_list.hpp
@@ -25,7 +25,7 @@ namespace seqan3
 
 /*!\brief Type that contains multiple types, an alias for
  * [meta::list](https://ericniebler.github.io/range-v3/structmeta_1_1list.html).
- * \ingroup core
+ * \ingroup type_list
  */
 template <typename ... types>
 using type_list = meta::list<types...>;
@@ -40,7 +40,7 @@ namespace seqan3::detail
 // ----------------------------------------------------------------------------
 
 /*!\brief Auxiliary concept that checks whether a type is a specialisation of seqan3::type_list.
- * \ingroup core
+ * \ingroup type_list
  */
 template <typename t>
 SEQAN3_CONCEPT TypeList = is_type_specialisation_of_v<t, type_list>;

--- a/include/seqan3/io/alignment_file/input_format_concept.hpp
+++ b/include/seqan3/io/alignment_file/input_format_concept.hpp
@@ -21,7 +21,7 @@
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
 #include <seqan3/alphabet/quality/aliases.hpp>
 #include <seqan3/alphabet/quality/phred42.hpp>
-#include <seqan3/core/type_list.hpp>
+#include <seqan3/core/type_list/type_list.hpp>
 #include <seqan3/io/alignment_file/header.hpp>
 #include <seqan3/io/alignment_file/input_options.hpp>
 #include <seqan3/io/alignment_file/sam_tag_dictionary.hpp>

--- a/include/seqan3/io/alignment_file/output_format_concept.hpp
+++ b/include/seqan3/io/alignment_file/output_format_concept.hpp
@@ -20,7 +20,7 @@
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
 #include <seqan3/alphabet/quality/aliases.hpp>
 #include <seqan3/alphabet/quality/phred42.hpp>
-#include <seqan3/core/type_list.hpp>
+#include <seqan3/core/type_list/type_list.hpp>
 #include <seqan3/io/alignment_file/header.hpp>
 #include <seqan3/io/alignment_file/output_options.hpp>
 #include <seqan3/io/alignment_file/sam_tag_dictionary.hpp>

--- a/include/seqan3/io/detail/misc.hpp
+++ b/include/seqan3/io/detail/misc.hpp
@@ -15,7 +15,7 @@
 #include <variant>
 
 #include <seqan3/core/type_traits/template_inspection.hpp>
-#include <seqan3/core/type_list.hpp>
+#include <seqan3/core/type_list/type_list.hpp>
 #include <seqan3/io/exception.hpp>
 #include <seqan3/io/sequence_file/input_format_concept.hpp>
 #include <seqan3/std/algorithm>

--- a/include/seqan3/io/record.hpp
+++ b/include/seqan3/io/record.hpp
@@ -16,7 +16,7 @@
 
 #include <meta/meta.hpp>
 
-#include <seqan3/core/type_list.hpp>
+#include <seqan3/core/type_list/type_list.hpp>
 #include <seqan3/core/type_traits/template_inspection.hpp>
 
 namespace seqan3

--- a/include/seqan3/io/sequence_file/input_format_concept.hpp
+++ b/include/seqan3/io/sequence_file/input_format_concept.hpp
@@ -20,7 +20,7 @@
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
 #include <seqan3/alphabet/quality/aliases.hpp>
 #include <seqan3/alphabet/quality/phred42.hpp>
-#include <seqan3/core/type_list.hpp>
+#include <seqan3/core/type_list/type_list.hpp>
 #include <seqan3/io/sequence_file/input_options.hpp>
 
 namespace seqan3::detail

--- a/include/seqan3/io/sequence_file/output_format_concept.hpp
+++ b/include/seqan3/io/sequence_file/output_format_concept.hpp
@@ -19,7 +19,7 @@
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
 #include <seqan3/alphabet/quality/aliases.hpp>
 #include <seqan3/alphabet/quality/phred42.hpp>
-#include <seqan3/core/type_list.hpp>
+#include <seqan3/core/type_list/type_list.hpp>
 #include <seqan3/io/sequence_file/output_options.hpp>
 
 namespace seqan3::detail

--- a/include/seqan3/io/structure_file/input_format_concept.hpp
+++ b/include/seqan3/io/structure_file/input_format_concept.hpp
@@ -21,7 +21,7 @@
 #include <seqan3/alphabet/nucleotide/rna5.hpp>
 #include <seqan3/alphabet/structure/structured_rna.hpp>
 #include <seqan3/alphabet/structure/wuss.hpp>
-#include <seqan3/core/type_list.hpp>
+#include <seqan3/core/type_list/type_list.hpp>
 #include <seqan3/io/structure_file/input_options.hpp>
 
 namespace seqan3::detail

--- a/include/seqan3/io/structure_file/output_format_concept.hpp
+++ b/include/seqan3/io/structure_file/output_format_concept.hpp
@@ -19,7 +19,7 @@
 
 #include <seqan3/alphabet/nucleotide/rna5.hpp>
 #include <seqan3/alphabet/structure/all.hpp>
-#include <seqan3/core/type_list.hpp>
+#include <seqan3/core/type_list/type_list.hpp>
 #include <seqan3/io/structure_file/output_options.hpp>
 
 namespace seqan3::detail

--- a/test/documentation/DoxygenLayout.xml
+++ b/test/documentation/DoxygenLayout.xml
@@ -28,6 +28,7 @@
         </tab>
         <tab type="usergroup" visible="yes" title="About" intro="">
             <tab type="user" visible="yes" title="API/ABI stability"    url="\ref about_api"           intro=""/>
+            <tab type="user" visible="yes" title="Changelog"            url="\ref about_changelog"     intro=""/>
             <tab type="user" visible="yes" title="Citing"               url="\ref about_citing"        intro=""/>
             <tab type="user" visible="yes" title="Copyright"            url="\ref about_copyright"     intro=""/>
             <tab type="user" visible="yes" title="Code of Conduct"      url="\ref about_code_of_conduct" intro=""/>

--- a/test/documentation/seqan3_doxygen_cfg.in
+++ b/test/documentation/seqan3_doxygen_cfg.in
@@ -9,6 +9,7 @@ INCLUDE_PATH           = ${SEQAN3_DOXYGEN_SOURCE_DIR}/include
 INPUT                  = ${SEQAN3_DOXYGEN_SOURCE_DIR}/include               \
                          ${SEQAN3_DOXYGEN_SOURCE_DIR}/doc                   \
                          ${SEQAN3_DOXYGEN_SOURCE_DIR}/LICENSE.md            \
+                         ${SEQAN3_DOXYGEN_SOURCE_DIR}/CHANGELOG.md          \
                          ${SEQAN3_DOXYGEN_SOURCE_DIR}/CODE_OF_CONDUCT.md    \
                          ${SEQAN3_DOXYGEN_SOURCE_DIR}/CONTRIBUTING.md
 STRIP_FROM_PATH        = ${SEQAN3_DOXYGEN_SOURCE_DIR}/include

--- a/test/snippet/core/algorithm/for_each_type_list.cpp
+++ b/test/snippet/core/algorithm/for_each_type_list.cpp
@@ -2,7 +2,7 @@
 #include <string>
 
 #include <seqan3/core/algorithm/parameter_pack.hpp>
-#include <seqan3/core/type_list.hpp>
+#include <seqan3/core/type_list/type_list.hpp>
 #include <seqan3/core/debug_stream.hpp>
 
 using namespace seqan3;

--- a/test/unit/alignment/scoring_scheme_test.cpp
+++ b/test/unit/alignment/scoring_scheme_test.cpp
@@ -17,7 +17,7 @@
 #include <seqan3/alphabet/aminoacid/all.hpp>
 #include <seqan3/alphabet/nucleotide/all.hpp>
 #include <seqan3/alphabet/quality/all.hpp>
-#include <seqan3/core/type_list.hpp>
+#include <seqan3/core/type_list/type_list.hpp>
 #include <seqan3/test/cereal.hpp>
 
 using namespace seqan3;

--- a/test/unit/alphabet/aminoacid/aminoacid_conversion_integration_test.cpp
+++ b/test/unit/alphabet/aminoacid/aminoacid_conversion_integration_test.cpp
@@ -10,7 +10,7 @@
 #include <meta/meta.hpp>
 
 #include <seqan3/alphabet/aminoacid/all.hpp>
-#include <seqan3/core/type_list.hpp>
+#include <seqan3/core/type_list/type_list.hpp>
 
 using namespace seqan3;
 

--- a/test/unit/alphabet/nucleotide/nucleotide_conversion_integration_test.cpp
+++ b/test/unit/alphabet/nucleotide/nucleotide_conversion_integration_test.cpp
@@ -10,7 +10,7 @@
 #include <meta/meta.hpp>
 
 #include <seqan3/alphabet/nucleotide/all.hpp>
-#include <seqan3/core/type_list.hpp>
+#include <seqan3/core/type_list/type_list.hpp>
 
 using namespace seqan3;
 

--- a/test/unit/core/algorithm/parameter_pack_test.cpp
+++ b/test/unit/core/algorithm/parameter_pack_test.cpp
@@ -9,7 +9,7 @@
 
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/core/algorithm/parameter_pack.hpp>
-#include <seqan3/core/type_list.hpp>
+#include <seqan3/core/type_list/type_list.hpp>
 
 using namespace seqan3;
 

--- a/test/unit/core/simd/detail/builtin_simd_test.cpp
+++ b/test/unit/core/simd/detail/builtin_simd_test.cpp
@@ -10,7 +10,7 @@
 #include <seqan3/core/algorithm/parameter_pack.hpp>
 #include <seqan3/core/simd/concept.hpp>
 #include <seqan3/core/simd/detail/builtin_simd.hpp>
-#include <seqan3/core/type_list.hpp>
+#include <seqan3/core/type_list/type_list.hpp>
 #include <seqan3/std/type_traits>
 
 #include <iostream>

--- a/test/unit/core/type_list_test.cpp
+++ b/test/unit/core/type_list_test.cpp
@@ -9,7 +9,7 @@
 
 #include <gtest/gtest.h>
 
-#include <seqan3/core/type_list.hpp>
+#include <seqan3/core/type_list/type_list.hpp>
 #include <seqan3/core/type_list/traits.hpp>
 
 using namespace seqan3;

--- a/test/unit/core/type_list_test.cpp
+++ b/test/unit/core/type_list_test.cpp
@@ -10,6 +10,7 @@
 #include <gtest/gtest.h>
 
 #include <seqan3/core/type_list.hpp>
+#include <seqan3/core/type_list/traits.hpp>
 
 using namespace seqan3;
 
@@ -18,4 +19,206 @@ TEST(type_list, basic)
     using t = type_list<int, char, double>;
 
     EXPECT_TRUE((std::is_same_v<meta::at_c<t, 1>, char>));
+}
+
+// ----------------------------------------------------------------------------
+// pack tests
+// ----------------------------------------------------------------------------
+
+TEST(pack_traits, size)
+{
+    EXPECT_EQ((pack_traits::size<int, bool &, double const>),
+               3u);
+}
+
+TEST(pack_traits, at)
+{
+    EXPECT_TRUE((std::is_same_v<pack_traits::at<2, int, bool &, double const, long, float>,
+                                double const>));
+    EXPECT_TRUE((std::is_same_v<pack_traits::at<-2, int, bool &, double const, long, float>,
+                                long>));
+}
+
+TEST(pack_traits, front)
+{
+    EXPECT_TRUE((std::is_same_v<pack_traits::front<int, bool &, double const, long, float>,
+                                int>));
+}
+
+TEST(pack_traits, back)
+{
+    EXPECT_TRUE((std::is_same_v<pack_traits::back<int, bool &, double const, long, float>,
+                                float>));
+}
+
+TEST(pack_traits, drop_front)
+{
+    EXPECT_TRUE((std::is_same_v<pack_traits::drop_front<int, bool &, double const, long, float>,
+                                type_list<bool &, double const, long, float>>));
+}
+
+TEST(pack_traits, take)
+{
+    EXPECT_TRUE((std::is_same_v<pack_traits::take<0, int, bool &, double const, long, float>,
+                                type_list<>>));
+    EXPECT_TRUE((std::is_same_v<pack_traits::take<3, int, bool &, double const, long, float>,
+                                type_list<int, bool &, double const>>));
+    EXPECT_TRUE((std::is_same_v<pack_traits::take<5, int, bool &, double const, long, float>,
+                                type_list<int, bool &, double const, long, float>>));
+}
+
+TEST(pack_traits, drop)
+{
+    EXPECT_TRUE((std::is_same_v<pack_traits::drop<0, int, bool &, double const, long, float>,
+                                type_list<int, bool &, double const, long, float>>));
+    EXPECT_TRUE((std::is_same_v<pack_traits::drop<3, int, bool &, double const, long, float>,
+                                type_list<long, float>>));
+    EXPECT_TRUE((std::is_same_v<pack_traits::drop<5, int, bool &, double const, long, float>,
+                                type_list<>>));
+}
+
+TEST(pack_traits, take_last)
+{
+    EXPECT_TRUE((std::is_same_v<pack_traits::take_last<0, int, bool &, double const, long, float>,
+                                type_list<>>));
+    EXPECT_TRUE((std::is_same_v<pack_traits::take_last<3, int, bool &, double const, long, float>,
+                                type_list<double const, long, float>>));
+    EXPECT_TRUE((std::is_same_v<pack_traits::take_last<5, int, bool &, double const, long, float>,
+                                type_list<int, bool &, double const, long, float>>));
+}
+
+TEST(pack_traits, drop_last)
+{
+    EXPECT_TRUE((std::is_same_v<pack_traits::drop_last<0, int, bool &, double const, long, float>,
+                                type_list<int, bool &, double const, long, float>>));
+    EXPECT_TRUE((std::is_same_v<pack_traits::drop_last<3, int, bool &, double const, long, float>,
+                                type_list<int, bool &>>));
+    EXPECT_TRUE((std::is_same_v<pack_traits::drop_last<5, int, bool &, double const, long, float>,
+                                type_list<>>));
+}
+
+TEST(pack_traits, split_after)
+{
+    using split0 = pack_traits::split_after<0, int, bool &, double const, long, float>;
+    EXPECT_TRUE((std::is_same_v<typename split0::first_type,
+                                type_list<>>));
+    EXPECT_TRUE((std::is_same_v<typename split0::second_type,
+                                type_list<int, bool &, double const, long, float>>));
+
+    using split3 = pack_traits::split_after<3, int, bool &, double const, long, float>;
+    EXPECT_TRUE((std::is_same_v<typename split3::first_type,
+                                type_list<int, bool &, double const>>));
+    EXPECT_TRUE((std::is_same_v<typename split3::second_type,
+                                type_list<long, float>>));
+
+
+    using split5 = pack_traits::split_after<5, int, bool &, double const, long, float>;
+    EXPECT_TRUE((std::is_same_v<typename split5::first_type,
+                                type_list<int, bool &, double const, long, float>>));
+    EXPECT_TRUE((std::is_same_v<typename split5::second_type,
+                                type_list<>>));
+}
+
+// ----------------------------------------------------------------------------
+// list tests
+// ----------------------------------------------------------------------------
+
+TEST(list_traits, size)
+{
+    EXPECT_EQ((list_traits::size<type_list<int, bool &, double const>>),
+               3u);
+}
+
+TEST(list_traits, at)
+{
+    EXPECT_TRUE((std::is_same_v<list_traits::at<2, type_list<int, bool &, double const, long, float>>,
+                                double const>));
+    EXPECT_TRUE((std::is_same_v<list_traits::at<-2, type_list<int, bool &, double const, long, float>>,
+                                long>));
+}
+
+TEST(list_traits, front)
+{
+    EXPECT_TRUE((std::is_same_v<list_traits::front<type_list<int, bool &, double const, long, float>>,
+                                int>));
+}
+
+TEST(list_traits, back)
+{
+    EXPECT_TRUE((std::is_same_v<list_traits::back<type_list<int, bool &, double const, long, float>>,
+                                float>));
+}
+
+TEST(list_traits, concat)
+{
+    EXPECT_TRUE((std::is_same_v<list_traits::concat<type_list<int, bool &, double const>, type_list<long, float>>,
+                                type_list<int, bool &, double const, long, float>>));
+}
+
+TEST(list_traits, drop_front)
+{
+    EXPECT_TRUE((std::is_same_v<list_traits::drop_front<type_list<int, bool &, double const, long, float>>,
+                                type_list<bool &, double const, long, float>>));
+}
+
+TEST(list_traits, take)
+{
+    EXPECT_TRUE((std::is_same_v<list_traits::take<0, type_list<int, bool &, double const, long, float>>,
+                                type_list<>>));
+    EXPECT_TRUE((std::is_same_v<list_traits::take<3, type_list<int, bool &, double const, long, float>>,
+                                type_list<int, bool &, double const>>));
+    EXPECT_TRUE((std::is_same_v<list_traits::take<5, type_list<int, bool &, double const, long, float>>,
+                                type_list<int, bool &, double const, long, float>>));
+}
+
+TEST(list_traits, drop)
+{
+    EXPECT_TRUE((std::is_same_v<list_traits::drop<0, type_list<int, bool &, double const, long, float>>,
+                                type_list<int, bool &, double const, long, float>>));
+    EXPECT_TRUE((std::is_same_v<list_traits::drop<3, type_list<int, bool &, double const, long, float>>,
+                                type_list<long, float>>));
+    EXPECT_TRUE((std::is_same_v<list_traits::drop<5, type_list<int, bool &, double const, long, float>>,
+                                type_list<>>));
+}
+
+TEST(list_traits, take_last)
+{
+    EXPECT_TRUE((std::is_same_v<list_traits::take_last<0, type_list<int, bool &, double const, long, float>>,
+                                type_list<>>));
+    EXPECT_TRUE((std::is_same_v<list_traits::take_last<3, type_list<int, bool &, double const, long, float>>,
+                                type_list<double const, long, float>>));
+    EXPECT_TRUE((std::is_same_v<list_traits::take_last<5, type_list<int, bool &, double const, long, float>>,
+                                type_list<int, bool &, double const, long, float>>));
+}
+
+TEST(list_traits, drop_last)
+{
+    EXPECT_TRUE((std::is_same_v<list_traits::drop_last<0, type_list<int, bool &, double const, long, float>>,
+                                type_list<int, bool &, double const, long, float>>));
+    EXPECT_TRUE((std::is_same_v<list_traits::drop_last<3, type_list<int, bool &, double const, long, float>>,
+                                type_list<int, bool &>>));
+    EXPECT_TRUE((std::is_same_v<list_traits::drop_last<5, type_list<int, bool &, double const, long, float>>,
+                                type_list<>>));
+}
+
+TEST(list_traits, split_after)
+{
+    using split0 = list_traits::split_after<0, type_list<int, bool &, double const, long, float>>;
+    EXPECT_TRUE((std::is_same_v<typename split0::first_type,
+                                type_list<>>));
+    EXPECT_TRUE((std::is_same_v<typename split0::second_type,
+                                type_list<int, bool &, double const, long, float>>));
+
+    using split3 = list_traits::split_after<3, type_list<int, bool &, double const, long, float>>;
+    EXPECT_TRUE((std::is_same_v<typename split3::first_type,
+                                type_list<int, bool &, double const>>));
+    EXPECT_TRUE((std::is_same_v<typename split3::second_type,
+                                type_list<long, float>>));
+
+
+    using split5 = list_traits::split_after<5, type_list<int, bool &, double const, long, float>>;
+    EXPECT_TRUE((std::is_same_v<typename split5::first_type,
+                                type_list<int, bool &, double const, long, float>>));
+    EXPECT_TRUE((std::is_same_v<typename split5::second_type,
+                                type_list<>>));
 }

--- a/test/unit/core/type_traits/template_inspection_test.cpp
+++ b/test/unit/core/type_traits/template_inspection_test.cpp
@@ -11,7 +11,7 @@
 
 #include <seqan3/core/type_traits/concept.hpp>
 #include <seqan3/core/type_traits/template_inspection.hpp>
-#include <seqan3/core/type_list.hpp>
+#include <seqan3/core/type_list/type_list.hpp>
 
 using namespace seqan3;
 


### PR DESCRIPTION
This is our own meta library with almost identical interfaces for dealing with seqan3::type_list, but also parameter packs (it's usually faster to work on the latter).

Currently available:

* at (linear-time)
* front
* back
* concat
* drop (linear-time)
* drop_front (constant)
* drop_last (linear-time)
* take (linear-time)
* take_last (linear-time)
* take (linear-time)
* split_after (linear-time)

Notably absent:
* drop_back because it's not possible to do in constant time without integer_sequence and a whole lot instantiaten. Actually, back was already tricky! @rrahn: You could have a look at this after we merge this, or you could just use drop_front on your example and move the `void` to the top and the commas to the front.


