### PR TITLE
Feature/alignment debug mode

### DIFF
--- a/include/seqan3/alignment/configuration/align_config_debug.hpp
+++ b/include/seqan3/alignment/configuration/align_config_debug.hpp
@@ -1,0 +1,38 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides seqan3::align_cfg::debug.
+ * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <seqan3/alignment/configuration/detail.hpp>
+#include <seqan3/core/algorithm/algorithm_debugging.hpp>
+#include <seqan3/core/algorithm/pipeable_config_element.hpp>
+
+namespace seqan3::align_cfg
+{
+//!\cond DEV
+/*!\brief Configuration element for debugging the alignment algorithm.
+ * \ingroup alignment_configuration
+ *
+ * \details
+ *
+ * Using this configuration allows to output the alignment matrices from the DP algorithm using the
+ * returned seqan3::alignment_result.
+ * The score matrix is always accessible, while the trace matrix can only be computed if an alignment was
+ * requested via the seqan3::align_cfg::result configuration.
+ *
+ * \note This configuration is only useful for debugging purposes as it can have a significant impact on the
+ *       performance.
+ */
+inline constexpr detail::algorithm_debugging<std::integral_constant<detail::align_config_id,
+                                                                    detail::align_config_id::debug>> debug{};
+//!\endcond
+}  // namespace seqan3::align_cfg

--- a/include/seqan3/alignment/configuration/all.hpp
+++ b/include/seqan3/alignment/configuration/all.hpp
@@ -14,6 +14,7 @@
 
 #include <seqan3/alignment/configuration/align_config_aligned_ends.hpp>
 #include <seqan3/alignment/configuration/align_config_band.hpp>
+#include <seqan3/alignment/configuration/align_config_debug.hpp>
 #include <seqan3/alignment/configuration/align_config_edit.hpp>
 #include <seqan3/alignment/configuration/align_config_gap.hpp>
 #include <seqan3/alignment/configuration/align_config_max_error.hpp>

