### PR TITLE
[MISC] replace seqan3::size_type_t with std::ranges::range_size_t

### DIFF
--- a/include/seqan3/range/container/bitcompressed_vector.hpp
+++ b/include/seqan3/range/container/bitcompressed_vector.hpp
@@ -143,7 +143,7 @@ public:
     //!\brief A signed integer type (usually std::ptrdiff_t)
     using difference_type   = std::ranges::range_difference_t<data_type>;
     //!\brief An unsigned integer type (usually std::size_t)
-    using size_type         = size_type_t<data_type>;
+    using size_type         = std::ranges::range_size_t<data_type>;
     //!\}
 
     //!\cond

--- a/include/seqan3/range/container/concatenated_sequences.hpp
+++ b/include/seqan3/range/container/concatenated_sequences.hpp
@@ -127,7 +127,7 @@ template <typename inner_type,
 //!\cond
     requires reservible_container<std::remove_reference_t<inner_type>> &&
              reservible_container<std::remove_reference_t<data_delimiters_type>> &&
-             std::is_same_v<size_type_t<inner_type>, value_type_t<data_delimiters_type>>
+             std::is_same_v<std::ranges::range_size_t<inner_type>, value_type_t<data_delimiters_type>>
 //!\endcond
 class concatenated_sequences
 {
@@ -169,7 +169,7 @@ public:
 
     //!\brief An unsigned integer type (usually std::size_t)
     //!\hideinitializer
-    using size_type = size_type_t<data_delimiters_type>;
+    using size_type = std::ranges::range_size_t<data_delimiters_type>;
     //!\}
 
     //!\cond

--- a/include/seqan3/range/decorator/gap_decorator.hpp
+++ b/include/seqan3/range/decorator/gap_decorator.hpp
@@ -108,7 +108,7 @@ public:
     //!       be modified.
     using const_reference = reference;
     //!\brief The size_type of the underlying sequence.
-    using size_type = size_type_t<inner_type>;
+    using size_type = std::ranges::range_size_t<inner_type>;
     //!\brief The difference type of the underlying sequence.
     using difference_type = std::ranges::range_difference_t<inner_type>;
     //!\}

--- a/include/seqan3/range/views/interleave.hpp
+++ b/include/seqan3/range/views/interleave.hpp
@@ -75,7 +75,7 @@ public:
     //!\brief The value_type (which equals the reference_type with any references removed).
     using value_type        = std::ranges::range_value_t<urng_t>;
     //!\brief This resolves to range_type::size_type as the underlying range is guaranteed to be Sized.
-    using size_type         = size_type_t<urng_t>;
+    using size_type         = std::ranges::range_size_t<urng_t>;
     //!\brief A signed integer type, usually std::ptrdiff_t.
     using difference_type   = std::ranges::range_difference_t<urng_t>;
     //!\brief The iterator type of this view (a random access iterator).

--- a/include/seqan3/range/views/translate.hpp
+++ b/include/seqan3/range/views/translate.hpp
@@ -176,7 +176,7 @@ public:
     //!\brief The value_type (which equals the reference_type with any references removed).
     using value_type        = aa27;
     //!\brief The size_type.
-    using size_type         = size_type_t<urng_t>;
+    using size_type         = std::ranges::range_size_t<urng_t>;
     //!\brief A signed integer type, usually std::ptrdiff_t.
     using difference_type   = std::ranges::range_difference_t<urng_t>;
     //!\brief The iterator type of this view (a random access iterator).
@@ -547,7 +547,7 @@ public:
     //!\brief The value_type (which equals the reference_type with any references removed).
     using value_type        = reference;
     //!\brief The size_type.
-    using size_type         = size_type_t<urng_t>;
+    using size_type         = std::ranges::range_size_t<urng_t>;
     //!\brief A signed integer type, usually std::ptrdiff_t.
     using difference_type   = std::ranges::range_difference_t<urng_t>;
     //!\brief The iterator type of this view (a random access iterator).

--- a/include/seqan3/range/views/translate_join.hpp
+++ b/include/seqan3/range/views/translate_join.hpp
@@ -63,7 +63,7 @@ protected:
     //!\brief The value_type (which equals the reference_type with any references removed).
     using value_type        = reference;
     //!\brief The size_type.
-    using size_type         = size_type_t<std::ranges::range_reference_t<urng_t>>;
+    using size_type         = std::ranges::range_size_t<std::ranges::range_reference_t<urng_t>>;
     //!\brief A signed integer type, usually std::ptrdiff_t.
     using difference_type   = std::ranges::range_difference_t<std::ranges::range_reference_t<urng_t>>;
     //!\brief The iterator type of this view (a random access iterator).

--- a/include/seqan3/std/ranges
+++ b/include/seqan3/std/ranges
@@ -62,6 +62,7 @@ namespace std::ranges
 namespace
 {
 
+using ::ranges::range_size_t;
 using namespace ::ranges::cpp20;
 
 } // anonymous namespace

--- a/test/snippet/core/type_traits/lazy.cpp
+++ b/test/snippet/core/type_traits/lazy.cpp
@@ -10,14 +10,14 @@ void foobar(rng_t && range)
 
 #if 0
     // The following would fail to compile if rng_t is not sized,
-    // because size_type_t<rngt_t> needs to be valid
+    // because std::ranges::range_size_t<rngt_t> needs to be valid
     // (independent of whether the condition evaluates to true)
     using size_type = std::conditional_t<std::ranges::sized_range<rng_t>,
-                                         seqan3::size_type_t<rng_t>,
+                                         std::ranges::range_size_t<rng_t>,
                                          void>;
 #endif
 
-    // This delays instantiation of size_type_t<rngt_t> until after the
+    // This delays instantiation of std::ranges::range_size_t<rngt_t> until after the
     // conditional-decision is made:
     using size_type = seqan3::detail::lazy_conditional_t<std::ranges::sized_range<rng_t>,
                                                          seqan3::detail::lazy<seqan3::size_type_t, rng_t>,

--- a/test/unit/core/type_traits/range_iterator_test.cpp
+++ b/test/unit/core/type_traits/range_iterator_test.cpp
@@ -192,14 +192,12 @@ TEST(range_and_iterator, size_type_)
     //TODO(h-2): add something that actually has a different size_type
 // iota is not a sized range, but take_exactly is
     auto v = std::views::iota(0) | seqan3::views::take_exactly(2);
-    using type_list_example = seqan3::type_list<seqan3::size_type_t<std::vector<int>>, // short
-                                                typename seqan3::size_type<std::vector<int>>::type, // long
+    using type_list_example = seqan3::type_list<std::ranges::range_size_t<std::vector<int>>, // short
                                                 typename std::vector<int>::size_type, // member type
-                                                seqan3::size_type_t<std::vector<int> const>, // const container
-                                                seqan3::size_type_t<decltype(v)>>; // range, no member
+                                                std::ranges::range_size_t<std::vector<int> const>, // const container
+                                                std::ranges::range_size_t<decltype(v)>>; // range, no member
 
     using comp_list = seqan3::type_list<size_t,
-                                        size_t,
                                         size_t,
                                         size_t,
                                         size_t>;


### PR DESCRIPTION
Resolves part of #1549

Replaces occurrences of `seqan3::size_type_t` with `std::ranges::range_size_t` as part of the deprecation of `type_traits/iterator.hpp`