### PR TITLE
Makes the exception names of the argument parser consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,13 @@ Note that 3.1.0 will be the first API stable release and interfaces in this rele
 * The member type that denotes which arguments a `validator` can validate has been renamed from `value_type` to
   `option_value_type`
   ([\#1394](https://github.com/seqan/seqan3/pull/1394)).
+* Some exception names were altered and some removed ([\#1394](https://github.com/seqan/seqan3/pull/1467)):
+  * The exception seqan3::parser_invalid_argument was renamed to seqan3::argument_parser_error.
+  * The exception seqan3::validation_failed was renamed to seqan3::validation_error.
+  * The exception seqan3::parser_design_error was renamed to seqan3::design_error and also inherits from
+    seqan3::argument_parser_error.
+  * The exception seqan3::type_conversion_failed was deprecated, you can catch seqan3::user_input_error instead.
+  * The exception seqan3::overflow_error_on_conversion was deprecated, you can catch seqan3::user_input_error instead.
 
 #### Build system
 

--- a/doc/howto/subcommand_argument_parser/subcommand_arg_parse.cpp
+++ b/doc/howto/subcommand_argument_parser/subcommand_arg_parse.cpp
@@ -22,7 +22,7 @@ int run_git_pull(seqan3::argument_parser & parser)
     {
         parser.parse();
     }
-    catch (seqan3::parser_invalid_argument const & ext)
+    catch (seqan3::argument_parser_error const & ext)
     {
         seqan3::debug_stream << "[Error git pull] " << ext.what() << "\n";
         return -1;
@@ -55,7 +55,7 @@ int run_git_push(seqan3::argument_parser & parser)
     {
         parser.parse();
     }
-    catch (seqan3::parser_invalid_argument const & ext)
+    catch (seqan3::argument_parser_error const & ext)
     {
         seqan3::debug_stream << "[Error git push] " << ext.what() << "\n";
         return -1;
@@ -87,7 +87,7 @@ int main(int argc, char const ** argv)
     {
         top_level_parser.parse(); // trigger command line parsing
     }
-    catch (seqan3::parser_invalid_argument const & ext) // catch user errors
+    catch (seqan3::argument_parser_error const & ext) // catch user errors
     {
         seqan3::debug_stream << "[Error] " << ext.what() << "\n"; // customise your error message
         return -1;

--- a/doc/tutorial/alphabet/alphabet_gc_content.cpp
+++ b/doc/tutorial/alphabet/alphabet_gc_content.cpp
@@ -20,7 +20,7 @@ int main (int argc, char * argv[])
     {
         parser.parse();
     }
-    catch (seqan3::parser_invalid_argument const & ext) // the input is invalid
+    catch (seqan3::argument_parser_error const & ext) // the input is invalid
     {
         seqan3::debug_stream << "[PARSER ERROR] " << ext.what() << '\n';
         return 0;

--- a/doc/tutorial/argument_parser/basic_parser_setup.cpp
+++ b/doc/tutorial/argument_parser/basic_parser_setup.cpp
@@ -11,7 +11,7 @@ int main(int argc, char ** argv)
     {
          myparser.parse();                                                  // trigger command line parsing
     }
-    catch (seqan3::parser_invalid_argument const & ext)                     // catch user errors
+    catch (seqan3::argument_parser_error const & ext)                     // catch user errors
     {
         seqan3::debug_stream << "[Winter has come] " << ext.what() << "\n"; // customise your error message
         return -1;

--- a/doc/tutorial/argument_parser/solution3.cpp
+++ b/doc/tutorial/argument_parser/solution3.cpp
@@ -102,7 +102,7 @@ int main(int argc, char ** argv)
     {
          myparser.parse();                                                  // trigger command line parsing
     }
-    catch (seqan3::parser_invalid_argument const & ext)                     // catch user errors
+    catch (seqan3::argument_parser_error const & ext)                     // catch user errors
     {
         seqan3::debug_stream << "[Winter has come] " << ext.what() << "\n"; // customise your error message
         return -1;

--- a/doc/tutorial/argument_parser/solution4.cpp
+++ b/doc/tutorial/argument_parser/solution4.cpp
@@ -102,7 +102,7 @@ int main(int argc, char ** argv)
     {
          myparser.parse();                                                  // trigger command line parsing
     }
-    catch (seqan3::parser_invalid_argument const & ext)                     // catch user errors
+    catch (seqan3::argument_parser_error const & ext)                     // catch user errors
     {
         seqan3::debug_stream << "[Winter has come] " << ext.what() << "\n"; // customise your error message
         return -1;

--- a/doc/tutorial/argument_parser/solution5.cpp
+++ b/doc/tutorial/argument_parser/solution5.cpp
@@ -100,7 +100,7 @@ int main(int argc, char ** argv)
     {
          myparser.parse();                                                  // trigger command line parsing
     }
-    catch (seqan3::parser_invalid_argument const & ext)                     // catch user errors
+    catch (seqan3::argument_parser_error const & ext)                     // catch user errors
     {
         seqan3::debug_stream << "[Winter has come] " << ext.what() << "\n"; // customise your error message
         return -1;

--- a/doc/tutorial/argument_parser/solution6.cpp
+++ b/doc/tutorial/argument_parser/solution6.cpp
@@ -107,7 +107,7 @@ int main(int argc, char ** argv)
     {
          myparser.parse();                                                  // trigger command line parsing
     }
-    catch (seqan3::parser_invalid_argument const & ext)                     // catch user errors
+    catch (seqan3::argument_parser_error const & ext)                     // catch user errors
     {
         seqan3::debug_stream << "[Winter has come] " << ext.what() << "\n"; // customise your error message
         return -1;

--- a/doc/tutorial/concepts/custom_validator_solution2.cpp
+++ b/doc/tutorial/concepts/custom_validator_solution2.cpp
@@ -11,7 +11,7 @@ struct custom_validator
         if ((std::round(val)                         != val) ||  // not an integer
             (std::pow(std::round(std::sqrt(val)), 2) != val))    // not a square
         {
-            throw seqan3::parser_invalid_argument{"The provided number is not an arithmetic square."};
+            throw seqan3::validation_error{"The provided number is not an arithmetic square."};
         }
     }
 
@@ -42,7 +42,7 @@ int main(int argc, char ** argv)
     {
          myparser.parse(); // trigger command line parsing
     }
-    catch (seqan3::parser_invalid_argument const & ext)
+    catch (seqan3::argument_parser_error const & ext)
     {
         seqan3::debug_stream << ext.what() << '\n';
         return -1;

--- a/doc/tutorial/concepts/index.md
+++ b/doc/tutorial/concepts/index.md
@@ -304,7 +304,7 @@ It should print "Yeah!" for the arguments `-i 0`, `-i 4`, or `-i 144`; and/or `-
 It should fail for the arguments `-i 3`; and/or `-j 144` or `-j 3`.
 
 \assignment{Exercise: Custom validator II}
-Implement your validator fully, i.e. make it throw seqan3::parser_invalid_argument if the number provided is not a
+Implement your validator fully, i.e. make it throw seqan3::validation_error if the number provided is not a
 square.
 Also give a nice description for the help page.
 

--- a/doc/tutorial/introduction/introduction_argument_parser.cpp
+++ b/doc/tutorial/introduction/introduction_argument_parser.cpp
@@ -16,7 +16,7 @@ int main(int argc, char * argv[])
     {
         parser.parse();
     }
-    catch (seqan3::parser_invalid_argument const & ext)
+    catch (seqan3::argument_parser_error const & ext)
     {
         seqan3::debug_stream << "[PARSER ERROR] " << ext.what() << '\n';
         return 0;

--- a/doc/tutorial/introduction/introduction_read_fasta.cpp
+++ b/doc/tutorial/introduction/introduction_read_fasta.cpp
@@ -15,7 +15,7 @@ int main(int argc, char * argv[])
     {
         parser.parse();
     }
-    catch (seqan3::parser_invalid_argument const & ext)
+    catch (seqan3::argument_parser_error const & ext)
     {
         seqan3::debug_stream << "[PARSER ERROR] " << ext.what() << '\n';
         return 0;

--- a/doc/tutorial/ranges/range_solution4.cpp
+++ b/doc/tutorial/ranges/range_solution4.cpp
@@ -18,7 +18,7 @@ int main(int argc, char ** argv)
     {
          myparser.parse();
     }
-    catch (seqan3::parser_invalid_argument const & ext)                     // catch user errors
+    catch (seqan3::argument_parser_error const & ext)                     // catch user errors
     {
         seqan3::debug_stream << "[Error] " << ext.what() << "\n";
         return -1;

--- a/doc/tutorial/read_mapper/read_mapper_indexer_step1.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_indexer_step1.cpp
@@ -39,7 +39,7 @@ int main(int argc, char const ** argv)
     {
         parser.parse();
     }
-    catch (seqan3::parser_invalid_argument const & ext)
+    catch (seqan3::argument_parser_error const & ext)
     {
         std::cerr << "[PARSER ERROR] " << ext.what() << '\n';
         return -1;

--- a/doc/tutorial/read_mapper/read_mapper_indexer_step2.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_indexer_step2.cpp
@@ -65,7 +65,7 @@ int main(int argc, char const ** argv)
     {
         parser.parse();
     }
-    catch (seqan3::parser_invalid_argument const & ext)
+    catch (seqan3::argument_parser_error const & ext)
     {
         std::cerr << "[PARSER ERROR] " << ext.what() << '\n';
         return -1;

--- a/doc/tutorial/read_mapper/read_mapper_indexer_step3.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_indexer_step3.cpp
@@ -80,7 +80,7 @@ int main(int argc, char const ** argv)
     {
         parser.parse();
     }
-    catch (seqan3::parser_invalid_argument const & ext)
+    catch (seqan3::argument_parser_error const & ext)
     {
         std::cerr << "[PARSER ERROR] " << ext.what() << '\n';
         return -1;

--- a/doc/tutorial/read_mapper/read_mapper_step1.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_step1.cpp
@@ -57,7 +57,7 @@ int main(int argc, char const ** argv)
     {
         parser.parse();
     }
-    catch (seqan3::parser_invalid_argument const & ext)
+    catch (seqan3::argument_parser_error const & ext)
     {
         std::cerr << "[PARSER ERROR] " << ext.what() << '\n';
         return -1;

--- a/doc/tutorial/read_mapper/read_mapper_step2.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_step2.cpp
@@ -114,7 +114,7 @@ int main(int argc, char const ** argv)
     {
         parser.parse();
     }
-    catch (seqan3::parser_invalid_argument const & ext)
+    catch (seqan3::argument_parser_error const & ext)
     {
         std::cerr << "[PARSER ERROR] " << ext.what() << '\n';
         return -1;

--- a/doc/tutorial/read_mapper/read_mapper_step3.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_step3.cpp
@@ -132,7 +132,7 @@ int main(int argc, char const ** argv)
     {
         parser.parse();
     }
-    catch (seqan3::parser_invalid_argument const & ext)
+    catch (seqan3::argument_parser_error const & ext)
     {
         std::cerr << "[PARSER ERROR] " << ext.what() << '\n';
         return -1;

--- a/doc/tutorial/read_mapper/read_mapper_step4.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_step4.cpp
@@ -138,7 +138,7 @@ int main(int argc, char const ** argv)
     {
         parser.parse();
     }
-    catch (seqan3::parser_invalid_argument const & ext)
+    catch (seqan3::argument_parser_error const & ext)
     {
         std::cerr << "[PARSER ERROR] " << ext.what() << '\n';
         return -1;

--- a/include/seqan3/argument_parser/detail/format_parse.hpp
+++ b/include/seqan3/argument_parser/detail/format_parse.hpp
@@ -181,6 +181,13 @@ public:
     }
 
 private:
+    //!\brief Describes the result of parsing the user input string given the respective option value type.
+    enum class option_parse_result
+    {
+        success, //!< Parsing of user input was successful.
+        error, //!< There was some error while trying to parse the user input.
+        overflow_error //!< Parsing was successful but the arithmetic value would cause an overflow.
+    };
 
     /*!\brief Appends a double dash to a long identifier and returns it.
     * \param[in] long_id The name of the long identifier.
@@ -283,86 +290,87 @@ private:
         return false;
     }
 
-    /*!\brief Tries to cast an input string into a value.
+    /*!\brief Tries to parse an input string into a value using the stream `operator>>`.
      * \tparam option_t Must model seqan3::input_stream_over.
-     * \param[out] value Stores the casted value.
-     * \param[in]  in    The input argument to be casted.
-     *
-     * \throws seqan3::type_conversion_failed
+     * \param[out] value Stores the parsed value.
+     * \param[in] in The input argument to be parsed.
+     * \returns seqan3::option_parse_result::error if `in` could not be parsed via the stream
+     *          operator and otherwise seqan3::option_parse_result::success.
      */
     template <typename option_t>
     //!\cond
         requires input_stream_over<std::istringstream, option_t>
     //!\endcond
-    void retrieve_value(option_t & value, std::string const & in)
+    option_parse_result parse_option_value(option_t & value, std::string const & in)
     {
         std::istringstream stream{in};
         stream >> value;
 
         if (stream.fail() || !stream.eof())
-        {
-            throw type_conversion_failed("Argument " + in + " could not be casted to type " +
-                                         get_type_name_as_string(value) + ".");
-        }
+            return option_parse_result::error;
+
+        return option_parse_result::success;
     }
 
     /*!\brief Sets an option value depending on the keys found in seqan3::enumeration_names<option_t>.
      * \tparam option_t Must model seqan3::named_enumeration.
-     * \param[out] value Stores the cast value.
-     * \param[in]  in    The input argument to be cast.
-     *
-     * \throws seqan3::type_conversion_failed
+     * \param[out] value Stores the parsed value.
+     * \param[in] in The input argument to be parsed.
+     * \returns seqan3::option_parse_result::error if `in` could not be found in the
+     *          seqan3::enumeration_names<option_t> map and otherwise seqan3::option_parse_result::success.
      */
     template <named_enumeration option_t>
-    void retrieve_value(option_t & value, std::string_view const in)
+    option_parse_result parse_option_value(option_t & value, std::string_view const in)
     {
         auto map = seqan3::enumeration_names<option_t>;
 
         if (auto it = map.find(in); it == map.end())
-        {
-            throw type_conversion_failed("Argument " + std::string{in} + " could not be cast to enum type " +
-                                         type_name_as_string<option_t> + ".");
-        }
+            return option_parse_result::error;
         else
-        {
             value = it->second;
-        }
+
+        return option_parse_result::success;
     }
 
     //!\cond
-    void retrieve_value(std::string & value, std::string const & in)
+    option_parse_result parse_option_value(std::string & value, std::string const & in)
     {
         value = in;
+        return option_parse_result::success;
     }
     //!\endcond
 
-    /*!\brief Appends a casted value to its container.
+    /*!\brief Parses the given option value and appends it to the target container.
+     * \tparam container_option_t Must model the seqan3::sequence_container and
+     *                            its value_type must model the seqan3::input_stream_over
      *
-     * \tparam container_option_t Must satisfy the seqan3::sequence_container and
-     *                            its value_type must satisfy the seqan3::input_stream_over
-     *
-     * \param[out] value container that stores the casted value.
-     * \param[in]  in    The input argument to be casted.
+     * \param[out] value The container that stores the parsed value.
+     * \param[in] in The input argument to be parsed.
+     * \returns A seqan3::option_parse_result whether parsing was successful or not.
      */
     template <sequence_container container_option_t>
     //!\cond
         requires input_stream_over<std::istringstream, typename container_option_t::value_type>
     //!\cond
-    void retrieve_value(container_option_t & value, std::string const & in)
+    option_parse_result parse_option_value(container_option_t & value, std::string const & in)
     {
         typename container_option_t::value_type tmp;
 
-        retrieve_value(tmp, in); // throws on failure
-        value.push_back(tmp);
+        auto res = parse_option_value(tmp, in);
+
+        if (res == option_parse_result::success)
+            value.push_back(tmp);
+
+        return res;
     }
 
-    /*!\brief Tries to cast an input string into an arithmetic value.
-     * \tparam option_t  The optiona value type; must model seqan3::arithmetic.
-     * \param[out] value Stores the casted value.
-     * \param[in]  in    The input argument to be casted.
-     *
-     * \throws seqan3::type_conversion_failed
-     * \throws seqan3::overflow_error_on_conversion
+    /*!\brief Tries to parse an input string into an arithmetic value.
+     * \tparam option_t The option value type; must model seqan3::arithmetic.
+     * \param[out] value Stores the parsed value.
+     * \param[in] in The input argument to be parsed.
+     * \returns seqan3::option_parse_result::error if `in` could not be parsed to an arithmetic type
+     *          via std::from_chars, seqan3::option_parse_result::overflow_error if `in` could be parsed but the
+     *          value is too large for the respective type, and otherwise seqan3::option_parse_result::success.
      *
      * \details
      *
@@ -372,30 +380,28 @@ private:
     //!\cond
         requires input_stream_over<std::istringstream, option_t>
     //!\endcond
-    void retrieve_value(option_t & value, std::string const & in)
+    option_parse_result parse_option_value(option_t & value, std::string const & in)
     {
         auto res = std::from_chars(&in[0], &in[in.size()], value);
 
         if (res.ec == std::errc::result_out_of_range)
-            throw overflow_error_on_conversion("Argument " + in + " is not in integer range [" +
-                                               std::to_string(std::numeric_limits<option_t>::min()) + "," +
-                                               std::to_string(std::numeric_limits<option_t>::max()) + "].");
+            return option_parse_result::overflow_error;
         else if (res.ec == std::errc::invalid_argument || res.ptr != &in[in.size()])
-            throw type_conversion_failed("Argument " + in + " could not be casted to type " +
-                                         get_type_name_as_string(value) + ".");
+            return option_parse_result::error;
+
+        return option_parse_result::success;
     }
 
-    /*!\brief Tries to cast an input string into boolean value.
-     * \param[out] value Stores the casted value.
-     * \param[in]  in    The input argument to be casted.
-     *
-     * \throws seqan3::type_conversion_failed
+    /*!\brief Tries to parse an input string into a boolean value.
+     * \param[out] value Stores the parsed value.
+     * \param[in] in The input argument to be parsed.
+     * \returns A seqan3::option_parse_result whether parsing was successful or not.
      *
      * \details
      *
      * This function delegates to std::from_chars.
      */
-    void retrieve_value(bool & value, std::string const & in)
+    option_parse_result parse_option_value(bool & value, std::string const & in)
     {
         if (in == "0")
             value = false;
@@ -406,12 +412,47 @@ private:
         else if (in == "false")
             value = false;
         else
-            throw type_conversion_failed("Argument '" + in + "' could not be casted to boolean.");
+            return option_parse_result::error;
+
+        return option_parse_result::success;
+    }
+
+    /*!\brief Tries to parse an input string into boolean value.
+     * \param[in] res A result value of parsing an input string to the respective option value type.
+     * \param[in] option_name The name of the option whose input was parsed.
+     * \param[in] input_value The original user input in question.
+     *
+     * \throws seqan3::user_input_error if `res` was not seqan3::option_parse_result::success.
+     */
+    template <typename option_type>
+    void throw_on_input_error(option_parse_result const res,
+                              std::string const & option_name,
+                              std::string const & input_value)
+    {
+        std::string msg{"Value parse failed for " + option_name + ": "};
+
+        if (res == option_parse_result::error)
+        {
+            throw parser_invalid_argument{msg + "Argument " + input_value + " could not be parsed as type " +
+                                          get_type_name_as_string(input_value) + "."};
+        }
+
+        if constexpr (arithmetic<option_type>)
+        {
+            if (res == option_parse_result::overflow_error)
+            {
+                throw parser_invalid_argument{msg + "Numeric argument " + input_value + " is not in the valid range [" +
+                                              std::to_string(std::numeric_limits<option_type>::min()) + "," +
+                                              std::to_string(std::numeric_limits<option_type>::max()) + "]."};
+            }
+        }
+
+        assert(res == option_parse_result::success); // if nothing was thrown, the result must have been a success
     }
 
     /*!\brief Handles value retrieval for options based on different kev value pairs.
      *
-     * \param[out] value     Stores the value found in argv, casted by retrieve_value.
+     * \param[out] value     Stores the value found in argv, parsed by parse_option_value.
      * \param[in]  option_it The iterator where the option identifier was found.
      * \param[in]  id        The option identifier supplied on the command line.
      *
@@ -421,7 +462,7 @@ private:
      *
      * The value at option_it is inspected whether it is an '-key value', '-key=value'
      * or '-keyValue' pair and the input is extracted accordingly. The input
-     * will then be tried to be casted into the `value` parameter.
+     * will then be tried to be parsed into the `value` parameter.
      *
      * Returns true on success and false otherwise.
      */
@@ -440,7 +481,7 @@ private:
                 if ((*option_it)[id_size] == '=') // -key=value
                 {
                     if ((*option_it).size() == id_size + 1) // malformed because no value follows '-i='
-                        throw parser_invalid_argument("Value cast failed for option " +
+                        throw parser_invalid_argument("Value parsing failed for option " +
                                                       prepend_dash(id) +
                                                       ": No value was provided.");
                     input_value = (*option_it).substr(id_size + 1);
@@ -457,21 +498,15 @@ private:
                 *option_it = ""; // remove used identifier
                 ++option_it;
                 if (option_it == end_of_options_it) // should not happen
-                    throw parser_invalid_argument("Value cast failed for option " +
+                    throw parser_invalid_argument("Value parsing failed for option " +
                                                   prepend_dash(id) +
                                                   ": No value was provided.");
                 input_value = *option_it;
                 *option_it = ""; // remove value
             }
 
-            try
-            {
-                retrieve_value(value, input_value);
-            }
-            catch (parser_invalid_argument const & ex)
-            {
-                throw parser_invalid_argument("Value cast failed for option " + prepend_dash(id) + ": " + ex.what());
-            }
+            auto res = parse_option_value(value, input_value);
+            throw_on_input_error<option_type>(res, prepend_dash(id), input_value);
 
             return true;
         }
@@ -480,15 +515,15 @@ private:
 
     /*!\brief Handles value retrieval (non container type) options.
      *
-     * \param[out] value Stores the value found in argv, casted by retrieve_value.
-     * \param[in]  id    The option identifier supplied on the command line.
+     * \param[out] value Stores the value found in argv, parsed by parse_option_value.
+     * \param[in] id The option identifier supplied on the command line.
      *
      * \throws seqan3::option_declared_multiple_times
      *
      * \details
      *
      * If the option identifier is found in format_parse::argv, the value of
-     * the following position in argv is tried to be casted into value
+     * the following position in argv is tried to be parsed given the respective option value type
      * and the identifier and value argument are removed from argv.
      *
      * Returns true on success and false otherwise. This is needed to catch
@@ -512,7 +547,7 @@ private:
 
     /*!\brief Handles value retrieval (container type) options.
      *
-     * \param[out] value Stores all values found in argv, casted by retrieve_value.
+     * \param[out] value Stores all values found in argv, parsed by parse_option_value.
      * \param[in]  id    The option identifier supplied on the command line.
      *
      * \details
@@ -689,10 +724,7 @@ private:
      *
      * This function
      * - checks if the user did not provide enough arguments,
-     * - retrieves the next(no container type) or all (container type),
-     *   remaining non empty value/s in argv,
-     * - re-throws the value cast exception with appended positional option information,
-     * - and re-throws the validation exception with appended positional option information.
+     * - retrieves the next (no container type) or all (container type) remaining non empty value/s in argv
      */
     template <typename option_type, typename validator_type>
     void get_positional_option(option_type & value,
@@ -711,15 +743,9 @@ private:
 
             while (it != argv.end())
             {
-                try
-                {
-                    retrieve_value(value, *it);
-                }
-                catch (parser_invalid_argument const & ex)
-                {
-                    throw parser_invalid_argument("Value cast failed for positional option " +
-                                                  std::to_string(positional_option_count) + ": " + ex.what());
-                }
+                auto res = parse_option_value(value, *it);
+                std::string id = "positional option" + std::to_string(positional_option_count);
+                throw_on_input_error<option_type>(res, id, *it);
 
                 *it = ""; // remove arg from argv
                 it = std::find_if(it, argv.end(), [](std::string const & s){return (s != "");});
@@ -728,15 +754,9 @@ private:
         }
         else
         {
-            try
-            {
-                retrieve_value(value, *it);
-            }
-            catch (parser_invalid_argument const & ex)
-            {
-                throw parser_invalid_argument("Value cast failed for positional option " +
-                                              std::to_string(positional_option_count) + ": " + ex.what());
-            }
+            auto res = parse_option_value(value, *it);
+            std::string id = "positional option" + std::to_string(positional_option_count);
+            throw_on_input_error<option_type>(res, id, *it);
 
             *it = ""; // remove arg from argv
         }

--- a/include/seqan3/argument_parser/exceptions.hpp
+++ b/include/seqan3/argument_parser/exceptions.hpp
@@ -19,6 +19,17 @@
 namespace seqan3
 {
 
+//!\brief This class is deprecated.
+//!\deprecated Use seqan3::argument_parser_error instead.
+class SEQAN3_DEPRECATED_310 parser_invalid_argument : public std::invalid_argument
+{
+public:
+    /*!\brief The constructor.
+     * \param[in] s The error message.
+     */
+    parser_invalid_argument(std::string const & s) : std::invalid_argument(s) {}
+};
+
 /*!\brief Argument parser exception that is thrown whenever there is an error
  * while parsing the command line arguments.
  *
@@ -34,67 +45,68 @@ namespace seqan3
  * - Type conversion failed
  * - Validation failed (as defined by the developer)
  */
-class parser_invalid_argument : public std::invalid_argument
+class argument_parser_error : public std::runtime_error
 {
 public:
     /*!\brief The constructor.
      * \param[in] s The error message.
      */
-    parser_invalid_argument(std::string const & s) : std::invalid_argument(s) {}
+    argument_parser_error(std::string const & s) : std::runtime_error(s) {}
 };
 
 //!\brief Argument parser exception thrown when encountering unknown option.
-class unknown_option : public parser_invalid_argument
+class unknown_option : public argument_parser_error
 {
 public:
     /*!\brief The constructor.
      * \param[in] s The error message.
      */
-    unknown_option(std::string const & s) : parser_invalid_argument(s) {}
+    unknown_option(std::string const & s) : argument_parser_error(s) {}
 };
 
 //!\brief Argument parser exception thrown when too many arguments are provided.
-class too_many_arguments : public parser_invalid_argument
+class too_many_arguments : public argument_parser_error
 {
 public:
     /*!\brief The constructor.
      * \param[in] s The error message.
      */
-    too_many_arguments(std::string const & s) : parser_invalid_argument(s) {}
+    too_many_arguments(std::string const & s) : argument_parser_error(s) {}
 };
 
 //!\brief Argument parser exception thrown when too few arguments are provided.
-class too_few_arguments : public parser_invalid_argument
+class too_few_arguments : public argument_parser_error
 {
 public:
     /*!\brief The constructor.
      * \param[in] s The error message.
      */
-    too_few_arguments(std::string const & s) : parser_invalid_argument(s) {}
+    too_few_arguments(std::string const & s) : argument_parser_error(s) {}
 };
 
 //!\brief Argument parser exception thrown when a required option is missing.
-class required_option_missing : public parser_invalid_argument
+class required_option_missing : public argument_parser_error
 {
 public:
     /*!\brief The constructor.
      * \param[in] s The error message.
      */
-    required_option_missing(std::string const & s) : parser_invalid_argument(s) {}
+    required_option_missing(std::string const & s) : argument_parser_error(s) {}
 };
 
 //!\brief Argument parser exception thrown when a non-list option is declared multiple times.
-class option_declared_multiple_times : public parser_invalid_argument
+class option_declared_multiple_times : public argument_parser_error
 {
 public:
     /*!\brief The constructor.
      * \param[in] s The error message.
      */
-    option_declared_multiple_times(std::string const & s) : parser_invalid_argument(s) {}
+    option_declared_multiple_times(std::string const & s) : argument_parser_error(s) {}
 };
 
-//!\brief Argument parser exception thrown when an argument could not be casted to the according type.
-class type_conversion_failed : public parser_invalid_argument
+//!\brief This class is deprecated.
+//!\deprecated Use seqan3::user_input_error instead.
+class SEQAN3_DEPRECATED_310 type_conversion_failed : public parser_invalid_argument
 {
 public:
     /*!\brief The constructor.
@@ -103,8 +115,9 @@ public:
     type_conversion_failed(std::string const & s) : parser_invalid_argument(s) {}
 };
 
-//!\brief Argument parser exception thrown when an argument could not be casted to the according type.
-class overflow_error_on_conversion : public parser_invalid_argument
+//!\brief This class is deprecated.
+//!\deprecated Use seqan3::user_input_error instead.
+class SEQAN3_DEPRECATED_310 overflow_error_on_conversion : public parser_invalid_argument
 {
 public:
     /*!\brief The constructor.
@@ -113,14 +126,35 @@ public:
     overflow_error_on_conversion(std::string const & s) : parser_invalid_argument(s) {}
 };
 
-//!\brief Argument parser exception thrown when an argument could not be casted to the according type.
-class validation_failed : public parser_invalid_argument
+//!\brief Argument parser exception thrown when an incorrect argument is given as (positional) option value.
+class user_input_error : public argument_parser_error
 {
 public:
     /*!\brief The constructor.
      * \param[in] s The error message.
      */
-    validation_failed(std::string const & s) : parser_invalid_argument(s) {}
+    user_input_error(std::string const & s) : argument_parser_error(s) {}
+};
+
+//!\brief Argument parser exception thrown when an argument could not be casted to the according type.
+class validation_error : public argument_parser_error
+{
+public:
+    /*!\brief The constructor.
+     * \param[in] s The error message.
+     */
+    validation_error(std::string const & s) : argument_parser_error(s) {}
+};
+
+//!\brief This class is deprecated.
+//!\deprecated Use seqan3::validation_error instead.
+class SEQAN3_DEPRECATED_310 validation_failed : public argument_parser_error
+{
+public:
+    /*!\brief The constructor.
+     * \param[in] s The error message.
+     */
+    validation_failed(std::string const & s) : argument_parser_error(s) {}
 };
 
 /*!\brief Argument parser exception that is thrown whenever there is an design
@@ -133,7 +167,18 @@ public:
  * - Reuse of a short or long identifier (must be unique)
  * - Both identifiers must not be empty (one is ok)
  */
-class parser_design_error : public std::logic_error
+class design_error : public argument_parser_error
+{
+public:
+    /*!\brief The constructor.
+     * \param[in] s The error message.
+     */
+    design_error(std::string const & s) : argument_parser_error(s) {}
+};
+
+//!\brief This class is deprecated.
+//!\deprecated Use seqan3::design_error instead.
+class SEQAN3_DEPRECATED_310 parser_design_error : std::logic_error
 {
 public:
     /*!\brief The constructor.

--- a/test/snippet/argument_parser/argument_parser_1.cpp
+++ b/test/snippet/argument_parser/argument_parser_1.cpp
@@ -17,7 +17,7 @@ int main(int argc, char ** argv)
     {
         myparser.parse();
     }
-    catch (seqan3::parser_invalid_argument const & ext) // the user did something wrong
+    catch (seqan3::argument_parser_error const & ext) // the user did something wrong
     {
         std::cerr << "[PARSER ERROR] " << ext.what() << "\n"; // customize your error message
         return -1;

--- a/test/snippet/argument_parser/argument_parser_2.cpp
+++ b/test/snippet/argument_parser/argument_parser_2.cpp
@@ -13,7 +13,7 @@ int main(int argc, char ** argv)
     {
         myparser.parse();
     }
-    catch (seqan3::parser_invalid_argument const & ext) // the user did something wrong
+    catch (seqan3::argument_parser_error const & ext) // the user did something wrong
     {
         std::cerr << "The-Age-App - [PARSER ERROR] " << ext.what() << "\n"; // customize your error message
         return -1;

--- a/test/snippet/argument_parser/argument_parser_3.cpp
+++ b/test/snippet/argument_parser/argument_parser_3.cpp
@@ -27,7 +27,7 @@ int main(int argc, char ** argv)
     {
         myparser.parse();
     }
-    catch (seqan3::parser_invalid_argument const & ext) // the user did something wrong
+    catch (seqan3::argument_parser_error const & ext) // the user did something wrong
     {
         std::cerr << ext.what() << "\n";
         return -1;

--- a/test/snippet/argument_parser/custom_argument_parsing_enumeration.cpp
+++ b/test/snippet/argument_parser/custom_argument_parsing_enumeration.cpp
@@ -37,7 +37,7 @@ int main(int argc, char const * argv[])
     {
         parser.parse();
     }
-    catch (seqan3::parser_invalid_argument const & ext) // the user did something wrong
+    catch (seqan3::argument_parser_error const & ext) // the user did something wrong
     {
         std::cerr << "[PARSER ERROR] " << ext.what() << "\n"; // customize your error message
         return -1;

--- a/test/snippet/argument_parser/custom_enumeration.cpp
+++ b/test/snippet/argument_parser/custom_enumeration.cpp
@@ -35,7 +35,7 @@ int main(int argc, char const * argv[])
     {
         parser.parse();
     }
-    catch (seqan3::parser_invalid_argument const & ext) // the user did something wrong
+    catch (seqan3::argument_parser_error const & ext) // the user did something wrong
     {
         std::cerr << "[PARSER ERROR] " << ext.what() << "\n"; // customize your error message
         return -1;

--- a/test/snippet/argument_parser/validators_1.cpp
+++ b/test/snippet/argument_parser/validators_1.cpp
@@ -19,7 +19,7 @@ int main(int argc, const char ** argv)
     {
         myparser.parse();
     }
-    catch (seqan3::parser_invalid_argument const & ext) // the user did something wrong
+    catch (seqan3::argument_parser_error const & ext) // the user did something wrong
     {
         std::cerr << "[PARSER ERROR] " << ext.what() << "\n"; // customize your error message
         return -1;

--- a/test/snippet/argument_parser/validators_2.cpp
+++ b/test/snippet/argument_parser/validators_2.cpp
@@ -19,7 +19,7 @@ int main(int argc, const char ** argv)
     {
         myparser.parse();
     }
-    catch (seqan3::parser_invalid_argument const & ext) // the user did something wrong
+    catch (seqan3::argument_parser_error const & ext) // the user did something wrong
     {
         std::cerr << "[PARSER ERROR] " << ext.what() << "\n"; // customize your error message
         return -1;

--- a/test/snippet/argument_parser/validators_3.cpp
+++ b/test/snippet/argument_parser/validators_3.cpp
@@ -20,7 +20,7 @@ int main(int argc, const char ** argv)
     {
         myparser.parse();
     }
-    catch (seqan3::parser_invalid_argument const & ext) // the user did something wrong
+    catch (seqan3::argument_parser_error const & ext) // the user did something wrong
     {
         std::cerr << "[PARSER ERROR] " << ext.what() << "\n"; // customize your error message
         return -1;

--- a/test/snippet/argument_parser/validators_4.cpp
+++ b/test/snippet/argument_parser/validators_4.cpp
@@ -19,7 +19,7 @@ int main(int argc, const char ** argv)
     {
         myparser.parse();
     }
-    catch (seqan3::parser_invalid_argument const & ext) // the user did something wrong
+    catch (seqan3::argument_parser_error const & ext) // the user did something wrong
     {
         std::cerr << "[PARSER ERROR] " << ext.what() << "\n"; // customize your error message
         return -1;

--- a/test/snippet/argument_parser/validators_chaining.cpp
+++ b/test/snippet/argument_parser/validators_chaining.cpp
@@ -21,7 +21,7 @@ int main(int argc, const char ** argv)
     {
         myparser.parse();
     }
-    catch (seqan3::parser_invalid_argument const & ext) // the user did something wrong
+    catch (seqan3::argument_parser_error const & ext) // the user did something wrong
     {
         std::cerr << "[PARSER ERROR] " << ext.what() << "\n"; // customize your error message
         return -1;

--- a/test/snippet/argument_parser/validators_input_directory.cpp
+++ b/test/snippet/argument_parser/validators_input_directory.cpp
@@ -19,7 +19,7 @@ int main(int argc, const char ** argv)
     {
         myparser.parse();
     }
-    catch (seqan3::parser_invalid_argument const & ext) // the user did something wrong
+    catch (seqan3::argument_parser_error const & ext) // the user did something wrong
     {
         std::cerr << "[PARSER ERROR] " << ext.what() << "\n"; // customize your error message
         return -1;

--- a/test/snippet/argument_parser/validators_input_file.cpp
+++ b/test/snippet/argument_parser/validators_input_file.cpp
@@ -19,7 +19,7 @@ int main(int argc, const char ** argv)
     {
         myparser.parse();
     }
-    catch (seqan3::parser_invalid_argument const & ext) // the user did something wrong
+    catch (seqan3::argument_parser_error const & ext) // the user did something wrong
     {
         std::cerr << "[PARSER ERROR] " << ext.what() << "\n"; // customize your error message
         return -1;

--- a/test/snippet/argument_parser/validators_output_directory.cpp
+++ b/test/snippet/argument_parser/validators_output_directory.cpp
@@ -19,7 +19,7 @@ int main(int argc, const char ** argv)
     {
         myparser.parse();
     }
-    catch (seqan3::parser_invalid_argument const & ext) // the user did something wrong
+    catch (seqan3::argument_parser_error const & ext) // the user did something wrong
     {
         std::cerr << "[PARSER ERROR] " << ext.what() << "\n"; // customize your error message
         return -1;

--- a/test/snippet/argument_parser/validators_output_file.cpp
+++ b/test/snippet/argument_parser/validators_output_file.cpp
@@ -20,7 +20,7 @@ int main(int argc, const char ** argv)
     {
         myparser.parse();
     }
-    catch (seqan3::parser_invalid_argument const & ext) // the user did something wrong
+    catch (seqan3::argument_parser_error const & ext) // the user did something wrong
     {
         std::cerr << "[PARSER ERROR] " << ext.what() << "\n"; // customize your error message
         return -1;

--- a/test/unit/argument_parser/argument_parser_design_error_test.cpp
+++ b/test/unit/argument_parser/argument_parser_design_error_test.cpp
@@ -11,20 +11,20 @@
 
 using namespace seqan3;
 
-TEST(parser_design_error, app_name_validation)
+TEST(design_error, app_name_validation)
 {
     const char * argv[] = {"./argument_parser_test"};
 
     EXPECT_NO_THROW((argument_parser{"test_parser", 1, argv}));
     EXPECT_NO_THROW((argument_parser{"test-parser1234_foo", 1, argv}));
 
-    EXPECT_THROW((argument_parser{"test parser", 1, argv}),       parser_design_error);
-    EXPECT_THROW((argument_parser{"test;", 1, argv}),             parser_design_error);
-    EXPECT_THROW((argument_parser{";", 1, argv}),                 parser_design_error);
-    EXPECT_THROW((argument_parser{"test;bad script:D", 1, argv}), parser_design_error);
+    EXPECT_THROW((argument_parser{"test parser", 1, argv}),       design_error);
+    EXPECT_THROW((argument_parser{"test;", 1, argv}),             design_error);
+    EXPECT_THROW((argument_parser{";", 1, argv}),                 design_error);
+    EXPECT_THROW((argument_parser{"test;bad script:D", 1, argv}), design_error);
 }
 
-TEST(parse_test, parser_design_error)
+TEST(parse_test, design_error)
 {
     int option_value;
 
@@ -33,18 +33,18 @@ TEST(parse_test, parser_design_error)
     argument_parser parser{"test_parser", 1, argv};
     parser.add_option(option_value, 'i', "int", "this is a int option.");
     EXPECT_THROW(parser.add_option(option_value, 'i', "aint", "oh oh same id."),
-                 parser_design_error);
+                 design_error);
 
     // long option
     argument_parser parser2{"test_parser", 1, argv};
     parser2.add_option(option_value, 'i', "int", "this is an int option.");
     EXPECT_THROW(parser2.add_option(option_value, 'a', "int", "oh oh another id."),
-                 parser_design_error);
+                 design_error);
 
     // empty identifier
     argument_parser parser3{"test_parser", 1, argv};
     EXPECT_THROW(parser3.add_option(option_value, '\0', "", "oh oh all is empty."),
-                 parser_design_error);
+                 design_error);
 
     bool flag_value;
 
@@ -52,52 +52,52 @@ TEST(parse_test, parser_design_error)
     argument_parser parser4{"test_parser", 1, argv};
     parser4.add_flag(flag_value, 'i', "int1", "this is an int option.");
     EXPECT_THROW(parser4.add_flag(flag_value, 'i', "int2", "oh oh another id."),
-                 parser_design_error);
+                 design_error);
 
     // long flag
     argument_parser parser5{"test_parser", 1, argv};
     parser5.add_flag(flag_value, 'i', "int", "this is an int option.");
     EXPECT_THROW(parser5.add_flag(flag_value, 'a', "int", "oh oh another id."),
-                 parser_design_error);
+                 design_error);
 
     // empty identifier
     argument_parser parser6{"test_parser", 1, argv};
     EXPECT_THROW(parser6.add_flag(flag_value, '\0', "", "oh oh another id."),
-                 parser_design_error);
+                 design_error);
 
     // positional option not at the end
     const char * argv2[] = {"./argument_parser_test", "arg1", "arg2", "arg3"};
     std::vector<int> vec;
     argument_parser parser7{"test_parser", 4, argv2};
     parser7.add_positional_option(vec, "oh oh list not at the end.");
-    EXPECT_THROW(parser7.add_positional_option(option_value, "desc."), parser_design_error);
+    EXPECT_THROW(parser7.add_positional_option(option_value, "desc."), design_error);
 
     // using h, help, advanced-help, and export-help
     argument_parser parser8{"test_parser", 1, argv};
     EXPECT_THROW(parser8.add_option(option_value, 'h', "", "-h is bad."),
-                 parser_design_error);
+                 design_error);
     EXPECT_THROW(parser8.add_option(option_value, '\0', "help", "help is bad."),
-                 parser_design_error);
+                 design_error);
     EXPECT_THROW(parser8.add_option(option_value, '\0', "advanced-help",
-                 "advanced-help is bad"), parser_design_error);
+                 "advanced-help is bad"), design_error);
     EXPECT_THROW(parser8.add_option(option_value, '\0', "export-help",
-                 "export-help is bad"), parser_design_error);
+                 "export-help is bad"), design_error);
 
     // using one-letter long identifiers.
     argument_parser parser9{"test_parser", 1, argv};
     EXPECT_THROW(parser9.add_option(option_value, 'y', "z", "long identifier is one letter"),
-                 parser_design_error);
+                 design_error);
     EXPECT_THROW(parser9.add_flag(flag_value, 'y', "z", "long identifier is one letter"),
-                 parser_design_error);
+                 design_error);
 
     // using non-printable characters
     argument_parser parser10{"test_parser", 1, argv};
     EXPECT_THROW(parser10.add_option(option_value, '\t', "no\n", "tab and newline don't work!"),
-                 parser_design_error);
+                 design_error);
     EXPECT_THROW(parser10.add_flag(flag_value, 'i', "no\n", "tab and newline don't work!"),
-                 parser_design_error);
+                 design_error);
     EXPECT_THROW(parser10.add_flag(flag_value, 'a', "-no", "can't start long_id with a hyphen"),
-                 parser_design_error);
+                 design_error);
 }
 
 TEST(parse_test, parse_called_twice)
@@ -113,7 +113,7 @@ TEST(parse_test, parse_called_twice)
     EXPECT_TRUE((testing::internal::GetCapturedStderr()).empty());
     EXPECT_EQ(option_value, "option_string");
 
-    EXPECT_THROW(parser.parse(), parser_design_error);
+    EXPECT_THROW(parser.parse(), design_error);
 }
 
 TEST(parse_test, subcommand_argument_parser_error)
@@ -129,14 +129,14 @@ TEST(parse_test, subcommand_argument_parser_error)
         EXPECT_NO_THROW(top_level_parser.parse());
         EXPECT_EQ(true, flag_value);
 
-        EXPECT_THROW(top_level_parser.get_sub_parser(), parser_design_error);
+        EXPECT_THROW(top_level_parser.get_sub_parser(), design_error);
     }
 
     // subcommand key word must only contain alpha numeric characters
     {
         const char * argv[]{"./top_level", "-f"};
-        EXPECT_THROW((argument_parser{"top_level", 2, argv, false, {"with space"}}), parser_design_error);
-        EXPECT_THROW((argument_parser{"top_level", 2, argv, false, {"-dash"}}), parser_design_error);
+        EXPECT_THROW((argument_parser{"top_level", 2, argv, false, {"with space"}}), design_error);
+        EXPECT_THROW((argument_parser{"top_level", 2, argv, false, {"-dash"}}), design_error);
     }
 
     // no positional/options are allowed
@@ -144,7 +144,7 @@ TEST(parse_test, subcommand_argument_parser_error)
         const char * argv[]{"./top_level", "foo"};
         argument_parser top_level_parser{"top_level", 2, argv, false, {"foo"}};
 
-        EXPECT_THROW((top_level_parser.add_option(flag_value, 'f', "foo", "foo bar")), parser_design_error);
-        EXPECT_THROW((top_level_parser.add_positional_option(flag_value, "foo bar")), parser_design_error);
+        EXPECT_THROW((top_level_parser.add_option(flag_value, 'f', "foo", "foo bar")), design_error);
+        EXPECT_THROW((top_level_parser.add_positional_option(flag_value, "foo bar")), design_error);
     }
 }

--- a/test/unit/argument_parser/detail/format_html_test.cpp
+++ b/test/unit/argument_parser/detail/format_html_test.cpp
@@ -189,11 +189,11 @@ TEST(export_help, parse_error)
     const char * argv3[] = {"./help_add_test --version-check 0", "--export-help", "atml"};
 
     // no value after --export-help
-    EXPECT_THROW((argument_parser{"test_parser", 2, argv}), parser_invalid_argument);
+    EXPECT_THROW((argument_parser{"test_parser", 2, argv}), argument_parser_error);
 
     // wrong value after --export-help
-    EXPECT_THROW((argument_parser{"test_parser", 2, argv2}), validation_failed);
+    EXPECT_THROW((argument_parser{"test_parser", 2, argv2}), validation_error);
 
     // wrong value after --export-help
-    EXPECT_THROW((argument_parser{"test_parser", 3, argv3}), validation_failed);
+    EXPECT_THROW((argument_parser{"test_parser", 3, argv3}), validation_error);
 }

--- a/test/unit/argument_parser/format_parse_test.cpp
+++ b/test/unit/argument_parser/format_parse_test.cpp
@@ -385,28 +385,28 @@ TEST(parse_test, empty_value_error)
     argument_parser parser{"test_parser", 2, argv, false};
     parser.add_option(option_value, 'i', "long", "this is a int option.");
 
-    EXPECT_THROW(parser.parse(), parser_invalid_argument);
+    EXPECT_THROW(parser.parse(), argument_parser_error);
 
     // long option
     const char * argv2[] = {"./argument_parser_test", "--long"};
     argument_parser parser2{"test_parser", 2, argv2, false};
     parser2.add_option(option_value, 'i', "long", "this is an int option.");
 
-    EXPECT_THROW(parser2.parse(), parser_invalid_argument);
+    EXPECT_THROW(parser2.parse(), argument_parser_error);
 
     // short option
     const char * argv3[] = {"./argument_parser_test", "-i="};
     argument_parser parser3{"test_parser", 2, argv3, false};
     parser3.add_option(option_value, 'i', "long", "this is an int option.");
 
-    EXPECT_THROW(parser3.parse(), parser_invalid_argument);
+    EXPECT_THROW(parser3.parse(), argument_parser_error);
 
     // short option
     const char * argv4[] = {"./argument_parser_test", "--long="};
     argument_parser parser4{"test_parser", 2, argv4, false};
     parser4.add_option(option_value, 'i', "long", "this is an int option.");
 
-    EXPECT_THROW(parser4.parse(), parser_invalid_argument);
+    EXPECT_THROW(parser4.parse(), argument_parser_error);
 }
 
 TEST(parse_type_test, parse_success_bool_option)
@@ -503,14 +503,14 @@ TEST(parse_type_test, parse_error_bool_option)
     argument_parser parser{"test_parser", 3, argv, false};
     parser.add_option(option_value, 'b', "bool-option", "this is a bool option.");
 
-    EXPECT_THROW(parser.parse(), parser_invalid_argument);
+    EXPECT_THROW(parser.parse(), argument_parser_error);
 
     // fail on number input expect 0 and 1
     const char * argv2[] = {"./argument_parser_test", "-b", "124"};
     argument_parser parser2{"test_parser", 3, argv2, false};
     parser2.add_option(option_value, 'b', "bool-option", "this is a bool option.");
 
-    EXPECT_THROW(parser2.parse(), parser_invalid_argument);
+    EXPECT_THROW(parser2.parse(), argument_parser_error);
 }
 
 TEST(parse_type_test, parse_error_int_option)
@@ -522,21 +522,21 @@ TEST(parse_type_test, parse_error_int_option)
     argument_parser parser{"test_parser", 3, argv, false};
     parser.add_option(option_value, 'i', "int-option", "this is a int option.");
 
-    EXPECT_THROW(parser.parse(), parser_invalid_argument);
+    EXPECT_THROW(parser.parse(), argument_parser_error);
 
     // fail on number followed by character
     const char * argv2[] = {"./argument_parser_test", "-i", "2abc"};
     argument_parser parser2{"test_parser", 3, argv2, false};
     parser2.add_option(option_value, 'i', "int-option", "this is a int option.");
 
-    EXPECT_THROW(parser2.parse(), parser_invalid_argument);
+    EXPECT_THROW(parser2.parse(), argument_parser_error);
 
     // fail on double
     const char * argv3[] = {"./argument_parser_test", "-i", "3.12"};
     argument_parser parser3{"test_parser", 3, argv3, false};
     parser3.add_option(option_value, 'i', "int-option", "this is a int option.");
 
-    EXPECT_THROW(parser3.parse(), parser_invalid_argument);
+    EXPECT_THROW(parser3.parse(), argument_parser_error);
 
     // fail on negative number for unsigned
     unsigned option_value_u;
@@ -544,7 +544,7 @@ TEST(parse_type_test, parse_error_int_option)
     argument_parser parser4{"test_parser", 3, argv4, false};
     parser4.add_option(option_value_u, 'i', "int-option", "this is a int option.");
 
-    EXPECT_THROW(parser4.parse(), parser_invalid_argument);
+    EXPECT_THROW(parser4.parse(), argument_parser_error);
 
     // fail on overflow
     int8_t option_value_int8;
@@ -552,14 +552,14 @@ TEST(parse_type_test, parse_error_int_option)
     argument_parser parser5{"test_parser", 3, argv5, false};
     parser5.add_option(option_value_int8, 'i', "int-option", "this is a int option.");
 
-    EXPECT_THROW(parser5.parse(), parser_invalid_argument);
+    EXPECT_THROW(parser5.parse(), argument_parser_error);
 
     uint8_t option_value_uint8;
     const char * argv6[] = {"./argument_parser_test", "-i", "267"};
     argument_parser parser6{"test_parser", 3, argv6, false};
     parser6.add_option(option_value_uint8, 'i', "int-option", "this is a int option.");
 
-    EXPECT_THROW(parser6.parse(), parser_invalid_argument);
+    EXPECT_THROW(parser6.parse(), argument_parser_error);
 }
 
 TEST(parse_type_test, parse_error_double_option)
@@ -571,14 +571,14 @@ TEST(parse_type_test, parse_error_double_option)
     argument_parser parser{"test_parser", 3, argv, false};
     parser.add_option(option_value, 'd', "double-option", "this is a double option.");
 
-    EXPECT_THROW(parser.parse(), parser_invalid_argument);
+    EXPECT_THROW(parser.parse(), argument_parser_error);
 
     // fail on number followed by character
     const char * argv2[] = {"./argument_parser_test", "-d", "12.457a"};
     argument_parser parser2{"test_parser", 3, argv2, false};
     parser2.add_option(option_value, 'd', "double-option", "this is a double option.");
 
-    EXPECT_THROW(parser2.parse(), parser_invalid_argument);
+    EXPECT_THROW(parser2.parse(), argument_parser_error);
 }
 
 namespace foo
@@ -650,7 +650,7 @@ TEST(parse_type_test, parse_error_enum_option)
     argument_parser parser{"test_parser", 3, argv, false};
     parser.add_option(option_value, 'e', "enum-option", "this is an enum option.");
 
-    EXPECT_THROW(parser.parse(), parser_invalid_argument);
+    EXPECT_THROW(parser.parse(), argument_parser_error);
 }
 
 TEST(parse_test, too_many_arguments_error)
@@ -867,12 +867,12 @@ TEST(parse_test, version_check_option_error)
 {
     {   // version-check must be followed by a value
         const char * argv[] = {"./argument_parser_test", "--version-check"};
-        EXPECT_THROW((argument_parser{"test_parser", 2, argv}), parser_invalid_argument);
+        EXPECT_THROW((argument_parser{"test_parser", 2, argv}), argument_parser_error);
     }
 
     {   // version-check value must be 0 or 1
         const char * argv[] = {"./argument_parser_test", "--version-check", "foo"};
-        EXPECT_THROW((argument_parser{"test_parser", 3, argv}), parser_invalid_argument);
+        EXPECT_THROW((argument_parser{"test_parser", 3, argv}), argument_parser_error);
     }
 }
 
@@ -934,6 +934,6 @@ TEST(parse_test, subcommand_argument_parser_success)
     // incorrect sub command
     {
         const char * argv[]{"./top_level", "-f", "2", "subiddysub", "foo"};
-        EXPECT_THROW((argument_parser{"top_level", 5, argv, false, {"sub1", "sub2"}}), parser_invalid_argument);
+        EXPECT_THROW((argument_parser{"top_level", 5, argv, false, {"sub1", "sub2"}}), argument_parser_error);
     }
 }

--- a/test/unit/argument_parser/format_parse_validators_test.cpp
+++ b/test/unit/argument_parser/format_parse_validators_test.cpp
@@ -91,19 +91,19 @@ TEST(validator_test, input_file)
             std::filesystem::path does_not_exist{tmp_name.get_path()};
             does_not_exist.replace_extension(".bam");
             input_file_validator my_validator{formats};
-            EXPECT_THROW(my_validator(does_not_exist), parser_invalid_argument);
+            EXPECT_THROW(my_validator(does_not_exist), validation_error);
         }
 
         { // file has wrong format.
             input_file_validator my_validator{std::vector{std::string{"sam"}}};
-            EXPECT_THROW(my_validator(tmp_name.get_path()), parser_invalid_argument);
+            EXPECT_THROW(my_validator(tmp_name.get_path()), validation_error);
         }
 
         { // file has no extension.
             std::filesystem::path does_not_exist{tmp_name.get_path()};
             does_not_exist.replace_extension();
             input_file_validator my_validator{formats};
-            EXPECT_THROW(my_validator(does_not_exist), parser_invalid_argument);
+            EXPECT_THROW(my_validator(does_not_exist), validation_error);
         }
 
         {  // read from file
@@ -188,19 +188,19 @@ TEST(validator_test, output_file)
             std::ofstream tmp_file_2(tmp_name_2.get_path());
             std::filesystem::path does_not_exist{tmp_name_2.get_path()};
             output_file_validator my_validator{formats};
-            EXPECT_THROW(my_validator(does_not_exist), parser_invalid_argument);
+            EXPECT_THROW(my_validator(does_not_exist), validation_error);
         }
 
         { // file has wrong format.
             output_file_validator my_validator{std::vector{std::string{"sam"}}};
-            EXPECT_THROW(my_validator(tmp_name.get_path()), parser_invalid_argument);
+            EXPECT_THROW(my_validator(tmp_name.get_path()), validation_error);
         }
 
         { // file has no extension.
             std::filesystem::path no_extension{tmp_name.get_path()};
             no_extension.replace_extension();
             output_file_validator my_validator{formats};
-            EXPECT_THROW(my_validator(no_extension), parser_invalid_argument);
+            EXPECT_THROW(my_validator(no_extension), validation_error);
         }
 
         {  // read from file
@@ -276,7 +276,7 @@ TEST(validator_test, input_directory)
         { // has filename
             std::ofstream tmp_dir(tmp_name.get_path());
             input_directory_validator my_validator{};
-            EXPECT_THROW(my_validator(tmp_name.get_path()), parser_invalid_argument);
+            EXPECT_THROW(my_validator(tmp_name.get_path()), validation_error);
         }
 
         { // read directory
@@ -416,7 +416,7 @@ TEST(validator_test, inputfile_not_readable)
 
     if (!read_access(tmp_file))
     {
-        EXPECT_THROW(input_file_validator{}(tmp_file), parser_invalid_argument);
+        EXPECT_THROW(input_file_validator{}(tmp_file), validation_error);
     }
 
     std::filesystem::permissions(tmp_file,
@@ -441,7 +441,7 @@ TEST(validator_test, inputdir_not_readable)
 
     if (!read_access(tmp_dir))
     {
-        EXPECT_THROW(input_directory_validator{}(tmp_dir), parser_invalid_argument);
+        EXPECT_THROW(input_directory_validator{}(tmp_dir), validation_error);
     }
 
     std::filesystem::permissions(tmp_dir,
@@ -465,7 +465,7 @@ TEST(validator_test, outputfile_not_writable)
 
     if (!write_access(tmp_file))
     {
-        EXPECT_THROW(output_file_validator{}(tmp_file), parser_invalid_argument);
+        EXPECT_THROW(output_file_validator{}(tmp_file), validation_error);
     }
 
     // make sure we can remove the directory.
@@ -491,7 +491,7 @@ TEST(validator_test, outputdir_not_writable)
 
         if (!write_access(tmp_dir))
         {
-            EXPECT_THROW(output_directory_validator{}(tmp_dir), parser_invalid_argument);
+            EXPECT_THROW(output_directory_validator{}(tmp_dir), validation_error);
         }
 
         // make sure we can remove the directory.
@@ -516,7 +516,7 @@ TEST(validator_test, outputdir_not_writable)
 
         if (!write_access(tmp_dir))
         {
-            EXPECT_THROW(output_directory_validator{}(tmp_dir), parser_invalid_argument);
+            EXPECT_THROW(output_directory_validator{}(tmp_dir), validation_error);
         }
 
         // make sure we can remove the directory.
@@ -642,7 +642,7 @@ TEST(validator_test, arithmetic_range_validator_error)
     parser.add_option(option_value, 'i', "int-option", "desc",
                       option_spec::DEFAULT, arithmetic_range_validator{1, 20});
 
-    EXPECT_THROW(parser.parse(), validation_failed);
+    EXPECT_THROW(parser.parse(), validation_error);
 
     // option - below min
     const char * argv2[] = {"./argument_parser_test", "-i", "-21"};
@@ -650,21 +650,21 @@ TEST(validator_test, arithmetic_range_validator_error)
     parser2.add_option(option_value, 'i', "int-option", "desc",
                        option_spec::DEFAULT, arithmetic_range_validator{-20, 20});
 
-    EXPECT_THROW(parser2.parse(), validation_failed);
+    EXPECT_THROW(parser2.parse(), validation_error);
 
     // positional option - above max
     const char * argv3[] = {"./argument_parser_test", "30"};
     argument_parser parser3{"test_parser", 2, argv3, false};
     parser3.add_positional_option(option_value, "desc", arithmetic_range_validator{1, 20});
 
-    EXPECT_THROW(parser3.parse(), validation_failed);
+    EXPECT_THROW(parser3.parse(), validation_error);
 
     // positional option - below min
     const char * argv4[] = {"./argument_parser_test", "--", "-21"};
     argument_parser parser4{"test_parser", 3, argv4, false};
     parser4.add_positional_option(option_value, "desc", arithmetic_range_validator{-20, 20});
 
-    EXPECT_THROW(parser4.parse(), validation_failed);
+    EXPECT_THROW(parser4.parse(), validation_error);
 
     // option - vector
     const char * argv5[] = {"./argument_parser_test", "-i", "-100"};
@@ -672,7 +672,7 @@ TEST(validator_test, arithmetic_range_validator_error)
     parser5.add_option(option_vector, 'i', "int-option", "desc",
                        option_spec::DEFAULT, arithmetic_range_validator{-50, 50});
 
-    EXPECT_THROW(parser5.parse(), validation_failed);
+    EXPECT_THROW(parser5.parse(), validation_error);
 
     // positional option - vector
     option_vector.clear();
@@ -680,7 +680,7 @@ TEST(validator_test, arithmetic_range_validator_error)
     argument_parser parser6{"test_parser", 4, argv6, false};
     parser6.add_positional_option(option_vector, "desc", arithmetic_range_validator{-20, 20});
 
-    EXPECT_THROW(parser6.parse(), validation_failed);
+    EXPECT_THROW(parser6.parse(), validation_error);
 
     // option - double value
     double double_option_value;
@@ -689,7 +689,7 @@ TEST(validator_test, arithmetic_range_validator_error)
     parser7.add_option(double_option_value, 'i', "double-option", "desc",
                        option_spec::DEFAULT, arithmetic_range_validator{1, 20});
 
-    EXPECT_THROW(parser7.parse(), validation_failed);
+    EXPECT_THROW(parser7.parse(), validation_error);
 }
 
 enum class foo
@@ -814,14 +814,14 @@ TEST(validator_test, value_list_validator_error)
     parser.add_option(option_value, 's', "string-option", "desc",
                       option_spec::DEFAULT, value_list_validator{"ha", "ba", "ma"});
 
-    EXPECT_THROW(parser.parse(), validation_failed);
+    EXPECT_THROW(parser.parse(), validation_error);
 
     // positional option
     const char * argv3[] = {"./argument_parser_test", "30"};
     argument_parser parser3{"test_parser", 2, argv3, false};
     parser3.add_positional_option(option_value_int, "desc", value_list_validator{0, 5, 10});
 
-    EXPECT_THROW(parser3.parse(), validation_failed);
+    EXPECT_THROW(parser3.parse(), validation_error);
 
     // positional option - vector
     const char * argv4[] = {"./argument_parser_test", "fo", "ma"};
@@ -829,7 +829,7 @@ TEST(validator_test, value_list_validator_error)
     parser4.add_positional_option(option_vector, "desc",
                                   value_list_validator{"ha", "ba", "ma"});
 
-    EXPECT_THROW(parser4.parse(), validation_failed);
+    EXPECT_THROW(parser4.parse(), validation_error);
 
     // option - vector
     const char * argv5[] = {"./argument_parser_test", "-i", "-10", "-i", "488"};
@@ -837,7 +837,7 @@ TEST(validator_test, value_list_validator_error)
     parser5.add_option(option_vector_int, 'i', "int-option", "desc",
                        option_spec::DEFAULT, value_list_validator<int>{-10, 48, 50});
 
-    EXPECT_THROW(parser5.parse(), validation_failed);
+    EXPECT_THROW(parser5.parse(), validation_error);
 }
 
 TEST(validator_test, regex_validator_success)
@@ -927,7 +927,7 @@ TEST(validator_test, regex_validator_error)
     parser.add_option(option_value, '\0', "string-option", "desc",
                       option_spec::DEFAULT, regex_validator{"tt"});
 
-    EXPECT_THROW(parser.parse(), validation_failed);
+    EXPECT_THROW(parser.parse(), validation_error);
 
     // positional option
     const char * argv2[] = {"./argument_parser_test", "jessy"};
@@ -935,7 +935,7 @@ TEST(validator_test, regex_validator_error)
     parser2.add_positional_option(option_value, "desc",
                                   regex_validator{"[0-9]"});
 
-    EXPECT_THROW(parser2.parse(), validation_failed);
+    EXPECT_THROW(parser2.parse(), validation_error);
 
     // positional option - vector
     const char * argv3[] = {"./argument_parser_test", "rollo", "bttllo", "lollo"};
@@ -943,7 +943,7 @@ TEST(validator_test, regex_validator_error)
     parser3.add_positional_option(option_vector, "desc",
                                   regex_validator{".*oll.*"});
 
-    EXPECT_THROW(parser3.parse(), validation_failed);
+    EXPECT_THROW(parser3.parse(), validation_error);
 
     // option - vector
     option_vector.clear();
@@ -952,7 +952,7 @@ TEST(validator_test, regex_validator_error)
     parser4.add_option(option_vector, 's', "", "desc",
                        option_spec::DEFAULT, regex_validator{"tt"});
 
-    EXPECT_THROW(parser4.parse(), validation_failed);
+    EXPECT_THROW(parser4.parse(), validation_error);
 }
 
 TEST(validator_test, chaining_validators)
@@ -987,7 +987,7 @@ TEST(validator_test, chaining_validators)
         parser.add_option(option_value, 's', "string-option", "desc",
                           option_spec::DEFAULT, absolute_path_validator | my_file_ext_validator);
 
-        EXPECT_THROW(parser.parse(), validation_failed);
+        EXPECT_THROW(parser.parse(), validation_error);
     }
 
     {
@@ -997,7 +997,7 @@ TEST(validator_test, chaining_validators)
         parser.add_option(option_value, 's', "string-option", "desc",
                           option_spec::DEFAULT, absolute_path_validator | my_file_ext_validator);
 
-        EXPECT_THROW(parser.parse(), validation_failed);
+        EXPECT_THROW(parser.parse(), validation_error);
     }
 
     // with temporary validators


### PR DESCRIPTION
Resolves #481

I changed the names according to our resolution in the strategy meeting ([card](https://github.com/orgs/seqan/projects/4#card-26600178))
Additionally, the first commit get's rid of the internal exception in the function retrive_value. The success is indicated by a return value instead and the exception is thrown outside. This also made the exceptions std::type_conversion-error and std::overflow_errow obsolete which lowers the number of exceptions in general.
