### PR TITLE
Misc/remove char type from file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,9 +62,16 @@ If possible, provide tooling that performs the changes, e.g. a shell-script.
 
 #### I/O
 
-* The field-based in- and output interface for structure files through std::get and std::tie has been removed.
+* **Removed the field-based in- and output interface for structure files through std::get and std::tie:**
   Output can instead be achieved with seqan3::views:zip(), for input we will implement unzip() in the future.
 * The `field::FLAG` of SAM/BAM input and output is now an **enum** instead of a simple integer (see seqan3::sam_flag).
+
+* **Removed the char type from the input and output files:**
+  Most user code will be unaffected; however, if you have fully specified all templates of any of the input or output
+  files in your code, you need to remove the template parameter to select the char type of the stream
+  (e.g. change `seqan3::sequence_file_input<traits_t, fields_t, formats_t, char>` to
+  `seqan3::sequence_file_input<traits_t, fields_t, formats_t>`). Before this change, setting the char type gave the
+  impression that also streams over wide characters are supported which is not the case yet.
 
 #### Range
 

--- a/include/seqan3/io/alignment_file/input.hpp
+++ b/include/seqan3/io/alignment_file/input.hpp
@@ -228,7 +228,6 @@ struct alignment_file_input_default_traits
  *                              must be in seqan3::alignment_file_input::field_ids.
  * \tparam valid_formats        A seqan3::type_list of the selectable formats (each must meet
  *                              seqan3::alignment_file_input_format).
- * \tparam stream_char_type     The type of the underlying stream device(s); must model std::integral.
  *
  * \details
  *
@@ -363,24 +362,23 @@ struct alignment_file_input_default_traits
  *   * seqan3::format_bam
  */
 template <
