### PR TITLE
Pass result to alignment/add function traits

### DIFF
--- a/include/seqan3/core/type_traits/function.hpp
+++ b/include/seqan3/core/type_traits/function.hpp
@@ -12,7 +12,51 @@
 
 #pragma once
 
-#include <seqan3/core/platform.hpp>
+#include <functional>
+
+#include <seqan3/core/type_list/traits.hpp>
+
+namespace seqan3
+{
+// ----------------------------------------------------------------------------
+// function_traits
+// ----------------------------------------------------------------------------
+
+//!\cond
+template <typename function_t>
+struct function_traits;
+//!\endcond
+
+/*!\brief A traits class to provide a uniform interface to the properties of a std::function type.
+ * \ingroup type_traits
+ *
+ * seqan3::function_traits is the type trait class that provides a uniform interface to the properties of
+ * a std::function type.
+ * This makes it possible to access the return type and the argument types of the stored target function.
+ *
+ * ### Example
+ *
+ * \include snippet/core/type_traits/function_traits.cpp
+ */
+template <typename return_t, typename ...args_t>
+struct function_traits<std::function<return_t(args_t...)>>
+{
+    //!\brief The number of arguments passed to the std::function target.
+    static constexpr size_t argument_count = sizeof...(args_t);
+
+    //!\brief The return type of the function target.
+    using result_type = return_t;
+
+    /*!\brief The argument type at the given `index`.
+     * \tparam index The position of the argument to get the type for; must be smaller than `argument_count`.
+     */
+    template <size_t index>
+    //!\cond
+        requires index < argument_count
+    //!\endcond
+    using argument_type_at = pack_traits::at<index, args_t...>;
+};
+} // namespace seqan3
 
 namespace seqan3::detail
 {

--- a/test/snippet/core/type_traits/function_traits.cpp
+++ b/test/snippet/core/type_traits/function_traits.cpp
@@ -1,0 +1,18 @@
+#include <functional>
+#include <string>
+
+#include <seqan3/core/type_traits/function.hpp>
+#include <seqan3/std/concepts>
+
+std::function my_caller = [] (size_t position, std::string & sequence)
+{
+    assert(position < sequence.size());
+    return sequence[position];
+};
+
+using my_function_t = decltype(my_caller);
+
+static_assert(std::same_as<seqan3::function_traits<my_function_t>::result_type, char>);
+static_assert(seqan3::function_traits<my_function_t>::argument_count == 2);
+static_assert(std::same_as<seqan3::function_traits<my_function_t>::argument_type_at<0>, size_t>);
+static_assert(std::same_as<seqan3::function_traits<my_function_t>::argument_type_at<1>, std::string &>);

--- a/test/unit/core/type_traits/basic_test.cpp
+++ b/test/unit/core/type_traits/basic_test.cpp
@@ -18,6 +18,10 @@
 #include <seqan3/core/type_traits/basic.hpp>
 #include <seqan3/range/detail/random_access_iterator.hpp>
 
+//------------------------------------------------------------------------------
+// Tests for remove_cvref transformation trait
+//------------------------------------------------------------------------------
+
 TEST(type_trait, remove_cvref_t)
 {
     EXPECT_TRUE((std::is_same_v<int, seqan3::remove_cvref_t<int>>));
@@ -33,4 +37,71 @@ TEST(type_trait, remove_cvref_t)
     EXPECT_FALSE((std::is_same_v<int, seqan3::remove_cvref_t<int[3]>>));    // type stays same
     EXPECT_FALSE((std::is_same_v<int*, seqan3::remove_cvref_t<int[3]>>));   // type stays same
     // the last example would be true for std::decay_t
+}
+
+//------------------------------------------------------------------------------
+// Tests for is_constexpr
+//------------------------------------------------------------------------------
+
+constexpr int constexpr_nonvoid_free_fun(int i) { return i; }
+int nonconstexpr_nonvoid_free_fun(int i) { return i; }
+
+constexpr int constexpr_nonvoid_free_fun_const_ref(int const & i) { return i; }
+int nonconstexpr_nonvoid_free_fun_const_ref(int const & i) { return i; }
+
+constexpr void constexpr_void_free_fun(int) { return; }
+void nonconstexpr_void_free_fun(int) { return; }
+
+struct constexpr_nonvoid_member_t
+{
+    int constexpr get_i(int i)
+    {
+        return i;
+    }
+};
+
+struct constexpr_void_member_t
+{
+    void constexpr get_i(int)
+    {}
+};
+
+struct nonconstexpr_nonvoid_member_t
+{
+    int get_i(int i)
+    {
+        return i;
+    }
+};
+
+struct nonconstexpr_void_member_t
+{
+    void get_i(int)
+    {}
+};
+
+TEST(type_trait, is_constexpr_invocable)
+{
+    int i = 32;
+    int constexpr j = 42;
+
+    EXPECT_TRUE((SEQAN3_IS_CONSTEXPR(constexpr_nonvoid_free_fun(3))));
+    EXPECT_TRUE((SEQAN3_IS_CONSTEXPR(constexpr_nonvoid_free_fun(j))));
+    EXPECT_TRUE((!SEQAN3_IS_CONSTEXPR(constexpr_nonvoid_free_fun(i))));
+    EXPECT_TRUE((!SEQAN3_IS_CONSTEXPR(nonconstexpr_nonvoid_free_fun(3))));
+
+    EXPECT_TRUE((SEQAN3_IS_CONSTEXPR(constexpr_nonvoid_free_fun_const_ref(static_cast<int const &>(3)))));
+    EXPECT_TRUE((SEQAN3_IS_CONSTEXPR(constexpr_nonvoid_free_fun_const_ref(j))));
+    EXPECT_TRUE((!SEQAN3_IS_CONSTEXPR(constexpr_nonvoid_free_fun_const_ref(i))));
+    EXPECT_TRUE((!SEQAN3_IS_CONSTEXPR(nonconstexpr_nonvoid_free_fun_const_ref(static_cast<int const &>(3)))));
+
+    EXPECT_TRUE((SEQAN3_IS_CONSTEXPR(constexpr_void_free_fun(3))));
+    EXPECT_TRUE((SEQAN3_IS_CONSTEXPR(constexpr_void_free_fun(j))));
+    EXPECT_TRUE((!SEQAN3_IS_CONSTEXPR(constexpr_void_free_fun(i))));
+    EXPECT_TRUE((!SEQAN3_IS_CONSTEXPR(nonconstexpr_void_free_fun(3))));
+
+    EXPECT_TRUE((SEQAN3_IS_CONSTEXPR(constexpr_nonvoid_member_t{}.get_i(3))));
+    EXPECT_TRUE((SEQAN3_IS_CONSTEXPR(constexpr_void_member_t{}.get_i(3))));
+    EXPECT_TRUE((!SEQAN3_IS_CONSTEXPR(nonconstexpr_nonvoid_member_t{}.get_i(3))));
+    EXPECT_TRUE((!SEQAN3_IS_CONSTEXPR(nonconstexpr_void_member_t{}.get_i(3))));
 }

--- a/test/unit/core/type_traits/function_test.cpp
+++ b/test/unit/core/type_traits/function_test.cpp
@@ -9,74 +9,7 @@
 
 #include <string>
 
-#include <seqan3/core/type_traits/basic.hpp>
 #include <seqan3/core/type_traits/function.hpp>
-
-constexpr
-int    constexpr_nonvoid_free_fun(int i) { return i; }
-int nonconstexpr_nonvoid_free_fun(int i) { return i; }
-
-constexpr
-int constexpr_nonvoid_free_fun_const_ref(int const & i) { return i; }
-int nonconstexpr_nonvoid_free_fun_const_ref(int const & i) { return i; }
-
-constexpr
-void    constexpr_void_free_fun(int) { return; }
-void nonconstexpr_void_free_fun(int) { return; }
-
-struct constexpr_nonvoid_member_t
-{
-    int constexpr get_i(int i)
-    {
-        return i;
-    }
-};
-
-struct constexpr_void_member_t
-{
-    void constexpr get_i(int)
-    {}
-};
-
-struct nonconstexpr_nonvoid_member_t
-{
-    int get_i(int i)
-    {
-        return i;
-    }
-};
-
-struct nonconstexpr_void_member_t
-{
-    void get_i(int)
-    {}
-};
-
-TEST(type_trait, is_constexpr_invocable)
-{
-    int i = 32;
-    int constexpr j = 42;
-
-    EXPECT_TRUE((SEQAN3_IS_CONSTEXPR(constexpr_nonvoid_free_fun(3))));
-    EXPECT_TRUE((SEQAN3_IS_CONSTEXPR(constexpr_nonvoid_free_fun(j))));
-    EXPECT_TRUE((!SEQAN3_IS_CONSTEXPR(constexpr_nonvoid_free_fun(i))));
-    EXPECT_TRUE((!SEQAN3_IS_CONSTEXPR(nonconstexpr_nonvoid_free_fun(3))));
-
-    EXPECT_TRUE((SEQAN3_IS_CONSTEXPR(constexpr_nonvoid_free_fun_const_ref(static_cast<int const &>(3)))));
-    EXPECT_TRUE((SEQAN3_IS_CONSTEXPR(constexpr_nonvoid_free_fun_const_ref(j))));
-    EXPECT_TRUE((!SEQAN3_IS_CONSTEXPR(constexpr_nonvoid_free_fun_const_ref(i))));
-    EXPECT_TRUE((!SEQAN3_IS_CONSTEXPR(nonconstexpr_nonvoid_free_fun_const_ref(static_cast<int const &>(3)))));
-
-    EXPECT_TRUE((SEQAN3_IS_CONSTEXPR(constexpr_void_free_fun(3))));
-    EXPECT_TRUE((SEQAN3_IS_CONSTEXPR(constexpr_void_free_fun(j))));
-    EXPECT_TRUE((!SEQAN3_IS_CONSTEXPR(constexpr_void_free_fun(i))));
-    EXPECT_TRUE((!SEQAN3_IS_CONSTEXPR(nonconstexpr_void_free_fun(3))));
-
-    EXPECT_TRUE((SEQAN3_IS_CONSTEXPR(constexpr_nonvoid_member_t{}.get_i(3))));
-    EXPECT_TRUE((SEQAN3_IS_CONSTEXPR(constexpr_void_member_t{}.get_i(3))));
-    EXPECT_TRUE((!SEQAN3_IS_CONSTEXPR(nonconstexpr_nonvoid_member_t{}.get_i(3))));
-    EXPECT_TRUE((!SEQAN3_IS_CONSTEXPR(nonconstexpr_void_member_t{}.get_i(3))));
-}
 
 std::function test_function_object = [] (size_t arg1, std::string & arg2)
 {

--- a/test/unit/core/type_traits/function_test.cpp
+++ b/test/unit/core/type_traits/function_test.cpp
@@ -7,7 +7,10 @@
 
 #include <gtest/gtest.h>
 
+#include <string>
+
 #include <seqan3/core/type_traits/basic.hpp>
+#include <seqan3/core/type_traits/function.hpp>
 
 constexpr
 int    constexpr_nonvoid_free_fun(int i) { return i; }
@@ -73,4 +76,29 @@ TEST(type_trait, is_constexpr_invocable)
     EXPECT_TRUE((SEQAN3_IS_CONSTEXPR(constexpr_void_member_t{}.get_i(3))));
     EXPECT_TRUE((!SEQAN3_IS_CONSTEXPR(nonconstexpr_nonvoid_member_t{}.get_i(3))));
     EXPECT_TRUE((!SEQAN3_IS_CONSTEXPR(nonconstexpr_void_member_t{}.get_i(3))));
+}
+
+std::function test_function_object = [] (size_t arg1, std::string & arg2)
+{
+    assert(arg1 < arg2.size());
+    return arg2[arg1];
+};
+
+TEST(function_traits, argument_count)
+{
+    using function_t = decltype(test_function_object);
+    EXPECT_EQ(seqan3::function_traits<function_t>::argument_count, 2u);
+}
+
+TEST(function_traits, result_type)
+{
+    using function_t = decltype(test_function_object);
+    EXPECT_TRUE((std::same_as<seqan3::function_traits<function_t>::result_type, char>));
+}
+
+TEST(function_traits, argument_type_at)
+{
+    using function_t = decltype(test_function_object);
+    EXPECT_TRUE((std::same_as<seqan3::function_traits<function_t>::argument_type_at<0>, size_t>));
+    EXPECT_TRUE((std::same_as<seqan3::function_traits<function_t>::argument_type_at<1>, std::string &>));
 }


### PR DESCRIPTION
Adds a traits class to evaluate properties of std::function objects such as the return type or the type of the arguments. 
This is a part of #1692, which will in the end remove the dependency to call make_result_type at various different places with potentially different types and thereby causing unforseen issues.