### PR TITLE
More alphabet cleanup

### DIFF
--- a/include/seqan3/alphabet/cigar/cigar.hpp
+++ b/include/seqan3/alphabet/cigar/cigar.hpp
@@ -93,12 +93,6 @@ public:
 
     // Inherit operators from base
     using base_t::operator=;
-    using base_t::operator==;
-    using base_t::operator!=;
-    using base_t::operator>=;
-    using base_t::operator<=;
-    using base_t::operator<;
-    using base_t::operator>;
 
     /*!\name Read functions
      * \{

--- a/include/seqan3/alphabet/mask/masked.hpp
+++ b/include/seqan3/alphabet/mask/masked.hpp
@@ -81,12 +81,6 @@ public:
 
     // Inherit operators from base
     using base_type::operator=;
-    using base_type::operator==;
-    using base_type::operator!=;
-    using base_type::operator>=;
-    using base_type::operator<=;
-    using base_type::operator<;
-    using base_type::operator>;
 
     /*!\name Write functions
      * \{

--- a/include/seqan3/alphabet/quality/qualified.hpp
+++ b/include/seqan3/alphabet/quality/qualified.hpp
@@ -86,12 +86,6 @@ public:
 
     // Inherit operators from base
     using base_type::operator=;
-    using base_type::operator==;
-    using base_type::operator!=;
-    using base_type::operator>=;
-    using base_type::operator<=;
-    using base_type::operator<;
-    using base_type::operator>;
 
     //!\copydoc alphabet_tuple_base::alphabet_tuple_base(component_type const alph)
     SEQAN3_DOXYGEN_ONLY(( constexpr qualified(component_type const alph) noexcept {} ))

--- a/include/seqan3/alphabet/structure/structured_aa.hpp
+++ b/include/seqan3/alphabet/structure/structured_aa.hpp
@@ -90,12 +90,6 @@ public:
 
     // Inherit operators from base
     using base_type::operator=;
-    using base_type::operator==;
-    using base_type::operator!=;
-    using base_type::operator>=;
-    using base_type::operator<=;
-    using base_type::operator<;
-    using base_type::operator>;
 
     /*!\name Write functions
      * \{

--- a/include/seqan3/alphabet/structure/structured_rna.hpp
+++ b/include/seqan3/alphabet/structure/structured_rna.hpp
@@ -90,12 +90,6 @@ public:
 
     // Inherit operators from base
     using base_type::operator=;
-    using base_type::operator==;
-    using base_type::operator!=;
-    using base_type::operator>=;
-    using base_type::operator<=;
-    using base_type::operator<;
-    using base_type::operator>;
 
     //!\name Write functions
     //!\{

--- a/include/seqan3/core/concept/core_language.hpp
+++ b/include/seqan3/core/concept/core_language.hpp
@@ -35,48 +35,46 @@ SEQAN3_CONCEPT weakly_equality_comparable_with =
     requires(std::remove_reference_t<T> const & t,
              std::remove_reference_t<U> const & u)
     {
-        t == u ? 1 : 0;
-        t != u ? 1 : 0;
-        u == t ? 1 : 0;
-        u != t ? 1 : 0;
+        std::convertible_to<decltype(t == u), bool>;
+        std::convertible_to<decltype(t != u), bool>;
+        std::convertible_to<decltype(u == t), bool>;
+        std::convertible_to<decltype(u != t), bool>;
     };
 //!\endcond
 
-/*!\interface   seqan3::detail::weakly_equality_comparable_by_members_with <>
- * \brief       Like seqan3::detail::weakly_equality_comparable_with, but considers only member operators of the LHS.
+//!\brief Binary type trait that behaves like the seqan3::detail::weakly_equality_comparable_with concept.
+template <typename lhs_t, typename rhs_t>
+struct weakly_equality_comparable_with_trait :
+    std::integral_constant<bool, weakly_equality_comparable_with<lhs_t, rhs_t>>
+{};
+
+/*!\interface   seqan3::detail::weakly_ordered_with <>
+ * \tparam t1   The first type to compare.
+ * \tparam t2   The second type to compare.
+ * \brief       Requires the two operands to be comparable with `<`, `<=`, `>` and `>=` in both directions.
  */
 //!\cond
-template <typename lhs_t, typename rhs_t>
-SEQAN3_CONCEPT weakly_equality_comparable_by_members_with = requires (lhs_t const & lhs, rhs_t const & rhs)
+template <typename t1, typename t2>
+SEQAN3_CONCEPT weakly_ordered_with = requires (std::remove_reference_t<t1> const & v1,
+                                               std::remove_reference_t<t2> const & v2)
 {
-    lhs.operator==(rhs); std::boolean<decltype(lhs.operator==(rhs))>;
-    lhs.operator!=(rhs); std::boolean<decltype(lhs.operator!=(rhs))>;
-};
-//!\endcond
-/*!\interface   seqan3::detail::weakly_ordered_by_members_with <>
- * \brief       Like seqan3::weakly_ordered_with, but considers only member operators of the LHS.
- */
-//!\cond
-template <typename lhs_t, typename rhs_t>
-SEQAN3_CONCEPT weakly_ordered_by_members_with = requires (lhs_t const & lhs, rhs_t const & rhs)
-{
-    lhs.operator< (rhs); std::boolean<decltype(lhs.operator< (rhs))>;
-    lhs.operator> (rhs); std::boolean<decltype(lhs.operator> (rhs))>;
-    lhs.operator<=(rhs); std::boolean<decltype(lhs.operator<=(rhs))>;
-    lhs.operator>=(rhs); std::boolean<decltype(lhs.operator>=(rhs))>;
+    std::convertible_to<decltype(v1 <  v2), bool>;
+    std::convertible_to<decltype(v1 <= v2), bool>;
+    std::convertible_to<decltype(v1 >  v2), bool>;
+    std::convertible_to<decltype(v1 >= v2), bool>;
+
+    std::convertible_to<decltype(v2 <  v1), bool>;
+    std::convertible_to<decltype(v2 <= v1), bool>;
+    std::convertible_to<decltype(v2 >  v1), bool>;
+    std::convertible_to<decltype(v2 >= v1), bool>;
 };
 //!\endcond
 
-/*!\interface   seqan3::detail::convertible_to_by_member <>
- * \brief       Like seqan3::implicitly_convertible_to, but only considers member operators of the source type.
- */
-//!\cond
-template <typename source_t, typename target_t>
-SEQAN3_CONCEPT convertible_to_by_member = requires (source_t s)
-{
-    { s.operator target_t() } -> target_t;
-};
-//!\endcond
+//!\brief Binary type trait that behaves like the seqan3::detail::weakly_ordered_with concept.
+template <typename lhs_t, typename rhs_t>
+struct weakly_ordered_with_trait : std::integral_constant<bool, weakly_ordered_with<lhs_t, rhs_t>>
+{};
+
 //!\}
 
 } // seqan3::detail
@@ -87,24 +85,6 @@ namespace seqan3
 /*!\addtogroup concept
  * \{
  */
-
-/*!\interface   seqan3::weakly_ordered_with <>
- * \tparam t1   The first type to compare.
- * \tparam t2   The second type to compare.
- * \brief       Requires the two operands to be comparable with `==` and `!=` in both directions.
- * \sa          https://en.cppreference.com/w/cpp/experimental/ranges/concepts/weakly_equality_comparable_with
- */
-//!\cond
-template <typename t1, typename t2>
-SEQAN3_CONCEPT weakly_ordered_with = requires (std::remove_reference_t<t1> const & v1,
-                                             std::remove_reference_t<t2> const & v2)
-{
-    { v1 <  v2 } -> bool &&;
-    { v1 <= v2 } -> bool &&;
-    { v2 >  v1 } -> bool &&;
-    { v2 >= v1 } -> bool &&;
-};
-//!\endcond
 
 /*!\interface   seqan3::implicitly_convertible_to <>
  * \brief       Resolves to `std::ranges::implicitly_convertible_to<type1, type2>()`.

--- a/include/seqan3/core/detail/debug_stream_tuple.hpp
+++ b/include/seqan3/core/detail/debug_stream_tuple.hpp
@@ -31,8 +31,9 @@ namespace seqan3::detail
 template <typename char_t, typename tuple_t, std::size_t ...I>
 void print_tuple(debug_stream_type<char_t> & s, tuple_t && t, std::index_sequence<I...> const &)
 {
+    using std::get;
     s << '(';
-    ((s << (I == 0 ? "" : ",") << std::get<I>(t)), ...);
+    ((s << (I == 0 ? "" : ",") << get<I>(t)), ...);
     s << ')';
 }
 

--- a/include/seqan3/core/platform.hpp
+++ b/include/seqan3/core/platform.hpp
@@ -224,6 +224,15 @@
 #   endif
 #endif
 
+//!\brief Requires statements are not properly lazy evaluated.
+#ifndef SEQAN3_WORKAROUND_GCC_LAZY_REQUIRES
+#   if defined(__GNUC__) && (__GNUC__ <= 8)
+#       define SEQAN3_WORKAROUND_GCC_LAZY_REQUIRES 1
+#   else
+#       define SEQAN3_WORKAROUND_GCC_LAZY_REQUIRES 0
+#   endif
+#endif
+
 // ============================================================================
 //  Backmatter
 // ============================================================================

--- a/include/seqan3/core/type_traits/lazy.hpp
+++ b/include/seqan3/core/type_traits/lazy.hpp
@@ -72,6 +72,61 @@ template <typename t>
 using instantiate_t = typename instantiate<t>::type;
 
 // ----------------------------------------------------------------------------
+// instantiate_if
+// ----------------------------------------------------------------------------
+
+/*!\brief A transformation trait that instantiates seqan3::lazy types given a boolean condition.
+ *        Base template is std::false_type.
+ * \tparam t The type to operate on.
+ * \implements seqan3::transformation_trait
+ */
+template <typename t, bool condition>
+struct instantiate_if : std::false_type
+{};
+
+/*!\brief A transformation trait that instantiates seqan3::lazy types given a boolean condition.
+ *        If condition is true and parameter is not lazy, the type identity.
+ * \tparam t The type to operate on.
+ * \implements seqan3::transformation_trait
+ */
+template <typename t>
+struct instantiate_if<t, true> : std::type_identity<t>
+{};
+
+/*!\brief A transformation trait that instantiates seqan3::lazy types given a boolean condition.
+ *        If condition is true and parameter is lazy, the instantiated type.
+ * \tparam template_t The uninstantiated template.
+ * \tparam spec_t     The arguments to template_t.
+ * \implements seqan3::transformation_trait
+ */
+template <template <typename ...> typename template_t, typename ...spec_t>
+struct instantiate_if<lazy<template_t, spec_t...>, true>
+{
+    //!\brief Return type of the trait [instantiates the template arguments].
+    using type = template_t<spec_t...>;
+};
+
+/*!\brief A transformation trait that instantiates seqan3::lazy types, conditionally. Transformation trait shortcut.
+ * \tparam t The type to operate on.
+ * \relates seqan3::detail::instantiate_if
+ */
+template <typename t, bool condition>
+//!\cond
+    requires requires { typename instantiate_if<t, condition>::type; }
+//!\endcond
+using instantiate_if_t = typename instantiate_if<t, condition>::type;
+
+/*!\brief A transformation trait that instantiates seqan3::lazy types, conditionally. Type trait shortcut.
+ * \tparam t The type to operate on.
+ * \relates seqan3::detail::instantiate_if
+ */
+template <typename t, bool condition>
+//!\cond
+    requires requires { instantiate_if_t<t, condition>::value; }
+//!\endcond
+inline constexpr auto instantiate_if_v = instantiate_if_t<t, condition>::value;
+
+// ----------------------------------------------------------------------------
 // lazy_conditional
 // ----------------------------------------------------------------------------
 

