### PR TITLE
[TEST] Remove 'using namespace seqan3' from test/snippet

### DIFF
--- a/test/snippet/alignment/matrix/debug_matrix_score.cpp
+++ b/test/snippet/alignment/matrix/debug_matrix_score.cpp
@@ -26,16 +26,16 @@ int main()
         }
     };
 
-    seqan3::debug_stream << "database:\t" << database << std::endl;
-    seqan3::debug_stream << "query:\t\t" << query << std::endl;
-    seqan3::debug_stream << std::endl;
+    seqan3::debug_stream << "database:\t" << database << '\n';
+    seqan3::debug_stream << "query:\t\t" << query << '\n';
+    seqan3::debug_stream << '\n';
 
     seqan3::debug_stream << "score_matrix: " << score_matrix.cols() << " columns and "
-              << score_matrix.rows() << " rows" << std::endl;
+              << score_matrix.rows() << " rows\n";
 
     // Prints out the matrix in a convenient way
-    seqan3::debug_stream << score_matrix << std::endl; // without sequences
-    seqan3::debug_stream << debug_matrix{score_matrix, database, query} << std::endl; // with sequences
+    seqan3::debug_stream << score_matrix << '\n'; // without sequences
+    seqan3::debug_stream << debug_matrix{score_matrix, database, query} << '\n'; // with sequences
     seqan3::debug_stream << seqan3::fmtflags2::utf8 << debug_matrix{score_matrix, database, query}; // as utf8
 
     return 0;

--- a/test/snippet/alignment/matrix/debug_matrix_trace.cpp
+++ b/test/snippet/alignment/matrix/debug_matrix_trace.cpp
@@ -7,7 +7,6 @@
 
 int main()
 {
-    // using namespace seqan3;
     using seqan3::detail::debug_matrix;
     using seqan3::operator""_dna4;
     using seqan3::operator|;
@@ -34,16 +33,16 @@ int main()
         }
     };
 
-    seqan3::debug_stream << "database:\t" << database << std::endl;
-    seqan3::debug_stream << "query:\t\t" << query << std::endl;
-    seqan3::debug_stream << std::endl;
+    seqan3::debug_stream << "database:\t" << database << '\n';
+    seqan3::debug_stream << "query:\t\t" << query << '\n';
+    seqan3::debug_stream << '\n';
 
     seqan3::debug_stream << "trace_matrix: " << trace_matrix.cols() << " columns and "
-              << trace_matrix.rows() << " rows" << std::endl;
+              << trace_matrix.rows() << " rows\n";
 
     // Prints out the matrix in a convenient way
-    seqan3::debug_stream << trace_matrix << std::endl; // without sequences
-    seqan3::debug_stream << debug_matrix{trace_matrix, database, query} << std::endl; // with sequences
+    seqan3::debug_stream << trace_matrix << '\n'; // without sequences
+    seqan3::debug_stream << debug_matrix{trace_matrix, database, query} << '\n'; // with sequences
     seqan3::debug_stream << seqan3::fmtflags2::utf8 << debug_matrix{trace_matrix, database, query}; // as utf8
     return 0;
 }

--- a/test/snippet/alignment/matrix/detail/alignment_matrix_column_major_range_base.cpp
+++ b/test/snippet/alignment/matrix/detail/alignment_matrix_column_major_range_base.cpp
@@ -4,7 +4,6 @@
 #include <seqan3/core/debug_stream.hpp>
 #include <seqan3/std/span>
 
-using namespace seqan3;
 using namespace seqan3::detail;
 
 class my_matrix : public alignment_matrix_column_major_range_base<my_matrix>
@@ -72,5 +71,5 @@ int main()
 
     // Print the matrix column by column
     for (auto col : matrix)
-        debug_stream << col << "\n";
+        seqan3::debug_stream << col << '\n';
 }

--- a/test/snippet/alphabet/nucleotide/sam_dna16.cpp
+++ b/test/snippet/alphabet/nucleotide/sam_dna16.cpp
@@ -10,5 +10,5 @@ int main()
     my_letter.assign_char('=');
 
     my_letter.assign_char('F'); // unknown characters are implicitly converted to N.
-    seqan3::debug_stream << my_letter << std::endl; // "N";
+    seqan3::debug_stream << my_letter << '\n'; // "N";
 }

--- a/test/snippet/alphabet/quality/phred42_literal.cpp
+++ b/test/snippet/alphabet/quality/phred42_literal.cpp
@@ -12,5 +12,5 @@ int main()
     // This is the same as a sequence of char literals:
     std::vector<seqan3::phred42> qual_vec2 = {'#'_phred42, '#'_phred42, '#'_phred42, '!'_phred42};
 
