### PR TITLE
 [FIX] explicitly import cxx20 things into std namespace

### DIFF
--- a/include/seqan3/range/views/minimiser.hpp
+++ b/include/seqan3/range/views/minimiser.hpp
@@ -190,7 +190,7 @@ public:
     /*!\brief Tag this class as a forward iterator if `urng_t` models std::ranges::forward range, otherwise as an
      *        input iterator.
      */
-    using iterator_category = std::conditional_t<std::ranges::forward_iterator<it_t>,
+    using iterator_category = std::conditional_t<std::ranges::forward_range<rng_t>,
                                                  std::forward_iterator_tag,
                                                  std::input_iterator_tag>;
     /*!\brief Tag this class as a forward iterator if `urng_t` models std::ranges::forward range, otherwise as an

--- a/include/seqan3/std/algorithm
+++ b/include/seqan3/std/algorithm
@@ -41,4 +41,221 @@
 #include <range/v3/algorithm/sort.hpp>
 #include <range/v3/algorithm/transform.hpp>
 
+namespace std::ranges
+{
+
+namespace
+{
+// https://eel.is/c++draft/algorithm.syn
+
+// [algorithms.results], algorithm result types
+// using ::ranges::cpp20::in_fun_result;
+// using ::ranges::cpp20::in_in_result;
+// using ::ranges::cpp20::in_out_result;
+// using ::ranges::cpp20::in_in_out_result;
+// using ::ranges::cpp20::in_out_out_result;
+// using ::ranges::cpp20::min_max_result;
+// using ::ranges::cpp20::in_found_result;
+
+// =====================================================
+// [alg.nonmodifying], non-modifying sequence operations
+// =====================================================
+
+// [alg.all.of], all of
+using ::ranges::cpp20::all_of;
+
+// [alg.any.of], any of
+// using ::ranges::cpp20::any_of;
+
+// [alg.none.of], none of
+// using ::ranges::cpp20::none_of;
+
+// [alg.foreach], for each
+// using ::ranges::cpp20::for_each_result;
+using ::ranges::cpp20::for_each;
+// using ::ranges::cpp20::for_each_n_result;
+// using ::ranges::cpp20::for_each_n;
+
+// [alg.find], find
+using ::ranges::cpp20::find;
+using ::ranges::cpp20::find_if;
+using ::ranges::cpp20::find_if_not;
+
+// [alg.find.end], find end
+// using ::ranges::cpp20::find_end;
+
+// [alg.find.first.of], find first
+// using ::ranges::cpp20::find_first_of;
+
+// [alg.adjacent.find], adjacent find
+// using ::ranges::cpp20::adjacent_find;
+
+// [alg.count], count
+// using ::ranges::cpp20::count;
+// using ::ranges::cpp20::count_if;
+
+// [mismatch], mismatch
+// using ::ranges::cpp20::mismatch;
+
+// [alg.equal], equal
+using ::ranges::cpp20::equal;
+
+// [alg.is.permutation], is permutation
+// using ::ranges::cpp20::is_permutation;
+
+// [alg.search], search
+// using ::ranges::cpp20::search;
+// using ::ranges::cpp20::search_n;
+
+// ========================================================
+// [alg.modifying.operations], mutating sequence operations
+// ========================================================
+
+// [alg.copy], copy
+// using ::ranges::cpp20::copy_result;
+using ::ranges::cpp20::copy;
+// using ::ranges::cpp20::copy_n_result;
+using ::ranges::cpp20::copy_n;
+// using ::ranges::cpp20::copy_if_result;
+// using ::ranges::cpp20::copy_if;
+// using ::ranges::cpp20::copy_backward_result;
+// using ::ranges::cpp20::copy_backward;
+
+// [alg.move], move
+// using ::ranges::cpp20::move_result;
+using ::ranges::cpp20::move;
+// using ::ranges::cpp20::move_backward_result;
+using ::ranges::cpp20::move_backward;
+
+// [alg.swap], swap
+// using ::ranges::cpp20::swap_ranges_result;
+// using ::ranges::cpp20::swap_ranges;
+
+// [alg.transform], transform
+// using ::ranges::cpp20::unary_transform_result;
+// using ::ranges::cpp20::binary_transform_result;
+using ::ranges::cpp20::transform;
+
+// [alg.replace], replace
+// using ::ranges::cpp20::replace;
+// using ::ranges::cpp20::replace_if;
+// using ::ranges::cpp20::replace_copy_result;
+// using ::ranges::cpp20::replace_copy;
+// using ::ranges::cpp20::replace_copy_if_result;
+// using ::ranges::cpp20::replace_copy_if;
+
+// [alg.fill], fill
+using ::ranges::cpp20::fill;
+// using ::ranges::cpp20::fill_n;
+
+// [alg.generate], generate
+using ::ranges::cpp20::generate;
+
+// [alg.remove], remove
+// using ::ranges::cpp20::remove;
+// using ::ranges::cpp20::remove_if;
+// using ::ranges::cpp20::remove_copy_result;
+// using ::ranges::cpp20::remove_copy;
+// using ::ranges::cpp20::remove_copy_if_result;
+// using ::ranges::cpp20::remove_copy_if;
+
+// [alg.unique], unique
+// using ::ranges::cpp20::unique;
+// using ::ranges::cpp20::unique_copy_result;
+// using ::ranges::cpp20::unique_copy;
+
+// [alg.reverse], reverse
+using ::ranges::cpp20::reverse;
+// using ::ranges::cpp20::reverse_copy_result;
+// using ::ranges::cpp20::reverse_copy;
+
+// [alg.rotate], rotate
+// using ::ranges::cpp20::rotate;
+// using ::ranges::cpp20::rotate_copy_result;
+// using ::ranges::cpp20::rotate_copy;
+
+// [alg.random.sample], sample
+// using ::ranges::cpp20::sample;
+
+// [alg.random.shuffle], shuffle
+// using ::ranges::cpp20::shuffle;
+
+// =============================================
+// [alg.sorting], sorting and related operations
+// =============================================
+
+// [alg.sort], sorting
+using ::ranges::cpp20::sort;
+// using ::ranges::cpp20::stable_sort;
+// using ::ranges::cpp20::partial_sort;
+// using ::ranges::cpp20::partial_sort_copy;
+// using ::ranges::cpp20::is_sorted;
+// using ::ranges::cpp20::is_sorted_until;
+
+// [alg.nth.element], Nth element
+// using ::ranges::cpp20::nth_element;
+
+// [alg.binary.search], binary search
+// using ::ranges::cpp20::lower_bound;
+// using ::ranges::cpp20::upper_bound;
+// using ::ranges::cpp20::equal_range;
+// using ::ranges::cpp20::binary_search;
+
+// [alg.partitions], partitions
+// using ::ranges::cpp20::is_partitioned;
+// using ::ranges::cpp20::partition;
+// using ::ranges::cpp20::stable_partition;
+// using ::ranges::cpp20::partition_copy_result;
+// using ::ranges::cpp20::partition_copy;
+// using ::ranges::cpp20::partition_point;
+
+// [alg.merge], merge
+// using ::ranges::cpp20::merge_result;
+// using ::ranges::cpp20::merge;
+// using ::ranges::cpp20::inplace_merge;
+
+// [alg.set.operations], set operations
+// using ::ranges::cpp20::includes;
+// using ::ranges::cpp20::set_union_result;
+// using ::ranges::cpp20::set_union;
+// using ::ranges::cpp20::set_intersection_result;
+// using ::ranges::cpp20::set_intersection;
+// using ::ranges::cpp20::set_difference_result;
+// using ::ranges::cpp20::set_difference;
+// using ::ranges::cpp20::set_symmetric_difference_result;
+// using ::ranges::cpp20::set_symmetric_difference;
+
+// [alg.heap.operations], heap operations
+// using ::ranges::cpp20::push_heap;
+// using ::ranges::cpp20::pop_heap;
+// using ::ranges::cpp20::make_heap;
+// using ::ranges::cpp20::sort_heap;
+// using ::ranges::cpp20::is_heap;
+// using ::ranges::cpp20::is_heap_until;
+
+// [alg.min.max], minimum and maximum
+// using ::ranges::cpp20::min;
+// using ::ranges::cpp20::max;
+// using ::ranges::cpp20::minmax_result;
+// using ::ranges::cpp20::minmax;
+// using ::ranges::cpp20::min_element;
+using ::ranges::cpp20::max_element;
+// using ::ranges::cpp20::minmax_element;
+
+// [alg.clamp], bounded value
+// using ::ranges::cpp20::clamp;
+
+// [alg.lex.comparison], lexicographical comparison
+// using ::ranges::cpp20::lexicographical_compare;
+
+// [alg.permutation.generators], permutations
+// using ::ranges::cpp20::next_permutation_result;
+// using ::ranges::cpp20::next_permutation;
+// using ::ranges::cpp20::prev_permutation_result;
+// using ::ranges::cpp20::prev_permutation;
+
+} // anonymous namespace
+
+} // namespace std::ranges
+
 #endif  // __cpp_lib_ranges

--- a/include/seqan3/std/iterator
+++ b/include/seqan3/std/iterator
@@ -15,45 +15,7 @@
 
 #include <iterator>
 
-#ifdef __cpp_lib_ranges // C++20 iterators
-
-namespace std
-{
-inline namespace deprecated
-{
-//!\cond
-/*!\brief This should be named indirectly_readable.
- * \deprecated Use std::indirectly_readable instead.
- */
-template<class T>
-concept readable = ::std::indirectly_readable<T>;
-
-/*!\brief This should be named indirectly_writable.
- * \deprecated Use std::indirectly_writable instead.
- */
-template<class Out, class T>
-concept writable = ::std::indirectly_writable<Out, T>;
-//!\endcond
-} // namespace std::deprecated
-} // namespace std
-
-// we wrongly assume that these are in std::ranges namespace, even though they are in std namespace
-namespace std::ranges
-{
-inline namespace deprecated
-{
-// https://eel.is/c++draft/iterator.synopsis#lib:default_sentinel
-// // Header <iterator> synopsis
-// // [default.sentinels], default sentinels
-// struct default_sentinel_t;
-// inline constexpr default_sentinel_t default_sentinel{};
-using ::std::default_sentinel_t;
-using ::std::default_sentinel;
-using ::std::back_inserter;
-} // namespace std::ranges::deprecated
-} // namespace std::ranges
-
-#else // implement C++20 iterators via range-v3
+#ifndef __cpp_lib_ranges // implement C++20 iterators via range-v3
 
 #ifndef RANGES_DEEP_STL_INTEGRATION
 #define RANGES_DEEP_STL_INTEGRATION 1