--- a/include/seqan3/range/hash.hpp
+++ b/include/seqan3/range/hash.hpp
@@ -14,6 +14,8 @@
 
 #include <seqan3/alphabet/hash.hpp>
 #include <seqan3/core/type_traits/range.hpp>
+#include <seqan3/range/concept.hpp>
+#include <seqan3/std/ranges>
 
 namespace std
 {
@@ -23,22 +25,27 @@ namespace std
                   range must model seqan3::semialphabet.
  */
 template <ranges::input_range urng_t>
-    //!\cond
-    requires seqan3::semialphabet<seqan3::reference_t<urng_t>>
-    //!\endcond
+//!\cond
+    requires seqan3::semialphabet<std::ranges::range_reference_t<urng_t>>
+//!\endcond
 struct hash<urng_t>
 {
     /*!\brief Compute the hash for a range of characters.
+     * \tparam urng2_t  The same as `urng_t` (+- cvref); used to get forwarding reference in the interface.
      * \param[in] range The input range to process. Must model std::ranges::input_range and the reference type of the
                         range of the range must model seqan3::semialphabet.
      * \returns size_t.
      */
-    size_t operator()(urng_t const & range) const noexcept
+    template <ranges::input_range urng2_t>
+    //!\cond
+        requires seqan3::semialphabet<std::ranges::range_reference_t<urng2_t>>
+    //!\endcond
+    size_t operator()(urng2_t && range) const noexcept
     {
-        using alphabet_t = seqan3::value_type_t<urng_t>;
+        using alphabet_t = std::ranges::range_reference_t<urng_t>;
         size_t result{0};
         hash<alphabet_t> h{};
-        for (auto const character : range)
+        for (alphabet_t character : range)
         {
             result *= seqan3::alphabet_size<alphabet_t>;
             result += h(character);

--- a/include/seqan3/search/fm_index/fm_index_cursor.hpp
+++ b/include/seqan3/search/fm_index/fm_index_cursor.hpp
@@ -19,7 +19,7 @@
 
 #include <range/v3/view/slice.hpp>
 
-#include <seqan3/alphabet/all.hpp>
+#include <seqan3/alphabet/concept.hpp>
 #include <seqan3/core/type_traits/range.hpp>
 #include <seqan3/range/views/join.hpp>
 #include <seqan3/range/views/slice.hpp>

--- a/test/snippet/alphabet/composite/alphabet_variant_conversion.cpp
+++ b/test/snippet/alphabet/composite/alphabet_variant_conversion.cpp
@@ -7,4 +7,5 @@ int main()
     using seqan3::operator""_rna4;
 
     seqan3::alphabet_variant<seqan3::dna4, seqan3::gap> letter1{'C'_rna4};
+    seqan3::alphabet_variant<seqan3::dna4, seqan3::gap> letter2 = 'C'_rna4;
 }

--- a/test/snippet/alphabet/composite/alphabet_variant_conversion_explicit.cpp
+++ b/test/snippet/alphabet/composite/alphabet_variant_conversion_explicit.cpp
@@ -1,0 +1,13 @@
+#include <seqan3/alphabet/composite/alphabet_variant.hpp>
+#include <seqan3/alphabet/gap/gap.hpp>
+#include <seqan3/alphabet/nucleotide/all.hpp>
+
+int main()
+{
+    using seqan3::operator""_dna5;
+
+    // possible:
+    seqan3::alphabet_variant<seqan3::dna4, seqan3::gap> letter1{'C'_dna5};
+    // not possible:
+    // seqan3::alphabet_variant<seqan3::dna4, seqan3::gap> letter2 = 'C'_dna5;
+}

--- a/test/unit/alignment/aligned_sequence_test_template.hpp
+++ b/test/unit/alignment/aligned_sequence_test_template.hpp
@@ -17,32 +17,33 @@
 #include <seqan3/io/alignment_file/detail.hpp>
 #include <seqan3/std/iterator>
 
-using namespace seqan3;
-using seqan3::detail::to_string;
+using seqan3::operator""_dna4;
+
+using namespace seqan3; // necessary right now because assign_unaligned is falsely a hidden friend
 
 template <typename T>
 class aligned_sequence_ : public ::testing::Test
 {};
 
-dna4_vector const seq = "ACTA"_dna4;
+seqan3::dna4_vector const seq = "ACTA"_dna4;
 
 TYPED_TEST_CASE_P(aligned_sequence_);
 
 TYPED_TEST_P(aligned_sequence_, fulfills_concept)
 {
-    EXPECT_TRUE((aligned_sequence<TypeParam>));
-    EXPECT_FALSE((aligned_sequence<std::vector<dna4>>));
+    EXPECT_TRUE((seqan3::aligned_sequence<TypeParam>));
+    EXPECT_FALSE((seqan3::aligned_sequence<std::vector<seqan3::dna4>>));
 }
 
 TYPED_TEST_P(aligned_sequence_, assign_unaligned_sequence)
 {
-    using unaligned_seq_type = remove_cvref_t<detail::unaligned_seq_t<TypeParam>>;
+    using unaligned_seq_type = seqan3::remove_cvref_t<seqan3::detail::unaligned_seq_t<TypeParam>>;
     unaligned_seq_type unaligned_seq{};
 
-    if constexpr (sequence_container<unaligned_seq_type>)
+    if constexpr (seqan3::sequence_container<unaligned_seq_type>)
     {
         unaligned_seq.resize(seq.size());
-        std::copy(seq.begin(), seq.end(), begin(unaligned_seq));
+        std::copy(seq.begin(), seq.end(), std::ranges::begin(unaligned_seq));
     }
     else // type is view, happens for gap_decorator tests
         unaligned_seq = unaligned_seq_type{seq};
@@ -52,12 +53,12 @@ TYPED_TEST_P(aligned_sequence_, assign_unaligned_sequence)
     assign_unaligned(aligned_seq, unaligned_seq);
 
     EXPECT_EQ(aligned_seq.size(), unaligned_seq.size());
-    EXPECT_TRUE((ranges::equal(aligned_seq, unaligned_seq)));
+    EXPECT_TRUE((std::ranges::equal(aligned_seq, unaligned_seq)));
 }
 
 TYPED_TEST_P(aligned_sequence_, assign_empty_unaligned_sequence)
 {
-    using unaligned_seq_type = remove_cvref_t<detail::unaligned_seq_t<TypeParam>>;
+    using unaligned_seq_type = seqan3::remove_cvref_t<seqan3::detail::unaligned_seq_t<TypeParam>>;
     unaligned_seq_type unaligned_seq{};
     TypeParam aligned_seq{};
 
@@ -74,18 +75,18 @@ TYPED_TEST_P(aligned_sequence_, insert_one_gap)
 
     EXPECT_EQ(aligned_seq.size(), 4u);
 
-    auto it = insert_gap(aligned_seq, std::ranges::next(begin(aligned_seq), 1));
-    EXPECT_EQ(*it, gap{});
-    EXPECT_EQ(aligned_seq[1], gap{});
+    auto it = seqan3::insert_gap(aligned_seq, std::ranges::next(std::ranges::begin(aligned_seq), 1));
+    EXPECT_EQ(*it, seqan3::gap{});
+    EXPECT_EQ(aligned_seq[1], seqan3::gap{});
     EXPECT_EQ(aligned_seq.size(), 5u);
-    EXPECT_EQ(to_string(aligned_seq), "A-CTA");
+    EXPECT_EQ(seqan3::detail::to_string(aligned_seq), "A-CTA");
 
-    it = insert_gap(aligned_seq, std::ranges::next(begin(aligned_seq), 1));
-    EXPECT_EQ(*it, gap{});
-    EXPECT_EQ(aligned_seq[1], gap{});
-    EXPECT_EQ(aligned_seq[2], gap{});
+    it = seqan3::insert_gap(aligned_seq, std::ranges::next(std::ranges::begin(aligned_seq), 1));
+    EXPECT_EQ(*it, seqan3::gap{});
+    EXPECT_EQ(aligned_seq[1], seqan3::gap{});
+    EXPECT_EQ(aligned_seq[2], seqan3::gap{});
     EXPECT_EQ(aligned_seq.size(), 6u);
-    EXPECT_EQ(to_string(aligned_seq), "A--CTA");
+    EXPECT_EQ(seqan3::detail::to_string(aligned_seq), "A--CTA");
 }
 
 TYPED_TEST_P(aligned_sequence_, insert_multiple_gaps)
@@ -94,24 +95,24 @@ TYPED_TEST_P(aligned_sequence_, insert_multiple_gaps)
     TestFixture::initialise_typed_test_container(aligned_seq, seq);
     EXPECT_EQ(aligned_seq.size(), 4u);
 
-    auto it = insert_gap(aligned_seq, std::ranges::next(begin(aligned_seq), 1), 2);
-    EXPECT_EQ(*it, gap{});
-    EXPECT_EQ(*++it, gap{});
-    EXPECT_EQ(aligned_seq[1], gap{});
-    EXPECT_EQ(aligned_seq[2], gap{});
+    auto it = seqan3::insert_gap(aligned_seq, std::ranges::next(begin(aligned_seq), 1), 2);
+    EXPECT_EQ(*it, seqan3::gap{});
+    EXPECT_EQ(*++it, seqan3::gap{});
+    EXPECT_EQ(aligned_seq[1], seqan3::gap{});
+    EXPECT_EQ(aligned_seq[2], seqan3::gap{});
     EXPECT_EQ(aligned_seq.size(), 6u);
 
     // insert a gap within another gap
-    insert_gap(aligned_seq, std::ranges::next(begin(aligned_seq), 2), 4);
-    EXPECT_EQ(to_string(aligned_seq), "A------CTA");
+    seqan3::insert_gap(aligned_seq, std::ranges::next(begin(aligned_seq), 2), 4);
+    EXPECT_EQ(seqan3::detail::to_string(aligned_seq), "A------CTA");
 
     // insert at begin
-    insert_gap(aligned_seq, begin(aligned_seq), 2);
-    EXPECT_EQ(to_string(aligned_seq), "--A------CTA");
+    seqan3::insert_gap(aligned_seq, std::ranges::begin(aligned_seq), 2);
+    EXPECT_EQ(seqan3::detail::to_string(aligned_seq), "--A------CTA");
 
     // insert at end
-    insert_gap(aligned_seq, end(aligned_seq), 2);
-    EXPECT_EQ(to_string(aligned_seq), "--A------CTA--");
+    seqan3::insert_gap(aligned_seq, std::ranges::end(aligned_seq), 2);
+    EXPECT_EQ(seqan3::detail::to_string(aligned_seq), "--A------CTA--");
 }
 
 TYPED_TEST_P(aligned_sequence_, insert_zero_gaps)
@@ -120,10 +121,10 @@ TYPED_TEST_P(aligned_sequence_, insert_zero_gaps)
     TestFixture::initialise_typed_test_container(aligned_seq, seq);
     EXPECT_EQ(aligned_seq.size(), 4u);
 
-    auto it = insert_gap(aligned_seq, std::ranges::next(begin(aligned_seq), 1), 0);
+    auto it = seqan3::insert_gap(aligned_seq, std::ranges::next(begin(aligned_seq), 1), 0);
     typename TypeParam::value_type val{'C'_dna4};
     EXPECT_EQ(*it, val);
-    EXPECT_EQ(to_string(aligned_seq), "ACTA");
+    EXPECT_EQ(seqan3::detail::to_string(aligned_seq), "ACTA");
 }
 
 TYPED_TEST_P(aligned_sequence_, erase_one_gap)
@@ -132,22 +133,24 @@ TYPED_TEST_P(aligned_sequence_, erase_one_gap)
     TypeParam aligned_seq;
     TestFixture::initialise_typed_test_container(aligned_seq, seq);
     EXPECT_EQ(aligned_seq.size(), 4u);
-    EXPECT_EQ(to_string(aligned_seq), "ACTA");
+    EXPECT_EQ(seqan3::detail::to_string(aligned_seq), "ACTA");
 
     insert_gap(aligned_seq, std::ranges::next(begin(aligned_seq), 1));
     EXPECT_EQ(aligned_seq.size(), 5u);
-    EXPECT_EQ(to_string(aligned_seq), "A-CTA");
+    EXPECT_EQ(seqan3::detail::to_string(aligned_seq), "A-CTA");
 
     typename TypeParam::value_type val{'C'_dna4};
-    auto it = erase_gap(aligned_seq, std::ranges::next(begin(aligned_seq), 1));
+    auto it = seqan3::erase_gap(aligned_seq, std::ranges::next(begin(aligned_seq), 1));
     EXPECT_EQ(*it, val);
     EXPECT_EQ(aligned_seq.size(), 4u);
-    EXPECT_EQ(to_string(aligned_seq), "ACTA");
+    EXPECT_EQ(seqan3::detail::to_string(aligned_seq), "ACTA");
 
     // 2) Removing a non-gap
-    EXPECT_THROW(erase_gap(aligned_seq, std::ranges::next(begin(aligned_seq), 2)), gap_erase_failure);
+    EXPECT_THROW(seqan3::erase_gap(aligned_seq,
+                                   std::ranges::next(std::ranges::begin(aligned_seq), 2)),
+                 seqan3::gap_erase_failure);
     EXPECT_EQ(aligned_seq.size(), 4u); // no change
-    EXPECT_EQ(to_string(aligned_seq), "ACTA");
+    EXPECT_EQ(seqan3::detail::to_string(aligned_seq), "ACTA");
 }
 
 TYPED_TEST_P(aligned_sequence_, erase_multiple_gaps)
