### PR TITLE
Range awareness for execution handler.

### DIFF
--- a/include/seqan3/alignment/pairwise/execution/execution_handler_parallel.hpp
+++ b/include/seqan3/alignment/pairwise/execution/execution_handler_parallel.hpp
@@ -99,15 +99,15 @@ public:
     /*!\brief Invokes the passed alignment instance in a non-blocking manner.
      * \copydetails execution_handler_sequential::execute
      */
-    template <typename fn_type, typename first_range_type, typename second_range_type, typename delegate_type>
+    template <typename algorithm_t, typename first_range_type, typename second_range_type, typename delegate_type>
     //!\cond
-        requires std::invocable<fn_type, size_t const, first_range_type, second_range_type> &&
-                 std::invocable<delegate_type, std::invoke_result_t<fn_type,
+        requires std::invocable<algorithm_t, size_t const, first_range_type, second_range_type> &&
+                 std::invocable<delegate_type, std::invoke_result_t<algorithm_t,
                                                                     size_t const,
                                                                     first_range_type,
                                                                     second_range_type>>
     //!\endcond
-    void execute(fn_type && func,
+    void execute(algorithm_t && algorithm,
                  size_t const idx,
                  first_range_type first_range,
                  second_range_type second_range,
@@ -120,7 +120,7 @@ public:
 
         task_type task = [=, first_range = std::move(first_range), second_range = std::move(second_range)] ()
         {
-            delegate(func(idx, std::move(first_range), std::move(second_range)));
+            delegate(algorithm(idx, std::move(first_range), std::move(second_range)));
         };
         // Asynchronously pushes the task to the queue.
         [[maybe_unused]] contrib::queue_op_status status = state->queue.wait_push(std::move(task));

--- a/include/seqan3/alignment/pairwise/execution/execution_handler_sequential.hpp
+++ b/include/seqan3/alignment/pairwise/execution/execution_handler_sequential.hpp
@@ -15,6 +15,7 @@
 #include <functional>
 
 #include <seqan3/core/platform.hpp>
+#include <seqan3/range/views/view_all.hpp>
 #include <seqan3/std/concepts>
 #include <seqan3/std/ranges>
 
@@ -29,28 +30,28 @@ struct execution_handler_sequential
 public:
 
     /*!\brief Invokes the passed alignment instance in a blocking manner.
-     * \tparam fn_type           The callable that needs to be invoked; must model std::invocable with first_range_type
+     * \tparam algorithm_t       The callable that needs to be invoked; must model std::invocable with first_range_type
      *                           and second_range_type.
      * \tparam first_range_type  The type of the first range; must model std::ranges::view.
      * \tparam second_range_type The type of the second range; must model std::ranges::view.
-     * \tparam delegate_type     The type of the callable invoked on the std::invoke_result of `fn_type`; must model
+     * \tparam delegate_type     The type of the callable invoked on the std::invoke_result of `algorithm_t`; must model
      *                           std::invocable.
      *
-     * \param[in] func         The callable invoking the alignment algorithm.
+     * \param[in] algorithm    The alignment algorithm to invoke.
      * \param[in] idx          The index of the current processed sequence pair.
      * \param[in] first_range  The first range.
      * \param[in] second_range The second range.
      * \param[in] delegate     The callable invoked with the result of the alignment.
      */
-    template <typename fn_type, typename first_range_type, typename second_range_type, typename delegate_type>
+    template <typename algorithm_t, typename first_range_type, typename second_range_type, typename delegate_type>
     //!\cond
-        requires std::invocable<fn_type, size_t const, first_range_type, second_range_type> &&
-                 std::invocable<delegate_type, std::invoke_result_t<fn_type,
+        requires std::invocable<algorithm_t, size_t const, first_range_type, second_range_type> &&
+                 std::invocable<delegate_type, std::invoke_result_t<algorithm_t,
                                                                     size_t const,
                                                                     first_range_type,
                                                                     second_range_type>>
     //!\endcond
-    void execute(fn_type && func,
+    void execute(algorithm_t && algorithm,
                  size_t const idx,
                  first_range_type first_range,
                  second_range_type second_range,
@@ -59,7 +60,27 @@ public:
         static_assert(std::ranges::view<first_range_type>, "Expected a view!");
         static_assert(std::ranges::view<second_range_type>, "Expected a view!");
 
-        delegate(func(idx, std::move(first_range), std::move(second_range)));
+        delegate(algorithm(idx, std::move(first_range), std::move(second_range)));
+    }
+
+    /*!\brief Takes underlying range of sequence pairs and invokes an alignment on each instance.
+     * \tparam algorithm_t              The type of the alignment algorithm.
+     * \tparam indexed_sequence_pairs_t The type of underlying sequence pairs annotated with an index;
+     *                                  must model std::ranges::forward_range.
+     * \tparam delegate_type            The type of the callable invoked on the std::invoke_result of `algorithm_t`.
+     *
+     * \param[in] algorithm              The alignment algorithm to invoke.
+     * \param[in] indexed_sequence_pairs The range of underlying annotated sequence pairs to be aligned.
+     * \param[in] delegate               A callable which will be invoked on each result of the computed alignments.
+     */
+    template <typename algorithm_t, std::ranges::forward_range indexed_sequence_pairs_t, typename delegate_type>
+    void execute(algorithm_t && algorithm,
+                 indexed_sequence_pairs_t indexed_sequence_pairs,
+                 delegate_type && delegate)
+    {
+        using std::get;
+        for (auto && [sequence_pair, idx] : indexed_sequence_pairs)
+            execute(std::forward<algorithm_t>(algorithm), idx, get<0>(sequence_pair), get<1>(sequence_pair), delegate);
     }
 
     //!\brief Waits for the submitted alignments jobs to finish. (Noop).


### PR DESCRIPTION
Resolves  Issue #1308

Added interface that takes underlying range of sequence pairs and executes a callback on the results.
The proposed function`execution_handler.execute(config, start_id, [(s1,s2),...],callback)` was changed to 
`execution_handler.execute(config, [(id, s1,s2),...],callback)` to simply the usage of this function.
 in execution_handler_sequential.

Example call for this function in include/seqan3/alignment/pairwise/execution/alignment_executor_two_way.hpp can be found here:
https://github.com/svnbgnk/seqan3/tree/range_for_execution_handler_test