### PR TITLE
[FEATURE] add seqan3::detail::iter_pointer[_t]

### DIFF
--- a/include/seqan3/core/simd/view_to_simd.hpp
+++ b/include/seqan3/core/simd/view_to_simd.hpp
@@ -48,7 +48,7 @@ namespace seqan3::detail
  *
  * Depending on the types of the input ranges a more efficient transformation using simd instructions is used.
  * The following requirements must be fulfilled by the inner range type of the underlying range:
- *  * they must model std::ranges::ContigiousRange
+ *  * they must model std::ranges::contiguous_range
  *  * the iterator and sentinel types must model std::sized_sentinel_for
  *  * the size of the rank type of the underlying alphabet must be 1.
  *

--- a/include/seqan3/core/type_traits/iterator.hpp
+++ b/include/seqan3/core/type_traits/iterator.hpp
@@ -167,10 +167,10 @@ struct size_type<it_t>
 template <typename it_t>
 struct iterator_tag
 {
-SEQAN3_DOXYGEN_ONLY(
+#if SEQAN3_DOXYGEN_ONLY(1)0
     //!\brief The [iterator_category](https://en.cppreference.com/w/cpp/iterator/iterator_tags).
     using type = iterator_category;
-)
+#endif
 };
 
 //!\cond
@@ -231,3 +231,45 @@ using iterator_tag_t = typename iterator_tag<it_t>::type;
 //!\}
 
 } // namespace seqan3
+
+namespace seqan3::detail
+{
+// ----------------------------------------------------------------------------
+// iter_pointer
+// ----------------------------------------------------------------------------
+
+/*!\brief This is like std::iter_value_t, but for the pointer type.
+ * \implements seqan3::transformation_trait
+ * \tparam it_t The type to operate on.
+ * \see seqan3::detail::iter_pointer_t
+ *
+ * \attention
+ * C++20 does not provide a `std::iter_pointer_t`, because the new C++20 iterators do not need to provide a pointer
+ * type.
+ */
+template <typename it_t>
+struct iter_pointer
+{
+    //!\brief The pointer type of std::iterator_traits or void.
+    using type = void;
+};
+
+//!\cond
+template <typename it_t>
+    requires requires { typename std::iterator_traits<it_t>::pointer; }
+struct iter_pointer<it_t>
+{
+    //!\brief This is defined for every legacy input-iterator.
+    //!\sa https://en.cppreference.com/w/cpp/iterator/iterator_traits
+    using type = typename std::iterator_traits<it_t>::pointer;
+};
+//!\endcond
+
+/*!\brief Return the `pointer` type of the input type (transformation_trait shortcut).
+ * \tparam it_t The type to operate on.
+ * \see seqan3::detail::iter_pointer
+ */
+template <typename it_t>
+using iter_pointer_t = typename iter_pointer<it_t>::type;
+
+} // namespace seqan3::detail

--- a/include/seqan3/io/sequence_file/output_format_concept.hpp
+++ b/include/seqan3/io/sequence_file/output_format_concept.hpp
@@ -6,7 +6,7 @@
 // -----------------------------------------------------------------------------------------------------
 
 /*!\file
- * \brief Provides seqan3::SequenceFileFormatOut and auxiliary classes.
+ * \brief Provides seqan3::sequence_file_output_format and auxiliary classes.
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  */
 
@@ -145,7 +145,8 @@ template <typename ...ts>
 constexpr bool is_type_list_of_sequence_file_output_formats_v<type_list<ts...>> =
     (sequence_file_output_format<ts> && ...);
 
-/*!\brief Auxiliary concept that checks whether a type is a seqan3::type_list and all types meet seqan3::SequenceFileFormat.
+/*!\brief Auxiliary concept that checks whether a type is a seqan3::type_list and all types meet
+ *        seqan3::sequence_file_output_format.
  * \ingroup core
  * \see seqan3::is_type_list_of_sequence_file_formats_v
  */

--- a/include/seqan3/io/structure_file/input_format_concept.hpp
+++ b/include/seqan3/io/structure_file/input_format_concept.hpp
@@ -153,7 +153,7 @@ SEQAN3_CONCEPT structure_file_input_format = requires(detail::structure_file_inp
  *                                comment_type & comment,
  *                                offset_type & offset)
  * \brief Read from the specified stream and back-insert into the given field buffers.
- * \tparam stream_type      Input stream, must satisfy seqan3::Istream with `char`.
+ * \tparam stream_type      Input stream, must satisfy seqan3::input_stream_over with `char`.
  * \tparam seq_type         Type of the seqan3::field::seq input; must satisfy std::ranges::output_range
  * over a seqan3::alphabet.
  * \tparam id_type          Type of the seqan3::field::id input; must satisfy std::ranges::output_range

