### PR TITLE
gcc-10 --std=c++2a iterators

### DIFF
--- a/include/seqan3/std/iterator
+++ b/include/seqan3/std/iterator
@@ -37,6 +37,22 @@ concept writable = ::std::indirectly_writable<Out, T>;
 } // namespace std::deprecated
 } // namespace std
 
+// we wrongly assume that these are in std::ranges namespace, even though they are in std namespace
+namespace std::ranges
+{
+inline namespace deprecated
+{
+// https://eel.is/c++draft/iterator.synopsis#lib:default_sentinel
+// // Header <iterator> synopsis
+// // [default.sentinels], default sentinels
+// struct default_sentinel_t;
+// inline constexpr default_sentinel_t default_sentinel{};
+using ::std::default_sentinel_t;
+using ::std::default_sentinel;
+using ::std::back_inserter;
+} // namespace std::ranges::deprecated
+} // namespace std::ranges
+
 #else // implement C++20 iterators via range-v3
 
 #ifndef RANGES_DEEP_STL_INTEGRATION

--- a/include/seqan3/std/iterator
+++ b/include/seqan3/std/iterator
@@ -15,7 +15,29 @@
 
 #include <iterator>
 
-#ifndef __cpp_lib_ranges
+#ifdef __cpp_lib_ranges // C++20 iterators
+
+namespace std
+{
+inline namespace deprecated
+{
+//!\cond
+/*!\brief This should be named indirectly_readable.
+ * \deprecated Use std::indirectly_readable instead.
+ */
+template<class T>
+concept readable = ::std::indirectly_readable<T>;
+
+/*!\brief This should be named indirectly_writable.
+ * \deprecated Use std::indirectly_writable instead.
+ */
+template<class Out, class T>
+concept writable = ::std::indirectly_writable<Out, T>;
+//!\endcond
+} // namespace std::deprecated
+} // namespace std
+
+#else // implement C++20 iterators via range-v3
 
 #ifndef RANGES_DEEP_STL_INTEGRATION
 #define RANGES_DEEP_STL_INTEGRATION 1
@@ -88,7 +110,6 @@ namespace
     using incrementable_traits = ::ranges::incrementable_traits<T>;
     template<typename T>
     using readable_traits = ::ranges::readable_traits<T>;
-
 } // anonymous namespace
 
 } // namespace std


### PR DESCRIPTION
* gcc10-std2a add readable = indirectly_readable to std namespace (for now)
* gcc10-std2a add writable = indirectly_writable to std namespace (for now)

The standard has renamed `std::readable` to `std::indirectly_readable` and
`std::writable` to `std::indirectly_writable`, but we internally use the old names.

To make `-std=c++2a` work, we import the names into the standard namespace.

In a later PR we should do the renaming.

Part of seqan/product_backlog#61

----

We falsely use

* `std::ranges::back_inserter` that is actually in `std::back_inserter`
* `std::ranges::default_sentinel` that is actually in `std::default_sentinel`
* `std::ranges::default_sentinel_t` that is actually in `std::default_sentinel_t`

To make `-std=c++2a` work, we import the names into the standard ranges namespace.

In a later PR we should put them in the namespace they belong.

Part of seqan/product_backlog#61