### PR TITLE
Optimise alignment/part2 avx2 optimisations

### DIFF
--- a/include/seqan3/core/simd/detail/simd_algorithm_avx2.hpp
+++ b/include/seqan3/core/simd/detail/simd_algorithm_avx2.hpp
@@ -139,17 +139,27 @@ constexpr target_simd_t upcast_unsigned_avx2(source_simd_t const & src)
     }
 }
 
-// TODO: not implemented and used yet, if you implement it don't forget to add it to seqan3::detail::extract_halve
 template <uint8_t index, simd::simd_concept simd_t>
-constexpr simd_t extract_halve_avx2(simd_t const & src);
+constexpr simd_t extract_halve_avx2(simd_t const & src)
+{
+    return reinterpret_cast<simd_t>(_mm256_castsi128_si256(
+            _mm256_extracti128_si256(reinterpret_cast<__m256i const &>(src), index)));
+}
 
-// TODO: not implemented and used yet, if you implement it don't forget to add it to seqan3::detail::extract_quarter
 template <uint8_t index, simd::simd_concept simd_t>
-constexpr simd_t extract_quarter_avx2(simd_t const & src);
+constexpr simd_t extract_quarter_avx2(simd_t const & src)
+{
+    return reinterpret_cast<simd_t>(_mm256_castsi128_si256(
+            _mm_cvtsi64x_si128(_mm256_extract_epi64(reinterpret_cast<__m256i const &>(src), index))));
+}
 
 // TODO: not implemented and used yet, if you implement it don't forget to add it to seqan3::detail::extract_eighth
 template <uint8_t index, simd::simd_concept simd_t>
-constexpr simd_t extract_eighth_avx2(simd_t const & src);
+constexpr simd_t extract_eighth_avx2(simd_t const & src)
+{
+    return reinterpret_cast<simd_t>(_mm256_castsi128_si256(
+            _mm_cvtsi32_si128(_mm256_extract_epi32(reinterpret_cast<__m256i const &>(src), index))));
+}
 
 } // namespace seqan3::detail
 

--- a/include/seqan3/core/simd/detail/simd_algorithm_avx2.hpp
+++ b/include/seqan3/core/simd/detail/simd_algorithm_avx2.hpp
@@ -46,11 +46,11 @@ constexpr target_simd_t upcast_signed_avx2(source_simd_t const & src);
 template <simd::simd_concept target_simd_t, simd::simd_concept source_simd_t>
 constexpr target_simd_t upcast_unsigned_avx2(source_simd_t const & src);
 
-/*!\copydoc seqan3::detail::extract_halve
+/*!\copydoc seqan3::detail::extract_half
  * \attention This is the implementation for AVX2 intrinsics.
  */
 template <uint8_t index, simd::simd_concept simd_t>
