### PR TITLE
[MISC] Renaming seqan3::dimension_v, innermost_value_type, innermost_value_type_t and concept compatible 

### DIFF
--- a/include/seqan3/core/type_traits/range.hpp
+++ b/include/seqan3/core/type_traits/range.hpp
@@ -21,7 +21,7 @@
 #include <seqan3/std/ranges>
 #include <seqan3/std/iterator>
 
-// TODO(h-2): add innermost_reference instead of or addition to innermost_value_type?
+// TODO(h-2): add innermost_reference instead of or addition to range_innermost_value?
 
 //NOTE(h-2): for the range overloads we explicitly forbid that the type is iteratoer
 // because some types are actually both (e.g. std::directory_iterator)
@@ -152,7 +152,7 @@ struct size_type<rng_t>
 };
 
 // ----------------------------------------------------------------------------
-// innermost_value_type
+// range_innermost_value
 // ----------------------------------------------------------------------------
 
 //NOTE(h-2): this could be moved to a separate file, because it also applies to iterators
@@ -169,7 +169,7 @@ template <typename t>
 //!\cond
     requires detail::has_range_value_type<t>
 //!\endcond
-struct innermost_value_type
+struct range_innermost_value
 {
     //!\brief The return type (recursion not shown).
     using type = std::ranges::range_value_t<remove_cvref_t<t>>;
@@ -178,16 +178,16 @@ struct innermost_value_type
 //!\cond
 template <typename t>
     requires detail::has_range_value_type<t> && detail::has_range_value_type<std::ranges::range_value_t<remove_cvref_t<t>>>
-struct innermost_value_type<t>
+struct range_innermost_value<t>
 {
-    using type = typename innermost_value_type<std::ranges::range_value_t<remove_cvref_t<t>>>::type;
+    using type = typename range_innermost_value<std::ranges::range_value_t<remove_cvref_t<t>>>::type;
 };
 //!\endcond
 
-//!\brief Shortcut for seqan3::innermost_value_type (transformation_trait shortcut).
-//!\see seqan3::innermost_value_type
+//!\brief Shortcut for seqan3::range_innermost_value (transformation_trait shortcut).
+//!\see seqan3::range_innermost_value
 template <typename t>
-using innermost_value_type_t = typename innermost_value_type<t>::type;
+using innermost_value_type_t = typename range_innermost_value<t>::type;
 
 // ----------------------------------------------------------------------------
 // range_dimension_v

--- a/include/seqan3/core/type_traits/range.hpp
+++ b/include/seqan3/core/type_traits/range.hpp
@@ -190,7 +190,7 @@ template <typename t>
 using innermost_value_type_t = typename innermost_value_type<t>::type;
 
 // ----------------------------------------------------------------------------
-// dimension_v
+// range_dimension_v
 // ----------------------------------------------------------------------------
 
 //NOTE(h-2): this could be moved to a separate file, because it also applies to iterators
@@ -207,12 +207,12 @@ template <typename t>
 //!\cond
     requires detail::has_range_value_type<t>
 //!\endcond
-constexpr size_t dimension_v = 1;
+constexpr size_t range_dimension_v = 1;
 
 //!\cond
 template <typename t>
     requires detail::has_range_value_type<t> && detail::has_range_value_type<std::ranges::range_value_t<remove_cvref_t<t>>>
-constexpr size_t dimension_v<t> = dimension_v<std::ranges::range_value_t<remove_cvref_t<t>>> + 1;
+constexpr size_t range_dimension_v<t> = range_dimension_v<std::ranges::range_value_t<remove_cvref_t<t>>> + 1;
 //!\endcond
 
 // ----------------------------------------------------------------------------
@@ -222,7 +222,7 @@ constexpr size_t dimension_v<t> = dimension_v<std::ranges::range_value_t<remove_
 //NOTE(h-2): this could be moved to a separate file, because it also applies to iterators
 
 /*!\interface seqan3::compatible <>
- * \brief Two types are "compatible" if their seqan3::dimension_v and their seqan3::innermost_value_type_t are
+ * \brief Two types are "compatible" if their seqan3::range_dimension_v and their seqan3::innermost_value_type_t are
  * the same.
  *
  * \details
@@ -236,7 +236,7 @@ constexpr size_t dimension_v<t> = dimension_v<std::ranges::range_value_t<remove_
 template <typename t1, typename t2>
 SEQAN3_CONCEPT compatible = requires (t1, t2)
 {
-    requires (dimension_v<t1> == dimension_v<t2>);
+    requires (range_dimension_v<t1> == range_dimension_v<t2>);
 
     requires std::is_same_v<innermost_value_type_t<t1>, innermost_value_type_t<t2>>;
 };

--- a/include/seqan3/core/type_traits/range.hpp
+++ b/include/seqan3/core/type_traits/range.hpp
@@ -187,7 +187,7 @@ struct range_innermost_value<t>
 //!\brief Shortcut for seqan3::range_innermost_value (transformation_trait shortcut).
 //!\see seqan3::range_innermost_value
 template <typename t>
-using innermost_value_type_t = typename range_innermost_value<t>::type;
+using range_innermost_value_t = typename range_innermost_value<t>::type;
 
 // ----------------------------------------------------------------------------
 // range_dimension_v
@@ -222,7 +222,7 @@ constexpr size_t range_dimension_v<t> = range_dimension_v<std::ranges::range_val
 //NOTE(h-2): this could be moved to a separate file, because it also applies to iterators
 
 /*!\interface seqan3::compatible <>
- * \brief Two types are "compatible" if their seqan3::range_dimension_v and their seqan3::innermost_value_type_t are
+ * \brief Two types are "compatible" if their seqan3::range_dimension_v and their seqan3::range_innermost_value_t are
  * the same.
  *
  * \details
@@ -238,7 +238,7 @@ SEQAN3_CONCEPT compatible = requires (t1, t2)
 {
     requires (range_dimension_v<t1> == range_dimension_v<t2>);
 
-    requires std::is_same_v<innermost_value_type_t<t1>, innermost_value_type_t<t2>>;
+    requires std::is_same_v<range_innermost_value_t<t1>, range_innermost_value_t<t2>>;
 };
 //!\endcond
 

--- a/include/seqan3/core/type_traits/range.hpp
+++ b/include/seqan3/core/type_traits/range.hpp
@@ -216,12 +216,12 @@ constexpr size_t range_dimension_v<t> = range_dimension_v<std::ranges::range_val
 //!\endcond
 
 // ----------------------------------------------------------------------------
-// compatible
+// range_compatible
 // ----------------------------------------------------------------------------
 
 //NOTE(h-2): this could be moved to a separate file, because it also applies to iterators
 
-/*!\interface seqan3::compatible <>
+/*!\interface seqan3::range_compatible <>
  * \brief Two types are "compatible" if their seqan3::range_dimension_v and their seqan3::range_innermost_value_t are
  * the same.
  *
@@ -234,7 +234,7 @@ constexpr size_t range_dimension_v<t> = range_dimension_v<std::ranges::range_val
  */
 //!\cond
 template <typename t1, typename t2>
-SEQAN3_CONCEPT compatible = requires (t1, t2)
+SEQAN3_CONCEPT range_compatible = requires (t1, t2)
 {
     requires (range_dimension_v<t1> == range_dimension_v<t2>);
 

--- a/include/seqan3/io/alignment_file/header.hpp
+++ b/include/seqan3/io/alignment_file/header.hpp
@@ -92,7 +92,7 @@ private:
     static void ref_ids_deleter_default(ref_ids_type * ptr) { delete ptr; }
     //!\brief The key's type of ref_dict.
     using key_type = std::conditional_t<std::ranges::contiguous_range<std::ranges::range_reference_t<ref_ids_type>>,
-                        std::span<innermost_value_type_t<ref_ids_type> const>,
+                        std::span<range_innermost_value_t<ref_ids_type> const>,
                         type_reduce_view<std::ranges::range_reference_t<ref_ids_type>>>;
     //!\brief The pointer to reference ids information (non-owning if reference information is given).
     ref_ids_ptr_t ref_ids_ptr{new ref_ids_type{}, ref_ids_deleter_default};

--- a/include/seqan3/range/container/concatenated_sequences.hpp
+++ b/include/seqan3/range/container/concatenated_sequences.hpp
@@ -187,7 +187,7 @@ protected:
     template <std::ranges::range t>
     static constexpr bool is_compatible_with_value_type_aux(std::type_identity<t>)
     {
-        return dimension_v<t> == dimension_v<value_type> &&
+        return range_dimension_v<t> == range_dimension_v<value_type> &&
                std::convertible_to<std::ranges::range_reference_t<t>, std::ranges::range_value_t<value_type>>;
     }
 

--- a/include/seqan3/range/container/concatenated_sequences.hpp
+++ b/include/seqan3/range/container/concatenated_sequences.hpp
@@ -179,7 +179,7 @@ public:
 
 protected:
     /*!\name Compatibility
-     * \brief Static constexpr variables that emulate/encapsulate seqan3::compatible (which doesn't work for types during their definition).
+     * \brief Static constexpr variables that emulate/encapsulate seqan3::range_compatible (which doesn't work for types during their definition).
      * \{
      */
     //!\cond
@@ -197,13 +197,13 @@ protected:
     }
     //!\endcond
 
-    //!\brief Whether a type satisfies seqan3::compatible with this class's `value_type` or `reference` type.
+    //!\brief Whether a type satisfies seqan3::range_compatible with this class's `value_type` or `reference` type.
     //!\hideinitializer
     // we explicitly check same-ness, because these types may not be fully resolved, yet
     template <std::ranges::range t>
     static constexpr bool is_compatible_with_value_type = is_compatible_with_value_type_aux(std::type_identity<t>{});
 
-    //!\brief Whether a type satisfies seqan3::compatible with this class.
+    //!\brief Whether a type satisfies seqan3::range_compatible with this class.
     //!\hideinitializer
     // cannot use the concept, because this class is not yet fully defined
     template <typename t>
@@ -212,7 +212,7 @@ protected:
     //!\endcond
     static constexpr bool iter_value_t_is_compatible_with_value_type = true;
 
-    //!\brief Whether a type satisfies seqan3::compatible with this class.
+    //!\brief Whether a type satisfies seqan3::range_compatible with this class.
     //!\hideinitializer
     // cannot use the concept, because this class is not yet fully defined
     template <std::ranges::range t>

--- a/include/seqan3/range/views/translate.hpp
+++ b/include/seqan3/range/views/translate.hpp
@@ -564,7 +564,7 @@ protected:
     //!\cond
     // unfortunately we cannot specialise the variable template so we have to add an auxiliary here
     template <typename t>
-        requires (dimension_v<t> == dimension_v<value_type> + 1) &&
+        requires (range_dimension_v<t> == range_dimension_v<value_type> + 1) &&
                  std::is_same_v<remove_cvref_t<innermost_value_type_t<value_type>>,
                                 remove_cvref_t<innermost_value_type_t<t>>>
     static constexpr bool is_compatible_this_aux = true;

--- a/include/seqan3/range/views/translate.hpp
+++ b/include/seqan3/range/views/translate.hpp
@@ -565,8 +565,8 @@ protected:
     // unfortunately we cannot specialise the variable template so we have to add an auxiliary here
     template <typename t>
         requires (range_dimension_v<t> == range_dimension_v<value_type> + 1) &&
-                 std::is_same_v<remove_cvref_t<innermost_value_type_t<value_type>>,
-                                remove_cvref_t<innermost_value_type_t<t>>>
+                 std::is_same_v<remove_cvref_t<range_innermost_value_t<value_type>>,
+                                remove_cvref_t<range_innermost_value_t<t>>>
     static constexpr bool is_compatible_this_aux = true;
     //!\endcond
     //!\}

--- a/include/seqan3/range/views/translate.hpp
+++ b/include/seqan3/range/views/translate.hpp
@@ -558,7 +558,7 @@ public:
 
 protected:
     /*!\name Compatibility
-     * \brief Static constexpr variables that emulate/encapsulate seqan3::compatible (which doesn't work for types during their definition).
+     * \brief Static constexpr variables that emulate/encapsulate seqan3::range_compatible (which doesn't work for types during their definition).
      * \{
      */
     //!\cond

--- a/include/seqan3/range/views/translate_join.hpp
+++ b/include/seqan3/range/views/translate_join.hpp
@@ -74,22 +74,26 @@ private:
 
 public:
 
-    static_assert(dimension_v<urng_t> == 2,
-        "This adaptor only handles range-of-range (two dimensions) as input.");
+    static_assert(range_dimension_v<urng_t> == 2,
+                  "This adaptor only handles range-of-range (two dimensions) as input.");
     static_assert(std::ranges::viewable_range<urng_t>,
-        "The range parameter to views::translate_join cannot be a temporary of a non-view range.");
+                  "The range parameter to views::translate_join cannot be a temporary of a non-view range.");
     static_assert(std::ranges::viewable_range<std::ranges::range_reference_t<urng_t>>,
-        "The inner range of the range parameter to views::translate_join cannot be a temporary of a non-view range.");
+                  "The inner range of the range parameter to views::translate_join cannot be a temporary of "
+                  "a non-view range.");
     static_assert(std::ranges::sized_range<urng_t>,
-        "The range parameter to views::translate_join must model std::ranges::sized_range.");
+                  "The range parameter to views::translate_join must model std::ranges::sized_range.");
     static_assert(std::ranges::sized_range<std::ranges::range_reference_t<urng_t>>,
-        "The inner range of the range parameter to views::translate_join must model std::ranges::sized_range.");
+                  "The inner range of the range parameter to views::translate_join must model "
+                  "std::ranges::sized_range.");
     static_assert(std::ranges::random_access_range<urng_t>,
-        "The range parameter to views::translate_join must model std::ranges::random_access_range.");
+                  "The range parameter to views::translate_join must model std::ranges::random_access_range.");
     static_assert(std::ranges::random_access_range<std::ranges::range_reference_t<urng_t>>,
-        "The inner range of the range parameter to views::translate_join must model std::ranges::random_access_range.");
+                  "The inner range of the range parameter to views::translate_join must model "
+                  "std::ranges::random_access_range.");
     static_assert(nucleotide_alphabet<std::ranges::range_reference_t<std::ranges::range_reference_t<urng_t>>>,
-        "The range parameter to views::translate_join must be over a range over elements of seqan3::nucleotide_alphabet.");
+                  "The range parameter to views::translate_join must be over a range over elements of "
+                  "seqan3::nucleotide_alphabet.");
 
     /*!\name Constructors, destructor and assignment
      * \{
@@ -291,22 +295,26 @@ struct translate_join_fn
     template <std::ranges::range urng_t>
     constexpr auto operator()(urng_t && urange, translation_frames const tf = translation_frames::SIX_FRAME) const
     {
-        static_assert(dimension_v<urng_t> == 2,
-            "This adaptor only handles range-of-range (two dimensions) as input.");
+        static_assert(range_dimension_v<urng_t> == 2,
+                      "This adaptor only handles range-of-range (two dimensions) as input.");
         static_assert(std::ranges::viewable_range<urng_t>,
-            "The range parameter to views::translate_join cannot be a temporary of a non-view range.");
+                      "The range parameter to views::translate_join cannot be a temporary of a non-view range.");
         static_assert(std::ranges::viewable_range<std::ranges::range_reference_t<urng_t>>,
-            "The inner range of the range parameter to views::translate_join cannot be a temporary of a non-view range.");
+                      "The inner range of the range parameter to views::translate_join cannot be a "
+                      "temporary of a non-view range.");
         static_assert(std::ranges::sized_range<urng_t>,
-            "The range parameter to views::translate_join must model std::ranges::sized_range.");
+                      "The range parameter to views::translate_join must model std::ranges::sized_range.");
         static_assert(std::ranges::sized_range<std::ranges::range_reference_t<urng_t>>,
-            "The inner range of the range parameter to views::translate_join must model std::ranges::sized_range.");
+                      "The inner range of the range parameter to views::translate_join must model "
+                      "std::ranges::sized_range.");
         static_assert(std::ranges::random_access_range<urng_t>,
-            "The range parameter to views::translate_join must model std::ranges::random_access_range.");
+                      "The range parameter to views::translate_join must model std::ranges::random_access_range.");
         static_assert(std::ranges::random_access_range<std::ranges::range_reference_t<urng_t>>,
-            "The inner range of the range parameter to views::translate_join must model std::ranges::random_access_range.");
+                      "The inner range of the range parameter to views::translate_join must model "
+                      "std::ranges::random_access_range.");
         static_assert(nucleotide_alphabet<std::ranges::range_reference_t<std::ranges::range_reference_t<urng_t>>>,
-            "The range parameter to views::translate_join must be over a range over elements of seqan3::nucleotide_alphabet.");
+                      "The range parameter to views::translate_join must be over a range over elements of "
+                      "seqan3::nucleotide_alphabet.");
 
         return detail::view_translate_join{std::forward<urng_t>(urange), tf};
     }

--- a/include/seqan3/search/fm_index/bi_fm_index.hpp
+++ b/include/seqan3/search/fm_index/bi_fm_index.hpp
@@ -121,8 +121,8 @@ private:
     void construct(text_t && text)
     {
         static_assert(std::ranges::bidirectional_range<text_t>, "The text must model bidirectional_range.");
-        static_assert(alphabet_size<innermost_value_type_t<text_t>> <= 256, "The alphabet is too big.");
-        static_assert(std::convertible_to<innermost_value_type_t<text_t>, alphabet_t>,
+        static_assert(alphabet_size<range_innermost_value_t<text_t>> <= 256, "The alphabet is too big.");
+        static_assert(std::convertible_to<range_innermost_value_t<text_t>, alphabet_t>,
                      "The alphabet of the text collection must be convertible to the alphabet of the index.");
         static_assert(range_dimension_v<text_t> == 1, "The input cannot be a text collection.");
 
@@ -145,8 +145,8 @@ private:
         static_assert(std::ranges::bidirectional_range<text_t>, "The text must model bidirectional_range.");
         static_assert(std::ranges::bidirectional_range<std::ranges::range_reference_t<text_t>>,
                       "The elements of the text collection must model bidirectional_range.");
-        static_assert(alphabet_size<innermost_value_type_t<text_t>> <= 256, "The alphabet is too big.");
-        static_assert(std::convertible_to<innermost_value_type_t<text_t>, alphabet_t>,
+        static_assert(alphabet_size<range_innermost_value_t<text_t>> <= 256, "The alphabet is too big.");
+        static_assert(std::convertible_to<range_innermost_value_t<text_t>, alphabet_t>,
                      "The alphabet of the text collection must be convertible to the alphabet of the index.");
         static_assert(range_dimension_v<text_t> == 2, "The input must be a text collection.");
 
@@ -353,7 +353,7 @@ public:
  */
 //! \brief Deduces the dimensions of the text.
 template <std::ranges::range text_t>
