### PR TITLE
[FIX] trace_iterator_base: use same constraints

### DIFF
--- a/include/seqan3/alignment/matrix/detail/trace_iterator_base.hpp
+++ b/include/seqan3/alignment/matrix/detail/trace_iterator_base.hpp
@@ -66,7 +66,7 @@ private:
                   "Value type of the underlying iterator must be seqan3::detail::trace_directions.");
 
     //!\brief Befriend with corresponding const_iterator.
-    template <typename other_derived_t, typename other_matrix_iter_t>
+    template <typename other_derived_t, two_dimensional_matrix_iterator other_matrix_iter_t>
     //!\cond
         requires std::constructible_from<derived_t, other_derived_t> &&
                  std::constructible_from<matrix_iter_t, other_matrix_iter_t>


### PR DESCRIPTION
```
In file included from /seqan3/include/seqan3/alignment/matrix/detail/trace_iterator.hpp:15,
                 from /seqan3/test/unit/alignment/matrix/detail/trace_iterator_test.cpp:13:
/seqan3/include/seqan3/alignment/matrix/detail/trace_iterator_base.hpp: In instantiation of ‘class seqan3::detail::trace_iterator_base<seqan3::detail::trace_iterator<seqan3::detail::two_dimensional_matrix<seqan3::detail::trace_directions>::iterator_type<seqan3::detail::two_dimensional_matrix<seqan3::detail::trace_directions> > >, seqan3::detail::two_dimensional_matrix<seqan3::detail::trace_directions>::iterator_type<seqan3::detail::two_dimensional_matrix<seqan3::detail::trace_directions> > >’:
/seqan3/include/seqan3/alignment/matrix/detail/trace_iterator.hpp:32:7:   required from ‘class seqan3::detail::trace_iterator<seqan3::detail::two_dimensional_matrix<seqan3::detail::trace_directions>::iterator_type<seqan3::detail::two_dimensional_matrix<seqan3::detail::trace_directions> > >’
/seqan3/test/unit/alignment/matrix/detail/trace_iterator_test.cpp:40:71:   required from here
/seqan3/include/seqan3/alignment/matrix/detail/trace_iterator_base.hpp:69:41: error: declaration of template parameter ‘class other_matrix_iter_t’ with different constraints
   69 |     template <typename other_derived_t, typename other_matrix_iter_t>
      |                                         ^~~~~~~~
/seqan3/include/seqan3/alignment/matrix/detail/trace_iterator_base.hpp:61:31: note: original declaration appeared here
   61 | template <typename derived_t, two_dimensional_matrix_iterator matrix_iter_t>
      |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```