### PR TITLE
[DOC] Allow linebreaks in long template parameters

### DIFF
--- a/test/documentation/seqan3.css
+++ b/test/documentation/seqan3.css
@@ -26,6 +26,17 @@ h1 {
 table {
     font-size: 12pt;
     font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+    table-layout: auto;
+    width: 100%;
+}
+
+.memItemLeft, .memTemplItemLeft {
+    white-space: normal;
+    width: 30%;
+}
+
+.memItemRight {
+    width: 70%;
 }
 
 div.contents {


### PR DESCRIPTION
Resolves #1567

**FROM**
<img width="1185" alt="Screenshot 2019-12-12 at 11 34 05" src="https://user-images.githubusercontent.com/12967715/70717935-a0472500-1cef-11ea-984c-b145ddafb9f7.png">
**TO**
<img width="1150" alt="Screenshot 2019-12-12 at 11 33 33" src="https://user-images.githubusercontent.com/12967715/70717932-a0472500-1cef-11ea-9b39-a69a4457d25c.png">

But also
**FROM**
<img width="1130" alt="Screenshot 2019-12-12 at 11 33 56" src="https://user-images.githubusercontent.com/12967715/70717934-a0472500-1cef-11ea-8ba2-3978846228dd.png">
**TO**
<img width="1124" alt="Screenshot 2019-12-12 at 11 33 40" src="https://user-images.githubusercontent.com/12967715/70717933-a0472500-1cef-11ea-8414-324e9c183e23.png">


