### PR TITLE
[MISC] Remove 'using namespace seqan3' from test/unit/alphabet/*.

### DIFF
--- a/test/unit/alphabet/debug_stream_alphabet_test.cpp
+++ b/test/unit/alphabet/debug_stream_alphabet_test.cpp
@@ -13,19 +13,22 @@
 #include <seqan3/alphabet/quality/qualified.hpp>
 #include <seqan3/core/detail/debug_stream_alphabet.hpp>
 
-using namespace seqan3;
+using seqan3::operator""_dna4;
 
 template <typename T>
 using debug_stream_test = ::testing::Test;
 
-using alphabet_types = ::testing::Types<dna4, qualified<dna4, phred42>, gapped<dna4>>;
+using alphabet_types = ::testing::Types<seqan3::dna4,
+                                        seqan3::qualified<seqan3::dna4,
+                                        seqan3::phred42>,
+                                        seqan3::gapped<seqan3::dna4>>;
 
 TYPED_TEST_SUITE(debug_stream_test, alphabet_types, );
 
 TYPED_TEST(debug_stream_test, alphabet)
 {
     std::ostringstream o;
-    debug_stream_type my_stream{o};
+    seqan3::debug_stream_type my_stream{o};
 
     TypeParam val{'C'_dna4};
     my_stream << val;

--- a/test/unit/alphabet/detail/alphabet_proxy_test.cpp
+++ b/test/unit/alphabet/detail/alphabet_proxy_test.cpp
@@ -13,13 +13,12 @@
 #include "../semi_alphabet_constexpr_test_template.hpp"
 #include "../semi_alphabet_test_template.hpp"
 
-using namespace seqan3;
 
-class alphabet_proxy_example : public alphabet_proxy<alphabet_proxy_example, dna4>
+class alphabet_proxy_example : public seqan3::alphabet_proxy<alphabet_proxy_example, seqan3::dna4>
 {
 private:
-    using alphabet_type = dna4;
-    using base_t = alphabet_proxy<alphabet_proxy_example, alphabet_type>;
+    using alphabet_type = seqan3::dna4;
+    using base_t = seqan3::alphabet_proxy<alphabet_proxy_example, alphabet_type>;
     friend base_t;
 
     constexpr void on_update() noexcept
@@ -110,11 +109,11 @@ static_assert(seqan3::alphabet_size<my_namespace::my_alph> == 2);
 static_assert(seqan3::semialphabet<my_namespace::my_alph>);
 static_assert(seqan3::alphabet<my_namespace::my_alph>);
 
-class alphabet_proxy_example2 : public alphabet_proxy<alphabet_proxy_example2, my_namespace::my_alph>
+class alphabet_proxy_example2 : public seqan3::alphabet_proxy<alphabet_proxy_example2, my_namespace::my_alph>
 {
 private:
     using alphabet_type = my_namespace::my_alph;
-    using base_t = alphabet_proxy<alphabet_proxy_example2, alphabet_type>;
+    using base_t = seqan3::alphabet_proxy<alphabet_proxy_example2, alphabet_type>;
     friend base_t;
 
     constexpr void on_update() noexcept

--- a/test/unit/alphabet/gap/gap_test.cpp
+++ b/test/unit/alphabet/gap/gap_test.cpp
@@ -17,18 +17,16 @@
 #include "../semi_alphabet_constexpr_test_template.hpp"
 #include "../semi_alphabet_test_template.hpp"
 
-using namespace seqan3;
-
-INSTANTIATE_TYPED_TEST_SUITE_P(gap, alphabet_, gap, );
-INSTANTIATE_TYPED_TEST_SUITE_P(gap, semi_alphabet_test, gap, );
-INSTANTIATE_TYPED_TEST_SUITE_P(gap, alphabet_constexpr, gap, );
-INSTANTIATE_TYPED_TEST_SUITE_P(gap, semi_alphabet_constexpr, gap, );
+INSTANTIATE_TYPED_TEST_SUITE_P(gap, alphabet_, seqan3::gap, );
+INSTANTIATE_TYPED_TEST_SUITE_P(gap, semi_alphabet_test, seqan3::gap, );
+INSTANTIATE_TYPED_TEST_SUITE_P(gap, alphabet_constexpr, seqan3::gap, );
+INSTANTIATE_TYPED_TEST_SUITE_P(gap, semi_alphabet_constexpr, seqan3::gap, );
 
 TEST(gap_test, default_initialization)
 {
-    gap gap1;
-    gap gap2{};
-    gap gap3 = gap{};
+    seqan3::gap gap1;
+    seqan3::gap gap2{};
+    seqan3::gap gap3 = seqan3::gap{};
 
     EXPECT_EQ(gap1.to_rank(), 0);
     EXPECT_EQ(gap2.to_rank(), 0);
@@ -40,24 +38,24 @@ TEST(gap_test, default_initialization)
 
 TEST(gap_test, relations)
 {
-    EXPECT_EQ(gap{}, gap{});
-    EXPECT_LE(gap{}, gap{});
-    EXPECT_GE(gap{}, gap{});
+    EXPECT_EQ(seqan3::gap{}, seqan3::gap{});
+    EXPECT_LE(seqan3::gap{}, seqan3::gap{});
+    EXPECT_GE(seqan3::gap{}, seqan3::gap{});
 }
 
 TEST(gap_test, assign_char)
 {
-    EXPECT_EQ(gap{}.assign_char('-'), gap{});
-    EXPECT_EQ(gap{}.assign_char('x'), gap{});
+    EXPECT_EQ(seqan3::gap{}.assign_char('-'), seqan3::gap{});
+    EXPECT_EQ(seqan3::gap{}.assign_char('x'), seqan3::gap{});
 }
 
 TEST(gap_test, to_rank)
 {
-    EXPECT_EQ(gap{}.to_rank(), 0);
+    EXPECT_EQ(seqan3::gap{}.to_rank(), 0);
 }
 
 TEST(gap_test, assign_rank)
 {
-    EXPECT_EQ(gap{}.assign_rank(0), gap{});
-    // EXPECT_EQ(gap{}.assign_rank(13), gap{});
+    EXPECT_EQ(seqan3::gap{}.assign_rank(0), seqan3::gap{});
+    // EXPECT_EQ(seqan3::gap{}.assign_rank(13), seqan3::gap{});
 }

--- a/test/unit/alphabet/gap/gapped_test.cpp
+++ b/test/unit/alphabet/gap/gapped_test.cpp
@@ -23,9 +23,11 @@
 #include "../semi_alphabet_constexpr_test_template.hpp"
 #include "../semi_alphabet_test_template.hpp"
 
-using namespace seqan3;
+using seqan3::operator""_dna4;
 
-using gapped_types = ::testing::Types<gapped<dna4>, gapped<dna15>, gapped<qualified<dna4, phred42>>>;
+using gapped_types = ::testing::Types<seqan3::gapped<seqan3::dna4>,
+                                      seqan3::gapped<seqan3::dna15>,
+                                      seqan3::gapped<seqan3::qualified<seqan3::dna4, seqan3::phred42>>>;
 
 INSTANTIATE_TYPED_TEST_SUITE_P(gapped, alphabet_, gapped_types, );
 INSTANTIATE_TYPED_TEST_SUITE_P(gapped, semi_alphabet_test, gapped_types, );
@@ -39,12 +41,12 @@ TYPED_TEST_SUITE(gapped_test, gapped_types, );
 
 TYPED_TEST(gapped_test, concept_check)
 {
-    EXPECT_TRUE((aligned_sequence<std::vector<TypeParam>>));
+    EXPECT_TRUE((seqan3::aligned_sequence<std::vector<TypeParam>>));
 }
 
 TEST(gapped_test, initialise_from_component_alphabet)
 {
-    using alphabet_t = gapped<dna4>;
+    using alphabet_t = seqan3::gapped<seqan3::dna4>;
 
     constexpr alphabet_t letter0{'A'_dna4};
     constexpr alphabet_t letter1 = 'C'_dna4;
@@ -56,8 +58,8 @@ TEST(gapped_test, initialise_from_component_alphabet)
     alphabet_t letter6 = {'G'_dna4};
     alphabet_t letter7 = static_cast<alphabet_t>('T'_dna4);
 
-    constexpr alphabet_t letter8{gap{}}; // letter3 = 'T'_dna4; does not work
-    alphabet_t letter9{gap{}};
+    constexpr alphabet_t letter8{seqan3::gap{}}; // letter3 = 'T'_dna4; does not work
+    alphabet_t letter9{seqan3::gap{}};
 
     EXPECT_EQ(letter0.to_rank(), 0);
     EXPECT_EQ(letter1.to_rank(), 1);
@@ -73,10 +75,10 @@ TEST(gapped_test, initialise_from_component_alphabet)
 
 TEST(gapped_test, assign_from_component_alphabet)
 {
-    using alphabet_t = gapped<dna4>;
+    using alphabet_t = seqan3::gapped<seqan3::dna4>;
     alphabet_t letter{};
 
-    letter = gap{};
+    letter = seqan3::gap{};
     EXPECT_EQ(letter.to_rank(), 4);
 
     letter = 'A'_dna4;

--- a/test/unit/alphabet/mask/mask_test.cpp
+++ b/test/unit/alphabet/mask/mask_test.cpp
@@ -12,40 +12,38 @@
 #include "../semi_alphabet_test_template.hpp"
 #include "../semi_alphabet_constexpr_test_template.hpp"
 
-using namespace seqan3;
-
-INSTANTIATE_TYPED_TEST_SUITE_P(mask, semi_alphabet_test, mask, );
-INSTANTIATE_TYPED_TEST_SUITE_P(mask, semi_alphabet_constexpr, mask, );
+INSTANTIATE_TYPED_TEST_SUITE_P(mask, semi_alphabet_test, seqan3::mask, );
+INSTANTIATE_TYPED_TEST_SUITE_P(mask, semi_alphabet_constexpr, seqan3::mask, );
 
 TEST(mask, assign_rank)
 {
     // l-value
-    mask lmask;
-    EXPECT_EQ(lmask.assign_rank(1), mask::MASKED);
+    seqan3::mask lmask;
+    EXPECT_EQ(lmask.assign_rank(1), seqan3::mask::MASKED);
     EXPECT_TRUE(lmask.to_rank());
-    EXPECT_EQ(lmask.assign_rank(0), mask::UNMASKED);
+    EXPECT_EQ(lmask.assign_rank(0), seqan3::mask::UNMASKED);
     EXPECT_FALSE(lmask.to_rank());
-    EXPECT_EQ(lmask.assign_rank(true), mask::MASKED);
-    EXPECT_EQ(lmask.assign_rank(false), mask::UNMASKED);
+    EXPECT_EQ(lmask.assign_rank(true), seqan3::mask::MASKED);
+    EXPECT_EQ(lmask.assign_rank(false), seqan3::mask::UNMASKED);
 
     // const l-value
     lmask.assign_rank(1);
-    mask const clmask{lmask};
+    seqan3::mask const clmask{lmask};
     EXPECT_TRUE(clmask.to_rank());
 
     // r-value
-    mask rmask{lmask};
+    seqan3::mask rmask{lmask};
     EXPECT_EQ(std::move(rmask).to_rank(), lmask.to_rank());
-    EXPECT_TRUE((std::is_same_v<decltype(std::move(rmask)), mask &&>));
-    EXPECT_EQ(std::move(rmask).assign_rank(1), mask::MASKED);
+    EXPECT_TRUE((std::is_same_v<decltype(std::move(rmask)), seqan3::mask &&>));
+    EXPECT_EQ(std::move(rmask).assign_rank(1), seqan3::mask::MASKED);
     EXPECT_TRUE(std::move(rmask).to_rank());
-    EXPECT_EQ(std::move(rmask).assign_rank(0), mask::UNMASKED);
+    EXPECT_EQ(std::move(rmask).assign_rank(0), seqan3::mask::UNMASKED);
     EXPECT_FALSE(std::move(rmask).to_rank());
-    EXPECT_EQ(std::move(rmask).assign_rank(true), mask::MASKED);
-    EXPECT_EQ(std::move(rmask).assign_rank(false), mask::UNMASKED);
+    EXPECT_EQ(std::move(rmask).assign_rank(true), seqan3::mask::MASKED);
+    EXPECT_EQ(std::move(rmask).assign_rank(false), seqan3::mask::UNMASKED);
 
     // const r-value
-    mask const crmask{lmask};
+    seqan3::mask const crmask{lmask};
     EXPECT_EQ(std::move(crmask).to_rank(), lmask.to_rank());
-    EXPECT_TRUE((std::is_same_v<decltype(std::move(crmask)), mask const &&>));
+    EXPECT_TRUE((std::is_same_v<decltype(std::move(crmask)), seqan3::mask const &&>));
 }

--- a/test/unit/alphabet/mask/masked_test.cpp
+++ b/test/unit/alphabet/mask/masked_test.cpp
@@ -17,9 +17,7 @@
 #include "../semi_alphabet_constexpr_test_template.hpp"
 #include "../semi_alphabet_test_template.hpp"
 
-using namespace seqan3;
-
-using masked_types = ::testing::Types<masked<dna4>, masked<dna5>>;
+using masked_types = ::testing::Types<seqan3::masked<seqan3::dna4>, seqan3::masked<seqan3::dna5>>;
 
 INSTANTIATE_TYPED_TEST_SUITE_P(masked, alphabet_, masked_types, );
 INSTANTIATE_TYPED_TEST_SUITE_P(masked, semi_alphabet_test, masked_types, );

--- a/test/unit/alphabet/nucleotide/dna15_test.cpp
+++ b/test/unit/alphabet/nucleotide/dna15_test.cpp
@@ -82,16 +82,14 @@ TEST(dna15, string_literal)
 TEST(dna15, char_is_valid)
 {
     constexpr auto validator = seqan3::is_char<'A'> || seqan3::is_char<'C'> || seqan3::is_char<'G'> ||
-                               seqan3::is_char<'T'> || seqan3::is_char<'U'> ||
-                               seqan3::is_char<'a'> || seqan3::is_char<'c'> || seqan3::is_char<'g'> ||
-                               seqan3::is_char<'t'> || seqan3::is_char<'u'> ||
-                               seqan3::is_char<'N'> || seqan3::is_char<'n'> ||
+                               seqan3::is_char<'T'> || seqan3::is_char<'U'> || seqan3::is_char<'a'> ||
+                               seqan3::is_char<'c'> || seqan3::is_char<'g'> || seqan3::is_char<'t'> ||
+                               seqan3::is_char<'u'> || seqan3::is_char<'N'> || seqan3::is_char<'n'> ||
                                seqan3::is_char<'R'> || seqan3::is_char<'Y'> || seqan3::is_char<'S'> ||
-                               seqan3::is_char<'W'> || seqan3::is_char<'K'> ||
-                               seqan3::is_char<'M'> || seqan3::is_char<'B'> || seqan3::is_char<'D'> ||
-                               seqan3::is_char<'H'> || seqan3::is_char<'V'> ||
-                               seqan3::is_char<'r'> || seqan3::is_char<'y'> || seqan3::is_char<'s'> ||
-                               seqan3::is_char<'w'> || seqan3::is_char<'k'> ||
+                               seqan3::is_char<'W'> || seqan3::is_char<'K'> || seqan3::is_char<'M'> ||
+                               seqan3::is_char<'B'> || seqan3::is_char<'D'> || seqan3::is_char<'H'> ||
+                               seqan3::is_char<'V'> || seqan3::is_char<'r'> || seqan3::is_char<'y'> ||
+                               seqan3::is_char<'s'> || seqan3::is_char<'w'> || seqan3::is_char<'k'> ||
                                seqan3::is_char<'m'> || seqan3::is_char<'b'> || seqan3::is_char<'d'> ||
                                seqan3::is_char<'h'> || seqan3::is_char<'v'>;
     for (char c : std::views::iota(std::numeric_limits<char>::min(), std::numeric_limits<char>::max()))

--- a/test/unit/alphabet/nucleotide/dna15_test.cpp
+++ b/test/unit/alphabet/nucleotide/dna15_test.cpp
@@ -13,79 +13,87 @@
 #include "../semi_alphabet_test_template.hpp"
 #include "nucleotide_test_template.hpp"
 
-INSTANTIATE_TYPED_TEST_SUITE_P(dna15, alphabet_, dna15, );
-INSTANTIATE_TYPED_TEST_SUITE_P(dna15, semi_alphabet_test, dna15, );
-INSTANTIATE_TYPED_TEST_SUITE_P(dna15, alphabet_constexpr, dna15, );
-INSTANTIATE_TYPED_TEST_SUITE_P(dna15, semi_alphabet_constexpr, dna15, );
-INSTANTIATE_TYPED_TEST_SUITE_P(dna15, nucleotide, dna15, );
+using seqan3::operator""_dna15;
+
+INSTANTIATE_TYPED_TEST_SUITE_P(dna15, alphabet_, seqan3::dna15, );
+INSTANTIATE_TYPED_TEST_SUITE_P(dna15, semi_alphabet_test, seqan3::dna15, );
+INSTANTIATE_TYPED_TEST_SUITE_P(dna15, alphabet_constexpr, seqan3::dna15, );
+INSTANTIATE_TYPED_TEST_SUITE_P(dna15, semi_alphabet_constexpr, seqan3::dna15, );
+INSTANTIATE_TYPED_TEST_SUITE_P(dna15, nucleotide, seqan3::dna15, );
 
 TEST(dna15, to_char_assign_char)
 {
-    EXPECT_EQ(to_char(dna15{}.assign_char('A')), 'A');
-    EXPECT_EQ(to_char(dna15{}.assign_char('C')), 'C');
-    EXPECT_EQ(to_char(dna15{}.assign_char('G')), 'G');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna15{}.assign_char('A')), 'A');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna15{}.assign_char('C')), 'C');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna15{}.assign_char('G')), 'G');
 
-    EXPECT_EQ(to_char(dna15{}.assign_char('U')), 'T');
-    EXPECT_EQ(to_char(dna15{}.assign_char('T')), 'T');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna15{}.assign_char('U')), 'T');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna15{}.assign_char('T')), 'T');
 
-    EXPECT_EQ(to_char(dna15{}.assign_char('R')), 'R');
-    EXPECT_EQ(to_char(dna15{}.assign_char('Y')), 'Y');
-    EXPECT_EQ(to_char(dna15{}.assign_char('S')), 'S');
-    EXPECT_EQ(to_char(dna15{}.assign_char('W')), 'W');
-    EXPECT_EQ(to_char(dna15{}.assign_char('K')), 'K');
-    EXPECT_EQ(to_char(dna15{}.assign_char('M')), 'M');
-    EXPECT_EQ(to_char(dna15{}.assign_char('B')), 'B');
-    EXPECT_EQ(to_char(dna15{}.assign_char('D')), 'D');
-    EXPECT_EQ(to_char(dna15{}.assign_char('H')), 'H');
-    EXPECT_EQ(to_char(dna15{}.assign_char('V')), 'V');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna15{}.assign_char('R')), 'R');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna15{}.assign_char('Y')), 'Y');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna15{}.assign_char('S')), 'S');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna15{}.assign_char('W')), 'W');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna15{}.assign_char('K')), 'K');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna15{}.assign_char('M')), 'M');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna15{}.assign_char('B')), 'B');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna15{}.assign_char('D')), 'D');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna15{}.assign_char('H')), 'H');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna15{}.assign_char('V')), 'V');
 
-    EXPECT_EQ(to_char(dna15{}.assign_char('N')), 'N');
-    EXPECT_EQ(to_char(dna15{}.assign_char('!')), 'N');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna15{}.assign_char('N')), 'N');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna15{}.assign_char('!')), 'N');
 }
 
 TEST(dna15, char_literal)
 {
-    EXPECT_EQ(to_char('A'_dna15), 'A');
-    EXPECT_EQ(to_char('C'_dna15), 'C');
-    EXPECT_EQ(to_char('G'_dna15), 'G');
+    EXPECT_EQ(seqan3::to_char('A'_dna15), 'A');
+    EXPECT_EQ(seqan3::to_char('C'_dna15), 'C');
+    EXPECT_EQ(seqan3::to_char('G'_dna15), 'G');
 
-    EXPECT_EQ(to_char('U'_dna15), 'T');
-    EXPECT_EQ(to_char('T'_dna15), 'T');
+    EXPECT_EQ(seqan3::to_char('U'_dna15), 'T');
+    EXPECT_EQ(seqan3::to_char('T'_dna15), 'T');
 
-    EXPECT_EQ(to_char('R'_dna15), 'R');
-    EXPECT_EQ(to_char('Y'_dna15), 'Y');
-    EXPECT_EQ(to_char('S'_dna15), 'S');
-    EXPECT_EQ(to_char('W'_dna15), 'W');
-    EXPECT_EQ(to_char('K'_dna15), 'K');
-    EXPECT_EQ(to_char('M'_dna15), 'M');
-    EXPECT_EQ(to_char('B'_dna15), 'B');
-    EXPECT_EQ(to_char('D'_dna15), 'D');
-    EXPECT_EQ(to_char('H'_dna15), 'H');
-    EXPECT_EQ(to_char('V'_dna15), 'V');
+    EXPECT_EQ(seqan3::to_char('R'_dna15), 'R');
+    EXPECT_EQ(seqan3::to_char('Y'_dna15), 'Y');
+    EXPECT_EQ(seqan3::to_char('S'_dna15), 'S');
+    EXPECT_EQ(seqan3::to_char('W'_dna15), 'W');
+    EXPECT_EQ(seqan3::to_char('K'_dna15), 'K');
+    EXPECT_EQ(seqan3::to_char('M'_dna15), 'M');
+    EXPECT_EQ(seqan3::to_char('B'_dna15), 'B');
+    EXPECT_EQ(seqan3::to_char('D'_dna15), 'D');
+    EXPECT_EQ(seqan3::to_char('H'_dna15), 'H');
+    EXPECT_EQ(seqan3::to_char('V'_dna15), 'V');
 
-    EXPECT_EQ(to_char('N'_dna15), 'N');
-    EXPECT_EQ(to_char('!'_dna15), 'N');
+    EXPECT_EQ(seqan3::to_char('N'_dna15), 'N');
+    EXPECT_EQ(seqan3::to_char('!'_dna15), 'N');
 }
 
 TEST(dna15, string_literal)
 {
-    dna15_vector v;
+    seqan3::dna15_vector v;
     v.resize(5, 'A'_dna15);
     EXPECT_EQ(v, "AAAAA"_dna15);
 
-    std::vector<dna15> w{'A'_dna15, 'C'_dna15, 'G'_dna15, 'T'_dna15, 'U'_dna15, 'N'_dna15};
+    std::vector<seqan3::dna15> w{'A'_dna15, 'C'_dna15, 'G'_dna15, 'T'_dna15, 'U'_dna15, 'N'_dna15};
     EXPECT_EQ(w, "ACGTTN"_dna15);
 }
 
 TEST(dna15, char_is_valid)
 {
-    constexpr auto validator = is_char<'A'> || is_char<'C'> || is_char<'G'> || is_char<'T'> || is_char<'U'>
-                            || is_char<'a'> || is_char<'c'> || is_char<'g'> || is_char<'t'> || is_char<'u'>
-                            || is_char<'N'> || is_char<'n'>
-                            || is_char<'R'> || is_char<'Y'> || is_char<'S'> || is_char<'W'> || is_char<'K'>
-                            || is_char<'M'> || is_char<'B'> || is_char<'D'> || is_char<'H'> || is_char<'V'>
-                            || is_char<'r'> || is_char<'y'> || is_char<'s'> || is_char<'w'> || is_char<'k'>
-                            || is_char<'m'> || is_char<'b'> || is_char<'d'> || is_char<'h'> || is_char<'v'>;
+    constexpr auto validator = seqan3::is_char<'A'> || seqan3::is_char<'C'> || seqan3::is_char<'G'> ||
+                               seqan3::is_char<'T'> || seqan3::is_char<'U'> ||
+                               seqan3::is_char<'a'> || seqan3::is_char<'c'> || seqan3::is_char<'g'> ||
+                               seqan3::is_char<'t'> || seqan3::is_char<'u'> ||
+                               seqan3::is_char<'N'> || seqan3::is_char<'n'> ||
+                               seqan3::is_char<'R'> || seqan3::is_char<'Y'> || seqan3::is_char<'S'> ||
+                               seqan3::is_char<'W'> || seqan3::is_char<'K'> ||
+                               seqan3::is_char<'M'> || seqan3::is_char<'B'> || seqan3::is_char<'D'> ||
+                               seqan3::is_char<'H'> || seqan3::is_char<'V'> ||
+                               seqan3::is_char<'r'> || seqan3::is_char<'y'> || seqan3::is_char<'s'> ||
+                               seqan3::is_char<'w'> || seqan3::is_char<'k'> ||
+                               seqan3::is_char<'m'> || seqan3::is_char<'b'> || seqan3::is_char<'d'> ||
+                               seqan3::is_char<'h'> || seqan3::is_char<'v'>;
     for (char c : std::views::iota(std::numeric_limits<char>::min(), std::numeric_limits<char>::max()))
-        EXPECT_EQ(dna15::char_is_valid(c), validator(c));
+        EXPECT_EQ(seqan3::dna15::char_is_valid(c), validator(c));
 }

--- a/test/unit/alphabet/nucleotide/dna4_test.cpp
+++ b/test/unit/alphabet/nucleotide/dna4_test.cpp
@@ -80,9 +80,9 @@ TEST(dna4, string_literal)
 TEST(dna4, char_is_valid)
 {
     constexpr auto validator = seqan3::is_char<'A'> || seqan3::is_char<'C'> || seqan3::is_char<'G'> ||
-                               seqan3::is_char<'T'> || seqan3::is_char<'U'> ||
-                               seqan3::is_char<'a'> || seqan3::is_char<'c'> || seqan3::is_char<'g'> ||
-                               seqan3::is_char<'t'> || seqan3::is_char<'u'>;
+                               seqan3::is_char<'T'> || seqan3::is_char<'U'> || seqan3::is_char<'a'> ||
+                               seqan3::is_char<'c'> || seqan3::is_char<'g'> || seqan3::is_char<'t'> ||
+                               seqan3::is_char<'u'>;
     for (char c : std::views::iota(std::numeric_limits<char>::min(), std::numeric_limits<char>::max()))
         EXPECT_EQ(seqan3::dna4::char_is_valid(c), validator(c));
 }

--- a/test/unit/alphabet/nucleotide/dna4_test.cpp
+++ b/test/unit/alphabet/nucleotide/dna4_test.cpp
@@ -11,74 +11,78 @@
 #include "../semi_alphabet_test_template.hpp"
 #include "nucleotide_test_template.hpp"
 
-INSTANTIATE_TYPED_TEST_SUITE_P(dna4, alphabet_, dna4, );
-INSTANTIATE_TYPED_TEST_SUITE_P(dna4, semi_alphabet_test, dna4, );
-INSTANTIATE_TYPED_TEST_SUITE_P(dna4, alphabet_constexpr, dna4, );
-INSTANTIATE_TYPED_TEST_SUITE_P(dna4, semi_alphabet_constexpr, dna4, );
-INSTANTIATE_TYPED_TEST_SUITE_P(dna4, nucleotide, dna4, );
+using seqan3::operator""_dna4;
+
+INSTANTIATE_TYPED_TEST_SUITE_P(dna4, alphabet_, seqan3::dna4, );
+INSTANTIATE_TYPED_TEST_SUITE_P(dna4, semi_alphabet_test, seqan3::dna4, );
+INSTANTIATE_TYPED_TEST_SUITE_P(dna4, alphabet_constexpr, seqan3::dna4, );
+INSTANTIATE_TYPED_TEST_SUITE_P(dna4, semi_alphabet_constexpr, seqan3::dna4, );
+INSTANTIATE_TYPED_TEST_SUITE_P(dna4, nucleotide, seqan3::dna4, );
 
 TEST(dna4, to_char_assign_char)
 {
-    EXPECT_EQ(to_char(dna4{}.assign_char('A')), 'A');
-    EXPECT_EQ(to_char(dna4{}.assign_char('C')), 'C');
-    EXPECT_EQ(to_char(dna4{}.assign_char('G')), 'G');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna4{}.assign_char('A')), 'A');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna4{}.assign_char('C')), 'C');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna4{}.assign_char('G')), 'G');
 
-    EXPECT_EQ(to_char(dna4{}.assign_char('U')), 'T');
-    EXPECT_EQ(to_char(dna4{}.assign_char('T')), 'T');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna4{}.assign_char('U')), 'T');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna4{}.assign_char('T')), 'T');
 
-    EXPECT_EQ(to_char(dna4{}.assign_char('R')), 'A');
-    EXPECT_EQ(to_char(dna4{}.assign_char('Y')), 'C');
-    EXPECT_EQ(to_char(dna4{}.assign_char('S')), 'C');
-    EXPECT_EQ(to_char(dna4{}.assign_char('W')), 'A');
-    EXPECT_EQ(to_char(dna4{}.assign_char('K')), 'G');
-    EXPECT_EQ(to_char(dna4{}.assign_char('M')), 'A');
-    EXPECT_EQ(to_char(dna4{}.assign_char('B')), 'C');
-    EXPECT_EQ(to_char(dna4{}.assign_char('D')), 'A');
-    EXPECT_EQ(to_char(dna4{}.assign_char('H')), 'A');
-    EXPECT_EQ(to_char(dna4{}.assign_char('V')), 'A');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna4{}.assign_char('R')), 'A');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna4{}.assign_char('Y')), 'C');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna4{}.assign_char('S')), 'C');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna4{}.assign_char('W')), 'A');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna4{}.assign_char('K')), 'G');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna4{}.assign_char('M')), 'A');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna4{}.assign_char('B')), 'C');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna4{}.assign_char('D')), 'A');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna4{}.assign_char('H')), 'A');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna4{}.assign_char('V')), 'A');
 
-    EXPECT_EQ(to_char(dna4{}.assign_char('N')), 'A');
-    EXPECT_EQ(to_char(dna4{}.assign_char('!')), 'A');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna4{}.assign_char('N')), 'A');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna4{}.assign_char('!')), 'A');
 }
 
 TEST(dna4, char_literal)
 {
-    EXPECT_EQ(to_char('A'_dna4), 'A');
-    EXPECT_EQ(to_char('C'_dna4), 'C');
-    EXPECT_EQ(to_char('G'_dna4), 'G');
+    EXPECT_EQ(seqan3::to_char('A'_dna4), 'A');
+    EXPECT_EQ(seqan3::to_char('C'_dna4), 'C');
+    EXPECT_EQ(seqan3::to_char('G'_dna4), 'G');
 
-    EXPECT_EQ(to_char('U'_dna4), 'T');
-    EXPECT_EQ(to_char('T'_dna4), 'T');
+    EXPECT_EQ(seqan3::to_char('U'_dna4), 'T');
+    EXPECT_EQ(seqan3::to_char('T'_dna4), 'T');
 
-    EXPECT_EQ(to_char('R'_dna4), 'A');
-    EXPECT_EQ(to_char('Y'_dna4), 'C');
-    EXPECT_EQ(to_char('S'_dna4), 'C');
-    EXPECT_EQ(to_char('W'_dna4), 'A');
-    EXPECT_EQ(to_char('K'_dna4), 'G');
-    EXPECT_EQ(to_char('M'_dna4), 'A');
-    EXPECT_EQ(to_char('B'_dna4), 'C');
-    EXPECT_EQ(to_char('D'_dna4), 'A');
-    EXPECT_EQ(to_char('H'_dna4), 'A');
-    EXPECT_EQ(to_char('V'_dna4), 'A');
+    EXPECT_EQ(seqan3::to_char('R'_dna4), 'A');
+    EXPECT_EQ(seqan3::to_char('Y'_dna4), 'C');
+    EXPECT_EQ(seqan3::to_char('S'_dna4), 'C');
+    EXPECT_EQ(seqan3::to_char('W'_dna4), 'A');
+    EXPECT_EQ(seqan3::to_char('K'_dna4), 'G');
+    EXPECT_EQ(seqan3::to_char('M'_dna4), 'A');
+    EXPECT_EQ(seqan3::to_char('B'_dna4), 'C');
+    EXPECT_EQ(seqan3::to_char('D'_dna4), 'A');
+    EXPECT_EQ(seqan3::to_char('H'_dna4), 'A');
+    EXPECT_EQ(seqan3::to_char('V'_dna4), 'A');
 
-    EXPECT_EQ(to_char('N'_dna4), 'A');
-    EXPECT_EQ(to_char('!'_dna4), 'A');
+    EXPECT_EQ(seqan3::to_char('N'_dna4), 'A');
+    EXPECT_EQ(seqan3::to_char('!'_dna4), 'A');
 }
 
 TEST(dna4, string_literal)
 {
-    dna4_vector v;
+    seqan3::dna4_vector v;
     v.resize(5, 'A'_dna4);
     EXPECT_EQ(v, "AAAAA"_dna4);
 
-    std::vector<dna4> w{'A'_dna4, 'C'_dna4, 'G'_dna4, 'T'_dna4, 'U'_dna4, 'N'_dna4};
+    std::vector<seqan3::dna4> w{'A'_dna4, 'C'_dna4, 'G'_dna4, 'T'_dna4, 'U'_dna4, 'N'_dna4};
     EXPECT_EQ(w, "ACGTTA"_dna4);
 }
 
 TEST(dna4, char_is_valid)
 {
-    constexpr auto validator = is_char<'A'> || is_char<'C'> || is_char<'G'> || is_char<'T'> || is_char<'U'>
-                            || is_char<'a'> || is_char<'c'> || is_char<'g'> || is_char<'t'> || is_char<'u'>;
+    constexpr auto validator = seqan3::is_char<'A'> || seqan3::is_char<'C'> || seqan3::is_char<'G'> ||
+                               seqan3::is_char<'T'> || seqan3::is_char<'U'> ||
+                               seqan3::is_char<'a'> || seqan3::is_char<'c'> || seqan3::is_char<'g'> ||
+                               seqan3::is_char<'t'> || seqan3::is_char<'u'>;
     for (char c : std::views::iota(std::numeric_limits<char>::min(), std::numeric_limits<char>::max()))
-        EXPECT_EQ(dna4::char_is_valid(c), validator(c));
+        EXPECT_EQ(seqan3::dna4::char_is_valid(c), validator(c));
 }

--- a/test/unit/alphabet/nucleotide/dna5_test.cpp
+++ b/test/unit/alphabet/nucleotide/dna5_test.cpp
@@ -13,75 +13,79 @@
 #include "../semi_alphabet_test_template.hpp"
 #include "nucleotide_test_template.hpp"
 
-INSTANTIATE_TYPED_TEST_SUITE_P(dna5, alphabet_, dna5, );
-INSTANTIATE_TYPED_TEST_SUITE_P(dna5, semi_alphabet_test, dna5, );
-INSTANTIATE_TYPED_TEST_SUITE_P(dna5, alphabet_constexpr, dna5, );
-INSTANTIATE_TYPED_TEST_SUITE_P(dna5, semi_alphabet_constexpr, dna5, );
-INSTANTIATE_TYPED_TEST_SUITE_P(dna5, nucleotide, dna5, );
+using seqan3::operator""_dna5;
+
+INSTANTIATE_TYPED_TEST_SUITE_P(dna5, alphabet_, seqan3::dna5, );
+INSTANTIATE_TYPED_TEST_SUITE_P(dna5, semi_alphabet_test, seqan3::dna5, );
+INSTANTIATE_TYPED_TEST_SUITE_P(dna5, alphabet_constexpr, seqan3::dna5, );
+INSTANTIATE_TYPED_TEST_SUITE_P(dna5, semi_alphabet_constexpr, seqan3::dna5, );
+INSTANTIATE_TYPED_TEST_SUITE_P(dna5, nucleotide, seqan3::dna5, );
 
 TEST(dna5, to_char_assign_char)
 {
-    EXPECT_EQ(to_char(dna5{}.assign_char('A')), 'A');
-    EXPECT_EQ(to_char(dna5{}.assign_char('C')), 'C');
-    EXPECT_EQ(to_char(dna5{}.assign_char('G')), 'G');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna5{}.assign_char('A')), 'A');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna5{}.assign_char('C')), 'C');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna5{}.assign_char('G')), 'G');
 
-    EXPECT_EQ(to_char(dna5{}.assign_char('U')), 'T');
-    EXPECT_EQ(to_char(dna5{}.assign_char('T')), 'T');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna5{}.assign_char('U')), 'T');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna5{}.assign_char('T')), 'T');
 
-    EXPECT_EQ(to_char(dna5{}.assign_char('R')), 'N');
-    EXPECT_EQ(to_char(dna5{}.assign_char('Y')), 'N');
-    EXPECT_EQ(to_char(dna5{}.assign_char('S')), 'N');
-    EXPECT_EQ(to_char(dna5{}.assign_char('W')), 'N');
-    EXPECT_EQ(to_char(dna5{}.assign_char('K')), 'N');
-    EXPECT_EQ(to_char(dna5{}.assign_char('M')), 'N');
-    EXPECT_EQ(to_char(dna5{}.assign_char('B')), 'N');
-    EXPECT_EQ(to_char(dna5{}.assign_char('D')), 'N');
-    EXPECT_EQ(to_char(dna5{}.assign_char('H')), 'N');
-    EXPECT_EQ(to_char(dna5{}.assign_char('V')), 'N');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna5{}.assign_char('R')), 'N');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna5{}.assign_char('Y')), 'N');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna5{}.assign_char('S')), 'N');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna5{}.assign_char('W')), 'N');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna5{}.assign_char('K')), 'N');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna5{}.assign_char('M')), 'N');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna5{}.assign_char('B')), 'N');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna5{}.assign_char('D')), 'N');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna5{}.assign_char('H')), 'N');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna5{}.assign_char('V')), 'N');
 
-    EXPECT_EQ(to_char(dna5{}.assign_char('N')), 'N');
-    EXPECT_EQ(to_char(dna5{}.assign_char('!')), 'N');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna5{}.assign_char('N')), 'N');
+    EXPECT_EQ(seqan3::to_char(seqan3::dna5{}.assign_char('!')), 'N');
 }
 
 TEST(dna5, char_literal)
 {
-    EXPECT_EQ(to_char('A'_dna5), 'A');
-    EXPECT_EQ(to_char('C'_dna5), 'C');
-    EXPECT_EQ(to_char('G'_dna5), 'G');
+    EXPECT_EQ(seqan3::to_char('A'_dna5), 'A');
+    EXPECT_EQ(seqan3::to_char('C'_dna5), 'C');
+    EXPECT_EQ(seqan3::to_char('G'_dna5), 'G');
 
-    EXPECT_EQ(to_char('U'_dna5), 'T');
-    EXPECT_EQ(to_char('T'_dna5), 'T');
+    EXPECT_EQ(seqan3::to_char('U'_dna5), 'T');
+    EXPECT_EQ(seqan3::to_char('T'_dna5), 'T');
 
-    EXPECT_EQ(to_char('R'_dna5), 'N');
-    EXPECT_EQ(to_char('Y'_dna5), 'N');
-    EXPECT_EQ(to_char('S'_dna5), 'N');
-    EXPECT_EQ(to_char('W'_dna5), 'N');
-    EXPECT_EQ(to_char('K'_dna5), 'N');
-    EXPECT_EQ(to_char('M'_dna5), 'N');
-    EXPECT_EQ(to_char('B'_dna5), 'N');
-    EXPECT_EQ(to_char('D'_dna5), 'N');
-    EXPECT_EQ(to_char('H'_dna5), 'N');
-    EXPECT_EQ(to_char('V'_dna5), 'N');
+    EXPECT_EQ(seqan3::to_char('R'_dna5), 'N');
+    EXPECT_EQ(seqan3::to_char('Y'_dna5), 'N');
+    EXPECT_EQ(seqan3::to_char('S'_dna5), 'N');
+    EXPECT_EQ(seqan3::to_char('W'_dna5), 'N');
+    EXPECT_EQ(seqan3::to_char('K'_dna5), 'N');
+    EXPECT_EQ(seqan3::to_char('M'_dna5), 'N');
+    EXPECT_EQ(seqan3::to_char('B'_dna5), 'N');
+    EXPECT_EQ(seqan3::to_char('D'_dna5), 'N');
+    EXPECT_EQ(seqan3::to_char('H'_dna5), 'N');
+    EXPECT_EQ(seqan3::to_char('V'_dna5), 'N');
 
-    EXPECT_EQ(to_char('N'_dna5), 'N');
-    EXPECT_EQ(to_char('!'_dna5), 'N');
+    EXPECT_EQ(seqan3::to_char('N'_dna5), 'N');
+    EXPECT_EQ(seqan3::to_char('!'_dna5), 'N');
 }
 
 TEST(dna5, string_literal)
 {
-    dna5_vector v;
+    seqan3::dna5_vector v;
     v.resize(5, 'A'_dna5);
     EXPECT_EQ(v, "AAAAA"_dna5);
 
-    std::vector<dna5> w{'A'_dna5, 'C'_dna5, 'G'_dna5, 'T'_dna5, 'U'_dna5, 'N'_dna5};
+    std::vector<seqan3::dna5> w{'A'_dna5, 'C'_dna5, 'G'_dna5, 'T'_dna5, 'U'_dna5, 'N'_dna5};
     EXPECT_EQ(w, "ACGTTN"_dna5);
 }
 
 TEST(dna5, char_is_valid)
 {
-    constexpr auto validator = is_char<'A'> || is_char<'C'> || is_char<'G'> || is_char<'T'> || is_char<'U'>
-                            || is_char<'a'> || is_char<'c'> || is_char<'g'> || is_char<'t'> || is_char<'u'>
-                            || is_char<'N'> || is_char<'n'>;
+    constexpr auto validator = seqan3::is_char<'A'> || seqan3::is_char<'C'> || seqan3::is_char<'G'> ||
+                               seqan3::is_char<'T'> || seqan3::is_char<'U'> ||
+                               seqan3::is_char<'a'> || seqan3::is_char<'c'> || seqan3::is_char<'g'> ||
+                               seqan3::is_char<'t'> || seqan3::is_char<'u'> ||
+                               seqan3::is_char<'N'> || seqan3::is_char<'n'>;
     for (char c : std::views::iota(std::numeric_limits<char>::min(), std::numeric_limits<char>::max()))
-        EXPECT_EQ(dna5::char_is_valid(c), validator(c));
+        EXPECT_EQ(seqan3::dna5::char_is_valid(c), validator(c));
 }

--- a/test/unit/alphabet/nucleotide/dna5_test.cpp
+++ b/test/unit/alphabet/nucleotide/dna5_test.cpp
@@ -82,10 +82,9 @@ TEST(dna5, string_literal)
 TEST(dna5, char_is_valid)
 {
     constexpr auto validator = seqan3::is_char<'A'> || seqan3::is_char<'C'> || seqan3::is_char<'G'> ||
-                               seqan3::is_char<'T'> || seqan3::is_char<'U'> ||
-                               seqan3::is_char<'a'> || seqan3::is_char<'c'> || seqan3::is_char<'g'> ||
-                               seqan3::is_char<'t'> || seqan3::is_char<'u'> ||
-                               seqan3::is_char<'N'> || seqan3::is_char<'n'>;
+                               seqan3::is_char<'T'> || seqan3::is_char<'U'> || seqan3::is_char<'a'> ||
+                               seqan3::is_char<'c'> || seqan3::is_char<'g'> || seqan3::is_char<'t'> ||
+                               seqan3::is_char<'u'> || seqan3::is_char<'N'> || seqan3::is_char<'n'>;
     for (char c : std::views::iota(std::numeric_limits<char>::min(), std::numeric_limits<char>::max()))
         EXPECT_EQ(seqan3::dna5::char_is_valid(c), validator(c));
 }

--- a/test/unit/alphabet/nucleotide/nucleotide_conversion_integration_test.cpp
+++ b/test/unit/alphabet/nucleotide/nucleotide_conversion_integration_test.cpp
@@ -13,13 +13,16 @@
 #include <seqan3/core/detail/pack_algorithm.hpp>
 #include <seqan3/core/type_list/type_list.hpp>
 
-using namespace seqan3;
-
 template <typename T>
 using nucleotide_conversion = ::testing::Test;
 
-using nucleotide_types = type_list<dna4, dna5, dna15, rna4, rna5, rna15>; // needed for some tests
-using nucleotide_gtest_types = detail::transfer_template_args_onto_t<nucleotide_types, ::testing::Types>;
+using nucleotide_types = seqan3::type_list<seqan3::dna4,
+                                           seqan3::dna5,
+                                           seqan3::dna15,
+                                           seqan3::rna4,
+                                           seqan3::rna5,
+                                           seqan3::rna15>; // needed for some tests
+using nucleotide_gtest_types = seqan3::detail::transfer_template_args_onto_t<nucleotide_types, ::testing::Types>;
 
 
 TYPED_TEST_SUITE(nucleotide_conversion, nucleotide_gtest_types, );
@@ -27,7 +30,7 @@ TYPED_TEST_SUITE(nucleotide_conversion, nucleotide_gtest_types, );
 // conversion to any other nucleotide type
 TYPED_TEST(nucleotide_conversion, explicit_conversion)
 {
-    detail::for_each<nucleotide_types>([&] (auto nucl) constexpr
+    seqan3::detail::for_each<nucleotide_types>([&] (auto nucl) constexpr
     {
         using out_type = std::decay_t<typename decltype(nucl)::type>;
         EXPECT_EQ(static_cast<out_type>(TypeParam{}.assign_char('A')), out_type{}.assign_char('A'));
@@ -42,12 +45,12 @@ TYPED_TEST(nucleotide_conversion, explicit_conversion)
 // conversion to rna/dna of same size
 TYPED_TEST(nucleotide_conversion, implicit_conversion)
 {
-    using other_type = std::conditional_t<std::is_same_v<TypeParam, rna4>,  dna4,
-                       std::conditional_t<std::is_same_v<TypeParam, dna4>,  rna4,
-                       std::conditional_t<std::is_same_v<TypeParam, rna5>,  dna5,
-                       std::conditional_t<std::is_same_v<TypeParam, dna5>,  rna5,
-                       std::conditional_t<std::is_same_v<TypeParam, dna15>, rna15,
-                       /* must be rna15 */                                  dna15>>>>>;
+    using other_type = std::conditional_t<std::is_same_v<TypeParam, seqan3::rna4>,  seqan3::dna4,
+                       std::conditional_t<std::is_same_v<TypeParam, seqan3::dna4>,  seqan3::rna4,
+                       std::conditional_t<std::is_same_v<TypeParam, seqan3::rna5>,  seqan3::dna5,
+                       std::conditional_t<std::is_same_v<TypeParam, seqan3::dna5>,  seqan3::rna5,
+                       std::conditional_t<std::is_same_v<TypeParam, seqan3::dna15>, seqan3::rna15,
+                       /* must be seqan3::rna15 */                                  seqan3::dna15>>>>>;
 
     // construct
     EXPECT_EQ(other_type{TypeParam{}.assign_char('C')}, other_type{}.assign_char('C'));

