### PR TITLE
[TEST] rename alphabet_ test suite in test template

### DIFF
--- a/test/unit/alphabet/adaptation/char_test.cpp
+++ b/test/unit/alphabet/adaptation/char_test.cpp
@@ -18,7 +18,7 @@
 
 using char_types = ::testing::Types<char, char16_t, char32_t, wchar_t>;
 
-INSTANTIATE_TYPED_TEST_SUITE_P(char_adaptation, alphabet_, char_types, );
+INSTANTIATE_TYPED_TEST_SUITE_P(char_adaptation, alphabet, char_types, );
 INSTANTIATE_TYPED_TEST_SUITE_P(char_adaptation, semi_alphabet_test, char_types, );
 INSTANTIATE_TYPED_TEST_SUITE_P(char_adaptation, alphabet_constexpr, char_types, );
 INSTANTIATE_TYPED_TEST_SUITE_P(char_adaptation, semi_alphabet_constexpr, char_types, );

--- a/test/unit/alphabet/adaptation/uint_test.cpp
+++ b/test/unit/alphabet/adaptation/uint_test.cpp
@@ -19,7 +19,7 @@
 // uint32_t, too slow
 using fast_uint_types = ::testing::Types<uint8_t, uint16_t/*, uint32_t*/>;
 
-INSTANTIATE_TYPED_TEST_SUITE_P(uint_adaptation, alphabet_, fast_uint_types, );
+INSTANTIATE_TYPED_TEST_SUITE_P(uint_adaptation, alphabet, fast_uint_types, );
 INSTANTIATE_TYPED_TEST_SUITE_P(uint_adaptation, semi_alphabet_test, fast_uint_types, );
 INSTANTIATE_TYPED_TEST_SUITE_P(uint_adaptation, alphabet_constexpr, fast_uint_types, );
 INSTANTIATE_TYPED_TEST_SUITE_P(uint_adaptation, semi_alphabet_constexpr, fast_uint_types, );

--- a/test/unit/alphabet/alphabet_test_template.hpp
+++ b/test/unit/alphabet/alphabet_test_template.hpp
@@ -12,13 +12,13 @@
 #include <seqan3/test/pretty_printing.hpp>
 
 template <typename T>
-using alphabet_ = ::testing::Test;
+using alphabet = ::testing::Test;
 
 constexpr size_t max_iterations = 65536u;
 
-TYPED_TEST_SUITE_P(alphabet_);
+TYPED_TEST_SUITE_P(alphabet);
 
-TYPED_TEST_P(alphabet_, concept_check)
+TYPED_TEST_P(alphabet, concept_check)
 {
     EXPECT_TRUE(seqan3::alphabet<TypeParam>);
     EXPECT_TRUE(seqan3::alphabet<TypeParam &>);
@@ -31,7 +31,7 @@ TYPED_TEST_P(alphabet_, concept_check)
     EXPECT_FALSE(seqan3::writable_alphabet<TypeParam const &>);
 }
 
-TYPED_TEST_P(alphabet_, global_assign_char_to)
+TYPED_TEST_P(alphabet, assign_char_to)
 {
     using char_t = seqan3::alphabet_char_t<TypeParam>;
     if constexpr(std::integral<char_t>)
@@ -48,7 +48,7 @@ TYPED_TEST_P(alphabet_, global_assign_char_to)
     }
 }
 
-TYPED_TEST_P(alphabet_, global_char_is_valid_for) // only test negative example for most; more inside specialised tests
+TYPED_TEST_P(alphabet, char_is_valid_for) // only test negative example for most; more inside specialised tests
 {
     if constexpr (seqan3::alphabet_size<TypeParam> < 255) // includes most of our alphabets, but not the adaptations!
     {
@@ -56,7 +56,7 @@ TYPED_TEST_P(alphabet_, global_char_is_valid_for) // only test negative example 
     }
 }
 
-TYPED_TEST_P(alphabet_, global_assign_char_strictly_to)
+TYPED_TEST_P(alphabet, assign_char_strictly_to)
 {
     using char_t = seqan3::alphabet_char_t<TypeParam>;
     if constexpr(std::integral<char_t>)
@@ -74,7 +74,7 @@ TYPED_TEST_P(alphabet_, global_assign_char_strictly_to)
     }
 }
 
