### PR TITLE
[DOC] Remove `using namespace seqan3` from tutorial

### DIFF
--- a/doc/tutorial/alignment_file/alignment_file_read_cigar.cpp
+++ b/doc/tutorial/alignment_file/alignment_file_read_cigar.cpp
@@ -30,15 +30,13 @@ write_file_dummy_struct go{};
 #include <seqan3/io/alignment_file/all.hpp>
 #include <seqan3/std/filesystem>
 
-using namespace seqan3;
-
 int main()
 {
     std::filesystem::path tmp_dir = std::filesystem::temp_directory_path(); // get the temp directory
 
-    alignment_file_input fin{tmp_dir/"my.sam", fields<field::cigar>{}};
+    seqan3::alignment_file_input fin{tmp_dir/"my.sam", seqan3::fields<seqan3::field::cigar>{}};
 
     for (auto & [cigar] : fin)
-        debug_stream << cigar << std::endl;
+        seqan3::debug_stream << cigar << std::endl;
 }
 //![code]

--- a/doc/tutorial/alignment_file/alignment_file_read_cigar.cpp
+++ b/doc/tutorial/alignment_file/alignment_file_read_cigar.cpp
@@ -37,6 +37,6 @@ int main()
     seqan3::alignment_file_input fin{tmp_dir/"my.sam", seqan3::fields<seqan3::field::cigar>{}};
 
     for (auto & [cigar] : fin)
-        seqan3::debug_stream << cigar << std::endl;
+        seqan3::debug_stream << cigar << '\n';
 }
 //![code]

--- a/doc/tutorial/alignment_file/alignment_file_read_cigar.cpp
+++ b/doc/tutorial/alignment_file/alignment_file_read_cigar.cpp
@@ -36,7 +36,7 @@ int main()
 
     seqan3::alignment_file_input fin{tmp_dir/"my.sam", seqan3::fields<seqan3::field::cigar>{}};
 
-    for (auto & [cigar] : fin)
-        seqan3::debug_stream << cigar << '\n';
+    for (auto & [cigar_vector] : fin)
+        seqan3::debug_stream << cigar_vector << '\n';
 }
 //![code]

--- a/doc/tutorial/alignment_file/alignment_file_snippets.cpp
+++ b/doc/tutorial/alignment_file/alignment_file_snippets.cpp
@@ -115,7 +115,6 @@ int main()
 
 {
 //![alignments_with_ref]
-
     using seqan3::operator""_dna5;
 
     auto filename = std::filesystem::temp_directory_path()/"example.sam";

--- a/doc/tutorial/alignment_file/alignment_file_snippets.cpp
+++ b/doc/tutorial/alignment_file/alignment_file_snippets.cpp
@@ -67,7 +67,7 @@ int main()
 
 {
 //![file_extensions]
-    seqan3::debug_stream << seqan3::format_sam::file_extensions << std::endl; // prints [fastq,fq]
+    seqan3::debug_stream << seqan3::format_sam::file_extensions << '\n'; // prints [fastq,fq]
     seqan3::format_sam::file_extensions.push_back("sm");
 //![file_extensions]
 }
@@ -93,9 +93,9 @@ int main()
 
     for (auto & [id, seq, flag /*order!*/] : fin)
     {
-        seqan3::debug_stream << id << std::endl;
-        seqan3::debug_stream << seq << std::endl;
-        seqan3::debug_stream << flag << std::endl;
+        seqan3::debug_stream << id << '\n';
+        seqan3::debug_stream << seq << '\n';
+        seqan3::debug_stream << flag << '\n';
     }
 //![read_custom_fields]
 }
@@ -108,7 +108,7 @@ int main()
 
     for (auto & [ id, alignment ] : fin)
     {
-        seqan3::debug_stream << id << ": " << std::get<1>(alignment) << std::endl;
+        seqan3::debug_stream << id << ": " << std::get<1>(alignment) << '\n';
     }
 //![alignments_without_ref]
 }
@@ -127,7 +127,7 @@ int main()
 
     for (auto & [ alignment ] : fin)
     {
-        seqan3::debug_stream << alignment << std::endl; // Now you can print the whole alignment!
+        seqan3::debug_stream << alignment << '\n'; // Now you can print the whole alignment!
     }
 //![alignments_with_ref]
 }

--- a/doc/tutorial/alignment_file/alignment_file_snippets.cpp
+++ b/doc/tutorial/alignment_file/alignment_file_snippets.cpp
@@ -44,8 +44,6 @@ write_file_dummy_struct go{};
 //![main]
 #include <seqan3/io/alignment_file/all.hpp>
 
-using namespace seqan3;
-
 int main()
 {
 //![main]
@@ -54,7 +52,7 @@ int main()
 //![writing]
     auto filename = std::filesystem::temp_directory_path()/"out.sam";
 
-    alignment_file_output fout{filename, fields<field::flag, field::mapq>{}};
+    seqan3::alignment_file_output fout{filename, seqan3::fields<seqan3::field::flag, seqan3::field::mapq>{}};
 
     size_t mymapq{0};
     seqan3::sam_flag flag{seqan3::sam_flag::unmapped};
@@ -69,17 +67,17 @@ int main()
 
 {
 //![file_extensions]
-    debug_stream << format_sam::file_extensions << std::endl; // prints [fastq,fq]
-    format_sam::file_extensions.push_back("sm");
+    seqan3::debug_stream << seqan3::format_sam::file_extensions << std::endl; // prints [fastq,fq]
+    seqan3::format_sam::file_extensions.push_back("sm");
 //![file_extensions]
 }
 
 {
 /*
 //![filename_construction]
-    alignment_file_input fin_from_filename{"/tmp/my.sam"};
+    seqan3::alignment_file_input fin_from_filename{"/tmp/my.sam"};
 
-    alignment_file_input fin_from_stream{std::cin, format_sam{}};
+    seqan3::alignment_file_input fin_from_stream{std::cin, seqan3::format_sam{}};
 //![filename_construction]
 */
 }
@@ -89,13 +87,15 @@ int main()
 //![read_custom_fields]
     auto filename = std::filesystem::temp_directory_path()/"example.sam";
 
-    alignment_file_input fin{filename, fields<field::id, field::seq, field::flag>{}};
+    seqan3::alignment_file_input fin{filename, seqan3::fields<seqan3::field::id,
+                                               seqan3::field::seq,
+                                               seqan3::field::flag>{}};
 
     for (auto & [id, seq, flag /*order!*/] : fin)
     {
-        debug_stream << id << std::endl;
-        debug_stream << seq << std::endl;
-        debug_stream << flag << std::endl;
+        seqan3::debug_stream << id << std::endl;
+        seqan3::debug_stream << seq << std::endl;
+        seqan3::debug_stream << flag << std::endl;
     }
 //![read_custom_fields]
 }
@@ -104,27 +104,30 @@ int main()
 //![alignments_without_ref]
     auto filename = std::filesystem::temp_directory_path()/"example.sam";
 
-    alignment_file_input fin{filename, fields<field::id, field::alignment>{}};
+    seqan3::alignment_file_input fin{filename, seqan3::fields<seqan3::field::id, seqan3::field::alignment>{}};
 
     for (auto & [ id, alignment ] : fin)
     {
-        debug_stream << id << ": " << get<1>(alignment) << std::endl;
+        seqan3::debug_stream << id << ": " << std::get<1>(alignment) << std::endl;
     }
 //![alignments_without_ref]
 }
 
 {
 //![alignments_with_ref]
+
+    using seqan3::operator""_dna5;
+
     auto filename = std::filesystem::temp_directory_path()/"example.sam";
 
     std::vector<std::string> ref_ids{"ref"}; // list of one reference name
-    std::vector<dna5_vector> ref_sequences{"AGAGTTCGAGATCGAGGACTAGCGACGAGGCAGCGAGCGATCGAT"_dna5};
+    std::vector<seqan3::dna5_vector> ref_sequences{"AGAGTTCGAGATCGAGGACTAGCGACGAGGCAGCGAGCGATCGAT"_dna5};
 
-    alignment_file_input fin{filename, ref_ids, ref_sequences, fields<field::alignment>{}};
+    seqan3::alignment_file_input fin{filename, ref_ids, ref_sequences, seqan3::fields<seqan3::field::alignment>{}};
 
     for (auto & [ alignment ] : fin)
     {
-        debug_stream << alignment << std::endl; // Now you can print the whole alignment!
+        seqan3::debug_stream << alignment << std::endl; // Now you can print the whole alignment!
     }
 //![alignments_with_ref]
 }

--- a/doc/tutorial/alignment_file/alignment_file_snippets.cpp
+++ b/doc/tutorial/alignment_file/alignment_file_snippets.cpp
@@ -88,8 +88,8 @@ int main()
     auto filename = std::filesystem::temp_directory_path()/"example.sam";
 
     seqan3::alignment_file_input fin{filename, seqan3::fields<seqan3::field::id,
-                                               seqan3::field::seq,
-                                               seqan3::field::flag>{}};
+                                                              seqan3::field::seq,
+                                                              seqan3::field::flag>{}};
 
     for (auto & [id, seq, flag /*order!*/] : fin)
     {

--- a/doc/tutorial/alignment_file/alignment_file_solution1.cpp
+++ b/doc/tutorial/alignment_file/alignment_file_solution1.cpp
@@ -28,9 +28,9 @@ write_file_dummy_struct go{};
 //![solution]
 #include <seqan3/core/debug_stream.hpp>
 #include <seqan3/io/alignment_file/all.hpp>
+#include <seqan3/range/views/get.hpp>
 #include <seqan3/std/filesystem>
 #include <seqan3/std/ranges>
-#include <seqan3/range/views/get.hpp>
 
 int main()
 {
@@ -43,7 +43,8 @@ int main()
 
     std::ranges::for_each(fin.begin(), fin.end(), [&sum, &c] (auto & rec)
     {
-        sum += seqan3::get<seqan3::field::mapq>(rec); ++c;
+        sum += seqan3::get<seqan3::field::mapq>(rec);
+        ++c;
     });
 
     seqan3::debug_stream << "Average: " << (sum/c) << '\n';

--- a/doc/tutorial/alignment_file/alignment_file_solution1.cpp
+++ b/doc/tutorial/alignment_file/alignment_file_solution1.cpp
@@ -32,19 +32,20 @@ write_file_dummy_struct go{};
 #include <seqan3/range/views/get.hpp>
 #include <seqan3/std/ranges>
 
-using namespace seqan3;
-
 int main()
 {
     std::filesystem::path tmp_dir = std::filesystem::temp_directory_path(); // get the temp directory
 
-    alignment_file_input fin{tmp_dir/"my.sam", fields<field::mapq>{}};
+    seqan3::alignment_file_input fin{tmp_dir/"my.sam", seqan3::fields<seqan3::field::mapq>{}};
 
     double sum{};
     size_t c{};
 
-    std::ranges::for_each(fin.begin(), fin.end(), [&sum, &c] (auto & rec) { sum += get<field::mapq>(rec); ++c; });
+    std::ranges::for_each(fin.begin(), fin.end(), [&sum, &c] (auto & rec)
+    {
+        sum += seqan3::get<seqan3::field::mapq>(rec); ++c;
+    });
 
-    debug_stream << "Average: " << (sum/c) << std::endl;
+    seqan3::debug_stream << "Average: " << (sum/c) << std::endl;
 }
 //![solution]

--- a/doc/tutorial/alignment_file/alignment_file_solution1.cpp
+++ b/doc/tutorial/alignment_file/alignment_file_solution1.cpp
@@ -29,8 +29,8 @@ write_file_dummy_struct go{};
 #include <seqan3/core/debug_stream.hpp>
 #include <seqan3/io/alignment_file/all.hpp>
 #include <seqan3/std/filesystem>
-#include <seqan3/range/views/get.hpp>
 #include <seqan3/std/ranges>
+#include <seqan3/range/views/get.hpp>
 
 int main()
 {
@@ -46,6 +46,6 @@ int main()
         sum += seqan3::get<seqan3::field::mapq>(rec); ++c;
     });
 
-    seqan3::debug_stream << "Average: " << (sum/c) << std::endl;
+    seqan3::debug_stream << "Average: " << (sum/c) << '\n';
 }
 //![solution]

--- a/doc/tutorial/alignment_file/alignment_file_solution2.cpp
+++ b/doc/tutorial/alignment_file/alignment_file_solution2.cpp
@@ -57,10 +57,10 @@ r003	2064	chr2	18	10	5M	*	0	0	TAGGC	*
 write_file_dummy_struct go{};
 
 //![solution]
+#include <seqan3/alphabet/gap/gap.hpp>
 #include <seqan3/core/debug_stream.hpp>
 #include <seqan3/io/alignment_file/all.hpp>
 #include <seqan3/io/sequence_file/all.hpp>
-#include <seqan3/alphabet/gap/gap.hpp>
 #include <seqan3/std/filesystem>
 #include <seqan3/std/ranges>
 
@@ -104,7 +104,7 @@ int main()
 
         seqan3::debug_stream << id << " mapped against " << ref_id << " with "
                              << sum_read << " gaps in the read sequence and "
-                             << sum_ref  << " gaps in the reference sequence." << std::endl;
+                             << sum_ref  << " gaps in the reference sequence.\n";
     }
 }
 //![solution]

--- a/doc/tutorial/alignment_file/alignment_file_solution2.cpp
+++ b/doc/tutorial/alignment_file/alignment_file_solution2.cpp
@@ -57,16 +57,16 @@ r003	2064	chr2	18	10	5M	*	0	0	TAGGC	*
 write_file_dummy_struct go{};
 
 //![solution]
-#include <seqan3/alphabet/gap/gap.hpp>
 #include <seqan3/core/debug_stream.hpp>
 #include <seqan3/io/alignment_file/all.hpp>
 #include <seqan3/io/sequence_file/all.hpp>
+#include <seqan3/alphabet/gap/gap.hpp>
 #include <seqan3/std/filesystem>
 #include <seqan3/std/ranges>
 
-using seqan3::get;
+using namespace seqan3;
 
-struct my_traits : public seqan3::sequence_file_input_default_traits_dna
+struct my_traits : public sequence_file_input_default_traits_dna
 {
     //!\brief The container for sequences is now std::vector seqan3::concatenated_sequences.
     template <typename _sequence_container>
@@ -78,33 +78,30 @@ int main()
     std::filesystem::path tmp_dir = std::filesystem::temp_directory_path(); // get the temp directory
 
     // read in reference information
-    seqan3::sequence_file_input<my_traits> reference_file{tmp_dir/"reference.fasta"};
-    seqan3::concatenated_sequences<std::string> ref_ids = get<seqan3::field::id>(reference_file);
-    std::vector<std::vector<seqan3::dna5>> ref_seqs = get<seqan3::field::seq>(reference_file);
+    sequence_file_input<my_traits> reference_file{tmp_dir/"reference.fasta"};
+    concatenated_sequences<std::string> ref_ids = get<field::id>(reference_file);
+    std::vector<std::vector<dna5>> ref_seqs = get<field::seq>(reference_file);
 
-    seqan3::alignment_file_input mapping_file{tmp_dir/"mapping.sam",
-                                              ref_ids,
-                                              ref_seqs,
-                                              seqan3::fields<seqan3::field::id,
-                                                             seqan3::field::ref_id,
-                                                             seqan3::field::mapq,
-                                                             seqan3::field::alignment>{}};
+    alignment_file_input mapping_file{tmp_dir/"mapping.sam",
+                                      ref_ids,
+                                      ref_seqs,
+                                      fields<field::id,field::ref_id, field::mapq, field::alignment>{}};
 
-    auto mapq_filter = std::views::filter([] (auto & rec) { return seqan3::get<seqan3::field::mapq>(rec) >= 30; });
+    auto mapq_filter = std::views::filter([] (auto & rec) { return get<field::mapq>(rec) >= 30; });
 
     for (auto & [id, ref_id, mapq, alignment] : mapping_file | mapq_filter)
     {
-        auto & ref = std::get<0>(alignment);
+        auto & ref = get<0>(alignment);
         size_t sum_ref{};
-        std::ranges::for_each(ref.begin(), ref.end(), [&sum_ref] (auto c) { if (c == seqan3::gap{}) ++sum_ref; });
+        std::ranges::for_each(ref.begin(), ref.end(), [&sum_ref] (auto c) { if (c == gap{}) ++sum_ref; });
 
-        auto & read = std::get<0>(alignment);
+        auto & read = get<0>(alignment);
         size_t sum_read{};
-        std::ranges::for_each(read.begin(), read.end(), [&sum_read] (auto c) { if (c == seqan3::gap{}) ++sum_read; });
+        std::ranges::for_each(read.begin(), read.end(), [&sum_read] (auto c) { if (c == gap{}) ++sum_read; });
 
-        seqan3::debug_stream << id << " mapped against " << ref_id << " with "
-                             << sum_read << " gaps in the read sequence and "
-                             << sum_ref  << " gaps in the reference sequence.\n";
+        debug_stream << id << " mapped against " << ref_id << " with "
+                     << sum_read << " gaps in the read sequence and "
+                     << sum_ref  << " gaps in the reference sequence." << std::endl;
     }
 }
 //![solution]

--- a/doc/tutorial/alignment_file/alignment_file_solution3.cpp
+++ b/doc/tutorial/alignment_file/alignment_file_solution3.cpp
@@ -2,15 +2,16 @@
 #include <seqan3/io/alignment_file/all.hpp>
 #include <seqan3/std/filesystem>
 
