### PR TITLE
[MISC] Add a proxy type for an affine matrix cell.

### DIFF
--- a/include/seqan3/alignment/matrix/detail/affine_cell_proxy.hpp
+++ b/include/seqan3/alignment/matrix/detail/affine_cell_proxy.hpp
@@ -1,0 +1,117 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides seqan3::detail::affine_cell_proxy.
+ * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <tuple>
+
+#include <seqan3/core/tuple_utility.hpp>
+
+namespace seqan3::detail
+{
+
+/*!\brief A wrapper for an affine score matrix cell.
+ * \implements seqan3::tuple_like
+ * \ingroup pairwise_alignment
+ *
+ * \details
+ *
+ * This wrapper provides a uniform access to the different elements of the cell within an affine score matrix. This
+ * includes the optimal score, the horizontal gap score and the vertical gap score.
+ */
+template <tuple_like tuple_t>
+//!\cond
+    requires std::tuple_size_v<tuple_t> == 3
+//!\endcond
+class affine_cell_proxy : public tuple_t
+{
+public:
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    affine_cell_proxy()= default; //!< Defaulted.
+    affine_cell_proxy(affine_cell_proxy const &) = default; //!< Defaulted.
+    affine_cell_proxy(affine_cell_proxy &&) = default; //!< Defaulted.
+    affine_cell_proxy & operator=(affine_cell_proxy const &) = default; //!< Defaulted.
+    affine_cell_proxy & operator=(affine_cell_proxy &&) = default; //!< Defaulted.
+    ~affine_cell_proxy() = default; //!< Defaulted.
+
+    // Inherit the tuple constructors and assignment.
+    using tuple_t::tuple_t;
+    using tuple_t::operator=;
+    //!\}
+
+    /*!\name Optimal score
+     * \{
+     */
+    //!\brief Access the optimal score of the wrapped score matrix cell.
+    decltype(auto) optimal_score() & { using std::get; return get<0>(*this); }
+    //!\overload
+    decltype(auto) optimal_score() const & { using std::get; return get<0>(*this); }
+    //!\overload
+    decltype(auto) optimal_score() && { using std::get; return get<0>(std::move(*this)); }
+    //!\overload
+    decltype(auto) optimal_score() const &&
+    { //Unfortunately gcc7 does not preserve the const && type: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94967
+        using std::get;
+        return static_cast<std::tuple_element_t<0, tuple_t> const &&>(get<0>(std::move(*this)));
+    }
+    //!\}
+
+    /*!\name Horizontal score
+     * \{
+     */
+    //!\brief Access the horizontal score of the wrapped score matrix cell.
+    decltype(auto) horizontal_score() & { using std::get; return get<1>(*this); }
+    //!\overload
+    decltype(auto) horizontal_score() const & { using std::get; return get<1>(*this); }
+    //!\overload
+    decltype(auto) horizontal_score() && { using std::get; return get<1>(std::move(*this)); }
+    //!\overload
+     decltype(auto) horizontal_score() const &&
+    { //Unfortunately gcc7 does not preserve the const && type: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94967
+        using std::get;
+        return static_cast<std::tuple_element_t<1, tuple_t> const &&>(get<1>(std::move(*this)));
+    }
+    //!\}
+
+    /*!\name Vertical score
+     * \{
+     */
+    //!\brief Access the vertical score of the wrapped score matrix cell.
+    decltype(auto) vertical_score() & { using std::get; return get<2>(*this); }
+    //!\overload
+    decltype(auto) vertical_score() const & { using std::get; return get<2>(*this); }
+    //!\overload
+    decltype(auto) vertical_score() && { using std::get; return get<2>(std::move(*this)); }
+    //!\overload
+    decltype(auto) vertical_score() const &&
+    { //Unfortunately gcc7 does not preserve the const && type: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94967
+        using std::get;
+        return static_cast<std::tuple_element_t<2, tuple_t> const &&>(get<2>(std::move(*this)));
+    }
+    //!\}
+};
+} // namespace seqan3::detail
+
+namespace std
+{
+//!\cond
+template <typename tuple_t>
+struct tuple_size<seqan3::detail::affine_cell_proxy<tuple_t>> : tuple_size<tuple_t>
+{};
+
+template <size_t index, typename tuple_t>
+struct tuple_element<index, seqan3::detail::affine_cell_proxy<tuple_t>> : tuple_element<index, tuple_t>
+{};
+//!\endcond
+} // namespace std

--- a/test/unit/alignment/matrix/detail/CMakeLists.txt
+++ b/test/unit/alignment/matrix/detail/CMakeLists.txt
@@ -1,3 +1,4 @@
+seqan3_test (affine_cell_proxy_test.cpp)
 seqan3_test (aligned_sequence_builder_test.cpp)
 seqan3_test (alignment_matrix_column_major_range_test.cpp)
 seqan3_test (alignment_score_matrix_one_column_banded_test.cpp)

