### PR TITLE
Feature/pass through chunk to alignment call

### DIFF
--- a/include/seqan3/alignment/matrix/detail/aligned_sequence_builder.hpp
+++ b/include/seqan3/alignment/matrix/detail/aligned_sequence_builder.hpp
@@ -226,6 +226,7 @@ private:
  */
 //!\brief Deduces the type from the passed constructor arguments.
 template <std::ranges::viewable_range fst_sequence_t, std::ranges::viewable_range sec_sequence_t>
-aligned_sequence_builder(fst_sequence_t, sec_sequence_t) -> aligned_sequence_builder<fst_sequence_t, sec_sequence_t>;
+aligned_sequence_builder(fst_sequence_t &&, sec_sequence_t &&) ->
+    aligned_sequence_builder<fst_sequence_t, sec_sequence_t>;
 //!\}
 } // namespace seqan3::detail

--- a/include/seqan3/alignment/pairwise/align_pairwise.hpp
+++ b/include/seqan3/alignment/pairwise/align_pairwise.hpp
@@ -153,8 +153,8 @@ template <typename sequence_t, typename alignment_config_t>
 constexpr auto align_pairwise(sequence_t && sequences,
                               alignment_config_t const & config)
 {
-    using first_seq_t  = std::tuple_element_t<0, value_type_t<sequence_t>>;
-    using second_seq_t = std::tuple_element_t<1, value_type_t<sequence_t>>;
+    using first_seq_t  = std::tuple_element_t<0, std::ranges::range_value_t<sequence_t>>;
+    using second_seq_t = std::tuple_element_t<1, std::ranges::range_value_t<sequence_t>>;
 
     static_assert(std::ranges::random_access_range<first_seq_t> && std::ranges::sized_range<first_seq_t>,
                   "Alignment configuration error: The sequence must model random_access_range and sized_range.");

--- a/include/seqan3/alignment/pairwise/detail/concept.hpp
+++ b/include/seqan3/alignment/pairwise/detail/concept.hpp
@@ -14,13 +14,56 @@
 
 #include <tuple>
 
+#include <seqan3/alphabet/concept.hpp>
 #include <seqan3/core/concept/tuple.hpp>
 #include <seqan3/std/ranges>
 
 namespace seqan3::detail
 {
 
-/*!\brief A helper concept to check the input of the range based alignment algorithm interface.
+/*!\interface seqan3::detail::sequence_pair <>
+ * \brief A helper concept to check if a type is a sequence pair.
+ * \ingroup pairwise_alignment
+ *
+ * \tparam t The type to check.
+ *
+ * \details
+ *
+ * This concept checks if the given type models a seqan3::tuple_like type with exactly two elements and that both
+ * types in the tuple model std::ranges::forward_range. Furthermore, the value type of both ranges must model
+ * seqan3::semialphabet.
+ */
+//!\cond
+template <typename t>
+SEQAN3_CONCEPT sequence_pair = requires ()
+{
+    requires tuple_like<t>;
+    requires std::tuple_size_v<t> == 2;
+    requires std::ranges::forward_range<std::tuple_element_t<0, t>>;
+    requires std::ranges::forward_range<std::tuple_element_t<1, t>>;
+    requires semialphabet<std::ranges::range_value_t<std::tuple_element_t<0, t>>>;
+    requires semialphabet<std::ranges::range_value_t<std::tuple_element_t<1, t>>>;
+};
+//!\endcond
+
+/*!\interface seqan3::detail::sequence_pair_range <>
+ * \brief A helper concept to check if a type is a range over seqan3::detail::sequence_pair's.
+ * \ingroup pairwise_alignment
+ *
+ * \tparam t The type to check.
+ *
+ * \details
+ *
+ * This concept checks if the given type models a std::ranges::forward_range over and that the value type of the
+ * range models seqan3::detail::sequence_pair.
+ */
+//!\cond
+template <typename t>
+SEQAN3_CONCEPT sequence_pair_range = std::ranges::forward_range<t> && sequence_pair<std::ranges::range_value_t<t>>;
+//!\endcond
+
+/*!\interface seqan3::detail::indexed_sequence_pair_range <>
+ * \brief A helper concept to check the input of the range based alignment algorithm interface.
  * \ingroup pairwise_alignment
  *
  * \tparam t The type to check.
@@ -28,21 +71,21 @@ namespace seqan3::detail
  * \details
  *
  * This concept checks if the given type models a std::ranges::forward_range over indexed sequence pairs that are
- * passed to the alignment algorithms. An indexed sequence pair is a pair of sequences that shall be aligned. In
- * addition, the pair is annotated with an index so that the caller can infer the aligned sequences from the returned
- * seqan3::alignment_result. The layout of this indexed sequence type looks as follows:
- * * the first type of the pair refers to the sequence pair type, and
+ * passed to the alignment algorithms. An indexed sequence pair consists of a seqan3::detail::sequence_pair
+ * that shall be aligned and an index that is used to identify the aligned sequence pair.
+ * The caller can then infer the aligned sequences from the returned seqan3::alignment_result.
+ * The layout of this indexed sequence type looks as follows:
+ * * the first type of the pair must model seqan3::detail::sequence_pair, and
  * * the second type of the pair refers to the respective index type.
  */
 //!\cond
 template <typename t>
-SEQAN3_CONCEPT indexed_sequence_pair_range = requires (std::ranges::range_value_t<t> value)
+SEQAN3_CONCEPT indexed_sequence_pair_range = std::ranges::forward_range<t> &&
+                                             requires (std::ranges::range_value_t<t> value)
 {
-    requires std::ranges::forward_range<t>;
     requires tuple_like<decltype(value)>;
     requires std::tuple_size_v<decltype(value)> == 2;
-    requires tuple_like<std::tuple_element_t<0, decltype(value)>>;
-    requires std::tuple_size_v<std::tuple_element_t<0, decltype(value)>> == 2;
+    requires sequence_pair<std::tuple_element_t<0, decltype(value)>>;
 };
 //!\endcond
 }  // namespace seqan3::detail

--- a/include/seqan3/alignment/pairwise/detail/concept.hpp
+++ b/include/seqan3/alignment/pairwise/detail/concept.hpp
@@ -29,7 +29,7 @@ namespace seqan3::detail
  *
  * \details
  *
- * This concept checks if the given type models a seqan3::tuple_like type with exactly two elements and that both
+ * This concept checks if the given type models seqan3::tuple_like with exactly two elements and that both
  * types in the tuple model std::ranges::forward_range. Furthermore, the value type of both ranges must model
  * seqan3::semialphabet.
  */
@@ -47,14 +47,14 @@ SEQAN3_CONCEPT sequence_pair = requires ()
 //!\endcond
 
 /*!\interface seqan3::detail::sequence_pair_range <>
- * \brief A helper concept to check if a type is a range over seqan3::detail::sequence_pair's.
+ * \brief A helper concept to check if a type is a range over seqan3::detail::sequence_pair.
  * \ingroup pairwise_alignment
  *
  * \tparam t The type to check.
  *
  * \details
  *
- * This concept checks if the given type models a std::ranges::forward_range over and that the value type of the
+ * This concept checks if the given type models a std::ranges::forward_range and that the value type of the
  * range models seqan3::detail::sequence_pair.
  */
 //!\cond
@@ -76,7 +76,8 @@ SEQAN3_CONCEPT sequence_pair_range = std::ranges::forward_range<t> && sequence_p
  * The caller can then infer the aligned sequences from the returned seqan3::alignment_result.
  * The layout of this indexed sequence type looks as follows:
  * * the first type of the pair must model seqan3::detail::sequence_pair, and
- * * the second type of the pair refers to the respective index type.
+ * * the second type of the pair refers to the respective index type, which can be any type but must model
+ *   std::copy_constructible.
  */
 //!\cond
 template <typename t>
@@ -86,6 +87,7 @@ SEQAN3_CONCEPT indexed_sequence_pair_range = std::ranges::forward_range<t> &&
     requires tuple_like<decltype(value)>;
     requires std::tuple_size_v<decltype(value)> == 2;
     requires sequence_pair<std::tuple_element_t<0, decltype(value)>>;
+    requires std::copy_constructible<std::tuple_element_t<1, decltype(value)>>;
 };
 //!\endcond
 }  // namespace seqan3::detail

