### PR TITLE
[MISC] Remove 'using namespace seqan3' from test/unit/contrib test/unit/search test/unit/std 

### DIFF
--- a/test/unit/contrib/parallel/buffer_queue_parallel_test.cpp
+++ b/test/unit/contrib/parallel/buffer_queue_parallel_test.cpp
@@ -15,7 +15,6 @@
 
 #include <seqan3/contrib/parallel/buffer_queue.hpp>
 
-using namespace seqan3;
 using namespace seqan3::contrib;
 using namespace seqan3::detail;
 
@@ -35,8 +34,8 @@ void test_buffer_queue_wait_status()
     if constexpr (sequential_pop_t::value)
         thread_count = writer_count + 1;
 
-    // std::cout << "threads: " << thread_count << std::endl;
-    // std::cout << "writers: " << writer_count << std::endl;
+    // std::cout << "threads: " << thread_count << ‘\n‘;
+    // std::cout << "writers: " << writer_count << ‘\n‘;
 
     constexpr size_t size_v = 10000;
     dynamic_buffer_queue<uint32_t> queue{100};
@@ -149,8 +148,8 @@ void test_buffer_queue_wait_throw(size_t initialCapacity)
     if constexpr (sequential_pop_t::value)
         thread_count = writer_count + 1;
 
-    // std::cout << "threads: " << thread_count << std::endl;
-    // std::cout << "writers: " << writer_count << std::endl;
+    // std::cout << "threads: " << thread_count << ‘\n‘;
+    // std::cout << "writers: " << writer_count << ‘\n‘;
 
     ASSERT_GE(thread_count, 2u);
 
@@ -244,7 +243,7 @@ void test_buffer_queue_wait_throw(size_t initialCapacity)
 
     // std::chrono::steady_clock::time_point stop = std::chrono::steady_clock::now();
     // double time_span = std::chrono::duration_cast<std::chrono::duration<double> >(stop - start).count();
-    // std::cout << "throughput: " << static_cast<size_t>(random.size() / time_span) << " values/s" << std::endl;
+    // std::cout << "throughput: " << static_cast<size_t>(random.size() / time_span) << " values/s\n";
 
     EXPECT_EQ(chk_sum, chk_sum2);
     EXPECT_TRUE(push_status == queue_op_status::success);

--- a/test/unit/contrib/stream/bgzf_istream_test.cpp
+++ b/test/unit/contrib/stream/bgzf_istream_test.cpp
@@ -11,8 +11,6 @@
 
 #include "../../io/stream/istream_test_template.hpp"
 
-using namespace seqan3;
-
 template <>
 class istream<contrib::bgzf_istream> : public ::testing::Test
 {

--- a/test/unit/contrib/stream/bgzf_ostream_test.cpp
+++ b/test/unit/contrib/stream/bgzf_ostream_test.cpp
@@ -11,8 +11,6 @@
 
 #include "../../io/stream/ostream_test_template.hpp"
 
-using namespace seqan3;
-
 template <>
 class ostream<contrib::bgzf_ostream> : public ::testing::Test
 {

--- a/test/unit/contrib/stream/bz2_istream_test.cpp
+++ b/test/unit/contrib/stream/bz2_istream_test.cpp
@@ -11,8 +11,6 @@
 
 #include "../../io/stream/istream_test_template.hpp"
 
-using namespace seqan3;
-
 template <>
 class istream<contrib::bz2_istream> : public ::testing::Test
 {

--- a/test/unit/contrib/stream/bz2_ostream_test.cpp
+++ b/test/unit/contrib/stream/bz2_ostream_test.cpp
@@ -11,8 +11,6 @@
 
 #include "../../io/stream/ostream_test_template.hpp"
 
-using namespace seqan3;
-
 template <>
 class ostream<contrib::bz2_ostream> : public ::testing::Test
 {

--- a/test/unit/contrib/stream/gz_istream_test.cpp
+++ b/test/unit/contrib/stream/gz_istream_test.cpp
@@ -11,8 +11,6 @@
 
 #include "../../io/stream/istream_test_template.hpp"
 
-using namespace seqan3;
-
 template <>
 class istream<contrib::gz_istream> : public ::testing::Test
 {

--- a/test/unit/contrib/stream/gz_ostream_test.cpp
+++ b/test/unit/contrib/stream/gz_ostream_test.cpp
@@ -11,8 +11,6 @@
 
 #include "../../io/stream/ostream_test_template.hpp"
 
-using namespace seqan3;
-
 template <>
 class ostream<contrib::gz_ostream> : public ::testing::Test
 {

--- a/test/unit/search/fm_index/bi_fm_index_aa27_test.cpp
+++ b/test/unit/search/fm_index/bi_fm_index_aa27_test.cpp
@@ -8,7 +8,9 @@
 #include "fm_index_collection_test_template.hpp"
 #include "fm_index_test_template.hpp"
 
-using t1 = std::pair<bi_fm_index<aa27, text_layout::single>, std::vector<aa27>>;
+using t1 = std::pair<seqan3::bi_fm_index<seqan3::aa27, seqan3::text_layout::single>,
+                     seqan3::aa27_vector>;
 INSTANTIATE_TYPED_TEST_SUITE_P(aa27, fm_index_test, t1, );
-using t2 = std::pair<bi_fm_index<aa27, text_layout::collection>, std::vector<std::vector<aa27>>>;
+using t2 = std::pair<seqan3::bi_fm_index<seqan3::aa27, seqan3::text_layout::collection>,
+                     std::vector<seqan3::aa27_vector>>;
 INSTANTIATE_TYPED_TEST_SUITE_P(aa27_collection, fm_index_collection_test, t2, );

--- a/test/unit/search/fm_index/bi_fm_index_char_test.cpp
+++ b/test/unit/search/fm_index/bi_fm_index_char_test.cpp
@@ -8,14 +8,16 @@
 #include "fm_index_collection_test_template.hpp"
 #include "fm_index_test_template.hpp"
 
-using t1 = std::pair<bi_fm_index<unsigned char, text_layout::single>, std::vector<unsigned char>>;
+using t1 = std::pair<seqan3::bi_fm_index<unsigned char, seqan3::text_layout::single>,
+                     std::vector<unsigned char>>;
 INSTANTIATE_TYPED_TEST_SUITE_P(char, fm_index_test, t1, );
-using t2 = std::pair<bi_fm_index<unsigned char, text_layout::collection>, std::vector<std::vector<unsigned char>>>;
+using t2 = std::pair<seqan3::bi_fm_index<unsigned char, seqan3::text_layout::collection>,
+                     std::vector<std::vector<unsigned char>>>;
 INSTANTIATE_TYPED_TEST_SUITE_P(char_collection, fm_index_collection_test, t2, );
 
 TEST(char, throw_on_reserved_char)
 {
-    using bi_fm_index_t = bi_fm_index<unsigned char, text_layout::single>;
+    using bi_fm_index_t = seqan3::bi_fm_index<unsigned char, seqan3::text_layout::single>;
 
     unsigned char c = 255;
     std::vector<unsigned char> text{'a', 'u', ',', c, '0'};
@@ -25,7 +27,7 @@ TEST(char, throw_on_reserved_char)
 
 TEST(char_collection, throw_on_reserved_char)
 {
-    using bi_fm_index_t = bi_fm_index<unsigned char, text_layout::collection>;
+    using bi_fm_index_t = seqan3::bi_fm_index<unsigned char, seqan3::text_layout::collection>;
 
     {
         unsigned char c = 255;

--- a/test/unit/search/fm_index/bi_fm_index_dna4_test.cpp
+++ b/test/unit/search/fm_index/bi_fm_index_dna4_test.cpp
@@ -8,7 +8,9 @@
 #include "fm_index_collection_test_template.hpp"
 #include "fm_index_test_template.hpp"
 
-using t1 = std::pair<bi_fm_index<dna4, text_layout::single>, std::vector<dna4>>;
+using t1 = std::pair<seqan3::bi_fm_index<seqan3::dna4, seqan3::text_layout::single>,
+                     seqan3::dna4_vector>;
 INSTANTIATE_TYPED_TEST_SUITE_P(dna4, fm_index_test, t1, );
-using t2 = std::pair<bi_fm_index<dna4, text_layout::collection>, std::vector<std::vector<dna4>>>;
+using t2 = std::pair<seqan3::bi_fm_index<seqan3::dna4, seqan3::text_layout::collection>,
+                     std::vector<seqan3::dna4_vector>>;
 INSTANTIATE_TYPED_TEST_SUITE_P(dna4_collection, fm_index_collection_test, t2, );

--- a/test/unit/search/fm_index/fm_index_collection_test_template.hpp
+++ b/test/unit/search/fm_index/fm_index_collection_test_template.hpp
@@ -12,8 +12,6 @@
 #include <seqan3/search/fm_index/all.hpp>
 #include <seqan3/test/cereal.hpp>
 
-using namespace seqan3;
-
 template <typename T>
 class fm_index_collection_test : public ::testing::Test
 {};
@@ -24,7 +22,7 @@ TYPED_TEST_P(fm_index_collection_test, ctr)
 {
     using index_t = typename TypeParam::first_type;
     using text_t = typename TypeParam::second_type;
-    using inner_text_type = value_type_t<text_t>;
+    using inner_text_type = seqan3::value_type_t<text_t>;
 
     text_t text{inner_text_type(10), inner_text_type(10)}; // initialized with smallest char
 
@@ -74,7 +72,7 @@ TYPED_TEST_P(fm_index_collection_test, swap)
 {
     using index_t = typename TypeParam::first_type;
     using text_t = typename TypeParam::second_type;
-    using inner_text_type = value_type_t<text_t>;
+    using inner_text_type = seqan3::value_type_t<text_t>;
 
     text_t textA{inner_text_type(10), inner_text_type(10)};
     text_t textB{inner_text_type(20), inner_text_type(20)};
@@ -107,7 +105,7 @@ TYPED_TEST_P(fm_index_collection_test, size)
 {
     using index_t = typename TypeParam::first_type;
     using text_t = typename TypeParam::second_type;
-    using inner_text_type = value_type_t<text_t>;
+    using inner_text_type = seqan3::value_type_t<text_t>;
 
     index_t fm;
     EXPECT_TRUE(fm.empty());
@@ -121,10 +119,11 @@ TYPED_TEST_P(fm_index_collection_test, concept_check)
 {
     using index_t = typename TypeParam::first_type;
 
-    EXPECT_TRUE((fm_index_specialisation<index_t>));
-    if constexpr (std::same_as<index_t, bi_fm_index<typename index_t::alphabet_type, text_layout::collection>>)
+    EXPECT_TRUE((seqan3::fm_index_specialisation<index_t>));
+    if constexpr (std::same_as<index_t, seqan3::bi_fm_index<typename index_t::alphabet_type,
+                                                            seqan3::text_layout::collection>>)
     {
-        EXPECT_TRUE(bi_fm_index_specialisation<index_t>);
+        EXPECT_TRUE(seqan3::bi_fm_index_specialisation<index_t>);
     }
 }
 
@@ -147,12 +146,12 @@ TYPED_TEST_P(fm_index_collection_test, serialisation)
 {
     using index_t = typename TypeParam::first_type;
     using text_t = typename TypeParam::second_type;
-    using inner_text_type = value_type_t<text_t>;
+    using inner_text_type = seqan3::value_type_t<text_t>;
 
     text_t text{inner_text_type(4), inner_text_type(12)};
 
     index_t fm{text};
-    test::do_serialisation(fm);
+    seqan3::test::do_serialisation(fm);
 }
 
 REGISTER_TYPED_TEST_SUITE_P(fm_index_collection_test, ctr, swap, size, serialisation, concept_check, empty_text);

--- a/test/unit/search/fm_index/fm_index_dna4_test.cpp
+++ b/test/unit/search/fm_index/fm_index_dna4_test.cpp
@@ -8,24 +8,25 @@
 #include "fm_index_collection_test_template.hpp"
 #include "fm_index_test_template.hpp"
 
-using t1 = std::pair<fm_index<dna4, text_layout::single>, std::vector<dna4>>;
+using t1 = std::pair<seqan3::fm_index<seqan3::dna4, seqan3::text_layout::single>, seqan3::dna4_vector>;
 INSTANTIATE_TYPED_TEST_SUITE_P(dna4, fm_index_test, t1, );
-using t2 = std::pair<fm_index<dna4, text_layout::collection>, std::vector<std::vector<dna4>>>;
+using t2 = std::pair<seqan3::fm_index<seqan3::dna4, seqan3::text_layout::collection>, std::vector<seqan3::dna4_vector>>;
 INSTANTIATE_TYPED_TEST_SUITE_P(dna4_collection, fm_index_collection_test, t2, );
 
 TEST(fm_index_test, additional_concepts)
 {
-    EXPECT_TRUE(detail::sdsl_index<default_sdsl_index_type>);
+    EXPECT_TRUE(seqan3::detail::sdsl_index<seqan3::default_sdsl_index_type>);
 }
 
 TEST(fm_index_test, cerealisation_errors)
 {
 #if SEQAN3_WITH_CEREAL
-    using namespace seqan3;
 
-    fm_index<dna4, text_layout::single> index{"AGTCTGATGCTGCTAC"_dna4};
+    using seqan3::operator""_dna4;
 
-    test::tmp_filename filename{"cereal_test"};
+    seqan3::fm_index<seqan3::dna4, seqan3::text_layout::single> index{"AGTCTGATGCTGCTAC"_dna4};
+
+    seqan3::test::tmp_filename filename{"cereal_test"};
 
     {
         std::ofstream os{filename.get_path(), std::ios::binary};
@@ -34,14 +35,14 @@ TEST(fm_index_test, cerealisation_errors)
     }
 
     {
-        fm_index<dna5, text_layout::single> in;
+        seqan3::fm_index<seqan3::dna5, seqan3::text_layout::single> in;
         std::ifstream is{filename.get_path(), std::ios::binary};
         cereal::BinaryInputArchive iarchive{is};
         EXPECT_THROW(iarchive(in), std::logic_error);
     }
 
     {
-        fm_index<dna4, text_layout::collection> in;
+        seqan3::fm_index<seqan3::dna4, seqan3::text_layout::collection> in;
         std::ifstream is{filename.get_path(), std::ios::binary};
         cereal::BinaryInputArchive iarchive{is};
         EXPECT_THROW(iarchive(in), std::logic_error);

--- a/test/unit/search/fm_index/fm_index_test_template.hpp
+++ b/test/unit/search/fm_index/fm_index_test_template.hpp
@@ -12,8 +12,6 @@
 #include <seqan3/search/fm_index/all.hpp>
 #include <seqan3/test/cereal.hpp>
 
-using namespace seqan3;
-
 template <typename T>
 class fm_index_test : public ::testing::Test
 {};
@@ -91,10 +89,11 @@ TYPED_TEST_P(fm_index_test, size)
 TYPED_TEST_P(fm_index_test, concept_check)
 {
     using index_t = typename TypeParam::first_type;
-    EXPECT_TRUE(fm_index_specialisation<index_t>);
-    if constexpr (std::same_as<index_t, bi_fm_index<typename index_t::alphabet_type, text_layout::single>>)
+    EXPECT_TRUE(seqan3::fm_index_specialisation<index_t>);
+    if constexpr (std::same_as<index_t, seqan3::bi_fm_index<typename index_t::alphabet_type,
+                                                            seqan3::text_layout::single>>)
     {
-        EXPECT_TRUE(bi_fm_index_specialisation<index_t>);
+        EXPECT_TRUE(seqan3::bi_fm_index_specialisation<index_t>);
     }
 }
 
@@ -115,7 +114,7 @@ TYPED_TEST_P(fm_index_test, serialisation)
     text_t text(10);
 
     index_t fm{text};
-    test::do_serialisation(fm);
+    seqan3::test::do_serialisation(fm);
 }
 
 REGISTER_TYPED_TEST_SUITE_P(fm_index_test, ctr, swap, size, concept_check, empty_text, serialisation);

--- a/test/unit/search/fm_index_cursor/bi_fm_index_cursor_collection_test.cpp
+++ b/test/unit/search/fm_index_cursor/bi_fm_index_cursor_collection_test.cpp
@@ -7,5 +7,5 @@
 
 #include "bi_fm_index_cursor_collection_test_template.hpp"
 
-using it_t1 = bi_fm_index_cursor<bi_fm_index<dna4, text_layout::collection>>;
+using it_t1 = seqan3::bi_fm_index_cursor<seqan3::bi_fm_index<seqan3::dna4, seqan3::text_layout::collection>>;
 INSTANTIATE_TYPED_TEST_SUITE_P(dna4, bi_fm_index_cursor_collection_test, it_t1, );

--- a/test/unit/search/fm_index_cursor/bi_fm_index_cursor_collection_test_template.hpp
+++ b/test/unit/search/fm_index_cursor/bi_fm_index_cursor_collection_test_template.hpp
@@ -16,7 +16,7 @@
 
 #include <gtest/gtest.h>
 
-using namespace seqan3;
+using seqan3::operator""_dna4;
 
 template <typename T>
 class bi_fm_index_cursor_collection_test : public ::testing::Test
@@ -26,96 +26,98 @@ TYPED_TEST_SUITE_P(bi_fm_index_cursor_collection_test);
 
 TYPED_TEST_P(bi_fm_index_cursor_collection_test, begin)
 {
-    std::vector<std::vector<dna4>> text{"AACGATCGGA"_dna4, "AACGATCGGA"_dna4};
-    auto rev_text = text | views::deep{std::views::reverse} | views::deep{views::persist};
+    std::vector<seqan3::dna4_vector> text{"AACGATCGGA"_dna4, "AACGATCGGA"_dna4};
+    auto rev_text = text | seqan3::views::deep{std::views::reverse} | seqan3::views::deep{seqan3::views::persist};
 
     typename TypeParam::index_type bi_fm{text};
-    bi_fm_index fm_fwd{text};
-    bi_fm_index fm_rev{rev_text};
+    seqan3::bi_fm_index fm_fwd{text};
+    seqan3::bi_fm_index fm_rev{rev_text};
 
     TypeParam bi_it = bi_fm.begin();
-    EXPECT_EQ(uniquify(bi_it.locate()), uniquify(bi_fm.fwd_begin().locate()));
-    EXPECT_EQ(uniquify(bi_it.locate()), uniquify(bi_fm.rev_begin().locate()));
+    EXPECT_EQ(seqan3::uniquify(bi_it.locate()), seqan3::uniquify(bi_fm.fwd_begin().locate()));
+    EXPECT_EQ(seqan3::uniquify(bi_it.locate()), seqan3::uniquify(bi_fm.rev_begin().locate()));
 }
 
 TYPED_TEST_P(bi_fm_index_cursor_collection_test, extend)
 {
-    std::vector<std::vector<dna4>> text{"ACGGTAGGACG"_dna4, "TGCTACGATCC"_dna4};
+    std::vector<seqan3::dna4_vector> text{"ACGGTAGGACG"_dna4, "TGCTACGATCC"_dna4};
     typename TypeParam::index_type bi_fm{text};
 
     auto it = bi_fm.begin();
     EXPECT_TRUE(it.extend_right()); // "A"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 0}, {0, 5}, {0, 8},
-                                                                                 {1, 4}, {1, 7}}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 0}, {0, 5}, {0, 8},
+                                                                                         {1, 4}, {1, 7}}));
     EXPECT_TRUE(it.extend_left()); // "GA"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 7}, {1,6}}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 7}, {1,6}}));
     EXPECT_TRUE(it.extend_right()); // "GAC"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 7}}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 7}}));
     EXPECT_TRUE(it.extend_right()); // "GACG"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 7}}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 7}}));
     EXPECT_FALSE(it.extend_right()); // "GACG"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 7}}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 7}}));
     EXPECT_TRUE(it.extend_left()); // "GGACG"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 6}}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 6}}));
 }
 
 TYPED_TEST_P(bi_fm_index_cursor_collection_test, extend_char)
 {
-    std::vector<std::vector<dna4>> text{"ACGGTAGGACG"_dna4, "TGCTACGATCC"_dna4};
+    std::vector<seqan3::dna4_vector> text{"ACGGTAGGACG"_dna4, "TGCTACGATCC"_dna4};
     typename TypeParam::index_type bi_fm{text};
 
     auto it = bi_fm.begin();
     EXPECT_TRUE(it.extend_left('G'_dna4)); // "G"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 2}, {0, 3}, {0, 6},
-                                                                                 {0, 7}, {0, 10},
-                                                                                 {1, 1}, {1, 6}}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 2}, {0, 3}, {0, 6},
+                                                                                         {0, 7}, {0, 10},
+                                                                                         {1, 1}, {1, 6}}));
     EXPECT_TRUE(it.extend_left('C'_dna4)); // "CG"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 1}, {0, 9}, {1, 5}}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 1}, {0, 9}, {1, 5}}));
     EXPECT_FALSE(it.extend_left('C'_dna4)); // "CG"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 1}, {0, 9}, {1, 5}}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 1}, {0, 9}, {1, 5}}));
     EXPECT_FALSE(it.extend_left('G'_dna4)); // "CG"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 1}, {0, 9}, {1, 5}}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 1}, {0, 9}, {1, 5}}));
     EXPECT_FALSE(it.extend_right('T'_dna4)); // "CG"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 1}, {0, 9}, {1, 5}}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 1}, {0, 9}, {1, 5}}));
     EXPECT_TRUE(it.extend_right('G'_dna4)); // "CGG"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 1}}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 1}}));
     EXPECT_TRUE(it.extend_right('T'_dna4)); // "CGGT"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 1}}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 1}}));
     EXPECT_TRUE(it.extend_right('A'_dna4)); // "CGGTA"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 1}}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 1}}));
     EXPECT_TRUE(it.extend_left('A'_dna4)); // "ACGGTA"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 0}}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 0}}));
     EXPECT_FALSE(it.extend_left('A'_dna4)); // "ACGGTA"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 0}}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 0}}));
 }
 
 TYPED_TEST_P(bi_fm_index_cursor_collection_test, extend_range)
 {
-    std::vector<std::vector<dna4>> text{"ACGGTAGGACG"_dna4, "TGCTACGATCC"_dna4};
+    std::vector<seqan3::dna4_vector> text{"ACGGTAGGACG"_dna4, "TGCTACGATCC"_dna4};
     typename TypeParam::index_type bi_fm{text};
 
     auto it = bi_fm.begin();
     EXPECT_FALSE(it.extend_left("CAG"_dna4)); // ""
     // sentinel and delimiter position included
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 0}, {0, 1}, {0, 2}, {0, 3}, {0, 4},
-                                                                                 {0, 5}, {0, 6}, {0, 7}, {0, 8}, {0, 9},
-                                                                                 {0, 10}, {0, 11},
-                                                                                 {1, 0}, {1, 1}, {1, 2}, {1, 3}, {1, 4},
-                                                                                 {1, 5}, {1, 6}, {1, 7}, {1, 8}, {1, 9},
-                                                                                 {1, 10}, {1, 11}}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 0}, {0, 1}, {0, 2}, {0, 3},
+                                                                                         {0, 4}, {0, 5}, {0, 6}, {0, 7},
+                                                                                         {0, 8}, {0, 9}, {0, 10},
+                                                                                         {0, 11},
+                                                                                         {1, 0}, {1, 1}, {1, 2}, {1, 3},
+                                                                                         {1, 4}, {1, 5}, {1, 6}, {1, 7},
+                                                                                         {1, 8}, {1, 9}, {1, 10},
+                                                                                         {1, 11}}));
     EXPECT_TRUE(it.extend_left("CG"_dna4)); // "CG"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 1}, {0, 9}, {1, 5}}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 1}, {0, 9}, {1, 5}}));
     EXPECT_TRUE(it.extend_right("GTA"_dna4)); // "CGGTA"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 1}}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 1}}));
     EXPECT_FALSE(it.extend_left("TA"_dna4)); // "CGGTA"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 1}}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 1}}));
     EXPECT_TRUE(it.extend_left("A"_dna4)); // "ACGGTA"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 0}}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 0}}));
 }
 
 TYPED_TEST_P(bi_fm_index_cursor_collection_test, extend_and_cycle)
 {
-    std::vector<std::vector<dna4>> text{"ACGGTAGGACG"_dna4, "TGCTACGATCC"_dna4};
+    std::vector<seqan3::dna4_vector> text{"ACGGTAGGACG"_dna4, "TGCTACGATCC"_dna4};
     typename TypeParam::index_type bi_fm{text};
 
     auto it = bi_fm.begin();
@@ -124,55 +126,55 @@ TYPED_TEST_P(bi_fm_index_cursor_collection_test, extend_and_cycle)
     EXPECT_DEATH(it.cycle_front(), "");
 #endif
     EXPECT_TRUE(it.extend_left()); // "GA"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 7}, {1, 6}}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 7}, {1, 6}}));
 #ifndef NDEBUG
     EXPECT_DEATH(it.cycle_back(), "");
 #endif
     EXPECT_TRUE(it.cycle_front()); // "TA"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 4}, {1, 3}}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 4}, {1, 3}}));
     EXPECT_FALSE(it.cycle_front()); // "TA"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 4}, {1, 3}}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 4}, {1, 3}}));
 }
 
 TYPED_TEST_P(bi_fm_index_cursor_collection_test, extend_range_and_cycle)
 {
-    std::vector<std::vector<dna4>> text{"ACGGTAGGACGTAG"_dna4, "TGCTACGATCC"_dna4};
+    std::vector<seqan3::dna4_vector> text{"ACGGTAGGACGTAG"_dna4, "TGCTACGATCC"_dna4};
     typename TypeParam::index_type bi_fm{text};
 
     auto it = bi_fm.begin();
     EXPECT_TRUE(it.extend_right("AC"_dna4)); // "AC"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 0}, {0, 8}, {1, 4}}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 0}, {0, 8}, {1, 4}}));
 #ifndef NDEBUG
     EXPECT_DEATH(it.cycle_front(), "");
 #endif
     EXPECT_TRUE(it.cycle_back()); // "AG"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 5}, {0, 12}}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 5}, {0, 12}}));
 #ifndef NDEBUG
     EXPECT_DEATH(it.cycle_front(), "");
 #endif
     EXPECT_FALSE(it.extend_left("TT"_dna4)); // "AG"
     EXPECT_TRUE(it.extend_left("CGT"_dna4)); // "CGTAG"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 9}}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 9}}));
 #ifndef NDEBUG
     EXPECT_DEATH(it.cycle_back(), "");
 #endif
     EXPECT_TRUE(it.cycle_front()); // "GGTAG"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 2}}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 2}}));
 }
 
 TYPED_TEST_P(bi_fm_index_cursor_collection_test, to_fwd_cursor)
 {
-    std::vector<std::vector<dna4>> text{"ACGGTAGGACGTAGC"_dna4, "TGCTACGATCC"_dna4};
+    std::vector<seqan3::dna4_vector> text{"ACGGTAGGACGTAGC"_dna4, "TGCTACGATCC"_dna4};
     typename TypeParam::index_type bi_fm{text};
 
     {
         auto it = bi_fm.begin();
         EXPECT_TRUE(it.extend_right("GTAGC"_dna4)); // "GTAGC"
-        EXPECT_EQ(uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 10}}));
+        EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 10}}));
 
         auto fwd_it = it.to_fwd_cursor();
         EXPECT_TRUE(fwd_it.cycle_back()); // "GTAGG"