--- a/include/seqan3/io/structure_file/output_format_concept.hpp
+++ b/include/seqan3/io/structure_file/output_format_concept.hpp
@@ -218,7 +218,7 @@ constexpr bool is_type_list_of_structure_file_output_formats_v<type_list<ts...>>
                 = (structure_file_output_format<ts> && ...);
 
 /*!\brief Auxiliary concept that checks whether a type is a seqan3::type_list and all types meet
- * seqan3::StructureFileFormat.
+ *        seqan3::structure_file_output_format.
  * \ingroup core
  * \see seqan3::is_type_list_of_structure_file_formats_v
  */

--- a/include/seqan3/range/detail/inherited_iterator_base.hpp
+++ b/include/seqan3/range/detail/inherited_iterator_base.hpp
@@ -60,13 +60,13 @@ public:
      */
 
     //!\brief The difference type.
-    using difference_type       = typename std::iterator_traits<base_t>::difference_type;
+    using difference_type = std::iter_difference_t<base_t>;
     //!\brief The value type.
-    using value_type            = typename std::iterator_traits<base_t>::value_type;
+    using value_type = std::iter_value_t<base_t>;
     //!\brief The reference type.
-    using reference             = typename std::iterator_traits<base_t>::reference;
+    using reference = std::iter_reference_t<base_t>;
     //!\brief The pointer type.
-    using pointer               = typename std::iterator_traits<base_t>::pointer;
+    using pointer = detail::iter_pointer_t<base_t>;
     //!\brief The iterator category tag.
     using iterator_category = iterator_tag_t<base_t>;
     //!\brief The iterator concept tag.

--- a/include/seqan3/range/views/async_input_buffer.hpp
+++ b/include/seqan3/range/views/async_input_buffer.hpp
@@ -33,7 +33,7 @@ namespace seqan3::detail
 
 /*!\brief The type returned by seqan3::views::async_input_buffer.
  * \tparam urng_t The underlying range type.
- * \implements std::ranges::InputRange
+ * \implements std::ranges::input_range
  * \ingroup views
  */
 template <std::ranges::range urng_t>
@@ -41,11 +41,11 @@ class async_input_buffer_view : public std::ranges::view_interface<async_input_b
 {
 private:
     static_assert(std::ranges::input_range<urng_t>,
-        "The range parameter to async_input_buffer_view must be at least an std::ranges::InputRange.");
+        "The range parameter to async_input_buffer_view must be at least an std::ranges::input_range.");
     static_assert(std::ranges::view<urng_t>,
-        "The range parameter to async_input_buffer_view must model std::ranges::View.");
+        "The range parameter to async_input_buffer_view must model std::ranges::view.");
     static_assert(std::movable<std::ranges::range_value_t<urng_t>>,
-        "The range parameter to async_input_buffer_view must have a value_type that is std::Movable.");
+        "The range parameter to async_input_buffer_view must have a value_type that is std::movable.");
     static_assert(std::constructible_from<std::ranges::range_value_t<urng_t>,
                                           std::remove_reference_t<std::ranges::range_reference_t<urng_t>> &&>,
         "The range parameter to async_input_buffer_view must have a value_type that is constructible by a moved "
@@ -77,12 +77,12 @@ public:
     /*!\name Constructor, destructor, and assignment.
      * \{
      */
-    async_input_buffer_view()                                         = default; //!< Defaulted.
-    async_input_buffer_view(async_input_buffer_view const &)                = default; //!< Defaulted.
-    async_input_buffer_view(async_input_buffer_view &&)                     = default; //!< Defaulted.
-    async_input_buffer_view & operator=(async_input_buffer_view const &)    = default; //!< Defaulted.
-    async_input_buffer_view & operator=(async_input_buffer_view &&)         = default; //!< Defaulted.
-    ~async_input_buffer_view()                                        = default; //!< Defaulted.
+    async_input_buffer_view() = default; //!< Defaulted.
+    async_input_buffer_view(async_input_buffer_view const &) = default; //!< Defaulted.
+    async_input_buffer_view(async_input_buffer_view &&) = default; //!< Defaulted.
+    async_input_buffer_view & operator=(async_input_buffer_view const &) = default; //!< Defaulted.
+    async_input_buffer_view & operator=(async_input_buffer_view &&) = default; //!< Defaulted.
+    ~async_input_buffer_view() = default; //!< Defaulted.
 
     //!\brief Construction from the underlying view.
     async_input_buffer_view(urng_t _urng, size_t const buffer_size)
@@ -114,7 +114,7 @@ public:
         state_ptr->producer = std::thread{runner};
     }
 