--- a/include/seqan3/alignment/pairwise/detail/type_traits.hpp
+++ b/include/seqan3/alignment/pairwise/detail/type_traits.hpp
@@ -6,7 +6,7 @@
 // -----------------------------------------------------------------------------------------------------
 
 /*!\file
- * \brief Provides utility traits for the configuration and execution of the alignment algorithm.
+ * \brief Provides helper type traits for the configuration and execution of the alignment algorithm.
  * \author Rene Rahn <rene.rahn AT fu-berlin.de>
  */
 
@@ -28,7 +28,7 @@ namespace seqan3::detail
  *
  * \details
  *
- * This transformation trait transforms a range over sequence pairs into an indexed range over sequence pairs.
+ * This transformation trait transforms a range over sequence pairs into a range over indexed sequence pairs.
  * In addition, the range is chunked which is the common interface for alignment algorithms.
  * The returned type models seqan3::detail::indexed_sequence_pair_range.
  */

--- a/include/seqan3/alignment/pairwise/detail/utility_traits.hpp
+++ b/include/seqan3/alignment/pairwise/detail/utility_traits.hpp
@@ -1,0 +1,45 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides utility traits for the configuration and execution of the alignment algorithm.
+ * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <seqan3/alignment/pairwise/detail/concept.hpp>
+#include <seqan3/range/views/chunk.hpp>
+#include <seqan3/range/views/zip.hpp>
+#include <seqan3/std/ranges>
+
+namespace seqan3::detail
+{
+
+/*!\brief A transformation trait to retrieve the chunked range over indexed sequence pairs.
+ * \ingroup pairwise_alignment
+ * \implements seqan3::transformation_trait
+ *
+ * \tparam sequence_pairs_t The type of the sequences to be transformed; must model seqan3::detail::sequence_pair_range.
+ *
+ * \details
+ *
+ * This transformation trait transforms a range over sequence pairs into an indexed range over sequence pairs.
+ * In addition, the range is chunked which is the common interface for alignment algorithms.
+ * The returned type models seqan3::detail::indexed_sequence_pair_range.
+ */
+template <typename sequence_pairs_t>
+//!\cond
+    requires sequence_pair_range<std::remove_reference_t<sequence_pairs_t>>
+//!\endcond
+struct chunked_indexed_sequence_pairs
+{
+    //!\brief The transformed type that models seqan3::detail::indexed_sequence_pair_range.
+    using type = decltype(views::zip(std::declval<sequence_pairs_t>(), std::views::iota(0)) | views::chunk(1));
+};
+
+}  // namespace seqan3::detail