-bi_fm_index(text_t &&) -> bi_fm_index<innermost_value_type_t<text_t>, text_layout{range_dimension_v<text_t> != 1}>;
+bi_fm_index(text_t &&) -> bi_fm_index<range_innermost_value_t<text_t>, text_layout{range_dimension_v<text_t> != 1}>;
 //!\}
 
 //!\}

--- a/include/seqan3/search/fm_index/bi_fm_index.hpp
+++ b/include/seqan3/search/fm_index/bi_fm_index.hpp
@@ -124,7 +124,7 @@ private:
         static_assert(alphabet_size<innermost_value_type_t<text_t>> <= 256, "The alphabet is too big.");
         static_assert(std::convertible_to<innermost_value_type_t<text_t>, alphabet_t>,
                      "The alphabet of the text collection must be convertible to the alphabet of the index.");
-        static_assert(dimension_v<text_t> == 1, "The input cannot be a text collection.");
+        static_assert(range_dimension_v<text_t> == 1, "The input cannot be a text collection.");
 
         // text must not be empty
         if (std::ranges::begin(text) == std::ranges::end(text))
@@ -148,7 +148,7 @@ private:
         static_assert(alphabet_size<innermost_value_type_t<text_t>> <= 256, "The alphabet is too big.");
         static_assert(std::convertible_to<innermost_value_type_t<text_t>, alphabet_t>,
                      "The alphabet of the text collection must be convertible to the alphabet of the index.");
