### PR TITLE
[MISC] remove unused associated types in take view(|_until)

### DIFF
--- a/include/seqan3/range/views/take.hpp
+++ b/include/seqan3/range/views/take.hpp
@@ -280,25 +280,18 @@ private:
         //!\}
     }; // class iterator_type
 
+private:
     /*!\name Associated types
      * \{
      */
-    //!\brief The reference_type.
-    using reference         = std::ranges::range_reference_t<urng_t>;
-    //!\brief The const_reference type is equal to the reference type if the underlying range is const-iterable.
-    using const_reference   = detail::transformation_trait_or_t<seqan3::reference<urng_t const>, void>;
-    //!\brief The value_type (which equals the reference_type with any references removed).
-    using value_type        = std::ranges::range_value_t<urng_t>;
-    //!\brief The size_type is `size_t` if the view is exact, otherwise `void`.
-    using size_type         = std::conditional_t<exactly || std::ranges::sized_range<urng_t>,
-                                                 transformation_trait_or_t<seqan3::size_type<urng_t>, size_t>,
-                                                 void>;
-    //!\brief A signed integer type, usually std::ptrdiff_t.
-    using difference_type   = std::ranges::range_difference_t<urng_t>;
     //!\brief The iterator type of this view (a random access iterator).
     using iterator          = iterator_type<urng_t>;
-    //!\brief The const_iterator type is equal to the iterator type if the underlying range is const-iterable.
-    using const_iterator    = detail::transformation_trait_or_t<std::type_identity<iterator_type<urng_t const>>, void>;
+    /*!\brief Note that this declaration does not give any compiler errors for non-const iterable ranges. Although
+     * `iterator_type` inherits from std::ranges::iterator_t which is not defined on a const-range, i.e. `urng_t const,
+     *  if it is not const-iterable. We only just declare this type and never instantiate it, i.e. use this type within
+     *  this class, if the underlying range is not const-iterable.
+     */
+    using const_iterator    = iterator_type<urng_t const>;
     //!\}
 
 public:
@@ -444,8 +437,9 @@ public:
     /*!\brief Returns the number of elements in the view.
      * \returns The number of elements in the view.
      *
-     * This overload is only available if the underlying range models std::ranges::sized_range or for
-     * specialisation that have the `exactly` template parameter set.
+     * This overload is only available if the underlying range models std::ranges::sized_range (return type is
+     * std::ranges::range_size_t<urng_type>) or for specialisation that have the `exactly` (return type is std::size_t)
+     * template parameter set. If both conditions are true the return type is `std::size_t`.
      *
      * ### Complexity
      *
@@ -455,7 +449,7 @@ public:
      *
      * No-throw guarantee.
      */
-    constexpr size_type size() const noexcept
+    constexpr auto size() const noexcept
         requires exactly || std::ranges::sized_range<urng_t>
     {
         return target_size;

--- a/include/seqan3/range/views/take_until.hpp
+++ b/include/seqan3/range/views/take_until.hpp
@@ -345,32 +345,20 @@ private:
         //!\}
     }; // class iterator_type_consume_input
 
-public:
+private:
     /*!\name Associated types
      * \{
      */
-    //!\brief The reference_type.
-    using reference         = std::ranges::range_reference_t<urng_t>;
-    //!\brief The const_reference type is equal to the reference type if the underlying range is const-iterable.
-    using const_reference   = detail::transformation_trait_or_t<seqan3::reference<urng_t const>, void>;
-    //!\brief The value_type (which equals the reference_type with any references removed).
-    using value_type        = std::ranges::range_value_t<urng_t>;
-    //!\brief The size_type is void, because this range is never sized.
-    using size_type         = void;
-    //!\brief A signed integer type, usually std::ptrdiff_t.
-    using difference_type   = std::ranges::range_difference_t<urng_t>;
     //!\brief The iterator type of this view (a random access iterator).
     using iterator          = std::conditional_t<and_consume && !std::ranges::forward_range<urng_t>,
