### PR TITLE
[MISC] Cleanup for the refactoring task: Remove 'using namespace seqan3'

### DIFF
--- a/include/seqan3/core/concept/cereal.hpp
+++ b/include/seqan3/core/concept/cereal.hpp
@@ -117,7 +117,6 @@ SEQAN3_CONCEPT cereal_text_archive = false;
  *
  * ```
  * #include <seqan3/core/concept/cereal.hpp>
- * using namespace seqan3;
  *
  * // fundamental types are serialisable
  * static_assert(cerealisable<int>);

--- a/include/seqan3/core/concept/cereal.hpp
+++ b/include/seqan3/core/concept/cereal.hpp
@@ -119,14 +119,14 @@ SEQAN3_CONCEPT cereal_text_archive = false;
  * #include <seqan3/core/concept/cereal.hpp>
  *
  * // fundamental types are serialisable
- * static_assert(cerealisable<int>);
+ * static_assert(seqan3::cerealisable<int>);
  *
  * #include <array>
  * #include <cereal/types/array.hpp> // std::array is now serialisable
- * static_assert(cerealisable<std::array<int, 12>>);
+ * static_assert(seqan3::cerealisable<std::array<int, 12>>);
  *
  * #include <seqan3/alphabet/nucleotide/dna4.hpp> // dna4 is serialisable
- * static_assert(cerealisable<dna4>);
+ * static_assert(seqan3::cerealisable<seqan3::dna4>);
  * ```
  *
  * ### Example

--- a/test/performance/alignment/edit_distance_unbanded_benchmark.cpp
+++ b/test/performance/alignment/edit_distance_unbanded_benchmark.cpp
@@ -27,8 +27,6 @@
 #include <seqan/sequence.h>
 #endif
 
-using namespace seqan3::test;
-
 constexpr auto edit_distance_cfg = seqan3::align_cfg::edit |
                                    seqan3::align_cfg::result{seqan3::with_score};
 
@@ -62,8 +60,8 @@ int global_edit_distance_seqan2(
 void seqan3_edit_distance_dna4(benchmark::State & state)
 {
     size_t sequence_length = 500;
-    auto seq1 = generate_sequence<seqan3::dna4>(sequence_length, 0, 0);
-    auto seq2 = generate_sequence<seqan3::dna4>(sequence_length, 0, 1);
+    auto seq1 = seqan3::test::generate_sequence<seqan3::dna4>(sequence_length, 0, 0);
+    auto seq2 = seqan3::test::generate_sequence<seqan3::dna4>(sequence_length, 0, 1);
     int score = 0;
 
     using seq1_ref_t = std::add_lvalue_reference_t<decltype(seq1)>;
@@ -89,15 +87,16 @@ void seqan3_edit_distance_dna4(benchmark::State & state)
     }
 
     state.counters["score"] = score;
-    state.counters["cells"] = pairwise_cell_updates(std::views::single(std::tie(seq1, seq2)), edit_distance_cfg);
-    state.counters["CUPS"] = cell_updates_per_second(state.counters["cells"]);
+    state.counters["cells"] = seqan3::test::pairwise_cell_updates(std::views::single(std::tie(seq1, seq2)),
+                                                                  edit_distance_cfg);
+    state.counters["CUPS"] = seqan3::test::cell_updates_per_second(state.counters["cells"]);
 }
 
 void seqan3_edit_distance_dna4_selector(benchmark::State & state)
 {
     size_t sequence_length = 500;
-    auto seq1 = generate_sequence<seqan3::dna4>(sequence_length, 0, 0);
-    auto seq2 = generate_sequence<seqan3::dna4>(sequence_length, 0, 1);
+    auto seq1 = seqan3::test::generate_sequence<seqan3::dna4>(sequence_length, 0, 0);
+    auto seq2 = seqan3::test::generate_sequence<seqan3::dna4>(sequence_length, 0, 1);
     int score = 0;
 
     for (auto _ : state)
@@ -107,39 +106,42 @@ void seqan3_edit_distance_dna4_selector(benchmark::State & state)
     }
 
     state.counters["score"] = score;
-    state.counters["cells"] = pairwise_cell_updates(std::views::single(std::tie(seq1, seq2)), edit_distance_cfg);
-    state.counters["CUPS"] = cell_updates_per_second(state.counters["cells"]);
+    state.counters["cells"] = seqan3::test::pairwise_cell_updates(std::views::single(std::tie(seq1, seq2)),
+                                                                  edit_distance_cfg);
+    state.counters["CUPS"] = seqan3::test::cell_updates_per_second(state.counters["cells"]);
 }
 
 #ifdef SEQAN3_HAS_SEQAN2
 void seqan2_edit_distance_dna4(benchmark::State & state)
 {
     size_t sequence_length = 500;
-    auto seq1 = generate_sequence_seqan2<seqan::Dna>(sequence_length, 0, 0);
-    auto seq2 = generate_sequence_seqan2<seqan::Dna>(sequence_length, 0, 1);
+    auto seq1 = seqan3::test::generate_sequence_seqan2<seqan::Dna>(sequence_length, 0, 0);
+    auto seq2 = seqan3::test::generate_sequence_seqan2<seqan::Dna>(sequence_length, 0, 1);
     int score = 0;
 
     for (auto _ : state)
         score += global_edit_distance_seqan2(seq1, seq2);
 
     state.counters["score"] = score;
-    state.counters["cells"] = pairwise_cell_updates(std::views::single(std::tie(seq1, seq2)), edit_distance_cfg);
-    state.counters["CUPS"] = cell_updates_per_second(state.counters["cells"]);
+    state.counters["cells"] = seqan3::test::pairwise_cell_updates(std::views::single(std::tie(seq1, seq2)),
+                                                                  edit_distance_cfg);
+    state.counters["CUPS"] = seqan3::test::cell_updates_per_second(state.counters["cells"]);
 }
 
 void seqan2_edit_distance_generic_dna4(benchmark::State & state)
 {
     size_t sequence_length = 500;
-    auto seq1 = generate_sequence_seqan2<seqan::Dna>(sequence_length, 0, 0);
-    auto seq2 = generate_sequence_seqan2<seqan::Dna>(sequence_length, 0, 1);
+    auto seq1 = seqan3::test::generate_sequence_seqan2<seqan::Dna>(sequence_length, 0, 0);
+    auto seq2 = seqan3::test::generate_sequence_seqan2<seqan::Dna>(sequence_length, 0, 1);
     int score = 0;
 
     for (auto _ : state)
         score += seqan::globalAlignmentScore(seq1, seq2, seqan::Score<int>{0, -1, -1});
 
     state.counters["score"] = score;
-    state.counters["cells"] = pairwise_cell_updates(std::views::single(std::tie(seq1, seq2)), edit_distance_cfg);
-    state.counters["CUPS"] = cell_updates_per_second(state.counters["cells"]);
+    state.counters["cells"] = seqan3::test::pairwise_cell_updates(std::views::single(std::tie(seq1, seq2)),
+                                                                  edit_distance_cfg);
+    state.counters["CUPS"] = seqan3::test::cell_updates_per_second(state.counters["cells"]);
 }
 #endif // SEQAN3_HAS_SEQAN2
 
