### PR TITLE
[FIX] cxx20: view_to_simd add explicit empty()

### DIFF
--- a/include/seqan3/core/simd/view_to_simd.hpp
+++ b/include/seqan3/core/simd/view_to_simd.hpp
@@ -166,7 +166,8 @@ public:
     constexpr void cend() const noexcept = delete;
     //!\}
 
-    constexpr size_t empty() const noexcept
+    //!\brief Checks whether the range is empty.
+    constexpr bool empty() const noexcept
     //!\cond
         requires std::ranges::forward_range<inner_range_type>
     //!\endcond

--- a/include/seqan3/core/simd/view_to_simd.hpp
+++ b/include/seqan3/core/simd/view_to_simd.hpp
@@ -166,6 +166,17 @@ public:
     constexpr void cend() const noexcept = delete;
     //!\}
 
+    constexpr size_t empty() const noexcept
+    //!\cond
+        requires std::ranges::forward_range<inner_range_type>
+    //!\endcond
+    {
+        return std::ranges::all_of(urng, [] (auto & rng)
+        {
+            return std::ranges::empty(rng);
+        });
+    }
+
     /*!\brief Returns the size of this range.
      *
      * \details


### PR DESCRIPTION
Add explicit empty() since the implicit definition from view_interface
requires std::ranges::forward_range, but view_to_simd is only an input range.

See https://eel.is/c++draft/view.interface#1