### PR TITLE
[FIX] workaround gcc10: view + std::filesystem:path constructor = bad

### DIFF
--- a/doc/tutorial/alignment_file/alignment_file_solution2.cpp
+++ b/doc/tutorial/alignment_file/alignment_file_solution2.cpp
@@ -91,9 +91,15 @@ int main()
 
     seqan3::alignment_file_input mapping_file{tmp_dir/"mapping.sam", ref_ids, ref_seqs, field_type{}};
 
+#if !SEQAN3_WORKAROUND_GCC_93983
     auto mapq_filter = std::views::filter([] (auto & rec) { return seqan3::get<seqan3::field::mapq>(rec) >= 30; });
+#endif // !SEQAN3_WORKAROUND_GCC_93983
 
+#if SEQAN3_WORKAROUND_GCC_93983
+    for (auto & [id, ref_id, mapq, alignment] : mapping_file /*| mapq_filter*/)
+#else // ^^^ workaround / no workaround vvv
     for (auto & [id, ref_id, mapq, alignment] : mapping_file | mapq_filter)
+#endif // SEQAN3_WORKAROUND_GCC_93983
     {
         using seqan3::get;
         size_t sum_ref{};

--- a/doc/tutorial/read_mapper/read_mapper_step2.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_step2.cpp
@@ -50,7 +50,11 @@ void map_reads(std::filesystem::path const & query_path,
     seqan3::configuration const search_config = seqan3::search_cfg::max_error{seqan3::search_cfg::total{errors}} |
                                                 seqan3::search_cfg::hit_all_best;
 
+#if SEQAN3_WORKAROUND_GCC_93983
+    for (auto && record : query_file_in /*| seqan3::views::take(20)*/)
+#else // ^^^ workaround / no workaround vvv
     for (auto && record : query_file_in | seqan3::views::take(20))
+#endif // SEQAN3_WORKAROUND_GCC_93983
     {
         seqan3::debug_stream << "Hits:" << '\n';
         for (auto && result : search(seqan3::get<seqan3::field::seq>(record), index, search_config))

--- a/doc/tutorial/read_mapper/read_mapper_step3.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_step3.cpp
@@ -57,7 +57,11 @@ void map_reads(std::filesystem::path const & query_path,
                                                seqan3::align_cfg::result{seqan3::with_alignment};
 //! [alignment_config]
 
+#if SEQAN3_WORKAROUND_GCC_93983
+    for (auto && record : query_file_in /*| seqan3::views::take(20)*/)
+#else // ^^^ workaround / no workaround vvv
     for (auto && record : query_file_in | seqan3::views::take(20))
+#endif // SEQAN3_WORKAROUND_GCC_93983
     {
         auto & query = seqan3::get<seqan3::field::seq>(record);
         for (auto && result : search(query, index, search_config))

--- a/doc/tutorial/sequence_file/sequence_file_solution3.cpp
+++ b/doc/tutorial/sequence_file/sequence_file_solution3.cpp
@@ -60,6 +60,7 @@ write_file_dummy_struct go{};
 
 int main()
 {
+#if !SEQAN3_WORKAROUND_GCC_93983
     std::filesystem::path tmp_dir = std::filesystem::temp_directory_path(); // get the temp directory
 
     seqan3::sequence_file_input fin{tmp_dir/"my.fastq"};
@@ -86,5 +87,6 @@ int main()
     // Note that you need to know the type of id (std::string)
 
     seqan3::debug_stream << ids << '\n';
+#endif // !SEQAN3_WORKAROUND_GCC_93983
 }
 //![solution]

--- a/doc/tutorial/sequence_file/sequence_file_solution4.cpp
+++ b/doc/tutorial/sequence_file/sequence_file_solution4.cpp
@@ -65,6 +65,7 @@ write_file_dummy_struct go{};
 
 int main()
 {
+#if !SEQAN3_WORKAROUND_GCC_93983
     std::filesystem::path tmp_dir = std::filesystem::temp_directory_path(); // get the temp directory
 
     seqan3::sequence_file_input fin{tmp_dir/"my.fastq"};
@@ -79,5 +80,6 @@ int main()
     {
         fout.push_back(rec);
     }
+#endif // !SEQAN3_WORKAROUND_GCC_93983
 }
 //![solution]

--- a/doc/tutorial/sequence_file/sequence_file_solution5.cpp
+++ b/doc/tutorial/sequence_file/sequence_file_solution5.cpp
@@ -66,6 +66,7 @@ write_file_dummy_struct go{};
 
 int main()
 {
+#if !SEQAN3_WORKAROUND_GCC_93983
     std::filesystem::path tmp_dir = std::filesystem::temp_directory_path(); // get the temp directory
 
     seqan3::sequence_file_input fin{tmp_dir/"my.fastq"};
@@ -80,5 +81,6 @@ int main()
 
     // This would also work:
     // fin | length_filter | fout;
+#endif // !SEQAN3_WORKAROUND_GCC_93983
 }
 //![solution]

--- a/include/seqan3/core/platform.hpp
+++ b/include/seqan3/core/platform.hpp
@@ -212,6 +212,15 @@
 #   endif
 #endif
 
+//!\brief https://gcc.gnu.org/bugzilla/show_bug.cgi?id=93983
+#ifndef SEQAN3_WORKAROUND_GCC_93983
+#   if defined(__GNUC__) && (__GNUC__ == 10 && __GNUC_MINOR__ <= 1)
+#       define SEQAN3_WORKAROUND_GCC_93983 1
+#   else
+#       define SEQAN3_WORKAROUND_GCC_93983 0
+#   endif
+#endif
+
 //!\brief https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95371
 #ifndef SEQAN3_WORKAROUND_GCC_95371 // regressed in gcc10, fixed for gcc10.2
 #   if defined(__GNUC__) && (__GNUC__ == 10 && __GNUC_MINOR__ < 2)

--- a/test/snippet/io/alignment_file/alignment_file_input_reading_filter.cpp
+++ b/test/snippet/io/alignment_file/alignment_file_input_reading_filter.cpp
@@ -19,11 +19,17 @@ int main()
 
     seqan3::alignment_file_input fin{std::istringstream{sam_file_raw}, seqan3::format_sam{}};
 
+#if !SEQAN3_WORKAROUND_GCC_93983
     auto minimum_length10_filter = std::views::filter([] (auto const & rec)
     {
         return std::ranges::size(get<seqan3::field::seq>(rec)) >= 10;
     });
+#endif // !SEQAN3_WORKAROUND_GCC_93983
 
+#if SEQAN3_WORKAROUND_GCC_93983
+    for (auto & rec : fin /*| minimum_length10_filter*/) // only records with sequence length >= 10 will "appear"
+#else // ^^^ workaround / no workaround vvv
     for (auto & rec : fin | minimum_length10_filter) // only records with sequence length >= 10 will "appear"
+#endif // SEQAN3_WORKAROUND_GCC_93983
         seqan3::debug_stream << get<seqan3::field::id>(rec) << '\n';
 }

--- a/test/snippet/io/alignment_file/alignment_file_output_io_pipeline.cpp
+++ b/test/snippet/io/alignment_file/alignment_file_output_io_pipeline.cpp
@@ -14,8 +14,10 @@ r001	147	ref	237	30	*	=	7	-39	CAGCGGCAT	*	NM:i:1
 
 int main()
 {
+#if !SEQAN3_WORKAROUND_GCC_93983
     seqan3::alignment_file_input{std::istringstream{sam_file_raw}, seqan3::format_sam{}}
         | seqan3::views::persist
         | std::views::take(3) // take only the first 3 records
         | seqan3::alignment_file_output{std::ostringstream{}, seqan3::format_sam{}};
+#endif // !SEQAN3_WORKAROUND_GCC_93983
 }

--- a/test/snippet/io/sequence_file/sequence_file_input_file_view.cpp
+++ b/test/snippet/io/sequence_file/sequence_file_input_file_view.cpp
@@ -17,12 +17,18 @@ int main()
 
     seqan3::sequence_file_input fin{std::istringstream{}, seqan3::format_fasta{}};
 
+#if !SEQAN3_WORKAROUND_GCC_93983
     auto minimum_length5_filter = std::views::filter([] (auto const & rec)
     {
         return std::ranges::size(get<seqan3::field::seq>(rec)) >= 5;
     });
+#endif // !SEQAN3_WORKAROUND_GCC_93983
 
+#if SEQAN3_WORKAROUND_GCC_93983
+    for (auto & rec : fin /*| minimum_length5_filter*/) // only record with sequence length >= 5 will "appear"
+#else // ^^^ workaround / no workaround vvv
     for (auto & rec : fin | minimum_length5_filter) // only record with sequence length >= 5 will "appear"
+#endif // SEQAN3_WORKAROUND_GCC_93983
     {
         seqan3::debug_stream << "IDs of seq_length >= 5: " << get<seqan3::field::id>(rec) << '\n';
         // ...

--- a/test/snippet/io/sequence_file/sequence_file_output_view_pipeline.cpp
+++ b/test/snippet/io/sequence_file/sequence_file_output_view_pipeline.cpp
@@ -21,6 +21,7 @@ GGAGTATAATATATATATATATAT
 
 int main()
 {
+#if !SEQAN3_WORKAROUND_GCC_93983
     using seqan3::get;
 
     // minimum_average_quality_filter and minimum_sequence_length_filter need to be implemented first
@@ -45,4 +46,5 @@ int main()
         | minimum_sequence_length_filter
         | std::views::take(3)
         | seqan3::sequence_file_output{std::ostringstream{}, seqan3::format_fasta{}};
+#endif // !SEQAN3_WORKAROUND_GCC_93983
 }

--- a/test/snippet/io/structure_file/structure_file_input_filter_criteria.cpp
+++ b/test/snippet/io/structure_file/structure_file_input_filter_criteria.cpp
@@ -18,11 +18,17 @@ int main()
 
     seqan3::structure_file_input fin{std::istringstream{input}, seqan3::format_vienna{}};
 
+#if !SEQAN3_WORKAROUND_GCC_93983
     auto minimum_length5_filter = std::views::filter([] (auto const & rec)
     {
         return std::ranges::size(get<seqan3::field::seq>(rec)) >= 5;
     });
+#endif // !SEQAN3_WORKAROUND_GCC_93983
 
+#if SEQAN3_WORKAROUND_GCC_93983
+    for (auto & rec : fin /*| minimum_length5_filter*/) // only record with sequence length >= 5 will "appear"
+#else // ^^^ workaround / no workaround vvv
     for (auto & rec : fin | minimum_length5_filter) // only record with sequence length >= 5 will "appear"
+#endif // SEQAN3_WORKAROUND_GCC_93983
         seqan3::debug_stream << (get<0>(rec) | seqan3::views::to_char) << '\n';
 }

--- a/test/snippet/io/structure_file/structure_file_output_pipeline.cpp
+++ b/test/snippet/io/structure_file/structure_file_output_pipeline.cpp
@@ -13,6 +13,8 @@ UUGGAGUACACAACCUGUACACUCUUUC
 
 int main()
 {
+#if !SEQAN3_WORKAROUND_GCC_93983
     seqan3::structure_file_input my_in{std::istringstream{input}, seqan3::format_vienna{}};
     my_in | seqan3::views::take(2) | seqan3::structure_file_output{std::ostringstream{}, seqan3::format_vienna{}};
+#endif // !SEQAN3_WORKAROUND_GCC_93983
 }

--- a/test/snippet/range/views/async_input_buffer.cpp
+++ b/test/snippet/range/views/async_input_buffer.cpp
@@ -35,6 +35,7 @@ ACGACTACGACGATCATCGATCGATCGATCGATCGATCGATCGATCGTACTACGATCGATCG
 
 int main()
 {
+#if !SEQAN3_WORKAROUND_GCC_93983
     // initialise random number generator, only needed for demonstration purposes
     std::srand(std::time(nullptr));
 
@@ -63,4 +64,5 @@ int main()
     // launch two threads and pass the lambda function to both
     auto f0 = std::async(std::launch::async, worker);
     auto f1 = std::async(std::launch::async, worker);
+#endif // !SEQAN3_WORKAROUND_GCC_93983
 }

--- a/test/unit/io/alignment_file/alignment_file_input_test.cpp
+++ b/test/unit/io/alignment_file/alignment_file_input_test.cpp
@@ -291,14 +291,23 @@ TEST_F(alignment_file_input_f, file_view)
 {
     seqan3::alignment_file_input fin{std::istringstream{input}, seqan3::format_sam{}};
 
+#if !SEQAN3_WORKAROUND_GCC_93983
     auto minimum_length_filter = std::views::filter([] (auto const & rec)
     {
         return size(seqan3::get<seqan3::field::seq>(rec)) >= 5;
     });
+#endif
 
     size_t counter = 1; // the first record will be filtered out
+#if SEQAN3_WORKAROUND_GCC_93983
+    for (auto & rec : fin /*| minimum_length_filter*/)
+    {
+        if (!(size(seqan3::get<seqan3::field::seq>(rec)) >= 5))
+            continue;
+#else // ^^^ workaround / no workaround vvv
     for (auto & rec : fin | minimum_length_filter)
     {
+#endif // SEQAN3_WORKAROUND_GCC_93983
         EXPECT_TRUE((std::ranges::equal(seqan3::get<seqan3::field::seq>(rec), seq_comp[counter])));
         EXPECT_TRUE((std::ranges::equal(seqan3::get<seqan3::field::id>(rec), id_comp[counter])));
         EXPECT_TRUE((std::ranges::equal(seqan3::get<seqan3::field::qual>(rec), qual_comp[counter])));

--- a/test/unit/io/sequence_file/sequence_file_input_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_input_test.cpp
@@ -305,14 +305,23 @@ TEST_F(sequence_file_input_f, file_view)
 {
     seqan3::sequence_file_input fin{std::istringstream{input}, seqan3::format_fasta{}};
 
+#if !SEQAN3_WORKAROUND_GCC_93983
     auto minimum_length_filter = std::views::filter([] (auto const & rec)
     {
         return size(seqan3::get<seqan3::field::seq>(rec)) >= 5;
     });
+#endif
 
     size_t counter = 1; // the first record will be filtered out
+#if SEQAN3_WORKAROUND_GCC_93983
+    for (auto & rec : fin /*| minimum_length_filter*/)
+    {
+        if (!(size(seqan3::get<seqan3::field::seq>(rec)) >= 5))
+            continue;
+#else // ^^^ workaround / no workaround vvv
     for (auto & rec : fin | minimum_length_filter)
     {
+#endif // SEQAN3_WORKAROUND_GCC_93983
         EXPECT_TRUE((std::ranges::equal(seqan3::get<seqan3::field::seq>(rec), seq_comp[counter])));
         EXPECT_TRUE((std::ranges::equal(seqan3::get<seqan3::field::id>(rec),  id_comp[counter])));
         EXPECT_TRUE(empty(seqan3::get<seqan3::field::qual>(rec)));

--- a/test/unit/io/sequence_file/sequence_file_integration_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_integration_test.cpp
@@ -92,6 +92,7 @@ TEST(integration, view)
         "AGGCTGNAGGCTGAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGN\n"
     };
 
+#if !SEQAN3_WORKAROUND_GCC_93983
     // valid without assignment?
     seqan3::sequence_file_input{std::istringstream{input},
                                 seqan3::format_fasta{}} | seqan3::views::persist
@@ -107,6 +108,7 @@ TEST(integration, view)
 
     fout.get_stream().flush();
     EXPECT_EQ(reinterpret_cast<std::ostringstream&>(fout.get_stream()).str(), output);
+#endif // !SEQAN3_WORKAROUND_GCC_93983
 }
 
 TEST(integration, convert_fastq_to_fasta)

--- a/test/unit/io/structure_file/structure_file_input_test.cpp
+++ b/test/unit/io/structure_file/structure_file_input_test.cpp
@@ -363,13 +363,19 @@ TEST_F(structure_file_input_read, record_file_view)
                                                     seqan3::field::structure,
                                                     seqan3::field::energy>{}};
 
+#if !SEQAN3_WORKAROUND_GCC_93983
     auto minimum_length_filter = std::views::filter([] (auto const & rec)
     {
         return size(seqan3::get<seqan3::field::seq>(rec)) >= 5;
     });
+#endif
 
     size_t counter = 0ul; // the first record will be filtered out
+#if SEQAN3_WORKAROUND_GCC_93983
+    for (auto & rec : fin /*| minimum_length_filter*/)
+#else // ^^^ workaround / no workaround vvv
     for (auto & rec : fin | minimum_length_filter)
+#endif // SEQAN3_WORKAROUND_GCC_93983
     {
         EXPECT_TRUE((std::ranges::equal(seqan3::get<seqan3::field::seq>(rec), seq_comp[counter])));
         EXPECT_TRUE((std::ranges::equal(seqan3::get<seqan3::field::id>(rec),  id_comp[counter])));


### PR DESCRIPTION
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=93983 has the consequences
that a view with a custom constructor of std::filesystem::path produces
an infinite loop.