### PR TITLE
 [API] The alignment configuration for the band changed to seqan3::align_cfg::band_fixed_size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,16 @@ Note that 3.1.0 will be the first API stable release and interfaces in this rele
 
 ## API changes
 
+### Alignment
+
+* The alignment configuration elements were refactored:
+  * The option `seqan3::align_cfg::band` is now renamed to `seqan3::align_cfg::band_fixed_size` and directly initialised
+    with a `seqan3::align_cfg::lower_diagonal` and `seqan3::align_cfg::upper_diagonal` instead of `seqan3::static_band`.
+    It also directly exposes the lower_diagonal and upper_diagonal as public members
+    ([\#1873](https://github.com/seqan/seqan3/pull/1873)).
+
+### Core
+
 * In accordance with the standard, the following concepts are renamed:
   * `default_constructible` to `default_initializable`
   * `readable` to `indirectly_readable`

--- a/doc/tutorial/pairwise_alignment/configurations.cpp
+++ b/doc/tutorial/pairwise_alignment/configurations.cpp
@@ -20,7 +20,6 @@
 //! [include_result]
 
 //! [include_band]
-#include <seqan3/alignment/band/static_band.hpp>
 #include <seqan3/alignment/configuration/align_config_band.hpp>
 //! [include_band]
 
@@ -92,7 +91,8 @@ auto cfg = seqan3::align_cfg::result{seqan3::with_score};
 //! [band]
 
 // Configure a banded alignment.
-auto cfg = seqan3::align_cfg::band{seqan3::static_band{seqan3::lower_bound{-4}, seqan3::upper_bound{4}}};
+auto cfg = seqan3::align_cfg::band_fixed_size{seqan3::align_cfg::lower_diagonal{-4},
+                                              seqan3::align_cfg::upper_diagonal{4}};
 //! [band]
 (void) cfg;
 }

--- a/doc/tutorial/pairwise_alignment/index.md
+++ b/doc/tutorial/pairwise_alignment/index.md
@@ -267,14 +267,14 @@ In many situations it is not necessary to compute the entire alignment matrix bu
 positive impacts on the performance. To limit the computation space the alignment matrix can be bounded by a band.
 Thus, only the alignment is computed that fits in this band. Note that this must not be the optimal alignment but in
 many cases we can give a rough bound on how similar the sequences will be and therefor use the banded alignment.
-To do so, you can use a seqan3::static_band. It will be initialised with a seqan3::lower_bound and a
-seqan3::upper_bound. To configure the banded alignment you need to use the seqan3::align_cfg::band configuration.
+To do so, you can configure the alignment using the seqan3::align_cfg::band_fixed_size option. This configuration
+element will be initialised with a seqan3::align_cfg::lower_diagonal and seqan3::align_cfg::upper_diagonal.
 
 \snippet doc/tutorial/pairwise_alignment/configurations.cpp include_band
 \snippet doc/tutorial/pairwise_alignment/configurations.cpp band
 
 \assignment{Assignment 5}
-Use the example from assignment 4 and compute it in a band with lower bound set to `-3` and upper bound set to `8`.
+Use the example from assignment 4 and compute it in a band with lower diagonal set to `-3` and upper diagonal set to `8`.
 How does the result change?
 
 \endassignment

--- a/doc/tutorial/pairwise_alignment/pairwise_alignment_solution_5.cpp
+++ b/doc/tutorial/pairwise_alignment/pairwise_alignment_solution_5.cpp
@@ -1,6 +1,5 @@
 #include <utility>
 
-#include <seqan3/alignment/band/static_band.hpp>
 #include <seqan3/alignment/pairwise/align_pairwise.hpp>
 #include <seqan3/alignment/scoring/nucleotide_scoring_scheme.hpp>
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
@@ -20,7 +19,8 @@ int main()
                   seqan3::align_cfg::gap{seqan3::gap_scheme{seqan3::gap_score{-4}}} |
                   seqan3::align_cfg::aligned_ends{seqan3::free_ends_all} |
                   seqan3::align_cfg::result{seqan3::with_alignment} |
-                  seqan3::align_cfg::band{seqan3::static_band{seqan3::lower_bound{-3}, seqan3::upper_bound{8}}};
+                  seqan3::align_cfg::band_fixed_size{seqan3::align_cfg::lower_diagonal{-3},
+                                                     seqan3::align_cfg::upper_diagonal{8}};
 
     for (auto const & res : seqan3::align_pairwise(std::tie(seq1, seq2), config))
     {

--- a/include/seqan3/alignment/all.hpp
+++ b/include/seqan3/alignment/all.hpp
@@ -81,7 +81,7 @@
  * | **Config**                                              | **0** | **1** | **2** | **3** | **4** | **5** | **6** | **7** | **8** | **9** |
  * | --------------------------------------------------------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|
  * | \ref seqan3::align_cfg::aligned_ends "0: Aligned ends"  |   ❌   |   ✅   |  ✅    |  ❌    |  ✅    |  ✅    |  ✅    |  ✅    |  ✅    |  ✅    |
- * | \ref seqan3::align_cfg::band "1: Band"                  |       |   ❌   |  ✅    |  ✅    |  ✅    |  ✅    |  ✅    |  ✅    |  ✅    |  ✅    |
+ * | \ref seqan3::align_cfg::band_fixed_size "1: Band"       |       |   ❌   |  ✅    |  ✅    |  ✅    |  ✅    |  ✅    |  ✅    |  ✅    |  ✅    |
  * | \ref seqan3::align_cfg::gap "2: Gap scheme"             |       |       |   ❌   |  ✅    |  ✅    |  ✅    |  ✅    |  ✅    |  ✅    |  ✅    |
  * | \ref seqan3::global_alignment "3: Global alignment"     |       |       |       |  ❌    |  ❌    |  ✅    |  ✅    |  ✅    |  ✅    |  ✅    |
  * | \ref seqan3::local_alignment "4: Local alignment"       |       |       |       |       |  ❌    |  ❌    |  ✅    |  ✅    |  ✅    |  ✅    |
@@ -171,12 +171,12 @@
  *
  * SeqAn offers the computation of banded alignments to reduce the running time of the algorithm. This can be
  * helpful if the region in which the optimal alignment exists is known a priori. To specify the banded alignment
- * the developer can use the seqan3::align_cfg::band option initialised with a seqan3::static_band.
- * The seqan3::static_band is constructed with a lower bound and an upper bound. The upper bound must always be greater
- * than or equal to the lower bound. To position the band, imagine a rectangle where the first sequence is written on
- * top and the second sequence along the left vertical side. A negative bound implies a start of the band within the
- * vertical part while a positive bound implies a start within the top part of this rectangle at the respective
- * position.
+ * the developer can use the seqan3::align_cfg::band_fixed_size option.
+ * This band configuration is initialised with a seqan3::align_cfg::lower_diagonal and an
+ * seqan3::align_cfg::upper_diagonal. The upper diagonal must always be greater than or equal to the lower diagonal.
+ * To choose the correct band parameters, imagine a matrix with the first sequence written on top and the second sequence
+ * along the left vertical side. A negative value reflects a start of the diagonal within the vertical part while a
+ * positive value implies a start within the top part of this matrix at the respective position.
  *
  * ## Global and local alignments
  *

--- a/include/seqan3/alignment/configuration/detail.hpp
+++ b/include/seqan3/alignment/configuration/detail.hpp
@@ -25,7 +25,7 @@ enum struct align_config_id : uint8_t
     //!\brief ID for the \ref seqan3::align_cfg::alignment_result_capture "alignment_result_capture" option.
     alignment_result_capture,
     aligned_ends, //!< ID for the \ref seqan3::align_cfg::aligned_ends "aligned_ends" option.
-    band,         //!< ID for the \ref seqan3::align_cfg::band "band" option.
+    band,         //!< ID for the \ref seqan3::align_cfg::band_fixed_size "band" option.
     debug,        //!< ID for the \ref seqan3::align_cfg::debug "debug" option.
     gap,          //!< ID for the \ref seqan3::align_cfg::gap "gap" option.
     global,       //!< ID for the \ref seqan3::global_alignment "global alignment" option.

--- a/include/seqan3/alignment/matrix/detail/aligned_sequence_builder.hpp
+++ b/include/seqan3/alignment/matrix/detail/aligned_sequence_builder.hpp
@@ -16,7 +16,6 @@
 #include <vector>
 
 #include <seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp>
-#include <seqan3/alignment/band/static_band.hpp>
 #include <seqan3/alignment/matrix/detail/matrix_coordinate.hpp>
 #include <seqan3/alignment/matrix/trace_directions.hpp>
 #include <seqan3/alphabet/gap/gapped.hpp>

--- a/include/seqan3/alignment/matrix/detail/alignment_score_matrix_one_column_banded.hpp
+++ b/include/seqan3/alignment/matrix/detail/alignment_score_matrix_one_column_banded.hpp
@@ -12,7 +12,7 @@
 
 #pragma once
 
-#include <seqan3/alignment/band/static_band.hpp>
+#include <seqan3/alignment/configuration/align_config_band.hpp>
 #include <seqan3/alignment/matrix/detail/alignment_matrix_column_major_range_base.hpp>
 #include <seqan3/alignment/matrix/detail/alignment_score_matrix_one_column_base.hpp>
 #include <seqan3/alignment/matrix/detail/alignment_score_matrix_proxy.hpp>
@@ -99,7 +99,7 @@ public:
      *
      * \param[in] first          The first range.
      * \param[in] second         The second range.
-     * \param[in] band           The seqan3::static_band in which to calculate the alignment.
+     * \param[in] band           The seqan3::align_cfg::band_fixed_size in which to calculate the alignment.
      * \param[in] initial_value  The value to initialise the matrix with. Default initialised if not specified.
      *
      * \details
@@ -111,14 +111,14 @@ public:
               std::ranges::forward_range second_sequence_t>
     constexpr alignment_score_matrix_one_column_banded(first_sequence_t && first,
                                                        second_sequence_t && second,
-                                                       static_band const & band,
+                                                       align_cfg::band_fixed_size const & band,
                                                        score_t const initial_value = score_t{})
     {
         matrix_base_t::num_cols = static_cast<size_type>(std::ranges::distance(first) + 1);
         matrix_base_t::num_rows = static_cast<size_type>(std::ranges::distance(second) + 1);
 
-        band_col_index = std::min<int32_t>(std::max<int32_t>(band.upper_bound, 0), matrix_base_t::num_cols - 1);
-        band_row_index = std::min<int32_t>(std::abs(std::min<int32_t>(band.lower_bound, 0)),
+        band_col_index = std::min<int32_t>(std::max<int32_t>(band.upper_diagonal.get(), 0), matrix_base_t::num_cols - 1);
+        band_row_index = std::min<int32_t>(std::abs(std::min<int32_t>(band.lower_diagonal.get(), 0)),
                                            matrix_base_t::num_rows - 1);
 
         band_size = band_col_index + band_row_index + 1;

--- a/include/seqan3/alignment/matrix/detail/alignment_trace_matrix_full_banded.hpp
+++ b/include/seqan3/alignment/matrix/detail/alignment_trace_matrix_full_banded.hpp
@@ -12,7 +12,7 @@
 
 #pragma once
 
-#include <seqan3/alignment/band/static_band.hpp>
+#include <seqan3/alignment/configuration/align_config_band.hpp>
 #include <seqan3/alignment/matrix/detail/alignment_matrix_column_major_range_base.hpp>
 #include <seqan3/alignment/matrix/detail/alignment_trace_matrix_base.hpp>
 #include <seqan3/alignment/matrix/detail/alignment_trace_matrix_proxy.hpp>
@@ -115,7 +115,7 @@ public:
      *
      * \param[in] first         The first range.
      * \param[in] second        The second range.
-     * \param[in] band          The seqan3::static_band in which to calculate the alignment.
+     * \param[in] band          The seqan3::align_cfg::band_fixed_size in which to calculate the alignment.
      * \param[in] initial_value The value to initialise the matrix with. Default initialised if not specified.
      *
      * \details
@@ -127,14 +127,16 @@ public:
     template <std::ranges::forward_range first_sequence_t, std::ranges::forward_range second_sequence_t>
     constexpr alignment_trace_matrix_full_banded(first_sequence_t && first,
                                                  second_sequence_t && second,
-                                                 static_band const & band,
+                                                 align_cfg::band_fixed_size const & band,
                                                  [[maybe_unused]] trace_t const initial_value = trace_t{})
     {
         matrix_base_t::num_cols = static_cast<size_type>(std::ranges::distance(first) + 1);
         matrix_base_t::num_rows = static_cast<size_type>(std::ranges::distance(second) + 1);
 
-        band_col_index = std::min<int32_t>(std::max<int32_t>(band.upper_bound, 0), matrix_base_t::num_cols - 1);
-        band_row_index = std::min<int32_t>(std::abs(std::min<int32_t>(band.lower_bound, 0)), matrix_base_t::num_rows - 1);
+        band_col_index = std::min<int32_t>(std::max<int32_t>(band.upper_diagonal.get(), 0),
+                                           matrix_base_t::num_cols - 1);
+        band_row_index = std::min<int32_t>(std::abs(std::min<int32_t>(band.lower_diagonal.get(), 0)),
+                                           matrix_base_t::num_rows - 1);
         band_size = band_col_index + band_row_index + 1;
 
         // Reserve one more cell to deal with last cell in the banded column which needs only the diagonal and up cell.

--- a/include/seqan3/alignment/pairwise/detail/type_traits.hpp
+++ b/include/seqan3/alignment/pairwise/detail/type_traits.hpp
@@ -112,7 +112,7 @@ public:
     //!\brief Flag indicating whether local alignment mode is enabled.
     static constexpr bool is_local = configuration_t::template exists<align_cfg::mode<detail::local_alignment_type>>();
     //!\brief Flag indicating whether banded alignment mode is enabled.
-    static constexpr bool is_banded = configuration_t::template exists<align_cfg::band>();
+    static constexpr bool is_banded = configuration_t::template exists<align_cfg::band_fixed_size>();
     //!\brief Flag indicating whether debug mode is enabled.
     static constexpr bool is_debug = configuration_t::template exists<detail::debug_mode>();
 

--- a/include/seqan3/alignment/pairwise/policy/alignment_matrix_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/alignment_matrix_policy.hpp
@@ -15,7 +15,7 @@
 #include <limits>
 #include <tuple>
 
-#include <seqan3/alignment/band/static_band.hpp>
+#include <seqan3/alignment/configuration/align_config_band.hpp>
 #include <seqan3/alignment/pairwise/detail/alignment_algorithm_state.hpp>
 #include <seqan3/core/type_traits/basic.hpp>
 #include <seqan3/range/views/slice.hpp>
@@ -106,7 +106,7 @@ private:
     template <typename sequence1_t, typename sequence2_t, typename score_t>
     constexpr void allocate_matrix(sequence1_t && sequence1,
                                    sequence2_t && sequence2,
-                                   static_band const & band,
+                                   align_cfg::band_fixed_size const & band,
                                    alignment_algorithm_state<score_t> const & state)
     {
         assert(state.gap_extension_score <= 0); // We expect it to never be positive.
@@ -130,7 +130,7 @@ private:
     * \tparam sequence2_t The type of the second sequence to align; must model std::forward_ranges.
     * \param[in] sequence1 The first sequence to align.
     * \param[in] sequence2 The second sequence to align.
-    * \param[in] band The seqan3::static_band used to limit the alignment space.
+    * \param[in] band The seqan3::align_cfg::band_fixed_size used to limit the alignment space.
     *
     * \details
     *
@@ -140,22 +140,22 @@ private:
     template <typename sequence1_t, typename sequence2_t>
     constexpr auto slice_sequences(sequence1_t & sequence1,
                                    sequence2_t & sequence2,
-                                   static_band const & band) const noexcept
+                                   align_cfg::band_fixed_size const & band) const noexcept
     {
         size_t seq1_size = std::ranges::distance(sequence1);
         size_t seq2_size = std::ranges::distance(sequence2);
 
         auto trim_sequence1 = [&] () constexpr
         {
-            size_t begin_pos = std::max<std::ptrdiff_t>(band.lower_bound - 1, 0);
-            size_t end_pos = std::min<std::ptrdiff_t>(band.upper_bound + seq2_size, seq1_size);
+            size_t begin_pos = std::max<std::ptrdiff_t>(band.lower_diagonal.get() - 1, 0);
+            size_t end_pos = std::min<std::ptrdiff_t>(band.upper_diagonal.get() + seq2_size, seq1_size);
             return sequence1 | views::slice(begin_pos, end_pos);
         };
 
         auto trim_sequence2 = [&] () constexpr
         {
-            size_t begin_pos = std::abs(std::min<std::ptrdiff_t>(band.upper_bound + 1, 0));
-            size_t end_pos = std::min<std::ptrdiff_t>(seq1_size - band.lower_bound, seq2_size);
+            size_t begin_pos = std::abs(std::min<std::ptrdiff_t>(band.upper_diagonal.get() + 1, 0));
+            size_t end_pos = std::min<std::ptrdiff_t>(seq1_size - band.lower_diagonal.get(), seq2_size);
             return sequence2 | views::slice(begin_pos, end_pos);
         };
 

--- a/include/seqan3/core/detail/strong_type.hpp
+++ b/include/seqan3/core/detail/strong_type.hpp
@@ -16,6 +16,7 @@
 #include <type_traits>
 
 #include <seqan3/core/add_enum_bitwise_operators.hpp>
+#include <seqan3/core/detail/debug_stream_type.hpp>
 #include <seqan3/core/type_traits/basic.hpp>
 
 namespace seqan3::detail
@@ -498,3 +499,35 @@ private:
     //!\brief The underlying value, which is wrapped as a strong type.
     value_t value;
 };
+
+//------------------------------------------------------------------------------
+// related functions
+//------------------------------------------------------------------------------
+
+/*!\name Formatted output
+ * \relates seqan3::detail::strong_type
+ * \{
+ */
+
+/*!\brief Formatted output to a seqan3::detail::debug_stream_type.
+ * \tparam char_t The char type of the seqan3::detail::debug_stream_type.
+ * \tparam strong_type_t The strong type to print; must model seqan3::detail::strong_type_specialisation.
+ *
+ * \param[in,out] stream The output stream.
+ * \param[in] value The strong typed value to print.
+ *
+ * \details
+ *
+ * Prints the stored value of the given strong type.
+ *
+ * \returns `stream_t &` A reference to the given stream.
+ */
+template <typename char_t, strong_type_specialisation strong_type_t>
+debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & stream, strong_type_t && value)
+{
+    stream << value.get();
+    return stream;
+}
+//!\}
+
+} // namespace seqan3::detail

--- a/test/snippet/alignment/configuration/align_cfg_band_example.cpp
+++ b/test/snippet/alignment/configuration/align_cfg_band_example.cpp
@@ -1,4 +1,3 @@
-#include <seqan3/alignment/band/static_band.hpp>
 #include <seqan3/alignment/configuration/align_config_band.hpp>
 
 int main()
@@ -6,16 +5,20 @@ int main()
 try
 {
     // A symmetric band around the main diagonal.
-    seqan3::align_cfg::band band_cfg{seqan3::static_band{seqan3::lower_bound{-4}, seqan3::upper_bound{4}}};
+    seqan3::align_cfg::band_fixed_size band_cfg{seqan3::align_cfg::lower_diagonal{-4},
+                                                seqan3::align_cfg::upper_diagonal{4}};
 
     // A band starting with the main diagonal shifted by 3 cells to the right.
-    seqan3::align_cfg::band band_cfg_hi{seqan3::static_band{seqan3::lower_bound{3}, seqan3::upper_bound{7}}};
+    seqan3::align_cfg::band_fixed_size band_cfg_hi{seqan3::align_cfg::lower_diagonal{3},
+                                                   seqan3::align_cfg::upper_diagonal{7}};
 
     // A band starting with the main diagonal shifted by 3 cells down.
-    seqan3::align_cfg::band band_cfg_lo{seqan3::static_band{seqan3::lower_bound{-7}, seqan3::upper_bound{-3}}};
+    seqan3::align_cfg::band_fixed_size band_cfg_lo{seqan3::align_cfg::lower_diagonal{-7},
+                                                   seqan3::align_cfg::upper_diagonal{-3}};
 
     // An invalid band configuration.
-    seqan3::align_cfg::band band_cfg_invalid{seqan3::static_band{seqan3::lower_bound{7}, seqan3::upper_bound{3}}};
+    seqan3::align_cfg::band_fixed_size band_cfg_invalid{seqan3::align_cfg::lower_diagonal{7},
+                                                        seqan3::align_cfg::upper_diagonal{3}};
 }
 catch(...)
 {

--- a/test/snippet/core/algorithm/configuration_combine.cpp
+++ b/test/snippet/core/algorithm/configuration_combine.cpp
@@ -1,4 +1,3 @@
-#include <seqan3/alignment/band/static_band.hpp>
 #include <seqan3/alignment/configuration/align_config_band.hpp>
 #include <seqan3/alignment/configuration/align_config_mode.hpp>
 #include <seqan3/core/algorithm/configuration.hpp>
@@ -8,6 +7,6 @@ int main()
 {
     // Here we use the global and banded alignment configurations to show how they can be combined.
     seqan3::configuration my_cfg = seqan3::align_cfg::mode{seqan3::global_alignment} |
-                                   seqan3::align_cfg::band{seqan3::static_band{seqan3::lower_bound{-4},
-                                                                               seqan3::upper_bound{4}}};
+                                   seqan3::align_cfg::band_fixed_size{seqan3::align_cfg::lower_diagonal{-4},
+                                                                      seqan3::align_cfg::upper_diagonal{4}};
 }

--- a/test/snippet/core/algorithm/configuration_get.cpp
+++ b/test/snippet/core/algorithm/configuration_get.cpp
@@ -1,4 +1,3 @@
-#include <seqan3/alignment/band/static_band.hpp>
 #include <seqan3/alignment/configuration/align_config_band.hpp>
 #include <seqan3/alignment/configuration/align_config_gap.hpp>
 #include <seqan3/alignment/scoring/gap_scheme.hpp>
@@ -12,11 +11,11 @@ int main()
 
     seqan3::configuration my_cfg = seqan3::align_cfg::gap{seqan3::gap_scheme{seqan3::gap_score{-1},
                                                                              seqan3::gap_open_score{-10}}} |
-                                   seqan3::align_cfg::band{seqan3::static_band{seqan3::lower_bound{-4},
-                                                                               seqan3::upper_bound{4}}};
+                                   seqan3::align_cfg::band_fixed_size{seqan3::align_cfg::lower_diagonal{-4},
+                                                                      seqan3::align_cfg::upper_diagonal{4}};
     // my_cfg is now of type configuration<gap, band>
 
-    seqan3::debug_stream << get<1>(my_cfg).value.lower_bound                          << '\n';  // prints -4
-    seqan3::debug_stream << get<seqan3::align_cfg::band>(my_cfg).value.upper_bound    << '\n';  // prints 4
-    seqan3::debug_stream << get<seqan3::align_cfg::gap>(my_cfg).value.get_gap_score() << '\n';  // prints -1
+    seqan3::debug_stream << get<1>(my_cfg).lower_diagonal                                  << '\n';  // prints -4
+    seqan3::debug_stream << get<seqan3::align_cfg::band_fixed_size>(my_cfg).upper_diagonal << '\n';  // prints 4
+    seqan3::debug_stream << get<seqan3::align_cfg::gap>(my_cfg).value.get_gap_score()      << '\n';  // prints -1
 }

--- a/test/unit/alignment/configuration/align_config_band_test.cpp
+++ b/test/unit/alignment/configuration/align_config_band_test.cpp
@@ -12,30 +12,66 @@
 #include <seqan3/alignment/configuration/align_config_band.hpp>
 #include <seqan3/core/algorithm/configuration.hpp>
 
-TEST(align_config_band, config_element_specialisation)
+#include "../../core/algorithm/pipeable_config_element_test_template.hpp"
+
+using test_types = ::testing::Types<seqan3::align_cfg::band_fixed_size>;
+
+INSTANTIATE_TYPED_TEST_SUITE_P(band_elements, pipeable_config_element_test, test_types, );
+
+TEST(band_fixed_size, config_element_specialisation)
 {
-    EXPECT_TRUE((seqan3::detail::config_element_specialisation<seqan3::align_cfg::band<seqan3::static_band>>));
+    EXPECT_TRUE((seqan3::detail::config_element_specialisation<seqan3::align_cfg::band_fixed_size>));
 }
 
-TEST(align_config_band, configuration)
+TEST(band_fixed_size, construct)
 {
-    {
-        seqan3::align_cfg::band elem{seqan3::static_band{seqan3::lower_bound{-5}, seqan3::upper_bound{5}}};
-        seqan3::configuration cfg{elem};
-        EXPECT_EQ((std::is_same_v<std::remove_reference_t<decltype(seqan3::get<seqan3::align_cfg::band>(cfg).value)>,
-                                  seqan3::static_band>), true);
+    using seqan3::get;
 
-        EXPECT_EQ(seqan3::get<seqan3::align_cfg::band>(cfg).value.lower_bound, -5);
-        EXPECT_EQ(seqan3::get<seqan3::align_cfg::band>(cfg).value.upper_bound, 5);
+    constexpr int32_t minus_infinity = std::numeric_limits<int32_t>::lowest();
+    constexpr int32_t plus_infinity = std::numeric_limits<int32_t>::max();
+
+    { // Default construct
+        seqan3::align_cfg::band_fixed_size band_config{};
+        EXPECT_EQ(band_config.lower_diagonal.get(), minus_infinity);
+        EXPECT_EQ(band_config.upper_diagonal.get(), plus_infinity);
     }
 
-    {
-        seqan3::configuration cfg{seqan3::align_cfg::band{seqan3::static_band{seqan3::lower_bound{-5},
-                                                                              seqan3::upper_bound{5}}}};
-        EXPECT_EQ((std::is_same_v<std::remove_reference_t<decltype(seqan3::get<seqan3::align_cfg::band>(cfg).value)>,
-                                  seqan3::static_band>), true);
+    { // Construct with parameter
+        seqan3::align_cfg::band_fixed_size band_config{seqan3::align_cfg::lower_diagonal{-5},
+                                                       seqan3::align_cfg::upper_diagonal{5}};
 
-        EXPECT_EQ(seqan3::get<seqan3::align_cfg::band>(cfg).value.lower_bound, -5);
-        EXPECT_EQ(seqan3::get<seqan3::align_cfg::band>(cfg).value.upper_bound, 5);
+        EXPECT_EQ(band_config.lower_diagonal.get(), -5);
+        EXPECT_EQ(band_config.upper_diagonal.get(), 5);
     }
+}
+
+TEST(band_fixed_size, assign)
+{
+    seqan3::align_cfg::band_fixed_size band_config{};
+
+    band_config.lower_diagonal = seqan3::align_cfg::lower_diagonal{-5};
+    band_config.upper_diagonal = seqan3::align_cfg::upper_diagonal{5};
+
+    EXPECT_EQ(band_config.lower_diagonal.get(), -5);
+    EXPECT_EQ(band_config.upper_diagonal.get(), 5);
+}
+
+TEST(band_fixed_size, get_and_assign)
+{
+    using seqan3::get;
+
+    seqan3::align_cfg::band_fixed_size band_config{seqan3::align_cfg::lower_diagonal{-5},
+                                                   seqan3::align_cfg::upper_diagonal{5}};
+    seqan3::configuration config{band_config};
+
+    auto & selected_band_config = get<seqan3::align_cfg::band_fixed_size>(config);
+
+    EXPECT_EQ(selected_band_config.lower_diagonal.get(), -5);
+    EXPECT_EQ(selected_band_config.upper_diagonal.get(), 5);
+
+    selected_band_config.lower_diagonal = seqan3::align_cfg::lower_diagonal{-4};
+    selected_band_config.upper_diagonal = seqan3::align_cfg::upper_diagonal{8};
+
+    EXPECT_EQ(get<seqan3::align_cfg::band_fixed_size>(config).lower_diagonal.get(), -4);
+    EXPECT_EQ(get<seqan3::align_cfg::band_fixed_size>(config).upper_diagonal.get(), 8);
 }

--- a/test/unit/alignment/configuration/align_config_common_test.cpp
+++ b/test/unit/alignment/configuration/align_config_common_test.cpp
@@ -10,7 +10,6 @@
 #include <type_traits>
 
 #include <seqan3/alignment/configuration/all.hpp>
-#include <seqan3/alignment/band/static_band.hpp>
 #include <seqan3/alignment/scoring/nucleotide_scoring_scheme.hpp>
 
 template <typename T>
@@ -20,7 +19,7 @@ class alignment_configuration_test : public ::testing::Test
 using alignment_result_t = seqan3::alignment_result<seqan3::detail::alignment_result_value_type<int, int>>;
 
 using test_types = ::testing::Types<seqan3::align_cfg::aligned_ends<std::remove_const_t<decltype(seqan3::free_ends_all)>>,
-                                    seqan3::align_cfg::band<seqan3::static_band>,
+                                    seqan3::align_cfg::band_fixed_size,
                                     seqan3::align_cfg::gap<seqan3::gap_scheme<>>,
                                     seqan3::align_cfg::max_error,
                                     seqan3::align_cfg::mode<seqan3::detail::global_alignment_type>,

--- a/test/unit/alignment/matrix/detail/alignment_matrix_base_test_template.hpp
+++ b/test/unit/alignment/matrix/detail/alignment_matrix_base_test_template.hpp
@@ -7,7 +7,7 @@
 
 #include <gtest/gtest.h>
 
-#include <seqan3/alignment/band/static_band.hpp>
+#include <seqan3/alignment/configuration/align_config_band.hpp>
 #include <seqan3/std/ranges>
 
 template <typename t>
@@ -19,7 +19,10 @@ struct alignment_matrix_base_test : public ::testing::Test
     alignment_matrix_base_test()
     {
         if constexpr (is_banded)
-            test_range = matrix_t{first, second, seqan3::static_band{seqan3::lower_bound{-2}, seqan3::upper_bound{2}}};
+            test_range = matrix_t{first,
+                                  second,
+                                  seqan3::align_cfg::band_fixed_size{seqan3::align_cfg::lower_diagonal{-2},
+                                                                     seqan3::align_cfg::upper_diagonal{2}}};
         else
             test_range = matrix_t{first, second};
     }
@@ -90,7 +93,8 @@ TYPED_TEST_P(alignment_matrix_base_test, empty_row)
 
     if constexpr (TestFixture::is_banded)
     {
-        seqan3::static_band band{seqan3::lower_bound{-2}, seqan3::upper_bound{4}};
+        seqan3::align_cfg::band_fixed_size band{seqan3::align_cfg::lower_diagonal{-2},
+                                                seqan3::align_cfg::upper_diagonal{4}};
         test_matrix_iteration(matrix_type{this->first, std::string{""}, band}, 5, 5);
     }
     else
@@ -105,7 +109,8 @@ TYPED_TEST_P(alignment_matrix_base_test, empty_col)
 
     if constexpr (TestFixture::is_banded)
     {
-        seqan3::static_band band{seqan3::lower_bound{-2}, seqan3::upper_bound{2}};
+        seqan3::align_cfg::band_fixed_size band{seqan3::align_cfg::lower_diagonal{-2},
+                                                seqan3::align_cfg::upper_diagonal{2}};
         test_matrix_iteration(matrix_type{std::string{""}, this->second, band}, 1, 3);
     }
     else
@@ -120,7 +125,8 @@ TYPED_TEST_P(alignment_matrix_base_test, empty_col_row)
 
     if constexpr (TestFixture::is_banded)
     {
-        seqan3::static_band band{seqan3::lower_bound{0}, seqan3::upper_bound{2}};
+        seqan3::align_cfg::band_fixed_size band{seqan3::align_cfg::lower_diagonal{0},
+                                                seqan3::align_cfg::upper_diagonal{2}};
         test_matrix_iteration(matrix_type{std::string{""}, std::string{""}, band}, 1, 1);
     }
     else

--- a/test/unit/alignment/matrix/detail/alignment_score_matrix_one_column_banded_test.cpp
+++ b/test/unit/alignment/matrix/detail/alignment_score_matrix_one_column_banded_test.cpp
@@ -24,7 +24,11 @@ struct alignment_score_matrix_one_column_banded_test
 
     alignment_score_matrix_one_column_banded_test() = default;
     alignment_score_matrix_one_column_banded_test(std::string f, std::string s) :
-        matrix{matrix_t{f, s, seqan3::static_band{seqan3::lower_bound{-2}, seqan3::upper_bound{2}}, -100}}
+        matrix{matrix_t{f,
+                        s,
+                        seqan3::align_cfg::band_fixed_size{seqan3::align_cfg::lower_diagonal{-2},
+                                                           seqan3::align_cfg::upper_diagonal{2}},
+                        -100}}
     {}
 
     // Banded matrix. We write only partial columns to the result.

--- a/test/unit/alignment/matrix/detail/alignment_trace_matrix_full_banded_test.cpp
+++ b/test/unit/alignment/matrix/detail/alignment_trace_matrix_full_banded_test.cpp
@@ -118,7 +118,10 @@ INSTANTIATE_TYPED_TEST_SUITE_P(banded_trace_matrix_inner_iterator,
 TEST(trace_matrix, trace_path)
 {
     seqan3::detail::alignment_trace_matrix_full_banded<seqan3::detail::trace_directions>
-        matrix{"acgt", "acgt", seqan3::static_band{seqan3::lower_bound{-3}, seqan3::upper_bound{3}}};
+        matrix{"acgt",
+               "acgt",
+               seqan3::align_cfg::band_fixed_size{seqan3::align_cfg::lower_diagonal{-3},
+                                                  seqan3::align_cfg::upper_diagonal{3}}};
 
     EXPECT_THROW((matrix.trace_path(seqan3::detail::matrix_coordinate{seqan3::detail::row_index_type{7u},
                                                                       seqan3::detail::column_index_type{4u}})),

--- a/test/unit/alignment/pairwise/alignment_configurator_test.cpp
+++ b/test/unit/alignment/pairwise/alignment_configurator_test.cpp
@@ -73,8 +73,8 @@ TEST(alignment_configurator, configure_edit_semi)
 TEST(alignment_configurator, configure_edit_banded)
 {
     EXPECT_THROW((run_test(seqan3::align_cfg::edit |
-                           seqan3::align_cfg::band{seqan3::static_band{seqan3::lower_bound{-1},
-                                                                       seqan3::upper_bound{1}}})),
+                           seqan3::align_cfg::band_fixed_size{seqan3::align_cfg::lower_diagonal{-1},
+                                                              seqan3::align_cfg::upper_diagonal{1}})),
                  seqan3::invalid_alignment_configuration);
 }
 
@@ -138,7 +138,7 @@ TEST(alignment_configurator, configure_affine_global_banded)
         auto cfg = seqan3::align_cfg::mode{seqan3::global_alignment} |
                    seqan3::align_cfg::scoring{seqan3::nucleotide_scoring_scheme{}} |
                    seqan3::align_cfg::gap{seqan3::gap_scheme{seqan3::gap_score{-1}, seqan3::gap_open_score{-10}}} |
-                   seqan3::align_cfg::band{seqan3::static_band{seqan3::lower_bound{-1}, seqan3::upper_bound{1}}};
+          seqan3::align_cfg::band_fixed_size{seqan3::align_cfg::lower_diagonal{-1}, seqan3::align_cfg::upper_diagonal{1}};
 
         EXPECT_EQ(run_test(cfg).score(), 0);
     }
@@ -147,10 +147,10 @@ TEST(alignment_configurator, configure_affine_global_banded)
         auto cfg_base = seqan3::align_cfg::mode{seqan3::global_alignment} |
                         seqan3::align_cfg::scoring{seqan3::nucleotide_scoring_scheme{}} |
                         seqan3::align_cfg::gap{seqan3::gap_scheme{seqan3::gap_score{-1}, seqan3::gap_open_score{-10}}};
-        auto cfg_lower = cfg_base | seqan3::align_cfg::band{seqan3::static_band{seqan3::lower_bound{-10},
-                                                                                seqan3::upper_bound{-5}}};
-        auto cfg_upper = cfg_base | seqan3::align_cfg::band{seqan3::static_band{seqan3::lower_bound{5},
-                                                                                seqan3::upper_bound{6}}};
+        auto cfg_lower = cfg_base | seqan3::align_cfg::band_fixed_size{seqan3::align_cfg::lower_diagonal{-10},
+                                                                       seqan3::align_cfg::upper_diagonal{-5}};
+        auto cfg_upper = cfg_base | seqan3::align_cfg::band_fixed_size{seqan3::align_cfg::lower_diagonal{5},
+                                                                       seqan3::align_cfg::upper_diagonal{6}};
 
         EXPECT_THROW(run_test(cfg_lower), seqan3::invalid_alignment_configuration);
         EXPECT_THROW(run_test(cfg_upper), seqan3::invalid_alignment_configuration);
@@ -162,7 +162,7 @@ TEST(alignment_configurator, configure_affine_global_banded_with_alignment)
     auto cfg = seqan3::align_cfg::mode{seqan3::global_alignment} |
                seqan3::align_cfg::gap{seqan3::gap_scheme{seqan3::gap_score{-1}, seqan3::gap_open_score{-10}}} |
                seqan3::align_cfg::scoring{seqan3::nucleotide_scoring_scheme{}} |
-               seqan3::align_cfg::band{seqan3::static_band{seqan3::lower_bound{-1}, seqan3::upper_bound{1}}};
+      seqan3::align_cfg::band_fixed_size{seqan3::align_cfg::lower_diagonal{-1}, seqan3::align_cfg::upper_diagonal{1}};
 
     auto cfg_trace = cfg | seqan3::align_cfg::result{seqan3::with_alignment};
     auto cfg_begin = cfg | seqan3::align_cfg::result{seqan3::with_front_coordinate};

--- a/test/unit/alignment/pairwise/fixture/global_affine_banded.hpp
+++ b/test/unit/alignment/pairwise/fixture/global_affine_banded.hpp
@@ -30,8 +30,8 @@ namespace seqan3::test::alignment::fixture::global::affine::banded
 inline constexpr auto align_config = seqan3::align_cfg::mode{seqan3::global_alignment} |
                                      seqan3::align_cfg::gap{seqan3::gap_scheme{seqan3::gap_score{-1},
                                                                                seqan3::gap_open_score{-10}}} |
-                                     seqan3::align_cfg::band{seqan3::static_band{seqan3::lower_bound{-3},
-                                                                                 seqan3::upper_bound{8}}};
+                                     seqan3::align_cfg::band_fixed_size{seqan3::align_cfg::lower_diagonal{-3},
+                                                                        seqan3::align_cfg::upper_diagonal{8}};
 
 static auto dna4_01 = []()
 {   //    AACCGGTTAACCGGTT

--- a/test/unit/alignment/pairwise/fixture/local_affine_banded.hpp
+++ b/test/unit/alignment/pairwise/fixture/local_affine_banded.hpp
@@ -48,7 +48,8 @@ static auto dna4_01 = []()
         "ACGTCTACGTA"_dna4,
         align_config | seqan3::align_cfg::scoring{seqan3::nucleotide_scoring_scheme{seqan3::match_score{4},
                                                                                     seqan3::mismatch_score{-5}}}
-                     | seqan3::align_cfg::band{seqan3::static_band{seqan3::lower_bound{-2}, seqan3::upper_bound{5}}},
+                     | seqan3::align_cfg::band_fixed_size{seqan3::align_cfg::lower_diagonal{-2},
+                                                          seqan3::align_cfg::upper_diagonal{5}},
         11,
         "GTTTA",
         "GTCTA",
@@ -101,7 +102,8 @@ static auto dna4_02 = []()
         "AACCGGTTTAACCGGTT"_dna4,
         align_config | seqan3::align_cfg::scoring{seqan3::nucleotide_scoring_scheme{seqan3::match_score{4},
                                                                                     seqan3::mismatch_score{-5}}}
-                     | seqan3::align_cfg::band{seqan3::static_band{seqan3::lower_bound{-2}, seqan3::upper_bound{5}}},
+                     | seqan3::align_cfg::band_fixed_size{seqan3::align_cfg::lower_diagonal{-2},
+                                                          seqan3::align_cfg::upper_diagonal{5}},
         8,
         "AC",
         "AC",
@@ -168,7 +170,8 @@ static auto dna4_03 = []()
             | seqan3::align_cfg::gap{seqan3::gap_scheme{seqan3::gap_score{0}, seqan3::gap_open_score{0}}}
             | seqan3::align_cfg::scoring{seqan3::nucleotide_scoring_scheme{seqan3::match_score{2},
                                                                            seqan3::mismatch_score{-1}}}
-            | seqan3::align_cfg::band{seqan3::static_band{seqan3::lower_bound{0}, seqan3::upper_bound{0}}},
+            | seqan3::align_cfg::band_fixed_size{seqan3::align_cfg::lower_diagonal{0},
+                                                 seqan3::align_cfg::upper_diagonal{0}},
         8,
         "TAAGCGT",
         "TCAGAGT",
@@ -221,7 +224,8 @@ static auto dna4_04 = []()
         "CCCCCC"_dna4,
         align_config | seqan3::align_cfg::scoring{seqan3::nucleotide_scoring_scheme{seqan3::match_score{4},
                                                                                     seqan3::mismatch_score{-5}}}
-                     | seqan3::align_cfg::band{seqan3::static_band{seqan3::lower_bound{-2}, seqan3::upper_bound{2}}},
+                     | seqan3::align_cfg::band_fixed_size{seqan3::align_cfg::lower_diagonal{-2},
+                                                          seqan3::align_cfg::upper_diagonal{2}},
         0,
         "",
         "",
@@ -264,7 +268,8 @@ static auto dna4_05 = []()
         "CCCCCCTAAAAAA"_dna4,
         align_config | seqan3::align_cfg::scoring{seqan3::nucleotide_scoring_scheme{seqan3::match_score{4},
                                                                                     seqan3::mismatch_score{-5}}}
-                     | seqan3::align_cfg::band{seqan3::static_band{seqan3::lower_bound{-100}, seqan3::upper_bound{0}}},
+                     | seqan3::align_cfg::band_fixed_size{seqan3::align_cfg::lower_diagonal{-100},
+                                                          seqan3::align_cfg::upper_diagonal{0}},
         24,
         "AAAAAA",
         "AAAAAA",
@@ -322,7 +327,8 @@ static auto dna4_06 = []()
         "CCCCCCTAAAAAA"_dna4,
         align_config | seqan3::align_cfg::scoring{seqan3::nucleotide_scoring_scheme{seqan3::match_score{4},
                                                                                     seqan3::mismatch_score{-5}}}
-                     | seqan3::align_cfg::band{seqan3::static_band{seqan3::lower_bound{0}, seqan3::upper_bound{100}}},
+                     | seqan3::align_cfg::band_fixed_size{seqan3::align_cfg::lower_diagonal{0},
+                                                          seqan3::align_cfg::upper_diagonal{100}},
         24,
         "CCCCCC",
         "CCCCCC",
@@ -378,7 +384,8 @@ static auto rna5_01 = []()
         "AAAAAAUUUUNNUUUUCCCCCC"_rna5,
         "AAAAAACCCCCC"_rna5,
         align_config | seqan3::align_cfg::scoring{seqan3::nucleotide_scoring_scheme{seqan3::match_score{4}, seqan3::mismatch_score{-5}}}
-                     | seqan3::align_cfg::band{seqan3::static_band{seqan3::lower_bound{-10}, seqan3::upper_bound{10}}},
+                     | seqan3::align_cfg::band_fixed_size{seqan3::align_cfg::lower_diagonal{-10},
+                                                          seqan3::align_cfg::upper_diagonal{10}},
         28,
         "AAAAAAUUUUNNUUUUCCCCCC",
         "AAAAAA----------CCCCCC",
@@ -433,7 +440,8 @@ static auto aa27_01 = []()
         "GALORA"_aa27,
         align_config
             | seqan3::align_cfg::scoring{aminoacid_scoring_scheme{aminoacid_similarity_matrix::BLOSUM62}}
-            | seqan3::align_cfg::band{seqan3::static_band{seqan3::lower_bound{-10000}, seqan3::upper_bound{10000}}},
+            | seqan3::align_cfg::band_fixed_size{seqan3::align_cfg::lower_diagonal{-10000},
+                                                 seqan3::align_cfg::upper_diagonal{10000}},
         13,
         "GATOR",
         "GALOR",

--- a/test/unit/alignment/pairwise/fixture/semi_global_affine_banded.hpp
+++ b/test/unit/alignment/pairwise/fixture/semi_global_affine_banded.hpp
@@ -30,8 +30,8 @@ namespace seqan3::test::alignment::fixture::semi_global::affine::banded
 inline constexpr auto align_config = seqan3::align_cfg::mode{seqan3::global_alignment} |
                                      seqan3::align_cfg::gap{seqan3::gap_scheme{seqan3::gap_score{-1},
                                                                                seqan3::gap_open_score{-10}}} |
-                                     seqan3::align_cfg::band{seqan3::static_band{seqan3::lower_bound{-4},
-                                                                                 seqan3::upper_bound{8}}};
+                                     seqan3::align_cfg::band_fixed_size{seqan3::align_cfg::lower_diagonal{-4},
+                                                                        seqan3::align_cfg::upper_diagonal{8}};
 
 inline constexpr auto align_config_semi_seq1 = align_config | seqan3::align_cfg::aligned_ends{seqan3::free_ends_first};
 inline constexpr auto align_config_semi_seq2 = align_config | seqan3::align_cfg::aligned_ends{seqan3::free_ends_second};

--- a/test/unit/alignment/pairwise/policy/affine_gap_init_policy_test.cpp
+++ b/test/unit/alignment/pairwise/policy/affine_gap_init_policy_test.cpp
@@ -57,10 +57,14 @@ public:
     {
         if constexpr (std::tuple_element_t<2, test_types>::value)
         {
-            score_matrix = score_matrix_t{"ACGT"_dna4, "ACGT"_dna4, seqan3::static_band{seqan3::lower_bound{-2},
-                                                                                        seqan3::upper_bound{2}}};
-            trace_matrix = trace_matrix_t{"ACGT"_dna4, "ACGT"_dna4, seqan3::static_band{seqan3::lower_bound{-2},
-                                                                                        seqan3::upper_bound{2}}};
+            score_matrix = score_matrix_t{"ACGT"_dna4,
+                                          "ACGT"_dna4,
+                                          seqan3::align_cfg::band_fixed_size{seqan3::align_cfg::lower_diagonal{-2},
+                                                                             seqan3::align_cfg::upper_diagonal{2}}};
+            trace_matrix = trace_matrix_t{"ACGT"_dna4,
+                                          "ACGT"_dna4,
+                                          seqan3::align_cfg::band_fixed_size{seqan3::align_cfg::lower_diagonal{-2},
+                                                                             seqan3::align_cfg::upper_diagonal{2}}};
         }
         else
         {

--- a/test/unit/alignment/pairwise/policy/affine_gap_policy_test.cpp
+++ b/test/unit/alignment/pairwise/policy/affine_gap_policy_test.cpp
@@ -62,10 +62,14 @@ struct affine_gap_fixture : public ::testing::Test
     {
         if constexpr (std::tuple_element_t<2, test_types>::value)
         {
-            score_matrix = score_matrix_t{"ACGT"_dna4, "ACGT"_dna4, seqan3::static_band{seqan3::lower_bound{-2},
-                                                                                        seqan3::upper_bound{2}}};
-            trace_matrix = trace_matrix_t{"ACGT"_dna4, "ACGT"_dna4, seqan3::static_band{seqan3::lower_bound{-2},
-                                                                                        seqan3::upper_bound{2}}};
+            score_matrix = score_matrix_t{"ACGT"_dna4,
+                                          "ACGT"_dna4,
+                                          seqan3::align_cfg::band_fixed_size{seqan3::align_cfg::lower_diagonal{-2},
+                                                                             seqan3::align_cfg::upper_diagonal{2}}};
+            trace_matrix = trace_matrix_t{"ACGT"_dna4,
+                                          "ACGT"_dna4,
+                                          seqan3::align_cfg::band_fixed_size{seqan3::align_cfg::lower_diagonal{-2},
+                                                                             seqan3::align_cfg::upper_diagonal{2}}};
         }
         else
         {

--- a/test/unit/core/algorithm/pipeable_config_element_test_template.hpp
+++ b/test/unit/core/algorithm/pipeable_config_element_test_template.hpp
@@ -46,6 +46,13 @@ TYPED_TEST_P(pipeable_config_element_test, configuration_assignment)
     EXPECT_TRUE((std::same_as<decltype(cfg), seqan3::configuration<TypeParam>>));
 }
 
+TYPED_TEST_P(pipeable_config_element_test, exists)
+{
+    using configuration_t = seqan3::configuration<TypeParam>;
+
+    EXPECT_TRUE(configuration_t::template exists<TypeParam>());
+}
+
 // make mock config element foo always pipeable with any other config element
 namespace seqan3::detail
 {
@@ -91,4 +98,5 @@ REGISTER_TYPED_TEST_SUITE_P(pipeable_config_element_test,
                             standard_construction,
                             configuration_construction,
                             configuration_assignment,
+                            exists,
                             pipeability);

--- a/test/unit/core/detail/CMakeLists.txt
+++ b/test/unit/core/detail/CMakeLists.txt
@@ -1,4 +1,5 @@
 seqan3_test(int_types_test.cpp)
 seqan3_test(pack_algorithm_test.cpp)
+seqan3_test(strong_type_debug_stream_test.cpp)
 seqan3_test(strong_type_test.cpp)
 seqan3_test(type_inspection_test.cpp)

--- a/test/unit/core/detail/strong_type_debug_stream_test.cpp
+++ b/test/unit/core/detail/strong_type_debug_stream_test.cpp
@@ -1,0 +1,25 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <seqan3/core/detail/strong_type.hpp>
+
+struct my_type : seqan3::detail::strong_type<int, my_type>
+{
+    using seqan3::detail::strong_type<int, my_type>::strong_type;
+};
+
+TEST(strong_type, debug_stremable)
+{
+    my_type obj{10};
+
+    std::ostringstream buffer{};
+    seqan3::debug_stream_type stream{buffer};
+    stream << obj;
+    EXPECT_EQ(buffer.str(), "10");
+}

--- a/test/unit/core/detail/strong_type_test.cpp
+++ b/test/unit/core/detail/strong_type_test.cpp
@@ -99,6 +99,14 @@ struct multi_skill_type : seqan3::detail::strong_type<int,
                                                              seqan3::detail::strong_type_skill::convert>::strong_type;
 };
 
+TEST(strong_type, concept)
+{
+    EXPECT_TRUE(seqan3::detail::strong_type_specialisation<pure_type &>);
+    EXPECT_TRUE(seqan3::detail::strong_type_specialisation<pure_type const &>);
+    EXPECT_TRUE(seqan3::detail::strong_type_specialisation<pure_type &&>);
+    EXPECT_TRUE(seqan3::detail::strong_type_specialisation<pure_type const &&>);
+}
+
 TEST(strong_type, pure_type)
 {
     {


### PR DESCRIPTION
### Changes


* Make strong type streamable
* Add test case for exists in configuration test template
* Rename the existing band to align_cfg::band_fixed_size
* Introducing strong types for setting lower and upper diagonal
* Direct access of the members via the config.
* Adjust the tutorial and all snippets
* Adjust the API documentation
* Remove all references to the old static_band mechanism
* Fix all dependent classes and tests

fixes seqan/product_backlog#98

