### PR TITLE
[FIX] minimiser should use std::ranges::range_reference_t

### DIFF
--- a/include/seqan3/range/views/minimiser.hpp
+++ b/include/seqan3/range/views/minimiser.hpp
@@ -39,8 +39,8 @@ class minimiser_view : public std::ranges::view_interface<minimiser_view<urng_t>
 {
 private:
     static_assert(std::ranges::forward_range<urng_t const>, "The minimiser_view only works on forward_ranges.");
-    static_assert(std::totally_ordered<reference_t<urng_t>>, "The reference type of the underlying range must model "
-                                                             "std::totally_ordered.");
+    static_assert(std::totally_ordered<std::ranges::range_reference_t<urng_t>>,
+                  "The reference type of the underlying range must model std::totally_ordered.");
     //!\brief The underlying range.
     urng_t urange;
 

--- a/include/seqan3/range/views/minimiser_hash.hpp
+++ b/include/seqan3/range/views/minimiser_hash.hpp
@@ -75,7 +75,7 @@ struct minimiser_hash_fn
             "The range parameter to views::minimiser_hash cannot be a temporary of a non-view range.");
         static_assert(std::ranges::forward_range<urng_t>,
             "The range parameter to views::minimiser_hash must model std::ranges::forward_range.");
-        static_assert(semialphabet<reference_t<urng_t>>,
+        static_assert(semialphabet<std::ranges::range_reference_t<urng_t>>,
             "The range parameter to views::minimiser_hash must be over elements of seqan3::semialphabet.");
 
         if (shape.size() > window_size.get())

--- a/test/include/seqan3/test/performance/naive_minimiser_hash.hpp
+++ b/test/include/seqan3/test/performance/naive_minimiser_hash.hpp
@@ -60,7 +60,7 @@ struct naive_minimiser_hash_fn
            "The range parameter to views::minimiser_hash cannot be a temporary of a non-view range.");
        static_assert(std::ranges::forward_range<urng_t>,
            "The range parameter to views::minimiser_hash must model std::ranges::forward_range.");
-       static_assert(semialphabet<reference_t<urng_t>>,
+       static_assert(semialphabet<std::ranges::range_reference_t<urng_t>>,
            "The range parameter to views::minimiser_hash must be over elements of seqan3::semialphabet.");
        if (shape.size() > window_size)
            throw std::invalid_argument{"The size of the shape cannot be greater than the window size."};


### PR DESCRIPTION
Part of https://github.com/seqan/seqan3/issues/1549