### PR TITLE
[FEATURE] Generalise the two way executor for other algorithms.

### DIFF
--- a/include/seqan3/alignment/pairwise/align_pairwise.hpp
+++ b/include/seqan3/alignment/pairwise/align_pairwise.hpp
@@ -176,11 +176,14 @@ constexpr auto align_pairwise(sequence_t && sequences,
     };
 
     using alignment_result_t = typename traits_t::alignment_result_type;
+
+    auto indexed_sequence_chunk_view = views::zip(seq_view, std::views::iota(0))
+                                     | views::chunk(traits_t::alignments_per_vector);
+
     // Create a two-way executor for the alignment.
-    detail::alignment_executor_two_way executor{std::move(seq_view),
+    detail::alignment_executor_two_way executor{indexed_sequence_chunk_view,
                                                 std::move(algorithm),
                                                 alignment_result_t{},
-                                                traits_t::alignments_per_vector,
                                                 get_execution_rule()};
     // Return the range over the alignments.
     return alignment_range{std::move(executor)};

--- a/include/seqan3/alignment/pairwise/execution/alignment_executor_two_way.hpp
+++ b/include/seqan3/alignment/pairwise/execution/alignment_executor_two_way.hpp
@@ -283,7 +283,7 @@ private:
      */
     bool is_buffer_empty() const
     {
-        return bucket_iterator == bucket_end || buffer_iterator == bucket_iterator->end();
+        return bucket_iterator == bucket_end;
     }
 
     /*!\brief Resets the buckets.

--- a/include/seqan3/alignment/pairwise/execution/alignment_executor_two_way.hpp
+++ b/include/seqan3/alignment/pairwise/execution/alignment_executor_two_way.hpp
@@ -78,7 +78,7 @@ private:
     using buffer_type = std::vector<value_t>;
     //!\brief The type of the bucket container.
     using bucket_type = std::vector<buffer_type>;
-    //!\brief The pointer type of the buffer.
+    //!\brief The iterator type of the buffer.
     using buffer_iterator_type = std::ranges::iterator_t<buffer_type>;
     //!\brief The iterator type over the bucket container.
     using bucket_iterator_type = std::ranges::iterator_t<bucket_type>;
@@ -299,7 +299,7 @@ private:
         for (auto & bucket : bucket_vector)
             bucket.clear();
 
-        // Reset the iterators over the buckets.
+        // Reset the iterator over the buckets.
         bucket_iterator = bucket_vector.begin();
     }
 

--- a/test/unit/alignment/pairwise/execution/alignment_executor_two_way_test.cpp
+++ b/test/unit/alignment/pairwise/execution/alignment_executor_two_way_test.cpp
@@ -21,30 +21,28 @@
 // which counts the number of equal base pairs.
 struct dummy_alignment
 {
-    template <typename indexed_sequence_pairs_t, typename callback_t>
-    constexpr void operator()(indexed_sequence_pairs_t && indexed_sequence_pairs,
+    template <typename sequences_t, typename callback_t>
+    constexpr void operator()(sequences_t && sequence_pairs,
                               callback_t && callback) const
     {
-        for (auto && indexed_pair : indexed_sequence_pairs)
-        {
-            using std::get;
+        auto && [first_seq, second_seq] = sequence_pairs;
 
-            size_t count = 0;
-            auto & [first_seq, second_seq] = get<0>(indexed_pair);
-            for (auto [lhs, rhs] : seqan3::views::zip(first_seq, second_seq))
-                if (lhs == rhs)
-                    ++count;
+        size_t count = 0;
+        for (auto && [lhs, rhs] : seqan3::views::zip(first_seq, second_seq))
+            if (lhs == rhs)
+                ++count;
 
-            callback(count);
-        }
+        if (count == 0)  // Simulating not to call the callback without a result.
+            return;
+
+        callback(count);
     }
 };
 
 template <typename resource_t>
 struct algorithm_type_for_input
 {
-    using indexed_sequence_pairs_t = typename seqan3::detail::chunked_indexed_sequence_pairs<resource_t>::type;
-    using algorithm_input_t = std::ranges::range_value_t<indexed_sequence_pairs_t>;
+    using algorithm_input_t = std::ranges::range_value_t<resource_t>;
     using callback_t = std::function<void(size_t)>;
     using type = std::function<void(algorithm_input_t, callback_t)>;
 };
@@ -78,36 +76,6 @@ TYPED_TEST(alignment_executor_two_way_test, construction)
     EXPECT_TRUE(std::is_move_constructible_v<alignment_executor_t>);
     EXPECT_FALSE(std::is_copy_assignable_v<alignment_executor_t>);
     EXPECT_TRUE(std::is_move_assignable_v<alignment_executor_t>);
-}
-
-TYPED_TEST(alignment_executor_two_way_test, construct_with_chunk_size)
-{
-    using algorithm_t = typename algorithm_type_for_input<typename TestFixture::sequence_pairs_t &>::type;
-    using alignment_executor_t =
-        seqan3::detail::alignment_executor_two_way<typename TestFixture::sequence_pairs_t &,
-                                                   algorithm_t,
-                                                   size_t,
-                                                   TypeParam>;
-
-    {  // default chunk size should be 1.
-        alignment_executor_t exec{this->sequence_pairs, algorithm_t{dummy_alignment{}}};
-        EXPECT_EQ(exec.chunk_size(), 1u);
-    }
-
-    { // chunk size should be 4.
-        alignment_executor_t exec{this->sequence_pairs, algorithm_t{dummy_alignment{}}, 0, 4};
-        EXPECT_EQ(exec.chunk_size(), 4u);
-    }
-
-    { // with chunk size and execution policy.
-        alignment_executor_t exec{this->sequence_pairs, algorithm_t{dummy_alignment{}}, 0, 4, seqan3::seq};
-        EXPECT_EQ(exec.chunk_size(), 4u);
-    }
-
-    { // throw with invalid chunk size.
-        EXPECT_THROW((alignment_executor_t{this->sequence_pairs, algorithm_t{dummy_alignment{}}, 0, 0, seqan3::seq}),
-                     std::invalid_argument);
-    }
 }
 
 TYPED_TEST(alignment_executor_two_way_test, is_eof)
@@ -166,28 +134,11 @@ TYPED_TEST(alignment_executor_two_way_test, move_assignment)
     EXPECT_EQ(exec_move_assigned.bump().value(), 7u);
     EXPECT_EQ(exec_move_assigned.bump().value(), 7u);
     EXPECT_EQ(exec_move_assigned.bump().value(), 7u);
-    EXPECT_EQ(exec_move_assigned.bump().value(), 7u);
-    EXPECT_EQ(exec_move_assigned.bump().value(), 7u);
-    EXPECT_FALSE(static_cast<bool>(exec_move_assigned.bump()));
-}
 
-TYPED_TEST(alignment_executor_two_way_test, in_avail)
-{
-    using algorithm_t = typename algorithm_type_for_input<typename TestFixture::sequence_pairs_t &>::type;
-    using alignment_executor_t =
-        seqan3::detail::alignment_executor_two_way<typename TestFixture::sequence_pairs_t &,
-                                                   algorithm_t,
-                                                   size_t,
-                                                   TypeParam>;
-
-    alignment_executor_t exec{this->sequence_pairs, algorithm_t{dummy_alignment{}}};
-
-    EXPECT_EQ(exec.in_avail(), 0u);
-    EXPECT_EQ(exec.bump().value(), 7u);
-    if constexpr (std::same_as<TypeParam, seqan3::detail::execution_handler_parallel>)
-        EXPECT_EQ(exec.in_avail(), 4u);
-    else
-        EXPECT_EQ(exec.in_avail(), 0u);
+    alignment_executor_t exec_move_constructed{std::move(exec_move_assigned)};
+    EXPECT_EQ(exec_move_constructed.bump().value(), 7u);
+    EXPECT_EQ(exec_move_constructed.bump().value(), 7u);
+    EXPECT_FALSE(static_cast<bool>(exec_move_constructed.bump()));
 }
 
 TYPED_TEST(alignment_executor_two_way_test, lvalue_sequence_pair_view)
@@ -246,6 +197,24 @@ TYPED_TEST(alignment_executor_two_way_test, rvalue_sequence_pairs_view)
 
     alignment_executor_t exec{this->sequence_pairs | seqan3::views::persist, algorithm_t{dummy_alignment{}}};
     EXPECT_EQ(exec.bump().value(), 7u);
+    EXPECT_EQ(exec.bump().value(), 7u);
+    EXPECT_EQ(exec.bump().value(), 7u);
+    EXPECT_EQ(exec.bump().value(), 7u);
+    EXPECT_EQ(exec.bump().value(), 7u);
+    EXPECT_FALSE(static_cast<bool>(exec.bump()));
+}
+
+TYPED_TEST(alignment_executor_two_way_test, empty_result_bucket)
+{
+    using algorithm_t = typename algorithm_type_for_input<typename TestFixture::sequence_pairs_t &>::type;
+    using alignment_executor_t =
+        seqan3::detail::alignment_executor_two_way<typename TestFixture::sequence_pairs_t &,
+                                                   algorithm_t,
+                                                   size_t,
+                                                   TypeParam>;
+    this->sequence_pairs[3].first = "";
+    alignment_executor_t exec{this->sequence_pairs, algorithm_t{dummy_alignment{}}};
+
     EXPECT_EQ(exec.bump().value(), 7u);
     EXPECT_EQ(exec.bump().value(), 7u);
     EXPECT_EQ(exec.bump().value(), 7u);

--- a/test/unit/alignment/pairwise/execution/alignment_executor_two_way_test.cpp
+++ b/test/unit/alignment/pairwise/execution/alignment_executor_two_way_test.cpp
@@ -32,10 +32,8 @@ struct dummy_alignment
             if (lhs == rhs)
                 ++count;
 
-        if (count == 0)  // Simulating not to call the callback without a result.
-            return;
-
-        callback(count);
+        if (count != 0)  // Simulating not to call the callback without a result.
+            callback(count);
     }
 };
 


### PR DESCRIPTION
This is a first step to generalise the two way executor for any algorithm.
Thus, the executor is not alignment specific anymore and can be used for the search algorithm as well. This commit only contains the structural changes. The documentation and relocation will happen in separate commits.

This way the reviewer can focus on the non-trivial changes.

Changes include:

* removing of the chunking within the two way executor and the chunk related interfaces
* introducing a bucket structure for storing all results per invocation
* Allowing to have invocations without producing results at all.

Note, later in the alignment but also within the search a single algorithm invocation can produce multiple results. How many is not known before. So the result of every invocation is buffered dynamically in a bucket and the executor offers an internal organisation of the current read position. At the moment the buffer size (number of buckets) is one for the sequential mode and the size of the input resource for the parallel mode (e.g. a bucket for every query in the search). Another extension is that empty buckets can be skipped. This means that invocations of the algorithm must not need to produce results (e.g. no hits for the query or no alignment within the min score threshold). Thus, with this change the executor gets aligned with the changes made by #1740 where the algorithm invokes the callback or not, which is also the first step to allow a `on_result` interface.

There are some other more general issues like the class should not offer a reference type, the function to get a new element should not be called `bump`, or `gptr` is also a very bad name,  etc. But in my opintion these are separate no-brainer changes and would only complicate this PR.

### TODO

- [x] complete the tests

part of seqan/product_backlog#27