-TYPED_TEST_P(alphabet_, global_to_char)
+TYPED_TEST_P(alphabet, to_char)
 {
     TypeParam t0;
     EXPECT_TRUE((std::is_same_v<decltype(seqan3::to_char(t0)), seqan3::alphabet_char_t<TypeParam>>));
@@ -83,9 +83,9 @@ TYPED_TEST_P(alphabet_, global_to_char)
 
 }
 
-REGISTER_TYPED_TEST_SUITE_P(alphabet_,
+REGISTER_TYPED_TEST_SUITE_P(alphabet,
                             concept_check,
-                            global_assign_char_to,
-                            global_char_is_valid_for,
-                            global_assign_char_strictly_to,
-                            global_to_char);
+                            assign_char_to,
+                            char_is_valid_for,
+                            assign_char_strictly_to,
+                            to_char);

--- a/test/unit/alphabet/aminoacid/aa10li_test.cpp
+++ b/test/unit/alphabet/aminoacid/aa10li_test.cpp
@@ -16,7 +16,7 @@
 
 using seqan3::operator""_aa10li;
 
-INSTANTIATE_TYPED_TEST_SUITE_P(aa10li, alphabet_, seqan3::aa10li, );
+INSTANTIATE_TYPED_TEST_SUITE_P(aa10li, alphabet, seqan3::aa10li, );
 INSTANTIATE_TYPED_TEST_SUITE_P(aa10li, semi_alphabet_test, seqan3::aa10li, );
 INSTANTIATE_TYPED_TEST_SUITE_P(aa10li, alphabet_constexpr, seqan3::aa10li, );
 INSTANTIATE_TYPED_TEST_SUITE_P(aa10li, semi_alphabet_constexpr, seqan3::aa10li, );

--- a/test/unit/alphabet/aminoacid/aa10murphy_test.cpp
+++ b/test/unit/alphabet/aminoacid/aa10murphy_test.cpp
@@ -16,7 +16,7 @@
 
 using seqan3::operator""_aa10murphy;
 
-INSTANTIATE_TYPED_TEST_SUITE_P(aa10murphy, alphabet_, seqan3::aa10murphy, );
+INSTANTIATE_TYPED_TEST_SUITE_P(aa10murphy, alphabet, seqan3::aa10murphy, );
 INSTANTIATE_TYPED_TEST_SUITE_P(aa10murphy, semi_alphabet_test, seqan3::aa10murphy, );
 INSTANTIATE_TYPED_TEST_SUITE_P(aa10murphy, alphabet_constexpr, seqan3::aa10murphy, );
 INSTANTIATE_TYPED_TEST_SUITE_P(aa10murphy, semi_alphabet_constexpr, seqan3::aa10murphy, );

--- a/test/unit/alphabet/aminoacid/aa20_test.cpp
+++ b/test/unit/alphabet/aminoacid/aa20_test.cpp
@@ -16,7 +16,7 @@
 
 using seqan3::operator""_aa20;
 
-INSTANTIATE_TYPED_TEST_SUITE_P(aa20, alphabet_, seqan3::aa20, );
+INSTANTIATE_TYPED_TEST_SUITE_P(aa20, alphabet, seqan3::aa20, );
 INSTANTIATE_TYPED_TEST_SUITE_P(aa20, semi_alphabet_test, seqan3::aa20, );
 INSTANTIATE_TYPED_TEST_SUITE_P(aa20, alphabet_constexpr, seqan3::aa20, );
 INSTANTIATE_TYPED_TEST_SUITE_P(aa20, semi_alphabet_constexpr, seqan3::aa20, );

--- a/test/unit/alphabet/aminoacid/aa27_test.cpp
+++ b/test/unit/alphabet/aminoacid/aa27_test.cpp
@@ -16,7 +16,7 @@
 
 using seqan3::operator""_aa27;
 
-INSTANTIATE_TYPED_TEST_SUITE_P(aa27, alphabet_, seqan3::aa27, );
+INSTANTIATE_TYPED_TEST_SUITE_P(aa27, alphabet, seqan3::aa27, );
 INSTANTIATE_TYPED_TEST_SUITE_P(aa27, semi_alphabet_test, seqan3::aa27, );
 INSTANTIATE_TYPED_TEST_SUITE_P(aa27, alphabet_constexpr, seqan3::aa27, );
 INSTANTIATE_TYPED_TEST_SUITE_P(aa27, semi_alphabet_constexpr, seqan3::aa27, );

