### PR TITLE
[TEST] two_dimensional_matrix_test use original fix again

### DIFF
--- a/test/unit/alignment/matrix/detail/two_dimensional_matrix_test.cpp
+++ b/test/unit/alignment/matrix/detail/two_dimensional_matrix_test.cpp
@@ -30,30 +30,26 @@ using test_matrix_t = seqan3::detail::two_dimensional_matrix<score_t, allocator_
 template <typename score_type, matrix_major_order order = matrix_major_order::row>
 std::vector<score_type, std::allocator<score_type>> create_matrix_storage()
 {
-    // this is a small hack to allow simd types in an initialiser list on gcc 7;
-#if defined(__GNUC__) && (__GNUC__ == 7)
+    // this is a small hack to allow simd types in an initialiser list on gcc 7 and gcc 10;
     using storage_t = std::array<score_type, 12>;
-#else
-    using storage_t = std::vector<score_type>;
-#endif
 
     // note: we represent the same matrix in one case with a row-wise data layout and in the other case with a
     // column-wise data layout. Also note that the score_type can be a builtin integer or a simd vector of a builtin
     // integer.
     storage_t row_wise
-    {
+    {{
         score_type{0}, score_type{1}, score_type{ 2}, score_type{ 3},
         score_type{4}, score_type{5}, score_type{ 6}, score_type{ 7},
         score_type{8}, score_type{9}, score_type{10}, score_type{11}
-    };
+    }};
 
     storage_t column_wise
-    {
+    {{
         score_type{0}, score_type{4}, score_type{8},
         score_type{1}, score_type{5}, score_type{9},
         score_type{2}, score_type{6}, score_type{10},
         score_type{3}, score_type{7}, score_type{11}
-    };
+    }};
 
     // for a simd vector we make sure that some simd values are completely set, i.e. each scalar value in that simd
     // vector has some value.


### PR DESCRIPTION
```
/seqan3/test/unit/alignment/matrix/detail/two_dimensional_matrix_test.cpp: In instantiation of ‘std::vector<T> create_matrix_storage() [with score_type = __vector(1) int; seqan3::detail::matrix_major_order order = seqan3::detail::matrix_major_order::row]’:
/seqan3-build/gcc-10-std17-debug/vendor/googletest/googletest/include/gtest/internal/gtest-internal.h:460:40:   recursively required from ‘gtest_suite_iterator_fixture_::compare_geq<seqan3::detail::two_dimensional_matrix<__vector(1) int, std::allocator<__vector(1) int>, seqan3::detail::matrix_major_order::column> >::compare_geq()’
/seqan3-build/gcc-10-std17-debug/vendor/googletest/googletest/include/gtest/internal/gtest-internal.h:460:40:   required from ‘testing::Test* testing::internal::TestFactoryImpl<TestClass>::CreateTest() [with TestClass = gtest_suite_iterator_fixture_::compare_geq<seqan3::detail::two_dimensional_matrix<__vector(1) int, std::allocator<__vector(1) int>, seqan3::detail::matrix_major_order::column> >]’
/seqan3-build/gcc-10-std17-debug/vendor/googletest/googletest/include/gtest/internal/gtest-internal.h:460:9:   required from here
/seqan3/test/unit/alignment/matrix/detail/two_dimensional_matrix_test.cpp:43:15: error: invalid type ‘__vector(1) int’ as initializer for a vector of type ‘const __vector(1) int’
   43 |     storage_t row_wise
      |               ^~~~~~~~
/seqan3/test/unit/alignment/matrix/detail/two_dimensional_matrix_test.cpp:50:15: error: invalid type ‘__vector(1) int’ as initializer for a vector of type ‘const __vector(1) int’
   50 |     storage_t column_wise
      |               ^~~~~~~~~~~
```