### PR TITLE
[FEATURE] Add a simd vectorised scoring scheme which uses scoring matricies

### DIFF
--- a/include/seqan3/alignment/scoring/detail/simd_matrix_scoring_scheme.hpp
+++ b/include/seqan3/alignment/scoring/detail/simd_matrix_scoring_scheme.hpp
@@ -1,0 +1,186 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides seqan3::detail::simd_matrix_scoring_scheme.
+ * \author Joshua Kim <joshua.kim AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <seqan3/alignment/configuration/align_config_mode.hpp>
+#include <seqan3/alignment/scoring/scoring_scheme_concept.hpp>
+#include <seqan3/alphabet/concept.hpp>
+#include <seqan3/core/concept/cereal.hpp>
+#include <seqan3/core/simd/concept.hpp>
+#include <seqan3/core/simd/simd_algorithm.hpp>
+#include <seqan3/std/concepts>
+
+namespace seqan3::detail
+{
+
+/*!\brief A vectorised scoring scheme to handle scoring matrices.
+ * \ingroup scoring
+ * \tparam simd_score_t The type of the simd vector; must model seqan3::simd::simd_concept.
+ * \tparam alphabet_t The type of the alphabet over which to define the scoring scheme; must model seqan3::semialphabet.
+ * \tparam alignment_t The type of the alignment to compute; must be either seqan3::detail::global_alignment_type or
+ *                     seqan3::detail::local_alignment_type.
+ * \tparam scoring_scheme_t The type of the scoring scheme which will be used. Must model seqan3::scoring_scheme with
+ *                          the given `alphabet_t`.
+ *
+ * \details
+ *
+ * When scoring two seqan3::detail::simd vectors, this performs element-wise lookups of the compared simd vectors
+ * using the underlying scoring matrix and returns the result in another seqan3::detail::simd vector.
+ *
+ * \note Note that the alphabet type information is lost during the conversion to the simd vectors and
+ * only the ranks of the alphabet are used.
+ */
+template <simd_concept simd_score_t, semialphabet alphabet_t, typename alignment_t, typename scoring_scheme_t>
+//!\cond
+    requires scoring_scheme<scoring_scheme_t, alphabet_t> &&
+             (std::same_as<alignment_t, detail::local_alignment_type> ||
+              std::same_as<alignment_t, detail::global_alignment_type>)
+//!\endcond
+class simd_matrix_scoring_scheme
+{
+public:
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    constexpr simd_matrix_scoring_scheme() = default; //!< Defaulted.
+    constexpr simd_matrix_scoring_scheme(simd_matrix_scoring_scheme const &) = default; //!< Defaulted.
+    constexpr simd_matrix_scoring_scheme(simd_matrix_scoring_scheme &&) = default; //!< Defaulted.
+    constexpr simd_matrix_scoring_scheme & operator=(simd_matrix_scoring_scheme const &) = default; //!< Defaulted.
+    constexpr simd_matrix_scoring_scheme & operator=(simd_matrix_scoring_scheme &&) = default; //!< Defaulted.
+    ~simd_matrix_scoring_scheme() = default; //!< Defaulted.
+
+    //!\copydoc seqan3::detail::simd_matrix_scoring_scheme::initialise_from_scalar_scoring_scheme
+    constexpr explicit simd_matrix_scoring_scheme(scoring_scheme_t const & scoring_scheme)
+    {
+        initialise_from_scalar_scoring_scheme(scoring_scheme);
+    }
+
+    //!\copydoc seqan3::detail::simd_matrix_scoring_scheme::initialise_from_scalar_scoring_scheme
+    constexpr simd_matrix_scoring_scheme & operator=(scoring_scheme_t const & scoring_scheme)
+    {
+        initialise_from_scalar_scoring_scheme(scoring_scheme);
+        return *this;
+    }
+    //!\}
+
+    /*!\name Score computation
+     *\{
+     */
+    /*!\brief Given two simd vectors, compute an element-wise score and return another simd vector.
+     * \param[in] lhs The left operand to compare.
+     * \param[in] rhs The right operand to compare.
+     * \returns A simd vector of the same type as the input, with scores computed between both inputs.
+     *
+     * ### Exception
+     *
+     * No-throw guarantee.
+     *
+     * ### Complexity
+     *
+     * Linear in the length of one input vector (`lhs` and `rhs` are equally sized).
+     *
+     * ### Thread safety
+     *
+     * Thread-safe.
+     */
+    constexpr simd_score_t score(simd_score_t const & lhs, simd_score_t const & rhs) const noexcept
+    {
+        simd_score_t result{};
+
+        for (size_t i = 0; i < simd_traits<simd_score_t>::length; ++i)
+        {
+            if (is_padded(lhs[i]) || is_padded(rhs[i]))
+            {
+                if constexpr (std::same_as<alignment_t, detail::global_alignment_type>)
+                    result[i] = 1;
+                else
+                    result[i] = -1;
+            }
+            else
+            {
+                result[i] = internal_scoring_scheme.score(assign_rank_to(lhs[i], alphabet_t{}),
+                                                          assign_rank_to(rhs[i], alphabet_t{}));
+            }
+        }
+
+        return result;
+    }
+    //!\}
+
+private:
+    //!\brief Internally stores the given scalar scoring scheme matrix.
+    scoring_scheme_t internal_scoring_scheme;
+
+    /*!\brief Store the given scoring scheme matrix into a private member variable.
+     * \param[in] scoring_scheme The scoring scheme to initialise the vectorised match and mismatch score with.
+     */
+    constexpr void initialise_from_scalar_scoring_scheme(scoring_scheme_t const & scoring_scheme)
+    {
+        using score_t = decltype(std::declval<scoring_scheme_t const &>().score(alphabet_t{}, alphabet_t{}));
+        using simd_scalar_t = typename simd_traits<simd_score_t>::scalar_type;
+
+        // Check if the scoring scheme match and mismatch scores do not overflow with the respective scalar type.
+        if constexpr (sizeof(simd_scalar_t) < sizeof(score_t))
+        {
+            if (min_or_max_exceeded<score_t, simd_scalar_t>(scoring_scheme))
+                throw std::invalid_argument{"The selected scoring scheme score overflows "
+                                            "for the selected scalar type of the simd type."};
+        }
+
+        internal_scoring_scheme = scoring_scheme;
+    }
+
+    /*!\brief Check if any score in the scoring scheme matrix exceeds the min or max value allowed by the simd vector.
+     * \param[in] scoring_scheme The scoring scheme to check for min or max violations.
+     * \tparam score_t The type of the scores in the scoring scheme matrix.
+     * \tparam simd_scalar_t The type of the simd vector.
+     * \returns Returns `true` if it encounters a value larger than the maximum or lower than the minimum allowed by
+     *          the simd vector, and `false` if otherwise.
+     */
+    template <typename score_t, typename simd_scalar_t>
+    constexpr bool min_or_max_exceeded(scoring_scheme_t const & scoring_scheme)
+    {
+        score_t max_val = static_cast<score_t>(std::numeric_limits<simd_scalar_t>::max());
+        score_t min_val = static_cast<score_t>(std::numeric_limits<simd_scalar_t>::lowest());
+
+        for (uint8_t i = 0; i < alphabet_size<alphabet_t>; ++i)
+        {
+            for (uint8_t j = 0; j < alphabet_size<alphabet_t>; ++j)
+            {
+                score_t tmp_score = scoring_scheme.score(assign_rank_to(i, alphabet_t{}),
+                                                         assign_rank_to(j, alphabet_t{}));
+
+                if (tmp_score > max_val || tmp_score < min_val)
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    /*!\brief Checks whether the given value is a padded value or not.
+     * \param[in] value The value to check if it is padded.
+     * \returns Returns `true` if the value is padded and `false` otherwise.
+     *
+     * \details This check is done by casting the scalar type of the value into an unsigned value, and then checking
+     *          to see if this is larger than the alphabet size, which would imply that it is a padded value.
+     */
+    constexpr bool is_padded(typename simd_traits<simd_score_t>::scalar_type const & value) const
+    {
+        using unsigned_scalar_t = typename std::make_unsigned<typename simd_traits<simd_score_t>::scalar_type>::type;
+
+        return static_cast<unsigned_scalar_t>(value) >= alphabet_size<alphabet_t>;
+    }
+};
+
+} // namespace seqan3::detail

--- a/test/unit/alignment/scoring/CMakeLists.txt
+++ b/test/unit/alignment/scoring/CMakeLists.txt
@@ -1,3 +1,4 @@
 seqan3_test(gap_scheme_test.cpp)
 seqan3_test(scoring_scheme_test.cpp)
 seqan3_test(simd_match_mismatch_scoring_scheme_test.cpp)
+seqan3_test(simd_matrix_scoring_scheme_test.cpp)

--- a/test/unit/alignment/scoring/simd_matrix_scoring_scheme_test.cpp
+++ b/test/unit/alignment/scoring/simd_matrix_scoring_scheme_test.cpp
@@ -1,0 +1,223 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <seqan3/alignment/scoring/aminoacid_scoring_scheme.hpp>
+#include <seqan3/alignment/scoring/detail/simd_matrix_scoring_scheme.hpp>
+#include <seqan3/alphabet/aminoacid/aa27.hpp>
+#include <seqan3/test/pretty_printing.hpp>
+#include <seqan3/test/simd_utility.hpp>
+
+using namespace seqan3;
+using namespace seqan3::detail;
+
+template <typename simd_t>
+struct simd_matrix_scoring_scheme_test : public ::testing::Test
+{
+    using scalar_t = typename simd_traits<simd_t>::scalar_type;
+
+    scalar_t padded_value1 = std::numeric_limits<scalar_t>::lowest();      // sets the most significant bit.
+    scalar_t padded_value2 = std::numeric_limits<scalar_t>::lowest() >> 1; // sets the bit before most significant bit.
+};
+
+using simd_test_types = ::testing::Types<//simd::simd_type_t<int8_t>,
+                                         //simd::simd_type_t<int16_t>,
+                                         simd::simd_type_t<int32_t>>;
+
+TYPED_TEST_CASE(simd_matrix_scoring_scheme_test, simd_test_types);
+
+TYPED_TEST(simd_matrix_scoring_scheme_test, basic_construction)
+{
+    using scheme_t = simd_matrix_scoring_scheme<TypeParam,
+                                                aa27,
+                                                detail::global_alignment_type,
+                                                aminoacid_scoring_scheme<>>;
+
+    EXPECT_TRUE(std::is_nothrow_default_constructible_v<scheme_t>);
+    EXPECT_TRUE(std::is_nothrow_copy_constructible_v<scheme_t>);
+    EXPECT_TRUE(std::is_nothrow_move_constructible_v<scheme_t>);
+    EXPECT_TRUE(std::is_nothrow_copy_assignable_v<scheme_t>);
+    EXPECT_TRUE(std::is_nothrow_move_assignable_v<scheme_t>);
+    EXPECT_TRUE(std::is_nothrow_destructible_v<scheme_t>);
+    EXPECT_TRUE((std::is_constructible_v<scheme_t, aminoacid_scoring_scheme<>>));
+    EXPECT_TRUE(std::semiregular<scheme_t>);
+}
+
+TYPED_TEST(simd_matrix_scoring_scheme_test, construct_from_scoring_scheme_nothrow)
+{
+    using scheme_t = simd_matrix_scoring_scheme<TypeParam,
+                                                aa27,
+                                                detail::global_alignment_type,
+                                                aminoacid_scoring_scheme<>>;
+
+    scheme_t simd_scheme{aminoacid_scoring_scheme{aminoacid_similarity_matrix::BLOSUM30}};
+
+    TypeParam simd_value1 = simd::fill<TypeParam>(2);
+    TypeParam simd_value2 = simd::fill<TypeParam>(2);
+    SIMD_EQ(simd_scheme.score(simd_value1, simd_value2), simd::fill<TypeParam>(17));
+
+    simd_value2 = simd::fill<TypeParam>(1);
+    SIMD_EQ(simd_scheme.score(simd_value1, simd_value2), simd::fill<TypeParam>(-2));
+}
+
+TYPED_TEST(simd_matrix_scoring_scheme_test, construct_from_scoring_scheme_throw_on_overflow)
+{
+    using scalar_t = typename simd_traits<TypeParam>::scalar_type;
+    using scheme_t = simd_matrix_scoring_scheme<TypeParam,
+                                                aa27,
+                                                detail::global_alignment_type,
+                                                aminoacid_scoring_scheme<int64_t>>;
+
+    int64_t too_big = static_cast<int64_t>(std::numeric_limits<scalar_t>::max()) + 1;
+    int64_t too_small = static_cast<int64_t>(std::numeric_limits<scalar_t>::lowest()) - 1;
+
+    typename aminoacid_scoring_scheme<int64_t>::matrix_type matrix{};
+
+    EXPECT_NO_THROW(scheme_t{aminoacid_scoring_scheme<int64_t>{matrix}});
+
+    matrix[0][0] = too_big;
+    EXPECT_THROW((scheme_t{aminoacid_scoring_scheme<int64_t>{matrix}}),
+                 std::invalid_argument);
+    matrix[0][0] = too_small;
+    EXPECT_THROW((scheme_t{aminoacid_scoring_scheme<int64_t>{matrix}}),
+                 std::invalid_argument);
+
+    matrix[0][0] = 0;
+    matrix[alphabet_size<aa27> - 1][alphabet_size<aa27> - 1] = too_big;
+    EXPECT_THROW((scheme_t{aminoacid_scoring_scheme<int64_t>{matrix}}),
+                 std::invalid_argument);
+    matrix[alphabet_size<aa27> - 1][alphabet_size<aa27> - 1] = too_small;
+    EXPECT_THROW((scheme_t{aminoacid_scoring_scheme<int64_t>{matrix}}),
+                 std::invalid_argument);
+}
+
+TYPED_TEST(simd_matrix_scoring_scheme_test, score_global)
+{
+    using scheme_t = simd_matrix_scoring_scheme<TypeParam,
+                                                aa27,
+                                                detail::global_alignment_type,
+                                                aminoacid_scoring_scheme<>>;
+
+    scheme_t scheme{aminoacid_scoring_scheme{aminoacid_similarity_matrix::BLOSUM30}};
+
+    TypeParam simd_value1 = simd::fill<TypeParam>(2);
+    TypeParam simd_value2 = simd::fill<TypeParam>(2);
+
+    // all match
+    SIMD_EQ(scheme.score(simd_value1, simd_value2), simd::fill<TypeParam>(17));
+
+    // all mismatch
+    simd_value2 = simd::fill<TypeParam>(3);
+    SIMD_EQ(scheme.score(simd_value1, simd_value2), simd::fill<TypeParam>(-3));
+
+    // first matches, remaining mismatches.
+    simd_value2[0] = 2;
+    TypeParam result = simd::fill<TypeParam>(-3);
+    result[0] = 17;
+    SIMD_EQ(scheme.score(simd_value1, simd_value2), result);
+
+    // first mismatches, remaining matches.
+    simd_value1 = simd_value2;
+    simd_value1[0] = 3;
+    result = simd::fill<TypeParam>(9);
+    result[0] = -3;
+    SIMD_EQ(scheme.score(simd_value1, simd_value2), result);
+}
+
+TYPED_TEST(simd_matrix_scoring_scheme_test, score_global_with_padding)
+{
+    using scheme_t = simd_matrix_scoring_scheme<TypeParam,
+                                                aa27,
+                                                detail::global_alignment_type,
+                                                aminoacid_scoring_scheme<>>;
+
+    scheme_t scheme{aminoacid_scoring_scheme{aminoacid_similarity_matrix::BLOSUM30}};
+
+    TypeParam simd_value1 = simd::fill<TypeParam>(2);
+    TypeParam simd_value2 = simd::fill<TypeParam>(3);
+    TypeParam result = simd::fill<TypeParam>(-3);
+
+    SIMD_EQ(scheme.score(simd_value1, simd_value2), result);
+
+    // First value is regular symbol; second value is padded symbol => score of 1.
+    simd_value2[0] = this->padded_value1;
+    result[0] = 1;
+    SIMD_EQ(scheme.score(simd_value1, simd_value2), result);
+
+    // First value is padded symbol; second value is padded symbol => score of 1.
+    simd_value1[0] = this->padded_value1;
+    SIMD_EQ(scheme.score(simd_value1, simd_value2), result);
+
+    // First value is padded symbol; second value is regular symbol => score of 1.
+    simd_value2[0] = 2;
+    SIMD_EQ(scheme.score(simd_value1, simd_value2), result);
+}
+
+TYPED_TEST(simd_matrix_scoring_scheme_test, score_local)
+{
+    // In local alignment we always want to mismatch.
+    using scheme_t = simd_matrix_scoring_scheme<TypeParam,
+                                                aa27,
+                                                detail::local_alignment_type,
+                                                aminoacid_scoring_scheme<>>;
+
+    scheme_t scheme{aminoacid_scoring_scheme{aminoacid_similarity_matrix::BLOSUM30}};
+
+    TypeParam simd_value1 = simd::fill<TypeParam>(2);
+    TypeParam simd_value2 = simd::fill<TypeParam>(2);
+
+    // all match
+    SIMD_EQ(scheme.score(simd_value1, simd_value2), simd::fill<TypeParam>(17));
+
+    // all mismatch
+    simd_value2 = simd::fill<TypeParam>(3);
+    SIMD_EQ(scheme.score(simd_value1, simd_value2), simd::fill<TypeParam>(-3));
+
+    // first matches, remaining mismatches.
+    simd_value2[0] = 2;
+    TypeParam result = simd::fill<TypeParam>(-3);
+    result[0] = 17;
+    SIMD_EQ(scheme.score(simd_value1, simd_value2), result);
+
+    // first mismatches, remaining matches.
+    simd_value1 = simd_value2;
+    simd_value1[0] = 3;
+    result = simd::fill<TypeParam>(9);
+    result[0] = -3;
+    SIMD_EQ(scheme.score(simd_value1, simd_value2), result);
+}
+
+TYPED_TEST(simd_matrix_scoring_scheme_test, score_local_with_padding)
+{
+    // In local alignment we always want to mismatch.
+    using scheme_t = simd_matrix_scoring_scheme<TypeParam,
+                                                aa27,
+                                                detail::local_alignment_type,
+                                                aminoacid_scoring_scheme<>>;
+
+    scheme_t scheme{aminoacid_scoring_scheme{aminoacid_similarity_matrix::BLOSUM30}};
+
+    TypeParam simd_value1 = simd::fill<TypeParam>(2);
+    TypeParam simd_value2 = simd::fill<TypeParam>(2);
+    TypeParam result = simd::fill<TypeParam>(17);
+
+    SIMD_EQ(scheme.score(simd_value1, simd_value2), result);
+
+    // First value is regular symbol; second value is padded symbol => score of -1.
+    simd_value2[0] = this->padded_value2;
+    result[0] = -1;
+    SIMD_EQ(scheme.score(simd_value1, simd_value2), result);
+
+    // First value is padded symbol; second value is padded symbol => score of -1.
+    simd_value1[0] = this->padded_value1;
+    SIMD_EQ(scheme.score(simd_value1, simd_value2), result);
+
+    // First value is padded symbol; second value is regular symbol => score of -1.
+    simd_value2[0] = 3;
+    SIMD_EQ(scheme.score(simd_value1, simd_value2), result);
+}


### PR DESCRIPTION
Along with appropriate test file.

Follows similar structure to #1332.

Does not yet fully satisfy #1352. Still need to use gather in score and other optimizations.

Resolves #1352 