### PR TITLE
 [FEATURE] new test macro EXPECT_RANGE_EQ

### DIFF
--- a/test/include/seqan3/test/expect_range_eq.hpp
+++ b/test/include/seqan3/test/expect_range_eq.hpp
@@ -1,0 +1,54 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides test utilities for std::ranges::range types.
+ * \author Marcel Ehrhardt <marcel.ehrhardt AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <seqan3/std/algorithm>
+#include <seqan3/std/ranges>
+
+#include <seqan3/core/detail/debug_stream_range.hpp>
+#include <seqan3/core/detail/to_string.hpp>
+#include <seqan3/test/pretty_printing.hpp>
+
+namespace seqan3::test
+{
+#define EXPECT_RANGE_EQ(val1, val2) \
+    EXPECT_PRED_FORMAT2(::seqan3::test::expect_range_eq{}, val1, val2);
+
+struct expect_range_eq
+{
+    template <typename rng_t>
+    auto copy_range(rng_t && rng)
+    {
+        using value_t = std::ranges::range_value_t<rng_t>;
+        std::vector<value_t> rng_copy{};
+        std::ranges::copy(rng, std::ranges::back_inserter(rng_copy));
+        return rng_copy;
+    }
+
+    template <std::ranges::range lhs_t, std::ranges::range rhs_t>
+    ::testing::AssertionResult operator()(char const * lhs_expression, char const * rhs_expression,
+                                          lhs_t && lhs, rhs_t && rhs)
+    {
+        std::vector lhs_copy = copy_range(lhs);
+        std::vector rhs_copy = copy_range(rhs);
+
+        if (std::ranges::equal(lhs_copy, rhs_copy))
+            return ::testing::AssertionSuccess();
+
+        return ::testing::internal::CmpHelperEQFailure(lhs_expression, rhs_expression, lhs_copy, rhs_copy);
+    }
+};
+
+} // namespace seqan3::test

--- a/test/include/seqan3/test/pretty_printing.hpp
+++ b/test/include/seqan3/test/pretty_printing.hpp
@@ -22,7 +22,8 @@ namespace seqan3
 //!\cond DEV
 //!\brief Overload for the googletest PrintTo function that always delegates to our debug_stream.
 template <typename t>
-    requires true // tricks the compiler to consider this as more specialized than googletests generic PrintTo
+    requires (!std::input_or_output_iterator<t>)
+    // tricks the compiler to consider this as more specialized than googletests generic PrintTo
 void PrintTo (t const & v, std::ostream * out)
 {
     debug_stream_type my_stream{*out};

--- a/test/unit/alignment/pairwise/pairwise_alignment_single_test_template.hpp
+++ b/test/unit/alignment/pairwise/pairwise_alignment_single_test_template.hpp
@@ -12,6 +12,7 @@
 #include <seqan3/alignment/pairwise/align_pairwise.hpp>
 #include <seqan3/range/views/to_char.hpp>
 #include <seqan3/range/views/to.hpp>
+#include <seqan3/test/expect_range_eq.hpp>
 
 #include "fixture/alignment_fixture.hpp"
 
@@ -105,8 +106,8 @@ TYPED_TEST_P(pairwise_alignment_test, alignment)
     using score_matrix_t = seqan3::detail::two_dimensional_matrix<std::optional<int32_t>>;
     using trace_matrix_t = seqan3::detail::two_dimensional_matrix<std::optional<seqan3::detail::trace_directions>>;
 
-    EXPECT_TRUE(std::ranges::equal(static_cast<score_matrix_t>(res.score_matrix()), fixture.score_vector));
-    EXPECT_TRUE(std::ranges::equal(static_cast<trace_matrix_t>(res.trace_matrix()), fixture.trace_vector));
+    EXPECT_RANGE_EQ(static_cast<score_matrix_t>(res.score_matrix()), fixture.score_vector);
+    EXPECT_RANGE_EQ(static_cast<trace_matrix_t>(res.trace_matrix()), fixture.trace_vector);
 }
 
 REGISTER_TYPED_TEST_SUITE_P(pairwise_alignment_test,

--- a/test/unit/io/alignment_file/alignment_file_format_test_template.hpp
+++ b/test/unit/io/alignment_file/alignment_file_format_test_template.hpp
@@ -15,6 +15,7 @@
 #include <seqan3/io/alignment_file/input.hpp>
 #include <seqan3/io/alignment_file/output.hpp>
 #include <seqan3/range/views/take.hpp>
+#include <seqan3/test/expect_range_eq.hpp>
 #include <seqan3/test/pretty_printing.hpp>
 
 using seqan3::operator""_cigar_op;
@@ -212,10 +213,8 @@ TYPED_TEST_P(alignment_file_read, read_in_all_data)
         EXPECT_EQ(seqan3::get<seqan3::field::offset>(rec), this->offsets[i]);
         EXPECT_EQ(seqan3::get<seqan3::field::ref_id>(rec), 0);
         EXPECT_EQ(*seqan3::get<seqan3::field::ref_offset>(rec), this->ref_offsets[i]);
-        EXPECT_TRUE(std::ranges::equal(std::get<0>(seqan3::get<seqan3::field::alignment>(rec)),
-                                       std::get<0>(this->alignments[i])));
-        EXPECT_TRUE(std::ranges::equal(std::get<1>(seqan3::get<seqan3::field::alignment>(rec)),
-                                       std::get<1>(this->alignments[i])));
+        EXPECT_RANGE_EQ(std::get<0>(seqan3::get<seqan3::field::alignment>(rec)), std::get<0>(this->alignments[i]));
+        EXPECT_RANGE_EQ(std::get<1>(seqan3::get<seqan3::field::alignment>(rec)), std::get<1>(this->alignments[i]));
         EXPECT_EQ(seqan3::get<seqan3::field::flag>(rec), this->flags[i]);
         EXPECT_EQ(seqan3::get<seqan3::field::mapq>(rec), this->mapqs[i]);
         EXPECT_EQ(seqan3::get<seqan3::field::mate>(rec), this->mates[i]);
@@ -268,8 +267,8 @@ TYPED_TEST_P(alignment_file_read, read_in_alignment_only_with_ref)
         size_t i{0};
         for (auto & [alignment] : fin)
         {
-            EXPECT_TRUE(std::ranges::equal(std::get<0>(alignment), std::get<0>(this->alignments[i])));
-            EXPECT_TRUE(std::ranges::equal(std::get<1>(alignment), std::get<1>(this->alignments[i])));
+            EXPECT_RANGE_EQ(std::get<0>(alignment), std::get<0>(this->alignments[i]));
+            EXPECT_RANGE_EQ(std::get<1>(alignment), std::get<1>(this->alignments[i]));
             ++i;
         }
     }