-    alignment_file_input_traits                     traits_type_        = alignment_file_input_default_traits<>,
-    detail::fields_specialisation                               selected_field_ids_ = fields<field::SEQ,
-                                                                                             field::ID,
-                                                                                             field::OFFSET,
-                                                                                             field::REF_SEQ,
-                                                                                             field::REF_ID,
-                                                                                             field::REF_OFFSET,
-                                                                                             field::ALIGNMENT,
-                                                                                             field::MAPQ,
-                                                                                             field::QUAL,
-                                                                                             field::FLAG,
-                                                                                             field::MATE,
-                                                                                             field::TAGS,
-                                                                                             field::EVALUE,
-                                                                                             field::BIT_SCORE,
-                                                                                             field::HEADER_PTR>,
-    detail::type_list_of_alignment_file_input_formats  valid_formats_    = type_list<format_sam, format_bam>,
-    std::integral                                stream_char_type_ = char>
+    alignment_file_input_traits traits_type_ = alignment_file_input_default_traits<>,
+    detail::fields_specialisation selected_field_ids_ = fields<field::SEQ,
+                                                               field::ID,
+                                                               field::OFFSET,
+                                                               field::REF_SEQ,
+                                                               field::REF_ID,
+                                                               field::REF_OFFSET,
+                                                               field::ALIGNMENT,
+                                                               field::MAPQ,
+                                                               field::QUAL,
+                                                               field::FLAG,
+                                                               field::MATE,
+                                                               field::TAGS,
+                                                               field::EVALUE,
+                                                               field::BIT_SCORE,
+                                                               field::HEADER_PTR>,
+    detail::type_list_of_alignment_file_input_formats valid_formats_ = type_list<format_sam, format_bam>>
 class alignment_file_input
 {
 public:
@@ -394,8 +392,8 @@ public:
     using selected_field_ids    = selected_field_ids_;
     //!\brief A seqan3::type_list with the possible formats.
     using valid_formats         = valid_formats_;
-    //!\brief Character type of the stream(s), usually `char`.
-    using stream_char_type      = stream_char_type_;
+    //!\brief Character type of the stream(s).
+    using stream_char_type      = char;
     //!\}
 
 private:
@@ -609,6 +607,9 @@ public:
      * See the section on \link io_compression compression and decompression \endlink for more information.
      */
     template <input_stream stream_t, alignment_file_input_format file_format>
+    //!\cond
+        requires std::same_as<typename std::remove_reference_t<stream_t>::char_type, stream_char_type>
+    //!\endcond
     alignment_file_input(stream_t                 & stream,
                          file_format        const & SEQAN3_DOXYGEN_ONLY(format_tag),
                          selected_field_ids const & SEQAN3_DOXYGEN_ONLY(fields_tag) = selected_field_ids{}) :
@@ -619,6 +620,9 @@ public:
 
     //!\overload
     template <input_stream stream_t, alignment_file_input_format file_format>
+    //!\cond
+        requires std::same_as<typename std::remove_reference_t<stream_t>::char_type, stream_char_type>
+    //!\endcond
     alignment_file_input(stream_t                && stream,
                          file_format        const & SEQAN3_DOXYGEN_ONLY(format_tag),
                          selected_field_ids const & SEQAN3_DOXYGEN_ONLY(fields_tag) = selected_field_ids{}) :
@@ -1003,54 +1007,50 @@ protected:
  * \relates seqan3::alignment_file_input
  * \{
  */
-//!\brief Deduce selected fields, file_format and stream char type, default the rest.
-template <input_stream                 stream_type,
+//!\brief Deduce selected fields, file_format, and default the rest.
+template <input_stream stream_type,
           alignment_file_input_format file_format,
-          detail::fields_specialisation           selected_field_ids>
+          detail::fields_specialisation selected_field_ids>
 alignment_file_input(stream_type && stream,
                      file_format const &,
                      selected_field_ids const &)
     -> alignment_file_input<typename alignment_file_input<>::traits_type,       // actually use the default
                             selected_field_ids,
-                            type_list<file_format>,
-                            typename std::remove_reference_t<stream_type>::char_type>;
+                            type_list<file_format>>;
 
-//!\brief Deduce selected fields, file_format and stream char type, default the rest.
-template <input_stream                 stream_type,
+//!\brief Deduce selected fields, file_format, and default the rest.
+template <input_stream stream_type,
           alignment_file_input_format file_format,
-          detail::fields_specialisation           selected_field_ids>
+          detail::fields_specialisation selected_field_ids>
 alignment_file_input(stream_type & stream,
                      file_format const &,
                      selected_field_ids const &)
     -> alignment_file_input<typename alignment_file_input<>::traits_type,       // actually use the default
                             selected_field_ids,
-                            type_list<file_format>,
-                            typename std::remove_reference_t<stream_type>::char_type>;
+                            type_list<file_format>>;
 
-//!\brief Deduce file_format and stream char type, default the rest.
-template <input_stream                 stream_type,
+//!\brief Deduce file_format, and default the rest.
+template <input_stream stream_type,
           alignment_file_input_format file_format>
 alignment_file_input(stream_type && stream,
                      file_format const &)
     -> alignment_file_input<typename alignment_file_input<>::traits_type,        // actually use the default
                             typename alignment_file_input<>::selected_field_ids, // actually use the default
-                            type_list<file_format>,
-                            typename std::remove_reference_t<stream_type>::char_type>;
+                            type_list<file_format>>;
 
-//!\brief Deduce file_format and stream char type, default the rest.
-template <input_stream                 stream_type,
+//!\brief Deduce file_format, and default the rest.
+template <input_stream stream_type,
           alignment_file_input_format file_format>
 alignment_file_input(stream_type & stream,
                      file_format const &)
     -> alignment_file_input<typename alignment_file_input<>::traits_type,        // actually use the default
                             typename alignment_file_input<>::selected_field_ids, // actually use the default
-                            type_list<file_format>,
-                            typename std::remove_reference_t<stream_type>::char_type>;
+                            type_list<file_format>>;
 
 //!\brief Deduce selected fields, ref_sequences_t and ref_ids_t, default the rest.
-template <std::ranges::forward_range           ref_ids_t,
-          std::ranges::forward_range           ref_sequences_t,
-          detail::fields_specialisation                      selected_field_ids>
+template <std::ranges::forward_range ref_ids_t,
+          std::ranges::forward_range ref_sequences_t,
+          detail::fields_specialisation selected_field_ids>
 alignment_file_input(std::filesystem::path path,
                      ref_ids_t &,
                      ref_sequences_t &,
@@ -1058,8 +1058,7 @@ alignment_file_input(std::filesystem::path path,
     -> alignment_file_input<alignment_file_input_default_traits<std::remove_reference_t<ref_sequences_t>,
                                                                 std::remove_reference_t<ref_ids_t>>,
                             selected_field_ids,
-                            typename alignment_file_input<>::valid_formats,      // actually use the default
-                            typename alignment_file_input<>::stream_char_type>;  // actually use the default
+                            typename alignment_file_input<>::valid_formats>;  // actually use the default
 
 //!\brief Deduce ref_sequences_t and ref_ids_t, default the rest.
 template <std::ranges::forward_range ref_ids_t,
@@ -1070,15 +1069,14 @@ alignment_file_input(std::filesystem::path path,
     -> alignment_file_input<alignment_file_input_default_traits<std::remove_reference_t<ref_sequences_t>,
                                                                 std::remove_reference_t<ref_ids_t>>,
                             typename alignment_file_input<>::selected_field_ids, // actually use the default
-                            typename alignment_file_input<>::valid_formats,      // actually use the default
-                            typename alignment_file_input<>::stream_char_type>;  // actually use the default
+                            typename alignment_file_input<>::valid_formats>;     // actually use the default
 
-//!\brief Deduce selected fields, ref_sequences_t and ref_ids_t, file format and stream char type.
-template <input_stream                  stream_type,
+//!\brief Deduce selected fields, ref_sequences_t and ref_ids_t, and file format.
+template <input_stream stream_type,
           std::ranges::forward_range ref_ids_t,
           std::ranges::forward_range ref_sequences_t,
-          alignment_file_input_format  file_format,
-          detail::fields_specialisation            selected_field_ids>
+          alignment_file_input_format file_format,
+          detail::fields_specialisation selected_field_ids>
 alignment_file_input(stream_type && stream,
                      ref_ids_t &,
                      ref_sequences_t &,
@@ -1087,15 +1085,14 @@ alignment_file_input(stream_type && stream,
     -> alignment_file_input<alignment_file_input_default_traits<std::remove_reference_t<ref_sequences_t>,
                                                                 std::remove_reference_t<ref_ids_t>>,
                             selected_field_ids,
-                            type_list<file_format>,
-                            typename std::remove_reference_t<stream_type>::char_type>;
+                            type_list<file_format>>;
 
-//!\brief Deduce selected fields, ref_sequences_t and ref_ids_t, file format and stream char type.
-template <input_stream                  stream_type,
+//!\brief Deduce selected fields, ref_sequences_t and ref_ids_t, and file format.
+template <input_stream stream_type,
           std::ranges::forward_range ref_ids_t,
           std::ranges::forward_range ref_sequences_t,
-          alignment_file_input_format  file_format,
-          detail::fields_specialisation            selected_field_ids>
+          alignment_file_input_format file_format,
+          detail::fields_specialisation selected_field_ids>
 alignment_file_input(stream_type & stream,
                      ref_ids_t &,
                      ref_sequences_t &,
@@ -1104,14 +1101,13 @@ alignment_file_input(stream_type & stream,
     -> alignment_file_input<alignment_file_input_default_traits<std::remove_reference_t<ref_sequences_t>,
                                                                 std::remove_reference_t<ref_ids_t>>,
                             selected_field_ids,
-                            type_list<file_format>,
-                            typename std::remove_reference_t<stream_type>::char_type>;
+                            type_list<file_format>>;
 
-//!\brief Deduce ref_sequences_t and ref_ids_t, file format and stream char type.
-template <input_stream                  stream_type,
+//!\brief Deduce ref_sequences_t and ref_ids_t, and file format.
+template <input_stream stream_type,
           std::ranges::forward_range ref_ids_t,
           std::ranges::forward_range ref_sequences_t,
-          alignment_file_input_format  file_format>
+          alignment_file_input_format file_format>
 alignment_file_input(stream_type && stream,
                      ref_ids_t &,
                      ref_sequences_t &,
@@ -1119,11 +1115,10 @@ alignment_file_input(stream_type && stream,
     -> alignment_file_input<alignment_file_input_default_traits<std::remove_reference_t<ref_sequences_t>,
                                                                 std::remove_reference_t<ref_ids_t>>,
                             typename alignment_file_input<>::selected_field_ids, // actually use the default
-                            type_list<file_format>,
-                            typename std::remove_reference_t<stream_type>::char_type>;
+                            type_list<file_format>>;
 
-//!\brief Deduce selected fields, ref_sequences_t and ref_ids_t, file format and stream char type.
-template <input_stream                  stream_type,
+//!\brief Deduce selected fields, ref_sequences_t and ref_ids_t, and file format.
+template <input_stream stream_type,
           std::ranges::forward_range ref_ids_t,
           std::ranges::forward_range ref_sequences_t,
           alignment_file_input_format  file_format>
@@ -1134,8 +1129,7 @@ alignment_file_input(stream_type & stream,
     -> alignment_file_input<alignment_file_input_default_traits<std::remove_reference_t<ref_sequences_t>,
                                                                 std::remove_reference_t<ref_ids_t>>,
                             typename alignment_file_input<>::selected_field_ids, // actually use the default
-                            type_list<file_format>,
-                            typename std::remove_reference_t<stream_type>::char_type>;
+                            type_list<file_format>>;
 //!\}
 
 } // namespace seqan3
@@ -1152,11 +1146,10 @@ namespace std
  * \ingroup alignment_file
  * \see std::tuple_size_v
  */
-template <seqan3::alignment_file_input_traits                    traits_type,
-          seqan3::detail::fields_specialisation                              selected_field_ids,
-          seqan3::detail::type_list_of_alignment_file_input_formats valid_formats,
-          std::integral                                       stream_char_t>
-struct tuple_size<seqan3::alignment_file_input<traits_type, selected_field_ids, valid_formats, stream_char_t>>
+template <seqan3::alignment_file_input_traits traits_type,
+          seqan3::detail::fields_specialisation selected_field_ids,
+          seqan3::detail::type_list_of_alignment_file_input_formats valid_formats>
+struct tuple_size<seqan3::alignment_file_input<traits_type, selected_field_ids, valid_formats>>
 {
     //!\brief The value equals the number of selected fields in the file.
     static constexpr size_t value = selected_field_ids::as_array.size();
@@ -1167,16 +1160,14 @@ struct tuple_size<seqan3::alignment_file_input<traits_type, selected_field_ids, 
  * \ingroup alignment_file
  * \see [std::tuple_element](https://en.cppreference.com/w/cpp/utility/tuple/tuple_element)
  */
-template <size_t                                              elem_no,
-          seqan3::alignment_file_input_traits                    traits_type,
-          seqan3::detail::fields_specialisation                              selected_field_ids,
-          seqan3::detail::type_list_of_alignment_file_input_formats valid_formats,
-          std::integral                                       stream_char_t>
-struct tuple_element<elem_no, seqan3::alignment_file_input<traits_type, selected_field_ids, valid_formats, stream_char_t>>
+template <size_t elem_no,
+          seqan3::alignment_file_input_traits traits_type,
+          seqan3::detail::fields_specialisation  selected_field_ids,
+          seqan3::detail::type_list_of_alignment_file_input_formats valid_formats>
+struct tuple_element<elem_no, seqan3::alignment_file_input<traits_type, selected_field_ids, valid_formats>>
     : tuple_element<elem_no, typename seqan3::alignment_file_input<traits_type,
-                                                               selected_field_ids,
-                                                               valid_formats,
-                                                               stream_char_t>::file_as_tuple_type>
+                                                                   selected_field_ids,
+                                                                   valid_formats>::file_as_tuple_type>
 {};
 
 } // namespace std

--- a/include/seqan3/io/alignment_file/input_format_concept.hpp
+++ b/include/seqan3/io/alignment_file/input_format_concept.hpp
@@ -31,11 +31,28 @@
 namespace seqan3::detail
 {
 
+/*!\brief Internal class used to expose the actual format interface to read alignment records from the file.
+ * \ingroup alignment_file
+ *
+ * \tparam format_type The type of the format to be exposed.
+ *
+ * \details
+ *
+ * Exposes the protected member function `read_alignment_record` from the given `format_type`, such that the file can
+ * call the proper function for the selected format.
+ */
 template <typename format_type>
 struct alignment_file_input_format_exposer : public format_type
 {
 public:
-    using format_type::read_alignment_record;
+    // Can't use `using format_type::read_alignment_record` as it produces a hard failure in the format concept check
+    // for types that do not model the format concept, i.e. don't offer the proper read_alignment_record interface.
+    //!\brief Forwards to the seqan3::alignment_file_input_format::read_alignment_record interface.
+    template <typename ...ts>
+    void read_alignment_record(ts && ...args)
+    {
+        format_type::read_alignment_record(std::forward<ts>(args)...);
+    }
 };
 
 } // namespace seqan3::detail

--- a/include/seqan3/io/alignment_file/output.hpp
+++ b/include/seqan3/io/alignment_file/output.hpp
@@ -49,7 +49,6 @@ namespace seqan3
  *                              fields IDs; only relevant if these can't be deduced.
  * \tparam valid_formats        A seqan3::type_list of the selectable formats (each
  *                              must model seqan3::alignment_file_output_format).
- * \tparam stream_char_type     The type of character of the underlying stream, must model seqan3::builtin_character.
  *
  * \details
  *
@@ -183,7 +182,6 @@ template <detail::fields_specialisation selected_field_ids_ =
                      field::BIT_SCORE,
                      field::HEADER_PTR>,
           detail::type_list_of_alignment_file_output_formats valid_formats_ = type_list<format_sam, format_bam>,
-          builtin_character stream_char_type_ = char,
           typename ref_ids_type = ref_info_not_given>
 class alignment_file_output
 {
@@ -196,8 +194,8 @@ public:
     using selected_field_ids    = selected_field_ids_;
     //!\brief A seqan3::type_list with the possible formats.
     using valid_formats         = valid_formats_;
-    //!\brief Character type of the stream(s), usually `char`.
-    using stream_char_type      = stream_char_type_;
+    //!\brief Character type of the stream(s).
+    using stream_char_type      = char;
     //!\}
 
     //!\brief The subset of seqan3::field IDs that are valid for this file.
@@ -332,6 +330,9 @@ public:
      * See the section on \link io_compression compression and decompression \endlink for more information.
      */
     template <output_stream stream_type, alignment_file_output_format file_format>
+    //!\cond
+        requires std::same_as<typename std::remove_reference_t<stream_type>::char_type, stream_char_type>
+    //!\endcond
     alignment_file_output(stream_type              & stream,
                           file_format        const & SEQAN3_DOXYGEN_ONLY(format_tag),
                           selected_field_ids const & SEQAN3_DOXYGEN_ONLY(fields_tag) = selected_field_ids{}) :
@@ -345,6 +346,9 @@ public:
 
     //!\overload
     template <output_stream stream_type, alignment_file_output_format file_format>
+    //!\cond
+        requires std::same_as<typename std::remove_reference_t<stream_type>::char_type, stream_char_type>
+    //!\endcond
     alignment_file_output(stream_type             && stream,
                           file_format        const & SEQAN3_DOXYGEN_ONLY(format_tag),
                           selected_field_ids const & SEQAN3_DOXYGEN_ONLY(fields_tag) = selected_field_ids{}) :
@@ -827,63 +831,58 @@ protected:
  */
 
 /*!\brief Deduces selected_field_ids from input and sets alignment_file_output::ref_ids_type to
- * seqan3::detail::ref_info_not_given. Valid formats and stream_char_type are defaulted.
+ *        seqan3::detail::ref_info_not_given. valid_formats is defaulted.
  */
-template <detail::fields_specialisation    selected_field_ids>
+template <detail::fields_specialisation selected_field_ids>
 alignment_file_output(std::filesystem::path, selected_field_ids const &)
     -> alignment_file_output<selected_field_ids,
                              typename alignment_file_output<>::valid_formats,
-                             typename alignment_file_output<>::stream_char_type,
                              ref_info_not_given>;
 
-/*!\brief Deduces selected_field_ids, the valid format and the stream_char_type from input and
- * sets alignment_file_output::ref_ids_type to seqan3::detail::ref_info_not_given.
+/*!\brief Deduces selected_field_ids, and the valid format from input and
+ *        sets alignment_file_output::ref_ids_type to seqan3::detail::ref_info_not_given.
  */
-template <output_stream                  stream_type,
+template <output_stream stream_type,
           alignment_file_output_format file_format,
-          detail::fields_specialisation            selected_field_ids>
+          detail::fields_specialisation selected_field_ids>
 alignment_file_output(stream_type &&, file_format const &, selected_field_ids const &)
     -> alignment_file_output<selected_field_ids,
                              type_list<file_format>,
-                             typename std::remove_reference_t<stream_type>::char_type,
                              ref_info_not_given>;
 
-/*!\brief Deduces selected_field_ids, the valid format and the stream_char_type from input and
- * sets alignment_file_output::ref_ids_type to seqan3::detail::ref_info_not_given.
+/*!\brief Deduces selected_field_ids, and the valid format from input and
+ *        sets alignment_file_output::ref_ids_type to seqan3::detail::ref_info_not_given.
  */
-template <output_stream                  stream_type,
+template <output_stream stream_type,
           alignment_file_output_format file_format,
-          detail::fields_specialisation            selected_field_ids>
+          detail::fields_specialisation selected_field_ids>
 alignment_file_output(stream_type &, file_format const &, selected_field_ids const &)
     -> alignment_file_output<selected_field_ids,
                              type_list<file_format>,
-                             typename std::remove_reference_t<stream_type>::char_type,
                              ref_info_not_given>;
 
-/*!\brief Deduces the valid format and the stream_char_type from input and
- * sets alignment_file_output::ref_ids_type to seqan3::detail::ref_info_not_given.
+/*!\brief Deduces the valid format from input and sets alignment_file_output::ref_ids_type to
+ *        seqan3::detail::ref_info_not_given. selected_field_ids is defaulted.
  */
-template <output_stream                  stream_type,
+template <output_stream stream_type,
           alignment_file_output_format file_format>
 alignment_file_output(stream_type &&, file_format const &)
     -> alignment_file_output<typename alignment_file_output<>::selected_field_ids,
                              type_list<file_format>,
-                             typename std::remove_reference_t<stream_type>::char_type,
                              ref_info_not_given>;
 
-/*!\brief Deduces the valid format and the stream_char_type from input and
- * sets alignment_file_output::ref_ids_type to seqan3::detail::ref_info_not_given.
+/*!\brief Deduces the valid format from input and sets alignment_file_output::ref_ids_type to
+ *        seqan3::detail::ref_info_not_given. selected_field_ids is defaulted.
  */
-template <output_stream                  stream_type,
+template <output_stream stream_type,
           alignment_file_output_format file_format>
 alignment_file_output(stream_type &, file_format const &)
     -> alignment_file_output<typename alignment_file_output<>::selected_field_ids,
                              type_list<file_format>,
-                             typename std::remove_reference_t<stream_type>::char_type,
                              ref_info_not_given>;
 
-//!\brief Deduces selected_field_ids and ref_ids_type from input. Valid formats and stream_char_type are defaulted.
-template <detail::fields_specialisation    selected_field_ids,
+//!\brief Deduces selected_field_ids and ref_ids_type from input. valid_formats is defaulted.
+template <detail::fields_specialisation selected_field_ids,
           std::ranges::forward_range ref_ids_type,
           std::ranges::forward_range ref_lengths_type>
 alignment_file_output(std::filesystem::path const &,
@@ -892,10 +891,9 @@ alignment_file_output(std::filesystem::path const &,
                       selected_field_ids const &)
     -> alignment_file_output<selected_field_ids,
                              typename alignment_file_output<>::valid_formats,
-                             typename alignment_file_output<>::stream_char_type,
                              std::remove_reference_t<ref_ids_type>>;
 
-//!\brief Deduces ref_ids_type from input. Valid formats, selected_field_ids and stream_char_type are defaulted.
+//!\brief Deduces ref_ids_type from input. Valid formats, and selected_field_ids are defaulted.
 template <std::ranges::forward_range ref_ids_type,
           std::ranges::forward_range ref_lengths_type>
 alignment_file_output(std::filesystem::path const &,
@@ -903,15 +901,14 @@ alignment_file_output(std::filesystem::path const &,
                       ref_lengths_type &&)
     -> alignment_file_output<typename alignment_file_output<>::selected_field_ids,
                              typename alignment_file_output<>::valid_formats,
-                             typename alignment_file_output<>::stream_char_type,
                              std::remove_reference_t<ref_ids_type>>;
 
-//!\brief Deduces selected_field_ids, the valid format, stream_char_type and the ref_ids_type from input.
-template <output_stream                  stream_type,
+//!\brief Deduces selected_field_ids, the valid format, and the ref_ids_type from input.
+template <output_stream stream_type,
           std::ranges::forward_range ref_ids_type,
           std::ranges::forward_range ref_lengths_type,
           alignment_file_output_format file_format,
-          detail::fields_specialisation            selected_field_ids>
+          detail::fields_specialisation selected_field_ids>
 alignment_file_output(stream_type &&,
                       ref_ids_type &&,
                       ref_lengths_type &&,
@@ -919,15 +916,14 @@ alignment_file_output(stream_type &&,
                       selected_field_ids const &)
     -> alignment_file_output<selected_field_ids,
                              type_list<file_format>,
-                             typename std::remove_reference_t<stream_type>::char_type,
                              std::remove_reference_t<ref_ids_type>>;
 
-//!\brief Deduces selected_field_ids, the valid format, stream_char_type and the ref_ids_type from input.
-template <output_stream                  stream_type,
+//!\brief Deduces selected_field_ids, the valid format, and the ref_ids_type from input.
+template <output_stream stream_type,
           std::ranges::forward_range ref_ids_type,
           std::ranges::forward_range ref_lengths_type,
           alignment_file_output_format file_format,
-          detail::fields_specialisation            selected_field_ids>
+          detail::fields_specialisation selected_field_ids>
 alignment_file_output(stream_type &,
                       ref_ids_type &&,
                       ref_lengths_type &&,
@@ -935,11 +931,10 @@ alignment_file_output(stream_type &,
                       selected_field_ids const &)
     -> alignment_file_output<selected_field_ids,
                              type_list<file_format>,
-                             typename std::remove_reference_t<stream_type>::char_type,
                              std::remove_reference_t<ref_ids_type>>;
 
-//!\brief Deduces the valid format, stream_char_type and the ref_ids_type from input. selected_field_ids are defaulted.
-template <output_stream                  stream_type,
+//!\brief Deduces the valid format, and the ref_ids_type from input. selected_field_ids is defaulted.
+template <output_stream stream_type,
           std::ranges::forward_range ref_ids_type,
           std::ranges::forward_range ref_lengths_type,
           alignment_file_output_format file_format>
@@ -949,11 +944,10 @@ alignment_file_output(stream_type &&,
                       file_format const &)
     -> alignment_file_output<typename alignment_file_output<>::selected_field_ids,
                              type_list<file_format>,
-                             typename std::remove_reference_t<stream_type>::char_type,
                              std::remove_reference_t<ref_ids_type>>;
 
-//!\brief Deduces the valid format, stream_char_type and the ref_ids_type from input. selected_field_ids are defaulted.
-template <output_stream                  stream_type,
+//!\brief Deduces the valid format, and the ref_ids_type from input. selected_field_ids is defaulted.
+template <output_stream stream_type,
           std::ranges::forward_range ref_ids_type,
           std::ranges::forward_range ref_lengths_type,
           alignment_file_output_format file_format>
@@ -963,7 +957,6 @@ alignment_file_output(stream_type &,
                       file_format const &)
     -> alignment_file_output<typename alignment_file_output<>::selected_field_ids,
                              type_list<file_format>,
-                             typename std::remove_reference_t<stream_type>::char_type,
                              std::remove_reference_t<ref_ids_type>>;
 //!\}
 

--- a/include/seqan3/io/alignment_file/output_format_concept.hpp
+++ b/include/seqan3/io/alignment_file/output_format_concept.hpp
@@ -30,11 +30,28 @@
 namespace seqan3::detail
 {
 
+/*!\brief Internal class used to expose the actual format interface to write alignment records into the file.
+ * \ingroup alignment_file
+ *
+ * \tparam format_type The type of the format to be exposed.
+ *
+ * \details
+ *
+ * Exposes the protected member function `write_alignment_record` from the given `format_type`, such that the file can
+ * call the proper function for the selected format.
+ */
 template <typename format_type>
 struct alignment_file_output_format_exposer : public format_type
 {
 public:
-    using format_type::write_alignment_record;
+    // Can't use `using format_type::write_alignment_record` as it produces a hard failure in the format concept check
+    // for types that do not model the format concept, i.e. don't offer the proper write_alignment_record interface.
+    //!\brief Forwards to the seqan3::alignment_file_output_format::write_alignment_record interface.
+    template <typename ...ts>
+    void write_alignment_record(ts && ...args)
+    {
+        format_type::write_alignment_record(std::forward<ts>(args)...);
+    }
 };
 
 } // namespace seqan3::detail

--- a/include/seqan3/io/sequence_file/input.hpp
+++ b/include/seqan3/io/sequence_file/input.hpp
@@ -221,12 +221,12 @@ struct sequence_file_input_default_traits_aa : sequence_file_input_default_trait
 /*!\brief A class for reading sequence files, e.g. FASTA, FASTQ ...
  * \ingroup sequence
  * \tparam traits_type          An auxiliary type that defines certain member types and constants, must satisfy
- * seqan3::sequence_file_input_traits.
+ *                              seqan3::sequence_file_input_traits.
  * \tparam selected_field_ids   A seqan3::fields type with the list and order of desired record entries; all fields
- * must be in seqan3::sequence_file_input::field_ids.
+ *                              must be in seqan3::sequence_file_input::field_ids.
  * \tparam valid_formats        A seqan3::type_list of the selectable formats (each must meet
- * seqan3::sequence_file_input_format).
- * \tparam stream_char_type     The type of the underlying stream device(s); must model seqan3::builtin_character.
+ *                              seqan3::sequence_file_input_format).
+ *
  * \details
  *
  * ### Introduction
@@ -361,8 +361,7 @@ template <
                                                                                format_fasta,
                                                                                format_fastq,
                                                                                format_genbank,
-                                                                               format_sam>,
-    builtin_character                                       stream_char_type_   = char>
+                                                                               format_sam>>
 class sequence_file_input
 {
 public:
@@ -376,8 +375,8 @@ public:
     using selected_field_ids    = selected_field_ids_;
     //!\brief A seqan3::type_list with the possible formats.
     using valid_formats         = valid_formats_;
-    //!\brief Character type of the stream(s), usually `char`.
-    using stream_char_type      = stream_char_type_;
+    //!\brief Character type of the stream(s).
+    using stream_char_type      = char;
     //!\}
 
     /*!\brief The subset of seqan3::field IDs that are valid for this file; order corresponds to the types in
@@ -545,6 +544,9 @@ public:
      */
     template <input_stream stream_t,
               sequence_file_input_format file_format>
+    //!\cond
+        requires std::same_as<typename std::remove_reference_t<stream_t>::char_type, stream_char_type>
+    //!\endcond
     sequence_file_input(stream_t                 & stream,
                         file_format        const & SEQAN3_DOXYGEN_ONLY(format_tag),
                         selected_field_ids const & SEQAN3_DOXYGEN_ONLY(fields_tag) = selected_field_ids{}) :
@@ -561,6 +563,9 @@ public:
     //!\overload
     template <input_stream stream_t,
               sequence_file_input_format file_format>
+    //!\cond
+        requires std::same_as<typename std::remove_reference_t<stream_t>::char_type, stream_char_type>
+    //!\endcond
     sequence_file_input(stream_t                && stream,
                         file_format        const & SEQAN3_DOXYGEN_ONLY(format_tag),
                         selected_field_ids const & SEQAN3_DOXYGEN_ONLY(fields_tag) = selected_field_ids{}) :
@@ -824,48 +829,44 @@ protected:
  */
 
 //!\brief Deduces the sequence input file type from the stream and the format.
-template <input_stream                           stream_type,
-          sequence_file_input_format            file_format>
+template <input_stream stream_type,
+          sequence_file_input_format file_format>
 sequence_file_input(stream_type & stream,
                     file_format const &)
     -> sequence_file_input<typename sequence_file_input<>::traits_type,         // actually use the default
                            typename sequence_file_input<>::selected_field_ids,  // default field ids.
-                           type_list<file_format>,
-                           typename std::remove_reference_t<stream_type>::char_type>;
+                           type_list<file_format>>;
 
 //!\overload
-template <input_stream                           stream_type,
-          sequence_file_input_format            file_format>
+template <input_stream stream_type,
+          sequence_file_input_format file_format>
 sequence_file_input(stream_type && stream,
                     file_format const &)
    -> sequence_file_input<typename sequence_file_input<>::traits_type,         // actually use the default
                           typename sequence_file_input<>::selected_field_ids,  // default field ids.
-                          type_list<file_format>,
-                          typename std::remove_reference_t<stream_type>::char_type>;
+                          type_list<file_format>>;
 
 //!\brief Deduces the sequence input file type from the stream, the format and the field ids.
-template <input_stream                           stream_type,
-          sequence_file_input_format            file_format,
-          detail::fields_specialisation                     selected_field_ids>
+template <input_stream stream_type,
+          sequence_file_input_format file_format,
+          detail::fields_specialisation selected_field_ids>
 sequence_file_input(stream_type && stream,
                     file_format const &,
                     selected_field_ids const &)
     -> sequence_file_input<typename sequence_file_input<>::traits_type,       // actually use the default
                            selected_field_ids,
-                           type_list<file_format>,
-                           typename std::remove_reference_t<stream_type>::char_type>;
+                           type_list<file_format>>;
 
 //!\overload
-template <input_stream                           stream_type,
-          sequence_file_input_format            file_format,
-          detail::fields_specialisation                     selected_field_ids>
+template <input_stream stream_type,
+          sequence_file_input_format file_format,
+          detail::fields_specialisation selected_field_ids>
 sequence_file_input(stream_type & stream,
                     file_format const &,
                     selected_field_ids const &)
     -> sequence_file_input<typename sequence_file_input<>::traits_type,       // actually use the default
                            selected_field_ids,
-                           type_list<file_format>,
-                           typename std::remove_reference_t<stream_type>::char_type>;
+                           type_list<file_format>>;
 //!\}
 
 } // namespace seqan3
@@ -881,11 +882,10 @@ namespace std
  * \ingroup sequence
  * \see std::tuple_size_v
  */
-template <seqan3::sequence_file_input_traits                    traits_type,
-          seqan3::detail::fields_specialisation                             selected_field_ids,
-          seqan3::detail::type_list_of_sequence_file_input_formats valid_formats,
-          seqan3::builtin_character                                       stream_char_t>
-struct tuple_size<seqan3::sequence_file_input<traits_type, selected_field_ids, valid_formats, stream_char_t>>
+template <seqan3::sequence_file_input_traits traits_type,
+          seqan3::detail::fields_specialisation selected_field_ids,
+          seqan3::detail::type_list_of_sequence_file_input_formats valid_formats>
+struct tuple_size<seqan3::sequence_file_input<traits_type, selected_field_ids, valid_formats>>
 {
     //!\brief The value equals the number of selected fields in the file.
     static constexpr size_t value = selected_field_ids::as_array.size();
@@ -896,16 +896,14 @@ struct tuple_size<seqan3::sequence_file_input<traits_type, selected_field_ids, v
  * \ingroup sequence
  * \see [std::tuple_element](https://en.cppreference.com/w/cpp/utility/tuple/tuple_element)
  */
-template <size_t                                             elem_no,
-          seqan3::sequence_file_input_traits                    traits_type,
-          seqan3::detail::fields_specialisation                             selected_field_ids,
-          seqan3::detail::type_list_of_sequence_file_input_formats valid_formats,
-          seqan3::builtin_character                                       stream_char_t>
-struct tuple_element<elem_no, seqan3::sequence_file_input<traits_type, selected_field_ids, valid_formats, stream_char_t>>
+template <size_t elem_no,
+          seqan3::sequence_file_input_traits traits_type,
+          seqan3::detail::fields_specialisation selected_field_ids,
+          seqan3::detail::type_list_of_sequence_file_input_formats valid_formats>
+struct tuple_element<elem_no, seqan3::sequence_file_input<traits_type, selected_field_ids, valid_formats>>
     : tuple_element<elem_no, typename seqan3::sequence_file_input<traits_type,
-                                                               selected_field_ids,
-                                                               valid_formats,
-                                                               stream_char_t>::file_as_tuple_type>
+                                                                  selected_field_ids,
+                                                                  valid_formats>::file_as_tuple_type>
 {};
 
 } // namespace std

--- a/include/seqan3/io/sequence_file/input_format_concept.hpp
+++ b/include/seqan3/io/sequence_file/input_format_concept.hpp
@@ -26,11 +26,29 @@
 namespace seqan3::detail
 {
 
+/*!\brief Internal class used to expose the actual format interface to read sequence records from the file.
+ * \ingroup sequence_file
+ *
+ * \tparam format_type The type of the format to be exposed.
+ *
+ * \details
+ *
+ * Exposes the protected member function `read_sequence_record` from the given `format_type`, such that the file can
+ * call the proper function for the selected format.
+ */
 template <typename format_type>
 struct sequence_file_input_format_exposer : public format_type
 {
 public:
-    using format_type::read_sequence_record;
+
+    // Can't use `using format_type::read_sequence_record` as it produces a hard failure in the format concept check
+    // for types that do not model the format concept, i.e. don't offer the proper read_sequence_record interface.
+    //!\brief Forwards to the seqan3::sequence_file_input_format::read_sequence_record interface.
+    template <typename ...ts>
+    void read_sequence_record(ts && ...args)
+    {
+        format_type::read_sequence_record(std::forward<ts>(args)...);
+    }
 };
 
 } // namespace seqan3::detail

--- a/include/seqan3/io/sequence_file/output.hpp
+++ b/include/seqan3/io/sequence_file/output.hpp
@@ -55,10 +55,10 @@ namespace seqan3
 /*!\brief A class for writing sequence files, e.g. FASTA, FASTQ ...
  * \ingroup sequence
  * \tparam selected_field_ids   A seqan3::fields type with the list and order of fields IDs; only relevant if these
- * can't be deduced.
+ *                              can't be deduced.
  * \tparam valid_formats        A seqan3::type_list of the selectable formats (each must meet
- * seqan3::sequence_file_output_format).
- * \tparam stream_char_type     The type of the underlying stream device(s); must model seqan3::builtin_character.
+ *                              seqan3::sequence_file_output_format).
+ *
  * \details
  *
  * ### Introduction
@@ -168,8 +168,7 @@ namespace seqan3
 
 template <detail::fields_specialisation selected_field_ids_ = fields<field::SEQ, field::ID, field::QUAL>,
           detail::type_list_of_sequence_file_output_formats valid_formats_ =
-              type_list<format_embl, format_fasta, format_fastq, format_genbank, format_sam>,
-          builtin_character stream_char_type_ = char>
+              type_list<format_embl, format_fasta, format_fastq, format_genbank, format_sam>>
 class sequence_file_output
 {
 public:
@@ -181,8 +180,8 @@ public:
     using selected_field_ids    = selected_field_ids_;
     //!\brief A seqan3::type_list with the possible formats.
     using valid_formats         = valid_formats_;
-    //!\brief Character type of the stream(s), usually `char`.
-    using stream_char_type      = stream_char_type_;
+    //!\brief Character type of the stream(s).
+    using stream_char_type      = char;
     //!\}
 
     //!\brief The subset of seqan3::field IDs that are valid for this file.
@@ -291,6 +290,9 @@ public:
      */
     template <output_stream stream_t,
               sequence_file_output_format file_format>
+    //!\cond
+        requires std::same_as<typename std::remove_reference_t<stream_t>::char_type, stream_char_type>
+    //!\endcond
     sequence_file_output(stream_t                 & stream,
                          file_format        const & SEQAN3_DOXYGEN_ONLY(format_tag),
                          selected_field_ids const & SEQAN3_DOXYGEN_ONLY(fields_tag) = selected_field_ids{}) :
@@ -305,6 +307,9 @@ public:
     //!\overload
     template <output_stream stream_t,
               sequence_file_output_format file_format>
+    //!\cond
+        requires std::same_as<typename std::remove_reference_t<stream_t>::char_type, stream_char_type>
+    //!\endcond
     sequence_file_output(stream_t                && stream,
                          file_format        const & SEQAN3_DOXYGEN_ONLY(format_tag),
                          selected_field_ids const & SEQAN3_DOXYGEN_ONLY(fields_tag) = selected_field_ids{}) :
@@ -733,44 +738,40 @@ protected:
  */
 
 //!\brief Deduction guide for given stream and file format.
-template <output_stream                 stream_t,
+template <output_stream stream_t,
           sequence_file_output_format file_format>
 sequence_file_output(stream_t &,
                      file_format const &)
     -> sequence_file_output<typename sequence_file_output<>::selected_field_ids,  // default field ids
-                            type_list<file_format>,
-                            typename std::remove_reference_t<stream_t>::char_type>;
+                            type_list<file_format>>;
 
 //!\overload
-template <output_stream                 stream_t,
+template <output_stream stream_t,
           sequence_file_output_format file_format>
 sequence_file_output(stream_t &&,
                      file_format const &)
     -> sequence_file_output<typename sequence_file_output<>::selected_field_ids,  // default field ids.
-                            type_list<file_format>,
-                            typename std::remove_reference_t<stream_t>::char_type>;
+                            type_list<file_format>>;
 
 //!\brief Deduction guide for given stream, file format and field ids.
-template <output_stream                 stream_t,
+template <output_stream stream_t,
           sequence_file_output_format file_format,
-          detail::fields_specialisation           selected_field_ids>
+          detail::fields_specialisation selected_field_ids>
 sequence_file_output(stream_t &&,
                      file_format const &,
                      selected_field_ids const &)
     -> sequence_file_output<selected_field_ids,
-                            type_list<file_format>,
-                            typename std::remove_reference_t<stream_t>::char_type>;
+                            type_list<file_format>>;
 
 //!\overload
-template <output_stream                 stream_t,
+template <output_stream stream_t,
           sequence_file_output_format file_format,
-          detail::fields_specialisation           selected_field_ids>
+          detail::fields_specialisation selected_field_ids>
 sequence_file_output(stream_t &,
                      file_format const &,
                      selected_field_ids const &)
     -> sequence_file_output<selected_field_ids,
-                            type_list<file_format>,
-                            typename std::remove_reference_t<stream_t>::char_type>;
+                            type_list<file_format>>;
 //!\}
 } // namespace seqan3
 

--- a/include/seqan3/io/sequence_file/output_format_concept.hpp
+++ b/include/seqan3/io/sequence_file/output_format_concept.hpp
@@ -25,11 +25,29 @@
 namespace seqan3::detail
 {
 
+/*!\brief Internal class used to expose the actual format interface to write sequence records into the file.
+ * \ingroup sequence_file
+ *
+ * \tparam format_type The type of the format to be exposed.
+ *
+ * \details
+ *
+ * Exposes the protected member function `write_sequence_record` from the given `format_type`, such that the file can
+ * call the proper function for the selected format.
+ */
 template <typename format_type>
 struct sequence_file_output_format_exposer : public format_type
 {
 public:
-    using format_type::write_sequence_record;
+
+    // Can't use `using format_type::write_sequence_record` as it produces a hard failure in the format concept check
+    // for types that do not model the format concept, i.e. don't offer the proper write_sequence_record interface.
+    //!\brief Forwards to the seqan3::sequence_file_output_format::write_sequence_record interface.
+    template <typename ...ts>
+    void write_sequence_record(ts && ...args)
+    {
+        format_type::write_sequence_record(std::forward<ts>(args)...);
+    }
 };
 
 } // namespace seqan3::detail
@@ -49,7 +67,6 @@ namespace seqan3
  */
 //!\cond
 template <typename t>
-
 SEQAN3_CONCEPT sequence_file_output_format = requires (detail::sequence_file_output_format_exposer<t> & v,
                                                        std::ofstream                                  & f,
                                                        sequence_file_output_options                   & options,

--- a/include/seqan3/io/structure_file/input.hpp
+++ b/include/seqan3/io/structure_file/input.hpp
@@ -351,7 +351,6 @@ struct structure_file_input_default_traits_aa : structure_file_input_default_tra
  *                            must be in seqan3::structure_file_input::field_ids.
  * \tparam valid_formats      A seqan3::type_list of the selectable formats (each must meet
  *                            seqan3::structure_file_input_format).
- * \tparam stream_char_type   The type of the underlying stream device(s); must model seqan3::builtin_character.
  * \details
  *
  * ### Introduction
@@ -464,10 +463,8 @@ struct structure_file_input_default_traits_aa : structure_file_input_default_tra
  * Currently, the only implemented format is seqan3::format_vienna. More formats will follow soon.
  */
 template <structure_file_input_traits traits_type_ = structure_file_input_default_traits_rna,
-         detail::fields_specialisation selected_field_ids_ = fields<field::SEQ, field::ID, field::STRUCTURE>,
-         detail::type_list_of_structure_file_input_formats valid_formats_
-             = type_list<format_vienna>,
-         builtin_character stream_char_type_ = char>
+          detail::fields_specialisation selected_field_ids_ = fields<field::SEQ, field::ID, field::STRUCTURE>,
+          detail::type_list_of_structure_file_input_formats valid_formats_ = type_list<format_vienna>>
 class structure_file_input
 {
 public:
@@ -481,8 +478,8 @@ public:
     using selected_field_ids = selected_field_ids_;
     //!\brief A seqan3::type_list with the possible formats.
     using valid_formats      = valid_formats_;
-    //!\brief Character type of the stream(s), usually `char`.
-    using stream_char_type   = stream_char_type_;
+    //!\brief Character type of the stream(s).
+    using stream_char_type   = char;
     //!\}
 
     /*!\brief The subset of seqan3::field IDs that are valid for this file; order corresponds to the types in
@@ -641,6 +638,9 @@ public:
      * See the section on \link io_compression compression and decompression \endlink for more information.
      */
     template <input_stream stream_t, structure_file_input_format file_format>
+    //!\cond
+        requires std::same_as<typename std::remove_reference_t<stream_t>::char_type, char>
+    //!\endcond
     structure_file_input(stream_t & stream,
                          file_format const & SEQAN3_DOXYGEN_ONLY(format_tag),
                          selected_field_ids const & SEQAN3_DOXYGEN_ONLY(fields_tag) = selected_field_ids{}) :
@@ -656,6 +656,9 @@ public:
 
     //!\overload
     template <input_stream stream_t, structure_file_input_format file_format>
+    //!\cond
+        requires std::same_as<typename std::remove_reference_t<stream_t>::char_type, char>
+    //!\endcond
     structure_file_input(stream_t && stream,
                          file_format const & SEQAN3_DOXYGEN_ONLY(format_tag),
                          selected_field_ids const & SEQAN3_DOXYGEN_ONLY(fields_tag) = selected_field_ids{}) :
@@ -851,24 +854,22 @@ protected:
  */
 
 //!\brief Deduction of the selected fields, the file format and the stream type.
-template <input_stream                 stream_type,
+template <input_stream stream_type,
           structure_file_input_format file_format,
-          detail::fields_specialisation           selected_field_ids>
+          detail::fields_specialisation selected_field_ids>
 structure_file_input(stream_type && stream, file_format const &, selected_field_ids const &)
     -> structure_file_input<typename structure_file_input<>::traits_type,       // actually use the default
                             selected_field_ids,
-                            type_list<file_format>,
-                            typename std::remove_reference_t<stream_type>::char_type>;
+                            type_list<file_format>>;
 
 //!\overload
-template <input_stream                 stream_type,
+template <input_stream stream_type,
           structure_file_input_format file_format,
-          detail::fields_specialisation           selected_field_ids>
+          detail::fields_specialisation selected_field_ids>
 structure_file_input(stream_type & stream, file_format const &, selected_field_ids const &)
     -> structure_file_input<typename structure_file_input<>::traits_type,       // actually use the default
                             selected_field_ids,
-                            type_list<file_format>,
-                            typename std::remove_reference_t<stream_type>::char_type>;
+                            type_list<file_format>>;
 //!\}
 
 } // namespace seqan3

--- a/include/seqan3/io/structure_file/input_format_concept.hpp
+++ b/include/seqan3/io/structure_file/input_format_concept.hpp
@@ -27,11 +27,28 @@
 namespace seqan3::detail
 {
 
+/*!\brief Internal class used to expose the actual format interface to read structure records from the file.
+ * \ingroup structure_file
+ *
+ * \tparam format_type The type of the format to be exposed.
+ *
+ * \details
+ *
+ * Exposes the protected member function `read_structure_record` from the given `format_type`, such that the file can
+ * call the proper function for the selected format.
+ */
 template <typename format_type>
 struct structure_file_input_format_exposer : public format_type
 {
 public:
-    using format_type::read_structure_record;
+    // Can't use `using format_type::read_structure_record` as it produces a hard failure in the format concept check
+    // for types that do not model the format concept, i.e. don't offer the proper read_structure_record interface.
+    //!\brief Forwards to the seqan3::structure_file_input_format::read_structure_record interface.
+    template <typename ...ts>
+    void read_structure_record(ts && ...args)
+    {
+        format_type::read_structure_record(std::forward<ts>(args)...);
+    }
 };
 
 } // namespace seqan3::detail

--- a/include/seqan3/io/structure_file/output.hpp
+++ b/include/seqan3/io/structure_file/output.hpp
@@ -55,7 +55,6 @@ namespace seqan3
  *                            can't be deduced.
  * \tparam valid_formats      A seqan3::type_list of the selectable formats (each must meet
  *                            seqan3::structure_file_output_format).
- * \tparam stream_char_type   The type of the underlying stream device(s); must model seqan3::builtin_character.
  * \details
  *
  * ### Introduction
@@ -164,8 +163,7 @@ namespace seqan3
  */
 
 template <detail::fields_specialisation selected_field_ids_ = fields<field::SEQ, field::ID, field::STRUCTURE>,
-          detail::type_list_of_structure_file_output_formats valid_formats_ = type_list<format_vienna>,
-          builtin_character stream_char_type_ = char>
+          detail::type_list_of_structure_file_output_formats valid_formats_ = type_list<format_vienna>>
 class structure_file_output
 {
 public:
@@ -177,8 +175,8 @@ public:
     using selected_field_ids    = selected_field_ids_;
     //!\brief A seqan3::type_list with the possible formats.
     using valid_formats         = valid_formats_;
-    //!\brief Character type of the stream(s), usually `char`.
-    using stream_char_type      = stream_char_type_;
+    //!\brief Character type of the stream(s).
+    using stream_char_type      = char;
     //!\}
 
     //!\brief The subset of seqan3::field IDs that are valid for this file.
@@ -296,6 +294,9 @@ public:
      * See the section on \link io_compression compression and decompression \endlink for more information.
      */
     template <output_stream stream_t, structure_file_output_format file_format>
+    //!\cond
+        requires std::same_as<typename std::remove_reference_t<stream_t>::char_type, char>
+    //!\endcond
     structure_file_output(stream_t & stream,
                           file_format const & SEQAN3_DOXYGEN_ONLY(format_tag),
                           selected_field_ids const & SEQAN3_DOXYGEN_ONLY(fields_tag) = selected_field_ids{}) :
@@ -309,6 +310,9 @@ public:
 
     //!\overload
     template <output_stream stream_t, structure_file_output_format file_format>
+    //!\cond
+        requires std::same_as<typename std::remove_reference_t<stream_t>::char_type, char>
+    //!\endcond
     structure_file_output(stream_t && stream,
                           file_format const & SEQAN3_DOXYGEN_ONLY(format_tag),
                           selected_field_ids const & SEQAN3_DOXYGEN_ONLY(fields_tag) = selected_field_ids{}) :
@@ -650,22 +654,20 @@ protected:
  */
 
 //!\brief Deduction of the selected fields, the file format and the stream type.
-template <output_stream                  stream_t,
+template <output_stream stream_t,
           structure_file_output_format file_format,
-          detail::fields_specialisation            selected_field_ids>
+          detail::fields_specialisation selected_field_ids>
 structure_file_output(stream_t &&, file_format const &, selected_field_ids const &)
     -> structure_file_output<selected_field_ids,
-                             type_list<file_format>,
-                             typename std::remove_reference_t<stream_t>::char_type>;
+                             type_list<file_format>>;
 
 //!\overload
-template <output_stream                  stream_t,
+template <output_stream stream_t,
           structure_file_output_format file_format,
-          detail::fields_specialisation            selected_field_ids>
+          detail::fields_specialisation selected_field_ids>
 structure_file_output(stream_t &, file_format const &, selected_field_ids const &)
     -> structure_file_output<selected_field_ids,
-                             type_list<file_format>,
-                             typename std::remove_reference_t<stream_t>::char_type>;
+                             type_list<file_format>>;
 //!\}
 
 } // namespace seqan3

--- a/include/seqan3/io/structure_file/output_format_concept.hpp
+++ b/include/seqan3/io/structure_file/output_format_concept.hpp
@@ -25,11 +25,28 @@
 namespace seqan3::detail
 {
 
+/*!\brief Internal class used to expose the actual format interface to write structure records into the file.
+ * \ingroup structure_file
+ *
+ * \tparam format_type The type of the format to be exposed.
+ *
+ * \details
+ *
+ * Exposes the protected member function `write_structure_record` from the given `format_type`, such that the file can
+ * call the proper function for the selected format.
+ */
 template <typename format_type>
 struct structure_file_output_format_exposer : public format_type
 {
 public:
-    using format_type::write_structure_record;
+    // Can't use `using format_type::write_structure_record` as it produces a hard failure in the format concept check
+    // for types that do not model the format concept, i.e. don't offer the proper write_structure_record interface.
+    //!\brief Forwards to the seqan3::structure_file_output_format::write_structure_record interface.
+    template <typename ...ts>
+    void write_structure_record(ts && ...args)
+    {
+        format_type::write_structure_record(std::forward<ts>(args)...);
+    }
 };
 
 } // namespace seqan3::detail

--- a/test/snippet/io/alignment_file/alignment_file_input_construction_without_automatic_type_deduction.cpp
+++ b/test/snippet/io/alignment_file/alignment_file_input_construction_without_automatic_type_deduction.cpp
@@ -29,8 +29,7 @@ int main()
     using alignment_file_input_t = seqan3::alignment_file_input<seqan3::alignment_file_input_default_traits<>,
                                                                 default_fields,
                                                                 // Which formats are allowed:
-                                                                seqan3::type_list<seqan3::format_sam>,
-                                                                char>; // Value type of the stream.
+                                                                seqan3::type_list<seqan3::format_sam>>;
 
     alignment_file_input_t fin{std::istringstream{input}, seqan3::format_sam{}};
 }

--- a/test/snippet/io/sequence_file/sequence_file_input_template_specification.cpp
+++ b/test/snippet/io/sequence_file/sequence_file_input_template_specification.cpp
@@ -17,6 +17,6 @@ int main()
                                                                  seqan3::fields<seqan3::field::SEQ,
                                                                                 seqan3::field::ID,
                                                                                 seqan3::field::QUAL>,
-                                                                 seqan3::type_list<seqan3::format_fasta>, char>;
+                                                                 seqan3::type_list<seqan3::format_fasta>>;
     sequence_file_input_type fin{std::istringstream{input}, seqan3::format_fasta{}};
 }

--- a/test/snippet/io/structure_file/structure_file_input_trait_def.cpp
+++ b/test/snippet/io/structure_file/structure_file_input_trait_def.cpp
@@ -15,6 +15,6 @@ int main()
     // ... input had amino acid sequences
     seqan3::structure_file_input<seqan3::structure_file_input_default_traits_aa,
                                  seqan3::fields<seqan3::field::SEQ, seqan3::field::ID, seqan3::field::STRUCTURE>,
-                                 seqan3::type_list<seqan3::format_vienna>,
-                                 char> fin{std::istringstream{input}, seqan3::format_vienna{}};
+                                 seqan3::type_list<seqan3::format_vienna>> fin{std::istringstream{input},
+                                                                               seqan3::format_vienna{}};
 }

--- a/test/unit/io/alignment_file/alignment_file_input_test.cpp
+++ b/test/unit/io/alignment_file/alignment_file_input_test.cpp
@@ -116,8 +116,7 @@ TEST_F(alignment_file_input_f, construct_by_filename)
 
         EXPECT_NO_THROW(( alignment_file_input<alignment_file_input_default_traits<>,
                                                fields<field::SEQ>,
-                                               type_list<format_sam>,
-                                               char>{filename.get_path(), fields<field::SEQ>{}} ));
+                                               type_list<format_sam>>{filename.get_path(), fields<field::SEQ>{}} ));
     }
 }
 
@@ -126,18 +125,16 @@ TEST_F(alignment_file_input_f, construct_from_stream)
     /* stream + format_tag */
     EXPECT_NO_THROW(( alignment_file_input<alignment_file_input_default_traits<>,
                                            fields<field::SEQ, field::ID, field::QUAL>,
-                                           type_list<format_sam>,
-                                           char>{std::istringstream{input},
-                                                 format_sam{}} ));
+                                           type_list<format_sam>>{std::istringstream{input},
+                                                                  format_sam{}} ));
 
 
     /* stream + format_tag + fields */
     EXPECT_NO_THROW(( alignment_file_input<alignment_file_input_default_traits<>,
                                            fields<field::SEQ, field::ID, field::QUAL>,
-                                           type_list<format_sam>,
-                                           char>{std::istringstream{input},
-                                                 format_sam{},
-                                                 fields<field::SEQ, field::ID, field::QUAL>{}} ));
+                                           type_list<format_sam>>{std::istringstream{input},
+                                                                  format_sam{},
+                                                                  fields<field::SEQ, field::ID, field::QUAL>{}} ));
 }
 
 TEST_F(alignment_file_input_f, default_template_args_and_deduction_guides)
@@ -214,31 +211,6 @@ TEST_F(alignment_file_input_f, default_template_args_and_deduction_guides)
         EXPECT_TRUE((std::is_same_v<typename t::selected_field_ids, comp1>));
         EXPECT_TRUE((std::is_same_v<typename t::valid_formats,      type_list<format_sam>>));
         EXPECT_TRUE((std::is_same_v<typename t::stream_char_type,   comp3>));
-    }
-
-    /* guided stream constructor + custom fields + different stream char type */
-    {
-        auto winput = input | views::convert<wchar_t> | views::to<std::wstring>;
-        std::wistringstream ext{winput};
-        alignment_file_input fin{ext, format_sam{}, fields<field::SEQ>{}};
-
-        using t = decltype(fin);
-        EXPECT_TRUE((std::is_same_v<typename t::traits_type,        comp0>));
-        EXPECT_TRUE((std::is_same_v<typename t::selected_field_ids, fields<field::SEQ>>));
-        EXPECT_TRUE((std::is_same_v<typename t::valid_formats,      type_list<format_sam>>));
-        EXPECT_TRUE((std::is_same_v<typename t::stream_char_type,   wchar_t>));
-    }
-
-    /* guided stream temporary constructor + custom fields + different stream char type */
-    {
-        auto winput = input | views::convert<wchar_t> | views::to<std::wstring>;
-        alignment_file_input fin{std::wistringstream{winput}, format_sam{}, fields<field::SEQ>{}};
-
-        using t = decltype(fin);
-        EXPECT_TRUE((std::is_same_v<typename t::traits_type,        comp0>));
-        EXPECT_TRUE((std::is_same_v<typename t::selected_field_ids, fields<field::SEQ>>));
-        EXPECT_TRUE((std::is_same_v<typename t::valid_formats,      type_list<format_sam>>));
-        EXPECT_TRUE((std::is_same_v<typename t::stream_char_type,   wchar_t>));
     }
 }
 

--- a/test/unit/io/alignment_file/alignment_file_output_test.cpp
+++ b/test/unit/io/alignment_file/alignment_file_output_test.cpp
@@ -90,8 +90,7 @@ TEST(general, construct_by_filename)
     {
         test::tmp_filename filename{"alignment_file_output_constructor.sam"};
         EXPECT_NO_THROW(( alignment_file_output<fields<field::SEQ>,
-                                                type_list<format_sam>,
-                                                char>{filename.get_path(), fields<field::SEQ>{}} ));
+                                                type_list<format_sam>>{filename.get_path(), fields<field::SEQ>{}} ));
     }
 }
 
