### PR TITLE
[TEST] Add max_error(_rate) configuration test and remove redundant search tests

### DIFF
--- a/test/unit/search/search_configuration_test.cpp
+++ b/test/unit/search/search_configuration_test.cpp
@@ -52,6 +52,114 @@ TYPED_TEST(search_configuration_test, configuration_exists)
     EXPECT_TRUE(decltype(cfg)::template exists<TypeParam>());
 }
 
+TEST(search_configuration_test, max_error_defaults)
+{
+    // empty config defaults to 0 for every error
+    EXPECT_EQ((seqan3::search_cfg::max_error{}.value),
+              (seqan3::search_cfg::max_error{seqan3::search_cfg::total{0},
+                                             seqan3::search_cfg::substitution{0},
+                                             seqan3::search_cfg::insertion{0},
+                                             seqan3::search_cfg::deletion{0}}.value));
+
+    // if only total is given, all others default to total
+    EXPECT_EQ((seqan3::search_cfg::max_error{seqan3::search_cfg::total{0}}.value),
+              (seqan3::search_cfg::max_error{seqan3::search_cfg::total{0},
+                                             seqan3::search_cfg::substitution{0},
+                                             seqan3::search_cfg::insertion{0},
+                                             seqan3::search_cfg::deletion{0}}.value));
+
+    EXPECT_EQ((seqan3::search_cfg::max_error{seqan3::search_cfg::total{12}}.value),
+              (seqan3::search_cfg::max_error{seqan3::search_cfg::total{12},
+                                             seqan3::search_cfg::substitution{12},
+                                             seqan3::search_cfg::insertion{12},
+                                             seqan3::search_cfg::deletion{12}}.value));
+
+    // if total and another error type is given, the others default to 0
+    EXPECT_EQ((seqan3::search_cfg::max_error{seqan3::search_cfg::total{12},
+                                             seqan3::search_cfg::substitution{12}}.value),
+              (seqan3::search_cfg::max_error{seqan3::search_cfg::total{12},
+                                             seqan3::search_cfg::substitution{12},
+                                             seqan3::search_cfg::insertion{0},
+                                             seqan3::search_cfg::deletion{0}}.value));
+
+    EXPECT_EQ((seqan3::search_cfg::max_error{seqan3::search_cfg::total{12},
+                                             seqan3::search_cfg::insertion{12}}.value),
+              (seqan3::search_cfg::max_error{seqan3::search_cfg::total{12},
+                                             seqan3::search_cfg::substitution{0},
+                                             seqan3::search_cfg::insertion{12},
+                                             seqan3::search_cfg::deletion{0}}.value));
+
+    EXPECT_EQ((seqan3::search_cfg::max_error{seqan3::search_cfg::total{12},
+                                             seqan3::search_cfg::deletion{12}}.value),
+              (seqan3::search_cfg::max_error{seqan3::search_cfg::total{12},
+                                             seqan3::search_cfg::substitution{0},
+                                             seqan3::search_cfg::insertion{0},
+                                             seqan3::search_cfg::deletion{12}}.value));
+
+    // if total is not set, it will be computed by the sum of the others
+    EXPECT_EQ((seqan3::search_cfg::max_error{seqan3::search_cfg::substitution{1},
+                                             seqan3::search_cfg::insertion{2},
+                                             seqan3::search_cfg::deletion{3}}.value),
+              (seqan3::search_cfg::max_error{seqan3::search_cfg::total{6},
+                                             seqan3::search_cfg::substitution{1},
+                                             seqan3::search_cfg::insertion{2},
+                                             seqan3::search_cfg::deletion{3}}.value));
+}
+
+TEST(search_configuration_test, max_error_rate_defaults)
+{
+    // empty config defaults to 0 for every error
+    EXPECT_EQ((seqan3::search_cfg::max_error_rate{}.value),
+              (seqan3::search_cfg::max_error_rate{seqan3::search_cfg::total{0.0},
+                                                  seqan3::search_cfg::substitution{0.0},
+                                                  seqan3::search_cfg::insertion{0.0},
+                                                  seqan3::search_cfg::deletion{0.0}}.value));
+
+    // if total is given, all others default to total
+    EXPECT_EQ((seqan3::search_cfg::max_error_rate{seqan3::search_cfg::total{0.0}}.value),
+              (seqan3::search_cfg::max_error_rate{seqan3::search_cfg::total{0.0},
+                                                  seqan3::search_cfg::substitution{0.0},
+                                                  seqan3::search_cfg::insertion{0.0},
+                                                  seqan3::search_cfg::deletion{0.0}}.value));
+
+    EXPECT_EQ((seqan3::search_cfg::max_error_rate{seqan3::search_cfg::total{0.34}}.value),
+              (seqan3::search_cfg::max_error_rate{seqan3::search_cfg::total{0.34},
+                                                  seqan3::search_cfg::substitution{0.34},
+                                                  seqan3::search_cfg::insertion{0.34},
+                                                  seqan3::search_cfg::deletion{0.34}}.value));
+
+    // if total and another error type is given, the others default to 0
+    EXPECT_EQ((seqan3::search_cfg::max_error_rate{seqan3::search_cfg::total{0.34},
+                                                  seqan3::search_cfg::substitution{0.34}}.value),
+              (seqan3::search_cfg::max_error_rate{seqan3::search_cfg::total{0.34},
+                                                  seqan3::search_cfg::substitution{0.34},
+                                                  seqan3::search_cfg::insertion{0},
+                                                  seqan3::search_cfg::deletion{0}}.value));
+
+    EXPECT_EQ((seqan3::search_cfg::max_error_rate{seqan3::search_cfg::total{0.34},
+                                                  seqan3::search_cfg::insertion{0.34}}.value),
+              (seqan3::search_cfg::max_error_rate{seqan3::search_cfg::total{0.34},
+                                                  seqan3::search_cfg::substitution{0},
+                                                  seqan3::search_cfg::insertion{0.34},
+                                                  seqan3::search_cfg::deletion{0}}.value));
+
+    EXPECT_EQ((seqan3::search_cfg::max_error_rate{seqan3::search_cfg::total{0.34},
+                                                  seqan3::search_cfg::deletion{0.34}}.value),
+              (seqan3::search_cfg::max_error_rate{seqan3::search_cfg::total{0.34},
+                                                  seqan3::search_cfg::substitution{0},
+                                                  seqan3::search_cfg::insertion{0},
+                                                  seqan3::search_cfg::deletion{0.34}}.value));
+
+    // if total is not set, it will be computed by the sum of the others
+    EXPECT_EQ((seqan3::search_cfg::max_error{seqan3::search_cfg::substitution{0.1},
+                                             seqan3::search_cfg::insertion{0.2},
+                                             seqan3::search_cfg::deletion{0.3}}.value),
+              (seqan3::search_cfg::max_error{seqan3::search_cfg::total{0.6},
+                                             seqan3::search_cfg::substitution{0.1},
+                                             seqan3::search_cfg::insertion{0.2},
+                                             seqan3::search_cfg::deletion{0.3}}.value));
+}
+
 // TEST(search_configuration_test, illegal_runtime_configurations)
 // {
 //     seqan3::dna4_vector text{"ACGT"_dna4}, query{"ACG"_dna4};