@@ -296,7 +295,7 @@ TYPED_TEST_P(alignment_file_read, read_in_alignment_only_without_ref)
         size_t i{0};
         for (auto & [alignment] : fin)
         {
-            EXPECT_TRUE(std::ranges::equal(std::get<1>(alignment), std::get<1>(this->alignments[i++])));
+            EXPECT_RANGE_EQ(std::get<1>(alignment), std::get<1>(this->alignments[i++]));
             auto & ref_aln = std::get<0>(alignment);
             EXPECT_THROW((ref_aln[0]), std::logic_error); // access on a dummy seq is not allowed
         }

--- a/test/unit/io/alignment_file/format_bam_test.cpp
+++ b/test/unit/io/alignment_file/format_bam_test.cpp
@@ -405,10 +405,10 @@ TEST_F(bam_format, too_long_cigar_string_read)
 
         seqan3::alignment_file_input fin{stream, this->ref_ids, this->ref_sequences, seqan3::format_bam{}};
 
-        EXPECT_TRUE(std::ranges::equal(std::get<0>(seqan3::get<seqan3::field::alignment>(*fin.begin())),
-                                       std::get<0>(this->alignments[0])));
-        EXPECT_TRUE(std::ranges::equal(std::get<1>(seqan3::get<seqan3::field::alignment>(*fin.begin())),
-                                       std::get<1>(this->alignments[0])));
+        EXPECT_RANGE_EQ(std::get<0>(seqan3::get<seqan3::field::alignment>(*fin.begin())),
+                        std::get<0>(this->alignments[0]));
+        EXPECT_RANGE_EQ(std::get<1>(seqan3::get<seqan3::field::alignment>(*fin.begin())),
+                        std::get<1>(this->alignments[0]));
         EXPECT_EQ(seqan3::get<seqan3::field::tags>(*fin.begin()).size(), 0u); // redundant CG tag is removed
     }
 

--- a/test/unit/io/record_test.cpp
+++ b/test/unit/io/record_test.cpp
@@ -15,10 +15,22 @@
 #include <seqan3/io/detail/record.hpp>
 #include <seqan3/core/concept/tuple.hpp>
 #include <seqan3/std/algorithm>
+#include <seqan3/test/expect_range_eq.hpp>
 
 using seqan3::operator""_dna4;
 
 using default_fields = seqan3::fields<seqan3::field::seq, seqan3::field::id, seqan3::field::qual>;
+
+// This is needed for EXPECT_RANGE_EQ:
+namespace seqan3
+{
+template <typename char_t>
+inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & stream, field f)
+{
+    stream << "<field: " << static_cast<size_t>(f) << ">";
+    return stream;
+}
+} // namespace seqan3
 
 // ----------------------------------------------------------------------------
 // fields
@@ -28,7 +40,7 @@ TEST(fields, usage)
 {
     std::array comp{seqan3::field::seq, seqan3::field::id, seqan3::field::qual};
 
-    EXPECT_TRUE(std::ranges::equal(default_fields::as_array, comp));
+    EXPECT_RANGE_EQ(default_fields::as_array, comp);
     EXPECT_TRUE(default_fields::contains(seqan3::field::seq));
     EXPECT_TRUE(default_fields::contains(seqan3::field::id));
     EXPECT_TRUE(default_fields::contains(seqan3::field::qual));
@@ -73,7 +85,7 @@ TEST_F(record_, get_by_index)
     record_type r{"MY ID", "ACGT"_dna4};
 
     EXPECT_EQ(std::get<0>(r), "MY ID");
-    EXPECT_TRUE(std::ranges::equal(std::get<1>(r), "ACGT"_dna4));
+    EXPECT_RANGE_EQ(std::get<1>(r), "ACGT"_dna4);
 }
 
 TEST_F(record_, get_by_type)
@@ -81,7 +93,7 @@ TEST_F(record_, get_by_type)
     record_type r{"MY ID", "ACGT"_dna4};
 
     EXPECT_EQ(std::get<std::string>(r), "MY ID");
-    EXPECT_TRUE(std::ranges::equal(std::get<seqan3::dna4_vector>(r), "ACGT"_dna4));
+    EXPECT_RANGE_EQ(std::get<seqan3::dna4_vector>(r), "ACGT"_dna4);
 }
 
 TEST_F(record_, get_by_field)
@@ -89,7 +101,7 @@ TEST_F(record_, get_by_field)
     record_type r{"MY ID", "ACGT"_dna4};
 
     EXPECT_EQ(seqan3::get<seqan3::field::id>(r), "MY ID");
-    EXPECT_TRUE(std::ranges::equal(seqan3::get<seqan3::field::seq>(r), "ACGT"_dna4));
+    EXPECT_RANGE_EQ(seqan3::get<seqan3::field::seq>(r), "ACGT"_dna4);
 }
 
 // ----------------------------------------------------------------------------