--- a/include/seqan3/alignment/configuration/detail.hpp
+++ b/include/seqan3/alignment/configuration/detail.hpp
@@ -24,6 +24,7 @@ enum struct align_config_id : uint8_t
 {
     aligned_ends, //!< ID for the \ref seqan3::align_cfg::aligned_ends "aligned_ends" option.
     band,         //!< ID for the \ref seqan3::align_cfg::band "band" option.
+    debug,        //!< ID for the \ref seqan3::align_cfg::debug "debug" option.
     gap,          //!< ID for the \ref seqan3::align_cfg::gap "gap" option.
     global,       //!< ID for the \ref seqan3::global_alignment "global alignment" option.
     local,        //!< ID for the \ref seqan3::local_alignment "local alignment" option.
@@ -46,15 +47,16 @@ template <>
 inline constexpr std::array<std::array<bool, static_cast<uint8_t>(align_config_id::SIZE)>,
                             static_cast<uint8_t>(align_config_id::SIZE)> compatibility_table<align_config_id>
 {
-    {   //0  1  2  3  4, 5  6  7
-        { 0, 1, 1, 1, 0, 1, 1, 1}, // 0: aligned_ends
-        { 1, 0, 1, 1, 1, 1, 1, 1}, // 1: band
-        { 1, 1, 0, 1, 1, 1, 1, 1}, // 2: gap
-        { 1, 1, 1, 0, 0, 1, 1, 1}, // 3: global
-        { 0, 1, 1, 0, 0, 0, 1, 1}, // 4: local
-        { 1, 1, 1, 1, 0, 0, 1, 1}, // 5: max_error
-        { 1, 1, 1, 1, 1, 1, 0, 1}, // 6: result
-        { 1, 1, 1, 1, 1, 1, 1, 0}  // 7: scoring
+    {   //0  1  2  3  4  5  6  7  8
+        { 0, 1, 1, 1, 1, 0, 1, 1, 1}, // 0: aligned_ends
+        { 1, 0, 1, 1, 1, 1, 1, 1, 1}, // 1: band
+        { 1, 1, 0, 1, 1, 1, 1, 1, 1}, // 2: debug
+        { 1, 1, 1, 0, 1, 1, 1, 1, 1}, // 2: gap
+        { 1, 1, 1, 1, 0, 0, 1, 1, 1}, // 3: global
+        { 0, 1, 1, 1, 0, 0, 0, 1, 1}, // 4: local
+        { 1, 1, 1, 1, 1, 0, 0, 1, 1}, // 5: max_error
+        { 1, 1, 1, 1, 1, 1, 1, 0, 1}, // 6: result
+        { 1, 1, 1, 1, 1, 1, 1, 1, 0}  // 7: scoring
     }
 };
 

--- a/include/seqan3/alignment/pairwise/alignment_algorithm.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_algorithm.hpp
@@ -12,6 +12,8 @@
 
 #pragma once
 
+#include <type_traits>
+
 #include <range/v3/algorithm/for_each.hpp>
 #include <range/v3/view/drop_exactly.hpp>
 #include <range/v3/view/zip.hpp>
@@ -19,14 +21,16 @@
 #include <seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp>
 #include <seqan3/alignment/configuration/all.hpp>
 #include <seqan3/alignment/exception.hpp>
+#include <seqan3/alignment/matrix/trace_directions.hpp>
+#include <seqan3/alignment/pairwise/align_result_selector.hpp>
 #include <seqan3/alignment/pairwise/policy/affine_gap_init_policy.hpp>
 #include <seqan3/alignment/pairwise/policy/affine_gap_policy.hpp>
 #include <seqan3/alignment/pairwise/policy/unbanded_score_dp_matrix_policy.hpp>
-#include <seqan3/alignment/pairwise/align_result_selector.hpp>
 #include <seqan3/alignment/scoring/gap_scheme.hpp>
 #include <seqan3/alignment/scoring/scoring_scheme_base.hpp>
 
 #include <seqan3/core/concept/tuple.hpp>
+#include <seqan3/core/detail/empty_type.hpp>
 #include <seqan3/core/type_traits/deferred_crtp_base.hpp>
 #include <seqan3/range/view/get.hpp>
 #include <seqan3/range/view/slice.hpp>
@@ -78,7 +82,14 @@ class alignment_algorithm :
 private:
 
     //!\brief Check if the alignment is banded.
-    static constexpr bool is_banded = std::remove_reference_t<config_t>::template exists<align_cfg::band>();
+    static constexpr bool is_banded = config_t::template exists<align_cfg::band>();
+    //!\brief Check if debug mode is enabled.
+    static constexpr bool is_debug_mode = config_t::template exists<detail::algorithm_debugging>();
+
+    //!\brief The type of the score debug matrix type.
+    using score_debug_matrix_t = std::conditional_t<is_debug_mode, std::vector<int32_t>, empty_type>;
+    //!\brief The type of the trace debug matrix type.
+    using trace_debug_matrix_t = std::conditional_t<is_debug_mode, std::vector<trace_directions>, empty_type>;
 
 public:
     /*!\name Constructors, destructor and assignment
@@ -571,6 +582,10 @@ private:
 
     //!\brief The alignment configuration stored on the heap.
     std::shared_ptr<config_t> cfg_ptr{};
+    //!\brief The debug matrix for the scores.
+    score_debug_matrix_t score_debug_matrix{};
+    //!\brief The debug matrix for the traces.
+    trace_debug_matrix_t trace_debug_matrix{};
 };
 
 } // namespace seqan3::detail

--- a/include/seqan3/alignment/pairwise/alignment_result.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_result.hpp
@@ -19,17 +19,21 @@ namespace seqan3::detail
 {
 
 /*!\brief A struct that contains the actual alignment result data.
- * \tparam id_t          The type for the alignment identifier.
- * \tparam score_t       The type for the resulting score.
- * \tparam back_coord_t  The type for the back coordinate, can be omitted.
- * \tparam front_coord_t The type for the front coordinate, can be omitted.
- * \tparam alignment_t   The type for the alignment, can be omitted.
+ * \tparam id_t                  The type for the alignment identifier.
+ * \tparam score_t               The type for the resulting score.
+ * \tparam back_coord_t          The type for the back coordinate, can be omitted.
+ * \tparam front_coord_t         The type for the front coordinate, can be omitted.
+ * \tparam alignment_t           The type for the alignment, can be omitted.
+ * \tparam score_debug_matrix_t  The type for the score matrix. Only present if seqan3::align_cfg::debug is enabled.
+ * \tparam trace_debug_matrix_t  The type for the trace matrix. Only present if seqan3::align_cfg::debug is enabled.
  */
 template <typename id_t,
           typename score_t,
           typename back_coord_t = std::nullopt_t *,
           typename front_coord_t = std::nullopt_t *,
-          typename alignment_t = std::nullopt_t *>
+          typename alignment_t = std::nullopt_t *,
+          typename score_debug_matrix_t = std::nullopt_t *,
+          typename trace_debug_matrix_t = std::nullopt_t *>
 struct alignment_result_value_type
 {
     //! \brief The alignment identifier.
@@ -42,6 +46,11 @@ struct alignment_result_value_type
     front_coord_t front_coordinate{};
     //! \brief The alignment, i.e. the actual base pair matching.
     alignment_t alignment{};
+
+    //!\brief The score matrix. Only accessible with seqan3::align_cfg::debug.
+    score_debug_matrix_t score_debug_matrix{};
+    //!\brief The trace matrix. Only accessible with seqan3::align_cfg::debug.
+    trace_debug_matrix_t trace_debug_matrix{};
 };
 
 /*!\name Type deduction guides
@@ -141,7 +150,7 @@ public:
 
     /*!\brief Returns the alignment identifier.
      * \return The id field.
-     * \attention This function will fail the compilation, if the id is not set.
+     * \attention Compiling this function will fail, if the id is not set.
      */
     constexpr id_t id() const noexcept
     {
@@ -152,7 +161,7 @@ public:
 
     /*!\brief Returns the alignment score.
      * \return The score field.
-     * \attention This function will fail the compilation, if the score is not set.
+     * \attention Compiling this function will fail, if the score is not set.
      */
     constexpr score_t score() const noexcept
     {
@@ -163,7 +172,7 @@ public:
 
     /*!\brief Returns the back coordinate of the alignment.
      * \return A pair of positions in the respective sequences, where the calculated alignment ends (inclusive).
-     * \attention This function will fail the compilation, if the back coordinate was not requested in the alignment
+     * \attention Compiling this function will fail, if the back coordinate was not requested in the alignment
      * configuration.
      */
     constexpr back_coord_t const & back_coordinate() const noexcept
@@ -177,7 +186,7 @@ public:
     /*!\brief Returns the front coordinate of the alignment.
      * \return  A pair of positions in the respective sequences, where the calculated alignment starts.
      * \details Guaranteed to be smaller than or equal to `back_coordinate()`.
-     * \attention This function will fail the compilation, if the front coordinate was not requested in the alignment
+     * \attention Compiling this function will fail, if the front coordinate was not requested in the alignment
      * configuration.
      */
     constexpr front_coord_t const & front_coordinate() const noexcept
@@ -190,7 +199,7 @@ public:
 
     /*!\brief Returns the actual alignment, i.e. the base pair matching.
      * \return At least two aligned sequences, which represent the alignment.
-     * \attention This function with fail the compilation, if the alignment was not requested in the alignment
+     * \attention Compiling this function will fail, if the alignment was not requested in the alignment
      * configuration.
      */
     constexpr alignment_t const & alignment() const noexcept
@@ -200,6 +209,43 @@ public:
         return data.alignment;
     }
     //!\}
+
+    //!\cond DEV
+    /*!\brief Returns the score matrix used to compute the alignment.
+     * \return The score matrix.
+     *
+     * \details
+     *
+     * This function is only used for debugging such that performance can be affected significantly when enabling
+     * seqan3::align_cfg::debug.
+     *
+     * \attention Compiling this function will fail, if seqan3::align_cfg::debug was not selected.
+     */
+    constexpr auto const & score_matrix() const noexcept
+    {
+        static_assert(!std::is_same_v<decltype(data.score_debug_matrix), std::nullopt_t *>,
+                      "Trying to access the score matrix, although it was not requested in the alignment configuration.");
+        return data.score_debug_matrix;
+    }
+
+    /*!\brief Returns the trace matrix used to compute the alignment.
+     * \return The score matrix.
+     *
+     * \details
+     *
+     * This function is only used for debugging such that performance can be affected significantly when enabling
+     * seqan3::align_cfg::debug.
+     *
+     * \attention Compiling this function will fail, if seqan3::align_cfg::debug was not selected and the alignment
+     *             was not requested in the configuration.
+     */
+    constexpr auto const & trace_matrix() const noexcept
+    {
+        static_assert(!std::is_same_v<decltype(data.trace_debug_matrix), std::nullopt_t *>,
+                      "Trying to access the trace matrix, although it was not requested in the alignment configuration.");
+        return data.trace_debug_matrix;
+    }
+    //!\endcond
 };
 
 } // namespace seqan3

--- a/include/seqan3/core/algorithm/algorithm_debugging.hpp
+++ b/include/seqan3/core/algorithm/algorithm_debugging.hpp
@@ -1,0 +1,34 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides seqan3::detail::algorithm_debugging.
+ * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <seqan3/core/algorithm/pipeable_config_element.hpp>
+
+namespace seqan3::detail
+{
+/*!\brief A global configuration type used to enabled debugging of algorithms.
+ * \ingroup alignment_configuration
+ * \tparam wrapped_config_id_t The algorithm specific configuration id wrapped in a std::integral_constant.
+ *
+ * \details
+ *
+ * This type is used to enable specific debugging behaviour of the algorithms, e.g. to output the score and the
+ * trace matrix of the alignment algorithm.
+ */
+template <typename wrapped_config_id_t>
+struct algorithm_debugging : public pipeable_config_element<algorithm_debugging<wrapped_config_id_t>, bool>
+{
+    //!\brief Internal id to check for consistent configuration settings.
+    static constexpr typename wrapped_config_id_t::value_type id{wrapped_config_id_t::value};
+};
+} // namespace seqan3::detail

--- a/include/seqan3/core/detail/empty_type.hpp
+++ b/include/seqan3/core/detail/empty_type.hpp
@@ -1,0 +1,25 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides seqan3::detail::empty_type.
+ * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <seqan3/core/platform.hpp>
+
+namespace seqan3::detail
+{
+
+//!\brief An empty class type used in meta programming.
+//!\ingroup core
+struct empty_type
+{};
+
+}  // namespace seqan3::detail

--- a/include/seqan3/core/type_list/traits.hpp
+++ b/include/seqan3/core/type_list/traits.hpp
@@ -329,6 +329,22 @@ auto split_after(type_list<pack1_t...>, type_list<head_t, pack2_t...>)
 template <template <typename> typename trait_t, typename ...pack_t>
 type_list<trait_t<pack_t>...> transform(type_list<pack_t...>);
 
+/*!\brief Implementation for replace_at.
+ * \tparam replace_t The type replacing the old one.
+ * \tparam pack1_t   Types before the replacement.
+ * \tparam head_t    The type to be replaced.
+ * \tparam pack2_t   Types after the replacement.
+ * \ingroup type_list
+ */
+template <typename replace_t,
+          typename ...pack1_t,
+          typename head_t,
+          typename ...pack2_t>
+auto replace_at(std::pair<type_list<pack1_t...>, type_list<head_t, pack2_t...>>)
+{
+    return type_list<pack1_t..., replace_t, pack2_t...>{};
+}
+
 } // namespace seqan3::list_traits::detail
 
 // ----------------------------------------------------------------------------
