### PR TITLE
Rename concepts to be standard conform 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,11 @@ Note that 3.1.0 will be the first API stable release and interfaces in this rele
 
 ## API changes
 
+* In accordance with the standard, the following concepts are renamed:
+  * `default_constructible` to `default_initializable`
+  * `readable` to `indirectly_readable`
+  * `writable` to `indirectly_writable` ([\#1860](https://github.com/seqan/seqan3/pull/1860)).
+
 #### Range
 
 * The `seqan3::begin()`, `seqan3::end()`, `seqan3::cbegin()`, `seqan3::cend()`, `seqan3::size()`, `seqan3::empty()`

--- a/doc/howto/write_a_view/index.md
+++ b/doc/howto/write_a_view/index.md
@@ -362,7 +362,7 @@ the same as of the underlying range, we just pass it through.
 
 For many more complex views you will have to define the sentinel type yourself or derive it from the underlying
 type in a similar manner to how we derived the iterator type.
-Often you can use `std::ranges::default_sentinel_t` as the type for your sentinel and implement the
+Often you can use `std::default_sentinel_t` as the type for your sentinel and implement the
 "end-condition" in the iterator's equality comparison operator against that type.
 
 \snippet doc/howto/write_a_view/solution_view.cpp view_constructors

--- a/doc/howto/write_a_view/solution_view.cpp
+++ b/doc/howto/write_a_view/solution_view.cpp
@@ -133,7 +133,7 @@ public:
 //![view_deduction_guide]
 // A deduction guide for the view class template
 template <std::ranges::viewable_range orng_t>
-my_view(orng_t &&) -> my_view<std::ranges::all_view<orng_t>>;
+my_view(orng_t &&) -> my_view<std::views::all_t<orng_t>>;
 //![view_deduction_guide]
 
 //![adaptor_type_definition]

--- a/doc/tutorial/argument_parser/solution3.cpp
+++ b/doc/tutorial/argument_parser/solution3.cpp
@@ -17,7 +17,7 @@ number_type to_number(range_type && range)
 {
     std::string str;
     number_type num;
-    std::ranges::copy(range, std::ranges::back_inserter(str));
+    std::ranges::copy(range, std::cpp20::back_inserter(str));
     auto res = std::from_chars(&str[0], &str[0] + str.size(), num);
 
     if (res.ec != std::errc{})

--- a/doc/tutorial/argument_parser/solution4.cpp
+++ b/doc/tutorial/argument_parser/solution4.cpp
@@ -16,7 +16,7 @@ number_type to_number(range_type && range)
 {
     std::string str;
     number_type num;
-    std::ranges::copy(range, std::ranges::back_inserter(str));
+    std::ranges::copy(range, std::cpp20::back_inserter(str));
     auto res = std::from_chars(&str[0], &str[0] + str.size(), num);
 
     if (res.ec != std::errc{})

--- a/doc/tutorial/argument_parser/solution5.cpp
+++ b/doc/tutorial/argument_parser/solution5.cpp
@@ -16,7 +16,7 @@ number_type to_number(range_type && range)
 {
     std::string str;
     number_type num;
-    std::ranges::copy(range, std::ranges::back_inserter(str));
+    std::ranges::copy(range, std::cpp20::back_inserter(str));
     auto res = std::from_chars(&str[0], &str[0] + str.size(), num);
 
     if (res.ec != std::errc{})

--- a/doc/tutorial/argument_parser/solution6.cpp
+++ b/doc/tutorial/argument_parser/solution6.cpp
@@ -16,7 +16,7 @@ number_type to_number(range_type && range)
 {
     std::string str;
     number_type num;
-    std::ranges::copy(range, std::ranges::back_inserter(str));
+    std::ranges::copy(range, std::cpp20::back_inserter(str));
     auto res = std::from_chars(&str[0], &str[0] + str.size(), num);
 
     if (res.ec != std::errc{})

--- a/doc/tutorial/sequence_file/sequence_file_solution2.cpp
+++ b/doc/tutorial/sequence_file/sequence_file_solution2.cpp
@@ -57,7 +57,7 @@ int main()
     // }
 
     // But you can also do this:
-    std::ranges::copy(fin, std::ranges::back_inserter(records));
+    std::ranges::copy(fin, std::cpp20::back_inserter(records));
 
     seqan3::debug_stream << records << '\n';
 }

--- a/include/seqan3/alignment/matrix/detail/alignment_matrix_column_major_range_base.hpp
+++ b/include/seqan3/alignment/matrix/detail/alignment_matrix_column_major_range_base.hpp
@@ -368,26 +368,26 @@ private:
          * \{
          */
         //!\brief Returns `true` if the behind-the-end column was reached, `false` otherwise.
-        constexpr bool operator==(std::ranges::default_sentinel_t const &) const noexcept
+        constexpr bool operator==(std::default_sentinel_t const &) const noexcept
         {
             return column_index == me_ptr->num_cols;
         }
 
         //!\copydoc operator==
-        friend constexpr bool operator==(std::ranges::default_sentinel_t const & lhs, iterator_type const & rhs)
+        friend constexpr bool operator==(std::default_sentinel_t const & lhs, iterator_type const & rhs)
             noexcept
         {
             return rhs == lhs;
         }
 
         //!\brief Returns `true` if the behind-the-end column was not reached, `false` otherwise.
-        constexpr bool operator!=(std::ranges::default_sentinel_t const & rhs) const noexcept
+        constexpr bool operator!=(std::default_sentinel_t const & rhs) const noexcept
         {
             return !(*this == rhs);
         }
 
         //!\copydoc operator!=
-        friend constexpr bool operator!=(std::ranges::default_sentinel_t const & lhs, iterator_type const & rhs)
+        friend constexpr bool operator!=(std::default_sentinel_t const & lhs, iterator_type const & rhs)
             noexcept
         {
             return rhs != lhs;
@@ -488,7 +488,7 @@ private:
     //!\brief The type of the iterator.
     using iterator = iterator_type;
     //!\brief The type of sentinel.
-    using sentinel = std::ranges::default_sentinel_t;
+    using sentinel = std::default_sentinel_t;
 
 public:
     /*!\name Iterators

--- a/include/seqan3/alignment/matrix/detail/alignment_matrix_column_major_range_base.hpp
+++ b/include/seqan3/alignment/matrix/detail/alignment_matrix_column_major_range_base.hpp
@@ -510,7 +510,7 @@ public:
     //!\brief Returns a sentinel marking the end of the matrix.
     constexpr sentinel end() noexcept
     {
-        return std::ranges::default_sentinel;
+        return std::default_sentinel;
     }
 
     //!\brief Deleted end for const-qualified alignment matrix.

--- a/include/seqan3/alignment/matrix/detail/alignment_trace_matrix_full.hpp
+++ b/include/seqan3/alignment/matrix/detail/alignment_trace_matrix_full.hpp
@@ -149,7 +149,7 @@ public:
             throw std::invalid_argument{"The given coordinate exceeds the matrix in vertical or horizontal direction."};
 
         return path_t{trace_iterator_t{matrix_base_t::data.begin() + matrix_offset{trace_begin}},
-                      std::ranges::default_sentinel};
+                      std::default_sentinel};
     }
 
 private:

--- a/include/seqan3/alignment/matrix/detail/alignment_trace_matrix_full.hpp
+++ b/include/seqan3/alignment/matrix/detail/alignment_trace_matrix_full.hpp
@@ -143,7 +143,7 @@ public:
 
         using matrix_iter_t = std::ranges::iterator_t<typename matrix_base_t::pool_type>;
         using trace_iterator_t = trace_iterator<matrix_iter_t>;
-        using path_t = std::ranges::subrange<trace_iterator_t, std::ranges::default_sentinel_t>;
+        using path_t = std::ranges::subrange<trace_iterator_t, std::default_sentinel_t>;
 
         if (trace_begin.row >= matrix_base_t::num_rows || trace_begin.col >= matrix_base_t::num_cols)
             throw std::invalid_argument{"The given coordinate exceeds the matrix in vertical or horizontal direction."};

--- a/include/seqan3/alignment/matrix/detail/alignment_trace_matrix_full_banded.hpp
+++ b/include/seqan3/alignment/matrix/detail/alignment_trace_matrix_full_banded.hpp
@@ -161,7 +161,7 @@ public:
 
         return path_t{trace_iterator_t{matrix_base_t::data.begin() + matrix_offset{trace_begin},
                                        column_index_type{band_col_index}},
-                      std::ranges::default_sentinel};
+                      std::default_sentinel};
     }
 
     //!\brief The column index where the upper bound of the band passes through.

--- a/include/seqan3/alignment/matrix/detail/alignment_trace_matrix_full_banded.hpp
+++ b/include/seqan3/alignment/matrix/detail/alignment_trace_matrix_full_banded.hpp
@@ -154,7 +154,7 @@ public:
 
         using matrix_iter_t = std::ranges::iterator_t<typename matrix_base_t::pool_type>;
         using trace_iterator_t = trace_iterator_banded<matrix_iter_t>;
-        using path_t = std::ranges::subrange<trace_iterator_t, std::ranges::default_sentinel_t>;
+        using path_t = std::ranges::subrange<trace_iterator_t, std::default_sentinel_t>;
 
         if (trace_begin.row >= static_cast<size_t>(band_size) || trace_begin.col >= matrix_base_t::num_cols)
             throw std::invalid_argument{"The given coordinate exceeds the trace matrix size."};

--- a/include/seqan3/alignment/matrix/detail/trace_iterator_base.hpp
+++ b/include/seqan3/alignment/matrix/detail/trace_iterator_base.hpp
@@ -207,7 +207,7 @@ public:
     //!\brief copydoc operator==()
     constexpr friend bool operator==(std::default_sentinel_t const &, derived_t const & rhs) noexcept
     {
-        return rhs == std::ranges::default_sentinel;
+        return rhs == std::default_sentinel;
     }
 
     //!\brief Returns `true` if both iterators are not equal, `false` otherwise.
@@ -219,13 +219,13 @@ public:
     //!\brief Returns `true` if the pointed-to-element is not seqan3::detail::trace_directions::none.
     constexpr friend bool operator!=(derived_t const & lhs, std::default_sentinel_t const &) noexcept
     {
-        return !(lhs == std::ranges::default_sentinel);
+        return !(lhs == std::default_sentinel);
     }
 
     //!\brief copydoc operator!=()
     constexpr friend bool operator!=(std::default_sentinel_t const &, derived_t const & rhs) noexcept
     {
-        return !(rhs == std::ranges::default_sentinel);
+        return !(rhs == std::default_sentinel);
     }
     //!\}
 

--- a/include/seqan3/alignment/matrix/detail/trace_iterator_base.hpp
+++ b/include/seqan3/alignment/matrix/detail/trace_iterator_base.hpp
@@ -199,13 +199,13 @@ public:
     }
 
     //!\brief Returns `true` if the pointed-to-element is seqan3::detail::trace_directions::none.
-    constexpr friend bool operator==(derived_t const & lhs, std::ranges::default_sentinel_t const &) noexcept
+    constexpr friend bool operator==(derived_t const & lhs, std::default_sentinel_t const &) noexcept
     {
         return *lhs.matrix_iter == trace_directions::none;
     }
 
     //!\brief copydoc operator==()
-    constexpr friend bool operator==(std::ranges::default_sentinel_t const &, derived_t const & rhs) noexcept
+    constexpr friend bool operator==(std::default_sentinel_t const &, derived_t const & rhs) noexcept
     {
         return rhs == std::ranges::default_sentinel;
     }
@@ -217,13 +217,13 @@ public:
     }
 
     //!\brief Returns `true` if the pointed-to-element is not seqan3::detail::trace_directions::none.
-    constexpr friend bool operator!=(derived_t const & lhs, std::ranges::default_sentinel_t const &) noexcept
+    constexpr friend bool operator!=(derived_t const & lhs, std::default_sentinel_t const &) noexcept
     {
         return !(lhs == std::ranges::default_sentinel);
     }
 
     //!\brief copydoc operator!=()
-    constexpr friend bool operator!=(std::ranges::default_sentinel_t const &, derived_t const & rhs) noexcept
+    constexpr friend bool operator!=(std::default_sentinel_t const &, derived_t const & rhs) noexcept
     {
         return !(rhs == std::ranges::default_sentinel);
     }

--- a/include/seqan3/alignment/pairwise/alignment_range.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_range.hpp
@@ -109,7 +109,7 @@ public:
      */
     constexpr std::default_sentinel_t end() noexcept
     {
-        return std::ranges::default_sentinel;
+        return std::default_sentinel;
     }
 
     //!\brief This range is not const-iterable.

--- a/include/seqan3/alignment/pairwise/alignment_range.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_range.hpp
@@ -107,13 +107,13 @@ public:
      * The alignment range is an input range and the end is reached when the internal buffer over the alignment
      * results has signaled end-of-stream.
      */
-    constexpr std::ranges::default_sentinel_t end() noexcept
+    constexpr std::default_sentinel_t end() noexcept
     {
         return std::ranges::default_sentinel;
     }
 
     //!\brief This range is not const-iterable.
-    constexpr std::ranges::default_sentinel_t end() const = delete;
+    constexpr std::default_sentinel_t end() const = delete;
     //!\}
 
 protected:
@@ -235,13 +235,13 @@ public:
      */
     //!\brief Checks whether lhs is equal to the sentinel.
     friend constexpr bool operator==(alignment_range_iterator const & lhs,
-                                     std::ranges::default_sentinel_t const &) noexcept
+                                     std::default_sentinel_t const &) noexcept
     {
         return lhs.at_end;
     }
 
     //!\brief Checks whether `lhs` is equal to `rhs`.
-    friend constexpr bool operator==(std::ranges::default_sentinel_t const & lhs,
+    friend constexpr bool operator==(std::default_sentinel_t const & lhs,
                                      alignment_range_iterator const & rhs) noexcept
     {
         return rhs == lhs;
@@ -249,13 +249,13 @@ public:
 
     //!\brief Checks whether `*this` is not equal to the sentinel.
     friend constexpr bool operator!=(alignment_range_iterator const & lhs,
-                                     std::ranges::default_sentinel_t const & rhs) noexcept
+                                     std::default_sentinel_t const & rhs) noexcept
     {
         return !(lhs == rhs);
     }
 
     //!\brief Checks whether `lhs` is not equal to `rhs`.
-    friend constexpr bool operator!=(std::ranges::default_sentinel_t const & lhs,
+    friend constexpr bool operator!=(std::default_sentinel_t const & lhs,
                                      alignment_range_iterator const & rhs) noexcept
     {
         return rhs != lhs;

--- a/include/seqan3/argument_parser/detail/format_help.hpp
+++ b/include/seqan3/argument_parser/detail/format_help.hpp
@@ -375,7 +375,7 @@ protected:
         std::istringstream iss(text.c_str());
         std::vector<std::string> tokens;
         std::ranges::copy(std::istream_iterator<std::string>(iss), std::istream_iterator<std::string>(),
-                          std::ranges::back_inserter(tokens));
+                          std::cpp20::back_inserter(tokens));
 
         // Print the text.
         assert(pos <= tab);

--- a/include/seqan3/argument_parser/validators.hpp
+++ b/include/seqan3/argument_parser/validators.hpp
@@ -201,7 +201,7 @@ public:
     value_list_validator(range_type rng)
     {
         values.clear();
-        std::ranges::move(std::move(rng), std::ranges::back_inserter(values));
+        std::ranges::move(std::move(rng), std::cpp20::back_inserter(values));
     }
 
     /*!\brief Constructing from a parameter pack.

--- a/include/seqan3/core/algorithm/detail/algorithm_executor_blocking.hpp
+++ b/include/seqan3/core/algorithm/detail/algorithm_executor_blocking.hpp
@@ -68,7 +68,7 @@ private:
      * \{
      */
     //!\brief The underlying resource type.
-    using resource_type = std::ranges::all_view<resource_t>;
+    using resource_type = std::views::all_t<resource_t>;
     //!\brief The iterator over the underlying resource.
     using resource_iterator_type = std::ranges::iterator_t<resource_type>;
     //!\}

--- a/include/seqan3/core/detail/pack_algorithm.hpp
+++ b/include/seqan3/core/detail/pack_algorithm.hpp
@@ -132,7 +132,7 @@ constexpr bool all_of(unary_predicate_t && fn, pack_t && ...args)
  *  * call the parameter pack version of seqan3::detail::all_of with the instances of std::identity (as a pack).
  *
  * Note that wrapping the types in std::type_identity is a technical trick to make a type representable as a value.
- * Instantiating a type might not work because they might not be std::default_constructible.
+ * Instantiating a type might not work because they might not be std::default_initializable.
  * In addition it is possible, to invoke the predicate on incomplete types.
  *
  * ### Example
@@ -216,7 +216,7 @@ constexpr void for_each(unary_function_t && fn, pack_t && ...args)
  *  * call the parameter pack version of seqan3::detail::for_each with the instances of std::identity (as a pack).
  *
  * Note that wrapping the types in std::type_identity is a technical trick to make a type representable as a value.
- * Instantiating a type might not work because they might not be std::default_constructible.
+ * Instantiating a type might not work because they might not be std::default_initializable.
  * In addition, it is possible to invoke the unary function on incomplete types.
  *
  * ### Example

--- a/include/seqan3/core/simd/view_to_simd.hpp
+++ b/include/seqan3/core/simd/view_to_simd.hpp
@@ -157,7 +157,7 @@ public:
     //!\brief A sentinel representing the end of this range.
     constexpr std::default_sentinel_t end() noexcept
     {
-        return std::ranges::default_sentinel;
+        return std::default_sentinel;
     }
 
     //!\brief Const iteration is disabled.

--- a/include/seqan3/core/simd/view_to_simd.hpp
+++ b/include/seqan3/core/simd/view_to_simd.hpp
@@ -155,7 +155,7 @@ public:
     constexpr void cbegin() const noexcept = delete;
 
     //!\brief A sentinel representing the end of this range.
-    constexpr std::ranges::default_sentinel_t end() noexcept
+    constexpr std::default_sentinel_t end() noexcept
     {
         return std::ranges::default_sentinel;
     }
@@ -316,25 +316,25 @@ public:
      * \{
      */
     //!\brief Returns `true` if iterator reached the end, otherwise `false`.
-    constexpr bool operator==(std::ranges::default_sentinel_t const &) const noexcept
+    constexpr bool operator==(std::default_sentinel_t const &) const noexcept
     {
         return at_end;
     }
 
     //!\copydoc seqan3::detail::view_to_simd::iterator_type::operator==
-    friend constexpr bool operator==(std::ranges::default_sentinel_t const &, iterator_type const & rhs) noexcept
+    friend constexpr bool operator==(std::default_sentinel_t const &, iterator_type const & rhs) noexcept
     {
         return rhs.at_end;
     }
 
     //!\brief Returns `true` if iterator did not reach the end yet, otherwise `false`.
-    constexpr bool operator!=(std::ranges::default_sentinel_t const &) const noexcept
+    constexpr bool operator!=(std::default_sentinel_t const &) const noexcept
     {
         return !at_end;
     }
 
     //!\copydoc seqan3::detail::view_to_simd::iterator_type::operator!=
-    friend constexpr bool operator!=(std::ranges::default_sentinel_t const &, iterator_type const & rhs) noexcept
+    friend constexpr bool operator!=(std::default_sentinel_t const &, iterator_type const & rhs) noexcept
     {
         return !rhs.at_end;
     }

--- a/include/seqan3/core/simd/view_to_simd.hpp
+++ b/include/seqan3/core/simd/view_to_simd.hpp
@@ -64,7 +64,7 @@ private:
                   "The underlying range must model forward_range.");
     static_assert(std::ranges::input_range<std::ranges::range_value_t<urng_t>>,
                   "Expects the value type of the underlying range to be an input_range.");
-    static_assert(std::default_constructible<std::ranges::range_value_t<urng_t>>,
+    static_assert(std::default_initializable<std::ranges::range_value_t<urng_t>>,
                   "Expects the inner range to be default constructible.");
     static_assert(semialphabet<std::ranges::range_value_t<std::ranges::range_value_t<urng_t>>>,
                   "Expects semi-alphabet as value type of the inner range.");
@@ -723,7 +723,7 @@ namespace seqan3::views
  *
  * * `urng_t` is the type of the range modified by this view (input).
  * * the expression `std::ranges::input_range<std::ranges::range_value_t<urng_t>` must evaluate to `true`
- * * the expression `std::default_constructible<std::ranges::range_value_t<urng_t>>` must evaluate to `true`
+ * * the expression `std::default_initializable<std::ranges::range_value_t<urng_t>>` must evaluate to `true`
  * * the expression `semialphabet<std::ranges::range_value_t<std::ranges::range_value_t<urng_t>>>` must evaluate to `true`
  * * `rrng_type` is the type of the range returned by this view.
  * * for more details, see \ref views.

--- a/include/seqan3/io/alignment_file/format_sam_base.hpp
+++ b/include/seqan3/io/alignment_file/format_sam_base.hpp
@@ -372,7 +372,7 @@ inline void format_sam_base::read_field(stream_view_type && stream_view, target_
 {
     if (!is_char<'*'>(*std::ranges::begin(stream_view)))
         std::ranges::copy(stream_view | views::char_to<std::ranges::range_value_t<target_range_type>>,
-                          std::ranges::back_inserter(target));
+                          std::cpp20::back_inserter(target));
     else
         std::ranges::next(std::ranges::begin(stream_view)); // skip '*'
 }

--- a/include/seqan3/io/alignment_file/input.hpp
+++ b/include/seqan3/io/alignment_file/input.hpp
@@ -541,7 +541,7 @@ public:
     //!\brief The const iterator type is void because files are not const-iterable.
     using const_iterator    = void;
     //!\brief The type returned by end().
-    using sentinel          = std::ranges::default_sentinel_t;
+    using sentinel          = std::default_sentinel_t;
     //!\}
 
     /*!\name Constructors, destructor and assignment

--- a/include/seqan3/io/alignment_file/output.hpp
+++ b/include/seqan3/io/alignment_file/output.hpp
@@ -223,7 +223,7 @@ public:
     //!\brief The const iterator type is void, because files are not const-iterable.
     using const_iterator    = void;
     //!\brief The type returned by end().
-    using sentinel          = std::ranges::default_sentinel_t;
+    using sentinel          = std::default_sentinel_t;
     //!\}
 
     /*!\name Constructors, destructor and assignment

--- a/include/seqan3/io/detail/in_file_iterator.hpp
+++ b/include/seqan3/io/detail/in_file_iterator.hpp
@@ -144,14 +144,14 @@ public:
     constexpr friend bool operator==(std::default_sentinel_t const &,
                                      in_file_iterator const & it) noexcept
     {
-        return (it == std::ranges::default_sentinel);
+        return (it == std::default_sentinel);
     }
 
     //!\brief Checks whether `it` is not equal to the sentinel.
     constexpr friend bool operator!=(std::default_sentinel_t const &,
                                      in_file_iterator const & it) noexcept
     {
-        return (it != std::ranges::default_sentinel);
+        return (it != std::default_sentinel);
     }
     //!\}
 

--- a/include/seqan3/io/detail/in_file_iterator.hpp
+++ b/include/seqan3/io/detail/in_file_iterator.hpp
@@ -36,7 +36,7 @@ namespace seqan3::detail
  * previous iterators are always invalid (all iterators point to the current position in single-pass
  * ranges).
  *
- * This iterator may be compared against std::ranges::default_sentinel_t, this check delegates to
+ * This iterator may be compared against std::default_sentinel_t, this check delegates to
  * calling the `eof()` member function on the file's stream.
  */
 template <typename file_type>
@@ -127,28 +127,28 @@ public:
      */
 
     //!\brief Checks whether `*this` is equal to the sentinel.
-    constexpr bool operator==(std::ranges::default_sentinel_t const &) const noexcept
+    constexpr bool operator==(std::default_sentinel_t const &) const noexcept
     {
         assert(host != nullptr);
         return host->at_end;
     }
 
     //!\brief Checks whether `*this` is not equal to the sentinel.
-    constexpr bool operator!=(std::ranges::default_sentinel_t const &) const noexcept
+    constexpr bool operator!=(std::default_sentinel_t const &) const noexcept
     {
         assert(host != nullptr);
         return !host->at_end;
     }
 
     //!\brief Checks whether `it` is equal to the sentinel.
-    constexpr friend bool operator==(std::ranges::default_sentinel_t const &,
+    constexpr friend bool operator==(std::default_sentinel_t const &,
                                      in_file_iterator const & it) noexcept
     {
         return (it == std::ranges::default_sentinel);
     }
 
     //!\brief Checks whether `it` is not equal to the sentinel.
-    constexpr friend bool operator!=(std::ranges::default_sentinel_t const &,
+    constexpr friend bool operator!=(std::default_sentinel_t const &,
                                      in_file_iterator const & it) noexcept
     {
         return (it != std::ranges::default_sentinel);

--- a/include/seqan3/io/detail/misc.hpp
+++ b/include/seqan3/io/detail/misc.hpp
@@ -149,7 +149,7 @@ inline std::vector<std::string> valid_file_extensions()
     detail::for_each<formats_t>([&extensions] (auto t_identity)
     {
         using format_t = typename decltype(t_identity)::type;
-        std::ranges::copy(format_t::file_extensions, std::ranges::back_inserter(extensions));
+        std::ranges::copy(format_t::file_extensions, std::cpp20::back_inserter(extensions));
     });
 
     return extensions;

--- a/include/seqan3/io/detail/out_file_iterator.hpp
+++ b/include/seqan3/io/detail/out_file_iterator.hpp
@@ -36,14 +36,14 @@ namespace seqan3::detail
  * specific file's constraints and is not checked by the iterator.
  *
  * The increment operations are no-ops (perform nothing) and comparisons against
- * std::ranges::default_sentinel always return false (there is no end in an output file).
+ * std::default_sentinel always return false (there is no end in an output file).
  *
  * If any of these characteristics seem unusual to you, please refer to the [standard library's
  * documentation on output iterators](https://en.cppreference.com/w/cpp/concept/output_iterator).
  *
  * This class template differs from std::back_insert_iterator only in that it performs
  * no checks itself on the assigned values and that it allows comparisons against
- * std::ranges::default_sentinel.
+ * std::default_sentinel.
  */
 template <typename file_type>
 class out_file_iterator
@@ -150,14 +150,14 @@ public:
     constexpr friend bool operator==(std::default_sentinel_t const &,
                                      out_file_iterator const & it) noexcept
     {
-        return (it == std::ranges::default_sentinel);
+        return (it == std::default_sentinel);
     }
 
     //!\brief Checks whether `it` is not equal to the sentinel.
     constexpr friend bool operator!=(std::default_sentinel_t const &,
                                      out_file_iterator const & it) noexcept
     {
-        return (it != std::ranges::default_sentinel);
+        return (it != std::default_sentinel);
     }
     //!\}
 

--- a/include/seqan3/io/detail/out_file_iterator.hpp
+++ b/include/seqan3/io/detail/out_file_iterator.hpp
@@ -135,26 +135,26 @@ public:
      */
 
     //!\brief Checks whether `*this` is equal to the sentinel (always false).
-    constexpr bool operator==(std::ranges::default_sentinel_t const &) const noexcept
+    constexpr bool operator==(std::default_sentinel_t const &) const noexcept
     {
         return false;
     }
 
     //!\brief Checks whether `*this` is not equal to the sentinel (always true).
-    constexpr bool operator!=(std::ranges::default_sentinel_t const &) const noexcept
+    constexpr bool operator!=(std::default_sentinel_t const &) const noexcept
     {
         return true;
     }
 
     //!\brief Checks whether `it` is equal to the sentinel.
-    constexpr friend bool operator==(std::ranges::default_sentinel_t const &,
+    constexpr friend bool operator==(std::default_sentinel_t const &,
                                      out_file_iterator const & it) noexcept
     {
         return (it == std::ranges::default_sentinel);
     }
 
     //!\brief Checks whether `it` is not equal to the sentinel.
-    constexpr friend bool operator!=(std::ranges::default_sentinel_t const &,
+    constexpr friend bool operator!=(std::default_sentinel_t const &,
                                      out_file_iterator const & it) noexcept
     {
         return (it != std::ranges::default_sentinel);

--- a/include/seqan3/io/sequence_file/format_embl.hpp
+++ b/include/seqan3/io/sequence_file/format_embl.hpp
@@ -105,7 +105,7 @@ protected:
 
         std::string idbuffer;
         std::ranges::copy(stream_view | views::take_until_or_throw(is_cntrl || is_blank),
-                          std::ranges::back_inserter(idbuffer));
+                          std::cpp20::back_inserter(idbuffer));
         if (idbuffer != "ID")
             throw parse_error{"An entry has to start with the code word ID."};
 
@@ -113,12 +113,12 @@ protected:
         {
             if (options.embl_genbank_complete_header)
             {
-                std::ranges::copy(idbuffer | views::char_to<std::ranges::range_value_t<id_type>>, std::ranges::back_inserter(id));
+                std::ranges::copy(idbuffer | views::char_to<std::ranges::range_value_t<id_type>>, std::cpp20::back_inserter(id));
                 do
                 {
                     std::ranges::copy(stream_view | views::take_until_or_throw(is_char<'S'>)
                                                   | views::char_to<std::ranges::range_value_t<id_type>>,
-                                 std::ranges::back_inserter(id));
+                                 std::cpp20::back_inserter(id));
                     id.push_back(*stream_it);
                     ++stream_it;
                 } while (*stream_it != 'Q');
@@ -135,13 +135,13 @@ protected:
                 {
                     std::ranges::copy(stream_view | views::take_until_or_throw(is_blank || is_char<';'> || is_cntrl)
                                                   | views::char_to<std::ranges::range_value_t<id_type>>,
-                                 std::ranges::back_inserter(id));
+                                 std::cpp20::back_inserter(id));
                 }
                 else
                 {
                     std::ranges::copy(stream_view | views::take_until_or_throw(is_char<';'>)
                                                   | views::char_to<std::ranges::range_value_t<id_type>>,
-                                 std::ranges::back_inserter(id));
+                                 std::cpp20::back_inserter(id));
                 }
             }
         }
@@ -177,7 +177,7 @@ protected:
                                         return c;
                                     })
                                   | views::char_to<std::ranges::range_value_t<seq_type>>,         // convert to actual target alphabet
-                         std::ranges::back_inserter(sequence));
+                         std::cpp20::back_inserter(sequence));
         }
         else
         {

--- a/include/seqan3/io/sequence_file/format_fasta.hpp
+++ b/include/seqan3/io/sequence_file/format_fasta.hpp
@@ -213,7 +213,7 @@ private:
                 std::ranges::copy(stream_view | std::views::drop_while(is_id || is_blank)        // skip leading >
                                               | views::take_until_or_throw(is_cntrl || is_blank) // read ID until delimiter…
                                               | views::char_to<std::ranges::range_value_t<id_type>>,
-                                  std::ranges::back_inserter(id));                               // … ^A is old delimiter
+                                  std::cpp20::back_inserter(id));                               // … ^A is old delimiter
 
                 // consume rest of line
                 detail::consume(stream_view | views::take_line_or_throw);
@@ -247,7 +247,7 @@ private:
                 std::ranges::copy(stream_view | views::take_line_or_throw                    // read line
                                               | std::views::drop_while(is_id || is_blank)    // skip leading >
                                               | views::char_to<std::ranges::range_value_t<id_type>>,
-                                  std::ranges::back_inserter(id));
+                                  std::cpp20::back_inserter(id));
             #endif // SEQAN3_WORKAROUND_VIEW_PERFORMANCE
             }
         }
@@ -305,7 +305,7 @@ private:
                                                 return c;
                                             })                                      // enforce legal alphabet
                                           | views::char_to<std::ranges::range_value_t<seq_type>>, // convert to actual target alphabet
-                              std::ranges::back_inserter(seq));
+                              std::cpp20::back_inserter(seq));
         #endif // SEQAN3_WORKAROUND_VIEW_PERFORMANCE
         }
         else