--- a/test/unit/io/structure_file/format_vienna_test.cpp
+++ b/test/unit/io/structure_file/format_vienna_test.cpp
@@ -20,6 +20,7 @@
 #include <seqan3/range/views/convert.hpp>
 #include <seqan3/std/algorithm>
 #include <seqan3/std/iterator>
+#include <seqan3/test/expect_range_eq.hpp>
 
 using seqan3::operator""_rna5;
 using seqan3::operator""_wuss51;
@@ -237,7 +238,7 @@ TEST_F(read_fields, only_seq)
     auto it = fin.begin();
     for (size_t idx = 0ul; idx < expected_seq.size(); ++idx, ++it)
     {
-        EXPECT_TRUE(std::ranges::equal(seqan3::get<seqan3::field::seq>(*it), expected_seq[idx]));
+        EXPECT_RANGE_EQ(seqan3::get<seqan3::field::seq>(*it), expected_seq[idx]);
     }
 }
 
@@ -248,7 +249,7 @@ TEST_F(read_fields, only_id)
     auto it = fin.begin();
     for (size_t idx = 0ul; idx < expected_seq.size(); ++idx, ++it)
     {
-        EXPECT_TRUE(std::ranges::equal(seqan3::get<seqan3::field::id>(*it), expected_id[idx]));
+        EXPECT_RANGE_EQ(seqan3::get<seqan3::field::id>(*it), expected_id[idx]);
     }
 }
 
@@ -259,7 +260,7 @@ TEST_F(read_fields, only_structure)
     auto it = fin.begin();
     for (size_t idx = 0ul; idx < expected_seq.size(); ++idx, ++it)
     {
-        EXPECT_TRUE(std::ranges::equal(seqan3::get<seqan3::field::structure>(*it), expected_structure[idx]));
+        EXPECT_RANGE_EQ(seqan3::get<seqan3::field::structure>(*it), expected_structure[idx]);
     }
 }
 
@@ -282,12 +283,10 @@ TEST_F(read_fields, structured_seq)
     auto it = fin.begin();
     for (size_t idx = 0ul; idx < expected_seq.size(); ++idx, ++it)
     {
-        EXPECT_TRUE(std::ranges::equal(seqan3::get<seqan3::field::structured_seq>(*it)
-                                       | seqan3::views::convert<seqan3::rna5>,
-                                       expected_seq[idx]));
-        EXPECT_TRUE(std::ranges::equal(seqan3::get<seqan3::field::structured_seq>(*it)
-                                       | seqan3::views::convert<seqan3::wuss<51>>,
-                                       expected_structure[idx]));
+        EXPECT_RANGE_EQ(seqan3::get<seqan3::field::structured_seq>(*it) | seqan3::views::convert<seqan3::rna5>,
+                        expected_seq[idx]);
+        EXPECT_RANGE_EQ(seqan3::get<seqan3::field::structured_seq>(*it) | seqan3::views::convert<seqan3::wuss<51>>,
+                        expected_structure[idx]);
     }
 }
 

--- a/test/unit/range/container/container_of_container_test.cpp
+++ b/test/unit/range/container/container_of_container_test.cpp
@@ -13,6 +13,7 @@
 #include <seqan3/range/container/bitcompressed_vector.hpp>
 #include <seqan3/range/container/concatenated_sequences.hpp>
 #include <seqan3/test/cereal.hpp>
+#include <seqan3/test/expect_range_eq.hpp>
 #include <seqan3/test/pretty_printing.hpp>
 
 using seqan3::operator""_dna4;
@@ -100,16 +101,16 @@ TYPED_TEST(container_of_container, iterators)
     TypeParam const t2{"ACGT"_dna4, "ACGT"_dna4, "GAGGA"_dna4};
 
     // begin
-    EXPECT_TRUE(std::ranges::equal(*t1.begin(),  "ACGT"_dna4));
-    EXPECT_TRUE(std::ranges::equal(*t1.cbegin(), "ACGT"_dna4));
-    EXPECT_TRUE(std::ranges::equal(*t2.begin(),  "ACGT"_dna4));
-    EXPECT_TRUE(std::ranges::equal(*t2.cbegin(), "ACGT"_dna4));
+    EXPECT_RANGE_EQ(*t1.begin(),  "ACGT"_dna4);
+    EXPECT_RANGE_EQ(*t1.cbegin(), "ACGT"_dna4);
+    EXPECT_RANGE_EQ(*t2.begin(),  "ACGT"_dna4);
+    EXPECT_RANGE_EQ(*t2.cbegin(), "ACGT"_dna4);
 
     // end and arithmetic
-    EXPECT_TRUE(std::ranges::equal(*(t1.end()  - 1), "GAGGA"_dna4));
-    EXPECT_TRUE(std::ranges::equal(*(t1.cend() - 1), "GAGGA"_dna4));
-    EXPECT_TRUE(std::ranges::equal(*(t2.end()  - 1), "GAGGA"_dna4));
-    EXPECT_TRUE(std::ranges::equal(*(t2.cend() - 1), "GAGGA"_dna4));
+    EXPECT_RANGE_EQ(*(t1.end()  - 1), "GAGGA"_dna4);
+    EXPECT_RANGE_EQ(*(t1.cend() - 1), "GAGGA"_dna4);
+    EXPECT_RANGE_EQ(*(t2.end()  - 1), "GAGGA"_dna4);
+    EXPECT_RANGE_EQ(*(t2.cend() - 1), "GAGGA"_dna4);
 
     // convertibility between const and non-const
     EXPECT_TRUE(t1.cend() == t1.end());
@@ -125,28 +126,28 @@ TYPED_TEST(container_of_container, element_access)
     TypeParam const t2{"ACGT"_dna4, "ACGT"_dna4, "GAGGA"_dna4};
 
     // at
