### PR TITLE
Remove bi/fm_index concepts

### DIFF
--- a/include/seqan3/search/algorithm/detail/search.hpp
+++ b/include/seqan3/search/algorithm/detail/search.hpp
@@ -26,6 +26,19 @@ namespace seqan3::detail
  * \{
  */
 
+/*!\brief Searches a query sequence in an index.
+ *
+ * \copydetails search_algo_bi
+ */
+template <bool abort_on_hit, typename index_t, typename query_t, typename delegate_t>
+inline void search_algo(index_t const & index, query_t & query, search_param const error_left, delegate_t && delegate)
+{
+    if constexpr (bi_fm_index_specialisation<index_t>)
+        search_algo_bi<abort_on_hit>(index, query, error_left, delegate);
+    else
+        search_trivial<abort_on_hit>(index, query, error_left, delegate);
+}
+
 /*!\brief Search a single query in an index.
  * \tparam index_t   Must model seqan3::fm_index_specialisation.
  * \tparam queries_t Must model std::ranges::random_access_range over the index's alphabet.

--- a/include/seqan3/search/algorithm/detail/search.hpp
+++ b/include/seqan3/search/algorithm/detail/search.hpp
@@ -17,7 +17,7 @@
 #include <seqan3/search/algorithm/detail/search_traits.hpp>
 #include <seqan3/search/algorithm/detail/search_trivial.hpp>
 #include <seqan3/search/configuration/all.hpp>
-#include <seqan3/search/fm_index/concept.hpp>
+#include <seqan3/search/fm_index/all.hpp>
 
 namespace seqan3::detail
 {
@@ -33,7 +33,10 @@ namespace seqan3::detail
 template <bool abort_on_hit, typename index_t, typename query_t, typename delegate_t>
 inline void search_algo(index_t const & index, query_t & query, search_param const error_left, delegate_t && delegate)
 {
-    if constexpr (bi_fm_index_specialisation<index_t>)
+    using bi_fm_index_spec = seqan3::bi_fm_index<typename index_t::alphabet_type,
+                                                 index_t::text_layout_mode,
+                                                 typename index_t::sdsl_index_type>;
+    if constexpr (std::same_as<index_t, bi_fm_index_spec>)
         search_algo_bi<abort_on_hit>(index, query, error_left, delegate);
     else
         search_trivial<abort_on_hit>(index, query, error_left, delegate);

--- a/include/seqan3/search/algorithm/detail/search_scheme_algorithm.hpp
+++ b/include/seqan3/search/algorithm/detail/search_scheme_algorithm.hpp
@@ -435,7 +435,9 @@ inline bool search_ss(cursor_t cur, query_t & query,
 
 /*!\brief Searches a query sequence in a bidirectional index using search schemes.
  * \tparam abort_on_hit     If the flag is set, the search aborts on the first hit.
- * \tparam index_t          Must model seqan3::bi_fm_index_specialisation.
+ * \tparam alphabet_t       The alphabet type of the seqan3::bi_fm_index.
+ * \tparam text_layout_mode The text layout of the seqan3::bi_fm_index.
+ * \tparam sdsl_index_type  The sdsl index type of the seqan3::bi_fm_index.
  * \tparam query_t          Must model std::ranges::random_access_range over the index's alphabet.
  * \tparam search_scheme_t  Is of type `seqan3::detail::search_scheme_type` or `seqan3::detail::search_scheme_dyn_type`.
  * \tparam delegate_t       Takes `typename index_t::cursor_type` as argument.
@@ -454,9 +456,16 @@ inline bool search_ss(cursor_t cur, query_t & query,
  * Strong exception guarantee if iterating the query does not change its state and if invoking the delegate also has a
  * strong exception guarantee; basic exception guarantee otherwise.
  */
-template <bool abort_on_hit, typename index_t, typename query_t, typename search_scheme_t, typename delegate_t>
-inline void search_ss(index_t const & index, query_t & query, search_param const error_left,
-                      search_scheme_t const & search_scheme, delegate_t && delegate)
+template <bool abort_on_hit,
+          typename alphabet_t, text_layout text_layout_mode, typename sdsl_index_type,
+          typename query_t,
+          typename search_scheme_t,
+          typename delegate_t>
+inline void search_ss(bi_fm_index<alphabet_t, text_layout_mode, sdsl_index_type> const & index,
+                      query_t & query,
+                      search_param const error_left,
+                      search_scheme_t const & search_scheme,
+                      delegate_t && delegate)
 {
     // retrieve cumulative block lengths and starting position
     auto const block_info = search_scheme_block_info(search_scheme, std::ranges::size(query));
@@ -486,7 +495,9 @@ inline void search_ss(index_t const & index, query_t & query, search_param const
 
 /*!\brief Searches a query sequence in a bidirectional index.
  * \tparam abort_on_hit    If the flag is set, the search aborts on the first hit.
- * \tparam index_t         Must model seqan3::bi_fm_index_specialisation.
+ * \tparam alphabet_t       The alphabet type of the seqan3::bi_fm_index.
+ * \tparam text_layout_mode The text layout of the seqan3::bi_fm_index.
+ * \tparam sdsl_index_type  The sdsl index type of the seqan3::bi_fm_index.
  * \tparam query_t         Must model std::ranges::random_access_range over the index's alphabet.
  * \tparam delegate_t      Takes `typename index_t::cursor_type` as argument.
  * \param[in] index        String index built on the text that will be searched.
@@ -503,8 +514,14 @@ inline void search_ss(index_t const & index, query_t & query, search_param const
  * Strong exception guarantee if iterating the query does not change its state and if invoking the delegate also has a
  * strong exception guarantee; basic exception guarantee otherwise.
  */
-template <bool abort_on_hit, typename index_t, typename query_t, typename delegate_t>
-inline void search_algo_bi(index_t const & index, query_t & query, search_param const error_left,
+
+template <bool abort_on_hit,
+          typename alphabet_t, text_layout text_layout_mode, typename sdsl_index_type,
+          typename query_t,
+          typename delegate_t>
+inline void search_algo_bi(bi_fm_index<alphabet_t, text_layout_mode, sdsl_index_type> const & index,
+                           query_t & query,
+                           search_param const error_left,
                            delegate_t && delegate)
 {
     switch (error_left.total)

--- a/include/seqan3/search/algorithm/detail/search_scheme_algorithm.hpp
+++ b/include/seqan3/search/algorithm/detail/search_scheme_algorithm.hpp
@@ -527,31 +527,6 @@ inline void search_algo_bi(index_t const & index, query_t & query, search_param 
             break;
     }
 }
-
-/*!\brief Searches a query sequence in a unidirectional index.
- *
- * \copydetails search_algo_bi
- */
-template <bool abort_on_hit, typename index_t, typename query_t, typename delegate_t>
-inline void search_algo_uni(index_t const & index, query_t & query, search_param const error_left,
-                            delegate_t && delegate)
-{
-    search_trivial<abort_on_hit>(index, query, error_left, delegate);
-}
-
-/*!\brief Searches a query sequence in an index.
- *
- * \copydetails search_algo_bi
- */
-template <bool abort_on_hit, typename index_t, typename query_t, typename delegate_t>
-inline void search_algo(index_t const & index, query_t & query, search_param const error_left, delegate_t && delegate)
-{
-    if constexpr (bi_fm_index_specialisation<index_t>)
-        search_algo_bi<abort_on_hit>(index, query, error_left, delegate);
-    else
-        search_algo_uni<abort_on_hit>(index, query, error_left, delegate);
-}
-
 //!\}
 
 } // namespace seqan3::detail

--- a/include/seqan3/search/algorithm/detail/search_trivial.hpp
+++ b/include/seqan3/search/algorithm/detail/search_trivial.hpp
@@ -199,7 +199,7 @@ inline bool search_trivial(cursor_t cur,
 
 /*!\brief Searches a query sequence in an index using trivial backtracking.
  * \tparam abort_on_hit  If the flag is set, the search algorithm aborts on the first hit.
- * \tparam index_t       Must model seqan3::fm_index_specialisation.
+ * \tparam index_t       Must be a seqan3::fm_index or seqan3::bi_fm_index.
  * \tparam query_t       Must model std::ranges::input_range over the index's alphabet.
  * \tparam delegate_t    Takes `index::cursor_type` as argument.
  * \param[in] index      String index built on the text that will be searched.

--- a/include/seqan3/search/algorithm/search.hpp
+++ b/include/seqan3/search/algorithm/search.hpp
@@ -108,7 +108,7 @@ namespace seqan3
  */
 
 /*!\brief Search a query or a range of queries in an index.
- * \tparam index_t    Must model seqan3::fm_index_specialisation.
+ * \tparam index_t    Must be a seqan3::fm_index or a seqan3::bi_fm_index.
  * \tparam queries_t  Must model std::ranges::random_access_range over the index's alphabet and std::ranges::sized_range.
  *                    A range of queries must additionally model std::ranges::forward_range and std::ranges::sized_range.
  * \param[in] queries A single query or a range of queries.
@@ -167,7 +167,10 @@ namespace seqan3
  *
  * \include test/snippet/search/algorithm/search.cpp
  */
-template <fm_index_specialisation index_t, typename queries_t, typename configuration_t = decltype(search_cfg::default_configuration)>
+template <typename index_t, typename queries_t, typename configuration_t = decltype(search_cfg::default_configuration)>
+//!cond
+    // TODO
+//!\endcond
 inline auto search(queries_t && queries,
                    index_t const & index,
                    configuration_t const & cfg = search_cfg::default_configuration)
@@ -197,7 +200,10 @@ inline auto search(queries_t && queries,
 
 //!\cond DEV
 //! \overload
-template <fm_index_specialisation index_t, typename configuration_t = decltype(search_cfg::default_configuration)>
+template <typename index_t, typename configuration_t = decltype(search_cfg::default_configuration)>
+//!cond
+    // TODO
+//!\endcond
 inline auto search(char const * const queries,
                    index_t const & index,
                    configuration_t const & cfg = search_cfg::default_configuration)
@@ -206,7 +212,10 @@ inline auto search(char const * const queries,
 }
 
 //! \overload
-template <fm_index_specialisation index_t, typename configuration_t = decltype(search_cfg::default_configuration)>
+template <typename index_t, typename configuration_t = decltype(search_cfg::default_configuration)>
+//!cond
+    // TODO
+//!\endcond
 inline auto search(std::initializer_list<char const * const> const & queries,
                    index_t const & index,
                    configuration_t const & cfg = search_cfg::default_configuration)

--- a/include/seqan3/search/fm_index/bi_fm_index.hpp
+++ b/include/seqan3/search/fm_index/bi_fm_index.hpp
@@ -63,13 +63,14 @@ template <semialphabet alphabet_t,
           detail::sdsl_index sdsl_index_type_ = default_sdsl_index_type>
 class bi_fm_index
 {
-private:
     /*!\name Index types
      * \{
      */
+public:
     //!\brief The type of the underlying SDSL index for the original text.
     using sdsl_index_type = sdsl_index_type_;
 
+private:
     //!\brief The type of the underlying SDSL index for the reversed text.
     using rev_sdsl_index_type = sdsl_index_type_;
 

--- a/include/seqan3/search/fm_index/concept.hpp
+++ b/include/seqan3/search/fm_index/concept.hpp
@@ -86,56 +86,11 @@ enum text_layout : bool
     collection
 };
 
-// ============================================================================
-//  fm_index_specialisation
-// ============================================================================
+template <semialphabet alphabet_type, text_layout text_layout_mode, detail::sdsl_index sdsl_index_type>
+class fm_index; // forward declaration
 
-/*!\interface seqan3::fm_index_specialisation <>
- * \brief Concept for unidirectional FM indices.
- *
- * This concept defines the interface for unidirectional FM indices.
- */
-//!\cond
-template <typename t>
-SEQAN3_CONCEPT fm_index_specialisation = std::semiregular<t> && requires (t index)
-{
-    typename t::alphabet_type;
-    typename t::size_type;
-    typename t::cursor_type;
-
-    // NOTE: circular dependency
-    // requires fm_index_cursor_specialisation<typename t::cursor_type>;
-    requires requires (t index, std::conditional_t<t::text_layout_mode == text_layout::collection,
-                                                   std::vector<std::vector<typename t::alphabet_type>>,
-                                                   std::vector<typename t::alphabet_type>> const text)
-    {
-        { t(text) };
-    };
-
-    { index.begin() } -> typename t::cursor_type;
-
-    { index.size()  } -> typename t::size_type;
-    { index.empty() } -> bool;
-};
-//!\endcond
-/*!\name Requirements for seqan3::fm_index_specialisation
- * \relates seqan3::fm_index_specialisation
- * \brief You can expect these member types and member functions on all types that satisfy seqan3::fm_index_specialisation.
- * \{
- *
- * \typedef typename t::text_type text_type
- * \brief Type of the indexed text.
- *
- * \typedef typename t::alphabet_type alphabet_type
- * \brief Type of the underlying character of text_type.
- *
- * \typedef typename t::size_type size_type
- * \brief Type for representing the size of the indexed text.
- *
- * \typedef typename t::cursor_type cursor_type
- * \brief Type of the unidirectional FM index cursor.
- * \}
- */
+template <semialphabet alphabet_type, text_layout text_layout_mode, detail::sdsl_index sdsl_index_type>
+class bi_fm_index;
 
 // ============================================================================
 //  fm_index_cursor_specialisation
@@ -153,7 +108,7 @@ SEQAN3_CONCEPT fm_index_cursor_specialisation = std::semiregular<t> && requires 
     typename t::index_type;
     typename t::size_type;
 
-    requires fm_index_specialisation<typename t::index_type>;
+    requires std::same_as<typename t::index_type, fm_index>;
 
     requires requires (typename t::index_type const index) { { t(index) }; };
 
@@ -194,46 +149,6 @@ SEQAN3_CONCEPT fm_index_cursor_specialisation = std::semiregular<t> && requires 
  */
 
 // ============================================================================
-//  bi_fm_index_specialisation
-// ============================================================================
-
-/*!\interface seqan3::bi_fm_index_specialisation <>
- * \brief Concept for bidirectional FM indices.
- *
- * This concept defines the interface for bidirectional FM indices.
- */
-//!\cond
-template <typename t>
-SEQAN3_CONCEPT bi_fm_index_specialisation = fm_index_specialisation<t> && requires (t index)
-{
-    typename t::cursor_type; // already required by fm_index_specialisation but has a different documentation
-    typename t::fwd_cursor_type;
-    typename t::rev_cursor_type;
-
-    // NOTE: circular dependency
-    // requires bi_fm_index_cursor_specialisation<typename t::cursor_type>;
-
-    { index.fwd_begin() } -> typename t::fwd_cursor_type;
-    { index.rev_begin() } -> typename t::rev_cursor_type;
-};
-//!\endcond
-/*!\name Requirements for seqan3::bi_fm_index_specialisation
- * \relates seqan3::bi_fm_index_specialisation
- * \brief You can expect these member types and member functions on all types that satisfy seqan3::bi_fm_index_specialisation.
- * \{
- *
- * \typedef typename t::cursor_type cursor_type
- * \brief Type of the bidirectional FM index cursor.
- *
- * \typedef typename t::fwd_cursor_type fwd_cursor_type
- * \brief Type of the unidirectional FM index cursor based on the unidirectional FM index on the original text.
- *
- * \typedef typename t::rev_cursor_type rev_cursor_type
- * \brief Type of the unidirectional FM index cursor based on the unidirectional FM index on the reversed text.
- * \}
- */
-
-// ============================================================================
 //  bi_fm_index_cursor_specialisation
 // ============================================================================
 
@@ -246,7 +161,7 @@ SEQAN3_CONCEPT bi_fm_index_specialisation = fm_index_specialisation<t> && requir
 template <typename t>
 SEQAN3_CONCEPT bi_fm_index_cursor_specialisation = fm_index_cursor_specialisation<t> && requires (t cur)
 {
-    requires bi_fm_index_specialisation<typename t::index_type>;
+    requires std::same_as<typename t::index_type, bi_fm_index>;
 
     requires requires (typename t::index_type const index) { { t(index) }; };
 

--- a/include/seqan3/search/fm_index/fm_index.hpp
+++ b/include/seqan3/search/fm_index/fm_index.hpp
@@ -132,15 +132,16 @@ template <semialphabet alphabet_t,
           detail::sdsl_index sdsl_index_type_ = default_sdsl_index_type>
 class fm_index
 {
-private:
     /*!\name Member types
      * \{
      */
+public:
     //!\brief The type of the underlying SDSL index.
     using sdsl_index_type = sdsl_index_type_;
     /*!\brief The type of the reduced alphabet type. (The reduced alphabet might be smaller than the original alphabet
      *        in case not all possible characters occur in the indexed text.)
      */
+private:
     using sdsl_char_type = typename sdsl_index_type::alphabet_type::char_type;
     //!\brief The type of the alphabet size of the underlying SDSL index.
     using sdsl_sigma_type = typename sdsl_index_type::alphabet_type::sigma_type;


### PR DESCRIPTION
As discussed in the strategy meeting I tried to remove the concepts.
Here is a WIP branch but I have the following issue:

Since the bi/fm_index classes have type AND value template arguments, I can neither use `is_type_specialisation_of` nor `is_value_specialisation_of` to check whether I am working with fm_index or bi_fm_index.. or am I doing something wrong?

The only solution I see would be the very lengthy one I show in the `search_algo` function or to keep the concepts but move them to detail. 

@seqan/core what do you think?