--- a/test/unit/alphabet/cigar/cigar_op_test.cpp
+++ b/test/unit/alphabet/cigar/cigar_op_test.cpp
@@ -15,7 +15,7 @@
 
 using seqan3::operator""_cigar_op;
 
-INSTANTIATE_TYPED_TEST_SUITE_P(cigar_op, alphabet_, seqan3::cigar_op, );
+INSTANTIATE_TYPED_TEST_SUITE_P(cigar_op, alphabet, seqan3::cigar_op, );
 INSTANTIATE_TYPED_TEST_SUITE_P(cigar_op, semi_alphabet_test, seqan3::cigar_op, );
 INSTANTIATE_TYPED_TEST_SUITE_P(cigar_op, alphabet_constexpr, seqan3::cigar_op, );
 INSTANTIATE_TYPED_TEST_SUITE_P(cigar_op, semi_alphabet_constexpr, seqan3::cigar_op, );

--- a/test/unit/alphabet/composite/alphabet_variant_test.cpp
+++ b/test/unit/alphabet/composite/alphabet_variant_test.cpp
@@ -28,7 +28,7 @@ using alphabet_variant_types = ::testing::Types<seqan3::alphabet_variant<seqan3:
                                                 seqan3::alphabet_variant<seqan3::dna4, seqan3::dna5, seqan3::gap>,
                                                 seqan3::alphabet_variant<char, seqan3::gap>>;
 
-INSTANTIATE_TYPED_TEST_SUITE_P(alphabet_variant, alphabet_, alphabet_variant_types, );
+INSTANTIATE_TYPED_TEST_SUITE_P(alphabet_variant, alphabet, alphabet_variant_types, );
 INSTANTIATE_TYPED_TEST_SUITE_P(alphabet_variant, semi_alphabet_test, alphabet_variant_types, );
 INSTANTIATE_TYPED_TEST_SUITE_P(alphabet_variant, alphabet_constexpr, alphabet_variant_types, );
 INSTANTIATE_TYPED_TEST_SUITE_P(alphabet_variant, semi_alphabet_constexpr, alphabet_variant_types, );

--- a/test/unit/alphabet/custom_alphabet3_test.cpp
+++ b/test/unit/alphabet/custom_alphabet3_test.cpp
@@ -79,7 +79,7 @@ struct seqan3::custom::alphabet<third_party_ns::third_party_type>
 static_assert(seqan3::alphabet<third_party_ns::third_party_type>);
 //![third_party_type]
 
-INSTANTIATE_TYPED_TEST_SUITE_P(third_party_type, alphabet_,           third_party_ns::third_party_type, );
-INSTANTIATE_TYPED_TEST_SUITE_P(third_party_type, semi_alphabet_test,  third_party_ns::third_party_type, );
-INSTANTIATE_TYPED_TEST_SUITE_P(third_party_type, alphabet_constexpr,  third_party_ns::third_party_type, );
+INSTANTIATE_TYPED_TEST_SUITE_P(third_party_type, alphabet, third_party_ns::third_party_type, );
+INSTANTIATE_TYPED_TEST_SUITE_P(third_party_type, semi_alphabet_test, third_party_ns::third_party_type, );
+INSTANTIATE_TYPED_TEST_SUITE_P(third_party_type, alphabet_constexpr, third_party_ns::third_party_type, );
 INSTANTIATE_TYPED_TEST_SUITE_P(third_party_type, semi_alphabet_constexpr, third_party_ns::third_party_type, );

--- a/test/unit/alphabet/custom_alphabet_test.cpp
+++ b/test/unit/alphabet/custom_alphabet_test.cpp
@@ -73,7 +73,7 @@ constexpr my_alph & assign_char_to(char const c, my_alph & a) noexcept
 static_assert(seqan3::alphabet<my_namespace::my_alph>);
 //![my_alph]
 
-INSTANTIATE_TYPED_TEST_SUITE_P(my_alph, alphabet_, my_namespace::my_alph, );
+INSTANTIATE_TYPED_TEST_SUITE_P(my_alph, alphabet, my_namespace::my_alph, );
 INSTANTIATE_TYPED_TEST_SUITE_P(my_alph, semi_alphabet_test, my_namespace::my_alph, );
 INSTANTIATE_TYPED_TEST_SUITE_P(my_alph, alphabet_constexpr, my_namespace::my_alph, );
 INSTANTIATE_TYPED_TEST_SUITE_P(my_alph, semi_alphabet_constexpr, my_namespace::my_alph, );

