### PR TITLE
[FIX,DOC] Doxygen 1.8.16 warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,7 @@ matrix:
     addons:
       apt:
         # adds epstopdf, ghostscript, latex
-        packages: ['texlive-font-utils', 'ghostscript', 'texlive-latex-base']
+        packages: ['texlive-font-utils', 'ghostscript', 'texlive-latex-extra']
     env:
       - BUILD=documentation
       - CMAKE_VERSION=3.7.2
@@ -97,7 +97,7 @@ matrix:
       directories:
           - /tmp/doxygen-download
     before_install:
-       - DOXYGEN_VER=1.8.13
+       - DOXYGEN_VER=1.8.16
        - DOXYGEN_FOLDER=doxygen-${DOXYGEN_VER}
        - mkdir -p /tmp/doxygen-download
        - wget --no-clobber --directory-prefix=/tmp/doxygen-download/ https://sourceforge.net/projects/doxygen/files/rel-${DOXYGEN_VER}/${DOXYGEN_FOLDER}.linux.bin.tar.gz

--- a/include/seqan3/alignment/matrix/detail/aligned_sequence_builder.hpp
+++ b/include/seqan3/alignment/matrix/detail/aligned_sequence_builder.hpp
@@ -127,7 +127,7 @@ public:
     constexpr aligned_sequence_builder & operator=(aligned_sequence_builder &&) = default; //!< Defaulted.
     ~aligned_sequence_builder() = default; //!< Defaulted.
 
-    /*\brief Construction from the underlying sequences.
+    /*!\brief Construction from the underlying sequences.
      * \param[in] fst_rng The first range to build the aligned sequence for.
      * \param[in] sec_rng The second range to build the aligned sequence for.
      */

--- a/include/seqan3/alignment/matrix/detail/two_dimensional_matrix.hpp
+++ b/include/seqan3/alignment/matrix/detail/two_dimensional_matrix.hpp
@@ -301,10 +301,15 @@ public:
     /*!\name Associated types
     * \{
     */
+    //!\brief Value type of this iterator.
     using value_type = value_type_t<storage_iterator>;
+    //!\brief Reference to `value_type`.
     using reference = reference_t<storage_iterator>;
+    //!\brief The pointer type.
     using pointer = typename storage_iterator::pointer;
+    //!\brief Type for distances between iterators.
     using difference_type = difference_type_t<storage_iterator>;
+    //!\brief The iterator tag.
     using iterator_category = std::random_access_iterator_tag;
     //!\}
 

--- a/include/seqan3/alphabet/alphabet_base.hpp
+++ b/include/seqan3/alphabet/alphabet_base.hpp
@@ -176,36 +176,43 @@ public:
 
     //!\name Comparison operators
     //!\{
+
+    //!\brief Checks whether the letters `lhs` and `rhs` are equal.
     friend constexpr bool operator==(derived_type const lhs, derived_type const rhs) noexcept
     {
         using seqan3::to_rank;
         return to_rank(lhs) == to_rank(rhs);
     }
 
+    //!\brief Checks whether the letters `lhs` and `rhs` are unequal.
     friend constexpr bool operator!=(derived_type const lhs, derived_type const rhs) noexcept
     {
         using seqan3::to_rank;
         return to_rank(lhs) != to_rank(rhs);
     }
 
+    //!\brief Checks whether the letter `lhs` is smaller than `rhs`.
     friend constexpr bool operator<(derived_type const lhs, derived_type const rhs) noexcept
     {
         using seqan3::to_rank;
         return to_rank(lhs) < to_rank(rhs);
     }
 
+    //!\brief Checks whether the letter `lhs` is greater than `rhs`.
     friend constexpr bool operator>(derived_type const lhs, derived_type const rhs) noexcept
     {
         using seqan3::to_rank;
         return to_rank(lhs) > to_rank(rhs);
     }
 
+    //!\brief Checks whether the letter `lhs` is smaller than or equal to `rhs`.
     friend constexpr bool operator<=(derived_type const lhs, derived_type const rhs) noexcept
     {
         using seqan3::to_rank;
         return to_rank(lhs) <= to_rank(rhs);
     }
 
