### PR TITLE
[FIX] Doxygen warnings fixed triggered by version update to 1.8.17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,7 +98,7 @@ matrix:
       directories:
           - /tmp/doxygen-download
     before_install:
-       - DOXYGEN_VER=1.8.16
+       - DOXYGEN_VER=1.8.17
        - DOXYGEN_FOLDER=doxygen-${DOXYGEN_VER}
        - mkdir -p /tmp/doxygen-download
        - wget --no-clobber --directory-prefix=/tmp/doxygen-download/ https://sourceforge.net/projects/doxygen/files/rel-${DOXYGEN_VER}/${DOXYGEN_FOLDER}.linux.bin.tar.gz

--- a/include/seqan3/alphabet/composite/alphabet_tuple_base.hpp
+++ b/include/seqan3/alphabet/composite/alphabet_tuple_base.hpp
@@ -762,4 +762,3 @@ struct tuple_size<tuple_t> :
 {};
 
 } // namespace std
-

--- a/include/seqan3/alphabet/structure/structured_aa.hpp
+++ b/include/seqan3/alphabet/structure/structured_aa.hpp
@@ -77,19 +77,27 @@ public:
 
     using base_type::base_type; // Inherit non-default constructors
 
-
+#if SEQAN3_DOXYGEN_ONLY(1)0
     //!\copydoc alphabet_tuple_base::alphabet_tuple_base(component_type const alph)
-    SEQAN3_DOXYGEN_ONLY(( constexpr structured_aa(component_type const alph) {} ))
-    //!\copydoc alphabet_tuple_base::alphabet_tuple_base(indirect_component_type const alph)
-    SEQAN3_DOXYGEN_ONLY(( constexpr structured_aa(indirect_component_type const alph) {} ))
-    //!\copydoc alphabet_tuple_base::operator=(component_type const alph)
-    SEQAN3_DOXYGEN_ONLY(( constexpr structured_aa & operator=(component_type const alph) {} ))
-    //!\copydoc alphabet_tuple_base::operator=(indirect_component_type const alph)
-    SEQAN3_DOXYGEN_ONLY(( constexpr structured_aa & operator=(indirect_component_type const alph) {} ))
-    //!\}
+    template <typename component_type>
+    constexpr structured_aa(component_type const alph) {}
 
-    // Inherit operators from base
+    //!\copydoc alphabet_tuple_base::alphabet_tuple_base(indirect_component_type const alph)
+    template <typename indirect_component_type>
+    constexpr structured_aa(indirect_component_type const alph) {}
+
+    //!\copydoc alphabet_tuple_base::operator=(component_type const alph)
+    template <typename component_type>
+    constexpr structured_aa & operator=(component_type const alph) {}
+
+    //!\copydoc alphabet_tuple_base::operator=(indirect_component_type const alph)
+    template <typename indirect_component_type>
+    constexpr structured_aa & operator=(indirect_component_type const alph) {}
+#endif
+
+    //!\brief Inherit operators from base
     using base_type::operator=;
+    //!\}
 
     /*!\name Write functions
      * \{

--- a/include/seqan3/io/stream/iterator.hpp
+++ b/include/seqan3/io/stream/iterator.hpp
@@ -43,29 +43,20 @@ struct stream_buffer_exposer : public std::basic_streambuf<char_t, traits_t>
     //!\brief The actual stream type.
     using base_t = std::basic_streambuf<char_t, traits_t>;
 
+    //!\cond
     // Expose protected members:
-    //!\brief Beginning of the buffered part of the input sequence.
     using base_t::eback;
-    //!\brief Current position in the input sequence ("get pointer").
     using base_t::gptr;
-    //!\brief End of the buffered part of the input sequence.
     using base_t::egptr;
-    //!\brief Skips count characters in the get area. This is done by advancing the get pointer by count characters.
-    //        No checks are done for underflow.
     using base_t::gbump;
-    //!\brief Fetch the next available input characters from the sequences and transform them into simd vectors.
     using base_t::underflow;
 
-    //!\brief Beginning of the buffered part of the output sequence.
     using base_t::pbase;
-    //!\brief Current position in the output sequence ("put pointer").
     using base_t::pptr;
-    //!\brief End of the buffered part of the output sequence.
     using base_t::epptr;
-    //!\brief Increase put pointer.
     using base_t::pbump;
-    //!\brief Checks for capacity in the given buffer.
     using base_t::overflow;
+    //!\endcond
 };
 
 /*!\brief Functionally the same as std::istreambuf_iterator, but faster.

--- a/include/seqan3/io/stream/iterator.hpp
+++ b/include/seqan3/io/stream/iterator.hpp
@@ -44,16 +44,27 @@ struct stream_buffer_exposer : public std::basic_streambuf<char_t, traits_t>
     using base_t = std::basic_streambuf<char_t, traits_t>;
 
     // Expose protected members:
+    //!\brief Beginning of the buffered part of the input sequence.
     using base_t::eback;
+    //!\brief Current position in the input sequence ("get pointer").
     using base_t::gptr;
+    //!\brief End of the buffered part of the input sequence.
     using base_t::egptr;
+    //!\brief Skips count characters in the get area. This is done by advancing the get pointer by count characters.
+    //        No checks are done for underflow.
     using base_t::gbump;
+    //!\brief Fetch the next available input characters from the sequences and transform them into simd vectors.
     using base_t::underflow;
 
+    //!\brief Beginning of the buffered part of the output sequence.
     using base_t::pbase;
+    //!\brief Current position in the output sequence ("put pointer").
     using base_t::pptr;
+    //!\brief End of the buffered part of the output sequence.
     using base_t::epptr;
+    //!\brief Increase put pointer.
     using base_t::pbump;
+    //!\brief Checks for capacity in the given buffer.
     using base_t::overflow;
 };
 


### PR DESCRIPTION
Resolves #1499 :

- Doxygen warnings fixed triggered by version update 1.8.16 -> 1.8.17.
- Removed gbump, because it is never used.