### PR TITLE
Test/add matrices to alignment tests

### DIFF
--- a/include/seqan3/alignment/matrix/detail/two_dimensional_matrix.hpp
+++ b/include/seqan3/alignment/matrix/detail/two_dimensional_matrix.hpp
@@ -51,9 +51,11 @@ struct number_rows : strong_type<size_t, number_rows>
  *
  * \details
  *
- * This two dimensional matrix type is a base data structure for several alignment matrices. It can be customised by
- * providing another allocator type. Depending on the given `order` the element access on the underlying buffer
- * follows a row-major-order or a column-major-order.
+ * This two dimensional matrix type is a base data structure for several alignment matrices. It can be customised over
+ * the value type, the  allocator type and the major matrix order. The data is stored in a flat std::vector.
+ * Depending on the given `order`, the element access on the underlying buffer follows a row-major-order or a
+ * column-major-order. Accordingly, it is cache friendly and thus more efficient to access the data in the
+ * row-major-order row by row instead of column by column and vice versa for the column-major-order.
  */
 template <typename value_t,
           typename allocator_t = std::allocator<value_t>,
@@ -253,6 +255,52 @@ public:
         return end();
     }
     //!\}
+
+    /*!\brief Explicit transformation to the other major-order.
+     * \tparam other_value_t The target value type; must be assignable from `value_t`.
+     * \tparam other_allocator_t The allocator type used for the target matrix.
+     * \tparam other_order The other seqan3::detail::matrix_major_order; must not be the same as `order`.
+     *
+     * \details
+     *
+     * Copies the matrix cell by cell, rearranging the stored elements in the internal memory to represent the
+     * converted major-order.
+     *
+     * Consider the following matrix:
+     *
+     * 0  1  2  3
+     * 4  5  6  7
+     * 8  9  10 11
+     *
+     * In row-major-order the data is stored in a flat vector in the following way:
+     * 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11
+     *
+     * Converting it to column-major-order will rearrange the elements:
+     * 0, 4, 8, 1, 5, 9, 2, 6, 10, 3, 7, 11
+     *
+     * Note that the matrix is not transposed, such that the general layout as displayed above will remain the same.
+     * It only changes the matrix major order, i.e. data stored row wise is now stored column wise and vice versa.
+     */
+    template <typename other_value_t, typename other_allocator_t, matrix_major_order other_order>
+    //!\cond
+        requires order != other_order && std::assignable_from<other_value_t &, value_t &>
+    //!\endcond
+    explicit constexpr operator two_dimensional_matrix<other_value_t, other_allocator_t, other_order>() const
+    {
+        using converted_t = two_dimensional_matrix<other_value_t, other_allocator_t, other_order>;
+        converted_t tmp{number_rows{rows()}, number_cols{cols()}};
+
+        for (size_t i = 0; i < cols(); ++i)
+        {
+            for (size_t j = 0; j < rows(); ++j)
+            {
+                matrix_coordinate coord{row_index_type{j}, column_index_type{i}};
+                tmp[coord] = (*this)[coord];
+            }
+        }
+
+        return tmp;
+    }
 
 private:
 

--- a/test/unit/alignment/matrix/detail/two_dimensional_matrix_test.cpp
+++ b/test/unit/alignment/matrix/detail/two_dimensional_matrix_test.cpp
@@ -81,7 +81,7 @@ TYPED_TEST(two_dimensional_matrix_test, range)
     using matrix_type = typename TestFixture::matrix_type;
 
     matrix_type matrix{number_rows{3}, number_cols{4}};
-    auto it = std::copy(this->expected_range.begin(), this->expected_range.end(), matrix.begin());
+    auto it = std::ranges::copy(this->expected_range, matrix.begin()).out;
 
     EXPECT_EQ(it, matrix.end());
     EXPECT_TRUE(std::equal(this->expected_range.begin(), this->expected_range.end(), matrix.begin()));
@@ -92,7 +92,7 @@ TYPED_TEST(two_dimensional_matrix_test, subscript)
     using matrix_type = typename TestFixture::matrix_type;
 
     matrix_type matrix{number_rows{3}, number_cols{4}};
-    auto it = std::copy(this->expected_range.begin(), this->expected_range.end(), matrix.begin());
+    std::ranges::copy(this->expected_range, matrix.begin());
 
     if constexpr (TypeParam::value == matrix_major_order::row)
     {
@@ -119,7 +119,7 @@ TYPED_TEST(two_dimensional_matrix_test, at)
     using matrix_type = typename TestFixture::matrix_type;
 
     matrix_type matrix{number_rows{3}, number_cols{4}};
-    auto it = std::copy(this->expected_range.begin(), this->expected_range.end(), matrix.begin());
+    std::ranges::copy(this->expected_range, matrix.begin());
 
     if constexpr (TypeParam::value == matrix_major_order::row)
     {
@@ -138,11 +138,45 @@ TYPED_TEST(two_dimensional_matrix_test, at)
         EXPECT_EQ((matrix.at({row_index_type{0u}, column_index_type{3u}})), 9);
         EXPECT_EQ((matrix.at({row_index_type{2u}, column_index_type{0u}})), 2);
         EXPECT_EQ((matrix.at({row_index_type{2u}, column_index_type{3u}})), 11);
-
     }
 
     EXPECT_THROW((matrix.at({row_index_type{3u}, column_index_type{3u}})), std::invalid_argument);
     EXPECT_THROW((matrix.at({row_index_type{2u}, column_index_type{4u}})), std::invalid_argument);
+}
+
+TYPED_TEST(two_dimensional_matrix_test, conversion)
+{
+    using matrix_type = typename TestFixture::matrix_type;
+
+    matrix_type matrix{number_rows{3}, number_cols{4}};
+    std::ranges::copy(this->expected_range, matrix.begin());
+
+    if constexpr (TypeParam::value == matrix_major_order::row)
+    {
+        using converted_t = two_dimensional_matrix<uint32_t, std::allocator<uint32_t>, matrix_major_order::column>;
+        converted_t converted = static_cast<converted_t>(matrix);
+        EXPECT_EQ(converted.rows(), matrix.rows());
+        EXPECT_EQ(converted.cols(), matrix.cols());
+        EXPECT_EQ((converted[{row_index_type{0u}, column_index_type{0u}}]), 0u);
+        EXPECT_EQ((converted[{row_index_type{1u}, column_index_type{0u}}]), 4u);
+        EXPECT_EQ((converted[{row_index_type{0u}, column_index_type{1u}}]), 1u);
+        EXPECT_EQ((converted[{row_index_type{0u}, column_index_type{3u}}]), 3u);
+        EXPECT_EQ((converted[{row_index_type{2u}, column_index_type{0u}}]), 8u);
+        EXPECT_EQ((converted[{row_index_type{2u}, column_index_type{3u}}]), 11u);
+    }
+    else
+    {
+        using converted_t = two_dimensional_matrix<uint32_t, std::allocator<uint32_t>, matrix_major_order::row>;
+        converted_t converted = static_cast<converted_t>(matrix);
+        EXPECT_EQ(converted.rows(), matrix.rows());
+        EXPECT_EQ(converted.cols(), matrix.cols());
+        EXPECT_EQ((converted[{row_index_type{0u}, column_index_type{0u}}]), 0u);
+        EXPECT_EQ((converted[{row_index_type{1u}, column_index_type{0u}}]), 1u);
+        EXPECT_EQ((converted[{row_index_type{0u}, column_index_type{1u}}]), 3u);
+        EXPECT_EQ((converted[{row_index_type{0u}, column_index_type{3u}}]), 9u);
+        EXPECT_EQ((converted[{row_index_type{2u}, column_index_type{0u}}]), 2u);
+        EXPECT_EQ((converted[{row_index_type{2u}, column_index_type{3u}}]), 11u);
+    }
 }
 
 //-----------------------------------------------------------------------------

--- a/test/unit/alignment/matrix/edit_distance_trace_matrix_full_test.cpp
+++ b/test/unit/alignment/matrix/edit_distance_trace_matrix_full_test.cpp
@@ -62,7 +62,7 @@ TEST(global, epsilon)
 
     // row-wise matrix
     std::vector<std::vector<detail::trace_directions>> result = as_row_wise_vector(matrix);
-    std::vector<std::vector<detail::trace_directions>> expect{{NON}};
+    std::vector<std::vector<detail::trace_directions>> expect{{N}};
 
     EXPECT_EQ(result, expect);
 }
@@ -79,7 +79,7 @@ TEST(global, epsilon_row)
 
     // row-wise matrix
     std::vector<std::vector<detail::trace_directions>> result = as_row_wise_vector(matrix);
-    std::vector<std::vector<detail::trace_directions>> expect{{NON, L, L, L, L}};
+    std::vector<std::vector<detail::trace_directions>> expect{{N, l, l, l, l}};
 
     EXPECT_EQ(result, expect);
 }
@@ -104,15 +104,15 @@ TEST(global, single_word)
     std::vector<std::vector<detail::trace_directions>> result = as_row_wise_vector(matrix);
     std::vector<std::vector<detail::trace_directions>> expect
     {
-        {NON,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  },
-        {U  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL },
-        {U  ,U  ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  },
-        {U  ,U  ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  },
-        {U  ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  },
-        {U  ,DU ,D  ,DUL,DU ,DU ,DU ,DU ,D  ,D  },
-        {U  ,U  ,U  ,D  ,DL ,DUL,DU ,DU ,DU ,DU },
-        {U  ,U  ,U  ,U  ,D  ,D  ,DL ,DUL,DU ,DU },
-        {U  ,U  ,U  ,U  ,DU ,DU ,D  ,D  ,DL ,DUL}
+        {N  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  },
+        {u  ,D  ,Dl ,l  ,l  ,l  ,l  ,l  ,l  ,Dl },
+        {u  ,u  ,D  ,D  ,Dl ,l  ,l  ,l  ,l  ,l  },
+        {u  ,u  ,Du ,Du ,D  ,D  ,Dl ,l  ,l  ,l  },
+        {u  ,u  ,Du ,Du ,Du ,Du ,D  ,D  ,Dl ,l  },
+        {u  ,Du ,D  ,Dul,Du ,Du ,Du ,Du ,D  ,D  },
+        {u  ,u  ,u  ,D  ,Dl ,Dul,Du ,Du ,Du ,Du },
+        {u  ,u  ,u  ,u  ,D  ,D  ,Dl ,Dul,Du ,Du },
+        {u  ,u  ,u  ,u  ,Du ,Du ,D  ,D  ,Dl ,Dul}
     };
 
     EXPECT_EQ(result, expect);
@@ -158,24 +158,24 @@ TEST(global, multiple_words)
     std::vector<std::vector<detail::trace_directions>> result = as_row_wise_vector(matrix);
     std::vector<std::vector<detail::trace_directions>> expect
     {
-        {NON,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  },
-        {U  ,D  ,L  ,L  ,L  ,DL ,L  ,L  ,L  ,DL },
-        {U  ,DU ,D  ,DL ,DL ,D  ,L  ,L  ,L  ,DL },
-        {U  ,U  ,D  ,DL ,DL ,DUL,D  ,L  ,L  ,L  },
-        {U  ,U  ,DU ,D  ,DL ,DL ,DU ,D  ,DL ,DL },
-        {U  ,U  ,U  ,D  ,DL ,DL ,DUL,D  ,DL ,DL },
-        {U  ,U  ,U  ,DU ,D  ,DL ,DL ,DU ,D  ,DL },
-        {U  ,U  ,U  ,U  ,D  ,DL ,DL ,DUL,D  ,DL },
-        {U  ,U  ,U  ,U  ,DU ,D  ,DL ,DL ,DU ,D  },
-        {U  ,DU ,U  ,U  ,U  ,D  ,DL ,DL ,DUL,D  },
-        {U  ,DU ,U  ,U  ,U  ,DU ,D  ,DL ,DL ,DU },
-        {U  ,U  ,DU ,U  ,U  ,U  ,D  ,DL ,DL ,DUL},
-        {U  ,U  ,DU ,U  ,U  ,U  ,DU ,D  ,DL ,DL },
-        {U  ,U  ,U  ,DU ,U  ,U  ,U  ,D  ,DL ,DL },
-        {U  ,U  ,U  ,DU ,U  ,U  ,U  ,DU ,D  ,DL },
-        {U  ,U  ,U  ,U  ,DU ,U  ,U  ,U  ,D  ,DL },
-        {U  ,U  ,U  ,U  ,DU ,U  ,U  ,U  ,DU ,D  },
-        {U  ,U  ,U  ,U  ,DU ,U  ,U  ,U  ,DU ,D  }
+        {N  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  },
+        {u  ,D  ,l  ,l  ,l  ,Dl ,l  ,l  ,l  ,Dl },
+        {u  ,Du ,D  ,Dl ,Dl ,D  ,l  ,l  ,l  ,Dl },
+        {u  ,u  ,D  ,Dl ,Dl ,Dul,D  ,l  ,l  ,l  },
+        {u  ,u  ,Du ,D  ,Dl ,Dl ,Du ,D  ,Dl ,Dl },
+        {u  ,u  ,u  ,D  ,Dl ,Dl ,Dul,D  ,Dl ,Dl },
+        {u  ,u  ,u  ,Du ,D  ,Dl ,Dl ,Du ,D  ,Dl },
+        {u  ,u  ,u  ,u  ,D  ,Dl ,Dl ,Dul,D  ,Dl },
+        {u  ,u  ,u  ,u  ,Du ,D  ,Dl ,Dl ,Du ,D  },
+        {u  ,Du ,u  ,u  ,u  ,D  ,Dl ,Dl ,Dul,D  },
+        {u  ,Du ,u  ,u  ,u  ,Du ,D  ,Dl ,Dl ,Du },
+        {u  ,u  ,Du ,u  ,u  ,u  ,D  ,Dl ,Dl ,Dul},
+        {u  ,u  ,Du ,u  ,u  ,u  ,Du ,D  ,Dl ,Dl },
+        {u  ,u  ,u  ,Du ,u  ,u  ,u  ,D  ,Dl ,Dl },
+        {u  ,u  ,u  ,Du ,u  ,u  ,u  ,Du ,D  ,Dl },
+        {u  ,u  ,u  ,u  ,Du ,u  ,u  ,u  ,D  ,Dl },
+        {u  ,u  ,u  ,u  ,Du ,u  ,u  ,u  ,Du ,D  },
+        {u  ,u  ,u  ,u  ,Du ,u  ,u  ,u  ,Du ,D  }
     };
 
     EXPECT_EQ(result, expect);
@@ -200,7 +200,7 @@ TEST(semi_global, epsilon)
 
     // row-wise matrix
     std::vector<std::vector<detail::trace_directions>> result = as_row_wise_vector(matrix);
-    std::vector<std::vector<detail::trace_directions>> expect{{NON}};
+    std::vector<std::vector<detail::trace_directions>> expect{{N}};
 
     EXPECT_EQ(result, expect);
 }
@@ -217,7 +217,7 @@ TEST(semi_global, epsilon_row)
 
     // row-wise matrix
     std::vector<std::vector<detail::trace_directions>> result = as_row_wise_vector(matrix);
-    std::vector<std::vector<detail::trace_directions>> expect{{NON, NON, NON, NON, NON}};
+    std::vector<std::vector<detail::trace_directions>> expect{{N, N, N, N, N}};
 
     EXPECT_EQ(result, expect);
 }
@@ -242,15 +242,15 @@ TEST(semi_global, single_word)
     std::vector<std::vector<detail::trace_directions>> result = as_row_wise_vector(matrix);
     std::vector<std::vector<detail::trace_directions>> expect
     {
-        {NON,NON,NON,NON,NON,NON,NON,NON,NON,NON},
-        {U  ,D  ,D  ,DUL,DU ,DU ,DU ,DU ,DU ,D  },
-        {U  ,U  ,DU ,D  ,DL ,DUL,DU ,DU ,DU ,U  },
-        {U  ,U  ,DU ,U  ,D  ,D  ,DL ,DUL,DU ,U  },
-        {U  ,U  ,DU ,U  ,DU ,DU ,D  ,D  ,DL ,U  },
-        {U  ,DU ,D  ,U  ,DU ,DU ,DU ,DU ,D  ,D  },
-        {U  ,U  ,U  ,D  ,D  ,DUL,DU ,DU ,DU ,DU },
-        {U  ,U  ,U  ,U  ,DU ,D  ,DL ,DUL,DU ,DU },
-        {U  ,U  ,U  ,U  ,DU ,U  ,D  ,D  ,DL ,DUL}
+        {N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  },
+        {u  ,D  ,D  ,Dul,Du ,Du ,Du ,Du ,Du ,D  },
+        {u  ,u  ,Du ,D  ,Dl ,Dul,Du ,Du ,Du ,u  },
+        {u  ,u  ,Du ,u  ,D  ,D  ,Dl ,Dul,Du ,u  },
+        {u  ,u  ,Du ,u  ,Du ,Du ,D  ,D  ,Dl ,u  },
+        {u  ,Du ,D  ,u  ,Du ,Du ,Du ,Du ,D  ,D  },
+        {u  ,u  ,u  ,D  ,D  ,Dul,Du ,Du ,Du ,Du },
+        {u  ,u  ,u  ,u  ,Du ,D  ,Dl ,Dul,Du ,Du },
+        {u  ,u  ,u  ,u  ,Du ,u  ,D  ,D  ,Dl ,Dul}
     };
 
     EXPECT_EQ(result, expect);
@@ -296,24 +296,24 @@ TEST(semi_global, multiple_words)
     std::vector<std::vector<detail::trace_directions>> result = as_row_wise_vector(matrix);
     std::vector<std::vector<detail::trace_directions>> expect
     {
-        {NON,NON,NON,NON,NON,NON,NON,NON,NON,NON},
-        {U  ,D  ,DUL,DU ,DU ,D  ,DUL,DU ,DU ,D  },
-        {U  ,DU ,D  ,DUL,DU ,DU ,D  ,DL ,DUL,DU },
-        {U  ,U  ,D  ,DL ,DUL,U  ,DU ,D  ,DL ,U  },
-        {U  ,U  ,DU ,D  ,DL ,U  ,DU ,D  ,DL ,UL },
-        {U  ,U  ,U  ,D  ,DL ,DUL,U  ,DU ,D  ,D  },
-        {U  ,U  ,U  ,DU ,D  ,DL ,U  ,DU ,D  ,D  },
-        {U  ,U  ,U  ,U  ,D  ,DL ,DUL,U  ,DU ,DU },
-        {U  ,U  ,U  ,U  ,DU ,D  ,DL ,U  ,DU ,D  },
-        {U  ,DU ,U  ,U  ,U  ,D  ,DL ,DUL,U  ,DU },
-        {U  ,DU ,U  ,U  ,U  ,DU ,D  ,DL ,U  ,DU },
-        {U  ,U  ,DU ,U  ,U  ,U  ,D  ,DL ,DUL,U  },
-        {U  ,U  ,DU ,U  ,U  ,U  ,DU ,D  ,DL ,U  },
-        {U  ,U  ,U  ,DU ,U  ,U  ,U  ,D  ,DL ,DUL},
-        {U  ,U  ,U  ,DU ,U  ,U  ,U  ,DU ,D  ,DL },
-        {U  ,U  ,U  ,U  ,DU ,U  ,U  ,U  ,D  ,DL },
-        {U  ,U  ,U  ,U  ,DU ,U  ,U  ,U  ,DU ,D  },
-        {U  ,U  ,U  ,U  ,DU ,U  ,U  ,U  ,DU ,D  }
+        {N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  },
+        {u  ,D  ,Dul,Du ,Du ,D  ,Dul,Du ,Du ,D  },
+        {u  ,Du ,D  ,Dul,Du ,Du ,D  ,Dl ,Dul,Du },
+        {u  ,u  ,D  ,Dl ,Dul,u  ,Du ,D  ,Dl ,u  },
+        {u  ,u  ,Du ,D  ,Dl ,u  ,Du ,D  ,Dl ,ul },
+        {u  ,u  ,u  ,D  ,Dl ,Dul,u  ,Du ,D  ,D  },
+        {u  ,u  ,u  ,Du ,D  ,Dl ,u  ,Du ,D  ,D  },
+        {u  ,u  ,u  ,u  ,D  ,Dl ,Dul,u  ,Du ,Du },
+        {u  ,u  ,u  ,u  ,Du ,D  ,Dl ,u  ,Du ,D  },
+        {u  ,Du ,u  ,u  ,u  ,D  ,Dl ,Dul,u  ,Du },
+        {u  ,Du ,u  ,u  ,u  ,Du ,D  ,Dl ,u  ,Du },
+        {u  ,u  ,Du ,u  ,u  ,u  ,D  ,Dl ,Dul,u  },
+        {u  ,u  ,Du ,u  ,u  ,u  ,Du ,D  ,Dl ,u  },
+        {u  ,u  ,u  ,Du ,u  ,u  ,u  ,D  ,Dl ,Dul},
+        {u  ,u  ,u  ,Du ,u  ,u  ,u  ,Du ,D  ,Dl },
+        {u  ,u  ,u  ,u  ,Du ,u  ,u  ,u  ,D  ,Dl },
+        {u  ,u  ,u  ,u  ,Du ,u  ,u  ,u  ,Du ,D  },
+        {u  ,u  ,u  ,u  ,Du ,u  ,u  ,u  ,Du ,D  }
     };
 
     EXPECT_EQ(result, expect);
@@ -338,7 +338,7 @@ TEST(global_max_errors, epsilon)
 
     // row-wise matrix
     std::vector<std::vector<detail::trace_directions>> result = as_row_wise_vector(matrix);
-    std::vector<std::vector<detail::trace_directions>> expect{{NON}};
+    std::vector<std::vector<detail::trace_directions>> expect{{N}};
 
     EXPECT_EQ(result, expect);
 }
@@ -355,7 +355,7 @@ TEST(global_max_errors, epsilon_row)
 
     // row-wise matrix
     std::vector<std::vector<detail::trace_directions>> result = as_row_wise_vector(matrix);
-    std::vector<std::vector<detail::trace_directions>> expect{{NON, L, L,NON,NON}};
+    std::vector<std::vector<detail::trace_directions>> expect{{N, l, l, N, N}};
 
     EXPECT_EQ(result, expect);
 }
@@ -380,15 +380,15 @@ TEST(global_max_errors, single_word_1)
     std::vector<std::vector<detail::trace_directions>> result = as_row_wise_vector(matrix);
     std::vector<std::vector<detail::trace_directions>> expect
     {
-        {NON,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  },
-        {U  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL },
-        {U  ,U  ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  },
-        {U  ,U  ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  },
-        {U  ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  },
-        {U  ,DU ,D  ,DUL,DU ,DU ,DU ,DU ,D  ,D  },
-        {NON,U  ,U  ,D  ,DL ,DUL,DU ,DU ,DU ,DU },
-        {NON,NON,U  ,U  ,D  ,D  ,DL ,DUL,NON,NON},
-        {NON,NON,NON,U  ,DU ,DU ,D  ,D  ,NON,NON}
+        {N  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  },
+        {u  ,D  ,Dl ,l  ,l  ,l  ,l  ,l  ,l  ,Dl },
+        {u  ,u  ,D  ,D  ,Dl ,l  ,l  ,l  ,l  ,l  },
+        {u  ,u  ,Du ,Du ,D  ,D  ,Dl ,l  ,l  ,l  },
+        {u  ,u  ,Du ,Du ,Du ,Du ,D  ,D  ,Dl ,l  },
+        {u  ,Du ,D  ,Dul,Du ,Du ,Du ,Du ,D  ,D  },
+        {N  ,u  ,u  ,D  ,Dl ,Dul,Du ,Du ,Du ,Du },
+        {N  ,N  ,u  ,u  ,D  ,D  ,Dl ,Dul,N  ,N  },
+        {N  ,N  ,N  ,u  ,Du ,Du ,D  ,D  ,N  ,N  }
     };
 
     EXPECT_EQ(result, expect);
