### PR TITLE
[FIX] Buffer the first record when calling begin instead of at construction.

### DIFF
--- a/include/seqan3/io/detail/in_file_iterator.hpp
+++ b/include/seqan3/io/detail/in_file_iterator.hpp
@@ -110,14 +110,14 @@ public:
     reference operator*() noexcept
     {
         assert(host != nullptr);
-        return host->front();
+        return host->record_buffer;
     }
 
     //!\brief Dereference returns the currently buffered record.
     reference operator*() const noexcept
     {
         assert(host != nullptr);
-        return host->front();
+        return host->record_buffer;
     }
     //!\}
 

--- a/test/unit/io/alignment_file/alignment_file_format_test_template.hpp
+++ b/test/unit/io/alignment_file/alignment_file_format_test_template.hpp
@@ -336,12 +336,14 @@ TYPED_TEST_P(alignment_file_read, format_error_ref_id_not_in_reference_informati
 {
     {   // with reference information given
         typename TestFixture::stream_type istream{this->unknown_ref};
-        EXPECT_THROW((alignment_file_input{istream, this->ref_ids, this->ref_sequences, TypeParam{}}), format_error);
+        alignment_file_input fin{istream, this->ref_ids, this->ref_sequences, TypeParam{}};
+        EXPECT_THROW((fin.begin()), format_error);
     }
 
     {   // with reference information in the header
         typename TestFixture::stream_type istream{this->unknown_ref_header};
-        EXPECT_THROW((alignment_file_input{istream, TypeParam{}}), format_error);
+        alignment_file_input fin{istream, TypeParam{}};
+        EXPECT_THROW((fin.begin()), format_error);
     }
 }
 

--- a/test/unit/io/alignment_file/format_bam_test.cpp
+++ b/test/unit/io/alignment_file/format_bam_test.cpp
@@ -249,7 +249,8 @@ struct bam_format : public alignment_file_data
 TEST_F(bam_format, wrong_magic_bytes)
 {
     std::istringstream stream{std::string{'\x43', '\x41', '\x4D', '\x01' /*CAM\1*/}};
-    EXPECT_THROW((alignment_file_input{stream, format_bam{}}), format_error);
+    alignment_file_input fin{stream, format_bam{}};
+    EXPECT_THROW(fin.begin(), format_error);
 }
 
 TEST_F(bam_format, unknown_ref_in_header)
@@ -264,7 +265,8 @@ TEST_F(bam_format, unknown_ref_in_header)
     };
 
     std::istringstream stream{unknown_ref};
-    EXPECT_THROW((alignment_file_input{stream, this->ref_ids, this->ref_sequences, format_bam{}}), format_error);
+    alignment_file_input fin{stream, this->ref_ids, this->ref_sequences, format_bam{}};
+    EXPECT_THROW(fin.begin(), format_error);
 }
 
 TEST_F(bam_format, wrong_ref_length_in_header)
@@ -279,7 +281,8 @@ TEST_F(bam_format, wrong_ref_length_in_header)
     };
 
     std::istringstream stream{wrong_ref_length};
-    EXPECT_THROW((alignment_file_input{stream, this->ref_ids, this->ref_sequences, format_bam{}}), format_error);
+    alignment_file_input fin{stream, this->ref_ids, this->ref_sequences, format_bam{}};
+    EXPECT_THROW(fin.begin(), format_error);
 }
 
 TEST_F(bam_format, wrong_order_in_header)
@@ -301,7 +304,8 @@ TEST_F(bam_format, wrong_order_in_header)
     };
 
     std::istringstream stream{wrong_order};
-    EXPECT_THROW((alignment_file_input{stream, rids, rseqs, format_bam{}}), format_error);
+    alignment_file_input fin{stream, rids, rseqs, format_bam{}};
+    EXPECT_THROW(fin.begin(), format_error);
 }
 
 TEST_F(bam_format, wrong_char_as_tag_identifier)
@@ -324,7 +328,8 @@ TEST_F(bam_format, wrong_char_as_tag_identifier)
         };
 
         std::istringstream stream{wrong_char_in_tag};
-        EXPECT_THROW((alignment_file_input{stream, this->ref_ids, this->ref_sequences, format_bam{}}), format_error);
+        alignment_file_input fin{stream, this->ref_ids, this->ref_sequences, format_bam{}};
+        EXPECT_THROW(fin.begin(), format_error);
     }
     {
         std::string wrong_char_in_tag{ // Y in CG:B array tag
@@ -344,7 +349,8 @@ TEST_F(bam_format, wrong_char_as_tag_identifier)
         };
 
         std::istringstream stream{wrong_char_in_tag};
-        EXPECT_THROW((alignment_file_input{stream, this->ref_ids, this->ref_sequences, format_bam{}}), format_error);
+        alignment_file_input fin{stream, this->ref_ids, this->ref_sequences, format_bam{}};
+        EXPECT_THROW(fin.begin(), format_error);
     }
 }
 
