### PR TITLE
[FIX] sort all hits and remove duplicates once

### DIFF
--- a/include/seqan3/search/algorithm/detail/search.hpp
+++ b/include/seqan3/search/algorithm/detail/search.hpp
@@ -152,9 +152,9 @@ inline auto search_single(index_t const & index, query_t & query, configuration_
             {
                 for (auto const & text_pos : cur.locate())
                     hits.push_back(text_pos);
-                std::sort(hits.begin(), hits.end());
-                hits.erase(std::unique(hits.begin(), hits.end()), hits.end());
             }
+            std::sort(hits.begin(), hits.end());
+            hits.erase(std::unique(hits.begin(), hits.end()), hits.end());
         }
         return hits;
     }


### PR DESCRIPTION
Instead of sorting and "uniquifying" the added locations from each cursor. All result are uniquifying at once.