@@ -152,7 +154,7 @@ void seqan3_edit_distance_dna4_collection(benchmark::State & state)
     size_t sequence_length = 500;
     size_t set_size = 100;
 
-    auto vec = generate_sequence_pairs<seqan3::dna4>(sequence_length, set_size);
+    auto vec = seqan3::test::generate_sequence_pairs<seqan3::dna4>(sequence_length, set_size);
     int score = 0;
 
     using seq1_t = std::tuple_element_t<0, std::ranges::range_value_t<decltype(vec)>>;
@@ -183,8 +185,8 @@ void seqan3_edit_distance_dna4_collection(benchmark::State & state)
     }
 
     state.counters["score"] = score;
-    state.counters["cells"] = pairwise_cell_updates(vec, edit_distance_cfg);
-    state.counters["CUPS"] = cell_updates_per_second(state.counters["cells"]);
+    state.counters["cells"] = seqan3::test::pairwise_cell_updates(vec, edit_distance_cfg);
+    state.counters["CUPS"] = seqan3::test::cell_updates_per_second(state.counters["cells"]);
 }
 
 void seqan3_edit_distance_dna4_collection_selector(benchmark::State & state)
@@ -192,7 +194,7 @@ void seqan3_edit_distance_dna4_collection_selector(benchmark::State & state)
     size_t sequence_length = 500;
     size_t set_size = 100;
 
-    auto vec = generate_sequence_pairs<seqan3::dna4>(sequence_length, set_size);
+    auto vec = seqan3::test::generate_sequence_pairs<seqan3::dna4>(sequence_length, set_size);
     int score = 0;
 
     for (auto _ : state)
@@ -202,8 +204,8 @@ void seqan3_edit_distance_dna4_collection_selector(benchmark::State & state)
     }
 
     state.counters["score"] = score;
-    state.counters["cells"] = pairwise_cell_updates(vec, edit_distance_cfg);
-    state.counters["CUPS"] = cell_updates_per_second(state.counters["cells"]);
+    state.counters["cells"] = seqan3::test::pairwise_cell_updates(vec, edit_distance_cfg);
+    state.counters["CUPS"] = seqan3::test::cell_updates_per_second(state.counters["cells"]);
 }
 
 #ifdef SEQAN3_HAS_SEQAN2
@@ -212,7 +214,7 @@ void seqan2_edit_distance_dna4_collection(benchmark::State & state)
     size_t sequence_length = 500;
     size_t set_size = 100;
 
-    auto [vec1, vec2] = generate_sequence_pairs_seqan2<seqan::Dna>(sequence_length, set_size);
+    auto [vec1, vec2] = seqan3::test::generate_sequence_pairs_seqan2<seqan::Dna>(sequence_length, set_size);
     int score = 0;
 
     for (auto _ : state)
@@ -222,8 +224,8 @@ void seqan2_edit_distance_dna4_collection(benchmark::State & state)
     }
 
     state.counters["score"] = score;
-    state.counters["cells"] = pairwise_cell_updates(seqan3::views::zip(vec1, vec2), edit_distance_cfg);
-    state.counters["CUPS"] = cell_updates_per_second(state.counters["cells"]);
+    state.counters["cells"] = seqan3::test::pairwise_cell_updates(seqan3::views::zip(vec1, vec2), edit_distance_cfg);
+    state.counters["CUPS"] = seqan3::test::cell_updates_per_second(state.counters["cells"]);
 }
 
 void seqan2_edit_distance_dna4_generic_collection(benchmark::State & state)
@@ -231,7 +233,7 @@ void seqan2_edit_distance_dna4_generic_collection(benchmark::State & state)
     size_t sequence_length = 500;
     size_t set_size = 100;
 
-    auto [vec1, vec2] = generate_sequence_pairs_seqan2<seqan::Dna>(sequence_length, set_size);
+    auto [vec1, vec2] = seqan3::test::generate_sequence_pairs_seqan2<seqan::Dna>(sequence_length, set_size);
     int score = 0;
 
     for (auto _ : state)
@@ -241,8 +243,8 @@ void seqan2_edit_distance_dna4_generic_collection(benchmark::State & state)
     }
 
     state.counters["score"] = score;
-    state.counters["cells"] = pairwise_cell_updates(seqan3::views::zip(vec1, vec2), edit_distance_cfg);
-    state.counters["CUPS"] = cell_updates_per_second(state.counters["cells"]);
+    state.counters["cells"] = seqan3::test::pairwise_cell_updates(seqan3::views::zip(vec1, vec2), edit_distance_cfg);
+    state.counters["CUPS"] = seqan3::test::cell_updates_per_second(state.counters["cells"]);
 }
 #endif // SEQAN3_HAS_SEQAN2
 

--- a/test/performance/alignment/global_affine_alignment_benchmark.cpp
+++ b/test/performance/alignment/global_affine_alignment_benchmark.cpp
@@ -26,8 +26,6 @@
     #include <seqan/align.h>
 #endif
 
-using namespace seqan3::test;
-
 constexpr auto affine_cfg = seqan3::align_cfg::mode{seqan3::global_alignment} |
                             seqan3::align_cfg::gap{seqan3::gap_scheme{seqan3::gap_score{-1},
                                                                       seqan3::gap_open_score{-10}}} |
