### PR TITLE
[MISC] Remove 'using namespace seqan3' from test/unit/argument_parser

### DIFF
--- a/test/unit/argument_parser/argument_parser_design_error_test.cpp
+++ b/test/unit/argument_parser/argument_parser_design_error_test.cpp
@@ -9,19 +9,17 @@
 
 #include <seqan3/argument_parser/all.hpp>
 
-using namespace seqan3;
-
 TEST(design_error, app_name_validation)
 {
     const char * argv[] = {"./argument_parser_test"};
 
-    EXPECT_NO_THROW((argument_parser{"test_parser", 1, argv}));
-    EXPECT_NO_THROW((argument_parser{"test-parser1234_foo", 1, argv}));
+    EXPECT_NO_THROW((seqan3::argument_parser{"test_parser", 1, argv}));
+    EXPECT_NO_THROW((seqan3::argument_parser{"test-parser1234_foo", 1, argv}));
 
-    EXPECT_THROW((argument_parser{"test parser", 1, argv}),       design_error);
-    EXPECT_THROW((argument_parser{"test;", 1, argv}),             design_error);
-    EXPECT_THROW((argument_parser{";", 1, argv}),                 design_error);
-    EXPECT_THROW((argument_parser{"test;bad script:D", 1, argv}), design_error);
+    EXPECT_THROW((seqan3::argument_parser{"test parser", 1, argv}),       seqan3::design_error);
+    EXPECT_THROW((seqan3::argument_parser{"test;", 1, argv}),             seqan3::design_error);
+    EXPECT_THROW((seqan3::argument_parser{";", 1, argv}),                 seqan3::design_error);
+    EXPECT_THROW((seqan3::argument_parser{"test;bad script:D", 1, argv}), seqan3::design_error);
 }
 
 TEST(parse_test, design_error)
@@ -30,74 +28,74 @@ TEST(parse_test, design_error)
 
     // short option
     const char * argv[] = {"./argument_parser_test"};
-    argument_parser parser{"test_parser", 1, argv};
+    seqan3::argument_parser parser{"test_parser", 1, argv};
     parser.add_option(option_value, 'i', "int", "this is a int option.");
     EXPECT_THROW(parser.add_option(option_value, 'i', "aint", "oh oh same id."),
-                 design_error);
+                 seqan3::design_error);
 
     // long option
-    argument_parser parser2{"test_parser", 1, argv};
+    seqan3::argument_parser parser2{"test_parser", 1, argv};
     parser2.add_option(option_value, 'i', "int", "this is an int option.");
     EXPECT_THROW(parser2.add_option(option_value, 'a', "int", "oh oh another id."),
-                 design_error);
+                 seqan3::design_error);
 
     // empty identifier
-    argument_parser parser3{"test_parser", 1, argv};
+    seqan3::argument_parser parser3{"test_parser", 1, argv};
     EXPECT_THROW(parser3.add_option(option_value, '\0', "", "oh oh all is empty."),
-                 design_error);
+                 seqan3::design_error);
 
     bool flag_value;
 
     // short flag
-    argument_parser parser4{"test_parser", 1, argv};
+    seqan3::argument_parser parser4{"test_parser", 1, argv};
     parser4.add_flag(flag_value, 'i', "int1", "this is an int option.");
     EXPECT_THROW(parser4.add_flag(flag_value, 'i', "int2", "oh oh another id."),
-                 design_error);
+                 seqan3::design_error);
 
     // long flag
-    argument_parser parser5{"test_parser", 1, argv};
+    seqan3::argument_parser parser5{"test_parser", 1, argv};
     parser5.add_flag(flag_value, 'i', "int", "this is an int option.");
     EXPECT_THROW(parser5.add_flag(flag_value, 'a', "int", "oh oh another id."),
-                 design_error);
+                 seqan3::design_error);
 
     // empty identifier
-    argument_parser parser6{"test_parser", 1, argv};
+    seqan3::argument_parser parser6{"test_parser", 1, argv};
     EXPECT_THROW(parser6.add_flag(flag_value, '\0', "", "oh oh another id."),
-                 design_error);
+                 seqan3::design_error);
 
     // positional option not at the end
     const char * argv2[] = {"./argument_parser_test", "arg1", "arg2", "arg3"};
     std::vector<int> vec;
-    argument_parser parser7{"test_parser", 4, argv2};
+    seqan3::argument_parser parser7{"test_parser", 4, argv2};
     parser7.add_positional_option(vec, "oh oh list not at the end.");
-    EXPECT_THROW(parser7.add_positional_option(option_value, "desc."), design_error);
+    EXPECT_THROW(parser7.add_positional_option(option_value, "desc."), seqan3::design_error);
 
     // using h, help, advanced-help, and export-help
-    argument_parser parser8{"test_parser", 1, argv};
+    seqan3::argument_parser parser8{"test_parser", 1, argv};
     EXPECT_THROW(parser8.add_option(option_value, 'h', "", "-h is bad."),
-                 design_error);
+                 seqan3::design_error);
     EXPECT_THROW(parser8.add_option(option_value, '\0', "help", "help is bad."),
-                 design_error);
+                 seqan3::design_error);
     EXPECT_THROW(parser8.add_option(option_value, '\0', "advanced-help",
-                 "advanced-help is bad"), design_error);
+                 "advanced-help is bad"), seqan3::design_error);
     EXPECT_THROW(parser8.add_option(option_value, '\0', "export-help",
-                 "export-help is bad"), design_error);
+                 "export-help is bad"), seqan3::design_error);
 
     // using one-letter long identifiers.
-    argument_parser parser9{"test_parser", 1, argv};
+    seqan3::argument_parser parser9{"test_parser", 1, argv};
     EXPECT_THROW(parser9.add_option(option_value, 'y', "z", "long identifier is one letter"),
-                 design_error);
+                 seqan3::design_error);
     EXPECT_THROW(parser9.add_flag(flag_value, 'y', "z", "long identifier is one letter"),
-                 design_error);
+                 seqan3::design_error);
 
     // using non-printable characters
-    argument_parser parser10{"test_parser", 1, argv};
+    seqan3::argument_parser parser10{"test_parser", 1, argv};
     EXPECT_THROW(parser10.add_option(option_value, '\t', "no\n", "tab and newline don't work!"),
-                 design_error);
+                 seqan3::design_error);
     EXPECT_THROW(parser10.add_flag(flag_value, 'i', "no\n", "tab and newline don't work!"),
-                 design_error);
+                 seqan3::design_error);
     EXPECT_THROW(parser10.add_flag(flag_value, 'a', "-no", "can't start long_id with a hyphen"),
-                 design_error);
+                 seqan3::design_error);
 }
 
 TEST(parse_test, parse_called_twice)
@@ -105,7 +103,7 @@ TEST(parse_test, parse_called_twice)
     std::string option_value;
 
     const char * argv[] = {"./argument_parser_test", "--version-check", "0", "-s", "option_string"};
-    argument_parser parser{"test_parser", 5, argv};
+    seqan3::argument_parser parser{"test_parser", 5, argv};
     parser.add_option(option_value, 's', "string-option", "this is a string option.");
 
     testing::internal::CaptureStderr();
@@ -113,7 +111,7 @@ TEST(parse_test, parse_called_twice)
     EXPECT_TRUE((testing::internal::GetCapturedStderr()).empty());
     EXPECT_EQ(option_value, "option_string");
 
-    EXPECT_THROW(parser.parse(), design_error);
+    EXPECT_THROW(parser.parse(), seqan3::design_error);
 }
 
 TEST(parse_test, subcommand_argument_parser_error)
@@ -123,28 +121,28 @@ TEST(parse_test, subcommand_argument_parser_error)
     // subcommand parsing was not enabled on construction but get_sub_parser() is called
     {
         const char * argv[]{"./top_level", "-f"};
-        argument_parser top_level_parser{"top_level", 2, argv, false};
+        seqan3::argument_parser top_level_parser{"top_level", 2, argv, false};
         top_level_parser.add_flag(flag_value, 'f', "foo", "foo bar");
 
         EXPECT_NO_THROW(top_level_parser.parse());
         EXPECT_EQ(true, flag_value);
 
-        EXPECT_THROW(top_level_parser.get_sub_parser(), design_error);
+        EXPECT_THROW(top_level_parser.get_sub_parser(), seqan3::design_error);
     }
 
     // subcommand key word must only contain alpha numeric characters
     {
         const char * argv[]{"./top_level", "-f"};
-        EXPECT_THROW((argument_parser{"top_level", 2, argv, false, {"with space"}}), design_error);
-        EXPECT_THROW((argument_parser{"top_level", 2, argv, false, {"-dash"}}), design_error);
+        EXPECT_THROW((seqan3::argument_parser{"top_level", 2, argv, false, {"with space"}}), seqan3::design_error);
+        EXPECT_THROW((seqan3::argument_parser{"top_level", 2, argv, false, {"-dash"}}), seqan3::design_error);
     }
 
     // no positional/options are allowed
     {
         const char * argv[]{"./top_level", "foo"};
-        argument_parser top_level_parser{"top_level", 2, argv, false, {"foo"}};
+        seqan3::argument_parser top_level_parser{"top_level", 2, argv, false, {"foo"}};
 
-        EXPECT_THROW((top_level_parser.add_option(flag_value, 'f', "foo", "foo bar")), design_error);
-        EXPECT_THROW((top_level_parser.add_positional_option(flag_value, "foo bar")), design_error);
+        EXPECT_THROW((top_level_parser.add_option(flag_value, 'f', "foo", "foo bar")), seqan3::design_error);
+        EXPECT_THROW((top_level_parser.add_positional_option(flag_value, "foo bar")), seqan3::design_error);
     }
 }

--- a/test/unit/argument_parser/detail/format_help_test.cpp
+++ b/test/unit/argument_parser/detail/format_help_test.cpp
@@ -21,8 +21,6 @@
 #include <seqan3/range/views/get.hpp>
 #include <seqan3/range/views/to.hpp>
 
-using namespace seqan3;
-
 // reused global variables
 std::string std_cout;
 std::string expected;