@@ -157,88 +160,95 @@ TYPED_TEST_P(aligned_sequence_, erase_multiple_gaps)
     // 1) Removing a gap of length > 1
     TestFixture::initialise_typed_test_container(aligned_seq, seq);
     EXPECT_EQ(aligned_seq.size(), 4u);
-    EXPECT_EQ(to_string(aligned_seq), "ACTA");
+    EXPECT_EQ(seqan3::detail::to_string(aligned_seq), "ACTA");
 
-    insert_gap(aligned_seq, std::ranges::next(begin(aligned_seq), 1), 2);
+    seqan3::insert_gap(aligned_seq, std::ranges::next(std::ranges::begin(aligned_seq), 1), 2);
     EXPECT_EQ(aligned_seq.size(), 6u);
-    EXPECT_EQ(to_string(aligned_seq), "A--CTA");
+    EXPECT_EQ(seqan3::detail::to_string(aligned_seq), "A--CTA");
 
     typename TypeParam::value_type val{'C'_dna4};
-    auto it = erase_gap(aligned_seq, std::ranges::next(begin(aligned_seq), 1),
-                        std::ranges::next(begin(aligned_seq), 3));
+    auto it = seqan3::erase_gap(aligned_seq,
+                                std::ranges::next(std::ranges::begin(aligned_seq), 1),
+                                std::ranges::next(std::ranges::begin(aligned_seq), 3));
     EXPECT_EQ(aligned_seq.size(), 4u);
     EXPECT_EQ(*it, val);
-    EXPECT_EQ(to_string(aligned_seq), "ACTA");
+    EXPECT_EQ(seqan3::detail::to_string(aligned_seq), "ACTA");
 
     // 2) Removing a non-gap
     TestFixture::initialise_typed_test_container(aligned_seq, seq); // reset
 
-    EXPECT_THROW(erase_gap(aligned_seq, std::ranges::next(begin(aligned_seq), 1),
-                           std::ranges::next(begin(aligned_seq), 3)),
-                 gap_erase_failure);
+    EXPECT_THROW(seqan3::erase_gap(aligned_seq,
+                                   std::ranges::next(std::ranges::begin(aligned_seq), 1),
+                                   std::ranges::next(std::ranges::begin(aligned_seq), 3)),
+                 seqan3::gap_erase_failure);
     EXPECT_EQ(aligned_seq.size(), seq.size()); // no change
-    EXPECT_EQ(to_string(aligned_seq), "ACTA");
+    EXPECT_EQ(seqan3::detail::to_string(aligned_seq), "ACTA");
 
     // 3) Remove a gap of length 1 within a gap of length 5
     TestFixture::initialise_typed_test_container(aligned_seq, seq);  // reset
-    insert_gap(aligned_seq, std::ranges::next(begin(aligned_seq), 1), 5);
+    insert_gap(aligned_seq, std::ranges::next(std::ranges::begin(aligned_seq), 1), 5);
     EXPECT_EQ(aligned_seq.size(), seq.size() + 5);
-    EXPECT_EQ(to_string(aligned_seq), "A-----CTA");
+    EXPECT_EQ(seqan3::detail::to_string(aligned_seq), "A-----CTA");
 
-    it = erase_gap(aligned_seq, std::ranges::next(begin(aligned_seq), 3)); // erase one in the middle of 5
+    it = erase_gap(aligned_seq, std::ranges::next(std::ranges::begin(aligned_seq), 3)); // erase one in the middle of 5
     EXPECT_EQ(aligned_seq.size(), seq.size() + 4);
     EXPECT_EQ(aligned_seq[5], val);
-    EXPECT_EQ(*it, gap{});
-    EXPECT_EQ(to_string(aligned_seq), "A----CTA");
+    EXPECT_EQ(*it, seqan3::gap{});
+    EXPECT_EQ(seqan3::detail::to_string(aligned_seq), "A----CTA");
 
     // 4) Remove gaps two times
     TestFixture::initialise_typed_test_container(aligned_seq, seq);  // reset
-    insert_gap(aligned_seq, std::ranges::next(begin(aligned_seq), 3), 4);
-    insert_gap(aligned_seq, std::ranges::next(begin(aligned_seq), 1), 5);
+    insert_gap(aligned_seq, std::ranges::next(std::ranges::begin(aligned_seq), 3), 4);
+    insert_gap(aligned_seq, std::ranges::next(std::ranges::begin(aligned_seq), 1), 5);
     EXPECT_EQ(aligned_seq.size(), seq.size() + 9);
-    EXPECT_EQ(to_string(aligned_seq), "A-----CT----A");
+    EXPECT_EQ(seqan3::detail::to_string(aligned_seq), "A-----CT----A");
 
-    erase_gap(aligned_seq, std::ranges::next(begin(aligned_seq), 2), std::ranges::next(begin(aligned_seq), 4));
-    erase_gap(aligned_seq, std::ranges::next(begin(aligned_seq), 6), std::ranges::next(begin(aligned_seq), 10));
-    EXPECT_EQ(to_string(aligned_seq), "A---CTA");
+    seqan3::erase_gap(aligned_seq,
+                      std::ranges::next(std::ranges::begin(aligned_seq), 2),
+                      std::ranges::next(std::ranges::begin(aligned_seq), 4));
+    seqan3::erase_gap(aligned_seq,
+                      std::ranges::next(std::ranges::begin(aligned_seq), 6),
+                      std::ranges::next(std::ranges::begin(aligned_seq), 10));
+    EXPECT_EQ(seqan3::detail::to_string(aligned_seq), "A---CTA");
 
     // 5) Removing too much from a gap
-    EXPECT_THROW(erase_gap(aligned_seq, std::ranges::next(begin(aligned_seq), 2),
-                           std::ranges::next(begin(aligned_seq), 5)),
-                 gap_erase_failure);
+    EXPECT_THROW(seqan3::erase_gap(aligned_seq,
+                                   std::ranges::next(std::ranges::begin(aligned_seq), 2),
+                                   std::ranges::next(std::ranges::begin(aligned_seq), 5)),
+                 seqan3::gap_erase_failure);
     EXPECT_EQ(aligned_seq.size(), 7u); // no change
-    EXPECT_EQ(to_string(aligned_seq), "A---CTA");
+    EXPECT_EQ(seqan3::detail::to_string(aligned_seq), "A---CTA");
 }
 
 TYPED_TEST_P(aligned_sequence_, insert_erase_on_empty_sequence)
 {
-    using unaligned_seq_type = remove_cvref_t<detail::unaligned_seq_t<TypeParam>>;
+    using unaligned_seq_type = seqan3::remove_cvref_t<seqan3::detail::unaligned_seq_t<TypeParam>>;
     unaligned_seq_type unaligned{};
     TypeParam aligned_seq{};
 
     assign_unaligned(aligned_seq, unaligned);
 
-    auto it = insert_gap(aligned_seq, begin(aligned_seq));
-    EXPECT_EQ(*it, gap{});
+    auto it = insert_gap(aligned_seq, std::ranges::begin(aligned_seq));
+    EXPECT_EQ(*it, seqan3::gap{});
     EXPECT_EQ(aligned_seq.size(), 1u);
-    EXPECT_EQ(to_string(aligned_seq), "-");
+    EXPECT_EQ(seqan3::detail::to_string(aligned_seq), "-");
 
-    it = insert_gap(aligned_seq, end(aligned_seq), 3);
-    EXPECT_EQ(*it, gap{});
+    it = seqan3::insert_gap(aligned_seq, std::ranges::end(aligned_seq), 3);
+    EXPECT_EQ(*it, seqan3::gap{});
     EXPECT_EQ(aligned_seq.size(), 4u);
-    EXPECT_EQ(to_string(aligned_seq), "----");
+    EXPECT_EQ(seqan3::detail::to_string(aligned_seq), "----");
 
-    it = insert_gap(aligned_seq, end(aligned_seq), 0);
+    it = seqan3::insert_gap(aligned_seq, std::ranges::end(aligned_seq), 0);
     EXPECT_EQ(aligned_seq.size(), 4u);
-    EXPECT_EQ(to_string(aligned_seq), "----");
+    EXPECT_EQ(seqan3::detail::to_string(aligned_seq), "----");
 
-    it = erase_gap(aligned_seq, begin(aligned_seq));
+    it = seqan3::erase_gap(aligned_seq, std::ranges::begin(aligned_seq));
     EXPECT_EQ(aligned_seq.size(), 3u);
-    EXPECT_EQ(to_string(aligned_seq), "---");
+    EXPECT_EQ(seqan3::detail::to_string(aligned_seq), "---");
 
-    it = erase_gap(aligned_seq, begin(aligned_seq), end(aligned_seq));
+    it = seqan3::erase_gap(aligned_seq, std::ranges::begin(aligned_seq), std::ranges::end(aligned_seq));
     EXPECT_EQ(aligned_seq.size(), 0u);
-    EXPECT_EQ(to_string(aligned_seq), "");
+    EXPECT_EQ(seqan3::detail::to_string(aligned_seq), "");
 }
 
 TYPED_TEST_P(aligned_sequence_, cigar_string)
@@ -250,12 +260,12 @@ TYPED_TEST_P(aligned_sequence_, cigar_string)
         TypeParam read;
         TestFixture::initialise_typed_test_container(ref,  seq_ref);
         TestFixture::initialise_typed_test_container(read, seq_read);
-        insert_gap(ref, std::ranges::next(begin(ref), 7), 2);
-        insert_gap(read, std::ranges::next(begin(read), 4), 1);
+        seqan3::insert_gap(ref, std::ranges::next(begin(ref), 7), 2);
+        seqan3::insert_gap(read, std::ranges::next(begin(read), 4), 1);
 
         std::string expected = "4M1D2M2I3M";
 
-        EXPECT_EQ(expected, detail::get_cigar_string(std::make_pair(ref, read)));
+        EXPECT_EQ(expected, seqan3::detail::get_cigar_string(std::make_pair(ref, read)));
 
         TypeParam ref2;
         TypeParam read2;