--- a/test/unit/search/search_test.cpp
+++ b/test/unit/search/search_test.cpp
@@ -65,48 +65,16 @@ TYPED_TEST(search_test, error_free)
 
     {
         // successful and unsuccesful exact search using empty max_total_error
+        // default max_error{} sets all error to 0
         seqan3::configuration const cfg = seqan3::search_cfg::max_error{};
         EXPECT_EQ(uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{{0, 0}, {0, 4}, {0, 8}}));
         EXPECT_EQ(uniquify(search("ACGG"_dna4, this->index, cfg)), (hits_result_t{}));
     }
 
     {
-        // successful and unsuccesful exact search using short version of max_total_error
-        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::total{0}};
-        EXPECT_EQ(uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{{0, 0}, {0, 4}, {0, 8}}));
-        EXPECT_EQ(uniquify(search("ACGG"_dna4, this->index, cfg)), (hits_result_t{}));
-    }
-
-    {
-        // successful and unsuccesful exact search using max_total_error
-        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::total{0},
-                                                                        seqan3::search_cfg::substitution{0},
-                                                                        seqan3::search_cfg::insertion{0},
-                                                                        seqan3::search_cfg::deletion{0}};
-        EXPECT_EQ(uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{{0, 0}, {0, 4}, {0, 8}}));
-        EXPECT_EQ(uniquify(search("ACGG"_dna4, this->index, cfg)), (hits_result_t{}));
-    }
-
-    {
         // successful and unsuccesful exact search using empty max_total_error_rate
+        // default max_error_rate{} sets all error to 0.0
         seqan3::configuration const cfg = seqan3::search_cfg::max_error_rate{};
-        EXPECT_EQ(uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{{0, 0}, {0, 4}, {0, 8}}));
-        EXPECT_EQ(uniquify(search("ACGG"_dna4, this->index, cfg)), (hits_result_t{}));
-    }
-
-    {
-        // successful and unsuccesful exact search using short version of max_total_error_rate
-        seqan3::configuration const cfg = seqan3::search_cfg::max_error_rate{seqan3::search_cfg::total{.0}};
-        EXPECT_EQ(uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{{0, 0}, {0, 4}, {0, 8}}));
-        EXPECT_EQ(uniquify(search("ACGG"_dna4, this->index, cfg)), (hits_result_t{}));
-    }
-
-    {
-        // successful and unsuccesful exact search using max_total_error_rate
-        seqan3::configuration const cfg = seqan3::search_cfg::max_error_rate{seqan3::search_cfg::total{.0},
-                                                                             seqan3::search_cfg::substitution{.0},
-                                                                             seqan3::search_cfg::insertion{.0},
-                                                                             seqan3::search_cfg::deletion{.0}};
         EXPECT_EQ(uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{{0, 0}, {0, 4}, {0, 8}}));
         EXPECT_EQ(uniquify(search("ACGG"_dna4, this->index, cfg)), (hits_result_t{}));
     }