@@ -56,8 +54,8 @@ std::string const basic_version_str = "VERSION"
 
 TEST(help_page_printing, short_help)
 {
-    // Empty call with no options given. For detail::format_short_help
-    argument_parser parser0{"empty_options", 1, argv0};
+    // Empty call with no options given. For seqan3::detail::format_short_help
+    seqan3::argument_parser parser0{"empty_options", 1, argv0};
     parser0.info.synopsis.push_back("./some_binary_name synopsis");
     testing::internal::CaptureStdout();
     EXPECT_EXIT(parser0.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
@@ -66,13 +64,14 @@ TEST(help_page_printing, short_help)
                "============="
                "./some_binary_name synopsis"
                "Try -h or --help for more information.";
-    EXPECT_TRUE(ranges::equal((std_cout | std::views::filter(!is_space)), expected | std::views::filter(!is_space)));
+    EXPECT_TRUE(ranges::equal((std_cout | std::views::filter(!seqan3::is_space)),
+                              expected | std::views::filter(!seqan3::is_space)));
 }
 
 TEST(help_page_printing, no_information)
 {
     // Empty help call with -h
-    argument_parser parser1{"test_parser", 2, argv1};
+    seqan3::argument_parser parser1{"test_parser", 2, argv1};
     testing::internal::CaptureStdout();
     EXPECT_EXIT(parser1.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
     std_cout = testing::internal::GetCapturedStdout();
@@ -80,13 +79,14 @@ TEST(help_page_printing, no_information)
                "===========" +
                basic_options_str +
                basic_version_str;
-    EXPECT_TRUE(ranges::equal((std_cout | std::views::filter(!is_space)), expected | std::views::filter(!is_space)));
+    EXPECT_TRUE(ranges::equal((std_cout | std::views::filter(!seqan3::is_space)),
+                              expected | std::views::filter(!seqan3::is_space)));
 }
 
 TEST(help_page_printing, with_short_copyright)
 {
     // Again, but with short copyright, long copyright, and citation.
-    argument_parser short_copy("test_parser", 2, argv1);
+    seqan3::argument_parser short_copy("test_parser", 2, argv1);
     short_copy.info.short_copyright = "short";
     testing::internal::CaptureStdout();
     EXPECT_EXIT(short_copy.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
@@ -98,12 +98,13 @@ TEST(help_page_printing, with_short_copyright)
                "LEGAL"
                "test_parser Copyright: short"
                "SeqAn Copyright: 2006-2015 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.";
-    EXPECT_TRUE(ranges::equal((std_cout | std::views::filter(!is_space)), expected | std::views::filter(!is_space)));
+    EXPECT_TRUE(ranges::equal((std_cout | std::views::filter(!seqan3::is_space)),
+                              expected | std::views::filter(!seqan3::is_space)));
 }
 
 TEST(help_page_printing, with_long_copyright)
 {
-    argument_parser long_copy("test_parser", 2, argv1);
+    seqan3::argument_parser long_copy("test_parser", 2, argv1);
     long_copy.info.long_copyright = "long";
     testing::internal::CaptureStdout();
     EXPECT_EXIT(long_copy.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
@@ -115,12 +116,13 @@ TEST(help_page_printing, with_long_copyright)
                "LEGAL"
                "SeqAn Copyright: 2006-2015 Knut Reinert, FU-Berlin; released under the 3-clause BSDL."
                "For full copyright and/or warranty information see --copyright.";
-    EXPECT_TRUE(ranges::equal((std_cout | std::views::filter(!is_space)), expected | std::views::filter(!is_space)));
+    EXPECT_TRUE(ranges::equal((std_cout | std::views::filter(!seqan3::is_space)),
+                              expected | std::views::filter(!seqan3::is_space)));
 }
 
 TEST(help_page_printing, with_citation)
 {
-    argument_parser citation("test_parser", 2, argv1);
+    seqan3::argument_parser citation("test_parser", 2, argv1);
     citation.info.citation = "citation";
     testing::internal::CaptureStdout();
     EXPECT_EXIT(citation.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
@@ -132,13 +134,14 @@ TEST(help_page_printing, with_citation)
                "LEGAL"
                "SeqAn Copyright: 2006-2015 Knut Reinert, FU-Berlin; released under the 3-clause BSDL."
                "In your academic works please cite: citation";
-    EXPECT_TRUE(ranges::equal((std_cout | std::views::filter(!is_space)), expected | std::views::filter(!is_space)));
+    EXPECT_TRUE(ranges::equal((std_cout | std::views::filter(!seqan3::is_space)),
+                              expected | std::views::filter(!seqan3::is_space)));
 }
 
 TEST(help_page_printing, empty_advanced_help)
 {
     // Empty help call with -hh
-    argument_parser parser2{"test_parser", 2, argv2};
+    seqan3::argument_parser parser2{"test_parser", 2, argv2};
     testing::internal::CaptureStdout();
     EXPECT_EXIT(parser2.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
     std_cout = testing::internal::GetCapturedStdout();
@@ -146,26 +149,28 @@ TEST(help_page_printing, empty_advanced_help)
                "===========" +
                basic_options_str +
                basic_version_str;
-    EXPECT_TRUE(ranges::equal((std_cout | std::views::filter(!is_space)), expected | std::views::filter(!is_space)));
+    EXPECT_TRUE(ranges::equal((std_cout | std::views::filter(!seqan3::is_space)),
+                              expected | std::views::filter(!seqan3::is_space)));
 }
 
 TEST(help_page_printing, empty_version_call)
 {
     // Empty version call
-    argument_parser parser3{"test_parser", 2, argv3};
+    seqan3::argument_parser parser3{"test_parser", 2, argv3};
     testing::internal::CaptureStdout();
     EXPECT_EXIT(parser3.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
     std_cout = testing::internal::GetCapturedStdout();
     expected = "test_parser"
                "===========" +
                basic_version_str;
-    EXPECT_TRUE(ranges::equal((std_cout | std::views::filter(!is_space)), expected | std::views::filter(!is_space)));
+    EXPECT_TRUE(ranges::equal((std_cout | std::views::filter(!seqan3::is_space)),
+                              expected | std::views::filter(!seqan3::is_space)));
 }
 
 TEST(help_page_printing, version_call)
 {
     // Version call with url and options.
-    argument_parser parser4{"test_parser", 2, argv3};
+    seqan3::argument_parser parser4{"test_parser", 2, argv3};
     parser4.info.url = "www.seqan.de";
     parser4.add_option(option_value, 'i', "int", "this is a int option.");
     parser4.add_flag(flag_value, 'f', "flag", "this is a flag.");
@@ -178,15 +183,16 @@ TEST(help_page_printing, version_call)
                basic_version_str +
                "URL"
                "www.seqan.de";
-    EXPECT_TRUE(ranges::equal((std_cout | std::views::filter(!is_space)), expected | std::views::filter(!is_space)));
+    EXPECT_TRUE(ranges::equal((std_cout | std::views::filter(!seqan3::is_space)),
+                              expected | std::views::filter(!seqan3::is_space)));
 }
 
 TEST(help_page_printing, do_not_print_hidden_options)
 {
     // Add an option and request help.
-    argument_parser parser5{"test_parser", 2, argv1};
-    parser5.add_option(option_value, 'i', "int", "this is a int option.", option_spec::HIDDEN);
-    parser5.add_flag(flag_value, 'f', "flag", "this is a flag.", option_spec::HIDDEN);
+    seqan3::argument_parser parser5{"test_parser", 2, argv1};
+    parser5.add_option(option_value, 'i', "int", "this is a int option.", seqan3::option_spec::HIDDEN);
+    parser5.add_flag(flag_value, 'f', "flag", "this is a flag.", seqan3::option_spec::HIDDEN);
     testing::internal::CaptureStdout();
     EXPECT_EXIT(parser5.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
     std_cout = testing::internal::GetCapturedStdout();
@@ -194,7 +200,8 @@ TEST(help_page_printing, do_not_print_hidden_options)
                "===========" +
                basic_options_str +
                basic_version_str;
-    EXPECT_TRUE(ranges::equal((std_cout | std::views::filter(!is_space)), expected | std::views::filter(!is_space)));
+    EXPECT_TRUE(ranges::equal((std_cout | std::views::filter(!seqan3::is_space)),
+                              expected | std::views::filter(!seqan3::is_space)));
 }
 
 enum class foo
@@ -216,16 +223,17 @@ TEST(help_page_printing, full_information)
     foo enum_option_value{};
 
     // Add synopsis, description, short description, positional option, option, flag, and example.
-    argument_parser parser6{"test_parser", 2, argv1};
+    seqan3::argument_parser parser6{"test_parser", 2, argv1};
     parser6.info.synopsis.push_back("./some_binary_name synopsis");
     parser6.info.synopsis.push_back("./some_binary_name synopsis2");
     parser6.info.description.push_back("description");
     parser6.info.description.push_back("description2");
     parser6.info.short_description = "so short";
     parser6.add_option(option_value, 'i', "int", "this is a int option.");
-    parser6.add_option(enum_option_value, 'e', "enum", "this is an enum option.", option_spec::DEFAULT,
-                       value_list_validator{seqan3::enumeration_names<foo> | views::get<1>});
-    parser6.add_option(required_option, 'r', "required-int", "this is another int option.", option_spec::REQUIRED);
+    parser6.add_option(enum_option_value, 'e', "enum", "this is an enum option.", seqan3::option_spec::DEFAULT,
+                       seqan3::value_list_validator{seqan3::enumeration_names<foo> | seqan3::views::get<1>});
+    parser6.add_option(required_option, 'r', "required-int", "this is another int option.",
+                       seqan3::option_spec::REQUIRED);
     parser6.add_section("Flags");
     parser6.add_subsection("SubFlags");
     parser6.add_line("here come all the flags");
@@ -266,14 +274,15 @@ TEST(help_page_printing, full_information)
                "example\n"
                "example2" +
                basic_version_str;
-    EXPECT_TRUE(ranges::equal((std_cout | std::views::filter(!is_space)), expected | std::views::filter(!is_space)));
+    EXPECT_TRUE(ranges::equal((std_cout | std::views::filter(!seqan3::is_space)),
+                              expected | std::views::filter(!seqan3::is_space)));
 }
 
 TEST(help_page_printing, copyright)
 {
     // Tests the --copyright call.
     const char * argvCopyright[] = {"./copyright", "--copyright"};
-    argument_parser copyright("myApp", 2, argvCopyright);
+    seqan3::argument_parser copyright("myApp", 2, argvCopyright);
 
     std::ifstream license_file{std::string{{SEQAN3_TEST_LICENSE_DIR}} + "/LICENSE.md"};
     std::ranges::subrange<std::istreambuf_iterator<char>, std::istreambuf_iterator<char>> sub
@@ -282,8 +291,10 @@ TEST(help_page_printing, copyright)
         std::istreambuf_iterator<char>()
     };
 
-    detail::consume(sub | views::take_until_and_consume(is_char<'`'>));
-    std::string license_string{sub | views::drop(1) | views::take_until(is_char<'`'>)  | views::to<std::string>};
+    seqan3::detail::consume(sub | seqan3::views::take_until_and_consume(seqan3::is_char<'`'>));
+    std::string license_string{sub | seqan3::views::drop(1)
+                                   | seqan3::views::take_until(seqan3::is_char<'`'>)
+                                   | seqan3::views::to<std::string>};
 
     // Test --copyright with empty short and long copyright info.
     {
@@ -351,7 +362,7 @@ TEST(parse_test, subcommand_argument_parser)
     std::string option_value2{};
 
     const char * argv[]{"./test_parser", "-h"};
-    argument_parser top_level_parser{"test_parser", 2, argv, true, {"sub1", "sub2"}};
+    seqan3::argument_parser top_level_parser{"test_parser", 2, argv, true, {"sub1", "sub2"}};
     top_level_parser.info.description.push_back("description");
     top_level_parser.add_option(option_value, 'f', "foo", "foo bar.");
 
@@ -376,5 +387,6 @@ TEST(parse_test, subcommand_argument_parser)
                            "    foo bar. Default: 0.\n" +
                            basic_version_str;
 
-    EXPECT_TRUE(ranges::equal((std_cout | std::views::filter(!is_space)), expected | std::views::filter(!is_space)));
+    EXPECT_TRUE(ranges::equal((std_cout | std::views::filter(!seqan3::is_space)),
+                              expected | std::views::filter(!seqan3::is_space)));
 }

--- a/test/unit/argument_parser/detail/format_html_test.cpp
+++ b/test/unit/argument_parser/detail/format_html_test.cpp
@@ -14,8 +14,6 @@
 #include <seqan3/argument_parser/detail/format_html.hpp>
 #include <seqan3/core/char_operations/predicate.hpp>
 
-using namespace seqan3;
-
 TEST(html_format, empty_information)
 {
     std::string my_stdout;
@@ -23,7 +21,7 @@ TEST(html_format, empty_information)
 
     // Empty html help page.
     const char * argv0[] = {"./help_add_test --version-check 0", "--export-help", "html"};
-    argument_parser parser0{"empty_options", 3, argv0};
+    seqan3::argument_parser parser0{"empty_options", 3, argv0};
     testing::internal::CaptureStdout();
     EXPECT_EXIT(parser0.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
     my_stdout = testing::internal::GetCapturedStdout();
@@ -56,13 +54,13 @@ TEST(html_format, empty_information)
                            "<h2>Version</h2>\n"
                            "<strong>Last update:</strong> <br>\n"
                            "<strong>empty_options version:</strong> <br>\n"
-                           "<strong>SeqAn version:</strong> " + seqan3_version + "<br>\n"
+                           "<strong>SeqAn version:</strong> " + seqan3::seqan3_version + "<br>\n"
                            "<br>\n"
                            "</body></html>");
     EXPECT_EQ(my_stdout, expected);
 
     const char * argv1[] = {"./help_add_test --version-check 0", "--export-help=html"};
-    argument_parser parser1{"empty_options", 2, argv1};
+    seqan3::argument_parser parser1{"empty_options", 2, argv1};
     testing::internal::CaptureStdout();
     EXPECT_EXIT(parser1.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
     my_stdout = testing::internal::GetCapturedStdout();
@@ -80,7 +78,7 @@ TEST(html_format, full_information_information)
 
    // Full html help page.
    const char * argv0[] = {"./help_add_test --version-check 0", "--export-help", "html"};
-   argument_parser parser1{"program_full_options", 3, argv0};
+   seqan3::argument_parser parser1{"program_full_options", 3, argv0};
    parser1.info.synopsis.push_back("./some_binary_name synopsis");
    parser1.info.synopsis.push_back("./some_binary_name synopsis2");
    parser1.info.description.push_back("description");
@@ -91,7 +89,7 @@ TEST(html_format, full_information_information)
    parser1.info.long_copyright = "long_copyright";
    parser1.info.citation = "citation";
    parser1.add_option(option_value, 'i', "int", "this is a int option.");
-   parser1.add_option(option_value, 'j', "jint", "this is a required int option.", option_spec::REQUIRED);
+   parser1.add_option(option_value, 'j', "jint", "this is a required int option.", seqan3::option_spec::REQUIRED);
    parser1.add_flag(flag_value, 'f', "flag", "this is a flag.");
    parser1.add_flag(flag_value, 'k', "kflag", "this is a flag.");
    parser1.add_positional_option(non_list_pos_opt_value, "this is a positional option.");
@@ -169,7 +167,7 @@ TEST(html_format, full_information_information)
                           "<h2>Version</h2>\n"
                           "<strong>Last update:</strong> <br>\n"
                           "<strong>program_full_options version:</strong> <br>\n"
-                          "<strong>SeqAn version:</strong> " + seqan3_version + "<br>\n"
+                          "<strong>SeqAn version:</strong> " + seqan3::seqan3_version + "<br>\n"
                           "<h2>Url</h2>\n"
                           "www.seqan.de<br>\n"
                           "<br>\n"
@@ -189,11 +187,11 @@ TEST(export_help, parse_error)
     const char * argv3[] = {"./help_add_test --version-check 0", "--export-help", "atml"};
 
     // no value after --export-help
-    EXPECT_THROW((argument_parser{"test_parser", 2, argv}), argument_parser_error);
+    EXPECT_THROW((seqan3::argument_parser{"test_parser", 2, argv}), seqan3::argument_parser_error);
 
     // wrong value after --export-help
-    EXPECT_THROW((argument_parser{"test_parser", 2, argv2}), validation_error);
+    EXPECT_THROW((seqan3::argument_parser{"test_parser", 2, argv2}), seqan3::validation_error);
 
     // wrong value after --export-help
-    EXPECT_THROW((argument_parser{"test_parser", 3, argv3}), validation_error);
+    EXPECT_THROW((seqan3::argument_parser{"test_parser", 3, argv3}), seqan3::validation_error);
 }

--- a/test/unit/argument_parser/detail/format_man_test.cpp
+++ b/test/unit/argument_parser/detail/format_man_test.cpp
@@ -13,8 +13,6 @@
 #include <seqan3/argument_parser/all.hpp>
 #include <seqan3/argument_parser/detail/format_man.hpp>
 
-using namespace seqan3;
-
 // Reused global variables
 struct format_man_test : public ::testing::Test
 {
@@ -85,7 +83,7 @@ struct format_man_test : public ::testing::Test
     R"(example2)" "\n";
 
     // Full info parser initialisation
-    void dummy_init(argument_parser & parser)
+    void dummy_init(seqan3::argument_parser & parser)
     {
         parser.info.date = "December 01, 1994";
         parser.info.version = "01.01.01";
@@ -96,7 +94,7 @@ struct format_man_test : public ::testing::Test
         parser.info.description.push_back("description");
         parser.info.description.push_back("description2");
         parser.add_option(option_value, 'i', "int", "this is a int option.");
-        parser.add_option(option_value, 'j', "jint", "this is a required int option.", option_spec::REQUIRED);
+        parser.add_option(option_value, 'j', "jint", "this is a required int option.", seqan3::option_spec::REQUIRED);
         parser.add_section("Flags");
         parser.add_subsection("SubFlags");
         parser.add_line("here come all the flags");
@@ -112,7 +110,7 @@ struct format_man_test : public ::testing::Test
 TEST_F(format_man_test, empty_information)
 {
     // Create the dummy parser.
-    argument_parser parser{"default", 3, argv};
+    seqan3::argument_parser parser{"default", 3, argv};
     parser.info.date = "December 01, 1994";
     parser.info.version = "01.01.01";
     parser.info.man_page_title = "default_man_page_title";
@@ -155,7 +153,7 @@ TEST_F(format_man_test, empty_information)
 TEST_F(format_man_test, full_information)
 {
     // Create the dummy parser.
-    argument_parser parser{"default", 3, argv};
+    seqan3::argument_parser parser{"default", 3, argv};
 
     // Fill out the dummy parser with options and flags and sections and subsections.
     dummy_init(parser);
@@ -170,7 +168,7 @@ TEST_F(format_man_test, full_information)
 TEST_F(format_man_test, full_info_short_copyright)
 {
     // Create the dummy parser.
-    argument_parser parser{"default", 3, argv};
+    seqan3::argument_parser parser{"default", 3, argv};
 
     // Fill out the dummy parser with options and flags and sections and subsections.
     dummy_init(parser);
@@ -192,7 +190,7 @@ TEST_F(format_man_test, full_info_short_copyright)
 TEST_F(format_man_test, full_info_short_and_citation)
 {
     // Create the dummy parser.
-    argument_parser parser{"default", 3, argv};
+    seqan3::argument_parser parser{"default", 3, argv};
 
     // Fill out the dummy parser with options and flags and sections and subsections.
     dummy_init(parser);
@@ -217,7 +215,7 @@ TEST_F(format_man_test, full_info_short_and_citation)
 TEST_F(format_man_test, full_info_short_long_and_citation)
 {
     // Create the dummy parser.
-    argument_parser parser{"default", 3, argv};
+    seqan3::argument_parser parser{"default", 3, argv};
 
     // Fill out the dummy parser with options and flags and sections and subsections.
     dummy_init(parser);

--- a/test/unit/argument_parser/detail/version_check_test.hpp
+++ b/test/unit/argument_parser/detail/version_check_test.hpp
@@ -15,8 +15,6 @@
 #include <seqan3/argument_parser/all.hpp>
 #include <seqan3/test/tmp_filename.hpp>
 
-using namespace seqan3;
-
 //------------------------------------------------------------------------------
 // test fixtures
 //------------------------------------------------------------------------------
@@ -25,16 +23,16 @@ namespace seqan3::detail
 {
 struct test_accessor
 {
-    static auto & version_check_future(argument_parser & parser)
+    static auto & version_check_future(seqan3::argument_parser & parser)
     {
         return parser.version_check_future;
     }
 };
 } // seqan3::detail
 
-bool wait_for(argument_parser & parser)
+bool wait_for(seqan3::argument_parser & parser)
 {
-    auto & future = detail::test_accessor::version_check_future(parser);
+    auto & future = seqan3::detail::test_accessor::version_check_future(parser);
 
     if (future.valid())
         return future.get();
@@ -57,10 +55,10 @@ struct version_check : public ::testing::Test
         using namespace std::string_literals;
         auto tmp_directory = tmp_file.get_path().parent_path();
 
-        int result = setenv(detail::version_checker::home_env_name, tmp_directory.c_str(), 1);
+        int result = setenv(seqan3::detail::version_checker::home_env_name, tmp_directory.c_str(), 1);
         if (result != 0)
             throw std::runtime_error{"Couldn't set environment variable 'home_env_name' (="s +
-                                     detail::version_checker::home_env_name + ")"s};
+                                     seqan3::detail::version_checker::home_env_name + ")"s};
 
         auto is_prefix_path = [](std::string const & base_path, std::string const & path)
         {
@@ -84,7 +82,7 @@ struct version_check : public ::testing::Test
 
     std::filesystem::path app_tmp_path()
     {
-        return detail::version_checker::get_path();
+        return seqan3::detail::version_checker::get_path();
     }
 
     std::filesystem::path app_version_filename()
@@ -114,7 +112,7 @@ struct version_check : public ::testing::Test
 
         bool app_call_succeeded{false};
 
-        argument_parser parser{app_name, argc, argv};
+        seqan3::argument_parser parser{app_name, argc, argv};
         parser.info.version = "2.3.4";
 
         // In case we don't want to specify --version-check but avoid that short help format will be set (no arguments)
@@ -220,7 +218,7 @@ TEST_F(version_check, option_on)
     }
     else
     {
-        std::cout << "App call did not succeed (server offline?) and could thus not be tested." << std::endl;
+        std::cout << "App call did not succeed (server offline?) and could thus not be tested.\n";
     }
 
     EXPECT_TRUE(remove_files_from_path()); // clear files again
@@ -252,7 +250,7 @@ TEST_F(version_check, option_implicitely_on)
     }
     else
     {
-        std::cout << "App call did not succeed (server offline?) and could thus not be tested." << std::endl;
+        std::cout << "App call did not succeed (server offline?) and could thus not be tested.\n";
     }
 
     EXPECT_TRUE(remove_files_from_path()); // clear files again
@@ -284,7 +282,7 @@ TEST_F(version_check, environment_variable_set)
 
     const char * argv[2] = {app_name.c_str(), "-f"};
 
-    argument_parser parser{app_name, 2, argv};
+    seqan3::argument_parser parser{app_name, 2, argv};
     parser.info.version = "2.3.4";
     bool dummy{};
     parser.add_flag(dummy, 'f', "dummy-flag", "A dummy flag.");
@@ -336,7 +334,7 @@ TEST_F(version_check, option_off)
     if (env != nullptr)
         unsetenv("SEQAN3_NO_VERSION_CHECK");
 
-    argument_parser parser{app_name, 4, argv2};
+    seqan3::argument_parser parser{app_name, 4, argv2};
     parser.info.version = "2.3.4";
 
     EXPECT_EXIT(parser.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
@@ -370,7 +368,7 @@ TEST_F(version_check, smaller_seqan3_version)
     (void) app_call_succeeded;
 
     EXPECT_EQ(out, "");
-    EXPECT_EQ(err, detail::version_checker::message_seqan3_update);
+    EXPECT_EQ(err, seqan3::detail::version_checker::message_seqan3_update);
 
     EXPECT_TRUE(std::regex_match(read_file(app_timestamp_filename()), timestamp_regex));
 
@@ -392,7 +390,7 @@ TEST_F(version_check, greater_app_version)
     (void) app_call_succeeded;
 
     EXPECT_EQ(out, "");
-    EXPECT_EQ(err, detail::version_checker::message_registered_app_update);
+    EXPECT_EQ(err, seqan3::detail::version_checker::message_registered_app_update);
 
     EXPECT_TRUE(std::regex_match(read_file(app_timestamp_filename()), timestamp_regex));
 
@@ -413,7 +411,7 @@ TEST_F(version_check, unregistered_app)
     (void) app_call_succeeded;
 
     EXPECT_EQ(out, "");
-    EXPECT_EQ(err, detail::version_checker::message_unregistered_app);
+    EXPECT_EQ(err, seqan3::detail::version_checker::message_unregistered_app);
 
     EXPECT_TRUE(std::regex_match(read_file(app_timestamp_filename()), timestamp_regex));
 
@@ -437,7 +435,7 @@ TEST_F(version_check, smaller_app_version)
     (void) app_call_succeeded;
 
     EXPECT_EQ(out, "");
-    EXPECT_EQ(err, (detail::version_checker{app_name, "2.3.4"}.message_app_update));
+    EXPECT_EQ(err, (seqan3::detail::version_checker{app_name, "2.3.4"}.message_app_update));
 
     EXPECT_TRUE(std::regex_match(read_file(app_timestamp_filename()), timestamp_regex));
 
@@ -458,7 +456,7 @@ TEST_F(version_check, smaller_app_version_custom_url)
     // create timestamp file that dates one day before current to trigger a message (one day = 86400 seconds)
     ASSERT_TRUE(create_file(app_timestamp_filename(), current_unix_timestamp() - 100401));
 
-    argument_parser parser{app_name, 3, argv};
+    seqan3::argument_parser parser{app_name, 3, argv};
     parser.info.version = "2.3.4";
     parser.info.url = "https//foo.de";
 
@@ -473,7 +471,8 @@ TEST_F(version_check, smaller_app_version_custom_url)
     wait_for(parser);
 
     EXPECT_EQ(out, "");
-    EXPECT_EQ(err, (detail::version_checker{app_name, parser.info.version, parser.info.url}.message_app_update));
+    EXPECT_EQ(err,
+              (seqan3::detail::version_checker{app_name, parser.info.version, parser.info.url}.message_app_update));
 
     EXPECT_TRUE(std::regex_match(read_file(app_timestamp_filename()), timestamp_regex));
 
@@ -521,7 +520,7 @@ TEST_F(version_check, user_specified_always)
     }
     else
     {
-        std::cout << "App call did not succeed (server offline?) and could thus not be tested." << std::endl;
+        std::cout << "App call did not succeed (server offline?) and could thus not be tested.\n";
     }
 
     EXPECT_EQ(read_file(app_timestamp_filename()), "ALWAYS"); // should not be modified

--- a/test/unit/argument_parser/format_parse_test.cpp
+++ b/test/unit/argument_parser/format_parse_test.cpp
@@ -9,14 +9,12 @@
 
 #include <seqan3/argument_parser/all.hpp>
 
-using namespace seqan3;
-
 TEST(parse_type_test, add_option_short_id)
 {
     std::string option_value;
 
     const char * argv[] = {"./argument_parser_test", "-s", "option_string"};
-    argument_parser parser{"test_parser", 3, argv, false};
+    seqan3::argument_parser parser{"test_parser", 3, argv, false};
     parser.add_section("My options");       // no-op for code coverage
     parser.add_subsection("My suboptions"); // no-op for code coverage
     parser.add_line("line");                // no-op for code coverage
@@ -30,7 +28,7 @@ TEST(parse_type_test, add_option_short_id)
 
     // add with no space
     const char * argv2[] = {"./argument_parser_test", "-Soption_string"};
-    argument_parser parser2{"test_parser", 2, argv2, false};
+    seqan3::argument_parser parser2{"test_parser", 2, argv2, false};
     parser2.add_option(option_value, 'S', "string-option", "this is a string option.");
 
     testing::internal::CaptureStderr();
@@ -40,7 +38,7 @@ TEST(parse_type_test, add_option_short_id)
 
     // ad with = sign
     const char * argv3[] = {"./argument_parser_test", "-s=option_string"};
-    argument_parser parser3{"test_parser", 2, argv3, false};
+    seqan3::argument_parser parser3{"test_parser", 2, argv3, false};
     parser3.add_option(option_value, 's', "string-option", "this is a string option.");
 
     testing::internal::CaptureStderr();
@@ -54,7 +52,7 @@ TEST(parse_type_test, add_option_long_id)
     std::string option_value;
 
     const char * argv[] = {"./argument_parser_test", "--string-option", "option_string"};
-    argument_parser parser{"test_parser", 3, argv, false};
+    seqan3::argument_parser parser{"test_parser", 3, argv, false};
     parser.add_option(option_value, 's', "string-option", "this is a string option.");
 
     testing::internal::CaptureStderr();
@@ -64,7 +62,7 @@ TEST(parse_type_test, add_option_long_id)
 
     // add with no space
     const char * argv2[] = {"./argument_parser_test", "--string-optionoption_string"};
-    argument_parser parser2{"test_parser", 2, argv2, false};
+    seqan3::argument_parser parser2{"test_parser", 2, argv2, false};
     parser2.add_option(option_value, 'S', "string-option", "this is a string option.");
 
     testing::internal::CaptureStderr();
@@ -73,7 +71,7 @@ TEST(parse_type_test, add_option_long_id)
     EXPECT_EQ(option_value, "option_string");
 
     const char * argv3[] = {"./argument_parser_test", "--string-option=option_string"};
-    argument_parser parser3{"test_parser", 2, argv3, false};
+    seqan3::argument_parser parser3{"test_parser", 2, argv3, false};
     parser3.add_option(option_value, 's', "string-option", "this is a string option.");
 
     testing::internal::CaptureStderr();
@@ -88,7 +86,7 @@ TEST(parse_type_test, add_flag_short_id_single)
     bool option_value2{true};
 
     const char * argv[] = {"./argument_parser_test", "-t"};
-    argument_parser parser{"test_parser", 2, argv, false};
+    seqan3::argument_parser parser{"test_parser", 2, argv, false};
     parser.add_flag(option_value1, 't', "true-flag", "this is a flag.");
     parser.add_flag(option_value2, 'f', "false-flag", "this is a flag.");
 
@@ -107,7 +105,7 @@ TEST(parse_type_test, add_flag_short_id_multiple)
     bool option_value4{false};
 
     const char * argv[] = {"./argument_parser_test", "-tab"};
-    argument_parser parser{"test_parser", 2, argv, false};
+    seqan3::argument_parser parser{"test_parser", 2, argv, false};
     parser.add_flag(option_value1, 't', "true-flag", "this is a flag.");
     parser.add_flag(option_value2, 'f', "false-flag", "this is a flag.");
     parser.add_flag(option_value3, 'a', "additional-flag", "this is a flag.");
@@ -128,7 +126,7 @@ TEST(parse_type_test, add_flag_long_id)
     bool option_value2{true};
 
     const char * argv[] = {"./argument_parser_test", "--true-flag"};
-    argument_parser parser{"test_parser", 2, argv, false};
+    seqan3::argument_parser parser{"test_parser", 2, argv, false};
     parser.add_flag(option_value1, 't', "true-flag", "this is a flag.");
     parser.add_flag(option_value2, 'f', "false-flag", "this is a flag.");
 
@@ -144,7 +142,7 @@ TEST(parse_type_test, add_positional_option)
     std::string positional_value;
 
     const char * argv[] = {"./argument_parser_test", "positional_string"};
-    argument_parser parser{"test_parser", 2, argv, false};
+    seqan3::argument_parser parser{"test_parser", 2, argv, false};
     parser.add_positional_option(positional_value, "this is a string positional.");
 
     testing::internal::CaptureStderr();
@@ -163,7 +161,7 @@ TEST(parse_type_test, independent_add_order)
 
     // Order 1: option, flag, positional
     const char * argv[] = {"./argument_parser_test", "-i", "2", "-b", "arg"};
-    argument_parser parser{"test_parser", 5, argv, false};
+    seqan3::argument_parser parser{"test_parser", 5, argv, false};
     parser.add_option(option_value, 'i', "int-option", "this is a int option.");
     parser.add_flag(flag_value, 'b', "flag", "this is a flag.");
     parser.add_positional_option(positional_value, "this is a string positional.");
@@ -176,7 +174,7 @@ TEST(parse_type_test, independent_add_order)
     EXPECT_EQ(flag_value, true);
 
     // Order 1: flag, option, positional
-    argument_parser parser2{"test_parser", 5, argv, false};
+    seqan3::argument_parser parser2{"test_parser", 5, argv, false};
     parser2.add_flag(flag_value, 'b', "flag", "this is a flag.");
     parser2.add_option(option_value, 'i', "int-option", "this is a int option.");
     parser2.add_positional_option(positional_value, "this is a string positional.");
@@ -189,7 +187,7 @@ TEST(parse_type_test, independent_add_order)
     EXPECT_EQ(flag_value, true);
 
     // Order 1: option, positional, flag
-    argument_parser parser3{"test_parser", 5, argv, false};
+    seqan3::argument_parser parser3{"test_parser", 5, argv, false};
     parser3.add_option(option_value, 'i', "int-option", "this is a int option.");
     parser3.add_positional_option(positional_value, "this is a string positional.");
     parser3.add_flag(flag_value, 'b', "flag", "this is a flag.");
@@ -202,7 +200,7 @@ TEST(parse_type_test, independent_add_order)
     EXPECT_EQ(flag_value, true);
 
     // Order 1: flag, positional, option
-    argument_parser parser4{"test_parser", 5, argv, false};
+    seqan3::argument_parser parser4{"test_parser", 5, argv, false};
     parser4.add_flag(flag_value, 'b', "flag", "this is a flag.");
     parser4.add_positional_option(positional_value, "this is a string positional.");
     parser4.add_option(option_value, 'i', "int-option", "this is a int option.");
@@ -215,7 +213,7 @@ TEST(parse_type_test, independent_add_order)
     EXPECT_EQ(flag_value, true);
 
     // Order 1: positional, flag, option
-    argument_parser parser5{"test_parser", 5, argv, false};
+    seqan3::argument_parser parser5{"test_parser", 5, argv, false};
     parser5.add_positional_option(positional_value, "this is a string positional.");
     parser5.add_flag(flag_value, 'b', "flag", "this is a flag.");
     parser5.add_option(option_value, 'i', "int-option", "this is a int option.");
@@ -228,7 +226,7 @@ TEST(parse_type_test, independent_add_order)
     EXPECT_EQ(flag_value, true);
 
     // Order 1: positional, option, flag
-    argument_parser parser6{"test_parser", 5, argv, false};
+    seqan3::argument_parser parser6{"test_parser", 5, argv, false};
     parser6.add_positional_option(positional_value, "this is a string positional.");
     parser6.add_option(option_value, 'i', "int-option", "this is a int option.");
     parser6.add_flag(flag_value, 'b', "flag", "this is a flag.");
@@ -251,7 +249,7 @@ TEST(parse_type_test, independent_cmd_order)
 
     // Order 1: option, flag, positional (POSIX conform)
     const char * argv[] = {"./argument_parser_test", "-i", "2", "-b", "arg"};
-    argument_parser parser{"test_parser", 5, argv, false};
+    seqan3::argument_parser parser{"test_parser", 5, argv, false};
     parser.add_option(option_value, 'i', "int-option", "this is a int option.");
     parser.add_flag(flag_value, 'b', "flag", "this is a flag.");
     parser.add_positional_option(positional_value, "this is a string positional.");
@@ -265,7 +263,7 @@ TEST(parse_type_test, independent_cmd_order)
 
     // Order 1: flag, option, positional (POSIX conform)
     const char * argv2[] = {"./argument_parser_test", "-b", "-i", "2", "arg"};
-    argument_parser parser2{"test_parser", 5, argv2, false};
+    seqan3::argument_parser parser2{"test_parser", 5, argv2, false};
     parser2.add_option(option_value, 'i', "int-option", "this is a int option.");
     parser2.add_flag(flag_value, 'b', "flag", "this is a flag.");
     parser2.add_positional_option(positional_value, "this is a string positional.");
@@ -279,7 +277,7 @@ TEST(parse_type_test, independent_cmd_order)
 
     // Order 1: option, positional, flag
     const char * argv3[] = {"./argument_parser_test", "-i", "2", "arg", "-b"};
-    argument_parser parser3{"test_parser", 5, argv3, false};
+    seqan3::argument_parser parser3{"test_parser", 5, argv3, false};
     parser3.add_option(option_value, 'i', "int-option", "this is a int option.");
     parser3.add_flag(flag_value, 'b', "flag", "this is a flag.");
     parser3.add_positional_option(positional_value, "this is a string positional.");
@@ -293,7 +291,7 @@ TEST(parse_type_test, independent_cmd_order)
 
     // Order 1: flag, positional, option
     const char * argv4[] = {"./argument_parser_test", "-b", "arg", "-i", "2"};
-    argument_parser parser4{"test_parser", 5, argv4, false};
+    seqan3::argument_parser parser4{"test_parser", 5, argv4, false};
     parser4.add_option(option_value, 'i', "int-option", "this is a int option.");
     parser4.add_flag(flag_value, 'b', "flag", "this is a flag.");
     parser4.add_positional_option(positional_value, "this is a string positional.");
@@ -307,7 +305,7 @@ TEST(parse_type_test, independent_cmd_order)
 
     // Order 1: positional, flag, option
     const char * argv5[] = {"./argument_parser_test", "arg", "-b", "-i", "2"};
-    argument_parser parser5{"test_parser", 5, argv5, false};
+    seqan3::argument_parser parser5{"test_parser", 5, argv5, false};
     parser5.add_option(option_value, 'i', "int-option", "this is a int option.");
     parser5.add_flag(flag_value, 'b', "flag", "this is a flag.");
     parser5.add_positional_option(positional_value, "this is a string positional.");
@@ -321,7 +319,7 @@ TEST(parse_type_test, independent_cmd_order)
 
     // Order 1: positional, option, flag
     const char * argv6[] = {"./argument_parser_test", "arg", "-i", "2", "-b"};
-    argument_parser parser6{"test_parser", 5, argv6, false};
+    seqan3::argument_parser parser6{"test_parser", 5, argv6, false};
     parser6.add_option(option_value, 'i', "int-option", "this is a int option.");
     parser6.add_flag(flag_value, 'b', "flag", "this is a flag.");
     parser6.add_positional_option(positional_value, "this is a string positional.");
@@ -340,7 +338,7 @@ TEST(parse_test, double_dash_separation_success)
 
     // string option with dash
     const char * argv[] = {"./argument_parser_test", "--", "-strange"};
-    argument_parser parser{"test_parser", 3, argv, false};
+    seqan3::argument_parser parser{"test_parser", 3, argv, false};
     parser.add_positional_option(option_value, "this is a string option.");
 
     testing::internal::CaptureStderr();
@@ -351,7 +349,7 @@ TEST(parse_test, double_dash_separation_success)
     // negative integer option
     int option_value_int;
     const char * argv2[] = {"./argument_parser_test", "--", "-120"};
-    argument_parser parser2{"test_parser", 3, argv2, false};
+    seqan3::argument_parser parser2{"test_parser", 3, argv2, false};
     parser2.add_positional_option(option_value_int, "this is a int option.");
 
     testing::internal::CaptureStderr();
@@ -367,7 +365,7 @@ TEST(parse_test, special_characters_as_value_success)
     // weird option value. But since r/regex option is parsed and with it's
     // value should work correct
     const char * argv[] = {"./argument_parser_test", "--regex", "-i=/45*&//--"};
-    argument_parser parser{"test_parser", 3, argv, false};
+    seqan3::argument_parser parser{"test_parser", 3, argv, false};
     parser.add_option(option_value, 'r', "regex", "strange option value.");
 
     testing::internal::CaptureStderr();
@@ -382,31 +380,31 @@ TEST(parse_test, empty_value_error)
 
     // short option
     const char * argv[] = {"./argument_parser_test", "-i"};
-    argument_parser parser{"test_parser", 2, argv, false};
+    seqan3::argument_parser parser{"test_parser", 2, argv, false};
     parser.add_option(option_value, 'i', "long", "this is a int option.");
 
-    EXPECT_THROW(parser.parse(), argument_parser_error);
+    EXPECT_THROW(parser.parse(), seqan3::argument_parser_error);
 
     // long option
     const char * argv2[] = {"./argument_parser_test", "--long"};
-    argument_parser parser2{"test_parser", 2, argv2, false};
+    seqan3::argument_parser parser2{"test_parser", 2, argv2, false};
     parser2.add_option(option_value, 'i', "long", "this is an int option.");
 
-    EXPECT_THROW(parser2.parse(), argument_parser_error);
+    EXPECT_THROW(parser2.parse(), seqan3::argument_parser_error);
 
     // short option
     const char * argv3[] = {"./argument_parser_test", "-i="};
-    argument_parser parser3{"test_parser", 2, argv3, false};
+    seqan3::argument_parser parser3{"test_parser", 2, argv3, false};
     parser3.add_option(option_value, 'i', "long", "this is an int option.");
 
-    EXPECT_THROW(parser3.parse(), argument_parser_error);
+    EXPECT_THROW(parser3.parse(), seqan3::argument_parser_error);
 
     // short option
     const char * argv4[] = {"./argument_parser_test", "--long="};
-    argument_parser parser4{"test_parser", 2, argv4, false};
+    seqan3::argument_parser parser4{"test_parser", 2, argv4, false};
     parser4.add_option(option_value, 'i', "long", "this is an int option.");
 
-    EXPECT_THROW(parser4.parse(), argument_parser_error);
+    EXPECT_THROW(parser4.parse(), seqan3::argument_parser_error);
 }
 
 TEST(parse_type_test, parse_success_bool_option)
@@ -417,7 +415,7 @@ TEST(parse_type_test, parse_success_bool_option)
     // numbers 0 and 1
     {
         const char * argv[] = {"./argument_parser_test", "-b", "1", "0"};
-        argument_parser parser{"test_parser", 4, argv, false};
+        seqan3::argument_parser parser{"test_parser", 4, argv, false};
         parser.add_option(option_value, 'b', "bool-option", "this is a bool option.");
         parser.add_positional_option(positional_value, "this is a bool positional.");
 
@@ -432,7 +430,7 @@ TEST(parse_type_test, parse_success_bool_option)
     // true and false
     {
         const char * argv[] = {"./argument_parser_test", "-b", "true", "false"};
-        argument_parser parser{"test_parser", 4, argv, false};
+        seqan3::argument_parser parser{"test_parser", 4, argv, false};
         parser.add_option(option_value, 'b', "bool-option", "this is a bool option.");
         parser.add_positional_option(positional_value, "this is a bool positional.");
 
@@ -451,7 +449,7 @@ TEST(parse_type_test, parse_success_int_option)
     size_t positional_value;
 
     const char * argv[] = {"./argument_parser_test", "-i", "-2", "278"};
-    argument_parser parser{"test_parser", 4, argv, false};
+    seqan3::argument_parser parser{"test_parser", 4, argv, false};
     parser.add_option(option_value, 'i', "int-option", "this is a int option.");
     parser.add_positional_option(positional_value, "this is a int positional.");
 
@@ -469,7 +467,7 @@ TEST(parse_type_test, parse_success_double_option)
     double positional_value;
 
     const char * argv[] = {"./argument_parser_test", "-d", "12.457", "0.123"};
-    argument_parser parser{"test_parser", 4, argv, false};
+    seqan3::argument_parser parser{"test_parser", 4, argv, false};
     parser.add_option(option_value, 'd', "double-option", "this is a double option.");
     parser.add_positional_option(positional_value, "this is a double positional.");
 
@@ -482,7 +480,7 @@ TEST(parse_type_test, parse_success_double_option)
 
     // double expression with e
     const char * argv2[] = {"./argument_parser_test", "-d", "6.0221418e23"};
-    argument_parser parser2{"test_parser", 3, argv2, false};
+    seqan3::argument_parser parser2{"test_parser", 3, argv2, false};
     parser2.add_option(option_value, 'd', "double-option", "this is a double option.");
 
     testing::internal::CaptureStderr();
@@ -500,17 +498,17 @@ TEST(parse_type_test, parse_error_bool_option)
 
     // fail on character input
     const char * argv[] = {"./argument_parser_test", "-b", "a"};
-    argument_parser parser{"test_parser", 3, argv, false};
+    seqan3::argument_parser parser{"test_parser", 3, argv, false};
     parser.add_option(option_value, 'b', "bool-option", "this is a bool option.");
 
-    EXPECT_THROW(parser.parse(), argument_parser_error);
+    EXPECT_THROW(parser.parse(), seqan3::argument_parser_error);
 
     // fail on number input expect 0 and 1
     const char * argv2[] = {"./argument_parser_test", "-b", "124"};
-    argument_parser parser2{"test_parser", 3, argv2, false};
+    seqan3::argument_parser parser2{"test_parser", 3, argv2, false};
     parser2.add_option(option_value, 'b', "bool-option", "this is a bool option.");
 
-    EXPECT_THROW(parser2.parse(), argument_parser_error);
+    EXPECT_THROW(parser2.parse(), seqan3::argument_parser_error);
 }
 
 TEST(parse_type_test, parse_error_int_option)
@@ -519,47 +517,47 @@ TEST(parse_type_test, parse_error_int_option)
 
     // fail on character
     const char * argv[] = {"./argument_parser_test", "-i", "abc"};
-    argument_parser parser{"test_parser", 3, argv, false};
+    seqan3::argument_parser parser{"test_parser", 3, argv, false};
     parser.add_option(option_value, 'i', "int-option", "this is a int option.");
 
-    EXPECT_THROW(parser.parse(), argument_parser_error);
+    EXPECT_THROW(parser.parse(), seqan3::argument_parser_error);
 
     // fail on number followed by character
     const char * argv2[] = {"./argument_parser_test", "-i", "2abc"};
-    argument_parser parser2{"test_parser", 3, argv2, false};
+    seqan3::argument_parser parser2{"test_parser", 3, argv2, false};
     parser2.add_option(option_value, 'i', "int-option", "this is a int option.");
 
-    EXPECT_THROW(parser2.parse(), argument_parser_error);
+    EXPECT_THROW(parser2.parse(), seqan3::argument_parser_error);
 
     // fail on double
     const char * argv3[] = {"./argument_parser_test", "-i", "3.12"};
-    argument_parser parser3{"test_parser", 3, argv3, false};
+    seqan3::argument_parser parser3{"test_parser", 3, argv3, false};
     parser3.add_option(option_value, 'i', "int-option", "this is a int option.");
 
-    EXPECT_THROW(parser3.parse(), argument_parser_error);
+    EXPECT_THROW(parser3.parse(), seqan3::argument_parser_error);
 
     // fail on negative number for unsigned
     unsigned option_value_u;
     const char * argv4[] = {"./argument_parser_test", "-i", "-1"};
-    argument_parser parser4{"test_parser", 3, argv4, false};
+    seqan3::argument_parser parser4{"test_parser", 3, argv4, false};
     parser4.add_option(option_value_u, 'i', "int-option", "this is a int option.");
 
-    EXPECT_THROW(parser4.parse(), argument_parser_error);
+    EXPECT_THROW(parser4.parse(), seqan3::argument_parser_error);
 
     // fail on overflow
     int8_t option_value_int8;
     const char * argv5[] = {"./argument_parser_test", "-i", "129"};
-    argument_parser parser5{"test_parser", 3, argv5, false};
+    seqan3::argument_parser parser5{"test_parser", 3, argv5, false};
     parser5.add_option(option_value_int8, 'i', "int-option", "this is a int option.");
 
-    EXPECT_THROW(parser5.parse(), argument_parser_error);
+    EXPECT_THROW(parser5.parse(), seqan3::argument_parser_error);
 
     uint8_t option_value_uint8;
     const char * argv6[] = {"./argument_parser_test", "-i", "267"};
-    argument_parser parser6{"test_parser", 3, argv6, false};
+    seqan3::argument_parser parser6{"test_parser", 3, argv6, false};
     parser6.add_option(option_value_uint8, 'i', "int-option", "this is a int option.");
 
-    EXPECT_THROW(parser6.parse(), argument_parser_error);
+    EXPECT_THROW(parser6.parse(), seqan3::argument_parser_error);
 }
 
 TEST(parse_type_test, parse_error_double_option)
@@ -568,17 +566,17 @@ TEST(parse_type_test, parse_error_double_option)
 
     // fail on character
     const char * argv[] = {"./argument_parser_test", "-i", "abc"};
-    argument_parser parser{"test_parser", 3, argv, false};
+    seqan3::argument_parser parser{"test_parser", 3, argv, false};
     parser.add_option(option_value, 'd', "double-option", "this is a double option.");
 
-    EXPECT_THROW(parser.parse(), argument_parser_error);
+    EXPECT_THROW(parser.parse(), seqan3::argument_parser_error);
 
     // fail on number followed by character
     const char * argv2[] = {"./argument_parser_test", "-d", "12.457a"};
-    argument_parser parser2{"test_parser", 3, argv2, false};
+    seqan3::argument_parser parser2{"test_parser", 3, argv2, false};
     parser2.add_option(option_value, 'd', "double-option", "this is a double option.");
 
-    EXPECT_THROW(parser2.parse(), argument_parser_error);
+    EXPECT_THROW(parser2.parse(), seqan3::argument_parser_error);
 }
 
 namespace foo
@@ -623,7 +621,7 @@ TEST(parse_type_test, parse_success_enum_option)
         foo::bar option_value{};
 
         const char * argv[] = {"./argument_parser_test", "-e", "two"};
-        argument_parser parser{"test_parser", 3, argv, false};
+        seqan3::argument_parser parser{"test_parser", 3, argv, false};
         parser.add_option(option_value, 'e', "enum-option", "this is an enum option.");
 
         EXPECT_NO_THROW(parser.parse());
@@ -634,7 +632,7 @@ TEST(parse_type_test, parse_success_enum_option)
         Other::bar option_value{};
 
         const char * argv[] = {"./argument_parser_test", "-e", "two"};
-        argument_parser parser{"test_parser", 3, argv, false};
+        seqan3::argument_parser parser{"test_parser", 3, argv, false};
         parser.add_option(option_value, 'e', "enum-option", "this is an enum option.");
 
         EXPECT_NO_THROW(parser.parse());
@@ -647,10 +645,10 @@ TEST(parse_type_test, parse_error_enum_option)
     foo::bar option_value{};
 
     const char * argv[] = {"./argument_parser_test", "-e", "four"};
-    argument_parser parser{"test_parser", 3, argv, false};
+    seqan3::argument_parser parser{"test_parser", 3, argv, false};
     parser.add_option(option_value, 'e', "enum-option", "this is an enum option.");
 
-    EXPECT_THROW(parser.parse(), argument_parser_error);
+    EXPECT_THROW(parser.parse(), seqan3::argument_parser_error);
 }
 
 TEST(parse_test, too_many_arguments_error)
@@ -658,18 +656,18 @@ TEST(parse_test, too_many_arguments_error)
     int option_value;
 
     const char * argv[] = {"./argument_parser_test", "5", "15"};
-    argument_parser parser{"test_parser", 3, argv, false};
+    seqan3::argument_parser parser{"test_parser", 3, argv, false};
     parser.add_positional_option(option_value, "this is an int option.");
 
-    EXPECT_THROW(parser.parse(), too_many_arguments);
+    EXPECT_THROW(parser.parse(), seqan3::too_many_arguments);
 
     // since -- indicates -i as a positional argument, this causes a too many args error
     const char * argv2[] = {"./argument_parser_test", "2", "--", "-i"};
-    argument_parser parser2{"test_parser", 4, argv2, false};
+    seqan3::argument_parser parser2{"test_parser", 4, argv2, false};
     parser2.add_positional_option(option_value, "normal int positional argument.");
     parser2.add_option(option_value, 'i', "int-option", "this is an int option.");
 
-    EXPECT_THROW(parser2.parse(), too_many_arguments);
+    EXPECT_THROW(parser2.parse(), seqan3::too_many_arguments);
 }
 
 TEST(parse_test, too_few_arguments_error)
@@ -677,64 +675,64 @@ TEST(parse_test, too_few_arguments_error)
     int option_value;
 
     const char * argv[] = {"./argument_parser_test", "15"};
-    argument_parser parser{"test_parser", 2, argv, false};
+    seqan3::argument_parser parser{"test_parser", 2, argv, false};
     parser.add_positional_option(option_value, "this is an int option.");
     parser.add_positional_option(option_value, "this is another option.");
 
-    EXPECT_THROW(parser.parse(), too_few_arguments);
+    EXPECT_THROW(parser.parse(), seqan3::too_few_arguments);
 
     // since -- indicates -i as a positional argument, this causes a too many args error
     const char * argv2[] = {"./argument_parser_test", "-i", "2"};
-    argument_parser parser2{"test_parser", 3, argv2, false};
+    seqan3::argument_parser parser2{"test_parser", 3, argv2, false};
     parser2.add_positional_option(option_value, "normal int positional argument.");
     parser2.add_option(option_value, 'i', "int-option", "this is an int option.");
 
-    EXPECT_THROW(parser2.parse(), too_few_arguments);
+    EXPECT_THROW(parser2.parse(), seqan3::too_few_arguments);
 }
 
 TEST(parse_test, unknown_option_error)
 {
     // unknown short option
     const char * argv[] = {"./argument_parser_test", "-i", "15"};
-    argument_parser parser{"test_parser", 3, argv, false};
+    seqan3::argument_parser parser{"test_parser", 3, argv, false};
 
-    EXPECT_THROW(parser.parse(), unknown_option);
+    EXPECT_THROW(parser.parse(), seqan3::unknown_option);
 
     // unknown long option
     const char * argv2[] = {"./argument_parser_test", "--arg", "8"};
-    argument_parser parser2{"test_parser", 3, argv2, false};
+    seqan3::argument_parser parser2{"test_parser", 3, argv2, false};
 
-    EXPECT_THROW(parser2.parse(), unknown_option);
+    EXPECT_THROW(parser2.parse(), seqan3::unknown_option);
 
     // unknown short flag
     const char * argv3[] = {"./argument_parser_test", "-a"};
-    argument_parser parser3{"test_parser", 2, argv3, false};
+    seqan3::argument_parser parser3{"test_parser", 2, argv3, false};
 
-    EXPECT_THROW(parser3.parse(), unknown_option);
+    EXPECT_THROW(parser3.parse(), seqan3::unknown_option);
 
     // unknown long flag
     const char * argv4[] = {"./argument_parser_test", "--arg"};
-    argument_parser parser4{"test_parser", 2, argv4, false};
+    seqan3::argument_parser parser4{"test_parser", 2, argv4, false};
 
-    EXPECT_THROW(parser4.parse(), unknown_option);
+    EXPECT_THROW(parser4.parse(), seqan3::unknown_option);
 
     // negative numbers are seen as options
     const char * argv5[] = {"./argument_parser_test", "-5"};
-    argument_parser parser5{"test_parser", 2, argv5, false};
+    seqan3::argument_parser parser5{"test_parser", 2, argv5, false};
 
-    EXPECT_THROW(parser5.parse(), unknown_option);
+    EXPECT_THROW(parser5.parse(), seqan3::unknown_option);
 
     // unknown short option in more complex command line
     int option_value_i;
     std::string option_value_a;
     std::string positional_option;
     const char * argv6[] = {"./argument_parser_test", "-i", "129", "arg1", "-b", "bcd", "-a", "abc"};
-    argument_parser parser6{"test_parser", 8, argv6, false};
+    seqan3::argument_parser parser6{"test_parser", 8, argv6, false};
     parser6.add_option(option_value_i, 'i', "int-option", "this is a int option.");
     parser6.add_option(option_value_a, 'a', "string-option", "this is a string option.");
     parser6.add_positional_option(positional_option, "normal int positional argument.");
 
-    EXPECT_THROW(parser6.parse(), unknown_option);
+    EXPECT_THROW(parser6.parse(), seqan3::unknown_option);
 }
 
 TEST(parse_test, option_declared_multiple_times_error)
@@ -743,24 +741,24 @@ TEST(parse_test, option_declared_multiple_times_error)
 
     // short option
     const char * argv[] = {"./argument_parser_test", "-i", "15", "-i", "3"};
-    argument_parser parser{"test_parser", 5, argv, false};
+    seqan3::argument_parser parser{"test_parser", 5, argv, false};
     parser.add_option(option_value, 'i', "long", "this is a int option.");
 
-    EXPECT_THROW(parser.parse(), option_declared_multiple_times);
+    EXPECT_THROW(parser.parse(), seqan3::option_declared_multiple_times);
 
     // since -- indicates -i as a positional argument, this causes a too many args error
     const char * argv2[] = {"./argument_parser_test", "--long", "5", "--long", "6"};
-    argument_parser parser2{"test_parser", 5, argv2, false};
+    seqan3::argument_parser parser2{"test_parser", 5, argv2, false};
     parser2.add_option(option_value, 'i', "long", "this is an int option.");
 
-    EXPECT_THROW(parser2.parse(), option_declared_multiple_times);
+    EXPECT_THROW(parser2.parse(), seqan3::option_declared_multiple_times);
 
     // since -- indicates -i as a positional argument, this causes a too many args error
     const char * argv3[] = {"./argument_parser_test", "-i", "5", "--long", "6"};
-    argument_parser parser3{"test_parser", 5, argv3, false};
+    seqan3::argument_parser parser3{"test_parser", 5, argv3, false};
     parser3.add_option(option_value, 'i', "long", "this is an int option.");
 
-    EXPECT_THROW(parser3.parse(), option_declared_multiple_times);
+    EXPECT_THROW(parser3.parse(), seqan3::option_declared_multiple_times);
 }
 
 TEST(parse_test, required_option_missing)
@@ -769,12 +767,12 @@ TEST(parse_test, required_option_missing)
 
     // option is required
     const char * argv[] = {"./argument_parser_test", "5", "-i", "15"};
-    argument_parser parser{"test_parser", 4, argv, false};
+    seqan3::argument_parser parser{"test_parser", 4, argv, false};
     parser.add_option(option_value, 'i', "int-option", "this is an int option.");
-    parser.add_option(option_value, 'a', "req-option", "I am required.", option_spec::REQUIRED);
+    parser.add_option(option_value, 'a', "req-option", "I am required.", seqan3::option_spec::REQUIRED);
     parser.add_positional_option(option_value, "this is an int option.");
 
-    EXPECT_THROW(parser.parse(), required_option_missing);
+    EXPECT_THROW(parser.parse(), seqan3::required_option_missing);
 }
 
 TEST(parse_test, argv_const_combinations)
@@ -787,7 +785,7 @@ TEST(parse_test, argv_const_combinations)
 
     // all const*
     char const * const * const argv_all_const{argv};
-    argument_parser parser{"test_parser", 2, argv_all_const, false};
+    seqan3::argument_parser parser{"test_parser", 2, argv_all_const, false};
     parser.add_flag(flag_value, 'f', "flag", "this is a flag.");
 
     EXPECT_NO_THROW(parser.parse());
@@ -795,7 +793,7 @@ TEST(parse_test, argv_const_combinations)
 
     // none const
     flag_value = false;
-    parser = argument_parser{"test_parser", 2, argv, false};
+    parser = seqan3::argument_parser{"test_parser", 2, argv, false};
     parser.add_flag(flag_value, 'f', "flag", "this is a flag.");
 
     EXPECT_NO_THROW(parser.parse());
@@ -804,7 +802,7 @@ TEST(parse_test, argv_const_combinations)
     // const 1
     flag_value = false;
     char const * argv_const1[] = {"./argument_parser_test", "-f"};
-    parser = argument_parser{"test_parser", 2, argv_const1, false};
+    parser = seqan3::argument_parser{"test_parser", 2, argv_const1, false};
     parser.add_flag(flag_value, 'f', "flag", "this is a flag.");
 
     EXPECT_NO_THROW(parser.parse());
@@ -813,7 +811,7 @@ TEST(parse_test, argv_const_combinations)
     // const 2
     flag_value = false;
     char * const argv_const2[] = {arg1, arg2};
-    parser = argument_parser{"test_parser", 2, argv_const2, false};
+    parser = seqan3::argument_parser{"test_parser", 2, argv_const2, false};
     parser.add_flag(flag_value, 'f', "flag", "this is a flag.");
 
     EXPECT_NO_THROW(parser.parse());
@@ -822,7 +820,7 @@ TEST(parse_test, argv_const_combinations)
     // const 12
     flag_value = false;
     char const * const argv_const12[] = {arg1, arg2};
-    parser = argument_parser{"test_parser", 2, argv_const12, false};
+    parser = seqan3::argument_parser{"test_parser", 2, argv_const12, false};
     parser.add_flag(flag_value, 'f', "flag", "this is a flag.");
 
     EXPECT_NO_THROW(parser.parse());
@@ -835,7 +833,7 @@ TEST(parse_test, multiple_empty_options)
 
     {
         const char * argv[]{"./empty_long", "-s=1"};
-        argument_parser parser{"empty_long", 2, argv, false};
+        seqan3::argument_parser parser{"empty_long", 2, argv, false};
         parser.add_option(option_value, 'i', "", "no long");
         parser.add_option(option_value, 's', "", "no long");
 
@@ -845,16 +843,16 @@ TEST(parse_test, multiple_empty_options)
 
     {
         const char * argv[]{"./empty_long", "-s=1", "--unknown"};
-        argument_parser parser{"empty_long", 3, argv, false};
+        seqan3::argument_parser parser{"empty_long", 3, argv, false};
         parser.add_option(option_value, 'i', "", "no long");
         parser.add_option(option_value, 's', "", "no long");
 
-        EXPECT_THROW(parser.parse(), unknown_option);
+        EXPECT_THROW(parser.parse(), seqan3::unknown_option);
     }
 
     {
         const char * argv[]{"./empty_short", "--long=2"};
-        argument_parser parser{"empty_short", 2, argv, false};
+        seqan3::argument_parser parser{"empty_short", 2, argv, false};
         parser.add_option(option_value, '\0', "longi", "no short");
         parser.add_option(option_value, '\0', "long", "no short");
 
@@ -867,12 +865,12 @@ TEST(parse_test, version_check_option_error)
 {
     {   // version-check must be followed by a value
         const char * argv[] = {"./argument_parser_test", "--version-check"};
-        EXPECT_THROW((argument_parser{"test_parser", 2, argv}), argument_parser_error);
+        EXPECT_THROW((seqan3::argument_parser{"test_parser", 2, argv}), seqan3::argument_parser_error);
     }
 
     {   // version-check value must be 0 or 1
         const char * argv[] = {"./argument_parser_test", "--version-check", "foo"};
-        EXPECT_THROW((argument_parser{"test_parser", 3, argv}), argument_parser_error);
+        EXPECT_THROW((seqan3::argument_parser{"test_parser", 3, argv}), seqan3::argument_parser_error);
     }
 }
 
@@ -884,13 +882,13 @@ TEST(parse_test, subcommand_argument_parser_success)
     // parsing
     {
         const char * argv[]{"./top_level", "-f", "sub1", "foo"};
-        argument_parser top_level_parser{"top_level", 4, argv, false, {"sub1", "sub2"}};
+        seqan3::argument_parser top_level_parser{"top_level", 4, argv, false, {"sub1", "sub2"}};
         top_level_parser.add_flag(flag_value, 'f', "foo", "foo bar");
 
         EXPECT_NO_THROW(top_level_parser.parse());
         EXPECT_EQ(true, flag_value);
 
-        argument_parser & sub_parser = top_level_parser.get_sub_parser();
+        seqan3::argument_parser & sub_parser = top_level_parser.get_sub_parser();
 
         EXPECT_EQ(sub_parser.info.app_name, "top_level-sub1");
 
@@ -903,7 +901,7 @@ TEST(parse_test, subcommand_argument_parser_success)
     // top-level help page
     {
         const char * argv[]{"./top_level", "-h", "-f", "sub1", "foo"};
-        argument_parser top_level_parser{"top_level", 5, argv, false, {"sub1", "sub2"}};
+        seqan3::argument_parser top_level_parser{"top_level", 5, argv, false, {"sub1", "sub2"}};
         top_level_parser.add_flag(flag_value, 'f', "foo", "foo bar");
 
         testing::internal::CaptureStdout();
@@ -914,13 +912,13 @@ TEST(parse_test, subcommand_argument_parser_success)
     // sub-parser help page
     {
         const char * argv[]{"./top_level", "-f", "sub1", "-h"};
-        argument_parser top_level_parser{"top_level", 4, argv, false, {"sub1", "sub2"}};
+        seqan3::argument_parser top_level_parser{"top_level", 4, argv, false, {"sub1", "sub2"}};
         top_level_parser.add_flag(flag_value, 'f', "foo", "foo bar");
 
         EXPECT_NO_THROW(top_level_parser.parse());
         EXPECT_EQ(true, flag_value);
 
-        argument_parser & sub_parser = top_level_parser.get_sub_parser();
+        seqan3::argument_parser & sub_parser = top_level_parser.get_sub_parser();
 
         EXPECT_EQ(sub_parser.info.app_name, "top_level-sub1");
 
@@ -934,6 +932,7 @@ TEST(parse_test, subcommand_argument_parser_success)
     // incorrect sub command
     {
         const char * argv[]{"./top_level", "-f", "2", "subiddysub", "foo"};
-        EXPECT_THROW((argument_parser{"top_level", 5, argv, false, {"sub1", "sub2"}}), argument_parser_error);
+        EXPECT_THROW((seqan3::argument_parser{"top_level", 5, argv, false, {"sub1", "sub2"}}),
+                     seqan3::argument_parser_error);
     }
 }

--- a/test/unit/argument_parser/format_parse_validators_test.cpp
+++ b/test/unit/argument_parser/format_parse_validators_test.cpp
@@ -17,8 +17,6 @@
 #include <seqan3/std/filesystem>
 #include <seqan3/test/tmp_filename.hpp>
 
-using namespace seqan3;
-
 struct dummy_file
 {
 
@@ -32,7 +30,7 @@ struct dummy_file
         static inline std::vector<std::string> file_extensions{ {"sam"}, {"bam"}};
     };
 
-    using valid_formats = type_list<format1, format2>;
+    using valid_formats = seqan3::type_list<format1, format2>;
 };
 
 std::string const basic_options_str = "OPTIONS"
@@ -47,33 +45,33 @@ std::string const basic_options_str = "OPTIONS"
 std::string const basic_version_str = "VERSION"
                                       "Last update:"
                                       "test_parser version:"
-                                      "SeqAn version: " + seqan3_version;
+                                      "SeqAn version: " + seqan3::seqan3_version;
 
 TEST(validator_test, fullfill_concept)
 {
-    EXPECT_FALSE(validator<int>);
+    EXPECT_FALSE(seqan3::validator<int>);
 
-    EXPECT_TRUE(validator<detail::default_validator<int>>);
-    EXPECT_TRUE(validator<detail::default_validator<int> const>);
-    EXPECT_TRUE(validator<detail::default_validator<int> &>);
+    EXPECT_TRUE(seqan3::validator<seqan3::detail::default_validator<int>>);
+    EXPECT_TRUE(seqan3::validator<seqan3::detail::default_validator<int> const>);
+    EXPECT_TRUE(seqan3::validator<seqan3::detail::default_validator<int> &>);
 
-    EXPECT_TRUE(validator<detail::default_validator<std::vector<int>>>);
-    EXPECT_TRUE(validator<arithmetic_range_validator>);
-    EXPECT_TRUE(validator<value_list_validator<double>>);
-    EXPECT_TRUE(validator<value_list_validator<std::string>>);
-    EXPECT_TRUE(validator<input_file_validator<>>);
-    EXPECT_TRUE(validator<output_file_validator<>>);
-    EXPECT_TRUE(validator<input_directory_validator>);
-    EXPECT_TRUE(validator<output_directory_validator>);
-    EXPECT_TRUE(validator<regex_validator>);
+    EXPECT_TRUE(seqan3::validator<seqan3::detail::default_validator<std::vector<int>>>);
+    EXPECT_TRUE(seqan3::validator<seqan3::arithmetic_range_validator>);
+    EXPECT_TRUE(seqan3::validator<seqan3::value_list_validator<double>>);
+    EXPECT_TRUE(seqan3::validator<seqan3::value_list_validator<std::string>>);
+    EXPECT_TRUE(seqan3::validator<seqan3::input_file_validator<>>);
+    EXPECT_TRUE(seqan3::validator<seqan3::output_file_validator<>>);
+    EXPECT_TRUE(seqan3::validator<seqan3::input_directory_validator>);
+    EXPECT_TRUE(seqan3::validator<seqan3::output_directory_validator>);
+    EXPECT_TRUE(seqan3::validator<seqan3::regex_validator>);
 
-    EXPECT_TRUE(validator<decltype(input_file_validator{{"t"}} | regex_validator{".*"})>);
+    EXPECT_TRUE(seqan3::validator<decltype(seqan3::input_file_validator{{"t"}} | seqan3::regex_validator{".*"})>);
 }
 
 TEST(validator_test, input_file)
 {
-    test::tmp_filename tmp_name{"testbox.fasta"};
-    test::tmp_filename tmp_name_2{"testbox_2.fasta"};
+    seqan3::test::tmp_filename tmp_name{"testbox.fasta"};
+    seqan3::test::tmp_filename tmp_name_2{"testbox_2.fasta"};
 
     std::vector formats{std::string{"fa"}, std::string{"sam"}, std::string{"fasta"}};
 
@@ -83,31 +81,31 @@ TEST(validator_test, input_file)
     { // single file
 
         { // empty list of file.
-            input_file_validator my_validator{};
+            seqan3::input_file_validator my_validator{};
             EXPECT_NO_THROW(my_validator(tmp_name.get_path()));
         }
 
         { // file already exists.
             std::filesystem::path does_not_exist{tmp_name.get_path()};
             does_not_exist.replace_extension(".bam");
-            input_file_validator my_validator{formats};
-            EXPECT_THROW(my_validator(does_not_exist), validation_error);
+            seqan3::input_file_validator my_validator{formats};
+            EXPECT_THROW(my_validator(does_not_exist), seqan3::validation_error);
         }
 
         { // file has wrong format.
-            input_file_validator my_validator{std::vector{std::string{"sam"}}};
-            EXPECT_THROW(my_validator(tmp_name.get_path()), validation_error);
+            seqan3::input_file_validator my_validator{std::vector{std::string{"sam"}}};
+            EXPECT_THROW(my_validator(tmp_name.get_path()), seqan3::validation_error);
         }
 
         { // file has no extension.
             std::filesystem::path does_not_exist{tmp_name.get_path()};
             does_not_exist.replace_extension();
-            input_file_validator my_validator{formats};
-            EXPECT_THROW(my_validator(does_not_exist), validation_error);
+            seqan3::input_file_validator my_validator{formats};
+            EXPECT_THROW(my_validator(does_not_exist), seqan3::validation_error);
         }
 
         {  // read from file
-            input_file_validator<dummy_file> my_validator{};
+            seqan3::input_file_validator<dummy_file> my_validator{};
             EXPECT_NO_THROW(my_validator(tmp_name.get_path()));
         }
 
@@ -116,9 +114,9 @@ TEST(validator_test, input_file)
         // option
         std::string const & path = tmp_name.get_path().string();
         const char * argv[] = {"./argument_parser_test", "-i", path.c_str()};
-        argument_parser parser{"test_parser", 3, argv, false};
+        seqan3::argument_parser parser{"test_parser", 3, argv, false};
         parser.add_option(file_in_path, 'i', "int-option", "desc",
-                          option_spec::DEFAULT, input_file_validator{formats});
+                          seqan3::option_spec::DEFAULT, seqan3::input_file_validator{formats});
 
         EXPECT_NO_THROW(parser.parse());
         EXPECT_EQ(file_in_path.string(), path);
@@ -132,8 +130,8 @@ TEST(validator_test, input_file)
         std::string const & path_2 = tmp_name_2.get_path().string();
 
         const char * argv[] = {"./argument_parser_test", path.c_str(), path_2.c_str()};
-        argument_parser parser{"test_parser", 3, argv, false};
-        parser.add_positional_option(input_files, "desc", input_file_validator{formats});
+        seqan3::argument_parser parser{"test_parser", 3, argv, false};
+        parser.add_positional_option(input_files, "desc", seqan3::input_file_validator{formats});
 
         EXPECT_NO_THROW(parser.parse());
         EXPECT_EQ(input_files.size(), 2u);
@@ -144,8 +142,8 @@ TEST(validator_test, input_file)
     { // get help page message
         std::filesystem::path path;
         const char * argv[] = {"./argument_parser_test", "-h"};
-        argument_parser parser{"test_parser", 2, argv, false};
-        parser.add_positional_option(path, "desc", input_file_validator{formats});
+        seqan3::argument_parser parser{"test_parser", 2, argv, false};
+        parser.add_positional_option(path, "desc", seqan3::input_file_validator{formats});
 
         testing::internal::CaptureStdout();
         EXPECT_EXIT(parser.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
@@ -157,54 +155,55 @@ TEST(validator_test, input_file)
                                "          desc Valid input file formats: [fa, sam, fasta]"} +
                                basic_options_str +
                                basic_version_str;
-        EXPECT_TRUE(ranges::equal((my_stdout | std::views::filter(!is_space)), expected | std::views::filter(!is_space)));
+        EXPECT_TRUE(ranges::equal((my_stdout | std::views::filter(!seqan3::is_space)), expected
+                                             | std::views::filter(!seqan3::is_space)));
     }
 }
 
 TEST(validator_test, input_file_ext_from_file)
 {
     // Give as a template argument the seqan3 file type to get all valid extensions for this file.
-    input_file_validator<dummy_file> validator{};
+    seqan3::input_file_validator<dummy_file> validator{};
 
     EXPECT_EQ(validator.get_help_page_message(), "Valid input file formats: [fa, fasta, sam, bam]");
 }
 
 TEST(validator_test, output_file)
 {
-    test::tmp_filename tmp_name{"testbox.fasta"};
-    test::tmp_filename tmp_name_2{"testbox_2.fasta"};
-    test::tmp_filename tmp_name_3{"testbox_3.fa"};
+    seqan3::test::tmp_filename tmp_name{"testbox.fasta"};
+    seqan3::test::tmp_filename tmp_name_2{"testbox_2.fasta"};
+    seqan3::test::tmp_filename tmp_name_3{"testbox_3.fa"};
 
     std::vector formats{std::string{"fa"}, std::string{"sam"}, std::string{"fasta"}};
 
     { // single file
 
         { // empty list of file.
-            output_file_validator my_validator{};
+            seqan3::output_file_validator my_validator{};
             EXPECT_NO_THROW(my_validator(tmp_name.get_path()));
         }
 
         { // file does not exist.
             std::ofstream tmp_file_2(tmp_name_2.get_path());
             std::filesystem::path does_not_exist{tmp_name_2.get_path()};
-            output_file_validator my_validator{formats};
-            EXPECT_THROW(my_validator(does_not_exist), validation_error);
+            seqan3::output_file_validator my_validator{formats};
+            EXPECT_THROW(my_validator(does_not_exist), seqan3::validation_error);
         }
 
         { // file has wrong format.
-            output_file_validator my_validator{std::vector{std::string{"sam"}}};
-            EXPECT_THROW(my_validator(tmp_name.get_path()), validation_error);
+            seqan3::output_file_validator my_validator{std::vector{std::string{"sam"}}};
+            EXPECT_THROW(my_validator(tmp_name.get_path()), seqan3::validation_error);
         }
 
         { // file has no extension.
             std::filesystem::path no_extension{tmp_name.get_path()};
             no_extension.replace_extension();
-            output_file_validator my_validator{formats};
-            EXPECT_THROW(my_validator(no_extension), validation_error);
+            seqan3::output_file_validator my_validator{formats};
+            EXPECT_THROW(my_validator(no_extension), seqan3::validation_error);
         }
 
         {  // read from file
-            output_file_validator<dummy_file> my_validator{};
+            seqan3::output_file_validator<dummy_file> my_validator{};
             EXPECT_NO_THROW(my_validator(tmp_name.get_path()));
         }
 
@@ -213,9 +212,9 @@ TEST(validator_test, output_file)
         // option
         std::string const & path = tmp_name.get_path().string();
         const char * argv[] = {"./argument_parser_test", "-o", path.c_str()};
-        argument_parser parser{"test_parser", 3, argv, false};
+        seqan3::argument_parser parser{"test_parser", 3, argv, false};
         parser.add_option(file_out_path, 'o', "out-option", "desc",
-                          option_spec::DEFAULT, output_file_validator{formats});
+                          seqan3::option_spec::DEFAULT, seqan3::output_file_validator{formats});
 
         EXPECT_NO_THROW(parser.parse());
         EXPECT_EQ(file_out_path.string(), path);
@@ -229,8 +228,8 @@ TEST(validator_test, output_file)
         std::string const & path_3 = tmp_name_3.get_path().string();
 
         const char * argv[] = {"./argument_parser_test", path.c_str(), path_3.c_str()};
-        argument_parser parser{"test_parser", 3, argv, false};
-        parser.add_positional_option(output_files, "desc", output_file_validator{formats});
+        seqan3::argument_parser parser{"test_parser", 3, argv, false};
+        parser.add_positional_option(output_files, "desc", seqan3::output_file_validator{formats});
 
         EXPECT_NO_THROW(parser.parse());
         EXPECT_EQ(output_files.size(), 2u);
@@ -242,8 +241,8 @@ TEST(validator_test, output_file)
     {
         std::filesystem::path path;
         const char * argv[] = {"./argument_parser_test", "-h"};
-        argument_parser parser{"test_parser", 2, argv, false};
-        parser.add_positional_option(path, "desc", output_file_validator{formats});
+        seqan3::argument_parser parser{"test_parser", 2, argv, false};
+        parser.add_positional_option(path, "desc", seqan3::output_file_validator{formats});
 
         testing::internal::CaptureStdout();
         EXPECT_EXIT(parser.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
@@ -255,35 +254,36 @@ TEST(validator_test, output_file)
                                "          desc Valid output file formats: [fa, sam, fasta]"} +
                                basic_options_str +
                                basic_version_str;
-        EXPECT_TRUE(ranges::equal((my_stdout | std::views::filter(!is_space)), expected | std::views::filter(!is_space)));
+        EXPECT_TRUE(ranges::equal((my_stdout | std::views::filter(!seqan3::is_space)), expected
+                                             | std::views::filter(!seqan3::is_space)));
     }
 }
 
 TEST(validator_test, output_file_ext_from_file)
 {
     // Give as a template argument the seqan3 file type to get all valid extensions for this file.
-    output_file_validator<dummy_file> validator{};
+    seqan3::output_file_validator<dummy_file> validator{};
 
     EXPECT_EQ(validator.get_help_page_message(), "Valid output file formats: [fa, fasta, sam, bam]");
 }
 
 TEST(validator_test, input_directory)
 {
-    test::tmp_filename tmp_name{"testbox.fasta"};
+    seqan3::test::tmp_filename tmp_name{"testbox.fasta"};
 
     { // directory
 
         { // has filename
             std::ofstream tmp_dir(tmp_name.get_path());
-            input_directory_validator my_validator{};
-            EXPECT_THROW(my_validator(tmp_name.get_path()), validation_error);
+            seqan3::input_directory_validator my_validator{};
+            EXPECT_THROW(my_validator(tmp_name.get_path()), seqan3::validation_error);
         }
 
         { // read directory
             std::filesystem::path p = tmp_name.get_path();
             p.remove_filename();
             std::ofstream tmp_dir(p);
-            input_directory_validator my_validator{};
+            seqan3::input_directory_validator my_validator{};
             my_validator(p);
             EXPECT_NO_THROW(my_validator(p));
 
@@ -292,9 +292,9 @@ TEST(validator_test, input_directory)
             // option
             std::string const & path = p.string();
             const char * argv[] = {"./argument_parser_test", "-i", path.c_str()};
-            argument_parser parser{"test_parser", 3, argv, false};
+            seqan3::argument_parser parser{"test_parser", 3, argv, false};
             parser.add_option(dir_in_path, 'i', "input-option", "desc",
-                              option_spec::DEFAULT, input_directory_validator{});
+                              seqan3::option_spec::DEFAULT, seqan3::input_directory_validator{});
 
             EXPECT_NO_THROW(parser.parse());
             EXPECT_EQ(path, dir_in_path.string());
@@ -305,8 +305,8 @@ TEST(validator_test, input_directory)
         // get help page message
         std::filesystem::path path;
         const char * argv[] = {"./argument_parser_test", "-h"};
-        argument_parser parser{"test_parser", 2, argv, false};
-        parser.add_positional_option(path, "desc", input_directory_validator{});
+        seqan3::argument_parser parser{"test_parser", 2, argv, false};
+        parser.add_positional_option(path, "desc", seqan3::input_directory_validator{});
 
         testing::internal::CaptureStdout();
         EXPECT_EXIT(parser.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
@@ -319,18 +319,19 @@ TEST(validator_test, input_directory)
                                basic_options_str +
                                basic_version_str;
 
-        EXPECT_TRUE(ranges::equal((my_stdout | std::views::filter(!is_space)), expected | std::views::filter(!is_space)));
+        EXPECT_TRUE(ranges::equal((my_stdout | std::views::filter(!seqan3::is_space)), expected
+                                             | std::views::filter(!seqan3::is_space)));
     }
 }
 
 TEST(validator_test, output_directory)
 {
-    test::tmp_filename tmp_name{"testbox.fasta"};
+    seqan3::test::tmp_filename tmp_name{"testbox.fasta"};
 
     { // read directory
         std::filesystem::path p = tmp_name.get_path();
         p.remove_filename();
-        output_directory_validator my_validator{};
+        seqan3::output_directory_validator my_validator{};
         my_validator(p);
         EXPECT_NO_THROW();
 
@@ -339,9 +340,9 @@ TEST(validator_test, output_directory)
         // option
         std::string const & path = p.string();
         const char * argv[] = {"./argument_parser_test", "-o", path.c_str()};
-        argument_parser parser{"test_parser", 3, argv, false};
+        seqan3::argument_parser parser{"test_parser", 3, argv, false};
         parser.add_option(dir_out_path, 'o', "output-option", "desc",
-                          option_spec::DEFAULT, output_directory_validator{});
+                          seqan3::option_spec::DEFAULT, seqan3::output_directory_validator{});
 
         EXPECT_NO_THROW(parser.parse());
         EXPECT_EQ(path, dir_out_path.string());
@@ -351,8 +352,8 @@ TEST(validator_test, output_directory)
         // get help page message
         std::filesystem::path path;
         const char * argv[] = {"./argument_parser_test", "-h"};
-        argument_parser parser{"test_parser", 2, argv, false};
-        parser.add_positional_option(path, "desc", output_directory_validator{});
+        seqan3::argument_parser parser{"test_parser", 2, argv, false};
+        parser.add_positional_option(path, "desc", seqan3::output_directory_validator{});
 
         testing::internal::CaptureStdout();
         EXPECT_EXIT(parser.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
@@ -365,7 +366,8 @@ TEST(validator_test, output_directory)
                                basic_options_str +
                                basic_version_str;
 
-        EXPECT_TRUE(ranges::equal((my_stdout | std::views::filter(!is_space)), expected | std::views::filter(!is_space)));
+        EXPECT_TRUE(ranges::equal((my_stdout | std::views::filter(!seqan3::is_space)), expected
+                                             | std::views::filter(!seqan3::is_space)));
     }
 }
 
@@ -403,11 +405,11 @@ inline bool write_access(std::filesystem::path const & file)
 
 TEST(validator_test, inputfile_not_readable)
 {
-    test::tmp_filename tmp_name{"my_file.test"};
+    seqan3::test::tmp_filename tmp_name{"my_file.test"};
     std::filesystem::path tmp_file{tmp_name.get_path()};
     std::ofstream str{tmp_name.get_path()};
 
-    EXPECT_NO_THROW(input_file_validator{}(tmp_file));
+    EXPECT_NO_THROW(seqan3::input_file_validator{}(tmp_file));
 
     std::filesystem::permissions(tmp_file,
                                  std::filesystem::perms::owner_read | std::filesystem::perms::group_read |
@@ -416,7 +418,7 @@ TEST(validator_test, inputfile_not_readable)
 
     if (!read_access(tmp_file))
     {
-        EXPECT_THROW(input_file_validator{}(tmp_file), validation_error);
+        EXPECT_THROW(seqan3::input_file_validator{}(tmp_file), seqan3::validation_error);
     }
 
     std::filesystem::permissions(tmp_file,
@@ -427,12 +429,12 @@ TEST(validator_test, inputfile_not_readable)
 
 TEST(validator_test, inputdir_not_readable)
 {
-    test::tmp_filename tmp_name{"dir"};
+    seqan3::test::tmp_filename tmp_name{"dir"};
     std::filesystem::path tmp_dir{tmp_name.get_path()};
 
     std::filesystem::create_directory(tmp_dir);
 
-    EXPECT_NO_THROW(input_directory_validator{}(tmp_dir));
+    EXPECT_NO_THROW(seqan3::input_directory_validator{}(tmp_dir));
 
     std::filesystem::permissions(tmp_dir,
                                  std::filesystem::perms::owner_read | std::filesystem::perms::group_read |
@@ -441,7 +443,7 @@ TEST(validator_test, inputdir_not_readable)
 
     if (!read_access(tmp_dir))
     {
-        EXPECT_THROW(input_directory_validator{}(tmp_dir), validation_error);
+        EXPECT_THROW(seqan3::input_directory_validator{}(tmp_dir), seqan3::validation_error);
     }
 
     std::filesystem::permissions(tmp_dir,
@@ -452,10 +454,10 @@ TEST(validator_test, inputdir_not_readable)
 
 TEST(validator_test, outputfile_not_writable)
 {
-    test::tmp_filename tmp_name{"my_file.test"};
+    seqan3::test::tmp_filename tmp_name{"my_file.test"};
     std::filesystem::path tmp_file{tmp_name.get_path()};
 
-    EXPECT_NO_THROW(output_file_validator{}(tmp_file));
+    EXPECT_NO_THROW(seqan3::output_file_validator{}(tmp_file));
 
     // Parent path is not writable.
     std::filesystem::permissions(tmp_file.parent_path(),
@@ -465,7 +467,7 @@ TEST(validator_test, outputfile_not_writable)
 
     if (!write_access(tmp_file))
     {
-        EXPECT_THROW(output_file_validator{}(tmp_file), validation_error);
+        EXPECT_THROW(seqan3::output_file_validator{}(tmp_file), seqan3::validation_error);
     }
 
     // make sure we can remove the directory.
@@ -478,10 +480,10 @@ TEST(validator_test, outputfile_not_writable)
 TEST(validator_test, outputdir_not_writable)
 {
     { // parent dir is not writable.
-        test::tmp_filename tmp_name{"dir"};
+        seqan3::test::tmp_filename tmp_name{"dir"};
         std::filesystem::path tmp_dir{tmp_name.get_path()};
 
-        EXPECT_NO_THROW(output_directory_validator{}(tmp_dir));
+        EXPECT_NO_THROW(seqan3::output_directory_validator{}(tmp_dir));
         EXPECT_FALSE(std::filesystem::exists(tmp_dir));
         // Parent path is not writable.
         std::filesystem::permissions(tmp_dir.parent_path(),
@@ -491,7 +493,7 @@ TEST(validator_test, outputdir_not_writable)
 
         if (!write_access(tmp_dir))
         {
-            EXPECT_THROW(output_directory_validator{}(tmp_dir), validation_error);
+            EXPECT_THROW(seqan3::output_directory_validator{}(tmp_dir), seqan3::validation_error);
         }
 
         // make sure we can remove the directory.
@@ -502,11 +504,11 @@ TEST(validator_test, outputdir_not_writable)
     }
 
     {  // this dir is not writable
-        test::tmp_filename tmp_name{"dir"};
+        seqan3::test::tmp_filename tmp_name{"dir"};
         std::filesystem::path tmp_dir{tmp_name.get_path()};
 
         std::filesystem::create_directory(tmp_dir);
-        EXPECT_NO_THROW(output_directory_validator{}(tmp_dir));
+        EXPECT_NO_THROW(seqan3::output_directory_validator{}(tmp_dir));
 
         // This path exists but is not writable.
         std::filesystem::permissions(tmp_dir,
@@ -516,7 +518,7 @@ TEST(validator_test, outputdir_not_writable)
 
         if (!write_access(tmp_dir))
         {
-            EXPECT_THROW(output_directory_validator{}(tmp_dir), validation_error);
+            EXPECT_THROW(seqan3::output_directory_validator{}(tmp_dir), seqan3::validation_error);
         }
 
         // make sure we can remove the directory.
@@ -535,9 +537,9 @@ TEST(validator_test, arithmetic_range_validator_success)
 
     // option
     const char * argv[] = {"./argument_parser_test", "-i", "10"};
-    argument_parser parser{"test_parser", 3, argv, false};
+    seqan3::argument_parser parser{"test_parser", 3, argv, false};
     parser.add_option(option_value, 'i', "int-option", "desc",
-                      option_spec::DEFAULT, arithmetic_range_validator{1, 20});
+                      seqan3::option_spec::DEFAULT, seqan3::arithmetic_range_validator{1, 20});
 
     testing::internal::CaptureStderr();
     EXPECT_NO_THROW(parser.parse());
@@ -546,9 +548,9 @@ TEST(validator_test, arithmetic_range_validator_success)
 
     // option - negative values
     const char * argv2[] = {"./argument_parser_test", "-i", "-10"};
-    argument_parser parser2{"test_parser", 3, argv2, false};
+    seqan3::argument_parser parser2{"test_parser", 3, argv2, false};
     parser2.add_option(option_value, 'i', "int-option", "desc",
-                       option_spec::DEFAULT, arithmetic_range_validator{-20, 20});
+                       seqan3::option_spec::DEFAULT, seqan3::arithmetic_range_validator{-20, 20});
 
     testing::internal::CaptureStderr();
     EXPECT_NO_THROW(parser2.parse());
@@ -557,8 +559,8 @@ TEST(validator_test, arithmetic_range_validator_success)
 
     // positional option
     const char * argv3[] = {"./argument_parser_test", "10"};
-    argument_parser parser3{"test_parser", 2, argv3, false};
-    parser3.add_positional_option(option_value, "desc", arithmetic_range_validator{1, 20});
+    seqan3::argument_parser parser3{"test_parser", 2, argv3, false};
+    parser3.add_positional_option(option_value, "desc", seqan3::arithmetic_range_validator{1, 20});
 
     testing::internal::CaptureStderr();
     EXPECT_NO_THROW(parser3.parse());
@@ -567,8 +569,8 @@ TEST(validator_test, arithmetic_range_validator_success)
 
     // positional option - negative values
     const char * argv4[] = {"./argument_parser_test", "--", "-10"};
-    argument_parser parser4{"test_parser", 3, argv4, false};
-    parser4.add_positional_option(option_value, "desc", arithmetic_range_validator{-20, 20});
+    seqan3::argument_parser parser4{"test_parser", 3, argv4, false};
+    parser4.add_positional_option(option_value, "desc", seqan3::arithmetic_range_validator{-20, 20});
 
     testing::internal::CaptureStderr();
     EXPECT_NO_THROW(parser4.parse());
@@ -577,9 +579,9 @@ TEST(validator_test, arithmetic_range_validator_success)
 
     // option - vector
     const char * argv5[] = {"./argument_parser_test", "-i", "-10", "-i", "48"};
-    argument_parser parser5{"test_parser", 5, argv5, false};
+    seqan3::argument_parser parser5{"test_parser", 5, argv5, false};
     parser5.add_option(option_vector, 'i', "int-option", "desc",
-                       option_spec::DEFAULT, arithmetic_range_validator{-50,50});
+                       seqan3::option_spec::DEFAULT, seqan3::arithmetic_range_validator{-50,50});
 
     testing::internal::CaptureStderr();
     EXPECT_NO_THROW(parser5.parse());
@@ -590,8 +592,8 @@ TEST(validator_test, arithmetic_range_validator_success)
     // positional option - vector
     option_vector.clear();
     const char * argv6[] = {"./argument_parser_test", "--", "-10", "1"};
-    argument_parser parser6{"test_parser", 4, argv6, false};
-    parser6.add_positional_option(option_vector, "desc", arithmetic_range_validator{-20,20});
+    seqan3::argument_parser parser6{"test_parser", 4, argv6, false};
+    parser6.add_positional_option(option_vector, "desc", seqan3::arithmetic_range_validator{-20,20});
 
     testing::internal::CaptureStderr();
     EXPECT_NO_THROW(parser6.parse());
@@ -602,8 +604,8 @@ TEST(validator_test, arithmetic_range_validator_success)
     // get help page message
     option_vector.clear();
     const char * argv7[] = {"./argument_parser_test", "-h"};
-    argument_parser parser7{"test_parser", 2, argv7, false};
-    parser7.add_positional_option(option_vector, "desc", arithmetic_range_validator{-20,20});
+    seqan3::argument_parser parser7{"test_parser", 2, argv7, false};
+    parser7.add_positional_option(option_vector, "desc", seqan3::arithmetic_range_validator{-20,20});
 
     testing::internal::CaptureStdout();
     EXPECT_EXIT(parser7.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
@@ -615,15 +617,15 @@ TEST(validator_test, arithmetic_range_validator_success)
                            "          desc Default: []. Value must be in range [-20,20]." +
                            basic_options_str +
                            basic_version_str);
-    EXPECT_TRUE(ranges::equal((my_stdout | std::views::filter(!is_space)),
-                               expected | std::views::filter(!is_space)));
+    EXPECT_TRUE(ranges::equal((my_stdout | std::views::filter(!seqan3::is_space)),
+                               expected | std::views::filter(!seqan3::is_space)));
 
     // option - double value
     double double_option_value;
     const char * argv8[] = {"./argument_parser_test", "-i", "10.9"};
-    argument_parser parser8{"test_parser", 3, argv8, false};
+    seqan3::argument_parser parser8{"test_parser", 3, argv8, false};
     parser8.add_option(double_option_value, 'i', "double-option", "desc",
-                       option_spec::DEFAULT, arithmetic_range_validator{1, 20});
+                       seqan3::option_spec::DEFAULT, seqan3::arithmetic_range_validator{1, 20});
 
     testing::internal::CaptureStderr();
     EXPECT_NO_THROW(parser8.parse());
@@ -638,58 +640,58 @@ TEST(validator_test, arithmetic_range_validator_error)
 
     // option - above max
     const char * argv[] = {"./argument_parser_test", "-i", "30"};
-    argument_parser parser{"test_parser", 3, argv, false};
+    seqan3::argument_parser parser{"test_parser", 3, argv, false};
     parser.add_option(option_value, 'i', "int-option", "desc",
-                      option_spec::DEFAULT, arithmetic_range_validator{1, 20});
+                      seqan3::option_spec::DEFAULT, seqan3::arithmetic_range_validator{1, 20});
 
-    EXPECT_THROW(parser.parse(), validation_error);
+    EXPECT_THROW(parser.parse(), seqan3::validation_error);
 
     // option - below min
     const char * argv2[] = {"./argument_parser_test", "-i", "-21"};
-    argument_parser parser2{"test_parser", 3, argv2, false};
+    seqan3::argument_parser parser2{"test_parser", 3, argv2, false};
     parser2.add_option(option_value, 'i', "int-option", "desc",
-                       option_spec::DEFAULT, arithmetic_range_validator{-20, 20});
+                       seqan3::option_spec::DEFAULT, seqan3::arithmetic_range_validator{-20, 20});
 
-    EXPECT_THROW(parser2.parse(), validation_error);
+    EXPECT_THROW(parser2.parse(), seqan3::validation_error);
 
     // positional option - above max
     const char * argv3[] = {"./argument_parser_test", "30"};
-    argument_parser parser3{"test_parser", 2, argv3, false};
-    parser3.add_positional_option(option_value, "desc", arithmetic_range_validator{1, 20});
+    seqan3::argument_parser parser3{"test_parser", 2, argv3, false};
+    parser3.add_positional_option(option_value, "desc", seqan3::arithmetic_range_validator{1, 20});
 
-    EXPECT_THROW(parser3.parse(), validation_error);
+    EXPECT_THROW(parser3.parse(), seqan3::validation_error);
 
     // positional option - below min
     const char * argv4[] = {"./argument_parser_test", "--", "-21"};
-    argument_parser parser4{"test_parser", 3, argv4, false};
-    parser4.add_positional_option(option_value, "desc", arithmetic_range_validator{-20, 20});
+    seqan3::argument_parser parser4{"test_parser", 3, argv4, false};
+    parser4.add_positional_option(option_value, "desc", seqan3::arithmetic_range_validator{-20, 20});
 
-    EXPECT_THROW(parser4.parse(), validation_error);
+    EXPECT_THROW(parser4.parse(), seqan3::validation_error);
 
     // option - vector
     const char * argv5[] = {"./argument_parser_test", "-i", "-100"};
-    argument_parser parser5{"test_parser", 3, argv5, false};
+    seqan3::argument_parser parser5{"test_parser", 3, argv5, false};
     parser5.add_option(option_vector, 'i', "int-option", "desc",
-                       option_spec::DEFAULT, arithmetic_range_validator{-50, 50});
+                       seqan3::option_spec::DEFAULT, seqan3::arithmetic_range_validator{-50, 50});
 
-    EXPECT_THROW(parser5.parse(), validation_error);
+    EXPECT_THROW(parser5.parse(), seqan3::validation_error);
 
     // positional option - vector
     option_vector.clear();
     const char * argv6[] = {"./argument_parser_test", "--", "-10", "100"};
-    argument_parser parser6{"test_parser", 4, argv6, false};
-    parser6.add_positional_option(option_vector, "desc", arithmetic_range_validator{-20, 20});
+    seqan3::argument_parser parser6{"test_parser", 4, argv6, false};
+    parser6.add_positional_option(option_vector, "desc", seqan3::arithmetic_range_validator{-20, 20});
 
-    EXPECT_THROW(parser6.parse(), validation_error);
+    EXPECT_THROW(parser6.parse(), seqan3::validation_error);
 
     // option - double value
     double double_option_value;
     const char * argv7[] = {"./argument_parser_test", "-i", "0.9"};
-    argument_parser parser7{"test_parser", 3, argv7, false};
+    seqan3::argument_parser parser7{"test_parser", 3, argv7, false};
     parser7.add_option(double_option_value, 'i', "double-option", "desc",
-                       option_spec::DEFAULT, arithmetic_range_validator{1, 20});
+                       seqan3::option_spec::DEFAULT, seqan3::arithmetic_range_validator{1, 20});
 
-    EXPECT_THROW(parser7.parse(), validation_error);
+    EXPECT_THROW(parser7.parse(), seqan3::validation_error);
 }
 
 enum class foo
@@ -704,18 +706,25 @@ TEST(validator_test, value_list_validator_success)
     // type deduction
     // --------------
     // all arithmetic types are deduced to double in order to easily allow chaining of arithmetic validators
-    EXPECT_TRUE((std::same_as<value_list_validator<double>, decltype(value_list_validator{1})>));
+    EXPECT_TRUE((std::same_as<seqan3::value_list_validator<double>,
+                 decltype(seqan3::value_list_validator{1})>));
     // The same holds for a range of arithmetic types
     std::vector v{1, 2, 3};
-    EXPECT_TRUE((std::same_as<value_list_validator<double>, decltype(value_list_validator{v})>));
-    EXPECT_TRUE((std::same_as<value_list_validator<double>, decltype(value_list_validator{v | views::take(2)})>));
+    EXPECT_TRUE((std::same_as<seqan3::value_list_validator<double>,
+                 decltype(seqan3::value_list_validator{v})>));
+    EXPECT_TRUE((std::same_as<seqan3::value_list_validator<double>,
+                 decltype(seqan3::value_list_validator{v | seqan3::views::take(2)})>));
     // const char * is deduced to std::string
     std::vector v2{"ha", "ba", "ma"};
-    EXPECT_TRUE((std::same_as<value_list_validator<std::string>, decltype(value_list_validator{"ha", "ba", "ma"})>));
-    EXPECT_TRUE((std::same_as<value_list_validator<std::string>, decltype(value_list_validator{v2})>));
-    EXPECT_TRUE((std::same_as<value_list_validator<std::string>, decltype(value_list_validator{v2 | views::take(2)})>));
+    EXPECT_TRUE((std::same_as<seqan3::value_list_validator<std::string>,
+                 decltype(seqan3::value_list_validator{"ha", "ba", "ma"})>));
+    EXPECT_TRUE((std::same_as<seqan3::value_list_validator<std::string>,
+                 decltype(seqan3::value_list_validator{v2})>));
+    EXPECT_TRUE((std::same_as<seqan3::value_list_validator<std::string>,
+                 decltype(seqan3::value_list_validator{v2 | seqan3::views::take(2)})>));
     // custom types are used as is
-    EXPECT_TRUE((std::same_as<value_list_validator<foo>, decltype(value_list_validator{foo::one, foo::two})>));
+    EXPECT_TRUE((std::same_as<seqan3::value_list_validator<foo>,
+                 decltype(seqan3::value_list_validator{foo::one, foo::two})>));
 
     // usage
     // -----
@@ -727,9 +736,10 @@ TEST(validator_test, value_list_validator_success)
     // option
     std::vector<std::string> valid_str_values{"ha", "ba", "ma"};
     const char * argv[] = {"./argument_parser_test", "-s", "ba"};
-    argument_parser parser{"test_parser", 3, argv, false};
+    seqan3::argument_parser parser{"test_parser", 3, argv, false};
     parser.add_option(option_value, 's', "string-option", "desc",
-                      option_spec::DEFAULT, value_list_validator{valid_str_values | views::take(2)});
+                      seqan3::option_spec::DEFAULT,
+                      seqan3::value_list_validator{valid_str_values | seqan3::views::take(2)});
 
     testing::internal::CaptureStderr();
     EXPECT_NO_THROW(parser.parse());
@@ -738,9 +748,9 @@ TEST(validator_test, value_list_validator_success)
 
     // option with integers
     const char * argv2[] = {"./argument_parser_test", "-i", "-21"};
-    argument_parser parser2{"test_parser", 3, argv2, false};
+    seqan3::argument_parser parser2{"test_parser", 3, argv2, false};
     parser2.add_option(option_value_int, 'i', "int-option", "desc",
-                       option_spec::DEFAULT, value_list_validator<int>{0, -21, 10});
+                       seqan3::option_spec::DEFAULT, seqan3::value_list_validator<int>{0, -21, 10});
 
     testing::internal::CaptureStderr();
     EXPECT_NO_THROW(parser2.parse());
@@ -749,8 +759,8 @@ TEST(validator_test, value_list_validator_success)
 
     // positional option
     const char * argv3[] = {"./argument_parser_test", "ma"};
-    argument_parser parser3{"test_parser", 2, argv3, false};
-    parser3.add_positional_option(option_value, "desc", value_list_validator{valid_str_values});
+    seqan3::argument_parser parser3{"test_parser", 2, argv3, false};
+    parser3.add_positional_option(option_value, "desc", seqan3::value_list_validator{valid_str_values});
 
     testing::internal::CaptureStderr();
     EXPECT_NO_THROW(parser3.parse());
@@ -759,8 +769,8 @@ TEST(validator_test, value_list_validator_success)
 
     // positional option - vector
     const char * argv4[] = {"./argument_parser_test", "ha", "ma"};
-    argument_parser parser4{"test_parser", 3, argv4, false};
-    parser4.add_positional_option(option_vector, "desc", value_list_validator{"ha", "ba", "ma"});
+    seqan3::argument_parser parser4{"test_parser", 3, argv4, false};
+    parser4.add_positional_option(option_vector, "desc", seqan3::value_list_validator{"ha", "ba", "ma"});
 
     testing::internal::CaptureStderr();
     EXPECT_NO_THROW(parser4.parse());
@@ -770,9 +780,9 @@ TEST(validator_test, value_list_validator_success)
 
     // option - vector
     const char * argv5[] = {"./argument_parser_test", "-i", "-10", "-i", "48"};
-    argument_parser parser5{"test_parser", 5, argv5, false};
+    seqan3::argument_parser parser5{"test_parser", 5, argv5, false};
     parser5.add_option(option_vector_int, 'i', "int-option", "desc",
-                       option_spec::DEFAULT, value_list_validator<int>{-10, 48, 50});
+                       seqan3::option_spec::DEFAULT, seqan3::value_list_validator<int>{-10, 48, 50});
 
     testing::internal::CaptureStderr();
     EXPECT_NO_THROW(parser5.parse());
@@ -783,9 +793,9 @@ TEST(validator_test, value_list_validator_success)
     // get help page message
     option_vector_int.clear();
     const char * argv7[] = {"./argument_parser_test", "-h"};
-    argument_parser parser7{"test_parser", 2, argv7, false};
+    seqan3::argument_parser parser7{"test_parser", 2, argv7, false};
     parser7.add_option(option_vector_int, 'i', "int-option", "desc",
-                       option_spec::DEFAULT, value_list_validator<int>{-10, 48, 50});
+                       seqan3::option_spec::DEFAULT, seqan3::value_list_validator<int>{-10, 48, 50});
 
     option_vector_int.clear();
     testing::internal::CaptureStdout();
@@ -797,8 +807,8 @@ TEST(validator_test, value_list_validator_success)
                            "    -i, --int-option (List of signed 32 bit integer's)"
                            "          desc Default: []. Value must be one of [-10, 48, 50]." +
                            basic_version_str);
-    EXPECT_TRUE(ranges::equal((my_stdout | std::views::filter(!is_space)),
-                               expected | std::views::filter(!is_space)));
+    EXPECT_TRUE(ranges::equal((my_stdout | std::views::filter(!seqan3::is_space)),
+                               expected | std::views::filter(!seqan3::is_space)));
 }
 
 TEST(validator_test, value_list_validator_error)
@@ -810,48 +820,48 @@ TEST(validator_test, value_list_validator_error)
 
     // option
     const char * argv[] = {"./argument_parser_test", "-s", "sa"};
-    argument_parser parser{"test_parser", 3, argv, false};
+    seqan3::argument_parser parser{"test_parser", 3, argv, false};
     parser.add_option(option_value, 's', "string-option", "desc",
-                      option_spec::DEFAULT, value_list_validator{"ha", "ba", "ma"});
+                      seqan3::option_spec::DEFAULT, seqan3::value_list_validator{"ha", "ba", "ma"});
 
-    EXPECT_THROW(parser.parse(), validation_error);
+    EXPECT_THROW(parser.parse(), seqan3::validation_error);
 
     // positional option
     const char * argv3[] = {"./argument_parser_test", "30"};
-    argument_parser parser3{"test_parser", 2, argv3, false};
-    parser3.add_positional_option(option_value_int, "desc", value_list_validator{0, 5, 10});
+    seqan3::argument_parser parser3{"test_parser", 2, argv3, false};
+    parser3.add_positional_option(option_value_int, "desc", seqan3::value_list_validator{0, 5, 10});
 
-    EXPECT_THROW(parser3.parse(), validation_error);
+    EXPECT_THROW(parser3.parse(), seqan3::validation_error);
 
     // positional option - vector
     const char * argv4[] = {"./argument_parser_test", "fo", "ma"};
-    argument_parser parser4{"test_parser", 3, argv4, false};
+    seqan3::argument_parser parser4{"test_parser", 3, argv4, false};
     parser4.add_positional_option(option_vector, "desc",
-                                  value_list_validator{"ha", "ba", "ma"});
+                                  seqan3::value_list_validator{"ha", "ba", "ma"});
 
-    EXPECT_THROW(parser4.parse(), validation_error);
+    EXPECT_THROW(parser4.parse(), seqan3::validation_error);
 
     // option - vector
     const char * argv5[] = {"./argument_parser_test", "-i", "-10", "-i", "488"};
-    argument_parser parser5{"test_parser", 5, argv5, false};
+    seqan3::argument_parser parser5{"test_parser", 5, argv5, false};
     parser5.add_option(option_vector_int, 'i', "int-option", "desc",
-                       option_spec::DEFAULT, value_list_validator<int>{-10, 48, 50});
+                       seqan3::option_spec::DEFAULT, seqan3::value_list_validator<int>{-10, 48, 50});
 
-    EXPECT_THROW(parser5.parse(), validation_error);
+    EXPECT_THROW(parser5.parse(), seqan3::validation_error);
 }
 
 TEST(validator_test, regex_validator_success)
 {
     std::string option_value;
     std::vector<std::string> option_vector;
-    regex_validator email_validator("[a-zA-Z]+@[a-zA-Z]+\\.com");
-    regex_validator email_vector_validator("[a-zA-Z]+@[a-zA-Z]+\\.com");
+    seqan3::regex_validator email_validator("[a-zA-Z]+@[a-zA-Z]+\\.com");
+    seqan3::regex_validator email_vector_validator("[a-zA-Z]+@[a-zA-Z]+\\.com");
 
     // option
     const char * argv[] = {"./argument_parser_test", "-s", "ballo@rollo.com"};
-    argument_parser parser{"test_parser", 3, argv, false};
+    seqan3::argument_parser parser{"test_parser", 3, argv, false};
     parser.add_option(option_value, 's', "string-option", "desc",
-                      option_spec::DEFAULT, email_validator);
+                      seqan3::option_spec::DEFAULT, email_validator);
 
     testing::internal::CaptureStderr();
     EXPECT_NO_THROW(parser.parse());
@@ -860,9 +870,9 @@ TEST(validator_test, regex_validator_success)
 
     // positional option
     const char * argv2[] = {"./argument_parser_test", "chr1"};
-    argument_parser parser2{"test_parser", 2, argv2, false};
+    seqan3::argument_parser parser2{"test_parser", 2, argv2, false};
     parser2.add_positional_option(option_value, "desc",
-                                  regex_validator{"^chr[0-9]+"});
+                                  seqan3::regex_validator{"^chr[0-9]+"});
 
     testing::internal::CaptureStderr();
     EXPECT_NO_THROW(parser2.parse());
@@ -871,9 +881,9 @@ TEST(validator_test, regex_validator_success)
 
     // positional option - vector
     const char * argv3[] = {"./argument_parser_test", "rollo", "bollo", "lollo"};
-    argument_parser parser3{"test_parser", 4, argv3, false};
+    seqan3::argument_parser parser3{"test_parser", 4, argv3, false};
     parser3.add_positional_option(option_vector, "desc",
-                                  regex_validator{".*oll.*"});
+                                  seqan3::regex_validator{".*oll.*"});
 
     testing::internal::CaptureStderr();
     EXPECT_NO_THROW(parser3.parse());
@@ -885,9 +895,9 @@ TEST(validator_test, regex_validator_success)
     // option - vector
     option_vector.clear();
     const char * argv4[] = {"./argument_parser_test", "-s", "rita@rambo.com", "-s", "tina@rambo.com"};
-    argument_parser parser4{"test_parser", 5, argv4, false};
+    seqan3::argument_parser parser4{"test_parser", 5, argv4, false};
     parser4.add_option(option_vector, 's', "string-option", "desc",
-                       option_spec::DEFAULT, email_vector_validator);
+                       seqan3::option_spec::DEFAULT, email_vector_validator);
 
     testing::internal::CaptureStderr();
     EXPECT_NO_THROW(parser4.parse());
@@ -898,9 +908,9 @@ TEST(validator_test, regex_validator_success)
     // get help page message
     option_vector.clear();
     const char * argv7[] = {"./argument_parser_test", "-h"};
-    argument_parser parser7{"test_parser", 2, argv7, false};
+    seqan3::argument_parser parser7{"test_parser", 2, argv7, false};
     parser7.add_option(option_vector, 's', "string-option", "desc",
-                       option_spec::DEFAULT, email_vector_validator);
+                       seqan3::option_spec::DEFAULT, email_vector_validator);
 
     option_vector.clear();
     testing::internal::CaptureStdout();
@@ -912,8 +922,8 @@ TEST(validator_test, regex_validator_success)
                            "    -s, --string-option (List of std::string's)"
                            "          desc Default: []. Value must match the pattern '[a-zA-Z]+@[a-zA-Z]+\\.com'." +
                            basic_version_str);