-constexpr simd_t extract_halve_avx2(simd_t const & src);
+constexpr simd_t extract_half_avx2(simd_t const & src);
 
 /*!\copydoc seqan3::detail::extract_quarter
  * \attention This is the implementation for AVX2 intrinsics.
@@ -190,7 +190,7 @@ constexpr target_simd_t upcast_unsigned_avx2(source_simd_t const & src)
 }
 
 template <uint8_t index, simd::simd_concept simd_t>
-constexpr simd_t extract_halve_avx2(simd_t const & src)
+constexpr simd_t extract_half_avx2(simd_t const & src)
 {
     return reinterpret_cast<simd_t>(_mm256_castsi128_si256(
             _mm256_extracti128_si256(reinterpret_cast<__m256i const &>(src), index)));

--- a/include/seqan3/core/simd/detail/simd_algorithm_avx2.hpp
+++ b/include/seqan3/core/simd/detail/simd_algorithm_avx2.hpp
@@ -81,9 +81,59 @@ constexpr simd_t load_avx2(void const * mem_addr)
     return reinterpret_cast<simd_t>(_mm256_loadu_si256(reinterpret_cast<__m256i const *>(mem_addr)));
 }
 
-// TODO: not implemented and used yet, if you implement it don't forget to add it to seqan3::simd::transpose
 template <simd::simd_concept simd_t>
-inline void transpose_matrix_avx2(std::array<simd_t, simd_traits<simd_t>::length> & matrix);
+inline void transpose_matrix_avx2(std::array<simd_t, simd_traits<simd_t>::length> & matrix)
+{
+    // emulate missing _mm256_unpacklo_epi128/_mm256_unpackhi_epi128 instructions
+    auto _mm256_unpacklo_epi128 = [] (__m256i const & a, __m256i const & b)
+    {
+        return _mm256_permute2x128_si256(a, b, 0x20);
+    };
+
+    auto _mm256_unpackhi_epi128 = [] (__m256i const & a, __m256i const & b)
+    {
+        return _mm256_permute2x128_si256(a, b, 0x31);
+    };
+
+    // A look-up table to reverse the lowest 4 bits in order to permute the transposed rows.
+    static const uint8_t bit_rev[] = { 0, 8, 4,12, 2,10, 6,14, 1, 9, 5,13, 3,11, 7,15,
+                                      16,24,20,28,18,26,22,30,17,25,21,29,19,27,23,31};
+
+    // transpose a 32x32 byte matrix
+    __m256i tmp1[32];
+    for (int i = 0; i < 16; ++i)
+    {
+        tmp1[i]    = _mm256_unpacklo_epi8(
+            reinterpret_cast<const __m256i &>(matrix[2*i]),
+            reinterpret_cast<const __m256i &>(matrix[2*i+1])
+        );
+        tmp1[i+16] = _mm256_unpackhi_epi8(
+            reinterpret_cast<const __m256i &>(matrix[2*i]),
+            reinterpret_cast<const __m256i &>(matrix[2*i+1])
+        );
+    }
+    __m256i  tmp2[32];
+    for (int i = 0; i < 16; ++i)
+    {
+        tmp2[i]    = _mm256_unpacklo_epi16(tmp1[2*i], tmp1[2*i+1]);
+        tmp2[i+16] = _mm256_unpackhi_epi16(tmp1[2*i], tmp1[2*i+1]);
+    }
+    for (int i = 0; i < 16; ++i)
+    {
+        tmp1[i]    = _mm256_unpacklo_epi32(tmp2[2*i], tmp2[2*i+1]);
+        tmp1[i+16] = _mm256_unpackhi_epi32(tmp2[2*i], tmp2[2*i+1]);
+    }
+    for (int i = 0; i < 16; ++i)
+    {
+        tmp2[i]    = _mm256_unpacklo_epi64(tmp1[2*i], tmp1[2*i+1]);
+        tmp2[i+16] = _mm256_unpackhi_epi64(tmp1[2*i], tmp1[2*i+1]);
+    }
+    for (int i = 0; i < 16; ++i)
+    {
+        matrix[bit_rev[i]]    = reinterpret_cast<simd_t>(_mm256_unpacklo_epi128(tmp2[2*i],tmp2[2*i+1]));
+        matrix[bit_rev[i+16]] = reinterpret_cast<simd_t>(_mm256_unpackhi_epi128(tmp2[2*i],tmp2[2*i+1]));
+    }
+}
 
 template <simd::simd_concept target_simd_t, simd::simd_concept source_simd_t>
 constexpr target_simd_t upcast_signed_avx2(source_simd_t const & src)
@@ -153,7 +203,6 @@ constexpr simd_t extract_quarter_avx2(simd_t const & src)
             _mm_cvtsi64x_si128(_mm256_extract_epi64(reinterpret_cast<__m256i const &>(src), index))));
 }
 
-// TODO: not implemented and used yet, if you implement it don't forget to add it to seqan3::detail::extract_eighth
 template <uint8_t index, simd::simd_concept simd_t>
 constexpr simd_t extract_eighth_avx2(simd_t const & src)
 {

--- a/include/seqan3/core/simd/detail/simd_algorithm_avx512.hpp
+++ b/include/seqan3/core/simd/detail/simd_algorithm_avx512.hpp
@@ -46,11 +46,11 @@ constexpr target_simd_t upcast_signed_avx512(source_simd_t const & src);
 template <simd::simd_concept target_simd_t, simd::simd_concept source_simd_t>
 constexpr target_simd_t upcast_unsigned_avx512(source_simd_t const & src);
 
-/*!\copydoc seqan3::detail::extract_halve
+/*!\copydoc seqan3::detail::extract_half
  * \attention This is the implementation for AVX512 intrinsics.
  */
 template <uint8_t index, simd::simd_concept simd_t>
