### PR TITLE
[FIX] use std::ranges::view_base instead of ranges one

### DIFF
--- a/include/seqan3/range/views/translate.hpp
+++ b/include/seqan3/range/views/translate.hpp
@@ -154,7 +154,7 @@ template <std::ranges::view urng_t>
              std::ranges::random_access_range<urng_t> &&
              nucleotide_alphabet<std::ranges::range_reference_t<urng_t>>
 //!\endcond
-class view_translate_single : public ranges::view_base
+class view_translate_single : public std::ranges::view_base
 {
 private:
     //!\brief The input range (of ranges).
@@ -526,7 +526,7 @@ template <std::ranges::view urng_t>
              std::ranges::random_access_range<urng_t> &&
              nucleotide_alphabet<std::ranges::range_reference_t<urng_t>>
 //!\endcond
-class view_translate : public ranges::view_base
+class view_translate : public std::ranges::view_base
 {
 private:
     //!\brief The data members of view_translate_single.

--- a/include/seqan3/range/views/translate_join.hpp
+++ b/include/seqan3/range/views/translate_join.hpp
@@ -38,7 +38,7 @@ namespace seqan3::detail
  * \ingroup views
  */
 template <std::ranges::view urng_t>
-class view_translate_join : public ranges::view_base
+class view_translate_join : public std::ranges::view_base
 {
 private:
     //!\brief The data members of view_translate_join.

--- a/include/seqan3/std/ranges
+++ b/include/seqan3/std/ranges
@@ -124,7 +124,7 @@ using ::ranges::cpp20::sized_range;
 
 // [range.view], views
 using ::ranges::cpp20::enable_view;
-// using ::ranges::cpp20::view_base;
+using ::ranges::view_base;
 using ::ranges::cpp20::view;
 
 // [range.refinements], other range refinements


### PR DESCRIPTION
Part of https://github.com/seqan/product_backlog/issues/124