### PR TITLE
Deprecate seqan3::value_type

### DIFF
--- a/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
+++ b/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
@@ -242,12 +242,12 @@ SEQAN3_CONCEPT aligned_sequence =
  */
 template <sequence_container aligned_seq_t>
 //!\cond
-    requires detail::is_gapped_alphabet<value_type_t<aligned_seq_t>>
+    requires detail::is_gapped_alphabet<std::iter_value_t<aligned_seq_t>>
 //!\endcond
 inline typename aligned_seq_t::iterator insert_gap(aligned_seq_t & aligned_seq,
                                                    typename aligned_seq_t::const_iterator pos_it)
 {
-    return aligned_seq.insert(pos_it, value_type_t<aligned_seq_t>{gap{}});
+    return aligned_seq.insert(pos_it, std::iter_value_t<aligned_seq_t>{gap{}});
 }
 
 /*!\brief An implementation of seqan3::aligned_sequence::insert_gap for sequence containers.
@@ -268,13 +268,13 @@ inline typename aligned_seq_t::iterator insert_gap(aligned_seq_t & aligned_seq,
  */
 template <sequence_container aligned_seq_t>
 //!\cond
-    requires detail::is_gapped_alphabet<value_type_t<aligned_seq_t>>
+    requires detail::is_gapped_alphabet<std::iter_value_t<aligned_seq_t>>
 //!\endcond
 inline typename aligned_seq_t::iterator insert_gap(aligned_seq_t & aligned_seq,
                                                    typename aligned_seq_t::const_iterator pos_it,
                                                    typename aligned_seq_t::size_type size)
 {
-    return aligned_seq.insert(pos_it, size, value_type_t<aligned_seq_t>{gap{}});
+    return aligned_seq.insert(pos_it, size, std::iter_value_t<aligned_seq_t>{gap{}});
 }
 
 /*!\brief An implementation of seqan3::aligned_sequence::erase_gap for sequence containers.
@@ -298,7 +298,7 @@ inline typename aligned_seq_t::iterator insert_gap(aligned_seq_t & aligned_seq,
  */
 template <sequence_container aligned_seq_t>
 //!\cond
-    requires detail::is_gapped_alphabet<value_type_t<aligned_seq_t>>
+    requires detail::is_gapped_alphabet<std::iter_value_t<aligned_seq_t>>
 //!\endcond
 inline typename aligned_seq_t::iterator erase_gap(aligned_seq_t & aligned_seq,
                                                   typename aligned_seq_t::const_iterator pos_it)
