### PR TITLE
[MISC] Remove 'using namespace seqan3' from test/unit/alignment/matrix.

### DIFF
--- a/test/unit/alignment/matrix/alignment_coordinate_test.cpp
+++ b/test/unit/alignment/matrix/alignment_coordinate_test.cpp
@@ -14,46 +14,45 @@
 #include <seqan3/alignment/matrix/alignment_coordinate.hpp>
 #include <seqan3/test/pretty_printing.hpp>
 
-using namespace seqan3;
-
 TEST(advanceable_alignment_coordinate, column_index_type)
 {
-    detail::column_index_type ci{1u};
+    seqan3::detail::column_index_type ci{1u};
     EXPECT_EQ(ci.get(), 1u);
     EXPECT_TRUE((std::same_as<std::remove_reference_t<decltype(ci.get())>, size_t>));
 
-    detail::column_index_type ci2{1};
+    seqan3::detail::column_index_type ci2{1};
     EXPECT_EQ(ci2.get(), 1);
     EXPECT_TRUE((std::same_as<std::remove_reference_t<decltype(ci2.get())>, std::ptrdiff_t>));
 }
 
 TEST(advanceable_alignment_coordinate, row_index_type)
 {
-    detail::row_index_type ri{1u};
+    seqan3::detail::row_index_type ri{1u};
     EXPECT_EQ(ri.get(), 1u);
     EXPECT_TRUE((std::same_as<std::remove_reference_t<decltype(ri.get())>, size_t>));
 
-    detail::row_index_type ri2{1};
+    seqan3::detail::row_index_type ri2{1};
     EXPECT_EQ(ri2.get(), 1);
     EXPECT_TRUE((std::same_as<std::remove_reference_t<decltype(ri2.get())>, std::ptrdiff_t>));
 }
 
 TEST(advanceable_alignment_coordinate, construction)
 {
-    EXPECT_TRUE(std::is_default_constructible<detail::advanceable_alignment_coordinate<>>::value);
-    EXPECT_TRUE(std::is_copy_constructible<detail::advanceable_alignment_coordinate<>>::value);
-    EXPECT_TRUE(std::is_copy_assignable<detail::advanceable_alignment_coordinate<>>::value);
-    EXPECT_TRUE(std::is_move_constructible<detail::advanceable_alignment_coordinate<>>::value);
-    EXPECT_TRUE(std::is_move_assignable<detail::advanceable_alignment_coordinate<>>::value);
-    EXPECT_TRUE(std::is_destructible<detail::advanceable_alignment_coordinate<>>::value);
+    EXPECT_TRUE(std::is_default_constructible<seqan3::detail::advanceable_alignment_coordinate<>>::value);
+    EXPECT_TRUE(std::is_copy_constructible<seqan3::detail::advanceable_alignment_coordinate<>>::value);
+    EXPECT_TRUE(std::is_copy_assignable<seqan3::detail::advanceable_alignment_coordinate<>>::value);
+    EXPECT_TRUE(std::is_move_constructible<seqan3::detail::advanceable_alignment_coordinate<>>::value);
+    EXPECT_TRUE(std::is_move_assignable<seqan3::detail::advanceable_alignment_coordinate<>>::value);
+    EXPECT_TRUE(std::is_destructible<seqan3::detail::advanceable_alignment_coordinate<>>::value);
 }
 
 TEST(advanceable_alignment_coordinate, construction_with_different_state)
 {
-    detail::advanceable_alignment_coordinate<detail::advanceable_alignment_coordinate_state::row>
-        ro{detail::column_index_type{2u}, detail::row_index_type{3u}};
+    seqan3::detail::advanceable_alignment_coordinate<seqan3::detail::advanceable_alignment_coordinate_state::row>
+        ro{seqan3::detail::column_index_type{2u}, seqan3::detail::row_index_type{3u}};
 
-    detail::advanceable_alignment_coordinate<detail::advanceable_alignment_coordinate_state::none> no{ro};
+    seqan3::detail::advanceable_alignment_coordinate<seqan3::detail::advanceable_alignment_coordinate_state::none>
+        no{ro};
 
     EXPECT_EQ(no.first, 2u);
     EXPECT_EQ(no.second, 3u);
@@ -61,22 +60,25 @@ TEST(advanceable_alignment_coordinate, construction_with_different_state)
 
 TEST(advanceable_alignment_coordinate, type_deduction)
 {
-    detail::advanceable_alignment_coordinate def_co{};
-    EXPECT_TRUE((std::is_same_v<decltype(def_co),
-                    detail::advanceable_alignment_coordinate<detail::advanceable_alignment_coordinate_state::none>>));
+    using not_incrementable =
+        seqan3::detail::advanceable_alignment_coordinate<seqan3::detail::advanceable_alignment_coordinate_state::none>;
 
-    detail::advanceable_alignment_coordinate co{detail::column_index_type{2u}, detail::row_index_type{3u}};
-    EXPECT_TRUE((std::is_same_v<decltype(co),
-                    detail::advanceable_alignment_coordinate<detail::advanceable_alignment_coordinate_state::none>>));
+    seqan3::detail::advanceable_alignment_coordinate def_co{};
+    EXPECT_TRUE((std::is_same_v<decltype(def_co), not_incrementable>));
+
+    seqan3::detail::advanceable_alignment_coordinate co{seqan3::detail::column_index_type{2u},
+                                                        seqan3::detail::row_index_type{3u}};
+    EXPECT_TRUE((std::is_same_v<decltype(co), not_incrementable>));
 }
 
 TEST(advanceable_alignment_coordinate, access)
 {
-    detail::advanceable_alignment_coordinate def_co{};
+    seqan3::detail::advanceable_alignment_coordinate def_co{};
     EXPECT_EQ(def_co.first, 0u);
     EXPECT_EQ(def_co.second, 0u);
 
-    detail::advanceable_alignment_coordinate co{detail::column_index_type{2u}, detail::row_index_type{3u}};
+    seqan3::detail::advanceable_alignment_coordinate co{seqan3::detail::column_index_type{2u},
+                                                        seqan3::detail::row_index_type{3u}};
     EXPECT_EQ(co.first, 2u);
     EXPECT_EQ(co.second, 3u);
 }
@@ -84,11 +86,11 @@ TEST(advanceable_alignment_coordinate, access)
 TEST(advanceable_alignment_coordinate, weakly_equality_comparable_concept)
 {
     using not_incrementable =
-        detail::advanceable_alignment_coordinate<detail::advanceable_alignment_coordinate_state::none>;
+        seqan3::detail::advanceable_alignment_coordinate<seqan3::detail::advanceable_alignment_coordinate_state::none>;
     using row_incrementable =
-        detail::advanceable_alignment_coordinate<detail::advanceable_alignment_coordinate_state::row>;
+        seqan3::detail::advanceable_alignment_coordinate<seqan3::detail::advanceable_alignment_coordinate_state::row>;
     using column_incrementable =
-        detail::advanceable_alignment_coordinate<detail::advanceable_alignment_coordinate_state::column>;
+        seqan3::detail::advanceable_alignment_coordinate<seqan3::detail::advanceable_alignment_coordinate_state::column>;
 
     EXPECT_TRUE(std::equality_comparable<not_incrementable>);
     EXPECT_TRUE(std::equality_comparable<row_incrementable>);
@@ -98,11 +100,11 @@ TEST(advanceable_alignment_coordinate, weakly_equality_comparable_concept)
 TEST(advanceable_alignment_coordinate, equality)
 {
     using test_type =
-        detail::advanceable_alignment_coordinate<detail::advanceable_alignment_coordinate_state::none>;
+        seqan3::detail::advanceable_alignment_coordinate<seqan3::detail::advanceable_alignment_coordinate_state::none>;
 
-    test_type t1{detail::column_index_type{10u}, detail::row_index_type{5u}};
-    test_type t2{detail::column_index_type{5u}, detail::row_index_type{5u}};
-    test_type t3{detail::column_index_type{10u}, detail::row_index_type{10u}};
+    test_type t1{seqan3::detail::column_index_type{10u}, seqan3::detail::row_index_type{5u}};
+    test_type t2{seqan3::detail::column_index_type{5u}, seqan3::detail::row_index_type{5u}};
+    test_type t3{seqan3::detail::column_index_type{10u}, seqan3::detail::row_index_type{10u}};
 
     EXPECT_TRUE(t1 == t1);
     EXPECT_FALSE(t2 == t1);
@@ -113,11 +115,11 @@ TEST(advanceable_alignment_coordinate, equality)
 TEST(advanceable_alignment_coordinate, inequality)
 {
     using test_type =
-        detail::advanceable_alignment_coordinate<detail::advanceable_alignment_coordinate_state::none>;
+        seqan3::detail::advanceable_alignment_coordinate<seqan3::detail::advanceable_alignment_coordinate_state::none>;
 
-    test_type t1{detail::column_index_type{10u}, detail::row_index_type{5u}};
-    test_type t2{detail::column_index_type{5u}, detail::row_index_type{5u}};
-    test_type t3{detail::column_index_type{10u}, detail::row_index_type{10u}};
+    test_type t1{seqan3::detail::column_index_type{10u}, seqan3::detail::row_index_type{5u}};
+    test_type t2{seqan3::detail::column_index_type{5u}, seqan3::detail::row_index_type{5u}};
+    test_type t3{seqan3::detail::column_index_type{10u}, seqan3::detail::row_index_type{10u}};
 
     EXPECT_FALSE(t1 != t1);
     EXPECT_TRUE(t2 != t1);
@@ -128,11 +130,11 @@ TEST(advanceable_alignment_coordinate, inequality)
 TEST(advanceable_alignment_coordinate, incremental_concept)
 {
     using not_incrementable =
-        detail::advanceable_alignment_coordinate<detail::advanceable_alignment_coordinate_state::none>;
+        seqan3::detail::advanceable_alignment_coordinate<seqan3::detail::advanceable_alignment_coordinate_state::none>;
     using row_incrementable =
-        detail::advanceable_alignment_coordinate<detail::advanceable_alignment_coordinate_state::row>;
+        seqan3::detail::advanceable_alignment_coordinate<seqan3::detail::advanceable_alignment_coordinate_state::row>;
     using column_incrementable =
-        detail::advanceable_alignment_coordinate<detail::advanceable_alignment_coordinate_state::column>;
+        seqan3::detail::advanceable_alignment_coordinate<seqan3::detail::advanceable_alignment_coordinate_state::column>;
 
     EXPECT_FALSE(std::weakly_incrementable<not_incrementable>);
     EXPECT_TRUE(std::weakly_incrementable<row_incrementable>);
@@ -142,9 +144,9 @@ TEST(advanceable_alignment_coordinate, incremental_concept)
 TEST(advanceable_alignment_coordinate, increment_row)
 {
     using row_incrementable =
-        detail::advanceable_alignment_coordinate<detail::advanceable_alignment_coordinate_state::row>;
+        seqan3::detail::advanceable_alignment_coordinate<seqan3::detail::advanceable_alignment_coordinate_state::row>;
 
-    row_incrementable co{detail::column_index_type{0u}, detail::row_index_type{0u}};
+    row_incrementable co{seqan3::detail::column_index_type{0u}, seqan3::detail::row_index_type{0u}};
     co = ++co;
     EXPECT_EQ(co.first, 0u);
     EXPECT_EQ(co.second, 1u);
@@ -161,9 +163,9 @@ TEST(advanceable_alignment_coordinate, increment_row)
 TEST(advanceable_alignment_coordinate, increment_col)
 {
     using col_incrementable =
-        detail::advanceable_alignment_coordinate<detail::advanceable_alignment_coordinate_state::column>;
+        seqan3::detail::advanceable_alignment_coordinate<seqan3::detail::advanceable_alignment_coordinate_state::column>;
 
-    col_incrementable co{detail::column_index_type{0u}, detail::row_index_type{0u}};
+    col_incrementable co{seqan3::detail::column_index_type{0u}, seqan3::detail::row_index_type{0u}};
     co = ++co;
     EXPECT_EQ(co.first, 1u);
     EXPECT_EQ(co.second, 0u);
@@ -180,9 +182,9 @@ TEST(advanceable_alignment_coordinate, increment_col)
 TEST(advanceable_alignment_coordinate, decrement_row)
 {
     using row_incrementable =
-        detail::advanceable_alignment_coordinate<detail::advanceable_alignment_coordinate_state::row>;
+        seqan3::detail::advanceable_alignment_coordinate<seqan3::detail::advanceable_alignment_coordinate_state::row>;
 
-    row_incrementable co{detail::column_index_type{0u}, detail::row_index_type{0u}};
+    row_incrementable co{seqan3::detail::column_index_type{0u}, seqan3::detail::row_index_type{0u}};
     co += 4;
     auto co_tmp = co--;
     EXPECT_EQ(co_tmp.first, 0u);
@@ -202,9 +204,9 @@ TEST(advanceable_alignment_coordinate, decrement_row)
 TEST(advanceable_alignment_coordinate, decrement_col)
 {
     using col_incrementable =
-        detail::advanceable_alignment_coordinate<detail::advanceable_alignment_coordinate_state::column>;
+        seqan3::detail::advanceable_alignment_coordinate<seqan3::detail::advanceable_alignment_coordinate_state::column>;
 
-    col_incrementable co{detail::column_index_type{0u}, detail::row_index_type{0u}};
+    col_incrementable co{seqan3::detail::column_index_type{0u}, seqan3::detail::row_index_type{0u}};
     co += 4;
     auto co_tmp = co--;
     EXPECT_EQ(co_tmp.first, 4u);
@@ -224,9 +226,9 @@ TEST(advanceable_alignment_coordinate, decrement_col)
 TEST(advanceable_alignment_coordinate, advance_row)
 {
     using row_incrementable =
-        detail::advanceable_alignment_coordinate<detail::advanceable_alignment_coordinate_state::row>;
+        seqan3::detail::advanceable_alignment_coordinate<seqan3::detail::advanceable_alignment_coordinate_state::row>;
 
-    row_incrementable co{detail::column_index_type{0u}, detail::row_index_type{0u}};
+    row_incrementable co{seqan3::detail::column_index_type{0u}, seqan3::detail::row_index_type{0u}};
 
     co = co + 4;
     EXPECT_EQ(co.first, 0u);
@@ -240,9 +242,9 @@ TEST(advanceable_alignment_coordinate, advance_row)
 TEST(advanceable_alignment_coordinate, advance_col)
 {
     using col_incrementable =
-        detail::advanceable_alignment_coordinate<detail::advanceable_alignment_coordinate_state::column>;
+        seqan3::detail::advanceable_alignment_coordinate<seqan3::detail::advanceable_alignment_coordinate_state::column>;
 
-    col_incrementable co{detail::column_index_type{0u}, detail::row_index_type{0u}};
+    col_incrementable co{seqan3::detail::column_index_type{0u}, seqan3::detail::row_index_type{0u}};
     co = co + 4;
     EXPECT_EQ(co.first, 4u);
     EXPECT_EQ(co.second, 0u);
@@ -255,10 +257,10 @@ TEST(advanceable_alignment_coordinate, advance_col)
 TEST(advanceable_alignment_coordinate, iota_column_index)
 {
     using col_incrementable =
-        detail::advanceable_alignment_coordinate<detail::advanceable_alignment_coordinate_state::column>;
+        seqan3::detail::advanceable_alignment_coordinate<seqan3::detail::advanceable_alignment_coordinate_state::column>;
 
-    col_incrementable co_begin{detail::column_index_type{0u}, detail::row_index_type{0u}};
-    col_incrementable co_end{detail::column_index_type{5u}, detail::row_index_type{0u}};
+    col_incrementable co_begin{seqan3::detail::column_index_type{0u}, seqan3::detail::row_index_type{0u}};
+    col_incrementable co_end{seqan3::detail::column_index_type{5u}, seqan3::detail::row_index_type{0u}};
     auto v = std::views::iota(co_begin, co_end);
 
     EXPECT_TRUE((std::same_as<decltype(v.begin()), decltype(v.end())>));
@@ -272,10 +274,10 @@ TEST(advanceable_alignment_coordinate, iota_column_index)
 TEST(advanceable_alignment_coordinate, iota_row_index)
 {
     using row_incrementable =
-        detail::advanceable_alignment_coordinate<detail::advanceable_alignment_coordinate_state::row>;
+        seqan3::detail::advanceable_alignment_coordinate<seqan3::detail::advanceable_alignment_coordinate_state::row>;
 
-    row_incrementable co_begin{detail::column_index_type{0u}, detail::row_index_type{0u}};
-    row_incrementable co_end{detail::column_index_type{0u}, detail::row_index_type{5u}};
+    row_incrementable co_begin{seqan3::detail::column_index_type{0u}, seqan3::detail::row_index_type{0u}};
+    row_incrementable co_end{seqan3::detail::column_index_type{0u}, seqan3::detail::row_index_type{5u}};
     auto v = std::views::iota(co_begin, co_end);
 
     EXPECT_TRUE((std::same_as<decltype(v.begin()), decltype(v.end())>));
@@ -288,45 +290,45 @@ TEST(advanceable_alignment_coordinate, iota_row_index)
 
 TEST(alignment_coordinate, basic)
 {
-    EXPECT_TRUE(std::is_default_constructible<alignment_coordinate>::value);
-    EXPECT_TRUE(std::is_copy_constructible<alignment_coordinate>::value);
-    EXPECT_TRUE(std::is_copy_assignable<alignment_coordinate>::value);
-    EXPECT_TRUE(std::is_move_constructible<alignment_coordinate>::value);
-    EXPECT_TRUE(std::is_move_assignable<alignment_coordinate>::value);
-    EXPECT_TRUE(std::is_destructible<alignment_coordinate>::value);
+    EXPECT_TRUE(std::is_default_constructible<seqan3::alignment_coordinate>::value);
+    EXPECT_TRUE(std::is_copy_constructible<seqan3::alignment_coordinate>::value);
+    EXPECT_TRUE(std::is_copy_assignable<seqan3::alignment_coordinate>::value);
+    EXPECT_TRUE(std::is_move_constructible<seqan3::alignment_coordinate>::value);
+    EXPECT_TRUE(std::is_move_assignable<seqan3::alignment_coordinate>::value);
+    EXPECT_TRUE(std::is_destructible<seqan3::alignment_coordinate>::value);
 
     using not_incrementable =
-        detail::advanceable_alignment_coordinate<detail::advanceable_alignment_coordinate_state::none>;
+        seqan3::detail::advanceable_alignment_coordinate<seqan3::detail::advanceable_alignment_coordinate_state::none>;
     using row_incrementable =
-        detail::advanceable_alignment_coordinate<detail::advanceable_alignment_coordinate_state::row>;
+        seqan3::detail::advanceable_alignment_coordinate<seqan3::detail::advanceable_alignment_coordinate_state::row>;
     using col_incrementable =
-        detail::advanceable_alignment_coordinate<detail::advanceable_alignment_coordinate_state::column>;
+        seqan3::detail::advanceable_alignment_coordinate<seqan3::detail::advanceable_alignment_coordinate_state::column>;
 
-    not_incrementable co_not{detail::column_index_type{10u}, detail::row_index_type{5u}};
-    col_incrementable co_col{detail::column_index_type{10u}, detail::row_index_type{5u}};
-    row_incrementable co_row{detail::column_index_type{10u}, detail::row_index_type{5u}};
+    not_incrementable co_not{seqan3::detail::column_index_type{10u}, seqan3::detail::row_index_type{5u}};
+    col_incrementable co_col{seqan3::detail::column_index_type{10u}, seqan3::detail::row_index_type{5u}};
+    row_incrementable co_row{seqan3::detail::column_index_type{10u}, seqan3::detail::row_index_type{5u}};
 
-    alignment_coordinate test1{co_not};
+    seqan3::alignment_coordinate test1{co_not};
     EXPECT_EQ(test1.first, 10u);
     EXPECT_EQ(test1.second, 5u);
 
-    alignment_coordinate test2{co_col};
+    seqan3::alignment_coordinate test2{co_col};
     EXPECT_EQ(test2.first, 10u);
     EXPECT_EQ(test2.second, 5u);
 
-    alignment_coordinate test3{co_row};
+    seqan3::alignment_coordinate test3{co_row};
     EXPECT_EQ(test3.first, 10u);
     EXPECT_EQ(test3.second, 5u);
 
-    alignment_coordinate test4{detail::column_index_type{10u}, detail::row_index_type{5u}};
+    seqan3::alignment_coordinate test4{seqan3::detail::column_index_type{10u}, seqan3::detail::row_index_type{5u}};
     EXPECT_EQ(test4.first, 10u);
     EXPECT_EQ(test4.second, 5u);
 }
 
 TEST(alignment_coordinate, matrix_coordainte_conversion)
 {
-    alignment_coordinate co{detail::column_index_type{10u}, detail::row_index_type{5u}};
-    detail::matrix_coordinate mc = co;
+    seqan3::alignment_coordinate co{seqan3::detail::column_index_type{10u}, seqan3::detail::row_index_type{5u}};
+    seqan3::detail::matrix_coordinate mc = co;
 
     EXPECT_EQ(mc.col, 10u);
     EXPECT_EQ(mc.row, 5u);

--- a/test/unit/alignment/matrix/debug_matrix_test.cpp
+++ b/test/unit/alignment/matrix/debug_matrix_test.cpp
@@ -11,15 +11,15 @@
 #include <seqan3/alignment/matrix/trace_directions.hpp>
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 
-using namespace seqan3;
-using namespace seqan3::detail;
+using seqan3::operator""_dna4;
+using seqan3::operator|;
 
 struct debug_matrix_test : public ::testing::Test
 {
     static constexpr std::nullopt_t inf = std::nullopt;
 
-    std::vector<dna4> first_sequence = "AACACGTTAACCGGTT"_dna4;
-    std::vector<dna4> second_sequence = "ACGTACGT"_dna4;
+    std::vector<seqan3::dna4> first_sequence = "AACACGTTAACCGGTT"_dna4;
+    std::vector<seqan3::dna4> second_sequence = "ACGTACGT"_dna4;
 
     std::vector<bool> masking_matrix
     {
@@ -92,12 +92,14 @@ struct debug_matrix_test : public ::testing::Test
        -8, -7, -6, -5, -5, -5, -4, -3, -4, -5, -6, -7, -7, -7, -7, -7, -8
     };
 
-    row_wise_matrix<int> score_matrix{number_rows{9u}, number_cols{17u}, scores};
+    seqan3::detail::row_wise_matrix<int> score_matrix{seqan3::detail::number_rows{9u},
+                                                      seqan3::detail::number_cols{17u},
+                                                      scores};
 
-    row_wise_matrix<int> transposed_score_matrix
+    seqan3::detail::row_wise_matrix<int> transposed_score_matrix
     {
-        number_rows{17u},
-        number_cols{9u},
+        seqan3::detail::number_rows{17u},
+        seqan3::detail::number_cols{9u},
         std::vector
         {
            -0, -1, -2, -3, -4, -5, -6, -7, -8,
@@ -120,10 +122,10 @@ struct debug_matrix_test : public ::testing::Test
         }
     };
 
-    row_wise_matrix<std::optional<int>> masked_score_matrix
+    seqan3::detail::row_wise_matrix<std::optional<int>> masked_score_matrix
     {
-        number_rows{9u},
-        number_cols{17u},
+        seqan3::detail::number_rows{9u},
+        seqan3::detail::number_cols{17u},
         std::vector<std::optional<int>>
         {
             -0, -1, -2, -3, -4, -5, -6, -7, -8, -9,-10,-11,-12,-13,-14,-15,-16,
@@ -138,10 +140,10 @@ struct debug_matrix_test : public ::testing::Test
         }
     };
 
-    row_wise_matrix<int> score_matrix_s9u_7u
+    seqan3::detail::row_wise_matrix<int> score_matrix_s9u_7u
     {
-        number_rows{9u},
-        number_cols{7u},
+        seqan3::detail::number_rows{9u},
+        seqan3::detail::number_cols{7u},
         std::vector
         {
            -0, -1, -2, -3, -4, -5, -6,
@@ -156,10 +158,10 @@ struct debug_matrix_test : public ::testing::Test
         }
     };
 
-    row_wise_matrix<int> transposed_score_matrix_s9u_7u
+    seqan3::detail::row_wise_matrix<int> transposed_score_matrix_s9u_7u
     {
-        number_rows{7u},
-        number_cols{9u},
+        seqan3::detail::number_rows{7u},
+        seqan3::detail::number_cols{9u},
         std::vector
         {
            -0, -1, -2, -3, -4, -5, -6, -7, -8,
@@ -172,10 +174,10 @@ struct debug_matrix_test : public ::testing::Test
         }
     };
 
-    row_wise_matrix<int> score_matrix_s4u_17u
+    seqan3::detail::row_wise_matrix<int> score_matrix_s4u_17u
     {
-        number_rows{4u},
-        number_cols{17u},
+        seqan3::detail::number_rows{4u},
+        seqan3::detail::number_cols{17u},
         std::vector
         {
            -0, -1, -2, -3, -4, -5, -6, -7, -8, -9,-10,-11,-12,-13,-14,-15,-16,
@@ -185,13 +187,13 @@ struct debug_matrix_test : public ::testing::Test
         }
     };
 
-    trace_directions N{},
-        D{trace_directions::diagonal},
-        L{trace_directions::left},
-        U{trace_directions::up},
+    seqan3::detail::trace_directions N{},
+        D{seqan3::detail::trace_directions::diagonal},
+        L{seqan3::detail::trace_directions::left},
+        U{seqan3::detail::trace_directions::up},
         DL{D|L}, DU{D|U}, UL{U|L}, DUL{D|U|L};
 
-    std::vector<trace_directions> traces
+    std::vector<seqan3::detail::trace_directions> traces
     {
         N,  L,  L,  L,  L,  L,  L,  L,  L,  L,  L,  L,  L,  L,  L,  L,  L,
         U,  D,  DL, L,  DL, L,  L,  L,  L,  DL, DL, L,  L,  L,  L,  L,  L,
@@ -204,12 +206,14 @@ struct debug_matrix_test : public ::testing::Test
         U,  U,  U,  U,  DU, DU, U,  D,  DL, L,  L,  DUL,DU, DU, D,  D,  DL
     };
 
-    row_wise_matrix<trace_directions> trace_matrix{number_rows{9u}, number_cols{17u}, traces};
+    seqan3::detail::row_wise_matrix<seqan3::detail::trace_directions> trace_matrix{seqan3::detail::number_rows{9u},
+                                                                                   seqan3::detail::number_cols{17u},
+                                                                                   traces};
 
-    row_wise_matrix<trace_directions> transposed_trace_matrix
+    seqan3::detail::row_wise_matrix<seqan3::detail::trace_directions> transposed_trace_matrix
     {
-        number_rows{17u},
-        number_cols{9u},
+        seqan3::detail::number_rows{17u},
+        seqan3::detail::number_cols{9u},
         std::vector
         {
             N,  L,  L,  L,  L,  L,  L,  L,  L,
@@ -232,10 +236,10 @@ struct debug_matrix_test : public ::testing::Test
         }
     };
 
-    row_wise_matrix<trace_directions> masked_trace_matrix
+    seqan3::detail::row_wise_matrix<seqan3::detail::trace_directions> masked_trace_matrix
     {
-        number_rows{9u},
-        number_cols{17u},
+        seqan3::detail::number_rows{9u},
+        seqan3::detail::number_cols{17u},
         std::vector
         {
             N,  L,  L,  L,  L,  L,  L,  L,  L,  L,  L,  L,  L,  L,  L,  L,  L,
@@ -250,10 +254,10 @@ struct debug_matrix_test : public ::testing::Test
         }
     };
 
-    row_wise_matrix<trace_directions> trace_matrix_s9u_7u
+    seqan3::detail::row_wise_matrix<seqan3::detail::trace_directions> trace_matrix_s9u_7u
     {
-        number_rows{9u},
-        number_cols{7u},
+        seqan3::detail::number_rows{9u},
+        seqan3::detail::number_cols{7u},
         std::vector
         {
             N,  L,  L,  L,  L,  L,  L,
@@ -268,10 +272,10 @@ struct debug_matrix_test : public ::testing::Test
         }
     };
 
-    row_wise_matrix<trace_directions> trace_matrix_s4u_17u
+    seqan3::detail::row_wise_matrix<seqan3::detail::trace_directions> trace_matrix_s4u_17u
     {
-        number_rows{4u},
-        number_cols{17u},
+        seqan3::detail::number_rows{4u},
+        seqan3::detail::number_cols{17u},
         std::vector
         {
             N,  L,  L,  L,  L,  L,  L,  L,  L,  L,  L,  L,  L,  L,  L,  L,  L,
@@ -287,25 +291,26 @@ struct debug_matrix_test : public ::testing::Test
         EXPECT_EQ(matrix.cols(), 17u);
         EXPECT_EQ(matrix.rows(), 9u);
 
-        EXPECT_EQ(matrix.at({row_index_type{0u}, column_index_type{0u}}), -0);
-        EXPECT_EQ(matrix.at({row_index_type{0u}, column_index_type{6u}}), -6);
-        EXPECT_EQ(matrix.at({row_index_type{0u}, column_index_type{16u}}), -16);
+        EXPECT_EQ(matrix.at({seqan3::detail::row_index_type{0u}, seqan3::detail::column_index_type{0u}}), -0);
+        EXPECT_EQ(matrix.at({seqan3::detail::row_index_type{0u}, seqan3::detail::column_index_type{6u}}), -6);
+        EXPECT_EQ(matrix.at({seqan3::detail::row_index_type{0u}, seqan3::detail::column_index_type{16u}}), -16);
 
-        EXPECT_EQ(matrix.at({row_index_type{3u}, column_index_type{0u}}), -3);
-        EXPECT_EQ(matrix.at({row_index_type{3u}, column_index_type{6u}}), -3);
-        EXPECT_EQ(matrix.at({row_index_type{3u}, column_index_type{16u}}), -13);
+        EXPECT_EQ(matrix.at({seqan3::detail::row_index_type{3u}, seqan3::detail::column_index_type{0u}}), -3);
+        EXPECT_EQ(matrix.at({seqan3::detail::row_index_type{3u}, seqan3::detail::column_index_type{6u}}), -3);
+        EXPECT_EQ(matrix.at({seqan3::detail::row_index_type{3u}, seqan3::detail::column_index_type{16u}}), -13);
 
-        EXPECT_EQ(matrix.at({row_index_type{4u}, column_index_type{0u}}), -4);
-        EXPECT_EQ(matrix.at({row_index_type{4u}, column_index_type{6u}}), -4);
-        EXPECT_EQ(matrix.at({row_index_type{4u}, column_index_type{16u}}), -12);
+        EXPECT_EQ(matrix.at({seqan3::detail::row_index_type{4u}, seqan3::detail::column_index_type{0u}}), -4);
+        EXPECT_EQ(matrix.at({seqan3::detail::row_index_type{4u}, seqan3::detail::column_index_type{6u}}), -4);
+        EXPECT_EQ(matrix.at({seqan3::detail::row_index_type{4u}, seqan3::detail::column_index_type{16u}}), -12);
 
-        EXPECT_EQ(matrix.at({row_index_type{8u}, column_index_type{0u}}), -8);
-        EXPECT_EQ(matrix.at({row_index_type{8u}, column_index_type{6u}}), -4);
-        EXPECT_EQ(matrix.at({row_index_type{8u}, column_index_type{16u}}), -8);
+        EXPECT_EQ(matrix.at({seqan3::detail::row_index_type{8u}, seqan3::detail::column_index_type{0u}}), -8);
+        EXPECT_EQ(matrix.at({seqan3::detail::row_index_type{8u}, seqan3::detail::column_index_type{6u}}), -4);
+        EXPECT_EQ(matrix.at({seqan3::detail::row_index_type{8u}, seqan3::detail::column_index_type{16u}}), -8);
 
         for (size_t row = 0; row < matrix.rows(); row++)
             for (size_t col = 0; col < matrix.cols(); col++)
-                EXPECT_EQ((matrix.at({row_index_type{row}, column_index_type{col}})), scores[row * matrix.cols() + col]);
+                EXPECT_EQ((matrix.at({seqan3::detail::row_index_type{row},
+                                      seqan3::detail::column_index_type{col}})), scores[row * matrix.cols() + col]);
     }
 
     template <typename trace_matrix_t>
@@ -314,18 +319,19 @@ struct debug_matrix_test : public ::testing::Test
         EXPECT_EQ(matrix.cols(), 17u);
         EXPECT_EQ(matrix.rows(), 9u);
 
-        EXPECT_EQ(matrix.at({row_index_type{0u}, column_index_type{0u}}), N);
-        EXPECT_EQ(matrix.at({row_index_type{3u}, column_index_type{6u}}), D);
-        EXPECT_EQ(matrix.at({row_index_type{3u}, column_index_type{0u}}), U);
-        EXPECT_EQ(matrix.at({row_index_type{0u}, column_index_type{6u}}), L);
-        EXPECT_EQ(matrix.at({row_index_type{8u}, column_index_type{5u}}), DU);
-        EXPECT_EQ(matrix.at({row_index_type{2u}, column_index_type{5u}}), DL);
-        EXPECT_EQ(matrix.at({row_index_type{6u}, column_index_type{4u}}), UL);
-        EXPECT_EQ(matrix.at({row_index_type{4u}, column_index_type{6u}}), DUL);
+        EXPECT_EQ(matrix.at({seqan3::detail::row_index_type{0u}, seqan3::detail::column_index_type{0u}}), N);
+        EXPECT_EQ(matrix.at({seqan3::detail::row_index_type{3u}, seqan3::detail::column_index_type{6u}}), D);
+        EXPECT_EQ(matrix.at({seqan3::detail::row_index_type{3u}, seqan3::detail::column_index_type{0u}}), U);
+        EXPECT_EQ(matrix.at({seqan3::detail::row_index_type{0u}, seqan3::detail::column_index_type{6u}}), L);
+        EXPECT_EQ(matrix.at({seqan3::detail::row_index_type{8u}, seqan3::detail::column_index_type{5u}}), DU);
+        EXPECT_EQ(matrix.at({seqan3::detail::row_index_type{2u}, seqan3::detail::column_index_type{5u}}), DL);
+        EXPECT_EQ(matrix.at({seqan3::detail::row_index_type{6u}, seqan3::detail::column_index_type{4u}}), UL);
+        EXPECT_EQ(matrix.at({seqan3::detail::row_index_type{4u}, seqan3::detail::column_index_type{6u}}), DUL);
 
         for (size_t row = 0; row < matrix.rows(); row++)
             for (size_t col = 0; col < matrix.cols(); col++)
-                EXPECT_EQ(matrix.at({row_index_type{row}, column_index_type{col}}), traces[row * matrix.cols() + col]);
+                EXPECT_EQ(matrix.at({seqan3::detail::row_index_type{row},
+                                     seqan3::detail::column_index_type{col}}), traces[row * matrix.cols() + col]);
     }
 };
 
@@ -335,8 +341,8 @@ using trace_matrix_test = debug_matrix_test;
 template <typename>
 struct debug_matrix_traits;
 
-template <matrix matrix_t, typename first_sequence_t, typename second_sequence_t>
-struct debug_matrix_traits<debug_matrix<matrix_t, first_sequence_t, second_sequence_t>>
+template <seqan3::detail::matrix matrix_t, typename first_sequence_t, typename second_sequence_t>
+struct debug_matrix_traits<seqan3::detail::debug_matrix<matrix_t, first_sequence_t, second_sequence_t>>
 {
     using matrix_type = matrix_t;
     using first_sequence_type = first_sequence_t;
@@ -345,51 +351,51 @@ struct debug_matrix_traits<debug_matrix<matrix_t, first_sequence_t, second_seque
 
 TEST_F(debug_matrix_test, matrix_concept)
 {
-    EXPECT_TRUE((matrix<row_wise_matrix<int>>));
-    EXPECT_TRUE((matrix<row_wise_matrix<int> &>));
-    EXPECT_TRUE((matrix<row_wise_matrix<int> const>));
-    EXPECT_TRUE((matrix<row_wise_matrix<int> const &>));
-    EXPECT_TRUE((matrix<debug_matrix<row_wise_matrix<int>>>));
-    EXPECT_TRUE((matrix<debug_matrix<row_wise_matrix<int> &>>));
-    EXPECT_TRUE((matrix<debug_matrix<row_wise_matrix<int> const>>));
-    EXPECT_TRUE((matrix<debug_matrix<row_wise_matrix<int> const &>>));
+    EXPECT_TRUE((seqan3::detail::matrix<seqan3::detail::row_wise_matrix<int>>));
+    EXPECT_TRUE((seqan3::detail::matrix<seqan3::detail::row_wise_matrix<int> &>));
+    EXPECT_TRUE((seqan3::detail::matrix<seqan3::detail::row_wise_matrix<int> const>));
+    EXPECT_TRUE((seqan3::detail::matrix<seqan3::detail::row_wise_matrix<int> const &>));
+    EXPECT_TRUE((seqan3::detail::matrix<seqan3::detail::debug_matrix<seqan3::detail::row_wise_matrix<int>>>));
+    EXPECT_TRUE((seqan3::detail::matrix<seqan3::detail::debug_matrix<seqan3::detail::row_wise_matrix<int> &>>));
+    EXPECT_TRUE((seqan3::detail::matrix<seqan3::detail::debug_matrix<seqan3::detail::row_wise_matrix<int> const>>));
+    EXPECT_TRUE((seqan3::detail::matrix<seqan3::detail::debug_matrix<seqan3::detail::row_wise_matrix<int> const &>>));
 }
 
 TEST_F(debug_matrix_test, construct_with_references)
 {
-    using debug_matrix_type = decltype(debug_matrix{score_matrix, first_sequence, second_sequence});
+    using debug_matrix_type = decltype(seqan3::detail::debug_matrix{score_matrix, first_sequence, second_sequence});
     using matrix_type = typename debug_matrix_traits<debug_matrix_type>::matrix_type;
     using first_sequence_type = typename debug_matrix_traits<debug_matrix_type>::first_sequence_type;
     using second_sequence_type = typename debug_matrix_traits<debug_matrix_type>::second_sequence_type;
 
-    EXPECT_TRUE((std::same_as<matrix_type, row_wise_matrix<int> &>));
-    EXPECT_TRUE((std::same_as<first_sequence_type, std::vector<dna4> &>));
-    EXPECT_TRUE((std::same_as<second_sequence_type, std::vector<dna4> &>));
+    EXPECT_TRUE((std::same_as<matrix_type, seqan3::detail::row_wise_matrix<int> &>));
+    EXPECT_TRUE((std::same_as<first_sequence_type, std::vector<seqan3::dna4> &>));
+    EXPECT_TRUE((std::same_as<second_sequence_type, std::vector<seqan3::dna4> &>));
 }
 
 TEST_F(debug_matrix_test, construct_with_move)
 {
-    using debug_matrix_type = decltype(debug_matrix{std::move(score_matrix),
+    using debug_matrix_type = decltype(seqan3::detail::debug_matrix{std::move(score_matrix),
                                                     std::move(first_sequence), std::move(second_sequence)});
     using matrix_type = typename debug_matrix_traits<debug_matrix_type>::matrix_type;
     using first_sequence_type = typename debug_matrix_traits<debug_matrix_type>::first_sequence_type;
     using second_sequence_type = typename debug_matrix_traits<debug_matrix_type>::second_sequence_type;
 
-    EXPECT_TRUE((std::same_as<matrix_type, row_wise_matrix<int>>));
-    EXPECT_TRUE((std::same_as<first_sequence_type, std::vector<dna4>>));
-    EXPECT_TRUE((std::same_as<second_sequence_type, std::vector<dna4>>));
+    EXPECT_TRUE((std::same_as<matrix_type, seqan3::detail::row_wise_matrix<int>>));
+    EXPECT_TRUE((std::same_as<first_sequence_type, std::vector<seqan3::dna4>>));
+    EXPECT_TRUE((std::same_as<second_sequence_type, std::vector<seqan3::dna4>>));
 }
 
 TEST_F(score_matrix_test, other_matrix)
 {
-    debug_matrix matrix{score_matrix};
+    seqan3::detail::debug_matrix matrix{score_matrix};
 
     test_score_matrix(std::move(matrix));
 }
 
 TEST_F(score_matrix_test, sequences_other_matrix)
 {
-    debug_matrix matrix{score_matrix, first_sequence, second_sequence};
+    seqan3::detail::debug_matrix matrix{score_matrix, first_sequence, second_sequence};
 
     EXPECT_EQ(matrix.first_sequence(), first_sequence);
     EXPECT_EQ(matrix.second_sequence(), second_sequence);
@@ -402,9 +408,11 @@ TEST_F(score_matrix_test, equal)
     // last entry of second row
     std::vector<int> scores_unequal{scores};
     scores_unequal[2 * 16] = -16;
-    row_wise_matrix<int> score_matrix_unequal{number_rows{9u}, number_cols{17u}, std::move(scores_unequal)};
+    seqan3::detail::row_wise_matrix<int> score_matrix_unequal{seqan3::detail::number_rows{9u},
+                                                              seqan3::detail::number_cols{17u},
+                                                              std::move(scores_unequal)};
 
-    debug_matrix matrix{score_matrix};
+    seqan3::detail::debug_matrix matrix{score_matrix};
 
     EXPECT_EQ(matrix, score_matrix);
     EXPECT_EQ(matrix, matrix);
@@ -418,9 +426,11 @@ TEST_F(score_matrix_test, not_equal)
     // last entry of second row
     std::vector<int> scores_unequal{scores};
     scores_unequal[2 * 16] = -16;
-    row_wise_matrix<int> score_matrix_unequal{number_rows{9u}, number_cols{17u}, std::move(scores_unequal)};
+    seqan3::detail::row_wise_matrix<int> score_matrix_unequal{seqan3::detail::number_rows{9u},
+                                                              seqan3::detail::number_cols{17u},
+                                                              std::move(scores_unequal)};
 
-    debug_matrix matrix{score_matrix};
+    seqan3::detail::debug_matrix matrix{score_matrix};
 
     EXPECT_FALSE(matrix != score_matrix);
     EXPECT_FALSE(matrix != matrix);
@@ -433,8 +443,8 @@ TEST_F(score_matrix_test, sub_matrix_lvalue)
 {
     auto first_sequence_expect = first_sequence;
     auto second_sequence_expect = second_sequence;
-    debug_matrix matrix{score_matrix, std::move(first_sequence), std::move(second_sequence)};
-    debug_matrix sub_matrix = matrix.sub_matrix(9u, 7u);
+    seqan3::detail::debug_matrix matrix{score_matrix, std::move(first_sequence), std::move(second_sequence)};
+    seqan3::detail::debug_matrix sub_matrix = matrix.sub_matrix(9u, 7u);
 
     EXPECT_EQ(sub_matrix.rows(), 9u);
     EXPECT_EQ(sub_matrix.cols(), 7u);
@@ -448,8 +458,8 @@ TEST_F(score_matrix_test, sub_matrix_rvalue)
 {
     auto first_sequence_expect = first_sequence;
     auto second_sequence_expect = second_sequence;
-    debug_matrix matrix{score_matrix, std::move(first_sequence), std::move(second_sequence)};
-    debug_matrix sub_matrix = std::move(matrix).sub_matrix(9u, 7u);
+    seqan3::detail::debug_matrix matrix{score_matrix, std::move(first_sequence), std::move(second_sequence)};
+    seqan3::detail::debug_matrix sub_matrix = std::move(matrix).sub_matrix(9u, 7u);
 
     EXPECT_EQ(sub_matrix.rows(), 9u);
     EXPECT_EQ(sub_matrix.cols(), 7u);
@@ -457,15 +467,15 @@ TEST_F(score_matrix_test, sub_matrix_rvalue)
     EXPECT_EQ(sub_matrix.second_sequence(), second_sequence_expect);
 
     EXPECT_EQ(sub_matrix, score_matrix_s9u_7u);
-    EXPECT_EQ((debug_matrix{score_matrix}.sub_matrix(4u, 17u)), score_matrix_s4u_17u);
+    EXPECT_EQ((seqan3::detail::debug_matrix{score_matrix}.sub_matrix(4u, 17u)), score_matrix_s4u_17u);
 }
 
 TEST_F(score_matrix_test, mask_matrix_lvalue)
 {
     auto first_sequence_expect = first_sequence;
     auto second_sequence_expect = second_sequence;
-    debug_matrix matrix{score_matrix, std::move(first_sequence), std::move(second_sequence)};
-    debug_matrix mask_matrix = matrix.mask_matrix(masking_matrix);
+    seqan3::detail::debug_matrix matrix{score_matrix, std::move(first_sequence), std::move(second_sequence)};
+    seqan3::detail::debug_matrix mask_matrix = matrix.mask_matrix(masking_matrix);
 
     EXPECT_EQ(mask_matrix.rows(), 9u);
     EXPECT_EQ(mask_matrix.cols(), 17u);
@@ -479,8 +489,8 @@ TEST_F(score_matrix_test, mask_matrix_rvalue)
 {
     auto first_sequence_expect = first_sequence;
     auto second_sequence_expect = second_sequence;
-    debug_matrix matrix{score_matrix, std::move(first_sequence), std::move(second_sequence)};
-    debug_matrix mask_matrix = std::move(matrix).mask_matrix(masking_matrix);
+    seqan3::detail::debug_matrix matrix{score_matrix, std::move(first_sequence), std::move(second_sequence)};
+    seqan3::detail::debug_matrix mask_matrix = std::move(matrix).mask_matrix(masking_matrix);
 
     EXPECT_EQ(mask_matrix.rows(), 9u);
     EXPECT_EQ(mask_matrix.cols(), 17u);
@@ -494,8 +504,8 @@ TEST_F(score_matrix_test, transpose_matrix_lvalue)
 {
     auto first_sequence_expect = second_sequence;
     auto second_sequence_expect = first_sequence;
-    debug_matrix matrix{score_matrix, std::move(first_sequence), std::move(second_sequence)};
-    debug_matrix transpose_matrix = matrix.transpose_matrix();
+    seqan3::detail::debug_matrix matrix{score_matrix, std::move(first_sequence), std::move(second_sequence)};
+    seqan3::detail::debug_matrix transpose_matrix = matrix.transpose_matrix();
 
     EXPECT_EQ(transpose_matrix.rows(), 17u);
     EXPECT_EQ(transpose_matrix.cols(), 9u);
@@ -509,8 +519,8 @@ TEST_F(score_matrix_test, transpose_matrix_rvalue)
 {
     auto first_sequence_expect = second_sequence;
     auto second_sequence_expect = first_sequence;
-    debug_matrix matrix{score_matrix, std::move(first_sequence), std::move(second_sequence)};
-    debug_matrix transpose_matrix = std::move(matrix).transpose_matrix();
+    seqan3::detail::debug_matrix matrix{score_matrix, std::move(first_sequence), std::move(second_sequence)};
+    seqan3::detail::debug_matrix transpose_matrix = std::move(matrix).transpose_matrix();
 
     EXPECT_EQ(transpose_matrix.rows(), 17u);
     EXPECT_EQ(transpose_matrix.cols(), 9u);
@@ -522,8 +532,8 @@ TEST_F(score_matrix_test, transpose_matrix_rvalue)
 
 TEST_F(score_matrix_test, combine_sub_transpose_operations)
 {
-    debug_matrix matrix1{score_matrix, first_sequence, second_sequence};
-    debug_matrix matrix2{score_matrix, first_sequence, second_sequence};
+    seqan3::detail::debug_matrix matrix1{score_matrix, first_sequence, second_sequence};
+    seqan3::detail::debug_matrix matrix2{score_matrix, first_sequence, second_sequence};
     matrix1.transpose_matrix().sub_matrix(7u, 9u);
     matrix2.sub_matrix(9u, 7u).transpose_matrix();
 
@@ -538,8 +548,8 @@ TEST_F(score_matrix_test, combine_sub_transpose_operations)
 
 TEST_F(score_matrix_test, combine_mask_transpose_operations)
 {
-    debug_matrix matrix1{score_matrix, first_sequence, second_sequence};
-    debug_matrix matrix2{score_matrix, first_sequence, second_sequence};
+    seqan3::detail::debug_matrix matrix1{score_matrix, first_sequence, second_sequence};
+    seqan3::detail::debug_matrix matrix2{score_matrix, first_sequence, second_sequence};
     matrix1.mask_matrix(masking_matrix).sub_matrix(9u, 7u);
     matrix2.sub_matrix(9u, 7u).mask_matrix(masking_matrix_s9u_7u);
 
@@ -552,12 +562,12 @@ TEST_F(score_matrix_test, combine_mask_transpose_operations)
 
 TEST_F(score_matrix_test, combine_sub_mask_transpose_operations)
 {
-    debug_matrix matrix1{score_matrix, first_sequence, second_sequence};
-    debug_matrix matrix2{score_matrix, first_sequence, second_sequence};
-    debug_matrix matrix3{score_matrix, first_sequence, second_sequence};
-    debug_matrix matrix4{score_matrix, first_sequence, second_sequence};
-    debug_matrix matrix5{score_matrix, first_sequence, second_sequence};
-    debug_matrix matrix6{score_matrix, first_sequence, second_sequence};
+    seqan3::detail::debug_matrix matrix1{score_matrix, first_sequence, second_sequence};
+    seqan3::detail::debug_matrix matrix2{score_matrix, first_sequence, second_sequence};
+    seqan3::detail::debug_matrix matrix3{score_matrix, first_sequence, second_sequence};
+    seqan3::detail::debug_matrix matrix4{score_matrix, first_sequence, second_sequence};
+    seqan3::detail::debug_matrix matrix5{score_matrix, first_sequence, second_sequence};
+    seqan3::detail::debug_matrix matrix6{score_matrix, first_sequence, second_sequence};
     matrix1.mask_matrix(masking_matrix).transpose_matrix().sub_matrix(7u, 9u);
     matrix2.mask_matrix(masking_matrix).sub_matrix(9u, 7u).transpose_matrix();
     matrix3.sub_matrix(9u, 7u).mask_matrix(masking_matrix_s9u_7u).transpose_matrix();
@@ -596,14 +606,14 @@ TEST_F(score_matrix_test, combine_sub_mask_transpose_operations)
 
 TEST_F(trace_matrix_test, other_matrix)
 {
-    debug_matrix matrix{trace_matrix};
+    seqan3::detail::debug_matrix matrix{trace_matrix};
 
     test_trace_matrix(std::move(matrix));
 }
 
 TEST_F(trace_matrix_test, sequences_other_matrix)
 {
-    debug_matrix matrix{trace_matrix, first_sequence, second_sequence};
+    seqan3::detail::debug_matrix matrix{trace_matrix, first_sequence, second_sequence};
 
     EXPECT_EQ(matrix.first_sequence(), first_sequence);
     EXPECT_EQ(matrix.second_sequence(), second_sequence);
@@ -614,13 +624,14 @@ TEST_F(trace_matrix_test, sequences_other_matrix)
 TEST_F(trace_matrix_test, equal)
 {
     // last entry of second row
-    std::vector<trace_directions> traces_unequal{traces};
-    traces_unequal[2 * 16] = trace_directions::up;
-    row_wise_matrix<trace_directions> trace_matrix_unequal{number_rows{9u},
-                                                           number_cols{17u},
-                                                           std::move(traces_unequal)};
+    std::vector<seqan3::detail::trace_directions> traces_unequal{traces};
+    traces_unequal[2 * 16] = seqan3::detail::trace_directions::up;
+    seqan3::detail::row_wise_matrix<seqan3::detail::trace_directions>
+        trace_matrix_unequal{seqan3::detail::number_rows{9u},
+                             seqan3::detail::number_cols{17u},
+                             std::move(traces_unequal)};
 
-    debug_matrix matrix{trace_matrix};
+    seqan3::detail::debug_matrix matrix{trace_matrix};
 
     EXPECT_EQ(matrix, trace_matrix);
     EXPECT_EQ(matrix, matrix);
@@ -632,13 +643,14 @@ TEST_F(trace_matrix_test, equal)
 TEST_F(trace_matrix_test, not_equal)
 {
     // last entry of second row
-    std::vector<trace_directions> traces_unequal{traces};
-    traces_unequal[2 * 16] = trace_directions::up;
-    row_wise_matrix<trace_directions> trace_matrix_unequal{number_rows{9u},
-                                                           number_cols{17u},
-                                                           std::move(traces_unequal)};
+    std::vector<seqan3::detail::trace_directions> traces_unequal{traces};
+    traces_unequal[2 * 16] = seqan3::detail::trace_directions::up;
+    seqan3::detail::row_wise_matrix<seqan3::detail::trace_directions>
+        trace_matrix_unequal{seqan3::detail::number_rows{9u},
+                             seqan3::detail::number_cols{17u},
+                             std::move(traces_unequal)};
 
-    debug_matrix matrix{trace_matrix};
+    seqan3::detail::debug_matrix matrix{trace_matrix};
 
     EXPECT_FALSE(matrix != trace_matrix);
     EXPECT_FALSE(matrix != matrix);
@@ -651,8 +663,8 @@ TEST_F(trace_matrix_test, sub_matrix_lvalue)
 {
     auto first_sequence_expect = first_sequence;
     auto second_sequence_expect = second_sequence;
-    debug_matrix matrix{trace_matrix, std::move(first_sequence), std::move(second_sequence)};
-    debug_matrix sub_matrix = matrix.sub_matrix(9u, 7u);
+    seqan3::detail::debug_matrix matrix{trace_matrix, std::move(first_sequence), std::move(second_sequence)};
+    seqan3::detail::debug_matrix sub_matrix = matrix.sub_matrix(9u, 7u);
 
     EXPECT_EQ(sub_matrix.rows(), 9u);
     EXPECT_EQ(sub_matrix.cols(), 7u);
@@ -666,8 +678,8 @@ TEST_F(trace_matrix_test, sub_matrix_rvalue)
 {
     auto first_sequence_expect = first_sequence;
     auto second_sequence_expect = second_sequence;
-    debug_matrix matrix{trace_matrix, std::move(first_sequence), std::move(second_sequence)};
-    debug_matrix sub_matrix = std::move(matrix).sub_matrix(9u, 7u);
+    seqan3::detail::debug_matrix matrix{trace_matrix, std::move(first_sequence), std::move(second_sequence)};
+    seqan3::detail::debug_matrix sub_matrix = std::move(matrix).sub_matrix(9u, 7u);
 
     EXPECT_EQ(sub_matrix.rows(), 9u);
     EXPECT_EQ(sub_matrix.cols(), 7u);
@@ -675,15 +687,15 @@ TEST_F(trace_matrix_test, sub_matrix_rvalue)
     EXPECT_EQ(sub_matrix.second_sequence(), second_sequence_expect);
 
     EXPECT_EQ(sub_matrix, trace_matrix_s9u_7u);
-    EXPECT_EQ((debug_matrix{trace_matrix}.sub_matrix(4u, 17u)), trace_matrix_s4u_17u);
+    EXPECT_EQ((seqan3::detail::debug_matrix{trace_matrix}.sub_matrix(4u, 17u)), trace_matrix_s4u_17u);
 }
 
 TEST_F(trace_matrix_test, mask_matrix_lvalue)
 {
     auto first_sequence_expect = first_sequence;
     auto second_sequence_expect = second_sequence;
-    debug_matrix matrix{trace_matrix, std::move(first_sequence), std::move(second_sequence)};
-    debug_matrix mask_matrix = matrix.mask_matrix(masking_matrix);
+    seqan3::detail::debug_matrix matrix{trace_matrix, std::move(first_sequence), std::move(second_sequence)};
+    seqan3::detail::debug_matrix mask_matrix = matrix.mask_matrix(masking_matrix);
 
     EXPECT_EQ(mask_matrix.rows(), 9u);
     EXPECT_EQ(mask_matrix.cols(), 17u);
@@ -697,8 +709,8 @@ TEST_F(trace_matrix_test, mask_matrix_rvalue)
 {
     auto first_sequence_expect = first_sequence;
     auto second_sequence_expect = second_sequence;
-    debug_matrix matrix{trace_matrix, std::move(first_sequence), std::move(second_sequence)};
-    debug_matrix mask_matrix = std::move(matrix).mask_matrix(masking_matrix);
+    seqan3::detail::debug_matrix matrix{trace_matrix, std::move(first_sequence), std::move(second_sequence)};
+    seqan3::detail::debug_matrix mask_matrix = std::move(matrix).mask_matrix(masking_matrix);
 
     EXPECT_EQ(mask_matrix.rows(), 9u);
     EXPECT_EQ(mask_matrix.cols(), 17u);
@@ -712,8 +724,8 @@ TEST_F(trace_matrix_test, transpose_matrix_lvalue)
 {
     auto first_sequence_expect = second_sequence;
     auto second_sequence_expect = first_sequence;
-    debug_matrix matrix{trace_matrix, std::move(first_sequence), std::move(second_sequence)};
-    debug_matrix transpose_matrix = matrix.transpose_matrix();
+    seqan3::detail::debug_matrix matrix{trace_matrix, std::move(first_sequence), std::move(second_sequence)};
+    seqan3::detail::debug_matrix transpose_matrix = matrix.transpose_matrix();
 
     EXPECT_EQ(transpose_matrix.rows(), 17u);
     EXPECT_EQ(transpose_matrix.cols(), 9u);
@@ -727,8 +739,8 @@ TEST_F(trace_matrix_test, transpose_matrix_rvalue)
 {
     auto first_sequence_expect = second_sequence;
     auto second_sequence_expect = first_sequence;
-    debug_matrix matrix{trace_matrix, std::move(first_sequence), std::move(second_sequence)};
-    debug_matrix transpose_matrix = std::move(matrix).transpose_matrix();
+    seqan3::detail::debug_matrix matrix{trace_matrix, std::move(first_sequence), std::move(second_sequence)};
+    seqan3::detail::debug_matrix transpose_matrix = std::move(matrix).transpose_matrix();
 
     EXPECT_EQ(transpose_matrix.rows(), 17u);
     EXPECT_EQ(transpose_matrix.cols(), 9u);

--- a/test/unit/alignment/matrix/debug_matrix_test.cpp
+++ b/test/unit/alignment/matrix/debug_matrix_test.cpp
@@ -309,8 +309,8 @@ struct debug_matrix_test : public ::testing::Test
 
         for (size_t row = 0; row < matrix.rows(); row++)
             for (size_t col = 0; col < matrix.cols(); col++)
-                EXPECT_EQ((matrix.at({seqan3::detail::row_index_type{row},
-                                      seqan3::detail::column_index_type{col}})), scores[row * matrix.cols() + col]);
+                EXPECT_EQ((matrix.at({seqan3::detail::row_index_type{row}, seqan3::detail::column_index_type{col}})),
+                          scores[row * matrix.cols() + col]);
     }
 
     template <typename trace_matrix_t>
@@ -330,8 +330,8 @@ struct debug_matrix_test : public ::testing::Test
 
         for (size_t row = 0; row < matrix.rows(); row++)
             for (size_t col = 0; col < matrix.cols(); col++)
-                EXPECT_EQ(matrix.at({seqan3::detail::row_index_type{row},
-                                     seqan3::detail::column_index_type{col}}), traces[row * matrix.cols() + col]);
+                EXPECT_EQ(matrix.at({seqan3::detail::row_index_type{row}, seqan3::detail::column_index_type{col}}),
+                          traces[row * matrix.cols() + col]);
     }
 };
 

--- a/test/unit/alignment/matrix/debug_stream_alignment_coordinate_test.cpp
+++ b/test/unit/alignment/matrix/debug_stream_alignment_coordinate_test.cpp
@@ -11,27 +11,28 @@
 
 #include <seqan3/alignment/matrix/alignment_coordinate.hpp>
 
-using namespace seqan3;
-
 TEST(debug_stream_test, advanceable_alignment_coordinate)
 {
     using not_incrementable =
-        detail::advanceable_alignment_coordinate<detail::advanceable_alignment_coordinate_state::none>;
+        seqan3::detail::advanceable_alignment_coordinate<seqan3::detail::advanceable_alignment_coordinate_state::none>;
     using row_incrementable =
-        detail::advanceable_alignment_coordinate<detail::advanceable_alignment_coordinate_state::row>;
+        seqan3::detail::advanceable_alignment_coordinate<seqan3::detail::advanceable_alignment_coordinate_state::row>;
     using col_incrementable =
-        detail::advanceable_alignment_coordinate<detail::advanceable_alignment_coordinate_state::column>;
+        seqan3::detail::advanceable_alignment_coordinate<seqan3::detail::advanceable_alignment_coordinate_state::column>;
 
-    not_incrementable co_not{detail::column_index_type{10u}, detail::row_index_type{5u}};
-    col_incrementable co_col{detail::column_index_type{10u}, detail::row_index_type{5u}};
-    row_incrementable co_row{detail::column_index_type{10u}, detail::row_index_type{5u}};
+    not_incrementable co_not{seqan3::detail::column_index_type{10u}, seqan3::detail::row_index_type{5u}};
+    col_incrementable co_col{seqan3::detail::column_index_type{10u}, seqan3::detail::row_index_type{5u}};
+    row_incrementable co_row{seqan3::detail::column_index_type{10u}, seqan3::detail::row_index_type{5u}};
 
-    EXPECT_TRUE((detail::is_value_specialisation_of_v<not_incrementable, detail::advanceable_alignment_coordinate>));
-    EXPECT_TRUE((detail::is_value_specialisation_of_v<col_incrementable, detail::advanceable_alignment_coordinate>));
-    EXPECT_TRUE((detail::is_value_specialisation_of_v<row_incrementable, detail::advanceable_alignment_coordinate>));
+    EXPECT_TRUE((seqan3::detail::is_value_specialisation_of_v<not_incrementable,
+                 seqan3::detail::advanceable_alignment_coordinate>));
+    EXPECT_TRUE((seqan3::detail::is_value_specialisation_of_v<col_incrementable,
+                 seqan3::detail::advanceable_alignment_coordinate>));
+    EXPECT_TRUE((seqan3::detail::is_value_specialisation_of_v<row_incrementable,
+                 seqan3::detail::advanceable_alignment_coordinate>));
 
     std::stringstream sstream{};
-    debug_stream_type dstream{sstream};
+    seqan3::debug_stream_type dstream{sstream};
     dstream << co_not;
     dstream << co_col;
     dstream << co_row;
@@ -44,12 +45,13 @@ TEST(debug_stream_test, advanceable_alignment_coordinate)
 
 TEST(debug_stream_test, alignment_coordinate)
 {
-    alignment_coordinate co_align{detail::column_index_type{10u}, detail::row_index_type{5u}};
+    seqan3::alignment_coordinate co_align{seqan3::detail::column_index_type{10u}, seqan3::detail::row_index_type{5u}};
 
-    EXPECT_FALSE((detail::is_value_specialisation_of_v<decltype(co_align), detail::advanceable_alignment_coordinate>));
+    EXPECT_FALSE((seqan3::detail::is_value_specialisation_of_v<decltype(co_align),
+                  seqan3::detail::advanceable_alignment_coordinate>));
 
     std::stringstream sstream{};
-    debug_stream_type dstream{sstream};
+    seqan3::debug_stream_type dstream{sstream};
     dstream << co_align;
     EXPECT_EQ(sstream.str(), "(10,5)");
 

--- a/test/unit/alignment/matrix/debug_stream_alignment_coordinate_test.cpp
+++ b/test/unit/alignment/matrix/debug_stream_alignment_coordinate_test.cpp
@@ -25,11 +25,11 @@ TEST(debug_stream_test, advanceable_alignment_coordinate)
     row_incrementable co_row{seqan3::detail::column_index_type{10u}, seqan3::detail::row_index_type{5u}};
 
     EXPECT_TRUE((seqan3::detail::is_value_specialisation_of_v<not_incrementable,
-                 seqan3::detail::advanceable_alignment_coordinate>));
+                                                              seqan3::detail::advanceable_alignment_coordinate>));
     EXPECT_TRUE((seqan3::detail::is_value_specialisation_of_v<col_incrementable,
-                 seqan3::detail::advanceable_alignment_coordinate>));
+                                                              seqan3::detail::advanceable_alignment_coordinate>));
     EXPECT_TRUE((seqan3::detail::is_value_specialisation_of_v<row_incrementable,
-                 seqan3::detail::advanceable_alignment_coordinate>));
+                                                              seqan3::detail::advanceable_alignment_coordinate>));
 
     std::stringstream sstream{};
     seqan3::debug_stream_type dstream{sstream};
@@ -48,7 +48,7 @@ TEST(debug_stream_test, alignment_coordinate)
     seqan3::alignment_coordinate co_align{seqan3::detail::column_index_type{10u}, seqan3::detail::row_index_type{5u}};
 
     EXPECT_FALSE((seqan3::detail::is_value_specialisation_of_v<decltype(co_align),
-                  seqan3::detail::advanceable_alignment_coordinate>));
+                                                               seqan3::detail::advanceable_alignment_coordinate>));
 
     std::stringstream sstream{};
     seqan3::debug_stream_type dstream{sstream};

--- a/test/unit/alignment/matrix/debug_stream_debug_matrix_test.cpp
+++ b/test/unit/alignment/matrix/debug_stream_debug_matrix_test.cpp
@@ -10,19 +10,19 @@
 #include <seqan3/alignment/matrix/debug_matrix.hpp>
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 
-using namespace seqan3;
+using seqan3::operator""_dna4;
 
 namespace seqan3::detail
 {
 struct debug_matrix_stream_test : public ::testing::Test
 {
     static constexpr auto inf = std::nullopt;
-    std::vector<dna4> sequence1 = "AACACGTTAACCGGTT"_dna4;
-    std::vector<dna4> sequence2 = "ACGTACGT"_dna4;
+    std::vector<seqan3::dna4> sequence1 = "AACACGTTAACCGGTT"_dna4;
+    std::vector<seqan3::dna4> sequence2 = "ACGTACGT"_dna4;
 
-    detail::row_wise_matrix<std::optional<int>> score_matrix
+    seqan3::detail::row_wise_matrix<std::optional<int>> score_matrix
     {
-        number_rows{9u}, number_cols{17u}, std::vector<std::optional<int>>
+        seqan3::detail::number_rows{9u}, seqan3::detail::number_cols{17u}, std::vector<std::optional<int>>
         {
             0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16,
             1,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,
@@ -36,15 +36,15 @@ struct debug_matrix_stream_test : public ::testing::Test
         }
     };
 
-    detail::trace_directions N{},
-        D{detail::trace_directions::diagonal},
-        L{detail::trace_directions::left},
-        U{detail::trace_directions::up},
+    seqan3::detail::trace_directions N{},
+        D{seqan3::detail::trace_directions::diagonal},
+        L{seqan3::detail::trace_directions::left},
+        U{seqan3::detail::trace_directions::up},
         DL{D|L}, DU{D|U}, UL{U|L}, DUL{D|U|L};
 
-    detail::row_wise_matrix<detail::trace_directions> trace_matrix
+    seqan3::detail::row_wise_matrix<detail::trace_directions> trace_matrix
     {
-        number_rows{9u}, number_cols{17u}, std::vector
+        seqan3::detail::number_rows{9u}, seqan3::detail::number_cols{17u}, std::vector
         {
             N,  L,  L,  L,  L,  L,  L,  L,  L,  L,  L,  L,  L,  L,  L,  L,  L,
             U,  D,  DL, L,  DL, L,  L,  L,  L,  DL, DL, L,  L,  L,  L,  L,  L,
@@ -274,9 +274,9 @@ TEST_F(debug_matrix_stream_test, unicode_str_length)
 
 TEST_F(debug_matrix_stream_test, score_matrix_ascii)
 {
-    detail::debug_matrix matrix{score_matrix};
+    seqan3::detail::debug_matrix matrix{score_matrix};
 
-    fmtflags2 flags = fmtflags2::default_;
+    seqan3::fmtflags2 flags = seqan3::fmtflags2::default_;
 
     std::stringstream stream;
     matrix.stream_matrix(stream, flags);
@@ -285,9 +285,9 @@ TEST_F(debug_matrix_stream_test, score_matrix_ascii)
 
 TEST_F(debug_matrix_stream_test, score_matrix_ascii_with_sequences)
 {
-    detail::debug_matrix matrix{score_matrix, sequence1, sequence2};
+    seqan3::detail::debug_matrix matrix{score_matrix, sequence1, sequence2};
 
-    fmtflags2 flags = fmtflags2::default_;
+    seqan3::fmtflags2 flags = seqan3::fmtflags2::default_;
     EXPECT_EQ(matrix.auto_column_width(flags), 2u);
 
     std::stringstream stream;
@@ -297,9 +297,9 @@ TEST_F(debug_matrix_stream_test, score_matrix_ascii_with_sequences)
 
 TEST_F(debug_matrix_stream_test, score_matrix_unicode)
 {
-    detail::debug_matrix matrix{score_matrix};
+    seqan3::detail::debug_matrix matrix{score_matrix};
 
-    fmtflags2 flags = fmtflags2::default_ | fmtflags2::utf8;
+    seqan3::fmtflags2 flags = seqan3::fmtflags2::default_ | seqan3::fmtflags2::utf8;
     EXPECT_EQ(matrix.auto_column_width(flags), 2u);
 
     std::stringstream stream;
@@ -309,10 +309,10 @@ TEST_F(debug_matrix_stream_test, score_matrix_unicode)
 
 TEST_F(debug_matrix_stream_test, score_matrix_unicode_with_sequences)
 {
-    detail::debug_matrix matrix{score_matrix, sequence1, sequence2};
+    seqan3::detail::debug_matrix matrix{score_matrix, sequence1, sequence2};
     matrix.column_width = 4u;
 
-    fmtflags2 flags = fmtflags2::default_ | fmtflags2::utf8;
+    seqan3::fmtflags2 flags = seqan3::fmtflags2::default_ | seqan3::fmtflags2::utf8;
     EXPECT_EQ(matrix.auto_column_width(flags), 2u);
 
     std::stringstream stream;
@@ -322,10 +322,10 @@ TEST_F(debug_matrix_stream_test, score_matrix_unicode_with_sequences)
 
 TEST_F(debug_matrix_stream_test, trace_matrix_ascii)
 {
-    detail::debug_matrix matrix{trace_matrix};
+    seqan3::detail::debug_matrix matrix{trace_matrix};
     matrix.column_width = 4u;
 
-    fmtflags2 flags = fmtflags2::default_;
+    seqan3::fmtflags2 flags = seqan3::fmtflags2::default_;
 
     EXPECT_EQ(matrix.auto_column_width(flags), 3u);
 
@@ -336,10 +336,10 @@ TEST_F(debug_matrix_stream_test, trace_matrix_ascii)
 
 TEST_F(debug_matrix_stream_test, trace_matrix_ascii_with_sequences)
 {
-    detail::debug_matrix matrix{trace_matrix, sequence1, sequence2};
+    seqan3::detail::debug_matrix matrix{trace_matrix, sequence1, sequence2};
     matrix.column_width = 4u;
 
-    fmtflags2 flags = fmtflags2::default_;
+    seqan3::fmtflags2 flags = seqan3::fmtflags2::default_;
 
     EXPECT_EQ(matrix.auto_column_width(flags), 3u);
 
@@ -350,9 +350,9 @@ TEST_F(debug_matrix_stream_test, trace_matrix_ascii_with_sequences)
 
 TEST_F(debug_matrix_stream_test, trace_matrix_unicode)
 {
-    detail::debug_matrix matrix{trace_matrix};
+    seqan3::detail::debug_matrix matrix{trace_matrix};
 
-    fmtflags2 flags = fmtflags2::default_ | fmtflags2::utf8;
+    seqan3::fmtflags2 flags = seqan3::fmtflags2::default_ | seqan3::fmtflags2::utf8;
     EXPECT_EQ(matrix.auto_column_width(flags), 3u);
 
     std::stringstream stream;
@@ -362,10 +362,10 @@ TEST_F(debug_matrix_stream_test, trace_matrix_unicode)
 
 TEST_F(debug_matrix_stream_test, trace_matrix_unicode_with_sequences)
 {
-    detail::debug_matrix matrix{trace_matrix, sequence1, sequence2};
+    seqan3::detail::debug_matrix matrix{trace_matrix, sequence1, sequence2};
     matrix.column_width = 4u;
 
-    fmtflags2 flags = fmtflags2::default_ | fmtflags2::utf8;
+    seqan3::fmtflags2 flags = seqan3::fmtflags2::default_ | seqan3::fmtflags2::utf8;
     EXPECT_EQ(matrix.auto_column_width(flags), 3u);
 
     std::stringstream stream;
@@ -375,10 +375,10 @@ TEST_F(debug_matrix_stream_test, trace_matrix_unicode_with_sequences)
 
 TEST_F(debug_stream_test, score_matrix_ascii)
 {
-    detail::debug_matrix matrix{score_matrix};
+    seqan3::detail::debug_matrix matrix{score_matrix};
 
     std::stringstream stream;
-    debug_stream_type debug_stream{stream};
+    seqan3::debug_stream_type debug_stream{stream};
     debug_stream << matrix;
 
     EXPECT_EQ(stream.str(), score_matrix_ascii);
@@ -386,10 +386,10 @@ TEST_F(debug_stream_test, score_matrix_ascii)
 
 TEST_F(debug_stream_test, score_matrix_ascii_with_sequences)
 {
-    detail::debug_matrix matrix{detail::debug_matrix{score_matrix}, sequence1, sequence2};
+    seqan3::detail::debug_matrix matrix{seqan3::detail::debug_matrix{score_matrix}, sequence1, sequence2};
 
     std::stringstream stream;
-    debug_stream_type debug_stream{stream};
+    seqan3::debug_stream_type debug_stream{stream};
     debug_stream << matrix;
 
     EXPECT_EQ(stream.str(), score_matrix_ascii_with_sequences);
@@ -397,34 +397,34 @@ TEST_F(debug_stream_test, score_matrix_ascii_with_sequences)
 
 TEST_F(debug_stream_test, score_matrix_unicode)
 {
-    detail::debug_matrix matrix{score_matrix};
+    seqan3::detail::debug_matrix matrix{score_matrix};
 
     std::stringstream stream;
-    debug_stream_type debug_stream{stream};
-    debug_stream << fmtflags2::utf8 << matrix;
+    seqan3::debug_stream_type debug_stream{stream};
+    debug_stream << seqan3::fmtflags2::utf8 << matrix;
 
     EXPECT_EQ(stream.str(), score_matrix_unicode);
 }
 
 TEST_F(debug_stream_test, score_matrix_unicode_with_sequences)
 {
-    detail::debug_matrix matrix{detail::debug_matrix{score_matrix}, sequence1, sequence2};
+    seqan3::detail::debug_matrix matrix{seqan3::detail::debug_matrix{score_matrix}, sequence1, sequence2};
     matrix.column_width = 4u;
 
     std::stringstream stream;
-    debug_stream_type debug_stream{stream};
-    debug_stream << fmtflags2::utf8 << matrix;
+    seqan3::debug_stream_type debug_stream{stream};
+    debug_stream << seqan3::fmtflags2::utf8 << matrix;
 
     EXPECT_EQ(stream.str(), score_matrix_unicode_with_sequences);
 }
 
 TEST_F(debug_stream_test, trace_matrix_ascii)
 {
-    detail::debug_matrix matrix{trace_matrix};
+    seqan3::detail::debug_matrix matrix{trace_matrix};
     matrix.column_width = 4u;
 
     std::stringstream stream;
-    debug_stream_type debug_stream{stream};
+    seqan3::debug_stream_type debug_stream{stream};
     debug_stream << matrix;
 
     EXPECT_EQ(stream.str(), trace_matrix_ascii);
@@ -432,11 +432,11 @@ TEST_F(debug_stream_test, trace_matrix_ascii)
 
 TEST_F(debug_stream_test, trace_matrix_ascii_with_sequences)
 {
-    detail::debug_matrix matrix{detail::debug_matrix{trace_matrix}, sequence1, sequence2};
+    seqan3::detail::debug_matrix matrix{seqan3::detail::debug_matrix{trace_matrix}, sequence1, sequence2};
     matrix.column_width = 4u;
 
     std::stringstream stream;
-    debug_stream_type debug_stream{stream};
+    seqan3::debug_stream_type debug_stream{stream};
     debug_stream << matrix;
 
     EXPECT_EQ(stream.str(), trace_matrix_ascii_with_sequences);
@@ -444,23 +444,23 @@ TEST_F(debug_stream_test, trace_matrix_ascii_with_sequences)
 
 TEST_F(debug_stream_test, trace_matrix_unicode)
 {
-    detail::debug_matrix matrix{trace_matrix};
+    seqan3::detail::debug_matrix matrix{trace_matrix};
 
     std::stringstream stream;
-    debug_stream_type debug_stream{stream};
-    debug_stream << fmtflags2::utf8 << matrix;
+    seqan3::debug_stream_type debug_stream{stream};
+    debug_stream << seqan3::fmtflags2::utf8 << matrix;
 
     EXPECT_EQ(stream.str(), trace_matrix_unicode);
 }
 
 TEST_F(debug_stream_test, trace_matrix_unicode_with_sequences)
 {
-    detail::debug_matrix matrix{detail::debug_matrix{trace_matrix}, sequence1, sequence2};
+    seqan3::detail::debug_matrix matrix{seqan3::detail::debug_matrix{trace_matrix}, sequence1, sequence2};
     matrix.column_width = 4u;
 
     std::stringstream stream;
-    debug_stream_type debug_stream{stream};
-    debug_stream << fmtflags2::utf8 << matrix;
+    seqan3::debug_stream_type debug_stream{stream};
+    debug_stream << seqan3::fmtflags2::utf8 << matrix;
 
     EXPECT_EQ(stream.str(), trace_matrix_unicode_with_sequences);
 }

--- a/test/unit/alignment/matrix/debug_stream_trace_directions_test.cpp
+++ b/test/unit/alignment/matrix/debug_stream_trace_directions_test.cpp
@@ -12,20 +12,19 @@
 #include <seqan3/alignment/matrix/trace_directions.hpp>
 #include <seqan3/core/debug_stream.hpp>
 
-using namespace seqan3;
-using namespace seqan3::detail;
+using seqan3::operator|;
 
-static constexpr trace_directions N = trace_directions::none;
-static constexpr trace_directions D = trace_directions::diagonal;
-static constexpr trace_directions u = trace_directions::up;
-static constexpr trace_directions l = trace_directions::left;
-static constexpr trace_directions U = trace_directions::up_open;
-static constexpr trace_directions L = trace_directions::left_open;
+static constexpr seqan3::detail::trace_directions N = seqan3::detail::trace_directions::none;
+static constexpr seqan3::detail::trace_directions D = seqan3::detail::trace_directions::diagonal;
+static constexpr seqan3::detail::trace_directions u = seqan3::detail::trace_directions::up;
+static constexpr seqan3::detail::trace_directions l = seqan3::detail::trace_directions::left;
+static constexpr seqan3::detail::trace_directions U = seqan3::detail::trace_directions::up_open;
+static constexpr seqan3::detail::trace_directions L = seqan3::detail::trace_directions::left_open;
 
 TEST(debug_stream_test, ascii)
 {
     std::stringstream s{};
-    debug_stream_type stream{s};
+    seqan3::debug_stream_type stream{s};
     stream << N << ";" << D << ";" << U << ";" << L << ";" << (D|U) << ";" << (D|L) << ";" << (U|L) << ";" << (D|U|L);
     stream << ";" << u << ";" << l << ";" << (D|u) << ";" << (D|u|l) << ";" << (D|U|u|L|l);
 
@@ -35,8 +34,8 @@ TEST(debug_stream_test, ascii)
 TEST(debug_stream_test, unicode)
 {
     std::stringstream s{};
-    debug_stream_type stream{s};
-    stream << fmtflags2::utf8;
+    seqan3::debug_stream_type stream{s};
+    stream << seqan3::fmtflags2::utf8;
     stream << N << ";" << D << ";" << U << ";" << L << ";" << (D|U) << ";" << (D|L) << ";" << (U|L) << ";" << (D|U|L);
     stream << ";" << u << ";" << l << ";" << (D|u) << ";" << (D|u|l) << ";" << (D|U|u|L|l);
 

--- a/test/unit/alignment/matrix/detail/aligned_sequence_builder_test.cpp
+++ b/test/unit/alignment/matrix/detail/aligned_sequence_builder_test.cpp
@@ -20,20 +20,21 @@
 #include <seqan3/range/views/to.hpp>
 #include <seqan3/std/algorithm>
 
-using namespace seqan3;
-using namespace seqan3::detail;
+using seqan3::operator|;
 
 template <typename test_type>
 struct aligned_sequence_builder_fixture : ::testing::Test
 {
-    static constexpr trace_directions N = trace_directions::none;
-    static constexpr trace_directions D = trace_directions::diagonal;
-    static constexpr trace_directions U = trace_directions::up;
-    static constexpr trace_directions UO = trace_directions::up_open;
-    static constexpr trace_directions L = trace_directions::left;
-    static constexpr trace_directions LO = trace_directions::left_open;
+    static constexpr seqan3::detail::trace_directions N = seqan3::detail::trace_directions::none;
+    static constexpr seqan3::detail::trace_directions D = seqan3::detail::trace_directions::diagonal;
+    static constexpr seqan3::detail::trace_directions U = seqan3::detail::trace_directions::up;
+    static constexpr seqan3::detail::trace_directions UO = seqan3::detail::trace_directions::up_open;
+    static constexpr seqan3::detail::trace_directions L = seqan3::detail::trace_directions::left;
+    static constexpr seqan3::detail::trace_directions LO = seqan3::detail::trace_directions::left_open;
 
-    two_dimensional_matrix<trace_directions> matrix{number_rows{3}, number_cols{4}, std::vector
+    seqan3::detail::two_dimensional_matrix<seqan3::detail::trace_directions> matrix{seqan3::detail::number_rows{3},
+                                                                                    seqan3::detail::number_cols{4},
+                                                                                    std::vector
     {
         N,           LO, L,          L,
         UO, D | LO | UO, L, D | L | UO,
@@ -43,28 +44,28 @@ struct aligned_sequence_builder_fixture : ::testing::Test
     using fst_seq_t = std::tuple_element_t<0, test_type>;
     using sec_seq_t = std::tuple_element_t<1, test_type>;
 
-    using fst_seq_value_t = value_type_t<fst_seq_t>;
-    using sec_seq_value_t = value_type_t<sec_seq_t>;
+    using fst_seq_value_t = seqan3::value_type_t<fst_seq_t>;
+    using sec_seq_value_t = seqan3::value_type_t<sec_seq_t>;
 
-    using type_param = aligned_sequence_builder<fst_seq_t, sec_seq_t>;
+    using type_param = seqan3::detail::aligned_sequence_builder<fst_seq_t, sec_seq_t>;
 
     void SetUp()
     {
-        fst.push_back(assign_char_to('A', fst_seq_value_t{}));
-        fst.push_back(assign_char_to('C', fst_seq_value_t{}));
-        fst.push_back(assign_char_to('G', fst_seq_value_t{}));
-        sec.push_back(assign_char_to('A', sec_seq_value_t{}));
-        sec.push_back(assign_char_to('G', sec_seq_value_t{}));
+        fst.push_back(seqan3::assign_char_to('A', fst_seq_value_t{}));
+        fst.push_back(seqan3::assign_char_to('C', fst_seq_value_t{}));
+        fst.push_back(seqan3::assign_char_to('G', fst_seq_value_t{}));
+        sec.push_back(seqan3::assign_char_to('A', sec_seq_value_t{}));
+        sec.push_back(seqan3::assign_char_to('G', sec_seq_value_t{}));
 
         builder = type_param{fst, sec};
     }
 
-    auto path(matrix_offset const & offset)
+    auto path(seqan3::detail::matrix_offset const & offset)
     {
-        using iterator_t = decltype(trace_iterator{matrix.begin() + offset});
+        using iterator_t = decltype(seqan3::detail::trace_iterator{matrix.begin() + offset});
         return std::ranges::subrange<iterator_t, std::ranges::default_sentinel_t>
         {
-            trace_iterator{matrix.begin() + offset},
+            seqan3::detail::trace_iterator{matrix.begin() + offset},
             std::ranges::default_sentinel
         };
     }
@@ -74,10 +75,10 @@ struct aligned_sequence_builder_fixture : ::testing::Test
     type_param builder;
 };
 
-using test_types = ::testing::Types<std::pair<dna4_vector &, dna4_vector &>,
-                                    std::pair<dna4_vector &, dna15_vector &>,
-                                    std::pair<dna4_vector &, std::list<dna4> &>,
-                                    std::pair<std::list<dna4> &, std::list<dna4> &>>;
+using test_types = ::testing::Types<std::pair<seqan3::dna4_vector &, seqan3::dna4_vector &>,
+                                    std::pair<seqan3::dna4_vector &, seqan3::dna15_vector &>,
+                                    std::pair<seqan3::dna4_vector &, std::list<seqan3::dna4> &>,
+                                    std::pair<std::list<seqan3::dna4> &, std::list<seqan3::dna4> &>>;
 
 TYPED_TEST_SUITE(aligned_sequence_builder_fixture, test_types, );
 
@@ -96,134 +97,146 @@ TYPED_TEST(aligned_sequence_builder_fixture, construction)
 
 TYPED_TEST(aligned_sequence_builder_fixture, build_from_2_3)
 {
-    auto p = this->path(matrix_offset{row_index_type{2}, column_index_type{3}});
+    auto p = this->path(seqan3::detail::matrix_offset{seqan3::detail::row_index_type{2},
+                                                      seqan3::detail::column_index_type{3}});
     auto [first_sequence_slice_positions, second_sequence_slice_positions, alignment] = this->builder(p);
 
     EXPECT_EQ(first_sequence_slice_positions, (std::pair<size_t, size_t>{0, 3}));
     EXPECT_EQ(second_sequence_slice_positions, (std::pair<size_t, size_t>{0, 2}));
-    EXPECT_EQ(std::get<0>(alignment) | views::to_char | views::to<std::string>, std::string{"--ACG"});
-    EXPECT_EQ(std::get<1>(alignment) | views::to_char | views::to<std::string>, std::string{"AG---"});
+    EXPECT_EQ(std::get<0>(alignment) | seqan3::views::to_char | seqan3::views::to<std::string>, std::string{"--ACG"});
+    EXPECT_EQ(std::get<1>(alignment) | seqan3::views::to_char | seqan3::views::to<std::string>, std::string{"AG---"});
 }
 
 TYPED_TEST(aligned_sequence_builder_fixture, build_from_2_2)
 {
-    auto p = this->path(matrix_offset{row_index_type{2}, column_index_type{2}});
+    auto p = this->path(seqan3::detail::matrix_offset{seqan3::detail::row_index_type{2},
+                                                      seqan3::detail::column_index_type{2}});
     auto [first_sequence_slice_positions, second_sequence_slice_positions, alignment] = this->builder(p);
 
     EXPECT_EQ(first_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 2u}));
     EXPECT_EQ(second_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 2u}));
-    EXPECT_EQ(std::get<0>(alignment) | views::to_char | views::to<std::string>, std::string{"AC"});
-    EXPECT_EQ(std::get<1>(alignment) | views::to_char | views::to<std::string>, std::string{"AG"});
+    EXPECT_EQ(std::get<0>(alignment) | seqan3::views::to_char | seqan3::views::to<std::string>, std::string{"AC"});
+    EXPECT_EQ(std::get<1>(alignment) | seqan3::views::to_char | seqan3::views::to<std::string>, std::string{"AG"});
 }
 
 TYPED_TEST(aligned_sequence_builder_fixture, build_from_2_1)
 {
-    auto p = this->path(matrix_offset{row_index_type{2}, column_index_type{1}});
+    auto p = this->path(seqan3::detail::matrix_offset{seqan3::detail::row_index_type{2},
+                                                      seqan3::detail::column_index_type{1}});
     auto [first_sequence_slice_positions, second_sequence_slice_positions, alignment] = this->builder(p);
 
     EXPECT_EQ(first_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 1u}));
     EXPECT_EQ(second_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 2u}));
-    EXPECT_EQ(std::get<0>(alignment) | views::to_char | views::to<std::string>, std::string{"A--"});
-    EXPECT_EQ(std::get<1>(alignment) | views::to_char | views::to<std::string>, std::string{"-AG"});
+    EXPECT_EQ(std::get<0>(alignment) | seqan3::views::to_char | seqan3::views::to<std::string>, std::string{"A--"});
+    EXPECT_EQ(std::get<1>(alignment) | seqan3::views::to_char | seqan3::views::to<std::string>, std::string{"-AG"});
 }
 
 TYPED_TEST(aligned_sequence_builder_fixture, build_from_2_0)
 {
-    auto p = this->path(matrix_offset{row_index_type{2}, column_index_type{0}});
+    auto p = this->path(seqan3::detail::matrix_offset{seqan3::detail::row_index_type{2},
+                                                      seqan3::detail::column_index_type{0}});
     auto [first_sequence_slice_positions, second_sequence_slice_positions, alignment] = this->builder(p);
 
     EXPECT_EQ(first_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 0u}));
     EXPECT_EQ(second_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 2u}));
-    EXPECT_EQ(std::get<0>(alignment) | views::to_char | views::to<std::string>, std::string{"--"});
-    EXPECT_EQ(std::get<1>(alignment) | views::to_char | views::to<std::string>, std::string{"AG"});
+    EXPECT_EQ(std::get<0>(alignment) | seqan3::views::to_char | seqan3::views::to<std::string>, std::string{"--"});
+    EXPECT_EQ(std::get<1>(alignment) | seqan3::views::to_char | seqan3::views::to<std::string>, std::string{"AG"});
 }
 
 TYPED_TEST(aligned_sequence_builder_fixture, build_from_1_3)
 {
-    auto p = this->path(matrix_offset{row_index_type{1}, column_index_type{3}});
+    auto p = this->path(seqan3::detail::matrix_offset{seqan3::detail::row_index_type{1},
+                                                      seqan3::detail::column_index_type{3}});
     auto [first_sequence_slice_positions, second_sequence_slice_positions, alignment] = this->builder(p);
 
     EXPECT_EQ(first_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 3u}));
     EXPECT_EQ(second_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 1u}));
-    EXPECT_EQ(std::get<0>(alignment) | views::to_char | views::to<std::string>, std::string{"ACG"});
-    EXPECT_EQ(std::get<1>(alignment) | views::to_char | views::to<std::string>, std::string{"--A"});
+    EXPECT_EQ(std::get<0>(alignment) | seqan3::views::to_char | seqan3::views::to<std::string>, std::string{"ACG"});
+    EXPECT_EQ(std::get<1>(alignment) | seqan3::views::to_char | seqan3::views::to<std::string>, std::string{"--A"});
 }
 
 TYPED_TEST(aligned_sequence_builder_fixture, build_from_1_2)
 {
-    auto p = this->path(matrix_offset{row_index_type{1}, column_index_type{2}});
+    auto p = this->path(seqan3::detail::matrix_offset{seqan3::detail::row_index_type{1},
+                                                      seqan3::detail::column_index_type{2}});
     auto [first_sequence_slice_positions, second_sequence_slice_positions, alignment] = this->builder(p);
 
     EXPECT_EQ(first_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 2u}));
     EXPECT_EQ(second_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 1u}));
-    EXPECT_EQ(std::get<0>(alignment) | views::to_char | views::to<std::string>, std::string{"-AC"});
-    EXPECT_EQ(std::get<1>(alignment) | views::to_char | views::to<std::string>, std::string{"A--"});
+    EXPECT_EQ(std::get<0>(alignment) | seqan3::views::to_char | seqan3::views::to<std::string>, std::string{"-AC"});
+    EXPECT_EQ(std::get<1>(alignment) | seqan3::views::to_char | seqan3::views::to<std::string>, std::string{"A--"});
 }
 
 TYPED_TEST(aligned_sequence_builder_fixture, build_from_1_1)
 {
-    auto p = this->path(matrix_offset{row_index_type{1}, column_index_type{1}});
+    auto p = this->path(seqan3::detail::matrix_offset{seqan3::detail::row_index_type{1},
+                                                      seqan3::detail::column_index_type{1}});
     auto [first_sequence_slice_positions, second_sequence_slice_positions, alignment] = this->builder(p);
 
     EXPECT_EQ(first_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 1u}));
     EXPECT_EQ(second_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 1u}));
-    EXPECT_EQ(std::get<0>(alignment) | views::to_char | views::to<std::string>, std::string{"A"});
-    EXPECT_EQ(std::get<1>(alignment) | views::to_char | views::to<std::string>, std::string{"A"});
+    EXPECT_EQ(std::get<0>(alignment) | seqan3::views::to_char | seqan3::views::to<std::string>, std::string{"A"});
+    EXPECT_EQ(std::get<1>(alignment) | seqan3::views::to_char | seqan3::views::to<std::string>, std::string{"A"});
 }
 
 TYPED_TEST(aligned_sequence_builder_fixture, build_from_1_0)
 {
-    auto p = this->path(matrix_offset{row_index_type{1}, column_index_type{0}});
+    auto p = this->path(seqan3::detail::matrix_offset{seqan3::detail::row_index_type{1},
+                                                      seqan3::detail::column_index_type{0}});
     auto [first_sequence_slice_positions, second_sequence_slice_positions, alignment] = this->builder(p);
 
     EXPECT_EQ(first_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 0u}));
     EXPECT_EQ(second_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 1u}));
-    EXPECT_EQ(std::get<0>(alignment) | views::to_char | views::to<std::string>, std::string{"-"});
-    EXPECT_EQ(std::get<1>(alignment) | views::to_char | views::to<std::string>, std::string{"A"});
+    EXPECT_EQ(std::get<0>(alignment) | seqan3::views::to_char | seqan3::views::to<std::string>, std::string{"-"});
+    EXPECT_EQ(std::get<1>(alignment) | seqan3::views::to_char | seqan3::views::to<std::string>, std::string{"A"});
 }
 
 TYPED_TEST(aligned_sequence_builder_fixture, build_from_0_3)
 {
-    auto p = this->path(matrix_offset{row_index_type{0}, column_index_type{3}});
+    auto p = this->path(seqan3::detail::matrix_offset{seqan3::detail::row_index_type{0},
+                                                      seqan3::detail::column_index_type{3}});
     auto [first_sequence_slice_positions, second_sequence_slice_positions, alignment] = this->builder(p);
 
     EXPECT_EQ(first_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 3u}));
     EXPECT_EQ(second_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 0u}));
-    EXPECT_EQ(std::get<0>(alignment) | views::to_char | views::to<std::string>, std::string{"ACG"});
-    EXPECT_EQ(std::get<1>(alignment) | views::to_char | views::to<std::string>, std::string{"---"});
+    EXPECT_EQ(std::get<0>(alignment) | seqan3::views::to_char | seqan3::views::to<std::string>, std::string{"ACG"});
+    EXPECT_EQ(std::get<1>(alignment) | seqan3::views::to_char | seqan3::views::to<std::string>, std::string{"---"});
 }
 
 TYPED_TEST(aligned_sequence_builder_fixture, build_from_0_2)
 {
-    auto p = this->path(matrix_offset{row_index_type{0}, column_index_type{2}});
+    auto p = this->path(seqan3::detail::matrix_offset{seqan3::detail::row_index_type{0},
+                                                      seqan3::detail::column_index_type{2}});
     auto [first_sequence_slice_positions, second_sequence_slice_positions, alignment] = this->builder(p);
 
     EXPECT_EQ(first_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 2u}));
     EXPECT_EQ(second_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 0u}));
-    EXPECT_EQ(std::get<0>(alignment) | views::to_char | views::to<std::string>, std::string{"AC"});
-    EXPECT_EQ(std::get<1>(alignment) | views::to_char | views::to<std::string>, std::string{"--"});
+    EXPECT_EQ(std::get<0>(alignment) | seqan3::views::to_char | seqan3::views::to<std::string>, std::string{"AC"});
+    EXPECT_EQ(std::get<1>(alignment) | seqan3::views::to_char | seqan3::views::to<std::string>, std::string{"--"});
 }
 
 TYPED_TEST(aligned_sequence_builder_fixture, build_from_0_1)
 {
-    auto p = this->path(matrix_offset{row_index_type{0}, column_index_type{1}});
+    auto p = this->path(seqan3::detail::matrix_offset{seqan3::detail::row_index_type{0},
+                                                      seqan3::detail::column_index_type{1}});
     auto [first_sequence_slice_positions, second_sequence_slice_positions, alignment] = this->builder(p);
 
     EXPECT_EQ(first_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 1u}));
     EXPECT_EQ(second_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 0u}));
-    EXPECT_EQ(std::get<0>(alignment) | views::to_char | views::to<std::string>, std::string{"A"});
-    EXPECT_EQ(std::get<1>(alignment) | views::to_char | views::to<std::string>, std::string{"-"});
+    EXPECT_EQ(std::get<0>(alignment) | seqan3::views::to_char | seqan3::views::to<std::string>, std::string{"A"});
+    EXPECT_EQ(std::get<1>(alignment) | seqan3::views::to_char | seqan3::views::to<std::string>, std::string{"-"});
 }
 
 TYPED_TEST(aligned_sequence_builder_fixture, build_from_0_0)
 {
-    auto p = this->path(matrix_offset{row_index_type{0}, column_index_type{0}});
+    auto p = this->path(seqan3::detail::matrix_offset{seqan3::detail::row_index_type{0},
+                                                      seqan3::detail::column_index_type{0}});
     auto [first_sequence_slice_positions, second_sequence_slice_positions, alignment] = this->builder(p);
 
     EXPECT_EQ(first_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 0u}));
     EXPECT_EQ(second_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 0u}));
-    EXPECT_EQ(std::get<0>(alignment) | views::to_char | views::to<std::string>, std::string{""});
-    EXPECT_EQ(std::get<1>(alignment) | views::to_char | views::to<std::string>, std::string{""});
+    EXPECT_EQ(std::get<0>(alignment) | seqan3::views::to_char | seqan3::views::to<std::string>, std::string{""});
+    EXPECT_EQ(std::get<1>(alignment) | seqan3::views::to_char | seqan3::views::to<std::string>, std::string{""});
 }
 
 TYPED_TEST(aligned_sequence_builder_fixture, both_empty)
@@ -233,13 +246,14 @@ TYPED_TEST(aligned_sequence_builder_fixture, both_empty)
 
     typename TestFixture::type_param builder{first, second};
 
-    auto p = this->path(matrix_offset{row_index_type{0}, column_index_type{0}});
+    auto p = this->path(seqan3::detail::matrix_offset{seqan3::detail::row_index_type{0},
+                                                      seqan3::detail::column_index_type{0}});
     auto [first_sequence_slice_positions, second_sequence_slice_positions, alignment] = builder(p);
 
     EXPECT_EQ(first_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 0u}));
     EXPECT_EQ(second_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 0u}));
