### PR TITLE
[FIX] remove explicit noexcept from rule-of-5

### DIFF
--- a/include/seqan3/range/views/async_input_buffer.hpp
+++ b/include/seqan3/range/views/async_input_buffer.hpp
@@ -203,16 +203,17 @@ public:
     //!\}
 
     /*!\name Construction, destruction and assignment
+     * \brief Not explicitly `noexcept` because this depends on construction/copy/... of value_type.
      * \{
      */
-    async_input_buffer_iterator()                                                    noexcept = default; //!< Defaulted.
+    async_input_buffer_iterator()                                                    = default; //!< Defaulted.
     //TODO: delete:
-    async_input_buffer_iterator(async_input_buffer_iterator const & rhs)             noexcept = default; //!< Defaulted.
-    async_input_buffer_iterator(async_input_buffer_iterator && rhs)                  noexcept = default; //!< Defaulted.
+    async_input_buffer_iterator(async_input_buffer_iterator const & rhs)             = default; //!< Defaulted.
+    async_input_buffer_iterator(async_input_buffer_iterator && rhs)                  = default; //!< Defaulted.
     //TODO: delete:
-    async_input_buffer_iterator & operator=(async_input_buffer_iterator const & rhs) noexcept = default; //!< Defaulted.
-    async_input_buffer_iterator & operator=(async_input_buffer_iterator && rhs)      noexcept = default; //!< Defaulted.
-    ~async_input_buffer_iterator()                                                   noexcept = default; //!< Defaulted.
+    async_input_buffer_iterator & operator=(async_input_buffer_iterator const & rhs) = default; //!< Defaulted.
+    async_input_buffer_iterator & operator=(async_input_buffer_iterator && rhs)      = default; //!< Defaulted.
+    ~async_input_buffer_iterator()                                          noexcept = default; //!< Defaulted.
 
     //!\brief Constructing from the underlying seqan3::async_input_buffer_view.
     async_input_buffer_iterator(contrib::fixed_buffer_queue<value_type_t<urng_t>> & buffer) noexcept :


### PR DESCRIPTION
noexceptness depends on the value_type, because a value of the value_type is held as member. This also means that only value_types are supported that are default-constructible, maybe it would be better to wrap the member into a semiregular-optional-thingy.

I have made a card for this.