-                                                iterator_type_consume_input<urng_t>,
-                                                iterator_type<urng_t>>;
+                                                 iterator_type_consume_input<urng_t>,
+                                                 iterator_type<urng_t>>;
 
     //!\brief The const_iterator type is equal to the iterator type if the underlying range is const-iterable.
-    using const_iterator    = std::conditional_t<and_consume && !std::ranges::forward_range<urng_t>,
-                                                 void,
-                                                 detail::transformation_trait_or_t<
-                                                    std::type_identity<iterator_type<urng_t const>>, void>>;
+    using const_iterator    = iterator_type<urng_t const>;
     //!\}
 
+public:
     /*!\name Constructors, destructor and assignment
      * \{
      */

--- a/test/unit/range/views/view_take_test.cpp
+++ b/test/unit/range/views/view_take_test.cpp
@@ -103,6 +103,20 @@ void do_concepts(adaptor_t && adaptor, bool const exactly)
     EXPECT_FALSE(std::ranges::common_range<decltype(v2)>);
     EXPECT_FALSE(seqan3::const_iterable_range<decltype(v2)>);
     EXPECT_TRUE((std::ranges::output_range<decltype(v2), int>));
+
+    // explicit test for non const-iterable views
+    // https://github.com/seqan/seqan3/pull/1734#discussion_r408829267
+    auto const & v2_cref = v2;
+
+    EXPECT_FALSE(std::ranges::input_range<decltype(v2_cref)>);
+    EXPECT_FALSE(std::ranges::forward_range<decltype(v2_cref)>);
+    EXPECT_FALSE(std::ranges::bidirectional_range<decltype(v2_cref)>);
+    EXPECT_FALSE(std::ranges::random_access_range<decltype(v2_cref)>);
+    EXPECT_FALSE(std::ranges::view<decltype(v2_cref)>);
+    EXPECT_FALSE(std::ranges::sized_range<decltype(v2_cref)>);
+    EXPECT_FALSE(std::ranges::common_range<decltype(v2_cref)>);
+    EXPECT_FALSE(seqan3::const_iterable_range<decltype(v2_cref)>);
+    EXPECT_FALSE((std::ranges::output_range<decltype(v2_cref), int>));
 }
 
 // ============================================================================

--- a/test/unit/range/views/view_take_until_test.cpp
+++ b/test/unit/range/views/view_take_until_test.cpp
@@ -85,6 +85,20 @@ void do_concepts(adaptor_t && adaptor, bool const_it)
     EXPECT_FALSE(std::ranges::common_range<decltype(v2)>);
     EXPECT_FALSE(seqan3::const_iterable_range<decltype(v2)>);
     EXPECT_TRUE((std::ranges::output_range<decltype(v2), char>));
+
+    // explicit test for non const-iterable views
+    // https://github.com/seqan/seqan3/pull/1734#discussion_r408829267
+    auto const & v2_cref = v2;
+
+    EXPECT_FALSE(std::ranges::input_range<decltype(v2_cref)>);
+    EXPECT_FALSE(std::ranges::forward_range<decltype(v2_cref)>);
+    EXPECT_FALSE(std::ranges::bidirectional_range<decltype(v2_cref)>);
+    EXPECT_FALSE(std::ranges::random_access_range<decltype(v2_cref)>);
+    EXPECT_FALSE(std::ranges::view<decltype(v2_cref)>);
+    EXPECT_FALSE(std::ranges::sized_range<decltype(v2_cref)>);
+    EXPECT_FALSE(std::ranges::common_range<decltype(v2_cref)>);
+    EXPECT_FALSE(seqan3::const_iterable_range<decltype(v2_cref)>);
+    EXPECT_FALSE((std::ranges::output_range<decltype(v2_cref), int>));
 }
 
 // ============================================================================


### PR DESCRIPTION
This fixes part of seqan/product_backlog#51 and fixes also part of #1549.