@@ -99,16 +98,14 @@ TEST(general, construct_from_stream)
 {
     /* stream + format_tag */
     EXPECT_NO_THROW(( alignment_file_output<fields<field::SEQ, field::ID, field::QUAL>,
-                                            type_list<format_sam>,
-                                            char>{std::ostringstream{}, format_sam{}} ));
+                                            type_list<format_sam>>{std::ostringstream{}, format_sam{}} ));
 
 
     /* stream + format_tag + fields */
     EXPECT_NO_THROW(( alignment_file_output<fields<field::SEQ, field::ID, field::QUAL>,
-                                            type_list<format_sam>,
-                                            char>{std::ostringstream{},
-                                                  format_sam{},
-                                                  fields<field::SEQ, field::ID, field::QUAL>{}} ));
+                                            type_list<format_sam>>{std::ostringstream{},
+                                                                   format_sam{},
+                                                                   fields<field::SEQ, field::ID, field::QUAL>{}} ));
 }
 
 TEST(general, default_template_args_and_deduction_guides)
@@ -182,27 +179,6 @@ TEST(general, default_template_args_and_deduction_guides)
         EXPECT_TRUE((std::is_same_v<typename t::selected_field_ids, comp1>));
         EXPECT_TRUE((std::is_same_v<typename t::valid_formats,      type_list<format_sam>>)); // changed
         EXPECT_TRUE((std::is_same_v<typename t::stream_char_type,   comp3>));
