### PR TITLE
[FIX, FEATURE] Fixes some formats and restructures test: detail -> public

### DIFF
--- a/include/seqan3/io/alignment_file/format_sam.hpp
+++ b/include/seqan3/io/alignment_file/format_sam.hpp
@@ -312,7 +312,7 @@ public:
             auto seq_stream = field_view | std::views::transform([is_legal_alph] (char const c) // enforce legal alphabet
                                            {
                                                if (!is_legal_alph(c))
-                                                   throw format_error{std::string{"Encountered an unexpected letter: "} +
+                                                   throw parse_error{std::string{"Encountered an unexpected letter: "} +
                                                                      is_legal_alph.msg.str() +
                                                                      " evaluated to false on " +
                                                                      detail::make_printable(c)};

--- a/include/seqan3/io/sequence_file/format_genbank.hpp
+++ b/include/seqan3/io/sequence_file/format_genbank.hpp
@@ -143,10 +143,19 @@ public:
             else
             {
                 detail::consume(stream_view | views::take_until(!is_blank));
-                // read id
-                std::ranges::copy(stream_view | views::take_until_or_throw(is_cntrl || is_blank)
-                                              | views::char_to<value_type_t<id_type>>,
-                                                std::back_inserter(id));
+
+                auto read_id_until = [&stream_view, &id] (auto predicate)
+                {
+                    std::ranges::copy(stream_view | views::take_until_or_throw(predicate)
+                                                  | views::char_to<value_type_t<id_type>>,
+                                                    std::back_inserter(id));
+                };
+
+                if (options.truncate_ids)
+                    read_id_until(is_space);
+                else
+                    read_id_until(is_cntrl);
+
                 detail::consume(stream_view | views::take_line_or_throw);
             }
         }

--- a/include/seqan3/io/sequence_file/format_sam.hpp
+++ b/include/seqan3/io/sequence_file/format_sam.hpp
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include <seqan3/io/alignment_file/format_sam.hpp>
+#include <seqan3/io/exception.hpp>
 #include <seqan3/io/sequence_file/input_format_concept.hpp>
 #include <seqan3/io/sequence_file/input_options.hpp>
 #include <seqan3/io/sequence_file/output_format_concept.hpp>
@@ -99,10 +100,10 @@ public:
 
         if constexpr (!detail::decays_to_ignore_v<seq_type>)
             if (std::ranges::distance(sequence) == 0)
-                throw format_error{"The sequence information must not be empty."};
+                throw parse_error{"The sequence information must not be empty."};
         if constexpr (!detail::decays_to_ignore_v<id_type>)
             if (std::ranges::distance(id) == 0)
-                throw format_error{"The sequence information must not be empty."};
+                throw parse_error{"The id information must not be empty."};
 
         if (options.truncate_ids)
             id = id | views::take_until_and_consume(is_space) | std::ranges::to<id_type>;

--- a/include/seqan3/io/sequence_file/format_sam.hpp
+++ b/include/seqan3/io/sequence_file/format_sam.hpp
@@ -23,6 +23,8 @@
 #include <seqan3/io/sequence_file/input_options.hpp>
 #include <seqan3/io/sequence_file/output_format_concept.hpp>
 #include <seqan3/io/sequence_file/output_options.hpp>
+#include <seqan3/range/views/take_until.hpp>
+#include <seqan3/std/ranges>
 
 namespace seqan3::detail
 {
@@ -71,7 +73,7 @@ public:
               typename id_type,
               typename qual_type>
     void read(stream_type                                                               & stream,
-              sequence_file_input_options<seq_legal_alph_type, seq_qual_combined> const & SEQAN3_DOXYGEN_ONLY(options),
+              sequence_file_input_options<seq_legal_alph_type, seq_qual_combined> const & options,
               seq_type                                                                  & sequence,
               id_type                                                                   & id,
               qual_type                                                                 & qualities)
@@ -96,11 +98,14 @@ public:
         }
 
         if constexpr (!detail::decays_to_ignore_v<seq_type>)
-            if (std::distance(std::ranges::begin(sequence), std::ranges::end(sequence)) == 0)
+            if (std::ranges::distance(sequence) == 0)
                 throw format_error{"The sequence information must not be empty."};
         if constexpr (!detail::decays_to_ignore_v<id_type>)
-            if (std::distance(std::ranges::begin(id), std::ranges::end(id)) == 0)
+            if (std::ranges::distance(id) == 0)
                 throw format_error{"The sequence information must not be empty."};
+
+        if (options.truncate_ids)
+            id = id | views::take_until_and_consume(is_space) | std::ranges::to<id_type>;
     }
 
 private:

--- a/include/seqan3/io/sequence_file/output.hpp
+++ b/include/seqan3/io/sequence_file/output.hpp
@@ -603,7 +603,7 @@ public:
     //!\}
 
     //!\brief The options are public and its members can be set directly.
-    sequence_file_output_options options;
+    sequence_file_output_options options{};
 
     /*!\cond DEV
      * \brief Expose a reference to the secondary stream. [public, but not documented as part of the API]

--- a/test/performance/io/format_fasta_benchmark.cpp
+++ b/test/performance/io/format_fasta_benchmark.cpp
@@ -56,7 +56,7 @@ void write3(benchmark::State & state)
 {
     std::ostringstream ostream;
     detail::sequence_file_output_format_REMOVEME<format_fasta> format;
-    sequence_file_output_options options;
+    sequence_file_output_options options{};
 
     for (auto _ : state)
     {

--- a/test/unit/io/alignment_file/format_sam_test.cpp
+++ b/test/unit/io/alignment_file/format_sam_test.cpp
@@ -183,7 +183,7 @@ TEST_F(sam_format, format_error_illegal_character_in_seq)
     std::istringstream istream(std::string("*\t0\t*\t0\t0\t*\t*\t0\t0\tAC!T\t*\n"));
 
     alignment_file_input fin{istream, format_sam{}};
-    EXPECT_THROW(fin.begin(), format_error);
+    EXPECT_THROW(fin.begin(), parse_error);
 }
 
 TEST_F(sam_format, format_error_invalid_arithmetic_value)

--- a/test/unit/io/sequence_file/sequence_file_format_fastq_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_format_fastq_test.cpp
@@ -6,6 +6,7 @@
 // -----------------------------------------------------------------------------------------------------
 
 #include <sstream>
+#include <string>
 
 #include <gtest/gtest.h>
 
@@ -17,23 +18,74 @@
 #include <seqan3/std/algorithm>
 #include <seqan3/std/ranges>
 
+#include "sequence_file_format_test_template.hpp"
+
 using namespace seqan3;
 
-// ----------------------------------------------------------------------------
-// general
-// ----------------------------------------------------------------------------
-
-TEST(general, concepts)
+template <>
+struct sequence_file_read<format_fastq> : public sequence_file_data
 {
-    EXPECT_TRUE((sequence_file_input_format<format_fastq>));
-    EXPECT_TRUE((sequence_file_output_format<format_fastq>));
-}
+    std::string standard_input
+    {
+        "@ID1\n"
+        "ACGTTTTTTTTTTTTTTT\n"
+        "+\n"
+        "!##$%&'()*+,-./++-\n"
+        "@ID2\n"
+        "ACGTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT\n"
+        "+\n"
+        "!##$&'()*+,-./+)*+,-)*+,-)*+,-)*+,BDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDE\n"
+        "@ID3 lala\n"
+        "ACGTTTA\n"
+        "+\n"
+        "!!!!!!!\n"
+    };
+
+    std::string illegal_alphabet_character_input
+    {
+        "@ID1\n"
+        "ACGTTPTTTTTTTTTTTT\n"
+        "+\n"
+        "!##$%&'()*+,-./++-\n"
+    };
+
+    std::string standard_output
+    {
+        "@ID1\n"
+        "ACGTTTTTTTTTTTTTTT\n"
+        "+\n"
+        "!##$%&'()*+,-./++-\n"
+        "@ID2\n"
+        "ACGTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT\n"
+        "+\n"
+        "!##$&'()*+,-./+)*+,-)*+,-)*+,-)*+,BDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDE\n"
+        "@ID3 lala\n"
+        "ACGTTTA\n"
+        "+\n"
+        "!!!!!!!\n"
+    };
+
+    std::string no_or_ill_formatted_id_input
+    {
+        "#ID1\n"
+        "ACGTTPTTTTTTTTTTTT\n"
+        "+\n"
+        "!##$%&'()*+,-./++-\n"
+    };
+};
+
+// ---------------------------------------------------------------------------------------------------------------------
+// parametrized tests
+// ---------------------------------------------------------------------------------------------------------------------
+
+INSTANTIATE_TYPED_TEST_CASE_P(fastq, sequence_file_read, format_fastq);
+INSTANTIATE_TYPED_TEST_CASE_P(fastq, sequence_file_write, format_fastq);
 
 // ----------------------------------------------------------------------------
 // reading
 // ----------------------------------------------------------------------------
 
-struct read : public ::testing::Test
+struct read : public sequence_file_data
 {
     std::string input
     {
@@ -51,58 +103,23 @@ struct read : public ::testing::Test
         "!!!!!!!\n"
     };
 
-    std::vector<std::string> expected_ids
-    {
-        { "ID1" },
-        { "ID2" },
-        { "ID3 lala" },
-    };
-
-    std::vector<dna5_vector> expected_seqs
-    {
-        { "ACGTTTTTTTTTTTTTTT"_dna5 },
-        { "ACGTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT"_dna5 },
-        { "ACGTTTA"_dna5 },
-    };
-
-    std::vector<std::vector<phred42>> expected_quals
-    {
-        { "!##$%&'()*+,-./++-"_phred42 },
-        { "!##$&'()*+,-./+)*+,-)*+,-)*+,-)*+,BDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDE"_phred42 },
-        { "!!!!!!!"_phred42 },
-    };
-
-    detail::sequence_file_input_format_REMOVEME<format_fastq> format;
-
-    sequence_file_input_options<dna5, false> options;
-
-    std::string id;
-    dna5_vector seq;
-    std::vector<phred42> qual;
+    sequence_file_input_options<dna15, false> options{};
 
     void do_read_test(std::string const & input)
     {
         std::stringstream istream{input};
+        sequence_file_input fin{istream, format_fastq{}};
+        fin.options = options;
 
-        for (unsigned i = 0; i < 3; ++i)
+        auto it = fin.begin();
+        for (unsigned i = 0; i < 3; ++i, ++it)
         {
-            id.clear();
-            seq.clear();
-            qual.clear();
-
-            EXPECT_NO_THROW(( format.read(istream, options, seq, id, qual) ));
-
-            EXPECT_TRUE((std::ranges::equal(seq, expected_seqs[i])));
-            EXPECT_TRUE((std::ranges::equal(id, expected_ids[i])));
-            EXPECT_TRUE((std::ranges::equal(qual, expected_quals[i])));
+            EXPECT_TRUE((std::ranges::equal(get<field::SEQ>(*it), seqs[i])));
+            EXPECT_TRUE((std::ranges::equal(get<field::ID>(*it), ids[i])));
+            EXPECT_TRUE((std::ranges::equal(get<field::QUAL>(*it), quals[i])));
         }
     }
 };
-
-TEST_F(read, standard)
-{
-    do_read_test(input);
-}
 
 TEST_F(read, newline_before_eof)
 {
@@ -184,140 +201,31 @@ TEST_F(read, mixed_issues)
     do_read_test(input);
 }
 
-TEST_F(read, options_truncate_ids)
-{
-    input =
-    {
-        "@ID1\n"
-        "ACGTTTTTTTTTTTTTTT\n"
-        "+\n"
-        "!##$%&'()*+,-./++-\n"
-        "@ID2\n"
-        "ACGTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT\n"
-        "+\n"
-        "!##$&'()*+,-./+)*+,-)*+,-)*+,-)*+,BDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDE\n"
-        "@ID3 lala\n"
-        "ACGTTTA\n"
-        "+\n"
-        "!!!!!!!\n"
-    };
-
-    options.truncate_ids = true;
-    expected_ids[2] = "ID3"; // "lala" is stripped
-    do_read_test(input);
-}
-
-TEST_F(read, only_seq)
-{
-    std::stringstream istream{input};
-
-    for (unsigned i = 0; i < 3; ++i)
-    {
-        id.clear();
-        seq.clear();
-        qual.clear();
-
-        format.read(istream, options, seq, std::ignore, std::ignore);
-
-        EXPECT_TRUE((std::ranges::equal(seq, expected_seqs[i])));
-    }
-}
-
-TEST_F(read, only_id)
-{
-    std::stringstream istream{input};
-
-    for (unsigned i = 0; i < 3; ++i)
-    {
-        id.clear();
-        seq.clear();
-        qual.clear();
-
-        format.read(istream, options, std::ignore, id, std::ignore);
-
-        EXPECT_TRUE((std::ranges::equal(id, expected_ids[i])));
-    }
-}
-
 TEST_F(read, only_qual)
 {
     std::stringstream istream{input};
+    sequence_file_input fin{istream, format_fastq{}, fields<field::QUAL>{}};
 
-    for (unsigned i = 0; i < 3; ++i)
-    {
-        id.clear();
-        seq.clear();
-        qual.clear();
-
-        format.read(istream, options, std::ignore, std::ignore, qual);
-
-        EXPECT_TRUE((std::ranges::equal(qual, expected_quals[i])));
-    }
-}
-
-TEST_F(read, seq_qual)
-{
-    std::stringstream istream{input};
-
-    std::vector<qualified<dna5, phred42>> seq_qual;
-    sequence_file_input_options<dna5, true> options2;
-
-    for (unsigned i = 0; i < 3; ++i)
-    {
-        id.clear();
-        seq_qual.clear();
-
-        format.read(istream, options2, seq_qual, id, seq_qual);
-
-        EXPECT_TRUE((std::ranges::equal(id, expected_ids[i])));
-        EXPECT_TRUE((std::ranges::equal(seq_qual | views::convert<dna5>, expected_seqs[i])));
-        EXPECT_TRUE((std::ranges::equal(seq_qual | views::convert<phred42>, expected_quals[i])));
-    }
-}
-
-TEST_F(read, fail_no_id)
-{
-    input[0] = '#'; // invalid character for ID line
-
-    std::stringstream istream{input};
-
-    EXPECT_THROW( (format.read(istream, options, std::ignore, id, std::ignore)),
-                  parse_error );
+    auto it = fin.begin();
+    for (unsigned i = 0; i < 3; ++i, ++it)
+        EXPECT_TRUE((std::ranges::equal(get<0>(*it), quals[i])));
 }
 
 //TODO fail_no_2nd_id
 TEST_F(read, fail_no_seq_after_id)
 {
-    input =
+    std::stringstream istream{input =
     {
         "@ID1\n"
         "ACGTTTTTTTTTTTTTTT"
-    };
+    }};
 
-    std::stringstream istream{input};
-
-    EXPECT_THROW( (format.read(istream, options, seq, id, qual)),
-                  unexpected_end_of_input );
+    sequence_file_input fin{istream, format_fastq{}};
+    EXPECT_THROW(fin.begin(), unexpected_end_of_input);
 }
 
 //TODO fail_no_quals
 //TODO fail_quals_shorter_seq
-
-TEST_F(read, fail_wrong_char)
-{
-    input =
-    {
-        "@ID1\n"
-        "ACGTTPTTTTTTTTTTTT\n"
-        "+\n"
-        "!##$%&'()*+,-./++-\n"
-    };
-
-    std::stringstream istream{input};
-
-    EXPECT_THROW( (format.read(istream, options, seq, id, qual)),
-                  parse_error );
-}
 
 // ----------------------------------------------------------------------------
 // writing
@@ -346,120 +254,32 @@ struct write : public ::testing::Test
         { "!!*+,-./+*+,-./+!!FF!!"_phred42 },
     };
 
-    detail::sequence_file_output_format_REMOVEME<format_fastq> format;
-
-    sequence_file_output_options options;
+    sequence_file_output_options options{};
 
     std::ostringstream ostream;
 
     void do_write_test()
     {
+        sequence_file_output fout{ostream, format_fastq{}};
+        fout.options = options;
+
         for (unsigned i = 0; i < 3; ++i)
-            EXPECT_NO_THROW(( format.write(ostream, options, seqs[i], ids[i], quals[i]) ));
+            EXPECT_NO_THROW(( fout.emplace_back(seqs[i], ids[i], quals[i]) ));
 
         ostream.flush();
     }
 };
 
-TEST_F(write, arg_handling_id_missing)
-{
-    EXPECT_THROW( (format.write(ostream, options, seqs[0], std::ignore, quals[0])),
-                   std::logic_error );
-}
-
-TEST_F(write, arg_handling_id_empty)
-{
-    EXPECT_THROW( (format.write(ostream, options, seqs[0], std::string_view{""}, quals[0])),
-                   std::runtime_error );
-}
-
-TEST_F(write, arg_handling_seq_missing)
-{
-    EXPECT_THROW( (format.write(ostream, options, std::ignore, ids[0], quals[0])),
-                   std::logic_error );
-}
-
-TEST_F(write, arg_handling_seq_empty)
-{
-    EXPECT_THROW( (format.write(ostream, options, std::string_view{""}, ids[0], quals[0])),
-                   std::runtime_error );
-}
-
 TEST_F(write, arg_handling_qual_missing)
 {
-    EXPECT_THROW( (format.write(ostream, options, seqs[0], ids[0], std::ignore)),
-                   std::logic_error );
+    sequence_file_output fout{ostream, format_fastq{}, fields<field::ID, field::SEQ>{}};
+    EXPECT_THROW((fout.emplace_back(ids[0], seqs[0])), std::logic_error);
 }
 
 TEST_F(write, arg_handling_qual_empty)
 {
-    EXPECT_THROW( (format.write(ostream, options, seqs[0], ids[0], std::string_view{""})),
-                   std::runtime_error );
-}
-
-TEST_F(write, default_options)
-{
-    std::string comp
-    {
-        "@TEST 1\n"
-        "ACGT\n"
-        "+\n"
-        "!##$\n"
-        "@Test2\n"
-        "AGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGN\n"
-        "+\n"
-        "!##$&'()*+,-./+)*+,-)*+,-)*+,-)*+,BDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDBDDEBDBEEBEBE\n"
-        "@Test3\n"
-        "GGAGTATAATATATATATATAT\n"
-        "+\n"
-        "!!*+,-./+*+,-./+!!FF!!\n"
-    };
-
-    do_write_test();
-
-    EXPECT_EQ(ostream.str(), comp);
-}
-
-TEST_F(write, seq_qual)
-{
-    std::vector<std::vector<qualified<dna5, phred42>>> vec;
-    vec.resize(3);
-    for (unsigned i = 0; i < 3; ++i)
-    {
-        vec[i].resize(seqs[i].size());
-        for (unsigned j = 0; j < seqs[i].size(); ++j)
-        {
-            vec[i][j] = seqs[i][j];
-            vec[i][j] = quals[i][j];
-        }
-    }
-
-    for (unsigned i = 0; i < 3; ++i)
-        EXPECT_NO_THROW(( format.write(ostream,
-                                       options,
-                                       vec[i] | views::convert<dna5>,
-                                       ids[i],
-                                       vec[i] | views::convert<phred42>) ));
-
-    ostream.flush();
-
-    std::string comp
-    {
-        "@TEST 1\n"
-        "ACGT\n"
-        "+\n"
-        "!##$\n"
-        "@Test2\n"
-        "AGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGN\n"
-        "+\n"
-        "!##$&'()*+,-./+)*+,-)*+,-)*+,-)*+,BDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDBDDEBDBEEBEBE\n"
-        "@Test3\n"
-        "GGAGTATAATATATATATATAT\n"
-        "+\n"
-        "!!*+,-./+*+,-./+!!FF!!\n"
-    };
-
-    EXPECT_EQ(ostream.str(), comp);
+    sequence_file_output fout{ostream, format_fastq{}};
+    EXPECT_THROW((fout.emplace_back(seqs[0], ids[0], std::string_view{""})), std::runtime_error);
 }
 
 TEST_F(write, options_fastq_double_id)

--- a/test/unit/io/sequence_file/sequence_file_format_genbank_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_format_genbank_test.cpp
@@ -6,52 +6,24 @@
 // -----------------------------------------------------------------------------------------------------
 
 #include <sstream>
+#include <string>
 
 #include <gtest/gtest.h>
 
-#include <seqan3/alphabet/quality/all.hpp>
-#include <seqan3/io/sequence_file/input.hpp>
-#include <seqan3/io/sequence_file/input_format_concept.hpp>
-#include <seqan3/io/sequence_file/output.hpp>
-#include <seqan3/io/sequence_file/output_format_concept.hpp>
-#include <seqan3/io/sequence_file/format_genbank.hpp>
+#include <seqan3/alphabet/nucleotide/dna15.hpp>
+#include <seqan3/io/sequence_file/all.hpp>
 #include <seqan3/test/pretty_printing.hpp>
+
+#include "sequence_file_format_test_template.hpp"
 
 using namespace seqan3;
 
-// ----------------------------------------------------------------------------
-// general
-// ----------------------------------------------------------------------------
-
-TEST(general, concepts)
+template <>
+struct sequence_file_read<format_genbank> : public sequence_file_data
 {
-    EXPECT_TRUE((sequence_file_input_format<format_genbank>));
-    EXPECT_TRUE((sequence_file_output_format<format_genbank>));
-}
-
-// ----------------------------------------------------------------------------
-// reading
-// ----------------------------------------------------------------------------
-
-struct read : public ::testing::Test
-{
-    std::vector<std::string> expected_ids
+    std::string standard_input
     {
-        { "ID1 stuff" },
-        { "ID2" },
-        { "ID3" },
-    };
-
-    std::vector<dna5_vector> expected_seqs
-    {
-        { "ACGTTTTTTTTTTTTTTT"_dna5 },
-        { "ACGTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT"_dna5 },
-        { "ACGTTTA"_dna5 },
-    };
-
-    std::string input
-    {
-R"(LOCUS ID1 stuff
+R"(LOCUS ID1
 DEFINITION  Homo sapiens mRNA for prepro cortistatin like peptide, complete
             cds.
 ACCESSION   ID1
@@ -76,7 +48,7 @@ ORIGIN
         1  ACGTTTTTTT TTTTTTTTTT TTTTTTTTTT TTTTTTTTTT TTTTTTTTTT TTTTTTTTTT
        61 TTTTTTTTTT TTTTTTTTTT TT
 //
-LOCUS ID3
+LOCUS ID3 lala
 DEFINITION  Homo sapiens mRNA for prepro cortistatin like peptide, complete
             cds.
 ACCESSION   ID3
@@ -86,40 +58,81 @@ ORIGIN
 )"
     };
 
-    detail::sequence_file_input_format_REMOVEME<format_genbank> format;
+    std::string illegal_alphabet_character_input
+    {
+R"(LOCUS ID1
+DEFINITION  Homo sapiens mRNA for prepro cortistatin like peptide, complete
+            cds.
+ACCESSION   ID1
+ORIGIN
+        1 ACGTTTT?TT TTTTTTTT
+//
+)"
+    };
 
-    sequence_file_input_options<dna5, false> options;
+    std::string standard_output
+    {
+R"(LOCUS       ID1                 18 bp
+ORIGIN
+        1 ACGTTTTTTT TTTTTTTT
+//
+LOCUS       ID2                 82 bp
+ORIGIN
+        1 ACGTTTTTTT TTTTTTTTTT TTTTTTTTTT TTTTTTTTTT TTTTTTTTTT TTTTTTTTTT
+       61 TTTTTTTTTT TTTTTTTTTT TT
+//
+LOCUS       ID3 lala                 7 bp
+ORIGIN
+        1 ACGTTTA
+//
+)"
+    };
 
-    std::string id;
-    dna5_vector seq;
+    std::string no_or_ill_formatted_id_input
+    {
+R"(LOCOS ID1    stuff
+ORIGIN
+        1 ACGTTTTTTT TTTTTTTT
+//
+)"
+    };
+};
+
+// ---------------------------------------------------------------------------------------------------------------------
+// parametrized tests
+// ---------------------------------------------------------------------------------------------------------------------
+
+INSTANTIATE_TYPED_TEST_CASE_P(genbank, sequence_file_read, format_genbank);
+INSTANTIATE_TYPED_TEST_CASE_P(genbank, sequence_file_write, format_genbank);
+
+// ----------------------------------------------------------------------------
+// reading
+// ----------------------------------------------------------------------------
+
+struct read : public sequence_file_read<format_genbank>
+{
+    sequence_file_input_options<dna15, false> options{};
 
     void do_read_test(std::string const & input)
     {
         std::stringstream istream{input};
 
-        for (unsigned i = 0; i < 3; ++i)
-        {
-            id.clear();
-            seq.clear();
+        sequence_file_input fin{istream, format_genbank{}};
+        fin.options = options;
 
-            EXPECT_NO_THROW(( format.read(istream, options, seq, id, std::ignore) ));
-            EXPECT_EQ(id, expected_ids[i]);
-            EXPECT_EQ(seq, expected_seqs[i]);
-            EXPECT_TRUE((ranges::equal(seq, expected_seqs[i])));
-            EXPECT_TRUE((ranges::equal(id, expected_ids[i])));
+        auto it = fin.begin();
+        for (unsigned i = 0; i < 3; ++i, ++it)
+        {
+            EXPECT_EQ(get<field::ID>(*it), ids[i]);
+            EXPECT_EQ(get<field::SEQ>(*it), seqs[i]);
         }
     }
 };
 
-TEST_F(read, standard)
-{
-    do_read_test(input);
-}
-
 TEST_F(read, complete_header)
 {
     options.embl_genbank_complete_header = true;
-    expected_ids[0] = R"(LOCUS ID1 stuff
+    ids[0] = R"(LOCUS ID1
 DEFINITION  Homo sapiens mRNA for prepro cortistatin like peptide, complete
             cds.
 ACCESSION   ID1
@@ -134,238 +147,41 @@ REFERENCE   1  (bases 1 to 5028)
 FEATURES             Location/Qualifiers
      source          1..5028
 )";
-    expected_ids[1] = R"(LOCUS ID2
+    ids[1] = R"(LOCUS ID2
 DEFINITION  Homo sapiens mRNA for prepro cortistatin like peptide, complete
             cds.
 ACCESSION   ID2
 )";
-    expected_ids[2] = R"(LOCUS ID3
+    ids[2] = R"(LOCUS ID3 lala
 DEFINITION  Homo sapiens mRNA for prepro cortistatin like peptide, complete
             cds.
 ACCESSION   ID3
 )";
-    do_read_test(input);
-}
 
-TEST_F(read, only_seq)
-{
-    std::stringstream istream{input};
-
-    for (unsigned i = 0; i < 3; ++i)
-    {
-        id.clear();
-        seq.clear();
-
-        EXPECT_NO_THROW( (format.read(istream, options, seq, std::ignore, std::ignore) ));
-
-        EXPECT_TRUE((ranges::equal(seq, expected_seqs[i])));
-    }
-}
-
-TEST_F(read, only_id)
-{
-    std::stringstream istream{input};
-
-    for (unsigned i = 0; i < 3; ++i)
-    {
-        id.clear();
-        seq.clear();
-
-        EXPECT_NO_THROW( (format.read(istream, options, std::ignore, id, std::ignore) ));
-
-        EXPECT_TRUE((ranges::equal(id, expected_ids[i])));
-    }
-}
-
-TEST_F(read, ignore_id)
-{
-    std::stringstream istream{input};
-
-    for (unsigned i = 0; i < 3; ++i)
-    {
-        seq.clear();
-
-        EXPECT_NO_THROW( (format.read(istream, options, seq, std::ignore, std::ignore) ));
-
-        EXPECT_TRUE((ranges::equal(seq, expected_seqs[i])));
-    }
-}
-
-TEST_F(read, no_locus)
-{
-    std::string input
-    {
-R"(LOCOS ID1	stuff
-DEFINITION  Homo sapiens mRNA for prepro cortistatin like peptide, complete
-            cds.
-ACCESSION   ID1
-ORIGIN
-        1 ACGTTTTTTT TTTTTTTT
-//
-)"
-    };
-
-    std::stringstream istream{input};
-    seq.clear();
-    EXPECT_THROW( (format.read(istream, options, seq, std::ignore, std::ignore)), parse_error);
-
-}
-
-TEST_F(read, seq_qual)
-{
-    std::stringstream istream{input};
-    sequence_file_input_options<dna5, true> options2;
-
-    std::vector<qualified<dna5, phred42>> seq_qual;
-
-    for (unsigned i = 0; i < 3; ++i)
-    {
-        id.clear();
-        seq_qual.clear();
-
-        EXPECT_NO_THROW( (format.read(istream, options2, seq_qual, id, seq_qual) ));
-
-        EXPECT_TRUE((ranges::equal(id, expected_ids[i])));
-        EXPECT_TRUE((ranges::equal(seq_qual | views::convert<dna5>, expected_seqs[i])));
-    }
-}
-
-TEST_F(read, illegal_alphabet)
-{
-    std::string input
-    {
-R"(LOCUS ID1	stuff
-DEFINITION  Homo sapiens mRNA for prepro cortistatin like peptide, complete
-            cds.
-ACCESSION   ID1
-ORIGIN
-        1 ACGTTTT?TT TTTTTTTT
-//
-)"
-    };
-
-    std::stringstream istream{input};
-    EXPECT_THROW(( format.read(istream, options, seq, id, std::ignore)), parse_error );
-}
-
-TEST_F(read, from_stream_file)
-{
-    sequence_file_input fin{std::istringstream{input}, format_genbank{}, fields<field::SEQ, field::ID>{}};
-
-    size_t counter = 0;
-    for (auto & [ seq, id ] : fin)
-    {
-        EXPECT_TRUE((std::ranges::equal(seq,  expected_seqs[counter])));
-        EXPECT_TRUE((std::ranges::equal(id,  expected_ids[counter])));
-
-        counter++;
-    }
-
-    EXPECT_EQ(counter, 3u);
+    do_read_test(standard_input);
 }
 
 // ----------------------------------------------------------------------------
 // writing
 // ----------------------------------------------------------------------------
 
-struct write : public ::testing::Test
+struct write : public sequence_file_data
 {
-    std::vector<dna5_vector> seqs
-    {
-        { "ACGTTTTTTTTTTTTTTT"_dna5 },
-        { "ACGTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT"_dna5 },
-        { "ACGTTTA"_dna5 },
-    };
-
-    std::vector<std::string> ids
-    {
-        "ID1",
-        "ID2",
-        "ID3"
-    };
-
-    std::string comp
-    {
-R"(LOCUS       ID1                 18 bp
-ORIGIN
-        1 ACGTTTTTTT TTTTTTTT
-//
-LOCUS       ID2                 82 bp
-ORIGIN
-        1 ACGTTTTTTT TTTTTTTTTT TTTTTTTTTT TTTTTTTTTT TTTTTTTTTT TTTTTTTTTT
-       61 TTTTTTTTTT TTTTTTTTTT TT
-//
-LOCUS       ID3                 7 bp
-ORIGIN
-        1 ACGTTTA
-//
-)"
-    };
-
-    detail::sequence_file_output_format_REMOVEME<format_genbank> format;
-
-    sequence_file_output_options options;
+    sequence_file_output_options options{};
 
     std::ostringstream ostream;
 
     void do_write_test()
     {
+        sequence_file_output fout{ostream, format_genbank{}, fields<field::SEQ, field::ID>{}};
+        fout.options = options;
+
         for (unsigned i = 0; i < 3; ++i)
-            EXPECT_NO_THROW(( format.write(ostream, options, seqs[i], ids[i], std::ignore) ));
+            EXPECT_NO_THROW((fout.emplace_back(seqs[i], ids[i])));
 
         ostream.flush();
     }
 };
-
-TEST_F(write, arg_handling_id_missing)
-{
-    EXPECT_THROW( (format.write(ostream, options, seqs[0], std::ignore, std::ignore)),
-                   std::logic_error );
-}
-
-TEST_F(write, arg_handling_id_empty)
-{
-    EXPECT_THROW( (format.write(ostream, options, seqs[0], std::string_view{""}, std::ignore)),
-                   std::runtime_error );
-}
-
-TEST_F(write, arg_handling_seq_missing)
-{
-    EXPECT_THROW( (format.write(ostream, options, std::ignore, ids[0], std::ignore)),
-                   std::logic_error );
-}
-
-TEST_F(write, arg_handling_seq_empty)
-{
-    EXPECT_THROW( (format.write(ostream, options, std::string_view{""}, ids[0], std::ignore)),
-                   std::runtime_error );
-}
-
-TEST_F(write, default_options)
-{
-    do_write_test();
-
-    EXPECT_EQ(ostream.str(), comp);
-}
-
-TEST_F(write, seq_qual)
-{
-    auto convert_to_qualified = std::views::transform([] (auto const in)
-    {
-        return qualified<dna5, phred42>{} = in;
-    });
-
-    for (unsigned i = 0; i < 3; ++i)
-        EXPECT_NO_THROW(( format.write(ostream,
-                                       options,
-                                       seqs[i] | convert_to_qualified,
-                                       ids[i],
-                                       seqs[i] | convert_to_qualified) ));
-
-    ostream.flush();
-
-    EXPECT_EQ(ostream.str(), comp);
-}
 
 TEST_F(write, complete_header)
 {
@@ -435,18 +251,4 @@ SOURCE      .
     do_write_test();
 
     EXPECT_EQ(ostream.str(), comp);
-}
-
-TEST_F(write, from_stream_file)
-{
-    sequence_file_output fout{std::ostringstream{}, format_genbank{}};
-
-    for(int i = 0; i < 3; i++)
-    {
-        fout.emplace_back(seqs[i],ids[i]);
-    }
-
-    fout.get_stream().flush();
-
-    EXPECT_EQ(reinterpret_cast<std::ostringstream&>(fout.get_stream()).str(), comp);
 }

--- a/test/unit/io/sequence_file/sequence_file_format_genbank_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_format_genbank_test.cpp
@@ -37,7 +37,7 @@ struct read : public ::testing::Test
 {
     std::vector<std::string> expected_ids
     {
-        { "ID1" },
+        { "ID1 stuff" },
         { "ID2" },
         { "ID3" },
     };

--- a/test/unit/io/sequence_file/sequence_file_format_test_template.hpp
+++ b/test/unit/io/sequence_file/sequence_file_format_test_template.hpp
@@ -1,0 +1,245 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <seqan3/alphabet/nucleotide/dna5.hpp>
+#include <seqan3/alphabet/quality/all.hpp>
+#include <seqan3/io/sequence_file/all.hpp>
+#include <seqan3/range/views/convert.hpp>
+#include <seqan3/std/ranges>
+#include <seqan3/std/concepts>
+#include <seqan3/test/pretty_printing.hpp>
+
+using namespace seqan3;
+
+struct sequence_file_data : public ::testing::Test
+{
+    std::vector<std::string> ids
+    {
+        { "ID1" },
+        { "ID2" },
+        { "ID3 lala" },
+    };
+
+    std::vector<dna5_vector> seqs
+    {
+        { "ACGTTTTTTTTTTTTTTT"_dna5 },
+        { "ACGTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT"_dna5 },
+        { "ACGTTTA"_dna5 },
+    };
+
+    std::vector<std::vector<phred42>> quals
+    {
+        { "!##$%&'()*+,-./++-"_phred42 },
+        { "!##$&'()*+,-./+)*+,-)*+,-)*+,-)*+,BDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDE"_phred42 },
+        { "!!!!!!!"_phred42 },
+    };
+
+    std::ostringstream ostream{};
+};
+
+template <typename format_t>
+struct sequence_file_read : public sequence_file_data
+{};
+
+TYPED_TEST_CASE_P(sequence_file_read);
+
+// ----------------------------------------------------------------------------
+// general
+// ----------------------------------------------------------------------------
+
+TYPED_TEST_P(sequence_file_read, concept_check)
+{
+    EXPECT_TRUE((sequence_file_input_format<TypeParam>));
+}
+
+// ----------------------------------------------------------------------------
+// sequence_file_read
+// ----------------------------------------------------------------------------
+
+TYPED_TEST_P(sequence_file_read, standard)
+{
+    std::stringstream istream{this->standard_input};
+    sequence_file_input fin{istream, TypeParam{}};
+
+    auto it = fin.begin();
+    for (unsigned i = 0; i < 3; ++i, ++it)
+    {
+        EXPECT_TRUE((std::ranges::equal(get<field::SEQ>(*it), this->seqs[i])));
+        EXPECT_EQ(get<field::ID>(*it), this->ids[i]);
+        if constexpr (std::same_as<TypeParam, format_fastq> || std::same_as<TypeParam, format_sam>)
+        {
+            EXPECT_TRUE((std::ranges::equal(get<field::QUAL>(*it), this->quals[i])));
+        }
+    }
+}
+
+TYPED_TEST_P(sequence_file_read, only_seq)
+{
+    std::stringstream istream{this->standard_input};
+    sequence_file_input fin{istream, TypeParam{}, fields<field::SEQ>{}};
+
+    auto it = fin.begin();
+    for (unsigned i = 0; i < 3; ++i, ++it)
+        EXPECT_EQ(get<0>(*it), this->seqs[i]);
+}
+
+TYPED_TEST_P(sequence_file_read, only_id)
+{
+    std::stringstream istream{this->standard_input};
+    sequence_file_input fin{istream, TypeParam{}, fields<field::ID>{}};
+
+    auto it = fin.begin();
+    for (unsigned i = 0; i < 3; ++i, ++it)
+        EXPECT_EQ(get<0>(*it), this->ids[i]);
+}
+
+TYPED_TEST_P(sequence_file_read, seq_qual)
+{
+    std::stringstream istream{this->standard_input};
+    sequence_file_input fin{istream, TypeParam{}, fields<field::ID, field::SEQ_QUAL>{}};
+
+    auto it = fin.begin();
+    for (unsigned i = 0; i < 3; ++i, ++it)
+    {
+        EXPECT_TRUE((std::ranges::equal(get<field::ID>(*it), this->ids[i])));
+        EXPECT_TRUE((std::ranges::equal(get<field::SEQ_QUAL>(*it) | views::convert<dna5>, this->seqs[i])));
+    }
+}
+
+TYPED_TEST_P(sequence_file_read, options_truncate_ids)
+{
+    std::stringstream istream{this->standard_input};
+    sequence_file_input fin{istream, TypeParam{}, fields<field::ID>{}};
+    fin.options.truncate_ids = true;
+    this->ids[2] = "ID3"; // "lala" is stripped
+
+    auto it = fin.begin();
+    for (unsigned i = 0; i < 3; ++i, ++it)
+        EXPECT_EQ(get<0>(*it), this->ids[i]);
+}
+
+TYPED_TEST_P(sequence_file_read, illegal_alphabet_character)
+{
+    std::stringstream istream{this->illegal_alphabet_character_input};
+    sequence_file_input fin{istream, TypeParam{}};
+    EXPECT_THROW(fin.begin(), parse_error);
+}
+
+TYPED_TEST_P(sequence_file_read, no_or_ill_formatted_id)
+{
+    std::stringstream istream{this->no_or_ill_formatted_id_input};
+    sequence_file_input fin{istream, TypeParam{}};
+    EXPECT_THROW(fin.begin(), parse_error);
+}
+
+// ----------------------------------------------------------------------------
+// sequence_file_write
+// ----------------------------------------------------------------------------
+
+template <typename format_type>
+struct sequence_file_write : public sequence_file_read<format_type>
+{};
+
+TYPED_TEST_CASE_P(sequence_file_write);
+
+TYPED_TEST_P(sequence_file_write, concept_check)
+{
+    EXPECT_TRUE((sequence_file_output_format<TypeParam>));
+}
+
+TYPED_TEST_P(sequence_file_write, standard)
+{
+    sequence_file_output fout{this->ostream, TypeParam{}};
+
+    for (unsigned i = 0; i < 3; ++i)
+        EXPECT_NO_THROW((fout.emplace_back(this->seqs[i], this->ids[i], this->quals[i])));
+
+    this->ostream.flush();
+    EXPECT_EQ(this->ostream.str(), this->standard_output);
+}
+
+TYPED_TEST_P(sequence_file_write, seq_qual)
+{
+    auto convert_to_qualified = std::views::transform([] (auto const in)
+    {
+        return qualified<dna5, phred42>{get<0>(in), get<1>(in)};
+    });
+
+    sequence_file_output fout{this->ostream, TypeParam{}, fields<field::ID, field::SEQ_QUAL>{}};
+
+    for (unsigned i = 0; i < 3; ++i)
+    {
+        EXPECT_NO_THROW((fout.emplace_back(this->ids[i],
+                                           std::views::zip(this->seqs[i], this->quals[i]) | convert_to_qualified)));
+    }
+
+    this->ostream.flush();
+
+    EXPECT_EQ(this->ostream.str(), this->standard_output);
+}
+
+TYPED_TEST_P(sequence_file_write, arg_handling_id_missing)
+{
+    if constexpr (!std::same_as<TypeParam, format_sam>)
+    {
+        sequence_file_output fout{this->ostream, TypeParam{}, fields<field::SEQ>{}};
+        EXPECT_THROW((fout.emplace_back(this->seqs[0])), std::logic_error);
+    }
+}
+
+TYPED_TEST_P(sequence_file_write, arg_handling_id_empty)
+{
+    if constexpr (!std::same_as<TypeParam, format_sam>)
+    {
+        sequence_file_output fout{this->ostream, TypeParam{}, fields<field::SEQ, field::ID>{}};
+        EXPECT_THROW((fout.emplace_back(this->seqs[0], std::string_view{""}, std::ignore)), std::runtime_error);
+    }
+}
+
+TYPED_TEST_P(sequence_file_write, arg_handling_seq_missing)
+{
+    if constexpr (!std::same_as<TypeParam, format_sam>)
+    {
+        sequence_file_output fout{this->ostream, TypeParam{}, fields<field::ID>{}};
+        EXPECT_THROW((fout.emplace_back(this->ids[0])), std::logic_error);
+    }
+}
+
+TYPED_TEST_P(sequence_file_write, arg_handling_seq_empty)
+{
+    if constexpr (!std::same_as<TypeParam, format_sam>)
+    {
+        sequence_file_output fout{this->ostream, TypeParam{}, fields<field::SEQ, field::ID>{}};
+        EXPECT_THROW((fout.emplace_back(std::string_view{""}, this->ids[0], std::ignore)), std::runtime_error);
+    }
+}
+
+REGISTER_TYPED_TEST_CASE_P(sequence_file_read,
+                           concept_check,
+                           standard,
+                           only_seq,
+                           only_id,
+                           seq_qual,
+                           illegal_alphabet_character,
+                           options_truncate_ids,
+                           no_or_ill_formatted_id);
+
+REGISTER_TYPED_TEST_CASE_P(sequence_file_write,
+                           concept_check,
+                           standard,
+                           seq_qual,
+                           arg_handling_id_missing,
+                           arg_handling_id_empty,
+                           arg_handling_seq_missing,
+                           arg_handling_seq_empty);


### PR DESCRIPTION
The restructuring "detail -> public" and a test template **halved the LOC** !

---

* **commit 1: Fix truncate_id option for genbank format.**
The genebank format did not handle the truncate_ids option correctly (It always truncated ids after the first space).


* **commit 2: Fix structured_seq handling to also throw if sequence and structure differ in length..**
The vienna format did only check for equal length in sequence and structure if the seq_type did not decay to std::ignore. It is legal though to read in a structured_seq object (alphabet tuple) in which case seq_type decays to ignore but the same length should still be checked.

* **commit 3: sequence file sam format now truncates ids if specified..**
The sequence file sam format did not handle the truncate_ids option correctly (It never truncated ids after the first space).

* **commit 4: Restructure file IO tests to test public interface.**
The restructuring is necessary before the formats will be changed to be customisable because then, read and write look differently and are protected. If I touch the tests anyway, it is better to test the publich API directly. Also a test template for sequence file formats was introduced.

Some comments:

* In commit 4 there is a name change in format_sam from `format_error` to `parse_error`. Apperrently in sequence file formats we use parse_error everywhere and in alignment files `format_error`. I needed to make this change for the test template but in general we should make the exception names consistent.

* in the sequence file format sam test I deleted a test: wrong_qual3. Wrong quality characters in FASTQ are implicitely casted when reading so this should be the same in both (and it is with the public design)