--- a/include/seqan3/io/sequence_file/format_fastq.hpp
+++ b/include/seqan3/io/sequence_file/format_fastq.hpp
@@ -131,14 +131,14 @@ protected:
             {
                 std::ranges::copy(stream_view | views::take_until_or_throw(is_cntrl || is_blank)
                                               | views::char_to<std::ranges::range_value_t<id_type>>,
-                                  std::ranges::back_inserter(id));
+                                  std::cpp20::back_inserter(id));
                 detail::consume(stream_view | views::take_line_or_throw);
             }
             else
             {
                 std::ranges::copy(stream_view | views::take_line_or_throw
                                               | views::char_to<std::ranges::range_value_t<id_type>>,
-                                  std::ranges::back_inserter(id));
+                                  std::cpp20::back_inserter(id));
             }
         }
         else
@@ -164,7 +164,7 @@ protected:
                                         return c;
                                     })
                                         | views::char_to<std::ranges::range_value_t<seq_type>>,         // convert to actual target alphabet
-                              std::ranges::back_inserter(sequence));
+                              std::cpp20::back_inserter(sequence));
             sequence_size_after = size(sequence);
         }
         else // consume, but count
@@ -199,7 +199,7 @@ protected:
         else if constexpr (!detail::decays_to_ignore_v<qual_type>)
         {
             std::ranges::copy(qview | views::char_to<std::ranges::range_value_t<qual_type>>,
-                              std::ranges::back_inserter(qualities));
+                              std::cpp20::back_inserter(qualities));
         }
         else
         {

--- a/include/seqan3/io/sequence_file/format_genbank.hpp
+++ b/include/seqan3/io/sequence_file/format_genbank.hpp
@@ -115,13 +115,13 @@ protected:
         {
             if (options.embl_genbank_complete_header)
             {
-                std::ranges::copy(std::string_view{"LOCUS"}, std::ranges::back_inserter(id));
+                std::ranges::copy(std::string_view{"LOCUS"}, std::cpp20::back_inserter(id));
 
                 while (!is_char<'O'>(*std::ranges::begin(stream_view)))
                 {
                         std::ranges::copy(stream_view | views::take_line_or_throw
                                                       | views::char_to<std::ranges::range_value_t<id_type>>,
-                                                        std::ranges::back_inserter(id));
+                                                        std::cpp20::back_inserter(id));
                         id.push_back('\n');
                 }
             }
@@ -133,7 +133,7 @@ protected:
                 {
                     std::ranges::copy(stream_view | views::take_until_or_throw(predicate)
                                                   | views::char_to<std::ranges::range_value_t<id_type>>,
-                                      std::ranges::back_inserter(id));
+                                      std::cpp20::back_inserter(id));
                 };
 
                 if (options.truncate_ids)