--- a/test/unit/alphabet/nucleotide/nucleotide_test_template.hpp
+++ b/test/unit/alphabet/nucleotide/nucleotide_test_template.hpp
@@ -15,8 +15,6 @@
 #include <seqan3/alphabet/nucleotide/all.hpp>
 #include <seqan3/core/char_operations/predicate.hpp>
 
-using namespace seqan3;
-
 template <typename T>
 using nucleotide = ::testing::Test;
 
@@ -24,26 +22,26 @@ TYPED_TEST_SUITE_P(nucleotide);
 
 TYPED_TEST_P(nucleotide, concept_check)
 {
-    EXPECT_TRUE(nucleotide_alphabet<TypeParam>);
-    EXPECT_TRUE(nucleotide_alphabet<TypeParam &>);
-    EXPECT_TRUE(nucleotide_alphabet<TypeParam const>);
-    EXPECT_TRUE(nucleotide_alphabet<TypeParam const &>);
+    EXPECT_TRUE(seqan3::nucleotide_alphabet<TypeParam>);
+    EXPECT_TRUE(seqan3::nucleotide_alphabet<TypeParam &>);
+    EXPECT_TRUE(seqan3::nucleotide_alphabet<TypeParam const>);
+    EXPECT_TRUE(seqan3::nucleotide_alphabet<TypeParam const &>);
 }
 
 TYPED_TEST_P(nucleotide, global_complement)
 {
-    EXPECT_EQ(complement(TypeParam{}.assign_char('A')), TypeParam{}.assign_char('T'));
-    EXPECT_EQ(complement(TypeParam{}.assign_char('C')), TypeParam{}.assign_char('G'));
-    EXPECT_EQ(complement(TypeParam{}.assign_char('G')), TypeParam{}.assign_char('C'));
-    EXPECT_EQ(complement(TypeParam{}.assign_char('T')), TypeParam{}.assign_char('A'));
+    EXPECT_EQ(seqan3::complement(TypeParam{}.assign_char('A')), TypeParam{}.assign_char('T'));
+    EXPECT_EQ(seqan3::complement(TypeParam{}.assign_char('C')), TypeParam{}.assign_char('G'));
+    EXPECT_EQ(seqan3::complement(TypeParam{}.assign_char('G')), TypeParam{}.assign_char('C'));
+    EXPECT_EQ(seqan3::complement(TypeParam{}.assign_char('T')), TypeParam{}.assign_char('A'));
 
-    using vsize_t = std::decay_t<decltype(alphabet_size<TypeParam>)>;
+    using vsize_t = std::decay_t<decltype(seqan3::alphabet_size<TypeParam>)>;
 
-    for (vsize_t i = 0u; i < alphabet_size<TypeParam>; ++i)
+    for (vsize_t i = 0u; i < seqan3::alphabet_size<TypeParam>; ++i)
     {
-        TypeParam c = assign_rank_to(i, TypeParam{});
+        TypeParam c = seqan3::assign_rank_to(i, TypeParam{});
 
-        EXPECT_EQ(complement(complement(c)), c);
+        EXPECT_EQ(seqan3::complement(seqan3::complement(c)), c);
     }
 }
 

