### PR TITLE
[MISC] Renames ranges::view to ranges::views

### DIFF
--- a/doc/tutorial/sequence_file/index.md
+++ b/doc/tutorial/sequence_file/index.md
@@ -302,7 +302,7 @@ This enables us to create solutions for lot of use cases using only a few lines 
 
 A common use case is to read chunks from a file instead of the whole file at once or line by line.
 
-You can do so easily on a file range by using the ranges::view::chunk.
+You can do so easily on a file range by using the ranges::views::chunk.
 
 \snippet doc/tutorial/sequence_file/sequence_file_snippets.cpp read_in_batches
 

--- a/doc/tutorial/sequence_file/sequence_file_snippets.cpp
+++ b/doc/tutorial/sequence_file/sequence_file_snippets.cpp
@@ -1,5 +1,5 @@
 #include <fstream>
-#include <numeric> // std::accumulate 
+#include <numeric> // std::accumulate
 //![include_ranges_chunk]
 #include <range/v3/view/chunk.hpp>
 //![include_ranges_chunk]
@@ -137,8 +137,9 @@ for (auto && [rec1, rec2] : seqan3::views::zip(fin1, fin2)) // && is important!
 //![read_in_batches]
 seqan3::sequence_file_input fin{std::filesystem::temp_directory_path()/"my.fastq"};
 