-        EXPECT_EQ(uniquify(fwd_it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 3}}));
+        EXPECT_EQ(seqan3::uniquify(fwd_it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 3}}));
         EXPECT_TRUE(std::ranges::equal(fwd_it.path_label(text), "GTAGG"_dna4));
         EXPECT_FALSE(fwd_it.cycle_back());
     }
@@ -180,40 +182,39 @@ TYPED_TEST_P(bi_fm_index_cursor_collection_test, to_fwd_cursor)
     {
         auto it = bi_fm.begin();
         EXPECT_TRUE(it.extend_left("GTAG"_dna4)); // "GTAG"
-        EXPECT_EQ(uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 3}, {0, 10}}));
+        EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 3}, {0, 10}}));
 
         auto fwd_it = it.to_fwd_cursor();
     #ifndef NDEBUG
         EXPECT_DEATH(fwd_it.cycle_back(), "");
     #endif
         EXPECT_TRUE(fwd_it.extend_right());
-        EXPECT_EQ(uniquify(fwd_it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 10}}));
+        EXPECT_EQ(seqan3::uniquify(fwd_it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 10}}));
         EXPECT_TRUE(std::ranges::equal(fwd_it.path_label(text), "GTAGC"_dna4));
         EXPECT_TRUE(fwd_it.cycle_back());
-        EXPECT_EQ(uniquify(fwd_it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 3}}));
+        EXPECT_EQ(seqan3::uniquify(fwd_it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 3}}));
         EXPECT_TRUE(std::ranges::equal(fwd_it.path_label(text), "GTAGG"_dna4));
     }
 }
 
 TYPED_TEST_P(bi_fm_index_cursor_collection_test, to_rev_cursor)
 {
-    std::vector<std::vector<dna4>> text{"ACGGTAGGACGTAGC"_dna4, "TGCTACGATCC"_dna4};
-    std::vector<std::vector<dna4>> rev_text = text
-                                            | views::deep{std::views::reverse}
-                                            | std::views::reverse
-                                            | views::to<std::vector<std::vector<dna4>>>;
+    std::vector<seqan3::dna4_vector> text{"ACGGTAGGACGTAGC"_dna4, "TGCTACGATCC"_dna4};
+    std::vector<seqan3::dna4_vector> rev_text = text | seqan3::views::deep{std::views::reverse}
+                                                     | std::views::reverse
+                                                     | seqan3::views::to<std::vector<seqan3::dna4_vector>>;
     typename TypeParam::index_type bi_fm{text};
 
     {
         auto it = bi_fm.begin();
         EXPECT_TRUE(it.extend_left("CGTAG"_dna4)); // "CGTAG"
-        EXPECT_EQ(uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 9}}));
+        EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 9}}));
 
         auto rev_it = it.to_rev_cursor(); // text "CCTAGCATCGT|CGATGCAGGATGGCA"
-        EXPECT_EQ(uniquify(rev_it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{1, 1}}));
+        EXPECT_EQ(seqan3::uniquify(rev_it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{1, 1}}));
         EXPECT_TRUE(std::ranges::equal(rev_it.path_label(rev_text), "GATGC"_dna4));   //ATGCA
         EXPECT_TRUE(rev_it.cycle_back()); // "GATGG"
-        EXPECT_EQ(uniquify(rev_it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{1, 8}}));
+        EXPECT_EQ(seqan3::uniquify(rev_it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{1, 8}}));
         EXPECT_TRUE(std::ranges::equal(rev_it.path_label(rev_text), "GATGG"_dna4));
         EXPECT_FALSE(rev_it.cycle_back());
     }
@@ -221,17 +222,17 @@ TYPED_TEST_P(bi_fm_index_cursor_collection_test, to_rev_cursor)
     {
         auto it = bi_fm.begin();
         EXPECT_TRUE(it.extend_right("GTAG"_dna4)); // "GTAG"
-        EXPECT_EQ(uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 3}, {0, 10}}));
+        EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 3}, {0, 10}}));
 
         auto rev_it = it.to_rev_cursor(); // text "CCTAGCATCGT|CGATGCAGGATGGCA"
     #ifndef NDEBUG
         EXPECT_DEATH(rev_it.cycle_back(), "");
     #endif
         EXPECT_TRUE(rev_it.extend_right()); // "CGTAG" resp. "GATGC"
-        EXPECT_EQ(uniquify(rev_it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{1, 1}}));
+        EXPECT_EQ(seqan3::uniquify(rev_it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{1, 1}}));
         EXPECT_TRUE(std::ranges::equal(rev_it.path_label(rev_text), "GATGC"_dna4));
         EXPECT_TRUE(rev_it.cycle_back()); // "GGTAG" resp. "GATGG"
-        EXPECT_EQ(uniquify(rev_it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{1, 8}}));
+        EXPECT_EQ(seqan3::uniquify(rev_it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{1, 8}}));
         EXPECT_TRUE(std::ranges::equal(rev_it.path_label(rev_text), "GATGG"_dna4));
     }
 }

--- a/test/unit/search/fm_index_cursor/bi_fm_index_cursor_test.cpp
+++ b/test/unit/search/fm_index_cursor/bi_fm_index_cursor_test.cpp
@@ -7,5 +7,5 @@
 
 #include "bi_fm_index_cursor_test_template.hpp"
 
-using it_t1 = bi_fm_index_cursor<bi_fm_index<dna4, text_layout::single>>;
+using it_t1 = seqan3::bi_fm_index_cursor<seqan3::bi_fm_index<seqan3::dna4, seqan3::text_layout::single>>;
 INSTANTIATE_TYPED_TEST_SUITE_P(dna4, bi_fm_index_cursor_test, it_t1, );

--- a/test/unit/search/fm_index_cursor/bi_fm_index_cursor_test_template.hpp
+++ b/test/unit/search/fm_index_cursor/bi_fm_index_cursor_test_template.hpp
@@ -16,7 +16,7 @@
 
 #include <gtest/gtest.h>
 
-using namespace seqan3;
+using seqan3::operator""_dna4;
 
 template <typename T>
 class bi_fm_index_cursor_test : public ::testing::Test
@@ -26,89 +26,89 @@ TYPED_TEST_SUITE_P(bi_fm_index_cursor_test);
 
 TYPED_TEST_P(bi_fm_index_cursor_test, begin)
 {
-    std::vector<dna4> text{"AACGATCGGA"_dna4};
+    seqan3::dna4_vector text{"AACGATCGGA"_dna4};
     auto rev_text = std::views::reverse(text);
 
 
     typename TypeParam::index_type bi_fm{text};
-    fm_index fm_fwd{text};
-    fm_index fm_rev{rev_text};
+    seqan3::fm_index fm_fwd{text};
+    seqan3::fm_index fm_rev{rev_text};
 
     TypeParam bi_it = bi_fm.begin();
-    EXPECT_EQ(uniquify(bi_it.locate()), uniquify(bi_fm.fwd_begin().locate()));
-    EXPECT_EQ(uniquify(bi_it.locate()), uniquify(bi_fm.rev_begin().locate()));
+    EXPECT_EQ(seqan3::uniquify(bi_it.locate()), seqan3::uniquify(bi_fm.fwd_begin().locate()));
+    EXPECT_EQ(seqan3::uniquify(bi_it.locate()), seqan3::uniquify(bi_fm.rev_begin().locate()));
 }
 
 TYPED_TEST_P(bi_fm_index_cursor_test, extend)
 {
-    std::vector<dna4> text{"ACGGTAGGACG"_dna4};
+    seqan3::dna4_vector text{"ACGGTAGGACG"_dna4};
     typename TypeParam::index_type bi_fm{text};
 
     auto it = bi_fm.begin();
     EXPECT_TRUE(it.extend_right()); // "A"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{0, 5, 8}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<uint64_t>{0, 5, 8}));
     EXPECT_TRUE(it.extend_left()); // "GA"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{7}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<uint64_t>{7}));
     EXPECT_TRUE(it.extend_right()); // "GAC"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{7}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<uint64_t>{7}));
     EXPECT_TRUE(it.extend_right()); // "GACG"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{7}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<uint64_t>{7}));
     EXPECT_FALSE(it.extend_right()); // "GACG"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{7}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<uint64_t>{7}));
     EXPECT_TRUE(it.extend_left()); // "GGACG"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{6}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<uint64_t>{6}));
 }
 
 TYPED_TEST_P(bi_fm_index_cursor_test, extend_char)
 {
-    std::vector<dna4> text{"ACGGTAGGACG"_dna4};
+    seqan3::dna4_vector text{"ACGGTAGGACG"_dna4};
     typename TypeParam::index_type bi_fm{text};
 
     auto it = bi_fm.begin();
     EXPECT_TRUE(it.extend_left('G'_dna4)); // "G"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{2, 3, 6, 7, 10}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<uint64_t>{2, 3, 6, 7, 10}));
     EXPECT_TRUE(it.extend_left('C'_dna4)); // "CG"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{1, 9}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<uint64_t>{1, 9}));
     EXPECT_FALSE(it.extend_left('C'_dna4)); // "CG"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{1, 9}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<uint64_t>{1, 9}));
     EXPECT_FALSE(it.extend_left('G'_dna4)); // "CG"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{1, 9}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<uint64_t>{1, 9}));
     EXPECT_FALSE(it.extend_right('T'_dna4)); // "CG"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{1, 9}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<uint64_t>{1, 9}));
     EXPECT_TRUE(it.extend_right('G'_dna4)); // "CGG"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{1}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<uint64_t>{1}));
     EXPECT_TRUE(it.extend_right('T'_dna4)); // "CGGT"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{1}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<uint64_t>{1}));
     EXPECT_TRUE(it.extend_right('A'_dna4)); // "CGGTA"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{1}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<uint64_t>{1}));
     EXPECT_TRUE(it.extend_left('A'_dna4)); // "ACGGTA"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{0}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<uint64_t>{0}));
     EXPECT_FALSE(it.extend_left('A'_dna4)); // "ACGGTA"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{0}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<uint64_t>{0}));
 }
 
 TYPED_TEST_P(bi_fm_index_cursor_test, extend_range)
 {
-    std::vector<dna4> text{"ACGGTAGGACG"_dna4};
+    seqan3::dna4_vector text{"ACGGTAGGACG"_dna4};
     typename TypeParam::index_type bi_fm{text};
 
     auto it = bi_fm.begin();
     EXPECT_FALSE(it.extend_left("CAG"_dna4)); // ""
     // sentinel position included
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<uint64_t>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}));
     EXPECT_TRUE(it.extend_left("CG"_dna4)); // "CG"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{1, 9}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<uint64_t>{1, 9}));
     EXPECT_TRUE(it.extend_right("GTA"_dna4)); // "CGGTA"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{1}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<uint64_t>{1}));
     EXPECT_FALSE(it.extend_left("TA"_dna4)); // "CGGTA"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{1}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<uint64_t>{1}));
     EXPECT_TRUE(it.extend_left("A"_dna4)); // "ACGGTA"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{0}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<uint64_t>{0}));
 }
 
 TYPED_TEST_P(bi_fm_index_cursor_test, extend_and_cycle)
 {
-    std::vector<dna4> text{"ACGGTAGGACG"_dna4};
+    seqan3::dna4_vector text{"ACGGTAGGACG"_dna4};
     typename TypeParam::index_type bi_fm{text};
 
     auto it = bi_fm.begin();
@@ -117,55 +117,55 @@ TYPED_TEST_P(bi_fm_index_cursor_test, extend_and_cycle)
     EXPECT_DEATH(it.cycle_front(), "");
 #endif
     EXPECT_TRUE(it.extend_left()); // "GA"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{7}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<uint64_t>{7}));
 #ifndef NDEBUG
     EXPECT_DEATH(it.cycle_back(), "");
 #endif
     EXPECT_TRUE(it.cycle_front()); // "TA"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{4}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<uint64_t>{4}));
     EXPECT_FALSE(it.cycle_front()); // "TA"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{4}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<uint64_t>{4}));
 }
 
 TYPED_TEST_P(bi_fm_index_cursor_test, extend_range_and_cycle)
 {
-    std::vector<dna4> text{"ACGGTAGGACGTAG"_dna4};
+    seqan3::dna4_vector text{"ACGGTAGGACGTAG"_dna4};
     typename TypeParam::index_type bi_fm{text};
 
     auto it = bi_fm.begin();
     EXPECT_TRUE(it.extend_right("AC"_dna4)); // "AC"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{0, 8}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<uint64_t>{0, 8}));
 #ifndef NDEBUG
     EXPECT_DEATH(it.cycle_front(), "");
 #endif
     EXPECT_TRUE(it.cycle_back()); // "AG"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{5, 12}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<uint64_t>{5, 12}));
 #ifndef NDEBUG
     EXPECT_DEATH(it.cycle_front(), "");
 #endif
     EXPECT_FALSE(it.extend_left("TT"_dna4)); // "AG"
     EXPECT_TRUE(it.extend_left("CGT"_dna4)); // "CGTAG"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{9}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<uint64_t>{9}));
 #ifndef NDEBUG
     EXPECT_DEATH(it.cycle_back(), "");
 #endif
     EXPECT_TRUE(it.cycle_front()); // "GGTAG"
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{2}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<uint64_t>{2}));
 }
 
 TYPED_TEST_P(bi_fm_index_cursor_test, to_fwd_cursor)
 {
-    std::vector<dna4> text{"ACGGTAGGACGTAGC"_dna4};
+    seqan3::dna4_vector text{"ACGGTAGGACGTAGC"_dna4};
     typename TypeParam::index_type bi_fm{text};
 
     {
         auto it = bi_fm.begin();
         EXPECT_TRUE(it.extend_right("GTAGC"_dna4)); // "GTAGC"
-        EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{10}));
+        EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<uint64_t>{10}));
 
         auto fwd_it = it.to_fwd_cursor();
         EXPECT_TRUE(fwd_it.cycle_back()); // "GTAGG"
-        EXPECT_EQ(uniquify(fwd_it.locate()), (std::vector<uint64_t>{3}));
+        EXPECT_EQ(seqan3::uniquify(fwd_it.locate()), (std::vector<uint64_t>{3}));
         EXPECT_TRUE(std::ranges::equal(fwd_it.path_label(text), "GTAGG"_dna4));
         EXPECT_FALSE(fwd_it.cycle_back());
     }
@@ -173,37 +173,37 @@ TYPED_TEST_P(bi_fm_index_cursor_test, to_fwd_cursor)
     {
         auto it = bi_fm.begin();
         EXPECT_TRUE(it.extend_left("GTAG"_dna4)); // "GTAG"
-        EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{3, 10}));
+        EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<uint64_t>{3, 10}));
 
         auto fwd_it = it.to_fwd_cursor();
     #ifndef NDEBUG
         EXPECT_DEATH(fwd_it.cycle_back(), "");
     #endif
         EXPECT_TRUE(fwd_it.extend_right());
-        EXPECT_EQ(uniquify(fwd_it.locate()), (std::vector<uint64_t>{10}));
+        EXPECT_EQ(seqan3::uniquify(fwd_it.locate()), (std::vector<uint64_t>{10}));
         EXPECT_TRUE(std::ranges::equal(fwd_it.path_label(text), "GTAGC"_dna4));
         EXPECT_TRUE(fwd_it.cycle_back());
-        EXPECT_EQ(uniquify(fwd_it.locate()), (std::vector<uint64_t>{3}));
+        EXPECT_EQ(seqan3::uniquify(fwd_it.locate()), (std::vector<uint64_t>{3}));
         EXPECT_TRUE(std::ranges::equal(fwd_it.path_label(text), "GTAGG"_dna4));
     }
 }
 
 TYPED_TEST_P(bi_fm_index_cursor_test, to_rev_cursor)
 {
-    std::vector<dna4> text{"ACGGTAGGACGTAGC"_dna4};
-    std::vector<dna4> rev_text{text | std::views::reverse | views::to<std::vector<dna4>>};
+    seqan3::dna4_vector text{"ACGGTAGGACGTAGC"_dna4};
+    seqan3::dna4_vector rev_text{text | std::views::reverse | seqan3::views::to<seqan3::dna4_vector>};
     typename TypeParam::index_type bi_fm{text};
 
     {
         auto it = bi_fm.begin();
         EXPECT_TRUE(it.extend_left("CGTAG"_dna4)); // "CGTAG"
-        EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{9}));
+        EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<uint64_t>{9}));
 
         auto rev_it = it.to_rev_cursor(); // text "CGATGCAGGATGGCA"
-        EXPECT_EQ(uniquify(rev_it.locate()), (std::vector<uint64_t>{1}));
+        EXPECT_EQ(seqan3::uniquify(rev_it.locate()), (std::vector<uint64_t>{1}));
         EXPECT_TRUE(std::ranges::equal(rev_it.path_label(rev_text), "GATGC"_dna4));
         EXPECT_TRUE(rev_it.cycle_back()); // "GATGG"