@@ -41,8 +39,8 @@ constexpr auto affine_cfg = seqan3::align_cfg::mode{seqan3::global_alignment} |
 void seqan3_affine_dna4(benchmark::State & state)
 {
     size_t sequence_length = 500;
-    auto seq1 = generate_sequence<seqan3::dna4>(sequence_length, 0, 0);
-    auto seq2 = generate_sequence<seqan3::dna4>(sequence_length, 0, 1);
+    auto seq1 = seqan3::test::generate_sequence<seqan3::dna4>(sequence_length, 0, 0);
+    auto seq2 = seqan3::test::generate_sequence<seqan3::dna4>(sequence_length, 0, 1);
 
     for (auto _ : state)
     {
@@ -50,8 +48,8 @@ void seqan3_affine_dna4(benchmark::State & state)
         *std::ranges::begin(rng);
     }
 
-    state.counters["cells"] = pairwise_cell_updates(std::views::single(std::tie(seq1, seq2)), affine_cfg);
-    state.counters["CUPS"] = cell_updates_per_second(state.counters["cells"]);
+    state.counters["cells"] = seqan3::test::pairwise_cell_updates(std::views::single(std::tie(seq1, seq2)), affine_cfg);
+    state.counters["CUPS"] = seqan3::test::cell_updates_per_second(state.counters["cells"]);
 }
 
 BENCHMARK(seqan3_affine_dna4);
@@ -70,8 +68,8 @@ void seqan2_affine_dna4(benchmark::State & state)
         seqan::globalAlignmentScore(seq1, seq2, seqan::Score<int>{4, -5, -1, -11});
     }
 
-    state.counters["cells"] = pairwise_cell_updates(std::views::single(std::tie(seq1, seq2)), affine_cfg);
-    state.counters["CUPS"] = cell_updates_per_second(state.counters["cells"]);
+    state.counters["cells"] = seqan3::test::pairwise_cell_updates(std::views::single(std::tie(seq1, seq2)), affine_cfg);
+    state.counters["CUPS"] = seqan3::test::cell_updates_per_second(state.counters["cells"]);
 }
 
 BENCHMARK(seqan2_affine_dna4);
@@ -84,8 +82,8 @@ BENCHMARK(seqan2_affine_dna4);
 void seqan3_affine_dna4_trace(benchmark::State & state)
 {
     size_t sequence_length = 500;
-    auto seq1 = generate_sequence<seqan3::dna4>(sequence_length, 0, 0);
-    auto seq2 = generate_sequence<seqan3::dna4>(sequence_length, 0, 1);
+    auto seq1 = seqan3::test::generate_sequence<seqan3::dna4>(sequence_length, 0, 0);
+    auto seq2 = seqan3::test::generate_sequence<seqan3::dna4>(sequence_length, 0, 1);
 
     for (auto _ : state)
     {
@@ -93,8 +91,8 @@ void seqan3_affine_dna4_trace(benchmark::State & state)
         *std::ranges::begin(rng);
     }
 
-    state.counters["cells"] = pairwise_cell_updates(std::views::single(std::tie(seq1, seq2)), affine_cfg);
-    state.counters["CUPS"] = cell_updates_per_second(state.counters["cells"]);
+    state.counters["cells"] = seqan3::test::pairwise_cell_updates(std::views::single(std::tie(seq1, seq2)), affine_cfg);
+    state.counters["CUPS"] = seqan3::test::cell_updates_per_second(state.counters["cells"]);
 }
 
 BENCHMARK(seqan3_affine_dna4_trace);
@@ -115,8 +113,8 @@ void seqan2_affine_dna4_trace(benchmark::State & state)
         seqan::globalAlignment(gap1, gap2, seqan::Score<int>{4, -5, -1, -11});
     }
 
-    state.counters["cells"] = pairwise_cell_updates(std::views::single(std::tie(seq1, seq2)), affine_cfg);
-    state.counters["CUPS"] = cell_updates_per_second(state.counters["cells"]);
+    state.counters["cells"] = seqan3::test::pairwise_cell_updates(std::views::single(std::tie(seq1, seq2)), affine_cfg);
+    state.counters["CUPS"] = seqan3::test::cell_updates_per_second(state.counters["cells"]);
 }
 
 BENCHMARK(seqan2_affine_dna4_trace);
@@ -130,13 +128,13 @@ void seqan3_affine_dna4_collection(benchmark::State & state)
 {
     size_t sequence_length = 100;
     size_t set_size = 100;
-    using sequence_t = decltype(generate_sequence<seqan3::dna4>());
+    using sequence_t = decltype(seqan3::test::generate_sequence<seqan3::dna4>());
 
     std::vector<std::pair<sequence_t, sequence_t>> vec;
     for (unsigned i = 0; i < set_size; ++i)
     {
-        sequence_t seq1 = generate_sequence<seqan3::dna4>(sequence_length, 0, i);
-        sequence_t seq2 = generate_sequence<seqan3::dna4>(sequence_length, 0, i + set_size);
+        sequence_t seq1 = seqan3::test::generate_sequence<seqan3::dna4>(sequence_length, 0, i);
+        sequence_t seq2 = seqan3::test::generate_sequence<seqan3::dna4>(sequence_length, 0, i + set_size);
         vec.push_back(std::pair{seq1, seq2});
     }
 
@@ -146,8 +144,8 @@ void seqan3_affine_dna4_collection(benchmark::State & state)
             rng.score();
     }
 
-    state.counters["cells"] = pairwise_cell_updates(vec, affine_cfg);
-    state.counters["CUPS"] = cell_updates_per_second(state.counters["cells"]);
+    state.counters["cells"] = seqan3::test::pairwise_cell_updates(vec, affine_cfg);
+    state.counters["CUPS"] = seqan3::test::cell_updates_per_second(state.counters["cells"]);
 }
 
 BENCHMARK(seqan3_affine_dna4_collection);
@@ -176,8 +174,8 @@ void seqan2_affine_dna4_collection(benchmark::State & state)
         seqan::globalAlignmentScore(vec1, vec2, seqan::Score<int>{4, -5, -1, -11});
     }
 
-    state.counters["cells"] = pairwise_cell_updates(seqan3::views::zip(vec1, vec2), affine_cfg);
-    state.counters["CUPS"] = cell_updates_per_second(state.counters["cells"]);
+    state.counters["cells"] = seqan3::test::pairwise_cell_updates(seqan3::views::zip(vec1, vec2), affine_cfg);
+    state.counters["CUPS"] = seqan3::test::cell_updates_per_second(state.counters["cells"]);
 }
 
 BENCHMARK(seqan2_affine_dna4_collection);