@@ -83,51 +45,229 @@ namespace std
 
 namespace
 {
-    // from range/v3/iterator/concepts.hpp
-    using ::ranges::bidirectional_iterator;
-    using ::ranges::contiguous_iterator;
-    using ::ranges::forward_iterator;
-    using ::ranges::incrementable;
-    using ::ranges::indirect_relation;
-    using ::ranges::indirect_result_t;
-    using ::ranges::indirect_strict_weak_order;
-    using ::ranges::indirect_unary_predicate;
-    using ::ranges::indirectly_comparable;
-    using ::ranges::indirectly_copyable;
-    using ::ranges::indirectly_copyable_storable;
-    using ::ranges::indirectly_movable;
-    using ::ranges::indirectly_movable_storable;
-    using ::ranges::indirectly_regular_unary_invocable;
-    using ::ranges::indirectly_swappable;
-    using ::ranges::indirectly_unary_invocable;
-    using ::ranges::input_iterator;
-    using ::ranges::input_or_output_iterator;
-    using ::ranges::mergeable;
-    using ::ranges::output_iterator;
-    using ::ranges::permutable;
-    using ::ranges::projected;
-    using ::ranges::random_access_iterator;
-    using ::ranges::readable;
-    using ::ranges::sentinel_for;
-    using ::ranges::sized_sentinel_for;
-    using ::ranges::sortable;
-    using ::ranges::weakly_incrementable;
-    using ::ranges::writable;
+// https://eel.is/c++draft/iterator.synopsis
 
-    // from range/v3/iterator/traits.hpp
-    using ::ranges::iter_common_reference_t;
-    using ::ranges::iter_difference_t;
-    using ::ranges::iter_reference_t;
-    using ::ranges::iter_rvalue_reference_t;
-    using ::ranges::iter_value_t;
+// ========================================
+// [iterator.assoc.types], associated types
+// ========================================
 
-    using ::ranges::disable_sized_sentinel;
-    template<typename T>
-    using incrementable_traits = ::ranges::incrementable_traits<T>;
-    template<typename T>
-    using readable_traits = ::ranges::readable_traits<T>;
+// [incrementable.traits], incrementable traits
+using ::ranges::cpp20::incrementable_traits;
+using ::ranges::cpp20::iter_difference_t;
+
+// [readable.traits], indirectly readable traits
+// using ::ranges::cpp20::indirectly_readable_traits;
+using ::ranges::cpp20::iter_value_t;
+
+// [iterator.traits], iterator traits
+using ::ranges::cpp20::iter_reference_t;
+using ::ranges::cpp20::iter_rvalue_reference_t;
+
+// ======================================
+// [iterator.concepts], iterator concepts
+// ======================================
+
+// [iterator.concept.readable], concept indirectly_readable
+template <class T>
+SEQAN3_CONCEPT indirectly_readable = ::ranges::cpp20::readable<T>;
+// using ::ranges::cpp20::iter_common_reference_t;
+
+// [iterator.concept.writable], concept indirectly_writable
+template<class Out, class T>
+SEQAN3_CONCEPT indirectly_writable = ::ranges::cpp20::writable<Out, T>;
+
+// [iterator.concept.winc], concept weakly_incrementable
+using ::ranges::cpp20::weakly_incrementable;
+
+// [iterator.concept.inc], concept incrementable
+using ::ranges::cpp20::incrementable;
+
+// [iterator.concept.iterator], concept input_or_output_iterator
+using ::ranges::cpp20::input_or_output_iterator;
+
+// [iterator.concept.sentinel], concept sentinel_for
+using ::ranges::cpp20::sentinel_for;
+
+// [iterator.concept.sizedsentinel], concept sized_sentinel_for
+// using ::ranges::cpp20::disable_sized_sentinel_for;
+using ::ranges::cpp20::disable_sized_sentinel; // deprecated
+using ::ranges::cpp20::sized_sentinel_for;
+
+// [iterator.concept.input], concept input_iterator
+using ::ranges::cpp20::input_iterator;
+
+// [iterator.concept.output], concept output_iterator
+using ::ranges::cpp20::output_iterator;
+
+// [iterator.concept.forward], concept forward_iterator
+using ::ranges::cpp20::forward_iterator;
+
+// [iterator.concept.bidir], concept bidirectional_iterator
+using ::ranges::cpp20::bidirectional_iterator;
+
+// [iterator.concept.random.access], concept random_­access_­iterator
+using ::ranges::cpp20::random_access_iterator;
+
+// [iterator.concept.contiguous], concept contiguous_iterator
+using ::ranges::cpp20::contiguous_iterator;
+
+// ==================================================
+// [indirectcallable], indirect callable requirements
+// ==================================================
+
+// [indirectcallable.indirectinvocable], indirect callables
+using ::ranges::cpp20::indirectly_unary_invocable;
+using ::ranges::cpp20::indirectly_regular_unary_invocable;
+using ::ranges::cpp20::indirect_unary_predicate;
+// using ::ranges::cpp20::indirect_binary_predicate;
+// using ::ranges::cpp20::indirect_equivalence_relation;
+using ::ranges::cpp20::indirect_strict_weak_order;
+using ::ranges::cpp20::indirect_result_t;
+
+// [projected], projected
+using ::ranges::cpp20::projected;
+
+// ========================================
+// [alg.req], common algorithm requirements
+// ========================================
+
+// [alg.req.ind.move], concept indirectly_movable
+using ::ranges::cpp20::indirectly_movable;
+using ::ranges::cpp20::indirectly_movable_storable;
+
+// [alg.req.ind.copy], concept indirectly_copyable
+using ::ranges::cpp20::indirectly_copyable;
+using ::ranges::cpp20::indirectly_copyable_storable;
+
+// [alg.req.ind.swap], concept indirectly_swappable
+using ::ranges::cpp20::indirectly_swappable;
+
+// [alg.req.ind.cmp], concept indirectly_comparable
+// using ::ranges::cpp20::indirectly_comparable;
+
+// [alg.req.permutable], concept permutable
+using ::ranges::cpp20::permutable;
+
+// [alg.req.mergeable], concept mergeable
+using ::ranges::cpp20::mergeable;
+
+// [alg.req.sortable], concept sortable
+using ::ranges::cpp20::sortable;
+
+// =================================
+// [iterator.primitives], primitives
+// =================================
+
+// [std.iterator.tags], iterator tags
+// using ::ranges::cpp20::contiguous_iterator_tag;
+
+// ======================================================
+// [predef.iterators], predefined iterators and sentinels
+// ======================================================
+
+// [insert.iterators], insert iterators
+inline namespace cpp20
+{
+// see https://github.com/orgs/seqan/projects/4#card-37029069
+using ::ranges::cpp20::back_inserter;
+// using ::ranges::cpp20::front_inserter;
+// using ::ranges::cpp20::insert_iterator;
+} // inline namespace cpp20
+
+// [iterators.common], common iterators
+// using ::ranges::cpp20::common_iterator;
+
+// [default.sentinels], default sentinels
+using ::ranges::cpp20::default_sentinel_t;
+using ::ranges::cpp20::default_sentinel;
+
+// [iterators.counted], counted iterators
+// using ::ranges::cpp20::counted_iterator;
+
+// [unreachable.sentinels], unreachable sentinels
+// using ::ranges::cpp20::unreachable_sentinel_t;
+// using ::ranges::cpp20::unreachable_sentinel;
+
+// [iterator.range], range access
+// using ::ranges::cpp20::ssize;
 } // anonymous namespace
 
 } // namespace std
 
