### PR TITLE
[DOC] Change snippets for cigar to use the cigar alphabet instead of …

### DIFF
--- a/include/seqan3/alphabet/cigar/cigar.hpp
+++ b/include/seqan3/alphabet/cigar/cigar.hpp
@@ -73,7 +73,7 @@ public:
     using base_t::base_t;
 
     /*!\brief Construction via a value of one of the components.
-     * \tparam component_type One of the component types. Must be uniquely contained in the type list of the composite.
+     * \tparam component_type One of the component types; must be uniquely contained in the type list of the composite.
      * \param[in] alph        The value of a component that should be assigned.
      *
      * \include test/snippet/alphabet/cigar/cigar_value_construction.cpp
@@ -81,7 +81,7 @@ public:
     SEQAN3_DOXYGEN_ONLY(( constexpr cigar(component_type const alph) noexcept {} ))
 
     /*!\brief Assignment via a value of one of the components.
-     * \tparam component_type One of the component types. Must be uniquely contained in the type list of the composite.
+     * \tparam component_type One of the component types; must be uniquely contained in the type list of the composite.
      * \param[in] alph        The value of a component that should be assigned.
      *
      * \include test/snippet/alphabet/cigar/cigar_value_assignment.cpp
@@ -139,6 +139,24 @@ public:
 
         return *this;
     }
+    //!\}
+
+    /*!\name Get functions
+     * \{
+     */
+    /*!\copydoc alphabet_tuple_base::get(alphabet_tuple_base & l)
+     *
+     * \include test/snippet/alphabet/cigar/cigar_get_index.cpp
+     */
+    SEQAN3_DOXYGEN_ONLY(( template <size_t index> constexpr auto get(cigar & l) noexcept {} ))
+
+    /*!\copybrief get
+     * \tparam type Return the element of specified type; only available if the type is unique in the set of components.
+     * \returns A proxy to the contained element that models the same alphabet concepts and supports assignment.
+     *
+     * \include test/snippet/alphabet/cigar/cigar_get_type.cpp
+     */
+    SEQAN3_DOXYGEN_ONLY(( template <typename type> constexpr auto get(cigar & l) noexcept {} ))
     //!\}
 };
 

--- a/include/seqan3/alphabet/cigar/cigar.hpp
+++ b/include/seqan3/alphabet/cigar/cigar.hpp
@@ -72,14 +72,21 @@ public:
     // Inherit constructors from base
     using base_t::base_t;
 
-    //!\copydoc alphabet_tuple_base::alphabet_tuple_base(component_type const alph)
+    /*!\brief Construction via a value of one of the components.
+     * \tparam component_type One of the component types. Must be uniquely contained in the type list of the composite.
+     * \param[in] alph        The value of a component that should be assigned.
+     *
+     * \include test/snippet/alphabet/cigar/cigar_value_construction.cpp
+     */
     SEQAN3_DOXYGEN_ONLY(( constexpr cigar(component_type const alph) noexcept {} ))
-    //!\copydoc alphabet_tuple_base::alphabet_tuple_base(indirect_component_type const alph)
-    SEQAN3_DOXYGEN_ONLY(( constexpr cigar(indirect_component_type const alph) noexcept {} ))
-    //!\copydoc alphabet_tuple_base::operator=(component_type const alph)
+
+    /*!\brief Assignment via a value of one of the components.
+     * \tparam component_type One of the component types. Must be uniquely contained in the type list of the composite.
+     * \param[in] alph        The value of a component that should be assigned.
+     *
+     * \include test/snippet/alphabet/cigar/cigar_value_assignment.cpp
+     */
     SEQAN3_DOXYGEN_ONLY(( constexpr cigar & operator=(component_type const alph) noexcept {} ))
-    //!\copydoc alphabet_tuple_base::operator=(indirect_component_type const alph)
-    SEQAN3_DOXYGEN_ONLY(( constexpr cigar & operator=(indirect_component_type const alph) noexcept {} ))
     //!\}
 
     // Inherit operators from base

