### PR TITLE
Search configuration: output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,8 +120,15 @@ Note that 3.1.0 will be the first API stable release and interfaces in this rele
   * The configuration element `seqan3::search_cfg::mode` does not exist anymore.
     You can replace it by directly using one of the above mentioned "hit strategy" configuration elements
     ([\#1639](https://github.com/seqan/seqan3/pull/1639)).
-  * Removed `seqan3::bi_fm_index_cursor::to_rev_cursor()` and `seqan3::bi_fm_index::rev_cursor()`
-    ([\#1892](https://github.com/seqan/seqan3/pull/1892)).
+  * The configuration element `seqan3::search_cfg::output` does not exist anymore. It has been replaced by the
+    individual configuration elements
+    * `seqan3::search_cfg::output_query_id`
+    * `seqan3::search_cfg::output_reference_id`
+    * `seqan3::search_cfg::output_reference_begin_pos`
+    * `seqan3::search_cfg::output_index_cursor`
+    see the \ref search_configuration_subsection_output "output configuration" for further details.
+* Removed `seqan3::bi_fm_index_cursor::to_rev_cursor()` and `seqan3::bi_fm_index::rev_cursor()`
+  ([\#1892](https://github.com/seqan/seqan3/pull/1892)).
 
 ## Notable Bug-fixes
 

--- a/include/seqan3/search/configuration/all.hpp
+++ b/include/seqan3/search/configuration/all.hpp
@@ -43,7 +43,7 @@
  * where all can be given as an \ref seqan3::search_cfg::error_count "absolute number"
  * or a \ref seqan3::search_cfg::error_rate "rate" of \ref search_configuration_subsection_error "errors".
  * Furthermore, it can be configured what hits are reported based on a \ref search_configuration_subsection_hit_strategy
- * "strategy", and how to \ref seqan3::search_cfg::output "output" the results.
+ * "strategy", and which information should the \ref search_configuration_subsection_output "result" contain.
  * These configurations exist in their own namespace, namely seqan3::search_cfg, to disambiguate them from the
  * configuration of other algorithms.
  *
@@ -64,13 +64,9 @@
  * | \ref seqan3::search_cfg::max_error_substitution "1: Max error substitution" |  ✅   |  ❌   |  ✅   |  ✅   |  ✅   |  ✅   |  ✅   |
  * | \ref seqan3::search_cfg::max_error_insertion "2: Max error insertion"       |  ✅   |  ✅   |  ❌   |  ✅   |  ✅   |  ✅   |  ✅   |
  * | \ref seqan3::search_cfg::max_error_deletion "3: Max error deletion"         |  ✅   |  ✅   |  ✅   |  ❌   |  ✅   |  ✅   |  ✅   |
- * | \ref seqan3::search_cfg::output "4: Output"                                 |  ✅   |  ✅   |  ✅   |  ✅   |  ❌   |  ✅   |  ✅   |
+ * | \ref search_configuration_subsection_output "4: Output"                     |  ✅   |  ✅   |  ✅   |  ✅   |  ❌   |  ✅   |  ✅   |
  * | \ref search_configuration_subsection_hit_strategy "5: Hit"                  |  ✅   |  ✅   |  ✅   |  ✅   |  ✅   |  ❌   |  ✅   |
  * | \ref seqan3::search_cfg::parallel "6: Parallel"                             |  ✅   |  ✅   |  ✅   |  ✅   |  ✅   |  ✅   |  ❌   |
- *
- * \subsection search_configuration_search_result Search result type
- *
- * \copydetails seqan3::search_result
  *
  * \subsection search_configuration_subsection_error 0 - 3: Max Error Configuration
  *
@@ -96,6 +92,37 @@
  * ### Example
  *
  * \include test/snippet/search/configuration_error.cpp
+ *
+ * \subsection search_configuration_subsection_output 2. Output Configuration
+ *
+ * The output configuration is closely tied to the seqan3::search_result:
+ *
+ * \copydetails seqan3::search_result
+ *
+ * #### Configuring the result type
+ *
+ * As mentioned above, we can configure which information are accessible in the seqan3::search_result.
+ * For each member function there is a respective configuration element:
+ *
+ * * seqan3::search_cfg::output_query_id
+ * * seqan3::search_cfg::output_reference_id
+ * * seqan3::search_cfg::output_reference_begin_pos
+ * * seqan3::search_cfg::output_index_cursor
+ *
+ * If you specify any of the above mentioned output configuration elements, then nothing else but the selected
+ * output information is included.
+ *
+ * \include test/snippet/search/configuration_output.cpp
+ *
+ * The index cursor is an advanced data structure that lets you navigate within the index.
+ * See seqan3::fm_index_cursor and seqan3::bi_fm_index_cursor for more information.
+ * If you don't need the reference id nor the position, returning only the cursor is faster.
+ * This is, because the operation to get the id and position of a hit can be computationally intensive
+ * depending on the underlying index structure.
+ *
+ * \note A single index cursor points to **a range of text positions**. Although the normal use case is to return
+ *       either the cursor or the positions, both can be returned simultaneously. In this case, the same cursor will
+ *       be copied into the seqan3::search_result for each of its associated positions.
  *
  * \subsection search_configuration_subsection_hit_strategy 5: Hit Configuration
  *

--- a/include/seqan3/search/configuration/default_configuration.hpp
+++ b/include/seqan3/search/configuration/default_configuration.hpp
@@ -29,12 +29,12 @@ namespace seqan3::search_cfg
  * \todo Make constexpr after GCC7 support is dropped.
  * \endif
  */
-
 inline const configuration default_configuration = max_error_total{error_count{0}} |
                                                    max_error_substitution{error_count{0}} |
                                                    max_error_insertion{error_count{0}} |
                                                    max_error_deletion{error_count{0}} |
-                                                   output{text_position} |
+                                                   output_query_id |
+                                                   output_reference_id |
+                                                   output_reference_begin_pos |
                                                    hit_all;
-
 } // namespace seqan3::search_cfg

--- a/include/seqan3/search/configuration/detail.hpp
+++ b/include/seqan3/search/configuration/detail.hpp
@@ -44,7 +44,10 @@ enum struct search_config_id : uint8_t
     max_error_substitution, //!< Identifier for the max_error_substitution configuration.
     max_error_insertion, //!< Identifier for the max_error_insertion configuration.
     max_error_deletion, //!< Identifier for the max_error_deletion configuration.
-    output, //!< Identifier for the output configuration.
+    output_query_id, //!< Identifier for the output configuration of the query_id.
+    output_reference_id, //!< Identifier for the output configuration of the reference_id.
+    output_reference_begin_pos, //!< Identifier for the output configuration of the reference_begin_pos.
+    output_index_cursor, //!< Identifier for the output configuration of the index_cursor.
     hit, //!< Identifier for the hit configuration (all, all_best, single_best, strata).
     parallel, //!< Identifier for the parallel execution configuration.
     result_type, //!< Identifier for the configured search result type.
@@ -73,15 +76,28 @@ inline constexpr std::array<std::array<bool, static_cast<uint8_t>(search_config_
                             static_cast<uint8_t>(search_config_id::SIZE)> compatibility_table<search_config_id> =
 {
     {
-        // max_error_total, max_error_substitution, max_error_insertion, max_error_deletion, output, hit, parallel, result_type
-        { 0, 1, 1, 1, 1, 1, 1, 1}, // max_error_total
-        { 1, 0, 1, 1, 1, 1, 1, 1}, // max_error_substitution
-        { 1, 1, 0, 1, 1, 1, 1, 1}, // max_error_insertion
-        { 1, 1, 1, 0, 1, 1, 1, 1}, // max_error_deletion
-        { 1, 1, 1, 1, 0, 1, 1, 1}, // output
-        { 1, 1, 1, 1, 1, 0, 1, 1}, // hit
-        { 1, 1, 1, 1, 1, 1, 0, 1}, // parallel
-        { 1, 1, 1, 1, 1, 1, 1, 0}  // result_type
+       // max_error_total,
+       // |  max_error_substitution,
+       // |  |  max_error_insertion,
+       // |  |  |  max_error_deletion,
+       // |  |  |  |  output_query_id,
+       // |  |  |  |  |  output_reference_id,
+       // |  |  |  |  |  |  output_reference_begin_pos,
+       // |  |  |  |  |  |  |  output_index_cursor,
+       // |  |  |  |  |  |  |  |  hit,
+       // |  |  |  |  |  |  |  |  |  parallel,
+       // |  |  |  |  |  |  |  |  |  |  result_type
+        { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, // max_error_total
+        { 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1}, // max_error_substitution
+        { 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1}, // max_error_insertion
+        { 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1}, // max_error_deletion
+        { 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1}, // output_query_id
+        { 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1}, // output_reference_id
+        { 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1}, // output_reference_begin_pos
+        { 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1}, // output_index_cursor
+        { 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1}, // hit
+        { 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1}, // parallel
+        { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0}  // result_type
     }
 };
 

--- a/include/seqan3/search/configuration/output.hpp
+++ b/include/seqan3/search/configuration/output.hpp
@@ -6,71 +6,89 @@
 // -----------------------------------------------------------------------------------------------------
 
 /*!\file
- * \brief Provides the configuration for returning positions in the text.
+ * \brief Provides the configuration for the content of the search result.
  * \author Christopher Pockrandt <christopher.pockrandt AT fu-berlin.de>
  * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ * \author Svenja Mehringer <svenja.mehringer AT fu-berlin.de>
  */
 
 #pragma once
 
 #include <seqan3/core/algorithm/configuration.hpp>
 #include <seqan3/core/algorithm/pipeable_config_element.hpp>
-#include <seqan3/core/detail/strong_type.hpp>
-#include <seqan3/core/type_traits/basic.hpp>
+#include <seqan3/core/detail/empty_type.hpp>
 #include <seqan3/search/configuration/detail.hpp>
 
 namespace seqan3::detail
 {
 
-//!\brief Type for the "index_cursor" value for the configuration element "output".
+//!\brief Include the query_id in the seqan3::search_result returned by a call to seqan3::search.
 //!\ingroup search_configuration
-struct search_output_index_cursor {};
-//!\brief Type for the "text_position" value for the configuration element "output".
+struct output_query_id_tag : public pipeable_config_element<output_query_id_tag>
+{
+    //!\privatesection
+    //!\brief Internal id to check for consistent configuration settings.
+    static constexpr detail::search_config_id id{detail::search_config_id::output_query_id};
+};
+
+//!\brief Include the reference_id in the seqan3::search_result returned by a call to seqan3::search.
 //!\ingroup search_configuration
-struct search_output_text_position {};
+struct output_reference_id_tag : public pipeable_config_element<output_reference_id_tag>
+{
+    //!\privatesection
+    //!\brief Internal id to check for consistent configuration settings.
+    static constexpr detail::search_config_id id{detail::search_config_id::output_reference_id};
+};
+
+//!\brief Include the reference_begin_pos in the seqan3::search_result returned by a call to seqan3::search.
+//!\ingroup search_configuration
+struct output_reference_begin_pos_tag : public pipeable_config_element<output_reference_begin_pos_tag>
+{
+    //!\privatesection
+    //!\brief Internal id to check for consistent configuration settings.
+    static constexpr detail::search_config_id id{detail::search_config_id::output_reference_begin_pos};
+};
+
+//!\brief Include the index_cursor in the seqan3::search_result returned by a call to seqan3::search.
+//!\ingroup search_configuration
+struct output_index_cursor_tag : public pipeable_config_element<output_index_cursor_tag>
+{
+    //!\privatesection
+    //!\brief Internal id to check for consistent configuration settings.
+    static constexpr detail::search_config_id id{detail::search_config_id::output_index_cursor};
+};
 
 } // namespace seqan3::detail
 
 namespace seqan3::search_cfg
 {
 
-//!\brief Configuration element to receive all hits within the error bounds.
-//!\ingroup search_configuration
-inline seqan3::detail::search_output_index_cursor constexpr index_cursor;
-//!\brief Configuration element to receive all hits within the lowest number of errors.
-//!\ingroup search_configuration
-inline seqan3::detail::search_output_text_position constexpr text_position;
-
-/*!\brief Configuration element to determine the output type of hits.
+/*!\brief \copybrief seqan3::detail::output_query_id_tag
  * \ingroup search_configuration
- *
- * \details
- * This configuration element can be used to determine the output type.
- *
- * ### Example
- *
- * \include test/snippet/search/configuration_output.cpp
+ * \sa \ref search_configuration_subsection_output "Section on Output"
+ * \hideinitializer
  */
-template <typename output_t>
-//!\cond
-    requires std::same_as<remove_cvref_t<output_t>, seqan3::detail::search_output_text_position> ||
-             std::same_as<remove_cvref_t<output_t>, seqan3::detail::search_output_index_cursor>
-//!\endcond
-struct output : public pipeable_config_element<output<output_t>, output_t>
-{
-    //!\privatesection
-    //!\brief Internal id to check for consistent configuration settings.
-    static constexpr seqan3::detail::search_config_id id{seqan3::detail::search_config_id::output};
-};
+inline constexpr detail::output_query_id_tag output_query_id{};
 
-/*!\name Type deduction guides
- * \relates seqan3::search_cfg::output
- * \{
+/*!\brief \copybrief seqan3::detail::output_reference_id_tag
+ * \ingroup search_configuration
+ * \sa \ref search_configuration_subsection_output "Section on Output"
+ * \hideinitializer
  */
+inline constexpr detail::output_reference_id_tag output_reference_id{};
 
-//!\brief Deduces search output type from constructor argument.
-template <typename output_t>
-output(output_t) -> output<remove_cvref_t<output_t>>;
-//!\}
+/*!\brief \copybrief seqan3::detail::output_reference_begin_pos_tag
+ * \ingroup search_configuration
+ * \sa \ref search_configuration_subsection_output "Section on Output"
+ * \hideinitializer
+ */
+inline constexpr detail::output_reference_begin_pos_tag output_reference_begin_pos{};
+
+/*!\brief \copybrief seqan3::detail::output_index_cursor_tag
+ * \ingroup search_configuration
+ * \sa \ref search_configuration_subsection_output "Section on Output"
+ * \hideinitializer
+ */
+inline constexpr detail::output_index_cursor_tag output_index_cursor{};
 
 } // namespace seqan3::search_cfg

--- a/include/seqan3/search/detail/policy_search_result_builder.hpp
+++ b/include/seqan3/search/detail/policy_search_result_builder.hpp
@@ -38,7 +38,7 @@ protected:
 
     static_assert(!std::same_as<search_result_type, empty_type>, "The search result type was not configured properly.");
 
-    /*!\brief Returns all hits (index cursors) without calling locate on each cursor.
+    /*!\brief Invoke the callback on all hits (index cursors) without calling locate on each cursor.
      *
      * \tparam index_cursor_t The type of index cursor used in the search algorithm.
      * \tparam query_index_t The index type of the query.
@@ -53,57 +53,12 @@ protected:
      * The result is independent from the search modus (all, single_best, all_best, strata).
      */
     template <typename index_cursor_t, typename query_index_t, typename callback_t>
-    //!\cond
-        requires !search_traits_type::output_requires_locate_call
-    //!\endcond
     void make_results(std::vector<index_cursor_t> internal_hits, query_index_t idx, callback_t && callback)
     {
-        static_assert(std::destructible<decltype(search_result_type{std::declval<query_index_t &&>(),
-                                                                    std::declval<index_cursor_t &>(),
-                                                                    std::declval<unsigned &&>(),
-                                                                    std::declval<unsigned &&>()})>,
-                      "The configured search result type is not compatible with the requested search output. "
-                      "Note trying to instantiate search result with an index cursor.");
-
-        for (size_t i = 0; i < internal_hits.size(); ++i)
-            callback(search_result_type{std::move(idx), internal_hits[i], 0u, 0u});
+        return make_results_impl(std::move(internal_hits), idx, std::forward<callback_t>(callback));
     }
 
-    /*!\brief If `internal_hits` is not empty, calls lazy_locate on the first cursor and returns a
-    *         seqan3::search_result with the first text position.
-    *
-    * \tparam index_cursor_t The type of index cursor used in the search algorithm.
-    * \tparam query_index_t The index type of the query.
-    * \tparam callback_t The callback which is called for every hit.
-    *
-    * \param[in] internal_hits internal_hits A range over internal cursor results.
-    * \param[in] idx The index associated with the current query.
-    * \param[in] callback The callback to invoke for every hit.
-    */
-    template <typename index_cursor_t, typename query_index_t, typename callback_t>
-    //!\cond
-        requires search_traits_type::output_requires_locate_call &&
-                 search_traits_type::search_single_best_hit
-    //!\endcond
-    void make_results(std::vector<index_cursor_t> internal_hits, query_index_t idx, callback_t && callback)
-    {
-        using ref_location_pair_t = decltype(std::declval<index_cursor_t &>().lazy_locate().front());
-        static_assert(std::destructible<decltype(search_result_type{std::declval<query_index_t &&>(),
-                                                                    std::declval<index_cursor_t &>(),
-                                                                    std::declval<ref_location_pair_t &>().first,
-                                                                    std::declval<ref_location_pair_t &>().second})>,
-                      "The configured search result type is not compatible with the requested search output. "
-                      "Note trying to instantiate search result with text positions and single best hit strategy.");
-
-        if (!internal_hits.empty())
-        {
-            // only one cursor is reported but it might contain more than one text position
-            auto && [ref_id, ref_pos] = internal_hits[0].lazy_locate()[0];
-            callback(search_result_type{std::move(idx), internal_hits[0], ref_id, ref_pos});
-        }
-    }
-
-    /*!\brief Returns a range over seqan3::search_result by calling locate on each cursor.
+    /*!\brief Invokes the callback on each seqan3::search_result after calling locate on each cursor.
      *
      * \tparam index_cursor_t The type of index cursor used in the search algorithm.
      * \tparam query_index_t The index type of the query.
@@ -126,34 +81,79 @@ protected:
     //!\endcond
     void make_results(std::vector<index_cursor_t> internal_hits, query_index_t idx, callback_t && callback)
     {
-        using ref_location_pair_t = decltype(std::declval<index_cursor_t>().lazy_locate().front());
-        static_assert(std::destructible<decltype(search_result_type{std::declval<query_index_t &&>(),
-                                                                    std::declval<index_cursor_t &>(),
-                                                                    std::declval<ref_location_pair_t &>().first,
-                                                                    std::declval<ref_location_pair_t &>().second})>,
-                      "The configured search result type is not compatible with the requested search output. "
-                      "Note trying to instantiate search result with text positions with either all, all_best or "
-                      "strata hit strategy.");
-
         std::vector<search_result_type> results{};
         results.reserve(internal_hits.size()); // expect at least as many text positions as cursors, possibly more
 
-        for (auto const & cursor : internal_hits)
-            for (auto && [ref_id, ref_pos] : cursor.locate())
-                results.push_back(search_result_type{std::move(idx), cursor, ref_id, ref_pos});
+        make_results_impl(std::move(internal_hits), idx, [&results] (auto && search_result)
+        {
+            results.push_back(std::move(search_result));
+        });
 
         // sort by reference id or by reference position if both have the same reference id.
-        auto compare = [] (auto const & r1, auto const & r2)
+        std::sort(results.begin(), results.end(), [] (auto const & r1, auto const & r2)
         {
             return (r1.reference_id() == r2.reference_id()) ? (r1.reference_begin_pos() < r2.reference_begin_pos())
                                                             : (r1.reference_id() < r2.reference_id());
-        };
+        });
 
-        std::sort(results.begin(), results.end(), compare);
         results.erase(std::unique(results.begin(), results.end()), results.end());
 
         for (auto && search_result : results)
             callback(std::move(search_result));
+    }
+
+private:
+    /*!\brief Invokes the callback on each seqan3::search_result and calls locate on the cursor depending on the config.
+     *
+     * \tparam index_cursor_t The type of index cursor used in the search algorithm.
+     * \tparam query_index_t The index type of the query.
+     * \tparam callback_t The callback which is called for every hit.
+     *
+     * \param[in] internal_hits internal_hits A range over internal cursor results.
+     * \param[in] idx The index associated with the current query.
+     * \param[in] callback The callback to invoke for every hit.
+     *
+     * \details
+     *
+     * For each cursor `in internal_hits`, this function calls `cursor.layz_locate()` if the search configuration
+     * requires it (search_traits_type::output_requires_locate_call) and then constructs a seqan3::search_result from
+     * the resulting data. The seqan3::search_result will be filled only with the data that was asked for by the user
+     * via the `search_traits_type::output_[...]` trait (e.g. `search_traits_type::output_query_id`).
+     */
+    template <typename index_cursor_t, typename query_index_t, typename callback_t>
+    void make_results_impl(std::vector<index_cursor_t> internal_hits,
+                           [[maybe_unused]] query_index_t idx,
+                           callback_t && callback)
+    {
+        auto maybe_locate = [] (auto const & cursor)
+        {
+            if constexpr (search_traits_type::output_requires_locate_call)
+                return cursor.lazy_locate();
+            else
+                return std::views::single(std::tuple{0, 0});
+        };
+
+        for (auto const & cursor : internal_hits)
+        {
+            for (auto && [ref_id, ref_pos] : maybe_locate(cursor))
+            {
+                search_result_type result{};
+
+                if constexpr (search_traits_type::output_query_id)
+                    result.query_id_ = std::move(idx);
+                if constexpr (search_traits_type::output_index_cursor)
+                    result.cursor_ = cursor;
+                if constexpr (search_traits_type::output_reference_id)
+                    result.reference_id_ = std::move(ref_id);
+                if constexpr (search_traits_type::output_reference_begin_pos)
+                    result.reference_begin_pos_ = std::move(ref_pos);
+
+                callback(result);
+
+                if constexpr (search_traits_type::search_single_best_hit)
+                    return;
+            }
+        }
     }
 };
 

--- a/include/seqan3/search/detail/search_traits.hpp
+++ b/include/seqan3/search/detail/search_traits.hpp
@@ -26,8 +26,7 @@ namespace seqan3::detail
 /*!\brief A collection of traits extracted from the search configuration.
  * \ingroup search
  *
- * \tparam search_configuration_t The type of the search algorithm configuration; must be of type
- *                                seqan3::configuration.
+ * \tparam search_configuration_t The type of the search algorithm configuration; must be of type seqan3::configuration.
  */
 template <typename search_configuration_t>
 struct search_traits
@@ -80,14 +79,25 @@ public:
                                                   search_strata_hits ||
                                                   search_configuration_t::template exists<search_cfg::hit>();
 
-    //!\brief A flag indicating whether search should return the index cursor.
-    static constexpr bool search_return_index_cursor =
-        search_configuration_t::template exists<search_cfg::output<detail::search_output_index_cursor>>();
-    //!\brief A flag indicating whether search should return the text position.
-    static constexpr bool search_return_text_position =
-        search_configuration_t::template exists<search_cfg::output<detail::search_output_text_position>>();
+    //!\brief A flag indicating whether search should return the query_id.
+    static constexpr bool output_query_id = search_configuration_t::template exists<detail::output_query_id_tag>();
+    //!\brief A flag indicating whether search should return the reference_id.
+    static constexpr bool output_reference_id =
+                              search_configuration_t::template exists<detail::output_reference_id_tag>();
+    //!\brief A flag indicating whether search should return the reference_begin_pos.
+    static constexpr bool output_reference_begin_pos =
+                              search_configuration_t::template exists<detail::output_reference_begin_pos_tag>();
+    //!\brief A flag indicating whether search should return the index_cursor.
+    static constexpr bool output_index_cursor =
+                              search_configuration_t::template exists<detail::output_index_cursor_tag>();
+    //!\brief A flag indicating whether it is required to call cursor.locate() to retrieve the respective information.
+    static constexpr bool output_requires_locate_call = output_reference_id | output_reference_begin_pos;
+
     //!\brief A flag indicating whether output configuration was set in the search configuration.
-    static constexpr bool has_output_configuration = search_return_index_cursor | search_return_text_position;
+    static constexpr bool has_output_configuration = output_query_id |
+                                                     output_reference_id |
+                                                     output_reference_begin_pos |
+                                                     output_index_cursor;
 };
 
 } // namespace seqan3::detail

--- a/include/seqan3/search/search_result.hpp
+++ b/include/seqan3/search/search_result.hpp
@@ -59,8 +59,8 @@ namespace seqan3
  * * seqan3::search_result::reference_begin_pos()
  *
  * Note that the index cursor is not included in a hit by default. If you are trying to use the respective member
- * function, a static_assert will prevent you from doing so. You can configure the result of the search with the output
- * configuration (see seqan3::search_cfg::output).
+ * function, a static_assert will prevent you from doing so. You can configure the result of the search with the
+ * \ref search_configuration_subsection_output "output configuration".
  */
 template <typename query_id_type, typename cursor_type, typename reference_id_type, typename reference_begin_pos_type>
 //!\cond
@@ -81,22 +81,53 @@ private:
     //!\brief Stores the reference_begin_pos of the search result.
     reference_begin_pos_type reference_begin_pos_{};
 
-    /*!\brief Construct from a query id and an index cursor.
-     * \param[in] id The query id of the search result.
+    /*!\brief A generic constructor from all parameters.
+     * \tparam query_id_t Must be equal to query_id_t, if query_id_t is not empty_type.
+     * \tparam cursor_t Must be equal to cursor_t, if cursor_t is not empty_type.
+     * \tparam reference_id_t Must be equal to reference_id_t, if reference_id_t is not empty_type.
+     * \tparam reference_begin_pos_t Must be equal to reference_begin_pos_t, if reference_begin_pos_t is not empty_type.
+     * \param[in] query_id The query id of the search result.
      * \param[in] cursor The cursor of the search result.
-     */
-    search_result(query_id_type id, cursor_type cursor) :
-        query_id_(id), cursor_(std::move(cursor))
-    {}
-
-    /*!\brief Construct from a query id, a reference id and a begin position in the reference.
-     * \param[in] q_id The query id of the search result.
      * \param[in] ref_id The reference id of the search result.
      * \param[in] ref_pos The reference begin position of the search result.
+     *
+     * Each member (the order matters!) will only be initialized if the respective type is not seqan3::detail::empty_type.
+     * That way, the constructor call is independent of the output configuration and the search result
+     * will handle the initialisation.
      */
-    search_result(query_id_type q_id, reference_id_type ref_id, reference_begin_pos_type ref_pos) :
-        query_id_(q_id), reference_id_(std::move(ref_id)), reference_begin_pos_(std::move(ref_pos))
-    {}
+    template <typename query_id_t, typename cursor_t, typename reference_id_t, typename reference_begin_pos_t>
+    search_result(query_id_t query_id,
+                  [[maybe_unused]] cursor_t cursor,
+                  [[maybe_unused]] reference_id_t ref_id,
+                  [[maybe_unused]] reference_begin_pos_t ref_pos)
+    {
+        if constexpr (!std::same_as<query_id_type, detail::empty_type>)
+        {
+            static_assert(std::assignable_from<query_id_type &, query_id_t &&>,
+                          "The member variable query_id_ must be assignable from parameter query_id!");
+            query_id_ = std::move(query_id);
+        }
+        if constexpr (!std::same_as<cursor_type, detail::empty_type>)
+        {
+            static_assert(std::assignable_from<cursor_type &, cursor_t &&>,
+                          "The member variable cursor_ must be assignable from parameter cursor!");
+            cursor_ = std::move(cursor);
+        }
+        if constexpr (!std::same_as<reference_id_type, detail::empty_type>)
+        {
+            static_assert(std::assignable_from<reference_id_type &, reference_id_t &&>,
+                          "The member variable passed reference_id_ must be assignable from parameter ref_id!");
+            reference_id_ = std::move(ref_id);
+        }
+        if constexpr (!std::same_as<reference_begin_pos_type, detail::empty_type>)
+        {
+            static_assert(std::assignable_from<reference_begin_pos_type &, reference_begin_pos_t &&>,
+                          "The member variable passed to reference_begin_pos_ must be assignable from parameter "
+                          "ref_pos!");
+            reference_begin_pos_ = std::move(ref_pos);
+        }
+        (void) query_id; // [[maybe_unused]] bug for gcc < 9.3 (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81429)
+    }
 
     // Grant the policy access to private constructors.
     template <typename search_configuration_t>

--- a/include/seqan3/search/search_result.hpp
+++ b/include/seqan3/search/search_result.hpp
@@ -81,54 +81,6 @@ private:
     //!\brief Stores the reference_begin_pos of the search result.
     reference_begin_pos_type reference_begin_pos_{};
 
-    /*!\brief A generic constructor from all parameters.
-     * \tparam query_id_t Must be equal to query_id_t, if query_id_t is not empty_type.
-     * \tparam cursor_t Must be equal to cursor_t, if cursor_t is not empty_type.
-     * \tparam reference_id_t Must be equal to reference_id_t, if reference_id_t is not empty_type.
-     * \tparam reference_begin_pos_t Must be equal to reference_begin_pos_t, if reference_begin_pos_t is not empty_type.
-     * \param[in] query_id The query id of the search result.
-     * \param[in] cursor The cursor of the search result.
-     * \param[in] ref_id The reference id of the search result.
-     * \param[in] ref_pos The reference begin position of the search result.
-     *
-     * Each member (the order matters!) will only be initialized if the respective type is not seqan3::detail::empty_type.
-     * That way, the constructor call is independent of the output configuration and the search result
-     * will handle the initialisation.
-     */
-    template <typename query_id_t, typename cursor_t, typename reference_id_t, typename reference_begin_pos_t>
-    search_result(query_id_t query_id,
-                  [[maybe_unused]] cursor_t cursor,
-                  [[maybe_unused]] reference_id_t ref_id,
-                  [[maybe_unused]] reference_begin_pos_t ref_pos)
-    {
-        if constexpr (!std::same_as<query_id_type, detail::empty_type>)
-        {
-            static_assert(std::assignable_from<query_id_type &, query_id_t &&>,
-                          "The member variable query_id_ must be assignable from parameter query_id!");
-            query_id_ = std::move(query_id);
-        }
-        if constexpr (!std::same_as<cursor_type, detail::empty_type>)
-        {
-            static_assert(std::assignable_from<cursor_type &, cursor_t &&>,
-                          "The member variable cursor_ must be assignable from parameter cursor!");
-            cursor_ = std::move(cursor);
-        }
-        if constexpr (!std::same_as<reference_id_type, detail::empty_type>)
-        {
-            static_assert(std::assignable_from<reference_id_type &, reference_id_t &&>,
-                          "The member variable passed reference_id_ must be assignable from parameter ref_id!");
-            reference_id_ = std::move(ref_id);
-        }
-        if constexpr (!std::same_as<reference_begin_pos_type, detail::empty_type>)
-        {
-            static_assert(std::assignable_from<reference_begin_pos_type &, reference_begin_pos_t &&>,
-                          "The member variable passed to reference_begin_pos_ must be assignable from parameter "
-                          "ref_pos!");
-            reference_begin_pos_ = std::move(ref_pos);
-        }
-        (void) query_id; // [[maybe_unused]] bug for gcc < 9.3 (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81429)
-    }
-
     // Grant the policy access to private constructors.
     template <typename search_configuration_t>
     #if !SEQAN3_WORKAROUND_GCC_93467

--- a/test/snippet/search/configuration_default.cpp
+++ b/test/snippet/search/configuration_default.cpp
@@ -10,7 +10,9 @@ int main()
                                               seqan3::search_cfg::max_error_substitution{zero_errors} |
                                               seqan3::search_cfg::max_error_insertion{zero_errors} |
                                               seqan3::search_cfg::max_error_deletion{zero_errors} |
-                                              seqan3::search_cfg::output{seqan3::search_cfg::text_position} |
+                                              seqan3::search_cfg::output_query_id |
+                                              seqan3::search_cfg::output_reference_id |
+                                              seqan3::search_cfg::output_reference_begin_pos |
                                               seqan3::search_cfg::hit_all;
     return 0;
 }

--- a/test/snippet/search/configuration_output.cpp
+++ b/test/snippet/search/configuration_output.cpp
@@ -3,17 +3,15 @@
 
 int main()
 {
-    // Report hits as positions in the text.
-    seqan3::configuration const cfg1 = seqan3::search_cfg::max_error_total{seqan3::search_cfg::error_count{1}} |
-                                       seqan3::search_cfg::max_error_substitution{seqan3::search_cfg::error_count{0}} |
-                                       seqan3::search_cfg::max_error_insertion{seqan3::search_cfg::error_count{1}} |
-                                       seqan3::search_cfg::max_error_deletion{seqan3::search_cfg::error_count{1}} |
-                                       seqan3::search_cfg::output{seqan3::search_cfg::text_position};
+    // Only return the reference id where a query matched the reference:
+    seqan3::configuration const cfg1 = seqan3::search_cfg::output_reference_id;
 
-    // Return cursors of the index.
-    seqan3::configuration const cfg2 = seqan3::search_cfg::max_error_substitution{seqan3::search_cfg::error_count{0}} |
-                                       seqan3::search_cfg::max_error_insertion{seqan3::search_cfg::error_count{1}} |
-                                       seqan3::search_cfg::max_error_deletion{seqan3::search_cfg::error_count{1}} |
-                                       seqan3::search_cfg::output{seqan3::search_cfg::index_cursor};
+    // Same as the default:
+    seqan3::configuration const cfg2 = seqan3::search_cfg::output_query_id |
+                                       seqan3::search_cfg::output_reference_id |
+                                       seqan3::search_cfg::output_reference_begin_pos;
+
+    // Only return cursors of the index.
+    seqan3::configuration const cfg3 = seqan3::search_cfg::output_index_cursor;
     return 0;
 }

--- a/test/unit/search/search_configuration_test.cpp
+++ b/test/unit/search/search_configuration_test.cpp
@@ -30,7 +30,10 @@ using test_types = ::testing::Types<seqan3::search_cfg::max_error_total,
                                     seqan3::search_cfg::max_error_insertion,
                                     seqan3::search_cfg::max_error_deletion,
                                     seqan3::detail::hit_single_best_tag,
-                                    seqan3::search_cfg::output<seqan3::detail::search_output_text_position>,
+                                    seqan3::detail::output_query_id_tag,
+                                    seqan3::detail::output_reference_id_tag,
+                                    seqan3::detail::output_reference_begin_pos_tag,
+                                    seqan3::detail::output_index_cursor_tag,
                                     seqan3::search_cfg::parallel,
                                     seqan3::search_cfg::detail::result_type_tag<search_result_t>>;
 

--- a/test/unit/search/search_scheme_algorithm_test.cpp
+++ b/test/unit/search/search_scheme_algorithm_test.cpp
@@ -42,7 +42,7 @@ static void search_trivial(index_t const & index,
                seqan3::search_cfg::max_error_insertion{seqan3::search_cfg::error_count{error_left.insertion}} |
                seqan3::search_cfg::max_error_deletion{seqan3::search_cfg::error_count{error_left.deletion}} |
                seqan3::search_cfg::hit_all |
-               seqan3::search_cfg::output{seqan3::search_cfg::index_cursor};
+               seqan3::search_cfg::output_index_cursor;
 
     auto indexed_query = std::pair{size_t{0}, query};
     auto algo = std::get<0>(seqan3::detail::search_configurator::configure_algorithm<decltype(indexed_query)>(cfg,


### PR DESCRIPTION
Fixes seqan/product_backlog#67

The configuration element `seqan3::search_cfg::output` does not exist anymore. 
It has been replaced by individual configuration elements
    * `seqan3::search_cfg::output_query_id`
    * `seqan3::search_cfg::output_reference_id`
    * `seqan3::search_cfg::output_reference_begin_pos`
    * `seqan3::search_cfg::output_index_cursor`


**Note**: Before you could only either output text positions or cursors. Now you can output both. I updated the documentation with a note about this.