-    }
-
-    /* guided stream constructor + custom fields + different stream_char_type */
-    {
-        std::wostringstream ext{};
-        alignment_file_output fout{ext, format_sam{}, fields<field::SEQ>{}};
-
-        using t = decltype(fout);
-        EXPECT_TRUE((std::is_same_v<typename t::selected_field_ids, fields<field::SEQ>>));                   // changed
-        EXPECT_TRUE((std::is_same_v<typename t::valid_formats,      type_list<format_sam>>)); // changed
-        EXPECT_TRUE((std::is_same_v<typename t::stream_char_type,   wchar_t>));                              // changed
-    }
-
-    /* guided stream temporary constructor + custom fields + different stream_char_type */
-    {
-        alignment_file_output fout{std::wostringstream{}, format_sam{}, fields<field::REF_ID>{}};
-
-        using t = decltype(fout);
-        EXPECT_TRUE((std::is_same_v<typename t::selected_field_ids, fields<field::REF_ID>>));                // changed
-        EXPECT_TRUE((std::is_same_v<typename t::valid_formats,      type_list<format_sam>>)); // changed
-        EXPECT_TRUE((std::is_same_v<typename t::stream_char_type,   wchar_t>));                              // changed
     }
 }
 
@@ -578,7 +554,6 @@ std::string compression_by_filename_impl(test::tmp_filename & filename)
         // explicitly only test compression on sam format
         alignment_file_output<typename alignment_file_output<>::selected_field_ids,
                              type_list<format_sam>,