@@ -331,7 +331,7 @@ inline typename aligned_seq_t::iterator erase_gap(aligned_seq_t & aligned_seq,
  */
 template <sequence_container aligned_seq_t>
 //!\cond
-    requires detail::is_gapped_alphabet<value_type_t<aligned_seq_t>>
+    requires detail::is_gapped_alphabet<std::iter_value_t<aligned_seq_t>>
 //!\endcond
 inline typename aligned_seq_t::iterator erase_gap(aligned_seq_t & aligned_seq,
                                                   typename aligned_seq_t::const_iterator first,
@@ -368,7 +368,7 @@ inline typename aligned_seq_t::iterator erase_gap(aligned_seq_t & aligned_seq,
  */
 template <sequence_container aligned_seq_t, std::ranges::forward_range unaligned_sequence_type>
 //!\cond
-    requires detail::is_gapped_alphabet<value_type_t<aligned_seq_t>> &&
+    requires detail::is_gapped_alphabet<std::iter_value_t<aligned_seq_t>> &&
              weakly_assignable_from<reference_t<aligned_seq_t>, reference_t<unaligned_sequence_type>>
 //!\endcond
 inline void assign_unaligned(aligned_seq_t & aligned_seq, unaligned_sequence_type && unaligned_seq)

--- a/include/seqan3/alignment/matrix/detail/aligned_sequence_builder.hpp
+++ b/include/seqan3/alignment/matrix/detail/aligned_sequence_builder.hpp
@@ -153,7 +153,7 @@ public:
 
     /*!\brief Builds the aligned sequences from the given trace path.
      * \tparam trace_path_t The type of the trace path; must model std::ranges::input_range and
-     *                      std::same_as<value_type_t<trace_path_t>, seqan::detail::trace_directions> must evaluate to
+     *                      std::same_as<std::ranges::range_value_t<trace_path_t>, seqan::detail::trace_directions> must evaluate to
      *                      `true`.
      * \param[in] trace_path The trace path.
      * \returns seqan3::detail::aligned_sequence_builder::result_type with the built alignment.
@@ -168,7 +168,7 @@ public:
     template <std::ranges::input_range trace_path_t>
     result_type operator()(trace_path_t && trace_path)
     {
-        static_assert(std::same_as<value_type_t<trace_path_t>, trace_directions>,
+        static_assert(std::same_as<std::ranges::range_value_t<trace_path_t>, trace_directions>,
                       "The value type of the trace path must be seqan3::detail::trace_directions");
 
         result_type res{};

--- a/include/seqan3/alignment/matrix/detail/trace_iterator.hpp
+++ b/include/seqan3/alignment/matrix/detail/trace_iterator.hpp
@@ -22,7 +22,7 @@ namespace seqan3::detail
  *
  * \tparam matrix_iter_t The wrapped matrix iterator; must model seqan3::detail::two_dimensional_matrix_iterator and
  *                       the iterator's value type must be the same as seqan3::detail::trace_directions, i.e.
- *                       `std::same_as<value_type_t<matrix_iter_t>, trace_directions>` must evaluate to `true`.
+ *                       `std::same_as<std::iter_value_t<matrix_iter_t>, trace_directions>` must evaluate to `true`.
  *
  * \details
  *
@@ -32,7 +32,7 @@ template <two_dimensional_matrix_iterator matrix_iter_t>
 class trace_iterator : public trace_iterator_base<trace_iterator<matrix_iter_t>, matrix_iter_t>
 {
 private:
-    static_assert(std::same_as<value_type_t<matrix_iter_t>, trace_directions>,
+    static_assert(std::same_as<std::iter_value_t<matrix_iter_t>, trace_directions>,
                   "Value type of the underlying iterator must be trace_directions.");
 
     //!\brief The type of the base class.

--- a/include/seqan3/alignment/matrix/detail/trace_iterator_banded.hpp
+++ b/include/seqan3/alignment/matrix/detail/trace_iterator_banded.hpp
@@ -22,7 +22,7 @@ namespace seqan3::detail
  *
  * \tparam matrix_iter_t The wrapped matrix iterator; must model seqan3::detail::two_dimensional_matrix_iterator and
  *                       the iterator's value type must be the same as seqan3::detail::trace_directions, i.e.
- *                       `std::same_as<value_type_t<matrix_iter_t>, trace_directions>` must evaluate to `true`.
+ *                       `std::same_as<std::iter_value_t<matrix_iter_t>, trace_directions>` must evaluate to `true`.
  *
  * \details
  *
@@ -32,7 +32,7 @@ template <two_dimensional_matrix_iterator matrix_iter_t>
 class trace_iterator_banded : public trace_iterator_base<trace_iterator_banded<matrix_iter_t>, matrix_iter_t>
 {
 private:
-    static_assert(std::same_as<value_type_t<matrix_iter_t>, trace_directions>,
+    static_assert(std::same_as<std::iter_value_t<matrix_iter_t>, trace_directions>,
                   "Value type of the underlying iterator must be trace_directions.");
 
     //!\brief The type of the base class.

--- a/include/seqan3/alignment/matrix/detail/trace_iterator_base.hpp
+++ b/include/seqan3/alignment/matrix/detail/trace_iterator_base.hpp
@@ -28,7 +28,7 @@ namespace seqan3::detail
  * \tparam derived_t The derived iterator type.
  * \tparam matrix_iter_t The wrapped matrix iterator; must model seqan3::detail::two_dimensional_matrix_iterator and
  *                       the iterator's value type must be the same as seqan3::detail::trace_directions, i.e.
- *                       `std::same_as<value_type_t<matrix_iter_t>, trace_directions>` must evaluate to `true`.
+ *                       `std::same_as<std::iter_value_t<matrix_iter_t>, trace_directions>` must evaluate to `true`.
  *
  * \details
  *
@@ -62,7 +62,7 @@ template <typename derived_t, two_dimensional_matrix_iterator matrix_iter_t>
 class trace_iterator_base
 {
 private:
-    static_assert(std::same_as<value_type_t<matrix_iter_t>, trace_directions>,
+    static_assert(std::same_as<std::iter_value_t<matrix_iter_t>, trace_directions>,
                   "Value type of the underlying iterator must be seqan3::detail::trace_directions.");
 
     //!\brief Befriend with corresponding const_iterator.

--- a/include/seqan3/alignment/matrix/detail/two_dimensional_matrix.hpp
+++ b/include/seqan3/alignment/matrix/detail/two_dimensional_matrix.hpp
@@ -118,13 +118,13 @@ public:
      */
     template <std::ranges::forward_range entries_t>
     //!\cond
-        requires (std::convertible_to<value_type_t<entries_t>, value_type>)
+        requires (std::convertible_to<std::ranges::range_value_t<entries_t>, value_type>)
     //!\endcond
     two_dimensional_matrix(number_rows const row_dim, number_cols const col_dim, entries_t entries) :
         row_dim{row_dim.get()},
         col_dim{col_dim.get()}
     {
-        static_assert(std::move_constructible<value_type_t<entries_t>>, "The value type must be moveable.");
+        static_assert(std::move_constructible<std::ranges::range_value_t<entries_t>>, "The value type must be moveable.");
 
         assert(static_cast<size_t>(std::ranges::distance(entries)) == (row_dim.get() * col_dim.get()));
         storage.resize(row_dim.get() * col_dim.get());
@@ -345,7 +345,7 @@ public:
     * \{
     */
     //!\brief Value type of this iterator.
-    using value_type = value_type_t<storage_iterator>;
+    using value_type = std::iter_value_t<storage_iterator>;
     //!\brief Reference to `value_type`.
     using reference = reference_t<storage_iterator>;
     //!\brief The pointer type.

--- a/include/seqan3/alignment/pairwise/alignment_configurator.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_configurator.hpp
@@ -88,12 +88,12 @@ private:
     /*!\brief Auxiliary member types
      * \{
      */
-     //!\brief Range type with removed references.
-     using unref_range_type = std::remove_reference_t<range_type>;
-     //!\brief The type of the first sequence.
-    using first_seq_t  = std::tuple_element_t<0, value_type_t<std::ranges::iterator_t<unref_range_type>>>;
+    //!\brief Range type with removed references.
+    using unref_range_type = std::remove_reference_t<range_type>;
+    //!\brief The type of the first sequence.
+    using first_seq_t  = std::tuple_element_t<0, std::ranges::range_value_t<unref_range_type>>;
     //!\brief The type of the second sequence.
-    using second_seq_t = std::tuple_element_t<1, value_type_t<std::ranges::iterator_t<unref_range_type>>>;
+    using second_seq_t = std::tuple_element_t<1, std::ranges::range_value_t<unref_range_type>>;
     //!\}
 
 public:
@@ -101,7 +101,7 @@ public:
     constexpr static bool expects_tuple_like_value_type()
     {
         return tuple_like<alignment_config_type> &&
-               std::tuple_size_v<value_type_t<std::ranges::iterator_t<unref_range_type>>> == 2;
+               std::tuple_size_v<std::ranges::range_value_t<unref_range_type>> == 2;
     }
 
     //!\brief Tests whether the scoring scheme is set and can be invoked with the sequences passed.
@@ -113,8 +113,8 @@ public:
                                     decltype(get<align_cfg::scoring>(std::declval<alignment_config_type>()).value)
                                  >;
             return static_cast<bool>(scoring_scheme<scoring_type,
-                                                   value_type_t<first_seq_t>,
-                                                   value_type_t<second_seq_t>>);
+                                                   std::ranges::range_value_t<first_seq_t>,
+                                                   std::ranges::range_value_t<second_seq_t>>);
         }
         else
         {
@@ -251,8 +251,8 @@ public:
             // Configure the type-erased alignment function.
             // ----------------------------------------------------------------------------
 
-            using first_seq_t = std::tuple_element_t<0, value_type_t<sequences_t>>;
-            using second_seq_t = std::tuple_element_t<1, value_type_t<sequences_t>>;
+            using first_seq_t = std::tuple_element_t<0, std::ranges::range_value_t<sequences_t>>;
+            using second_seq_t = std::tuple_element_t<1, std::ranges::range_value_t<sequences_t>>;
 
             using wrapped_first_t  = type_reduce_view<first_seq_t &>;
             using wrapped_second_t = type_reduce_view<second_seq_t &>;

--- a/include/seqan3/contrib/parallel/buffer_queue.hpp
+++ b/include/seqan3/contrib/parallel/buffer_queue.hpp
@@ -114,7 +114,7 @@ public:
     }
 
     template <std::ranges::input_range range_type>
-        requires std::convertible_to<value_type_t<range_type>, value_type>
+        requires std::convertible_to<std::ranges::range_value_t<range_type>, value_type>
     buffer_queue(size_type const init_capacity, range_type && r) : buffer_queue{init_capacity}
     {
         std::ranges::copy(r, std::ranges::begin(buffer));

--- a/include/seqan3/core/type_traits/iterator.hpp
+++ b/include/seqan3/core/type_traits/iterator.hpp
@@ -157,7 +157,7 @@ struct iterator_tag<it_t>
 };
 
 template <typename it_t>
-    requires !std::input_iterator<it_t> && std::output_iterator<it_t, value_type_t<it_t>> &&
+    requires !std::input_iterator<it_t> && std::output_iterator<it_t, std::iter_value_t<it_t>> &&
              !requires { typename std::iterator_traits<it_t>::iterator_category; }
 struct iterator_tag<it_t>
 {

--- a/include/seqan3/io/alignment_file/format_bam.hpp
+++ b/include/seqan3/io/alignment_file/format_bam.hpp
@@ -451,7 +451,7 @@ inline void format_bam::read_alignment_record(stream_type & stream,
                 if (!tmp_cigar_vector.empty()) // only parse alignment if cigar information was given
                 {
                     assert(core.l_seq == (seq_length + offset_tmp + soft_clipping_end)); // sanity check
-                    using alph_t = value_type_t<decltype(get<1>(align))>;
+                    using alph_t = std::ranges::range_value_t<decltype(get<1>(align))>;
                     constexpr auto from_dna16 = detail::convert_through_char_representation<alph_t, sam_dna16>;
 
                     get<1>(align).reserve(seq_length);
@@ -496,7 +496,7 @@ inline void format_bam::read_alignment_record(stream_type & stream,
         }
         else
         {
-            using alph_t = value_type_t<decltype(seq)>;
+            using alph_t = std::ranges::range_value_t<decltype(seq)>;
             constexpr auto from_dna16 = detail::convert_through_char_representation<alph_t, sam_dna16>;
 
             for (auto [d1, d2] : seq_stream)
@@ -870,7 +870,7 @@ inline void format_bam::write_alignment_record([[maybe_unused]] stream_type &  s
         }
 
         // write seq (bit-compressed: sam_dna16 characters go into one byte)
-        using alph_t = value_type_t<seq_type>;
+        using alph_t = std::ranges::range_value_t<seq_type>;
         constexpr auto to_dna16 = detail::convert_through_char_representation<sam_dna16, alph_t>;
 
         auto sit = std::ranges::begin(seq);
@@ -1188,7 +1188,8 @@ inline std::string format_bam::get_tag_dict_str(sam_tag_dictionary const & tag_d
         {
             int32_t sz{static_cast<int32_t>(arg.size())};
             result.append(reinterpret_cast<char *>(&sz), 4);
-            result.append(reinterpret_cast<char const *>(arg.data()), arg.size() * sizeof(value_type_t<T>));
+            result.append(reinterpret_cast<char const *>(arg.data()),
+                          arg.size() * sizeof(std::ranges::range_value_t<T>));
         }
     };
 

--- a/include/seqan3/io/alignment_file/format_sam.hpp
+++ b/include/seqan3/io/alignment_file/format_sam.hpp
@@ -411,7 +411,7 @@ inline void format_sam::read_alignment_record(stream_type & stream,
 
     // these variables need to be stored to compute the ALIGNMENT
     int32_t ref_offset_tmp{};
-    value_type_t<decltype(header.ref_ids())> ref_id_tmp{};
+    std::ranges::range_value_t<decltype(header.ref_ids())> ref_id_tmp{};
     [[maybe_unused]] int32_t offset_tmp{};
     [[maybe_unused]] int32_t soft_clipping_end{};
     [[maybe_unused]] std::vector<cigar> tmp_cigar_vector{};
@@ -476,7 +476,7 @@ inline void format_sam::read_alignment_record(stream_type & stream,
     // -------------------------------------------------------------------------------------------------------------
     if constexpr (!detail::decays_to_ignore_v<mate_type>)
     {
-        value_type_t<decltype(header.ref_ids())> tmp_mate_ref_id{};
+        std::ranges::range_value_t<decltype(header.ref_ids())> tmp_mate_ref_id{};
         read_field(field_view, tmp_mate_ref_id); // RNEXT
 
         if (tmp_mate_ref_id == "=") // indicates "same as ref id"
@@ -541,7 +541,7 @@ inline void format_sam::read_alignment_record(stream_type & stream,
 
                     for (; seq_length > 0; --seq_length) // seq_length is not needed anymore
                     {
-                        get<1>(align).push_back(value_type_t<decltype(get<1>(align))>{}.assign_char(*tmp_iter));
+                        get<1>(align).push_back(std::ranges::range_value_t<decltype(get<1>(align))>{}.assign_char(*tmp_iter));
                         ++tmp_iter;
                     }
 

--- a/include/seqan3/io/alignment_file/format_sam_base.hpp
+++ b/include/seqan3/io/alignment_file/format_sam_base.hpp
@@ -317,7 +317,7 @@ inline void format_sam_base::construct_alignment(align_type                     
         else
         {
             using unaligned_t = remove_cvref_t<detail::unaligned_seq_t<decltype(get<0>(align))>>;
-            auto dummy_seq    = views::repeat_n(value_type_t<unaligned_t>{}, ref_length)
+            auto dummy_seq    = views::repeat_n(std::ranges::range_value_t<unaligned_t>{}, ref_length)
                               | std::views::transform(detail::access_restrictor_fn{});
             static_assert(std::same_as<unaligned_t, decltype(dummy_seq)>,
                           "No reference information was given so the type of the first alignment tuple position"
@@ -341,7 +341,7 @@ inline void format_sam_base::construct_alignment(align_type                     
         else
         {
             using unaligned_t = remove_cvref_t<detail::unaligned_seq_t<decltype(get<0>(align))>>;
-            assign_unaligned(get<0>(align), views::repeat_n(value_type_t<unaligned_t>{}, 0)
+            assign_unaligned(get<0>(align), views::repeat_n(std::ranges::range_value_t<unaligned_t>{}, 0)
                                             | std::views::transform(detail::access_restrictor_fn{}));
         }
     }
@@ -371,7 +371,7 @@ template <typename stream_view_type, std::ranges::forward_range target_range_typ
 inline void format_sam_base::read_field(stream_view_type && stream_view, target_range_type & target)
 {
     if (!is_char<'*'>(*std::ranges::begin(stream_view)))
-        std::ranges::copy(stream_view | views::char_to<value_type_t<target_range_type>>,
+        std::ranges::copy(stream_view | views::char_to<std::ranges::range_value_t<target_range_type>>,
                           std::ranges::back_inserter(target));
     else
         std::ranges::next(std::ranges::begin(stream_view)); // skip '*'
@@ -492,7 +492,7 @@ inline void format_sam_base::read_header(stream_view_type && stream_view,
         else if (is_char<'S'>(*std::ranges::begin(stream_view)))              // SQ (sequence dictionary) tag
         {
             ref_info_present_in_header = true;
-            value_type_t<decltype(hdr.ref_ids())> id;
+            std::ranges::range_value_t<decltype(hdr.ref_ids())> id;
             std::tuple<int32_t, std::string> info{};
 
             parse_tag_value(id);                                         // parse required SN (sequence name) tag

--- a/include/seqan3/io/alignment_file/input.hpp
+++ b/include/seqan3/io/alignment_file/input.hpp
@@ -152,11 +152,11 @@ SEQAN3_CONCEPT alignment_file_input_traits = requires (t v)
     // field::alignment
     // the alignment type cannot be configured.
     // Type of tuple entry 1 (reference) is set to
-    // 1) a std::ranges::subrange over value_type_t<typename t::ref_sequences> if reference information was given
+    // 1) a std::ranges::subrange over std::ranges::range_value_t<typename t::ref_sequences> if reference information was given
     // or 2) a "dummy" sequence type:
     // views::repeat_n(sequence_alphabet{}, size_t{}) | std::views::transform(detail::access_restrictor_fn{})
     // Type of tuple entry 2 (query) is set to
-    // 1) a std::ranges::subrange over value_type_t<typename t::ref_sequences> if reference information was given
+    // 1) a std::ranges::subrange over std::ranges::range_value_t<typename t::ref_sequences> if reference information was given
     // or 2) a "dummy" sequence type:
 };
 //!\endcond

--- a/include/seqan3/io/sequence_file/format_embl.hpp
+++ b/include/seqan3/io/sequence_file/format_embl.hpp
@@ -113,11 +113,11 @@ protected:
         {
             if (options.embl_genbank_complete_header)
             {
-                std::ranges::copy(idbuffer | views::char_to<value_type_t<id_type>>, std::ranges::back_inserter(id));
+                std::ranges::copy(idbuffer | views::char_to<std::ranges::range_value_t<id_type>>, std::ranges::back_inserter(id));
                 do
                 {
                     std::ranges::copy(stream_view | views::take_until_or_throw(is_char<'S'>)
-                                                  | views::char_to<value_type_t<id_type>>,
+                                                  | views::char_to<std::ranges::range_value_t<id_type>>,
                                  std::ranges::back_inserter(id));
                     id.push_back(*stream_it);
                     ++stream_it;
@@ -134,13 +134,13 @@ protected:
                 if (options.truncate_ids)
                 {
                     std::ranges::copy(stream_view | views::take_until_or_throw(is_blank || is_char<';'> || is_cntrl)
-                                                  | views::char_to<value_type_t<id_type>>,
+                                                  | views::char_to<std::ranges::range_value_t<id_type>>,
                                  std::ranges::back_inserter(id));
                 }
                 else
                 {
                     std::ranges::copy(stream_view | views::take_until_or_throw(is_char<';'>)
-                                                  | views::char_to<value_type_t<id_type>>,
+                                                  | views::char_to<std::ranges::range_value_t<id_type>>,
                                  std::ranges::back_inserter(id));
                 }
             }
@@ -176,7 +176,7 @@ protected:
                                         }
                                         return c;
                                     })
-                                  | views::char_to<value_type_t<seq_type>>,         // convert to actual target alphabet
+                                  | views::char_to<std::ranges::range_value_t<seq_type>>,         // convert to actual target alphabet
                          std::ranges::back_inserter(sequence));
         }
         else

--- a/include/seqan3/io/sequence_file/format_fasta.hpp
+++ b/include/seqan3/io/sequence_file/format_fasta.hpp
@@ -199,7 +199,7 @@ private:
                         at_delimiter = true;
                         break;
                     }
-                    id.push_back(assign_char_to(*it, value_type_t<id_type>{}));
+                    id.push_back(assign_char_to(*it, std::ranges::range_value_t<id_type>{}));
                 }
 
                 if (!at_delimiter)
@@ -212,7 +212,7 @@ private:
 
                 std::ranges::copy(stream_view | std::views::drop_while(is_id || is_blank)        // skip leading >
                                               | views::take_until_or_throw(is_cntrl || is_blank) // read ID until delimiter…
-                                              | views::char_to<value_type_t<id_type>>,
+                                              | views::char_to<std::ranges::range_value_t<id_type>>,
                                   std::ranges::back_inserter(id));                               // … ^A is old delimiter
 
                 // consume rest of line
@@ -236,7 +236,7 @@ private:
                         at_delimiter = true;
                         break;
                     }
-                    id.push_back(assign_char_to(*it, value_type_t<id_type>{}));
+                    id.push_back(assign_char_to(*it, std::ranges::range_value_t<id_type>{}));
                 }
 
                 if (!at_delimiter)
@@ -246,7 +246,7 @@ private:
 
                 std::ranges::copy(stream_view | views::take_line_or_throw                    // read line
                                               | std::views::drop_while(is_id || is_blank)    // skip leading >
-                                              | views::char_to<value_type_t<id_type>>,
+                                              | views::char_to<std::ranges::range_value_t<id_type>>,
                                   std::ranges::back_inserter(id));
             #endif // SEQAN3_WORKAROUND_VIEW_PERFORMANCE
             }
@@ -286,7 +286,7 @@ private:
                                         detail::make_printable(*it)};
                 }
 
-                seq.push_back(assign_char_to(*it, value_type_t<seq_type>{}));
+                seq.push_back(assign_char_to(*it, std::ranges::range_value_t<seq_type>{}));
             }
 
         #else // ↑↑↑ WORKAROUND | ORIGINAL ↓↓↓
@@ -304,7 +304,7 @@ private:
                                                 }
                                                 return c;
                                             })                                      // enforce legal alphabet
-                                          | views::char_to<value_type_t<seq_type>>, // convert to actual target alphabet
+                                          | views::char_to<std::ranges::range_value_t<seq_type>>, // convert to actual target alphabet
                               std::ranges::back_inserter(seq));
         #endif // SEQAN3_WORKAROUND_VIEW_PERFORMANCE
         }

--- a/include/seqan3/io/sequence_file/format_fastq.hpp
+++ b/include/seqan3/io/sequence_file/format_fastq.hpp
@@ -130,14 +130,14 @@ protected:
             if (options.truncate_ids)
             {
                 std::ranges::copy(stream_view | views::take_until_or_throw(is_cntrl || is_blank)
-                                              | views::char_to<value_type_t<id_type>>,
+                                              | views::char_to<std::ranges::range_value_t<id_type>>,
                                   std::ranges::back_inserter(id));
                 detail::consume(stream_view | views::take_line_or_throw);
             }
             else
             {
                 std::ranges::copy(stream_view | views::take_line_or_throw
-                                              | views::char_to<value_type_t<id_type>>,
+                                              | views::char_to<std::ranges::range_value_t<id_type>>,
                                   std::ranges::back_inserter(id));
             }
         }
@@ -163,7 +163,7 @@ protected:
                                         }
                                         return c;
                                     })
