### PR TITLE
[DOC,MISC] add aligned_sequence_concept.hpp to debug_stream.hpp

### DIFF
--- a/doc/tutorial/alignment_file/alignment_file_snippets.cpp
+++ b/doc/tutorial/alignment_file/alignment_file_snippets.cpp
@@ -3,10 +3,6 @@
 #include <seqan3/core/debug_stream.hpp>
 #include <seqan3/std/filesystem>
 
-//![include_aligned_sequence]
-#include <seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp>
-//![include_aligned_sequence]
-
 struct write_file_dummy_struct
 {
     std::filesystem::path const file_path = std::filesystem::temp_directory_path()/"example.sam";

--- a/include/seqan3/core/debug_stream.hpp
+++ b/include/seqan3/core/debug_stream.hpp
@@ -14,6 +14,7 @@
 
 #include <iostream>
 
+#include <seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp>
 #include <seqan3/core/detail/debug_stream_alphabet.hpp>
 #include <seqan3/core/detail/debug_stream_optional.hpp>
 #include <seqan3/core/detail/debug_stream_range.hpp>


### PR DESCRIPTION
This commit adds `aligned_sequence_concept.hpp` to`debug_stream.hpp` and removes unnecessary includes of `aligned_sequence_concept.hpp` in snippets and Documentation.
Due to problems with the Documentationtests on my laptop, I did not check if the Documentationtests still work properly.

Fixes #1647