### PR TITLE
[DOC] Rename all instances of SeqAn3 to SeqAn.

### DIFF
--- a/doc/howto/subcommand_argument_parser/index.md
+++ b/doc/howto/subcommand_argument_parser/index.md
@@ -2,7 +2,7 @@
 
 [TOC]
 
-This HowTo shows you how to write an argument parser with subcommand like `git push` using SeqAn3.
+This HowTo shows you how to write an argument parser with subcommand like `git push` using SeqAn.
 
 \tutorial_head{Easy, 15 min, \ref tutorial_argument_parser, }
 

--- a/doc/howto/write_a_view/index.md
+++ b/doc/howto/write_a_view/index.md
@@ -2,7 +2,7 @@
 
 [TOC]
 
-This HowTo documents how to write a view using the standard library and some helpers from SeqAn3.
+This HowTo documents how to write a view using the standard library and some helpers from SeqAn.
 
 \tutorial_head{Difficult, 120 min, \ref tutorial_concepts\,\ref tutorial_ranges, }
 

--- a/doc/howto/write_an_alphabet/index.md
+++ b/doc/howto/write_an_alphabet/index.md
@@ -2,7 +2,7 @@
 
 [TOC]
 
-This HowTo documents how to write a custom alphabet that can be used with the algorithms and data structures in SeqAn3.
+This HowTo documents how to write a custom alphabet that can be used with the algorithms and data structures in SeqAn.
 
 \tutorial_head{Moderate, 45 min, \ref tutorial_concepts\, \ref tutorial_alphabets, \ref alphabet}
 
@@ -135,7 +135,7 @@ your type also model these concepts.
 \snippet dna2_alphabet.cpp writable_alphabet
 \endsolution
 
-At this point the seqan3::alphabet concept should be modelled successfully and even seqan3::writable_alphabet 
+At this point the seqan3::alphabet concept should be modelled successfully and even seqan3::writable_alphabet
 is fine because we implemented `assign_char` and `char_is_valid`.
 \snippet dna2_alphabet.cpp writable_alphabet_concept
 

--- a/doc/main_page.md
+++ b/doc/main_page.md
@@ -4,7 +4,7 @@ Welcome to the documentation of the SeqAn library.
 This web-site contains the API reference (documentation of our interfaces) and more elaborate Tutorials and
 How-Tos.
 
-If you are new to SeqAn3, we recommend that you begin by reading \ref setup and doing the full tutorial,
+If you are new to SeqAn, we recommend that you begin by reading \ref setup and doing the full tutorial,
 starting with \ref tutorial_first_example.
 
 In contrast to the Tutorials (which are expected to be useful for all developers), the How-Tos contain more advanced

--- a/doc/setup/quickstart_cmake/index.md
+++ b/doc/setup/quickstart_cmake/index.md
@@ -1,7 +1,7 @@
 # Quick Setup (using CMake) {#setup}
 
 <b>Learning Objective:</b><br>
-In this short guide you will learn how to set up SeqAn3 and how to compile a small example to test whether everything
+In this short guide you will learn how to set up SeqAn and how to compile a small example to test whether everything
 works.
 
 \tutorial_head{Easy, 30 Minutes, No prerequisites, }

--- a/doc/tutorial/alignment_file/index.md
+++ b/doc/tutorial/alignment_file/index.md
@@ -1,4 +1,4 @@
-# Alignment Input and Output in SeqAn3 {#tutorial_alignment_file}
+# Alignment Input and Output in SeqAn {#tutorial_alignment_file}
 
 ***Learning Objective:***
 
@@ -16,7 +16,7 @@ Alignment files are used to store pairwise alignments between two (biological) s
 Common file formats are the Sequence Alignment/Map format (SAM) and BLAST output format.
 Next to the alignment, those formats store additional information like the start positions or mapping qualities.
 Alignment files are a little more complex than sequence files but the basic design is the same.
-If you are new to SeqAn3, we strongly recommend to do the tutorial \ref tutorial_sequence_file first.
+If you are new to SeqAn, we strongly recommend to do the tutorial \ref tutorial_sequence_file first.
 
 # Alignment file formats
 
@@ -142,7 +142,7 @@ You can select fields by providing a seqan3::fields object as an extra parameter
 In the example above we only select the id, sequence and flag information
 so the seqan3::record object has three tuple elements that are decomposed using structural bindings.
 
-Note that this is possible for all seqan3 file objects.
+Note that this is possible for all SeqAn file objects.
 
 \assignment{Exercise: Accumulating mapping qualities}
 
@@ -170,7 +170,7 @@ Average: 27.4
 
 # Alignment representation in the SAM format
 
-In SeqAn3 we represent an alignment as a tuple of two *aligned_sequences*,
+In SeqAn we represent an alignment as a tuple of two *aligned_sequences*,
 as you have probably learned by now from the alignment tutorial.
 
 The SAM format is the common output format of read mappers where you align short read sequences
@@ -209,7 +209,7 @@ or the [SAMtools paper](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2723002/).
 
 ## Completing reference information
 
-In SeqAn3 the conversion from a CIGAR string to an alignment (two *aligned_sequences*) is done automatically for you.
+In SeqAn the conversion from a CIGAR string to an alignment (two *aligned_sequences*) is done automatically for you.
 You can just pass the alignment object to the alignment file:
 
 \snippet doc/tutorial/alignment_file/alignment_file_snippets.cpp main

