### PR TITLE
[FEATURE] Argument Parser: new member function that checks if an option was set.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ If possible, provide tooling that performs the changes, e.g. a shell-script.
 
 * We expanded the `seqan3::output_file_validator`, with a parameter `seqan3::output_file_open_options` to allow overwriting
   output files ([\#2009](https://github.com/seqan/seqan3/pull/2009)).
+* The `seqan3::argument_parser` has a new member function `seqan3::argument_parser::is_option_set` that
+  checks whether an option, identified by its long or short name, was set on the command line by the user
+  ([\#1859](https://github.com/seqan/seqan3/pull/1859)).
 
 #### Search
 

--- a/include/seqan3/argument_parser/argument_parser.hpp
+++ b/include/seqan3/argument_parser/argument_parser.hpp
@@ -566,6 +566,25 @@ private:
     //!\brief Stores the sub-parser names in case \link subcommand_arg_parse subcommand parsing \endlink is enabled.
     std::vector<std::string> subcommands{};
 
+    /*!\brief The format of the argument parser that decides the behavior when
+     *        calling the seqan3::argument_parser::parse function.
+     *
+     * \details
+     *
+     * The format is set in the function argument_parser::init.
+     */
+    std::variant<detail::format_parse,
+                 detail::format_help,
+                 detail::format_short_help,
+                 detail::format_version,
+                 detail::format_html,
+                 detail::format_man,
+                 detail::format_copyright/*,
+                 detail::format_ctd*/> format{detail::format_help{{}, false}}; // Will be overwritten in any case.
+
+    //!\brief List of option/flag identifiers that are already used.
+    std::set<std::string> used_option_ids{"h", "hh", "help", "advanced-help", "export-help", "version", "copyright"};
+
     /*!\brief Initializes the seqan3::argument_parser class on construction.
      *
      * \param[in] argc        The number of command line arguments.
@@ -764,22 +783,6 @@ private:
         if (detail::format_parse::is_empty_id(short_id) && detail::format_parse::is_empty_id(long_id))
             throw design_error("Option Identifiers cannot both be empty.");
     }
-
-    /*!\brief The format of the argument parser that decides the behavior when
-     * calling the seqan3::argument_parser::parse function.
-     * \details The format is set in the function argument_parser::init.
-     */
-    std::variant<detail::format_parse,
-                 detail::format_help,
-                 detail::format_short_help,
-                 detail::format_version,
-                 detail::format_html,
-                 detail::format_man,
-                 detail::format_copyright/*,
-                 detail::format_ctd*/> format{detail::format_help{{}, false}}; // Will be overwritten in any case.
-
-    //!\brief List of option/flag identifiers that are already used.
-    std::set<std::string> used_option_ids{"h", "hh", "help", "advanced-help", "export-help", "version", "copyright"};
 };
 
 } // namespace seqan3

--- a/include/seqan3/argument_parser/argument_parser.hpp
+++ b/include/seqan3/argument_parser/argument_parser.hpp
@@ -585,6 +585,9 @@ private:
     //!\brief List of option/flag identifiers that are already used.
     std::set<std::string> used_option_ids{"h", "hh", "help", "advanced-help", "export-help", "version", "copyright"};
 
+    //!\brief The command line arguments.
+    std::vector<std::string> cmd_arguments{};
+
     /*!\brief Initializes the seqan3::argument_parser class on construction.
      *
      * \param[in] argc        The number of command line arguments.
@@ -598,7 +601,7 @@ private:
      *
      * \details
      *
-     * This function adds all command line parameters to a std::vector<std::string>
+     * This function adds all command line parameters to the cmd_arguments member variable
      * to take advantage of the vector functionality later on. Additionally,
      * the format member variable is set, depending on which parameters are given
      * by the user:
@@ -619,9 +622,6 @@ private:
      */
     void init(int argc, char const * const * const argv)
     {
-        // cash command line input, in case --version-check is specified but shall not be passed to format_parse()
-        std::vector<std::string> argv_new{};
-
         if (argc <= 1) // no arguments provided
         {
             format = detail::format_short_help{};
@@ -708,18 +708,17 @@ private:
                 else
                     throw validation_error{"Value for option --version-check must be 1 or 0."};
 
+                // in case --version-check is specified it shall not be passed to format_parse()
                 argc -= 2;
             }
             else
             {
-                argv_new.push_back(std::move(arg));
+                cmd_arguments.push_back(std::move(arg));
             }
         }
 
         if (!special_format_was_set)
-        {
-            format = detail::format_parse(argc, std::move(argv_new));
-        }
+            format = detail::format_parse(argc, cmd_arguments);
     }
 
     //!\brief Adds standard options to the help page.

--- a/include/seqan3/argument_parser/detail/format_parse.hpp
+++ b/include/seqan3/argument_parser/detail/format_parse.hpp
@@ -219,7 +219,7 @@ private:
     * \param[in] long_id The name of the long identifier.
     * \returns The input long name prepended with a double dash.
     */
-    std::string prepend_dash(std::string const & long_id)
+    static std::string prepend_dash(std::string const & long_id)
     {
         return ("--" + long_id);
     }
@@ -228,7 +228,7 @@ private:
     * \param[in] short_id The name of the short identifier.
     * \returns The input short name prepended with a single dash.
     */
-    std::string prepend_dash(char const short_id)
+    static std::string prepend_dash(char const short_id)
     {
         return ("-" + std::string(1, short_id));
     }

--- a/include/seqan3/argument_parser/detail/format_parse.hpp
+++ b/include/seqan3/argument_parser/detail/format_parse.hpp
@@ -66,7 +66,7 @@ public:
      * \param[in] argc_ The number of command line arguments.
      * \param[in] argv_ The command line arguments to parse.
      */
-    format_parse(int const argc_, std::vector<std::string> && argv_) :
+    format_parse(int const argc_, std::vector<std::string> argv_) :
         argc{argc_ - 1}, argv{std::move(argv_)}
     {}
     //!\}

--- a/include/seqan3/argument_parser/detail/format_parse.hpp
+++ b/include/seqan3/argument_parser/detail/format_parse.hpp
@@ -221,7 +221,7 @@ private:
     */
     static std::string prepend_dash(std::string const & long_id)
     {
-        return ("--" + long_id);
+        return {"--" + long_id};
     }
 
     /*!\brief Appends a double dash to a short identifier and returns it.
@@ -230,7 +230,7 @@ private:
     */
     static std::string prepend_dash(char const short_id)
     {
-        return ("-" + std::string(1, short_id));
+        return {"-" + std::string{short_id}};
     }
 
     /*!\brief Returns "-[short_id]/--[long_id]" if both are non-empty or just one of them if the other is empty.

--- a/include/seqan3/argument_parser/detail/format_parse.hpp
+++ b/include/seqan3/argument_parser/detail/format_parse.hpp
@@ -159,48 +159,6 @@ public:
             return is_char<'\0'>(id);
     }
 
-private:
-    //!\brief Describes the result of parsing the user input string given the respective option value type.
-    enum class option_parse_result
-    {
-        success, //!< Parsing of user input was successful.
-        error, //!< There was some error while trying to parse the user input.
-        overflow_error //!< Parsing was successful but the arithmetic value would cause an overflow.
-    };
-
-    /*!\brief Appends a double dash to a long identifier and returns it.
-    * \param[in] long_id The name of the long identifier.
-    * \returns The input long name prepended with a double dash.
-    */
-    std::string prepend_dash(std::string const & long_id)
-    {
-        return ("--" + long_id);
-    }
-
-    /*!\brief Appends a double dash to a short identifier and returns it.
-    * \param[in] short_id The name of the short identifier.
-    * \returns The input short name prepended with a single dash.
-    */
-    std::string prepend_dash(char const short_id)
-    {
-        return ("-" + std::string(1, short_id));
-    }
-
-    /*!\brief Returns "-[short_id]/--[long_id]" if both are non-empty or just one of them if the other is empty.
-    * \param[in] short_id The name of the short identifier.
-    * \param[in] long_id  The name of the long identifier.
-    * \returns The short_id prepended with a single dash and the long_id prepended with a double dash, separated by '/'.
-    */
-    std::string combine_option_names(char const short_id, std::string const & long_id)
-    {
-        if (short_id == '\0')
-            return prepend_dash(long_id);
-        else if (long_id.empty())
-            return prepend_dash(short_id);
-        else // both are set (note: both cannot be empty, this is caught before)
-            return prepend_dash(short_id) + "/" + prepend_dash(long_id);
-    }
-
     /*!\brief Finds the position of a short/long identifier in format_parse::argv.
      * \tparam id_type The identifier type; must be either of type `char` if it denotes a short identifier or
      *                 std::string if it denotes a long identifier.
@@ -246,6 +204,48 @@ private:
                            (current_arg.size() == full_id.size() || current_arg[full_id.size()] == '='); // space or `=`
                 }
             }));
+    }
+
+private:
+    //!\brief Describes the result of parsing the user input string given the respective option value type.
+    enum class option_parse_result
+    {
+        success, //!< Parsing of user input was successful.
+        error, //!< There was some error while trying to parse the user input.
+        overflow_error //!< Parsing was successful but the arithmetic value would cause an overflow.
+    };
+
+    /*!\brief Appends a double dash to a long identifier and returns it.
+    * \param[in] long_id The name of the long identifier.
+    * \returns The input long name prepended with a double dash.
+    */
+    std::string prepend_dash(std::string const & long_id)
+    {
+        return ("--" + long_id);
+    }
+
+    /*!\brief Appends a double dash to a short identifier and returns it.
+    * \param[in] short_id The name of the short identifier.
+    * \returns The input short name prepended with a single dash.
+    */
+    std::string prepend_dash(char const short_id)
+    {
+        return ("-" + std::string(1, short_id));
+    }
+
+    /*!\brief Returns "-[short_id]/--[long_id]" if both are non-empty or just one of them if the other is empty.
+    * \param[in] short_id The name of the short identifier.
+    * \param[in] long_id  The name of the long identifier.
+    * \returns The short_id prepended with a single dash and the long_id prepended with a double dash, separated by '/'.
+    */
+    std::string combine_option_names(char const short_id, std::string const & long_id)
+    {
+        if (short_id == '\0')
+            return prepend_dash(long_id);
+        else if (long_id.empty())
+            return prepend_dash(short_id);
+        else // both are set (note: both cannot be empty, this is caught before)
+            return prepend_dash(short_id) + "/" + prepend_dash(long_id);
     }
 
     /*!\brief Returns true and removes the long identifier if it is in format_parse::argv.

--- a/test/snippet/argument_parser/is_option_set.cpp
+++ b/test/snippet/argument_parser/is_option_set.cpp
@@ -1,0 +1,31 @@
+#include <seqan3/argument_parser/all.hpp>
+#include <seqan3/core/debug_stream.hpp>
+
+int main(int argc, char ** argv)
+{
+    seqan3::argument_parser myparser{"awesome-app", argc, argv}; // initialize
+
+    int a{3};
+    myparser.add_option(a, 'a', "awesome-parameter", "Please specify an integer.");
+
+    try
+    {
+        myparser.parse();
+    }
+    catch (seqan3::argument_parser_error const & ext) // the user did something wrong
+    {
+        std::cerr << "[PARSER ERROR] " << ext.what() << '\n'; // customize your error message
+        return -1;
+    }
+
+    if (myparser.is_option_set('a'))
+        seqan3::debug_stream << "The user set option -a on the command line.\n";
+
+    if (myparser.is_option_set("awesome-parameter"))
+        seqan3::debug_stream << "The user set option --awesome-parameter on the command line.\n";
+
+    // Asking for an option identifier that was not used before throws an error:
+    // myparser.is_option_set("foo"); // throws seqan3::design_error
+
+    return 0;
+}

--- a/test/unit/argument_parser/format_parse_test.cpp
+++ b/test/unit/argument_parser/format_parse_test.cpp
@@ -986,3 +986,35 @@ TEST(parse_test, issue1544)
         EXPECT_EQ(foobar_option_value, "ballo");
     }
 }
+
+TEST(parse_test, is_option_set)
+{
+    std::string option_value{};
+    const char * argv[] = {"./argument_parser_test", "-l", "hallo", "--foobar", "ballo", "--", "--loo"};
+    seqan3::argument_parser parser{"test_parser", 5, argv, seqan3::update_notifications::off};
+    parser.add_option(option_value, 'l', "loo", "this is a option.");
+    parser.add_option(option_value, 'f', "foobar", "this is a option.");
+
+    EXPECT_THROW(parser.is_option_set("foo"), seqan3::design_error); // you cannot call option_is_set before parse()
+
+    EXPECT_NO_THROW(parser.parse());
+
+    EXPECT_TRUE(parser.is_option_set('l'));
+    EXPECT_TRUE(parser.is_option_set("foobar"));
+
+    EXPECT_FALSE(parser.is_option_set('f'));
+    EXPECT_FALSE(parser.is_option_set("loo")); // --loo is behind the `--` which signals the end of options!
+
+    // errors:
+    EXPECT_THROW(parser.is_option_set("l"), seqan3::design_error); // short identifiers are passed as chars not strings
+    EXPECT_THROW(parser.is_option_set("f"), seqan3::design_error); // short identifiers are passed as chars not strings
+
+    EXPECT_THROW(parser.is_option_set("foo"), seqan3::design_error);
+    EXPECT_THROW(parser.is_option_set("--"), seqan3::design_error);
+    EXPECT_THROW(parser.is_option_set(""), seqan3::design_error);
+
+    EXPECT_THROW(parser.is_option_set('!'), seqan3::design_error);
+    EXPECT_THROW(parser.is_option_set('-'), seqan3::design_error);
+    EXPECT_THROW(parser.is_option_set('_'), seqan3::design_error);
+    EXPECT_THROW(parser.is_option_set('\0'), seqan3::design_error);
+}


### PR DESCRIPTION
Fixes #1741 

Current look:

```cpp
int main(int argc, char ** argv)
{
    int i{5}; // default
    seqan3::argument_parser parser{"test_parser", argc, argv};
    // parser.add_option(i, 'f', "foo", "description");
    // parser.parse(); 
    // return parser.option_overwritten('f');
    // return parser.default_overwritten('f');
    // return parser.default_overwridden('f');
    // return parser.overwritten_by_user('f');
    // return parser.overwritten_on_cmd('f');
    // return parser.option_is_set('f'); // tloka's fav
    return parser.is_option_set('f');
    // return parser.option_is_set_by_user('f');
    // return parser.option_is_set_on_cmd('f');
    // return parser.set_by_user('f');
}
```

```cpp
int main(int argc, char ** argv)
{
    std::optional<int> i{std::nullopt}; // default

    seqan3::argument_parser parser{"test_parser", argc, argv};
    parser.add_option(i, 'f', "foo", "Default is computed.");
    parser.parse(); 

    return i.has_value();
}
```


would return 1 if called with `./test_parser -f 1`
would return 0 if called with `./test_parser -g 1`

There are open design questions:
1. Naming: `option_was_set`, `option_is_set`, `is_set`, `was_set`, `option_is_overwritten` ... suggestions?
2. By design, this function **could** be called without the necessity of
  (a) a respective option was added (`parser.add_option('f', ...)`)
  (b) `parser.parse()` was called and all options values were parsed
  Do we want to allow this? We can easily introduce these semantic requirements. 

**Resolution**: `parser.is_option_set`

The function will return an enum that can be implicitly cast to bool.