-    EXPECT_EQ(std::get<0>(alignment) | views::to_char | views::to<std::string>, std::string{""});
-    EXPECT_EQ(std::get<1>(alignment) | views::to_char | views::to<std::string>, std::string{""});
+    EXPECT_EQ(std::get<0>(alignment) | seqan3::views::to_char | seqan3::views::to<std::string>, std::string{""});
+    EXPECT_EQ(std::get<1>(alignment) | seqan3::views::to_char | seqan3::views::to<std::string>, std::string{""});
 }
 
 TYPED_TEST(aligned_sequence_builder_fixture, first_empty)
@@ -248,13 +262,14 @@ TYPED_TEST(aligned_sequence_builder_fixture, first_empty)
 
     typename TestFixture::type_param builder{first, this->sec};
 
-    auto p = this->path(matrix_offset{row_index_type{2}, column_index_type{0}});
+    auto p = this->path(seqan3::detail::matrix_offset{seqan3::detail::row_index_type{2},
+                                                      seqan3::detail::column_index_type{0}});
     auto [first_sequence_slice_positions, second_sequence_slice_positions, alignment] = builder(p);
 
     EXPECT_EQ(first_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 0u}));
     EXPECT_EQ(second_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 2u}));
-    EXPECT_EQ(std::get<0>(alignment) | views::to_char | views::to<std::string>, std::string{"--"});
-    EXPECT_EQ(std::get<1>(alignment) | views::to_char | views::to<std::string>, std::string{"AG"});
+    EXPECT_EQ(std::get<0>(alignment) | seqan3::views::to_char | seqan3::views::to<std::string>, std::string{"--"});
+    EXPECT_EQ(std::get<1>(alignment) | seqan3::views::to_char | seqan3::views::to<std::string>, std::string{"AG"});
 }
 
 TYPED_TEST(aligned_sequence_builder_fixture, second_empty)