-        static_assert(dimension_v<text_t> == 2, "The input must be a text collection.");
+        static_assert(range_dimension_v<text_t> == 2, "The input must be a text collection.");
 
         // text must not be empty
         if (std::ranges::begin(text) == std::ranges::end(text))
@@ -353,7 +353,7 @@ public:
  */
 //! \brief Deduces the dimensions of the text.
 template <std::ranges::range text_t>
-bi_fm_index(text_t &&) -> bi_fm_index<innermost_value_type_t<text_t>, text_layout{dimension_v<text_t> != 1}>;
+bi_fm_index(text_t &&) -> bi_fm_index<innermost_value_type_t<text_t>, text_layout{range_dimension_v<text_t> != 1}>;
 //!\}
 
 //!\}

--- a/include/seqan3/search/fm_index/bi_fm_index_cursor.hpp
+++ b/include/seqan3/search/fm_index/bi_fm_index_cursor.hpp
@@ -527,7 +527,7 @@ public:
     bool extend_right(seq_t && seq) noexcept
     {
         static_assert(std::ranges::forward_range<seq_t>, "The query must model forward_range.");
-        static_assert(std::convertible_to<innermost_value_type_t<seq_t>, index_alphabet_type>,
+        static_assert(std::convertible_to<range_innermost_value_t<seq_t>, index_alphabet_type>,
                       "The alphabet of the sequence must be convertible to the alphabet of the index.");
 
         assert(index != nullptr);
@@ -597,7 +597,7 @@ public:
     bool extend_left(seq_t && seq) noexcept
     {
         static_assert(std::ranges::bidirectional_range<seq_t>, "The query must model bidirectional_range.");
-        static_assert(std::convertible_to<innermost_value_type_t<seq_t>, index_alphabet_type>,
+        static_assert(std::convertible_to<range_innermost_value_t<seq_t>, index_alphabet_type>,
                       "The alphabet of the sequence must be convertible to the alphabet of the index.");
         assert(index != nullptr);
 
@@ -907,7 +907,7 @@ public:
     {
         static_assert(std::ranges::input_range<text_t>, "The text must model input_range.");
         static_assert(range_dimension_v<text_t> == 1, "The input cannot be a text collection.");
-        static_assert(std::same_as<innermost_value_type_t<text_t>, index_alphabet_type>,
+        static_assert(std::same_as<range_innermost_value_t<text_t>, index_alphabet_type>,
                       "The alphabet types of the given text and index differ.");
         assert(index != nullptr);
 
@@ -924,7 +924,7 @@ public:
     {
         static_assert(std::ranges::input_range<text_t>, "The text collection must model input_range.");
         static_assert(range_dimension_v<text_t> == 2, "The input must be a text collection.");
-        static_assert(std::same_as<innermost_value_type_t<text_t>, index_alphabet_type>,
+        static_assert(std::same_as<range_innermost_value_t<text_t>, index_alphabet_type>,
                       "The alphabet types of the given text and index differ.");
         assert(index != nullptr);
 

--- a/include/seqan3/search/fm_index/bi_fm_index_cursor.hpp
+++ b/include/seqan3/search/fm_index/bi_fm_index_cursor.hpp
@@ -906,7 +906,7 @@ public:
     //!\endcond
     {
         static_assert(std::ranges::input_range<text_t>, "The text must model input_range.");
-        static_assert(dimension_v<text_t> == 1, "The input cannot be a text collection.");
+        static_assert(range_dimension_v<text_t> == 1, "The input cannot be a text collection.");
         static_assert(std::same_as<innermost_value_type_t<text_t>, index_alphabet_type>,
                       "The alphabet types of the given text and index differ.");
         assert(index != nullptr);
@@ -923,7 +923,7 @@ public:
     //!\endcond
     {
         static_assert(std::ranges::input_range<text_t>, "The text collection must model input_range.");
-        static_assert(dimension_v<text_t> == 2, "The input must be a text collection.");
+        static_assert(range_dimension_v<text_t> == 2, "The input must be a text collection.");
         static_assert(std::same_as<innermost_value_type_t<text_t>, index_alphabet_type>,
                       "The alphabet types of the given text and index differ.");
         assert(index != nullptr);

--- a/include/seqan3/search/fm_index/fm_index.hpp
+++ b/include/seqan3/search/fm_index/fm_index.hpp
@@ -185,7 +185,7 @@ private:
         static_assert(alphabet_size<innermost_value_type_t<text_t>> <= 256, "The alphabet is too big.");
         static_assert(std::convertible_to<innermost_value_type_t<text_t>, alphabet_t>,
                      "The alphabet of the text collection must be convertible to the alphabet of the index.");
-        static_assert(dimension_v<text_t> == 1, "The input cannot be a text collection.");
+        static_assert(range_dimension_v<text_t> == 1, "The input cannot be a text collection.");
 
         // text must not be empty
         if (std::ranges::empty(text))
@@ -237,7 +237,7 @@ private:
         static_assert(alphabet_size<innermost_value_type_t<text_t>> <= 256, "The alphabet is too big.");
         static_assert(std::convertible_to<innermost_value_type_t<text_t>, alphabet_t>,
                      "The alphabet of the text collection must be convertible to the alphabet of the index.");
-        static_assert(dimension_v<text_t> == 2, "The input must be a text collection.");
+        static_assert(range_dimension_v<text_t> == 2, "The input must be a text collection.");
 
         // text collection must not be empty
         if (std::ranges::begin(text) == std::ranges::end(text))
@@ -520,7 +520,7 @@ public:
  */
 //! \brief Deduces the alphabet and dimensions of the text.
 template <std::ranges::range text_t>
-fm_index(text_t &&) -> fm_index<innermost_value_type_t<text_t>, text_layout{dimension_v<text_t> != 1}>;
+fm_index(text_t &&) -> fm_index<innermost_value_type_t<text_t>, text_layout{range_dimension_v<text_t> != 1}>;
 //!\}
 
 //!\}

--- a/include/seqan3/search/fm_index/fm_index.hpp
+++ b/include/seqan3/search/fm_index/fm_index.hpp
@@ -182,8 +182,8 @@ private:
     void construct(text_t && text)
     {
         static_assert(std::ranges::bidirectional_range<text_t>, "The text must model bidirectional_range.");
-        static_assert(alphabet_size<innermost_value_type_t<text_t>> <= 256, "The alphabet is too big.");
-        static_assert(std::convertible_to<innermost_value_type_t<text_t>, alphabet_t>,
+        static_assert(alphabet_size<range_innermost_value_t<text_t>> <= 256, "The alphabet is too big.");
+        static_assert(std::convertible_to<range_innermost_value_t<text_t>, alphabet_t>,
                      "The alphabet of the text collection must be convertible to the alphabet of the index.");
         static_assert(range_dimension_v<text_t> == 1, "The input cannot be a text collection.");
 
@@ -234,8 +234,8 @@ private:
         static_assert(std::ranges::bidirectional_range<text_t>, "The text collection must model bidirectional_range.");
         static_assert(std::ranges::bidirectional_range<std::ranges::range_reference_t<text_t>>,
                       "The elements of the text collection must model bidirectional_range.");
-        static_assert(alphabet_size<innermost_value_type_t<text_t>> <= 256, "The alphabet is too big.");
-        static_assert(std::convertible_to<innermost_value_type_t<text_t>, alphabet_t>,
+        static_assert(alphabet_size<range_innermost_value_t<text_t>> <= 256, "The alphabet is too big.");
+        static_assert(std::convertible_to<range_innermost_value_t<text_t>, alphabet_t>,
                      "The alphabet of the text collection must be convertible to the alphabet of the index.");
         static_assert(range_dimension_v<text_t> == 2, "The input must be a text collection.");
 
@@ -520,7 +520,7 @@ public:
  */
 //! \brief Deduces the alphabet and dimensions of the text.
 template <std::ranges::range text_t>
-fm_index(text_t &&) -> fm_index<innermost_value_type_t<text_t>, text_layout{range_dimension_v<text_t> != 1}>;
+fm_index(text_t &&) -> fm_index<range_innermost_value_t<text_t>, text_layout{range_dimension_v<text_t> != 1}>;
 //!\}
 
 //!\}

--- a/include/seqan3/search/fm_index/fm_index_cursor.hpp
+++ b/include/seqan3/search/fm_index/fm_index_cursor.hpp
@@ -470,7 +470,7 @@ public:
     //!\endcond
     {
         static_assert(std::ranges::input_range<text_t>, "The text must model input_range.");
-        static_assert(dimension_v<text_t> == 1, "The input cannot be a text collection.");
+        static_assert(range_dimension_v<text_t> == 1, "The input cannot be a text collection.");
         static_assert(std::same_as<innermost_value_type_t<text_t>, index_alphabet_type>,
                       "The alphabet types of the given text and index differ.");
         assert(index != nullptr);
@@ -487,7 +487,7 @@ public:
     //!\endcond
     {
         static_assert(std::ranges::input_range<text_t>, "The text collection must model input_range.");
-        static_assert(dimension_v<text_t> == 2, "The input must be a text collection.");
+        static_assert(range_dimension_v<text_t> == 2, "The input must be a text collection.");
         static_assert(std::same_as<innermost_value_type_t<text_t>, index_alphabet_type>,
                       "The alphabet types of the given text and index differ.");
         assert(index != nullptr);

--- a/include/seqan3/search/fm_index/fm_index_cursor.hpp
+++ b/include/seqan3/search/fm_index/fm_index_cursor.hpp
@@ -321,7 +321,7 @@ public:
     bool extend_right(seq_t && seq) noexcept
     {
         static_assert(std::ranges::forward_range<seq_t>, "The query must model forward_range.");
-        static_assert(std::convertible_to<innermost_value_type_t<seq_t>, index_alphabet_type>,
+        static_assert(std::convertible_to<range_innermost_value_t<seq_t>, index_alphabet_type>,
                      "The alphabet of the sequence must be convertible to the alphabet of the index.");
 
         assert(index != nullptr); // range must not be empty!
@@ -471,7 +471,7 @@ public:
     {
         static_assert(std::ranges::input_range<text_t>, "The text must model input_range.");
         static_assert(range_dimension_v<text_t> == 1, "The input cannot be a text collection.");
-        static_assert(std::same_as<innermost_value_type_t<text_t>, index_alphabet_type>,
+        static_assert(std::same_as<range_innermost_value_t<text_t>, index_alphabet_type>,
                       "The alphabet types of the given text and index differ.");
         assert(index != nullptr);
 
@@ -488,7 +488,7 @@ public:
     {
         static_assert(std::ranges::input_range<text_t>, "The text collection must model input_range.");
         static_assert(range_dimension_v<text_t> == 2, "The input must be a text collection.");
-        static_assert(std::same_as<innermost_value_type_t<text_t>, index_alphabet_type>,
+        static_assert(std::same_as<range_innermost_value_t<text_t>, index_alphabet_type>,
                       "The alphabet types of the given text and index differ.");
         assert(index != nullptr);
 

--- a/include/seqan3/search/search.hpp
+++ b/include/seqan3/search/search.hpp
@@ -187,7 +187,7 @@ struct search_configuration_validator
     static void validate_query_type()
     {
         using pure_query_t = remove_cvref_t<query_t>;
-        if constexpr(dimension_v<pure_query_t> == 1u)
+        if constexpr(range_dimension_v<pure_query_t> == 1u)
         {
             static_assert(std::ranges::random_access_range<pure_query_t>,
                           "The query sequence must model random_access_range.");

--- a/test/performance/search/index_construction_benchmark.cpp
+++ b/test/performance/search/index_construction_benchmark.cpp
@@ -57,7 +57,7 @@ sequence_store_seqan3 store{};
 template <tag index_tag, typename rng_t>
 void index_benchmark_seqan3(benchmark::State & state)
 {
-    using alphabet_t = seqan3::innermost_value_type_t<rng_t>;
+    using alphabet_t = seqan3::range_innermost_value_t<rng_t>;
     using inner_rng_t = std::conditional_t<seqan3::range_dimension_v<rng_t> == 1, rng_t, std::ranges::range_value_t<rng_t>>;
 
     rng_t sequence;

--- a/test/performance/search/index_construction_benchmark.cpp
+++ b/test/performance/search/index_construction_benchmark.cpp
@@ -58,7 +58,7 @@ template <tag index_tag, typename rng_t>
 void index_benchmark_seqan3(benchmark::State & state)
 {
     using alphabet_t = seqan3::innermost_value_type_t<rng_t>;
-    using inner_rng_t = std::conditional_t<seqan3::dimension_v<rng_t> == 1, rng_t, std::ranges::range_value_t<rng_t>>;
+    using inner_rng_t = std::conditional_t<seqan3::range_dimension_v<rng_t> == 1, rng_t, std::ranges::range_value_t<rng_t>>;
 
     rng_t sequence;
     inner_rng_t inner_sequence;
@@ -69,7 +69,7 @@ void index_benchmark_seqan3(benchmark::State & state)
     else
         inner_sequence = store.char_rng | seqan3::views::take(state.range(0)) | seqan3::views::to<inner_rng_t>;
 
-    if constexpr (seqan3::dimension_v<rng_t> == 1)
+    if constexpr (seqan3::range_dimension_v<rng_t> == 1)
     {
         sequence = std::move(inner_sequence);
     }
@@ -103,7 +103,7 @@ struct sequence_store_seqan2
 
 sequence_store_seqan2 store2{};
 
-// Since the seqan2 alphabet has a value type, the dimension is actually one less than seqan3::dimension_v reports.
+// Since the seqan2 alphabet has a value type, the dimension is actually one less than seqan3::range_dimension_v reports.
 template <typename rng_t>
 constexpr size_t seqan_dimension_v()
 {

--- a/test/snippet/core/type_traits/range.cpp
+++ b/test/snippet/core/type_traits/range.cpp
@@ -3,6 +3,6 @@
 int main()
 {
     // these evaluate to true:
-    static_assert(seqan3::compatible<std::string,              std::vector<char>>);
-    static_assert(seqan3::compatible<std::vector<std::string>, std::vector<std::vector<char>>>);
+    static_assert(seqan3::range_compatible<std::string,              std::vector<char>>);
+    static_assert(seqan3::range_compatible<std::vector<std::string>, std::vector<std::vector<char>>>);
 }

--- a/test/unit/core/type_traits/range_iterator_test.cpp
+++ b/test/unit/core/type_traits/range_iterator_test.cpp
@@ -227,20 +227,21 @@ TEST(range_and_iterator, dimension)
     EXPECT_EQ(2u, seqan3::range_dimension_v<std::vector<std::vector<int>>>);
 }
 
-TEST(range_and_iterator, compatible)
+TEST(range_and_iterator, range_compatible)
 {
     // true for "compatible" ranges
-    EXPECT_TRUE((seqan3::compatible<std::vector<int>, std::list<int>>));
-    EXPECT_TRUE((seqan3::compatible<std::list<std::vector<char>>, std::vector<std::string>>));
+    EXPECT_TRUE((seqan3::range_compatible<std::vector<int>, std::list<int>>));
+    EXPECT_TRUE((seqan3::range_compatible<std::list<std::vector<char>>, std::vector<std::string>>));
 
     // false for un-"compatible" ranges
-    EXPECT_FALSE((seqan3::compatible<std::list<std::vector<char>>, std::string>));
-    EXPECT_FALSE((seqan3::compatible<std::list<int>, int>));
-    EXPECT_FALSE((seqan3::compatible<std::vector<int>, std::string>));
+    EXPECT_FALSE((seqan3::range_compatible<std::list<std::vector<char>>, std::string>));
+    EXPECT_FALSE((seqan3::range_compatible<std::list<int>, int>));
+    EXPECT_FALSE((seqan3::range_compatible<std::vector<int>, std::string>));
 
     // compatible not defined on iterators
-    EXPECT_FALSE((seqan3::compatible<std::vector<int>, std::ranges::iterator_t<std::vector<int>>>));
-    EXPECT_FALSE((seqan3::compatible<std::vector<int>, std::ranges::iterator_t<std::vector<int> const>>));
-    EXPECT_FALSE((seqan3::compatible<std::list<std::vector<char>>, std::ranges::iterator_t<std::vector<std::string>>>));
-    EXPECT_FALSE((seqan3::compatible<std::list<std::vector<char>>, std::ranges::iterator_t<std::string>>));
+    EXPECT_FALSE((seqan3::range_compatible<std::vector<int>, std::ranges::iterator_t<std::vector<int>>>));
+    EXPECT_FALSE((seqan3::range_compatible<std::vector<int>, std::ranges::iterator_t<std::vector<int> const>>));
+    EXPECT_FALSE((seqan3::range_compatible<std::list<std::vector<char>>,
+                                           std::ranges::iterator_t<std::vector<std::string>>>));
+    EXPECT_FALSE((seqan3::range_compatible<std::list<std::vector<char>>, std::ranges::iterator_t<std::string>>));
 }

--- a/test/unit/core/type_traits/range_iterator_test.cpp
+++ b/test/unit/core/type_traits/range_iterator_test.cpp
@@ -205,12 +205,12 @@ TEST(range_and_iterator, size_type_)
     expect_same_types<type_list_example, comp_list>();
 }
 
-TEST(range_and_iterator, innermost_value_type_)
+TEST(range_and_iterator, range_innermost_value)
 {
     using vector_of_int_vector = std::vector<std::vector<int>>;
     using type_list_example = seqan3::type_list<typename seqan3::range_innermost_value<std::vector<int>>::type, // long
-                                                seqan3::innermost_value_type_t<std::vector<int>>, // short
-                                                seqan3::innermost_value_type_t<vector_of_int_vector>>; // two-level
+                                                seqan3::range_innermost_value_t<std::vector<int>>, // short
+                                                seqan3::range_innermost_value_t<vector_of_int_vector>>; // two-level
 
     using comp_list = seqan3::type_list<int,
                                         int,

--- a/test/unit/core/type_traits/range_iterator_test.cpp
+++ b/test/unit/core/type_traits/range_iterator_test.cpp
@@ -208,7 +208,7 @@ TEST(range_and_iterator, size_type_)
 TEST(range_and_iterator, innermost_value_type_)
 {
     using vector_of_int_vector = std::vector<std::vector<int>>;
-    using type_list_example = seqan3::type_list<typename seqan3::innermost_value_type<std::vector<int>>::type, // long
+    using type_list_example = seqan3::type_list<typename seqan3::range_innermost_value<std::vector<int>>::type, // long
                                                 seqan3::innermost_value_type_t<std::vector<int>>, // short
                                                 seqan3::innermost_value_type_t<vector_of_int_vector>>; // two-level
 

--- a/test/unit/core/type_traits/range_iterator_test.cpp
+++ b/test/unit/core/type_traits/range_iterator_test.cpp
@@ -223,8 +223,8 @@ TEST(range_and_iterator, innermost_value_type_)
 
 TEST(range_and_iterator, dimension)
 {
-    EXPECT_EQ(1u, seqan3::dimension_v<std::vector<int>>);
-    EXPECT_EQ(2u, seqan3::dimension_v<std::vector<std::vector<int>>>);
+    EXPECT_EQ(1u, seqan3::range_dimension_v<std::vector<int>>);
+    EXPECT_EQ(2u, seqan3::range_dimension_v<std::vector<std::vector<int>>>);
 }
 
 TEST(range_and_iterator, compatible)


### PR DESCRIPTION
This PR fixes https://github.com/seqan/product_backlog/issues/86. 
It renames: 
`constexpr size_t dimension_v = 1;`
to
`constexpr size_t range_dimension_v = 1;`
 
`struct innermost_value_type`
to 
`struct range_innermost_value`
 
`using innermost_value_type_t = typename innermost_value_type<t>::type;`
to
`using range_innermost_value_t = typename range_innermost_value<t>::type;`
 
`concept compatible`
to
`concept range_compatible`