### PR TITLE
[FIX] Add data access for containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,11 @@ If possible, provide tooling that performs the changes, e.g. a shell-script.
 * **The `type_list` header has moved:**
   If you included `<seqan3/core/type_list.hpp>` you need to change the path to `<seqan3/core/type_list/type_list.hpp>`.
 
+#### Range
+
+* **The `seqan3::concatenated_sequences::data()` function has been deprecated:**
+  Use `seqan3::concatenated_sequences::raw_data()` instead.
+
 ## Notable Bug-fixes
 
 # 3.0.0 ("Escala")

--- a/include/seqan3/range/container/bitcompressed_vector.hpp
+++ b/include/seqan3/range/container/bitcompressed_vector.hpp
@@ -518,6 +518,27 @@ public:
         return (*this)[size()-1];
     }
 
+    /*!\brief Provides direct, unsafe access to underlying data structures.
+     * \returns A reference to an SDSL bitvector.
+     *
+     * \details
+     *
+     * \noapi
+     *
+     * The exact representation of the data is implementation defined. Do not rely on it for API stability.
+     */
+    constexpr data_type & raw_data() noexcept
+    {
+        return data;
+    }
+
+    //!\copydoc raw_data()
+    constexpr data_type const & raw_data() const noexcept
+    {
+        return data;
+    }
+    //!\}
+
     /*!\name Capacity
      * \{
      */
@@ -1008,7 +1029,7 @@ public:
     template <CerealArchive archive_t>
     void CEREAL_SERIALIZE_FUNCTION_NAME(archive_t & archive)
     {
-        archive(data); //TODO: data not yet serialisable
+        archive(data);
     }
     //!\endcond
 };

--- a/include/seqan3/range/container/concatenated_sequences.hpp
+++ b/include/seqan3/range/container/concatenated_sequences.hpp
@@ -53,7 +53,7 @@ namespace seqan3
  * * Better cache locality when parsing the sequences linearly (and often also on random access).
  * * Constant time access to the concatenation of the sequences via concat().
  * * This access is also writable so that certain transformations can be done globally, instead of element-wise.
- * * Also direct access to the delimiters via data() [this is used by some algorithms].
+ * * Also direct access to the delimiters via raw_data() [this is used by some algorithms].
  *
  * The disadvantages are:
  *
@@ -600,17 +600,35 @@ public:
     /*!\brief Provides direct, unsafe access to underlying data structures.
      * \returns An std::pair of the concatenated sequences and the delimiter string.
      *
-     * This exact representation of the data is implementation defined. Do not rely on it for API stability.
+     * \details
+     *
+     * \noapi
+     *
+     * The exact representation of the data is implementation defined. Do not rely on it for API stability.
      */
-    std::pair<decltype(data_values) &, decltype(data_delimiters) &> data()
+    std::pair<decltype(data_values) &, decltype(data_delimiters) &> raw_data()
     {
         return {data_values, data_delimiters};
     }
 
-    //!\copydoc data()
-    std::pair<decltype(data_values) const &, decltype(data_delimiters) const &> data() const
+    //!\copydoc raw_data()
+    std::pair<decltype(data_values) const &, decltype(data_delimiters) const &> raw_data() const
     {
         return {std::as_const(data_values), std::as_const(data_delimiters)};
+    }
+
+    //!\copydoc raw_data()
+    //!\deprecated Use raw_data() instead.
+    SEQAN3_DEPRECATED_310 std::pair<decltype(data_values) &, decltype(data_delimiters) &> data()
+    {
+        return raw_data();
+    }
+
+    //!\copydoc raw_data()
+    //!\deprecated Use raw_data() instead.
+    SEQAN3_DEPRECATED_310 std::pair<decltype(data_values) const &, decltype(data_delimiters) const &> data() const
+    {
+        return raw_data();
     }
     //!\}
 
@@ -1243,37 +1261,37 @@ public:
     //!\brief Checks whether `*this` is equal to `rhs`.
     constexpr bool operator==(concatenated_sequences const & rhs) const noexcept
     {
-        return data() == rhs.data();
+        return raw_data() == rhs.raw_data();
     }
 
     //!\brief Checks whether `*this` is not equal to `rhs`.
     constexpr bool operator!=(concatenated_sequences const & rhs) const noexcept
     {
-        return data() != rhs.data();
+        return raw_data() != rhs.raw_data();
     }
 
     //!\brief Checks whether `*this` is less than `rhs`.
     constexpr bool operator<(concatenated_sequences const & rhs) const noexcept
     {
-        return data() < rhs.data();
+        return raw_data() < rhs.raw_data();
     }
 
     //!\brief Checks whether `*this` is greater than `rhs`.
     constexpr bool operator>(concatenated_sequences const & rhs) const noexcept
     {
-        return data() > rhs.data();
+        return raw_data() > rhs.raw_data();
     }
 
     //!\brief Checks whether `*this` is less than or equal to `rhs`.
     constexpr bool operator<=(concatenated_sequences const & rhs) const noexcept
     {
-        return data() <= rhs.data();
+        return raw_data() <= rhs.data();
     }
 
     //!\brief Checks whether `*this` is greater than or equal to `rhs`.
     constexpr bool operator>=(concatenated_sequences const & rhs) const noexcept
     {
-        return data() >= rhs.data();
+        return raw_data() >= rhs.raw_data();
     }
     //!\}
 

--- a/test/unit/range/container/container_of_container_test.cpp
+++ b/test/unit/range/container/container_of_container_test.cpp
@@ -152,10 +152,10 @@ TYPED_TEST(container_of_container, element_access)
         EXPECT_EQ(dna4_vector(t2.concat()), "ACGTACGTGAGGA"_dna4);
 
         // data
-        EXPECT_EQ(std::get<0>(t1.data()), "ACGTACGTGAGGA"_dna4);
-        EXPECT_EQ(std::get<0>(t2.data()), "ACGTACGTGAGGA"_dna4);
-        EXPECT_EQ(std::get<1>(t1.data()), (std::vector<size_type>{0, 4, 8, 13}));
-        EXPECT_EQ(std::get<1>(t2.data()), (std::vector<size_type>{0, 4, 8, 13}));
+        EXPECT_EQ(std::get<0>(t1.raw_data()), "ACGTACGTGAGGA"_dna4);
+        EXPECT_EQ(std::get<0>(t2.raw_data()), "ACGTACGTGAGGA"_dna4);
+        EXPECT_EQ(std::get<1>(t1.raw_data()), (std::vector<size_type>{0, 4, 8, 13}));
+        EXPECT_EQ(std::get<1>(t2.raw_data()), (std::vector<size_type>{0, 4, 8, 13}));
     }
 
 }


### PR DESCRIPTION
* Adds `raw_data()` for `bitcompressed_vector` and allows access of the underlying SDSL vector.
* Renames `data()` to `raw_data()` in `concatenated_sequences` since `data()` implies contiguous memory locations.
* `small_vector` and `small_string` have `data()` and are contiguous, ergo no changes here.