@@ -414,15 +414,15 @@ TEST(global_max_errors, single_word_2)
     std::vector<std::vector<detail::trace_directions>> result = as_row_wise_vector(matrix);
     std::vector<std::vector<detail::trace_directions>> expect
     {
-        {NON,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  },
-        {U  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL },
-        {U  ,U  ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  },
-        {U  ,U  ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  },
-        {U  ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  },
-        {NON,DU ,D  ,DUL,DU ,DU ,DU ,DU ,D  ,D  },
-        {NON,NON,U  ,D  ,DL ,DUL,NON,NON,NON,NON},
-        {NON,NON,NON,U  ,D  ,D  ,NON,NON,NON,NON},
-        {NON,NON,NON,NON,NON,NON,NON,NON,NON,NON}
+        {N  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  },
+        {u  ,D  ,Dl ,l  ,l  ,l  ,l  ,l  ,l  ,Dl },
+        {u  ,u  ,D  ,D  ,Dl ,l  ,l  ,l  ,l  ,l  },
+        {u  ,u  ,Du ,Du ,D  ,D  ,Dl ,l  ,l  ,l  },
+        {u  ,u  ,Du ,Du ,Du ,Du ,D  ,D  ,Dl ,l  },
+        {N  ,Du ,D  ,Dul,Du ,Du ,Du ,Du ,D  ,D  },
+        {N  ,N  ,u  ,D  ,Dl ,Dul,N  ,N  ,N  ,N  },
+        {N  ,N  ,N  ,u  ,D  ,D  ,N  ,N  ,N  ,N  },
+        {N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  }
     };
 
     EXPECT_EQ(result, expect);
@@ -448,15 +448,15 @@ TEST(global_max_errors, single_word_3)
     std::vector<std::vector<detail::trace_directions>> result = as_row_wise_vector(matrix);
     std::vector<std::vector<detail::trace_directions>> expect
     {
-        {NON,L  ,L  ,L  ,L  ,L  ,L  ,L  ,NON,NON},
-        {U  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,NON,NON},
-        {U  ,U  ,D  ,D  ,DL ,L  ,L  ,L  ,NON,NON},
-        {U  ,U  ,DU ,DU ,D  ,D  ,DL ,L  ,NON,NON},
-        {NON,U  ,DU ,DU ,DU ,DU ,D  ,D  ,NON,NON},
-        {NON,NON,D  ,DUL,NON,NON,NON,NON,NON,NON},
-        {NON,NON,NON,D  ,NON,NON,NON,NON,NON,NON},
-        {NON,NON,NON,NON,NON,NON,NON,NON,NON,NON},
-        {NON,NON,NON,NON,NON,NON,NON,NON,NON,NON}
+        {N  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,N  ,N  },
+        {u  ,D  ,Dl ,l  ,l  ,l  ,l  ,l  ,N  ,N  },
+        {u  ,u  ,D  ,D  ,Dl ,l  ,l  ,l  ,N  ,N  },
+        {u  ,u  ,Du ,Du ,D  ,D  ,Dl ,l  ,N  ,N  },
+        {N  ,u  ,Du ,Du ,Du ,Du ,D  ,D  ,N  ,N  },
+        {N  ,N  ,D  ,Dul,N  ,N  ,N  ,N  ,N  ,N  },
+        {N  ,N  ,N  ,D  ,N  ,N  ,N  ,N  ,N  ,N  },
+        {N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  },
+        {N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  }
     };
 
     EXPECT_EQ(result, expect);
@@ -482,16 +482,16 @@ TEST(global_max_errors, multiple_words_1)
     std::vector<std::vector<detail::trace_directions>> result = as_row_wise_vector(matrix);
     std::vector<std::vector<detail::trace_directions>> expect
     {
-        {NON,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  },
-        {U  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL },
-        {U  ,U  ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  },
-        {U  ,U  ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  },
-        {U  ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  },
-        {U  ,DU ,D  ,DUL,DU ,DU ,DU ,DU ,D  ,D  },
-        {NON,U  ,U  ,D  ,DL ,DUL,DU ,DU ,DU ,DU },
-        {NON,NON,U  ,U  ,D  ,D  ,DL ,DUL,NON,NON},
-        {NON,NON,NON,U  ,DU ,DU ,D  ,D  ,NON,NON},
-        {NON,NON,NON,NON,NON,NON,NON,NON,NON,NON}
+        {N  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  },
+        {u  ,D  ,Dl ,l  ,l  ,l  ,l  ,l  ,l  ,Dl },
+        {u  ,u  ,D  ,D  ,Dl ,l  ,l  ,l  ,l  ,l  },
+        {u  ,u  ,Du ,Du ,D  ,D  ,Dl ,l  ,l  ,l  },
+        {u  ,u  ,Du ,Du ,Du ,Du ,D  ,D  ,Dl ,l  },
+        {u  ,Du ,D  ,Dul,Du ,Du ,Du ,Du ,D  ,D  },
+        {N  ,u  ,u  ,D  ,Dl ,Dul,Du ,Du ,Du ,Du },
+        {N  ,N  ,u  ,u  ,D  ,D  ,Dl ,Dul,N  ,N  },
+        {N  ,N  ,N  ,u  ,Du ,Du ,D  ,D  ,N  ,N  },
+        {N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  }
     };
 
     EXPECT_EQ(result, expect);
@@ -537,24 +537,24 @@ TEST(global_max_errors, multiple_words_2)
     std::vector<std::vector<detail::trace_directions>> result = as_row_wise_vector(matrix);
     std::vector<std::vector<detail::trace_directions>> expect
     {
-        {NON,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  },
-        {U  ,D  ,L  ,L  ,L  ,DL ,L  ,L  ,L  ,DL },
-        {U  ,DU ,D  ,DL ,DL ,D  ,L  ,L  ,L  ,DL },
-        {U  ,U  ,D  ,DL ,DL ,DUL,D  ,L  ,L  ,L  },
-        {U  ,U  ,DU ,D  ,DL ,DL ,DU ,D  ,DL ,DL },
-        {U  ,U  ,U  ,D  ,DL ,DL ,DUL,D  ,DL ,DL },
-        {U  ,U  ,U  ,DU ,D  ,DL ,DL ,DU ,D  ,DL },
-        {U  ,U  ,U  ,U  ,D  ,DL ,DL ,DUL,D  ,DL },
-        {U  ,U  ,U  ,U  ,DU ,D  ,DL ,DL ,DU ,D  },
-        {NON,DU ,U  ,U  ,U  ,D  ,DL ,DL ,DUL,D  },
-        {NON,NON,U  ,U  ,U  ,DU ,D  ,DL ,DL ,DU },
-        {NON,NON,NON,U  ,U  ,U  ,D  ,DL ,DL ,DUL},
-        {NON,NON,NON,NON,U  ,U  ,DU ,D  ,DL ,DL },
-        {NON,NON,NON,NON,NON,U  ,U  ,D  ,DL ,DL },
-        {NON,NON,NON,NON,NON,NON,U  ,DU ,D  ,DL },
-        {NON,NON,NON,NON,NON,NON,NON,U  ,D  ,DL },
-        {NON,NON,NON,NON,NON,NON,NON,NON,DU ,D  },
-        {NON,NON,NON,NON,NON,NON,NON,NON,NON,D  }
+        {N  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  },
+        {u  ,D  ,l  ,l  ,l  ,Dl ,l  ,l  ,l  ,Dl },
+        {u  ,Du ,D  ,Dl ,Dl ,D  ,l  ,l  ,l  ,Dl },
+        {u  ,u  ,D  ,Dl ,Dl ,Dul,D  ,l  ,l  ,l  },
+        {u  ,u  ,Du ,D  ,Dl ,Dl ,Du ,D  ,Dl ,Dl },
+        {u  ,u  ,u  ,D  ,Dl ,Dl ,Dul,D  ,Dl ,Dl },
+        {u  ,u  ,u  ,Du ,D  ,Dl ,Dl ,Du ,D  ,Dl },
+        {u  ,u  ,u  ,u  ,D  ,Dl ,Dl ,Dul,D  ,Dl },
+        {u  ,u  ,u  ,u  ,Du ,D  ,Dl ,Dl ,Du ,D  },
+        {N  ,Du ,u  ,u  ,u  ,D  ,Dl ,Dl ,Dul,D  },
+        {N  ,N  ,u  ,u  ,u  ,Du ,D  ,Dl ,Dl ,Du },
+        {N  ,N  ,N  ,u  ,u  ,u  ,D  ,Dl ,Dl ,Dul},
+        {N  ,N  ,N  ,N  ,u  ,u  ,Du ,D  ,Dl ,Dl },
+        {N  ,N  ,N  ,N  ,N  ,u  ,u  ,D  ,Dl ,Dl },
+        {N  ,N  ,N  ,N  ,N  ,N  ,u  ,Du ,D  ,Dl },
+        {N  ,N  ,N  ,N  ,N  ,N  ,N  ,u  ,D  ,Dl },
+        {N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,Du ,D  },
+        {N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,D  }
     };
 
     EXPECT_EQ(result, expect);
@@ -579,7 +579,7 @@ TEST(semi_global_max_errors, epsilon)
 
     // row-wise matrix
     std::vector<std::vector<detail::trace_directions>> result = as_row_wise_vector(matrix);
-    std::vector<std::vector<detail::trace_directions>> expect{{NON}};
+    std::vector<std::vector<detail::trace_directions>> expect{{N}};
 
     EXPECT_EQ(result, expect);
 }
@@ -596,7 +596,7 @@ TEST(semi_global_max_errors, epsilon_row)
 
     // row-wise matrix
     std::vector<std::vector<detail::trace_directions>> result = as_row_wise_vector(matrix);
-    std::vector<std::vector<detail::trace_directions>> expect{{NON,NON,NON,NON,NON}};
+    std::vector<std::vector<detail::trace_directions>> expect{{N, N, N, N, N}};
 
     EXPECT_EQ(result, expect);
 }
@@ -621,15 +621,15 @@ TEST(semi_global_max_errors, single_word)
     std::vector<std::vector<detail::trace_directions>> result = as_row_wise_vector(matrix);
     std::vector<std::vector<detail::trace_directions>> expect
     {
-        {NON,NON,NON,NON,NON,NON,NON,NON,NON,NON},
-        {U  ,D  ,D  ,DUL,DU ,DU ,DU ,DU ,DU ,D  },
-        {U  ,U  ,DU ,D  ,DL ,DUL,DU ,DU ,DU ,U  },
-        {U  ,U  ,DU ,U  ,D  ,D  ,DL ,DUL,DU ,U  },
-        {U  ,U  ,DU ,U  ,DU ,DU ,D  ,D  ,DL ,U  },
-        {U  ,DU ,D  ,U  ,DU ,DU ,DU ,DU ,D  ,D  },
-        {NON,U  ,U  ,D  ,D  ,DUL,DU ,DU ,DU ,DU },
-        {NON,NON,U  ,U  ,DU ,D  ,DL ,DUL,DU ,DU },
-        {NON,NON,NON,U  ,DU ,U  ,D  ,D  ,DL ,NON}
+        {N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  },
+        {u  ,D  ,D  ,Dul,Du ,Du ,Du ,Du ,Du ,D  },
+        {u  ,u  ,Du ,D  ,Dl ,Dul,Du ,Du ,Du ,u  },
+        {u  ,u  ,Du ,u  ,D  ,D  ,Dl ,Dul,Du ,u  },
+        {u  ,u  ,Du ,u  ,Du ,Du ,D  ,D  ,Dl ,u  },
+        {u  ,Du ,D  ,u  ,Du ,Du ,Du ,Du ,D  ,D  },
+        {N  ,u  ,u  ,D  ,D  ,Dul,Du ,Du ,Du ,Du },
+        {N  ,N  ,u  ,u  ,Du ,D  ,Dl ,Dul,Du ,Du },
+        {N  ,N  ,N  ,u  ,Du ,u  ,D  ,D  ,Dl ,N  }
     };
 
     EXPECT_EQ(result, expect);
@@ -675,24 +675,24 @@ TEST(semi_global_max_errors, multiple_words)
     std::vector<std::vector<detail::trace_directions>> result = as_row_wise_vector(matrix);
     std::vector<std::vector<detail::trace_directions>> expect
     {
-        {NON,NON,NON,NON,NON,NON,NON,NON,NON,NON},
-        {U  ,D  ,DUL,DU ,DU ,D  ,DUL,DU ,DU ,D  },
-        {U  ,DU ,D  ,DUL,DU ,DU ,D  ,DL ,DUL,DU },
-        {U  ,U  ,D  ,DL ,DUL,U  ,DU ,D  ,DL ,U  },
-        {U  ,U  ,DU ,D  ,DL ,U  ,DU ,D  ,DL ,UL },
-        {U  ,U  ,U  ,D  ,DL ,DUL,U  ,DU ,D  ,D  },
-        {U  ,U  ,U  ,DU ,D  ,DL ,U  ,DU ,D  ,D  },
-        {U  ,U  ,U  ,U  ,D  ,DL ,DUL,U  ,DU ,DU },
-        {U  ,U  ,U  ,U  ,DU ,D  ,DL ,U  ,DU ,D  },
-        {NON,DU ,U  ,U  ,U  ,D  ,DL ,DUL,U  ,DU },
-        {NON,NON,U  ,U  ,U  ,DU ,D  ,DL ,U  ,DU },
-        {NON,NON,NON,U  ,U  ,U  ,D  ,DL ,DUL,U  },
-        {NON,NON,NON,NON,U  ,U  ,DU ,D  ,DL ,U  },
-        {NON,NON,NON,NON,NON,U  ,U  ,D  ,DL ,DUL},
-        {NON,NON,NON,NON,NON,NON,U  ,DU ,D  ,DL },
-        {NON,NON,NON,NON,NON,NON,NON,U  ,D  ,DL },
-        {NON,NON,NON,NON,NON,NON,NON,NON,DU ,D  },
-        {NON,NON,NON,NON,NON,NON,NON,NON,NON,D  }
+        {N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  },
+        {u  ,D  ,Dul,Du ,Du ,D  ,Dul,Du ,Du ,D  },
+        {u  ,Du ,D  ,Dul,Du ,Du ,D  ,Dl ,Dul,Du },
+        {u  ,u  ,D  ,Dl ,Dul,u  ,Du ,D  ,Dl ,u  },
+        {u  ,u  ,Du ,D  ,Dl ,u  ,Du ,D  ,Dl ,ul },
+        {u  ,u  ,u  ,D  ,Dl ,Dul,u  ,Du ,D  ,D  },
+        {u  ,u  ,u  ,Du ,D  ,Dl ,u  ,Du ,D  ,D  },
+        {u  ,u  ,u  ,u  ,D  ,Dl ,Dul,u  ,Du ,Du },
+        {u  ,u  ,u  ,u  ,Du ,D  ,Dl ,u  ,Du ,D  },
+        {N  ,Du ,u  ,u  ,u  ,D  ,Dl ,Dul,u  ,Du },
+        {N  ,N  ,u  ,u  ,u  ,Du ,D  ,Dl ,u  ,Du },
+        {N  ,N  ,N  ,u  ,u  ,u  ,D  ,Dl ,Dul,u  },
+        {N  ,N  ,N  ,N  ,u  ,u  ,Du ,D  ,Dl ,u  },
+        {N  ,N  ,N  ,N  ,N  ,u  ,u  ,D  ,Dl ,Dul},
+        {N  ,N  ,N  ,N  ,N  ,N  ,u  ,Du ,D  ,Dl },
+        {N  ,N  ,N  ,N  ,N  ,N  ,N  ,u  ,D  ,Dl },
+        {N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,Du ,D  },
+        {N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,D  }
     };
 
     EXPECT_EQ(result, expect);

--- a/test/unit/alignment/pairwise/fixture/alignment_fixture.hpp
+++ b/test/unit/alignment/pairwise/fixture/alignment_fixture.hpp
@@ -16,14 +16,38 @@ namespace seqan3::test::alignment::fixture
 
 static constexpr auto INF = std::nullopt;
 
-static constexpr auto NON = detail::trace_directions::none;
-static constexpr auto D = detail::trace_directions::diagonal;
-static constexpr auto U = detail::trace_directions::up;
-static constexpr auto L = detail::trace_directions::left;
-static constexpr auto DU = D | U;
-static constexpr auto UL = U | L;
-static constexpr auto DL = D | L;
-static constexpr auto DUL = D | U | L;
+static constexpr auto N     = detail::trace_directions::none;
+static constexpr auto D     = detail::trace_directions::diagonal;
+static constexpr auto u     = detail::trace_directions::up;
+static constexpr auto l     = detail::trace_directions::left;
+static constexpr auto U     = detail::trace_directions::up_open;
+static constexpr auto L     = detail::trace_directions::left_open;
+static constexpr auto DU    = D | U;
+static constexpr auto UL    = U | L;
+static constexpr auto DL    = D | L;
+static constexpr auto DUL   = D | U | L;
+static constexpr auto Du    = D | u;
+static constexpr auto Uu    = U | u;
+static constexpr auto uL    = u | L;
+static constexpr auto DuL   = D | u | L;
+static constexpr auto DUu   = D | U | u;
+static constexpr auto UuL   = U | u | L;
+static constexpr auto DUuL  = D | U | u | L;
+static constexpr auto Dl    = D | l;
+static constexpr auto Ul    = U | l;
+static constexpr auto DUl   = D | U | l;
+static constexpr auto Ll    = L | l;
+static constexpr auto DLl   = D | L | l;
+static constexpr auto ULl   = U | L | l;
+static constexpr auto DULl  = D | U | L | l;
+static constexpr auto ul    = u | l;
+static constexpr auto Dul   = D | u | l;
+static constexpr auto Uul   = U | u | l ;
+static constexpr auto DUul  = D | U | u | l;
+static constexpr auto uLl   = u | L | l;
+static constexpr auto DuLl  = D | u | L | l;
+static constexpr auto UuLl  = U | u | L | l;
+static constexpr auto DUuLl = D | U | u | L | l;
 
 template <typename sequence1_t, typename sequence2_t, typename config_t, typename score_t,
           typename score_vector_or_matrix_t, typename trace_vector_or_matrix_t>

--- a/test/unit/alignment/pairwise/fixture/global_affine_banded.hpp
+++ b/test/unit/alignment/pairwise/fixture/global_affine_banded.hpp
@@ -54,7 +54,35 @@ static auto dna4_01 = []()
         "A---ACCGGTTAACCGGTT",
         "ACGTAC----------GTA",
         alignment_coordinate{detail::column_index_type{0u}, detail::row_index_type{0u}},
-        alignment_coordinate{detail::column_index_type{16u}, detail::row_index_type{9u}}
+        alignment_coordinate{detail::column_index_type{16u}, detail::row_index_type{9u}},
+        std::vector<std::optional<int32_t>>
+        {
+        //       A  ,A  ,C  ,C  ,G  ,G  ,T  ,T  ,A  ,A  ,C  ,C  ,G  ,G  ,T  ,T  ,
+             0  ,-11,-12,-13,-14,-15,-16,-17,-18,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*A*/-11,4  ,-7 ,-8 ,-9 ,-10,-11,-12,-13,-14,INF,INF,INF,INF,INF,INF,INF,
+        /*C*/-12,-7 ,-1 ,-3 ,-4 ,-14,-15,-16,-17,-18,-19,INF,INF,INF,INF,INF,INF,
+        /*G*/-13,-8 ,-12,-6 ,-8 ,0  ,-10,-12,-13,-14,-15,-16,INF,INF,INF,INF,INF,
+        /*T*/INF,-9 ,-13,-15,-11,-11,-5 ,-6 ,-8 ,-18,-19,-20,-21,INF,INF,INF,INF,
+        /*A*/INF,INF,-5 ,-16,-17,-12,-16,-10,-11,-4 ,-14,-16,-17,-18,INF,INF,INF,
+        /*C*/INF,INF,INF,-1 ,-12,-13,-14,-15,-15,-15,-9 ,-10,-12,-21,-22,INF,INF,
+        /*G*/INF,INF,INF,INF,-6 ,-8 ,-9 ,-19,-20,-16,-20,-14,-15,-8 ,-17,-20,INF,
+        /*T*/INF,INF,INF,INF,INF,-11,-13,-5 ,-15,-17,-18,-19,-19,-19,-13,-13,-16,
+        /*A*/INF,INF,INF,INF,INF,INF,-16,-16,-10,-11,-13,-23,-24,-20,-24,-18,-18
+        },
+        std::vector<std::optional<trace_directions>>
+        {
+        //       A  ,A  ,C  ,C  ,G  ,G  ,T  ,T  ,A  ,A  ,C  ,C  ,G  ,G  ,T  ,T  ,
+             N  ,L  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*A*/U  ,DUL,DUL,l  ,l  ,l  ,l  ,l  ,l  ,D  ,INF,INF,INF,INF,INF,INF,INF,
+        /*C*/u  ,UL ,DUL,DUL,DUl,DUl,DUl,DUl,DUl,DUl,D  ,INF,INF,INF,INF,INF,INF,
+        /*G*/u  ,uL ,DUL,DUl,DUL,Dul,DuL,l  ,l  ,l  ,l  ,l  ,INF,INF,INF,INF,INF,
+        /*T*/INF,u  ,DuL,ul ,Dul,UL ,DUL,DUL,DUl,DUl,DUl,DUl,D  ,INF,INF,INF,INF,
+        /*A*/INF,INF,Du ,uL ,ul ,ul ,DUl,DUl,DUl,Dul,DuL,l  ,l  ,l  ,INF,INF,INF,
+        /*C*/INF,INF,INF,Du ,DuL,ul ,l  ,l  ,Dul,Ul ,DUl,DUl,DUl,l  ,l  ,INF,INF,
+        /*G*/INF,INF,INF,INF,Du ,DuL,Dul,Dul,Dul,ul ,DUl,DUl,DUl,Dul,DUL,l  ,INF,
+        /*T*/INF,INF,INF,INF,INF,Du ,DuL,Dul,DuL,ul ,l  ,l  ,Dul,Ul ,DUl,DUl,D  ,
+        /*A*/INF,INF,INF,INF,INF,INF,Du ,UL ,DuL,DuL,Dul,Dul,Dul,ul ,DUl,DUl,DUl
+        }
     };
 }();
 

--- a/test/unit/alignment/pairwise/fixture/global_affine_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/global_affine_unbanded.hpp
@@ -9,8 +9,8 @@
 
 #include <vector>
 
-#include <seqan3/alignment/configuration/align_config_mode.hpp>
 #include <seqan3/alignment/configuration/align_config_gap.hpp>
