### PR TITLE
[FEATURE] more type list algorithms

### DIFF
--- a/test/unit/core/type_list_test.cpp
+++ b/test/unit/core/type_list_test.cpp
@@ -54,6 +54,16 @@ TEST(pack_traits, find)
                1u);
 }
 
+TEST(pack_traits, find_if)
+{
+    EXPECT_EQ((pack_traits::find_if<std::is_integral>),
+               -1ll);
+    EXPECT_EQ((pack_traits::find_if<std::is_integral, float, double const>),
+               -1ll);
+    EXPECT_EQ((pack_traits::find_if<std::is_integral, float, int, double const, long>),
+               1ll);
+}
+
 TEST(pack_traits, contains)
 {
     EXPECT_EQ((pack_traits::contains<int>),
@@ -202,6 +212,16 @@ TEST(list_traits, find)
                1u);
 }
 
+TEST(list_traits, find_if)
+{
+    EXPECT_EQ((list_traits::find_if<std::is_integral, type_list<>>),
+               -1ll);
+    EXPECT_EQ((list_traits::find_if<std::is_integral, type_list<float, double const>>),
+               -1ll);
+    EXPECT_EQ((list_traits::find_if<std::is_integral, type_list<float, int, double const, long>>),
+               1ll);
+}
+
 TEST(list_traits, contains)
 {
     EXPECT_EQ((list_traits::contains<int, type_list<>>),
@@ -236,6 +256,12 @@ TEST(list_traits, concat)
 {
     EXPECT_TRUE((std::is_same_v<list_traits::concat<type_list<int, bool &, double const>, type_list<long, float>>,
                                 type_list<int, bool &, double const, long, float>>));
+
+    EXPECT_TRUE((std::is_same_v<list_traits::concat<type_list<int, bool &, double const>,
+                                                    type_list<long, float>,
+                                                    type_list<>,
+                                                    type_list<long &>>,
+                                type_list<int, bool &, double const, long, float, long &>>));
 }
 
 TEST(list_traits, drop_front)


### PR DESCRIPTION
These should help you replace the meta:: stuff.

Note that our `find_if` behaves like our `find` and not like `meta::find_if`, i.e. it returns the position of the first type that matches. 

So the following:

```cpp
using component_type = meta::front<meta::find_if<component_list, detail::implicitly_convertible_from<indirect_component_type>>>;
```
would be replaced by 
```cpp
static constexpr bool pos =
    list_traits::find_if<detail::implicitly_convertible_from<indirect_component_type>::invoke,
                         component_list>;
using component_type = list_traits::at<pos, component_list>;
```

possibly:
```cpp
static constexpr bool pos =
    list_traits::find_if<detail::implicitly_convertible_from<indirect_component_type>::template invoke,
                         component_list>;
using component_type = list_traits::at<pos, component_list>;
```

I know the whole `detail::implicitly_convertible_from<indirect_component_type>::template invoke` is messy, it's on my list of clean up stuff...

Btw: once you are done with this taks, you could add meaningful snippets to all the stuff in `list_traits` / `pack_traits`  :smiley: 