--- a/test/unit/alphabet/nucleotide/rna15_test.cpp
+++ b/test/unit/alphabet/nucleotide/rna15_test.cpp
@@ -11,79 +11,87 @@
 #include "../semi_alphabet_test_template.hpp"
 #include "nucleotide_test_template.hpp"
 
-INSTANTIATE_TYPED_TEST_SUITE_P(rna15, alphabet_, rna15, );
-INSTANTIATE_TYPED_TEST_SUITE_P(rna15, semi_alphabet_test, rna15, );
-INSTANTIATE_TYPED_TEST_SUITE_P(rna15, alphabet_constexpr, rna15, );
-INSTANTIATE_TYPED_TEST_SUITE_P(rna15, semi_alphabet_constexpr, rna15, );
-INSTANTIATE_TYPED_TEST_SUITE_P(rna15, nucleotide, rna15, );
+using seqan3::operator""_rna15;
+
+INSTANTIATE_TYPED_TEST_SUITE_P(rna15, alphabet_, seqan3::rna15, );
+INSTANTIATE_TYPED_TEST_SUITE_P(rna15, semi_alphabet_test, seqan3::rna15, );
+INSTANTIATE_TYPED_TEST_SUITE_P(rna15, alphabet_constexpr, seqan3::rna15, );
+INSTANTIATE_TYPED_TEST_SUITE_P(rna15, semi_alphabet_constexpr, seqan3::rna15, );
+INSTANTIATE_TYPED_TEST_SUITE_P(rna15, nucleotide, seqan3::rna15, );
 
 TEST(rna15, to_char_assign_char)
 {
-    EXPECT_EQ(to_char(rna15{}.assign_char('A')), 'A');
-    EXPECT_EQ(to_char(rna15{}.assign_char('C')), 'C');
-    EXPECT_EQ(to_char(rna15{}.assign_char('G')), 'G');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna15{}.assign_char('A')), 'A');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna15{}.assign_char('C')), 'C');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna15{}.assign_char('G')), 'G');
 