--- a/include/seqan3/alignment/pairwise/edit_distance_algorithm.hpp
+++ b/include/seqan3/alignment/pairwise/edit_distance_algorithm.hpp
@@ -83,11 +83,11 @@ public:
         using sequence_pair_t = std::tuple_element_t<0, indexed_sequence_pair_t>; // The sequence pair type.
         using sequence1_t = std::remove_reference_t<std::tuple_element_t<0, sequence_pair_t>>;
         using sequence2_t = std::remove_reference_t<std::tuple_element_t<1, sequence_pair_t>>;
-        using alignment_result_t = typename align_result_selector<sequence1_t, sequence2_t, config_t>::type;
+        using alignment_result_value_t = typename align_result_selector<sequence1_t, sequence2_t, config_t>::type;
 
         using std::get;
 
-        std::vector<alignment_result_t> result_vector{};  // Stores the results.
+        std::vector<alignment_result<alignment_result_value_t>> result_vector{};  // Stores the results.
         for (auto && [sequence_pair, index] : indexed_sequence_pairs)
             result_vector.push_back((*this)(index, get<0>(sequence_pair), get<1>(sequence_pair)));
 

--- a/test/unit/alignment/pairwise/align_pairwise_test.cpp
+++ b/test/unit/alignment/pairwise/align_pairwise_test.cpp
@@ -27,7 +27,15 @@ using namespace seqan3;
 
 template <typename t>
 struct align_pairwise_test : ::testing::Test