-#endif
+namespace std::ranges
+{
+
+namespace
+{
+// =============================================
+// [iterator.cust], customization points
+// =============================================
+
+// [iterator.cust.move], ranges::iter_move
+using ::ranges::cpp20::iter_move;
+
+// [iterator.cust.swap], ranges::iter_swap
+// using ::ranges::cpp20::iter_swap;
+
+// =============================================
+// [range.iter.ops], range iterator operations
+// =============================================
+
+// [range.iter.op.advance], ranges::advance
+using ::ranges::cpp20::advance;
+
+// [range.iter.op.distance], ranges::distance
+using ::ranges::cpp20::distance;
+
+// [range.iter.op.next], ranges::next
+using ::ranges::cpp20::next;
+
+// [range.iter.op.prev], ranges::prev
+using ::ranges::cpp20::prev;
+} // anonymous namespace
+
+} // namespace std::ranges
+
+#endif // __cpp_lib_ranges
+
+// ==========================================
+// LEGACY wrong std:: and std::ranges:: usage
+// ==========================================
+
+#include <seqan3/core/platform.hpp> // SEQAN3_CONCEPT
+
+namespace std
+{
+inline namespace deprecated
+{
+//!\cond
+/*!\brief This should be named indirectly_readable.
+ * \deprecated Use std::indirectly_readable instead.
+ */
+template<class T>
+SEQAN3_CONCEPT readable = ::std::indirectly_readable<T>;
+
+/*!\brief This should be named indirectly_writable.
+ * \deprecated Use std::indirectly_writable instead.
+ */
+template<class Out, class T>
+SEQAN3_CONCEPT writable = ::std::indirectly_writable<Out, T>;
+//!\endcond
+} // namespace std::deprecated
+} // namespace std
+
+// we wrongly assume that these are in std::ranges namespace, even though they are in std namespace
+namespace std::ranges
+{
+inline namespace deprecated
+{
+// https://eel.is/c++draft/iterator.synopsis#lib:default_sentinel
+// // Header <iterator> synopsis
+// // [default.sentinels], default sentinels
+// struct default_sentinel_t;
+// inline constexpr default_sentinel_t default_sentinel{};
+using ::std::default_sentinel_t;
+using ::std::default_sentinel;
+using ::std::cpp20::back_inserter;
+} // namespace std::ranges::deprecated
+} // namespace std::ranges

