### PR TITLE
[MISC] Let banded trace iterator return actual matrix coordinates.

### DIFF
--- a/include/seqan3/alignment/matrix/detail/alignment_trace_matrix_full_banded.hpp
+++ b/include/seqan3/alignment/matrix/detail/alignment_trace_matrix_full_banded.hpp
@@ -158,7 +158,8 @@ public:
         if (trace_begin.row >= static_cast<size_t>(band_size) || trace_begin.col >= matrix_base_t::num_cols)
             throw std::invalid_argument{"The given coordinate exceeds the trace matrix size."};
 
-        return path_t{trace_iterator_t{matrix_base_t::data.begin() + matrix_offset{trace_begin}},
+        return path_t{trace_iterator_t{matrix_base_t::data.begin() + matrix_offset{trace_begin},
+                                       column_index_type{band_col_index}},
                       std::ranges::default_sentinel};
     }
 

--- a/include/seqan3/alignment/matrix/detail/trace_iterator_banded.hpp
+++ b/include/seqan3/alignment/matrix/detail/trace_iterator_banded.hpp
@@ -54,8 +54,14 @@ public:
 
     /*!\brief Constructs from the underlying trace matrix iterator indicating the start of the trace path.
      * \param[in] matrix_iter The underlying matrix iterator.
+     * \param[in] pivot_column The last column index which is still inside of the band in the first row of the
+     *                         banded matrix.
      */
-    constexpr trace_iterator_banded(matrix_iter_t const matrix_iter) noexcept : base_t{matrix_iter}
+    template <typename index_t>
+    constexpr trace_iterator_banded(matrix_iter_t const matrix_iter, column_index_type<index_t> const & pivot_column)
+        noexcept :
+        base_t{matrix_iter},
+        pivot_column{static_cast<size_t>(pivot_column.get())}
     {}
 
     /*!\brief Constructs from the underlying trace matrix iterator indicating the start of the trace path.
@@ -75,6 +81,14 @@ public:
     {}
     //!\}
 
+    //!\copydoc seqan3::detail::trace_iterator_base::coordinate()
+    [[nodiscard]] constexpr matrix_coordinate coordinate() const noexcept
+    {
+        auto coord = base_t::coordinate();
+        coord.row += static_cast<int32_t>(coord.col - pivot_column);
+        return coord;
+    }
+
 private:
     //!\copydoc seqan3::detail::trace_iterator_base::go_left
     constexpr void go_left(matrix_iter_t & iter) const noexcept
@@ -91,14 +105,16 @@ private:
         // So going diagonal means go to the previous column and stay in the same row.
         iter -= matrix_offset{row_index_type{0}, column_index_type{1}};
     }
+
+    size_t pivot_column{}; //!< The largest column index which is inside of the band in the first row of the matrix.
 };
 
 /*!\name Type deduction guides
  * \{
  */
 //!\brief Deduces the template argument from the passed iterator.
-template <two_dimensional_matrix_iterator matrix_iter_t>
-trace_iterator_banded(matrix_iter_t const) -> trace_iterator_banded<matrix_iter_t>;
+// template <two_dimensional_matrix_iterator matrix_iter_t>
+// trace_iterator_banded(matrix_iter_t const) -> trace_iterator_banded<matrix_iter_t>;
 //!\}
 
 } // namespace seqan3::detail

--- a/include/seqan3/alignment/matrix/detail/trace_iterator_base.hpp
+++ b/include/seqan3/alignment/matrix/detail/trace_iterator_base.hpp
@@ -140,7 +140,7 @@ public:
     }
 
     //!\brief Returns the current coordinate in two-dimensional space.
-    constexpr matrix_coordinate coordinate() const noexcept
+    [[nodiscard]] constexpr matrix_coordinate coordinate() const noexcept
     {
         return matrix_iter.coordinate();
     }