-    EXPECT_TRUE(std::ranges::equal(t1.at(0), "ACGT"_dna4));
-    EXPECT_TRUE(std::ranges::equal(t2.at(0), "ACGT"_dna4));
+    EXPECT_RANGE_EQ(t1.at(0), "ACGT"_dna4);
+    EXPECT_RANGE_EQ(t2.at(0), "ACGT"_dna4);
     //TODO once we have throwing assert, check at's ability to throw
 
     // []
-    EXPECT_TRUE(std::ranges::equal(t1[0], "ACGT"_dna4));
-    EXPECT_TRUE(std::ranges::equal(t2[0], "ACGT"_dna4));
+    EXPECT_RANGE_EQ(t1[0], "ACGT"_dna4);
+    EXPECT_RANGE_EQ(t2[0], "ACGT"_dna4);
 
     // front
-    EXPECT_TRUE(std::ranges::equal(t1.front(), "ACGT"_dna4));
-    EXPECT_TRUE(std::ranges::equal(t2.front(), "ACGT"_dna4));
+    EXPECT_RANGE_EQ(t1.front(), "ACGT"_dna4);
+    EXPECT_RANGE_EQ(t2.front(), "ACGT"_dna4);
 
     // back
-    EXPECT_TRUE(std::ranges::equal(t1.back(), "GAGGA"_dna4));
-    EXPECT_TRUE(std::ranges::equal(t2.back(), "GAGGA"_dna4));
+    EXPECT_RANGE_EQ(t1.back(), "GAGGA"_dna4);
+    EXPECT_RANGE_EQ(t2.back(), "GAGGA"_dna4);
 
     if constexpr (std::is_same_v<TypeParam, seqan3::concatenated_sequences<std::vector<seqan3::dna4>>>)
     {
         using size_type = typename TypeParam::size_type;
         // concat
-        EXPECT_TRUE(std::ranges::equal(t1.concat(), "ACGTACGTGAGGA"_dna4));
-        EXPECT_TRUE(std::ranges::equal(t2.concat(), "ACGTACGTGAGGA"_dna4));
+        EXPECT_RANGE_EQ(t1.concat(), "ACGTACGTGAGGA"_dna4);
+        EXPECT_RANGE_EQ(t2.concat(), "ACGTACGTGAGGA"_dna4);
 
         // data
         EXPECT_EQ(std::get<0>(t1.raw_data()), "ACGTACGTGAGGA"_dna4);

--- a/test/unit/range/views/view_async_input_buffer_test.cpp
+++ b/test/unit/range/views/view_async_input_buffer_test.cpp
@@ -17,6 +17,7 @@
 #include <seqan3/range/views/single_pass_input.hpp>
 #include <seqan3/range/views/take.hpp>
 #include <seqan3/std/ranges>
+#include <seqan3/test/expect_range_eq.hpp>
 
 #include "../iterator_test_template.hpp"
 
@@ -45,7 +46,7 @@ TEST(async_input_buffer, in_out)
 
     auto v = vec | seqan3::views::async_input_buffer(3);
 
-    EXPECT_TRUE(std::ranges::equal(vec, v));
+    EXPECT_RANGE_EQ(vec, v);
 }
 
 TEST(async_input_buffer, in_out_empty)
@@ -70,7 +71,7 @@ TEST(async_input_buffer, buffer_size_huge)
 
     auto v = vec | seqan3::views::async_input_buffer(100000);
 
-    EXPECT_TRUE(std::ranges::equal(vec, v));
+    EXPECT_RANGE_EQ(vec, v);
 }
 
 TEST(async_input_buffer, destruct_with_full_buffer)
@@ -106,7 +107,7 @@ TEST(async_input_buffer, combinability)
 
     auto v = vec | adapt;
 
-    EXPECT_TRUE(std::ranges::equal(cmp, v));
+    EXPECT_RANGE_EQ(cmp, v);
 }
 
 TEST(async_input_buffer, concepts)

--- a/test/unit/range/views/view_enforce_random_access_test.cpp
+++ b/test/unit/range/views/view_enforce_random_access_test.cpp
@@ -13,6 +13,7 @@
 #include <seqan3/range/views/to_char.hpp>
 #include <seqan3/std/algorithm>
 #include <seqan3/std/ranges>
+#include <seqan3/test/expect_range_eq.hpp>
 
 #include "../iterator_test_template.hpp"
 
@@ -168,15 +169,15 @@ TYPED_TEST(enforce_random_access_test, adaptor)
 
     // pipe notation
     auto v = test_range | seqan3::views::enforce_random_access;
-    EXPECT_TRUE(std::ranges::equal(v, source));
+    EXPECT_RANGE_EQ(v, source);
 
     // function notation
     auto v2 = seqan3::views::enforce_random_access(test_range);
-    EXPECT_TRUE(std::ranges::equal(v2, source));
+    EXPECT_RANGE_EQ(v2, source);
 
     // combinability
     auto v3 = test_range | seqan3::views::enforce_random_access | std::views::drop(1);
-    EXPECT_TRUE(std::ranges::equal(v3, std::vector{1, 2, 3}));
+    EXPECT_RANGE_EQ(v3, (std::vector{1, 2, 3}));
 }
 
 // ----------------------------------------------------------------------------

--- a/test/unit/range/views/view_istreambuf_test.cpp
+++ b/test/unit/range/views/view_istreambuf_test.cpp
@@ -18,6 +18,7 @@
 #include <seqan3/range/views/istreambuf.hpp>
 #include <seqan3/range/views/take_until.hpp>
 #include <seqan3/range/views/to.hpp>
+#include <seqan3/test/expect_range_eq.hpp>
 #include <seqan3/test/tmp_filename.hpp>
 
 #include "../iterator_test_template.hpp"