-        EXPECT_EQ(uniquify(rev_it.locate()), (std::vector<uint64_t>{8}));
+        EXPECT_EQ(seqan3::uniquify(rev_it.locate()), (std::vector<uint64_t>{8}));
         EXPECT_TRUE(std::ranges::equal(rev_it.path_label(rev_text), "GATGG"_dna4));
         EXPECT_FALSE(rev_it.cycle_back());
     }
@@ -211,17 +211,17 @@ TYPED_TEST_P(bi_fm_index_cursor_test, to_rev_cursor)
     {
         auto it = bi_fm.begin();
         EXPECT_TRUE(it.extend_right("GTAG"_dna4)); // "GTAG"
-        EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{3, 10}));
+        EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<uint64_t>{3, 10}));
 
         auto rev_it = it.to_rev_cursor(); // text "CGATGCAGGATGGCA"
     #ifndef NDEBUG
         EXPECT_DEATH(rev_it.cycle_back(), "");
     #endif
         EXPECT_TRUE(rev_it.extend_right()); // "CGTAG" resp. "GATGC"
-        EXPECT_EQ(uniquify(rev_it.locate()), (std::vector<uint64_t>{1}));
+        EXPECT_EQ(seqan3::uniquify(rev_it.locate()), (std::vector<uint64_t>{1}));
         EXPECT_TRUE(std::ranges::equal(rev_it.path_label(rev_text), "GATGC"_dna4));
         EXPECT_TRUE(rev_it.cycle_back()); // "GGTAG" resp. "GATGG"
-        EXPECT_EQ(uniquify(rev_it.locate()), (std::vector<uint64_t>{8}));
+        EXPECT_EQ(seqan3::uniquify(rev_it.locate()), (std::vector<uint64_t>{8}));
         EXPECT_TRUE(std::ranges::equal(rev_it.path_label(rev_text), "GATGG"_dna4));
     }
 }

--- a/test/unit/search/fm_index_cursor/fm_index_cursor_collection_test.cpp
+++ b/test/unit/search/fm_index_cursor/fm_index_cursor_collection_test.cpp
@@ -7,14 +7,18 @@
 
 #include "fm_index_cursor_collection_test_template.hpp"
 
-using it_t1 = fm_index_cursor<fm_index<dna4, text_layout::collection>>;
+using it_t1 = seqan3::fm_index_cursor<seqan3::fm_index<seqan3::dna4, seqan3::text_layout::collection>>;
 INSTANTIATE_TYPED_TEST_SUITE_P(default_traits, fm_index_cursor_collection_test, it_t1, );
 
-using it_t2 = fm_index_cursor<fm_index<dna4, text_layout::collection, sdsl_byte_index_type>>;
+using it_t2 = seqan3::fm_index_cursor<seqan3::fm_index<seqan3::dna4,
+                                                       seqan3::text_layout::collection,
+                                                       sdsl_byte_index_type>>;
 INSTANTIATE_TYPED_TEST_SUITE_P(byte_alphabet_traits, fm_index_cursor_collection_test, it_t2, );
 
-using it_t3 = bi_fm_index_cursor<bi_fm_index<dna4, text_layout::collection>>;
+using it_t3 = seqan3::bi_fm_index_cursor<seqan3::bi_fm_index<seqan3::dna4, seqan3::text_layout::collection>>;
 INSTANTIATE_TYPED_TEST_SUITE_P(bi_default_traits, fm_index_cursor_collection_test, it_t3, );
 
-using it_t4 = bi_fm_index_cursor<bi_fm_index<dna4, text_layout::collection, sdsl_byte_index_type>>;
+using it_t4 = seqan3::bi_fm_index_cursor<seqan3::bi_fm_index<seqan3::dna4,
+                                                             seqan3::text_layout::collection,
+                                                             sdsl_byte_index_type>>;
 INSTANTIATE_TYPED_TEST_SUITE_P(bi_byte_alphabet_traits, fm_index_cursor_collection_test, it_t4, );

--- a/test/unit/search/fm_index_cursor/fm_index_cursor_collection_test_template.hpp
+++ b/test/unit/search/fm_index_cursor/fm_index_cursor_collection_test_template.hpp
@@ -15,7 +15,7 @@
 
 #include <gtest/gtest.h>
 
-using namespace seqan3;
+using seqan3::operator""_dna4;
 
 using sdsl_byte_index_type = sdsl::csa_wt<
         sdsl::wt_blcd<
@@ -39,7 +39,7 @@ TYPED_TEST_SUITE_P(fm_index_cursor_collection_test);
 
 TYPED_TEST_P(fm_index_cursor_collection_test, ctr)
 {
-    std::vector<std::vector<dna4>> text{"ACGACG"_dna4, "ACGACG"_dna4};
+    std::vector<seqan3::dna4_vector> text{"ACGACG"_dna4, "ACGACG"_dna4};
     typename TypeParam::index_type fm{text};
 
     // custom constructor
@@ -69,28 +69,29 @@ TYPED_TEST_P(fm_index_cursor_collection_test, ctr)
 
 TYPED_TEST_P(fm_index_cursor_collection_test, begin)
 {
-    std::vector<std::vector<dna4>> text{"ACGACG"_dna4, "ACGACG"_dna4};
+    std::vector<seqan3::dna4_vector> text{"ACGACG"_dna4, "ACGACG"_dna4};
     typename TypeParam::index_type fm{text};
 
     // begin
     TypeParam it(fm);
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0,0}, {0,1}, {0,2}, {0,3}, {0,4},
-                                                                                 {0,5}, {0,6}, {1,0},{1,1}, {1,2},
-                                                                                 {1,3}, {1,4}, {1,5}, {1,6}}));
-                                                                                 // one sentinel position included
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0,0}, {0,1}, {0,2}, {0,3},
+                                                                                         {0,4}, {0,5}, {0,6},
+                                                                                         {1,0},{1,1}, {1,2}, {1,3},
+                                                                                         {1,4}, {1,5}, {1,6}}));
+                                                                                       // one sentinel position included
     EXPECT_EQ(it.query_length(), 0u);
     EXPECT_EQ(it.count(), 14u);
 }
 
 TYPED_TEST_P(fm_index_cursor_collection_test, extend_right_range)
 {
-    std::vector<std::vector<dna4>> text{"ACGACG"_dna4, "TGCGATCGA"_dna4};
+    std::vector<seqan3::dna4_vector> text{"ACGACG"_dna4, "TGCGATCGA"_dna4};
     typename TypeParam::index_type fm{text};
 
     // successful extend_right(range)
     TypeParam it(fm);
     EXPECT_TRUE(it.extend_right("CG"_dna4));
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0,1}, {0,4}, {1,2}, {1,6}}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0,1}, {0,4}, {1,2}, {1,6}}));
     EXPECT_EQ(it.query_length(), 2u);
     EXPECT_EQ(it.count(), 4u);
 
@@ -112,13 +113,13 @@ TYPED_TEST_P(fm_index_cursor_collection_test, extend_right_range)
 
 TYPED_TEST_P(fm_index_cursor_collection_test, extend_right_range_empty_text)
 {
-    std::vector<std::vector<dna4>> text{"ACGACG"_dna4, ""_dna4, ""_dna4, "TGCGATCGA"_dna4};
+    std::vector<seqan3::dna4_vector> text{"ACGACG"_dna4, ""_dna4, ""_dna4, "TGCGATCGA"_dna4};
     typename TypeParam::index_type fm{text};
 
     // successful extend_right(range)
     TypeParam it(fm);
     EXPECT_TRUE(it.extend_right("CG"_dna4));
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0,1}, {0,4}, {3,2}, {3,6}}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0,1}, {0,4}, {3,2}, {3,6}}));
     EXPECT_EQ(it.query_length(), 2u);
     EXPECT_EQ(it.count(), 4u);
 
@@ -141,7 +142,7 @@ TYPED_TEST_P(fm_index_cursor_collection_test, extend_right_range_empty_text)
 // TODO: doesn't work with the current structure of typed tests
 // TYPED_TEST_P(fm_index_cursor_collection_test, extend_right_convertible_range)
 // {
-//     std::vector<std::vector<dna4>> text{"ANGACGNN"_dna5};
+//     std::vector<seqan3::dna4_vector> text{"ANGACGNN"_dna5};
 //     typename TypeParam::index_type fm{text};
 //
 //     // successful extend_right(range) using a different alphabet
@@ -153,17 +154,17 @@ TYPED_TEST_P(fm_index_cursor_collection_test, extend_right_range_empty_text)
 
 TYPED_TEST_P(fm_index_cursor_collection_test, extend_right_char)
 {
-    std::vector<std::vector<dna4>> text{"ACGACG"_dna4, "TGCGATCGA"_dna4};
+    std::vector<seqan3::dna4_vector> text{"ACGACG"_dna4, "TGCGATCGA"_dna4};
     typename TypeParam::index_type fm{text};
 
     // successful extend_right(char)
     TypeParam it(fm);
     EXPECT_TRUE(it.extend_right("A"_dna4));
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0,0}, {0,3}, {1,4}, {1,8}}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0,0}, {0,3}, {1,4}, {1,8}}));
     EXPECT_EQ(it.query_length(), 1u);
 
     EXPECT_TRUE(it.extend_right("C"_dna4));
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0,0}, {0,3}}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0,0}, {0,3}}));
     EXPECT_EQ(it.query_length(), 2u);
 
     // unsuccessful extend_right(char), it remains untouched
@@ -175,19 +176,19 @@ TYPED_TEST_P(fm_index_cursor_collection_test, extend_right_char)
 // TODO: doesn't work with the current structure of typed tests
 // TYPED_TEST_P(fm_index_cursor_collection_test, extend_right_convertible_char)
 // {
-//     std::vector<std::vector<dna4>> text{"ANGACGNN"_dna5};
+//     std::vector<seqan3::dna4_vector> text{"ANGACGNN"_dna5};
 //     typename TypeParam::index_type fm{text};
 //
 //     // successful extend_right(char) using a different alphabet
 //     TypeParam it(fm);
 //     EXPECT_TRUE(it.extend_right("A"_dna4));
-//     EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{0, 3}));
+//     EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<uint64_t>{0, 3}));
 //     EXPECT_EQ(it.query_length(), 1);
 // }
 
 TYPED_TEST_P(fm_index_cursor_collection_test, extend_right_range_and_cycle)
 {
-    std::vector<std::vector<dna4>> text{"ACGAACGC"_dna4, "TACGATCGA"_dna4};
+    std::vector<seqan3::dna4_vector> text{"ACGAACGC"_dna4, "TACGATCGA"_dna4};
     typename TypeParam::index_type fm{text};
 
     // successful extend_right() and cycle_back()
@@ -203,37 +204,39 @@ TYPED_TEST_P(fm_index_cursor_collection_test, extend_right_range_and_cycle)
 
 TYPED_TEST_P(fm_index_cursor_collection_test, extend_right_char_and_cycle)
 {
-    std::vector<std::vector<dna4>> text{"ACGAACGC"_dna4, "TGCGATCGA"_dna4};
+    std::vector<seqan3::dna4_vector> text{"ACGAACGC"_dna4, "TGCGATCGA"_dna4};
     typename TypeParam::index_type fm{text};
 
     // successful extend_right() and cycle_back()
     TypeParam it(fm);
     EXPECT_TRUE(it.extend_right("A"_dna4));
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0,0}, {0,3}, {0,4}, {1,4}, {1,8}}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0,0}, {0,3}, {0,4},
+                                                                                         {1,4}, {1,8}}));
     EXPECT_EQ(it.query_length(), 1u);
 
     EXPECT_TRUE(it.cycle_back());
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0,1}, {0,5}, {0,7}, {1,2}, {1,6}}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0,1}, {0,5}, {0,7},
+                                                                                         {1,2}, {1,6}}));
     EXPECT_EQ(it.query_length(), 1u);
 }
 
 TYPED_TEST_P(fm_index_cursor_collection_test, extend_right_and_cycle)
 {
-    std::vector<std::vector<dna4>> text{"ACGACG"_dna4, "TGCGATCGA"_dna4};
+    std::vector<seqan3::dna4_vector> text{"ACGACG"_dna4, "TGCGATCGA"_dna4};
     typename TypeParam::index_type fm{text};
 
     // successful extend_right() and cycle_back()
     TypeParam it(fm);
     EXPECT_TRUE(it.extend_right());
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0,0}, {0,3}, {1,4}, {1,8}}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0,0}, {0,3}, {1,4}, {1,8}}));
     EXPECT_EQ(it.query_length(), 1u);
 
     EXPECT_TRUE(it.cycle_back());
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0,1}, {0,4}, {1,2}, {1,6}}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0,1}, {0,4}, {1,2}, {1,6}}));
     EXPECT_EQ(it.query_length(), 1u);
 
     EXPECT_TRUE(it.extend_right());
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0,1}, {0,4}, {1,2}, {1,6}}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0,1}, {0,4}, {1,2}, {1,6}}));
     EXPECT_EQ(it.query_length(), 2u);
 
     // unsuccessful cycle_back(), it remains untouched
@@ -258,7 +261,7 @@ TYPED_TEST_P(fm_index_cursor_collection_test, extend_right_and_cycle)
 
 TYPED_TEST_P(fm_index_cursor_collection_test, query)
 {
-    std::vector<std::vector<dna4>> text{"ACGACG"_dna4, "TGCGATCGA"_dna4};
+    std::vector<seqan3::dna4_vector> text{"ACGACG"_dna4, "TGCGATCGA"_dna4};
     typename TypeParam::index_type fm{text};
 
     // query()
@@ -269,13 +272,13 @@ TYPED_TEST_P(fm_index_cursor_collection_test, query)
 
 TYPED_TEST_P(fm_index_cursor_collection_test, last_rank)
 {
-    std::vector<std::vector<dna4>> text{"ACGACG"_dna4, "TGCGATCGA"_dna4};
+    std::vector<seqan3::dna4_vector> text{"ACGACG"_dna4, "TGCGATCGA"_dna4};
     typename TypeParam::index_type fm{text};
 
     // last_rank()
     TypeParam it(fm);
     EXPECT_TRUE(it.extend_right("ACG"_dna4));
-    bool a = it.last_rank() == to_rank('G'_dna4);
+    bool a = it.last_rank() == seqan3::to_rank('G'_dna4);
     EXPECT_TRUE(a);
 }
 
@@ -283,7 +286,7 @@ TYPED_TEST_P(fm_index_cursor_collection_test, incomplete_alphabet)
 {
     // search a char that does not occur in the text (higher rank than largest char occurring in text)
     {
-        std::vector<std::vector<dna4>> text{"ACGACG"_dna4, "ACGACG"_dna4};
+        std::vector<seqan3::dna4_vector> text{"ACGACG"_dna4, "ACGACG"_dna4};
         typename TypeParam::index_type fm{text};
         TypeParam it = TypeParam(fm);
         EXPECT_FALSE(it.extend_right("T"_dna4));
@@ -292,7 +295,7 @@ TYPED_TEST_P(fm_index_cursor_collection_test, incomplete_alphabet)
 
     // search a char that does not occur in the text (smaller rank than smallest char occurring in text)
     {
-        std::vector<std::vector<dna4>> text{"CGTCGT"_dna4, "CGTCGT"_dna4};
+        std::vector<seqan3::dna4_vector> text{"CGTCGT"_dna4, "CGTCGT"_dna4};
         typename TypeParam::index_type fm{text};
         TypeParam it = TypeParam(fm);
         EXPECT_FALSE(it.extend_right("A"_dna4));
@@ -302,7 +305,7 @@ TYPED_TEST_P(fm_index_cursor_collection_test, incomplete_alphabet)
     // search a char that does not occur in the text
     // (some rank that is neither the smallest nor the highest occurring in text)
     {
-        std::vector<std::vector<dna4>> text{"ATATAT"_dna4, "ATATAT"_dna4};
+        std::vector<seqan3::dna4_vector> text{"ATATAT"_dna4, "ATATAT"_dna4};
         typename TypeParam::index_type fm{text};
         TypeParam it = TypeParam(fm);
         EXPECT_FALSE(it.extend_right("C"_dna4));
@@ -319,7 +322,7 @@ TYPED_TEST_P(fm_index_cursor_collection_test, incomplete_alphabet)
 
 TYPED_TEST_P(fm_index_cursor_collection_test, lazy_locate)
 {
-    std::vector<std::vector<dna4>> text{"ACGTACGT"_dna4, "TGCGATACGA"_dna4};
+    std::vector<seqan3::dna4_vector> text{"ACGTACGT"_dna4, "TGCGATACGA"_dna4};
     typename TypeParam::index_type fm{text};
 
     TypeParam it = TypeParam(fm);
@@ -330,7 +333,7 @@ TYPED_TEST_P(fm_index_cursor_collection_test, lazy_locate)
 
 TYPED_TEST_P(fm_index_cursor_collection_test, concept_check)
 {
-    EXPECT_TRUE(fm_index_cursor_specialisation<TypeParam>);
+    EXPECT_TRUE(seqan3::fm_index_cursor_specialisation<TypeParam>);
 }
 
 REGISTER_TYPED_TEST_SUITE_P(fm_index_cursor_collection_test, ctr, begin, extend_right_range,

--- a/test/unit/search/fm_index_cursor/fm_index_cursor_test.cpp
+++ b/test/unit/search/fm_index_cursor/fm_index_cursor_test.cpp
@@ -7,14 +7,18 @@
 
 #include "fm_index_cursor_test_template.hpp"
 
-using it_t1 = fm_index_cursor<fm_index<dna4, text_layout::single>>;
+using it_t1 = seqan3::fm_index_cursor<seqan3::fm_index<seqan3::dna4, seqan3::text_layout::single>>;
 INSTANTIATE_TYPED_TEST_SUITE_P(default_traits, fm_index_cursor_test, it_t1, );
 
-using it_t2 = fm_index_cursor<fm_index<dna4, text_layout::single, sdsl_byte_index_type>>;
+using it_t2 = seqan3::fm_index_cursor<seqan3::fm_index<seqan3::dna4,
+                                                       seqan3::text_layout::single,
+                                                       sdsl_byte_index_type>>;
 INSTANTIATE_TYPED_TEST_SUITE_P(byte_alphabet_traits, fm_index_cursor_test, it_t2, );
 
-using it_t3 = bi_fm_index_cursor<bi_fm_index<dna4, text_layout::single>>;
+using it_t3 = seqan3::bi_fm_index_cursor<seqan3::bi_fm_index<seqan3::dna4, seqan3::text_layout::single>>;
 INSTANTIATE_TYPED_TEST_SUITE_P(bi_default_traits, fm_index_cursor_test, it_t3, );
 
-using it_t4 = bi_fm_index_cursor<bi_fm_index<dna4, text_layout::single, sdsl_byte_index_type>>;
+using it_t4 = seqan3::bi_fm_index_cursor<seqan3::bi_fm_index<seqan3::dna4,
+                                                             seqan3::text_layout::single,
+                                                             sdsl_byte_index_type>>;
 INSTANTIATE_TYPED_TEST_SUITE_P(bi_byte_alphabet_traits, fm_index_cursor_test, it_t4, );

--- a/test/unit/search/fm_index_cursor/fm_index_cursor_test_template.hpp
+++ b/test/unit/search/fm_index_cursor/fm_index_cursor_test_template.hpp
@@ -15,7 +15,7 @@
 
 #include <gtest/gtest.h>
 
-using namespace seqan3;
+using seqan3::operator""_dna4;
 
 using sdsl_byte_index_type = sdsl::csa_wt<
         sdsl::wt_blcd<
@@ -39,7 +39,7 @@ TYPED_TEST_SUITE_P(fm_index_cursor_test);
 
 TYPED_TEST_P(fm_index_cursor_test, ctr)
 {
-    std::vector<dna4> text{"ACGACG"_dna4};
+    seqan3::dna4_vector text{"ACGACG"_dna4};
     typename TypeParam::index_type fm{text};
 
     // custom constructor
@@ -69,25 +69,25 @@ TYPED_TEST_P(fm_index_cursor_test, ctr)
 
 TYPED_TEST_P(fm_index_cursor_test, begin)
 {
-    std::vector<dna4> text{"ACGACG"_dna4};
+    seqan3::dna4_vector text{"ACGACG"_dna4};
     typename TypeParam::index_type fm{text};
 
     // begin
     TypeParam it(fm);
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{0, 1, 2, 3, 4, 5, 6})); // sentinel position included
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<uint64_t>{0, 1, 2, 3, 4, 5, 6}));// sentinel position included
     EXPECT_EQ(it.query_length(), 0u);
     EXPECT_EQ(it.count(), 7u);
 }
 
 TYPED_TEST_P(fm_index_cursor_test, extend_right_range)
 {
-    std::vector<dna4> text{"ACGACG"_dna4};
+    seqan3::dna4_vector text{"ACGACG"_dna4};
     typename TypeParam::index_type fm{text};
 
     // successful extend_right(range)
     TypeParam it(fm);
     EXPECT_TRUE(it.extend_right("CG"_dna4));
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{1, 4}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<uint64_t>{1, 4}));
     EXPECT_EQ(it.query_length(), 2u);
     EXPECT_EQ(it.count(), 2u);
 
@@ -110,7 +110,7 @@ TYPED_TEST_P(fm_index_cursor_test, extend_right_range)
 // TODO: doesn't work with the current structure of typed tests
 // TYPED_TEST_P(fm_index_cursor_test, extend_right_convertible_range)
 // {
-//     std::vector<dna4> text{"ANGACGNN"_dna5};
+//     seqan3::dna4_vector text{"ANGACGNN"_dna5};
 //     typename TypeParam::index_type fm{text};
 //
 //     // successful extend_right(range) using a different alphabet
@@ -122,17 +122,17 @@ TYPED_TEST_P(fm_index_cursor_test, extend_right_range)
 
 TYPED_TEST_P(fm_index_cursor_test, extend_right_char)
 {
-    std::vector<dna4> text{"ACGACG"_dna4};
+    seqan3::dna4_vector text{"ACGACG"_dna4};
     typename TypeParam::index_type fm{text};
 
     // successful extend_right(char)
     TypeParam it(fm);
     EXPECT_TRUE(it.extend_right('A'_dna4));
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{0, 3}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<uint64_t>{0, 3}));
     EXPECT_EQ(it.query_length(), 1u);
 
     EXPECT_TRUE(it.extend_right('C'_dna4));
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{0, 3}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<uint64_t>{0, 3}));
     EXPECT_EQ(it.query_length(), 2u);
 
     // unsuccessful extend_right(char), it remains untouched
