### PR TITLE
Search config/main dynamic hit config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ Note that 3.1.0 will be the first API stable release and interfaces in this rele
 
 * Added `seqan3::interleaved_bloom_filter`, a data structure that efficiently answers set-membership queries for
   multiple bins ([\#920](https://github.com/seqan/seqan3/pull/920)).
+* Added `seqan3::search_cfg::hit`, which allows dynamic configuration of the hit strategy.
+  ([\#1853](https://github.com/seqan/seqan3/pull/1853)).
 
 ## API changes
 

--- a/doc/tutorial/search/index.md
+++ b/doc/tutorial/search/index.md
@@ -229,6 +229,8 @@ Besides the error configuration, you can define which hits should be reported:
 Any hit configuration element is appended to the error configuration by using the `|`-operator:
 \snippet doc/tutorial/search/search_small_snippets.cpp hit_best
 
+If you want to choose the hit strategy at runtime you can also use the dynamic configuration `seqan3::search_cfg::hit`.
+
 The `seqan3::search_cfg::strata` configuration element needs an additional parameter:
 \snippet doc/tutorial/search/search_small_snippets.cpp hit_strata
 

--- a/include/seqan3/core/platform.hpp
+++ b/include/seqan3/core/platform.hpp
@@ -221,6 +221,15 @@
 #   endif
 #endif
 
+//!\brief See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=93467
+#ifndef SEQAN3_WORKAROUND_GCC_93467
+#   if defined(__GNUC__) && ((__GNUC__ == 7) || (__GNUC__ == 8) || (__GNUC__ == 9) || (__GNUC__ == 10))
+#       define SEQAN3_WORKAROUND_GCC_93467 1
+#   else
+#       define SEQAN3_WORKAROUND_GCC_93467 0
+#   endif
+#endif
+
 // ============================================================================
 //  Backmatter
 // ============================================================================

--- a/include/seqan3/search/configuration/all.hpp
+++ b/include/seqan3/search/configuration/all.hpp
@@ -74,10 +74,25 @@
  * | seqan3::search_cfg::hit_all         | Report all hits within error bounds.                                |
  * | seqan3::search_cfg::hit_all_best    | Report all hits with the lowest number of errors within the bounds. |
  * | seqan3::search_cfg::hit_single_best | Report one best hit (hit with lowest error) within bounds.          |
- * | seqan3::search_cfg::hit_strata      | Report all hits within best + `stratum` errors.                             |
+ * | seqan3::search_cfg::hit_strata      | Report all hits within best + `stratum` errors.                     |
  *
  * The individual configuration elements to select a search strategy cannot be combined with each other
  * (mutual exclusivity).
  *
  * \include test/snippet/search/hit_configuration_examples.cpp
+ *
+ * ### Dynamic hit configuration
+ *
+ * Sometimes a program needs to support different hit strategies based on some user input. Since these are mostly
+ * runtime decisisons the code can become quite cumbersome to handle the static hit configurations.
+ * Instead, one can use the dynamic hit configuration element seqan3::search::cfg::hit.
+ * This configuration element allows to set one of the above mentioned hit configurations at runtime. Later during the
+ * configuration phase of the search algorithm the selected search configuration is used for the final search algorithm.
+ * If the dynamic hit configuration is default constructed it does not hold any hit configuration. If you call search
+ * with the dynamic configuration in this state an exception will be thrown.
+ * Also note that using the dynamic configuration might have implications on the compile time, so we recommend to use
+ * the static configurations if only a single hit strategy is supported.
+ * The following example demonstrates the usage of the dynamic configuration:
+ *
+ * \include test/snippet/search/dynamic_hit_configuration_example.cpp
  */

--- a/include/seqan3/search/configuration/all.hpp
+++ b/include/seqan3/search/configuration/all.hpp
@@ -20,6 +20,7 @@
 #include <seqan3/search/configuration/hit.hpp>
 #include <seqan3/search/configuration/output.hpp>
 #include <seqan3/search/configuration/parallel.hpp>
+#include <seqan3/search/configuration/result_type.hpp>
 
 /*!\namespace seqan3::search_cfg
  * \brief A special sub namespace for the search configurations.

--- a/include/seqan3/search/configuration/detail.hpp
+++ b/include/seqan3/search/configuration/detail.hpp
@@ -44,6 +44,7 @@ enum struct search_config_id : uint8_t
     output, //!< Identifier for the output configuration.
     hit, //!< Identifier for the hit configuration (all, all_best, single_best, strata).
     parallel, //!< Identifier for the parallel execution configuration.
+    result_type, //!< Identifier for the configured search result type.
     //!\cond
     // ATTENTION: Must always be the last item; will be used to determine the number of ids.
     SIZE //!< Determines the size of the enum.
@@ -69,12 +70,13 @@ inline constexpr std::array<std::array<bool, static_cast<uint8_t>(search_config_
                             static_cast<uint8_t>(search_config_id::SIZE)> compatibility_table<search_config_id> =
 {
     {
-        // max_error, max_error_rate, output, hit, parallel
-        { 0, 0, 1, 1, 1},
-        { 0, 0, 1, 1, 1},
-        { 1, 1, 0, 1, 1},
-        { 1, 1, 1, 0, 1},
-        { 1, 1, 1, 1, 0}
+        // max_error, max_error_rate, output, hit, parallel, result_type
+        { 0, 0, 1, 1, 1, 1},
+        { 0, 0, 1, 1, 1, 1},
+        { 1, 1, 0, 1, 1, 1},
+        { 1, 1, 1, 0, 1, 1},
+        { 1, 1, 1, 1, 0, 1},
+        { 1, 1, 1, 1, 1, 0}
     }
 };
 

--- a/include/seqan3/search/configuration/max_error_rate.hpp
+++ b/include/seqan3/search/configuration/max_error_rate.hpp
@@ -18,6 +18,7 @@
 #include <seqan3/core/algorithm/configuration.hpp>
 #include <seqan3/core/algorithm/pipeable_config_element.hpp>
 #include <seqan3/core/detail/pack_algorithm.hpp>
+#include <seqan3/core/type_traits/template_inspection.hpp>
 #include <seqan3/range/views/slice.hpp>
 #include <seqan3/search/configuration/detail.hpp>
 #include <seqan3/search/configuration/max_error_common.hpp>
@@ -38,10 +39,10 @@ namespace seqan3::search_cfg
 template <typename ...errors_t>
 //!\cond
     requires (sizeof...(errors_t) <= 4) &&
-             ((detail::is_type_specialisation_of_v<std::remove_reference_t<errors_t>, total> ||
-               detail::is_type_specialisation_of_v<std::remove_reference_t<errors_t>, substitution> ||
-               detail::is_type_specialisation_of_v<std::remove_reference_t<errors_t>, deletion>  ||
-               detail::is_type_specialisation_of_v<std::remove_reference_t<errors_t>, insertion>) && ...)
+             ((seqan3::detail::is_type_specialisation_of_v<std::remove_reference_t<errors_t>, total> ||
+               seqan3::detail::is_type_specialisation_of_v<std::remove_reference_t<errors_t>, substitution> ||
+               seqan3::detail::is_type_specialisation_of_v<std::remove_reference_t<errors_t>, deletion>  ||
+               seqan3::detail::is_type_specialisation_of_v<std::remove_reference_t<errors_t>, insertion>) && ...)
 //!\endcond
 class max_error_rate : public pipeable_config_element<max_error_rate<errors_t...>, std::array<double, 4>>
 {
@@ -77,7 +78,7 @@ public:
 
     //!\privatesection
     //!\brief Internal id to check for consistent configuration settings.
-    static constexpr detail::search_config_id id{detail::search_config_id::max_error_rate};
+    static constexpr seqan3::detail::search_config_id id{seqan3::detail::search_config_id::max_error_rate};
 
     //!\publicsection
     /*!\name Constructor, destructor and assignment
@@ -94,8 +95,6 @@ public:
     /*!\brief Constructs the object from a set of error specifiers.
      * \tparam    errors_t A template parameter pack with the error types.
      * \param[in] errors   A pack of error specifiers.
-     *
-     * \details
      *
      * \details
      *
@@ -121,13 +120,13 @@ public:
     //!\endcond
         : base_t{}
     {
-        detail::for_each([this](auto e)
+        seqan3::detail::for_each([this] (auto e)
         {
             base_t::value[remove_cvref_t<decltype(e)>::_id()] = e.get();
         }, std::forward<errors_t>(errors)...);
 
         // check correct values.
-        std::ranges::for_each(base_t::value, [](auto error_elem)
+        std::ranges::for_each(base_t::value, [] (auto error_elem)
         {
             if (0.0 > error_elem  || error_elem > 1.0)
                 throw std::invalid_argument("Error rates must be between 0 and 1.");

--- a/include/seqan3/search/configuration/output.hpp
+++ b/include/seqan3/search/configuration/output.hpp
@@ -36,10 +36,10 @@ namespace seqan3::search_cfg
 
 //!\brief Configuration element to receive all hits within the error bounds.
 //!\ingroup search_configuration
-inline detail::search_output_index_cursor constexpr index_cursor;
+inline seqan3::detail::search_output_index_cursor constexpr index_cursor;
 //!\brief Configuration element to receive all hits within the lowest number of errors.
 //!\ingroup search_configuration
-inline detail::search_output_text_position constexpr text_position;
+inline seqan3::detail::search_output_text_position constexpr text_position;
 
 /*!\brief Configuration element to determine the output type of hits.
  * \ingroup search_configuration
@@ -53,14 +53,14 @@ inline detail::search_output_text_position constexpr text_position;
  */
 template <typename output_t>
 //!\cond
-    requires std::same_as<remove_cvref_t<output_t>, detail::search_output_text_position> ||
-             std::same_as<remove_cvref_t<output_t>, detail::search_output_index_cursor>
+    requires std::same_as<remove_cvref_t<output_t>, seqan3::detail::search_output_text_position> ||
+             std::same_as<remove_cvref_t<output_t>, seqan3::detail::search_output_index_cursor>
 //!\endcond
 struct output : public pipeable_config_element<output<output_t>, output_t>
 {
     //!\privatesection
     //!\brief Internal id to check for consistent configuration settings.
-    static constexpr detail::search_config_id id{detail::search_config_id::output};
+    static constexpr seqan3::detail::search_config_id id{seqan3::detail::search_config_id::output};
 };
 
 /*!\name Type deduction guides

--- a/include/seqan3/search/configuration/result_type.hpp
+++ b/include/seqan3/search/configuration/result_type.hpp
@@ -1,0 +1,71 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides seqan3::search_cfg::detail::result_type.
+ * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <seqan3/std/type_traits>
+
+#include <seqan3/core/algorithm/pipeable_config_element.hpp>
+#include <seqan3/core/type_traits/template_inspection.hpp>
+#include <seqan3/search/configuration/detail.hpp>
+#include <seqan3/search/search_result.hpp>
+
+namespace seqan3::search_cfg::detail
+{
+
+/*!\brief The configuration element storing the configured search result type.
+ * \ingroup search_configuration
+ *
+ * \tparam search_result_t The type of the search result to capture; must be a type specialisation of
+ *                         seqan3::search_result.
+ *
+ * \details
+ *
+ * Implementation of the search result type configuration element.
+ *
+ * \see seqan3::search_cfg::result_type
+ */
+template <typename search_result_t>
+//!\cond
+    requires seqan3::detail::is_type_specialisation_of_v<search_result_t, search_result>
+//!\endcond
+struct result_type_tag : public pipeable_config_element<result_type_tag<search_result_t>, seqan3::detail::empty_type>
+{
+    //!\brief The configured seqan3::search_result type.
+    using type = search_result_t;
+
+    //!\brief Internal id to check for consistent configuration settings.
+    static constexpr seqan3::detail::search_config_id id{seqan3::detail::search_config_id::result_type};
+};
+
+/*!\brief Configuration element storing the configured seqan3::search_result for the search algorithm.
+ * \ingroup search_configuration
+ * \tparam search_result_t The search result type to store; must be a type specialisation of seqan3::search_result.
+ *
+ * \details
+ *
+ * This configuration element stores the seqan3::search_result type after configuring the
+ * search algorithm with the seqan3::detail::search_configurator.
+ * The result type can be accessed via the seqan3::detail::search_traits over the corresponding
+ * search configuration type.
+ * If the stored search result was not added yet to the search configuration the corresponding
+ * result type member will deduce to seqan3::detail::empty_type.
+ *
+ * \note This configuration element is only added internally during the search configuration and is not intended for
+ *       public use.
+ */
+template <typename search_result_t>
+//!\cond
+    requires seqan3::detail::is_type_specialisation_of_v<search_result_t, search_result>
+//!\endcond
+inline constexpr detail::result_type_tag<search_result_t> result_type{};
+}  // namespace seqan3::search_cfg::detail

--- a/include/seqan3/search/detail/policy_max_error.hpp
+++ b/include/seqan3/search/detail/policy_max_error.hpp
@@ -27,12 +27,12 @@ struct policy_max_error
 protected:
     /*!\brief Returns a detail::search_param object filled by the information from the configuration.
      * \tparam configuration_t The search configuration type.
-     * \tparam query_t Must model std::ranges::foward_range over the index's alphabet.
+     * \tparam query_t Must model std::ranges::forward_range over the index's alphabet.
      * \param[in] cfg The configuration object.
      * \param[in] query The current query sequence.
      *
      * \details
-     * 
+     *
      * If seqan3::max_error is set in the configuration, its value already is of type detail::search_param and
      * can be returned as is.
      * If seqan3::max_error_rate is set in the configuration, the error rates are converted to error counts

--- a/include/seqan3/search/detail/policy_search_result_builder.hpp
+++ b/include/seqan3/search/detail/policy_search_result_builder.hpp
@@ -7,7 +7,7 @@
 
 /*!\file
  * \author Svenja Mehringer <svenja.mehringer AT fu-berlin.de>
- * \brief Provides the seqan3::detail::policy_result_builder.
+ * \brief Provides the seqan3::detail::policy_search_result_builder.
  */
 
 #pragma once
@@ -21,7 +21,7 @@ namespace seqan3::detail
 
 //!\brief Provides the function `make_results` if inherited by a search algorithm.
 //!\ingroup search
-struct policy_result_builder
+struct policy_search_result_builder
 {
 protected:
     /*!\brief Returns all hits (index cursors) without calling locate on each cursor.

--- a/include/seqan3/search/detail/search_configurator.hpp
+++ b/include/seqan3/search/detail/search_configurator.hpp
@@ -1,0 +1,125 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides seqan3::detail::search_configurator.
+ * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <seqan3/search/detail/policy_max_error.hpp>
+#include <seqan3/search/detail/policy_result_builder.hpp>
+#include <seqan3/search/detail/search_scheme_algorithm.hpp>
+#include <seqan3/search/detail/unidirectional_search_algorithm.hpp>
+
+namespace seqan3::detail
+{
+
+/*!\brief Class used to update the search configuration, e.g. add defaults.
+ * \ingroup search
+ */
+class search_configurator
+{
+public:
+    /*!\brief Add seqan3::search_cfg::hit_all to the configuration if no search strategy (hit configuration) was chosen.
+     * \tparam configuration_t The type of the search configuration.
+     * \param[in] cfg The configuration to be modified if necessary.
+     * \returns The configuration which is guaranteed to have a hit configuration element available.
+     *
+     * \details
+     *
+     * If no \ref search_configuration_subsection_hit_strategy "hit configuration" was set,
+     * it defaults to seqan3::search_cfg::hit_all.
+     */
+    template <typename configuration_t>
+    static auto add_default_hit_configuration(configuration_t const & cfg)
+    {
+        if constexpr (!detail::search_traits<configuration_t>::has_hit_configuration)
+            return cfg | search_cfg::hit_all;
+        else
+            return cfg;
+    }
+
+    /*!\brief Add seqan3::search_cfg::text_position to the configuration if seqan3::search_cfg::output was not set.
+     * \tparam configuration_t The type of the search configuration.
+     * \param[in] cfg The configuration to be modified if necessary.
+     * \returns The configuration which is guaranteed to have a seqan3::search_cfg::output available.
+     *
+     * \details
+     *
+     * If seqan3::search_cfg::output was not set, it defaults to seqan3::search_cfg::text_position.
+     */
+    template <typename configuration_t>
+    static auto add_default_output_configuration(configuration_t const & cfg)
+    {
+        if constexpr (!detail::search_traits<configuration_t>::has_output_configuration)
+            return cfg | search_cfg::output{search_cfg::text_position};
+        else
+            return cfg;
+    }
+
+    /*!\brief Adds default configurations if they were not set by the user.
+     * \tparam configuration_t The type of the search configuration.
+     * \param[in] cfg The configuration to be modified.
+     * \returns The modified configuration.
+     *
+     * \details
+     *
+     * Modifies the configuration object by adding default configuration elements.
+     *
+     * \sa seqan3::details::search_configurator::add_default_hit_configuration
+     * \sa seqan3::details::search_configurator::add_default_output_configuration
+     */
+    template <typename configuration_t>
+    static auto add_defaults(configuration_t const & cfg)
+    {
+        static_assert(detail::is_type_specialisation_of_v<configuration_t, configuration>,
+                      "cfg must be a specialisation of seqan3::configuration.");
+
+        auto cfg1 = add_default_hit_configuration(cfg);
+        auto cfg2 = add_default_output_configuration(cfg1);
+
+        return cfg2;
+    }
+
+    /*!\brief Chooses the appropriate search algorithm depending on the index.
+     * \tparam configuration_t The type of the search configuration.
+     * \tparam index_t The type of the index.
+     * \param[in] cfg The search configuration object that is passed to the algorithm.
+     * \param[in] index The index that is passed to the algorithm.
+     * \returns A search algorithm.
+     *
+     * \details
+     *
+     * If the `index_t` models seqan3::bi_fm_index_specialisation, then the
+     * seqan3::detail::search_scheme_algorithm is chosen. Otherwise, the
+     * seqan3::detail::unidirectional_search_algorithm is chosen.
+     */
+    template <typename configuration_t, typename index_t>
+    static auto configure_algorithm(configuration_t const & cfg, index_t const & index)
+    {
+        if constexpr (bi_fm_index_specialisation<index_t>)
+        {
+            using algorithm_t = search_scheme_algorithm<configuration_t,
+                                                        index_t,
+                                                        policy_max_error,
+                                                        policy_result_builder>;
+            return algorithm_t{cfg, index};
+        }
+        else
+        {
+            using algorithm_t = unidirectional_search_algorithm<configuration_t,
+                                                                index_t,
+                                                                policy_max_error,
+                                                                policy_result_builder>;
+            return algorithm_t{cfg, index};
+        }
+    }
+};
+
+} // namespace seqan3::detail

--- a/include/seqan3/search/detail/search_configurator.hpp
+++ b/include/seqan3/search/detail/search_configurator.hpp
@@ -108,7 +108,7 @@ public:
             using algorithm_t = search_scheme_algorithm<configuration_t,
                                                         index_t,
                                                         policy_max_error,
-                                                        policy_search_result_builder>;
+                                                        policy_search_result_builder<configuration_t>>;
             return algorithm_t{cfg, index};
         }
         else
@@ -116,7 +116,7 @@ public:
             using algorithm_t = unidirectional_search_algorithm<configuration_t,
                                                                 index_t,
                                                                 policy_max_error,
-                                                                policy_search_result_builder>;
+                                                                policy_search_result_builder<configuration_t>>;
             return algorithm_t{cfg, index};
         }
     }

