### PR TITLE
[MISC] Do not use x86 intrinsics if not available.

### DIFF
--- a/include/seqan3/core/platform.hpp
+++ b/include/seqan3/core/platform.hpp
@@ -186,18 +186,6 @@
 #endif
 
 // ============================================================================
-//  Architectures
-// ============================================================================
-
-// Warn if NO_WARN_X86_INTRINSICS is not set on PowerPC. See https://github.com/seqan/seqan3/pull/1157.
-#if defined(__powerpc64__)
-#   ifndef NO_WARN_X86_INTRINSICS
-#      pragma GCC warning "To use SeqAn3 on PowerPC, you may need to set -DNO_WARN_X86_INTRINSICS. \
-                           Please note that SeqAn3 is not yet optimised for PowerPC."
-#   endif
-#endif
-
-// ============================================================================
 //  Workarounds
 // ============================================================================
 

--- a/include/seqan3/core/simd/detail/builtin_simd_intrinsics.hpp
+++ b/include/seqan3/core/simd/detail/builtin_simd_intrinsics.hpp
@@ -1,0 +1,29 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides intrinsics include for builtin simd.
+ * \author Marcel Ehrhardt <marcel.ehrhardt AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <seqan3/core/platform.hpp>
+
+#if __has_include(<x86intrin.h>)
+#include <x86intrin.h> // x86 intrinsics (linux)
+#endif
+
+#if __has_include(<intrin.h>)
+#include <intrin.h> // x86 intrinsics (windows)
+#endif
+
+// MSVC doesn't define SSE4 macros, even if the instruction set is available (e.g. when AVX is defined)
+#if defined(_MSC_VER) && defined(__AVX__) && !defined(__SSE4_1__) && !defined(__SSE4_2__)
+#define __SSE4_1__ 1
+#define __SSE4_2__ 1
+#endif