-    EXPECT_TRUE(std::ranges::equal((my_stdout | std::views::filter(!is_space)),
-                                    expected  | std::views::filter(!is_space)));
+    EXPECT_TRUE(std::ranges::equal((my_stdout | std::views::filter(!seqan3::is_space)),
+                                    expected  | std::views::filter(!seqan3::is_space)));
 }
 
 TEST(validator_test, regex_validator_error)
@@ -923,46 +933,46 @@ TEST(validator_test, regex_validator_error)
 
     // option
     const char * argv[] = {"./argument_parser_test", "--string-option", "sally"};
-    argument_parser parser{"test_parser", 3, argv, false};
+    seqan3::argument_parser parser{"test_parser", 3, argv, false};
     parser.add_option(option_value, '\0', "string-option", "desc",
-                      option_spec::DEFAULT, regex_validator{"tt"});
+                      seqan3::option_spec::DEFAULT, seqan3::regex_validator{"tt"});
 
-    EXPECT_THROW(parser.parse(), validation_error);
+    EXPECT_THROW(parser.parse(), seqan3::validation_error);
 
     // positional option
     const char * argv2[] = {"./argument_parser_test", "jessy"};
-    argument_parser parser2{"test_parser", 2, argv2, false};
+    seqan3::argument_parser parser2{"test_parser", 2, argv2, false};
     parser2.add_positional_option(option_value, "desc",
-                                  regex_validator{"[0-9]"});
+                                  seqan3::regex_validator{"[0-9]"});
 
