### PR TITLE
[FIX] Timezone in deployed docs

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -41,6 +41,8 @@ jobs:
         run: sudo apt-get install texlive-font-utils ghostscript texlive-latex-extra graphviz # graphviz for dot, latex to parse formulas
 
       - name: Build documentation
+        env:
+          TZ: Europe/Berlin
         shell: bash
         run: |
           mkdir doc-build


### PR DESCRIPTION
I often check the timestamp of the docs to see if something was already deployed or when the docs were last updated and find it rather confusing that the time is off by a few hours.