### PR TITLE
[MISC] Remove 'Associated type' in views

### DIFF
--- a/include/seqan3/range/views/interleave.hpp
+++ b/include/seqan3/range/views/interleave.hpp
@@ -54,7 +54,6 @@ template <std::ranges::random_access_range urng_t, std::ranges::random_access_ra
 class view_interleave : public std::ranges::view_interface<view_interleave<urng_t, inserted_rng_t>>
 {
 private:
-
     //!\brief The underlying range.
     urng_t urange;
     //!\brief The step size for the insertion.
@@ -90,7 +89,6 @@ private:
     friend class detail::random_access_iterator_base;
 
 public:
-
     /*!\name Constructors, destructor and assignment
      * \{
      */

--- a/include/seqan3/range/views/interleave.hpp
+++ b/include/seqan3/range/views/interleave.hpp
@@ -54,6 +54,7 @@ template <std::ranges::random_access_range urng_t, std::ranges::random_access_ra
 class view_interleave : public std::ranges::view_interface<view_interleave<urng_t, inserted_rng_t>>
 {
 private:
+
     //!\brief The underlying range.
     urng_t urange;
     //!\brief The step size for the insertion.
@@ -61,8 +62,8 @@ private:
     //!\brief The range to be inserted into urange.
     inserted_rng_t inserted_range;
 
-    /*!\name Associated types iterator
-     * These associated types are needed in seqan3::detail::random_access_iterator.
+    /*!\name Associated types
+     * \brief These associated types are needed in seqan3::detail::random_access_iterator.
      * \{
      */
     //!\brief This resolves to range_type::size_type as the underlying range is guaranteed to be sized.
@@ -78,6 +79,10 @@ private:
     using value_type        = std::ranges::range_value_t<urng_t>;
     //!\brief A signed integer type, usually std::ptrdiff_t.
     using difference_type   = std::ranges::range_difference_t<urng_t>;
+    //!\brief The iterator type of this view (a random access iterator).
+    using iterator          = detail::random_access_iterator<view_interleave>;
+    //!\brief The const_iterator type is equal to the iterator type.
+    using const_iterator    = detail::random_access_iterator<view_interleave const>;
     //!\}
 
     //!\brief Befriend the following class s.t. iterator and const_iterator can be defined for this type.
@@ -85,14 +90,6 @@ private:
     friend class detail::random_access_iterator_base;
 
 public:
-    /*!\name Associated types
-     * \{
-     */
-    //!\brief The iterator type of this view (a random access iterator).
-    using iterator          = detail::random_access_iterator<view_interleave>;
-    //!\brief The const_iterator type is equal to the iterator type.
-    using const_iterator    = detail::random_access_iterator<view_interleave const>;
-    //!\}
 
     /*!\name Constructors, destructor and assignment
      * \{

--- a/include/seqan3/range/views/interleave.hpp
+++ b/include/seqan3/range/views/interleave.hpp
@@ -60,13 +60,13 @@ private:
     size_t step_size{};
     //!\brief The range to be inserted into urange.
     inserted_rng_t inserted_range;
-    //!\brief This resolves to range_type::size_type as the underlying range is guaranteed to be Sized.
-    using size_type         = std::ranges::range_size_t<urng_t>;
 
-public:
     /*!\name Associated types
+     *!\brief These associated types are needed in random_access_iterator.
      * \{
      */
+    //!\brief This resolves to range_type::size_type as the underlying range is guaranteed to be Sized.
+    using size_type         = std::ranges::range_size_t<urng_t>;
     //!\brief The reference_type.
     using reference         = ranges::common_reference_t<std::ranges::range_reference_t<urng_t>,
                                                          std::ranges::range_reference_t<inserted_rng_t>>;
@@ -78,6 +78,16 @@ public:
     using value_type        = std::ranges::range_value_t<urng_t>;
     //!\brief A signed integer type, usually std::ptrdiff_t.
     using difference_type   = std::ranges::range_difference_t<urng_t>;
+    //!\}
+
+public:
+    //!\brief Befriend the following class s.t. iterator and const_iterator can be defined for this type.
+    template <typename parent_type, typename crtp_base>
+    friend class detail::random_access_iterator_base;
+
+    /*!\name Associated types
+     * \{
+     */
     //!\brief The iterator type of this view (a random access iterator).
     using iterator          = detail::random_access_iterator<view_interleave>;
     //!\brief The const_iterator type is equal to the iterator type.

--- a/include/seqan3/range/views/interleave.hpp
+++ b/include/seqan3/range/views/interleave.hpp
@@ -61,11 +61,11 @@ private:
     //!\brief The range to be inserted into urange.
     inserted_rng_t inserted_range;
 
-    /*!\name Associated types
-     *!\brief These associated types are needed in random_access_iterator.
+    /*!\name Associated types iterator
+     * These associated types are needed in seqan3::detail::random_access_iterator.
      * \{
      */
-    //!\brief This resolves to range_type::size_type as the underlying range is guaranteed to be Sized.
+    //!\brief This resolves to range_type::size_type as the underlying range is guaranteed to be sized.
     using size_type         = std::ranges::range_size_t<urng_t>;
     //!\brief The reference_type.
     using reference         = ranges::common_reference_t<std::ranges::range_reference_t<urng_t>,
@@ -80,11 +80,11 @@ private:
     using difference_type   = std::ranges::range_difference_t<urng_t>;
     //!\}
 
-public:
     //!\brief Befriend the following class s.t. iterator and const_iterator can be defined for this type.
     template <typename parent_type, typename crtp_base>
     friend class detail::random_access_iterator_base;
 
+public:
     /*!\name Associated types
      * \{
      */

--- a/include/seqan3/range/views/interleave.hpp
+++ b/include/seqan3/range/views/interleave.hpp
@@ -60,6 +60,8 @@ private:
     size_t step_size{};
     //!\brief The range to be inserted into urange.
     inserted_rng_t inserted_range;
+    //!\brief This resolves to range_type::size_type as the underlying range is guaranteed to be Sized.
+    using size_type         = std::ranges::range_size_t<urng_t>;
 
 public:
     /*!\name Associated types
@@ -74,8 +76,6 @@ public:
                                                          std::ranges::range_reference_t<inserted_rng_t const>>, void>;
     //!\brief The value_type (which equals the reference_type with any references removed).
     using value_type        = std::ranges::range_value_t<urng_t>;
-    //!\brief This resolves to range_type::size_type as the underlying range is guaranteed to be Sized.
-    using size_type         = std::ranges::range_size_t<urng_t>;
     //!\brief A signed integer type, usually std::ptrdiff_t.
     using difference_type   = std::ranges::range_difference_t<urng_t>;
     //!\brief The iterator type of this view (a random access iterator).

--- a/include/seqan3/range/views/pairwise_combine.hpp
+++ b/include/seqan3/range/views/pairwise_combine.hpp
@@ -446,16 +446,6 @@ public:
     //!\brief The const iterator type. Evaluates to void if the underlying range is not const iterable.
     using const_iterator    = transformation_trait_or_t<std::type_identity<iterator_type<underlying_range_type const>>,
                                                         void>;
-    //!\brief The reference_type.
-    using reference         = typename iterator::reference;
-    //!\brief The const_reference type is equal to the reference type.
-    using const_reference   = reference;
-    //!\brief The value_type (which equals the reference_type with any references removed).
-    using value_type        = typename iterator::value_type;
-    //!\brief If the underliying range is Sized, this resolves to range_type::size_type, otherwise void.
-    using size_type         = detail::transformation_trait_or_t<seqan3::size_type<underlying_range_type>, void>;
-    //!\brief A signed integer type, usually std::ptrdiff_t.
-    using difference_type   = std::iter_difference_t<iterator>;
     //!\}
 
     /*!\name Constructors, destructor and assignment
@@ -634,7 +624,7 @@ public:
      * \{
      */
     //!\brief Computes the size based on the size of the underlying range.
-    constexpr size_type size() const noexcept
+    constexpr auto size() const noexcept
     //!\cond
         requires std::ranges::sized_range<underlying_range_type>
     //!\endcond

--- a/include/seqan3/range/views/pairwise_combine.hpp
+++ b/include/seqan3/range/views/pairwise_combine.hpp
@@ -435,8 +435,6 @@ private:
         underlying_iterator_type end_it{};
     };
 
-public:
-
     /*!\name Associated types
      * \{
      */
@@ -447,6 +445,8 @@ public:
     using const_iterator    = transformation_trait_or_t<std::type_identity<iterator_type<underlying_range_type const>>,
                                                         void>;
     //!\}
+    
+public:
 
     /*!\name Constructors, destructor and assignment
      * \{

--- a/include/seqan3/range/views/pairwise_combine.hpp
+++ b/include/seqan3/range/views/pairwise_combine.hpp
@@ -447,7 +447,6 @@ private:
     //!\}
     
 public:
-
     /*!\name Constructors, destructor and assignment
      * \{
      */

--- a/include/seqan3/range/views/persist.hpp
+++ b/include/seqan3/range/views/persist.hpp
@@ -50,7 +50,6 @@ private:
     //!\brief Shared storage of the underlying range.
     std::shared_ptr<urng_t> urange;
 
-public:
     /*!\name Associated types
      * \{
      */
@@ -59,6 +58,8 @@ public:
     //!\brief The const_iterator type is equal to the iterator type.
     using const_iterator    = iterator;
     //!\}
+    
+public:
 
     /*!\name Constructors, destructor and assignment
      * \{

--- a/include/seqan3/range/views/persist.hpp
+++ b/include/seqan3/range/views/persist.hpp
@@ -60,7 +60,6 @@ private:
     //!\}
     
 public:
-
     /*!\name Constructors, destructor and assignment
      * \{
      */

--- a/include/seqan3/range/views/persist.hpp
+++ b/include/seqan3/range/views/persist.hpp
@@ -54,16 +54,6 @@ public:
     /*!\name Associated types
      * \{
      */
-    //!\brief The reference_type.
-    using reference         = std::ranges::range_reference_t<urng_t>;
-    //!\brief The const_reference type is equal to the reference type.
-    using const_reference   = reference;
-    //!\brief The value_type (which equals the reference_type with any references removed).
-    using value_type        = std::ranges::range_value_t<urng_t>;
-    //!\brief If the underliying range is Sized, this resolves to range_type::size_type, otherwise void.
-    using size_type         = detail::transformation_trait_or_t<seqan3::size_type<urng_t>, void>;
-    //!\brief A signed integer type, usually std::ptrdiff_t.
-    using difference_type   = std::ranges::range_difference_t<urng_t>;
     //!\brief The iterator type of this view (a random access iterator).
     using iterator          = std::ranges::iterator_t<urng_t>;
     //!\brief The const_iterator type is equal to the iterator type.

--- a/include/seqan3/range/views/repeat.hpp
+++ b/include/seqan3/range/views/repeat.hpp
@@ -146,8 +146,6 @@ public:
     using reference  = value_type &;
     //!\brief The const reference type.
     using const_reference = value_type const &;
-    //!\brief The size_type is void, because this range is never sized.
-    using size_type = void;
     //!\brief The type to store the difference of two iterators.
     using difference_type = ptrdiff_t;
     //!\brief The iterator type of this view (a random access iterator).

--- a/include/seqan3/range/views/repeat.hpp
+++ b/include/seqan3/range/views/repeat.hpp
@@ -44,13 +44,14 @@ template <std::copy_constructible value_t>
 class repeat_view : public std::ranges::view_interface<repeat_view<value_t>>
 {
 private:
+
     //!/brief the base type.
     using base_t = std::ranges::view_interface<repeat_view<value_t>>;
 
     //!\brief The sentinel type is set to std::ranges::default_sentinel_t.
     using sentinel_type = std::ranges::default_sentinel_t;
 
-    /*!\name Associated types iterator
+    /*!\name Associated types
      * These associated types are needed in seqan3::detail::random_access_iterator.
      * \{
      */
@@ -150,19 +151,21 @@ private:
         //!\}
     };
 
-    //!\brief Befriend the following class s.t. iterator and const_iterator can be defined for this type.
-    template <typename parent_type, typename crtp_base>
-    friend class detail::random_access_iterator_base;
-
-public:
     /*!\name Associated types
-     * \{
-     */
+    * \{
+    */
     //!\brief The iterator type of this view (a random access iterator).
     using iterator = repeat_view_iterator<repeat_view>;
     //!\brief The const_iterator type is equal to the iterator type but over the const qualified type.
     using const_iterator = repeat_view_iterator<repeat_view const>;
     //!\}
+
+    //!\brief Befriend the following class s.t. iterator and const_iterator can be defined for this type.
+    template <typename parent_type, typename crtp_base>
+    friend class detail::random_access_iterator_base;
+    
+
+public:
 
     /*!\name Constructors, destructor and assignment
      * \{

--- a/include/seqan3/range/views/repeat.hpp
+++ b/include/seqan3/range/views/repeat.hpp
@@ -44,7 +44,6 @@ template <std::copy_constructible value_t>
 class repeat_view : public std::ranges::view_interface<repeat_view<value_t>>
 {
 private:
-
     //!/brief the base type.
     using base_t = std::ranges::view_interface<repeat_view<value_t>>;
 
@@ -163,10 +162,8 @@ private:
     //!\brief Befriend the following class s.t. iterator and const_iterator can be defined for this type.
     template <typename parent_type, typename crtp_base>
     friend class detail::random_access_iterator_base;
-    
 
 public:
-
     /*!\name Constructors, destructor and assignment
      * \{
      */

--- a/include/seqan3/range/views/repeat.hpp
+++ b/include/seqan3/range/views/repeat.hpp
@@ -50,6 +50,20 @@ private:
     //!\brief The sentinel type is set to std::ranges::default_sentinel_t.
     using sentinel_type = std::ranges::default_sentinel_t;
 
+    /*!\name Associated types
+     *!\brief These associated types are needed in random_access_iterator.
+     * \{
+     */
+    //!\brief The value type (equals the value_t with any references removed).
+    using value_type = std::remove_reference_t<value_t>;
+    //!\brief The reference_type.
+    using reference  = value_type &;
+    //!\brief The const reference type.
+    using const_reference = value_type const &;
+    //!\brief The type to store the difference of two iterators.
+    using difference_type = ptrdiff_t;
+    //!\}
+
     //!\brief The iterator type for views::repeat (a random access iterator).
     template <typename parent_type>
     class repeat_view_iterator : public detail::random_access_iterator_base<parent_type, repeat_view_iterator>
@@ -137,17 +151,14 @@ private:
     };
 
 public:
+
+    //!\brief Befriend the following class s.t. iterator and const_iterator can be defined for this type.
+    template <typename parent_type, typename crtp_base>
+    friend class detail::random_access_iterator_base;
+
     /*!\name Associated types
      * \{
      */
-    //!\brief The value type (equals the value_t with any references removed).
-    using value_type = std::remove_reference_t<value_t>;
-    //!\brief The reference_type.
-    using reference  = value_type &;
-    //!\brief The const reference type.
-    using const_reference = value_type const &;
-    //!\brief The type to store the difference of two iterators.
-    using difference_type = ptrdiff_t;
     //!\brief The iterator type of this view (a random access iterator).
     using iterator = repeat_view_iterator<repeat_view>;
     //!\brief The const_iterator type is equal to the iterator type but over the const qualified type.

--- a/include/seqan3/range/views/repeat.hpp
+++ b/include/seqan3/range/views/repeat.hpp
@@ -50,8 +50,8 @@ private:
     //!\brief The sentinel type is set to std::ranges::default_sentinel_t.
     using sentinel_type = std::ranges::default_sentinel_t;
 
-    /*!\name Associated types
-     *!\brief These associated types are needed in random_access_iterator.
+    /*!\name Associated types iterator
+     * These associated types are needed in seqan3::detail::random_access_iterator.
      * \{
      */
     //!\brief The value type (equals the value_t with any references removed).
@@ -150,12 +150,11 @@ private:
         //!\}
     };
 
