### PR TITLE
[FEATURE] Adding information only to the advanced help pages is now possible.  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,16 @@ Note that 3.1.0 will be the first API stable release and interfaces in this rele
 
 ## New features
 
+#### Argument Parser
+
+* The following functions accept a `seqan3::argument_parser::option_spec::ADVANCED` to control what is
+  displayed on the (advanced) help page:
+  * `seqan3::argument_parser::add_section`
+  * `seqan3::argument_parser::add_subsection`
+  * `seqan3::argument_parser::add_line`
+  * `seqan3::argument_parser::add_list_item`
+  Note that other `seqan3::argument_parser::option_spec`s like `REQUIRED` are ignored.
+
 #### I/O
 
 * The `seqan3::format_fasta` accepts the file extenstion `.fas` as a valid extension for the FASTA format

--- a/include/seqan3/argument_parser/argument_parser.hpp
+++ b/include/seqan3/argument_parser/argument_parser.hpp
@@ -420,38 +420,45 @@ public:
 
     /*!\brief Adds an help page section to the seqan3::argument_parser.
      * \param[in] title The title of the section.
+     * \param[in] spec Whether to always display this section title (seqan3::option_spec::DEFAULT), only when showing
+     *                 the advanced help page (seqan3::option_spec::ADVANCED) or never (seqan3::option_spec::HIDDEN).
      * \details This only affects the help page and other output formats.
      */
-    void add_section(std::string const & title)
+    void add_section(std::string const & title, option_spec const spec = option_spec::DEFAULT)
     {
-        std::visit([&] (auto & f) { f.add_section(title); }, format);
+        std::visit([&] (auto & f) { f.add_section(title, spec); }, format);
     }
 
     /*!\brief Adds an help page subsection to the seqan3::argument_parser.
      * \param[in] title The title of the subsection.
+     * \param[in] spec Whether to always display this subsection title (seqan3::option_spec::DEFAULT), only when showing
+     *                 the advanced help page (seqan3::option_spec::ADVANCED) or never (seqan3::option_spec::HIDDEN).
      * \details This only affects the help page and other output formats.
      */
-    void add_subsection(std::string const & title)
+    void add_subsection(std::string const & title, option_spec const spec = option_spec::DEFAULT)
     {
-        std::visit([&] (auto & f) { f.add_subsection(title); }, format);
+        std::visit([&] (auto & f) { f.add_subsection(title, spec); }, format);
     }
 
     /*!\brief Adds an help page text line to the seqan3::argument_parser.
      * \param[in] text The text to print.
-     * \param[in] line_is_paragraph Whether to insert as paragraph
-     *            or just a line (Default: false).
+     * \param[in] is_paragraph Whether to insert as paragraph or just a line (Default: false).
+     * \param[in] spec Whether to always display this line (seqan3::option_spec::DEFAULT), only when showing
+     *                 the advanced help page (seqan3::option_spec::ADVANCED) or never (seqan3::option_spec::HIDDEN).
      * \details
      * If the line is not a paragraph (false), only one line break is appended, otherwise two line breaks are appended.
      * This only affects the help page and other output formats.
      */
-    void add_line(std::string const & text, bool line_is_paragraph = false)
+    void add_line(std::string const & text, bool is_paragraph = false, option_spec const spec = option_spec::DEFAULT)
     {
-        std::visit([&] (auto & f) { f.add_line(text, line_is_paragraph); }, format);
+        std::visit([&] (auto & f) { f.add_line(text, is_paragraph, spec); }, format);
     }
 
     /*!\brief Adds an help page list item (key-value) to the seqan3::argument_parser.
      * \param[in] key  The key of the key-value pair of the list item.
      * \param[in] desc The value of the key-value pair of the list item.
+     * \param[in] spec Whether to always display this list item (seqan3::option_spec::DEFAULT), only when showing
+     *                 the advanced help page (seqan3::option_spec::ADVANCED) or never (seqan3::option_spec::HIDDEN).
      *
      * \details
      *
@@ -465,9 +472,9 @@ public:
      *            Super important integer for age.
      *```
      */