@@ -368,7 +374,8 @@ TEST_F(bam_format, invalid_cigar_op)
         };
 
         std::istringstream stream{wrong_char_in_tag};
-        EXPECT_THROW((alignment_file_input{stream, this->ref_ids, this->ref_sequences, format_bam{}}), format_error);
+        alignment_file_input fin{stream, this->ref_ids, this->ref_sequences, format_bam{}};
+        EXPECT_THROW(fin.begin(), format_error);
     }
 }
 
@@ -403,14 +410,15 @@ TEST_F(bam_format, too_long_cigar_string_read)
     {   // error: sam_tag_dictionary is not read
         std::istringstream stream{sam_file_with_too_long_cigar_string};
 
-        ASSERT_THROW((alignment_file_input{stream, format_bam{}, fields<field::ALIGNMENT>{}}), format_error);
+        alignment_file_input fin{stream, format_bam{}, fields<field::ALIGNMENT>{}};
+        ASSERT_THROW(fin.begin(), format_error);
     }
 
     {   // error: sequence is not read
         std::istringstream stream{sam_file_with_too_long_cigar_string};
 
-        ASSERT_THROW((alignment_file_input{stream, format_bam{}, fields<field::ALIGNMENT, field::TAGS>{}}),
-                     format_error);
+        alignment_file_input fin{stream, format_bam{}, fields<field::ALIGNMENT, field::TAGS>{}};
+        ASSERT_THROW(fin.begin(), format_error);
     }
 
     {   // error no CG tag
@@ -429,7 +437,8 @@ TEST_F(bam_format, too_long_cigar_string_read)
             '\x00', '\x02', '\x02', '\x03'
         }};
 
-        ASSERT_THROW((alignment_file_input{stream, format_bam{}}), format_error);
+        alignment_file_input fin{stream, format_bam{}};
+        ASSERT_THROW(fin.begin(), format_error);
     }
 }
 

--- a/test/unit/io/detail/in_file_iterator_test.cpp
+++ b/test/unit/io/detail/in_file_iterator_test.cpp
@@ -23,20 +23,26 @@ struct fake_file_t : std::vector<int>
 
     using base::base;
 
+    using iterator = detail::in_file_iterator<fake_file_t>;
+
     size_t current_position = 0;
     bool at_end = false;
 
     void read_next_record()
     {
+        record_buffer = base::operator[](current_position);
         ++current_position;
         if (current_position == size())
             at_end = true;
     }
 
-    int & front()
+    iterator begin()
     {
-        return begin()[current_position];
+        read_next_record();
+        return {*this};
     }
+
+    int record_buffer;
 
     fake_file_t() :
         base{}
@@ -74,7 +80,7 @@ TEST(in_file_iterator, operations)
     fake_file_t f{1, 2, 3, 4, 5, 6, 8};
 
     // construct
-    it_t it{f};
+    it_t it = f.begin();
 
     // deref
     EXPECT_EQ(*it, 1);
@@ -94,7 +100,7 @@ TEST(in_file_iterator, comparison)
     using it_t = detail::in_file_iterator<fake_file_t>;
 
     fake_file_t f{1, 2, 3, 4, 5, 6, 8};
-    it_t it{f};
+    it_t it = f.begin();
 
     // not at end
     EXPECT_FALSE(it == std::ranges::default_sentinel);

--- a/test/unit/io/sequence_file/sequence_file_input_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_input_test.cpp
@@ -299,6 +299,30 @@ TEST_F(sequence_file_input_f, record_reading_custom_fields)
     EXPECT_EQ(counter, 3u);
 }
 
+TEST_F(sequence_file_input_f, record_reading_custom_options)
+{
+    std::istringstream istream{std::string
+    {
+        "> ID1 lala\n"
+        "ACGTTTTTTTTTTTTTTT\n"
+        "> ID2\n"
+        "ACGTTTTTTT\n"
+        "> ID3 lala\n"
+        "ACGTTTA\n"
+    }};
+
+    /* record based reading */
+    sequence_file_input fin{istream, format_fasta{}};
+    fin.options.truncate_ids = true;
+
+    auto it = fin.begin();
+    EXPECT_EQ(get<field::ID>(*it), "ID1");
+    ++it;
+    EXPECT_EQ(get<field::ID>(*it), "ID2");
+    ++it;
+    EXPECT_EQ(get<field::ID>(*it), "ID3");
+}
+
 TEST_F(sequence_file_input_f, file_view)
 {
     sequence_file_input fin{std::istringstream{input}, format_fasta{}};


### PR DESCRIPTION
Resolves #1232

I included a test in sequence file input. 
Alignment file cannot be tested since there are no input options yet.
Structure file already has a test for truncate_ids which would fail if the public API is tested instead of the detail test with format. This will be changed in the next PR so I would refrain from already changing it now.