-    EXPECT_EQ(to_char(rna15{}.assign_char('U')), 'U');
-    EXPECT_EQ(to_char(rna15{}.assign_char('T')), 'U');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna15{}.assign_char('U')), 'U');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna15{}.assign_char('T')), 'U');
 
-    EXPECT_EQ(to_char(rna15{}.assign_char('R')), 'R');
-    EXPECT_EQ(to_char(rna15{}.assign_char('Y')), 'Y');
-    EXPECT_EQ(to_char(rna15{}.assign_char('S')), 'S');
-    EXPECT_EQ(to_char(rna15{}.assign_char('W')), 'W');
-    EXPECT_EQ(to_char(rna15{}.assign_char('K')), 'K');
-    EXPECT_EQ(to_char(rna15{}.assign_char('M')), 'M');
-    EXPECT_EQ(to_char(rna15{}.assign_char('B')), 'B');
-    EXPECT_EQ(to_char(rna15{}.assign_char('D')), 'D');
-    EXPECT_EQ(to_char(rna15{}.assign_char('H')), 'H');
-    EXPECT_EQ(to_char(rna15{}.assign_char('V')), 'V');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna15{}.assign_char('R')), 'R');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna15{}.assign_char('Y')), 'Y');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna15{}.assign_char('S')), 'S');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna15{}.assign_char('W')), 'W');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna15{}.assign_char('K')), 'K');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna15{}.assign_char('M')), 'M');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna15{}.assign_char('B')), 'B');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna15{}.assign_char('D')), 'D');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna15{}.assign_char('H')), 'H');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna15{}.assign_char('V')), 'V');
 
-    EXPECT_EQ(to_char(rna15{}.assign_char('N')), 'N');
-    EXPECT_EQ(to_char(rna15{}.assign_char('!')), 'N');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna15{}.assign_char('N')), 'N');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna15{}.assign_char('!')), 'N');
 }
 
 TEST(rna15, char_literal)
 {
-    EXPECT_EQ(to_char('A'_rna15), 'A');
-    EXPECT_EQ(to_char('C'_rna15), 'C');
-    EXPECT_EQ(to_char('G'_rna15), 'G');
+    EXPECT_EQ(seqan3::to_char('A'_rna15), 'A');
+    EXPECT_EQ(seqan3::to_char('C'_rna15), 'C');
+    EXPECT_EQ(seqan3::to_char('G'_rna15), 'G');
 
-    EXPECT_EQ(to_char('U'_rna15), 'U');
-    EXPECT_EQ(to_char('T'_rna15), 'U');
+    EXPECT_EQ(seqan3::to_char('U'_rna15), 'U');
+    EXPECT_EQ(seqan3::to_char('T'_rna15), 'U');
 
-    EXPECT_EQ(to_char('R'_rna15), 'R');
-    EXPECT_EQ(to_char('Y'_rna15), 'Y');
-    EXPECT_EQ(to_char('S'_rna15), 'S');
-    EXPECT_EQ(to_char('W'_rna15), 'W');
-    EXPECT_EQ(to_char('K'_rna15), 'K');
-    EXPECT_EQ(to_char('M'_rna15), 'M');
-    EXPECT_EQ(to_char('B'_rna15), 'B');
-    EXPECT_EQ(to_char('D'_rna15), 'D');
-    EXPECT_EQ(to_char('H'_rna15), 'H');
-    EXPECT_EQ(to_char('V'_rna15), 'V');
+    EXPECT_EQ(seqan3::to_char('R'_rna15), 'R');
+    EXPECT_EQ(seqan3::to_char('Y'_rna15), 'Y');
+    EXPECT_EQ(seqan3::to_char('S'_rna15), 'S');
+    EXPECT_EQ(seqan3::to_char('W'_rna15), 'W');
+    EXPECT_EQ(seqan3::to_char('K'_rna15), 'K');
+    EXPECT_EQ(seqan3::to_char('M'_rna15), 'M');
+    EXPECT_EQ(seqan3::to_char('B'_rna15), 'B');
+    EXPECT_EQ(seqan3::to_char('D'_rna15), 'D');
+    EXPECT_EQ(seqan3::to_char('H'_rna15), 'H');
+    EXPECT_EQ(seqan3::to_char('V'_rna15), 'V');
 
-    EXPECT_EQ(to_char('N'_rna15), 'N');
-    EXPECT_EQ(to_char('!'_rna15), 'N');
+    EXPECT_EQ(seqan3::to_char('N'_rna15), 'N');
+    EXPECT_EQ(seqan3::to_char('!'_rna15), 'N');
 }
 
 TEST(rna15, string_literal)
 {
-    rna15_vector v;
+    seqan3::rna15_vector v;
     v.resize(5, 'A'_rna15);
     EXPECT_EQ(v, "AAAAA"_rna15);
 
-    std::vector<rna15> w{'A'_rna15, 'C'_rna15, 'G'_rna15, 'T'_rna15, 'U'_rna15, 'N'_rna15};
+    std::vector<seqan3::rna15> w{'A'_rna15, 'C'_rna15, 'G'_rna15, 'T'_rna15, 'U'_rna15, 'N'_rna15};
     EXPECT_EQ(w, "ACGTTN"_rna15);
 }
 
 TEST(rna15, char_is_valid)
 {
-    constexpr auto validator = is_char<'A'> || is_char<'C'> || is_char<'G'> || is_char<'T'> || is_char<'U'>
-                            || is_char<'a'> || is_char<'c'> || is_char<'g'> || is_char<'t'> || is_char<'u'>
-                            || is_char<'N'> || is_char<'n'>
-                            || is_char<'R'> || is_char<'Y'> || is_char<'S'> || is_char<'W'> || is_char<'K'>
-                            || is_char<'M'> || is_char<'B'> || is_char<'D'> || is_char<'H'> || is_char<'V'>
-                            || is_char<'r'> || is_char<'y'> || is_char<'s'> || is_char<'w'> || is_char<'k'>
-                            || is_char<'m'> || is_char<'b'> || is_char<'d'> || is_char<'h'> || is_char<'v'>;
+    constexpr auto validator = seqan3::is_char<'A'> || seqan3::is_char<'C'> || seqan3::is_char<'G'> ||
+                               seqan3::is_char<'T'> || seqan3::is_char<'U'> ||
+                               seqan3::is_char<'a'> || seqan3::is_char<'c'> || seqan3::is_char<'g'> ||
+                               seqan3::is_char<'t'> || seqan3::is_char<'u'> ||
+                               seqan3::is_char<'N'> || seqan3::is_char<'n'> ||
+                               seqan3::is_char<'R'> || seqan3::is_char<'Y'> || seqan3::is_char<'S'> ||
+                               seqan3::is_char<'W'> || seqan3::is_char<'K'> ||
+                               seqan3::is_char<'M'> || seqan3::is_char<'B'> || seqan3::is_char<'D'> ||
+                               seqan3::is_char<'H'> || seqan3::is_char<'V'> ||
+                               seqan3::is_char<'r'> || seqan3::is_char<'y'> || seqan3::is_char<'s'> ||
+                               seqan3::is_char<'w'> || seqan3::is_char<'k'> ||
+                               seqan3::is_char<'m'> || seqan3::is_char<'b'> || seqan3::is_char<'d'> ||
+                               seqan3::is_char<'h'> || seqan3::is_char<'v'>;
     for (char c : std::views::iota(std::numeric_limits<char>::min(), std::numeric_limits<char>::max()))
-        EXPECT_EQ(rna15::char_is_valid(c), validator(c));
+        EXPECT_EQ(seqan3::rna15::char_is_valid(c), validator(c));
 }

