### PR TITLE
Fix/pairwise combine const

### DIFF
--- a/include/seqan3/core/common_tuple.hpp
+++ b/include/seqan3/core/common_tuple.hpp
@@ -1,0 +1,40 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides seqan3::common_tuple and seqan3::common_pair.
+ * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <range/v3/utility/common_tuple.hpp>
+
+#include <seqan3/core/platform.hpp>
+
+namespace seqan3
+{
+
+/*!\brief A common tuple type that behaves like a regular std::tuple, but can be used as a reference type proxy for
+ *        output iterators.
+ *
+ * \details
+ *
+ * Alias definition of the ranges::common_tuple.
+ */
+using SEQAN3_DOXYGEN_ONLY(common_tuple =) ::ranges::common_tuple;
+
+/*!\brief A common pair type that behaves like a regular std::pair, but can be used as a reference type proxy for
+ *        output iterators.
+ *
+ * \details
+ *
+ * Alias definition of the ranges::common_pair.
+ */
+using SEQAN3_DOXYGEN_ONLY(common_pair =) ::ranges::common_pair;
+
+}  // namespace seqan3

--- a/include/seqan3/range/views/pairwise_combine.hpp
+++ b/include/seqan3/range/views/pairwise_combine.hpp
@@ -14,6 +14,7 @@
 
 #include <cmath>
 
+#include <seqan3/core/common_tuple.hpp>
 #include <seqan3/range/concept.hpp>
 #include <seqan3/range/views/detail.hpp>
 #include <seqan3/std/ranges>
@@ -72,8 +73,8 @@ private:
         using underlying_val_t = typename std::iterator_traits<underlying_iterator_type>::value_type;
         //!\brief Alias for the reference type of the underlying iterator type.
         using underlying_ref_t = typename std::iterator_traits<underlying_iterator_type>::reference;
-    public:
 
+    public:
         /*!\name Associated types
          * \{
          */
@@ -83,7 +84,7 @@ private:
         //!\brief The value type.
         using value_type        = std::tuple<underlying_val_t, underlying_val_t>;
         //!\brief The reference type.
-        using reference         = std::tuple<underlying_ref_t, underlying_ref_t>;
+        using reference         = common_tuple<underlying_ref_t, underlying_ref_t>;
         //!\brief The pointer type.
         using pointer           = void;
         //!\brief The iterator category tag.
@@ -143,7 +144,7 @@ private:
         constexpr reference operator*() const
             noexcept(noexcept(*std::declval<underlying_iterator_type>()))
         {
-            return {*first_it, *second_it};
+            return reference{*first_it, *second_it};
         }
 
         /*!\brief Access the element at the given index
@@ -160,8 +161,7 @@ private:
         }
         //!\}
 
-        /*!
-ame Arithmetic operators
+        /*!\name Arithmetic operators
          * \{
          */
         //!\brief Pre-increment operator.
@@ -697,22 +697,22 @@ namespace seqan3::views
  *
  * ### View properties
  *
- * | Concepts and traits              | `urng_t` (underlying range type)      | `rrng_t` (returned range type)                                       |
- * |----------------------------------|:-------------------------------------:|:--------------------------------------------------------------------:|
- * | std::ranges::input_range         | *required*                            | *preserved*                                                          |
- * | std::ranges::forward_range       | *required*                            | *preserved*                                                          |
- * | std::ranges::bidirectional_range |                                       | *preserved*                                                          |
- * | std::ranges::random_access_range |                                       | *preserved*                                                          |
- * | std::ranges::contiguous_range    |                                       | *lost*                                                               |
- * |                                  |                                       |                                                                      |
- * | std::ranges::viewable_range      | *required*                            | *guaranteed*                                                         |
- * | std::ranges::view                |                                       | *guaranteed*                                                         |
- * | std::ranges::sized_range         |                                       | *preserved*                                                          |
- * | std::ranges::common_range        | *required*                            | *guaranteed*                                                         |
- * | std::ranges::output_range        |                                       | *lost*                                                               |
- * | seqan3::const_iterable_range     |                                       | *preserved*                                                          |
- * |                                  |                                       |                                                                      |
- * | std::ranges::range_reference_t   |                                       | std::tuple<seqan3::reference_t<urng_t>, seqan3::reference_t<urng_t>> |
+ * | Concepts and traits              | `urng_t` (underlying range type)      | `rrng_t` (returned range type)                                         |
+ * |----------------------------------|:-------------------------------------:|:----------------------------------------------------------------------:|
+ * | std::ranges::input_range         | *required*                            | *preserved*                                                            |
+ * | std::ranges::forward_range       | *required*                            | *preserved*                                                            |
+ * | std::ranges::bidirectional_range |                                       | *preserved*                                                            |
+ * | std::ranges::random_access_range |                                       | *preserved*                                                            |
+ * | std::ranges::contiguous_range    |                                       | *lost*                                                                 |
+ * |                                  |                                       |                                                                        |
+ * | std::ranges::viewable_range      | *required*                            | *guaranteed*                                                           |
+ * | std::ranges::view                |                                       | *guaranteed*                                                           |
+ * | std::ranges::sized_range         |                                       | *preserved*                                                            |
+ * | std::ranges::common_range        | *required*                            | *guaranteed*                                                           |
+ * | std::ranges::output_range        |                                       | *preserved*                                                            |
+ * | seqan3::const_iterable_range     |                                       | *preserved*                                                            |
+ * |                                  |                                       |                                                                        |
+ * | std::ranges::range_reference_t   |                                       | common_tuple<seqan3::reference_t<urng_t>, seqan3::reference_t<urng_t>> |
  *
  * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.
  *