+#include <seqan3/alignment/configuration/align_config_mode.hpp>
 #include <seqan3/alignment/configuration/align_config_scoring.hpp>
 #include <seqan3/alignment/scoring/aminoacid_scoring_scheme.hpp>
 #include <seqan3/alignment/scoring/gap_scheme.hpp>
@@ -49,31 +49,31 @@ static auto dna4_01 = []()
         alignment_coordinate{column_index_type{16u}, row_index_type{9u}},
         std::vector
         {
-        //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
-        /*e*/  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16,
-        /*A*/  1,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,
-        /*C*/  2,  1,  1,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
-        /*G*/  3,  2,  2,  2,  2,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13,
-        /*T*/  4,  3,  3,  3,  3,  3,  3,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12,
-        /*A*/  5,  4,  3,  4,  4,  4,  4,  4,  4,  4,  5,  6,  7,  8,  9, 10, 11,
-        /*C*/  6,  5,  4,  3,  4,  5,  5,  5,  5,  5,  5,  5,  6,  7,  8,  9, 10,
-        /*G*/  7,  6,  5,  4,  4,  4,  5,  6,  6,  6,  6,  6,  6,  6,  7,  8,  9,
-        /*T*/  8,  7,  6,  5,  5,  5,  5,  5,  6,  7,  7,  7,  7,  7,  7,  7,  8,
-        /*A*/  9,  8,  7,  6,  6,  6,  6,  6,  6,  6,  7,  8,  8,  8,  8,  8,  8
+        //      e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
+        /*e*/  0 ,-11,-12,-13,-14,-15,-16,-17,-18,-19,-20,-21,-22,-23,-24,-25,-26,
+        /*A*/ -11,  4, -7, -8, -9,-10,-11,-12,-13,-14,-15,-16,-17,-18,-19,-20,-21,
+        /*C*/ -12, -7, -1, -3, -4,-14,-15,-16,-17,-18,-19,-11,-12,-22,-23,-24,-25,
+        /*G*/ -13, -8,-12, -6, -8,  0,-10,-12,-13,-14,-15,-16,-16,-8 ,-18,-20,-21,
+        /*T*/ -14, -9,-13,-15,-11,-11,-5 , -6, -8,-18,-19,-20,-21,-19,-13,-14,-16,
+        /*A*/ -15,-10,-5 ,-16,-17,-12,-16,-10,-11, -4,-14,-16,-17,-18,-19,-18,-19,
+        /*C*/ -16,-11,-15, -1,-12,-13,-14,-15,-15,-15, -9,-10,-12,-21,-22,-23,-23,
+        /*G*/ -17,-12,-16,-12, -6, -8, -9,-19,-20,-16,-20,-14,-15, -8,-17,-20,-21,
+        /*T*/ -18,-13,-17,-13,-17,-11,-13, -5,-15,-17,-18,-19,-19,-19,-13,-13,-16,
+        /*A*/ -19,-14,-9 ,-14,-18,-16,-16,-16,-10,-11,-13,-23,-24,-20,-24,-18,-18
         },
         std::vector
         {
-        //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
-        /*e*/NON,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,
-        /*A*/U  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
-        /*C*/U  ,U  ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,L  ,L  ,
-        /*G*/U  ,U  ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,
-        /*T*/U  ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,
-        /*A*/U  ,DU ,D  ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
-        /*C*/U  ,U  ,U  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,
-        /*G*/U  ,U  ,U  ,U  ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,
-        /*T*/U  ,U  ,U  ,U  ,DU ,DU ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,
-        /*A*/U  ,DU ,DU ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D
+        //      e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
+        /*e*/ N  ,L  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,
+        /*A*/ U  ,DUL,DUL,l  ,l  ,l  ,l  ,l  ,l  ,DUl,DUl,l  ,l  ,l  ,l  ,l  ,l  ,
+        /*C*/ u  ,UL ,DUL,DUL,DUl,DUl,DUl,DUl,DUl,DUl,DUl,DUl,DUl,DUl,DUl,DUl,DUl,
+        /*G*/ u  ,uL ,DUL,DUl,DUL,Dul,DuL,l  ,l  ,l  ,l  ,l  ,DUl,Dul,Dul,l  ,l  ,
+        /*T*/ u  ,uL ,DuL,ul ,Dul,UL ,DUL,DUL,DUl,DUl,DUl,Dul,Dul,Ul ,DUl,DUl,DUl,
+        /*A*/ u  ,DuL,DuL,uL ,ul ,ul ,DUl,DUl,DUl,Dul,DuL,l  ,l  ,l  ,l  ,DUl,DUl,
+        /*C*/ u  ,uL ,DuL,Dul,DuL,ul ,l  ,l  ,Dul,Ul ,DUl,Dul,Dul,ul ,l  ,l  ,Dul,
+        /*G*/ u  ,uL ,DuL,Ul ,DuL,DuL,Dul,Dul,Dul,ul ,DUl,DUl,DUl,Dul,DuL,l  ,l  ,
+        /*T*/ u  ,uL ,DuL,ul ,DUL,Dul,DuL,Dul,DuL,ul ,l  ,l  ,Dul,Ul ,Dul,Dul,Dul,
+        /*A*/ u  ,DuL,DuL,uL ,Dul,ul ,Dul,Ul ,Dul,DuL,Dul,Dul,Dul,ul ,DUl,DUl,DUl
         }
     };
 }();
@@ -92,31 +92,45 @@ static auto dna4_02 = []()
         alignment_coordinate{column_index_type{9u}, row_index_type{16u}},
         std::vector
         {
-        //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
-        /*e*/  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16,
-        /*A*/  1,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,
-        /*C*/  2,  1,  1,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
-        /*G*/  3,  2,  2,  2,  2,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13,
-        /*T*/  4,  3,  3,  3,  3,  3,  3,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12,
-        /*A*/  5,  4,  3,  4,  4,  4,  4,  4,  4,  4,  5,  6,  7,  8,  9, 10, 11,
-        /*C*/  6,  5,  4,  3,  4,  5,  5,  5,  5,  5,  5,  5,  6,  7,  8,  9, 10,
-        /*G*/  7,  6,  5,  4,  4,  4,  5,  6,  6,  6,  6,  6,  6,  6,  7,  8,  9,
-        /*T*/  8,  7,  6,  5,  5,  5,  5,  5,  6,  7,  7,  7,  7,  7,  7,  7,  8,
-        /*A*/  9,  8,  7,  6,  6,  6,  6,  6,  6,  6,  7,  8,  8,  8,  8,  8,  8
+        //      e,  A,  C,  G,  T,  A,  C,  G,  T,  A
+        /*e*/ 0  ,-11,-12,-13,-14,-15,-16,-17,-18,-19,
+        /*A*/ -11,  4, -7, -8, -9,-10,-11,-12,-13,-14,
+        /*A*/ -12, -7, -1,-12,-13, -5,-15,-16,-17, -9,
+        /*C*/ -13, -8, -3, -6,-15,-16, -1,-12,-13,-14,
+        /*C*/ -14, -9, -4, -8,-11,-17,-12, -6,-17,-18,
+        /*G*/ -15,-10,-14,  0,-11,-12,-13, -8,-11,-16,
+        /*G*/ -16,-11,-15,-10, -5,-16,-14, -9,-13,-16,
+        /*T*/ -17,-12,-16,-12, -6,-10,-15,-19, -5,-16,
+        /*T*/ -18,-13,-17,-13, -8,-11,-15,-20,-15,-10,
+        /*A*/ -19,-14,-18,-14,-18, -4,-15,-16,-17,-11,
+        /*A*/ -20,-15,-19,-15,-19,-14, -9,-20,-18,-13,
+        /*C*/ -21,-16,-11,-16,-20,-16,-10,-14,-19,-23,
+        /*C*/ -22,-17,-12,-16,-21,-17,-12,-15,-19,-24,
+        /*G*/ -23,-18,-22, -8,-19,-18,-21, -8,-19,-20,
+        /*G*/ -24,-19,-23,-18,-13,-19,-22,-17,-13,-24,
+        /*T*/ -25,-20,-24,-20,-14,-18,-23,-20,-13,-18,
+        /*T*/ -26,-21,-25,-21,-16,-19,-23,-21,-16,-18
         },
         std::vector
         {
-        //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
-        /*e*/NON,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,
-        /*A*/U  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
-        /*C*/U  ,U  ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,L  ,L  ,
-        /*G*/U  ,U  ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,
-        /*T*/U  ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,
-        /*A*/U  ,DU ,D  ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
-        /*C*/U  ,U  ,U  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,
-        /*G*/U  ,U  ,U  ,U  ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,
-        /*T*/U  ,U  ,U  ,U  ,DU ,DU ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,
-        /*A*/U  ,DU ,DU ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D
+        //	    e,  A,  C,  G,  T,  A,  C,  G,  T,  A
+        /*e*/ N  ,L  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,
+        /*A*/ U  ,DUL,L  ,l  ,l  ,DUl,l  ,l  ,l  ,DUl,
+        /*A*/ u  ,DUL,DUL,DUL,DUl,DUl,DUl,DUl,DUl,DUl,
+        /*C*/ u  ,uL ,DUL,DuL,l  ,Ul ,Dul,L  ,l  ,l  ,
+        /*C*/ u  ,uL ,DuL,DUL,Dul,ul ,DUl,DUl,DUL,Dul,
+        /*G*/ u  ,uL ,DuL,Dul,L  ,l  ,ul ,DUl,Dul,l  ,
+        /*G*/ u  ,uL ,DuL,DUl,DUL,DuL,ul ,Dul,DUl,Dul,
+        /*T*/ u  ,uL ,DuL,ul ,DUL,DuL,ul ,Dul,Dul,L  ,
+        /*T*/ u  ,uL ,DuL,ul ,DuL,DuL,Dul,Dul,DUl,Dul,
+        /*A*/ u  ,DuL,DuL,ul ,DuL,Dul,L  ,l  ,ul ,DUl,
+        /*A*/ u  ,DuL,DuL,ul ,DuL,DUl,DuL,DuL,ul ,Dul,
+        /*C*/ u  ,uL ,DuL,uL ,Dul,ul ,Dul,DuL,ul ,Dul,
+        /*C*/ u  ,uL ,DuL,DuL,Dul,ul ,Dul,DuL,Dul,Dul,
+        /*G*/ u  ,uL ,DuL,Dul,L  ,ul ,ul ,Dul,L  ,l  ,
+        /*G*/ u  ,uL ,DuL,Dul,DuL,uL ,ul ,DUl,Dul,DuL,
+        /*T*/ u  ,uL ,DuL,ul ,DuL,DuL,ul ,ul ,Dul,DuL,
+        /*T*/ u  ,uL ,DuL,ul ,DuL,DuL,Dul,ul ,Dul,DuL,
         }
     };
 }();

--- a/test/unit/alignment/pairwise/fixture/global_edit_distance_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/global_edit_distance_unbanded.hpp
@@ -54,17 +54,17 @@ static auto dna4_01 = []()
         },
         std::vector
         {
-        //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
-        /*e*/NON,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,
-        /*A*/U  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
-        /*C*/U  ,U  ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,L  ,L  ,
-        /*G*/U  ,U  ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,
-        /*T*/U  ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,
-        /*A*/U  ,DU ,D  ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
-        /*C*/U  ,U  ,U  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,
-        /*G*/U  ,U  ,U  ,U  ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,
-        /*T*/U  ,U  ,U  ,U  ,DU ,DU ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,
-        /*A*/U  ,DU ,DU ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D
+        //      e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
+        /*e*/ N  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,
+        /*A*/ u  ,D  ,Dl ,l  ,l  ,l  ,l  ,l  ,l  ,Dl ,Dl ,l  ,l  ,l  ,l  ,l  ,l  ,
+        /*C*/ u  ,u  ,D  ,D  ,Dl ,l  ,l  ,l  ,l  ,l  ,l  ,Dl ,Dl ,l  ,l  ,l  ,l  ,
+        /*G*/ u  ,u  ,Du ,Du ,D  ,D  ,Dl ,l  ,l  ,l  ,l  ,l  ,l  ,Dl ,Dl ,l  ,l  ,
+        /*T*/ u  ,u  ,Du ,Du ,Du ,Du ,D  ,D  ,Dl ,l  ,l  ,l  ,l  ,l  ,l  ,Dl ,Dl ,
+        /*A*/ u  ,Du ,D  ,Dul,Du ,Du ,Du ,Du ,D  ,D  ,Dl ,l  ,l  ,l  ,l  ,l  ,l  ,
+        /*C*/ u  ,u  ,u  ,D  ,Dl ,Dul,Du ,Du ,Du ,Du ,D  ,D  ,Dl ,l  ,l  ,l  ,l  ,
+        /*G*/ u  ,u  ,u  ,u  ,D  ,D  ,Dl ,Dul,Du ,Du ,Du ,Du ,D  ,D  ,Dl ,l  ,l  ,
+        /*T*/ u  ,u  ,u  ,u  ,Du ,Du ,D  ,D  ,Dl ,Dul,Du ,Du ,Du ,Du ,D  ,D  ,Dl ,
+        /*A*/ u  ,Du ,Du ,u  ,Du ,Du ,Du ,Du ,D  ,D  ,Dl ,Dul,Du ,Du ,Du ,Du ,D
         }
     };
 }();
@@ -124,17 +124,17 @@ static auto dna4_02 = []()
         },
         std::vector
         {
-        //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
-        /*e*/NON,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,
-        /*A*/U  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
-        /*C*/U  ,U  ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,L  ,L  ,
-        /*G*/U  ,U  ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,
-        /*T*/U  ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,
-        /*A*/U  ,DU ,D  ,DUL,DU ,DU ,DU ,DU ,D  ,DL ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
-        /*C*/U  ,U  ,U  ,D  ,DL ,DUL,DU ,DU ,U  ,D  ,DL ,D  ,DL ,L  ,L  ,L  ,L  ,
-        /*G*/U  ,U  ,U  ,U  ,D  ,D  ,DL ,DUL,U  ,DU ,D  ,DUL,D  ,D  ,DL ,L  ,L  ,
-        /*T*/U  ,U  ,U  ,U  ,DU ,DU ,D  ,D  ,UL ,DU ,DU ,D  ,DUL,DU ,D  ,D  ,DL ,
-        /*A*/U  ,DU ,DU ,U  ,DU ,DU ,DU ,DU ,D  ,DL ,D  ,DUL,D  ,DUL,DU ,DU ,D
+        //      e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
+        /*e*/ N  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,
+        /*A*/ u  ,D  ,Dl ,l  ,l  ,l  ,l  ,l  ,Dl ,Dl ,Dl ,l  ,l  ,l  ,l  ,l  ,l  ,
+        /*C*/ u  ,u  ,D  ,D  ,Dl ,l  ,l  ,l  ,l  ,l  ,l  ,Dl ,Dl ,l  ,l  ,l  ,l  ,
+        /*G*/ u  ,u  ,Du ,Du ,D  ,D  ,Dl ,l  ,l  ,l  ,l  ,l  ,l  ,Dl ,Dl ,l  ,l  ,
+        /*T*/ u  ,u  ,Du ,Du ,Du ,Du ,D  ,D  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,Dl ,Dl ,
+        /*A*/ u  ,Du ,D  ,Dul,Du ,Du ,Du ,Du ,D  ,Dl ,Dl ,l  ,l  ,l  ,l  ,l  ,l  ,
+        /*C*/ u  ,u  ,u  ,D  ,Dl ,Dul,Du ,Du ,u  ,D  ,Dl ,D  ,Dl ,l  ,l  ,l  ,l  ,
+        /*G*/ u  ,u  ,u  ,u  ,D  ,D  ,Dl ,Dul,u  ,Du ,D  ,Dul,D  ,D  ,Dl ,l  ,l  ,
+        /*T*/ u  ,u  ,u  ,u  ,Du ,Du ,D  ,D  ,ul ,Du ,Du ,D  ,Dul,Du ,D  ,D  ,Dl ,
+        /*A*/ u  ,Du ,Du ,u  ,Du ,Du ,Du ,Du ,D  ,Dl ,D  ,Dul,D  ,Dul,Du ,Du ,D
         }
     };
 }();
@@ -241,7 +241,7 @@ static auto dna4_03 = []()
         alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
         alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
         std::vector<int>{0},
-        std::vector<detail::trace_directions>{NON}
+        std::vector<detail::trace_directions>{N}
     };
 }();
 
@@ -278,17 +278,17 @@ static auto aa27_01 = []()
         },
         std::vector
         {
-        //     e,  U,  U,  W,  W,  R,  R,  I,  I,  U,  U,  W,  W,  R,  R,  I,  I
-        /*e*/NON,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,
-        /*U*/U  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
-        /*W*/U  ,U  ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,L  ,L  ,
-        /*R*/U  ,U  ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,
-        /*I*/U  ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,
-        /*U*/U  ,DU ,D  ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
-        /*W*/U  ,U  ,U  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,
-        /*R*/U  ,U  ,U  ,U  ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,
-        /*I*/U  ,U  ,U  ,U  ,DU ,DU ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,
-        /*U*/U  ,DU ,DU ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D
+        //      e,  U,  U,  W,  W,  R,  R,  I,  I,  U,  U,  W,  W,  R,  R,  I,  I
+        /*e*/ N  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,
+        /*u*/ u  ,D  ,Dl ,l  ,l  ,l  ,l  ,l  ,l  ,Dl ,Dl ,l  ,l  ,l  ,l  ,l  ,l  ,
+        /*W*/ u  ,u  ,D  ,D  ,Dl ,l  ,l  ,l  ,l  ,l  ,l  ,Dl ,Dl ,l  ,l  ,l  ,l  ,
+        /*R*/ u  ,u  ,Du ,Du ,D  ,D  ,Dl ,l  ,l  ,l  ,l  ,l  ,l  ,Dl ,Dl ,l  ,l  ,
+        /*I*/ u  ,u  ,Du ,Du ,Du ,Du ,D  ,D  ,Dl ,l  ,l  ,l  ,l  ,l  ,l  ,Dl ,Dl ,
+        /*u*/ u  ,Du ,D  ,Dul,Du ,Du ,Du ,Du ,D  ,D  ,Dl ,l  ,l  ,l  ,l  ,l  ,l  ,
+        /*W*/ u  ,u  ,u  ,D  ,Dl ,Dul,Du ,Du ,Du ,Du ,D  ,D  ,Dl ,l  ,l  ,l  ,l  ,
+        /*R*/ u  ,u  ,u  ,u  ,D  ,D  ,Dl ,Dul,Du ,Du ,Du ,Du ,D  ,D  ,Dl ,l  ,l  ,
+        /*I*/ u  ,u  ,u  ,u  ,Du ,Du ,D  ,D  ,Dl ,Dul,Du ,Du ,Du ,Du ,D  ,D  ,Dl ,
+        /*u*/ u  ,Du ,Du ,u  ,Du ,Du ,Du ,Du ,D  ,D  ,Dl ,Dul,Du ,Du ,Du ,Du ,D
         }
     };
 }();

--- a/test/unit/alignment/pairwise/fixture/local_affine_banded.hpp
+++ b/test/unit/alignment/pairwise/fixture/local_affine_banded.hpp
@@ -10,8 +10,8 @@
 #include <vector>
 
 #include <seqan3/alignment/configuration/align_config_band.hpp>
-#include <seqan3/alignment/configuration/align_config_mode.hpp>
 #include <seqan3/alignment/configuration/align_config_gap.hpp>
+#include <seqan3/alignment/configuration/align_config_mode.hpp>
 #include <seqan3/alignment/configuration/align_config_scoring.hpp>
 #include <seqan3/alignment/scoring/aminoacid_scoring_scheme.hpp>
 #include <seqan3/alignment/scoring/nucleotide_scoring_scheme.hpp>
@@ -49,7 +49,39 @@ static auto dna4_01 = []()
         "GTTTA",
         "GTCTA",
         alignment_coordinate{column_index_type{5u}, row_index_type{2u}},
-        alignment_coordinate{column_index_type{10u}, row_index_type{7u}}
+        alignment_coordinate{column_index_type{10u}, row_index_type{7u}},
+        std::vector<std::optional<int32_t>>
+        {
+        //      e,  A,  A,  C,  C,  G,  G,  T,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
+        /*e*/ 0  ,0  ,0  ,0  ,0  ,0  ,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*A*/ 0  ,4  ,4  ,0  ,0  ,0  ,0  ,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*C*/ 0  ,0  ,0  ,8  ,4  ,0  ,0  ,0  ,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*G*/ INF,0  ,0  ,0  ,3  ,8  ,4  ,0  ,0  ,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*T*/ INF,INF,0  ,0  ,0  ,0  ,3  ,8  ,4  ,4  ,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*C*/ INF,INF,INF,4  ,4  ,0  ,0  ,0  ,3  ,0  ,0  ,INF,INF,INF,INF,INF,INF,INF,
+        /*T*/ INF,INF,INF,INF,0  ,0  ,0  ,4  ,4  ,7  ,0  ,0  ,INF,INF,INF,INF,INF,INF,
+        /*A*/ INF,INF,INF,INF,INF,0  ,0  ,0  ,0  ,0  ,11 ,4  ,0  ,INF,INF,INF,INF,INF,
+        /*C*/ INF,INF,INF,INF,INF,INF,0  ,0  ,0  ,0  ,0  ,6  ,8  ,4  ,INF,INF,INF,INF,
+        /*G*/ INF,INF,INF,INF,INF,INF,INF,0  ,0  ,0  ,0  ,0  ,1  ,3  ,8  ,INF,INF,INF,
+        /*T*/ INF,INF,INF,INF,INF,INF,INF,INF,4  ,4  ,0  ,0  ,0  ,0  ,0  ,3  ,INF,INF,
+        /*A*/ INF,INF,INF,INF,INF,INF,INF,INF,INF,0  ,8  ,4  ,0  ,0  ,0  ,0  ,0  ,INF
+        },
+        std::vector<std::optional<detail::trace_directions>>
+        {
+        //      e,  A,  A,  C,  C,  G,  G,  T,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
+        /*e*/ N  ,N  ,N  ,N  ,N  ,N  ,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*A*/ N  ,DUL,DUL,N  ,N  ,N  ,N  ,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*C*/ N  ,N  ,N  ,DUL,DUL,N  ,N  ,N  ,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*G*/ INF,N  ,N  ,N  ,DUL,DUL,DUL,N  ,N  ,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*T*/ INF,INF,N  ,N  ,N  ,N  ,DUL,DUL,DUL,D  ,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*C*/ INF,INF,INF,Du ,DuL,N  ,N  ,N  ,DUl,N  ,N  ,INF,INF,INF,INF,INF,INF,INF,
+        /*T*/ INF,INF,INF,INF,N  ,N  ,N  ,DuL,DuL,DuL,N  ,N  ,INF,INF,INF,INF,INF,INF,
+        /*A*/ INF,INF,INF,INF,INF,N  ,N  ,N  ,N  ,N  ,DUL,DUL,N  ,INF,INF,INF,INF,INF,
+        /*C*/ INF,INF,INF,INF,INF,INF,N  ,N  ,N  ,N  ,UL ,DUL,DUL,D  ,INF,INF,INF,INF,
+        /*G*/ INF,INF,INF,INF,INF,INF,INF,N  ,N  ,N  ,N  ,N  ,DUL,DUL,D  ,INF,INF,INF,
+        /*T*/ INF,INF,INF,INF,INF,INF,INF,INF,Du ,DuL,N  ,N  ,N  ,N  ,N  ,D  ,INF,INF,
+        /*A*/ INF,INF,INF,INF,INF,INF,INF,INF,INF,N  ,DuL,DuL,N  ,N  ,N  ,N  ,N  ,INF
+        }
     };
 }();
 
