### PR TITLE
[FEATURE] Make the final chunk only as long as the longest sequence in the collection.

### DIFF
--- a/test/performance/core/simd/view_to_simd_chunk_benchmark.cpp
+++ b/test/performance/core/simd/view_to_simd_chunk_benchmark.cpp
@@ -152,7 +152,7 @@ void to_simd(benchmark::State& state)
     size_t value = 0;
     for (auto _ : state)
     {
-        for (auto & chunk : sequences | views::to_simd<simd_t>)
+        for (auto && chunk : sequences | views::to_simd<simd_t>)
             for (simd_t const & vec : chunk)
                 value += vec[0];
     }

--- a/test/snippet/core/simd/view_to_simd.cpp
+++ b/test/snippet/core/simd/view_to_simd.cpp
@@ -23,7 +23,7 @@ int main()
     auto to_soa = batch | seqan3::views::to_simd<uint16x8_t>(8);
 
     size_t chunk_count = 0;
-    for (auto & chunk : to_soa)
+    for (auto && chunk : to_soa)
     {
         seqan3::debug_stream << "Chunk " << chunk_count++ << ":\n";
         for (auto & vec : chunk)


### PR DESCRIPTION
Before this change the last chunk always had a size of simd_traits<simd_t>::length, which caused some issues when dealing with the last chunk, since the last elements in the transformed sequence might not have carried any information anymore if the size of the longest sequence was not a multiple of the simd size. Instead, the new code tracks the end of the last column in the final chunk and returns a span that only covers the sequences.