### PR TITLE
[FIX] Correct header include in adaptor_base_test

### DIFF
--- a/test/unit/range/views/adaptor_base_test.cpp
+++ b/test/unit/range/views/adaptor_base_test.cpp
@@ -10,7 +10,7 @@
 
 #include <gtest/gtest.h>
 
-#include <seqan3/core/type_traits/function.hpp>
+#include <seqan3/core/type_traits/basic.hpp>
 #include <seqan3/range/views/detail.hpp>
 
 using namespace seqan3;


### PR DESCRIPTION
Minor fix to resolve to correct include. The error was not seen, since `views/detail.hpp` also pulls in `type_traits/basic.hpp` but this should be fixed in order to prevent issues later.