### PR TITLE
[FIXES-1339] avoid underflow for input of size 0 and 1

### DIFF
--- a/include/seqan3/range/views/translate.hpp
+++ b/include/seqan3/range/views/translate.hpp
@@ -319,12 +319,12 @@ public:
             case translation_frames::FWD_FRAME_1:
                 [[fallthrough]];
             case translation_frames::REV_FRAME_1:
-                return (seqan3::size(urange) - 1) / 3;
+                return (std::max<size_type>(seqan3::size(urange), 1) - 1) / 3;
                 break;
             case translation_frames::FWD_FRAME_2:
                 [[fallthrough]];
             case translation_frames::REV_FRAME_2:
-                return (seqan3::size(urange) - 2) / 3;
+                return (std::max<size_type>(seqan3::size(urange), 2) - 2) / 3;
                 break;
             default:
                 throw std::invalid_argument(multiple_frame_error.c_str());
@@ -345,12 +345,12 @@ public:
             case translation_frames::FWD_FRAME_1:
                 [[fallthrough]];
             case translation_frames::REV_FRAME_1:
-                return (seqan3::size(urange) - 1) / 3;
+                return (std::max<size_type>(seqan3::size(urange), 1) - 1) / 3;
                 break;
             case translation_frames::FWD_FRAME_2:
                 [[fallthrough]];
             case translation_frames::REV_FRAME_2:
-                return (seqan3::size(urange) - 2) / 3;
+                return (std::max<size_type>(seqan3::size(urange), 2) - 2) / 3;
                 break;
             default:
                 throw std::invalid_argument(multiple_frame_error.c_str());

--- a/test/unit/range/views/view_translate_test.cpp
+++ b/test/unit/range/views/view_translate_test.cpp
@@ -231,3 +231,30 @@ TYPED_TEST(nucleotide, view_translate_concepts)
     EXPECT_TRUE(std::ranges::sized_range<reference_t<decltype(v1)>>);
     EXPECT_TRUE(std::ranges::view<reference_t<decltype(v1)>>);
 }
+
+TYPED_TEST(nucleotide, issue1339)
+{
+    // empty input
+    std::string in{};
+    std::vector<TypeParam> vec = in | views::char_to<TypeParam> | views::to<std::vector>;
+
+    auto v = vec | views::translate;
+
+    auto out_vecvec = v | views::to<std::vector<std::vector<aa27>>>;
+
+    EXPECT_EQ(out_vecvec.size(), 6u);
+    for (auto & out_vec : out_vecvec)
+        EXPECT_TRUE(out_vec.empty());
+
+    // input of size 1
+    in = "A";
+    vec = in | views::char_to<TypeParam> | views::to<std::vector>;
+
+    v = vec | views::translate;
+
+    out_vecvec = v | views::to<std::vector<std::vector<aa27>>>;
+
+    EXPECT_EQ(out_vecvec.size(), 6u);
+    for (auto & out_vec : out_vecvec)
+        EXPECT_TRUE(out_vec.empty());
+}


### PR DESCRIPTION
fixes #1339

(does this need double review?)