@@ -191,13 +189,13 @@ void seqan3_affine_dna4_trace_collection(benchmark::State & state)
 {
     size_t sequence_length = 100;
     size_t set_size = 100;
-    using sequence_t = decltype(generate_sequence<seqan3::dna4>());
+    using sequence_t = decltype(seqan3::test::generate_sequence<seqan3::dna4>());
 
     std::vector<std::pair<sequence_t, sequence_t>> vec;
     for (unsigned i = 0; i < set_size; ++i)
     {
-        sequence_t seq1 = generate_sequence<seqan3::dna4>(sequence_length, 0, i);
-        sequence_t seq2 = generate_sequence<seqan3::dna4>(sequence_length, 0, i + set_size);
+        sequence_t seq1 = seqan3::test::generate_sequence<seqan3::dna4>(sequence_length, 0, i);
+        sequence_t seq2 = seqan3::test::generate_sequence<seqan3::dna4>(sequence_length, 0, i + set_size);
         vec.push_back(std::pair{seq1, seq2});
     }
 
@@ -207,8 +205,8 @@ void seqan3_affine_dna4_trace_collection(benchmark::State & state)
             rng.score();
     }
 
-    state.counters["cells"] = pairwise_cell_updates(vec, affine_cfg);
-    state.counters["CUPS"] = cell_updates_per_second(state.counters["cells"]);
+    state.counters["cells"] = seqan3::test::pairwise_cell_updates(vec, affine_cfg);
+    state.counters["CUPS"] = seqan3::test::cell_updates_per_second(state.counters["cells"]);
 }
 
 BENCHMARK(seqan3_affine_dna4_trace_collection);
@@ -246,8 +244,8 @@ void seqan2_affine_dna4_trace_collection(benchmark::State & state)
         seqan::globalAlignment(gap1, gap2, seqan::Score<int>{4, -5, -1, -11});
     }
 
-    state.counters["cells"] = pairwise_cell_updates(seqan3::views::zip(vec1, vec2), affine_cfg);
-    state.counters["CUPS"] = cell_updates_per_second(state.counters["cells"]);
+    state.counters["cells"] = seqan3::test::pairwise_cell_updates(seqan3::views::zip(vec1, vec2), affine_cfg);
+    state.counters["CUPS"] = seqan3::test::cell_updates_per_second(state.counters["cells"]);
 }
 
 BENCHMARK(seqan2_affine_dna4_trace_collection);

--- a/test/performance/alignment/global_affine_alignment_parallel_benchmark.cpp
+++ b/test/performance/alignment/global_affine_alignment_parallel_benchmark.cpp
@@ -31,8 +31,6 @@
     #include <seqan/align_parallel.h>
 #endif
 
-using namespace seqan3::test;
-
 constexpr auto affine_cfg = seqan3::align_cfg::mode{seqan3::global_alignment} |
                             seqan3::align_cfg::gap{seqan3::gap_scheme{seqan3::gap_score{-1},
                                                                       seqan3::gap_open_score{-10}}} |
@@ -51,14 +49,14 @@ inline constexpr size_t variance        = 10;
 template <typename alphabet_t>
 auto generate_data_seqan3()
 {
-    using sequence_t = decltype(generate_sequence<alphabet_t>());
+    using sequence_t = decltype(seqan3::test::generate_sequence<alphabet_t>());
 
     std::vector<sequence_t> vec1;
     std::vector<sequence_t> vec2;
     for (unsigned i = 0; i < set_size; ++i)
     {
-        vec1.push_back(generate_sequence<alphabet_t>(sequence_length, variance, i));
-        vec2.push_back(generate_sequence<alphabet_t>(sequence_length, variance, i + set_size));
+        vec1.push_back(seqan3::test::generate_sequence<alphabet_t>(sequence_length, variance, i));
+        vec2.push_back(seqan3::test::generate_sequence<alphabet_t>(sequence_length, variance, i + set_size));
     }
     return std::pair{vec1, vec2};
 }
@@ -102,8 +100,8 @@ void seqan3_affine_dna4_parallel(benchmark::State & state)
         }
     }
 
-    state.counters["cells"] = pairwise_cell_updates(seqan3::views::zip(vec1, vec2), affine_cfg);
-    state.counters["CUPS"] = cell_updates_per_second(state.counters["cells"]);
+    state.counters["cells"] = seqan3::test::pairwise_cell_updates(seqan3::views::zip(vec1, vec2), affine_cfg);
+    state.counters["CUPS"] = seqan3::test::cell_updates_per_second(state.counters["cells"]);
     state.counters["total"] = total;
 }
 
@@ -128,8 +126,8 @@ void seqan3_affine_dna4_omp_for(benchmark::State & state)
         }
     }
 
-    state.counters["cells"] = pairwise_cell_updates(seqan3::views::zip(vec1, vec2), affine_cfg);
-    state.counters["CUPS"] = cell_updates_per_second(state.counters["cells"]);
+    state.counters["cells"] = seqan3::test::pairwise_cell_updates(seqan3::views::zip(vec1, vec2), affine_cfg);
+    state.counters["CUPS"] = seqan3::test::cell_updates_per_second(state.counters["cells"]);
     state.counters["total"] = total;
 }
 
@@ -142,8 +140,6 @@ BENCHMARK_TEMPLATE(seqan3_affine_dna4_omp_for, trace)->UseRealTime();
 template <typename result_t>
 void seqan2_affine_dna4_parallel(benchmark::State & state)
 {
-    using namespace seqan;
-
     auto [vec1, vec2] = generate_data_seqan2<seqan::Dna>();
     ExecutionPolicy<Parallel, Serial> exec{};
     setNumThreads(exec, std::thread::hardware_concurrency());
@@ -156,8 +152,8 @@ void seqan2_affine_dna4_parallel(benchmark::State & state)
         total = std::accumulate(seqan::begin(res), seqan::end(res), total);
     }
 
-    state.counters["cells"] = pairwise_cell_updates(seqan3::views::zip(vec1, vec2), affine_cfg);
-    state.counters["CUPS"] = cell_updates_per_second(state.counters["cells"]);
+    state.counters["cells"] = seqan3::test::pairwise_cell_updates(seqan3::views::zip(vec1, vec2), affine_cfg);
+    state.counters["CUPS"] = seqan3::test::cell_updates_per_second(state.counters["cells"]);
     state.counters["total"] = total;
 }
 
@@ -198,8 +194,8 @@ void seqan2_affine_dna4_omp_for(benchmark::State & state)
         }
     }
 
-    state.counters["cells"] = pairwise_cell_updates(seqan3::views::zip(vec1, vec2), affine_cfg);
-    state.counters["CUPS"] = cell_updates_per_second(state.counters["cells"]);
+    state.counters["cells"] = seqan3::test::pairwise_cell_updates(seqan3::views::zip(vec1, vec2), affine_cfg);
+    state.counters["CUPS"] = seqan3::test::cell_updates_per_second(state.counters["cells"]);
     state.counters["total"] = total;
 }
 

