### PR TITLE
Feature/remove obsolete execution handler interface

### DIFF
--- a/include/seqan3/alignment/pairwise/alignment_configurator.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_configurator.hpp
@@ -232,6 +232,7 @@ public:
      *
      * \include snippet/alignment/pairwise/alignment_configurator.cpp
      *
+     *
      * The arguments to the function object are two ranges, which always need to be passed as lvalue references.
      * Note that even if they are not passed as const lvalue reference (which is not possible, since not all views are
      * const-iterable), they are not modified within the alignment algorithm.

--- a/include/seqan3/alignment/pairwise/execution/execution_handler_parallel.hpp
+++ b/include/seqan3/alignment/pairwise/execution/execution_handler_parallel.hpp
@@ -97,37 +97,6 @@ public:
     }
     //!\}
 
-    /*!\brief Invokes the passed alignment instance in a non-blocking manner.
-     * \copydetails execution_handler_sequential::execute
-     */
-    template <typename algorithm_t, typename first_range_type, typename second_range_type, typename delegate_type>
-    //!\cond
-        requires std::invocable<algorithm_t, size_t const, first_range_type, second_range_type> &&
-                 std::invocable<delegate_type, std::invoke_result_t<algorithm_t,
-                                                                    size_t const,
-                                                                    first_range_type,
-                                                                    second_range_type>>
-    //!\endcond
-    void execute(algorithm_t && algorithm,
-                 size_t const idx,
-                 first_range_type first_range,
-                 second_range_type second_range,
-                 delegate_type && delegate)
-    {
-        static_assert(std::ranges::view<first_range_type>, "Expected a view!");
-        static_assert(std::ranges::view<second_range_type>, "Expected a view!");
-
-        assert(state != nullptr);
-
-        task_type task = [=, first_range = std::move(first_range), second_range = std::move(second_range)] ()
-        {
-            delegate(algorithm(idx, std::move(first_range), std::move(second_range)));
-        };
-        // Asynchronously pushes the task to the queue.
-        [[maybe_unused]] contrib::queue_op_status status = state->queue.wait_push(std::move(task));
-        assert(status == contrib::queue_op_status::success);
-    }
-
     /*!\brief Takes underlying range of sequence pairs and invokes an alignment on each instance.
      * \tparam algorithm_t              The type of the alignment algorithm.
      * \tparam indexed_sequence_pairs_t The type of underlying sequence pairs annotated with an index;

--- a/include/seqan3/alignment/pairwise/execution/execution_handler_sequential.hpp
+++ b/include/seqan3/alignment/pairwise/execution/execution_handler_sequential.hpp
@@ -30,40 +30,6 @@ struct execution_handler_sequential
 {
 public:
 
-    /*!\brief Invokes the passed alignment instance in a blocking manner.
-     * \tparam algorithm_t       The callable that needs to be invoked; must model std::invocable with first_range_type
-     *                           and second_range_type.
-     * \tparam first_range_type  The type of the first range; must model std::ranges::view.
-     * \tparam second_range_type The type of the second range; must model std::ranges::view.
-     * \tparam delegate_type     The type of the callable invoked on the std::invoke_result of `algorithm_t`; must model
-     *                           std::invocable.
-     *
-     * \param[in] algorithm    The alignment algorithm to invoke.
-     * \param[in] idx          The index of the current processed sequence pair.
-     * \param[in] first_range  The first range.
-     * \param[in] second_range The second range.
-     * \param[in] delegate     The callable invoked with the result of the alignment.
-     */
-    template <typename algorithm_t, typename first_range_type, typename second_range_type, typename delegate_type>
-    //!\cond
-        requires std::invocable<algorithm_t, size_t const, first_range_type, second_range_type> &&
-                 std::invocable<delegate_type, std::invoke_result_t<algorithm_t,
-                                                                    size_t const,
-                                                                    first_range_type,
-                                                                    second_range_type>>
-    //!\endcond
-    void execute(algorithm_t && algorithm,
-                 size_t const idx,
-                 first_range_type first_range,
-                 second_range_type second_range,
-                 delegate_type && delegate)
-    {
-        static_assert(std::ranges::view<first_range_type>, "Expected a view!");
-        static_assert(std::ranges::view<second_range_type>, "Expected a view!");
-
-        delegate(algorithm(idx, std::move(first_range), std::move(second_range)));
-    }
-
     /*!\brief Takes underlying range of sequence pairs and invokes an alignment on each instance.
      * \tparam algorithm_t              The type of the alignment algorithm.
      * \tparam indexed_sequence_pairs_t The type of underlying sequence pairs annotated with an index;

--- a/test/unit/alignment/pairwise/execution/execution_handler_template.hpp
+++ b/test/unit/alignment/pairwise/execution/execution_handler_template.hpp
@@ -67,53 +67,6 @@ auto simulate_alignment_with_range = [] (auto indexed_sequence_pairs)
 
 TYPED_TEST_CASE_P(execution_handler);
 
-TYPED_TEST_P(execution_handler, execute_with_lvalue)
-{
-    std::vector<std::pair<size_t, size_t>> buffer;
-    buffer.resize(this->total_size);
-
-    TypeParam exec_handler{};
-
-    size_t pos = 0;
-    for (unsigned i = 0; i < this->total_size; ++i, ++pos)
-    {
-        auto seq_collection1_as_view = this->sequence_collection1[i] | views::all;
-        auto seq_collection2_as_view = this->sequence_collection2[i] | views::all;
-        exec_handler.execute(simulate_alignment,
-                             i,
-                             seq_collection1_as_view,
-                             seq_collection2_as_view,
-                             [pos, &buffer] (auto && res) { buffer[pos] = std::move(res); });
-    }
-
-    exec_handler.wait();
-
-    this->check_result(buffer);
-}
-
-TYPED_TEST_P(execution_handler, execute_with_rvalue)
-{
-    std::vector<std::pair<size_t, size_t>> buffer;
-    buffer.resize(this->total_size);
-
-    TypeParam exec_handler{};
-
-    size_t pos = 0;
-
-    for (unsigned i = 0; i < this->total_size; ++i, ++pos)
-    {
-        exec_handler.execute(simulate_alignment,
-                             i,
-                             this->sequence_collection1[i] | views::all,
-                             this->sequence_collection2[i] | views::all,
-                             [&buffer, pos] (auto && res) { buffer[pos] = std::move(res); });
-    }
-
-    exec_handler.wait();
-
-    this->check_result(buffer);
-}
-
 TYPED_TEST_P(execution_handler, execute_as_indexed_sequence_pairs)
 {
     std::vector<std::pair<size_t, size_t>> buffer;
@@ -145,6 +98,4 @@ TYPED_TEST_P(execution_handler, execute_as_indexed_sequence_pairs)
 }
 
 REGISTER_TYPED_TEST_CASE_P(execution_handler,
-                           execute_with_lvalue,
-                           execute_with_rvalue,
                            execute_as_indexed_sequence_pairs);


### PR DESCRIPTION
Fixes #1375 

Removes unused interfaces.

Depends on #1374 and #1372 