### PR TITLE
[MISC] remove restraints on comparison operators of small string

### DIFF
--- a/include/seqan3/range/container/small_vector.hpp
+++ b/include/seqan3/range/container/small_vector.hpp
@@ -869,9 +869,6 @@ public:
 
     //!\brief Performs element-wise comparison.
     template <size_t cap2>
-    //!\cond
-        requires cap2 <= capacity_ /* resolves ambiguousness when comparing two small_vectors of unequal capacity */
-    //!\endcond
     friend constexpr bool operator==(small_vector const & lhs, small_vector<value_type, cap2> const & rhs) noexcept
     {
         return std::ranges::equal(lhs, rhs);
@@ -879,9 +876,6 @@ public:
 
     //!\brief Performs element-wise comparison.
     template <size_t cap2>
-    //!\cond
-        requires cap2 <= capacity_
-    //!\endcond
     friend constexpr bool operator!=(small_vector const & lhs, small_vector<value_type, cap2> const & rhs) noexcept
     {
         return !(lhs == rhs);
@@ -889,9 +883,6 @@ public:
 
     //!\brief Performs element-wise comparison.
     template <size_t cap2>
-    //!\cond
-        requires cap2 <= capacity_
-    //!\endcond
     friend constexpr bool operator<(small_vector const & lhs, small_vector<value_type, cap2> const & rhs) noexcept
     {
         for (size_t i = 0; i < std::min(lhs.size(), rhs.size()); ++i)
@@ -904,9 +895,6 @@ public:
 
     //!\brief Performs element-wise comparison.
     template <size_t cap2>
-    //!\cond
-        requires cap2 <= capacity_
-    //!\endcond
     friend constexpr bool operator>(small_vector const & lhs, small_vector<value_type, cap2> const & rhs) noexcept
     {
         for (size_t i = 0; i < std::min(lhs.size(), rhs.size()); ++i)
@@ -919,9 +907,6 @@ public:
 
     //!\brief Performs element-wise comparison.
     template <size_t cap2>
-    //!\cond
-        requires cap2 <= capacity_
-    //!\endcond
     friend constexpr bool operator<=(small_vector const & lhs, small_vector<value_type, cap2> const & rhs) noexcept
     {
         return !(lhs > rhs);
@@ -929,9 +914,6 @@ public:
 
     //!\brief Performs element-wise comparison.
     template <size_t cap2>
-    //!\cond
-        requires cap2 <= capacity_
-    //!\endcond
     friend constexpr bool operator>=(small_vector const & lhs, small_vector<value_type, cap2> const & rhs) noexcept
     {
         return !(lhs < rhs);

--- a/test/unit/range/container/small_string_test.cpp
+++ b/test/unit/range/container/small_string_test.cpp
@@ -16,65 +16,65 @@
 #include <seqan3/test/pretty_printing.hpp>
 
 using namespace std::literals;
-using namespace seqan3;
 
 // standard construction.
 TEST(small_string, standard_construction)
 {
-    EXPECT_TRUE((std::is_default_constructible_v<small_string<4>>));
-    EXPECT_TRUE((std::is_nothrow_default_constructible_v<small_string<4>>));
-    EXPECT_TRUE((std::is_copy_constructible_v<small_string<4>>));
-    EXPECT_TRUE((std::is_trivially_copy_constructible_v<small_string<4>>));
-    EXPECT_TRUE((std::is_nothrow_copy_constructible_v<small_string<4>>));
-    EXPECT_TRUE((std::is_move_constructible_v<small_string<4>>));
-    EXPECT_TRUE((std::is_trivially_move_constructible_v<small_string<4>>));
-    EXPECT_TRUE((std::is_nothrow_move_constructible_v<small_string<4>>));
-    EXPECT_TRUE((std::is_copy_assignable_v<small_string<4>>));
-    EXPECT_TRUE((std::is_trivially_copy_assignable_v<small_string<4>>));
-    EXPECT_TRUE((std::is_nothrow_copy_assignable_v<small_string<4>>));
-    EXPECT_TRUE((std::is_move_assignable_v<small_string<4>>));
-    EXPECT_TRUE((std::is_trivially_move_assignable_v<small_string<4>>));
-    EXPECT_TRUE((std::is_nothrow_move_assignable_v<small_string<4>>));
+    EXPECT_TRUE((std::is_default_constructible_v<seqan3::small_string<4>>));
+    EXPECT_TRUE((std::is_nothrow_default_constructible_v<seqan3::small_string<4>>));
+    EXPECT_TRUE((std::is_copy_constructible_v<seqan3::small_string<4>>));
+    EXPECT_TRUE((std::is_trivially_copy_constructible_v<seqan3::small_string<4>>));
+    EXPECT_TRUE((std::is_nothrow_copy_constructible_v<seqan3::small_string<4>>));
+    EXPECT_TRUE((std::is_move_constructible_v<seqan3::small_string<4>>));
+    EXPECT_TRUE((std::is_trivially_move_constructible_v<seqan3::small_string<4>>));
+    EXPECT_TRUE((std::is_nothrow_move_constructible_v<seqan3::small_string<4>>));
+    EXPECT_TRUE((std::is_copy_assignable_v<seqan3::small_string<4>>));
+    EXPECT_TRUE((std::is_trivially_copy_assignable_v<seqan3::small_string<4>>));
+    EXPECT_TRUE((std::is_nothrow_copy_assignable_v<seqan3::small_string<4>>));
+    EXPECT_TRUE((std::is_move_assignable_v<seqan3::small_string<4>>));
+    EXPECT_TRUE((std::is_trivially_move_assignable_v<seqan3::small_string<4>>));
+    EXPECT_TRUE((std::is_nothrow_move_assignable_v<seqan3::small_string<4>>));
 }
 
 TEST(small_string, container)
 {
-    EXPECT_TRUE(container<small_string<4>>);
-    EXPECT_TRUE(std::ranges::random_access_range<small_string<4>>);
+    EXPECT_TRUE(seqan3::container<seqan3::small_string<4>>);
+    EXPECT_TRUE(std::ranges::random_access_range<seqan3::small_string<4>>);
 }
 
 // construction from literal.
 TEST(small_string, construct_from_literal)
 {
-    EXPECT_TRUE((std::is_same_v<small_string<5>, decltype(small_string{"hello"})>));
+    EXPECT_TRUE((std::is_same_v<seqan3::small_string<5>, decltype(seqan3::small_string{"hello"})>));
 }
 
 // construction from char.
 TEST(small_string, construct_from_char)
 {
-    EXPECT_TRUE((std::is_same_v<small_string<1>, decltype(small_string{'h'})>));
+    EXPECT_TRUE((std::is_same_v<seqan3::small_string<1>, decltype(seqan3::small_string{'h'})>));
 }
 
 // construction from array.
 TEST(small_string, construct_from_array)
 {
-    EXPECT_TRUE((std::is_same_v<small_string<5>, decltype(small_string{std::array{'h','e','l','l','o'}})>));
+    EXPECT_TRUE((std::is_same_v<seqan3::small_string<5>,
+                                decltype(seqan3::small_string{std::array{'h','e','l','l','o'}})>));
 }
 
 // assignment from literal.
 TEST(small_string, assign_from_literal)
 {
-    small_string<20> em{};
+    seqan3::small_string<20> em{};
     em = "hello";
-    EXPECT_EQ(em, small_string<20>{"hello"});
+    EXPECT_EQ(em, seqan3::small_string<20>{"hello"});
 
     em.assign("boo");
-    EXPECT_EQ(em, small_string<20>{"boo"});
+    EXPECT_EQ(em, seqan3::small_string<20>{"boo"});
 }
 
 TEST(small_string, capacity)
 {
-    constexpr small_string em{"hello"};
+    constexpr seqan3::small_string em{"hello"};
 
     EXPECT_EQ(em.max_size(), 5u);
     constexpr auto msize = em.max_size();
@@ -88,42 +88,42 @@ TEST(small_string, capacity)
 TEST(small_string, c_str)
 {
     {
-        small_string em{"hello"};
+        seqan3::small_string em{"hello"};
         EXPECT_EQ(std::string{em.c_str()}, "hello"s);
     }
 
     {
-        small_string em{'x'};
+        seqan3::small_string em{'x'};
         EXPECT_EQ(std::string{em.c_str()}, "x"s);
     }
 }
 
 TEST(small_string, string)
 {
-    small_string em{"hello"};
+    seqan3::small_string em{"hello"};
     EXPECT_EQ(em.str(), "hello"s);  // explicit
 }
 
 TEST(small_string, implicit_conversion)
 {
-    small_string em{"hello"};
+    seqan3::small_string em{"hello"};
     std::string str = em;
     EXPECT_EQ(str, "hello"s);  // explicit
 }
 
 constexpr bool erase_test()
 {
-    small_string em{"hello"};
+    seqan3::small_string em{"hello"};
     em.erase();
     bool res = em.empty();
 
-    small_string em1{"hello"};
+    seqan3::small_string em1{"hello"};
     em1.erase(2);
-    res = res && (em1 == small_string<5>{"he"});
+    res = res && (em1 == seqan3::small_string<5>{"he"});
 
-    small_string em2{"hello"};
+    seqan3::small_string em2{"hello"};
     em2.erase(2, 2);
-    res = res && (em2 == small_string<5>{"heo"});
+    res = res && (em2 == seqan3::small_string<5>{"heo"});
 
     return res;
 }
@@ -137,9 +137,9 @@ TEST(small_string, erase)
 TEST(small_string, concat)
 {
     {
-        constexpr small_string em = small_string{"hello"} +
-                                    small_string{' '} +
-                                    small_string{"world"};
+        constexpr seqan3::small_string em = seqan3::small_string{"hello"} +
+                                            seqan3::small_string{' '} +
+                                            seqan3::small_string{"world"};
         constexpr auto size = em.size();
 
         EXPECT_EQ(size, 11u);
@@ -150,7 +150,7 @@ TEST(small_string, concat)
         static constexpr char const a[] = "hello";
         static constexpr char const b[] = " ";
         static constexpr char const c[] = "world";
-        constexpr auto em = small_string{a} + small_string{b} + small_string{c};
+        constexpr auto em = seqan3::small_string{a} + seqan3::small_string{b} + seqan3::small_string{c};
         constexpr auto size = em.size();
 
         EXPECT_EQ(size, 11u);
@@ -160,61 +160,61 @@ TEST(small_string, concat)
 
 TEST(small_string, begin)
 {
-    small_string s{"hello"};
+    seqan3::small_string s{"hello"};
     EXPECT_EQ(*s.begin(), 'h');
     EXPECT_TRUE((std::is_same_v<decltype(s)::iterator, decltype(s.begin())>));
 
-    small_string<5> const cs{s};
+    seqan3::small_string<5> const cs{s};
     EXPECT_EQ(*cs.begin(), 'h');
     EXPECT_TRUE((std::is_same_v<decltype(cs)::const_iterator, decltype(cs.begin())>));
 }
 
 TEST(small_string, cbegin)
 {
-    small_string s{"hello"};
+    seqan3::small_string s{"hello"};
     EXPECT_EQ(*s.begin(), 'h');
     EXPECT_TRUE((std::is_same_v<decltype(s)::const_iterator, decltype(s.cbegin())>));
 }
 
 TEST(small_string, end)
 {
-    small_string s{"hello"};
+    seqan3::small_string s{"hello"};
     EXPECT_EQ(*(s.end() - 1), 'o');
     EXPECT_TRUE((std::is_same_v<decltype(s)::iterator, decltype(s.end())>));
 
-    small_string<5> const cs{s};
-    static_assert(std::is_same_v<small_string<5> const, decltype(cs)>);
+    seqan3::small_string<5> const cs{s};
+    static_assert(std::is_same_v<seqan3::small_string<5> const, decltype(cs)>);
     EXPECT_EQ(*(cs.end() - 1), 'o');
     EXPECT_TRUE((std::is_same_v<decltype(cs)::const_iterator, decltype(cs.end())>));
 }
 
 TEST(small_string, cend)
 {
-    small_string s{"hello"};
+    seqan3::small_string s{"hello"};
     EXPECT_EQ(*(s.cend() - 1), 'o');
     EXPECT_TRUE((std::is_same_v<decltype(s)::const_iterator, decltype(s.cend())>));
 }
 
 TEST(small_string, swap)
 {
-    small_string s1{"hello"};
-    small_string s2{"olleh"};
+    seqan3::small_string s1{"hello"};
+    seqan3::small_string s2{"olleh"};
     {  // global function.
         std::swap(s1, s2);
-        EXPECT_EQ(s1, small_string{"olleh"});
-        EXPECT_EQ(s2, small_string{"hello"});
+        EXPECT_EQ(s1, seqan3::small_string{"olleh"});
+        EXPECT_EQ(s2, seqan3::small_string{"hello"});
     }
 
     { // member function
         s1.swap(s2);
-        EXPECT_EQ(s1, small_string{"hello"});
-        EXPECT_EQ(s2, small_string{"olleh"});
+        EXPECT_EQ(s1, seqan3::small_string{"hello"});
+        EXPECT_EQ(s2, seqan3::small_string{"olleh"});
     }
 }
 
 TEST(small_string, modifying)
 {
-    small_string<50> s1{"hello"};
+    seqan3::small_string<50> s1{"hello"};
     EXPECT_EQ(std::string{s1.c_str()}, "hello"s);
 
     s1.pop_back();
@@ -244,10 +244,10 @@ TEST(small_string, modifying)
 
 TEST(small_string, equality)
 {
-    constexpr bool cmp1 = small_string{"hello"} == small_string{"hello"};
-    constexpr bool cmp2 = small_string{"hello"} == small_string{"hell"};
-    constexpr bool cmp3 = small_string{"hell"}  == small_string{"hello"};
-    constexpr bool cmp4 = small_string{"hella"} == small_string{"hello"};
+    constexpr bool cmp1 = seqan3::small_string{"hello"} == seqan3::small_string{"hello"};
+    constexpr bool cmp2 = seqan3::small_string{"hello"} == seqan3::small_string{"hell"};
+    constexpr bool cmp3 = seqan3::small_string{"hell"}  == seqan3::small_string{"hello"};
+    constexpr bool cmp4 = seqan3::small_string{"hella"} == seqan3::small_string{"hello"};
 
     EXPECT_TRUE(cmp1);
     EXPECT_FALSE(cmp2);
@@ -257,10 +257,10 @@ TEST(small_string, equality)
 
 TEST(small_string, inequality)
 {
-    constexpr bool cmp1 = small_string{"hello"} != small_string{"hello"};
-    constexpr bool cmp2 = small_string{"hello"} != small_string{"hell"};
-    constexpr bool cmp3 = small_string{"hell"}  != small_string{"hello"};
-    constexpr bool cmp4 = small_string{"hella"} != small_string{"hello"};
+    constexpr bool cmp1 = seqan3::small_string{"hello"} != seqan3::small_string{"hello"};
+    constexpr bool cmp2 = seqan3::small_string{"hello"} != seqan3::small_string{"hell"};
+    constexpr bool cmp3 = seqan3::small_string{"hell"}  != seqan3::small_string{"hello"};
+    constexpr bool cmp4 = seqan3::small_string{"hella"} != seqan3::small_string{"hello"};
 
     EXPECT_FALSE(cmp1);
     EXPECT_TRUE(cmp2);
@@ -270,10 +270,10 @@ TEST(small_string, inequality)
 
 TEST(small_string, less)
 {
-    constexpr bool cmp1 = small_string{"hello"} < small_string{"hello"};
-    constexpr bool cmp2 = small_string{"hello"} < small_string{"hell"};
-    constexpr bool cmp3 = small_string{"hell"}  < small_string{"hello"};
-    constexpr bool cmp4 = small_string{"hella"} < small_string{"hello"};
+    constexpr bool cmp1 = seqan3::small_string{"hello"} < seqan3::small_string{"hello"};
+    constexpr bool cmp2 = seqan3::small_string{"hello"} < seqan3::small_string{"hell"};
+    constexpr bool cmp3 = seqan3::small_string{"hell"}  < seqan3::small_string{"hello"};
+    constexpr bool cmp4 = seqan3::small_string{"hella"} < seqan3::small_string{"hello"};
 
     EXPECT_FALSE(cmp1);
     EXPECT_FALSE(cmp2);
@@ -283,10 +283,10 @@ TEST(small_string, less)
 
 TEST(small_string, less_equal)
 {
-    constexpr bool cmp1 = small_string{"hello"} <= small_string{"hello"};
-    constexpr bool cmp2 = small_string{"hello"} <= small_string{"hell"};
-    constexpr bool cmp3 = small_string{"hell"}  <= small_string{"hello"};
-    constexpr bool cmp4 = small_string{"hella"} <= small_string{"hello"};
+    constexpr bool cmp1 = seqan3::small_string{"hello"} <= seqan3::small_string{"hello"};
+    constexpr bool cmp2 = seqan3::small_string{"hello"} <= seqan3::small_string{"hell"};
+    constexpr bool cmp3 = seqan3::small_string{"hell"}  <= seqan3::small_string{"hello"};
+    constexpr bool cmp4 = seqan3::small_string{"hella"} <= seqan3::small_string{"hello"};
 
     EXPECT_TRUE(cmp1);
     EXPECT_FALSE(cmp2);
@@ -296,10 +296,10 @@ TEST(small_string, less_equal)
 
 TEST(small_string, greater)
 {
-    constexpr bool cmp1 = small_string{"hello"} > small_string{"hello"};
-    constexpr bool cmp2 = small_string{"hello"} > small_string{"hell"};
-    constexpr bool cmp3 = small_string{"hell"}  > small_string{"hello"};
-    constexpr bool cmp4 = small_string{"hella"} > small_string{"hello"};
+    constexpr bool cmp1 = seqan3::small_string{"hello"} > seqan3::small_string{"hello"};
+    constexpr bool cmp2 = seqan3::small_string{"hello"} > seqan3::small_string{"hell"};
+    constexpr bool cmp3 = seqan3::small_string{"hell"}  > seqan3::small_string{"hello"};
+    constexpr bool cmp4 = seqan3::small_string{"hella"} > seqan3::small_string{"hello"};
 
     EXPECT_FALSE(cmp1);
     EXPECT_TRUE(cmp2);
@@ -309,10 +309,10 @@ TEST(small_string, greater)
 
 TEST(small_string, greater_equal)
 {
-    constexpr bool cmp1 = small_string{"hello"} >= small_string{"hello"};
-    constexpr bool cmp2 = small_string{"hello"} >= small_string{"hell"};
-    constexpr bool cmp3 = small_string{"hell"}  >= small_string{"hello"};
-    constexpr bool cmp4 = small_string{"hella"} >= small_string{"hello"};
+    constexpr bool cmp1 = seqan3::small_string{"hello"} >= seqan3::small_string{"hello"};
+    constexpr bool cmp2 = seqan3::small_string{"hello"} >= seqan3::small_string{"hell"};
+    constexpr bool cmp3 = seqan3::small_string{"hell"}  >= seqan3::small_string{"hello"};
+    constexpr bool cmp4 = seqan3::small_string{"hella"} >= seqan3::small_string{"hello"};
 
     EXPECT_TRUE(cmp1);
     EXPECT_TRUE(cmp2);
@@ -321,7 +321,7 @@ TEST(small_string, greater_equal)
 }
 
 template <std::size_t N>
-constexpr small_string<N> fill_small_string(small_string<N> s, char const val)
+constexpr seqan3::small_string<N> fill_small_string(seqan3::small_string<N> s, char const val)
 {
     s.resize(N);
 
@@ -335,13 +335,13 @@ constexpr small_string<N> fill_small_string(small_string<N> s, char const val)
 
 TEST(small_string, compile_time_fill)
 {
-    constexpr bool cmp = fill_small_string(small_string<4>{}, 'x') == small_string{"xxxx"};
+    constexpr bool cmp = fill_small_string(seqan3::small_string<4>{}, 'x') == seqan3::small_string{"xxxx"};
     EXPECT_TRUE(cmp);
 }
 
 TEST(small_string, output)
 {
-    small_string em{"hello"};
+    seqan3::small_string em{"hello"};
     std::ostringstream os;
     os << em;
     EXPECT_EQ(os.str(), "hello"s);
@@ -350,14 +350,14 @@ TEST(small_string, output)
 TEST(small_string, input)
 {
     { // Until whitespace
-        small_string<50> em{"test"};
+        seqan3::small_string<50> em{"test"};
         std::istringstream is{"hello test"};
         is >> em;
         EXPECT_EQ(em.str(), "hello"s);
     }
 
     { // Exceed capacity
-        small_string<5> em{"test"};
+        seqan3::small_string<5> em{"test"};
         std::istringstream is{"hellotest"};
         is >> em;
         EXPECT_EQ(em.str(), "hello"s);
@@ -368,7 +368,7 @@ TEST(small_string, input)
     }
 
     { // eof before capacity reached
-        small_string<50> em{""};
+        seqan3::small_string<50> em{""};
         std::istringstream is{"hellotest"};
         is >> em;
         EXPECT_EQ(em.str(), "hellotest"s);


### PR DESCRIPTION
Fixes

```
/seqan3/test/unit/range/container/small_string_test.cpp: In member function ‘virtual void small_string_equality_Test::TestBody()’:
/seqan3/test/unit/range/container/small_string_test.cpp:249:49: error: no match for ‘operator==’ (operand types are ‘seqan3::small_string<4>’ and ‘seqan3::small_string<5>’)
  249 |     constexpr bool cmp3 = small_string{"hell"}  == small_string{"hello"};
      |                           ~~~~~~~~~~~~~~~~~~~~  ^~ ~~~~~~~~~~~~~~~~~~~~~
      |                           |                        |
      |                           small_string<4>          small_string<5>
In file included from /seqan3/include/seqan3/range/container/small_string.hpp:15,
                 from /seqan3/test/unit/range/container/small_string_test.cpp:14:
/seqan3/include/seqan3/range/container/small_vector.hpp:875:27: note: candidate: ‘template<long unsigned int cap2>  requires (‘integer_type’ not supported by expression) <= 5 constexpr bool seqan3::operator==(const seqan3::small_vector<char, 6>&, const seqan3::small_vector<char, cap2>&)’
  875 |     friend constexpr bool operator==(small_vector const & lhs, small_vector<value_type, cap2> const & rhs) noexcept
      |                           ^~~~~~~~
```