### PR TITLE
[FIX] fm_index_cursor::path_label for 2D texts should not return views::join | views::slice

### DIFF
--- a/include/seqan3/search/fm_index/bi_fm_index_cursor.hpp
+++ b/include/seqan3/search/fm_index/bi_fm_index_cursor.hpp
@@ -19,7 +19,6 @@
 #include <seqan3/alphabet/adaptation/char.hpp>
 #include <seqan3/alphabet/adaptation/uint.hpp>
 #include <seqan3/core/type_traits/range.hpp>
-#include <seqan3/range/views/join.hpp>
 #include <seqan3/range/views/slice.hpp>
 #include <seqan3/search/fm_index/bi_fm_index.hpp>
 #include <seqan3/std/ranges>
@@ -911,20 +910,18 @@ public:
         // Position of query in concatenated text.
         size_type const location = offset() - index->fwd_fm.index[fwd_lb];
 
-        // The rank represents the number of delimiters before position `location + 1`.
-        // Furthermore, this number represents the i-th text this (text) position originates from, since each delimiter
-        // corresponds to one text in the whole concatenated text from left-to-right.
+        // The rank represents the number of start positions of the individual sequences/texts in the collection
+        // before position `location + 1` and thereby also the number of delimiters.
         size_type const rank = index->fwd_fm.text_begin_rs.rank(location + 1);
         assert(rank > 0);
         size_type const text_id = rank - 1;
 
-        // The sum of all text lengths prior to the i-th text is the start location of the i-th text in the concatenated
-        // sequence.
+        // The start location of the `text_id`-th text in the sequence (position of the `rank`-th 1 in the bitvector).
         size_type const start_location = index->fwd_fm.text_begin_ss.select(rank);
         // Substract lengths of previous sequences.
         size_type const query_begin = location - start_location;
 
-        // Take subtext, slice query out of it <-my
+        // Take subtext, slice query out of it
         return text[text_id] | views::slice(query_begin, query_begin + query_length());
     }
 

--- a/include/seqan3/search/fm_index/bi_fm_index_cursor.hpp
+++ b/include/seqan3/search/fm_index/bi_fm_index_cursor.hpp
@@ -908,9 +908,14 @@ public:
                       "The alphabet types of the given text and index differ.");
         assert(index != nullptr);
 