--- a/test/unit/alphabet/detail/alphabet_proxy_test.cpp
+++ b/test/unit/alphabet/detail/alphabet_proxy_test.cpp
@@ -38,7 +38,7 @@ public:
     using base_t::operator=;
 };
 
-INSTANTIATE_TYPED_TEST_SUITE_P(alphabet_proxy, alphabet_, alphabet_proxy_example, );
+INSTANTIATE_TYPED_TEST_SUITE_P(alphabet_proxy, alphabet, alphabet_proxy_example, );
 INSTANTIATE_TYPED_TEST_SUITE_P(alphabet_proxy, semi_alphabet_test, alphabet_proxy_example, );
 INSTANTIATE_TYPED_TEST_SUITE_P(alphabet_proxy, alphabet_constexpr, alphabet_proxy_example, );
 INSTANTIATE_TYPED_TEST_SUITE_P(alphabet_proxy, semi_alphabet_constexpr, alphabet_proxy_example, );
@@ -131,5 +131,5 @@ public:
     {};
 };
 
-INSTANTIATE_TYPED_TEST_SUITE_P(alphabet_proxy2, alphabet_, alphabet_proxy_example2, );
+INSTANTIATE_TYPED_TEST_SUITE_P(alphabet_proxy2, alphabet, alphabet_proxy_example2, );
 INSTANTIATE_TYPED_TEST_SUITE_P(alphabet_proxy2, alphabet_constexpr, alphabet_proxy_example2, );

--- a/test/unit/alphabet/gap/gap_test.cpp
+++ b/test/unit/alphabet/gap/gap_test.cpp
@@ -17,7 +17,7 @@
 #include "../semi_alphabet_constexpr_test_template.hpp"
 #include "../semi_alphabet_test_template.hpp"
 
-INSTANTIATE_TYPED_TEST_SUITE_P(gap, alphabet_, seqan3::gap, );
+INSTANTIATE_TYPED_TEST_SUITE_P(gap, alphabet, seqan3::gap, );
 INSTANTIATE_TYPED_TEST_SUITE_P(gap, semi_alphabet_test, seqan3::gap, );
 INSTANTIATE_TYPED_TEST_SUITE_P(gap, alphabet_constexpr, seqan3::gap, );
 INSTANTIATE_TYPED_TEST_SUITE_P(gap, semi_alphabet_constexpr, seqan3::gap, );

--- a/test/unit/alphabet/gap/gapped_test.cpp
+++ b/test/unit/alphabet/gap/gapped_test.cpp
@@ -29,7 +29,7 @@ using gapped_types = ::testing::Types<seqan3::gapped<seqan3::dna4>,
                                       seqan3::gapped<seqan3::dna15>,
                                       seqan3::gapped<seqan3::qualified<seqan3::dna4, seqan3::phred42>>>;
 
-INSTANTIATE_TYPED_TEST_SUITE_P(gapped, alphabet_, gapped_types, );
+INSTANTIATE_TYPED_TEST_SUITE_P(gapped, alphabet, gapped_types, );
 INSTANTIATE_TYPED_TEST_SUITE_P(gapped, semi_alphabet_test, gapped_types, );
 INSTANTIATE_TYPED_TEST_SUITE_P(gapped, alphabet_constexpr, gapped_types, );
 INSTANTIATE_TYPED_TEST_SUITE_P(gapped, semi_alphabet_constexpr, gapped_types, );

--- a/test/unit/alphabet/mask/masked_test.cpp
+++ b/test/unit/alphabet/mask/masked_test.cpp
@@ -19,7 +19,7 @@
 
 using masked_types = ::testing::Types<seqan3::masked<seqan3::dna4>, seqan3::masked<seqan3::dna5>>;
 
-INSTANTIATE_TYPED_TEST_SUITE_P(masked, alphabet_, masked_types, );
+INSTANTIATE_TYPED_TEST_SUITE_P(masked, alphabet, masked_types, );
 INSTANTIATE_TYPED_TEST_SUITE_P(masked, semi_alphabet_test, masked_types, );
 INSTANTIATE_TYPED_TEST_SUITE_P(masked, alphabet_constexpr, masked_types, );
 INSTANTIATE_TYPED_TEST_SUITE_P(masked, semi_alphabet_constexpr, masked_types, );