@@ -144,19 +144,19 @@ TYPED_TEST_P(fm_index_cursor_test, extend_right_char)
 // TODO: doesn't work with the current structure of typed tests
 // TYPED_TEST_P(fm_index_cursor_test, extend_right_convertible_char)
 // {
-//     std::vector<dna4> text{"ANGACGNN"_dna5};
+//     seqan3::dna4_vector text{"ANGACGNN"_dna5};
 //     typename TypeParam::index_type fm{text};
 //
 //     // successful extend_right(char) using a different alphabet
 //     TypeParam it(fm);
 //     EXPECT_TRUE(it.extend_right('A'_dna4));
-//     EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{0, 3}));
+//     EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<uint64_t>{0, 3}));
 //     EXPECT_EQ(it.query_length(), 1);
 // }
 
 TYPED_TEST_P(fm_index_cursor_test, extend_right_range_and_cycle)
 {
-    std::vector<dna4> text{"ACGAACGC"_dna4};
+    seqan3::dna4_vector text{"ACGAACGC"_dna4};
     typename TypeParam::index_type fm{text};
 
     // successful extend_right() and cycle_back()
@@ -172,37 +172,37 @@ TYPED_TEST_P(fm_index_cursor_test, extend_right_range_and_cycle)
 
 TYPED_TEST_P(fm_index_cursor_test, extend_right_char_and_cycle)
 {
-    std::vector<dna4> text{"ACGAACGC"_dna4};
+    seqan3::dna4_vector text{"ACGAACGC"_dna4};
     typename TypeParam::index_type fm{text};
 
     // successful extend_right() and cycle_back()
     TypeParam it(fm);
     EXPECT_TRUE(it.extend_right('A'_dna4));
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{0, 3, 4}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<uint64_t>{0, 3, 4}));
     EXPECT_EQ(it.query_length(), 1u);
 
     EXPECT_TRUE(it.cycle_back());
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{1, 5, 7}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<uint64_t>{1, 5, 7}));
     EXPECT_EQ(it.query_length(), 1u);
 }
 
 TYPED_TEST_P(fm_index_cursor_test, extend_right_and_cycle)
 {
-    std::vector<dna4> text{"ACGACG"_dna4};
+    seqan3::dna4_vector text{"ACGACG"_dna4};
     typename TypeParam::index_type fm{text};
 
     // successful extend_right() and cycle_back()
     TypeParam it(fm);
     EXPECT_TRUE(it.extend_right());
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{0, 3}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<uint64_t>{0, 3}));
     EXPECT_EQ(it.query_length(), 1u);
 
     EXPECT_TRUE(it.cycle_back());
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{1, 4}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<uint64_t>{1, 4}));
     EXPECT_EQ(it.query_length(), 1u);
 
     EXPECT_TRUE(it.extend_right());
-    EXPECT_EQ(uniquify(it.locate()), (std::vector<uint64_t>{1, 4}));
+    EXPECT_EQ(seqan3::uniquify(it.locate()), (std::vector<uint64_t>{1, 4}));
     EXPECT_EQ(it.query_length(), 2u);
 
     // unsuccessful cycle_back(), it remains untouched
@@ -227,7 +227,7 @@ TYPED_TEST_P(fm_index_cursor_test, extend_right_and_cycle)
 
 TYPED_TEST_P(fm_index_cursor_test, query)
 {
-    std::vector<dna4> text{"ACGACG"_dna4};
+    seqan3::dna4_vector text{"ACGACG"_dna4};
     typename TypeParam::index_type fm{text};
 
     // query()
@@ -238,13 +238,13 @@ TYPED_TEST_P(fm_index_cursor_test, query)
 
 TYPED_TEST_P(fm_index_cursor_test, last_rank)
 {
-    std::vector<dna4> text{"ACGACG"_dna4};
+    seqan3::dna4_vector text{"ACGACG"_dna4};
     typename TypeParam::index_type fm{text};
 
     // last_rank()
     TypeParam it(fm);
     EXPECT_TRUE(it.extend_right("ACG"_dna4));
-    bool a = it.last_rank() == to_rank('G'_dna4);
+    bool a = it.last_rank() == seqan3::to_rank('G'_dna4);
     EXPECT_TRUE(a);
 }
 
@@ -252,7 +252,7 @@ TYPED_TEST_P(fm_index_cursor_test, incomplete_alphabet)
 {
     // search a char that does not occur in the text (higher rank than largest char occurring in text)
     {
-        std::vector<dna4> text{"ACGACG"_dna4};
+        seqan3::dna4_vector text{"ACGACG"_dna4};
         typename TypeParam::index_type fm{text};
         TypeParam it = TypeParam(fm);
         EXPECT_FALSE(it.extend_right('T'_dna4));
@@ -261,7 +261,7 @@ TYPED_TEST_P(fm_index_cursor_test, incomplete_alphabet)
 
     // search a char that does not occur in the text (smaller rank than smallest char occurring in text)
     {
-        std::vector<dna4> text{"CGTCGT"_dna4};
+        seqan3::dna4_vector text{"CGTCGT"_dna4};
         typename TypeParam::index_type fm{text};
         TypeParam it = TypeParam(fm);
         EXPECT_FALSE(it.extend_right('A'_dna4));
@@ -271,7 +271,7 @@ TYPED_TEST_P(fm_index_cursor_test, incomplete_alphabet)
     // search a char that does not occur in the text
     // (some rank that is neither the smallest nor the highest occurring in text)
     {
-        std::vector<dna4> text{"ATATAT"_dna4};
+        seqan3::dna4_vector text{"ATATAT"_dna4};
         typename TypeParam::index_type fm{text};
         TypeParam it = TypeParam(fm);
         EXPECT_FALSE(it.extend_right('C'_dna4));
@@ -288,7 +288,7 @@ TYPED_TEST_P(fm_index_cursor_test, incomplete_alphabet)
 
 TYPED_TEST_P(fm_index_cursor_test, lazy_locate)
 {
-    std::vector<dna4> text{"ACGTACGT"_dna4};
+    seqan3::dna4_vector text{"ACGTACGT"_dna4};
     typename TypeParam::index_type fm{text};
 
     TypeParam it = TypeParam(fm);
@@ -299,7 +299,7 @@ TYPED_TEST_P(fm_index_cursor_test, lazy_locate)
 
 TYPED_TEST_P(fm_index_cursor_test, concept_check)
 {
-    EXPECT_TRUE(fm_index_cursor_specialisation<TypeParam>);
+    EXPECT_TRUE(seqan3::fm_index_cursor_specialisation<TypeParam>);
 }
 
 REGISTER_TYPED_TEST_SUITE_P(fm_index_cursor_test, ctr, begin, extend_right_range, extend_right_char,

--- a/test/unit/search/helper.hpp
+++ b/test/unit/search/helper.hpp
@@ -45,7 +45,7 @@ std::vector<std::vector<std::pair<T1, T2>>> uniquify(std::vector<std::vector<std
     return v;
 }
 
-void random_text(std::vector<dna4> & text, uint64_t const length)
+void random_text(seqan3::dna4_vector & text, uint64_t const length)
 {
     uint8_t alphabet_size{4};
 

--- a/test/unit/search/kmer_index/shape_test.cpp
+++ b/test/unit/search/kmer_index/shape_test.cpp
@@ -12,29 +12,29 @@
 #include <seqan3/std/algorithm>
 #include <seqan3/std/ranges>
 
-using namespace seqan3;
+using seqan3::operator""_shape;
 
 constexpr bool construction_test()
 {
     bool res{true};
 
-    shape s1{bin_literal{0b1011}};
+    seqan3::shape s1{seqan3::bin_literal{0b1011}};
     res &= std::ranges::size(s1) == 4;
     res &= s1.all() == false;
 
-    shape s2{0b1011_shape};
+    seqan3::shape s2{0b1011_shape};
     res &= std::ranges::size(s2) == 4;
     res &= s2.all() == false;
 
-    shape s3{ungapped{3}};
+    seqan3::shape s3{seqan3::ungapped{3}};
     res &= std::ranges::size(s3) == 3;
     res &= s3.all() == true;
 
-    shape s4{bin_literal{0b1111}};
+    seqan3::shape s4{seqan3::bin_literal{0b1111}};
     res &= std::ranges::size(s4) == 4;
     res &= s4.all() == true;
 
-    shape s5{0b1111_shape};
+    seqan3::shape s5{0b1111_shape};
     res &= std::ranges::size(s5) == 4;
     res &= s5.all() == true;
 
@@ -43,20 +43,20 @@ constexpr bool construction_test()
 
 TEST(shape, ctr)
 {
-    EXPECT_TRUE((std::is_default_constructible_v<shape>));
-    EXPECT_TRUE((std::is_nothrow_default_constructible_v<shape>));
-    EXPECT_TRUE((std::is_copy_constructible_v<shape>));
-    EXPECT_TRUE((std::is_trivially_copy_constructible_v<shape>));
-    EXPECT_TRUE((std::is_nothrow_copy_constructible_v<shape>));
-    EXPECT_TRUE((std::is_move_constructible_v<shape>));
-    EXPECT_TRUE((std::is_trivially_move_constructible_v<shape>));
-    EXPECT_TRUE((std::is_nothrow_move_constructible_v<shape>));
-    EXPECT_TRUE((std::is_copy_assignable_v<shape>));
-    EXPECT_TRUE((std::is_trivially_copy_assignable_v<shape>));
-    EXPECT_TRUE((std::is_nothrow_copy_assignable_v<shape>));
-    EXPECT_TRUE((std::is_move_assignable_v<shape>));
-    EXPECT_TRUE((std::is_trivially_move_assignable_v<shape>));
-    EXPECT_TRUE((std::is_nothrow_move_assignable_v<shape>));
+    EXPECT_TRUE((std::is_default_constructible_v<seqan3::shape>));
+    EXPECT_TRUE((std::is_nothrow_default_constructible_v<seqan3::shape>));
+    EXPECT_TRUE((std::is_copy_constructible_v<seqan3::shape>));
+    EXPECT_TRUE((std::is_trivially_copy_constructible_v<seqan3::shape>));
+    EXPECT_TRUE((std::is_nothrow_copy_constructible_v<seqan3::shape>));
+    EXPECT_TRUE((std::is_move_constructible_v<seqan3::shape>));
+    EXPECT_TRUE((std::is_trivially_move_constructible_v<seqan3::shape>));
+    EXPECT_TRUE((std::is_nothrow_move_constructible_v<seqan3::shape>));
+    EXPECT_TRUE((std::is_copy_assignable_v<seqan3::shape>));
+    EXPECT_TRUE((std::is_trivially_copy_assignable_v<seqan3::shape>));
+    EXPECT_TRUE((std::is_nothrow_copy_assignable_v<seqan3::shape>));
+    EXPECT_TRUE((std::is_move_assignable_v<seqan3::shape>));
+    EXPECT_TRUE((std::is_trivially_move_assignable_v<seqan3::shape>));
+    EXPECT_TRUE((std::is_nothrow_move_assignable_v<seqan3::shape>));
 
     constexpr bool constexpr_ctr = construction_test();
     EXPECT_TRUE(constexpr_ctr);
@@ -67,8 +67,8 @@ TEST(shape, ctr)
 constexpr bool size_test()
 {
     bool res{true};
-    res = res && (std::ranges::size(shape{ungapped{1}}) == 1u);
-    res = res && (std::ranges::size(shape{ungapped{30}}) == 30u);
+    res = res && (std::ranges::size(seqan3::shape{seqan3::ungapped{1}}) == 1u);
+    res = res && (std::ranges::size(seqan3::shape{seqan3::ungapped{30}}) == 30u);
     res = res && (std::ranges::size(0b11_shape) == 2u);
     res = res && (std::ranges::size(0b10101_shape) == 5u);
 

--- a/test/unit/search/search_collection_test.cpp
+++ b/test/unit/search/search_collection_test.cpp
@@ -14,7 +14,9 @@
 
 #include "helper.hpp"
 
-using namespace seqan3;
+using seqan3::operator""_dna4;
+using seqan3::operator""_phred42;
+
 using namespace seqan3::search_cfg;
 using namespace std::string_literals;
 
@@ -22,7 +24,7 @@ template <typename T>
 class search_test : public ::testing::Test
 {
 public:
-    std::vector<std::vector<dna4>> text{"ACGTACGTACGT"_dna4, "ACGTACGTACGT"_dna4};
+    std::vector<seqan3::dna4_vector> text{"ACGTACGTACGT"_dna4, "ACGTACGTACGT"_dna4};
     T index{text};
 };
 
@@ -34,10 +36,10 @@ public:
     T index{text};
 };
 
-using fm_index_types        = ::testing::Types<fm_index<dna4, text_layout::collection>,
-                                               bi_fm_index<dna4, text_layout::collection>>;
-using fm_index_string_types = ::testing::Types<fm_index<char, text_layout::collection>,
-                                               bi_fm_index<char, text_layout::collection>>;
+using fm_index_types        = ::testing::Types<seqan3::fm_index<seqan3::dna4, seqan3::text_layout::collection>,
+                                               seqan3::bi_fm_index<seqan3::dna4, seqan3::text_layout::collection>>;
+using fm_index_string_types = ::testing::Types<seqan3::fm_index<char, seqan3::text_layout::collection>,
+                                               seqan3::bi_fm_index<char, seqan3::text_layout::collection>>;
 
 TYPED_TEST_SUITE(search_test, fm_index_types, );
 TYPED_TEST_SUITE(search_string_test, fm_index_string_types, );
@@ -49,65 +51,65 @@ TYPED_TEST(search_test, error_free)
 
     {
         // successful and unsuccesful exact search without cfg
-        EXPECT_EQ(uniquify(search("ACGT"_dna4, this->index)), (hits_result_t{{0, 0}, {0, 4}, {0, 8},
-                                                                             {1, 0}, {1, 4}, {1, 8}}));
-        EXPECT_EQ(uniquify(search("ACGG"_dna4, this->index)), (hits_result_t{}));
+        EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4, this->index)), (hits_result_t{{0, 0}, {0, 4}, {0, 8},
+                                                                                     {1, 0}, {1, 4}, {1, 8}}));
+        EXPECT_EQ(seqan3::uniquify(search("ACGG"_dna4, this->index)), (hits_result_t{}));
     }
 
     {
         // successful and unsuccesful exact search with empty cfg
-        configuration const cfg;
-        EXPECT_EQ(uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{{0, 0}, {0, 4}, {0, 8},
-                                                                                  {1, 0}, {1, 4}, {1, 8}}));
-        EXPECT_EQ(uniquify(search("ACGG"_dna4, this->index, cfg)), (hits_result_t{}));
+        seqan3::configuration const cfg;
+        EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{{0, 0}, {0, 4}, {0, 8},
+                                                                                          {1, 0}, {1, 4}, {1, 8}}));
+        EXPECT_EQ(seqan3::uniquify(search("ACGG"_dna4, this->index, cfg)), (hits_result_t{}));
     }
 
     {
         // successful and unsuccesful exact search using empty max_total_error
-        configuration const cfg = max_error{};
-        EXPECT_EQ(uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{{0, 0}, {0, 4}, {0, 8},
-                                                                                  {1, 0}, {1, 4}, {1, 8}}));
-        EXPECT_EQ(uniquify(search("ACGG"_dna4, this->index, cfg)), (hits_result_t{}));
+        seqan3::configuration const cfg = max_error{};
+        EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{{0, 0}, {0, 4}, {0, 8},
+                                                                                          {1, 0}, {1, 4}, {1, 8}}));
+        EXPECT_EQ(seqan3::uniquify(search("ACGG"_dna4, this->index, cfg)), (hits_result_t{}));
     }
 
     {
         // successful and unsuccesful exact search using short version of max_total_error
-        configuration const cfg = max_error{total{0}};
-        EXPECT_EQ(uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{{0, 0}, {0, 4}, {0, 8},
-                                                                                  {1, 0}, {1, 4}, {1, 8}}));
-        EXPECT_EQ(uniquify(search("ACGG"_dna4, this->index, cfg)), (hits_result_t{}));
+        seqan3::configuration const cfg = max_error{total{0}};
+        EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{{0, 0}, {0, 4}, {0, 8},
+                                                                                          {1, 0}, {1, 4}, {1, 8}}));
+        EXPECT_EQ(seqan3::uniquify(search("ACGG"_dna4, this->index, cfg)), (hits_result_t{}));
     }
 
     {
         // successful and unsuccesful exact search using max_total_error
-        configuration const cfg = max_error{total{0}, substitution{0}, insertion{0}, deletion{0}};
-        EXPECT_EQ(uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{{0, 0}, {0, 4}, {0, 8},
-                                                                                  {1, 0}, {1, 4}, {1, 8}}));
-        EXPECT_EQ(uniquify(search("ACGG"_dna4, this->index, cfg)), (hits_result_t{}));
+        seqan3::configuration const cfg = max_error{total{0}, substitution{0}, insertion{0}, deletion{0}};
+        EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{{0, 0}, {0, 4}, {0, 8},
+                                                                                          {1, 0}, {1, 4}, {1, 8}}));
+        EXPECT_EQ(seqan3::uniquify(search("ACGG"_dna4, this->index, cfg)), (hits_result_t{}));
     }
 
     {
         // successful and unsuccesful exact search using empty max_total_error_rate
-        configuration const cfg = max_error_rate{};
-        EXPECT_EQ(uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{{0, 0}, {0, 4}, {0, 8},
-                                                                                  {1, 0}, {1, 4}, {1, 8}}));
-        EXPECT_EQ(uniquify(search("ACGG"_dna4, this->index, cfg)), (hits_result_t{}));
+        seqan3::configuration const cfg = max_error_rate{};
+        EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{{0, 0}, {0, 4}, {0, 8},
+                                                                                          {1, 0}, {1, 4}, {1, 8}}));
+        EXPECT_EQ(seqan3::uniquify(search("ACGG"_dna4, this->index, cfg)), (hits_result_t{}));
     }
 
     {
         // successful and unsuccesful exact search using short version of max_total_error_rate
-        configuration const cfg = max_error_rate{total{.0}};
-        EXPECT_EQ(uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{{0, 0}, {0, 4}, {0, 8},
-                                                                                  {1, 0}, {1, 4}, {1, 8}}));
-        EXPECT_EQ(uniquify(search("ACGG"_dna4, this->index, cfg)), (hits_result_t{}));
+        seqan3::configuration const cfg = max_error_rate{total{.0}};
+        EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{{0, 0}, {0, 4}, {0, 8},
+                                                                                          {1, 0}, {1, 4}, {1, 8}}));
+        EXPECT_EQ(seqan3::uniquify(search("ACGG"_dna4, this->index, cfg)), (hits_result_t{}));
     }
 
     {
         // successful and unsuccesful exact search using max_total_error_rate
-        configuration const cfg = max_error_rate{total{.0}, substitution{.0}, insertion{.0}, deletion{.0}};
-        EXPECT_EQ(uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{{0, 0}, {0, 4}, {0, 8},
-                                                                                  {1, 0}, {1, 4}, {1, 8}}));
-        EXPECT_EQ(uniquify(search("ACGG"_dna4, this->index, cfg)), (hits_result_t{}));
+        seqan3::configuration const cfg = max_error_rate{total{.0}, substitution{.0}, insertion{.0}, deletion{.0}};
+        EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{{0, 0}, {0, 4}, {0, 8},
+                                                                                          {1, 0}, {1, 4}, {1, 8}}));
+        EXPECT_EQ(seqan3::uniquify(search("ACGG"_dna4, this->index, cfg)), (hits_result_t{}));
     }
 }
 
@@ -115,12 +117,13 @@ TYPED_TEST(search_test, convertible_query)
 {
     using result_t = std::pair<typename TypeParam::size_type, typename TypeParam::size_type>;
     using hits_result_t = std::vector<result_t>;
-    std::vector<qualified<dna4, phred42>> query{{'A'_dna4, '!'_phred42},
-                                                {'C'_dna4, '!'_phred42},
-                                                {'G'_dna4, '!'_phred42},
-                                                {'T'_dna4, '!'_phred42}};
+    std::vector<seqan3::qualified<seqan3::dna4, seqan3::phred42>> query{{'A'_dna4, '!'_phred42},
+                                                                        {'C'_dna4, '!'_phred42},
+                                                                        {'G'_dna4, '!'_phred42},
+                                                                        {'T'_dna4, '!'_phred42}};
 
-    EXPECT_EQ(uniquify(search(query, this->index)), (hits_result_t{{0, 0}, {0, 4}, {0, 8}, {1, 0}, {1, 4}, {1, 8}}));
+    EXPECT_EQ(seqan3::uniquify(search(query, this->index)), (hits_result_t{{0, 0}, {0, 4}, {0, 8},
+                                                                           {1, 0}, {1, 4}, {1, 8}}));
 }
 
 TYPED_TEST(search_test, single_element_collection)
@@ -128,23 +131,23 @@ TYPED_TEST(search_test, single_element_collection)
     using result_t = std::pair<typename TypeParam::size_type, typename TypeParam::size_type>;
     using hits_result_t = std::vector<result_t>;
 
-    std::vector<std::vector<dna4>> text{"ACGATACG"_dna4};
+    std::vector<seqan3::dna4_vector> text{"ACGATACG"_dna4};
     TypeParam index{text};
 
