### PR TITLE
[FIX] Fixes read header in bam format.

### DIFF
--- a/include/seqan3/io/alignment_file/format_bam.hpp
+++ b/include/seqan3/io/alignment_file/format_bam.hpp
@@ -334,10 +334,7 @@ inline void format_bam::read_alignment_record(stream_type & stream,
         read_field(stream_view, tmp32);
 
         if (tmp32 > 0) // header text is present
-            read_header(stream_view | views::take_exactly_or_throw(tmp32)
-                                    | views::take_until_and_consume(is_char<'\0'>),
-                        header,
-                        ref_seqs);
+            read_header(stream_view | views::take_exactly_or_throw(tmp32), header, ref_seqs);
 
         int32_t n_ref;
         read_field(stream_view, n_ref);


### PR DESCRIPTION
The header has a well defined byte size and is not appended with a \0 character.

The tests will follow with the PR #1470. This is a cerry-pick of one commit within.