### PR TITLE
Pass result to alignment/add alignment function traits

### DIFF
--- a/include/seqan3/alignment/pairwise/detail/type_traits.hpp
+++ b/include/seqan3/alignment/pairwise/detail/type_traits.hpp
@@ -26,6 +26,7 @@
 #include <seqan3/core/bit_manipulation.hpp>
 #include <seqan3/core/simd/simd_traits.hpp>
 #include <seqan3/core/simd/simd.hpp>
+#include <seqan3/core/type_traits/function.hpp>
 #include <seqan3/core/type_traits/template_inspection.hpp>
 #include <seqan3/range/views/chunk.hpp>
 #include <seqan3/range/views/zip.hpp>
@@ -33,6 +34,10 @@
 
 namespace seqan3::detail
 {
+
+//------------------------------------------------------------------------------
+// chunked_indexed_sequence_pairs
+//------------------------------------------------------------------------------
 
 /*!\brief A transformation trait to retrieve the chunked range over indexed sequence pairs.
  * \ingroup pairwise_alignment
@@ -55,6 +60,10 @@ struct chunked_indexed_sequence_pairs
     //!\brief The transformed type that models seqan3::detail::indexed_sequence_pair_range.
     using type = decltype(views::zip(std::declval<sequence_pairs_t>(), std::views::iota(0)) | views::chunk(1));
 };
+
+//------------------------------------------------------------------------------
+// alignment_configuration_traits
+//------------------------------------------------------------------------------
 
 /*!\brief A traits type for the alignment algorithm that exposes static information stored within the alignment
  *        configuration object.
@@ -115,6 +124,26 @@ struct alignment_configuration_traits
     //!\brief The padding symbol to use for the computation of the alignment.
     static constexpr original_score_type padding_symbol =
         static_cast<original_score_type>(1u << (sizeof_bits<original_score_type> - 1));
+};
+
+//------------------------------------------------------------------------------
+// alignment_function_traits
+//------------------------------------------------------------------------------
+
+/*!\brief A traits class to provide a uniform access to the properties of the wrapped alignment algorithm.
+ * \ingroup pairwise_alignment
+ *
+ * \tparam function_t The type of the std::function object that stores the alignment algorithm as the target.
+ */
+template <typename function_t>
+struct alignment_function_traits
+{
+    //!\brief The type of the sequence input to the alignment algorithm.
+    using sequence_input_type = typename function_traits<function_t>::template argument_type_at<0>;
+    //!\brief The type of the callback function called when a result was computed.
+    using callback_type = typename function_traits<function_t>::template argument_type_at<1>;
+    //!\brief The type of the alignment result to be computed.
+    using alignment_result_type = typename function_traits<callback_type>::template argument_type_at<0>;
 };
 
 }  // namespace seqan3::detail

--- a/test/unit/alignment/pairwise/detail/CMakeLists.txt
+++ b/test/unit/alignment/pairwise/detail/CMakeLists.txt
@@ -1,0 +1,1 @@
+seqan3_test(type_traits_test.cpp)

--- a/test/unit/alignment/pairwise/detail/type_traits_test.cpp
+++ b/test/unit/alignment/pairwise/detail/type_traits_test.cpp
@@ -1,0 +1,30 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include <seqan3/alignment/pairwise/detail/type_traits.hpp>
+#include <seqan3/std/concepts>
+
+TEST(traits, alignment_function_traits)
+{
+    using result_callback_t = std::function<void(int)>;  // The callback type.
+    using algorithm_t = std::function<void(std::string, result_callback_t)>; // The algorithm type.
+
+    // Get the traits class and evaluate the member types.
+    using function_traits_t =  seqan3::detail::alignment_function_traits<algorithm_t>;
+
+    using input_t = typename function_traits_t::sequence_input_type;
+    using callback_t = typename function_traits_t::callback_type;
+    using alignment_result_t = typename function_traits_t::alignment_result_type;
+
+    EXPECT_TRUE((std::same_as<input_t, std::string>));
+    EXPECT_TRUE((std::same_as<callback_t, result_callback_t>));
+    EXPECT_TRUE((std::same_as<alignment_result_t, int>));
+}


### PR DESCRIPTION
Part of #1692 
Allows to extract the respective parameters for the returned function object wrapping the alignment algorithm. This allows later to determine the actual result type from the passed callback and decouples the configuration from the implementation of the algorithm.