@@ -70,7 +102,51 @@ static auto dna4_02 = []()
         "AC",
         "AC",
         alignment_coordinate{column_index_type{0u}, row_index_type{1u}},
-        alignment_coordinate{column_index_type{2u}, row_index_type{3u}}
+        alignment_coordinate{column_index_type{2u}, row_index_type{3u}},
+        std::vector<std::optional<int32_t>>
+        {
+        //      e,  A,  C,  G,  T,  C,  T,  A,  C,  G,  T,  A
+        /*e*/ 0  ,0  ,0  ,0  ,0  ,0  ,INF,INF,INF,INF,INF,INF,
+        /*A*/ 0  ,4  ,0  ,0  ,0  ,0  ,0  ,INF,INF,INF,INF,INF,
+        /*A*/ 0  ,4  ,0  ,0  ,0  ,0  ,0  ,4  ,INF,INF,INF,INF,
+        /*C*/ INF,0  ,8  ,0  ,0  ,4  ,0  ,0  ,8  ,INF,INF,INF,
+        /*C*/ INF,INF,4  ,3  ,0  ,4  ,0  ,0  ,4  ,3  ,INF,INF,
+        /*G*/ INF,INF,INF,8  ,0  ,0  ,0  ,0  ,0  ,8  ,0  ,INF,
+        /*G*/ INF,INF,INF,INF,3  ,0  ,0  ,0  ,0  ,4  ,3  ,0  ,
+        /*T*/ INF,INF,INF,INF,INF,0  ,4  ,0  ,0  ,0  ,8  ,0  ,
+        /*T*/ INF,INF,INF,INF,INF,INF,4  ,0  ,0  ,0  ,4  ,3  ,
+        /*T*/ INF,INF,INF,INF,INF,INF,INF,0  ,0  ,0  ,4  ,0  ,
+        /*A*/ INF,INF,INF,INF,INF,INF,INF,INF,0  ,0  ,0  ,8  ,
+        /*A*/ INF,INF,INF,INF,INF,INF,INF,INF,INF,0  ,0  ,4  ,
+        /*C*/ INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,0  ,0  ,
+        /*C*/ INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,0  ,
+        /*G*/ INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*G*/ INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*T*/ INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*T*/ INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF
+        },
+        std::vector<std::optional<detail::trace_directions>>
+        {
+        //      e,  A,  C,  G,  T,  C,  T,  A,  C,  G,  T,  A
+        /*e*/ N  ,N  ,N  ,N  ,N  ,N  ,INF,INF,INF,INF,INF,INF,
+        /*A*/ N  ,DUL,N  ,N  ,N  ,N  ,N  ,INF,INF,INF,INF,INF,
+        /*A*/ N  ,DUL,N  ,N  ,N  ,N  ,N  ,D  ,INF,INF,INF,INF,
+        /*C*/ INF,N  ,DUL,N  ,N  ,DUl,N  ,N  ,D  ,INF,INF,INF,
+        /*C*/ INF,INF,DU ,DUL,N  ,DUl,N  ,N  ,DUl,D  ,INF,INF,
+        /*G*/ INF,INF,INF,DU ,N  ,N  ,N  ,N  ,N  ,DUl,N  ,INF,
+        /*G*/ INF,INF,INF,INF,DU ,N  ,N  ,N  ,N  ,DUL,DUL,N  ,
+        /*T*/ INF,INF,INF,INF,INF,N  ,DUL,N  ,N  ,N  ,DUl,N  ,
+        /*T*/ INF,INF,INF,INF,INF,INF,DU ,N  ,N  ,N  ,DUl,DUL,
+        /*T*/ INF,INF,INF,INF,INF,INF,INF,N  ,N  ,N  ,DuL,N  ,
+        /*A*/ INF,INF,INF,INF,INF,INF,INF,INF,N  ,N  ,N  ,DuL,
+        /*A*/ INF,INF,INF,INF,INF,INF,INF,INF,INF,N  ,N  ,DUL,
+        /*C*/ INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,N  ,N  ,
+        /*C*/ INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,N  ,
+        /*G*/ INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*G*/ INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*T*/ INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*T*/ INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF
+        }
     };
 }();
 
@@ -92,7 +168,39 @@ static auto dna4_03 = []()
         "TAAGCGT",
         "TCAGAGT",
         alignment_coordinate{column_index_type{1u}, row_index_type{1u}},
-        alignment_coordinate{column_index_type{8u}, row_index_type{8u}}
+        alignment_coordinate{column_index_type{8u}, row_index_type{8u}},
+        std::vector<std::optional<int32_t>>
+        {
+        //      e,  A,  T,  A,  A,  G,  C,  G,  T,  C,  T,  C,  G
+        /*e*/ 0  ,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*C*/ INF,0  ,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*T*/ INF,INF,2  ,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*C*/ INF,INF,INF,1  ,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*A*/ INF,INF,INF,INF,3  ,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*G*/ INF,INF,INF,INF,INF,5  ,INF,INF,INF,INF,INF,INF,INF,
+        /*A*/ INF,INF,INF,INF,INF,INF,4  ,INF,INF,INF,INF,INF,INF,
+        /*G*/ INF,INF,INF,INF,INF,INF,INF,6  ,INF,INF,INF,INF,INF,
+        /*T*/ INF,INF,INF,INF,INF,INF,INF,INF,8  ,INF,INF,INF,INF,
+        /*T*/ INF,INF,INF,INF,INF,INF,INF,INF,INF,7  ,INF,INF,INF,
+        /*G*/ INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,6  ,INF,INF,
+        /*C*/ INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,8  ,INF
+        },
+        std::vector<std::optional<detail::trace_directions>>
+        {
+        //      e,  A,  T,  A,  A,  G,  C,  G,  T,  C,  T,  C,  G
+        /*e*/ N  ,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*C*/ INF,N  ,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*T*/ INF,INF,D  ,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*C*/ INF,INF,INF,D  ,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*A*/ INF,INF,INF,INF,D  ,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*G*/ INF,INF,INF,INF,INF,D  ,INF,INF,INF,INF,INF,INF,INF,
+        /*A*/ INF,INF,INF,INF,INF,INF,D  ,INF,INF,INF,INF,INF,INF,
+        /*G*/ INF,INF,INF,INF,INF,INF,INF,D  ,INF,INF,INF,INF,INF,
+        /*T*/ INF,INF,INF,INF,INF,INF,INF,INF,D  ,INF,INF,INF,INF,
+        /*T*/ INF,INF,INF,INF,INF,INF,INF,INF,INF,D  ,INF,INF,INF,
+        /*G*/ INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,D  ,INF,INF,
+        /*C*/ INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,D  ,INF
+        }
     };
 }();
 
@@ -113,7 +221,29 @@ static auto dna4_04 = []()
         "",
         "",
         alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
-        alignment_coordinate{column_index_type{0u}, row_index_type{0u}}
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        std::vector<std::optional<int32_t>>
+        {
+        //      e,  A,  A,  A,  A,  A,  A
+        /*e*/ 0  ,0  ,0  ,INF,INF,INF,INF,
+        /*C*/ 0  ,0  ,0  ,0  ,INF,INF,INF,
+        /*C*/ 0  ,0  ,0  ,0  ,0  ,INF,INF,
+        /*C*/ INF,0  ,0  ,0  ,0  ,0  ,INF,
+        /*C*/ INF,INF,0  ,0  ,0  ,0  ,0  ,
+        /*C*/ INF,INF,INF,0  ,0  ,0  ,0  ,
+        /*C*/ INF,INF,INF,INF,0  ,0  ,0
+        },
+        std::vector<std::optional<detail::trace_directions>>
+        {
+        //      e,  A,  A,  A,  A,  A,  A
+        /*e*/ N  ,N  ,N  ,INF,INF,INF,INF,
+        /*C*/ N  ,N  ,N  ,N  ,INF,INF,INF,
+        /*C*/ N  ,N  ,N  ,N  ,N  ,INF,INF,
+        /*C*/ INF,N  ,N  ,N  ,N  ,N  ,INF,
+        /*C*/ INF,INF,N  ,N  ,N  ,N  ,N  ,
+        /*C*/ INF,INF,INF,N  ,N  ,N  ,N  ,
+        /*C*/ INF,INF,INF,INF,N  ,N  ,N
+        }
     };
 }();
 
@@ -134,7 +264,43 @@ static auto dna4_05 = []()
         "AAAAAA",
         "AAAAAA",
         alignment_coordinate{column_index_type{0u}, row_index_type{7u}},
-        alignment_coordinate{column_index_type{6u}, row_index_type{13u}}
+        alignment_coordinate{column_index_type{6u}, row_index_type{13u}},
+        std::vector<std::optional<int32_t>>
+        {
+        //      e,  A,  A,  A,  A,  A,  A,  T,  C,  C,  C,  C,  C,  C
+        /*e*/ 0  ,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*C*/ 0  ,0  ,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*C*/ 0  ,0  ,0  ,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*C*/ 0  ,0  ,0  ,0  ,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*C*/ 0  ,0  ,0  ,0  ,0  ,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*C*/ 0  ,0  ,0  ,0  ,0  ,0  ,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*C*/ 0  ,0  ,0  ,0  ,0  ,0  ,0  ,INF,INF,INF,INF,INF,INF,INF,
+        /*T*/ 0  ,0  ,0  ,0  ,0  ,0  ,0  ,4  ,INF,INF,INF,INF,INF,INF,
+        /*A*/ 0  ,4  ,4  ,4  ,4  ,4  ,4  ,0  ,0  ,INF,INF,INF,INF,INF,
+        /*A*/ 0  ,4  ,8  ,8  ,8  ,8  ,8  ,0  ,0  ,0  ,INF,INF,INF,INF,
+        /*A*/ 0  ,4  ,8  ,12 ,12 ,12 ,12 ,3  ,0  ,0  ,0  ,INF,INF,INF,
+        /*A*/ 0  ,4  ,8  ,12 ,16 ,16 ,16 ,7  ,4  ,3  ,2  ,1  ,INF,INF,
+        /*A*/ 0  ,4  ,8  ,12 ,16 ,20 ,20 ,11 ,8  ,7  ,6  ,5  ,4  ,INF,
+        /*A*/ 0  ,4  ,8  ,12 ,16 ,20 ,24 ,15 ,12 ,11 ,10 ,9  ,8  ,7
+        },
+        std::vector<std::optional<detail::trace_directions>>
+        {
+        //      e,  A,  A,  A,  A,  A,  A,  T,  C,  C,  C,  C,  C,  C
+        /*e*/ N  ,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*C*/ N  ,N  ,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*C*/ N  ,N  ,N  ,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*C*/ N  ,N  ,N  ,N  ,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*C*/ N  ,N  ,N  ,N  ,N  ,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*C*/ N  ,N  ,N  ,N  ,N  ,N  ,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*C*/ N  ,N  ,N  ,N  ,N  ,N  ,N  ,INF,INF,INF,INF,INF,INF,INF,
+        /*T*/ N  ,N  ,N  ,N  ,N  ,N  ,N  ,D  ,INF,INF,INF,INF,INF,INF,
+        /*A*/ N  ,DUL,DUL,DUL,DUL,DUL,DUL,N  ,N  ,INF,INF,INF,INF,INF,
+        /*A*/ N  ,DUL,DUL,DUL,DUL,DUL,DUL,N  ,N  ,N  ,INF,INF,INF,INF,
+        /*A*/ N  ,DUL,DUL,DUL,DUL,DUL,DUL,DuL,l  ,N  ,N  ,INF,INF,INF,
+        /*A*/ N  ,DUL,DUL,DUL,DUL,DUL,DUL,DUL,l  ,l  ,l  ,l  ,INF,INF,
+        /*A*/ N  ,DUL,DUL,DUL,DUL,DUL,DUL,DUL,l  ,l  ,l  ,l  ,l  ,INF,
+        /*A*/ N  ,DUL,DUL,DUL,DUL,DUL,DUL,DUL,l  ,l  ,l  ,l  ,l  ,l
+        }
     };
 }();
 
@@ -156,7 +322,43 @@ static auto dna4_06 = []()
         "CCCCCC",
         "CCCCCC",
         alignment_coordinate{column_index_type{7u}, row_index_type{0u}},
-        alignment_coordinate{column_index_type{13u}, row_index_type{6u}}
+        alignment_coordinate{column_index_type{13u}, row_index_type{6u}},
+        std::vector<std::optional<int32_t>>
+        {
+        //      e,  A,  A,  A,  A,  A,  A,  T,  C,  C,  C,  C,  C,  C
+        /*e*/ 0  ,0  ,0  ,0  ,0  ,0  ,0  ,0  ,0  ,0  ,0  ,0  ,0  ,0  ,
+        /*C*/ INF,0  ,0  ,0  ,0  ,0  ,0  ,0  ,4  ,4  ,4  ,4  ,4  ,4  ,
+        /*C*/ INF,INF,0  ,0  ,0  ,0  ,0  ,0  ,4  ,8  ,8  ,8  ,8  ,8  ,
+        /*C*/ INF,INF,INF,0  ,0  ,0  ,0  ,0  ,4  ,8  ,12 ,12 ,12 ,12 ,
+        /*C*/ INF,INF,INF,INF,0  ,0  ,0  ,0  ,4  ,8  ,12 ,16 ,16 ,16 ,
+        /*C*/ INF,INF,INF,INF,INF,0  ,0  ,0  ,4  ,8  ,12 ,16 ,20 ,20 ,
+        /*C*/ INF,INF,INF,INF,INF,INF,0  ,0  ,4  ,8  ,12 ,16 ,20 ,24 ,
+        /*T*/ INF,INF,INF,INF,INF,INF,INF,4  ,0  ,0  ,3  ,7  ,11 ,15 ,
+        /*A*/ INF,INF,INF,INF,INF,INF,INF,INF,0  ,0  ,0  ,4  ,8  ,12 ,
+        /*A*/ INF,INF,INF,INF,INF,INF,INF,INF,INF,0  ,0  ,3  ,7  ,11 ,
+        /*A*/ INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,0  ,2  ,6  ,10 ,
+        /*A*/ INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,1  ,5  ,9  ,
+        /*A*/ INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,4  ,8  ,
+        /*A*/ INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,7
+        },
+        std::vector<std::optional<detail::trace_directions>>
+        {
+        //      e,  A,  A,  A,  A,  A,  A,  T,  C,  C,  C,  C,  C,  C
+        /*e*/ N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,
+        /*C*/ INF,N  ,N  ,N  ,N  ,N  ,N  ,N  ,DUL,DUL,DUL,DUL,DUL,DUL,
+        /*C*/ INF,INF,N  ,N  ,N  ,N  ,N  ,N  ,DUL,DUL,DUL,DUL,DUL,DUL,
+        /*C*/ INF,INF,INF,N  ,N  ,N  ,N  ,N  ,DUL,DUL,DUL,DUL,DUL,DUL,
+        /*C*/ INF,INF,INF,INF,N  ,N  ,N  ,N  ,DUL,DUL,DUL,DUL,DUL,DUL,
+        /*C*/ INF,INF,INF,INF,INF,N  ,N  ,N  ,DUL,DUL,DUL,DUL,DUL,DUL,
+        /*C*/ INF,INF,INF,INF,INF,INF,N  ,N  ,DUL,DUL,DUL,DUL,DUL,DUL,
+        /*T*/ INF,INF,INF,INF,INF,INF,INF,DU ,N  ,N  ,DUl,DUL,DUL,DUL,
+        /*A*/ INF,INF,INF,INF,INF,INF,INF,INF,N  ,N  ,uL ,uL ,uL ,uL ,
+        /*A*/ INF,INF,INF,INF,INF,INF,INF,INF,INF,N  ,N  ,uL ,uL ,uL ,
+        /*A*/ INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,N  ,uL ,uL ,uL ,
+        /*A*/ INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,u  ,uL ,uL ,
+        /*A*/ INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,u  ,uL ,
+        /*A*/ INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,u
+        }
     };
 }();
 
@@ -177,7 +379,41 @@ static auto rna5_01 = []()
         "AAAAAAUUUUNNUUUUCCCCCC",
         "AAAAAA----------CCCCCC",
         alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
-        alignment_coordinate{column_index_type{22u}, row_index_type{12u}}
+        alignment_coordinate{column_index_type{22u}, row_index_type{12u}},
+        std::vector<std::optional<int32_t>>
+        {
+        //      e,  A,  A,  A,  A,  A,  A,  U,  U,  U,  U,  N,  N,  U,  U,  U,  U,  C,  C,  C,  C,  C,  C
+        /*e*/ 0  ,0  ,0  ,0  ,0  ,0  ,0  ,0  ,0  ,0  ,0  ,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*A*/ 0  ,4  ,4  ,4  ,4  ,4  ,4  ,0  ,0  ,0  ,0  ,0  ,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*A*/ 0  ,4  ,8  ,8  ,8  ,8  ,8  ,0  ,0  ,0  ,0  ,0  ,0  ,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*A*/ 0  ,4  ,8  ,12 ,12 ,12 ,12 ,3  ,0  ,0  ,0  ,0  ,0  ,0  ,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*A*/ 0  ,4  ,8  ,12 ,16 ,16 ,16 ,7  ,4  ,3  ,2  ,1  ,0  ,0  ,0  ,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*A*/ 0  ,4  ,8  ,12 ,16 ,20 ,20 ,11 ,8  ,7  ,6  ,5  ,4  ,3  ,2  ,1  ,INF,INF,INF,INF,INF,INF,INF,
+        /*A*/ 0  ,4  ,8  ,12 ,16 ,20 ,24 ,15 ,12 ,11 ,10 ,9  ,8  ,7  ,6  ,5  ,4  ,INF,INF,INF,INF,INF,INF,
+        /*C*/ 0  ,0  ,0  ,3  ,7  ,11 ,15 ,19 ,10 ,7  ,6  ,5  ,4  ,3  ,2  ,1  ,0  ,8  ,INF,INF,INF,INF,INF,
+        /*C*/ 0  ,0  ,0  ,0  ,4  ,8  ,12 ,10 ,14 ,5  ,2  ,1  ,0  ,0  ,0  ,0  ,0  ,4  ,12 ,INF,INF,INF,INF,
+        /*C*/ 0  ,0  ,0  ,0  ,3  ,7  ,11 ,7  ,5  ,9  ,0  ,0  ,0  ,0  ,0  ,0  ,0  ,4  ,8  ,16 ,INF,INF,INF,
+        /*C*/ 0  ,0  ,0  ,0  ,2  ,6  ,10 ,6  ,2  ,0  ,4  ,0  ,0  ,0  ,0  ,0  ,0  ,4  ,8  ,12 ,20 ,INF,INF,
+        /*C*/ INF,0  ,0  ,0  ,1  ,5  ,9  ,5  ,1  ,0  ,0  ,0  ,0  ,0  ,0  ,0  ,0  ,4  ,8  ,12 ,16 ,24 ,INF,
+        /*C*/ INF,INF,0  ,0  ,0  ,4  ,8  ,4  ,0  ,0  ,0  ,0  ,0  ,0  ,0  ,0  ,0  ,4  ,8  ,12 ,16 ,20 ,28
+        },
+        std::vector<std::optional<detail::trace_directions>>
+        {
+        //      e,  A,  A,  A,  A,  A,  A,  U,  U,  U,  U,  N,  N,  U,  U,  U,  U,  C,  C,  C,  C,  C,  C
+        /*e*/ N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*A*/ N  ,DUL,DUL,DUL,DUL,DUL,DUL,N  ,N  ,N  ,N  ,N  ,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*A*/ N  ,DUL,DUL,DUL,DUL,DUL,DUL,N  ,N  ,N  ,N  ,N  ,N  ,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*A*/ N  ,DUL,DUL,DUL,DUL,DUL,DUL,DUL,l  ,N  ,N  ,N  ,N  ,N  ,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*A*/ N  ,DUL,DUL,DUL,DUL,DUL,DUL,DUL,l  ,l  ,l  ,l  ,l  ,N  ,N  ,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*A*/ N  ,DUL,DUL,DUL,DUL,DUL,DUL,DUL,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,INF,INF,INF,INF,INF,INF,INF,
+        /*A*/ N  ,DUL,DUL,DUL,DUL,DUL,DUL,DUL,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,INF,INF,INF,INF,INF,INF,
+        /*C*/ N  ,N  ,N  ,DUL,DUL,DUL,DUL,DUL,DUL,DUl,DUl,DUl,DUl,DUl,DUl,DUl,DUl,D  ,INF,INF,INF,INF,INF,
+        /*C*/ N  ,N  ,N  ,uL ,uL ,uL ,uL ,DUL,Dul,DuL,Dul,Dul,Dul,N  ,N  ,N  ,N  ,DUl,D  ,INF,INF,INF,INF,
+        /*C*/ N  ,N  ,N  ,N  ,uL ,uL ,uL ,DuL,DUl,Dul,DuL,N  ,N  ,N  ,N  ,N  ,N  ,Dul,DUL,D  ,INF,INF,INF,
+        /*C*/ N  ,N  ,N  ,N  ,uL ,uL ,uL ,DuL,Dul,DUl,Dul,N  ,N  ,N  ,N  ,N  ,N  ,Dul,DuL,DUL,D  ,INF,INF,
+        /*C*/ INF,N  ,N  ,N  ,uL ,uL ,uL ,DuL,Dul,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,DuL,DuL,DuL,DUL,D  ,INF,
+        /*C*/ INF,INF,N  ,N  ,uL ,uL ,uL ,DuL,Dul,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,DuL,DuL,DuL,DuL,DUL,D
+        }
     };
 }();
 
@@ -198,7 +434,29 @@ static auto aa27_01 = []()
         "GATOR",
         "GALOR",
         alignment_coordinate{column_index_type{3u}, row_index_type{0u}},
-        alignment_coordinate{column_index_type{8u}, row_index_type{5u}}
+        alignment_coordinate{column_index_type{8u}, row_index_type{5u}},
+        std::vector
+        {
+        //     e, A, L, I, G, A, T, O, R
+        /*e*/ 0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,
+        /*G*/ 0 ,0 ,0 ,0 ,6 ,0 ,0 ,0 ,0 ,
+        /*A*/ 0 ,4 ,0 ,0 ,0 ,10,0 ,0 ,0 ,
+        /*L*/ 0 ,0 ,8 ,2 ,0 ,0 ,9 ,0 ,0 ,
+        /*O*/ 0 ,0 ,0 ,7 ,1 ,0 ,0 ,8 ,0 ,
+        /*R*/ 0 ,0 ,0 ,0 ,5 ,0 ,0 ,0 ,13,
+        /*A*/ 0 ,4 ,0 ,0 ,0 ,9 ,0 ,0 ,2
+        },
+        std::vector
+        {
+        //      e,  A,  L,  I,  G,  A,  T,  O,  R
+        /*e*/ N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,
+        /*G*/ N  ,DUL,N  ,N  ,DUL,DUL,N  ,N  ,N  ,
+        /*A*/ N  ,DUL,N  ,N  ,DUl,DUl,DUL,DUl,N  ,
+        /*L*/ N  ,N  ,DUL,DUL,N  ,N  ,DUl,N  ,N  ,
+        /*O*/ N  ,DuL,N  ,DUL,DuL,Dul,DUl,DUl,N  ,
+        /*R*/ N  ,N  ,N  ,N  ,DuL,DuL,N  ,N  ,DUl,
+        /*A*/ N  ,DuL,N  ,N  ,DUl,Dul,DuL,Dul,Ul
+        }
     };
 }();
 

