### PR TITLE
[TEST] Add reverse to naive minimiser view

### DIFF
--- a/test/include/seqan3/test/performance/naive_minimiser_hash.hpp
+++ b/test/include/seqan3/test/performance/naive_minimiser_hash.hpp
@@ -75,13 +75,10 @@ struct naive_minimiser_hash_fn
                                                    | std::views::transform([seed] (uint64_t i) { return i ^ seed; })
                                                    | std::views::reverse;
        auto both = seqan3::views::zip(forward, reverse)
-                   | std::views::transform( [ ] (auto i) {return std::min(std::get<0>(i), std::get<1>(i));});
+                 | std::views::transform( [ ] (auto i) {return std::min(std::get<0>(i), std::get<1>(i));});
 
        return both | ranges::views::sliding(window_size - shape.size() + 1)
-                                         | std::views::transform([] (auto const in)
-                                                                   {
-                                                                       return *std::min_element(in.begin(), in.end());
-                                                                   });
+                   | std::views::transform([] (auto const in) {return *std::min_element(in.begin(), in.end());});
    }
 };
 

--- a/test/include/seqan3/test/performance/naive_minimiser_hash.hpp
+++ b/test/include/seqan3/test/performance/naive_minimiser_hash.hpp
@@ -67,16 +67,16 @@ struct naive_minimiser_hash_fn
        if (shape.size() > window_size)
            throw std::invalid_argument{"The size of the shape cannot be greater than the window size."};
 
-       // Use random seed to randomise order on forward strand
+       // Use random seed to randomise order on forward strand.
        auto forward = std::forward<urng_t>(urange) | seqan3::views::kmer_hash(shape)
                                                    | std::views::transform([seed] (uint64_t const i)
                                                                            { return i ^ seed; });
-       // Create reverse complement strand and use random seed to randomise order on reverse complement strand
-       auto reverse = std::forward<urng_t>(urange) | seqan3::views::complement // Create complement
-                                                   | std::views::reverse       // Reverse order
-                                                   | seqan3::views::kmer_hash(shape) // Get hash values
+       // Create reverse complement strand and use random seed to randomise order on reverse complement strand.
+       auto reverse = std::forward<urng_t>(urange) | seqan3::views::complement // Create complement.
+                                                   | std::views::reverse       // Reverse order.
+                                                   | seqan3::views::kmer_hash(shape) // Get hash values.
                                                    | std::views::transform([seed] (uint64_t const i)
-                                                                           { return i ^ seed; }) // Randomise
+                                                                           { return i ^ seed; }) // Randomise.
                                                    | std::views::reverse; // Reverse again, so that the first hash value
                                                                           // is the reverse complement of the first
                                                                           // hash value in the forward strand.


### PR DESCRIPTION
Naive approach of minimisers considers now reverse strand, which makes it already comparable with seqan2 and can be used in the future for comparison of seqan3's minimiser_hash, once minimiser_hash handles reverse as well.