@@ -263,14 +273,14 @@ TYPED_TEST_P(aligned_sequence_, cigar_string)
         TestFixture::initialise_typed_test_container(read2, seq_read);
         insert_gap(ref2, std::ranges::next(begin(ref2), 10), 2);
         insert_gap(ref2, std::ranges::next(begin(ref2), 7), 2);
-        insert_gap(ref2, begin(ref2), 3);
+        insert_gap(ref2, std::ranges::begin(ref2), 3);
         insert_gap(read2, std::ranges::next(begin(read2), 11), 4);
         insert_gap(read2, std::ranges::next(begin(read2), 4), 1);
-        insert_gap(read2, begin(read2), 1);
+        insert_gap(read2, std::ranges::begin(read2), 1);
 
         std::string expected2 = "1P2I2M1D4M2I1M2D2P";
 
-        EXPECT_EQ(expected2, detail::get_cigar_string(std::make_pair(ref2, read2)));
+        EXPECT_EQ(expected2, seqan3::detail::get_cigar_string(std::make_pair(ref2, read2)));
     }
     {
         // with soft clipping
@@ -280,28 +290,28 @@ TYPED_TEST_P(aligned_sequence_, cigar_string)
         TypeParam read;
         TestFixture::initialise_typed_test_container(ref,  seq_ref);
         TestFixture::initialise_typed_test_container(read, seq_read);
-        insert_gap(ref, std::ranges::next(begin(ref), 7), 2);
-        insert_gap(read, std::ranges::next(begin(read), 4), 1);
+        insert_gap(ref, std::ranges::next(std::ranges::begin(ref), 7), 2);
+        insert_gap(read, std::ranges::next(std::ranges::begin(read), 4), 1);
 
         std::string expected = "5S4M1D2M2I3M60S";
 
-        EXPECT_EQ(expected, detail::get_cigar_string(std::make_pair(ref, read), 5, 60));
+        EXPECT_EQ(expected, seqan3::detail::get_cigar_string(std::make_pair(ref, read), 5, 60));
 
         // gaps at the end
         TypeParam ref2;
         TypeParam read2;
         TestFixture::initialise_typed_test_container(ref2,  seq_ref);
         TestFixture::initialise_typed_test_container(read2, seq_read);
-        insert_gap(ref2, std::ranges::next(begin(ref2), 10), 2);
-        insert_gap(ref2, std::ranges::next(begin(ref2), 7), 2);
-        insert_gap(ref2, begin(ref2), 3);
-        insert_gap(read2, std::ranges::next(begin(read2), 11), 4);
-        insert_gap(read2, std::ranges::next(begin(read2), 4), 1);
-        insert_gap(read2, begin(read2), 1);
+        seqan3::insert_gap(ref2, std::ranges::next(begin(ref2), 10), 2);
+        seqan3::insert_gap(ref2, std::ranges::next(begin(ref2), 7), 2);
+        seqan3::insert_gap(ref2, std::ranges::begin(ref2), 3);
+        seqan3::insert_gap(read2, std::ranges::next(begin(read2), 11), 4);
+        seqan3::insert_gap(read2, std::ranges::next(begin(read2), 4), 1);
+        seqan3::insert_gap(read2, std::ranges::begin(read2), 1);
 
         std::string expected2 = "3S1P2I2M1D4M2I1M2D2P5S";
 
-        EXPECT_EQ(expected2, detail::get_cigar_string(std::make_pair(ref2, read2), 3, 5));
+        EXPECT_EQ(expected2, seqan3::detail::get_cigar_string(std::make_pair(ref2, read2), 3, 5));
     }
     {
         // no gaps at the end
@@ -311,14 +321,14 @@ TYPED_TEST_P(aligned_sequence_, cigar_string)
         TypeParam read;
         TestFixture::initialise_typed_test_container(ref,  seq_ref);
         TestFixture::initialise_typed_test_container(read, seq_read);
-        insert_gap(ref, std::ranges::next(begin(ref), 7), 2);
-        insert_gap(read, std::ranges::next(begin(read), 4), 1);
+        seqan3::insert_gap(ref, std::ranges::next(std::ranges::begin(ref), 7), 2);
+        seqan3::insert_gap(read, std::ranges::next(std::ranges::begin(read), 4), 1);
 
         std::string expected1 =    "4=1D2X2I1=1X1=";
         std::string expected2 = "5S4=1D2X2I1=1X1=60S";
 
-        EXPECT_EQ(expected1, detail::get_cigar_string(std::make_pair(ref, read), 0, 0, true));
-        EXPECT_EQ(expected2, detail::get_cigar_string(std::make_pair(ref, read), 5, 60, true));
+        EXPECT_EQ(expected1, seqan3::detail::get_cigar_string(std::make_pair(ref, read), 0, 0, true));
+        EXPECT_EQ(expected2, seqan3::detail::get_cigar_string(std::make_pair(ref, read), 5, 60, true));
     }
 }
 

--- a/test/unit/alignment/aligned_sequence_test_template.hpp
+++ b/test/unit/alignment/aligned_sequence_test_template.hpp
@@ -123,7 +123,6 @@ TYPED_TEST_P(aligned_sequence_, insert_zero_gaps)
     auto it = insert_gap(aligned_seq, std::ranges::next(begin(aligned_seq), 1), 0);
     typename TypeParam::value_type val{'C'_dna4};
     EXPECT_EQ(*it, val);
-    EXPECT_TRUE((ranges::equal(aligned_seq, seq)));
     EXPECT_EQ(to_string(aligned_seq), "ACTA");
 }
 

--- a/test/unit/alphabet/alphabet_hash_test.cpp
+++ b/test/unit/alphabet/alphabet_hash_test.cpp
@@ -13,12 +13,10 @@
 #include <seqan3/alphabet/quality/qualified.hpp>
 #include <seqan3/range/hash.hpp>
 
-using namespace seqan3;
-
 template <typename T>
 using alphabet_hashing = ::testing::Test;
 
-using test_types = ::testing::Types<dna4, qualified<dna4, phred42>, gapped<dna4>>;
+using test_types = ::testing::Types<seqan3::dna4, seqan3::qualified<seqan3::dna4, seqan3::phred42>, seqan3::gapped<seqan3::dna4>>;
 
 TYPED_TEST_CASE(alphabet_hashing, test_types);
 
@@ -29,17 +27,17 @@ TYPED_TEST(alphabet_hashing, hash)
         std::hash<TypeParam> h{};
         if constexpr (std::same_as<TypeParam, char>)
         {
-            for (size_t i = 0; i < alphabet_size<TypeParam>/2; ++i)
+            for (size_t i = 0; i < seqan3::alphabet_size<TypeParam>/2; ++i)
             {
-                assign_rank_to(i, t0);
+                seqan3::assign_rank_to(i, t0);
                 ASSERT_EQ(h(t0), i);
             }
         }
         else
         {
-            for (size_t i = 0; i < alphabet_size<TypeParam>; ++i)
+            for (size_t i = 0; i < seqan3::alphabet_size<TypeParam>; ++i)
             {
-                assign_rank_to(i, t0);
+                seqan3::assign_rank_to(i, t0);
                 ASSERT_EQ(h(t0), i);
             }
         }
@@ -49,7 +47,7 @@ TYPED_TEST(alphabet_hashing, hash)
         text.reserve(4);
         for (size_t i = 0; i < 4; ++i)
         {
-            text.push_back(assign_rank_to(0, TypeParam{}));
+            text.push_back(seqan3::assign_rank_to(0, TypeParam{}));
         }
         std::hash<decltype(text)> h{};
         ASSERT_EQ(h(text), 0u);
@@ -58,23 +56,23 @@ TYPED_TEST(alphabet_hashing, hash)
         std::hash<TypeParam const> h{};
         if constexpr (std::same_as<TypeParam, char>)
         {
-            for (size_t i = 0; i < alphabet_size<TypeParam>/2; ++i)
+            for (size_t i = 0; i < seqan3::alphabet_size<TypeParam>/2; ++i)
             {
-                TypeParam const t0 = assign_rank_to(i, TypeParam{});
+                TypeParam const t0 = seqan3::assign_rank_to(i, TypeParam{});
                 ASSERT_EQ(h(t0), i);
             }
         }
         else
         {
-            for (size_t i = 0; i < alphabet_size<TypeParam>; ++i)
+            for (size_t i = 0; i < seqan3::alphabet_size<TypeParam>; ++i)
             {
-                TypeParam const t0 = assign_rank_to(i, TypeParam{});
+                TypeParam const t0 = seqan3::assign_rank_to(i, TypeParam{});
                 ASSERT_EQ(h(t0), i);
             }
         }
     }
     {
-        std::vector<TypeParam> const text(4, assign_rank_to(0, TypeParam{}));
+        std::vector<TypeParam> const text(4, seqan3::assign_rank_to(0, TypeParam{}));
         std::hash<decltype(text)> h{};
         ASSERT_EQ(h(text), 0u);
     }

--- a/test/unit/alphabet/alphabet_test_template.hpp
+++ b/test/unit/alphabet/alphabet_test_template.hpp
@@ -11,8 +11,6 @@
 #include <seqan3/alphabet/exception.hpp>
 #include <seqan3/test/pretty_printing.hpp>
 
-using namespace seqan3;
-
 template <typename T>
 using alphabet_ = ::testing::Test;
 
