### PR TITLE
gcc-10 --std=c++2a concepts

### DIFF
--- a/include/seqan3/std/concepts
+++ b/include/seqan3/std/concepts
@@ -17,6 +17,18 @@
 
 #ifdef __cpp_lib_concepts        // C++20 ranges available
 #include <concepts>
+
+namespace std
+{
+inline namespace deprecated
+{
+/*!\brief This should be named default_initializable.
+ * \deprecated Use std::default_initializable instead.
+ */
+template<class T>
+concept default_constructible = default_initializable<T>;
+} // inline namespace std::deprecated
+} // namespace std
 #else                         // use range-v3 to emulate
 
 #include <functional>

--- a/include/seqan3/std/concepts
+++ b/include/seqan3/std/concepts
@@ -54,6 +54,29 @@ concept boolean =
     };
 } // inline namespace std::deprecated
 } // namespace std
+
+namespace std::detail
+{
+/*!\interface   std::detail::weakly_equality_comparable_with <>
+ * \tparam t1   The first type to compare.
+ * \tparam t2   The second type to compare.
+ * \brief       Requires the two operands to be comparable with `==` and `!=` in both directions.
+ * \sa          https://en.cppreference.com/w/cpp/concepts/equality_comparable
+ */
+//!\cond
+template <class T, class U>
+concept weakly_equality_comparable_with =
+    requires(std::remove_reference_t<T> const & t,
+             std::remove_reference_t<U> const & u)
+    {
+        t == u; requires boolean<decltype(t == u)>;
+        t != u; requires boolean<decltype(t != u)>;
+        u == t; requires boolean<decltype(u == t)>;
+        u != t; requires boolean<decltype(u != t)>;
+    };
+//!\endcond
+} // namespace std::detail
+
 #else                         // use range-v3 to emulate
 
 #include <functional>
@@ -444,7 +467,7 @@ namespace std::detail
  * \tparam t1   The first type to compare.
  * \tparam t2   The second type to compare.
  * \brief       Requires the two operands to be comparable with `==` and `!=` in both directions.
- * \sa          https://en.cppreference.com/w/cpp/concepts/weakly_equality_comparable_with
+ * \sa          https://en.cppreference.com/w/cpp/concepts/equality_comparable
  */
 //!\cond
 template <class T, class U>

--- a/include/seqan3/std/concepts
+++ b/include/seqan3/std/concepts
@@ -13,10 +13,11 @@
 
 #pragma once
 
-#include <seqan3/core/platform.hpp>
-
-#ifdef __cpp_lib_concepts        // C++20 ranges available
+#if __has_include(<concepts>)
 #include <concepts>
+#endif // __has_include(<concepts>)
+
+#ifdef __cpp_lib_concepts        // C++20 concepts available
 
 namespace std
 {

--- a/include/seqan3/std/concepts
+++ b/include/seqan3/std/concepts
@@ -27,6 +27,31 @@ inline namespace deprecated
  */
 template<class T>
 concept default_constructible = default_initializable<T>;
+
+/*!\brief This should be removed.
+ * \deprecated No viable alternative.
+ */
+template <class B>
+concept boolean =
+    movable<std::remove_cvref_t<B>> &&
+    requires(std::remove_reference_t<B> const & b1,
+             std::remove_reference_t<B> const & b2, bool const a)
+    {
+        requires convertible_to<const std::remove_reference_t<B>&, bool>;
+        !b1;      requires convertible_to<decltype(!b1), bool>;
+        b1 && a;  requires same_as<decltype(b1 && a), bool>;
+        b1 || a;  requires same_as<decltype(b1 || a), bool>;
+        b1 && b2; requires same_as<decltype(b1 && b2), bool>;
+        a && b2;  requires same_as<decltype(a && b2), bool>;
+        b1 || b2; requires same_as<decltype(b1 || b2), bool>;
+        a || b2;  requires same_as<decltype(a || b2), bool>;
+        b1 == b2; requires convertible_to<decltype(b1 == b2), bool>;
+        b1 == a;  requires convertible_to<decltype(b1 == a), bool>;
+        a == b2;  requires convertible_to<decltype(a == b2), bool>;
+        b1 != b2; requires convertible_to<decltype(b1 != b2), bool>;
+        b1 != a;  requires convertible_to<decltype(b1 != a), bool>;
+        a != b2;  requires convertible_to<decltype(a != b2), bool>;
+    };
 } // inline namespace std::deprecated
 } // namespace std
 #else                         // use range-v3 to emulate


### PR DESCRIPTION
There is no `std::detail::weakly_equality_comparable_with` concept.
The standard introduces a exposition-only concept named `weakly-equality-comparable-with`
(https://eel.is/c++draft/concept.equalitycomparable#1).

This PR adds this concept into the std namespace, but a later PR should
remove all usage of this exposition-only concept or we should move that
concept into the seqan namespace.

Part of seqan/product_backlog#61

---

There is no `std::boolean` concept.
The standard introduces a exposition-only concept named `boolean-testable`
(https://eel.is/c++draft/concepts#concept.booleantestable-1).

This PR adds this concept into the std namespace, but a later PR should
remove all usage of this exposition-only concept or we should move that
concept into the seqan namespace.

Part of seqan/product_backlog#61

---

The standard has renamed `std::default_constructible` to `std::default_initializable`, but we internally use `std::default_constructible`.

To make `-std=c++2a` work, we import the name into the standard namespace.

In a later PR we should do the renaming.

Part of seqan/product_backlog#61