-    seqan3::debug_stream << std::ranges::equal(qual_vec, qual_vec2) << std::endl; // prints 1 (true)
+    seqan3::debug_stream << std::ranges::equal(qual_vec, qual_vec2) << '\n'; // prints 1 (true)
 }

--- a/test/snippet/alphabet/quality/phred63_literal.cpp
+++ b/test/snippet/alphabet/quality/phred63_literal.cpp
@@ -12,5 +12,5 @@ int main()
     // This is the same as a sequence of char literals:
     std::vector<seqan3::phred63> qual_vec2 = {'#'_phred63, '#'_phred63, '#'_phred63, '!'_phred63};
 
-    seqan3::debug_stream << std::ranges::equal(qual_vec, qual_vec2) << std::endl; // prints 1 (true)
+    seqan3::debug_stream << std::ranges::equal(qual_vec, qual_vec2) << '\n'; // prints 1 (true)
 }

--- a/test/snippet/alphabet/quality/phred68legacy_literal.cpp
+++ b/test/snippet/alphabet/quality/phred68legacy_literal.cpp
@@ -13,5 +13,5 @@ int main()
     std::vector<seqan3::phred68legacy> qual_vec2 = {'#'_phred68legacy, '#'_phred68legacy,
                                                     '#'_phred68legacy, '!'_phred68legacy};
 
-    seqan3::debug_stream << std::ranges::equal(qual_vec, qual_vec2) << std::endl; // prints 1 (true)
+    seqan3::debug_stream << std::ranges::equal(qual_vec, qual_vec2) << '\n'; // prints 1 (true)
 }

--- a/test/snippet/alphabet/structure/structured_rna.cpp
+++ b/test/snippet/alphabet/structure/structured_rna.cpp
@@ -3,8 +3,6 @@
 #include <seqan3/alphabet/structure/dot_bracket3.hpp>
 #include <seqan3/core/debug_stream.hpp>
 
-using namespace seqan3;
-
 int main()
 {
     using seqan3::operator""_rna4;

--- a/test/snippet/argument_parser/argument_parser_1.cpp
+++ b/test/snippet/argument_parser/argument_parser_1.cpp
@@ -19,7 +19,7 @@ int main(int argc, char ** argv)
     }
     catch (seqan3::parser_invalid_argument const & ext) // the user did something wrong
     {
-        std::cerr << "[PARSER ERROR] " << ext.what() << "\n"; // customize your error message
+        std::cerr << "[PARSER ERROR] " << ext.what() << '\n'; // customize your error message
         return -1;
     }
 
@@ -32,7 +32,7 @@ int main(int argc, char ** argv)
 
     avg = avg / grades.size();
 
-    seqan3::debug_stream << name << " has an average grade of " << avg << std::endl;
+    seqan3::debug_stream << name << " has an average grade of " << avg << '\n';
 
     return 0;
 }

--- a/test/snippet/argument_parser/argument_parser_2.cpp
+++ b/test/snippet/argument_parser/argument_parser_2.cpp
@@ -15,10 +15,10 @@ int main(int argc, char ** argv)
     }
     catch (seqan3::parser_invalid_argument const & ext) // the user did something wrong
     {
-        std::cerr << "The-Age-App - [PARSER ERROR] " << ext.what() << "\n"; // customize your error message
+        std::cerr << "The-Age-App - [PARSER ERROR] " << ext.what() << '\n'; // customize your error message
         return -1;
     }
 
-    seqan3::debug_stream << "integer given by user: " << age << std::endl;
+    seqan3::debug_stream << "integer given by user: " << age << '\n';
     return 0;
 }

--- a/test/snippet/core/simd/simd_extract.cpp
+++ b/test/snippet/core/simd/simd_extract.cpp
@@ -1,19 +1,17 @@
 #include <seqan3/core/simd/all.hpp>
 
-using namespace seqan3;
-
-using int16x8_t = simd_type_t<int16_t, 8>;
+using int16x8_t = seqan3::simd::simd_type_t<int16_t, 8>;
 
 int main()
 {
     int16x8_t a{0, -1, 2, -3, 4, -5, 6, -7};
 
-    int16x8_t b = detail::extract_halve<1>(a);
-    int16x8_t c = detail::extract_quarter<1>(a);
-    int16x8_t d = detail::extract_eighth<7>(a);
+    int16x8_t b = seqan3::detail::extract_halve<1>(a);
+    int16x8_t c = seqan3::detail::extract_quarter<1>(a);
+    int16x8_t d = seqan3::detail::extract_eighth<7>(a);
 
-    debug_stream << b << "\n"; // [4,-5,6,-7,0,0,0,0]
-    debug_stream << c << "\n"; // [2,-3,0,0,0,0,0,0]
-    debug_stream << d << "\n"; // [-7,0,0,0,0,0,0,0]
+    seqan3::debug_stream << b << '\n'; // [4,-5,6,-7,0,0,0,0]
+    seqan3::debug_stream << c << '\n'; // [2,-3,0,0,0,0,0,0]
+    seqan3::debug_stream << d << '\n'; // [-7,0,0,0,0,0,0,0]
     return 0;
 }

