### PR TITLE
[FEATURE] Reading hexadecimal SAM tags part 1

### DIFF
--- a/include/seqan3/core/debug_stream.hpp
+++ b/include/seqan3/core/debug_stream.hpp
@@ -15,6 +15,7 @@
 #include <iostream>
 
 #include <seqan3/core/detail/debug_stream_alphabet.hpp>
+#include <seqan3/core/detail/debug_stream_byte.hpp>
 #include <seqan3/core/detail/debug_stream_optional.hpp>
 #include <seqan3/core/detail/debug_stream_range.hpp>
 #include <seqan3/core/detail/debug_stream_tuple.hpp>

--- a/include/seqan3/core/detail/debug_stream_byte.hpp
+++ b/include/seqan3/core/detail/debug_stream_byte.hpp
@@ -1,0 +1,43 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \author Enrico Seiler <enrico.seiler AT fu-berlin.de>
+ * \brief Provides seqan3::debug_stream and related types.
+ */
+
+#pragma once
+
+#include <seqan3/std/concepts>
+#include <seqan3/std/type_traits>
+
+#include <seqan3/core/detail/debug_stream_type.hpp>
+
+namespace seqan3
+{
+/*!\name Formatted output overloads
+ * \{
+ */
+/*!\brief A std::byte can be printed by printing its value as integer.
+ * \tparam    byte_type     The type of the input; must be equal to `std::byte`.
+ * \param[in] s             The seqan3::debug_stream.
+ * \param[in] arg           The std::byte.
+ * \relates seqan3::debug_stream_type
+ */
+template <typename char_t, typename byte_type>
+//!\cond
+    requires std::same_as<std::remove_cvref_t<byte_type>, std::byte>
+//!\endcond
+inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, byte_type && arg)
+{
+    s << std::to_integer<uint8_t>(arg);
+    return s;
+}
+
+//!\}
+
+} // namespace seqan3

--- a/include/seqan3/io/alignment_file/format_sam.hpp
+++ b/include/seqan3/io/alignment_file/format_sam.hpp
@@ -1107,6 +1107,19 @@ inline void format_sam::write_tag_fields(stream_it_t & stream_it, sam_tag_dictio
             {
                 stream_it.write_range(arg);
             }
+            else if constexpr (std::same_as<std::remove_cvref_t<std::ranges::range_reference_t<T>>, std::byte>)
+            {
+                if (!std::ranges::empty(arg))
+                {
+                    stream_it.write_number(std::to_integer<uint8_t>(*std::ranges::begin(arg)));
+
+                    for (auto && elem : arg | views::drop(1))
+                    {
+                        *stream_it = ',';
+                        stream_it.write_number(std::to_integer<uint8_t>(elem));
+                    }
+                }
+            }
             else
             {
                 if (!std::ranges::empty(arg))

--- a/include/seqan3/io/alignment_file/sam_tag_dictionary.hpp
+++ b/include/seqan3/io/alignment_file/sam_tag_dictionary.hpp
@@ -26,15 +26,16 @@ namespace seqan3::detail
     //!\brief std::variant of allowed types for optional tag fields of the SAM format.
     //!\ingroup alignment_file_io
     using sam_tag_variant = std::variant<char, int32_t, float, std::string,
+                                         std::vector<std::byte>,
                                          std::vector<int8_t>, std::vector<uint8_t>,
                                          std::vector<int16_t>, std::vector<uint16_t>,
                                          std::vector<int32_t>, std::vector<uint32_t>,
                                          std::vector<float>>;
 
     //!\brief Each SAM tag type char identifier. Index corresponds to the seqan3::detail::sam_tag_variant types.
-    char constexpr sam_tag_type_char[11]       = {'A',  'i',  'f',  'Z',  'B', 'B', 'B', 'B', 'B', 'B', 'B'};
+    char constexpr sam_tag_type_char[12]       = {'A',  'i',  'f',  'Z', 'H', 'B', 'B', 'B', 'B', 'B', 'B', 'B'};
     //!\brief Each types SAM tag type extra char id. Index corresponds to the seqan3::detail::sam_tag_variant types.
-    char constexpr sam_tag_type_char_extra[11] = {'\0', '\0', '\0', '\0', 'c', 'C', 's', 'S', 'i', 'I', 'f'};
+    char constexpr sam_tag_type_char_extra[12] = {'\0', '\0', '\0', '\0', '\0', 'c', 'C', 's', 'S', 'i', 'I', 'f'};
 }
 
 namespace seqan3

--- a/test/unit/core/debug_stream_test.cpp
+++ b/test/unit/core/debug_stream_test.cpp
@@ -276,3 +276,13 @@ TEST(debug_stream_test, sam_flags)
     o.flush();
     EXPECT_EQ(o.str(), "0,4");
 }
+
+TEST(debug_stream_test, byte)
+{
+    std::ostringstream o{};
+    seqan3::debug_stream_type my_stream{o};
+
+    my_stream << std::byte{40} << "," << std::byte{244};
+    o.flush();
+    EXPECT_EQ(o.str(), "40,244");
+}

--- a/test/unit/io/alignment_file/alignment_file_format_test_template.hpp
+++ b/test/unit/io/alignment_file/alignment_file_format_test_template.hpp
@@ -11,6 +11,7 @@
 
 #include <seqan3/alphabet/quality/phred42.hpp>
 #include <seqan3/core/detail/debug_stream_alphabet.hpp>
+#include <seqan3/core/detail/debug_stream_byte.hpp>
 #include <seqan3/core/detail/debug_stream_optional.hpp>
 #include <seqan3/core/detail/debug_stream_tuple.hpp>
 #include <seqan3/core/detail/debug_stream_variant.hpp>

--- a/test/unit/io/alignment_file/sam_tag_dictionary_test.cpp
+++ b/test/unit/io/alignment_file/sam_tag_dictionary_test.cpp
@@ -111,10 +111,12 @@ TEST(sam_tag_dictionary, get_function_unknown_tag)
     dict["nm"_tag] = std::vector<int32_t>{3, 4, 5}; // overwrites previous
     dict["co"_tag] = std::string("comment");
     dict["cg"_tag] = std::vector<int32_t>{3, 4, 5};
+    dict["zb"_tag] = std::vector<std::byte>{std::byte{80}, std::byte{244}, std::byte{12}};
 
     EXPECT_EQ(dict["nm"_tag], variant_type{(std::vector<int32_t>{3, 4, 5})});
     EXPECT_EQ(dict["co"_tag], variant_type{"comment"});
     EXPECT_EQ(dict["cg"_tag], variant_type{(std::vector<int32_t>{3, 4, 5})});
+    EXPECT_EQ(dict["zb"_tag], variant_type{(std::vector<std::byte>{std::byte{80}, std::byte{244}, std::byte{12}})});
 }
 
 TEST(sam_tag_dictionary, get_function_const)


### PR DESCRIPTION
Resolves #1414

This adds the hexadecimal SAM tag to the `sam_tag_dictionary`.

I chose a `std::vector<std::byte>>` since we need to represent bytes and the types in the `std::variant` need to be distinct.

Since the code paths for all variants need to be valid at compile time, it also at some point tries to call `write_field`, hence we need an overload for the `std::byte`; this needs to be adapted once we write hexadecimal flags!

At some point the `value_type` needs to be streamable, so I added an overload for `std::byte` in the `debug_stream`.