### PR TITLE
[MISC] Use correct definition of std::span<T, E> (extent should be std::size_t)

### DIFF
--- a/include/seqan3/io/detail/magic_header.hpp
+++ b/include/seqan3/io/detail/magic_header.hpp
@@ -94,7 +94,7 @@ struct bgzf_compression
      * \param[in] header The header to validate.
      * \returns `true` if it is a bgzf header, otherwise `false`.
      */
-    template <typename char_t, ptrdiff_t extend>
+    template <typename char_t, size_t extend>
     static bool validate_header(std::span<char_t, extend> header)
     {
         static_assert(seqan3::detail::weakly_equality_comparable_with<char_t, char>,

--- a/include/seqan3/std/span
+++ b/include/seqan3/std/span
@@ -35,13 +35,13 @@
 
 namespace std
 {
-inline constexpr ptrdiff_t dynamic_extent = -1;
-template <typename span_tp, ptrdiff_t span_extent = dynamic_extent> class span;
+inline constexpr size_t dynamic_extent = -1;
+template <typename span_tp, size_t span_extent = dynamic_extent> class span;
 
 template <class span_tp>
 struct is_span_impl : public false_type {};
 
-template <class span_tp, ptrdiff_t span_extent>
+template <class span_tp, size_t span_extent>
 struct is_span_impl<span<span_tp, span_extent>> : public true_type {};
 
 template <class span_tp>
@@ -75,7 +75,7 @@ inline constexpr bool enable_safe_range<span_tp> = true;
 
 namespace std
 {
-template <typename span_tp, ptrdiff_t span_extent>
+template <typename span_tp, size_t span_extent>
 class span {
 public:
 //  constants and types
@@ -134,7 +134,7 @@ public:
 
 //  ~span() noexcept = default;
 
-    template <ptrdiff_t count>
+    template <size_t count>
     inline constexpr span<element_type, count> first() const noexcept
     {
         static_assert(count >= 0, "Count must be >= 0 in span::first()");
@@ -142,7 +142,7 @@ public:
         return {data(), count};
     }
 
-    template <ptrdiff_t count>
+    template <size_t count>
     inline constexpr span<element_type, count> last() const noexcept
     {
         static_assert(count >= 0, "Count must be >= 0 in span::last()");
@@ -162,7 +162,7 @@ public:
         return {data() + size() - count, count};
     }
 
-    template <ptrdiff_t offset, ptrdiff_t count = dynamic_extent>
+    template <size_t offset, size_t count = dynamic_extent>
     inline constexpr auto subspan() const noexcept
         -> span<element_type, count != dynamic_extent ? count : span_extent - offset>
     {
@@ -298,7 +298,7 @@ public:
     constexpr span(range_t && rng) : data_{ranges::data(rng)}, size_{static_cast<index_type>(ranges::size(rng))}
     {}
 
-    template <class OtherElementType, ptrdiff_t _OtherExtent>
+    template <class OtherElementType, size_t _OtherExtent>
     inline constexpr span(const span<OtherElementType, _OtherExtent>& other,
                        enable_if_t<
                           is_convertible_v<OtherElementType(*)[], element_type (*)[]>,
@@ -307,7 +307,7 @@ public:
 
 //    ~span() noexcept = default;
 
-    template <ptrdiff_t count>
+    template <size_t count>
     inline constexpr span<element_type, count> first() const noexcept
     {
         static_assert(count >= 0, "Count must be >= 0 in span::first()");
@@ -315,7 +315,7 @@ public:
         return {data(), count};
     }
 
-    template <ptrdiff_t count>
+    template <size_t count>
     inline constexpr span<element_type, count> last() const noexcept
     {
         static_assert(count >= 0, "Count must be >= 0 in span::last()");
@@ -335,7 +335,7 @@ public:
         return {data() + size() - count, count};
     }
 
-    template <ptrdiff_t offset, ptrdiff_t count = dynamic_extent>
+    template <size_t offset, size_t count = dynamic_extent>
     inline constexpr span<span_tp, dynamic_extent> subspan() const noexcept
     {
         assert(offset >= 0 && offset <= size());
@@ -414,30 +414,30 @@ private:
     index_type size_;
 };
 
-template <typename span_tp, ptrdiff_t extend>
+template <typename span_tp, size_t extend>
 constexpr auto begin(span<span_tp, extend> s) noexcept
 {
     return s.begin();
 }
 
-template <typename span_tp, ptrdiff_t extend>
+template <typename span_tp, size_t extend>
 constexpr auto end(span<span_tp, extend> s) noexcept
 {
     return s.end();
 }
 
 //  as_bytes & as_writeable_bytes
-template <class span_tp, ptrdiff_t span_extent>
+template <class span_tp, size_t span_extent>
     auto as_bytes(span<span_tp, span_extent> s) noexcept
     -> decltype(s.as_bytes())
     { return s.as_bytes(); }
 
-template <class span_tp, ptrdiff_t span_extent>
+template <class span_tp, size_t span_extent>
     auto as_writeable_bytes(span<span_tp, span_extent> s) noexcept
     -> typename enable_if<!is_const_v<span_tp>, decltype(s.as_writeable_bytes())>::type
     { return s.as_writeable_bytes(); }
 
-template <class span_tp, ptrdiff_t span_extent>
+template <class span_tp, size_t span_extent>
     constexpr void swap(span<span_tp, span_extent> &lhs, span<span_tp, span_extent> &rhs) noexcept
     { lhs.swap(rhs); }
 

--- a/include/seqan3/std/span
+++ b/include/seqan3/std/span
@@ -58,15 +58,9 @@ struct is_std_array : public is_std_array_impl<remove_cv_t<span_tp>> {};
 
 } // namespace std
 
-#if RANGE_V3_VERSION >= 901
+#if RANGE_V3_VERSION >= 1000
 namespace ranges
 {
-// forward declare in case we deal with an old version (between >= 0.9.1 and < 0.10.0) of ranges v3
-#if RANGE_V3_VERSION < 1000
-template<class span_tp>
-inline constexpr bool enable_safe_range;
-#endif // RANGE_V3_VERSION < 1000
-
 template<typename span_tp, std::size_t span_sz>
 inline constexpr bool enable_safe_range<std::span<span_tp, span_sz>> = true;
 
@@ -75,7 +69,7 @@ inline constexpr bool enable_safe_range<std::span<span_tp, span_sz>> = true;
 template<typename span_tp, std::size_t span_sz>
 inline constexpr bool enable_view<std::span<span_tp, span_sz>> = span_sz + 1 < 2;
 } // namespace ranges
-#endif // RANGE_V3_VERSION >= 901
+#endif // RANGE_V3_VERSION >= 1000
 
 namespace std
 {

--- a/include/seqan3/std/span
+++ b/include/seqan3/std/span
@@ -67,9 +67,13 @@ template<class span_tp>
 inline constexpr bool enable_safe_range;
 #endif // RANGE_V3_VERSION < 1000
 
-template<class span_tp>
-    requires std::is_span<span_tp>::value
-inline constexpr bool enable_safe_range<span_tp> = true;
+template<typename span_tp, std::size_t span_sz>
+inline constexpr bool enable_safe_range<std::span<span_tp, span_sz>> = true;
+
+// we follow the definition of the ranges library for enable_view:
+// https://github.com/ericniebler/range-v3/blob/6103268542c27210dbc3f99f1fa0c1e348b52184/include/range/v3/range/concepts.hpp#L201
+template<typename span_tp, std::size_t span_sz>
+inline constexpr bool enable_view<std::span<span_tp, span_sz>> = span_sz + 1 < 2;
 } // namespace ranges
 #endif // RANGE_V3_VERSION >= 901
 


### PR DESCRIPTION
Extracted from PR #1702 to make this change better trackable.

Do we need a changelog entry for this?