### PR TITLE
[MISC] scoring scheme: concept template paramater can't be constrained

### DIFF
--- a/include/seqan3/alignment/scoring/scoring_scheme_concept.hpp
+++ b/include/seqan3/alignment/scoring/scoring_scheme_concept.hpp
@@ -57,11 +57,14 @@ namespace seqan3
 //!\}
 
 //!\cond
-template <typename t, alphabet alphabet_t, alphabet alphabet2_t = alphabet_t>
+template <typename t, typename alphabet_t, typename alphabet2_t = alphabet_t>
 SEQAN3_CONCEPT scoring_scheme = requires (t scheme,
                                                 alphabet_t const alph1,
                                                 alphabet2_t const alph2)
 {
+    requires alphabet<alphabet_t>;
+    requires alphabet<alphabet2_t>;
+
     { scheme.score(alph1, alph2) };
     requires std::common_reference_with<decltype(scheme.score(alph1, alph2)),
                                         typename std::remove_reference_t<t>::score_type>;

--- a/include/seqan3/alignment/scoring/scoring_scheme_concept.hpp
+++ b/include/seqan3/alignment/scoring/scoring_scheme_concept.hpp
@@ -59,8 +59,8 @@ namespace seqan3
 //!\cond
 template <typename t, typename alphabet_t, typename alphabet2_t = alphabet_t>
 SEQAN3_CONCEPT scoring_scheme = requires (t scheme,
-                                                alphabet_t const alph1,
-                                                alphabet2_t const alph2)
+                                          alphabet_t const alph1,
+                                          alphabet2_t const alph2)
 {
     requires alphabet<alphabet_t>;
     requires alphabet<alphabet2_t>;


### PR DESCRIPTION
Fixes gcc10 error:

```
In file included from /seqan3/include/seqan3/alignment/configuration/align_config_scoring.hpp:18,
                 from /seqan3/include/seqan3/alignment/configuration/align_config_edit.hpp:17,
                 from /seqan3/test/unit/alignment/configuration/align_config_edit_test.cpp:10:
/seqan3/include/seqan3/alignment/scoring/scoring_scheme_concept.hpp:61:16: error: a variable concept cannot be constrained
   61 | SEQAN3_CONCEPT scoring_scheme = requires (t scheme,
      |
```