### PR TITLE
[FIX] cxx20: std::is_pod_v<int> is deprecated

### DIFF
--- a/include/seqan3/core/pod_tuple.hpp
+++ b/include/seqan3/core/pod_tuple.hpp
@@ -54,7 +54,7 @@ struct pod_tuple
 template <typename type0, typename ...types>
 struct pod_tuple<type0, types...>
 {
-    static_assert(std::is_pod_v<type0>, SEQAN_NOT_POD);
+    static_assert(std::is_standard_layout_v<type0> && std::is_trivial_v<type0>, SEQAN_NOT_POD);
     //!\cond DEV
     //!\brief The first element as member.
     type0 _head;
@@ -111,7 +111,7 @@ struct pod_tuple<type0, types...>
 template <typename type0>
 struct pod_tuple<type0>
 {
-    static_assert(std::is_pod_v<type0>, SEQAN_NOT_POD);
+    static_assert(std::is_standard_layout_v<type0> && std::is_trivial_v<type0>, SEQAN_NOT_POD);
     //!\cond DEV
     //!\brief The first element as member.
     type0 _head;

--- a/test/snippet/core/pod_tuple.cpp
+++ b/test/snippet/core/pod_tuple.cpp
@@ -4,7 +4,8 @@
 int main()
 {
     seqan3::pod_tuple<int, float> t{3, 4.7};
-    static_assert(std::is_pod_v<seqan3::pod_tuple<int, float>>);
+    static_assert(std::is_standard_layout_v<seqan3::pod_tuple<int, float>>);
+    static_assert(std::is_trivial_v<seqan3::pod_tuple<int, float>>);
 
     // template parameters are automatically deduced:
     seqan3::pod_tuple t2{17, 3.7f, 19l};


### PR DESCRIPTION
```c++
seqan3/include/seqan3/core/pod_tuple.hpp:57:24: error: ‘std::is_pod_v<int>’ is deprecated: use is_standard_layout_v && is_trivial_v instead [-Werror=deprecated-declarations]
   57 |     static_assert(std::is_pod_v<type0>, SEQAN_NOT_POD);
      |                   ~~~~~^~~~~~~~~~~~~~~
```