-using namespace seqan3;
+using seqan3::operator""_dna4;
 
 int main()
 {
     std::vector<std::string> ids = {"read1", "read2"};
-    std::vector<std::vector<dna4>> seqs = {"ACGATCGACTAGCTACGATCAGCTAGCAG"_dna4, "AGAAAGAGCGAGGCTATTTTAGCGAGTTA"_dna4};
+    std::vector<std::vector<seqan3::dna4>> seqs = {"ACGATCGACTAGCTACGATCAGCTAGCAG"_dna4,
+                                                   "AGAAAGAGCGAGGCTATTTTAGCGAGTTA"_dna4};
 
     auto tmp_dir = std::filesystem::temp_directory_path();
-    alignment_file_output fout{tmp_dir/"my.sam", fields<field::id, field::seq>{}};
+    seqan3::alignment_file_output fout{tmp_dir/"my.sam", seqan3::fields<seqan3::field::id, seqan3::field::seq>{}};
 
     for (size_t i = 0; i < ids.size(); ++i)
     {

--- a/doc/tutorial/alphabet/alphabet_gc_content.cpp
+++ b/doc/tutorial/alphabet/alphabet_gc_content.cpp
@@ -9,7 +9,7 @@
 #include <seqan3/range/views/char_to.hpp>
 #include <seqan3/range/views/to.hpp>
 
-using namespace seqan3;
+using seqan3::operator""_dna5;
 
 int main (int argc, char * argv[])
 {
@@ -22,18 +22,18 @@ int main (int argc, char * argv[])
     }
     catch (seqan3::parser_invalid_argument const & ext) // the input is invalid
     {
-        debug_stream << "[PARSER ERROR] " << ext.what() << '\n';
+        seqan3::debug_stream << "[PARSER ERROR] " << ext.what() << '\n';
         return 0;
     }
 
     // Convert the input to a dna5 sequence.
-    std::vector<dna5> sequence = input | views::char_to<dna5> | views::to<std::vector>;
+    std::vector<seqan3::dna5> sequence = input | seqan3::views::char_to<seqan3::dna5> | seqan3::views::to<std::vector>;
 
     // Initialise an array with count values for dna5 symbols.
-    std::array<size_t, dna5::alphabet_size> count{}; // default initialised with zeroes
+    std::array<size_t, seqan3::dna5::alphabet_size> count{}; // default initialised with zeroes
 
     // Increase the symbol count according to the sequence.
-    for (dna5 symbol : sequence)
+    for (seqan3::dna5 symbol : sequence)
         ++count[symbol.to_rank()];
 
     // Calculate the GC content: (#G + #C) / (#A + #T + #G + #C).
@@ -41,7 +41,7 @@ int main (int argc, char * argv[])
     size_t atgc = input.size() - count['N'_dna5.to_rank()];
     float gc_content = 1.0f * gc / atgc;
 
-    debug_stream << "The GC content of " << sequence << " is " << 100 * gc_content << "%.\n";
+    seqan3::debug_stream << "The GC content of " << sequence << " is " << 100 * gc_content << "%.\n";
 
     return 0;
 }

--- a/doc/tutorial/alphabet/alphabet_main.cpp
+++ b/doc/tutorial/alphabet/alphabet_main.cpp
@@ -6,16 +6,18 @@
 //! [create]
 #include <seqan3/alphabet/all.hpp> // for working with alphabets directly
 
-using namespace seqan3;
+using seqan3::operator""_dna4;
+using seqan3::operator""_dna5;
+using seqan3::operator""_rna5;
 
 int main ()
 {
     // Two objects of seqan3::dna4 alphabet constructed with a char literal.
-    dna4 ade = 'A'_dna4;
-    dna4 gua = 'G'_dna4;
+    seqan3::dna4 ade = 'A'_dna4;
+    seqan3::dna4 gua = 'G'_dna4;
 
     // Two additional objects assigned explicitly from char or rank.
-    dna4 cyt, thy;
+    seqan3::dna4 cyt, thy;
     cyt.assign_char('C');
     thy.assign_rank(3);
 
@@ -26,7 +28,7 @@ int main ()
 
 //! [rank]
     // Get the rank type of the alphabet (here uint8_t).
-    using rank_type = seqan3::alphabet_rank_t<dna4>;
+    using rank_type = seqan3::alphabet_rank_t<seqan3::dna4>;
 
     // Retrieve the numerical representation (rank) of the objects.
     rank_type rank_a = ade.to_rank();   // => 0
@@ -37,7 +39,7 @@ int main ()
 
 //! [char]
     // Get the character type of the alphabet (here char).
-    using char_type = seqan3::alphabet_char_t<dna4>;
+    using char_type = seqan3::alphabet_char_t<seqan3::dna4>;
 
     // Retrieve the character representation.
     char_type char_a = ade.to_char();   // => 'A'
@@ -48,15 +50,15 @@ int main ()
 
 //! [char_strict]
     // Assign from character with value check.
-    assign_char_strictly_to('C', cyt);
+    seqan3::assign_char_strictly_to('C', cyt);
 
-    // assign_char_strictly_to('X', thy); // would throw seqan3::invalid_char_assignment
+    // seqan3::assign_char_strictly_to('X', thy); // would throw seqan3::invalid_char_assignment
 //! [char_strict]
     assert(cyt == 'C'_dna4);
 
 //! [size]
     // Get the alphabet size as class member of the alphabet.
-    uint8_t const size1 = dna4::alphabet_size;        // => 4
+    uint8_t const size1 = seqan3::dna4::alphabet_size;        // => 4
 //! [size]
     assert(size1 == 4u);
 
@@ -70,7 +72,7 @@ int main ()
     bool st  = (ade <  'C'_dna4); // true
 
     // Sort a vector of symbols.
-    std::vector<dna4> some_nucl{"GTA"_dna4};
+    std::vector<seqan3::dna4> some_nucl{"GTA"_dna4};
     std::sort(some_nucl.begin(), some_nucl.end()); // some_nucl: "AGT"
 //! [compare]
     assert(eq && neq && geq && gt && seq && st);
@@ -78,21 +80,21 @@ int main ()
 
 //! [gapped]
     // Assign a gap symbol to a gapped RNA alphabet.
-    gapped<rna5> sym = gap{};                         // => -
+    seqan3::gapped<seqan3::rna5> sym = seqan3::gap{};                         // => -
 
     // Each seqan3::rna5 symbol is still valid.
     sym = 'U'_rna5;                                   // => U
 
     // The alphabet size is six (AUGCN-).
-    uint8_t const size2 = gapped<rna5>::alphabet_size;   // => 6
+    uint8_t const size2 = seqan3::gapped<seqan3::rna5>::alphabet_size;   // => 6
 //! [gapped]
     assert(size2 == 6u);
 
 //! [containers]
     // Examples of different container types with SeqAn's alphabets.
-    std::vector<dna5> dna_sequence{"GATTANAG"_dna5};
-    std::pair<gapped<dna4>, gapped<dna4>> alignment_column{gap{}, thy};
-    std::set<dna4> pyrimidines{'C'_dna4, 'T'_dna4};
+    std::vector<seqan3::dna5> dna_sequence{"GATTANAG"_dna5};
+    std::pair<seqan3::gapped<seqan3::dna4>, seqan3::gapped<seqan3::dna4>> alignment_column{seqan3::gap{}, thy};
+    std::set<seqan3::dna4> pyrimidines{'C'_dna4, 'T'_dna4};
 //! [containers]
 
     // Prevent -Wunused-variable warnings.

--- a/doc/tutorial/alphabet/alphabet_main.cpp
+++ b/doc/tutorial/alphabet/alphabet_main.cpp
@@ -7,8 +7,6 @@
 #include <seqan3/alphabet/all.hpp> // for working with alphabets directly
 
 using seqan3::operator""_dna4;
-using seqan3::operator""_dna5;
-using seqan3::operator""_rna5;
 
 int main ()
 {
@@ -82,6 +80,7 @@ int main ()
     // Assign a gap symbol to a gapped RNA alphabet.
     seqan3::gapped<seqan3::rna5> sym = seqan3::gap{};                         // => -
 
+    using seqan3::operator""_rna5;
     // Each seqan3::rna5 symbol is still valid.
     sym = 'U'_rna5;                                   // => U
 
@@ -91,6 +90,8 @@ int main ()
     assert(size2 == 6u);
 
 //! [containers]
+    using seqan3::operator""_dna5;
+
     // Examples of different container types with SeqAn's alphabets.
     std::vector<seqan3::dna5> dna_sequence{"GATTANAG"_dna5};
     std::pair<seqan3::gapped<seqan3::dna4>, seqan3::gapped<seqan3::dna4>> alignment_column{seqan3::gap{}, thy};

--- a/doc/tutorial/argument_parser/basic_parser_setup.cpp
+++ b/doc/tutorial/argument_parser/basic_parser_setup.cpp
@@ -1,21 +1,19 @@
-#include <seqan3/argument_parser/all.hpp>     // includes all necessary headers
-#include <seqan3/core/debug_stream.hpp>  // our custom output stream
-
-using namespace seqan3;
+#include <seqan3/argument_parser/all.hpp>   // includes all necessary headers
+#include <seqan3/core/debug_stream.hpp>     // our custom output stream
 
 int main(int argc, char ** argv)
 {
-    argument_parser myparser{"Game-of-Parsing", argc, argv};        // initialise myparser
+    seqan3::argument_parser myparser{"Game-of-Parsing", argc, argv};        // initialise myparser
 
     // ... add information, options, flags and positional options
 
     try
     {
-         myparser.parse();                                          // trigger command line parsing
+         myparser.parse();                                                  // trigger command line parsing
     }
-    catch (parser_invalid_argument const & ext)                     // catch user errors
+    catch (seqan3::parser_invalid_argument const & ext)                     // catch user errors
     {
-        debug_stream << "[Winter has come] " << ext.what() << "\n"; // customise your error message
+        seqan3::debug_stream << "[Winter has come] " << ext.what() << "\n"; // customise your error message
         return -1;
     }
 }

--- a/doc/tutorial/argument_parser/disable_version_check.cpp
+++ b/doc/tutorial/argument_parser/disable_version_check.cpp
@@ -1,9 +1,7 @@
 #include <seqan3/argument_parser/all.hpp>
 
-using namespace seqan3;
-
 int main(int argc, char ** argv)
 {
-    argument_parser myparser{"Game-of-Parsing", argc, argv, false};
+    seqan3::argument_parser myparser{"Game-of-Parsing", argc, argv, false};
     // disable version checks permanently --------------------^
 }

--- a/doc/tutorial/argument_parser/disable_version_check.cpp
+++ b/doc/tutorial/argument_parser/disable_version_check.cpp
@@ -3,5 +3,5 @@
 int main(int argc, char ** argv)
 {
     seqan3::argument_parser myparser{"Game-of-Parsing", argc, argv, false};
-    // disable version checks permanently --------------------^
+    // disable version checks permanently ----------------------------^
 }

--- a/doc/tutorial/argument_parser/index.md
+++ b/doc/tutorial/argument_parser/index.md
@@ -116,7 +116,7 @@ Of course there is not much information to display yet, since we did not provide
 \assignment{Assignment 2}
 
 1. Extend the minimal example from assignment 1 by a function
-   `void initialize_argument_parser(seqan3::argument_parser & parser)`.
+   `void initialise_argument_parser(seqan3::argument_parser & parser)`.
 2. Within this function, customise the parser with the following information:
    * Set the author to your favourite Game of Thrones character (Don't have one? Really? Take "Cersei").
    * Set the short description to "Aggregate average US. Game of Thrones viewers by season.".

--- a/doc/tutorial/argument_parser/small_snippets.cpp
+++ b/doc/tutorial/argument_parser/small_snippets.cpp
@@ -5,8 +5,6 @@
 #include <seqan3/argument_parser/validators.hpp>
 //![validator_include]
 
-using namespace seqan3;
-
 struct cmd_arguments
 {
     std::filesystem::path file_path{};
@@ -21,7 +19,7 @@ int main(int argc, char ** argv)
 {
 
 {
-argument_parser parser{"Example-Parser", argc, argv};
+seqan3::argument_parser parser{"Example-Parser", argc, argv};
 //![add_positional_option]
 size_t variable{};
 parser.add_positional_option(variable, "This is a description.");
@@ -29,7 +27,7 @@ parser.add_positional_option(variable, "This is a description.");
 }
 
 {
-argument_parser parser{"Example-Parser", argc, argv};
+seqan3::argument_parser parser{"Example-Parser", argc, argv};
 //![add_option]
 size_t variable{};
 parser.add_option(variable, 'n', "my-number", "This is a description.");
@@ -37,7 +35,7 @@ parser.add_option(variable, 'n', "my-number", "This is a description.");
 }
 
 {
-argument_parser parser{"Example-Parser", argc, argv};
+seqan3::argument_parser parser{"Example-Parser", argc, argv};
 //![add_flag]
 bool variable{};
 parser.add_flag(variable, 'f', "my_flag", "This is a description.");
@@ -45,7 +43,7 @@ parser.add_flag(variable, 'f', "my_flag", "This is a description.");
 }
 
 {
-argument_parser parser{"Example-Parser", argc, argv};
+seqan3::argument_parser parser{"Example-Parser", argc, argv};
 //![option_list]
 std::vector<std::string> list_variable{};
 parser.add_option(list_variable, 'n', "names", "Give me some names.");
@@ -53,7 +51,7 @@ parser.add_option(list_variable, 'n', "names", "Give me some names.");
 }
 
 {
-argument_parser parser{"Example-Parser", argc, argv};
+seqan3::argument_parser parser{"Example-Parser", argc, argv};
 //![positional_option_list]
 std::string variable{};
 std::vector<std::string> list_variable{};
@@ -63,18 +61,18 @@ parser.add_positional_option(list_variable, "Give me one or more variables!.");
 }
 
 {
-argument_parser parser{"Example-Parser", argc, argv};
+seqan3::argument_parser parser{"Example-Parser", argc, argv};
 //![required_option]
 std::string required_variable{};
-parser.add_option(required_variable, 'n', "name", "I really need a name.", option_spec::REQUIRED);
+parser.add_option(required_variable, 'n', "name", "I really need a name.", seqan3::option_spec::REQUIRED);
 //![required_option]
 }
 
 {
-argument_parser parser{"Example-Parser", argc, argv};
+seqan3::argument_parser parser{"Example-Parser", argc, argv};
 //![input_file_validator]
 parser.add_positional_option(args.file_path, "Please provide a tab separated data file.",
-                             input_file_validator{{"tsv"}});
+                             seqan3::input_file_validator{{"tsv"}});
 //![input_file_validator]
 }
 

--- a/doc/tutorial/argument_parser/solution1.cpp
+++ b/doc/tutorial/argument_parser/solution1.cpp
@@ -1,9 +1,7 @@
 #include <seqan3/argument_parser/all.hpp> // includes all necessary headers
 #include <seqan3/core/debug_stream.hpp>   // our custom output stream
 
-using namespace seqan3;
-
-void initialize_argument_parser(argument_parser & parser)
+void initialize_argument_parser(seqan3::argument_parser & parser)
 {
     parser.info.author = "Cersei";
     parser.info.short_description = "Aggregate average Game of Thrones viewers by season.";
@@ -12,7 +10,7 @@ void initialize_argument_parser(argument_parser & parser)
 
 int main(int argc, char ** argv)
 {
-    argument_parser myparser{"Game-of-Parsing", argc, argv};
+    seqan3::argument_parser myparser{"Game-of-Parsing", argc, argv};
 
     // code from assignment 1
 }

--- a/doc/tutorial/argument_parser/solution1.cpp
+++ b/doc/tutorial/argument_parser/solution1.cpp
@@ -1,7 +1,7 @@
 #include <seqan3/argument_parser/all.hpp> // includes all necessary headers
 #include <seqan3/core/debug_stream.hpp>   // our custom output stream
 
-void initialize_argument_parser(seqan3::argument_parser & parser)
+void initialise_argument_parser(seqan3::argument_parser & parser)
 {
     parser.info.author = "Cersei";
     parser.info.short_description = "Aggregate average Game of Thrones viewers by season.";

--- a/doc/tutorial/argument_parser/solution3.cpp
+++ b/doc/tutorial/argument_parser/solution3.cpp
@@ -50,12 +50,12 @@ void run_program(std::filesystem::path & path, uint32_t yr, std::string & aggr_b
         }
 
         if (aggr_by == "median")
-            seqan3::debug_stream << ([&v] () { std::sort(v.begin(), v.end()); return v[v.size()/2]; })() << std::endl;
+            seqan3::debug_stream << ([&v] () { std::sort(v.begin(), v.end()); return v[v.size()/2]; })() << '\n';
         else if (aggr_by == "mean")
             seqan3::debug_stream << ([&v] () { double sum{}; for (auto i : v) sum += i; return sum / v.size(); })()
-                                 << std::endl;
+                                 << '\n';
         else
-            seqan3::debug_stream << "I do not know the aggregation method " << aggr_by << std::endl;
+            seqan3::debug_stream << "I do not know the aggregation method " << aggr_by << '\n';
     }
     else
     {

--- a/doc/tutorial/argument_parser/solution3.cpp
+++ b/doc/tutorial/argument_parser/solution3.cpp
@@ -9,8 +9,6 @@
 #include <seqan3/std/charconv>            // includes std::from_chars
 #include <seqan3/std/filesystem>          // use std::filesystem::path
 
-using namespace seqan3;
-
 // This is the program!
 // Take a look at it if you are interested in an example of parsing a data file.
 // -----------------------------------------------------------------------------
@@ -24,7 +22,7 @@ number_type to_number(range_type && range)
 
     if (res.ec != std::errc{})
     {
-        debug_stream << "Could not cast '" << range << "' to a valid number\n";
+        seqan3::debug_stream << "Could not cast '" << range << "' to a valid number\n";
         throw std::invalid_argument{"CAST ERROR"};
     }
     return num;
@@ -52,15 +50,16 @@ void run_program(std::filesystem::path & path, uint32_t yr, std::string & aggr_b
         }
 
         if (aggr_by == "median")
-            debug_stream << ([&v] () { std::sort(v.begin(), v.end()); return v[v.size()/2]; })() << std::endl;
+            seqan3::debug_stream << ([&v] () { std::sort(v.begin(), v.end()); return v[v.size()/2]; })() << std::endl;
         else if (aggr_by == "mean")
-            debug_stream << ([&v] () { double sum{}; for (auto i : v) sum += i; return sum / v.size(); })() << std::endl;
+            seqan3::debug_stream << ([&v] () { double sum{}; for (auto i : v) sum += i; return sum / v.size(); })()
+                                 << std::endl;
         else
-            debug_stream << "I do not know the aggregation method " << aggr_by << std::endl;
+            seqan3::debug_stream << "I do not know the aggregation method " << aggr_by << std::endl;
     }
     else
     {
-        debug_stream << "Error: Cannot open file for reading.\n";
+        seqan3::debug_stream << "Error: Cannot open file for reading.\n";
     }
 }
 // -----------------------------------------------------------------------------
@@ -75,7 +74,7 @@ struct cmd_arguments
 //![program]
 
 //![solution]
-void initialize_argument_parser(argument_parser & parser, cmd_arguments & args)
+void initialize_argument_parser(seqan3::argument_parser & parser, cmd_arguments & args)
 {
     parser.info.author = "Cercei";
     parser.info.short_description = "Aggregate average Game of Thrones viewers by season.";
@@ -94,18 +93,18 @@ void initialize_argument_parser(argument_parser & parser, cmd_arguments & args)
 
 int main(int argc, char ** argv)
 {
-    argument_parser myparser{"Game-of-Parsing", argc, argv};        // initialise myparser
+    seqan3::argument_parser myparser{"Game-of-Parsing", argc, argv};        // initialise myparser
     cmd_arguments args{};
 
     initialize_argument_parser(myparser, args);
 
     try
     {
-         myparser.parse();                                          // trigger command line parsing
+         myparser.parse();                                                  // trigger command line parsing
     }
-    catch (parser_invalid_argument const & ext)                     // catch user errors
+    catch (seqan3::parser_invalid_argument const & ext)                     // catch user errors
     {
-        debug_stream << "[Winter has come] " << ext.what() << "\n"; // customise your error message
+        seqan3::debug_stream << "[Winter has come] " << ext.what() << "\n"; // customise your error message
         return -1;
     }
 

--- a/doc/tutorial/argument_parser/solution3.cpp
+++ b/doc/tutorial/argument_parser/solution3.cpp
@@ -74,7 +74,7 @@ struct cmd_arguments
 //![program]
 
 //![solution]
-void initialize_argument_parser(seqan3::argument_parser & parser, cmd_arguments & args)
+void initialise_argument_parser(seqan3::argument_parser & parser, cmd_arguments & args)
 {
     parser.info.author = "Cercei";
     parser.info.short_description = "Aggregate average Game of Thrones viewers by season.";
@@ -96,7 +96,7 @@ int main(int argc, char ** argv)
     seqan3::argument_parser myparser{"Game-of-Parsing", argc, argv};        // initialise myparser
     cmd_arguments args{};
 
-    initialize_argument_parser(myparser, args);
+    initialise_argument_parser(myparser, args);
 
     try
     {

--- a/doc/tutorial/argument_parser/solution4.cpp
+++ b/doc/tutorial/argument_parser/solution4.cpp
@@ -74,7 +74,7 @@ struct cmd_arguments
     bool header_is_set{};
 };
 
-void initialize_argument_parser(seqan3::argument_parser & parser, cmd_arguments & args)
+void initialise_argument_parser(seqan3::argument_parser & parser, cmd_arguments & args)
 {
     parser.info.author = "Cercei";
     parser.info.short_description = "Aggregate average Game of Thrones viewers by season.";
@@ -96,7 +96,7 @@ int main(int argc, char ** argv)
     seqan3::argument_parser myparser{"Game-of-Parsing", argc, argv};        // initialise myparser
     cmd_arguments args{};
 
-    initialize_argument_parser(myparser, args);
+    initialise_argument_parser(myparser, args);
 
     try
     {

--- a/doc/tutorial/argument_parser/solution4.cpp
+++ b/doc/tutorial/argument_parser/solution4.cpp
@@ -51,12 +51,12 @@ void run_program(std::filesystem::path & path, std::vector<uint8_t> sn, std::str
         //![altered_while]
 
         if (aggr_by == "median")
-            seqan3::debug_stream << ([&v] () { std::sort(v.begin(), v.end()); return v[v.size()/2]; })() << std::endl;
+            seqan3::debug_stream << ([&v] () { std::sort(v.begin(), v.end()); return v[v.size()/2]; })() << '\n';
         else if (aggr_by == "mean")
             seqan3::debug_stream << ([&v] () { double sum{}; for (auto i : v) sum += i; return sum / v.size(); })()
-                                 << std::endl;
+                                 << '\n';
         else
-            seqan3::debug_stream << "I do not know the aggregation method " << aggr_by << std::endl;
+            seqan3::debug_stream << "I do not know the aggregation method " << aggr_by << '\n';
     }
     else
     {

--- a/doc/tutorial/argument_parser/solution4.cpp
+++ b/doc/tutorial/argument_parser/solution4.cpp
@@ -8,8 +8,6 @@
 #include <seqan3/std/charconv>            // includes std::from_chars
 #include <seqan3/std/filesystem>          // use std::filesystem::path
 
-using namespace seqan3;
-
 // This is the program!
 // Take a look at it if you are interested in an example of parsing a data file.
 // -----------------------------------------------------------------------------
@@ -23,7 +21,7 @@ number_type to_number(range_type && range)
 
     if (res.ec != std::errc{})
     {
-        debug_stream << "Could not cast '" << range << "' to a valid number\n";
+        seqan3::debug_stream << "Could not cast '" << range << "' to a valid number\n";
         throw std::invalid_argument{"CAST ERROR"};
     }
     return num;
@@ -53,15 +51,16 @@ void run_program(std::filesystem::path & path, std::vector<uint8_t> sn, std::str
         //![altered_while]
 
         if (aggr_by == "median")
-            debug_stream << ([&v] () { std::sort(v.begin(), v.end()); return v[v.size()/2]; })() << std::endl;
+            seqan3::debug_stream << ([&v] () { std::sort(v.begin(), v.end()); return v[v.size()/2]; })() << std::endl;
         else if (aggr_by == "mean")
-            debug_stream << ([&v] () { double sum{}; for (auto i : v) sum += i; return sum / v.size(); })() << std::endl;
+            seqan3::debug_stream << ([&v] () { double sum{}; for (auto i : v) sum += i; return sum / v.size(); })()
+                                 << std::endl;
         else
-            debug_stream << "I do not know the aggregation method " << aggr_by << std::endl;
+            seqan3::debug_stream << "I do not know the aggregation method " << aggr_by << std::endl;
     }
     else
     {
-        debug_stream << "Error: Cannot open file for reading.\n";
+        seqan3::debug_stream << "Error: Cannot open file for reading.\n";
     }
 }
 // -----------------------------------------------------------------------------
@@ -75,7 +74,7 @@ struct cmd_arguments
     bool header_is_set{};
 };
 
-void initialize_argument_parser(argument_parser & parser, cmd_arguments & args)
+void initialize_argument_parser(seqan3::argument_parser & parser, cmd_arguments & args)
 {
     parser.info.author = "Cercei";
     parser.info.short_description = "Aggregate average Game of Thrones viewers by season.";
@@ -94,18 +93,18 @@ void initialize_argument_parser(argument_parser & parser, cmd_arguments & args)
 
 int main(int argc, char ** argv)
 {
-    argument_parser myparser{"Game-of-Parsing", argc, argv};        // initialise myparser
+    seqan3::argument_parser myparser{"Game-of-Parsing", argc, argv};        // initialise myparser
     cmd_arguments args{};
 
     initialize_argument_parser(myparser, args);
 
     try
     {
-         myparser.parse();                                          // trigger command line parsing
+         myparser.parse();                                                  // trigger command line parsing
     }
-    catch (parser_invalid_argument const & ext)                     // catch user errors
+    catch (seqan3::parser_invalid_argument const & ext)                     // catch user errors
     {
-        debug_stream << "[Winter has come] " << ext.what() << "\n"; // customise your error message
+        seqan3::debug_stream << "[Winter has come] " << ext.what() << "\n"; // customise your error message
         return -1;
     }
 

--- a/doc/tutorial/argument_parser/solution5.cpp
+++ b/doc/tutorial/argument_parser/solution5.cpp
@@ -8,8 +8,6 @@
 #include <seqan3/std/charconv>            // includes std::from_chars
 #include <seqan3/std/filesystem>          // use std::filesystem::path
 
-using namespace seqan3;
-
 // This is the program!
 // Take a look at it if you are interested in an example of parsing a data file.
 // -----------------------------------------------------------------------------
@@ -23,7 +21,7 @@ number_type to_number(range_type && range)
 
     if (res.ec != std::errc{})
     {
-        debug_stream << "Could not cast '" << range << "' to a valid number\n";
+        seqan3::debug_stream << "Could not cast '" << range << "' to a valid number\n";
         throw std::invalid_argument{"CAST ERROR"};
     }
     return num;
@@ -51,15 +49,16 @@ void run_program(std::filesystem::path & path, std::vector<uint8_t> sn, std::str
         }
 
         if (aggr_by == "median")
-            debug_stream << ([&v] () { std::sort(v.begin(), v.end()); return v[v.size()/2]; })() << std::endl;
+            seqan3::debug_stream << ([&v] () { std::sort(v.begin(), v.end()); return v[v.size()/2]; })() << std::endl;
         else if (aggr_by == "mean")
-            debug_stream << ([&v] () { double sum{}; for (auto i : v) sum += i; return sum / v.size(); })() << std::endl;
+            seqan3::debug_stream << ([&v] () { double sum{}; for (auto i : v) sum += i; return sum / v.size(); })()
+                                 << std::endl;
         else
-            debug_stream << "I do not know the aggregation method " << aggr_by << std::endl;
+            seqan3::debug_stream << "I do not know the aggregation method " << aggr_by << std::endl;
     }
     else
     {
-        debug_stream << "Error: Cannot open file for reading.\n";
+        seqan3::debug_stream << "Error: Cannot open file for reading.\n";
     }
 }
 // -----------------------------------------------------------------------------
@@ -72,7 +71,7 @@ struct cmd_arguments
     bool header_is_set{};
 };
 
-void initialize_argument_parser(argument_parser & parser, cmd_arguments & args)
+void initialize_argument_parser(seqan3::argument_parser & parser, cmd_arguments & args)
 {
     parser.info.author = "Cercei";
     parser.info.short_description = "Aggregate average Game of Thrones viewers by season.";
@@ -81,7 +80,7 @@ void initialize_argument_parser(argument_parser & parser, cmd_arguments & args)
     parser.add_positional_option(args.file_path, "Please provide a tab separated data file.");
 
 //![solution]
-    parser.add_option(args.seasons, 's', "season", "Choose the seasons to aggregate.", option_spec::REQUIRED);
+    parser.add_option(args.seasons, 's', "season", "Choose the seasons to aggregate.", seqan3::option_spec::REQUIRED);
 //![solution]
 
     parser.add_option(args.aggregate_by, 'a', "aggregate-by", "Choose your method of aggregation: mean or median.");
@@ -92,18 +91,18 @@ void initialize_argument_parser(argument_parser & parser, cmd_arguments & args)
 
 int main(int argc, char ** argv)
 {
-    argument_parser myparser{"Game-of-Parsing", argc, argv};        // initialise myparser
+    seqan3::argument_parser myparser{"Game-of-Parsing", argc, argv};        // initialise myparser
     cmd_arguments args{};
 
     initialize_argument_parser(myparser, args);
 
     try
     {
-         myparser.parse();                                          // trigger command line parsing
+         myparser.parse();                                                  // trigger command line parsing
     }
-    catch (parser_invalid_argument const & ext)                     // catch user errors
+    catch (seqan3::parser_invalid_argument const & ext)                     // catch user errors
     {
-        debug_stream << "[Winter has come] " << ext.what() << "\n"; // customise your error message
+        seqan3::debug_stream << "[Winter has come] " << ext.what() << "\n"; // customise your error message
         return -1;
     }
 

--- a/doc/tutorial/argument_parser/solution5.cpp
+++ b/doc/tutorial/argument_parser/solution5.cpp
@@ -71,7 +71,7 @@ struct cmd_arguments
     bool header_is_set{};
 };
 
-void initialize_argument_parser(seqan3::argument_parser & parser, cmd_arguments & args)
+void initialise_argument_parser(seqan3::argument_parser & parser, cmd_arguments & args)
 {
     parser.info.author = "Cercei";
     parser.info.short_description = "Aggregate average Game of Thrones viewers by season.";
@@ -94,7 +94,7 @@ int main(int argc, char ** argv)
     seqan3::argument_parser myparser{"Game-of-Parsing", argc, argv};        // initialise myparser
     cmd_arguments args{};
 
-    initialize_argument_parser(myparser, args);
+    initialise_argument_parser(myparser, args);
 
     try
     {

--- a/doc/tutorial/argument_parser/solution5.cpp
+++ b/doc/tutorial/argument_parser/solution5.cpp
@@ -49,12 +49,12 @@ void run_program(std::filesystem::path & path, std::vector<uint8_t> sn, std::str
         }
 
         if (aggr_by == "median")
-            seqan3::debug_stream << ([&v] () { std::sort(v.begin(), v.end()); return v[v.size()/2]; })() << std::endl;
+            seqan3::debug_stream << ([&v] () { std::sort(v.begin(), v.end()); return v[v.size()/2]; })() << '\n';
         else if (aggr_by == "mean")
             seqan3::debug_stream << ([&v] () { double sum{}; for (auto i : v) sum += i; return sum / v.size(); })()
-                                 << std::endl;
+                                 << '\n';
         else
-            seqan3::debug_stream << "I do not know the aggregation method " << aggr_by << std::endl;
+            seqan3::debug_stream << "I do not know the aggregation method " << aggr_by << '\n';
     }
     else
     {

--- a/doc/tutorial/argument_parser/solution6.cpp
+++ b/doc/tutorial/argument_parser/solution6.cpp
@@ -71,7 +71,7 @@ struct cmd_arguments
     bool header_is_set{};
 };
 
-void initialize_argument_parser(seqan3::argument_parser & parser, cmd_arguments & args)
+void initialise_argument_parser(seqan3::argument_parser & parser, cmd_arguments & args)
 {
     parser.info.author = "Cercei";
     parser.info.short_description = "Aggregate average Game of Thrones viewers by season.";
@@ -101,7 +101,7 @@ int main(int argc, char ** argv)
     seqan3::argument_parser myparser{"Game-of-Parsing", argc, argv};        // initialise myparser
     cmd_arguments args{};
 
-    initialize_argument_parser(myparser, args);
+    initialise_argument_parser(myparser, args);
 
     try
     {

--- a/doc/tutorial/argument_parser/solution6.cpp
+++ b/doc/tutorial/argument_parser/solution6.cpp
@@ -8,8 +8,6 @@
 #include <seqan3/std/charconv>            // includes std::from_chars
 #include <seqan3/std/filesystem>          // use std::filesystem::path
 
-using namespace seqan3;
-
 // This is the program!
 // Take a look at it if you are interested in an example of parsing a data file.
 // -----------------------------------------------------------------------------
@@ -23,7 +21,7 @@ number_type to_number(range_type && range)
 
     if (res.ec != std::errc{})
     {
-        debug_stream << "Could not cast '" << range << "' to a valid number\n";
+        seqan3::debug_stream << "Could not cast '" << range << "' to a valid number\n";
         throw std::invalid_argument{"CAST ERROR"};
     }
     return num;
@@ -51,15 +49,16 @@ void run_program(std::filesystem::path & path, std::vector<uint8_t> sn, std::str
         }
 
         if (aggr_by == "median")
-            debug_stream << ([&v] () { std::sort(v.begin(), v.end()); return v[v.size()/2]; })() << std::endl;
+            seqan3::debug_stream << ([&v] () { std::sort(v.begin(), v.end()); return v[v.size()/2]; })() << std::endl;
         else if (aggr_by == "mean")
-            debug_stream << ([&v] () { double sum{}; for (auto i : v) sum += i; return sum / v.size(); })() << std::endl;
+            seqan3::debug_stream << ([&v] () { double sum{}; for (auto i : v) sum += i; return sum / v.size(); })()
+                                 << std::endl;
         else
-            debug_stream << "I do not know the aggregation method " << aggr_by << std::endl;
+            seqan3::debug_stream << "I do not know the aggregation method " << aggr_by << std::endl;
     }
     else
     {
-        debug_stream << "Error: Cannot open file for reading.\n";
+        seqan3::debug_stream << "Error: Cannot open file for reading.\n";
     }
 }
 // -----------------------------------------------------------------------------
@@ -72,7 +71,7 @@ struct cmd_arguments
     bool header_is_set{};
 };
 
-void initialize_argument_parser(argument_parser & parser, cmd_arguments & args)
+void initialize_argument_parser(seqan3::argument_parser & parser, cmd_arguments & args)
 {
     parser.info.author = "Cercei";
     parser.info.short_description = "Aggregate average Game of Thrones viewers by season.";
@@ -80,17 +79,17 @@ void initialize_argument_parser(argument_parser & parser, cmd_arguments & args)
 
     //![file_validator]
     parser.add_positional_option(args.file_path, "Please provide a tab separated seasons file.",
-                                 regex_validator{".*seasons\\..+$"} | input_file_validator{{"tsv"}} );
+                                 seqan3::regex_validator{".*seasons\\..+$"} | seqan3::input_file_validator{{"tsv"}} );
     //![file_validator]
 
     //![arithmetic_range_validator]
     parser.add_option(args.seasons, 's', "season", "Choose the seasons to aggregate.",
-                      option_spec::REQUIRED, arithmetic_range_validator{1, 7});
+                      seqan3::option_spec::REQUIRED, seqan3::arithmetic_range_validator{1, 7});
     //![arithmetic_range_validator]
 
     //![value_list_validator]
     parser.add_option(args.aggregate_by, 'a', "aggregate-by", "Choose your method of aggregation.",
-                      option_spec::DEFAULT, value_list_validator{"median", "mean"});
+                      seqan3::option_spec::DEFAULT, seqan3::value_list_validator{"median", "mean"});
     //![value_list_validator]
 
     parser.add_flag(args.header_is_set, 'H', "header-is-set", "Let us know whether your data file contains a "
@@ -99,18 +98,18 @@ void initialize_argument_parser(argument_parser & parser, cmd_arguments & args)
 
 int main(int argc, char ** argv)
 {
-    argument_parser myparser{"Game-of-Parsing", argc, argv};        // initialise myparser
+    seqan3::argument_parser myparser{"Game-of-Parsing", argc, argv};        // initialise myparser
     cmd_arguments args{};
 
     initialize_argument_parser(myparser, args);
 
     try
     {
-         myparser.parse();                                          // trigger command line parsing
+         myparser.parse();                                                  // trigger command line parsing
     }
-    catch (parser_invalid_argument const & ext)                     // catch user errors
+    catch (seqan3::parser_invalid_argument const & ext)                     // catch user errors
     {
-        debug_stream << "[Winter has come] " << ext.what() << "\n"; // customise your error message
+        seqan3::debug_stream << "[Winter has come] " << ext.what() << "\n"; // customise your error message
         return -1;
     }
 

--- a/doc/tutorial/argument_parser/solution6.cpp
+++ b/doc/tutorial/argument_parser/solution6.cpp
@@ -49,12 +49,12 @@ void run_program(std::filesystem::path & path, std::vector<uint8_t> sn, std::str
         }
 
         if (aggr_by == "median")
-            seqan3::debug_stream << ([&v] () { std::sort(v.begin(), v.end()); return v[v.size()/2]; })() << std::endl;
+            seqan3::debug_stream << ([&v] () { std::sort(v.begin(), v.end()); return v[v.size()/2]; })() << '\n';
         else if (aggr_by == "mean")
             seqan3::debug_stream << ([&v] () { double sum{}; for (auto i : v) sum += i; return sum / v.size(); })()
-                                 << std::endl;
+                                 << '\n';
         else
-            seqan3::debug_stream << "I do not know the aggregation method " << aggr_by << std::endl;
+            seqan3::debug_stream << "I do not know the aggregation method " << aggr_by << '\n';
     }
     else
     {

--- a/doc/tutorial/concepts/custom_validator_solution2.cpp
+++ b/doc/tutorial/concepts/custom_validator_solution2.cpp
@@ -48,7 +48,7 @@ int main(int argc, char ** argv)
         return -1;
     }
 
-    seqan3::debug_stream << "Yeah!" << std::endl;
+    seqan3::debug_stream << "Yeah!\n";
 
     return 0;
 }

--- a/doc/tutorial/concepts/index.md
+++ b/doc/tutorial/concepts/index.md
@@ -170,7 +170,8 @@ Write a small program, similar to the one above with the following "skeleton":
 ```cpp
 // which includes?
 
-using namespace seqan3;
+using seqan3::operator""_dna5;
+using seqan3::operator""_aa27;
 
 // Add one or more `void print` function template(s) here //
 
@@ -178,7 +179,7 @@ int main()
 {
     auto d = 'A'_dna5;
     auto a = 'L'_aa27;
-    auto g = gap{};
+    auto g = seqan3::gap{};
 
     print(d);
     print(a);
@@ -313,4 +314,3 @@ Also give a nice description for the help page.
 \endsolution
 
 You have now written your own type that is compatible with our constrained interfaces!
-

--- a/doc/tutorial/concepts/overloading_solution1.cpp
+++ b/doc/tutorial/concepts/overloading_solution1.cpp
@@ -1,19 +1,20 @@
 #include <iostream>                     // for std::cout
 #include <seqan3/alphabet/all.hpp>      // include all alphabet headers
 
-using namespace seqan3;
-
-template <alphabet t>
+template <seqan3::alphabet t>
 void print(t const v)
 {
-    std::cout << "I am an alphabet and my value as char is: " << to_char(v) << '\n';
+    std::cout << "I am an alphabet and my value as char is: " << seqan3::to_char(v) << '\n';
 }
+
+using seqan3::operator""_dna5;
+using seqan3::operator""_aa27;
 
 int main()
 {
     auto d = 'A'_dna5;
     auto a = 'L'_aa27;
-    auto g = gap{};
+    auto g = seqan3::gap{};
 
     print(d);
     print(a);

--- a/doc/tutorial/concepts/overloading_solution2.cpp
+++ b/doc/tutorial/concepts/overloading_solution2.cpp
@@ -1,26 +1,27 @@
 #include <iostream>                     // for std::cout
 #include <seqan3/alphabet/all.hpp>      // include all alphabet headers
 
-using namespace seqan3;
-
-template <alphabet t>
+template <seqan3::alphabet t>
 void print(t const v)
 {
-    std::cout << "I am an alphabet and my value as char is: " << to_char(v) << '\n';
+    std::cout << "I am an alphabet and my value as char is: " << seqan3::to_char(v) << '\n';
 }
 
-template <nucleotide_alphabet t>
+template <seqan3::nucleotide_alphabet t>
 void print(t const v)
 {
-    std::cout << "I am a nucleotide, my value as char is: " << to_char(v)
-              << " and my complement is: " << to_char(complement(v)) << '\n';
+    std::cout << "I am a nucleotide, my value as char is: " << seqan3::to_char(v)
+              << " and my complement is: " << seqan3::to_char(seqan3::complement(v)) << '\n';
 }
+
+using seqan3::operator""_dna5;
+using seqan3::operator""_aa27;
 
 int main()
 {
     auto d = 'A'_dna5;
     auto a = 'L'_aa27;
-    auto g = gap{};
+    auto g = seqan3::gap{};
 
     print(d);
     print(a);

--- a/doc/tutorial/introduction/introduction_align.cpp
+++ b/doc/tutorial/introduction/introduction_align.cpp
@@ -1,8 +1,8 @@
 #include <seqan3/io/sequence_file/output.hpp>
 
 //! [sequence_input_include]
-#include <seqan3/io/sequence_file/input.hpp> // for sequence_file_input
 #include <seqan3/core/debug_stream.hpp>      // for debug_stream
+#include <seqan3/io/sequence_file/input.hpp> // for sequence_file_input
 //! [sequence_input_include]
 
 //! [alignment_include]
@@ -11,6 +11,8 @@
 #include <seqan3/alignment/pairwise/align_pairwise.hpp>                   // for align_pairwise
 //! [alignment_include]
 
+using seqan3::operator""_dna4;
+
 int main()
 {
     auto tmp_dir = std::filesystem::temp_directory_path();
@@ -18,7 +20,6 @@ int main()
     {
         // Create a /tmp/my.fasta file.
         seqan3::sequence_file_output file_out{filename};
-        using seqan3::operator""_dna4;
         file_out.emplace_back("ACGTGATG"_dna4, std::string{"seq1"});
         file_out.emplace_back("AGTGATACT"_dna4, std::string{"seq2"});
     }

--- a/doc/tutorial/introduction/introduction_align.cpp
+++ b/doc/tutorial/introduction/introduction_align.cpp
@@ -11,41 +11,41 @@
 #include <seqan3/alignment/pairwise/align_pairwise.hpp>                   // for align_pairwise
 //! [alignment_include]
 
-using namespace seqan3;
-
 int main()
 {
     auto tmp_dir = std::filesystem::temp_directory_path();
     std::string filename{tmp_dir/"seq.fasta"};
     {
         // Create a /tmp/my.fasta file.
-        sequence_file_output file_out{filename};
+        seqan3::sequence_file_output file_out{filename};
+        using seqan3::operator""_dna4;
         file_out.emplace_back("ACGTGATG"_dna4, std::string{"seq1"});
         file_out.emplace_back("AGTGATACT"_dna4, std::string{"seq2"});
     }
 
 //! [sequence_input]
     // Initialise a file input object with a FastA file.
-    sequence_file_input file_in{filename}; // filename: "seq.fasta"
+    seqan3::sequence_file_input file_in{filename}; // filename: "seq.fasta"
 
     // Retrieve the sequences and ids.
     for (auto &[seq, id, qual] : file_in)
     {
-        debug_stream << "ID:  " << id << '\n';
-        debug_stream << "SEQ: " << seq << '\n';
-        debug_stream << "EMPTY QUAL." << qual << '\n'; // qual is empty for FastA files
+        seqan3::debug_stream << "ID:  " << id << '\n';
+        seqan3::debug_stream << "SEQ: " << seq << '\n';
+        seqan3::debug_stream << "EMPTY QUAL." << qual << '\n'; // qual is empty for FastA files
     }
 //! [sequence_input]
 
+    using seqan3::operator""_dna5;
     std::vector<seqan3::dna5_vector> sequences{"ACGTGATG"_dna5, "AGTGATACT"_dna5};
 //! [alignment]
     // Call a pairwise alignment with edit distance and traceback.
     for (auto && res : align_pairwise(std::tie(sequences[0], sequences[1]),
-                                      align_cfg::edit | align_cfg::result{with_alignment}))
+                                      seqan3::align_cfg::edit | seqan3::align_cfg::result{seqan3::with_alignment}))
     {
         // Print the resulting score and the alignment.
-        debug_stream << res.score() << '\n';              // => -4
-        debug_stream << res.alignment() << '\n';          // =>       0     .    :
+        seqan3::debug_stream << res.score() << '\n';      // => -4
+        seqan3::debug_stream << res.alignment() << '\n';  // =>       0     .    :
                                                           //            ACGTGATG--
                                                           //            | |||||
                                                           //            A-GTGATACT

--- a/doc/tutorial/introduction/introduction_argument_parser.cpp
+++ b/doc/tutorial/introduction/introduction_argument_parser.cpp
@@ -3,8 +3,6 @@
 #include <seqan3/argument_parser/all.hpp> // for argument_parser
 #include <seqan3/core/debug_stream.hpp>   // for debug_stream
 
-using namespace seqan3;
-
 int main(int argc, char * argv[])
 {
     // Create a buffer for the input.
@@ -20,10 +18,10 @@ int main(int argc, char * argv[])
     }
     catch (seqan3::parser_invalid_argument const & ext)
     {
-        debug_stream << "[PARSER ERROR] " << ext.what() << '\n';
+        seqan3::debug_stream << "[PARSER ERROR] " << ext.what() << '\n';
         return 0;
     }
 
-    debug_stream << "The text was: " << input << "\n";
+    seqan3::debug_stream << "The text was: " << input << "\n";
 }
 //! [argparse]

--- a/doc/tutorial/introduction/introduction_debug_stream.cpp
+++ b/doc/tutorial/introduction/introduction_debug_stream.cpp
@@ -1,14 +1,12 @@
 //! [debug]
 #include <iostream>                          // for std::cerr, std::endl
 #include <vector>                            // for std::vector
-#include <seqan3/core/debug_stream.hpp> // for debug_stream
-
-using namespace seqan3;
+#include <seqan3/core/debug_stream.hpp>      // for debug_stream
 
 int main()
 {
     std::vector<int> vec{-1,0,1};
-    debug_stream << vec << std::endl;   // => [-1,0,1]
+    seqan3::debug_stream << vec << std::endl;   // => [-1,0,1]
     // std::cerr << vec << std::endl;   // compiler error: no operator<< for std::vector<int>
 }
 //! [debug]

--- a/doc/tutorial/introduction/introduction_debug_stream.cpp
+++ b/doc/tutorial/introduction/introduction_debug_stream.cpp
@@ -1,12 +1,12 @@
 //! [debug]
-#include <iostream>                          // for std::cerr, std::endl
+#include <iostream>                          // for std::cerr
 #include <vector>                            // for std::vector
 #include <seqan3/core/debug_stream.hpp>      // for debug_stream
 
 int main()
 {
     std::vector<int> vec{-1,0,1};
-    seqan3::debug_stream << vec << std::endl;   // => [-1,0,1]
-    // std::cerr << vec << std::endl;   // compiler error: no operator<< for std::vector<int>
+    seqan3::debug_stream << vec << '\n';    // => [-1,0,1]
+    // std::cerr << vec << '\n';            // compiler error: no operator<< for std::vector<int>
 }
 //! [debug]

--- a/doc/tutorial/introduction/introduction_hello_world.cpp
+++ b/doc/tutorial/introduction/introduction_hello_world.cpp
@@ -1,10 +1,8 @@
 //! [hello]
 #include <seqan3/core/debug_stream.hpp> // for debug_stream
 
-using namespace seqan3;
-
 int main()
 {
-    debug_stream << "Hello World!\n";
+    seqan3::debug_stream << "Hello World!\n";
 }
 //! [hello]

--- a/doc/tutorial/introduction/introduction_read_fasta.cpp
+++ b/doc/tutorial/introduction/introduction_read_fasta.cpp
@@ -3,9 +3,7 @@
 #include <vector>                            // for std::vector
 #include <seqan3/argument_parser/all.hpp>    // for argument_parser
 #include <seqan3/io/sequence_file/input.hpp> // for sequence_file_input
-#include <seqan3/core/debug_stream.hpp> // for debug_stream
-
-using namespace seqan3;
+#include <seqan3/core/debug_stream.hpp>      // for debug_stream
 
 int main(int argc, char * argv[])
 {
@@ -19,16 +17,16 @@ int main(int argc, char * argv[])
     }
     catch (seqan3::parser_invalid_argument const & ext)
     {
-        debug_stream << "[PARSER ERROR] " << ext.what() << '\n';
+        seqan3::debug_stream << "[PARSER ERROR] " << ext.what() << '\n';
         return 0;
     }
-    debug_stream << "Reading file " << filename << "\n";
+    seqan3::debug_stream << "Reading file " << filename << "\n";
 
     // Create the vector to store sequences of type seqan3::dna5_vector.
     std::vector<seqan3::dna5_vector> sequences;
 
     // Iterate through the file and store the sequences.
-    sequence_file_input file_in{filename};
+    seqan3::sequence_file_input file_in{filename};
     for (auto & [ seq, id, qual ] : file_in)
     {
         sequences.push_back(seq);

--- a/doc/tutorial/introduction/introduction_read_fasta.cpp
+++ b/doc/tutorial/introduction/introduction_read_fasta.cpp
@@ -2,8 +2,8 @@
 #include <string>                            // for std::string
 #include <vector>                            // for std::vector
 #include <seqan3/argument_parser/all.hpp>    // for argument_parser
-#include <seqan3/io/sequence_file/input.hpp> // for sequence_file_input
 #include <seqan3/core/debug_stream.hpp>      // for debug_stream
+#include <seqan3/io/sequence_file/input.hpp> // for sequence_file_input
 
 int main(int argc, char * argv[])
 {

--- a/doc/tutorial/pairwise_alignment/configurations.cpp
+++ b/doc/tutorial/pairwise_alignment/configurations.cpp
@@ -35,15 +35,14 @@ int main()
 {
 {
 //! [aligned_ends]
-using namespace seqan3;
 
-front_end_first fef{std::true_type{}};
-back_end_first bef{std::false_type{}};
-front_end_second fes{true};
-back_end_second bes{false};
+seqan3::front_end_first fef{std::true_type{}};
+seqan3::back_end_first bef{std::false_type{}};
+seqan3::front_end_second fes{true};
+seqan3::back_end_second bes{false};
 
-auto cfg_1 = align_cfg::aligned_ends{end_gaps{fef, bef, fes, bes}};
-auto cfg_2 = align_cfg::aligned_ends{end_gaps{fef, fes}};
+auto cfg_1 = seqan3::align_cfg::aligned_ends{seqan3::end_gaps{fef, bef, fes, bes}};
+auto cfg_2 = seqan3::align_cfg::aligned_ends{seqan3::end_gaps{fef, fes}};
 //! [aligned_ends]
 (void) cfg_1;
 (void) cfg_2;
@@ -51,15 +50,16 @@ auto cfg_2 = align_cfg::aligned_ends{end_gaps{fef, fes}};
 
 {
 //! [scoring_scheme]
-using namespace seqan3;
+using seqan3::operator""_dna4;
+using seqan3::operator""_aa27;
 
 // Define a simple scoring scheme with match and mismatch cost and get the score.
-nucleotide_scoring_scheme nc_scheme{match_score{4}, mismatch_score{-5}};
+seqan3::nucleotide_scoring_scheme nc_scheme{seqan3::match_score{4}, seqan3::mismatch_score{-5}};
 auto sc_nc = nc_scheme.score('A'_dna4, 'C'_dna4); // sc_nc == -5.
 
 // Define a amino acid similarity matrix and get the score.
-aminoacid_scoring_scheme aa_scheme{};
-aa_scheme.set_similarity_matrix(aminoacid_similarity_matrix::BLOSUM30);
+seqan3::aminoacid_scoring_scheme aa_scheme{};
+aa_scheme.set_similarity_matrix(seqan3::aminoacid_similarity_matrix::BLOSUM30);
 auto sc_aa = aa_scheme.score('M'_aa27, 'K'_aa27); // sc_aa == 2.
 //! [scoring_scheme]
 (void) sc_nc;
@@ -68,10 +68,9 @@ auto sc_aa = aa_scheme.score('M'_aa27, 'K'_aa27); // sc_aa == 2.
 
 {
 //! [gap_scheme]
-using namespace seqan3;
 
 // Define a gap scheme with custom gap scores.
-gap_scheme g{gap_score{-1}, gap_open_score{-10}};
+seqan3::gap_scheme g{seqan3::gap_score{-1}, seqan3::gap_open_score{-10}};
 
 auto gap = g.get_gap_score();  // gap == -1
 auto gap_open = g.get_gap_open_score(); // gap_open == -10
@@ -82,30 +81,27 @@ auto gap_open = g.get_gap_open_score(); // gap_open == -10
 
 {
 //! [result]
-using namespace seqan3;
 
 // Configure the alignment to only compute the score.
-auto cfg = align_cfg::result{with_score};
+auto cfg = seqan3::align_cfg::result{seqan3::with_score};
 //! [result]
 (void) cfg;
 }
 
 {
 //! [band]
-using namespace seqan3;
 
 // Configure a banded alignment.
-auto cfg = align_cfg::band{static_band{lower_bound{-4}, upper_bound{4}}};
+auto cfg = seqan3::align_cfg::band{seqan3::static_band{seqan3::lower_bound{-4}, seqan3::upper_bound{4}}};
 //! [band]
 (void) cfg;
 }
 
 {
 //! [edit]
-using namespace seqan3;
 
 // Configure an edit distance alignment.
-auto cfg = align_cfg::edit;
+auto cfg = seqan3::align_cfg::edit;
 //! [edit]
 (void) cfg;
 }

--- a/doc/tutorial/pairwise_alignment/pa_assignment_3_solution.cpp
+++ b/doc/tutorial/pairwise_alignment/pa_assignment_3_solution.cpp
@@ -1,9 +1,9 @@
 #include <utility>
 #include <vector>
 
-#include <seqan3/alignment/scoring/nucleotide_scoring_scheme.hpp>
-#include <seqan3/alignment/scoring/aminoacid_scoring_scheme.hpp>
 #include <seqan3/alignment/pairwise/align_pairwise.hpp>
+#include <seqan3/alignment/scoring/aminoacid_scoring_scheme.hpp>
+#include <seqan3/alignment/scoring/nucleotide_scoring_scheme.hpp>
 #include <seqan3/alphabet/all.hpp>
 #include <seqan3/core/debug_stream.hpp>
 

--- a/doc/tutorial/pairwise_alignment/pa_assignment_3_solution.cpp
+++ b/doc/tutorial/pairwise_alignment/pa_assignment_3_solution.cpp
@@ -29,8 +29,7 @@ int main()
     // Configure the alignment kernel.
     auto config = seqan3::align_cfg::mode{seqan3::global_alignment} |
                   seqan3::align_cfg::scoring{seqan3::aminoacid_scoring_scheme{
-                      seqan3::aminoacid_similarity_matrix::BLOSUM62
-                  }} |
+                      seqan3::aminoacid_similarity_matrix::BLOSUM62}} |
                   seqan3::align_cfg::aligned_ends{seqan3::free_ends_second};
 
     for (auto const & res : seqan3::align_pairwise(source, config))

--- a/doc/tutorial/pairwise_alignment/pa_assignment_3_solution.cpp
+++ b/doc/tutorial/pairwise_alignment/pa_assignment_3_solution.cpp
@@ -7,7 +7,7 @@
 #include <seqan3/alphabet/all.hpp>
 #include <seqan3/core/debug_stream.hpp>
 
-using namespace seqan3;
+using seqan3::operator""_aa27;
 
 int main()
 {
@@ -27,10 +27,12 @@ int main()
     }
 
     // Configure the alignment kernel.
-    auto config = align_cfg::mode{global_alignment} |
-                  align_cfg::scoring{aminoacid_scoring_scheme{aminoacid_similarity_matrix::BLOSUM62}} |
-                  align_cfg::aligned_ends{free_ends_second};
+    auto config = seqan3::align_cfg::mode{seqan3::global_alignment} |
+                  seqan3::align_cfg::scoring{seqan3::aminoacid_scoring_scheme{
+                      seqan3::aminoacid_similarity_matrix::BLOSUM62
+                  }} |
+                  seqan3::align_cfg::aligned_ends{seqan3::free_ends_second};
 
-    for (auto const & res : align_pairwise(source, config))
-        debug_stream << "Score: " << res.score() << '\n';
+    for (auto const & res : seqan3::align_pairwise(source, config))
+        seqan3::debug_stream << "Score: " << res.score() << '\n';
 }

--- a/doc/tutorial/pairwise_alignment/pairwise_alignment_first_global.cpp
+++ b/doc/tutorial/pairwise_alignment/pairwise_alignment_first_global.cpp
@@ -1,7 +1,7 @@
 #include <utility>
 
-#include <seqan3/alignment/scoring/nucleotide_scoring_scheme.hpp>
 #include <seqan3/alignment/pairwise/align_pairwise.hpp>
+#include <seqan3/alignment/scoring/nucleotide_scoring_scheme.hpp>
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/core/debug_stream.hpp>
 

--- a/doc/tutorial/pairwise_alignment/pairwise_alignment_first_global.cpp
+++ b/doc/tutorial/pairwise_alignment/pairwise_alignment_first_global.cpp
@@ -5,19 +5,19 @@
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/core/debug_stream.hpp>
 
-using namespace seqan3;
+using seqan3::operator""_dna4;
 
 int main()
 {
-    dna4_vector s1 = "ACGTGAACTGACT"_dna4;
-    dna4_vector s2 = "ACGAAGACCGAT"_dna4;
+    seqan3::dna4_vector s1 = "ACGTGAACTGACT"_dna4;
+    seqan3::dna4_vector s2 = "ACGAAGACCGAT"_dna4;
 
     // Configure the alignment kernel.
-    auto config = align_cfg::mode{global_alignment} |
-                  align_cfg::scoring{nucleotide_scoring_scheme{}};
+    auto config = seqan3::align_cfg::mode{seqan3::global_alignment} |
+                  seqan3::align_cfg::scoring{seqan3::nucleotide_scoring_scheme{}};
 
     // Invoke the pairwise alignment which returns a lazy range over alignment results.
-    auto results = align_pairwise(std::tie(s1, s2), config);
+    auto results = seqan3::align_pairwise(std::tie(s1, s2), config);
     auto & res = *results.begin();
-    debug_stream << "Score: " << res.score() << '\n';
+    seqan3::debug_stream << "Score: " << res.score() << '\n';
 }

--- a/doc/tutorial/pairwise_alignment/pairwise_alignment_solution_1.cpp
+++ b/doc/tutorial/pairwise_alignment/pairwise_alignment_solution_1.cpp
@@ -1,8 +1,8 @@
 #include <utility>
 #include <vector>
 
-#include <seqan3/alignment/scoring/nucleotide_scoring_scheme.hpp>
 #include <seqan3/alignment/pairwise/align_pairwise.hpp>
+#include <seqan3/alignment/scoring/nucleotide_scoring_scheme.hpp>
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/core/debug_stream.hpp>
 #include <seqan3/range/views/pairwise_combine.hpp>

--- a/doc/tutorial/pairwise_alignment/pairwise_alignment_solution_1.cpp
+++ b/doc/tutorial/pairwise_alignment/pairwise_alignment_solution_1.cpp
@@ -7,7 +7,7 @@
 #include <seqan3/core/debug_stream.hpp>
 #include <seqan3/range/views/pairwise_combine.hpp>
 
-using namespace seqan3;
+using seqan3::operator""_dna4;
 
 int main()
 {
@@ -17,9 +17,9 @@ int main()
                     "AGGTACGAGCGACACT"_dna4};
 
     // Configure the alignment kernel.
-    auto config = align_cfg::mode{global_alignment} |
-                  align_cfg::scoring{nucleotide_scoring_scheme{}};
+    auto config = seqan3::align_cfg::mode{seqan3::global_alignment} |
+                  seqan3::align_cfg::scoring{seqan3::nucleotide_scoring_scheme{}};
 
-    for (auto const & res : align_pairwise(views::pairwise_combine(vec), config))
-        debug_stream << "Score: " << res.score() << '\n';
+    for (auto const & res : seqan3::align_pairwise(seqan3::views::pairwise_combine(vec), config))
+        seqan3::debug_stream << "Score: " << res.score() << '\n';
 }

--- a/doc/tutorial/pairwise_alignment/pairwise_alignment_solution_2.cpp
+++ b/doc/tutorial/pairwise_alignment/pairwise_alignment_solution_2.cpp
@@ -1,8 +1,8 @@
 #include <utility>
 #include <vector>
 
-#include <seqan3/alignment/scoring/nucleotide_scoring_scheme.hpp>
 #include <seqan3/alignment/pairwise/align_pairwise.hpp>
+#include <seqan3/alignment/scoring/nucleotide_scoring_scheme.hpp>
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/core/debug_stream.hpp>
 #include <seqan3/range/views/pairwise_combine.hpp>

--- a/doc/tutorial/pairwise_alignment/pairwise_alignment_solution_2.cpp
+++ b/doc/tutorial/pairwise_alignment/pairwise_alignment_solution_2.cpp
@@ -7,7 +7,7 @@
 #include <seqan3/core/debug_stream.hpp>
 #include <seqan3/range/views/pairwise_combine.hpp>
 
-using namespace seqan3;
+using seqan3::operator""_dna4;
 
 int main()
 {
@@ -17,10 +17,10 @@ int main()
                     "AGGTACGAGCGACACT"_dna4};
 
     // Configure the alignment kernel.
-    auto config = align_cfg::mode{global_alignment} |
-                  align_cfg::scoring{nucleotide_scoring_scheme{}} |
-                  align_cfg::aligned_ends{free_ends_first};
+    auto config = seqan3::align_cfg::mode{seqan3::global_alignment} |
+                  seqan3::align_cfg::scoring{seqan3::nucleotide_scoring_scheme{}} |
+                  seqan3::align_cfg::aligned_ends{seqan3::free_ends_first};
 
-    for (auto const & res : align_pairwise(views::pairwise_combine(vec), config))
-        debug_stream << "Score: " << res.score() << '\n';
+    for (auto const & res : seqan3::align_pairwise(seqan3::views::pairwise_combine(vec), config))
+        seqan3::debug_stream << "Score: " << res.score() << '\n';
 }

--- a/doc/tutorial/pairwise_alignment/pairwise_alignment_solution_3.cpp
+++ b/doc/tutorial/pairwise_alignment/pairwise_alignment_solution_3.cpp
@@ -6,7 +6,7 @@
 #include <seqan3/alphabet/aminoacid/aa27.hpp>
 #include <seqan3/core/debug_stream.hpp>
 
-using namespace seqan3;
+using seqan3::operator""_aa27;
 
 int main()
 {
@@ -14,10 +14,12 @@ int main()
     auto seq2 = "AFLPGWQEENKLSKIWMKDCGCLW"_aa27;
 
     // Configure the alignment kernel.
-    auto config = align_cfg::mode{global_alignment} |
-                  align_cfg::scoring{aminoacid_scoring_scheme{aminoacid_similarity_matrix::BLOSUM62}} |
-                  align_cfg::gap{gap_scheme{gap_score{-2}, gap_open_score{-9}}};
+    auto config = seqan3::align_cfg::mode{seqan3::global_alignment} |
+                  seqan3::align_cfg::scoring{seqan3::aminoacid_scoring_scheme{
+                      seqan3::aminoacid_similarity_matrix::BLOSUM62
+                  }} |
+                  seqan3::align_cfg::gap{seqan3::gap_scheme{seqan3::gap_score{-2}, seqan3::gap_open_score{-9}}};
 
-    for (auto const & res : align_pairwise(std::tie(seq1, seq2), config))
-        debug_stream << "Score: " << res.score() << '\n';
+    for (auto const & res : seqan3::align_pairwise(std::tie(seq1, seq2), config))
+        seqan3::debug_stream << "Score: " << res.score() << '\n';
 }

--- a/doc/tutorial/pairwise_alignment/pairwise_alignment_solution_3.cpp
+++ b/doc/tutorial/pairwise_alignment/pairwise_alignment_solution_3.cpp
@@ -16,8 +16,7 @@ int main()
     // Configure the alignment kernel.
     auto config = seqan3::align_cfg::mode{seqan3::global_alignment} |
                   seqan3::align_cfg::scoring{seqan3::aminoacid_scoring_scheme{
-                      seqan3::aminoacid_similarity_matrix::BLOSUM62
-                  }} |
+                      seqan3::aminoacid_similarity_matrix::BLOSUM62}} |
                   seqan3::align_cfg::gap{seqan3::gap_scheme{seqan3::gap_score{-2}, seqan3::gap_open_score{-9}}};
 
     for (auto const & res : seqan3::align_pairwise(std::tie(seq1, seq2), config))

--- a/doc/tutorial/pairwise_alignment/pairwise_alignment_solution_4.cpp
+++ b/doc/tutorial/pairwise_alignment/pairwise_alignment_solution_4.cpp
@@ -15,8 +15,7 @@ int main()
     // Configure the alignment kernel.
     auto config = seqan3::align_cfg::mode{seqan3::global_alignment} |
                   seqan3::align_cfg::scoring{seqan3::nucleotide_scoring_scheme{
-                      seqan3::match_score{4}, seqan3::mismatch_score{-2}
-                  }} |
+                      seqan3::match_score{4}, seqan3::mismatch_score{-2}}} |
                   seqan3::align_cfg::gap{seqan3::gap_scheme{seqan3::gap_score{-4}}} |
                   seqan3::align_cfg::aligned_ends{seqan3::free_ends_all} |
                   seqan3::align_cfg::result{seqan3::with_alignment};

--- a/doc/tutorial/pairwise_alignment/pairwise_alignment_solution_4.cpp
+++ b/doc/tutorial/pairwise_alignment/pairwise_alignment_solution_4.cpp
@@ -5,7 +5,7 @@
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/core/debug_stream.hpp>
 
-using namespace seqan3;
+using seqan3::operator""_dna4;
 
 int main()
 {
@@ -13,17 +13,19 @@ int main()
     auto seq2 = "GGACGACATGACGTACGACTTTACGTACGACTAGC"_dna4;
 
     // Configure the alignment kernel.
-    auto config = align_cfg::mode{global_alignment} |
-                  align_cfg::scoring{nucleotide_scoring_scheme{match_score{4}, mismatch_score{-2}}} |
-                  align_cfg::gap{gap_scheme{gap_score{-4}}} |
-                  align_cfg::aligned_ends{free_ends_all} |
-                  align_cfg::result{with_alignment};
+    auto config = seqan3::align_cfg::mode{seqan3::global_alignment} |
+                  seqan3::align_cfg::scoring{seqan3::nucleotide_scoring_scheme{
+                      seqan3::match_score{4}, seqan3::mismatch_score{-2}
+                  }} |
+                  seqan3::align_cfg::gap{seqan3::gap_scheme{seqan3::gap_score{-4}}} |
+                  seqan3::align_cfg::aligned_ends{seqan3::free_ends_all} |
+                  seqan3::align_cfg::result{seqan3::with_alignment};
 
-    for (auto const & res : align_pairwise(std::tie(seq1, seq2), config))
+    for (auto const & res : seqan3::align_pairwise(std::tie(seq1, seq2), config))
     {
-        debug_stream << "Score: " << res.score() << '\n';
-        debug_stream << "Begin: " << res.front_coordinate() << '\n';
-        debug_stream << "End: " << res.back_coordinate() << '\n';
-        debug_stream << "Alignment: \n" << res.alignment() << '\n';
+        seqan3::debug_stream << "Score: " << res.score() << '\n';
+        seqan3::debug_stream << "Begin: " << res.front_coordinate() << '\n';
+        seqan3::debug_stream << "End: " << res.back_coordinate() << '\n';
+        seqan3::debug_stream << "Alignment: \n" << res.alignment() << '\n';
     }
 }

--- a/doc/tutorial/pairwise_alignment/pairwise_alignment_solution_5.cpp
+++ b/doc/tutorial/pairwise_alignment/pairwise_alignment_solution_5.cpp
@@ -16,8 +16,7 @@ int main()
     // Configure the alignment kernel.
     auto config = seqan3::align_cfg::mode{seqan3::global_alignment} |
                   seqan3::align_cfg::scoring{seqan3::nucleotide_scoring_scheme{
-                      seqan3::match_score{4}, seqan3::mismatch_score{-2}
-                  }} |
+                      seqan3::match_score{4}, seqan3::mismatch_score{-2}}} |
                   seqan3::align_cfg::gap{seqan3::gap_scheme{seqan3::gap_score{-4}}} |
                   seqan3::align_cfg::aligned_ends{seqan3::free_ends_all} |
                   seqan3::align_cfg::result{seqan3::with_alignment} |

--- a/doc/tutorial/pairwise_alignment/pairwise_alignment_solution_5.cpp
+++ b/doc/tutorial/pairwise_alignment/pairwise_alignment_solution_5.cpp
@@ -6,7 +6,7 @@
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/core/debug_stream.hpp>
 
-using namespace seqan3;
+using seqan3::operator""_dna4;
 
 int main()
 {
@@ -14,18 +14,20 @@ int main()
     auto seq2 = "GGACGACATGACGTACGACTTTACGTACGACTAGC"_dna4;
 
     // Configure the alignment kernel.
-    auto config = align_cfg::mode{global_alignment} |
-                  align_cfg::scoring{nucleotide_scoring_scheme{match_score{4}, mismatch_score{-2}}} |
-                  align_cfg::gap{gap_scheme{gap_score{-4}}} |
-                  align_cfg::aligned_ends{free_ends_all} |
-                  align_cfg::result{with_alignment} |
-                  align_cfg::band{static_band{lower_bound{-3}, upper_bound{8}}};
+    auto config = seqan3::align_cfg::mode{seqan3::global_alignment} |
+                  seqan3::align_cfg::scoring{seqan3::nucleotide_scoring_scheme{
+                      seqan3::match_score{4}, seqan3::mismatch_score{-2}
+                  }} |
+                  seqan3::align_cfg::gap{seqan3::gap_scheme{seqan3::gap_score{-4}}} |
+                  seqan3::align_cfg::aligned_ends{seqan3::free_ends_all} |
+                  seqan3::align_cfg::result{seqan3::with_alignment} |
+                  seqan3::align_cfg::band{seqan3::static_band{seqan3::lower_bound{-3}, seqan3::upper_bound{8}}};
 
-    for (auto const & res : align_pairwise(std::tie(seq1, seq2), config))
+    for (auto const & res : seqan3::align_pairwise(std::tie(seq1, seq2), config))
     {
-        debug_stream << "Score: " << res.score() << '\n';
-        debug_stream << "Begin: " << res.front_coordinate() << '\n';
-        debug_stream << "End: " << res.back_coordinate() << '\n';
-        debug_stream << "Alignment: \n" << res.alignment() << '\n';
+        seqan3::debug_stream << "Score: " << res.score() << '\n';
+        seqan3::debug_stream << "Begin: " << res.front_coordinate() << '\n';
+        seqan3::debug_stream << "End: " << res.back_coordinate() << '\n';
+        seqan3::debug_stream << "Alignment: \n" << res.alignment() << '\n';
     }
 }

--- a/doc/tutorial/pairwise_alignment/pairwise_alignment_solution_6.cpp
+++ b/doc/tutorial/pairwise_alignment/pairwise_alignment_solution_6.cpp
@@ -8,7 +8,7 @@
 #include <seqan3/range/views/pairwise_combine.hpp>
 #include <seqan3/std/ranges>
 
-using namespace seqan3;
+using seqan3::operator""_dna4;
 
 int main()
 {
@@ -18,14 +18,14 @@ int main()
                     "AGGTACGAGCGACACT"_dna4};
 
     // Configure the alignment kernel.
-    auto config = align_cfg::edit |
-                  align_cfg::max_error{7u} |
-                  align_cfg::result{with_score};
+    auto config = seqan3::align_cfg::edit |
+                  seqan3::align_cfg::max_error{7u} |
+                  seqan3::align_cfg::result{seqan3::with_score};
 
     auto filter_v = std::views::filter([](auto && res) { return res.score() >= -6;});
 
-    for (auto const & res : align_pairwise(views::pairwise_combine(vec), config) | views::persist | filter_v)
+    for (auto const & res : seqan3::align_pairwise(seqan3::views::pairwise_combine(vec), config) | seqan3::views::persist | filter_v)
     {
-        debug_stream << "Score: " << res.score() << '\n';
+        seqan3::debug_stream << "Score: " << res.score() << '\n';
     }
 }

--- a/doc/tutorial/ranges/range_solution4.cpp
+++ b/doc/tutorial/ranges/range_solution4.cpp
@@ -4,11 +4,11 @@
 #include <seqan3/argument_parser/all.hpp>                       // include argument parser
 #include <seqan3/range/container/bitcompressed_vector.hpp>      // include bitcompressed vector
 
-using namespace seqan3;
+using seqan3::operator""_dna4;
 
 int main(int argc, char ** argv)
 {
-    argument_parser myparser("Vector-implementations-comparison", argc, argv);
+    seqan3::argument_parser myparser("Vector-implementations-comparison", argc, argv);
     size_t size{};
     bool use_bitvector{};
     myparser.add_positional_option(size, "Size of vector");
@@ -18,21 +18,22 @@ int main(int argc, char ** argv)
     {
          myparser.parse();
     }
-    catch (parser_invalid_argument const & ext)                     // catch user errors
+    catch (seqan3::parser_invalid_argument const & ext)                     // catch user errors
     {
-        debug_stream << "[Error] " << ext.what() << "\n";
+        seqan3::debug_stream << "[Error] " << ext.what() << "\n";
         return -1;
     }
 
     if (use_bitvector)
     {
-        bitcompressed_vector<dna4> vector;
+        seqan3::bitcompressed_vector<seqan3::dna4> vector;
         vector.resize(size, 'A'_dna4);
-        debug_stream << "Allocated bitcompressed_vector<dna4> of size " << vector.size() << std::endl;
+        seqan3::debug_stream << "Allocated seqan3::bitcompressed_vector<seqan3::dna4> of size "
+                             << vector.size() << std::endl;
     }
     else
     {
-        std::vector<dna4> vector{size};
-        debug_stream << "Allocated std::vector<dna4> of size " << vector.size() << std::endl;
+        std::vector<seqan3::dna4> vector{size};
+        seqan3::debug_stream << "Allocated std::vector<seqan3::dna4> of size " << vector.size() << std::endl;
     }
 }

--- a/doc/tutorial/ranges/range_solution4.cpp
+++ b/doc/tutorial/ranges/range_solution4.cpp
@@ -29,11 +29,11 @@ int main(int argc, char ** argv)
         seqan3::bitcompressed_vector<seqan3::dna4> vector;
         vector.resize(size, 'A'_dna4);
         seqan3::debug_stream << "Allocated seqan3::bitcompressed_vector<seqan3::dna4> of size "
-                             << vector.size() << std::endl;
+                             << vector.size() << '\n';
     }
     else
     {
         std::vector<seqan3::dna4> vector{size};
-        seqan3::debug_stream << "Allocated std::vector<seqan3::dna4> of size " << vector.size() << std::endl;
+        seqan3::debug_stream << "Allocated std::vector<seqan3::dna4> of size " << vector.size() << '\n';
     }
 }

--- a/doc/tutorial/read_mapper/read_mapper_indexer_step1.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_indexer_step1.cpp
@@ -1,13 +1,11 @@
 #include <seqan3/argument_parser/all.hpp>
 #include <seqan3/core/debug_stream.hpp>
 
-using namespace seqan3;
-
 void run_program(std::filesystem::path const & reference_path,
                  std::filesystem::path const & index_path)
 {
-    debug_stream << "reference_file_path: " << reference_path << '\n';
-    debug_stream << "index_path           " << index_path << '\n';
+    seqan3::debug_stream << "reference_file_path: " << reference_path << '\n';
+    seqan3::debug_stream << "index_path           " << index_path << '\n';
 }
 
 struct cmd_arguments
@@ -16,21 +14,23 @@ struct cmd_arguments
     std::filesystem::path index_path{"out.index"};
 };
 
-void initialise_argument_parser(argument_parser & parser, cmd_arguments & args)
+void initialise_argument_parser(seqan3::argument_parser & parser, cmd_arguments & args)
 {
     parser.info.author = "E. coli";
     parser.info.short_description = "Creates an index over a reference.";
     parser.info.version = "1.0.0";
-    parser.add_option(args.reference_path, 'r', "reference", "The path to the reference.", option_spec::REQUIRED,
-                      input_file_validator{{"fa","fasta"}});
-    parser.add_option(args.index_path, 'o', "output", "The output index file path.", option_spec::DEFAULT,
-                      output_file_validator{{"index"}});
+    parser.add_option(args.reference_path, 'r', "reference", "The path to the reference.",
+                      seqan3::option_spec::REQUIRED,
+                      seqan3::input_file_validator{{"fa","fasta"}});
+    parser.add_option(args.index_path, 'o', "output", "The output index file path.",
+                      seqan3::option_spec::DEFAULT,
+                      seqan3::output_file_validator{{"index"}});
 }
 
 //![main]
 int main(int argc, char const ** argv)
 {
-    argument_parser parser("Indexer", argc, argv);
+    seqan3::argument_parser parser("Indexer", argc, argv);
     cmd_arguments args{};
 
     initialise_argument_parser(parser, args);
@@ -39,7 +39,7 @@ int main(int argc, char const ** argv)
     {
         parser.parse();
     }
-    catch (parser_invalid_argument const & ext)
+    catch (seqan3::parser_invalid_argument const & ext)
     {
         std::cerr << "[PARSER ERROR] " << ext.what() << '\n';
         return -1;

--- a/doc/tutorial/read_mapper/read_mapper_indexer_step2.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_indexer_step2.cpp
@@ -1,15 +1,13 @@
 #include <seqan3/argument_parser/all.hpp>
-#include <seqan3/io/sequence_file/input.hpp>
 #include <seqan3/core/debug_stream.hpp>
-
-using namespace seqan3;
+#include <seqan3/io/sequence_file/input.hpp>
 
 //! [solution]
 //! [reference_storage_t]
 struct reference_storage_t
 {
     std::vector<std::string> ids;
-    std::vector<std::vector<dna5>> seqs;
+    std::vector<std::vector<seqan3::dna5>> seqs;
 };
 //! [reference_storage_t]
 
@@ -18,20 +16,20 @@ void read_reference(std::filesystem::path const & reference_path,
                     reference_storage_t & storage)
 //! [read_reference]
 {
-    sequence_file_input reference_in{reference_path};
+    seqan3::sequence_file_input reference_in{reference_path};
     for (auto & [seq, id, qual] : reference_in)
     {
         storage.ids.push_back(std::move(id));
         storage.seqs.push_back(std::move(seq));
     }
-    debug_stream << "Reference IDs: " << storage.ids << '\n';
+    seqan3::debug_stream << "Reference IDs: " << storage.ids << '\n';
 }
 
 void run_program(std::filesystem::path const & reference_path,
                  std::filesystem::path const & index_path)
 {
-    debug_stream << "reference_file_path: " << reference_path << '\n';
-    debug_stream << "index_path           " << index_path << '\n';
+    seqan3::debug_stream << "reference_file_path: " << reference_path << '\n';
+    seqan3::debug_stream << "index_path           " << index_path << '\n';
     reference_storage_t storage{};
     read_reference(reference_path, storage);
 }
@@ -43,20 +41,22 @@ struct cmd_arguments
     std::filesystem::path index_path{"out.index"};
 };
 
-void initialise_argument_parser(argument_parser & parser, cmd_arguments & args)
+void initialise_argument_parser(seqan3::argument_parser & parser, cmd_arguments & args)
 {
     parser.info.author = "E. coli";
     parser.info.short_description = "Creates an index over a reference.";
     parser.info.version = "1.0.0";
-    parser.add_option(args.reference_path, 'r', "reference", "The path to the reference.", option_spec::REQUIRED,
-                      input_file_validator{{"fa","fasta"}});
-    parser.add_option(args.index_path, 'o', "output", "The output index file path.", option_spec::DEFAULT,
-                      output_file_validator{{"index"}});
+    parser.add_option(args.reference_path, 'r', "reference", "The path to the reference.",
+                      seqan3::option_spec::REQUIRED,
+                      seqan3::input_file_validator{{"fa","fasta"}});
+    parser.add_option(args.index_path, 'o', "output", "The output index file path.",
+                      seqan3::option_spec::DEFAULT,
+                      seqan3::output_file_validator{{"index"}});
 }
 
 int main(int argc, char const ** argv)
 {
-    argument_parser parser("Indexer", argc, argv);
+    seqan3::argument_parser parser("Indexer", argc, argv);
     cmd_arguments args{};
 
     initialise_argument_parser(parser, args);
@@ -65,7 +65,7 @@ int main(int argc, char const ** argv)
     {
         parser.parse();
     }
-    catch (parser_invalid_argument const & ext)
+    catch (seqan3::parser_invalid_argument const & ext)
     {
         std::cerr << "[PARSER ERROR] " << ext.what() << '\n';
         return -1;

--- a/doc/tutorial/read_mapper/read_mapper_indexer_step3.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_indexer_step3.cpp
@@ -7,22 +7,19 @@
 
 #include <seqan3/argument_parser/all.hpp>
 #include <seqan3/io/sequence_file/input.hpp>
-#include <seqan3/core/debug_stream.hpp>
 #include <seqan3/search/fm_index/bi_fm_index.hpp>
-
-using namespace seqan3;
 
 struct reference_storage_t
 {
     std::vector<std::string> ids;
-    std::vector<std::vector<dna5>> seqs;
+    std::vector<std::vector<seqan3::dna5>> seqs;
 };
 
 //! [solution]
 void read_reference(std::filesystem::path const & reference_path,
                     reference_storage_t & storage)
 {
-    sequence_file_input reference_in{reference_path};
+    seqan3::sequence_file_input reference_in{reference_path};
     for (auto & [seq, id, qual] : reference_in)
     {
         storage.ids.push_back(std::move(id));
@@ -36,7 +33,7 @@ void create_index(std::filesystem::path const & index_path,
                   reference_storage_t & storage)
 //! [create_index]
 {
-    bi_fm_index index{storage.seqs};
+    seqan3::bi_fm_index index{storage.seqs};
     {
         std::ofstream os{index_path, std::ios::binary};
         cereal::BinaryOutputArchive oarchive{os};
@@ -59,20 +56,22 @@ struct cmd_arguments
     std::filesystem::path index_path{"out.index"};
 };
 
-void initialise_argument_parser(argument_parser & parser, cmd_arguments & args)
+void initialise_argument_parser(seqan3::argument_parser & parser, cmd_arguments & args)
 {
     parser.info.author = "E. coli";
     parser.info.short_description = "Creates an index over a reference.";
     parser.info.version = "1.0.0";
-    parser.add_option(args.reference_path, 'r', "reference", "The path to the reference.", option_spec::REQUIRED,
-                      input_file_validator{{"fa","fasta"}});
-    parser.add_option(args.index_path, 'o', "output", "The output index file path.", option_spec::DEFAULT,
-                      output_file_validator{{"index"}});
+    parser.add_option(args.reference_path, 'r', "reference", "The path to the reference.",
+                      seqan3::option_spec::REQUIRED,
+                      seqan3::input_file_validator{{"fa","fasta"}});
+    parser.add_option(args.index_path, 'o', "output", "The output index file path.",
+                      seqan3::option_spec::DEFAULT,
+                      seqan3::output_file_validator{{"index"}});
 }
 
 int main(int argc, char const ** argv)
 {
-    argument_parser parser("Indexer", argc, argv);
+    seqan3::argument_parser parser("Indexer", argc, argv);
     cmd_arguments args{};
 
     initialise_argument_parser(parser, args);
@@ -81,7 +80,7 @@ int main(int argc, char const ** argv)
     {
         parser.parse();
     }
-    catch (parser_invalid_argument const & ext)
+    catch (seqan3::parser_invalid_argument const & ext)
     {
         std::cerr << "[PARSER ERROR] " << ext.what() << '\n';
         return -1;

--- a/doc/tutorial/read_mapper/read_mapper_step1.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_step1.cpp
@@ -1,19 +1,17 @@
 #include <seqan3/argument_parser/all.hpp>
 #include <seqan3/core/debug_stream.hpp>
 
-using namespace seqan3;
-
 void run_program(std::filesystem::path const & reference_path,
                  std::filesystem::path const & query_path,
                  std::filesystem::path const & index_path,
                  std::filesystem::path const & sam_path,
                  uint8_t const errors)
 {
-    debug_stream << "reference_path: " << reference_path << '\n';
-    debug_stream << "query_path:     " << query_path << '\n';
-    debug_stream << "index_path      " << index_path << '\n';
-    debug_stream << "sam_path        " << sam_path << '\n';
-    debug_stream << "errors:         " << errors << '\n';
+    seqan3::debug_stream << "reference_path: " << reference_path << '\n';
+    seqan3::debug_stream << "query_path:     " << query_path << '\n';
+    seqan3::debug_stream << "index_path      " << index_path << '\n';
+    seqan3::debug_stream << "sam_path        " << sam_path << '\n';
+    seqan3::debug_stream << "errors:         " << errors << '\n';
 }
 
 struct cmd_arguments
@@ -25,27 +23,32 @@ struct cmd_arguments
     uint8_t errors{0};
 };
 
-void initialise_argument_parser(argument_parser & parser, cmd_arguments & args)
+void initialise_argument_parser(seqan3::argument_parser & parser, cmd_arguments & args)
 {
     parser.info.author = "E. coli";
     parser.info.short_description = "Map reads against a reference.";
     parser.info.version = "1.0.0";
-    parser.add_option(args.reference_path, 'r', "reference", "The path to the reference.", option_spec::REQUIRED,
-                      input_file_validator{{"fa","fasta"}});
-    parser.add_option(args.query_path, 'q', "query", "The path to the query.", option_spec::REQUIRED,
-                      input_file_validator{{"fq","fastq"}});
-    parser.add_option(args.index_path, 'i', "index", "The path to the index.", option_spec::REQUIRED,
-                      input_file_validator{{"index"}});
-    parser.add_option(args.sam_path, 'o', "output", "The output SAM file path.", option_spec::DEFAULT,
-                      output_file_validator{{"sam"}});
-    parser.add_option(args.errors, 'e', "error", "Maximum allowed errors.", option_spec::DEFAULT,
-                      arithmetic_range_validator{0, 4});
+    parser.add_option(args.reference_path, 'r', "reference", "The path to the reference.",
+                      seqan3::option_spec::REQUIRED,
+                      seqan3::input_file_validator{{"fa","fasta"}});
+    parser.add_option(args.query_path, 'q', "query", "The path to the query.",
+                      seqan3::option_spec::REQUIRED,
+                      seqan3::input_file_validator{{"fq","fastq"}});
+    parser.add_option(args.index_path, 'i', "index", "The path to the index.",
+                      seqan3::option_spec::REQUIRED,
+                      seqan3::input_file_validator{{"index"}});
+    parser.add_option(args.sam_path, 'o', "output", "The output SAM file path.",
+                      seqan3::option_spec::DEFAULT,
+                      seqan3::output_file_validator{{"sam"}});
+    parser.add_option(args.errors, 'e', "error", "Maximum allowed errors.",
+                      seqan3::option_spec::DEFAULT,
+                      seqan3::arithmetic_range_validator{0, 4});
 }
 
 //![main]
 int main(int argc, char const ** argv)
 {
-    argument_parser parser("Mapper", argc, argv);
+    seqan3::argument_parser parser("Mapper", argc, argv);
     cmd_arguments args{};
 
     initialise_argument_parser(parser, args);
@@ -54,7 +57,7 @@ int main(int argc, char const ** argv)
     {
         parser.parse();
     }
-    catch (parser_invalid_argument const & ext)
+    catch (seqan3::parser_invalid_argument const & ext)
     {
         std::cerr << "[PARSER ERROR] " << ext.what() << '\n';
         return -1;

--- a/doc/tutorial/read_mapper/read_mapper_step2.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_step2.cpp
@@ -6,23 +6,21 @@
 #include <cereal/archives/binary.hpp>
 
 #include <seqan3/argument_parser/all.hpp>
-#include <seqan3/io/sequence_file/input.hpp>
 #include <seqan3/core/debug_stream.hpp>
+#include <seqan3/io/sequence_file/input.hpp>
 #include <seqan3/search/algorithm/all.hpp>
-
-using namespace seqan3;
 
 //! [solution]
 struct reference_storage_t
 {
     std::vector<std::string> ids;
-    std::vector<std::vector<dna5>> seqs;
+    std::vector<std::vector<seqan3::dna5>> seqs;
 };
 
 void read_reference(std::filesystem::path const & reference_path,
                     reference_storage_t & storage)
 {
-    sequence_file_input reference_in{reference_path};
+    seqan3::sequence_file_input reference_in{reference_path};
     for (auto & [seq, id, qual] : reference_in)
     {
         storage.ids.push_back(std::move(id));
@@ -38,24 +36,25 @@ void map_reads(std::filesystem::path const & query_path,
                uint8_t const errors)
 //! [map_reads]
 {
-    bi_fm_index<dna5, text_layout::collection> index; // we need the alphabet and text layout before loading
+    // we need the alphabet and text layout before loading
+    seqan3::bi_fm_index<seqan3::dna5, seqan3::text_layout::collection> index;
     {
         std::ifstream is{index_path, std::ios::binary};
         cereal::BinaryInputArchive iarchive{is};
         iarchive(index);
     }
 
-    sequence_file_input query_in{query_path};
+    seqan3::sequence_file_input query_in{query_path};
 
-    configuration const search_config = search_cfg::max_error{search_cfg::total{errors}} |
-                                        search_cfg::mode{search_cfg::all_best};
+    seqan3::configuration const search_config = seqan3::search_cfg::max_error{seqan3::search_cfg::total{errors}} |
+                                                seqan3::search_cfg::mode{seqan3::search_cfg::all_best};
 
-    for (auto & [query, id, qual] : query_in | views::take(20))
+    for (auto & [query, id, qual] : query_in | seqan3::views::take(20))
     {
         auto positions = search(query, index, search_config);
-        debug_stream << "id:           " << id << '\n';
-        debug_stream << "positions:    " << positions << '\n';
-        debug_stream << "======================" << '\n';
+        seqan3::debug_stream << "id:           " << id << '\n';
+        seqan3::debug_stream << "positions:    " << positions << '\n';
+        seqan3::debug_stream << "======================" << '\n';
     }
     (void) sam_path; // prevent unused parameter warning
     (void) storage; // prevent unused parameter warning
@@ -82,26 +81,31 @@ struct cmd_arguments
     uint8_t errors{0};
 };
 
-void initialise_argument_parser(argument_parser & parser, cmd_arguments & args)
+void initialise_argument_parser(seqan3::argument_parser & parser, cmd_arguments & args)
 {
     parser.info.author = "E. coli";
     parser.info.short_description = "Map reads against a reference.";
     parser.info.version = "1.0.0";
-    parser.add_option(args.reference_path, 'r', "reference", "The path to the reference.", option_spec::REQUIRED,
-                      input_file_validator{{"fa","fasta"}});
-    parser.add_option(args.query_path, 'q', "query", "The path to the query.", option_spec::REQUIRED,
-                      input_file_validator{{"fq","fastq"}});
-    parser.add_option(args.index_path, 'i', "index", "The path to the index.", option_spec::REQUIRED,
-                      input_file_validator{{"index"}});
-    parser.add_option(args.sam_path, 'o', "output", "The output SAM file path.", option_spec::DEFAULT,
-                      output_file_validator{{"sam"}});
-    parser.add_option(args.errors, 'e', "error", "Maximum allowed errors.", option_spec::DEFAULT,
-                      arithmetic_range_validator{0, 4});
+    parser.add_option(args.reference_path, 'r', "reference", "The path to the reference.",
+                      seqan3::option_spec::REQUIRED,
+                      seqan3::input_file_validator{{"fa","fasta"}});
+    parser.add_option(args.query_path, 'q', "query", "The path to the query.",
+                      seqan3::option_spec::REQUIRED,
+                      seqan3::input_file_validator{{"fq","fastq"}});
+    parser.add_option(args.index_path, 'i', "index", "The path to the index.",
+                      seqan3::option_spec::REQUIRED,
+                      seqan3::input_file_validator{{"index"}});
+    parser.add_option(args.sam_path, 'o', "output", "The output SAM file path.",
+                      seqan3::option_spec::DEFAULT,
+                      seqan3::output_file_validator{{"sam"}});
+    parser.add_option(args.errors, 'e', "error", "Maximum allowed errors.",
+                      seqan3::option_spec::DEFAULT,
+                      seqan3::arithmetic_range_validator{0, 4});
 }
 
 int main(int argc, char const ** argv)
 {
-    argument_parser parser("Mapper", argc, argv);
+    seqan3::argument_parser parser("Mapper", argc, argv);
     cmd_arguments args{};
 
     initialise_argument_parser(parser, args);
@@ -110,7 +114,7 @@ int main(int argc, char const ** argv)
     {
         parser.parse();
     }
-    catch (parser_invalid_argument const & ext)
+    catch (seqan3::parser_invalid_argument const & ext)
     {
         std::cerr << "[PARSER ERROR] " << ext.what() << '\n';
         return -1;

--- a/doc/tutorial/read_mapper/read_mapper_step4.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_step4.cpp
@@ -10,22 +10,19 @@
 #include <seqan3/argument_parser/all.hpp>
 #include <seqan3/io/alignment_file/output.hpp>
 #include <seqan3/io/sequence_file/input.hpp>
-#include <seqan3/core/debug_stream.hpp>
 #include <seqan3/search/algorithm/all.hpp>
 #include <seqan3/std/span>
-
-using namespace seqan3;
 
 struct reference_storage_t
 {
     std::vector<std::string> ids;
-    std::vector<std::vector<dna5>> seqs;
+    std::vector<std::vector<seqan3::dna5>> seqs;
 };
 
 void read_reference(std::filesystem::path const & reference_path,
                     reference_storage_t & storage)
 {
-    sequence_file_input reference_in{reference_path};
+    seqan3::sequence_file_input reference_in{reference_path};
     for (auto & [seq, id, qual] : reference_in)
     {
         storage.ids.push_back(std::move(id));
@@ -40,31 +37,32 @@ void map_reads(std::filesystem::path const & query_path,
                reference_storage_t & storage,
                uint8_t const errors)
 {
-    bi_fm_index<dna5, text_layout::collection> index; // we need the alphabet and text layout before loading
+    // we need the alphabet and text layout before loading
+    seqan3::bi_fm_index<seqan3::dna5, seqan3::text_layout::collection> index;
     {
         std::ifstream is{index_path, std::ios::binary};
         cereal::BinaryInputArchive iarchive{is};
         iarchive(index);
     }
 
-    sequence_file_input query_in{query_path};
+    seqan3::sequence_file_input query_in{query_path};
 
 //! [alignment_file_output]
-    alignment_file_output sam_out{sam_path, fields<field::seq,
-                                                   field::id,
-                                                   field::ref_id,
-                                                   field::ref_offset,
-                                                   field::alignment,
-                                                   field::qual,
-                                                   field::mapq>{}};
+    seqan3::alignment_file_output sam_out{sam_path, seqan3::fields<seqan3::field::seq,
+                                                                   seqan3::field::id,
+                                                                   seqan3::field::ref_id,
+                                                                   seqan3::field::ref_offset,
+                                                                   seqan3::field::alignment,
+                                                                   seqan3::field::qual,
+                                                                   seqan3::field::mapq>{}};
 //! [alignment_file_output]
 
-    configuration const search_config = search_cfg::max_error{search_cfg::total{errors}} |
-                                        search_cfg::mode{search_cfg::all_best};
+    seqan3::configuration const search_config = seqan3::search_cfg::max_error{seqan3::search_cfg::total{errors}} |
+                                                seqan3::search_cfg::mode{seqan3::search_cfg::all_best};
 
-    configuration const align_config = align_cfg::edit |
-                                       align_cfg::aligned_ends{free_ends_first} |
-                                       align_cfg::result{with_alignment};
+    seqan3::configuration const align_config = seqan3::align_cfg::edit |
+                                               seqan3::align_cfg::aligned_ends{seqan3::free_ends_first} |
+                                               seqan3::align_cfg::result{seqan3::with_alignment};
 
     for (auto & [query, id, qual] : query_in)
     {
@@ -74,7 +72,7 @@ void map_reads(std::filesystem::path const & query_path,
             size_t start = pos ? pos - 1 : 0;
             std::span text_view{std::data(storage.seqs[idx]) + start, query.size() + 1};
 
-            for (auto && alignment : align_pairwise(std::tie(text_view, query), align_config))
+            for (auto && alignment : seqan3::align_pairwise(std::tie(text_view, query), align_config))
             {
                 auto aligned_seq = alignment.alignment();
                 size_t ref_offset = alignment.front_coordinate().first + 2 + start;
@@ -107,26 +105,31 @@ struct cmd_arguments
     uint8_t errors{0};
 };
 
-void initialise_argument_parser(argument_parser & parser, cmd_arguments & args)
+void initialise_argument_parser(seqan3::argument_parser & parser, cmd_arguments & args)
 {
     parser.info.author = "E. coli";
     parser.info.short_description = "Map reads against a reference.";
     parser.info.version = "1.0.0";
-    parser.add_option(args.reference_path, 'r', "reference", "The path to the reference.", option_spec::REQUIRED,
-                      input_file_validator{{"fa","fasta"}});
-    parser.add_option(args.query_path, 'q', "query", "The path to the query.", option_spec::REQUIRED,
-                      input_file_validator{{"fq","fastq"}});
-    parser.add_option(args.index_path, 'i', "index", "The path to the index.", option_spec::REQUIRED,
-                      input_file_validator{{"index"}});
-    parser.add_option(args.sam_path, 'o', "output", "The output SAM file path.", option_spec::DEFAULT,
-                      output_file_validator{{"sam"}});
-    parser.add_option(args.errors, 'e', "error", "Maximum allowed errors.", option_spec::DEFAULT,
-                      arithmetic_range_validator{0, 4});
+    parser.add_option(args.reference_path, 'r', "reference", "The path to the reference.",
+                      seqan3::option_spec::REQUIRED,
+                      seqan3::input_file_validator{{"fa","fasta"}});
+    parser.add_option(args.query_path, 'q', "query", "The path to the query.",
+                      seqan3::option_spec::REQUIRED,
+                      seqan3::input_file_validator{{"fq","fastq"}});
+    parser.add_option(args.index_path, 'i', "index", "The path to the index.",
+                      seqan3::option_spec::REQUIRED,
+                      seqan3::input_file_validator{{"index"}});
+    parser.add_option(args.sam_path, 'o', "output", "The output SAM file path.",
+                      seqan3::option_spec::DEFAULT,
+                      seqan3::output_file_validator{{"sam"}});
+    parser.add_option(args.errors, 'e', "error", "Maximum allowed errors.",
+                      seqan3::option_spec::DEFAULT,
+                      seqan3::arithmetic_range_validator{0, 4});
 }
 
 int main(int argc, char const ** argv)
 {
-    argument_parser parser("Mapper", argc, argv);
+    seqan3::argument_parser parser("Mapper", argc, argv);
     cmd_arguments args{};
 
     initialise_argument_parser(parser, args);
@@ -135,7 +138,7 @@ int main(int argc, char const ** argv)
     {
         parser.parse();
     }
-    catch (parser_invalid_argument const & ext)
+    catch (seqan3::parser_invalid_argument const & ext)
     {
         std::cerr << "[PARSER ERROR] " << ext.what() << '\n';
         return -1;

--- a/doc/tutorial/search/search_basic_index.cpp
+++ b/doc/tutorial/search/search_basic_index.cpp
@@ -1,11 +1,9 @@
 #include <seqan3/search/fm_index/bi_fm_index.hpp>   // for using the bi_fm_index
 #include <seqan3/search/fm_index/fm_index.hpp>      // for using the fm_index
 
-using namespace seqan3;
-
 int main()
 {
     std::string text{"Garfield the fat cat without a hat."};
-    fm_index index{text};        // unidirectional index on single text
-    bi_fm_index bi_index{text};  // bidirectional index on single text
+    seqan3::fm_index index{text};        // unidirectional index on single text
+    seqan3::bi_fm_index bi_index{text};  // bidirectional index on single text
 }

--- a/doc/tutorial/search/search_basic_search.cpp
+++ b/doc/tutorial/search/search_basic_search.cpp
@@ -1,12 +1,11 @@
 #include <seqan3/core/debug_stream.hpp>       // pretty printing
 #include <seqan3/search/algorithm/search.hpp> // this already includes (bi)_fm_index
 
-using namespace seqan3;
 using namespace std::string_literals; // for using the ""s string literal
 
 int main()
 {
     std::string text{"Garfield the fat cat without a hat."};
-    fm_index index{text};
-    debug_stream << search("cat"s, index) << '\n'; // [17]
+    seqan3::fm_index index{text};
+    seqan3::debug_stream << search("cat"s, index) << '\n'; // [17]
 }

--- a/doc/tutorial/search/search_small_snippets.cpp
+++ b/doc/tutorial/search/search_small_snippets.cpp
@@ -13,7 +13,6 @@ seqan3::cleanup index_file{"index.file"};
 #include <seqan3/search/fm_index/fm_index.hpp>
 #include <seqan3/std/filesystem>
 
-using namespace seqan3;
 using namespace std::string_literals;
 
 int main()
@@ -24,8 +23,8 @@ int main()
 std::vector<std::string> text{{"Garfield the fat cat without a hat."},
                               {"He is infinite, he is eternal."},
                               {"Yet another text I have to think about."}};
-fm_index index{text};
-bi_fm_index bi_index{text};
+seqan3::fm_index index{text};
+seqan3::bi_fm_index bi_index{text};
 //![text_collection]
 }
 
@@ -37,7 +36,7 @@ bi_fm_index bi_index{text};
 #include <cereal/archives/binary.hpp>               // for storing/loading indices via cereal
 
 std::string text{"Garfield the fat cat without a hat."};
-fm_index index{text};
+seqan3::fm_index index{text};
 {
     std::ofstream os{"index.file", std::ios::binary};
     cereal::BinaryOutputArchive oarchive{os};
@@ -49,7 +48,7 @@ fm_index index{text};
 {
 //![load]
 // we need to tell the index that we work on a single text and a `char` alphabet before loading
-fm_index<char, text_layout::single> index;
+seqan3::fm_index<char, seqan3::text_layout::single> index;
 {
     std::ifstream is{"index.file", std::ios::binary};
     cereal::BinaryInputArchive iarchive{is};
@@ -62,50 +61,50 @@ fm_index<char, text_layout::single> index;
 {
 //![error_search]
 std::string text{"Garfield the fat cat without a hat."};
-fm_index index{text};
-configuration const cfg = search_cfg::max_error{search_cfg::total{1},
-                                                search_cfg::substitution{0},
-                                                search_cfg::insertion{1},
-                                                search_cfg::deletion{1}};
-debug_stream << search("cat"s, index, cfg) << '\n'; // [14,17,18,32]
+seqan3::fm_index index{text};
+seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::total{1},
+                                                                seqan3::search_cfg::substitution{0},
+                                                                seqan3::search_cfg::insertion{1},
+                                                                seqan3::search_cfg::deletion{1}};
+seqan3::debug_stream << search("cat"s, index, cfg) << '\n'; // [14,17,18,32]
 //![error_search]
 }
 
 {
 //![multiple_queries]
 std::string text{"Garfield the fat cat without a hat."};
-fm_index index{text};
+seqan3::fm_index index{text};
 std::vector<std::string> query{"cat"s, "hat"s};
-debug_stream << search(query, index) << '\n'; // [[17],[31]]
+seqan3::debug_stream << search(query, index) << '\n'; // [[17],[31]]
 //![multiple_queries]
 }
 
 {
 //![error_sum]
-configuration const cfg = search_cfg::max_error{search_cfg::total{2},
-                                                search_cfg::substitution{2},
-                                                search_cfg::insertion{1},
-                                                search_cfg::deletion{1}};
+seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::total{2},
+                                                                seqan3::search_cfg::substitution{2},
+                                                                seqan3::search_cfg::insertion{1},
+                                                                seqan3::search_cfg::deletion{1}};
 //![error_sum]
 }
 
 {
 //![mode_best]
-configuration const cfg = search_cfg::max_error{search_cfg::total{1},
-                                                search_cfg::substitution{0},
-                                                search_cfg::insertion{1},
-                                                search_cfg::deletion{1}} |
-                          search_cfg::mode{search_cfg::best};
+seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::total{1},
+                                                                seqan3::search_cfg::substitution{0},
+                                                                seqan3::search_cfg::insertion{1},
+                                                                seqan3::search_cfg::deletion{1}} |
+                                                                seqan3::search_cfg::mode{seqan3::search_cfg::best};
 //![mode_best]
 }
 
 {
 //![mode_strata]
-configuration const cfg = search_cfg::max_error{search_cfg::total{2},
-                                                search_cfg::substitution{0},
-                                                search_cfg::insertion{1},
-                                                search_cfg::deletion{1}} |
-                          search_cfg::mode{search_cfg::strata{2}};
+seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::total{2},
+                                                                seqan3::search_cfg::substitution{0},
+                                                                seqan3::search_cfg::insertion{1},
+                                                                seqan3::search_cfg::deletion{1}} |
+                                                                seqan3::search_cfg::mode{seqan3::search_cfg::strata{2}};
 //![mode_strata]
 }
 

--- a/doc/tutorial/search/search_solution1.cpp
+++ b/doc/tutorial/search/search_solution1.cpp
@@ -10,12 +10,13 @@ seqan3::cleanup index_file{"index.file"};
 
 #include <seqan3/search/fm_index/fm_index.hpp>
 
-using namespace seqan3;
+using seqan3::operator""_dna4;
 
 int main()
 {
-    dna4_vector text{"CGCTGTCTGAAGGATGAGTGTCAGCCAGTGTAACCCGATGAGCTACCCAGTAGTCGAACTGGGCCAGACAACCCGGCGCTAATGCACTCA"_dna4};
-    fm_index index{text};
+    seqan3::dna4_vector
+                text{"CGCTGTCTGAAGGATGAGTGTCAGCCAGTGTAACCCGATGAGCTACCCAGTAGTCGAACTGGGCCAGACAACCCGGCGCTAATGCACTCA"_dna4};
+    seqan3::fm_index index{text};
 
     {
         std::ofstream os{"index.file", std::ios::binary};
@@ -24,7 +25,7 @@ int main()
     }
 
     // we need to tell the index that we work on a single text and a `dna4` alphabet before loading
-    fm_index<dna4, text_layout::single> index2;
+    seqan3::fm_index<seqan3::dna4, seqan3::text_layout::single> index2;
     {
         std::ifstream is{"index.file", std::ios::binary};
         cereal::BinaryInputArchive iarchive{is};

--- a/doc/tutorial/search/search_solution2.cpp
+++ b/doc/tutorial/search/search_solution2.cpp
@@ -1,37 +1,38 @@
 #include <seqan3/core/debug_stream.hpp>
 #include <seqan3/search/algorithm/search.hpp>
 
-using namespace seqan3;
+using seqan3::operator""_dna4;
 
 void run_text_single()
 {
-    dna4_vector text{"CGCTGTCTGAAGGATGAGTGTCAGCCAGTGTAACCCGATGAGCTACCCAGTAGTCGAACTGGGCCAGACAACCCGGCGCTAATGCACTCA"_dna4};
-    fm_index index{text};
+    seqan3::dna4_vector
+                text{"CGCTGTCTGAAGGATGAGTGTCAGCCAGTGTAACCCGATGAGCTACCCAGTAGTCGAACTGGGCCAGACAACCCGGCGCTAATGCACTCA"_dna4};
+    seqan3::fm_index index{text};
 
     auto results = search("GCT"_dna4, index);
     std::ranges::sort(results);
-    debug_stream << "=====   Running on a single text   =====\n";
-    debug_stream << "There are " << results.size() << " hits.\n";
-    debug_stream << "The positions are " << results << '\n';
+    seqan3::debug_stream << "=====   Running on a single text   =====\n";
+    seqan3::debug_stream << "There are " << results.size() << " hits.\n";
+    seqan3::debug_stream << "The positions are " << results << '\n';
 }
 
 void run_text_collection()
 {
-    std::vector<dna4_vector> text{"CGCTGTCTGAAGGATGAGTGTCAGCCAGTGTA"_dna4,
-                                  "ACCCGATGAGCTACCCAGTAGTCGAACTG"_dna4,
-                                  "GGCCAGACAACCCGGCGCTAATGCACTCA"_dna4};
-    fm_index index{text};
+    std::vector<seqan3::dna4_vector> text{"CGCTGTCTGAAGGATGAGTGTCAGCCAGTGTA"_dna4,
+                                          "ACCCGATGAGCTACCCAGTAGTCGAACTG"_dna4,
+                                          "GGCCAGACAACCCGGCGCTAATGCACTCA"_dna4};
+    seqan3::fm_index index{text};
 
     auto results = search("GCT"_dna4, index);
     std::ranges::sort(results);
-    debug_stream << "===== Running on a text collection =====\n";
-    debug_stream << "There are " << results.size() << " hits.\n";
-    debug_stream << "The positions are " << results << '\n';
+    seqan3::debug_stream << "===== Running on a text collection =====\n";
+    seqan3::debug_stream << "There are " << results.size() << " hits.\n";
+    seqan3::debug_stream << "The positions are " << results << '\n';
 }
 
 int main()
 {
    run_text_single();
-   debug_stream << '\n';
+   seqan3::debug_stream << '\n';
    run_text_collection();
 }

--- a/doc/tutorial/search/search_solution3.cpp
+++ b/doc/tutorial/search/search_solution3.cpp
@@ -2,24 +2,25 @@
 #include <seqan3/search/algorithm/search.hpp>
 #include <seqan3/std/span>
 
-using namespace seqan3;
+using seqan3::operator""_dna4;
 
 int main()
 {
-    dna4_vector text{"CGCTGTCTGAAGGATGAGTGTCAGCCAGTGTAACCCGATGAGCTACCCAGTAGTCGAACTGGGCCAGACAACCCGGCGCTAATGCACTCA"_dna4};
-    fm_index index{text};
+    seqan3::dna4_vector
+                text{"CGCTGTCTGAAGGATGAGTGTCAGCCAGTGTAACCCGATGAGCTACCCAGTAGTCGAACTGGGCCAGACAACCCGGCGCTAATGCACTCA"_dna4};
+    seqan3::fm_index index{text};
 
-    configuration const cfg = search_cfg::max_error{search_cfg::substitution{1}};
+    seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::substitution{1}};
 
     auto results = search("GCT"_dna4, index, cfg);
     std::ranges::sort(results);
 
-    debug_stream << "There are " << results.size() << " hits.\n";
+    seqan3::debug_stream << "There are " << results.size() << " hits.\n";
 
     for (auto && pos : results)
     {
-        debug_stream << "At position " << pos << ": "
-                     << std::span{std::data(text) + pos, 3}
-                     << '\n';
+        seqan3::debug_stream << "At position " << pos << ": "
+                             << std::span{std::data(text) + pos, 3}
+                             << '\n';
     }
 }

--- a/doc/tutorial/search/search_solution4.cpp
+++ b/doc/tutorial/search/search_solution4.cpp
@@ -1,36 +1,37 @@
 #include <seqan3/core/debug_stream.hpp>
 #include <seqan3/search/algorithm/search.hpp>
 
-using namespace seqan3;
+using seqan3::operator""_dna4;
 
 int main()
 {
-    dna4_vector text{"CGCTGTCTGAAGGATGAGTGTCAGCCAGTGTAACCCGATGAGCTACCCAGTAGTCGAACTGGGCCAGACAACCCGGCGCTAATGCACTCA"_dna4};
-    dna4_vector query{"GCT"_dna4};
+    seqan3::dna4_vector
+                text{"CGCTGTCTGAAGGATGAGTGTCAGCCAGTGTAACCCGATGAGCTACCCAGTAGTCGAACTGGGCCAGACAACCCGGCGCTAATGCACTCA"_dna4};
+    seqan3::dna4_vector query{"GCT"_dna4};
 
-    fm_index index{text};
+    seqan3::fm_index index{text};
 
-    debug_stream << "Searching all hits\n";
-    configuration const cfg_all = search_cfg::max_error{search_cfg::total{1}} |
-                                  search_cfg::mode{search_cfg::all};
+    seqan3::debug_stream << "Searching all hits\n";
+    seqan3::configuration const cfg_all = seqan3::search_cfg::max_error{seqan3::search_cfg::total{1}} |
+                                          seqan3::search_cfg::mode{seqan3::search_cfg::all};
     auto results_all = search(query, index, cfg_all);
-    debug_stream << "There are " << results_all.size() << " hits.\n";
+    seqan3::debug_stream << "There are " << results_all.size() << " hits.\n";
 
-    debug_stream << "Searching all best hits\n";
-    configuration const cfg_all_best = search_cfg::max_error{search_cfg::total{1}} |
-                                       search_cfg::mode{search_cfg::all_best};
+    seqan3::debug_stream << "Searching all best hits\n";
+    seqan3::configuration const cfg_all_best = seqan3::search_cfg::max_error{seqan3::search_cfg::total{1}} |
+                                               seqan3::search_cfg::mode{seqan3::search_cfg::all_best};
     auto results_all_best = search(query, index, cfg_all_best);
-    debug_stream << "There are " << results_all_best.size() << " hits.\n";
+    seqan3::debug_stream << "There are " << results_all_best.size() << " hits.\n";
 
-    debug_stream << "Searching best hit\n";
-    configuration const cfg_best = search_cfg::max_error{search_cfg::total{1}} |
-                                   search_cfg::mode{search_cfg::best};
+    seqan3::debug_stream << "Searching best hit\n";
+    seqan3::configuration const cfg_best = seqan3::search_cfg::max_error{seqan3::search_cfg::total{1}} |
+                                           seqan3::search_cfg::mode{seqan3::search_cfg::best};
     auto results_best = search(query, index, cfg_best);
-    debug_stream << "There is " << results_best.size() << " hit.\n";
+    seqan3::debug_stream << "There is " << results_best.size() << " hit.\n";
 
-    debug_stream << "Searching all hits in the 1-stratum\n";
-    configuration const cfg_strata = search_cfg::max_error{search_cfg::total{1}} |
-                                     search_cfg::mode{search_cfg::strata{1}};
+    seqan3::debug_stream << "Searching all hits in the 1-stratum\n";
+    seqan3::configuration const cfg_strata = seqan3::search_cfg::max_error{seqan3::search_cfg::total{1}} |
+                                             seqan3::search_cfg::mode{seqan3::search_cfg::strata{1}};
     auto results_strata = search(query, index, cfg_strata);
-    debug_stream << "There are " << results_strata.size() << " hits.\n";
+    seqan3::debug_stream << "There are " << results_strata.size() << " hits.\n";
 }

--- a/doc/tutorial/search/search_solution5.cpp
+++ b/doc/tutorial/search/search_solution5.cpp
@@ -4,26 +4,27 @@
 #include <seqan3/search/algorithm/search.hpp>
 #include <seqan3/std/span>
 
-using namespace seqan3;
+using seqan3::operator""_dna4;
 
 void run_text_single()
 {
-    dna4_vector text{"CGCTGTCTGAAGGATGAGTGTCAGCCAGTGTAACCCGATGAGCTACCCAGTAGTCGAACTGGGCCAGACAACCCGGCGCTAATGCACTCA"_dna4};
-    dna4_vector query{"GCT"_dna4};
-    fm_index index{text};
+    seqan3::dna4_vector
+                text{"CGCTGTCTGAAGGATGAGTGTCAGCCAGTGTAACCCGATGAGCTACCCAGTAGTCGAACTGGGCCAGACAACCCGGCGCTAATGCACTCA"_dna4};
+    seqan3::dna4_vector query{"GCT"_dna4};
+    seqan3::fm_index index{text};
 
-    debug_stream << "Searching all best hits allowing for 1 error in a single text\n";
+    seqan3::debug_stream << "Searching all best hits allowing for 1 error in a single text\n";
 
-    configuration const search_config = search_cfg::max_error{search_cfg::total{1}} |
-                                        search_cfg::mode{search_cfg::all_best};
-    configuration const align_config = align_cfg::edit |
-                                       align_cfg::aligned_ends{free_ends_first} |
-                                       align_cfg::result{with_alignment};
+    seqan3::configuration const search_config = seqan3::search_cfg::max_error{seqan3::search_cfg::total{1}} |
+                                                seqan3::search_cfg::mode{seqan3::search_cfg::all_best};
+    seqan3::configuration const align_config = seqan3::align_cfg::edit |
+                                               seqan3::align_cfg::aligned_ends{seqan3::free_ends_first} |
+                                               seqan3::align_cfg::result{seqan3::with_alignment};
 
     auto results = search(query, index, search_config);
 
-    debug_stream << "There are " << results.size() << " hits.\n";
-    debug_stream << "-----------------\n";
+    seqan3::debug_stream << "There are " << results.size() << " hits.\n";
+    seqan3::debug_stream << "-----------------\n";
 
     for (auto && pos : results)
     {
@@ -33,34 +34,34 @@ void run_text_single()
         for (auto && res : align_pairwise(std::tie(text_view, query), align_config))
         {
             auto && [aligned_database, aligned_query] = res.alignment();
-            debug_stream << "score:    " << res.score() << '\n';
-            debug_stream << "database: " << aligned_database << '\n';
-            debug_stream << "query:    "  << aligned_query << '\n';
-            debug_stream << "=============\n";
+            seqan3::debug_stream << "score:    " << res.score() << '\n';
+            seqan3::debug_stream << "database: " << aligned_database << '\n';
+            seqan3::debug_stream << "query:    "  << aligned_query << '\n';
+            seqan3::debug_stream << "=============\n";
         }
     }
 }
 
 void run_text_collection()
 {
-    std::vector<dna4_vector> text{"CGCTGTCTGAAGGATGAGTGTCAGCCAGTGTA"_dna4,
-                                  "ACCCGATGAGCTACCCAGTAGTCGAACTG"_dna4,
-                                  "GGCCAGACAACCCGGCGCTAATGCACTCA"_dna4};
-    dna4_vector query{"GCT"_dna4};
-    fm_index index{text};
+    std::vector<seqan3::dna4_vector> text{"CGCTGTCTGAAGGATGAGTGTCAGCCAGTGTA"_dna4,
+                                          "ACCCGATGAGCTACCCAGTAGTCGAACTG"_dna4,
+                                          "GGCCAGACAACCCGGCGCTAATGCACTCA"_dna4};
+    seqan3::dna4_vector query{"GCT"_dna4};
+    seqan3::fm_index index{text};
 
-    debug_stream << "Searching all best hits allowing for 1 error in a text collection\n";
+    seqan3::debug_stream << "Searching all best hits allowing for 1 error in a text collection\n";
 
-    configuration const search_config = search_cfg::max_error{search_cfg::total{1}} |
-                                        search_cfg::mode{search_cfg::all_best};
-    configuration const align_config = align_cfg::edit |
-                                       align_cfg::aligned_ends{free_ends_first} |
-                                       align_cfg::result{with_alignment};
+    seqan3::configuration const search_config = seqan3::search_cfg::max_error{seqan3::search_cfg::total{1}} |
+                                                seqan3::search_cfg::mode{seqan3::search_cfg::all_best};
+    seqan3::configuration const align_config = seqan3::align_cfg::edit |
+                                               seqan3::align_cfg::aligned_ends{seqan3::free_ends_first} |
+                                               seqan3::align_cfg::result{seqan3::with_alignment};
 
     auto results = search(query, index, search_config);
 
-    debug_stream << "There are " << results.size() << " hits.\n";
-    debug_stream << "-----------------\n";
+    seqan3::debug_stream << "There are " << results.size() << " hits.\n";
+    seqan3::debug_stream << "-----------------\n";
 
     for (auto [idx, pos] : results)
     {
@@ -70,10 +71,10 @@ void run_text_collection()
         for (auto && res : align_pairwise(std::tie(text_view, query), align_config))
         {
             auto && [aligned_database, aligned_query] = res.alignment();
-            debug_stream << "score:    " << res.score() << '\n';
-            debug_stream << "database: " << aligned_database << '\n';
-            debug_stream << "query:    "  << aligned_query << '\n';
-            debug_stream << "=============\n";
+            seqan3::debug_stream << "score:    " << res.score() << '\n';
+            seqan3::debug_stream << "database: " << aligned_database << '\n';
+            seqan3::debug_stream << "query:    "  << aligned_query << '\n';
+            seqan3::debug_stream << "=============\n";
         }
     }
 }
@@ -81,6 +82,6 @@ void run_text_collection()
 int main()
 {
    run_text_single();
-   debug_stream << '\n';
+   seqan3::debug_stream << '\n';
    run_text_collection();
 }

--- a/doc/tutorial/search/search_span.cpp
+++ b/doc/tutorial/search/search_span.cpp
@@ -1,8 +1,6 @@
 #include <seqan3/core/debug_stream.hpp>
 #include <seqan3/std/span>
 
-using namespace seqan3;
-
 int main()
 {
     std::string text{"Garfield the fat cat without a hat."};
@@ -11,5 +9,5 @@ int main()
 
     std::span text_view{std::data(text) + start, span}; // represent interval [2, 4]
 
-    debug_stream << text_view << '\n'; // Prints "rfi"
+    seqan3::debug_stream << text_view << '\n'; // Prints "rfi"
 }

--- a/doc/tutorial/sequence_file/sequence_file_snippets.cpp
+++ b/doc/tutorial/sequence_file/sequence_file_snippets.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 #include <fstream>
 
 #include <range/v3/numeric/accumulate.hpp>   // ranges::accumulate
@@ -80,7 +79,7 @@ int main()
 
 {
 //![file_extensions]
-seqan3::debug_stream << seqan3::format_fastq::file_extensions << std::endl; // prints [fastq,fq]
+seqan3::debug_stream << seqan3::format_fastq::file_extensions << '\n'; // prints [fastq,fq]
 //![file_extensions]
 
 //![modify_file_extensions]

--- a/doc/tutorial/sequence_file/sequence_file_snippets.cpp
+++ b/doc/tutorial/sequence_file/sequence_file_snippets.cpp
@@ -75,39 +75,37 @@ IIIIHHGIIIIHHGIIIH
 
 write_file_dummy_struct go{}; // write file
 
-using namespace seqan3;
-
 int main()
 {
 
 {
 //![file_extensions]
-debug_stream << format_fastq::file_extensions << std::endl; // prints [fastq,fq]
+seqan3::debug_stream << seqan3::format_fastq::file_extensions << std::endl; // prints [fastq,fq]
 //![file_extensions]
 
 //![modify_file_extensions]
-format_fastq::file_extensions.push_back("qq");
-sequence_file_input fin{std::filesystem::temp_directory_path()/"my.qq"}; // detects FASTQ format
+seqan3::format_fastq::file_extensions.push_back("qq");
+seqan3::sequence_file_input fin{std::filesystem::temp_directory_path()/"my.qq"}; // detects FASTQ format
 //![modify_file_extensions]
 }
 
 {
 /*
 //![construct_from_cin]
-sequence_file_input fin{std::cin, format_fasta{}};
+seqan3::sequence_file_input fin{std::cin, format_fasta{}};
 //![construct_from_cin]
 */
 }
 
 {
 //![amino_acid_type_trait]
-sequence_file_input<sequence_file_input_default_traits_aa> fin{std::filesystem::temp_directory_path()/"my.fasta"};
+seqan3::sequence_file_input<seqan3::sequence_file_input_default_traits_aa> fin{std::filesystem::temp_directory_path()/"my.fasta"};
 //![amino_acid_type_trait]
 }
 
 {
 //![record_type]
-sequence_file_input fin{std::filesystem::temp_directory_path()/"my.fastq"};
+seqan3::sequence_file_input fin{std::filesystem::temp_directory_path()/"my.fastq"};
 using record_type = typename decltype(fin)::record_type;
 
 // Because `fin` is a range, we can access the first element by dereferencing fin.begin()
@@ -116,7 +114,7 @@ record_type rec = *fin.begin();
 }
 
 {
-sequence_file_input fin{std::filesystem::temp_directory_path()/"my.fastq"};
+seqan3::sequence_file_input fin{std::filesystem::temp_directory_path()/"my.fastq"};
 using record_type = typename decltype(fin)::record_type;
 //![record_type2]
 record_type rec = std::move(*fin.begin()); // avoid copying
@@ -125,12 +123,13 @@ record_type rec = std::move(*fin.begin()); // avoid copying
 
 {
 //![paired_reads]
-sequence_file_input fin1{std::filesystem::temp_directory_path()/"my.fastq"};
-sequence_file_input fin2{std::filesystem::temp_directory_path()/"my.fastq"}; // for simplicity we take the same file
+// for simplicity we take the same file
+seqan3::sequence_file_input fin1{std::filesystem::temp_directory_path()/"my.fastq"};
+seqan3::sequence_file_input fin2{std::filesystem::temp_directory_path()/"my.fastq"};
 
-for (auto && [rec1, rec2] : views::zip(fin1, fin2)) // && is important! because views::zip returns temporaries
-{
-    if (get<field::id>(rec1) != get<field::id>(rec2))
+for (auto && [rec1, rec2] : seqan3::views::zip(fin1, fin2)) // && is important!
+{                                                           // because seqan3::views::zip returns temporaries
+    if (seqan3::get<seqan3::field::id>(rec1) != seqan3::get<seqan3::field::id>(rec2))
         throw std::runtime_error("Oh oh your pairs don't match.");
 }
 //![paired_reads]
@@ -138,32 +137,32 @@ for (auto && [rec1, rec2] : views::zip(fin1, fin2)) // && is important! because 
 
 {
 //![read_in_batches]
-sequence_file_input fin{std::filesystem::temp_directory_path()/"my.fastq"};
+seqan3::sequence_file_input fin{std::filesystem::temp_directory_path()/"my.fastq"};
 
-for (auto && records : fin | ranges::view::chunk(10)) // && is important! because views::chunk returns temporaries
-{
+for (auto && records : fin | ranges::view::chunk(10))   // && is important!
+{                                                       // because seqan3::views::chunk returns temporaries
     // `records` contains 10 elements (or less at the end)
-    debug_stream << "Taking the next 10 sequences:\n";
-    debug_stream << "ID:  " << get<field::id>(*records.begin()) << '\n'; // prints first ID in batch
-}
+    seqan3::debug_stream << "Taking the next 10 sequences:\n";
+    seqan3::debug_stream << "ID:  " << seqan3::get<seqan3::field::id>(*records.begin()) << '\n';
+}                                                                                           // prints first ID in batch
 //![read_in_batches]
 }
 
 {
 //![quality_filter]
-sequence_file_input fin{std::filesystem::temp_directory_path()/"my.fastq"};
+seqan3::sequence_file_input fin{std::filesystem::temp_directory_path()/"my.fastq"};
 
 // std::views::filter takes a function object (a lambda in this case) as input that returns a boolean
 auto minimum_quality_filter = std::views::filter([] (auto const & rec)
 {
-    auto qual = get<field::qual>(rec) | std::views::transform([] (auto q) { return q.to_phred(); });
+    auto qual = seqan3::get<seqan3::field::qual>(rec) | std::views::transform([] (auto q) { return q.to_phred(); });
     double sum = ranges::accumulate(qual.begin(), qual.end(), 0);
     return sum / std::ranges::size(qual) >= 40; // minimum average quality >= 40
 });
 
 for (auto & rec : fin | minimum_quality_filter)
 {
-    debug_stream << "ID: " << get<field::id>(rec) << '\n';
+    seqan3::debug_stream << "ID: " << seqan3::get<seqan3::field::id>(rec) << '\n';
 }
 //![quality_filter]
 }
@@ -172,15 +171,15 @@ for (auto & rec : fin | minimum_quality_filter)
 //![piping_in_out]
 auto tmp_dir = std::filesystem::temp_directory_path();
 
-sequence_file_input fin{tmp_dir/"my.fastq"};
-sequence_file_output fout{tmp_dir/"output.fastq"};
+seqan3::sequence_file_input fin{tmp_dir/"my.fastq"};
+seqan3::sequence_file_output fout{tmp_dir/"output.fastq"};
 
 // the following are equivalent:
 fin | fout;
 
 fout = fin;
 
-sequence_file_output{tmp_dir/"output.fastq"} = sequence_file_input{tmp_dir/"my.fastq"};
+seqan3::sequence_file_output{tmp_dir/"output.fastq"} = seqan3::sequence_file_input{tmp_dir/"my.fastq"};
 //![piping_in_out]
 }
 
@@ -188,7 +187,7 @@ sequence_file_output{tmp_dir/"output.fastq"} = sequence_file_input{tmp_dir/"my.f
 //![file_conversion]
 auto tmp_dir = std::filesystem::temp_directory_path();
 
-sequence_file_output{tmp_dir/"output.fasta"} = sequence_file_input{tmp_dir/"my.fastq"};
+seqan3::sequence_file_output{tmp_dir/"output.fasta"} = seqan3::sequence_file_input{tmp_dir/"my.fastq"};
 //![file_conversion]
 }
 

--- a/doc/tutorial/sequence_file/sequence_file_solution1.cpp
+++ b/doc/tutorial/sequence_file/sequence_file_solution1.cpp
@@ -47,19 +47,17 @@ write_file_dummy_struct go{};
 #include <seqan3/io/sequence_file/all.hpp>
 #include <seqan3/std/filesystem>
 
-using namespace seqan3;
-
 int main()
 {
     std::filesystem::path tmp_dir = std::filesystem::temp_directory_path(); // get the temp directory
 
-    sequence_file_input fin{tmp_dir/"my.fastq"};
+    seqan3::sequence_file_input fin{tmp_dir/"my.fastq"};
 
     for (auto & rec : fin)
     {
-        debug_stream << "ID:  "  << get<field::id>(rec) << '\n';
-        debug_stream << "SEQ: "  << get<field::seq>(rec) << '\n';
-        debug_stream << "QUAL: " << get<field::qual>(rec) << '\n';
+        seqan3::debug_stream << "ID:  "  << seqan3::get<seqan3::field::id>(rec) << '\n';
+        seqan3::debug_stream << "SEQ: "  << seqan3::get<seqan3::field::seq>(rec) << '\n';
+        seqan3::debug_stream << "QUAL: " << seqan3::get<seqan3::field::qual>(rec) << '\n';
     }
 }
 //![solution]

--- a/doc/tutorial/sequence_file/sequence_file_solution2.cpp
+++ b/doc/tutorial/sequence_file/sequence_file_solution2.cpp
@@ -40,13 +40,11 @@ write_file_dummy_struct go{};
 #include <seqan3/std/filesystem>
 #include <seqan3/std/ranges> // std::ranges::copy
 
-using namespace seqan3;
-
 int main()
 {
     std::filesystem::path tmp_dir = std::filesystem::temp_directory_path(); // get the temp directory
 
-    sequence_file_input fin{tmp_dir/"my.fasta"};
+    seqan3::sequence_file_input fin{tmp_dir/"my.fasta"};
 
     using record_type = decltype(fin)::record_type;
     std::vector<record_type> records{};
@@ -61,6 +59,6 @@ int main()
     // But you can also do this:
     std::ranges::copy(fin, std::ranges::back_inserter(records));
 
-    debug_stream << records << std::endl;
+    seqan3::debug_stream << records << std::endl;
 }
 //![solution]

--- a/doc/tutorial/sequence_file/sequence_file_solution2.cpp
+++ b/doc/tutorial/sequence_file/sequence_file_solution2.cpp
@@ -59,6 +59,6 @@ int main()
     // But you can also do this:
     std::ranges::copy(fin, std::ranges::back_inserter(records));
 
-    seqan3::debug_stream << records << std::endl;
+    seqan3::debug_stream << records << '\n';
 }
 //![solution]

--- a/doc/tutorial/sequence_file/sequence_file_solution3.cpp
+++ b/doc/tutorial/sequence_file/sequence_file_solution3.cpp
@@ -85,6 +85,6 @@ int main()
     // Note that you need to know the type of id (std::string)
     // Converting to && prevents the IDs from being copied
 
-    seqan3::debug_stream << ids << std::endl;
+    seqan3::debug_stream << ids << '\n';
 }
 //![solution]

--- a/doc/tutorial/sequence_file/sequence_file_solution3.cpp
+++ b/doc/tutorial/sequence_file/sequence_file_solution3.cpp
@@ -57,36 +57,34 @@ write_file_dummy_struct go{};
 #include <seqan3/std/filesystem>
 #include <seqan3/std/ranges>
 
-using namespace seqan3;
-
 int main()
 {
     std::filesystem::path tmp_dir = std::filesystem::temp_directory_path(); // get the temp directory
 
-    sequence_file_input fin{tmp_dir/"my.fastq"};
+    seqan3::sequence_file_input fin{tmp_dir/"my.fastq"};
 
     auto length_filter = std::views::filter([] (auto const & rec)
     {
-        return std::ranges::size(get<field::seq>(rec)) >= 5;
+        return std::ranges::size(seqan3::get<seqan3::field::seq>(rec)) >= 5;
     });
 
     // you can use a for loop
 
     // for (auto & rec : fin | length_filter | std::views::take(2))
     // {
-    //     debug_stream << "ID: " << get<field::id>(rec) << '\n';
+    //     seqan3::debug_stream << "ID: " << seqan3::get<seqan3::field::id>(rec) << '\n';
     // }
 
     // But you can also do this to retrieve all IDs into a vector:
     std::vector<std::string> ids = fin
-                                 | length_filter                                // apply length filter
-                                 | std::views::take(2)                          // take first two records
-                                 | views::get<field::id>                        // select only ID from record
-                                 | views::convert<std::string &&>               // mark ID to be moved out of record
-                                 | views::to<std::vector<std::string>>;         // convert to container
+                                 | length_filter                                    // apply length filter
+                                 | std::views::take(2)                              // take first two records
+                                 | seqan3::views::get<seqan3::field::id>            // select only ID from record
+                                 | seqan3::views::convert<std::string &&>           // mark ID to be moved out of record
+                                 | seqan3::views::to<std::vector<std::string>>;     // convert to container
     // Note that you need to know the type of id (std::string)
     // Converting to && prevents the IDs from being copied
 
-    debug_stream << ids << std::endl;
+    seqan3::debug_stream << ids << std::endl;
 }
 //![solution]

--- a/doc/tutorial/sequence_file/sequence_file_solution4.cpp
+++ b/doc/tutorial/sequence_file/sequence_file_solution4.cpp
@@ -59,23 +59,20 @@ IIIIIHIIJJIIIII
 write_file_dummy_struct go{};
 
 //![solution]
-#include <seqan3/core/debug_stream.hpp>
 #include <seqan3/io/sequence_file/all.hpp>
 #include <seqan3/std/filesystem>
 #include <seqan3/std/ranges>
-
-using namespace seqan3;
 
 int main()
 {
     std::filesystem::path tmp_dir = std::filesystem::temp_directory_path(); // get the temp directory
 
-    sequence_file_input fin{tmp_dir/"my.fastq"};
-    sequence_file_output fout{tmp_dir/"output.fastq"};
+    seqan3::sequence_file_input fin{tmp_dir/"my.fastq"};
+    seqan3::sequence_file_output fout{tmp_dir/"output.fastq"};
 
     auto length_filter = std::views::filter([] (auto const & rec)
     {
-        return std::ranges::size(get<field::seq>(rec)) >= 5;
+        return std::ranges::size(seqan3::get<seqan3::field::seq>(rec)) >= 5;
     });
 
     for (auto & rec : fin | length_filter)

--- a/doc/tutorial/sequence_file/sequence_file_solution5.cpp
+++ b/doc/tutorial/sequence_file/sequence_file_solution5.cpp
@@ -59,24 +59,21 @@ IIIIIHIIJJIIIII
 write_file_dummy_struct go{};
 
 //![solution]
-#include <seqan3/core/debug_stream.hpp>
 #include <seqan3/io/sequence_file/all.hpp>
 #include <seqan3/range/views/persist.hpp>
 #include <seqan3/std/filesystem>
 #include <seqan3/std/ranges>
 
-using namespace seqan3;
-
 int main()
 {
     std::filesystem::path tmp_dir = std::filesystem::temp_directory_path(); // get the temp directory
 
-    sequence_file_input fin{tmp_dir/"my.fastq"};
-    sequence_file_output fout{tmp_dir/"output.fastq"};
+    seqan3::sequence_file_input fin{tmp_dir/"my.fastq"};
+    seqan3::sequence_file_output fout{tmp_dir/"output.fastq"};
 
     auto length_filter = std::views::filter([] (auto & rec)
     {
-        return std::ranges::size(get<field::seq>(rec)) >= 5;
+        return std::ranges::size(seqan3::get<seqan3::field::seq>(rec)) >= 5;
     });
 
     fout = fin | length_filter;


### PR DESCRIPTION
Resolves #1364

Additionally, the includes got sorted and std::endl got removed.

 The file doc/tutorial/alignment_file/alignment_file_solution2.cpp will be done by #1412.