-                                        | views::char_to<value_type_t<seq_type>>,         // convert to actual target alphabet
+                                        | views::char_to<std::ranges::range_value_t<seq_type>>,         // convert to actual target alphabet
                               std::ranges::back_inserter(sequence));
             sequence_size_after = size(sequence);
         }
@@ -193,12 +193,12 @@ protected:
         {
             // seq_qual field implies that they are the same variable
             assert(std::addressof(sequence) == std::addressof(qualities));
-            std::ranges::copy(qview | views::char_to<typename value_type_t<qual_type>::quality_alphabet_type>,
+            std::ranges::copy(qview | views::char_to<typename std::ranges::range_value_t<qual_type>::quality_alphabet_type>,
                               begin(qualities) + sequence_size_before);
         }
         else if constexpr (!detail::decays_to_ignore_v<qual_type>)
         {
-            std::ranges::copy(qview | views::char_to<value_type_t<qual_type>>,
+            std::ranges::copy(qview | views::char_to<std::ranges::range_value_t<qual_type>>,
                               std::ranges::back_inserter(qualities));
         }
         else

--- a/include/seqan3/io/sequence_file/format_genbank.hpp
+++ b/include/seqan3/io/sequence_file/format_genbank.hpp
@@ -120,7 +120,7 @@ protected:
                 while (!is_char<'O'>(*std::ranges::begin(stream_view)))
                 {
                         std::ranges::copy(stream_view | views::take_line_or_throw
-                                                      | views::char_to<value_type_t<id_type>>,
+                                                      | views::char_to<std::ranges::range_value_t<id_type>>,
                                                         std::ranges::back_inserter(id));
                         id.push_back('\n');
                 }
@@ -132,7 +132,7 @@ protected:
                 auto read_id_until = [&stream_view, &id] (auto predicate)
                 {
                     std::ranges::copy(stream_view | views::take_until_or_throw(predicate)
-                                                  | views::char_to<value_type_t<id_type>>,
+                                                  | views::char_to<std::ranges::range_value_t<id_type>>,
                                       std::ranges::back_inserter(id));
                 };
 
@@ -168,7 +168,7 @@ protected:
                                                 }
                                                 return c;
                                             })
-                                          | views::char_to<value_type_t<seq_type>>,    // convert to actual target alphabet
+                                          | views::char_to<std::ranges::range_value_t<seq_type>>,    // convert to actual target alphabet
                                             std::ranges::back_inserter(sequence));
         }
         else

