### PR TITLE
Optimise alignment/part2 simd matrix coordinate

### DIFF
--- a/include/seqan3/alignment/matrix/detail/matrix_coordinate.hpp
+++ b/include/seqan3/alignment/matrix/detail/matrix_coordinate.hpp
@@ -16,15 +16,20 @@
 
 #include <seqan3/core/concept/core_language.hpp>
 #include <seqan3/core/detail/strong_type.hpp>
+#include <seqan3/core/simd/concept.hpp>
+#include <seqan3/core/simd/simd_algorithm.hpp>
 #include <seqan3/std/concepts>
 
 namespace seqan3::detail
 {
 /*!\brief A strong type for designated initialisation of the column index of a marix.
  * \ingroup alignment_matrix
- * \tparam index_type The type of the index to store; must model seqan3::arithmetic.
+ * \tparam index_type The type of the index to store; must model seqan3::arithmetic or seqan3::simd::simd_concept.
  */
-template <std::integral index_type>
+template <typename index_type>
+//!\cond
+    requires (std::integral<index_type> || simd_concept<index_type>)
+//!\endcond
 struct column_index_type : detail::strong_type<index_type, column_index_type<index_type>>
 {
     //!!\brief Import base class constructor.
@@ -42,13 +47,20 @@ column_index_type(index_type) -> column_index_type<std::ptrdiff_t>;
 //!\brief Deduces an unsigned integral type to size_t.
 template <std::unsigned_integral index_type>
 column_index_type(index_type) -> column_index_type<size_t>;
+
+//!\brief Deduces the template argument from a simd vector index type.
+template <simd_concept index_type>
+column_index_type(index_type) -> column_index_type<index_type>;
 //!\}
 
 /*!\brief A strong type for designated initialisation of the row index of a marix.
  * \ingroup alignment_matrix
- * \tparam index_type The type of the index to store; must model seqan3::arithmetic.
+ * \tparam index_type The type of the index to store; must model seqan3::arithmetic or seqan3::simd::simd_concept
  */
-template <std::integral index_type>
+template <typename index_type>
+//!\cond
+    requires (std::integral<index_type> || simd_concept<index_type>)
+//!\endcond
 struct row_index_type : detail::strong_type<index_type, row_index_type<index_type>>
 {
     //!!\brief Import base class constructor.
@@ -66,11 +78,20 @@ row_index_type(index_type) -> row_index_type<std::ptrdiff_t>;
 //!\brief Deduces an unsigned integral type to size_t.
 template <std::unsigned_integral index_type>
 row_index_type(index_type) -> row_index_type<size_t>;
+
+//!\brief Deduces the template argument from a simd vector index type.
+template <simd_concept index_type>
+row_index_type(index_type) -> row_index_type<index_type>;
 //!\}
 
-//!\brief A representation of a location or offset within a two-dimensional matrix.
-//!\ingroup alignment_matrix
-template <std::integral index_t>
+/*!\brief A representation of a location or offset within a two-dimensional matrix.
+ * \ingroup alignment_matrix
+ * \tparam index_t The underlying index type; must model seqan3::arithmetic or seqan3::simd::simd_concept.
+ */
+template <typename index_t>
+//!\cond
+    requires (std::integral<index_t> || simd_concept<index_t>)
+//!\endcond
 struct matrix_index
 {
     /*!\name Constructors, destructor and assignment
@@ -87,9 +108,40 @@ struct matrix_index
      * \param row_idx The row index to set.
      * \param col_idx The column index to set.
      */
-    constexpr matrix_index(row_index_type<index_t> const row_idx,
-                           column_index_type<index_t> const col_idx) noexcept
-        : row{row_idx.get()}, col{col_idx.get()}
+    constexpr matrix_index(row_index_type<index_t> const row_idx, column_index_type<index_t> const col_idx) noexcept :
+        row{row_idx.get()},
+        col{col_idx.get()}
+    {}
+
+    /*!\brief Construction from strongly typed row index and column index over a scalar type when the index is a simd
+     *        vector.
+     *
+     * \tparam scalar_index_t The type of the scalar index type; must model seqan3::arithmetic and must model
+     *                        std::convertible_to the scalar type of the simd vector `index_t`.
+     *
+     * \param row_idx The row index to set.
+     * \param col_idx The column index to set.
+     *
+     * \details
+     *
+     * This constructor initialises the row and col index which is represented as simd vectors. The vectors are
+     * initialised with the scalar types of the given strong types over the scalar value. This constructor is only
+     * available if `index_t` is a simd vector type and the `scalar_index_t` is convertible to the scalar type of
+     * the simd index.
+     */
+    template <seqan3::arithmetic scalar_index_t>
+    constexpr matrix_index(row_index_type<scalar_index_t> const row_idx,
+                           column_index_type<scalar_index_t> const col_idx) noexcept
+    //!\cond
+        requires (simd_concept<index_t> &&
+                  requires ()
+                  {
+                     requires std::convertible_to<scalar_index_t, typename simd_traits<scalar_index_t>::scalar_type>;
+                  })
+    //!\endcond
+    // Note the explicit type conversion is necessary since the scalar type might be of smaller bit size.
+        : row{simd::fill<index_t>(static_cast<typename simd_traits<index_t>::scalar_type>(row_idx.get()))},
+          col{simd::fill<index_t>(static_cast<typename simd_traits<index_t>::scalar_type>(col_idx.get()))}
     {}
 
     /*!\brief Construction from other matrix_index with different integral type.
@@ -130,11 +182,21 @@ template <std::integral row_index_t, std::integral col_index_t>
 matrix_index(row_index_type<row_index_t>, column_index_type<col_index_t>) ->
     matrix_index<std::common_type_t<row_index_t, col_index_t>>;
 
+//!\brief Deduces the index type from the simd vector index type.
+template <simd_concept index_t>
+matrix_index(row_index_type<index_t>, column_index_type<index_t>) -> matrix_index<index_t>;
 //!\}
 
 //!\brief A coordinate type to access an element inside of a two-dimensional matrix.
 //!\ingroup alignment_matrix
 using matrix_coordinate = matrix_index<size_t>;
+
+/*!\brief A coordinate type to access an element inside of a two-dimensional simd vector matrix.
+ * \ingroup alignment_matrix
+ * \tparam index_t The underlying index type; must model seqan3::simd::simd_concept.
+ */
+template <simd_concept index_t>
+using simd_matrix_coordinate = matrix_index<index_t>;
 
 //!\brief An offset type to move a matrix iterator in two-dimensional space.
 //!\ingroup alignment_matrix

--- a/include/seqan3/alignment/pairwise/detail/type_traits.hpp
+++ b/include/seqan3/alignment/pairwise/detail/type_traits.hpp
@@ -23,6 +23,7 @@
 #include <seqan3/alignment/configuration/align_config_result.hpp>
 #include <seqan3/alignment/configuration/align_config_scoring.hpp>
 #include <seqan3/alignment/configuration/align_config_vectorise.hpp>
+#include <seqan3/alignment/matrix/detail/matrix_coordinate.hpp>
 #include <seqan3/alignment/matrix/trace_directions.hpp>
 #include <seqan3/alignment/pairwise/detail/concept.hpp>
 #include <seqan3/core/algorithm/configuration.hpp>
@@ -31,6 +32,7 @@
 #include <seqan3/core/simd/simd_traits.hpp>
 #include <seqan3/core/simd/simd.hpp>
 #include <seqan3/core/type_traits/function.hpp>
+#include <seqan3/core/type_traits/lazy.hpp>
 #include <seqan3/core/type_traits/template_inspection.hpp>
 #include <seqan3/range/views/chunk.hpp>
 #include <seqan3/range/views/zip.hpp>
@@ -83,6 +85,19 @@ template <typename configuration_t>
 struct alignment_configuration_traits
 {
 private:
+    /*!\brief An index type (i.e. unsigned integral) for a score_type which has the same bit size.
+     * \tparam score_t The score type for which the corresponding index type shall be returned; must model
+     *                 seqan3::arithmetic.
+     *
+     * \details
+     *
+     * If the score type models std::integral it will simply be converted to its unsigned counterpart.
+     * For floating point types the bit size is determined and the corresponding minimal viable
+     * unsigned integral type (seqan3::detail::min_viable_uint_t) is returned.
+     */
+    template <arithmetic score_t>
+    using select_scalar_index_t = min_viable_uint_t<1ull << (sizeof_bits<score_t> - 1)>;
+
     //!\brief Helper function to determine the alignment result type.
     static constexpr auto determine_alignment_result_type() noexcept
     {
@@ -133,6 +148,14 @@ public:
     using trace_type = std::conditional_t<is_vectorised, simd_type_t<original_score_type>, trace_directions>;
     //!\brief The alignment result type if present. Otherwise seqan3::detail::empty_type.
     using alignment_result_type = decltype(determine_alignment_result_type());
+    //!\brief The type of the matrix index.
+    using matrix_index_type = std::conditional_t<is_vectorised,
+                                                 simd_type_t<select_scalar_index_t<original_score_type>>,
+                                                 size_t>;
+    //!\brief The type of the matrix coordinate.
+    using matrix_coordinate_type = lazy_conditional_t<is_vectorised,
+                                                      lazy<simd_matrix_coordinate, matrix_index_type>,
+                                                      matrix_coordinate>;
 
     //!\brief The number of alignments that can be computed in one simd vector.
     static constexpr size_t alignments_per_vector = [] () constexpr


### PR DESCRIPTION
part of #1804 

Allows to use matrix_coordinate with simd types such that we can have a simd coordinate matrix. Updates the alignment configuration traits to provide correct simd coordinate types and index types. Note, that the index type is the unsigned version of the original score type but needs some extra handling of floating-point types.