@@ -169,7 +169,7 @@ protected:
                                                 return c;
                                             })
                                           | views::char_to<std::ranges::range_value_t<seq_type>>,    // convert to actual target alphabet
-                                            std::ranges::back_inserter(sequence));
+                                            std::cpp20::back_inserter(sequence));
         }
         else
         {

--- a/include/seqan3/io/sequence_file/input.hpp
+++ b/include/seqan3/io/sequence_file/input.hpp
@@ -398,7 +398,7 @@ public:
     //!\brief The const iterator type is void, because files are not const-iterable.
     using const_iterator    = void;
     //!\brief The type returned by end().
-    using sentinel          = std::ranges::default_sentinel_t;
+    using sentinel          = std::default_sentinel_t;
     //!\}
 
     /*!\name Constructors, destructor and assignment

--- a/include/seqan3/io/sequence_file/output.hpp
+++ b/include/seqan3/io/sequence_file/output.hpp
@@ -220,7 +220,7 @@ public:
     //!\brief The const iterator type is void, because files are not const-iterable.
     using const_iterator    = void;
     //!\brief The type returned by end().
-    using sentinel          = std::ranges::default_sentinel_t;
+    using sentinel          = std::default_sentinel_t;
     //!\}
 
     /*!\name Constructors, destructor and assignment

--- a/include/seqan3/io/stream/iterator.hpp
+++ b/include/seqan3/io/stream/iterator.hpp
@@ -148,7 +148,7 @@ public:
      * \{
      */
     //!\brief True if the read buffer is not empty; involves no vtable lookup.
-    friend bool operator==(fast_istreambuf_iterator const & lhs, std::ranges::default_sentinel_t const &) noexcept
+    friend bool operator==(fast_istreambuf_iterator const & lhs, std::default_sentinel_t const &) noexcept
     {
         assert(lhs.stream_buf != nullptr);
         // compare size of remaining buffer; since ++ always resizes if possible, safe to compare pointers here
@@ -156,19 +156,19 @@ public:
     }
 
     //!\brief True if the read buffer is empty; involves no vtable lookup.
-    friend bool operator!=(fast_istreambuf_iterator const & lhs, std::ranges::default_sentinel_t const &) noexcept
+    friend bool operator!=(fast_istreambuf_iterator const & lhs, std::default_sentinel_t const &) noexcept
     {
         return !(lhs == std::ranges::default_sentinel);
     }
 
     //!\brief True if the read buffer is not empty; involves no vtable lookup.
-    friend bool operator==(std::ranges::default_sentinel_t const &, fast_istreambuf_iterator const & rhs) noexcept
+    friend bool operator==(std::default_sentinel_t const &, fast_istreambuf_iterator const & rhs) noexcept
     {
         return rhs == std::ranges::default_sentinel;
     }
 
     //!\brief True if the read buffer is empty; involves no vtable lookup.
-    friend bool operator!=(std::ranges::default_sentinel_t const &, fast_istreambuf_iterator const & rhs) noexcept
+    friend bool operator!=(std::default_sentinel_t const &, fast_istreambuf_iterator const & rhs) noexcept
     {
         return !(rhs == std::ranges::default_sentinel);
     }

--- a/include/seqan3/io/stream/iterator.hpp
+++ b/include/seqan3/io/stream/iterator.hpp
@@ -158,19 +158,19 @@ public:
     //!\brief True if the read buffer is empty; involves no vtable lookup.
     friend bool operator!=(fast_istreambuf_iterator const & lhs, std::default_sentinel_t const &) noexcept
     {
-        return !(lhs == std::ranges::default_sentinel);
+        return !(lhs == std::default_sentinel);
     }
 
     //!\brief True if the read buffer is not empty; involves no vtable lookup.
     friend bool operator==(std::default_sentinel_t const &, fast_istreambuf_iterator const & rhs) noexcept
     {
-        return rhs == std::ranges::default_sentinel;
+        return rhs == std::default_sentinel;
     }
 
     //!\brief True if the read buffer is empty; involves no vtable lookup.
     friend bool operator!=(std::default_sentinel_t const &, fast_istreambuf_iterator const & rhs) noexcept
     {
-        return !(rhs == std::ranges::default_sentinel);
+        return !(rhs == std::default_sentinel);
     }
     //!\}
 };