-    void add_list_item(std::string const & key, std::string const & desc)
+    void add_list_item(std::string const & key, std::string const & desc, option_spec const spec = option_spec::DEFAULT)
     {
-        std::visit([&] (auto & f) { f.add_list_item(key, desc); }, format);
+        std::visit([&] (auto & f) { f.add_list_item(key, desc, spec); }, format);
     }
     //!\}
 

--- a/include/seqan3/argument_parser/argument_parser.hpp
+++ b/include/seqan3/argument_parser/argument_parser.hpp
@@ -238,7 +238,7 @@ public:
                     char const short_id,
                     std::string const & long_id,
                     std::string const & desc,
-                    option_spec const & spec = option_spec::DEFAULT,
+                    option_spec const spec = option_spec::DEFAULT,
                     validator_type validator = validator_type{}) // copy to bind rvalues
     {
         if (sub_parser != nullptr)
@@ -262,7 +262,7 @@ public:
                   char const short_id,
                   std::string const & long_id,
                   std::string const & desc,
-                  option_spec const & spec = option_spec::DEFAULT)
+                  option_spec const spec = option_spec::DEFAULT)
     {
         verify_identifiers(short_id, long_id);
         // copy variables into the lambda because the calls are pushed to a stack

--- a/include/seqan3/argument_parser/detail/format_base.hpp
+++ b/include/seqan3/argument_parser/detail/format_base.hpp
@@ -223,16 +223,7 @@ private:
 
 public:
     /*!\brief Adds a seqan3::print_list_item call to be evaluated later on.
-     *
-     * \tparam option_type    The type of variable in which to store the given command line argument.
-     * \tparam validator_type The type of validator applied to the value after parsing.
-     *
-     * \param[out] value     The variable in which to store the given command line argument.
-     * \param[in]  short_id  The short identifier for the option (e.g. 'i').
-     * \param[in]  long_id   The long identifier for the option (e.g. "integer").
-     * \param[in]  desc      The description of the option.
-     * \param[in]  spec      Advanced option specification, see seqan3::option_spec.
-     * \param[in]  validator The validator applied to the value after parsing (callable).
+     * \copydetails seqan3::argument_parser::add_option
      */
     template <typename option_type, typename validator_type>
     void add_option(option_type & value,
@@ -258,13 +249,9 @@ public:
     }
 
     /*!\brief Adds a seqan3::print_list_item call to be evaluated later on.
-     *
-     * \param[in]  short_id The short identifier for the flag (e.g. 'i').
-     * \param[in]  long_id  The long identifier for the flag (e.g. "integer").
-     * \param[in]  desc     The description of the flag.
-     * \param[in]  spec     Advanced flag specification, see seqan3::option_spec.
+     * \copydetails seqan3::argument_parser::add_flag
      */
-    void add_flag(bool & /*value*/,
+    void add_flag(bool & SEQAN3_DOXYGEN_ONLY(value),
                   char const short_id,
                   std::string const & long_id,
                   std::string const & desc,
@@ -278,13 +265,7 @@ public:
     }
 
     /*!\brief Adds a seqan3::print_list_item call to be evaluated later on.
-     *
-     * \tparam option_type    The type of variable in which to store the given command line argument.
-     * \tparam validator_type The type of validator applied to the value after parsing.
-     *
-     * \param[out] value     The variable in which to store the given command line argument.
-     * \param[in]  desc      The description of the positional option.
-     * \param[in]  validator The validator applied to the value after parsing (callable).
+     * \copydetails seqan3::argument_parser::add_positional_option
      */
     template <typename option_type, typename validator_type>
     void add_positional_option(option_type & value,
@@ -371,7 +352,7 @@ public:
     }
 
     /*!\brief Adds a print_section call to parser_set_up_calls.
-     * \param[in] title The title of the section of the help page.
+     * \copydetails seqan3::argument_parser::add_section
      */
     void add_section(std::string const & title)
     {
@@ -382,7 +363,7 @@ public:
     }
 
     /*!\brief Adds a print_subsection call to parser_set_up_calls.
-     * \param[in] title The title of the subsection of the help page.
+     * \copydetails seqan3::argument_parser::add_subsection
      */
     void add_subsection(std::string const & title)
     {
@@ -393,8 +374,7 @@ public:
     }
 
     /*!\brief Adds a print_line call to parser_set_up_calls.
-     * \param[in] text The line text to be printed to the help page.
-     * \param[in] line_is_paragraph True if you want a new line at the end.
+     * \copydetails seqan3::argument_parser::add_line
      */
     void add_line(std::string const & text, bool line_is_paragraph)
     {
@@ -405,8 +385,7 @@ public:
     }
 
     /*!\brief Adds a seqan3::print_list_item call to parser_set_up_calls.
-     * \param[in] key The key of the key-value pair list item.
-     * \param[in] desc The key of the key-value pair list item.
+     * \copydetails seqan3::argument_parser::add_list_item
      */
     void add_list_item(std::string const & key, std::string const & desc)
     {

--- a/include/seqan3/argument_parser/detail/format_base.hpp
+++ b/include/seqan3/argument_parser/detail/format_base.hpp
@@ -230,7 +230,7 @@ public:
                     char const short_id,
                     std::string const & long_id,
                     std::string const & desc,
-                    option_spec const & spec,
+                    option_spec const spec,
                     validator_type && validator)
     {
         std::string id = prep_id_for_help(short_id, long_id) + " " + option_type_and_list_info(value);
@@ -247,7 +247,7 @@ public:
                   char const short_id,
                   std::string const & long_id,
                   std::string const & desc,
-                  option_spec const & spec)
+                  option_spec const spec)
     {
         std::string id = prep_id_for_help(short_id, long_id);
         store_help_page_element([this, id, desc] () { derived_t().print_list_item(id, desc); }, spec);

--- a/include/seqan3/argument_parser/detail/format_parse.hpp
+++ b/include/seqan3/argument_parser/detail/format_parse.hpp
@@ -78,7 +78,7 @@ public:
                     char const short_id,
                     std::string const & long_id,
                     std::string const & SEQAN3_DOXYGEN_ONLY(desc),
-                    option_spec const & spec,
+                    option_spec const spec,
                     validator_type && validator)
     {
         option_calls.push_back([this, &value, short_id, long_id, spec, validator]()
@@ -633,7 +633,7 @@ private:
     void get_option(option_type & value,
                      char const short_id,
                      std::string const & long_id,
-                     option_spec const & spec,
+                     option_spec const spec,
                      validator_type && validator)
     {
         bool short_id_is_set{get_option_by_id(value, short_id)};

--- a/include/seqan3/argument_parser/detail/format_parse.hpp
+++ b/include/seqan3/argument_parser/detail/format_parse.hpp
@@ -71,23 +71,13 @@ public:
     //!\}
 
     /*!\brief Adds an seqan3::detail::get_option call to be evaluated later on.
-     *
-     * \tparam option_type    The type of variable in which to store the given command line argument.
-     * \tparam validator_type The type of validator applied to the value after parsing.
-     *
-     * \param[out] value     The variable in which to store the given command line argument.
-     * \param[in]  short_id  The short identifier for the option (e.g. 'i').
-     * \param[in]  long_id   The long identifier for the option (e.g. "integer").
-     * \param[in]  spec      Advanced option specification, see seqan3::option_spec.
-     * \param[in]  validator The validator applied to the value after parsing (callable).
-     *
-     * \throws seqan3::design_error
+     * \copydetails seqan3::argument_parser::add_option
      */
     template <typename option_type, typename validator_type>
     void add_option(option_type & value,
                     char const short_id,
                     std::string const & long_id,
-                    std::string const & /*desc*/,
+                    std::string const & SEQAN3_DOXYGEN_ONLY(desc),
                     option_spec const & spec,
                     validator_type && validator)
     {
@@ -98,18 +88,13 @@ public:
     }
 
     /*!\brief Adds a get_flag call to be evaluated later on.
-     *
-     * \param[out] value    The variable in which to store the given command line argument.
-     * \param[in]  short_id The short identifier for the flag (e.g. 'i').
-     * \param[in]  long_id  The long identifier for the flag (e.g. "integer").
-     *
-     * \throws seqan3::design_error
+     * \copydetails seqan3::argument_parser::add_flag
      */
     void add_flag(bool & value,
                   char const short_id,
                   std::string const & long_id,
-                  std::string const & /*desc*/,
-                  option_spec const & /*spec*/)
+                  std::string const & SEQAN3_DOXYGEN_ONLY(desc),
+                  option_spec const & SEQAN3_DOXYGEN_ONLY(spec))
     {
         flag_calls.push_back([this, &value, short_id, long_id]()
         {
@@ -118,18 +103,11 @@ public:
     }
 
     /*!\brief Adds a get_positional_option call to be evaluated later on.
-     *
-     * \tparam option_type    The type of variable in which to store the given command line argument.
-     * \tparam validator_type The type of validator applied to the value after parsing.
-     *
-     * \param[out] value     The variable in which to store the given command line argument.
-     * \param[in]  validator The validator applied to the value after parsing (callable).
-     *
-     * \throws seqan3::design_error
+     * \copydetails seqan3::argument_parser::add_positional_option
      */
     template <typename option_type, typename validator_type>
     void add_positional_option(option_type & value,
-                               std::string const & /*desc*/,
+                               std::string const & SEQAN3_DOXYGEN_ONLY(desc),
                                validator_type && validator)
     {
         positional_option_calls.push_back([this, &value, validator]()

--- a/include/seqan3/argument_parser/detail/format_parse.hpp
+++ b/include/seqan3/argument_parser/detail/format_parse.hpp
@@ -142,10 +142,10 @@ public:
 
     // functions are not needed for command line parsing but are part of the format interface.
     //!\cond
-    void add_section(std::string const &) {}
-    void add_subsection(std::string const &) {}
-    void add_line(std::string const &, bool) {}
-    void add_list_item(std::string const &, std::string const &) {}
+    void add_section(std::string const &, option_spec const) {}
+    void add_subsection(std::string const &, option_spec const) {}
+    void add_line(std::string const &, bool, option_spec const) {}
+    void add_list_item(std::string const &, std::string const &, option_spec const) {}
     //!\endcond
 
     //!\brief Checks whether `id` is empty.

--- a/test/unit/argument_parser/format_parse_validators_test.cpp
+++ b/test/unit/argument_parser/format_parse_validators_test.cpp
@@ -1055,6 +1055,7 @@ TEST(validator_test, chaining_validators)
 
     // help page message
     {
+        option_value.clear();
         const char * argv[] = {"./argument_parser_test", "-h"};
         seqan3::argument_parser parser{"test_parser", 2, argv, false};
         parser.add_option(option_value, 's', "string-option", "desc",
@@ -1064,7 +1065,6 @@ TEST(validator_test, chaining_validators)
                           seqan3::regex_validator{".*"});
 
         testing::internal::CaptureStdout();
-        option_value.clear();
         EXPECT_EXIT(parser.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
         std::string my_stdout = testing::internal::GetCapturedStdout();
         std::string expected = std::string{"test_parser"
@@ -1076,7 +1076,7 @@ TEST(validator_test, chaining_validators)
                                "          Value must match the pattern '.*'."} +
                                basic_version_str;
         EXPECT_TRUE(std::ranges::equal((my_stdout | std::views::filter(!seqan3::is_space)),
-                                        expected  | std::views::filter(!seqan3::is_space)));
+                                        expected  | std::views::filter(!seqan3::is_space))) << my_stdout;
     }
 
     // chaining with a container option value type


### PR DESCRIPTION
Fixes  #1175

The following functions accept a `seqan3::argument_parser::option_spec::ADVANCED` to control what is displayed on the (advanced) help page:
  * `seqan3::argument_parser::add_section`
  * `seqan3::argument_parser::add_subsection`
  * `seqan3::argument_parser::add_line`
  * `seqan3::argument_parser::add_list_item`

Note that other `seqan3::argument_parser::option_spec`s like `REQUIRED` are ignored.