--- a/test/unit/alphabet/nucleotide/dna15_test.cpp
+++ b/test/unit/alphabet/nucleotide/dna15_test.cpp
@@ -14,7 +14,7 @@
 
 using seqan3::operator""_dna15;
 
-INSTANTIATE_TYPED_TEST_SUITE_P(dna15, alphabet_, seqan3::dna15, );
+INSTANTIATE_TYPED_TEST_SUITE_P(dna15, alphabet, seqan3::dna15, );
 INSTANTIATE_TYPED_TEST_SUITE_P(dna15, semi_alphabet_test, seqan3::dna15, );
 INSTANTIATE_TYPED_TEST_SUITE_P(dna15, alphabet_constexpr, seqan3::dna15, );
 INSTANTIATE_TYPED_TEST_SUITE_P(dna15, semi_alphabet_constexpr, seqan3::dna15, );

--- a/test/unit/alphabet/nucleotide/dna3bs_test.cpp
+++ b/test/unit/alphabet/nucleotide/dna3bs_test.cpp
@@ -13,7 +13,7 @@
 #include "../semi_alphabet_constexpr_test_template.hpp"
 #include "../semi_alphabet_test_template.hpp"
 
-INSTANTIATE_TYPED_TEST_SUITE_P(dna3bs, alphabet_, seqan3::dna3bs, );
+INSTANTIATE_TYPED_TEST_SUITE_P(dna3bs, alphabet, seqan3::dna3bs, );
 INSTANTIATE_TYPED_TEST_SUITE_P(dna3bs, semi_alphabet_test, seqan3::dna3bs, );
 INSTANTIATE_TYPED_TEST_SUITE_P(dna3bs, alphabet_constexpr, seqan3::dna3bs, );
 INSTANTIATE_TYPED_TEST_SUITE_P(dna3bs, semi_alphabet_constexpr, seqan3::dna3bs, );

--- a/test/unit/alphabet/nucleotide/dna4_test.cpp
+++ b/test/unit/alphabet/nucleotide/dna4_test.cpp
@@ -13,7 +13,7 @@
 
 using seqan3::operator""_dna4;
 
-INSTANTIATE_TYPED_TEST_SUITE_P(dna4, alphabet_, seqan3::dna4, );
+INSTANTIATE_TYPED_TEST_SUITE_P(dna4, alphabet, seqan3::dna4, );
 INSTANTIATE_TYPED_TEST_SUITE_P(dna4, semi_alphabet_test, seqan3::dna4, );
 INSTANTIATE_TYPED_TEST_SUITE_P(dna4, alphabet_constexpr, seqan3::dna4, );
 INSTANTIATE_TYPED_TEST_SUITE_P(dna4, semi_alphabet_constexpr, seqan3::dna4, );

--- a/test/unit/alphabet/nucleotide/dna5_test.cpp
+++ b/test/unit/alphabet/nucleotide/dna5_test.cpp
@@ -14,7 +14,7 @@
 
 using seqan3::operator""_dna5;
 
-INSTANTIATE_TYPED_TEST_SUITE_P(dna5, alphabet_, seqan3::dna5, );
+INSTANTIATE_TYPED_TEST_SUITE_P(dna5, alphabet, seqan3::dna5, );
 INSTANTIATE_TYPED_TEST_SUITE_P(dna5, semi_alphabet_test, seqan3::dna5, );
 INSTANTIATE_TYPED_TEST_SUITE_P(dna5, alphabet_constexpr, seqan3::dna5, );
 INSTANTIATE_TYPED_TEST_SUITE_P(dna5, semi_alphabet_constexpr, seqan3::dna5, );

--- a/test/unit/alphabet/nucleotide/rna15_test.cpp
+++ b/test/unit/alphabet/nucleotide/rna15_test.cpp
@@ -13,7 +13,7 @@
 
 using seqan3::operator""_rna15;
 
-INSTANTIATE_TYPED_TEST_SUITE_P(rna15, alphabet_, seqan3::rna15, );
+INSTANTIATE_TYPED_TEST_SUITE_P(rna15, alphabet, seqan3::rna15, );
 INSTANTIATE_TYPED_TEST_SUITE_P(rna15, semi_alphabet_test, seqan3::rna15, );
 INSTANTIATE_TYPED_TEST_SUITE_P(rna15, alphabet_constexpr, seqan3::rna15, );
 INSTANTIATE_TYPED_TEST_SUITE_P(rna15, semi_alphabet_constexpr, seqan3::rna15, );

