### PR TITLE
[TEST] limit test execution to 30s

### DIFF
--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -19,7 +19,7 @@ macro (seqan3_test unit_test_cpp)
     add_executable (${target} ${unit_test_cpp})
     target_link_libraries (${target} seqan3::test::unit)
     if (NOT CMAKE_VERSION VERSION_LESS 3.10) # cmake >= 3.10
-        gtest_discover_tests(${target} TEST_PREFIX "${test_name}::")
+        gtest_discover_tests(${target} TEST_PREFIX "${test_name}::" PROPERTIES TIMEOUT "30")
     else ()
         add_test (NAME "${test_name}" COMMAND ${target})
     endif ()


### PR DESCRIPTION
I ran in a situation where I had an infinite loop and the CI job had to
force quite after one hour of execution. This ensures that every test is
only allowed to execute for 30s.

The 10 longest test run (debug build gcc9) with `-j 8`:

```
> ctest -j 8 > test.output
> awk '{match($0,/[[:digit:]]+.[[:digit:]]+ sec/,a)}{print substr(a[0], 1, length(a[0])-2),$0}' test.output | sort -nk1 -r | cut -f2- -d ' ' | head -n 10

100% tests passed, 0 tests failed out of 6661
s Total Test time (real) =  32.12 sec
s 3486/6661 Test #6195: search/search_scheme_algorithm_test::search_scheme_test.search_scheme_hamming .................................................................................................................................................................................................................................................................................................................................   Passed    6.50 sec
s  892/6661 Test #6196: search/search_scheme_algorithm_test::search_scheme_test.search_scheme_edit ....................................................................................................................................................................................................................................................................................................................................   Passed    3.07 sec
s 6602/6661 Test #6477: search/fm_index_cursor/bi_fm_index_cursor_test::char/bi_fm_index_cursor_test/seqan3::bi_fm_index_cursor<seqan3::bi_fm_index<char, (seqan3::text_layout)0, sdsl::csa_wt<sdsl::wt_pc<sdsl::balanced_shape, sdsl::int_vector<(unsigned char)1>, sdsl::rank_support_v<(unsigned char)1, (unsigned char)1>, sdsl::select_support_scan<(unsig....extend_range_and_cycle .............................................   Passed    1.98 sec
s 6591/6661 Test #6469: search/fm_index_cursor/bi_fm_index_cursor_test::dna5/bi_fm_index_cursor_test/seqan3::bi_fm_index_cursor<seqan3::bi_fm_index<seqan3::dna5, (seqan3::text_layout)0, sdsl::csa_wt<sdsl::wt_pc<sdsl::balanced_shape, sdsl::int_vector<(unsigned char)1>, sdsl::rank_support_v<(unsigned char)1, (unsigned char)1>, sdsl::select_support_sca....extend_range_and_cycle .............................................   Passed    1.89 sec
s 6658/6661 Test #6485: search/fm_index_cursor/bi_fm_index_cursor_collection_test::dna4/bi_fm_index_cursor_collection_test/seqan3::bi_fm_index_cursor<seqan3::bi_fm_index<seqan3::dna4, (seqan3::text_layout)1, sdsl::csa_wt<sdsl::wt_pc<sdsl::balanced_shape, sdsl::int_vector<(unsigned char)1>, sdsl::rank_support_v<(unsigned char)1, (unsigned char)1>, sdsl::select_support_sca....extend_range_and_cycle .......................   Passed    1.82 sec
s 6582/6661 Test #6461: search/fm_index_cursor/bi_fm_index_cursor_test::dna4/bi_fm_index_cursor_test/seqan3::bi_fm_index_cursor<seqan3::bi_fm_index<seqan3::dna4, (seqan3::text_layout)0, sdsl::csa_wt<sdsl::wt_pc<sdsl::balanced_shape, sdsl::int_vector<(unsigned char)1>, sdsl::rank_support_v<(unsigned char)1, (unsigned char)1>, sdsl::select_support_sca....extend_range_and_cycle .............................................   Passed    1.80 sec
s   36/6661 Test #4661: core/parallel/detail/reader_writer_manager_test::reader_writer_manager.parallel ...............................................................................................................................................................................................................................................................................................................................   Passed    1.68 sec
s 6484/6661 Test #6345: search/fm_index_cursor/fm_index_cursor_test::bi_byte_alphabet_traits/fm_index_cursor_test/seqan3::bi_fm_index_cursor<seqan3::bi_fm_index<seqan3::dna4, (seqan3::text_layout)0, sdsl::csa_wt<sdsl::wt_pc<sdsl::balanced_shape, sdsl::int_vector<(unsigned char)1>, sdsl::rank_support_v<(unsigned char)1, (unsigned char)1>, sdsl::select_support_sca....incomplete_alphabet ...................................   Passed    1.53 sec
s 6465/6661 Test #6333: search/fm_index_cursor/fm_index_cursor_test::bi_default_traits/fm_index_cursor_test/seqan3::bi_fm_index_cursor<seqan3::bi_fm_index<seqan3::dna4, (seqan3::text_layout)0, sdsl::csa_wt<sdsl::wt_pc<sdsl::balanced_shape, sdsl::int_vector<(unsigned char)1>, sdsl::rank_support_v<(unsigned char)1, (unsigned char)1>, sdsl::select_support_sca....incomplete_alphabet .........................................   Passed    1.48 sec
s   20/6661 Test #6241: search/dream_index/interleaved_bloom_filter_test::interleaved_bloom_filter_test/seqan3::interleaved_bloom_filter<(seqan3::data_layout)0>.serialisation ........................................................................................................................................................................................................................................................   Passed    1.43 sec
```

I simply took 5 * 6s = 30s. That should be reasonable for most
systems and for our CI.

I'm not sure if we should assume 10 * 6, because emulation can
take as much as 10x slower for sde or qemu.