### PR TITLE
[TEST] Fix concept of HasExpectEqualMemberFunction in iterator_test_template

### DIFF
--- a/test/unit/range/iterator_test_template.hpp
+++ b/test/unit/range/iterator_test_template.hpp
@@ -45,8 +45,10 @@ struct iterator_fixture : public ::testing::Test
 
 // Helper concept to check whether the test fixture has a member function expect_eq.
 template <typename T>
-SEQAN3_CONCEPT HasExpectEqualMemberFunction = requires(T a) {
-    { a.expect_eq(*std::ranges::begin(a.test_range), *std::ranges::begin(a.expected_range)) } -> void;
+SEQAN3_CONCEPT HasExpectEqualMemberFunction = requires(T & a)
+{
+    requires std::same_as<decltype(T::expect_eq(*std::ranges::begin(a.test_range),
+                                                *std::ranges::begin(a.expected_range))), void>;
 };
 
 // Delegates to the test fixture member function `expect_eq` if available and falls back to EXPECT_EQ otherwise.


### PR DESCRIPTION
Original gcc 10 error:
```
In file included from /seqan3/test/unit/alignment/matrix/detail/alignment_score_matrix_one_column_test.cpp:17:
/seqan3/test/unit/alignment/matrix/detail/../../../range/iterator_test_template.hpp: In instantiation of ‘void gtest_suite_iterator_fixture_::concept_check<gtest_TypeParam_>::TestBody() [with gtest_TypeParam_ = inner_iterator]’:
/seqan3/test/unit/alignment/matrix/detail/../../../range/iterator_test_template.hpp:64:1:   required from here
/seqan3/test/unit/alignment/matrix/detail/../../../range/iterator_test_template.hpp:70:28: error: static assertion failed: The reference types of begin_iterator and expected_range must be equality comparable. If they are not, you may specify a custom void expect_eq(i1, r2) function in the fixture.
   70 |         static_assert(std::equality_comparable_with<decltype(*std::ranges::begin(this->test_range)),
      |                       ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   71 |                                                     decltype(*std::ranges::begin(this->expected_range))>,
      |                                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/seqan3/test/unit/alignment/matrix/detail/../../../range/iterator_test_template.hpp:70:28: note: constraints not satisfied
In file included from /seqan3/include/seqan3/std/iterator:32,
                 from /seqan3/include/seqan3/core/type_traits/iterator.hpp:20,
                 from /seqan3/include/seqan3/core/type_traits/range.hpp:20,
                 from /seqan3/include/seqan3/alignment/matrix/detail/alignment_matrix_column_major_range_base.hpp:16,
                 from /seqan3/include/seqan3/alignment/matrix/detail/alignment_score_matrix_one_column.hpp:15,
                 from /seqan3/test/unit/alignment/matrix/detail/alignment_score_matrix_one_column_test.cpp:13:
/seqan3/include/seqan3/std/concepts:405:16:   required for the satisfaction of ‘weakly_equality_comparable_with<seqan3::detail::alignment_score_matrix_proxy<int>, seqan3::detail::alignment_score_matrix_proxy<int> >’
/seqan3/include/seqan3/std/concepts:446:16:   required for the satisfaction of ‘equality_comparable<seqan3::detail::alignment_score_matrix_proxy<int> >’
/seqan3/include/seqan3/std/concepts:406:5:   in requirements with ‘std::remove_reference_t<seqan3::detail::alignment_score_matrix_proxy<int> >& t’, ‘std::remove_reference_t<seqan3::detail::alignment_score_matrix_proxy<int> >& u’
/seqan3/include/seqan3/std/concepts:409:11: note: the required expression ‘(t == u)’ is invalid
  409 |         t == u; requires boolean<decltype(t == u)>;
      |         ~~^~~~
/seqan3/include/seqan3/std/concepts:409:26: note: nested requirement ‘boolean<decltype ((t == u))>’ is not satisfied
  409 |         t == u; requires boolean<decltype(t == u)>;
      |                          ^~~~~~~~~~~~~~~~~~~~~~~~~
/seqan3/include/seqan3/std/concepts:410:11: note: the required expression ‘(t != u)’ is invalid
  410 |         t != u; requires boolean<decltype(t != u)>;
      |         ~~^~~~
/seqan3/include/seqan3/std/concepts:410:26: note: nested requirement ‘boolean<decltype ((t != u))>’ is not satisfied
  410 |         t != u; requires boolean<decltype(t != u)>;
      |                          ^~~~~~~~~~~~~~~~~~~~~~~~~
/seqan3/include/seqan3/std/concepts:411:11: note: the required expression ‘(u == t)’ is invalid
  411 |         u == t; requires boolean<decltype(u == t)>;
      |         ~~^~~~
/seqan3/include/seqan3/std/concepts:411:26: note: nested requirement ‘boolean<decltype ((u == t))>’ is not satisfied
  411 |         u == t; requires boolean<decltype(u == t)>;
      |                          ^~~~~~~~~~~~~~~~~~~~~~~~~
/seqan3/include/seqan3/std/concepts:412:11: note: the required expression ‘(u != t)’ is invalid
  412 |         u != t; requires boolean<decltype(u != t)>;
      |         ~~^~~~
/seqan3/include/seqan3/std/concepts:412:26: note: nested requirement ‘boolean<decltype ((u != t))>’ is not satisfied
  412 |         u != t; requires boolean<decltype(u != t)>;
      |                          ^~~~~~~~~~~~~~~~~~~~~~~~~
```

Found out that this is a problem with the definition of `HasExpectEqualMemberFunction` that gave me the following diagnostic:

```
In file included from /seqan3/test/unit/alignment/matrix/detail/alignment_score_matrix_one_column_test.cpp:17:
/seqan3/test/unit/range/iterator_test_template.hpp: In instantiation of ‘void gtest_suite_iterator_fixture_::concept_check<gtest_TypeParam_>::TestBody() [with gtest_TypeParam_ = inner_iterator]’:
/seqan3/test/unit/range/iterator_test_template.hpp:64:1:   required from here
/seqan3/test/unit/range/iterator_test_template.hpp:68:20: error: static assertion failed
   68 |     static_assert (HasExpectEqualMemberFunction<iterator_fixture<TypeParam>>);
      |                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/seqan3/test/unit/range/iterator_test_template.hpp:68:20: note: constraints not satisfied
/seqan3/test/unit/range/iterator_test_template.hpp:48:16:   required by the constraints of ‘template<class T> concept const bool HasExpectEqualMemberFunction<T>’
/seqan3/test/unit/range/iterator_test_template.hpp:48:47:   in requirements with ‘iterator_fixture<inner_iterator> a’
/seqan3/test/unit/range/iterator_test_template.hpp:48:47: error: invalid abstract parameter type ‘iterator_fixture<inner_iterator>’
   48 | SEQAN3_CONCEPT HasExpectEqualMemberFunction = requires(T a) {
      |                                               ^~~~~~~~~~~~~~~
   49 |     { a.expect_eq(*std::ranges::begin(a.test_range), *std::ranges::begin(a.expected_range)) } -> void;
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   50 | };
      | ~
/seqan3/test/unit/alignment/matrix/detail/alignment_score_matrix_one_column_test.cpp:86:8: note:   because the following virtual functions are pure within ‘iterator_fixture<inner_iterator>’:
   86 | struct iterator_fixture<inner_iterator> : alignment_matrix_base_test<test_type>
      |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /seqan3/test/unit/alignment/matrix/detail/alignment_score_matrix_one_column_test.cpp:8:
/seqan3-build/gcc-10-std17-debug/vendor/googletest/googletest/include/gtest/gtest.h:485:16: note:     ‘virtual void testing::Test::TestBody()’
  485 |   virtual void TestBody() = 0;
      |                ^~~~~~~~
```

This indicated that gcc10 seems to not `std::declval()` on arguments on
`requires` anymore. Thus, we will declval the iterator_fixture instance
ourselves. Be aware that you need to use `std::declval<T &>` to make the
complete expression a lvalue reference.