### PR TITLE
[MISC] use std::(ranges::range|iter)_(value|reference)_t

### DIFF
--- a/include/seqan3/range/container/concatenated_sequences.hpp
+++ b/include/seqan3/range/container/concatenated_sequences.hpp
@@ -223,7 +223,9 @@ protected:
     //!\hideinitializer
     // cannot use the concept, because this class is not yet fully defined
     template <typename t>
+    //!\cond
         requires std::ranges::range<std::iter_reference_t<t>>
+    //!\endcond
     static constexpr bool iter_value_t_is_compatible_with_value_type =
         !std::is_same_v<remove_cvref_t<t>, concatenated_sequences> &&
         (
@@ -236,7 +238,9 @@ protected:
     //!\hideinitializer
     // cannot use the concept, because this class is not yet fully defined
     template <std::ranges::range t>
+    //!\cond
         requires std::ranges::range<std::ranges::range_reference_t<t>>
+    //!\endcond
     static constexpr bool range_value_t_is_compatible_with_value_type =
         !std::is_same_v<remove_cvref_t<t>, iterator> &&
         !std::is_same_v<remove_cvref_t<t>, const_iterator> &&
@@ -264,7 +268,8 @@ public:
     ~concatenated_sequences() = default;
 
     /*!\brief Construct/assign from a different range.
-     * \tparam rng_of_rng_type The type of range to be inserted; must satisfy \ref is_compatible_this.
+     * \tparam rng_of_rng_type The type of range to be inserted; must satisfy
+     *         \ref range_value_t_is_compatible_with_value_type.
      * \param rng_of_rng The sequences to construct/assign from.
      *
      * ###Complexity
@@ -292,7 +297,7 @@ public:
     }
 
     /*!\brief Construct/assign with `count` times `value`.
-     * \tparam rng_type The type of range to be inserted; must satisfy \ref is_compatible_value.
+     * \tparam rng_type The type of range to be inserted; must satisfy \ref is_compatible_with_value_type.
      * \param count Number of elements.
      * \param value The initial value to be assigned.
      *
@@ -319,7 +324,7 @@ public:
 
     /*!\brief Construct/assign from pair of iterators.
      * \tparam begin_iterator_type Must satisfy std::forward_iterator and must satisfy
-     * \ref is_compatible_value.
+     *         \ref iter_value_t_is_compatible_with_value_type.
      * \tparam end_iterator_type Must satisfy std::sized_sentinel_for.
      * \param begin_it begin of range to construct/assign from.
      * \param end_it end of range to construct/assign from.
@@ -343,7 +348,7 @@ public:
     }
 
     /*!\brief Construct/assign from `std::initializer_list`.
-     * \tparam rng_type The type of range to be inserted; must satisfy \ref is_compatible_value.
+     * \tparam rng_type The type of range to be inserted; must satisfy \ref is_compatible_with_value_type.
      * \param ilist an `std::initializer_list` of `rng_type`.
      *
      * ###Complexity
@@ -355,14 +360,16 @@ public:
      * Strong exception guarantee (no data is modified in case an exception is thrown).
      */
     template <std::ranges::forward_range value_type_t = value_type>
+    //!\cond
         requires is_compatible_with_value_type<value_type_t>
+    //!\endcond
     concatenated_sequences(std::initializer_list<value_type_t> ilist)
     {
         assign(std::begin(ilist), std::end(ilist));
     }
 
     /*!\brief Construct/assign from `std::initializer_list`.
-     * \tparam rng_type The type of range to be inserted; must satisfy \ref is_compatible_value.
+     * \tparam rng_type The type of range to be inserted; must satisfy \ref is_compatible_with_value_type.
      * \param ilist an `std::initializer_list` of `rng_type`.
      *
      * ###Complexity
@@ -384,7 +391,8 @@ public:
     }
 
     /*!\brief Construct/assign from a different range.
-     * \tparam rng_of_rng_type The type of range to be inserted; must satisfy \ref is_compatible_this.
+     * \tparam rng_of_rng_type The type of range to be inserted; must satisfy
+     *         \ref range_value_t_is_compatible_with_value_type.
      * \param rng_of_rng The sequences to construct/assign from.
      *
      * ###Complexity
@@ -406,7 +414,7 @@ public:
     }
 
     /*!\brief Construct/assign with `count` times `value`.
-     * \tparam rng_type The type of range to be inserted; must satisfy \ref is_compatible_value.
+     * \tparam rng_type The type of range to be inserted; must satisfy \ref is_compatible_with_value_type.
      * \param count Number of elements.
      * \param value The initial value to be assigned.
      *
@@ -429,7 +437,8 @@ public:
     }
 
     /*!\brief Construct/assign from pair of iterators.
-     * \tparam begin_iterator_type Must satisfy std::forward_iterator and satisfy \ref is_compatible_value.
+     * \tparam begin_iterator_type Must satisfy std::forward_iterator and satisfy
+     *         \ref iter_value_t_is_compatible_with_value_type.
      * \tparam end_iterator_type Must satisfy std::sized_sentinel_for.
      * \param begin_it begin of range to construct/assign from.
      * \param end_it end of range to construct/assign from.
@@ -454,7 +463,7 @@ public:
     }
 
     /*!\brief Construct/assign from `std::initializer_list`.
-     * \tparam rng_type The type of range to be inserted; must satisfy \ref is_compatible_value.
+     * \tparam rng_type The type of range to be inserted; must satisfy \ref is_compatible_with_value_type.
      * \param ilist an `std::initializer_list` of `rng_type`.
      *
      * ###Complexity
@@ -944,14 +953,16 @@ public:
      */
     template <std::ranges::forward_range rng_type>
     iterator insert(const_iterator pos, rng_type && value)
+    //!\cond
         requires is_compatible_with_value_type<rng_type>
+    //!\endcond
     {
         return insert(pos, 1, std::forward<rng_type>(value));
     }
     // no specialisation for temporaries, since we have to copy anyway
 
     /*!\brief Inserts count copies of value before position in the container.
-     * \tparam rng_type The type of range to be inserted; must satisfy \ref is_compatible_this.
+     * \tparam rng_type The type of range to be inserted; must satisfy \ref is_compatible_with_value_type.
      * \param pos Iterator before which the content will be inserted. `pos` may be the end() iterator.
      * \param count Number of copies.
      * \param value Element value to insert.
@@ -976,7 +987,9 @@ public:
      */
     template <std::ranges::forward_range rng_type>
     iterator insert(const_iterator pos, size_type const count, rng_type && value)
+    //!\cond
         requires is_compatible_with_value_type<rng_type>
+    //!\endcond
     {
         auto const pos_as_num = std::distance(cbegin(), pos); // we want to insert BEFORE this position
         // TODO SEQAN_UNLIKELY
@@ -1031,7 +1044,8 @@ public:
     }
 
     /*!\brief Inserts elements from range `[first, last)` before position in the container.
-     * \tparam begin_iterator_type Must satisfy std::forward_iterator and \ref is_compatible_value.
+     * \tparam begin_iterator_type Must satisfy std::forward_iterator and
+     *         \ref iter_value_t_is_compatible_with_value_type.
      * \tparam end_iterator_type Must satisfy std::sized_sentinel_for.
      * \param pos Iterator before which the content will be inserted. `pos` may be the end() iterator.
      * \param first Begin of range to insert.
@@ -1109,7 +1123,7 @@ public:
     }
 
     /*!\brief Inserts elements from initializer list before position in the container.
-     * \tparam rng_type The type of range to be inserted; must satisfy \ref is_compatible_value.
+     * \tparam rng_type The type of range to be inserted; must satisfy \ref is_compatible_with_value_type.
      * \param pos Iterator before which the content will be inserted. `pos` may be the end() iterator.
      * \param ilist Initializer list with values to insert.
      * \returns Iterator pointing to the first element inserted, or pos if `ilist` is empty.
@@ -1129,7 +1143,9 @@ public:
      */
     template <std::ranges::forward_range rng_type>
     iterator insert(const_iterator pos, std::initializer_list<rng_type> const & ilist)
+    //!\cond
         requires is_compatible_with_value_type<rng_type>
+    //!\endcond
     {
         return insert(pos, ilist.begin(), ilist.end());
     }
@@ -1204,7 +1220,7 @@ public:
     }
 
     /*!\brief Appends the given element value to the end of the container.
-     * \tparam rng_type The type of range to be inserted; must satisfy \ref is_compatible_value.
+     * \tparam rng_type The type of range to be inserted; must satisfy \ref is_compatible_with_value_type.
      * \param value The value to append.
      *
      * If the new size() is greater than capacity() then all iterators and references (including the past-the-end
@@ -1221,7 +1237,9 @@ public:
      */
     template <std::ranges::forward_range rng_type>
     void push_back(rng_type && value)
