### PR TITLE
[MISC] Move is_constexpr into type_traits basic.

### DIFF
--- a/include/seqan3/core/type_traits/basic.hpp
+++ b/include/seqan3/core/type_traits/basic.hpp
@@ -15,7 +15,17 @@
 #include <tuple>
 #include <type_traits>
 
-#include <seqan3/core/type_traits/function.hpp>
+#include <seqan3/core/platform.hpp>
+
+// ----------------------------------------------------------------------------
+// is_constexpr
+// ----------------------------------------------------------------------------
+
+/*!\brief Returns true if the expression passed to this macro can be evaluated at compile time, false otherwise.
+ * \ingroup type_traits
+ * \returns true or false.
+ */
+#define SEQAN3_IS_CONSTEXPR(...) std::integral_constant<bool, __builtin_constant_p((__VA_ARGS__, 0))>::value
 
 namespace seqan3
 {

--- a/include/seqan3/core/type_traits/function.hpp
+++ b/include/seqan3/core/type_traits/function.hpp
@@ -14,22 +14,11 @@
 
 #include <seqan3/core/platform.hpp>
 
-// ----------------------------------------------------------------------------
-// is_constexpr
-// ----------------------------------------------------------------------------
-
-/*!\brief Returns true if the expression passed to this macro can be evaluated at compile time, false otherwise.
- * \ingroup type_traits
- * \returns true or false.
- */
-#define SEQAN3_IS_CONSTEXPR(...) std::integral_constant<bool, __builtin_constant_p((__VA_ARGS__, 0))>::value
-
+namespace seqan3::detail
+{
 // ----------------------------------------------------------------------------
 // multi_invocable
 // ----------------------------------------------------------------------------
-
-namespace seqan3::detail
-{
 
 /*!\brief A type that can conveniently inherit multiple invocables and acts as a union over them.
  * \tparam invocable_ts The types to inherit from.

--- a/test/unit/core/type_traits/function_test.cpp
+++ b/test/unit/core/type_traits/function_test.cpp
@@ -7,7 +7,7 @@
 
 #include <gtest/gtest.h>
 
-#include <seqan3/core/type_traits/function.hpp>
+#include <seqan3/core/type_traits/basic.hpp>
 
 constexpr
 int    constexpr_nonvoid_free_fun(int i) { return i; }


### PR DESCRIPTION
There are some cyclic dependencies when function pulls in some other headers from core type traits.
Since the macro works in general for all expressions it is better suited in the basic header of type_traits.

Part of #1692