### PR TITLE
[MISC] Use more appropriate suffix _type for type aliases defined in alignment traits.

### DIFF
--- a/include/seqan3/alignment/pairwise/align_result_selector.hpp
+++ b/include/seqan3/alignment/pairwise/align_result_selector.hpp
@@ -73,7 +73,7 @@ struct align_result_selector
 {
 private:
     //!\brief The user configured score type.
-    using score_type = typename alignment_configuration_traits<configuration_t>::original_score_t;
+    using score_type = typename alignment_configuration_traits<configuration_t>::original_score_type;
 
     //!\brief Helper function to determine the actual result type.
     static constexpr auto select()

--- a/include/seqan3/alignment/pairwise/alignment_algorithm.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_algorithm.hpp
@@ -91,8 +91,8 @@ private:
     //!\brief The type of the score debug matrix.
     using score_debug_matrix_t =
         std::conditional_t<traits_t::is_debug,
-                           two_dimensional_matrix<std::optional<typename traits_t::original_score_t>,
-                                                  std::allocator<std::optional<typename traits_t::original_score_t>>,
+                           two_dimensional_matrix<std::optional<typename traits_t::original_score_type>,
+                                                  std::allocator<std::optional<typename traits_t::original_score_type>>,
                                                   matrix_major_order::column>,
                            empty_type>;
     //!\brief The type of the trace debug matrix.
@@ -202,8 +202,8 @@ public:
     {
         assert(cfg_ptr != nullptr);
 
-        static_assert(simd_concept<typename traits_t::score_t>, "Expected simd score type.");
-        static_assert(simd_concept<typename traits_t::trace_t>, "Expected simd trace type.");
+        static_assert(simd_concept<typename traits_t::score_type>, "Expected simd score type.");
+        static_assert(simd_concept<typename traits_t::trace_type>, "Expected simd trace type.");
 
         // Extract the batch of sequences for the first and the second sequence.
         auto sequence1_range = indexed_sequence_pairs | views::get<0> | views::get<0>;
@@ -247,7 +247,7 @@ private:
     {
         assert(static_cast<size_t>(std::ranges::distance(sequences)) <= traits_t::alignments_per_vector);
 
-        using simd_score_t = typename traits_t::score_t;
+        using simd_score_t = typename traits_t::score_type;
 
         std::vector<simd_score_t, aligned_allocator<simd_score_t, alignof(simd_score_t)>> simd_sequence{};
 

--- a/include/seqan3/alignment/pairwise/alignment_configurator.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_configurator.hpp
@@ -142,13 +142,13 @@ private:
 
         //!\brief The selected score matrix for either banded or unbanded alignments.
         using score_matrix_t = std::conditional_t<traits_t::is_banded,
-                                                  alignment_score_matrix_one_column_banded<typename traits_t::score_t>,
-                                                  alignment_score_matrix_one_column<typename traits_t::score_t>>;
+                                                  alignment_score_matrix_one_column_banded<typename traits_t::score_type>,
+                                                  alignment_score_matrix_one_column<typename traits_t::score_type>>;
         //!\brief The selected trace matrix for either banded or unbanded alignments.
         using trace_matrix_t = std::conditional_t<traits_t::is_banded,
-                                                  alignment_trace_matrix_full_banded<typename traits_t::trace_t,
+                                                  alignment_trace_matrix_full_banded<typename traits_t::trace_type,
                                                                                      only_coordinates>,
-                                                  alignment_trace_matrix_full<typename traits_t::trace_t,
+                                                  alignment_trace_matrix_full<typename traits_t::trace_type,
                                                                               only_coordinates>>;
 
     public:
@@ -164,7 +164,7 @@ private:
     {
     private:
         //!\brief The score type for the alignment computation.
-        using score_t = typename traits_t::score_t;
+        using score_t = typename traits_t::score_type;
         //!\brief The is_local constant converted to a type.
         using is_local_t = std::bool_constant<traits_t::is_local>;
 
@@ -186,7 +186,7 @@ private:
     {
     private:
         //!\brief The score type for the alignment computation.
-        using score_t = typename traits_t::score_t;
+        using score_t = typename traits_t::score_type;
         //!\brief A bool constant to disambiguate true global alignments.
         static constexpr bool is_global_alignment = traits_t::is_global && !traits_t::is_aligned_ends;
 
@@ -491,10 +491,10 @@ constexpr function_wrapper_t alignment_configurator::configure_scoring_scheme(co
     using alignment_scoring_scheme_t =
         lazy_conditional_t<traits_t::is_vectorised,
                            lazy<simd_match_mismatch_scoring_scheme,
-                                typename traits_t::score_t,
-                                typename traits_t::scoring_scheme_alphabet_t,
-                                typename traits_t::alignment_mode_t>,
-                           typename traits_t::scoring_scheme_t>;
+                                typename traits_t::score_type,
+                                typename traits_t::scoring_scheme_alphabet_type,
+                                typename traits_t::alignment_mode_type>,
+                                typename traits_t::scoring_scheme_type>;
 
     using scoring_scheme_policy_t = deferred_crtp_base<scoring_scheme_policy, alignment_scoring_scheme_t>;
     return configure_free_ends_initialisation<function_wrapper_t, scoring_scheme_policy_t>(cfg);

--- a/include/seqan3/alignment/pairwise/detail/type_traits.hpp
+++ b/include/seqan3/alignment/pairwise/detail/type_traits.hpp
@@ -53,57 +53,61 @@ struct chunked_indexed_sequence_pairs
  *        configuration object.
  * \ingroup pairwise_alignment
  *
- * \tparam config_t The type of the alignment configuration object; must be a specialisation of seqan3::configuration.
+ * \tparam configuration_t The type of the alignment configuration object; must be a specialisation of
+ *         seqan3::configuration.
  */
-template <typename config_t>
+template <typename configuration_t>
 //!\cond
-    requires is_type_specialisation_of_v<config_t, configuration>
+    requires is_type_specialisation_of_v<configuration_t, configuration>
 //!\endcond
 struct alignment_configuration_traits
 {
     //!\brief Flag to indicate vectorised mode.
-    static constexpr bool is_vectorised = config_t::template exists<remove_cvref_t<decltype(align_cfg::vectorise)>>();
+    static constexpr bool is_vectorised =
+        configuration_t::template exists<remove_cvref_t<decltype(align_cfg::vectorise)>>();
     //!\brief Flag indicating whether parallel alignment mode is enabled.
-    static constexpr bool is_parallel = config_t::template exists<align_cfg::parallel>();
+    static constexpr bool is_parallel = configuration_t::template exists<align_cfg::parallel>();
     //!\brief Flag indicating whether global alignment mode is enabled.
-    static constexpr bool is_global = config_t::template exists<align_cfg::mode<detail::global_alignment_type>>();
+    static constexpr bool is_global =
+        configuration_t::template exists<align_cfg::mode<detail::global_alignment_type>>();
     //!\brief Flag indicating whether global alignment mode with free ends is enabled.
-    static constexpr bool is_aligned_ends = config_t::template exists<align_cfg::aligned_ends>();
+    static constexpr bool is_aligned_ends = configuration_t::template exists<align_cfg::aligned_ends>();
     //!\brief Flag indicating whether local alignment mode is enabled.
-    static constexpr bool is_local = config_t::template exists<align_cfg::mode<detail::local_alignment_type>>();
+    static constexpr bool is_local = configuration_t::template exists<align_cfg::mode<detail::local_alignment_type>>();
     //!\brief Flag indicating whether banded alignment mode is enabled.
-    static constexpr bool is_banded = config_t::template exists<align_cfg::band>();
+    static constexpr bool is_banded = configuration_t::template exists<align_cfg::band>();
     //!\brief Flag indicating whether debug mode is enabled.
-    static constexpr bool is_debug = config_t::template exists<detail::debug_mode>();
+    static constexpr bool is_debug = configuration_t::template exists<detail::debug_mode>();
 
     //!\brief The configured alignment mode.
-    using alignment_mode_t = decltype(get<align_cfg::mode>(std::declval<config_t>()).value);
+    using alignment_mode_type = decltype(get<align_cfg::mode>(std::declval<configuration_t>()).value);
     //!\brief The selected scoring scheme.
-    using scoring_scheme_t = decltype(get<align_cfg::scoring>(std::declval<config_t>()).value);
+    using scoring_scheme_type = decltype(get<align_cfg::scoring>(std::declval<configuration_t>()).value);
     //!\brief The alphabet of the selected scoring scheme.
-    using scoring_scheme_alphabet_t = typename scoring_scheme_t::alphabet_type;
+    using scoring_scheme_alphabet_type = typename scoring_scheme_type::alphabet_type;
     //!\brief The selected result type.
-    using result_t = std::remove_reference_t<decltype(seqan3::get<align_cfg::result>(std::declval<config_t>()))>;
+    using result_type =
+        std::remove_reference_t<decltype(seqan3::get<align_cfg::result>(std::declval<configuration_t>()))>;
     //!\brief The original score type selected by the user.
-    using original_score_t = typename result_t::score_type;
+    using original_score_type = typename result_type::score_type;
     //!\brief The score type for the alignment algorithm.
-    using score_t = std::conditional_t<is_vectorised, simd_type_t<original_score_t>, original_score_t>;
+    using score_type = std::conditional_t<is_vectorised, simd_type_t<original_score_type>, original_score_type>;
     //!\brief The trace directions type for the alignment algorithm.
-    using trace_t = std::conditional_t<is_vectorised, simd_type_t<original_score_t>, trace_directions>;
+    using trace_type = std::conditional_t<is_vectorised, simd_type_t<original_score_type>, trace_directions>;
 
     //!\brief The number of alignments that can be computed in one simd vector.
     static constexpr size_t alignments_per_vector = [] () constexpr
                                                     {
                                                         if constexpr (is_vectorised)
-                                                            return simd_traits<score_t>::length;
+                                                            return simd_traits<score_type>::length;
                                                         else
                                                             return 1;
                                                     }();
     //!\brief The rank of the selected result type.
-    static constexpr int8_t result_type_rank = static_cast<int8_t>(decltype(std::declval<result_t>().value)::rank);
+    static constexpr int8_t result_type_rank = static_cast<int8_t>(decltype(std::declval<result_type>().value)::rank);
     //!\brief The padding symbol to use for the computation of the alignment.
-    static constexpr original_score_t padding_symbol =
-        static_cast<original_score_t>(1u << (sizeof_bits<original_score_t> - 1));
+    static constexpr original_score_type padding_symbol =
+        static_cast<original_score_type>(1u << (sizeof_bits<original_score_type> - 1));
 };
 
 }  // namespace seqan3::detail


### PR DESCRIPTION
Some minor change to be more consistent with naming style.