--- a/test/unit/alignment/matrix/detail/trace_iterator_banded_test.cpp
+++ b/test/unit/alignment/matrix/detail/trace_iterator_banded_test.cpp
@@ -30,20 +30,29 @@ struct trace_iterator_banded_test : public ::testing::Test
     static constexpr trace_directions LO = trace_directions::left_open;
 
     two_dimensional_matrix<trace_directions> matrix{number_rows{5}, number_cols{6}, std::vector
-    {
+    {  // emulating band {row:2, col:2}
          N,  N,  L,  D,  D,  L,
          N, LO,  D,  D, UO, UO,
          N,  D,  D, LO,  D,  U,
         UO,  D,  D,  D,  D,  N,
          U,  D,  D,  D,  N,  N
     }};
+            // Band view
+        //   0  1  2  3  4  5
+        //0  N LO  L
+        //1 UO  D  D  D
+        //2  U  D  D  D  D
+        //3     D  D LO UO  L
+        //4        D  D  D UO
+        //5           D  D  U
 
-    using trace_iterator_type = decltype(trace_iterator_banded{matrix.begin()});
+    using trace_iterator_type = decltype(trace_iterator_banded{matrix.begin(), column_index_type{0}});
     using path_type = std::ranges::subrange<trace_iterator_type, std::ranges::default_sentinel_t>;
 
     path_type path(matrix_offset const & offset)
     {
-        return path_type{trace_iterator_type{matrix.begin() + offset}, std::ranges::default_sentinel};
+        return path_type{trace_iterator_type{matrix.begin() + offset, column_index_type{2}},
+                         std::ranges::default_sentinel};
     }
 };
 
@@ -68,31 +77,31 @@ TEST_F(trace_iterator_banded_test, coordinate)
     auto p = path(matrix_offset{row_index_type{2}, column_index_type{5}});
     auto it = p.begin();
 
-    EXPECT_EQ(it.coordinate().row, 2u);
+    EXPECT_EQ(it.coordinate().row, 5u);
     EXPECT_EQ(it.coordinate().col, 5u);
     ++it;
-    EXPECT_EQ(it.coordinate().row, 1u);
+    EXPECT_EQ(it.coordinate().row, 4u);
     EXPECT_EQ(it.coordinate().col, 5u);
     ++it;
-    EXPECT_EQ(it.coordinate().row, 0u);
+    EXPECT_EQ(it.coordinate().row, 3u);
     EXPECT_EQ(it.coordinate().col, 5u);
     ++it;
-    EXPECT_EQ(it.coordinate().row, 1u);
+    EXPECT_EQ(it.coordinate().row, 3u);
     EXPECT_EQ(it.coordinate().col, 4u);
     ++it;
-    EXPECT_EQ(it.coordinate().row, 2u);
+    EXPECT_EQ(it.coordinate().row, 3u);
     EXPECT_EQ(it.coordinate().col, 3u);
     ++it;
     EXPECT_EQ(it.coordinate().row, 3u);
     EXPECT_EQ(it.coordinate().col, 2u);
     ++it;
-    EXPECT_EQ(it.coordinate().row, 3u);
+    EXPECT_EQ(it.coordinate().row, 2u);
     EXPECT_EQ(it.coordinate().col, 1u);
     ++it;
-    EXPECT_EQ(it.coordinate().row, 3u);
+    EXPECT_EQ(it.coordinate().row, 1u);
     EXPECT_EQ(it.coordinate().col, 0u);
     ++it;
-    EXPECT_EQ(it.coordinate().row, 2u);
+    EXPECT_EQ(it.coordinate().row, 0u);
     EXPECT_EQ(it.coordinate().col, 0u);
 }
 
@@ -106,7 +115,7 @@ struct iterator_fixture<trace_iterator_banded_test> : public trace_iterator_band
     using base_t = trace_iterator_banded_test;
 
     using iterator_type = typename base_t::trace_iterator_type;
-    using const_iterator_type = decltype(trace_iterator_banded{base_t::matrix.cbegin()});
+    using const_iterator_type = decltype(trace_iterator_banded{base_t::matrix.cbegin(), column_index_type{0}});
 
     // Test forward iterator concept.
     using iterator_tag = std::forward_iterator_tag;
@@ -116,12 +125,14 @@ struct iterator_fixture<trace_iterator_banded_test> : public trace_iterator_band
     {
         auto begin()
         {
-            return iterator_type{matrix.begin() + matrix_offset{row_index_type{2}, column_index_type{5}}};
+            return iterator_type{matrix.begin() + matrix_offset{row_index_type{2}, column_index_type{5}},
+                                 column_index_type{2}};
         }
 
         auto cbegin() const
         {
-            return const_iterator_type{matrix.cbegin() + matrix_offset{row_index_type{2}, column_index_type{5}}};
+            return const_iterator_type{matrix.cbegin() + matrix_offset{row_index_type{2}, column_index_type{5}},
+                                       column_index_type{2}};
         }
 
         auto end() { return std::ranges::default_sentinel; }


### PR DESCRIPTION
The banded trace iterator should return the actual coordinates within the global alignment matrix and not the coordinates of the underlying storage. This corresponding mapping is only known by the banded trace matrix.

This is a upstream fix for #1237 where the solution was not well designed and done in another class that had noting to do with it. Now the interface is again clean.