--- a/include/seqan3/search/detail/search_configurator.hpp
+++ b/include/seqan3/search/detail/search_configurator.hpp
@@ -13,7 +13,7 @@
 #pragma once
 
 #include <seqan3/search/detail/policy_max_error.hpp>
-#include <seqan3/search/detail/policy_result_builder.hpp>
+#include <seqan3/search/detail/policy_search_result_builder.hpp>
 #include <seqan3/search/detail/search_scheme_algorithm.hpp>
 #include <seqan3/search/detail/unidirectional_search_algorithm.hpp>
 
@@ -108,7 +108,7 @@ public:
             using algorithm_t = search_scheme_algorithm<configuration_t,
                                                         index_t,
                                                         policy_max_error,
-                                                        policy_result_builder>;
+                                                        policy_search_result_builder>;
             return algorithm_t{cfg, index};
         }
         else
@@ -116,7 +116,7 @@ public:
             using algorithm_t = unidirectional_search_algorithm<configuration_t,
                                                                 index_t,
                                                                 policy_max_error,
-                                                                policy_result_builder>;
+                                                                policy_search_result_builder>;
             return algorithm_t{cfg, index};
         }
     }

--- a/include/seqan3/search/detail/search_scheme_algorithm.hpp
+++ b/include/seqan3/search/detail/search_scheme_algorithm.hpp
@@ -85,7 +85,7 @@ public:
 
         perform_search_by_hit_strategy(internal_hits, query, error_state, on_hit_delegate);
 