--- a/include/seqan3/io/structure_file/format_vienna.hpp
+++ b/include/seqan3/io/structure_file/format_vienna.hpp
@@ -140,7 +140,7 @@ protected:
                     std::ranges::copy(stream_view | std::views::drop_while(is_id || is_blank) // skip leading >
                                                   | views::take_until_or_throw(is_cntrl || is_blank)
                                                   | views::char_to<std::ranges::range_value_t<id_type>>,
-                                      std::ranges::back_inserter(id));
+                                      std::cpp20::back_inserter(id));
                     detail::consume(stream_view | views::take_line_or_throw);
                 }
                 else
@@ -148,7 +148,7 @@ protected:
                     std::ranges::copy(stream_view | std::views::drop_while(is_id || is_blank) // skip leading >
                                                   | views::take_line_or_throw
                                                   | views::char_to<std::ranges::range_value_t<id_type>>,
-                                      std::ranges::back_inserter(id));
+                                      std::cpp20::back_inserter(id));
                 }
             }
             else
@@ -185,7 +185,7 @@ protected:
                                               return c;
                                             })
                                           | views::char_to<std::ranges::range_value_t<seq_type>>, // convert to actual target alphabet
-                              std::ranges::back_inserter(seq));
+                              std::cpp20::back_inserter(seq));
         }
         else
         {
@@ -211,7 +211,7 @@ protected:
             else
             {
                 using alph_type = std::ranges::range_value_t<structure_type>;
-                std::ranges::copy(read_structure<alph_type>(stream_view), std::ranges::back_inserter(structure));
+                std::ranges::copy(read_structure<alph_type>(stream_view), std::cpp20::back_inserter(structure));
                 structure_length = std::ranges::distance(structure);
 
                 if constexpr (!detail::decays_to_ignore_v<bpp_type>)

--- a/include/seqan3/io/structure_file/input.hpp
+++ b/include/seqan3/io/structure_file/input.hpp
@@ -568,7 +568,7 @@ public:
     //!\brief The const iterator type is void, because files are not const-iterable.
     using const_iterator  = void;
     //!\brief The type returned by end().
-    using sentinel        = std::ranges::default_sentinel_t;
+    using sentinel        = std::default_sentinel_t;
     //!\}
 
     /*!\name Constructors, destructor and assignment

--- a/include/seqan3/io/structure_file/output.hpp
+++ b/include/seqan3/io/structure_file/output.hpp
@@ -222,7 +222,7 @@ public:
     //!\brief The const iterator type is void, because files are not const-iterable.
     using const_iterator    = void;
     //!\brief The type returned by end().
-    using sentinel          = std::ranges::default_sentinel_t;
+    using sentinel          = std::default_sentinel_t;
     //!\}
 
     /*!\name Constructors, destructor and assignment

--- a/include/seqan3/range/detail/inherited_iterator_base.hpp
+++ b/include/seqan3/range/detail/inherited_iterator_base.hpp
@@ -322,7 +322,7 @@ public:
     //!\brief Dereference operator returns element currently pointed at.
     constexpr reference operator*() noexcept(noexcept(*std::declval<base_t &>()))
     //!\cond
-        requires std::readable<base_t>
+        requires std::indirectly_readable<base_t>
     //!\endcond
     {
         return **this_to_base();
@@ -331,7 +331,7 @@ public:
     //!\brief Dereference operator returns element currently pointed at.
     constexpr decltype(auto) operator*() const noexcept(noexcept(*std::declval<base_t const &>()))
     //!\cond
-        requires std::readable<base_t>
+        requires std::indirectly_readable<base_t>
     //!\endcond
     {
         return **this_to_base();

--- a/include/seqan3/range/views/async_input_buffer.hpp
+++ b/include/seqan3/range/views/async_input_buffer.hpp
@@ -155,7 +155,7 @@ public:
     //!\brief Returns a sentinel.
     std::default_sentinel_t end()
     {
-        return std::ranges::default_sentinel;
+        return std::default_sentinel;
     }
 
     //!\brief Const-qualified async_input_buffer_view::end() is deleted, because iterating changes the view.

--- a/include/seqan3/range/views/async_input_buffer.hpp
+++ b/include/seqan3/range/views/async_input_buffer.hpp
@@ -153,16 +153,16 @@ public:
     async_input_buffer_iterator cbegin() const = delete;
 
     //!\brief Returns a sentinel.
-    std::ranges::default_sentinel_t end()
+    std::default_sentinel_t end()
     {
         return std::ranges::default_sentinel;
     }
 
     //!\brief Const-qualified async_input_buffer_view::end() is deleted, because iterating changes the view.
-    std::ranges::default_sentinel_t end() const = delete;
+    std::default_sentinel_t end() const = delete;
 
     //!\copydoc async_input_buffer_view::end() const
-    std::ranges::default_sentinel_t cend() const = delete;
+    std::default_sentinel_t cend() const = delete;
     //!\}
 };
 
@@ -171,7 +171,7 @@ template <typename urng_t>
 class async_input_buffer_view<urng_t>::async_input_buffer_iterator
 {
     //!\brief The sentinel type to compare to.
-    using sentinel_type = std::ranges::default_sentinel_t;
+    using sentinel_type = std::default_sentinel_t;
 
     //!\brief The pointer to the associated view.
     contrib::fixed_buffer_queue<std::ranges::range_value_t<urng_t>> * buffer_ptr = nullptr;
@@ -267,30 +267,30 @@ public:
      */
     //!\brief Compares for equality with sentinel.
     friend constexpr bool operator==(async_input_buffer_iterator const & lhs,
-                                     std::ranges::default_sentinel_t const &) noexcept
+                                     std::default_sentinel_t const &) noexcept
     {
         return lhs.at_end;
     }
 
     //!\copydoc operator==
-    friend constexpr bool operator==(std::ranges::default_sentinel_t const &,
+    friend constexpr bool operator==(std::default_sentinel_t const &,
                                      async_input_buffer_iterator const & rhs) noexcept
     {
-        return rhs == std::ranges::default_sentinel_t{};
+        return rhs == std::default_sentinel_t{};
     }
 
     //!\brief Compares for inequality with sentinel.
     friend constexpr bool operator!=(async_input_buffer_iterator const & lhs,
-                                     std::ranges::default_sentinel_t const &) noexcept
+                                     std::default_sentinel_t const &) noexcept
     {
-        return !(lhs == std::ranges::default_sentinel_t{});
+        return !(lhs == std::default_sentinel_t{});
     }
 
     //!\copydoc operator!=
-    friend constexpr bool operator!=(std::ranges::default_sentinel_t const &,
+    friend constexpr bool operator!=(std::default_sentinel_t const &,
                                      async_input_buffer_iterator const & rhs) noexcept
     {
-        return rhs != std::ranges::default_sentinel_t{};
+        return rhs != std::default_sentinel_t{};
     }
     //!\}
 };

--- a/include/seqan3/range/views/async_input_buffer.hpp
+++ b/include/seqan3/range/views/async_input_buffer.hpp
@@ -302,7 +302,7 @@ public:
 
 //!\brief Deduces the async_input_buffer_view from the underlying range if it is a std::ranges::ViewableRange.
 template <std::ranges::viewable_range urng_t>
-async_input_buffer_view(urng_t &&, size_t const buffer_size) -> async_input_buffer_view<std::ranges::all_view<urng_t>>;
+async_input_buffer_view(urng_t &&, size_t const buffer_size) -> async_input_buffer_view<std::views::all_t<urng_t>>;
 //!\}
 
 // ============================================================================

--- a/include/seqan3/range/views/enforce_random_access.hpp
+++ b/include/seqan3/range/views/enforce_random_access.hpp
@@ -265,7 +265,7 @@ public:
  */
 //!\brief A deduction guide for the view class template.
 template <std::ranges::viewable_range rng_t>
-view_enforce_random_access(rng_t &&) -> view_enforce_random_access<std::ranges::all_view<rng_t>>;
+view_enforce_random_access(rng_t &&) -> view_enforce_random_access<std::views::all_t<rng_t>>;
 //!\}
 
 // ============================================================================

--- a/include/seqan3/range/views/istreambuf.hpp
+++ b/include/seqan3/range/views/istreambuf.hpp
@@ -33,23 +33,23 @@ struct istreambuf_fn
      * \param[in,out] s Reference to the stream buffer.
      * \tparam stream_char_t builtin_characteracter type of the stream device.
      * \tparam stream_traits_t Traits type of the stream device.
-     * \returns A std::ranges::subrange over a detail::fast_istreambuf_iterator and std::ranges::default_sentinel_t.
+     * \returns A std::ranges::subrange over a detail::fast_istreambuf_iterator and std::default_sentinel_t.
      */
     template <typename stream_char_t, typename stream_traits_t>
     constexpr auto operator()(std::basic_streambuf<stream_char_t, stream_traits_t> & s) const
     {
         return std::ranges::subrange<detail::fast_istreambuf_iterator<stream_char_t, stream_traits_t>,
-                                     std::ranges::default_sentinel_t>
+                                     std::default_sentinel_t>
         {
             detail::fast_istreambuf_iterator<stream_char_t, stream_traits_t>{s},
-            std::ranges::default_sentinel_t{}
+            std::default_sentinel_t{}
         };
     }
 
     /*!\brief Return the view object.
      * \tparam stream_t Type of the stream, must model seqan3::input_stream.
      * \param[in,out] s Reference to a stream object.
-     * \returns A std::ranges::subrange over a detail::fast_istreambuf_iterator and std::ranges::default_sentinel_t.
+     * \returns A std::ranges::subrange over a detail::fast_istreambuf_iterator and std::default_sentinel_t.
      */
     template <input_stream stream_t>
     constexpr auto operator()(stream_t & s) const

--- a/include/seqan3/range/views/kmer_hash.hpp
+++ b/include/seqan3/range/views/kmer_hash.hpp
@@ -643,7 +643,7 @@ private:
 
 //!\brief A deduction guide for the view class template.
 template <std::ranges::viewable_range rng_t>
-kmer_hash_view(rng_t &&, shape const & shape_) -> kmer_hash_view<std::ranges::all_view<rng_t>>;
+kmer_hash_view(rng_t &&, shape const & shape_) -> kmer_hash_view<std::views::all_t<rng_t>>;
 
 // ---------------------------------------------------------------------------------------------------------------------
 // kmer_hash_fn (adaptor definition)

--- a/include/seqan3/range/views/minimiser.hpp
+++ b/include/seqan3/range/views/minimiser.hpp
@@ -138,7 +138,7 @@ public:
      */
     auto end() const
     {
-        return std::ranges::default_sentinel;
+        return std::default_sentinel;
     }
 
     //!\copydoc end()

--- a/include/seqan3/range/views/minimiser.hpp
+++ b/include/seqan3/range/views/minimiser.hpp
@@ -160,7 +160,7 @@ private:
     //!\brief The sentinel type of the underlying range.
     using sentinel_t = std::ranges::sentinel_t<rng_t>;
     //!\brief The sentinel type of the minimiser_view.
-    using sentinel_type = std::ranges::default_sentinel_t;
+    using sentinel_type = std::default_sentinel_t;
 
     template <typename urng2_t>
     friend class window_iterator;

--- a/include/seqan3/range/views/minimiser.hpp
+++ b/include/seqan3/range/views/minimiser.hpp
@@ -385,7 +385,7 @@ private:
 
 //!\brief A deduction guide for the view class template.
 template <std::ranges::viewable_range rng_t>
-minimiser_view(rng_t &&, uint32_t const & window_values_size) -> minimiser_view<std::ranges::all_view<rng_t>>;
+minimiser_view(rng_t &&, uint32_t const & window_values_size) -> minimiser_view<std::views::all_t<rng_t>>;
 
 
 // ---------------------------------------------------------------------------------------------------------------------

--- a/include/seqan3/range/views/pairwise_combine.hpp
+++ b/include/seqan3/range/views/pairwise_combine.hpp
@@ -647,7 +647,7 @@ private:
 //!\brief Deduces the correct template type from a non-view lvalue range by wrapping the range in std::views::all.
 template <std::ranges::viewable_range other_range_t>
 pairwise_combine_view(other_range_t && range) ->
-    pairwise_combine_view<std::ranges::all_view<other_range_t>>;
+    pairwise_combine_view<std::views::all_t<other_range_t>>;
 //!\}
 
 } // namespace seqan3::detail

