### PR TITLE
[INFRA] seqan3-config-version.cmake should not disallow 32bit

### DIFF
--- a/build_system/seqan3-config-version.cmake
+++ b/build_system/seqan3-config-version.cmake
@@ -47,6 +47,10 @@ endif()
 # check that the installed version has the same 32/64bit-ness as the one which is currently searching:
 if(NOT "${CMAKE_SIZEOF_VOID_P}" STREQUAL "8")
     math(EXPR installedBits "8 * 8")
-    set(PACKAGE_VERSION "${PACKAGE_VERSION} (${installedBits}bit)")
-    set(PACKAGE_VERSION_UNSUITABLE TRUE)
+    # For some time we set these variables to show that we do not support 32 bit architectures,
+    # but it seems to hard to actively forbid them. Most of the library does build, but some parts
+    # might not.
+    # set(PACKAGE_VERSION "${PACKAGE_VERSION} (${installedBits}bit)")
+    # set(PACKAGE_VERSION_UNSUITABLE TRUE)
+    message (AUTHOR_WARNING "SeqAn3 does not support 32bit architectures; No guarantees; Patches are welcome.")
 endif()


### PR DESCRIPTION
We currently disallow `find_package(SeqAn3)` on 32 bit architectures.

This PR will relax that constraint that `find_package(SeqAn3)` is
now working for every architecture, but issues a warning if we know that
this platform has problems or is unsupported.