### PR TITLE
[MISC] Remove unnecessary template arguments from search_cfg::max_error.

### DIFF
--- a/include/seqan3/search/configuration/max_error.hpp
+++ b/include/seqan3/search/configuration/max_error.hpp
@@ -13,15 +13,12 @@
 
 #pragma once
 
-#include <range/v3/numeric/accumulate.hpp>
-
 #include <seqan3/core/algorithm/configuration.hpp>
 #include <seqan3/core/algorithm/pipeable_config_element.hpp>
 #include <seqan3/core/detail/pack_algorithm.hpp>
-#include <seqan3/range/views/slice.hpp>
 #include <seqan3/search/configuration/detail.hpp>
 #include <seqan3/search/configuration/max_error_common.hpp>
-#include <seqan3/std/algorithm>
+#include <seqan3/search/detail/search_common.hpp>
 
 namespace seqan3::search_cfg
 {
@@ -33,18 +30,10 @@ namespace seqan3::search_cfg
  *          a deletion corresponds to a base deleted from the query sequence that does occur in the indexed text.
  *          Deletions at the beginning and at the end of the sequence are not considered during a search.
  */
-template <typename ...errors_t>
-//!\cond
-    requires sizeof...(errors_t) <= 4 &&
-            ((detail::is_type_specialisation_of_v<std::remove_reference_t<errors_t>, total> ||
-              detail::is_type_specialisation_of_v<std::remove_reference_t<errors_t>, substitution> ||
-              detail::is_type_specialisation_of_v<std::remove_reference_t<errors_t>, deletion>  ||
-              detail::is_type_specialisation_of_v<std::remove_reference_t<errors_t>, insertion>) && ...)
-//!\endcond
-class max_error : public pipeable_config_element<max_error<errors_t...>, std::array<uint8_t, 4>>
+class max_error : public pipeable_config_element<max_error, detail::search_param>
 {
     //!\brief An alias type for the base class.
-    using base_t = pipeable_config_element<max_error<errors_t...>, std::array<uint8_t, 4>>;
+    using base_t = pipeable_config_element<max_error, detail::search_param>;
 
     //!\brief Helper function to check valid max error configuration.
     template <typename ..._errors_t>
@@ -67,26 +56,21 @@ class max_error : public pipeable_config_element<max_error<errors_t...>, std::ar
         }
     }
 
-    static_assert(check_consistency(errors_t{}...),
-                  "You may not use the same error specifier more than once.");
-
 public:
-
     //!\privatesection
     //!\brief Internal id to check for consistent configuration settings.
     static constexpr detail::search_config_id id{detail::search_config_id::max_error};
 
     //!\publicsection
     /*!\name Constructor, destructor and assignment
-     * \brief Defaulted all standard constructor.
      * \{
      */
-    constexpr max_error()                              noexcept = default; //!< Default constructor.
-    constexpr max_error(max_error const &)             noexcept = default; //!< Copy constructor.
-    constexpr max_error(max_error &&)                  noexcept = default; //!< Move constructor.
-    constexpr max_error & operator=(max_error const &) noexcept = default; //!< Copy assignment.
-    constexpr max_error & operator=(max_error &&)      noexcept = default; //!< Move assignment.
-    ~max_error()                                       noexcept = default; //!< Destructor.
+    constexpr max_error() = default; //!< Defaulted.
+    constexpr max_error(max_error const &) = default; //!< Defaulted.
+    constexpr max_error(max_error &&) = default; //!< Defaulted.
+    constexpr max_error & operator=(max_error const &) = default; //!< Defaulted.
+    constexpr max_error & operator=(max_error &&) = default; //!< Defaulted.
+    ~max_error() = default; //!< Defaulted
 
     /*!\brief Constructs the object from a set of error specifiers.
      * \tparam    errors_t A template parameter pack with the error types.
@@ -110,42 +94,40 @@ public:
      *
      * \include test/snippet/search/configuration_error.cpp
      */
-    constexpr max_error(errors_t && ...errors) noexcept
+    template <typename ...errors_t>
     //!\cond
-        requires sizeof...(errors_t) > 0
+        requires sizeof...(errors_t) > 0 && sizeof...(errors_t) <= 4 &&
+                 ((detail::is_type_specialisation_of_v<std::remove_reference_t<errors_t>, total> ||
+                   detail::is_type_specialisation_of_v<std::remove_reference_t<errors_t>, substitution> ||
+                   detail::is_type_specialisation_of_v<std::remove_reference_t<errors_t>, deletion>  ||
+                   detail::is_type_specialisation_of_v<std::remove_reference_t<errors_t>, insertion>) && ...)
     //!\endcond
