### PR TITLE
[FEATURE] Add comparability skill to strong type.

### DIFF
--- a/include/seqan3/core/detail/strong_type.hpp
+++ b/include/seqan3/core/detail/strong_type.hpp
@@ -391,7 +391,7 @@ public:
     }
     //!\}
 
-    /*!\name Comparison operators.
+    /*!\name Comparison operators
      * \brief Only available if the corresponding skill from seqan3::detail::strong_type_skill is added.
      *
      * \if DEV
@@ -399,22 +399,22 @@ public:
      * \endif
      * \{
      */
-    //!\brief Return whether this instance is equal to `other`.
+    //!\brief Return whether this instance is equal to `rhs`.
     constexpr bool operator==(strong_type const & other) const
     //!\cond
         requires ((skills & strong_type_skill::comparable) != strong_type_skill::none)
     //!\endcond
     {
-        return get() == other.get();
+        return get() == rhs.get();
     }
 
-    //!\brief Return whether this instance is not equal to `other`.
-    constexpr bool operator!=(strong_type const & other) const
+    //!\brief Return whether this instance is not equal to `rhs`.
+    constexpr bool operator!=(strong_type const & rhs) const
     //!\cond
         requires ((skills & strong_type_skill::comparable) != strong_type_skill::none)
     //!\endcond
     {
-        return !(*this == other);
+        return !(*this == rhs);
     }
     //!\}
 

--- a/include/seqan3/core/detail/strong_type.hpp
+++ b/include/seqan3/core/detail/strong_type.hpp
@@ -400,7 +400,7 @@ public:
      * \{
      */
     //!\brief Return whether this instance is equal to `rhs`.
-    constexpr bool operator==(strong_type const & other) const
+    constexpr bool operator==(strong_type const & rhs) const
     //!\cond
         requires ((skills & strong_type_skill::comparable) != strong_type_skill::none)
     //!\endcond

--- a/include/seqan3/core/detail/strong_type.hpp
+++ b/include/seqan3/core/detail/strong_type.hpp
@@ -44,6 +44,7 @@ enum struct strong_type_skill
     increment      = 1 << 14,
     decrement      = 1 << 15,
     convert        = 1 << 16,
+    comparable     = 1 << 17,
     additive       = add | subtract,
     multiplicative = multiply | divide | modulo,
     bitwise_logic  = bitwise_and | bitwise_or | bitwise_xor | bitwise_not,
@@ -387,6 +388,33 @@ public:
         derived_t tmp{get()};
         --get();
         return tmp;
+    }
+    //!\}
+
+    /*!\name Comparison operators.
+     * \brief Only available if the corresponding skill from seqan3::detail::strong_type_skill is added.
+     *
+     * \if DEV
+     * Implemented as member functions because requires does not work on friends.
+     * \endif
+     * \{
+     */
+    //!\brief Return whether this instance is equal to `other`.
+    constexpr bool operator==(strong_type const & other) const
+    //!\cond
+        requires ((skills & strong_type_skill::comparable) != strong_type_skill::none)
+    //!\endcond
+    {
+        return get() == other.get();
+    }
+
+    //!\brief Return whether this instance is not equal to `other`.
+    constexpr bool operator!=(strong_type const & other) const
+    //!\cond
+        requires ((skills & strong_type_skill::comparable) != strong_type_skill::none)
+    //!\endcond
+    {
+        return !(*this == other);
     }
     //!\}
 

--- a/test/unit/core/detail/strong_type_test.cpp
+++ b/test/unit/core/detail/strong_type_test.cpp
@@ -81,6 +81,11 @@ struct convertible_type : seqan3::detail::strong_type<int, convertible_type, seq
     using seqan3::detail::strong_type<int, convertible_type, seqan3::detail::strong_type_skill::convert>::strong_type;
 };
 
+struct comp_type : seqan3::detail::strong_type<int, comp_type, seqan3::detail::strong_type_skill::comparable>
+{
+    using seqan3::detail::strong_type<int, comp_type, seqan3::detail::strong_type_skill::comparable>::strong_type;
+};
+
 struct multi_skill_type : seqan3::detail::strong_type<int,
                                                       multi_skill_type,
                                                       seqan3::detail::strong_type_skill::additive  |
@@ -256,6 +261,17 @@ TEST(strong_type, convertible_type)
     convertible_type f1{1};
     int v{f1};
     EXPECT_EQ(v, f1.get());
+}
+
+TEST(strong_type, comparable_type)
+{
+    comp_type f1{1};
+    comp_type f2{1};
+    comp_type f3{42};
+
+    EXPECT_EQ(f1, f2);
+    EXPECT_NE(f1, f3);
+    EXPECT_NE(f2, f3);
 }
 
 TEST(strong_type, multi_skill_type)


### PR DESCRIPTION
This comes in very handy in a lot of cases.
E.g. consider 
```cpp
    using t = std::variant<my_strong_type1, my_strong_type2>;
    t v1{my_strong_type1{2}};
    t v2{my_strong_type1{3}};
```
you can neither do 
```cpp
    v1 == v2 // error, no comparison operator for my_strong_type1
```
nor
```cpp
    v1.get() == v2.get() // error, variant has no member get
```
You would need some nested std::visit for the two variants which is ugly.
