### PR TITLE
[FIX] use insert_gap correctly

### DIFF
--- a/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
+++ b/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
@@ -423,8 +423,8 @@ std::ranges::iterator_t<range_type> insert_gap(range_type & rng,
  * \tparam range_type   Type of the range to modify; must have an erase_gap(it) member function.
  * \param[in,out] rng   The range to modify.
  * \param[in] pos_it    The iterator pointing to the position where to erase one gap.
- * \returns       An iterator following the removed element. If the iterator `pos_it` refers to the last element, the
- *                std::ranges::end() iterator is returned.
+ * \returns An iterator following the removed element. If the iterator `pos_it` refers to the last element, the
+ *          std::ranges::end() iterator is returned.
  *
  * \details
  *

--- a/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
+++ b/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
@@ -233,11 +233,14 @@ SEQAN3_CONCEPT aligned_sequence =
  *                                The value type must be a seqan3::gapped alphabet.
  * \param[in,out] aligned_seq     The aligned container to modify.
  * \param[in]     pos_it          The iterator pointing to the position where to insert a gap.
+ * \returns       std::ranges::iterator_t<aligned_seq_t> An iterator pointing to the inserted gap.
  *
  * \details
  *
  * This function delegates to the member function `insert(iterator, value)` of
  * the container.
+ *
+ * \note This may cause reallocations and thus invalidate all iterators and references. Use the returned iterator.
  */
 template <sequence_container aligned_seq_t>
 //!\cond
@@ -256,11 +259,15 @@ inline typename aligned_seq_t::iterator insert_gap(aligned_seq_t & aligned_seq,
  * \param[in,out] aligned_seq     The aligned container to modify.
  * \param[in]     pos_it          The iterator pointing to the position where to insert gaps.
  * \param[in]     size            The number of gap symbols to insert (will result in a gap of length `size`).
+ * \returns       std::ranges::iterator_t<aligned_seq_t> An iterator pointing to the first inserted gap or `pos_it` if
+ *                `size == 0`.
  *
  * \details
  *
  * This function delegates to the member function `insert(iterator, `size`, `value`)`
  * of the container.
+ *
+ * \note This may cause reallocations and thus invalidate all iterators and references. Use the returned iterator.
  */
 template <sequence_container aligned_seq_t>
 //!\cond
@@ -279,6 +286,8 @@ inline typename aligned_seq_t::iterator insert_gap(aligned_seq_t & aligned_seq,
  *                                The value type must be a seqan3::gapped alphabet.
  * \param[in,out] aligned_seq     The aligned container to modify.
  * \param[in]     pos_it          The iterator pointing to the position where to erase a gap.
+ * \returns       std::ranges::iterator_t<aligned_seq_t> An Iterator following the removed element. If the iterator
+ *                `pos_it` refers to the last element, the std::ranges::end() iterator is returned.
  *
  * \throws seqan3::gap_erase_failure if there is no seqan3::gap at \p pos_it.
  *
@@ -287,6 +296,8 @@ inline typename aligned_seq_t::iterator insert_gap(aligned_seq_t & aligned_seq,
  * This function delegates to the member function `erase(iterator)` of the
  * container. Before delegating, the function checks if the position pointed to
  * by \p pos_it is an actual seqan3::gap and throws an exception if not.
+ *
+ * \note This may cause reallocations and thus invalidate all iterators and references. Use the returned iterator.
  */
 template <sequence_container aligned_seq_t>
 //!\cond
@@ -308,6 +319,8 @@ inline typename aligned_seq_t::iterator erase_gap(aligned_seq_t & aligned_seq,
  * \param[in,out] aligned_seq     The aligned container to modify.
  * \param[in]     first           The iterator pointing to the position where to start erasing gaps.
  * \param[in]     last            The iterator pointing to the position where to stop erasing gaps.
+ * \returns       std::ranges::iterator_t<aligned_seq_t> An Iterator following the last removed element. If the iterator
+ *                `last` refers to the last element, the std::ranges::end() iterator is returned.
  *
  * \throws seqan3::gap_erase_failure if one of the characters in [\p first, \p last) no seqan3::gap.
  *
@@ -316,6 +329,8 @@ inline typename aligned_seq_t::iterator erase_gap(aligned_seq_t & aligned_seq,
  * This function delegates to the member function `erase(iterator, iterator)` of
  * the container. Before delegating, the function checks if the range
  * [\p first, \p last) contains only seqan3::gap symbols.
+ *
+ * \note This may cause reallocations and thus invalidate all iterators and references. Use the returned iterator.
  */
 template <sequence_container aligned_seq_t>
 //!\cond
@@ -377,14 +392,18 @@ inline void assign_unaligned(aligned_seq_t & aligned_seq, unaligned_sequence_typ
 /*!\brief An implementation of seqan3::aligned_sequence::insert_gap for ranges with the corresponding
  *        member function insert_gap(it, size).
  * \ingroup aligned_sequence
- * \tparam range_type   Type of the range to modify; must have an insert_gap(it, size) member function.
- * \param[in,out] rng   The range to modify.
- * \param[in]     it    The iterator pointing to the position where to start inserting gaps.
- * \param[in]     size  The number of gaps to insert as an optional argument, default is 1.
+ * \tparam range_type    Type of the range to modify; must have an insert_gap(it, size) member function.
+ * \param[in,out] rng    The range to modify.
+ * \param[in]     pos_it The iterator pointing to the position where to start inserting gaps.
+ * \param[in]     size   The number of gaps to insert as an optional argument, default is 1.
+ * \returns       std::ranges::iterator_t<rng> An iterator pointing to the first inserted gap or `pos_it` if
+ *                `size == 0`.
  *
  * \details
  *
  * This function delegates to the member function `insert(iterator, size)` of the range.
+ *
+ * \note This may cause reallocations and thus invalidate all iterators and references. Use the returned iterator.
  */
 template <typename range_type>
 //!\cond
@@ -395,10 +414,10 @@ template <typename range_type>
         }
 //!\endcond
 std::ranges::iterator_t<range_type> insert_gap(range_type & rng,
-                                               std::ranges::iterator_t<range_type> const it,
+                                               std::ranges::iterator_t<range_type> const pos_it,
                                                typename range_type::size_type const size = 1)
 {
-    return rng.insert_gap(it, size);
+    return rng.insert_gap(pos_it, size);
 }
 
 /*!\brief An implementation of seqan3::aligned_sequence::erase_gap for ranges with the corresponding
@@ -406,21 +425,25 @@ std::ranges::iterator_t<range_type> insert_gap(range_type & rng,
  * \ingroup aligned_sequence
  * \tparam range_type   Type of the range to modify; must have an erase_gap(it) member function.
  * \param[in,out] rng   The range to modify.
- * \param[in] it        The iterator pointing to the position where to erase one gap.
+ * \param[in] pos_it    The iterator pointing to the position where to erase one gap.
+ * \returns       std::ranges::iterator_t<rng> An Iterator following the removed element. If the iterator
+ *                `pos_it` refers to the last element, the std::ranges::end() iterator is returned.
  *
  * \details
  *
  * This function delegates to the member function `erase(it)` of
  * the range.
+ *
+ * \note This may cause reallocations and thus invalidate all iterators and references. Use the returned iterator.
  */
 template <typename range_type>
 //!\cond
     requires requires (range_type v) { v.erase_gap(std::ranges::iterator_t<range_type>{}); }
 //!\endcond
 std::ranges::iterator_t<range_type> erase_gap(range_type & rng,
-                                              std::ranges::iterator_t<range_type> const it)
+                                              std::ranges::iterator_t<range_type> const pos_it)
 {
-    return rng.erase_gap(it);
+    return rng.erase_gap(pos_it);
 }
 
 /*!\brief An implementation of seqan3::aligned_sequence::erase_gap for ranges with the corresponding
@@ -430,12 +453,16 @@ std::ranges::iterator_t<range_type> erase_gap(range_type & rng,
  * \param[in,out] rng   The range to modify.
  * \param[in] first     The iterator pointing to the position where to start erasing gaps.
  * \param[in] last      The iterator pointing to the position where to stop erasing gaps.
+ * \returns       std::ranges::iterator_t<rng> An Iterator following the last removed element. If the iterator
+ *                `last` refers to the last element, the std::ranges::end() iterator is returned.
  *
  * \throws seqan3::gap_erase_failure if one of the characters in [\p first, \p last) is no seqan3::gap.
  *
  * \details
  *
  * This function delegates to the member function `erase(first, last)` of the range.
+ *
+ * \note This may cause reallocations and thus invalidate all iterators and references. Use the returned iterator.
  */
 template <typename range_type>
 //!\cond

--- a/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
+++ b/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
@@ -113,18 +113,21 @@ namespace seqan3
  * \relates seqan3::aligned_sequence
  * \{
  */
-/*!\fn      inline aligned_seq_t::iterator insert_gap(aligned_seq_t & aligned_seq, typename aligned_seq_t::const_iterator pos_it)
+/*!\fn      inline std::ranges::iterator_t<aligned_seq_t> insert_gap(aligned_seq_t & aligned_seq, typename aligned_seq_t::const_iterator pos_it)
  * \brief   Insert a seqan3::gap into an aligned sequence.
  *
  * \tparam        aligned_seq_t   Type of the range to modify; must model seqan3::aligned_sequence.
  * \param[in,out] aligned_seq     The aligned sequence to modify.
  * \param[in]     pos_it          The iterator pointing to the position where to insert a gap.
+ * \returns       std::ranges::iterator_t<aligned_seq_t> An iterator pointing to the inserted gap.
  *
  * \details
+ * \note      This may cause reallocations and thus invalidate all iterators and references. Use the returned iterator.
+ *
  * \attention This is a concept requirement, not an actual function (however types
  *            modelling this concept will provide an implementation).
  */
-/*!\fn      inline aligned_seq_t::iterator insert_gap(aligned_seq_t & aligned_seq, typename aligned_seq_t::const_iterator
+/*!\fn      inline std::ranges::iterator_t<aligned_seq_t> insert_gap(aligned_seq_t & aligned_seq, typename aligned_seq_t::const_iterator
  *          pos_it, typename aligned_seq_t::size_type size)
  * \brief   Insert multiple seqan3::gap into an aligned sequence.
  *
@@ -132,26 +135,34 @@ namespace seqan3
  * \param[in,out] aligned_seq     The aligned sequence to modify.
  * \param[in]     pos_it          The iterator pointing to the position where to insert a gaps.
  * \param[in]     size            The number of gap symbols to insert (will result in a gap of length `size`).
+ * \returns       std::ranges::iterator_t<aligned_seq_t> An iterator pointing to the first inserted gap or `pos_it` if
+ *                `size == 0`.
  *
  * \details
+ * \note      This may cause reallocations and thus invalidate all iterators and references. Use the returned iterator.
+ *
  * \attention This is a concept requirement, not an actual function (however types
  *            modelling this concept will provide an implementation).
  */
-/*!\fn      inline aligned_seq_t::iterator erase_gap(aligned_seq_t & aligned_seq, typename aligned_seq_t::const_iterator
+/*!\fn      inline std::ranges::iterator_t<aligned_seq_t> erase_gap(aligned_seq_t & aligned_seq, typename aligned_seq_t::const_iterator
  *          pos_it)
  * \brief   Erase a seqan3::gap from an aligned sequence.
  *
  * \tparam        aligned_seq_t   Type of the range to modify; must model seqan3::aligned_sequence.
  * \param[in,out] aligned_seq     The aligned sequence to modify.
  * \param[in]     pos_it          The iterator pointing to the position where to erase a gap.
+ * \returns       std::ranges::iterator_t<aligned_seq_t> An Iterator following the removed element. If the iterator
+ *                `pos_it` refers to the last element, the std::ranges::end() iterator is returned.
  *
  * \throws seqan3::gap_erase_failure if there is no seqan3::gap at \p pos_it.
  *
  * \details
+ * \note      This may cause reallocations and thus invalidate all iterators and references. Use the returned iterator.
+ *
  * \attention This is a concept requirement, not an actual function (however types
  *            modelling this concept will provide an implementation).
  */
-/*!\fn      inline aligned_seq_t::iterator erase_gap(aligned_seq_t & aligned_seq, typename aligned_seq_t::const_iterator
+/*!\fn      inline std::ranges::iterator_t<aligned_seq_t> erase_gap(aligned_seq_t & aligned_seq, typename aligned_seq_t::const_iterator
  *          first, typename aligned_seq_t::const_iterator last)
  * \brief   Erase multiple seqan3::gap from an aligned sequence.
  *
@@ -159,10 +170,14 @@ namespace seqan3
  * \param[in,out] aligned_seq     The aligned sequence to modify.
  * \param[in]     first           The iterator pointing to the position where to start erasing gaps.
  * \param[in]     last            The iterator pointing to the position where to stop erasing gaps.
+ * \returns       std::ranges::iterator_t<aligned_seq_t> An Iterator following the last removed element. If the iterator
+ *                `last` refers to the last element, the std::ranges::end() iterator is returned.
  *
  * \throws seqan3::gap_erase_failure if one of the characters in [\p first, \p last) no seqan3::gap.
  *
  * \details
+ * \note      This may cause reallocations and thus invalidate all iterators and references. Use the returned iterator.
+ *
  * \attention This is a concept requirement, not an actual function (however types
  *            modelling this concept will provide an implementation).
  */

--- a/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
+++ b/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
@@ -113,7 +113,8 @@ namespace seqan3
  * \relates seqan3::aligned_sequence
  * \{
  */
-/*!\fn      inline std::ranges::iterator_t<aligned_seq_t> insert_gap(aligned_seq_t & aligned_seq, typename aligned_seq_t::const_iterator pos_it)
+/*!\fn      inline std::ranges::iterator_t<aligned_seq_t> insert_gap(aligned_seq_t & aligned_seq,
+ *          typename aligned_seq_t::const_iterator pos_it)
  * \brief   Insert a seqan3::gap into an aligned sequence.
  *
  * \tparam        aligned_seq_t   Type of the range to modify; must model seqan3::aligned_sequence.
@@ -127,8 +128,8 @@ namespace seqan3
  * \attention This is a concept requirement, not an actual function (however types
  *            modelling this concept will provide an implementation).
  */
-/*!\fn      inline std::ranges::iterator_t<aligned_seq_t> insert_gap(aligned_seq_t & aligned_seq, typename aligned_seq_t::const_iterator
- *          pos_it, typename aligned_seq_t::size_type size)
+/*!\fn      inline std::ranges::iterator_t<aligned_seq_t> insert_gap(aligned_seq_t & aligned_seq,
+ *          typename aligned_seq_t::const_iterator pos_it, typename aligned_seq_t::size_type size)
  * \brief   Insert multiple seqan3::gap into an aligned sequence.
  *
  * \tparam        aligned_seq_t   Type of the range to modify; must model seqan3::aligned_sequence.
@@ -144,8 +145,8 @@ namespace seqan3
  * \attention This is a concept requirement, not an actual function (however types
  *            modelling this concept will provide an implementation).
  */
-/*!\fn      inline std::ranges::iterator_t<aligned_seq_t> erase_gap(aligned_seq_t & aligned_seq, typename aligned_seq_t::const_iterator
- *          pos_it)
+/*!\fn      inline std::ranges::iterator_t<aligned_seq_t> erase_gap(aligned_seq_t & aligned_seq,
+ *          typename aligned_seq_t::const_iterator pos_it)
  * \brief   Erase a seqan3::gap from an aligned sequence.
  *
  * \tparam        aligned_seq_t   Type of the range to modify; must model seqan3::aligned_sequence.
@@ -162,8 +163,8 @@ namespace seqan3
  * \attention This is a concept requirement, not an actual function (however types
  *            modelling this concept will provide an implementation).
  */
-/*!\fn      inline std::ranges::iterator_t<aligned_seq_t> erase_gap(aligned_seq_t & aligned_seq, typename aligned_seq_t::const_iterator
- *          first, typename aligned_seq_t::const_iterator last)
+/*!\fn      inline std::ranges::iterator_t<aligned_seq_t> erase_gap(aligned_seq_t & aligned_seq,
+ *          typename aligned_seq_t::const_iterator first, typename aligned_seq_t::const_iterator last)
  * \brief   Erase multiple seqan3::gap from an aligned sequence.
  *
  * \tparam        aligned_seq_t   Type of the range to modify; must model seqan3::aligned_sequence.

--- a/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
+++ b/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
@@ -120,7 +120,7 @@ namespace seqan3
  * \tparam        aligned_seq_t   Type of the range to modify; must model seqan3::aligned_sequence.
  * \param[in,out] aligned_seq     The aligned sequence to modify.
  * \param[in]     pos_it          The iterator pointing to the position where to insert a gap.
- * \returns       std::ranges::iterator_t<aligned_seq_t> An iterator pointing to the inserted gap.
+ * \returns       An iterator pointing to the inserted gap.
  *
  * \details
  * \note      This may cause reallocations and thus invalidate all iterators and references. Use the returned iterator.
@@ -136,8 +136,7 @@ namespace seqan3
  * \param[in,out] aligned_seq     The aligned sequence to modify.
  * \param[in]     pos_it          The iterator pointing to the position where to insert a gaps.
  * \param[in]     size            The number of gap symbols to insert (will result in a gap of length `size`).
- * \returns       std::ranges::iterator_t<aligned_seq_t> An iterator pointing to the first inserted gap or `pos_it` if
- *                `size == 0`.
+ * \returns       An iterator pointing to the first inserted gap or `pos_it` if `size == 0`.
  *
  * \details
  * \note      This may cause reallocations and thus invalidate all iterators and references. Use the returned iterator.
@@ -152,8 +151,8 @@ namespace seqan3
  * \tparam        aligned_seq_t   Type of the range to modify; must model seqan3::aligned_sequence.
  * \param[in,out] aligned_seq     The aligned sequence to modify.
  * \param[in]     pos_it          The iterator pointing to the position where to erase a gap.
- * \returns       std::ranges::iterator_t<aligned_seq_t> An Iterator following the removed element. If the iterator
- *                `pos_it` refers to the last element, the std::ranges::end() iterator is returned.
+ * \returns       An Iterator following the removed element. If the iterator `pos_it` refers to the last element, the
+ *                std::ranges::end() iterator is returned.
  *
  * \throws seqan3::gap_erase_failure if there is no seqan3::gap at \p pos_it.
  *
@@ -171,8 +170,8 @@ namespace seqan3
  * \param[in,out] aligned_seq     The aligned sequence to modify.
  * \param[in]     first           The iterator pointing to the position where to start erasing gaps.
  * \param[in]     last            The iterator pointing to the position where to stop erasing gaps.
- * \returns       std::ranges::iterator_t<aligned_seq_t> An Iterator following the last removed element. If the iterator
- *                `last` refers to the last element, the std::ranges::end() iterator is returned.
+ * \returns       An Iterator following the last removed element. If the iterator `last` refers to the last element, the
+ *                std::ranges::end() iterator is returned.
  *
  * \throws seqan3::gap_erase_failure if one of the characters in [\p first, \p last) no seqan3::gap.
  *
@@ -233,7 +232,7 @@ SEQAN3_CONCEPT aligned_sequence =
  *                                The value type must be a seqan3::gapped alphabet.
  * \param[in,out] aligned_seq     The aligned container to modify.
  * \param[in]     pos_it          The iterator pointing to the position where to insert a gap.
- * \returns       std::ranges::iterator_t<aligned_seq_t> An iterator pointing to the inserted gap.
+ * \returns       An iterator pointing to the inserted gap.
  *
  * \details
  *
@@ -259,8 +258,7 @@ inline typename aligned_seq_t::iterator insert_gap(aligned_seq_t & aligned_seq,
  * \param[in,out] aligned_seq     The aligned container to modify.
  * \param[in]     pos_it          The iterator pointing to the position where to insert gaps.
  * \param[in]     size            The number of gap symbols to insert (will result in a gap of length `size`).
- * \returns       std::ranges::iterator_t<aligned_seq_t> An iterator pointing to the first inserted gap or `pos_it` if
- *                `size == 0`.
+ * \returns       An iterator pointing to the first inserted gap or `pos_it` if `size == 0`.
  *
  * \details
  *
@@ -286,8 +284,8 @@ inline typename aligned_seq_t::iterator insert_gap(aligned_seq_t & aligned_seq,
  *                                The value type must be a seqan3::gapped alphabet.
  * \param[in,out] aligned_seq     The aligned container to modify.
  * \param[in]     pos_it          The iterator pointing to the position where to erase a gap.
- * \returns       std::ranges::iterator_t<aligned_seq_t> An Iterator following the removed element. If the iterator
- *                `pos_it` refers to the last element, the std::ranges::end() iterator is returned.
+ * \returns       An Iterator following the removed element. If the iterator `pos_it` refers to the last element, the
+ *                std::ranges::end() iterator is returned.
  *
  * \throws seqan3::gap_erase_failure if there is no seqan3::gap at \p pos_it.
  *
@@ -319,8 +317,8 @@ inline typename aligned_seq_t::iterator erase_gap(aligned_seq_t & aligned_seq,
  * \param[in,out] aligned_seq     The aligned container to modify.
  * \param[in]     first           The iterator pointing to the position where to start erasing gaps.
  * \param[in]     last            The iterator pointing to the position where to stop erasing gaps.
- * \returns       std::ranges::iterator_t<aligned_seq_t> An Iterator following the last removed element. If the iterator
- *                `last` refers to the last element, the std::ranges::end() iterator is returned.
+ * \returns       An Iterator following the last removed element. If the iterator `last` refers to the last element, the
+ *                std::ranges::end() iterator is returned.
  *
  * \throws seqan3::gap_erase_failure if one of the characters in [\p first, \p last) no seqan3::gap.
  *
@@ -396,8 +394,7 @@ inline void assign_unaligned(aligned_seq_t & aligned_seq, unaligned_sequence_typ
  * \param[in,out] rng    The range to modify.
  * \param[in]     pos_it The iterator pointing to the position where to start inserting gaps.
  * \param[in]     size   The number of gaps to insert as an optional argument, default is 1.
- * \returns       std::ranges::iterator_t<range_type> An iterator pointing to the first inserted gap or `pos_it` if
- *                `size == 0`.
+ * \returns       An iterator pointing to the first inserted gap or `pos_it` if `size == 0`.
  *
  * \details
  *
@@ -426,8 +423,8 @@ std::ranges::iterator_t<range_type> insert_gap(range_type & rng,
  * \tparam range_type   Type of the range to modify; must have an erase_gap(it) member function.
  * \param[in,out] rng   The range to modify.
  * \param[in] pos_it    The iterator pointing to the position where to erase one gap.
- * \returns       std::ranges::iterator_t<range_type> An Iterator following the removed element. If the iterator
- *                `pos_it` refers to the last element, the std::ranges::end() iterator is returned.
+ * \returns       An Iterator following the removed element. If the iterator `pos_it` refers to the last element, the
+ *                std::ranges::end() iterator is returned.
  *
  * \details
  *
@@ -453,8 +450,8 @@ std::ranges::iterator_t<range_type> erase_gap(range_type & rng,
  * \param[in,out] rng   The range to modify.
  * \param[in] first     The iterator pointing to the position where to start erasing gaps.
  * \param[in] last      The iterator pointing to the position where to stop erasing gaps.
- * \returns       std::ranges::iterator_t<range_type> An Iterator following the last removed element. If the iterator
- *                `last` refers to the last element, the std::ranges::end() iterator is returned.
+ * \returns       An Iterator following the last removed element. If the iterator `last` refers to the last element, the
+ *                std::ranges::end() iterator is returned.
  *
  * \throws seqan3::gap_erase_failure if one of the characters in [\p first, \p last) is no seqan3::gap.
  *

--- a/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
+++ b/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
@@ -396,7 +396,7 @@ inline void assign_unaligned(aligned_seq_t & aligned_seq, unaligned_sequence_typ
  * \param[in,out] rng    The range to modify.
  * \param[in]     pos_it The iterator pointing to the position where to start inserting gaps.
  * \param[in]     size   The number of gaps to insert as an optional argument, default is 1.
- * \returns       std::ranges::iterator_t<rng> An iterator pointing to the first inserted gap or `pos_it` if
+ * \returns       std::ranges::iterator_t<range_type> An iterator pointing to the first inserted gap or `pos_it` if
  *                `size == 0`.
  *
  * \details
@@ -426,7 +426,7 @@ std::ranges::iterator_t<range_type> insert_gap(range_type & rng,
  * \tparam range_type   Type of the range to modify; must have an erase_gap(it) member function.
  * \param[in,out] rng   The range to modify.
  * \param[in] pos_it    The iterator pointing to the position where to erase one gap.
- * \returns       std::ranges::iterator_t<rng> An Iterator following the removed element. If the iterator
+ * \returns       std::ranges::iterator_t<range_type> An Iterator following the removed element. If the iterator
  *                `pos_it` refers to the last element, the std::ranges::end() iterator is returned.
  *
  * \details
@@ -453,7 +453,7 @@ std::ranges::iterator_t<range_type> erase_gap(range_type & rng,
  * \param[in,out] rng   The range to modify.
  * \param[in] first     The iterator pointing to the position where to start erasing gaps.
  * \param[in] last      The iterator pointing to the position where to stop erasing gaps.
- * \returns       std::ranges::iterator_t<rng> An Iterator following the last removed element. If the iterator
+ * \returns       std::ranges::iterator_t<range_type> An Iterator following the last removed element. If the iterator
  *                `last` refers to the last element, the std::ranges::end() iterator is returned.
  *
  * \throws seqan3::gap_erase_failure if one of the characters in [\p first, \p last) is no seqan3::gap.

--- a/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
+++ b/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
@@ -123,7 +123,7 @@ namespace seqan3
  * \returns       An iterator pointing to the inserted gap.
  *
  * \details
- * \note      This may cause reallocations and thus invalidate all iterators and references. Use the returned iterator.
+ * \note      This may cause reallocations and thus invalidates all iterators and references. Use the returned iterator.
  *
  * \attention This is a concept requirement, not an actual function (however types
  *            modelling this concept will provide an implementation).
@@ -139,7 +139,7 @@ namespace seqan3
  * \returns       An iterator pointing to the first inserted gap or `pos_it` if `size == 0`.
  *
  * \details
- * \note      This may cause reallocations and thus invalidate all iterators and references. Use the returned iterator.
+ * \note      This may cause reallocations and thus invalidates all iterators and references. Use the returned iterator.
  *
  * \attention This is a concept requirement, not an actual function (however types
  *            modelling this concept will provide an implementation).
@@ -157,7 +157,7 @@ namespace seqan3
  * \throws seqan3::gap_erase_failure if there is no seqan3::gap at \p pos_it.
  *
  * \details
- * \note      This may cause reallocations and thus invalidate all iterators and references. Use the returned iterator.
+ * \note      This may cause reallocations and thus invalidates all iterators and references. Use the returned iterator.
  *
  * \attention This is a concept requirement, not an actual function (however types
  *            modelling this concept will provide an implementation).
@@ -176,7 +176,7 @@ namespace seqan3
  * \throws seqan3::gap_erase_failure if one of the characters in [\p first, \p last) no seqan3::gap.
  *
  * \details
- * \note      This may cause reallocations and thus invalidate all iterators and references. Use the returned iterator.
+ * \note      This may cause reallocations and thus invalidates all iterators and references. Use the returned iterator.
  *
  * \attention This is a concept requirement, not an actual function (however types
  *            modelling this concept will provide an implementation).
@@ -239,7 +239,7 @@ SEQAN3_CONCEPT aligned_sequence =
  * This function delegates to the member function `insert(iterator, value)` of
  * the container.
  *
- * \note This may cause reallocations and thus invalidate all iterators and references. Use the returned iterator.
+ * \note This may cause reallocations and thus invalidates all iterators and references. Use the returned iterator.
  */
 template <sequence_container aligned_seq_t>
 //!\cond
@@ -265,7 +265,7 @@ inline typename aligned_seq_t::iterator insert_gap(aligned_seq_t & aligned_seq,
  * This function delegates to the member function `insert(iterator, `size`, `value`)`
  * of the container.
  *
- * \note This may cause reallocations and thus invalidate all iterators and references. Use the returned iterator.
+ * \note This may cause reallocations and thus invalidates all iterators and references. Use the returned iterator.
  */
 template <sequence_container aligned_seq_t>
 //!\cond
@@ -295,7 +295,7 @@ inline typename aligned_seq_t::iterator insert_gap(aligned_seq_t & aligned_seq,
  * container. Before delegating, the function checks if the position pointed to
  * by \p pos_it is an actual seqan3::gap and throws an exception if not.
  *
- * \note This may cause reallocations and thus invalidate all iterators and references. Use the returned iterator.
+ * \note This may cause reallocations and thus invalidates all iterators and references. Use the returned iterator.
  */
 template <sequence_container aligned_seq_t>
 //!\cond
@@ -328,7 +328,7 @@ inline typename aligned_seq_t::iterator erase_gap(aligned_seq_t & aligned_seq,
  * the container. Before delegating, the function checks if the range
  * [\p first, \p last) contains only seqan3::gap symbols.
  *
- * \note This may cause reallocations and thus invalidate all iterators and references. Use the returned iterator.
+ * \note This may cause reallocations and thus invalidates all iterators and references. Use the returned iterator.
  */
 template <sequence_container aligned_seq_t>
 //!\cond
@@ -400,7 +400,7 @@ inline void assign_unaligned(aligned_seq_t & aligned_seq, unaligned_sequence_typ
  *
  * This function delegates to the member function `insert(iterator, size)` of the range.
  *
- * \note This may cause reallocations and thus invalidate all iterators and references. Use the returned iterator.
+ * \note This may cause reallocations and thus invalidates all iterators and references. Use the returned iterator.
  */
 template <typename range_type>
 //!\cond
@@ -431,7 +431,7 @@ std::ranges::iterator_t<range_type> insert_gap(range_type & rng,
  * This function delegates to the member function `erase(it)` of
  * the range.
  *
- * \note This may cause reallocations and thus invalidate all iterators and references. Use the returned iterator.
+ * \note This may cause reallocations and thus invalidates all iterators and references. Use the returned iterator.
  */
 template <typename range_type>
 //!\cond
@@ -459,7 +459,7 @@ std::ranges::iterator_t<range_type> erase_gap(range_type & rng,
  *
  * This function delegates to the member function `erase(first, last)` of the range.
  *
- * \note This may cause reallocations and thus invalidate all iterators and references. Use the returned iterator.
+ * \note This may cause reallocations and thus invalidates all iterators and references. Use the returned iterator.
  */
 template <typename range_type>
 //!\cond

--- a/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
+++ b/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
@@ -450,8 +450,8 @@ std::ranges::iterator_t<range_type> erase_gap(range_type & rng,
  * \param[in,out] rng   The range to modify.
  * \param[in] first     The iterator pointing to the position where to start erasing gaps.
  * \param[in] last      The iterator pointing to the position where to stop erasing gaps.
- * \returns       An iterator following the last removed element. If the iterator `last` refers to the last element, the
- *                std::ranges::end() iterator is returned.
+ * \returns An iterator following the last removed element. If the iterator `last` refers to the last element, the
+ *          std::ranges::end() iterator is returned.
  *
  * \throws seqan3::gap_erase_failure if one of the characters in [\p first, \p last) is no seqan3::gap.
  *

--- a/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
+++ b/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
@@ -151,7 +151,7 @@ namespace seqan3
  * \tparam        aligned_seq_t   Type of the range to modify; must model seqan3::aligned_sequence.
  * \param[in,out] aligned_seq     The aligned sequence to modify.
  * \param[in]     pos_it          The iterator pointing to the position where to erase a gap.
- * \returns       An Iterator following the removed element. If the iterator `pos_it` refers to the last element, the
+ * \returns       An iterator following the removed element. If the iterator `pos_it` refers to the last element, the
  *                std::ranges::end() iterator is returned.
  *
  * \throws seqan3::gap_erase_failure if there is no seqan3::gap at \p pos_it.
@@ -170,7 +170,7 @@ namespace seqan3
  * \param[in,out] aligned_seq     The aligned sequence to modify.
  * \param[in]     first           The iterator pointing to the position where to start erasing gaps.
  * \param[in]     last            The iterator pointing to the position where to stop erasing gaps.
- * \returns       An Iterator following the last removed element. If the iterator `last` refers to the last element, the
+ * \returns       An iterator following the last removed element. If the iterator `last` refers to the last element, the
  *                std::ranges::end() iterator is returned.
  *
  * \throws seqan3::gap_erase_failure if one of the characters in [\p first, \p last) no seqan3::gap.
@@ -284,7 +284,7 @@ inline typename aligned_seq_t::iterator insert_gap(aligned_seq_t & aligned_seq,
  *                                The value type must be a seqan3::gapped alphabet.
  * \param[in,out] aligned_seq     The aligned container to modify.
  * \param[in]     pos_it          The iterator pointing to the position where to erase a gap.
- * \returns       An Iterator following the removed element. If the iterator `pos_it` refers to the last element, the
+ * \returns       An iterator following the removed element. If the iterator `pos_it` refers to the last element, the
  *                std::ranges::end() iterator is returned.
  *
  * \throws seqan3::gap_erase_failure if there is no seqan3::gap at \p pos_it.
@@ -317,7 +317,7 @@ inline typename aligned_seq_t::iterator erase_gap(aligned_seq_t & aligned_seq,
  * \param[in,out] aligned_seq     The aligned container to modify.
  * \param[in]     first           The iterator pointing to the position where to start erasing gaps.
  * \param[in]     last            The iterator pointing to the position where to stop erasing gaps.
- * \returns       An Iterator following the last removed element. If the iterator `last` refers to the last element, the
+ * \returns       An iterator following the last removed element. If the iterator `last` refers to the last element, the
  *                std::ranges::end() iterator is returned.
  *
  * \throws seqan3::gap_erase_failure if one of the characters in [\p first, \p last) no seqan3::gap.
@@ -423,7 +423,7 @@ std::ranges::iterator_t<range_type> insert_gap(range_type & rng,
  * \tparam range_type   Type of the range to modify; must have an erase_gap(it) member function.
  * \param[in,out] rng   The range to modify.
  * \param[in] pos_it    The iterator pointing to the position where to erase one gap.
- * \returns       An Iterator following the removed element. If the iterator `pos_it` refers to the last element, the
+ * \returns       An iterator following the removed element. If the iterator `pos_it` refers to the last element, the
  *                std::ranges::end() iterator is returned.
  *
  * \details
@@ -450,7 +450,7 @@ std::ranges::iterator_t<range_type> erase_gap(range_type & rng,
  * \param[in,out] rng   The range to modify.
  * \param[in] first     The iterator pointing to the position where to start erasing gaps.
  * \param[in] last      The iterator pointing to the position where to stop erasing gaps.
- * \returns       An Iterator following the last removed element. If the iterator `last` refers to the last element, the
+ * \returns       An iterator following the last removed element. If the iterator `last` refers to the last element, the
  *                std::ranges::end() iterator is returned.
  *
  * \throws seqan3::gap_erase_failure if one of the characters in [\p first, \p last) is no seqan3::gap.

--- a/include/seqan3/alignment/matrix/alignment_trace_algorithms.hpp
+++ b/include/seqan3/alignment/matrix/alignment_trace_algorithms.hpp
@@ -136,12 +136,12 @@ inline alignment_t alignment_trace(database_t && database,
         {
             coordinate.col = std::max<size_t>(coordinate.col, 1) - 1;
             --end_aligned_db;
-            insert_gap(std::get<1>(aligned_seq), end_aligned_qy);
+            end_aligned_qy = insert_gap(std::get<1>(aligned_seq), end_aligned_qy);
         }
         else if ((dir & U) == U)
         {
             coordinate.row = std::max<size_t>(coordinate.row, 1) - 1;
-            insert_gap(std::get<0>(aligned_seq), end_aligned_db);
+            end_aligned_db = insert_gap(std::get<0>(aligned_seq), end_aligned_db);
             --end_aligned_qy;
         }
         else if ((dir & D) == D)


### PR DESCRIPTION
use `insert_gap` in alignment_trace_algorithms correctly since it didn't work for `gap_decorators`

This may be an example for a `[[nodiscard]]` attribute :)