--- a/test/unit/alphabet/nucleotide/rna4_test.cpp
+++ b/test/unit/alphabet/nucleotide/rna4_test.cpp
@@ -13,7 +13,7 @@
 
 using seqan3::operator""_rna4;
 
-INSTANTIATE_TYPED_TEST_SUITE_P(rna4, alphabet_, seqan3::rna4, );
+INSTANTIATE_TYPED_TEST_SUITE_P(rna4, alphabet, seqan3::rna4, );
 INSTANTIATE_TYPED_TEST_SUITE_P(rna4, semi_alphabet_test, seqan3::rna4, );
 INSTANTIATE_TYPED_TEST_SUITE_P(rna4, alphabet_constexpr, seqan3::rna4, );
 INSTANTIATE_TYPED_TEST_SUITE_P(rna4, semi_alphabet_constexpr, seqan3::rna4, );

--- a/test/unit/alphabet/nucleotide/rna5_test.cpp
+++ b/test/unit/alphabet/nucleotide/rna5_test.cpp
@@ -13,7 +13,7 @@
 
 using seqan3::operator""_rna5;
 
-INSTANTIATE_TYPED_TEST_SUITE_P(rna5, alphabet_, seqan3::rna5, );
+INSTANTIATE_TYPED_TEST_SUITE_P(rna5, alphabet, seqan3::rna5, );
 INSTANTIATE_TYPED_TEST_SUITE_P(rna5, semi_alphabet_test, seqan3::rna5, );
 INSTANTIATE_TYPED_TEST_SUITE_P(rna5, alphabet_constexpr, seqan3::rna5, );
 INSTANTIATE_TYPED_TEST_SUITE_P(rna5, semi_alphabet_constexpr, seqan3::rna5, );

--- a/test/unit/alphabet/nucleotide/sam_dna16_test.cpp
+++ b/test/unit/alphabet/nucleotide/sam_dna16_test.cpp
@@ -20,7 +20,7 @@ using seqan3::operator""_sam_dna16;
 // sam_dna16 alphabet
 // ------------------------------------------------------------------
 
-INSTANTIATE_TYPED_TEST_SUITE_P(sam_dna16, alphabet_, seqan3::sam_dna16, );
+INSTANTIATE_TYPED_TEST_SUITE_P(sam_dna16, alphabet, seqan3::sam_dna16, );
 INSTANTIATE_TYPED_TEST_SUITE_P(sam_dna16, semi_alphabet_test, seqan3::sam_dna16, );
 INSTANTIATE_TYPED_TEST_SUITE_P(sam_dna16, alphabet_constexpr, seqan3::sam_dna16, );
 INSTANTIATE_TYPED_TEST_SUITE_P(sam_dna16, semi_alphabet_constexpr, seqan3::sam_dna16, );

--- a/test/unit/alphabet/quality/phred42_test.cpp
+++ b/test/unit/alphabet/quality/phred42_test.cpp
@@ -17,7 +17,7 @@
 
 using seqan3::operator""_phred42;
 
-INSTANTIATE_TYPED_TEST_SUITE_P(phred42, alphabet_, seqan3::phred42, );
+INSTANTIATE_TYPED_TEST_SUITE_P(phred42, alphabet, seqan3::phred42, );
 INSTANTIATE_TYPED_TEST_SUITE_P(phred42, semi_alphabet_test, seqan3::phred42, );
 INSTANTIATE_TYPED_TEST_SUITE_P(phred42, alphabet_constexpr, seqan3::phred42, );
 INSTANTIATE_TYPED_TEST_SUITE_P(phred42, semi_alphabet_constexpr, seqan3::phred42, );

--- a/test/unit/alphabet/quality/phred63_test.cpp
+++ b/test/unit/alphabet/quality/phred63_test.cpp
@@ -17,7 +17,7 @@
 
 using seqan3::operator""_phred63;
 
-INSTANTIATE_TYPED_TEST_SUITE_P(phred63, alphabet_, seqan3::phred63, );
+INSTANTIATE_TYPED_TEST_SUITE_P(phred63, alphabet, seqan3::phred63, );
 INSTANTIATE_TYPED_TEST_SUITE_P(phred63, semi_alphabet_test, seqan3::phred63, );
 INSTANTIATE_TYPED_TEST_SUITE_P(phred63, alphabet_constexpr, seqan3::phred63, );
 INSTANTIATE_TYPED_TEST_SUITE_P(phred63, semi_alphabet_constexpr, seqan3::phred63, );

