### PR TITLE
[FIX] gcc-10.1: workaround for ICE

### DIFF
--- a/include/seqan3/core/algorithm/configuration.hpp
+++ b/include/seqan3/core/algorithm/configuration.hpp
@@ -296,7 +296,9 @@ public:
     template <typename query_t>
     [[nodiscard]] constexpr auto remove() const
     //!\cond
-        requires exists<query_t>()
+#if !SEQAN3_WORKAROUND_GCC_95371
+        requires (exists<query_t>())
+#endif // !SEQAN3_WORKAROUND_GCC_95371
     //!\endcond
     {
         constexpr int index = pack_traits::find<query_t, configs_t...>;
@@ -307,7 +309,9 @@ public:
     template <template <typename ...> typename query_t>
     [[nodiscard]] constexpr auto remove() const
     //!\cond
-        requires exists<query_t>()
+#if !SEQAN3_WORKAROUND_GCC_95371
+        requires (exists<query_t>())
+#endif // !SEQAN3_WORKAROUND_GCC_95371
     //!\endcond
     {
         constexpr int index = pack_traits::find_if<detail::is_same_configuration_f<query_t>::template invoke,

--- a/include/seqan3/core/platform.hpp
+++ b/include/seqan3/core/platform.hpp
@@ -212,6 +212,15 @@
 #   endif
 #endif
 
+//!\brief https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95371
+#ifndef SEQAN3_WORKAROUND_GCC_95371 // regressed in gcc10, fixed for gcc10.2
+#   if defined(__GNUC__) && (__GNUC__ == 10 && __GNUC_MINOR__ < 2)
+#       define SEQAN3_WORKAROUND_GCC_95371 1
+#   else
+#       define SEQAN3_WORKAROUND_GCC_95371 0
+#   endif
+#endif
+
 //!\brief Various concept problems only present in GCC7 and GCC8.
 #ifndef SEQAN3_WORKAROUND_GCC7_AND_8_CONCEPT_ISSUES
 #   if defined(__GNUC__) && ((__GNUC__ == 7) || (__GNUC__ == 8))


### PR DESCRIPTION
```c++
core/algorithm/configuration_test.cpp:209:72: internal compiler error: Segmentation fault
  209 |         EXPECT_TRUE((std::same_as<decltype(cfg.template remove<foobar>()), seqan3::configuration<foo, bar>>));
      |                                                                        ^
```

Fixes partially #1877