### PR TITLE
[FIX] don't include x86intrin.h on powerpc

### DIFF
--- a/include/seqan3/core/simd/detail/builtin_simd_intrinsics.hpp
+++ b/include/seqan3/core/simd/detail/builtin_simd_intrinsics.hpp
@@ -14,7 +14,13 @@
 
 #include <seqan3/core/platform.hpp>
 
-#if __has_include(<x86intrin.h>)
+// Exclude powerpc since it may have this header and triggers a warning (-DNO_WARN_X86_INTRINSICS) which tells you that
+// x86intrin.h is only there to allow porting x86_64 code to powerpc, specifically Intel intrinsics to powerpc64le.
+// Since we will not support powerpc for the builtin simd backend, we will avoid including this header.
+//
+// See the following link for a full description of the x86intrin.h header on powerpc
+// https://github.com/gcc-mirror/gcc/blob/41d6b10e96a1de98e90a7c0378437c3255814b16/gcc/config/rs6000/xmmintrin.h#L27-L55
+#if __has_include(<x86intrin.h>) && !(defined(__powerpc__) || defined(__ppc__) || defined(__PPC__))
 #include <x86intrin.h> // x86 intrinsics (linux)
 #endif
 
@@ -23,6 +29,7 @@
 #endif
 
 // MSVC doesn't define SSE4 macros, even if the instruction set is available (e.g. when AVX is defined)
+// See https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=vs-2019
 #if defined(_MSC_VER) && defined(__AVX__) && !defined(__SSE4_1__) && !defined(__SSE4_2__)
 #define __SSE4_1__ 1
 #define __SSE4_2__ 1


### PR DESCRIPTION
#1407 solved the issue not to use x86 intrinsics if they aren't available. One part of the fix was to detect if the `x86intrin.h` header can be included.

It turns out that on powerpc this `x86intrin.h` header is defined to make porting form x86 more easy and triggers a warning when included. In our case this is not good, because warnings are hard failures in our setup. 

This PR should fix that once for all :sunglasses: 

```log
                 from /scratch/local/seiler/nightly-builds/src/include/seqan3/alignment/pairwise/policy/all.hpp:17,
                 from /scratch/local/seiler/nightly-builds/src/include/seqan3/alignment/pairwise/alignment_configurator.hpp:25,
                 from /scratch/local/seiler/nightly-builds/src/include/seqan3/alignment/pairwise/align_pairwise.hpp:24,
                 from alignment/pairwise/global_affine_unbanded_collection_simd_test.cpp:12:

/usr/lib/gcc/powerpc64le-linux-gnu/8/include/mmintrin.h:52:2: error: #error "Please read comment above.  Use -DNO_WARN_X86_INTRINSICS to disable this error."

 #error "Please read comment above.  Use -DNO_WARN_X86_INTRINSICS to disable this error."
  ^~~~~
In file included from /scratch/local/seiler/nightly-builds/src/include/seqan3/core/simd/detail/builtin_simd_intrinsics.hpp:18,
                 from /scratch/local/seiler/nightly-builds/src/include/seqan3/core/simd/detail/simd_algorithm_sse4.hpp:16,
                 from /scratch/local/seiler/nightly-builds/src/include/seqan3/core/simd/simd_algorithm.hpp:20,
                 from /scratch/local/seiler/nightly-builds/src/include/seqan3/core/simd/view_to_simd.hpp:17,
                 from core/simd/view_to_simd_test.cpp:18:
```