+    //!\brief Checks whether the letter `lhs` is bigger than or equal to `rhs`.
     friend constexpr bool operator>=(derived_type const lhs, derived_type const rhs) noexcept
     {
         using seqan3::to_rank;
@@ -297,31 +304,38 @@ public:
 
     //!\name Comparison operators
     //!\{
+
+    //!\brief Letters are always equal.
     friend constexpr bool operator==(derived_type const, derived_type const) noexcept
     {
         return true;
     }
 
+    //!\brief Letters are never unequal.
     friend constexpr bool operator!=(derived_type const, derived_type const) noexcept
     {
         return false;
     }
 
+    //!\brief One letter cannot be smaller than another.
     friend constexpr bool operator<(derived_type const,  derived_type const)  noexcept
     {
         return false;
     }
 
+    //!\brief One letter cannot be bigger than another.
     friend constexpr bool operator>(derived_type const,  derived_type const)  noexcept
     {
         return false;
     }
 
+    //!\brief Letters are always equal.
     friend constexpr bool operator<=(derived_type const, derived_type const) noexcept
     {
         return true;
     }
 
+    //!\brief Letters are always equal.
     friend constexpr bool operator>=(derived_type const, derived_type const) noexcept
     {
         return true;

--- a/include/seqan3/alphabet/aminoacid/translation.hpp
+++ b/include/seqan3/alphabet/aminoacid/translation.hpp
@@ -145,7 +145,7 @@ constexpr aa27 translate_triplet SEQAN3_DEPRECATED_310 (range_type && input_rang
 
 /*!\brief Translate one nucleotide triplet into single amino acid (range interface, input range allows random access).
  * \ingroup aminoacid
- * \tparam range_type Type of input_range; must satisfy std::ranges::random_access_range.
+ * \tparam rng_t Type of input_range; must satisfy std::ranges::random_access_range.
  * \param[in] input_range Range of three nucleotides that should be converted to amino acid.
  *
  * \details
@@ -162,11 +162,11 @@ constexpr aa27 translate_triplet SEQAN3_DEPRECATED_310 (range_type && input_rang
  *
  * \deprecated Use seqan3::translate_triplet(nucl_type const & n1, nucl_type const & n2, nucl_type const & n3) instead.
  */
-template <genetic_code gc = genetic_code::CANONICAL, std::ranges::random_access_range range_type>
+template <genetic_code gc = genetic_code::CANONICAL, std::ranges::random_access_range rng_t>
 //!\cond
-    requires nucleotide_alphabet<reference_t<std::decay_t<range_type>>>
+    requires nucleotide_alphabet<reference_t<std::decay_t<rng_t>>>
 //!\endcond
-constexpr aa27 translate_triplet SEQAN3_DEPRECATED_310 (range_type && input_range)
+constexpr aa27 translate_triplet SEQAN3_DEPRECATED_310 (rng_t && input_range)
 {
     assert(input_range.begin() != end(input_range));
     assert(input_range.begin() + 1 != end(input_range));

--- a/include/seqan3/alphabet/composite/alphabet_tuple_base.hpp
+++ b/include/seqan3/alphabet/composite/alphabet_tuple_base.hpp
@@ -259,6 +259,7 @@ private:
         constexpr component_proxy & operator=(component_proxy &&) = default;       //!< Defaulted.
         ~component_proxy() = default;                                              //!< Defaulted.
 
+        //!\brief Construct from an alphabet letter and reference to the parent object.
         constexpr component_proxy(alphabet_type const l, alphabet_tuple_base & p) :
             base_t{l}, parent{&p}
         {}
@@ -270,12 +271,12 @@ private:
     /*!\name Constructors, destructor and assignment
      * \{
      */
-    constexpr alphabet_tuple_base() noexcept : base_t{} {}
-    constexpr alphabet_tuple_base(alphabet_tuple_base const &) = default;
-    constexpr alphabet_tuple_base(alphabet_tuple_base &&) = default;
-    constexpr alphabet_tuple_base & operator=(alphabet_tuple_base const &) = default;
-    constexpr alphabet_tuple_base & operator=(alphabet_tuple_base &&) = default;
-    ~alphabet_tuple_base() = default;
+    constexpr alphabet_tuple_base() noexcept : base_t{} {}                            //!< Defaulted.
+    constexpr alphabet_tuple_base(alphabet_tuple_base const &) = default;             //!< Defaulted.
+    constexpr alphabet_tuple_base(alphabet_tuple_base &&) = default;                  //!< Defaulted.
+    constexpr alphabet_tuple_base & operator=(alphabet_tuple_base const &) = default; //!< Defaulted.
+    constexpr alphabet_tuple_base & operator=(alphabet_tuple_base &&) = default;      //!< Defaulted.
+    ~alphabet_tuple_base() = default;                                                 //!< Defaulted.
 
     using base_t::base_t;
     //!\}
@@ -409,10 +410,8 @@ public:
     //!\cond
     // If not assignable but implicit convertible, convert first and assign afterwards
     template <typename indirect_component_type>
-    //!\cond
         requires !detail::one_component_is<alphabet_tuple_base, derived_type, detail::assignable_from, indirect_component_type> &&
                  detail::one_component_is<alphabet_tuple_base, derived_type, detail::implicitly_convertible_from, indirect_component_type>
-    //!\endcond
     constexpr derived_type & operator=(indirect_component_type const alph) noexcept
     {
         using component_type = meta::front<meta::find_if<component_list, detail::implicitly_convertible_from<indirect_component_type>>>;
@@ -506,6 +505,7 @@ public:
      *        that a component type is comparable with).
      * \{
      */
+    //!\brief Checks whether `*this` is equal to `rhs`.
     template <typename indirect_component_type>
     constexpr bool operator==(indirect_component_type const rhs) const noexcept
     //!\cond
@@ -516,6 +516,7 @@ public:
         return get<component_type>(*this) == rhs;
     }
 
+    //!\brief Checks whether `*this` is unequal to `rhs`.
     template <typename indirect_component_type>
     constexpr bool operator!=(indirect_component_type const rhs) const noexcept
     //!\cond
@@ -526,6 +527,7 @@ public:
         return get<component_type>(*this) != rhs;
     }
 
+    //!\brief Checks whether `*this` is smaller than `rhs`.
     template <typename indirect_component_type>
     constexpr bool operator<(indirect_component_type const rhs) const noexcept
     //!\cond
@@ -536,6 +538,7 @@ public:
         return get<component_type>(*this) < rhs;
     }
 
+    //!\brief Checks whether `*this` is greater than `rhs`.
     template <typename indirect_component_type>
     constexpr bool operator>(indirect_component_type const rhs) const noexcept
     //!\cond
@@ -546,6 +549,7 @@ public:
         return get<component_type>(*this) > rhs;
     }
 
+    //!\brief Checks whether `*this` is smaller than or equal to `rhs`.
     template <typename indirect_component_type>
     constexpr bool operator<=(indirect_component_type const rhs) const noexcept
     //!\cond
@@ -556,6 +560,7 @@ public:
         return get<component_type>(*this) <= rhs;
     }
 