-    EXPECT_THROW(parser2.parse(), validation_error);
+    EXPECT_THROW(parser2.parse(), seqan3::validation_error);
 
     // positional option - vector
     const char * argv3[] = {"./argument_parser_test", "rollo", "bttllo", "lollo"};
-    argument_parser parser3{"test_parser", 4, argv3, false};
+    seqan3::argument_parser parser3{"test_parser", 4, argv3, false};
     parser3.add_positional_option(option_vector, "desc",
-                                  regex_validator{".*oll.*"});
+                                  seqan3::regex_validator{".*oll.*"});
 
-    EXPECT_THROW(parser3.parse(), validation_error);
+    EXPECT_THROW(parser3.parse(), seqan3::validation_error);
 
     // option - vector
     option_vector.clear();
     const char * argv4[] = {"./argument_parser_test", "-s", "gh", "-s", "tt"};
-    argument_parser parser4{"test_parser", 5, argv4, false};
+    seqan3::argument_parser parser4{"test_parser", 5, argv4, false};
     parser4.add_option(option_vector, 's', "", "desc",
-                       option_spec::DEFAULT, regex_validator{"tt"});
+                       seqan3::option_spec::DEFAULT, seqan3::regex_validator{"tt"});
 
-    EXPECT_THROW(parser4.parse(), validation_error);
+    EXPECT_THROW(parser4.parse(), seqan3::validation_error);
 }
 
 TEST(validator_test, chaining_validators)
 {
     std::string option_value{};
     std::vector<std::string> option_vector{};
-    regex_validator absolute_path_validator{"(/[^/]+)+/.*\\.[^/\\.]+$"};
-    output_file_validator my_file_ext_validator{{"sa", "so"}};
+    seqan3::regex_validator absolute_path_validator{"(/[^/]+)+/.*\\.[^/\\.]+$"};
+    seqan3::output_file_validator my_file_ext_validator{{"sa", "so"}};
 
-    test::tmp_filename tmp_name{"file.sa"};
+    seqan3::test::tmp_filename tmp_name{"file.sa"};
     std::filesystem::path invalid_extension{tmp_name.get_path()};
     invalid_extension.replace_extension(".invalid");
 
@@ -970,9 +980,9 @@ TEST(validator_test, chaining_validators)
     {
         std::string const & path = tmp_name.get_path().string();
         const char * argv[] = {"./argument_parser_test", "-s", path.c_str()};
-        argument_parser parser{"test_parser", 3, argv, false};
+        seqan3::argument_parser parser{"test_parser", 3, argv, false};
         parser.add_option(option_value, 's', "string-option", "desc",
-                          option_spec::DEFAULT, absolute_path_validator | my_file_ext_validator);
+                          seqan3::option_spec::DEFAULT, absolute_path_validator | my_file_ext_validator);
 
         testing::internal::CaptureStderr();
         EXPECT_NO_THROW(parser.parse());
@@ -983,32 +993,32 @@ TEST(validator_test, chaining_validators)
     {
         auto rel_path = tmp_name.get_path().relative_path().string();
         const char * argv[] = {"./argument_parser_test", "-s", rel_path.c_str()};
-        argument_parser parser{"test_parser", 3, argv, false};
+        seqan3::argument_parser parser{"test_parser", 3, argv, false};
         parser.add_option(option_value, 's', "string-option", "desc",
-                          option_spec::DEFAULT, absolute_path_validator | my_file_ext_validator);
+                          seqan3::option_spec::DEFAULT, absolute_path_validator | my_file_ext_validator);
 
-        EXPECT_THROW(parser.parse(), validation_error);
+        EXPECT_THROW(parser.parse(), seqan3::validation_error);
     }
 
     {
         std::string const & path = invalid_extension.string();
         const char * argv[] = {"./argument_parser_test", "-s", path.c_str()};
-        argument_parser parser{"test_parser", 3, argv, false};
+        seqan3::argument_parser parser{"test_parser", 3, argv, false};
         parser.add_option(option_value, 's', "string-option", "desc",
-                          option_spec::DEFAULT, absolute_path_validator | my_file_ext_validator);
+                          seqan3::option_spec::DEFAULT, absolute_path_validator | my_file_ext_validator);
 
