### PR TITLE
[FIX] add ; after requires expression

### DIFF
--- a/include/seqan3/search/fm_index/concept.hpp
+++ b/include/seqan3/search/fm_index/concept.hpp
@@ -155,7 +155,7 @@ SEQAN3_CONCEPT fm_index_cursor_specialisation = std::semiregular<t> && requires 
 
     requires fm_index_specialisation<typename t::index_type>;
 
-    requires requires (typename t::index_type const index) { { t(index) } };
+    requires requires (typename t::index_type const index) { { t(index) }; };
 
     requires requires (t cur,
                        typename t::index_type::alphabet_type const c,
@@ -248,7 +248,7 @@ SEQAN3_CONCEPT bi_fm_index_cursor_specialisation = fm_index_cursor_specialisatio
 {
     requires bi_fm_index_specialisation<typename t::index_type>;
 
-    requires requires (typename t::index_type const index) { { t(index) } };
+    requires requires (typename t::index_type const index) { { t(index) }; };
 
     requires requires (t cur,
                        typename t::index_type::alphabet_type const c,


### PR DESCRIPTION
```
In file included from /seqan3/include/seqan3/search/algorithm/detail/search_scheme_algorithm.hpp:22,
                 from /seqan3-build/header-git-std17/seqan3_header_test_files/seqan3/search/algorithm/detail/search_scheme_algorithm-2.cpp:2:
/seqan3/include/seqan3/search/fm_index/concept.hpp:158:74: error: expected ‘;’ before ‘}’ token
  158 |     requires requires (typename t::index_type const index) { { t(index) } };
      |                                                                          ^~
      |                                                                          ;
```