-{};
+{
+    // two helper variables to check if the TypeParam contains vectorise.
+    using dummy_cfg_t = std::conditional_t<std::is_same_v<void, t>,
+                                           decltype(align_cfg::max_error{1}),
+                                           t>;
+    using config_t = decltype(align_cfg::edit | dummy_cfg_t{});
+
+    static constexpr bool is_vectorised = config_t::template exists<detail::vectorise_tag>();
+};
 
 using testing_types = ::testing::Types<void,
                                        align_cfg::parallel,
@@ -58,12 +66,11 @@ TYPED_TEST(align_pairwise_test, single_pair)
     auto p = std::tie(seq1, seq2);
 
     {  // the score
-        configuration cfg = align_cfg::edit | align_cfg::result{with_score, using_score_type<double>};
+        configuration cfg = align_cfg::edit | align_cfg::result{with_score};
 
         for (auto && res : call_alignment<TypeParam>(p, cfg))
         {
             EXPECT_EQ(res.score(), -4.0);
-            EXPECT_TRUE((std::same_as<decltype(res.score()), double>));
         }
     }
 
@@ -79,6 +86,42 @@ TYPED_TEST(align_pairwise_test, single_pair)
             auto && [gap1, gap2] = res.alignment();
             EXPECT_EQ(gap1 | views::to_char | views::to<std::string>, "ACGTGATG--");
             EXPECT_EQ(gap2 | views::to_char | views::to<std::string>, "A-GTGATACT");
+        }
+    }
+}
+
+TYPED_TEST(align_pairwise_test, single_pair_double_score)
+{
+    if constexpr (!TestFixture::is_vectorised)
+    { // not building for vectorised version.
+        auto seq1 = "ACGTGATG"_dna4;
+        auto seq2 = "AGTGATACT"_dna4;
+
+        auto p = std::tie(seq1, seq2);
+
+        {  // the score
+            configuration cfg = align_cfg::edit | align_cfg::result{with_score, using_score_type<double>};
+
+            for (auto && res : call_alignment<TypeParam>(p, cfg))
+            {
+                EXPECT_EQ(res.score(), -4.0);
+                EXPECT_TRUE((std::same_as<decltype(res.score()), double>));
+            }
+        }
+
+        {  // the alignment
+            configuration cfg = align_cfg::edit | align_cfg::result{with_alignment, using_score_type<double>};
+            unsigned idx = 0;
+            for (auto && res : call_alignment<TypeParam>(p, cfg))
+            {
+                EXPECT_EQ(res.id(), idx++);
+                EXPECT_EQ(res.score(), -4);
+                EXPECT_EQ(res.back_coordinate().first, 8u);
+                EXPECT_EQ(res.back_coordinate().second, 9u);
+                auto && [gap1, gap2] = res.alignment();
+                EXPECT_EQ(gap1 | views::to_char | views::to<std::string>, "ACGTGATG--");
+                EXPECT_EQ(gap2 | views::to_char | views::to<std::string>, "A-GTGATACT");
+            }
         }
     }
 }
@@ -118,12 +161,33 @@ TYPED_TEST(align_pairwise_test, collection)
     auto p = std::tie(seq1, seq2);
     std::vector<decltype(p)> vec{10, p};
 
