### PR TITLE
[MISC] search: Use decltype on result_type to avoid inconsistencies.

### DIFF
--- a/include/seqan3/search/algorithm/detail/search.hpp
+++ b/include/seqan3/search/algorithm/detail/search.hpp
@@ -192,8 +192,8 @@ inline auto search_all(index_t const & index, queries_t && queries, configuratio
         //                  duplicates. more efficient to call delegate once with one vector instead of calling
         //                  delegate for each hit separately at once.
         using query_t = std::ranges::range_value_t<queries_t>;
-        using single_querry_result_t = decltype(search_single(index, std::declval<query_t &>(), cfg));
-        using search_fn_t = std::function<single_querry_result_t(query_t &)>;
+        using single_query_result_t = decltype(search_single(index, std::declval<query_t &>(), cfg));
+        using search_fn_t = std::function<single_query_result_t(query_t &)>;
 
         search_fn_t search_fn = [&, cfg] (query_t & query) { return search_single(index, query, cfg); };
 

--- a/include/seqan3/search/algorithm/detail/search.hpp
+++ b/include/seqan3/search/algorithm/detail/search.hpp
@@ -187,20 +187,13 @@ inline auto search_all(index_t const & index, queries_t && queries, configuratio
     }
     else
     {
-        using search_traits_t = search_traits<configuration_t>;
-
         // return type: for each query: a vector of text_positions (or cursors)
         // delegate params: text_position (or cursor). we will withhold all hits of one query anyway to filter
         //                  duplicates. more efficient to call delegate once with one vector instead of calling
         //                  delegate for each hit separately at once.
-        using text_pos_t = std::conditional_t<index_t::text_layout_mode == text_layout::collection,
-                                              std::pair<typename index_t::size_type, typename index_t::size_type>,
-                                              typename index_t::size_type>;
-        using hit_t = std::conditional_t<search_traits_t::search_return_index_cursor,
-                                         typename index_t::cursor_type,
-                                         text_pos_t>;
         using query_t = std::ranges::range_value_t<queries_t>;
-        using search_fn_t = std::function<std::vector<hit_t>(query_t &)>;
+        using single_querry_result_t = decltype(search_single(index, std::declval<query_t &>(), cfg));
+        using search_fn_t = std::function<single_querry_result_t(query_t &)>;
 
         search_fn_t search_fn = [&, cfg] (query_t & query) { return search_single(index, query, cfg); };
 


### PR DESCRIPTION
Small refactoring that removes unnecessary code and thereby avoids possible inconsistencies between types.