### PR TITLE
[FEATURE] Increase reading FASTA performance by reducing an if-check.

### DIFF
--- a/include/seqan3/io/sequence_file/format_fasta.hpp
+++ b/include/seqan3/io/sequence_file/format_fasta.hpp
@@ -276,10 +276,11 @@ private:
             auto e = stream_view.end();
             for (; (it != e) && ((!is_id)(*it)); ++it)
             {
-                if ((is_space || is_digit)(*it))
-                    continue;
-                else if (not_in_alph(*it))
+                if (not_in_alph(*it))
                 {
+                    if ((is_space || is_digit)(*it))
+                        continue;
+
                     throw parse_error{std::string{"Encountered an unexpected letter: "} +
                                         not_in_alph.msg +
                                         " evaluated to true on " +


### PR DESCRIPTION
This improves reading a FASTA file by roughly 2-3% (1GB macro benchmark).
Not a lot but we might as well include it.

Belongs to #1571 