-    configuration const cfg = max_error{total{1}, substitution{1}, insertion{0}, deletion{0}};
-    EXPECT_EQ(uniquify(search("ACGACACG"_dna4, index, cfg)), (hits_result_t{{0, 0}}));
+    seqan3::configuration const cfg = max_error{total{1}, substitution{1}, insertion{0}, deletion{0}};
+    EXPECT_EQ(seqan3::uniquify(search("ACGACACG"_dna4, index, cfg)), (hits_result_t{{0, 0}}));
 }
 
 TYPED_TEST(search_test, multiple_queries)
 {
     using result_t = std::vector<std::pair<typename TypeParam::size_type, typename TypeParam::size_type>>;
     using hits_result_t = std::vector<result_t>;
-    std::vector<std::vector<dna4>> const queries{{"GG"_dna4, "ACGTACGTACGT"_dna4, "ACGTA"_dna4}};
+    std::vector<seqan3::dna4_vector> const queries{{"GG"_dna4, "ACGTACGTACGT"_dna4, "ACGTA"_dna4}};
 
-    configuration const cfg = max_error_rate{total{.0}, substitution{.0}, insertion{.0}, deletion{.0}};
-    EXPECT_EQ(uniquify(search(queries, this->index, cfg)), (hits_result_t{{},
-                                                                          {{0, 0}, {1, 0}},
-                                                                          {{0, 0}, {0, 4}, {1, 0}, {1, 4}}}));
+    seqan3::configuration const cfg = max_error_rate{total{.0}, substitution{.0}, insertion{.0}, deletion{.0}};
+    EXPECT_EQ(seqan3::uniquify(search(queries, this->index, cfg)), (hits_result_t{{},
+                                                                                  {{0, 0}, {1, 0}},
+                                                                                  {{0, 0}, {0, 4}, {1, 0}, {1, 4}}}));
 }
 
 TYPED_TEST(search_string_test, error_free_string)
@@ -154,8 +157,8 @@ TYPED_TEST(search_string_test, error_free_string)
 
     {
         // successful and unsuccesful exact search without cfg
-        EXPECT_EQ(uniquify(search("at"s, this->index)), (hits_result_t{{0, 14}, {0, 18}, {1, 17}}));
-        EXPECT_EQ(uniquify(search("Jon"s, this->index)), (hits_result_t{}));
+        EXPECT_EQ(seqan3::uniquify(search("at"s, this->index)), (hits_result_t{{0, 14}, {0, 18}, {1, 17}}));
+        EXPECT_EQ(seqan3::uniquify(search("Jon"s, this->index)), (hits_result_t{}));
     }
 }
 
@@ -166,8 +169,8 @@ TYPED_TEST(search_string_test, error_free_raw)
 
     {
         // successful and unsuccesful exact search without cfg
-        EXPECT_EQ(uniquify(search("at", this->index)), (hits_result_t{{0, 14}, {0, 18}, {1, 17}}));
-        EXPECT_EQ(uniquify(search("Jon", this->index)), (hits_result_t{}));
+        EXPECT_EQ(seqan3::uniquify(search("at", this->index)), (hits_result_t{{0, 14}, {0, 18}, {1, 17}}));
+        EXPECT_EQ(seqan3::uniquify(search("Jon", this->index)), (hits_result_t{}));
     }
 }
 
@@ -178,8 +181,8 @@ TYPED_TEST(search_string_test, multiple_queries_string)
 
     std::vector<std::string> const queries{"at", "Jon"};
 
-    EXPECT_EQ(uniquify(search(queries, this->index)), (hits_result_t{{{0, 14}, {0, 18}, {1, 17}},
-                                                                     {}})); // 3 and 0 hits
+    EXPECT_EQ(seqan3::uniquify(search(queries, this->index)), (hits_result_t{{{0, 14}, {0, 18}, {1, 17}},
+                                                                             {}})); // 3 and 0 hits
 }
 
 TYPED_TEST(search_string_test, multiple_queries_raw)
@@ -187,6 +190,6 @@ TYPED_TEST(search_string_test, multiple_queries_raw)
     using result_t = std::vector<std::pair<typename TypeParam::size_type, typename TypeParam::size_type>>;
     using hits_result_t = std::vector<result_t>;
 
-    EXPECT_EQ(uniquify(search({"at", "Jon"}, this->index)), (hits_result_t{{{0, 14}, {0, 18}, {1, 17}},
-                                                                           {}})); // 3 and 0 hits
+    EXPECT_EQ(seqan3::uniquify(search({"at", "Jon"}, this->index)), (hits_result_t{{{0, 14}, {0, 18}, {1, 17}},
+                                                                                   {}})); // 3 and 0 hits
 }

--- a/test/unit/search/search_collection_test.cpp
+++ b/test/unit/search/search_collection_test.cpp
@@ -17,7 +17,6 @@
 using seqan3::operator""_dna4;
 using seqan3::operator""_phred42;
 
-using namespace seqan3::search_cfg;
 using namespace std::string_literals;
 
 template <typename T>
@@ -66,7 +65,7 @@ TYPED_TEST(search_test, error_free)
 
     {
         // successful and unsuccesful exact search using empty max_total_error
-        seqan3::configuration const cfg = max_error{};
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error{};
         EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{{0, 0}, {0, 4}, {0, 8},
                                                                                           {1, 0}, {1, 4}, {1, 8}}));
         EXPECT_EQ(seqan3::uniquify(search("ACGG"_dna4, this->index, cfg)), (hits_result_t{}));
@@ -74,7 +73,7 @@ TYPED_TEST(search_test, error_free)
 
     {
         // successful and unsuccesful exact search using short version of max_total_error
-        seqan3::configuration const cfg = max_error{total{0}};
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::total{0}};
         EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{{0, 0}, {0, 4}, {0, 8},
                                                                                           {1, 0}, {1, 4}, {1, 8}}));
         EXPECT_EQ(seqan3::uniquify(search("ACGG"_dna4, this->index, cfg)), (hits_result_t{}));
@@ -82,7 +81,10 @@ TYPED_TEST(search_test, error_free)
 
     {
         // successful and unsuccesful exact search using max_total_error
-        seqan3::configuration const cfg = max_error{total{0}, substitution{0}, insertion{0}, deletion{0}};
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::total{0},
+                                                                        seqan3::search_cfg::substitution{0},
+                                                                        seqan3::search_cfg::insertion{0},
+                                                                        seqan3::search_cfg::deletion{0}};
         EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{{0, 0}, {0, 4}, {0, 8},
                                                                                           {1, 0}, {1, 4}, {1, 8}}));
         EXPECT_EQ(seqan3::uniquify(search("ACGG"_dna4, this->index, cfg)), (hits_result_t{}));
@@ -90,7 +92,7 @@ TYPED_TEST(search_test, error_free)
 
     {
         // successful and unsuccesful exact search using empty max_total_error_rate
-        seqan3::configuration const cfg = max_error_rate{};
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error_rate{};
         EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{{0, 0}, {0, 4}, {0, 8},
                                                                                           {1, 0}, {1, 4}, {1, 8}}));
         EXPECT_EQ(seqan3::uniquify(search("ACGG"_dna4, this->index, cfg)), (hits_result_t{}));
@@ -98,7 +100,7 @@ TYPED_TEST(search_test, error_free)
 
     {
         // successful and unsuccesful exact search using short version of max_total_error_rate
-        seqan3::configuration const cfg = max_error_rate{total{.0}};
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error_rate{seqan3::search_cfg::total{.0}};
         EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{{0, 0}, {0, 4}, {0, 8},
                                                                                           {1, 0}, {1, 4}, {1, 8}}));
         EXPECT_EQ(seqan3::uniquify(search("ACGG"_dna4, this->index, cfg)), (hits_result_t{}));
@@ -106,7 +108,10 @@ TYPED_TEST(search_test, error_free)
 
     {
         // successful and unsuccesful exact search using max_total_error_rate
-        seqan3::configuration const cfg = max_error_rate{total{.0}, substitution{.0}, insertion{.0}, deletion{.0}};
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error_rate{seqan3::search_cfg::total{.0},
+                                                                            seqan3::search_cfg::substitution{.0},
+                                                                            seqan3::search_cfg::insertion{.0},
+                                                                            seqan3::search_cfg::deletion{.0}};
         EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{{0, 0}, {0, 4}, {0, 8},
                                                                                           {1, 0}, {1, 4}, {1, 8}}));
         EXPECT_EQ(seqan3::uniquify(search("ACGG"_dna4, this->index, cfg)), (hits_result_t{}));
@@ -134,7 +139,10 @@ TYPED_TEST(search_test, single_element_collection)
     std::vector<seqan3::dna4_vector> text{"ACGATACG"_dna4};
     TypeParam index{text};
 
-    seqan3::configuration const cfg = max_error{total{1}, substitution{1}, insertion{0}, deletion{0}};
+    seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::total{1},
+                                                                    seqan3::search_cfg::substitution{1},
+                                                                    seqan3::search_cfg::insertion{0},
+                                                                    seqan3::search_cfg::deletion{0}};
     EXPECT_EQ(seqan3::uniquify(search("ACGACACG"_dna4, index, cfg)), (hits_result_t{{0, 0}}));
 }
 
@@ -144,7 +152,10 @@ TYPED_TEST(search_test, multiple_queries)
     using hits_result_t = std::vector<result_t>;
     std::vector<seqan3::dna4_vector> const queries{{"GG"_dna4, "ACGTACGTACGT"_dna4, "ACGTA"_dna4}};
 
-    seqan3::configuration const cfg = max_error_rate{total{.0}, substitution{.0}, insertion{.0}, deletion{.0}};
+    seqan3::configuration const cfg = seqan3::search_cfg::max_error_rate{seqan3::search_cfg::total{.0},
+                                                                         seqan3::search_cfg::substitution{.0},
+                                                                         seqan3::search_cfg::insertion{.0},
+                                                                         seqan3::search_cfg::deletion{.0}};
     EXPECT_EQ(seqan3::uniquify(search(queries, this->index, cfg)), (hits_result_t{{},
                                                                                   {{0, 0}, {1, 0}},
                                                                                   {{0, 0}, {0, 4}, {1, 0}, {1, 4}}}));

--- a/test/unit/search/search_configuration_test.cpp
+++ b/test/unit/search/search_configuration_test.cpp
@@ -11,33 +11,31 @@
 
 #include <gtest/gtest.h>
 
-using namespace seqan3;
-
 template <typename T>
 class search_configuration_test : public ::testing::Test
 {};
 
