### PR TITLE
[FEATURE] Add internal alignment configuration to capture alignment result from algorithm configuration

### DIFF
--- a/include/seqan3/alignment/configuration/align_config_alignment_result_capture.hpp
+++ b/include/seqan3/alignment/configuration/align_config_alignment_result_capture.hpp
@@ -1,0 +1,78 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides seqan3::align_cfg::alignment_result_capture.
+ * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <seqan3/alignment/configuration/detail.hpp>
+#include <seqan3/alignment/pairwise/alignment_result.hpp>
+#include <seqan3/core/algorithm/pipeable_config_element.hpp>
+#include <seqan3/std/type_traits>
+
+namespace seqan3::detail
+{
+
+/*!\brief The configuration element storing the captured alignment result type.
+ * \ingroup alignment_configuration
+ *
+ * \tparam alignment_result_t The type of the alignment result to capture; must be a type specialisation of
+ *                            seqan3::alignment_result.
+ *
+ * \details
+ *
+ * Implementation of the alignment result capture config.
+ *
+ * \see seqan3::align_cfg::alignment_result_capture
+ */
+template <typename alignment_result_t>
+//!\cond
+    requires is_type_specialisation_of_v<alignment_result_t, alignment_result>
+//!\endcond
+struct alignment_result_capture_element :
+    public pipeable_config_element<alignment_result_capture_element<alignment_result_t>,
+                                   std::type_identity<alignment_result_t>>
+{
+    //!\brief Internal id to check for consistent configuration settings.
+    static constexpr detail::align_config_id id{detail::align_config_id::alignment_result_capture};
+};
+
+} // namespace seqan3::detail
+
+namespace seqan3::align_cfg
+{
+/*!\if DEV
+ * \brief Configuration element capturing the configured seqan3::alignment_result for the alignment algorithm.
+ * \ingroup alignment_configuration
+ * \tparam alignment_result_t The alignment result type to capture; must be a type specialisation of
+ *                            seqan3::alignment_result.
+ *
+ * \details
+ *
+ * This configuration element allows to capture the concrete seqan3::alignment_result type after configuring the
+ * alignment algorithm with the seqan3::detail::alignment_configurator. The actual result type is wrapped in
+ * std::type_identity to preserve the trivial type properties of the configuration element. Thus, on access the
+ * actual type needs to be unwrapped using the member typedef `type` before it can be used.
+ * The result type can be accessed via the seqan3::detail::alignment_configuration_traits over the corresponding
+ * alignment configuration type.
+ * If the captured alignment result wasn't added yet to the alignment configuration the corresponding
+ * result type member will deduce to seqan3::detail::empty_type.
+ *
+ * \note This configuration element is only added internally during the alignment configuration and is not intended for
+ *       public use.
+ * \endif
+ */
+template <typename alignment_result_t>
+//!\cond
+    requires detail::is_type_specialisation_of_v<alignment_result_t, alignment_result>
+//!\endcond
+inline constexpr detail::alignment_result_capture_element<alignment_result_t> alignment_result_capture{};
+}  // namespace seqan3::align_cfg
+

--- a/include/seqan3/alignment/configuration/all.hpp
+++ b/include/seqan3/alignment/configuration/all.hpp
@@ -13,6 +13,7 @@
  #pragma once
 
 #include <seqan3/alignment/configuration/align_config_aligned_ends.hpp>
+#include <seqan3/alignment/configuration/align_config_alignment_result_capture.hpp>
 #include <seqan3/alignment/configuration/align_config_band.hpp>
 #include <seqan3/alignment/configuration/align_config_debug.hpp>
 #include <seqan3/alignment/configuration/align_config_edit.hpp>

