### PR TITLE
Optimise alignment/part 4 result builder

### DIFF
--- a/include/seqan3/alignment/pairwise/alignment_configurator.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_configurator.hpp
@@ -22,6 +22,7 @@
 #include <seqan3/alignment/matrix/detail/alignment_score_matrix_one_column_banded.hpp>
 #include <seqan3/alignment/matrix/detail/alignment_trace_matrix_full.hpp>
 #include <seqan3/alignment/matrix/detail/alignment_trace_matrix_full_banded.hpp>
+#include <seqan3/alignment/pairwise/detail/policy_alignment_result_builder.hpp>
 #include <seqan3/alignment/pairwise/detail/policy_affine_gap_recursion.hpp>
 #include <seqan3/alignment/pairwise/detail/policy_optimum_tracker.hpp>
 #include <seqan3/alignment/pairwise/policy/affine_gap_policy.hpp>
@@ -513,8 +514,12 @@ private:
         {
             using optimum_tracker_policy_t = policy_optimum_tracker<config_t>;
             using gap_cost_policy_t = policy_affine_gap_recursion<config_t>;
+            using result_builder_policy_t = policy_alignment_result_builder<config_t>;
 
-            return pairwise_alignment_algorithm<config_t, gap_cost_policy_t, optimum_tracker_policy_t>{cfg};
+            return pairwise_alignment_algorithm<config_t,
+                                                gap_cost_policy_t,
+                                                optimum_tracker_policy_t,
+                                                result_builder_policy_t>{cfg};
         }
     }
 };

--- a/include/seqan3/alignment/pairwise/alignment_result.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_result.hpp
@@ -15,10 +15,20 @@
 
 #include <optional>
 