@@ -68,7 +69,7 @@ TEST(view_istreambuf, basic)
     is.seekg(0, std::ios::beg);
     auto v3 = seqan3::views::istreambuf(is) | seqan3::views::char_to<seqan3::dna5> | seqan3::views::complement;
     std::vector<seqan3::dna5> comp{"TGCATATATATANTATATANAATNNNTATATT"_dna5};
-    EXPECT_TRUE(std::ranges::equal(v3, comp));
+    EXPECT_RANGE_EQ(v3, comp);
 
     // combinability 2
     is.clear();
@@ -76,7 +77,7 @@ TEST(view_istreambuf, basic)
     auto v4 = seqan3::views::istreambuf(is) | seqan3::views::take_until(seqan3::is_space);
     std::string out2 = v4 | seqan3::views::to<std::string>;
     std::string comp2 = "ACGTATATATAT";
-    EXPECT_TRUE(std::ranges::equal(out2, comp2));
+    EXPECT_RANGE_EQ(out2, comp2);
 }
 
 TEST(view_istreambuf, concepts)
@@ -110,8 +111,8 @@ TEST(view_istreambuf, big_file_stram)
     auto v = seqan3::views::istreambuf(istream);
     while (v.begin() != v.end())
     {
-        EXPECT_TRUE(std::ranges::equal(v | seqan3::views::take_until_or_throw_and_consume(seqan3::is_char<'\n'>),
-                                       std::string_view{"halloballo"}));
+        EXPECT_RANGE_EQ(v | seqan3::views::take_until_or_throw_and_consume(seqan3::is_char<'\n'>),
+                        std::string_view{"halloballo"});
     }
 
 }

--- a/test/unit/range/views/view_repeat_n_test.cpp
+++ b/test/unit/range/views/view_repeat_n_test.cpp
@@ -14,6 +14,7 @@
 #include <seqan3/range/views/take.hpp>
 #include <seqan3/std/algorithm>
 #include <seqan3/std/ranges>
+#include <seqan3/test/expect_range_eq.hpp>
 
 TEST(general, construction)
 {
@@ -62,7 +63,7 @@ TEST(view, factory)
         char const chr{'X'};
         auto v = seqan3::views::repeat_n(chr, 3);
         EXPECT_EQ(v.size(), 3u);
-        EXPECT_TRUE(std::ranges::equal(v, std::vector<char>{chr, chr, chr}));
+        EXPECT_RANGE_EQ(v, (std::vector<char>{chr, chr, chr}));
     }
 
     // string
@@ -78,14 +79,14 @@ TEST(view, factory)
     {
         auto view = std::string{"foobar"} | seqan3::views::persist | std::views::take(3);
         auto v = seqan3::views::repeat_n(view, 5);
-        EXPECT_TRUE(std::ranges::equal(*v.begin(), std::string{"foo"}));
+        EXPECT_RANGE_EQ(*v.begin(), std::string{"foo"});
     }
 
     // combinability
     {
         std::string str{"foobar"};
         auto v = seqan3::views::repeat_n(str, 2) | std::views::transform([] (auto & str) { return str.substr(3); });
-        EXPECT_TRUE(std::ranges::equal(v, std::vector<std::string>{"bar", "bar"}));
+        EXPECT_RANGE_EQ(v, (std::vector<std::string>{"bar", "bar"}));
     }
 }
 

--- a/test/unit/range/views/view_repeat_test.cpp
+++ b/test/unit/range/views/view_repeat_test.cpp
@@ -15,6 +15,7 @@
 #include <seqan3/range/views/take_exactly.hpp>
 #include <seqan3/std/algorithm>
 #include <seqan3/std/ranges>
+#include <seqan3/test/expect_range_eq.hpp>
 
 TEST(general, construction)
 {
@@ -143,7 +144,7 @@ TEST(view, factory)
     {
         auto view = std::string{"foobar"} | seqan3::views::persist | std::views::take(3);
         auto v = seqan3::views::repeat(view);
-        EXPECT_TRUE(std::ranges::equal(*v.begin(), view));
+        EXPECT_RANGE_EQ(*v.begin(), view);
     }
 
     // combinability

--- a/test/unit/range/views/view_take_test.cpp
+++ b/test/unit/range/views/view_take_test.cpp
@@ -24,6 +24,7 @@
 #include <seqan3/std/algorithm>
 #include <seqan3/std/concepts>
 #include <seqan3/std/ranges>
+#include <seqan3/test/expect_range_eq.hpp>
 
 // ============================================================================
 //  test templates
@@ -51,7 +52,7 @@ void do_test(adaptor_t const & adaptor, std::string const & vec)
     EXPECT_EQ("rab", v3b);
 
     // comparability against self
-    EXPECT_TRUE(std::ranges::equal(v,v));
+    EXPECT_RANGE_EQ(v, v);
 }
 
 template <typename adaptor_t>

--- a/test/unit/range/views/view_take_until_test.cpp
+++ b/test/unit/range/views/view_take_until_test.cpp
@@ -17,6 +17,7 @@
 #include <seqan3/std/algorithm>
 #include <seqan3/std/ranges>
 #include <seqan3/std/span>
+#include <seqan3/test/expect_range_eq.hpp>
 
 // ============================================================================
 //  test templates
@@ -45,7 +46,7 @@ void do_test(adaptor_t const & adaptor, fun_t && fun, std::string const & vec)
     EXPECT_EQ("foo", v4 | seqan3::views::to<std::string>);
 
     // comparability against self
-    EXPECT_TRUE(std::ranges::equal(v,v));
+    EXPECT_RANGE_EQ(v, v);
 }
 
 template <typename adaptor_t>