@@ -598,6 +614,25 @@ using split_after = decltype(detail::split_after<i>(type_list<>{}, list_t{}));
 template <template <typename> typename trait_t, seqan3::detail::type_list_specialisation list_t>
 using transform = decltype(detail::transform<trait_t>(list_t{}));
 
+/*!\brief Replace the type at the given index with the given type.
+ * \tparam replace_t The type to replace the old type with.
+ * \tparam i         The index of the type to be replaced.
+ * \tparam list_t    The (input) type list.
+ * \ingroup type_list
+ *
+ * \details
+ *
+ * ### (Compile-time) Complexity
+ *
+ * * Number of template instantiations: O(n)
+ * * Other operations: O(n)
+ */
+template <typename replace_t, std::ptrdiff_t i, seqan3::detail::type_list_specialisation list_t>
+//!\cond
+    requires (i >= 0 && i < size<list_t>)
+//!\endcond
+using replace_at = decltype(detail::replace_at<replace_t>(detail::split_after<i>(type_list<>{}, list_t{})));
+
 //!\}
 
 } // namespace seqan3::list_traits
@@ -702,6 +737,25 @@ template <ptrdiff_t i, typename ...pack_t>
     requires (i >= 0 && i <= sizeof...(pack_t))
 //!\endcond
 using split_after = seqan3::list_traits::split_after<i, type_list<pack_t...>>;