--- a/include/seqan3/alignment/configuration/detail.hpp
+++ b/include/seqan3/alignment/configuration/detail.hpp
@@ -22,6 +22,8 @@ namespace seqan3::detail
  */
 enum struct align_config_id : uint8_t
 {
+    //!\brief ID for the \ref seqan3::align_cfg::alignment_result_capture "alignment_result_capture" option.
+    alignment_result_capture,
     aligned_ends, //!< ID for the \ref seqan3::align_cfg::aligned_ends "aligned_ends" option.
     band,         //!< ID for the \ref seqan3::align_cfg::band "band" option.
     debug,        //!< ID for the \ref seqan3::align_cfg::debug "debug" option.
@@ -49,18 +51,19 @@ template <>
 inline constexpr std::array<std::array<bool, static_cast<uint8_t>(align_config_id::SIZE)>,
                             static_cast<uint8_t>(align_config_id::SIZE)> compatibility_table<align_config_id>
 {
-    {   //0  1  2  3  4  5  6  7  8  9 10
-        { 0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1}, //  0: aligned_ends
-        { 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1}, //  1: band
-        { 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1}, //  2: debug
-        { 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1}, //  3: gap
-        { 1, 1, 1, 1, 0, 0, 1, 1, 1, 1, 1}, //  4: global
-        { 0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 1}, //  5: local
-        { 1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1}, //  6: max_error
-        { 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1}, //  7: parallel
-        { 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1}, //  8: result
-        { 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1}, //  9: scoring
-        { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0}  // 10: vectorise
+    {   //0  1  2  3  4  5  6  7  8  9 10 11
+        { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, //  0: alignment_result_capture
+        { 1, 0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1}, //  1: aligned_ends
+        { 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1}, //  2: band
+        { 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1}, //  3: debug
+        { 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1}, //  4: gap
+        { 1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1, 1}, //  5: global
+        { 1, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 1}, //  6: local
+        { 1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1}, //  7: max_error
+        { 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1}, //  8: parallel
+        { 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1}, //  9: result
+        { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1}, // 10: scoring
+        { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0}  // 11: vectorise
     }
 };
 

--- a/test/unit/alignment/configuration/align_config_common_test.cpp
+++ b/test/unit/alignment/configuration/align_config_common_test.cpp
@@ -17,6 +17,8 @@ template <typename T>
 class alignment_configuration_test : public ::testing::Test
 {};
 
+using alignment_result_t = seqan3::alignment_result<seqan3::detail::alignment_result_value_type<int, int>>;
+
 using test_types = ::testing::Types<seqan3::align_cfg::aligned_ends<std::remove_const_t<decltype(seqan3::free_ends_all)>>,
                                     seqan3::align_cfg::band<seqan3::static_band>,
                                     seqan3::align_cfg::gap<seqan3::gap_scheme<>>,
@@ -26,7 +28,8 @@ using test_types = ::testing::Types<seqan3::align_cfg::aligned_ends<std::remove_
                                     seqan3::align_cfg::parallel,
                                     seqan3::align_cfg::result<>,
                                     seqan3::align_cfg::scoring<seqan3::nucleotide_scoring_scheme<int8_t>>,
-                                    seqan3::detail::vectorise_tag>;
+                                    seqan3::detail::vectorise_tag,
+                                    seqan3::detail::alignment_result_capture_element<alignment_result_t>>;
 
 TYPED_TEST_SUITE(alignment_configuration_test, test_types, );
 
@@ -51,7 +54,7 @@ TEST(alignment_configuration_test, symmetric_configuration)
 TEST(alignment_configuration_test, number_of_configs)
 {
     // NOTE(rrahn): You must update this test if you add a new value to seqan3::align_cfg::id
-    EXPECT_EQ(static_cast<uint8_t>(seqan3::detail::align_config_id::SIZE), 11);
+    EXPECT_EQ(static_cast<uint8_t>(seqan3::detail::align_config_id::SIZE), 12);
 }
 
 TYPED_TEST(alignment_configuration_test, config_element)


### PR DESCRIPTION
Part of #1692 

### Description

This change allows to capture the configured alignment result in the alignment configuration object that is passed to the alignment result. Thus, the algorithm can ensure that it uses the same alignment algorithm as it was originally configured and avoids possible incompatibilities that are hard to track.