-constexpr simd_t extract_halve_avx512(simd_t const & src);
+constexpr simd_t extract_half_avx512(simd_t const & src);
 
 /*!\copydoc seqan3::detail::extract_quarter
  * \attention This is the implementation for AVX512 intrinsics.
@@ -139,9 +139,9 @@ constexpr target_simd_t upcast_unsigned_avx512(source_simd_t const & src)
     }
 }
 
-// TODO: not implemented and used yet, if you implement it don't forget to add it to seqan3::detail::extract_halve
+// TODO: not implemented and used yet, if you implement it don't forget to add it to seqan3::detail::extract_half
 template <uint8_t index, simd::simd_concept simd_t>
-constexpr simd_t extract_halve_avx512(simd_t const & src);
+constexpr simd_t extract_half_avx512(simd_t const & src);
 
 // TODO: not implemented and used yet, if you implement it don't forget to add it to seqan3::detail::extract_quarter
 template <uint8_t index, simd::simd_concept simd_t>

--- a/include/seqan3/core/simd/detail/simd_algorithm_sse4.hpp
+++ b/include/seqan3/core/simd/detail/simd_algorithm_sse4.hpp
@@ -46,11 +46,11 @@ constexpr target_simd_t upcast_signed_sse4(source_simd_t const & src);
 template <simd::simd_concept target_simd_t, simd::simd_concept source_simd_t>
 constexpr target_simd_t upcast_unsigned_sse4(source_simd_t const & src);
 
-/*!\copydoc seqan3::detail::extract_halve
+/*!\copydoc seqan3::detail::extract_half
  * \attention This is the implementation for SSE4 intrinsics.
  */
 template <uint8_t index, simd::simd_concept simd_t>
-constexpr simd_t extract_halve_sse4(simd_t const & src);
+constexpr simd_t extract_half_sse4(simd_t const & src);
 
 /*!\copydoc seqan3::detail::extract_quarter
  * \attention This is the implementation for SSE4 intrinsics.
@@ -202,7 +202,7 @@ constexpr target_simd_t upcast_unsigned_sse4(source_simd_t const & src)
 }
 
 template <uint8_t index, simd::simd_concept simd_t>
-constexpr simd_t extract_halve_sse4(simd_t const & src)
+constexpr simd_t extract_half_sse4(simd_t const & src)
 {
     return reinterpret_cast<simd_t>(_mm_srli_si128(reinterpret_cast<__m128i const &>(src), (index) << 3));
 }

--- a/include/seqan3/core/simd/simd_algorithm.hpp
+++ b/include/seqan3/core/simd/simd_algorithm.hpp
@@ -160,6 +160,20 @@ constexpr simd_t extract_halve(simd_t const & src)
     else // if constexpr (simd_traits<simd_t>::max_length == 16) // SSE4
         return detail::extract_halve_sse4<index>(src);
 }
+
+template <uint8_t index, simd::simd_concept simd_t>
+    requires detail::is_builtin_simd_v<simd_t> &&
+             detail::is_native_builtin_simd_v<simd_t> &&
+             simd_traits<simd_t>::max_length == 32
+constexpr simd_t extract_halve(simd_t const & src)
+{
+    static_assert(index < 2, "The index must be in the range of [0, 1]");
+
+    if constexpr (simd_traits<simd_t>::length < 2) // In case there are less elements available return unchanged value.
+        return src;
+    else // if constexpr (simd_traits<simd_t>::max_length == 32) // AVX2
+        return detail::extract_halve_avx2<index>(src);
+}
 //!\endcond
 
 /*!\brief Extracts one quarter of the given simd vector and stores it in the lower quarter of the target vector.
@@ -206,6 +220,20 @@ constexpr simd_t extract_quarter(simd_t const & src)
     else // if constexpr (simd_traits<simd_t>::max_length == 16) // SSE4
         return detail::extract_quarter_sse4<index>(src);
 }
+
+template <uint8_t index, simd::simd_concept simd_t>
+    requires detail::is_builtin_simd_v<simd_t> &&
+             detail::is_native_builtin_simd_v<simd_t> &&
+             simd_traits<simd_t>::max_length == 32
+constexpr simd_t extract_quarter(simd_t const & src)
+{
+    static_assert(index < 4, "The index must be in the range of [0, 1, 2, 3]");
+
+    if constexpr (simd_traits<simd_t>::length < 4) // In case there are less elements available return unchanged value.
+        return src;
+    else // if constexpr (simd_traits<simd_t>::max_length == 32) // AVX2
+        return detail::extract_quarter_avx2<index>(src);
+}
 //!\endcond
 
 /*!\brief Extracts one eighth of the given simd vector and stores it in the lower eighth of the target vector.
@@ -249,6 +277,20 @@ constexpr simd_t extract_eighth(simd_t const & src)
         return src;
     else // if constexpr (simd_traits<simd_t>::max_length == 16) // SSE4
         return detail::extract_eighth_sse4<index>(src);
+}
+
+template <uint8_t index, simd::simd_concept simd_t>
+    requires detail::is_builtin_simd_v<simd_t> &&
+             detail::is_native_builtin_simd_v<simd_t> &&
+             simd_traits<simd_t>::max_length == 32
+constexpr simd_t extract_eighth(simd_t const & src)
+{
+    static_assert(index < 8, "The index must be in the range of [0, 1, 2, 3, 4, 5, 6, 7]");
+
+    if constexpr (simd_traits<simd_t>::length < 8) // In case there are less elements available return unchanged value.
+        return src;
+    else // if constexpr (simd_traits<simd_t>::max_length == 16) // AVX2
+        return detail::extract_eighth_avx2<index>(src);
 }
 //!\endcond
 

--- a/include/seqan3/core/simd/simd_algorithm.hpp
+++ b/include/seqan3/core/simd/simd_algorithm.hpp
@@ -116,12 +116,12 @@ constexpr target_simd_t upcast_unsigned(source_simd_t const & src)
         static_assert(simd_traits<source_simd_t>::max_length <= 32, "simd type is not supported.");
 }
 
-/*!\brief Extracts one halve of the given simd vector and stores the result in the lower halve of the target vector.
+/*!\brief Extracts one half of the given simd vector and stores the result in the lower half of the target vector.
  * \ingroup simd
  * \tparam index An index value in the range of [0, 1].
  * \tparam simd_t The simd type.
- * \param src The source to extract the halve from.
- * \returns A simd vector with the lower bits set with the respective halve from `src`
+ * \param src The source to extract the half from.
+ * \returns A simd vector with the lower bits set with the respective half from `src`
  *          If the simd vector contains less than 2 elements, the unchanged source will be returned.
  *
  * \details
@@ -139,7 +139,7 @@ constexpr target_simd_t upcast_unsigned(source_simd_t const & src)
  * ```
  */
 template <uint8_t index, simd::simd_concept simd_t>