-        size_type const loc = offset() - index->fwd_fm.index[fwd_lb];
-        size_type const query_begin = loc - index->fwd_fm.text_begin_rs.rank(loc + 1) + 1; // Substract delimiters
-        return text | views::join | views::slice(query_begin, query_begin + query_length());
+        size_type const loc = offset() - index->fwd_fm.index[fwd_lb];   // Position of query in concatenated texts.
+        size_type const text_idx = index->fwd_fm.text_begin_rs.rank(loc + 1) - 1; // Position of subtext in text vector,
+                                                                        // where the query was found
+                                                                        // = rank of Bitvector of the concatenated texts
+        size_type const query_begin = loc - index->fwd_fm.text_begin_ss.select(text_idx + 1);
+                                                                        // Substract lengths of previous sequences
+        return text[text_idx] | views::slice(query_begin, query_begin + query_length());
+                                                                        // Take subtext, slice query out of it    }
     }
 
     /*!\brief Counts the number of occurrences of the searched query in the text.

--- a/include/seqan3/search/fm_index/bi_fm_index_cursor.hpp
+++ b/include/seqan3/search/fm_index/bi_fm_index_cursor.hpp
@@ -910,17 +910,20 @@ public:
 
         // Position of query in concatenated text.
         size_type const location = offset() - index->fwd_fm.index[fwd_lb];
+
         // The rank represents the number of delimiters before position `location + 1`.
         // Furthermore, this number represents the i-th text this (text) position originates from, since each delimiter
         // corresponds to one text in the whole concatenated text from left-to-right.
         size_type const rank = index->fwd_fm.text_begin_rs.rank(location + 1);
+        assert(rank > 0);
+        size_type const text_id = rank - 1;
+
         // The sum of all text lengths prior to the i-th text is the start location of the i-th text in the concatenated
         // sequence.
         size_type const start_location = index->fwd_fm.text_begin_ss.select(rank);
-        assert(rank > 0);
-        size_type const text_id = rank - 1;
         // Substract lengths of previous sequences.
         size_type const query_begin = location - start_location;
+
         // Take subtext, slice query out of it <-my
         return text[text_id] | views::slice(query_begin, query_begin + query_length());
     }

--- a/include/seqan3/search/fm_index/fm_index_cursor.hpp
+++ b/include/seqan3/search/fm_index/fm_index_cursor.hpp
@@ -482,9 +482,14 @@ public:
                       "The alphabet types of the given text and index differ.");
         assert(index != nullptr);
 
-        size_type const loc = offset() - index->index[node.lb];
-        size_type const query_begin = loc - index->text_begin_rs.rank(loc + 1) + 1; // Substract delimiters
-        return text | views::join | views::slice(query_begin, query_begin + query_length());
+        size_type const loc = offset() - index->index[node.lb];         // Position of query in concatenated texts.
+        size_type const text_idx = index->text_begin_rs.rank(loc + 1) - 1; // Position of subtext in text vector,
+                                                                        // where the query was found
+                                                                        // = rank of Bitvector of the concatenated texts
+        size_type const query_begin = loc - index->text_begin_ss.select(text_idx + 1);
+                                                                        // Substract lengths of previous sequences
+        return text[text_idx] | views::slice(query_begin, query_begin + query_length());
+                                                                        // Take subtext, slice query out of it
     }
 
     /*!\brief Counts the number of occurrences of the searched query in the text.

--- a/include/seqan3/search/fm_index/fm_index_cursor.hpp
+++ b/include/seqan3/search/fm_index/fm_index_cursor.hpp
@@ -484,18 +484,21 @@ public:
 
         // Position of query in concatenated text.
         size_type const location = offset() - index->index[node.lb];
+
         // The rank represents the number of delimiters before position `location + 1`.
         // Furthermore, this number represents the i-th text this (text) position originates from, since each delimiter
         // corresponds to one text in the whole concatenated text from left-to-right.
         size_type const rank = index->text_begin_rs.rank(location + 1);
+        assert(rank > 0);
+        size_type const text_id = rank - 1;
+
         // The sum of all text lengths prior to the i-th text is the start location of the i-th text in the concatenated
         // sequence.
         size_type const start_location = index->text_begin_ss.select(rank);
-        assert(rank > 0);
-        size_type const text_id = rank - 1;
         assert(text_id + 1 != 0);
         // Substract lengths of previous sequences.
         size_type const query_begin = location - start_location;
+
         // Take subtext, slice query out of it <-my
         return text[text_id] | views::slice(query_begin, query_begin + query_length());
     }

--- a/include/seqan3/search/fm_index/fm_index_cursor.hpp
+++ b/include/seqan3/search/fm_index/fm_index_cursor.hpp
@@ -21,7 +21,6 @@
 
 #include <seqan3/alphabet/concept.hpp>
 #include <seqan3/core/type_traits/range.hpp>
-#include <seqan3/range/views/join.hpp>
 #include <seqan3/range/views/slice.hpp>
 #include <seqan3/search/fm_index/detail/fm_index_cursor.hpp>
 #include <seqan3/search/fm_index/fm_index.hpp>
@@ -485,21 +484,18 @@ public:
         // Position of query in concatenated text.
         size_type const location = offset() - index->index[node.lb];
 
-        // The rank represents the number of delimiters before position `location + 1`.
-        // Furthermore, this number represents the i-th text this (text) position originates from, since each delimiter
-        // corresponds to one text in the whole concatenated text from left-to-right.
+        // The rank represents the number of start positions of the individual sequences/texts in the collection
+        // before position `location + 1` and thereby also the number of delimiters.
         size_type const rank = index->text_begin_rs.rank(location + 1);
         assert(rank > 0);
         size_type const text_id = rank - 1;
 
-        // The sum of all text lengths prior to the i-th text is the start location of the i-th text in the concatenated
-        // sequence.
+        // The start location of the `text_id`-th text in the sequence (position of the `rank`-th 1 in the bitvector).
         size_type const start_location = index->text_begin_ss.select(rank);
-        assert(text_id + 1 != 0);
         // Substract lengths of previous sequences.
         size_type const query_begin = location - start_location;
 
-        // Take subtext, slice query out of it <-my
+        // Take subtext, slice query out of it
         return text[text_id] | views::slice(query_begin, query_begin + query_length());
     }
 

--- a/include/seqan3/search/fm_index/fm_index_cursor.hpp
+++ b/include/seqan3/search/fm_index/fm_index_cursor.hpp
@@ -482,14 +482,22 @@ public:
                       "The alphabet types of the given text and index differ.");
         assert(index != nullptr);
 
-        size_type const loc = offset() - index->index[node.lb];         // Position of query in concatenated texts.
-        size_type const text_idx = index->text_begin_rs.rank(loc + 1) - 1; // Position of subtext in text vector,
-                                                                        // where the query was found
-                                                                        // = rank of Bitvector of the concatenated texts
-        size_type const query_begin = loc - index->text_begin_ss.select(text_idx + 1);
-                                                                        // Substract lengths of previous sequences
-        return text[text_idx] | views::slice(query_begin, query_begin + query_length());
-                                                                        // Take subtext, slice query out of it
+        // Position of query in concatenated text.
+        size_type const location = offset() - index->index[node.lb];
+        // The rank represents the number of delimiters before position `location + 1`.
+        // Furthermore, this number represents the i-th text this (text) position originates from, since each delimiter
+        // corresponds to one text in the whole concatenated text from left-to-right.
+        size_type const rank = index->text_begin_rs.rank(location + 1);
+        // The sum of all text lengths prior to the i-th text is the start location of the i-th text in the concatenated
+        // sequence.
+        size_type const start_location = index->text_begin_ss.select(rank);
+        assert(rank > 0);
+        size_type const text_id = rank - 1;
+        assert(text_id + 1 != 0);
+        // Substract lengths of previous sequences.
+        size_type const query_begin = location - start_location;
+        // Take subtext, slice query out of it <-my
+        return text[text_id] | views::slice(query_begin, query_begin + query_length());
     }
 
     /*!\brief Counts the number of occurrences of the searched query in the text.

--- a/test/snippet/search/bi_fm_index_cursor_cycle.cpp
+++ b/test/snippet/search/bi_fm_index_cursor_cycle.cpp
@@ -10,7 +10,7 @@ int main()
 
     seqan3::debug_stream << "Example cycle_back() and cycle_front()\n";
 
-    std::vector<seqan3::dna4> genome{"GAATTAATGAAC"_dna4};
+    seqan3::dna4_vector genome{"GAATTAATGAAC"_dna4};
     seqan3::bi_fm_index index{genome};                      // build the bidirectional index
 
     auto cur = index.cursor();                              // create a cursor
@@ -25,7 +25,7 @@ int main()
     seqan3::debug_stream << cur.last_rank() << '\n';        // outputs 3
 
     cur.extend_left('G'_dna4);                              // search the sequence "GAAT"
-    seqan3::debug_stream << cur.path_label(genome) << '\n'; // outputs "GAAC"
+    seqan3::debug_stream << cur.path_label(genome) << '\n'; // outputs "GAAT"
     seqan3::debug_stream << cur.last_rank() << '\n';        // outputs 2
 
     // cur.cycle_back();                                    // undefined behaviour! only cycle_front() is allowed after extend_left()

--- a/test/snippet/search/bi_fm_index_cursor_extend_left_seq.cpp
+++ b/test/snippet/search/bi_fm_index_cursor_extend_left_seq.cpp
@@ -10,7 +10,7 @@ int main()
 
     seqan3::debug_stream << "Example extend_left(seq)\n";
 
-    std::vector<seqan3::dna4> genome{"GAATTAATGAAC"_dna4};
+    seqan3::dna4_vector genome{"GAATTAATGAAC"_dna4};
     seqan3::bi_fm_index index{genome};                      // build the bidirectional index
 
     auto cur = index.cursor();                              // create a cursor
@@ -18,5 +18,5 @@ int main()
     seqan3::debug_stream << cur.path_label(genome) << '\n'; // outputs "AAC"
     cur.extend_left("ATG"_dna4);                            // extend the query to "ATGAAC"
                                                             // The rightmost character of "ATG" is extended to the left first.
-    seqan3::debug_stream << cur.path_label(genome) << '\n'; // outputs "ATGAAT"
+    seqan3::debug_stream << cur.path_label(genome) << '\n'; // outputs "ATGAAC"
 }

--- a/test/snippet/search/bi_fm_index_cursor_to_fwd_cursor.cpp
+++ b/test/snippet/search/bi_fm_index_cursor_to_fwd_cursor.cpp
@@ -10,14 +10,14 @@ int main()
 
     seqan3::debug_stream << "Example to_fwd_cursor()\n";
 
-    std::vector<seqan3::dna4> genome{"GAATTAACGAAC"_dna4};
+    seqan3::dna4_vector genome{"GAATTAACGAAC"_dna4};
     seqan3::bi_fm_index index{genome};                          // build the bidirectional index
 
     auto cur = index.cursor();                                  // create a cursor
     cur.extend_left("AAC"_dna4);                                // search the sequence "AAC"
     seqan3::debug_stream << cur.path_label(genome) << '\n';     // outputs "AAC"
     auto uni_it = cur.to_fwd_cursor();                          // unidirectional cursor on the text "GAATTAACGAAC"
-    seqan3::debug_stream << uni_it.path_label(genome) << '\n';  // outputs "CAA"
+    seqan3::debug_stream << uni_it.path_label(genome) << '\n';  // outputs "AAC"
     // Undefined behaviour! Cannot be called on the forward cursor if the last extension on the bidirectional
     // cursor was to the left:
     // cur.cycle_back();

--- a/test/snippet/search/bi_fm_index_cursor_to_rev_cursor.cpp
+++ b/test/snippet/search/bi_fm_index_cursor_to_rev_cursor.cpp
@@ -10,21 +10,22 @@ int main()
 
     seqan3::debug_stream << "Example to_rev_cursor()\n";
 
-    std::vector<seqan3::dna4> genome{"GAATTAACGAAC"_dna4};
-    seqan3::bi_fm_index index{genome};                         // build the bidirectional index
+    seqan3::dna4_vector genome{"GAATTAACGAAC"_dna4};
+    seqan3::bi_fm_index index{genome};                              // build the bidirectional index
 
-    auto cur = index.cursor();                                 // create a cursor
-    cur.extend_right("AAC"_dna4);                              // search the sequence "AAC"
-    seqan3::debug_stream << cur.path_label(genome) << '\n';    // outputs "AAC"
-    auto uni_it = cur.to_rev_cursor();                         // unidirectional cursor on the text "CAAGCAATTAAG"
-    seqan3::debug_stream << uni_it.path_label(genome) << '\n'; // outputs "CAA"
+    auto cur = index.cursor();                                      // create a cursor
+    cur.extend_right("AAC"_dna4);                                   // search the sequence "AAC"
+    seqan3::debug_stream << cur.path_label(genome) << '\n';         // outputs "AAC"
+    auto uni_it = cur.to_rev_cursor();                              // unidirectional cursor on the text "CAAGCAATTAAG"
+    auto genome_rev = genome | std::views::reverse;                 // create reverse text
+    seqan3::debug_stream << uni_it.path_label(genome_rev) << '\n';  // outputs "CAA"
     // Undefined behaviour! Cannot be called on the reversed cursor if the last extension on the bidirectional
     // cursor was to the right:
     // cur.cycle_back();
     // seqan3::debug_stream << cur.last_rank() << '\n';
 
-    uni_it.extend_right('G'_dna4);                             // search the sequence "CAAG"
-    seqan3::debug_stream << uni_it.path_label(genome) << '\n'; // outputs "CAAG"
-    seqan3::debug_stream << uni_it.last_rank() << '\n';        // outputs 2
-    uni_it.cycle_back();                                       // search the sequence "CAAT"
+    uni_it.extend_right('G'_dna4);                                  // search the sequence "CAAG"
+    seqan3::debug_stream << uni_it.path_label(genome) << '\n';      // outputs "GAAT"
+    seqan3::debug_stream << uni_it.last_rank() << '\n';             // outputs 2
+    uni_it.cycle_back();                                            // search the sequence "CAAT"
 }

--- a/test/snippet/search/bi_fm_index_cursor_to_rev_cursor.cpp
+++ b/test/snippet/search/bi_fm_index_cursor_to_rev_cursor.cpp
@@ -16,16 +16,16 @@ int main()
     auto cur = index.cursor();                                      // create a cursor
     cur.extend_right("AAC"_dna4);                                   // search the sequence "AAC"
     seqan3::debug_stream << cur.path_label(genome) << '\n';         // outputs "AAC"
-    auto uni_it = cur.to_rev_cursor();                              // unidirectional cursor on the text "CAAGCAATTAAG"
+    auto rev_cur = cur.to_rev_cursor();                             // unidirectional cursor on the text "CAAGCAATTAAG"
     auto genome_rev = genome | std::views::reverse;                 // create reverse text
-    seqan3::debug_stream << uni_it.path_label(genome_rev) << '\n';  // outputs "CAA"
+    seqan3::debug_stream << rev_cur.path_label(genome_rev) << '\n'; // outputs "CAA"
     // Undefined behaviour! Cannot be called on the reversed cursor if the last extension on the bidirectional
     // cursor was to the right:
     // cur.cycle_back();
     // seqan3::debug_stream << cur.last_rank() << '\n';
 
-    uni_it.extend_right('G'_dna4);                                  // search the sequence "CAAG"
-    seqan3::debug_stream << uni_it.path_label(genome) << '\n';      // outputs "GAAT"
-    seqan3::debug_stream << uni_it.last_rank() << '\n';             // outputs 2
-    uni_it.cycle_back();                                            // search the sequence "CAAT"
+    rev_cur.extend_right('G'_dna4);                                  // search the sequence "CAAG"
+    seqan3::debug_stream << rev_cur.path_label(genome_rev) << '\n';  // outputs "CAAG"
+    seqan3::debug_stream << rev_cur.last_rank() << '\n';             // outputs 2
+    rev_cur.cycle_back();                                            // search the sequence "CAAT"
 }


### PR DESCRIPTION
Resolves #1646
I made the change for fm_index_cursor and bi_fm_index_cursor. 
I also fixed a snippet and corrected some snippet comments.