### PR TITLE
[MISC] aligned_sequence_builder should use std::tuple instead of std::pair

### DIFF
--- a/include/seqan3/alignment/matrix/detail/aligned_sequence_builder.hpp
+++ b/include/seqan3/alignment/matrix/detail/aligned_sequence_builder.hpp
@@ -68,7 +68,7 @@ struct make_aligned_sequence_type
 /*!\brief Builds the alignment for a given pair of sequences and the respective trace.
  * \ingroup alignment_matrix
  * \tparam fst_sequence_t The first sequence of the pairwise alignment; must model std::ranges::viewable_range.
- * \tparam sec_sequence_t The first sequence of the pairwise alignment; must model std::ranges::viewable_range.
+ * \tparam sec_sequence_t The second sequence of the pairwise alignment; must model std::ranges::viewable_range.
  *
  * \details
  *
@@ -100,6 +100,8 @@ private:
                   "sec_aligned_t is required to model seqan3::aligned_sequence!");
 
 public:
+    //!\brief The pairwise alignment type of the two sequences.
+    using alignment_type = std::tuple<fst_aligned_t, sec_aligned_t>;
 
     //!\brief The result type when building the aligned sequences.
     struct [[nodiscard]] result_type
@@ -110,7 +112,7 @@ public:
         std::pair<size_t, size_t> second_sequence_slice_positions{};
         //!\brief The alignment over the slices of the first and second sequence, which corresponds to the given
         //!\      trace path.
-        std::pair<fst_aligned_t, sec_aligned_t> alignment{};
+        alignment_type alignment{};
     };
 
     /*!\name Constructors, destructor and assignment
@@ -173,13 +175,17 @@ public:
         std::tie(res.first_sequence_slice_positions.first, res.second_sequence_slice_positions.first) =
             std::pair<size_t, size_t>{trace_it.coordinate()};
 
-        assign_unaligned(res.alignment.first, fst_rng  | views::slice(res.first_sequence_slice_positions.first,
-                                                                      res.first_sequence_slice_positions.second));
-        assign_unaligned(res.alignment.second, sec_rng | views::slice(res.second_sequence_slice_positions.first,
-                                                                      res.second_sequence_slice_positions.second));
+        assign_unaligned(std::get<0>(res.alignment),
+                         fst_rng | views::slice(res.first_sequence_slice_positions.first,
+                                                res.first_sequence_slice_positions.second));
+        assign_unaligned(std::get<1>(res.alignment),
+                         sec_rng | views::slice(res.second_sequence_slice_positions.first,
+                                                res.second_sequence_slice_positions.second));
 
         // Now we need to insert the values.
-        fill_aligned_sequence(trace_segments | std::views::reverse, res.alignment.first, res.alignment.second);
+        fill_aligned_sequence(trace_segments | std::views::reverse,
+                              std::get<0>(res.alignment),
+                              std::get<1>(res.alignment));
 
         return res;
     }

--- a/test/unit/alignment/matrix/detail/aligned_sequence_builder_test.cpp
+++ b/test/unit/alignment/matrix/detail/aligned_sequence_builder_test.cpp
@@ -101,8 +101,8 @@ TYPED_TEST(aligned_sequence_builder_fixture, build_from_2_3)
 
     EXPECT_EQ(first_sequence_slice_positions, (std::pair<size_t, size_t>{0, 3}));
     EXPECT_EQ(second_sequence_slice_positions, (std::pair<size_t, size_t>{0, 2}));
-    EXPECT_EQ(alignment.first  | views::to_char | views::to<std::string>, std::string{"--ACG"});
-    EXPECT_EQ(alignment.second | views::to_char | views::to<std::string>, std::string{"AG---"});
+    EXPECT_EQ(std::get<0>(alignment) | views::to_char | views::to<std::string>, std::string{"--ACG"});
+    EXPECT_EQ(std::get<1>(alignment) | views::to_char | views::to<std::string>, std::string{"AG---"});
 }
 
 TYPED_TEST(aligned_sequence_builder_fixture, build_from_2_2)
@@ -112,8 +112,8 @@ TYPED_TEST(aligned_sequence_builder_fixture, build_from_2_2)
 
     EXPECT_EQ(first_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 2u}));
     EXPECT_EQ(second_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 2u}));
-    EXPECT_EQ(alignment.first  | views::to_char | views::to<std::string>, std::string{"AC"});
-    EXPECT_EQ(alignment.second | views::to_char | views::to<std::string>, std::string{"AG"});
+    EXPECT_EQ(std::get<0>(alignment) | views::to_char | views::to<std::string>, std::string{"AC"});
+    EXPECT_EQ(std::get<1>(alignment) | views::to_char | views::to<std::string>, std::string{"AG"});
 }
 
 TYPED_TEST(aligned_sequence_builder_fixture, build_from_2_1)
@@ -123,8 +123,8 @@ TYPED_TEST(aligned_sequence_builder_fixture, build_from_2_1)
 
     EXPECT_EQ(first_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 1u}));
     EXPECT_EQ(second_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 2u}));
-    EXPECT_EQ(alignment.first  | views::to_char | views::to<std::string>, std::string{"A--"});
-    EXPECT_EQ(alignment.second | views::to_char | views::to<std::string>, std::string{"-AG"});
+    EXPECT_EQ(std::get<0>(alignment) | views::to_char | views::to<std::string>, std::string{"A--"});
+    EXPECT_EQ(std::get<1>(alignment) | views::to_char | views::to<std::string>, std::string{"-AG"});
 }
 
 TYPED_TEST(aligned_sequence_builder_fixture, build_from_2_0)
@@ -134,8 +134,8 @@ TYPED_TEST(aligned_sequence_builder_fixture, build_from_2_0)
 
     EXPECT_EQ(first_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 0u}));
     EXPECT_EQ(second_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 2u}));
-    EXPECT_EQ(alignment.first  | views::to_char | views::to<std::string>, std::string{"--"});
-    EXPECT_EQ(alignment.second | views::to_char | views::to<std::string>, std::string{"AG"});
+    EXPECT_EQ(std::get<0>(alignment) | views::to_char | views::to<std::string>, std::string{"--"});
+    EXPECT_EQ(std::get<1>(alignment) | views::to_char | views::to<std::string>, std::string{"AG"});
 }
 
 TYPED_TEST(aligned_sequence_builder_fixture, build_from_1_3)
@@ -145,8 +145,8 @@ TYPED_TEST(aligned_sequence_builder_fixture, build_from_1_3)
 
     EXPECT_EQ(first_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 3u}));
     EXPECT_EQ(second_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 1u}));
-    EXPECT_EQ(alignment.first  | views::to_char | views::to<std::string>, std::string{"ACG"});
-    EXPECT_EQ(alignment.second | views::to_char | views::to<std::string>, std::string{"--A"});
+    EXPECT_EQ(std::get<0>(alignment) | views::to_char | views::to<std::string>, std::string{"ACG"});
+    EXPECT_EQ(std::get<1>(alignment) | views::to_char | views::to<std::string>, std::string{"--A"});
 }
 
 TYPED_TEST(aligned_sequence_builder_fixture, build_from_1_2)
@@ -156,8 +156,8 @@ TYPED_TEST(aligned_sequence_builder_fixture, build_from_1_2)
 
     EXPECT_EQ(first_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 2u}));
     EXPECT_EQ(second_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 1u}));
-    EXPECT_EQ(alignment.first  | views::to_char | views::to<std::string>, std::string{"-AC"});
-    EXPECT_EQ(alignment.second | views::to_char | views::to<std::string>, std::string{"A--"});
+    EXPECT_EQ(std::get<0>(alignment) | views::to_char | views::to<std::string>, std::string{"-AC"});
+    EXPECT_EQ(std::get<1>(alignment) | views::to_char | views::to<std::string>, std::string{"A--"});
 }
 
 TYPED_TEST(aligned_sequence_builder_fixture, build_from_1_1)
@@ -167,8 +167,8 @@ TYPED_TEST(aligned_sequence_builder_fixture, build_from_1_1)
 
     EXPECT_EQ(first_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 1u}));
     EXPECT_EQ(second_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 1u}));
-    EXPECT_EQ(alignment.first  | views::to_char | views::to<std::string>, std::string{"A"});
-    EXPECT_EQ(alignment.second | views::to_char | views::to<std::string>, std::string{"A"});
+    EXPECT_EQ(std::get<0>(alignment) | views::to_char | views::to<std::string>, std::string{"A"});
+    EXPECT_EQ(std::get<1>(alignment) | views::to_char | views::to<std::string>, std::string{"A"});
 }
 
 TYPED_TEST(aligned_sequence_builder_fixture, build_from_1_0)
@@ -178,8 +178,8 @@ TYPED_TEST(aligned_sequence_builder_fixture, build_from_1_0)
 
     EXPECT_EQ(first_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 0u}));
     EXPECT_EQ(second_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 1u}));
-    EXPECT_EQ(alignment.first  | views::to_char | views::to<std::string>, std::string{"-"});
-    EXPECT_EQ(alignment.second | views::to_char | views::to<std::string>, std::string{"A"});
+    EXPECT_EQ(std::get<0>(alignment) | views::to_char | views::to<std::string>, std::string{"-"});
+    EXPECT_EQ(std::get<1>(alignment) | views::to_char | views::to<std::string>, std::string{"A"});
 }
 
 TYPED_TEST(aligned_sequence_builder_fixture, build_from_0_3)
@@ -189,8 +189,8 @@ TYPED_TEST(aligned_sequence_builder_fixture, build_from_0_3)
 
     EXPECT_EQ(first_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 3u}));
     EXPECT_EQ(second_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 0u}));
-    EXPECT_EQ(alignment.first  | views::to_char | views::to<std::string>, std::string{"ACG"});
-    EXPECT_EQ(alignment.second | views::to_char | views::to<std::string>, std::string{"---"});
+    EXPECT_EQ(std::get<0>(alignment) | views::to_char | views::to<std::string>, std::string{"ACG"});
+    EXPECT_EQ(std::get<1>(alignment) | views::to_char | views::to<std::string>, std::string{"---"});
 }
 
 TYPED_TEST(aligned_sequence_builder_fixture, build_from_0_2)
@@ -200,8 +200,8 @@ TYPED_TEST(aligned_sequence_builder_fixture, build_from_0_2)
 
     EXPECT_EQ(first_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 2u}));
     EXPECT_EQ(second_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 0u}));
-    EXPECT_EQ(alignment.first  | views::to_char | views::to<std::string>, std::string{"AC"});
-    EXPECT_EQ(alignment.second | views::to_char | views::to<std::string>, std::string{"--"});
+    EXPECT_EQ(std::get<0>(alignment) | views::to_char | views::to<std::string>, std::string{"AC"});
+    EXPECT_EQ(std::get<1>(alignment) | views::to_char | views::to<std::string>, std::string{"--"});
 }
 
 TYPED_TEST(aligned_sequence_builder_fixture, build_from_0_1)
@@ -211,8 +211,8 @@ TYPED_TEST(aligned_sequence_builder_fixture, build_from_0_1)
 
     EXPECT_EQ(first_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 1u}));
     EXPECT_EQ(second_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 0u}));
-    EXPECT_EQ(alignment.first  | views::to_char | views::to<std::string>, std::string{"A"});
-    EXPECT_EQ(alignment.second | views::to_char | views::to<std::string>, std::string{"-"});
+    EXPECT_EQ(std::get<0>(alignment) | views::to_char | views::to<std::string>, std::string{"A"});
+    EXPECT_EQ(std::get<1>(alignment) | views::to_char | views::to<std::string>, std::string{"-"});
 }
 
 TYPED_TEST(aligned_sequence_builder_fixture, build_from_0_0)
@@ -222,8 +222,8 @@ TYPED_TEST(aligned_sequence_builder_fixture, build_from_0_0)
 
     EXPECT_EQ(first_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 0u}));
     EXPECT_EQ(second_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 0u}));
-    EXPECT_EQ(alignment.first  | views::to_char | views::to<std::string>, std::string{""});
-    EXPECT_EQ(alignment.second | views::to_char | views::to<std::string>, std::string{""});
+    EXPECT_EQ(std::get<0>(alignment) | views::to_char | views::to<std::string>, std::string{""});
+    EXPECT_EQ(std::get<1>(alignment) | views::to_char | views::to<std::string>, std::string{""});
 }
 
 TYPED_TEST(aligned_sequence_builder_fixture, both_empty)
@@ -238,8 +238,8 @@ TYPED_TEST(aligned_sequence_builder_fixture, both_empty)
 
     EXPECT_EQ(first_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 0u}));
     EXPECT_EQ(second_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 0u}));
-    EXPECT_EQ(alignment.first  | views::to_char | views::to<std::string>, std::string{""});
-    EXPECT_EQ(alignment.second | views::to_char | views::to<std::string>, std::string{""});
+    EXPECT_EQ(std::get<0>(alignment) | views::to_char | views::to<std::string>, std::string{""});
+    EXPECT_EQ(std::get<1>(alignment) | views::to_char | views::to<std::string>, std::string{""});
 }
 
 TYPED_TEST(aligned_sequence_builder_fixture, first_empty)
@@ -253,8 +253,8 @@ TYPED_TEST(aligned_sequence_builder_fixture, first_empty)
 
     EXPECT_EQ(first_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 0u}));
     EXPECT_EQ(second_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 2u}));
-    EXPECT_EQ(alignment.first  | views::to_char | views::to<std::string>, std::string{"--"});
-    EXPECT_EQ(alignment.second | views::to_char | views::to<std::string>, std::string{"AG"});
+    EXPECT_EQ(std::get<0>(alignment) | views::to_char | views::to<std::string>, std::string{"--"});
+    EXPECT_EQ(std::get<1>(alignment) | views::to_char | views::to<std::string>, std::string{"AG"});
 }
 
 TYPED_TEST(aligned_sequence_builder_fixture, second_empty)
@@ -268,6 +268,6 @@ TYPED_TEST(aligned_sequence_builder_fixture, second_empty)
 
     EXPECT_EQ(first_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 3u}));
     EXPECT_EQ(second_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 0u}));
-    EXPECT_EQ(alignment.first  | views::to_char | views::to<std::string>, std::string{"ACG"});
-    EXPECT_EQ(alignment.second | views::to_char | views::to<std::string>, std::string{"---"});
+    EXPECT_EQ(std::get<0>(alignment) | views::to_char | views::to<std::string>, std::string{"ACG"});
+    EXPECT_EQ(std::get<1>(alignment) | views::to_char | views::to<std::string>, std::string{"---"});
 }


### PR DESCRIPTION
One step to fix issue #1598.

The sequence builder uses internally a pair to represent a sequence alignment that will be implicitly converted to a std::tuple in the final returned result.