+#include <seqan3/core/algorithm/configuration.hpp>
 #include <seqan3/core/type_traits/template_inspection.hpp>
 
 namespace seqan3::detail
 {
+
+// forward declaration for friend declaraion in alignment_result.
+template <typename>
+#if !SEQAN3_WORKAROUND_GCC_93467
+//!\cond
+    requires is_type_specialisation_of_v<configuration_t, configuration>
+//!\endcond
+#endif // !SEQAN3_WORKAROUND_GCC_93467
+class policy_alignment_result_builder;
 
 /*!\brief A struct that contains the actual alignment result data.
  * \ingroup pairwise_alignment
@@ -114,6 +124,8 @@ namespace seqan3
  * \if DEV
  * To access the type of the passed alignment result value use the seqan3::detail::alignment_result_value_type_accessor
  * transformation trait.
+ * The seqan3::detail::policy_alignment_result_builder is used to set the respective
+ * values. This class is befriended with this class to allow access to the private data member.
  * \endif
  */
 template <typename alignment_result_value_t>
@@ -131,16 +143,25 @@ private:
      * \{
      */
     //! \brief The type for the alignment identifier.
-    using id_t          = decltype(data.id);
+    using id_t = decltype(data.id);
     //! \brief The type for the resulting score.
-    using score_t       = decltype(data.score);
+    using score_t = decltype(data.score);
     //! \brief The type for the back coordinate.
-    using back_coord_t   = decltype(data.back_coordinate);
+    using back_coord_t = decltype(data.back_coordinate);
     //! \brief The type for the front coordinate.
     using front_coord_t = decltype(data.front_coordinate);
     //! \brief The type for the alignment.
-    using alignment_t   = decltype(data.alignment);
+    using alignment_t = decltype(data.alignment);
     //!\}
+
+    //!\brief Befriend alignment result builder.
+    template <typename configuration_t>
+    #if !SEQAN3_WORKAROUND_GCC_93467
+    //!\cond
+        requires is_type_specialisation_of_v<configuration_t, configuration>
+    //!\endcond
+    #endif // !SEQAN3_WORKAROUND_GCC_93467
+    friend class detail::policy_alignment_result_builder;
 
 public:
     /*!\name Constructors, destructor and assignment

--- a/include/seqan3/alignment/pairwise/detail/policy_alignment_result_builder.hpp
+++ b/include/seqan3/alignment/pairwise/detail/policy_alignment_result_builder.hpp
@@ -1,0 +1,116 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides seqan3::detail::policy_alignment_result_builder.
+ * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <seqan3/alignment/pairwise/detail/type_traits.hpp>
+#include <seqan3/core/algorithm/configuration.hpp>
+#include <seqan3/core/detail/empty_type.hpp>
+#include <seqan3/core/type_traits/template_inspection.hpp>
+
+namespace seqan3::detail
+{
+
+/*!\brief Implements the alignment result builder.
+ * \ingroup pairwise_alignment
+ *
+ * \tparam alignment_configuration_t The type of the alignment configuration; must be a type specialisation of
+ *                                   seqan3::configuration.
+ *
+ * \details
+ *
+ * Implements the interfaces to build the alignment result based on the previously selected output configurations.
+ */
+template <typename alignment_configuration_t>
+#if !SEQAN3_WORKAROUND_GCC_93467
+//!\cond
+    requires is_type_specialisation_of_v<alignment_configuration_t, configuration>
+//!\endcond
+#endif // !SEQAN3_WORKAROUND_GCC_93467
+class policy_alignment_result_builder
+{
+protected:
+    //!\brief The configuration traits type.
+    using traits_type = alignment_configuration_traits<alignment_configuration_t>;
+    //!\brief The alignment result type.
+    using result_type = typename traits_type::alignment_result_type;
+
+    static_assert(!std::same_as<result_type, empty_type>, "The alignment result type was not configured.");
+
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    policy_alignment_result_builder() = default; //!< Defaulted.
+    policy_alignment_result_builder(policy_alignment_result_builder const &) = default; //!< Defaulted.
+    policy_alignment_result_builder(policy_alignment_result_builder &&) = default; //!< Defaulted.
+    policy_alignment_result_builder & operator=(policy_alignment_result_builder const &) = default; //!< Defaulted.
+    policy_alignment_result_builder & operator=(policy_alignment_result_builder &&) = default; //!< Defaulted.
+    ~policy_alignment_result_builder() = default; //!< Defaulted.
+
+    /*!\brief Construction and initialisation using the alignment configuration.
+     * \param[in] config The alignment configuration [not used in this context].
+     */
+    policy_alignment_result_builder(alignment_configuration_t const & SEQAN3_DOXYGEN_ONLY(config))
+    {}
+    //!\}
+
+    /*!\brief Builds the seqan3::alignment_result based on the given alignment result type and then invokes the
+     *        given callable with the result.
+     *
+     * \tparam sequence_pair_t The type of the sequence pair.
+     * \tparam id_t The type of the id.
+     * \tparam score_t The type of the score.
+     * \tparam callback_t The type of the callback to invoke.
+     *
+     * \param[in] sequence_pair The indexed sequence pair.
+     * \param[in] id The associated id.
+     * \param[in] score The best alignment score.
+     * \param[in] callback The callback to invoke with the generated result.
+     *
+     * \details
+     *
+     * Generates a seqan3::alignment_result object with the results computed during the alignment. Depending on the
+     * seqan3::align_cfg::result configuration only the requested values are stored. In some cases some additional
+     * work is done to generate the requested result. For example computing the associated alignment from the traceback
+     * matrix.
+     */
+    template <typename sequence_pair_t, typename index_t, typename score_t, typename callback_t>
+    //!\cond
+        requires std::invocable<callback_t, result_type>
+    //!\endcond
+    void make_result_and_invoke([[maybe_unused]] sequence_pair_t && sequence_pair,
+                                [[maybe_unused]] index_t && id,
+                                [[maybe_unused]] score_t score,
+                                callback_t && callback)
+    {
+        using std::get;
+        using invalid_t = std::nullopt_t *;
+
+        result_type result{};
+
+        static_assert(!std::same_as<decltype(result.data.id), invalid_t>,
+                      "Invalid configuration. Expected result with id!");
+        result.data.id = std::move(id);
+
+        if constexpr (traits_type::compute_score)
+        {
+            static_assert(!std::same_as<decltype(result.data.score), invalid_t>,
+                          "Invalid configuration. Expected result with score!");
+            result.data.score = std::move(score);
+        }
+
+       // TODO: Add other result.data like sequence1_begin_position, sequence1_end_position, and so on.
+
+        callback(std::move(result));
+    }
+};
+} // namespace seqan3::detail


### PR DESCRIPTION
Adds result builder policy to new alignment result implementation.
This will replace the result value mechanism as we used it before in the future.

part of seqan/product_backlog#74