### PR TITLE
[INFRA] Add top level CMakeLists.txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,16 @@ The following API changes should be documented as such:
 If possible, provide tooling that performs the changes, e.g. a shell-script.
 -->
 
+# 3.0.2
+
+Note that 3.1.0 will be the first API stable release and interfaces in this release might still change.
+
+## New features
+
+## API changes
+
+## Notable Bug-fixes
+
 # 3.0.1
 
 Note that 3.1.0 will be the first API stable release and interfaces in this release might still change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ Note that 3.1.0 will be the first API stable release and interfaces in this rele
 
 ## New features
 
+#### Build system
+
+* Add top-level `CMakeLists.txt`
+  ([\#1475](https://github.com/seqan/seqan3/pull/1475)).
+
 ## API changes
 
 ## Notable Bug-fixes

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,36 @@
+# -----------------------------------------------------------------------------------------------------
+# Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+# Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+# This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+# shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+# -----------------------------------------------------------------------------------------------------
+
+# This file provides functionality common to the different test modules used by
+# SeqAn3. To build tests, run cmake on one of the sub-folders in this directory
+# which contain a CMakeLists.txt.
+
+cmake_minimum_required (VERSION 3.4)
+
+find_path (SEQAN3_MODULE_PATH "seqan3-config.cmake" HINTS "${CMAKE_CURRENT_LIST_DIR}/build_system/")
+list (APPEND CMAKE_MODULE_PATH "${SEQAN3_MODULE_PATH}")
+
+include (seqan3-config-version)
+
+if (CMAKE_VERSION VERSION_LESS 3.12)
+    project (seqan3 LANGUAGES CXX VERSION "${PACKAGE_VERSION}")
+else ()
+    project (
+        seqan3 LANGUAGES CXX VERSION "${PACKAGE_VERSION}"
+        DESCRIPTION "SeqAn3 -- the modern C++ library for sequence analysis" # since cmake 3.9
+        HOMEPAGE_URL "https://github.com/seqan/seqan3" # since cmake 3.12
+    )
+endif ()
+
+find_package (SeqAn3 3.0 REQUIRED HINTS ${SEQAN3_MODULE_PATH})
+
+option(INSTALL_SEQAN3 "Enable installation of seqan3. (Projects embedding seqan3 may want to turn this OFF.)" ON)
+
+if (INSTALL_SEQAN3)
+    include (seqan3-install)
+    include (seqan3-package)
+endif ()

--- a/doc/setup/quickstart_cmake/index.md
+++ b/doc/setup/quickstart_cmake/index.md
@@ -81,6 +81,7 @@ tutorial
 ├── source
 ├── build
 └── seqan3
+    ├── CMakeLists.txt
     ├── LICENSE
     ├── README.md
     ├── build_system
@@ -104,8 +105,7 @@ To compile it we first create a `CMakeLists.txt` file in the `source` directory:
 cmake_minimum_required (VERSION 3.4)
 project (seqan3_tutorial CXX)
 
-set(SeqAn3_DIR "${CMAKE_SOURCE_DIR}/../seqan3/build_system")
-find_package (SeqAn3 REQUIRED)
+find_package (SeqAn3 3.0.0 REQUIRED HINTS "${CMAKE_SOURCE_DIR}/../seqan3/build_system")
 
 add_executable (hello_world hello_world.cpp)
 
@@ -121,6 +121,7 @@ tutorial
     └── hello_world.cpp
 ├── build
 └── seqan3
+    ├── CMakeLists.txt
     ├── LICENSE
     ...
 ```
@@ -157,8 +158,7 @@ For example, after adding `another_program.cpp` your `CMakeLists.txt` may look l
 cmake_minimum_required (VERSION 3.4)
 project (seqan3_tutorial CXX)
 
-set(SeqAn3_DIR "${CMAKE_SOURCE_DIR}/../seqan3/build_system")
-find_package (SeqAn3 REQUIRED)
+find_package (SeqAn3 3.0.0 REQUIRED HINTS "${CMAKE_SOURCE_DIR}/../seqan3/build_system")
 
 add_executable (hello_world hello_world.cpp)
 add_executable (another_program another_program.cpp)


### PR DESCRIPTION
Add a top-level CMakeLists.txt which exposes seqan3 targets (by calling `find_package(SeqAn3)`), defines `make install` of the seqan3 header-only library and defines how to package seqan3.

This resolves #1387.