### PR TITLE
[INFRA] modularise cmake scripts

### DIFF
--- a/test/cmake/add_subdirectories.cmake
+++ b/test/cmake/add_subdirectories.cmake
@@ -1,0 +1,39 @@
+# -----------------------------------------------------------------------------------------------------
+# Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+# Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+# This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+# shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+# -----------------------------------------------------------------------------------------------------
+
+# Calls add_subdirectory on all (direct) subdirectories of the given directory if they contain a `CMakeLists.txt`
+#
+# Example:
+# If we have
+# * /some/path/directory/subdir1/CMakeLists.txt
+# * /some/path/directory/subdir2/CMakeLists.txt
+# * /some/path/directory/subdir3/CMakeLists.txt
+# * /some/path/directory/subdir4/has-no-CMakeLists.txt
+#
+# This macro calls
+# * `add_subdirectory ("/some/path/directory/subdir1")`,
+# * `add_subdirectory ("/some/path/directory/subdir2")`, and
+# * `add_subdirectory ("/some/path/directory/subdir3")`,
+# but not `add_subdirectory ("/some/path/directory/subdir4")`, because it does not contain a CMakeLists.txt
+macro (add_subdirectories_of directory)
+    file (GLOB ENTRIES
+          RELATIVE ${directory}
+          ${directory}/[!.]*)
+
+    foreach (ENTRY ${ENTRIES})
+        if (IS_DIRECTORY ${directory}/${ENTRY})
+            if (EXISTS ${directory}/${ENTRY}/CMakeLists.txt)
+                add_subdirectory (${directory}/${ENTRY} ${CMAKE_CURRENT_BINARY_DIR}/${ENTRY})
+            endif ()
+        endif ()
+    endforeach ()
+    unset (ENTRIES)
+endmacro ()
+
+macro (add_subdirectories)
+    add_subdirectories_of(${CMAKE_CURRENT_SOURCE_DIR})
+endmacro ()

--- a/test/cmake/seqan3_require_benchmark.cmake
+++ b/test/cmake/seqan3_require_benchmark.cmake
@@ -1,0 +1,50 @@
+# -----------------------------------------------------------------------------------------------------
+# Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+# Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+# This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+# shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+# -----------------------------------------------------------------------------------------------------
+
+# Exposes the google-benchmark target `gbenchmark`.
+macro (seqan3_require_benchmark)
+    enable_testing ()
+
+    set (gbenchmark_project_args ${SEQAN3_EXTERNAL_PROJECT_CMAKE_ARGS})
+    list (APPEND gbenchmark_project_args "-DBENCHMARK_ENABLE_TESTING=false")
+    # google-benchmarks suggest to use LTO (link-time optimisation), but we don't really need that because we are a
+    # header only library. This option might be still interesting for external libraries benchmarks.
+    # see https://github.com/google/benchmark#debug-vs-release
+    # list (APPEND gbenchmark_project_args "-DBENCHMARK_ENABLE_LTO=true")
+
+    # force that libraries are installed to `lib/`, because GNUInstallDirs might install it into `lib64/`
+    list (APPEND gbenchmark_project_args "-DCMAKE_INSTALL_LIBDIR=${PROJECT_BINARY_DIR}/lib/")
+
+    set (gbenchmark_path "${PROJECT_BINARY_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}benchmark${CMAKE_STATIC_LIBRARY_SUFFIX}")
+
+    include (ExternalProject)
+    ExternalProject_Add (
+        gbenchmark_project
+        PREFIX gbenchmark_project
+        GIT_REPOSITORY "https://github.com/google/benchmark.git"
+        GIT_TAG "v1.5.0"
+        SOURCE_DIR "${SEQAN3_BENCHMARK_CLONE_DIR}"
+        CMAKE_ARGS "${gbenchmark_project_args}"
+        BUILD_BYPRODUCTS "${gbenchmark_path}"
+        UPDATE_DISCONNECTED ${SEQAN3_TEST_BUILD_OFFLINE}
+    )
+    unset (gbenchmark_project_args)
+
+    add_library (gbenchmark STATIC IMPORTED)
+    add_dependencies (gbenchmark gbenchmark_project)
+    set_target_properties (gbenchmark PROPERTIES IMPORTED_LOCATION "${gbenchmark_path}")
+    set_property (TARGET gbenchmark APPEND PROPERTY INTERFACE_LINK_LIBRARIES "pthread")
+
+    # NOTE: google benchmarks needs Shlwapi (Shell Lightweight Utility Functions) on windows
+    # see https://msdn.microsoft.com/en-us/library/windows/desktop/bb759844(v=vs.85).aspx
+    # see https://github.com/google/benchmark/blob/c614dfc0d4eadcd19b188ff9c7e226c138f894a1/README.md#platform-specific-libraries
+    if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+        target_link_libraries (gbenchmark INTERFACE "Shlwapi")
+    endif()
+
+    unset (gbenchmark_path)
+endmacro ()

