### PR TITLE
Optimise alignment/part2 optimum tracker policy

### DIFF
--- a/include/seqan3/alignment/pairwise/alignment_configurator.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_configurator.hpp
@@ -23,6 +23,7 @@
 #include <seqan3/alignment/matrix/detail/alignment_trace_matrix_full.hpp>
 #include <seqan3/alignment/matrix/detail/alignment_trace_matrix_full_banded.hpp>
 #include <seqan3/alignment/pairwise/detail/policy_affine_gap_recursion.hpp>
+#include <seqan3/alignment/pairwise/detail/policy_optimum_tracker.hpp>
 #include <seqan3/alignment/pairwise/policy/affine_gap_policy.hpp>
 #include <seqan3/alignment/pairwise/policy/affine_gap_init_policy.hpp>
 #include <seqan3/alignment/pairwise/policy/alignment_matrix_policy.hpp>
@@ -511,9 +512,10 @@ private:
         }
         else  // Use new alignment algorithm implementation.
         {
+            using optimum_tracker_policy_t = policy_optimum_tracker<config_t>;
             using gap_cost_policy_t = policy_affine_gap_recursion<config_t>;
 
-            return pairwise_alignment_algorithm<config_t, gap_cost_policy_t>{cfg};
+            return pairwise_alignment_algorithm<config_t, gap_cost_policy_t, optimum_tracker_policy_t>{cfg};
         }
     }
 };

--- a/include/seqan3/alignment/pairwise/detail/policy_optimum_tracker.hpp
+++ b/include/seqan3/alignment/pairwise/detail/policy_optimum_tracker.hpp
@@ -1,0 +1,173 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides seqan3::detail::policy_optimum_tracker.
+ * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <limits>
+
+#include <seqan3/alignment/pairwise/detail/type_traits.hpp>
+#include <seqan3/core/algorithm/configuration.hpp>
+#include <seqan3/core/type_traits/template_inspection.hpp>
+
+namespace seqan3::detail
+{
+
+/*!\brief Implements the tracker to store the global optimum for a particular alignment computation.
+ * \ingroup pairwise_alignment
+ *
+ * \tparam alignment_configuration_t The type of the alignment configuration; must be a type specialisation of
+ *                                   seqan3::configuration.
+ *
+ * \details
+ *
+ * Implements the interface to track the alignment optimum. It updates the currently stored optimum if the
+ * optimal score of the given cell compares greater or equal to the stored optimum.
+ * Special methods are offered to track any cell (for example when computing the local alignment), the last cell of a
+ * column or a row (for example when using free-end gaps), or the final cell of the entire matrix (for example in the
+ * standard global alignment).
+ * Depending on the configuration they might or might not evaluate the stored optimum score of that cell to compare
+ * it with the currently stored optimum.
+ * The optimum needs to be reset in between alignment computations in order to ensure that the correct result is
+ * tracked.
+ */
+template <typename alignment_configuration_t>
+//!\cond
+    requires is_type_specialisation_of_v<alignment_configuration_t, configuration>
+//!\endcond
+class policy_optimum_tracker
+{
+private:
+    //!\brief The configuration traits type.
+    using traits_type = alignment_configuration_traits<alignment_configuration_t>;
+    //!\brief The configured score type.
+    using score_type = typename traits_type::score_type;
+
+    //!\brief The tracked score of the global optimum.
+    score_type m_optimal_score{};
+
+protected:
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    policy_optimum_tracker() = default; //!< Defaulted.
+    policy_optimum_tracker(policy_optimum_tracker const &) = default; //!< Defaulted.
+    policy_optimum_tracker(policy_optimum_tracker &&) = default; //!< Defaulted.
+    policy_optimum_tracker & operator=(policy_optimum_tracker const &) = default; //!< Defaulted.
+    policy_optimum_tracker & operator=(policy_optimum_tracker &&) = default; //!< Defaulted.
+    ~policy_optimum_tracker() = default; //!< Defaulted.
+
+    /*!\brief Construction and initialisation using the alignment configuration.
+     * \param[in] config The alignment configuration (not used in this context).
+     *
+     * \details
+     *
+     * Resets the optimum on construction.
+     */
+    policy_optimum_tracker(alignment_configuration_t const & SEQAN3_DOXYGEN_ONLY(config))
+    {
+        reset_optimum();
+    }
+    //!\}
+
+    /*!\brief Tracks any cell within the alignment matrix.
+     *
+     * \tparam cell_t The cell type of the alignment matrix; must have a member function `optimal_score()`.
+     *
+     * \param[in] cell The current cell to be tracked.
+     *
+     * \returns The forwarded cell.
+     *
+     * \details
+     *
+     * A call to this function only tracks the optimal score of the given cell if the configuration of the alignment
+     * algorithm requires it, for example when a local alignment shall be computed.
+     */
+    template <typename cell_t>
+    decltype(auto) track_cell(cell_t && cell) noexcept
+    {
+        return std::forward<cell_t>(cell);
+    }
+
+    /*!\brief Tracks the last cell of a row within the alignment matrix.
+     *
+     * \tparam cell_t The cell type of the alignment matrix; must have a member function `optimal_score()`.
+     *
+     * \param[in] cell The current cell to be tracked.
+     *
+     * \returns The forwarded cell.
+     *
+     * \details
+     *
+     * A call to this function only tracks the optimal score of the given cell if the configuration of the alignment
+     * algorithm requires it, for example when a semi-global alignment shall be computed.
+     */
+    template <typename cell_t>
+    decltype(auto) track_last_row_cell(cell_t && cell) noexcept
+    {
+        return std::forward<cell_t>(cell);
+    }
+
+    /*!\brief Tracks the last cell of a column within the alignment matrix.
+     *
+     * \tparam cell_t The cell type of the alignment matrix; must have a member function `optimal_score()`.
+     *
+     * \param[in] cell The current cell to be tracked.
+     *
+     * \returns The forwarded cell.
+     *
+     * \details
+     *
+     * A call to this function only tracks the optimal score of the given cell if the configuration of the alignment
+     * algorithm requires it, for example when a semi-global alignment shall be computed.
+     */
+    template <typename cell_t>
+    decltype(auto) track_last_column_cell(cell_t && cell) noexcept
+    {
+        return std::forward<cell_t>(cell);
+    }
+
+    /*!\brief Tracks the final cell of the alignment matrix.
+     *
+     * \tparam cell_t The cell type of the alignment matrix; must have a member function `optimal_score()`.
+     *
+     * \param[in] cell The current cell to be tracked.
+     *
+     * \returns The forwarded cell.
+     *
+     * \details
+     *
+     * A call to this function only tracks the optimal score of the given cell if the configuration of the alignment
+     * algorithm requires it, for example when a global alignment shall be computed.
+     */
+    template <typename cell_t>
+    decltype(auto) track_final_cell(cell_t && cell) noexcept
+    {
+        m_optimal_score = (cell.optimal_score() >= m_optimal_score) ? cell.optimal_score() : m_optimal_score;
+        return std::forward<cell_t>(cell);
+    }
+
+    /*!\brief Returns the stored optimum.
+     *
+     * \returns The stored optimum.
+     */
+    score_type tracked_optimum() const noexcept
+    {
+        return m_optimal_score;
+    }
+
+    //!\brief Resets the optimum such that a new alignment can be computed.
+    void reset_optimum() noexcept
+    {
+        m_optimal_score = std::numeric_limits<score_type>::lowest();
+    }
+};
+} // namespace seqan3::detail