--- a/test/snippet/core/simd/simd_load.cpp
+++ b/test/snippet/core/simd/simd_load.cpp
@@ -1,13 +1,11 @@
 #include <seqan3/core/simd/all.hpp>
 
-using namespace seqan3;
-
-using uint16x8_t = simd_type_t<uint16_t, 8>;
+using uint16x8_t = seqan3::simd::simd_type_t<uint16_t, 8>;
 
 int main()
 {
     std::vector<uint16_t> memory{0, 1, 2, 3, 4, 5, 6, 7};
-    uint16x8_t a = load<uint16x8_t>(memory.data());
-    debug_stream << a << "\n"; // [0,1,2,3,4,5,6,7]
+    uint16x8_t a = seqan3::simd::load<uint16x8_t>(memory.data());
+    seqan3::debug_stream << a << '\n'; // [0,1,2,3,4,5,6,7]
     return 0;
 }

--- a/test/snippet/core/simd/simd_transpose.cpp
+++ b/test/snippet/core/simd/simd_transpose.cpp
@@ -2,9 +2,7 @@
 
 #include <seqan3/core/simd/all.hpp>
 
-using namespace seqan3;
-
-using uint8x4_t = simd_type_t<uint8_t, 4>;
+using uint8x4_t = seqan3::simd::simd_type_t<uint8_t, 4>;
 
 int main()
 {
@@ -12,11 +10,11 @@ int main()
                                      uint8x4_t{0, 1, 2, 3},
                                      uint8x4_t{0, 1, 2, 3},
                                      uint8x4_t{0, 1, 2, 3}}};
-    transpose(matrix);
+    seqan3::simd::transpose(matrix);
 
-    debug_stream << matrix[0] << "\n"; // [0,0,0,0]
-    debug_stream << matrix[1] << "\n"; // [1,1,1,1]
-    debug_stream << matrix[2] << "\n"; // [2,2,2,2]
-    debug_stream << matrix[3] << "\n"; // [3,3,3,3]
+    seqan3::debug_stream << matrix[0] << '\n'; // [0,0,0,0]
+    seqan3::debug_stream << matrix[1] << '\n'; // [1,1,1,1]
+    seqan3::debug_stream << matrix[2] << '\n'; // [2,2,2,2]
+    seqan3::debug_stream << matrix[3] << '\n'; // [3,3,3,3]
     return 0;
 }

--- a/test/snippet/core/simd/simd_upcast.cpp
+++ b/test/snippet/core/simd/simd_upcast.cpp
@@ -1,15 +1,13 @@
 #include <seqan3/core/simd/all.hpp>
 
-using namespace seqan3;
-
-using int16x8_t = simd_type_t<int16_t, 8>;
-using int32x4_t = simd_type_t<int32_t, 4>;
+using int16x8_t = seqan3::simd::simd_type_t<int16_t, 8>;
+using int32x4_t = seqan3::simd::simd_type_t<int32_t, 4>;
 
 int main()
 {
     int16x8_t a{0, -1, 2, -3, 4, -5, 6, -7};
-    int32x4_t b = upcast<int32x4_t>(a);
+    int32x4_t b = seqan3::simd::upcast<int32x4_t>(a);
 
-    debug_stream << b << "\n"; // [0,-1,2,-3]
+    seqan3::debug_stream << b << '\n'; // [0,-1,2,-3]
     return 0;
 }

--- a/test/snippet/range/container/small_string.cpp
+++ b/test/snippet/range/container/small_string.cpp
@@ -7,12 +7,12 @@ int main()
 
     static_assert(sm[0] == 'h');                    // This way I can also test it at compile-time
 
-    seqan3::debug_stream << sm.size() << std::endl; // prints 5! (the null character is only stored internally)
+    seqan3::debug_stream << sm.size() << '\n'; // prints 5! (the null character is only stored internally)
 
     // conversion to a normal string:
     std::string sm_string{sm.str()};
     // access data directly with a pointer to the underlying zero-terminated array:
     char const * sm_cstr{sm.c_str()};
 
-    seqan3::debug_stream << sm << sm_string << sm_cstr << std::endl; // prints "hellohellohello"
+    seqan3::debug_stream << sm << sm_string << sm_cstr << '\n'; // prints "hellohellohello"
 }


### PR DESCRIPTION
& replace std::endl with ‘\n‘.

Resolves #1466 .