### PR TITLE
[INFRA] don't override CMAKE_CXX_COMPILER_LAUNCHER

### DIFF
--- a/test/seqan3-test.cmake
+++ b/test/seqan3-test.cmake
@@ -158,7 +158,12 @@ macro (seqan3_require_ccache)
         find_package_message (CCACHE_PROGRAM "Finding program ccache - Success" "[${CCACHE_PROGRAM}]")
         # New option since cmake >= 3.4:
         # https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER_LAUNCHER.html
-        set (CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+        if (NOT CMAKE_VERSION VERSION_LESS 3.15) # cmake >= 3.15
+            list (PREPEND CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+        else ()
+            # prepend ccache to CMAKE_CXX_COMPILER_LAUNCHER
+            list (INSERT CMAKE_CXX_COMPILER_LAUNCHER 0 "${CCACHE_PROGRAM}")
+        endif ()
 
         # use ccache in external cmake projects
         list (APPEND SEQAN3_EXTERNAL_PROJECT_CMAKE_ARGS "-DCMAKE_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER}")


### PR DESCRIPTION
We override CMAKE_CXX_COMPILER_LAUNCHER in our tests. This is bad if you want to use different `COMPILER_LAUNCHER` such as [distcc](https://github.com/distcc/distcc).