--- a/test/performance/alignment/global_affine_alignment_simd_benchmark.cpp
+++ b/test/performance/alignment/global_affine_alignment_simd_benchmark.cpp
@@ -109,8 +109,6 @@ BENCHMARK_CAPTURE(seqan3_affine_dna4_accelerated,
 template <typename ...args_t>
 void seqan2_affine_dna4_accelerated(benchmark::State & state, args_t && ...args)
 {
-    using namespace seqan;
-
     std::tuple captured_args{args...};
 
     size_t sequence_length_variance = state.range(0);

--- a/test/performance/alignment/local_affine_alignment_benchmark.cpp
+++ b/test/performance/alignment/local_affine_alignment_benchmark.cpp
@@ -27,8 +27,6 @@
     #include <seqan/align.h>
 #endif
 
-using namespace seqan3::test;
-
 constexpr auto local_affine_cfg = seqan3::align_cfg::mode{seqan3::local_alignment} |
                                   seqan3::align_cfg::gap{seqan3::gap_scheme{seqan3::gap_score{-1},
                                                                             seqan3::gap_open_score{-10}}} |
@@ -43,8 +41,8 @@ constexpr auto local_affine_cfg = seqan3::align_cfg::mode{seqan3::local_alignmen
 
 void seqan3_affine_dna4(benchmark::State & state)
 {
-    auto seq1 = generate_sequence<seqan3::dna4>(500, 0, 0);
-    auto seq2 = generate_sequence<seqan3::dna4>(250, 0, 1);
+    auto seq1 = seqan3::test::generate_sequence<seqan3::dna4>(500, 0, 0);
+    auto seq2 = seqan3::test::generate_sequence<seqan3::dna4>(250, 0, 1);
 
     for (auto _ : state)
     {
@@ -53,8 +51,9 @@ void seqan3_affine_dna4(benchmark::State & state)
         *std::ranges::begin(rng);
     }
 
-    state.counters["cells"] = pairwise_cell_updates(std::views::single(std::tie(seq1, seq2)), local_affine_cfg);
-    state.counters["CUPS"] = cell_updates_per_second(state.counters["cells"]);
+    state.counters["cells"] = seqan3::test::pairwise_cell_updates(std::views::single(std::tie(seq1, seq2)),
+                                                                  local_affine_cfg);
+    state.counters["CUPS"] = seqan3::test::cell_updates_per_second(state.counters["cells"]);
 }
 
 BENCHMARK(seqan3_affine_dna4);
@@ -72,8 +71,9 @@ void seqan2_affine_dna4(benchmark::State & state)
         seqan::localAlignmentScore(seq1, seq2, seqan::Score<int>{4, -5, -1, -11});
     }
 
-    state.counters["cells"] = pairwise_cell_updates(std::views::single(std::tie(seq1, seq2)), local_affine_cfg);
-    state.counters["CUPS"] = cell_updates_per_second(state.counters["cells"]);
+    state.counters["cells"] = seqan3::test::pairwise_cell_updates(std::views::single(std::tie(seq1, seq2)),
+                                                                  local_affine_cfg);
+    state.counters["CUPS"] = seqan3::test::cell_updates_per_second(state.counters["cells"]);
 }
 
 BENCHMARK(seqan2_affine_dna4);
@@ -85,8 +85,8 @@ BENCHMARK(seqan2_affine_dna4);
 
 void seqan3_affine_dna4_trace(benchmark::State & state)
 {
-    auto seq1 = generate_sequence<seqan3::dna4>(500, 0, 0);
-    auto seq2 = generate_sequence<seqan3::dna4>(250, 0, 1);
+    auto seq1 = seqan3::test::generate_sequence<seqan3::dna4>(500, 0, 0);
+    auto seq2 = seqan3::test::generate_sequence<seqan3::dna4>(250, 0, 1);
 
     for (auto _ : state)
     {
@@ -95,8 +95,9 @@ void seqan3_affine_dna4_trace(benchmark::State & state)
         *std::ranges::begin(rng);
     }
 
-    state.counters["cells"] = pairwise_cell_updates(std::views::single(std::tie(seq1, seq2)), local_affine_cfg);
-    state.counters["CUPS"] = cell_updates_per_second(state.counters["cells"]);
+    state.counters["cells"] = seqan3::test::pairwise_cell_updates(std::views::single(std::tie(seq1, seq2)),
+                                                                  local_affine_cfg);
+    state.counters["CUPS"] = seqan3::test::cell_updates_per_second(state.counters["cells"]);
 }
 
 BENCHMARK(seqan3_affine_dna4_trace);
@@ -116,8 +117,9 @@ void seqan2_affine_dna4_trace(benchmark::State & state)
         seqan::localAlignment(gap1, gap2, seqan::Score<int>{4, -5, -1, -11});
     }
 
-    state.counters["cells"] = pairwise_cell_updates(std::views::single(std::tie(seq1, seq2)), local_affine_cfg);
-    state.counters["CUPS"] = cell_updates_per_second(state.counters["cells"]);
+    state.counters["cells"] = seqan3::test::pairwise_cell_updates(std::views::single(std::tie(seq1, seq2)),
+                                                                  local_affine_cfg);
+    state.counters["CUPS"] = seqan3::test::cell_updates_per_second(state.counters["cells"]);
 }
 
 BENCHMARK(seqan2_affine_dna4_trace);
@@ -129,13 +131,13 @@ BENCHMARK(seqan2_affine_dna4_trace);
 
 void seqan3_affine_dna4_collection(benchmark::State & state)
 {
-    using sequence_t = decltype(generate_sequence<seqan3::dna4>());
+    using sequence_t = decltype(seqan3::test::generate_sequence<seqan3::dna4>());
 
     std::vector<std::pair<sequence_t, sequence_t>> vec;
     for (unsigned i = 0; i < 100; ++i)
     {
-        sequence_t seq1 = generate_sequence<seqan3::dna4>(100, 0, i);
-        sequence_t seq2 = generate_sequence<seqan3::dna4>(50, 0, i + 100);
+        sequence_t seq1 = seqan3::test::generate_sequence<seqan3::dna4>(100, 0, i);
+        sequence_t seq2 = seqan3::test::generate_sequence<seqan3::dna4>(50, 0, i + 100);
         vec.push_back(std::pair{seq1, seq2});
     }
 
@@ -145,8 +147,8 @@ void seqan3_affine_dna4_collection(benchmark::State & state)
             rng.score();
     }
 