--- a/test/unit/range/views/view_pairwise_combine_test.cpp
+++ b/test/unit/range/views/view_pairwise_combine_test.cpp
@@ -145,25 +145,25 @@ TYPED_TEST(pairwise_combine_iterator_test, associated_types)
     { // non-const view over non-const range
         using u_ref_t = typename std::iterator_traits<u_iter_t>::reference;
         EXPECT_TRUE((std::is_same_v<typename std::iterator_traits<v_iter_t>::reference,
-                                    std::tuple<u_ref_t, u_ref_t>>));
+                                    seqan3::common_tuple<u_ref_t, u_ref_t>>));
     }
 
     { // non-const view over const range
         using u_ref_t = typename std::iterator_traits<u_const_iter_t>::reference;
         EXPECT_TRUE((std::is_same_v<typename std::iterator_traits<v_const_iter_t>::reference,
-                                    std::tuple<u_ref_t, u_ref_t>>));
+                                    seqan3::common_tuple<u_ref_t, u_ref_t>>));
     }
 
     { // const view over non-const range
         using u_ref_t = typename std::iterator_traits<u_iter_t>::reference;
         EXPECT_TRUE((std::is_same_v<typename std::iterator_traits<const v_iter_t>::reference,
-                                    std::tuple<u_ref_t, u_ref_t>>));
+                                    seqan3::common_tuple<u_ref_t, u_ref_t>>));
     }
 
     { // const view over const range
         using u_ref_t = typename std::iterator_traits<u_const_iter_t>::reference;
         EXPECT_TRUE((std::is_same_v<typename std::iterator_traits<const v_const_iter_t>::reference,
-                                    std::tuple<u_ref_t, u_ref_t>>));
+                                    seqan3::common_tuple<u_ref_t, u_ref_t>>));
     }
 
     { // value type
@@ -353,11 +353,21 @@ TYPED_TEST(pairwise_combine_test, view_concept)
     EXPECT_TRUE(std::ranges::input_range<typename TestFixture::view_t>);
     EXPECT_TRUE(std::ranges::forward_range<typename TestFixture::view_t>);
     EXPECT_TRUE(std::ranges::view<typename TestFixture::view_t>);
-    EXPECT_FALSE((std::ranges::output_range<typename TestFixture::view_t, std::tuple<char &, char &>>));
+    EXPECT_TRUE((std::ranges::output_range<typename TestFixture::view_t, std::tuple<char &, char &>>));
     EXPECT_EQ(std::ranges::bidirectional_range<TypeParam>,
               std::ranges::bidirectional_range<typename TestFixture::view_t>);
     EXPECT_EQ(std::ranges::sized_range<TypeParam>, std::ranges::sized_range<typename TestFixture::view_t>);
     EXPECT_EQ(std::ranges::random_access_range<TypeParam>, std::ranges::random_access_range<typename TestFixture::view_t>);
+
+    EXPECT_TRUE(std::ranges::input_range<typename TestFixture::const_view_t>);
+    EXPECT_TRUE(std::ranges::forward_range<typename TestFixture::const_view_t>);
+    EXPECT_TRUE(std::ranges::view<typename TestFixture::const_view_t>);
+    //TODO: Investigate, because this should be false. It cannot be used as a output range!
+    // EXPECT_FALSE((std::ranges::output_range<typename TestFixture::const_view_t, std::tuple<char, char>>));
+    EXPECT_EQ(std::ranges::bidirectional_range<TypeParam>,
+              std::ranges::bidirectional_range<typename TestFixture::const_view_t>);
+    EXPECT_EQ(std::ranges::sized_range<TypeParam>, std::ranges::sized_range<typename TestFixture::const_view_t>);
+    EXPECT_EQ(std::ranges::random_access_range<TypeParam>, std::ranges::random_access_range<typename TestFixture::const_view_t>);
 }
 
 TYPED_TEST(pairwise_combine_test, basic_construction)
@@ -475,6 +485,22 @@ TEST(pairwise_combine_fn_test, filter_input)
     EXPECT_EQ(*++it, (std::tuple{'a', 'd'}));
     EXPECT_EQ(*++it, (std::tuple{'b', 'c'}));
     EXPECT_EQ(*++it, (std::tuple{'b', 'd'}));
+    EXPECT_EQ(*++it, (std::tuple{'c', 'd'}));
+}
+
+TEST(pairwise_combine_fn_test, output)
+{
+    std::vector orig{'a', 'b', 'c', 'd'};
+    auto v = orig | seqan3::views::pairwise_combine;
+
+    *v.begin() = std::tuple{'x', 'y'};
+
+    auto it = v.begin();
+    EXPECT_EQ(*it,   (std::tuple{'x', 'y'}));
+    EXPECT_EQ(*++it, (std::tuple{'x', 'c'}));
+    EXPECT_EQ(*++it, (std::tuple{'x', 'd'}));
+    EXPECT_EQ(*++it, (std::tuple{'y', 'c'}));
+    EXPECT_EQ(*++it, (std::tuple{'y', 'd'}));
     EXPECT_EQ(*++it, (std::tuple{'c', 'd'}));
 }
 


### PR DESCRIPTION
Adds common_tuple and common_pair alias for ranges versions.
Makes pairwise combine view also an output range and fixes an issue when the underlying range is const.