--- a/test/unit/range/views/view_translate_join_test.cpp
+++ b/test/unit/range/views/view_translate_join_test.cpp
@@ -19,6 +19,7 @@
 #include <seqan3/range/views/complement.hpp>
 #include <seqan3/range/views/to.hpp>
 #include <seqan3/range/views/translate_join.hpp>
+#include <seqan3/test/expect_range_eq.hpp>
 
 #include "../iterator_test_template.hpp"
 
@@ -43,7 +44,7 @@ struct iterator_fixture<iterator_type> : public ::testing::Test
     template <typename A, typename B>
     static void expect_eq(A && test_range_value, B && expected_range_value)
     {
-        EXPECT_TRUE(std::ranges::equal(test_range_value, expected_range_value));
+        EXPECT_RANGE_EQ(test_range_value, expected_range_value);
     }
 };
 

--- a/test/unit/search/fm_index_cursor/bi_fm_index_cursor_collection_test_template.hpp
+++ b/test/unit/search/fm_index_cursor/bi_fm_index_cursor_collection_test_template.hpp
@@ -11,6 +11,7 @@
 #include <seqan3/range/views/slice.hpp>
 #include <seqan3/search/fm_index/bi_fm_index_cursor.hpp>
 #include <seqan3/std/algorithm>
+#include <seqan3/test/expect_range_eq.hpp>
 
 #include "../helper.hpp"
 
@@ -162,7 +163,7 @@ TYPED_TEST_P(bi_fm_index_cursor_collection_test, to_fwd_cursor)
         auto fwd_it = it.to_fwd_cursor();
         EXPECT_TRUE(fwd_it.cycle_back()); // "GTAGG"
         EXPECT_EQ(seqan3::uniquify(fwd_it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 3}}));
-        EXPECT_TRUE(std::ranges::equal(fwd_it.path_label(this->text_col4), seqan3::views::slice(this->text, 3, 8)));
+        EXPECT_RANGE_EQ(fwd_it.path_label(this->text_col4), seqan3::views::slice(this->text, 3, 8));
         EXPECT_FALSE(fwd_it.cycle_back());
     }
 
@@ -177,12 +178,10 @@ TYPED_TEST_P(bi_fm_index_cursor_collection_test, to_fwd_cursor)
     #endif
         EXPECT_TRUE(fwd_it.extend_right());
         EXPECT_EQ(seqan3::uniquify(fwd_it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 10}}));
-        EXPECT_TRUE(std::ranges::equal(fwd_it.path_label(this->text_col4),
-                                       seqan3::views::slice(this->text, 10, 15))); // "GTAGC"
+        EXPECT_RANGE_EQ(fwd_it.path_label(this->text_col4), seqan3::views::slice(this->text, 10, 15)); // "GTAGC"
         EXPECT_TRUE(fwd_it.cycle_back());
         EXPECT_EQ(seqan3::uniquify(fwd_it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{0, 3}}));
-        EXPECT_TRUE(std::ranges::equal(fwd_it.path_label(this->text_col4),
-                                       seqan3::views::slice(this->text, 3, 8))); // "GTAGG"
+        EXPECT_RANGE_EQ(fwd_it.path_label(this->text_col4), seqan3::views::slice(this->text, 3, 8)); // "GTAGG"
     }
 }
 
@@ -197,10 +196,10 @@ TYPED_TEST_P(bi_fm_index_cursor_collection_test, to_rev_cursor)
 
         auto rev_it = it.to_rev_cursor(); // text_col4 "CCTAGCATCGT|CGATGCAGGATGGCA"
         EXPECT_EQ(seqan3::uniquify(rev_it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{1, 1}}));
-        EXPECT_TRUE(std::ranges::equal(rev_it.path_label(this->rev_text2), this->pattern3));   //ATGCA
+        EXPECT_RANGE_EQ(rev_it.path_label(this->rev_text2), this->pattern3);   //ATGCA
         EXPECT_TRUE(rev_it.cycle_back()); // "GATGG"
         EXPECT_EQ(seqan3::uniquify(rev_it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{1, 8}}));
-        EXPECT_TRUE(std::ranges::equal(rev_it.path_label(this->rev_text2), this->pattern4));  // "GATGG"
+        EXPECT_RANGE_EQ(rev_it.path_label(this->rev_text2), this->pattern4);  // "GATGG"
         EXPECT_FALSE(rev_it.cycle_back());
     }
 
@@ -215,10 +214,10 @@ TYPED_TEST_P(bi_fm_index_cursor_collection_test, to_rev_cursor)
     #endif
         EXPECT_TRUE(rev_it.extend_right()); // "CGTAG" resp. "GATGC"
         EXPECT_EQ(seqan3::uniquify(rev_it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{1, 1}}));
-        EXPECT_TRUE(std::ranges::equal(rev_it.path_label(this->rev_text2), this->pattern3));  // "GATGC"
+        EXPECT_RANGE_EQ(rev_it.path_label(this->rev_text2), this->pattern3);  // "GATGC"
         EXPECT_TRUE(rev_it.cycle_back()); // "GGTAG" resp. "GATGG"
         EXPECT_EQ(seqan3::uniquify(rev_it.locate()), (std::vector<std::pair<uint64_t, uint64_t>>{{1, 8}}));
-        EXPECT_TRUE(std::ranges::equal(rev_it.path_label(this->rev_text2), this->pattern4));  // "GATGG"
+        EXPECT_RANGE_EQ(rev_it.path_label(this->rev_text2), this->pattern4);  // "GATGG"
     }
 }
 
@@ -240,7 +239,7 @@ TYPED_TEST_P(bi_fm_index_cursor_collection_test, extend_const_char_pointer)
             it1.extend_right(cg);
             it2.extend_right(seqan3::views::slice(this->text1, 1, 3));      // "CG"
 
