### PR TITLE
Massively reduce include graph within alphabet module.

### DIFF
--- a/doc/howto/write_a_view/solution_iterator.cpp
+++ b/doc/howto/write_a_view/solution_iterator.cpp
@@ -11,7 +11,7 @@ struct my_iterator : std::ranges::iterator_t<urng_t>
 {
 //![start]
     //![static_assert]
-    static_assert(nucleotide_alphabet<reference_t<urng_t>>,
+    static_assert(nucleotide_alphabet<std::ranges::range_reference_t<urng_t>>,
                   "You can only iterate over ranges of nucleotides!");
     //![static_assert]
 

--- a/include/seqan3/alignment/scoring/scoring_scheme_base.hpp
+++ b/include/seqan3/alignment/scoring/scoring_scheme_base.hpp
@@ -17,6 +17,7 @@
 
 #include <seqan3/alphabet/concept.hpp>
 #include <seqan3/core/concept/cereal.hpp>
+#include <seqan3/core/concept/core_language.hpp>
 #include <seqan3/core/detail/strong_type.hpp>
 #include <seqan3/range/shortcuts.hpp>
 #include <seqan3/std/algorithm>

--- a/include/seqan3/alphabet/adaptation/char.hpp
+++ b/include/seqan3/alphabet/adaptation/char.hpp
@@ -25,13 +25,8 @@
 
 #pragma once
 
-#include <limits>
-
 #include <seqan3/alphabet/concept.hpp>
-#include <seqan3/core/concept/core_language.hpp>
-#include <seqan3/core/detail/customisation_point.hpp>
 #include <seqan3/core/detail/int_types.hpp>
-#include <seqan3/std/concepts>
 
 namespace seqan3::detail
 {

--- a/include/seqan3/alphabet/adaptation/uint.hpp
+++ b/include/seqan3/alphabet/adaptation/uint.hpp
@@ -25,12 +25,8 @@
 
 #pragma once
 
-#include <limits>
-
 #include <seqan3/alphabet/concept.hpp>
-#include <seqan3/core/detail/customisation_point.hpp>
 #include <seqan3/core/detail/int_types.hpp>
-#include <seqan3/std/concepts>
 
 namespace seqan3::detail
 {

--- a/include/seqan3/alphabet/alphabet_base.hpp
+++ b/include/seqan3/alphabet/alphabet_base.hpp
@@ -14,7 +14,6 @@
 
 #include <seqan3/alphabet/concept.hpp>
 #include <seqan3/core/detail/int_types.hpp>
-#include <seqan3/core/detail/reflection.hpp>
 #include <seqan3/std/concepts>
 #include <seqan3/std/type_traits>
 

--- a/include/seqan3/alphabet/composite/alphabet_variant.hpp
+++ b/include/seqan3/alphabet/composite/alphabet_variant.hpp
@@ -21,17 +21,10 @@
 
 #include <meta/meta.hpp>
 
-#include <seqan3/alphabet/concept.hpp>
-#include <seqan3/alphabet/composite/detail.hpp>
 #include <seqan3/alphabet/alphabet_base.hpp>
-#include <seqan3/core/concept/core_language.hpp>
-#include <seqan3/core/detail/int_types.hpp>
+#include <seqan3/alphabet/composite/detail.hpp>
 #include <seqan3/core/type_traits/pack.hpp>
-#include <seqan3/core/type_traits/range.hpp>
-#include <seqan3/core/type_traits/transformation_trait_or.hpp>
 #include <seqan3/core/tuple_utility.hpp>
-#include <seqan3/std/concepts>
-#include <seqan3/std/type_traits>
 
 namespace seqan3::detail
 {

--- a/include/seqan3/alphabet/composite/detail.hpp
+++ b/include/seqan3/alphabet/composite/detail.hpp
@@ -12,10 +12,7 @@
 
 #pragma once
 
-#include <type_traits>
-
 #include <seqan3/alphabet/concept.hpp>
-#include <seqan3/core/platform.hpp>
 #include <seqan3/core/concept/core_language.hpp>
 
 namespace seqan3::detail

--- a/include/seqan3/alphabet/concept.hpp
+++ b/include/seqan3/alphabet/concept.hpp
@@ -16,7 +16,7 @@
 #include <seqan3/core/concept/cereal.hpp>
 #include <seqan3/core/concept/core_language.hpp>
 #include <seqan3/core/detail/customisation_point.hpp>
-#include <seqan3/core/detail/reflection.hpp>
+#include <seqan3/std/type_traits>
 
 // ============================================================================
 // forwards
@@ -544,7 +544,7 @@ struct assign_char_strictly_to_fn
     decltype(auto) operator()(seqan3::alphabet_char_t<alph_t> const r, alph_t & a) const
     {
         if (!seqan3::char_is_valid_for<alph_t>(r))
-            throw seqan3::invalid_char_assignment{seqan3::detail::get_display_name_v<alph_t>, r};
+            throw seqan3::invalid_char_assignment{"Alphabet", r};
 
         return seqan3::assign_char_to(r, a);
     }

--- a/include/seqan3/alphabet/concept.hpp
+++ b/include/seqan3/alphabet/concept.hpp
@@ -1044,5 +1044,3 @@ SEQAN3_CONCEPT writable_constexpr_alphabet =
 //!\endcond
 
 } // namespace seqan3::detail
-
-#include <seqan3/alphabet/detail/hash.hpp>

--- a/include/seqan3/alphabet/concept.hpp
+++ b/include/seqan3/alphabet/concept.hpp
@@ -17,9 +17,6 @@
 #include <seqan3/core/concept/core_language.hpp>
 #include <seqan3/core/detail/customisation_point.hpp>
 #include <seqan3/core/detail/reflection.hpp>
-#include <seqan3/core/type_traits/basic.hpp>
-#include <seqan3/core/type_traits/function.hpp>
-#include <seqan3/std/concepts>
 
 // ============================================================================
 // forwards

--- a/include/seqan3/alphabet/detail/convert.hpp
+++ b/include/seqan3/alphabet/detail/convert.hpp
@@ -14,11 +14,9 @@
 
 #pragma once
 
-#include <algorithm>
 #include <array>
 
 #include <seqan3/alphabet/concept.hpp>
-#include <seqan3/alphabet/quality/concept.hpp>
 
 // ============================================================================
 // conversion to/from char/rank types

--- a/include/seqan3/alphabet/hash.hpp
+++ b/include/seqan3/alphabet/hash.hpp
@@ -1,0 +1,41 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \author Enrico Seiler <enrico.seiler AT fu-berlin.de>
+ * \brief Provides overloads for std::hash.
+ */
+
+#pragma once
+
+#include <seqan3/alphabet/concept.hpp>
+
+namespace std
+{
+/*!\brief Struct for hashing a character.
+ * \ingroup alphabet
+ * \tparam alphabet_t The type of character to hash; must model seqan3::semialphabet.
+ */
+template <typename alphabet_t>
+//!\cond
+    requires seqan3::semialphabet<alphabet_t>
+//!\endcond
+struct hash<alphabet_t>
+{
+    /*!\brief Compute the hash for a character.
+     * \param[in] character The character to process; must model seqan3::semialphabet.
+     *
+     * \returns The rank of the character.
+     * \sa seqan3::to_rank.
+     */
+    size_t operator()(alphabet_t const character) const noexcept
+    {
+        return seqan3::to_rank(character);
+    }
+};
+
+} // namespace std

--- a/include/seqan3/alphabet/nucleotide/dna4.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna4.hpp
@@ -15,7 +15,6 @@
 #include <vector>
 
 #include <seqan3/alphabet/nucleotide/nucleotide_base.hpp>
-#include <seqan3/core/char_operations/transform.hpp>
 
 // ------------------------------------------------------------------
 // dna4

--- a/include/seqan3/alphabet/quality/aliases.hpp
+++ b/include/seqan3/alphabet/quality/aliases.hpp
@@ -13,9 +13,9 @@
 #pragma once
 
 #include <seqan3/alphabet/concept.hpp>
-#include <seqan3/alphabet/quality/qualified.hpp>
 #include <seqan3/alphabet/quality/concept.hpp>
 #include <seqan3/alphabet/quality/phred42.hpp>
+#include <seqan3/alphabet/quality/qualified.hpp>
 #include <seqan3/alphabet/nucleotide/all.hpp>
 
 namespace seqan3

--- a/include/seqan3/alphabet/structure/concept.hpp
+++ b/include/seqan3/alphabet/structure/concept.hpp
@@ -13,6 +13,7 @@
 #pragma once
 
 #include <optional>
+
 #include <seqan3/alphabet/concept.hpp>
 #include <seqan3/core/detail/customisation_point.hpp>
 #include <seqan3/std/concepts>

--- a/include/seqan3/core/char_operations/predicate_detail.hpp
+++ b/include/seqan3/core/char_operations/predicate_detail.hpp
@@ -23,7 +23,6 @@
 #include <seqan3/alphabet/concept.hpp>
 #include <seqan3/core/detail/reflection.hpp>
 #include <seqan3/core/type_traits/basic.hpp>
-#include <seqan3/range/container/small_string.hpp>
 
 namespace seqan3::detail
 {

--- a/include/seqan3/core/char_operations/transform.hpp
+++ b/include/seqan3/core/char_operations/transform.hpp
@@ -13,7 +13,6 @@
 #pragma once
 
 #include <array>
-#include <cmath>
 
 #include <seqan3/core/concept/core_language.hpp>
 #include <seqan3/core/detail/int_types.hpp>

--- a/include/seqan3/core/concept/core_language.hpp
+++ b/include/seqan3/core/concept/core_language.hpp
@@ -16,7 +16,6 @@
 
 #include <seqan3/core/platform.hpp>
 #include <seqan3/std/concepts>
-#include <seqan3/std/ranges>
 
 namespace seqan3::detail
 {

--- a/include/seqan3/core/detail/int_types.hpp
+++ b/include/seqan3/core/detail/int_types.hpp
@@ -9,7 +9,6 @@
 
 #include <type_traits>
 
-#include <seqan3/core/platform.hpp>
 #include <seqan3/std/concepts>
 
 /*!\file

--- a/include/seqan3/core/type_traits/template_inspection.hpp
+++ b/include/seqan3/core/type_traits/template_inspection.hpp
@@ -12,8 +12,6 @@
 
 #pragma once
 
-#include <meta/meta.hpp>
-
 #include <seqan3/core/type_traits/transformation_trait_or.hpp>
 
 #include <seqan3/std/concepts>

--- a/include/seqan3/core/type_traits/transformation_trait_or.hpp
+++ b/include/seqan3/core/type_traits/transformation_trait_or.hpp
@@ -14,9 +14,6 @@
 
 #include <type_traits>
 
-#include <meta/meta.hpp>
-
-#include <seqan3/core/platform.hpp>
 #include <seqan3/core/type_traits/concept.hpp>
 #include <seqan3/std/type_traits>
 

--- a/include/seqan3/io/alignment_file/header.hpp
+++ b/include/seqan3/io/alignment_file/header.hpp
@@ -17,9 +17,9 @@
 #include <vector>
 
 #include <seqan3/alphabet/concept.hpp>
-#include <seqan3/alphabet/detail/hash.hpp>
 #include <seqan3/core/type_traits/pre.hpp>
 #include <seqan3/io/alignment_file/detail.hpp>
+#include <seqan3/range/hash.hpp>
 #include <seqan3/range/views/view_all.hpp>
 #include <seqan3/std/ranges>
 

--- a/include/seqan3/io/structure_file/detail.hpp
+++ b/include/seqan3/io/structure_file/detail.hpp
@@ -16,6 +16,8 @@
 #include <stack>
 
 #include <seqan3/alphabet/structure/concept.hpp>
+#include <seqan3/io/exception.hpp>
+#include <seqan3/std/ranges>
 
 namespace seqan3::detail
 {

--- a/include/seqan3/range/container/small_string.hpp
+++ b/include/seqan3/range/container/small_string.hpp
@@ -12,7 +12,6 @@
 
 #pragma once
 
-#include <algorithm>
 #include <seqan3/range/container/small_vector.hpp>
 
 namespace seqan3

--- a/include/seqan3/range/container/small_vector.hpp
+++ b/include/seqan3/range/container/small_vector.hpp
@@ -23,9 +23,6 @@
 #include <seqan3/core/detail/int_types.hpp>
 #include <seqan3/core/type_traits/template_inspection.hpp>
 #include <seqan3/range/views/repeat_n.hpp>
-#include <seqan3/range/views/take.hpp>
-#include <seqan3/std/algorithm>
-#include <seqan3/std/ranges>
 
 namespace seqan3
 {

--- a/include/seqan3/range/hash.hpp
+++ b/include/seqan3/range/hash.hpp
@@ -12,34 +12,11 @@
 
 #pragma once
 
-#include <functional>
-
-#include <seqan3/alphabet/concept.hpp>
+#include <seqan3/alphabet/hash.hpp>
+#include <seqan3/core/type_traits/range.hpp>
 
 namespace std
 {
-/*!\brief Struct for hashing a character.
- * \ingroup alphabet
- * \tparam alphabet_t The type of character to hash; Must model seqan3::semialphabet.
- */
-template <typename alphabet_t>
-    //!\cond
-    requires seqan3::semialphabet<alphabet_t>
-    //!\endcond
-struct hash<alphabet_t>
-{
-    /*!\brief Compute the hash for a character.
-     * \param[in] character The character to process. Must model seqan3::semialphabet.
-     *
-     * \returns size_t.
-     * \sa seqan3::to_rank.
-     */
-    size_t operator()(alphabet_t const character) const noexcept
-    {
-        return seqan3::to_rank(character);
-    }
-};
-
 /*!\brief Struct for hashing a range of characters.
  * \ingroup alphabet
  * \tparam urng_t The type of the range; Must model std::ranges::input_range and the reference type of the range of the
@@ -69,4 +46,5 @@ struct hash<urng_t>
         return result;
     }
 };
+
 } // namespace std

--- a/include/seqan3/range/views/kmer_hash.hpp
+++ b/include/seqan3/range/views/kmer_hash.hpp
@@ -15,6 +15,7 @@
 #include <cmath>
 
 #include <seqan3/alphabet/concept.hpp>
+#include <seqan3/range/hash.hpp>
 #include <seqan3/search/kmer_index/shape.hpp>
 
 namespace seqan3::detail

--- a/test/snippet/alphabet/quality/phred42_literal.cpp
+++ b/test/snippet/alphabet/quality/phred42_literal.cpp
@@ -1,15 +1,16 @@
 #include <seqan3/alphabet/quality/phred42.hpp>
 #include <seqan3/core/debug_stream.hpp>
+#include <seqan3/std/algorithm>
 
 int main()
 {
     using seqan3::operator""_phred42;
-    
+
     // directly assign to a std::vector<phred42> using a string literal
     std::vector<seqan3::phred42> qual_vec = "###!"_phred42;
 
     // This is the same as a sequence of char literals:
     std::vector<seqan3::phred42> qual_vec2 = {'#'_phred42, '#'_phred42, '#'_phred42, '!'_phred42};
 
-    seqan3::debug_stream << ranges::equal(qual_vec, qual_vec2) << std::endl; // prints 1 (true)
+    seqan3::debug_stream << std::ranges::equal(qual_vec, qual_vec2) << std::endl; // prints 1 (true)
 }

--- a/test/snippet/alphabet/quality/phred63_literal.cpp
+++ b/test/snippet/alphabet/quality/phred63_literal.cpp
@@ -1,5 +1,6 @@
 #include <seqan3/alphabet/quality/phred63.hpp>
 #include <seqan3/core/debug_stream.hpp>
+#include <seqan3/std/algorithm>
 
 int main()
 {
@@ -11,5 +12,5 @@ int main()
     // This is the same as a sequence of char literals:
     std::vector<seqan3::phred63> qual_vec2 = {'#'_phred63, '#'_phred63, '#'_phred63, '!'_phred63};
 
-    seqan3::debug_stream << ranges::equal(qual_vec, qual_vec2) << std::endl; // prints 1 (true)
+    seqan3::debug_stream << std::ranges::equal(qual_vec, qual_vec2) << std::endl; // prints 1 (true)
 }

--- a/test/snippet/alphabet/quality/phred68legacy_literal.cpp
+++ b/test/snippet/alphabet/quality/phred68legacy_literal.cpp
@@ -1,5 +1,6 @@
 #include <seqan3/alphabet/quality/phred68legacy.hpp>
 #include <seqan3/core/debug_stream.hpp>
+#include <seqan3/std/algorithm>
 
 int main()
 {
@@ -12,5 +13,5 @@ int main()
     std::vector<seqan3::phred68legacy> qual_vec2 = {'#'_phred68legacy, '#'_phred68legacy,
                                                     '#'_phred68legacy, '!'_phred68legacy};
 
-    seqan3::debug_stream << ranges::equal(qual_vec, qual_vec2) << std::endl; // prints 1 (true)
+    seqan3::debug_stream << std::ranges::equal(qual_vec, qual_vec2) << std::endl; // prints 1 (true)
 }

--- a/test/unit/alphabet/alphabet_constexpr_test_template.hpp
+++ b/test/unit/alphabet/alphabet_constexpr_test_template.hpp
@@ -9,8 +9,6 @@
 
 #include <seqan3/alphabet/concept.hpp>
 
-using namespace seqan3;
-
 template <typename T>
 using alphabet_constexpr = ::testing::Test;
 
@@ -18,17 +16,17 @@ TYPED_TEST_CASE_P(alphabet_constexpr);
 
 TYPED_TEST_P(alphabet_constexpr, concept_check)
 {
-    EXPECT_TRUE(detail::constexpr_alphabet<TypeParam   >);
-    EXPECT_TRUE(detail::constexpr_alphabet<TypeParam & >);
+    EXPECT_TRUE(seqan3::detail::constexpr_alphabet<TypeParam   >);
+    EXPECT_TRUE(seqan3::detail::constexpr_alphabet<TypeParam & >);
 
-    EXPECT_TRUE(detail::constexpr_alphabet<TypeParam const   >);
-    EXPECT_TRUE(detail::constexpr_alphabet<TypeParam const & >);
+    EXPECT_TRUE(seqan3::detail::constexpr_alphabet<TypeParam const   >);
+    EXPECT_TRUE(seqan3::detail::constexpr_alphabet<TypeParam const & >);
 
-    EXPECT_TRUE(detail::writable_constexpr_alphabet<TypeParam   >);
-    EXPECT_TRUE(detail::writable_constexpr_alphabet<TypeParam & >);
+    EXPECT_TRUE(seqan3::detail::writable_constexpr_alphabet<TypeParam   >);
+    EXPECT_TRUE(seqan3::detail::writable_constexpr_alphabet<TypeParam & >);
 
-    EXPECT_FALSE(detail::writable_constexpr_alphabet<TypeParam const   >);
-    EXPECT_FALSE(detail::writable_constexpr_alphabet<TypeParam const & >);
+    EXPECT_FALSE(seqan3::detail::writable_constexpr_alphabet<TypeParam const   >);
+    EXPECT_FALSE(seqan3::detail::writable_constexpr_alphabet<TypeParam const & >);
 }
 
 TYPED_TEST_P(alphabet_constexpr, global_assign_char)
@@ -39,7 +37,7 @@ TYPED_TEST_P(alphabet_constexpr, global_assign_char)
 TYPED_TEST_P(alphabet_constexpr, global_to_char)
 {
     constexpr TypeParam t0{TypeParam{}};
-    [[maybe_unused]] constexpr alphabet_char_t<TypeParam> c = seqan3::to_char(t0);
+    [[maybe_unused]] constexpr seqan3::alphabet_char_t<TypeParam> c = seqan3::to_char(t0);
 }
 
 REGISTER_TYPED_TEST_CASE_P(alphabet_constexpr,

--- a/test/unit/alphabet/alphabet_hash_test.cpp
+++ b/test/unit/alphabet/alphabet_hash_test.cpp
@@ -11,6 +11,7 @@
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/alphabet/quality/phred42.hpp>
 #include <seqan3/alphabet/quality/qualified.hpp>
+#include <seqan3/range/hash.hpp>
 
 using namespace seqan3;
 

--- a/test/unit/alphabet/alphabet_test_template.hpp
+++ b/test/unit/alphabet/alphabet_test_template.hpp
@@ -9,7 +9,6 @@
 
 #include <seqan3/alphabet/concept.hpp>
 #include <seqan3/alphabet/exception.hpp>
-#include <seqan3/core/concept/core_language.hpp>
 #include <seqan3/test/pretty_printing.hpp>
 
 using namespace seqan3;

--- a/test/unit/range/views/view_enforce_random_access_test.cpp
+++ b/test/unit/range/views/view_enforce_random_access_test.cpp
@@ -11,6 +11,7 @@
 
 #include <seqan3/range/views/enforce_random_access.hpp>
 #include <seqan3/range/views/to_char.hpp>
+#include <seqan3/std/algorithm>
 #include <seqan3/std/ranges>
 
 #include "../iterator_test_template.hpp"


### PR DESCRIPTION
Right now nearly every small change effects the whole library, because everything includes everything. This PR reduces the number of includes enormously.

### Before:

![Screenshot_2019-09-09 SeqAn3 seqan3 alphabet nucleotide dna15 hpp File Reference(1)](https://user-images.githubusercontent.com/103778/64532290-7a396f80-d311-11e9-84c7-523369c02431.png)

### After:

![Screenshot_2019-09-09 SeqAn3 seqan3 alphabet nucleotide dna15 hpp File Reference](https://user-images.githubusercontent.com/103778/64532332-89b8b880-d311-11e9-8509-bbda4bed9b38.png)
