### PR TITLE
[FEATURE] Enable vectorised alignment for different sized sequences.

### DIFF
--- a/include/seqan3/alignment/pairwise/detail/type_traits.hpp
+++ b/include/seqan3/alignment/pairwise/detail/type_traits.hpp
@@ -16,6 +16,7 @@
 #include <seqan3/alignment/matrix/trace_directions.hpp>
 #include <seqan3/alignment/pairwise/detail/concept.hpp>
 #include <seqan3/core/algorithm/configuration.hpp>
+#include <seqan3/core/bit_manipulation.hpp>
 #include <seqan3/core/simd/simd_traits.hpp>
 #include <seqan3/core/simd/simd.hpp>
 #include <seqan3/core/type_traits/template_inspection.hpp>
@@ -64,6 +65,10 @@ struct alignment_configuration_traits
     static constexpr bool is_vectorised = config_t::template exists<remove_cvref_t<decltype(align_cfg::vectorise)>>();
     //!\brief Flag indicating whether parallel alignment mode is enabled.
     static constexpr bool is_parallel = config_t::template exists<align_cfg::parallel>();
+    //!\brief Flag indicating whether global alignment mode is enabled.
+    static constexpr bool is_global = config_t::template exists<align_cfg::mode<detail::global_alignment_type>>();
+    //!\brief Flag indicating whether global alignment mode with free ends is enabled.
+    static constexpr bool is_aligned_ends = config_t::template exists<align_cfg::aligned_ends>();
     //!\brief Flag indicating whether local alignment mode is enabled.
     static constexpr bool is_local = config_t::template exists<align_cfg::mode<detail::local_alignment_type>>();
     //!\brief Flag indicating whether banded alignment mode is enabled.
@@ -96,6 +101,9 @@ struct alignment_configuration_traits
                                                     }();
     //!\brief The rank of the selected result type.
     static constexpr int8_t result_type_rank = static_cast<int8_t>(decltype(std::declval<result_t>().value)::rank);
+    //!\brief The padding symbol to use for the computation of the alignment.
+    static constexpr original_score_t padding_symbol =
+        static_cast<original_score_t>(1u << (sizeof_bits<original_score_t> - 1));
 };
 
 }  // namespace seqan3::detail

--- a/include/seqan3/alignment/pairwise/policy/all.hpp
+++ b/include/seqan3/alignment/pairwise/policy/all.hpp
@@ -20,6 +20,7 @@
 #include <seqan3/alignment/pairwise/policy/find_optimum_policy.hpp>
 #include <seqan3/alignment/pairwise/policy/scoring_scheme_policy.hpp>
 #include <seqan3/alignment/pairwise/policy/simd_affine_gap_policy.hpp>
