### PR TITLE
[CI] action-rsyncer can't handle --contimeout=60, remove it again

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -56,7 +56,7 @@ jobs:
           REMOTE_USER: ${{ secrets.REMOTE_USER }}
           TARGET: ${{ secrets.REMOTE_TARGET }}
         with:
-          flags: '-avzr --delete --timeout=60 --contimeout=60'
+          flags: '-avzr --delete --timeout=60'
           src: 'doc-build/doc_usr/html/'
           dest: '$REMOTE_USER@$REMOTE_HOST:$TARGET/3-master-user'
 
@@ -68,6 +68,6 @@ jobs:
           REMOTE_USER: ${{ secrets.REMOTE_USER }}
           TARGET: ${{ secrets.REMOTE_TARGET }}
         with:
-          flags: '-avzr --delete --timeout=60 --contimeout=60'
+          flags: '-avzr --delete --timeout=60'
           src: 'doc-build/doc_dev/html/'
           dest: '$REMOTE_USER@$REMOTE_HOST:$TARGET/3-master-dev'


### PR DESCRIPTION
My latest change to the documentation ci did not work https://github.com/seqan/seqan3/pull/1816.

It says

> The --contimeout option may only be used when connecting to an rsync daemon.

https://github.com/seqan/seqan3/runs/720168867?check_suite_focus=true#step:9:14

Since `--contimeout` is not working this PR removes that command again.