### PR TITLE
[TEST] Performance test for Vienna format

### DIFF
--- a/test/performance/io/CMakeLists.txt
+++ b/test/performance/io/CMakeLists.txt
@@ -1,3 +1,4 @@
 seqan3_benchmark(stream_input_benchmark.cpp)
 seqan3_benchmark(stream_output_benchmark.cpp)
 seqan3_benchmark(format_fasta_benchmark.cpp)
+seqan3_benchmark(format_vienna_benchmark.cpp)

--- a/test/performance/io/format_vienna_benchmark.cpp
+++ b/test/performance/io/format_vienna_benchmark.cpp
@@ -1,0 +1,151 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+#if __has_include(<seqan/rna_io.h>)
+    #include <seqan/rna_io.h>
+#endif
+
+#include <sstream>
+#include <string>
+
+#include <benchmark/benchmark.h>
+
+#include <seqan3/io/structure_file/input.hpp>
+#include <seqan3/io/structure_file/input_format_concept.hpp>
+#include <seqan3/io/structure_file/output.hpp>
+#include <seqan3/io/structure_file/output_format_concept.hpp>
+#include <seqan3/io/structure_file/format_vienna.hpp>
+#include <seqan3/test/performance/units.hpp>
+
+using namespace seqan3;
+using namespace seqan3::test;
+
+inline constexpr size_t iterations_per_run = 1024;
+
+inline std::string const header{"seq foobar blobber"};
+inline std::string const sequence
+{
+    "ACTAGACTAGCTACGATCAGCTACGATCAGCTACGAACTAGACTAGCTACGATACTAGACTAGCTACGATCAGCTACGA"
+    "ACTAGACTAGCTACGATCAGCTACGATCAGCTACGAACTAGACTAGCTACGATACTAGACTAGCTACGATCAGCTACGA"
+    "ACTAGACTAGCTACGATCAGCTACGATCAGCTACGAACTAGACTAGCTACGATACTAGACTAGCTACGATCAGCTACGA"
+    "ACTAGACTAGCTACGATCAGCTACGATCAGCTACGAACTAGACTAGCTACGATACTAGACTAGCTACGATCAGCTACGA"
+    "ACTAGACTAGCTACGATCAGCTACGATCAGCTACGAACTAGACTAGCTACGATACTAGACTAGCTACGATCAGCTACGA"
+    "ACTAGACTAGCTACGATCAGCTACGATCAGCTACGAACTAGACTAGCTACGATACTAGACTAGCTACGATCAGCTACGA"
+};
+inline std::string const structure
+{
+    "(((((((..((((........)))).((((.........)))).....(((((.......))))))))))))......."
+    "(((((((..((((........)))).((((.........)))).....(((((.......))))))))))))......."
+    "(((((((..((((........)))).((((.........)))).....(((((.......))))))))))))......."
+    "(((((((..((((........)))).((((.........)))).....(((((.......))))))))))))......."
+    "(((((((..((((........)))).((((.........)))).....(((((.......))))))))))))......."
+    "(((((((..((((........)))).((((.........)))).....(((((.......))))))))))))......."
+};
+
+static std::string vienna_file = []()
+{
+    std::string file{};
+    for (size_t idx = 0; idx < iterations_per_run; idx++)
+        file += "> " + header + "\n" + sequence + "\n" + structure + "\n";
+    return file;
+}();
+
+void write3(benchmark::State & state)
+{
+    std::ostringstream ostream;
+    structure_file_output fout{ostream, format_vienna{}};
+
+    for (auto _ : state)
+    {
+        for (size_t idx = 0; idx < iterations_per_run; ++idx)
+            fout.emplace_back(sequence, header, structure);
+    }
+
+    ostream = std::ostringstream{};
+    fout.emplace_back(sequence, header, structure);
+    size_t bytes_per_run = ostream.str().size() * iterations_per_run;
+    state.counters["iterations_per_run"] = iterations_per_run;
+    state.counters["bytes_per_run"] = bytes_per_run;
+    state.counters["bytes_per_second"] = bytes_per_second(bytes_per_run);
+}
+BENCHMARK(write3);
+
+#if __has_include(<seqan/rna_io.h>)
+void write2(benchmark::State & state)
+{
+    std::ostringstream ostream;
+    seqan::RnaRecord record{};
+    record.name = header;
+    record.sequence = sequence;
+    seqan::bracket2graph(record.fixedGraphs, structure);
+
+    for (auto _ : state)
+    {
+        for (size_t idx = 0; idx < iterations_per_run; ++idx)
+            seqan::writeRecord(ostream, record, seqan::Vienna());
+    }
+
+    ostream = std::ostringstream{};
+    seqan::writeRecord(ostream, record, seqan::Vienna());
+    size_t bytes_per_run = ostream.str().size() * iterations_per_run;
+    state.counters["iterations_per_run"] = iterations_per_run;
+    state.counters["bytes_per_run"] = bytes_per_run;
+    state.counters["bytes_per_second"] = bytes_per_second(bytes_per_run);
+}
+BENCHMARK(write2);
+#endif
+
+void read3(benchmark::State & state)
+{
+    std::istringstream istream{vienna_file};
+    structure_file_input fin{istream, format_vienna{}};
+
+    for (auto _ : state)
+    {
+        istream.clear();
+        istream.seekg(0, std::ios::beg);
+
+        auto it = fin.begin();
+        for (size_t idx = 0; idx < iterations_per_run; ++idx)
+            it++;
+    }
+
+    size_t bytes_per_run = vienna_file.size();
+    state.counters["iterations_per_run"] = iterations_per_run;
+    state.counters["bytes_per_run"] = bytes_per_run;
+    state.counters["bytes_per_second"] = bytes_per_second(bytes_per_run);
+}
+BENCHMARK(read3);
+
+#if __has_include(<seqan/rna_io.h>)
+void read2(benchmark::State & state)
+{
+    seqan::RnaRecord record{};
+    std::istringstream istream{vienna_file};
+
+    for (auto _ : state)
+    {
+        istream.clear();
+        istream.seekg(0, std::ios::beg);
+        auto it = seqan::Iter<std::istringstream, seqan::StreamIterator<seqan::Input>>(istream);
+
+        for (size_t idx = 0; idx < iterations_per_run; ++idx)
+        {
+            seqan::readRecord(record, it, seqan::Vienna());
+            clear(record);
+        }
+    }
+
+    size_t bytes_per_run = vienna_file.size();
+    state.counters["iterations_per_run"] = iterations_per_run;
+    state.counters["bytes_per_run"] = bytes_per_run;
+    state.counters["bytes_per_second"] = bytes_per_second(bytes_per_run);
+}
+BENCHMARK(read2);
+#endif
+
+BENCHMARK_MAIN();

