### PR TITLE
[DOC] fix documentation issues #1027

### DIFF
--- a/doc/tutorial/pairwise_alignment/index.md
+++ b/doc/tutorial/pairwise_alignment/index.md
@@ -21,9 +21,8 @@ The goal of the pairwise alignment is to obtain an optimal transcript that descr
 to each other by means of substitutions, insertions, or deletions. The computed transcript describes then the operations
 necessary to translate the one sequence into the other, as can be seen in the following picture.
 
-\htmlonly
-<img src="doc/tutorial/pairwise_alignment/align_transcript.png" alt="A transcript between two aligned sequences" style="width:300px;"/>
-\endhtmlonly
+\image html align_transcript.png
+\image latex align_transcript.png width=\\textwidth
 
 The alignment problem is solved with a dynamic programming (DP) algorithm which runs in \f$ (\mathcal{O}(n^2))\f$ time
 and space. Besides the global alignment approach many more variations of this DP based algorithm have been developed

--- a/include/seqan3/alignment/matrix/all.hpp
+++ b/include/seqan3/alignment/matrix/all.hpp
@@ -12,7 +12,7 @@
 
 #pragma once
 
-/*!\defgroup alignment_matrix matrix
+/*!\defgroup alignment_matrix Matrix
  * \brief Provides data structures for representing alignment coordinates and alignments as a matrix.
  * \ingroup alignment
  * \see alignment

--- a/include/seqan3/alphabet/adaptation/char.hpp
+++ b/include/seqan3/alphabet/adaptation/char.hpp
@@ -32,9 +32,12 @@ namespace seqan3::detail
 {
 //!\brief Whether a type is `char`, `char16_t`, `char32_t` or `wchar_t` (type trait).
 //!\ingroup adaptation
+//!\hideinitializer
 template <typename type>
-constexpr bool is_char_adaptation_v = std::same_as<type, char> || std::same_as<type, char16_t> ||
-    std::same_as<type, char32_t> || std::same_as<type, wchar_t>;
+constexpr bool is_char_adaptation_v = std::same_as<type, char>     ||
+                                      std::same_as<type, char16_t> ||
+                                      std::same_as<type, char32_t> ||
+                                      std::same_as<type, wchar_t>;
 } // namespace seqan3::detail
 
 namespace seqan3::custom

--- a/include/seqan3/alphabet/adaptation/char.hpp
+++ b/include/seqan3/alphabet/adaptation/char.hpp
@@ -33,10 +33,8 @@ namespace seqan3::detail
 //!\brief Whether a type is `char`, `char16_t`, `char32_t` or `wchar_t` (type trait).
 //!\ingroup adaptation
 template <typename type>
-constexpr bool is_char_adaptation_v = std::same_as<type, char>     ||
-                                      std::same_as<type, char16_t> ||
-                                      std::same_as<type, char32_t> ||
-                                      std::same_as<type, wchar_t>;
+constexpr bool is_char_adaptation_v = std::same_as<type, char> || std::same_as<type, char16_t> ||
+    std::same_as<type, char32_t> || std::same_as<type, wchar_t>;
 } // namespace seqan3::detail
 
 namespace seqan3::custom

--- a/include/seqan3/alphabet/adaptation/uint.hpp
+++ b/include/seqan3/alphabet/adaptation/uint.hpp
@@ -33,9 +33,8 @@ namespace seqan3::detail
 //!\brief Whether a type is `uint8_t`, `uint16_t` or `uint32_t`.
 //!\ingroup adaptation
 template <typename type>
-constexpr bool is_uint_adaptation_v = std::same_as<type, uint8_t>  ||
-                                      std::same_as<type, uint16_t> ||
-                                      std::same_as<type, uint32_t>;
+constexpr bool is_uint_adaptation_v = std::same_as<type, uint8_t> || std::same_as<type, uint16_t> ||
+    std::same_as<type, uint32_t>;
 } // namespace seqan3::detail
 
 namespace seqan3::custom

--- a/include/seqan3/alphabet/adaptation/uint.hpp
+++ b/include/seqan3/alphabet/adaptation/uint.hpp
@@ -32,9 +32,11 @@ namespace seqan3::detail
 {
 //!\brief Whether a type is `uint8_t`, `uint16_t` or `uint32_t`.
 //!\ingroup adaptation
+//!\hideinitializer
 template <typename type>
-constexpr bool is_uint_adaptation_v = std::same_as<type, uint8_t> || std::same_as<type, uint16_t> ||
-    std::same_as<type, uint32_t>;
+constexpr bool is_uint_adaptation_v = std::same_as<type, uint8_t>  ||
+                                      std::same_as<type, uint16_t> ||
+                                      std::same_as<type, uint32_t>;
 } // namespace seqan3::detail
 
 namespace seqan3::custom

--- a/include/seqan3/alphabet/all.hpp
+++ b/include/seqan3/alphabet/all.hpp
@@ -123,7 +123,7 @@
  * seqan3::writable_alphabet whenever the values might be changed.
  * Semi-alphabets are less useful in application code.
  *
- * |                                  | seqan3::semialphabet | seqan3::writable_semialphabet | seqan3::alphabet | seqan3::writable_alphabet | Aux |
+ * |                                  | [semialphabet](seqan3::semialphabet) | [writable_semialphabet](seqan3::writable_semialphabet) | [alphabet](seqan3::alphabet) | [writable_alphabet](seqan3::writable_alphabet) | Aux |
  * |----------------------------------|:--------------------:|:----------------------------:|:----------------:|:------------------------:|:---:|
  * | seqan3::alphabet_size            | ✅                    | ✅                            | ✅                | ✅                        |     |
  * | seqan3::to_rank                  | ✅                    | ✅                            | ✅                | ✅                        |     |
@@ -136,7 +136,7 @@
  * | seqan3::assign_char_strictly_to  |                      |                              |                  | ✅                        |  🔗 |
  *
  * The above table shows all alphabet concepts and related functions and type traits.
- * The entities marked as "auxiliary" provide shortcuts to the other "essential" entitities.
+ * The entities marked as "auxiliary" provide shortcuts to the other "essential" entities.
  * This difference is only relevant if you want to create your own alphabet (you do not need to provide an
  * implementation for the "auxiliary" entities, they are provided automatically).
  *

--- a/include/seqan3/alphabet/all.hpp
+++ b/include/seqan3/alphabet/all.hpp
@@ -123,17 +123,17 @@
  * seqan3::writable_alphabet whenever the values might be changed.
  * Semi-alphabets are less useful in application code.
  *
- * |                                  | [semialphabet](seqan3::semialphabet) | [writable_semialphabet](seqan3::writable_semialphabet) | [alphabet](seqan3::alphabet) | [writable_alphabet](seqan3::writable_alphabet) | Aux |
- * |----------------------------------|:--------------------:|:----------------------------:|:----------------:|:------------------------:|:---:|
- * | seqan3::alphabet_size            | ✅                    | ✅                            | ✅                | ✅                        |     |
- * | seqan3::to_rank                  | ✅                    | ✅                            | ✅                | ✅                        |     |
- * | seqan3::alphabet_rank_t          | ✅                    | ✅                            | ✅                | ✅                        |  🔗 |
- * | seqan3::assign_rank_to           |                      | ✅                            |                  | ✅                        |     |
- * | seqan3::to_char                  |                      |                              | ✅                | ✅                        |     |
- * | seqan3::alphabet_char_t          |                      |                              | ✅                | ✅                        |  🔗 |
- * | seqan3::assign_char_to           |                      |                              |                  | ✅                        |     |
- * | seqan3::char_is_valid_for        |                      |                              |                  | ✅                        |     |
- * | seqan3::assign_char_strictly_to  |                      |                              |                  | ✅                        |  🔗 |
+ * |                                                            | [semialphabet](seqan3::semialphabet) | [writable_semialphabet](seqan3::writable_semialphabet) | [alphabet](seqan3::alphabet) | [writable_alphabet](seqan3::writable_alphabet) | Aux |
+ * |------------------------------------------------------------|:------------------------------------:|:------------------------------------------------------:|:----------------------------:|:----------------------------------------------:|:---:|
+ * | [alphabet_size](seqan3::alphabet_size)                     | ✅                                    | ✅                                                      | ✅                            | ✅                                               |     |
+ * | [to_rank](seqan3::to_rank)                                 | ✅                                    | ✅                                                      | ✅                            | ✅                                               |     |
+ * | [alphabet_rank_t](seqan3::alphabet_rank_t)                 | ✅                                    | ✅                                                      | ✅                            | ✅                                               |  🔗  |
+ * | [assign_rank_to](seqan3::assign_rank_to)                   |                                      | ✅                                                      |                              | ✅                                               |     |
+ * | [to_char](seqan3::to_char)                                 |                                      |                                                        | ✅                            | ✅                                               |     |
+ * | [alphabet_char_t](seqan3::alphabet_char_t)                 |                                      |                                                        | ✅                            | ✅                                               |  🔗  |
+ * | [assign_char_to](seqan3::assign_char_to)                   |                                      |                                                        |                              | ✅                                               |     |
+ * | [char_is_valid_for](seqan3::char_is_valid_for)             |                                      |                                                        |                              | ✅                                               |     |
+ * | [assign_char_strictly_to](seqan3::assign_char_strictly_to) |                                      |                                                        |                              | ✅                                               |  🔗  |
  *
  * The above table shows all alphabet concepts and related functions and type traits.
  * The entities marked as "auxiliary" provide shortcuts to the other "essential" entities.

--- a/include/seqan3/io/alignment_file/header.hpp
+++ b/include/seqan3/io/alignment_file/header.hpp
@@ -140,23 +140,12 @@ public:
      *
      * | TAG | Description and Rules                                            |
      * | --- | ---------------------------------------------------------------- |
-     * | AH  | Indicates that this sequence is an alternate locus. The value is
-     *         the locus in the primary assembly for which this sequence is an
-     *         alternative, in the format 'chr:start-end', 'chr' (if known),
-     *         or '*' (if unknown), where 'chr' is a sequence in the primary assembly.
-     *         Must not be present on sequences in the primary assembly. |
-     * | AN  | Alternative reference sequence names. A comma-separated list
-     *         of alternative names that tools may use when referring to this
-     *         reference sequence. These alternative names are not used elsewhere
-     *         within the SAM file; in  particular, they must not appear in alignment
-     *         records’ RNAME or RNEXT fields. regular expression : name (, name )*
-     *         where name is [0-9A-Za-z][0-9A-Za-z*+.@ |-]* |
+     * | AH  | Indicates that this sequence is an alternate locus. The value is the locus in the primary assembly for which this sequence is an alternative, in the format 'chr:start-end', 'chr' (if known), or '*' (if unknown), where 'chr' is a sequence in the primary assembly. Must not be present on sequences in the primary assembly. |
+     * | AN  | Alternative reference sequence names. A comma-separated list of alternative names that tools may use when referring to this reference sequence. These alternative names are not used elsewhere within the SAM file; in  particular, they must not appear in alignment records’ RNAME or RNEXT fields. regular expression : name (, name )* where name is [0-9A-Za-z][0-9A-Za-z*+.@ \|-]* |
      * | AS  | Genome assembly identifier. |
      * | M5  | MD5 checksum of the sequence.  See Section 1.3.1 |
      * | SP  | Species. |
-     * | UR  | URI of the sequence.  This value may start with one of the standard
-     *         protocols, e.g http:  or ftp:. If it does not start with one of these
-     *         protocols, it is assumed to be a file-system path |
+     * | UR  | URI of the sequence.  This value may start with one of the standard protocols, e.g http:  or ftp:. If it does not start with one of these protocols, it is assumed to be a file-system path |
      */
     std::vector<std::tuple<int32_t, std::string>> ref_id_info{};
 
