### PR TITLE
[DOC] Use consistent naming/numbering of assignments in tutorial

### DIFF
--- a/doc/tutorial/alignment_file/index.md
+++ b/doc/tutorial/alignment_file/index.md
@@ -144,7 +144,7 @@ so the seqan3::record object has three tuple elements that are decomposed using 
 
 Note that this is possible for all SeqAn file objects.
 
-\assignment{Exercise: Accumulating mapping qualities}
+\assignment{Assignment 1: Accumulating mapping qualities}
 
 Let's assume we want to compute the average mapping quality of a SAM file.
 
@@ -229,7 +229,7 @@ You can pass reference ids and reference sequences as additional constructor par
 \snippet doc/tutorial/alignment_file/alignment_file_snippets.cpp alignments_with_ref
 \snippet doc/tutorial/alignment_file/alignment_file_snippets.cpp main_end
 
-\assignment{Exercise: Combining sequence and alignment files}
+\assignment{Assignment 2: Combining sequence and alignment files}
 
 Read in the following reference sequence FASTA file (see the sequence file tutorial if you need a remainder):
 
@@ -291,7 +291,7 @@ For this purpose, you can also select specific fields by giving an additional se
 Note that this only works because in the SAM format **all fields are optional**.
 So if we provide less fields when writing, default values are printed.
 
-\assignment{Exercise: Writing id and sequence information}
+\assignment{Assignment 3: Writing id and sequence information}
 
 Write a small program that writes the following read ids + sequences:
 

--- a/doc/tutorial/alphabet/index.md
+++ b/doc/tutorial/alphabet/index.md
@@ -9,7 +9,7 @@ After completion, you will be able to use the alphabets inside of STL containers
 \tutorial_head{Easy, 45 min, \ref setup, None}
 
 The links on this page mostly point straight into the API documentation which you should use as a reference.
-The code examples and exercises are designed to provide some practical experience with our interface
+The code examples and assignments are designed to provide some practical experience with our interface
 as well as a code basis for your own program development.
 
 [TOC]
@@ -112,13 +112,13 @@ equality and inequality of two values can be tested with `==` and `!=`.
 
 ## Example
 
-To wrap up this section on the nucleotide alphabet, the following exercise lets you
+To wrap up this section on the nucleotide alphabet, the following assignment lets you
 practise the use of a SeqAn alphabet and its related functions.
 It will also show you a handy advantage of using a vector over an alphabet instead
 of using `std::string`: The rank representation can be used straight as an array
 index (opposed to using a map with logarithmic access times, for example).
 
-\assignment{Excercise: GC content of a sequence}
+\assignment{Assignment 1: GC content of a sequence}
 An important property of DNA and RNA sequences is the *GC content*,
 which is the percentage of nucleobases that are either Guanine or Cytosine.
 Given the nucleotide counts \f$n_A\f$, \f$n_T\f$, \f$n_G\f$, \f$n_C\f$ the GC content \f$c\f$ is calculated as

--- a/doc/tutorial/concepts/index.md
+++ b/doc/tutorial/concepts/index.md
@@ -165,7 +165,7 @@ But as soon as we introduce another overload, the compiler will pick the "best" 
 
 \include doc/tutorial/concepts/overloading2.cpp
 
-\assignment{Exercise: Static polymorphism with alphabets I}
+\assignment{Assignment 1: Static polymorphism with alphabets I}
 Write a small program, similar to the one above with the following "skeleton":
 ```cpp
 // which includes?
@@ -195,7 +195,7 @@ Try calling `print` with a different type, e.g. `int` to make sure that it does.
 \include doc/tutorial/concepts/overloading_solution1.cpp
 \endsolution
 
-\assignment{Exercise: Static polymorphism with alphabets II}
+\assignment{Assignment 2: Static polymorphism with alphabets II}
 Adapt your previous solution to handle nucleotides different from the rest. For nucleotides it should print,
 both, the value and its complement.
 \endassignment
@@ -282,7 +282,7 @@ static_assert(seqan3::validator<custom_validator>);
 To formally satisfy the requirements, your functions don't need the correct behaviour, yet.
 Only the signatures need to be fully specified.
 
-\assignment{Exercise: Custom validator I}
+\assignment{Assignment 3: Custom validator I}
 Implement enough of the above mentioned `struct custom_validator` for it to model seqan3::validator and pass
 the check. You can use an empty `main()`-function for now.
 \endassignment
@@ -303,7 +303,7 @@ It should print "Yeah!" for the arguments `-i 0`, `-i 4`, or `-i 144`; and/or `-
 
 It should fail for the arguments `-i 3`; and/or `-j 144` or `-j 3`.
 
-\assignment{Exercise: Custom validator II}
+\assignment{Assignment 4: Custom validator II}
 Implement your validator fully, i.e. make it throw seqan3::validation_error if the number provided is not a
 square.
 Also give a nice description for the help page.

