### PR TITLE
[DOC] Improve tutorial section 'Sequence file I/O'

### DIFF
--- a/doc/tutorial/sequence_file/index.md
+++ b/doc/tutorial/sequence_file/index.md
@@ -42,7 +42,7 @@ Currently, SeqAn supports the following file formats:
 For instance, you need to have *zlib* installed for reading `.gz` files and *libbz2* for reading `.bz2` files.
 You can check whether you have installed these libraries by running `cmake .` in your build directory.
 If `-- Optional dependency: ZLIB-x.x.x found.` is displayed on the command line then you can read/write
-compressed files in your programs. TODO what about bz2
+compressed files in your programs.
 
 ## Basic layout of SeqAn file objects
 
@@ -130,7 +130,7 @@ The formerly introduced formats can be identified by the following file name ext
 | EMBL        | seqan3::format_embl  |   `.embl`                                         |
 
 
-You can access the valid file extension via the `file_extension` member variable in a format:
+You can access the valid file extension via the `file_extensions` member variable in a format:
 
 \snippet doc/tutorial/sequence_file/sequence_file_snippets.cpp file_extensions
 

--- a/doc/tutorial/sequence_file/sequence_file_snippets.cpp
+++ b/doc/tutorial/sequence_file/sequence_file_snippets.cpp
@@ -1,6 +1,5 @@
 #include <fstream>
-
-#include <range/v3/numeric/accumulate.hpp>   // ranges::accumulate
+#include <numeric> // std::accumulate 
 //![include_ranges_chunk]
 #include <range/v3/view/chunk.hpp>
 //![include_ranges_chunk]
@@ -155,7 +154,7 @@ seqan3::sequence_file_input fin{std::filesystem::temp_directory_path()/"my.fastq
 auto minimum_quality_filter = std::views::filter([] (auto const & rec)
 {
     auto qual = seqan3::get<seqan3::field::qual>(rec) | std::views::transform([] (auto q) { return q.to_phred(); });
-    double sum = ranges::accumulate(qual.begin(), qual.end(), 0);
+    double sum = std::accumulate(qual.begin(), qual.end(), 0);
     return sum / std::ranges::size(qual) >= 40; // minimum average quality >= 40
 });
 

--- a/test/snippet/io/sequence_file/sequence_file_input_record_iter.cpp
+++ b/test/snippet/io/sequence_file/sequence_file_input_record_iter.cpp
@@ -12,14 +12,13 @@ GGAGTATAATATATATATATATAT)";
 
 int main()
 {
-    using seqan3::get;
 
     seqan3::sequence_file_input fin{std::istringstream{input}, seqan3::format_fasta{}};
 
     for (auto & rec : fin)
     {
-        seqan3::debug_stream << "ID:  " << get<seqan3::field::id>(rec) << '\n';
-        seqan3::debug_stream << "SEQ: " << get<seqan3::field::seq>(rec) << '\n';
+        seqan3::debug_stream << "ID:  " << seqan3::get<seqan3::field::id>(rec) << '\n';
+        seqan3::debug_stream << "SEQ: " << seqan3::get<seqan3::field::seq>(rec) << '\n';
         // a quality field also exists, but is not printed, because we know it's empty for FastA files.
     }
 }


### PR DESCRIPTION
Resolves part of #1608

Combination of small fixes:
[DOC] 1.6.1 Remove 'TODO' in warning.
[DOC] 1.6.2 fix typo in file extension member 'file_extensions'
[DOC] 1.6.3 Remove "using seqan3::get;"
[DOC] 1.6.4 Use 'std::accumulate' in snippet