@@ -22,20 +20,20 @@ TYPED_TEST_CASE_P(alphabet_);
 
 TYPED_TEST_P(alphabet_, concept_check)
 {
-    EXPECT_TRUE(alphabet<TypeParam>);
-    EXPECT_TRUE(alphabet<TypeParam &>);
-    EXPECT_TRUE(alphabet<TypeParam const>);
-    EXPECT_TRUE(alphabet<TypeParam const &>);
+    EXPECT_TRUE(seqan3::alphabet<TypeParam>);
+    EXPECT_TRUE(seqan3::alphabet<TypeParam &>);
+    EXPECT_TRUE(seqan3::alphabet<TypeParam const>);
+    EXPECT_TRUE(seqan3::alphabet<TypeParam const &>);
 
-    EXPECT_TRUE(writable_alphabet<TypeParam>);
-    EXPECT_TRUE(writable_alphabet<TypeParam &>);
-    EXPECT_FALSE(writable_alphabet<TypeParam const>);
-    EXPECT_FALSE(writable_alphabet<TypeParam const &>);
+    EXPECT_TRUE(seqan3::writable_alphabet<TypeParam>);
+    EXPECT_TRUE(seqan3::writable_alphabet<TypeParam &>);
+    EXPECT_FALSE(seqan3::writable_alphabet<TypeParam const>);
+    EXPECT_FALSE(seqan3::writable_alphabet<TypeParam const &>);
 }
 
 TYPED_TEST_P(alphabet_, global_assign_char_to)
 {
-    using char_t = alphabet_char_t<TypeParam>;
+    using char_t = seqan3::alphabet_char_t<TypeParam>;
     if constexpr(std::integral<char_t>)
     {
         char_t i = std::numeric_limits<char_t>::min();
@@ -52,15 +50,15 @@ TYPED_TEST_P(alphabet_, global_assign_char_to)
 
 TYPED_TEST_P(alphabet_, global_char_is_valid_for) // only test negative example for most; more inside specialised tests
 {
-    if constexpr (alphabet_size<TypeParam> < 255) // includes most of our alphabets, but not the adaptations!
+    if constexpr (seqan3::alphabet_size<TypeParam> < 255) // includes most of our alphabets, but not the adaptations!
     {
-        EXPECT_FALSE((char_is_valid_for<TypeParam>(0))); // for none of our alphabets char{0} is valid
+        EXPECT_FALSE((seqan3::char_is_valid_for<TypeParam>(0))); // for none of our alphabets char{0} is valid
     }
 }
 
 TYPED_TEST_P(alphabet_, global_assign_char_strictly_to)
 {
-    using char_t = alphabet_char_t<TypeParam>;
+    using char_t = seqan3::alphabet_char_t<TypeParam>;
     if constexpr(std::integral<char_t>)
     {
         char_t i = std::numeric_limits<char_t>::min();
@@ -68,10 +66,10 @@ TYPED_TEST_P(alphabet_, global_assign_char_strictly_to)
 
         for (size_t k = 0; i < j && k < max_iterations; ++i, ++k)
         {
-            if (char_is_valid_for<TypeParam>(i))
+            if (seqan3::char_is_valid_for<TypeParam>(i))
                 EXPECT_NO_THROW(seqan3::assign_char_strictly_to(i, TypeParam{}));
             else
-                EXPECT_THROW(seqan3::assign_char_strictly_to(i, TypeParam{}), invalid_char_assignment);
+                EXPECT_THROW(seqan3::assign_char_strictly_to(i, TypeParam{}), seqan3::invalid_char_assignment);
         }
     }
 }
@@ -79,7 +77,7 @@ TYPED_TEST_P(alphabet_, global_assign_char_strictly_to)
 TYPED_TEST_P(alphabet_, global_to_char)
 {
     TypeParam t0;
-    EXPECT_TRUE((std::is_same_v<decltype(seqan3::to_char(t0)), alphabet_char_t<TypeParam>>));
+    EXPECT_TRUE((std::is_same_v<decltype(seqan3::to_char(t0)), seqan3::alphabet_char_t<TypeParam>>));
 
     // more elaborate tests are done in specific alphabets
 

--- a/test/unit/alphabet/cigar/cigar_op_test.cpp
+++ b/test/unit/alphabet/cigar/cigar_op_test.cpp
@@ -13,31 +13,33 @@
 #include "../semi_alphabet_test_template.hpp"
 #include <seqan3/alphabet/cigar/cigar_op.hpp>
 
-INSTANTIATE_TYPED_TEST_CASE_P(cigar_op, alphabet_, cigar_op);
-INSTANTIATE_TYPED_TEST_CASE_P(cigar_op, semi_alphabet_test, cigar_op);
-INSTANTIATE_TYPED_TEST_CASE_P(cigar_op, alphabet_constexpr, cigar_op);
-INSTANTIATE_TYPED_TEST_CASE_P(cigar_op, semi_alphabet_constexpr, cigar_op);
+INSTANTIATE_TYPED_TEST_CASE_P(cigar_op, alphabet_, seqan3::cigar_op);
+INSTANTIATE_TYPED_TEST_CASE_P(cigar_op, semi_alphabet_test, seqan3::cigar_op);
+INSTANTIATE_TYPED_TEST_CASE_P(cigar_op, alphabet_constexpr, seqan3::cigar_op);
+INSTANTIATE_TYPED_TEST_CASE_P(cigar_op, semi_alphabet_constexpr, seqan3::cigar_op);
+
+using seqan3::operator""_cigar_op;
 
 TEST(cigar_op, to_char_assign_char)
 {
     for (char chr : std::string{"MDISHNPX="})
-        EXPECT_EQ(to_char(cigar_op{}.assign_char(chr)), chr);
+        EXPECT_EQ(seqan3::to_char(seqan3::cigar_op{}.assign_char(chr)), chr);
 }
 
 TEST(cigar_op, char_literal)
 {
-    EXPECT_EQ(to_char(cigar_op{'M'_cigar_op}), 'M');
-    EXPECT_EQ(to_char(cigar_op{'D'_cigar_op}), 'D');
-    EXPECT_EQ(to_char(cigar_op{'I'_cigar_op}), 'I');
-    EXPECT_EQ(to_char(cigar_op{'S'_cigar_op}), 'S');
-    EXPECT_EQ(to_char(cigar_op{'H'_cigar_op}), 'H');
-    EXPECT_EQ(to_char(cigar_op{'N'_cigar_op}), 'N');
-    EXPECT_EQ(to_char(cigar_op{'P'_cigar_op}), 'P');
-    EXPECT_EQ(to_char(cigar_op{'X'_cigar_op}), 'X');
-    EXPECT_EQ(to_char(cigar_op{'='_cigar_op}), '=');
+    EXPECT_EQ(seqan3::to_char(seqan3::cigar_op{'M'_cigar_op}), 'M');
+    EXPECT_EQ(seqan3::to_char(seqan3::cigar_op{'D'_cigar_op}), 'D');
+    EXPECT_EQ(seqan3::to_char(seqan3::cigar_op{'I'_cigar_op}), 'I');
+    EXPECT_EQ(seqan3::to_char(seqan3::cigar_op{'S'_cigar_op}), 'S');
+    EXPECT_EQ(seqan3::to_char(seqan3::cigar_op{'H'_cigar_op}), 'H');
+    EXPECT_EQ(seqan3::to_char(seqan3::cigar_op{'N'_cigar_op}), 'N');
+    EXPECT_EQ(seqan3::to_char(seqan3::cigar_op{'P'_cigar_op}), 'P');
+    EXPECT_EQ(seqan3::to_char(seqan3::cigar_op{'X'_cigar_op}), 'X');
+    EXPECT_EQ(seqan3::to_char(seqan3::cigar_op{'='_cigar_op}), '=');
 }
 
 TEST(cigar_op, assign_char_strictly_to)
 {
-    EXPECT_THROW(assign_char_strictly_to('A', cigar_op{}), invalid_char_assignment);
+    EXPECT_THROW(seqan3::assign_char_strictly_to('A', seqan3::cigar_op{}), seqan3::invalid_char_assignment);
 }

--- a/test/unit/alphabet/cigar/cigar_test.cpp
+++ b/test/unit/alphabet/cigar/cigar_test.cpp
@@ -13,8 +13,10 @@
 #include "../semi_alphabet_test_template.hpp"
 #include "../semi_alphabet_constexpr_test_template.hpp"
 
-INSTANTIATE_TYPED_TEST_CASE_P(cigar, semi_alphabet_test, cigar);
-INSTANTIATE_TYPED_TEST_CASE_P(cigar, semi_alphabet_constexpr, cigar);
+INSTANTIATE_TYPED_TEST_CASE_P(cigar, semi_alphabet_test, seqan3::cigar);
+INSTANTIATE_TYPED_TEST_CASE_P(cigar, semi_alphabet_constexpr, seqan3::cigar);
+
+using namespace seqan3;
 
 TEST(cigar, brace_init)
 {

--- a/test/unit/alphabet/composite/alphabet_tuple_base_test.cpp
+++ b/test/unit/alphabet/composite/alphabet_tuple_base_test.cpp
@@ -11,8 +11,8 @@
 #include <seqan3/alphabet/nucleotide/rna4.hpp>
 #include <seqan3/alphabet/nucleotide/rna5.hpp>
 
-#include "alphabet_tuple_base_test_template.hpp"
 #include "../semi_alphabet_test_template.hpp"
+#include "alphabet_tuple_base_test_template.hpp"
 
 using namespace seqan3;
 

--- a/test/unit/alphabet/composite/alphabet_tuple_base_test.cpp
+++ b/test/unit/alphabet/composite/alphabet_tuple_base_test.cpp
@@ -12,6 +12,7 @@
 #include <seqan3/alphabet/nucleotide/rna5.hpp>
 
 #include "alphabet_tuple_base_test_template.hpp"
+#include "../semi_alphabet_test_template.hpp"
 
 using namespace seqan3;
 
@@ -21,13 +22,6 @@ struct test_composite : public alphabet_tuple_base<test_composite<type1, type2>,
     using base_t = alphabet_tuple_base<test_composite<type1, type2>, type1, type2>;
     using base_t::base_t;
     using base_t::operator=;
-
-    using base_t::operator==;
-    using base_t::operator!=;
-    using base_t::operator<;
-    using base_t::operator>;
-    using base_t::operator<=;
-    using base_t::operator>=;
 };
 
 template <>
@@ -68,4 +62,5 @@ public:
 
 using test_composite_types = ::testing::Types<test_composite<dna4, dna5>>;
 
+INSTANTIATE_TYPED_TEST_CASE_P(test_composite, semi_alphabet_test, test_composite_types);
 INSTANTIATE_TYPED_TEST_CASE_P(test_composite, alphabet_tuple_base_test, test_composite_types);

--- a/test/unit/alphabet/composite/alphabet_variant_test.cpp
+++ b/test/unit/alphabet/composite/alphabet_variant_test.cpp
@@ -312,3 +312,20 @@ TEST(alphabet_variant_test, convert_by_type)
     gap g = u.convert_unsafely_to<gap>();
     EXPECT_EQ(g, gap{});
 }
+
+TEST(alphabet_variant_test, two_different_variants)
+{
+    alphabet_variant<dna4, gap> l{gap{}};
+    alphabet_variant<dna5, gap> r{gap{}};
+
+    EXPECT_EQ(l, r);
+
+    l = 'A'_dna4;
+    r = 'C'_dna5;
+    // r = 'A'_dna5 would also not be equal, because dna4 and dna5 are not comparable, only gap and both aren't gap
+
+    EXPECT_NE(l, r);
+
+    alphabet_variant<rna4, gap> r2{'A'_rna4};
+    EXPECT_EQ(l, r2); // this works because rna4 and dna4 are implicitly convertible to each other
+}

--- a/test/unit/alphabet/composite/semialphabet_any_test.cpp
+++ b/test/unit/alphabet/composite/semialphabet_any_test.cpp
@@ -13,18 +13,21 @@
 #include <seqan3/alphabet/aminoacid/all.hpp>
 #include <seqan3/alphabet/composite/semialphabet_any.hpp>
 
+using seqan3::operator""_aa10li;
+using seqan3::operator""_aa10murphy;
+
 TEST(semialphabet_any_test, initialise_from_alphabet)
 {
-    semialphabet_any<10> letter0{'A'_aa10li};
-    semialphabet_any<10> letter1{'B'_aa10li};
-    semialphabet_any<10> letter2{'C'_aa10li};
-    semialphabet_any<10> letter3{'F'_aa10li};
-    semialphabet_any<10> letter4{'G'_aa10li};
-    semialphabet_any<10> letter5{'H'_aa10li};
-    semialphabet_any<10> letter6{'I'_aa10li};
-    semialphabet_any<10> letter7{'J'_aa10li};
-    semialphabet_any<10> letter8{'K'_aa10li};
-    semialphabet_any<10> letter9{'P'_aa10li};
+    seqan3::semialphabet_any<10> letter0{'A'_aa10li};
+    seqan3::semialphabet_any<10> letter1{'B'_aa10li};
+    seqan3::semialphabet_any<10> letter2{'C'_aa10li};
+    seqan3::semialphabet_any<10> letter3{'F'_aa10li};
+    seqan3::semialphabet_any<10> letter4{'G'_aa10li};
+    seqan3::semialphabet_any<10> letter5{'H'_aa10li};
+    seqan3::semialphabet_any<10> letter6{'I'_aa10li};
+    seqan3::semialphabet_any<10> letter7{'J'_aa10li};
+    seqan3::semialphabet_any<10> letter8{'K'_aa10li};
+    seqan3::semialphabet_any<10> letter9{'P'_aa10li};
 
     EXPECT_EQ(letter0.to_rank(), 0);
     EXPECT_EQ(letter1.to_rank(), 1);
@@ -37,16 +40,16 @@ TEST(semialphabet_any_test, initialise_from_alphabet)
     EXPECT_EQ(letter8.to_rank(), 8);
     EXPECT_EQ(letter9.to_rank(), 9);
 
-    aa10murphy new_letter0{'A'_aa10murphy};
-    aa10murphy new_letter1{'B'_aa10murphy};
-    aa10murphy new_letter2{'C'_aa10murphy};
-    aa10murphy new_letter3{'F'_aa10murphy};
-    aa10murphy new_letter4{'G'_aa10murphy};
-    aa10murphy new_letter5{'H'_aa10murphy};
-    aa10murphy new_letter6{'I'_aa10murphy};
-    aa10murphy new_letter7{'K'_aa10murphy};
-    aa10murphy new_letter8{'P'_aa10murphy};
-    aa10murphy new_letter9{'S'_aa10murphy};
+    seqan3::aa10murphy new_letter0{'A'_aa10murphy};
+    seqan3::aa10murphy new_letter1{'B'_aa10murphy};
+    seqan3::aa10murphy new_letter2{'C'_aa10murphy};
+    seqan3::aa10murphy new_letter3{'F'_aa10murphy};
+    seqan3::aa10murphy new_letter4{'G'_aa10murphy};
+    seqan3::aa10murphy new_letter5{'H'_aa10murphy};
+    seqan3::aa10murphy new_letter6{'I'_aa10murphy};
+    seqan3::aa10murphy new_letter7{'K'_aa10murphy};
+    seqan3::aa10murphy new_letter8{'P'_aa10murphy};
+    seqan3::aa10murphy new_letter9{'S'_aa10murphy};
 
     EXPECT_EQ(letter0.to_rank(), new_letter0.to_rank());
     EXPECT_EQ(letter1.to_rank(), new_letter1.to_rank());
@@ -62,36 +65,36 @@ TEST(semialphabet_any_test, initialise_from_alphabet)
 
 TEST(semialphabet_any_test, convert_to_alphabet)
 {
-    semialphabet_any<10> letter0{'A'_aa10li};
-    semialphabet_any<10> letter1{'B'_aa10li};
-    semialphabet_any<10> letter2{'C'_aa10li};
-    semialphabet_any<10> letter3{'F'_aa10li};
-    semialphabet_any<10> letter4{'G'_aa10li};
-    semialphabet_any<10> letter5{'H'_aa10li};
-    semialphabet_any<10> letter6{'I'_aa10li};
-    semialphabet_any<10> letter7{'J'_aa10li};
-    semialphabet_any<10> letter8{'K'_aa10li};
-    semialphabet_any<10> letter9{'P'_aa10li};
+    seqan3::semialphabet_any<10> letter0{'A'_aa10li};
+    seqan3::semialphabet_any<10> letter1{'B'_aa10li};
+    seqan3::semialphabet_any<10> letter2{'C'_aa10li};
+    seqan3::semialphabet_any<10> letter3{'F'_aa10li};
+    seqan3::semialphabet_any<10> letter4{'G'_aa10li};
+    seqan3::semialphabet_any<10> letter5{'H'_aa10li};
+    seqan3::semialphabet_any<10> letter6{'I'_aa10li};
+    seqan3::semialphabet_any<10> letter7{'J'_aa10li};
+    seqan3::semialphabet_any<10> letter8{'K'_aa10li};
+    seqan3::semialphabet_any<10> letter9{'P'_aa10li};
 
-    EXPECT_EQ(static_cast<aa10li>(letter0), 'A'_aa10li);
-    EXPECT_EQ(static_cast<aa10li>(letter1), 'B'_aa10li);
-    EXPECT_EQ(static_cast<aa10li>(letter2), 'C'_aa10li);
-    EXPECT_EQ(static_cast<aa10li>(letter3), 'F'_aa10li);
-    EXPECT_EQ(static_cast<aa10li>(letter4), 'G'_aa10li);
-    EXPECT_EQ(static_cast<aa10li>(letter5), 'H'_aa10li);
-    EXPECT_EQ(static_cast<aa10li>(letter6), 'I'_aa10li);
-    EXPECT_EQ(static_cast<aa10li>(letter7), 'J'_aa10li);
-    EXPECT_EQ(static_cast<aa10li>(letter8), 'K'_aa10li);
-    EXPECT_EQ(static_cast<aa10li>(letter9), 'P'_aa10li);
+    EXPECT_EQ(static_cast<seqan3::aa10li>(letter0), 'A'_aa10li);
+    EXPECT_EQ(static_cast<seqan3::aa10li>(letter1), 'B'_aa10li);
+    EXPECT_EQ(static_cast<seqan3::aa10li>(letter2), 'C'_aa10li);
+    EXPECT_EQ(static_cast<seqan3::aa10li>(letter3), 'F'_aa10li);
+    EXPECT_EQ(static_cast<seqan3::aa10li>(letter4), 'G'_aa10li);
+    EXPECT_EQ(static_cast<seqan3::aa10li>(letter5), 'H'_aa10li);
+    EXPECT_EQ(static_cast<seqan3::aa10li>(letter6), 'I'_aa10li);
+    EXPECT_EQ(static_cast<seqan3::aa10li>(letter7), 'J'_aa10li);
+    EXPECT_EQ(static_cast<seqan3::aa10li>(letter8), 'K'_aa10li);
+    EXPECT_EQ(static_cast<seqan3::aa10li>(letter9), 'P'_aa10li);
 
-    EXPECT_EQ(static_cast<aa10murphy>(letter0), 'A'_aa10murphy);
-    EXPECT_EQ(static_cast<aa10murphy>(letter1), 'B'_aa10murphy);
-    EXPECT_EQ(static_cast<aa10murphy>(letter2), 'C'_aa10murphy);
-    EXPECT_EQ(static_cast<aa10murphy>(letter3), 'F'_aa10murphy);
-    EXPECT_EQ(static_cast<aa10murphy>(letter4), 'G'_aa10murphy);
-    EXPECT_EQ(static_cast<aa10murphy>(letter5), 'H'_aa10murphy);
-    EXPECT_EQ(static_cast<aa10murphy>(letter6), 'I'_aa10murphy);
-    EXPECT_EQ(static_cast<aa10murphy>(letter7), 'K'_aa10murphy);
-    EXPECT_EQ(static_cast<aa10murphy>(letter8), 'P'_aa10murphy);
-    EXPECT_EQ(static_cast<aa10murphy>(letter9), 'S'_aa10murphy);
+    EXPECT_EQ(static_cast<seqan3::aa10murphy>(letter0), 'A'_aa10murphy);
+    EXPECT_EQ(static_cast<seqan3::aa10murphy>(letter1), 'B'_aa10murphy);
+    EXPECT_EQ(static_cast<seqan3::aa10murphy>(letter2), 'C'_aa10murphy);
+    EXPECT_EQ(static_cast<seqan3::aa10murphy>(letter3), 'F'_aa10murphy);
+    EXPECT_EQ(static_cast<seqan3::aa10murphy>(letter4), 'G'_aa10murphy);
+    EXPECT_EQ(static_cast<seqan3::aa10murphy>(letter5), 'H'_aa10murphy);
+    EXPECT_EQ(static_cast<seqan3::aa10murphy>(letter6), 'I'_aa10murphy);
+    EXPECT_EQ(static_cast<seqan3::aa10murphy>(letter7), 'K'_aa10murphy);
+    EXPECT_EQ(static_cast<seqan3::aa10murphy>(letter8), 'P'_aa10murphy);
+    EXPECT_EQ(static_cast<seqan3::aa10murphy>(letter9), 'S'_aa10murphy);
 }

--- a/test/unit/alphabet/nucleotide/dna3bs_test.cpp
+++ b/test/unit/alphabet/nucleotide/dna3bs_test.cpp
@@ -14,89 +14,92 @@
 #include "../semi_alphabet_constexpr_test_template.hpp"
 #include "../semi_alphabet_test_template.hpp"
 
-INSTANTIATE_TYPED_TEST_CASE_P(dna3bs, alphabet_, dna3bs);
-INSTANTIATE_TYPED_TEST_CASE_P(dna3bs, semi_alphabet_test, dna3bs);
-INSTANTIATE_TYPED_TEST_CASE_P(dna3bs, alphabet_constexpr, dna3bs);
-INSTANTIATE_TYPED_TEST_CASE_P(dna3bs, semi_alphabet_constexpr, dna3bs);
+INSTANTIATE_TYPED_TEST_CASE_P(dna3bs, alphabet_, seqan3::dna3bs);
+INSTANTIATE_TYPED_TEST_CASE_P(dna3bs, semi_alphabet_test, seqan3::dna3bs);
+INSTANTIATE_TYPED_TEST_CASE_P(dna3bs, alphabet_constexpr, seqan3::dna3bs);
+INSTANTIATE_TYPED_TEST_CASE_P(dna3bs, semi_alphabet_constexpr, seqan3::dna3bs);
+
+using seqan3::operator""_dna3bs;
 
 TEST(dna3bs, concept_check)
 {
-    EXPECT_TRUE(nucleotide_alphabet<dna3bs>);
-    EXPECT_TRUE(nucleotide_alphabet<dna3bs &>);
-    EXPECT_TRUE(nucleotide_alphabet<dna3bs const>);
-    EXPECT_TRUE(nucleotide_alphabet<dna3bs const &>);
+    EXPECT_TRUE(seqan3::nucleotide_alphabet<seqan3::dna3bs>);
+    EXPECT_TRUE(seqan3::nucleotide_alphabet<seqan3::dna3bs &>);
+    EXPECT_TRUE(seqan3::nucleotide_alphabet<seqan3::dna3bs const>);
+    EXPECT_TRUE(seqan3::nucleotide_alphabet<seqan3::dna3bs const &>);
 }
 
 TEST(dna3bs, global_complement)
 {
-    EXPECT_EQ(complement(dna3bs{}.assign_char('A')), dna3bs{}.assign_char('T'));
-    EXPECT_EQ(complement(dna3bs{}.assign_char('C')), dna3bs{}.assign_char('A'));
-    EXPECT_EQ(complement(dna3bs{}.assign_char('G')), dna3bs{}.assign_char('T'));
-    EXPECT_EQ(complement(dna3bs{}.assign_char('T')), dna3bs{}.assign_char('A'));
+    EXPECT_EQ(seqan3::complement(seqan3::dna3bs{}.assign_char('A')), seqan3::dna3bs{}.assign_char('T'));
+    EXPECT_EQ(seqan3::complement(seqan3::dna3bs{}.assign_char('C')), seqan3::dna3bs{}.assign_char('A'));
+    EXPECT_EQ(seqan3::complement(seqan3::dna3bs{}.assign_char('G')), seqan3::dna3bs{}.assign_char('T'));
+    EXPECT_EQ(seqan3::complement(seqan3::dna3bs{}.assign_char('T')), seqan3::dna3bs{}.assign_char('A'));
 }
 
 TEST(dna3bs, to_char_assign_char)
 {
-    EXPECT_EQ(to_char(dna3bs{}.assign_char('A')), 'A');
-    EXPECT_EQ(to_char(dna3bs{}.assign_char('C')), 'T');
-    EXPECT_EQ(to_char(dna3bs{}.assign_char('G')), 'G');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna3bs{}.assign_char('A')), 'A');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna3bs{}.assign_char('C')), 'T');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna3bs{}.assign_char('G')), 'G');
 