@@ -147,8 +115,7 @@ TYPED_TEST(search_test, error_substitution)
     using hits_result_t = typename TestFixture::hits_result_t;
 
     {
-        seqan3::configuration const cfg = seqan3::search_cfg::max_error_rate{seqan3::search_cfg::total{.25},
-                                                                             seqan3::search_cfg::substitution{.25}};
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error_rate{seqan3::search_cfg::substitution{.25}};
 
         EXPECT_EQ(uniquify(search("ACGT"_dna4    , this->index, cfg)), (hits_result_t{{0, 0}, {0, 4}, {0, 8}})); // exact match
         EXPECT_EQ(uniquify(search("CGG"_dna4     , this->index, cfg)), (hits_result_t{}));                       // not enough mismatches
@@ -158,34 +125,7 @@ TYPED_TEST(search_test, error_substitution)
     }
 
     {
-        seqan3::configuration const cfg = seqan3::search_cfg::max_error_rate{seqan3::search_cfg::total{.25},
-                                                                             seqan3::search_cfg::substitution{.25},
-                                                                             seqan3::search_cfg::insertion{.0},
-                                                                             seqan3::search_cfg::deletion{.0}};
-
-        EXPECT_EQ(uniquify(search("ACGT"_dna4    , this->index, cfg)), (hits_result_t{{0, 0}, {0, 4}, {0, 8}})); // exact match
-        EXPECT_EQ(uniquify(search("CGG"_dna4     , this->index, cfg)), (hits_result_t{}));                       // not enough mismatches
-        EXPECT_EQ(uniquify(search("CGTC"_dna4    , this->index, cfg)), (hits_result_t{{0, 1}, {0, 5}}));         // 1 mismatch
-        EXPECT_EQ(uniquify(search("ACGGACG"_dna4 , this->index, cfg)), (hits_result_t{{0, 0}, {0, 4}}));         // 1 mismatch
-        EXPECT_EQ(uniquify(search("ACGGACGG"_dna4, this->index, cfg)), (hits_result_t{{0, 0}, {0, 4}}));         // 2 mismatches
-    }
-
-    {
-        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::total{1},
-                                                                        seqan3::search_cfg::substitution{1}};
-
-        EXPECT_EQ(uniquify(search("ACGT"_dna4    , this->index, cfg)), (hits_result_t{{0, 0}, {0, 4}, {0, 8}})); // exact match
-        EXPECT_EQ(uniquify(search("CGTTT"_dna4   , this->index, cfg)), (hits_result_t{}));                       // not enough mismatches
-        EXPECT_EQ(uniquify(search("CGG"_dna4     , this->index, cfg)), (hits_result_t{{0, 1}, {0, 5}, {0, 9}})); // 1 mismatch
-        EXPECT_EQ(uniquify(search("ACGGACG"_dna4 , this->index, cfg)), (hits_result_t{{0, 0}, {0, 4}}));         // 1 mismatch
-        EXPECT_EQ(uniquify(search("CGTCCGTA"_dna4, this->index, cfg)), (hits_result_t{{0, 1}}));                 // 1 mismatch
-    }
-
-    {
-        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::total{1},
-                                                                        seqan3::search_cfg::substitution{1},
-                                                                        seqan3::search_cfg::insertion{0},
-                                                                        seqan3::search_cfg::deletion{0}};
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::substitution{1}};
 
         EXPECT_EQ(uniquify(search("ACGT"_dna4    , this->index, cfg)), (hits_result_t{{0, 0}, {0, 4}, {0, 8}})); // exact match
         EXPECT_EQ(uniquify(search("CGTTT"_dna4   , this->index, cfg)), (hits_result_t{}));                       // not enough mismatches