@@ -263,11 +278,12 @@ TYPED_TEST(aligned_sequence_builder_fixture, second_empty)
 
     typename TestFixture::type_param builder{this->fst, second};
 
-    auto p = this->path(matrix_offset{row_index_type{0}, column_index_type{3}});
+    auto p = this->path(seqan3::detail::matrix_offset{seqan3::detail::row_index_type{0},
+                                                      seqan3::detail::column_index_type{3}});
     auto [first_sequence_slice_positions, second_sequence_slice_positions, alignment] = builder(p);
 
     EXPECT_EQ(first_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 3u}));
     EXPECT_EQ(second_sequence_slice_positions, (std::pair<size_t, size_t>{0u, 0u}));
-    EXPECT_EQ(std::get<0>(alignment) | views::to_char | views::to<std::string>, std::string{"ACG"});
-    EXPECT_EQ(std::get<1>(alignment) | views::to_char | views::to<std::string>, std::string{"---"});
+    EXPECT_EQ(std::get<0>(alignment) | seqan3::views::to_char | seqan3::views::to<std::string>, std::string{"ACG"});
+    EXPECT_EQ(std::get<1>(alignment) | seqan3::views::to_char | seqan3::views::to<std::string>, std::string{"---"});
 }

--- a/test/unit/alignment/matrix/detail/alignment_matrix_base_test_template.hpp
+++ b/test/unit/alignment/matrix/detail/alignment_matrix_base_test_template.hpp
@@ -10,9 +10,6 @@
 #include <seqan3/alignment/band/static_band.hpp>
 #include <seqan3/std/ranges>
 