-        EXPECT_THROW(parser.parse(), validation_error);
+        EXPECT_THROW(parser.parse(), seqan3::validation_error);
     }
 
     // with temporary validators
     {
         std::string const & path = tmp_name.get_path().string();
         const char * argv[] = {"./argument_parser_test", "-s", path.c_str()};
-        argument_parser parser{"test_parser", 3, argv, false};
+        seqan3::argument_parser parser{"test_parser", 3, argv, false};
         parser.add_option(option_value, 's', "string-option", "desc",
-                          option_spec::DEFAULT,
-                          regex_validator{"(/[^/]+)+/.*\\.[^/\\.]+$"} |
-                          output_file_validator{{"sa", "so"}});
+                          seqan3::option_spec::DEFAULT,
+                          seqan3::regex_validator{"(/[^/]+)+/.*\\.[^/\\.]+$"} |
+                          seqan3::output_file_validator{{"sa", "so"}});
 
         testing::internal::CaptureStderr();
         EXPECT_NO_THROW(parser.parse());
@@ -1020,12 +1030,12 @@ TEST(validator_test, chaining_validators)
     {
         std::string const & path = tmp_name.get_path().string();
         const char * argv[] = {"./argument_parser_test", "-s", path.c_str()};
-        argument_parser parser{"test_parser", 3, argv, false};
+        seqan3::argument_parser parser{"test_parser", 3, argv, false};
         parser.add_option(option_value, 's', "string-option", "desc",
-                          option_spec::DEFAULT,
-                          regex_validator{"(/[^/]+)+/.*\\.[^/\\.]+$"} |
-                          output_file_validator{{"sa", "so"}} |
-                          regex_validator{".*"});
+                          seqan3::option_spec::DEFAULT,
+                          seqan3::regex_validator{"(/[^/]+)+/.*\\.[^/\\.]+$"} |
+                          seqan3::output_file_validator{{"sa", "so"}} |
+                          seqan3::regex_validator{".*"});
 
         testing::internal::CaptureStderr();
         EXPECT_NO_THROW(parser.parse());