--- a/doc/tutorial/alphabet/index.md
+++ b/doc/tutorial/alphabet/index.md
@@ -1,8 +1,8 @@
-# Alphabets in SeqAn3 {#tutorial_alphabets}
+# Alphabets in SeqAn {#tutorial_alphabets}
 
 ***Learning Objective:***
 
-In this tutorial we look at alphabets and you will learn how to work with nucleotides and amino acids in SeqAn3.
+In this tutorial we look at alphabets and you will learn how to work with nucleotides and amino acids in SeqAn.
 We guide you through the most important properties of SeqAn's alphabets and show you the different implemented types.
 After completion, you will be able to use the alphabets inside of STL containers and to compare alphabet values.
 
@@ -29,7 +29,7 @@ This is a detailed introduction to the alphabet module and demonstrates its main
 
 Nucleotides are the components of (Deoxy)Ribonucleic acid (DNA/RNA) and contain one of the nucleobases
 Adenine (A), Cytosine (C), Guanine (G), Thymine (T, only DNA) and Uracil (U, only RNA).
-In SeqAn3 the alphabets seqan3::dna4 and seqan3::rna4 contain exactly the four respective nucleotides.
+In SeqAn the alphabets seqan3::dna4 and seqan3::rna4 contain exactly the four respective nucleotides.
 The trailed number in the alphabets' name represents the number of entities the alphabet holds –
 we denote this number as *alphabet size*.
 For instance, the alphabet seqan3::dna5 represents five entities as it contains the additional symbol 'N'
@@ -52,7 +52,7 @@ We have shown three solutions for assigning variables of alphabet type.
 
 ## The rank of an alphabet symbol
 The rank of a symbol is a number in range \[0..alphabet_size) where each number is paired with
-an alphabet symbol by a bijective function. In SeqAn3 the rank is always determined by the lexicographical
+an alphabet symbol by a bijective function. In SeqAn the rank is always determined by the lexicographical
 order of the underlying characters. For instance, in seqan3::dna4 the bijection is <br>
 <code>'A'_dna4 ⟼ 0</code> <br>
 <code>'C'_dna4 ⟼ 1</code> <br>
@@ -103,7 +103,7 @@ Please note how easily a sequence can be created via the string literal.
 
 ## Comparability
 
-All alphabets in SeqAn3 are regular and comparable. This means that you can
+All alphabets in SeqAn are regular and comparable. This means that you can
 use the `<`, `<=`, `>` and `>=` operators to compare the values based on the rank.
 For instance, this is useful for sorting a text over the alphabet. Regular implies that the
 equality and inequality of two values can be tested with `==` and `!=`.

--- a/doc/tutorial/argument_parser/index.md
+++ b/doc/tutorial/argument_parser/index.md
@@ -1,4 +1,4 @@
-# Parsing command line arguments with SeqAn3 {#tutorial_argument_parser}
+# Parsing command line arguments with SeqAn {#tutorial_argument_parser}
 
 <b>Learning Objective:</b> <br>
 You will learn how to use the seqan3::argument_parser class to parse command line arguments. This tutorial is a walkthrough with links to the API documentation and is also meant as a source for copy-and-paste code.
@@ -11,7 +11,7 @@ You will learn how to use the seqan3::argument_parser class to parse command lin
 
 # Introduction
 
-An easy and very flexible interface to a program is through the command line. This tutorial explains how to parse the command line using the SeqAn3 library’s seqan3::argument_parser class.
+An easy and very flexible interface to a program is through the command line. This tutorial explains how to parse the command line using the SeqAn library’s seqan3::argument_parser class.
 
 This class will give you the following functionality:
 
@@ -43,7 +43,7 @@ We will get to know the wide functionality of the argument parser by writing a l
 
 We want to build an application that is able to read the file with or without a header line, select certain seasons and compute the average or median from the "Avg. U.S. viewers (millions)" of the selected seasons.
 
-# The SeqAn3 argument parser class
+# The SeqAn argument parser class
 
 Before we add any of the options, flags, and positional options, we will take a look at the seqan3::argument_parser class itself. It is constructed by giving a program's name and passing the parameters `argc` and `argv` from main. Note that no command line arguments have been parsed so far, but we can now add more information to the parser. After adding all desired information, the parsing is triggered by calling the seqan3::argument_parser::parse member function. Since the function throws in case any errors occur, we need to wrap it into a try-catch block. Here is a first working example:
 
@@ -150,7 +150,7 @@ So how does this look like? The following code snippet adds a positional option 
 
 Additionally to the variable that will store the value, you need to pass a description. This description will help users of your application to understand how the option is affecting your program.
 
-\note As the name suggest, positional options are identified by their position. In SeqAn3, the first `add_positional_option()` will be linked to the first command line argument that is neither an option-value pair nor a flag. So the order of initialising your parser determines the order of assigning command line arguments to the respective variables.
+\note As the name suggest, positional options are identified by their position. In SeqAn, the first `add_positional_option()` will be linked to the first command line argument that is neither an option-value pair nor a flag. So the order of initialising your parser determines the order of assigning command line arguments to the respective variables.
 We personally recommend to always use regular options (id-value pairs) because they are more expressive and it is easier to spot errors.
 
 You can add an option like this:
@@ -342,9 +342,9 @@ A *validator* is a [functor](https://stackoverflow.com/questions/356950/what-are
 
 \attention You can pass a validator to the seqan3::argument_parser::add_option function only after passing the seqan3::option_spec parameter. Pass the seqan3::option_spec::DEFAULT tag, if there are no further restrictions on your option.
 
-## SeqAn3 validators
+## SeqAn validators
 
-The following validators are provided in the SeqAn3 library and can be included with the following header:
+The following validators are provided in the SeqAn library and can be included with the following header:
 
 \snippet doc/tutorial/argument_parser/small_snippets.cpp validator_include
 
@@ -384,7 +384,7 @@ Add a seqan3::value_list_validator to the `-a/--aggregate-by` option that sets t
 
 ### The file validator
 
-SeqAn3 offers two file validator types: the seqan3::input_file_validator and the seqan3::output_file_validator.
+SeqAn offers two file validator types: the seqan3::input_file_validator and the seqan3::output_file_validator.
 On construction, the validator receives a list (vector) of valid file extensions that are tested against the extension
 of the parsed option value.
 The validator throws a seqan3::parser_invalid_argument exception whenever a given filename's extension is not in the
@@ -405,7 +405,7 @@ Using the seqan3::output_file_validator:
 
 ### The directory validator
 
-In addition to the file validator types, SeqAn3 offers directory validator types. These are useful if one needs
+In addition to the file validator types, SeqAn offers directory validator types. These are useful if one needs
 to provide an input directory (using the seqan3::input_directory_validator) or output directory
 (using the seqan3::output_directory_validator) where multiple files need to be read from or written to.
 The seqan3::input_directory_validator checks whether the specified path is a directory and is readable.

--- a/doc/tutorial/concepts/index.md
+++ b/doc/tutorial/concepts/index.md
@@ -3,7 +3,7 @@
 [TOC]
 
 This tutorial introduces "C++ Concepts", a feature of C++20 (and available to some extent in older GCC versions).
-You will learn the terminology used in the context of concepts and how to use SeqAn3's concepts in your application.
+You will learn the terminology used in the context of concepts and how to use SeqAn's concepts in your application.
 
 \tutorial_head{Moderate, 60 min, \ref setup\, \ref tutorial_argument_parser,}
 
@@ -220,7 +220,7 @@ It requires that both parameters are the same. The `static_assert` checks condit
 used to verify whether a type or a combination of types model a concept. In the above case we can use the combination
 to check the "return type" of the transformation trait.
 
-# Concepts in SeqAn3 and this documentation
+# Concepts in SeqAn and this documentation
 
 SeqAn uses concepts extensively, for specialisation/overloading, but also to prevent misuse of templates and to clearly
 specify all public interfaces.
@@ -254,7 +254,7 @@ Do you understand the requirements formulated on that page?
 In order to model the seqan3::validator, your custom validator must provide the following:
 
   1. It needs to expose a `value_type` type member which identifies the type of variable the validator works on.
-     Currently, the SeqAn3 validators either have value_type `double` or `std::string`.
+     Currently, the SeqAn validators either have value_type `double` or `std::string`.
      Since the validator works on every type that has a common reference type to `value_type`, it enables a validator
      with `value_type = double` to work on all arithmetic values.
      \attention In order to be chainable, the validators need to share the same value_type!

--- a/doc/tutorial/introduction/index.md
+++ b/doc/tutorial/introduction/index.md
@@ -1,8 +1,8 @@
-# First steps with SeqAn3 {#tutorial_first_example}
+# First steps with SeqAn {#tutorial_first_example}
 
 ***Learning Objective:***
 
-This tutorial walks you through small SeqAn3 programs. It is intended to give you a short overview
+This tutorial walks you through small SeqAn programs. It is intended to give you a short overview
 of what to expect in the other tutorials and how to use this documentation.
 
 \tutorial_head{Easy, 30 min, \ref setup, [Ranges](https://github.com/seqan/seqan3/wiki/Ranges)\,
@@ -31,7 +31,7 @@ This is a code snippet. You will see many code snippets in our documentation.
 Most of them are compilable as-is, but some are only valid in their context,
 e.g. they depend on other code snippets given before/after the current one or
 other statements implied by the text. You can copy'n'paste freely from these examples,
-this implies no copyright-obligations (however distributing SeqAn3 or an application
+this implies no copyright-obligations (however distributing SeqAn or an application
 using it does, see [Copyright](https://docs.seqan.de/seqan/3-master-user/about_copyright.html) and [Citing](https://docs.seqan.de/seqan/3-master-user/about_citing.html).
 
 You may ask, why we do not use std::cout or std::cerr for console output.
@@ -57,7 +57,7 @@ so don't worry too much if your solution is different from ours.
 # Parse command line arguments
 
 After we have seen the *Hello World!* program, we want to go a bit further and parse arguments from the command line.
-The following snippet shows you how this is done in SeqAn3. Here the program expects a string argument in the
+The following snippet shows you how this is done in SeqAn. Here the program expects a string argument in the
 program call and prints it to your terminal.
 
 \snippet introduction_argument_parser.cpp argparse
@@ -78,10 +78,10 @@ You may have spotted that the blue coloured keywords link you directly to the re
 This is helpful if you need further information on a function, concept or class. We recommend you to open them
 in separate browser tabs such that you can easily switch back to the tutorial.
 
-## Modules in SeqAn3
+## Modules in SeqAn
 
-You have just been introduced to one of the **Modules** of SeqAn3, the *Argument Parser*.
-Modules structure the SeqAn3 library into logical units, as there are for instance `alignment`, `alphabet`,
+You have just been introduced to one of the **Modules** of SeqAn, the *Argument Parser*.
+Modules structure the SeqAn library into logical units, as there are for instance `alignment`, `alphabet`,
 `argument_parser`, `io`, `search` and some more. See the *API Reference (Modules)* section in the
 navigation column for a complete overview.
 
@@ -99,7 +99,7 @@ you can enter it in the search bar (top-right).
 
 # Read sequence files
 
-Let's look at some functions of the IO module: SeqAn3 provides fast and easy access to biological file formats.
+Let's look at some functions of the IO module: SeqAn provides fast and easy access to biological file formats.
 The following code example demonstrates the interface of seqan3::sequence_file_input.
 
 \snippet introduction_align.cpp sequence_input_include
@@ -123,7 +123,7 @@ AGTGATACT
 
 \assignment{Exercise: Read a FastA file}
 Combine the code from above to read a FastA file and store its sequences in a std::vector of type seqan3::dna5_vector
-(which is a common DNA sequence type in SeqAn3). Use the argument parser for obtaining the filename as command line
+(which is a common DNA sequence type in SeqAn). Use the argument parser for obtaining the filename as command line
 argument to your program (e.g. call `./myprogram seq.fasta`).
 \endassignment
 \solution
@@ -154,10 +154,10 @@ you wish to compute a traceback or not. The configurations have their own namesp
 be combined via the logical OR operator (`|`) for building combinations. Check out the alignment tutorial if you want to learn more.
 
 \note
-We use a lot of Modern C++ in SeqAn3 so some things might look alien at first,
+We use a lot of Modern C++ in SeqAn so some things might look alien at first,
 e.g. type templates are used like ordinary types in many situations (no `<>`).
 We also always use `{}` to initialise objects and not `()` which is only used for function calls.
 In general the style should be much easier for newcomers.
 
-Now that you reached the end of this first tutorial, you know how SeqAn3 code looks like and you are able
+Now that you reached the end of this first tutorial, you know how SeqAn code looks like and you are able
 to write some first code fragments. Let's go more into detail with the module-based tutorials!

--- a/doc/tutorial/pairwise_alignment/index.md
+++ b/doc/tutorial/pairwise_alignment/index.md
@@ -2,7 +2,7 @@
 
 <b>Learning Objective:</b> <br/>
 
-In this tutorial you will learn how to compute pairwise sequence alignments with SeqAn3.
+In this tutorial you will learn how to compute pairwise sequence alignments with SeqAn.
 This tutorial is a walkthrough with links to the API documentation and is also meant as a source for copy-and-paste code.
 
 \tutorial_head{Intermediate, 60-90 min, \ref setup \ref tutorial_alphabets \ref tutorial_ranges, }
@@ -32,7 +32,7 @@ thus, with all possible configurations, is a very versatile and powerful tool to
 
 # Computing pairwise alignments
 
-Let us first have look at an example of computing a global alignment in SeqAn3.
+Let us first have look at an example of computing a global alignment in SeqAn.
 
 \includelineno doc/tutorial/pairwise_alignment/pairwise_alignment_first_global.cpp
 
@@ -82,7 +82,7 @@ the result values.
 
 \endsolution
 
-Congratulations, you have computed your first pairwise alignment with seqan3!
+Congratulations, you have computed your first pairwise alignment with SeqAn!
 As you can see, the interface is really simple, yet the configuration object makes it extremely flexible to conduct
 various different alignment calculations. In the following chapter you will learn more about the various configuration
 possibilities.

--- a/doc/tutorial/read_mapper/index.md
+++ b/doc/tutorial/read_mapper/index.md
@@ -1,8 +1,8 @@
-# Implementing your own read mapper with SeqAn3 {#tutorial_read_mapper}
+# Implementing your own read mapper with SeqAn {#tutorial_read_mapper}
 
 <b>Learning Objective:</b><br>
 In this tutorial you will learn how to combine the components of previous tutorials to create your very first
-SeqAn3 application: a read mapper!
+SeqAn application: a read mapper!
 
 \tutorial_head{High, 90 Minutes, All,}
 

--- a/doc/tutorial/search/index.md
+++ b/doc/tutorial/search/index.md
@@ -1,4 +1,4 @@
-# Indexing and searching with SeqAn3 {#tutorial_index_search}
+# Indexing and searching with SeqAn {#tutorial_index_search}
 
 <b>Learning Objective:</b><br>
 In this tutorial you will learn how to construct an index and conduct searches.
@@ -25,10 +25,10 @@ The general solution is to use a data structure called **index**. An index is bu
 to be computed once for a given data set. It is used to speed up the search in the reference and can be re-used by
 storing it to disk and loading it again without recomputation.
 
-There are two groups of indices: hash tables and suffix-based indices. SeqAn3 implements the FM-Index and Bi-FM-Index
+There are two groups of indices: hash tables and suffix-based indices. SeqAn implements the FM-Index and Bi-FM-Index
 as suffix-based indices. While the Bi-FM-Index needs more space (a factor of about 2), it allows faster searches.
 
-Given an index, SeqAn3 will choose the best search strategy for you. Since very different algorithms may be selected
+Given an index, SeqAn will choose the best search strategy for you. Since very different algorithms may be selected
 internally depending on the configuration, it is advisable to do benchmarks with your application. A rule of thumb is
 to use the Bi-FM-Index when allowing more than 2 errors.
 

--- a/doc/tutorial/sequence_file/index.md
+++ b/doc/tutorial/sequence_file/index.md
@@ -1,7 +1,7 @@
 # Sequence File Input and Output {#tutorial_sequence_file}
 
 <b>Learning Objective:</b> <br/>
-You will get an overview of how file Input/Output is handled in seqan3 and learn how to read and write
+You will get an overview of how file Input/Output is handled in SeqAn and learn how to read and write
 sequence files. This tutorial is a walk-through with links into the API documentation and also meant as a
 source for copy-and-paste code.
 
@@ -9,10 +9,10 @@ source for copy-and-paste code.
 
 [TOC]
 
-# File I/O in SeqAn3
+# File I/O in SeqAn
 
 Most file formats in bioinformatics are structured as lists of records.
-In SeqAn3 we model our files as a **range over records**.
+In SeqAn we model our files as a **range over records**.
 This interface allows us to easily stream over a file, apply filters and convert formats,
 sometimes only in a single line of code.
 The file format is automatically detected by the file name extension and compressed files can be handled
@@ -24,7 +24,7 @@ for (auto & record : file)
 ```
 
 We will explain the details about reading and writing files in the [Sequence File](#section_sequence_files) section below.
-Currently, SeqAn3 supports the following file formats:
+Currently, SeqAn supports the following file formats:
 
 - Sequence file formats:
   - seqan3::format_fasta
@@ -44,7 +44,7 @@ You can check whether you have installed these libraries by running `cmake .` in
 If `-- Optional dependency: ZLIB-x.x.x found.` is displayed on the command line then you can read/write
 compressed files in your programs. TODO what about bz2
 
-## Basic layout of SeqAn3 file objects
+## Basic layout of SeqAn file objects
 
 Before we dive into the details, we will outline the general design of our file objects,
 hoping that it will make the following tutorial easier to understand.
@@ -81,7 +81,7 @@ CCCCCCCCCCCCCCC
 CGATCGATC
 ```
 
-In SeqAn3 we provide the seqan3::format_fasta to read sequence files in FASTA format.
+In SeqAn we provide the seqan3::format_fasta to read sequence files in FASTA format.
 
 ### FASTQ format
 
@@ -98,7 +98,7 @@ CGATCGATC
 IIIIIIIII
 ```
 
-In SeqAn3 we provide the seqan3::format_fastq to read sequence files in FASTQ format.
+In SeqAn we provide the seqan3::format_fastq to read sequence files in FASTQ format.
 
 ### EMBL format
 
@@ -116,14 +116,14 @@ SQ   Sequence 1859 BP; 609 A; 314 C; 355 G; 581 T; 0 other;
      cacaattact tccacaaatg cagttgaagc ttctactctt cttgacatag gtaacctgag
 ```
 
-In SeqAn3 we provide the seqan3::format_embl to read sequence files in EMBL format.
+In SeqAn we provide the seqan3::format_embl to read sequence files in EMBL format.
 
 ### File extensions
 
 The formerly introduced formats can be identified by the following file name extensions
 (this is important for automatic format detection from a file name as you will learn in the next section).
 
-| File Format | SeqAn3 format class  | File Extensions                                   |
+| File Format | SeqAn format class   | File Extensions                                   |
 | ------------| ---------------------|---------------------------------------------------|
 | FASTA       | seqan3::format_fasta |   `.fa`, `.fasta`, `.fna`, `.ffn`, `.ffa`, `.frn` |
 | FASTQ       | seqan3::format_fastq |   `.fq`, `.fastq`                                 |
@@ -156,7 +156,7 @@ which introduces reading a file with custom selected fields.
 
 # Reading a sequence file
 
-You can include the SeqAn3 sequence file functionality with:
+You can include the SeqAn sequence file functionality with:
 
 \snippet doc/tutorial/sequence_file/sequence_file_snippets.cpp include
 

--- a/include/seqan3/alphabet/all.hpp
+++ b/include/seqan3/alphabet/all.hpp
@@ -102,7 +102,7 @@
  * seqan3::debug_stream:
  * \include test/snippet/alphabet/all_nonambiguous.cpp
  *
- * To reduce the burden of calling `assign_char` often, most alphabets in SeqAn3 provide custom literals for
+ * To reduce the burden of calling `assign_char` often, most alphabets in SeqAn provide custom literals for
  * the alphabet and sequences over the alphabet:
  *
  * \include test/snippet/alphabet/all_literal.cpp
@@ -154,7 +154,7 @@
  *
  * # containers over alphabets
  *
- * In SeqAn3 it is recommended you use the STL container classes like std::vector for storing sequence data,
+ * In SeqAn it is recommended you use the STL container classes like std::vector for storing sequence data,
  * but you can use other class templates if they satisfy the respective seqan3::container, e.g. `std::deque` or
  * <a href="https://github.com/facebook/folly/blob/master/folly/docs/FBVector.md" target="_blank">
  * <tt>folly::fbvector</tt></a> or even <a href="https://doc.qt.io/qt-5/qvector.html" target="_blank">

--- a/include/seqan3/alphabet/concept.hpp
+++ b/include/seqan3/alphabet/concept.hpp
@@ -795,7 +795,7 @@ SEQAN3_CONCEPT semialphabet =
  *
  * ### Serialisation
  *
- * Types that model the concept (and all refinements) can be serialised via SeqAn3
+ * Types that model the concept (and all refinements) can be serialised via SeqAn
  * serialisation support.
  * The rank value is (de-)serialised, types need not provide any overloads themselves.
  */
@@ -879,7 +879,7 @@ SEQAN3_CONCEPT alphabet = semialphabet<t> && requires (t v)
  *
  * ### Serialisation
  *
- * Types that model the concept (and all refinements) can be serialised via SeqAn3
+ * Types that model the concept (and all refinements) can be serialised via SeqAn
  * serialisation support.
  * The rank value is (de-)serialised, types need not provide any overloads themselves.
  */

--- a/include/seqan3/alphabet/nucleotide/all.hpp
+++ b/include/seqan3/alphabet/nucleotide/all.hpp
@@ -72,7 +72,7 @@
  *
  * ###Printing and conversion to char
  *
- * As with all alphabets in SeqAn3, none of the nucleotide alphabets can be directly converted to char or printed.
+ * As with all alphabets in SeqAn, none of the nucleotide alphabets can be directly converted to char or printed.
  * You need to explicitly call seqan3::to_char to convert to char. The only exception is seqan3::debug_stream
  * which does this conversion to char automatically.
  *

--- a/include/seqan3/argument_parser/detail/format_help.hpp
+++ b/include/seqan3/argument_parser/detail/format_help.hpp
@@ -546,7 +546,7 @@ DAMAGE.)"};
         }
 
         strem << views::repeat_n('=', 80) << to_text("\n\\fB")
-              << "This program contains SeqAn3 code licensed under the following terms:\n" << to_text("\\fP")
+              << "This program contains SeqAn code licensed under the following terms:\n" << to_text("\\fP")
               << views::repeat_n('-', 80) << '\n' << seqan_license << '\n';
 
         std::exit(EXIT_SUCCESS);

--- a/include/seqan3/argument_parser/detail/version_check.hpp
+++ b/include/seqan3/argument_parser/detail/version_check.hpp
@@ -409,7 +409,7 @@ public:
     static constexpr std::string_view unregistered_app = "UNREGISTERED_APP";
     //!\brief The message directed to the developer of the app if a new seqan3 version is available.
     static constexpr std::string_view message_seqan3_update =
-        "[SEQAN3 INFO] :: A new SeqAn3 version is available online.\n"
+        "[SEQAN3 INFO] :: A new SeqAn version is available online.\n"
         "[SEQAN3 INFO] :: Please visit www.github.com/seqan/seqan3.git for an update\n"
         "[SEQAN3 INFO] :: or inform the developer of this app.\n"
         "[SEQAN3 INFO] :: If you don't wish to receive further notifications, set --version-check OFF.\n\n";

--- a/include/seqan3/contrib/stream/bgzf_istream.hpp
+++ b/include/seqan3/contrib/stream/bgzf_istream.hpp
@@ -16,7 +16,7 @@
 //
 // Author: Jonathan de Halleux, dehalleux@pelikhan.com, 2003   (original zlib stream)
 // Author: David Weese, dave.weese@gmail.com, 2014             (extension to parallel block-wise compression in bgzf format)
-// Author: Rene Rahn, rene.rahn AT fu-berlin.de, 2019          (adaption to SeqAn3)
+// Author: Rene Rahn, rene.rahn AT fu-berlin.de, 2019          (adaption to SeqAn library version 3)
 
 #pragma once
 

--- a/include/seqan3/contrib/stream/bgzf_ostream.hpp
+++ b/include/seqan3/contrib/stream/bgzf_ostream.hpp
@@ -16,7 +16,7 @@
 //
 // Author: Jonathan de Halleux, dehalleux@pelikhan.com, 2003   (original zlib stream)
 // Author: David Weese, dave.weese@gmail.com, 2014             (extension to parallel block-wise compression in bgzf format)
-// Author: René Rahn, rene.rahn [at] fu-berlin.de, 2019        (adaptions to SeqAn3)
+// Author: René Rahn, rene.rahn [at] fu-berlin.de, 2019        (adaptions to SeqAn library version 3)
 
 #pragma once
 

--- a/include/seqan3/core/char_operations/predicate.hpp
+++ b/include/seqan3/core/char_operations/predicate.hpp
@@ -312,11 +312,11 @@ inline auto constexpr is_xdigit = is_in_interval<'0', '9'> ||
  * \details
  *
  * Char predicates are function like objects that can be used to check if a character `c` fulfills certain
- * constraints. SeqAn3 implements all predicates also available in the standard library and some more.
+ * constraints. SeqAn implements all predicates also available in the standard library and some more.
  *
  * ### Disjunction and Negation
  *
- * In contrast to the standard library (where the checks are implemented as functions), the functors in SeqAn3 can be
+ * In contrast to the standard library (where the checks are implemented as functions), the functors in SeqAn can be
  * joined efficiently, maintaining constant-time evaluation independent of the number of checks. Functors can be
  * combined with the `||-operator` or negated via the `!-operator`:
  *

--- a/include/seqan3/core/concept/all.hpp
+++ b/include/seqan3/core/concept/all.hpp
@@ -18,7 +18,7 @@
 
 /*!\defgroup concept Concept
  * \ingroup core
- * \brief Additional concepts that are not specific to a SeqAn3 module.
+ * \brief Additional concepts that are not specific to a SeqAn module.
  *
  * \details
  *

--- a/include/seqan3/core/simd/all.hpp
+++ b/include/seqan3/core/simd/all.hpp
@@ -39,7 +39,7 @@
 #include <seqan3/core/simd/view_to_simd.hpp>
 
 /*!\namespace seqan3::simd
- * \brief The SeqAn3 namespace for simd data types, algorithms and meta functions.
+ * \brief The SeqAn namespace for simd data types, algorithms and meta functions.
  * \sa https://en.wikipedia.org/wiki/SIMD What is SIMD conceptually?
  * \sa https://en.wikipedia.org/wiki/stream_REMOVEMEing_SIMD_Extensions Which SIMD architectures exist?
  */

--- a/include/seqan3/io/alignment_file/format_sam.hpp
+++ b/include/seqan3/io/alignment_file/format_sam.hpp
@@ -86,7 +86,7 @@ namespace seqan3
  * ### SAM format columns -> fields
  *
  * Since many users will be accustomed to the columns of the SAM format, here is a
- * mapping of the common SAM format columns to the SeqAn3 record fields:
+ * mapping of the common SAM format columns to the SeqAn record fields:
  *
  * | #  | SAM Column ID |  FIELD name                                       |
  * |:--:|:--------------|:--------------------------------------------------|

--- a/include/seqan3/io/alignment_file/output.hpp
+++ b/include/seqan3/io/alignment_file/output.hpp
@@ -152,7 +152,7 @@ namespace seqan3
  * ### File I/O pipelines
  *
  * Record-wise writing in batches also works for writing from input files directly to output files, because input
- * files are also input ranges in SeqAn3:
+ * files are also input ranges in SeqAn:
  *
  * \include test/snippet/io/alignment_file/alignment_file_output_input_range.cpp
  *

--- a/include/seqan3/io/alignment_file/sam_tag_dictionary.hpp
+++ b/include/seqan3/io/alignment_file/sam_tag_dictionary.hpp
@@ -106,7 +106,7 @@ constexpr uint16_t operator""_tag()
  *
  * The seqan3::sam_tag_type is overloaded the following SAM tags:
  *
- * | Tag Name | SeqAn3 Type Implementation |
+ * | Tag Name | SeqAn Type Implementation |
  * | -------- | --------------------- |
  * | "AM"_tag | int32_t               |
  * | "AS"_tag | int32_t               |

--- a/include/seqan3/io/detail/misc_output.hpp
+++ b/include/seqan3/io/detail/misc_output.hpp
@@ -69,7 +69,7 @@ inline auto make_secondary_ostream(std::basic_ostream<char_t> & primary_stream, 
     }
     else if (extension == ".zst")
     {
-        throw file_open_error{"Trying to write a zst'ed file, but SeqAn3 does not yet support this."};
+        throw file_open_error{"Trying to write a zst'ed file, but SeqAn does not yet support this."};
     }
 
     return {&primary_stream, stream_deleter_noop};

--- a/include/seqan3/range/all.hpp
+++ b/include/seqan3/range/all.hpp
@@ -28,7 +28,7 @@
  * This is resembled by the range concepts defined in this module. Another way to classify ranges is by their storage
  * behaviour, i.e. whether they own the data that is accessible through them. See below for more details.
  *
- * Ranges are found throughout the SeqAn3 library, this module provides general-purpose ranges that are not specific
+ * Ranges are found throughout the SeqAn library, this module provides general-purpose ranges that are not specific
  * to another module or biological function.
  *
  * ### Iterator capabilities
@@ -49,7 +49,7 @@
  *
  * ### Storage behaviour
  *
- * **containers** are the ranges most well known, they own their elements. SeqAn3 makes use of standard STL containers
+ * **containers** are the ranges most well known, they own their elements. SeqAn makes use of standard STL containers
  * like `std::vector`, but also implements some custom containers. See the \link container container submodule \endlink
  * for more details.
  *

--- a/include/seqan3/range/concept.hpp
+++ b/include/seqan3/range/concept.hpp
@@ -35,7 +35,7 @@ namespace seqan3
  * there is something in the range that changes on every iterator increment (and `const` ranges can't change);
  *   * certain views store a state with their algorithm that also changes when `begin()` is called or an
  * iterator is incremented; these may be not be `const`-iterable, because the standard library
- * (and also SeqAn3) guarantees that it is safe to call `const`-qualified functions concurrently.
+ * (and also SeqAn) guarantees that it is safe to call `const`-qualified functions concurrently.
  */
 //!\cond
 template <typename type>

--- a/include/seqan3/range/container/all.hpp
+++ b/include/seqan3/range/container/all.hpp
@@ -20,7 +20,7 @@
 #include <seqan3/range/container/small_vector.hpp>
 
 /*!\defgroup container Container
- * \brief The container submodule contains special SeqAn3 containers and generic container concepts.
+ * \brief The container submodule contains special SeqAn containers and generic container concepts.
  * \ingroup range
  * \sa https://en.cppreference.com/w/cpp/container
  * \sa range/container/all.hpp

--- a/include/seqan3/range/decorator/all.hpp
+++ b/include/seqan3/range/decorator/all.hpp
@@ -16,7 +16,7 @@
 #include <seqan3/range/decorator/gap_decorator.hpp>
 
 /*!\defgroup decorator Decorator
- * \brief The decorator submodule contains special SeqAn3 decorators and generic decorator concepts.
+ * \brief The decorator submodule contains special SeqAn decorators and generic decorator concepts.
  * \ingroup range
  * \sa seqan3/range/decorator/all.hpp
  */

--- a/include/seqan3/range/views/all.hpp
+++ b/include/seqan3/range/views/all.hpp
@@ -38,7 +38,7 @@
  *
  * \details
  *
- * SeqAn3 makes heavy use of views as defined in the
+ * SeqAn makes heavy use of views as defined in the
  * [Ranges Technical Specification](https://en.cppreference.com/w/cpp/experimental/ranges). From the original
  * documentation:  <i>"A view is a lightweight wrapper that presents a view of an underlying sequence of elements in
  * some custom way without mutating or copying it. Views are cheap to create and copy, and have non-owning reference
@@ -49,9 +49,9 @@
  *
  * See the \link range range module \endlink for how views relate to containers and decorators.
  *
- * Most views provided by SeqAn3 are specific to biological operations, like seqan3::views::trim which trims
+ * Most views provided by SeqAn are specific to biological operations, like seqan3::views::trim which trims
  * sequences based on the quality or seqan3::views::complement which generates the complement of a nucleotide sequence.
- * But SeqAn3 also provides some general purpose views.
+ * But SeqAn also provides some general purpose views.
  *
  * ### Namespaces
  *
@@ -176,7 +176,7 @@
 
 /*!
  * \namespace seqan3::views
- * \brief The SeqAn3 namespace for views.
+ * \brief The SeqAn namespace for views.
  *
  * Since views often have name clashes with regular functions and ranges they are implemented in the sub
  * namespace `view`.

--- a/include/seqan3/search/all.hpp
+++ b/include/seqan3/search/all.hpp
@@ -32,7 +32,7 @@
  * \todo k-mer indices are coming soon. Stay tuned!
  * \endif
  *
- * SeqAn3 currently supports very fast FM indices. For more details visit the \ref submodule_fm_index
+ * SeqAn currently supports very fast FM indices. For more details visit the \ref submodule_fm_index
  * "FM Index submodule".
  *
  */

--- a/include/seqan3/search/fm_index/all.hpp
+++ b/include/seqan3/search/fm_index/all.hpp
@@ -38,7 +38,7 @@
  *
  * Index Cursors are lightweight objects, i.e. they are cheap to copy.
  *
- * Note that although the SeqAn3 index cursor, although having similar behaviour, don't model any of the standard library
+ * Note that although the SeqAn index cursor, although having similar behaviour, don't model any of the standard library
  * iterator concepts, not even std::input_or_output_iterator.
  *
  */

--- a/include/seqan3/search/fm_index/concept.hpp
+++ b/include/seqan3/search/fm_index/concept.hpp
@@ -58,7 +58,7 @@ SEQAN3_CONCEPT sdsl_index = requires (t sdsl_index)
 //!\endcond
 /*!\name Requirements for seqan3::detail::sdsl_index
  * \relates seqan3::detail::sdsl_index
- * \brief The SDSL index must support the following interface to work with SeqAn3 FM indices.
+ * \brief The SDSL index must support the following interface to work with SeqAn FM indices.
  * \{
  *
  * \typedef typename t::size_type size_type

--- a/test/unit/argument_parser/detail/format_help_test.cpp
+++ b/test/unit/argument_parser/detail/format_help_test.cpp
@@ -278,7 +278,7 @@ TEST(help_page_printing, copyright)
                    "--------------------------------------------------------------------------------\n"
                    "myApp copyright information not available.\n"
                    "================================================================================\n"
-                   "This program contains SeqAn3 code licensed under the following terms:\n"
+                   "This program contains SeqAn code licensed under the following terms:\n"
                    "--------------------------------------------------------------------------------\n"
                    + license_string;
 
@@ -299,7 +299,7 @@ TEST(help_page_printing, copyright)
                    "short copyright line 1\n"
                    "short copyright line 2\n"
                    "================================================================================\n"
-                   "This program contains SeqAn3 code licensed under the following terms:\n"
+                   "This program contains SeqAn code licensed under the following terms:\n"
                    "--------------------------------------------------------------------------------\n"
                    + license_string;
 
@@ -319,7 +319,7 @@ TEST(help_page_printing, copyright)
                    "long copyright line 1\n"
                    "long copyright line 2\n"
                    "================================================================================\n"
-                   "This program contains SeqAn3 code licensed under the following terms:\n"
+                   "This program contains SeqAn code licensed under the following terms:\n"
                    "--------------------------------------------------------------------------------\n"
                    + license_string;
 


### PR DESCRIPTION
Fixes SeqAn3 naming in the documentation where appropriate.