--- a/test/unit/alignment/pairwise/fixture/local_affine_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/local_affine_unbanded.hpp
@@ -9,8 +9,8 @@
 
 #include <vector>
 
-#include <seqan3/alignment/configuration/align_config_mode.hpp>
 #include <seqan3/alignment/configuration/align_config_gap.hpp>
+#include <seqan3/alignment/configuration/align_config_mode.hpp>
 #include <seqan3/alignment/configuration/align_config_scoring.hpp>
 #include <seqan3/alignment/scoring/aminoacid_scoring_scheme.hpp>
 #include <seqan3/alignment/scoring/nucleotide_scoring_scheme.hpp>
@@ -46,7 +46,39 @@ static auto dna4_01 = []()
         "GTTTA",
         "GTCTA",
         alignment_coordinate{column_index_type{5u}, row_index_type{2u}},
-        alignment_coordinate{column_index_type{10u}, row_index_type{7u}}
+        alignment_coordinate{column_index_type{10u}, row_index_type{7u}},
+        std::vector
+        {
+        //     e, A, A, C, C, G, G, T, T, T, A, A, C, C, G, G, T, T
+        /*e*/ 0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,
+        /*A*/ 0 ,4 ,4 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,4 ,4 ,0 ,0 ,0 ,0 ,0 ,0 ,
+        /*C*/ 0 ,0 ,0 ,8 ,4 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,8 ,4 ,0 ,0 ,0 ,0 ,
+        /*G*/ 0 ,0 ,0 ,0 ,3 ,8 ,4 ,0 ,0 ,0 ,0 ,0 ,0 ,3 ,8 ,4 ,0 ,0 ,
+        /*T*/ 0 ,0 ,0 ,0 ,0 ,0 ,3 ,8 ,4 ,4 ,0 ,0 ,0 ,0 ,0 ,3 ,8 ,4 ,
+        /*C*/ 0 ,0 ,0 ,4 ,4 ,0 ,0 ,0 ,3 ,0 ,0 ,0 ,4 ,4 ,0 ,0 ,0 ,3 ,
+        /*T*/ 0 ,0 ,0 ,0 ,0 ,0 ,0 ,4 ,4 ,7 ,0 ,0 ,0 ,0 ,0 ,0 ,4 ,4 ,
+        /*A*/ 0 ,4 ,4 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,11,4 ,0 ,0 ,0 ,0 ,0 ,0 ,
+        /*C*/ 0 ,0 ,0 ,8 ,4 ,0 ,0 ,0 ,0 ,0 ,0 ,6 ,8 ,4 ,0 ,0 ,0 ,0 ,
+        /*G*/ 0 ,0 ,0 ,0 ,3 ,8 ,4 ,0 ,0 ,0 ,0 ,0 ,1 ,3 ,8 ,4 ,0 ,0 ,
+        /*T*/ 0 ,0 ,0 ,0 ,0 ,0 ,3 ,8 ,4 ,4 ,0 ,0 ,0 ,0 ,0 ,3 ,8 ,4 ,
+        /*A*/ 0 ,4 ,4 ,0 ,0 ,0 ,0 ,0 ,3 ,0 ,8 ,4 ,0 ,0 ,0 ,0 ,0 ,3
+        },
+        std::vector
+        {
+        //      e,  A,  A,  C,  C,  G,  G,  T,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
+        /*e*/ N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,
+        /*A*/ N  ,DUL,DUL,N  ,N  ,N  ,N  ,N  ,N  ,N  ,DUL,DUL,N  ,N  ,N  ,N  ,N  ,N  ,
+        /*C*/ N  ,N  ,N  ,DUL,DUL,N  ,N  ,N  ,N  ,N  ,N  ,N  ,DUl,DUL,N  ,N  ,N  ,N  ,
+        /*G*/ N  ,N  ,N  ,N  ,DUL,DUL,DUL,N  ,N  ,N  ,N  ,N  ,N  ,DUl,DUL,DUL,N  ,N  ,
+        /*T*/ N  ,N  ,N  ,N  ,N  ,N  ,DUL,DUL,DUL,DUl,N  ,N  ,N  ,N  ,N  ,DUl,DUL,DUL,
+        /*C*/ N  ,N  ,N  ,DuL,DuL,N  ,N  ,N  ,DUl,N  ,N  ,N  ,Dul,DuL,N  ,N  ,N  ,DUl,
+        /*T*/ N  ,N  ,N  ,N  ,N  ,N  ,N  ,DuL,DuL,DuL,N  ,N  ,N  ,N  ,N  ,N  ,Dul,DuL,
+        /*A*/ N  ,DUL,DUL,N  ,N  ,N  ,N  ,N  ,N  ,N  ,DUL,DUL,N  ,N  ,N  ,N  ,N  ,N  ,
+        /*C*/ N  ,N  ,N  ,DuL,DuL,N  ,N  ,N  ,N  ,N  ,Ul ,DUl,DuL,DuL,N  ,N  ,N  ,N  ,
+        /*G*/ N  ,N  ,N  ,N  ,DUL,DuL,DUL,N  ,N  ,N  ,N  ,N  ,DUl,DUl,DuL,DUL,N  ,N  ,
+        /*T*/ N  ,N  ,N  ,N  ,N  ,N  ,DUL,DuL,DuL,Dul,N  ,N  ,N  ,N  ,N  ,DUl,DuL,DuL,
+        /*A*/ N  ,DuL,DuL,N  ,N  ,N  ,N  ,N  ,DUL,N  ,Dul,DuL,N  ,N  ,N  ,N  ,N  ,DUl
+        }
     };
 }();
 
@@ -65,7 +97,51 @@ static auto dna4_02 = []()
         "GTCTA",
         "GTTTA",
         alignment_coordinate{column_index_type{2u}, row_index_type{5u}},
-        alignment_coordinate{column_index_type{7u}, row_index_type{10u}}
+        alignment_coordinate{column_index_type{7u}, row_index_type{10u}},
+        std::vector
+        {
+        //     e, A, C, G, T, C, T, A, C, G, T, A
+        /*e*/ 0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,
+        /*A*/ 0 ,4 ,0 ,0 ,0 ,0 ,0 ,4 ,0 ,0 ,0 ,4 ,
+        /*A*/ 0 ,4 ,0 ,0 ,0 ,0 ,0 ,4 ,0 ,0 ,0 ,4 ,
+        /*C*/ 0 ,0 ,8 ,0 ,0 ,4 ,0 ,0 ,8 ,0 ,0 ,0 ,
+        /*C*/ 0 ,0 ,4 ,3 ,0 ,4 ,0 ,0 ,4 ,3 ,0 ,0 ,
+        /*G*/ 0 ,0 ,0 ,8 ,0 ,0 ,0 ,0 ,0 ,8 ,0 ,0 ,
+        /*G*/ 0 ,0 ,0 ,4 ,3 ,0 ,0 ,0 ,0 ,4 ,3 ,0 ,
+        /*T*/ 0 ,0 ,0 ,0 ,8 ,0 ,4 ,0 ,0 ,0 ,8 ,0 ,
+        /*T*/ 0 ,0 ,0 ,0 ,4 ,3 ,4 ,0 ,0 ,0 ,4 ,3 ,
+        /*T*/ 0 ,0 ,0 ,0 ,4 ,0 ,7 ,0 ,0 ,0 ,4 ,0 ,
+        /*A*/ 0 ,4 ,0 ,0 ,0 ,0 ,0 ,11,0 ,0 ,0 ,8 ,
+        /*A*/ 0 ,4 ,0 ,0 ,0 ,0 ,0 ,4 ,6 ,0 ,0 ,4 ,
+        /*C*/ 0 ,0 ,8 ,0 ,0 ,4 ,0 ,0 ,8 ,1 ,0 ,0 ,
+        /*C*/ 0 ,0 ,4 ,3 ,0 ,4 ,0 ,0 ,4 ,3 ,0 ,0 ,
+        /*G*/ 0 ,0 ,0 ,8 ,0 ,0 ,0 ,0 ,0 ,8 ,0 ,0 ,
+        /*G*/ 0 ,0 ,0 ,4 ,3 ,0 ,0 ,0 ,0 ,4 ,3 ,0 ,
+        /*T*/ 0 ,0 ,0 ,0 ,8 ,0 ,4 ,0 ,0 ,0 ,8 ,0 ,
+        /*T*/ 0 ,0 ,0 ,0 ,4 ,3 ,4 ,0 ,0 ,0 ,4 ,3
+        },
+        std::vector
+        {
+        //      e,  A,  C,  G,  T,  C,  T,  A,  C,  G,  T,  A
+        /*e*/ N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,
+        /*A*/ N  ,DUL,N  ,N  ,N  ,N  ,N  ,DUL,N  ,N  ,N  ,DUl,
+        /*A*/ N  ,DUL,N  ,N  ,N  ,N  ,N  ,DUL,N  ,N  ,N  ,DUl,
+        /*C*/ N  ,N  ,DUL,N  ,N  ,DUl,N  ,N  ,DUl,N  ,N  ,N  ,
+        /*C*/ N  ,N  ,DUL,DUL,N  ,DUl,N  ,N  ,DUl,DUL,N  ,N  ,
+        /*G*/ N  ,N  ,N  ,DUL,N  ,N  ,N  ,N  ,N  ,DUl,N  ,N  ,
+        /*G*/ N  ,N  ,N  ,DUL,DUL,N  ,N  ,N  ,N  ,DUL,DUL,N  ,
+        /*T*/ N  ,N  ,N  ,N  ,DUL,N  ,DUl,N  ,N  ,N  ,DUl,N  ,
+        /*T*/ N  ,N  ,N  ,N  ,DUL,DuL,DUl,N  ,N  ,N  ,DUl,DUL,
+        /*T*/ N  ,N  ,N  ,N  ,DuL,N  ,DUl,N  ,N  ,N  ,Dul,N  ,
+        /*A*/ N  ,DUL,N  ,N  ,N  ,N  ,N  ,DUL,L  ,N  ,N  ,Dul,
+        /*A*/ N  ,DUL,N  ,N  ,N  ,N  ,N  ,DUL,DuL,N  ,N  ,DUl,
+        /*C*/ N  ,N  ,DuL,N  ,N  ,Dul,N  ,N  ,DUl,DuL,N  ,N  ,
+        /*C*/ N  ,N  ,DUL,DuL,N  ,DUl,N  ,N  ,DUl,DuL,N  ,N  ,
+        /*G*/ N  ,N  ,N  ,DUL,N  ,N  ,N  ,N  ,N  ,DUl,N  ,N  ,
+        /*G*/ N  ,N  ,N  ,DUL,DuL,N  ,N  ,N  ,N  ,DUL,DuL,N  ,
+        /*T*/ N  ,N  ,N  ,N  ,DUL,N  ,Dul,N  ,N  ,N  ,DUl,N  ,
+        /*T*/ N  ,N  ,N  ,N  ,DUL,DuL,DUl,N  ,N  ,N  ,DUl,DuL
+        }
     };
 }();
 
@@ -86,7 +162,41 @@ static auto dna4_03 = []()
         "ATAAGCGT",
         "AT-AGAGT",
         alignment_coordinate{column_index_type{0u}, row_index_type{2u}},
-        alignment_coordinate{column_index_type{8u}, row_index_type{9u}}
+        alignment_coordinate{column_index_type{8u}, row_index_type{9u}},
+        std::vector
+        {
+        //    e,A,T,A,A,G,C,G,T,C,T,C,G
+        /*e*/ 0,0,0,0,0,0,0,0,0,0,0,0,0,
+        /*T*/ 0,0,2,0,0,0,0,0,2,0,2,0,0,
+        /*C*/ 0,0,0,1,0,0,2,0,0,4,2,4,2,
+        /*A*/ 0,2,0,2,3,1,0,1,0,2,3,2,3,
+        /*T*/ 0,0,4,2,1,2,0,0,3,1,4,2,1,
+        /*A*/ 0,2,2,6,4,3,2,1,1,2,2,3,1,
+        /*G*/ 0,0,1,4,5,6,4,4,2,1,1,1,5,
+        /*A*/ 0,2,0,3,6,4,5,3,3,1,0,0,3,
+        /*G*/ 0,0,1,2,4,8,6,7,5,4,3,2,2,
+        /*T*/ 0,0,2,1,3,6,7,5,9,7,6,5,4,
+        /*T*/ 0,0,2,1,2,5,5,6,7,8,9,7,6,
+        /*G*/ 0,0,0,1,1,4,4,7,6,6,7,8,9,
+        /*C*/ 0,0,0,0,0,3,6,5,6,8,6,9,7
+        },
+        std::vector
+        {
+        //      e,  A,  T,  A,  A,  G,  C,  G,  T,  C,  T,  C,  G
+        /*e*/ N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,
+        /*T*/ N  ,N  ,DUL,L  ,N  ,N  ,N  ,N  ,DUL,L  ,DUl,L  ,N  ,
+        /*C*/ N  ,N  ,UL ,DUL,N  ,N  ,DUL,L  ,Ul ,DUl,L  ,DUl,L  ,
+        /*A*/ N  ,DUL,L  ,DUl,DUL,L  ,Ul ,DUl,N  ,Ul ,DUL,UL ,DUl,
+        /*T*/ N  ,UL ,DuL,L  ,DUl,DUl,DuL,N  ,Dul,uL ,DUl,DuL,DUl,
+        /*A*/ N  ,DuL,UL ,DUL,DuL,l  ,l  ,l  ,Ul ,Dul,UL ,DuL,DuL,
+        /*G*/ N  ,UL ,DuL,UL ,DUL,DUL,L  ,DUl,l  ,l  ,Dul,DUl,DuL,
+        /*A*/ N  ,DuL,uL ,Dul,DUL,DUL,DUl,DUL,DUl,Dul,Dul,Dul,Ul ,
+        /*G*/ N  ,UL ,DuL,uL ,UL ,DuL,L  ,Dul,L  ,l  ,l  ,l  ,Dul,
+        /*T*/ N  ,N  ,DUL,uL ,ul ,UL ,DUL,DUL,DUl,L  ,DUl,l  ,l  ,
+        /*T*/ N  ,N  ,DUL,DuL,ul ,uL ,DUL,DuL,DUL,DUL,DUL,L  ,l  ,
+        /*G*/ N  ,N  ,UL ,DuL,uL ,DuL,DuL,DUL,uL ,DUl,DUL,DUL,DUL,
+        /*C*/ N  ,N  ,N  ,N  ,DuL,uL ,DuL,UL ,Dul,DuL,uL ,DUl,DUL
+        }
     };
 }();
 
@@ -105,7 +215,29 @@ static auto dna4_04 = []()
         "",
         "",
         alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
-        alignment_coordinate{column_index_type{0u}, row_index_type{0u}}
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        std::vector
+        {
+        //    e,A,A,A,A,A,A
+        /*e*/ 0,0,0,0,0,0,0,
+        /*C*/ 0,0,0,0,0,0,0,
+        /*C*/ 0,0,0,0,0,0,0,
+        /*C*/ 0,0,0,0,0,0,0,
+        /*C*/ 0,0,0,0,0,0,0,
+        /*C*/ 0,0,0,0,0,0,0,
+        /*C*/ 0,0,0,0,0,0,0
+        },
+        std::vector
+        {
+        //    e,A,A,A,A,A,A
+        /*e*/ N,N,N,N,N,N,N,
+        /*C*/ N,N,N,N,N,N,N,
+        /*C*/ N,N,N,N,N,N,N,
+        /*C*/ N,N,N,N,N,N,N,
+        /*C*/ N,N,N,N,N,N,N,
+        /*C*/ N,N,N,N,N,N,N,
+        /*C*/ N,N,N,N,N,N,N
+        }
     };
 }();
 
@@ -124,7 +256,43 @@ static auto dna4_05 = []()
         "AAAAAA",
         "AAAAAA",
         alignment_coordinate{column_index_type{0u}, row_index_type{7u}},
-        alignment_coordinate{column_index_type{6u}, row_index_type{13u}}
+        alignment_coordinate{column_index_type{6u}, row_index_type{13u}},
+        std::vector
+        {
+        //     e, A, A, A, A, A, A, T, C, C, C, C, C, C
+        /*e*/ 0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,
+        /*C*/ 0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,4 ,4 ,4 ,4 ,4 ,4 ,
+        /*C*/ 0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,4 ,8 ,8 ,8 ,8 ,8 ,
+        /*C*/ 0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,4 ,8 ,12,12,12,12,
+        /*C*/ 0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,4 ,8 ,12,16,16,16,
+        /*C*/ 0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,4 ,8 ,12,16,20,20,
+        /*C*/ 0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,4 ,8 ,12,16,20,24,
+        /*T*/ 0 ,0 ,0 ,0 ,0 ,0 ,0 ,4 ,0 ,0 ,3 ,7 ,11,15,
+        /*A*/ 0 ,4 ,4 ,4 ,4 ,4 ,4 ,0 ,0 ,0 ,0 ,4 ,8 ,12,
+        /*A*/ 0 ,4 ,8 ,8 ,8 ,8 ,8 ,0 ,0 ,0 ,0 ,3 ,7 ,11,
+        /*A*/ 0 ,4 ,8 ,12,12,12,12,3 ,0 ,0 ,0 ,2 ,6 ,10,
+        /*A*/ 0 ,4 ,8 ,12,16,16,16,7 ,4 ,3 ,2 ,1 ,5 ,9 ,
+        /*A*/ 0 ,4 ,8 ,12,16,20,20,11,8 ,7 ,6 ,5 ,4 ,8 ,
+        /*A*/ 0 ,4 ,8 ,12,16,20,24,15,12,11,10,9 ,8 ,7
+        },
+        std::vector
+        {
+        //      e,  A,  A,  A,  A,  A,  A,  T,  C,  C,  C,  C,  C,  C
+        /*e*/ N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,
+        /*C*/ N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,DUL,DUL,DUL,DUL,DUL,DUL,
+        /*C*/ N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,DUL,DUL,DUL,DUL,DUL,DUL,
+        /*C*/ N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,DUL,DUL,DUL,DUL,DUL,DUL,
+        /*C*/ N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,DUL,DUL,DUL,DUL,DUL,DUL,
+        /*C*/ N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,DUL,DUL,DUL,DUL,DUL,DUL,
+        /*C*/ N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,DUL,DUL,DUL,DUL,DUL,DUL,
+        /*T*/ N  ,N  ,N  ,N  ,N  ,N  ,N  ,DUL,N  ,N  ,DUl,DUL,DUL,DUL,
+        /*A*/ N  ,DUL,DUL,DUL,DUL,DUL,DUL,N  ,N  ,N  ,ul ,ul ,uL ,uL ,
+        /*A*/ N  ,DUL,DUL,DUL,DUL,DUL,DUL,N  ,N  ,N  ,N  ,ul ,ul ,uL ,
+        /*A*/ N  ,DUL,DUL,DUL,DUL,DUL,DUL,DuL,l  ,N  ,N  ,ul ,ul ,ul ,
+        /*A*/ N  ,DUL,DUL,DUL,DUL,DUL,DUL,DUL,l  ,l  ,l  ,ul ,ul ,ul ,
+        /*A*/ N  ,DUL,DUL,DUL,DUL,DUL,DUL,DUL,l  ,l  ,l  ,l  ,ul ,ul ,
+        /*A*/ N  ,DUL,DUL,DUL,DUL,DUL,DUL,DUL,l  ,l  ,l  ,l  ,l  ,ul
+        }
     };
 }();
 
@@ -143,7 +311,41 @@ static auto rna5_01 = []()
         "AAAAAAUUUUNNUUUUCCCCCC",
         "AAAAAA----------CCCCCC",
         alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
-        alignment_coordinate{column_index_type{22u}, row_index_type{12u}}
+        alignment_coordinate{column_index_type{22u}, row_index_type{12u}},
+        std::vector
+        {
+        //     e, A, A, A, A, A, A, U, U, U, U, N, N, U, U, U, U, C, C, C, C, C, C
+        /*e*/ 0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,
+        /*A*/ 0 ,4 ,4 ,4 ,4 ,4 ,4 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,
+        /*A*/ 0 ,4 ,8 ,8 ,8 ,8 ,8 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,
+        /*A*/ 0 ,4 ,8 ,12,12,12,12,3 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,
+        /*A*/ 0 ,4 ,8 ,12,16,16,16,7 ,4 ,3 ,2 ,1 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,
+        /*A*/ 0 ,4 ,8 ,12,16,20,20,11,8 ,7 ,6 ,5 ,4 ,3 ,2 ,1 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,
+        /*A*/ 0 ,4 ,8 ,12,16,20,24,15,12,11,10,9 ,8 ,7 ,6 ,5 ,4 ,3 ,2 ,1 ,0 ,0 ,0 ,
+        /*C*/ 0 ,0 ,0 ,3 ,7 ,11,15,19,10,7 ,6 ,5 ,4 ,3 ,2 ,1 ,0 ,8 ,7 ,6 ,5 ,4 ,4 ,
+        /*C*/ 0 ,0 ,0 ,0 ,4 ,8 ,12,10,14,5 ,2 ,1 ,0 ,0 ,0 ,0 ,0 ,4 ,12,11,10,9 ,8 ,
+        /*C*/ 0 ,0 ,0 ,0 ,3 ,7 ,11,7 ,5 ,9 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,4 ,8 ,16,15,14,13,
+        /*C*/ 0 ,0 ,0 ,0 ,2 ,6 ,10,6 ,2 ,0 ,4 ,0 ,0 ,0 ,0 ,0 ,0 ,4 ,8 ,12,20,19,18,
+        /*C*/ 0 ,0 ,0 ,0 ,1 ,5 ,9 ,5 ,1 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,4 ,8 ,12,16,24,23,
+        /*C*/ 0 ,0 ,0 ,0 ,0 ,4 ,8 ,4 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,4 ,8 ,12,16,20,28
+        },
+        std::vector
+        {
+        //      e,  A,  A,  A,  A,  A,  A,  U,  U,  U,  U,  N,  N,  U,  U,  U,  U,  C,  C,  C,  C,  C,  C
+        /*e*/ N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,
+        /*A*/ N  ,DUL,DUL,DUL,DUL,DUL,DUL,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,
+        /*A*/ N  ,DUL,DUL,DUL,DUL,DUL,DUL,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,
+        /*A*/ N  ,DUL,DUL,DUL,DUL,DUL,DUL,DUL,l  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,
+        /*A*/ N  ,DUL,DUL,DUL,DUL,DUL,DUL,DUL,l  ,l  ,l  ,l  ,l  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,
+        /*A*/ N  ,DUL,DUL,DUL,DUL,DUL,DUL,DUL,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,N  ,N  ,N  ,N  ,N  ,N  ,
+        /*A*/ N  ,DUL,DUL,DUL,DUL,DUL,DUL,DUL,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,N  ,N  ,
+        /*C*/ N  ,N  ,N  ,DUL,DUL,DUL,DUL,DUL,DUL,DUl,DUl,DUl,DUl,DUl,DUl,DUl,DUl,DUl,DUl,DUl,DUl,DUl,DUl,
+        /*C*/ N  ,N  ,N  ,uL ,uL ,uL ,uL ,DUL,Dul,DuL,Dul,Dul,Dul,N  ,N  ,N  ,N  ,DUl,DUl,DUL,DUl,DUl,DUl,
+        /*C*/ N  ,N  ,N  ,N  ,uL ,uL ,uL ,DuL,DUl,Dul,DuL,N  ,N  ,N  ,N  ,N  ,N  ,Dul,DUL,DUL,DUL,DUl,DUl,
+        /*C*/ N  ,N  ,N  ,N  ,uL ,uL ,uL ,DuL,Dul,DUl,Dul,N  ,N  ,N  ,N  ,N  ,N  ,Dul,DuL,DUL,DUL,DUL,DUl,
+        /*C*/ N  ,N  ,N  ,N  ,uL ,uL ,uL ,DuL,Dul,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,DuL,DuL,DuL,DUL,DUL,DUL,
+        /*C*/ N  ,N  ,N  ,N  ,uL ,uL ,uL ,DuL,Dul,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,DuL,DuL,DuL,DuL,DUL,DUL
+        }
     };
 }();
 
