### PR TITLE
[FIX] Remove const from static assert

### DIFF
--- a/include/seqan3/range/views/kmer_hash.hpp
+++ b/include/seqan3/range/views/kmer_hash.hpp
@@ -39,7 +39,7 @@ template <std::ranges::view urng_t>
 class kmer_hash_view : public std::ranges::view_interface<kmer_hash_view<urng_t>>
 {
 private:
-    static_assert(std::ranges::forward_range<urng_t const>, "The kmer_hash_view only works on forward_ranges");
+    static_assert(std::ranges::forward_range<urng_t>, "The kmer_hash_view only works on forward_ranges");
     static_assert(semialphabet<std::ranges::range_reference_t<urng_t>>,
                   "The reference type of the underlying range must model seqan3::semialphabet.");
 

--- a/test/unit/range/views/view_kmer_hash_test.cpp
+++ b/test/unit/range/views/view_kmer_hash_test.cpp
@@ -206,3 +206,22 @@ TYPED_TEST(kmer_hash_ungapped_test, issue1719)
         EXPECT_EQ(4u, v3.size());
     }
 }
+
+//https://github.com/seqan/seqan3/issues/1754
+TYPED_TEST(kmer_hash_ungapped_test, issue1754)
+{
+    TypeParam text1{'A'_dna4, 'C'_dna4, 'G'_dna4, 'T'_dna4, 'A'_dna4, 'G'_dna4, 'C'_dna4}; // ACGTAGC
+    if constexpr (std::ranges::bidirectional_range<TypeParam>) // excludes forward_list
+    {
+        EXPECT_NO_THROW(text1 | prefix_until_first_thymine | std::views::reverse | ungapped_view);
+    }
+}
+
+TYPED_TEST(kmer_hash_gapped_test, issue1754)
+{
+    TypeParam text1{'A'_dna4, 'C'_dna4, 'G'_dna4, 'T'_dna4, 'A'_dna4, 'G'_dna4, 'C'_dna4}; // ACGTAGC
+    if constexpr (std::ranges::bidirectional_range<TypeParam>) // excludes forward_list
+    {
+        EXPECT_NO_THROW(text1 | prefix_until_first_thymine | std::views::reverse | gapped_view);
+    }
+}


### PR DESCRIPTION
Kmer_hash view now accepts not const_iterable ranges like the combination of take_until with reverse
Part of #1754 