### PR TITLE
[I/O,MISC] Remove #pragma GCC diagnostics

### DIFF
--- a/include/seqan3/io/alignment_file/all.hpp
+++ b/include/seqan3/io/alignment_file/all.hpp
@@ -17,9 +17,6 @@
  * \brief Provides files and formats for handling alignment data.
  */
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-
 #include <seqan3/io/alignment_file/format_bam.hpp>
 #include <seqan3/io/alignment_file/format_sam.hpp>
 #include <seqan3/io/alignment_file/header.hpp>
@@ -30,5 +27,3 @@
 #include <seqan3/io/alignment_file/output_format_concept.hpp>
 #include <seqan3/io/alignment_file/output_options.hpp>
 #include <seqan3/io/alignment_file/sam_tag_dictionary.hpp>
-
-#pragma GCC diagnostic pop

--- a/include/seqan3/io/sequence_file/all.hpp
+++ b/include/seqan3/io/sequence_file/all.hpp
@@ -19,13 +19,8 @@
  * \see \ref tutorial_sequence_file
  */
 
-#pragma GCC diagnostic push // buggy deprecation warning is triggered in the ranges library
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-
 #include <seqan3/io/sequence_file/format_fasta.hpp>
 #include <seqan3/io/sequence_file/input_format_concept.hpp>
 #include <seqan3/io/sequence_file/input.hpp>
 #include <seqan3/io/sequence_file/output_format_concept.hpp>
 #include <seqan3/io/sequence_file/output.hpp>
-
-#pragma GCC diagnostic pop

--- a/include/seqan3/io/sequence_file/input.hpp
+++ b/include/seqan3/io/sequence_file/input.hpp
@@ -17,11 +17,6 @@
 #include <string>
 #include <variant>
 #include <vector>
-
-// remove the following after range-v3 is updated to 1.0
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-
 #include <seqan3/alphabet/adaptation/char.hpp>
 #include <seqan3/alphabet/aminoacid/aa27.hpp>
 #include <seqan3/alphabet/nucleotide/all.hpp>
@@ -716,4 +711,3 @@ sequence_file_input(stream_type & stream,
 //!\}
 
 } // namespace seqan3
-#pragma GCC diagnostic pop

--- a/include/seqan3/io/sequence_file/output.hpp
+++ b/include/seqan3/io/sequence_file/output.hpp
@@ -17,11 +17,6 @@
 #include <string>
 #include <variant>
 #include <vector>
-
-// remove the following after range-v3 is updated to 1.0
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-
 #include <seqan3/core/detail/pack_algorithm.hpp>
 #include <seqan3/core/type_list/traits.hpp>
 #include <seqan3/core/concept/tuple.hpp>
@@ -655,5 +650,3 @@ sequence_file_output(stream_t &,
                             type_list<file_format>>;
 //!\}
 } // namespace seqan3
-
-#pragma GCC diagnostic pop

--- a/include/seqan3/io/structure_file/input.hpp
+++ b/include/seqan3/io/structure_file/input.hpp
@@ -21,11 +21,6 @@
 #include <utility>
 #include <variant>
 #include <vector>
-
-// remove the following after range-v3 is updated to 1.0
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-
 #include <seqan3/alphabet/adaptation/char.hpp>
 #include <seqan3/alphabet/aminoacid/all.hpp>
 #include <seqan3/alphabet/nucleotide/rna15.hpp>
@@ -873,5 +868,3 @@ structure_file_input(stream_type & stream, file_format const &, selected_field_i
 //!\}
 
 } // namespace seqan3
-
-#pragma GCC diagnostic pop

--- a/include/seqan3/io/structure_file/output.hpp
+++ b/include/seqan3/io/structure_file/output.hpp
@@ -19,11 +19,6 @@
 #include <type_traits>
 #include <variant>
 #include <vector>
-
-// remove the following after range-v3 is updated to 1.0
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-
 #include <seqan3/alphabet/structure/all.hpp>
 #include <seqan3/core/type_list/traits.hpp>
 #include <seqan3/core/concept/tuple.hpp>
@@ -670,4 +665,3 @@ structure_file_output(stream_t &, file_format const &, selected_field_ids const 
 //!\}
 
 } // namespace seqan3
-#pragma GCC diagnostic pop

--- a/test/unit/range/container/container_of_container_test.cpp
+++ b/test/unit/range/container/container_of_container_test.cpp
@@ -245,14 +245,6 @@ TYPED_TEST(container_of_container, insert)
     t1 = {"GAGGA"_dna4, "ACGT"_dna4, "ACGT"_dna4, "GAGGA"_dna4};
     t0.insert(t0.cend(), t1.begin() + 1, t1.begin() + 3);
 
-    // remove the following after range-v3 is updated to 1.0
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    t0.insert(t0.cend(),   t1.cend() - 1, t1.cend());
-    #pragma GCC diagnostic pop
-    t0.insert(t0.cbegin(), t1.cend() - 1, t1.cend());
-    EXPECT_EQ(t0, t1);
-
     // initializer list
     t0.clear();
     t1 = {"ACGT"_dna4, "ACGT"_dna4, "GAGGA"_dna4};

--- a/test/unit/range/container/container_of_container_test.cpp
+++ b/test/unit/range/container/container_of_container_test.cpp
@@ -245,6 +245,14 @@ TYPED_TEST(container_of_container, insert)
     t1 = {"GAGGA"_dna4, "ACGT"_dna4, "ACGT"_dna4, "GAGGA"_dna4};
     t0.insert(t0.cend(), t1.begin() + 1, t1.begin() + 3);
 
+    // remove the following after range-v3 is updated to 1.0
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    t0.insert(t0.cend(),   t1.cend() - 1, t1.cend());
+    #pragma GCC diagnostic pop
+    t0.insert(t0.cbegin(), t1.cend() - 1, t1.cend());
+    EXPECT_EQ(t0, t1);
+
     // initializer list
     t0.clear();
     t1 = {"ACGT"_dna4, "ACGT"_dna4, "GAGGA"_dna4};


### PR DESCRIPTION
These changes resolve issue #[1610](https://github.com/seqan/seqan3/issues/1610).
I removed all 
- #pragma GCC diagnostic push
- #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
- #pragma GCC diagnostic pop

In the file seqan3/test/unit/range/container/container_of_container_test.cpp, I removed the whole paragraph although I'm not 100% sure if that was right.
All tests ran properly. 