-using test_types = ::testing::Types<search_cfg::max_error_rate<>,
-                                    search_cfg::max_error<>,
-                                    search_cfg::mode<detail::search_mode_best>,
-                                    search_cfg::output<detail::search_output_text_position>,
-                                    search_cfg::parallel>;
+using test_types = ::testing::Types<seqan3::search_cfg::max_error_rate<>,
+                                    seqan3::search_cfg::max_error<>,
+                                    seqan3::search_cfg::mode<seqan3::detail::search_mode_best>,
+                                    seqan3::search_cfg::output<seqan3::detail::search_output_text_position>,
+                                    seqan3::search_cfg::parallel>;
 
 TYPED_TEST_SUITE(search_configuration_test, test_types, );
 
 // TODO: this should go to a typed configuration test that also checks the alignment configuration
 TEST(search_configuration_test, symmetric_configuration)
 {
-    for (uint8_t i = 0; i < static_cast<uint8_t>(detail::search_config_id::SIZE); ++i)
+    for (uint8_t i = 0; i < static_cast<uint8_t>(seqan3::detail::search_config_id::SIZE); ++i)
     {
         // no element can occur twice in a configuration
-        EXPECT_FALSE(detail::compatibility_table<detail::search_config_id>[i][i])
+        EXPECT_FALSE(seqan3::detail::compatibility_table<seqan3::detail::search_config_id>[i][i])
             << "There is a TRUE value on the diagonal of the search configuration matrix.";
         for (uint8_t j = 0; j < i; ++j)
         {
             // symmetric matrix
-            EXPECT_EQ(detail::compatibility_table<detail::search_config_id>[i][j],
-                      detail::compatibility_table<detail::search_config_id>[j][i])
+            EXPECT_EQ(seqan3::detail::compatibility_table<seqan3::detail::search_config_id>[i][j],
+                      seqan3::detail::compatibility_table<seqan3::detail::search_config_id>[j][i])
                 << "Search configuration matrix is not symmetric.";
         }
     }
@@ -45,28 +43,28 @@ TEST(search_configuration_test, symmetric_configuration)
 
 TYPED_TEST(search_configuration_test, config_element)
 {
-    EXPECT_TRUE((detail::config_element<TypeParam>));
+    EXPECT_TRUE((seqan3::detail::config_element<TypeParam>));
 }
 
 TYPED_TEST(search_configuration_test, configuration_exists)
 {
-    configuration cfg{TypeParam{}};
+    seqan3::configuration cfg{TypeParam{}};
     EXPECT_TRUE(decltype(cfg)::template exists<TypeParam>());
 }
 
 // TEST(search_configuration_test, illegal_runtime_configurations)
 // {
-//     std::vector<dna4> text{"ACGT"_dna4}, query{"ACG"_dna4};
-//     fm_index<std::vector<dna4>> fm{text};
+//     seqan3::dna4_vector text{"ACGT"_dna4}, query{"ACG"_dna4};
+//     seqan3::fm_index<seqan3::dna4_vector> fm{text};
 //
 //     // max_error* without error_type
 //     search(fm, query, max_total_error(0) | error_type(error_type_enum::none));
-//     EXPECT_DEATH(search(fm, query, detail::configuration {max_error(1)}), "");
-//     EXPECT_DEATH(search(fm, query, detail::configuration {max_error_rate(.1)}), "");
+//     EXPECT_DEATH(search(fm, query, seqan3::detail::configuration {max_error(1)}), "");
+//     EXPECT_DEATH(search(fm, query, seqan3::detail::configuration {max_error_rate(.1)}), "");
 //     EXPECT_DEATH(search(fm, query, max_error(1) | error_type(error_type_enum::none)), "");
 //
 //     // error_type without max_error*
-//     search(fm, query, detail::configuration {error_type(error_type_enum::none)});
+//     search(fm, query, seqan3::detail::configuration {error_type(error_type_enum::none)});
 //     search(fm, query, error_type(error_type_enum::none) | max_error_rate(.0));
 //     EXPECT_DEATH(search(fm, query, detail::configuration {error_type(error_type_enum::substitution)}), "");
 //     EXPECT_DEATH(search(fm, query, error_type(error_type_enum::substitution) | max_error(0)), "");

--- a/test/unit/search/search_scheme_algorithm_test.cpp
+++ b/test/unit/search/search_scheme_algorithm_test.cpp
@@ -26,8 +26,6 @@
 #define SEQAN3_SEARCH_TEST_ITERATIONS 10
 #endif
 
-using namespace seqan3;
-
 template <typename text_t>
 inline void test_search_hamming(auto index, text_t const & text, auto const & search, uint64_t const query_length,
                                 std::vector<uint8_t> const & error_distribution, time_t const seed,
@@ -37,7 +35,7 @@ inline void test_search_hamming(auto index, text_t const & text, auto const & se
     using char_t = typename text_t::value_type;
 
     uint64_t const pos = std::rand() % (text.size() - query_length + 1);
-    text_t const orig_query = text | views::slice(pos, pos + query_length) | views::to<text_t>;
+    text_t const orig_query = text | seqan3::views::slice(pos, pos + query_length) | seqan3::views::to<text_t>;
 
     // Modify query s.t. it has errors matching error_distribution.
     auto query = orig_query;
@@ -49,9 +47,9 @@ inline void test_search_hamming(auto index, text_t const & text, auto const & se
         EXPECT_LE(error_distribution[block], single_block_length);
         if (error_distribution[block] > single_block_length)
         {
-            debug_stream << "Error in block " << block << "(+ 1): " << error_distribution[block]
-                         << " errors cannot fit into a block of length " << single_block_length << "." << '\n'
-                         << "Error Distribution: " << error_distribution << '\n';
+            seqan3::debug_stream << "Error in block " << block << "(+ 1): " << error_distribution[block]
+                                 << " errors cannot fit into a block of length " << single_block_length << "." << '\n'
+                                 << "Error Distribution: " << error_distribution << '\n';
             exit(1);
         }
 
@@ -70,11 +68,11 @@ inline void test_search_hamming(auto index, text_t const & text, auto const & se
         {
             uint64_t const pos = error_positions[error] + current_blocks_length;
             // Decrease alphabet size by one because we don't want to replace query[pos], with the same character.
-            uint8_t new_rank = std::rand() % (alphabet_size<char_t> - 1);
+            uint8_t new_rank = std::rand() % (seqan3::alphabet_size<char_t> - 1);
             // If it is a match now, it can't be the highest rank of the alphabet. Thus we set it to the highest rank.
-            if (new_rank == to_rank(query[pos]))
-                new_rank = alphabet_size<char_t> - 1;
-            assign_rank_to(new_rank, query[pos]);
+            if (new_rank == seqan3::to_rank(query[pos]))
+                new_rank = seqan3::alphabet_size<char_t> - 1;
+            seqan3::assign_rank_to(new_rank, query[pos]);
         }
         current_blocks_length += single_block_length;
     }
@@ -95,14 +93,16 @@ inline void test_search_hamming(auto index, text_t const & text, auto const & se
 
     auto remove_predicate_ss = [&text, &orig_query, query_length] (uint64_t const hit)
     {
-        dna4_vector matched_seq = text | views::slice(hit, hit + query_length) | views::to<dna4_vector>;
+        seqan3::dna4_vector matched_seq = text | seqan3::views::slice(hit, hit + query_length)
+                                               | seqan3::views::to<seqan3::dna4_vector>;
         return (matched_seq != orig_query);
     };
 
     auto remove_predicate_trivial = [&] (uint64_t const hit)
     {
         // filter only correct error distributions
-        dna4_vector matched_seq = text | views::slice(hit, hit + query_length) | views::to<dna4_vector>;
+        seqan3::dna4_vector matched_seq = text | seqan3::views::slice(hit, hit + query_length)
+                                               | seqan3::views::to<seqan3::dna4_vector>;
         if (orig_query != matched_seq)
             return true;
 
@@ -129,14 +129,14 @@ inline void test_search_hamming(auto index, text_t const & text, auto const & se
     uint8_t const total        = search.u.back();
     uint8_t const substitution = std::rand() % (total + 1);
 
-    detail::search_param error_left{total, substitution, 0, 0};
+    seqan3::detail::search_param error_left{total, substitution, 0, 0};
 
     // Find all hits using search schemes.
-    detail::search_ss<false>(it, query, start_pos, start_pos + 1, 0, 0, true, search, blocks_length, error_left,
-                             delegate_ss);
+    seqan3::detail::search_ss<false>(it, query, start_pos, start_pos + 1, 0, 0, true, search, blocks_length, error_left,
+                                     delegate_ss);
 
     // Find all hits using trivial backtracking.
-    detail::search_trivial<false>(index, query, error_left, delegate_trivial);
+    seqan3::detail::search_trivial<false>(index, query, error_left, delegate_trivial);
 
     // Eliminate hits that we are not interested in (based on the search and chosen error distribution)
     hits_ss.erase(std::remove_if(hits_ss.begin(), hits_ss.end(), remove_predicate_ss), hits_ss.end());
@@ -145,18 +145,18 @@ inline void test_search_hamming(auto index, text_t const & text, auto const & se
                        hits_trivial.end());
 
     // Eliminate duplicates
-    hits_ss = uniquify(hits_ss);
-    hits_trivial = uniquify(hits_trivial);
+    hits_ss = seqan3::uniquify(hits_ss);
+    hits_trivial = seqan3::uniquify(hits_trivial);
 
     EXPECT_EQ(hits_ss, hits_trivial);
     if (hits_ss != hits_trivial)
     {
-        debug_stream << "Seed: " << seed << '\n'
-                     << "Text: " << text << '\n'
-                     << "Query: " << query << '\n'
-                     << "Errors: " << total << ", " << substitution << '\n'
-                     << "SS hits: " << hits_ss << '\n'
-                     << "Trivial hits: " << hits_trivial << '\n';
+        seqan3::debug_stream << "Seed: " << seed << '\n'
+                             << "Text: " << text << '\n'
+                             << "Query: " << query << '\n'
+                             << "Errors: " << total << ", " << substitution << '\n'
+                             << "SS hits: " << hits_ss << '\n'
+                             << "Trivial hits: " << hits_trivial << '\n';
     }
 }
 
@@ -164,9 +164,7 @@ template <typename search_scheme_t>
 inline void test_search_scheme_hamming(search_scheme_t const & search_scheme, time_t const seed,
                                        uint64_t const iterations)
 {
-    using text_t = dna4_vector;
-
-    text_t text;
+    seqan3::dna4_vector text;
 
     search_scheme_t ordered_search_scheme;
     std::vector<std::vector<std::vector<uint8_t> > > error_distributions(search_scheme.size());
@@ -176,9 +174,9 @@ inline void test_search_scheme_hamming(search_scheme_t const & search_scheme, ti
     for (uint8_t search_id = 0; search_id < search_scheme.size(); ++search_id)
     {
         ordered_search_scheme[search_id] = search_scheme[search_id];
-        search_error_distribution(error_distributions[search_id], search_scheme[search_id]);
+        seqan3::search_error_distribution(error_distributions[search_id], search_scheme[search_id]);
         for (std::vector<uint8_t> & resElem : error_distributions[search_id])
-            order_search_vector(resElem, search_scheme[search_id]);
+            seqan3::order_search_vector(resElem, search_scheme[search_id]);
         max_error = std::max(max_error, search_scheme[search_id].u.back());
     }
 
@@ -188,7 +186,7 @@ inline void test_search_scheme_hamming(search_scheme_t const & search_scheme, ti
         uint64_t const query_length_max = std::min<uint64_t>(16, text_length);
 
         random_text(text, text_length);
-        bi_fm_index index(text);
+        seqan3::bi_fm_index index(text);
 
         for (uint64_t i = 0; i < iterations; ++i)
         {
@@ -200,8 +198,8 @@ inline void test_search_scheme_hamming(search_scheme_t const & search_scheme, ti
                     auto const & [blocks_length, start_pos] = block_info[search_id];
 
                     std::vector<uint64_t> ordered_blocks_length;
-                    get_ordered_search(search_scheme[search_id], blocks_length,
-                                       ordered_search_scheme[search_id], ordered_blocks_length);
+                    seqan3::get_ordered_search(search_scheme[search_id], blocks_length,
+                                               ordered_search_scheme[search_id], ordered_blocks_length);
 
                     for (auto && error_distribution : error_distributions[search_id])
                     {
@@ -217,9 +215,7 @@ inline void test_search_scheme_hamming(search_scheme_t const & search_scheme, ti
 template <typename search_scheme_t>
 inline void test_search_scheme_edit(search_scheme_t const & search_scheme, time_t const seed, uint64_t const iterations)
 {
-    using text_t = dna4_vector;
-
-    text_t text, query;
+    seqan3::dna4_vector text, query;
 
     // retrieve maximum number of errors from search_scheme
     uint8_t max_error = 0;
@@ -232,12 +228,12 @@ inline void test_search_scheme_edit(search_scheme_t const & search_scheme, time_
         uint64_t const query_length_max = std::min<uint64_t>(16, text_length);
 
         random_text(text, text_length);
-        bi_fm_index index(text);
+        seqan3::bi_fm_index index(text);
 
         uint8_t const substitution = std::rand() % (max_error + 1);
         uint8_t const insertion    = std::rand() % (max_error + 1);
         uint8_t const deletion     = std::rand() % (max_error + 1);
-        detail::search_param error_left{max_error, substitution, insertion, deletion};
+        seqan3::detail::search_param error_left{max_error, substitution, insertion, deletion};
 
         for (uint64_t i = 0; i < iterations; ++i)
         {
@@ -260,24 +256,24 @@ inline void test_search_scheme_edit(search_scheme_t const & search_scheme, time_
                 };
 
                 // Find all hits using search schemes.
-                detail::search_ss<false>(index, query, error_left, search_scheme, delegate_ss);
+                seqan3::detail::search_ss<false>(index, query, error_left, search_scheme, delegate_ss);
                 // Find all hits using trivial backtracking.
-                detail::search_trivial<false>(index, query, error_left, delegate_trivial);
+                seqan3::detail::search_trivial<false>(index, query, error_left, delegate_trivial);
 
                 // Eliminate duplicates
-                hits_ss = uniquify(hits_ss);
-                hits_trivial = uniquify(hits_trivial);
+                hits_ss = seqan3::uniquify(hits_ss);
+                hits_trivial = seqan3::uniquify(hits_trivial);
 
                 EXPECT_EQ(hits_ss, hits_trivial);
                 if (hits_ss != hits_trivial)
                 {
-                    debug_stream << "Seed: " << seed << '\n'
-                                 << "Text: " << text << '\n'
-                                 << "Query: " << query << '\n'
-                                 << "Errors: " << max_error << ", " << substitution << ", "
-                                               << insertion << ", " << deletion << '\n'
-                                 << "SS hits: " << hits_ss << '\n'
-                                 << "Trivial hits: " << hits_trivial << '\n';
+                    seqan3::debug_stream << "Seed: " << seed << '\n'
+                                         << "Text: " << text << '\n'
+                                         << "Query: " << query << '\n'
+                                         << "Errors: " << max_error << ", " << substitution << ", "
+                                                       << insertion << ", " << deletion << '\n'
+                                         << "SS hits: " << hits_ss << '\n'
+                                         << "Trivial hits: " << hits_trivial << '\n';
                 }
             }
         }
@@ -289,16 +285,16 @@ TEST(search_scheme_test, search_scheme_hamming)
     time_t seed = std::time(nullptr);
     std::srand(seed);
 
-    test_search_scheme_hamming(detail::optimum_search_scheme<0, 0>, seed, SEQAN3_SEARCH_TEST_ITERATIONS);
-    test_search_scheme_hamming(detail::optimum_search_scheme<0, 1>, seed, SEQAN3_SEARCH_TEST_ITERATIONS);
-    test_search_scheme_hamming(detail::optimum_search_scheme<1, 1>, seed, SEQAN3_SEARCH_TEST_ITERATIONS);
-    test_search_scheme_hamming(detail::optimum_search_scheme<0, 2>, seed, SEQAN3_SEARCH_TEST_ITERATIONS);
-    test_search_scheme_hamming(detail::optimum_search_scheme<1, 2>, seed, SEQAN3_SEARCH_TEST_ITERATIONS);
-    test_search_scheme_hamming(detail::optimum_search_scheme<2, 2>, seed, SEQAN3_SEARCH_TEST_ITERATIONS);
-    test_search_scheme_hamming(detail::optimum_search_scheme<0, 3>, seed, SEQAN3_SEARCH_TEST_ITERATIONS);
-    test_search_scheme_hamming(detail::optimum_search_scheme<1, 3>, seed, SEQAN3_SEARCH_TEST_ITERATIONS);
-    test_search_scheme_hamming(detail::optimum_search_scheme<2, 3>, seed, SEQAN3_SEARCH_TEST_ITERATIONS);
-    // test_search_scheme_hamming(detail::optimum_search_scheme<3, 3>, seed, SEQAN3_SEARCH_TEST_ITERATIONS);
+    test_search_scheme_hamming(seqan3::detail::optimum_search_scheme<0, 0>, seed, SEQAN3_SEARCH_TEST_ITERATIONS);
+    test_search_scheme_hamming(seqan3::detail::optimum_search_scheme<0, 1>, seed, SEQAN3_SEARCH_TEST_ITERATIONS);
+    test_search_scheme_hamming(seqan3::detail::optimum_search_scheme<1, 1>, seed, SEQAN3_SEARCH_TEST_ITERATIONS);
+    test_search_scheme_hamming(seqan3::detail::optimum_search_scheme<0, 2>, seed, SEQAN3_SEARCH_TEST_ITERATIONS);
+    test_search_scheme_hamming(seqan3::detail::optimum_search_scheme<1, 2>, seed, SEQAN3_SEARCH_TEST_ITERATIONS);
+    test_search_scheme_hamming(seqan3::detail::optimum_search_scheme<2, 2>, seed, SEQAN3_SEARCH_TEST_ITERATIONS);
+    test_search_scheme_hamming(seqan3::detail::optimum_search_scheme<0, 3>, seed, SEQAN3_SEARCH_TEST_ITERATIONS);
+    test_search_scheme_hamming(seqan3::detail::optimum_search_scheme<1, 3>, seed, SEQAN3_SEARCH_TEST_ITERATIONS);
+    test_search_scheme_hamming(seqan3::detail::optimum_search_scheme<2, 3>, seed, SEQAN3_SEARCH_TEST_ITERATIONS);
+    // test_search_scheme_hamming(seqan3::detail::optimum_search_scheme<3, 3>, seed, SEQAN3_SEARCH_TEST_ITERATIONS);
 }
 
 TEST(search_scheme_test, search_scheme_edit)
@@ -308,10 +304,10 @@ TEST(search_scheme_test, search_scheme_edit)
 
     // TODO: test with lower bounds != 0.
     // For that we need alignment statistics to know the number of errors spent in search_trivial
-    test_search_scheme_edit(detail::optimum_search_scheme<0, 0>, seed, SEQAN3_SEARCH_TEST_ITERATIONS);
-    test_search_scheme_edit(detail::optimum_search_scheme<0, 1>, seed, SEQAN3_SEARCH_TEST_ITERATIONS);
-    test_search_scheme_edit(detail::optimum_search_scheme<0, 2>, seed, SEQAN3_SEARCH_TEST_ITERATIONS);
-    test_search_scheme_edit(detail::optimum_search_scheme<0, 3>, seed, SEQAN3_SEARCH_TEST_ITERATIONS);
+    test_search_scheme_edit(seqan3::detail::optimum_search_scheme<0, 0>, seed, SEQAN3_SEARCH_TEST_ITERATIONS);
+    test_search_scheme_edit(seqan3::detail::optimum_search_scheme<0, 1>, seed, SEQAN3_SEARCH_TEST_ITERATIONS);
+    test_search_scheme_edit(seqan3::detail::optimum_search_scheme<0, 2>, seed, SEQAN3_SEARCH_TEST_ITERATIONS);
+    test_search_scheme_edit(seqan3::detail::optimum_search_scheme<0, 3>, seed, SEQAN3_SEARCH_TEST_ITERATIONS);
 }
 
 #undef SEQAN3_SEARCH_TEST_ITERATIONS

--- a/test/unit/search/search_scheme_test.cpp
+++ b/test/unit/search/search_scheme_test.cpp
@@ -14,22 +14,24 @@
 
 #include <gtest/gtest.h>
 
-using namespace seqan3;
-
 template <uint8_t min_error, uint8_t max_error, bool precomputed_scheme>
 void error_distributions(auto & expected, auto & actual)
 {
     if constexpr (precomputed_scheme)
     {
-        auto const & oss{detail::optimum_search_scheme<min_error, max_error>};
-        search_scheme_error_distribution(actual, oss);
-        search_scheme_error_distribution(expected, trivial_search_scheme(min_error, max_error, oss.front().blocks()));
+        auto const & oss{seqan3::detail::optimum_search_scheme<min_error, max_error>};
+        seqan3::search_scheme_error_distribution(actual, oss);
+        seqan3::search_scheme_error_distribution(expected, seqan3::trivial_search_scheme(min_error,
+                                                                                         max_error,
+                                                                                         oss.front().blocks()));
     }
     else
     {
-        auto const & ss{detail::compute_ss(min_error, max_error)};
-        search_scheme_error_distribution(actual, ss);
-        search_scheme_error_distribution(expected, trivial_search_scheme(min_error, max_error, ss.front().blocks()));
+        auto const & ss{seqan3::detail::compute_ss(min_error, max_error)};
+        seqan3::search_scheme_error_distribution(actual, ss);
+        seqan3::search_scheme_error_distribution(expected, seqan3::trivial_search_scheme(min_error,
+                                                                                         max_error,
+                                                                                         ss.front().blocks()));
     }
     std::sort(expected.begin(), expected.end());
     std::sort(actual.begin(), actual.end());
@@ -117,11 +119,13 @@ bool check_disjoint_search_scheme()
 {
     std::vector<std::vector<uint8_t> > error_distributions;
 
-    auto const & oss{detail::optimum_search_scheme<min_error, max_error>};
-    search_scheme_error_distribution(error_distributions, oss);
+    auto const & oss{seqan3::detail::optimum_search_scheme<min_error, max_error>};
+    seqan3::search_scheme_error_distribution(error_distributions, oss);
     uint64_t size = error_distributions.size();
     std::sort(error_distributions.begin(), error_distributions.end());
-    error_distributions.erase(std::unique(error_distributions.begin(), error_distributions.end()), error_distributions.end());
+    error_distributions.erase(std::unique(error_distributions.begin(),
+                                          error_distributions.end()),
+                                          error_distributions.end());
     return size == error_distributions.size();
 }
 

--- a/test/unit/search/search_test.cpp
+++ b/test/unit/search/search_test.cpp
@@ -17,7 +17,6 @@
 using seqan3::operator""_dna4;
 using seqan3::operator""_phred42;
 
-using namespace seqan3::search_cfg;
 using namespace std::string_literals;
 
 template <typename T>
@@ -63,42 +62,48 @@ TYPED_TEST(search_test, error_free)
 
     {
         // successful and unsuccesful exact search using empty max_total_error
-        seqan3::configuration const cfg = max_error{};
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error{};
         EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{0, 4, 8}));
         EXPECT_EQ(seqan3::uniquify(search("ACGG"_dna4, this->index, cfg)), (hits_result_t{}));
     }
 
     {
         // successful and unsuccesful exact search using short version of max_total_error
-        seqan3::configuration const cfg = max_error{total{0}};
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::total{0}};
         EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{0, 4, 8}));
         EXPECT_EQ(seqan3::uniquify(search("ACGG"_dna4, this->index, cfg)), (hits_result_t{}));
     }
 
     {
         // successful and unsuccesful exact search using max_total_error
-        seqan3::configuration const cfg = max_error{total{0}, substitution{0}, insertion{0}, deletion{0}};
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::total{0},
+                                                                        seqan3::search_cfg::substitution{0},
+                                                                        seqan3::search_cfg::insertion{0},
+                                                                        seqan3::search_cfg::deletion{0}};
         EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{0, 4, 8}));
         EXPECT_EQ(seqan3::uniquify(search("ACGG"_dna4, this->index, cfg)), (hits_result_t{}));
     }
 
     {
         // successful and unsuccesful exact search using empty max_total_error_rate
-        seqan3::configuration const cfg = max_error_rate{};
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error_rate{};
         EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{0, 4, 8}));
         EXPECT_EQ(seqan3::uniquify(search("ACGG"_dna4, this->index, cfg)), (hits_result_t{}));
     }
 
     {
         // successful and unsuccesful exact search using short version of max_total_error_rate
-        seqan3::configuration const cfg = max_error_rate{total{.0}};
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error_rate{seqan3::search_cfg::total{.0}};
         EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{0, 4, 8}));
         EXPECT_EQ(seqan3::uniquify(search("ACGG"_dna4, this->index, cfg)), (hits_result_t{}));
     }
 
     {
         // successful and unsuccesful exact search using max_total_error_rate
-        seqan3::configuration const cfg = max_error_rate{total{.0}, substitution{.0}, insertion{.0}, deletion{.0}};
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error_rate{seqan3::search_cfg::total{.0},
+                                                                             seqan3::search_cfg::substitution{.0},
+                                                                             seqan3::search_cfg::insertion{.0},
+                                                                             seqan3::search_cfg::deletion{.0}};
         EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{0, 4, 8}));
         EXPECT_EQ(seqan3::uniquify(search("ACGG"_dna4, this->index, cfg)), (hits_result_t{}));
     }
@@ -120,13 +125,17 @@ TYPED_TEST(search_test, multiple_queries)
     using hits_result_t = std::vector<std::vector<typename TypeParam::size_type>>;
     std::vector<seqan3::dna4_vector> const queries{{"GG"_dna4, "ACGTACGTACGT"_dna4, "ACGTA"_dna4}};
 
-    seqan3::configuration const cfg = max_error_rate{total{.0}, substitution{.0}, insertion{.0}, deletion{.0}};
+    seqan3::configuration const cfg = seqan3::search_cfg::max_error_rate{seqan3::search_cfg::total{.0},
+                                                                         seqan3::search_cfg::substitution{.0},
+                                                                         seqan3::search_cfg::insertion{.0},
+                                                                         seqan3::search_cfg::deletion{.0}};
     EXPECT_EQ(seqan3::uniquify(search(queries, this->index, cfg)), (hits_result_t{{}, {0}, {0, 4}})); // 0, 1 and 2 hits
 }
 
 TYPED_TEST(search_test, invalid_error_configuration)
 {
-    seqan3::configuration const cfg = max_error{total{0}, substitution{1}};
+    seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::total{0},
+                                                                    seqan3::search_cfg::substitution{1}};
     EXPECT_THROW(search("A"_dna4, this->index, cfg), std::invalid_argument);
 }
 
@@ -135,7 +144,8 @@ TYPED_TEST(search_test, error_substitution)
     using hits_result_t = std::vector<typename TypeParam::size_type>;
 
     {
-        seqan3::configuration const cfg = max_error_rate{total{.25}, substitution{.25}};
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error_rate{seqan3::search_cfg::total{.25},
+                                                                             seqan3::search_cfg::substitution{.25}};
 
         EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4,     this->index, cfg)), (hits_result_t{0, 4, 8})); // exact match
         EXPECT_EQ(seqan3::uniquify(search("CGG"_dna4,      this->index, cfg)), (hits_result_t{}));        // not enough
@@ -146,7 +156,10 @@ TYPED_TEST(search_test, error_substitution)
     }
 
     {
-        seqan3::configuration const cfg = max_error_rate{total{.25}, substitution{.25}, insertion{.0}, deletion{.0}};
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error_rate{seqan3::search_cfg::total{.25},
+                                                                             seqan3::search_cfg::substitution{.25},
+                                                                             seqan3::search_cfg::insertion{.0},
+                                                                             seqan3::search_cfg::deletion{.0}};
 
         EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4,     this->index, cfg)), (hits_result_t{0, 4, 8})); // exact match
         EXPECT_EQ(seqan3::uniquify(search("CGG"_dna4,      this->index, cfg)), (hits_result_t{}));        // not enough
@@ -157,7 +170,8 @@ TYPED_TEST(search_test, error_substitution)
     }
 
     {
-        seqan3::configuration const cfg = max_error{total{1}, substitution{1}};
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::total{1},
+                                                                        seqan3::search_cfg::substitution{1}};
 
         EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4,     this->index, cfg)), (hits_result_t{0, 4, 8})); // exact match
         EXPECT_EQ(seqan3::uniquify(search("CGTTT"_dna4,    this->index, cfg)), (hits_result_t{}));        // not enough
@@ -168,7 +182,10 @@ TYPED_TEST(search_test, error_substitution)
     }
 
     {
-        seqan3::configuration const cfg = max_error{total{1}, substitution{1}, insertion{0}, deletion{0}};
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::total{1},
+                                                                        seqan3::search_cfg::substitution{1},
+                                                                        seqan3::search_cfg::insertion{0},
+                                                                        seqan3::search_cfg::deletion{0}};
 
         EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4,     this->index, cfg)), (hits_result_t{0, 4, 8})); // exact match
         EXPECT_EQ(seqan3::uniquify(search("CGTTT"_dna4,    this->index, cfg)), (hits_result_t{}));        // not enough
@@ -185,12 +202,13 @@ TYPED_TEST(search_test, error_configuration_types)
 
     {
         uint8_t s = 1, t = 1;
-        seqan3::configuration const cfg = max_error{total{t}, substitution{s}};
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::total{t},
+                                                                        seqan3::search_cfg::substitution{s}};
         EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{0, 4, 8}));
     }
 
     {
-        seqan3::configuration const cfg = max_error{substitution{1}};
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::substitution{1}};
         EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{0, 4, 8}));
     }
 }
@@ -200,7 +218,8 @@ TYPED_TEST(search_test, error_insertion)
     using hits_result_t = std::vector<typename TypeParam::size_type>;
 
     {
-        seqan3::configuration const cfg = max_error_rate{total{.25}, insertion{.25}};
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error_rate{seqan3::search_cfg::total{.25},
+                                                                             seqan3::search_cfg::insertion{.25}};
 
         // exact match and insertion at the beginning of the query
         EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4,     this->index, cfg)), (hits_result_t{0, 1, 4, 5, 8, 9}));
@@ -215,7 +234,8 @@ TYPED_TEST(search_test, error_insertion)
     }
 
     {
-        seqan3::configuration const cfg = max_error{total{1}, insertion{1}};
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::total{1},
+                                                                        seqan3::search_cfg::insertion{1}};
 
         // exact match and insertion at the beginning of the query
         EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4,     this->index, cfg)), (hits_result_t{0, 1, 4, 5, 8, 9}));
@@ -233,7 +253,8 @@ TYPED_TEST(search_test, error_deletion)
     using hits_result_t = std::vector<typename TypeParam::size_type>;
 
     {
-        seqan3::configuration const cfg = max_error_rate{total{.25}, deletion{.25}};
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error_rate{seqan3::search_cfg::total{.25},
+                                                                             seqan3::search_cfg::deletion{.25}};
 
         // exact match, no deletion
         EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4,     this->index, cfg)), (hits_result_t{0, 4, 8}));
@@ -248,7 +269,8 @@ TYPED_TEST(search_test, error_deletion)
     }
 
     {
-        seqan3::configuration const cfg = max_error{total{1}, deletion{1}};
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::total{1},
+                                                                        seqan3::search_cfg::deletion{1}};
 
         // exact match, no deletion
         EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4,     this->index, cfg)), (hits_result_t{0, 4, 8}));
@@ -266,14 +288,14 @@ TYPED_TEST(search_test, error_levenshtein)
     using hits_result_t = std::vector<typename TypeParam::size_type>;
 
     {
-        seqan3::configuration const cfg = max_error{total{1}};
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::total{1}};
         EXPECT_EQ(seqan3::uniquify(search("CCGT"_dna4, this->index, cfg)), (hits_result_t{0, 1, 4, 5, 8, 9}));
     }
 
     {
-        seqan3::configuration const cfg = max_error{total{2}};
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::total{2}};
         EXPECT_EQ(seqan3::uniquify(search("CCGT"_dna4, this->index, cfg)),
-                                   (hits_result_t{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}));
+                  (hits_result_t{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}));
     }
 }
 
@@ -283,13 +305,17 @@ TYPED_TEST(search_test, error_indel_no_substitution)
 
     {
         // Match one mismatch with 1 insertion and deletion since mismatches are not allowed.
-        seqan3::configuration const cfg = max_error{total{2}, deletion{2}, insertion{2}};
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::total{2},
+                                                                        seqan3::search_cfg::deletion{2},
+                                                                        seqan3::search_cfg::insertion{2}};
         EXPECT_EQ(seqan3::uniquify(search("GTACCTAC"_dna4, this->index, cfg)), (hits_result_t{2}));
     }
 
     {
         // Enumerate a deletion and match one mismatch with 1 insertion and deletion since mismatches are not allowed.
-        seqan3::configuration const cfg = max_error{total{3}, deletion{3}, insertion{3}};
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::total{3},
+                                                                        seqan3::search_cfg::deletion{3},
+                                                                        seqan3::search_cfg::insertion{3}};
         EXPECT_EQ(seqan3::uniquify(search("GTATCCTAC"_dna4, this->index, cfg)), (hits_result_t{2}));
     }
 }
