### PR TITLE
[MISC] quality aliases should explicitly include needed dna* and rna* includes

### DIFF
--- a/include/seqan3/alphabet/quality/aliases.hpp
+++ b/include/seqan3/alphabet/quality/aliases.hpp
@@ -16,7 +16,12 @@
 #include <seqan3/alphabet/quality/concept.hpp>
 #include <seqan3/alphabet/quality/phred42.hpp>
 #include <seqan3/alphabet/quality/qualified.hpp>
-#include <seqan3/alphabet/nucleotide/all.hpp>
+#include <seqan3/alphabet/nucleotide/dna4.hpp>
+#include <seqan3/alphabet/nucleotide/dna5.hpp>
+#include <seqan3/alphabet/nucleotide/dna15.hpp>
+#include <seqan3/alphabet/nucleotide/rna4.hpp>
+#include <seqan3/alphabet/nucleotide/rna5.hpp>
+#include <seqan3/alphabet/nucleotide/rna15.hpp>
 
 namespace seqan3
 {


### PR DESCRIPTION
We should avoid including `all.hpp` and only include things we really
need.