### PR TITLE
[FIX] ICE in constexpr alphabet tests

### DIFF
--- a/test/unit/alphabet/alphabet_constexpr_test_template.hpp
+++ b/test/unit/alphabet/alphabet_constexpr_test_template.hpp
@@ -38,7 +38,7 @@ TYPED_TEST_P(alphabet_constexpr, global_assign_char)
 
 TYPED_TEST_P(alphabet_constexpr, global_to_char)
 {
-    constexpr TypeParam t0{};
+    constexpr TypeParam t0{TypeParam{}};
     [[maybe_unused]] constexpr alphabet_char_t<TypeParam> c = seqan3::to_char(t0);
 }
 


### PR DESCRIPTION
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=91607