@@ -179,25 +168,16 @@ public:
      *
      * | TAG | Description and Rules                                            |
      * | --- | ---------------------------------------------------------------- |
-     * | BC  | Barcode sequence identifying the sample or library. This value is
-     *         the expected barcode bases as read by the sequencing machine in
-     *         the absence of errors. If there are several barcodes for the
-     *         sample/library (e.g., one on each end of the template), the
-     *         recommended implementation concatenates all the barcodes separating
-     *         them with hyphens ('-'). |
+     * | BC  | Barcode sequence identifying the sample or library. This value is the expected barcode bases as read by the sequencing machine in the absence of errors. If there are several barcodes for the sample/library (e.g., one on each end of the template), the recommended implementation concatenates all the barcodes separating them with hyphens ('-'). |
      * | CN  | Name of sequencing center producing the read. |
      * | DS  | Description.  UTF-8 encoding may be used. |
      * | DT  | Date the run was produced (ISO8601 date or date/time). |
-     * | FO  | Flow order. The array of nucleotide bases that correspond to the
-     *         nucleotides used for each flow of each read. Multi-base flows are
-     *         encoded in IUPAC format, and non-nucleotide flows by various other
-     *         characters. Format : /\*|[ACMGRSVTWYHKDBN]+/ |
+     * | FO  | Flow order. The array of nucleotide bases that correspond to the nucleotides used for each flow of each read. Multi-base flows are encoded in IUPAC format, and non-nucleotide flows by various other characters. Format : /\*\|[ACMGRSVTWYHKDBN]+/ |
      * | KS  | The array of nucleotide bases that correspond to the key sequence of each read. |
      * | LB  | Library. |
      * | PG  | Programs used for processing the read group. |
      * | PI  | Predicted median insert size. |
