### PR TITLE
[FIX] Fixes the constructor of the combined range closur adaptor.

### DIFF
--- a/include/seqan3/range/views/detail.hpp
+++ b/include/seqan3/range/views/detail.hpp
@@ -252,12 +252,12 @@ public:
 
     //!\brief Inherit the base type's constructors.
     using base_type::base_type;
-    //!\}
 
     //!\brief Store both arguments in the adaptor.
-    combined_adaptor(left_adaptor_t l, right_adaptor_t r) :
+    constexpr combined_adaptor(left_adaptor_t l, right_adaptor_t r) :
         base_type{std::forward<left_adaptor_t>(l), std::forward<right_adaptor_t>(r)}
     {}
+    //!\}
 };
 
 // ============================================================================

--- a/test/unit/range/views/adaptor_base_test.cpp
+++ b/test/unit/range/views/adaptor_base_test.cpp
@@ -10,6 +10,7 @@
 
 #include <gtest/gtest.h>
 
+#include <seqan3/core/type_traits/function.hpp>
 #include <seqan3/range/views/detail.hpp>
 
 using namespace seqan3;
@@ -178,4 +179,16 @@ TEST(arg_ownership, const_rval_adaptor)
     EXPECT_EQ(std::get<3>(f).move_count, 0ul);
     EXPECT_EQ(c4.copy_count, 0ul);
     EXPECT_EQ(c4.move_count, 0ul);
+}
+
+template <typename t>
+struct dummy_view
+{};
+
+TEST(adaptor_combination, constexpr_combine)
+{
+    constexpr auto adaptor1 = seqan3::detail::adaptor_for_view_without_args<dummy_view>{};
+    constexpr auto adaptor2 = seqan3::detail::adaptor_for_view_without_args<dummy_view>{};
+
+    EXPECT_TRUE((SEQAN3_IS_CONSTEXPR(adaptor1 | adaptor2)));
 }


### PR DESCRIPTION
Fixes the constructor of the combined range adaptor closure object. Before it could not be called in a constexpr context, even though it should. Also the forward declarations where useless  because the tempalte parameters came from the class defintion and not the constructor so if the type was not explicitly set to an reference type (which I don't see how it should happen) it was always a copy of the closure objects. Which is also fine in this context I believe.