+#include <seqan3/alignment/pairwise/policy/simd_find_optimum_policy.hpp>
 
 //!\cond DEV
 /*!\defgroup alignment_policy Alignment policies

--- a/include/seqan3/alignment/pairwise/policy/simd_find_optimum_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/simd_find_optimum_policy.hpp
@@ -1,0 +1,305 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2019, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2019, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides seqan3::detail::simd_find_optimum_policy.
+ * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <type_traits>
+
+#include <seqan3/alignment/matrix/alignment_optimum.hpp>
+#include <seqan3/alignment/pairwise/detail/alignment_algorithm_state.hpp>
+#include <seqan3/alignment/pairwise/policy/find_optimum_policy.hpp>
+#include <seqan3/core/detail/empty_type.hpp>
+#include <seqan3/core/simd/concept.hpp>
+#include <seqan3/range/views/zip.hpp>
+
+namespace seqan3::detail
+{
+
+/*!\brief A state that is only used for global alignments.
+ * \ingroup pairwise_alignment
+ * \tparam simd_t The simd vector score type; must model seqan3::simd::simd_concept.
+ *
+ * \details
+ *
+ * This state is only used for the global alignment to compute the correct optimum for every sequence pair.
+ * If the sequences have different lengths the respective cells in the alignment matrix need to be queried to check for
+ * the global optimum. In addition, the final scores and coordinates must be corrected as they are based on the
+ * outer matrix defined by the longest sequence in the first and second collection.
+ */
+template <simd::simd_concept simd_t>
+struct simd_global_alignment_state
+{
+    //!\brief The score offset that needs to be subtracted for every alignment to get the correct result.
+    simd_t score_offset{};
+    //!\brief A coordinate offset that needs to be subtracted for every alignment to get the correct end position.
+    simd_t coordinate_offset{};
+    //!\brief A mask vector storing the row indices for alignments that end in the last column of the global matrix.
+    simd_t last_column_mask{};
+    //!\brief A mask vector storing the column indices for alignments that end in the last row of the global matrix.
+    simd_t last_row_mask{};
+};
+
+/*!\brief The CRTP-policy to determine the optimum of the dynamic programming matrix.
+ * \ingroup alignment_policy
+ * \tparam alignment_algorithm_t The derived type (seqan3::detail::alignment_algorithm) to be augmented with this
+ *                               CRTP-policy.
+ * \tparam simd_t The simd vector type used for computing the scores; must model seqan3::simd::simd_concept.
+ * \tparam is_global_alignment_t A std::bool_constant type to check whether a global alignment was requested.
+ * \tparam traits_type A traits type that determines which cells should be considered for the optimum.
+ *                     Defaults to seqan3::detail::default_find_optimum_trait.
+ *
+ * \details
+ *
+ * This class determines the matrix wide optimum. The search space can be further refined using the
+ * `traits_type` which configures the search space of the alignment matrix.
+ *
+ * This class inherits from seqan3::detail::simd_global_alignment_state if it is a global alignment, otherwise it
+ * inherits from seqan3::detail::empty_type that is optimised away due to empty base class optimisation.
+ * The tracking behaviour for the optimum of the global alignment is slightly modified compared to the local alignment
+ * or free end gap computation. Specifically, instead of checking for a new optimal score the coordinates are checked.
+ * For the global alignment the cell which contains the optimum is already fixed (the sink of each matrix). To account
+ * for different sizes of the sequences a padding match score is used to always add match scores after the end of a
+ * smaller sequence has been reached. Accordingly, the target score will be mapped to a cell on
+ * the last row or last column of the global matrix. Note the dimensions of the global matrix is defined by the size of
+ * the longest sequence in collection 1 and 2 respectively. If the last cell of any of the contained matrices is
+ * projected to a cell on the last row (following the diagonal going through the sink of this particular matrix),
+ * then the column indices are tested to check if any sequence ends in this projected end point. Similarly, if the
+ * last cell is projected to a cell on the last column, then the row indices are compared. The found score as well
+ * as the indices are finally corrected to represent the original score and coordinates as if the sequence pair
+ * was computed in scalar mode.
+ */
+template <typename alignment_algorithm_t,
+          simd::simd_concept simd_t,
+          typename is_global_alignment_t,
+          typename traits_type = default_find_optimum_trait>
+class simd_find_optimum_policy : public std::conditional_t<is_global_alignment_t::value,
+                                                           simd_global_alignment_state<simd_t>,
+                                                           empty_type>
+{
+private:
+    //!\brief Befriends the derived class to grant it access to the private members.
+    friend alignment_algorithm_t;
+
+    //!\brief A bool constant to check if global alignment is computed.
+    static constexpr bool is_global_alignment = is_global_alignment_t::value;
+    //!\brief A bool constant to check if every cell needs to be tested for the global optimum.
+    static constexpr bool search_in_every_cell = traits_type::find_in_every_cell_type::value;
+    //!\brief A bool constant to check if cells of the last row need to be tested for the global optimum.
+    static constexpr bool search_in_last_row = traits_type::find_in_last_row_type::value || is_global_alignment;
+    //!\brief A bool constant to check if cells of the last column need to be tested for the global optimum.
+    static constexpr bool search_in_last_column = traits_type::find_in_last_column_type::value || is_global_alignment;
+
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    constexpr simd_find_optimum_policy() = default; //!< Defaulted.
+    constexpr simd_find_optimum_policy(simd_find_optimum_policy const &) = default; //!< Defaulted.
+    constexpr simd_find_optimum_policy(simd_find_optimum_policy &&) = default; //!< Defaulted.
+    constexpr simd_find_optimum_policy & operator=(simd_find_optimum_policy const &) = default; //!< Defaulted.
+    constexpr simd_find_optimum_policy & operator=(simd_find_optimum_policy &&) = default; //!< Defaulted.
+    ~simd_find_optimum_policy() = default; //!< Defaulted.
+    //!\}
+
+protected:
+    //!\copydoc seqan3::detail::find_optimum_policy::check_score_of_cell
+    template <typename cell_t, typename score_t>
+    constexpr void check_score_of_cell([[maybe_unused]] cell_t const & current_cell,
+                                       [[maybe_unused]] alignment_algorithm_state<score_t> & state) const noexcept
+    {
+        if constexpr (search_in_every_cell)
+            check_and_update(current_cell, state);
+    }
+
+    //!\brief Befriend the seqan3::detail::simd_affine_gap_policy to grant access to the check_score_of_cell function.
+    template <typename other_alignment_algorithm_t, typename score_t, typename is_local_t>
+    friend class simd_affine_gap_policy;
+
+    //!\brief Allow seqan3::detail::affine_gap_init_policy to access check_score.
+    template <typename other_alignment_algorithm_t, typename other_traits_type>
+    friend class affine_gap_init_policy;
+
+    //!\copydoc seqan3::detail::find_optimum_policy::check_score_of_last_row_cell
+    template <typename cell_t, typename score_t>
+    constexpr void check_score_of_last_row_cell([[maybe_unused]] cell_t const & last_row_cell,
+                                                [[maybe_unused]] alignment_algorithm_state<score_t> & state) const
+        noexcept
+    {
+        // Only search in last row if requested and not done already.}
+        if constexpr (!search_in_every_cell && search_in_last_row)
+        {
+            if constexpr (is_global_alignment)
+                check_and_update<true>(last_row_cell, state);
+            else
+                check_and_update(last_row_cell, state);
+        }
+    }
+
+    //!\copydoc seqan3::detail::find_optimum_policy::check_score_of_cells_in_last_column
+    template <typename alignment_column_t, typename score_t>
+    constexpr void check_score_of_cells_in_last_column([[maybe_unused]] alignment_column_t && last_column,
+                                                       [[maybe_unused]] alignment_algorithm_state<score_t> & state)
+        const noexcept
+    {
+        // Only check last cell if not done before.
+        if constexpr (!search_in_every_cell && search_in_last_column)
+        {
+            for (auto && cell : last_column)
+            {
+                if constexpr (is_global_alignment)
+                    check_and_update<false>(cell, state);
+                else
+                    check_and_update(cell, state);
+            }
+        }
+    }
+
+    //!\copydoc seqan3::detail::find_optimum_policy::check_score_of_last_cell
+    template <typename cell_t, typename score_t>
+    constexpr void check_score_of_last_cell([[maybe_unused]] cell_t const & last_cell,
+                                            [[maybe_unused]] alignment_algorithm_state<score_t> & state) const noexcept
+    {
+        // Only check last cell if not done before.
+        if constexpr (!search_in_every_cell && !search_in_last_row && !search_in_last_column)
+            check_and_update(last_cell, state);
+    }
+
+    /*!\brief Initialises the global alignment state for the current batch of sequences.
+     *
+     * \tparam sequence1_collection_t The type of the first collection; must model std::ranges::forward_range and
+     *                                the value type must model std::ranges::forward_range.
+     * \tparam sequence2_collection_t The type of the second collection; must model std::ranges::forward_range and
+     *                                the value type must model std::ranges::forward_range.
+     * \tparam score_t The type of the scoring scheme's padding score; must model seqan3::arithmetic.
+     *
+     * \param[in] sequence1_collection The first collection used for initialisation.
+     * \param[in] sequence2_collection The second collection used for initialisation.
+     * \param[in] padding_score The padding match score used for determining the resulting score offset.
+     */
+    template <std::ranges::forward_range sequence1_collection_t,
+              std::ranges::forward_range sequence2_collection_t,
+              arithmetic score_t>
+    void initialise_find_optimum_policy([[maybe_unused]] sequence1_collection_t && sequence1_collection,
+                                        [[maybe_unused]] sequence2_collection_t && sequence2_collection,
+                                        [[maybe_unused]] score_t const padding_score)
+    {
+        if constexpr (is_global_alignment)
+        {
+            assert(std::ranges::distance(sequence1_collection) == std::ranges::distance(sequence2_collection));
+
+            constexpr size_t simd_size = simd_traits<simd_t>::length;
+            // First get global size.
+            std::array<size_t, simd_size> sequence1_sizes{};
+            std::array<size_t, simd_size> sequence2_sizes{};
+
+            std::ptrdiff_t max_sequence1_size{};
+            std::ptrdiff_t max_sequence2_size{};
+
+            size_t array_index{};
+            for (auto && [sequence1, sequence2] : views::zip(sequence1_collection, sequence2_collection))
+            {
+                sequence1_sizes[array_index] = std::ranges::distance(sequence1);
+                sequence2_sizes[array_index] = std::ranges::distance(sequence2);
+                max_sequence1_size = std::max<std::ptrdiff_t>(sequence1_sizes[array_index], max_sequence1_size);
+                max_sequence2_size = std::max<std::ptrdiff_t>(sequence2_sizes[array_index], max_sequence2_size);
+                ++array_index;
+            }
+
+            // The global diagonal ending in the sink of the outer alignment matrix.
+            std::ptrdiff_t global_diagonal = max_sequence1_size - max_sequence2_size;
+
+            for (size_t simd_index = 0; simd_index < simd_size; ++simd_index)
+            {
+                if (std::ptrdiff_t local_diagonal = sequence1_sizes[simd_index] - sequence2_sizes[simd_index];
+                    local_diagonal < global_diagonal)
+                { // optimum is stored in last row.
+                    this->last_row_mask[simd_index] = max_sequence1_size - (global_diagonal - local_diagonal);
+                    this->last_column_mask[simd_index] = max_sequence2_size + 1;
+                    this->coordinate_offset[simd_index] = max_sequence2_size - sequence2_sizes[simd_index];
+                    this->score_offset[simd_index] = padding_score * this->coordinate_offset[simd_index];
+                }
+                else // optimum is stored in last column
+                {
+                    this->last_column_mask[simd_index] = max_sequence2_size - (local_diagonal - global_diagonal);
+                    this->last_row_mask[simd_index] = max_sequence1_size + 1;
+                    this->coordinate_offset[simd_index] = max_sequence1_size - sequence1_sizes[simd_index];
+                    this->score_offset[simd_index] = padding_score * this->coordinate_offset[simd_index];
+                }
+            }
+        }
+        // else no-op
+    }
+
+private:
+    /*!\brief Tests if the score in the current cell is greater than the current alignment optimum.
+     * \tparam cell_t The type of the alignment matrix cell. The cell type corresponds to the value type of the range
+     *                returned by seqan3::detail::alignment_matrix_policy::current_alignment_column.
+     * \tparam score_t The alignment algorithm score type.
+     *
+     * \param[in] cell The current cell to get the score and the coordinate from.
+     * \param[in,out] state The state with the current optimum to update.
+     */
+    template <typename cell_t, typename score_t>
+    constexpr void check_and_update(cell_t const & cell, alignment_algorithm_state<score_t> & state) const noexcept
+    {
+        static_assert(!is_global_alignment, "This function should not be called for the global alignment. "
+                                            "Use the other check_and_update function instead.");
+        auto const & [score_cell, trace_cell] = cell;
+        state.optimum.update_if_new_optimal_score(score_cell.current,
+                                                  column_index_type{trace_cell.coordinate.first},
+                                                  row_index_type{trace_cell.coordinate.second});
+    }
+
+    /*!\brief Tests if the current row, respectively column, is part of a global alignment to track.
+     *
+     * \tparam in_last_row A bool constant to indicate whether this check is done for the last row.
+     * \tparam cell_t The type of the alignment matrix cell. The cell type corresponds to the value type of the range
+     *                returned by seqan3::detail::alignment_matrix_policy::current_alignment_column.
+     * \tparam score_t The alignment algorithm score type.
+     *
+     * \param[in] cell The current cell to get the score and the coordinate from.
+     * \param[in,out] state The state with the current optimum to update.
+     *
+     * \details
+     *
+     * Checks for the last row if the current column coordinate matches any column coordinate stored in the mask for
+     * the last row, respectively for the last column if the current row coordinate matches any row coordinate stored
+     * in the mask for the last column.
+     */
+    template <bool in_last_row, typename cell_t, typename score_t>
+    constexpr void check_and_update(cell_t const & cell, alignment_algorithm_state<score_t> & state) const noexcept
+    {
+        static_assert(is_global_alignment, "This function should only be called for the global alignment. "
+                                           "Use the other check_and_update function instead.");
+
+        using simd_mask_t = typename simd_traits<simd_t>::mask_type;
+        auto const & [score_cell, trace_cell] = cell;
+        simd_t column_positions = simd::fill<simd_t>(trace_cell.coordinate.first);
+        simd_t row_positions = simd::fill<simd_t>(trace_cell.coordinate.second);
+
+        simd_mask_t mask{};
+
+        if constexpr (in_last_row) // Check if column was masked
+            mask = (column_positions == this->last_row_mask);
+        else // Check if row was masked
+            mask = (row_positions == this->last_column_mask);
+
+        // In global alignment we are only interested in the position not the max of the scores.
+        // In addition, the scores need to be corrected in order to track the right score.
+        state.optimum.score = mask ? score_cell.current - this->score_offset : state.optimum.score;
+        state.optimum.column_index = mask ? column_positions - this->coordinate_offset
+                                          : state.optimum.column_index;
+        state.optimum.row_index = mask ? row_positions - this->coordinate_offset
+                                       : state.optimum.row_index;
+    }
+};
+
+} // namespace seqan3::detail

