### PR TITLE
[DOCS] Encourage use of --recurse-submodules over --recursive

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ We recommend that you use CMake to build your project:
 
 Quick-Setup without CMake:
 
-  * Clone the repository with submodules: `git clone --recursive https://github.com/seqan/seqan3.git`
+  * Clone the repository with submodules: `git clone --recurse-submodules https://github.com/seqan/seqan3.git`
   * Add the following to your compiler invocation:
     * the include directories of SeqAn and its dependencies
     * C++17 mode with concepts support

--- a/doc/setup/quickstart_cmake/index.md
+++ b/doc/setup/quickstart_cmake/index.md
@@ -66,13 +66,13 @@ tutorial
 └── seqan3
 ```
 
-To set these directories up you can follow this script (note the <b>\--recursive</b> when cloning SeqAn3):
+To set these directories up you can follow this script (note the <b>\--recurse-submodules</b> when cloning SeqAn3):
 ```
 mkdir tutorial
 cd tutorial
 mkdir build
 mkdir source
-git clone --recursive https://github.com/seqan/seqan3.git
+git clone --recurse-submodules https://github.com/seqan/seqan3.git
 ```
 
 The directory should now look like this:


### PR DESCRIPTION
`--recursive` is deprecated.
The [git docs](https://git-scm.com/docs/git-clone/2.22.0) list `--recurse-submodules` as only option since 2.13.2 (about two years ago).