### PR TITLE
[FIX] Iterator Tag in kmer_hash

### DIFF
--- a/include/seqan3/range/views/kmer_hash.hpp
+++ b/include/seqan3/range/views/kmer_hash.hpp
@@ -224,7 +224,7 @@ public:
     //!\brief Reference to `value_type`.
     using reference = value_type;
     //!\brief Tag this class as input iterator.
-    using iterator_category = std::input_iterator_tag;
+    using iterator_category = typename std::iterator_traits<it_t>::iterator_category;
     //!\brief Tag this class depending on which concept `it_t` models.
     using iterator_concept = std::conditional_t<std::contiguous_iterator<it_t>,
                                                  typename std::random_access_iterator_tag,


### PR DESCRIPTION
For the minimiser view (#1654) I had problems preserving the forward_range properties, changing the tag in the kmer hash from input range to iterator_tag solved this problem.