-public:
-
     //!\brief Befriend the following class s.t. iterator and const_iterator can be defined for this type.
     template <typename parent_type, typename crtp_base>
     friend class detail::random_access_iterator_base;
 
+public:
     /*!\name Associated types
      * \{
      */

--- a/include/seqan3/range/views/translate_join.hpp
+++ b/include/seqan3/range/views/translate_join.hpp
@@ -49,7 +49,7 @@ private:
     small_vector<translation_frames, 6> selected_frames{};
 
     /*!\name Associated types iterator
-     * These associated types are needed in seqan3::detail::random_access_iterator.
+     * \brief These associated types are needed in seqan3::detail::random_access_iterator.
      * \{
      */
     //!\brief The reference_type.
@@ -62,21 +62,15 @@ private:
     using size_type         = std::ranges::range_size_t<std::ranges::range_reference_t<urng_t>>;
     //!\brief A signed integer type, usually std::ptrdiff_t.
     using difference_type   = std::ranges::range_difference_t<std::ranges::range_reference_t<urng_t>>;
-    //!\}
-
-protected:
-    //!\brief Befriend the following class s.t. iterator and const_iterator can be defined for this type.
-    template <typename, typename>
-    friend class detail::random_access_iterator_base;
-
-    /*!\name Associated types
-     * \{
-     */
     //!\brief The iterator type of this view (a random access iterator).
     using iterator          = detail::random_access_iterator<view_translate_join>;
     //!\brief The const iterator type of this view (same as iterator, because it's a view).
     using const_iterator    = detail::random_access_iterator<view_translate_join const>;
     //!\}
