### PR TITLE
[FIX] clang10: struct / class should be the same in all declarations

### DIFF
--- a/include/seqan3/core/char_operations/predicate_detail.hpp
+++ b/include/seqan3/core/char_operations/predicate_detail.hpp
@@ -91,7 +91,7 @@ inline const std::string condition_message_v
 
 //!\cond
 template <typename condition_t>
-class char_predicate_base;
+struct char_predicate_base;
 //!\endcond
 
 /*!\interface seqan3::detail::char_predicate <>


### PR DESCRIPTION
```
seqan3/include/seqan3/core/char_operations/predicate_detail.hpp:162:1: error: 'char_predicate_base' defined as a struct template here but previously declared as a class template; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Werror,-Wmismatched-tags]
struct char_predicate_base
^
seqan3/include/seqan3/core/char_operations/predicate_detail.hpp:94:1: note: did you mean struct here?
class char_predicate_base;
^~~~~
struct
```

Part of `clang10-support` #1556 