### PR TITLE
[FIX] cxx20: repeat_view uses single_view wrong?!

### DIFF
--- a/include/seqan3/range/views/repeat.hpp
+++ b/include/seqan3/range/views/repeat.hpp
@@ -50,6 +50,9 @@ private:
     //!\brief The sentinel type is set to std::default_sentinel_t.
     using sentinel_type = std::default_sentinel_t;
 
+    //!\brief The view which wraps the single value to repeat.
+    using single_value_t = decltype(std::views::single(std::declval<value_t>()));
+
     /*!\name Associated types
      * These associated types are needed in seqan3::detail::random_access_iterator.
      * \{
@@ -175,11 +178,11 @@ public:
     ~repeat_view() = default;                                         //!< Defaulted.
 
     //!\brief Construct from any type (Note: the value will be copied into views::single).
-    constexpr explicit repeat_view(value_t const & value) : single_value{ranges::single_view{value}}
+    constexpr explicit repeat_view(value_t const & value) : single_value{value}
     {}
 
     //!\overload
-    constexpr explicit repeat_view(value_t && value) : single_value{ranges::single_view{std::move(value)}}
+    constexpr explicit repeat_view(value_t && value) : single_value{std::move(value)}
     {}
     //!\}
 
@@ -284,7 +287,7 @@ public:
 
 private:
     //!\brief A std::views::single over the input.
-    decltype(std::views::single(std::declval<value_t &>())) single_value;
+    single_value_t single_value;
 };
 
 // ---------------------------------------------------------------------------------------------------------------------

--- a/test/unit/range/views/view_repeat_test.cpp
+++ b/test/unit/range/views/view_repeat_test.cpp
@@ -17,6 +17,18 @@
 #include <seqan3/std/ranges>
 #include <seqan3/test/expect_range_eq.hpp>
 
+TEST(repeat_view, deduction_guide)
+{
+    int value = 0;
+    int const & value_cref = value;
+
+    seqan3::detail::repeat_view repeat_view1{value};
+    EXPECT_TRUE((std::same_as<decltype(repeat_view1), seqan3::detail::repeat_view<int>>));
+
+    seqan3::detail::repeat_view repeat_view2{value_cref};
+    EXPECT_TRUE((std::same_as<decltype(repeat_view2), seqan3::detail::repeat_view<int>>));
+}
+
 TEST(general, construction)
 {
     // char


### PR DESCRIPTION
```c++
/seqan3/include/seqan3/range/views/repeat.hpp:178:100: error: no matching function for call to ‘std::ranges::single_view<std::_Swallow_assign>::single_view(<brace-enclosed initializer list>)’
  178 |     constexpr explicit repeat_view(value_t const & value) : single_value{ranges::single_view{value}}
      |
```