-     * | PL  | Platform/technology used to produce the reads.
-     *         Valid values : CAPILLARY, LS454, ILLUMINA, SOLID, HELICOS, IONTORRENT, ONT, and PACBIO. |
+     * | PL  | Platform/technology used to produce the reads. Valid values : CAPILLARY, LS454, ILLUMINA, SOLID, HELICOS, IONTORRENT, ONT, and PACBIO. |
      * | PM  | Platform model. Free-form text providing further details of the platform/technology used. |
      * | PU  | Platform unit (e.g. flowcell-barcode.lane for Illumina or slide for SOLiD). Unique identifier. |
      * | SM  | Sample. Use pool name where a pool is being sequenced. |

--- a/include/seqan3/io/alignment_file/header.hpp
+++ b/include/seqan3/io/alignment_file/header.hpp
@@ -138,14 +138,19 @@ public:
      * TAG:VALUE format, where TAG must be one of [AH, AN, AS, m5, SP, UR].
      * The following information and rules apply for each tag (taken from the SAM specs):
      *
-     * | TAG | Description and Rules                                            |
-     * | --- | ---------------------------------------------------------------- |
-     * | AH  | Indicates that this sequence is an alternate locus. The value is the locus in the primary assembly for which this sequence is an alternative, in the format 'chr:start-end', 'chr' (if known), or '*' (if unknown), where 'chr' is a sequence in the primary assembly. Must not be present on sequences in the primary assembly. |
-     * | AN  | Alternative reference sequence names. A comma-separated list of alternative names that tools may use when referring to this reference sequence. These alternative names are not used elsewhere within the SAM file; in  particular, they must not appear in alignment records’ RNAME or RNEXT fields. regular expression : name (, name )* where name is [0-9A-Za-z][0-9A-Za-z*+.@ \|-]* |
-     * | AS  | Genome assembly identifier. |
-     * | M5  | MD5 checksum of the sequence.  See Section 1.3.1 |
-     * | SP  | Species. |
-     * | UR  | URI of the sequence.  This value may start with one of the standard protocols, e.g http:  or ftp:. If it does not start with one of these protocols, it is assumed to be a file-system path |
+     * * **AH:** Indicates that this sequence is an alternate locus. The value is the locus in the primary assembly for
+     *           which this sequence is an alternative, in the format 'chr:start-end', 'chr' (if known), or '*' (if
+     *           unknown), where 'chr' is a sequence in the primary assembly. Must not be present on sequences in the
+     *           primary assembly.
+     * * **AN:** Alternative reference sequence names. A comma-separated list of alternative names that tools may use
+     *           when referring to this reference sequence. These alternative names are not used elsewhere within the
+     *           SAM file; in  particular, they must not appear in alignment records’ RNAME or RNEXT fields. regular
+     *           expression : name (, name )* where name is [0-9A-Za-z][0-9A-Za-z*+.@ \|-]*
+     * * **AS:** Genome assembly identifier.
+     * * **M5:** MD5 checksum of the sequence.  See Section 1.3.1
+     * * **SP:** Species.
+     * * **UR:** URI of the sequence.  This value may start with one of the standard protocols, e.g http:  or ftp:. If
+     *           it does not start with one of these protocols, it is assumed to be a file-system path
      */
     std::vector<std::tuple<int32_t, std::string>> ref_id_info{};
 