--- a/test/unit/alphabet/nucleotide/rna15_test.cpp
+++ b/test/unit/alphabet/nucleotide/rna15_test.cpp
@@ -80,16 +80,14 @@ TEST(rna15, string_literal)
 TEST(rna15, char_is_valid)
 {
     constexpr auto validator = seqan3::is_char<'A'> || seqan3::is_char<'C'> || seqan3::is_char<'G'> ||
-                               seqan3::is_char<'T'> || seqan3::is_char<'U'> ||
-                               seqan3::is_char<'a'> || seqan3::is_char<'c'> || seqan3::is_char<'g'> ||
-                               seqan3::is_char<'t'> || seqan3::is_char<'u'> ||
-                               seqan3::is_char<'N'> || seqan3::is_char<'n'> ||
+                               seqan3::is_char<'T'> || seqan3::is_char<'U'> || seqan3::is_char<'a'> ||
+                               seqan3::is_char<'c'> || seqan3::is_char<'g'> || seqan3::is_char<'t'> ||
+                               seqan3::is_char<'u'> || seqan3::is_char<'N'> || seqan3::is_char<'n'> ||
                                seqan3::is_char<'R'> || seqan3::is_char<'Y'> || seqan3::is_char<'S'> ||
-                               seqan3::is_char<'W'> || seqan3::is_char<'K'> ||
-                               seqan3::is_char<'M'> || seqan3::is_char<'B'> || seqan3::is_char<'D'> ||
-                               seqan3::is_char<'H'> || seqan3::is_char<'V'> ||
-                               seqan3::is_char<'r'> || seqan3::is_char<'y'> || seqan3::is_char<'s'> ||
-                               seqan3::is_char<'w'> || seqan3::is_char<'k'> ||
+                               seqan3::is_char<'W'> || seqan3::is_char<'K'> || seqan3::is_char<'M'> ||
+                               seqan3::is_char<'B'> || seqan3::is_char<'D'> || seqan3::is_char<'H'> ||
+                               seqan3::is_char<'V'> || seqan3::is_char<'r'> || seqan3::is_char<'y'> ||
+                               seqan3::is_char<'s'> || seqan3::is_char<'w'> || seqan3::is_char<'k'> ||
                                seqan3::is_char<'m'> || seqan3::is_char<'b'> || seqan3::is_char<'d'> ||
                                seqan3::is_char<'h'> || seqan3::is_char<'v'>;
     for (char c : std::views::iota(std::numeric_limits<char>::min(), std::numeric_limits<char>::max()))

--- a/test/unit/alphabet/nucleotide/rna4_test.cpp
+++ b/test/unit/alphabet/nucleotide/rna4_test.cpp
@@ -80,9 +80,9 @@ TEST(rna4, string_literal)
 TEST(rna4, char_is_valid)
 {
     constexpr auto validator = seqan3::is_char<'A'> || seqan3::is_char<'C'> || seqan3::is_char<'G'> ||
-                               seqan3::is_char<'T'> || seqan3::is_char<'U'> ||
-                               seqan3::is_char<'a'> || seqan3::is_char<'c'> || seqan3::is_char<'g'> ||
-                               seqan3::is_char<'t'> || seqan3::is_char<'u'>;
+                               seqan3::is_char<'T'> || seqan3::is_char<'U'> || seqan3::is_char<'a'> ||
+                               seqan3::is_char<'c'> || seqan3::is_char<'g'> || seqan3::is_char<'t'> ||
+                               seqan3::is_char<'u'>;
     for (char c : std::views::iota(std::numeric_limits<char>::min(), std::numeric_limits<char>::max()))
         EXPECT_EQ(seqan3::rna4::char_is_valid(c), validator(c));
 }

--- a/test/unit/alphabet/nucleotide/rna4_test.cpp
+++ b/test/unit/alphabet/nucleotide/rna4_test.cpp
@@ -11,74 +11,78 @@
 #include "../semi_alphabet_test_template.hpp"
 #include "nucleotide_test_template.hpp"
 
-INSTANTIATE_TYPED_TEST_SUITE_P(rna4, alphabet_, rna4, );
-INSTANTIATE_TYPED_TEST_SUITE_P(rna4, semi_alphabet_test, rna4, );
-INSTANTIATE_TYPED_TEST_SUITE_P(rna4, alphabet_constexpr, rna4, );
-INSTANTIATE_TYPED_TEST_SUITE_P(rna4, semi_alphabet_constexpr, rna4, );
-INSTANTIATE_TYPED_TEST_SUITE_P(rna4, nucleotide, rna4, );
+using seqan3::operator""_rna4;
+
+INSTANTIATE_TYPED_TEST_SUITE_P(rna4, alphabet_, seqan3::rna4, );
+INSTANTIATE_TYPED_TEST_SUITE_P(rna4, semi_alphabet_test, seqan3::rna4, );
+INSTANTIATE_TYPED_TEST_SUITE_P(rna4, alphabet_constexpr, seqan3::rna4, );
+INSTANTIATE_TYPED_TEST_SUITE_P(rna4, semi_alphabet_constexpr, seqan3::rna4, );
+INSTANTIATE_TYPED_TEST_SUITE_P(rna4, nucleotide, seqan3::rna4, );
 
 TEST(rna4, to_char_assign_char)
 {
-    EXPECT_EQ(to_char(rna4{}.assign_char('A')), 'A');
-    EXPECT_EQ(to_char(rna4{}.assign_char('C')), 'C');
-    EXPECT_EQ(to_char(rna4{}.assign_char('G')), 'G');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna4{}.assign_char('A')), 'A');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna4{}.assign_char('C')), 'C');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna4{}.assign_char('G')), 'G');
 
-    EXPECT_EQ(to_char(rna4{}.assign_char('U')), 'U');
-    EXPECT_EQ(to_char(rna4{}.assign_char('T')), 'U');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna4{}.assign_char('U')), 'U');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna4{}.assign_char('T')), 'U');
 
-    EXPECT_EQ(to_char(rna4{}.assign_char('R')), 'A');
-    EXPECT_EQ(to_char(rna4{}.assign_char('Y')), 'C');
-    EXPECT_EQ(to_char(rna4{}.assign_char('S')), 'C');
-    EXPECT_EQ(to_char(rna4{}.assign_char('W')), 'A');
-    EXPECT_EQ(to_char(rna4{}.assign_char('K')), 'G');
-    EXPECT_EQ(to_char(rna4{}.assign_char('M')), 'A');
-    EXPECT_EQ(to_char(rna4{}.assign_char('B')), 'C');
-    EXPECT_EQ(to_char(rna4{}.assign_char('D')), 'A');
-    EXPECT_EQ(to_char(rna4{}.assign_char('H')), 'A');
-    EXPECT_EQ(to_char(rna4{}.assign_char('V')), 'A');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna4{}.assign_char('R')), 'A');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna4{}.assign_char('Y')), 'C');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna4{}.assign_char('S')), 'C');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna4{}.assign_char('W')), 'A');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna4{}.assign_char('K')), 'G');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna4{}.assign_char('M')), 'A');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna4{}.assign_char('B')), 'C');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna4{}.assign_char('D')), 'A');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna4{}.assign_char('H')), 'A');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna4{}.assign_char('V')), 'A');
 
-    EXPECT_EQ(to_char(rna4{}.assign_char('N')), 'A');
-    EXPECT_EQ(to_char(rna4{}.assign_char('!')), 'A');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna4{}.assign_char('N')), 'A');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna4{}.assign_char('!')), 'A');
 }
 
 TEST(rna4, char_literal)
 {
-    EXPECT_EQ(to_char('A'_rna4), 'A');
-    EXPECT_EQ(to_char('C'_rna4), 'C');
-    EXPECT_EQ(to_char('G'_rna4), 'G');
+    EXPECT_EQ(seqan3::to_char('A'_rna4), 'A');
+    EXPECT_EQ(seqan3::to_char('C'_rna4), 'C');
+    EXPECT_EQ(seqan3::to_char('G'_rna4), 'G');
 
-    EXPECT_EQ(to_char('U'_rna4), 'U');
-    EXPECT_EQ(to_char('T'_rna4), 'U');
+    EXPECT_EQ(seqan3::to_char('U'_rna4), 'U');
+    EXPECT_EQ(seqan3::to_char('T'_rna4), 'U');
 
-    EXPECT_EQ(to_char('R'_rna4), 'A');
-    EXPECT_EQ(to_char('Y'_rna4), 'C');
-    EXPECT_EQ(to_char('S'_rna4), 'C');
-    EXPECT_EQ(to_char('W'_rna4), 'A');
-    EXPECT_EQ(to_char('K'_rna4), 'G');
-    EXPECT_EQ(to_char('M'_rna4), 'A');
-    EXPECT_EQ(to_char('B'_rna4), 'C');
-    EXPECT_EQ(to_char('D'_rna4), 'A');
-    EXPECT_EQ(to_char('H'_rna4), 'A');
-    EXPECT_EQ(to_char('V'_rna4), 'A');
+    EXPECT_EQ(seqan3::to_char('R'_rna4), 'A');
+    EXPECT_EQ(seqan3::to_char('Y'_rna4), 'C');
+    EXPECT_EQ(seqan3::to_char('S'_rna4), 'C');
+    EXPECT_EQ(seqan3::to_char('W'_rna4), 'A');
+    EXPECT_EQ(seqan3::to_char('K'_rna4), 'G');
+    EXPECT_EQ(seqan3::to_char('M'_rna4), 'A');
+    EXPECT_EQ(seqan3::to_char('B'_rna4), 'C');
+    EXPECT_EQ(seqan3::to_char('D'_rna4), 'A');
+    EXPECT_EQ(seqan3::to_char('H'_rna4), 'A');
+    EXPECT_EQ(seqan3::to_char('V'_rna4), 'A');
 
-    EXPECT_EQ(to_char('N'_rna4), 'A');
-    EXPECT_EQ(to_char('!'_rna4), 'A');
+    EXPECT_EQ(seqan3::to_char('N'_rna4), 'A');
+    EXPECT_EQ(seqan3::to_char('!'_rna4), 'A');
 }
 
 TEST(rna4, string_literal)
 {
-    rna4_vector v;
+    seqan3::rna4_vector v;
     v.resize(5, 'A'_rna4);
     EXPECT_EQ(v, "AAAAA"_rna4);
 
-    std::vector<rna4> w{'A'_rna4, 'C'_rna4, 'G'_rna4, 'T'_rna4, 'U'_rna4, 'N'_rna4};
+    std::vector<seqan3::rna4> w{'A'_rna4, 'C'_rna4, 'G'_rna4, 'T'_rna4, 'U'_rna4, 'N'_rna4};
     EXPECT_EQ(w, "ACGUUA"_rna4);
 }
 
 TEST(rna4, char_is_valid)
 {
-    constexpr auto validator = is_char<'A'> || is_char<'C'> || is_char<'G'> || is_char<'T'> || is_char<'U'>
-                            || is_char<'a'> || is_char<'c'> || is_char<'g'> || is_char<'t'> || is_char<'u'>;
+    constexpr auto validator = seqan3::is_char<'A'> || seqan3::is_char<'C'> || seqan3::is_char<'G'> ||
+                               seqan3::is_char<'T'> || seqan3::is_char<'U'> ||
+                               seqan3::is_char<'a'> || seqan3::is_char<'c'> || seqan3::is_char<'g'> ||
+                               seqan3::is_char<'t'> || seqan3::is_char<'u'>;
     for (char c : std::views::iota(std::numeric_limits<char>::min(), std::numeric_limits<char>::max()))
-        EXPECT_EQ(rna4::char_is_valid(c), validator(c));
+        EXPECT_EQ(seqan3::rna4::char_is_valid(c), validator(c));
 }

--- a/test/unit/alphabet/nucleotide/rna5_test.cpp
+++ b/test/unit/alphabet/nucleotide/rna5_test.cpp
@@ -11,75 +11,79 @@
 #include "../semi_alphabet_test_template.hpp"
 #include "nucleotide_test_template.hpp"
 
-INSTANTIATE_TYPED_TEST_SUITE_P(rna5, alphabet_, rna5, );
-INSTANTIATE_TYPED_TEST_SUITE_P(rna5, semi_alphabet_test, rna5, );
-INSTANTIATE_TYPED_TEST_SUITE_P(rna5, alphabet_constexpr, rna5, );
-INSTANTIATE_TYPED_TEST_SUITE_P(rna5, semi_alphabet_constexpr, rna5, );
-INSTANTIATE_TYPED_TEST_SUITE_P(rna5, nucleotide, rna5, );
+using seqan3::operator""_rna5;
+
+INSTANTIATE_TYPED_TEST_SUITE_P(rna5, alphabet_, seqan3::rna5, );
+INSTANTIATE_TYPED_TEST_SUITE_P(rna5, semi_alphabet_test, seqan3::rna5, );
+INSTANTIATE_TYPED_TEST_SUITE_P(rna5, alphabet_constexpr, seqan3::rna5, );
+INSTANTIATE_TYPED_TEST_SUITE_P(rna5, semi_alphabet_constexpr, seqan3::rna5, );
+INSTANTIATE_TYPED_TEST_SUITE_P(rna5, nucleotide, seqan3::rna5, );
 
 TEST(rna5, to_char_assign_char)
 {
-    EXPECT_EQ(to_char(rna5{}.assign_char('A')), 'A');
-    EXPECT_EQ(to_char(rna5{}.assign_char('C')), 'C');
-    EXPECT_EQ(to_char(rna5{}.assign_char('G')), 'G');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna5{}.assign_char('A')), 'A');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna5{}.assign_char('C')), 'C');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna5{}.assign_char('G')), 'G');
 
-    EXPECT_EQ(to_char(rna5{}.assign_char('U')), 'U');
-    EXPECT_EQ(to_char(rna5{}.assign_char('T')), 'U');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna5{}.assign_char('U')), 'U');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna5{}.assign_char('T')), 'U');
 
-    EXPECT_EQ(to_char(rna5{}.assign_char('R')), 'N');
-    EXPECT_EQ(to_char(rna5{}.assign_char('Y')), 'N');
-    EXPECT_EQ(to_char(rna5{}.assign_char('S')), 'N');
-    EXPECT_EQ(to_char(rna5{}.assign_char('W')), 'N');
-    EXPECT_EQ(to_char(rna5{}.assign_char('K')), 'N');
-    EXPECT_EQ(to_char(rna5{}.assign_char('M')), 'N');
-    EXPECT_EQ(to_char(rna5{}.assign_char('B')), 'N');
-    EXPECT_EQ(to_char(rna5{}.assign_char('D')), 'N');
-    EXPECT_EQ(to_char(rna5{}.assign_char('H')), 'N');
-    EXPECT_EQ(to_char(rna5{}.assign_char('V')), 'N');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna5{}.assign_char('R')), 'N');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna5{}.assign_char('Y')), 'N');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna5{}.assign_char('S')), 'N');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna5{}.assign_char('W')), 'N');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna5{}.assign_char('K')), 'N');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna5{}.assign_char('M')), 'N');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna5{}.assign_char('B')), 'N');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna5{}.assign_char('D')), 'N');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna5{}.assign_char('H')), 'N');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna5{}.assign_char('V')), 'N');
 
