### PR TITLE
[DOC] Fixes in doc

### DIFF
--- a/include/seqan3/search/configuration/all.hpp
+++ b/include/seqan3/search/configuration/all.hpp
@@ -52,11 +52,11 @@
  * types cannot be printed within the static assert, but the following table shows which combinations are possible.
  * In general, the same configuration element cannot occur more than once inside of a configuration specification.
  *
- * | **Config**                                                  | **0** | **1** | **2** | **3** |
- * | ------------------------------------------------------------|-------|-------|-------|-------|
- * | \ref seqan3::search_cfg::max_error  "0: Max error"          |   ❌   |   ❌   |   ✅   |  ✅    |  ✅    |
- * | \ref seqan3::search_cfg::max_error_rate "1: Max error rate" |   ❌   |   ❌   |   ✅   |  ✅    |  ✅    |
- * | \ref seqan3::search_cfg::output "2: Output"                 |   ✅    |   ✅    |   ❌   |  ✅    |  ✅    |
- * | \ref seqan3::search_cfg::mode "3: Mode"                     |   ✅    |   ✅    |   ✅   |  ❌    |  ✅    |
- * | \ref seqan3::search_cfg::parallel "4: Parallel"             |   ✅    |   ✅    |   ✅   |  ✅    |  ❌    |
+ * | **Config**                                                  | **0** | **1** | **2** | **3** | **4** |
+ * | ------------------------------------------------------------|-------|-------|-------|-------|-------|
+ * | \ref seqan3::search_cfg::max_error  "0: Max error"          |  ❌   |  ❌   |  ✅   |  ✅   |  ✅   |
+ * | \ref seqan3::search_cfg::max_error_rate "1: Max error rate" |  ❌   |  ❌   |  ✅   |  ✅   |  ✅   |
+ * | \ref seqan3::search_cfg::output "2: Output"                 |  ✅   |  ✅   |  ❌   |  ✅   |  ✅   |
+ * | \ref seqan3::search_cfg::mode "3: Mode"                     |  ✅   |  ✅   |  ✅   |  ❌   |  ✅   |
+ * | \ref seqan3::search_cfg::parallel "4: Parallel"             |  ✅   |  ✅   |  ✅   |  ✅   |  ❌   |
  */

--- a/include/seqan3/search/configuration/detail.hpp
+++ b/include/seqan3/search/configuration/detail.hpp
@@ -27,13 +27,13 @@ namespace seqan3::detail
  * \details
  *
  * The seqan3::detail::search_config_id used to identify a specific search configuration element independent of
- * it's concrete type and position within the seqan3::search_cfg::search_configuration object.
+ * its concrete type and position within the \ref seqan3::search_cfg "search configuration object".
  * Thus one can access the value of the corresponding configuration element via the special get interface.
  *
  * ### Example
  *
  * ```cpp
- * search_cfg::search_configuration cfg = search_cfg::max_total_errors(3);
+ * search_cfg cfg = search_cfg::max_total_errors(3);
  * auto max_total_errors = get<search_cfg::id::max_total_errors>(cfg);  // max_total_errors = 3;
  * ```
  */

--- a/include/seqan3/search/configuration/max_error.hpp
+++ b/include/seqan3/search/configuration/max_error.hpp
@@ -28,7 +28,8 @@ namespace seqan3::search_cfg
 /*!\brief A configuration element for the maximum number of errors across all error types (mismatches, insertions,
  *        deletions). This is an upper bound of errors independent from error numbers of specific error types.
  * \ingroup search_configuration
- * \details An insertion corresponds to a base inserted into the query that does not occur in the text at the position,
+ * \details A mismatch corresponds to diverging bases between text and query for a certain position.
+ *          An insertion corresponds to a base inserted into the query that does not occur in the text at the position,
  *          a deletion corresponds to a base deleted from the query sequence that does occur in the indexed text.
  *          Deletions at the beginning and at the end of the sequence are not considered during a search.
  */

--- a/include/seqan3/search/configuration/max_error_rate.hpp
+++ b/include/seqan3/search/configuration/max_error_rate.hpp
@@ -30,7 +30,8 @@ namespace seqan3::search_cfg
  *        (mismatches, insertions, deletions). This is an upper bound of errors independent from error rates of
  *        specific error types.
  * \ingroup search_configuration
- * \details An insertion corresponds to a base inserted into the query that does not occur in the text at the position,
+ * \details A mismatch corresponds to diverging bases between text and query for a certain position.
+ *          An insertion corresponds to a base inserted into the query that does not occur in the text at the position,
  *          a deletion corresponds to a base deleted from the query sequence that does occur in the indexed text.
  *          Deletions at the beginning and at the end of the sequence are not considered during a search.
  */

--- a/include/seqan3/search/configuration/mode.hpp
+++ b/include/seqan3/search/configuration/mode.hpp
@@ -50,7 +50,7 @@ inline detail::search_mode_best constexpr best;
 
 /*!\brief Configuration element to receive all hits with the best number of errors plus the strata value.
  *        A strong type of underlying type `uint8_t` that represents the number or errors for strata.
- *        All hits are found with the fewest numbererrors plus 'value'.
+ *        All hits are found with the fewest number of errors plus 'value'.
  * \ingroup search_configuration
  * \tparam value_t The underlying type.
  */

--- a/include/seqan3/search/fm_index/all.hpp
+++ b/include/seqan3/search/fm_index/all.hpp
@@ -38,7 +38,7 @@
  *
  * Index Cursors are lightweight objects, i.e. they are cheap to copy.
  *
- * Note that although the SeqAn index cursor, although having similar behaviour, don't model any of the standard library
+ * Note that the SeqAn index cursor, although having similar behaviour, doesn't model any of the standard library
  * iterator concepts, not even std::input_or_output_iterator.
  *
  */

--- a/include/seqan3/search/fm_index/bi_fm_index.hpp
+++ b/include/seqan3/search/fm_index/bi_fm_index.hpp
@@ -33,13 +33,13 @@ namespace seqan3
  * \tparam alphabet_t        The alphabet type; must model seqan3::semialphabet.
  * \tparam text_layout_mode_ Indicates whether this index works on a text collection or a single text.
  *                           See seqan3::text_layout.
- * \tparam sdsl_index_type_  The type of the underlying SDSL index, must model seqan3::sdsl_index.
+ * \tparam sdsl_index_type_  The type of the underlying SDSL index, must model seqan3::detail::sdsl_index.
  * \details
  *
  * The seqan3::bi_fm_index is a fast and space-efficient bidirectional string index to search strings and
  * collections of strings.
- * In general, we recommend to favour the seqan3::bi_fm_index over the seqan3::fm_index if you want to allow multiple errors when
- * searching.
+ * In general, we recommend to favour the seqan3::bi_fm_index over the unidirectional seqan3::fm_index if you want to
+ * allow multiple errors when searching.
  *
  * ### General information
  *

--- a/include/seqan3/search/fm_index/fm_index.hpp
+++ b/include/seqan3/search/fm_index/fm_index.hpp
@@ -48,7 +48,7 @@ class bi_fm_index_cursor;
  *
  * ### Running time / Space consumption
  *
- * \f$SAMPLING\_RATE = 16\f$
+ * \f$SAMPLING\_RATE = 16\f$ \n
  * \f$\Sigma\f$: alphabet_size<alphabet_type> where alphabet_type is the seqan3 alphabet type (e.g. seqan3::dna4 has an
  *               alphabet size of 4).
  *


### PR DESCRIPTION
Some small fixes for the search documentation, some spelling errors, some formatting (table correctly aligned), some missing definitions added and death links corrected.