### PR TITLE
gcc-10 --std=c++2a ranges

### DIFF
--- a/include/seqan3/std/ranges
+++ b/include/seqan3/std/ranges
@@ -13,8 +13,35 @@
 
 #pragma once
 
-#if __cpp_lib_ranges // C++20 ranges available
+#if __has_include(<ranges>)
 #include <ranges>
+#endif // __has_include(<ranges>)
+
+#if defined(__cpp_lib_ranges) // C++20 ranges available
+#include <seqan3/std/iterator>
+
+#include <range/v3/range/concepts.hpp>
+
+namespace ranges
+{
+//!\brief std::ranges::views are valid range-v3 views
+template<class T>
+//!\cond
+    requires ::std::derived_from<T, ::std::ranges::view_base>
+//!\endcond
+inline constexpr bool enable_view<T> = true;
+} // namespace ranges
+
+namespace std::ranges
+{
+//!\brief range-v3 views are valid std::ranges::views
+template<class T>
+//!\cond
+    requires ::std::derived_from<T, ::ranges::view_base>
+//!\endcond
+inline constexpr bool enable_view<T> = true;
+} // namespace std::ranges
+
 #else // implement via range-v3
 
 //!\cond

--- a/include/seqan3/std/ranges
+++ b/include/seqan3/std/ranges
@@ -42,6 +42,18 @@ template<class T>
 inline constexpr bool enable_view<T> = true;
 } // namespace std::ranges
 
+namespace std::ranges
+{
+inline namespace deprecated
+{
+/*!\brief this should be in std::ranges::views and not std::ranges
+ * \deprecated Use std::views::all_t instead.
+ */
+template <typename range_t>
+using all_view = std::views::all_t<range_t>;
+} // namespace std::ranges::deprecated
+} // namespace std::ranges
+
 #else // implement via range-v3
 
 //!\cond


### PR DESCRIPTION
This one was a bit unexpected, but ranges and std::ranges define there own `view_base` class and they both say, if my own version of that class is a base class then it is a view.

This fix makes views of these two worlds interoperable.

There is also an open issue in range-v3: ericniebler/range-v3#1470

Part of seqan/product_backlog#61

---

There is no `std::ranges::all_view`

* which should have been in `std::views`
* and was renamed to `std::views::all_t` (https://eel.is/c++draft/ranges).

This PR adds this view into the std ranges namespace, but a later PR should
remove all usage of this.

Part of seqan/product_backlog#61