-    configuration cfg = align_cfg::edit | align_cfg::result{with_alignment, using_score_type<double>};
+    configuration cfg = align_cfg::edit | align_cfg::result{with_alignment};
     for (auto && res : call_alignment<TypeParam>(vec, cfg))
     {
         EXPECT_EQ(res.score(), -4);
         auto && [gap1, gap2] = res.alignment();
         EXPECT_EQ(gap1 | views::to_char | views::to<std::string>, "ACGTGATG--");
         EXPECT_EQ(gap2 | views::to_char | views::to<std::string>, "A-GTGATACT");
+    }
+}
+
+TYPED_TEST(align_pairwise_test, collection_with_double_score_type)
+{
+    if constexpr (!TestFixture::is_vectorised)
+    {
+        auto seq1 = "ACGTGATG"_dna4;
+        auto seq2 = "AGTGATACT"_dna4;
+
+        auto p = std::tie(seq1, seq2);
+        std::vector<decltype(p)> vec{10, p};
+
+        configuration cfg = align_cfg::edit | align_cfg::result{with_alignment, using_score_type<double>};
+        for (auto && res : call_alignment<TypeParam>(vec, cfg))
+        {
+            EXPECT_EQ(res.score(), -4);
+            auto && [gap1, gap2] = res.alignment();
+            EXPECT_EQ(gap1 | views::to_char | views::to<std::string>, "ACGTGATG--");
+            EXPECT_EQ(gap2 | views::to_char | views::to<std::string>, "A-GTGATACT");
+        }
     }
 }

--- a/test/unit/alignment/pairwise/alignment_configurator_test.cpp
+++ b/test/unit/alignment/pairwise/alignment_configurator_test.cpp
@@ -11,7 +11,9 @@
 
 #include <seqan3/alignment/pairwise/alignment_configurator.hpp>
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
-#include <seqan3/range/views/view_all.hpp>
+#include <seqan3/range/views/chunk.hpp>
+#include <seqan3/range/views/zip.hpp>
+#include <seqan3/std/ranges>
 
 using namespace seqan3;
 
@@ -27,9 +29,9 @@ auto run_test(config_t const & cfg)
     auto r = setup();
     auto configuration_result = detail::alignment_configurator::configure<decltype(r)>(cfg);
     auto algorithm = configuration_result.first;
-    auto & [seq1, seq2] = *std::ranges::begin(r);
 
-    return algorithm(0u, seq1 | views::all, seq2 | views::all);
+    auto indexed_sequence_pairs = views::zip(r, std::views::iota(0)) | views::chunk(1);
+    return algorithm(*indexed_sequence_pairs.begin())[0];
 }
 
 TEST(alignment_configurator, configure_edit)

--- a/test/unit/alignment/pairwise/alignment_configurator_test.cpp
+++ b/test/unit/alignment/pairwise/alignment_configurator_test.cpp
@@ -22,38 +22,39 @@ auto setup()
 }
 
 template <typename config_t>
-bool run_test(config_t const & cfg)
+auto run_test(config_t const & cfg)
 {
     auto r = setup();
-    auto fn = detail::alignment_configurator::configure<decltype(r)>(cfg);
+    auto configuration_result = detail::alignment_configurator::configure<decltype(r)>(cfg);
+    auto algorithm = configuration_result.first;
     auto & [seq1, seq2] = *std::ranges::begin(r);
 
-    return fn(0u, seq1 | views::all, seq2 | views::all).score() == 0;
+    return algorithm(0u, seq1 | views::all, seq2 | views::all);
 }
 
 TEST(alignment_configurator, configure_edit)
 {
-    EXPECT_TRUE(run_test(align_cfg::edit));
+    EXPECT_EQ(run_test(align_cfg::edit).score(), 0);
 }
 
 TEST(alignment_configurator, configure_edit_end_position)
 {
-    EXPECT_TRUE(run_test(align_cfg::edit | align_cfg::result{with_back_coordinate}));
+    EXPECT_EQ(run_test(align_cfg::edit | align_cfg::result{with_back_coordinate}).score(), 0);
 }
 
 TEST(alignment_configurator, configure_edit_begin_position)
 {
-    EXPECT_TRUE(run_test(align_cfg::edit | align_cfg::result{with_front_coordinate}));
+    EXPECT_EQ(run_test(align_cfg::edit | align_cfg::result{with_front_coordinate}).score(), 0);
 }
 
 TEST(alignment_configurator, configure_edit_trace)
 {
-    EXPECT_TRUE(run_test(align_cfg::edit | align_cfg::result{with_alignment}));
+    EXPECT_EQ(run_test(align_cfg::edit | align_cfg::result{with_alignment}).score(), 0);
 }
 
 TEST(alignment_configurator, configure_edit_semi)
 {
-    EXPECT_TRUE(run_test(align_cfg::edit | align_cfg::aligned_ends{free_ends_first}));
+    EXPECT_EQ(run_test(align_cfg::edit | align_cfg::aligned_ends{free_ends_first}).score(), 0);
 }
 
 TEST(alignment_configurator, configure_edit_banded)