--- a/test/performance/io/format_vienna_benchmark.cpp
+++ b/test/performance/io/format_vienna_benchmark.cpp
@@ -15,9 +15,7 @@
 #include <benchmark/benchmark.h>
 
 #include <seqan3/io/structure_file/input.hpp>
-#include <seqan3/io/structure_file/input_format_concept.hpp>
 #include <seqan3/io/structure_file/output.hpp>
-#include <seqan3/io/structure_file/output_format_concept.hpp>
 #include <seqan3/io/structure_file/format_vienna.hpp>
 #include <seqan3/test/performance/units.hpp>
 

--- a/test/performance/io/format_vienna_benchmark.cpp
+++ b/test/performance/io/format_vienna_benchmark.cpp
@@ -44,7 +44,7 @@ inline std::string const structure
     "(((((((..((((........)))).((((.........)))).....(((((.......))))))))))))......."
 };
 
-static std::string vienna_file = []()
+inline std::string const vienna_file = []()
 {
     std::string file{};
     for (size_t idx = 0; idx < iterations_per_run; idx++)


### PR DESCRIPTION
Adds performance tests for the Vienna structure format.

Note: The run time for SeqAn2 is significantly slower, because the structure representation is a graph instead of a string over the wuss alphabet.

Resolves #1392. 