-        return this->make_results(std::move(internal_hits), config); // see policy_result_builder
+        return this->make_results(std::move(internal_hits), config); // see policy_search_result_builder
     }
 
 private:

--- a/include/seqan3/search/detail/search_scheme_algorithm.hpp
+++ b/include/seqan3/search/detail/search_scheme_algorithm.hpp
@@ -85,7 +85,7 @@ public:
 
         perform_search_by_hit_strategy(internal_hits, query, error_state, on_hit_delegate);
 
-        return this->make_results(std::move(internal_hits), config); // see policy_search_result_builder
+        return this->make_results(std::move(internal_hits)); // see policy_search_result_builder
     }
 
 private:

--- a/include/seqan3/search/detail/search_traits.hpp
+++ b/include/seqan3/search/detail/search_traits.hpp
@@ -50,10 +50,11 @@ struct search_traits
     //!\brief A flag indicating whether search should find strata hits.
     static constexpr bool search_strata_hits = search_configuration_t::template exists<search_cfg::hit_strata>();
     //!\brief A flag indicating whether hit configuration was set in the search configuration.
-    static constexpr bool has_hit_configuration = search_all_hits |
-                                                  search_single_best_hit |
-                                                  search_all_best_hits |
-                                                  search_strata_hits;
+    static constexpr bool has_hit_configuration = search_all_hits ||
+                                                  search_single_best_hit ||
+                                                  search_all_best_hits ||
+                                                  search_strata_hits ||
+                                                  search_configuration_t::template exists<search_cfg::hit>();
 
     //!\brief A flag indicating whether search should return the index cursor.
     static constexpr bool search_return_index_cursor =

