### PR TITLE
[TEST] Adds performance test for vectorised global alingment.

### DIFF
--- a/test/include/seqan3/test/performance/sequence_generator.hpp
+++ b/test/include/seqan3/test/performance/sequence_generator.hpp
@@ -72,9 +72,10 @@ auto generate_numeric_sequence(size_t const len = 500,
     return sequence;
 }
 
-
 template <typename alphabet_t>
-auto generate_sequence_pairs(size_t const sequence_length, size_t const set_size)
+auto generate_sequence_pairs(size_t const sequence_length,
+                             size_t const set_size,
+                             size_t const sequence_variance = 0)
 {
     using sequence_t = decltype(generate_sequence<alphabet_t>());
 
@@ -82,8 +83,8 @@ auto generate_sequence_pairs(size_t const sequence_length, size_t const set_size
 
     for (unsigned i = 0; i < set_size; ++i)
     {
-        sequence_t seq1 = generate_sequence<alphabet_t>(sequence_length, 0, i);
-        sequence_t seq2 = generate_sequence<alphabet_t>(sequence_length, 0, i + set_size);
+        sequence_t seq1 = generate_sequence<alphabet_t>(sequence_length, sequence_variance, i);
+        sequence_t seq2 = generate_sequence<alphabet_t>(sequence_length, sequence_variance, i + set_size);
         vec.push_back(std::pair{seq1, seq2});
     }
 
@@ -110,7 +111,9 @@ auto generate_sequence_seqan2(size_t const len = 500,
 }
 
 template <typename alphabet_t>
-auto generate_sequence_pairs_seqan2(size_t const sequence_length, size_t const set_size)
+auto generate_sequence_pairs_seqan2(size_t const sequence_length,
+                                    size_t const set_size,
+                                    size_t const sequence_variance = 0)
 {
     using sequence_t = decltype(generate_sequence_seqan2<alphabet_t>());
 
@@ -119,8 +122,8 @@ auto generate_sequence_pairs_seqan2(size_t const sequence_length, size_t const s
 
     for (unsigned i = 0; i < set_size; ++i)
     {
-        sequence_t seq1 = generate_sequence_seqan2<alphabet_t>(sequence_length, 0, i);
-        sequence_t seq2 = generate_sequence_seqan2<alphabet_t>(sequence_length, 0, i + set_size);
+        sequence_t seq1 = generate_sequence_seqan2<alphabet_t>(sequence_length, sequence_variance, i);
+        sequence_t seq2 = generate_sequence_seqan2<alphabet_t>(sequence_length, sequence_variance, i + set_size);
         appendValue(vec1, seq1);
         appendValue(vec2, seq2);
     }

--- a/test/performance/alignment/CMakeLists.txt
+++ b/test/performance/alignment/CMakeLists.txt
@@ -1,4 +1,5 @@
 seqan3_benchmark(global_affine_alignment_benchmark.cpp)
 seqan3_benchmark(global_affine_alignment_parallel_benchmark.cpp)
+seqan3_benchmark(global_affine_alignment_simd_benchmark.cpp)
 seqan3_benchmark(local_affine_alignment_benchmark.cpp)
 seqan3_benchmark(edit_distance_unbanded_benchmark.cpp)

--- a/test/performance/alignment/global_affine_alignment_simd_benchmark.cpp
+++ b/test/performance/alignment/global_affine_alignment_simd_benchmark.cpp
@@ -1,0 +1,156 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+#include <benchmark/benchmark.h>
+
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include <seqan3/alignment/pairwise/align_pairwise.hpp>
+#include <seqan3/alphabet/aminoacid/aa20.hpp>
+#include <seqan3/alphabet/nucleotide/dna4.hpp>
+#include <seqan3/range/views/to.hpp>
+#include <seqan3/range/views/zip.hpp>
+#include <seqan3/test/performance/sequence_generator.hpp>
+#include <seqan3/test/performance/units.hpp>
+#include <seqan3/test/seqan2.hpp>
+#include <seqan3/std/ranges>
+
+#ifdef SEQAN3_HAS_SEQAN2
+    #include <seqan/align.h>
+    #include <seqan/align_parallel.h>
+#endif
+
+constexpr auto affine_cfg = seqan3::align_cfg::mode{seqan3::global_alignment} |
+                            seqan3::align_cfg::gap{seqan3::gap_scheme{seqan3::gap_score{-1},
+                                                                      seqan3::gap_open_score{-10}}} |
+                            seqan3::align_cfg::scoring{seqan3::nucleotide_scoring_scheme{seqan3::match_score{4},
+                                                                                         seqan3::mismatch_score{-5}}};
+
+// Globally defined constants to ensure same test data.
+inline constexpr size_t sequence_length = 150;
+inline constexpr size_t set_size        = 1024;
+
+// Range to test for sequence length variance
+inline constexpr size_t deviation_begin = 0;
+inline constexpr size_t deviation_end = 64;
+inline constexpr size_t deviation_step = 8;
+
+//We don't know if the system supports hyper-threading so we use only half the threads so that the
+// simd benchmark is likely to run on physical cores only.
+uint32_t get_number_of_threads()
+{
+    uint32_t thread_count = std::thread::hardware_concurrency();
+    return (thread_count == 1) ? thread_count : thread_count >> 1;
+}
+
+// ============================================================================
+//  affine; score; dna4; collection
+// ============================================================================
+
+template <typename ...align_configs_t>
+void seqan3_affine_dna4_accelerated(benchmark::State & state, align_configs_t && ...configs)
+{
+    size_t sequence_length_variance = state.range(0);
+    auto data = seqan3::test::generate_sequence_pairs<seqan3::dna4>(sequence_length,
+                                                                    set_size,
+                                                                    sequence_length_variance);
+
+    int64_t total = 0;
+    auto accelerate_config = (affine_cfg | ... | configs);
+    for (auto _ : state)
+    {
+        for (auto && res : seqan3::align_pairwise(data, accelerate_config))
+            total += res.score();
+    }
+
+    state.counters["cells"] = seqan3::test::pairwise_cell_updates(data, affine_cfg);
+    state.counters["CUPS"] = seqan3::test::cell_updates_per_second(state.counters["cells"]);
+    state.counters["total"] = total;
+}
+
+BENCHMARK_CAPTURE(seqan3_affine_dna4_accelerated,
+                  simd_with_score,
+                  seqan3::align_cfg::result{seqan3::with_score, seqan3::using_score_type<int16_t>},
+                  seqan3::align_cfg::vectorise)
+                        ->UseRealTime()
+                        ->DenseRange(deviation_begin, deviation_end, deviation_step);
+
+BENCHMARK_CAPTURE(seqan3_affine_dna4_accelerated,
+                  simd_with_end_position,
+                  seqan3::align_cfg::result{seqan3::with_back_coordinate, seqan3::using_score_type<int16_t>},
+                  seqan3::align_cfg::vectorise)
+                        ->UseRealTime()
+                        ->DenseRange(deviation_begin, deviation_end, deviation_step);
+
+BENCHMARK_CAPTURE(seqan3_affine_dna4_accelerated,
+                  simd_parallel_with_score,
+                  seqan3::align_cfg::result{seqan3::with_score, seqan3::using_score_type<int16_t>},
+                  seqan3::align_cfg::vectorise,
+                  seqan3::align_cfg::parallel{get_number_of_threads()})
+                        ->UseRealTime()
+                        ->DenseRange(deviation_begin, deviation_end, deviation_step);
+
+BENCHMARK_CAPTURE(seqan3_affine_dna4_accelerated,
+                  simd_parallel_with_end_position,
+                  seqan3::align_cfg::result{seqan3::with_back_coordinate, seqan3::using_score_type<int16_t>},
+                  seqan3::align_cfg::vectorise,
+                  seqan3::align_cfg::parallel{get_number_of_threads()})
+                        ->UseRealTime()
+                        ->DenseRange(deviation_begin, deviation_end, deviation_step);
+
+#ifdef SEQAN3_HAS_SEQAN2
+
+template <typename ...args_t>
+void seqan2_affine_dna4_accelerated(benchmark::State & state, args_t && ...args)
+{
+    using namespace seqan;
+
+    std::tuple captured_args{args...};
+
+    size_t sequence_length_variance = state.range(0);
+    auto [vec1, vec2] = seqan3::test::generate_sequence_pairs_seqan2<seqan::Dna>(sequence_length,
+                                                                                 set_size,
+                                                                                 sequence_length_variance);
+    auto exec = std::get<0>(captured_args);
+    setNumThreads(exec, std::get<1>(captured_args));
+
+    int64_t total = 0;
+    for (auto _ : state)
+    {
+        // In SeqAn2 the gap open contains already the gap extension costs, that's why we use -11 here.
+        auto res = seqan::globalAlignmentScore(exec, vec1, vec2, seqan::Score<int>{4, -5, -1, -11});
+        total = std::accumulate(seqan::begin(res), seqan::end(res), total);
+    }
+
+    state.counters["cells"] = seqan3::test::pairwise_cell_updates(seqan3::views::zip(vec1, vec2), affine_cfg);
+    state.counters["CUPS"] = seqan3::test::cell_updates_per_second(state.counters["cells"]);
+    state.counters["total"] = total;
+}
+
+// Note SeqAn2 has no parallel interface yet for computing the traceback as well.
+BENCHMARK_CAPTURE(seqan2_affine_dna4_accelerated,
+                  simd_with_score,
+                  seqan::ExecutionPolicy<seqan::Serial, seqan::Vectorial>{},
+                  1)
+                        ->UseRealTime()
+                        ->DenseRange(deviation_begin, deviation_end, deviation_step);
+
+BENCHMARK_CAPTURE(seqan2_affine_dna4_accelerated,
+                  simd_parallel_with_score,
+                  seqan::ExecutionPolicy<seqan::Parallel, seqan::Vectorial>{},
+                  get_number_of_threads())
+                        ->UseRealTime()
+                        ->DenseRange(deviation_begin, deviation_end, deviation_step);
+#endif // SEQAN3_HAS_SEQAN2
+
+// ============================================================================
+//  instantiate tests
+// ============================================================================
+
+BENCHMARK_MAIN();


### PR DESCRIPTION
Resolves #1574 

Adds benchmarks for vectorised global alingment.
Here are the results from my local benchmark with SSE4.

```console
Running ./alignment/global_affine_alignment_simd_benchmark
Run on (8 X 2600 MHz CPU s)
CPU Caches:
  L1 Data 32K (x4)
  L1 Instruction 32K (x4)
  L2 Unified 262K (x4)
  L3 Unified 6291K (x1)
Load Average: 2.92, 2.99, 3.08
----------------------------------------------------------------------------------------------------------------------
Benchmark                                                            Time             CPU   Iterations UserCounters...
----------------------------------------------------------------------------------------------------------------------
seqan3_affine_dna4_simd<score>/0/real_time                     7600672 ns      7558451 ns           91 CUPS=3.07186G/s cells=23.3482M total=-6.47574M
seqan3_affine_dna4_simd<score>/8/real_time                     8264505 ns      8235000 ns           85 CUPS=2.81643G/s cells=23.2764M total=-6.08557M
seqan3_affine_dna4_simd<score>/16/real_time                    8787906 ns      8768622 ns           74 CUPS=2.64134G/s cells=23.2119M total=-5.30077M
seqan3_affine_dna4_simd<score>/24/real_time                    9933738 ns      9890493 ns           69 CUPS=2.32985G/s cells=23.1441M total=-4.98063M
seqan3_affine_dna4_simd<score>/32/real_time                   11355174 ns     11028946 ns           56 CUPS=2.03286G/s cells=23.0835M total=-4.07338M
seqan3_affine_dna4_simd<score>/40/real_time                   11108335 ns     11063083 ns           60 CUPS=2.07201G/s cells=23.0166M total=-4.42242M
seqan3_affine_dna4_simd<score>/48/real_time                   12102132 ns     12062811 ns           53 CUPS=1.8968G/s cells=22.9553M total=-3.96127M
seqan3_affine_dna4_simd<score>/56/real_time                   12775721 ns     12737870 ns           54 CUPS=1.79191G/s cells=22.8929M total=-4.10821M
seqan3_affine_dna4_simd<score>/64/real_time                   13963623 ns     13921420 ns           50 CUPS=1.63493G/s cells=22.8295M total=-3.89155M
seqan3_affine_dna4_simd<end_position>/0/real_time              7446336 ns      7434576 ns           92 CUPS=3.13553G/s cells=23.3482M total=-6.5469M
seqan3_affine_dna4_simd<end_position>/8/real_time              8261761 ns      8239475 ns           80 CUPS=2.81736G/s cells=23.2764M total=-5.7276M
seqan3_affine_dna4_simd<end_position>/16/real_time             8764267 ns      8740378 ns           74 CUPS=2.64847G/s cells=23.2119M total=-5.30077M
seqan3_affine_dna4_simd<end_position>/24/real_time             9604617 ns      9574521 ns           73 CUPS=2.40968G/s cells=23.1441M total=-5.26936M
seqan3_affine_dna4_simd<end_position>/32/real_time            10499088 ns     10469176 ns           68 CUPS=2.19862G/s cells=23.0835M total=-4.94625M
seqan3_affine_dna4_simd<end_position>/40/real_time            11236018 ns     11211016 ns           62 CUPS=2.04846G/s cells=23.0166M total=-4.56983M
seqan3_affine_dna4_simd<end_position>/48/real_time            12122554 ns     12097071 ns           56 CUPS=1.89361G/s cells=22.9553M total=-4.1855M
seqan3_affine_dna4_simd<end_position>/56/real_time            12678628 ns     12658943 ns           53 CUPS=1.80563G/s cells=22.8929M total=-4.03213M
seqan3_affine_dna4_simd<end_position>/64/real_time            13724687 ns     13691569 ns           51 CUPS=1.66339G/s cells=22.8295M total=-3.96938M
seqan3_affine_dna4_simd_parallel<score>/0/real_time            2087733 ns       483611 ns          352 CUPS=11.1835G/s cells=23.3482M total=-25.049M
seqan3_affine_dna4_simd_parallel<score>/8/real_time            2253220 ns       489483 ns          319 CUPS=10.3303G/s cells=23.2764M total=-22.8388M
seqan3_affine_dna4_simd_parallel<score>/16/real_time           2355413 ns       489446 ns          298 CUPS=9.85469G/s cells=23.2119M total=-21.3463M
seqan3_affine_dna4_simd_parallel<score>/24/real_time           3052400 ns       521400 ns          240 CUPS=7.58226G/s cells=23.1441M total=-17.3239M
seqan3_affine_dna4_simd_parallel<score>/32/real_time           2692046 ns       498588 ns          260 CUPS=8.57472G/s cells=23.0835M total=-18.9121M
seqan3_affine_dna4_simd_parallel<score>/40/real_time           2980305 ns       510594 ns          244 CUPS=7.72289G/s cells=23.0166M total=-17.9845M
seqan3_affine_dna4_simd_parallel<score>/48/real_time           3054948 ns       498150 ns          234 CUPS=7.51415G/s cells=22.9553M total=-17.4894M
seqan3_affine_dna4_simd_parallel<score>/56/real_time           3332705 ns       490600 ns          220 CUPS=6.86916G/s cells=22.8929M total=-16.7372M
seqan3_affine_dna4_simd_parallel<score>/64/real_time           3467255 ns       491353 ns          207 CUPS=6.58431G/s cells=22.8295M total=-16.111M
seqan3_affine_dna4_simd_parallel<end_position>/0/real_time     2091084 ns       490408 ns          333 CUPS=11.1656G/s cells=23.3482M total=-23.6969M
seqan3_affine_dna4_simd_parallel<end_position>/8/real_time     2246094 ns       488059 ns          320 CUPS=10.3631G/s cells=23.2764M total=-22.9104M
seqan3_affine_dna4_simd_parallel<end_position>/16/real_time    2428490 ns       493181 ns          271 CUPS=9.55814G/s cells=23.2119M total=-19.4123M
seqan3_affine_dna4_simd_parallel<end_position>/24/real_time    2543703 ns       482522 ns          276 CUPS=9.09858G/s cells=23.1441M total=-19.9225M
seqan3_affine_dna4_simd_parallel<end_position>/32/real_time    2757918 ns       494351 ns          242 CUPS=8.36991G/s cells=23.0835M total=-17.6028M
seqan3_affine_dna4_simd_parallel<end_position>/40/real_time    2933144 ns       481576 ns          238 CUPS=7.84706G/s cells=23.0166M total=-17.5423M
seqan3_affine_dna4_simd_parallel<end_position>/48/real_time    3147359 ns       490943 ns          211 CUPS=7.29352G/s cells=22.9553M total=-15.7704M
seqan3_affine_dna4_simd_parallel<end_position>/56/real_time    3436221 ns       505319 ns          207 CUPS=6.66223G/s cells=22.8929M total=-15.7481M
seqan3_affine_dna4_simd_parallel<end_position>/64/real_time    4233892 ns       531726 ns          168 CUPS=5.39208G/s cells=22.8295M total=-13.0756M
seqan2_affine_dna4_simd<score>/0/real_time                     6474490 ns      6433790 ns          100 CUPS=3.60619G/s cells=23.3482M total=-7.1162M
seqan2_affine_dna4_simd<score>/8/real_time                     9089863 ns      9065743 ns           74 CUPS=2.5607G/s cells=23.2764M total=-5.29803M
seqan2_affine_dna4_simd<score>/16/real_time                    9930999 ns      9902313 ns           67 CUPS=2.33731G/s cells=23.2119M total=-4.79934M
seqan2_affine_dna4_simd<score>/24/real_time                   10916453 ns     10864969 ns           64 CUPS=2.12011G/s cells=23.1441M total=-4.61971M
seqan2_affine_dna4_simd<score>/32/real_time                   11496536 ns     11466183 ns           60 CUPS=2.00787G/s cells=23.0835M total=-4.36434M
seqan2_affine_dna4_simd<score>/40/real_time                   12386365 ns     12343691 ns           55 CUPS=1.85822G/s cells=23.0166M total=-4.05389M
seqan2_affine_dna4_simd<score>/48/real_time                   15312298 ns     15100294 ns           51 CUPS=1.49914G/s cells=22.9553M total=-3.81179M
seqan2_affine_dna4_simd<score>/56/real_time                   14076291 ns     14029867 ns           45 CUPS=1.62634G/s cells=22.8929M total=-3.42351M
seqan2_affine_dna4_simd<score>/64/real_time                   14772515 ns     14730977 ns           43 CUPS=1.5454G/s cells=22.8295M total=-3.34673M
seqan2_affine_dna4_simd_parallel<score>/0/real_time            2170135 ns      1949401 ns          342 CUPS=10.7589G/s cells=23.3482M total=-24.3374M
seqan2_affine_dna4_simd_parallel<score>/8/real_time            2809440 ns      2642644 ns          180 CUPS=8.28506G/s cells=23.2764M total=-12.8871M
seqan2_affine_dna4_simd_parallel<score>/16/real_time           3046737 ns      2841892 ns          167 CUPS=7.6186G/s cells=23.2119M total=-11.9625M
seqan2_affine_dna4_simd_parallel<score>/24/real_time           4252225 ns      3561966 ns          119 CUPS=5.44282G/s cells=23.1441M total=-8.58978M
seqan2_affine_dna4_simd_parallel<score>/32/real_time           4735318 ns      3879006 ns          155 CUPS=4.87476G/s cells=23.0835M total=-11.2745M
seqan2_affine_dna4_simd_parallel<score>/40/real_time           4456511 ns      4060742 ns          178 CUPS=5.1647G/s cells=23.0166M total=-13.1198M
seqan2_affine_dna4_simd_parallel<score>/48/real_time           6129391 ns      5589870 ns          100 CUPS=3.74513G/s cells=22.9553M total=-7.4741M
seqan2_affine_dna4_simd_parallel<score>/56/real_time           9020744 ns      5767146 ns           82 CUPS=2.5378G/s cells=22.8929M total=-6.2384M
seqan2_affine_dna4_simd_parallel<score>/64/real_time           4532458 ns      4268313 ns          144 CUPS=5.03689G/s cells=22.8295M total=-11.2077M
```