@@ -200,13 +140,6 @@ TYPED_TEST(search_test, error_configuration_types)
     using hits_result_t = typename TestFixture::hits_result_t;
 
     {
-        uint8_t s = 1, t = 1;
-        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::total{t},
-                                                                        seqan3::search_cfg::substitution{s}};
-        EXPECT_EQ(uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{{0, 0}, {0, 4}, {0, 8}}));
-    }
-
-    {
         seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::substitution{1}};
         EXPECT_EQ(uniquify(search("ACGT"_dna4, this->index, cfg)), (hits_result_t{{0, 0}, {0, 4}, {0, 8}}));
     }
@@ -217,8 +150,7 @@ TYPED_TEST(search_test, error_insertion)
     using hits_result_t = typename TestFixture::hits_result_t;
 
     {
-        seqan3::configuration const cfg = seqan3::search_cfg::max_error_rate{seqan3::search_cfg::total{.25},
-                                                                             seqan3::search_cfg::insertion{.25}};
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error_rate{seqan3::search_cfg::insertion{.25}};
 
         // exact match and insertion at the beginning of the query
         EXPECT_EQ(uniquify(search("ACGT"_dna4    , this->index, cfg)), (hits_result_t{{0, 0}, {0, 1}, {0, 4}, {0, 5},
@@ -234,8 +166,7 @@ TYPED_TEST(search_test, error_insertion)
     }
 
     {
-        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::total{1},
-                                                                        seqan3::search_cfg::insertion{1}};
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::insertion{1}};
 
         // exact match and insertion at the beginning of the query
         EXPECT_EQ(uniquify(search("ACGT"_dna4    , this->index, cfg)), (hits_result_t{{0, 0}, {0, 1}, {0, 4}, {0, 5},
@@ -254,8 +185,7 @@ TYPED_TEST(search_test, error_deletion)
     using hits_result_t = typename TestFixture::hits_result_t;
 
     {
-        seqan3::configuration const cfg = seqan3::search_cfg::max_error_rate{seqan3::search_cfg::total{.25},
-                                                                             seqan3::search_cfg::deletion{.25}};
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error_rate{seqan3::search_cfg::deletion{.25}};
 
         // exact match, no deletion
         EXPECT_EQ(uniquify(search("ACGT"_dna4    , this->index, cfg)), (hits_result_t{{0, 0}, {0, 4}, {0, 8}}));
@@ -270,8 +200,7 @@ TYPED_TEST(search_test, error_deletion)
     }
 
     {
-        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::total{1},
-                                                                        seqan3::search_cfg::deletion{1}};
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::deletion{1}};
 
         // exact match, no deletion
         EXPECT_EQ(uniquify(search("ACGT"_dna4    , this->index, cfg)), (hits_result_t{{0, 0}, {0, 4}, {0, 8}}));
@@ -359,8 +288,7 @@ TYPED_TEST(search_test, search_strategy_best)
     }
 
     { // Find best match with 1 insertion at the end.
-        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::total{1},
-                                                                        seqan3::search_cfg::insertion{1}} |
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::insertion{1}} |
                                           search_cfg_mode_best;
 
         hits_result_t result = search("ACGTT"_dna4, this->index, cfg) | seqan3::views::to<std::vector>;
@@ -369,8 +297,7 @@ TYPED_TEST(search_test, search_strategy_best)
     }
 
     {  // Find best match with a match at the end, allowing a insertion.
-        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::total{1},
-                                                                        seqan3::search_cfg::insertion{1}} |
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::insertion{1}} |
                                           search_cfg_mode_best;
 
         hits_result_t result = search("ACGT"_dna4, this->index, cfg) | seqan3::views::to<std::vector>;
