### PR TITLE
[FIX] Always use https if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 This changelog contains a top-level entry for each release with sections on new features, API changes and notable
 bug-fixes (not all bug-fixes will be listed).
-See the documentation on [API stability](http://docs.seqan.de/seqan/3-master-user/about_api.html) to learn about
+See the documentation on [API stability](https://docs.seqan.de/seqan/3-master-user/about_api.html) to learn about
 when API changes are allowed.
 
 <!--

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -46,7 +46,7 @@ DAMAGE.
 # Documentation
 
 The API documentation and manual are additionally provided under the
-terms of the [Creative Commons Attribution 4.0 International License](http://creativecommons.org/licenses/by/4.0/).
+terms of the [Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0/).
 This includes
   * doxygen-style comments within the library source code;
   * Markdown files and images in the `doc`-subfolder;

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ for:
 
 By leveraging *Modern C++* it provides unprecedented ease-of-use without sacrificing performance.
 
-Please see the [online documentation](http://docs.seqan.de/seqan/3-master-user/) for more details.
+Please see the [online documentation](https://docs.seqan.de/seqan/3-master-user/) for more details.
 
 ## Quick facts
 
@@ -32,7 +32,7 @@ Please see the [online documentation](http://docs.seqan.de/seqan/3-master-user/)
 
 |                   | requirement                                          | version  | comment                                     |
 |-------------------|------------------------------------------------------|----------|---------------------------------------------|
-|**compiler**       | [GCC](http://gcc.gnu.org)                            | ≥ 7      | no other compiler is currently supported!   |
+|**compiler**       | [GCC](https://gcc.gnu.org)                           | ≥ 7      | no other compiler is currently supported!   |
 |**build system**   | [CMake](https://cmake.org)                           | ≥ 3.4    | optional, but recommended                   |
 |**required libs**  | [SDSL](https://github.com/xxsds/sdsl-lite)           | ≥ 3      |                                             |
 |                   | [Range-V3](https://github.com/ericniebler/range-v3)  | ≥ 1.0    |                                             |
@@ -44,7 +44,7 @@ Please see the [online documentation](http://docs.seqan.de/seqan/3-master-user/)
 
 We recommend that you use CMake to build your project:
 
-  * [Setup-Tutorial](http://docs.seqan.de/seqan/3-master-user/setup.html)
+  * [Setup-Tutorial](https://docs.seqan.de/seqan/3-master-user/setup.html)
   * Using CMake guarantees that all optional dependencies are automatically detected and activated.
 
 Quick-Setup without CMake:

--- a/doc/howto/write_a_view/index.md
+++ b/doc/howto/write_a_view/index.md
@@ -9,7 +9,7 @@ This HowTo documents how to write a view using the standard library and some hel
 \note
 Some of the links from this HowTo only resolve in the developer documentation because
 they refer to entities from the seqan3::detail namespace.
-We recommend you open this tutorial from [the developer documentation](http://docs.seqan.de/seqan/3.0.0-master-dev/).
+We recommend you open this tutorial from [the developer documentation](https://docs.seqan.de/seqan/3-master-dev/).
 
 # Motivation
 
@@ -66,7 +66,7 @@ We will discuss the details of these adaptor objects in the following sections.
 
 # Custom range adaptor objects
 
-Read [section 24.7 and 24.7.1 of the C++ standard](http://eel.is/c++draft/range.adaptors).
+Read [section 24.7 and 24.7.1 of the C++ standard](https://eel.is/c++draft/range.adaptors).
 
 The wording of the standard needs some getting used to, but some important notes for us are:
   1. You can pipe a viewable range into series of *adaptor closure objects* and will get back a view (this is also

--- a/doc/tutorial/pairwise_alignment/index.md
+++ b/doc/tutorial/pairwise_alignment/index.md
@@ -290,7 +290,7 @@ How does the result change?
 A special form of the pairwise sequence alignment is the edit distance. This distance metric counts the number of
 edits necessary to transform one sequence into the other. The cost model for the edit distance is fixed. In particular,
 the match score is `0` and the scores for a mismatch and a gap is `-1`. Due to the special metric a fast
-[bitvector](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.332.9395&rep=rep1&type=pdf) implementation can be
+[bitvector](https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.332.9395&rep=rep1&type=pdf) implementation can be
 used to compute the edit distance. This happens in SeqAn automatically if the respective configurations are used.
 To do so, you need a scoring scheme initialised with Manhattan distance (at the moment only
 seqan3::nucleotide_scoring_scheme supports this) and a gap scheme initialised with `-1` for a gap and `0`

--- a/doc/tutorial/ranges/index.md
+++ b/doc/tutorial/ranges/index.md
@@ -281,7 +281,9 @@ On Linux based systems use `/usr/bin/time -v <program> <args>` and look for "Max
 
 On macOS and BSD use `/usr/bin/time -l <program> <args>` and look for "maximum resident set size".
 
-\note This command diplays the peak memory usage and only gives you a first impression. You can use [valgrind](http://valgrind.org/docs/manual/ms-manual.html) if you want to have a more detailed analysis of your memory consumption.
+\note This command diplays the peak memory usage and only gives you a first impression. You can use [valgrind]
+(http://valgrind.org/docs/manual/ms-manual.html) if you want to have a more detailed analysis of your memory
+consumption.
 \endassignment
 \solution
 \include doc/tutorial/ranges/range_solution4.cpp

--- a/doc/tutorial/read_mapper/index.md
+++ b/doc/tutorial/read_mapper/index.md
@@ -36,8 +36,8 @@ map the reads.
 
 # The data
 
-We provide an example [reference](http://ftp.imp.fu-berlin.de/pub/SeqAn/seqan3_read_mapper/reference.fasta)
-and an example [query](http://ftp.imp.fu-berlin.de/pub/SeqAn/seqan3_read_mapper/query.fastq) file.
+We provide an example [reference](https://ftp.imp.fu-berlin.de/pub/SeqAn/seqan3_read_mapper/reference.fasta)
+and an example [query](https://ftp.imp.fu-berlin.de/pub/SeqAn/seqan3_read_mapper/query.fastq) file.
 
 # The indexer
 

--- a/doc/tutorial/sequence_file/index.md
+++ b/doc/tutorial/sequence_file/index.md
@@ -215,7 +215,7 @@ which is a specialisation of seqan3::record and behaves like an std::tuple
 \note It is important to write `auto &` and not just `auto`, otherwise you will copy the record on every iteration.
 
 Since the return type seqan3::record behaves like a tuple, you can also use
-[structured bindings](http://en.cppreference.com/w/cpp/language/structured_binding)
+[structured bindings](https://en.cppreference.com/w/cpp/language/structured_binding)
 to decompose the record into its elements:
 
 \include test/snippet/io/sequence_file/sequence_file_input_decomposed.cpp

--- a/include/seqan3/alphabet/all.hpp
+++ b/include/seqan3/alphabet/all.hpp
@@ -157,7 +157,7 @@
  * In SeqAn3 it is recommended you use the STL container classes like std::vector for storing sequence data,
  * but you can use other class templates if they satisfy the respective seqan3::container, e.g. `std::deque` or
  * <a href="https://github.com/facebook/folly/blob/master/folly/docs/FBVector.md" target="_blank">
- * <tt>folly::fbvector</tt></a> or even <a href="http://doc.qt.io/qt-5/qvector.html" target="_blank">
+ * <tt>folly::fbvector</tt></a> or even <a href="https://doc.qt.io/qt-5/qvector.html" target="_blank">
  * <tt>Qt::QVector</tt></a>.
  *
  * `std::basic_string` is also supported, however, we recommend against using it,

--- a/include/seqan3/alphabet/aminoacid/aa10li.hpp
+++ b/include/seqan3/alphabet/aminoacid/aa10li.hpp
@@ -73,7 +73,7 @@ namespace seqan3
  * residue grouping. Protein Eng., 16(5):323–330, May 2003.\n
  * <sup><b>2</b></sup>Trotta, E. (2016). Selective forces and mutational biases drive stop codon usage
  * in the human genome: a comparison with sense codon usage.
- * BMC Genomics, 17, 366. http://doi.org/10.1186/s12864-016-2692-4
+ * BMC Genomics, 17, 366. https://doi.org/10.1186/s12864-016-2692-4
  *
  * \include test/snippet/alphabet/aminoacid/aa10li.cpp
  */

--- a/include/seqan3/alphabet/aminoacid/aa10murphy.hpp
+++ b/include/seqan3/alphabet/aminoacid/aa10murphy.hpp
@@ -72,7 +72,7 @@ namespace seqan3
  * fold recognition and implications for folding. Protein Eng., 13(3):149–152, Mar 2000.\n
  * <sup><b>2</b></sup>Trotta, E. (2016). Selective forces and mutational biases drive stop codon usage
  * in the human genome: a comparison with sense codon usage.
- * BMC Genomics, 17, 366. http://doi.org/10.1186/s12864-016-2692-4
+ * BMC Genomics, 17, 366. https://doi.org/10.1186/s12864-016-2692-4
  *
  * \include test/snippet/alphabet/aminoacid/aa10murphy.cpp
  */

--- a/include/seqan3/alphabet/aminoacid/aa20.hpp
+++ b/include/seqan3/alphabet/aminoacid/aa20.hpp
@@ -54,7 +54,7 @@ namespace seqan3
  * Science, 164(3881), 788-798. doi:10.1126/science.164.3881.788\n
  * <sup><b>2</b></sup>Trotta, E. (2016). Selective forces and mutational biases drive stop codon usage
  * in the human genome: a comparison with sense codon usage.
- * BMC Genomics, 17, 366. http://doi.org/10.1186/s12864-016-2692-4
+ * BMC Genomics, 17, 366. https://doi.org/10.1186/s12864-016-2692-4
  *
  * \include test/snippet/alphabet/aminoacid/aa20_construction.cpp
  */

--- a/include/seqan3/alphabet/aminoacid/translation_genetic_code.hpp
+++ b/include/seqan3/alphabet/aminoacid/translation_genetic_code.hpp
@@ -20,7 +20,7 @@ namespace seqan3
  *
  * \details
  * The numeric values of the enums correspond to the genbank transl_table values
- * (see http://www.ncbi.nlm.nih.gov/Taxonomy/Utils/wprintgc.cgi).
+ * (see https://www.ncbi.nlm.nih.gov/Taxonomy/Utils/wprintgc.cgi).
  */
 enum struct genetic_code : uint8_t
 {

--- a/include/seqan3/argument_parser/argument_parser.hpp
+++ b/include/seqan3/argument_parser/argument_parser.hpp
@@ -172,7 +172,7 @@ public:
      * The application name must only contain alpha-numeric characters, '_' or '-',
      * i.e. the following regex must evaluate to true: `\"^[a-zA-Z0-9_-]+$\"`.
      *
-     * See the [argument parser tutorial](http://docs.seqan.de/seqan/3.0.0-master-dev/tutorial_argument_parser.html)
+     * See the [argument parser tutorial](https://docs.seqan.de/seqan/3-master-dev/tutorial_argument_parser.html)
      * for more information about the version check functionality.
      */
     argument_parser(std::string const app_name,
@@ -207,7 +207,7 @@ public:
      *                     If option_type is a container, its value type must have the
      *                     formatted input function (exception: std::string is not
      *                     regarded as a container).
-     *                     See <a href="http://en.cppreference.com/w/cpp/concept/FormattedInputFunction"> FormattedInputFunction </a>.
+     *                     See <a href="https://en.cppreference.com/w/cpp/concept/FormattedInputFunction"> FormattedInputFunction </a>.
      * \tparam validator_type The type of validator to be applied to the option
      *                        value. Must satisfy seqan3::validator.
      *
@@ -263,7 +263,7 @@ public:
      *                     If option_type is a container, its value type must have the
      *                     formateted input function (exception: std::string is not
      *                     regarded as a container).
-     *                     See <a href="http://en.cppreference.com/w/cpp/concept/FormattedInputFunction"> FormattedInputFunction </a>.
+     *                     See <a href="https://en.cppreference.com/w/cpp/concept/FormattedInputFunction"> FormattedInputFunction </a>.
      * \tparam validator_type The type of validator to be applied to the option
      *                        value. Must satisfy seqan3::validator.
      *

--- a/include/seqan3/contrib/stream/bgzf_stream_util.hpp
+++ b/include/seqan3/contrib/stream/bgzf_stream_util.hpp
@@ -87,7 +87,7 @@ struct DefaultPageSize<detail::bgzf_compression>
 {
     static const unsigned MAX_BLOCK_SIZE = 64 * 1024;
     static const unsigned BLOCK_FOOTER_LENGTH = 8;
-    // 5 bytes block overhead (see 3.2.4. at http://www.gzip.org/zlib/rfc-deflate.html)
+    // 5 bytes block overhead (see 3.2.4. at https://tools.ietf.org/html/rfc1951)
     static const unsigned ZLIB_BLOCK_OVERHEAD = 5;
 
     // Reduce the maximal input size, such that the compressed data

--- a/include/seqan3/contrib/stream/gz_istream.hpp
+++ b/include/seqan3/contrib/stream/gz_istream.hpp
@@ -43,7 +43,7 @@ const size_t GZ_INPUT_DEFAULT_BUFFER_SIZE = 921600;
 // Class basic_gz_istreambuf
 // --------------------------------------------------------------------------
 // A stream decorator that takes compressed input and unzips it to a istream.
-// The class wraps up the deflate method of the zlib library 1.1.4 http://www.gzip.org/zlib/
+// The class wraps up the deflate method of the zlib library 1.1.4 https://www.zlib.net
 
 template <typename Elem,
           typename Tr = std::char_traits<Elem>,

--- a/include/seqan3/contrib/stream/gz_ostream.hpp
+++ b/include/seqan3/contrib/stream/gz_ostream.hpp
@@ -55,7 +55,7 @@ enum EStrategy
 // Class basic_gz_ostreambuf
 // --------------------------------------------------------------------------
 // A stream decorator that takes raw input and zips it to a ostream.
-// The class wraps up the inflate method of the zlib library 1.1.4 http://www.gzip.org/zlib/
+// The class wraps up the inflate method of the zlib library 1.1.4 https://www.zlib.net
 
 template <typename Elem,
           typename Tr = std::char_traits<Elem>,

--- a/include/seqan3/core/concept/core_language.hpp
+++ b/include/seqan3/core/concept/core_language.hpp
@@ -75,7 +75,7 @@ namespace seqan3
  * \tparam t1   The first type to compare.
  * \tparam t2   The second type to compare.
  * \brief       Requires the two operands to be comparable with `==` and `!=` in both directions.
- * \sa          http://en.cppreference.com/w/cpp/experimental/ranges/concepts/weakly_equality_comparable_with
+ * \sa          https://en.cppreference.com/w/cpp/experimental/ranges/concepts/weakly_equality_comparable_with
  */
 //!\cond
 template <typename t1, typename t2>
@@ -107,7 +107,7 @@ SEQAN3_CONCEPT explicitly_convertible_to = requires (t vt) { { static_cast<u>(vt
 
 /*!\interface   seqan3::arithmetic <>
  * \brief       A type that satisfies std::is_arithmetic_v<t>.
- * \sa          http://en.cppreference.com/w/cpp/types/is_arithmetic
+ * \sa          https://en.cppreference.com/w/cpp/types/is_arithmetic
  */
 //!\cond
 template <typename t>
@@ -117,7 +117,7 @@ SEQAN3_CONCEPT arithmetic = std::is_arithmetic_v<t>;
 /*!\interface   seqan3::floating_point <>
  * \extends     seqan3::arithmetic
  * \brief       An arithmetic type that also satisfies std::is_floating_point_v<t>.
- * \sa          http://en.cppreference.com/w/cpp/types/is_floating_point
+ * \sa          https://en.cppreference.com/w/cpp/types/is_floating_point
  */
 //!\cond
 template <typename t>
@@ -143,7 +143,7 @@ SEQAN3_CONCEPT builtin_character = std::integral<t> &&
 /*!\interface   seqan3::trivially_destructible <>
  * \extends     std::destructible
  * \brief       A type that satisfies std::is_trivially_destructible_v<t>.
- * \sa          http://en.cppreference.com/w/cpp/types/is_destructible
+ * \sa          https://en.cppreference.com/w/cpp/types/is_destructible
  */
 //!\cond
 template <typename t>
@@ -153,7 +153,7 @@ SEQAN3_CONCEPT trivially_destructible = std::destructible<t> && std::is_triviall
 /*!\interface   seqan3::trivially_copyable
  * \brief       A type that satisfies std::is_trivially_copyable_v<t>.
  * \extends     std::copyable
- * \sa          http://en.cppreference.com/w/cpp/types/is_trivially_copyable
+ * \sa          https://en.cppreference.com/w/cpp/types/is_trivially_copyable
  */
 //!\cond
 template <typename t>
@@ -164,7 +164,7 @@ SEQAN3_CONCEPT trivially_copyable = std::copyable<t> && std::is_trivially_copyab
  * \brief       A type that satisfies seqan3::trivially_copyable and seqan3::trivially_destructible.
  * \extends     seqan3::trivially_copyable
  * \extends     seqan3::trivially_destructible
- * \sa          http://en.cppreference.com/w/cpp/experimental/ranges/concepts/copyable
+ * \sa          https://en.cppreference.com/w/cpp/experimental/ranges/concepts/copyable
  */
 //!\cond
 template <typename t>

--- a/include/seqan3/core/detail/strong_type.hpp
+++ b/include/seqan3/core/detail/strong_type.hpp
@@ -102,7 +102,7 @@ namespace seqan3::detail
  * implementation the underlying value can then be extracted using the `getter`-member functions of the
  * seqan3::detail::strong_type class. However, there might be scenarios, where the strong type is exposed to the user
  * to work with, but with a restricted set of operations that can be applied to the type.
- * A familiar use case are the time typedefs of the [std::chrono](http://en.cppreference.com/w/cpp/header/chrono)
+ * A familiar use case are the time typedefs of the [std::chrono](https://en.cppreference.com/w/cpp/header/chrono)
  * library. It is convenient for the user to subtract two time values representing, for example seconds, to get the
  * duration between two time points. But not all operations like modulo or multiplication are really useful for this.
  * In order to add skills to the seqan3::detail::strong_type the typedef can be further specialized with

--- a/include/seqan3/core/pod_tuple.hpp
+++ b/include/seqan3/core/pod_tuple.hpp
@@ -32,7 +32,7 @@ struct pod_tuple
 {};
 //!\endcond
 
-/*!\brief Behaves like std::tuple but is an aggregate [PODType](http://en.cppreference.com/w/cpp/concept/PODType).
+/*!\brief Behaves like std::tuple but is an aggregate [PODType](https://en.cppreference.com/w/cpp/concept/PODType).
  * \ingroup core
  * \implements seqan3::tuple_like
  * \tparam type0    The first type (the first type).
@@ -43,10 +43,10 @@ struct pod_tuple
  * actually enforces this on all types in the tuple (if you want to add non POD types, just use
  * std::tuple instead).
  *
- * It (only) supports [aggregate initialization](http://en.cppreference.com/w/cpp/language/aggregate_initialization),
+ * It (only) supports [aggregate initialization](https://en.cppreference.com/w/cpp/language/aggregate_initialization),
  * i.e. you must use brace-initializiers and cannot
  * use paranthesis. You can use seqan3::get or std::get and also
- * [structured bindings](http://en.cppreference.com/w/cpp/language/declarations#Structured_binding_declaration)
+ * [structured bindings](https://en.cppreference.com/w/cpp/language/declarations#Structured_binding_declaration)
  * to access the elements in the tuple.
  *
  * \include test/snippet/core/pod_tuple.cpp
@@ -170,7 +170,7 @@ pod_tuple(types && ...) -> pod_tuple<types...>;
 
 /*!\name Access an element of a pod_tuple by index
  * \{
- * \brief The same as [std::get](http://en.cppreference.com/w/cpp/utility/tuple/get) on an std::tuple.
+ * \brief The same as [std::get](https://en.cppreference.com/w/cpp/utility/tuple/get) on an std::tuple.
  *
  * Note that these functions are available, both, in the seqan3 namespace and in namespace std.
  */
@@ -221,7 +221,7 @@ constexpr auto const && get(seqan3::pod_tuple<types...> const && t) noexcept
 //!\}
 
 /*!\name Access an element of a pod_tuple by type
- * \brief The same as [std::get](http://en.cppreference.com/w/cpp/utility/tuple/get) on an std::tuple.
+ * \brief The same as [std::get](https://en.cppreference.com/w/cpp/utility/tuple/get) on an std::tuple.
  *
  * Note that these functions are available, both, in the seqan3 namespace and in namespace std.
  * As is the case with std::tuple, this function is only defined if the type appears once

--- a/include/seqan3/io/alignment_file/input.hpp
+++ b/include/seqan3/io/alignment_file/input.hpp
@@ -290,7 +290,7 @@ struct alignment_file_input_default_traits
  *
  * Note that this is not the same as writing `alignment_file_input<>` (with angle brackets). In the latter case they
  * are explicitly set to their default values, in the former case
- * [automatic deduction](http://en.cppreference.com/w/cpp/language/class_template_argument_deduction) happens which
+ * [automatic deduction](https://en.cppreference.com/w/cpp/language/class_template_argument_deduction) happens which
  * chooses different parameters depending on the constructor arguments. For opening from file, `alignment_file_input<>`
  * would have also worked, but for opening from stream it would not have.
  *
@@ -333,7 +333,7 @@ struct alignment_file_input_default_traits
  * ### Reading record-wise (decomposed records)
  *
  * Instead of using `get` on the record, you can also use
- * [structured bindings](http://en.cppreference.com/w/cpp/language/structured_binding)
+ * [structured bindings](https://en.cppreference.com/w/cpp/language/structured_binding)
  * to decompose the record into its elements. Considering the example of reading only the flag and mapping quality
  * like before you can also write:
  *

--- a/include/seqan3/io/alignment_file/output.hpp
+++ b/include/seqan3/io/alignment_file/output.hpp
@@ -103,7 +103,7 @@ namespace seqan3
  * Note that this is not the same as writing `alignment_file_output<>`
  * (with angle brackets). In the latter case they are explicitly set to their
  * default values, in the former case
- * [automatic deduction](http://en.cppreference.com/w/cpp/language/class_template_argument_deduction)
+ * [automatic deduction](https://en.cppreference.com/w/cpp/language/class_template_argument_deduction)
  * happens which chooses different parameters depending on the constructor arguments.
  * For opening from file, `alignment_file_output<>` would have also worked, but for
  * opening from stream it would not have.

--- a/include/seqan3/io/all.hpp
+++ b/include/seqan3/io/all.hpp
@@ -21,7 +21,7 @@
  * | **Format** | **Extension**   | **Dependency**                   | **Description**                                   |
  * |:-----------|:----------------|:---------------------------------|:--------------------------------------------------|
  * | GZip       | `.gz`¹          | [zlib](https://zlib.net/)        | GNU-Zip, most common format on UNIX               |
- * | BGZF       | `.gz`, `.bgzf`² | [zlib](https://zlib.net/)        | [Blocked GZip](http://samtools.github.io/hts-specs/SAMv1.pdf), compatible extension to GZip, features parallelisation|
+ * | BGZF       | `.gz`, `.bgzf`² | [zlib](https://zlib.net/)        | [Blocked GZip](https://samtools.github.io/hts-specs/SAMv1.pdf), compatible extension to GZip, features parallelisation|
  * | BZip2      | `.bz2`          | [libbz2](https://www.bzip.org)   | Stronger compression than GZip, slower to compress |
  *
  * <small>¹ SeqAn always assumes GZip and does not handle pure `.Z`.<br>
@@ -94,7 +94,7 @@
  * This enables you to store data structures like indexes or sequences directly to disk.
  *
  * We use the [cereal library](https://github.com/USCiLab/cereal) to accomplish this.
- * For more information see [cereal's documentation](http://uscilab.github.io/cereal/) or our tutorial on
+ * For more information see [cereal's documentation](https://uscilab.github.io/cereal/) or our tutorial on
  * \ref tutorial_index_search which contains an example.
  */
 

--- a/include/seqan3/io/detail/ignore_output_iterator.hpp
+++ b/include/seqan3/io/detail/ignore_output_iterator.hpp
@@ -33,7 +33,7 @@ public:
     /*!\name Member types
      * \{
      * \brief Associated types are void for output iterators, see also
-     * [output iterator concept](http://en.cppreference.com/w/cpp/concept/output_iterator).
+     * [output iterator concept](https://en.cppreference.com/w/cpp/concept/output_iterator).
      */
 
     //!\brief The value type (void).

--- a/include/seqan3/io/detail/out_file_iterator.hpp
+++ b/include/seqan3/io/detail/out_file_iterator.hpp
@@ -39,7 +39,7 @@ namespace seqan3::detail
  * std::ranges::default_sentinel always return false (there is no end in an output file).
  *
  * If any of these characteristics seem unusual to you, please refer to the [standard library's
- * documentation on output iterators](http://en.cppreference.com/w/cpp/concept/output_iterator).
+ * documentation on output iterators](https://en.cppreference.com/w/cpp/concept/output_iterator).
  *
  * This class template differs from std::back_insert_iterator only in that it performs
  * no checks itself on the assigned values and that it allows comparisons against

--- a/include/seqan3/io/sequence_file/format_genbank.hpp
+++ b/include/seqan3/io/sequence_file/format_genbank.hpp
@@ -52,8 +52,8 @@ namespace seqan3
  *
  * ### Introduction
  *
- * genbank is the format used in GenBank sequence database. See
- * (http://quma.cdb.riken.jp/help/gbHelp.html) for a an in-depth description of the format.
+ * genbank is the format used in the GenBank sequence database. See [this example record at NCBI]
+ * (https://www.ncbi.nlm.nih.gov/Sitemap/samplerecord.html) for more details about the format.
  *
  * ### fields_specialisation
  *

--- a/include/seqan3/io/sequence_file/input.hpp
+++ b/include/seqan3/io/sequence_file/input.hpp
@@ -260,7 +260,7 @@ struct sequence_file_input_default_traits_aa : sequence_file_input_default_trait
  *
  * Note that this is not the same as writing `sequence_file_input<>` (with angle brackets). In the latter case they are
  * explicitly set to their default values, in the former case
- * [automatic deduction](http://en.cppreference.com/w/cpp/language/class_template_argument_deduction) happens which
+ * [automatic deduction](https://en.cppreference.com/w/cpp/language/class_template_argument_deduction) happens which
  * chooses different parameters depending on the constructor arguments. For opening from file, `sequence_file_input<>`
  * would have also worked, but for opening from stream it would not have.
  *
@@ -295,7 +295,7 @@ struct sequence_file_input_default_traits_aa : sequence_file_input_default_trait
  * ### Reading record-wise (decomposed records)
  *
  * Instead of using `get` on the record, you can also use
- * [structured bindings](http://en.cppreference.com/w/cpp/language/structured_binding)
+ * [structured bindings](https://en.cppreference.com/w/cpp/language/structured_binding)
  * to decompose the record into its elements:
  *
  * \include test/snippet/io/sequence_file/sequence_file_input_decomposed.cpp

--- a/include/seqan3/io/sequence_file/output.hpp
+++ b/include/seqan3/io/sequence_file/output.hpp
@@ -93,7 +93,7 @@ namespace seqan3
  *
  * Note that this is not the same as writing `sequence_file_output<>` (with angle brackets). In the latter case they are
  * explicitly set to their default values, in the former case
- * [automatic deduction](http://en.cppreference.com/w/cpp/language/class_template_argument_deduction) happens which
+ * [automatic deduction](https://en.cppreference.com/w/cpp/language/class_template_argument_deduction) happens which
  * chooses different parameters depending on the constructor arguments. Prefer deduction over explicit defaults.
  *
  * ### Writing record-wise

--- a/include/seqan3/io/stream/concept.hpp
+++ b/include/seqan3/io/stream/concept.hpp
@@ -23,9 +23,9 @@ namespace seqan3
  * \ingroup stream
  * \brief Concept for output streams.
  *
- * An object is an output stream if it inherits from the [std::ios_base](http://en.cppreference.com/w/cpp/io/ios_base)
+ * An object is an output stream if it inherits from the [std::ios_base](https://en.cppreference.com/w/cpp/io/ios_base)
  * and supports the (un)formatted output function (`operator<<`) for a l-value of a given `value_type`.
- * It further needs to define the public member types as described in the [STD](http://en.cppreference.com/w/cpp/io/basic_ios).
+ * It further needs to define the public member types as described in the [STD](https://en.cppreference.com/w/cpp/io/basic_ios).
  */
 //!\cond
 template <typename stream_type, typename value_type>
@@ -90,9 +90,9 @@ SEQAN3_CONCEPT output_stream = requires { typename std::remove_reference_t<strea
  * \ingroup stream
  * \brief Concept for input streams.
  *
- * An object is an input stream if it inherits from the [std::ios_base](http://en.cppreference.com/w/cpp/io/ios_base)
+ * An object is an input stream if it inherits from the [std::ios_base](https://en.cppreference.com/w/cpp/io/ios_base)
  * and supports the (un)formatted input function (`operator>>`) for a l-value of a given `value_type`.
- * It further needs to define the public member types as described in the [STD](http://en.cppreference.com/w/cpp/io/basic_ios).
+ * It further needs to define the public member types as described in the [STD](https://en.cppreference.com/w/cpp/io/basic_ios).
  */
 //!\cond
 template <typename stream_type, typename value_type>

--- a/include/seqan3/io/structure_file/input.hpp
+++ b/include/seqan3/io/structure_file/input.hpp
@@ -491,7 +491,7 @@ struct structure_file_input_default_traits_aa : structure_file_input_default_tra
  *
  * Note that this is not the same as writing `structure_file_input<>` (with angle brackets). In the latter case they are
  * explicitly set to their default values, in the former case
- * [automatic deduction](http://en.cppreference.com/w/cpp/language/class_template_argument_deduction) happens which
+ * [automatic deduction](https://en.cppreference.com/w/cpp/language/class_template_argument_deduction) happens which
  * chooses different parameters depending on the constructor arguments. For opening from file, `structure_file_input<>`
  * would have also worked, but for opening from stream it would not have.
  *
@@ -526,7 +526,7 @@ struct structure_file_input_default_traits_aa : structure_file_input_default_tra
  * ### Reading record-wise (decomposed records)
  *
  * Instead of using `get` on the record, you can also use
- * [structured bindings](http://en.cppreference.com/w/cpp/language/structured_binding)
+ * [structured bindings](https://en.cppreference.com/w/cpp/language/structured_binding)
  * to decompose the record into its elements:
  *
  * \include test/snippet/io/structure_file/structure_file_input_structured_bindings.cpp

--- a/include/seqan3/io/structure_file/output.hpp
+++ b/include/seqan3/io/structure_file/output.hpp
@@ -99,7 +99,7 @@ namespace seqan3
  *
  * Note that this is not the same as writing `structure_file_output<>` (with angle brackets). In the latter case they are
  * explicitly set to their default values, in the former case
- * [automatic deduction](http://en.cppreference.com/w/cpp/language/class_template_argument_deduction) happens which
+ * [automatic deduction](https://en.cppreference.com/w/cpp/language/class_template_argument_deduction) happens which
  * chooses different parameters depending on the constructor arguments. Prefer deduction over explicit defaults.
  *
  * ### Writing record-wise

--- a/include/seqan3/range/concept.hpp
+++ b/include/seqan3/range/concept.hpp
@@ -50,7 +50,7 @@ SEQAN3_CONCEPT const_iterable_range =
 /*!\interface seqan3::forwarding_range<>
  * \extends std::Range
  * \brief Specifies a range whose iterators may outlive the range and remain valid.
- * \see http://eel.is/c++draft/range.req
+ * \see https://eel.is/c++draft/range.req
  */
 //!\cond
 template <typename type>

--- a/include/seqan3/range/container/aligned_allocator.hpp
+++ b/include/seqan3/range/container/aligned_allocator.hpp
@@ -52,8 +52,8 @@ namespace seqan3
  * As you can see, in the case of the aligned_allocator it is guaranteed that the
  * first element in the vector starts at offset 0.
  *
- * \see http://en.cppreference.com/w/cpp/concept/Allocator
- * \see http://en.cppreference.com/w/cpp/memory/c/aligned_alloc
+ * \see https://en.cppreference.com/w/cpp/concept/Allocator
+ * \see https://en.cppreference.com/w/cpp/memory/c/aligned_alloc
  */
 template <typename value_t, size_t alignment_v = __STDCPP_DEFAULT_NEW_ALIGNMENT__>
 class aligned_allocator
@@ -118,7 +118,7 @@ public:
         // causes the function to fail and return a null pointer (C11, as
         // published, specified undefined behavior in this case, this was
         // corrected by DR 460).
-        // http://en.cppreference.com/w/cpp/memory/c/aligned_alloc
+        // https://en.cppreference.com/w/cpp/memory/c/aligned_alloc
         if (auto p = static_cast<pointer>(std::aligned_alloc(alignment, n * sizeof(value_type))))
             return p;
 #endif

--- a/include/seqan3/range/container/all.hpp
+++ b/include/seqan3/range/container/all.hpp
@@ -22,6 +22,6 @@
 /*!\defgroup container container
  * \brief The container submodule contains special SeqAn3 containers and generic container concepts.
  * \ingroup range
- * \sa http://en.cppreference.com/w/cpp/container
+ * \sa https://en.cppreference.com/w/cpp/container
  * \sa range/container/all.hpp
  */

--- a/include/seqan3/range/container/concept.hpp
+++ b/include/seqan3/range/container/concept.hpp
@@ -67,7 +67,7 @@ namespace seqan3
  * \extends seqan3::const_iterable_range
  * \brief The (most general) container concept as defined by the standard library.
  * \details
- * The container concept is modelled as in the [STL](http://en.cppreference.com/w/cpp/concept/Container), but
+ * The container concept is modelled as in the [STL](https://en.cppreference.com/w/cpp/concept/Container), but
  * additionally requires std::swap() to be implemented.
  *
  * \attention
@@ -132,7 +132,7 @@ SEQAN3_CONCEPT container = requires (type val, type val2, type const cval, typen
  *
  * Includes constraints on constructors, `assign()`, `.insert()`, `.erase()`, `.push_back()`, `.pop_back`, `.clear()`,
  * `.size()`, `front()` and `.back()` member functions with corresponding signatures. Models the subset of the
- * [STL SequenceConcept](http://en.cppreference.com/w/cpp/concept/SequenceConcept) that is supported
+ * [STL SequenceConcept](https://en.cppreference.com/w/cpp/concept/SequenceConcept) that is supported
  * by `std::list`, `std::vector`, `std::deque`, `std::basic_string`.
  *
  * \attention
@@ -192,7 +192,7 @@ SEQAN3_CONCEPT sequence_container = requires (type val, type val2, type const cv
  * \brief A more refined container concept than seqan3::sequence_container.
  *
  * Adds requirements for `.at()`, `.resize()` and the subscript operator `[]`. Models the subset of the
- * [STL SequenceConcept](http://en.cppreference.com/w/cpp/concept/SequenceConcept) that is supported
+ * [STL SequenceConcept](httpa://en.cppreference.com/w/cpp/concept/SequenceConcept) that is supported
  * by `std::vector`, `std::deque` and `std::basic_string`.
  *
  * \attention

--- a/include/seqan3/range/view/all.hpp
+++ b/include/seqan3/range/view/all.hpp
@@ -39,7 +39,7 @@
  * \details
  *
  * SeqAn3 makes heavy use of views as defined in the
- * [Ranges Technical Specification](http://en.cppreference.com/w/cpp/experimental/ranges). From the original
+ * [Ranges Technical Specification](https://en.cppreference.com/w/cpp/experimental/ranges). From the original
  * documentation:  <i>"A view is a lightweight wrapper that presents a view of an underlying sequence of elements in
  * some custom way without mutating or copying it. Views are cheap to create and copy, and have non-owning reference
  * semantics. [...] The big advantage of ranges over iterators is their composability. They permit a functional style

--- a/include/seqan3/std/concepts
+++ b/include/seqan3/std/concepts
@@ -298,7 +298,7 @@ SEQAN3_CONCEPT copy_constructible =
  * \extends     std::assignable_from
  * \extends     std::swappable
  *
- * \sa http://en.cppreference.com/w/cpp/concepts/movable
+ * \sa https://en.cppreference.com/w/cpp/concepts/movable
  */
 //!\cond
 template < class T >
@@ -347,7 +347,7 @@ namespace std::detail
  * \tparam t1   The first type to compare.
  * \tparam t2   The second type to compare.
  * \brief       Requires the two operands to be comparable with `==` and `!=` in both directions.
- * \sa          http://en.cppreference.com/w/cpp/concepts/weakly_equality_comparable_with
+ * \sa          https://en.cppreference.com/w/cpp/concepts/weakly_equality_comparable_with
  */
 //!\cond
 template <class T, class U>
@@ -368,7 +368,7 @@ namespace std
 
 /*!\interface   std::equality_comparable <>
  * \brief       The same as std::weakly_equality_comparable_with<t,t>.
- * \sa          http://en.cppreference.com/w/cpp/concepts/equality_comparable
+ * \sa          https://en.cppreference.com/w/cpp/concepts/equality_comparable
  */
 /*!\name Requirements for std::equality_comparable
  * \brief You can expect these functions on all types that implement std::Equality_comparable.
@@ -401,7 +401,7 @@ SEQAN3_CONCEPT equality_comparable = detail::weakly_equality_comparable_with<T, 
  *              their common_reference_t satisfy std::equality_comparable.
  * \tparam t1   The first type to compare.
  * \tparam t2   The second type to compare.
- * \sa          http://en.cppreference.com/w/cpp/concepts/equality_comparable
+ * \sa          https://en.cppreference.com/w/cpp/concepts/equality_comparable
  */
 //!\cond
 template <class T, class U>
@@ -417,7 +417,7 @@ SEQAN3_CONCEPT equality_comparable_with =
 /*!\interface   std::totally_ordered
  * \extends     std::equality_comparable
  * \brief       Requires std::equality_comparable and all remaing comparison operators (`<`, `<=`, `>`, `>=`).
- * \sa          http://en.cppreference.com/w/cpp/concepts/totally_ordered
+ * \sa          https://en.cppreference.com/w/cpp/concepts/totally_ordered
  */
 /*!\name Requirements for std::totally_ordered
  * \brief You can expect these functions on all types that implement std::totally_ordered.
@@ -466,7 +466,7 @@ SEQAN3_CONCEPT totally_ordered =
  * \brief       Requires std::equality_comparable and all remaing comparison operators (`<`, `<=`, `>`, `>=`).
  * \tparam t1   The first type to compare.
  * \tparam t2   The second type to compare.
- * \sa          http://en.cppreference.com/w/cpp/concepts/totally_ordered
+ * \sa          https://en.cppreference.com/w/cpp/concepts/totally_ordered
  */
 //!\cond
 template <class T, class U>
@@ -500,7 +500,7 @@ SEQAN3_CONCEPT totally_ordered_with =
  *              requires that the type be std::assignable_from bool from a `const &` of itself.
  * \extends     std::movable
  * \extends     std::copy_constructible
- * \sa          http://en.cppreference.com/w/cpp/concepts/copyable
+ * \sa          https://en.cppreference.com/w/cpp/concepts/copyable
  */
 //!\cond
 template <class T>
@@ -511,7 +511,7 @@ SEQAN3_CONCEPT copyable = copy_constructible<T> && movable<T> && assignable_from
  * \brief       Subsumes std::copyable and std::default_constructible.
  * \extends     std::copyable
  * \extends     std::default_constructible
- * \sa          http://en.cppreference.com/w/cpp/concepts/semiregular
+ * \sa          https://en.cppreference.com/w/cpp/concepts/semiregular
  */
 //!\cond
 template <class T>
@@ -522,7 +522,7 @@ SEQAN3_CONCEPT semiregular = copyable<T> && default_constructible<T>;
  * \brief       Subsumes std::semiregular and std::equality_comparable.
  * \extends     std::semiregular
  * \extends     std::equality_comparable
- * \sa          http://en.cppreference.com/w/cpp/concepts/regular
+ * \sa          https://en.cppreference.com/w/cpp/concepts/regular
  */
 //!\cond
 template <class T>
@@ -535,7 +535,7 @@ SEQAN3_CONCEPT regular = semiregular<T> && equality_comparable<T>;
 
 /*!\interface   std::invocable <>
  * \brief       Specifies whether the given callable is invocable with the given arguments.
- * \sa          http://en.cppreference.com/w/cpp/concepts/invocable
+ * \sa          https://en.cppreference.com/w/cpp/concepts/invocable
  */
 //!\cond
 template< class F, class... Args >
@@ -551,7 +551,7 @@ SEQAN3_CONCEPT invocable =
  * \extends     std::invocable
  * \brief       Specifies whether the given callable is invocable with the given arguments and equality preserving
  *              (invocations change neither the callable, nor the arguments).
- * \sa          http://en.cppreference.com/w/cpp/concepts/regular_invocable
+ * \sa          https://en.cppreference.com/w/cpp/concepts/regular_invocable
  */
 //!\cond
 template< class F, class... Args >
@@ -561,7 +561,7 @@ SEQAN3_CONCEPT regular_invocable = invocable<F, Args...>;
 /*!\interface   std::predicate <>
  * \extends     std::regular_invocable
  * \brief       Specifies whether the given callable is std::regular_invocable and returns bool.
- * \sa          http://en.cppreference.com/w/cpp/concepts/predicate
+ * \sa          https://en.cppreference.com/w/cpp/concepts/predicate
  */
 //!\cond
 template < class F, class... Args >
@@ -572,7 +572,7 @@ SEQAN3_CONCEPT predicate = regular_invocable<F, Args...> && boolean<std::invoke_
  * \extends     std::predicate
  * \brief       Specifies that R defines a binary relation over the set of expressions whose type and value category
  *              are those encoded by either t or u.
- * \sa          http://en.cppreference.com/w/cpp/concepts/relation
+ * \sa          https://en.cppreference.com/w/cpp/concepts/relation
  */
 //!\cond
 template <class R, class T, class U>
@@ -591,7 +591,7 @@ SEQAN3_CONCEPT relation =
  * \extends     std::relation
  * \brief       The concept strict_weak_order<R, T, U> specifies that the relation R imposes a strict weak ordering
  *              on its arguments.
- * \sa          http://en.cppreference.com/w/cpp/concepts/relation
+ * \sa          https://en.cppreference.com/w/cpp/concepts/relation
  */
 //!\cond
 template < class R, class T, class U >

--- a/include/seqan3/std/ranges
+++ b/include/seqan3/std/ranges
@@ -55,7 +55,7 @@ namespace std::ranges
 /*!\interface std::ranges::range <>
  * \brief Defines the requirements of a type that allows iteration over its elements by providing a begin iterator
  * and an end sentinel.
- * \sa http://en.cppreference.com/w/cpp/ranges/Range
+ * \sa https://en.cppreference.com/w/cpp/ranges/Range
  */
 //!\cond
 template <typename type>
@@ -65,7 +65,7 @@ SEQAN3_CONCEPT range = ::ranges::Range<type>;
 /*!\interface std::ranges::sized_range <>
  * \extends std::ranges::range
  * \brief Specifies the requirements of a Range type that knows its size in constant time with the size function.
- * \sa http://en.cppreference.com/w/cpp/ranges/sized_range
+ * \sa https://en.cppreference.com/w/cpp/ranges/sized_range
  */
 //!\cond
 template <typename type>
@@ -75,7 +75,7 @@ SEQAN3_CONCEPT sized_range = range<type> && ::ranges::SizedRange<type>;
 /*!\interface std::ranges::common_range  <>
  * \extends std::ranges::range
  * \brief Specifies requirements of a Range type for which `begin` and `end` return objects of the same type.
- * \sa http://en.cppreference.com/w/cpp/ranges/BoundedRange
+ * \sa https://en.cppreference.com/w/cpp/ranges/BoundedRange
  */
 //!\cond
 template <typename type>
@@ -86,7 +86,7 @@ SEQAN3_CONCEPT common_range = range<type> && ::ranges::CommonRange<type>;
  * \extends std::ranges::range
  * \brief Specifies requirements of a Range type for which `begin` returns a type that models
  * std::output_iterator.
- * \sa http://en.cppreference.com/w/cpp/ranges/output_range
+ * \sa https://en.cppreference.com/w/cpp/ranges/output_range
  */
 //!\cond
 template <typename type, typename out_type>
@@ -97,7 +97,7 @@ SEQAN3_CONCEPT output_range = range<type> && ::ranges::OutputRange<type, out_typ
  * \extends std::ranges::range
  * \brief Specifies requirements of a Range type for which `begin` returns a type that models
  * std::input_iterator.
- * \sa http://en.cppreference.com/w/cpp/ranges/input_range
+ * \sa https://en.cppreference.com/w/cpp/ranges/input_range
  */
 //!\cond
 template <typename type>
@@ -108,7 +108,7 @@ SEQAN3_CONCEPT input_range = range<type> && ::ranges::InputRange<type>;
  * \extends std::ranges::input_range
  * \brief Specifies requirements of a Range type for which `begin` returns a type that models
  * std::forward_iterator.
- * \sa http://en.cppreference.com/w/cpp/ranges/forward_range
+ * \sa https://en.cppreference.com/w/cpp/ranges/forward_range
  */
 //!\cond
 template <typename type>
@@ -119,7 +119,7 @@ SEQAN3_CONCEPT forward_range = input_range<type> && ::ranges::ForwardRange<type>
  * \extends std::ranges::forward_range
  * \brief Specifies requirements of a Range type for which `begin` returns a type that models
  * std::bidirectional_iterator.
- * \sa http://en.cppreference.com/w/cpp/ranges/bidirectional_range
+ * \sa https://en.cppreference.com/w/cpp/ranges/bidirectional_range
  */
 //!\cond
 template <typename type>
@@ -130,7 +130,7 @@ SEQAN3_CONCEPT bidirectional_range = forward_range<type> && ::ranges::Bidirectio
  * \extends std::ranges::bidirectional_range
  * \brief Specifies requirements of a Range type for which `begin` returns a type that models
  * std::random_access_iterator.
- * \sa http://en.cppreference.com/w/cpp/ranges/random_access_range
+ * \sa https://en.cppreference.com/w/cpp/ranges/random_access_range
  */
 //!\cond
 template <typename type>
@@ -151,7 +151,7 @@ SEQAN3_CONCEPT contiguous_range = random_access_range<type> && ::ranges::Contigu
  * \extends std::ranges::viewable_range
  * \brief Specifies the requirements of a Range type that has constant time copy, move and assignment operators.
  * \sa \ref view
- * \sa http://en.cppreference.com/w/cpp/ranges/View
+ * \sa https://en.cppreference.com/w/cpp/ranges/View
  */
 //!\cond
 template <typename type>

--- a/test/documentation/seqan3_doxygen_cfg.in
+++ b/test/documentation/seqan3_doxygen_cfg.in
@@ -52,7 +52,7 @@ PREDEFINED             = "CEREAL_SERIALIZE_FUNCTION_NAME=serialize" \
 
 EXPAND_AS_DEFINED      = SEQAN3_CPO_IMPL SEQAN3_DEPRECATED_310
 
-TAGFILES               += "${SEQAN3_DOXYGEN_STD_TAGFILE}=http://en.cppreference.com/w/"
+TAGFILES               += "${SEQAN3_DOXYGEN_STD_TAGFILE}=https://en.cppreference.com/w/"
 
 EXCLUDE_SYMBOLS        = seqan3::contrib
 

--- a/test/unit/core/bit_manipulation_test.cpp
+++ b/test/unit/core/bit_manipulation_test.cpp
@@ -168,7 +168,7 @@ TYPED_TEST(unsigned_operations, count_trailing_zeros)
     }
 }
 
-// http://graphics.stanford.edu/~seander/bithacks.html#NextBitPermutation
+// https://graphics.stanford.edu/~seander/bithacks.html#NextBitPermutation
 template <std::unsigned_integral unsigned_t>
 unsigned_t permute_bits(unsigned_t v)
 {

--- a/test/unit/range/container/container_concept_test.cpp
+++ b/test/unit/range/container/container_concept_test.cpp
@@ -61,7 +61,7 @@ TEST(container_, sequence_container_former_travis_bug)
     // see https://github.com/seqan/seqan3/pull/113/
     using namespace std::string_literals;
 
-    // example code from http://en.cppreference.com/w/cpp/string/basic_string/insert
+    // example code from https://en.cppreference.com/w/cpp/string/basic_string/insert
     std::string s = "xmplr";
 
     // insert(size_type index, size_type count, char ch)


### PR DESCRIPTION
This PR also fixes dead links.

No HTTPS available:

bzip.org
cmbi.ru.nl
doxygen.nl
ericniebler.com
open-std.org
seqan-update.informatik.uni-tuebingen.de
stroustrup.com
valgrind.org


We also have some XML with the xml-namespace set to the default stuff.
Since it doesn't really matter what is written there, we could just use `https` there (valid URL) or just put whatever namespace there.
But this isn't technically an URL, but an URI (?) and never accessed anyway.