--- a/include/seqan3/alignment/scoring/detail/simd_match_mismatch_scoring_scheme.hpp
+++ b/include/seqan3/alignment/scoring/detail/simd_match_mismatch_scoring_scheme.hpp
@@ -150,6 +150,12 @@ public:
     }
     //!\}
 
+    //!\brief Returns the match score used for padded symbols.
+    constexpr auto padding_match_score() noexcept
+    {
+        return match_score[0];
+    }
+
 private:
     /*!\brief Initialises the simd vector match score and mismatch score from the given scoring scheme.
      * \tparam scoring_scheme_t The type of the underlying scoring scheme; must model seqan3::scoring_scheme for

--- a/include/seqan3/alignment/scoring/detail/simd_matrix_scoring_scheme.hpp
+++ b/include/seqan3/alignment/scoring/detail/simd_matrix_scoring_scheme.hpp
@@ -117,6 +117,12 @@ public:
     }
     //!\}
 
+    //!\brief Returns the match score used for padded symbols.
+    constexpr typename scoring_scheme_t::score_type padding_match_score() noexcept
+    {
+        return 1;
+    }
+
 private:
     //!\brief Internally stores the given scalar scoring scheme matrix.
     scoring_scheme_t internal_scoring_scheme;

--- a/test/unit/alignment/pairwise/alignment_configurator_test.cpp
+++ b/test/unit/alignment/pairwise/alignment_configurator_test.cpp
@@ -210,7 +210,6 @@ TEST(alignment_configurator, configure_affine_local_alignment)
 TEST(alignment_configurator, configure_result_score_type)
 {
     auto cfg = align_cfg::edit | align_cfg::result{with_back_coordinate, using_score_type<double>};
-
     auto result = run_test(cfg);
 
     EXPECT_DOUBLE_EQ(result.score(), 0.0);

--- a/test/unit/alignment/pairwise/global_affine_unbanded_collection_simd_test.cpp
+++ b/test/unit/alignment/pairwise/global_affine_unbanded_collection_simd_test.cpp
@@ -17,24 +17,70 @@
 namespace seqan3::test::alignment::collection::simd::global::affine::unbanded
 {
 
-static auto dna4_01 = []()
+static auto dna4_all_same = []()
 {
-    using namespace seqan3::test::alignment::fixture;
-
     auto base_fixture = fixture::global::affine::unbanded::dna4_match_4_mismatch_5_gap_1_open_10_part_01;
     using fixture_t = decltype(base_fixture);
 
-    std::vector<fixture_t> data;
+    std::vector<fixture_t> data{};
     for (size_t i = 0; i < 100; ++i)
         data.push_back(base_fixture);
 
     return alignment_fixture_collection{base_fixture.config | align_cfg::vectorise, data};
 }();
 
+static auto dna4_different_length = []()
+{
+    auto base_fixture_01 = fixture::global::affine::unbanded::dna4_match_4_mismatch_5_gap_1_open_10_part_01;
+    auto base_fixture_02 = fixture::global::affine::unbanded::dna4_match_4_mismatch_5_gap_1_open_10_part_02;
+    auto base_fixture_03 = fixture::global::affine::unbanded::dna4_match_4_mismatch_5_gap_1_open_10_part_03;
+    auto base_fixture_04 = fixture::global::affine::unbanded::dna4_match_4_mismatch_5_gap_1_open_10_part_04;
+
+    using fixture_t = decltype(base_fixture_01);
+
+    std::vector<fixture_t> data{};
+    for (size_t i = 0; i < 25; ++i)
+    {
+        data.push_back(base_fixture_01);
+        data.push_back(base_fixture_02);
+        data.push_back(base_fixture_03);
+        data.push_back(base_fixture_04);
+    }
+
+    return alignment_fixture_collection{base_fixture_01.config | align_cfg::vectorise, data};
+}();
+
+static auto dna4_with_empty_sequences = []()
+{
+    auto base_fixture_01 = fixture::global::affine::unbanded::dna4_match_4_mismatch_5_gap_1_open_10_part_01;
+    auto base_fixture_02 = fixture::global::affine::unbanded::dna4_match_4_mismatch_5_gap_1_open_10_part_02;
+    auto base_fixture_03 = fixture::global::affine::unbanded::dna4_match_4_mismatch_5_gap_1_open_10_part_04;
+    auto base_fixture_04 = fixture::global::affine::unbanded::dna4_match_4_mismatch_5_gap_1_open_10_seq1_empty;
+    auto base_fixture_05 = fixture::global::affine::unbanded::dna4_match_4_mismatch_5_gap_1_open_10_seq2_empty;
+    auto base_fixture_06 = fixture::global::affine::unbanded::dna4_match_4_mismatch_5_gap_1_open_10_both_empty;
+
+    using fixture_t = decltype(base_fixture_01);
+
+    std::vector<fixture_t> data{};
+    for (size_t i = 0; i < 25; ++i)
+    {
+        data.push_back(base_fixture_01);
+        data.push_back(base_fixture_02);
+        data.push_back(base_fixture_03);
+        data.push_back(base_fixture_04);
+        data.push_back(base_fixture_05);
+        data.push_back(base_fixture_06);
+    }
+
+    return alignment_fixture_collection{base_fixture_01.config | align_cfg::vectorise, data};
+}();
+
 } // namespace seqan3::test::alignment::collection::simd::global::affine::unbanded
 
 using pairwise_collection_simd_global_affine_unbanded_testing_types = ::testing::Types<
-        pairwise_alignment_fixture<&seqan3::test::alignment::collection::simd::global::affine::unbanded::dna4_01>
+        pairwise_alignment_fixture<&seqan3::test::alignment::collection::simd::global::affine::unbanded::dna4_all_same>,
+        pairwise_alignment_fixture<&seqan3::test::alignment::collection::simd::global::affine::unbanded::dna4_different_length>,
+        pairwise_alignment_fixture<&seqan3::test::alignment::collection::simd::global::affine::unbanded::dna4_with_empty_sequences>
     >;
 
 INSTANTIATE_TYPED_TEST_CASE_P(pairwise_collection_simd_global_affine_unbanded,


### PR DESCRIPTION
Fixes #1443

Allows the computation of the vectrorised global alignment score and end coordinate when the sequences in one batch have a different size.
Adds a new find_optimum policy that is simd aware and uses an additional state to find the optimum for each algorithm.