-constexpr simd_t extract_halve(simd_t const & src)
+constexpr simd_t extract_half(simd_t const & src)
 {
     static_assert(index < 2, "The index must be in the range of [0, 1]");
 
@@ -150,16 +150,16 @@ constexpr simd_t extract_halve(simd_t const & src)
 template <uint8_t index, simd::simd_concept simd_t>
     requires detail::is_builtin_simd_v<simd_t> &&
              detail::is_native_builtin_simd_v<simd_t>
-constexpr simd_t extract_halve(simd_t const & src)
+constexpr simd_t extract_half(simd_t const & src)
 {
     static_assert(index < 2, "The index must be in the range of [0, 1]");
 
     if constexpr (simd_traits<simd_t>::length < 2) // In case there are less elements available return unchanged value.
         return src;
     else if constexpr (simd_traits<simd_t>::max_length == 16) // SSE4
-        return detail::extract_halve_sse4<index>(src);
+        return detail::extract_half_sse4<index>(src);
     else if constexpr (simd_traits<simd_t>::max_length == 32) // AVX2
-        return detail::extract_halve_avx2<index>(src);
+        return detail::extract_half_avx2<index>(src);
     else // Anything else
         return detail::extract_impl<2>(src, index);
 }

--- a/include/seqan3/core/simd/simd_algorithm.hpp
+++ b/include/seqan3/core/simd/simd_algorithm.hpp
@@ -149,30 +149,19 @@ constexpr simd_t extract_halve(simd_t const & src)
 //!\cond
 template <uint8_t index, simd::simd_concept simd_t>
     requires detail::is_builtin_simd_v<simd_t> &&
-             detail::is_native_builtin_simd_v<simd_t> &&
-             (simd_traits<simd_t>::max_length == 16)
+             detail::is_native_builtin_simd_v<simd_t>
 constexpr simd_t extract_halve(simd_t const & src)
 {
     static_assert(index < 2, "The index must be in the range of [0, 1]");
 
     if constexpr (simd_traits<simd_t>::length < 2) // In case there are less elements available return unchanged value.
         return src;
-    else // if constexpr (simd_traits<simd_t>::max_length == 16) // SSE4
+    else if constexpr (simd_traits<simd_t>::max_length == 16) // SSE4
         return detail::extract_halve_sse4<index>(src);
-}
-
-template <uint8_t index, simd::simd_concept simd_t>
-    requires detail::is_builtin_simd_v<simd_t> &&
-             detail::is_native_builtin_simd_v<simd_t> &&
-             simd_traits<simd_t>::max_length == 32
-constexpr simd_t extract_halve(simd_t const & src)
-{
-    static_assert(index < 2, "The index must be in the range of [0, 1]");
-
-    if constexpr (simd_traits<simd_t>::length < 2) // In case there are less elements available return unchanged value.
-        return src;
-    else // if constexpr (simd_traits<simd_t>::max_length == 32) // AVX2
+    else if constexpr (simd_traits<simd_t>::max_length == 32) // AVX2
         return detail::extract_halve_avx2<index>(src);
+    else // Anything else
+        return detail::extract_impl<2>(src, index);
 }
 //!\endcond
 
@@ -209,30 +198,19 @@ constexpr simd_t extract_quarter(simd_t const & src)
 //!\cond
 template <uint8_t index, simd::simd_concept simd_t>
     requires detail::is_builtin_simd_v<simd_t> &&
-             detail::is_native_builtin_simd_v<simd_t> &&
-             (simd_traits<simd_t>::max_length == 16)
+             detail::is_native_builtin_simd_v<simd_t>
 constexpr simd_t extract_quarter(simd_t const & src)
 {
     static_assert(index < 4, "The index must be in the range of [0, 1, 2, 3]");
 
     if constexpr (simd_traits<simd_t>::length < 4) // In case there are less elements available return unchanged value.
         return src;
-    else // if constexpr (simd_traits<simd_t>::max_length == 16) // SSE4
+    else if constexpr (simd_traits<simd_t>::max_length == 16) // SSE4
         return detail::extract_quarter_sse4<index>(src);
-}
-
-template <uint8_t index, simd::simd_concept simd_t>
-    requires detail::is_builtin_simd_v<simd_t> &&
-             detail::is_native_builtin_simd_v<simd_t> &&
-             simd_traits<simd_t>::max_length == 32
-constexpr simd_t extract_quarter(simd_t const & src)
-{
-    static_assert(index < 4, "The index must be in the range of [0, 1, 2, 3]");
-
-    if constexpr (simd_traits<simd_t>::length < 4) // In case there are less elements available return unchanged value.
-        return src;
-    else // if constexpr (simd_traits<simd_t>::max_length == 32) // AVX2
+    else if constexpr (simd_traits<simd_t>::max_length == 32) // AVX2
         return detail::extract_quarter_avx2<index>(src);
+    else // Anything else
+        return detail::extract_impl<4>(src, index);
 }
 //!\endcond
 
@@ -267,30 +245,19 @@ constexpr simd_t extract_eighth(simd_t const & src)
 //!\cond
 template <uint8_t index, simd::simd_concept simd_t>
     requires detail::is_builtin_simd_v<simd_t> &&
-             detail::is_native_builtin_simd_v<simd_t> &&
-             (simd_traits<simd_t>::max_length == 16)
+             detail::is_native_builtin_simd_v<simd_t>
 constexpr simd_t extract_eighth(simd_t const & src)
 {
     static_assert(index < 8, "The index must be in the range of [0, 1, 2, 3, 4, 5, 6, 7]");
 
     if constexpr (simd_traits<simd_t>::length < 8) // In case there are less elements available return unchanged value.
         return src;
-    else // if constexpr (simd_traits<simd_t>::max_length == 16) // SSE4
+    else if constexpr (simd_traits<simd_t>::max_length == 16) // SSE4
         return detail::extract_eighth_sse4<index>(src);
-}
-
-template <uint8_t index, simd::simd_concept simd_t>
-    requires detail::is_builtin_simd_v<simd_t> &&
-             detail::is_native_builtin_simd_v<simd_t> &&
-             simd_traits<simd_t>::max_length == 32
-constexpr simd_t extract_eighth(simd_t const & src)
-{
-    static_assert(index < 8, "The index must be in the range of [0, 1, 2, 3, 4, 5, 6, 7]");
-
-    if constexpr (simd_traits<simd_t>::length < 8) // In case there are less elements available return unchanged value.
-        return src;
-    else // if constexpr (simd_traits<simd_t>::max_length == 16) // AVX2
+    else if constexpr (simd_traits<simd_t>::max_length == 32) // AVX2
         return detail::extract_eighth_avx2<index>(src);
+    else  // Anything else
+        return detail::extract_impl<8>(src, index);
 }
 //!\endcond
 
@@ -406,14 +373,19 @@ constexpr void transpose(std::array<simd_t, simd_traits<simd_t>::length> & matri
 }
 
 //!\cond
+// Implementation for seqan builtin simd.
 template <simd::simd_concept simd_t>
     requires detail::is_builtin_simd_v<simd_t> &&
              detail::is_native_builtin_simd_v<simd_t> &&
-             (simd_traits<simd_t>::max_length == 16) &&
-             (simd_traits<simd_t>::length == 16)
+             (simd_traits<simd_t>::max_length == simd_traits<simd_t>::length)
 constexpr void transpose(std::array<simd_t, simd_traits<simd_t>::length> & matrix)
 {
-    detail::transpose_matrix_sse4(matrix);
+    if constexpr (simd_traits<simd_t>::length == 16) // SSE4 implementation
+        detail::transpose_matrix_sse4(matrix);
+    else if constexpr (simd_traits<simd_t>::length == 32) // AVX2 implementation
+        detail::transpose_matrix_avx2(matrix);
+    else
+        transpose(matrix);
 }
 //!\endcond
 

--- a/include/seqan3/core/simd/view_to_simd.hpp
+++ b/include/seqan3/core/simd/view_to_simd.hpp
@@ -348,8 +348,8 @@ private:
     {
         if constexpr (chunk_size == simd_traits<max_simd_type>::length / 2)  // upcast into 2 vectors.
         {
-            return std::array{simd::upcast<simd_t>(extract_halve<0>(row)),  // 1. half
-                              simd::upcast<simd_t>(extract_halve<1>(row))}; // 2. half
+            return std::array{simd::upcast<simd_t>(extract_half<0>(row)),  // 1. half
+                              simd::upcast<simd_t>(extract_half<1>(row))}; // 2. half
         }
         else if constexpr (chunk_size == simd_traits<max_simd_type>::length / 4) // upcast into 4 vectors.
         {

--- a/test/snippet/core/simd/simd_extract.cpp
+++ b/test/snippet/core/simd/simd_extract.cpp
@@ -7,7 +7,7 @@ int main()
 {
     int16x8_t a{0, -1, 2, -3, 4, -5, 6, -7};
 
-    int16x8_t b = seqan3::detail::extract_halve<1>(a);
+    int16x8_t b = seqan3::detail::extract_half<1>(a);
     int16x8_t c = seqan3::detail::extract_quarter<1>(a);
     int16x8_t d = seqan3::detail::extract_eighth<7>(a);
 

--- a/test/unit/core/simd/simd_algorithm_test.cpp
+++ b/test/unit/core/simd/simd_algorithm_test.cpp
@@ -107,15 +107,15 @@ using simd_extract_types = ::testing::Types<seqan3::simd::simd_type_t<uint8_t>,
                                             seqan3::simd::simd_type_t<int64_t>>;
 TYPED_TEST_SUITE(simd_algorithm_extract, simd_extract_types, );
 
-TYPED_TEST(simd_algorithm_extract, extract_halve)
+TYPED_TEST(simd_algorithm_extract, extract_half)
 {
     TypeParam vec = seqan3::simd::iota<TypeParam>(0);
 
     // + 1 needed for emulated types without arch specification (simd length = 1).
     for (size_t idx = 0; idx < (TestFixture::simd_length + 1)/ 2; ++idx)
     {
-        EXPECT_EQ(seqan3::detail::extract_halve<0>(vec)[idx], vec[idx]);
-        EXPECT_EQ(seqan3::detail::extract_halve<1>(vec)[idx], vec[idx + TestFixture::simd_length / 2]);
+        EXPECT_EQ(seqan3::detail::extract_half<0>(vec)[idx], vec[idx]);
+        EXPECT_EQ(seqan3::detail::extract_half<1>(vec)[idx], vec[idx + TestFixture::simd_length / 2]);
     }
 }
 


### PR DESCRIPTION
Adds avx2 intrinsic implementations for transpose and extract. 
This makes the transformation of the sequence batches to simd vectors faster.

Part of #1804 