--- a/include/seqan3/range/views/repeat.hpp
+++ b/include/seqan3/range/views/repeat.hpp
@@ -47,8 +47,8 @@ private:
     //!/brief the base type.
     using base_t = std::ranges::view_interface<repeat_view<value_t>>;
 
-    //!\brief The sentinel type is set to std::ranges::default_sentinel_t.
-    using sentinel_type = std::ranges::default_sentinel_t;
+    //!\brief The sentinel type is set to std::default_sentinel_t.
+    using sentinel_type = std::default_sentinel_t;
 
     /*!\name Associated types
      * These associated types are needed in seqan3::detail::random_access_iterator.
@@ -123,26 +123,26 @@ private:
         using base_t::operator!=;
 
         //!\brief Equality comparison to the sentinel always returns false on an infinite view.
-        constexpr bool operator==(std::ranges::default_sentinel_t const &) const noexcept
+        constexpr bool operator==(std::default_sentinel_t const &) const noexcept
         {
             return false;
         }
 
         //!\brief Inequality comparison to the sentinel always returns true on an infinite view.
-        constexpr bool operator!=(std::ranges::default_sentinel_t const &) const noexcept
+        constexpr bool operator!=(std::default_sentinel_t const &) const noexcept
         {
             return true;
         }
 
         //!\brief Equality comparison to the sentinel always returns false on an infinite view.
-        friend constexpr bool operator==(std::ranges::default_sentinel_t const &,
+        friend constexpr bool operator==(std::default_sentinel_t const &,
                                          repeat_view_iterator const &) noexcept
         {
             return false;
         }
 
         //!\brief Inequality comparison to the sentinel always returns true on an infinite view.
-        friend constexpr bool operator!=(std::ranges::default_sentinel_t const &,
+        friend constexpr bool operator!=(std::default_sentinel_t const &,
                                          repeat_view_iterator const &) noexcept
         {
             return true;

--- a/include/seqan3/range/views/single_pass_input.hpp
+++ b/include/seqan3/range/views/single_pass_input.hpp
@@ -154,7 +154,7 @@ public:
 //!\brief Deduces the single_pass_input_view from the underlying range if it is a std::ranges::viewable_range.
 template <std::ranges::viewable_range urng_t>
 single_pass_input_view(urng_t &&) ->
-    single_pass_input_view<std::ranges::all_view<urng_t>>;
+    single_pass_input_view<std::views::all_t<urng_t>>;
 //!\}
 } // seqan3::detail
 

--- a/include/seqan3/range/views/take.hpp
+++ b/include/seqan3/range/views/take.hpp
@@ -341,7 +341,7 @@ public:
      */
     template <std::ranges::viewable_range rng_t>
     //!\cond
-        requires std::constructible_from<rng_t, std::ranges::all_view<rng_t>>
+        requires std::constructible_from<rng_t, std::views::all_t<rng_t>>
     //!\endcond
     constexpr view_take(rng_t && _urange, size_t const _size)
         : view_take{std::views::all(std::forward<rng_t>(_urange)), _size}
@@ -461,7 +461,7 @@ public:
 template <typename urng_t,
           bool exactly = false,
           bool or_throw = false>
-view_take(urng_t && , size_t) -> view_take<std::ranges::all_view<urng_t>, exactly, or_throw>;
+view_take(urng_t && , size_t) -> view_take<std::views::all_t<urng_t>, exactly, or_throw>;
 
 // ============================================================================
 //  take_fn (adaptor definition)
