### PR TITLE
[MISC] Exchange hard coded seqan version in html test with seqan3::seqan3_version.

### DIFF
--- a/test/unit/argument_parser/detail/format_html_test.cpp
+++ b/test/unit/argument_parser/detail/format_html_test.cpp
@@ -56,7 +56,7 @@ TEST(html_format, empty_information)
                            "<h2>Version</h2>\n"
                            "<strong>Last update:</strong> <br>\n"
                            "<strong>empty_options version:</strong> <br>\n"
-                           "<strong>SeqAn version:</strong> 3.0.0<br>\n"
+                           "<strong>SeqAn version:</strong> " + seqan3_version + "<br>\n"
                            "<br>\n"
                            "</body></html>");
     EXPECT_EQ(my_stdout, expected);
@@ -169,7 +169,7 @@ TEST(html_format, full_information_information)
                           "<h2>Version</h2>\n"
                           "<strong>Last update:</strong> <br>\n"
                           "<strong>program_full_options version:</strong> <br>\n"
-                          "<strong>SeqAn version:</strong> 3.0.0<br>\n"
+                          "<strong>SeqAn version:</strong> " + seqan3_version + "<br>\n"
                           "<h2>Url</h2>\n"
                           "www.seqan.de<br>\n"
                           "<br>\n"


### PR DESCRIPTION
This needs to be merged before bumping the version s.t. no test breaks