### PR TITLE
[FIX] visibility errors on gcc

### DIFF
--- a/include/seqan3/alphabet/composite/alphabet_tuple_base.hpp
+++ b/include/seqan3/alphabet/composite/alphabet_tuple_base.hpp
@@ -621,7 +621,7 @@ template <typename indirect_component_type, typename derived_type, typename ...c
              !detail::weakly_equality_comparable_by_members_with<indirect_component_type, derived_type>
 //!\endcond
 constexpr bool operator==(indirect_component_type const lhs,
-                          alphabet_tuple_base<derived_type, component_types...> const rhs) noexcept
+                          alphabet_tuple_base<derived_type, component_types...> const & rhs) noexcept
 {
     return rhs == lhs;
 }
@@ -632,7 +632,7 @@ template <typename indirect_component_type, typename derived_type, typename ...i
              !detail::weakly_equality_comparable_by_members_with<indirect_component_type, derived_type>
 //!\endcond
 constexpr bool operator!=(indirect_component_type const lhs,
-                          alphabet_tuple_base<derived_type, indirect_component_types...> const rhs) noexcept
+                          alphabet_tuple_base<derived_type, indirect_component_types...> const & rhs) noexcept
 {
     return rhs != lhs;
 }
@@ -643,7 +643,7 @@ template <typename indirect_component_type, typename derived_type, typename ...i
              !detail::weakly_ordered_by_members_with<indirect_component_type, derived_type>
 //!\endcond
 constexpr bool operator<(indirect_component_type const lhs,
-                         alphabet_tuple_base<derived_type, indirect_component_types...> const rhs) noexcept
+                         alphabet_tuple_base<derived_type, indirect_component_types...> const & rhs) noexcept
 {
     return rhs > lhs;
 }
@@ -654,7 +654,7 @@ template <typename indirect_component_type, typename derived_type, typename ...i
              !detail::weakly_ordered_by_members_with<indirect_component_type, derived_type>
 //!\endcond
 constexpr bool operator>(indirect_component_type const lhs,
-                         alphabet_tuple_base<derived_type, indirect_component_types...> const rhs) noexcept
+                         alphabet_tuple_base<derived_type, indirect_component_types...> const & rhs) noexcept
 {
     return rhs < lhs;
 }
@@ -665,7 +665,7 @@ template <typename indirect_component_type, typename derived_type, typename ...i
              !detail::weakly_ordered_by_members_with<indirect_component_type, derived_type>
 //!\endcond
 constexpr bool operator<=(indirect_component_type const lhs,
-                          alphabet_tuple_base<derived_type, indirect_component_types...> const rhs) noexcept
+                          alphabet_tuple_base<derived_type, indirect_component_types...> const & rhs) noexcept
 {
     return rhs >= lhs;
 }
@@ -676,7 +676,7 @@ template <typename indirect_component_type, typename derived_type, typename ...i
              !detail::weakly_ordered_by_members_with<indirect_component_type, derived_type>
 //!\endcond
 constexpr bool operator>=(indirect_component_type const lhs,
-                          alphabet_tuple_base<derived_type, indirect_component_types...> const rhs) noexcept
+                          alphabet_tuple_base<derived_type, indirect_component_types...> const & rhs) noexcept
 {
     return rhs <= lhs;
 }