--- a/test/unit/alphabet/quality/phred68legacy_test.cpp
+++ b/test/unit/alphabet/quality/phred68legacy_test.cpp
@@ -17,7 +17,7 @@
 
 using seqan3::operator""_phred68legacy;
 
-INSTANTIATE_TYPED_TEST_SUITE_P(phred68legacy, alphabet_, seqan3::phred68legacy, );
+INSTANTIATE_TYPED_TEST_SUITE_P(phred68legacy, alphabet, seqan3::phred68legacy, );
 INSTANTIATE_TYPED_TEST_SUITE_P(phred68legacy, semi_alphabet_test, seqan3::phred68legacy, );
 INSTANTIATE_TYPED_TEST_SUITE_P(phred68legacy, alphabet_constexpr, seqan3::phred68legacy, );
 INSTANTIATE_TYPED_TEST_SUITE_P(phred68legacy, semi_alphabet_constexpr, seqan3::phred68legacy, );

--- a/test/unit/alphabet/quality/qualified_test.cpp
+++ b/test/unit/alphabet/quality/qualified_test.cpp
@@ -70,7 +70,7 @@ using qualified_types = ::testing::Types<seqan3::qualified<seqan3::dna4, seqan3:
                                          seqan3::qualified<seqan3::gapped<seqan3::dna4>, seqan3::phred42>,
                                          seqan3::dna4q>;
 
-INSTANTIATE_TYPED_TEST_SUITE_P(qualified, alphabet_, qualified_types, );
+INSTANTIATE_TYPED_TEST_SUITE_P(qualified, alphabet, qualified_types, );
 INSTANTIATE_TYPED_TEST_SUITE_P(qualified, semi_alphabet_test, qualified_types, );
 INSTANTIATE_TYPED_TEST_SUITE_P(qualified, alphabet_constexpr, qualified_types, );
 INSTANTIATE_TYPED_TEST_SUITE_P(qualified, semi_alphabet_constexpr, qualified_types, );

--- a/test/unit/alphabet/structure/dot_bracket3_test.cpp
+++ b/test/unit/alphabet/structure/dot_bracket3_test.cpp
@@ -16,7 +16,7 @@
 
 using seqan3::operator""_db3;
 
-INSTANTIATE_TYPED_TEST_SUITE_P(dot_bracket3, alphabet_, seqan3::dot_bracket3, );
+INSTANTIATE_TYPED_TEST_SUITE_P(dot_bracket3, alphabet, seqan3::dot_bracket3, );
 INSTANTIATE_TYPED_TEST_SUITE_P(dot_bracket3, semi_alphabet_test, seqan3::dot_bracket3, );
 INSTANTIATE_TYPED_TEST_SUITE_P(dot_bracket3, alphabet_constexpr, seqan3::dot_bracket3, );
 INSTANTIATE_TYPED_TEST_SUITE_P(dot_bracket3, semi_alphabet_constexpr, seqan3::dot_bracket3, );

--- a/test/unit/alphabet/structure/dssp9_test.cpp
+++ b/test/unit/alphabet/structure/dssp9_test.cpp
@@ -15,7 +15,7 @@
 
 using seqan3::operator""_dssp9;
 
-INSTANTIATE_TYPED_TEST_SUITE_P(dssp9, alphabet_, seqan3::dssp9, );
+INSTANTIATE_TYPED_TEST_SUITE_P(dssp9, alphabet, seqan3::dssp9, );
 INSTANTIATE_TYPED_TEST_SUITE_P(dssp9, semi_alphabet_test, seqan3::dssp9, );
 INSTANTIATE_TYPED_TEST_SUITE_P(dssp9, alphabet_constexpr, seqan3::dssp9, );
 INSTANTIATE_TYPED_TEST_SUITE_P(dssp9, semi_alphabet_constexpr, seqan3::dssp9, );

--- a/test/unit/alphabet/structure/structured_aa_test.cpp
+++ b/test/unit/alphabet/structure/structured_aa_test.cpp
@@ -59,7 +59,7 @@ public:
 
 using structured_aa_types = ::testing::Types<seqan3::structured_aa<seqan3::aa27, seqan3::dssp9>>;
 