--- a/include/seqan3/io/sequence_file/input_format_concept.hpp
+++ b/include/seqan3/io/sequence_file/input_format_concept.hpp
@@ -114,7 +114,7 @@ SEQAN3_CONCEPT sequence_file_input_format = requires (detail::sequence_file_inpu
  *     [This is enforced by the concept checker!]
  *   * In this case the data read for that field shall be discarded by the format.
  *   * Instead of passing the fields seqan3::field::seq and seqan3::field::qual, you may also pass
- *     seqan3::field::seq_qual to both parameters. If you do, the seqan3::value_type_t of the argument must be
+ *     seqan3::field::seq_qual to both parameters. If you do, the std::ranges::range_value_t of the argument must be
  *     a specialisation of seqan3::qualified and the second template parameter to
  *     seqan3::sequence_file_input_options must be set to true.
  */

--- a/include/seqan3/io/sequence_file/output.hpp
+++ b/include/seqan3/io/sequence_file/output.hpp
@@ -585,7 +585,7 @@ protected:
                       "You may not select field::seq_qual and either of field::seq and field::qual at the same time.");
 
         if constexpr (!detail::decays_to_ignore_v<seq_qual_t>)
-            static_assert(detail::is_type_specialisation_of_v<value_type_t<seq_qual_t>, qualified>,
+            static_assert(detail::is_type_specialisation_of_v<std::ranges::range_value_t<seq_qual_t>, qualified>,
                           "The SEQ_QUAL field must contain a range over the seqan3::qualified alphabet.");
 
         assert(!format.valueless_by_exception());

--- a/include/seqan3/io/structure_file/format_vienna.hpp
+++ b/include/seqan3/io/structure_file/format_vienna.hpp
@@ -139,7 +139,7 @@ protected:
                 {
                     std::ranges::copy(stream_view | std::views::drop_while(is_id || is_blank) // skip leading >
                                                   | views::take_until_or_throw(is_cntrl || is_blank)
-                                                  | views::char_to<value_type_t<id_type>>,
+                                                  | views::char_to<std::ranges::range_value_t<id_type>>,
                                       std::ranges::back_inserter(id));
                     detail::consume(stream_view | views::take_line_or_throw);
                 }
@@ -147,7 +147,7 @@ protected:
                 {
                     std::ranges::copy(stream_view | std::views::drop_while(is_id || is_blank) // skip leading >
                                                   | views::take_line_or_throw
-                                                  | views::char_to<value_type_t<id_type>>,
+                                                  | views::char_to<std::ranges::range_value_t<id_type>>,
                                       std::ranges::back_inserter(id));
                 }
             }
@@ -184,7 +184,7 @@ protected:
                                                 }
                                               return c;
                                             })
-                                          | views::char_to<value_type_t<seq_type>>, // convert to actual target alphabet
+                                          | views::char_to<std::ranges::range_value_t<seq_type>>, // convert to actual target alphabet
                               std::ranges::back_inserter(seq));
         }
         else
