### PR TITLE
[FIX] cxx20: policy_result_builder::make_results is ambigious

### DIFF
--- a/include/seqan3/search/detail/policy_result_builder.hpp
+++ b/include/seqan3/search/detail/policy_result_builder.hpp
@@ -85,7 +85,8 @@ protected:
      */
     template <typename index_cursor_t, typename configuration_t>
     //!\cond
-        requires search_traits<configuration_t>::search_return_text_position
+        requires search_traits<configuration_t>::search_return_text_position &&
+                 (!search_traits<configuration_t>::search_best_hits)
     //!\endcond
     auto make_results(std::vector<index_cursor_t> internal_hits, configuration_t const &)
     {


### PR DESCRIPTION
Prior to C++20 and gcc 10 [partial ordering of the constraints]
(https://en.cppreference.com/w/cpp/language/constraints#Partial_ordering_of_constraints)
was allowed for any expression that was the same. Starting with gcc10
this ordering is only allowed on actual `concept` definitions.

For example:

```c++
// without concepts
template <int b>
    requires (b >= 1)
constexpr int foo()
{
    return 1;
}

template <int b>
    requires (b >= 1) && (b == 2)
constexpr int foo()
{
    return 10;
}

static_assert(foo<1>() == 1); // always unambiguous
// static_assert(foo<2>() == 10); // ambiguous gcc >= 10
```

`b=2` satisfies the require clauses for both definitions. This means that
both definitions are viable. Before gcc10 it used partial ordering on
expression level that made this construct unambiguous.

A solution would be to either extract the `b>=1` expression as a concept OR
add the constraint `(b != 2)` to the first overload.

```c++
// with concepts
template <int b>
concept b_is_atleast_one = b >= 1;

template <int b>
    requires b_is_atleast_one<b>
constexpr int bar()
{
    return 1;
}

template <int b>
    requires b_is_atleast_one<b> && (b == 2)
constexpr int bar()
{
    return 10;
}

static_assert(bar<1>() == 1); // always unambiguous
static_assert(bar<2>() == 10); // always unambiguous, because of partial ordering
```

https://godbolt.org/z/yCccYV