-    EXPECT_EQ(to_char(rna5{}.assign_char('N')), 'N');
-    EXPECT_EQ(to_char(rna5{}.assign_char('!')), 'N');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna5{}.assign_char('N')), 'N');
+    EXPECT_EQ(seqan3::to_char(seqan3::rna5{}.assign_char('!')), 'N');
 }
 
 TEST(rna5, char_literal)
 {
-    EXPECT_EQ(to_char('A'_rna5), 'A');
-    EXPECT_EQ(to_char('C'_rna5), 'C');
-    EXPECT_EQ(to_char('G'_rna5), 'G');
+    EXPECT_EQ(seqan3::to_char('A'_rna5), 'A');
+    EXPECT_EQ(seqan3::to_char('C'_rna5), 'C');
+    EXPECT_EQ(seqan3::to_char('G'_rna5), 'G');
 
-    EXPECT_EQ(to_char('U'_rna5), 'U');
-    EXPECT_EQ(to_char('T'_rna5), 'U');
+    EXPECT_EQ(seqan3::to_char('U'_rna5), 'U');
+    EXPECT_EQ(seqan3::to_char('T'_rna5), 'U');
 
-    EXPECT_EQ(to_char('R'_rna5), 'N');
-    EXPECT_EQ(to_char('Y'_rna5), 'N');
-    EXPECT_EQ(to_char('S'_rna5), 'N');
-    EXPECT_EQ(to_char('W'_rna5), 'N');
-    EXPECT_EQ(to_char('K'_rna5), 'N');
-    EXPECT_EQ(to_char('M'_rna5), 'N');
-    EXPECT_EQ(to_char('B'_rna5), 'N');
-    EXPECT_EQ(to_char('D'_rna5), 'N');
-    EXPECT_EQ(to_char('H'_rna5), 'N');
-    EXPECT_EQ(to_char('V'_rna5), 'N');
+    EXPECT_EQ(seqan3::to_char('R'_rna5), 'N');
+    EXPECT_EQ(seqan3::to_char('Y'_rna5), 'N');
+    EXPECT_EQ(seqan3::to_char('S'_rna5), 'N');
+    EXPECT_EQ(seqan3::to_char('W'_rna5), 'N');
+    EXPECT_EQ(seqan3::to_char('K'_rna5), 'N');
+    EXPECT_EQ(seqan3::to_char('M'_rna5), 'N');
+    EXPECT_EQ(seqan3::to_char('B'_rna5), 'N');
+    EXPECT_EQ(seqan3::to_char('D'_rna5), 'N');
+    EXPECT_EQ(seqan3::to_char('H'_rna5), 'N');
+    EXPECT_EQ(seqan3::to_char('V'_rna5), 'N');
 
-    EXPECT_EQ(to_char('N'_rna5), 'N');
-    EXPECT_EQ(to_char('!'_rna5), 'N');
+    EXPECT_EQ(seqan3::to_char('N'_rna5), 'N');
+    EXPECT_EQ(seqan3::to_char('!'_rna5), 'N');
 }
 
 TEST(rna5, string_literal)
 {
-    rna5_vector v;
+    seqan3::rna5_vector v;
     v.resize(5, 'A'_rna5);
     EXPECT_EQ(v, "AAAAA"_rna5);
 
-    std::vector<rna5> w{'A'_rna5, 'C'_rna5, 'G'_rna5, 'T'_rna5, 'U'_rna5, 'N'_rna5};
+    std::vector<seqan3::rna5> w{'A'_rna5, 'C'_rna5, 'G'_rna5, 'T'_rna5, 'U'_rna5, 'N'_rna5};
     EXPECT_EQ(w, "ACGUUN"_rna5);
 }
 
 TEST(rna5, char_is_valid)
 {
-    constexpr auto validator = is_char<'A'> || is_char<'C'> || is_char<'G'> || is_char<'T'> || is_char<'U'>
-                            || is_char<'a'> || is_char<'c'> || is_char<'g'> || is_char<'t'> || is_char<'u'>
-                            || is_char<'N'> || is_char<'n'>;
+    constexpr auto validator = seqan3::is_char<'A'> || seqan3::is_char<'C'> || seqan3::is_char<'G'> ||
+                               seqan3::is_char<'T'> || seqan3::is_char<'U'> ||
+                               seqan3::is_char<'a'> || seqan3::is_char<'c'> || seqan3::is_char<'g'> ||
+                               seqan3::is_char<'t'> || seqan3::is_char<'u'> ||
+                               seqan3::is_char<'N'> || seqan3::is_char<'n'>;
     for (char c : std::views::iota(std::numeric_limits<char>::min(), std::numeric_limits<char>::max()))
-        EXPECT_EQ(rna5::char_is_valid(c), validator(c));
+        EXPECT_EQ(seqan3::rna5::char_is_valid(c), validator(c));
 }

--- a/test/unit/alphabet/nucleotide/rna5_test.cpp
+++ b/test/unit/alphabet/nucleotide/rna5_test.cpp
@@ -80,10 +80,9 @@ TEST(rna5, string_literal)
 TEST(rna5, char_is_valid)
 {
     constexpr auto validator = seqan3::is_char<'A'> || seqan3::is_char<'C'> || seqan3::is_char<'G'> ||
-                               seqan3::is_char<'T'> || seqan3::is_char<'U'> ||
-                               seqan3::is_char<'a'> || seqan3::is_char<'c'> || seqan3::is_char<'g'> ||
-                               seqan3::is_char<'t'> || seqan3::is_char<'u'> ||
-                               seqan3::is_char<'N'> || seqan3::is_char<'n'>;
+                               seqan3::is_char<'T'> || seqan3::is_char<'U'> || seqan3::is_char<'a'> ||
+                               seqan3::is_char<'c'> || seqan3::is_char<'g'> || seqan3::is_char<'t'> ||
+                               seqan3::is_char<'u'> || seqan3::is_char<'N'> || seqan3::is_char<'n'>;
     for (char c : std::views::iota(std::numeric_limits<char>::min(), std::numeric_limits<char>::max()))
         EXPECT_EQ(seqan3::rna5::char_is_valid(c), validator(c));
 }

--- a/test/unit/alphabet/nucleotide/sam_dna16_test.cpp
+++ b/test/unit/alphabet/nucleotide/sam_dna16_test.cpp
@@ -111,19 +111,16 @@ TEST(sam_dna16, string_literal)
 TEST(sam_dna16, char_is_valid)
 {
     constexpr auto validator = seqan3::is_char<'A'> || seqan3::is_char<'C'> || seqan3::is_char<'G'> ||
-                               seqan3::is_char<'T'> || seqan3::is_char<'U'> ||
-                               seqan3::is_char<'a'> || seqan3::is_char<'c'> || seqan3::is_char<'g'> ||
-                               seqan3::is_char<'t'> || seqan3::is_char<'u'> ||
-                               seqan3::is_char<'N'> || seqan3::is_char<'n'> ||
+                               seqan3::is_char<'T'> || seqan3::is_char<'U'> || seqan3::is_char<'a'> ||
+                               seqan3::is_char<'c'> || seqan3::is_char<'g'> || seqan3::is_char<'t'> ||
+                               seqan3::is_char<'u'> || seqan3::is_char<'N'> || seqan3::is_char<'n'> ||
                                seqan3::is_char<'R'> || seqan3::is_char<'Y'> || seqan3::is_char<'S'> ||
-                               seqan3::is_char<'W'> || seqan3::is_char<'K'> ||
-                               seqan3::is_char<'M'> || seqan3::is_char<'B'> || seqan3::is_char<'D'> ||
-                               seqan3::is_char<'H'> || seqan3::is_char<'V'> ||
-                               seqan3::is_char<'r'> || seqan3::is_char<'y'> || seqan3::is_char<'s'> ||
-                               seqan3::is_char<'w'> || seqan3::is_char<'k'> ||
+                               seqan3::is_char<'W'> || seqan3::is_char<'K'> || seqan3::is_char<'M'> ||
+                               seqan3::is_char<'B'> || seqan3::is_char<'D'> || seqan3::is_char<'H'> ||
+                               seqan3::is_char<'V'> || seqan3::is_char<'r'> || seqan3::is_char<'y'> ||
+                               seqan3::is_char<'s'> || seqan3::is_char<'w'> || seqan3::is_char<'k'> ||
                                seqan3::is_char<'m'> || seqan3::is_char<'b'> || seqan3::is_char<'d'> ||
-                               seqan3::is_char<'h'> || seqan3::is_char<'v'> ||
-                               seqan3::is_char<'='>;
+                               seqan3::is_char<'h'> || seqan3::is_char<'v'> || seqan3::is_char<'='>;
 
     for (char c : std::views::iota(std::numeric_limits<char>::min(), std::numeric_limits<char>::max()))
         EXPECT_EQ(seqan3::sam_dna16::char_is_valid(c), validator(c));

--- a/test/unit/alphabet/nucleotide/sam_dna16_test.cpp
+++ b/test/unit/alphabet/nucleotide/sam_dna16_test.cpp
@@ -14,106 +14,117 @@
 #include "../semi_alphabet_constexpr_test_template.hpp"
 #include "../semi_alphabet_test_template.hpp"
 
-using namespace seqan3;
+using seqan3::operator""_sam_dna16;
 
 // ------------------------------------------------------------------
 // sam_dna16 alphabet
 // ------------------------------------------------------------------
 
-INSTANTIATE_TYPED_TEST_SUITE_P(sam_dna16, alphabet_, sam_dna16, );
-INSTANTIATE_TYPED_TEST_SUITE_P(sam_dna16, semi_alphabet_test, sam_dna16, );
-INSTANTIATE_TYPED_TEST_SUITE_P(sam_dna16, alphabet_constexpr, sam_dna16, );
-INSTANTIATE_TYPED_TEST_SUITE_P(sam_dna16, semi_alphabet_constexpr, sam_dna16, );
+INSTANTIATE_TYPED_TEST_SUITE_P(sam_dna16, alphabet_, seqan3::sam_dna16, );
+INSTANTIATE_TYPED_TEST_SUITE_P(sam_dna16, semi_alphabet_test, seqan3::sam_dna16, );
+INSTANTIATE_TYPED_TEST_SUITE_P(sam_dna16, alphabet_constexpr, seqan3::sam_dna16, );
+INSTANTIATE_TYPED_TEST_SUITE_P(sam_dna16, semi_alphabet_constexpr, seqan3::sam_dna16, );
 
 // nucleotide test: (because the complement is not bijective for sam_dna16 we need to test it manually)
 TEST(sam_dna16, nucleotide)
 {
-    EXPECT_TRUE(nucleotide_alphabet<sam_dna16>);
-    EXPECT_TRUE(nucleotide_alphabet<sam_dna16 &>);
+    EXPECT_TRUE(seqan3::nucleotide_alphabet<seqan3::sam_dna16>);
+    EXPECT_TRUE(seqan3::nucleotide_alphabet<seqan3::sam_dna16 &>);
 
-    EXPECT_EQ(complement('='_sam_dna16), 'N'_sam_dna16);
-    EXPECT_EQ(complement('A'_sam_dna16), 'T'_sam_dna16);
-    EXPECT_EQ(complement('C'_sam_dna16), 'G'_sam_dna16);
-    EXPECT_EQ(complement('M'_sam_dna16), 'K'_sam_dna16);
-    EXPECT_EQ(complement('G'_sam_dna16), 'C'_sam_dna16);
-    EXPECT_EQ(complement('R'_sam_dna16), 'Y'_sam_dna16);
-    EXPECT_EQ(complement('S'_sam_dna16), 'S'_sam_dna16);
-    EXPECT_EQ(complement('V'_sam_dna16), 'B'_sam_dna16);
-    EXPECT_EQ(complement('T'_sam_dna16), 'A'_sam_dna16);
-    EXPECT_EQ(complement('W'_sam_dna16), 'W'_sam_dna16);
-    EXPECT_EQ(complement('Y'_sam_dna16), 'R'_sam_dna16);
-    EXPECT_EQ(complement('H'_sam_dna16), 'D'_sam_dna16);
-    EXPECT_EQ(complement('K'_sam_dna16), 'M'_sam_dna16);
-    EXPECT_EQ(complement('D'_sam_dna16), 'H'_sam_dna16);
-    EXPECT_EQ(complement('B'_sam_dna16), 'V'_sam_dna16);
-    EXPECT_EQ(complement('N'_sam_dna16), 'N'_sam_dna16);
+    EXPECT_EQ(seqan3::complement('='_sam_dna16), 'N'_sam_dna16);
+    EXPECT_EQ(seqan3::complement('A'_sam_dna16), 'T'_sam_dna16);
+    EXPECT_EQ(seqan3::complement('C'_sam_dna16), 'G'_sam_dna16);
+    EXPECT_EQ(seqan3::complement('M'_sam_dna16), 'K'_sam_dna16);
+    EXPECT_EQ(seqan3::complement('G'_sam_dna16), 'C'_sam_dna16);
+    EXPECT_EQ(seqan3::complement('R'_sam_dna16), 'Y'_sam_dna16);
+    EXPECT_EQ(seqan3::complement('S'_sam_dna16), 'S'_sam_dna16);
+    EXPECT_EQ(seqan3::complement('V'_sam_dna16), 'B'_sam_dna16);
+    EXPECT_EQ(seqan3::complement('T'_sam_dna16), 'A'_sam_dna16);
+    EXPECT_EQ(seqan3::complement('W'_sam_dna16), 'W'_sam_dna16);
+    EXPECT_EQ(seqan3::complement('Y'_sam_dna16), 'R'_sam_dna16);
+    EXPECT_EQ(seqan3::complement('H'_sam_dna16), 'D'_sam_dna16);
+    EXPECT_EQ(seqan3::complement('K'_sam_dna16), 'M'_sam_dna16);
+    EXPECT_EQ(seqan3::complement('D'_sam_dna16), 'H'_sam_dna16);
+    EXPECT_EQ(seqan3::complement('B'_sam_dna16), 'V'_sam_dna16);
+    EXPECT_EQ(seqan3::complement('N'_sam_dna16), 'N'_sam_dna16);
 }
 
 TEST(sam_dna16, to_char_assign_char)
 {
-    using rank_t = alphabet_rank_t<sam_dna16>;
-    for (rank_t rank = 0; rank < alphabet_size<sam_dna16>; ++rank)
+    using rank_t = seqan3::alphabet_rank_t<seqan3::sam_dna16>;
+    for (rank_t rank = 0; rank < seqan3::alphabet_size<seqan3::sam_dna16>; ++rank)
     {
-        char chr = to_char(assign_rank_to(rank, sam_dna16{}));
-        EXPECT_EQ(to_char(sam_dna16{}.assign_char(chr)), chr);
+        char chr = seqan3::to_char(seqan3::assign_rank_to(rank, seqan3::sam_dna16{}));
+        EXPECT_EQ(seqan3::to_char(seqan3::sam_dna16{}.assign_char(chr)), chr);
     }
 
-    EXPECT_EQ(to_char(sam_dna16{}.assign_char('a')), 'A');
-    EXPECT_EQ(to_char(sam_dna16{}.assign_char('c')), 'C');
-    EXPECT_EQ(to_char(sam_dna16{}.assign_char('g')), 'G');
-    EXPECT_EQ(to_char(sam_dna16{}.assign_char('t')), 'T');
+    EXPECT_EQ(seqan3::to_char(seqan3::sam_dna16{}.assign_char('a')), 'A');
+    EXPECT_EQ(seqan3::to_char(seqan3::sam_dna16{}.assign_char('c')), 'C');
+    EXPECT_EQ(seqan3::to_char(seqan3::sam_dna16{}.assign_char('g')), 'G');
+    EXPECT_EQ(seqan3::to_char(seqan3::sam_dna16{}.assign_char('t')), 'T');
 
-    EXPECT_EQ(to_char(sam_dna16{}.assign_char('U')), 'T');
-    EXPECT_EQ(to_char(sam_dna16{}.assign_char('!')), 'N');
+    EXPECT_EQ(seqan3::to_char(seqan3::sam_dna16{}.assign_char('U')), 'T');
+    EXPECT_EQ(seqan3::to_char(seqan3::sam_dna16{}.assign_char('!')), 'N');
 }
 
 TEST(sam_dna16, char_literal)
 {
-    EXPECT_EQ(to_char('A'_sam_dna16), 'A');
-    EXPECT_EQ(to_char('C'_sam_dna16), 'C');
-    EXPECT_EQ(to_char('G'_sam_dna16), 'G');
+    EXPECT_EQ(seqan3::to_char('A'_sam_dna16), 'A');
+    EXPECT_EQ(seqan3::to_char('C'_sam_dna16), 'C');
+    EXPECT_EQ(seqan3::to_char('G'_sam_dna16), 'G');
 
-    EXPECT_EQ(to_char('U'_sam_dna16), 'T');
-    EXPECT_EQ(to_char('T'_sam_dna16), 'T');
+    EXPECT_EQ(seqan3::to_char('U'_sam_dna16), 'T');
+    EXPECT_EQ(seqan3::to_char('T'_sam_dna16), 'T');
 
-    EXPECT_EQ(to_char('R'_sam_dna16), 'R');
-    EXPECT_EQ(to_char('Y'_sam_dna16), 'Y');
-    EXPECT_EQ(to_char('S'_sam_dna16), 'S');
-    EXPECT_EQ(to_char('W'_sam_dna16), 'W');
-    EXPECT_EQ(to_char('K'_sam_dna16), 'K');
-    EXPECT_EQ(to_char('M'_sam_dna16), 'M');
-    EXPECT_EQ(to_char('B'_sam_dna16), 'B');
-    EXPECT_EQ(to_char('D'_sam_dna16), 'D');
-    EXPECT_EQ(to_char('H'_sam_dna16), 'H');
-    EXPECT_EQ(to_char('V'_sam_dna16), 'V');
+    EXPECT_EQ(seqan3::to_char('R'_sam_dna16), 'R');
+    EXPECT_EQ(seqan3::to_char('Y'_sam_dna16), 'Y');
+    EXPECT_EQ(seqan3::to_char('S'_sam_dna16), 'S');
+    EXPECT_EQ(seqan3::to_char('W'_sam_dna16), 'W');
+    EXPECT_EQ(seqan3::to_char('K'_sam_dna16), 'K');
+    EXPECT_EQ(seqan3::to_char('M'_sam_dna16), 'M');
+    EXPECT_EQ(seqan3::to_char('B'_sam_dna16), 'B');
+    EXPECT_EQ(seqan3::to_char('D'_sam_dna16), 'D');
+    EXPECT_EQ(seqan3::to_char('H'_sam_dna16), 'H');
+    EXPECT_EQ(seqan3::to_char('V'_sam_dna16), 'V');
 
-    EXPECT_EQ(to_char('='_sam_dna16), '=');
+    EXPECT_EQ(seqan3::to_char('='_sam_dna16), '=');
 
-    EXPECT_EQ(to_char('N'_sam_dna16), 'N');
-    EXPECT_EQ(to_char('!'_sam_dna16), 'N');
+    EXPECT_EQ(seqan3::to_char('N'_sam_dna16), 'N');
+    EXPECT_EQ(seqan3::to_char('!'_sam_dna16), 'N');
 }
 
 TEST(sam_dna16, string_literal)
 {
-    sam_dna16_vector v;
+    seqan3::sam_dna16_vector v;
     v.resize(5, 'A'_sam_dna16);
     EXPECT_EQ(v, "AAAAA"_sam_dna16);
 
-    std::vector<sam_dna16> w{'A'_sam_dna16, '='_sam_dna16, 'G'_sam_dna16, 'T'_sam_dna16, 'U'_sam_dna16, 'N'_sam_dna16};
+    std::vector<seqan3::sam_dna16> w{'A'_sam_dna16,
+                                     '='_sam_dna16,
+                                     'G'_sam_dna16,
+                                     'T'_sam_dna16,
+                                     'U'_sam_dna16,
+                                     'N'_sam_dna16};
     EXPECT_EQ(w, "A=GTTN"_sam_dna16);
 }
 
 TEST(sam_dna16, char_is_valid)
 {
-    constexpr auto validator = is_char<'A'> || is_char<'C'> || is_char<'G'> || is_char<'T'> || is_char<'U'> ||
-                               is_char<'a'> || is_char<'c'> || is_char<'g'> || is_char<'t'> || is_char<'u'> ||
-                               is_char<'N'> || is_char<'n'> ||
-                               is_char<'R'> || is_char<'Y'> || is_char<'S'> || is_char<'W'> || is_char<'K'> ||
-                               is_char<'M'> || is_char<'B'> || is_char<'D'> || is_char<'H'> || is_char<'V'> ||
-                               is_char<'r'> || is_char<'y'> || is_char<'s'> || is_char<'w'> || is_char<'k'> ||
-                               is_char<'m'> || is_char<'b'> || is_char<'d'> || is_char<'h'> || is_char<'v'> ||
-                               is_char<'='>;
+    constexpr auto validator = seqan3::is_char<'A'> || seqan3::is_char<'C'> || seqan3::is_char<'G'> ||
+                               seqan3::is_char<'T'> || seqan3::is_char<'U'> ||
+                               seqan3::is_char<'a'> || seqan3::is_char<'c'> || seqan3::is_char<'g'> ||
+                               seqan3::is_char<'t'> || seqan3::is_char<'u'> ||
+                               seqan3::is_char<'N'> || seqan3::is_char<'n'> ||
+                               seqan3::is_char<'R'> || seqan3::is_char<'Y'> || seqan3::is_char<'S'> ||
+                               seqan3::is_char<'W'> || seqan3::is_char<'K'> ||
+                               seqan3::is_char<'M'> || seqan3::is_char<'B'> || seqan3::is_char<'D'> ||
+                               seqan3::is_char<'H'> || seqan3::is_char<'V'> ||
+                               seqan3::is_char<'r'> || seqan3::is_char<'y'> || seqan3::is_char<'s'> ||
+                               seqan3::is_char<'w'> || seqan3::is_char<'k'> ||
+                               seqan3::is_char<'m'> || seqan3::is_char<'b'> || seqan3::is_char<'d'> ||
+                               seqan3::is_char<'h'> || seqan3::is_char<'v'> ||
+                               seqan3::is_char<'='>;
 
     for (char c : std::views::iota(std::numeric_limits<char>::min(), std::numeric_limits<char>::max()))
-        EXPECT_EQ(sam_dna16::char_is_valid(c), validator(c));
+        EXPECT_EQ(seqan3::sam_dna16::char_is_valid(c), validator(c));
 }

--- a/test/unit/alphabet/structure/dot_bracket3_test.cpp
+++ b/test/unit/alphabet/structure/dot_bracket3_test.cpp
@@ -14,22 +14,22 @@
 #include "../semi_alphabet_constexpr_test_template.hpp"
 #include "../semi_alphabet_test_template.hpp"
 
+using seqan3::operator""_db3;
+
 INSTANTIATE_TYPED_TEST_SUITE_P(dot_bracket3, alphabet_, seqan3::dot_bracket3, );
 INSTANTIATE_TYPED_TEST_SUITE_P(dot_bracket3, semi_alphabet_test, seqan3::dot_bracket3, );
 INSTANTIATE_TYPED_TEST_SUITE_P(dot_bracket3, alphabet_constexpr, seqan3::dot_bracket3, );
 INSTANTIATE_TYPED_TEST_SUITE_P(dot_bracket3, semi_alphabet_constexpr, seqan3::dot_bracket3, );
 
-using namespace seqan3;
-
 // concepts
 TEST(dot_bracket3, concept_check)
 {
-    EXPECT_TRUE(rna_structure_alphabet<dot_bracket3>);
-    EXPECT_TRUE(rna_structure_alphabet<dot_bracket3 &>);
-    EXPECT_TRUE(rna_structure_alphabet<dot_bracket3 const>);
-    EXPECT_TRUE(rna_structure_alphabet<dot_bracket3 const &>);
+    EXPECT_TRUE(seqan3::rna_structure_alphabet<seqan3::dot_bracket3>);
+    EXPECT_TRUE(seqan3::rna_structure_alphabet<seqan3::dot_bracket3 &>);
+    EXPECT_TRUE(seqan3::rna_structure_alphabet<seqan3::dot_bracket3 const>);
+    EXPECT_TRUE(seqan3::rna_structure_alphabet<seqan3::dot_bracket3 const &>);
 
-    EXPECT_NE(max_pseudoknot_depth<dot_bracket3>, 0);
+    EXPECT_NE(seqan3::max_pseudoknot_depth<seqan3::dot_bracket3>, 0);
 }
 
 // assign_char functions
@@ -43,7 +43,7 @@ TEST(dot_bracket3, assign_char)
         'H', 'B', 'E', 'G', 'I', 'T', 'S'
     };
 
