### PR TITLE
[FEATURE] Reduce memory footprint of FM-indices over text collections

### DIFF
--- a/include/seqan3/std/algorithm
+++ b/include/seqan3/std/algorithm
@@ -36,6 +36,7 @@
 #include <range/v3/algorithm/max_element.hpp>
 #include <range/v3/algorithm/move_backward.hpp>
 #include <range/v3/algorithm/move.hpp>
+#include <range/v3/algorithm/reverse.hpp>
 #include <range/v3/algorithm/sort.hpp>
 #include <range/v3/algorithm/transform.hpp>
 


### PR DESCRIPTION
## Changes

### Using `sdsl::sd_vector_builder`
The builder can be used iff
* You know the bitvector size
* You know the number of `1`s you want to set
* The positions of the `1`s are in a strictly increasing order

Since we actually fulfil all these requirements, we can use the builder.
This already reduces the memory footprint by a little bit - you do not need to allocate a bitvector of size `text_size` ( a vector using `text_size/8` many bytes).
This may be more noticeable for bigger texts since the allocation will take longer. Since I only measured memory peak, it's hard to tell exactly (the other steps use way more memory).

### Avoiding a copy

We can get rid of the copy from `std::vector<uint8_t>` to `sdsl::int_vector<8>`.
Note that we need to do a `std::ranges::reverse(tmp_text);` afterwards.
The alternative would be to do a `views::deep{views::reverse}` followed by an `views::reverse` in the `std::ranges::move`, but the deep reverse is very expensive (run time wise), so it's actually better to reverse the vector after flattening (`views::join`) it.
Also: We cannot do the `views::reverse` after the `views::join` because `views::join` strips the bidirectional(?) property off the range and hence `views::reverse` won't work.

I did some local benchmarks with a text of size 256Mbp.
The times are around the same, with this new version tending to be a bit faster.
Memory peak was reduced from 3,213,168 KB to 2,885,388 KB (- 10%).
Considering the text is only 256MB, the memory consumption is still rather high, though.

## Todos
* ~~Add `std::ranges::reverse` to `std/algorithm` and use it instead of `std::reverse`~~