### PR TITLE
[FIX] cxx20: add missing includes

### DIFF
--- a/doc/howto/write_an_alphabet/dna2_alphabet.cpp
+++ b/doc/howto/write_an_alphabet/dna2_alphabet.cpp
@@ -7,6 +7,7 @@
 
 //! [writable_alphabet]
 #include <cassert>
+
 #include <seqan3/alphabet/concept.hpp>                   // alphabet concept checks
 
 struct dna2

--- a/doc/howto/write_an_alphabet/dna2_alphabet.cpp
+++ b/doc/howto/write_an_alphabet/dna2_alphabet.cpp
@@ -6,6 +6,7 @@
 // -----------------------------------------------------------------------------------------------------
 
 //! [writable_alphabet]
+#include <cassert>
 #include <seqan3/alphabet/concept.hpp>                   // alphabet concept checks
 
 struct dna2

--- a/doc/howto/write_an_alphabet/dna2_semialphabet.cpp
+++ b/doc/howto/write_an_alphabet/dna2_semialphabet.cpp
@@ -7,6 +7,7 @@
 
 //! [semialphabet]
 #include <cassert>
+
 #include <seqan3/alphabet/concept.hpp>                   // alphabet concept checks
 
 struct dna2

--- a/doc/howto/write_an_alphabet/dna2_semialphabet.cpp
+++ b/doc/howto/write_an_alphabet/dna2_semialphabet.cpp
@@ -6,6 +6,7 @@
 // -----------------------------------------------------------------------------------------------------
 
 //! [semialphabet]
+#include <cassert>
 #include <seqan3/alphabet/concept.hpp>                   // alphabet concept checks
 
 struct dna2

--- a/include/seqan3/alignment/configuration/align_config_aligned_ends.hpp
+++ b/include/seqan3/alignment/configuration/align_config_aligned_ends.hpp
@@ -13,6 +13,7 @@
 
 #pragma once
 
+#include <cassert>
 #include <type_traits>
 #include <tuple>
 

--- a/include/seqan3/alignment/configuration/align_config_aligned_ends.hpp
+++ b/include/seqan3/alignment/configuration/align_config_aligned_ends.hpp
@@ -14,8 +14,8 @@
 #pragma once
 
 #include <cassert>
-#include <type_traits>
 #include <tuple>
+#include <type_traits>
 
 #include <seqan3/alignment/configuration/detail.hpp>
 #include <seqan3/core/algorithm/pipeable_config_element.hpp>

--- a/include/seqan3/alignment/matrix/detail/alignment_trace_matrix_proxy.hpp
+++ b/include/seqan3/alignment/matrix/detail/alignment_trace_matrix_proxy.hpp
@@ -12,9 +12,11 @@
 
 #pragma once
 
+#include <seqan3/std/concepts>
+
 #include <seqan3/alignment/matrix/trace_directions.hpp>
 #include <seqan3/core/simd/concept.hpp>