-using namespace seqan3;
-using namespace seqan3::detail;
-
 template <typename t>
 struct alignment_matrix_base_test : public ::testing::Test
 {
@@ -22,7 +19,7 @@ struct alignment_matrix_base_test : public ::testing::Test
     alignment_matrix_base_test()
     {
         if constexpr (is_banded)
-            test_range = matrix_t{first, second, static_band{lower_bound{-2}, upper_bound{2}}};
+            test_range = matrix_t{first, second, seqan3::static_band{seqan3::lower_bound{-2}, seqan3::upper_bound{2}}};
         else
             test_range = matrix_t{first, second};
     }
@@ -37,7 +34,7 @@ TYPED_TEST_SUITE_P(alignment_matrix_base_test);
 TYPED_TEST_P(alignment_matrix_base_test, range_concepts)
 {
     using outer_it = std::ranges::iterator_t<typename TestFixture::matrix_t>;
-    using column_t = value_type_t<outer_it>;
+    using column_t = seqan3::value_type_t<outer_it>;
     using inner_it = std::ranges::iterator_t<column_t>;
 
     EXPECT_TRUE(std::ranges::input_range<typename TestFixture::matrix_t>);
@@ -93,7 +90,7 @@ TYPED_TEST_P(alignment_matrix_base_test, empty_row)
 
     if constexpr (TestFixture::is_banded)
     {
-        static_band band{lower_bound{-2}, upper_bound{4}};
+        seqan3::static_band band{seqan3::lower_bound{-2}, seqan3::upper_bound{4}};
         test_matrix_iteration(matrix_type{this->first, std::string{""}, band}, 5, 5);
     }
     else
@@ -108,7 +105,7 @@ TYPED_TEST_P(alignment_matrix_base_test, empty_col)
 
     if constexpr (TestFixture::is_banded)
     {
-        static_band band{lower_bound{-2}, upper_bound{2}};
+        seqan3::static_band band{seqan3::lower_bound{-2}, seqan3::upper_bound{2}};
         test_matrix_iteration(matrix_type{std::string{""}, this->second, band}, 1, 3);
     }
     else
@@ -123,7 +120,7 @@ TYPED_TEST_P(alignment_matrix_base_test, empty_col_row)
 
     if constexpr (TestFixture::is_banded)
     {
-        static_band band{lower_bound{0}, upper_bound{2}};
+        seqan3::static_band band{seqan3::lower_bound{0}, seqan3::upper_bound{2}};
         test_matrix_iteration(matrix_type{std::string{""}, std::string{""}, band}, 1, 1);
     }
     else

--- a/test/unit/alignment/matrix/detail/alignment_matrix_column_major_range_test.cpp
+++ b/test/unit/alignment/matrix/detail/alignment_matrix_column_major_range_test.cpp
@@ -11,14 +11,11 @@
 
 #include <seqan3/alignment/matrix/detail/alignment_matrix_column_major_range_base.hpp>
 
-using namespace seqan3;
-using namespace seqan3::detail;
-
-class test_matrix : public alignment_matrix_column_major_range_base<test_matrix>
+class test_matrix : public seqan3::detail::alignment_matrix_column_major_range_base<test_matrix>
 {
 public:
 
-    using base_t = alignment_matrix_column_major_range_base<test_matrix>;
+    using base_t = seqan3::detail::alignment_matrix_column_major_range_base<test_matrix>;
 
     using element_type = int;
     using alignment_column_type = typename base_t::alignment_column_type;
@@ -99,7 +96,7 @@ protected:
 TEST(alignment_matrix_column_major_range_base, concepts)
 {
     using outer_it = std::ranges::iterator_t<test_matrix>;
-    using column_t = value_type_t<outer_it>;
+    using column_t = seqan3::value_type_t<outer_it>;
     using inner_it = std::ranges::iterator_t<column_t>;
 
     EXPECT_TRUE(std::ranges::input_range<test_matrix>);

--- a/test/unit/alignment/matrix/detail/alignment_score_matrix_one_column_banded_test.cpp
+++ b/test/unit/alignment/matrix/detail/alignment_score_matrix_one_column_banded_test.cpp
@@ -16,17 +16,15 @@
 #include "simulated_alignment_test_template.hpp"
 #include "../../../range/iterator_test_template.hpp"
 
-using namespace seqan3;
-
 template <typename t>
 struct alignment_score_matrix_one_column_banded_test
 {
-    using matrix_t = detail::alignment_score_matrix_one_column_banded<t>;
+    using matrix_t = seqan3::detail::alignment_score_matrix_one_column_banded<t>;
     using score_type = t;
 
     alignment_score_matrix_one_column_banded_test() = default;
     alignment_score_matrix_one_column_banded_test(std::string f, std::string s) :
-        matrix{matrix_t{f, s, static_band{lower_bound{-2}, upper_bound{2}}, -100}}
+        matrix{matrix_t{f, s, seqan3::static_band{seqan3::lower_bound{-2}, seqan3::upper_bound{2}}, -100}}
     {}
 
     // Banded matrix. We write only partial columns to the result.
@@ -46,7 +44,7 @@ INSTANTIATE_TYPED_TEST_SUITE_P(one_column_banded,
                                simulated_alignment_test,
                                alignment_score_matrix_one_column_banded_test<int32_t>, );
 
-using test_type = std::pair<detail::alignment_score_matrix_one_column_banded<int32_t>, std::true_type>;
+using test_type = std::pair<seqan3::detail::alignment_score_matrix_one_column_banded<int32_t>, std::true_type>;
 
 INSTANTIATE_TYPED_TEST_SUITE_P(one_column_banded,
                                alignment_matrix_base_test,

--- a/test/unit/alignment/matrix/detail/alignment_score_matrix_one_column_test.cpp
+++ b/test/unit/alignment/matrix/detail/alignment_score_matrix_one_column_test.cpp
@@ -16,12 +16,10 @@
 #include "simulated_alignment_test_template.hpp"
 #include "../../../range/iterator_test_template.hpp"
 
-using namespace seqan3;
-
 template <typename t>
 struct alignment_score_matrix_one_column_test
 {
-    using matrix_t = detail::alignment_score_matrix_one_column<t>;
+    using matrix_t = seqan3::detail::alignment_score_matrix_one_column<t>;
     using score_type = t;
 
     alignment_score_matrix_one_column_test() = default;

--- a/test/unit/alignment/matrix/detail/alignment_trace_matrix_full_banded_test.cpp
+++ b/test/unit/alignment/matrix/detail/alignment_trace_matrix_full_banded_test.cpp
@@ -16,10 +16,12 @@
 #include "alignment_matrix_base_test_template.hpp"
 #include "../../../range/iterator_test_template.hpp"
 
-using namespace seqan3;
-
-using trace_matrix_t = std::pair<detail::alignment_trace_matrix_full_banded<trace_directions>, std::true_type>;
-using coo_matrix_t = std::pair<detail::alignment_trace_matrix_full_banded<trace_directions, true>, std::true_type>;
+using trace_matrix_t =
+    std::pair<seqan3::detail::alignment_trace_matrix_full_banded<seqan3::detail::trace_directions>,
+              std::true_type>;
+using coo_matrix_t =
+    std::pair<seqan3::detail::alignment_trace_matrix_full_banded<seqan3::detail::trace_directions, true>,
+              std::true_type>;
 
 using testing_types = ::testing::Types<trace_matrix_t, coo_matrix_t>;
 INSTANTIATE_TYPED_TEST_SUITE_P(full_matrix_banded,
@@ -36,18 +38,19 @@ struct outer_iterator
 template <typename test_type>
 struct iterator_fixture<outer_iterator<test_type>> : alignment_matrix_base_test<test_type>
 {
-    static constexpr trace_directions N = trace_directions::none;
+    static constexpr seqan3::detail::trace_directions N = seqan3::detail::trace_directions::none;
 
     using base_t = alignment_matrix_base_test<test_type>;
     using iterator_tag = std::input_iterator_tag;
     static constexpr bool const_iterable = false;
 
     using base_t::test_range;
-    std::vector<std::pair<std::pair<size_t, size_t>, trace_directions>> expected_range{{{2, 0}, N},
-                                                                                       {{1, 1}, N},
-                                                                                       {{0, 2}, N},
-                                                                                       {{0, 3}, N},
-                                                                                       {{0, 4}, N}};
+    std::vector<std::pair<std::pair<size_t, size_t>,
+                          seqan3::detail::trace_directions>> expected_range{{{2, 0}, N},
+                                                                            {{1, 1}, N},
+                                                                            {{0, 2}, N},
+                                                                            {{0, 3}, N},
+                                                                            {{0, 4}, N}};
 
     template <typename lhs_t, typename rhs_t>
     static void test(lhs_t lhs, rhs_t rhs)
@@ -55,8 +58,10 @@ struct iterator_fixture<outer_iterator<test_type>> : alignment_matrix_base_test<
         EXPECT_EQ(lhs.coordinate.second, std::get<0>(std::get<0>(rhs)));
         EXPECT_EQ(lhs.coordinate.first, std::get<1>(std::get<0>(rhs)));
 
-        if constexpr (std::is_same_v<std::tuple_element_t<0, test_type>,
-                                     detail::alignment_trace_matrix_full_banded<trace_directions>>)
+        using full_banded_matrix_with_trace_directions =
+            seqan3::detail::alignment_trace_matrix_full_banded<seqan3::detail::trace_directions>;
+
+        if constexpr (std::is_same_v<std::tuple_element_t<0, test_type>, full_banded_matrix_with_trace_directions>)
         {
             EXPECT_EQ(lhs.current, std::get<1>(rhs));
         }
@@ -85,7 +90,7 @@ struct inner_iterator
 template <typename test_type>
 struct iterator_fixture<inner_iterator<test_type>> : iterator_fixture<outer_iterator<test_type>>
 {
-    static constexpr trace_directions N = trace_directions::none;
+    static constexpr seqan3::detail::trace_directions N = seqan3::detail::trace_directions::none;
 
     using base_t = iterator_fixture<outer_iterator<test_type>>;
 
@@ -93,9 +98,10 @@ struct iterator_fixture<inner_iterator<test_type>> : iterator_fixture<outer_iter
     static constexpr bool const_iterable = false;
 
     decltype(*base_t::test_range.begin()) test_range = *base_t::test_range.begin();
-    std::vector<std::pair<std::pair<size_t, size_t>, trace_directions>> expected_range{{{2, 0}, base_t::N},
-                                                                                       {{3, 0}, base_t::N},
-                                                                                       {{4, 0}, base_t::N}};
+    std::vector<std::pair<std::pair<size_t, size_t>,
+                          seqan3::detail::trace_directions>> expected_range{{{2, 0}, base_t::N},
+                                                                            {{3, 0}, base_t::N},
+                                                                            {{4, 0}, base_t::N}};
 
     template <typename lhs_t, typename rhs_t>
     static void expect_eq(lhs_t lhs, rhs_t rhs)
@@ -112,16 +118,19 @@ INSTANTIATE_TYPED_TEST_SUITE_P(banded_trace_matrix_inner_iterator,
 
 TEST(trace_matrix, trace_path)
 {
-    detail::alignment_trace_matrix_full_banded<trace_directions>
-        matrix{"acgt", "acgt", static_band{lower_bound{-3}, upper_bound{3}}};
+    seqan3::detail::alignment_trace_matrix_full_banded<seqan3::detail::trace_directions>
+        matrix{"acgt", "acgt", seqan3::static_band{seqan3::lower_bound{-3}, seqan3::upper_bound{3}}};
 
-    EXPECT_THROW((matrix.trace_path(matrix_coordinate{row_index_type{7u}, column_index_type{4u}})),
+    EXPECT_THROW((matrix.trace_path(seqan3::detail::matrix_coordinate{seqan3::detail::row_index_type{7u},
+                                                                      seqan3::detail::column_index_type{4u}})),
                  std::invalid_argument);
 
-    EXPECT_THROW((matrix.trace_path(matrix_coordinate{row_index_type{4u}, column_index_type{7u}})),
+    EXPECT_THROW((matrix.trace_path(seqan3::detail::matrix_coordinate{seqan3::detail::row_index_type{4u},
+                                                                      seqan3::detail::column_index_type{7u}})),
                  std::invalid_argument);
 
-    auto path = matrix.trace_path(matrix_coordinate{row_index_type{4u}, column_index_type{4u}});
+    auto path = matrix.trace_path(seqan3::detail::matrix_coordinate{seqan3::detail::row_index_type{4u},
+                                                                      seqan3::detail::column_index_type{4u}});
 
     EXPECT_TRUE(path.empty());
 }

--- a/test/unit/alignment/matrix/detail/alignment_trace_matrix_full_banded_test.cpp
+++ b/test/unit/alignment/matrix/detail/alignment_trace_matrix_full_banded_test.cpp
@@ -58,10 +58,9 @@ struct iterator_fixture<outer_iterator<test_type>> : alignment_matrix_base_test<
         EXPECT_EQ(lhs.coordinate.second, std::get<0>(std::get<0>(rhs)));
         EXPECT_EQ(lhs.coordinate.first, std::get<1>(std::get<0>(rhs)));
 
-        using full_banded_matrix_with_trace_directions =
-            seqan3::detail::alignment_trace_matrix_full_banded<seqan3::detail::trace_directions>;
-
-        if constexpr (std::is_same_v<std::tuple_element_t<0, test_type>, full_banded_matrix_with_trace_directions>)
+        if constexpr (std::is_same_v<std::tuple_element_t<0, test_type>,
+                                     seqan3::detail::alignment_trace_matrix_full_banded<seqan3::detail::trace_directions
+                                     >>)
         {
             EXPECT_EQ(lhs.current, std::get<1>(rhs));
         }

--- a/test/unit/alignment/matrix/detail/alignment_trace_matrix_full_test.cpp
+++ b/test/unit/alignment/matrix/detail/alignment_trace_matrix_full_test.cpp
@@ -16,10 +16,10 @@
 #include "alignment_matrix_base_test_template.hpp"
 #include "../../../range/iterator_test_template.hpp"
 
-using namespace seqan3;
-
-using trace_matrix_t = std::pair<detail::alignment_trace_matrix_full<trace_directions>, std::false_type>;
-using coo_matrix_t = std::pair<detail::alignment_trace_matrix_full<trace_directions, true>, std::false_type>;
+using trace_matrix_t = std::pair<seqan3::detail::alignment_trace_matrix_full<seqan3::detail::trace_directions>,
+                                                                             std::false_type>;
+using coo_matrix_t = std::pair<seqan3::detail::alignment_trace_matrix_full<seqan3::detail::trace_directions, true>,
+                                                                           std::false_type>;
 
 using testing_types = ::testing::Types<trace_matrix_t, coo_matrix_t>;
 
@@ -37,18 +37,18 @@ struct outer_iterator
 template <typename test_type>
 struct iterator_fixture<outer_iterator<test_type>> : alignment_matrix_base_test<test_type>
 {
-    static constexpr trace_directions N = trace_directions::none;
+    static constexpr seqan3::detail::trace_directions N = seqan3::detail::trace_directions::none;
 
     using base_t = alignment_matrix_base_test<test_type>;
     using iterator_tag = std::input_iterator_tag;
     static constexpr bool const_iterable = false;
 
     using base_t::test_range;
-    std::vector<std::pair<std::pair<size_t, size_t>, trace_directions>> expected_range{{{0, 0}, N},
-                                                                                       {{0, 1}, N},
-                                                                                       {{0, 2}, N},
-                                                                                       {{0, 3}, N},
-                                                                                       {{0, 4}, N}};
+    std::vector<std::pair<std::pair<size_t, size_t>, seqan3::detail::trace_directions>> expected_range{{{0, 0}, N},
+                                                                                                       {{0, 1}, N},
+                                                                                                       {{0, 2}, N},
+                                                                                                       {{0, 3}, N},
+                                                                                                       {{0, 4}, N}};
 
     template <typename lhs_t, typename rhs_t>
     static void test(lhs_t lhs, rhs_t rhs)
@@ -57,7 +57,7 @@ struct iterator_fixture<outer_iterator<test_type>> : alignment_matrix_base_test<
         EXPECT_EQ(lhs.coordinate.first, std::get<1>(std::get<0>(rhs)));
 
         if constexpr (std::is_same_v<std::tuple_element_t<0, test_type>,
-                                     detail::alignment_trace_matrix_full<trace_directions>>)
+                                     seqan3::detail::alignment_trace_matrix_full<seqan3::detail::trace_directions>>)
         {
             EXPECT_EQ(lhs.current, std::get<1>(rhs));
         }
@@ -92,11 +92,12 @@ struct iterator_fixture<inner_iterator<test_type>> : iterator_fixture<outer_iter
     static constexpr bool const_iterable = false;
 
     decltype(*base_t::test_range.begin()) test_range = *base_t::test_range.begin();
-    std::vector<std::pair<std::pair<size_t, size_t>, trace_directions>> expected_range{{{0, 0}, base_t::N},
-                                                                                       {{1, 0}, base_t::N},
-                                                                                       {{2, 0}, base_t::N},
-                                                                                       {{3, 0}, base_t::N},
-                                                                                       {{4, 0}, base_t::N}};
+    std::vector<std::pair<std::pair<size_t, size_t>,
+                          seqan3::detail::trace_directions>> expected_range{{{0, 0}, base_t::N},
+                                                                            {{1, 0}, base_t::N},
+                                                                            {{2, 0}, base_t::N},
+                                                                            {{3, 0}, base_t::N},
+                                                                            {{4, 0}, base_t::N}};
 
     template <typename lhs_t, typename rhs_t>
     static void expect_eq(lhs_t lhs, rhs_t rhs)
@@ -114,15 +115,18 @@ INSTANTIATE_TYPED_TEST_SUITE_P(trace_matrix_inner_iterator,
 
 TEST(trace_matrix, trace_path)
 {
-    detail::alignment_trace_matrix_full<trace_directions> matrix{"acgt", "acgt"};
+    seqan3::detail::alignment_trace_matrix_full<seqan3::detail::trace_directions> matrix{"acgt", "acgt"};
 
-    EXPECT_THROW((matrix.trace_path(matrix_coordinate{row_index_type{6u}, column_index_type{4u}})),
+    EXPECT_THROW((matrix.trace_path(seqan3::detail::matrix_coordinate{seqan3::detail::row_index_type{6u},
+                                                                      seqan3::detail::column_index_type{4u}})),
                  std::invalid_argument);
 
-    EXPECT_THROW((matrix.trace_path(matrix_coordinate{row_index_type{4u}, column_index_type{6u}})),
+    EXPECT_THROW((matrix.trace_path(seqan3::detail::matrix_coordinate{seqan3::detail::row_index_type{4u},
+                                                                      seqan3::detail::column_index_type{6u}})),
                  std::invalid_argument);
 
-    auto path = matrix.trace_path(matrix_coordinate{row_index_type{4u}, column_index_type{4u}});
+    auto path = matrix.trace_path(seqan3::detail::matrix_coordinate{seqan3::detail::row_index_type{4u},
+                                                                    seqan3::detail::column_index_type{4u}});
 
     EXPECT_TRUE(path.empty());
 }

--- a/test/unit/alignment/matrix/detail/simulated_alignment_test_template.hpp
+++ b/test/unit/alignment/matrix/detail/simulated_alignment_test_template.hpp
@@ -41,9 +41,6 @@ struct simulated_alignment_test : public ::testing::Test
 
 TYPED_TEST_SUITE_P(simulated_alignment_test);
 
-using namespace seqan3;
-using namespace seqan3::detail;
-
 TYPED_TEST_P(simulated_alignment_test, linear_alignment)
 {
     std::vector<typename TypeParam::score_type> cmp_matrix{};

--- a/test/unit/alignment/matrix/detail/trace_iterator_banded_test.cpp
+++ b/test/unit/alignment/matrix/detail/trace_iterator_banded_test.cpp
@@ -18,19 +18,18 @@
 
 #include "../../../range/iterator_test_template.hpp"
 
-using namespace seqan3;
-using namespace seqan3::detail;
-
 struct trace_iterator_banded_test : public ::testing::Test
 {
-    static constexpr trace_directions N = trace_directions::none;
-    static constexpr trace_directions D = trace_directions::diagonal;
-    static constexpr trace_directions U = trace_directions::up;
-    static constexpr trace_directions UO = trace_directions::up_open;
-    static constexpr trace_directions L = trace_directions::left;
-    static constexpr trace_directions LO = trace_directions::left_open;
+    static constexpr seqan3::detail::trace_directions N = seqan3::detail::trace_directions::none;
+    static constexpr seqan3::detail::trace_directions D = seqan3::detail::trace_directions::diagonal;
+    static constexpr seqan3::detail::trace_directions U = seqan3::detail::trace_directions::up;
+    static constexpr seqan3::detail::trace_directions UO = seqan3::detail::trace_directions::up_open;
+    static constexpr seqan3::detail::trace_directions L = seqan3::detail::trace_directions::left;
+    static constexpr seqan3::detail::trace_directions LO = seqan3::detail::trace_directions::left_open;
 
-    two_dimensional_matrix<trace_directions> matrix{number_rows{5}, number_cols{6}, std::vector
+    seqan3::detail::two_dimensional_matrix<seqan3::detail::trace_directions> matrix{seqan3::detail::number_rows{5},
+                                                                                    seqan3::detail::number_cols{6},
+                                                                                    std::vector
     {  // emulating band {row:2, col:2}
          N,  N,  L,  D,  D,  L,
          N, LO,  D,  D, UO, UO,
@@ -47,12 +46,13 @@ struct trace_iterator_banded_test : public ::testing::Test
         //4        D  D  D UO
         //5           D  D  U
 
-    using trace_iterator_type = decltype(trace_iterator_banded{matrix.begin(), column_index_type{0}});
+    using trace_iterator_type = decltype(seqan3::detail::trace_iterator_banded{matrix.begin(),
+                                                                               seqan3::detail::column_index_type{0}});
     using path_type = std::ranges::subrange<trace_iterator_type, std::ranges::default_sentinel_t>;
 
-    path_type path(matrix_offset const & offset)
+    path_type path(seqan3::detail::matrix_offset const & offset)
     {
-        return path_type{trace_iterator_type{matrix.begin() + offset, column_index_type{2}},
+        return path_type{trace_iterator_type{matrix.begin() + offset, seqan3::detail::column_index_type{2}},
                          std::ranges::default_sentinel};
     }
 };
@@ -67,13 +67,15 @@ TEST_F(trace_iterator_banded_test, concepts)
 
 TEST_F(trace_iterator_banded_test, type_deduction)
 {
-    trace_iterator_banded it{matrix.begin(), column_index_type{0u}};
+    seqan3::detail::trace_iterator_banded it{matrix.begin(), seqan3::detail::column_index_type{0u}};
     EXPECT_TRUE((std::is_same_v<decltype(it), seqan3::detail::trace_iterator_banded<decltype(matrix.begin())>>));
 }
 
 TEST_F(trace_iterator_banded_test, trace_path_2_5)
 {
-    std::vector vec = path(matrix_offset{row_index_type{2}, column_index_type{5}}) | views::to<std::vector>;
+    std::vector vec = path(seqan3::detail::matrix_offset{seqan3::detail::row_index_type{2},
+                                                         seqan3::detail::column_index_type{5}})
+                    | views::to<std::vector>;
 
     EXPECT_EQ(vec.size(), 8u);
     EXPECT_EQ(vec, (std::vector{U, U, L, L, L, D, D, U}));
@@ -81,7 +83,8 @@ TEST_F(trace_iterator_banded_test, trace_path_2_5)
 
 TEST_F(trace_iterator_banded_test, coordinate)
 {
-    auto p = path(matrix_offset{row_index_type{2}, column_index_type{5}});
+    auto p = path(seqan3::detail::matrix_offset{seqan3::detail::row_index_type{2},
+                                                seqan3::detail::column_index_type{5}});
     auto it = p.begin();
 
     EXPECT_EQ(it.coordinate().row, 5u);
@@ -122,7 +125,8 @@ struct iterator_fixture<trace_iterator_banded_test> : public trace_iterator_band
     using base_t = trace_iterator_banded_test;
 
     using iterator_type = typename base_t::trace_iterator_type;
-    using const_iterator_type = decltype(trace_iterator_banded{base_t::matrix.cbegin(), column_index_type{0}});
+    using const_iterator_type = decltype(seqan3::detail::trace_iterator_banded{base_t::matrix.cbegin(),
+                                                                               seqan3::detail::column_index_type{0}});
 
     // Test forward iterator concept.
     using iterator_tag = std::forward_iterator_tag;
@@ -132,14 +136,17 @@ struct iterator_fixture<trace_iterator_banded_test> : public trace_iterator_band
     {
         auto begin()
         {
-            return iterator_type{matrix.begin() + matrix_offset{row_index_type{2}, column_index_type{5}},
-                                 column_index_type{2}};
+            return iterator_type{matrix.begin() + seqan3::detail::matrix_offset{seqan3::detail::row_index_type{2},
+                                                                                seqan3::detail::column_index_type{5}},
+                                 seqan3::detail::column_index_type{2}};
         }
 
         auto begin() const
         {
-            return const_iterator_type{matrix.cbegin() + matrix_offset{row_index_type{2}, column_index_type{5}},
-                                       column_index_type{2}};
+            return const_iterator_type{matrix.cbegin() +
+                                       seqan3::detail::matrix_offset{seqan3::detail::row_index_type{2},
+                                                                     seqan3::detail::column_index_type{5}},
+                                       seqan3::detail::column_index_type{2}};
         }
 
         auto end() { return std::ranges::default_sentinel; }
@@ -149,7 +156,7 @@ struct iterator_fixture<trace_iterator_banded_test> : public trace_iterator_band
     };
 
     test_range_type test_range{base_t::matrix};
-    std::vector<trace_directions> expected_range{U, U, L, L, L, D, D, U};
+    std::vector<seqan3::detail::trace_directions> expected_range{U, U, L, L, L, D, D, U};
 };
 
 INSTANTIATE_TYPED_TEST_SUITE_P(trace_iterator_banded, iterator_fixture, trace_iterator_banded_test, );

--- a/test/unit/alignment/matrix/detail/trace_iterator_test.cpp
+++ b/test/unit/alignment/matrix/detail/trace_iterator_test.cpp
@@ -18,29 +18,28 @@
 
 #include "../../../range/iterator_test_template.hpp"
 
-using namespace seqan3;
-using namespace seqan3::detail;
-
 struct trace_iterator_fixture : public ::testing::Test
 {
-    static constexpr trace_directions N = trace_directions::none;
-    static constexpr trace_directions D = trace_directions::diagonal;
-    static constexpr trace_directions U = trace_directions::up;
-    static constexpr trace_directions UO = trace_directions::up_open;
-    static constexpr trace_directions L = trace_directions::left;
-    static constexpr trace_directions LO = trace_directions::left_open;
+    static constexpr seqan3::detail::trace_directions N = seqan3::detail::trace_directions::none;
+    static constexpr seqan3::detail::trace_directions D = seqan3::detail::trace_directions::diagonal;
+    static constexpr seqan3::detail::trace_directions U = seqan3::detail::trace_directions::up;
+    static constexpr seqan3::detail::trace_directions UO = seqan3::detail::trace_directions::up_open;
+    static constexpr seqan3::detail::trace_directions L = seqan3::detail::trace_directions::left;
+    static constexpr seqan3::detail::trace_directions LO = seqan3::detail::trace_directions::left_open;
 
-    two_dimensional_matrix<trace_directions> matrix{number_rows{3}, number_cols{4}, std::vector
+    seqan3::detail::two_dimensional_matrix<seqan3::detail::trace_directions> matrix{seqan3::detail::number_rows{3},
+                                                                                    seqan3::detail::number_cols{4},
+                                                                                    std::vector
     {
         N,           LO, L,          L,
         UO, D | LO | UO, L, D | L | UO,
         U,       LO | U, D,          L
     }};
 
-    using trace_iterator_type = decltype(trace_iterator{matrix.begin()});
+    using trace_iterator_type = decltype(seqan3::detail::trace_iterator{matrix.begin()});
     using path_type = std::ranges::subrange<trace_iterator_type, std::ranges::default_sentinel_t>;
 
-    path_type path(matrix_offset const & offset)
+    path_type path(seqan3::detail::matrix_offset const & offset)
     {
         return path_type{trace_iterator_type{matrix.begin() + offset}, std::ranges::default_sentinel};
     }
@@ -56,13 +55,15 @@ TEST_F(trace_iterator_fixture, concepts)
 
 TEST_F(trace_iterator_fixture, type_deduction)
 {
-    trace_iterator it{matrix.begin()};
+    seqan3::detail::trace_iterator it{matrix.begin()};
     EXPECT_TRUE((std::is_same_v<decltype(it), seqan3::detail::trace_iterator<decltype(matrix.begin())>>));
 }
 
 TEST_F(trace_iterator_fixture, trace_path_2_3)
 {
-    std::vector vec = path(matrix_offset{row_index_type{2}, column_index_type{3}}) | views::to<std::vector>;
+    std::vector vec = path(seqan3::detail::matrix_offset{seqan3::detail::row_index_type{2},
+                                                         seqan3::detail::column_index_type{3}})
+                    | views::to<std::vector>;
 
     EXPECT_EQ(vec.size(), 5u);
     EXPECT_EQ(vec, (std::vector{L, L, L, U, U}));
@@ -70,7 +71,9 @@ TEST_F(trace_iterator_fixture, trace_path_2_3)
 
 TEST_F(trace_iterator_fixture, trace_path_2_2)
 {
-    std::vector vec = path(matrix_offset{row_index_type{2}, column_index_type{2}}) | views::to<std::vector>;
+    std::vector vec = path(seqan3::detail::matrix_offset{seqan3::detail::row_index_type{2},
+                                                         seqan3::detail::column_index_type{2}})
+                    | views::to<std::vector>;
 
     EXPECT_EQ(vec.size(), 2u);
     EXPECT_EQ(vec, (std::vector{D, D}));
@@ -78,7 +81,9 @@ TEST_F(trace_iterator_fixture, trace_path_2_2)
 
 TEST_F(trace_iterator_fixture, trace_path_2_1)
 {
-    std::vector vec = path(matrix_offset{row_index_type{2}, column_index_type{1}}) | views::to<std::vector>;
+    std::vector vec = path(seqan3::detail::matrix_offset{seqan3::detail::row_index_type{2},
+                                                         seqan3::detail::column_index_type{1}})
+                    | views::to<std::vector>;
 
     EXPECT_EQ(vec.size(), 3u);
     EXPECT_EQ(vec, (std::vector{U, U, L}));
@@ -86,7 +91,9 @@ TEST_F(trace_iterator_fixture, trace_path_2_1)
 
 TEST_F(trace_iterator_fixture, trace_path_2_0)
 {
-    std::vector vec = path(matrix_offset{row_index_type{2}, column_index_type{0}}) | views::to<std::vector>;
+    std::vector vec = path(seqan3::detail::matrix_offset{seqan3::detail::row_index_type{2},
+                                                         seqan3::detail::column_index_type{0}})
+                    | views::to<std::vector>;
 
     EXPECT_EQ(vec.size(), 2u);
     EXPECT_EQ(vec, (std::vector{U, U}));
@@ -94,7 +101,9 @@ TEST_F(trace_iterator_fixture, trace_path_2_0)
 
 TEST_F(trace_iterator_fixture, trace_path_1_3)
 {
-    std::vector vec = path(matrix_offset{row_index_type{1}, column_index_type{3}}) | views::to<std::vector>;
+    std::vector vec = path(seqan3::detail::matrix_offset{seqan3::detail::row_index_type{1},
+                                                         seqan3::detail::column_index_type{3}})
+                    | views::to<std::vector>;
 
     EXPECT_EQ(vec.size(), 3u);
     EXPECT_EQ(vec, (std::vector{D, L, L}));
@@ -102,7 +111,9 @@ TEST_F(trace_iterator_fixture, trace_path_1_3)
 
 TEST_F(trace_iterator_fixture, trace_path_1_2)
 {
-    std::vector vec = path(matrix_offset{row_index_type{1}, column_index_type{2}}) | views::to<std::vector>;
+    std::vector vec = path(seqan3::detail::matrix_offset{seqan3::detail::row_index_type{1},
+                                                         seqan3::detail::column_index_type{2}})
+                    | views::to<std::vector>;
 
     EXPECT_EQ(vec.size(), 3u);
     EXPECT_EQ(vec, (std::vector{L, L, U}));
@@ -110,7 +121,9 @@ TEST_F(trace_iterator_fixture, trace_path_1_2)
 
 TEST_F(trace_iterator_fixture, trace_path_1_1)
 {
-    std::vector vec = path(matrix_offset{row_index_type{1}, column_index_type{1}}) | views::to<std::vector>;
+    std::vector vec = path(seqan3::detail::matrix_offset{seqan3::detail::row_index_type{1},
+                                                         seqan3::detail::column_index_type{1}})
+                    | views::to<std::vector>;
 
     EXPECT_EQ(vec.size(), 1u);
     EXPECT_EQ(vec, (std::vector{D}));
@@ -118,7 +131,9 @@ TEST_F(trace_iterator_fixture, trace_path_1_1)
 
 TEST_F(trace_iterator_fixture, trace_path_1_0)
 {
-    std::vector vec = path(matrix_offset{row_index_type{1}, column_index_type{0}}) | views::to<std::vector>;
+    std::vector vec = path(seqan3::detail::matrix_offset{seqan3::detail::row_index_type{1},
+                                                         seqan3::detail::column_index_type{0}})
+                    | views::to<std::vector>;
 
     EXPECT_EQ(vec.size(), 1u);
     EXPECT_EQ(vec, (std::vector{U}));
@@ -126,7 +141,9 @@ TEST_F(trace_iterator_fixture, trace_path_1_0)
 
 TEST_F(trace_iterator_fixture, trace_path_0_3)
 {
-    std::vector vec = path(matrix_offset{row_index_type{0}, column_index_type{3}}) | views::to<std::vector>;
+    std::vector vec = path(seqan3::detail::matrix_offset{seqan3::detail::row_index_type{0},
+                                                         seqan3::detail::column_index_type{3}})
+                    | views::to<std::vector>;
 
     EXPECT_EQ(vec.size(), 3u);
     EXPECT_EQ(vec, (std::vector{L, L, L}));
@@ -134,7 +151,9 @@ TEST_F(trace_iterator_fixture, trace_path_0_3)
 
 TEST_F(trace_iterator_fixture, trace_path_0_2)
 {
-    std::vector vec = path(matrix_offset{row_index_type{0}, column_index_type{2}}) | views::to<std::vector>;
+    std::vector vec = path(seqan3::detail::matrix_offset{seqan3::detail::row_index_type{0},
+                                                         seqan3::detail::column_index_type{2}})
+                    | views::to<std::vector>;
 
     EXPECT_EQ(vec.size(), 2u);
     EXPECT_EQ(vec, (std::vector{L, L}));
@@ -142,7 +161,9 @@ TEST_F(trace_iterator_fixture, trace_path_0_2)
 
 TEST_F(trace_iterator_fixture, trace_path_0_1)
 {
-    std::vector vec = path(matrix_offset{row_index_type{0}, column_index_type{1}}) | views::to<std::vector>;
+    std::vector vec = path(seqan3::detail::matrix_offset{seqan3::detail::row_index_type{0},
+                                                         seqan3::detail::column_index_type{1}})
+                    | views::to<std::vector>;
 
     EXPECT_EQ(vec.size(), 1u);
     EXPECT_EQ(vec, (std::vector{L}));
@@ -150,15 +171,18 @@ TEST_F(trace_iterator_fixture, trace_path_0_1)
 
 TEST_F(trace_iterator_fixture, trace_path_0_0)
 {
-    std::vector vec = path(matrix_offset{row_index_type{0}, column_index_type{0}}) | views::to<std::vector>;
+    std::vector vec = path(seqan3::detail::matrix_offset{seqan3::detail::row_index_type{0},
+                                                         seqan3::detail::column_index_type{0}})
+                    | views::to<std::vector>;
 
     EXPECT_EQ(vec.size(), 0u);
-    EXPECT_EQ(vec, (std::vector<trace_directions>{}));
+    EXPECT_EQ(vec, (std::vector<seqan3::detail::trace_directions>{}));
 }
 
 TEST_F(trace_iterator_fixture, coordinate)
 {
-    auto p = path(matrix_offset{row_index_type{2}, column_index_type{3}});
+    auto p = path(seqan3::detail::matrix_offset{seqan3::detail::row_index_type{2},
+                                                seqan3::detail::column_index_type{3}});
     auto it = p.begin();
 
     EXPECT_EQ(it.coordinate().row, 2u);
@@ -190,7 +214,7 @@ struct iterator_fixture<trace_iterator_fixture> : public trace_iterator_fixture
     using base_t = trace_iterator_fixture;
 
     using iterator_type = typename base_t::trace_iterator_type;
-    using const_iterator_type = decltype(trace_iterator{base_t::matrix.cbegin()});
+    using const_iterator_type = decltype(seqan3::detail::trace_iterator{base_t::matrix.cbegin()});
 
     // Test forward iterator concept.
     using iterator_tag = std::forward_iterator_tag;
@@ -200,12 +224,15 @@ struct iterator_fixture<trace_iterator_fixture> : public trace_iterator_fixture
     {
         auto begin()
         {
-            return iterator_type{matrix.begin() + matrix_offset{row_index_type{2}, column_index_type{3}}};
+            return iterator_type{matrix.begin() + seqan3::detail::matrix_offset{seqan3::detail::row_index_type{2},
+                                                                                seqan3::detail::column_index_type{3}}};
         }
 
         auto begin() const
         {
-            return const_iterator_type{matrix.cbegin() + matrix_offset{row_index_type{2}, column_index_type{3}}};
+            return const_iterator_type{matrix.cbegin() +
+                                       seqan3::detail::matrix_offset{seqan3::detail::row_index_type{2},
+                                                                     seqan3::detail::column_index_type{3}}};
         }
 
         auto end() { return std::ranges::default_sentinel; }
@@ -215,7 +242,7 @@ struct iterator_fixture<trace_iterator_fixture> : public trace_iterator_fixture
     };
 
     test_range_type test_range{base_t::matrix};
-    std::vector<trace_directions> expected_range{L, L, L, U, U};
+    std::vector<seqan3::detail::trace_directions> expected_range{L, L, L, U, U};
 };
 
 INSTANTIATE_TYPED_TEST_SUITE_P(trace_iterator, iterator_fixture, trace_iterator_fixture, );

--- a/test/unit/alignment/matrix/detail/two_dimensional_matrix_test.cpp
+++ b/test/unit/alignment/matrix/detail/two_dimensional_matrix_test.cpp
@@ -21,13 +21,10 @@
 
 #include "../../../range/iterator_test_template.hpp"
 
-using namespace seqan3;
-using namespace seqan3::detail;
-
-template <typename score_t, matrix_major_order order, typename allocator_t = std::allocator<score_t>>
+template <typename score_t, seqan3::detail::matrix_major_order order, typename allocator_t = std::allocator<score_t>>
 using test_matrix_t = seqan3::detail::two_dimensional_matrix<score_t, allocator_t, order>;
 
-template <typename score_type, matrix_major_order order = matrix_major_order::row>
+template <typename score_type, seqan3::detail::matrix_major_order order = seqan3::detail::matrix_major_order::row>
 std::vector<score_type, std::allocator<score_type>> create_matrix_storage()
 {
     // this is a small hack to allow simd types in an initialiser list on gcc 7 and gcc 10;
@@ -53,7 +50,7 @@ std::vector<score_type, std::allocator<score_type>> create_matrix_storage()
 
     // for a simd vector we make sure that some simd values are completely set, i.e. each scalar value in that simd
     // vector has some value.
-    if constexpr(seqan3::simd_concept<score_type>)
+    if constexpr(seqan3::simd::simd_concept<score_type>)
     {
         row_wise[5] = seqan3::simd::iota<score_type>(5); // 5, 6, 7, ...
         row_wise[8] = seqan3::simd::fill<score_type>(8); // 8, 8, 8, ...
@@ -62,21 +59,21 @@ std::vector<score_type, std::allocator<score_type>> create_matrix_storage()
         column_wise[2] = seqan3::simd::fill<score_type>(8);
     }
 
-    storage_t storage = order == matrix_major_order::row ? row_wise : column_wise;
+    storage_t storage = order == seqan3::detail::matrix_major_order::row ? row_wise : column_wise;
     return {storage.begin(), storage.end()};
 }
 
 template <typename score_t>
 struct make_unsigned_score_type : std::make_unsigned<score_t> {};
 
-template <simd::simd_concept simd_score_t>
+template <seqan3::simd::simd_concept simd_score_t>
 struct make_unsigned_score_type<simd_score_t>
 {
-    using score_type = typename simd::simd_traits<simd_score_t>::scalar_type;
+    using score_type = typename seqan3::simd::simd_traits<simd_score_t>::scalar_type;
     using unsigned_score_type = std::make_unsigned_t<score_type>;
-    static constexpr auto length = simd::simd_traits<simd_score_t>::length;
+    static constexpr auto length = seqan3::simd::simd_traits<simd_score_t>::length;
 
-    using type = simd::simd_type_t<unsigned_score_type, length>;
+    using type = seqan3::simd::simd_type_t<unsigned_score_type, length>;
 };
 
 //-----------------------------------------------------------------------------
@@ -86,53 +83,60 @@ struct make_unsigned_score_type<simd_score_t>
 template <typename matrix_t>
 struct two_dimensional_matrix_test;
 
-template <typename score_t, matrix_major_order order>
+template <typename score_t, seqan3::detail::matrix_major_order order>
 struct two_dimensional_matrix_test<test_matrix_t<score_t, order>> : public ::testing::Test
 {
     using matrix_type = test_matrix_t<score_t, order>;
     using score_type = typename matrix_type::value_type;
-    static constexpr matrix_major_order matrix_order = order;
+    static constexpr seqan3::detail::matrix_major_order matrix_order = order;
 
-    std::vector<score_type> expected_matrix_content{create_matrix_storage<score_type, matrix_major_order::row>()};
+    std::vector<score_type> expected_matrix_content{create_matrix_storage<score_type,
+                                                    seqan3::detail::matrix_major_order::row>()};
     std::vector<score_type> matrix_storage{create_matrix_storage<score_type, matrix_order>()};
 
     // Note: We construct the internal data representation of the matrix depending on the matrix_major_order.
     // This will ensure that all test matrices are independent of the matrix_major_order when accessed via the same
     // matrix coordinate.
-    matrix_type matrix{number_rows{3}, number_cols{4}, matrix_storage};
+    matrix_type matrix{seqan3::detail::number_rows{3}, seqan3::detail::number_cols{4}, matrix_storage};
 
     template <typename value1_t, typename value2_t>
-        requires !(seqan3::simd_concept<std::decay_t<value1_t>> && seqan3::simd_concept<std::decay_t<value2_t>>)
+        requires !(seqan3::simd::simd_concept<std::decay_t<value1_t>> &&
+                   seqan3::simd::simd_concept<std::decay_t<value2_t>>)
     static void expect_eq(value1_t v1, value2_t v2)
     {
         EXPECT_EQ(v1, v2);
     }
 
     template <typename value1_t, typename value2_t>
-        requires (seqan3::simd_concept<std::decay_t<value1_t>> && seqan3::simd_concept<std::decay_t<value2_t>>)
+        requires (seqan3::simd::simd_concept<std::decay_t<value1_t>> &&
+                  seqan3::simd::simd_concept<std::decay_t<value2_t>>)
     static void expect_eq(value1_t && v1, value2_t && v2)
     {
         SIMD_EQ(v1, v2);
     }
 };
 
-using testing_types = ::testing::Types<test_matrix_t<int, matrix_major_order::row>,
-                                       test_matrix_t<int, matrix_major_order::column>,
-                                       test_matrix_t<simd_type_t<int>, matrix_major_order::row>,
-                                       test_matrix_t<simd_type_t<int>, matrix_major_order::column>>;
+using testing_types = ::testing::Types<test_matrix_t<int, seqan3::detail::matrix_major_order::row>,
+                                       test_matrix_t<int, seqan3::detail::matrix_major_order::column>,
+                                       test_matrix_t<seqan3::simd::simd_type_t<int>,
+                                                     seqan3::detail::matrix_major_order::row>,
+                                       test_matrix_t<seqan3::simd::simd_type_t<int>,
+                                                     seqan3::detail::matrix_major_order::column>>;
 TYPED_TEST_SUITE(two_dimensional_matrix_test, testing_types, );
 
 TEST(two_dimensional_matrix_test, initializer_list)
 {
-    [[maybe_unused]] two_dimensional_matrix<int> matrix1{number_rows{0}, number_cols{0}, {}};
-    [[maybe_unused]] two_dimensional_matrix<int> matrix2{number_rows{1}, number_cols{1}, {0}};
+    [[maybe_unused]] seqan3::detail::two_dimensional_matrix<int> matrix1{seqan3::detail::number_rows{0},
+                                                                         seqan3::detail::number_cols{0}, {}};
+    [[maybe_unused]] seqan3::detail::two_dimensional_matrix<int> matrix2{seqan3::detail::number_rows{1},
+                                                                         seqan3::detail::number_cols{1}, {0}};
 }
 
 TYPED_TEST(two_dimensional_matrix_test, concepts)
 {
     using matrix_type = typename TestFixture::matrix_type;
 
-    EXPECT_TRUE(matrix<matrix_type>);
+    EXPECT_TRUE(seqan3::detail::matrix<matrix_type>);
     EXPECT_TRUE(std::ranges::input_range<matrix_type>);
     EXPECT_TRUE(std::ranges::forward_range<matrix_type>);
     EXPECT_TRUE(std::ranges::bidirectional_range<matrix_type>);
@@ -151,16 +155,24 @@ TYPED_TEST(two_dimensional_matrix_test, construction)
     EXPECT_TRUE(std::is_move_assignable_v<matrix_type>);
     EXPECT_TRUE(std::is_destructible_v<matrix_type>);
 
-    EXPECT_TRUE((std::is_constructible_v<matrix_type, number_rows, number_cols>));
-    EXPECT_TRUE((std::is_constructible_v<matrix_type, number_rows, number_cols, std::vector<score_type>>));
-    EXPECT_TRUE((std::is_constructible_v<matrix_type, number_rows, number_cols, matrix_type>));
+    EXPECT_TRUE((std::is_constructible_v<matrix_type,
+                                         seqan3::detail::number_rows,
+                                         seqan3::detail::number_cols>));
+    EXPECT_TRUE((std::is_constructible_v<matrix_type,
+                                         seqan3::detail::number_rows,
+                                         seqan3::detail::number_cols,
+                                         std::vector<score_type>>));
+    EXPECT_TRUE((std::is_constructible_v<matrix_type,
+                                         seqan3::detail::number_rows,
+                                         seqan3::detail::number_cols,
+                                         matrix_type>));
 }
 
 TYPED_TEST(two_dimensional_matrix_test, cols)
 {
     using matrix_type = typename TestFixture::matrix_type;
 
-    matrix_type matrix{number_rows{3}, number_cols{4}};
+    matrix_type matrix{seqan3::detail::number_rows{3}, seqan3::detail::number_cols{4}};
     EXPECT_EQ(matrix.cols(), 4u);
 }
 
@@ -168,7 +180,7 @@ TYPED_TEST(two_dimensional_matrix_test, rows)
 {
     using matrix_type = typename TestFixture::matrix_type;
 
-    matrix_type matrix{number_rows{3}, number_cols{4}};
+    matrix_type matrix{seqan3::detail::number_rows{3}, seqan3::detail::number_cols{4}};
     EXPECT_EQ(matrix.rows(), 3u);
 }
 
@@ -184,45 +196,72 @@ TYPED_TEST(two_dimensional_matrix_test, subscript)
 {
     // Note: Even if the internal storage has a different data layout, accessing the data via a matrix coordinate
     // yields the same cell and thus the same data.
-    this->expect_eq(this->matrix[{row_index_type{0u}, column_index_type{0u}}], this->expected_matrix_content[0]);
-    this->expect_eq(this->matrix[{row_index_type{0u}, column_index_type{1u}}], this->expected_matrix_content[1]);
-    this->expect_eq(this->matrix[{row_index_type{0u}, column_index_type{2u}}], this->expected_matrix_content[2]);
-    this->expect_eq(this->matrix[{row_index_type{0u}, column_index_type{3u}}], this->expected_matrix_content[3]);
-    this->expect_eq(this->matrix[{row_index_type{1u}, column_index_type{0u}}], this->expected_matrix_content[4]);
-    this->expect_eq(this->matrix[{row_index_type{1u}, column_index_type{1u}}], this->expected_matrix_content[5]);
-    this->expect_eq(this->matrix[{row_index_type{1u}, column_index_type{2u}}], this->expected_matrix_content[6]);
-    this->expect_eq(this->matrix[{row_index_type{1u}, column_index_type{3u}}], this->expected_matrix_content[7]);
-    this->expect_eq(this->matrix[{row_index_type{2u}, column_index_type{0u}}], this->expected_matrix_content[8]);
-    this->expect_eq(this->matrix[{row_index_type{2u}, column_index_type{1u}}], this->expected_matrix_content[9]);
-    this->expect_eq(this->matrix[{row_index_type{2u}, column_index_type{2u}}], this->expected_matrix_content[10]);
-    this->expect_eq(this->matrix[{row_index_type{2u}, column_index_type{3u}}], this->expected_matrix_content[11]);
+    this->expect_eq(this->matrix[{seqan3::detail::row_index_type{0u},
+                                  seqan3::detail::column_index_type{0u}}], this->expected_matrix_content[0]);
+    this->expect_eq(this->matrix[{seqan3::detail::row_index_type{0u},
+                                  seqan3::detail::column_index_type{1u}}], this->expected_matrix_content[1]);
+    this->expect_eq(this->matrix[{seqan3::detail::row_index_type{0u},
+                                  seqan3::detail::column_index_type{2u}}], this->expected_matrix_content[2]);
+    this->expect_eq(this->matrix[{seqan3::detail::row_index_type{0u},
+                                  seqan3::detail::column_index_type{3u}}], this->expected_matrix_content[3]);
+    this->expect_eq(this->matrix[{seqan3::detail::row_index_type{1u},
+                                  seqan3::detail::column_index_type{0u}}], this->expected_matrix_content[4]);
+    this->expect_eq(this->matrix[{seqan3::detail::row_index_type{1u},
+                                  seqan3::detail::column_index_type{1u}}], this->expected_matrix_content[5]);
+    this->expect_eq(this->matrix[{seqan3::detail::row_index_type{1u},
+                                  seqan3::detail::column_index_type{2u}}], this->expected_matrix_content[6]);
+    this->expect_eq(this->matrix[{seqan3::detail::row_index_type{1u},
+                                  seqan3::detail::column_index_type{3u}}], this->expected_matrix_content[7]);
+    this->expect_eq(this->matrix[{seqan3::detail::row_index_type{2u},
+                                  seqan3::detail::column_index_type{0u}}], this->expected_matrix_content[8]);
+    this->expect_eq(this->matrix[{seqan3::detail::row_index_type{2u},
+                                  seqan3::detail::column_index_type{1u}}], this->expected_matrix_content[9]);
+    this->expect_eq(this->matrix[{seqan3::detail::row_index_type{2u},
+                                  seqan3::detail::column_index_type{2u}}], this->expected_matrix_content[10]);
+    this->expect_eq(this->matrix[{seqan3::detail::row_index_type{2u},
+                                  seqan3::detail::column_index_type{3u}}], this->expected_matrix_content[11]);
 }
 
 TYPED_TEST(two_dimensional_matrix_test, at)
 {
-    this->expect_eq(this->matrix.at({row_index_type{0u}, column_index_type{0u}}), this->expected_matrix_content[0]);
-    this->expect_eq(this->matrix.at({row_index_type{0u}, column_index_type{1u}}), this->expected_matrix_content[1]);
-    this->expect_eq(this->matrix.at({row_index_type{0u}, column_index_type{2u}}), this->expected_matrix_content[2]);
-    this->expect_eq(this->matrix.at({row_index_type{0u}, column_index_type{3u}}), this->expected_matrix_content[3]);
-    this->expect_eq(this->matrix.at({row_index_type{1u}, column_index_type{0u}}), this->expected_matrix_content[4]);
-    this->expect_eq(this->matrix.at({row_index_type{1u}, column_index_type{1u}}), this->expected_matrix_content[5]);
-    this->expect_eq(this->matrix.at({row_index_type{1u}, column_index_type{2u}}), this->expected_matrix_content[6]);
-    this->expect_eq(this->matrix.at({row_index_type{1u}, column_index_type{3u}}), this->expected_matrix_content[7]);
-    this->expect_eq(this->matrix.at({row_index_type{2u}, column_index_type{0u}}), this->expected_matrix_content[8]);
-    this->expect_eq(this->matrix.at({row_index_type{2u}, column_index_type{1u}}), this->expected_matrix_content[9]);
-    this->expect_eq(this->matrix.at({row_index_type{2u}, column_index_type{2u}}), this->expected_matrix_content[10]);
-    this->expect_eq(this->matrix.at({row_index_type{2u}, column_index_type{3u}}), this->expected_matrix_content[11]);
+    this->expect_eq(this->matrix.at({seqan3::detail::row_index_type{0u},
+                                     seqan3::detail::column_index_type{0u}}), this->expected_matrix_content[0]);
+    this->expect_eq(this->matrix.at({seqan3::detail::row_index_type{0u},
+                                     seqan3::detail::column_index_type{1u}}), this->expected_matrix_content[1]);
+    this->expect_eq(this->matrix.at({seqan3::detail::row_index_type{0u},
+                                     seqan3::detail::column_index_type{2u}}), this->expected_matrix_content[2]);
+    this->expect_eq(this->matrix.at({seqan3::detail::row_index_type{0u},
+                                     seqan3::detail::column_index_type{3u}}), this->expected_matrix_content[3]);
+    this->expect_eq(this->matrix.at({seqan3::detail::row_index_type{1u},
+                                     seqan3::detail::column_index_type{0u}}), this->expected_matrix_content[4]);
+    this->expect_eq(this->matrix.at({seqan3::detail::row_index_type{1u},
+                                     seqan3::detail::column_index_type{1u}}), this->expected_matrix_content[5]);
+    this->expect_eq(this->matrix.at({seqan3::detail::row_index_type{1u},
+                                     seqan3::detail::column_index_type{2u}}), this->expected_matrix_content[6]);
+    this->expect_eq(this->matrix.at({seqan3::detail::row_index_type{1u},
+                                     seqan3::detail::column_index_type{3u}}), this->expected_matrix_content[7]);
+    this->expect_eq(this->matrix.at({seqan3::detail::row_index_type{2u},
+                                     seqan3::detail::column_index_type{0u}}), this->expected_matrix_content[8]);
+    this->expect_eq(this->matrix.at({seqan3::detail::row_index_type{2u},
+                                     seqan3::detail::column_index_type{1u}}), this->expected_matrix_content[9]);
+    this->expect_eq(this->matrix.at({seqan3::detail::row_index_type{2u},
+                                     seqan3::detail::column_index_type{2u}}), this->expected_matrix_content[10]);
+    this->expect_eq(this->matrix.at({seqan3::detail::row_index_type{2u},
+                                     seqan3::detail::column_index_type{3u}}), this->expected_matrix_content[11]);
 
-    EXPECT_THROW((this->matrix.at({row_index_type{3u}, column_index_type{3u}})), std::invalid_argument);
-    EXPECT_THROW((this->matrix.at({row_index_type{2u}, column_index_type{4u}})), std::invalid_argument);
+    EXPECT_THROW((this->matrix.at({seqan3::detail::row_index_type{3u},
+                                   seqan3::detail::column_index_type{3u}})), std::invalid_argument);
+    EXPECT_THROW((this->matrix.at({seqan3::detail::row_index_type{2u},
+                                   seqan3::detail::column_index_type{4u}})), std::invalid_argument);
 }
 
 TYPED_TEST(two_dimensional_matrix_test, construction_other_order)
 {
     // Test that changing the matrix layout works.
-    static constexpr matrix_major_order other_matrix_order = TestFixture::matrix_order == matrix_major_order::row
-                                                                ? matrix_major_order::column
-                                                                : matrix_major_order::row;
+    static constexpr seqan3::detail::matrix_major_order other_matrix_order = TestFixture::matrix_order
+                                                                           == seqan3::detail::matrix_major_order::row
+                                                                           ? seqan3::detail::matrix_major_order::column
+                                                                           : seqan3::detail::matrix_major_order::row;
 
     // Test that the implicit conversion of the underlying value_type works.
     // This does not work for every SIMD backend, in such a case we use the original score type.
@@ -245,7 +284,8 @@ TYPED_TEST(two_dimensional_matrix_test, construction_other_order)
     {
         for (unsigned col = 0; col < this->matrix.cols(); ++col)
         {
-            matrix_coordinate const idx{row_index_type{row}, column_index_type{col}};
+            seqan3::detail::matrix_coordinate const idx{seqan3::detail::row_index_type{row},
+                                                        seqan3::detail::column_index_type{col}};
             new_score_type actual = converted_matrix[idx];
             new_score_type expected = static_cast<new_score_type>(this->matrix[idx]);
             this->expect_eq(actual, expected);
@@ -257,7 +297,7 @@ TYPED_TEST(two_dimensional_matrix_test, construction_other_order)
 // Iterator tests
 //-----------------------------------------------------------------------------
 
-template <typename score_t, matrix_major_order order>
+template <typename score_t, seqan3::detail::matrix_major_order order>
 struct iterator_fixture<test_matrix_t<score_t, order>> : two_dimensional_matrix_test<test_matrix_t<score_t, order>>
 {
     using matrix_type = test_matrix_t<score_t, order>;
@@ -274,7 +314,7 @@ struct iterator_fixture<test_matrix_t<score_t, order>> : two_dimensional_matrix_
     // the internal data storage, i.e. the iterator's behaviour does not depend on the major matrix order. Thus, passing
     // expected_range as data storage into test_range, will result in an equal range as test_range.
     std::vector<score_t> expected_range{this->expected_matrix_content};
-    matrix_type test_range{number_rows{3}, number_cols{4}, expected_range};
+    matrix_type test_range{seqan3::detail::number_rows{3}, seqan3::detail::number_cols{4}, expected_range};
 };
 
 INSTANTIATE_TYPED_TEST_SUITE_P(two_dimensional_iterator, iterator_fixture, testing_types, );
@@ -286,20 +326,23 @@ struct two_dimensional_matrix_iterator_test : two_dimensional_matrix_test<matrix
     using base_t = two_dimensional_matrix_test<matrix_type>;
     using iterator_type = typename matrix_type::iterator;
 
-    matrix_type test_range{number_rows{3}, number_cols{4}, base_t::expected_matrix_content};
+    matrix_type test_range{seqan3::detail::number_rows{3},
+                           seqan3::detail::number_cols{4},
+                           base_t::expected_matrix_content};
 };
 
 TYPED_TEST_SUITE(two_dimensional_matrix_iterator_test, testing_types, );
 
 TYPED_TEST(two_dimensional_matrix_iterator_test, two_dimensional_concept)
 {
-    EXPECT_TRUE(two_dimensional_matrix_iterator<typename TestFixture::iterator_type>);
+    EXPECT_TRUE(seqan3::detail::two_dimensional_matrix_iterator<typename TestFixture::iterator_type>);
 }
 
 TYPED_TEST(two_dimensional_matrix_iterator_test, update_by_matrix_offset_add)
 {
     auto it = this->matrix.begin();
-    auto it_advanced = it += matrix_offset{row_index_type{1}, column_index_type{2}};
+    auto it_advanced = it += seqan3::detail::matrix_offset{seqan3::detail::row_index_type{1},
+                                                           seqan3::detail::column_index_type{2}};
 
     this->expect_eq(*it, this->expected_matrix_content[6]);
     this->expect_eq(*it_advanced, this->expected_matrix_content[6]);
@@ -308,7 +351,8 @@ TYPED_TEST(two_dimensional_matrix_iterator_test, update_by_matrix_offset_add)
 TYPED_TEST(two_dimensional_matrix_iterator_test, advance_by_matrix_offset_add)
 {
     auto it = this->matrix.begin();
-    auto it_advanced = it + matrix_offset{row_index_type{1}, column_index_type{2}};
+    auto it_advanced = it + seqan3::detail::matrix_offset{seqan3::detail::row_index_type{1},
+                                                          seqan3::detail::column_index_type{2}};
 
     this->expect_eq(*it, this->expected_matrix_content[0]);
     this->expect_eq(*it_advanced, this->expected_matrix_content[6]);
@@ -317,7 +361,8 @@ TYPED_TEST(two_dimensional_matrix_iterator_test, advance_by_matrix_offset_add)
 TYPED_TEST(two_dimensional_matrix_iterator_test, advance_by_matrix_offset_add_friend)
 {
     auto it = this->matrix.begin();
-    auto it_advanced = matrix_offset{row_index_type{1}, column_index_type{2}} + it;
+    auto it_advanced = seqan3::detail::matrix_offset{seqan3::detail::row_index_type{1},
+                                                     seqan3::detail::column_index_type{2}} + it;
 
     this->expect_eq(*it, this->expected_matrix_content[0]);
     this->expect_eq(*it_advanced, this->expected_matrix_content[6]);
@@ -325,8 +370,10 @@ TYPED_TEST(two_dimensional_matrix_iterator_test, advance_by_matrix_offset_add_fr
 
 TYPED_TEST(two_dimensional_matrix_iterator_test, update_by_matrix_offset_subtract)
 {
-    auto it = this->matrix.begin() + matrix_offset{row_index_type{2}, column_index_type{3}};
-    auto it_advanced = it -= matrix_offset{row_index_type{1}, column_index_type{2}};
+    auto it = this->matrix.begin() + seqan3::detail::matrix_offset{seqan3::detail::row_index_type{2},
+                                                                   seqan3::detail::column_index_type{3}};
+    auto it_advanced = it -= seqan3::detail::matrix_offset{seqan3::detail::row_index_type{1},
+                                                           seqan3::detail::column_index_type{2}};
 
     this->expect_eq(*it, this->expected_matrix_content[5]);
     this->expect_eq(*it_advanced, this->expected_matrix_content[5]);
@@ -334,8 +381,10 @@ TYPED_TEST(two_dimensional_matrix_iterator_test, update_by_matrix_offset_subtrac
 
 TYPED_TEST(two_dimensional_matrix_iterator_test, advance_by_matrix_offset_subtract)
 {
-    auto it = this->matrix.begin() + matrix_offset{row_index_type{2}, column_index_type{3}};
-    auto it_advanced = it - matrix_offset{row_index_type{1}, column_index_type{2}};
+    auto it = this->matrix.begin() + seqan3::detail::matrix_offset{seqan3::detail::row_index_type{2},
+                                                                   seqan3::detail::column_index_type{3}};
+    auto it_advanced = it - seqan3::detail::matrix_offset{seqan3::detail::row_index_type{1},
+                                                          seqan3::detail::column_index_type{2}};
 
     this->expect_eq(*it, this->expected_matrix_content[11]);
     this->expect_eq(*it_advanced, this->expected_matrix_content[5]);
@@ -344,7 +393,7 @@ TYPED_TEST(two_dimensional_matrix_iterator_test, advance_by_matrix_offset_subtra
 TYPED_TEST(two_dimensional_matrix_iterator_test, coordinate)
 {
     auto it = this->matrix.begin();
-    matrix_offset col_inc{row_index_type{0}, column_index_type{1}};
+    seqan3::detail::matrix_offset col_inc{seqan3::detail::row_index_type{0}, seqan3::detail::column_index_type{1}};
 
     // iterate row wise in the matrix
     for (std::ptrdiff_t pos = 0; it != this->matrix.end(); it += col_inc, ++pos)

--- a/test/unit/alignment/matrix/detail/two_dimensional_matrix_test.cpp
+++ b/test/unit/alignment/matrix/detail/two_dimensional_matrix_test.cpp
@@ -196,63 +196,63 @@ TYPED_TEST(two_dimensional_matrix_test, subscript)
 {
     // Note: Even if the internal storage has a different data layout, accessing the data via a matrix coordinate
     // yields the same cell and thus the same data.
-    this->expect_eq(this->matrix[{seqan3::detail::row_index_type{0u},
-                                  seqan3::detail::column_index_type{0u}}], this->expected_matrix_content[0]);
-    this->expect_eq(this->matrix[{seqan3::detail::row_index_type{0u},
-                                  seqan3::detail::column_index_type{1u}}], this->expected_matrix_content[1]);
-    this->expect_eq(this->matrix[{seqan3::detail::row_index_type{0u},
-                                  seqan3::detail::column_index_type{2u}}], this->expected_matrix_content[2]);
-    this->expect_eq(this->matrix[{seqan3::detail::row_index_type{0u},
-                                  seqan3::detail::column_index_type{3u}}], this->expected_matrix_content[3]);
-    this->expect_eq(this->matrix[{seqan3::detail::row_index_type{1u},
-                                  seqan3::detail::column_index_type{0u}}], this->expected_matrix_content[4]);
-    this->expect_eq(this->matrix[{seqan3::detail::row_index_type{1u},
-                                  seqan3::detail::column_index_type{1u}}], this->expected_matrix_content[5]);
-    this->expect_eq(this->matrix[{seqan3::detail::row_index_type{1u},
-                                  seqan3::detail::column_index_type{2u}}], this->expected_matrix_content[6]);
-    this->expect_eq(this->matrix[{seqan3::detail::row_index_type{1u},
-                                  seqan3::detail::column_index_type{3u}}], this->expected_matrix_content[7]);
-    this->expect_eq(this->matrix[{seqan3::detail::row_index_type{2u},
-                                  seqan3::detail::column_index_type{0u}}], this->expected_matrix_content[8]);
-    this->expect_eq(this->matrix[{seqan3::detail::row_index_type{2u},
-                                  seqan3::detail::column_index_type{1u}}], this->expected_matrix_content[9]);
-    this->expect_eq(this->matrix[{seqan3::detail::row_index_type{2u},
-                                  seqan3::detail::column_index_type{2u}}], this->expected_matrix_content[10]);
-    this->expect_eq(this->matrix[{seqan3::detail::row_index_type{2u},
-                                  seqan3::detail::column_index_type{3u}}], this->expected_matrix_content[11]);
+    this->expect_eq(this->matrix[{seqan3::detail::row_index_type{0u}, seqan3::detail::column_index_type{0u}}],
+                    this->expected_matrix_content[0]);
+    this->expect_eq(this->matrix[{seqan3::detail::row_index_type{0u}, seqan3::detail::column_index_type{1u}}],
+                    this->expected_matrix_content[1]);
+    this->expect_eq(this->matrix[{seqan3::detail::row_index_type{0u}, seqan3::detail::column_index_type{2u}}],
+                    this->expected_matrix_content[2]);
+    this->expect_eq(this->matrix[{seqan3::detail::row_index_type{0u}, seqan3::detail::column_index_type{3u}}],
+                    this->expected_matrix_content[3]);
+    this->expect_eq(this->matrix[{seqan3::detail::row_index_type{1u}, seqan3::detail::column_index_type{0u}}],
+                    this->expected_matrix_content[4]);
+    this->expect_eq(this->matrix[{seqan3::detail::row_index_type{1u}, seqan3::detail::column_index_type{1u}}],
+                    this->expected_matrix_content[5]);
+    this->expect_eq(this->matrix[{seqan3::detail::row_index_type{1u}, seqan3::detail::column_index_type{2u}}],
+                    this->expected_matrix_content[6]);
+    this->expect_eq(this->matrix[{seqan3::detail::row_index_type{1u}, seqan3::detail::column_index_type{3u}}],
+                    this->expected_matrix_content[7]);
+    this->expect_eq(this->matrix[{seqan3::detail::row_index_type{2u},  seqan3::detail::column_index_type{0u}}],
+                    this->expected_matrix_content[8]);
+    this->expect_eq(this->matrix[{seqan3::detail::row_index_type{2u}, seqan3::detail::column_index_type{1u}}],
+                    this->expected_matrix_content[9]);
+    this->expect_eq(this->matrix[{seqan3::detail::row_index_type{2u}, seqan3::detail::column_index_type{2u}}],
+                    this->expected_matrix_content[10]);
+    this->expect_eq(this->matrix[{seqan3::detail::row_index_type{2u}, seqan3::detail::column_index_type{3u}}],
+                    this->expected_matrix_content[11]);
 }
 
 TYPED_TEST(two_dimensional_matrix_test, at)
 {
-    this->expect_eq(this->matrix.at({seqan3::detail::row_index_type{0u},
-                                     seqan3::detail::column_index_type{0u}}), this->expected_matrix_content[0]);
-    this->expect_eq(this->matrix.at({seqan3::detail::row_index_type{0u},
-                                     seqan3::detail::column_index_type{1u}}), this->expected_matrix_content[1]);
-    this->expect_eq(this->matrix.at({seqan3::detail::row_index_type{0u},
-                                     seqan3::detail::column_index_type{2u}}), this->expected_matrix_content[2]);
-    this->expect_eq(this->matrix.at({seqan3::detail::row_index_type{0u},
-                                     seqan3::detail::column_index_type{3u}}), this->expected_matrix_content[3]);
-    this->expect_eq(this->matrix.at({seqan3::detail::row_index_type{1u},
-                                     seqan3::detail::column_index_type{0u}}), this->expected_matrix_content[4]);
-    this->expect_eq(this->matrix.at({seqan3::detail::row_index_type{1u},
-                                     seqan3::detail::column_index_type{1u}}), this->expected_matrix_content[5]);
-    this->expect_eq(this->matrix.at({seqan3::detail::row_index_type{1u},
-                                     seqan3::detail::column_index_type{2u}}), this->expected_matrix_content[6]);
-    this->expect_eq(this->matrix.at({seqan3::detail::row_index_type{1u},
-                                     seqan3::detail::column_index_type{3u}}), this->expected_matrix_content[7]);
-    this->expect_eq(this->matrix.at({seqan3::detail::row_index_type{2u},
-                                     seqan3::detail::column_index_type{0u}}), this->expected_matrix_content[8]);
-    this->expect_eq(this->matrix.at({seqan3::detail::row_index_type{2u},
-                                     seqan3::detail::column_index_type{1u}}), this->expected_matrix_content[9]);
-    this->expect_eq(this->matrix.at({seqan3::detail::row_index_type{2u},
-                                     seqan3::detail::column_index_type{2u}}), this->expected_matrix_content[10]);
-    this->expect_eq(this->matrix.at({seqan3::detail::row_index_type{2u},
-                                     seqan3::detail::column_index_type{3u}}), this->expected_matrix_content[11]);
+    this->expect_eq(this->matrix.at({seqan3::detail::row_index_type{0u}, seqan3::detail::column_index_type{0u}}),
+                    this->expected_matrix_content[0]);
+    this->expect_eq(this->matrix.at({seqan3::detail::row_index_type{0u}, seqan3::detail::column_index_type{1u}}),
+                    this->expected_matrix_content[1]);
+    this->expect_eq(this->matrix.at({seqan3::detail::row_index_type{0u}, seqan3::detail::column_index_type{2u}}),
+                    this->expected_matrix_content[2]);
+    this->expect_eq(this->matrix.at({seqan3::detail::row_index_type{0u}, seqan3::detail::column_index_type{3u}}),
+                    this->expected_matrix_content[3]);
+    this->expect_eq(this->matrix.at({seqan3::detail::row_index_type{1u}, seqan3::detail::column_index_type{0u}}),
+                    this->expected_matrix_content[4]);
+    this->expect_eq(this->matrix.at({seqan3::detail::row_index_type{1u}, seqan3::detail::column_index_type{1u}}),
+                    this->expected_matrix_content[5]);
+    this->expect_eq(this->matrix.at({seqan3::detail::row_index_type{1u}, seqan3::detail::column_index_type{2u}}),
+                    this->expected_matrix_content[6]);
+    this->expect_eq(this->matrix.at({seqan3::detail::row_index_type{1u}, seqan3::detail::column_index_type{3u}}),
+                    this->expected_matrix_content[7]);
+    this->expect_eq(this->matrix.at({seqan3::detail::row_index_type{2u}, seqan3::detail::column_index_type{0u}}),
+                    this->expected_matrix_content[8]);
+    this->expect_eq(this->matrix.at({seqan3::detail::row_index_type{2u}, seqan3::detail::column_index_type{1u}}),
+                    this->expected_matrix_content[9]);
+    this->expect_eq(this->matrix.at({seqan3::detail::row_index_type{2u}, seqan3::detail::column_index_type{2u}}),
+                    this->expected_matrix_content[10]);
+    this->expect_eq(this->matrix.at({seqan3::detail::row_index_type{2u}, seqan3::detail::column_index_type{3u}}),
+                    this->expected_matrix_content[11]);
 
-    EXPECT_THROW((this->matrix.at({seqan3::detail::row_index_type{3u},
-                                   seqan3::detail::column_index_type{3u}})), std::invalid_argument);
-    EXPECT_THROW((this->matrix.at({seqan3::detail::row_index_type{2u},
-                                   seqan3::detail::column_index_type{4u}})), std::invalid_argument);
+    EXPECT_THROW((this->matrix.at({seqan3::detail::row_index_type{3u}, seqan3::detail::column_index_type{3u}})),
+                 std::invalid_argument);
+    EXPECT_THROW((this->matrix.at({seqan3::detail::row_index_type{2u}, seqan3::detail::column_index_type{4u}})),
+                 std::invalid_argument);
 }
 
 TYPED_TEST(two_dimensional_matrix_test, construction_other_order)

--- a/test/unit/alignment/matrix/edit_distance_matrix/edit_distance_score_matrix.hpp
+++ b/test/unit/alignment/matrix/edit_distance_matrix/edit_distance_score_matrix.hpp
@@ -8,8 +8,6 @@
 #include <seqan3/alignment/matrix/edit_distance_trace_matrix_full.hpp>
 #include <seqan3/alignment/matrix/row_wise_matrix.hpp>
 
-using namespace seqan3;
-
 using score_type = int;
 using word_type = uint8_t;
 
@@ -29,7 +27,7 @@ public:
     using base_t::reserve;
 };
 
-static constexpr score_type INF = detail::matrix_inf<score_type>;
+static constexpr score_type INF = seqan3::detail::matrix_inf<score_type>;
 
 std::vector<std::vector<int>> as_row_wise_vector(auto matrix)
 {
@@ -39,7 +37,8 @@ std::vector<std::vector<int>> as_row_wise_vector(auto matrix)
         result.push_back({});
         for (unsigned col = 0; col < matrix.cols(); ++col)
         {
-            std::optional<int> entry = matrix.at({detail::row_index_type{row}, detail::column_index_type{col}});
+            std::optional<int> entry = matrix.at({seqan3::detail::row_index_type{row},
+                                                  seqan3::detail::column_index_type{col}});
             result.back().push_back(entry.value_or(INF));
         }
     }

--- a/test/unit/alignment/matrix/edit_distance_matrix/edit_distance_trace_matrix.hpp
+++ b/test/unit/alignment/matrix/edit_distance_matrix/edit_distance_trace_matrix.hpp
@@ -10,8 +10,7 @@
 
 #include "../../pairwise/fixture/alignment_fixture.hpp"
 
-using namespace seqan3;
-using namespace seqan3::test::alignment::fixture;
+using namespace seqan3::test::alignment::fixture;   // for N, D, u, l and combinations
 
 using word_type = uint8_t;
 
@@ -29,14 +28,15 @@ public:
     using base_t::reserve;
 };
 
-std::vector<std::vector<detail::trace_directions>> as_row_wise_vector(auto matrix)
+std::vector<std::vector<seqan3::detail::trace_directions>> as_row_wise_vector(auto matrix)
 {
-    std::vector<std::vector<detail::trace_directions>> result{};
+    std::vector<std::vector<seqan3::detail::trace_directions>> result{};
     for (unsigned row = 0; row < matrix.rows(); ++row)
     {
         result.push_back({});
         for (unsigned col = 0; col < matrix.cols(); ++col)
-            result.back().push_back(matrix.at({detail::row_index_type{row}, detail::column_index_type{col}}));
+            result.back().push_back(matrix.at({seqan3::detail::row_index_type{row},
+                                               seqan3::detail::column_index_type{col}}));
     }
     return result;
 }

--- a/test/unit/alignment/matrix/edit_distance_matrix/trace_matrix_unbanded_global_max_errors_test.cpp
+++ b/test/unit/alignment/matrix/edit_distance_matrix/trace_matrix_unbanded_global_max_errors_test.cpp
@@ -17,8 +17,8 @@ TEST(global_max_errors, empty)
     matrix_type<false, true> matrix{1u};
 
     // row-wise matrix
-    std::vector<std::vector<detail::trace_directions>> result = as_row_wise_vector(matrix);
-    std::vector<std::vector<detail::trace_directions>> expect{{}};
+    std::vector<std::vector<seqan3::detail::trace_directions>> result = as_row_wise_vector(matrix);
+    std::vector<std::vector<seqan3::detail::trace_directions>> expect{{}};
 
     EXPECT_EQ(result, expect);
 }
@@ -30,8 +30,8 @@ TEST(global_max_errors, epsilon)
     matrix.add_column({}, {}, {}, 1u);
 
     // row-wise matrix
-    std::vector<std::vector<detail::trace_directions>> result = as_row_wise_vector(matrix);
-    std::vector<std::vector<detail::trace_directions>> expect{{N}};
+    std::vector<std::vector<seqan3::detail::trace_directions>> result = as_row_wise_vector(matrix);
+    std::vector<std::vector<seqan3::detail::trace_directions>> expect{{N}};
 
     EXPECT_EQ(result, expect);
 }
@@ -47,8 +47,8 @@ TEST(global_max_errors, epsilon_row)
     matrix.add_column({}, {}, {}, 0u);
 
     // row-wise matrix
-    std::vector<std::vector<detail::trace_directions>> result = as_row_wise_vector(matrix);
-    std::vector<std::vector<detail::trace_directions>> expect{{N, l, l, N, N}};
+    std::vector<std::vector<seqan3::detail::trace_directions>> result = as_row_wise_vector(matrix);
+    std::vector<std::vector<seqan3::detail::trace_directions>> expect{{N, l, l, N, N}};
 
     EXPECT_EQ(result, expect);
 }
@@ -70,8 +70,8 @@ TEST(global_max_errors, single_word_1)
     matrix.add_column({0b1000'1111u}, {0b1111'0001u}, {0b1110'0000u}, 7u);
 
     // row-wise matrix
-    std::vector<std::vector<detail::trace_directions>> result = as_row_wise_vector(matrix);
-    std::vector<std::vector<detail::trace_directions>> expect
+    std::vector<std::vector<seqan3::detail::trace_directions>> result = as_row_wise_vector(matrix);
+    std::vector<std::vector<seqan3::detail::trace_directions>> expect
     {
         {N  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  },
         {u  ,D  ,Dl ,l  ,l  ,l  ,l  ,l  ,l  ,Dl },
@@ -104,8 +104,8 @@ TEST(global_max_errors, single_word_2)
     matrix.add_column({0b1000'1111u}, {0b1111'0001u}, {0b1110'0000u}, 6u);
 
     // row-wise matrix
-    std::vector<std::vector<detail::trace_directions>> result = as_row_wise_vector(matrix);
-    std::vector<std::vector<detail::trace_directions>> expect
+    std::vector<std::vector<seqan3::detail::trace_directions>> result = as_row_wise_vector(matrix);
+    std::vector<std::vector<seqan3::detail::trace_directions>> expect
     {
         {N  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  },
         {u  ,D  ,Dl ,l  ,l  ,l  ,l  ,l  ,l  ,Dl },
@@ -138,8 +138,8 @@ TEST(global_max_errors, single_word_3)
     matrix.add_column({0b1000'1111u}, {0b1111'0001u}, {0b1110'0000u}, 0u);
 
     // row-wise matrix
-    std::vector<std::vector<detail::trace_directions>> result = as_row_wise_vector(matrix);
-    std::vector<std::vector<detail::trace_directions>> expect
+    std::vector<std::vector<seqan3::detail::trace_directions>> result = as_row_wise_vector(matrix);
+    std::vector<std::vector<seqan3::detail::trace_directions>> expect
     {
         {N  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,N  ,N  },
         {u  ,D  ,Dl ,l  ,l  ,l  ,l  ,l  ,N  ,N  },
@@ -172,8 +172,8 @@ TEST(global_max_errors, multiple_words_1)
     matrix.add_column({0b1000'1111u, 0b0u}, {0b1111'0001u, 0b1u}, {0b1110'0000u, 0b0u}, 7u);
 
     // row-wise matrix
-    std::vector<std::vector<detail::trace_directions>> result = as_row_wise_vector(matrix);
-    std::vector<std::vector<detail::trace_directions>> expect
+    std::vector<std::vector<seqan3::detail::trace_directions>> result = as_row_wise_vector(matrix);
+    std::vector<std::vector<seqan3::detail::trace_directions>> expect
     {
         {N  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  },
         {u  ,D  ,Dl ,l  ,l  ,l  ,l  ,l  ,l  ,Dl },
@@ -227,8 +227,8 @@ TEST(global_max_errors, multiple_words_2)
                       {0b0000'0000u, 0b0000'0110u, 0b0u}, 18u);
 
     // row-wise matrix
-    std::vector<std::vector<detail::trace_directions>> result = as_row_wise_vector(matrix);
-    std::vector<std::vector<detail::trace_directions>> expect
+    std::vector<std::vector<seqan3::detail::trace_directions>> result = as_row_wise_vector(matrix);
+    std::vector<std::vector<seqan3::detail::trace_directions>> expect
     {
         {N  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  },
         {u  ,D  ,l  ,l  ,l  ,Dl ,l  ,l  ,l  ,Dl },

--- a/test/unit/alignment/matrix/edit_distance_matrix/trace_matrix_unbanded_global_test.cpp
+++ b/test/unit/alignment/matrix/edit_distance_matrix/trace_matrix_unbanded_global_test.cpp
@@ -17,8 +17,8 @@ TEST(global, empty)
     matrix_type<false, false> matrix{1u};
 
     // row-wise matrix
-    std::vector<std::vector<detail::trace_directions>> result = as_row_wise_vector(matrix);
-    std::vector<std::vector<detail::trace_directions>> expect{{}};
+    std::vector<std::vector<seqan3::detail::trace_directions>> result = as_row_wise_vector(matrix);
+    std::vector<std::vector<seqan3::detail::trace_directions>> expect{{}};
 
     EXPECT_EQ(result, expect);
 }
@@ -30,8 +30,8 @@ TEST(global, epsilon)
     matrix.add_column({}, {}, {});
 
     // row-wise matrix
-    std::vector<std::vector<detail::trace_directions>> result = as_row_wise_vector(matrix);
-    std::vector<std::vector<detail::trace_directions>> expect{{N}};
+    std::vector<std::vector<seqan3::detail::trace_directions>> result = as_row_wise_vector(matrix);
+    std::vector<std::vector<seqan3::detail::trace_directions>> expect{{N}};
 
     EXPECT_EQ(result, expect);
 }
@@ -47,8 +47,8 @@ TEST(global, epsilon_row)
     matrix.add_column({}, {}, {});
 
     // row-wise matrix
-    std::vector<std::vector<detail::trace_directions>> result = as_row_wise_vector(matrix);
-    std::vector<std::vector<detail::trace_directions>> expect{{N, l, l, l, l}};
+    std::vector<std::vector<seqan3::detail::trace_directions>> result = as_row_wise_vector(matrix);
+    std::vector<std::vector<seqan3::detail::trace_directions>> expect{{N, l, l, l, l}};
 
     EXPECT_EQ(result, expect);
 }
@@ -70,8 +70,8 @@ TEST(global, single_word)
     matrix.add_column({0b1000'1111u}, {0b1111'0001u}, {0b1110'0000u});
 
     // row-wise matrix
-    std::vector<std::vector<detail::trace_directions>> result = as_row_wise_vector(matrix);
-    std::vector<std::vector<detail::trace_directions>> expect
+    std::vector<std::vector<seqan3::detail::trace_directions>> result = as_row_wise_vector(matrix);
+    std::vector<std::vector<seqan3::detail::trace_directions>> expect
     {
         {N  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  },
         {u  ,D  ,Dl ,l  ,l  ,l  ,l  ,l  ,l  ,Dl },
@@ -124,8 +124,8 @@ TEST(global, multiple_words)
                       {0b0000'0000u, 0b0000'0110u, 0b0u});
 
     // row-wise matrix
-    std::vector<std::vector<detail::trace_directions>> result = as_row_wise_vector(matrix);
-    std::vector<std::vector<detail::trace_directions>> expect
+    std::vector<std::vector<seqan3::detail::trace_directions>> result = as_row_wise_vector(matrix);
+    std::vector<std::vector<seqan3::detail::trace_directions>> expect
     {
         {N  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  },
         {u  ,D  ,l  ,l  ,l  ,Dl ,l  ,l  ,l  ,Dl },

--- a/test/unit/alignment/matrix/edit_distance_matrix/trace_matrix_unbanded_semi_global_max_errors_test.cpp
+++ b/test/unit/alignment/matrix/edit_distance_matrix/trace_matrix_unbanded_semi_global_max_errors_test.cpp
@@ -17,8 +17,8 @@ TEST(semi_global_max_errors, empty)
     matrix_type<true, true> matrix{1u};
 
     // row-wise matrix
-    std::vector<std::vector<detail::trace_directions>> result = as_row_wise_vector(matrix);
-    std::vector<std::vector<detail::trace_directions>> expect{{}};
+    std::vector<std::vector<seqan3::detail::trace_directions>> result = as_row_wise_vector(matrix);
+    std::vector<std::vector<seqan3::detail::trace_directions>> expect{{}};
 
     EXPECT_EQ(result, expect);
 }
@@ -30,8 +30,8 @@ TEST(semi_global_max_errors, epsilon)
     matrix.add_column({}, {}, {}, 1u);
 
     // row-wise matrix
-    std::vector<std::vector<detail::trace_directions>> result = as_row_wise_vector(matrix);
-    std::vector<std::vector<detail::trace_directions>> expect{{N}};
+    std::vector<std::vector<seqan3::detail::trace_directions>> result = as_row_wise_vector(matrix);
+    std::vector<std::vector<seqan3::detail::trace_directions>> expect{{N}};
 
     EXPECT_EQ(result, expect);
 }
@@ -47,8 +47,8 @@ TEST(semi_global_max_errors, epsilon_row)
     matrix.add_column({}, {}, {}, 1u);
 
     // row-wise matrix
-    std::vector<std::vector<detail::trace_directions>> result = as_row_wise_vector(matrix);
-    std::vector<std::vector<detail::trace_directions>> expect{{N, N, N, N, N}};
+    std::vector<std::vector<seqan3::detail::trace_directions>> result = as_row_wise_vector(matrix);
+    std::vector<std::vector<seqan3::detail::trace_directions>> expect{{N, N, N, N, N}};
 
     EXPECT_EQ(result, expect);
 }
@@ -70,8 +70,8 @@ TEST(semi_global_max_errors, single_word)
     matrix.add_column({0b1000'0000u}, {0b1111'0001u}, {0b1110'1110u}, 8u);
 
     // row-wise matrix
-    std::vector<std::vector<detail::trace_directions>> result = as_row_wise_vector(matrix);
-    std::vector<std::vector<detail::trace_directions>> expect
+    std::vector<std::vector<seqan3::detail::trace_directions>> result = as_row_wise_vector(matrix);
+    std::vector<std::vector<seqan3::detail::trace_directions>> expect
     {
         {N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  },
         {u  ,D  ,D  ,Dul,Du ,Du ,Du ,Du ,Du ,D  },
@@ -124,8 +124,8 @@ TEST(semi_global_max_errors, multiple_words)
                       {0b0100'1110u, 0b0001'1111u, 0b0u}, 18u);
 
     // row-wise matrix
-    std::vector<std::vector<detail::trace_directions>> result = as_row_wise_vector(matrix);
-    std::vector<std::vector<detail::trace_directions>> expect
+    std::vector<std::vector<seqan3::detail::trace_directions>> result = as_row_wise_vector(matrix);
+    std::vector<std::vector<seqan3::detail::trace_directions>> expect
     {
         {N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  },
         {u  ,D  ,Dul,Du ,Du ,D  ,Dul,Du ,Du ,D  },

--- a/test/unit/alignment/matrix/edit_distance_matrix/trace_matrix_unbanded_semi_global_test.cpp
+++ b/test/unit/alignment/matrix/edit_distance_matrix/trace_matrix_unbanded_semi_global_test.cpp
@@ -17,8 +17,8 @@ TEST(semi_global, empty)
     matrix_type<true, false> matrix{1u};
 
     // row-wise matrix
-    std::vector<std::vector<detail::trace_directions>> result = as_row_wise_vector(matrix);
-    std::vector<std::vector<detail::trace_directions>> expect{{}};
+    std::vector<std::vector<seqan3::detail::trace_directions>> result = as_row_wise_vector(matrix);
+    std::vector<std::vector<seqan3::detail::trace_directions>> expect{{}};
 
     EXPECT_EQ(result, expect);
 }
@@ -30,8 +30,8 @@ TEST(semi_global, epsilon)
     matrix.add_column({}, {}, {});
 
     // row-wise matrix
-    std::vector<std::vector<detail::trace_directions>> result = as_row_wise_vector(matrix);
-    std::vector<std::vector<detail::trace_directions>> expect{{N}};
+    std::vector<std::vector<seqan3::detail::trace_directions>> result = as_row_wise_vector(matrix);
+    std::vector<std::vector<seqan3::detail::trace_directions>> expect{{N}};
 
     EXPECT_EQ(result, expect);
 }
@@ -47,8 +47,8 @@ TEST(semi_global, epsilon_row)
     matrix.add_column({}, {}, {});
 
     // row-wise matrix
-    std::vector<std::vector<detail::trace_directions>> result = as_row_wise_vector(matrix);
-    std::vector<std::vector<detail::trace_directions>> expect{{N, N, N, N, N}};
+    std::vector<std::vector<seqan3::detail::trace_directions>> result = as_row_wise_vector(matrix);
+    std::vector<std::vector<seqan3::detail::trace_directions>> expect{{N, N, N, N, N}};
 
     EXPECT_EQ(result, expect);
 }
@@ -70,8 +70,8 @@ TEST(semi_global, single_word)
     matrix.add_column({0b1000'0000u}, {0b1111'0001u}, {0b1110'1110u});
 
     // row-wise matrix
-    std::vector<std::vector<detail::trace_directions>> result = as_row_wise_vector(matrix);
-    std::vector<std::vector<detail::trace_directions>> expect
+    std::vector<std::vector<seqan3::detail::trace_directions>> result = as_row_wise_vector(matrix);
+    std::vector<std::vector<seqan3::detail::trace_directions>> expect
     {
         {N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  },
         {u  ,D  ,D  ,Dul,Du ,Du ,Du ,Du ,Du ,D  },
@@ -124,8 +124,8 @@ TEST(semi_global, multiple_words)
                       {0b0100'1110u, 0b0001'1111u, 0b0u});
 
     // row-wise matrix
-    std::vector<std::vector<detail::trace_directions>> result = as_row_wise_vector(matrix);
-    std::vector<std::vector<detail::trace_directions>> expect
+    std::vector<std::vector<seqan3::detail::trace_directions>> result = as_row_wise_vector(matrix);
+    std::vector<std::vector<seqan3::detail::trace_directions>> expect
     {
         {N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  },
         {u  ,D  ,Dul,Du ,Du ,D  ,Dul,Du ,Du ,D  },


### PR DESCRIPTION
Resolves #1623. 
 
I could not remove
```cpp
using namespace seqan3::test::alignment::fixture;
```
, because it would have become very confusing. I moved and commented the line instead. If you have a better idea, I'll be happy to take it.