--- a/include/seqan3/core/simd/detail/simd_algorithm_avx2.hpp
+++ b/include/seqan3/core/simd/detail/simd_algorithm_avx2.hpp
@@ -1,0 +1,156 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides specific algorithm implementations for AVX2 instruction set.
+ * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <seqan3/core/simd/concept.hpp>
+#include <seqan3/core/simd/detail/builtin_simd_intrinsics.hpp>
+#include <seqan3/core/simd/simd_traits.hpp>
+
+//-----------------------------------------------------------------------------
+// forward declare avx2 simd algorithms that use avx2 intrinsics
+//-----------------------------------------------------------------------------
+
+namespace seqan3::detail
+{
+/*!\copydoc seqan3::simd::load
+ * \attention This is the implementation for AVX2 intrinsics.
+ */
+template <simd::simd_concept simd_t>
+constexpr simd_t load_avx2(void const * mem_addr);
+
+/*!\copydoc seqan3::simd::transpose
+ * \attention This is the implementation for AVX2 intrinsics.
+ */
+template <simd::simd_concept simd_t>
+inline void transpose_matrix_avx2(std::array<simd_t, simd_traits<simd_t>::length> & matrix);
+
+/*!\copydoc seqan3::detail::upcast_signed
+ * \attention This is the implementation for AVX2 intrinsics.
+ */
+template <simd::simd_concept target_simd_t, simd::simd_concept source_simd_t>
+constexpr target_simd_t upcast_signed_avx2(source_simd_t const & src);
+
+/*!\copydoc seqan3::detail::upcast_unsigned
+ * \attention This is the implementation for AVX2 intrinsics.
+ */
+template <simd::simd_concept target_simd_t, simd::simd_concept source_simd_t>
+constexpr target_simd_t upcast_unsigned_avx2(source_simd_t const & src);
+
+/*!\copydoc seqan3::detail::extract_halve
+ * \attention This is the implementation for AVX2 intrinsics.
+ */
+template <uint8_t index, simd::simd_concept simd_t>
+constexpr simd_t extract_halve_avx2(simd_t const & src);
+
+/*!\copydoc seqan3::detail::extract_quarter
+ * \attention This is the implementation for AVX2 intrinsics.
+ */
+template <uint8_t index, simd::simd_concept simd_t>
+constexpr simd_t extract_quarter_avx2(simd_t const & src);
+
+/*!\copydoc seqan3::detail::extract_eighth
+ * \attention This is the implementation for AVX2 intrinsics.
+ */
+template <uint8_t index, simd::simd_concept simd_t>
+constexpr simd_t extract_eighth_avx2(simd_t const & src);
+
+}
+
+//-----------------------------------------------------------------------------
+// implementation
+//-----------------------------------------------------------------------------
+
+#ifdef __AVX2__
+
+namespace seqan3::detail
+{
+
+template <simd::simd_concept simd_t>
+constexpr simd_t load_avx2(void const * mem_addr)
+{
+    return reinterpret_cast<simd_t>(_mm256_loadu_si256(reinterpret_cast<__m256i const *>(mem_addr)));
+}
+
+// TODO: not implemented and used yet, if you implement it don't forget to add it to seqan3::simd::transpose
+template <simd::simd_concept simd_t>
+inline void transpose_matrix_avx2(std::array<simd_t, simd_traits<simd_t>::length> & matrix);
+
+template <simd::simd_concept target_simd_t, simd::simd_concept source_simd_t>
+constexpr target_simd_t upcast_signed_avx2(source_simd_t const & src)
+{
+    __m128i const & tmp = _mm256_castsi256_si128(reinterpret_cast<__m256i const &>(src));
+    if constexpr (simd_traits<source_simd_t>::length == 32) // cast from epi8 ...
+    {
+        if constexpr (simd_traits<target_simd_t>::length == 16) // to epi16
+            return reinterpret_cast<target_simd_t>(_mm256_cvtepi8_epi16(tmp));
+        if constexpr (simd_traits<target_simd_t>::length == 8) // to epi32
+            return reinterpret_cast<target_simd_t>(_mm256_cvtepi8_epi32(tmp));
+        if constexpr (simd_traits<target_simd_t>::length == 4) // to epi64
+            return reinterpret_cast<target_simd_t>(_mm256_cvtepi8_epi64(tmp));
+    }
+    else if constexpr (simd_traits<source_simd_t>::length == 16) // cast from epi16 ...
+    {
+        if constexpr (simd_traits<target_simd_t>::length == 8) // to epi32
+            return reinterpret_cast<target_simd_t>(_mm256_cvtepi16_epi32(tmp));
+        if constexpr (simd_traits<target_simd_t>::length == 4) // to epi64
+            return reinterpret_cast<target_simd_t>(_mm256_cvtepi16_epi64(tmp));
+    }
+    else // cast from epi32 to epi64
+    {
+        static_assert(simd_traits<source_simd_t>::length == 8, "Expected 32 bit scalar type.");
+        return reinterpret_cast<target_simd_t>(_mm256_cvtepi32_epi64(tmp));
+    }
+}
+
+template <simd::simd_concept target_simd_t, simd::simd_concept source_simd_t>
+constexpr target_simd_t upcast_unsigned_avx2(source_simd_t const & src)
+{
+    __m128i const & tmp = _mm256_castsi256_si128(reinterpret_cast<__m256i const &>(src));
+    if constexpr (simd_traits<source_simd_t>::length == 32) // cast from epi8 ...
+    {
+        if constexpr (simd_traits<target_simd_t>::length == 16) // to epi16
+            return reinterpret_cast<target_simd_t>(_mm256_cvtepu8_epi16(tmp));
+        if constexpr (simd_traits<target_simd_t>::length == 8) // to epi32
+            return reinterpret_cast<target_simd_t>(_mm256_cvtepu8_epi32(tmp));
+        if constexpr (simd_traits<target_simd_t>::length == 4) // to epi64
+            return reinterpret_cast<target_simd_t>(_mm256_cvtepu8_epi64(tmp));
+    }
+    else if constexpr (simd_traits<source_simd_t>::length == 16) // cast from epi16 ...
+    {
+        if constexpr (simd_traits<target_simd_t>::length == 8) // to epi32
+            return reinterpret_cast<target_simd_t>(_mm256_cvtepu16_epi32(tmp));
+        if constexpr (simd_traits<target_simd_t>::length == 4) // to epi64
+            return reinterpret_cast<target_simd_t>(_mm256_cvtepu16_epi64(tmp));
+    }
+    else // cast from epi32 to epi64
+    {
+        static_assert(simd_traits<source_simd_t>::length == 8, "Expected 32 bit scalar type.");
+        return reinterpret_cast<target_simd_t>(_mm256_cvtepu32_epi64(tmp));
+    }
+}
+
+// TODO: not implemented and used yet, if you implement it don't forget to add it to seqan3::detail::extract_halve
+template <uint8_t index, simd::simd_concept simd_t>
+constexpr simd_t extract_halve_avx2(simd_t const & src);
+
+// TODO: not implemented and used yet, if you implement it don't forget to add it to seqan3::detail::extract_quarter
+template <uint8_t index, simd::simd_concept simd_t>
+constexpr simd_t extract_quarter_avx2(simd_t const & src);
+
+// TODO: not implemented and used yet, if you implement it don't forget to add it to seqan3::detail::extract_eighth
+template <uint8_t index, simd::simd_concept simd_t>
+constexpr simd_t extract_eighth_avx2(simd_t const & src);
+
+} // namespace seqan3::detail
+
+#endif // __AVX2__