+
+/*!\brief Replace the type at the given index with the given type.
+ * \tparam replace_t The type to replace the old type with.
+ * \tparam i         The index of the type to be replaced.
+ * \tparam pack_t    The (input) type pack.
+ * \ingroup type_list
+ *
+ * \details
+ *
+ * ### (Compile-time) Complexity
+ *
+ * * Number of template instantiations: O(n)
+ * * Other operations: O(n)
+ */
+template <typename replace_t, std::ptrdiff_t i, typename ...pack_t>
+//!\cond
+    requires (i >= 0 && i < sizeof...(pack_t))
+//!\endcond
+using replace_at = decltype(seqan3::list_traits::replace_at<replace_t, i, type_list<pack_t...>>());
 
 //!\}
 

--- a/include/seqan3/range/detail/inherited_iterator_base.hpp
+++ b/include/seqan3/range/detail/inherited_iterator_base.hpp
@@ -15,15 +15,12 @@
 #include <cassert>
 #include <type_traits>
 
+#include <seqan3/core/detail/empty_type.hpp>
 #include <seqan3/core/type_traits/iterator.hpp>
 #include <seqan3/std/iterator>
 
 namespace seqan3::detail
 {
-
-//!\brief An empty class type used in meta programming.
-struct empty_type
-{};
 
 /*!\brief A CRTP base template for creating iterators that inherit from other iterators.
  * \tparam derived_t The CRTP specialisation.

--- a/test/unit/alignment/configuration/align_config_common_test.cpp
+++ b/test/unit/alignment/configuration/align_config_common_test.cpp
@@ -51,7 +51,7 @@ TEST(alignment_configuration_test, symmetric_configuration)
 TEST(alignment_configuration_test, number_of_configs)
 {
     // NOTE(rrahn): You must update this test if you add a new value to align_cfg::id
-    EXPECT_EQ(static_cast<uint8_t>(detail::align_config_id::SIZE), 8);
+    EXPECT_EQ(static_cast<uint8_t>(detail::align_config_id::SIZE), 9);
 }
 
 TYPED_TEST(alignment_configuration_test, config_element)

--- a/test/unit/core/type_list_test.cpp
+++ b/test/unit/core/type_list_test.cpp
@@ -162,6 +162,16 @@ TEST(pack_traits, split_after)
                                 type_list<>>));
 }
 
+TEST(pack_traits, replace_at)
+{
+    EXPECT_TRUE((std::is_same_v<pack_traits::replace_at<double, 0, int, float, bool>,
+                                type_list<double, float, bool>>));
+    EXPECT_TRUE((std::is_same_v<pack_traits::replace_at<double, 1, int, float, bool>,
+                                type_list<int, double, bool>>));
+    EXPECT_TRUE((std::is_same_v<pack_traits::replace_at<double, 2, int, float, bool>,
+                                type_list<int, float, double>>));
+}
+
 // ----------------------------------------------------------------------------
 // list tests
 // ----------------------------------------------------------------------------
@@ -304,4 +314,14 @@ TEST(list_traits, transform)
                                 type_list<int, bool>>));
     EXPECT_TRUE((std::is_same_v<list_traits::transform<reference_t, type_list<std::vector<int>, std::list<bool>>>,
                                 type_list<int &, bool &>>));
+}
+
+TEST(list_traits, replace_at)
+{
+    EXPECT_TRUE((std::is_same_v<list_traits::replace_at<double, 0, type_list<int, float, bool>>,
+                                type_list<double, float, bool>>));
+    EXPECT_TRUE((std::is_same_v<list_traits::replace_at<double, 1, type_list<int, float, bool>>,
+                                type_list<int, double, bool>>));
+    EXPECT_TRUE((std::is_same_v<list_traits::replace_at<double, 2, type_list<int, float, bool>>,
+                                type_list<int, float, double>>));
 }


### PR DESCRIPTION
Adds support for getting the alignment matrix and the trace matrix as debug configuration from the alignment result. 
Note, the actual behavior of dumping the matrix in the debug versions will be added by another PR, since I am currently refactoring a lot inside the kernel and need this functionality for debugging purposes. 