--- a/doc/tutorial/introduction/index.md
+++ b/doc/tutorial/introduction/index.md
@@ -41,7 +41,7 @@ However, the debug stream provides convenient output for SeqAn's types as well a
 (e.g. std::vector), which is especially helpful when you debug or develop your program
 (that's where the name originates).
 
-\assignment{Exercise: Debug stream}
+\assignment{Assignment 1: Debug stream}
 Write a program that creates a std::vector of type `int` and initialise the vector with a few values.
 Then print the vector with seqan3::debug_stream. Does your program also work with std::cerr?
 \endassignment
@@ -50,9 +50,9 @@ Then print the vector with seqan3::debug_stream. Does your program also work wit
 \endsolution
 
 \note
-This is an exercise with solution. You will find exercises in the tutorials to practise the discussed contents.
+This is an assignment with solution. You will find assignments in the tutorials to practise the discussed contents.
 We believe that programming them will help you to memorise better and makes the tutorials more interesting and
-interactive. The solutions provide the intended use; but often there are multiple ways to solve an exercise,
+interactive. The solutions provide the intended use; but often there are multiple ways to solve an assignment,
 so don't worry too much if your solution is different from ours.
 
 # Parse command line arguments
@@ -121,7 +121,7 @@ ACGTGATG
 AGTGATACT
 ~~~
 
-\assignment{Exercise: Read a FastA file}
+\assignment{Assignment 2: Read a FastA file}
 Combine the code from above to read a FastA file and store its sequences in a std::vector of type seqan3::dna5_vector
 (which is a common DNA sequence type in SeqAn). Use the argument parser for obtaining the filename as command line
 argument to your program (e.g. call `./myprogram seq.fasta`).

--- a/doc/tutorial/ranges/index.md
+++ b/doc/tutorial/ranges/index.md
@@ -140,7 +140,7 @@ the drop adaptor and a combined view object is returned.
 Note that accessing the 0th element of the view is still lazy, determining which element it maps to happens at the time
 of access.
 
-\assignment{Exercise: Fun with views I}
+\assignment{Assignment 1: Fun with views I}
 Look up the documentation of std::views::transform and std::views::filter.
 Both take a invocable object as parameter, e.g. a lambda function.
 std::views::transform applies the lambda on each element in the underlying range and std::views::filter
@@ -184,8 +184,8 @@ are not read-only**:
 
 \snippet doc/tutorial/ranges/range_snippets.cpp assign_through
 
-\assignment{Exercise: Fun with views II}
-Have a look at the solution to the previous exercise (filter+transform).
+\assignment{Assignment 2: Fun with views II}
+Have a look at the solution to the previous assignment (filter+transform).
 Which of the following concepts do you think `v` models?
 
 | Concept                          | yes/no? |
@@ -237,7 +237,7 @@ But SeqAn3 also provides some general purpose views.
 Have a look at the \link views views-submodule \endlink to get an overview of SeqAn's views and also read through the
 detailed description on that page now that you had a more gentle introduction.
 
-\assignment{Exercise: Fun with views III}
+\assignment{Assignment 3: Fun with views III}
 Create a small program that
   1. reads a string from the command line (first argument to the program)
   2. "converts" the string to a range of seqan3::dna5 (Bonus: throw an exception if loss of information occurs)
@@ -270,7 +270,7 @@ To store sequences of small alphabets more space-efficiently, we have developed 
 Open the API documentation of seqan3::bitcompressed_vector, display the inheritance diagram and read through the
 interface overview and the detailed description.
 
-\assignment{Exercise: The bitcompressed vector}
+\assignment{Assignment 4: The bitcompressed vector}
 Create a small program that asks the user for a size and then creates a vector of seqan3::dna4 of that size.
 Add an argument parser flag that allows the user to decide whether std::vector or seqan3::bitcompressed_vector is used.
 After creating the vector, print its size.

--- a/doc/tutorial/read_mapper/index.md
+++ b/doc/tutorial/read_mapper/index.md
@@ -46,7 +46,7 @@ As a first step, we want to parse command line arguments for our indexer. If you
 you can take a peek at the \ref tutorial_argument_parser "Argument Parser Tutorial" or the API documentation of
 the seqan3::argument_parser for help.
 
-\assignment{Parsing arguments}
+\assignment{Assignment 1: Parsing arguments}
 Let's start our application by setting up the argument parser with the following options:
 * The path to the reference file
 * An output path for the index
@@ -73,7 +73,7 @@ As a next step, we want to use the parsed file name to read in our reference dat
 using seqan3::sequence_file_input class. As a guide, you can take a look at the
 \ref tutorial_sequence_file "Sequence I/O Tutorial".
 
-\assignment{Reading the input}
+\assignment{Assignment 2: Reading the input}
 Extend your program to store the sequence information contained in the reference file into a struct.
 
 To do this, you should create:
@@ -108,7 +108,7 @@ Here is the complete program:
 Now that we have the necessary sequence information, we can create an index and store it. Read up on the
 \ref tutorial_index_search "Index Tutorial" if you have any questions.
 
-\assignment{Index}
+\assignment{Assignment 3: Index}
 We want to create a new function `create_index`:
 * It takes `index_path` and `storage` as parameters
 * Creates a bi_fm_index
@@ -138,7 +138,7 @@ Again, we want to parse command line arguments for our read mapper as a first st
 you can take a peek at the [Argumet Parser Tutorial](#tutorial_argument_parser) or the API documentation of
 the seqan3::argument_parser for help.
 
-\assignment{Parsing arguments}
+\assignment{Assignment 4: Parsing arguments}
 Let's start our application by setting up the argument parser with the following options:
 * The path to the reference file
 * The path to the query file
@@ -168,7 +168,7 @@ We also want to read the reference in the read mapper. This is done the same way
 We can now load the index and conduct a search. Read up on the \ref tutorial_index_search "Search Tutorial"
 if you have any questions.
 
-\assignment{Reading the input}
+\assignment{Assignment 5: Reading the input}
 Extend your program to read the reference file the same way the indexer does.
 After this you can load the index and print results of a search.
 
@@ -199,7 +199,7 @@ Here is the complete program:
 We can now use the obtained positions to align each query against the reference. Refer to the
 \ref tutorial_pairwise_alignment "Alignment Tutorial" if you have any questions.
 
-\assignment{Alignment}
+\assignment{Assignment 6: Alignment}
 We want to extend `map_reads` to:
 * Use the output of the search to align the query against the reference
 * Print the query ID, alignment score, subrange of the reference sequence and the query (for the first 20 queries)
@@ -220,7 +220,7 @@ Here is the complete program:
 ## Step 4 - Alignment output
 Finally, we can write our results into a SAM file.
 
-\assignment{SAM out}
+\assignment{Assignment 7: SAM out}
 We further need to extend `map_reads` to write the alignment results into a SAM file.
 Additionally, there should be no more debug output.
 

--- a/doc/tutorial/sequence_file/index.md
+++ b/doc/tutorial/sequence_file/index.md
@@ -227,7 +227,7 @@ In this case you immediately get the two elements of the tuple:
 You can read up more on the different ways to stream over the file object in the detailed documentation
 of seqan3::sequence_file_input.
 
-\assignment{Exercise: Reading a FASTQ file}
+\assignment{Assignment 1: Reading a FASTQ file}
 Copy and paste the following FASTQ file to some location, e.g. the tmp directory:
 
 \snippet doc/tutorial/sequence_file/sequence_file_snippets.cpp fastq_file
@@ -271,7 +271,7 @@ You can move the record out of the file if you want to store it somewhere withou
 
 \snippet doc/tutorial/sequence_file/sequence_file_snippets.cpp record_type2
 
-\assignment{Exercise: Storing records in a std::vector}
+\assignment{Assignment 2: Storing records in a std::vector}
 
 Create a small program that reads in a FASTA file and stores all the records in a std::vector.
 
@@ -332,7 +332,7 @@ If you want to handle one pair of reads at a time, you can do so easily with a v
 
 \snippet doc/tutorial/sequence_file/sequence_file_snippets.cpp paired_reads
 
-\assignment{Exercise: Fun with file ranges}
+\assignment{Assignment 3: Fun with file ranges}
 
 Implement a small program that reads in a FASTQ file and prints the first 2 sequences
 that have a length of at least 5.
@@ -382,9 +382,9 @@ second seqan3::field::id and the third one seqan3::field::qual.
 You may give less fields than are selected if the actual format you are writing to can cope with less
 (e.g. for FastA it is sufficient to give sequence and name information).
 
-\assignment{Exercise: Writing a FASTQ file}
+\assignment{Assignment 4: Writing a FASTQ file}
 
-Use your code (or the solution) from the previous exercise.
+Use your code (or the solution) from the previous assignment.
 Iterate over the records with a for loop and instead of just printing the ids,
 write out **all** the records that satisfy the filter to a new file called `output.fastq`.
 
@@ -419,9 +419,9 @@ a seqan3::sequence_file_input object. In the same way you can pipe the output fi
 
 \snippet doc/tutorial/sequence_file/sequence_file_snippets.cpp piping_in_out
 
-\assignment{Exercise: Fun with file ranges 2}
+\assignment{Assignment 5: Fun with file ranges 2}
 
-Working on your solution from the previous exercise, try to remove the for loop in favour of a pipe notation.
+Working on your solution from the previous assignment, try to remove the for loop in favour of a pipe notation.
 
 The result should be the same.
 


### PR DESCRIPTION
Fixes https://github.com/seqan/seqan3/issues/1608 1.0.1

Makes is easier for the user to keep well-arranged notes on where exactly that useful information is explained / snippet can be found.