### PR TITLE
[MISC] Change value_list_validator construction.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ If possible, provide tooling that performs the changes, e.g. a shell-script.
 
 #### Argument parser
 * Simplified reading file extensions from formatted files in the input/output file validators.
+* The seqan3::value_list_validator is now constructible from a range or a parameter pack.
 * Enable subcommand argument parsing ([How-to](https://docs.seqan.de/seqan/3-master-user/subcommand_arg_parse.html)).
 
 #### Core
@@ -42,6 +43,8 @@ If possible, provide tooling that performs the changes, e.g. a shell-script.
 
 #### Argument parser
 
+* The seqan3::value_list_validator is not constructible from a std::initialiser_list any more
+  (e.g. `seqan3::value_list_validator{{1,2,3}}` does **not** work, use `seqan3::value_list_validator{1,2,3}` instead).
 * **Changed class signature of input/output file validators:**
   Most user code will be unaffected; to fix possible compiler errors you need to add an empty template parameter list to
   the respective instances (e.g. change `input_file_validator` to `input_file_validator<>`).

--- a/doc/tutorial/argument_parser/solution6.cpp
+++ b/doc/tutorial/argument_parser/solution6.cpp
@@ -90,7 +90,7 @@ void initialize_argument_parser(argument_parser & parser, cmd_arguments & args)
 
     //![value_list_validator]
     parser.add_option(args.aggregate_by, 'a', "aggregate-by", "Choose your method of aggregation.",
-                      option_spec::DEFAULT, value_list_validator{{"median", "mean"}});
+                      option_spec::DEFAULT, value_list_validator{"median", "mean"});
     //![value_list_validator]
 
     parser.add_flag(args.header_is_set, 'H', "header-is-set", "Let us know whether your data file contains a "

--- a/test/snippet/argument_parser/validators_2.cpp
+++ b/test/snippet/argument_parser/validators_2.cpp
@@ -7,7 +7,7 @@ int main(int argc, const char ** argv)
 
     //![validator_call]
     int myint;
-    seqan3::value_list_validator my_validator{{2, 4, 6, 8, 10}};
+    seqan3::value_list_validator my_validator{2, 4, 6, 8, 10};
 
     myparser.add_option(myint,'i',"integer","Give me a number.",
                         seqan3::option_spec::DEFAULT, my_validator);


### PR DESCRIPTION
Part of #1196 

I noticed that you cannot construct a value_list_validator from a simple range (only from a vector or initialiser list). I added construction from a range, as well as construction from a parameter pack which makes initialiser lists obsolete, but this is an API break. @seqan/core Should I still provide an initialiser list constructor?

Also: where in the changelog did we report API changes?


```cpp
// What worked before and still works now:
std::vector<int> v{0, 1, 2};
seqan3::value_list_validator{v}; // l/rvalue std::vector 

// What works now that hasn't worked before:
seqan3::value_list_validator{0, 1, 2}; // parameter pack
seqan3::value_list_validator{v | views::take(2)}; // ranges/views

// What worked before but does not work anymore:
seqan3::value_list_validator{{0, 1, 2}}; // initialiser list
```
