### PR TITLE
[FIX] ppc64le: Compare to proper EOF value

### DIFF
--- a/include/seqan3/core/char_operations/predicate_detail.hpp
+++ b/include/seqan3/core/char_operations/predicate_detail.hpp
@@ -202,8 +202,9 @@ struct char_predicate_base
         requires (sizeof(value_t) != 1)
     //!\endcond
     {
+        using char_trait = std::char_traits<value_t>;
         return (static_cast<std::make_unsigned_t<value_t>>(val) < 256) ? operator()(static_cast<uint8_t>(val)) :
-               (static_cast<decltype(EOF)>(val) == EOF)                ? derived_t::data[256]                  : false;
+               (char_trait::eq_int_type(val, char_trait::eof()))       ? derived_t::data[256]                  : false;
     }
     //!\}
 


### PR DESCRIPTION
Fixes 

```
/dev/shm/tmp/seqan3/include/seqan3/core/char_operations/predicate_detail.hpp:206:49: error: comparison is always false due to limited range of data type [-Werror=type-limits]
  206 |                (static_cast<decltype(EOF)>(val) == EOF)                ? derived_t::data[256]                  : false;
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
```

The problem here is that `value_t` is `char16_t` - a 16 bit **unsigned** integer - but `EOF` is a 32 bit **signed** integer.
Any number that this `char16_t` may represented is cast to `int32_t` and compared to `EOF` (with a value of `-1`). Hence this is a contradiction (the bit representations of the number will never be the same).

The solution is to get the proper EOF value for the given char_type. 