### PR TITLE
[MISC] Remove specific alignment constraints from execution handler.

### DIFF
--- a/include/seqan3/alignment/pairwise/execution/execution_handler_parallel.hpp
+++ b/include/seqan3/alignment/pairwise/execution/execution_handler_parallel.hpp
@@ -99,15 +99,14 @@ public:
 
     /*!\brief Takes underlying range of sequence pairs and invokes an alignment on each instance.
      * \tparam algorithm_t              The type of the alignment algorithm.
-     * \tparam indexed_sequence_pairs_t The type of underlying sequence pairs annotated with an index;
-     *                                  must model seqan3::detail::indexed_sequence_pair_range.
+     * \tparam indexed_sequence_pairs_t The type of underlying sequence pairs annotated with an index.
      * \tparam delegate_type            The type of the callable invoked on the std::invoke_result of `algorithm_t`.
      *
      * \param[in] algorithm              The alignment algorithm to invoke.
      * \param[in] indexed_sequence_pairs The range of underlying annotated sequence pairs to be aligned.
      * \param[in] delegate               A callable which will be invoked on each result of the computed alignments.
      */
-    template <typename algorithm_t, indexed_sequence_pair_range indexed_sequence_pairs_t, typename delegate_type>
+    template <typename algorithm_t, typename indexed_sequence_pairs_t, typename delegate_type>
     void execute(algorithm_t && algorithm,
                  indexed_sequence_pairs_t indexed_sequence_pairs,
                  delegate_type && delegate)

--- a/include/seqan3/alignment/pairwise/execution/execution_handler_sequential.hpp
+++ b/include/seqan3/alignment/pairwise/execution/execution_handler_sequential.hpp
@@ -32,15 +32,14 @@ public:
 
     /*!\brief Takes underlying range of sequence pairs and invokes an alignment on each instance.
      * \tparam algorithm_t              The type of the alignment algorithm.
-     * \tparam indexed_sequence_pairs_t The type of underlying sequence pairs annotated with an index;
-     *                                  must model seqan3::detail::indexed_sequence_pair_range.
+     * \tparam indexed_sequence_pairs_t The type of underlying sequence pairs annotated with an index.
      * \tparam delegate_type            The type of the callable invoked on the std::invoke_result of `algorithm_t`.
      *
      * \param[in] algorithm              The alignment algorithm to invoke.
      * \param[in] indexed_sequence_pairs The range of underlying annotated sequence pairs to be aligned.
      * \param[in] delegate               A callable which will be invoked on each result of the computed alignments.
      */
-    template <typename algorithm_t, indexed_sequence_pair_range indexed_sequence_pairs_t, typename delegate_type>
+    template <typename algorithm_t, typename indexed_sequence_pairs_t, typename delegate_type>
     void execute(algorithm_t && algorithm,
                  indexed_sequence_pairs_t && indexed_sequence_pairs,
                  delegate_type && delegate)


### PR DESCRIPTION
As one step towards an uniform execution design for different algorithms this commit removes the constraints on the sequence types that need to be passed to the alignment, because other algorithms might have different requirements on this type.