@@ -299,12 +325,15 @@ TYPED_TEST(search_test, search_strategy_all)
     using hits_result_t = std::vector<typename TypeParam::size_type>;
 
     {
-        seqan3::configuration const cfg = max_error{total{1}};
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::total{1}};
         EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{0, 1, 4, 5, 8, 9}));
     }
 
     {
-        seqan3::configuration const cfg = max_error{total{1}} | mode{all};
+        auto search_cfg_mode_all = seqan3::search_cfg::mode{seqan3::search_cfg::all};
+
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::total{1}}
+                                                                        | search_cfg_mode_all;
         EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{0, 1, 4, 5, 8, 9}));
     }
 }
@@ -312,10 +341,12 @@ TYPED_TEST(search_test, search_strategy_all)
 TYPED_TEST(search_test, search_strategy_best)
 {
     using hits_result_t = std::vector<typename TypeParam::size_type>;
+    auto search_cfg_mode_best = seqan3::search_cfg::mode{seqan3::search_cfg::best};
 
     hits_result_t possible_hits{0, 4, 8}; // any of 0, 4, 8 ... 1, 5, 9 are not best hits
     {
-        seqan3::configuration const cfg = max_error{total{1}} | mode{best};
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::total{1}}
+                                                                        | search_cfg_mode_best;
 
         hits_result_t result = search("ACGT"_dna4, this->index, cfg);
         ASSERT_EQ(result.size(), 1u);
@@ -325,7 +356,9 @@ TYPED_TEST(search_test, search_strategy_best)
     }
 
     { // Find best match with 1 insertion at the end.
-        seqan3::configuration const cfg = max_error{total{1}, insertion{1}} | mode{best};
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::total{1},
+                                                                        seqan3::search_cfg::insertion{1}}
+                                                                        | search_cfg_mode_best;
 
         hits_result_t result = search("ACGTT"_dna4, this->index, cfg);
         ASSERT_EQ(result.size(), 1u);
@@ -333,7 +366,9 @@ TYPED_TEST(search_test, search_strategy_best)
     }
 
     {  // Find best match with a match at the end, allowing a insertion.
-        seqan3::configuration const cfg = max_error{total{1}, insertion{1}} | mode{best};
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::total{1},
+                                                                        seqan3::search_cfg::insertion{1}}
+                                                                        | search_cfg_mode_best;
 
         hits_result_t result = search("ACGT"_dna4, this->index, cfg);
         ASSERT_EQ(result.size(), 1u);
@@ -341,7 +376,9 @@ TYPED_TEST(search_test, search_strategy_best)
     }
 
     {  // Find best match with a deletion.
-        seqan3::configuration const cfg = max_error{total{1}, deletion{1}} | mode{best};
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::total{1},
+                                                                        seqan3::search_cfg::deletion{1}}
+                                                                        | search_cfg_mode_best;
 
         hits_result_t result = search("AGT"_dna4, this->index, cfg);
         ASSERT_EQ(result.size(), 1u);
@@ -349,7 +386,9 @@ TYPED_TEST(search_test, search_strategy_best)
     }
 
     { // Find best match with a match at the end, allowing a deletion.
-        seqan3::configuration const cfg = max_error{total{1}, deletion{1}} | mode{best};
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::total{1},
+                                                                        seqan3::search_cfg::deletion{1}}
+                                                                        | search_cfg_mode_best;
 
         hits_result_t result = search("ACGT"_dna4, this->index, cfg);
         ASSERT_EQ(result.size(), 1u);
@@ -357,7 +396,9 @@ TYPED_TEST(search_test, search_strategy_best)
     }
 
     {  // Find best match with a substitution at the end.
-        seqan3::configuration const cfg = max_error{total{1}, substitution{1}} | mode{best};
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::total{1},
+                                                                        seqan3::search_cfg::substitution{1}}
+                                                                        | search_cfg_mode_best;
 
         hits_result_t result = search("ACGC"_dna4, this->index, cfg);
         ASSERT_EQ(result.size(), 1u);
@@ -365,7 +406,9 @@ TYPED_TEST(search_test, search_strategy_best)
     }
 
     {  // Find best match with a match at the end, allowing a substitution.
-        seqan3::configuration const cfg = max_error{total{1}, substitution{1}} | mode{best};
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::total{1},
+                                                                        seqan3::search_cfg::substitution{1}}
+                                                                        | search_cfg_mode_best;
 
         hits_result_t result = search("ACGT"_dna4, this->index, cfg);
         ASSERT_EQ(result.size(), 1u);
@@ -374,7 +417,9 @@ TYPED_TEST(search_test, search_strategy_best)
 
     {  // Find best match with 2 deletions.
         hits_result_t possible_hits2d{0, 4}; // any of 0, 4 ... 1, 5 are not best hits
-        seqan3::configuration const cfg = max_error{total{2}, deletion{2}} | mode{best};
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::total{2},
+                                                                        seqan3::search_cfg::deletion{2}}
+                                                                        | search_cfg_mode_best;
 
         hits_result_t result = search("AGTAGT"_dna4, this->index, cfg);
         ASSERT_EQ(result.size(), 1u);
@@ -387,7 +432,9 @@ TYPED_TEST(search_test, search_strategy_all_best)
     using hits_result_t = std::vector<typename TypeParam::size_type>;
 
     {
-        seqan3::configuration const cfg = max_error{total{1}} | mode{all_best};
+        auto search_cfg_mode_all_best = seqan3::search_cfg::mode{seqan3::search_cfg::all_best};
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::total{1}}
+                                                                        | search_cfg_mode_all_best;
 
         EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4, this->index, cfg)),
                                    (hits_result_t{0, 4, 8})); // 1, 5, 9 are not best hits
@@ -401,17 +448,23 @@ TYPED_TEST(search_test, search_strategy_strata)
     using hits_result_t = std::vector<typename TypeParam::size_type>;
 
     {
-        seqan3::configuration const cfg = max_error{total{1}} | mode{strata{0}};
+        auto search_cfg_mode_strata_0 = seqan3::search_cfg::mode{seqan3::search_cfg::strata{0}};
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::total{1}}
+                                                                        | search_cfg_mode_strata_0;
         EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{0, 4, 8}));
     }
 
     {
-        seqan3::configuration const cfg = max_error{total{1}} | mode{strata{1}};
+        auto search_cfg_mode_strata_1 = seqan3::search_cfg::mode{seqan3::search_cfg::strata{1}};
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::total{1}}
+                                                                        | search_cfg_mode_strata_1;
         EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{0, 1, 4, 5, 8, 9}));
     }
 
     {
-        seqan3::configuration const cfg = max_error{total{1}} | mode{strata{1}};
+        auto search_cfg_mode_strata_1 = seqan3::search_cfg::mode{seqan3::search_cfg::strata{1}};
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::total{1}}
+                                                                        | search_cfg_mode_strata_1;
         EXPECT_EQ(search("AAAA"_dna4, this->index, cfg), (hits_result_t{})); // no hit
     }
 

--- a/test/unit/search/search_test.cpp
+++ b/test/unit/search/search_test.cpp
@@ -14,7 +14,9 @@
 
 #include "helper.hpp"
 
-using namespace seqan3;
+using seqan3::operator""_dna4;
+using seqan3::operator""_phred42;
+
 using namespace seqan3::search_cfg;
 using namespace std::string_literals;
 
@@ -22,7 +24,7 @@ template <typename T>
 class search_test : public ::testing::Test
 {
 public:
-    std::vector<dna4> text{"ACGTACGTACGT"_dna4};
+    seqan3::dna4_vector text{"ACGTACGTACGT"_dna4};
     T index{text};
 };
 
@@ -34,10 +36,10 @@ public:
     T index{text};
 };
 
-using fm_index_types        = ::testing::Types<fm_index<dna4, text_layout::single>,
-                                               bi_fm_index<dna4, text_layout::single>>;
-using fm_index_string_types = ::testing::Types<fm_index<char, text_layout::single>,
-                                               bi_fm_index<char, text_layout::single>>;
+using fm_index_types        = ::testing::Types<seqan3::fm_index<seqan3::dna4, seqan3::text_layout::single>,
+                                               seqan3::bi_fm_index<seqan3::dna4, seqan3::text_layout::single>>;
+using fm_index_string_types = ::testing::Types<seqan3::fm_index<char, seqan3::text_layout::single>,
+                                               seqan3::bi_fm_index<char, seqan3::text_layout::single>>;
 
 TYPED_TEST_SUITE(search_test, fm_index_types, );
 TYPED_TEST_SUITE(search_string_test, fm_index_string_types, );
@@ -48,83 +50,83 @@ TYPED_TEST(search_test, error_free)
 
     {
         // successful and unsuccesful exact search without cfg
-        EXPECT_EQ(uniquify(search("ACGT"_dna4, this->index)), (hits_result_t{0, 4, 8}));
-        EXPECT_EQ(uniquify(search("ACGG"_dna4, this->index)), (hits_result_t{}));
+        EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4, this->index)), (hits_result_t{0, 4, 8}));
+        EXPECT_EQ(seqan3::uniquify(search("ACGG"_dna4, this->index)), (hits_result_t{}));
     }
 
     {
         // successful and unsuccesful exact search with empty cfg
-        configuration const cfg;
-        EXPECT_EQ(uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{0, 4, 8}));
-        EXPECT_EQ(uniquify(search("ACGG"_dna4, this->index, cfg)), (hits_result_t{}));
+        seqan3::configuration const cfg;
+        EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{0, 4, 8}));
+        EXPECT_EQ(seqan3::uniquify(search("ACGG"_dna4, this->index, cfg)), (hits_result_t{}));
     }
 
     {
         // successful and unsuccesful exact search using empty max_total_error
-        configuration const cfg = max_error{};
-        EXPECT_EQ(uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{0, 4, 8}));
-        EXPECT_EQ(uniquify(search("ACGG"_dna4, this->index, cfg)), (hits_result_t{}));
+        seqan3::configuration const cfg = max_error{};
+        EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{0, 4, 8}));
+        EXPECT_EQ(seqan3::uniquify(search("ACGG"_dna4, this->index, cfg)), (hits_result_t{}));
     }
 
     {
         // successful and unsuccesful exact search using short version of max_total_error
-        configuration const cfg = max_error{total{0}};
-        EXPECT_EQ(uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{0, 4, 8}));
-        EXPECT_EQ(uniquify(search("ACGG"_dna4, this->index, cfg)), (hits_result_t{}));
+        seqan3::configuration const cfg = max_error{total{0}};
+        EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{0, 4, 8}));
+        EXPECT_EQ(seqan3::uniquify(search("ACGG"_dna4, this->index, cfg)), (hits_result_t{}));
     }
 
     {
         // successful and unsuccesful exact search using max_total_error
-        configuration const cfg = max_error{total{0}, substitution{0}, insertion{0}, deletion{0}};
-        EXPECT_EQ(uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{0, 4, 8}));
-        EXPECT_EQ(uniquify(search("ACGG"_dna4, this->index, cfg)), (hits_result_t{}));
+        seqan3::configuration const cfg = max_error{total{0}, substitution{0}, insertion{0}, deletion{0}};
+        EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{0, 4, 8}));
+        EXPECT_EQ(seqan3::uniquify(search("ACGG"_dna4, this->index, cfg)), (hits_result_t{}));
     }
 
     {
         // successful and unsuccesful exact search using empty max_total_error_rate
-        configuration const cfg = max_error_rate{};
-        EXPECT_EQ(uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{0, 4, 8}));
-        EXPECT_EQ(uniquify(search("ACGG"_dna4, this->index, cfg)), (hits_result_t{}));
+        seqan3::configuration const cfg = max_error_rate{};
+        EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{0, 4, 8}));
+        EXPECT_EQ(seqan3::uniquify(search("ACGG"_dna4, this->index, cfg)), (hits_result_t{}));
     }
 
     {
         // successful and unsuccesful exact search using short version of max_total_error_rate
-        configuration const cfg = max_error_rate{total{.0}};
-        EXPECT_EQ(uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{0, 4, 8}));
-        EXPECT_EQ(uniquify(search("ACGG"_dna4, this->index, cfg)), (hits_result_t{}));
+        seqan3::configuration const cfg = max_error_rate{total{.0}};
+        EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{0, 4, 8}));
+        EXPECT_EQ(seqan3::uniquify(search("ACGG"_dna4, this->index, cfg)), (hits_result_t{}));
     }
 
     {
         // successful and unsuccesful exact search using max_total_error_rate
-        configuration const cfg = max_error_rate{total{.0}, substitution{.0}, insertion{.0}, deletion{.0}};
-        EXPECT_EQ(uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{0, 4, 8}));
-        EXPECT_EQ(uniquify(search("ACGG"_dna4, this->index, cfg)), (hits_result_t{}));
+        seqan3::configuration const cfg = max_error_rate{total{.0}, substitution{.0}, insertion{.0}, deletion{.0}};
+        EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{0, 4, 8}));
+        EXPECT_EQ(seqan3::uniquify(search("ACGG"_dna4, this->index, cfg)), (hits_result_t{}));
     }
 }
 
 TYPED_TEST(search_test, convertible_query)
 {
     using hits_result_t = std::vector<typename TypeParam::size_type>;
-    std::vector<qualified<dna4, phred42>> query{{'A'_dna4, '!'_phred42},
-                                                {'C'_dna4, '!'_phred42},
-                                                {'G'_dna4, '!'_phred42},
-                                                {'T'_dna4, '!'_phred42}};
+    std::vector<seqan3::qualified<seqan3::dna4, seqan3::phred42>> query{{'A'_dna4, '!'_phred42},
+                                                                        {'C'_dna4, '!'_phred42},
+                                                                        {'G'_dna4, '!'_phred42},
+                                                                        {'T'_dna4, '!'_phred42}};
 
-    EXPECT_EQ(uniquify(search(query, this->index)), (hits_result_t{0, 4, 8}));
+    EXPECT_EQ(seqan3::uniquify(search(query, this->index)), (hits_result_t{0, 4, 8}));
 }
 
 TYPED_TEST(search_test, multiple_queries)
 {
     using hits_result_t = std::vector<std::vector<typename TypeParam::size_type>>;
-    std::vector<std::vector<dna4>> const queries{{"GG"_dna4, "ACGTACGTACGT"_dna4, "ACGTA"_dna4}};
+    std::vector<seqan3::dna4_vector> const queries{{"GG"_dna4, "ACGTACGTACGT"_dna4, "ACGTA"_dna4}};
 
-    configuration const cfg = max_error_rate{total{.0}, substitution{.0}, insertion{.0}, deletion{.0}};
-    EXPECT_EQ(uniquify(search(queries, this->index, cfg)), (hits_result_t{{}, {0}, {0, 4}})); // 0, 1 and 2 hits
+    seqan3::configuration const cfg = max_error_rate{total{.0}, substitution{.0}, insertion{.0}, deletion{.0}};
+    EXPECT_EQ(seqan3::uniquify(search(queries, this->index, cfg)), (hits_result_t{{}, {0}, {0, 4}})); // 0, 1 and 2 hits
 }
 
 TYPED_TEST(search_test, invalid_error_configuration)
 {
-    configuration const cfg = max_error{total{0}, substitution{1}};
+    seqan3::configuration const cfg = max_error{total{0}, substitution{1}};
     EXPECT_THROW(search("A"_dna4, this->index, cfg), std::invalid_argument);
 }
 
@@ -133,43 +135,47 @@ TYPED_TEST(search_test, error_substitution)
     using hits_result_t = std::vector<typename TypeParam::size_type>;
 
     {
-        configuration const cfg = max_error_rate{total{.25}, substitution{.25}};
+        seqan3::configuration const cfg = max_error_rate{total{.25}, substitution{.25}};
 
-        EXPECT_EQ(uniquify(search("ACGT"_dna4    , this->index, cfg)), (hits_result_t{0, 4, 8})); // exact match
-        EXPECT_EQ(uniquify(search("CGG"_dna4     , this->index, cfg)), (hits_result_t{}));        // not enough mismatches
-        EXPECT_EQ(uniquify(search("CGTC"_dna4    , this->index, cfg)), (hits_result_t{1, 5}));    // 1 mismatch
-        EXPECT_EQ(uniquify(search("ACGGACG"_dna4 , this->index, cfg)), (hits_result_t{0, 4}));    // 1 mismatch
-        EXPECT_EQ(uniquify(search("ACGGACGG"_dna4, this->index, cfg)), (hits_result_t{0, 4}));    // 2 mismatches
+        EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4,     this->index, cfg)), (hits_result_t{0, 4, 8})); // exact match
+        EXPECT_EQ(seqan3::uniquify(search("CGG"_dna4,      this->index, cfg)), (hits_result_t{}));        // not enough
+                                                                                                          //  mismatches
+        EXPECT_EQ(seqan3::uniquify(search("CGTC"_dna4,     this->index, cfg)), (hits_result_t{1, 5}));    // 1 mismatch
+        EXPECT_EQ(seqan3::uniquify(search("ACGGACG"_dna4,  this->index, cfg)), (hits_result_t{0, 4}));    // 1 mismatch
+        EXPECT_EQ(seqan3::uniquify(search("ACGGACGG"_dna4, this->index, cfg)), (hits_result_t{0, 4}));    // 2 mismatches
     }
 
     {
-        configuration const cfg = max_error_rate{total{.25}, substitution{.25}, insertion{.0}, deletion{.0}};
+        seqan3::configuration const cfg = max_error_rate{total{.25}, substitution{.25}, insertion{.0}, deletion{.0}};
 
-        EXPECT_EQ(uniquify(search("ACGT"_dna4    , this->index, cfg)), (hits_result_t{0, 4, 8})); // exact match
-        EXPECT_EQ(uniquify(search("CGG"_dna4     , this->index, cfg)), (hits_result_t{}));        // not enough mismatches
-        EXPECT_EQ(uniquify(search("CGTC"_dna4    , this->index, cfg)), (hits_result_t{1, 5}));    // 1 mismatch
-        EXPECT_EQ(uniquify(search("ACGGACG"_dna4 , this->index, cfg)), (hits_result_t{0, 4}));    // 1 mismatch
-        EXPECT_EQ(uniquify(search("ACGGACGG"_dna4, this->index, cfg)), (hits_result_t{0, 4}));    // 2 mismatches
+        EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4,     this->index, cfg)), (hits_result_t{0, 4, 8})); // exact match
+        EXPECT_EQ(seqan3::uniquify(search("CGG"_dna4,      this->index, cfg)), (hits_result_t{}));        // not enough
+                                                                                                          //  mismatches
+        EXPECT_EQ(seqan3::uniquify(search("CGTC"_dna4,     this->index, cfg)), (hits_result_t{1, 5}));    // 1 mismatch
+        EXPECT_EQ(seqan3::uniquify(search("ACGGACG"_dna4,  this->index, cfg)), (hits_result_t{0, 4}));    // 1 mismatch
+        EXPECT_EQ(seqan3::uniquify(search("ACGGACGG"_dna4, this->index, cfg)), (hits_result_t{0, 4}));    // 2 mismatches
     }
 
     {
-        configuration const cfg = max_error{total{1}, substitution{1}};
+        seqan3::configuration const cfg = max_error{total{1}, substitution{1}};
 
-        EXPECT_EQ(uniquify(search("ACGT"_dna4    , this->index, cfg)), (hits_result_t{0, 4, 8})); // exact match
-        EXPECT_EQ(uniquify(search("CGTTT"_dna4   , this->index, cfg)), (hits_result_t{}));        // not enough mismatches
-        EXPECT_EQ(uniquify(search("CGG"_dna4     , this->index, cfg)), (hits_result_t{1, 5, 9})); // 1 mismatch
-        EXPECT_EQ(uniquify(search("ACGGACG"_dna4 , this->index, cfg)), (hits_result_t{0, 4}));    // 1 mismatch
-        EXPECT_EQ(uniquify(search("CGTCCGTA"_dna4, this->index, cfg)), (hits_result_t{1}));       // 1 mismatch
+        EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4,     this->index, cfg)), (hits_result_t{0, 4, 8})); // exact match
+        EXPECT_EQ(seqan3::uniquify(search("CGTTT"_dna4,    this->index, cfg)), (hits_result_t{}));        // not enough
+                                                                                                          //  mismatches
+        EXPECT_EQ(seqan3::uniquify(search("CGG"_dna4,      this->index, cfg)), (hits_result_t{1, 5, 9})); // 1 mismatch
+        EXPECT_EQ(seqan3::uniquify(search("ACGGACG"_dna4,  this->index, cfg)), (hits_result_t{0, 4}));    // 1 mismatch
+        EXPECT_EQ(seqan3::uniquify(search("CGTCCGTA"_dna4, this->index, cfg)), (hits_result_t{1}));       // 1 mismatch
     }
 
     {
-        configuration const cfg = max_error{total{1}, substitution{1}, insertion{0}, deletion{0}};
+        seqan3::configuration const cfg = max_error{total{1}, substitution{1}, insertion{0}, deletion{0}};
 
-        EXPECT_EQ(uniquify(search("ACGT"_dna4    , this->index, cfg)), (hits_result_t{0, 4, 8})); // exact match
-        EXPECT_EQ(uniquify(search("CGTTT"_dna4   , this->index, cfg)), (hits_result_t{}));        // not enough mismatches
-        EXPECT_EQ(uniquify(search("CGG"_dna4     , this->index, cfg)), (hits_result_t{1, 5, 9})); // 1 mismatch
-        EXPECT_EQ(uniquify(search("ACGGACG"_dna4 , this->index, cfg)), (hits_result_t{0, 4}));    // 1 mismatch
-        EXPECT_EQ(uniquify(search("CGTCCGTA"_dna4, this->index, cfg)), (hits_result_t{1}));       // 1 mismatch
+        EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4,     this->index, cfg)), (hits_result_t{0, 4, 8})); // exact match
+        EXPECT_EQ(seqan3::uniquify(search("CGTTT"_dna4,    this->index, cfg)), (hits_result_t{}));        // not enough
+                                                                                                          //  mismatches
+        EXPECT_EQ(seqan3::uniquify(search("CGG"_dna4,      this->index, cfg)), (hits_result_t{1, 5, 9})); // 1 mismatch
+        EXPECT_EQ(seqan3::uniquify(search("ACGGACG"_dna4,  this->index, cfg)), (hits_result_t{0, 4}));    // 1 mismatch
+        EXPECT_EQ(seqan3::uniquify(search("CGTCCGTA"_dna4, this->index, cfg)), (hits_result_t{1}));       // 1 mismatch
     }
 }
 