@@ -64,7 +65,7 @@ TEST(alignment_configurator, configure_edit_banded)
 
 TEST(alignment_configurator, configure_edit_max_error)
 {
-    EXPECT_TRUE(run_test(align_cfg::edit | align_cfg::max_error{3u}));
+    EXPECT_EQ(run_test(align_cfg::edit | align_cfg::max_error{3u}).score(), 0);
 }
 
 TEST(alignment_configurator, configure_affine_global)
@@ -73,7 +74,7 @@ TEST(alignment_configurator, configure_affine_global)
                align_cfg::gap{gap_scheme{gap_score{-1}, gap_open_score{-10}}} |
                align_cfg::scoring{nucleotide_scoring_scheme{}};
 
-    EXPECT_TRUE(run_test(cfg));
+    EXPECT_EQ(run_test(cfg).score(), 0);
 }
 
 TEST(alignment_configurator, configure_affine_global_max_error)
@@ -93,7 +94,7 @@ TEST(alignment_configurator, configure_affine_global_end_position)
                align_cfg::scoring{nucleotide_scoring_scheme{}} |
                align_cfg::result{with_back_coordinate};
 
-    EXPECT_TRUE(run_test(cfg));
+    EXPECT_EQ(run_test(cfg).score(), 0);
 }
 
 TEST(alignment_configurator, configure_affine_global_begin_position)
@@ -103,7 +104,7 @@ TEST(alignment_configurator, configure_affine_global_begin_position)
                align_cfg::scoring{nucleotide_scoring_scheme{}} |
                align_cfg::result{with_front_coordinate};
 
-    EXPECT_TRUE(run_test(cfg));
+    EXPECT_EQ(run_test(cfg).score(), 0);
 }
 
 TEST(alignment_configurator, configure_affine_global_trace)
@@ -113,7 +114,7 @@ TEST(alignment_configurator, configure_affine_global_trace)
                align_cfg::scoring{nucleotide_scoring_scheme{}} |
                align_cfg::result{with_alignment};
 
-    EXPECT_TRUE(run_test(cfg));
+    EXPECT_EQ(run_test(cfg).score(), 0);
 }
 
 TEST(alignment_configurator, configure_affine_global_banded)
@@ -124,7 +125,7 @@ TEST(alignment_configurator, configure_affine_global_banded)
                    align_cfg::gap{gap_scheme{gap_score{-1}, gap_open_score{-10}}} |
                    align_cfg::band{static_band{lower_bound{-1}, upper_bound{1}}};
 
-        EXPECT_TRUE(run_test(cfg));
+        EXPECT_EQ(run_test(cfg).score(), 0);
     }
 
     {  // invalid band
@@ -150,9 +151,9 @@ TEST(alignment_configurator, configure_affine_global_banded_with_alignment)
     auto cfg_begin = cfg | align_cfg::result{with_front_coordinate};
     auto cfg_end = cfg | align_cfg::result{with_back_coordinate};
 
-    EXPECT_TRUE(run_test(cfg_end));
-    EXPECT_TRUE(run_test(cfg_trace));
-    EXPECT_TRUE(run_test(cfg_begin));
+    EXPECT_EQ(run_test(cfg_end).score(), 0);
+    EXPECT_EQ(run_test(cfg_trace).score(), 0);
+    EXPECT_EQ(run_test(cfg_begin).score(), 0);
 }
 
 TEST(alignment_configurator, configure_affine_global_semi)
@@ -162,7 +163,7 @@ TEST(alignment_configurator, configure_affine_global_semi)
                align_cfg::gap{gap_scheme{gap_score{-1}, gap_open_score{-10}}} |
                align_cfg::aligned_ends{free_ends_all};
 