-    std::vector<dot_bracket3> cmp
+    std::vector<seqan3::dot_bracket3> cmp
     {
         '.'_db3, '('_db3, ')'_db3,
         '.'_db3, '.'_db3, '.'_db3, '.'_db3, '.'_db3, '.'_db3,
@@ -51,31 +51,31 @@ TEST(dot_bracket3, assign_char)
         '.'_db3, '.'_db3, '.'_db3, '.'_db3, '.'_db3, '.'_db3, '.'_db3
     };
 
-    for (auto [ ch, cm ] : views::zip(input, cmp))
-        EXPECT_EQ((assign_char_to(ch, dot_bracket3{})), cm);
+    for (auto [ ch, cm ] : seqan3::views::zip(input, cmp))
+        EXPECT_EQ((seqan3::assign_char_to(ch, seqan3::dot_bracket3{})), cm);
 }
 
 // to_char functions
 TEST(dot_bracket3, to_char)
 {
-    EXPECT_EQ(to_char('.'_db3), '.');
-    EXPECT_EQ(to_char('('_db3), '(');
-    EXPECT_EQ(to_char(')'_db3), ')');
+    EXPECT_EQ(seqan3::to_char('.'_db3), '.');
+    EXPECT_EQ(seqan3::to_char('('_db3), '(');
+    EXPECT_EQ(seqan3::to_char(')'_db3), ')');
 }
 
 TEST(dot_bracket3, literals)
 {
-    std::vector<dot_bracket3> vec1;
+    std::vector<seqan3::dot_bracket3> vec1;
     vec1.resize(5, '('_db3);
     EXPECT_EQ(vec1, "((((("_db3);
 
-    std::vector<dot_bracket3> vec2{'.'_db3, '('_db3, '('_db3, ')'_db3, ')'_db3, '.'_db3};
+    std::vector<seqan3::dot_bracket3> vec2{'.'_db3, '('_db3, '('_db3, ')'_db3, ')'_db3, '.'_db3};
     EXPECT_EQ(vec2, ".(())."_db3);
 }
 
 TEST(dot_bracket3, rna_structure_properties)
 {
-    EXPECT_EQ(dot_bracket3::max_pseudoknot_depth, 1);
+    EXPECT_EQ(seqan3::dot_bracket3::max_pseudoknot_depth, 1);
     EXPECT_TRUE('.'_db3.is_unpaired());
     EXPECT_TRUE('('_db3.is_pair_open());
     EXPECT_TRUE(')'_db3.is_pair_close());

--- a/test/unit/alphabet/structure/dssp9_test.cpp
+++ b/test/unit/alphabet/structure/dssp9_test.cpp
@@ -13,12 +13,12 @@
 #include "../semi_alphabet_constexpr_test_template.hpp"
 #include "../semi_alphabet_test_template.hpp"
 
+using seqan3::operator""_dssp9;
+
 INSTANTIATE_TYPED_TEST_SUITE_P(dssp9, alphabet_, seqan3::dssp9, );
 INSTANTIATE_TYPED_TEST_SUITE_P(dssp9, semi_alphabet_test, seqan3::dssp9, );
 INSTANTIATE_TYPED_TEST_SUITE_P(dssp9, alphabet_constexpr, seqan3::dssp9, );
 INSTANTIATE_TYPED_TEST_SUITE_P(dssp9, semi_alphabet_constexpr, seqan3::dssp9, );
-
-using namespace seqan3;
 
 // assign_char functions
 TEST(dssp9, assign_char)
@@ -31,7 +31,7 @@ TEST(dssp9, assign_char)
         'H', 'B', 'E', 'G', 'I', 'T', 'S'
     };
 
-    std::vector<dssp9> cmp
+    std::vector<seqan3::dssp9> cmp
     {
         'X'_dssp9, 'X'_dssp9, 'X'_dssp9,
         'X'_dssp9, 'X'_dssp9, 'X'_dssp9, 'X'_dssp9, 'X'_dssp9, 'X'_dssp9,
@@ -39,31 +39,31 @@ TEST(dssp9, assign_char)
         'H'_dssp9, 'B'_dssp9, 'E'_dssp9, 'G'_dssp9, 'I'_dssp9, 'T'_dssp9, 'S'_dssp9
     };
 
-    for (auto [ ch, cm ] : views::zip(input, cmp))
-        EXPECT_EQ((assign_char_to(ch, dssp9{})), cm);
+    for (auto [ ch, cm ] : seqan3::views::zip(input, cmp))
+        EXPECT_EQ((seqan3::assign_char_to(ch, seqan3::dssp9{})), cm);
 }
 
 // to_char functions
 TEST(dssp9, to_char)
 {
-    EXPECT_EQ(to_char('H'_dssp9), 'H');
-    EXPECT_EQ(to_char('B'_dssp9), 'B');
-    EXPECT_EQ(to_char('E'_dssp9), 'E');
-    EXPECT_EQ(to_char('G'_dssp9), 'G');
-    EXPECT_EQ(to_char('I'_dssp9), 'I');
-    EXPECT_EQ(to_char('T'_dssp9), 'T');
-    EXPECT_EQ(to_char('S'_dssp9), 'S');
-    EXPECT_EQ(to_char('C'_dssp9), 'C');
-    EXPECT_EQ(to_char('X'_dssp9), 'X');
+    EXPECT_EQ(seqan3::to_char('H'_dssp9), 'H');
+    EXPECT_EQ(seqan3::to_char('B'_dssp9), 'B');
+    EXPECT_EQ(seqan3::to_char('E'_dssp9), 'E');
+    EXPECT_EQ(seqan3::to_char('G'_dssp9), 'G');
+    EXPECT_EQ(seqan3::to_char('I'_dssp9), 'I');
+    EXPECT_EQ(seqan3::to_char('T'_dssp9), 'T');
+    EXPECT_EQ(seqan3::to_char('S'_dssp9), 'S');
+    EXPECT_EQ(seqan3::to_char('C'_dssp9), 'C');
+    EXPECT_EQ(seqan3::to_char('X'_dssp9), 'X');
 }
 
 TEST(dssp9, literals)
 {
 
-    std::vector<dssp9> vec1;
+    std::vector<seqan3::dssp9> vec1;
     vec1.resize(5, 'H'_dssp9);
     EXPECT_EQ(vec1, "HHHHH"_dssp9);
 
-    std::vector<dssp9> vec2{'E'_dssp9, 'H'_dssp9, 'H'_dssp9, 'H'_dssp9, 'T'_dssp9, 'G'_dssp9};
+    std::vector<seqan3::dssp9> vec2{'E'_dssp9, 'H'_dssp9, 'H'_dssp9, 'H'_dssp9, 'T'_dssp9, 'G'_dssp9};
     EXPECT_EQ(vec2, "EHHHTG"_dssp9);
 }

--- a/test/unit/alphabet/structure/structured_aa_test.cpp
+++ b/test/unit/alphabet/structure/structured_aa_test.cpp
@@ -18,33 +18,34 @@
 #include "../semi_alphabet_test_template.hpp"
 #include "../composite/alphabet_tuple_base_test_template.hpp"
 
