### PR TITLE
[FIX] cxx20: make small_string a proper structural type

### DIFF
--- a/include/seqan3/range/container/small_vector.hpp
+++ b/include/seqan3/range/container/small_vector.hpp
@@ -920,7 +920,7 @@ public:
     }
     //!\}
 
-protected:
+public:
     //!\privatesection
 
     //!\brief Stores the actual data_.


### PR DESCRIPTION
‘seqan3::small_string<2>’ is not a valid type for a template non-type parameter because it is not structural

Definition of structural type: https://wg21.link/p1907

```c++
In file included from seqan3/test/unit/io/alignment_file/sam_tag_dictionary_test.cpp:12:
seqan3/include/seqan3/io/alignment_file/sam_tag_dictionary.hpp:64:27: error: ‘seqan3::small_string<2>’ is not a valid type for a template non-type parameter because it is not structural
   64 | template <small_string<2> str> // TODO: better handling if too large string is provided?
      |                           ^~~
In file included from seqan3/include/seqan3/io/alignment_file/sam_tag_dictionary.hpp:21,
                 from seqan3/test/unit/io/alignment_file/sam_tag_dictionary_test.cpp:12:
seqan3/include/seqan3/range/container/small_string.hpp:42:7: note: ‘seqan3::small_string<2>::<anonymous>’ has a non-structural type
   42 | class small_string : public small_vector<char, capacity_ + 1>
      |       ^~~~~~~~~~~~
In file included from seqan3/include/seqan3/range/container/small_string.hpp:15,
                 from seqan3/include/seqan3/io/alignment_file/sam_tag_dictionary.hpp:21,
                 from seqan3/test/unit/io/alignment_file/sam_tag_dictionary_test.cpp:12:
seqan3/include/seqan3/range/container/small_vector.hpp:927:39: note: ‘seqan3::small_vector<char, 3>::data_’ is not public
  927 |     std::array<value_type, capacity_> data_{};
      |                                       ^~~~~
```