### PR TITLE
[MISC] Disable auto deduction of traits type in unbanded edit distance algorithm

### DIFF
--- a/include/seqan3/alignment/pairwise/align_result_selector.hpp
+++ b/include/seqan3/alignment/pairwise/align_result_selector.hpp
@@ -52,7 +52,8 @@ struct align_result_selector
 {
 private:
     //!\brief The user configured score type.
-    using score_type = typename alignment_configuration_traits<configuration_t>::original_score_type;
+    using score_type = typename alignment_configuration_traits<
+                                    std::remove_reference_t<configuration_t>>::original_score_type;
 
     //!\brief Helper function to determine the actual result type.
     static constexpr auto select()

--- a/include/seqan3/alignment/pairwise/detail/type_traits.hpp
+++ b/include/seqan3/alignment/pairwise/detail/type_traits.hpp
@@ -12,6 +12,8 @@
 
 #pragma once
 
+#include <type_traits>
+
 #include <seqan3/alignment/configuration/align_config_aligned_ends.hpp>
 #include <seqan3/alignment/configuration/align_config_band.hpp>
 #include <seqan3/alignment/configuration/align_config_debug.hpp>
@@ -65,7 +67,7 @@ struct chunked_indexed_sequence_pairs
  */
 template <typename configuration_t>
 //!\cond
-    requires is_type_specialisation_of_v<configuration_t, configuration>
+    requires is_type_specialisation_of_v<std::remove_cv_t<configuration_t>, configuration>
 //!\endcond
 struct alignment_configuration_traits
 {

--- a/include/seqan3/alignment/pairwise/edit_distance_fwd.hpp
+++ b/include/seqan3/alignment/pairwise/edit_distance_fwd.hpp
@@ -131,7 +131,7 @@ using edit_distance_base =
 template <std::ranges::viewable_range database_t,
           std::ranges::viewable_range query_t,
           typename align_config_t,
-          typename traits_t = default_edit_distance_trait_type<database_t, query_t, align_config_t, std::false_type>>
+          typename traits_t>
 class edit_distance_unbanded; //forward declaration
 //!\endcond
 

--- a/include/seqan3/alignment/pairwise/edit_distance_unbanded.hpp
+++ b/include/seqan3/alignment/pairwise/edit_distance_unbanded.hpp
@@ -865,7 +865,7 @@ public:
     edit_distance_unbanded(database_t _database,
                            query_t _query,
                            align_config_t _config,
-                           edit_traits const & SEQAN3_DOXYGEN_ONLY(_traits) = edit_traits{}) :
+                           edit_traits const & SEQAN3_DOXYGEN_ONLY(_traits)) :
         database{std::forward<database_t>(_database)},
         query{std::forward<query_t>(_query)},
         config{std::forward<align_config_t>(_config)},
@@ -1168,11 +1168,6 @@ bool edit_distance_unbanded<database_t, query_t, align_config_t, traits_t>::larg
  * \relates seqan3::detail::edit_distance_unbanded
  * \{
  */
-
-//!\brief Deduce the type from the provided arguments.
-template <typename database_t, typename query_t, typename config_t>
-edit_distance_unbanded(database_t && database, query_t && query, config_t config)
-    -> edit_distance_unbanded<database_t, query_t, config_t>;
 
 //!\brief Deduce the type from the provided arguments.
 template <typename database_t, typename query_t, typename config_t, typename traits_t>

--- a/test/performance/alignment/edit_distance_unbanded_benchmark.cpp
+++ b/test/performance/alignment/edit_distance_unbanded_benchmark.cpp
@@ -61,9 +61,14 @@ void seqan3_edit_distance_dna4(benchmark::State & state)
     auto seq2 = generate_sequence<seqan3::dna4>(sequence_length, 0, 1);
     int score = 0;
 
+    using edit_traits_t = seqan3::detail::default_edit_distance_trait_type<std::add_lvalue_reference_t<decltype(seq1)>,
+                                                                           std::add_lvalue_reference_t<decltype(seq2)>,
+                                                                           decltype(edit_distance_cfg),
+                                                                           std::false_type>;
+
     for (auto _ : state)
     {
-        seqan3::detail::edit_distance_unbanded edit_distance{seq1, seq2, edit_distance_cfg};
+        seqan3::detail::edit_distance_unbanded edit_distance{seq1, seq2, edit_distance_cfg, edit_traits_t{}};
         edit_distance(0u);
         score += edit_distance.score().value_or(0u);
     }
@@ -135,11 +140,19 @@ void seqan3_edit_distance_dna4_collection(benchmark::State & state)
     auto vec = generate_sequence_pairs<seqan3::dna4>(sequence_length, set_size);
     int score = 0;
 
+    using seq1_t = std::tuple_element_t<0, std::ranges::range_value_t<decltype(vec)>>;
+    using seq2_t = std::tuple_element_t<1, std::ranges::range_value_t<decltype(vec)>>;
+
+    using edit_traits_t = seqan3::detail::default_edit_distance_trait_type<std::add_lvalue_reference_t<seq1_t>,
+                                                                           std::add_lvalue_reference_t<seq2_t>,
+                                                                           decltype(edit_distance_cfg),
+                                                                           std::false_type>;
+
     for (auto _ : state)
     {
         for (auto && [seq1, seq2] : vec)
         {
-            seqan3::detail::edit_distance_unbanded edit_distance{seq1, seq2, edit_distance_cfg};
+            seqan3::detail::edit_distance_unbanded edit_distance{seq1, seq2, edit_distance_cfg, edit_traits_t{}};
             edit_distance(0u);
             score += edit_distance.score().value_or(0u);
         }

--- a/test/unit/alignment/pairwise/edit_distance_unbanded_test_template.hpp
+++ b/test/unit/alignment/pairwise/edit_distance_unbanded_test_template.hpp
@@ -80,7 +80,7 @@ auto edit_distance(database_t && database, query_t && query, align_cfg_t && alig
 {
     using edit_traits = edit_traits_type<compute_score_matrix, database_t, query_t, align_cfg_t>;
     using algorithm_t = seqan3::detail::edit_distance_unbanded<database_t, query_t, align_cfg_t, edit_traits>;
-    auto alignment = algorithm_t{database, query, align_cfg};
+    auto alignment = algorithm_t{database, query, align_cfg, edit_traits{}};
 
     // compute alignment
     alignment(0u);


### PR DESCRIPTION
So it works to pass in the callback function.
Part of #1692

This change has no further implications as only an internal implementation is adapted which is wrapped by a specific calling interface.