### PR TITLE
[MISC] Remove debug requirement for score, end_position and begin_position test in pairwise alignment test template.

### DIFF
--- a/test/unit/alignment/pairwise/pairwise_alignment_single_test_template.hpp
+++ b/test/unit/alignment/pairwise/pairwise_alignment_single_test_template.hpp
@@ -34,8 +34,7 @@ TYPED_TEST_SUITE_P(pairwise_alignment_test);
 TYPED_TEST_P(pairwise_alignment_test, score)
 {
     auto const & fixture = this->fixture();
-    seqan3::configuration align_cfg = fixture.config | seqan3::align_cfg::result{seqan3::with_score}
-                                                     | seqan3::align_cfg::debug;
+    seqan3::configuration align_cfg = fixture.config | seqan3::align_cfg::result{seqan3::with_score};
 
     std::vector database = fixture.sequence1;
     std::vector query = fixture.sequence2;
@@ -50,10 +49,8 @@ TYPED_TEST_P(pairwise_alignment_test, back_coordinate)
 {
     auto const & fixture = this->fixture();
 
-    seqan3::configuration align_cfg = fixture.config
-                                    | seqan3::align_cfg::result{seqan3::with_back_coordinate,
-                                                                seqan3::using_score_type<double>}
-                                    | seqan3::align_cfg::debug;
+    seqan3::configuration align_cfg = fixture.config | seqan3::align_cfg::result{seqan3::with_back_coordinate,
+                                                                                 seqan3::using_score_type<double>};
 
     std::vector database = fixture.sequence1;
     std::vector query = fixture.sequence2;
@@ -69,8 +66,7 @@ TYPED_TEST_P(pairwise_alignment_test, back_coordinate)
 TYPED_TEST_P(pairwise_alignment_test, front_coordinate)
 {
     auto const & fixture = this->fixture();
-    seqan3::configuration align_cfg = fixture.config | seqan3::align_cfg::result{seqan3::with_front_coordinate}
-                                                     | seqan3::align_cfg::debug;
+    seqan3::configuration align_cfg = fixture.config | seqan3::align_cfg::result{seqan3::with_front_coordinate};
 
     std::vector database = fixture.sequence1;
     std::vector query = fixture.sequence2;


### PR DESCRIPTION
In the upcoming PRs I will step-by-step the implementation of the alignment algorithm which will run in the expected performance we'd like to see. This will enable the test for this new branch. Also it is redundant to test the trace and score matrix as they are tested once in the traceback test.