-    EXPECT_TRUE(run_test(cfg));
+    EXPECT_EQ(run_test(cfg).score(), 0);
 }
 
 TEST(alignment_configurator, configure_affine_local)
@@ -171,7 +172,7 @@ TEST(alignment_configurator, configure_affine_local)
                align_cfg::gap{gap_scheme{gap_score{-1}, gap_open_score{-10}}} |
                align_cfg::scoring{nucleotide_scoring_scheme{}};
 
-    EXPECT_TRUE(run_test(cfg));
+    EXPECT_EQ(run_test(cfg).score(), 0);
 }
 
 TEST(alignment_configurator, configure_affine_local_back_coordinate)
@@ -181,7 +182,7 @@ TEST(alignment_configurator, configure_affine_local_back_coordinate)
                align_cfg::scoring{nucleotide_scoring_scheme{}} |
                align_cfg::result{with_back_coordinate};
 
-    EXPECT_TRUE(run_test(cfg));
+    EXPECT_EQ(run_test(cfg).score(), 0);
 }
 
 TEST(alignment_configurator, configure_affine_local_front_coordinate)
@@ -191,7 +192,7 @@ TEST(alignment_configurator, configure_affine_local_front_coordinate)
                align_cfg::scoring{nucleotide_scoring_scheme{}} |
                align_cfg::result{with_front_coordinate};
 
-    EXPECT_TRUE(run_test(cfg));
+    EXPECT_EQ(run_test(cfg).score(), 0);
 }
 
 TEST(alignment_configurator, configure_affine_local_alignment)
@@ -201,20 +202,17 @@ TEST(alignment_configurator, configure_affine_local_alignment)
                align_cfg::scoring{nucleotide_scoring_scheme{}} |
                align_cfg::result{with_alignment};
 
-    EXPECT_TRUE(run_test(cfg));
+    EXPECT_EQ(run_test(cfg).score(), 0);
 }
 
 TEST(alignment_configurator, configure_result_score_type)
 {
     auto cfg = align_cfg::edit | align_cfg::result{with_back_coordinate, using_score_type<double>};
 
-    auto r = setup();
-    auto fn = detail::alignment_configurator::configure<decltype(r)>(cfg);
-    auto & [seq1, seq2] = *std::ranges::begin(r);
+    auto result = run_test(cfg);
 
-    auto res = fn(0u, seq1 | views::all, seq2 | views::all);
-
-    EXPECT_EQ(res.score(), 0);
-    EXPECT_EQ(res.back_coordinate(), (alignment_coordinate{detail::column_index_type{4u}, detail::row_index_type{4u}}));
-    EXPECT_TRUE((std::same_as<decltype(res.score()), double>));
+    EXPECT_DOUBLE_EQ(result.score(), 0.0);
+    EXPECT_EQ(result.back_coordinate(),
+              (alignment_coordinate{detail::column_index_type{4u}, detail::row_index_type{4u}}));
+    EXPECT_TRUE((std::same_as<decltype(result.score()), double>));
 }

--- a/test/unit/alignment/pairwise/pairwise_alignment_collection_test_template.hpp
+++ b/test/unit/alignment/pairwise/pairwise_alignment_collection_test_template.hpp
@@ -84,7 +84,7 @@ TYPED_TEST_P(pairwise_alignment_collection_test, front_coordinate)
 TYPED_TEST_P(pairwise_alignment_collection_test, alignment)
 {
     auto const & fixture = this->fixture();
-    configuration align_cfg = fixture.config | align_cfg::result{with_alignment, using_score_type<double>};
+    configuration align_cfg = fixture.config | align_cfg::result{with_alignment};
     auto [database, query] = fixture.get_sequences();
     auto res_vec = align_pairwise(views::zip(database, query), align_cfg | typename TestFixture::policy_t{})
                  | views::to<std::vector>;


### PR DESCRIPTION
Fixes #1372

The alignment executor will now call the execution handler directly with passing the chunk of indexed sequence pairs. This also means that now the return type is a vector which needs to be moved to the result buffer.