@@ -1036,12 +1046,12 @@ TEST(validator_test, chaining_validators)
     // help page message
     {
         const char * argv[] = {"./argument_parser_test", "-h"};
-        argument_parser parser{"test_parser", 2, argv, false};
+        seqan3::argument_parser parser{"test_parser", 2, argv, false};
         parser.add_option(option_value, 's', "string-option", "desc",
-                          option_spec::DEFAULT,
-                          regex_validator{"(/[^/]+)+/.*\\.[^/\\.]+$"} |
-                          output_file_validator{{"sa", "so"}} |
-                          regex_validator{".*"});
+                          seqan3::option_spec::DEFAULT,
+                          seqan3::regex_validator{"(/[^/]+)+/.*\\.[^/\\.]+$"} |
+                          seqan3::output_file_validator{{"sa", "so"}} |
+                          seqan3::regex_validator{".*"});
 
         testing::internal::CaptureStdout();
         option_value.clear();
@@ -1055,8 +1065,8 @@ TEST(validator_test, chaining_validators)
                                "          Valid output file formats:  [sa, so]"
                                "          Value must match the pattern '.*'."} +
                                basic_version_str;
-        EXPECT_TRUE(std::ranges::equal((my_stdout | std::views::filter(!is_space)),
-                                        expected  | std::views::filter(!is_space)));
+        EXPECT_TRUE(std::ranges::equal((my_stdout | std::views::filter(!seqan3::is_space)),
+                                        expected  | std::views::filter(!seqan3::is_space)));
     }
 
     // chaining with a container option value type
@@ -1064,10 +1074,11 @@ TEST(validator_test, chaining_validators)
         std::vector<std::string> option_list_value{};
         std::string const & path = tmp_name.get_path().string();
         const char * argv[] = {"./argument_parser_test", "-s", path.c_str()};
-        argument_parser parser{"test_parser", 3, argv, false};
+        seqan3::argument_parser parser{"test_parser", 3, argv, false};
         parser.add_option(option_list_value, 's', "string-option", "desc",
-                          option_spec::DEFAULT,
-                          regex_validator{"(/[^/]+)+/.*\\.[^/\\.]+$"} | output_file_validator{{"sa", "so"}});
+                          seqan3::option_spec::DEFAULT,
+                          seqan3::regex_validator{"(/[^/]+)+/.*\\.[^/\\.]+$"} | seqan3::output_file_validator{{"sa",
+                                                                                                               "so"}});
 
         testing::internal::CaptureStderr();
         EXPECT_NO_THROW(parser.parse());


### PR DESCRIPTION
& replace std::endl with ‘\n‘.

Resolves #1514