### PR TITLE
[MISC] use std::ranges::range_reference_t

### DIFF
--- a/include/seqan3/io/alignment_file/input.hpp
+++ b/include/seqan3/io/alignment_file/input.hpp
@@ -129,10 +129,10 @@ SEQAN3_CONCEPT alignment_file_input_traits = requires (t v)
 
     // field::ref_seq
     // either ref_info_not_given or a range over ranges over alphabet (e.g. std::vector<dna4_vector>)
-    requires std::same_as<typename t::ref_sequences, ref_info_not_given> ||
-         (std::ranges::forward_range<typename t::ref_sequences> &&
-         std::ranges::forward_range<detail::transformation_trait_or_t<reference<typename t::ref_sequences>, dna4_vector>> &&
-         alphabet<reference_t<detail::transformation_trait_or_t<reference<typename t::ref_sequences>, dna4_vector>>>);
+    requires std::same_as<typename t::ref_sequences, ref_info_not_given> || requires ()
+    {
+        requires alphabet<std::ranges::range_reference_t<std::ranges::range_reference_t<typename t::ref_sequences>>>
+    };
 
     // field::ref_id
     requires alphabet<reference_t<reference_t<typename t::ref_ids>>> &&


### PR DESCRIPTION
This one is quite hard to understand:

Before it slowly build up the required expression

```c++
alphabet<std::ranges::range_reference_t<std::ranges::range_reference_t<typename t::ref_sequences>>>
// the given ref_sequences are ranges of sequences (a sequence is a range over an alphabet)
```

and had fallbacks if one of those steps failed in that expression, such that the whole line
is ALWAYS a valid expression what-so-ever happens.

I moved the expression into a requires(), because this has the property
if anything fails or is not defined the whole requires() expression will
evaluate to false. Exactly the same semantics as before, but a bit
better readable.

Fixes part of #1549