@@ -538,7 +538,7 @@ struct take_fn
         // our type
         else
         {
-            return view_take<std::ranges::all_view<urng_t>, exactly, or_throw>
+            return view_take<std::views::all_t<urng_t>, exactly, or_throw>
             {
                 std::forward<urng_t>(urange),
                 target_size

--- a/include/seqan3/range/views/take_until.hpp
+++ b/include/seqan3/range/views/take_until.hpp
@@ -384,7 +384,7 @@ public:
      */
     template <std::ranges::viewable_range rng_t>
     //!\cond
-        requires std::constructible_from<rng_t, std::ranges::all_view<rng_t>>
+        requires std::constructible_from<rng_t, std::views::all_t<rng_t>>
     //!\endcond
     view_take_until(rng_t && _urange, fun_t _fun)
         : view_take_until{std::views::all(std::forward<rng_t>(_urange)), std::move(_fun)}
@@ -463,7 +463,7 @@ public:
 //!\brief Type deduction guide that strips references.
 //!\relates seqan3::detail::view_take_until
 template <typename urng_t, typename fun_t, bool or_throw = false, bool and_consume = false>
-view_take_until(urng_t &&, fun_t) -> view_take_until<std::ranges::all_view<urng_t>, fun_t, or_throw, and_consume>;
+view_take_until(urng_t &&, fun_t) -> view_take_until<std::views::all_t<urng_t>, fun_t, or_throw, and_consume>;
 
 // ============================================================================
 //  take_until_fn (adaptor definition)
@@ -492,7 +492,7 @@ struct take_until_fn
     template <std::ranges::viewable_range urng_t, typename fun_t>
     constexpr auto operator()(urng_t && urange, fun_t && fun) const
     {
-        return view_take_until<std::ranges::all_view<urng_t>, fun_t, or_throw, and_consume>
+        return view_take_until<std::views::all_t<urng_t>, fun_t, or_throw, and_consume>
         {
             std::views::all(std::forward<urng_t>(urange)),
             std::forward<fun_t>(fun)

--- a/include/seqan3/range/views/translate.hpp
+++ b/include/seqan3/range/views/translate.hpp
@@ -439,12 +439,12 @@ public:
 
 //!\brief Class template argument deduction for view_translate_single.
 template <typename urng_t>
-view_translate_single(urng_t &&, translation_frames const) -> view_translate_single<std::ranges::all_view<urng_t>>;
+view_translate_single(urng_t &&, translation_frames const) -> view_translate_single<std::views::all_t<urng_t>>;
 
 
 //!\brief Class template argument deduction for view_translate_single with default translation_frames.
 template <typename urng_t>
-view_translate_single(urng_t &&) -> view_translate_single<std::ranges::all_view<urng_t>>;
+view_translate_single(urng_t &&) -> view_translate_single<std::views::all_t<urng_t>>;
 
 } // namespace seqan3::detail
 
@@ -745,7 +745,7 @@ template <typename urng_t>
              std::ranges::random_access_range<urng_t> &&
              nucleotide_alphabet<std::ranges::range_reference_t<urng_t>>
 //!\endcond
-view_translate(urng_t &&, translation_frames const = translation_frames{}) -> view_translate<std::ranges::all_view<urng_t>>;
+view_translate(urng_t &&, translation_frames const = translation_frames{}) -> view_translate<std::views::all_t<urng_t>>;
 
 } // namespace seqan3::detail
 

--- a/include/seqan3/range/views/translate_join.hpp
+++ b/include/seqan3/range/views/translate_join.hpp
@@ -53,7 +53,7 @@ private:
      * \{
      */
     //!\brief The reference_type.
-    using reference         = view_translate_single<std::ranges::all_view<std::ranges::range_reference_t<urng_t>>>;
+    using reference         = view_translate_single<std::views::all_t<std::ranges::range_reference_t<urng_t>>>;
     //!\brief The const_reference type.
     using const_reference   = reference;
     //!\brief The value_type (which equals the reference_type with any references removed).
@@ -272,7 +272,7 @@ public:
 
 //!\brief Class template argument deduction for view_translate_join.
 template <typename urng_t>
-view_translate_join(urng_t &&, translation_frames const = translation_frames{}) -> view_translate_join<std::ranges::all_view<urng_t>>;
+view_translate_join(urng_t &&, translation_frames const = translation_frames{}) -> view_translate_join<std::views::all_t<urng_t>>;
 
 // ============================================================================
 //  translate_fn (adaptor definition for both views)

--- a/include/seqan3/search/search_result_range.hpp
+++ b/include/seqan3/search/search_result_range.hpp
@@ -107,13 +107,13 @@ public:
      *
      * The search result range is an input range and the end is reached when all queries have been processed.
      */
-    constexpr std::ranges::default_sentinel_t end() noexcept
+    constexpr std::default_sentinel_t end() noexcept
     {
         return {};
     }
 
-    constexpr std::ranges::default_sentinel_t end() const = delete;
-    constexpr std::ranges::default_sentinel_t cend() const = delete;
+    constexpr std::default_sentinel_t end() const = delete;
+    constexpr std::default_sentinel_t cend() const = delete;
     //!\}
 
 private:
@@ -264,13 +264,13 @@ public:
      */
     //!\brief Checks whether `lhs` is equal to the sentinel.
     friend constexpr bool operator==(search_result_range_iterator const & lhs,
-                                     std::ranges::default_sentinel_t const &) noexcept
+                                     std::default_sentinel_t const &) noexcept
     {
         return lhs.at_end && (lhs.current_buffer_it == lhs.last_buffer_it);
     }
 
     //!\brief Checks whether `lhs` is equal to `rhs`.
-    friend constexpr bool operator==(std::ranges::default_sentinel_t const & lhs,
+    friend constexpr bool operator==(std::default_sentinel_t const & lhs,
                                      search_result_range_iterator const & rhs) noexcept
     {
         return rhs == lhs;
@@ -278,13 +278,13 @@ public:
 
     //!\brief Checks whether `lhs` is not equal to the sentinel.
     friend constexpr bool operator!=(search_result_range_iterator const & lhs,
-                                     std::ranges::default_sentinel_t const & rhs) noexcept
+                                     std::default_sentinel_t const & rhs) noexcept
     {
         return !(lhs == rhs);
     }
 
     //!\brief Checks whether `lhs` is not equal to `rhs`.
-    friend constexpr bool operator!=(std::ranges::default_sentinel_t const & lhs,
+    friend constexpr bool operator!=(std::default_sentinel_t const & lhs,
                                      search_result_range_iterator const & rhs) noexcept
     {
         return !(lhs == rhs);

--- a/include/seqan3/std/concepts
+++ b/include/seqan3/std/concepts
@@ -23,12 +23,6 @@ namespace std
 {
 inline namespace deprecated
 {
-/*!\brief This should be named default_initializable.
- * \deprecated Use std::default_initializable instead.
- */
-template<class T>
-concept default_constructible = default_initializable<T>;
-
 /*!\brief This should be removed.
  * \deprecated No viable alternative.
  */
@@ -367,15 +361,15 @@ template < class T, class... Args >
 SEQAN3_CONCEPT constructible_from = destructible<T> && std::is_constructible_v<T, Args...>;
 //!\endcond
 
-/*!\interface   std::default_constructible <>
+/*!\interface   std::default_initializable <>
  * \extends     std::constructible_from
- * \brief       The std::default_constructible concept provides a shorthand for the common case when the question is whether
+ * \brief       The std::default_initializable concept provides a shorthand for the common case when the question is whether
  *              a type can be constructed with no arguments.
- * \sa          https://en.cppreference.com/w/cpp/concepts/default_constructible
+ * \sa          https://en.cppreference.com/w/cpp/concepts/default_initializable
  */
 //!\cond
 template < class T >
-SEQAN3_CONCEPT default_constructible = constructible_from<T>;
+SEQAN3_CONCEPT default_initializable = constructible_from<T>;
 //!\endcond
 
 /*!\interface   std::move_constructible <>
@@ -629,14 +623,14 @@ SEQAN3_CONCEPT copyable = copy_constructible<T> && movable<T> && assignable_from
 //!\endcond
 
 /*!\interface   std::semiregular
- * \brief       Subsumes std::copyable and std::default_constructible.
+ * \brief       Subsumes std::copyable and std::default_initializable.
  * \extends     std::copyable
- * \extends     std::default_constructible
+ * \extends     std::default_initializable
  * \sa          https://en.cppreference.com/w/cpp/concepts/semiregular
  */
 //!\cond
 template <class T>
-SEQAN3_CONCEPT semiregular = copyable<T> && default_constructible<T>;
+SEQAN3_CONCEPT semiregular = copyable<T> && default_initializable<T>;
 //!\endcond
 
 /*!\interface   std::regular

--- a/include/seqan3/std/iterator
+++ b/include/seqan3/std/iterator
@@ -243,21 +243,3 @@ using ::ranges::cpp20::prev;
 } // namespace std::ranges
 
 #endif // __cpp_lib_ranges
-
-// ==========================================
-// LEGACY wrong std:: and std::ranges:: usage
-// ==========================================
-
-// we wrongly assume that these are in std::ranges namespace, even though they are in std namespace
-namespace std::ranges
-{
-inline namespace deprecated
-{
-// https://eel.is/c++draft/iterator.synopsis#lib:default_sentinel
-// // Header <iterator> synopsis
-// // [default.sentinels], default sentinels
-// struct default_sentinel_t;
-// inline constexpr default_sentinel_t default_sentinel{};
-using ::std::cpp20::back_inserter;
-} // namespace std::ranges::deprecated
-} // namespace std::ranges

--- a/include/seqan3/std/iterator
+++ b/include/seqan3/std/iterator
@@ -258,7 +258,6 @@ inline namespace deprecated
 // // [default.sentinels], default sentinels
 // struct default_sentinel_t;
 // inline constexpr default_sentinel_t default_sentinel{};
-using ::std::default_sentinel_t;
 using ::std::default_sentinel;
 using ::std::cpp20::back_inserter;
 } // namespace std::ranges::deprecated

--- a/include/seqan3/std/iterator
+++ b/include/seqan3/std/iterator
@@ -255,12 +255,6 @@ namespace std
 inline namespace deprecated
 {
 //!\cond
-/*!\brief This should be named indirectly_readable.
- * \deprecated Use std::indirectly_readable instead.
- */
-template<class T>
-SEQAN3_CONCEPT readable = ::std::indirectly_readable<T>;
-
 /*!\brief This should be named indirectly_writable.
  * \deprecated Use std::indirectly_writable instead.
  */

--- a/include/seqan3/std/iterator
+++ b/include/seqan3/std/iterator
@@ -248,22 +248,6 @@ using ::ranges::cpp20::prev;
 // LEGACY wrong std:: and std::ranges:: usage
 // ==========================================
 
-#include <seqan3/core/platform.hpp> // SEQAN3_CONCEPT
-
-namespace std
-{
-inline namespace deprecated
-{
-//!\cond
-/*!\brief This should be named indirectly_writable.
- * \deprecated Use std::indirectly_writable instead.
- */
-template<class Out, class T>
-SEQAN3_CONCEPT writable = ::std::indirectly_writable<Out, T>;
-//!\endcond
-} // namespace std::deprecated
-} // namespace std
-
 // we wrongly assume that these are in std::ranges namespace, even though they are in std namespace
 namespace std::ranges
 {

--- a/include/seqan3/std/iterator
+++ b/include/seqan3/std/iterator
@@ -258,7 +258,6 @@ inline namespace deprecated
 // // [default.sentinels], default sentinels
 // struct default_sentinel_t;
 // inline constexpr default_sentinel_t default_sentinel{};
-using ::std::default_sentinel;
 using ::std::cpp20::back_inserter;
 } // namespace std::ranges::deprecated
 } // namespace std::ranges

--- a/include/seqan3/std/ranges
+++ b/include/seqan3/std/ranges
@@ -240,19 +240,3 @@ namespace views = ::std::ranges::views;
 } // namespace std::
 
 #endif // standard header
-
-// ==========================================
-// LEGACY wrong std:: and std::ranges:: usage
-// ==========================================
-
-namespace std::ranges
-{
-inline namespace deprecated
-{
-/*!\brief this should be in std::ranges::views and not std::ranges
- * \deprecated Use std::views::all_t instead.
- */
-template <typename range_t>
-using all_view = std::views::all_t<range_t>;
-} // namespace std::ranges::deprecated
-} // namespace std::ranges

--- a/test/include/seqan3/test/expect_range_eq.hpp
+++ b/test/include/seqan3/test/expect_range_eq.hpp
@@ -33,7 +33,7 @@ struct expect_range_eq
     {
         using value_t = std::ranges::range_value_t<rng_t>;
         std::vector<value_t> rng_copy{};
-        std::ranges::copy(rng, std::ranges::back_inserter(rng_copy));
+        std::ranges::copy(rng, std::cpp20::back_inserter(rng_copy));
         return rng_copy;
     }
 

--- a/test/performance/core/simd/view_to_simd_chunk_benchmark.cpp
+++ b/test/performance/core/simd/view_to_simd_chunk_benchmark.cpp
@@ -39,7 +39,7 @@ void to_simd_naive_wo_condition(benchmark::State& state)
 
     for (size_t i = 0; i < simd_length; ++i)
         std::ranges::copy(seqan3::test::generate_sequence<seqan3::dna4>(500, 10),
-                          std::ranges::back_inserter(sequences[i]));
+                          std::cpp20::back_inserter(sequences[i]));
 
     size_t value = 0;
     for (auto _ : state)
@@ -100,7 +100,7 @@ void to_simd_naive_w_condition(benchmark::State& state)
 
     for (size_t i = 0; i < simd_length; ++i)
         std::ranges::copy(seqan3::test::generate_sequence<seqan3::dna4>(500, 10),
-                          std::ranges::back_inserter(sequences[i]));
+                          std::cpp20::back_inserter(sequences[i]));
 
     size_t value = 0;
     for (auto _ : state)
@@ -149,7 +149,7 @@ void to_simd(benchmark::State& state)
 
     for (size_t i = 0; i < seqan3::simd::simd_traits<simd_t>::length; ++i)
         std::ranges::copy(seqan3::test::generate_sequence<seqan3::dna4>(500, 10),
-                          std::ranges::back_inserter(sequences[i]));
+                          std::cpp20::back_inserter(sequences[i]));
 
     size_t value = 0;
     for (auto _ : state)

--- a/test/performance/io/lowlevel_stream_input_benchmark.cpp
+++ b/test/performance/io/lowlevel_stream_input_benchmark.cpp
@@ -77,7 +77,7 @@ void read_all(benchmark::State & state)
         {
             std::ifstream s{filename.get_path(), std::ios::binary};
             seqan3::detail::fast_istreambuf_iterator<char> it{*s.rdbuf()};
-            std::ranges::default_sentinel_t e{};
+            std::default_sentinel_t e{};
 
             for (; it != e; ++it)
                 c += *it;

--- a/test/performance/io/stream_input_benchmark.cpp
+++ b/test/performance/io/stream_input_benchmark.cpp
@@ -136,7 +136,7 @@ void uncompressed(benchmark::State & state)
         s.seekg(0, std::ios::beg);
         seqan3::detail::fast_istreambuf_iterator<char> it{*s.rdbuf()};
 
-        for (; it != std::ranges::default_sentinel; ++it)
+        for (; it != std::default_sentinel; ++it)
             i += *it;
     }
 

--- a/test/performance/search/search_benchmark.cpp
+++ b/test/performance/search/search_benchmark.cpp
@@ -157,7 +157,7 @@ void unidirectional_search_all_collection(benchmark::State & state, options && o
                                                                           o.read_length, o.simulated_errors,
                                                                           o.prob_insertion, o.prob_deletion,
                                                                           o.stddev, i);
-        std::ranges::move(seq_reads, std::ranges::back_inserter(reads));
+        std::ranges::move(seq_reads, std::cpp20::back_inserter(reads));
     }
 
     seqan3::fm_index index{collection};

--- a/test/unit/alignment/matrix/detail/aligned_sequence_builder_test.cpp
+++ b/test/unit/alignment/matrix/detail/aligned_sequence_builder_test.cpp
@@ -63,7 +63,7 @@ struct aligned_sequence_builder_fixture : ::testing::Test
     auto path(seqan3::detail::matrix_offset const & offset)
     {
         using iterator_t = decltype(seqan3::detail::trace_iterator{matrix.begin() + offset});
-        return std::ranges::subrange<iterator_t, std::ranges::default_sentinel_t>
+        return std::ranges::subrange<iterator_t, std::default_sentinel_t>
         {
             seqan3::detail::trace_iterator{matrix.begin() + offset},
             std::ranges::default_sentinel

--- a/test/unit/alignment/matrix/detail/aligned_sequence_builder_test.cpp
+++ b/test/unit/alignment/matrix/detail/aligned_sequence_builder_test.cpp
@@ -66,7 +66,7 @@ struct aligned_sequence_builder_fixture : ::testing::Test
         return std::ranges::subrange<iterator_t, std::default_sentinel_t>
         {
             seqan3::detail::trace_iterator{matrix.begin() + offset},
-            std::ranges::default_sentinel
+            std::default_sentinel
         };
     }
 

--- a/test/unit/alignment/matrix/detail/trace_iterator_banded_test.cpp
+++ b/test/unit/alignment/matrix/detail/trace_iterator_banded_test.cpp
@@ -53,7 +53,7 @@ struct trace_iterator_banded_test : public ::testing::Test
     path_type path(seqan3::detail::matrix_offset const & offset)
     {
         return path_type{trace_iterator_type{matrix.begin() + offset, seqan3::detail::column_index_type{2}},
-                         std::ranges::default_sentinel};
+                         std::default_sentinel};
     }
 };
 
