### PR TITLE
[FIX] Missing seqan3 namespace identifier in gap_decorator_test.cpp

### DIFF
--- a/test/unit/range/decorator/gap_decorator_test.cpp
+++ b/test/unit/range/decorator/gap_decorator_test.cpp
@@ -21,12 +21,13 @@
 #include "../iterator_test_template.hpp"
 #include "../../alignment/aligned_sequence_test_template.hpp"
 
-using decorator_t = gap_decorator<std::vector<dna4> const &>;
+using decorator_t = seqan3::gap_decorator<std::vector<seqan3::dna4> const &>;
 
-std::vector<dna4> const dummy_obj{}; // dummy lvalue for type declaration of views
-using decorator_t2 = gap_decorator<
+std::vector<seqan3::dna4> const dummy_obj{}; // dummy lvalue for type declaration of views
+using decorator_t2 = seqan3::gap_decorator<
                          decltype(std::ranges::subrange<decltype(dummy_obj.begin()),
-                                                 decltype(dummy_obj.begin())>{dummy_obj.begin(), dummy_obj.end()})>;
+                                                        decltype(dummy_obj.begin())>{dummy_obj.begin(),
+                                                                                     dummy_obj.end()})>;
 
 
 using test_types = ::testing::Types<decorator_t, decorator_t2>;
@@ -36,21 +37,22 @@ using test_types = ::testing::Types<decorator_t, decorator_t2>;
 // ---------------------------------------------------------------------------------------------------------------------
 
 template <typename inner_type_>
-class aligned_sequence_<gap_decorator<inner_type_>> : public ::testing::Test
+class aligned_sequence_<seqan3::gap_decorator<inner_type_>> : public ::testing::Test
 {
 public:
     // Initialiser function is needed for the typed test because the gapped_decorator
-    // will be initialised differently than the naive vector<gapped<dna>>.
-    void initialise_typed_test_container(decorator_t & container_, dna4_vector const & target)
+    // will be initialised differently than the naive vector<seqan3::gapped<seqan3::dna>>.
+    void initialise_typed_test_container(decorator_t & container_, seqan3::dna4_vector const & target)
     {
         container_ = target;
     }
 
     // Initialiser function is needed for the typed test because the gapped_decorator
-    // will be initialised differently than the naive vector<gapped<dna>>.
-    void initialise_typed_test_container(decorator_t2 & container_, dna4_vector const & target)
+    // will be initialised differently than the naive vector<seqan3::gapped<seqan3::dna>>.
+    void initialise_typed_test_container(decorator_t2 & container_, seqan3::dna4_vector const & target)
     {
-        container_ = std::ranges::subrange<decltype(target.begin()), decltype(target.end())>{target.begin(), target.end()};
+        container_ = std::ranges::subrange<decltype(target.begin()),
+                                           decltype(target.end())>{target.begin(), target.end()};
     }
 };
 
@@ -62,7 +64,7 @@ struct iterator_fixture<std::ranges::iterator_t<decorator_t>> : public ::testing
     using iterator_tag = std::bidirectional_iterator_tag;
     static constexpr bool const_iterable = true;
 
-    std::vector<dna4> const vec{"ACTGACTG"_dna4};
+    std::vector<seqan3::dna4> const vec{"ACTGACTG"_dna4};
 
     template <typename t>
     static void initialise_with_gaps(t & v)
@@ -73,9 +75,9 @@ struct iterator_fixture<std::ranges::iterator_t<decorator_t>> : public ::testing
         insert_gap(v, v.begin(), 5);
     }
 
-    std::vector<gapped<dna4>> expected_range = [this] ()
+    std::vector<seqan3::gapped<seqan3::dna4>> expected_range = [this] ()
     {
-        std::vector<gapped<dna4>> tmp{};
+        std::vector<seqan3::gapped<seqan3::dna4>> tmp{};
         assign_unaligned(tmp, vec);
         initialise_with_gaps(tmp);
         return tmp;
@@ -130,7 +132,7 @@ TYPED_TEST(gap_decorator_f, concept_checks)
 
     EXPECT_FALSE((std::ranges::view<TypeParam>));
 
-    EXPECT_TRUE((aligned_sequence<TypeParam>));
+    EXPECT_TRUE((seqan3::aligned_sequence<TypeParam>));
 }
 
 TYPED_TEST(gap_decorator_f, construction_general)