-#include <seqan3/std/concepts>
+#include <seqan3/core/type_traits/basic.hpp>
 
 namespace seqan3::detail
 {

--- a/include/seqan3/alignment/pairwise/alignment_result.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_result.hpp
@@ -13,6 +13,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include <seqan3/core/type_traits/template_inspection.hpp>
 
 namespace seqan3::detail

--- a/include/seqan3/alphabet/alphabet_base.hpp
+++ b/include/seqan3/alphabet/alphabet_base.hpp
@@ -12,6 +12,8 @@
 
 #pragma once
 
+#include <cassert>
+
 #include <seqan3/alphabet/concept.hpp>
 #include <seqan3/core/detail/int_types.hpp>
 #include <seqan3/std/concepts>

--- a/include/seqan3/alphabet/concept.hpp
+++ b/include/seqan3/alphabet/concept.hpp
@@ -17,6 +17,7 @@
 #include <seqan3/core/concept/core_language.hpp>
 #include <seqan3/core/detail/customisation_point.hpp>
 #include <seqan3/core/detail/type_inspection.hpp>
+#include <seqan3/core/type_traits/basic.hpp>
 #include <seqan3/std/type_traits>
 
 // ============================================================================

--- a/include/seqan3/argument_parser/auxiliary.hpp
+++ b/include/seqan3/argument_parser/auxiliary.hpp
@@ -12,8 +12,8 @@
 
 #pragma once
 
-#include <unordered_map>
 #include <sstream>
+#include <unordered_map>
 #include <vector>
 
 #include <seqan3/core/detail/customisation_point.hpp>

--- a/include/seqan3/argument_parser/auxiliary.hpp
+++ b/include/seqan3/argument_parser/auxiliary.hpp
@@ -12,6 +12,7 @@
 
 #pragma once
 
+#include <unordered_map>
 #include <sstream>
 #include <vector>
 

--- a/include/seqan3/core/detail/debug_stream_optional.hpp
+++ b/include/seqan3/core/detail/debug_stream_optional.hpp
@@ -15,6 +15,7 @@
 #include <optional>
 
 #include <seqan3/core/detail/debug_stream_type.hpp>
+#include <seqan3/core/type_traits/basic.hpp>
 #include <seqan3/core/type_traits/template_inspection.hpp>
 
 namespace seqan3

--- a/include/seqan3/core/detail/debug_stream_variant.hpp
+++ b/include/seqan3/core/detail/debug_stream_variant.hpp
@@ -15,6 +15,7 @@
 #include <variant>
 
 #include <seqan3/core/detail/debug_stream_type.hpp>
+#include <seqan3/core/type_traits/basic.hpp>
 #include <seqan3/core/type_traits/template_inspection.hpp>
 
 namespace seqan3

--- a/include/seqan3/core/detail/int_types.hpp
+++ b/include/seqan3/core/detail/int_types.hpp
@@ -7,9 +7,10 @@
 
 #pragma once
 
+#include <seqan3/std/concepts>
 #include <type_traits>
 
-#include <seqan3/std/concepts>
+#include <seqan3/core/platform.hpp>
 
 /*!\file
  * \brief Provides metaprogramming utilities for integer types.

--- a/include/seqan3/core/math.hpp
+++ b/include/seqan3/core/math.hpp
@@ -12,8 +12,8 @@
 
 #pragma once
 
-#include <seqan3/std/concepts>
 #include <cmath>
+#include <seqan3/std/concepts>
 #include <stdexcept>
 
 #include <seqan3/core/platform.hpp>

--- a/include/seqan3/core/math.hpp
+++ b/include/seqan3/core/math.hpp
@@ -12,9 +12,11 @@
 
 #pragma once
 
-#include <cmath>
-
 #include <seqan3/std/concepts>
+#include <cmath>
+#include <stdexcept>
+
+#include <seqan3/core/platform.hpp>
 
 namespace seqan3
 {

--- a/include/seqan3/core/parallel/detail/reader_writer_manager.hpp
+++ b/include/seqan3/core/parallel/detail/reader_writer_manager.hpp
@@ -13,12 +13,13 @@
 #pragma once
 
 #include <cassert>
+#include <functional>
 #include <mutex>
+#include <seqan3/std/new>
 
 #include <seqan3/core/parallel/detail/latch.hpp>
 #include <seqan3/core/parallel/detail/spin_delay.hpp>
 #include <seqan3/core/detail/strong_type.hpp>
-#include <seqan3/std/new>
 
 namespace seqan3::detail
 {

--- a/include/seqan3/core/simd/detail/simd_algorithm_avx2.hpp
+++ b/include/seqan3/core/simd/detail/simd_algorithm_avx2.hpp
@@ -12,6 +12,8 @@
 
 #pragma once
 
+#include <array>
+
 #include <seqan3/core/simd/concept.hpp>
 #include <seqan3/core/simd/detail/builtin_simd_intrinsics.hpp>
 #include <seqan3/core/simd/simd_traits.hpp>

--- a/include/seqan3/core/simd/detail/simd_algorithm_avx512.hpp
+++ b/include/seqan3/core/simd/detail/simd_algorithm_avx512.hpp
@@ -12,6 +12,8 @@
 
 #pragma once
 
+#include <array>
+
 #include <seqan3/core/simd/concept.hpp>
 #include <seqan3/core/simd/detail/builtin_simd_intrinsics.hpp>
 #include <seqan3/core/simd/simd_traits.hpp>

--- a/include/seqan3/core/simd/detail/simd_algorithm_sse4.hpp
+++ b/include/seqan3/core/simd/detail/simd_algorithm_sse4.hpp
@@ -12,6 +12,8 @@
 
 #pragma once
 
+#include <array>
+
 #include <seqan3/core/simd/concept.hpp>
 #include <seqan3/core/simd/detail/builtin_simd_intrinsics.hpp>
 #include <seqan3/core/simd/simd_traits.hpp>

--- a/include/seqan3/range/container/concept.hpp
+++ b/include/seqan3/range/container/concept.hpp
@@ -22,6 +22,8 @@
 #include <seqan3/std/iterator>
 #include <seqan3/std/concepts>
 
+#include <seqan3/core/platform.hpp>
+
 // TODO:
 // * remove is_basic_string
 // * remove #include <string> in this file

--- a/include/seqan3/range/views/pairwise_combine.hpp
+++ b/include/seqan3/range/views/pairwise_combine.hpp
@@ -15,6 +15,7 @@
 #include <cmath>
 
 #include <seqan3/core/common_tuple.hpp>
+#include <seqan3/core/type_traits/transformation_trait_or.hpp>
 #include <seqan3/range/concept.hpp>
 #include <seqan3/range/views/detail.hpp>
 #include <seqan3/std/ranges>

--- a/test/performance/range/views/view_all_benchmark.cpp
+++ b/test/performance/range/views/view_all_benchmark.cpp
@@ -13,6 +13,7 @@
 #include <benchmark/benchmark.h>
 
 #include <seqan3/range/views/type_reduce.hpp>
+#include <range/v3/view/all.hpp>
 
 // ============================================================================
 //  sequential_read

--- a/test/performance/range/views/view_all_benchmark.cpp
+++ b/test/performance/range/views/view_all_benchmark.cpp
@@ -12,8 +12,9 @@
 
 #include <benchmark/benchmark.h>
 
+#include <seqan3/std/ranges>
+
 #include <seqan3/range/views/type_reduce.hpp>
-#include <range/v3/view/all.hpp>
 
 // ============================================================================
 //  sequential_read

--- a/test/snippet/core/type_traits/function_traits.cpp
+++ b/test/snippet/core/type_traits/function_traits.cpp
@@ -1,3 +1,4 @@
+#include <cassert>
 #include <functional>
 #include <string>
 

--- a/test/unit/range/iterator_test_template.hpp
+++ b/test/unit/range/iterator_test_template.hpp
@@ -13,6 +13,7 @@
 #include <seqan3/std/ranges>
 
 #include <seqan3/core/platform.hpp>
+
 template <typename T>
 struct iterator_fixture : public ::testing::Test
 {

--- a/test/unit/range/iterator_test_template.hpp
+++ b/test/unit/range/iterator_test_template.hpp
@@ -9,11 +9,10 @@
 
 #include <gtest/gtest.h>
 
-#include <seqan3/core/platform.hpp>
-
 #include <seqan3/std/iterator>
 #include <seqan3/std/ranges>
 
+#include <seqan3/core/platform.hpp>
 template <typename T>
 struct iterator_fixture : public ::testing::Test
 {

--- a/test/unit/range/iterator_test_template.hpp
+++ b/test/unit/range/iterator_test_template.hpp
@@ -9,6 +9,8 @@
 
 #include <gtest/gtest.h>
 
+#include <seqan3/core/platform.hpp>
+
 #include <seqan3/std/iterator>
 #include <seqan3/std/ranges>
 


### PR DESCRIPTION
* cxx20: missing include <array>
* cxx20: missing include <cassert>
* cxx20: missing include <optional>
* cxx20: missing include <stdexcept>
* cxx20: missing include <unordered_map>
* cxx20: missing include <range/v3/view/all.hpp>
* cxx20: missing include platform.hpp
* cxx20: missing include type_traits/basic.hpp

```c++
seqan3/include/seqan3/core/parallel/detail/reader_writer_manager.hpp:317:10: error: ‘function’ in namespace ‘std’ does not name a template type
  317 |     std::function<void()>                                               completion_fn;
      |          ^~~~~~~~
```

```c++
include/seqan3/core/detail/int_types-1.cpp:8:2: error: #error "Your header file is missing #include <seqan3/core/platform.hpp>"
    8 | #error "Your header file is missing #include <seqan3/core/platform.hpp>"
      |  ^~~~~
```

```c++
seqan3/include/seqan3/alignment/configuration/align_config_aligned_ends.hpp:324:9: error: there are no arguments to ‘assert’ that depend on a template parameter, so a declaration of ‘assert’ must be available [-fpermissive]
  324 |         assert(pos < values.size());
      |         ^~~~~~
```

```c++
seqan3/include/seqan3/alignment/matrix/detail/alignment_trace_matrix_proxy.hpp:36:19: error: ‘decays_to_ignore_v’ was not declared in this scope
   36 |                   decays_to_ignore_v<trace_type>,
      |                   ^~~~~~~~~~~~~~~~~~
```

```c++
seqan3/include/seqan3/core/simd/detail/simd_algorithm_sse4.hpp:35:13: error: variable or field ‘transpose_matrix_sse4’ declared void
   35 | inline void transpose_matrix_sse4(std::array<simd_t, simd_traits<simd_t>::length> & matrix);
      |             ^~~~~~~~~~~~~~~~~~~~~
```

```c++
seqan3/include/seqan3/argument_parser/auxiliary.hpp:73:6: error: ‘unordered_map’ in namespace ‘std’ does not name a template type
   73 | std::unordered_map<std::string_view, t> enumeration_names(t) = delete;
      |      ^~~~~~~~~~~~~
```

```c++
seqan3/include/seqan3/core/detail/debug_stream_variant.hpp:37:50: error: ‘remove_cvref_t’ was not declared in this scope; did you mean ‘std::remove_cvref_t’?
   37 |     requires detail::is_type_specialisation_of_v<remove_cvref_t<variant_type>, std::variant>
      |                                                  ^~~~~~~~~~~~~~
```

```c++
seqan3/include/seqan3/core/simd/detail/simd_algorithm_avx2.hpp:35:13: error: variable or field ‘transpose_matrix_avx2’ declared void
   35 | inline void transpose_matrix_avx2(std::array<simd_t, simd_traits<simd_t>::length> & matrix);
      |             ^~~~~~~~~~~~~~~~~~~~~
```

```c++
seqan3/include/seqan3/core/simd/detail/simd_algorithm_avx512.hpp:35:13: error: variable or field ‘transpose_matrix_avx512’ declared void
   35 | inline void transpose_matrix_avx512(std::array<simd_t, simd_traits<simd_t>::length> & matrix);
      |             ^~~~~~~~~~~~~~~~~~~~~~~
```

```c++
seqan3/core/math-1.cpp:8:2: error: #error "Your header file is missing #include <seqan3/core/platform.hpp>"
    8 | #error "Your header file is missing #include <seqan3/core/platform.hpp>"
      |  ^~~~~
```

```c++
seqan3/include/seqan3/core/detail/debug_stream_optional.hpp:33:26: error: ‘remove_cvref_t’ was not declared in this scope; did you mean ‘std::remove_cvref_t’?
   33 |    requires std::same_as<remove_cvref_t<optional_type>, std::nullopt_t>
      |                          ^~~~~~~~~~~~~~
```

```c++
seqan3/include/seqan3/core/math.hpp:62:28: error: ‘underflow_error’ is not a member of ‘std’
   62 |                 throw std::underflow_error{error_message + " underflow."};
      |                            ^~~~~~~~~~~~~~~
```

```c++
include/seqan3/alignment/pairwise/alignment_result.hpp:34:40: error: ‘nullopt_t’ in namespace ‘std’ does not name a type; did you mean ‘nullptr_t’?
   34 |           typename back_coord_t = std::nullopt_t *,
      |                                        ^~~~~~~~~
```

```c++
seqan3/test/snippet/core/type_traits/function_traits.cpp:9:5: error: ‘assert’ was not declared in this scope
    9 |     assert(position < sequence.size());
      |     ^~~~~~
```

```c++
seqan3/doc/howto/write_an_alphabet/dna2_semialphabet.cpp:26:9: error: ‘assert’ was not declared in this scope
   26 |         assert(rk < alphabet_size);
      |         ^~~~~~
```

```c++
seqan3/doc/howto/write_an_alphabet/dna2_alphabet.cpp:26:9: error: ‘assert’ was not declared in this scope
   26 |         assert(rk < alphabet_size);
      |         ^~~~~~
```