### PR TITLE
[FIX] cxx20: std::ranges::copy does not work on any range

### DIFF
--- a/include/seqan3/core/platform.hpp
+++ b/include/seqan3/core/platform.hpp
@@ -239,6 +239,15 @@
 #   endif
 #endif
 
+//!\brief https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95578
+#ifndef SEQAN3_WORKAROUND_GCC_95578 // regressed in gcc10, fixed for gcc10.2
+#   if defined(__GNUC__) && (__GNUC__ == 10 && __GNUC_MINOR__ < 2)
+#       define SEQAN3_WORKAROUND_GCC_95578 1
+#   else
+#       define SEQAN3_WORKAROUND_GCC_95578 0
+#   endif
+#endif
+
 //!\brief Various concept problems only present in GCC7 and GCC8.
 #ifndef SEQAN3_WORKAROUND_GCC7_AND_8_CONCEPT_ISSUES
 #   if defined(__GNUC__) && ((__GNUC__ == 7) || (__GNUC__ == 8))

--- a/test/include/seqan3/test/expect_range_eq.hpp
+++ b/test/include/seqan3/test/expect_range_eq.hpp
@@ -33,7 +33,12 @@ struct expect_range_eq
     {
         using value_t = std::ranges::range_value_t<rng_t>;
         std::vector<value_t> rng_copy{};
+#if SEQAN3_WORKAROUND_GCC_95578
+        for (auto && v : rng)
+            rng_copy.push_back(std::move(v));
+#else // ^^^ workaround / no workaround vvv
         std::ranges::copy(rng, std::cpp20::back_inserter(rng_copy));
+#endif // SEQAN3_WORKAROUND_GCC_95578
         return rng_copy;
     }
 

--- a/test/unit/std/CMakeLists.txt
+++ b/test/unit/std/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectories()
 
+seqan3_test(algorithm_test.cpp)
 seqan3_test(charconv_int_test.cpp)
 seqan3_test(charconv_float_test.cpp)
 seqan3_test(ranges_test.cpp)

--- a/test/unit/std/algorithm_test.cpp
+++ b/test/unit/std/algorithm_test.cpp
@@ -1,0 +1,27 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <seqan3/std/algorithm>
+#include <seqan3/std/iterator>
+#include <seqan3/std/ranges>
+#include <vector>
+
+#include <seqan3/core/platform.hpp>
+
+#if !SEQAN3_WORKAROUND_GCC_95578
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95578
+TEST(algorithm_test, gcc95578)
+{
+    std::vector<int> v{};
+    auto && rng = v | std::views::take_while([](auto &&){return true;});
+
+    std::vector<int> rng_copy{};
+    std::ranges::copy(rng, std::cpp20::back_inserter(rng_copy));
+}
+#endif // !SEQAN3_WORKAROUND_GCC_95578


### PR DESCRIPTION
This is a gcc10.1 regression and is fixed for gcc10.2.

See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95578