--- a/test/unit/alignment/matrix/detail/affine_cell_proxy_test.cpp
+++ b/test/unit/alignment/matrix/detail/affine_cell_proxy_test.cpp
@@ -1,0 +1,106 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+#include "gtest/gtest.h"
+
+#include <seqan3/alignment/matrix/detail/affine_cell_proxy.hpp>
+
+struct affine_cell_proxy_test : public ::testing::Test
+{
+    using base_t = std::tuple<int, int const &, int &>;
+    using cell_t = seqan3::detail::affine_cell_proxy<base_t>;
+
+    int optimal{4};
+    int horizontal{-1};
+    int vertical{10};
+
+    cell_t affine_cell{optimal, horizontal, vertical};
+    cell_t const const_affine_cell{affine_cell};
+};
+
+TEST_F(affine_cell_proxy_test, construction)
+{
+    int lvalue_variable{8};
+    cell_t other_cell{1, lvalue_variable, lvalue_variable};
+
+    EXPECT_EQ(std::get<0>(other_cell), 1);
+    EXPECT_EQ(std::get<1>(other_cell), 8);
+    EXPECT_EQ(std::get<2>(other_cell), 8);
+
+    cell_t other_cell2{affine_cell};
+    EXPECT_EQ(std::get<0>(other_cell2), 4);
+    EXPECT_EQ(std::get<1>(other_cell2), -1);
+    EXPECT_EQ(std::get<2>(other_cell2), 10);
+}
+
+TEST_F(affine_cell_proxy_test, assignment)
+{
+    int lvalue_variable{8};
+    seqan3::detail::affine_cell_proxy<std::tuple<int, int, int>> other_cell{1, lvalue_variable, lvalue_variable};
+
+    EXPECT_EQ(std::get<0>(other_cell), 1);
+    EXPECT_EQ(std::get<1>(other_cell), 8);
+    EXPECT_EQ(std::get<2>(other_cell), 8);
+
+    other_cell = affine_cell;
+    EXPECT_EQ(std::get<0>(other_cell), 4);
+    EXPECT_EQ(std::get<1>(other_cell), -1);
+    EXPECT_EQ(std::get<2>(other_cell), 10);
+}
+
+TEST_F(affine_cell_proxy_test, optimal_score)
+{
+    EXPECT_EQ(affine_cell.optimal_score(), 4);
+    EXPECT_EQ(const_affine_cell.optimal_score(), 4);
+    EXPECT_EQ(std::move(affine_cell).optimal_score(), 4);
+    EXPECT_EQ(std::move(const_affine_cell).optimal_score(), 4);
+    EXPECT_TRUE((std::same_as<decltype(affine_cell.optimal_score()), int &>));
+    EXPECT_TRUE((std::same_as<decltype(const_affine_cell.optimal_score()), int const &>));
+    EXPECT_TRUE((std::same_as<decltype(std::move(affine_cell).optimal_score()), int &&>));
+    EXPECT_TRUE((std::same_as<decltype(std::move(const_affine_cell).optimal_score()), int const &&>));
+}
+
+TEST_F(affine_cell_proxy_test, horizontal_score)
+{
+    EXPECT_EQ(affine_cell.horizontal_score(), -1);
+    EXPECT_EQ(const_affine_cell.horizontal_score(), -1);
+    EXPECT_EQ(std::move(affine_cell).horizontal_score(), -1);
+    EXPECT_EQ(std::move(const_affine_cell).horizontal_score(), -1);
+    EXPECT_TRUE((std::same_as<decltype(affine_cell.horizontal_score()), int const &>));
+    EXPECT_TRUE((std::same_as<decltype(const_affine_cell.horizontal_score()), int const &>));
+    EXPECT_TRUE((std::same_as<decltype(std::move(affine_cell).horizontal_score()), int const &>));
+    EXPECT_TRUE((std::same_as<decltype(std::move(const_affine_cell).horizontal_score()), int const &>));
+}
+
+TEST_F(affine_cell_proxy_test, vertical_score)
+{
+    EXPECT_EQ(affine_cell.vertical_score(), 10);
+    EXPECT_EQ(const_affine_cell.vertical_score(), 10);
+    EXPECT_EQ(std::move(affine_cell).vertical_score(), 10);
+    EXPECT_EQ(std::move(const_affine_cell).vertical_score(), 10);
+    EXPECT_TRUE((std::same_as<decltype(affine_cell.vertical_score()), int &>));
+    EXPECT_TRUE((std::same_as<decltype(const_affine_cell.vertical_score()), int &>));
+    EXPECT_TRUE((std::same_as<decltype(std::move(affine_cell).vertical_score()), int &>));
+    EXPECT_TRUE((std::same_as<decltype(std::move(const_affine_cell).vertical_score()), int &>));
+}
+
+TEST_F(affine_cell_proxy_test, tuple_size)
+{
+    EXPECT_EQ(std::tuple_size_v<cell_t>, 3u);
+}
+
+TEST_F(affine_cell_proxy_test, tuple_element)
+{
+    EXPECT_TRUE((std::same_as<std::tuple_element_t<0, cell_t>, int>));
+    EXPECT_TRUE((std::same_as<std::tuple_element_t<1, cell_t>, int const &>));
+    EXPECT_TRUE((std::same_as<std::tuple_element_t<2, cell_t>, int &>));
+}
+
+TEST_F(affine_cell_proxy_test, tuple_like_concept)
+{
+    EXPECT_TRUE(seqan3::tuple_like<cell_t>);
+}


### PR DESCRIPTION
Adds a wrapper type for the affine cell type in the new alignment algorithm. The simplified score matrix will return a transformed zip view over the different score matrices needed to compute the affine gap cost (optimal score, horizontal score and vertical score). The new matrix does not add any perfromance penalties but the tuple interface is hard to use inside of the algorithm. Therefor, the proxy just inherits from the actual tuple type and adds named accessor functions that can be used inside of the alignment. 

You can see the usage in the reference implementation in the draft PR #1761. 