### PR TITLE
[FIX] ppc64le: warning with alphabets [-W=type-limits]

### DIFF
--- a/include/seqan3/alphabet/concept.hpp
+++ b/include/seqan3/alphabet/concept.hpp
@@ -756,8 +756,7 @@ SEQAN3_CONCEPT semialphabet =
     std::is_nothrow_copy_constructible_v<t> &&
     requires (t v)
 {
-    requires seqan3::alphabet_size<t> >= 0;
-
+    { seqan3::alphabet_size<t> };
     { seqan3::to_rank(v) };
 };
 //!\endcond


### PR DESCRIPTION
```c++
/scratch/local/seiler/nightly-builds/src/include/seqan3/alphabet/concept.hpp:759:39: error: comparison is always true due to limited range of data type [-Werror=type-limits]
  759 |     requires seqan3::alphabet_size<t> >= 0;
      |              ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
cc1plus: all warnings being treated as errors
```

with `gcc10  -std=c++17 -fconcepts`