### PR TITLE
[FIX] Allow dimension, compatible and innermost_value only on ranges

### DIFF
--- a/include/seqan3/core/type_traits/range.hpp
+++ b/include/seqan3/core/type_traits/range.hpp
@@ -31,7 +31,7 @@ namespace seqan3::detail
 
 //!\cond
 template <typename t>
-SEQAN3_CONCEPT has_value_type = requires { typename value_type_t<remove_cvref_t<t>>; };
+SEQAN3_CONCEPT has_range_value_type = requires { typename std::ranges::range_value_t<remove_cvref_t<t>>; };
 //!\endcond
 
 } // namespace seqan3::detail
@@ -167,20 +167,20 @@ struct size_type<rng_t>
  */
 template <typename t>
 //!\cond
-    requires detail::has_value_type<t>
+    requires detail::has_range_value_type<t>
 //!\endcond
 struct innermost_value_type
 {
     //!\brief The return type (recursion not shown).
-    using type = value_type_t<remove_cvref_t<t>>;
+    using type = std::ranges::range_value_t<remove_cvref_t<t>>;
 };
 
 //!\cond
 template <typename t>
-    requires detail::has_value_type<t> && detail::has_value_type<value_type_t<remove_cvref_t<t>>>
+    requires detail::has_range_value_type<t> && detail::has_range_value_type<std::ranges::range_value_t<remove_cvref_t<t>>>
 struct innermost_value_type<t>
 {
-    using type = typename innermost_value_type<value_type_t<remove_cvref_t<t>>>::type;
+    using type = typename innermost_value_type<std::ranges::range_value_t<remove_cvref_t<t>>>::type;
 };
 //!\endcond
 
@@ -205,14 +205,14 @@ using innermost_value_type_t = typename innermost_value_type<t>::type;
  */
 template <typename t>
 //!\cond
-    requires detail::has_value_type<t>
+    requires detail::has_range_value_type<t>
 //!\endcond
 constexpr size_t dimension_v = 1;
 
 //!\cond
 template <typename t>
-    requires detail::has_value_type<t> && detail::has_value_type<value_type_t<remove_cvref_t<t>>>
-constexpr size_t dimension_v<t> = dimension_v<value_type_t<remove_cvref_t<t>>> + 1;
+    requires detail::has_range_value_type<t> && detail::has_range_value_type<std::ranges::range_value_t<remove_cvref_t<t>>>
+constexpr size_t dimension_v<t> = dimension_v<std::ranges::range_value_t<remove_cvref_t<t>>> + 1;
 //!\endcond
 
 // ----------------------------------------------------------------------------

--- a/test/unit/core/type_traits/range_iterator_test.cpp
+++ b/test/unit/core/type_traits/range_iterator_test.cpp
@@ -208,13 +208,9 @@ TEST(range_and_iterator, size_type_)
 TEST(range_and_iterator, innermost_value_type_)
 {
     using vector_of_int_vector = std::vector<std::vector<int>>;
-    using iterator_of_int_vector = std::ranges::iterator_t<std::vector<int>>;
-    using inner_value_type_of_const_iterator = seqan3::innermost_value_type_t<iterator_of_int_vector const>;
     using type_list_example = seqan3::type_list<typename seqan3::innermost_value_type<std::vector<int>>::type, // long
                                                 seqan3::innermost_value_type_t<std::vector<int>>, // short
-                                                seqan3::innermost_value_type_t<vector_of_int_vector>, // two-level
-                                                seqan3::innermost_value_type_t<iterator_of_int_vector>, // iterator
-                                                inner_value_type_of_const_iterator>; // const_iterator
+                                                seqan3::innermost_value_type_t<vector_of_int_vector>>; // two-level
 
     using comp_list = seqan3::type_list<int,
                                         int,
@@ -228,28 +224,23 @@ TEST(range_and_iterator, innermost_value_type_)
 TEST(range_and_iterator, dimension)
 {
     EXPECT_EQ(1u, seqan3::dimension_v<std::vector<int>>);
-    EXPECT_EQ(1u, seqan3::dimension_v<std::ranges::iterator_t<std::vector<int>>>);
     EXPECT_EQ(2u, seqan3::dimension_v<std::vector<std::vector<int>>>);
-    EXPECT_EQ(2u, seqan3::dimension_v<std::ranges::iterator_t<std::vector<std::vector<int>>>>);
 }
 
 TEST(range_and_iterator, compatible)
 {
-    EXPECT_TRUE((seqan3::compatible<std::vector<int>,
-                                    std::list<int>>));
-    EXPECT_TRUE((seqan3::compatible<std::vector<int>,
-                                    std::ranges::iterator_t<std::vector<int>>>));
-    EXPECT_TRUE((seqan3::compatible<std::vector<int>,
-                                    std::ranges::iterator_t<std::vector<int> const>>));
-    EXPECT_TRUE((seqan3::compatible<std::list<std::vector<char>>,
-                                    std::ranges::iterator_t<std::vector<std::string>>>));
+    // true for "compatible" ranges
+    EXPECT_TRUE((seqan3::compatible<std::vector<int>, std::list<int>>));
+    EXPECT_TRUE((seqan3::compatible<std::list<std::vector<char>>, std::vector<std::string>>));
 
-    EXPECT_FALSE((seqan3::compatible<std::list<std::vector<char>>,
-                                     std::string>));
-    EXPECT_FALSE((seqan3::compatible<std::list<std::vector<char>>,
-                                     std::ranges::iterator_t<std::string>>));
-    EXPECT_FALSE((seqan3::compatible<std::list<int>,
-                                     int>));
-    EXPECT_FALSE((seqan3::compatible<std::vector<int>,
-                                     std::string>));
+    // false for un-"compatible" ranges
+    EXPECT_FALSE((seqan3::compatible<std::list<std::vector<char>>, std::string>));
+    EXPECT_FALSE((seqan3::compatible<std::list<int>, int>));
+    EXPECT_FALSE((seqan3::compatible<std::vector<int>, std::string>));
+
+    // compatible not defined on iterators
+    EXPECT_FALSE((seqan3::compatible<std::vector<int>, std::ranges::iterator_t<std::vector<int>>>));
+    EXPECT_FALSE((seqan3::compatible<std::vector<int>, std::ranges::iterator_t<std::vector<int> const>>));
+    EXPECT_FALSE((seqan3::compatible<std::list<std::vector<char>>, std::ranges::iterator_t<std::vector<std::string>>>));
+    EXPECT_FALSE((seqan3::compatible<std::list<std::vector<char>>, std::ranges::iterator_t<std::string>>));
 }


### PR DESCRIPTION
This only changes the semantics part of issue https://github.com/seqan/product_backlog/issues/86
and is also part of https://github.com/seqan/seqan3/issues/1549 by using
`std::ranges::range_value_t`.