--- a/include/seqan3/search/detail/search_traits.hpp
+++ b/include/seqan3/search/detail/search_traits.hpp
@@ -12,11 +12,13 @@
 
 #pragma once
 
+#include <seqan3/core/detail/empty_type.hpp>
 #include <seqan3/core/type_traits/basic.hpp>
 #include <seqan3/search/configuration/max_error.hpp>
 #include <seqan3/search/configuration/max_error_rate.hpp>
 #include <seqan3/search/configuration/hit.hpp>
 #include <seqan3/search/configuration/output.hpp>
+#include <seqan3/search/configuration/result_type.hpp>
 
 namespace seqan3::detail
 {
@@ -33,6 +35,20 @@ template <typename search_configuration_t>
 //!\endcond
 struct search_traits
 {
+private:
+    //!\brief Maybe the result type configuration element or seqan3::detail::empty_type wrapped in std::type_identity.
+    static constexpr auto result_type_or_empty_type = [] ()
+    {
+        if constexpr (search_configuration_t::template exists<search_cfg::detail::result_type_tag>())
+            return get<search_cfg::detail::result_type_tag>(search_configuration_t{});
+        else
+            return std::type_identity<empty_type>{};
+    }();
+
+public:
+    //!\brief The configured search result type or seqan3::detail::empty_type if not configured yet.
+    using search_result_type = typename remove_cvref_t<decltype(result_type_or_empty_type)>::type;
+
     //!\brief A flag indicating whether search should be invoked with max error.
     static constexpr bool search_with_max_error = search_configuration_t::template exists<search_cfg::max_error>();
     //!\brief A flag indicating whether search should be invoked with max error rate.

--- a/include/seqan3/search/detail/unidirectional_search_algorithm.hpp
+++ b/include/seqan3/search/detail/unidirectional_search_algorithm.hpp
@@ -97,7 +97,7 @@ public:
 
         perform_search_by_hit_strategy(internal_hits, query, error_state);
 
-        return this->make_results(std::move(internal_hits), config); // see policy_result_builder
+        return this->make_results(std::move(internal_hits), config); // see policy_search_result_builder
     }
 
 private:

--- a/include/seqan3/search/detail/unidirectional_search_algorithm.hpp
+++ b/include/seqan3/search/detail/unidirectional_search_algorithm.hpp
@@ -165,9 +165,6 @@ private:
             search_trivial<false>(index_ptr->cursor(), query, 0, error_state, error_type::none);
         }
     }
