### PR TITLE
[DOCS] Small fix to std::hash docs

### DIFF
--- a/include/seqan3/alphabet/detail/hash.hpp
+++ b/include/seqan3/alphabet/detail/hash.hpp
@@ -29,7 +29,6 @@ template <typename alphabet_t>
 struct hash<alphabet_t>
 {
     /*!\brief Compute the hash for a character.
-     * \ingroup alphabet
      * \param[in] character The character to process. Must model seqan3::Semialphabet.
      *
      * \returns size_t.
@@ -54,7 +53,6 @@ template <ranges::InputRange urng_t>
 struct hash<urng_t>
 {
     /*!\brief Compute the hash for a range of characters.
-     * \ingroup alphabet
      * \param[in] range The input range to process. Must model std::ranges::InputRange and the reference type of the
                         range of the range must model seqan3::Semialphabet.
      * \returns size_t.

--- a/include/seqan3/range/container/dynamic_bitset.hpp
+++ b/include/seqan3/range/container/dynamic_bitset.hpp
@@ -1835,7 +1835,6 @@ template <size_t cap>
 struct hash<seqan3::dynamic_bitset<cap>>
 {
     /*!\brief Compute the hash for a `seqan3::dynamic_bitset`.
-     * \ingroup container
      * \param[in] arg The `seqan3::dynamic_bitset` to process.
      * \returns `size_t`.
      * \sa seqan3::dynamic_bitset.to_ullong().


### PR DESCRIPTION
This moves `operator()` into the `hash` struct.
E.g. [this one](https://docs.seqan.de/seqan/3-master-dev/group__alphabet.html#ga71cc78e9e1652f0a8b92a70726775b57).