@@ -166,21 +171,25 @@ public:
      * TAG:VALUE format, where TAG must be one of [AH, AN, AS, m5, SP, UR].
      * The following information and rules apply for each tag (taken from the SAM specs):
      *
-     * | TAG | Description and Rules                                            |
-     * | --- | ---------------------------------------------------------------- |
-     * | BC  | Barcode sequence identifying the sample or library. This value is the expected barcode bases as read by the sequencing machine in the absence of errors. If there are several barcodes for the sample/library (e.g., one on each end of the template), the recommended implementation concatenates all the barcodes separating them with hyphens ('-'). |
-     * | CN  | Name of sequencing center producing the read. |
-     * | DS  | Description.  UTF-8 encoding may be used. |
-     * | DT  | Date the run was produced (ISO8601 date or date/time). |
-     * | FO  | Flow order. The array of nucleotide bases that correspond to the nucleotides used for each flow of each read. Multi-base flows are encoded in IUPAC format, and non-nucleotide flows by various other characters. Format : /\*\|[ACMGRSVTWYHKDBN]+/ |
-     * | KS  | The array of nucleotide bases that correspond to the key sequence of each read. |
-     * | LB  | Library. |
-     * | PG  | Programs used for processing the read group. |
-     * | PI  | Predicted median insert size. |
-     * | PL  | Platform/technology used to produce the reads. Valid values : CAPILLARY, LS454, ILLUMINA, SOLID, HELICOS, IONTORRENT, ONT, and PACBIO. |
-     * | PM  | Platform model. Free-form text providing further details of the platform/technology used. |
-     * | PU  | Platform unit (e.g. flowcell-barcode.lane for Illumina or slide for SOLiD). Unique identifier. |
-     * | SM  | Sample. Use pool name where a pool is being sequenced. |
+     * * **BC:** Barcode sequence identifying the sample or library. This value is the expected barcode bases as read by
+     *           the sequencing machine in the absence of errors. If there are several barcodes for the sample/library
+     *           (e.g., one on each end of the template), the recommended implementation concatenates all the barcodes
+     *           separating them with hyphens ('-').
+     * * **CN:** Name of sequencing center producing the read.
+     * * **DS:** Description.  UTF-8 encoding may be used.
+     * * **DT:** Date the run was produced (ISO8601 date or date/time).
+     * * **FO:** Flow order. The array of nucleotide bases that correspond to the nucleotides used for each flow of each
+     *           read. Multi-base flows are encoded in IUPAC format, and non-nucleotide flows by various other
+     *           characters. Format : /\*\|[ACMGRSVTWYHKDBN]+/
+     * * **KS:** The array of nucleotide bases that correspond to the key sequence of each read.
+     * * **LB:** Library.
+     * * **PG:** Programs used for processing the read group.
+     * * **PI:** Predicted median insert size.
+     * * **PL:** Platform/technology used to produce the reads. Valid values : CAPILLARY, LS454, ILLUMINA, SOLID,
+     *           HELICOS, IONTORRENT, ONT, and PACBIO.
+     * * **PM:** Platform model. Free-form text providing further details of the platform/technology used.
+     * * **PU:** Platform unit (e.g. flowcell-barcode.lane for Illumina or slide for SOLiD). Unique identifier.
+     * * **SM:** Sample. Use pool name where a pool is being sequenced.
      */
     std::vector<std::pair<std::string, std::string>> read_groups;
 };

--- a/include/seqan3/io/alignment_file/input.hpp
+++ b/include/seqan3/io/alignment_file/input.hpp
@@ -1121,7 +1121,7 @@ alignment_file_input(stream_type && stream,
 template <input_stream stream_type,
           std::ranges::forward_range ref_ids_t,
           std::ranges::forward_range ref_sequences_t,
-          alignment_file_input_format  file_format>
+          alignment_file_input_format file_format>
 alignment_file_input(stream_type & stream,
                      ref_ids_t &,
                      ref_sequences_t &,


### PR DESCRIPTION
Resolves all ticked parts of #1027 (#1424 is resolving two of these):

Resolves:
  - [x] Table in Alphabet Overview for Different concepts is too wide. (Plus, there are some weird boxes in column Aux)
  - [x] weird spacing in is_char_adaptation_v, is_uint_adaptation_v
  - [x] read_groups in alignment file in IO, barcode table is not correctly shown , same problem in ref_id_info

Resolved by #1424:
- [x] Table Type definition in simd too wide
- [x] Type deduction guides table in alignment file in  IO too wide

Additionally:
- [x] Scale image to textwidth in Pairwise Alignment

(cherry picked from commit 0fdbfc142daaa17da7a94bfacb6e7dd4e7464516)