-    EXPECT_EQ(to_char(dna3bs{}.assign_char('U')), 'T');
-    EXPECT_EQ(to_char(dna3bs{}.assign_char('T')), 'T');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna3bs{}.assign_char('U')), 'T');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna3bs{}.assign_char('T')), 'T');
 
-    EXPECT_EQ(to_char(dna3bs{}.assign_char('R')), 'A');
-    EXPECT_EQ(to_char(dna3bs{}.assign_char('Y')), 'T');
-    EXPECT_EQ(to_char(dna3bs{}.assign_char('S')), 'T');
-    EXPECT_EQ(to_char(dna3bs{}.assign_char('W')), 'A');
-    EXPECT_EQ(to_char(dna3bs{}.assign_char('K')), 'G');
-    EXPECT_EQ(to_char(dna3bs{}.assign_char('M')), 'A');
-    EXPECT_EQ(to_char(dna3bs{}.assign_char('B')), 'T');
-    EXPECT_EQ(to_char(dna3bs{}.assign_char('D')), 'A');
-    EXPECT_EQ(to_char(dna3bs{}.assign_char('H')), 'A');
-    EXPECT_EQ(to_char(dna3bs{}.assign_char('V')), 'A');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna3bs{}.assign_char('R')), 'A');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna3bs{}.assign_char('Y')), 'T');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna3bs{}.assign_char('S')), 'T');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna3bs{}.assign_char('W')), 'A');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna3bs{}.assign_char('K')), 'G');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna3bs{}.assign_char('M')), 'A');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna3bs{}.assign_char('B')), 'T');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna3bs{}.assign_char('D')), 'A');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna3bs{}.assign_char('H')), 'A');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna3bs{}.assign_char('V')), 'A');
 