@@ -162,7 +364,29 @@ static auto aa27_01 = []()
         "GATOR",
         "GALOR",
         alignment_coordinate{column_index_type{3u}, row_index_type{0u}},
-        alignment_coordinate{column_index_type{8u}, row_index_type{5u}}
+        alignment_coordinate{column_index_type{8u}, row_index_type{5u}},
+        std::vector
+        {
+        //     e, A, L, I, G, A, T, O, R
+        /*e*/ 0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,
+        /*G*/ 0 ,0 ,0 ,0 ,6 ,0 ,0 ,0 ,0 ,
+        /*A*/ 0 ,4 ,0 ,0 ,0 ,10,0 ,0 ,0 ,
+        /*L*/ 0 ,0 ,8 ,2 ,0 ,0 ,9 ,0 ,0 ,
+        /*O*/ 0 ,0 ,0 ,7 ,1 ,0 ,0 ,8 ,0 ,
+        /*R*/ 0 ,0 ,0 ,0 ,5 ,0 ,0 ,0 ,13,
+        /*A*/ 0 ,4 ,0 ,0 ,0 ,9 ,0 ,0 ,2
+        },
+        std::vector
+        {
+        //      e,  A,  L,  I,  G,  A,  T,  O,  R
+        /*e*/ N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,
+        /*G*/ N  ,DUL,N  ,N  ,DUL,DUL,N  ,N  ,N  ,
+        /*A*/ N  ,DUL,N  ,N  ,DUl,DUl,DUL,DUl,N  ,
+        /*L*/ N  ,N  ,DUL,DUL,N  ,N  ,DUl,N  ,N  ,
+        /*O*/ N  ,DuL,N  ,DUL,DuL,Dul,DUl,DUl,N  ,
+        /*R*/ N  ,N  ,N  ,N  ,DuL,DuL,N  ,N  ,DUl,
+        /*A*/ N  ,DuL,N  ,N  ,DUl,Dul,DuL,Dul,Ul
+        }
     };
 }();
 
@@ -181,7 +405,17 @@ static auto aa27_02 = []()
         "",
         "",
         alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
-        alignment_coordinate{column_index_type{0u}, row_index_type{0u}}
+        alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
+        std::vector
+        {
+        //e,A,L,I,G,A,T,O,R
+          0,0,0,0,0,0,0,0,0
+        },
+        std::vector
+        {
+        //e,A,L,I,G,A,T,O,R
+          N,N,N,N,N,N,N,N,N
+        }
     };
 }();
 

--- a/test/unit/alignment/pairwise/fixture/semi_global_affine_banded.hpp
+++ b/test/unit/alignment/pairwise/fixture/semi_global_affine_banded.hpp
@@ -43,7 +43,39 @@ static auto dna4_01_semi_first = []()
         "ACGT---ATGT",
         "ACGTAAAACGT",
         alignment_coordinate{detail::column_index_type{5u}, detail::row_index_type{0u}},
-        alignment_coordinate{detail::column_index_type{13u}, detail::row_index_type{11u}}
+        alignment_coordinate{detail::column_index_type{13u}, detail::row_index_type{11u}},
+        std::vector<std::optional<int32_t>>
+        {
+        //      e,  T,  T,  T,  T,  T,  A,  C,  G,  T,  A,  T,  G,  T,  C,  C,  C,  C,  C
+        /*e*/  0 ,0  ,0  ,0  ,0  ,0  ,0  ,0  ,0  ,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*A*/ -11,-5 ,-5 ,-5 ,-5 ,-5 ,4  ,-5 ,-5 ,-5 ,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*C*/ -12,-12,-10,-10,-10,-10,-7 ,8  ,-3 ,-4 ,-5 ,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*G*/ -13,-13,-13,-13,-13,-13,-8 ,-3 ,12 ,1  ,0  ,-1 ,INF,INF,INF,INF,INF,INF,INF,
+        /*T*/ -14,-9 ,-9 ,-9 ,-9 ,-9 ,-9 ,-4 ,1  ,16 ,5  ,4  ,3  ,INF,INF,INF,INF,INF,INF,
+        /*A*/ INF,-15,-14,-14,-14,-14,-5 ,-5 ,0  ,5  ,20 ,9  ,8  ,7  ,INF,INF,INF,INF,INF,
+        /*A*/ INF,INF,-16,-16,-16,-16,-10,-6 ,-1 ,4  ,9  ,15 ,4  ,3  ,2  ,INF,INF,INF,INF,
+        /*A*/ INF,INF,INF,-17,-17,-17,-12,-7 ,-2 ,3  ,8  ,4  ,10 ,-1 ,-2 ,-3 ,INF,INF,INF,
+        /*A*/ INF,INF,INF,INF,-18,-18,-13,-8 ,-3 ,2  ,7  ,3  ,-1 ,5  ,-6 ,-7 ,-8 ,INF,INF,
+        /*C*/ INF,INF,INF,INF,INF,-19,-14,-9 ,-4 ,1  ,6  ,2  ,-2 ,-6 ,9  ,-2 ,-3 ,-4 ,INF,
+        /*G*/ INF,INF,INF,INF,INF,INF,-15,-10,-5 ,0  ,5  ,1  ,6  ,-5 ,-2 ,4  ,-7 ,-8 ,-9 ,
+        /*T*/ INF,INF,INF,INF,INF,INF,INF,-11,-6 ,-1 ,4  ,9  ,-2 ,10 ,-1 ,-2 ,-1 ,-4 ,-5
+        },
+        std::vector<std::optional<detail::trace_directions>>
+        {
+        //      e,  T,  T,  T,  T,  T,  A,  C,  G,  T,  A,  T,  G,  T,  C,  C,  C,  C,  C
+        /*e*/ N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*A*/ U  ,DUL,DUL,DUL,DUL,DUL,DUL,DUL,DUl,D  ,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*C*/ u  ,uL ,DuL,DuL,DuL,DuL,UL ,DuL,L  ,l  ,l  ,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*G*/ u  ,uL ,uL ,uL ,uL ,uL ,uL ,UL ,DuL,L  ,l  ,l  ,INF,INF,INF,INF,INF,INF,INF,
+        /*T*/ u  ,DuL,DuL,DuL,DuL,DuL,uL ,uL ,UL ,DUL,L  ,DUl,l  ,INF,INF,INF,INF,INF,INF,
+        /*A*/ INF,u  ,DuL,DuL,DuL,DuL,DuL,uL ,uL ,UL ,DUL,L  ,l  ,l  ,INF,INF,INF,INF,INF,
+        /*A*/ INF,INF,u  ,uL ,uL ,uL ,DuL,uL ,uL ,uL ,DUL,DUL,DUL,DUl,D  ,INF,INF,INF,INF,
+        /*A*/ INF,INF,INF,u  ,uL ,uL ,DuL,uL ,uL ,uL ,DuL,DUL,Dul,DuL,DUl,D  ,INF,INF,INF,
+        /*A*/ INF,INF,INF,INF,u  ,uL ,DuL,uL ,uL ,uL ,DuL,DuL,DUl,Dul,DuL,DUl,D  ,INF,INF,
+        /*C*/ INF,INF,INF,INF,INF,u  ,uL ,DuL,uL ,uL ,uL ,DuL,Dul,DUl,Dul,DuL,DUl,D  ,INF,
+        /*G*/ INF,INF,INF,INF,INF,INF,u  ,uL ,DuL,uL ,uL ,DuL,Dul,L  ,Ul ,DUl,DUL,DUl,D  ,
+        /*T*/ INF,INF,INF,INF,INF,INF,INF,u  ,uL ,DuL,uL ,DuL,L  ,Dul,L  ,l  ,Dul,l  ,l
+        }
     };
 }();
 
@@ -76,7 +108,39 @@ static auto dna4_03_semi_second = []()
         "TTTTTACGTATGTCCCCC",
         "GTAAAACGT---------",
         alignment_coordinate{detail::column_index_type{0u}, detail::row_index_type{2u}},
-        alignment_coordinate{detail::column_index_type{18u}, detail::row_index_type{11u}}
+        alignment_coordinate{detail::column_index_type{18u}, detail::row_index_type{11u}},
+        std::vector<std::optional<int32_t>>
+        {
+        //      e,  T,  T,  T,  T,  T,  A,  C,  G,  T,  A,  T,  G,  T,  C,  C,  C,  C,  C
+        /*e*/ 0  ,-11,-12,-13,-14,-15,-16,-17,-18,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*A*/ 0  ,-5 ,-12,-13,-14,-15,-11,-17,-18,-19,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*C*/ 0  ,-5 ,-10,-13,-14,-15,-16,-7 ,-18,-19,-20,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*G*/ 0  ,-5 ,-10,-13,-14,-15,-16,-17,-3 ,-14,-15,-16,INF,INF,INF,INF,INF,INF,INF,
+        /*T*/ 0  ,4  ,-1 ,-6 ,-9 ,-10,-11,-12,-13,1  ,-10,-11,-12,INF,INF,INF,INF,INF,INF,
+        /*A*/ INF,-5 ,-1 ,-6 ,-11,-14,-6 ,-16,-15,-10,5  ,-6 ,-7 ,-8 ,INF,INF,INF,INF,INF,
+        /*A*/ INF,INF,-10,-6 ,-11,-16,-10,-11,-16,-11,-6 ,0  ,-11,-12,-13,INF,INF,INF,INF,
+        /*A*/ INF,INF,INF,-15,-11,-16,-12,-15,-16,-12,-7 ,-11,-5 ,-16,-17,-18,INF,INF,INF,
+        /*A*/ INF,INF,INF,INF,-20,-16,-12,-17,-18,-13,-8 ,-12,-16,-10,-21,-22,-23,INF,INF,
+        /*C*/ INF,INF,INF,INF,INF,-25,-20,-8 ,-19,-14,-9 ,-13,-17,-21,-6 ,-17,-18,-19,INF,
+        /*G*/ INF,INF,INF,INF,INF,INF,-21,-19,-4 ,-15,-10,-14,-9 ,-19,-17,-11,-22,-23,-24,
+        /*T*/ INF,INF,INF,INF,INF,INF,INF,-20,-15,0  ,-11,-6 ,-13,-5 ,-15,-16,-16,-18,-19
+        },
+        std::vector<std::optional<detail::trace_directions>>
+        {
+        //      e,  T,  T,  T,  T,  T,  A,  C,  G,  T,  A,  T,  G,  T,  C,  C,  C,  C,  C
+        /*e*/ N  ,L  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*A*/ N  ,DUL,l  ,l  ,l  ,l  ,DUl,l  ,l  ,l  ,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*C*/ N  ,DUL,DUl,l  ,l  ,l  ,l  ,DUl,l  ,l  ,l  ,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*G*/ N  ,DUL,DUl,l  ,l  ,l  ,l  ,l  ,DUl,L  ,l  ,l  ,INF,INF,INF,INF,INF,INF,INF,
+        /*T*/ N  ,DUL,DUL,DUl,DUl,DUl,l  ,l  ,l  ,DUl,L  ,DUl,l  ,INF,INF,INF,INF,INF,INF,
+        /*A*/ INF,DU ,DUL,DUL,DUl,DUl,DUl,Dul,ul ,Ul ,DUl,L  ,l  ,l  ,INF,INF,INF,INF,INF,
+        /*A*/ INF,INF,DU ,DUL,DuL,Dul,DUl,Dul,ul ,ul ,DUL,DUL,DUL,DUl,D  ,INF,INF,INF,INF,
+        /*A*/ INF,INF,INF,DU ,DuL,DuL,Dul,DuL,Dul,ul ,DuL,DUL,Dul,DuL,DUl,D  ,INF,INF,INF,
+        /*A*/ INF,INF,INF,INF,DU ,DuL,DuL,DuL,ul ,ul ,DuL,DuL,DUl,Dul,DuL,DUl,D  ,INF,INF,
+        /*C*/ INF,INF,INF,INF,INF,Du ,uL ,DuL,uL ,ul ,ul ,DuL,Dul,DUl,Dul,DuL,DUl,D  ,INF,
+        /*G*/ INF,INF,INF,INF,INF,INF,u  ,UL ,DuL,uL ,ul ,Dul,Dul,l  ,Ul ,DUl,DUl,DUl,D  ,
+        /*T*/ INF,INF,INF,INF,INF,INF,INF,u  ,UL ,DuL,uL ,Dul,l  ,Dul,l  ,l  ,Dul,l  ,l
+        }
     };
 }();
 
@@ -91,7 +155,53 @@ static auto dna4_04_semi_second = []()
         "ACGTAAAACGT",
         "------TACGT",
         alignment_coordinate{detail::column_index_type{0u}, detail::row_index_type{4u}},
-        alignment_coordinate{detail::column_index_type{11u}, detail::row_index_type{9u}}
+        alignment_coordinate{detail::column_index_type{11u}, detail::row_index_type{9u}},
+        std::vector<std::optional<int32_t>>
+        {
+        //      e,  A,  C,  G,  T,  A,  A,  A,  A,  C,  G,  T
+        /*e*/ 0  ,-11,-12,-13,-14,-15,-16,-17,-18,INF,INF,INF,
+        /*T*/ 0  ,-5 ,-12,-13,-9 ,-15,-16,-17,-18,-19,INF,INF,
+        /*T*/ 0  ,-5 ,-10,-13,-9 ,-14,-16,-17,-18,-19,-20,INF,
+        /*T*/ 0  ,-5 ,-10,-13,-9 ,-14,-16,-17,-18,-19,-20,-16,
+        /*T*/ 0  ,-5 ,-10,-13,-9 ,-14,-16,-17,-18,-19,-20,-16,
+        /*T*/ INF,-5 ,-10,-15,-9 ,-14,-19,-21,-22,-23,-24,-16,
+        /*A*/ INF,INF,-10,-15,-20,-5 ,-10,-15,-17,-19,-20,-21,
+        /*C*/ INF,INF,INF,-15,-20,-16,-10,-15,-20,-13,-24,-25,
+        /*G*/ INF,INF,INF,INF,-20,-17,-21,-15,-20,-24,-9 ,-20,
+        /*T*/ INF,INF,INF,INF,INF,-18,-22,-26,-20,-25,-20,-5 ,
+        /*A*/ INF,INF,INF,INF,INF,INF,-14,-18,-22,-25,-21,-16,
+        /*T*/ INF,INF,INF,INF,INF,INF,INF,-19,-23,-27,-22,-17,
+        /*G*/ INF,INF,INF,INF,INF,INF,INF,INF,-24,-28,-23,-18,
+        /*T*/ INF,INF,INF,INF,INF,INF,INF,INF,INF,-29,-24,-19,
+        /*C*/ INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,-25,-20,
+        /*C*/ INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,-21,
+        /*C*/ INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*C*/ INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*C*/ INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF
+        },
+        std::vector<std::optional<detail::trace_directions>>
+        {
+        //      e,  A,  C,  G,  T,  A,  A,  A,  A,  C,  G,  T
+        /*e*/ N  ,L  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,INF,INF,INF,
+        /*T*/ N  ,DUL,l  ,l  ,DUl,l  ,l  ,l  ,l  ,l  ,INF,INF,
+        /*T*/ N  ,DUL,DUl,l  ,DUl,DUl,l  ,l  ,l  ,l  ,l  ,INF,
+        /*T*/ N  ,DUL,DUl,l  ,DUl,DUl,l  ,l  ,l  ,l  ,l  ,D  ,
+        /*T*/ N  ,DUL,DUl,l  ,DUl,DUl,l  ,l  ,l  ,l  ,l  ,DUl,
+        /*T*/ INF,DU ,DUL,DUl,DUl,DUl,DUl,DUl,DUl,DUl,DUl,DUl,
+        /*A*/ INF,INF,DU ,DuL,DUl,DUl,DuL,Dul,Dul,l  ,l  ,l  ,
+        /*C*/ INF,INF,INF,Du ,DuL,Ul ,DUL,DUL,DUl,DUl,DUl,Dul,
+        /*G*/ INF,INF,INF,INF,Du ,uL ,DUL,DUl,DuL,Ul ,Dul,L  ,
+        /*T*/ INF,INF,INF,INF,INF,u  ,DuL,DUl,Dul,DuL,Ul ,DuL,
+        /*A*/ INF,INF,INF,INF,INF,INF,Du ,DuL,Dul,Dul,ul ,Ul ,
+        /*T*/ INF,INF,INF,INF,INF,INF,INF,Du ,DuL,Dul,ul ,Dul,
+        /*G*/ INF,INF,INF,INF,INF,INF,INF,INF,Du ,DuL,Dul,uL ,
+        /*T*/ INF,INF,INF,INF,INF,INF,INF,INF,INF,Du ,uL ,DuL,
+        /*C*/ INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,u  ,uL ,
+        /*C*/ INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,u  ,
+        /*C*/ INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*C*/ INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*C*/ INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF
+        }
     };
 }();
 

--- a/test/unit/alignment/pairwise/fixture/semi_global_affine_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/semi_global_affine_unbanded.hpp
@@ -47,31 +47,35 @@ static auto dna4_01_semi_first = []()
         alignment_coordinate{column_index_type{13u}, row_index_type{11u}},
         std::vector
         {
-        //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
-        /*e*/  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16,
-        /*A*/  1,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,
-        /*C*/  2,  1,  1,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
-        /*G*/  3,  2,  2,  2,  2,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13,
-        /*T*/  4,  3,  3,  3,  3,  3,  3,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12,
-        /*A*/  5,  4,  3,  4,  4,  4,  4,  4,  4,  4,  5,  6,  7,  8,  9, 10, 11,
-        /*C*/  6,  5,  4,  3,  4,  5,  5,  5,  5,  5,  5,  5,  6,  7,  8,  9, 10,
-        /*G*/  7,  6,  5,  4,  4,  4,  5,  6,  6,  6,  6,  6,  6,  6,  7,  8,  9,
-        /*T*/  8,  7,  6,  5,  5,  5,  5,  5,  6,  7,  7,  7,  7,  7,  7,  7,  8,
-        /*A*/  9,  8,  7,  6,  6,  6,  6,  6,  6,  6,  7,  8,  8,  8,  8,  8,  8
+        //      e,  T,  T,  T,  T,  T,  A,  C,  G,  T,  A,  T,  G,  T,  C,  C,  C,  C,  C
+        /*e*/ 0  ,0  ,0  ,0  ,0  ,0  ,0  ,0  ,0  ,0  ,0  ,0  ,0  ,0  ,0  ,0  ,0  ,0  ,0  ,
+        /*A*/ -11,-5 ,-5 ,-5 ,-5 ,-5 ,4  ,-5 ,-5 ,-5 ,4  ,-5 ,-5 ,-5 ,-5 ,-5 ,-5 ,-5 ,-5 ,
+        /*C*/ -12,-12,-10,-10,-10,-10,-7 ,8  ,-3 ,-4 ,-5 ,-1 ,-7 ,-8 ,-1 ,-1 ,-1 ,-1 ,-1 ,
+        /*G*/ -13,-13,-13,-13,-13,-13,-8 ,-3 ,12 ,1  ,0  ,-1 ,3  ,-3 ,-4 ,-5 ,-6 ,-6 ,-6 ,
+        /*T*/ -14,-9 ,-9 ,-9 ,-9 ,-9 ,-9 ,-4 ,1  ,16 ,5  ,4  ,3  ,7  ,1  ,0  ,-1 ,-2 ,-3 ,
+        /*A*/ -15,-15,-14,-14,-14,-14,-5 ,-5 ,0  ,5  ,20 ,9  ,8  ,7  ,6  ,5  ,4  ,3  ,2  ,
+        /*A*/ -16,-16,-16,-16,-16,-16,-10,-6 ,-1 ,4  ,9  ,15 ,4  ,3  ,2  ,1  ,0  ,-1 ,-2 ,
+        /*A*/ -17,-17,-17,-17,-17,-17,-12,-7 ,-2 ,3  ,8  ,4  ,10 ,-1 ,-2 ,-3 ,-4 ,-5 ,-6 ,
+        /*A*/ -18,-18,-18,-18,-18,-18,-13,-8 ,-3 ,2  ,7  ,3  ,-1 ,5  ,-6 ,-7 ,-8 ,-9 ,-10,
+        /*C*/ -19,-19,-19,-19,-19,-19,-14,-9 ,-4 ,1  ,6  ,2  ,-2 ,-6 ,9  ,-2 ,-3 ,-4 ,-5 ,
+        /*G*/ -20,-20,-20,-20,-20,-20,-15,-10,-5 ,0  ,5  ,1  ,6  ,-5 ,-2 ,4  ,-7 ,-8 ,-9 ,
+        /*T*/ -21,-16,-16,-16,-16,-16,-16,-11,-6 ,-1 ,4  ,9  ,-2 ,10 ,-1 ,-2 ,-1 ,-4 ,-5
         },
         std::vector
         {
-        //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
-        /*e*/NON,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,
-        /*A*/U  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
-        /*C*/U  ,U  ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,L  ,L  ,
-        /*G*/U  ,U  ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,
-        /*T*/U  ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,
-        /*A*/U  ,DU ,D  ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
-        /*C*/U  ,U  ,U  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,
-        /*G*/U  ,U  ,U  ,U  ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,
-        /*T*/U  ,U  ,U  ,U  ,DU ,DU ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,
-        /*A*/U  ,DU ,DU ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D
+        //      e,  T,  T,  T,  T,  T,  A,  C,  G,  T,  A,  T,  G,  T,  C,  C,  C,  C,  C
+        /*e*/ N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,
+        /*A*/ U  ,DUL,DUL,DUL,DUL,DUL,DUL,DUL,DUl,DUl,DUl,DUL,DUl,DUl,DUl,DUl,DUl,DUl,DUl,
+        /*C*/ u  ,uL ,DuL,DuL,DuL,DuL,UL ,DuL,L  ,l  ,l  ,Dul,l  ,l  ,Dul,Dul,Dul,Dul,DuL,
+        /*G*/ u  ,uL ,uL ,uL ,uL ,uL ,uL ,UL ,DuL,L  ,l  ,l  ,Dul,l  ,l  ,l  ,DUl,DUl,DUl,
+        /*T*/ u  ,DuL,DuL,DuL,DuL,DuL,uL ,uL ,UL ,DUL,L  ,DUl,l  ,Dul,l  ,l  ,l  ,l  ,l  ,
+        /*A*/ u  ,uL ,DuL,DuL,DuL,DuL,DuL,uL ,uL ,UL ,DUL,L  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,
+        /*A*/ u  ,uL ,uL ,uL ,uL ,uL ,DuL,uL ,uL ,uL ,DUL,DUL,DUL,DUl,DUl,DUl,DUl,DUl,DUl,
+        /*A*/ u  ,uL ,uL ,uL ,uL ,uL ,DuL,uL ,uL ,uL ,DuL,DUL,Dul,DuL,Dul,Dul,Dul,Dul,Dul,
+        /*A*/ u  ,uL ,uL ,uL ,uL ,uL ,DuL,uL ,uL ,uL ,DuL,DuL,DUl,Dul,DuL,Dul,Dul,Dul,Dul,
+        /*C*/ u  ,uL ,uL ,uL ,uL ,uL ,uL ,DuL,uL ,uL ,uL ,DuL,Dul,DUl,Dul,DuL,Dul,Dul,Dul,
+        /*G*/ u  ,uL ,uL ,uL ,uL ,uL ,uL ,uL ,DuL,uL ,uL ,DuL,Dul,L  ,Ul ,Dul,DuL,Dul,Dul,
+        /*T*/ u  ,DuL,DuL,DuL,DuL,DuL,uL ,uL ,uL ,DuL,uL ,DuL,L  ,Dul,L  ,l  ,Dul,l  ,l
         }
     };
 }();