--- a/test/performance/alignment/global_affine_alignment_benchmark.cpp
+++ b/test/performance/alignment/global_affine_alignment_benchmark.cpp
@@ -59,8 +59,8 @@ BENCHMARK(seqan3_affine_dna4);
 void seqan2_affine_dna4(benchmark::State & state)
 {
     size_t sequence_length = 500;
-    auto seq1 = generate_sequence_seqan2<seqan::Dna>(sequence_length, 0, 0);
-    auto seq2 = generate_sequence_seqan2<seqan::Dna>(sequence_length, 0, 1);
+    auto seq1 = seqan3::test::generate_sequence_seqan2<seqan::Dna>(sequence_length, 0, 0);
+    auto seq2 = seqan3::test::generate_sequence_seqan2<seqan::Dna>(sequence_length, 0, 1);
 
     for (auto _ : state)
     {
@@ -102,8 +102,8 @@ BENCHMARK(seqan3_affine_dna4_trace);
 void seqan2_affine_dna4_trace(benchmark::State & state)
 {
     size_t sequence_length = 500;
-    auto seq1 = generate_sequence_seqan2<seqan::Dna>(sequence_length, 0, 0);
-    auto seq2 = generate_sequence_seqan2<seqan::Dna>(sequence_length, 0, 1);
+    auto seq1 = seqan3::test::generate_sequence_seqan2<seqan::Dna>(sequence_length, 0, 0);
+    auto seq2 = seqan3::test::generate_sequence_seqan2<seqan::Dna>(sequence_length, 0, 1);
 
     seqan::Gaps<decltype(seq1)> gap1{seq1};
     seqan::Gaps<decltype(seq2)> gap2{seq2};
@@ -156,14 +156,14 @@ void seqan2_affine_dna4_collection(benchmark::State & state)
 {
     size_t sequence_length = 100;
     size_t set_size = 100;
-    using sequence_t = decltype(generate_sequence_seqan2<seqan::Dna>());
+    using sequence_t = decltype(seqan3::test::generate_sequence_seqan2<seqan::Dna>());
 
     seqan::StringSet<sequence_t> vec1;
     seqan::StringSet<sequence_t> vec2;
     for (unsigned i = 0; i < set_size; ++i)
     {
-        sequence_t seq1 = generate_sequence_seqan2<seqan::Dna>(sequence_length, 0, i);
-        sequence_t seq2 = generate_sequence_seqan2<seqan::Dna>(sequence_length, 0, i + set_size);
+        sequence_t seq1 = seqan3::test::generate_sequence_seqan2<seqan::Dna>(sequence_length, 0, i);
+        sequence_t seq2 = seqan3::test::generate_sequence_seqan2<seqan::Dna>(sequence_length, 0, i + set_size);
         appendValue(vec1, seq1);
         appendValue(vec2, seq2);
     }
@@ -217,14 +217,14 @@ void seqan2_affine_dna4_trace_collection(benchmark::State & state)
 {
     size_t sequence_length = 100;
     size_t set_size = 100;
-    using sequence_t = decltype(generate_sequence_seqan2<seqan::Dna>());
+    using sequence_t = decltype(seqan3::test::generate_sequence_seqan2<seqan::Dna>());
 
     seqan::StringSet<sequence_t> vec1;
     seqan::StringSet<sequence_t> vec2;
     for (unsigned i = 0; i < set_size; ++i)
     {
-        sequence_t seq1 = generate_sequence_seqan2<seqan::Dna>(sequence_length, 0, i);
-        sequence_t seq2 = generate_sequence_seqan2<seqan::Dna>(sequence_length, 0, i + set_size);
+        sequence_t seq1 = seqan3::test::generate_sequence_seqan2<seqan::Dna>(sequence_length, 0, i);
+        sequence_t seq2 = seqan3::test::generate_sequence_seqan2<seqan::Dna>(sequence_length, 0, i + set_size);
         appendValue(vec1, seq1);
         appendValue(vec2, seq2);
     }


### PR DESCRIPTION
In the new alignment implementation we let the alignment algorithm decide when to check for the new alignment optimum. This removes the dependency between the recursion policy and the tracker policy as we used it before. This in turn allows us to remove the CRTP design from the alignment algorithm. The performance is still very competitive as the microbenchmark shows below. My macrobenchmarks on this design confirmed this as well.

This includes only the pre-work and does only work for the global alignment so far. My goal is to get as quickly as possible all minimal requirements into the new alignment design to provide a working vectorised version which has the optimal runtime of SeqAn2. For this I need to provide a special tracker that overloads the current one in order to check the end points for sequences that have not the same size in the batch. This is a general problem with our inter-sequence vectorisation design and my initial benchmarks show for the new version a 1.5x speedup over the implementation in SeqAn2.

Old microbenchmark of global affine alignment without vectorisation:
```
----------------------------------------------------------------------------------------------
Benchmark                                    Time             CPU   Iterations UserCounters...
----------------------------------------------------------------------------------------------
seqan3_affine_dna4                      912108 ns       901837 ns          724 CUPS=278.322M/s cells=251.001k
seqan2_affine_dna4                      507343 ns       501442 ns         1293 CUPS=500.558M/s cells=251.001k

seqan3_affine_dna4_collection          3780352 ns      3737470 ns          185 CUPS=272.939M/s cells=1020.1k
seqan2_affine_dna4_collection          2544802 ns      2516513 ns          273 CUPS=405.363M/s cells=1020.1k
```

New microbenchmark of global affine alignment without vectorisation:

```
----------------------------------------------------------------------------------------------
Benchmark                                    Time             CPU   Iterations UserCounters...
----------------------------------------------------------------------------------------------
seqan3_affine_dna4                      508742 ns       501681 ns         1315 CUPS=500.32M/s cells=251.001k
seqan2_affine_dna4                      506287 ns       500708 ns         1280 CUPS=501.292M/s cells=251.001k

seqan3_affine_dna4_collection          2098579 ns      2070642 ns          332 CUPS=492.649M/s cells=1020.1k
seqan2_affine_dna4_collection          2559029 ns      2508209 ns          273 CUPS=406.705M/s cells=1020.1k
```