### PR TITLE
[FEATURE] Add function remove to seqan3::configuration.

### DIFF
--- a/include/seqan3/core/algorithm/configuration.hpp
+++ b/include/seqan3/core/algorithm/configuration.hpp
@@ -83,6 +83,7 @@ class configuration : public std::tuple<configs_t...>
     //!\brief Friend declaration for other instances of the configuration.
     template <detail::config_element ... _configs_t>
     friend class configuration;
+
 public:
     //!\privatesection
     //!\brief A type alias for the base class.
@@ -425,38 +426,37 @@ private:
     //!\}
 
     /*!\brief Creates a new configuration object by recursively adding the configs from the tuple.
-     * \tparam    tuple_t The tuple from which to create a new configuration object; must model
-                          seqan3::tuple_like and must at least have one element.
-     * \param[in] tpl     The tuple to create the configuration from.
+     * \tparam tuple_t The tuple from which to create a new configuration object; must model seqan3::tuple_like.
+     * \param[in] tpl The tuple to create the configuration from.
      * \returns A new configuration object.
      */
-    template <typename tuple_t>
-    //!\cond
-        requires detail::is_type_specialisation_of_v<tuple_t, std::tuple> &&
-                 (std::tuple_size_v<remove_cvref_t<tuple_t>> > 0)
-    //!\endcond
+    template <tuple_like tuple_t>
     static constexpr auto make_configuration(tuple_t && tpl)
     {
-        auto make_config = [](auto && tpl)
+        if constexpr (std::tuple_size_v<remove_cvref_t<tuple_t>> == 0)
+        {
+            return configuration<>{};
+        }
+        else
         {
             auto impl = [](auto & impl_ref, auto && config, auto && head, auto && tail)
             {
+                using cfg_t = decltype(config);
                 if constexpr (std::tuple_size_v<remove_cvref_t<decltype(tail)>> == 0)
                 {
-                    return std::forward<decltype(config)>(config).push_back(std::get<0>(std::forward<decltype(head)>(head)));
+                    return std::forward<cfg_t>(config).push_back(std::get<0>(std::forward<decltype(head)>(head)));
                 }
                 else
                 {
                     auto [_head, _tail] = tuple_split<1>(std::forward<decltype(tail)>(tail));
-                    auto tmp = std::forward<decltype(config)>(config).push_back(
-                            std::get<0>(std::forward<decltype(head)>(head)));
+                    auto tmp = std::forward<cfg_t>(config).push_back(std::get<0>(std::forward<decltype(head)>(head)));
                     return impl_ref(impl_ref, std::move(tmp), std::move(_head), std::move(_tail));
                 }
             };
+
             auto [head, tail] = tuple_split<1>(std::forward<decltype(tpl)>(tpl));
             return impl(impl, configuration<>{}, std::move(head), std::move(tail));
-        };
-        return make_config(std::forward<tuple_t>(tpl));
+        }
     }
 
     /*!\name Modifiers

--- a/test/unit/core/algorithm/configuration_test.cpp
+++ b/test/unit/core/algorithm/configuration_test.cpp
@@ -170,6 +170,58 @@ TEST(configuration, exists_by_type_template)
     EXPECT_FALSE(decltype(cfg)::exists<foo>());
 }
 
+TEST(configuration, remove_by_type)
+{
+    {
+        seqan3::configuration<foo, bax, bar> cfg{};
+
+        // remove middle
+        EXPECT_TRUE((std::same_as<decltype(cfg.template remove<bax>()), seqan3::configuration<foo, bar>>));
+        // remove head
+        EXPECT_TRUE((std::same_as<decltype(cfg.template remove<bar>()), seqan3::configuration<foo, bax>>));
+        // remove tail
+        EXPECT_TRUE((std::same_as<decltype(cfg.template remove<foo>()), seqan3::configuration<bax, bar>>));
+
+        seqan3::configuration<foo> single_cfg{};
+        EXPECT_TRUE((std::same_as<decltype(single_cfg.template remove<foo>()), seqan3::configuration<>>));
+    }
+
+    {   // const cfg
+        seqan3::configuration<foo, bax, bar> const cfg{};
+
+        // remove middle
+        EXPECT_TRUE((std::same_as<decltype(cfg.template remove<bax>()), seqan3::configuration<foo, bar>>));
+        // remove head
+        EXPECT_TRUE((std::same_as<decltype(cfg.template remove<bar>()), seqan3::configuration<foo, bax>>));
+        // remove tail
+        EXPECT_TRUE((std::same_as<decltype(cfg.template remove<foo>()), seqan3::configuration<bax, bar>>));
+
+        seqan3::configuration<foo> const single_cfg{};
+        EXPECT_TRUE((std::same_as<decltype(single_cfg.template remove<foo>()), seqan3::configuration<>>));
+    }
+}
+
+TEST(configuration, remove_by_type_template)
+{
+    {
+        seqan3::configuration<foo, foobar<>, bar> cfg{};
+
+        EXPECT_TRUE((std::same_as<decltype(cfg.template remove<foobar>()), seqan3::configuration<foo, bar>>));
+
+        seqan3::configuration<foobar<>> single_cfg{};
+        EXPECT_TRUE((std::same_as<decltype(single_cfg.template remove<foobar>()), seqan3::configuration<>>));
+    }
+
+    {   //const cfg
+        seqan3::configuration<foo, foobar<>, bar> const cfg{};
+
+        EXPECT_TRUE((std::same_as<decltype(cfg.template remove<foobar>()), seqan3::configuration<foo, bar>>));
+
+        seqan3::configuration<foobar<>> const single_cfg{};
+        EXPECT_TRUE((std::same_as<decltype(single_cfg.template remove<foobar>()), seqan3::configuration<>>));
+    }
+}
+
 TEST(configuration, value_or_by_type)
 {
     seqan3::configuration cfg = bax{2.2} | bar{1};


### PR DESCRIPTION
This will make it easy to remove a dynamic configuration selector (see #1580 for details on the naming) and replace it with a static configuration.

E.g.
```cpp
    seqan3::configuration user_cfg = seqan3::search_cfg::mode{seqan3::search_cfg::hit_all};

    // somewhere over the rainbow
    auto mode_selection = get<seqan3::search_cfg::mode>(user_cfg).selection;
    auto stripped_cfg = user_cfg.template remove<seqan3::search_cfg::mode>(); // remove dynamic mode
    // select static config
    if (mode_selection == seqan3::search_cfg::hit_all)
        return  | seqan3::search_cfg::hit_all;
    else if (...)
    // ...
```