-
-    //!\brief Befriend seqan3::detail::test_accessor to grant access to layout.
-    friend struct ::seqan3::detail::test_accessor;
 };
 
 /*!\brief Searches a query sequence in an index using trivial backtracking.

--- a/include/seqan3/search/detail/unidirectional_search_algorithm.hpp
+++ b/include/seqan3/search/detail/unidirectional_search_algorithm.hpp
@@ -97,7 +97,7 @@ public:
 
         perform_search_by_hit_strategy(internal_hits, query, error_state);
 
-        return this->make_results(std::move(internal_hits), config); // see policy_search_result_builder
+        return this->make_results(std::move(internal_hits)); // see policy_search_result_builder
     }
 
 private:

--- a/include/seqan3/search/search.hpp
+++ b/include/seqan3/search/search.hpp
@@ -19,117 +19,12 @@
 #include <seqan3/range/views/persist.hpp>
 #include <seqan3/range/views/type_reduce.hpp>
 #include <seqan3/search/configuration/default_configuration.hpp>
-#include <seqan3/search/detail/policy_max_error.hpp>
-#include <seqan3/search/detail/policy_result_builder.hpp>
-#include <seqan3/search/detail/unidirectional_search_algorithm.hpp>
-#include <seqan3/search/detail/search_scheme_algorithm.hpp>
+#include <seqan3/search/detail/search_configurator.hpp>
 #include <seqan3/search/detail/search_traits.hpp>
 #include <seqan3/search/search_result_range.hpp>
 
 namespace seqan3::detail
 {
-
-/*!\brief Class used to update the search configuration, e.g. add defaults.
- * \ingroup search
- */
-struct search_configurator
-{
-    /*!\brief Add seqan3::search_cfg::hit_all to the configuration if no search strategy (hit configuration) was chosen.
-     * \tparam configuration_t The type of the search configuration.
-     * \param[in] cfg The configuration to be modified if necessary.
-     * \returns The configuration which is guaranteed to have a hit configuration element available.
-     *
-     * \details
-     *
-     * If no \ref search_configuration_subsection_hit_strategy "hit configuration" was set,
-     * it defaults to seqan3::search_cfg::hit_all.
-     */
-    template <typename configuration_t>
-    static auto add_default_hit_configuration(configuration_t const & cfg)
-    {
-        if constexpr (!detail::search_traits<configuration_t>::has_hit_configuration)
-            return cfg | search_cfg::hit_all;
-        else
-            return cfg;
-    }
-
-    /*!\brief Add seqan3::search_cfg::text_position to the configuration if seqan3::search_cfg::output was not set.
-     * \tparam configuration_t The type of the search configuration.
-     * \param[in] cfg The configuration to be modified if necessary.
-     * \returns The configuration which is guaranteed to have a seqan3::search_cfg::output available.
-     *
-     * \details
-     *
-     * If seqan3::search_cfg::output was not set, it defaults to seqan3::search_cfg::text_position.
-     */
-    template <typename configuration_t>
-    static auto add_default_output_configuration(configuration_t const & cfg)
-    {
-        if constexpr (!detail::search_traits<configuration_t>::has_output_configuration)
-            return cfg | search_cfg::output{search_cfg::text_position};
-        else
-            return cfg;
-    }
-
-    /*!\brief Adds default configurations if they were not set by the user.
-     * \tparam configuration_t The type of the search configuration.
-     * \param[in] cfg The configuration to be modified.
-     * \returns The modified configuration.
-     *
-     * \details
-     *
-     * Modifies the configuration object by adding default configuration elements.
-     *
-     * \sa seqan3::details::search_configurator::add_default_hit_configuration
-     * \sa seqan3::details::search_configurator::add_default_output_configuration
-     */
-    template <typename configuration_t>
-    static auto add_defaults(configuration_t const & cfg)
-    {
-        static_assert(detail::is_type_specialisation_of_v<configuration_t, configuration>,
-                      "cfg must be a specialisation of seqan3::configuration.");
-
-        auto cfg1 = add_default_hit_configuration(cfg);
-        auto cfg2 = add_default_output_configuration(cfg1);
-
-        return cfg2;
-    }
-
-    /*!\brief Chooses the appropriate search algorithm depending on the index.
-     * \tparam configuration_t The type of the search configuration.
-     * \tparam index_t The type of the index.
-     * \param[in] cfg The search configuration object that is passed to the algorithm.
-     * \param[in] index The index that is passed to the algorithm.
-     * \returns A search algorithm.
-     *
-     * \details
-     *
-     * If the `index_t` models seqan3::bi_fm_index_specialisation, then the
-     * seqan3::detail::search_scheme_algorithm is chosen. Otherwise, the
-     * detail::unidirectional_search_algorithm is chosen.
-     */
-    template <typename configuration_t, typename index_t>
-    static auto configure_algorithm(configuration_t const & cfg, index_t const & index)
-    {
-        if constexpr (bi_fm_index_specialisation<index_t>)
-        {
-            using algorithm_t = search_scheme_algorithm<configuration_t,
-                                                        index_t,
-                                                        policy_max_error,
-                                                        policy_result_builder>;
-            return algorithm_t{cfg, index};
-        }
-        else
-        {
-            using algorithm_t = unidirectional_search_algorithm<configuration_t,
-                                                                index_t,
-                                                                policy_max_error,
-                                                                policy_result_builder>;
-            return algorithm_t{cfg, index};
-        }
-    }
-};
-
 /*!\brief Class used to validate the search configuration.
  * \ingroup search
  */