@@ -379,8 +306,7 @@ TYPED_TEST(search_test, search_strategy_best)
     }
 
     {  // Find best match with a deletion.
-        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::total{1},
-                                                                        seqan3::search_cfg::deletion{1}} |
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::deletion{1}} |
                                           search_cfg_mode_best;
 
         hits_result_t result = search("AGT"_dna4, this->index, cfg) | seqan3::views::to<std::vector>;
@@ -389,8 +315,7 @@ TYPED_TEST(search_test, search_strategy_best)
     }
 
     { // Find best match with a match at the end, allowing a deletion.
-        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::total{1},
-                                                                        seqan3::search_cfg::deletion{1}} |
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::deletion{1}} |
                                           search_cfg_mode_best;
 
         hits_result_t result = search("ACGT"_dna4, this->index, cfg) | seqan3::views::to<std::vector>;
@@ -399,8 +324,7 @@ TYPED_TEST(search_test, search_strategy_best)
     }
 
     {  // Find best match with a substitution at the end.
-        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::total{1},
-                                                                        seqan3::search_cfg::substitution{1}} |
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::substitution{1}} |
                                           search_cfg_mode_best;
 
         hits_result_t result = search("ACGC"_dna4, this->index, cfg) | seqan3::views::to<std::vector>;
@@ -409,8 +333,7 @@ TYPED_TEST(search_test, search_strategy_best)
     }
 
     {  // Find best match with a match at the end, allowing a substitution.
-        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::total{1},
-                                                                        seqan3::search_cfg::substitution{1}} |
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::substitution{1}} |
                                           search_cfg_mode_best;
 
         hits_result_t result = search("ACGT"_dna4, this->index, cfg) | seqan3::views::to<std::vector>;
@@ -420,8 +343,7 @@ TYPED_TEST(search_test, search_strategy_best)
 
     {  // Find best match with 2 deletions.
         hits_result_t possible_hits2d{{0, 0}, {0, 4}}; // any of 0, 4 ... 1, 5 are not best hits
-        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::total{2},
-                                                                        seqan3::search_cfg::deletion{2}} |
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error{seqan3::search_cfg::deletion{2}} |
                                           seqan3::search_cfg::mode{seqan3::search_cfg::best};
 
         hits_result_t result = search("AGTAGT"_dna4, this->index, cfg) | seqan3::views::to<std::vector>;


### PR DESCRIPTION
The search test was often just testing if two configurations which are semantically the same also result in the same `search()` result. This is a lot of overhead in the search test. 
Instead, I added configuration tests and removed the redundant search tests.