-    EXPECT_EQ(to_char(dna3bs{}.assign_char('N')), 'A');
-    EXPECT_EQ(to_char(dna3bs{}.assign_char('!')), 'A');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna3bs{}.assign_char('N')), 'A');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna3bs{}.assign_char('!')), 'A');
 }
 
 TEST(dna3bs, char_literal)
 {
-    EXPECT_EQ(to_char('A'_dna3bs), 'A');
-    EXPECT_EQ(to_char('C'_dna3bs), 'T');
-    EXPECT_EQ(to_char('G'_dna3bs), 'G');
+    EXPECT_EQ(seqan3::to_char('A'_dna3bs), 'A');
+    EXPECT_EQ(seqan3::to_char('C'_dna3bs), 'T');
+    EXPECT_EQ(seqan3::to_char('G'_dna3bs), 'G');
 
-    EXPECT_EQ(to_char('U'_dna3bs), 'T');
-    EXPECT_EQ(to_char('T'_dna3bs), 'T');
+    EXPECT_EQ(seqan3::to_char('U'_dna3bs), 'T');
+    EXPECT_EQ(seqan3::to_char('T'_dna3bs), 'T');
 
-    EXPECT_EQ(to_char('R'_dna3bs), 'A');
-    EXPECT_EQ(to_char('Y'_dna3bs), 'T');
-    EXPECT_EQ(to_char('S'_dna3bs), 'T');
-    EXPECT_EQ(to_char('W'_dna3bs), 'A');
-    EXPECT_EQ(to_char('K'_dna3bs), 'G');
-    EXPECT_EQ(to_char('M'_dna3bs), 'A');
-    EXPECT_EQ(to_char('B'_dna3bs), 'T');
-    EXPECT_EQ(to_char('D'_dna3bs), 'A');
-    EXPECT_EQ(to_char('H'_dna3bs), 'A');
-    EXPECT_EQ(to_char('V'_dna3bs), 'A');
+    EXPECT_EQ(seqan3::to_char('R'_dna3bs), 'A');
+    EXPECT_EQ(seqan3::to_char('Y'_dna3bs), 'T');
+    EXPECT_EQ(seqan3::to_char('S'_dna3bs), 'T');
+    EXPECT_EQ(seqan3::to_char('W'_dna3bs), 'A');
+    EXPECT_EQ(seqan3::to_char('K'_dna3bs), 'G');
+    EXPECT_EQ(seqan3::to_char('M'_dna3bs), 'A');
+    EXPECT_EQ(seqan3::to_char('B'_dna3bs), 'T');
+    EXPECT_EQ(seqan3::to_char('D'_dna3bs), 'A');
+    EXPECT_EQ(seqan3::to_char('H'_dna3bs), 'A');
+    EXPECT_EQ(seqan3::to_char('V'_dna3bs), 'A');
 
-    EXPECT_EQ(to_char('N'_dna3bs), 'A');
-    EXPECT_EQ(to_char('!'_dna3bs), 'A');
+    EXPECT_EQ(seqan3::to_char('N'_dna3bs), 'A');
+    EXPECT_EQ(seqan3::to_char('!'_dna3bs), 'A');
 }
 
 TEST(dna3bs, string_literal)
 {
-    dna3bs_vector v;
+    seqan3::dna3bs_vector v;
     v.resize(5, 'A'_dna3bs);
     EXPECT_EQ(v, "AAAAA"_dna3bs);
 
-    std::vector<dna3bs> w{'A'_dna3bs, 'C'_dna3bs, 'G'_dna3bs, 'T'_dna3bs, 'U'_dna3bs, 'N'_dna3bs};
+    std::vector<seqan3::dna3bs> w{'A'_dna3bs, 'C'_dna3bs, 'G'_dna3bs, 'T'_dna3bs, 'U'_dna3bs, 'N'_dna3bs};
     EXPECT_EQ(w, "ATGTTA"_dna3bs);
 }
 
 TEST(dna3bs, char_is_valid)
 {
-    constexpr auto validator = is_char<'A'> || is_char<'G'> || is_char<'T'> || is_char<'U'>
-                            || is_char<'a'> || is_char<'g'> || is_char<'t'> || is_char<'u'>;
+    constexpr auto validator = seqan3::is_char<'A'> || seqan3::is_char<'G'> || seqan3::is_char<'T'>
+                            || seqan3::is_char<'U'> || seqan3::is_char<'a'> || seqan3::is_char<'g'>
+                            || seqan3::is_char<'t'> || seqan3::is_char<'u'>;
     for (char c : std::views::iota(std::numeric_limits<char>::min(), std::numeric_limits<char>::max()))
-        EXPECT_EQ(dna3bs::char_is_valid(c), validator(c));
+        EXPECT_EQ(seqan3::dna3bs::char_is_valid(c), validator(c));
 }

--- a/test/unit/alphabet/semi_alphabet_constexpr_test_template.hpp
+++ b/test/unit/alphabet/semi_alphabet_constexpr_test_template.hpp
@@ -9,8 +9,6 @@
 
 #include <seqan3/alphabet/concept.hpp>
 
-using namespace seqan3;
-
 template <typename T>
 using semi_alphabet_constexpr = ::testing::Test;
 
@@ -18,17 +16,17 @@ TYPED_TEST_CASE_P(semi_alphabet_constexpr);
 
 TYPED_TEST_P(semi_alphabet_constexpr, concept_check)
 {
-    EXPECT_TRUE(detail::constexpr_semialphabet<TypeParam>);
-    EXPECT_TRUE(detail::constexpr_semialphabet<TypeParam &>);
+    EXPECT_TRUE(seqan3::detail::constexpr_semialphabet<TypeParam>);
+    EXPECT_TRUE(seqan3::detail::constexpr_semialphabet<TypeParam &>);
 
-    EXPECT_TRUE(detail::constexpr_semialphabet<TypeParam const>);
-    EXPECT_TRUE(detail::constexpr_semialphabet<TypeParam const &>);
+    EXPECT_TRUE(seqan3::detail::constexpr_semialphabet<TypeParam const>);
+    EXPECT_TRUE(seqan3::detail::constexpr_semialphabet<TypeParam const &>);
 
-    EXPECT_TRUE(detail::writable_constexpr_semialphabet<TypeParam>);
-    EXPECT_TRUE(detail::writable_constexpr_semialphabet<TypeParam &>);
+    EXPECT_TRUE(seqan3::detail::writable_constexpr_semialphabet<TypeParam>);
+    EXPECT_TRUE(seqan3::detail::writable_constexpr_semialphabet<TypeParam &>);
 
-    EXPECT_FALSE(detail::writable_constexpr_semialphabet<TypeParam const>);
-    EXPECT_FALSE(detail::writable_constexpr_semialphabet<TypeParam const &>);
+    EXPECT_FALSE(seqan3::detail::writable_constexpr_semialphabet<TypeParam const>);
+    EXPECT_FALSE(seqan3::detail::writable_constexpr_semialphabet<TypeParam const &>);
 }
 
 TYPED_TEST_P(semi_alphabet_constexpr, default_value_constructor)