@@ -179,13 +185,13 @@ TYPED_TEST(search_test, error_configuration_types)
 
     {
         uint8_t s = 1, t = 1;
-        configuration const cfg = max_error{total{t}, substitution{s}};
-        EXPECT_EQ(uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{0, 4, 8}));
+        seqan3::configuration const cfg = max_error{total{t}, substitution{s}};
+        EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{0, 4, 8}));
     }
 
     {
-        configuration const cfg = max_error{substitution{1}};
-        EXPECT_EQ(uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{0, 4, 8}));
+        seqan3::configuration const cfg = max_error{substitution{1}};
+        EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{0, 4, 8}));
     }
 }
 
@@ -194,31 +200,31 @@ TYPED_TEST(search_test, error_insertion)
     using hits_result_t = std::vector<typename TypeParam::size_type>;
 
     {
-        configuration const cfg = max_error_rate{total{.25}, insertion{.25}};
+        seqan3::configuration const cfg = max_error_rate{total{.25}, insertion{.25}};
 
         // exact match and insertion at the beginning of the query
-        EXPECT_EQ(uniquify(search("ACGT"_dna4    , this->index, cfg)), (hits_result_t{0, 1, 4, 5, 8, 9}));
+        EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4,     this->index, cfg)), (hits_result_t{0, 1, 4, 5, 8, 9}));
         // 1 insertion
-        EXPECT_EQ(uniquify(search("CCGT"_dna4    , this->index, cfg)), (hits_result_t{1, 5, 9}));
+        EXPECT_EQ(seqan3::uniquify(search("CCGT"_dna4,     this->index, cfg)), (hits_result_t{1, 5, 9}));
         // 2 insertions
-        EXPECT_EQ(uniquify(search("ACCGGTAC"_dna4, this->index, cfg)), (hits_result_t{0, 4}));
+        EXPECT_EQ(seqan3::uniquify(search("ACCGGTAC"_dna4, this->index, cfg)), (hits_result_t{0, 4}));
         // 2 insertions necessary, only 1 allowed
-        EXPECT_EQ(uniquify(search("ACCGG"_dna4   , this->index, cfg)), (hits_result_t{}));
+        EXPECT_EQ(seqan3::uniquify(search("ACCGG"_dna4,    this->index, cfg)), (hits_result_t{}));
         // deletion necessary, not allowed
-        EXPECT_EQ(uniquify(search("ACTACGT"_dna4 , this->index, cfg)), (hits_result_t{}));
+        EXPECT_EQ(seqan3::uniquify(search("ACTACGT"_dna4,  this->index, cfg)), (hits_result_t{}));
     }
 
     {
-        configuration const cfg = max_error{total{1}, insertion{1}};
+        seqan3::configuration const cfg = max_error{total{1}, insertion{1}};
 
         // exact match and insertion at the beginning of the query
-        EXPECT_EQ(uniquify(search("ACGT"_dna4    , this->index, cfg)), (hits_result_t{0, 1, 4, 5, 8, 9}));
+        EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4,     this->index, cfg)), (hits_result_t{0, 1, 4, 5, 8, 9}));
         // 1 insertion
-        EXPECT_EQ(uniquify(search("CCGT"_dna4    , this->index, cfg)), (hits_result_t{1, 5, 9}));
+        EXPECT_EQ(seqan3::uniquify(search("CCGT"_dna4,     this->index, cfg)), (hits_result_t{1, 5, 9}));
         // 2 insertions necessary, only 1 allowed
-        EXPECT_EQ(uniquify(search("ACCGGTAC"_dna4, this->index, cfg)), (hits_result_t{}));
+        EXPECT_EQ(seqan3::uniquify(search("ACCGGTAC"_dna4, this->index, cfg)), (hits_result_t{}));
         // deletion necessary, not allowed
-        EXPECT_EQ(uniquify(search("ACTACGT"_dna4 , this->index, cfg)), (hits_result_t{}));
+        EXPECT_EQ(seqan3::uniquify(search("ACTACGT"_dna4,  this->index, cfg)), (hits_result_t{}));
     }
 }
 
@@ -227,31 +233,31 @@ TYPED_TEST(search_test, error_deletion)
     using hits_result_t = std::vector<typename TypeParam::size_type>;
 
     {
-        configuration const cfg = max_error_rate{total{.25}, deletion{.25}};
+        seqan3::configuration const cfg = max_error_rate{total{.25}, deletion{.25}};
 
         // exact match, no deletion
-        EXPECT_EQ(uniquify(search("ACGT"_dna4    , this->index, cfg)), (hits_result_t{0, 4, 8}));
+        EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4,     this->index, cfg)), (hits_result_t{0, 4, 8}));
         // not enough max errors
-        EXPECT_EQ(uniquify(search("AGT"_dna4     , this->index, cfg)), (hits_result_t{}));
+        EXPECT_EQ(seqan3::uniquify(search("AGT"_dna4,      this->index, cfg)), (hits_result_t{}));
         // one deletion (C)
-        EXPECT_EQ(uniquify(search("AGTA"_dna4    , this->index, cfg)), (hits_result_t{0, 4}));
+        EXPECT_EQ(seqan3::uniquify(search("AGTA"_dna4,     this->index, cfg)), (hits_result_t{0, 4}));
         // two deletion (C)
-        EXPECT_EQ(uniquify(search("AGTAGTAC"_dna4, this->index, cfg)), (hits_result_t{0}));
+        EXPECT_EQ(seqan3::uniquify(search("AGTAGTAC"_dna4, this->index, cfg)), (hits_result_t{0}));
         // no deletion at beginning. 0 and 4 cannot be reported
-        EXPECT_EQ(uniquify(search("CGTACGT"_dna4 , this->index, cfg)), (hits_result_t{1, 5}));
+        EXPECT_EQ(seqan3::uniquify(search("CGTACGT"_dna4,  this->index, cfg)), (hits_result_t{1, 5}));
     }
 
     {
-        configuration const cfg = max_error{total{1}, deletion{1}};
+        seqan3::configuration const cfg = max_error{total{1}, deletion{1}};
 
         // exact match, no deletion
-        EXPECT_EQ(uniquify(search("ACGT"_dna4    , this->index, cfg)), (hits_result_t{0, 4, 8}));
+        EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4,     this->index, cfg)), (hits_result_t{0, 4, 8}));
         // one deletion (C)
-        EXPECT_EQ(uniquify(search("AGTA"_dna4    , this->index, cfg)), (hits_result_t{0, 4}));
+        EXPECT_EQ(seqan3::uniquify(search("AGTA"_dna4,     this->index, cfg)), (hits_result_t{0, 4}));
         // 2 deletions necessary, only 1 allowed
-        EXPECT_EQ(uniquify(search("AGTAGTAC"_dna4, this->index, cfg)), (hits_result_t{}));
+        EXPECT_EQ(seqan3::uniquify(search("AGTAGTAC"_dna4, this->index, cfg)), (hits_result_t{}));
         // no deletion at beginning. 0 and 4 cannot be reported
-        EXPECT_EQ(uniquify(search("CGTACGT"_dna4 , this->index, cfg)), (hits_result_t{1, 5}));
+        EXPECT_EQ(seqan3::uniquify(search("CGTACGT"_dna4,  this->index, cfg)), (hits_result_t{1, 5}));
     }
 }
 
@@ -260,13 +266,14 @@ TYPED_TEST(search_test, error_levenshtein)
     using hits_result_t = std::vector<typename TypeParam::size_type>;
 
     {
-        configuration const cfg = max_error{total{1}};
-        EXPECT_EQ(uniquify(search("CCGT"_dna4, this->index, cfg)), (hits_result_t{0, 1, 4, 5, 8, 9}));
+        seqan3::configuration const cfg = max_error{total{1}};
+        EXPECT_EQ(seqan3::uniquify(search("CCGT"_dna4, this->index, cfg)), (hits_result_t{0, 1, 4, 5, 8, 9}));
     }
 
     {
-        configuration const cfg = max_error{total{2}};
-        EXPECT_EQ(uniquify(search("CCGT"_dna4, this->index, cfg)), (hits_result_t{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}));
+        seqan3::configuration const cfg = max_error{total{2}};
+        EXPECT_EQ(seqan3::uniquify(search("CCGT"_dna4, this->index, cfg)),
+                                   (hits_result_t{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}));
     }
 }
 
@@ -276,14 +283,14 @@ TYPED_TEST(search_test, error_indel_no_substitution)
 
     {
         // Match one mismatch with 1 insertion and deletion since mismatches are not allowed.
-        configuration const cfg = max_error{total{2}, deletion{2}, insertion{2}};
-        EXPECT_EQ(uniquify(search("GTACCTAC"_dna4, this->index, cfg)), (hits_result_t{2}));
+        seqan3::configuration const cfg = max_error{total{2}, deletion{2}, insertion{2}};
+        EXPECT_EQ(seqan3::uniquify(search("GTACCTAC"_dna4, this->index, cfg)), (hits_result_t{2}));
     }
 
     {
         // Enumerate a deletion and match one mismatch with 1 insertion and deletion since mismatches are not allowed.
-        configuration const cfg = max_error{total{3}, deletion{3}, insertion{3}};
-        EXPECT_EQ(uniquify(search("GTATCCTAC"_dna4, this->index, cfg)), (hits_result_t{2}));
+        seqan3::configuration const cfg = max_error{total{3}, deletion{3}, insertion{3}};
+        EXPECT_EQ(seqan3::uniquify(search("GTATCCTAC"_dna4, this->index, cfg)), (hits_result_t{2}));
     }
 }
 
@@ -292,13 +299,13 @@ TYPED_TEST(search_test, search_strategy_all)
     using hits_result_t = std::vector<typename TypeParam::size_type>;
 
     {
-        configuration const cfg = max_error{total{1}};
-        EXPECT_EQ(uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{0, 1, 4, 5, 8, 9}));
+        seqan3::configuration const cfg = max_error{total{1}};
+        EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{0, 1, 4, 5, 8, 9}));
     }
 
     {
-        configuration const cfg = max_error{total{1}} | mode{all};
-        EXPECT_EQ(uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{0, 1, 4, 5, 8, 9}));
+        seqan3::configuration const cfg = max_error{total{1}} | mode{all};
+        EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{0, 1, 4, 5, 8, 9}));
     }
 }
 
@@ -308,7 +315,7 @@ TYPED_TEST(search_test, search_strategy_best)
 
     hits_result_t possible_hits{0, 4, 8}; // any of 0, 4, 8 ... 1, 5, 9 are not best hits
     {
-        configuration const cfg = max_error{total{1}} | mode{best};
+        seqan3::configuration const cfg = max_error{total{1}} | mode{best};
 
         hits_result_t result = search("ACGT"_dna4, this->index, cfg);
         ASSERT_EQ(result.size(), 1u);
@@ -318,7 +325,7 @@ TYPED_TEST(search_test, search_strategy_best)
     }
 
     { // Find best match with 1 insertion at the end.
-        configuration const cfg = max_error{total{1}, insertion{1}} | mode{best};
+        seqan3::configuration const cfg = max_error{total{1}, insertion{1}} | mode{best};
 
         hits_result_t result = search("ACGTT"_dna4, this->index, cfg);
         ASSERT_EQ(result.size(), 1u);
@@ -326,7 +333,7 @@ TYPED_TEST(search_test, search_strategy_best)
     }
 
     {  // Find best match with a match at the end, allowing a insertion.
-        configuration const cfg = max_error{total{1}, insertion{1}} | mode{best};
+        seqan3::configuration const cfg = max_error{total{1}, insertion{1}} | mode{best};
 
         hits_result_t result = search("ACGT"_dna4, this->index, cfg);
         ASSERT_EQ(result.size(), 1u);
@@ -334,7 +341,7 @@ TYPED_TEST(search_test, search_strategy_best)
     }
 
     {  // Find best match with a deletion.
-        configuration const cfg = max_error{total{1}, deletion{1}} | mode{best};
+        seqan3::configuration const cfg = max_error{total{1}, deletion{1}} | mode{best};
 
         hits_result_t result = search("AGT"_dna4, this->index, cfg);
         ASSERT_EQ(result.size(), 1u);
@@ -342,7 +349,7 @@ TYPED_TEST(search_test, search_strategy_best)
     }
 
     { // Find best match with a match at the end, allowing a deletion.
-        configuration const cfg = max_error{total{1}, deletion{1}} | mode{best};
+        seqan3::configuration const cfg = max_error{total{1}, deletion{1}} | mode{best};
 
         hits_result_t result = search("ACGT"_dna4, this->index, cfg);
         ASSERT_EQ(result.size(), 1u);
@@ -350,7 +357,7 @@ TYPED_TEST(search_test, search_strategy_best)
     }
 
     {  // Find best match with a substitution at the end.
-        configuration const cfg = max_error{total{1}, substitution{1}} | mode{best};
+        seqan3::configuration const cfg = max_error{total{1}, substitution{1}} | mode{best};
 
         hits_result_t result = search("ACGC"_dna4, this->index, cfg);
         ASSERT_EQ(result.size(), 1u);
@@ -358,7 +365,7 @@ TYPED_TEST(search_test, search_strategy_best)
     }
 
     {  // Find best match with a match at the end, allowing a substitution.
-        configuration const cfg = max_error{total{1}, substitution{1}} | mode{best};
+        seqan3::configuration const cfg = max_error{total{1}, substitution{1}} | mode{best};
 
         hits_result_t result = search("ACGT"_dna4, this->index, cfg);
         ASSERT_EQ(result.size(), 1u);
@@ -367,7 +374,7 @@ TYPED_TEST(search_test, search_strategy_best)
 
     {  // Find best match with 2 deletions.
         hits_result_t possible_hits2d{0, 4}; // any of 0, 4 ... 1, 5 are not best hits
-        configuration const cfg = max_error{total{2}, deletion{2}} | mode{best};
+        seqan3::configuration const cfg = max_error{total{2}, deletion{2}} | mode{best};
 
         hits_result_t result = search("AGTAGT"_dna4, this->index, cfg);
         ASSERT_EQ(result.size(), 1u);
@@ -380,9 +387,10 @@ TYPED_TEST(search_test, search_strategy_all_best)
     using hits_result_t = std::vector<typename TypeParam::size_type>;
 
     {
-        configuration const cfg = max_error{total{1}} | mode{all_best};
+        seqan3::configuration const cfg = max_error{total{1}} | mode{all_best};
 
-        EXPECT_EQ(uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{0, 4, 8})); // 1, 5, 9 are not best hits
+        EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4, this->index, cfg)),
+                                   (hits_result_t{0, 4, 8})); // 1, 5, 9 are not best hits
 
         EXPECT_EQ(search("AAAA"_dna4, this->index, cfg), (hits_result_t{})); // no hit
     }
@@ -393,30 +401,32 @@ TYPED_TEST(search_test, search_strategy_strata)
     using hits_result_t = std::vector<typename TypeParam::size_type>;
 
     {
-        configuration const cfg = max_error{total{1}} | mode{strata{0}};
-        EXPECT_EQ(uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{0, 4, 8}));
+        seqan3::configuration const cfg = max_error{total{1}} | mode{strata{0}};
+        EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{0, 4, 8}));
     }
 
     {
-        configuration const cfg = max_error{total{1}} | mode{strata{1}};
-        EXPECT_EQ(uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{0, 1, 4, 5, 8, 9}));
+        seqan3::configuration const cfg = max_error{total{1}} | mode{strata{1}};
+        EXPECT_EQ(seqan3::uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{0, 1, 4, 5, 8, 9}));
     }
 
     {
-        configuration const cfg = max_error{total{1}} | mode{strata{1}};
+        seqan3::configuration const cfg = max_error{total{1}} | mode{strata{1}};
         EXPECT_EQ(search("AAAA"_dna4, this->index, cfg), (hits_result_t{})); // no hit
     }
 
     // {
     //     // best hit ACGT with 1 error, i.e. 1+1
-    //     configuration const cfg = max_total_error{1} | strategy_strata{1};
-    //     EXPECT_EQ(uniquify(search(this->index, "CCGT"_dna4, cfg)), (hits_result_t{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}));
+    //     seqan3::configuration const cfg = max_total_error{1} | strategy_strata{1};
+    //     EXPECT_EQ(seqan3::uniquify(search(this->index, "CCGT"_dna4, cfg)),
+    //                                (hits_result_t{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}));
     // }
 
     // {
     //     // best hit ACGT with 1 error, i.e. 1+1
-    //     configuration const cfg = max_total_error{1} | strategy_strata{1};
-    //     EXPECT_EQ(uniquify(search(this->index, "CCGT"_dna4, cfg)), (hits_result_t{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}));
+    //     seqan3::configuration const cfg = max_total_error{1} | strategy_strata{1};
+    //     EXPECT_EQ(seqan3::uniquify(search(this->index, "CCGT"_dna4, cfg)),
+    //                                (hits_result_t{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}));
     // }
 }
 
@@ -426,8 +436,8 @@ TYPED_TEST(search_string_test, error_free_string)
 
     {
         // successful and unsuccesful exact search without cfg
-        EXPECT_EQ(uniquify(search("at"s, this->index)), (hits_result_t{14, 18}));
-        EXPECT_EQ(uniquify(search("Jon"s, this->index)), (hits_result_t{}));
+        EXPECT_EQ(seqan3::uniquify(search("at"s, this->index)), (hits_result_t{14, 18}));
+        EXPECT_EQ(seqan3::uniquify(search("Jon"s, this->index)), (hits_result_t{}));
     }
 }
 
@@ -437,8 +447,8 @@ TYPED_TEST(search_string_test, error_free_raw)
 
     {
         // successful and unsuccesful exact search without cfg
-        EXPECT_EQ(uniquify(search("at", this->index)), (hits_result_t{14, 18}));
-        EXPECT_EQ(uniquify(search("Jon", this->index)), (hits_result_t{}));
+        EXPECT_EQ(seqan3::uniquify(search("at", this->index)), (hits_result_t{14, 18}));
+        EXPECT_EQ(seqan3::uniquify(search("Jon", this->index)), (hits_result_t{}));
     }
 }
 
@@ -447,14 +457,14 @@ TYPED_TEST(search_string_test, multiple_queries_string)
     using hits_result_t = std::vector<std::vector<typename TypeParam::size_type>>;
     std::vector<std::string> const queries{"at", "Jon"};
 
-    EXPECT_EQ(uniquify(search(queries, this->index)), (hits_result_t{{14, 18}, {}})); // 2 and 0 hits
+    EXPECT_EQ(seqan3::uniquify(search(queries, this->index)), (hits_result_t{{14, 18}, {}})); // 2 and 0 hits
 }
 
 TYPED_TEST(search_string_test, multiple_queries_raw)
 {
     using hits_result_t = std::vector<std::vector<typename TypeParam::size_type>>;
 
-    EXPECT_EQ(uniquify(search({"at", "Jon"}, this->index)), (hits_result_t{{14, 18}, {}})); // 2 and 0 hits
+    EXPECT_EQ(seqan3::uniquify(search({"at", "Jon"}, this->index)), (hits_result_t{{14, 18}, {}})); // 2 and 0 hits
 }
 
 // TYPED_TEST(search_test, return_iterator_index)

--- a/test/unit/std/concept/comparison_test.cpp
+++ b/test/unit/std/concept/comparison_test.cpp
@@ -14,8 +14,6 @@
 
 #include "auxiliary.hpp"
 
-using namespace seqan3;
-
 TEST(comparison_concepts, weakly_equality_comparable_with)
 {
     EXPECT_TRUE((seqan3::detail::weakly_equality_comparable_with<type_a, type_b>));

--- a/test/unit/std/concept/core_language_test.cpp
+++ b/test/unit/std/concept/core_language_test.cpp
@@ -14,8 +14,6 @@
 
 #include "auxiliary.hpp"
 
-using namespace seqan3;
-
 TEST(core_language_concepts, same_as)
 {
     EXPECT_TRUE((std::same_as<int, int>));
@@ -30,16 +28,16 @@ TEST(core_language_concepts, derived_from)
 
 TEST(implicitly_convertible_to, basic)
 {
-    EXPECT_TRUE((implicitly_convertible_to<type_b, type_c>));
-    EXPECT_TRUE((!implicitly_convertible_to<type_c, type_b>));
-    EXPECT_TRUE((!implicitly_convertible_to<type_a, type_c>));
+    EXPECT_TRUE((seqan3::implicitly_convertible_to<type_b, type_c>));
+    EXPECT_TRUE((!seqan3::implicitly_convertible_to<type_c, type_b>));
+    EXPECT_TRUE((!seqan3::implicitly_convertible_to<type_a, type_c>));
 }
 
 TEST(explicitly_convertible_to, basic)
 {
-    EXPECT_TRUE((explicitly_convertible_to<type_b, type_c>));
-    EXPECT_TRUE((!explicitly_convertible_to<type_c, type_b>));
-    EXPECT_TRUE((explicitly_convertible_to<type_a, type_c>));
+    EXPECT_TRUE((seqan3::explicitly_convertible_to<type_b, type_c>));
+    EXPECT_TRUE((!seqan3::explicitly_convertible_to<type_c, type_b>));
+    EXPECT_TRUE((seqan3::explicitly_convertible_to<type_a, type_c>));
 }
 
 TEST(core_language_concepts, convertible_to)

--- a/test/unit/std/concept/object_test.cpp
+++ b/test/unit/std/concept/object_test.cpp
@@ -14,8 +14,6 @@
 
 #include "auxiliary.hpp"
 
-using namespace seqan3;
-
 TEST(object_concepts, destructible)
 {
     EXPECT_TRUE((std::destructible<type_a>));


### PR DESCRIPTION
& replace std::endl with ‘\n‘.

Use the shorter spelling seqan3::dna4_vector instead of std::vector<seqan3::dna4> (likewise aa27_vector.

Resolves #1552.