@@ -93,31 +97,49 @@ static auto dna4_02_semi_first = []()
         alignment_coordinate{column_index_type{5u}, row_index_type{18u}},
         std::vector
         {
-        //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
-        /*e*/  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16,
-        /*A*/  1,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,
-        /*C*/  2,  1,  1,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
-        /*G*/  3,  2,  2,  2,  2,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13,
-        /*T*/  4,  3,  3,  3,  3,  3,  3,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12,
-        /*A*/  5,  4,  3,  4,  4,  4,  4,  4,  4,  4,  5,  6,  7,  8,  9, 10, 11,
-        /*C*/  6,  5,  4,  3,  4,  5,  5,  5,  5,  5,  5,  5,  6,  7,  8,  9, 10,
-        /*G*/  7,  6,  5,  4,  4,  4,  5,  6,  6,  6,  6,  6,  6,  6,  7,  8,  9,
-        /*T*/  8,  7,  6,  5,  5,  5,  5,  5,  6,  7,  7,  7,  7,  7,  7,  7,  8,
-        /*A*/  9,  8,  7,  6,  6,  6,  6,  6,  6,  6,  7,  8,  8,  8,  8,  8,  8
+        //      e,  A,  C,  G,  T,  A,  A,  A,  A,  C,  G,  T
+        /*e*/ 0  ,0  ,0  ,0  ,0  ,0  ,0  ,0  ,0  ,0  ,0  ,0  ,
+        /*T*/ -11,-5 ,-5 ,-5 ,4  ,-5 ,-5 ,-5 ,-5 ,-5 ,-5 ,4  ,
+        /*T*/ -12,-12,-10,-10,-1 ,-1 ,-10,-10,-10,-10,-10,-1 ,
+        /*T*/ -13,-13,-13,-13,-6 ,-6 ,-6 ,-13,-13,-13,-13,-6 ,
+        /*T*/ -14,-14,-14,-14,-9 ,-11,-11,-11,-14,-14,-14,-9 ,
+        /*T*/ -15,-15,-15,-15,-10,-14,-15,-15,-15,-15,-15,-10,
+        /*A*/ -16,-11,-16,-16,-11,-6 ,-10,-11,-11,-16,-16,-11,
+        /*C*/ -17,-17,-7 ,-17,-12,-16,-11,-15,-16,-7 ,-17,-12,
+        /*G*/ -18,-18,-18,-3 ,-13,-15,-16,-16,-18,-18,-3 ,-13,
+        /*T*/ -19,-19,-19,-14,1  ,-10,-11,-12,-13,-14,-14,1  ,
+        /*A*/ -20,-15,-20,-15,-10,5  ,-6 ,-7 ,-8 ,-9 ,-10,-10,
+        /*T*/ -21,-21,-20,-16,-11,-6 ,0  ,-11,-12,-13,-14,-6 ,
+        /*G*/ -22,-22,-22,-16,-12,-7 ,-11,-5 ,-16,-17,-9 ,-12,
+        /*T*/ -23,-23,-23,-18,-12,-8 ,-12,-16,-10,-21,-18,-5 ,
+        /*C*/ -24,-24,-19,-19,-14,-9 ,-13,-17,-21,-6 ,-17,-14,
+        /*C*/ -25,-25,-20,-20,-15,-10,-14,-18,-22,-17,-11,-15,
+        /*C*/ -26,-26,-21,-21,-16,-11,-15,-19,-23,-18,-21,-16,
+        /*C*/ -27,-27,-22,-22,-17,-12,-16,-20,-24,-19,-22,-17,
+        /*C*/ -28,-28,-23,-23,-18,-13,-17,-21,-25,-20,-23,-18
         },
         std::vector
         {
-        //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
-        /*e*/NON,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,
-        /*A*/U  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
-        /*C*/U  ,U  ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,L  ,L  ,
-        /*G*/U  ,U  ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,
-        /*T*/U  ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,
-        /*A*/U  ,DU ,D  ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
-        /*C*/U  ,U  ,U  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,
-        /*G*/U  ,U  ,U  ,U  ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,
-        /*T*/U  ,U  ,U  ,U  ,DU ,DU ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,
-        /*A*/U  ,DU ,DU ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D
+        //      e,  A,  C,  G,  T,  A,  A,  A,  A,  C,  G,  T
+        /*e*/ N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,
+        /*T*/ U  ,DUL,DUL,DUL,DUL,DUL,DUl,DUl,DUl,DUl,DUl,DUl,
+        /*T*/ u  ,uL ,DuL,DuL,DUL,DuL,DuL,Dul,Dul,Dul,Dul,DUl,
+        /*T*/ u  ,uL ,uL ,uL ,DuL,DUL,DuL,uL ,ul ,ul ,ul ,Dul,
+        /*T*/ u  ,uL ,uL ,uL ,DuL,DuL,Dul,Dul,uL ,ul ,ul ,Dul,
+        /*T*/ u  ,uL ,uL ,uL ,DuL,DuL,ul ,ul ,ul ,ul ,ul ,DuL,
+        /*A*/ u  ,DuL,uL ,ul ,ul ,DuL,DuL,Dul,Dul,ul ,ul ,ul ,
+        /*C*/ u  ,uL ,DuL,uL ,ul ,Dul,Dul,Dul,Dul,Dul,uL ,ul ,
+        /*G*/ u  ,uL ,uL ,DuL,uL ,l  ,l  ,Dul,ul ,ul ,Dul,uL ,
+        /*T*/ u  ,uL ,uL ,UL ,DuL,L  ,l  ,l  ,l  ,l  ,Ul ,Dul,
+        /*A*/ u  ,DuL,uL ,ul ,UL ,DuL,DuL,Dul,Dul,l  ,l  ,Ul ,
+        /*T*/ u  ,uL ,DuL,uL ,DuL,UL ,DUL,DUL,DUl,DUl,Dul,Dul,
+        /*G*/ u  ,uL ,uL ,DuL,uL ,uL ,DUL,Dul,DuL,Dul,Dul,ul ,
+        /*T*/ u  ,uL ,uL ,uL ,DuL,uL ,DuL,DUl,Dul,DuL,ul ,Dul,
+        /*C*/ u  ,uL ,DuL,uL ,uL ,uL ,DuL,Dul,DUl,Dul,L  ,ul ,
+        /*C*/ u  ,uL ,DuL,uL ,uL ,uL ,DuL,Dul,Dul,DUl,Dul,uL ,
+        /*C*/ u  ,uL ,DuL,uL ,uL ,uL ,DuL,Dul,Dul,Dul,ul ,Dul,
+        /*C*/ u  ,uL ,DuL,uL ,uL ,uL ,DuL,Dul,Dul,Dul,ul ,ul ,
+        /*C*/ u  ,uL ,DuL,uL ,uL ,uL ,DuL,Dul,Dul,Dul,ul ,ul
         }
     };
 }();
@@ -139,31 +161,35 @@ static auto dna4_03_semi_second = []()
         alignment_coordinate{column_index_type{18u}, row_index_type{5u}},
         std::vector
         {
-        //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
-        /*e*/  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16,
-        /*A*/  1,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,
-        /*C*/  2,  1,  1,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
-        /*G*/  3,  2,  2,  2,  2,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13,
-        /*T*/  4,  3,  3,  3,  3,  3,  3,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12,
-        /*A*/  5,  4,  3,  4,  4,  4,  4,  4,  4,  4,  5,  6,  7,  8,  9, 10, 11,
-        /*C*/  6,  5,  4,  3,  4,  5,  5,  5,  5,  5,  5,  5,  6,  7,  8,  9, 10,
-        /*G*/  7,  6,  5,  4,  4,  4,  5,  6,  6,  6,  6,  6,  6,  6,  7,  8,  9,
-        /*T*/  8,  7,  6,  5,  5,  5,  5,  5,  6,  7,  7,  7,  7,  7,  7,  7,  8,
-        /*A*/  9,  8,  7,  6,  6,  6,  6,  6,  6,  6,  7,  8,  8,  8,  8,  8,  8
+        //      e,  T,  T,  T,  T,  T,  A,  C,  G,  T,  A,  T,  G,  T,  C,  C,  C,  C,  C
+        /*e*/ 0  ,-11,-12,-13,-14,-15,-16,-17,-18,-19,-20,-21,-22,-23,-24,-25,-26,-27,-28,
+        /*A*/ 0  ,-5 ,-12,-13,-14,-15,-11,-17,-18,-19,-15,-21,-22,-23,-24,-25,-26,-27,-28,
+        /*C*/ 0  ,-5 ,-10,-13,-14,-15,-16,-7 ,-18,-19,-20,-20,-22,-23,-19,-20,-21,-22,-23,
+        /*G*/ 0  ,-5 ,-10,-13,-14,-15,-16,-17,-3 ,-14,-15,-16,-16,-18,-19,-20,-21,-22,-23,
+        /*T*/ 0  ,4  ,-1 ,-6 ,-9 ,-10,-11,-12,-13,1  ,-10,-11,-12,-12,-14,-15,-16,-17,-18,
+        /*A*/ 0  ,-5 ,-1 ,-6 ,-11,-14,-6 ,-16,-15,-10,5  ,-6 ,-7 ,-8 ,-9 ,-10,-11,-12,-13,
+        /*A*/ 0  ,-5 ,-10,-6 ,-11,-15,-10,-11,-16,-11,-6 ,0  ,-11,-12,-13,-14,-15,-16,-17,
+        /*A*/ 0  ,-5 ,-10,-13,-11,-15,-11,-15,-16,-12,-7 ,-11,-5 ,-16,-17,-18,-19,-20,-21,
+        /*A*/ 0  ,-5 ,-10,-13,-14,-15,-11,-16,-18,-13,-8 ,-12,-16,-10,-21,-22,-23,-24,-25,
+        /*C*/ 0  ,-5 ,-10,-13,-14,-15,-16,-7 ,-18,-14,-9 ,-13,-17,-21,-6 ,-17,-18,-19,-20,
+        /*G*/ 0  ,-5 ,-10,-13,-14,-15,-16,-17,-3 ,-14,-10,-14,-9 ,-18,-17,-11,-21,-22,-23,
+        /*T*/ 0  ,4  ,-1 ,-6 ,-9 ,-10,-11,-12,-13,1  ,-10,-6 ,-12,-5 ,-14,-15,-16,-17,-18
         },
         std::vector
         {
-        //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
-        /*e*/NON,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,
-        /*A*/U  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
-        /*C*/U  ,U  ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,L  ,L  ,
-        /*G*/U  ,U  ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,
-        /*T*/U  ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,
-        /*A*/U  ,DU ,D  ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
-        /*C*/U  ,U  ,U  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,
-        /*G*/U  ,U  ,U  ,U  ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,
-        /*T*/U  ,U  ,U  ,U  ,DU ,DU ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,
-        /*A*/U  ,DU ,DU ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D
+        //      e,  T,  T,  T,  T,  T,  A,  C,  G,  T,  A,  T,  G,  T,  C,  C,  C,  C,  C
+        /*e*/ N  ,L  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,
+        /*A*/ N  ,DUL,l  ,l  ,l  ,l  ,DUl,l  ,l  ,l  ,DUl,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,
+        /*C*/ N  ,DUL,DUl,l  ,l  ,l  ,l  ,DUl,l  ,l  ,l  ,DUl,l  ,l  ,DUl,DUl,DUl,DUl,DUl,
+        /*G*/ N  ,DUL,DUl,l  ,l  ,l  ,l  ,l  ,DUl,L  ,l  ,l  ,DUl,l  ,l  ,l  ,l  ,l  ,l  ,
+        /*T*/ N  ,DUL,DUL,DUl,DUl,DUl,l  ,l  ,l  ,DUl,L  ,DUl,l  ,DUl,l  ,l  ,l  ,l  ,l  ,
+        /*A*/ N  ,DUL,DUl,DUL,DUl,DUl,DUl,Dul,ul ,Ul ,DUl,L  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,
+        /*A*/ N  ,DuL,DUl,DUl,Dul,l  ,DUl,Dul,ul ,ul ,DUl,DUL,DUL,DUl,DUl,DUl,DUl,DUl,DUl,
+        /*A*/ N  ,DuL,Dul,l  ,Dul,l  ,Dul,Dul,Dul,ul ,Dul,DUL,Dul,DuL,Dul,Dul,Dul,Dul,Dul,
+        /*A*/ N  ,DuL,Dul,l  ,l  ,l  ,Dul,Dul,ul ,ul ,Dul,DuL,DUl,Dul,DuL,Dul,Dul,Dul,Dul,
+        /*C*/ N  ,DuL,Dul,l  ,l  ,l  ,l  ,Dul,l  ,ul ,ul ,DuL,Dul,DUl,Dul,DuL,Dul,Dul,Dul,
+        /*G*/ N  ,DuL,Dul,l  ,l  ,l  ,l  ,l  ,Dul,L  ,ul ,Dul,Dul,l  ,Ul ,Dul,l  ,l  ,l  ,
+        /*T*/ N  ,DuL,DuL,Dul,Dul,DUl,l  ,l  ,l  ,Dul,L  ,Dul,l  ,Dul,l  ,l  ,Dul,l  ,l
         }
     };
 }();
@@ -185,31 +211,49 @@ static auto dna4_04_semi_second = []()
         alignment_coordinate{column_index_type{11u}, row_index_type{13u}},
         std::vector
         {
-        //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
-        /*e*/  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16,
-        /*A*/  1,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,
-        /*C*/  2,  1,  1,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
-        /*G*/  3,  2,  2,  2,  2,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13,
-        /*T*/  4,  3,  3,  3,  3,  3,  3,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12,
-        /*A*/  5,  4,  3,  4,  4,  4,  4,  4,  4,  4,  5,  6,  7,  8,  9, 10, 11,
-        /*C*/  6,  5,  4,  3,  4,  5,  5,  5,  5,  5,  5,  5,  6,  7,  8,  9, 10,
-        /*G*/  7,  6,  5,  4,  4,  4,  5,  6,  6,  6,  6,  6,  6,  6,  7,  8,  9,
-        /*T*/  8,  7,  6,  5,  5,  5,  5,  5,  6,  7,  7,  7,  7,  7,  7,  7,  8,
-        /*A*/  9,  8,  7,  6,  6,  6,  6,  6,  6,  6,  7,  8,  8,  8,  8,  8,  8
+        //      e,  A,  C,  G,  T,  A,  A,  A,  A,  C,  G,  T
+        /*e*/ 0  ,-11,-12,-13,-14,-15,-16,-17,-18,-19,-20,-21,
+        /*T*/ 0  ,-5 ,-12,-13,-9 ,-15,-16,-17,-18,-19,-20,-16,
+        /*T*/ 0  ,-5 ,-10,-13,-9 ,-14,-16,-17,-18,-19,-20,-16,
+        /*T*/ 0  ,-5 ,-10,-13,-9 ,-14,-16,-17,-18,-19,-20,-16,
+        /*T*/ 0  ,-5 ,-10,-13,-9 ,-14,-16,-17,-18,-19,-20,-16,
+        /*T*/ 0  ,-5 ,-10,-13,-9 ,-14,-16,-17,-18,-19,-20,-16,
+        /*A*/ 0  ,4  ,-7 ,-8 ,-9 ,-5 ,-10,-12,-13,-14,-15,-16,
+        /*C*/ 0  ,-5 ,8  ,-3 ,-4 ,-5 ,-6 ,-7 ,-8 ,-9 ,-10,-11,
+        /*G*/ 0  ,-5 ,-3 ,12 ,1  ,0  ,-1 ,-2 ,-3 ,-4 ,-5 ,-6 ,
+        /*T*/ 0  ,-5 ,-4 ,1  ,16 ,5  ,4  ,3  ,2  ,1  ,0  ,-1 ,
+        /*A*/ 0  ,4  ,-5 ,0  ,5  ,20 ,9  ,8  ,7  ,6  ,5  ,4  ,
+        /*T*/ 0  ,-5 ,-1 ,-1 ,4  ,9  ,15 ,4  ,3  ,2  ,1  ,9  ,
+        /*G*/ 0  ,-5 ,-7 ,3  ,3  ,8  ,4  ,10 ,-1 ,-2 ,6  ,-2 ,
+        /*T*/ 0  ,-5 ,-8 ,-3 ,7  ,7  ,3  ,-1 ,5  ,-6 ,-5 ,10 ,
+        /*C*/ 0  ,-5 ,-1 ,-4 ,1  ,6  ,2  ,-2 ,-6 ,9  ,-2 ,-1 ,
+        /*C*/ 0  ,-5 ,-1 ,-5 ,0  ,5  ,1  ,-3 ,-7 ,-2 ,4  ,-2 ,
+        /*C*/ 0  ,-5 ,-1 ,-6 ,-1 ,4  ,0  ,-4 ,-8 ,-3 ,-7 ,-1 ,
+        /*C*/ 0  ,-5 ,-1 ,-6 ,-2 ,3  ,-1 ,-5 ,-9 ,-4 ,-8 ,-4 ,
+        /*C*/ 0  ,-5 ,-1 ,-6 ,-3 ,2  ,-2 ,-6 ,-10,-5 ,-9 ,-5 ,
         },
         std::vector
         {
-        //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
-        /*e*/NON,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,L  ,
-        /*A*/U  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
-        /*C*/U  ,U  ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,L  ,L  ,
-        /*G*/U  ,U  ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,L  ,L  ,
-        /*T*/U  ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,DL ,DL ,
-        /*A*/U  ,DU ,D  ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,L  ,L  ,
-        /*C*/U  ,U  ,U  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,L  ,L  ,
-        /*G*/U  ,U  ,U  ,U  ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,L  ,L  ,
-        /*T*/U  ,U  ,U  ,U  ,DU ,DU ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,DL ,
-        /*A*/U  ,DU ,DU ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,DL ,DUL,DU ,DU ,DU ,DU ,D
+        //      e,  A,  C,  G,  T,  A,  A,  A,  A,  C,  G,  T
+        /*e*/ N  ,L  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,
+        /*T*/ N  ,DUL,l  ,l  ,DUl,l  ,l  ,l  ,l  ,l  ,l  ,DUl,
+        /*T*/ N  ,DUL,DUl,l  ,DUl,DUl,l  ,l  ,l  ,l  ,l  ,DUl,
+        /*T*/ N  ,DUL,DUl,l  ,DUl,DUl,l  ,l  ,l  ,l  ,l  ,DUl,
+        /*T*/ N  ,DUL,DUl,l  ,DUl,DUl,l  ,l  ,l  ,l  ,l  ,DUl,
+        /*T*/ N  ,DUL,DUl,l  ,DUl,DUl,l  ,l  ,l  ,l  ,l  ,DUl,
+        /*A*/ N  ,DUL,L  ,l  ,l  ,DUl,DUl,DUl,DUl,l  ,l  ,l  ,
+        /*C*/ N  ,DUL,DUl,L  ,l  ,l  ,l  ,l  ,l  ,DUl,l  ,l  ,
+        /*G*/ N  ,DuL,Ul ,DUl,L  ,l  ,l  ,l  ,l  ,l  ,DUl,l  ,
+        /*T*/ N  ,DuL,ul ,Ul ,DUL,L  ,l  ,l  ,l  ,l  ,l  ,DUl,
+        /*A*/ N  ,DuL,uL ,ul ,Ul ,DUL,DUL,DUl,DUl,l  ,l  ,l  ,
+        /*T*/ N  ,DUL,Dul,uL ,DuL,UL ,DUL,DUL,DUl,DUl,DUl,DUl,
+        /*G*/ N  ,DuL,ul ,Dul,uL ,uL ,DUL,Dul,DuL,Dul,Dul,Ul ,
+        /*T*/ N  ,DuL,ul ,ul ,Dul,uL ,DuL,DUl,Dul,DuL,Ul ,Dul,
+        /*C*/ N  ,DuL,Dul,uL ,ul ,uL ,DuL,Dul,DUl,Dul,L  ,Ul ,
+        /*C*/ N  ,DuL,Dul,uL ,ul ,uL ,DuL,Dul,Dul,DUl,Dul,uL ,
+        /*C*/ N  ,DuL,Dul,DuL,ul ,uL ,DuL,Dul,Dul,Dul,DUl,Dul,
+        /*C*/ N  ,DuL,Dul,DuL,ul ,uL ,DuL,Dul,Dul,Dul,Dul,ul ,
+        /*C*/ N  ,DuL,DUl,DuL,ul ,ul ,DuL,Dul,Dul,Dul,Dul,ul ,
         }
     };
 }();

