### PR TITLE
[TEST] Introduce a config element test template.

### DIFF
--- a/test/unit/alignment/configuration/align_config_mode_test.cpp
+++ b/test/unit/alignment/configuration/align_config_mode_test.cpp
@@ -12,17 +12,27 @@
 #include <seqan3/alignment/configuration/align_config_mode.hpp>
 #include <seqan3/core/algorithm/configuration.hpp>
 
+#include "../../core/algorithm/pipeable_config_element_test_template.hpp"
+
+// ---------------------------------------------------------------------------------------------------------------------
+// pipeable_config_element_test template
+// ---------------------------------------------------------------------------------------------------------------------
+
+using config_element_types = ::testing::Types<seqan3::align_cfg::mode<seqan3::detail::global_alignment_type>,
+                                              seqan3::align_cfg::mode<seqan3::detail::local_alignment_type>>;
+
+INSTANTIATE_TYPED_TEST_SUITE_P(mode, pipeable_config_element_test, config_element_types, );
+
+// ---------------------------------------------------------------------------------------------------------------------
+// align_cfg_mode_test
+// ---------------------------------------------------------------------------------------------------------------------
+
 template <typename type>
 struct align_cfg_mode_test : public ::testing::Test
 {};
 
 using test_types = ::testing::Types<seqan3::detail::global_alignment_type, seqan3::detail::local_alignment_type>;
 TYPED_TEST_SUITE(align_cfg_mode_test, test_types, );
-
-TYPED_TEST(align_cfg_mode_test, config_element)
-{
-    EXPECT_EQ(seqan3::detail::config_element<seqan3::align_cfg::mode<TypeParam>>, true);
-}
 
 TYPED_TEST(align_cfg_mode_test, configuration)
 {

--- a/test/unit/core/algorithm/pipeable_config_element_test_template.hpp
+++ b/test/unit/core/algorithm/pipeable_config_element_test_template.hpp
@@ -1,0 +1,94 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+// This file can be used to test the basic functionality of a configuration element
+
+#include <gtest/gtest.h>
+
+#include <seqan3/core/algorithm/configuration.hpp>
+#include <seqan3/core/algorithm/pipeable_config_element.hpp>
+
+#include "configuration_mock.hpp"
+
+template <typename format_t>
+struct pipeable_config_element_test : public ::testing::Test
+{};
+
+TYPED_TEST_SUITE_P(pipeable_config_element_test);
+
+TYPED_TEST_P(pipeable_config_element_test, concept_check)
+{
+    EXPECT_TRUE((seqan3::detail::config_element<TypeParam>));
+}
+
+TYPED_TEST_P(pipeable_config_element_test, standard_construction)
+{
+    EXPECT_TRUE((std::is_default_constructible_v<TypeParam>));
+    EXPECT_TRUE((std::is_copy_constructible_v<TypeParam>));
+    EXPECT_TRUE((std::is_move_constructible_v<TypeParam>));
+    EXPECT_TRUE((std::is_copy_assignable_v<TypeParam>));
+    EXPECT_TRUE((std::is_move_assignable_v<TypeParam>));
+}
+
+TYPED_TEST_P(pipeable_config_element_test, configuration_construction)
+{
+    seqan3::configuration cfg{TypeParam{}};
+    EXPECT_TRUE((std::same_as<decltype(cfg), seqan3::configuration<TypeParam>>));
+}
+
+TYPED_TEST_P(pipeable_config_element_test, configuration_assignment)
+{
+    seqan3::configuration cfg = TypeParam{};
+    EXPECT_TRUE((std::same_as<decltype(cfg), seqan3::configuration<TypeParam>>));
+}
+
+// make mock config element foo always pipeable with any other config element
+namespace seqan3::detail
+{
+
+template <typename t>
+struct is_configuration_valid<t, foo> : public std::true_type
+{};
+
+template <typename t>
+struct is_configuration_valid<foo, t> : public std::true_type
+{};
+
+}
+
+TYPED_TEST_P(pipeable_config_element_test, pipeability)
+{
+    TypeParam elem{};
+    foo dummy{};
+
+    {   // lvalue | lvalue
+        auto cfg = dummy | elem;
+        EXPECT_TRUE((std::is_same_v<decltype(cfg), seqan3::configuration<foo, TypeParam>>));
+    }
+
+    {   // rvalue | lvalue
+        auto cfg = TypeParam{} | dummy;
+        EXPECT_TRUE((std::is_same_v<decltype(cfg), seqan3::configuration<TypeParam, foo>>));
+    }
+
+    {   // lvalue | rvalue
+        auto cfg = dummy | TypeParam{};
+        EXPECT_TRUE((std::is_same_v<decltype(cfg), seqan3::configuration<foo, TypeParam>>));
+    }
+
+    {   // rvalue | rvalue
+        auto cfg = foo{} | TypeParam{};
+        EXPECT_TRUE((std::is_same_v<decltype(cfg), seqan3::configuration<foo, TypeParam>>));
+    }
+}
+
+REGISTER_TYPED_TEST_SUITE_P(pipeable_config_element_test,
+                            concept_check,
+                            standard_construction,
+                            configuration_construction,
+                            configuration_assignment,
+                            pipeability);


### PR DESCRIPTION
When we will tackle the configuration stuff (I was updating my PR #1639), it will reduce a lot of testing code if we use a test template. Especially because none of the search configurations has an individual test yet.