--- a/test/cmake/seqan3_require_ccache.cmake
+++ b/test/cmake/seqan3_require_ccache.cmake
@@ -1,0 +1,34 @@
+# -----------------------------------------------------------------------------------------------------
+# Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+# Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+# This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+# shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+# -----------------------------------------------------------------------------------------------------
+
+# Uses `ccache` to cache build results.
+#
+# See also
+# * https://ccache.dev/
+# * https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER_LAUNCHER.html
+macro (seqan3_require_ccache)
+    find_program (CCACHE_PROGRAM ccache)
+    find_package_message (CCACHE_PROGRAM_PRE "Finding program ccache" "[${CCACHE_PROGRAM}]")
+
+    if (NOT CCACHE_PROGRAM)
+        find_package_message (CCACHE_PROGRAM "Finding program ccache - Failed" "[${CCACHE_PROGRAM}]")
+    else ()
+        find_package_message (CCACHE_PROGRAM "Finding program ccache - Success" "[${CCACHE_PROGRAM}]")
+        # New option since cmake >= 3.4:
+        # https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER_LAUNCHER.html
+        if (NOT CMAKE_VERSION VERSION_LESS 3.15) # cmake >= 3.15
+            list (PREPEND CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+        else ()
+            # prepend ccache to CMAKE_CXX_COMPILER_LAUNCHER
+            list (INSERT CMAKE_CXX_COMPILER_LAUNCHER 0 "${CCACHE_PROGRAM}")
+        endif ()
+
+        # use ccache in external cmake projects
+        list (APPEND SEQAN3_EXTERNAL_PROJECT_CMAKE_ARGS "-DCMAKE_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER}")
+    endif ()
+    unset (CCACHE_PROGRAM)
+endmacro ()

--- a/test/cmake/seqan3_require_test.cmake
+++ b/test/cmake/seqan3_require_test.cmake
@@ -1,0 +1,56 @@
+# -----------------------------------------------------------------------------------------------------
+# Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+# Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+# This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+# shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+# -----------------------------------------------------------------------------------------------------
+
+# Exposes the google-test targets `gtest` and `gtest_main`.
+macro (seqan3_require_test)
+    enable_testing ()
+
+    set (gtest_project_args ${SEQAN3_EXTERNAL_PROJECT_CMAKE_ARGS})
+    list (APPEND gtest_project_args "-DBUILD_GMOCK=0")
+
+    # force that libraries are installed to `lib/`, because GNUInstallDirs might install it into `lib64/`
+    list (APPEND gtest_project_args "-DCMAKE_INSTALL_LIBDIR=${PROJECT_BINARY_DIR}/lib/")
+
+    # google sets CMAKE_DEBUG_POSTFIX = "d"
+    set (gtest_main_path "${PROJECT_BINARY_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}gtest_main${CMAKE_STATIC_LIBRARY_SUFFIX}")
+    if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+        set (gtest_main_path "${PROJECT_BINARY_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}gtest_maind${CMAKE_STATIC_LIBRARY_SUFFIX}")
+    endif ()
+
+    set (gtest_path "${PROJECT_BINARY_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}gtest${CMAKE_STATIC_LIBRARY_SUFFIX}")
+    if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+        set (gtest_path "${PROJECT_BINARY_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}gtestd${CMAKE_STATIC_LIBRARY_SUFFIX}")
+    endif ()
+
+    include (ExternalProject)
+    ExternalProject_Add (
+        gtest_project
+        PREFIX gtest_project
+        GIT_REPOSITORY "https://github.com/google/googletest.git"
+        # we currently have warnings that were introduced in
+        # 03867b5389516a0f185af52672cf5472fa0c159c, which are still available
+        # in "release-1.8.1", see https://github.com/google/googletest/issues/1419
+        GIT_TAG "release-1.10.0"
+        SOURCE_DIR "${SEQAN3_TEST_CLONE_DIR}"
+        CMAKE_ARGS "${gtest_project_args}"
+        BUILD_BYPRODUCTS "${gtest_main_path}" "${gtest_path}"
+        UPDATE_DISCONNECTED ${SEQAN3_TEST_BUILD_OFFLINE}
+    )
+    unset (gtest_project_args)
+
+    add_library (gtest_main STATIC IMPORTED)
+    add_dependencies (gtest_main gtest_project)
+    set_target_properties (gtest_main PROPERTIES IMPORTED_LOCATION "${gtest_main_path}")
+
+    add_library (gtest STATIC IMPORTED)
+    add_dependencies (gtest gtest_main)
+    set_target_properties (gtest PROPERTIES IMPORTED_LOCATION "${gtest_path}")
+    set_property (TARGET gtest APPEND PROPERTY INTERFACE_LINK_LIBRARIES "pthread")
+
+    unset(gtest_main_path)
+    unset(gtest_path)
+endmacro ()

--- a/test/cmake/seqan3_test_component.cmake
+++ b/test/cmake/seqan3_test_component.cmake
@@ -1,0 +1,39 @@
+# -----------------------------------------------------------------------------------------------------
+# Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+# Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+# This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+# shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+# -----------------------------------------------------------------------------------------------------
+
+# Get a specific component of a test file which follows the seqan3 naming scheme.
+# e.g. target_source_file = "range/views/take.cpp"
+# component:
+#  * TARGET_NAME - the target name (e.g. "take")
+#  * TARGET_UNIQUE_NAME - the target name which includes the target_path (e.g. range-view-take)
+#  * TEST_NAME - the test name which includes the target_path (e.g. "range/views/take")
+#  * TARGET_PATH - the path to the target source (e.g. "range/view")
+macro (seqan3_test_component VAR target_source_file component_name_)
+    string (TOUPPER "${component_name_}" component_name)
+
+    get_filename_component (target_relative_path "${target_source_file}" DIRECTORY)
+    get_filename_component (target_name "${target_source_file}" NAME_WE)
+
+    if (component_name STREQUAL "TARGET_NAME")
+        set (${VAR} "${target_name}")
+    elseif (component_name MATCHES "TEST_NAME|TARGET_UNIQUE_NAME")
+        if (target_relative_path)
+            set (${VAR} "${target_relative_path}/${target_name}")
+        else ()
+            set (${VAR} "${target_name}")
+        endif ()
+
+        if (component_name STREQUAL "TARGET_UNIQUE_NAME")
+            string (REPLACE "/" "-" ${VAR} "${${VAR}}")
+        endif ()
+    elseif (component_name STREQUAL "TARGET_PATH")
+        set (${VAR} "${target_relative_path}")
+    endif ()
+
+    unset (target_name)
+    unset (target_relative_path)
+endmacro ()

--- a/test/cmake/seqan3_test_files.cmake
+++ b/test/cmake/seqan3_test_files.cmake
@@ -1,0 +1,37 @@
+# -----------------------------------------------------------------------------------------------------
+# Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+# Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+# This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+# shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+# -----------------------------------------------------------------------------------------------------
+
+# Finds all files relative to the `test_base_path_` which satisfy the given file pattern.
+#
+# Example:
+# seqan3_test_files (header_files "/seqan3/include" "*.hpp;*.h")
+#
+# The variable `header_files` will contain:
+#   seqan3/alphabet/adaptation/all.hpp
+#   seqan3/alphabet/adaptation/char.hpp
+#   seqan3/alphabet/adaptation/concept.hpp
+#   seqan3/alphabet/adaptation/uint.hpp
+#   seqan3/alphabet/all.hpp
+#   seqan3/alphabet/dna5_detail.hpp
+#   ....
+macro (seqan3_test_files VAR test_base_path_ extension_wildcards)
+    # test_base_path is /home/.../seqan3/test/
+    get_filename_component(test_base_path "${test_base_path_}" ABSOLUTE)
+    file (RELATIVE_PATH test_base_path_relative "${CMAKE_SOURCE_DIR}" "${test_base_path}")
+    # ./ is a hack to deal with empty test_base_path_relative
+    set (test_base_path_relative "./${test_base_path_relative}")
+    # collect all cpp files
+    set (${VAR} "")
+    foreach (extension_wildcard ${extension_wildcards})
+        file (GLOB_RECURSE test_files RELATIVE "${test_base_path}"
+        "${test_base_path_relative}/${extension_wildcard}")
+        list (APPEND ${VAR} ${test_files})
+    endforeach ()
+
+    unset (test_base_path)
+    unset (test_base_path_relative)
+endmacro ()

--- a/test/performance/CMakeLists.txt
+++ b/test/performance/CMakeLists.txt
@@ -15,16 +15,8 @@ macro (seqan3_benchmark benchmark_cpp)
     seqan3_test_component (target "${benchmark}" TARGET_NAME)
     seqan3_test_component (test_name "${benchmark}" TEST_NAME)
 
-    # Force alignment of benchmarked loops so that numbers are reliable.
-    # For large loops and erratic seeming bench results the value might
-    # have to be adapted or the option deactivated.
-    option (BENCHMARK_ALIGN_LOOPS "Pass -falign-loops=32 to the benchmark builds." ON)
-
     add_executable (${target} ${benchmark_cpp})
     target_link_libraries (${target} seqan3::test::performance)
-    if (BENCHMARK_ALIGN_LOOPS)
-        target_compile_options (${target} PUBLIC "-falign-loops=32")
-    endif ()
     add_test (NAME "${test_name}" COMMAND ${target})
 
     unset (benchmark)

--- a/test/seqan3-test.cmake
+++ b/test/seqan3-test.cmake
@@ -21,6 +21,11 @@ include (FindPackageMessage)
 
 option (SEQAN3_TEST_BUILD_OFFLINE "Skip the update step of external projects." OFF)
 
+# Force alignment of benchmarked loops so that numbers are reliable.
+# For large loops and erratic seeming bench results the value might
+# have to be adapted or the option deactivated.
+option (SEQAN3_BENCHMARK_ALIGN_LOOPS "Pass -falign-loops=32 to the benchmark builds." ON)
+
 # ----------------------------------------------------------------------------
 # Paths to folders.
 # ----------------------------------------------------------------------------
@@ -53,6 +58,10 @@ add_library (seqan3::test ALIAS seqan3_test)
 # needed for performance test cases in seqan3/test/performance
 add_library (seqan3_test_performance INTERFACE)
 target_link_libraries (seqan3_test_performance INTERFACE "seqan3::test" "gbenchmark")
+
+if (SEQAN3_BENCHMARK_ALIGN_LOOPS)
+    target_compile_options (seqan3_test_performance INTERFACE "-falign-loops=32")
+endif ()
 
 target_include_directories (seqan3_test_performance INTERFACE "${SEQAN3_BENCHMARK_CLONE_DIR}/include/")
 add_library (seqan3::test::performance ALIAS seqan3_test_performance)

--- a/test/seqan3-test.cmake
+++ b/test/seqan3-test.cmake
@@ -26,6 +26,8 @@ option (SEQAN3_TEST_BUILD_OFFLINE "Skip the update step of external projects." O
 # ----------------------------------------------------------------------------
 
 find_path (SEQAN3_TEST_INCLUDE_DIR NAMES seqan3/test/tmp_filename.hpp HINTS "${CMAKE_CURRENT_LIST_DIR}/include/")
+find_path (SEQAN3_TEST_CMAKE_MODULE_DIR NAMES seqan3_test_component.cmake HINTS "${CMAKE_CURRENT_LIST_DIR}/cmake/")
+list(APPEND CMAKE_MODULE_PATH "${SEQAN3_TEST_CMAKE_MODULE_DIR}")
 
 set (SEQAN3_BENCHMARK_CLONE_DIR "${PROJECT_BINARY_DIR}/vendor/benchmark")
 set (SEQAN3_TEST_CLONE_DIR "${PROJECT_BINARY_DIR}/vendor/googletest")
@@ -51,13 +53,6 @@ add_library (seqan3::test ALIAS seqan3_test)
 # needed for performance test cases in seqan3/test/performance
 add_library (seqan3_test_performance INTERFACE)
 target_link_libraries (seqan3_test_performance INTERFACE "seqan3::test" "gbenchmark")
-
-# NOTE: google benchmarks needs Shlwapi (Shell Lightweight Utility Functions) on windows
-# see https://msdn.microsoft.com/en-us/library/windows/desktop/bb759844(v=vs.85).aspx
-# see https://github.com/google/benchmark/blob/c614dfc0d4eadcd19b188ff9c7e226c138f894a1/README.md#platform-specific-libraries
-if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-    target_link_libraries (seqan3_test_performance INTERFACE "Shlwapi")
-endif()
 
 target_include_directories (seqan3_test_performance INTERFACE "${SEQAN3_BENCHMARK_CLONE_DIR}/include/")
 add_library (seqan3::test::performance ALIAS seqan3_test_performance)
@@ -97,177 +92,9 @@ list (APPEND SEQAN3_EXTERNAL_PROJECT_CMAKE_ARGS "-DCMAKE_VERBOSE_MAKEFILE=${CMAK
 # Commonly used macros for the different test modules in seqan3.
 # ----------------------------------------------------------------------------
 
-# Get a specific component of a test file which follows the seqan3 naming scheme.
-# e.g. target_source_file = "range/views/take.cpp"
-# component:
-#  * TARGET_NAME - the target name (e.g. "take")
-#  * TARGET_UNIQUE_NAME - the target name which includes the target_path (e.g. range-view-take)
-#  * TEST_NAME - the test name which includes the target_path (e.g. "range/views/take")
-#  * TARGET_PATH - the path to the target source (e.g. "range/view")
-macro (seqan3_test_component VAR target_source_file component_name_)
-    string (TOUPPER "${component_name_}" component_name)
-
-    get_filename_component (target_relative_path "${target_source_file}" DIRECTORY)
-    get_filename_component (target_name "${target_source_file}" NAME_WE)
-
-    if (component_name STREQUAL "TARGET_NAME")
-        set (${VAR} "${target_name}")
-    elseif (component_name MATCHES "TEST_NAME|TARGET_UNIQUE_NAME")
-        if (target_relative_path)
-            set (${VAR} "${target_relative_path}/${target_name}")
-        else ()
-            set (${VAR} "${target_name}")
-        endif ()
-
-        if (component_name STREQUAL "TARGET_UNIQUE_NAME")
-            string (REPLACE "/" "-" ${VAR} "${${VAR}}")
-        endif ()
-    elseif (component_name STREQUAL "TARGET_PATH")
-        set (${VAR} "${target_relative_path}")
-    endif ()
-
-    unset (target_name)
-    unset (target_relative_path)
-endmacro ()
-
-macro (seqan3_test_files VAR test_base_path_ extension_wildcards)
-    # test_base_path is /home/.../seqan3/test/
-    get_filename_component(test_base_path "${test_base_path_}" ABSOLUTE)
-    file (RELATIVE_PATH test_base_path_relative "${CMAKE_SOURCE_DIR}" "${test_base_path}")
-    # ./ is a hack to deal with empty test_base_path_relative
-    set (test_base_path_relative "./${test_base_path_relative}")
-    # collect all cpp files
-    set (${VAR} "")
-    foreach (extension_wildcard ${extension_wildcards})
-        file (GLOB_RECURSE test_files RELATIVE "${test_base_path}"
-        "${test_base_path_relative}/${extension_wildcard}")
-        list (APPEND ${VAR} ${test_files})
-    endforeach ()
-
-    unset (test_base_path)
-    unset (test_base_path_relative)
-endmacro ()
-
-macro (seqan3_require_ccache)
-    find_program (CCACHE_PROGRAM ccache)
-    find_package_message (CCACHE_PROGRAM_PRE "Finding program ccache" "[${CCACHE_PROGRAM}]")
-
-    if (NOT CCACHE_PROGRAM)
-        find_package_message (CCACHE_PROGRAM "Finding program ccache - Failed" "[${CCACHE_PROGRAM}]")
-    else ()
-        find_package_message (CCACHE_PROGRAM "Finding program ccache - Success" "[${CCACHE_PROGRAM}]")
-        # New option since cmake >= 3.4:
-        # https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER_LAUNCHER.html
-        if (NOT CMAKE_VERSION VERSION_LESS 3.15) # cmake >= 3.15
-            list (PREPEND CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
-        else ()
-            # prepend ccache to CMAKE_CXX_COMPILER_LAUNCHER
-            list (INSERT CMAKE_CXX_COMPILER_LAUNCHER 0 "${CCACHE_PROGRAM}")
-        endif ()
-
-        # use ccache in external cmake projects
-        list (APPEND SEQAN3_EXTERNAL_PROJECT_CMAKE_ARGS "-DCMAKE_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER}")
-    endif ()
-    unset (CCACHE_PROGRAM)
-endmacro ()
-
-macro (seqan3_require_benchmark)
-    enable_testing ()
-
-    set (gbenchmark_project_args ${SEQAN3_EXTERNAL_PROJECT_CMAKE_ARGS})
-    list (APPEND gbenchmark_project_args "-DBENCHMARK_ENABLE_TESTING=false")
-    # list (APPEND gbenchmark_project_args "-DBENCHMARK_ENABLE_LTO=true")
-
-    # force that libraries are installed to `lib/`, because GNUInstallDirs might install it into `lib64/`
-    list (APPEND gbenchmark_project_args "-DCMAKE_INSTALL_LIBDIR=${PROJECT_BINARY_DIR}/lib/")
-
-    set (gbenchmark_path "${PROJECT_BINARY_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}benchmark${CMAKE_STATIC_LIBRARY_SUFFIX}")
-
-    include (ExternalProject)
-    ExternalProject_Add (
-        gbenchmark_project
-        PREFIX gbenchmark_project
-        GIT_REPOSITORY "https://github.com/google/benchmark.git"
-        GIT_TAG "v1.5.0"
-        SOURCE_DIR "${SEQAN3_BENCHMARK_CLONE_DIR}"
-        CMAKE_ARGS "${gbenchmark_project_args}"
-        BUILD_BYPRODUCTS "${gbenchmark_path}"
-        UPDATE_DISCONNECTED ${SEQAN3_TEST_BUILD_OFFLINE}
-    )
-    unset (gbenchmark_project_args)
-
-    add_library (gbenchmark STATIC IMPORTED)
-    add_dependencies (gbenchmark gbenchmark_project)
-    set_target_properties (gbenchmark PROPERTIES IMPORTED_LOCATION "${gbenchmark_path}")
-    set_property (TARGET gbenchmark APPEND PROPERTY INTERFACE_LINK_LIBRARIES "pthread")
-
-    unset (gbenchmark_path)
-endmacro ()
-
-macro (seqan3_require_test)
-    enable_testing ()
-
-    set (gtest_project_args ${SEQAN3_EXTERNAL_PROJECT_CMAKE_ARGS})
-    list (APPEND gtest_project_args "-DBUILD_GMOCK=0")
-
-    # force that libraries are installed to `lib/`, because GNUInstallDirs might install it into `lib64/`
-    list (APPEND gtest_project_args "-DCMAKE_INSTALL_LIBDIR=${PROJECT_BINARY_DIR}/lib/")
-
-    # google sets CMAKE_DEBUG_POSTFIX = "d"
-    set (gtest_main_path "${PROJECT_BINARY_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}gtest_main${CMAKE_STATIC_LIBRARY_SUFFIX}")
-    if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-        set (gtest_main_path "${PROJECT_BINARY_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}gtest_maind${CMAKE_STATIC_LIBRARY_SUFFIX}")
-    endif ()
-
-    set (gtest_path "${PROJECT_BINARY_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}gtest${CMAKE_STATIC_LIBRARY_SUFFIX}")
-    if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-        set (gtest_path "${PROJECT_BINARY_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}gtestd${CMAKE_STATIC_LIBRARY_SUFFIX}")
-    endif ()
-
-    include (ExternalProject)
-    ExternalProject_Add (
-        gtest_project
-        PREFIX gtest_project
-        GIT_REPOSITORY "https://github.com/google/googletest.git"
-        # we currently have warnings that were introduced in
-        # 03867b5389516a0f185af52672cf5472fa0c159c, which are still available
-        # in "release-1.8.1", see https://github.com/google/googletest/issues/1419
-        GIT_TAG "release-1.10.0"
-        SOURCE_DIR "${SEQAN3_TEST_CLONE_DIR}"
-        CMAKE_ARGS "${gtest_project_args}"
-        BUILD_BYPRODUCTS "${gtest_main_path}" "${gtest_path}"
-        UPDATE_DISCONNECTED ${SEQAN3_TEST_BUILD_OFFLINE}
-    )
-    unset (gtest_project_args)
-
-    add_library (gtest_main STATIC IMPORTED)
-    add_dependencies (gtest_main gtest_project)
-    set_target_properties (gtest_main PROPERTIES IMPORTED_LOCATION "${gtest_main_path}")
-
-    add_library (gtest STATIC IMPORTED)
-    add_dependencies (gtest gtest_main)
-    set_target_properties (gtest PROPERTIES IMPORTED_LOCATION "${gtest_path}")
-    set_property (TARGET gtest APPEND PROPERTY INTERFACE_LINK_LIBRARIES "pthread")
-
-    unset(gtest_main_path)
-    unset(gtest_path)
-endmacro ()
-
-macro (add_subdirectories_of directory)
-    file (GLOB ENTRIES
-          RELATIVE ${directory}
-          ${directory}/[!.]*)
-
-    foreach (ENTRY ${ENTRIES})
-        if (IS_DIRECTORY ${directory}/${ENTRY})
-            if (EXISTS ${directory}/${ENTRY}/CMakeLists.txt)
-                add_subdirectory (${directory}/${ENTRY} ${CMAKE_CURRENT_BINARY_DIR}/${ENTRY})
-            endif ()
-        endif ()
-    endforeach ()
-    unset (ENTRIES)
-endmacro ()
-
-macro (add_subdirectories)
-    add_subdirectories_of(${CMAKE_CURRENT_SOURCE_DIR})
-endmacro ()
+include (seqan3_test_component)
+include (seqan3_test_files)
+include (seqan3_require_ccache)
+include (seqan3_require_benchmark)
+include (seqan3_require_test)
+include (add_subdirectories)


### PR DESCRIPTION
We want to add more features via cmake to our build infrastructure and want to re-use it in our application template that it makes sense to split out functionality of our cmake-infrastructure into an own dedicated folder.

@mr-c This might have implications for your debian packages.