-    state.counters["cells"] = pairwise_cell_updates(vec, local_affine_cfg);
-    state.counters["CUPS"] = cell_updates_per_second(state.counters["cells"]);
+    state.counters["cells"] = seqan3::test::pairwise_cell_updates(vec, local_affine_cfg);
+    state.counters["CUPS"] = seqan3::test::cell_updates_per_second(state.counters["cells"]);
 }
 
 BENCHMARK(seqan3_affine_dna4_collection);
@@ -183,13 +185,13 @@ BENCHMARK(seqan2_affine_dna4_collection);
 
 void seqan3_affine_dna4_trace_collection(benchmark::State & state)
 {
-    using sequence_t = decltype(generate_sequence<seqan3::dna4>());
+    using sequence_t = decltype(seqan3::test::generate_sequence<seqan3::dna4>());
 
     std::vector<std::pair<sequence_t, sequence_t>> vec;
     for (unsigned i = 0; i < 100; ++i)
     {
-        sequence_t seq1 = generate_sequence<seqan3::dna4>(100, 0, i);
-        sequence_t seq2 = generate_sequence<seqan3::dna4>(50, 0, i + 100);
+        sequence_t seq1 = seqan3::test::generate_sequence<seqan3::dna4>(100, 0, i);
+        sequence_t seq2 = seqan3::test::generate_sequence<seqan3::dna4>(50, 0, i + 100);
         vec.push_back(std::pair{seq1, seq2});
     }
 
@@ -199,8 +201,8 @@ void seqan3_affine_dna4_trace_collection(benchmark::State & state)
             rng.score();
     }
 
-    state.counters["cells"] = pairwise_cell_updates(vec, local_affine_cfg);
-    state.counters["CUPS"] = cell_updates_per_second(state.counters["cells"]);
+    state.counters["cells"] = seqan3::test::pairwise_cell_updates(vec, local_affine_cfg);
+    state.counters["CUPS"] = seqan3::test::cell_updates_per_second(state.counters["cells"]);
 }
 
 BENCHMARK(seqan3_affine_dna4_trace_collection);
@@ -237,8 +239,8 @@ void seqan2_affine_dna4_trace_collection(benchmark::State & state)
         seqan::localAlignment(gap1, gap2, seqan::Score<int>{4, -5, -1, -11}, seqan::Gotoh());
     }
 
-    state.counters["cells"] = pairwise_cell_updates(seqan3::views::zip(vec1, vec2), local_affine_cfg);
-    state.counters["CUPS"] = cell_updates_per_second(state.counters["cells"]);
+    state.counters["cells"] = seqan3::test::pairwise_cell_updates(seqan3::views::zip(vec1, vec2), local_affine_cfg);
+    state.counters["CUPS"] = seqan3::test::cell_updates_per_second(state.counters["cells"]);
 }
 
 BENCHMARK(seqan2_affine_dna4_trace_collection);

--- a/test/performance/example/example_benchmark.cpp
+++ b/test/performance/example/example_benchmark.cpp
@@ -12,8 +12,6 @@
 
 #include <seqan3/test/performance/units.hpp>
 
-using namespace seqan3::test;
-
 static void vector_copy_benchmark(benchmark::State & state) {
     std::vector<int> x = {15, 13, 12, 10};
     for (auto _ : state)
@@ -29,7 +27,7 @@ static void memcpy_benchmark(benchmark::State & state) {
     for (auto _ : state)
         memcpy(dst, src, size);
 
-    state.counters["bytes_per_second"] = bytes_per_second(size);
+    state.counters["bytes_per_second"] = seqan3::test::bytes_per_second(size);
     delete[] src;
     delete[] dst;
 }
@@ -43,7 +41,7 @@ static void copy_benchmark(benchmark::State & state) {
     for (auto _ : state)
         std::copy_n(src, size, dst);
 
-    state.counters["bytes_per_second"] = bytes_per_second(size);
+    state.counters["bytes_per_second"] = seqan3::test::bytes_per_second(size);
     delete[] src;
     delete[] dst;
 }

--- a/test/performance/io/format_fasta_benchmark.cpp
+++ b/test/performance/io/format_fasta_benchmark.cpp
@@ -29,8 +29,6 @@
 
 #include <sstream>
 
-using namespace seqan3::test;
-
 inline constexpr size_t iterations_per_run = 1024;
 
 inline std::string const fasta_hdr{"seq foobar blobber"};
@@ -68,7 +66,7 @@ void write3(benchmark::State & state)
     size_t bytes_per_run = ostream.str().size() * iterations_per_run;
     state.counters["iterations_per_run"] = iterations_per_run;
     state.counters["bytes_per_run"] = bytes_per_run;
-    state.counters["bytes_per_second"] = bytes_per_second(bytes_per_run);
+    state.counters["bytes_per_second"] = seqan3::test::bytes_per_second(bytes_per_run);
 }
 
 BENCHMARK(write3);
@@ -92,7 +90,7 @@ void write2(benchmark::State & state)
     size_t bytes_per_run = ostream.str().size() * iterations_per_run;
     state.counters["iterations_per_run"] = iterations_per_run;
     state.counters["bytes_per_run"] = bytes_per_run;
-    state.counters["bytes_per_second"] = bytes_per_second(bytes_per_run);
+    state.counters["bytes_per_second"] = seqan3::test::bytes_per_second(bytes_per_run);
 }
 
 BENCHMARK(write2);
@@ -116,7 +114,7 @@ void read3(benchmark::State & state)
     size_t bytes_per_run = fasta_file.size();
     state.counters["iterations_per_run"] = iterations_per_run;
     state.counters["bytes_per_run"] = bytes_per_run;
-    state.counters["bytes_per_second"] = bytes_per_second(bytes_per_run);
+    state.counters["bytes_per_second"] = seqan3::test::bytes_per_second(bytes_per_run);
 }
 BENCHMARK(read3);
 
@@ -148,7 +146,7 @@ void read2(benchmark::State & state)
     size_t bytes_per_run = fasta_file.size();
     state.counters["iterations_per_run"] = iterations_per_run;
     state.counters["bytes_per_run"] = bytes_per_run;
-    state.counters["bytes_per_second"] = bytes_per_second(bytes_per_run);
+    state.counters["bytes_per_second"] = seqan3::test::bytes_per_second(bytes_per_run);
 }
 BENCHMARK(read2);
 #endif