-                             typename alignment_file_output<>::stream_char_type,
                              ref_info_not_given> fout{filename.get_path()};
 
         for (size_t i = 0; i < 3; ++i)

--- a/test/unit/io/sequence_file/sequence_file_input_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_input_test.cpp
@@ -103,8 +103,7 @@ TEST_F(sequence_file_input_f, construct_by_filename)
 
         EXPECT_NO_THROW(( sequence_file_input<sequence_file_input_default_traits_dna,
                                              fields<field::SEQ>,
-                                             type_list<format_fasta>,
-                                             char>{filename.get_path(), fields<field::SEQ>{}} ));
+                                             type_list<format_fasta>>{filename.get_path(), fields<field::SEQ>{}} ));
     }
 }
 
@@ -113,18 +112,16 @@ TEST_F(sequence_file_input_f, construct_from_stream)
     /* stream + format_tag */
     EXPECT_NO_THROW(( sequence_file_input<sequence_file_input_default_traits_dna,
                                          fields<field::SEQ, field::ID, field::QUAL>,
-                                         type_list<format_fasta>,
-                                         char>{std::istringstream{input},
-                                               format_fasta{}} ));
+                                         type_list<format_fasta>>{std::istringstream{input},
+                                                                  format_fasta{}} ));
 
 
     /* stream + format_tag + fields */
     EXPECT_NO_THROW(( sequence_file_input<sequence_file_input_default_traits_dna,
                                           fields<field::SEQ, field::ID, field::QUAL>,
-                                          type_list<format_fasta>,
-                                          char>{std::istringstream{input},
-                                                format_fasta{},
-                                                fields<field::SEQ, field::ID, field::QUAL>{}} ));
+                                          type_list<format_fasta>>{std::istringstream{input},
+                                                                   format_fasta{},
+                                                                   fields<field::SEQ, field::ID, field::QUAL>{}} ));
 }
 
 TEST_F(sequence_file_input_f, default_template_args_and_deduction_guides)
