### PR TITLE
[TEST] Add coverage tests for format_man.hpp

### DIFF
--- a/include/seqan3/argument_parser/detail/format_parse.hpp
+++ b/include/seqan3/argument_parser/detail/format_parse.hpp
@@ -361,7 +361,7 @@ private:
                                          get_type_name_as_string(value) + ".");
     }
 
-    /*!\brief Tries to cast an input string into boleand value.
+    /*!\brief Tries to cast an input string into boolean value.
      * \param[out] value Stores the casted value.
      * \param[in]  in    The input argument to be casted.
      *

--- a/test/unit/argument_parser/detail/CMakeLists.txt
+++ b/test/unit/argument_parser/detail/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_definitions(-DSEQAN_INCLUDE_DIR="${SEQAN3_INCLUDE_DIR}")
 seqan3_test(format_help_test.cpp)
 seqan3_test(format_html_test.cpp)
+seqan3_test(format_man_test.cpp)
 seqan3_test(version_check_debug_test.cpp)
 seqan3_test(version_check_release_test.cpp)

--- a/test/unit/argument_parser/detail/format_man_test.cpp
+++ b/test/unit/argument_parser/detail/format_man_test.cpp
@@ -15,65 +15,75 @@
 
 using namespace seqan3;
 
-TEST(format_man, empty_information)
+// Reused global variables
+int option_value{5};
+bool flag_value{};
+int8_t non_list_pos_opt_value{1};
+std::vector<std::string> list_pos_opt_value{};
+const char * argv[] = {"./format_man_test --version-check 0", "--export-help", "man"};
+std::string my_stdout{};
+std::string expected{".TH DEFAULT 1 \"December 01, 1994\" \"default 01.01.01\" \"default_man_page_title\"\n"
+                     ".SH NAME\n"
+                     "default \\- A short description here.\n"
+                     ".SH SYNOPSIS\n"
+                     "\\fB./format_man_test\\fP synopsis\n"
+                     ".br\n"
+                     "\\fB./format_man_test\\fP synopsis2\n"
+                     ".SH DESCRIPTION\n"
+                     "description\n"
+                     ".sp\n"
+                     "description2\n"
+                     ".SH POSITIONAL ARGUMENTS\n"
+                     ".TP\n"
+                     "\\fBARGUMENT-1\\fP (\\fIsigned 8 bit integer\\fP)\n"
+                     "this is a positional option. \n"
+                     ".TP\n"
+                     "\\fBARGUMENT-2\\fP (\\fIList\\fP of \\fIstd::string\\fP's)\n"
+                     "this is a positional option. Default: []. \n"
+                     ".SH OPTIONS\n"
+                     ".SS Basic options:\n"
+                     ".TP\n"
+                     "\\fB-h\\fP, \\fB--help\\fP\n"
+                     "Prints the help page.\n"
+                     ".TP\n"
+                     "\\fB-hh\\fP, \\fB--advanced-help\\fP\n"
+                     "Prints the help page including advanced options.\n"
+                     ".TP\n"
+                     "\\fB--version\\fP\n"
+                     "Prints the version information.\n"
+                     ".TP\n"
+                     "\\fB--copyright\\fP\n"
+                     "Prints the copyright/license information.\n"
+                     ".TP\n"
+                     "\\fB--export-help\\fP (std::string)\n"
+                     "Export the help page information. Value must be one of [html, man].\n"
+                     ".TP\n"
+                     "\\fB--version-check\\fP (bool)\n"
+                     "Whether to to check for the newest app version. Default: 1.\n"
+                     ".SS \n"
+                     ".TP\n"
+                     "\\fB-i\\fP, \\fB--int\\fP (\\fIsigned 32 bit integer\\fP)\n"
+                     "this is a int option. Default: 5. \n"
+                     ".TP\n"
+                     "\\fB-j\\fP, \\fB--jint\\fP (\\fIsigned 32 bit integer\\fP)\n"
+                     "this is a required int option. \n"
+                     ".SH FLAGS\n"
+                     ".SS SubFlags\n"
+                     "here come all the flags\n"
+                     ".TP\n"
+                     "\\fB-f\\fP, \\fB--flag\\fP\n"
+                     "this is a flag.\n"
+                     ".TP\n"
+                     "\\fB-k\\fP, \\fB--kflag\\fP\n"
+                     "this is a flag.\n"
+                     ".SH EXAMPLES\n"
+                     "example\n"
+                     ".sp\n"
+                     "example2\n"};
+
+// Full info parser initialisation
+void dummy_init(argument_parser & parser)
 {
-    std::string my_stdout{};
-    std::string expected{};
-    // Create the dummy parser.
-    const char * argv[] = {"./format_man_test --version-check 0", "--export-help", "man"};
-    argument_parser parser{"default", 3, argv};
-    parser.info.date = "December 01, 1994";
-    parser.info.version = "01.01.01";
-    parser.info.man_page_title = "default_man_page_title";
-    parser.info.short_description = "A short description here.";
-
-    expected = std::string{".TH DEFAULT 1 \"December 01, 1994\" \"default 01.01.01\" \"default_man_page_title\"\n"
-                           ".SH NAME\n"
-                           "default \\- A short description here.\n"
-                           ".SH OPTIONS\n"
-                           ".SS Basic options:\n"
-                           ".TP\n"
-                           "\\fB-h\\fP, \\fB--help\\fP\n"
-                           "Prints the help page.\n"
-                           ".TP\n"
-                           "\\fB-hh\\fP, \\fB--advanced-help\\fP\n"
-                           "Prints the help page including advanced options.\n"
-                           ".TP\n"
-                           "\\fB--version\\fP\n"
-                           "Prints the version information.\n"
-                           ".TP\n"
-                           "\\fB--copyright\\fP\n"
-                           "Prints the copyright/license information.\n"
-                           ".TP\n"
-                           "\\fB--export-help\\fP (std::string)\n"
-                           "Export the help page information. Value must be one of [html, man].\n"
-                           ".TP\n"
-                           "\\fB--version-check\\fP (bool)\n"
-                           "Whether to to check for the newest app version. Default: 1.\n"
-                           ".SS \n"};
-
-    // Test the dummy parser with minimal information.
-    testing::internal::CaptureStdout();
-    EXPECT_EXIT(parser.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
-
-    my_stdout = testing::internal::GetCapturedStdout();
-    EXPECT_EQ(my_stdout, expected);
-}
-
-TEST(format_man, full_information)
-{
-    std::string my_stdout{};
-    std::string expected{};
-    int option_value{5};
-    bool flag_value{};
-    int8_t non_list_pos_opt_value{1};
-    std::vector<std::string> list_pos_opt_value{};
-
-    // Create the dummy parser.
-    const char * argv[] = {"./format_man_test --version-check 0", "--export-help", "man"};
-    argument_parser parser{"default", 3, argv};
-
-    // Fill out the dummy parser with options and flags and sections and subsections.
     parser.info.date = "December 01, 1994";
     parser.info.version = "01.01.01";
     parser.info.man_page_title = "default_man_page_title";
@@ -93,105 +103,120 @@ TEST(format_man, full_information)
     parser.add_positional_option(list_pos_opt_value, "this is a positional option.");
     parser.info.examples.push_back("example");
     parser.info.examples.push_back("example2");
-    expected = std::string{".TH DEFAULT 1 \"December 01, 1994\" \"default 01.01.01\" \"default_man_page_title\"\n"
-                           ".SH NAME\n"
-                           "default \\- A short description here.\n"
-                           ".SH SYNOPSIS\n"
-                           "\\fB./format_man_test\\fP synopsis\n"
-                           ".br\n"
-                           "\\fB./format_man_test\\fP synopsis2\n"
-                           ".SH DESCRIPTION\n"
-                           "description\n"
-                           ".sp\n"
-                           "description2\n"
-                           ".SH POSITIONAL ARGUMENTS\n"
-                           ".TP\n"
-                           "\\fBARGUMENT-1\\fP (\\fIsigned 8 bit integer\\fP)\n"
-                           "this is a positional option. \n"
-                           ".TP\n"
-                           "\\fBARGUMENT-2\\fP (\\fIList\\fP of \\fIstd::string\\fP's)\n"
-                           "this is a positional option. Default: []. \n"
-                           ".SH OPTIONS\n"
-                           ".SS Basic options:\n"
-                           ".TP\n"
-                           "\\fB-h\\fP, \\fB--help\\fP\n"
-                           "Prints the help page.\n"
-                           ".TP\n"
-                           "\\fB-hh\\fP, \\fB--advanced-help\\fP\n"
-                           "Prints the help page including advanced options.\n"
-                           ".TP\n"
-                           "\\fB--version\\fP\n"
-                           "Prints the version information.\n"
-                           ".TP\n"
-                           "\\fB--copyright\\fP\n"
-                           "Prints the copyright/license information.\n"
-                           ".TP\n"
-                           "\\fB--export-help\\fP (std::string)\n"
-                           "Export the help page information. Value must be one of [html, man].\n"
-                           ".TP\n"
-                           "\\fB--version-check\\fP (bool)\n"
-                           "Whether to to check for the newest app version. Default: 1.\n"
-                           ".SS \n"
-                           ".TP\n"
-                           "\\fB-i\\fP, \\fB--int\\fP (\\fIsigned 32 bit integer\\fP)\n"
-                           "this is a int option. Default: 5. \n"
-                           ".TP\n"
-                           "\\fB-j\\fP, \\fB--jint\\fP (\\fIsigned 32 bit integer\\fP)\n"
-                           "this is a required int option. \n"
-                           ".SH FLAGS\n"
-                           ".SS SubFlags\n"
-                           "here come all the flags\n"
-                           ".TP\n"
-                           "\\fB-f\\fP, \\fB--flag\\fP\n"
-                           "this is a flag.\n"
-                           ".TP\n"
-                           "\\fB-k\\fP, \\fB--kflag\\fP\n"
-                           "this is a flag.\n"
-                           ".SH EXAMPLES\n"
-                           "example\n"
-                           ".sp\n"
-                           "example2\n"};
-    {
-        // Test the dummy parser without any copyright or citations.
-        testing::internal::CaptureStdout();
-        EXPECT_EXIT(parser.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
+}
 
-        my_stdout = testing::internal::GetCapturedStdout();
-        EXPECT_EQ(my_stdout, expected);
-    }
+TEST(format_man, empty_information)
+{
+    // Create the dummy parser.
+    argument_parser parser{"default", 3, argv};
+    parser.info.date = "December 01, 1994";
+    parser.info.version = "01.01.01";
+    parser.info.man_page_title = "default_man_page_title";
+    parser.info.short_description = "A short description here.";
+
+    std::string expected_short{".TH DEFAULT 1 \"December 01, 1994\" \"default 01.01.01\" \"default_man_page_title\"\n"
+                               ".SH NAME\n"
+                               "default \\- A short description here.\n"
+                               ".SH OPTIONS\n"
+                               ".SS Basic options:\n"
+                               ".TP\n"
+                               "\\fB-h\\fP, \\fB--help\\fP\n"
+                               "Prints the help page.\n"
+                               ".TP\n"
+                               "\\fB-hh\\fP, \\fB--advanced-help\\fP\n"
+                               "Prints the help page including advanced options.\n"
+                               ".TP\n"
+                               "\\fB--version\\fP\n"
+                               "Prints the version information.\n"
+                               ".TP\n"
+                               "\\fB--copyright\\fP\n"
+                               "Prints the copyright/license information.\n"
+                               ".TP\n"
+                               "\\fB--export-help\\fP (std::string)\n"
+                               "Export the help page information. Value must be one of [html, man].\n"
+                               ".TP\n"
+                               "\\fB--version-check\\fP (bool)\n"
+                               "Whether to to check for the newest app version. Default: 1.\n"
+                               ".SS \n"};
+
+    // Test the dummy parser with minimal information.
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(parser.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
+
+    my_stdout = testing::internal::GetCapturedStdout();
+    EXPECT_EQ(my_stdout, expected_short);
+}
+
+TEST(format_man, full_information)
+{
+    // Create the dummy parser.
+    argument_parser parser{"default", 3, argv};
+
+    // Fill out the dummy parser with options and flags and sections and subsections.
+    dummy_init(parser);
+    // Test the dummy parser without any copyright or citations.
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(parser.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
+
+    my_stdout = testing::internal::GetCapturedStdout();
+    EXPECT_EQ(my_stdout, expected);
+}
+
+TEST(format_man, full_info_short_copyright)
+{
+    // Create the dummy parser.
+    argument_parser parser{"default", 3, argv};
+
+    // Fill out the dummy parser with options and flags and sections and subsections.
+    dummy_init(parser);
     // Add a short copyright and test the dummy parser.
     parser.info.short_copyright = "short copyright";
-    {
-        expected += std::string{".SH LEGAL\n"
-                                "\\fBdefault Copyright:\\fR short copyright\n"
-                                ".br\n"
-                                "\\fBSeqAn Copyright:\\fR 2006-2015 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.\n"
-                                ".br\n"};
-        testing::internal::CaptureStdout();
-        EXPECT_EXIT(parser.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
+    expected += std::string{".SH LEGAL\n"
+                            "\\fBdefault Copyright:\\fR short copyright\n"
+                            ".br\n"
+                            "\\fBSeqAn Copyright:\\fR 2006-2015 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.\n"
+                            ".br\n"};
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(parser.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
 
-        my_stdout = testing::internal::GetCapturedStdout();
-        EXPECT_EQ(my_stdout, expected);
-    }
-    // Now add a citation and test it again.
+    my_stdout = testing::internal::GetCapturedStdout();
+    EXPECT_EQ(my_stdout, expected);
+}
+
+TEST(format_man, full_info_short_and_citation)
+{
+    // Create the dummy parser.
+    argument_parser parser{"default", 3, argv};
+
+    // Fill out the dummy parser with options and flags and sections and subsections.
+    dummy_init(parser);
+    // Add a short copyright & citation and test the dummy parser.
+    parser.info.short_copyright = "short copyright";
     parser.info.citation = "citation";
-    {
-        expected += std::string{"\\fBIn your academic works please cite:\\fR citation\n"
-                                ".br\n"};
-        testing::internal::CaptureStdout();
-        EXPECT_EXIT(parser.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
+    expected += std::string{"\\fBIn your academic works please cite:\\fR citation\n"
+                            ".br\n"};
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(parser.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
 
-        my_stdout = testing::internal::GetCapturedStdout();
-        EXPECT_EQ(my_stdout, expected);
-    }
-    // Lastly, add a long copyright and test it one more time.
+    my_stdout = testing::internal::GetCapturedStdout();
+    EXPECT_EQ(my_stdout, expected);
+}
+
+TEST(format_man, full_info_short_long_and_citation)
+{
+    // Create the dummy parser.
+    argument_parser parser{"default", 3, argv};
+
+    // Fill out the dummy parser with options and flags and sections and subsections.
+    dummy_init(parser);
+    // Add a short copyright & citation & long copyright and test the dummy parser.
+    parser.info.short_copyright = "short copyright";
+    parser.info.citation = "citation";
     parser.info.long_copyright = "looong copyright";
-    {
-        expected += std::string{"For full copyright and/or warranty information see \\fB--copyright\\fR.\n"};
-        testing::internal::CaptureStdout();
-        EXPECT_EXIT(parser.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
+    expected += std::string{"For full copyright and/or warranty information see \\fB--copyright\\fR.\n"};
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(parser.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
 
-        my_stdout = testing::internal::GetCapturedStdout();
-        EXPECT_EQ(my_stdout, expected);
-    }
+    my_stdout = testing::internal::GetCapturedStdout();
+    EXPECT_EQ(my_stdout, expected);
 }

--- a/test/unit/argument_parser/detail/format_man_test.cpp
+++ b/test/unit/argument_parser/detail/format_man_test.cpp
@@ -16,96 +16,99 @@
 using namespace seqan3;
 
 // Reused global variables
-int option_value{5};
-bool flag_value{};
-int8_t non_list_pos_opt_value{1};
-std::vector<std::string> list_pos_opt_value{};
-const char * argv[] = {"./format_man_test --version-check 0", "--export-help", "man"};
-std::string my_stdout{};
-std::string expected{".TH DEFAULT 1 \"December 01, 1994\" \"default 01.01.01\" \"default_man_page_title\"\n"
-                     ".SH NAME\n"
-                     "default \\- A short description here.\n"
-                     ".SH SYNOPSIS\n"
-                     "\\fB./format_man_test\\fP synopsis\n"
-                     ".br\n"
-                     "\\fB./format_man_test\\fP synopsis2\n"
-                     ".SH DESCRIPTION\n"
-                     "description\n"
-                     ".sp\n"
-                     "description2\n"
-                     ".SH POSITIONAL ARGUMENTS\n"
-                     ".TP\n"
-                     "\\fBARGUMENT-1\\fP (\\fIsigned 8 bit integer\\fP)\n"
-                     "this is a positional option. \n"
-                     ".TP\n"
-                     "\\fBARGUMENT-2\\fP (\\fIList\\fP of \\fIstd::string\\fP's)\n"
-                     "this is a positional option. Default: []. \n"
-                     ".SH OPTIONS\n"
-                     ".SS Basic options:\n"
-                     ".TP\n"
-                     "\\fB-h\\fP, \\fB--help\\fP\n"
-                     "Prints the help page.\n"
-                     ".TP\n"
-                     "\\fB-hh\\fP, \\fB--advanced-help\\fP\n"
-                     "Prints the help page including advanced options.\n"
-                     ".TP\n"
-                     "\\fB--version\\fP\n"
-                     "Prints the version information.\n"
-                     ".TP\n"
-                     "\\fB--copyright\\fP\n"
-                     "Prints the copyright/license information.\n"
-                     ".TP\n"
-                     "\\fB--export-help\\fP (std::string)\n"
-                     "Export the help page information. Value must be one of [html, man].\n"
-                     ".TP\n"
-                     "\\fB--version-check\\fP (bool)\n"
-                     "Whether to to check for the newest app version. Default: 1.\n"
-                     ".SS \n"
-                     ".TP\n"
-                     "\\fB-i\\fP, \\fB--int\\fP (\\fIsigned 32 bit integer\\fP)\n"
-                     "this is a int option. Default: 5. \n"
-                     ".TP\n"
-                     "\\fB-j\\fP, \\fB--jint\\fP (\\fIsigned 32 bit integer\\fP)\n"
-                     "this is a required int option. \n"
-                     ".SH FLAGS\n"
-                     ".SS SubFlags\n"
-                     "here come all the flags\n"
-                     ".TP\n"
-                     "\\fB-f\\fP, \\fB--flag\\fP\n"
-                     "this is a flag.\n"
-                     ".TP\n"
-                     "\\fB-k\\fP, \\fB--kflag\\fP\n"
-                     "this is a flag.\n"
-                     ".SH EXAMPLES\n"
-                     "example\n"
-                     ".sp\n"
-                     "example2\n"};
-
-// Full info parser initialisation
-void dummy_init(argument_parser & parser)
+struct format_man_test : public ::testing::Test
 {
-    parser.info.date = "December 01, 1994";
-    parser.info.version = "01.01.01";
-    parser.info.man_page_title = "default_man_page_title";
-    parser.info.short_description = "A short description here.";
-    parser.info.synopsis.push_back("./format_man_test synopsis");
-    parser.info.synopsis.push_back("./format_man_test synopsis2");
-    parser.info.description.push_back("description");
-    parser.info.description.push_back("description2");
-    parser.add_option(option_value, 'i', "int", "this is a int option.");
-    parser.add_option(option_value, 'j', "jint", "this is a required int option.", option_spec::REQUIRED);
-    parser.add_section("Flags");
-    parser.add_subsection("SubFlags");
-    parser.add_line("here come all the flags");
-    parser.add_flag(flag_value, 'f', "flag", "this is a flag.");
-    parser.add_flag(flag_value, 'k', "kflag", "this is a flag.");
-    parser.add_positional_option(non_list_pos_opt_value, "this is a positional option.");
-    parser.add_positional_option(list_pos_opt_value, "this is a positional option.");
-    parser.info.examples.push_back("example");
-    parser.info.examples.push_back("example2");
-}
+    int option_value{5};
+    bool flag_value{};
+    int8_t non_list_pos_opt_value{1};
+    std::vector<std::string> list_pos_opt_value{};
+    std::string my_stdout{};
+    const char * argv[4] = {"./format_man_test --version-check 0", "--export-help", "man"};
+    std::string expected{".TH DEFAULT 1 \"December 01, 1994\" \"default 01.01.01\" \"default_man_page_title\"\n"
+                         ".SH NAME\n"
+                         "default \\- A short description here.\n"
+                         ".SH SYNOPSIS\n"
+                         "\\fB./format_man_test\\fP synopsis\n"
+                         ".br\n"
+                         "\\fB./format_man_test\\fP synopsis2\n"
+                         ".SH DESCRIPTION\n"
+                         "description\n"
+                         ".sp\n"
+                         "description2\n"
+                         ".SH POSITIONAL ARGUMENTS\n"
+                         ".TP\n"
+                         "\\fBARGUMENT-1\\fP (\\fIsigned 8 bit integer\\fP)\n"
+                         "this is a positional option. \n"
+                         ".TP\n"
+                         "\\fBARGUMENT-2\\fP (\\fIList\\fP of \\fIstd::string\\fP's)\n"
+                         "this is a positional option. Default: []. \n"
+                         ".SH OPTIONS\n"
+                         ".SS Basic options:\n"
+                         ".TP\n"
+                         "\\fB-h\\fP, \\fB--help\\fP\n"
+                         "Prints the help page.\n"
+                         ".TP\n"
+                         "\\fB-hh\\fP, \\fB--advanced-help\\fP\n"
+                         "Prints the help page including advanced options.\n"
+                         ".TP\n"
+                         "\\fB--version\\fP\n"
+                         "Prints the version information.\n"
+                         ".TP\n"
+                         "\\fB--copyright\\fP\n"
+                         "Prints the copyright/license information.\n"
+                         ".TP\n"
+                         "\\fB--export-help\\fP (std::string)\n"
+                         "Export the help page information. Value must be one of [html, man].\n"
+                         ".TP\n"
+                         "\\fB--version-check\\fP (bool)\n"
+                         "Whether to to check for the newest app version. Default: 1.\n"
+                         ".SS \n"
+                         ".TP\n"
+                         "\\fB-i\\fP, \\fB--int\\fP (\\fIsigned 32 bit integer\\fP)\n"
+                         "this is a int option. Default: 5. \n"
+                         ".TP\n"
+                         "\\fB-j\\fP, \\fB--jint\\fP (\\fIsigned 32 bit integer\\fP)\n"
+                         "this is a required int option. \n"
+                         ".SH FLAGS\n"
+                         ".SS SubFlags\n"
+                         "here come all the flags\n"
+                         ".TP\n"
+                         "\\fB-f\\fP, \\fB--flag\\fP\n"
+                         "this is a flag.\n"
+                         ".TP\n"
+                         "\\fB-k\\fP, \\fB--kflag\\fP\n"
+                         "this is a flag.\n"
+                         ".SH EXAMPLES\n"
+                         "example\n"
+                         ".sp\n"
+                         "example2\n"};
 
-TEST(format_man, empty_information)
+    // Full info parser initialisation
+    void dummy_init(argument_parser & parser)
+    {
+        parser.info.date = "December 01, 1994";
+        parser.info.version = "01.01.01";
+        parser.info.man_page_title = "default_man_page_title";
+        parser.info.short_description = "A short description here.";
+        parser.info.synopsis.push_back("./format_man_test synopsis");
+        parser.info.synopsis.push_back("./format_man_test synopsis2");
+        parser.info.description.push_back("description");
+        parser.info.description.push_back("description2");
+        parser.add_option(option_value, 'i', "int", "this is a int option.");
+        parser.add_option(option_value, 'j', "jint", "this is a required int option.", option_spec::REQUIRED);
+        parser.add_section("Flags");
+        parser.add_subsection("SubFlags");
+        parser.add_line("here come all the flags");
+        parser.add_flag(flag_value, 'f', "flag", "this is a flag.");
+        parser.add_flag(flag_value, 'k', "kflag", "this is a flag.");
+        parser.add_positional_option(non_list_pos_opt_value, "this is a positional option.");
+        parser.add_positional_option(list_pos_opt_value, "this is a positional option.");
+        parser.info.examples.push_back("example");
+        parser.info.examples.push_back("example2");
+    }
+};
+
+TEST_F(format_man_test, empty_information)
 {
     // Create the dummy parser.
     argument_parser parser{"default", 3, argv};
@@ -147,7 +150,7 @@ TEST(format_man, empty_information)
     EXPECT_EQ(my_stdout, expected_short);
 }
 
-TEST(format_man, full_information)
+TEST_F(format_man_test, full_information)
 {
     // Create the dummy parser.
     argument_parser parser{"default", 3, argv};
@@ -162,7 +165,7 @@ TEST(format_man, full_information)
     EXPECT_EQ(my_stdout, expected);
 }
 
-TEST(format_man, full_info_short_copyright)
+TEST_F(format_man_test, full_info_short_copyright)
 {
     // Create the dummy parser.
     argument_parser parser{"default", 3, argv};
@@ -183,7 +186,7 @@ TEST(format_man, full_info_short_copyright)
     EXPECT_EQ(my_stdout, expected);
 }
 
-TEST(format_man, full_info_short_and_citation)
+TEST_F(format_man_test, full_info_short_and_citation)
 {
     // Create the dummy parser.
     argument_parser parser{"default", 3, argv};
@@ -193,7 +196,12 @@ TEST(format_man, full_info_short_and_citation)
     // Add a short copyright & citation and test the dummy parser.
     parser.info.short_copyright = "short copyright";
     parser.info.citation = "citation";
-    expected += std::string{"\\fBIn your academic works please cite:\\fR citation\n"
+    expected += std::string{".SH LEGAL\n"
+                            "\\fBdefault Copyright:\\fR short copyright\n"
+                            ".br\n"
+                            "\\fBSeqAn Copyright:\\fR 2006-2015 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.\n"
+                            ".br\n"
+                            "\\fBIn your academic works please cite:\\fR citation\n"
                             ".br\n"};
     testing::internal::CaptureStdout();
     EXPECT_EXIT(parser.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
@@ -202,7 +210,7 @@ TEST(format_man, full_info_short_and_citation)
     EXPECT_EQ(my_stdout, expected);
 }
 
-TEST(format_man, full_info_short_long_and_citation)
+TEST_F(format_man_test, full_info_short_long_and_citation)
 {
     // Create the dummy parser.
     argument_parser parser{"default", 3, argv};
@@ -213,7 +221,14 @@ TEST(format_man, full_info_short_long_and_citation)
     parser.info.short_copyright = "short copyright";
     parser.info.citation = "citation";
     parser.info.long_copyright = "looong copyright";
-    expected += std::string{"For full copyright and/or warranty information see \\fB--copyright\\fR.\n"};
+    expected += std::string{".SH LEGAL\n"
+                            "\\fBdefault Copyright:\\fR short copyright\n"
+                            ".br\n"
+                            "\\fBSeqAn Copyright:\\fR 2006-2015 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.\n"
+                            ".br\n"
+                            "\\fBIn your academic works please cite:\\fR citation\n"
+                            ".br\n"
+                            "For full copyright and/or warranty information see \\fB--copyright\\fR.\n"};
     testing::internal::CaptureStdout();
     EXPECT_EXIT(parser.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
 

--- a/test/unit/argument_parser/detail/format_man_test.cpp
+++ b/test/unit/argument_parser/detail/format_man_test.cpp
@@ -24,64 +24,65 @@ struct format_man_test : public ::testing::Test
     std::vector<std::string> list_pos_opt_value{};
     std::string my_stdout{};
     const char * argv[4] = {"./format_man_test --version-check 0", "--export-help", "man"};
-    std::string expected{".TH DEFAULT 1 \"December 01, 1994\" \"default 01.01.01\" \"default_man_page_title\"\n"
-                         ".SH NAME\n"
-                         "default \\- A short description here.\n"
-                         ".SH SYNOPSIS\n"
-                         "\\fB./format_man_test\\fP synopsis\n"
-                         ".br\n"
-                         "\\fB./format_man_test\\fP synopsis2\n"
-                         ".SH DESCRIPTION\n"
-                         "description\n"
-                         ".sp\n"
-                         "description2\n"
-                         ".SH POSITIONAL ARGUMENTS\n"
-                         ".TP\n"
-                         "\\fBARGUMENT-1\\fP (\\fIsigned 8 bit integer\\fP)\n"
-                         "this is a positional option. \n"
-                         ".TP\n"
-                         "\\fBARGUMENT-2\\fP (\\fIList\\fP of \\fIstd::string\\fP's)\n"
-                         "this is a positional option. Default: []. \n"
-                         ".SH OPTIONS\n"
-                         ".SS Basic options:\n"
-                         ".TP\n"
-                         "\\fB-h\\fP, \\fB--help\\fP\n"
-                         "Prints the help page.\n"
-                         ".TP\n"
-                         "\\fB-hh\\fP, \\fB--advanced-help\\fP\n"
-                         "Prints the help page including advanced options.\n"
-                         ".TP\n"
-                         "\\fB--version\\fP\n"
-                         "Prints the version information.\n"
-                         ".TP\n"
-                         "\\fB--copyright\\fP\n"
-                         "Prints the copyright/license information.\n"
-                         ".TP\n"
-                         "\\fB--export-help\\fP (std::string)\n"
-                         "Export the help page information. Value must be one of [html, man].\n"
-                         ".TP\n"
-                         "\\fB--version-check\\fP (bool)\n"
-                         "Whether to to check for the newest app version. Default: 1.\n"
-                         ".SS \n"
-                         ".TP\n"
-                         "\\fB-i\\fP, \\fB--int\\fP (\\fIsigned 32 bit integer\\fP)\n"
-                         "this is a int option. Default: 5. \n"
-                         ".TP\n"
-                         "\\fB-j\\fP, \\fB--jint\\fP (\\fIsigned 32 bit integer\\fP)\n"
-                         "this is a required int option. \n"
-                         ".SH FLAGS\n"
-                         ".SS SubFlags\n"
-                         "here come all the flags\n"
-                         ".TP\n"
-                         "\\fB-f\\fP, \\fB--flag\\fP\n"
-                         "this is a flag.\n"
-                         ".TP\n"
-                         "\\fB-k\\fP, \\fB--kflag\\fP\n"
-                         "this is a flag.\n"
-                         ".SH EXAMPLES\n"
-                         "example\n"
-                         ".sp\n"
-                         "example2\n"};
+    std::string expected = R"(.TH DEFAULT 1 "December 01, 1994" "default 01.01.01" "default_man_page_title"
+.SH NAME
+default \- A short description here.
+.SH SYNOPSIS
+\fB./format_man_test\fP synopsis
+.br
+\fB./format_man_test\fP synopsis2
+.SH DESCRIPTION
+description
+.sp
+description2
+.SH POSITIONAL ARGUMENTS
+.TP
+\fBARGUMENT-1\fP (\fIsigned 8 bit integer\fP)
+this is a positional option. 
+.TP
+\fBARGUMENT-2\fP (\fIList\fP of \fIstd::string\fP's)
+this is a positional option. Default: []. 
+.SH OPTIONS
+.SS Basic options:
+.TP
+\fB-h\fP, \fB--help\fP
+Prints the help page.
+.TP
+\fB-hh\fP, \fB--advanced-help\fP
+Prints the help page including advanced options.
+.TP
+\fB--version\fP
+Prints the version information.
+.TP
+\fB--copyright\fP
+Prints the copyright/license information.
+.TP
+\fB--export-help\fP (std::string)
+Export the help page information. Value must be one of [html, man].
+.TP
+\fB--version-check\fP (bool)
+Whether to to check for the newest app version. Default: 1.
+.SS 
+.TP
+\fB-i\fP, \fB--int\fP (\fIsigned 32 bit integer\fP)
+this is a int option. Default: 5. 
+.TP
+\fB-j\fP, \fB--jint\fP (\fIsigned 32 bit integer\fP)
+this is a required int option. 
+.SH FLAGS
+.SS SubFlags
+here come all the flags
+.TP
+\fB-f\fP, \fB--flag\fP
+this is a flag.
+.TP
+\fB-k\fP, \fB--kflag\fP
+this is a flag.
+.SH EXAMPLES
+example
+.sp
+example2
+)";
 
     // Full info parser initialisation
     void dummy_init(argument_parser & parser)
@@ -117,30 +118,31 @@ TEST_F(format_man_test, empty_information)
     parser.info.man_page_title = "default_man_page_title";
     parser.info.short_description = "A short description here.";
 
-    std::string expected_short{".TH DEFAULT 1 \"December 01, 1994\" \"default 01.01.01\" \"default_man_page_title\"\n"
-                               ".SH NAME\n"
-                               "default \\- A short description here.\n"
-                               ".SH OPTIONS\n"
-                               ".SS Basic options:\n"
-                               ".TP\n"
-                               "\\fB-h\\fP, \\fB--help\\fP\n"
-                               "Prints the help page.\n"
-                               ".TP\n"
-                               "\\fB-hh\\fP, \\fB--advanced-help\\fP\n"
-                               "Prints the help page including advanced options.\n"
-                               ".TP\n"
-                               "\\fB--version\\fP\n"
-                               "Prints the version information.\n"
-                               ".TP\n"
-                               "\\fB--copyright\\fP\n"
-                               "Prints the copyright/license information.\n"
-                               ".TP\n"
-                               "\\fB--export-help\\fP (std::string)\n"
-                               "Export the help page information. Value must be one of [html, man].\n"
-                               ".TP\n"
-                               "\\fB--version-check\\fP (bool)\n"
-                               "Whether to to check for the newest app version. Default: 1.\n"
-                               ".SS \n"};
+    std::string expected_short = R"(.TH DEFAULT 1 "December 01, 1994" "default 01.01.01" "default_man_page_title"
+.SH NAME
+default \- A short description here.
+.SH OPTIONS
+.SS Basic options:
+.TP
+\fB-h\fP, \fB--help\fP
+Prints the help page.
+.TP
+\fB-hh\fP, \fB--advanced-help\fP
+Prints the help page including advanced options.
+.TP
+\fB--version\fP
+Prints the version information.
+.TP
+\fB--copyright\fP
+Prints the copyright/license information.
+.TP
+\fB--export-help\fP (std::string)
+Export the help page information. Value must be one of [html, man].
+.TP
+\fB--version-check\fP (bool)
+Whether to to check for the newest app version. Default: 1.
+.SS 
+)";
 
     // Test the dummy parser with minimal information.
     testing::internal::CaptureStdout();
@@ -174,11 +176,12 @@ TEST_F(format_man_test, full_info_short_copyright)
     dummy_init(parser);
     // Add a short copyright and test the dummy parser.
     parser.info.short_copyright = "short copyright";
-    expected += std::string{".SH LEGAL\n"
-                            "\\fBdefault Copyright:\\fR short copyright\n"
-                            ".br\n"
-                            "\\fBSeqAn Copyright:\\fR 2006-2015 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.\n"
-                            ".br\n"};
+    expected += R"(.SH LEGAL
+\fBdefault Copyright:\fR short copyright
+.br
+\fBSeqAn Copyright:\fR 2006-2015 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.
+.br
+)";
     testing::internal::CaptureStdout();
     EXPECT_EXIT(parser.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
 
@@ -196,13 +199,14 @@ TEST_F(format_man_test, full_info_short_and_citation)
     // Add a short copyright & citation and test the dummy parser.
     parser.info.short_copyright = "short copyright";
     parser.info.citation = "citation";
-    expected += std::string{".SH LEGAL\n"
-                            "\\fBdefault Copyright:\\fR short copyright\n"
-                            ".br\n"
-                            "\\fBSeqAn Copyright:\\fR 2006-2015 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.\n"
-                            ".br\n"
-                            "\\fBIn your academic works please cite:\\fR citation\n"
-                            ".br\n"};
+    expected += R"(.SH LEGAL
+\fBdefault Copyright:\fR short copyright
+.br
+\fBSeqAn Copyright:\fR 2006-2015 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.
+.br
+\fBIn your academic works please cite:\fR citation
+.br
+)";
     testing::internal::CaptureStdout();
     EXPECT_EXIT(parser.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
 
@@ -221,14 +225,15 @@ TEST_F(format_man_test, full_info_short_long_and_citation)
     parser.info.short_copyright = "short copyright";
     parser.info.citation = "citation";
     parser.info.long_copyright = "looong copyright";
-    expected += std::string{".SH LEGAL\n"
-                            "\\fBdefault Copyright:\\fR short copyright\n"
-                            ".br\n"
-                            "\\fBSeqAn Copyright:\\fR 2006-2015 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.\n"
-                            ".br\n"
-                            "\\fBIn your academic works please cite:\\fR citation\n"
-                            ".br\n"
-                            "For full copyright and/or warranty information see \\fB--copyright\\fR.\n"};
+    expected += R"(.SH LEGAL
+\fBdefault Copyright:\fR short copyright
+.br
+\fBSeqAn Copyright:\fR 2006-2015 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.
+.br
+\fBIn your academic works please cite:\fR citation
+.br
+For full copyright and/or warranty information see \fB--copyright\fR.
+)";
     testing::internal::CaptureStdout();
     EXPECT_EXIT(parser.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
 

--- a/test/unit/argument_parser/detail/format_man_test.cpp
+++ b/test/unit/argument_parser/detail/format_man_test.cpp
@@ -1,0 +1,197 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <seqan3/argument_parser/all.hpp>
+#include <seqan3/argument_parser/detail/format_man.hpp>
+
+using namespace seqan3;
+
+TEST(format_man, empty_information)
+{
+    std::string my_stdout{};
+    std::string expected{};
+    // Create the dummy parser.
+    const char * argv[] = {"./format_man_test --version-check 0", "--export-help", "man"};
+    argument_parser parser{"default", 3, argv};
+    parser.info.date = "December 01, 1994";
+    parser.info.version = "01.01.01";
+    parser.info.man_page_title = "default_man_page_title";
+    parser.info.short_description = "A short description here.";
+
+    expected = std::string{".TH DEFAULT 1 \"December 01, 1994\" \"default 01.01.01\" \"default_man_page_title\"\n"
+                           ".SH NAME\n"
+                           "default \\- A short description here.\n"
+                           ".SH OPTIONS\n"
+                           ".SS Basic options:\n"
+                           ".TP\n"
+                           "\\fB-h\\fP, \\fB--help\\fP\n"
+                           "Prints the help page.\n"
+                           ".TP\n"
+                           "\\fB-hh\\fP, \\fB--advanced-help\\fP\n"
+                           "Prints the help page including advanced options.\n"
+                           ".TP\n"
+                           "\\fB--version\\fP\n"
+                           "Prints the version information.\n"
+                           ".TP\n"
+                           "\\fB--copyright\\fP\n"
+                           "Prints the copyright/license information.\n"
+                           ".TP\n"
+                           "\\fB--export-help\\fP (std::string)\n"
+                           "Export the help page information. Value must be one of [html, man].\n"
+                           ".TP\n"
+                           "\\fB--version-check\\fP (bool)\n"
+                           "Whether to to check for the newest app version. Default: 1.\n"
+                           ".SS \n"};
+
+    // Test the dummy parser with minimal information.
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(parser.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
+
+    my_stdout = testing::internal::GetCapturedStdout();
+    EXPECT_EQ(my_stdout, expected);
+}
+
+TEST(format_man, full_information)
+{
+    std::string my_stdout{};
+    std::string expected{};
+    int option_value{5};
+    bool flag_value{};
+    int8_t non_list_pos_opt_value{1};
+    std::vector<std::string> list_pos_opt_value{};
+
+    // Create the dummy parser.
+    const char * argv[] = {"./format_man_test --version-check 0", "--export-help", "man"};
+    argument_parser parser{"default", 3, argv};
+
+    // Fill out the dummy parser with options and flags and sections and subsections.
+    parser.info.date = "December 01, 1994";
+    parser.info.version = "01.01.01";
+    parser.info.man_page_title = "default_man_page_title";
+    parser.info.short_description = "A short description here.";
+    parser.info.synopsis.push_back("./format_man_test synopsis");
+    parser.info.synopsis.push_back("./format_man_test synopsis2");
+    parser.info.description.push_back("description");
+    parser.info.description.push_back("description2");
+    parser.add_option(option_value, 'i', "int", "this is a int option.");
+    parser.add_option(option_value, 'j', "jint", "this is a required int option.", option_spec::REQUIRED);
+    parser.add_section("Flags");
+    parser.add_subsection("SubFlags");
+    parser.add_line("here come all the flags");
+    parser.add_flag(flag_value, 'f', "flag", "this is a flag.");
+    parser.add_flag(flag_value, 'k', "kflag", "this is a flag.");
+    parser.add_positional_option(non_list_pos_opt_value, "this is a positional option.");
+    parser.add_positional_option(list_pos_opt_value, "this is a positional option.");
+    parser.info.examples.push_back("example");
+    parser.info.examples.push_back("example2");
+    expected = std::string{".TH DEFAULT 1 \"December 01, 1994\" \"default 01.01.01\" \"default_man_page_title\"\n"
+                           ".SH NAME\n"
+                           "default \\- A short description here.\n"
+                           ".SH SYNOPSIS\n"
+                           "\\fB./format_man_test\\fP synopsis\n"
+                           ".br\n"
+                           "\\fB./format_man_test\\fP synopsis2\n"
+                           ".SH DESCRIPTION\n"
+                           "description\n"
+                           ".sp\n"
+                           "description2\n"
+                           ".SH POSITIONAL ARGUMENTS\n"
+                           ".TP\n"
+                           "\\fBARGUMENT-1\\fP (\\fIsigned 8 bit integer\\fP)\n"
+                           "this is a positional option. \n"
+                           ".TP\n"
+                           "\\fBARGUMENT-2\\fP (\\fIList\\fP of \\fIstd::string\\fP's)\n"
+                           "this is a positional option. Default: []. \n"
+                           ".SH OPTIONS\n"
+                           ".SS Basic options:\n"
+                           ".TP\n"
+                           "\\fB-h\\fP, \\fB--help\\fP\n"
+                           "Prints the help page.\n"
+                           ".TP\n"
+                           "\\fB-hh\\fP, \\fB--advanced-help\\fP\n"
+                           "Prints the help page including advanced options.\n"
+                           ".TP\n"
+                           "\\fB--version\\fP\n"
+                           "Prints the version information.\n"
+                           ".TP\n"
+                           "\\fB--copyright\\fP\n"
+                           "Prints the copyright/license information.\n"
+                           ".TP\n"
+                           "\\fB--export-help\\fP (std::string)\n"
+                           "Export the help page information. Value must be one of [html, man].\n"
+                           ".TP\n"
+                           "\\fB--version-check\\fP (bool)\n"
+                           "Whether to to check for the newest app version. Default: 1.\n"
+                           ".SS \n"
+                           ".TP\n"
+                           "\\fB-i\\fP, \\fB--int\\fP (\\fIsigned 32 bit integer\\fP)\n"
+                           "this is a int option. Default: 5. \n"
+                           ".TP\n"
+                           "\\fB-j\\fP, \\fB--jint\\fP (\\fIsigned 32 bit integer\\fP)\n"
+                           "this is a required int option. \n"
+                           ".SH FLAGS\n"
+                           ".SS SubFlags\n"
+                           "here come all the flags\n"
+                           ".TP\n"
+                           "\\fB-f\\fP, \\fB--flag\\fP\n"
+                           "this is a flag.\n"
+                           ".TP\n"
+                           "\\fB-k\\fP, \\fB--kflag\\fP\n"
+                           "this is a flag.\n"
+                           ".SH EXAMPLES\n"
+                           "example\n"
+                           ".sp\n"
+                           "example2\n"};
+    {
+        // Test the dummy parser without any copyright or citations.
+        testing::internal::CaptureStdout();
+        EXPECT_EXIT(parser.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
+
+        my_stdout = testing::internal::GetCapturedStdout();
+        EXPECT_EQ(my_stdout, expected);
+    }
+    // Add a short copyright and test the dummy parser.
+    parser.info.short_copyright = "short copyright";
+    {
+        expected += std::string{".SH LEGAL\n"
+                                "\\fBdefault Copyright:\\fR short copyright\n"
+                                ".br\n"
+                                "\\fBSeqAn Copyright:\\fR 2006-2015 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.\n"
+                                ".br\n"};
+        testing::internal::CaptureStdout();
+        EXPECT_EXIT(parser.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
+
+        my_stdout = testing::internal::GetCapturedStdout();
+        EXPECT_EQ(my_stdout, expected);
+    }
+    // Now add a citation and test it again.
+    parser.info.citation = "citation";
+    {
+        expected += std::string{"\\fBIn your academic works please cite:\\fR citation\n"
+                                ".br\n"};
+        testing::internal::CaptureStdout();
+        EXPECT_EXIT(parser.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
+
+        my_stdout = testing::internal::GetCapturedStdout();
+        EXPECT_EQ(my_stdout, expected);
+    }
+    // Lastly, add a long copyright and test it one more time.
+    parser.info.long_copyright = "looong copyright";
+    {
+        expected += std::string{"For full copyright and/or warranty information see \\fB--copyright\\fR.\n"};
+        testing::internal::CaptureStdout();
+        EXPECT_EXIT(parser.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
+
+        my_stdout = testing::internal::GetCapturedStdout();
+        EXPECT_EQ(my_stdout, expected);
+    }
+}


### PR DESCRIPTION
Adds two tests, one for a bare bones parser and another for a fully fleshed parser.