--- a/test/performance/io/format_vienna_benchmark.cpp
+++ b/test/performance/io/format_vienna_benchmark.cpp
@@ -25,15 +25,13 @@
     #include <seqan/rna_io.h>
 #endif
 
-using namespace seqan3::test;
-
 inline constexpr size_t iterations_per_run = 1024;
 
 inline std::string const header{"seq foobar blobber"};
-auto const sequence = generate_sequence<seqan3::rna4>(474, 0, 0) |
-                                        seqan3::views::persist |
-                                        seqan3::views::to_char |
-                                        seqan3::views::to<std::string>;
+auto const sequence = seqan3::test::generate_sequence<seqan3::rna4>(474, 0, 0) |
+                                                      seqan3::views::persist |
+                                                      seqan3::views::to_char |
+                                                      seqan3::views::to<std::string>;
 
 inline std::string const structure
 {
@@ -69,7 +67,7 @@ void write_seqan3(benchmark::State & state)
     size_t bytes_per_run = ostream.str().size() * iterations_per_run;
     state.counters["iterations_per_run"] = iterations_per_run;
     state.counters["bytes_per_run"] = bytes_per_run;
-    state.counters["bytes_per_second"] = bytes_per_second(bytes_per_run);
+    state.counters["bytes_per_second"] = seqan3::test::bytes_per_second(bytes_per_run);
 }
 BENCHMARK(write_seqan3);
 
@@ -93,7 +91,7 @@ void write_seqan2(benchmark::State & state)
     size_t bytes_per_run = ostream.str().size() * iterations_per_run;
     state.counters["iterations_per_run"] = iterations_per_run;
     state.counters["bytes_per_run"] = bytes_per_run;
-    state.counters["bytes_per_second"] = bytes_per_second(bytes_per_run);
+    state.counters["bytes_per_second"] = seqan3::test::bytes_per_second(bytes_per_run);
 }
 BENCHMARK(write_seqan2);
 #endif
@@ -116,7 +114,7 @@ void read_seqan3(benchmark::State & state)
     size_t bytes_per_run = vienna_file.size();
     state.counters["iterations_per_run"] = iterations_per_run;
     state.counters["bytes_per_run"] = bytes_per_run;
-    state.counters["bytes_per_second"] = bytes_per_second(bytes_per_run);
+    state.counters["bytes_per_second"] = seqan3::test::bytes_per_second(bytes_per_run);
 }
 BENCHMARK(read_seqan3);
 
@@ -142,7 +140,7 @@ void read_seqan2(benchmark::State & state)
     size_t bytes_per_run = vienna_file.size();
     state.counters["iterations_per_run"] = iterations_per_run;
     state.counters["bytes_per_run"] = bytes_per_run;
-    state.counters["bytes_per_second"] = bytes_per_second(bytes_per_run);
+    state.counters["bytes_per_second"] = seqan3::test::bytes_per_second(bytes_per_run);
 }
 BENCHMARK(read_seqan2);
 #endif

--- a/test/performance/range/views/view_translate_1D_benchmark.cpp
+++ b/test/performance/range/views/view_translate_1D_benchmark.cpp
@@ -22,8 +22,6 @@
 #include <seqan/translation.h>
 #endif
 
-using namespace seqan3::test;
-
 // Tags used to define the benchmark type
 struct baseline_tag{}; // Baseline where view is applied and only iterating the output range is benchmarked
 struct translate_tag{}; // Benchmark seqan3::views::translate_single

--- a/test/performance/range/views/view_translate_2D_1D_benchmark.cpp
+++ b/test/performance/range/views/view_translate_2D_1D_benchmark.cpp
@@ -24,8 +24,6 @@
 #include <seqan/translation.h>
 #endif
 
-using namespace seqan3::test;
-
 // Tags used to define the benchmark type
 struct baseline_tag{}; // Baseline where view is applied and only iterating the output range is benchmarked
 struct translate_tag{}; // Benchmark view_translate followed by seqan3::views::join

--- a/test/performance/range/views/view_translate_2D_benchmark.cpp
+++ b/test/performance/range/views/view_translate_2D_benchmark.cpp
@@ -24,8 +24,6 @@
 #include <seqan/translation.h>
 #endif
 
-using namespace seqan3::test;
-
 // Tags used to define the benchmark type
 struct baseline_tag{}; // Baseline where view is applied and only iterating the output range is benchmarked
 struct translate_tag{}; // Benchmark view_translate followed by seqan3::views::join

--- a/test/performance/search/dream_index/interleaved_bloom_filter_benchmark.cpp
+++ b/test/performance/search/dream_index/interleaved_bloom_filter_benchmark.cpp
@@ -11,8 +11,6 @@
 #include <seqan3/search/dream_index/interleaved_bloom_filter.hpp>
 #include <seqan3/test/performance/sequence_generator.hpp>
 
