### PR TITLE
[FIX] cxx20: use std::default_sentinel_t on minimiser view

### DIFF
--- a/include/seqan3/range/views/minimiser.hpp
+++ b/include/seqan3/range/views/minimiser.hpp
@@ -136,25 +136,13 @@ public:
      *
      * No-throw guarantee.
      */
-    auto end()
-    {
-        return std::ranges::end(urange);
-    }
-
-    //!\copydoc end()
     auto end() const
-    //!\cond
-        requires seqan3::const_iterable_range<urng_t>
-    //!\endcond
     {
-        return std::ranges::end(urange);
+        return std::ranges::default_sentinel;
     }
 
     //!\copydoc end()
     auto cend() const
-    //!\cond
-        requires seqan3::const_iterable_range<urng_t>
-    //!\endcond
     {
         return end();
     }
@@ -171,6 +159,8 @@ private:
     using it_t = std::ranges::iterator_t<rng_t>;
     //!\brief The sentinel type of the underlying range.
     using sentinel_t = std::ranges::sentinel_t<rng_t>;
+    //!\brief The sentinel type of the minimiser_view.
+    using sentinel_type = std::ranges::default_sentinel_t;
 
     template <typename urng2_t>
     friend class window_iterator;
@@ -248,15 +238,15 @@ public:
     //!\{
 
     //!\brief Compare to the sentinel of the underlying range.
-    friend bool operator==(window_iterator const & lhs, sentinel_t const & rhs)
+    friend bool operator==(window_iterator const & lhs, sentinel_type const &)
     {
-        return lhs.window_right == rhs;
+        return lhs.window_right == lhs.urange_end;
     }
 
     //!\brief Compare to the sentinel of the underlying range.
-    friend bool operator==(sentinel_t const & lhs, window_iterator const & rhs)
+    friend bool operator==(sentinel_type const & lhs, window_iterator const & rhs)
     {
-        return lhs == rhs.window_right;
+        return rhs == lhs;
     }
 
     //!\brief Compare to another window_iterator.
@@ -267,13 +257,13 @@ public:
     }
 
     //!\brief Compare to the sentinel of the underlying range.
-    friend bool operator!=(window_iterator const & lhs, sentinel_t const & rhs)
+    friend bool operator!=(window_iterator const & lhs, sentinel_type const & rhs)
     {
         return !(lhs == rhs);
     }
 
     //!\brief Compare to the sentinel of the underlying range.
-    friend bool operator!=(sentinel_t const & lhs, window_iterator const & rhs)
+    friend bool operator!=(sentinel_type const & lhs, window_iterator const & rhs)
     {
         return !(lhs == rhs);
     }


### PR DESCRIPTION
The expression `std::ranges::begin(this->test_range) == std::ranges::cend(this->test_range)`
for `this->test_range = seqan3::detail::minimiser_view` did not compile.

I tried to find out, but ultimately could only figure out that
the left hand side was

* `lhs_iterator = std::ranges::begin(this->test_range)`
* `lhs_iterator == minimiser_view<rng>::window_iterator<rng>`
  * with `rng = non-const std::ranges::transform_view` internally defined as
  * `lhs_iterator::sentinel == std::ranges::end(rng)` and
  * `std::ranges::end(rng) == std::ranges::transform_view::sentinel<false>`

Whereas the right side was

* `rhs_sentinel = std::ranges::cend(this->test_range)`
* `rhs_sentinel == std::ranges::cend(rng)`
    * with `rng = non-const std::ranges::transform_view`
* `rhs_sentinel == std::ranges::transform_view::sentinel<true>`

The `==` in `lhs_iterator` is defined as
* `operator==(lhs_iterator const &, lhs_iterator::sentinel const &)` which is the same as
* `operator==(minimiser_view<rng>::window_iterator<rng> const &, std::ranges::transform_view::sentinel<false> const &)`

The requested `==` of the expression
* `std::ranges::begin(this->test_range) == std::ranges::cend(this->test_range)`
* needs the following signature
* `operator==(minimiser_view<rng>::window_iterator<rng> const &, std::ranges::transform_view::sentinel<true> const &)`

As you can see, the signature does not match completely.

Normally you can convert a `std::ranges::transform_view::sentinel<false>` into a `std::ranges::transform_view::sentinel<true>` and from what I can see, the compiler is normally able to do this conversion sequence.

See [std::ranges::transform_view::iterator](https://eel.is/c++draft/range.transform.iterator) and [std::ranges::transform_view::sentinel](https://eel.is/c++draft/range.transform.sentinel).

They both don't have a special case for `sentinel<false>` or `sentinel<true>`.
(Note that they have less comparison operators, this is because since std20 you automatically define all reverse operators for `==` e.g. `a == b` also defines `b == a` and you get `!=` for free if `==` was defined.)

minimiser view has the same comparison operators defined and has a constructor for non-const to const conversion, but fails to find the conversion sequence.

My guess is that the conversion sequence does not work, because lhs and rhs are in different namespaces.
(Haven't confirmed that yet)

---

The fix in this PR is to make the signature of the `==` operator the same for const and non-const version.

This is done by using `std::default_sentinel_t`.