@@ -198,31 +195,6 @@ TEST_F(sequence_file_input_f, default_template_args_and_deduction_guides)
         EXPECT_TRUE((std::is_same_v<typename t::selected_field_ids, comp1>));
         EXPECT_TRUE((std::is_same_v<typename t::valid_formats,      type_list<format_fasta>>));// changed
         EXPECT_TRUE((std::is_same_v<typename t::stream_char_type,   comp3>));
-    }
-
-    /* guided stream constructor + custom fields + different stream char type */
-    {
-        auto winput = input | views::convert<wchar_t> | views::to<std::wstring>;
-        std::wistringstream ext{winput};
-        sequence_file_input fin{ext, format_fasta{}, fields<field::SEQ>{}};
-
-        using t = decltype(fin);
-        EXPECT_TRUE((std::is_same_v<typename t::traits_type,        comp0>));
-        EXPECT_TRUE((std::is_same_v<typename t::selected_field_ids, fields<field::SEQ>>));                   // changed
-        EXPECT_TRUE((std::is_same_v<typename t::valid_formats,      type_list<format_fasta>>));              // changed
-        EXPECT_TRUE((std::is_same_v<typename t::stream_char_type,   wchar_t>));                              // changed
-    }
-
-    /* guided stream temporary constructor + custom fields + different stream char type */
-    {
-        auto winput = input | views::convert<wchar_t> | views::to<std::wstring>;
-        sequence_file_input fin{std::wistringstream{winput}, format_fasta{}, fields<field::SEQ>{}};
-
-        using t = decltype(fin);
-        EXPECT_TRUE((std::is_same_v<typename t::traits_type,        comp0>));
-        EXPECT_TRUE((std::is_same_v<typename t::selected_field_ids, fields<field::SEQ>>));                   // changed
-        EXPECT_TRUE((std::is_same_v<typename t::valid_formats,      type_list<format_fasta>>));              // changed
-        EXPECT_TRUE((std::is_same_v<typename t::stream_char_type,   wchar_t>));                              // changed
     }
 }
 

