### PR TITLE
Fix/issue1801 custom thread count in alignment algorithm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,12 @@ Note that 3.1.0 will be the first API stable release and interfaces in this rele
 
 ## Notable Bug-fixes
 
+### Alignment
+
+* When invoking the alignment algorithm with a user defined thread count using the `seqan3::align_cfg::parallel`
+  configuration element, `std::thread::hardware_concurrency()` many threads were always spawned. This is now fixed and
+  only the specified number of threads will be spawned ([\#1854](https://github.com/seqan/seqan3/pull/1854)).
+
 ### Argument Parser
 
 * Long option identifiers and their value must be separated by a space or equal sign `=`.

--- a/include/seqan3/alignment/pairwise/alignment_range.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_range.hpp
@@ -76,7 +76,7 @@ public:
      * Constructs a new alignment range by taking ownership over the passed alignment buffer.
      */
     explicit alignment_range(alignment_executor_type && alignment_executor) :
-        alignment_executor_ptr{new alignment_executor_type{std::move(alignment_executor)}}
+        alignment_executor_ptr{std::make_unique<alignment_executor_type>(std::move(alignment_executor))}
     {}
     //!\}
 
@@ -163,6 +163,9 @@ template <typename alignment_executor_type>
 class alignment_range<alignment_executor_type>::alignment_range_iterator
 {
 public:
+    /*!\name Associated types
+     * \{
+     */
     //!\brief Type for distances between iterators.
     using difference_type = std::ptrdiff_t;
     //!\brief Value type of container elements.
@@ -173,6 +176,7 @@ public:
     using pointer = std::add_pointer_t<value_type>;
     //!\brief Sets iterator category as input iterator.
     using iterator_category = std::input_iterator_tag;
+    //!\}
 
     /*!\name Constructors, destructor and assignment
      * \{
@@ -185,7 +189,7 @@ public:
     ~alignment_range_iterator() = default; //!< Defaulted.
 
     //!\brief Construct from alignment stream.
-    constexpr alignment_range_iterator(alignment_range & range) : range_ptr(std::addressof(range))
+    explicit constexpr alignment_range_iterator(alignment_range & range) : range_ptr(std::addressof(range))
     {
         ++(*this); // Fetch the next element.
     }

--- a/include/seqan3/core/algorithm/detail/algorithm_executor_blocking.hpp
+++ b/include/seqan3/core/algorithm/detail/algorithm_executor_blocking.hpp
@@ -147,7 +147,7 @@ public:
      * \param[in] resource The underlying resource.
      * \param[in] algorithm The algorithm to invoke on the elements of the underlying resource.
      * \param[in] result A dummy result object to deduce the type of the underlying buffer value.
-     * \param[in] exec Optional execution policy to use. Defaults to seqan3::seq.
+     * \param[in] exec_handler The execution handler to use [optional].
      *
      * \details
      *
@@ -156,14 +156,11 @@ public:
      * Also note that the third argument is used for deducing the algorithm result type and is otherwise
      * not used in the context of the class' construction.
      */
-    template <typename exec_policy_t = sequenced_policy>
-    //!\cond
-        requires is_execution_policy_v<exec_policy_t>
-    //!\endcond
     algorithm_executor_blocking(resource_t resource,
                                 algorithm_t algorithm,
                                 algorithm_result_t const SEQAN3_DOXYGEN_ONLY(result) = algorithm_result_t{},
-                                exec_policy_t const & SEQAN3_DOXYGEN_ONLY(exec) = seq) :
+                                execution_handler_t && exec_handler = execution_handler_t{}) :
+        exec_handler{std::move(exec_handler)},
         resource{std::views::all(resource)},
         resource_it{std::ranges::begin(this->resource)},
         algorithm{std::move(algorithm)}
@@ -175,7 +172,6 @@ public:
         buffer_it = buffer.end();
         buffer_end_it = buffer_it;
     }
-
     //!}
 
     /*!\brief Returns the next available algorithm result.

--- a/include/seqan3/core/algorithm/detail/execution_handler_parallel.hpp
+++ b/include/seqan3/core/algorithm/detail/execution_handler_parallel.hpp
@@ -90,10 +90,10 @@ public:
     execution_handler_parallel() : execution_handler_parallel{std::thread::hardware_concurrency()}
     {}
 
-    execution_handler_parallel(execution_handler_parallel const &) = delete;                 //!< Deleted.
-    execution_handler_parallel(execution_handler_parallel &&) = default;                     //!< Defaulted.
-    execution_handler_parallel & operator=(execution_handler_parallel const &) = delete;     //!< Deleted.
-    execution_handler_parallel & operator=(execution_handler_parallel &&) = default;         //!< Defaulted.
+    execution_handler_parallel(execution_handler_parallel const &) = delete; //!< Deleted.
+    execution_handler_parallel(execution_handler_parallel &&) = default; //!< Defaulted.
+    execution_handler_parallel & operator=(execution_handler_parallel const &) = delete; //!< Deleted.
+    execution_handler_parallel & operator=(execution_handler_parallel &&) = default; //!< Defaulted.
 
     //!\brief Waits for threads to finish.
     ~execution_handler_parallel()

--- a/test/unit/core/algorithm/detail/algorithm_executor_blocking_test.cpp
+++ b/test/unit/core/algorithm/detail/algorithm_executor_blocking_test.cpp
@@ -217,3 +217,51 @@ TYPED_TEST(algorithm_executor_blocking_test, empty_result_bucket)
     EXPECT_EQ(exec.next_result().value(), 7u);
     EXPECT_FALSE(static_cast<bool>(exec.next_result()));
 }
+
+//See issue: https://github.com/seqan/seqan3/issues/1801
+TEST(algorithm_executor_blocking_test, issue_1801)
+{
+    std::vector<std::thread::id> thread_ids{}; // Stores the thread ids.
+    std::mutex push_mutex{}; // Used to synchronise concurrent push back operation on the thread_ids vector.
+
+    using callback_t = std::function<void(size_t)>;
+    std::function algorithm = [&] (std::string const & seq, callback_t && callback)
+    {
+        { // Tell which thread is working.
+            std::unique_lock push_lock{push_mutex};
+            thread_ids.push_back(std::this_thread::get_id());
+        }
+
+        callback(seq.size());
+    };
+
+    // The sequence vector.
+    std::vector<std::string> sequences{10000, std::string{"sequence"}};
+
+    // Define an parallel algorithm executor.
+    using algorithm_t = decltype(algorithm);
+    using executor_t =
+        seqan3::detail::algorithm_executor_blocking<std::vector<std::string> &,
+                                                    algorithm_t,
+                                                    size_t,
+                                                    seqan3::detail::execution_handler_parallel>;
+
+    // Allow at most 2 threads and then execute until no results are available anymore.
+    static constexpr size_t thread_count = 2u;
+    executor_t executor{sequences, algorithm, 0ull, seqan3::detail::execution_handler_parallel{thread_count}};
+    auto result = executor.next_result();
+
+    while (result.has_value())
+        result = executor.next_result();
+
+    // Expect exactly many ids as sequences were procesed.
+    EXPECT_EQ(thread_ids.size(), sequences.size());
+
+    // Sort and remove unique ids.
+    std::sort(thread_ids.begin(), thread_ids.end());
+    thread_ids.erase(std::unique(thread_ids.begin(), thread_ids.end()), thread_ids.end());
+
+    // Expect at most thread count many ids. Note it can also be fewer threads since it is not guaranteed, that
+    // all threads will get a piece of the cake.
+    EXPECT_LE(thread_ids.size(), thread_count);
+}


### PR DESCRIPTION
Fixes #1801

Allows to use only the thread count specified by the user.
Makes the algorithm_executor_blocking data structure constructible over the execution handler and sets the thread count set by the user for the parallel execution handler during the alignment configuration.