### PR TITLE
[FIX] deprecation warning

### DIFF
--- a/test/seqan3-test.cmake
+++ b/test/seqan3-test.cmake
@@ -19,6 +19,8 @@ include (CheckCXXSourceCompiles)
 include (FindPackageHandleStandardArgs)
 include (FindPackageMessage)
 
+option (SEQAN3_TEST_BUILD_OFFLINE "Skip the update step of external projects." OFF)
+
 # ----------------------------------------------------------------------------
 # Paths to folders.
 # ----------------------------------------------------------------------------
@@ -183,7 +185,7 @@ macro (seqan3_require_benchmark)
         SOURCE_DIR "${SEQAN3_BENCHMARK_CLONE_DIR}"
         CMAKE_ARGS "${gbenchmark_project_args}"
         BUILD_BYPRODUCTS "${gbenchmark_path}"
-        UPDATE_DISCONNECTED yes
+        UPDATE_DISCONNECTED ${SEQAN3_TEST_BUILD_OFFLINE}
     )
     unset (gbenchmark_project_args)
 
@@ -227,7 +229,7 @@ macro (seqan3_require_test)
         SOURCE_DIR "${SEQAN3_TEST_CLONE_DIR}"
         CMAKE_ARGS "${gtest_project_args}"
         BUILD_BYPRODUCTS "${gtest_main_path}" "${gtest_path}"
-        UPDATE_DISCONNECTED yes
+        UPDATE_DISCONNECTED ${SEQAN3_TEST_BUILD_OFFLINE}
     )
     unset (gtest_project_args)
 

--- a/test/unit/alignment/pairwise/alignment_range_test.cpp
+++ b/test/unit/alignment/pairwise/alignment_range_test.cpp
@@ -65,9 +65,7 @@ struct iterator_fixture<alignment_range_iterator> : ::testing::Test
     std::vector<size_t> expected_range{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 };
 
-INSTANTIATE_TYPED_TEST_CASE_P(alignment_range_iterator,
-                              iterator_fixture,
-                              alignment_range_iterator);
+INSTANTIATE_TYPED_TEST_SUITE_P(alignment_range_iterator, iterator_fixture, alignment_range_iterator, );
 
 // ----------------------------------------------------------------------------
 // Testing alignment range concepts and interfaces.


### PR DESCRIPTION
```
/home/travis/build/seqan/seqan3/test/unit/alignment/pairwise/alignment_range_test.cpp:68:37: error: ‘constexpr bool testing::internal::InstantiateTypedTestCase_P_IsDeprecated()’ is deprecated: INSTANTIATE_TYPED_TEST_CASE_P is deprecated, please use INSTANTIATE_TYPED_TEST_SUITE_P [-Werror=deprecated-declarations]

   68 | INSTANTIATE_TYPED_TEST_CASE_P(alignment_range_iterator,

      |                                     ^~~~~~~~~~~~~~~~~~~

In file included from /home/travis/build/seqan/seqan3-build/vendor/googletest/googletest/include/gtest/gtest.h:62,

                 from /home/travis/build/seqan/seqan3/test/unit/alignment/pairwise/alignment_range_test.cpp:8:

/home/travis/build/seqan/seqan3-build/vendor/googletest/googletest/include/gtest/internal/gtest-internal.h:1230:16: note: declared here

 1230 | constexpr bool InstantiateTypedTestCase_P_IsDeprecated() { return true; }

      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```