### PR TITLE
[MISC] Improve the l_read_name size computation.

### DIFF
--- a/include/seqan3/io/alignment_file/format_bam.hpp
+++ b/include/seqan3/io/alignment_file/format_bam.hpp
@@ -766,12 +766,20 @@ inline void format_bam::write_alignment_record([[maybe_unused]] stream_type &  s
 
         std::string tag_dict_binary_str = get_tag_dict_str(tag_dict);
 
+        // Compute the value for the l_read_name field for the bam record.
+        // This value is stored including a trailing `0`, so at most 254 characters of the id can be stored, since
+        // the data type to store the value is uint8_t and 255 is the maximal size.
+        // If the id is empty a '*' is written instead, i.e. the written id is never an empty string and stores at least
+        // 2 bytes.
+        uint8_t read_name_size = std::min<uint8_t>(std::ranges::distance(id), 254) + 1;
+        read_name_size += static_cast<uint8_t>(read_name_size == 1); // need size two since empty id is stored as '*'.
+
         alignment_record_core core
         {
             /* block_size  */ 0,  // will be initialised right after
             /* refID       */ -1, // will be initialised right after
             /* pos         */ ref_offset.value_or(-1),
-            /* l_read_name */ std::max<uint8_t>(std::min<size_t>(std::ranges::distance(id) + 1, 255), 2),
+            /* l_read_name */ read_name_size,
             /* mapq        */ mapq,
             /* bin         */ reg2bin(ref_offset.value_or(-1), ref_length),
             /* n_cigar_op  */ static_cast<uint16_t>(cigar_vector.size()),
@@ -850,7 +858,7 @@ inline void format_bam::write_alignment_record([[maybe_unused]] stream_type &  s
 
         std::ranges::copy_n(reinterpret_cast<char *>(&core), sizeof(core), stream_it);  // write core
 
-        if (std::ranges::distance(id) == 0) // empty id is represented as * for backward compatibility
+        if (std::ranges::empty(id)) // empty id is represented as * for backward compatibility
             stream_it = '*';
         else
             std::ranges::copy_n(std::ranges::begin(id), core.l_read_name - 1, stream_it); // write read id


### PR DESCRIPTION
The l_read_name size needs to be truncated at byte 254 to reserve one byte for the trailing '\0' character. This was hard to read from the code before. In addition, this refactoring removes one max computation. 

The tests will follow with the PR #1470. This is a cerry-pick of one commit within.