--- a/include/seqan3/alphabet/concept.hpp
+++ b/include/seqan3/alphabet/concept.hpp
@@ -78,7 +78,7 @@ void to_rank(args_t ...) = delete;
 //!\brief Functor definition for seqan3::to_rank.
 struct to_rank_fn
 {
-private:
+public:
     SEQAN3_CPO_IMPL(2, seqan3::custom::alphabet<decltype(v)>::to_rank(v))    // explicit customisation
     SEQAN3_CPO_IMPL(1, to_rank(v)                                       )    // ADL
     SEQAN3_CPO_IMPL(0, v.to_rank()                                      )    // member
@@ -169,7 +169,7 @@ void assign_rank_to(args_t ...) = delete;
 //!\ingroup alphabet
 struct assign_rank_to_fn
 {
-private:
+public:
     SEQAN3_CPO_IMPL(2, (seqan3::custom::alphabet<decltype(v)>::assign_rank_to(args..., v))) // explicit customisation
     SEQAN3_CPO_IMPL(1, (assign_rank_to(args..., v)                                       )) // ADL
     SEQAN3_CPO_IMPL(0, (v.assign_rank(args...)                                           )) // member
@@ -255,7 +255,7 @@ void to_char(args_t ...) = delete;
 //!\brief Functor definition for seqan3::to_char.
 struct to_char_fn
 {
-private:
+public:
     SEQAN3_CPO_IMPL(2, seqan3::custom::alphabet<decltype(v)>::to_char(v))    // explicit customisation
     SEQAN3_CPO_IMPL(1, to_char(v)                                       )    // ADL
     SEQAN3_CPO_IMPL(0, v.to_char()                                      )    // member
@@ -346,7 +346,7 @@ void assign_char_to(args_t ...) = delete;
 //!\ingroup alphabet
 struct assign_char_to_fn
 {
-private:
+public:
     SEQAN3_CPO_IMPL(2, (seqan3::custom::alphabet<decltype(v)>::assign_char_to(args..., v))) // explicit customisation
     SEQAN3_CPO_IMPL(1, (assign_char_to(args..., v)                                       )) // ADL
     SEQAN3_CPO_IMPL(0, (v.assign_char(args...)                                           )) // member
@@ -436,7 +436,7 @@ void char_is_valid_for(args_t ...) = delete;
 template <typename alph_t>
 struct char_is_valid_for_fn
 {
-private:
+public:
     //!\brief `alph_t` with cvref removed and possibly wrapped in std::type_identity.
     using s_alph_t = std::conditional_t<std::is_nothrow_default_constructible_v<remove_cvref_t<alph_t>>,
                                         remove_cvref_t<alph_t>,
@@ -617,7 +617,7 @@ void alphabet_size(args_t ...) = delete;
 template <typename alph_t>
 struct alphabet_size_fn
 {
-private:
+public:
     //!\brief `alph_t` with cvref removed and possibly wrapped in std::type_identity.
     using s_alph_t = std::conditional_t<std::is_nothrow_default_constructible_v<remove_cvref_t<alph_t>> &&
                                         seqan3::is_constexpr_default_constructible_v<remove_cvref_t<alph_t>>,

--- a/include/seqan3/alphabet/nucleotide/concept.hpp
+++ b/include/seqan3/alphabet/nucleotide/concept.hpp
@@ -30,7 +30,7 @@ void complement(args_t ...) = delete;
 //!\brief Functor definition for seqan3::complement.
 struct complement_fn
 {
-private:
+public:
     SEQAN3_CPO_IMPL(2, seqan3::custom::alphabet<decltype(v)>::complement(v)) // explicit customisation
     SEQAN3_CPO_IMPL(1, complement(v)                                       ) // ADL
     SEQAN3_CPO_IMPL(0, v.complement()                                      ) // member

--- a/include/seqan3/alphabet/quality/concept.hpp
+++ b/include/seqan3/alphabet/quality/concept.hpp
@@ -29,7 +29,7 @@ void to_phred(args_t ...) = delete;
 //!\brief Functor definition for seqan3::to_phred.
 struct to_phred_fn
 {
-private:
+public:
     SEQAN3_CPO_IMPL(2, seqan3::custom::alphabet<decltype(v)>::to_phred(v)) // explicit customisation
     SEQAN3_CPO_IMPL(1, to_phred(v)                                       ) // ADL
     SEQAN3_CPO_IMPL(0, v.to_phred()                                      ) // member
@@ -115,7 +115,7 @@ void assign_phred_to(args_t ...) = delete;
 //!\ingroup quality
 struct assign_phred_to_fn
 {
-private:
+public:
     SEQAN3_CPO_IMPL(2, (seqan3::custom::alphabet<decltype(v)>::assign_phred_to(args..., v))) // explicit customisation
     SEQAN3_CPO_IMPL(1, (assign_phred_to(args..., v)                                       )) // ADL
     SEQAN3_CPO_IMPL(0, (v.assign_phred(args...)                                           )) // member

--- a/include/seqan3/alphabet/structure/concept.hpp
+++ b/include/seqan3/alphabet/structure/concept.hpp
@@ -32,7 +32,7 @@ void is_pair_open(args_t ...) = delete;
 //!\brief Functor definition for seqan3::is_pair_open.
 struct is_pair_open_fn
 {
-private:
+public:
     SEQAN3_CPO_IMPL(2, seqan3::custom::alphabet<decltype(v)>::is_pair_open(v)) // explicit customisation
     SEQAN3_CPO_IMPL(1, is_pair_open(v)                                       ) // ADL
     SEQAN3_CPO_IMPL(0, v.is_pair_open()                                      ) // member
@@ -111,7 +111,7 @@ void is_pair_close(args_t ...) = delete;
 //!\brief Functor definition for seqan3::is_pair_close.
 struct is_pair_close_fn
 {
-private:
+public:
     SEQAN3_CPO_IMPL(2, seqan3::custom::alphabet<decltype(v)>::is_pair_close(v)) // explicit customisation
     SEQAN3_CPO_IMPL(1, is_pair_close(v)                                       ) // ADL
     SEQAN3_CPO_IMPL(0, v.is_pair_close()                                      ) // member
@@ -190,7 +190,7 @@ void is_unpaired(args_t ...) = delete;
 //!\brief Functor definition for seqan3::is_unpaired.
 struct is_unpaired_fn
 {
-private:
+public:
     SEQAN3_CPO_IMPL(2, seqan3::custom::alphabet<decltype(v)>::is_unpaired(v)) // explicit customisation
     SEQAN3_CPO_IMPL(1, is_unpaired(v)                                       ) // ADL
     SEQAN3_CPO_IMPL(0, v.is_unpaired()                                      ) // member
@@ -278,7 +278,7 @@ template <typename alph_t,
                                                  std::type_identity<alph_t>>>
 struct max_pseudoknot_depth_fn
 {
-private:
+public:
     SEQAN3_CPO_IMPL(2, (deferred_type_t<seqan3::custom::alphabet<alph_t>, decltype(v)>::max_pseudoknot_depth)) // custom
     SEQAN3_CPO_IMPL(1, (max_pseudoknot_depth(v)                                                             )) // ADL
     SEQAN3_CPO_IMPL(0, (deferred_type_t<remove_cvref_t<alph_t>, decltype(v)>::max_pseudoknot_depth          )) // member
@@ -379,7 +379,7 @@ void pseudoknot_id(args_t ...) = delete;
 //!\brief Functor definition for seqan3::pseudoknot_id.
 struct pseudoknot_id_fn
 {
-private:
+public:
     SEQAN3_CPO_IMPL(2, seqan3::custom::alphabet<decltype(v)>::pseudoknot_id(v)) // explicit customisation
     SEQAN3_CPO_IMPL(1, pseudoknot_id(v)                                       ) // ADL
     SEQAN3_CPO_IMPL(0, v.pseudoknot_id()                                      ) // member

--- a/include/seqan3/argument_parser/argument_parser.hpp
+++ b/include/seqan3/argument_parser/argument_parser.hpp
@@ -523,7 +523,7 @@ public:
      */
     argument_parser_meta_data info;
 
-private:
+protected:
     //!\brief Keeps track of whether the parse function has been called already.
     bool parse_was_called{false};
 

--- a/include/seqan3/range/container/small_string.hpp
+++ b/include/seqan3/range/container/small_string.hpp
@@ -158,11 +158,12 @@ public:
      *
      * No-throw guarantee if value_type is std::is_nothrow_copy_constructible.
      */
-    template <std::forward_iterator begin_it_type, std::sentinel_for<begin_it_type> end_it_type>
-    constexpr void assign(begin_it_type begin_it, end_it_type end_it) noexcept
+    template <std::forward_iterator begin_it_type, typename end_it_type>
     //!\cond
-        requires std::constructible_from<value_type, /*ranges::iter_reference_t*/reference_t<begin_it_type>>
+        requires std::sentinel_for<end_it_type, begin_it_type> &&
+                 std::constructible_from<value_type, /*ranges::iter_reference_t*/reference_t<begin_it_type>>
     //!\endcond
+    constexpr void assign(begin_it_type begin_it, end_it_type end_it) noexcept
     {
         base_t::assign(begin_it, end_it);
         data_[sz] = '\0';

--- a/include/seqan3/range/container/small_vector.hpp
+++ b/include/seqan3/range/container/small_vector.hpp
@@ -159,9 +159,10 @@ public:
      *
      * No-throw guarantee if value_type is std::is_nothrow_copy_constructible.
      */
-    template <std::forward_iterator begin_it_type, std::sentinel_for<begin_it_type> end_it_type>
+    template <std::forward_iterator begin_it_type, typename end_it_type>
     //!\cond
-        requires std::constructible_from<value_type, /*ranges::iter_reference_t*/reference_t<begin_it_type>>
+        requires std::sentinel_for<end_it_type, begin_it_type> &&
+                 std::constructible_from<value_type, /*ranges::iter_reference_t*/reference_t<begin_it_type>>
     //!\endcond
     constexpr small_vector(begin_it_type begin_it, end_it_type end_it) noexcept(is_noexcept) :
         small_vector{}
@@ -298,11 +299,12 @@ public:
      *
      * No-throw guarantee if value_type is std::is_nothrow_copy_constructible.
      */
-    template <std::forward_iterator begin_it_type, std::sentinel_for<begin_it_type> end_it_type>
-    constexpr void assign(begin_it_type begin_it, end_it_type end_it) noexcept(is_noexcept)
+    template <std::forward_iterator begin_it_type, typename end_it_type>
     //!\cond
-        requires std::constructible_from<value_type, /*ranges::iter_reference_t*/reference_t<begin_it_type>>
+        requires std::sentinel_for<end_it_type, begin_it_type> &&
+                 std::constructible_from<value_type, /*ranges::iter_reference_t*/reference_t<begin_it_type>>
     //!\endcond
+    constexpr void assign(begin_it_type begin_it, end_it_type end_it) noexcept(is_noexcept)
     {
         clear();
         insert(cbegin(), begin_it, end_it);
@@ -642,9 +644,10 @@ public:
      *
      * No-throw guarantee if value_type is std::is_nothrow_copy_constructible.
      */
-    template <std::forward_iterator begin_it_type, std::sentinel_for<begin_it_type> end_it_type>
+    template <std::forward_iterator begin_it_type, typename end_it_type>
     //!\cond
-        requires std::constructible_from<value_type, /*ranges::iter_reference_t*/reference_t<begin_it_type>>
+        requires std::sentinel_for<end_it_type, begin_it_type> &&
+                 std::constructible_from<value_type, /*ranges::iter_reference_t*/reference_t<begin_it_type>>
     //!\endcond
     constexpr iterator insert(const_iterator pos, begin_it_type begin_it, end_it_type end_it) noexcept(is_noexcept)
     {

--- a/include/seqan3/range/views/translate_join.hpp
+++ b/include/seqan3/range/views/translate_join.hpp
@@ -49,6 +49,10 @@ private:
     small_vector<translation_frames, 6> selected_frames{};
 
 protected:
+    //!\brief Befriend the following class s.t. iterator and const_iterator can be defined for this type.
+    template <typename, typename>
+    friend class detail::random_access_iterator_base;
+
     /*!\name Associated types
      * \{
      */

--- a/test/unit/alphabet/composite/alphabet_variant_test.cpp
+++ b/test/unit/alphabet/composite/alphabet_variant_test.cpp
@@ -246,9 +246,9 @@ TEST(alphabet_variant_test, rank_type)
     using alphabet2_t = alphabet_variant<gap, dna5, dna4>;
     using alphabet3_t = alphabet_variant<char, gap>;
 
-    EXPECT_TRUE((std::is_same_v<alphabet1_t::rank_type, uint8_t>));
-    EXPECT_TRUE((std::is_same_v<alphabet2_t::rank_type, uint8_t>));
-    EXPECT_TRUE((std::is_same_v<alphabet3_t::rank_type, uint16_t>));
+    EXPECT_TRUE((std::is_same_v<alphabet_rank_t<alphabet1_t>, uint8_t>));
+    EXPECT_TRUE((std::is_same_v<alphabet_rank_t<alphabet2_t>, uint8_t>));
+    EXPECT_TRUE((std::is_same_v<alphabet_rank_t<alphabet3_t>, uint16_t>));
 }
 
 TEST(alphabet_variant_test, alphabet_size_)

--- a/test/unit/alphabet/nucleotide/sam_dna16_test.cpp
+++ b/test/unit/alphabet/nucleotide/sam_dna16_test.cpp
@@ -21,6 +21,11 @@ using namespace seqan3;
 INSTANTIATE_TYPED_TEST_CASE_P(sam_dna16, alphabet_, sam_dna16);
 INSTANTIATE_TYPED_TEST_CASE_P(sam_dna16, alphabet_constexpr, sam_dna16);
 
+struct sam_dna16_accessor : public sam_dna16
+{
+    using sam_dna16::rank_to_char;
+};
+
 // nucleotide test: (because the complement is not bijective for sam_dna16 we need to test it manually)
 TEST(sam_dna16, nucleotide)
 {
@@ -47,7 +52,7 @@ TEST(sam_dna16, nucleotide)
 
 TEST(sam_dna16, to_char_assign_char)
 {
-    for (char chr : sam_dna16::rank_to_char)
+    for (char chr : sam_dna16_accessor::rank_to_char)
         EXPECT_EQ(to_char(sam_dna16{}.assign_char(chr)), chr);
 
     EXPECT_EQ(to_char(sam_dna16{}.assign_char('a')), 'A');


### PR DESCRIPTION
This PR fixes a variant of a visibility bug of gcc.

Apparently, if you use the short-notation for concepts in templates, like this,

```c++
template <typename Iterator, Sentinel<Iterator>>
struct foo;
```

all private/protected members of classes are accessible.

~Currently blocked by #1222 and #1225~