+
+    //!\brief Befriend the following class s.t. iterator and const_iterator can be defined for this type.
+    template <typename, typename>
+    friend class detail::random_access_iterator_base;
 
 public:
 

--- a/include/seqan3/range/views/translate_join.hpp
+++ b/include/seqan3/range/views/translate_join.hpp
@@ -48,14 +48,6 @@ private:
     //!\brief The selected frames corresponding to the frames required.
     small_vector<translation_frames, 6> selected_frames{};
 
-protected:
-    //!\brief Befriend the following class s.t. iterator and const_iterator can be defined for this type.
-    template <typename, typename>
-    friend class detail::random_access_iterator_base;
-
-    /*!\name Associated types
-     * \{
-     */
     //!\brief The reference_type.
     using reference         = view_translate_single<std::ranges::all_view<std::ranges::range_reference_t<urng_t>>>;
     //!\brief The const_reference type.
@@ -66,6 +58,15 @@ protected:
     using size_type         = std::ranges::range_size_t<std::ranges::range_reference_t<urng_t>>;
     //!\brief A signed integer type, usually std::ptrdiff_t.
     using difference_type   = std::ranges::range_difference_t<std::ranges::range_reference_t<urng_t>>;
+
+protected:
+    //!\brief Befriend the following class s.t. iterator and const_iterator can be defined for this type.
+    template <typename, typename>
+    friend class detail::random_access_iterator_base;
+
+    /*!\name Associated types
+     * \{
+     */
     //!\brief The iterator type of this view (a random access iterator).
     using iterator          = detail::random_access_iterator<view_translate_join>;
     //!\brief The const iterator type of this view (same as iterator, because it's a view).