--- a/include/seqan3/std/ranges
+++ b/include/seqan3/std/ranges
@@ -42,18 +42,6 @@ template<class T>
 inline constexpr bool enable_view<T> = true;
 } // namespace std::ranges
 
-namespace std::ranges
-{
-inline namespace deprecated
-{
-/*!\brief this should be in std::ranges::views and not std::ranges
- * \deprecated Use std::views::all_t instead.
- */
-template <typename range_t>
-using all_view = std::views::all_t<range_t>;
-} // namespace std::ranges::deprecated
-} // namespace std::ranges
-
 #else // implement via range-v3
 
 //!\cond
@@ -100,9 +88,145 @@ namespace std::ranges
 
 namespace
 {
+// https://eel.is/c++draft/ranges.syn
 
+// [range.access], range access
+using ::ranges::cpp20::begin;
+using ::ranges::cpp20::end;
+using ::ranges::cpp20::cbegin;
+using ::ranges::cpp20::cend;
+// using ::ranges::cpp20::rbegin;
+// using ::ranges::cpp20::rend;
+// using ::ranges::cpp20::crbegin;
+// using ::ranges::cpp20::crend;
+using ::ranges::cpp20::size;
+// using ::ranges::cpp20::ssize;
+using ::ranges::cpp20::empty;
+using ::ranges::cpp20::data;
+// using ::ranges::cpp20::cdata;
+
+// [range.range], ranges
+using ::ranges::cpp20::range;
+// using ::ranges::cpp20::enable_borrowed_range;
+// using ::ranges::cpp20::borrowed_range;
+
+using ::ranges::iterator_t;
+using ::ranges::sentinel_t;
+using ::ranges::range_difference_t;
 using ::ranges::range_size_t;
-using namespace ::ranges::cpp20;
+using ::ranges::range_value_t;
+using ::ranges::range_reference_t;
+using ::ranges::range_rvalue_reference_t;
+
+// [range.sized], sized ranges
+// using ::ranges::cpp20::disable_sized_range;
+using ::ranges::cpp20::sized_range;
+
+// [range.view], views
+using ::ranges::cpp20::enable_view;
+// using ::ranges::cpp20::view_base;
+using ::ranges::cpp20::view;
+
+// [range.refinements], other range refinements
+using ::ranges::cpp20::output_range;
+using ::ranges::cpp20::input_range;
+using ::ranges::cpp20::forward_range;
+using ::ranges::cpp20::bidirectional_range;
+using ::ranges::cpp20::random_access_range;
+using ::ranges::cpp20::contiguous_range;
+using ::ranges::cpp20::common_range;
+using ::ranges::cpp20::viewable_range;
+
+// [view.interface], class template view_interface
+using ::ranges::cpp20::view_interface;
+
+// [range.utility]
+using ::ranges::cpp20::subrange_kind;
+using ::ranges::cpp20::subrange;
+
+// [range.dangling], dangling iterator handling
+// using ::ranges::cpp20::dangling;
+// using ::ranges::cpp20::borrowed_iterator_t;
+// using ::ranges::cpp20::borrowed_subrange_t;
+
+// [range.empty], empty view
+// using ::ranges::cpp20::empty_view;
+// namespace views { template<class T> inline constexpr empty_view<T> empty{}; }
+
+// [range.single], single view
+// using ::ranges::cpp20::single_view;
+namespace views { using ::ranges::cpp20::views::single; }
+
+// [range.single], iota view
+// using ::ranges::cpp20::iota_view;
+namespace views { using ::ranges::cpp20::views::iota; }
+
+// [range.istream], istream view
+using ::ranges::cpp20::basic_istream_view;
+
+// [range.all], all view
+namespace views
+{
+using ::ranges::cpp20::views::all;
+
+template<viewable_range R>
+using all_t = ::ranges::cpp20::all_view<R>;
+} // namespace views
+// using ::ranges::cpp20::ref_view;
+
+// [range.filter], filter view
+// using ::ranges::cpp20::filter_view;
+namespace views { using ::ranges::cpp20::views::filter; }
+
+// [range.transform], transform view
+// using ::ranges::cpp20::transform_view;
+namespace views { using ::ranges::cpp20::views::transform; }
+
+// [range.take], take view
+// using ::ranges::cpp20::take_view;
+namespace views { using ::ranges::cpp20::views::take; }
+
+// [range.take.while], take while view
+// using ::ranges::cpp20::take_while_view;
+namespace views { using ::ranges::cpp20::views::take_while; }
+
+// [range.drop], drop view
+// using ::ranges::cpp20::drop_view;
+namespace views { using ::ranges::cpp20::views::drop; }
+
+// [range.drop.while], drop while view
+// using ::ranges::cpp20::drop_while;
+namespace views { using ::ranges::cpp20::views::drop_while; }
+
+// [range.join], join view
+// using ::ranges::cpp20::join_view;
+// namespace views { using ::ranges::cpp20::views::join; }
+
+// [range.split], split view
+// using ::ranges::cpp20::split_view;
+namespace views { using ::ranges::cpp20::views::split; }
+
+// [range.counted], counted view
+// namespace views { using ::ranges::cpp20::views::counted; }
+
+// [range.common], common view
+// using ::ranges::cpp20::common_view;
+namespace views { using ::ranges::cpp20::views::common; }
+
+// [range.reverse], reverse view
+// using ::ranges::cpp20::reverse_view;
+namespace views { using ::ranges::cpp20::views::reverse; }
+
+// [range.elements], elements view
+// using ::ranges::cpp20::elements_view;
+// using ::ranges::cpp20::keys_view;
+// using ::ranges::cpp20::values_view;
+namespace views
+{
+// using ::ranges::cpp20::views::elements;
+// using ::ranges::cpp20::views::keys;
+using ::ranges::cpp20::views::values;
+} // namespace views
 
 } // anonymous namespace
 
