### PR TITLE
[FIX] Wrong soft clipping values for short cigar strings of length two was fixed.

### DIFF
--- a/include/seqan3/io/alignment_file/format_sam.hpp
+++ b/include/seqan3/io/alignment_file/format_sam.hpp
@@ -556,17 +556,19 @@ protected:
      */
     void transfer_soft_clipping_to(std::vector<cigar> const & cigar_vector, int32_t & sc_begin, int32_t & sc_end) const
     {
+        auto v_size = cigar_vector.size();
+
         // check for soft clipping at the first two positions
         if (!cigar_vector.empty() && 'S'_cigar_op == cigar_vector[0])
             sc_begin = get<0>(cigar_vector[0]);
-        else if (cigar_vector.size() > 1 && 'S'_cigar_op == cigar_vector[1])
+        else if (v_size > 1 && 'H'_cigar_op == cigar_vector[0] && 'S'_cigar_op == cigar_vector[1])
             sc_begin = get<0>(cigar_vector[1]);
 
         // check for soft clipping at the last two positions
-        if (cigar_vector.size() > 1 && 'S'_cigar_op == cigar_vector[cigar_vector.size() - 1])
-            sc_end = get<0>(cigar_vector[cigar_vector.size() - 1]);
-        else if (cigar_vector.size() > 2 && 'S'_cigar_op == cigar_vector[cigar_vector.size() - 2])
-            sc_end = get<0>(cigar_vector[cigar_vector.size() - 2]);
+        if (v_size > 1 && 'S'_cigar_op == cigar_vector[v_size - 1])
+            sc_end = get<0>(cigar_vector[v_size - 1]);
+        else if (v_size > 2 && 'H'_cigar_op == cigar_vector[v_size - 1] && 'S'_cigar_op == cigar_vector[v_size - 2])
+            sc_end = get<0>(cigar_vector[v_size - 2]);
     }
 
     /*!\brief Construct the field::ALIGNMENT depending on the given information.

--- a/test/unit/io/alignment_file/format_sam_test.cpp
+++ b/test/unit/io/alignment_file/format_sam_test.cpp
@@ -254,6 +254,22 @@ TEST_F(sam_format, format_error_invalid_sam_tag_format)
     }
 }
 
+TEST_F(sam_format, short_cigar_string_with_softclipping)
+{
+	// The member function transfer_soft_clipping_to needs to work on 2 element cigar strings
+    {
+        std::istringstream istream("id	16	ref	0	255	10M5S	*	0	0	AGAGGGGGATAACCA	*\n");
+        alignment_file_input fin{istream, ref_ids, ref_sequences, format_sam{}, fields<field::ALIGNMENT>{}};
+        EXPECT_TRUE((std::ranges::equal(get<1>(get<0>(*fin.begin())), "AGAGGGGGAT"_dna5)));
+    }
+
+    {
+        std::istringstream istream("id	16	ref	0	255	5S10M	*	0	0	AGAGGGGGATAACCA	*\n");
+        alignment_file_input fin{istream, ref_ids, ref_sequences, format_sam{}, fields<field::ALIGNMENT>{}};
+        EXPECT_TRUE((std::ranges::equal(get<1>(get<0>(*fin.begin())), "GGGATAACCA"_dna5)));
+    }
+}
+
 TEST_F(sam_format, write_different_header)
 {
     std::ostringstream ostream;


### PR DESCRIPTION
Resolves #1327