--- a/test/unit/alignment/pairwise/fixture/semi_global_edit_distance_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/semi_global_edit_distance_unbanded.hpp
@@ -56,16 +56,16 @@ static auto dna4_01 = []()
         std::vector
         {
         //     e,  A,  A,  C,  C,  G,  G,  T,  T,  A,  A,  C,  C,  G,  G,  T,  T
-        /*e*/NON,NON,NON,NON,NON,NON,NON,NON,NON,NON,NON,NON,NON,NON,NON,NON,NON,
-        /*A*/U  ,D  ,D  ,DUL,DU ,DU ,DU ,DU ,DU ,D  ,D  ,DUL,DU ,DU ,DU ,DU ,DU ,
-        /*C*/U  ,U  ,DU ,D  ,DL ,DUL,DU ,DU ,DU ,U  ,DU ,D  ,DL ,DUL,DU ,DU ,DU ,
-        /*G*/U  ,U  ,DU ,U  ,D  ,D  ,DL ,DUL,DU ,U  ,DU ,U  ,D  ,D  ,DL ,DUL,DU ,
-        /*T*/U  ,U  ,DU ,U  ,DU ,DU ,D  ,D  ,DL ,U  ,DU ,U  ,DU ,DU ,D  ,D  ,DL ,
-        /*A*/U  ,DU ,D  ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,D  ,U  ,DU ,DU ,DU ,DU ,D  ,
-        /*C*/U  ,U  ,U  ,D  ,D  ,DUL,DU ,DU ,DU ,DU ,DU ,D  ,D  ,DUL,DU ,DU ,DU ,
-        /*G*/U  ,U  ,U  ,U  ,DU ,D  ,DL ,DUL,DU ,DU ,DU ,U  ,DU ,D  ,DL ,DUL,DU ,
-        /*T*/U  ,U  ,U  ,U  ,DU ,U  ,D  ,D  ,DL ,DUL,DU ,U  ,DU ,U  ,D  ,D  ,DL ,
-        /*A*/U  ,DU ,DU ,U  ,DU ,U  ,DU ,DU ,D  ,D  ,DL ,U  ,DU ,U  ,DU ,DU ,D
+        /*e*/N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,
+        /*A*/u  ,D  ,D  ,Dul,Du ,Du ,Du ,Du ,Du ,D  ,D  ,Dul,Du ,Du ,Du ,Du ,Du ,
+        /*C*/u  ,u  ,Du ,D  ,Dl ,Dul,Du ,Du ,Du ,u  ,Du ,D  ,Dl ,Dul,Du ,Du ,Du ,
+        /*G*/u  ,u  ,Du ,u  ,D  ,D  ,Dl ,Dul,Du ,u  ,Du ,u  ,D  ,D  ,Dl ,Dul,Du ,
+        /*T*/u  ,u  ,Du ,u  ,Du ,Du ,D  ,D  ,Dl ,u  ,Du ,u  ,Du ,Du ,D  ,D  ,Dl ,
+        /*A*/u  ,Du ,D  ,u  ,Du ,Du ,Du ,Du ,D  ,D  ,D  ,u  ,Du ,Du ,Du ,Du ,D  ,
+        /*C*/u  ,u  ,u  ,D  ,D  ,Dul,Du ,Du ,Du ,Du ,Du ,D  ,D  ,Dul,Du ,Du ,Du ,
+        /*G*/u  ,u  ,u  ,u  ,Du ,D  ,Dl ,Dul,Du ,Du ,Du ,u  ,Du ,D  ,Dl ,Dul,Du ,
+        /*T*/u  ,u  ,u  ,u  ,Du ,u  ,D  ,D  ,Dl ,Dul,Du ,u  ,Du ,u  ,D  ,D  ,Dl ,
+        /*A*/u  ,Du ,Du ,u  ,Du ,u  ,Du ,Du ,D  ,D  ,Dl ,u  ,Du ,u  ,Du ,Du ,D
         }
     };
 }();
@@ -111,23 +111,23 @@ static auto dna4_01T = []()
         std::vector
         {
         //     e,  A,  C,  G,  T,  A,  C,  G,  T,  A
-        /*e*/NON,NON,NON,NON,NON,NON,NON,NON,NON,NON,
-        /*A*/U  ,D  ,DUL,DU ,DU ,D  ,DUL,DU ,DU ,D  ,
-        /*A*/U  ,DU ,D  ,DUL,DU ,DU ,D  ,DUL,DU ,DU ,
-        /*C*/U  ,U  ,D  ,DL ,DUL,U  ,D  ,DL ,DUL,U  ,
-        /*C*/U  ,U  ,DU ,D  ,DL ,U  ,DU ,D  ,DL ,U  ,
-        /*G*/U  ,U  ,U  ,D  ,DL ,DUL,U  ,D  ,DL ,DUL,
-        /*G*/U  ,U  ,U  ,DU ,D  ,DL ,U  ,DU ,D  ,DL ,
-        /*T*/U  ,U  ,U  ,U  ,D  ,DL ,DUL,U  ,D  ,DL ,
-        /*T*/U  ,U  ,U  ,U  ,DU ,D  ,DL ,U  ,DU ,D  ,
-        /*A*/U  ,DU ,U  ,U  ,U  ,D  ,DL ,DUL,U  ,D  ,
-        /*A*/U  ,DU ,U  ,U  ,U  ,DU ,D  ,DL ,U  ,DU ,
-        /*C*/U  ,U  ,DU ,U  ,U  ,U  ,D  ,DL ,DUL,U  ,
-        /*C*/U  ,U  ,DU ,U  ,U  ,U  ,DU ,D  ,DL ,U  ,
-        /*G*/U  ,U  ,U  ,DU ,U  ,U  ,U  ,D  ,DL ,DUL,
-        /*G*/U  ,U  ,U  ,DU ,U  ,U  ,U  ,DU ,D  ,DL ,
-        /*T*/U  ,U  ,U  ,U  ,DU ,U  ,U  ,U  ,D  ,DL ,
-        /*T*/U  ,U  ,U  ,U  ,DU ,U  ,U  ,U  ,DU ,D
+        /*e*/N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,
+        /*A*/u  ,D  ,Dul,Du ,Du ,D  ,Dul,Du ,Du ,D  ,
+        /*A*/u  ,Du ,D  ,Dul,Du ,Du ,D  ,Dul,Du ,Du ,
+        /*C*/u  ,u  ,D  ,Dl ,Dul,u  ,D  ,Dl ,Dul,u  ,
+        /*C*/u  ,u  ,Du ,D  ,Dl ,u  ,Du ,D  ,Dl ,u  ,
+        /*G*/u  ,u  ,u  ,D  ,Dl ,Dul,u  ,D  ,Dl ,Dul,
+        /*G*/u  ,u  ,u  ,Du ,D  ,Dl ,u  ,Du ,D  ,Dl ,
+        /*T*/u  ,u  ,u  ,u  ,D  ,Dl ,Dul,u  ,D  ,Dl ,
+        /*T*/u  ,u  ,u  ,u  ,Du ,D  ,Dl ,u  ,Du ,D  ,
+        /*A*/u  ,Du ,u  ,u  ,u  ,D  ,Dl ,Dul,u  ,D  ,
+        /*A*/u  ,Du ,u  ,u  ,u  ,Du ,D  ,Dl ,u  ,Du ,
+        /*C*/u  ,u  ,Du ,u  ,u  ,u  ,D  ,Dl ,Dul,u  ,
+        /*C*/u  ,u  ,Du ,u  ,u  ,u  ,Du ,D  ,Dl ,u  ,
+        /*G*/u  ,u  ,u  ,Du ,u  ,u  ,u  ,D  ,Dl ,Dul,
+        /*G*/u  ,u  ,u  ,Du ,u  ,u  ,u  ,Du ,D  ,Dl ,
+        /*T*/u  ,u  ,u  ,u  ,Du ,u  ,u  ,u  ,D  ,Dl ,
+        /*T*/u  ,u  ,u  ,u  ,Du ,u  ,u  ,u  ,Du ,D
         }
     };
 }();
@@ -166,16 +166,16 @@ static auto dna4_02 = []()
         std::vector
         {
         //     e,  A,  A,  C,  C,  G,  G,  T,  A,  A,  A,  C,  C,  G,  G,  T,  T,
-        /*e*/NON,NON,NON,NON,NON,NON,NON,NON,NON,NON,NON,NON,NON,NON,NON,NON,NON,
-        /*A*/U  ,D  ,D  ,DUL,DU ,DU ,DU ,DU ,D  ,D  ,D  ,DUL,DU ,DU ,DU ,DU ,DU ,
-        /*C*/U  ,U  ,DU ,D  ,DL ,DUL,DU ,DU ,U  ,DU ,DU ,D  ,DL ,DUL,DU ,DU ,DU ,
-        /*G*/U  ,U  ,DU ,U  ,D  ,D  ,DL ,DUL,U  ,DU ,DU ,U  ,D  ,D  ,DL ,DUL,DU ,
-        /*T*/U  ,U  ,DU ,U  ,DU ,DU ,D  ,D  ,UL ,DU ,DU ,U  ,DU ,DU ,D  ,D  ,DL ,
-        /*A*/U  ,DU ,D  ,U  ,DU ,DU ,DU ,DU ,D  ,DL ,D  ,U  ,DU ,DU ,DU ,DU ,D  ,
-        /*C*/U  ,U  ,U  ,D  ,D  ,DUL,DU ,DU ,U  ,D  ,DUL,D  ,D  ,DUL,DU ,DU ,DU ,
-        /*G*/U  ,U  ,U  ,U  ,DU ,D  ,DL ,DUL,U  ,DU ,D  ,U  ,DU ,D  ,DL ,DUL,DU ,
-        /*T*/U  ,U  ,U  ,U  ,DU ,U  ,D  ,D  ,UL ,DU ,DU ,DU ,DU ,U  ,D  ,D  ,DL ,
-        /*A*/U  ,DU ,DU ,U  ,DU ,U  ,DU ,DU ,D  ,DL ,D  ,DUL,DU ,U  ,DU ,DU ,D
+        /*e*/N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,
+        /*A*/u  ,D  ,D  ,Dul,Du ,Du ,Du ,Du ,D  ,D  ,D  ,Dul,Du ,Du ,Du ,Du ,Du ,
+        /*C*/u  ,u  ,Du ,D  ,Dl ,Dul,Du ,Du ,u  ,Du ,Du ,D  ,Dl ,Dul,Du ,Du ,Du ,
+        /*G*/u  ,u  ,Du ,u  ,D  ,D  ,Dl ,Dul,u  ,Du ,Du ,u  ,D  ,D  ,Dl ,Dul,Du ,
+        /*T*/u  ,u  ,Du ,u  ,Du ,Du ,D  ,D  ,ul ,Du ,Du ,u  ,Du ,Du ,D  ,D  ,Dl ,
+        /*A*/u  ,Du ,D  ,u  ,Du ,Du ,Du ,Du ,D  ,Dl ,D  ,u  ,Du ,Du ,Du ,Du ,D  ,
+        /*C*/u  ,u  ,u  ,D  ,D  ,Dul,Du ,Du ,u  ,D  ,Dul,D  ,D  ,Dul,Du ,Du ,Du ,
+        /*G*/u  ,u  ,u  ,u  ,Du ,D  ,Dl ,Dul,u  ,Du ,D  ,u  ,Du ,D  ,Dl ,Dul,Du ,
+        /*T*/u  ,u  ,u  ,u  ,Du ,u  ,D  ,D  ,ul ,Du ,Du ,Du ,Du ,u  ,D  ,D  ,Dl ,
+        /*A*/u  ,Du ,Du ,u  ,Du ,u  ,Du ,Du ,D  ,Dl ,D  ,Dul,Du ,u  ,Du ,Du ,D
         }
     };
 }();
@@ -278,7 +278,7 @@ static auto dna4_03 = []()
         alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
         alignment_coordinate{column_index_type{0u}, row_index_type{0u}},
         std::vector<int>{0},
-        std::vector<detail::trace_directions>{NON}
+        std::vector<detail::trace_directions>{N}
     };
 }();
 
@@ -316,16 +316,16 @@ static auto aa27_01 = []()
         std::vector
         {
         //     e,  U,  U,  W,  W,  R,  R,  I,  I,  U,  U,  W,  W,  R,  R,  I,  I
-        /*e*/NON,NON,NON,NON,NON,NON,NON,NON,NON,NON,NON,NON,NON,NON,NON,NON,NON,
-        /*U*/U  ,D  ,D  ,DUL,DU ,DU ,DU ,DU ,DU ,D  ,D  ,DUL,DU ,DU ,DU ,DU ,DU ,
-        /*W*/U  ,U  ,DU ,D  ,DL ,DUL,DU ,DU ,DU ,U  ,DU ,D  ,DL ,DUL,DU ,DU ,DU ,
-        /*R*/U  ,U  ,DU ,U  ,D  ,D  ,DL ,DUL,DU ,U  ,DU ,U  ,D  ,D  ,DL ,DUL,DU ,
-        /*I*/U  ,U  ,DU ,U  ,DU ,DU ,D  ,D  ,DL ,U  ,DU ,U  ,DU ,DU ,D  ,D  ,DL ,
-        /*U*/U  ,DU ,D  ,U  ,DU ,DU ,DU ,DU ,D  ,D  ,D  ,U  ,DU ,DU ,DU ,DU ,D  ,
-        /*W*/U  ,U  ,U  ,D  ,D  ,DUL,DU ,DU ,DU ,DU ,DU ,D  ,D  ,DUL,DU ,DU ,DU ,
-        /*R*/U  ,U  ,U  ,U  ,DU ,D  ,DL ,DUL,DU ,DU ,DU ,U  ,DU ,D  ,DL ,DUL,DU ,
-        /*I*/U  ,U  ,U  ,U  ,DU ,U  ,D  ,D  ,DL ,DUL,DU ,U  ,DU ,U  ,D  ,D  ,DL ,
-        /*U*/U  ,DU ,DU ,U  ,DU ,U  ,DU ,DU ,D  ,D  ,DL ,U  ,DU ,U  ,DU ,DU ,D
+        /*e*/N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,
+        /*U*/u  ,D  ,D  ,Dul,Du ,Du ,Du ,Du ,Du ,D  ,D  ,Dul,Du ,Du ,Du ,Du ,Du ,
+        /*W*/u  ,u  ,Du ,D  ,Dl ,Dul,Du ,Du ,Du ,u  ,Du ,D  ,Dl ,Dul,Du ,Du ,Du ,
+        /*R*/u  ,u  ,Du ,u  ,D  ,D  ,Dl ,Dul,Du ,u  ,Du ,u  ,D  ,D  ,Dl ,Dul,Du ,
+        /*I*/u  ,u  ,Du ,u  ,Du ,Du ,D  ,D  ,Dl ,u  ,Du ,u  ,Du ,Du ,D  ,D  ,Dl ,
+        /*U*/u  ,Du ,D  ,u  ,Du ,Du ,Du ,Du ,D  ,D  ,D  ,u  ,Du ,Du ,Du ,Du ,D  ,
+        /*W*/u  ,u  ,u  ,D  ,D  ,Dul,Du ,Du ,Du ,Du ,Du ,D  ,D  ,Dul,Du ,Du ,Du ,
+        /*R*/u  ,u  ,u  ,u  ,Du ,D  ,Dl ,Dul,Du ,Du ,Du ,u  ,Du ,D  ,Dl ,Dul,Du ,
+        /*I*/u  ,u  ,u  ,u  ,Du ,u  ,D  ,D  ,Dl ,Dul,Du ,u  ,Du ,u  ,D  ,D  ,Dl ,
+        /*U*/u  ,Du ,Du ,u  ,Du ,u  ,Du ,Du ,D  ,D  ,Dl ,u  ,Du ,u  ,Du ,Du ,D
         }
     };
 }();
@@ -371,23 +371,23 @@ static auto aa27_01T = []()
         std::vector
         {
         //     e,  U,  W,  R,  I,  U,  W,  R,  I,  U
-        /*e*/NON,NON,NON,NON,NON,NON,NON,NON,NON,NON,
-        /*U*/U  ,D  ,DUL,DU ,DU ,D  ,DUL,DU ,DU ,D  ,
-        /*U*/U  ,DU ,D  ,DUL,DU ,DU ,D  ,DUL,DU ,DU ,
-        /*W*/U  ,U  ,D  ,DL ,DUL,U  ,D  ,DL ,DUL,U  ,
-        /*W*/U  ,U  ,DU ,D  ,DL ,U  ,DU ,D  ,DL ,U  ,
-        /*R*/U  ,U  ,U  ,D  ,DL ,DUL,U  ,D  ,DL ,DUL,
-        /*R*/U  ,U  ,U  ,DU ,D  ,DL ,U  ,DU ,D  ,DL ,
-        /*I*/U  ,U  ,U  ,U  ,D  ,DL ,DUL,U  ,D  ,DL ,
-        /*I*/U  ,U  ,U  ,U  ,DU ,D  ,DL ,U  ,DU ,D  ,
-        /*U*/U  ,DU ,U  ,U  ,U  ,D  ,DL ,DUL,U  ,D  ,
-        /*U*/U  ,DU ,U  ,U  ,U  ,DU ,D  ,DL ,U  ,DU ,
-        /*W*/U  ,U  ,DU ,U  ,U  ,U  ,D  ,DL ,DUL,U  ,
-        /*W*/U  ,U  ,DU ,U  ,U  ,U  ,DU ,D  ,DL ,U  ,
-        /*R*/U  ,U  ,U  ,DU ,U  ,U  ,U  ,D  ,DL ,DUL,
-        /*R*/U  ,U  ,U  ,DU ,U  ,U  ,U  ,DU ,D  ,DL ,
-        /*I*/U  ,U  ,U  ,U  ,DU ,U  ,U  ,U  ,D  ,DL ,
-        /*I*/U  ,U  ,U  ,U  ,DU ,U  ,U  ,U  ,DU ,D
+        /*e*/N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,
+        /*U*/u  ,D  ,Dul,Du ,Du ,D  ,Dul,Du ,Du ,D  ,
+        /*U*/u  ,Du ,D  ,Dul,Du ,Du ,D  ,Dul,Du ,Du ,
+        /*W*/u  ,u  ,D  ,Dl ,Dul,u  ,D  ,Dl ,Dul,u  ,
+        /*W*/u  ,u  ,Du ,D  ,Dl ,u  ,Du ,D  ,Dl ,u  ,
+        /*R*/u  ,u  ,u  ,D  ,Dl ,Dul,u  ,D  ,Dl ,Dul,
+        /*R*/u  ,u  ,u  ,Du ,D  ,Dl ,u  ,Du ,D  ,Dl ,
+        /*I*/u  ,u  ,u  ,u  ,D  ,Dl ,Dul,u  ,D  ,Dl ,
+        /*I*/u  ,u  ,u  ,u  ,Du ,D  ,Dl ,u  ,Du ,D  ,
+        /*U*/u  ,Du ,u  ,u  ,u  ,D  ,Dl ,Dul,u  ,D  ,
+        /*U*/u  ,Du ,u  ,u  ,u  ,Du ,D  ,Dl ,u  ,Du ,
+        /*W*/u  ,u  ,Du ,u  ,u  ,u  ,D  ,Dl ,Dul,u  ,
+        /*W*/u  ,u  ,Du ,u  ,u  ,u  ,Du ,D  ,Dl ,u  ,
+        /*R*/u  ,u  ,u  ,Du ,u  ,u  ,u  ,D  ,Dl ,Dul,
+        /*R*/u  ,u  ,u  ,Du ,u  ,u  ,u  ,Du ,D  ,Dl ,
+        /*I*/u  ,u  ,u  ,u  ,Du ,u  ,u  ,u  ,D  ,Dl ,
+        /*I*/u  ,u  ,u  ,u  ,Du ,u  ,u  ,u  ,Du ,D
         }
     };
 }();

--- a/test/unit/alignment/pairwise/pairwise_alignment_single_test_template.hpp
+++ b/test/unit/alignment/pairwise/pairwise_alignment_single_test_template.hpp
@@ -37,7 +37,7 @@ TYPED_TEST_CASE_P(pairwise_alignment_test);
 TYPED_TEST_P(pairwise_alignment_test, score)
 {
     auto const & fixture = this->fixture();
-    configuration align_cfg = fixture.config | align_cfg::result{with_score};
+    configuration align_cfg = fixture.config | align_cfg::result{with_score} | align_cfg::debug;
 
     std::vector database = fixture.sequence1;
     std::vector query = fixture.sequence2;
@@ -51,7 +51,7 @@ TYPED_TEST_P(pairwise_alignment_test, score)
 TYPED_TEST_P(pairwise_alignment_test, back_coordinate)
 {
     auto const & fixture = this->fixture();
-    configuration align_cfg = fixture.config | align_cfg::result{with_back_coordinate};
+    configuration align_cfg = fixture.config | align_cfg::result{with_back_coordinate} | align_cfg::debug;
 
     std::vector database = fixture.sequence1;
     std::vector query = fixture.sequence2;
@@ -66,7 +66,7 @@ TYPED_TEST_P(pairwise_alignment_test, back_coordinate)
 TYPED_TEST_P(pairwise_alignment_test, front_coordinate)
 {
     auto const & fixture = this->fixture();
-    configuration align_cfg = fixture.config | align_cfg::result{with_front_coordinate};
+    configuration align_cfg = fixture.config | align_cfg::result{with_front_coordinate} | align_cfg::debug;
 
     std::vector database = fixture.sequence1;
     std::vector query = fixture.sequence2;
@@ -82,7 +82,7 @@ TYPED_TEST_P(pairwise_alignment_test, front_coordinate)
 TYPED_TEST_P(pairwise_alignment_test, alignment)
 {
     auto const & fixture = this->fixture();
-    configuration align_cfg = fixture.config | align_cfg::result{with_alignment};
+    configuration align_cfg = fixture.config | align_cfg::result{with_alignment} | align_cfg::debug;
 
     std::vector database = fixture.sequence1;
     std::vector query = fixture.sequence2;
@@ -95,10 +95,14 @@ TYPED_TEST_P(pairwise_alignment_test, alignment)
     EXPECT_EQ(res.front_coordinate(), fixture.front_coordinate);
 
     auto && [gapped_database, gapped_query] = res.alignment();
-    EXPECT_EQ(gapped_database | views::to_char | views::to<decltype(fixture.aligned_sequence1)>,
-              fixture.aligned_sequence1);
-    EXPECT_EQ(gapped_query    | views::to_char | views::to<decltype(fixture.aligned_sequence2)>,
-              fixture.aligned_sequence2);
+    EXPECT_EQ(gapped_database | views::to_char | views::to<std::string>, fixture.aligned_sequence1);
+    EXPECT_EQ(gapped_query | views::to_char | views::to<std::string>, fixture.aligned_sequence2);
+
+    using score_matrix_t = detail::two_dimensional_matrix<std::optional<int32_t>>;
+    using trace_matrix_t = detail::two_dimensional_matrix<std::optional<trace_directions>>;
+
+    EXPECT_TRUE(std::ranges::equal(static_cast<score_matrix_t>(res.score_matrix()), fixture.score_vector));
+    EXPECT_TRUE(std::ranges::equal(static_cast<trace_matrix_t>(res.trace_matrix()), fixture.trace_vector));
 }
 
 REGISTER_TYPED_TEST_CASE_P(pairwise_alignment_test,


### PR DESCRIPTION
Adds tests for evaluating the alignment matrices of the standard pairwise alignment algorithm.
Depends on #1289.  

It general adds only one functionality, that is the conversion of a column based 2d matrix to a row based 2d matrix. Then it adds for each alignment test the true score and trace matrix. It also changes the order of the trace_directions short cuts to reflect the order that is outputted by the debug matrix for trace matrices in ascii mode. This helps to test for the correct implementation.