--- a/test/unit/io/sequence_file/sequence_file_output_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_output_test.cpp
@@ -177,27 +177,6 @@ TEST(general, default_template_args_and_deduction_guides)
         EXPECT_TRUE((std::is_same_v<typename t::valid_formats,      type_list<format_fasta>>));// changed
         EXPECT_TRUE((std::is_same_v<typename t::stream_char_type,   comp3>));
     }
-
-    /* guided stream constructor + custom fields + different stream_char_type */
-    {
-        std::wostringstream ext{};
-        sequence_file_output fout{ext, format_fasta{}, fields<field::SEQ>{}};
-
-        using t = decltype(fout);
-        EXPECT_TRUE((std::is_same_v<typename t::selected_field_ids, fields<field::SEQ>>));                   // changed
-        EXPECT_TRUE((std::is_same_v<typename t::valid_formats,      type_list<format_fasta>>));              // changed
-        EXPECT_TRUE((std::is_same_v<typename t::stream_char_type,   wchar_t>));                              // changed
-    }
-
-    /* guided stream temporary constructor + custom fields + different stream_char_type */
-    {
-        sequence_file_output fout{std::wostringstream{}, format_fasta{}, fields<field::SEQ>{}};
-
-        using t = decltype(fout);
-        EXPECT_TRUE((std::is_same_v<typename t::selected_field_ids, fields<field::SEQ>>));                   // changed
-        EXPECT_TRUE((std::is_same_v<typename t::valid_formats,      type_list<format_fasta>>));              // changed
-        EXPECT_TRUE((std::is_same_v<typename t::stream_char_type,   wchar_t>));                              // changed
-    }
 }
 
 // ----------------------------------------------------------------------------