@@ -111,8 +235,24 @@ using namespace ::ranges::cpp20;
 namespace std
 {
 
-namespace views = ranges::views;
+namespace views = ::std::ranges::views;
 
 } // namespace std::
 
 #endif // standard header
+
+// ==========================================
+// LEGACY wrong std:: and std::ranges:: usage
+// ==========================================
+
+namespace std::ranges
+{
+inline namespace deprecated
+{
+/*!\brief this should be in std::ranges::views and not std::ranges
+ * \deprecated Use std::views::all_t instead.
+ */
+template <typename range_t>
+using all_view = std::views::all_t<range_t>;
+} // namespace std::ranges::deprecated
+} // namespace std::ranges

--- a/test/snippet/range/views/move.cpp
+++ b/test/snippet/range/views/move.cpp
@@ -1,6 +1,7 @@
 #include <string>
 
 #include <seqan3/range/views/move.hpp>
+#include <seqan3/std/algorithm>
 #include <seqan3/std/ranges>
 
 int main()


### PR DESCRIPTION
With this PR the std headers have the same entities defined for `-std=c++17` as well as `-std=c++2a`.

We once decided that we will "import" things from the ranges library on demand, this PR comments in ranges stuff that we actually use.

I prefixed all names with `::ranges::cpp20::`, but be aware that this does not mean that each of those names really exist in the ranges library.

This is PART of seqan/product_backlog#49