-    //!\brief Construction from std::ranges::ViewableRange.
+    //!\brief Construction from std::ranges::viewable_range.
     template <typename other_urng_t>
     //!\cond
     requires (!std::same_as<remove_cvref_t<other_urng_t>, async_input_buffer_view>) && // prevent recursive instantiation
@@ -188,31 +188,31 @@ public:
     * \{
     */
     //!\brief Difference type.
-    using difference_type   = std::iter_difference_t<urng_iterator_type>;
+    using difference_type = std::iter_difference_t<urng_iterator_type>;
     //!\brief Value type.
-    using value_type        = std::iter_value_t<urng_iterator_type>;
+    using value_type = std::iter_value_t<urng_iterator_type>;
     //!\brief Pointer type.
-    using pointer           = value_type *;
+    using pointer = value_type *;
     //!\brief Reference type.
-    using reference         = value_type &;
+    using reference = value_type &;
     //!\brief Iterator category.
     using iterator_category = std::input_iterator_tag;
     //!\brief Iterator concept.
-    using iterator_concept  = iterator_category;
+    using iterator_concept = iterator_category;
     //!\}
 
     /*!\name Construction, destruction and assignment
      * \brief Not explicitly `noexcept` because this depends on construction/copy/... of value_type.
      * \{
      */
-    async_input_buffer_iterator()                                                    = default; //!< Defaulted.
+    async_input_buffer_iterator() = default; //!< Defaulted.
     //TODO: delete:
-    async_input_buffer_iterator(async_input_buffer_iterator const & rhs)             = default; //!< Defaulted.
-    async_input_buffer_iterator(async_input_buffer_iterator && rhs)                  = default; //!< Defaulted.
+    async_input_buffer_iterator(async_input_buffer_iterator const & rhs) = default; //!< Defaulted.
+    async_input_buffer_iterator(async_input_buffer_iterator && rhs) = default; //!< Defaulted.
     //TODO: delete:
     async_input_buffer_iterator & operator=(async_input_buffer_iterator const & rhs) = default; //!< Defaulted.
-    async_input_buffer_iterator & operator=(async_input_buffer_iterator && rhs)      = default; //!< Defaulted.
-    ~async_input_buffer_iterator()                                          noexcept = default; //!< Defaulted.
+    async_input_buffer_iterator & operator=(async_input_buffer_iterator && rhs) = default; //!< Defaulted.
+    ~async_input_buffer_iterator() noexcept = default; //!< Defaulted.
 
     //!\brief Constructing from the underlying seqan3::async_input_buffer_view.
     async_input_buffer_iterator(contrib::fixed_buffer_queue<std::ranges::range_value_t<urng_t>> & buffer) noexcept :
@@ -300,7 +300,7 @@ public:
  * \{
  */
 
-//!\brief Deduces the async_input_buffer_view from the underlying range if it is a std::ranges::ViewableRange.
+//!\brief Deduces the async_input_buffer_view from the underlying range if it is a std::ranges::viewable_range.
 template <std::ranges::viewable_range urng_t>
 async_input_buffer_view(urng_t &&, size_t const buffer_size) -> async_input_buffer_view<std::views::all_t<urng_t>>;
 //!\}
@@ -327,11 +327,11 @@ struct async_input_buffer_fn
     constexpr auto operator()(urng_t && urange, size_t const buffer_size) const
     {
         static_assert(std::ranges::input_range<urng_t>,
-            "The range parameter to views::async_input_buffer must be at least an std::ranges::InputRange.");
+            "The range parameter to views::async_input_buffer must be at least an std::ranges::input_range.");
         static_assert(std::ranges::viewable_range<urng_t>,
             "The range parameter to views::async_input_buffer cannot be a temporary of a non-view range.");
         static_assert(std::movable<std::ranges::range_value_t<urng_t>>,
-            "The range parameter to views::async_input_buffer must have a value_type that is std::Movable.");
+            "The range parameter to views::async_input_buffer must have a value_type that is std::movable.");
         static_assert(std::constructible_from<std::ranges::range_value_t<urng_t>,
                                               std::remove_reference_t<std::ranges::range_reference_t<urng_t>> &&>,
             "The range parameter to views::async_input_buffer must have a value_type that is constructible by a moved "

--- a/include/seqan3/range/views/async_input_buffer.hpp
+++ b/include/seqan3/range/views/async_input_buffer.hpp
@@ -192,9 +192,9 @@ public:
     //!\brief Value type.
     using value_type = std::iter_value_t<urng_iterator_type>;
     //!\brief Pointer type.
-    using pointer = value_type *;
+    using pointer = detail::iter_pointer_t<urng_iterator_type>;
     //!\brief Reference type.
-    using reference = value_type &;
+    using reference = std::iter_reference_t<urng_iterator_type>;
     //!\brief Iterator category.
     using iterator_category = std::input_iterator_tag;
     //!\brief Iterator concept.

--- a/include/seqan3/range/views/single_pass_input.hpp
+++ b/include/seqan3/range/views/single_pass_input.hpp
@@ -191,7 +191,7 @@ public:
     //!\brief Value type.
     using value_type = std::iter_value_t<base_iterator_type>;
     //!\brief Pointer type.
-    using pointer = typename std::iterator_traits<base_iterator_type>::pointer;
+    using pointer = detail::iter_pointer_t<base_iterator_type>;
     //!\brief Reference type.
     using reference = std::iter_reference_t<base_iterator_type>;
     //!\brief Iterator category.

--- a/include/seqan3/range/views/single_pass_input.hpp
+++ b/include/seqan3/range/views/single_pass_input.hpp
@@ -51,7 +51,7 @@ private:
     struct state
     {
         //!\brief The underlying range.
-        urng_t             urng;
+        urng_t urng;
         //!\brief The cached iterator of the underlying range.
         urng_iterator_type cached_urng_iter = std::ranges::begin(urng);
     };
@@ -59,24 +59,16 @@ private:
     //!\brief Manages the internal state.
     std::shared_ptr<state> state_ptr{};
 
-public:
     /*!\name Member types
      * \{
      */
     //!\brief Iterator type.
-    using iterator          = single_pass_input_iterator<single_pass_input_view>;
-    //!\brief Const iterator type is `void`, as iterating over this view as `const` is explicitly forbidden.
-    using const_iterator    = void;
+    using iterator = single_pass_input_iterator<single_pass_input_view>;
     //!\brief The sentinel type.
-    using sentinel          = std::ranges::sentinel_t<urng_t>;
-    //!\brief Value type.
-    using value_type        = typename iterator::value_type;
-    //!\brief Always returns immutable reference type, since single_pass_input cannot change the underlying values.
-    using reference         = typename iterator::reference;
-    //!\brief The const_reference type is `void`, as iterating over this view as `const` is explicitly forbidden.
-    using const_reference   = void;
+    using sentinel = std::ranges::sentinel_t<urng_t>;
     //\}
 
+public:
     /*!\name Constructor, destructor, and assignment.
      * \{
      * \brief All standard functions are explicitly defaulted.
@@ -123,14 +115,14 @@ public:
      */
     iterator begin()
     {
-        return iterator{*this};
+        return {*this};
     }
 
     //!\brief Const version of begin is deleted, since the underlying view_state must be mutable.
-    const_iterator begin() const = delete;
+    iterator begin() const = delete;
 
     //!\copydoc single_pass_input_view::begin() const
-    const_iterator cbegin() const = delete;
+    iterator cbegin() const = delete;
 
     //!\brief Returns a sentinel.
     sentinel end()
@@ -177,7 +169,7 @@ class single_pass_input_iterator<single_pass_input_view<view_type>>
     //!\brief The pointer to the associated view.
     using base_iterator_type = typename single_pass_input_view<view_type>::urng_iterator_type;
     //!\brief The sentinel type to compare to.
-    using sentinel_type      = typename single_pass_input_view<view_type>::sentinel;
+    using sentinel_type = typename single_pass_input_view<view_type>::sentinel;
 
     //!\brief The pointer to the associated view.
     single_pass_input_view<view_type> * view_ptr{};
@@ -195,13 +187,13 @@ public:
      * \{
      */
     //!\brief Difference type.
-    using difference_type   = std::iter_difference_t<base_iterator_type>;
+    using difference_type = std::iter_difference_t<base_iterator_type>;
     //!\brief Value type.
-    using value_type        = std::iter_value_t<base_iterator_type>;
+    using value_type = std::iter_value_t<base_iterator_type>;
     //!\brief Pointer type.
-    using pointer           = typename std::iterator_traits<base_iterator_type>::pointer;
+    using pointer = typename std::iterator_traits<base_iterator_type>::pointer;
     //!\brief Reference type.
-    using reference         = std::iter_reference_t<base_iterator_type>;
+    using reference = std::iter_reference_t<base_iterator_type>;
     //!\brief Iterator category.
     using iterator_category = std::input_iterator_tag;
     //!\}
@@ -284,8 +276,7 @@ public:
 
     //!\copydoc operator==
     friend constexpr bool
-    operator==(sentinel_type const & s,
-               single_pass_input_iterator<single_pass_input_view<view_type>> const & rhs) noexcept
+    operator==(sentinel_type const & s, single_pass_input_iterator const & rhs) noexcept
     {
         return rhs == s;
     }
@@ -298,8 +289,7 @@ public:
 
     //!\copydoc operator!=
     friend constexpr bool
-    operator!=(sentinel_type const & s,
-               single_pass_input_iterator<single_pass_input_view<view_type>> const & rhs) noexcept
+    operator!=(sentinel_type const & s, single_pass_input_iterator const & rhs) noexcept
     {
         return rhs != s;
     }

--- a/include/seqan3/range/views/take.hpp
+++ b/include/seqan3/range/views/take.hpp
@@ -114,15 +114,15 @@ private:
          */
 
         //!\brief The difference type.
-        using difference_type       = typename std::iterator_traits<base_base_t>::difference_type;
+        using difference_type = std::iter_difference_t<base_base_t>;
         //!\brief The value type.
-        using value_type            = typename std::iterator_traits<base_base_t>::value_type;
+        using value_type = std::iter_value_t<base_base_t>;
         //!\brief The reference type.
-        using reference             = typename std::iterator_traits<base_base_t>::reference;
+        using reference = std::iter_reference_t<base_base_t>;
         //!\brief The pointer type.
-        using pointer               = typename std::iterator_traits<base_base_t>::pointer;
+        using pointer = detail::iter_pointer_t<base_base_t>;
         //!\brief The iterator category tag.
-        using iterator_category     = iterator_tag_t<base_base_t>;
+        using iterator_category = iterator_tag_t<base_base_t>;
         //!\}
 
         /*!\name Arithmetic operators

--- a/include/seqan3/range/views/take_until.hpp
+++ b/include/seqan3/range/views/take_until.hpp
@@ -256,13 +256,13 @@ public:
      */
 
     //!\brief The difference type.
-    using difference_type = typename std::iterator_traits<base_base_t>::difference_type;
+    using difference_type = std::iter_difference_t<base_base_t>;
     //!\brief The value type.
-    using value_type = typename std::iterator_traits<base_base_t>::value_type;
+    using value_type = std::iter_value_t<base_base_t>;
     //!\brief The reference type.
-    using reference = typename std::iterator_traits<base_base_t>::reference;
+    using reference = std::iter_reference_t<base_base_t>;
     //!\brief The pointer type.
-    using pointer = typename std::iterator_traits<base_base_t>::pointer;
+    using pointer = detail::iter_pointer_t<base_base_t>;
     //!\brief The iterator category tag.
     using iterator_category = iterator_tag_t<base_base_t>;
     //!\}
@@ -336,10 +336,10 @@ public:
      * \brief All are derived from the base_base_t.
      * \{
      */
-    using difference_type = typename std::iterator_traits<base_base_t>::difference_type; //!< From base.
-    using value_type = typename std::iterator_traits<base_base_t>::value_type; //!< From base.
-    using reference = typename std::iterator_traits<base_base_t>::reference; //!< From base.
-    using pointer = typename std::iterator_traits<base_base_t>::pointer; //!< From base.
+    using difference_type = std::iter_difference_t<base_base_t>; //!< From base.
+    using value_type = std::iter_value_t<base_base_t>; //!< From base.
+    using reference = std::iter_reference_t<base_base_t>; //!< From base.
+    using pointer = detail::iter_pointer_t<base_base_t>; //!< From base.
     using iterator_category = std::input_iterator_tag; //!< Always input.
     //!\}
 

--- a/test/unit/alphabet/custom_alphabet3_test.cpp
+++ b/test/unit/alphabet/custom_alphabet3_test.cpp
@@ -16,7 +16,7 @@
 
 //![third_party_type]
 #include <cstddef>                      // for size_t
-#include <seqan3/alphabet/concept.hpp>  // for seqan3::Alphabet
+#include <seqan3/alphabet/concept.hpp>  // for seqan3::alphabet
 
 // this is from some other library:
 namespace third_party_ns


### PR DESCRIPTION
Similar to `std::iter_value_t` we need a `seqan3::detail::iter_pointer` type trait to get the pointer-type of an iterator.

The problem that `std::iterator_traits` will not be defined for some `std::*iterator`'s, because it is only defined (automatically) for legacy input iterators. This means the most generic way to access the value-type of an iterator is `std::iter_value_t`, because `std::iterator_traits::value_type` might not be defined for it.

Normally (C++20) views don't define `pointer`, because it is a thing of the past, but as long as we support older gcc versions we need a universal way to access the pointer type.