--- a/include/seqan3/search/search.hpp
+++ b/include/seqan3/search/search.hpp
@@ -152,7 +152,8 @@ inline auto search(queries_t && queries,
     detail::search_configuration_validator::validate_query_type<queries_t>();
     detail::search_configuration_validator::validate_error_configuration(updated_cfg);
 
-    auto algorithm = detail::search_configurator::configure_algorithm(updated_cfg, index);
+    using query_t = std::ranges::range_reference_t<queries_t>;
+    auto algorithm = detail::search_configurator::configure_algorithm<query_t>(updated_cfg, index);
 
     return search_result_range{std::move(algorithm), std::forward<queries_t>(queries) | views::type_reduce};
 }

--- a/include/seqan3/search/search_result.hpp
+++ b/include/seqan3/search/search_result.hpp
@@ -19,11 +19,16 @@
 #include <seqan3/core/detail/debug_stream_type.hpp>
 #include <seqan3/core/detail/empty_type.hpp>
 #include <seqan3/core/type_traits/template_inspection.hpp>
+#include <seqan3/core/algorithm/configuration.hpp>
 #include <seqan3/search/fm_index/concept.hpp>
 
 namespace seqan3::detail
 {
 // forward declaration
+template <typename search_configuration_t>
+#if !SEQAN3_WORKAROUND_GCC_93467
+    requires is_type_specialisation_of_v<search_configuration_t, configuration>
+#endif // !SEQAN3_WORKAROUND_GCC_93467
 struct policy_search_result_builder;
 } // namespace seqan3::detail
 
