### PR TITLE
Utility/requires for function traits

### DIFF
--- a/include/seqan3/core/type_traits/function.hpp
+++ b/include/seqan3/core/type_traits/function.hpp
@@ -27,12 +27,18 @@ template <typename function_t>
 struct function_traits;
 //!\endcond
 
-/*!\brief A traits class to provide a uniform interface to the properties of a std::function type.
+/*!\brief A traits class to provide a uniform interface to the properties of a function type.
  * \ingroup type_traits
+ * \tparam return_t The return type of the function.
+ * \tparam args_t A template parameter pack over the argument types of the function.
+ *
+ * \details
  *
  * seqan3::function_traits is the type trait class that provides a uniform interface to the properties of
- * a std::function type.
+ * a std::function type, a lambda type, a function type or a function pointer type.
  * This makes it possible to access the return type and the argument types of the stored target function.
+ * The function types must be complete, i.e. all argument types and the return type must be known, otherwise
+ * this traits class is incomplete.
  *
  * ### Example
  *
@@ -56,6 +62,14 @@ struct function_traits<std::function<return_t(args_t...)>>
     //!\endcond
     using argument_type_at = pack_traits::at<index, args_t...>;
 };
+
+//!\cond
+// Overload for all function types.
+template <typename function_t>
+    requires requires (function_t fn) { {std::function{fn}}; }
+struct function_traits<function_t> : function_traits<decltype(std::function{std::declval<function_t>()})>
+{};
+//!\endcond
 } // namespace seqan3
 
 namespace seqan3::detail

--- a/test/unit/core/type_traits/function_test.cpp
+++ b/test/unit/core/type_traits/function_test.cpp
@@ -17,16 +17,20 @@ std::function test_function_object = [] (size_t arg1, std::string & arg2)
     return arg2[arg1];
 };
 
+using function_ptr_t = std::string (*) (int, const double &&, bool &);
+
 TEST(function_traits, argument_count)
 {
     using function_t = decltype(test_function_object);
     EXPECT_EQ(seqan3::function_traits<function_t>::argument_count, 2u);
+    EXPECT_EQ(seqan3::function_traits<function_ptr_t>::argument_count, 3u);
 }
 
 TEST(function_traits, result_type)
 {
     using function_t = decltype(test_function_object);
     EXPECT_TRUE((std::same_as<seqan3::function_traits<function_t>::result_type, char>));
+    EXPECT_TRUE((std::same_as<seqan3::function_traits<function_ptr_t>::result_type, std::string>));
 }
 
 TEST(function_traits, argument_type_at)
@@ -34,4 +38,7 @@ TEST(function_traits, argument_type_at)
     using function_t = decltype(test_function_object);
     EXPECT_TRUE((std::same_as<seqan3::function_traits<function_t>::argument_type_at<0>, size_t>));
     EXPECT_TRUE((std::same_as<seqan3::function_traits<function_t>::argument_type_at<1>, std::string &>));
+    EXPECT_TRUE((std::same_as<seqan3::function_traits<function_ptr_t>::argument_type_at<0>, int>));
+    EXPECT_TRUE((std::same_as<seqan3::function_traits<function_ptr_t>::argument_type_at<1>, const double &&>));
+    EXPECT_TRUE((std::same_as<seqan3::function_traits<function_ptr_t>::argument_type_at<2>, bool &>));
 }


### PR DESCRIPTION
Followup of #1725 to constraint some generic traits classes.
Only commit 3 and 4 are relevant. The first two commits belong to #1725.