-for (auto && records : fin | ranges::view::chunk(10))   // && is important!
-{                                                       // because seqan3::views::chunk returns temporaries
+// `&&` is important because seqan3::views::chunk returns temporaries!
+for (auto && records : fin | ranges::views::chunk(10))
+{
     // `records` contains 10 elements (or less at the end)
     seqan3::debug_stream << "Taking the next 10 sequences:\n";
     seqan3::debug_stream << "ID:  " << seqan3::get<seqan3::field::id>(*records.begin()) << '\n';

--- a/include/seqan3/io/sequence_file/format_genbank.hpp
+++ b/include/seqan3/io/sequence_file/format_genbank.hpp
@@ -230,7 +230,7 @@ protected:
         else
         {
             std::ranges::copy(std::string_view{"ORIGIN\n"}, stream_it);
-            auto seq = sequence | ranges::view::chunk(60);
+            auto seq = sequence | ranges::views::chunk(60);
             size_t i = 0;
             size_t bp = 1;
 

--- a/include/seqan3/io/structure_file/format_vienna.hpp
+++ b/include/seqan3/io/structure_file/format_vienna.hpp
@@ -356,7 +356,7 @@ private:
      * \tparam alph_type        The alphabet type the structure is converted to.
      * \tparam stream_view_type The type of the input stream.
      * \param stream_view       The input stream to be read.
-     * \return                  A ranges::view containing the structure annotation string.
+     * \return                  A std::ranges::view containing the structure annotation string.
      */
     template <typename alph_type, typename stream_view_type>
     auto read_structure(stream_view_type & stream_view)

--- a/include/seqan3/range/container/concatenated_sequences.hpp
+++ b/include/seqan3/range/container/concatenated_sequences.hpp
@@ -527,7 +527,7 @@ public:
     /*!\brief Return the i-th element as a view.
      * \param i The element to retrieve.
      * \throws std::out_of_range If you access an element behind the last.
-     * \returns A ranges::view on the underlying concatenated sequences that acts as a proxy for the element.
+     * \returns A std::ranges::view on the underlying concatenated sequences that acts as a proxy for the element.
      *
      * ###Complexity
      *
@@ -556,7 +556,7 @@ public:
 
     /*!\brief Return the i-th element as a view.
      * \param i The element to retrieve.
-     * \returns A ranges::view on the underlying concatenated sequences that acts as a proxy for the element.
+     * \returns A std::ranges::view on the underlying concatenated sequences that acts as a proxy for the element.
      *
      * Accessing an element behind the last causes undefined behaviour. In debug mode an assertion checks the size of
      * the container.
@@ -582,7 +582,7 @@ public:
     }
 
     /*!\brief Return the first element as a view. Calling front on an empty container is undefined.
-     * \returns A ranges::view on the underlying concatenated sequences that acts as a proxy for the element.
+     * \returns A std::ranges::view on the underlying concatenated sequences that acts as a proxy for the element.
      *
      * Calling front on an empty container is undefined. In debug mode an assertion checks the size of the container.
      * ###Complexity
@@ -607,7 +607,7 @@ public:
     }
 
     /*!\brief Return the last element as a view.
-     * \returns A ranges::view on the underlying concatenated sequences that acts as a proxy for the element.
+     * \returns A std::ranges::view on the underlying concatenated sequences that acts as a proxy for the element.
      *
      * Calling back on an empty container is undefined. In debug mode an assertion checks the size of the container.
      * ###Complexity
@@ -632,7 +632,7 @@ public:
     }
 
     /*!\brief Return the concatenation of all members.
-     * \returns A ranges::view proxy on the concatenation of underlying sequences.
+     * \returns A std::ranges::view proxy on the concatenation of underlying sequences.
      *
      * This is a safe way of accessing the internal concatenated representation, i.e. you cannot do operations
      * that would invalidate this container (like insert or resize), but you can write to the individual positions.
@@ -969,11 +969,11 @@ public:
             return begin() + pos_as_num;
 
         /* TODO implement views::flat_repeat_n that is like
-         *  views::repeat_n(value, count) | views::join | ranges::view::bounded;
+         *  views::repeat_n(value, count) | views::join | ranges::views::bounded;
          * but preserves random access and size.
          *
          * then do
-         *  auto concatenated = ranges::view::flat_repeat_n(value, count);
+         *  auto concatenated = ranges::views::flat_repeat_n(value, count);
          *  insert(pos, concatenated.cbegin(), concatenated.cend())
          */
 

--- a/include/seqan3/range/views/interleave.hpp
+++ b/include/seqan3/range/views/interleave.hpp
@@ -364,7 +364,7 @@ namespace seqan3::views
  *
  *
  * If above requirements are not met, this adaptor forwards to
- * `| ranges::view::chunk(step_size) | views::join(inserted_range)`
+ * `| seqan3::views::chunk(step_size) | std::views::join(inserted_range)`
  * which returns a view with the following properties:
  *
  * | Concepts and traits              | `urng_t` (underlying range type)      | `rrng_t` (returned range type)       |

--- a/include/seqan3/search/fm_index/bi_fm_index_cursor.hpp
+++ b/include/seqan3/search/fm_index/bi_fm_index_cursor.hpp
@@ -1015,7 +1015,7 @@ public:
         return occ;
     }
 
-    /*!\brief Locates the occurrences of the searched query in the text on demand, i.e. a ranges::view is returned
+    /*!\brief Locates the occurrences of the searched query in the text on demand, i.e. a std::ranges::view is returned
      *        and every position is located once it is accessed.
      * \returns Positions in the text.
      *

--- a/include/seqan3/search/fm_index/fm_index_cursor.hpp
+++ b/include/seqan3/search/fm_index/fm_index_cursor.hpp
@@ -577,7 +577,7 @@ public:
         return occ;
     }
 
-    /*!\brief Locates the occurrences of the searched query in the text on demand, i.e. a ranges::view is returned and
+    /*!\brief Locates the occurrences of the searched query in the text on demand, i.e. a std::ranges::view is returned and
      *        every position is located once it is accessed.
      * \returns Positions in the text.
      *

--- a/test/include/seqan3/test/performance/naive_kmer_hash.hpp
+++ b/test/include/seqan3/test/performance/naive_kmer_hash.hpp
@@ -46,8 +46,7 @@ struct naive_kmer_hash_fn
     //!\endcond
     constexpr auto operator()(urng_t && urange, size_t const k) const noexcept
     {
-        return std::forward<urng_t>(urange) | ranges::view::sliding(k) | std::views::transform(
-        [] (auto const in)
+        return std::forward<urng_t>(urange) | ranges::views::sliding(k) | std::views::transform([] (auto const in)
         {
             std::hash<decltype(in)> h{};
             return h(in);

--- a/test/include/seqan3/test/performance/naive_minimiser_hash.hpp
+++ b/test/include/seqan3/test/performance/naive_minimiser_hash.hpp
@@ -67,7 +67,7 @@ struct naive_minimiser_hash_fn
 
        return std::forward<urng_t>(urange) | seqan3::views::kmer_hash(shape)
                                            | std::views::transform([seed] (uint64_t i) { return i ^ seed; })
-                                           | ranges::view::sliding(window_size - shape.size() + 1)
+                                           | ranges::views::sliding(window_size - shape.size() + 1)
                                            | std::views::transform([] (auto const in)
                                                                    {
                                                                        return *std::min_element(in.begin(), in.end());

--- a/test/unit/alphabet/aminoacid/aminoacid_translation_test.cpp
+++ b/test/unit/alphabet/aminoacid/aminoacid_translation_test.cpp
@@ -49,8 +49,8 @@ TEST(translate_triplets, random_access_range)
     seqan3::dna15 n3{'A'_dna15};
     seqan3::aa27 c{'L'_aa27};
 
-    auto range_triplet = ranges::view::concat(std::views::single(n1), std::views::single(n2),
-                                              std::views::single(n3));
+    auto range_triplet = ranges::views::concat(std::views::single(n1), std::views::single(n2),
+                                               std::views::single(n3));
     #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     seqan3::aa27 t2{seqan3::translate_triplet(range_triplet)};
 

--- a/test/unit/range/views/view_drop_test.cpp
+++ b/test/unit/range/views/view_drop_test.cpp
@@ -40,9 +40,9 @@ void do_test(adaptor_t const & adaptor, std::string const & vec)
     EXPECT_EQ("bar", v2);
 
     // combinability
-    auto v3 = vec | adaptor(1) | adaptor(1) | ranges::view::unique;
+    auto v3 = vec | adaptor(1) | adaptor(1) | ranges::views::unique;
     EXPECT_EQ("obar", v3 | seqan3::views::to<std::string>);
-    std::string v3b = vec | std::views::reverse | adaptor(3) | ranges::view::unique | seqan3::views::to<std::string>;
+    std::string v3b = vec | std::views::reverse | adaptor(3) | ranges::views::unique | seqan3::views::to<std::string>;
     EXPECT_EQ("of", v3b);
 
     // store arg
@@ -51,7 +51,7 @@ void do_test(adaptor_t const & adaptor, std::string const & vec)
     EXPECT_EQ("bar", v4 | seqan3::views::to<std::string>);
 
     // store combined
-    auto a1 = adaptor(1) | adaptor(1) | ranges::view::unique;
+    auto a1 = adaptor(1) | adaptor(1) | ranges::views::unique;
     auto v5 = vec | a1;
     EXPECT_EQ("obar", v5 | seqan3::views::to<std::string>);
 }

--- a/test/unit/range/views/view_persist_test.cpp
+++ b/test/unit/range/views/view_persist_test.cpp
@@ -36,17 +36,17 @@ TEST(view_persist, delegate_to_view_all)
     EXPECT_EQ("foo", v2);
 
     // combinability
-    auto v3 = vec | seqan3::views::persist | ranges::view::unique;
+    auto v3 = vec | seqan3::views::persist | ranges::views::unique;
     EXPECT_EQ("fo", v3 | seqan3::views::to<std::string>);
     std::string v3b = vec
                     | std::views::reverse
                     | seqan3::views::persist
-                    | ranges::view::unique
+                    | ranges::views::unique
                     | seqan3::views::to<std::string>;
     EXPECT_EQ("of", v3b);
 
     // store combined
-    auto a1 = seqan3::views::persist | ranges::view::unique;
+    auto a1 = seqan3::views::persist | ranges::views::unique;
     auto v5 = vec | a1;
     EXPECT_EQ("fo", v5 | seqan3::views::to<std::string>);
 }
@@ -62,12 +62,12 @@ TEST(view_persist, wrap_temporary)
     EXPECT_EQ("foo", v2);
 
     // combinability
-    auto v3 = std::string{"foo"} | seqan3::views::persist | ranges::view::unique;
+    auto v3 = std::string{"foo"} | seqan3::views::persist | ranges::views::unique;
     EXPECT_EQ("fo", v3 | seqan3::views::to<std::string>);
     std::string v3b = std::string{"foo"}
                     | seqan3::views::persist
                     | std::views::filter(seqan3::is_char<'o'>)
-                    | ranges::view::unique
+                    | ranges::views::unique
                     | seqan3::views::to<std::string>;
     EXPECT_EQ("o", v3b);
 }

--- a/test/unit/range/views/view_slice_test.cpp
+++ b/test/unit/range/views/view_slice_test.cpp
@@ -40,9 +40,9 @@ void do_test(adaptor_t const & adaptor, std::string const & vec)
     EXPECT_EQ("oob", v2);
 
     // combinability
-    auto v3 = vec | adaptor(0, 4) | adaptor(1, 3) | ranges::view::unique;
+    auto v3 = vec | adaptor(0, 4) | adaptor(1, 3) | ranges::views::unique;
     EXPECT_EQ("o", v3 | seqan3::views::to<std::string>);
-    std::string v3b = vec | std::views::reverse | adaptor(1, 4) | ranges::view::unique | seqan3::views::to<std::string>;
+    std::string v3b = vec | std::views::reverse | adaptor(1, 4) | ranges::views::unique | seqan3::views::to<std::string>;
     EXPECT_EQ("abo", v3b);
 
     // store arg
@@ -51,12 +51,12 @@ void do_test(adaptor_t const & adaptor, std::string const & vec)
     EXPECT_EQ("oob", v4 | seqan3::views::to<std::string>);
 
     // store combined
-    auto a1 = adaptor(0, 4) | adaptor(1, 3) | ranges::view::unique;
+    auto a1 = adaptor(0, 4) | adaptor(1, 3) | ranges::views::unique;
     auto v5 = vec | a1;
     EXPECT_EQ("o", v5 | seqan3::views::to<std::string>);
 
     // store combined in middle
-    auto a2 = std::views::reverse | adaptor(1, 4) | ranges::view::unique;
+    auto a2 = std::views::reverse | adaptor(1, 4) | ranges::views::unique;
     auto v6 = vec | a2;
     EXPECT_EQ("abo", v6 | seqan3::views::to<std::string>);
 }

--- a/test/unit/range/views/view_take_line_test.cpp
+++ b/test/unit/range/views/view_take_line_test.cpp
@@ -33,9 +33,9 @@ void do_test(adaptor_t const & adaptor, std::string const & vec)
     EXPECT_EQ("foo", v2);
 
     // combinability
-    auto v3 = vec | adaptor | ranges::view::unique;
+    auto v3 = vec | adaptor | ranges::views::unique;
     EXPECT_EQ("fo", v3 | seqan3::views::to<std::string>);
-    std::string v3b = vec | std::views::reverse | adaptor | ranges::view::unique | seqan3::views::to<std::string>;
+    std::string v3b = vec | std::views::reverse | adaptor | ranges::views::unique | seqan3::views::to<std::string>;
     EXPECT_EQ("rab", v3b);
 
     // consuming behaviour

--- a/test/unit/range/views/view_take_test.cpp
+++ b/test/unit/range/views/view_take_test.cpp
@@ -46,9 +46,9 @@ void do_test(adaptor_t const & adaptor, std::string const & vec)
     EXPECT_EQ("foo", v2);
 
     // combinability
-    auto v3 = vec | adaptor(3) | adaptor(3) | ranges::view::unique;
+    auto v3 = vec | adaptor(3) | adaptor(3) | ranges::views::unique;
     EXPECT_EQ("fo", v3 | seqan3::views::to<std::string>);
-    std::string v3b = vec | std::views::reverse | adaptor(3) | ranges::view::unique | seqan3::views::to<std::string>;
+    std::string v3b = vec | std::views::reverse | adaptor(3) | ranges::views::unique | seqan3::views::to<std::string>;
     EXPECT_EQ("rab", v3b);
 
     // comparability against self

--- a/test/unit/range/views/view_take_until_test.cpp
+++ b/test/unit/range/views/view_take_until_test.cpp
@@ -35,9 +35,9 @@ void do_test(adaptor_t const & adaptor, fun_t && fun, std::string const & vec)
     EXPECT_EQ("foo", v2);
 
     // combinability
-    auto v3 = vec | adaptor(fun) | ranges::view::unique;
+    auto v3 = vec | adaptor(fun) | ranges::views::unique;
     EXPECT_EQ("fo", v3  | seqan3::views::to<std::string>);
-    std::string v3b = vec | std::views::reverse | adaptor(fun) | ranges::view::unique | seqan3::views::to<std::string>;
+    std::string v3b = vec | std::views::reverse | adaptor(fun) | ranges::views::unique | seqan3::views::to<std::string>;
     EXPECT_EQ("rab", v3b);
 
     // pointer as iterator


### PR DESCRIPTION
This commit resolves https://github.com/seqan/product_backlog/issues/91 . 
The namespace ranges::view is deprecated and should be replaced by ranges::views. 