### PR TITLE
[FIX] use std::floating_point instead of seqan3::floating_point

### DIFF
--- a/include/seqan3/std/charconv
+++ b/include/seqan3/std/charconv
@@ -34,7 +34,6 @@
 #include <type_traits>
 
 #include <seqan3/core/char_operations/predicate.hpp>
-#include <seqan3/core/concept/core_language.hpp>
 #include <seqan3/std/concepts>
 
 /*!\defgroup charconv charconv
@@ -693,7 +692,7 @@ inline std::from_chars_result from_chars_integral(char const * first, char const
 //!\endcond
 
 //!\brief Delegates to functions strto[d/f/ld] for floating point value extraction.
-template <seqan3::floating_point value_type>
+template <std::floating_point value_type>
 inline std::from_chars_result from_chars_floating_point(char const * first,
                                                         char const * last,
                                                         value_type & value,
@@ -867,7 +866,7 @@ inline std::to_chars_result to_chars(char * first, char * last, value_type value
 
 //!\brief std::to_chars overload for floating point via a std::stringstream for default base = 10.
 //!\ingroup charconv
-template <seqan3::floating_point floating_point_type>
+template <std::floating_point floating_point_type>
 inline std::to_chars_result to_chars(char * first, char * last, floating_point_type value) noexcept
 {
     assert(first != nullptr);
@@ -1006,7 +1005,7 @@ inline std::from_chars_result from_chars(char const * first, char const * last, 
  *
  * \sa https://en.cppreference.com/w/cpp/utility/from_chars
  */
-template <seqan3::floating_point floating_point_type>
+template <std::floating_point floating_point_type>
 inline std::from_chars_result from_chars(char const * first,
                                          char const * last,
                                          floating_point_type & value,

--- a/include/seqan3/std/concepts
+++ b/include/seqan3/std/concepts
@@ -214,6 +214,15 @@ template <class T>
 SEQAN3_CONCEPT unsigned_integral = integral<T> && !signed_integral<T>;
 //!\endcond
 
+/*!\interface std::floating_point <>
+ * \brief The concept std::floating_point<T> is satisfied if and only if T is a floating-point type.
+ * \sa https://en.cppreference.com/w/cpp/types/is_floating_point
+ */
+//!\cond
+template <typename t>
+SEQAN3_CONCEPT floating_point = std::is_floating_point_v<t>;
+//!\endcond
+
 /*!\interface std::assignable_from <>
  * \brief The concept `std::assignable_from<LHS, RHS>` specifies that an expression of the type and value category specified
  *        by RHS can be assigned to an lvalue expression whose type is specified by LHS.


### PR DESCRIPTION
This PR imports `std::floating_point` into `seqan3/std/concepts`. We use that
concept in `seqan3/std/charconv` to remove dependencies of seqan3 in the std
headers.

Our `seqan3/std/*` headers (shim/polyfill headers) should not include anything
from seqan3 to avoid build failures like missing includes if the standard
headers are available.

Fixes partially #1678