-INSTANTIATE_TYPED_TEST_SUITE_P(structured_aa, alphabet_, structured_aa_types, );
+INSTANTIATE_TYPED_TEST_SUITE_P(structured_aa, alphabet, structured_aa_types, );
 INSTANTIATE_TYPED_TEST_SUITE_P(structured_aa, semi_alphabet_test, structured_aa_types, );
 INSTANTIATE_TYPED_TEST_SUITE_P(structured_aa, alphabet_constexpr, structured_aa_types, );
 INSTANTIATE_TYPED_TEST_SUITE_P(structured_aa, semi_alphabet_constexpr, structured_aa_types, );

--- a/test/unit/alphabet/structure/structured_rna_test.cpp
+++ b/test/unit/alphabet/structure/structured_rna_test.cpp
@@ -61,7 +61,7 @@ public:
 using structured_rna_types = ::testing::Types<seqan3::structured_rna<seqan3::rna5, seqan3::dot_bracket3>,
                                               seqan3::structured_rna<seqan3::rna4, seqan3::wuss51>>;
 
-INSTANTIATE_TYPED_TEST_SUITE_P(structured_rna, alphabet_, structured_rna_types, );
+INSTANTIATE_TYPED_TEST_SUITE_P(structured_rna, alphabet, structured_rna_types, );
 INSTANTIATE_TYPED_TEST_SUITE_P(structured_rna, semi_alphabet_test, structured_rna_types, );
 INSTANTIATE_TYPED_TEST_SUITE_P(structured_rna, alphabet_constexpr, structured_rna_types, );
 INSTANTIATE_TYPED_TEST_SUITE_P(structured_rna, semi_alphabet_constexpr, structured_rna_types, );

--- a/test/unit/alphabet/structure/wuss_test.cpp
+++ b/test/unit/alphabet/structure/wuss_test.cpp
@@ -16,15 +16,15 @@
 
 using seqan3::operator""_wuss51;
 
-INSTANTIATE_TYPED_TEST_SUITE_P(wuss51, alphabet_, seqan3::wuss51, );
+INSTANTIATE_TYPED_TEST_SUITE_P(wuss51, alphabet, seqan3::wuss51, );
 INSTANTIATE_TYPED_TEST_SUITE_P(wuss51, semi_alphabet_test, seqan3::wuss51, );
 INSTANTIATE_TYPED_TEST_SUITE_P(wuss51, alphabet_constexpr, seqan3::wuss51, );
 INSTANTIATE_TYPED_TEST_SUITE_P(wuss51, semi_alphabet_constexpr, seqan3::wuss51, );
-INSTANTIATE_TYPED_TEST_SUITE_P(wuss15, alphabet_, seqan3::wuss<15>, );
+INSTANTIATE_TYPED_TEST_SUITE_P(wuss15, alphabet, seqan3::wuss<15>, );
 INSTANTIATE_TYPED_TEST_SUITE_P(wuss15, semi_alphabet_test, seqan3::wuss<15>, );
 INSTANTIATE_TYPED_TEST_SUITE_P(wuss15, alphabet_constexpr, seqan3::wuss<15>, );
 INSTANTIATE_TYPED_TEST_SUITE_P(wuss15, semi_alphabet_constexpr, seqan3::wuss<15>, );
-INSTANTIATE_TYPED_TEST_SUITE_P(wuss67, alphabet_, seqan3::wuss<67>, );
+INSTANTIATE_TYPED_TEST_SUITE_P(wuss67, alphabet, seqan3::wuss<67>, );
 INSTANTIATE_TYPED_TEST_SUITE_P(wuss67, semi_alphabet_test, seqan3::wuss<67>, );
 INSTANTIATE_TYPED_TEST_SUITE_P(wuss67, alphabet_constexpr, seqan3::wuss<67>, );
 INSTANTIATE_TYPED_TEST_SUITE_P(wuss67, semi_alphabet_constexpr, seqan3::wuss<67>, );


### PR DESCRIPTION
@simonsasse asked me why we have a underscore in

```c++
TEST(range_and_iterator, innermost_value_type_) // ...
```

I wanted to give him the rational that we have a name clash, but then it
came to me that we actually don't have any name clashes any more due to
https://github.com/seqan/product_backlog/issues/89.

This means we can remove the underscore or `global_` constructs from our
test cases which avoided ambiguous names.

This PR should be used as an example how to rename other test suites.

Part of https://github.com/seqan/product_backlog/issues/90