--- a/test/unit/io/structure_file/structure_file_input_test.cpp
+++ b/test/unit/io/structure_file/structure_file_input_test.cpp
@@ -93,8 +93,7 @@ TEST_F(structure_file_input_class, construct_by_filename)
         test::tmp_filename filename = create_file("> ID\nACGU\n....\n");
         EXPECT_NO_THROW((structure_file_input<structure_file_input_default_traits_rna,
                                               fields<field::SEQ>,
-                                              type_list<format_vienna>,
-                                              char>{filename.get_path(), fields<field::SEQ>{}}));
+                                              type_list<format_vienna>>{filename.get_path(), fields<field::SEQ>{}}));
     }
 }
 
@@ -103,18 +102,16 @@ TEST_F(structure_file_input_class, construct_from_stream)
     /* stream + format_tag */
     EXPECT_NO_THROW((structure_file_input<structure_file_input_default_traits_rna,
                                           fields<field::SEQ, field::ID, field::STRUCTURE>,
-                                          type_list<format_vienna>,
-                                          char>{std::istringstream{"> ID\nACGU\n....\n"},
-                                                format_vienna{}}));
+                                          type_list<format_vienna>>{std::istringstream{"> ID\nACGU\n....\n"},
+                                                                    format_vienna{}}));
 
 
     /* stream + format_tag + fields */
     EXPECT_NO_THROW((structure_file_input<structure_file_input_default_traits_rna,
                                           fields<field::SEQ, field::ID, field::STRUCTURE>,
-                                          type_list<format_vienna>,
-                                          char>{std::istringstream{"> ID\nACGU\n....\n"},
-                                                format_vienna{},
-                                                fields<field::SEQ, field::ID, field::STRUCTURE>{}}));
+                                          type_list<format_vienna>>{std::istringstream{"> ID\nACGU\n....\n"},
+                                                                    format_vienna{},
+                                                                    fields<field::SEQ, field::ID, field::STRUCTURE>{}}));
 }
 
 TEST_F(structure_file_input_class, default_template_args)
@@ -163,22 +160,6 @@ TEST_F(structure_file_input_class, guided_stream_constructor)
     EXPECT_TRUE((std::is_same_v<typename t::selected_field_ids, comp1>));
     EXPECT_TRUE((std::is_same_v<typename t::valid_formats,      type_list<format_vienna>>));
     EXPECT_TRUE((std::is_same_v<typename t::stream_char_type,   comp3>));
-}
-
-TEST_F(structure_file_input_class, guided_stream_constructor_and_custom_fields)
-{
-    /* guided stream constructor + custom fields */
-    structure_file_input fin{std::wistringstream{"> ID\nACGU\n....\n"
-                                                 | views::convert<wchar_t>
-                                                 | views::to<std::wstring>},
-                             format_vienna{},
-                             fields<field::SEQ>{}};
-
-    using t = decltype(fin);
-    EXPECT_TRUE((std::is_same_v<typename t::traits_type,        comp0>));
-    EXPECT_TRUE((std::is_same_v<typename t::selected_field_ids, fields<field::SEQ>>));
-    EXPECT_TRUE((std::is_same_v<typename t::valid_formats,      type_list<format_vienna>>));
-    EXPECT_TRUE((std::is_same_v<typename t::stream_char_type,   wchar_t>));
 }
 
 TEST_F(structure_file_input_class, amino_acids_traits)

--- a/test/unit/io/structure_file/structure_file_output_test.cpp
+++ b/test/unit/io/structure_file/structure_file_output_test.cpp
@@ -149,27 +149,6 @@ TEST(structure_file_output_class, default_template_args_and_deduction_guides)
         EXPECT_TRUE((std::is_same_v<typename t::valid_formats,      type_list<format_vienna>>));
         EXPECT_TRUE((std::is_same_v<typename t::stream_char_type,   comp3>));
     }
-
-    /* guided stream constructor + custom fields + different stream_char_type */
-    {
-        std::wostringstream ext{};
-        structure_file_output fout{ext, format_vienna{}, fields<field::SEQ>{}};
-
-        using t = decltype(fout);
-        EXPECT_TRUE((std::is_same_v<typename t::selected_field_ids, fields<field::SEQ>>));
-        EXPECT_TRUE((std::is_same_v<typename t::valid_formats,      type_list<format_vienna>>));
-        EXPECT_TRUE((std::is_same_v<typename t::stream_char_type,   wchar_t>));
-    }
-
-    /* guided stream temporary constructor + custom fields + different stream_char_type */
-    {
-        structure_file_output fout{std::wostringstream{}, format_vienna{}, fields<field::SEQ>{}};
-
-        using t = decltype(fout);
-        EXPECT_TRUE((std::is_same_v<typename t::selected_field_ids, fields<field::SEQ>>));
-        EXPECT_TRUE((std::is_same_v<typename t::valid_formats,      type_list<format_vienna>>));
-        EXPECT_TRUE((std::is_same_v<typename t::stream_char_type,   wchar_t>));
-    }
 }
 
 struct structure_file_output_write : public ::testing::Test


### PR DESCRIPTION
Fixes #1399 

Removes the char type from the files.

It also fixes the file exposer which caused hard fails in the format concept checks due to the using statement to import the read/write interfaces for the different file formats. The problem here is that for types that are not formats the using declaration causes compiler errors, which are different from not finding an viable overload. This was first visible when the char type was removed. Also I am not quite sure why?
Strangely, the exposer were not documented nor excluded from documentation but doxygen didn't trigger a warning. Not sure why? But I added the documentation for them as well.

A changelog will be added soon as well.
I also need to check at which places the documentation explicitly refers to the char type. There were three snippets that used it.