--- a/include/seqan3/core/simd/detail/simd_algorithm_avx512.hpp
+++ b/include/seqan3/core/simd/detail/simd_algorithm_avx512.hpp
@@ -1,0 +1,156 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides specific algorithm implementations for AVX512 instruction set.
+ * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <seqan3/core/simd/concept.hpp>
+#include <seqan3/core/simd/detail/builtin_simd_intrinsics.hpp>
+#include <seqan3/core/simd/simd_traits.hpp>
+
+//-----------------------------------------------------------------------------
+// forward declare avx512 simd algorithms that use avx512 intrinsics
+//-----------------------------------------------------------------------------
+
+namespace seqan3::detail
+{
+/*!\copydoc seqan3::simd::load
+ * \attention This is the implementation for AVX512 intrinsics.
+ */
+template <simd::simd_concept simd_t>
+constexpr simd_t load_avx512(void const * mem_addr);
+
+/*!\copydoc seqan3::simd::transpose
+ * \attention This is the implementation for AVX512 intrinsics.
+ */
+template <simd::simd_concept simd_t>
+inline void transpose_matrix_avx512(std::array<simd_t, simd_traits<simd_t>::length> & matrix);
+
+/*!\copydoc seqan3::detail::upcast_signed
+ * \attention This is the implementation for AVX512 intrinsics.
+ */
+template <simd::simd_concept target_simd_t, simd::simd_concept source_simd_t>
+constexpr target_simd_t upcast_signed_avx512(source_simd_t const & src);
+
+/*!\copydoc seqan3::detail::upcast_unsigned
+ * \attention This is the implementation for AVX512 intrinsics.
+ */
+template <simd::simd_concept target_simd_t, simd::simd_concept source_simd_t>
+constexpr target_simd_t upcast_unsigned_avx512(source_simd_t const & src);
+
+/*!\copydoc seqan3::detail::extract_halve
+ * \attention This is the implementation for AVX512 intrinsics.
+ */
+template <uint8_t index, simd::simd_concept simd_t>
+constexpr simd_t extract_halve_avx512(simd_t const & src);
+
+/*!\copydoc seqan3::detail::extract_quarter
+ * \attention This is the implementation for AVX512 intrinsics.
+ */
+template <uint8_t index, simd::simd_concept simd_t>
+constexpr simd_t extract_quarter_avx512(simd_t const & src);
+
+/*!\copydoc seqan3::detail::extract_eighth
+ * \attention This is the implementation for AVX512 intrinsics.
+ */
+template <uint8_t index, simd::simd_concept simd_t>
+constexpr simd_t extract_eighth_avx512(simd_t const & src);
+
+}
+
+//-----------------------------------------------------------------------------
+// implementation
+//-----------------------------------------------------------------------------
+
+#ifdef __AVX512F__
+
+namespace seqan3::detail
+{
+
+template <simd::simd_concept simd_t>
+constexpr simd_t load_avx512(void const * mem_addr)
+{
+    return reinterpret_cast<simd_t>(_mm512_loadu_si512(mem_addr));
+}
+
+// TODO: not implemented and used yet, if you implement it don't forget to add it to seqan3::simd::transpose
+template <simd::simd_concept simd_t>
+inline void transpose_matrix_avx512(std::array<simd_t, simd_traits<simd_t>::length> & matrix);
+
+template <simd::simd_concept target_simd_t, simd::simd_concept source_simd_t>
+constexpr target_simd_t upcast_signed_avx512(source_simd_t const & src)
+{
+    __m512i const & tmp = reinterpret_cast<__m512i const &>(src);
+    if constexpr (simd_traits<source_simd_t>::length == 64) // cast from epi8 ...
+    {
+        if constexpr (simd_traits<target_simd_t>::length == 32) // to epi16
+            return reinterpret_cast<target_simd_t>(_mm512_cvtepi8_epi16(_mm512_castsi512_si256(tmp)));
+        if constexpr (simd_traits<target_simd_t>::length == 16) // to epi32
+            return reinterpret_cast<target_simd_t>(_mm512_cvtepi8_epi32(_mm512_castsi512_si128(tmp)));
+        if constexpr (simd_traits<target_simd_t>::length == 8) // to epi64
+            return reinterpret_cast<target_simd_t>(_mm512_cvtepi8_epi64(_mm512_castsi512_si128(tmp)));
+    }
+    else if constexpr (simd_traits<source_simd_t>::length == 32) // cast from epi16 ...
+    {
+        if constexpr (simd_traits<target_simd_t>::length == 16) // to epi32
+            return reinterpret_cast<target_simd_t>(_mm512_cvtepi16_epi32(_mm512_castsi512_si256(tmp)));
+        if constexpr (simd_traits<target_simd_t>::length == 8) // to epi64
+            return reinterpret_cast<target_simd_t>(_mm512_cvtepi16_epi64(_mm512_castsi512_si128(tmp)));
+    }
+    else // cast from epi32 to epi64
+    {
+        static_assert(simd_traits<source_simd_t>::length == 16, "Expected 32 bit scalar type.");
+        return reinterpret_cast<target_simd_t>(_mm512_cvtepi32_epi64(_mm512_castsi512_si256(tmp)));
+    }
+}
+
+template <simd::simd_concept target_simd_t, simd::simd_concept source_simd_t>
+constexpr target_simd_t upcast_unsigned_avx512(source_simd_t const & src)
+{
+    __m512i const & tmp = reinterpret_cast<__m512i const &>(src);
+    if constexpr (simd_traits<source_simd_t>::length == 64) // cast from epi8 ...
+    {
+        if constexpr (simd_traits<target_simd_t>::length == 32) // to epi16
+            return reinterpret_cast<target_simd_t>(_mm512_cvtepu8_epi16(_mm512_castsi512_si256(tmp)));
+        if constexpr (simd_traits<target_simd_t>::length == 16) // to epi32
+            return reinterpret_cast<target_simd_t>(_mm512_cvtepu8_epi32(_mm512_castsi512_si128(tmp)));
+        if constexpr (simd_traits<target_simd_t>::length == 8) // to epi64
+            return reinterpret_cast<target_simd_t>(_mm512_cvtepu8_epi64(_mm512_castsi512_si128(tmp)));
+    }
+    else if constexpr (simd_traits<source_simd_t>::length == 32) // cast from epi16 ...
+    {
+        if constexpr (simd_traits<target_simd_t>::length == 16) // to epi32
+            return reinterpret_cast<target_simd_t>(_mm512_cvtepu16_epi32(_mm512_castsi512_si256(tmp)));
+        if constexpr (simd_traits<target_simd_t>::length == 8) // to epi64
+            return reinterpret_cast<target_simd_t>(_mm512_cvtepu16_epi64(_mm512_castsi512_si128(tmp)));
+    }
+    else // cast from epi32 to epi64
+    {
+        static_assert(simd_traits<source_simd_t>::length == 16, "Expected 32 bit scalar type.");
+        return reinterpret_cast<target_simd_t>(_mm512_cvtepu32_epi64(_mm512_castsi512_si256(tmp)));
+    }
+}
+
+// TODO: not implemented and used yet, if you implement it don't forget to add it to seqan3::detail::extract_halve
+template <uint8_t index, simd::simd_concept simd_t>
+constexpr simd_t extract_halve_avx512(simd_t const & src);
+
+// TODO: not implemented and used yet, if you implement it don't forget to add it to seqan3::detail::extract_quarter
+template <uint8_t index, simd::simd_concept simd_t>
+constexpr simd_t extract_quarter_avx512(simd_t const & src);
+
+// TODO: not implemented and used yet, if you implement it don't forget to add it to seqan3::detail::extract_eighth
+template <uint8_t index, simd::simd_concept simd_t>
+constexpr simd_t extract_eighth_avx512(simd_t const & src);
+
+} // namespace seqan3::detail
+
+#endif // __AVX512F__

