### PR TITLE
[FIX] Allow to pass a pair of non lvalue references to align_pairwise.

### DIFF
--- a/include/seqan3/alignment/pairwise/align_pairwise.hpp
+++ b/include/seqan3/alignment/pairwise/align_pairwise.hpp
@@ -147,6 +147,23 @@ constexpr auto align_pairwise(sequence_t && seq, alignment_config_t const & conf
     return align_pairwise(std::views::single(std::forward<sequence_t>(seq)), config);
 }
 
+//!\overload
+template <typename sequence_t, typename alignment_config_t>
+//!\cond
+    requires tuple_like<sequence_t> && !detail::align_pairwise_single_input<std::remove_reference_t<sequence_t>>
+//!\endcond
+constexpr auto align_pairwise(sequence_t && seq, alignment_config_t const & config)
+{
+    static_assert(std::tuple_size_v<std::remove_reference_t<sequence_t>> == 2,
+                  "Alignment configuration error: Expects exactly two sequences for pairwise alignments.");
+
+    static_assert(std::is_lvalue_reference_v<sequence_t>,
+                  "Alignment configuration error: The given tuple/pair must be an lvalue reference.");
+
+    auto tied_pair = std::tie(get<0>(seq), get<1>(seq));
+    return align_pairwise(tied_pair, config);
+}
+
 //!\cond
 template <typename sequence_t, typename alignment_config_t>
     requires detail::align_pairwise_range_input<sequence_t> &&

--- a/test/unit/alignment/pairwise/align_pairwise_test.cpp
+++ b/test/unit/alignment/pairwise/align_pairwise_test.cpp
@@ -88,6 +88,38 @@ TYPED_TEST(align_pairwise_test, single_pair)
     }
 }
 
+TYPED_TEST(align_pairwise_test, single_pair_of_non_lvalues)
+{
+    auto const seq1 = "ACGTGATG"_dna4;
+    auto const seq2 = "AGTGATACT"_dna4;
+
+    auto p = std::make_pair(seq1, seq2);
+
+    {  // the score
+        seqan3::configuration cfg = seqan3::align_cfg::edit | seqan3::align_cfg::result{seqan3::with_score};
+
+        for (auto && res : call_alignment<TypeParam>(p, cfg))
+        {
+            EXPECT_EQ(res.score(), -4.0);
+        }
+    }
+
+    {  // the alignment
+        seqan3::configuration cfg = seqan3::align_cfg::edit | seqan3::align_cfg::result{seqan3::with_alignment};
+        unsigned idx = 0;
+        for (auto && res : call_alignment<TypeParam>(p, cfg))
+        {
+            EXPECT_EQ(res.id(), idx++);
+            EXPECT_EQ(res.score(), -4);
+            EXPECT_EQ(res.back_coordinate().first, 8u);
+            EXPECT_EQ(res.back_coordinate().second, 9u);
+            auto && [gap1, gap2] = res.alignment();
+            EXPECT_EQ(gap1 | seqan3::views::to_char | seqan3::views::to<std::string>, "ACGTGATG--");
+            EXPECT_EQ(gap2 | seqan3::views::to_char | seqan3::views::to<std::string>, "A-GTGATACT");
+        }
+    }
+}
+
 TYPED_TEST(align_pairwise_test, single_pair_double_score)
 {
     if constexpr (!TestFixture::is_vectorised)


### PR DESCRIPTION
Maybe Fixes #1516 