### PR TITLE
[FIX] Memory leak in aligned_allocator

### DIFF
--- a/include/seqan3/range/container/aligned_allocator.hpp
+++ b/include/seqan3/range/container/aligned_allocator.hpp
@@ -173,10 +173,11 @@ public:
      */
     void deallocate(pointer const p, size_type const n) const noexcept
     {
+        size_t bytes_to_deallocate = n * sizeof(value_type);
         if constexpr (alignment <= __STDCPP_DEFAULT_NEW_ALIGNMENT__)
-            ::operator delete(p, n);
+            ::operator delete(p, bytes_to_deallocate);
         else // Use alignment aware deallocator function.
-            ::operator delete(p, n, static_cast<std::align_val_t>(alignment));
+            ::operator delete(p, bytes_to_deallocate, static_cast<std::align_val_t>(alignment));
     }
 
     /*!\brief The aligned_allocator member template class aligned_allocator::rebind provides a way to obtain an


### PR DESCRIPTION
[N3536](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3536.html#new.delete.single) states 
> Requires: size shall equal that used to allocate ptr.

Hence, we deallocate only `1/sizeof(value_type)` of the bytes

```
[ RUN      ] aligned_allocator.memory_alignment
=================================================================
==20221==ERROR: AddressSanitizer: new-delete-type-mismatch on 0x6040000008d0 in thread T0:
  object passed to delete has wrong type:
  size of the allocated type:   40 bytes;
  size of the deallocated type: 10 bytes.
```