@@ -149,8 +149,8 @@ struct iterator_fixture<trace_iterator_banded_test> : public trace_iterator_band
                                        seqan3::detail::column_index_type{2}};
         }
 
-        auto end() { return std::ranges::default_sentinel; }
-        auto end() const { return std::ranges::default_sentinel; }
+        auto end() { return std::default_sentinel; }
+        auto end() const { return std::default_sentinel; }
 
         decltype(base_t::matrix) matrix;
     };

--- a/test/unit/alignment/matrix/detail/trace_iterator_banded_test.cpp
+++ b/test/unit/alignment/matrix/detail/trace_iterator_banded_test.cpp
@@ -48,7 +48,7 @@ struct trace_iterator_banded_test : public ::testing::Test
 
     using trace_iterator_type = decltype(seqan3::detail::trace_iterator_banded{matrix.begin(),
                                                                                seqan3::detail::column_index_type{0}});
-    using path_type = std::ranges::subrange<trace_iterator_type, std::ranges::default_sentinel_t>;
+    using path_type = std::ranges::subrange<trace_iterator_type, std::default_sentinel_t>;
 
     path_type path(seqan3::detail::matrix_offset const & offset)
     {

--- a/test/unit/alignment/matrix/detail/trace_iterator_test.cpp
+++ b/test/unit/alignment/matrix/detail/trace_iterator_test.cpp
@@ -39,7 +39,7 @@ struct trace_iterator_fixture : public ::testing::Test
     }};
 
     using trace_iterator_type = decltype(seqan3::detail::trace_iterator{matrix.begin()});
-    using path_type = std::ranges::subrange<trace_iterator_type, std::ranges::default_sentinel_t>;
+    using path_type = std::ranges::subrange<trace_iterator_type, std::default_sentinel_t>;
 
     path_type path(seqan3::detail::matrix_offset const & offset)
     {

--- a/test/unit/alignment/matrix/detail/trace_iterator_test.cpp
+++ b/test/unit/alignment/matrix/detail/trace_iterator_test.cpp
@@ -43,7 +43,7 @@ struct trace_iterator_fixture : public ::testing::Test
 
     path_type path(seqan3::detail::matrix_offset const & offset)
     {
-        return path_type{trace_iterator_type{matrix.begin() + offset}, std::ranges::default_sentinel};
+        return path_type{trace_iterator_type{matrix.begin() + offset}, std::default_sentinel};
     }
 };
 
@@ -237,8 +237,8 @@ struct iterator_fixture<trace_iterator_fixture> : public trace_iterator_fixture
                                                                      seqan3::detail::column_index_type{3}}};
         }
 
-        auto end() { return std::ranges::default_sentinel; }
-        auto end() const { return std::ranges::default_sentinel; }
+        auto end() { return std::default_sentinel; }
+        auto end() const { return std::default_sentinel; }
 
         decltype(base_t::matrix) matrix;
     };

--- a/test/unit/core/simd/view_to_simd_test.cpp
+++ b/test/unit/core/simd/view_to_simd_test.cpp
@@ -49,7 +49,7 @@ public:
             // Generate sequences that end on different boundaries
             size_t l = max_sequence_length - (i * seqan3::simd::simd_traits<simd_t>::length) - i;
             std::ranges::copy(seqan3::test::generate_sequence<std::iter_value_t<container_t>>(l),
-                              std::ranges::back_inserter(sequences[i]));
+                              std::cpp20::back_inserter(sequences[i]));
         }
 
         transformed_simd_vec.resize(max_sequence_length, seqan3::simd::fill<simd_t>(padding_value_dna4));
@@ -285,7 +285,7 @@ TYPED_TEST(view_to_simd_test, too_many_sequences)
 {
     using seqan3::operator""_dna4;
     typename TestFixture::container_t cont;
-    std::ranges::copy("ACGTACGACT"_dna4, std::ranges::back_inserter(cont));
+    std::ranges::copy("ACGTACGACT"_dna4, std::cpp20::back_inserter(cont));
     this->sequences.push_back(cont);
 
     EXPECT_THROW(typename TestFixture::view_to_simd_type{this->sequences}, std::invalid_argument);

--- a/test/unit/io/detail/in_file_iterator_test.cpp
+++ b/test/unit/io/detail/in_file_iterator_test.cpp
@@ -102,11 +102,11 @@ TEST(in_file_iterator, comparison)
     it_t it = f.begin();
 
     // not at end
-    EXPECT_FALSE(it == std::ranges::default_sentinel);
+    EXPECT_FALSE(it == std::default_sentinel);
 
     // consume the entire range
     ++it; ++it; ++it; ++it; ++it; ++it; ++it;
 
     // at end
-    EXPECT_TRUE(it == std::ranges::default_sentinel);
+    EXPECT_TRUE(it == std::default_sentinel);
 }