--- a/include/seqan3/alphabet/composite/alphabet_tuple_base.hpp
+++ b/include/seqan3/alphabet/composite/alphabet_tuple_base.hpp
@@ -317,8 +317,7 @@ public:
     }
 
     /*!\brief Construction via a value of one of the components.
-     * \tparam component_type Must be one uniquely contained in the type
-                              list of the composite.
+     * \tparam component_type Must be one uniquely contained in the type list of the composite.
      * \param  alph           The value of a component that should be assigned.
      *
      * Note: Since the alphabet_tuple_base is a CRTP base class, we show the working examples
@@ -371,8 +370,7 @@ public:
     //!\endcond
 
     /*!\brief Assignment via a value of one of the components.
-     * \tparam component_type One of the component types. Must be uniquely
-     *                        contained in the type list of the composite.
+     * \tparam component_type One of the component types. Must be uniquely contained in the type list of the composite.
      * \param  alph           The value of a component that should be assigned.
      *
      * Note: Since the alphabet_tuple_base is a CRTP base class, we show the working examples

--- a/test/snippet/alphabet/cigar/cigar_get_index.cpp
+++ b/test/snippet/alphabet/cigar/cigar_get_index.cpp
@@ -1,0 +1,18 @@
+#include <seqan3/alphabet/cigar/cigar.hpp>
+#include <seqan3/alphabet/cigar/cigar_op.hpp>
+#include <seqan3/core/debug_stream.hpp>
+
+int main()
+{
+    using seqan3::get;
+    using seqan3::operator""_cigar_op;
+
+    seqan3::cigar letter{10, 'M'_cigar_op};
+
+    uint32_t size{get<0>(letter)};               // Note this is equivalent to get<uint32_t>(letter)
+    seqan3::cigar_op cigar_char{get<1>(letter)}; // Note this is equivalent to get<seqan3::cigar_op>(letter)
+
+    seqan3::debug_stream << "Size is "       << size       << '\n';
+    seqan3::debug_stream << "Cigar char is " << cigar_char << '\n'; // seqan3::debug_stream converts to char on the fly.
+
+}

--- a/test/snippet/alphabet/cigar/cigar_get_type.cpp
+++ b/test/snippet/alphabet/cigar/cigar_get_type.cpp
@@ -1,0 +1,18 @@
+#include <seqan3/alphabet/cigar/cigar.hpp>
+#include <seqan3/alphabet/cigar/cigar_op.hpp>
+#include <seqan3/core/debug_stream.hpp>
+
+int main()
+{
+    using seqan3::get;
+    using seqan3::operator""_cigar_op;
+
+    seqan3::cigar letter{10, 'M'_cigar_op};
+
+    uint32_t size{get<uint32_t>(letter)};                       // Note this is equivalent to get<0>(letter)
+    seqan3::cigar_op cigar_char{get<seqan3::cigar_op>(letter)}; // Note this is equivalent to get<1>(letter)
+
+    seqan3::debug_stream << "Size is "       << size       << '\n';
+    seqan3::debug_stream << "Cigar char is " << cigar_char << '\n'; // seqan3::debug_stream converts to char on the fly.
+
+}

--- a/test/snippet/alphabet/cigar/cigar_op.cpp
+++ b/test/snippet/alphabet/cigar/cigar_op.cpp
@@ -5,9 +5,9 @@ using seqan3::operator""_cigar_op;
 
 int main()
 {
-// Initialze an seqan3::cigar_op:
-seqan3::cigar_op match{'M'_cigar_op};
+    // Initialise a seqan3::cigar_op:
+    seqan3::cigar_op match{'M'_cigar_op};
 
-// you can print cigar_op values:
-seqan3::debug_stream << match << std::endl;          // M
+    // you can print cigar_op values:
+    seqan3::debug_stream << match << std::endl; // M
 }

--- a/test/snippet/alphabet/cigar/cigar_value_assignment.cpp
+++ b/test/snippet/alphabet/cigar/cigar_value_assignment.cpp
@@ -6,11 +6,11 @@ int main()
 {
     using seqan3::operator""_cigar_op;
 
-    seqan3::cigar letter1{10, 'I'_cigar_op};
+    seqan3::cigar letter{10, 'I'_cigar_op};
 
-    letter1 = 'D'_cigar_op;  // yields 10D
-    letter1 = 20; // yields 20D
+    letter = 'D'_cigar_op;  // yields 10D
+    letter = 20; // yields 20D
 
-    if (letter1 == seqan3::cigar{20, 'D'_cigar_op})
+    if (letter == seqan3::cigar{20, 'D'_cigar_op})
         seqan3::debug_stream << "yeah\n";
 }

--- a/test/snippet/alphabet/cigar/cigar_value_assignment.cpp
+++ b/test/snippet/alphabet/cigar/cigar_value_assignment.cpp
@@ -1,0 +1,16 @@
+#include <seqan3/alphabet/cigar/cigar.hpp>
+#include <seqan3/alphabet/cigar/cigar_op.hpp>
+#include <seqan3/core/debug_stream.hpp>
+
+int main()
+{
+    using seqan3::operator""_cigar_op;
+
+    seqan3::cigar letter1{10, 'I'_cigar_op};
+
+    letter1 = 'D'_cigar_op;  // yields 10D
+    letter1 = 20; // yields 20D
+
+    if (letter1 == seqan3::cigar{20, 'D'_cigar_op})
+        seqan3::debug_stream << "yeah\n";
+}

--- a/test/snippet/alphabet/cigar/cigar_value_construction.cpp
+++ b/test/snippet/alphabet/cigar/cigar_value_construction.cpp
@@ -1,0 +1,19 @@
+#include <seqan3/alphabet/cigar/cigar.hpp>
+#include <seqan3/alphabet/cigar/cigar_op.hpp>
+#include <seqan3/core/debug_stream.hpp>
+
+int main()
+{
+    using seqan3::operator""_cigar_op;
+
+    seqan3::cigar letter1{0};
+    // creates 0M, as the cigar_op field is not provided.
+    seqan3::cigar letter2{'M'_cigar_op};
+    // creates 0M, as the integer field is not provided.
+
+    if (letter1 == letter2)
+        seqan3::debug_stream << "yeah\n"; // yeah
+
+    seqan3::cigar letter3{10, 'I'_cigar_op};
+    // creates 10I, as both fields are explicitly given.
+}


### PR DESCRIPTION
…qualified. Also remove the subtype snippets as it is not applicable.

Fixes #1216