### PR TITLE
[FIX] don't use seqan3::is_char in std/charconv

### DIFF
--- a/include/seqan3/argument_parser/detail/format_parse.hpp
+++ b/include/seqan3/argument_parser/detail/format_parse.hpp
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include <seqan3/argument_parser/detail/format_base.hpp>
+#include <seqan3/core/char_operations/predicate.hpp>
 #include <seqan3/core/detail/type_inspection.hpp>
 #include <seqan3/std/concepts>
 #include <seqan3/std/charconv>

--- a/include/seqan3/io/stream/iterator.hpp
+++ b/include/seqan3/io/stream/iterator.hpp
@@ -21,6 +21,7 @@
 #endif // __cpp_lib_ranges
 
 #include <seqan3/core/platform.hpp>
+#include <seqan3/core/concept/core_language.hpp>
 #include <seqan3/range/views/take.hpp>
 #include <seqan3/range/views/drop.hpp>
 #include <seqan3/std/algorithm>

--- a/include/seqan3/std/charconv
+++ b/include/seqan3/std/charconv
@@ -33,7 +33,6 @@
 #include <sstream>
 #include <type_traits>
 
-#include <seqan3/core/char_operations/predicate.hpp>
 #include <seqan3/std/concepts>
 
 /*!\defgroup charconv charconv
@@ -717,7 +716,7 @@ inline std::from_chars_result from_chars_floating_point(char const * first,
         bool exponent_is_present{false};
         for (auto it = first; it != last; ++it)
         {
-            if (seqan3::is_char<'e'>(*it) || seqan3::is_char<'E'>(*it))
+            if (*it == 'e' || *it == 'E')
             {
                 exponent_is_present = true;
                 break;


### PR DESCRIPTION
Our `seqan3/std/*` headers (shim/polyfill headers) should not include anything
from seqan3 to avoid build failures like missing includes if the standard
headers are available.

Fixes partially #1678