-using namespace seqan3;
+using seqan3::operator""_aa27;
+using seqan3::operator""_dssp9;
 
 template <>
-class alphabet_tuple_base_test<structured_aa<aa27, dssp9>>: public ::testing::Test
+class alphabet_tuple_base_test<seqan3::structured_aa<seqan3::aa27, seqan3::dssp9>>: public ::testing::Test
 {
 public:
-    using T = structured_aa<aa27, dssp9>;
+    using T = seqan3::structured_aa<seqan3::aa27, seqan3::dssp9>;
 
     T instance = T{value_1(), value_2()};
     T zero_instance = T{decltype(value_1()){}, decltype(value_2()){}};
     size_t tup_size{2};
 
-    // structured_aa<aa27, dssp9>
+    // seqan3::structured_aa<seqan3::aa27, seqan3::dssp9>
     // -------------------------------------------------------------------------
-    aa27 value_1()
+    seqan3::aa27 value_1()
     {
         return 'K'_aa27;
     }
-    aa27 assignable_to_value_1()
+    seqan3::aa27 assignable_to_value_1()
     {
         return 'K'_aa27; // replace if assignable subtype becomes available
     }
-    dssp9 value_2()
+    seqan3::dssp9 value_2()
     {
         return 'I'_dssp9;
     }
-    dssp9 assignable_to_value_2()
+    seqan3::dssp9 assignable_to_value_2()
     {
         return 'I'_dssp9; // replace if assignable subtype becomes available
     }
@@ -56,7 +57,7 @@ public:
     }
 };
 
-using structured_aa_types = ::testing::Types<structured_aa<aa27, dssp9>>;
+using structured_aa_types = ::testing::Types<seqan3::structured_aa<seqan3::aa27, seqan3::dssp9>>;
 
 INSTANTIATE_TYPED_TEST_SUITE_P(structured_aa, alphabet_, structured_aa_types, );
 INSTANTIATE_TYPED_TEST_SUITE_P(structured_aa, semi_alphabet_test, structured_aa_types, );

--- a/test/unit/alphabet/structure/structured_rna_test.cpp
+++ b/test/unit/alphabet/structure/structured_rna_test.cpp
@@ -20,21 +20,19 @@
 #include "../semi_alphabet_test_template.hpp"
 #include "../composite/alphabet_tuple_base_test_template.hpp"
 
-using namespace seqan3;
-
 template <typename rna_type, typename structure_type>
-class alphabet_tuple_base_test<structured_rna<rna_type, structure_type>> : public ::testing::Test
+class alphabet_tuple_base_test<seqan3::structured_rna<rna_type, structure_type>> : public ::testing::Test
 {
 public:
-    using T = structured_rna<rna_type, structure_type>;
+    using T = seqan3::structured_rna<rna_type, structure_type>;
 
-    using dna_type = std::conditional_t<std::is_same_v<rna_type, rna4>, dna4, dna5>;
+    using dna_type = std::conditional_t<std::is_same_v<rna_type, seqan3::rna4>, seqan3::dna4, seqan3::dna5>;
 
     T instance = T{value_1(), value_2()};
     T zero_instance = T{decltype(value_1()){}, decltype(value_2()){}};
     size_t tup_size{2};
 
-    // structured_rna<rna_type, structure_type>
+    // seqan3::structured_rna<rna_type, structure_type>
     // -------------------------------------------------------------------------
     rna_type value_1()
     {
@@ -60,7 +58,8 @@ public:
     }
 };
 
-using structured_rna_types = ::testing::Types<structured_rna<rna5, dot_bracket3>, structured_rna<rna4, wuss51>>;
+using structured_rna_types = ::testing::Types<seqan3::structured_rna<seqan3::rna5, seqan3::dot_bracket3>,
+                                              seqan3::structured_rna<seqan3::rna4, seqan3::wuss51>>;
 
 INSTANTIATE_TYPED_TEST_SUITE_P(structured_rna, alphabet_, structured_rna_types, );
 INSTANTIATE_TYPED_TEST_SUITE_P(structured_rna, semi_alphabet_test, structured_rna_types, );

--- a/test/unit/alphabet/structure/wuss_test.cpp
+++ b/test/unit/alphabet/structure/wuss_test.cpp
@@ -14,20 +14,20 @@
 #include "../semi_alphabet_constexpr_test_template.hpp"
 #include "../semi_alphabet_test_template.hpp"
 
-using namespace seqan3;
+using seqan3::operator""_wuss51;
 
-INSTANTIATE_TYPED_TEST_SUITE_P(wuss51, alphabet_, wuss51, );
-INSTANTIATE_TYPED_TEST_SUITE_P(wuss51, semi_alphabet_test, wuss51, );
-INSTANTIATE_TYPED_TEST_SUITE_P(wuss51, alphabet_constexpr, wuss51, );
-INSTANTIATE_TYPED_TEST_SUITE_P(wuss51, semi_alphabet_constexpr, wuss51, );
-INSTANTIATE_TYPED_TEST_SUITE_P(wuss15, alphabet_, wuss<15>, );
-INSTANTIATE_TYPED_TEST_SUITE_P(wuss15, semi_alphabet_test, wuss<15>, );
-INSTANTIATE_TYPED_TEST_SUITE_P(wuss15, alphabet_constexpr, wuss<15>, );
-INSTANTIATE_TYPED_TEST_SUITE_P(wuss15, semi_alphabet_constexpr, wuss<15>, );
-INSTANTIATE_TYPED_TEST_SUITE_P(wuss67, alphabet_, wuss<67>, );
-INSTANTIATE_TYPED_TEST_SUITE_P(wuss67, semi_alphabet_test, wuss<67>, );
-INSTANTIATE_TYPED_TEST_SUITE_P(wuss67, alphabet_constexpr, wuss<67>, );
-INSTANTIATE_TYPED_TEST_SUITE_P(wuss67, semi_alphabet_constexpr, wuss<67>, );
+INSTANTIATE_TYPED_TEST_SUITE_P(wuss51, alphabet_, seqan3::wuss51, );
+INSTANTIATE_TYPED_TEST_SUITE_P(wuss51, semi_alphabet_test, seqan3::wuss51, );
+INSTANTIATE_TYPED_TEST_SUITE_P(wuss51, alphabet_constexpr, seqan3::wuss51, );
+INSTANTIATE_TYPED_TEST_SUITE_P(wuss51, semi_alphabet_constexpr, seqan3::wuss51, );
+INSTANTIATE_TYPED_TEST_SUITE_P(wuss15, alphabet_, seqan3::wuss<15>, );
+INSTANTIATE_TYPED_TEST_SUITE_P(wuss15, semi_alphabet_test, seqan3::wuss<15>, );
+INSTANTIATE_TYPED_TEST_SUITE_P(wuss15, alphabet_constexpr, seqan3::wuss<15>, );
+INSTANTIATE_TYPED_TEST_SUITE_P(wuss15, semi_alphabet_constexpr, seqan3::wuss<15>, );
+INSTANTIATE_TYPED_TEST_SUITE_P(wuss67, alphabet_, seqan3::wuss<67>, );
+INSTANTIATE_TYPED_TEST_SUITE_P(wuss67, semi_alphabet_test, seqan3::wuss<67>, );
+INSTANTIATE_TYPED_TEST_SUITE_P(wuss67, alphabet_constexpr, seqan3::wuss<67>, );
+INSTANTIATE_TYPED_TEST_SUITE_P(wuss67, semi_alphabet_constexpr, seqan3::wuss<67>, );
 
 // assign_char functions
 TEST(wuss, assign_char)
@@ -40,7 +40,7 @@ TEST(wuss, assign_char)
         'H', 'B', 'E', 'G', 'I', 'T', 'S'
     };
 
-    std::vector<wuss51> cmp
+    std::vector<seqan3::wuss51> cmp
     {
         '.'_wuss51, '('_wuss51, ')'_wuss51,
         ':'_wuss51, ','_wuss51, '-'_wuss51, '_'_wuss51, '~'_wuss51, ';'_wuss51,
@@ -48,67 +48,67 @@ TEST(wuss, assign_char)
         'H'_wuss51, 'B'_wuss51, 'E'_wuss51, 'G'_wuss51, 'I'_wuss51, 'T'_wuss51, 'S'_wuss51
     };
 
-    for (auto [ ch, cm ] : views::zip(input, cmp))
-        EXPECT_EQ((assign_char_to(ch, wuss51{})), cm);
+    for (auto [ ch, cm ] : seqan3::views::zip(input, cmp))
+        EXPECT_EQ((seqan3::assign_char_to(ch, seqan3::wuss51{})), cm);
 }
 
 // to_char functions
 TEST(wuss, to_char)
 {
-    EXPECT_EQ(to_char('.'_wuss51), '.');
-    EXPECT_EQ(to_char(':'_wuss51), ':');
-    EXPECT_EQ(to_char(','_wuss51), ',');
-    EXPECT_EQ(to_char('-'_wuss51), '-');
-    EXPECT_EQ(to_char('_'_wuss51), '_');
-    EXPECT_EQ(to_char('~'_wuss51), '~');
-    EXPECT_EQ(to_char(';'_wuss51), ';');
-    EXPECT_EQ(to_char('<'_wuss51), '<');
-    EXPECT_EQ(to_char('>'_wuss51), '>');
-    EXPECT_EQ(to_char('('_wuss51), '(');
-    EXPECT_EQ(to_char(')'_wuss51), ')');
-    EXPECT_EQ(to_char('['_wuss51), '[');
-    EXPECT_EQ(to_char(']'_wuss51), ']');
-    EXPECT_EQ(to_char('{'_wuss51), '{');
-    EXPECT_EQ(to_char('}'_wuss51), '}');
+    EXPECT_EQ(seqan3::to_char('.'_wuss51), '.');
+    EXPECT_EQ(seqan3::to_char(':'_wuss51), ':');
+    EXPECT_EQ(seqan3::to_char(','_wuss51), ',');
+    EXPECT_EQ(seqan3::to_char('-'_wuss51), '-');
+    EXPECT_EQ(seqan3::to_char('_'_wuss51), '_');
+    EXPECT_EQ(seqan3::to_char('~'_wuss51), '~');
+    EXPECT_EQ(seqan3::to_char(';'_wuss51), ';');
+    EXPECT_EQ(seqan3::to_char('<'_wuss51), '<');
+    EXPECT_EQ(seqan3::to_char('>'_wuss51), '>');
+    EXPECT_EQ(seqan3::to_char('('_wuss51), '(');
+    EXPECT_EQ(seqan3::to_char(')'_wuss51), ')');
+    EXPECT_EQ(seqan3::to_char('['_wuss51), '[');
+    EXPECT_EQ(seqan3::to_char(']'_wuss51), ']');
+    EXPECT_EQ(seqan3::to_char('{'_wuss51), '{');
+    EXPECT_EQ(seqan3::to_char('}'_wuss51), '}');
 }
 
 // concepts
 TEST(wuss, concept_check)
 {
-    EXPECT_TRUE(rna_structure_alphabet<wuss51>);
-    EXPECT_TRUE(rna_structure_alphabet<wuss51 &>);
-    EXPECT_TRUE(rna_structure_alphabet<wuss51 const>);
-    EXPECT_TRUE(rna_structure_alphabet<wuss51 const &>);
-    EXPECT_NE(max_pseudoknot_depth<wuss51>, 0);
+    EXPECT_TRUE(seqan3::rna_structure_alphabet<seqan3::wuss51>);
+    EXPECT_TRUE(seqan3::rna_structure_alphabet<seqan3::wuss51 &>);
+    EXPECT_TRUE(seqan3::rna_structure_alphabet<seqan3::wuss51 const>);
+    EXPECT_TRUE(seqan3::rna_structure_alphabet<seqan3::wuss51 const &>);
+    EXPECT_NE(seqan3::max_pseudoknot_depth<seqan3::wuss51>, 0);
 
-    EXPECT_TRUE(rna_structure_alphabet<wuss<>>);  // same as wuss51
-    EXPECT_TRUE(rna_structure_alphabet<wuss<> &>);
-    EXPECT_TRUE(rna_structure_alphabet<wuss<> const>);
-    EXPECT_TRUE(rna_structure_alphabet<wuss<> const &>);
-    EXPECT_NE(max_pseudoknot_depth<wuss<>>, 0);
+    EXPECT_TRUE(seqan3::rna_structure_alphabet<seqan3::wuss<>>);  // same as wuss51
+    EXPECT_TRUE(seqan3::rna_structure_alphabet<seqan3::wuss<> &>);
+    EXPECT_TRUE(seqan3::rna_structure_alphabet<seqan3::wuss<> const>);
+    EXPECT_TRUE(seqan3::rna_structure_alphabet<seqan3::wuss<> const &>);
+    EXPECT_NE(seqan3::max_pseudoknot_depth<seqan3::wuss<>>, 0);
 
-    EXPECT_TRUE(rna_structure_alphabet<wuss<67>>);
-    EXPECT_TRUE(rna_structure_alphabet<wuss<67> &>);
-    EXPECT_TRUE(rna_structure_alphabet<wuss<67> const>);
-    EXPECT_TRUE(rna_structure_alphabet<wuss<67> const &>);
-    EXPECT_NE(max_pseudoknot_depth<wuss<67>>, 0);
+    EXPECT_TRUE(seqan3::rna_structure_alphabet<seqan3::wuss<67>>);
+    EXPECT_TRUE(seqan3::rna_structure_alphabet<seqan3::wuss<67> &>);
+    EXPECT_TRUE(seqan3::rna_structure_alphabet<seqan3::wuss<67> const>);
+    EXPECT_TRUE(seqan3::rna_structure_alphabet<seqan3::wuss<67> const &>);
+    EXPECT_NE(seqan3::max_pseudoknot_depth<seqan3::wuss<67>>, 0);
 
 }
 
 TEST(wuss, literals)
 {
-    std::vector<wuss51> vec1;
+    std::vector<seqan3::wuss51> vec1;
     vec1.resize(5, '<'_wuss51);
     EXPECT_EQ(vec1, "<<<<<"_wuss51);
 
-    std::vector<wuss51> vec2{'.'_wuss51, '<'_wuss51, '<'_wuss51, '>'_wuss51, '>'_wuss51, '.'_wuss51};
+    std::vector<seqan3::wuss51> vec2{'.'_wuss51, '<'_wuss51, '<'_wuss51, '>'_wuss51, '>'_wuss51, '.'_wuss51};
     EXPECT_EQ(vec2, ".<<>>."_wuss51);
 }
 
 TEST(wuss, rna_structure_properties)
 {
-    EXPECT_EQ(wuss51::max_pseudoknot_depth, 22);
-    std::vector<wuss51> vec = ".:,-_~;<>()[]{}AaBbCcDd"_wuss51;
+    EXPECT_EQ(seqan3::wuss51::max_pseudoknot_depth, 22);
+    std::vector<seqan3::wuss51> vec = ".:,-_~;<>()[]{}AaBbCcDd"_wuss51;
     for (unsigned idx = 0; idx <= 6; ++idx)
     {
         EXPECT_TRUE(vec[idx].is_unpaired());


### PR DESCRIPTION
Resolves #1746

test/unit/alphabet/a*-c* https://github.com/seqan/seqan3/pull/1657 and test/unit/alphabet/quality https://github.com/seqan/seqan3/pull/1638 are already done.