--- a/include/seqan3/range/views/translate_join.hpp
+++ b/include/seqan3/range/views/translate_join.hpp
@@ -48,6 +48,10 @@ private:
     //!\brief The selected frames corresponding to the frames required.
     small_vector<translation_frames, 6> selected_frames{};
 
+    /*!\name Associated types iterator
+     * These associated types are needed in seqan3::detail::random_access_iterator.
+     * \{
+     */
     //!\brief The reference_type.
     using reference         = view_translate_single<std::ranges::all_view<std::ranges::range_reference_t<urng_t>>>;
     //!\brief The const_reference type.
@@ -58,6 +62,7 @@ private:
     using size_type         = std::ranges::range_size_t<std::ranges::range_reference_t<urng_t>>;
     //!\brief A signed integer type, usually std::ptrdiff_t.
     using difference_type   = std::ranges::range_difference_t<std::ranges::range_reference_t<urng_t>>;
+    //!\}
 
 protected:
     //!\brief Befriend the following class s.t. iterator and const_iterator can be defined for this type.


### PR DESCRIPTION
This fixes part of seqan/product_backlog#51 and fixes also part of seqan#1549.

Previous PRs of the same kind #1734.

### Workflow:

- (1) If you can remove it, remove it.
- (2) If something uses it and does not compile anymore, leave it
- (3) Try to make the associated types of ranges private
- (4) If it does not work, leave it
- (5) Document places where you had problems.