--- a/test/seqan3-test.cmake
+++ b/test/seqan3-test.cmake
@@ -38,7 +38,7 @@ file(MAKE_DIRECTORY ${SEQAN3_TEST_CLONE_DIR}/googletest/include/)
 # seqan3::test exposes a base set of required flags, includes, definitions and
 # libraries which are in common for **all** seqan3 tests
 add_library (seqan3_test INTERFACE)
-target_compile_options (seqan3_test INTERFACE "-pedantic"  "-Wall" "-Wextra" "-Werror" "-DNO_WARN_X86_INTRINSICS")
+target_compile_options (seqan3_test INTERFACE "-pedantic"  "-Wall" "-Wextra" "-Werror")
 target_link_libraries (seqan3_test INTERFACE "seqan3::seqan3" "pthread")
 target_include_directories (seqan3_test INTERFACE "${SEQAN3_CLONE_DIR}/test/include/")
 add_library (seqan3::test ALIAS seqan3_test)


### PR DESCRIPTION
This fixes the platform issues when x86 intrinsics (#1381) are not available, like on arm or powerpc.

The main idea is to always forward declare each simd_algorithm for each instruction set, e.g. load_sse4, load_avx2, load_avx512.

If the instruction set is available we define the forward declared algorithm, e.g. load_avx2.

Note: We forward declare for example load_avx2 s.t. we can use the name load_avx2 inside of the simd::load function regardless of whether avx2 intrinsics are available or not. We guarantee in simd::load that load_avx2 will only be invoked if the instruction set provides avx2 or higher (via constexpr, but each constexpr branch needs to contain valid c++ code).