### PR TITLE
[I/O] Small fix when reading field::cigar and changing the alignment default fields.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,18 @@ Note that 3.1.0 will be the first API stable release and interfaces in this rele
 
 ## Notable Bug-fixes
 
+### I/O
+
+* The `seqan3::field::cigar` was added to the default fields for reading and writing alignment files
+  ([\#1642](https://github.com/seqan/seqan3/pull/1642)).
+  This has the following impact:
+   1. Reading and writing in one line is now possible without additional reference information:
+      `seqan3::alignment_file_output{"foo.sam"} = seqan3::alignment_file_input{"bar.sam"};`
+   2. The `seqan3::alignment_file_output` now accepts `seqan3::field::cigar` and `seqan3::field::alignment`
+      although they store redundant information. For the SAM/BAM format this ambiguity is handled by favoring the CIGAR
+      information at all times if present.
+  Note that this breaks your code if you have not selected custom fields and used structural bindings!
+
 #### Search
 
 * The `seqan3::fm_index_cursor::extend_right()`, `seqan3::bi_fm_index_cursor::extend_right()` and

--- a/doc/tutorial/alignment_file/alignment_file_read_cigar.cpp
+++ b/doc/tutorial/alignment_file/alignment_file_read_cigar.cpp
@@ -34,9 +34,9 @@ int main()
 {
     std::filesystem::path tmp_dir = std::filesystem::temp_directory_path(); // get the temp directory
 
-    seqan3::alignment_file_input fin{tmp_dir/"my.sam", seqan3::fields<seqan3::field::cigar>{}};
+    seqan3::alignment_file_input fin{tmp_dir/"my.sam"}; // default fields
 
-    for (auto & [cigar_vector] : fin)
-        seqan3::debug_stream << cigar_vector << '\n';
+    for (auto & rec : fin)
+        seqan3::debug_stream << seqan3::get<seqan3::field::cigar>(rec) << '\n'; // access cigar vector
 }
 //![code]

--- a/doc/tutorial/alignment_file/index.md
+++ b/doc/tutorial/alignment_file/index.md
@@ -188,10 +188,16 @@ If you want to read up more about cigar strings,
 take a look at the [SAM specifications](https://samtools.github.io/hts-specs/SAMv1.pdf)
 or the [SAMtools paper](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2723002/).
 
-## Completing reference information
+## Reading the CIGAR string
 
-In SeqAn the conversion from a CIGAR string to an alignment (two *aligned_sequences*) is done automatically for you.
-You can just pass the alignment object to the alignment file:
+By default, the `seqan3::alignment_file_input` will always read the `seqan3::field::cigar` and store it
+into a `std::vector<seqan3::cigar>`:
+
+\snippet doc/tutorial/alignment_file/alignment_file_read_cigar.cpp code
+
+## Reading the CIGAR information into an actual alignment
+
+In SeqAn, the conversion from a CIGAR string to an alignment (two *aligned_sequences*) is done automatically for you. You can access it by querying `seqan3::field::alignment` from the record:
 
 \snippet doc/tutorial/alignment_file/alignment_file_snippets.cpp main
 \snippet doc/tutorial/alignment_file/alignment_file_snippets.cpp alignments_without_ref
@@ -245,13 +251,6 @@ r004 mapped against 1 with 14 gaps in the read sequence and 0 gaps in the refere
 \snippet doc/tutorial/alignment_file/alignment_file_solution2.cpp solution
 
 \endsolution
-
-## Reading the CIGAR string
-
-If you are accustomed to the raw CIGAR information, we also provide reading the cigar information into a
-`std::vector<seqan3::cigar>` if you specify the `seqan3::field::cigar`.
-
-\snippet doc/tutorial/alignment_file/alignment_file_read_cigar.cpp code
 
 # Writing alignment files
 

--- a/include/seqan3/io/alignment_file/format_bam.hpp
+++ b/include/seqan3/io/alignment_file/format_bam.hpp
@@ -515,8 +515,8 @@ inline void format_bam::read_alignment_record(stream_type & stream,
             if constexpr (!detail::decays_to_ignore_v<align_type>)
             {
                 assign_unaligned(get<1>(align),
-                                 seq | views::slice(static_cast<decltype(std::ranges::distance(seq))>(offset_tmp),
-                                                   std::ranges::distance(seq) - soft_clipping_end));
+                                 seq | views::slice(static_cast<std::ranges::range_difference_t<seq_type>>(offset_tmp),
+                                                    std::ranges::distance(seq) - soft_clipping_end));
             }
         }
     }
@@ -538,7 +538,7 @@ inline void format_bam::read_alignment_record(stream_type & stream,
 
     // DONE READING - wrap up
     // -------------------------------------------------------------------------------------------------------------
-    if constexpr (!detail::decays_to_ignore_v<align_type>)
+    if constexpr (!detail::decays_to_ignore_v<align_type> || !detail::decays_to_ignore_v<cigar_type>)
     {
         // Check cigar, if it matches ‘kSmN’, where ‘k’ equals lseq, ‘m’ is the reference sequence length in the
         // alignment, and ‘S’ and ‘N’ are the soft-clipping and reference-clip, then the cigar string was larger
@@ -566,17 +566,21 @@ inline void format_bam::read_alignment_record(stream_type & stream,
                 std::tie(tmp_cigar_vector, ref_length, seq_length) = parse_cigar(cigar_view);
                 offset_tmp = soft_clipping_end = 0;
                 transfer_soft_clipping_to(tmp_cigar_vector, offset_tmp, soft_clipping_end);
-
-                assign_unaligned(get<1>(align),
-                                 seq | views::slice(static_cast<decltype(std::ranges::distance(seq))>(offset_tmp),
-                                                   std::ranges::distance(seq) - soft_clipping_end));
                 tag_dict.erase(it); // remove redundant information
+
+                if constexpr (!detail::decays_to_ignore_v<align_type>)
+                {
+                    assign_unaligned(get<1>(align),
+                                     seq | views::slice(static_cast<std::ranges::range_difference_t<seq_type>>(offset_tmp),
+                                                        std::ranges::distance(seq) - soft_clipping_end));
+                }
             }
         }
-
-        // Alignment object construction
-        construct_alignment(align, tmp_cigar_vector, core.refID, ref_seqs, core.pos, ref_length); // inherited from SAM format
     }
+
+    // Alignment object construction
+    if constexpr (!detail::decays_to_ignore_v<align_type>)
+        construct_alignment(align, tmp_cigar_vector, core.refID, ref_seqs, core.pos, ref_length); // inherited from SAM
 
     if constexpr (!detail::decays_to_ignore_v<cigar_type>)
         std::swap(cigar_vector, tmp_cigar_vector);

--- a/include/seqan3/io/alignment_file/format_sam.hpp
+++ b/include/seqan3/io/alignment_file/format_sam.hpp
@@ -832,7 +832,12 @@ inline void format_sam::write_alignment_record(stream_type & stream,
 
     stream << static_cast<unsigned>(mapq) << separator;
 
-    if (!std::ranges::empty(get<0>(align)) && !std::ranges::empty(get<1>(align)))
+    if (!std::ranges::empty(cigar_vector))
+    {
+        for (auto & c : cigar_vector)
+            stream << c.to_string(); // returns a small_vector instead of char so write_range doesn't work
+    }
+    else if (!std::ranges::empty(get<0>(align)) && !std::ranges::empty(get<1>(align)))
     {
         // compute possible distance from alignment end to sequence end
         // which indicates soft clipping at the end.
@@ -845,11 +850,6 @@ inline void format_sam::write_alignment_record(stream_type & stream,
         off_end -= std::ranges::size(get<1>(align));
 
         write_range(stream_it, detail::get_cigar_string(std::forward<align_type>(align), offset, off_end));
-    }
-    else if (!cigar_vector.empty())
-    {
-        for (auto & c : cigar_vector)
-            stream << c.to_string(); // returns a small_vector instead of char so write_range doesn't work
     }
     else
     {

--- a/include/seqan3/io/alignment_file/input.hpp
+++ b/include/seqan3/io/alignment_file/input.hpp
@@ -339,6 +339,7 @@ template <
                                                                field::ref_id,
                                                                field::ref_offset,
                                                                field::alignment,
+                                                               field::cigar,
                                                                field::mapq,
                                                                field::qual,
                                                                field::flag,

--- a/include/seqan3/io/alignment_file/output.hpp
+++ b/include/seqan3/io/alignment_file/output.hpp
@@ -148,6 +148,7 @@ template <detail::fields_specialisation selected_field_ids_ =
                      field::ref_id,
                      field::ref_offset,
                      field::alignment,
+                     field::cigar,
                      field::mapq,
                      field::qual,
                      field::flag,
@@ -201,13 +202,6 @@ public:
                   "You selected a field that is not valid for alignment files, "
                   "please refer to the documentation of "
                   "seqan3::alignment_file_output::field_ids for the accepted values.");
-
-    static_assert([] () constexpr
-                  {
-                      return !(selected_field_ids::contains(field::alignment) &&
-                               selected_field_ids::contains(field::cigar));
-                  }(),
-                  "You may not select field::alignment and field::cigar at the same time.");
 
     /*!\name Range associated types
      * \brief Most of the range associated types are `void` for output ranges.

--- a/test/unit/io/alignment_file/alignment_file_input_test.cpp
+++ b/test/unit/io/alignment_file/alignment_file_input_test.cpp
@@ -147,10 +147,21 @@ TEST_F(alignment_file_input_f, construct_from_stream)
 TEST_F(alignment_file_input_f, default_template_args_and_deduction_guides)
 {
     using comp0 = seqan3::alignment_file_input_default_traits<>;
-    using comp1 = seqan3::fields<seqan3::field::seq, seqan3::field::id, seqan3::field::offset, seqan3::field::ref_seq,
-                                 seqan3::field::ref_id, seqan3::field::ref_offset, seqan3::field::alignment,
-                                 seqan3::field::mapq, seqan3::field::qual, seqan3::field::flag, seqan3::field::mate,
-                                 seqan3::field::tags, seqan3::field::evalue, seqan3::field::bit_score,
+    using comp1 = seqan3::fields<seqan3::field::seq,
+                                 seqan3::field::id,
+                                 seqan3::field::offset,
+                                 seqan3::field::ref_seq,
+                                 seqan3::field::ref_id,
+                                 seqan3::field::ref_offset,
+                                 seqan3::field::alignment,
+                                 seqan3::field::cigar,
+                                 seqan3::field::mapq,
+                                 seqan3::field::qual,
+                                 seqan3::field::flag,
+                                 seqan3::field::mate,
+                                 seqan3::field::tags,
+                                 seqan3::field::evalue,
+                                 seqan3::field::bit_score,
                                  seqan3::field::header_ptr>;
     using comp2 = seqan3::type_list<seqan3::format_sam, seqan3::format_bam>;
     using comp3 = char;

--- a/test/unit/io/alignment_file/alignment_file_output_test.cpp
+++ b/test/unit/io/alignment_file/alignment_file_output_test.cpp
@@ -122,6 +122,7 @@ TEST(general, default_template_args_and_deduction_guides)
                                  seqan3::field::ref_id,
                                  seqan3::field::ref_offset,
                                  seqan3::field::alignment,
+                                 seqan3::field::cigar,
                                  seqan3::field::mapq,
                                  seqan3::field::qual,
                                  seqan3::field::flag,
@@ -486,14 +487,29 @@ read2	42	ref	2	62	7M1D1M1S	ref	10	300	AGGCTGNAG	!##$&'()*	xy:B:S,3,4,5
 read3	43	ref	3	63	1S1M1D1M1I1M1I1D1M1S	ref	10	300	GGAGTATA	!!*+,-./
 )";
 
-    seqan3::alignment_file_input fin{std::istringstream{comp}, ref_ids, ref_seqs, seqan3::format_sam{}};
-    seqan3::alignment_file_output fout{std::ostringstream{}, seqan3::format_sam{}};
+    // with reference information
+    {
+        seqan3::alignment_file_input fin{std::istringstream{comp}, ref_ids, ref_seqs, seqan3::format_sam{}};
+        seqan3::alignment_file_output fout{std::ostringstream{}, seqan3::format_sam{}};
 
-    fout = fin;
+        fout = fin;
 
-    fout.get_stream().flush();
+        fout.get_stream().flush();
 
-    EXPECT_EQ(reinterpret_cast<std::ostringstream &>(fout.get_stream()).str(), comp);
+        EXPECT_EQ(reinterpret_cast<std::ostringstream &>(fout.get_stream()).str(), comp);
+    }
+
+    // without reference information
+    {
+        seqan3::alignment_file_input fin{std::istringstream{comp}, seqan3::format_sam{}};
+        seqan3::alignment_file_output fout{std::ostringstream{}, seqan3::format_sam{}};
+
+        fout = fin;
+
+        fout.get_stream().flush();
+
+        EXPECT_EQ(reinterpret_cast<std::ostringstream &>(fout.get_stream()).str(), comp);
+    }
 }
 
 TEST(rows, assign_alignment_file_pipes)


### PR DESCRIPTION
Resolves #1616 
~Blocked by #1697~ 

The `seqan3::field::cigar` was added to the default fields for reading and writing alignment files.
  This has the following impact:
   1. Reading and writing in one line is now possible without additional reference information:
      `seqan3::alignment_file_output{"foo.sam"} = seqan3::alignment_file_input{"bar.sam"};`
   2. The `seqan3::alignment_file_output` now accepts `seqan3::field::cigar` and `seqan3::field::alignment`
      although they store redundant information. For the SAM/BAM format, this ambiguity is handled by favoring the CIGAR
      information at all times if present.

Afterwards, we can discuss if we want to discard the dummy sequence and only allow reading the alignment field if the reference information is present.