### PR TITLE
[INFRA] Delete workspace at end of build.

### DIFF
--- a/.jenkinsfile
+++ b/.jenkinsfile
@@ -90,8 +90,6 @@ def run_unit_tests(slave_name, compiler, build_type, model, with_cereal)
     {
         workspace = pwd()
         echo workspace
-        // Clean the workspace before building.
-        deleteDir()
 
         build_name = "$slave_name $compiler cereal-$with_cereal $build_type $env.BRANCH_NAME Build-$env.BUILD_NUMBER"
         disable_cereal = with_cereal ? 'OFF' : 'ON'
@@ -138,6 +136,12 @@ def run_unit_tests(slave_name, compiler, build_type, model, with_cereal)
                                      context: 'continuous-integration/jenkins/pr-merge',
                                      description: 'Running ctest failed.')
         throw ex
+    }
+    finally
+    { // cleanup
+        echo workspace
+        // Clean the workspace after building.
+        deleteDir()
     }
 }
 


### PR DESCRIPTION
In order to avoid eating up the memory of the docker host.