-using namespace seqan3;
-
 inline benchmark::Counter hashes_per_second(size_t const count)
 {
     return benchmark::Counter(count,
@@ -37,11 +35,11 @@ static void arguments(benchmark::internal::Benchmark* b)
 template <typename ibf_type>
 auto set_up(size_t bins, size_t bits, size_t hash_num, size_t sequence_length)
 {
-    auto bin_indices = test::generate_numeric_sequence<size_t>(sequence_length, 0u, bins - 1);
-    auto hash_values = test::generate_numeric_sequence<size_t>(sequence_length);
-    interleaved_bloom_filter tmp_ibf(seqan3::bin_count{bins},
-                                     seqan3::bin_size{bits},
-                                     seqan3::hash_function_count{hash_num});
+    auto bin_indices = seqan3::test::generate_numeric_sequence<size_t>(sequence_length, 0u, bins - 1);
+    auto hash_values = seqan3::test::generate_numeric_sequence<size_t>(sequence_length);
+    seqan3::interleaved_bloom_filter tmp_ibf(seqan3::bin_count{bins},
+                                             seqan3::bin_size{bits},
+                                             seqan3::hash_function_count{hash_num});
 
     ibf_type ibf{std::move(tmp_ibf)};
 
@@ -83,9 +81,12 @@ void bulk_contains_benchmark(::benchmark::State & state)
     state.counters["hashes/sec"] = hashes_per_second(std::ranges::size(hash_values));
 }
 
-BENCHMARK_TEMPLATE(emplace_benchmark, interleaved_bloom_filter<data_layout::uncompressed>)->Apply(arguments);
+BENCHMARK_TEMPLATE(emplace_benchmark,
+                   seqan3::interleaved_bloom_filter<seqan3::data_layout::uncompressed>)->Apply(arguments);
 
-BENCHMARK_TEMPLATE(bulk_contains_benchmark, interleaved_bloom_filter<data_layout::uncompressed>)->Apply(arguments);
-BENCHMARK_TEMPLATE(bulk_contains_benchmark, interleaved_bloom_filter<data_layout::compressed>)->Apply(arguments);
+BENCHMARK_TEMPLATE(bulk_contains_benchmark,
+                   seqan3::interleaved_bloom_filter<seqan3::data_layout::uncompressed>)->Apply(arguments);
+BENCHMARK_TEMPLATE(bulk_contains_benchmark,
+                   seqan3::interleaved_bloom_filter<seqan3::data_layout::compressed>)->Apply(arguments);
 
 BENCHMARK_MAIN();

--- a/test/performance/search/search_benchmark.cpp
+++ b/test/performance/search/search_benchmark.cpp
@@ -15,8 +15,6 @@
 #include <seqan3/range/views/join.hpp>
 #include <seqan3/range/views/to.hpp>
 
-using namespace seqan3::test;
-
 struct options
 {
     size_t const sequence_length;
@@ -130,7 +128,7 @@ std::vector<alphabet_t> generate_repeating_sequence(size_t const template_length
                                                     double const template_fraction = 1,
                                                     size_t const seed = 0)
 {
-    std::vector<alphabet_t> seq_template = generate_sequence<alphabet_t>(template_length, 0, seed);
+    std::vector<alphabet_t> seq_template = seqan3::test::generate_sequence<alphabet_t>(template_length, 0, seed);
 
     // copy substrings of length len from seq_template mutate and concatenate them
     size_t len = std::round(template_length * template_fraction);
@@ -154,7 +152,7 @@ void unidirectional_search_all_collection(benchmark::State & state, options && o
     std::vector<std::vector<seqan3::dna4>> reads;
     for (size_t i = 0; i < set_size; ++i)
     {
-        collection.push_back(generate_sequence<seqan3::dna4>(o.sequence_length, 0, i));
+        collection.push_back(seqan3::test::generate_sequence<seqan3::dna4>(o.sequence_length, 0, i));
         std::vector<std::vector<seqan3::dna4>> seq_reads = generate_reads(collection.back(), o.number_of_reads,
                                                                           o.read_length, o.simulated_errors,
                                                                           o.prob_insertion, o.prob_deletion,
@@ -178,7 +176,7 @@ void unidirectional_search_all(benchmark::State & state, options && o)
     std::vector<seqan3::dna4> ref = (o.has_repeats) ?
                                     generate_repeating_sequence<seqan3::dna4>(2 * o.sequence_length / o.repeats,
                                                                               o.repeats, 0.5, 0) :
-                                    generate_sequence<seqan3::dna4>(o.sequence_length, 0, 0);
+                                    seqan3::test::generate_sequence<seqan3::dna4>(o.sequence_length, 0, 0);
 
     seqan3::fm_index index{ref};
     std::vector<std::vector<seqan3::dna4>> reads = generate_reads(ref, o.number_of_reads, o.read_length,
@@ -199,7 +197,7 @@ void bidirectional_search_all(benchmark::State & state, options && o)
     std::vector<seqan3::dna4> ref = (o.has_repeats) ?
                                     generate_repeating_sequence<seqan3::dna4>(2 * o.sequence_length / o.repeats,
                                                                               o.repeats, 0.5, 0) :
-                                    generate_sequence<seqan3::dna4>(o.sequence_length, 0, 0);
+                                    seqan3::test::generate_sequence<seqan3::dna4>(o.sequence_length, 0, 0);
 
     seqan3::bi_fm_index index{ref};
     std::vector<std::vector<seqan3::dna4>> reads = generate_reads(ref, o.number_of_reads, o.read_length,
@@ -220,7 +218,7 @@ void unidirectional_search_stratified(benchmark::State & state, options && o)
     std::vector<seqan3::dna4> ref = (o.has_repeats) ?
                                     generate_repeating_sequence<seqan3::dna4>(2 * o.sequence_length / o.repeats,
                                                                               o.repeats, 0.5, 0) :
-                                    generate_sequence<seqan3::dna4>(o.sequence_length, 0, 0);
+                                    seqan3::test::generate_sequence<seqan3::dna4>(o.sequence_length, 0, 0);
 
     seqan3::fm_index index{ref};
     std::vector<std::vector<seqan3::dna4>> reads = generate_reads(ref, o.number_of_reads, o.read_length,
@@ -242,7 +240,7 @@ void bidirectional_search_stratified(benchmark::State & state, options && o)
     std::vector<seqan3::dna4> ref = (o.has_repeats) ?
                                     generate_repeating_sequence<seqan3::dna4>(2 * o.sequence_length / o.repeats,
                                                                               o.repeats, 0.5, 0) :
-                                    generate_sequence<seqan3::dna4>(o.sequence_length, 0, 0);
+                                    seqan3::test::generate_sequence<seqan3::dna4>(o.sequence_length, 0, 0);
 
     seqan3::bi_fm_index index{ref};
     std::vector<std::vector<seqan3::dna4>> reads = generate_reads(ref, o.number_of_reads, o.read_length,

--- a/test/snippet/alignment/matrix/detail/alignment_matrix_column_major_range_base.cpp
+++ b/test/snippet/alignment/matrix/detail/alignment_matrix_column_major_range_base.cpp
@@ -4,14 +4,12 @@
 #include <seqan3/core/debug_stream.hpp>
 #include <seqan3/std/span>
 
-using namespace seqan3::detail;
-
-class my_matrix : public alignment_matrix_column_major_range_base<my_matrix>
+class my_matrix : public seqan3::detail::alignment_matrix_column_major_range_base<my_matrix>
 {
 public:
 
     // Alias the base class
-    using base_t = alignment_matrix_column_major_range_base<my_matrix>;
+    using base_t = seqan3::detail::alignment_matrix_column_major_range_base<my_matrix>;
 
     friend base_t;
 


### PR DESCRIPTION
This should be the last PR for this topic.
Found and removed:
- One comment in the `include` directory,
- some last `using namespace seqan3::test` in `test/performance`,
- And one `using namespace seqan3::detail` in `test/snippet`.

(Resolves ... Is there any issue for the whole task?)