@@ -93,13 +98,17 @@ private:
         query_id_(q_id), reference_id_(std::move(ref_id)), reference_begin_pos_(std::move(ref_pos))
     {}
 
-    //!\cond
     // Grant the policy access to private constructors.
-    friend detail::policy_search_result_builder;
+    template <typename search_configuration_t>
+    #if !SEQAN3_WORKAROUND_GCC_93467
+    //!\cond
+        requires is_type_specialisation_of_v<search_configuration_t, configuration>
+    //!\endcond
+    #endif // !SEQAN3_WORKAROUND_GCC_93467
+    friend struct detail::policy_search_result_builder;
     // Currently, the query id is set within the search result range. This needs to be adapted.
     template <typename search_algorithm_t, typename query_range_t>
     friend class search_result_range;
-    //!\endcond
 
 public:
     /*!\name Constructors, destructor and assignment

--- a/include/seqan3/search/search_result.hpp
+++ b/include/seqan3/search/search_result.hpp
@@ -24,8 +24,8 @@
 namespace seqan3::detail
 {
 // forward declaration
-struct policy_result_builder;
-}
+struct policy_search_result_builder;
+} // namespace seqan3::detail
 
 namespace seqan3
 {
@@ -95,7 +95,7 @@ private:
 
     //!\cond
     // Grant the policy access to private constructors.
-    friend detail::policy_result_builder;
+    friend detail::policy_search_result_builder;
     // Currently, the query id is set within the search result range. This needs to be adapted.
     template <typename search_algorithm_t, typename query_range_t>
     friend class search_result_range;

--- a/test/snippet/search/dynamic_hit_configuration_example.cpp
+++ b/test/snippet/search/dynamic_hit_configuration_example.cpp
@@ -1,0 +1,27 @@
+#include <seqan3/search/configuration/all.hpp>
+
+int main()
+{
+    // Default constructed: Has no hit strategy selected.
+    seqan3::search_cfg::hit dynamic_hit{};
+
+    // Select hit_all
+    dynamic_hit = seqan3::search_cfg::hit_all;
+
+    // If condition is true choose strata strategy, otherwise find the single best hit.
+    if (true)
+        dynamic_hit = seqan3::search_cfg::hit_strata{4};
+    else
+        dynamic_hit = seqan3::search_cfg::hit_single_best;
+
+    // Combine it with other configurations.
+    seqan3::configuration const cfg = dynamic_hit | seqan3::search_cfg::max_error{seqan3::search_cfg::total{1}};
+
+    // Directly initialised.
+    seqan3::search_cfg::hit dynamic_hit2{seqan3::search_cfg::hit_all_best};
+
+    // You cannot combine the dynamic hit configuration with the static ones.
+    // auto fail = seqan3::search_cfg::hit_single_best | seqan3::search_cfg::hit; // doesn't compile
+
+    return 0;
+}

--- a/test/unit/search/configuration/hit_test.cpp
+++ b/test/unit/search/configuration/hit_test.cpp
@@ -19,7 +19,8 @@
 using test_types = ::testing::Types<seqan3::detail::hit_all_tag,
                                     seqan3::detail::hit_all_best_tag,
                                     seqan3::detail::hit_single_best_tag,
-                                    seqan3::search_cfg::hit_strata>;
+                                    seqan3::search_cfg::hit_strata,
+                                    seqan3::search_cfg::hit>;
 
 INSTANTIATE_TYPED_TEST_SUITE_P(mode_elements, pipeable_config_element_test, test_types, );
 
@@ -56,4 +57,51 @@ TEST(hit_strata_test, member_variable)
         strata_mode.value = 3;
         EXPECT_EQ(strata_mode.value, 3);
     }
+}
+
+TEST(hit_dynamic, empty)
+{
+    seqan3::search_cfg::hit dynamic_hit{};
+    EXPECT_TRUE(std::holds_alternative<seqan3::detail::empty_type>(dynamic_hit.hit_variant));
+}
+
+TEST(hit_dynamic, construction)
+{
+    {
+        seqan3::search_cfg::hit dynamic_hit{seqan3::search_cfg::hit_all};
+        EXPECT_TRUE(std::holds_alternative<seqan3::detail::hit_all_tag>(dynamic_hit.hit_variant));
+    }
+
+    {
+        seqan3::search_cfg::hit dynamic_hit{seqan3::search_cfg::hit_all_best};
+        EXPECT_TRUE(std::holds_alternative<seqan3::detail::hit_all_best_tag>(dynamic_hit.hit_variant));
+    }
+
+    {
+        seqan3::search_cfg::hit dynamic_hit{seqan3::search_cfg::hit_single_best};
+        EXPECT_TRUE(std::holds_alternative<seqan3::detail::hit_single_best_tag>(dynamic_hit.hit_variant));
+    }
+
+    {
+        seqan3::search_cfg::hit dynamic_hit{seqan3::search_cfg::hit_strata{4}};
+        EXPECT_TRUE(std::holds_alternative<seqan3::search_cfg::hit_strata>(dynamic_hit.hit_variant));
+        EXPECT_EQ(std::get<seqan3::search_cfg::hit_strata>(dynamic_hit.hit_variant).value, 4);
+    }
+}
+
+TEST(hit_dynamic, assignment)
+{
+    seqan3::search_cfg::hit dynamic_hit{};
+    dynamic_hit = seqan3::search_cfg::hit_all;
+    EXPECT_TRUE(std::holds_alternative<seqan3::detail::hit_all_tag>(dynamic_hit.hit_variant));
+
+    dynamic_hit = seqan3::search_cfg::hit_all_best;
+    EXPECT_TRUE(std::holds_alternative<seqan3::detail::hit_all_best_tag>(dynamic_hit.hit_variant));
+
+    dynamic_hit = seqan3::search_cfg::hit_single_best;
+    EXPECT_TRUE(std::holds_alternative<seqan3::detail::hit_single_best_tag>(dynamic_hit.hit_variant));
+
+    dynamic_hit = seqan3::search_cfg::hit_strata{4};
+    EXPECT_TRUE(std::holds_alternative<seqan3::search_cfg::hit_strata>(dynamic_hit.hit_variant));
+    EXPECT_EQ(std::get<seqan3::search_cfg::hit_strata>(dynamic_hit.hit_variant).value, 4);
 }

--- a/test/unit/search/search_configuration_test.cpp
+++ b/test/unit/search/search_configuration_test.cpp
@@ -8,6 +8,7 @@
 #include <type_traits>
 
 #include <seqan3/search/all.hpp>
+#include <seqan3/search/search_result.hpp>
 
 #include <gtest/gtest.h>
 
@@ -15,11 +16,17 @@ template <typename T>
 class search_configuration_test : public ::testing::Test
 {};
 
+using search_result_t = seqan3::search_result<seqan3::detail::empty_type,
+                                              seqan3::detail::empty_type,
+                                              seqan3::detail::empty_type,
+                                              seqan3::detail::empty_type>;
+
 using test_types = ::testing::Types<seqan3::search_cfg::max_error_rate<>,
                                     seqan3::search_cfg::max_error,
                                     seqan3::detail::hit_single_best_tag,
                                     seqan3::search_cfg::output<seqan3::detail::search_output_text_position>,
-                                    seqan3::search_cfg::parallel>;
+                                    seqan3::search_cfg::parallel,
+                                    seqan3::search_cfg::detail::result_type_tag<search_result_t>>;
 
 TYPED_TEST_SUITE(search_configuration_test, test_types, );
 

--- a/test/unit/search/search_scheme_algorithm_test.cpp
+++ b/test/unit/search/search_scheme_algorithm_test.cpp
@@ -17,7 +17,7 @@
 #include <seqan3/search/detail/search_scheme_algorithm.hpp>
 #include <seqan3/search/detail/unidirectional_search_algorithm.hpp>
 #include <seqan3/search/detail/policy_max_error.hpp>
-#include <seqan3/search/detail/policy_result_builder.hpp>
+#include <seqan3/search/detail/policy_search_result_builder.hpp>
 #include <seqan3/search/fm_index/all.hpp>
 #include <seqan3/range/views/slice.hpp>
 #include <seqan3/range/views/to.hpp>
@@ -39,7 +39,10 @@ struct test_accessor
 
         auto cfg = seqan3::search_cfg::default_configuration;
         using config_t = decltype(cfg);
-        using algorithm_t = unidirectional_search_algorithm<config_t, index_t, policy_max_error, policy_result_builder>;
+        using algorithm_t = unidirectional_search_algorithm<config_t,
+                                                            index_t,
+                                                            policy_max_error,
+                                                            policy_search_result_builder>;
         algorithm_t algo{cfg, index};
         algo.delegate = delegate;
         algo.template search_trivial<abort_on_hit>(index.cursor(), query, 0, error_left, error_type::none);

--- a/test/unit/search/search_scheme_algorithm_test.cpp
+++ b/test/unit/search/search_scheme_algorithm_test.cpp
@@ -42,7 +42,7 @@ struct test_accessor
         using algorithm_t = unidirectional_search_algorithm<config_t,
                                                             index_t,
                                                             policy_max_error,
-                                                            policy_search_result_builder>;
+                                                            policy_search_result_builder<config_t>>;
         algorithm_t algo{cfg, index};
         algo.delegate = delegate;
         algo.template search_trivial<abort_on_hit>(index.cursor(), query, 0, error_left, error_type::none);


### PR DESCRIPTION
### Description

Sometimes a program needs to support different hit strategies based on some user input. Since these are mostly runtime decisisons the code can become quite cumbersome to handle the static hit configurations. Instead, one can use the dynamic hit configuration element seqan3::search::cfg::hit. This configuration element allows to set one of the above mentioned hit configurations at runtime. Later during the configuration phase of the search algorithm the selected search configuration is used for the final search algorithm. If the dynamic hit configuration is default constructed it does not hold any hit configuration. If you call search with the dynamic configuration in this state an exception will be thrown.
Also note that using the dynamic configuration might have implications on the compile time, so we recommend to use the static configurations if only a single hit strategy is supported.

### Changes

The follwoing things are handled in this PR:

* Add dynamic hit configuration including test and documentation
* Move the search configurator in it's own class
* Let the search configurator return a type erased std::function object
* Adapts the search configurator to handle dynamic hit configuration
* Add result type configuration element to store the configured result type for the search
* Adapts the search traits type
* Renames policy_result_builder to policy_search_result_builder and makes it a template class with the configuration template.
* Refactors a little the search_trivial test to not depend on the internal function of the unidirectional search algorithm anymore.

Also note that this PR kind of depends on #1706. So some parts are commented but in general this already works.

### Fixes

Fixes seqan/product_backlog#79
Fixes seqan/product_backlog#31
Fixes seqan/seqan3#1436