### PR TITLE
Misc/refactor alignment algorithm final

### DIFF
--- a/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
+++ b/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
@@ -347,7 +347,7 @@ inline void assign_unaligned(aligned_seq_t & aligned_seq, unaligned_sequence_typ
     using std::swap;
     aligned_seq_t tmp;
     tmp.resize(std::ranges::distance(unaligned_seq));
-    std::copy(std::ranges::begin(unaligned_seq), std::ranges::end(unaligned_seq), std::ranges::begin(tmp));
+    std::ranges::copy(unaligned_seq, std::ranges::begin(tmp));
     swap(aligned_seq, tmp);
 }
 //!\}

--- a/include/seqan3/core/type_traits/lazy.hpp
+++ b/include/seqan3/core/type_traits/lazy.hpp
@@ -63,7 +63,7 @@ struct instantiate<lazy<template_t, spec_t...>>
 
 /*!\brief A transformation trait that instantiates seqan3::lazy types. Transformation trait shortcut.
  * \tparam t The type to operate on.
- * \relates seqan3::instantiate
+ * \relates seqan3::detail::instantiate
  */
 template <typename t>
 //!\cond
@@ -95,7 +95,7 @@ struct lazy_conditional : instantiate<std::conditional_t<decision, on_true_t, on
  * \tparam decision   Whether to resolve to the first type or the second.
  * \tparam on_true_t  The return type in case `decision` is true.
  * \tparam on_false_t The return type in case `decision` is false.
- * \relates seqan3::lazy_conditional
+ * \relates seqan3::detail::lazy_conditional
  */
 template <bool decision, typename on_true_t, typename on_false_t>
 //!\cond
@@ -103,5 +103,42 @@ template <bool decision, typename on_true_t, typename on_false_t>
 //!\endcond
 using lazy_conditional_t = instantiate_t<std::conditional_t<decision, on_true_t, on_false_t>>;
 
+/*!\brief An unary type trait that tests whether a template class can be instantiated with the given template type
+ *        parameters.
+ * \implements seqan3::unary_type_trait
+ * \tparam query_t The type of the template class to test.
+ * \tparam args_t  The template parameter pack to instantiate the template class with.
+ *
+ * \details
+ *
+ * Note, this unary type trait can be used in a seqan3::detail::lazy_conditional expression to check if instantiating
+ * a template class with specific template arguments would result in a valid template definition. Thus, the template
+ * parameters of the checked class must be constraint accordingly.
+ *
+ * ### Example
+ *
+ * \include test/snippet/core/type_traits/is_instantiable_with.cpp
+ */
+template <template <typename ...> typename query_t, typename ...args_t>
+struct is_instantiable_with :
+//!\cond
+    public std::false_type
+//!\endcond
+{};
+
+//!\cond
+template <template <typename ...> typename query_t, typename ...args_t>
+    requires requires { typename std::type_identity<query_t<args_t...>>::type; }
+struct is_instantiable_with<query_t, args_t...> : public std::true_type
+{};
+//!\endcond
+
+/*!\brief Helper variable template for seqan3::detail::is_instantiable_with.
+ * \tparam query_t The type of the template class to test.
+ * \tparam args_t  The template parameter pack to instantiate the template class with.
+ * \relates seqan3::detail::is_instantiable_with
+ */
+template <template <typename ...> typename query_t, typename ...args_t>
+inline constexpr bool is_instantiable_with_v = is_instantiable_with<query_t, args_t...>::value;
 //!\}
 } // namespace seqan3::detail

--- a/test/snippet/core/type_traits/is_instantiable_with.cpp
+++ b/test/snippet/core/type_traits/is_instantiable_with.cpp
@@ -1,0 +1,28 @@
+#include <type_traits>
+
+#include <seqan3/core/type_traits/lazy.hpp>
+#include <seqan3/core/debug_stream.hpp>
+
+template <typename t>
+    requires std::is_integral_v<t>
+struct foo
+{
+    t value;
+};
+
+template <typename t>
+auto bar(t const & v)
+{
+    using cond_t = seqan3::detail::lazy_conditional_t<seqan3::detail::is_instantiable_with_v<foo, t>,
+                                                      seqan3::detail::lazy<foo, t>,
+                                                      t>;
+    return cond_t{v};
+}
+
+int main()
+{
+    auto a = bar(10);
+    seqan3::debug_stream << "a: " << a.value << "\n";
+    auto b = bar(0.4f);
+    seqan3::debug_stream << "b: " << b << "\n";
+}

--- a/test/snippet/range/views/test_back_inserter_zip.cpp
+++ b/test/snippet/range/views/test_back_inserter_zip.cpp
@@ -1,0 +1,20 @@
+#include <vector>
+
+#include <seqan3/core/debug_stream.hpp>
+#include <seqan3/std/concepts>
+#include <seqan3/std/ranges>
+
+#include <range/v3/view/zip_with.hpp>
+
+
+int main()
+{
+    std::vector<std::string> id{};
+
+    std::vector<std::string> src{"hello", "world"};
+
+    auto v = ranges::view::zip_with([&](auto cur){ id.push_back(std::move(cur)); }, id);
+    std::ranges::copy(src, std::ranges::begin(v));
+
+    seqan3::debug_stream << id << '\n';
+}

--- a/test/unit/alignment/matrix/detail/aligned_sequence_builder_test.cpp
+++ b/test/unit/alignment/matrix/detail/aligned_sequence_builder_test.cpp
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 
 #include <list>
+#include <vector>
 
 #include <seqan3/alignment/matrix/detail/aligned_sequence_builder.hpp>
 #include <seqan3/alignment/matrix/detail/trace_iterator.hpp>
@@ -74,7 +75,8 @@ struct aligned_sequence_builder_fixture : ::testing::Test
 
 using test_types = ::testing::Types<std::pair<dna4_vector &, dna4_vector &>,
                                     std::pair<dna4_vector &, dna15_vector &>,
-                                    std::pair<dna4_vector &, std::list<dna4> &>>;
+                                    std::pair<dna4_vector &, std::list<dna4> &>,
+                                    std::pair<std::list<dna4> &, std::list<dna4> &>>;
 
 TYPED_TEST_CASE(aligned_sequence_builder_fixture, test_types);
 


### PR DESCRIPTION
In this PR, I switched the internal implementation to the new alignment matrix classes as well as the aligned sequence builder to compute the trace. 
A lot of code could be removed and the kernel policies are more independent of behavioral differences.
The following issues will be addressed with this PR. Note, since all changes are kind of related in a sense, it was difficult to split them further. However, most LOC are due to the added score and trace matrices for the tests and are not so important for the review.

Fixes #1259 
Fixes #1260
Fixes #1261
Fixes #1263

Open TODO:
- [x] remove unused files. 

Please review only commits starting with 9b41080 

Blocked by:

* #1240 
* #1237 