### PR TITLE
[INFRA,FIX] Increase ccache size in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 version: ~> 1.0
 os: linux
-dist: xenial
+dist: bionic
 language: cpp
 
 git:
@@ -98,6 +98,7 @@ install:
     tar -C /tmp/ -zxvf /tmp/cmake-download/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz
     export PATH="/tmp/cmake-${CMAKE_VERSION}-Linux-x86_64/bin:${PATH}"
   - ccache --version
+  - ccache -M 10G
   - $CXX -v
   - cmake --version
   - |


### PR DESCRIPTION
This allows the coverage build to be cached
![ccache](https://user-images.githubusercontent.com/12967715/83131561-4b9e3780-a0e0-11ea-8a7d-11b3282008b2.png)

The main time sinks are now running the tests in debug mode (coverage) and running the benchmarks (performance).

Going from xenial (16.04) to bionic (18.04) also upgrades the ccache package, which is quite an old version on xenial.
The default cache size for ccache is 5G on newer versions, the default for the old version is 500M.
The coverage build needs around 5.1G (~50G HDD available on travis).
