### PR TITLE
[FIX] type printing for references

### DIFF
--- a/include/seqan3/core/detail/type_inspection.hpp
+++ b/include/seqan3/core/detail/type_inspection.hpp
@@ -43,7 +43,7 @@ namespace seqan3::detail
 template <typename type>
 inline std::string const type_name_as_string = [] ()
 {
-    std::string demangled_name;
+    std::string demangled_name{};
 #if defined(__GNUC__) || defined(__clang__) // clang and gcc only return a mangled name.
     using safe_ptr_t = std::unique_ptr<char, std::function<void(char *)>>;
 

--- a/include/seqan3/core/detail/type_inspection.hpp
+++ b/include/seqan3/core/detail/type_inspection.hpp
@@ -32,7 +32,7 @@ namespace seqan3::detail
  *
  * \tparam type The type to get the human-readable name for.
  *
- * \detail
+ * \details
  *
  * On gcc and clang std::type_info only returns a mangled name.
  * The mangled name can be converted to human-readable form using implementation-specific API such as
@@ -41,18 +41,28 @@ namespace seqan3::detail
  * \note The returned name is implementation defined and might change between different tool chains.
  */
 template <typename type>
-inline static const std::string type_name_as_string = [] ()
+inline std::string const type_name_as_string = [] ()
 {
+    std::string demangled_name;
 #if defined(__GNUC__) || defined(__clang__) // clang and gcc only return a mangled name.
     using safe_ptr_t = std::unique_ptr<char, std::function<void(char *)>>;
 
     int status{};
     safe_ptr_t demangled_name_ptr{abi::__cxa_demangle(typeid(type).name(), 0, 0, &status),
                                   [] (char * name_ptr) { free(name_ptr); }};
-    return std::string{std::addressof(*demangled_name_ptr)};
+    demangled_name = std::string{std::addressof(*demangled_name_ptr)};
 #else // e.g. MSVC
-    return typeid(type).name();
+    demangled_name = typeid(type).name();
 #endif // defined(__GNUC__) || defined(__clang__)
+
+    if constexpr (std::is_const_v<std::remove_reference_t<type>>)
+        demangled_name += " const";
+    if constexpr (std::is_lvalue_reference_v<type>)
+        demangled_name += " &";
+    if constexpr (std::is_rvalue_reference_v<type>)
+        demangled_name += " &&";
+
+    return demangled_name;
 }();
 
 }  // namespace seqan3::detail

--- a/test/unit/core/detail/type_inspection_test.cpp
+++ b/test/unit/core/detail/type_inspection_test.cpp
@@ -22,8 +22,8 @@ struct bar
 // Some types to test if type inspection works as expected.
 // Note that the returned name might differ between compiler vendors and thus must be adapted accordingly
 // in case this tests fails for those vendors.
-using reflection_types = ::testing::Types<char, char16_t, char32_t, short, double,
-                                          foo::bar<char>, foo::bar<foo::bar<char, double>>>;
+using reflection_types = ::testing::Types<char, char16_t const, char32_t &, short *, double const * const,
+                                          foo::bar<char> const &, foo::bar<foo::bar<char, double>>>;
 
 // Helper type list to use some traits functions on type lists.
 using as_type_list_t = seqan3::detail::transfer_template_args_onto_t<reflection_types, seqan3::type_list>;
@@ -32,8 +32,8 @@ template <typename param_type>
 class type_inspection : public ::testing::Test
 {
     // The corresponding list of names that should be generated. Must have the same order as `reflection_types`.
-    inline static const std::vector names{"char", "char16_t", "char32_t", "short", "double",
-                                          "foo::bar<char>", "foo::bar<foo::bar<char, double> >"};
+    inline static const std::vector names{"char", "char16_t const", "char32_t &", "short*", "double const* const",
+                                          "foo::bar<char> const &", "foo::bar<foo::bar<char, double> >"};
 
 public:
     // Returns the name of the type according to the list of names defined above.


### PR DESCRIPTION
It was broken for const-ness and references which both weren't tested...