### PR TITLE
[INFRA] automate installing and packaging of seqan3

### DIFF
--- a/build_system/seqan3-install.cmake
+++ b/build_system/seqan3-install.cmake
@@ -1,0 +1,47 @@
+# -----------------------------------------------------------------------------------------------------
+# Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+# Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+# This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+# shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+# -----------------------------------------------------------------------------------------------------
+
+# This file describes where and which parts of SeqAn3 should be installed to.
+
+cmake_minimum_required (VERSION 3.7)
+
+include (GNUInstallDirs)
+
+# install documentation files in /share/doc
+install (
+    FILES
+    "${SEQAN3_CLONE_DIR}/CHANGELOG.md"
+    "${SEQAN3_CLONE_DIR}/CODE_OF_CONDUCT.md"
+    "${SEQAN3_CLONE_DIR}/CONTRIBUTING.md"
+    "${SEQAN3_CLONE_DIR}/LICENSE.md"
+    "${SEQAN3_CLONE_DIR}/README.md"
+    TYPE DOC
+)
+
+# install cmake files in /share/cmake
+install (
+    FILES
+    "${SEQAN3_CLONE_DIR}/build_system/seqan3-config.cmake"
+    "${SEQAN3_CLONE_DIR}/build_system/seqan3-config-version.cmake"
+    DESTINATION "${CMAKE_INSTALL_DATADIR}/cmake/seqan3"
+)
+
+# install seqan3 header files in /include/seqan3
+install (DIRECTORY "${SEQAN3_INCLUDE_DIR}/seqan3" TYPE INCLUDE)
+
+# install submodule header files, e.g. all external dependencies in /home/user/seqan3/submodules/*,
+# in /include/seqan3/submodules/<submodule>/include
+foreach (submodule_dir ${SEQAN3_DEPENDENCY_INCLUDE_DIRS})
+    # e.g. submodule_dir: (1) /home/user/seqan3/submodules/sdsl-lite/include or (2) /usr/include
+    # strip /home/user/seqan3/submodules/ and /include part.
+    file (RELATIVE_PATH submodule "${SEQAN3_SUBMODULES_DIR}/submodules" "${submodule_dir}/..")
+    # submodule is either a single module name, like sdsl-lite or a relative path to a folder ../../../usr
+    # skip relative folders and only keep submodules that reside in the submodules folder
+    if (NOT submodule MATCHES "^\\.\\.") # skip relative folders
+        install (DIRECTORY "${submodule_dir}" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/seqan3/submodules/${submodule}")
+    endif ()
+endforeach ()

--- a/build_system/seqan3-package.cmake
+++ b/build_system/seqan3-package.cmake
@@ -1,0 +1,22 @@
+# -----------------------------------------------------------------------------------------------------
+# Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+# Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+# This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+# shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+# -----------------------------------------------------------------------------------------------------
+
+# This file describes how SeqAn3 will be packaged.
+
+cmake_minimum_required (VERSION 3.7)
+
+set (CPACK_GENERATOR "ZIP" "TXZ")
+
+set (CPACK_PACKAGE_VENDOR "seqan")
+# A description of the project, used in places such as the introduction screen of CPack-generated Windows installers.
+# set (CPACK_PACKAGE_DESCRIPTION_FILE "") # TODO
+set (CPACK_PACKAGE_CHECKSUM "SHA256")
+set (CPACK_PACKAGE_ICON "${SEQAN3_CLONE_DIR}/test/documentation/seqan_logo.png")
+set (CPACK_RESOURCE_FILE_LICENSE "${SEQAN3_CLONE_DIR}/LICENSE.md")
+set (CPACK_RESOURCE_FILE_README "${SEQAN3_CLONE_DIR}/README.md")
+
+include (CPack)


### PR DESCRIPTION
This PR adds a description of which files should be installed and packaged.

We use the structure as proposed in debian, that means

* install documentation in `/share/doc/seqan3/*`
* install cmake scripts in `/share/cmake/seqan3/*`
* install seqan3 header files in `/include/seqan3/*`
* install external header (submodules) in `/include/seqan3/submodules/<submodule>/include/*`

This PR fixes #1387

*/CC:* @mr-c 