-            EXPECT_TRUE(std::ranges::equal(it1.locate(), it2.locate()));
+            EXPECT_RANGE_EQ(it1.locate(), it2.locate());
         }
         // extend_left()
         {
@@ -250,7 +249,7 @@ TYPED_TEST_P(bi_fm_index_cursor_collection_test, extend_const_char_pointer)
             it1.extend_left(cg);
             it2.extend_right(seqan3::views::slice(this->text1, 1, 3));      // "CG"
 
-            EXPECT_TRUE(std::ranges::equal(it1.locate(), it2.locate()));
+            EXPECT_RANGE_EQ(it1.locate(), it2.locate());
         }
     }
 }

--- a/test/unit/search/fm_index_cursor/bi_fm_index_cursor_test_template.hpp
+++ b/test/unit/search/fm_index_cursor/bi_fm_index_cursor_test_template.hpp
@@ -11,6 +11,7 @@
 #include <seqan3/range/views/slice.hpp>
 #include <seqan3/search/fm_index/bi_fm_index_cursor.hpp>
 #include <seqan3/std/algorithm>
+#include <seqan3/test/expect_range_eq.hpp>
 
 #include "../helper.hpp"
 
@@ -152,8 +153,7 @@ TYPED_TEST_P(bi_fm_index_cursor_test, to_fwd_cursor)
         auto fwd_it = it.to_fwd_cursor();
         EXPECT_TRUE(fwd_it.cycle_back()); // "GTAGG"
         EXPECT_EQ(seqan3::uniquify(fwd_it.locate()), (std::vector<uint64_t>{3}));
-        EXPECT_TRUE(std::ranges::equal(fwd_it.path_label(this->text),
-                                       seqan3::views::slice(this->text, 3, 8))); // "GTAGG"
+        EXPECT_RANGE_EQ(fwd_it.path_label(this->text), seqan3::views::slice(this->text, 3, 8)); // "GTAGG"
         EXPECT_FALSE(fwd_it.cycle_back());
     }
 
@@ -168,12 +168,10 @@ TYPED_TEST_P(bi_fm_index_cursor_test, to_fwd_cursor)
     #endif
         EXPECT_TRUE(fwd_it.extend_right());
         EXPECT_EQ(seqan3::uniquify(fwd_it.locate()), (std::vector<uint64_t>{10}));
-        EXPECT_TRUE(std::ranges::equal(fwd_it.path_label(this->text),
-                                       seqan3::views::slice(this->text, 10, 15)));    // "GTAGC"
+        EXPECT_RANGE_EQ(fwd_it.path_label(this->text), seqan3::views::slice(this->text, 10, 15)); // "GTAGC"
         EXPECT_TRUE(fwd_it.cycle_back());
         EXPECT_EQ(seqan3::uniquify(fwd_it.locate()), (std::vector<uint64_t>{3}));
-        EXPECT_TRUE(std::ranges::equal(fwd_it.path_label(this->text),
-                                       seqan3::views::slice(this->text, 3, 8)));    // "GTAGG"
+        EXPECT_RANGE_EQ(fwd_it.path_label(this->text), seqan3::views::slice(this->text, 3, 8)); // "GTAGG"
     }
 }
 
@@ -189,10 +187,10 @@ TYPED_TEST_P(bi_fm_index_cursor_test, to_rev_cursor)
 
         auto rev_it = it.to_rev_cursor(); // text "CGATGCAGGATGGCA"
         EXPECT_EQ(seqan3::uniquify(rev_it.locate()), (std::vector<uint64_t>{1}));
-        EXPECT_TRUE(std::ranges::equal(rev_it.path_label(this->rev_text1), this->pattern3));    // "GATGC"
+        EXPECT_RANGE_EQ(rev_it.path_label(this->rev_text1), this->pattern3);    // "GATGC"
         EXPECT_TRUE(rev_it.cycle_back()); // "GATGG"
         EXPECT_EQ(seqan3::uniquify(rev_it.locate()), (std::vector<uint64_t>{8}));
-        EXPECT_TRUE(std::ranges::equal(rev_it.path_label(this->rev_text1), this->pattern4));    // "GATGG"
+        EXPECT_RANGE_EQ(rev_it.path_label(this->rev_text1), this->pattern4);    // "GATGG"
         EXPECT_FALSE(rev_it.cycle_back());
     }
 
@@ -207,10 +205,10 @@ TYPED_TEST_P(bi_fm_index_cursor_test, to_rev_cursor)
     #endif
         EXPECT_TRUE(rev_it.extend_right()); // "CGTAG" resp. "GATGC"
         EXPECT_EQ(seqan3::uniquify(rev_it.locate()), (std::vector<uint64_t>{1}));
-        EXPECT_TRUE(std::ranges::equal(rev_it.path_label(this->rev_text1), this->pattern3));    // "GATGC"
+        EXPECT_RANGE_EQ(rev_it.path_label(this->rev_text1), this->pattern3);    // "GATGC"
         EXPECT_TRUE(rev_it.cycle_back()); // "GGTAG" resp. "GATGG"
         EXPECT_EQ(seqan3::uniquify(rev_it.locate()), (std::vector<uint64_t>{8}));
-        EXPECT_TRUE(std::ranges::equal(rev_it.path_label(this->rev_text1), this->pattern4));    // "GATGG"
+        EXPECT_RANGE_EQ(rev_it.path_label(this->rev_text1), this->pattern4);    // "GATGG"
     }
 }
 

--- a/test/unit/test/CMakeLists.txt
+++ b/test/unit/test/CMakeLists.txt
@@ -1,3 +1,4 @@
+seqan3_test(expect_range_eq_test.cpp)
 seqan3_test(pretty_printing_test.cpp)
 seqan3_test(seqan2_test.cpp)
 seqan3_test(tmp_filename_test.cpp)

