### PR TITLE
[TEST] Add regression test for `views::translate_join`

### DIFF
--- a/test/unit/alphabet/views/translate_join_test.cpp
+++ b/test/unit/alphabet/views/translate_join_test.cpp
@@ -190,6 +190,17 @@ TYPED_TEST(nucleotide, view_translate)
     EXPECT_RANGE_EQ(v11[1], "MHAC"_aa27);
     EXPECT_RANGE_EQ(v11[2], "SSRN"_aa27);
     EXPECT_RANGE_EQ(v11[3], "RFRE"_aa27);
+
+    // combinability
+    auto v12 = vec
+             | seqan3::views::complement
+             | seqan3::views::translate_join(seqan3::translation_frames::forward_reverse0)
+             | seqan3::views::deep{std::views::reverse};
+    EXPECT_EQ(v12.size(), 4u);
+    EXPECT_RANGE_EQ(v12[0], "AHMC"_aa27);
+    EXPECT_RANGE_EQ(v12[1], "CAHM"_aa27);
+    EXPECT_RANGE_EQ(v12[2], "NRSS"_aa27);
+    EXPECT_RANGE_EQ(v12[3], "ERFR"_aa27);
 }
 
 TYPED_TEST(nucleotide, view_translate_concepts)


### PR DESCRIPTION
Code example for #1520

This small test case leads to a very complex build failure on GCC7 and to an ICE on GCC9.

It is triggered e.g. when wanting to create a bidirectional index using `views::translate_join` which is arguably a very useful use-case.

I have spent several hours trying to get to the bottom of this, but was not successfull. I recommend opening an issue with GCC.

Here are my notes:
  *  It is neither specific to `views::deep` (you can trigger it by doing a std::views::transform on the outer range and manually calling `std::views::reverse` inside)
  * nor is it specific to `std::views::reverse`. I implemented an entire custom `seqan3::views::reverse` to verify this, it also triggers the problem and also a few other views that I tested (but not all of them).
  * Surprisingly it is not the statement defining the view that triggers the compiler problem, instead it happens on access. [Code compiles cleanly if the view is never accessed] But it is also not the comparison, simply reading the first element is sufficient.