@@ -38,21 +36,21 @@ TYPED_TEST_P(semi_alphabet_constexpr, default_value_constructor)
 
 TYPED_TEST_P(semi_alphabet_constexpr, global_assign_rank)
 {
-    constexpr size_t rank = 1 % alphabet_size<TypeParam>;
+    constexpr size_t rank = 1 % seqan3::alphabet_size<TypeParam>;
     [[maybe_unused]] constexpr TypeParam t0{seqan3::assign_rank_to(rank, TypeParam{})};
 }
 
 TYPED_TEST_P(semi_alphabet_constexpr, global_to_rank)
 {
-    constexpr size_t rank = 1 % alphabet_size<TypeParam>;
+    constexpr size_t rank = 1 % seqan3::alphabet_size<TypeParam>;
     constexpr TypeParam t0{seqan3::assign_rank_to(rank, TypeParam{})};
-    constexpr bool b = (to_rank(t0) == rank);
+    constexpr bool b = (seqan3::to_rank(t0) == rank);
     EXPECT_TRUE(b);
 }
 
 TYPED_TEST_P(semi_alphabet_constexpr, copy_constructor)
 {
-    constexpr alphabet_rank_t<TypeParam> rank = 1 % alphabet_size<TypeParam>;
+    constexpr seqan3::alphabet_rank_t<TypeParam> rank = 1 % seqan3::alphabet_size<TypeParam>;
     constexpr TypeParam t1{seqan3::assign_rank_to(rank, TypeParam{})};
 
     constexpr TypeParam t2{t1};
@@ -63,7 +61,7 @@ TYPED_TEST_P(semi_alphabet_constexpr, copy_constructor)
 
 TYPED_TEST_P(semi_alphabet_constexpr, move_constructor)
 {
-    constexpr alphabet_rank_t<TypeParam> rank = 1 % alphabet_size<TypeParam>;
+    constexpr seqan3::alphabet_rank_t<TypeParam> rank = 1 % seqan3::alphabet_size<TypeParam>;
     constexpr TypeParam t0{seqan3::assign_rank_to(rank, TypeParam{})};
     constexpr TypeParam t1{t0};
 
@@ -75,7 +73,7 @@ TYPED_TEST_P(semi_alphabet_constexpr, move_constructor)
 
 TYPED_TEST_P(semi_alphabet_constexpr, copy_assignment)
 {
-    constexpr size_t rank = 1 % alphabet_size<TypeParam>;
+    constexpr size_t rank = 1 % seqan3::alphabet_size<TypeParam>;
     constexpr TypeParam t0{seqan3::assign_rank_to(rank, TypeParam{})};
     // constexpr context:
     constexpr TypeParam t3 = [&] () constexpr
@@ -91,7 +89,7 @@ TYPED_TEST_P(semi_alphabet_constexpr, copy_assignment)
 
 TYPED_TEST_P(semi_alphabet_constexpr, move_assignment)
 {
-    constexpr size_t rank = 1 % alphabet_size<TypeParam>;
+    constexpr size_t rank = 1 % seqan3::alphabet_size<TypeParam>;
     constexpr TypeParam t0{seqan3::assign_rank_to(rank, TypeParam{})};
     // constexpr context:
     constexpr TypeParam t3 = [&] () constexpr
@@ -107,7 +105,7 @@ TYPED_TEST_P(semi_alphabet_constexpr, move_assignment)
 
 TYPED_TEST_P(semi_alphabet_constexpr, comparison_operators)
 {
-    if constexpr (alphabet_size<TypeParam> == 1)
+    if constexpr (seqan3::alphabet_size<TypeParam> == 1)
     {
         constexpr TypeParam t0{};
         constexpr TypeParam t1{};

--- a/test/unit/alphabet/semi_alphabet_test_template.hpp
+++ b/test/unit/alphabet/semi_alphabet_test_template.hpp
@@ -12,8 +12,6 @@
 #include <seqan3/core/concept/core_language.hpp>
 #include <seqan3/test/pretty_printing.hpp>
 
-using namespace seqan3;
-
 template <typename T>
 using semi_alphabet_test = ::testing::Test;
 
@@ -23,15 +21,15 @@ TYPED_TEST_CASE_P(semi_alphabet_test);
 
 TYPED_TEST_P(semi_alphabet_test, concept_check)
 {
-    EXPECT_TRUE(semialphabet<TypeParam>);
-    EXPECT_TRUE(semialphabet<TypeParam &>);
-    EXPECT_TRUE(semialphabet<TypeParam const>);
-    EXPECT_TRUE(semialphabet<TypeParam const &>);
+    EXPECT_TRUE(seqan3::semialphabet<TypeParam>);
+    EXPECT_TRUE(seqan3::semialphabet<TypeParam &>);
+    EXPECT_TRUE(seqan3::semialphabet<TypeParam const>);
+    EXPECT_TRUE(seqan3::semialphabet<TypeParam const &>);
 
-    EXPECT_TRUE(writable_semialphabet<TypeParam>);
-    EXPECT_TRUE(writable_semialphabet<TypeParam &>);
-    EXPECT_FALSE(writable_semialphabet<TypeParam const>);
-    EXPECT_FALSE(writable_semialphabet<TypeParam const &>);
+    EXPECT_TRUE(seqan3::writable_semialphabet<TypeParam>);
+    EXPECT_TRUE(seqan3::writable_semialphabet<TypeParam &>);
+    EXPECT_FALSE(seqan3::writable_semialphabet<TypeParam const>);
+    EXPECT_FALSE(seqan3::writable_semialphabet<TypeParam const &>);
 }
 
 TYPED_TEST_P(semi_alphabet_test, type_properties)
@@ -44,7 +42,7 @@ TYPED_TEST_P(semi_alphabet_test, type_properties)
 
 TYPED_TEST_P(semi_alphabet_test, alphabet_size_)
 {
-    EXPECT_GT(alphabet_size<TypeParam>, 0u);
+    EXPECT_GT(seqan3::alphabet_size<TypeParam>, 0u);
 }
 
 TYPED_TEST_P(semi_alphabet_test, default_value_constructor)
@@ -58,7 +56,7 @@ TYPED_TEST_P(semi_alphabet_test, global_assign_rank_to)
     EXPECT_EQ((seqan3::assign_rank_to(0, TypeParam{})), TypeParam{});
 
     TypeParam t0;
-    for (size_t i = 0u; i < alphabet_size<TypeParam> && i < maximum_iterations; ++i)
+    for (size_t i = 0u; i < seqan3::alphabet_size<TypeParam> && i < maximum_iterations; ++i)
         seqan3::assign_rank_to(i, t0);
 
     EXPECT_TRUE((std::is_same_v<decltype(seqan3::assign_rank_to(0, t0)), TypeParam &>));
@@ -71,17 +69,17 @@ TYPED_TEST_P(semi_alphabet_test, global_to_rank)
     EXPECT_EQ(seqan3::to_rank(TypeParam{}), 0u);
 
     TypeParam t0;
-    for (size_t i = 0; i < alphabet_size<TypeParam> && i < maximum_iterations; ++i)
+    for (size_t i = 0; i < seqan3::alphabet_size<TypeParam> && i < maximum_iterations; ++i)
         EXPECT_EQ((seqan3::to_rank(seqan3::assign_rank_to(i, t0))), i);
 
-    EXPECT_TRUE((std::is_same_v<decltype(seqan3::to_rank(t0)), alphabet_rank_t<TypeParam>>));
+    EXPECT_TRUE((std::is_same_v<decltype(seqan3::to_rank(t0)), seqan3::alphabet_rank_t<TypeParam>>));
 }
 
 TYPED_TEST_P(semi_alphabet_test, copy_constructor)
 {
     // the module operation ensures that the result is within the valid rank range;
     // it will be in the most cases 1 except for alphabets like seqan3::gap where it will be 0
-    constexpr alphabet_rank_t<TypeParam> rank = 1 % alphabet_size<TypeParam>;
+    constexpr seqan3::alphabet_rank_t<TypeParam> rank = 1 % seqan3::alphabet_size<TypeParam>;
     TypeParam t1;
     seqan3::assign_rank_to(rank, t1);
     TypeParam t2{t1};
@@ -92,7 +90,7 @@ TYPED_TEST_P(semi_alphabet_test, copy_constructor)
 
 TYPED_TEST_P(semi_alphabet_test, move_constructor)
 {
-    constexpr alphabet_rank_t<TypeParam> rank = 1 % alphabet_size<TypeParam>;
+    constexpr seqan3::alphabet_rank_t<TypeParam> rank = 1 % seqan3::alphabet_size<TypeParam>;
     TypeParam t0;
     seqan3::assign_rank_to(rank, t0);
     TypeParam t1{t0};
@@ -105,7 +103,7 @@ TYPED_TEST_P(semi_alphabet_test, move_constructor)
 
 TYPED_TEST_P(semi_alphabet_test, copy_assignment)
 {
-    constexpr alphabet_rank_t<TypeParam> rank = 1 % alphabet_size<TypeParam>;
+    constexpr seqan3::alphabet_rank_t<TypeParam> rank = 1 % seqan3::alphabet_size<TypeParam>;
     TypeParam t1;
     seqan3::assign_rank_to(rank, t1);
     TypeParam t2;
@@ -115,7 +113,7 @@ TYPED_TEST_P(semi_alphabet_test, copy_assignment)
 
 TYPED_TEST_P(semi_alphabet_test, move_assignment)
 {
-    constexpr alphabet_rank_t<TypeParam> rank = 1 % alphabet_size<TypeParam>;
+    constexpr seqan3::alphabet_rank_t<TypeParam> rank = 1 % seqan3::alphabet_size<TypeParam>;
     TypeParam t0;
     seqan3::assign_rank_to(rank, t0);
     TypeParam t1{t0};
@@ -129,7 +127,7 @@ TYPED_TEST_P(semi_alphabet_test, move_assignment)
 
 TYPED_TEST_P(semi_alphabet_test, swap)
 {
-    constexpr alphabet_rank_t<TypeParam> rank = 1 % alphabet_size<TypeParam>;
+    constexpr seqan3::alphabet_rank_t<TypeParam> rank = 1 % seqan3::alphabet_size<TypeParam>;
     TypeParam t0;
     seqan3::assign_rank_to(rank, t0);
     TypeParam t1{t0};
@@ -147,7 +145,7 @@ TYPED_TEST_P(semi_alphabet_test, comparison_operators)
     TypeParam t1{};
 
     seqan3::assign_rank_to(0, t0);
-    seqan3::assign_rank_to(1 % alphabet_size<TypeParam>, t1);
+    seqan3::assign_rank_to(1 % seqan3::alphabet_size<TypeParam>, t1);
 
     EXPECT_EQ(t0, t0);
     EXPECT_LE(t0, t1);
@@ -156,7 +154,7 @@ TYPED_TEST_P(semi_alphabet_test, comparison_operators)
     EXPECT_GE(t1, t1);
     EXPECT_GE(t1, t0);
 
-    if constexpr (alphabet_size<TypeParam> == 1)
+    if constexpr (seqan3::alphabet_size<TypeParam> == 1)
     {
         EXPECT_EQ(t0, t1);
     }

--- a/test/unit/alphabet/structure/dot_bracket3_test.cpp
+++ b/test/unit/alphabet/structure/dot_bracket3_test.cpp
@@ -14,10 +14,12 @@
 #include "../semi_alphabet_constexpr_test_template.hpp"
 #include "../semi_alphabet_test_template.hpp"
 
-INSTANTIATE_TYPED_TEST_CASE_P(dot_bracket3, alphabet_, dot_bracket3);
-INSTANTIATE_TYPED_TEST_CASE_P(dot_bracket3, semi_alphabet_test, dot_bracket3);
-INSTANTIATE_TYPED_TEST_CASE_P(dot_bracket3, alphabet_constexpr, dot_bracket3);
-INSTANTIATE_TYPED_TEST_CASE_P(dot_bracket3, semi_alphabet_constexpr, dot_bracket3);
+INSTANTIATE_TYPED_TEST_CASE_P(dot_bracket3, alphabet_, seqan3::dot_bracket3);
+INSTANTIATE_TYPED_TEST_CASE_P(dot_bracket3, semi_alphabet_test, seqan3::dot_bracket3);
+INSTANTIATE_TYPED_TEST_CASE_P(dot_bracket3, alphabet_constexpr, seqan3::dot_bracket3);
+INSTANTIATE_TYPED_TEST_CASE_P(dot_bracket3, semi_alphabet_constexpr, seqan3::dot_bracket3);
+
+using namespace seqan3;
 
 // concepts
 TEST(dot_bracket3, concept_check)

--- a/test/unit/alphabet/structure/dssp9_test.cpp
+++ b/test/unit/alphabet/structure/dssp9_test.cpp
@@ -13,10 +13,12 @@
 #include "../semi_alphabet_constexpr_test_template.hpp"
 #include "../semi_alphabet_test_template.hpp"
 
-INSTANTIATE_TYPED_TEST_CASE_P(dssp9, alphabet_, dssp9);
-INSTANTIATE_TYPED_TEST_CASE_P(dssp9, semi_alphabet_test, dssp9);
-INSTANTIATE_TYPED_TEST_CASE_P(dssp9, alphabet_constexpr, dssp9);
-INSTANTIATE_TYPED_TEST_CASE_P(dssp9, semi_alphabet_constexpr, dssp9);
+INSTANTIATE_TYPED_TEST_CASE_P(dssp9, alphabet_, seqan3::dssp9);
+INSTANTIATE_TYPED_TEST_CASE_P(dssp9, semi_alphabet_test, seqan3::dssp9);
+INSTANTIATE_TYPED_TEST_CASE_P(dssp9, alphabet_constexpr, seqan3::dssp9);
+INSTANTIATE_TYPED_TEST_CASE_P(dssp9, semi_alphabet_constexpr, seqan3::dssp9);
+
+using namespace seqan3;
 
 // assign_char functions
 TEST(dssp9, assign_char)

--- a/test/unit/alphabet/structure/wuss_test.cpp
+++ b/test/unit/alphabet/structure/wuss_test.cpp
@@ -14,6 +14,8 @@
 #include "../semi_alphabet_constexpr_test_template.hpp"
 #include "../semi_alphabet_test_template.hpp"
 
+using namespace seqan3;
+
 INSTANTIATE_TYPED_TEST_CASE_P(wuss51, alphabet_, wuss51);
 INSTANTIATE_TYPED_TEST_CASE_P(wuss51, semi_alphabet_test, wuss51);
 INSTANTIATE_TYPED_TEST_CASE_P(wuss51, alphabet_constexpr, wuss51);


### PR DESCRIPTION
  * This PR cleans up the mess in the composite alphabets that wrongly used free function operators which led to spurious compile failures because they were considered in entirely unrelated situations.
  * The composites now used friends that are constrained via SFINAE, because friends can't be constrained with concepts in GCC Concepts TS.
  * Many unused overloads were removed and also a lot of useless meta-machinery.
  * Fixes a design bug: a `alphabet_variant<a>` should only be implicitly constructible from `b`, if `a` is implicitly constructible from `b`. Previously it was possible to implicitly construct the variant, even if `a` can only be explicitly constructed from `b`. I added `explicit` to the respective constructor and fixed one affected test-case.
  * I have added tests, because of a lot of behaviour was previously untested. Only a single test was modified, because the behaviour it tested should never have worked.
  * Fixed a bunch of small things a long the way (in separate commits).

The main work is the fourth commit. I recommend to review by commit.