--- a/test/unit/test/expect_range_eq_test.cpp
+++ b/test/unit/test/expect_range_eq_test.cpp
@@ -1,0 +1,152 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+#include <gtest/gtest-spi.h> // provides test utility to test google test itself
+
+#include <seqan3/std/span>
+#include <string_view>
+
+#include <seqan3/test/expect_range_eq.hpp>
+
+TEST(expect_range_eq, braces_with_many_commas)
+{
+    std::vector expect{0, 1, 2};
+    EXPECT_RANGE_EQ(expect, std::vector({0, 1, 2}));
+
+    // Note: the macro can't handle the following expression,
+    //     EXPECT_RANGE_EQ(expect, std::vector{0, 1, 2});
+    // because it confuses it with a call with 4 arguments:
+    //     EXPECT_RANGE_EQ("expect", "std::vector{0", "1", "2"});
+
+    // workaround:
+    EXPECT_RANGE_EQ(expect, (std::vector{0, 1, 2}));
+}
+
+TEST(string_view, range_eq_pass)
+{
+    std::vector<char> expect{'H', 'e', 'l', 'l', 'o'};
+    std::string_view result{"Hello"};
+
+    auto && expect_result = seqan3::test::expect_range_eq{}("expect", "result", expect, result);
+    EXPECT_TRUE(expect_result);
+    EXPECT_RANGE_EQ(expect, result);
+}
+
+TEST(string_view, range_eq_fail)
+{
+    char const * error_message = "Expected equality of these values:\n"
+                                 "  expect\n"
+                                 "    Which is: Hel\n"
+                                 "lo\n"
+                                 "  result\n"
+                                 "    Which is: Hello!";
+
+    std::vector<char> expect{'H', 'e', 'l', '\n', 'l', 'o'};
+    std::string_view result{"Hello!"};
+
+    auto && expect_result = seqan3::test::expect_range_eq{}("expect", "result", expect, result);
+
+    EXPECT_FALSE(expect_result);
+    EXPECT_STREQ(error_message, expect_result.message());
+    EXPECT_NONFATAL_FAILURE(EXPECT_RANGE_EQ(expect, result), error_message);
+}
+
+TEST(span, range_eq_pass)
+{
+    std::vector<int> expect{0, 1, 2, 3, 4};
+    std::vector<int> source{-2, -1, 0, 1, 2, 3, 4, 5, 6};
+    std::span result{source.begin() + 2, 5};
+
+    auto && expect_result = seqan3::test::expect_range_eq{}("expect", "result", expect, result);
+    EXPECT_TRUE(expect_result);
+    EXPECT_RANGE_EQ(expect, result);
+}
+
+TEST(span, range_eq_fail)
+{
+    char const * error_message = "Expected equality of these values:\n"
+                                 "  expect\n"
+                                 "    Which is: [0,1,2,3,4]\n"
+                                 "  result\n"
+                                 "    Which is: [-1,0,1,2,3,4,5]";
+
+    std::vector<int> expect{0, 1, 2, 3, 4};
+    std::vector<int> source{-2, -1, 0, 1, 2, 3, 4, 5, 6};
+    std::span result{source.begin() + 1, 7};
+
+    auto && expect_result = seqan3::test::expect_range_eq{}("expect", "result", expect, result);
+
+    EXPECT_FALSE(expect_result);
+    EXPECT_STREQ(error_message, expect_result.message());
+    EXPECT_NONFATAL_FAILURE(EXPECT_RANGE_EQ(expect, result), error_message);
+}
+
+struct input_range
+{
+    static constexpr int values[]{0, 1, 2, 3, 4};
+    int const * current = values;
+    int const * sentinel = values + sizeof(values) / sizeof(int);
+
+    struct iterator
+    {
+        using difference_type = std::ptrdiff_t;
+        using value_type = int;
+
+        input_range * host;
+
+        int const & operator*() const { return *host->current; }
+        iterator & operator++() { ++host->current; return *this; }
+        value_type operator++(int) { value_type x = *(*this); ++*this; return x; }
+        bool operator==(iterator const &) const { return host->current == host->sentinel; }
+        bool operator!=(iterator const & sentinel) const { return !(*this == sentinel);}
+    };
+
+    iterator begin() { return {this}; }
+    iterator end() { return {this}; }
+};
+
+TEST(input_range, range_eq_pass)
+{
+    EXPECT_TRUE(std::ranges::input_range<input_range>);
+
+    std::vector<int> expect{0, 1, 2, 3, 4};
+
+    {
+        input_range result{};
+        auto && expect_result = seqan3::test::expect_range_eq{}("expect", "result", expect, result);
+        EXPECT_TRUE(expect_result);
+    }
+
+    {
+        input_range result{};
+        EXPECT_RANGE_EQ(expect, result);
+    }
+}
+
+TEST(input_range, range_eq_fail)
+{
+    char const * error_message = "Expected equality of these values:\n"
+                                 "  expect\n"
+                                 "    Which is: [0,1,2,3,4,5]\n"
+                                 "  result\n"
+                                 "    Which is: [0,1,2,3,4]";
+
+    std::vector<int> expect{0, 1, 2, 3, 4, 5};
+
+    {
+        input_range result{};
+        auto && expect_result = seqan3::test::expect_range_eq{}("expect", "result", expect, result);
+        EXPECT_FALSE(expect_result);
+        EXPECT_STREQ(error_message, expect_result.message());
+    }
+
+    {
+        input_range result{};
+        EXPECT_NONFATAL_FAILURE(EXPECT_RANGE_EQ(expect, result), error_message);
+    }
+}


### PR DESCRIPTION
Part of seqan/product_backlog#46

Add a new test macro `EXPECT_RANGE_EQ`.

It works for all ranges because we are copying them into std::vectors;
We might want to optimize this for large ranges, because the copy is not necessary if the given range is a forward range.