--- a/test/unit/io/detail/out_file_iterator_test.cpp
+++ b/test/unit/io/detail/out_file_iterator_test.cpp
@@ -81,5 +81,5 @@ TEST(out_file_iterator, comparison)
     it_t it{fake_file};
 
     // never at end
-    EXPECT_FALSE(it == std::ranges::default_sentinel);
+    EXPECT_FALSE(it == std::default_sentinel);
 }

--- a/test/unit/io/stream/fast_streambuf_iterator_test.cpp
+++ b/test/unit/io/stream/fast_streambuf_iterator_test.cpp
@@ -52,10 +52,10 @@ TEST(fast_istreambuf_iterator, comparison)
     std::istringstream str{"test\n"};
     seqan3::detail::fast_istreambuf_iterator<char> it{*str.rdbuf()};
 
-    EXPECT_FALSE(it == std::ranges::default_sentinel);
-    EXPECT_FALSE(std::ranges::default_sentinel == it);
-    EXPECT_TRUE(it != std::ranges::default_sentinel);
-    EXPECT_TRUE(std::ranges::default_sentinel != it);
+    EXPECT_FALSE(it == std::default_sentinel);
+    EXPECT_FALSE(std::default_sentinel == it);
+    EXPECT_TRUE(it != std::default_sentinel);
+    EXPECT_TRUE(std::default_sentinel != it);
 }
 
 // -----------------------------------------------------------------------------

--- a/test/unit/range/views/view_enforce_random_access_test.cpp
+++ b/test/unit/range/views/view_enforce_random_access_test.cpp
@@ -78,32 +78,32 @@ public:
         using base_t::operator==;
         using base_t::operator!=;
         using base_t::operator-;
-        bool operator==(std::ranges::default_sentinel_t const &) const
+        bool operator==(std::default_sentinel_t const &) const
         {
             return static_cast<u_iterator_t const &>(*this) == last;
         }
 
-        friend bool operator==(std::ranges::default_sentinel_t const &, test_iterator const & rhs)
+        friend bool operator==(std::default_sentinel_t const &, test_iterator const & rhs)
         {
             return rhs == std::ranges::default_sentinel;
         }
 
-        bool operator!=(std::ranges::default_sentinel_t const &) const
+        bool operator!=(std::default_sentinel_t const &) const
         {
             return !(*this == std::ranges::default_sentinel);
         }
 
-        friend bool operator!=(std::ranges::default_sentinel_t const &, test_iterator const & rhs)
+        friend bool operator!=(std::default_sentinel_t const &, test_iterator const & rhs)
         {
             return rhs != std::ranges::default_sentinel;
         }
 
-        typename base_t::difference_type operator-(std::ranges::default_sentinel_t const &) const
+        typename base_t::difference_type operator-(std::default_sentinel_t const &) const
         {
             return static_cast<u_iterator_t const &>(*this) - this->last;
         }
 
-        friend typename base_t::difference_type operator-(std::ranges::default_sentinel_t const &,
+        friend typename base_t::difference_type operator-(std::default_sentinel_t const &,
                                                           test_iterator const & rhs)
         {
             return rhs.last - static_cast<u_iterator_t const &>(rhs);

--- a/test/unit/range/views/view_enforce_random_access_test.cpp
+++ b/test/unit/range/views/view_enforce_random_access_test.cpp
@@ -85,17 +85,17 @@ public:
 
         friend bool operator==(std::default_sentinel_t const &, test_iterator const & rhs)
         {
-            return rhs == std::ranges::default_sentinel;
+            return rhs == std::default_sentinel;
         }
 
         bool operator!=(std::default_sentinel_t const &) const
         {
-            return !(*this == std::ranges::default_sentinel);
+            return !(*this == std::default_sentinel);
         }
 
         friend bool operator!=(std::default_sentinel_t const &, test_iterator const & rhs)
         {
-            return rhs != std::ranges::default_sentinel;
+            return rhs != std::default_sentinel;
         }
 
         typename base_t::difference_type operator-(std::default_sentinel_t const &) const
@@ -124,12 +124,12 @@ public:
 
     auto end() noexcept
     {
-        return std::ranges::default_sentinel;
+        return std::default_sentinel;
     }
 
     auto end() const
     {
-        return std::ranges::default_sentinel;
+        return std::default_sentinel;
     }
 };
 

--- a/test/unit/range/views/view_take_test.cpp
+++ b/test/unit/range/views/view_take_test.cpp
@@ -201,7 +201,7 @@ TEST(view_take, type_erasure)
 
         auto v = seqan3::views::take(urange, 3);
 
-        EXPECT_TRUE((std::same_as<decltype(v), seqan3::detail::view_take<std::ranges::all_view<std::list<int> &>,
+        EXPECT_TRUE((std::same_as<decltype(v), seqan3::detail::view_take<std::views::all_t<std::list<int> &>,
                                                                          false, false>>));
         EXPECT_TRUE((std::ranges::equal(v, std::vector{1, 2, 3})));
     }
@@ -299,7 +299,7 @@ TEST(view_take_exactly_or_throw, underlying_is_shorter)
                    std::invalid_argument); // no parsing, but throws in adaptor
 
     std::list l{'f', 'o', 'o'};
-    EXPECT_THROW(( seqan3::detail::view_take<std::ranges::all_view<std::list<char> &>, true, true>(l, 4) ),
+    EXPECT_THROW(( seqan3::detail::view_take<std::views::all_t<std::list<char> &>, true, true>(l, 4) ),
                    std::invalid_argument); // no parsing, but throws on construction
 
     std::string v;

--- a/test/unit/range/views/view_type_reduce_test.cpp
+++ b/test/unit/range/views/view_type_reduce_test.cpp
@@ -92,7 +92,7 @@ TEST(type_reduce, generic_overload)
 
         auto v = seqan3::views::type_reduce(urange);
 
-        EXPECT_TRUE((std::same_as<decltype(v), std::ranges::all_view<std::list<int> &>>));
+        EXPECT_TRUE((std::same_as<decltype(v), std::views::all_t<std::list<int> &>>));
         EXPECT_TRUE((std::ranges::equal(v, urange)));
     }
 
@@ -102,7 +102,7 @@ TEST(type_reduce, generic_overload)
         auto v = urange | std::views::filter([] (int) { return true; });
         auto v2 = seqan3::views::type_reduce(v);
 
-        EXPECT_TRUE((std::same_as<decltype(v2), std::ranges::all_view<decltype(v)>>));
+        EXPECT_TRUE((std::same_as<decltype(v2), std::views::all_t<decltype(v)>>));
         EXPECT_TRUE((std::ranges::equal(v2, urange)));
     }
 }

--- a/test/unit/std/concept/iterator_test.cpp
+++ b/test/unit/std/concept/iterator_test.cpp
@@ -23,14 +23,14 @@ TEST(iterator_concepts, readable)
 
 TEST(iterator_concepts, writable)
 {
-    EXPECT_TRUE((!std::writable<input_iterator, char>));
-    EXPECT_TRUE((std::writable<output_iterator, char>));
-    EXPECT_TRUE((std::writable<forward_iterator, char>));
-    EXPECT_TRUE((!std::writable<forward_iterator_const, char>));
-    EXPECT_TRUE((std::writable<bidirectional_iterator, char>));
-    EXPECT_TRUE((!std::writable<bidirectional_iterator_const, char>));
-    EXPECT_TRUE((std::writable<random_access_iterator, char>));
-    EXPECT_TRUE((!std::writable<random_access_iterator_const, char>));
+    EXPECT_TRUE((!std::indirectly_writable<input_iterator, char>));
+    EXPECT_TRUE((std::indirectly_writable<output_iterator, char>));
+    EXPECT_TRUE((std::indirectly_writable<forward_iterator, char>));
+    EXPECT_TRUE((!std::indirectly_writable<forward_iterator_const, char>));
+    EXPECT_TRUE((std::indirectly_writable<bidirectional_iterator, char>));
+    EXPECT_TRUE((!std::indirectly_writable<bidirectional_iterator_const, char>));
+    EXPECT_TRUE((std::indirectly_writable<random_access_iterator, char>));
+    EXPECT_TRUE((!std::indirectly_writable<random_access_iterator_const, char>));
 }
 
 TEST(iterator_concepts, weakly_incrementable)

--- a/test/unit/std/concept/iterator_test.cpp
+++ b/test/unit/std/concept/iterator_test.cpp
@@ -11,14 +11,14 @@
 
 TEST(iterator_concepts, readable)
 {
-    EXPECT_TRUE((std::readable<input_iterator>));
-    EXPECT_TRUE((!std::readable<output_iterator>));
-    EXPECT_TRUE((std::readable<forward_iterator>));
-    EXPECT_TRUE((std::readable<bidirectional_iterator>));
-    EXPECT_TRUE((std::readable<random_access_iterator>));
-    EXPECT_TRUE((std::readable<forward_iterator_const>));
-    EXPECT_TRUE((std::readable<bidirectional_iterator_const>));
-    EXPECT_TRUE((std::readable<random_access_iterator_const>));
+    EXPECT_TRUE((std::indirectly_readable<input_iterator>));
+    EXPECT_TRUE((!std::indirectly_readable<output_iterator>));
+    EXPECT_TRUE((std::indirectly_readable<forward_iterator>));
+    EXPECT_TRUE((std::indirectly_readable<bidirectional_iterator>));
+    EXPECT_TRUE((std::indirectly_readable<random_access_iterator>));
+    EXPECT_TRUE((std::indirectly_readable<forward_iterator_const>));
+    EXPECT_TRUE((std::indirectly_readable<bidirectional_iterator_const>));
+    EXPECT_TRUE((std::indirectly_readable<random_access_iterator_const>));
 }
 
 TEST(iterator_concepts, writable)

--- a/test/unit/std/concept/object_test.cpp
+++ b/test/unit/std/concept/object_test.cpp
@@ -27,10 +27,10 @@ TEST(object_concepts, constructible_from)
     EXPECT_TRUE((!std::constructible_from<type_c, int>));
 }
 
-TEST(object_concepts, default_constructible)
+TEST(object_concepts, default_initializable)
 {
-    EXPECT_TRUE((std::default_constructible<type_a>));
-    EXPECT_TRUE((!std::default_constructible<type_d>));
+    EXPECT_TRUE((std::default_initializable<type_a>));
+    EXPECT_TRUE((!std::default_initializable<type_d>));
 }
 
 TEST(object_concepts, move_constructible)


### PR DESCRIPTION
Fixes part of seqan/product_backlog#49.

Renaming the stuff that was renamed by the standard or was in the wrong namespace. 

* `std::default_constructible` -> `std::default_initializable`
* `std::readable` -> `std::indirectly_readable`
* `std::writable` -> `std::indirectly_writable`
* `std::back_inserter` -> `std::cpp20::back_inserter` (back_inserter has a new behaviour since cxx20; it is default initializable)
* `std::ranges::default_sentinel` -> `std::default_sentinel` (we wrongly assume that these are in std::ranges namespace, even though they are in std namespace)
* `std::ranges::default_sentinel_t` -> `std::default_sentinel_t` (we wrongly assume that these are in std::ranges namespace, even though they are in std namespace)
* `std::ranges::all_view` -> `std::views::all_t`