### PR TITLE
[MISC] Replace seqan::reference_t with std::ranges::range_reference_t/std::iter_reference_t

### DIFF
--- a/doc/howto/write_a_view/solution_view.cpp
+++ b/doc/howto/write_a_view/solution_view.cpp
@@ -14,7 +14,7 @@ class my_iterator : public seqan3::detail::inherited_iterator_base<my_iterator<u
                                                                    std::ranges::iterator_t<urng_t>>
 {
 private:
-    static_assert(seqan3::nucleotide_alphabet<seqan3::reference_t<urng_t>>,
+    static_assert(seqan3::nucleotide_alphabet<std::ranges::range_reference_t<urng_t>>,
                   "You can only iterate over ranges of nucleotides!");
 
     // the immediate base type is the CRTP-layer

--- a/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
+++ b/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
@@ -203,8 +203,8 @@ namespace seqan3
 template <typename t>
 SEQAN3_CONCEPT aligned_sequence =
     std::ranges::forward_range<t> &&
-    alphabet<reference_t<t>> &&
-    weakly_assignable_from<reference_t<t>, gap const &> &&
+    alphabet<std::ranges::range_reference_t<t>> &&
+    weakly_assignable_from<std::ranges::range_reference_t<t>, gap const &> &&
     requires { typename detail::unaligned_seq_t<t>; } &&
     requires (t v, detail::unaligned_seq_t<t> unaligned)
     {
@@ -369,7 +369,8 @@ inline typename aligned_seq_t::iterator erase_gap(aligned_seq_t & aligned_seq,
 template <sequence_container aligned_seq_t, std::ranges::forward_range unaligned_sequence_type>
 //!\cond
     requires detail::is_gapped_alphabet<std::iter_value_t<aligned_seq_t>> &&
-             weakly_assignable_from<reference_t<aligned_seq_t>, reference_t<unaligned_sequence_type>>
+             weakly_assignable_from<std::ranges::range_reference_t<aligned_seq_t>,
+                                    std::ranges::range_reference_t<unaligned_sequence_type>>
 //!\endcond
 inline void assign_unaligned(aligned_seq_t & aligned_seq, unaligned_sequence_type && unaligned_seq)
 {

--- a/include/seqan3/alignment/matrix/detail/two_dimensional_matrix.hpp
+++ b/include/seqan3/alignment/matrix/detail/two_dimensional_matrix.hpp
@@ -347,7 +347,7 @@ public:
     //!\brief Value type of this iterator.
     using value_type = std::iter_value_t<storage_iterator>;
     //!\brief Reference to `value_type`.
-    using reference = reference_t<storage_iterator>;
+    using reference = std::iter_reference_t<storage_iterator>;
     //!\brief The pointer type.
     using pointer = typename storage_iterator::pointer;
     //!\brief Type for distances between iterators.

--- a/include/seqan3/alignment/pairwise/edit_distance_fwd.hpp
+++ b/include/seqan3/alignment/pairwise/edit_distance_fwd.hpp
@@ -84,7 +84,7 @@ struct default_edit_distance_trait_type
     //!\brief The type of an iterator of the database sequence.
     using database_iterator = std::ranges::iterator_t<database_type>;
     //!\brief The alphabet type of the query sequence.
-    using query_alphabet_type = std::remove_reference_t<reference_t<query_type>>;
+    using query_alphabet_type = std::remove_reference_t<std::ranges::range_reference_t<query_type>>;
     //!\brief The intermediate result type of the execution of this function object.
     using result_value_type = typename align_result_selector<database_type, query_type, align_config_type>::type;
 

--- a/include/seqan3/alphabet/aminoacid/translation.hpp
+++ b/include/seqan3/alphabet/aminoacid/translation.hpp
@@ -128,7 +128,7 @@ constexpr aa27 translate_triplet SEQAN3_DEPRECATED_310 (tuple_type const & input
  */
 template <genetic_code gc = genetic_code::CANONICAL, std::ranges::input_range range_type>
 //!\cond
-    requires nucleotide_alphabet<reference_t<std::decay_t<range_type>>>
+    requires nucleotide_alphabet<std::ranges::range_reference_t<std::decay_t<range_type>>>
 //!\endcond
 constexpr aa27 translate_triplet SEQAN3_DEPRECATED_310 (range_type && input_range)
 {
@@ -164,7 +164,7 @@ constexpr aa27 translate_triplet SEQAN3_DEPRECATED_310 (range_type && input_rang
  */
 template <genetic_code gc = genetic_code::CANONICAL, std::ranges::random_access_range rng_t>
 //!\cond
-    requires nucleotide_alphabet<reference_t<std::decay_t<rng_t>>>
+    requires nucleotide_alphabet<std::ranges::range_reference_t<std::decay_t<rng_t>>>
 //!\endcond
 constexpr aa27 translate_triplet SEQAN3_DEPRECATED_310 (rng_t && input_range)
 {

--- a/include/seqan3/core/detail/debug_stream_range.hpp
+++ b/include/seqan3/core/detail/debug_stream_range.hpp
@@ -39,8 +39,8 @@ SEQAN3_CONCEPT debug_stream_range_guard =
     !std::same_as<remove_cvref_t<std::ranges::range_reference_t<rng_t>>,
                                 remove_cvref_t<rng_t>> && // prevent recursive instantiation
     // exclude null-terminated strings:
-    !(std::is_pointer_v<std::decay_t<rng_t>> && std::same_as<remove_cvref_t<std::ranges::range_reference_t<rng_t>>,
-                                                            char>);
+    !(std::is_pointer_v<std::decay_t<rng_t>> &&
+      std::same_as<remove_cvref_t<std::ranges::range_reference_t<rng_t>>, char>);
 
 /*!\brief Helper template variable that checks if the reference type of a range can be streamed into an instance of
  *        seqan3::debug_stream_type .

--- a/include/seqan3/core/detail/debug_stream_range.hpp
+++ b/include/seqan3/core/detail/debug_stream_range.hpp
@@ -30,15 +30,17 @@ namespace seqan3::detail
  * This concept refines the std::ranges::input_range concept to allow streaming the range object to the debug stream,
  * with the following requirements:
  *
- * * `rng_t` is not the same type as `reference_t<rng_t>`,
+ * * `rng_t` is not the same type as `std::ranges::range_reference_t<rng_t>`,
  * * `rng_t` is not a pointer or c-style array,
- * * `reference_t<rng_t>` is not `char`.
+ * * `std::ranges::range_reference_t<rng_t>` is not `char`.
  */
 template <typename rng_t>
 SEQAN3_CONCEPT debug_stream_range_guard =
-    !std::same_as<remove_cvref_t<reference_t<rng_t>>, remove_cvref_t<rng_t>> && // prevent recursive instantiation
+    !std::same_as<remove_cvref_t<std::ranges::range_reference_t<rng_t>>,
+                                remove_cvref_t<rng_t>> && // prevent recursive instantiation
     // exclude null-terminated strings:
-    !(std::is_pointer_v<std::decay_t<rng_t>> && std::same_as<remove_cvref_t<reference_t<rng_t>>, char>);
+    !(std::is_pointer_v<std::decay_t<rng_t>> && std::same_as<remove_cvref_t<std::ranges::range_reference_t<rng_t>>,
+                                                            char>);
 
 /*!\brief Helper template variable that checks if the reference type of a range can be streamed into an instance of
  *        seqan3::debug_stream_type .
@@ -56,7 +58,7 @@ constexpr bool reference_type_is_streamable_v = false;
 
 //!\cond
 template <std::ranges::range rng_t, typename char_t>
-    requires requires (reference_t<rng_t> l, debug_stream_type<char_t> s) { { s << l }; }
+    requires requires (std::ranges::range_reference_t<rng_t> l, debug_stream_type<char_t> s) { { s << l }; }
 constexpr bool reference_type_is_streamable_v<rng_t, char_t> = true;
 //!\endcond
 }
@@ -94,8 +96,8 @@ inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, rng
     static_assert(detail::reference_type_is_streamable_v<rng_t, char_t>,
                   "The reference type of the passed range cannot be streamed into the debug_stream.");
 
-    if constexpr (alphabet<reference_t<rng_t>> &&
-                  !detail::is_uint_adaptation_v<remove_cvref_t<reference_t<rng_t>>>)
+    if constexpr (alphabet<std::ranges::range_reference_t<rng_t>> &&
+                  !detail::is_uint_adaptation_v<remove_cvref_t<std::ranges::range_reference_t<rng_t>>>)
     {
         for (auto && l : r)
             s << l;

--- a/include/seqan3/core/type_traits/range.hpp
+++ b/include/seqan3/core/type_traits/range.hpp
@@ -112,7 +112,7 @@ template <std::ranges::input_range rng_t>
 struct const_reference<rng_t>
 {
     //!\brief Resolves to the reference type of the `const_iterator` of t (not the `const iterator`!).
-    using type = reference_t<std::ranges::iterator_t<rng_t const>>;
+    using type = std::iter_reference_t<std::ranges::iterator_t<rng_t const>>;
 };
 
 // ----------------------------------------------------------------------------

--- a/include/seqan3/io/alignment_file/detail.hpp
+++ b/include/seqan3/io/alignment_file/detail.hpp
@@ -298,8 +298,8 @@ template <std::ranges::forward_range ref_seq_type, std::ranges::forward_range qu
                                                   uint32_t const query_end_pos = 0,
                                                   bool const extended_cigar = false)
 //!\cond
-    requires std::detail::weakly_equality_comparable_with<gap, reference_t<ref_seq_type>> &&
-             std::detail::weakly_equality_comparable_with<gap, reference_t<query_seq_type>>
+    requires std::detail::weakly_equality_comparable_with<gap, std::ranges::range_reference_t<ref_seq_type>> &&
+             std::detail::weakly_equality_comparable_with<gap, std::ranges::range_reference_t<query_seq_type>>
 //!\endcond
 {
     return get_cigar_string(std::tie(ref_seq, query_seq), query_start_pos, query_end_pos, extended_cigar);

--- a/include/seqan3/io/alignment_file/format_bam.hpp
+++ b/include/seqan3/io/alignment_file/format_bam.hpp
@@ -617,17 +617,17 @@ inline void format_bam::write_alignment_record([[maybe_unused]] stream_type &  s
     // Type Requirements (as static asserts for user friendliness)
     // ---------------------------------------------------------------------
     static_assert((std::ranges::forward_range<seq_type>        &&
-                  alphabet<reference_t<seq_type>>),
+                  alphabet<std::ranges::range_reference_t<seq_type>>),
                   "The seq object must be a std::ranges::forward_range over "
                   "letters that model seqan3::alphabet.");
 
     static_assert((std::ranges::forward_range<id_type>         &&
-                  alphabet<reference_t<id_type>>),
+                  alphabet<std::ranges::range_reference_t<id_type>>),
                   "The id object must be a std::ranges::forward_range over "
                   "letters that model seqan3::alphabet.");
 
     static_assert((std::ranges::forward_range<ref_seq_type>    &&
-                  alphabet<reference_t<ref_seq_type>>),
+                  alphabet<std::ranges::range_reference_t<ref_seq_type>>),
                   "The ref_seq object must be a std::ranges::forward_range "
                   "over letters that model seqan3::alphabet.");
 
@@ -645,13 +645,13 @@ inline void format_bam::write_alignment_record([[maybe_unused]] stream_type &  s
                   "value_type is comparable to seqan3::gap");
 
     static_assert((std::tuple_size_v<remove_cvref_t<align_type>> == 2 &&
-                   std::equality_comparable_with<gap, reference_t<decltype(std::get<0>(align))>> &&
-                   std::equality_comparable_with<gap, reference_t<decltype(std::get<1>(align))>>),
+                   std::equality_comparable_with<gap, std::ranges::range_reference_t<decltype(std::get<0>(align))>> &&
+                   std::equality_comparable_with<gap, std::ranges::range_reference_t<decltype(std::get<1>(align))>>),
                   "The align object must be a std::pair of two ranges whose "
                   "value_type is comparable to seqan3::gap");
 
     static_assert((std::ranges::forward_range<qual_type>       &&
-                   alphabet<reference_t<qual_type>>),
+                   alphabet<std::ranges::range_reference_t<qual_type>>),
                   "The qual object must be a std::ranges::forward_range "
                   "over letters that model seqan3::alphabet.");
 

--- a/include/seqan3/io/alignment_file/format_sam.hpp
+++ b/include/seqan3/io/alignment_file/format_sam.hpp
@@ -676,12 +676,12 @@ inline void format_sam::write_alignment_record(stream_type & stream,
     // Type Requirements (as static asserts for user friendliness)
     // ---------------------------------------------------------------------
     static_assert((std::ranges::forward_range<seq_type>        &&
-                  alphabet<reference_t<seq_type>>),
+                  alphabet<std::ranges::range_reference_t<seq_type>>),
                   "The seq object must be a std::ranges::forward_range over "
                   "letters that model seqan3::alphabet.");
 
     static_assert((std::ranges::forward_range<id_type>         &&
-                  alphabet<reference_t<id_type>>),
+                  alphabet<std::ranges::range_reference_t<id_type>>),
                   "The id object must be a std::ranges::forward_range over "
                   "letters that model seqan3::alphabet.");
 
@@ -704,13 +704,13 @@ inline void format_sam::write_alignment_record(stream_type & stream,
                   "value_type is comparable to seqan3::gap");
 
     static_assert((std::tuple_size_v<remove_cvref_t<align_type>> == 2 &&
-                   std::equality_comparable_with<gap, reference_t<decltype(std::get<0>(align))>> &&
-                   std::equality_comparable_with<gap, reference_t<decltype(std::get<1>(align))>>),
+                   std::equality_comparable_with<gap, std::ranges::range_reference_t<decltype(std::get<0>(align))>> &&
+                   std::equality_comparable_with<gap, std::ranges::range_reference_t<decltype(std::get<1>(align))>>),
                   "The align object must be a std::pair of two ranges whose "
                   "value_type is comparable to seqan3::gap");
 
     static_assert((std::ranges::forward_range<qual_type>       &&
-                   alphabet<reference_t<qual_type>>),
+                   alphabet<std::ranges::range_reference_t<qual_type>>),
                   "The qual object must be a std::ranges::forward_range "
                   "over letters that model seqan3::alphabet.");
 

--- a/include/seqan3/io/alignment_file/header.hpp
+++ b/include/seqan3/io/alignment_file/header.hpp
@@ -91,9 +91,9 @@ private:
     //!\brief Stream deleter with default behaviour (ownership assumed).
     static void ref_ids_deleter_default(ref_ids_type * ptr) { delete ptr; }
     //!\brief The key's type of ref_dict.
-    using key_type = std::conditional_t<std::ranges::contiguous_range<reference_t<ref_ids_type>>,
+    using key_type = std::conditional_t<std::ranges::contiguous_range<std::ranges::range_reference_t<ref_ids_type>>,
                         std::span<innermost_value_type_t<ref_ids_type> const>,
-                        type_reduce_view<reference_t<ref_ids_type>>>;
+                        type_reduce_view<std::ranges::range_reference_t<ref_ids_type>>>;
     //!\brief The pointer to reference ids information (non-owning if reference information is given).
     ref_ids_ptr_t ref_ids_ptr{new ref_ids_type{}, ref_ids_deleter_default};
 

--- a/include/seqan3/io/alignment_file/input.hpp
+++ b/include/seqan3/io/alignment_file/input.hpp
@@ -134,10 +134,10 @@ SEQAN3_CONCEPT alignment_file_input_traits = requires (t v)
     };
 
     // field::ref_id
-    requires alphabet<reference_t<reference_t<typename t::ref_ids>>> &&
+    requires alphabet<std::ranges::range_reference_t<std::ranges::range_reference_t<typename t::ref_ids>>> &&
              (!std::same_as<typename t::ref_sequences, ref_info_not_given> ||
-              writable_alphabet<reference_t<reference_t<typename t::ref_ids>>>);
-    requires std::ranges::forward_range<reference_t<typename t::ref_ids>>;
+              writable_alphabet<std::ranges::range_reference_t<std::ranges::range_reference_t<typename t::ref_ids>>>);
+    requires std::ranges::forward_range<std::ranges::range_reference_t<typename t::ref_ids>>;
     requires std::ranges::forward_range<typename t::ref_ids>;
 
     // field::offset is fixed to int32_t
@@ -936,9 +936,10 @@ protected:
         {
             header_ptr->ref_id_info.emplace_back(std::ranges::distance(ref_sequences[idx]), "");
 
-            if constexpr (std::ranges::contiguous_range<reference_t<typename traits_type::ref_ids>> &&
-                          std::ranges::sized_range<reference_t<typename traits_type::ref_ids>> &&
-                          forwarding_range<reference_t<typename traits_type::ref_ids>>)
+            if constexpr (std::ranges::contiguous_range<std::ranges::range_reference_t<
+                                                            typename traits_type::ref_ids>> &&
+                          std::ranges::sized_range<std::ranges::range_reference_t<typename traits_type::ref_ids>> &&
+                          forwarding_range<std::ranges::range_reference_t<typename traits_type::ref_ids>>)
             {
                 auto && id = header_ptr->ref_ids()[idx];
                 header_ptr->ref_dict[std::span{std::ranges::data(id), std::ranges::size(id)}] = idx;

--- a/include/seqan3/io/alignment_file/output.hpp
+++ b/include/seqan3/io/alignment_file/output.hpp
@@ -615,7 +615,7 @@ public:
     template <typename rng_t>
     alignment_file_output & operator=(rng_t && range)
     //!\cond
-        requires std::ranges::input_range<rng_t> && tuple_like<reference_t<rng_t>>
+        requires std::ranges::input_range<rng_t> && tuple_like<std::ranges::range_reference_t<rng_t>>
     //!\endcond
     {
         for (auto && record : range)
@@ -654,7 +654,7 @@ public:
     template <typename rng_t>
     friend alignment_file_output & operator|(rng_t && range, alignment_file_output & f)
     //!\cond
-        requires std::ranges::input_range<rng_t> && tuple_like<reference_t<rng_t>>
+        requires std::ranges::input_range<rng_t> && tuple_like<std::ranges::range_reference_t<rng_t>>
     //!\endcond
     {
         f = range;
@@ -665,7 +665,7 @@ public:
     template <typename rng_t>
     friend alignment_file_output operator|(rng_t && range, alignment_file_output && f)
     //!\cond
-        requires std::ranges::input_range<rng_t> && tuple_like<reference_t<rng_t>>
+        requires std::ranges::input_range<rng_t> && tuple_like<std::ranges::range_reference_t<rng_t>>
     //!\endcond
     {
         f = range;
@@ -753,9 +753,9 @@ protected:
         {
             header_ptr->ref_id_info.emplace_back(ref_lengths[idx], "");
 
-            if constexpr (std::ranges::contiguous_range<reference_t<ref_ids_type_>> &&
-                          std::ranges::sized_range<reference_t<ref_ids_type_>> &&
-                          forwarding_range<reference_t<ref_ids_type_>>)
+            if constexpr (std::ranges::contiguous_range<std::ranges::range_reference_t<ref_ids_type_>> &&
+                          std::ranges::sized_range<std::ranges::range_reference_t<ref_ids_type_>> &&
+                          forwarding_range<std::ranges::range_reference_t<ref_ids_type_>>)
             {
                 auto && id = header_ptr->ref_ids()[idx];
                 header_ptr->ref_dict[std::span{std::ranges::data(id), std::ranges::size(id)}] = idx;

--- a/include/seqan3/io/sequence_file/output.hpp
+++ b/include/seqan3/io/sequence_file/output.hpp
@@ -386,8 +386,10 @@ public:
      */
     template <typename record_t>
     void push_back(record_t && r)
+    //!\cond
         requires tuple_like<record_t> &&
                  requires { requires detail::is_type_specialisation_of_v<remove_cvref_t<record_t>, record>; }
+    //!\endcond
     {
         write_record(detail::get_or_ignore<field::seq>(r),
                      detail::get_or_ignore<field::id>(r),
@@ -419,7 +421,9 @@ public:
      */
     template <typename tuple_t>
     void push_back(tuple_t && t)
+    //!\cond
         requires tuple_like<tuple_t>
+    //!\endcond
     {
         // index_of might return npos, but this will be handled well by get_or_ignore (and just return ignore)
         write_record(detail::get_or_ignore<selected_field_ids::index_of(field::seq)>(t),
@@ -480,7 +484,9 @@ public:
      */
     template <std::ranges::input_range rng_t>
     sequence_file_output & operator=(rng_t && range)
+    //!\cond
         requires tuple_like<std::ranges::range_reference_t<rng_t>>
+    //!\endcond
     {
         for (auto && record : range)
             push_back(std::forward<decltype(record)>(record));
@@ -516,7 +522,9 @@ public:
      */
     template <std::ranges::input_range rng_t>
     friend sequence_file_output & operator|(rng_t && range, sequence_file_output & f)
+    //!\cond
         requires tuple_like<std::ranges::range_reference_t<rng_t>>
+    //!\endcond
     {
         f = range;
         return f;
@@ -525,7 +533,9 @@ public:
     //!\overload
     template <std::ranges::input_range rng_t>
     friend sequence_file_output operator|(rng_t && range, sequence_file_output && f)
+    //!\cond
         requires tuple_like<std::ranges::range_reference_t<rng_t>>
+    //!\endcond
     {
     #if defined(__GNUC__) && (__GNUC__ == 9) // an unreported build problem of GCC9
         for (auto && record : range)

--- a/include/seqan3/io/sequence_file/output.hpp
+++ b/include/seqan3/io/sequence_file/output.hpp
@@ -480,7 +480,7 @@ public:
      */
     template <std::ranges::input_range rng_t>
     sequence_file_output & operator=(rng_t && range)
-        requires tuple_like<reference_t<rng_t>>
+        requires tuple_like<std::ranges::range_reference_t<rng_t>>
     {
         for (auto && record : range)
             push_back(std::forward<decltype(record)>(record));
@@ -516,7 +516,7 @@ public:
      */
     template <std::ranges::input_range rng_t>
     friend sequence_file_output & operator|(rng_t && range, sequence_file_output & f)
-        requires tuple_like<reference_t<rng_t>>
+        requires tuple_like<std::ranges::range_reference_t<rng_t>>
     {
         f = range;
         return f;
@@ -525,7 +525,7 @@ public:
     //!\overload
     template <std::ranges::input_range rng_t>
     friend sequence_file_output operator|(rng_t && range, sequence_file_output && f)
-        requires tuple_like<reference_t<rng_t>>
+        requires tuple_like<std::ranges::range_reference_t<rng_t>>
     {
     #if defined(__GNUC__) && (__GNUC__ == 9) // an unreported build problem of GCC9
         for (auto && record : range)

--- a/include/seqan3/io/structure_file/output.hpp
+++ b/include/seqan3/io/structure_file/output.hpp
@@ -492,7 +492,7 @@ public:
      */
     template <std::ranges::input_range rng_t>
     structure_file_output & operator=(rng_t && range)
-        requires tuple_like<reference_t<rng_t>>
+        requires tuple_like<std::ranges::range_reference_t<rng_t>>
     {
         for (auto && record : range)
             push_back(std::forward<decltype(record)>(record));
@@ -528,7 +528,7 @@ public:
      */
     template <std::ranges::input_range rng_t>
     friend structure_file_output & operator|(rng_t && range, structure_file_output & f)
-        requires tuple_like<reference_t<rng_t>>
+        requires tuple_like<std::ranges::range_reference_t<rng_t>>
     {
         f = range;
         return f;
@@ -537,7 +537,7 @@ public:
     //!\overload
     template <std::ranges::input_range rng_t>
     friend structure_file_output operator|(rng_t && range, structure_file_output && f)
-        requires tuple_like<reference_t<rng_t>>
+        requires tuple_like<std::ranges::range_reference_t<rng_t>>
     {
         f = range;
         return std::move(f);

--- a/include/seqan3/io/structure_file/output.hpp
+++ b/include/seqan3/io/structure_file/output.hpp
@@ -387,8 +387,10 @@ public:
      */
     template <typename record_t>
     void push_back(record_t && r)
+    //!\cond
         requires tuple_like<record_t> &&
                  requires { requires detail::is_type_specialisation_of_v<remove_cvref_t<record_t>, record>; }
+    //!\endcond
     {
         write_record(detail::get_or_ignore<field::seq>(r),
                      detail::get_or_ignore<field::id>(r),
@@ -425,7 +427,9 @@ public:
      */
     template <typename tuple_t>
     void push_back(tuple_t && t)
+    //!\cond
         requires tuple_like<tuple_t>
+    //!\endcond
     {
         // index_of might return npos, but this will be handled well by get_or_ignore (and just return ignore)
         write_record(detail::get_or_ignore<selected_field_ids::index_of(field::seq)>(t),
@@ -492,7 +496,9 @@ public:
      */
     template <std::ranges::input_range rng_t>
     structure_file_output & operator=(rng_t && range)
+    //!\cond
         requires tuple_like<std::ranges::range_reference_t<rng_t>>
+    //!\endcond
     {
         for (auto && record : range)
             push_back(std::forward<decltype(record)>(record));
@@ -528,7 +534,9 @@ public:
      */
     template <std::ranges::input_range rng_t>
     friend structure_file_output & operator|(rng_t && range, structure_file_output & f)
+    //!\cond
         requires tuple_like<std::ranges::range_reference_t<rng_t>>
+    //!\endcond
     {
         f = range;
         return f;
@@ -537,7 +545,9 @@ public:
     //!\overload
     template <std::ranges::input_range rng_t>
     friend structure_file_output operator|(rng_t && range, structure_file_output && f)
+    //!\cond
         requires tuple_like<std::ranges::range_reference_t<rng_t>>
+    //!\endcond
     {
         f = range;
         return std::move(f);

--- a/include/seqan3/range/container/bitcompressed_vector.hpp
+++ b/include/seqan3/range/container/bitcompressed_vector.hpp
@@ -86,7 +86,7 @@ private:
         friend base_t;
 
         //!\brief The proxy of the underlying data type.
-        reference_t<data_type> internal_proxy;
+        std::ranges::range_reference_t<data_type> internal_proxy;
 
         //!\brief Update the sdsl-proxy.
         constexpr void on_update() noexcept
@@ -110,7 +110,7 @@ private:
         ~reference_proxy_type()                                                  noexcept = default; //!< Defaulted.
 
         //!\brief Initialise from internal proxy type.
-        reference_proxy_type(reference_t<data_type> const & internal) noexcept :
+        reference_proxy_type(std::ranges::range_reference_t<data_type> const & internal) noexcept :
             internal_proxy{internal}
         {
             static_cast<base_t &>(*this).assign_rank(internal);

--- a/include/seqan3/range/container/dynamic_bitset.hpp
+++ b/include/seqan3/range/container/dynamic_bitset.hpp
@@ -1286,7 +1286,7 @@ public:
     template <std::forward_iterator begin_it_type, typename end_it_type>
     //!\cond
         requires std::sentinel_for<end_it_type, begin_it_type> &&
-                 std::constructible_from<value_type, ranges::iter_reference_t<begin_it_type>>
+                 std::constructible_from<value_type, std::iter_reference_t<begin_it_type>>
     //!\endcond
     constexpr iterator insert(const_iterator pos, begin_it_type begin_it, end_it_type end_it) noexcept
     {

--- a/include/seqan3/range/container/dynamic_bitset.hpp
+++ b/include/seqan3/range/container/dynamic_bitset.hpp
@@ -237,7 +237,7 @@ public:
     template <std::forward_iterator begin_it_type, typename end_it_type>
     //!\cond
         requires std::sentinel_for<end_it_type, begin_it_type> &&
-                 std::constructible_from<value_type, reference_t<begin_it_type>>
+                 std::constructible_from<value_type, std::iter_reference_t<begin_it_type>>
     //!\endcond
     constexpr dynamic_bitset(begin_it_type begin_it, end_it_type end_it) noexcept:
         dynamic_bitset{}
@@ -247,7 +247,7 @@ public:
 
     /*!\brief Construct from a different range.
      * \tparam other_range_t The type of range to be inserted; must satisfy std::ranges::input_range and `value_type`
-     *                       must be constructible from `reference_t<other_range_t>`.
+     *                       must be constructible from `std::ranges::range_reference_t<other_range_t>`.
      * \param[in] range The sequence to construct/assign from.
      *
      * \details
@@ -446,7 +446,7 @@ public:
 
     /*!\brief Assign from a different range.
      * \tparam other_range_t The type of range to be inserted; must satisfy std::ranges::input_range and `value_type`
-     *                       must be constructible from `reference_t<other_range_t>`.
+     *                       must be constructible from `std::ranges::range_reference_t<other_range_t>`.
      * \param[in] range The sequences to construct/assign from.
      *
      * \details
@@ -461,7 +461,7 @@ public:
      */
     template <std::ranges::input_range other_range_t>
     //!\cond
-        requires std::constructible_from<value_type, reference_t<other_range_t>>
+        requires std::constructible_from<value_type, std::ranges::range_reference_t<other_range_t>>
     //!\endcond
     constexpr void assign(other_range_t && range) noexcept
     {
@@ -488,7 +488,7 @@ public:
     template <std::forward_iterator begin_it_type, typename end_it_type>
     //!\cond
         requires std::sentinel_for<end_it_type, begin_it_type> &&
-                 std::constructible_from<value_type, reference_t<begin_it_type>>
+                 std::constructible_from<value_type, std::iter_reference_t<begin_it_type>>
     //!\endcond
     constexpr void assign(begin_it_type begin_it, end_it_type end_it) noexcept
     {
@@ -1286,7 +1286,7 @@ public:
     template <std::forward_iterator begin_it_type, typename end_it_type>
     //!\cond
         requires std::sentinel_for<end_it_type, begin_it_type> &&
-                 std::constructible_from<value_type, /*ranges::iter_reference_t*/reference_t<begin_it_type>>
+                 std::constructible_from<value_type, ranges::iter_reference_t<begin_it_type>>
     //!\endcond
     constexpr iterator insert(const_iterator pos, begin_it_type begin_it, end_it_type end_it) noexcept
     {

--- a/include/seqan3/range/container/small_string.hpp
+++ b/include/seqan3/range/container/small_string.hpp
@@ -160,7 +160,7 @@ public:
     template <std::forward_iterator begin_it_type, typename end_it_type>
     //!\cond
         requires std::sentinel_for<end_it_type, begin_it_type> &&
-                 std::constructible_from<value_type, ranges::iter_reference_t<begin_it_type>>
+                 std::constructible_from<value_type, std::iter_reference_t<begin_it_type>>
     //!\endcond
     constexpr void assign(begin_it_type begin_it, end_it_type end_it) noexcept
     {

--- a/include/seqan3/range/container/small_string.hpp
+++ b/include/seqan3/range/container/small_string.hpp
@@ -160,7 +160,7 @@ public:
     template <std::forward_iterator begin_it_type, typename end_it_type>
     //!\cond
         requires std::sentinel_for<end_it_type, begin_it_type> &&
-                 std::constructible_from<value_type, /*ranges::iter_reference_t*/reference_t<begin_it_type>>
+                 std::constructible_from<value_type, ranges::iter_reference_t<begin_it_type>>
     //!\endcond
     constexpr void assign(begin_it_type begin_it, end_it_type end_it) noexcept
     {

--- a/include/seqan3/range/container/small_vector.hpp
+++ b/include/seqan3/range/container/small_vector.hpp
@@ -159,7 +159,7 @@ public:
     template <std::forward_iterator begin_it_type, typename end_it_type>
     //!\cond
         requires std::sentinel_for<end_it_type, begin_it_type> &&
-                 std::constructible_from<value_type, /*ranges::iter_reference_t*/reference_t<begin_it_type>>
+                 std::constructible_from<value_type, std::iter_reference_t<begin_it_type>>
     //!\endcond
     constexpr small_vector(begin_it_type begin_it, end_it_type end_it) noexcept(is_noexcept) :
         small_vector{}
@@ -169,7 +169,7 @@ public:
 
     /*!\brief Construct from a different range.
      * \tparam other_range_t The type of range to be inserted; must satisfy std::ranges::input_range and `value_type`
-     *                       must be constructible from reference_t<other_range_t>.
+     *                       must be constructible from std::ranges::range_reference_t<other_range_t>.
      * \param[in]      range The sequences to construct/assign from.
      *
      * ### Complexity
@@ -183,7 +183,7 @@ public:
     template <std::ranges::input_range other_range_t>
     //!\cond
         requires !std::is_same_v<remove_cvref_t<other_range_t>, small_vector>
-                 /*ICE: && std::constructible_from<value_type, reference_t<other_range_t>>*/
+                 /*ICE: && std::constructible_from<value_type, std::ranges::range_reference_t<other_range_t>>*/
     //!\endcond
     explicit constexpr small_vector(other_range_t && range) noexcept(is_noexcept) :
         small_vector{std::ranges::begin(range), std::ranges::end(range)}
@@ -261,7 +261,7 @@ public:
 
     /*!\brief Assign from a different range.
      * \tparam other_range_t The type of range to be inserted; must satisfy std::ranges::input_range and `value_type`
-     *                       must be constructible from reference_t<other_range_t>.
+     *                       must be constructible from std::ranges::range_reference_t<other_range_t>.
      * \param[in]      range The sequences to construct/assign from.
      *
      * ### Complexity
@@ -274,7 +274,7 @@ public:
      */
     template <std::ranges::input_range other_range_t>
     //!\cond
-        requires std::constructible_from<value_type, /*ranges::range_reference_t*/reference_t<other_range_t>>
+        requires std::constructible_from<value_type, std::ranges::range_reference_t<other_range_t>>
     //!\endcond
     constexpr void assign(other_range_t && range) noexcept(is_noexcept)
     {
@@ -299,7 +299,7 @@ public:
     template <std::forward_iterator begin_it_type, typename end_it_type>
     //!\cond
         requires std::sentinel_for<end_it_type, begin_it_type> &&
-                 std::constructible_from<value_type, /*ranges::iter_reference_t*/reference_t<begin_it_type>>
+                 std::constructible_from<value_type, std::iter_reference_t<begin_it_type>>
     //!\endcond
     constexpr void assign(begin_it_type begin_it, end_it_type end_it) noexcept(is_noexcept)
     {
@@ -644,7 +644,7 @@ public:
     template <std::forward_iterator begin_it_type, typename end_it_type>
     //!\cond
         requires std::sentinel_for<end_it_type, begin_it_type> &&
-                 std::constructible_from<value_type, /*ranges::iter_reference_t*/reference_t<begin_it_type>>
+                 std::constructible_from<value_type, std::iter_reference_t<begin_it_type>>
     //!\endcond
     constexpr iterator insert(const_iterator pos, begin_it_type begin_it, end_it_type end_it) noexcept(is_noexcept)
     {

--- a/include/seqan3/range/views/all.hpp
+++ b/include/seqan3/range/views/all.hpp
@@ -163,7 +163,7 @@
  *
  * **Returned range's reference type:** Conversely certain views make guarantees on the concepts satisfied by the
  * return range's reference type or even always have a fixed type, e.g. seqan3::views::complement operates on
- * nucleotides and of course also returns nucleotides and "seqan3::reference_t<urng_t>" would imply that
+ * nucleotides and of course also returns nucleotides and "std::ranges::range_reference_t<urng_t>" would imply that
  * the reference type is the same. However, and this is important to note, the reference type
  * of seqan3::views::complement has any actual `&` removed from the underlying ranges' reference type (if originally present),
  * this goes hand-in-hand with std::ranges::output_range being lost → original elements cannot be written to through

--- a/include/seqan3/range/views/async_input_buffer.hpp
+++ b/include/seqan3/range/views/async_input_buffer.hpp
@@ -46,7 +46,8 @@ private:
         "The range parameter to async_input_buffer_view must model std::ranges::View.");
     static_assert(std::movable<std::ranges::range_value_t<urng_t>>,
         "The range parameter to async_input_buffer_view must have a value_type that is std::Movable.");
-    static_assert(std::constructible_from<std::ranges::range_value_t<urng_t>, std::remove_reference_t<reference_t<urng_t>> &&>,
+    static_assert(std::constructible_from<std::ranges::range_value_t<urng_t>,
+                                          std::remove_reference_t<std::ranges::range_reference_t<urng_t>> &&>,
         "The range parameter to async_input_buffer_view must have a value_type that is constructible by a moved "
         "value of its reference type.");
 
@@ -331,7 +332,8 @@ struct async_input_buffer_fn
             "The range parameter to views::async_input_buffer cannot be a temporary of a non-view range.");
         static_assert(std::movable<std::ranges::range_value_t<urng_t>>,
             "The range parameter to views::async_input_buffer must have a value_type that is std::Movable.");
-        static_assert(std::constructible_from<std::ranges::range_value_t<urng_t>, std::remove_reference_t<reference_t<urng_t>> &&>,
+        static_assert(std::constructible_from<std::ranges::range_value_t<urng_t>,
+                                              std::remove_reference_t<std::ranges::range_reference_t<urng_t>> &&>,
             "The range parameter to views::async_input_buffer must have a value_type that is constructible by a moved "
             "value of its reference type.");
 

--- a/include/seqan3/range/views/complement.hpp
+++ b/include/seqan3/range/views/complement.hpp
@@ -56,7 +56,7 @@ namespace seqan3::views
  * | std::ranges::output_range        |                                       | *lost*                                             |
  * | seqan3::const_iterable_range     |                                       | *preserved*                                        |
  * |                                  |                                       |                                                    |
- * | std::ranges::range_reference_t   | seqan3::nucleotide_alphabet            | std::remove_reference_t<seqan3::reference_t<urng_t>> |
+ * | std::ranges::range_reference_t   | seqan3::nucleotide_alphabet            | std::remove_reference_t<std::ranges::range_reference_t<urng_t>> |
  *
  * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.
  *

--- a/include/seqan3/range/views/complement.hpp
+++ b/include/seqan3/range/views/complement.hpp
@@ -41,22 +41,22 @@ namespace seqan3::views
  * This view is a **deep view** Given a range-of-range as input (as opposed to just a range), it will apply
  * the transformation on the innermost range (instead of the outermost range).
  *
- * | Concepts and traits              | `urng_t` (underlying range type)      | `rrng_t` (returned range type)                     |
- * |----------------------------------|:-------------------------------------:|:--------------------------------------------------:|
- * | std::ranges::input_range         | *required*                            | *preserved*                                        |
- * | std::ranges::forward_range       |                                       | *preserved*                                        |
- * | std::ranges::bidirectional_range |                                       | *preserved*                                        |
- * | std::ranges::random_access_range |                                       | *preserved*                                        |
- * | std::ranges::contiguous_range    |                                       | *lost*                                             |
- * |                                  |                                       |                                                    |
- * | std::ranges::viewable_range      | *required*                            | *guaranteed*                                       |
- * | std::ranges::view                |                                       | *guaranteed*                                       |
- * | std::ranges::sized_range         |                                       | *preserved*                                        |
- * | std::ranges::common_range        |                                       | *preserved*                                        |
- * | std::ranges::output_range        |                                       | *lost*                                             |
- * | seqan3::const_iterable_range     |                                       | *preserved*                                        |
- * |                                  |                                       |                                                    |
- * | std::ranges::range_reference_t   | seqan3::nucleotide_alphabet            | std::remove_reference_t<std::ranges::range_reference_t<urng_t>> |
+ * | Concepts and traits              | `urng_t` (underlying range type)      | `rrng_t` (returned range type)                                  |
+ * |----------------------------------|:-------------------------------------:|:---------------------------------------------------------------:|
+ * | std::ranges::input_range         | *required*                            | *preserved*                                                     |
+ * | std::ranges::forward_range       |                                       | *preserved*                                                     |
+ * | std::ranges::bidirectional_range |                                       | *preserved*                                                     |
+ * | std::ranges::random_access_range |                                       | *preserved*                                                     |
+ * | std::ranges::contiguous_range    |                                       | *lost*                                                          |
+ * |                                  |                                       |                                                                 |
+ * | std::ranges::viewable_range      | *required*                            | *guaranteed*                                                    |
+ * | std::ranges::view                |                                       | *guaranteed*                                                    |
+ * | std::ranges::sized_range         |                                       | *preserved*                                                     |
+ * | std::ranges::common_range        |                                       | *preserved*                                                     |
+ * | std::ranges::output_range        |                                       | *lost*                                                          |
+ * | seqan3::const_iterable_range     |                                       | *preserved*                                                     |
+ * |                                  |                                       |                                                                 |
+ * | std::ranges::range_reference_t   | seqan3::nucleotide_alphabet           | std::remove_reference_t<std::ranges::range_reference_t<urng_t>> |
  *
  * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.
  *

--- a/include/seqan3/range/views/deep.hpp
+++ b/include/seqan3/range/views/deep.hpp
@@ -151,7 +151,7 @@ public:
      */
     template <std::ranges::input_range urng_t>
     //!\cond
-        requires std::ranges::input_range<reference_t<urng_t>>
+        requires std::ranges::input_range<std::ranges::range_reference_t<urng_t>>
     //!\endcond
     constexpr auto operator()(urng_t && urange) const &
     {
@@ -164,7 +164,7 @@ public:
     //!\overload
     template <std::ranges::input_range urng_t>
     //!\cond
-        requires std::ranges::input_range<reference_t<urng_t>>
+        requires std::ranges::input_range<std::ranges::range_reference_t<urng_t>>
     //!\endcond
     constexpr auto operator()(urng_t && urange) &&
     {

--- a/include/seqan3/range/views/drop.hpp
+++ b/include/seqan3/range/views/drop.hpp
@@ -123,33 +123,33 @@ namespace seqan3::views
  *
  * ### View properties
  *
- * | Concepts and traits              | `urng_t` (underlying range type)   | `rrng_t` (returned range type)  |
- * |----------------------------------|:----------------------------------:|:-------------------------------:|
- * | std::ranges::input_range         | *required*                         | *preserved*                     |
- * | std::ranges::forward_range       |                                    | *preserved*                     |
- * | std::ranges::bidirectional_range |                                    | *preserved*                     |
- * | std::ranges::random_access_range |                                    | *preserved*                     |
- * | std::ranges::contiguous_range    |                                    | *preserved*                     |
- * |                                  |                                    |                                  |
- * | std::ranges::viewable_range      | *required*                         | *guaranteed*                    |
- * | std::ranges::view                |                                    | *guaranteed*                    |
- * | std::ranges::sized_range         |                                    | *preserved*                     |
- * | std::ranges::common_range        |                                    | *preserved*                     |
- * | std::ranges::output_range        |                                    | *preserved*                     |
- * | seqan3::const_iterable_range     |                                    | *preserved*                     |
- * |                                  |                                    |                                  |
- * | std::ranges::range_reference_t   |                                    | std::ranges::range_reference_t<urng_t>     |
+ * | Concepts and traits              | `urng_t` (underlying range type)   | `rrng_t` (returned range type)         |
+ * |----------------------------------|:----------------------------------:|:--------------------------------------:|
+ * | std::ranges::input_range         | *required*                         | *preserved*                            |
+ * | std::ranges::forward_range       |                                    | *preserved*                            |
+ * | std::ranges::bidirectional_range |                                    | *preserved*                            |
+ * | std::ranges::random_access_range |                                    | *preserved*                            |
+ * | std::ranges::contiguous_range    |                                    | *preserved*                            |
+ * |                                  |                                    |                                        |
+ * | std::ranges::viewable_range      | *required*                         | *guaranteed*                           |
+ * | std::ranges::view                |                                    | *guaranteed*                           |
+ * | std::ranges::sized_range         |                                    | *preserved*                            |
+ * | std::ranges::common_range        |                                    | *preserved*                            |
+ * | std::ranges::output_range        |                                    | *preserved*                            |
+ * | seqan3::const_iterable_range     |                                    | *preserved*                            |
+ * |                                  |                                    |                                        |
+ * | std::ranges::range_reference_t   |                                    | std::ranges::range_reference_t<urng_t> |
  *
  * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.
  *
  * ### Return type
  *
- * | `urng_t` (underlying range type)                                                       | `rrng_t` (returned range type)  |
- * |:--------------------------------------------------------------------------------------:|:-------------------------------:|
- * | `std::basic_string const &` *or* `std::basic_string_view`                              | `std::basic_string_view`        |
- * | `seqan3::forwarding_range && std::ranges::sized_range && std::ranges::contiguous_range`   | `std::span`                     |
+ * | `urng_t` (underlying range type)                                                           | `rrng_t` (returned range type)  |
+ * |:------------------------------------------------------------------------------------------:|:-------------------------------:|
+ * | `std::basic_string const &` *or* `std::basic_string_view`                                  | `std::basic_string_view`        |
+ * | `seqan3::forwarding_range && std::ranges::sized_range && std::ranges::contiguous_range`    | `std::span`                     |
  * | `seqan3::forwarding_range && std::ranges::sized_range && std::ranges::random_access_range` | `std::ranges::subrange`         |
- * | *else*                                                                                 | *implementation defined type*   |
+ * | *else*                                                                                     | *implementation defined type*   |
  *
  * The adaptor is different from std::views::drop in that it performs type erasure for some underlying ranges.
  * It returns exactly the type specified above.

--- a/include/seqan3/range/views/drop.hpp
+++ b/include/seqan3/range/views/drop.hpp
@@ -138,7 +138,7 @@ namespace seqan3::views
  * | std::ranges::output_range        |                                    | *preserved*                     |
  * | seqan3::const_iterable_range     |                                    | *preserved*                     |
  * |                                  |                                    |                                  |
- * | std::ranges::range_reference_t   |                                    | seqan3::reference_t<urng_t>     |
+ * | std::ranges::range_reference_t   |                                    | std::ranges::range_reference_t<urng_t>     |
  *
  * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.
  *

--- a/include/seqan3/range/views/enforce_random_access.hpp
+++ b/include/seqan3/range/views/enforce_random_access.hpp
@@ -369,7 +369,7 @@ namespace seqan3::views
  * | `urng_t` (underlying range type)       | `rrng_t` (returned range type)                       |
  * |:--------------------------------------:|:----------------------------------------------------:|
  * | `std::ranges::random_access_range`     | `std::ranges::ref_view<urng_t>`                      |
- * | `seqan3::pseudo_random_access_range`   | `seqan3::detail::view_enforce_random_access`          |
+ * | `seqan3::pseudo_random_access_range`   | `seqan3::detail::view_enforce_random_access`         |
  *
  * The adaptor returns exactly the type specified above. In the second case a view is returned whose iterator wraps
  * the iterator of the underlying range and adapts all of its functionality but overwrites the

--- a/include/seqan3/range/views/enforce_random_access.hpp
+++ b/include/seqan3/range/views/enforce_random_access.hpp
@@ -357,7 +357,7 @@ namespace seqan3::views
  * | std::ranges::output_range        |                                   | *preserved*                                |
  * | seqan3::const_iterable_range     |                                   | *preserved*                                |
  * |                                  |                                   |                                            |
- * | seqan3::reference_t              |                                   | seqan3::reference_t<urng_t>                |
+ * | std::ranges::range_reference_t   |                                   | std::ranges::range_reference_t<urng_t>     |
  *
  * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.
  *

--- a/include/seqan3/range/views/get.hpp
+++ b/include/seqan3/range/views/get.hpp
@@ -52,7 +52,7 @@ namespace seqan3::views
  * | std::ranges::output_range        |                                       | *preserved*                                             |
  * | seqan3::const_iterable_range     |                                       | *preserved*                                             |
  * |                                  |                                       |                                                         |
- * | std::ranges::range_reference_t   | seqan3::tuple_like                    | std::tuple_element_t<index, seqan3::reference_t<urng_t>>|
+ * | std::ranges::range_reference_t   | seqan3::tuple_like                    | std::tuple_element_t<index, std::ranges::range_reference_t<urng_t>>|
  *
  * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.
  *

--- a/include/seqan3/range/views/get.hpp
+++ b/include/seqan3/range/views/get.hpp
@@ -37,21 +37,21 @@ namespace seqan3::views
  *
  * ### View properties
  *
- * | Concepts and traits              | `urng_t` (underlying range type)      | `rrng_t` (returned range type)                          |
- * |----------------------------------|:-------------------------------------:|:-------------------------------------------------------:|
- * | std::ranges::input_range         | *required*                            | *preserved*                                             |
- * | std::ranges::forward_range       |                                       | *preserved*                                             |
- * | std::ranges::bidirectional_range |                                       | *preserved*                                             |
- * | std::ranges::random_access_range |                                       | *preserved*                                             |
- * | std::ranges::contiguous_range    |                                       | *lost*                                                  |
- * |                                  |                                       |                                                         |
- * | std::ranges::viewable_range      | *required*                            | *preserved*                                             |
- * | std::ranges::view                |                                       | *preserved*                                             |
- * | std::ranges::sized_range         |                                       | *preserved*                                             |
- * | std::ranges::common_range        |                                       | *preserved*                                             |
- * | std::ranges::output_range        |                                       | *preserved*                                             |
- * | seqan3::const_iterable_range     |                                       | *preserved*                                             |
- * |                                  |                                       |                                                         |
+ * | Concepts and traits              | `urng_t` (underlying range type)      | `rrng_t` (returned range type)                                     |
+ * |----------------------------------|:-------------------------------------:|:------------------------------------------------------------------:|
+ * | std::ranges::input_range         | *required*                            | *preserved*                                                        |
+ * | std::ranges::forward_range       |                                       | *preserved*                                                        |
+ * | std::ranges::bidirectional_range |                                       | *preserved*                                                        |
+ * | std::ranges::random_access_range |                                       | *preserved*                                                        |
+ * | std::ranges::contiguous_range    |                                       | *lost*                                                             |
+ * |                                  |                                       |                                                                    |
+ * | std::ranges::viewable_range      | *required*                            | *preserved*                                                        |
+ * | std::ranges::view                |                                       | *preserved*                                                        |
+ * | std::ranges::sized_range         |                                       | *preserved*                                                        |
+ * | std::ranges::common_range        |                                       | *preserved*                                                        |
+ * | std::ranges::output_range        |                                       | *preserved*                                                        |
+ * | seqan3::const_iterable_range     |                                       | *preserved*                                                        |
+ * |                                  |                                       |                                                                    |
  * | std::ranges::range_reference_t   | seqan3::tuple_like                    | std::tuple_element_t<index, std::ranges::range_reference_t<urng_t>>|
  *
  * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.

--- a/include/seqan3/range/views/interleave.hpp
+++ b/include/seqan3/range/views/interleave.hpp
@@ -48,7 +48,8 @@ template <std::ranges::random_access_range urng_t, std::ranges::random_access_ra
     //!\cond
     requires std::ranges::view<urng_t> && std::ranges::sized_range<urng_t> &&
              std::ranges::view<inserted_rng_t> && std::ranges::sized_range<inserted_rng_t> &&
-             std::common_reference_with<std::ranges::range_reference_t<urng_t>, std::ranges::range_reference_t<inserted_rng_t>>
+             std::common_reference_with<std::ranges::range_reference_t<urng_t>,
+                                        std::ranges::range_reference_t<inserted_rng_t>>
     //!\endcond
 class view_interleave : public std::ranges::view_interface<view_interleave<urng_t, inserted_rng_t>>
 {
@@ -65,10 +66,12 @@ public:
      * \{
      */
     //!\brief The reference_type.
-    using reference         = ranges::common_reference_t<std::ranges::range_reference_t<urng_t>, std::ranges::range_reference_t<inserted_rng_t>>;
+    using reference         = ranges::common_reference_t<std::ranges::range_reference_t<urng_t>,
+                                                         std::ranges::range_reference_t<inserted_rng_t>>;
     //!\brief The const_reference type is equal to the reference type.
     using const_reference   = detail::transformation_trait_or_t<
-                                ranges::common_reference<std::ranges::range_reference_t<urng_t const>, std::ranges::range_reference_t<inserted_rng_t const>>, void>;
+                                ranges::common_reference<std::ranges::range_reference_t<urng_t const>,
+                                                         std::ranges::range_reference_t<inserted_rng_t const>>, void>;
     //!\brief The value_type (which equals the reference_type with any references removed).
     using value_type        = std::ranges::range_value_t<urng_t>;
     //!\brief This resolves to range_type::size_type as the underlying range is guaranteed to be Sized.
@@ -115,7 +118,8 @@ public:
                  std::constructible_from<inserted_rng_t, decltype(views::persist(std::declval<oirng_t>()))>
         //!\endcond
     view_interleave(orng_t && _urange, size_t const _step_size, oirng_t && _inserted_range) :
-        view_interleave{views::type_reduce(std::forward<orng_t>(_urange)), _step_size, views::persist(std::forward<oirng_t>(_inserted_range))}
+        view_interleave{views::type_reduce(std::forward<orng_t>(_urange)), _step_size,
+                        views::persist(std::forward<oirng_t>(_inserted_range))}
     {}
     //!\}
 
@@ -251,10 +255,12 @@ template <std::ranges::random_access_range urng_t, std::ranges::random_access_ra
     //!\cond
     requires std::ranges::viewable_range<urng_t> && std::ranges::sized_range<urng_t> &&
              std::ranges::sized_range<inserted_rng_t> &&
-             std::common_reference_with<std::ranges::range_reference_t<urng_t>, std::ranges::range_reference_t<inserted_rng_t>>
+             std::common_reference_with<std::ranges::range_reference_t<urng_t>,
+                                        std::ranges::range_reference_t<inserted_rng_t>>
     //!\endcond
 view_interleave(urng_t &&, size_t, inserted_rng_t &&)
-    -> view_interleave<decltype(views::type_reduce(std::declval<urng_t>())), decltype(views::persist(std::declval<inserted_rng_t>()))>;
+    -> view_interleave<decltype(views::type_reduce(std::declval<urng_t>())),
+                       decltype(views::persist(std::declval<inserted_rng_t>()))>;
 
 // ============================================================================
 //  interleave_fn (adaptor definition)
@@ -341,15 +347,15 @@ namespace seqan3::views
  * | std::ranges::bidirectional_range | *required*                            | *preserved*                     |
  * | std::ranges::random_access_range | *required*                            | *preserved*                     |
  * | std::ranges::contiguous_range    |                                       | *lost*                          |
- * |                                  |                                       |                                  |
+ * |                                  |                                       |                                 |
  * | std::ranges::viewable_range      | *required*                            | *guaranteed*                    |
  * | std::ranges::view                |                                       | *guaranteed*                    |
  * | std::ranges::sized_range         | *required*                            | *preserved*                     |
  * | std::ranges::common_range        |                                       | *preserved*                     |
  * | std::ranges::output_range        |                                       | *preserved*                     |
  * | seqan3::const_iterable_range     |                                       | *preserved*                     |
- * |                                  |                                       |                                  |
- * | std::ranges::range_reference_t   |                                       | std::ranges::range_reference_t<urng_t>     |
+ * |                                  |                                       |                                 |
+ * | std::ranges::range_reference_t   |                                       | std::ranges::range_reference_t<urng_t> |
  *
  *
  * If above requirements are not met, this adaptor forwards to

--- a/include/seqan3/range/views/interleave.hpp
+++ b/include/seqan3/range/views/interleave.hpp
@@ -48,7 +48,7 @@ template <std::ranges::random_access_range urng_t, std::ranges::random_access_ra
     //!\cond
     requires std::ranges::view<urng_t> && std::ranges::sized_range<urng_t> &&
              std::ranges::view<inserted_rng_t> && std::ranges::sized_range<inserted_rng_t> &&
-             std::common_reference_with<reference_t<urng_t>, reference_t<inserted_rng_t>>
+             std::common_reference_with<std::ranges::range_reference_t<urng_t>, std::ranges::range_reference_t<inserted_rng_t>>
     //!\endcond
 class view_interleave : public std::ranges::view_interface<view_interleave<urng_t, inserted_rng_t>>
 {
@@ -65,10 +65,10 @@ public:
      * \{
      */
     //!\brief The reference_type.
-    using reference         = ranges::common_reference_t<reference_t<urng_t>, reference_t<inserted_rng_t>>;
+    using reference         = ranges::common_reference_t<std::ranges::range_reference_t<urng_t>, std::ranges::range_reference_t<inserted_rng_t>>;
     //!\brief The const_reference type is equal to the reference type.
     using const_reference   = detail::transformation_trait_or_t<
-                                ranges::common_reference<reference_t<urng_t const>, reference_t<inserted_rng_t const>>, void>;
+                                ranges::common_reference<std::ranges::range_reference_t<urng_t const>, std::ranges::range_reference_t<inserted_rng_t const>>, void>;
     //!\brief The value_type (which equals the reference_type with any references removed).
     using value_type        = std::ranges::range_value_t<urng_t>;
     //!\brief This resolves to range_type::size_type as the underlying range is guaranteed to be Sized.
@@ -251,7 +251,7 @@ template <std::ranges::random_access_range urng_t, std::ranges::random_access_ra
     //!\cond
     requires std::ranges::viewable_range<urng_t> && std::ranges::sized_range<urng_t> &&
              std::ranges::sized_range<inserted_rng_t> &&
-             std::common_reference_with<reference_t<urng_t>, reference_t<inserted_rng_t>>
+             std::common_reference_with<std::ranges::range_reference_t<urng_t>, std::ranges::range_reference_t<inserted_rng_t>>
     //!\endcond
 view_interleave(urng_t &&, size_t, inserted_rng_t &&)
     -> view_interleave<decltype(views::type_reduce(std::declval<urng_t>())), decltype(views::persist(std::declval<inserted_rng_t>()))>;
@@ -349,7 +349,7 @@ namespace seqan3::views
  * | std::ranges::output_range        |                                       | *preserved*                     |
  * | seqan3::const_iterable_range     |                                       | *preserved*                     |
  * |                                  |                                       |                                  |
- * | std::ranges::range_reference_t   |                                       | seqan3::reference_t<urng_t>     |
+ * | std::ranges::range_reference_t   |                                       | std::ranges::range_reference_t<urng_t>     |
  *
  *
  * If above requirements are not met, this adaptor forwards to

--- a/include/seqan3/range/views/interleave.hpp
+++ b/include/seqan3/range/views/interleave.hpp
@@ -340,21 +340,21 @@ namespace seqan3::views
  *
  * ### View properties
  *
- * | Concepts and traits              | `urng_t` (underlying range type)      | `rrng_t` (returned range type)  |
- * |----------------------------------|:-------------------------------------:|:-------------------------------:|
- * | std::ranges::input_range         | *required*                            | *preserved*                     |
- * | std::ranges::forward_range       | *required*                            | *preserved*                     |
- * | std::ranges::bidirectional_range | *required*                            | *preserved*                     |
- * | std::ranges::random_access_range | *required*                            | *preserved*                     |
- * | std::ranges::contiguous_range    |                                       | *lost*                          |
- * |                                  |                                       |                                 |
- * | std::ranges::viewable_range      | *required*                            | *guaranteed*                    |
- * | std::ranges::view                |                                       | *guaranteed*                    |
- * | std::ranges::sized_range         | *required*                            | *preserved*                     |
- * | std::ranges::common_range        |                                       | *preserved*                     |
- * | std::ranges::output_range        |                                       | *preserved*                     |
- * | seqan3::const_iterable_range     |                                       | *preserved*                     |
- * |                                  |                                       |                                 |
+ * | Concepts and traits              | `urng_t` (underlying range type)      | `rrng_t` (returned range type)         |
+ * |----------------------------------|:-------------------------------------:|:--------------------------------------:|
+ * | std::ranges::input_range         | *required*                            | *preserved*                            |
+ * | std::ranges::forward_range       | *required*                            | *preserved*                            |
+ * | std::ranges::bidirectional_range | *required*                            | *preserved*                            |
+ * | std::ranges::random_access_range | *required*                            | *preserved*                            |
+ * | std::ranges::contiguous_range    |                                       | *lost*                                 |
+ * |                                  |                                       |                                        |
+ * | std::ranges::viewable_range      | *required*                            | *guaranteed*                           |
+ * | std::ranges::view                |                                       | *guaranteed*                           |
+ * | std::ranges::sized_range         | *required*                            | *preserved*                            |
+ * | std::ranges::common_range        |                                       | *preserved*                            |
+ * | std::ranges::output_range        |                                       | *preserved*                            |
+ * | seqan3::const_iterable_range     |                                       | *preserved*                            |
+ * |                                  |                                       |                                        |
  * | std::ranges::range_reference_t   |                                       | std::ranges::range_reference_t<urng_t> |
  *
  *

--- a/include/seqan3/range/views/kmer_hash.hpp
+++ b/include/seqan3/range/views/kmer_hash.hpp
@@ -40,7 +40,7 @@ class kmer_hash_view : public std::ranges::view_interface<kmer_hash_view<urng_t>
 {
 private:
     static_assert(std::ranges::forward_range<urng_t const>, "The kmer_hash_view only works on forward_ranges");
-    static_assert(semialphabet<reference_t<urng_t>>, "The reference type of the underlying range must model "
+    static_assert(semialphabet<std::ranges::range_reference_t<urng_t>>, "The reference type of the underlying range must model "
                   "seqan3::semialphabet.");
 
     //!\brief The underlying range.
@@ -69,7 +69,7 @@ public:
      */
     kmer_hash_view(urng_t urange_, shape const & s_) : urange{std::move(urange_)}, shape_{s_}
     {
-        if (shape_.count() > (64 / std::log2(alphabet_size<reference_t<urng_t>>)))
+        if (shape_.count() > (64 / std::log2(alphabet_size<std::ranges::range_reference_t<urng_t>>)))
         {
             throw std::invalid_argument{"The chosen shape/alphabet combination is not valid. "
                                         "The alphabet or shape size must be reduced."};
@@ -89,7 +89,7 @@ public:
     kmer_hash_view(rng_t && urange_, shape const & s_) :
         urange{std::views::all(std::forward<rng_t>(urange_))}, shape_{s_}
     {
-        if (shape_.count() > (64 / std::log2(alphabet_size<reference_t<urng_t>>)))
+        if (shape_.count() > (64 / std::log2(alphabet_size<std::ranges::range_reference_t<urng_t>>)))
         {
             throw std::invalid_argument{"The chosen shape/alphabet combination is not valid. "
                                         "The alphabet or shape size must be reduced."};
@@ -647,7 +647,7 @@ struct kmer_hash_fn
             "The range parameter to views::kmer_hash cannot be a temporary of a non-view range.");
         static_assert(std::ranges::forward_range<urng_t>,
             "The range parameter to views::kmer_hash must model std::ranges::forward_range.");
-        static_assert(semialphabet<reference_t<urng_t>>,
+        static_assert(semialphabet<std::ranges::range_reference_t<urng_t>>,
             "The range parameter to views::kmer_hash must be over elements of seqan3::semialphabet.");
 
         return kmer_hash_view{std::forward<urng_t>(urange), shape_};

--- a/include/seqan3/range/views/kmer_hash.hpp
+++ b/include/seqan3/range/views/kmer_hash.hpp
@@ -40,8 +40,8 @@ class kmer_hash_view : public std::ranges::view_interface<kmer_hash_view<urng_t>
 {
 private:
     static_assert(std::ranges::forward_range<urng_t const>, "The kmer_hash_view only works on forward_ranges");
-    static_assert(semialphabet<std::ranges::range_reference_t<urng_t>>, "The reference type of the underlying range must model "
-                  "seqan3::semialphabet.");
+    static_assert(semialphabet<std::ranges::range_reference_t<urng_t>>,
+                  "The reference type of the underlying range must model seqan3::semialphabet.");
 
     //!\brief The underlying range.
     urng_t urange;

--- a/include/seqan3/range/views/pairwise_combine.hpp
+++ b/include/seqan3/range/views/pairwise_combine.hpp
@@ -697,21 +697,21 @@ namespace seqan3::views
  *
  * ### View properties
  *
- * | Concepts and traits              | `urng_t` (underlying range type)      | `rrng_t` (returned range type)                                         |
- * |----------------------------------|:-------------------------------------:|:----------------------------------------------------------------------:|
- * | std::ranges::input_range         | *required*                            | *preserved*                                                            |
- * | std::ranges::forward_range       | *required*                            | *preserved*                                                            |
- * | std::ranges::bidirectional_range |                                       | *preserved*                                                            |
- * | std::ranges::random_access_range |                                       | *preserved*                                                            |
- * | std::ranges::contiguous_range    |                                       | *lost*                                                                 |
- * |                                  |                                       |                                                                        |
- * | std::ranges::viewable_range      | *required*                            | *guaranteed*                                                           |
- * | std::ranges::view                |                                       | *guaranteed*                                                           |
- * | std::ranges::sized_range         |                                       | *preserved*                                                            |
- * | std::ranges::common_range        | *required*                            | *guaranteed*                                                           |
- * | std::ranges::output_range        |                                       | *preserved*                                                            |
- * | seqan3::const_iterable_range     |                                       | *preserved*                                                            |
- * |                                  |                                       |                                                                        |
+ * | Concepts and traits              | `urng_t` (underlying range type)      | `rrng_t` (returned range type)                                                               |
+ * |----------------------------------|:-------------------------------------:|:--------------------------------------------------------------------------------------------:|
+ * | std::ranges::input_range         | *required*                            | *preserved*                                                                                  |
+ * | std::ranges::forward_range       | *required*                            | *preserved*                                                                                  |
+ * | std::ranges::bidirectional_range |                                       | *preserved*                                                                                  |
+ * | std::ranges::random_access_range |                                       | *preserved*                                                                                  |
+ * | std::ranges::contiguous_range    |                                       | *lost*                                                                                       |
+ * |                                  |                                       |                                                                                              |
+ * | std::ranges::viewable_range      | *required*                            | *guaranteed*                                                                                 |
+ * | std::ranges::view                |                                       | *guaranteed*                                                                                 |
+ * | std::ranges::sized_range         |                                       | *preserved*                                                                                  |
+ * | std::ranges::common_range        | *required*                            | *guaranteed*                                                                                 |
+ * | std::ranges::output_range        |                                       | *preserved*                                                                                  |
+ * | seqan3::const_iterable_range     |                                       | *preserved*                                                                                  |
+ * |                                  |                                       |                                                                                              |
  * | std::ranges::range_reference_t   |                                       | common_tuple<std::ranges::range_reference_t<urng_t>, std::ranges::range_reference_t<urng_t>> |
  *
  * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.

--- a/include/seqan3/range/views/pairwise_combine.hpp
+++ b/include/seqan3/range/views/pairwise_combine.hpp
@@ -712,7 +712,7 @@ namespace seqan3::views
  * | std::ranges::output_range        |                                       | *preserved*                                                            |
  * | seqan3::const_iterable_range     |                                       | *preserved*                                                            |
  * |                                  |                                       |                                                                        |
- * | std::ranges::range_reference_t   |                                       | common_tuple<seqan3::reference_t<urng_t>, seqan3::reference_t<urng_t>> |
+ * | std::ranges::range_reference_t   |                                       | common_tuple<std::ranges::range_reference_t<urng_t>, std::ranges::range_reference_t<urng_t>> |
  *
  * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.
  *

--- a/include/seqan3/range/views/persist.hpp
+++ b/include/seqan3/range/views/persist.hpp
@@ -234,7 +234,7 @@ namespace seqan3::views
  * | std::ranges::output_range        |                                       | *preserved*                                        |
  * | seqan3::const_iterable_range     |                                       | *preserved*                                        |
  * |                                  |                                       |                                                    |
- * | std::ranges::range_reference_t   |                                       | std::ranges::range_reference_t<urng_t>                        |
+ * | std::ranges::range_reference_t   |                                       | std::ranges::range_reference_t<urng_t>             |
  *
  * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.
  *

--- a/include/seqan3/range/views/persist.hpp
+++ b/include/seqan3/range/views/persist.hpp
@@ -55,7 +55,7 @@ public:
      * \{
      */
     //!\brief The reference_type.
-    using reference         = reference_t<urng_t>;
+    using reference         = std::ranges::range_reference_t<urng_t>;
     //!\brief The const_reference type is equal to the reference type.
     using const_reference   = reference;
     //!\brief The value_type (which equals the reference_type with any references removed).
@@ -234,7 +234,7 @@ namespace seqan3::views
  * | std::ranges::output_range        |                                       | *preserved*                                        |
  * | seqan3::const_iterable_range     |                                       | *preserved*                                        |
  * |                                  |                                       |                                                    |
- * | std::ranges::range_reference_t   |                                       | seqan3::reference_t<urng_t>                        |
+ * | std::ranges::range_reference_t   |                                       | std::ranges::range_reference_t<urng_t>                        |
  *
  * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.
  *

--- a/include/seqan3/range/views/single_pass_input.hpp
+++ b/include/seqan3/range/views/single_pass_input.hpp
@@ -201,7 +201,7 @@ public:
     //!\brief Pointer type.
     using pointer           = typename std::iterator_traits<base_iterator_type>::pointer;
     //!\brief Reference type.
-    using reference         = reference_t<base_iterator_type>;
+    using reference         = std::iter_reference_t<base_iterator_type>;
     //!\brief Iterator category.
     using iterator_category = std::input_iterator_tag;
     //!\}
@@ -360,7 +360,7 @@ namespace seqan3::views
  * | std::ranges::output_range        |                                       | *preserved*                                        |
  * | seqan3::const_iterable_range     |                                       | *lost*                                             |
  * |                                  |                                       |                                                    |
- * | std::ranges::range_reference_t   |                                       | seqan3::reference_t<urng_t>                        |
+ * | std::ranges::range_reference_t   |                                       | std::ranges::range_reference_t<urng_t>                        |
  *
  * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.
  *

--- a/include/seqan3/range/views/single_pass_input.hpp
+++ b/include/seqan3/range/views/single_pass_input.hpp
@@ -360,7 +360,7 @@ namespace seqan3::views
  * | std::ranges::output_range        |                                       | *preserved*                                        |
  * | seqan3::const_iterable_range     |                                       | *lost*                                             |
  * |                                  |                                       |                                                    |
- * | std::ranges::range_reference_t   |                                       | std::ranges::range_reference_t<urng_t>                        |
+ * | std::ranges::range_reference_t   |                                       | std::ranges::range_reference_t<urng_t>             |
  *
  * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.
  *

--- a/include/seqan3/range/views/slice.hpp
+++ b/include/seqan3/range/views/slice.hpp
@@ -106,7 +106,7 @@ namespace seqan3::views
  * | std::ranges::output_range        |                                   | *preserved*                     |
  * | seqan3::const_iterable_range     |                                   | *preserved*                     |
  * |                                  |                                   |                                  |
- * | std::ranges::range_reference_t   |                                   | seqan3::reference_t<urng_t>     |
+ * | std::ranges::range_reference_t   |                                   | std::ranges::range_reference_t<urng_t>     |
  *
  * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.
  *

--- a/include/seqan3/range/views/slice.hpp
+++ b/include/seqan3/range/views/slice.hpp
@@ -98,15 +98,15 @@ namespace seqan3::views
  * | std::ranges::bidirectional_range |                                   | *preserved*                     |
  * | std::ranges::random_access_range |                                   | *preserved*                     |
  * | std::ranges::contiguous_range    |                                   | *preserved*                     |
- * |                                  |                                   |                                  |
+ * |                                  |                                   |                                 |
  * | std::ranges::viewable_range      | *required*                        | *guaranteed*                    |
  * | std::ranges::view                |                                   | *guaranteed*                    |
  * | std::ranges::sized_range         |                                   | *preserved*                     |
  * | std::ranges::common_range        |                                   | *preserved*                     |
  * | std::ranges::output_range        |                                   | *preserved*                     |
  * | seqan3::const_iterable_range     |                                   | *preserved*                     |
- * |                                  |                                   |                                  |
- * | std::ranges::range_reference_t   |                                   | std::ranges::range_reference_t<urng_t>     |
+ * |                                  |                                   |                                 |
+ * | std::ranges::range_reference_t   |                                   | std::ranges::range_reference_t<urng_t> |
  *
  * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.
  *

--- a/include/seqan3/range/views/slice.hpp
+++ b/include/seqan3/range/views/slice.hpp
@@ -91,21 +91,21 @@ namespace seqan3::views
  *
  * ### View properties
  *
- * | Concepts and traits              | `urng_t` (underlying range type)  | `rrng_t` (returned range type)  |
- * |----------------------------------|:---------------------------------:|:-------------------------------:|
- * | std::ranges::input_range         | *required*                        | *preserved*                     |
- * | std::ranges::forward_range       |                                   | *preserved*                     |
- * | std::ranges::bidirectional_range |                                   | *preserved*                     |
- * | std::ranges::random_access_range |                                   | *preserved*                     |
- * | std::ranges::contiguous_range    |                                   | *preserved*                     |
- * |                                  |                                   |                                 |
- * | std::ranges::viewable_range      | *required*                        | *guaranteed*                    |
- * | std::ranges::view                |                                   | *guaranteed*                    |
- * | std::ranges::sized_range         |                                   | *preserved*                     |
- * | std::ranges::common_range        |                                   | *preserved*                     |
- * | std::ranges::output_range        |                                   | *preserved*                     |
- * | seqan3::const_iterable_range     |                                   | *preserved*                     |
- * |                                  |                                   |                                 |
+ * | Concepts and traits              | `urng_t` (underlying range type)  | `rrng_t` (returned range type)         |
+ * |----------------------------------|:---------------------------------:|:--------------------------------------:|
+ * | std::ranges::input_range         | *required*                        | *preserved*                            |
+ * | std::ranges::forward_range       |                                   | *preserved*                            |
+ * | std::ranges::bidirectional_range |                                   | *preserved*                            |
+ * | std::ranges::random_access_range |                                   | *preserved*                            |
+ * | std::ranges::contiguous_range    |                                   | *preserved*                            |
+ * |                                  |                                   |                                        |
+ * | std::ranges::viewable_range      | *required*                        | *guaranteed*                           |
+ * | std::ranges::view                |                                   | *guaranteed*                           |
+ * | std::ranges::sized_range         |                                   | *preserved*                            |
+ * | std::ranges::common_range        |                                   | *preserved*                            |
+ * | std::ranges::output_range        |                                   | *preserved*                            |
+ * | seqan3::const_iterable_range     |                                   | *preserved*                            |
+ * |                                  |                                   |                                        |
  * | std::ranges::range_reference_t   |                                   | std::ranges::range_reference_t<urng_t> |
  *
  * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.
@@ -119,12 +119,12 @@ namespace seqan3::views
  *
  * ### Return type
  *
- * | `urng_t` (underlying range type)                                                       | `rrng_t` (returned range type)  |
- * |:--------------------------------------------------------------------------------------:|:-------------------------------:|
- * | `std::basic_string const &` *or* `std::basic_string_view`                              | `std::basic_string_view`        |
- * | `seqan3::forwarding_range && std::ranges::sized_range && std::ranges::contiguous_range`   | `std::span`                     |
+ * | `urng_t` (underlying range type)                                                           | `rrng_t` (returned range type)  |
+ * |:------------------------------------------------------------------------------------------:|:-------------------------------:|
+ * | `std::basic_string const &` *or* `std::basic_string_view`                                  | `std::basic_string_view`        |
+ * | `seqan3::forwarding_range && std::ranges::sized_range && std::ranges::contiguous_range`    | `std::span`                     |
  * | `seqan3::forwarding_range && std::ranges::sized_range && std::ranges::random_access_range` | `std::ranges::subrange`         |
- * | *else*                                                                                 | *implementation defined type*   |
+ * | *else*                                                                                     | *implementation defined type*   |
  *
  * The adaptor returns exactly the type specified above.
  *

--- a/include/seqan3/range/views/take.hpp
+++ b/include/seqan3/range/views/take.hpp
@@ -581,33 +581,33 @@ namespace seqan3::views
  *
  * ### View properties
  *
- * | Concepts and traits              | `urng_t` (underlying range type)   | `rrng_t` (returned range type)   |
- * |----------------------------------|:----------------------------------:|:--------------------------------:|
- * | std::ranges::input_range         | *required*                         | *preserved*                      |
- * | std::ranges::forward_range       |                                    | *preserved*                      |
- * | std::ranges::bidirectional_range |                                    | *preserved*                      |
- * | std::ranges::random_access_range |                                    | *preserved*                      |
- * | std::ranges::contiguous_range    |                                    | *preserved*                      |
- * |                                  |                                    |                                  |
- * | std::ranges::viewable_range      | *required*                         | *guaranteed*                     |
- * | std::ranges::view                |                                    | *guaranteed*                     |
- * | std::ranges::sized_range         |                                    | *preserved*                      |
- * | std::ranges::common_range        |                                    | *preserved*                      |
- * | std::ranges::output_range        |                                    | *preserved*                      |
- * | seqan3::const_iterable_range     |                                    | *preserved*                      |
- * |                                  |                                    |                                  |
+ * | Concepts and traits              | `urng_t` (underlying range type)   | `rrng_t` (returned range type)         |
+ * |----------------------------------|:----------------------------------:|:--------------------------------------:|
+ * | std::ranges::input_range         | *required*                         | *preserved*                            |
+ * | std::ranges::forward_range       |                                    | *preserved*                            |
+ * | std::ranges::bidirectional_range |                                    | *preserved*                            |
+ * | std::ranges::random_access_range |                                    | *preserved*                            |
+ * | std::ranges::contiguous_range    |                                    | *preserved*                            |
+ * |                                  |                                    |                                        |
+ * | std::ranges::viewable_range      | *required*                         | *guaranteed*                           |
+ * | std::ranges::view                |                                    | *guaranteed*                           |
+ * | std::ranges::sized_range         |                                    | *preserved*                            |
+ * | std::ranges::common_range        |                                    | *preserved*                            |
+ * | std::ranges::output_range        |                                    | *preserved*                            |
+ * | seqan3::const_iterable_range     |                                    | *preserved*                            |
+ * |                                  |                                    |                                        |
  * | std::ranges::range_reference_t   |                                    | std::ranges::range_reference_t<urng_t> |
  *
  * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.
  *
  * ### Return type
  *
- * | `urng_t` (underlying range type)                                                       | `rrng_t` (returned range type)  |
- * |:--------------------------------------------------------------------------------------:|:-------------------------------:|
- * | `std::basic_string const &` *or* `std::basic_string_view`                              | `std::basic_string_view`        |
- * | `seqan3::forwarding_range && std::ranges::sized_range && std::ranges::contiguous_range`   | `std::span`                     |
+ * | `urng_t` (underlying range type)                                                           | `rrng_t` (returned range type)  |
+ * |:------------------------------------------------------------------------------------------:|:-------------------------------:|
+ * | `std::basic_string const &` *or* `std::basic_string_view`                                  | `std::basic_string_view`        |
+ * | `seqan3::forwarding_range && std::ranges::sized_range && std::ranges::contiguous_range`    | `std::span`                     |
  * | `seqan3::forwarding_range && std::ranges::sized_range && std::ranges::random_access_range` | `std::ranges::subrange`         |
- * | *else*                                                                                 | *implementation defined type*   |
+ * | *else*                                                                                     | *implementation defined type*   |
  *
  * This adaptor is different from std::views::take in that it performs type erasure for some underlying ranges.
  * It returns exactly the type specified above.

--- a/include/seqan3/range/views/take.hpp
+++ b/include/seqan3/range/views/take.hpp
@@ -284,7 +284,7 @@ private:
      * \{
      */
     //!\brief The reference_type.
-    using reference         = reference_t<urng_t>;
+    using reference         = std::ranges::range_reference_t<urng_t>;
     //!\brief The const_reference type is equal to the reference type if the underlying range is const-iterable.
     using const_reference   = detail::transformation_trait_or_t<seqan3::reference<urng_t const>, void>;
     //!\brief The value_type (which equals the reference_type with any references removed).
@@ -596,7 +596,7 @@ namespace seqan3::views
  * | std::ranges::output_range        |                                    | *preserved*                      |
  * | seqan3::const_iterable_range     |                                    | *preserved*                      |
  * |                                  |                                    |                                  |
- * | std::ranges::range_reference_t   |                                    | seqan3::reference_t<urng_t>      |
+ * | std::ranges::range_reference_t   |                                    | std::ranges::range_reference_t<urng_t>      |
  *
  * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.
  *

--- a/include/seqan3/range/views/take.hpp
+++ b/include/seqan3/range/views/take.hpp
@@ -596,7 +596,7 @@ namespace seqan3::views
  * | std::ranges::output_range        |                                    | *preserved*                      |
  * | seqan3::const_iterable_range     |                                    | *preserved*                      |
  * |                                  |                                    |                                  |
- * | std::ranges::range_reference_t   |                                    | std::ranges::range_reference_t<urng_t>      |
+ * | std::ranges::range_reference_t   |                                    | std::ranges::range_reference_t<urng_t> |
  *
  * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.
  *

--- a/include/seqan3/range/views/take_exactly.hpp
+++ b/include/seqan3/range/views/take_exactly.hpp
@@ -55,7 +55,7 @@ namespace seqan3::views
  * | std::ranges::output_range        |                                       | *preserved* except if `urng_t` is std::basic_string|
  * | seqan3::const_iterable_range     |                                       | *preserved*                                        |
  * |                                  |                                       |                                                    |
- * | std::ranges::range_reference_t   |                                       | std::ranges::range_reference_t<urng_t>                        |
+ * | std::ranges::range_reference_t   |                                       | std::ranges::range_reference_t<urng_t>             |
  *
  * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.
  *

--- a/include/seqan3/range/views/take_exactly.hpp
+++ b/include/seqan3/range/views/take_exactly.hpp
@@ -55,7 +55,7 @@ namespace seqan3::views
  * | std::ranges::output_range        |                                       | *preserved* except if `urng_t` is std::basic_string|
  * | seqan3::const_iterable_range     |                                       | *preserved*                                        |
  * |                                  |                                       |                                                    |
- * | std::ranges::range_reference_t   |                                       | seqan3::reference_t<urng_t>                        |
+ * | std::ranges::range_reference_t   |                                       | std::ranges::range_reference_t<urng_t>                        |
  *
  * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.
  *

--- a/include/seqan3/range/views/take_line.hpp
+++ b/include/seqan3/range/views/take_line.hpp
@@ -63,7 +63,7 @@ namespace seqan3::views
  * | std::ranges::output_range        |                                       | *preserved*                                        |
  * | seqan3::const_iterable_range     |                                       | *preserved*                                        |
  * |                                  |                                       |                                                    |
- * | std::ranges::range_reference_t   | std::common_reference_with<char>            | seqan3::reference_t<urng_t>                        |
+ * | std::ranges::range_reference_t   | std::common_reference_with<char>            | std::ranges::range_reference_t<urng_t>                        |
  *
  * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.
  *

--- a/include/seqan3/range/views/take_line.hpp
+++ b/include/seqan3/range/views/take_line.hpp
@@ -63,7 +63,7 @@ namespace seqan3::views
  * | std::ranges::output_range        |                                       | *preserved*                                        |
  * | seqan3::const_iterable_range     |                                       | *preserved*                                        |
  * |                                  |                                       |                                                    |
- * | std::ranges::range_reference_t   | std::common_reference_with<char>            | std::ranges::range_reference_t<urng_t>                        |
+ * | std::ranges::range_reference_t   | std::common_reference_with<char>      | std::ranges::range_reference_t<urng_t>             |
  *
  * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.
  *

--- a/include/seqan3/range/views/take_until.hpp
+++ b/include/seqan3/range/views/take_until.hpp
@@ -54,7 +54,8 @@ class view_take_until : public std::ranges::view_interface<view_take_until<urng_
 private:
 
     static_assert(std::invocable<fun_t, std::ranges::range_reference_t<urng_t>>,
-                  "The functor type for views::take_until must model std::invocable<fun_t, std::ranges::range_reference_t<urng_t>>.");
+                  "The functor type for views::take_until must model"
+                  "std::invocable<fun_t, std::ranges::range_reference_t<urng_t>>.");
     static_assert(std::boolean<std::result_of_t<fun_t&&(std::ranges::range_reference_t<urng_t>)>>,
                   "The functor type for views::take_until must return std::boolean.");
 
@@ -557,7 +558,7 @@ namespace seqan3::views
  * | std::ranges::output_range        |                                       | *preserved*                                        |
  * | seqan3::const_iterable_range     |                                       | *preserved*¹                                       |
  * |                                  |                                       |                                                    |
- * | std::ranges::range_reference_t   |                                       | std::ranges::range_reference_t<urng_t>                        |
+ * | std::ranges::range_reference_t   |                                       | std::ranges::range_reference_t<urng_t>             |
  *
  * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.
  *

--- a/include/seqan3/range/views/take_until.hpp
+++ b/include/seqan3/range/views/take_until.hpp
@@ -38,7 +38,7 @@ namespace seqan3::detail
 /*!\brief The type returned by seqan3::views::take_until and seqan3::views::take_until_or_throw.
  * \tparam urng_t    The type of the underlying range, must model std::ranges::view.
  * \tparam fun_t     Type of the callable that will be evaluated on every member; must model
- *                   std::invocable with seqan3::reference_t<urng_t> as argument and return `bool`.
+ *                   std::invocable with std::ranges::range_reference_t<urng_t> as argument and return `bool`.
  * \tparam or_throw  Whether to throw an exception when the input is exhausted before the end of line is reached.
  * \implements std::ranges::view
  * \implements std::ranges::random_access_range
@@ -53,9 +53,9 @@ class view_take_until : public std::ranges::view_interface<view_take_until<urng_
 {
 private:
 
-    static_assert(std::invocable<fun_t, reference_t<urng_t>>,
-                  "The functor type for views::take_until must model std::invocable<fun_t, reference_t<urng_t>>.");
-    static_assert(std::boolean<std::result_of_t<fun_t&&(reference_t<urng_t>)>>,
+    static_assert(std::invocable<fun_t, std::ranges::range_reference_t<urng_t>>,
+                  "The functor type for views::take_until must model std::invocable<fun_t, std::ranges::range_reference_t<urng_t>>.");
+    static_assert(std::boolean<std::result_of_t<fun_t&&(std::ranges::range_reference_t<urng_t>)>>,
                   "The functor type for views::take_until must return std::boolean.");
 
     //!\brief The underlying range.
@@ -66,7 +66,7 @@ private:
 
     //!\brief Whether this view is const_iterable or not.
     static constexpr bool const_iterable = const_iterable_range<urng_t> &&
-                                           std::regular_invocable<fun_t, reference_t<urng_t>>;
+                                           std::regular_invocable<fun_t, std::ranges::range_reference_t<urng_t>>;
 
     //!\brief The iterator type inherits from the underlying type, but overwrites several operators.
     //!\tparam rng_t Should be `urng_t` for defining #iterator and `urng_t const` for defining #const_iterator.
@@ -349,7 +349,7 @@ public:
      * \{
      */
     //!\brief The reference_type.
-    using reference         = reference_t<urng_t>;
+    using reference         = std::ranges::range_reference_t<urng_t>;
     //!\brief The const_reference type is equal to the reference type if the underlying range is const-iterable.
     using const_reference   = detail::transformation_trait_or_t<seqan3::reference<urng_t const>, void>;
     //!\brief The value_type (which equals the reference_type with any references removed).
@@ -528,7 +528,7 @@ namespace seqan3::views
  *                      true (or the end of the underlying range is reached).
  * \tparam urng_t       The type of the range being processed. See below for requirements. [template parameter is
  *                      omitted in pipe notation]
- * \tparam fun_t        The type of the functor; must model std::invocable with seqan3::reference_t<urng_t>
+ * \tparam fun_t        The type of the functor; must model std::invocable with std::ranges::range_reference_t<urng_t>
  *                      and return a type convertible to `bool`.
  * \param[in] urange    The range being processed. [parameter is omitted in pipe notation]
  * \param[in] fun       The functor.
@@ -557,12 +557,12 @@ namespace seqan3::views
  * | std::ranges::output_range        |                                       | *preserved*                                        |
  * | seqan3::const_iterable_range     |                                       | *preserved*¹                                       |
  * |                                  |                                       |                                                    |
- * | std::ranges::range_reference_t   |                                       | seqan3::reference_t<urng_t>                        |
+ * | std::ranges::range_reference_t   |                                       | std::ranges::range_reference_t<urng_t>                        |
  *
  * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.
  *
  * ¹ The marked properties are only *preserved* if the specified functor models
- * `std::regular_invocable<fun_t, reference_t<urng_t>`, i.e. applying the functor doesn't change the functor.
+ * `std::regular_invocable<fun_t, std::ranges::range_reference_t<urng_t>`, i.e. applying the functor doesn't change the functor.
  * If the functor only models `std::invocable` and not `std::regular_invocable` these concepts are *lost*.
  *
  * Throwing: `seqan3::views::take_until_or_throw` and `seqan3::views::take_until_or_throw_and_consume` throw an exception

--- a/include/seqan3/range/views/to_lower.hpp
+++ b/include/seqan3/range/views/to_lower.hpp
@@ -40,22 +40,22 @@ namespace seqan3::views
  * This view is a **deep view** Given a range-of-range as input (as opposed to just a range), it will apply
  * the transformation on the innermost range (instead of the outermost range).
  *
- * | Concepts and traits              | `urng_t` (underlying range type) | `rrng_t` (returned range type)                          |
- * |----------------------------------|:--------------------------------:|:-------------------------------------------------------:|
- * | std::ranges::input_range         | *required*                       | *preserved*                                             |
- * | std::ranges::forward_range       |                                  | *preserved*                                             |
- * | std::ranges::bidirectional_range |                                  | *preserved*                                             |
- * | std::ranges::random_access_range |                                  | *preserved*                                             |
- * | std::ranges::contiguous_range    |                                  | *lost*                                                  |
- * |                                  |                                  |                                                         |
- * | std::ranges::viewable_range      | *required*                       | *guaranteed*                                            |
- * | std::ranges::view                |                                  | *guaranteed*                                            |
- * | std::ranges::sized_range         |                                  | *preserved*                                             |
- * | std::ranges::common_range        |                                  | *preserved*                                             |
- * | std::ranges::output_range        |                                  | *lost*                                                  |
- * | seqan3::const_iterable_range     |                                  | *preserved*                                             |
- * |                                  |                                  |                                                         |
- * | std::ranges::range_reference_t   | seqan3::builtin_character                     | seqan3::remove_reference_t<std::ranges::range_reference_t<urngt_>> |
+ * | Concepts and traits              | `urng_t` (underlying range type) | `rrng_t` (returned range type)                                     |
+ * |----------------------------------|:--------------------------------:|:------------------------------------------------------------------:|
+ * | std::ranges::input_range         | *required*                       | *preserved*                                                        |
+ * | std::ranges::forward_range       |                                  | *preserved*                                                        |
+ * | std::ranges::bidirectional_range |                                  | *preserved*                                                        |
+ * | std::ranges::random_access_range |                                  | *preserved*                                                        |
+ * | std::ranges::contiguous_range    |                                  | *lost*                                                             |
+ * |                                  |                                  |                                                                    |
+ * | std::ranges::viewable_range      | *required*                       | *guaranteed*                                                       |
+ * | std::ranges::view                |                                  | *guaranteed*                                                       |
+ * | std::ranges::sized_range         |                                  | *preserved*                                                        |
+ * | std::ranges::common_range        |                                  | *preserved*                                                        |
+ * | std::ranges::output_range        |                                  | *lost*                                                             |
+ * | seqan3::const_iterable_range     |                                  | *preserved*                                                        |
+ * |                                  |                                  |                                                                    |
+ * | std::ranges::range_reference_t   | seqan3::builtin_character        | seqan3::remove_reference_t<std::ranges::range_reference_t<urngt_>> |
  *
  * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.
  *

--- a/include/seqan3/range/views/to_lower.hpp
+++ b/include/seqan3/range/views/to_lower.hpp
@@ -55,7 +55,7 @@ namespace seqan3::views
  * | std::ranges::output_range        |                                  | *lost*                                                  |
  * | seqan3::const_iterable_range     |                                  | *preserved*                                             |
  * |                                  |                                  |                                                         |
- * | std::ranges::range_reference_t   | seqan3::builtin_character                     | seqan3::remove_reference_t<seqan3::reference_t<urngt_>> |
+ * | std::ranges::range_reference_t   | seqan3::builtin_character                     | seqan3::remove_reference_t<std::ranges::range_reference_t<urngt_>> |
  *
  * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.
  *

--- a/include/seqan3/range/views/to_upper.hpp
+++ b/include/seqan3/range/views/to_upper.hpp
@@ -40,22 +40,22 @@ namespace seqan3::views
  * This view is a **deep view** Given a range-of-range as input (as opposed to just a range), it will apply
  * the transformation on the innermost range (instead of the outermost range).
  *
- * | Concepts and traits              | `urng_t` (underlying range type) | `rrng_t` (returned range type)                          |
- * |----------------------------------|:--------------------------------:|:-------------------------------------------------------:|
- * | std::ranges::input_range         | *required*                       | *preserved*                                             |
- * | std::ranges::forward_range       |                                  | *preserved*                                             |
- * | std::ranges::bidirectional_range |                                  | *preserved*                                             |
- * | std::ranges::random_access_range |                                  | *preserved*                                             |
- * | std::ranges::contiguous_range    |                                  | *lost*                                                  |
- * |                                  |                                  |                                                         |
- * | std::ranges::viewable_range      | *required*                       | *guaranteed*                                            |
- * | std::ranges::view                |                                  | *guaranteed*                                            |
- * | std::ranges::sized_range         |                                  | *preserved*                                             |
- * | std::ranges::common_range        |                                  | *preserved*                                             |
- * | std::ranges::output_range        |                                  | *lost*                                                  |
- * | seqan3::const_iterable_range     |                                  | *preserved*                                             |
- * |                                  |                                  |                                                         |
- * | std::ranges::range_reference_t   | seqan3::builtin_character                     | seqan3::remove_reference_t<std::ranges::range_reference_t<urngt_>> |
+ * | Concepts and traits              | `urng_t` (underlying range type) | `rrng_t` (returned range type)                                     |
+ * |----------------------------------|:--------------------------------:|:------------------------------------------------------------------:|
+ * | std::ranges::input_range         | *required*                       | *preserved*                                                        |
+ * | std::ranges::forward_range       |                                  | *preserved*                                                        |
+ * | std::ranges::bidirectional_range |                                  | *preserved*                                                        |
+ * | std::ranges::random_access_range |                                  | *preserved*                                                        |
+ * | std::ranges::contiguous_range    |                                  | *lost*                                                             |
+ * |                                  |                                  |                                                                    |
+ * | std::ranges::viewable_range      | *required*                       | *guaranteed*                                                       |
+ * | std::ranges::view                |                                  | *guaranteed*                                                       |
+ * | std::ranges::sized_range         |                                  | *preserved*                                                        |
+ * | std::ranges::common_range        |                                  | *preserved*                                                        |
+ * | std::ranges::output_range        |                                  | *lost*                                                             |
+ * | seqan3::const_iterable_range     |                                  | *preserved*                                                        |
+ * |                                  |                                  |                                                                    |
+ * | std::ranges::range_reference_t   | seqan3::builtin_character        | seqan3::remove_reference_t<std::ranges::range_reference_t<urngt_>> |
   *
  * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.
  *

--- a/include/seqan3/range/views/to_upper.hpp
+++ b/include/seqan3/range/views/to_upper.hpp
@@ -55,7 +55,7 @@ namespace seqan3::views
  * | std::ranges::output_range        |                                  | *lost*                                                  |
  * | seqan3::const_iterable_range     |                                  | *preserved*                                             |
  * |                                  |                                  |                                                         |
- * | std::ranges::range_reference_t   | seqan3::builtin_character                     | seqan3::remove_reference_t<seqan3::reference_t<urngt_>> |
+ * | std::ranges::range_reference_t   | seqan3::builtin_character                     | seqan3::remove_reference_t<std::ranges::range_reference_t<urngt_>> |
   *
  * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.
  *

--- a/include/seqan3/range/views/translate.hpp
+++ b/include/seqan3/range/views/translate.hpp
@@ -39,7 +39,7 @@ template <std::ranges::view urng_t>
 //!\cond
     requires std::ranges::sized_range<urng_t> &&
              std::ranges::random_access_range<urng_t> &&
-             nucleotide_alphabet<reference_t<urng_t>>
+             nucleotide_alphabet<std::ranges::range_reference_t<urng_t>>
 //!\endcond
 class view_translate;
 
@@ -47,7 +47,7 @@ template <std::ranges::view urng_t>
 //!\cond
     requires std::ranges::sized_range<urng_t> &&
              std::ranges::random_access_range<urng_t> &&
-             nucleotide_alphabet<reference_t<urng_t>>
+             nucleotide_alphabet<std::ranges::range_reference_t<urng_t>>
 //!\endcond
 class view_translate_single;
 
@@ -121,7 +121,7 @@ struct translate_fn
             "The range parameter to views::translate[_single] must model std::ranges::sized_range.");
         static_assert(std::ranges::random_access_range<urng_t>,
             "The range parameter to views::translate[_single] must model std::ranges::random_access_range.");
-        static_assert(nucleotide_alphabet<reference_t<urng_t>>,
+        static_assert(nucleotide_alphabet<std::ranges::range_reference_t<urng_t>>,
             "The range parameter to views::translate[_single] must be over elements of seqan3::nucleotide_alphabet.");
 
         if constexpr (single)
@@ -152,7 +152,7 @@ template <std::ranges::view urng_t>
 //!\cond
     requires std::ranges::sized_range<urng_t> &&
              std::ranges::random_access_range<urng_t> &&
-             nucleotide_alphabet<reference_t<urng_t>>
+             nucleotide_alphabet<std::ranges::range_reference_t<urng_t>>
 //!\endcond
 class view_translate_single : public ranges::view_base
 {
@@ -524,7 +524,7 @@ template <std::ranges::view urng_t>
 //!\cond
     requires std::ranges::sized_range<urng_t> &&
              std::ranges::random_access_range<urng_t> &&
-             nucleotide_alphabet<reference_t<urng_t>>
+             nucleotide_alphabet<std::ranges::range_reference_t<urng_t>>
 //!\endcond
 class view_translate : public ranges::view_base
 {
@@ -743,7 +743,7 @@ template <typename urng_t>
 //!\cond
     requires std::ranges::sized_range<urng_t> &&
              std::ranges::random_access_range<urng_t> &&
-             nucleotide_alphabet<reference_t<urng_t>>
+             nucleotide_alphabet<std::ranges::range_reference_t<urng_t>>
 //!\endcond
 view_translate(urng_t &&, translation_frames const = translation_frames{}) -> view_translate<std::ranges::all_view<urng_t>>;
 

--- a/include/seqan3/range/views/translate_join.hpp
+++ b/include/seqan3/range/views/translate_join.hpp
@@ -57,15 +57,15 @@ protected:
      * \{
      */
     //!\brief The reference_type.
-    using reference         = view_translate_single<std::ranges::all_view<reference_t<urng_t>>>;
+    using reference         = view_translate_single<std::ranges::all_view<std::ranges::range_reference_t<urng_t>>>;
     //!\brief The const_reference type.
     using const_reference   = reference;
     //!\brief The value_type (which equals the reference_type with any references removed).
     using value_type        = reference;
     //!\brief The size_type.
-    using size_type         = size_type_t<reference_t<urng_t>>;
+    using size_type         = size_type_t<std::ranges::range_reference_t<urng_t>>;
     //!\brief A signed integer type, usually std::ptrdiff_t.
-    using difference_type   = std::ranges::range_difference_t<reference_t<urng_t>>;
+    using difference_type   = std::ranges::range_difference_t<std::ranges::range_reference_t<urng_t>>;
     //!\brief The iterator type of this view (a random access iterator).
     using iterator          = detail::random_access_iterator<view_translate_join>;
     //!\brief The const iterator type of this view (same as iterator, because it's a view).
@@ -78,17 +78,17 @@ public:
         "This adaptor only handles range-of-range (two dimensions) as input.");
     static_assert(std::ranges::viewable_range<urng_t>,
         "The range parameter to views::translate_join cannot be a temporary of a non-view range.");
-    static_assert(std::ranges::viewable_range<reference_t<urng_t>>,
+    static_assert(std::ranges::viewable_range<std::ranges::range_reference_t<urng_t>>,
         "The inner range of the range parameter to views::translate_join cannot be a temporary of a non-view range.");
     static_assert(std::ranges::sized_range<urng_t>,
         "The range parameter to views::translate_join must model std::ranges::sized_range.");
-    static_assert(std::ranges::sized_range<reference_t<urng_t>>,
+    static_assert(std::ranges::sized_range<std::ranges::range_reference_t<urng_t>>,
         "The inner range of the range parameter to views::translate_join must model std::ranges::sized_range.");
     static_assert(std::ranges::random_access_range<urng_t>,
         "The range parameter to views::translate_join must model std::ranges::random_access_range.");
-    static_assert(std::ranges::random_access_range<reference_t<urng_t>>,
+    static_assert(std::ranges::random_access_range<std::ranges::range_reference_t<urng_t>>,
         "The inner range of the range parameter to views::translate_join must model std::ranges::random_access_range.");
-    static_assert(nucleotide_alphabet<reference_t<reference_t<urng_t>>>,
+    static_assert(nucleotide_alphabet<std::ranges::range_reference_t<std::ranges::range_reference_t<urng_t>>>,
         "The range parameter to views::translate_join must be over a range over elements of seqan3::nucleotide_alphabet.");
 
     /*!\name Constructors, destructor and assignment
@@ -295,17 +295,17 @@ struct translate_join_fn
             "This adaptor only handles range-of-range (two dimensions) as input.");
         static_assert(std::ranges::viewable_range<urng_t>,
             "The range parameter to views::translate_join cannot be a temporary of a non-view range.");
-        static_assert(std::ranges::viewable_range<reference_t<urng_t>>,
+        static_assert(std::ranges::viewable_range<std::ranges::range_reference_t<urng_t>>,
             "The inner range of the range parameter to views::translate_join cannot be a temporary of a non-view range.");
         static_assert(std::ranges::sized_range<urng_t>,
             "The range parameter to views::translate_join must model std::ranges::sized_range.");
-        static_assert(std::ranges::sized_range<reference_t<urng_t>>,
+        static_assert(std::ranges::sized_range<std::ranges::range_reference_t<urng_t>>,
             "The inner range of the range parameter to views::translate_join must model std::ranges::sized_range.");
         static_assert(std::ranges::random_access_range<urng_t>,
             "The range parameter to views::translate_join must model std::ranges::random_access_range.");
-        static_assert(std::ranges::random_access_range<reference_t<urng_t>>,
+        static_assert(std::ranges::random_access_range<std::ranges::range_reference_t<urng_t>>,
             "The inner range of the range parameter to views::translate_join must model std::ranges::random_access_range.");
-        static_assert(nucleotide_alphabet<reference_t<reference_t<urng_t>>>,
+        static_assert(nucleotide_alphabet<std::ranges::range_reference_t<std::ranges::range_reference_t<urng_t>>>,
             "The range parameter to views::translate_join must be over a range over elements of seqan3::nucleotide_alphabet.");
 
         return detail::view_translate_join{std::forward<urng_t>(urange), tf};

--- a/include/seqan3/range/views/trim.hpp
+++ b/include/seqan3/range/views/trim.hpp
@@ -99,19 +99,19 @@ namespace seqan3::views
  * This view is a **deep view** Given a range-of-range as input (as opposed to just a range), it will apply
  * the transformation on the innermost range (instead of the outermost range).
  *
- * | Concepts and traits              | `urng_t` (underlying range type)      | `rrng_t` (returned range type)  |
- * |----------------------------------|:-------------------------------------:|:-------------------------------:|
- * | std::ranges::input_range         | *required*                            | *preserved*                     |
- * | std::ranges::forward_range       |                                       | *preserved*                     |
- * | std::ranges::bidirectional_range |                                       | *preserved*                     |
- * | std::ranges::random_access_range |                                       | *preserved*                     |
- * |                                  |                                       |                                 |
- * | std::ranges::view                |                                       | *guaranteed*                    |
- * | std::ranges::sized_range         |                                       | *lost*                          |
- * | std::ranges::common_range        |                                       | *lost*                          |
- * | std::ranges::output_range        |                                       | *preserved*                     |
- * | seqan3::const_iterable_range     |                                       | *preserved*                     |
- * |                                  |                                       |                                 |
+ * | Concepts and traits              | `urng_t` (underlying range type)      | `rrng_t` (returned range type)         |
+ * |----------------------------------|:-------------------------------------:|:--------------------------------------:|
+ * | std::ranges::input_range         | *required*                            | *preserved*                            |
+ * | std::ranges::forward_range       |                                       | *preserved*                            |
+ * | std::ranges::bidirectional_range |                                       | *preserved*                            |
+ * | std::ranges::random_access_range |                                       | *preserved*                            |
+ * |                                  |                                       |                                        |
+ * | std::ranges::view                |                                       | *guaranteed*                           |
+ * | std::ranges::sized_range         |                                       | *lost*                                 |
+ * | std::ranges::common_range        |                                       | *lost*                                 |
+ * | std::ranges::output_range        |                                       | *preserved*                            |
+ * | seqan3::const_iterable_range     |                                       | *preserved*                            |
+ * |                                  |                                       |                                        |
  * | std::ranges::range_reference_t   | seqan3::quality_alphabet              | std::ranges::range_reference_t<urng_t> |
  *
  * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.

--- a/include/seqan3/range/views/trim.hpp
+++ b/include/seqan3/range/views/trim.hpp
@@ -105,14 +105,14 @@ namespace seqan3::views
  * | std::ranges::forward_range       |                                       | *preserved*                     |
  * | std::ranges::bidirectional_range |                                       | *preserved*                     |
  * | std::ranges::random_access_range |                                       | *preserved*                     |
- * |                                  |                                       |                                  |
+ * |                                  |                                       |                                 |
  * | std::ranges::view                |                                       | *guaranteed*                    |
  * | std::ranges::sized_range         |                                       | *lost*                          |
  * | std::ranges::common_range        |                                       | *lost*                          |
  * | std::ranges::output_range        |                                       | *preserved*                     |
  * | seqan3::const_iterable_range     |                                       | *preserved*                     |
- * |                                  |                                       |                                  |
- * | std::ranges::range_reference_t   | seqan3::quality_alphabet               | std::ranges::range_reference_t<urng_t>     |
+ * |                                  |                                       |                                 |
+ * | std::ranges::range_reference_t   | seqan3::quality_alphabet              | std::ranges::range_reference_t<urng_t> |
  *
  * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.
  *

--- a/include/seqan3/range/views/trim.hpp
+++ b/include/seqan3/range/views/trim.hpp
@@ -46,16 +46,18 @@ struct trim_fn
     template <std::ranges::input_range irng_t, typename threshold_t>
     constexpr auto operator()(irng_t && irange, threshold_t const threshold) const
     {
-        static_assert(quality_alphabet<std::remove_reference_t<reference_t<irng_t>>>,
+        static_assert(quality_alphabet<std::remove_reference_t<std::ranges::range_reference_t<irng_t>>>,
                       "views::trim can only operate on ranges over seqan3::quality_alphabet.");
-        static_assert(std::same_as<remove_cvref_t<threshold_t>, remove_cvref_t<reference_t<irng_t>>> ||
+        static_assert(std::same_as<remove_cvref_t<threshold_t>,
+                     remove_cvref_t<std::ranges::range_reference_t<irng_t>>> ||
                       std::integral<remove_cvref_t<threshold_t>>,
                       "The threshold must either be a letter of the underlying alphabet or an integral type "
                       "in which case it is compared with the underlying phred type.");
 
         return views::take_until(std::forward<irng_t>(irange), [threshold] (auto const value)
         {
-            if constexpr (std::same_as<remove_cvref_t<threshold_t>, remove_cvref_t<reference_t<irng_t>>>)
+            if constexpr (std::same_as<remove_cvref_t<threshold_t>,
+                          remove_cvref_t<std::ranges::range_reference_t<irng_t>>>)
             {
                 return to_phred(value) < to_phred(threshold);
             }
@@ -110,7 +112,7 @@ namespace seqan3::views
  * | std::ranges::output_range        |                                       | *preserved*                     |
  * | seqan3::const_iterable_range     |                                       | *preserved*                     |
  * |                                  |                                       |                                  |
- * | std::ranges::range_reference_t   | seqan3::quality_alphabet               | seqan3::reference_t<urng_t>     |
+ * | std::ranges::range_reference_t   | seqan3::quality_alphabet               | std::ranges::range_reference_t<urng_t>     |
  *
  * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.
  *

--- a/include/seqan3/range/views/type_reduce.hpp
+++ b/include/seqan3/range/views/type_reduce.hpp
@@ -132,7 +132,7 @@ namespace seqan3::views
  * | std::ranges::output_range        |                                   | *preserved*                     |
  * | seqan3::const_iterable_range     |                                   | *preserved*                     |
  * |                                  |                                   |                                 |
- * | std::ranges::range_reference_t   |                                   | std::ranges::range_reference_t<urng_t>     |
+ * | std::ranges::range_reference_t   |                                   | std::ranges::range_reference_t<urng_t> |
  *
  * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.
  *

--- a/include/seqan3/range/views/type_reduce.hpp
+++ b/include/seqan3/range/views/type_reduce.hpp
@@ -117,21 +117,21 @@ namespace seqan3::views
  *
  * ### View properties
  *
- * | Concepts and traits              | `urng_t` (underlying range type)  | `rrng_t` (returned range type)  |
- * |----------------------------------|:---------------------------------:|:-------------------------------:|
- * | std::ranges::input_range         | *required*                        | *preserved*                     |
- * | std::ranges::forward_range       |                                   | *preserved*                     |
- * | std::ranges::bidirectional_range |                                   | *preserved*                     |
- * | std::ranges::random_access_range |                                   | *preserved*                     |
- * | std::ranges::contiguous_range    |                                   | *preserved*                     |
- * |                                  |                                   |                                 |
- * | std::ranges::viewable_range      | *required*                        | *guaranteed*                    |
- * | std::ranges::view                |                                   | *guaranteed*                    |
- * | std::ranges::sized_range         |                                   | *preserved*                     |
- * | std::ranges::common_range        |                                   | *preserved*                     |
- * | std::ranges::output_range        |                                   | *preserved*                     |
- * | seqan3::const_iterable_range     |                                   | *preserved*                     |
- * |                                  |                                   |                                 |
+ * | Concepts and traits              | `urng_t` (underlying range type)  | `rrng_t` (returned range type)         |
+ * |----------------------------------|:---------------------------------:|:--------------------------------------:|
+ * | std::ranges::input_range         | *required*                        | *preserved*                            |
+ * | std::ranges::forward_range       |                                   | *preserved*                            |
+ * | std::ranges::bidirectional_range |                                   | *preserved*                            |
+ * | std::ranges::random_access_range |                                   | *preserved*                            |
+ * | std::ranges::contiguous_range    |                                   | *preserved*                            |
+ * |                                  |                                   |                                        |
+ * | std::ranges::viewable_range      | *required*                        | *guaranteed*                           |
+ * | std::ranges::view                |                                   | *guaranteed*                           |
+ * | std::ranges::sized_range         |                                   | *preserved*                            |
+ * | std::ranges::common_range        |                                   | *preserved*                            |
+ * | std::ranges::output_range        |                                   | *preserved*                            |
+ * | seqan3::const_iterable_range     |                                   | *preserved*                            |
+ * |                                  |                                   |                                        |
  * | std::ranges::range_reference_t   |                                   | std::ranges::range_reference_t<urng_t> |
  *
  * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.

--- a/include/seqan3/range/views/type_reduce.hpp
+++ b/include/seqan3/range/views/type_reduce.hpp
@@ -132,7 +132,7 @@ namespace seqan3::views
  * | std::ranges::output_range        |                                   | *preserved*                     |
  * | seqan3::const_iterable_range     |                                   | *preserved*                     |
  * |                                  |                                   |                                 |
- * | std::ranges::range_reference_t   |                                   | seqan3::reference_t<urng_t>     |
+ * | std::ranges::range_reference_t   |                                   | std::ranges::range_reference_t<urng_t>     |
  *
  * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.
  *

--- a/include/seqan3/search/fm_index/bi_fm_index.hpp
+++ b/include/seqan3/search/fm_index/bi_fm_index.hpp
@@ -143,7 +143,7 @@ private:
     void construct(text_t && text)
     {
         static_assert(std::ranges::bidirectional_range<text_t>, "The text must model bidirectional_range.");
-        static_assert(std::ranges::bidirectional_range<reference_t<text_t>>,
+        static_assert(std::ranges::bidirectional_range<std::ranges::range_reference_t<text_t>>,
                       "The elements of the text collection must model bidirectional_range.");
         static_assert(alphabet_size<innermost_value_type_t<text_t>> <= 256, "The alphabet is too big.");
         static_assert(std::convertible_to<innermost_value_type_t<text_t>, alphabet_t>,

--- a/include/seqan3/search/fm_index/fm_index.hpp
+++ b/include/seqan3/search/fm_index/fm_index.hpp
@@ -232,7 +232,7 @@ private:
     void construct(text_t && text)
     {
         static_assert(std::ranges::bidirectional_range<text_t>, "The text collection must model bidirectional_range.");
-        static_assert(std::ranges::bidirectional_range<reference_t<text_t>>,
+        static_assert(std::ranges::bidirectional_range<std::ranges::range_reference_t<text_t>>,
                       "The elements of the text collection must model bidirectional_range.");
         static_assert(alphabet_size<innermost_value_type_t<text_t>> <= 256, "The alphabet is too big.");
         static_assert(std::convertible_to<innermost_value_type_t<text_t>, alphabet_t>,

--- a/test/include/seqan3/test/performance/naive_kmer_hash.hpp
+++ b/test/include/seqan3/test/performance/naive_kmer_hash.hpp
@@ -42,7 +42,7 @@ struct naive_kmer_hash_fn
      */
     template <std::ranges::viewable_range urng_t>
     //!\cond
-        requires semialphabet<reference_t<urng_t>>
+        requires semialphabet<std::ranges::range_reference_t<urng_t>>
     //!\endcond
     constexpr auto operator()(urng_t && urange, size_t const k) const noexcept
     {

--- a/test/snippet/core/type_list/list_traits_transform.cpp
+++ b/test/snippet/core/type_list/list_traits_transform.cpp
@@ -9,6 +9,6 @@ int main()
     using list_t = seqan3::type_list<std::vector<int>, std::vector<float>, std::list<bool>>;
 
     // Transform the types into reference types.
-    static_assert(std::same_as<seqan3::list_traits::transform<seqan3::reference_t, list_t>,
+    static_assert(std::same_as<seqan3::list_traits::transform<std::ranges::range_reference_t, list_t>,
                                seqan3::type_list<int &, float &, bool &>>);
 }

--- a/test/snippet/core/type_list/pack_traits_transform.cpp
+++ b/test/snippet/core/type_list/pack_traits_transform.cpp
@@ -7,7 +7,7 @@
 int main()
 {
     // Transform the types in the pack into reference types.
-    static_assert(std::same_as<seqan3::pack_traits::transform<seqan3::reference_t, std::vector<int>,
+    static_assert(std::same_as<seqan3::pack_traits::transform<std::ranges::range_reference_t, std::vector<int>,
                                                                                    std::vector<float>,
                                                                                    std::list<bool>>,
                                seqan3::type_list<int &, float &, bool &>>);

--- a/test/snippet/core/type_list/pack_traits_transform.cpp
+++ b/test/snippet/core/type_list/pack_traits_transform.cpp
@@ -8,7 +8,7 @@ int main()
 {
     // Transform the types in the pack into reference types.
     static_assert(std::same_as<seqan3::pack_traits::transform<std::ranges::range_reference_t, std::vector<int>,
-                                                                                   std::vector<float>,
-                                                                                   std::list<bool>>,
+                                                                                              std::vector<float>,
+                                                                                              std::list<bool>>,
                                seqan3::type_list<int &, float &, bool &>>);
 }

--- a/test/unit/core/type_list_test.cpp
+++ b/test/unit/core/type_list_test.cpp
@@ -103,7 +103,9 @@ TEST(pack_traits, transform)
                                 seqan3::type_list<>>));
     EXPECT_TRUE((std::is_same_v<seqan3::pack_traits::transform<std::ranges::range_value_t, std::vector<int>, std::list<bool>>,
                                 seqan3::type_list<int, bool>>));
-    EXPECT_TRUE((std::is_same_v<seqan3::pack_traits::transform<std::ranges::range_reference_t, std::vector<int>, std::list<bool>>,
+    EXPECT_TRUE((std::is_same_v<seqan3::pack_traits::transform<std::ranges::range_reference_t,
+                                                               std::vector<int>,
+                                                               std::list<bool>>,
                                 seqan3::type_list<int &, bool &>>));
 }
 

--- a/test/unit/core/type_list_test.cpp
+++ b/test/unit/core/type_list_test.cpp
@@ -103,7 +103,7 @@ TEST(pack_traits, transform)
                                 seqan3::type_list<>>));
     EXPECT_TRUE((std::is_same_v<seqan3::pack_traits::transform<std::ranges::range_value_t, std::vector<int>, std::list<bool>>,
                                 seqan3::type_list<int, bool>>));
-    EXPECT_TRUE((std::is_same_v<seqan3::pack_traits::transform<seqan3::reference_t, std::vector<int>, std::list<bool>>,
+    EXPECT_TRUE((std::is_same_v<seqan3::pack_traits::transform<std::ranges::range_reference_t, std::vector<int>, std::list<bool>>,
                                 seqan3::type_list<int &, bool &>>));
 }
 
@@ -327,7 +327,7 @@ TEST(list_traits, transform)
     EXPECT_TRUE((std::is_same_v<seqan3::list_traits::transform<std::ranges::range_value_t,
                                                                seqan3::type_list<std::vector<int>, std::list<bool>>>,
                                 seqan3::type_list<int, bool>>));
-    EXPECT_TRUE((std::is_same_v<seqan3::list_traits::transform<seqan3::reference_t,
+    EXPECT_TRUE((std::is_same_v<seqan3::list_traits::transform<std::ranges::range_reference_t,
                                                                seqan3::type_list<std::vector<int>, std::list<bool>>>,
                                 seqan3::type_list<int &, bool &>>));
 }

--- a/test/unit/core/type_traits/range_iterator_test.cpp
+++ b/test/unit/core/type_traits/range_iterator_test.cpp
@@ -94,16 +94,14 @@ TEST(range_and_iterator, reference_)
     using iterator_of_int_vector = std::ranges::iterator_t<std::vector<int>>;
     using foreign_iterator = seqan3::detail::random_access_iterator<std::vector<int>>;
     auto v = std::views::iota(1);
-    using type_list_example = seqan3::type_list<seqan3::reference_t<std::vector<int>>, // short
-                                                typename seqan3::reference<std::vector<int>>::type, // long
+    using type_list_example = seqan3::type_list<std::ranges::range_reference_t<std::vector<int>>, // short
                                                 typename std::vector<int>::reference, // member type
-                                                seqan3::reference_t<std::vector<int> const>, // const container
-                                                seqan3::reference_t<iterator_of_int_vector>, // iterator
-                                                seqan3::reference_t<foreign_iterator>, // iterator2
-                                                seqan3::reference_t<decltype(v)>>; // range, no member
+                                                std::ranges::range_reference_t<std::vector<int> const>, // const container
+                                                std::iter_reference_t<iterator_of_int_vector>, // iterator
+                                                std::iter_reference_t<foreign_iterator>, // iterator2
+                                                std::ranges::range_reference_t<decltype(v)>>; // range, no member
 
     using comp_list = seqan3::type_list<int &,
-                                        int &,
                                         int &,
                                         int const &, // container is const
                                         int &,

--- a/test/unit/range/views/view_pairwise_combine_test.cpp
+++ b/test/unit/range/views/view_pairwise_combine_test.cpp
@@ -405,7 +405,7 @@ TYPED_TEST(pairwise_combine_test, end)
 TYPED_TEST(pairwise_combine_test, iterate)
 {
     auto v = this->create_view();
-    using ref_t = seqan3::reference_t<std::ranges::iterator_t<decltype(v)>>;
+    using ref_t = std::iter_reference_t<std::ranges::iterator_t<decltype(v)>>;
     std::vector<ref_t> cmp;
 
     for (auto r : v)
@@ -419,7 +419,7 @@ TYPED_TEST(pairwise_combine_test, iterate_reverse)
     if constexpr (std::ranges::bidirectional_range<TypeParam>)
     {
         auto v = this->create_view();
-        using ref_t = seqan3::reference_t<std::ranges::iterator_t<decltype(v)>>;
+        using ref_t = std::iter_reference_t<std::ranges::iterator_t<decltype(v)>>;
         std::vector<ref_t> cmp;
 
         for (auto r : v | std::views::reverse)
@@ -446,7 +446,7 @@ TEST(pairwise_combine_fn_test, filter_output)
 
     auto v = orig | seqan3::views::pairwise_combine;
 
-    using ref_t = seqan3::reference_t<std::ranges::iterator_t<decltype(v)>>;
+    using ref_t = std::iter_reference_t<std::ranges::iterator_t<decltype(v)>>;
     std::vector<ref_t> cmp;
 
     auto v_filter = v | std::views::filter([](auto tpl)
@@ -473,7 +473,7 @@ TEST(pairwise_combine_fn_test, filter_input)
 
     auto v = v_filter | seqan3::views::pairwise_combine;
 
-    using ref_t = seqan3::reference_t<std::ranges::iterator_t<decltype(v)>>;
+    using ref_t = std::iter_reference_t<std::ranges::iterator_t<decltype(v)>>;
     std::vector<ref_t> cmp;
 
     for (auto r : v)

--- a/test/unit/range/views/view_single_pass_input_test.cpp
+++ b/test/unit/range/views/view_single_pass_input_test.cpp
@@ -72,8 +72,8 @@ TYPED_TEST(single_pass_input, view_concept)
     EXPECT_TRUE(std::ranges::range<view_t>);
     EXPECT_TRUE(std::ranges::view<view_t>);
     EXPECT_TRUE(std::ranges::input_range<view_t>);
-    EXPECT_EQ((std::ranges::output_range<view_t, seqan3::reference_t<view_t>>),
-              (std::ranges::output_range<rng_t, seqan3::reference_t<rng_t>>));
+    EXPECT_EQ((std::ranges::output_range<view_t, std::ranges::range_reference_t<view_t>>),
+              (std::ranges::output_range<rng_t, std::ranges::range_reference_t<rng_t>>));
     EXPECT_FALSE(std::ranges::common_range<view_t>);
     EXPECT_FALSE(std::ranges::forward_range<view_t>);
     EXPECT_FALSE(std::ranges::bidirectional_range<view_t>);

--- a/test/unit/range/views/view_to_lower_test.cpp
+++ b/test/unit/range/views/view_to_lower_test.cpp
@@ -87,8 +87,8 @@ TEST(view_to_lower, concepts)
               std::ranges::common_range<decltype(lower_view)>);
     EXPECT_EQ(seqan3::const_iterable_range<decltype(input_string)>,
               seqan3::const_iterable_range<decltype(lower_view)>);
-    EXPECT_TRUE((std::same_as<std::remove_reference_t<seqan3::reference_t<decltype(input_string)>>,
-                              std::remove_reference_t<seqan3::reference_t<decltype(lower_view)>>>));
+    EXPECT_TRUE((std::same_as<std::remove_reference_t<std::ranges::range_reference_t<decltype(input_string)>>,
+                              std::remove_reference_t<std::ranges::range_reference_t<decltype(lower_view)>>>));
 
     // Guaranteed
     EXPECT_TRUE(std::ranges::viewable_range<decltype(lower_view)>);

--- a/test/unit/range/views/view_to_upper_test.cpp
+++ b/test/unit/range/views/view_to_upper_test.cpp
@@ -87,8 +87,8 @@ TEST(view_to_upper, concepts)
               std::ranges::common_range<decltype(upper_view)>);
     EXPECT_EQ(seqan3::const_iterable_range<decltype(input_string)>,
               seqan3::const_iterable_range<decltype(upper_view)>);
-    EXPECT_TRUE((std::same_as<std::remove_reference_t<seqan3::reference_t<decltype(input_string)>>,
-                              std::remove_reference_t<seqan3::reference_t<decltype(upper_view)>>>));
+    EXPECT_TRUE((std::same_as<std::remove_reference_t<std::ranges::range_reference_t<decltype(input_string)>>,
+                              std::remove_reference_t<std::ranges::range_reference_t<decltype(upper_view)>>>));
 
     // Guaranteed
     EXPECT_TRUE(std::ranges::viewable_range<decltype(upper_view)>);

--- a/test/unit/range/views/view_translate_join_test.cpp
+++ b/test/unit/range/views/view_translate_join_test.cpp
@@ -185,7 +185,7 @@ TYPED_TEST(nucleotide, view_translate_concepts)
     EXPECT_TRUE(std::ranges::random_access_range<std::ranges::range_value_t<decltype(v1)>>);
     EXPECT_TRUE(std::ranges::sized_range<std::ranges::range_value_t<decltype(v1)>>);
     EXPECT_TRUE(std::ranges::view<std::ranges::range_value_t<decltype(v1)>>);
-    EXPECT_TRUE(std::ranges::random_access_range<seqan3::reference_t<decltype(v1)>>);
-    EXPECT_TRUE(std::ranges::sized_range<seqan3::reference_t<decltype(v1)>>);
-    EXPECT_TRUE(std::ranges::view<seqan3::reference_t<decltype(v1)>>);
+    EXPECT_TRUE(std::ranges::random_access_range<std::ranges::range_reference_t<decltype(v1)>>);
+    EXPECT_TRUE(std::ranges::sized_range<std::ranges::range_reference_t<decltype(v1)>>);
+    EXPECT_TRUE(std::ranges::view<std::ranges::range_reference_t<decltype(v1)>>);
 }

--- a/test/unit/range/views/view_translate_test.cpp
+++ b/test/unit/range/views/view_translate_test.cpp
@@ -222,7 +222,7 @@ TYPED_TEST(nucleotide, view_translate_single_concepts)
     EXPECT_TRUE(std::ranges::sized_range<decltype(v1)>);
     EXPECT_TRUE(std::ranges::view<decltype(v1)>);
     EXPECT_TRUE((std::is_same_v<seqan3::aa27, std::ranges::range_value_t<decltype(v1)>>));
-    EXPECT_TRUE((std::is_same_v<seqan3::aa27, seqan3::reference_t<decltype(v1)>>));
+    EXPECT_TRUE((std::is_same_v<seqan3::aa27, std::ranges::range_reference_t<decltype(v1)>>));
 }
 
 TYPED_TEST(nucleotide, view_translate_concepts)
@@ -242,9 +242,9 @@ TYPED_TEST(nucleotide, view_translate_concepts)
     EXPECT_TRUE(std::ranges::random_access_range<std::ranges::range_value_t<decltype(v1)>>);
     EXPECT_TRUE(std::ranges::sized_range<std::ranges::range_value_t<decltype(v1)>>);
     EXPECT_TRUE(std::ranges::view<std::ranges::range_value_t<decltype(v1)>>);
-    EXPECT_TRUE(std::ranges::random_access_range<seqan3::reference_t<decltype(v1)>>);
-    EXPECT_TRUE(std::ranges::sized_range<seqan3::reference_t<decltype(v1)>>);
-    EXPECT_TRUE(std::ranges::view<seqan3::reference_t<decltype(v1)>>);
+    EXPECT_TRUE(std::ranges::random_access_range<std::ranges::range_reference_t<decltype(v1)>>);
+    EXPECT_TRUE(std::ranges::sized_range<std::ranges::range_reference_t<decltype(v1)>>);
+    EXPECT_TRUE(std::ranges::view<std::ranges::range_reference_t<decltype(v1)>>);
 }
 
 TYPED_TEST(nucleotide, issue1339)


### PR DESCRIPTION
Resolves part of #1549

Replaces occurrences of `seqan3::reference_type<...>` with `std::iter_reference_t` or `std::ranges::range_reference_t` where possible.

There are still a few occurrences of `seqan3::reference_type(_t)` in the code and therefore the actual deprecation of seqan3::reference_type is not part of this PR and will be addressed in a later, separate PR.