### PR TITLE
[FIX] Fix const compatibility for the shape_iterator of the kmer_hash view.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,9 @@ Note that 3.1.0 will be the first API stable release and interfaces in this rele
 
 * Added size() function to `seqan3::views::kmer_hash`
   ([\#1722](https://github.com/seqan/seqan3/pull/1722)).
+* `operator[](difference_type const n)` of the iterator of the `seqan3::views::kmer_hash` is declared `const`
+  and returns value `n` steps after the current position without jumping to that position
+  ([\#1756](https://github.com/seqan/seqan3/pull/1756)).
 
 # 3.0.1
 

--- a/include/seqan3/range/views/kmer_hash.hpp
+++ b/include/seqan3/range/views/kmer_hash.hpp
@@ -223,6 +223,9 @@ private:
     //!\brief The sentinel type of the underlying range.
     using sentinel_t = std::ranges::sentinel_t<rng_t>;
 
+    template <typename urng2_t>
+    friend class shape_iterator;
+
 public:
     /*!\name Associated types
      * \{
@@ -252,6 +255,19 @@ public:
     constexpr shape_iterator & operator=(shape_iterator const &) = default; //!< Defaulted.
     constexpr shape_iterator & operator=(shape_iterator &&)      = default; //!< Defaulted.
     ~shape_iterator()                                            = default; //!< Defaulted.
+
+    //!\brief Allow iterator on a const range to be constructible from an iterator over a non-const range.
+    template <typename urng2_t>
+    //!\cond
+        requires std::same_as<std::remove_const_t<urng_t>, urng2_t>
+    //!\endcond
+    shape_iterator(shape_iterator<urng2_t> it) :
+        hash_value{std::move(it.hash_value)},
+        roll_factor{std::move(it.roll_factor)},
+        shape_{std::move(it.shape_)},
+        text_left{std::move(it.text_left)},
+        text_right{std::move(it.text_right)}
+    {}
 
     /*!\brief Construct from a given iterator on the text and a seqan3::shape.
     * /param[in] it_start Iterator pointing to the first position of the text.

--- a/include/seqan3/range/views/kmer_hash.hpp
+++ b/include/seqan3/range/views/kmer_hash.hpp
@@ -507,14 +507,12 @@ public:
     /*!\brief Move the iterator by a given offset and return the corresponding hash value.
      * \attention This function is only avaible if `it_t` models std::random_access_iterator.
      */
-    value_type operator[](difference_type const n)
+    reference operator[](difference_type const n) const
     //!\cond
         requires std::random_access_iterator<it_t>
     //!\endcond
     {
-        text_left += n;
-        hash_full();
-        return operator*();
+        return *(*this + n);
     }
 
     //!\brief Return the hash value.

--- a/test/unit/range/views/view_kmer_hash_test.cpp
+++ b/test/unit/range/views/view_kmer_hash_test.cpp
@@ -17,6 +17,8 @@
 #include <seqan3/range/views/take_until.hpp>
 #include <seqan3/test/expect_range_eq.hpp>
 
+#include "../iterator_test_template.hpp"
+
 #include <gtest/gtest.h>
 
 using seqan3::operator""_dna4;
@@ -28,6 +30,24 @@ static constexpr auto ungapped_view = seqan3::views::kmer_hash(seqan3::ungapped{
 static constexpr auto gapped_view = seqan3::views::kmer_hash(0b101_shape);
 static constexpr auto prefix_until_first_thymine = seqan3::views::take_until([] (seqan3::dna4 x)
                                                    { return x == 'T'_dna4; });
+
+using iterator_type = std::ranges::iterator_t<decltype(std::declval<seqan3::dna4_vector&>() | gapped_view)>;
+
+template <>
+struct iterator_fixture<iterator_type> : public ::testing::Test
+{
+    using iterator_tag = std::random_access_iterator_tag;
+    static constexpr bool const_iterable = true;
+
+    seqan3::dna4_vector text{"ACGTAGC"_dna4};
+
+    decltype(text | gapped_view) test_range = text | gapped_view;
+
+    std::vector<size_t> expected_range{2, 7, 8, 14, 1};
+};
+
+using test_type = ::testing::Types<iterator_type>;
+INSTANTIATE_TYPED_TEST_SUITE_P(iterator_fixture, iterator_fixture, test_type, );
 
 template <typename T>
 class kmer_hash_ungapped_test: public ::testing::Test {};


### PR DESCRIPTION
When introducing the iterator test template to the kmer_view, the following does not compile:

1. iterator urng_t const vs non-const comparison
     ```cpp
     EXPECT_TRUE(std::ranges::begin(this->test_range) == std::ranges::cbegin(this->test_range));
     ```
2. iterator const urng_t from iterator urng_t construction 
    ```cpp
    const_iterator_type it{std::ranges::begin(this->test_range)};
    ```

This PR introduces a custom constructor from the non-const version that fixes both problems.
.