@@ -199,7 +199,7 @@ protected:
             if constexpr (structured_seq_combined)
             {
                 assert(std::addressof(seq) == std::addressof(structure));
-                using alph_type = typename value_type_t<structure_type>::structure_alphabet_type;
+                using alph_type = typename std::ranges::range_value_t<structure_type>::structure_alphabet_type;
                 // We need the structure_length parameter to count the length of the structure while reading
                 // because we cannot infer it from the (already resized) structure_seq object.
                 auto res = std::ranges::copy(read_structure<alph_type>(stream_view), std::ranges::begin(structure));
@@ -210,7 +210,7 @@ protected:
             }
             else
             {
-                using alph_type = value_type_t<structure_type>;
+                using alph_type = std::ranges::range_value_t<structure_type>;
                 std::ranges::copy(read_structure<alph_type>(stream_view), std::ranges::back_inserter(structure));
                 structure_length = std::ranges::distance(structure);
 

--- a/include/seqan3/io/structure_file/input_format_concept.hpp
+++ b/include/seqan3/io/structure_file/input_format_concept.hpp
@@ -151,7 +151,7 @@ SEQAN3_CONCEPT structure_file_input_format = requires(detail::structure_file_inp
  *     [This is enforced by the concept checker!]
  *   * In this case the data read for that field shall be discarded by the format.
  *   * Instead of passing the fields seqan3::field::seq and seqan3::field::structure, you may also pass
- *     seqan3::field::structured_seq to both parameters. If you do, the seqan3::value_type_t of the argument must be
+ *     seqan3::field::structured_seq to both parameters. If you do, the std::ranges::range_value_t of the argument must be
  *     a specialisation of seqan3::structured_rna and the second template parameter to
  *     seqan3::structure_file_input_options must be set to true.
  */

--- a/include/seqan3/range/container/bitcompressed_vector.hpp
+++ b/include/seqan3/range/container/bitcompressed_vector.hpp
@@ -122,7 +122,7 @@ private:
     //!\cond
     //NOTE(h-2): it is entirely unclear to me why we need this
     template <typename t>
-        requires std::is_same_v<value_type_t<remove_cvref_t<t>>, alphabet_type>
+        requires std::is_same_v<std::ranges::range_value_t<remove_cvref_t<t>>, alphabet_type>
     static constexpr bool has_same_value_type_v = true;
     //!\endcond
 
@@ -163,7 +163,7 @@ public:
 
     /*!\brief Construct from a different range.
      * \tparam other_range_t The type of range to construct from; must satisfy std::ranges::input_range and
-     *                       std::common_reference_with<value_type_t<other_range_t>, value_type>.
+     *                       std::common_reference_with<std::ranges::range_value_t<other_range_t>, value_type>.
      * \param[in]      range The sequences to construct/assign from.
      *
      * ### Complexity
@@ -200,7 +200,7 @@ public:
 
     /*!\brief Construct from pair of iterators.
      * \tparam begin_iterator_type Must model std::forward_iterator and
-     *                             std::common_reference_with<value_type_t<begin_iterator_type>, value_type>.
+     *                             std::common_reference_with<std::iter_value_t<begin_iterator_type>, value_type>.
      * \tparam   end_iterator_type Must model std::sentinel_for.
      * \param[in]         begin_it Begin of range to construct/assign from.
      * \param[in]           end_it End of range to construct/assign from.
@@ -217,7 +217,7 @@ public:
     bitcompressed_vector(begin_iterator_type begin_it, end_iterator_type end_it)
     //!\cond
         requires std::sentinel_for<end_iterator_type, begin_iterator_type> &&
-                 std::common_reference_with<value_type_t<begin_iterator_type>, value_type>
+                 std::common_reference_with<std::iter_value_t<begin_iterator_type>, value_type>
     //!\endcond
     {
         insert(cend(), begin_it, end_it);
@@ -257,7 +257,7 @@ public:
 
     /*!\brief Assign from a different range.
      * \tparam other_range_t The type of range to be inserted; must satisfy std::ranges::input_range and
-     *                       std::common_reference_with<value_type_t<other_range_t>, value_type>.
+     *                       std::common_reference_with<std::ranges::range_value_t<other_range_t>, value_type>.
      * \param[in]      range The sequences to construct/assign from.
      *
      * ### Complexity
@@ -271,7 +271,7 @@ public:
     template <std::ranges::input_range other_range_t>
     void assign(other_range_t && range)
     //!\cond
-        requires std::common_reference_with<value_type_t<other_range_t>, value_type>
+        requires std::common_reference_with<std::ranges::range_value_t<other_range_t>, value_type>
     //!\endcond
     {
         bitcompressed_vector rhs{std::forward<other_range_t>(range)};
@@ -298,7 +298,7 @@ public:
 
     /*!\brief Assign from pair of iterators.
      * \tparam begin_iterator_type Must satisfy std::forward_iterator and
-     *                             std::common_reference_with<value_type_t<begin_iterator_type>, value_type>.
+     *                             std::common_reference_with<std::iter_value_t<begin_iterator_type>, value_type>.
      * \tparam   end_iterator_type Must satisfy std::sentinel_for.
      * \param[in]         begin_it Begin of range to construct/assign from.
      * \param[in]           end_it End of range to construct/assign from.
@@ -315,7 +315,7 @@ public:
     void assign(begin_iterator_type begin_it, end_iterator_type end_it)
     //!\cond
         requires std::sentinel_for<end_iterator_type, begin_iterator_type> &&
-                 std::common_reference_with<value_type_t<begin_iterator_type>, value_type>
+                 std::common_reference_with<std::iter_value_t<begin_iterator_type>, value_type>
     //!\endcond
     {
         bitcompressed_vector rhs{begin_it, end_it};
@@ -730,7 +730,7 @@ public:
 
     /*!\brief Inserts elements from range `[begin_it, end_it)` before position in the container.
      * \tparam begin_iterator_type Must satisfy std::forward_iterator and
-     *                             std::common_reference_with<value_type_t<begin_iterator_type>, value_type>.
+     *                             std::common_reference_with<std::iter_value_t<begin_iterator_type>, value_type>.
      * \tparam   end_iterator_type Must satisfy std::sentinel_for.
      * \param[in]              pos Iterator before which the content will be inserted. `pos` may be the end() iterator.
      * \param[in]         begin_it Begin of range to construct/assign from.
@@ -756,7 +756,7 @@ public:
     iterator insert(const_iterator pos, begin_iterator_type begin_it, end_iterator_type end_it)
     //!\cond
         requires std::sentinel_for<end_iterator_type, begin_iterator_type> &&
-                 std::common_reference_with<value_type_t<begin_iterator_type>, value_type>
+                 std::common_reference_with<std::iter_value_t<begin_iterator_type>, value_type>
     //!\endcond
     {
         auto const pos_as_num = std::distance(cbegin(), pos);

--- a/include/seqan3/range/decorator/gap_decorator.hpp
+++ b/include/seqan3/range/decorator/gap_decorator.hpp
@@ -98,7 +98,7 @@ public:
      * \{
      */
     //!\brief The variant type of the alphabet type and gap symbol type (see seqan3::gapped).
-    using value_type = gapped<value_type_t<inner_type>>;
+    using value_type = gapped<std::ranges::range_value_t<inner_type>>;
     //!\brief Use the value type as reference type because the underlying sequence must not be modified.
     using reference = value_type;
     //!\brief const_reference type equals reference type equals value type because the underlying sequence must not

--- a/include/seqan3/range/views/async_input_buffer.hpp
+++ b/include/seqan3/range/views/async_input_buffer.hpp
@@ -44,9 +44,9 @@ private:
         "The range parameter to async_input_buffer_view must be at least an std::ranges::InputRange.");
     static_assert(std::ranges::view<urng_t>,
         "The range parameter to async_input_buffer_view must model std::ranges::View.");
-    static_assert(std::movable<value_type_t<urng_t>>,
+    static_assert(std::movable<std::ranges::range_value_t<urng_t>>,
         "The range parameter to async_input_buffer_view must have a value_type that is std::Movable.");
-    static_assert(std::constructible_from<value_type_t<urng_t>, std::remove_reference_t<reference_t<urng_t>> &&>,
+    static_assert(std::constructible_from<std::ranges::range_value_t<urng_t>, std::remove_reference_t<reference_t<urng_t>> &&>,
         "The range parameter to async_input_buffer_view must have a value_type that is constructible by a moved "
         "value of its reference type.");
 
@@ -60,7 +60,7 @@ private:
         urng_t urange;
 
         //!\brief The buffer queue.
-        contrib::fixed_buffer_queue<value_type_t<urng_t>> buffer;
+        contrib::fixed_buffer_queue<std::ranges::range_value_t<urng_t>> buffer;
 
         //!\brief Thread that rebuffers in the background.
         std::thread producer;
@@ -97,7 +97,7 @@ public:
         };
 
         state_ptr = std::shared_ptr<state>(new state{std::move(_urng),
-                                                     contrib::fixed_buffer_queue<value_type_t<urng_t>>{buffer_size},
+                                                     contrib::fixed_buffer_queue<std::ranges::range_value_t<urng_t>>{buffer_size},
                                                      std::thread{}}, // thread is set/started below, needs rest of state
                                            deleter);
 
@@ -173,10 +173,10 @@ class async_input_buffer_view<urng_t>::async_input_buffer_iterator
     using sentinel_type = std::ranges::default_sentinel_t;
 
     //!\brief The pointer to the associated view.
-    contrib::fixed_buffer_queue<value_type_t<urng_t>> * buffer_ptr = nullptr;
+    contrib::fixed_buffer_queue<std::ranges::range_value_t<urng_t>> * buffer_ptr = nullptr;
 
     //!\brief The cached value this iterator holds.
-    mutable value_type_t<urng_t> cached_value;
+    mutable std::ranges::range_value_t<urng_t> cached_value;
 
     //!\brief Whether this iterator is at end (the buffer is empty and closed).
     bool at_end = false;
@@ -189,7 +189,7 @@ public:
     //!\brief Difference type.
     using difference_type   = difference_type_t<urng_iterator_type>;
     //!\brief Value type.
-    using value_type        = value_type_t<urng_iterator_type>;
+    using value_type        = std::iter_value_t<urng_iterator_type>;
     //!\brief Pointer type.
     using pointer           = value_type *;
     //!\brief Reference type.
@@ -214,7 +214,7 @@ public:
     ~async_input_buffer_iterator()                                          noexcept = default; //!< Defaulted.
 
     //!\brief Constructing from the underlying seqan3::async_input_buffer_view.
-    async_input_buffer_iterator(contrib::fixed_buffer_queue<value_type_t<urng_t>> & buffer) noexcept :
+    async_input_buffer_iterator(contrib::fixed_buffer_queue<std::ranges::range_value_t<urng_t>> & buffer) noexcept :
         buffer_ptr{&buffer}
     {
         ++(*this); // cache first value
@@ -329,9 +329,9 @@ struct async_input_buffer_fn
             "The range parameter to views::async_input_buffer must be at least an std::ranges::InputRange.");
         static_assert(std::ranges::viewable_range<urng_t>,
             "The range parameter to views::async_input_buffer cannot be a temporary of a non-view range.");
-        static_assert(std::movable<value_type_t<urng_t>>,
+        static_assert(std::movable<std::ranges::range_value_t<urng_t>>,
             "The range parameter to views::async_input_buffer must have a value_type that is std::Movable.");
-        static_assert(std::constructible_from<value_type_t<urng_t>, std::remove_reference_t<reference_t<urng_t>> &&>,
+        static_assert(std::constructible_from<std::ranges::range_value_t<urng_t>, std::remove_reference_t<reference_t<urng_t>> &&>,
             "The range parameter to views::async_input_buffer must have a value_type that is constructible by a moved "
             "value of its reference type.");
 
@@ -409,24 +409,24 @@ namespace seqan3::views
  *
  * ### View properties
  *
- * | concepts and reference type               | `urng_t` (underlying range type)  | `rrng_t` (returned range type)    |
- * |-------------------------------------------|:---------------------------------:|:---------------------------------:|
- * | std::ranges::input_range                  | *required*                        | *preserved*                       |
- * | std::ranges::forward_range                |                                   | *lost*                            |
- * | std::ranges::bidirectional_range          |                                   | *lost*                            |
- * | std::ranges::random_access_range          |                                   | *lost*                            |
- * | std::ranges::contiguous_range             |                                   | *lost*                            |
- * |                                           |                                   |                                   |
- * | std::ranges::viewable_range               | *required*                        | *guaranteed*                      |
- * | std::ranges::view                         |                                   | *guaranteed*                      |
- * | std::ranges::sized_range                  |                                   | *lost*                            |
- * | std::ranges::common_range                 |                                   | *lost*                            |
- * | std::ranges::output_range                 |                                   | *lost*                            |
- * | seqan3::const_iterable_range              |                                   | *lost*                            |
- * |                                           |                                   |                                   |
- * | std::ranges::range_reference_t            |                                   | `seqan3::value_type_t<urng_t> &`  |
- * |                                           |                                   |                                   |
- * | std::iterator_traits \::iterator_category |                                   | *none*                            |
+ * | concepts and reference type               | `urng_t` (underlying range type)  | `rrng_t` (returned range type)         |
+ * |-------------------------------------------|:---------------------------------:|:--------------------------------------:|
+ * | std::ranges::input_range                  | *required*                        | *preserved*                            |
+ * | std::ranges::forward_range                |                                   | *lost*                                 |
+ * | std::ranges::bidirectional_range          |                                   | *lost*                                 |
+ * | std::ranges::random_access_range          |                                   | *lost*                                 |
+ * | std::ranges::contiguous_range             |                                   | *lost*                                 |
+ * |                                           |                                   |                                        |
+ * | std::ranges::viewable_range               | *required*                        | *guaranteed*                           |
+ * | std::ranges::view                         |                                   | *guaranteed*                           |
+ * | std::ranges::sized_range                  |                                   | *lost*                                 |
+ * | std::ranges::common_range                 |                                   | *lost*                                 |
+ * | std::ranges::output_range                 |                                   | *lost*                                 |
+ * | seqan3::const_iterable_range              |                                   | *lost*                                 |
+ * |                                           |                                   |                                        |
+ * | std::ranges::range_reference_t            |                                   | `std::ranges::range_value_t<urng_t> &` |
+ * |                                           |                                   |                                        |
+ * | std::iterator_traits \::iterator_category |                                   | *none*                                 |
  *
  * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.
  *

--- a/include/seqan3/range/views/interleave.hpp
+++ b/include/seqan3/range/views/interleave.hpp
@@ -70,7 +70,7 @@ public:
     using const_reference   = detail::transformation_trait_or_t<
                                 ranges::common_reference<reference_t<urng_t const>, reference_t<inserted_rng_t const>>, void>;
     //!\brief The value_type (which equals the reference_type with any references removed).
-    using value_type        = value_type_t<urng_t>;
+    using value_type        = std::ranges::range_value_t<urng_t>;
     //!\brief This resolves to range_type::size_type as the underlying range is guaranteed to be Sized.
     using size_type         = size_type_t<urng_t>;
     //!\brief A signed integer type, usually std::ptrdiff_t.
@@ -356,22 +356,22 @@ namespace seqan3::views
  * `| ranges::view::chunk(step_size) | views::join(inserted_range)`
  * which returns a view with the following properties:
  *
- * | Concepts and traits              | `urng_t` (underlying range type)      | `rrng_t` (returned range type)  |
- * |----------------------------------|:-------------------------------------:|:-------------------------------:|
- * | std::ranges::input_range         | *required*                            | *preserved*                     |
- * | std::ranges::forward_range       | *required*                            | *lost*                          |
- * | std::ranges::bidirectional_range |                                       | *lost*                          |
- * | std::ranges::random_access_range |                                       | *lost*                          |
- * | std::ranges::contiguous_range    |                                       | *lost*                          |
- * |                                  |                                       |                                  |
- * | std::ranges::viewable_range      | *required*                            | *guaranteed*                    |
- * | std::ranges::view                |                                       | *guaranteed*                    |
- * | std::ranges::sized_range         |                                       | *lost*                          |
- * | std::ranges::common_range        |                                       | *lost*                          |
- * | std::ranges::output_range        |                                       | *lost*                          |
- * | seqan3::const_iterable_range     |                                       | *lost*                          |
- * |                                  |                                       |                                  |
- * | std::ranges::range_reference_t   |                                       | seqan3::value_type_t<urng_t>    |
+ * | Concepts and traits              | `urng_t` (underlying range type)      | `rrng_t` (returned range type)       |
+ * |----------------------------------|:-------------------------------------:|:------------------------------------:|
+ * | std::ranges::input_range         | *required*                            | *preserved*                          |
+ * | std::ranges::forward_range       | *required*                            | *lost*                               |
+ * | std::ranges::bidirectional_range |                                       | *lost*                               |
+ * | std::ranges::random_access_range |                                       | *lost*                               |
+ * | std::ranges::contiguous_range    |                                       | *lost*                               |
+ * |                                  |                                       |                                      |
+ * | std::ranges::viewable_range      | *required*                            | *guaranteed*                         |
+ * | std::ranges::view                |                                       | *guaranteed*                         |
+ * | std::ranges::sized_range         |                                       | *lost*                               |
+ * | std::ranges::common_range        |                                       | *lost*                               |
+ * | std::ranges::output_range        |                                       | *lost*                               |
+ * | seqan3::const_iterable_range     |                                       | *lost*                               |
+ * |                                  |                                       |                                      |
+ * | std::ranges::range_reference_t   |                                       | std::ranges::range_value_t<urng_t>   |
  *
  * * `urng_t` is the type of the range modified by this view (input).
  * * `rrng_type` is the type of the range returned by this view.

--- a/include/seqan3/range/views/kmer_hash.hpp
+++ b/include/seqan3/range/views/kmer_hash.hpp
@@ -494,7 +494,7 @@ public:
 
 private:
     //!\brief The alphabet type of the passed iterator.
-    using alphabet_t = value_type_t<it_t>;
+    using alphabet_t = std::iter_value_t<it_t>;
 
     //!\brief The alphabet size.
     static constexpr auto const sigma{alphabet_size<alphabet_t>};

--- a/include/seqan3/range/views/persist.hpp
+++ b/include/seqan3/range/views/persist.hpp
@@ -59,7 +59,7 @@ public:
     //!\brief The const_reference type is equal to the reference type.
     using const_reference   = reference;
     //!\brief The value_type (which equals the reference_type with any references removed).
-    using value_type        = value_type_t<urng_t>;
+    using value_type        = std::ranges::range_value_t<urng_t>;
     //!\brief If the underliying range is Sized, this resolves to range_type::size_type, otherwise void.
     using size_type         = detail::transformation_trait_or_t<seqan3::size_type<urng_t>, void>;
     //!\brief A signed integer type, usually std::ptrdiff_t.

--- a/include/seqan3/range/views/single_pass_input.hpp
+++ b/include/seqan3/range/views/single_pass_input.hpp
@@ -197,7 +197,7 @@ public:
     //!\brief Difference type.
     using difference_type   = difference_type_t<base_iterator_type>;
     //!\brief Value type.
-    using value_type        = value_type_t<base_iterator_type>;
+    using value_type        = std::iter_value_t<base_iterator_type>;
     //!\brief Pointer type.
     using pointer           = typename std::iterator_traits<base_iterator_type>::pointer;
     //!\brief Reference type.

--- a/include/seqan3/range/views/take.hpp
+++ b/include/seqan3/range/views/take.hpp
@@ -288,7 +288,7 @@ private:
     //!\brief The const_reference type is equal to the reference type if the underlying range is const-iterable.
     using const_reference   = detail::transformation_trait_or_t<seqan3::reference<urng_t const>, void>;
     //!\brief The value_type (which equals the reference_type with any references removed).
-    using value_type        = value_type_t<urng_t>;
+    using value_type        = std::ranges::range_value_t<urng_t>;
     //!\brief The size_type is `size_t` if the view is exact, otherwise `void`.
     using size_type         = std::conditional_t<exactly || std::ranges::sized_range<urng_t>,
                                                  transformation_trait_or_t<seqan3::size_type<urng_t>, size_t>,

--- a/include/seqan3/range/views/take_until.hpp
+++ b/include/seqan3/range/views/take_until.hpp
@@ -353,7 +353,7 @@ public:
     //!\brief The const_reference type is equal to the reference type if the underlying range is const-iterable.
     using const_reference   = detail::transformation_trait_or_t<seqan3::reference<urng_t const>, void>;
     //!\brief The value_type (which equals the reference_type with any references removed).
-    using value_type        = value_type_t<urng_t>;
+    using value_type        = std::ranges::range_value_t<urng_t>;
     //!\brief The size_type is void, because this range is never sized.
     using size_type         = void;
     //!\brief A signed integer type, usually std::ptrdiff_t.

--- a/include/seqan3/range/views/to_char.hpp
+++ b/include/seqan3/range/views/to_char.hpp
@@ -39,22 +39,22 @@ namespace seqan3::views
  * This view is a **deep view** Given a range-of-range as input (as opposed to just a range), it will apply
  * the transformation on the innermost range (instead of the outermost range).
  *
- * | Concepts and traits              | `urng_t` (underlying range type)      | `rrng_t` (returned range type)                     |
- * |----------------------------------|:-------------------------------------:|:--------------------------------------------------:|
- * | std::ranges::input_range         | *required*                            | *preserved*                                        |
- * | std::ranges::forward_range       |                                       | *preserved*                                        |
- * | std::ranges::bidirectional_range |                                       | *preserved*                                        |
- * | std::ranges::random_access_range |                                       | *preserved*                                        |
- * | std::ranges::contiguous_range    |                                       | *lost*                                             |
- * |                                  |                                       |                                                    |
- * | std::ranges::viewable_range      | *required*                            | *guaranteed*                                       |
- * | std::ranges::view                |                                       | *guaranteed*                                       |
- * | std::ranges::sized_range         |                                       | *preserved*                                        |
- * | std::ranges::common_range        |                                       | *preserved*                                        |
- * | std::ranges::output_range        |                                       | *lost*                                             |
- * | seqan3::const_iterable_range     |                                       | *preserved*                                        |
- * |                                  |                                       |                                                    |
- * | std::ranges::range_reference_t   | seqan3::alphabet                      | seqan3::alphabet_char_t<seqan3::value_type_t<urng_t>>   |
+ * | Concepts and traits              | `urng_t` (underlying range type)      | `rrng_t` (returned range type)                                |
+ * |----------------------------------|:-------------------------------------:|:-------------------------------------------------------------:|
+ * | std::ranges::input_range         | *required*                            | *preserved*                                                   |
+ * | std::ranges::forward_range       |                                       | *preserved*                                                   |
+ * | std::ranges::bidirectional_range |                                       | *preserved*                                                   |
+ * | std::ranges::random_access_range |                                       | *preserved*                                                   |
+ * | std::ranges::contiguous_range    |                                       | *lost*                                                        |
+ * |                                  |                                       |                                                               |
+ * | std::ranges::viewable_range      | *required*                            | *guaranteed*                                                  |
+ * | std::ranges::view                |                                       | *guaranteed*                                                  |
+ * | std::ranges::sized_range         |                                       | *preserved*                                                   |
+ * | std::ranges::common_range        |                                       | *preserved*                                                   |
+ * | std::ranges::output_range        |                                       | *lost*                                                        |
+ * | seqan3::const_iterable_range     |                                       | *preserved*                                                   |
+ * |                                  |                                       |                                                               |
+ * | std::ranges::range_reference_t   | seqan3::alphabet                      | seqan3::alphabet_char_t<std::ranges::range_value_t<urng_t>>   |
  *
  * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.
  *

--- a/include/seqan3/range/views/to_rank.hpp
+++ b/include/seqan3/range/views/to_rank.hpp
@@ -54,7 +54,7 @@ namespace seqan3::views
  * | std::ranges::output_range        |                                       | *lost*                                             |
  * | seqan3::const_iterable_range     |                                       | *preserved*                                        |
  * |                                  |                                       |                                                    |
- * | std::ranges::range_reference_t   | seqan3::alphabet                      | seqan3::alphabet_rank_t<seqan3::value_type_t<urng_t>>   |
+ * | std::ranges::range_reference_t   | seqan3::alphabet                      | seqan3::alphabet_rank_t<std::ranges::range_value_t<urng_t>>   |
  *
  * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.
  *

--- a/include/seqan3/range/views/to_rank.hpp
+++ b/include/seqan3/range/views/to_rank.hpp
@@ -39,21 +39,21 @@ namespace seqan3::views
  * This view is a **deep view** Given a range-of-range as input (as opposed to just a range), it will apply
  * the transformation on the innermost range (instead of the outermost range).
  *
- * | Concepts and traits              | `urng_t` (underlying range type)      | `rrng_t` (returned range type)                     |
- * |----------------------------------|:-------------------------------------:|:--------------------------------------------------:|
- * | std::ranges::input_range         | *required*                            | *preserved*                                        |
- * | std::ranges::forward_range       |                                       | *preserved*                                        |
- * | std::ranges::bidirectional_range |                                       | *preserved*                                        |
- * | std::ranges::random_access_range |                                       | *preserved*                                        |
- * | std::ranges::contiguous_range    |                                       | *lost*                                             |
- * |                                  |                                       |                                                    |
- * | std::ranges::viewable_range      | *required*                            | *guaranteed*                                       |
- * | std::ranges::view                |                                       | *guaranteed*                                       |
- * | std::ranges::sized_range         |                                       | *preserved*                                        |
- * | std::ranges::common_range        |                                       | *preserved*                                        |
- * | std::ranges::output_range        |                                       | *lost*                                             |
- * | seqan3::const_iterable_range     |                                       | *preserved*                                        |
- * |                                  |                                       |                                                    |
+ * | Concepts and traits              | `urng_t` (underlying range type)      | `rrng_t` (returned range type)                                |
+ * |----------------------------------|:-------------------------------------:|:-------------------------------------------------------------:|
+ * | std::ranges::input_range         | *required*                            | *preserved*                                                   |
+ * | std::ranges::forward_range       |                                       | *preserved*                                                   |
+ * | std::ranges::bidirectional_range |                                       | *preserved*                                                   |
+ * | std::ranges::random_access_range |                                       | *preserved*                                                   |
+ * | std::ranges::contiguous_range    |                                       | *lost*                                                        |
+ * |                                  |                                       |                                                               |
+ * | std::ranges::viewable_range      | *required*                            | *guaranteed*                                                  |
+ * | std::ranges::view                |                                       | *guaranteed*                                                  |
+ * | std::ranges::sized_range         |                                       | *preserved*                                                   |
+ * | std::ranges::common_range        |                                       | *preserved*                                                   |
+ * | std::ranges::output_range        |                                       | *lost*                                                        |
+ * | seqan3::const_iterable_range     |                                       | *preserved*                                                   |
+ * |                                  |                                       |                                                               |
  * | std::ranges::range_reference_t   | seqan3::alphabet                      | seqan3::alphabet_rank_t<std::ranges::range_value_t<urng_t>>   |
  *
  * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.

--- a/include/seqan3/range/views/trim.hpp
+++ b/include/seqan3/range/views/trim.hpp
@@ -79,8 +79,8 @@ namespace seqan3::views
 
 /*!\brief               A view that does quality-threshold trimming on a range of seqan3::quality_alphabet.
  * \tparam urng_t       The type of the range being processed. See below for requirements.
- * \tparam threshold_t  Either seqan3::value_type_t<urng_t> or
- *                      seqan3::alphabet_phred_t<seqan3::value_type_t<urng_t>>.
+ * \tparam threshold_t  Either std::ranges::range_value_t<urng_t> or
+ *                      seqan3::alphabet_phred_t<std::ranges::range_value_t<urng_t>>.
  * \param[in] urange    The range being processed. [parameter is omitted in pipe notation]
  * \param[in] threshold The minimum quality.
  * \returns             A trimmed range. See below for the properties of the returned range.

--- a/test/snippet/alignment/pairwise/alignment_configurator.cpp
+++ b/test/snippet/alignment/pairwise/alignment_configurator.cpp
@@ -5,8 +5,8 @@ int main()
     using sequences_t = std::vector<std::pair<std::string, std::string>>;
     using config_t = decltype(seqan3::align_cfg::edit | seqan3::align_cfg::result{seqan3::with_score});
 
-    using first_seq_t = std::tuple_element_t<0, seqan3::value_type_t<std::remove_reference_t<sequences_t>>>;
-    using second_seq_t = std::tuple_element_t<1, seqan3::value_type_t<std::remove_reference_t<sequences_t>>>;
+    using first_seq_t = std::tuple_element_t<0, std::ranges::range_value_t<std::remove_reference_t<sequences_t>>>;
+    using second_seq_t = std::tuple_element_t<1, std::ranges::range_value_t<std::remove_reference_t<sequences_t>>>;
 
     // Select the result type based on the sequences and the configuration.
     using result_t = seqan3::alignment_result<typename seqan3::detail::align_result_selector<std::remove_reference_t<first_seq_t>,

--- a/test/snippet/alignment/pairwise/alignment_configurator.cpp
+++ b/test/snippet/alignment/pairwise/alignment_configurator.cpp
@@ -5,8 +5,8 @@ int main()
     using sequences_t = std::vector<std::pair<std::string, std::string>>;
     using config_t = decltype(seqan3::align_cfg::edit | seqan3::align_cfg::result{seqan3::with_score});
 
-    using first_seq_t = std::tuple_element_t<0, std::ranges::range_value_t<std::remove_reference_t<sequences_t>>>;
-    using second_seq_t = std::tuple_element_t<1, std::ranges::range_value_t<std::remove_reference_t<sequences_t>>>;
+    using first_seq_t = std::tuple_element_t<0, std::ranges::range_value_t<sequences_t>>;
+    using second_seq_t = std::tuple_element_t<1, std::ranges::range_value_t<sequences_t>>;
 
     // Select the result type based on the sequences and the configuration.
     using result_t = seqan3::alignment_result<typename seqan3::detail::align_result_selector<std::remove_reference_t<first_seq_t>,

--- a/test/unit/alignment/matrix/detail/aligned_sequence_builder_test.cpp
+++ b/test/unit/alignment/matrix/detail/aligned_sequence_builder_test.cpp
@@ -44,8 +44,8 @@ struct aligned_sequence_builder_fixture : ::testing::Test
     using fst_seq_t = std::tuple_element_t<0, test_type>;
     using sec_seq_t = std::tuple_element_t<1, test_type>;
 
-    using fst_seq_value_t = seqan3::value_type_t<fst_seq_t>;
-    using sec_seq_value_t = seqan3::value_type_t<sec_seq_t>;
+    using fst_seq_value_t = std::ranges::range_value_t<fst_seq_t>;
+    using sec_seq_value_t = std::ranges::range_value_t<sec_seq_t>;
 
     using type_param = seqan3::detail::aligned_sequence_builder<fst_seq_t, sec_seq_t>;
 

--- a/test/unit/alignment/matrix/detail/alignment_matrix_base_test_template.hpp
+++ b/test/unit/alignment/matrix/detail/alignment_matrix_base_test_template.hpp
@@ -34,7 +34,7 @@ TYPED_TEST_SUITE_P(alignment_matrix_base_test);
 TYPED_TEST_P(alignment_matrix_base_test, range_concepts)
 {
     using outer_it = std::ranges::iterator_t<typename TestFixture::matrix_t>;
-    using column_t = seqan3::value_type_t<outer_it>;
+    using column_t = std::iter_value_t<outer_it>;
     using inner_it = std::ranges::iterator_t<column_t>;
 
     EXPECT_TRUE(std::ranges::input_range<typename TestFixture::matrix_t>);

--- a/test/unit/alignment/matrix/detail/alignment_matrix_column_major_range_test.cpp
+++ b/test/unit/alignment/matrix/detail/alignment_matrix_column_major_range_test.cpp
@@ -96,7 +96,7 @@ protected:
 TEST(alignment_matrix_column_major_range_base, concepts)
 {
     using outer_it = std::ranges::iterator_t<test_matrix>;
-    using column_t = seqan3::value_type_t<outer_it>;
+    using column_t = std::iter_value_t<outer_it>;
     using inner_it = std::ranges::iterator_t<column_t>;
 
     EXPECT_TRUE(std::ranges::input_range<test_matrix>);

--- a/test/unit/alignment/pairwise/fixture/alignment_fixture.hpp
+++ b/test/unit/alignment/pairwise/fixture/alignment_fixture.hpp
@@ -75,7 +75,7 @@ struct alignment_fixture
 
     auto score_matrix() const requires !seqan3::detail::matrix<score_vector_or_matrix_t>
     {
-        seqan3::detail::row_wise_matrix<value_type_t<score_vector_or_matrix_t>>
+        seqan3::detail::row_wise_matrix<std::ranges::range_value_t<score_vector_or_matrix_t>>
             score_matrix{seqan3::detail::number_rows{sequence2.size() + 1},
                          seqan3::detail::number_cols{sequence1.size() + 1},
                          score_vector};
@@ -89,7 +89,7 @@ struct alignment_fixture
 
     auto trace_matrix() const requires !seqan3::detail::matrix<trace_vector_or_matrix_t>
     {
-        seqan3::detail::row_wise_matrix<value_type_t<trace_vector_or_matrix_t>>
+        seqan3::detail::row_wise_matrix<std::ranges::range_value_t<trace_vector_or_matrix_t>>
             trace_matrix{seqan3::detail::number_rows{sequence2.size() + 1},
                          seqan3::detail::number_cols{sequence1.size() + 1},
                          trace_vector};

--- a/test/unit/core/simd/view_to_simd_test.cpp
+++ b/test/unit/core/simd/view_to_simd_test.cpp
@@ -37,7 +37,7 @@ public:
                                            std::allocator<simd_t>,
                                            seqan3::aligned_allocator<simd_t, sizeof(simd_t)>>;
 
-    static constexpr size_t padding_value_dna4 = seqan3::alphabet_size<seqan3::value_type_t<container_t>>;
+    static constexpr size_t padding_value_dna4 = seqan3::alphabet_size<std::ranges::range_value_t<container_t>>;
     static constexpr size_t padding_value_custom = 8;
     static constexpr size_t max_sequence_length = seqan3::simd::simd_traits<simd_t>::length * 64;
 
@@ -48,7 +48,7 @@ public:
         {
             // Generate sequences that end on different boundaries
             size_t l = max_sequence_length - (i * seqan3::simd::simd_traits<simd_t>::length) - i;
-            std::ranges::copy(seqan3::test::generate_sequence<seqan3::value_type_t<container_t>>(l),
+            std::ranges::copy(seqan3::test::generate_sequence<std::iter_value_t<container_t>>(l),
                               std::ranges::back_inserter(sequences[i]));
         }
 

--- a/test/unit/core/type_list_test.cpp
+++ b/test/unit/core/type_list_test.cpp
@@ -99,9 +99,9 @@ TEST(pack_traits, drop_front)
 
 TEST(pack_traits, transform)
 {
-    EXPECT_TRUE((std::is_same_v<seqan3::pack_traits::transform<seqan3::value_type_t>,
+    EXPECT_TRUE((std::is_same_v<seqan3::pack_traits::transform<std::ranges::range_value_t>,
                                 seqan3::type_list<>>));
-    EXPECT_TRUE((std::is_same_v<seqan3::pack_traits::transform<seqan3::value_type_t, std::vector<int>, std::list<bool>>,
+    EXPECT_TRUE((std::is_same_v<seqan3::pack_traits::transform<std::ranges::range_value_t, std::vector<int>, std::list<bool>>,
                                 seqan3::type_list<int, bool>>));
     EXPECT_TRUE((std::is_same_v<seqan3::pack_traits::transform<seqan3::reference_t, std::vector<int>, std::list<bool>>,
                                 seqan3::type_list<int &, bool &>>));
@@ -321,10 +321,10 @@ TEST(list_traits, split_after)
 
 TEST(list_traits, transform)
 {
-    EXPECT_TRUE((std::is_same_v<seqan3::list_traits::transform<seqan3::value_type_t,
+    EXPECT_TRUE((std::is_same_v<seqan3::list_traits::transform<std::ranges::range_value_t,
                                                                seqan3::type_list<>>,
                                 seqan3::type_list<>>));
-    EXPECT_TRUE((std::is_same_v<seqan3::list_traits::transform<seqan3::value_type_t,
+    EXPECT_TRUE((std::is_same_v<seqan3::list_traits::transform<std::ranges::range_value_t,
                                                                seqan3::type_list<std::vector<int>, std::list<bool>>>,
                                 seqan3::type_list<int, bool>>));
     EXPECT_TRUE((std::is_same_v<seqan3::list_traits::transform<seqan3::reference_t,

--- a/test/unit/core/type_traits/range_iterator_test.cpp
+++ b/test/unit/core/type_traits/range_iterator_test.cpp
@@ -72,16 +72,14 @@ TEST(range_and_iterator, value_type_)
     using foreign_iterator = seqan3::detail::random_access_iterator<std::vector<int>>;
     auto v = std::views::iota(1);
 
-    using type_list_example = seqan3::type_list<seqan3::value_type_t<std::vector<int>>, // short
-                                                typename seqan3::value_type<std::vector<int>>::type, // long
+    using type_list_example = seqan3::type_list<std::ranges::range_value_t<std::vector<int>>, // short
                                                 typename std::vector<int>::value_type, // member type
-                                                seqan3::value_type_t<std::vector<int> const>, // const container
-                                                seqan3::value_type_t<iterator_of_int_vector>, // iterator
-                                                seqan3::value_type_t<foreign_iterator>, // iterator2
-                                                seqan3::value_type_t<decltype(v)>>; // range, no member
+                                                std::ranges::range_value_t<std::vector<int> const>, // const container
+                                                std::iter_value_t<iterator_of_int_vector>, // iterator
+                                                std::iter_value_t<foreign_iterator>, // iterator2
+                                                std::ranges::range_value_t<decltype(v)>>; // range, no member
 
     using comp_list = seqan3::type_list<int,
-                                        int,
                                         int,
                                         int,
                                         int,

--- a/test/unit/range/views/view_single_pass_input_test.cpp
+++ b/test/unit/range/views/view_single_pass_input_test.cpp
@@ -181,7 +181,7 @@ TYPED_TEST(single_pass_input, iterator_pre_increment)
     seqan3::detail::single_pass_input_view view{p};
 
     auto it = view.begin();
-    if constexpr (std::is_same_v<seqan3::value_type_t<TypeParam>, char>)
+    if constexpr (std::is_same_v<std::ranges::range_value_t<TypeParam>, char>)
     {
         EXPECT_EQ(*it,   '1');
         EXPECT_EQ(*++it, '2');
@@ -207,7 +207,7 @@ TYPED_TEST(single_pass_input, iterator_post_increment)
 
     auto it = view.begin();
 
-    if constexpr (std::is_same_v<seqan3::value_type_t<TypeParam>, char>)
+    if constexpr (std::is_same_v<std::ranges::range_value_t<TypeParam>, char>)
     {
         EXPECT_EQ(*it, '1');
         it++;
@@ -320,7 +320,7 @@ TYPED_TEST(single_pass_input, fn_functional)
     auto view = p | seqan3::views::single_pass_input | seqan3::views::take(3);
     auto it = view.begin();
 
-    if constexpr (std::is_same_v<seqan3::value_type_t<TypeParam>, char>)
+    if constexpr (std::is_same_v<std::ranges::range_value_t<TypeParam>, char>)
     {
         EXPECT_EQ(*it,   '1');
         EXPECT_EQ(*++it, '2');
@@ -342,7 +342,7 @@ TYPED_TEST(single_pass_input, fn_pipeable)
 
     auto view = p | seqan3::views::single_pass_input | std::views::take(3);
     auto it = view.begin();
-    if constexpr (std::is_same_v<seqan3::value_type_t<TypeParam>, char>)
+    if constexpr (std::is_same_v<std::ranges::range_value_t<TypeParam>, char>)
     {
         EXPECT_EQ(*it,   '1');
         EXPECT_EQ(*++it, '2');

--- a/test/unit/range/views/view_translate_join_test.cpp
+++ b/test/unit/range/views/view_translate_join_test.cpp
@@ -182,9 +182,9 @@ TYPED_TEST(nucleotide, view_translate_concepts)
     EXPECT_TRUE(std::ranges::random_access_range<decltype(v1)>);
     EXPECT_TRUE(std::ranges::sized_range<decltype(v1)>);
     EXPECT_TRUE(std::ranges::view<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::random_access_range<seqan3::value_type_t<decltype(v1)>>);
-    EXPECT_TRUE(std::ranges::sized_range<seqan3::value_type_t<decltype(v1)>>);
-    EXPECT_TRUE(std::ranges::view<seqan3::value_type_t<decltype(v1)>>);
+    EXPECT_TRUE(std::ranges::random_access_range<std::ranges::range_value_t<decltype(v1)>>);
+    EXPECT_TRUE(std::ranges::sized_range<std::ranges::range_value_t<decltype(v1)>>);
+    EXPECT_TRUE(std::ranges::view<std::ranges::range_value_t<decltype(v1)>>);
     EXPECT_TRUE(std::ranges::random_access_range<seqan3::reference_t<decltype(v1)>>);
     EXPECT_TRUE(std::ranges::sized_range<seqan3::reference_t<decltype(v1)>>);
     EXPECT_TRUE(std::ranges::view<seqan3::reference_t<decltype(v1)>>);

--- a/test/unit/range/views/view_translate_test.cpp
+++ b/test/unit/range/views/view_translate_test.cpp
@@ -221,7 +221,7 @@ TYPED_TEST(nucleotide, view_translate_single_concepts)
     EXPECT_TRUE(std::ranges::random_access_range<decltype(v1)>);
     EXPECT_TRUE(std::ranges::sized_range<decltype(v1)>);
     EXPECT_TRUE(std::ranges::view<decltype(v1)>);
-    EXPECT_TRUE((std::is_same_v<seqan3::aa27, seqan3::value_type_t<decltype(v1)>>));
+    EXPECT_TRUE((std::is_same_v<seqan3::aa27, std::ranges::range_value_t<decltype(v1)>>));
     EXPECT_TRUE((std::is_same_v<seqan3::aa27, seqan3::reference_t<decltype(v1)>>));
 }
 
@@ -239,9 +239,9 @@ TYPED_TEST(nucleotide, view_translate_concepts)
     EXPECT_TRUE(std::ranges::random_access_range<decltype(v1)>);
     EXPECT_TRUE(std::ranges::sized_range<decltype(v1)>);
     EXPECT_TRUE(std::ranges::view<decltype(v1)>);
-    EXPECT_TRUE(std::ranges::random_access_range<seqan3::value_type_t<decltype(v1)>>);
-    EXPECT_TRUE(std::ranges::sized_range<seqan3::value_type_t<decltype(v1)>>);
-    EXPECT_TRUE(std::ranges::view<seqan3::value_type_t<decltype(v1)>>);
+    EXPECT_TRUE(std::ranges::random_access_range<std::ranges::range_value_t<decltype(v1)>>);
+    EXPECT_TRUE(std::ranges::sized_range<std::ranges::range_value_t<decltype(v1)>>);
+    EXPECT_TRUE(std::ranges::view<std::ranges::range_value_t<decltype(v1)>>);
     EXPECT_TRUE(std::ranges::random_access_range<seqan3::reference_t<decltype(v1)>>);
     EXPECT_TRUE(std::ranges::sized_range<seqan3::reference_t<decltype(v1)>>);
     EXPECT_TRUE(std::ranges::view<seqan3::reference_t<decltype(v1)>>);

--- a/test/unit/search/fm_index/fm_index_collection_test_template.hpp
+++ b/test/unit/search/fm_index/fm_index_collection_test_template.hpp
@@ -22,7 +22,7 @@ TYPED_TEST_P(fm_index_collection_test, ctr)
 {
     using index_t = typename TypeParam::first_type;
     using text_t = typename TypeParam::second_type;
-    using inner_text_type = seqan3::value_type_t<text_t>;
+    using inner_text_type = std::ranges::range_value_t<text_t>;
 
     text_t text{inner_text_type(10), inner_text_type(10)}; // initialized with smallest char
 
@@ -72,7 +72,7 @@ TYPED_TEST_P(fm_index_collection_test, swap)
 {
     using index_t = typename TypeParam::first_type;
     using text_t = typename TypeParam::second_type;
-    using inner_text_type = seqan3::value_type_t<text_t>;
+    using inner_text_type = std::ranges::range_value_t<text_t>;
 
     text_t textA{inner_text_type(10), inner_text_type(10)};
     text_t textB{inner_text_type(20), inner_text_type(20)};
@@ -105,7 +105,7 @@ TYPED_TEST_P(fm_index_collection_test, size)
 {
     using index_t = typename TypeParam::first_type;
     using text_t = typename TypeParam::second_type;
-    using inner_text_type = seqan3::value_type_t<text_t>;
+    using inner_text_type = std::ranges::range_value_t<text_t>;
 
     index_t fm;
     EXPECT_TRUE(fm.empty());
@@ -146,7 +146,7 @@ TYPED_TEST_P(fm_index_collection_test, serialisation)
 {
     using index_t = typename TypeParam::first_type;
     using text_t = typename TypeParam::second_type;
-    using inner_text_type = seqan3::value_type_t<text_t>;
+    using inner_text_type = std::ranges::range_value_t<text_t>;
 
     text_t text{inner_text_type(4), inner_text_type(12)};
 


### PR DESCRIPTION
Resolves part of #1549 

Replaces occurrences of ```seqan3::value_type<...>``` with ```std::iter_value_t ``` or ```std::ranges::range_difference_t```.

```seqan3::value_type2``` is introduced for occurrences where ```seqan3::value_type``` is used for both ranges and iterators and thus no ``std``` one could be used.  

Code will not pass the automatic tests at this time due to the deprecation tag in ```/include/seqan3/core/type_traits```.
``` 
template <typename t>
using value_type_t = typename value_type<t>::type; 
``` 
in ```core/type_traits/pre.hpp```  ([here](https://github.com/wvandertoorn/seqan3/blob/f03c5f870c3e28ee4156446925419e067f96cfa1/include/seqan3/core/type_traits/pre.hpp#L48)) uses the deprecated ```value_type```. @marehr is working on how to deal with this.