+    //!\brief Checks whether `*this` is bigger than or equal to `rhs`.
     template <typename indirect_component_type>
     constexpr bool operator>=(indirect_component_type const rhs) const noexcept
     //!\cond
@@ -615,6 +620,7 @@ private:
  * \{
  * \brief Free function comparison operators that forward to member operators (for types != self).
  */
+//!\brief Checks whether `lhs` is equal to `rhs`.
 template <typename indirect_component_type, typename derived_type, typename ...component_types>
 //!\cond
     requires detail::weakly_equality_comparable_by_members_with<derived_type, indirect_component_type> &&
@@ -626,6 +632,7 @@ constexpr bool operator==(indirect_component_type const lhs,
     return rhs == lhs;
 }
 
+//!\brief Checks whether `lhs` unequal to `rhs`.
 template <typename indirect_component_type, typename derived_type, typename ...indirect_component_types>
 //!\cond
     requires detail::weakly_equality_comparable_by_members_with<derived_type, indirect_component_type> &&
@@ -637,6 +644,7 @@ constexpr bool operator!=(indirect_component_type const lhs,
     return rhs != lhs;
 }
 
+//!\brief Checks whether `lhs` is smaller than `rhs`.
 template <typename indirect_component_type, typename derived_type, typename ...indirect_component_types>
 //!\cond
     requires detail::weakly_ordered_by_members_with<derived_type, indirect_component_type> &&
@@ -648,6 +656,7 @@ constexpr bool operator<(indirect_component_type const lhs,
     return rhs > lhs;
 }
 
+//!\brief Checks whether `lhs` is bigger than `rhs`.
 template <typename indirect_component_type, typename derived_type, typename ...indirect_component_types>
 //!\cond
     requires detail::weakly_ordered_by_members_with<derived_type, indirect_component_type> &&
@@ -659,6 +668,7 @@ constexpr bool operator>(indirect_component_type const lhs,
     return rhs < lhs;
 }
 
+//!\brief Checks whether `lhs` is smaller than or equal to `rhs`.
 template <typename indirect_component_type, typename derived_type, typename ...indirect_component_types>
 //!\cond
     requires detail::weakly_ordered_by_members_with<derived_type, indirect_component_type> &&
@@ -670,6 +680,7 @@ constexpr bool operator<=(indirect_component_type const lhs,
     return rhs >= lhs;
 }
 
+//!\brief Checks whether `lhs` is bigger than or equal to `rhs`.
 template <typename indirect_component_type, typename derived_type, typename ...indirect_component_types>
 //!\cond
     requires detail::weakly_ordered_by_members_with<derived_type, indirect_component_type> &&

--- a/include/seqan3/alphabet/composite/alphabet_variant.hpp
+++ b/include/seqan3/alphabet/composite/alphabet_variant.hpp
@@ -370,7 +370,9 @@ public:
      */
     template <typename alternative_t>
     constexpr bool is_alternative() const noexcept
+    //!\cond
         requires holds_alternative<alternative_t>()
+    //!\endcond
     {
         constexpr size_t index = meta::find_index<alternatives, alternative_t>::value;
         return is_alternative<index>();
@@ -382,7 +384,9 @@ public:
      */
     template <typename alternative_t>
     constexpr alternative_t convert_to() const
+    //!\cond
         requires holds_alternative<alternative_t>()
+    //!\endcond
     {
         constexpr size_t index = meta::find_index<alternatives, alternative_t>::value;
         return convert_impl<index, true>();
@@ -393,7 +397,9 @@ public:
      */
     template <typename alternative_t>
     constexpr alternative_t convert_unsafely_to() const noexcept
+    //!\cond
         requires holds_alternative<alternative_t>()
+    //!\endcond
     {
         constexpr size_t index = meta::find_index<alternatives, alternative_t>::value;
         return convert_impl<index, false>();
@@ -406,16 +412,22 @@ public:
      *        `alphabet_variant<dna5, gap>{gap{}} < 'C'_dna5`.
      * \{
      */
+    //!\brief Checks for equality.
     template <typename alternative_t>
     constexpr bool operator==(alternative_t const rhs) const noexcept
+    //!\cond
         requires holds_alternative<alternative_t>()
+    //!\endcond
     {
         return is_alternative<alternative_t>() && (convert_unsafely_to<alternative_t>() == rhs);
     }
 
+    //!\brief Checks for inequality.
     template <typename alternative_t>
     constexpr bool operator!=(alternative_t const rhs) const noexcept
+    //!\cond
         requires holds_alternative<alternative_t>()
+    //!\endcond
     {
         return !operator==(rhs);
     }
@@ -428,6 +440,7 @@ public:
      *        `alphabet_variant<dna5, gap>{gap{}} < 'C'_rna5`.
      * \{
      */
+    //!\brief Checks for equality.
     template <typename indirect_alternative_type>
     constexpr bool operator==(indirect_alternative_type const rhs) const noexcept
     //!\cond
@@ -442,6 +455,7 @@ public:
         return is_alternative<alternative_t>() && (convert_unsafely_to<alternative_t>() == rhs);
     }
 
+    //!\brief Checks for inequality.
     template <typename indirect_alternative_type>
     constexpr bool operator!=(indirect_alternative_type const rhs) const noexcept
     //!\cond
@@ -616,6 +630,7 @@ protected:
  * \brief Free function (in-)equality comparison operators that forward to member operators (for types != self).
  *\{
  */
+//!\brief Checks for equality.
 template <typename lhs_t, typename ...alternative_types>
 constexpr bool operator==(lhs_t const lhs, alphabet_variant<alternative_types...> const rhs) noexcept
 //!\cond
@@ -626,6 +641,7 @@ constexpr bool operator==(lhs_t const lhs, alphabet_variant<alternative_types...
     return rhs == lhs;
 }
 
+//!\brief Checks for inequality.
 template <typename lhs_t, typename ...alternative_types>
 constexpr bool operator!=(lhs_t const lhs, alphabet_variant<alternative_types...> const rhs) noexcept
 //!\cond

--- a/include/seqan3/alphabet/detail/alphabet_proxy.hpp
+++ b/include/seqan3/alphabet/detail/alphabet_proxy.hpp
@@ -190,7 +190,9 @@ private:
     //!\brief Assignment from any type that the emulated type is assignable from.
     template <typename indirect_assignable_type>
     constexpr derived_type & operator=(indirect_assignable_type const & c) noexcept
+    //!\cond
         requires weakly_assignable_from<alphabet_type, indirect_assignable_type>
+    //!\endcond
     {
         alphabet_type a{};
         a = c;
@@ -207,6 +209,7 @@ public:
      *        the assignment operator which invokes derived behaviour.
      * \{
      */
+    //!\brief Assigns a rank.
     constexpr derived_type & assign_rank(alphabet_rank_t<alphabet_type> const r) noexcept
     {
         alphabet_type tmp{};
@@ -214,16 +217,22 @@ public:
         return operator=(tmp);
     }
 
+    //!\brief Assigns a character.
     constexpr derived_type & assign_char(char_type const c) noexcept
+    //!\cond
         requires writable_alphabet<alphabet_type>
+    //!\endcond
     {
         alphabet_type tmp{};
         assign_char_to(c, tmp);
         return operator=(tmp);
     }
 
+    //!\brief Assigns a phred.
     constexpr derived_type & assign_phred(phred_type const c) noexcept
+    //!\cond
         requires writable_quality_alphabet<alphabet_type>
+    //!\endcond
     {
         alphabet_type tmp{};
         assign_phred_to(c, tmp);
@@ -251,8 +260,11 @@ public:
         return operator alphabet_type();
     }
 
+    //!\brief Returns the character.
     constexpr auto to_char() const noexcept
+    //!\cond
         requires alphabet<alphabet_type>
+    //!\endcond
     {
         /* (smehringer) Explicit conversion instead of static_cast:
          * See explanation in to_phred().
@@ -260,8 +272,11 @@ public:
         return seqan3::to_char(operator alphabet_type());
     }
 
+    //!\brief Returns the phred.
     constexpr auto to_phred() const noexcept
+    //!\cond
         requires quality_alphabet<alphabet_type>
+    //!\endcond
     {
         using seqan3::to_phred;
         /* (smehringer) Explicit conversion instead of static_cast:
@@ -287,7 +302,9 @@ public:
 
     //!\brief Delegate to the emulated type's validator.
     static constexpr bool char_is_valid(char_type const c) noexcept
+    //!\cond
         requires writable_alphabet<alphabet_type>
+    //!\endcond
     {
         return char_is_valid_for<alphabet_type>(c);
     }

--- a/include/seqan3/alphabet/mask/mask.hpp
+++ b/include/seqan3/alphabet/mask/mask.hpp
@@ -57,8 +57,8 @@ public:
      * \details Similar to an Enum interface.
      */
     //!\{
-    static const mask UNMASKED;
-    static const mask MASKED;
+    static const mask UNMASKED; //!< Member for UNMASKED.
+    static const mask MASKED;   //!< Member for MASKED.
     //!\}
 };
 

--- a/include/seqan3/alphabet/structure/dot_bracket3.hpp
+++ b/include/seqan3/alphabet/structure/dot_bracket3.hpp
@@ -149,8 +149,8 @@ protected:
 
 /*!\name Literals
  * \{
- *
- * \brief The seqan3::db3 string literal.
+ */
+/*!\brief The seqan3::db3 string literal.
  * \relates seqan3::dot_bracket3
  * \param[in] str A pointer to the character string to assign.
  * \param[in] len The size of the character string to assign.

--- a/include/seqan3/alphabet/structure/dssp9.hpp
+++ b/include/seqan3/alphabet/structure/dssp9.hpp
@@ -111,8 +111,8 @@ protected:
 
 /*!\name Literals
  * \{
- *
- * \brief The seqan3::dssp9 string literal.
+ */
+/*!\brief The seqan3::dssp9 string literal.
  * \relates seqan3::dssp9
  * \param[in] str A pointer to the character string to assign.
  * \param[in] len The size of the character string to assign.

--- a/include/seqan3/alphabet/structure/structured_rna.hpp
+++ b/include/seqan3/alphabet/structure/structured_rna.hpp
@@ -99,6 +99,7 @@ public:
 
     //!\name Write functions
     //!\{
+
     //!\brief Assign from a nucleotide character. This modifies the internal sequence letter.
     constexpr structured_rna & assign_char(char_type const c) noexcept
     {

--- a/include/seqan3/alphabet/structure/wuss.hpp
+++ b/include/seqan3/alphabet/structure/wuss.hpp
@@ -86,8 +86,8 @@ public:
 
     /*!\name RNA structure properties
      * \{
-     *
-     *!\brief Check whether the character represents a rightward interaction in an RNA structure.
+     */
+    /*!\brief Check whether the character represents a rightward interaction in an RNA structure.
      * \returns True if the letter represents a rightward interaction, False otherwise.
      */
     constexpr bool is_pair_open() const noexcept

--- a/include/seqan3/argument_parser/validators.hpp
+++ b/include/seqan3/argument_parser/validators.hpp
@@ -223,15 +223,18 @@ private:
  * \relates seqan3::value_list_validator
  * \{
  */
-
+//!\brief Deduction guide for `std::vector` over an arithmetic type.
 template <arithmetic option_value_type>
 value_list_validator(std::vector<option_value_type>) -> value_list_validator<double>;
 
+//!\brief Deduction guide for `std::initializer_list` over an arithmetic type.
 template <arithmetic option_value_type>
 value_list_validator(std::initializer_list<option_value_type>) -> value_list_validator<double>;
 
+//!\brief Deduction guide for `std::vector` over `const char *`.
 value_list_validator(std::vector<const char *>) -> value_list_validator<std::string>;
 
+//!\brief Deduction guide for `std::initializer_list` over `const char *`.
 value_list_validator(std::initializer_list<const char *>) -> value_list_validator<std::string>;
 //!\}
 

--- a/include/seqan3/core/char_operations/predicate_detail.hpp
+++ b/include/seqan3/core/char_operations/predicate_detail.hpp
@@ -190,13 +190,19 @@ struct char_predicate_base
     //!\brief Invokes the condition on `val`.
     template <std::integral value_t>
     constexpr bool operator()(value_t const val) const noexcept
+    //!\cond
         requires sizeof(value_t) == 1
+    //!\endcond
     {
         return derived_t::data[static_cast<unsigned char>(val)];
     }
+
+    //!\overload
     template <std::integral value_t>
     constexpr bool operator()(value_t const val) const noexcept
+    //!\cond
         requires sizeof(value_t) != 1
+    //!\endcond
     {
         return (static_cast<std::make_unsigned_t<value_t>>(val) < 256) ? operator()(static_cast<uint8_t>(val)) :
                (static_cast<decltype(EOF)>(val) == EOF)                ? derived_t::data[256]                  : false;

--- a/include/seqan3/core/pod_tuple.hpp
+++ b/include/seqan3/core/pod_tuple.hpp
@@ -174,10 +174,13 @@ pod_tuple(types && ...) -> pod_tuple<types...>;
  *
  * Note that these functions are available, both, in the seqan3 namespace and in namespace std.
  */
+//!\brief The same as [std::get](https://en.cppreference.com/w/cpp/utility/tuple/get) on an std::tuple.
 //!\relates seqan3::pod_tuple
 template <std::size_t i, typename ...types>
 constexpr auto & get(seqan3::pod_tuple<types...> & t) noexcept
+//!\cond
     requires i < sizeof...(types)
+//!\endcond
 {
     if constexpr (i == 0)
         return t._head;
@@ -185,10 +188,13 @@ constexpr auto & get(seqan3::pod_tuple<types...> & t) noexcept
         return seqan3::get<i-1>(t._tail);
 }
 
+//!\brief The same as [std::get](https://en.cppreference.com/w/cpp/utility/tuple/get) on an std::tuple.
 //!\relates seqan3::pod_tuple
 template <std::size_t i, typename ...types>
 constexpr auto const & get(seqan3::pod_tuple<types...> const & t) noexcept
+//!\cond
     requires i < sizeof...(types)
+//!\endcond
 {
     if constexpr (i == 0)
         return t._head;
@@ -197,10 +203,13 @@ constexpr auto const & get(seqan3::pod_tuple<types...> const & t) noexcept
 }
 
 // extra overloads for temporaries required, because members of temporaries may only be returned as temporaries
+//!\brief The same as [std::get](https://en.cppreference.com/w/cpp/utility/tuple/get) on an std::tuple.
 //!\relates seqan3::pod_tuple
 template <std::size_t i, typename ...types>
 constexpr auto && get(seqan3::pod_tuple<types...> && t) noexcept
+//!\cond
     requires i < sizeof...(types)
+//!\endcond
 {
     if constexpr (i == 0)
         return std::move(t._head);
@@ -208,10 +217,13 @@ constexpr auto && get(seqan3::pod_tuple<types...> && t) noexcept
         return seqan3::get<i-1>(std::move(t._tail));
 }
 
+//!\brief The same as [std::get](https://en.cppreference.com/w/cpp/utility/tuple/get) on an std::tuple.
 //!\relates seqan3::pod_tuple
 template <std::size_t i, typename ...types>
 constexpr auto const && get(seqan3::pod_tuple<types...> const && t) noexcept
+//!\cond
     requires i < sizeof...(types)
+//!\endcond
 {
     if constexpr (i == 0)
         return std::move(t._head);
@@ -228,45 +240,56 @@ constexpr auto const && get(seqan3::pod_tuple<types...> const && t) noexcept
  * in the tuple, i.e. `std::get<int>(std::tuple<int, int>{1,2})` is not defined.
  * \{
  */
-
+//!\brief The same as [std::get](https://en.cppreference.com/w/cpp/utility/tuple/get) on an std::tuple.
 //!\relates seqan3::pod_tuple
-template <typename type, typename ...types>
-constexpr auto & get(seqan3::pod_tuple<types...> & t) noexcept
-    requires meta::in<meta::list<types...>, type>::value &&
-             (meta::find_index<meta::list<types...>, type>::value ==
-              meta::reverse_find_index<meta::list<types...>, type>::value)
+template <typename type, typename ...arg_types>
+constexpr auto & get(seqan3::pod_tuple<arg_types...> & t) noexcept
+//!\cond
+    requires meta::in<meta::list<arg_types...>, type>::value &&
+             (meta::find_index<meta::list<arg_types...>, type>::value ==
+              meta::reverse_find_index<meta::list<arg_types...>, type>::value)
+//!\endcond
 {
-    return seqan3::get<meta::find_index<meta::list<types...>, type>::value>(t);
+    return seqan3::get<meta::find_index<meta::list<arg_types...>, type>::value>(t);
 }
 
+//!\brief The same as [std::get](https://en.cppreference.com/w/cpp/utility/tuple/get) on an std::tuple.
 //!\relates seqan3::pod_tuple
-template <typename type, typename ...types>
-constexpr auto const & get(seqan3::pod_tuple<types...> const & t) noexcept
-    requires meta::in<meta::list<types...>, type>::value &&
-             (meta::find_index<meta::list<types...>, type>::value ==
-              meta::reverse_find_index<meta::list<types...>, type>::value)
+template <typename type, typename ...arg_types>
+constexpr auto const & get(seqan3::pod_tuple<arg_types...> const & t) noexcept
+//!\cond
+    requires meta::in<meta::list<arg_types...>, type>::value &&
+             (meta::find_index<meta::list<arg_types...>, type>::value ==
+              meta::reverse_find_index<meta::list<arg_types...>, type>::value)
+//!\endcond
 {
-    return seqan3::get<meta::find_index<meta::list<types...>, type>::value>(t);
+    return seqan3::get<meta::find_index<meta::list<arg_types...>, type>::value>(t);
 }
 
+//!\brief The same as [std::get](https://en.cppreference.com/w/cpp/utility/tuple/get) on an std::tuple.
 //!\relates seqan3::pod_tuple
-template <typename type, typename ...types>
-constexpr auto && get(seqan3::pod_tuple<types...> && t) noexcept
-    requires meta::in<meta::list<types...>, type>::value &&
-             (meta::find_index<meta::list<types...>, type>::value ==
-              meta::reverse_find_index<meta::list<types...>, type>::value)
+template <typename type, typename ...arg_types>
+constexpr auto && get(seqan3::pod_tuple<arg_types...> && t) noexcept
+//!\cond
+    requires meta::in<meta::list<arg_types...>, type>::value &&
+             (meta::find_index<meta::list<arg_types...>, type>::value ==
+              meta::reverse_find_index<meta::list<arg_types...>, type>::value)
+//!\endcond
 {
-    return seqan3::get<meta::find_index<meta::list<types...>, type>::value>(std::move(t));
+    return seqan3::get<meta::find_index<meta::list<arg_types...>, type>::value>(std::move(t));
 }
 
+//!\brief The same as [std::get](https://en.cppreference.com/w/cpp/utility/tuple/get) on an std::tuple.
 //!\relates seqan3::pod_tuple
-template <typename type, typename ...types>
-constexpr auto const && get(seqan3::pod_tuple<types...> const && t) noexcept
-    requires meta::in<meta::list<types...>, type>::value &&
-             (meta::find_index<meta::list<types...>, type>::value ==
-              meta::reverse_find_index<meta::list<types...>, type>::value)
+template <typename type, typename ...arg_types>
+constexpr auto const && get(seqan3::pod_tuple<arg_types...> const && t) noexcept
+//!\cond
+    requires meta::in<meta::list<arg_types...>, type>::value &&
+             (meta::find_index<meta::list<arg_types...>, type>::value ==
+              meta::reverse_find_index<meta::list<arg_types...>, type>::value)
+//!\endcond
 {
-    return seqan3::get<meta::find_index<meta::list<types...>, type>::value>(std::move(t));
+    return seqan3::get<meta::find_index<meta::list<arg_types...>, type>::value>(std::move(t));
 }
 //!\}
 

--- a/include/seqan3/core/simd/view_to_simd.hpp
+++ b/include/seqan3/core/simd/view_to_simd.hpp
@@ -760,5 +760,5 @@ namespace seqan3::views
 
 template <simd::simd_concept simd_t>
 inline constexpr auto to_simd = detail::to_simd_fn<simd_t>{};
-//!\}
+
 } // namespace seqan3::views

--- a/include/seqan3/range/container/bitcompressed_vector.hpp
+++ b/include/seqan3/range/container/bitcompressed_vector.hpp
@@ -952,7 +952,6 @@ public:
     {
         std::swap(data, rhs.data);
     }
-    //!\}
 
     /*!\brief Swap contents with another instance.
      * \param lhs The first instance.

--- a/include/seqan3/range/views/kmer_hash.hpp
+++ b/include/seqan3/range/views/kmer_hash.hpp
@@ -138,61 +138,62 @@ private:
         //!\anchor shape_iterator_comparison
         //!\name Comparison operators
         //!\{
-        //\!brief Compare to iterator on text.
+
+        //!\brief Compare to iterator on text.
         friend bool operator==(shape_iterator const & lhs, sentinel_t const & rhs) noexcept
         {
             return lhs.text_right == rhs;
         }
 
-        //\!brief Compare to iterator on text.
+        //!\brief Compare to iterator on text.
         friend bool operator==(sentinel_t const & lhs, shape_iterator const & rhs) noexcept
         {
             return lhs == rhs.text_right;
         }
 
-        //\!brief Compare to another shape_iterator.
+        //!\brief Compare to another shape_iterator.
         friend bool operator==(shape_iterator const & lhs, shape_iterator const & rhs) noexcept
         {
             return std::tie(lhs.text_right, lhs.shape_) == std::tie(rhs.text_right, rhs.shape_);
         }
 
-        //\!brief Compare to iterator on text.
+        //!\brief Compare to iterator on text.
         friend bool operator!=(shape_iterator const & lhs, sentinel_t const & rhs) noexcept
         {
             return !(lhs == rhs);
         }
 
-        //\!brief Compare to iterator on text.
+        //!\brief Compare to iterator on text.
         friend bool operator!=(sentinel_t const & lhs, shape_iterator const & rhs) noexcept
         {
             return !(lhs == rhs);
         }
 
-        //\!brief Compare to another shape_iterator.
+        //!\brief Compare to another shape_iterator.
         friend bool operator!=(shape_iterator const & lhs, shape_iterator const & rhs) noexcept
         {
             return !(lhs == rhs);
         }
 
-        //\!brief Compare to another shape_iterator.
+        //!\brief Compare to another shape_iterator.
         friend bool operator<(shape_iterator const & lhs, shape_iterator const & rhs) noexcept
         {
             return (lhs.shape_ <= rhs.shape_) && (lhs.text_right < rhs.text_right);
         }
 
-        //\!brief Compare to another shape_iterator.
+        //!\brief Compare to another shape_iterator.
         friend bool operator>(shape_iterator const & lhs, shape_iterator const & rhs) noexcept
         {
             return (lhs.shape_ >= rhs.shape_) && (lhs.text_right > rhs.text_right);
         }
 
-        //\!brief Compare to another shape_iterator.
+        //!\brief Compare to another shape_iterator.
         friend bool operator<=(shape_iterator const & lhs, shape_iterator const & rhs) noexcept
         {
             return (lhs.shape_ <= rhs.shape_) && (lhs.text_right <= rhs.text_right);
         }
 
-        //\!brief Compare to another shape_iterator.
+        //!\brief Compare to another shape_iterator.
         friend bool operator>=(shape_iterator const & lhs, shape_iterator const & rhs) noexcept
         {
             return (lhs.shape_ >= rhs.shape_) && (lhs.text_right >= rhs.text_right);

--- a/include/seqan3/search/fm_index/fm_index.hpp
+++ b/include/seqan3/search/fm_index/fm_index.hpp
@@ -343,14 +343,16 @@ public:
      */
     fm_index() = default;              //!< Defaulted.
 
-    fm_index(fm_index const & rhs) :   //!< When copy constructing, also update internal data structures.
+    //!\brief When copy constructing, also update internal data structures.
+    fm_index(fm_index const & rhs) :
         index{rhs.index}, text_begin{rhs.text_begin}, text_begin_ss{rhs.text_begin_ss}, text_begin_rs{rhs.text_begin_rs}
     {
         text_begin_ss.set_vector(&text_begin);
         text_begin_rs.set_vector(&text_begin);
     }
 
-    fm_index(fm_index && rhs) :        //!< When move constructing, also update internal data structures.
+    //!\brief When move constructing, also update internal data structures.
+    fm_index(fm_index && rhs) :
         index{std::move(rhs.index)}, text_begin{std::move(rhs.text_begin)},text_begin_ss{std::move(rhs.text_begin_ss)},
         text_begin_rs{std::move(rhs.text_begin_rs)}
     {
@@ -358,7 +360,8 @@ public:
         text_begin_rs.set_vector(&text_begin);
     }
 
-    fm_index & operator=(fm_index rhs) //!< When copy/move assigning, also update internal data structures.
+    //!\brief When copy/move assigning, also update internal data structures.
+    fm_index & operator=(fm_index rhs)
     {
         index = std::move(rhs.index);
         text_begin = std::move(rhs.text_begin);


### PR DESCRIPTION
Resolves #754

The more esoteric stuff:
 * After opening a group, there usually needs to be a new line unless the documentation comment style changes from line (`//!`) to block (`/*!`) or vice versa. A member also cannot be documented in the same documentation block as the group was opened in.
* If an entire function is excluded via `//!\cond`, we cannot `//!\cond` the requires clause since we did not close the last `//!\cond` block that uses the same condition (in this case no condition).
* In `alphabet/aminoacid/translation.hpp` I needed to change the template parameter name to help doxygen resolve the function signature. Otherwise there would be two functions with the same signature (parameter name does not count, parameter template does count) and it would only take the last overload and complain about multiple or missing parameter documentation.
* For travis, we need to change from `texlive-latex-base` to `texlive-latex-extra`, because the LaTex package `newunicodechar` is now required. Usually it would be enough to install base and run `tlmgr install newunicodechar` ... but this is again broken and would need workarounds.