### PR TITLE
[FIX] cxx20: concepts in forward declaration must be the same

### DIFF
--- a/include/seqan3/search/search_result.hpp
+++ b/include/seqan3/search/search_result.hpp
@@ -107,7 +107,7 @@ private:
     #endif // !SEQAN3_WORKAROUND_GCC_93467
     friend struct detail::policy_search_result_builder;
     // Currently, the query id is set within the search result range. This needs to be adapted.
-    template <typename search_algorithm_t, typename query_range_t>
+    template <typename search_algorithm_t, std::ranges::view query_range_t>
     friend class search_result_range;
 
 public:
@@ -228,4 +228,3 @@ inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & stream
 }
 
 } // namespace seqan3
-


### PR DESCRIPTION
```c++
seqan3/include/seqan3/search/search_result.hpp:100:44: error: declaration of template parameter ‘class query_range_t’ with different constraints
  100 |     template <typename search_algorithm_t, typename query_range_t>
      |                                            ^~~~~~~~

seqan3/include/seqan3/search/search_result_range.hpp:36:40: note: original declaration appeared here
   36 | template <typename search_algorithm_t, std::ranges::view query_range_t>
      |                                        ^~~
```

Fixes #1877