@@ -182,31 +184,31 @@ TYPED_TEST(gap_decorator_f, construction_general)
 TEST(gap_decorator, construction_from_ungapped_sequence)
 {
     {
-        std::vector<dna4> v{"ACTG"_dna4};
-        std::vector<dna4> const v_const{"ACTG"_dna4};
+        std::vector<seqan3::dna4> v{"ACTG"_dna4};
+        std::vector<seqan3::dna4> const v_const{"ACTG"_dna4};
 
         // non-const version
-        gap_decorator dec{v};
+        seqan3::gap_decorator dec{v};
         EXPECT_EQ('A'_dna4, dec[0]);
         EXPECT_EQ('C'_dna4, dec[1]);
 
         // const version
-        gap_decorator const dec2(v_const);
+        seqan3::gap_decorator const dec2(v_const);
         EXPECT_EQ('A'_dna4, dec2[0]);
         EXPECT_EQ('C'_dna4, dec2[1]);
     }
 
     {
-        std::vector<dna4> v{"ACTG"_dna4};
-        std::vector<dna4> const v_const{"ACTG"_dna4};
+        std::vector<seqan3::dna4> v{"ACTG"_dna4};
+        std::vector<seqan3::dna4> const v_const{"ACTG"_dna4};
 
         // non-const version
-        gap_decorator dec = v;
+        seqan3::gap_decorator dec = v;
         EXPECT_EQ('A'_dna4, dec[0]);
         EXPECT_EQ('C'_dna4, dec[1]);
 
         // const version
-        gap_decorator const dec2 = v_const;
+        seqan3::gap_decorator const dec2 = v_const;
         EXPECT_EQ('A'_dna4, dec2[0]);
         EXPECT_EQ('C'_dna4, dec2[1]);
     }
@@ -215,11 +217,11 @@ TEST(gap_decorator, construction_from_ungapped_sequence)
 TEST(gap_decorator, assignment_from_ungapped_sequence)
 {
     {
-        std::vector<dna4> v{"TT"_dna4};
-        std::vector<dna4> v2{"ACTG"_dna4};
-        std::vector<dna4> const v_const{"TGCC"_dna4};
+        std::vector<seqan3::dna4> v{"TT"_dna4};
+        std::vector<seqan3::dna4> v2{"ACTG"_dna4};
+        std::vector<seqan3::dna4> const v_const{"TGCC"_dna4};
 
-        gap_decorator dec{v};
+        seqan3::gap_decorator dec{v};
         dec = v2;
         EXPECT_EQ('A'_dna4, dec[0]);
         EXPECT_EQ('C'_dna4, dec[1]);
@@ -242,10 +244,10 @@ TEST(gap_decorator, assignment_from_ungapped_sequence)
 
 TEST(gap_decorator, comparison)
 {
-    std::vector<dna4> v{"ACTG"_dna4};
+    std::vector<seqan3::dna4> v{"ACTG"_dna4};
 
-    gap_decorator dec{v};
-    gap_decorator dec2{v};
+    seqan3::gap_decorator dec{v};
+    seqan3::gap_decorator dec2{v};
 
     EXPECT_EQ(dec, dec2);
     EXPECT_LE(dec, dec2);
@@ -268,17 +270,17 @@ TEST(gap_decorator, comparison)
     EXPECT_LT(dec, dec2);
     EXPECT_LE(dec, dec2);
 
-    std::vector<dna4> v2{"TCTG"_dna4};
-    gap_decorator decNE{v2};
+    std::vector<seqan3::dna4> v2{"TCTG"_dna4};
+    seqan3::gap_decorator decNE{v2};
     EXPECT_NE(dec, decNE);
 }
 
 TEST(gap_decorator, begin_and_end)
 {
-    std::vector<dna4> v{"ACTG"_dna4};
+    std::vector<seqan3::dna4> v{"ACTG"_dna4};
 
-    gap_decorator dec{v};
-    gap_decorator const dec_const{v};
+    seqan3::gap_decorator dec{v};
+    seqan3::gap_decorator const dec_const{v};
 
     EXPECT_EQ(*dec.begin(), 'A'_dna4);
     EXPECT_EQ(*dec.cbegin(), 'A'_dna4);
@@ -291,10 +293,10 @@ TEST(gap_decorator, begin_and_end)
 
 TEST(gap_decorator, decorator_on_views)
 {
-    std::vector<dna4> v{"ACTG"_dna4};
+    std::vector<seqan3::dna4> v{"ACTG"_dna4};
 
     auto sub = std::ranges::subrange<decltype(v.begin()), decltype(v.begin())>{v.begin()+1, v.begin()+3};
-    gap_decorator dec{sub};
+    seqan3::gap_decorator dec{sub};
 
     EXPECT_EQ(dec.size(), 2u);
     EXPECT_EQ(*dec.begin(), 'C'_dna4);
@@ -304,16 +306,16 @@ TEST(gap_decorator, decorator_on_views)
 
     EXPECT_EQ(dec.size(), 4u);
     EXPECT_EQ(*dec.begin(), 'C'_dna4);
-    EXPECT_EQ(*(std::next(dec.begin(), 1)), gap{});
-    EXPECT_EQ(*it, gap{});
+    EXPECT_EQ(*(std::next(dec.begin(), 1)), seqan3::gap{});
+    EXPECT_EQ(*it, seqan3::gap{});
 
     // auto v_char = v | seqan3::views::to_char;
-    gap_decorator dec2{v | seqan3::views::to_char};
+    seqan3::gap_decorator dec2{v | seqan3::views::to_char};
     EXPECT_EQ(dec2.size(), 4u);
     EXPECT_EQ(*dec2.begin(), 'A');
     EXPECT_EQ(*++dec2.begin(), 'C');
 
-    auto dec3 = dec | std::views::filter([] (auto chr) { return chr != gap{}; });
+    auto dec3 = dec | std::views::filter([] (auto chr) { return chr != seqan3::gap{}; });
     EXPECT_EQ(*dec3.begin(), 'C'_dna4);
     EXPECT_EQ(*(std::next(dec3.begin())), 'T'_dna4);
 }


### PR DESCRIPTION
Something appears to have gone wrong in the removal of  `using namespace seqan3` from `test/unit/range/gap_decorator_test.cpp`. The seqan3 namespace identifier were missing. This PR adds them.


Edit (@eseiler):
The `gap_decorator_test` has `#include "../../alignment/aligned_sequence_test_template.hpp"`, this file had an `using namespace seqan3;`. 
So in the `unit/range` PR (#1766) , the gap_decorator` still worked because it had an `using namespace` in an include. 
With the `unit/alignment` PR (#1749) this was removed, but because the latter PR (#1766) was not rebased on master, the error did not occur in the PR but the following master branch build