-        : base_t{}
+    constexpr max_error(errors_t && ...errors) noexcept : base_t{}
     {
+        static_assert(check_consistency(errors_t{}...), "You may not use the same error specifier more than once.");
+
         detail::for_each([this](auto e)
         {
-            base_t::value[remove_cvref_t<decltype(e)>::_id()] = e.get();
+            switch (remove_cvref_t<decltype(e)>::_id())
+            {
+                case 0 : value.total = e.get(); break;
+                case 1 : value.substitution = e.get(); break;
+                case 2 : value.insertion = e.get(); break;
+                case 3 : value.deletion = e.get(); break;
+            }
         }, std::forward<errors_t>(errors)...);
 
         // Only total is set so we set all other errors to the total limit.
         if constexpr (((std::remove_reference_t<errors_t>::_id() == 0) || ...) && sizeof...(errors) == 1)
         {
-            std::ranges::fill(base_t::value | views::slice(1, 4), base_t::value[0]);
+            value.substitution = value.insertion = value.deletion = value.total;
         } // otherwise if total is not set but any other field is set than use total as the sum of all set errors.
         else if constexpr (!((std::remove_reference_t<errors_t>::_id() == 0) || ...) && sizeof...(errors) > 0)
         {
-            base_t::value[0] = std::min(static_cast<uint8_t>(255), ranges::accumulate(base_t::value | views::slice(1, 4),
-                                                                              static_cast<uint8_t>(0)));
+            value.total = std::min<uint32_t>(255, value.substitution + value.insertion + value.deletion);
         }
     }
-    //!}
+    //!\}
 };
-
-/*!\name Type deduction guides
- * \relates seqan3::search_cfg::max_error
- * \{
- */
-
-//!\brief Deduces empty list of error specifiers.
-max_error() -> max_error<>;
-
-//!\brief Deduces template arguments from the passed error specifiers.
-template <typename ...errors_t>
-max_error(errors_t && ...) -> max_error<remove_cvref_t<errors_t>...>;
-//!\}
 
 } // namespace seqan3::search_cfg

--- a/include/seqan3/search/detail/search.hpp
+++ b/include/seqan3/search/detail/search.hpp
@@ -53,9 +53,7 @@ inline auto search_single(index_t const & index, query_t & query, configuration_
     detail::search_param max_error{0, 0, 0, 0};
     if constexpr (search_traits_t::search_with_max_error)
     {
-        auto & [total, subs, ins, del] = max_error;
-        std::tie(total, subs, ins, del) = std::apply([](auto ...args){ return std::tuple{args...}; },
-                                                     get<search_cfg::max_error>(cfg).value);
+        max_error = get<search_cfg::max_error>(cfg).value;
     }
     else if constexpr (search_traits_t::search_with_max_error_rate)
     {

--- a/include/seqan3/search/detail/search_common.hpp
+++ b/include/seqan3/search/detail/search_common.hpp
@@ -12,7 +12,7 @@
 
 #pragma once
 
-#include <type_traits>
+#include <tuple>
 
 #include <seqan3/core/platform.hpp>
 
@@ -23,13 +23,26 @@ namespace seqan3::detail
 struct search_param
 {
     //!\brief Total number of errors (upper bound over all error types).
-    uint8_t total;
+    uint8_t total{};
     //!\brief Total number of substitution errors.
-    uint8_t substitution;
+    uint8_t substitution{};
     //!\brief Total number of insertion errors.
-    uint8_t insertion;
+    uint8_t insertion{};
     //!\brief Total number of deletion errors.
-    uint8_t deletion;
+    uint8_t deletion{};
+
+    //!\brief Returns `true` if all member variables of `lhs` and `rhs` are equal, `false` otherwise.
+    constexpr friend bool operator==(search_param const & lhs, search_param const & rhs) noexcept
+    {
+        return std::tie(lhs.total, lhs.substitution, lhs.insertion, lhs.deletion) ==
+               std::tie(rhs.total, rhs.substitution, rhs.insertion, rhs.deletion);
+    }
+
+    //!\brief Returns `true` if any member variable of `lhs` and `rhs` are not equal, `false` otherwise.
+    constexpr friend bool operator!=(search_param const & lhs, search_param const & rhs) noexcept
+    {
+        return !(lhs == rhs);
+    }
 };
 
 } // namespace seqan3::detail

--- a/test/unit/search/search_configuration_test.cpp
+++ b/test/unit/search/search_configuration_test.cpp
@@ -16,7 +16,7 @@ class search_configuration_test : public ::testing::Test
 {};
 
 using test_types = ::testing::Types<seqan3::search_cfg::max_error_rate<>,
-                                    seqan3::search_cfg::max_error<>,
+                                    seqan3::search_cfg::max_error,
                                     seqan3::search_cfg::mode<seqan3::detail::search_mode_best>,
                                     seqan3::search_cfg::output<seqan3::detail::search_output_text_position>,
                                     seqan3::search_cfg::parallel>;


### PR DESCRIPTION
This also gets rid of dependencies on ranges.