### PR TITLE
[FIX] forward declare must use the same declaration

### DIFF
--- a/include/seqan3/alignment/pairwise/policy/find_optimum_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/find_optimum_policy.hpp
@@ -92,7 +92,7 @@ protected:
     template <typename other_alignment_algorithm_t, typename score_t, typename is_local_t>
     friend class affine_gap_policy;
 
-    template <typename other_alignment_algorithm_t, typename score_t, typename is_local_t>
+    template <typename other_alignment_algorithm_t, simd_concept score_t, typename is_local_t>
     friend class simd_affine_gap_policy;
 
     //!\brief Allow seqan3::detail::affine_gap_init_policy to access check_score.

--- a/include/seqan3/alignment/pairwise/policy/simd_find_optimum_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/simd_find_optimum_policy.hpp
@@ -120,7 +120,7 @@ protected:
     }
 
     //!\brief Befriend the seqan3::detail::simd_affine_gap_policy to grant access to the check_score_of_cell function.
-    template <typename other_alignment_algorithm_t, typename score_t, typename is_local_t>
+    template <typename other_alignment_algorithm_t, simd_concept score_t, typename is_local_t>
     friend class simd_affine_gap_policy;
 
     //!\brief Allow seqan3::detail::affine_gap_init_policy to access check_score.


### PR DESCRIPTION
```
/seqan3/test/unit/alignment/pairwise/pairwise_alignment_collection_test_template.hpp:76:38:   required from ‘void gtest_suite_pairwise_alignment_collection_test_::front_coordinate<gtest_TypeParam_>::TestBody() [with gtest_TypeParam_ = pairwise_alignment_fixture<(& seqan3::test::alignment::collection::global::affine::unbanded::dna4_01)>]’
/seqan3/test/unit/alignment/pairwise/pairwise_alignment_collection_test_template.hpp:66:1:   required from here
/seqan3/include/seqan3/alignment/pairwise/policy/find_optimum_policy.hpp:95:53: error: declaration of template parameter ‘class score_t’ with different constraints
   95 |     template <typename other_alignment_algorithm_t, typename score_t, typename is_local_t>
      |                                                     ^~~~~~~~
In file included from /seqan3/include/seqan3/alignment/pairwise/policy/all.hpp:22,
                 from /seqan3/include/seqan3/alignment/pairwise/alignment_configurator.hpp:25,
                 from /seqan3/include/seqan3/alignment/pairwise/align_pairwise.hpp:24,
                 from /seqan3/test/unit/alignment/pairwise/global_affine_unbanded_collection_test.cpp:12:
/seqan3/include/seqan3/alignment/pairwise/policy/simd_affine_gap_policy.hpp:53:43: note: original declaration appeared here
   53 | template <typename alignment_algorithm_t, simd_concept score_t, typename align_local_t = std::false_type>
      |                                           ^~~~~~~~~~~~
/seqan3/submodules/range-v3/include/range/v3/range/primitives.hpp:252: confused by earlier errors, bailing out
```