### Work:
Searching for "associate" in `include/seqan3/range/views`. Hits in:

- [x] async_input buffer:
no associated types in view class, only in iterator class.

- [x] interleave
    - [x] reference, const_reference, value_type, and difference_type
    **edit** 28.04.20:  befriending the inherited iterator allowed making the associated types private
    
      ~~removing not possible~~
    
      ~~replacing, no coresponding iterator types.~~
    
      ~~private? Also not possible, results in build errors in `random_access_iterator.hpp`~~
    
    - [x] size_type
    
- [x] kmer_hash:
no associated types in view class, only in iterator class.

- [x] pairwise_combine
  - [x] reference
  - [x] const_reference
  - [x] value_type  
  - [x] size_type
  - [x] difference_type
  
- [x] persist
  - [x] reference
  - [x] const_reference
  - [x] value_type  
  - [x] size_type
  - [x] difference_type
- [x] repeat
   
  - [x] reference const_reference, value_type, and difference_type 
    **edit** 28.04.20:  befriending the inherited iterator allowed making the associated types private
    ~~removing? not posible.~~
   
    ~~replace? not working~~
  	
  	~~random_access_iterator.hpp:46:85: error: invalid use of incomplete type ‘class seqan3::detail::repeat_view<std::_Swallow_assign>’~~
	~~using position_type = std::make_unsigned_t<typename range_type::difference_type>;~~

    ~~private? build error in `random_access_iterator.hpp`~~
  - [x] size_type
  
- [x] single_pass_input: no associated types in view class, only in iterator class.

- [x] take_until
  - [x] reference
  - [x] const_reference
  - [x] value_type
  - [x] size_type
  - [x] difference_type
- [x] take
  - [x] reference
  - [x] const_reference
  - [x] value_type
  - [x] size_type
  - [x] difference_type
- [x] translate_join
  - [x] reference
  - [x] const_reference
  - [x] value_type
  - [x] size_type
  - [x] difference_type