+    //!\cond
         requires is_compatible_with_value_type<rng_type>
+    //!\endcond
     {
         data_values.insert(data_values.end(), std::ranges::begin(value), std::ranges::end(value));
         data_delimiters.push_back(data_delimiters.back() + std::ranges::size(value));
@@ -1285,13 +1303,15 @@ public:
     }
 
     /*!\copybrief resize()
-     * \tparam rng_type The type of range to be inserted; must satisfy \ref is_compatible_value.
+     * \tparam rng_type The type of range to be inserted; must satisfy \ref is_compatible_with_value_type.
      * \param value Instead of appending empty containers, append copies of value.
      * \copydetails resize()
      */
     template <std::ranges::forward_range rng_type>
     void resize(size_type const count, rng_type && value)
+    //!\cond
         requires is_compatible_with_value_type<rng_type>
+    //!\endcond
     {
         assert(count < max_size());
         assert(concat_size() + count * std::ranges::size(value) < data_values.max_size());

--- a/include/seqan3/range/container/concatenated_sequences.hpp
+++ b/include/seqan3/range/container/concatenated_sequences.hpp
@@ -208,13 +208,13 @@ protected:
     // unfortunately we cannot specialise the variable template so we have to add an auxiliary here
     template <typename t>
         requires std::ranges::range<std::iter_reference_t<t>> &&
-                 (dimension_v<t> == dimension_v<value_type> + 1) &&
+                 (dimension_v<std::iter_reference_t<t>> == dimension_v<value_type>) &&
                  is_compatible_with_value_type<std::iter_reference_t<t>>
     static constexpr bool iter_value_t_is_compatible_with_value_type_aux = true;
 
     template <std::ranges::range t>
         requires std::ranges::range<std::ranges::range_reference_t<t>> &&
-                 (dimension_v<t> == dimension_v<value_type> + 1) &&
+                 (dimension_v<std::ranges::range_reference_t<t>> == dimension_v<value_type>) &&
                  is_compatible_with_value_type<std::ranges::range_reference_t<t>>
     static constexpr bool range_value_t_is_compatible_with_value_type_aux = true;
     //!\endcond

--- a/include/seqan3/range/container/concatenated_sequences.hpp
+++ b/include/seqan3/range/container/concatenated_sequences.hpp
@@ -354,9 +354,8 @@ public:
      *
      * Strong exception guarantee (no data is modified in case an exception is thrown).
      */
-    template <std::ranges::forward_range value_type_t = value_type>//,
+    template <std::ranges::forward_range value_type_t = value_type>
         requires is_compatible_with_value_type<value_type_t>
-              // typename initializer_list_t = std::enable_if_t<is_compatible_with_value_type<value_type_t>>>
     concatenated_sequences(std::initializer_list<value_type_t> ilist)
     {
         assign(std::begin(ilist), std::end(ilist));

--- a/include/seqan3/range/container/concatenated_sequences.hpp
+++ b/include/seqan3/range/container/concatenated_sequences.hpp
@@ -348,8 +348,8 @@ public:
     }
 
     /*!\brief Construct/assign from `std::initializer_list`.
-     * \tparam rng_type The type of range to be inserted; must satisfy \ref is_compatible_with_value_type.
-     * \param ilist an `std::initializer_list` of `rng_type`.
+     * \tparam value_type_t The type of range to be inserted; must satisfy \ref is_compatible_with_value_type.
+     * \param ilist an `std::initializer_list` of `value_type_t`.
      *
      * ###Complexity
      *
@@ -369,8 +369,8 @@ public:
     }
 
     /*!\brief Construct/assign from `std::initializer_list`.
-     * \tparam rng_type The type of range to be inserted; must satisfy \ref is_compatible_with_value_type.
-     * \param ilist an `std::initializer_list` of `rng_type`.
+     * \tparam value_type_t The type of range to be inserted; must satisfy \ref is_compatible_with_value_type.
+     * \param ilist an `std::initializer_list` of `value_type_t`.
      *
      * ###Complexity
      *

--- a/include/seqan3/range/container/concatenated_sequences.hpp
+++ b/include/seqan3/range/container/concatenated_sequences.hpp
@@ -380,10 +380,10 @@ public:
      *
      * Strong exception guarantee (no data is modified in case an exception is thrown).
      */
-    template <std::ranges::forward_range rng_type>
-    concatenated_sequences & operator=(std::initializer_list<rng_type> ilist)
+    template <std::ranges::forward_range value_type_t>
+    concatenated_sequences & operator=(std::initializer_list<value_type_t> ilist)
     //!\cond
-        requires is_compatible_with_value_type<rng_type>
+        requires is_compatible_with_value_type<value_type_t>
     //!\endcond
     {
         assign(std::begin(ilist), std::end(ilist));


### PR DESCRIPTION
This fixes part of #1549. I'm not sure why this version works, but I
tested it for gcc 7, 8 and 9 and it worked.

The main problem I had was to allow the syntax:

```c++
// this should call the constructor which takes two iterators
concatenated_sequences seqs{iterator, sentinel};
```

https://github.com/seqan/seqan3/blob/75f934f1886ee225fb1bad01b9c9f474caf4c508/include/seqan3/range/container/concatenated_sequences.hpp#L299-L307

In many versions I tried, this call instead tried

https://github.com/seqan/seqan3/blob/75f934f1886ee225fb1bad01b9c9f474caf4c508/include/seqan3/range/container/concatenated_sequences.hpp#L321-L328

This caused some issues, because the template also tried to instantiate
those constructors with not-yet defined class types (like for example the
iterator type within the class)

All those complicated overloads are only available in this class, to
allow constructions of sequences of "compatible" type (i.e. range value
types that are convertible to the value type of the class)
`std::vector<rna4>` and `std::vector<dna4>`.

For the future (and maybe gcc10 compatibility) we should remove the
ability to plug any possible way to add somehow compatible types. This
should be limited.

For now the proposed fix keeps the old behaviour.