### PR TITLE
[FIX] enums shouldn't be used with same_as

### DIFF
--- a/include/seqan3/alignment/matrix/alignment_coordinate.hpp
+++ b/include/seqan3/alignment/matrix/alignment_coordinate.hpp
@@ -89,7 +89,7 @@ public:
     //!\brief Copy-constructs from another advanceable_alignment_coordinate with a different policy.
     template <advanceable_alignment_coordinate_state other_state>
     //!\cond
-        requires !std::same_as<other_state, state>
+        requires other_state != state
     //!\endcond
     constexpr advanceable_alignment_coordinate(advanceable_alignment_coordinate<other_state> const & other) :
         first{other.first},
@@ -99,7 +99,7 @@ public:
     //!\brief Move-constructs from another advanceable_alignment_coordinate with a different policy.
     template <advanceable_alignment_coordinate_state other_state>
     //!\cond
-        requires !std::same_as<other_state, state>
+        requires other_state != state
     //!\endcond
     constexpr advanceable_alignment_coordinate(advanceable_alignment_coordinate<other_state> && other) :
         first{std::move(other.first)},


### PR DESCRIPTION
```
In file included from /seqan3/include/seqan3/alignment/pairwise/align_result_selector.hpp:20,
                 from /seqan3/include/seqan3/alignment/pairwise/edit_distance_fwd.hpp:17,
                 from /seqan3/include/seqan3/alignment/matrix/edit_distance_trace_matrix_full.hpp:18,
                 from /seqan3/test/unit/alignment/matrix/edit_distance_trace_matrix_full_test.cpp:10:
/seqan3/include/seqan3/alignment/matrix/alignment_coordinate.hpp:92:24: error: type/value mismatch at argument 1 in template parameter list for ‘template<class T, class U> concept const bool std::same_as<T, U>’
   92 |         requires !std::same_as<other_state, state>
      |                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~
```