### PR TITLE
Pass result to alignment/enable alignment result type in alignment configurations

### DIFF
--- a/include/seqan3/alignment/pairwise/detail/type_traits.hpp
+++ b/include/seqan3/alignment/pairwise/detail/type_traits.hpp
@@ -25,9 +25,9 @@
 #include <seqan3/alignment/configuration/align_config_vectorise.hpp>
 #include <seqan3/alignment/matrix/trace_directions.hpp>
 #include <seqan3/alignment/pairwise/detail/concept.hpp>
-#include <seqan3/core/detail/empty_type.hpp>
 #include <seqan3/core/algorithm/configuration.hpp>
 #include <seqan3/core/bit_manipulation.hpp>
+#include <seqan3/core/detail/empty_type.hpp>
 #include <seqan3/core/simd/simd_traits.hpp>
 #include <seqan3/core/simd/simd.hpp>
 #include <seqan3/core/type_traits/function.hpp>

--- a/test/unit/alignment/pairwise/alignment_configurator_test.cpp
+++ b/test/unit/alignment/pairwise/alignment_configurator_test.cpp
@@ -9,6 +9,7 @@
 
 #include <range/v3/view/single.hpp>
 
+#include <seqan3/alignment/pairwise/detail/type_traits.hpp>
 #include <seqan3/alignment/pairwise/alignment_configurator.hpp>
 #include <seqan3/alignment/pairwise/detail/type_traits.hpp>
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
@@ -28,13 +29,13 @@ template <typename config_t>
 auto run_test(config_t const & cfg)
 {
     auto r = setup();
-    auto configuration_result = seqan3::detail::alignment_configurator::configure<decltype(r)>(cfg);
-    auto algorithm = configuration_result.first;
+    auto [algorithm, new_config] = seqan3::detail::alignment_configurator::configure<decltype(r)>(cfg);
 
     auto indexed_sequence_pairs = seqan3::views::zip(r, std::views::iota(0)) | seqan3::views::chunk(1);
 
-    using function_traits_t = typename seqan3::detail::alignment_function_traits<decltype(algorithm)>;
-    using alignment_result_t = typename function_traits_t::alignment_result_type;
+    using new_configuration_t = decltype(new_config);
+    using traits_t = seqan3::detail::alignment_configuration_traits<new_configuration_t>;
+    using alignment_result_t = typename traits_t::alignment_result_type;
 
     alignment_result_t align_result{};
     algorithm(*indexed_sequence_pairs.begin(), [&] (auto && res) mutable

--- a/test/unit/alignment/pairwise/alignment_configurator_test.cpp
+++ b/test/unit/alignment/pairwise/alignment_configurator_test.cpp
@@ -9,7 +9,6 @@
 
 #include <range/v3/view/single.hpp>
 
-#include <seqan3/alignment/pairwise/detail/type_traits.hpp>
 #include <seqan3/alignment/pairwise/alignment_configurator.hpp>
 #include <seqan3/alignment/pairwise/detail/type_traits.hpp>
 #include <seqan3/alphabet/nucleotide/dna4.hpp>


### PR DESCRIPTION
Part of #1692 

### Description

Adds a type definition for the alignment result type inside of the alignment configuration traits. This allows to get the result type in a centralised way that is available to all algorithms and the result type needs to be defined only in one place during the configuration phase.

~### Note for the reviewer:~

~This PR is based on #1740 and only the last commit is relevant for this change.~