### PR TITLE
[MISC] Config parallel with member thread_count

### DIFF
--- a/include/seqan3/alignment/pairwise/align_pairwise.hpp
+++ b/include/seqan3/alignment/pairwise/align_pairwise.hpp
@@ -88,6 +88,7 @@ namespace seqan3
  *
  * Might throw std::bad_alloc if it fails to allocate the alignment matrix or seqan3::invalid_alignment_configuration
  * if the configuration is invalid.
+ * Throws std::bad_optional_access if seqan3::align_cfg::parallel has been specified without a `thread_count` value.
  *
  * ### Complexity
  *
@@ -187,7 +188,7 @@ constexpr auto align_pairwise(sequence_t && sequences,
     auto select_execution_handler = [&] ()
     {
         if constexpr (std::same_as<execution_handler_t, detail::execution_handler_parallel>)
-            return execution_handler_t{get<align_cfg::parallel>(complete_config).thread_count};
+            return execution_handler_t{get<align_cfg::parallel>(complete_config).thread_count.value()};
         else
             return execution_handler_t{};
     };

--- a/include/seqan3/alignment/pairwise/align_pairwise.hpp
+++ b/include/seqan3/alignment/pairwise/align_pairwise.hpp
@@ -88,7 +88,7 @@ namespace seqan3
  *
  * Might throw std::bad_alloc if it fails to allocate the alignment matrix or seqan3::invalid_alignment_configuration
  * if the configuration is invalid.
- * Throws std::bad_optional_access if seqan3::align_cfg::parallel has been specified without a `thread_count` value.
+ * Throws std::runtime_error if seqan3::align_cfg::parallel has been specified without a `thread_count` value.
  *
  * ### Complexity
  *
@@ -188,9 +188,17 @@ constexpr auto align_pairwise(sequence_t && sequences,
     auto select_execution_handler = [&] ()
     {
         if constexpr (std::same_as<execution_handler_t, detail::execution_handler_parallel>)
-            return execution_handler_t{get<align_cfg::parallel>(complete_config).thread_count.value()};
+        {
+            auto thread_count = get<align_cfg::parallel>(complete_config).thread_count;
+            if (!thread_count)
+                throw std::runtime_error{"You must configure the number of threads in seqan3::align_cfg::parallel."};
+
+            return execution_handler_t{*thread_count};
+        }
         else
+        {
             return execution_handler_t{};
+        }
     };
 
     // Return the range over the alignments.

--- a/include/seqan3/alignment/pairwise/align_pairwise.hpp
+++ b/include/seqan3/alignment/pairwise/align_pairwise.hpp
@@ -187,7 +187,7 @@ constexpr auto align_pairwise(sequence_t && sequences,
     auto select_execution_handler = [&] ()
     {
         if constexpr (std::same_as<execution_handler_t, detail::execution_handler_parallel>)
-            return execution_handler_t{get<align_cfg::parallel>(complete_config).value};
+            return execution_handler_t{get<align_cfg::parallel>(complete_config).thread_count};
         else
             return execution_handler_t{};
     };

--- a/include/seqan3/core/algorithm/configuration_element_parallel_mode.hpp
+++ b/include/seqan3/core/algorithm/configuration_element_parallel_mode.hpp
@@ -13,6 +13,7 @@
 
 #pragma once
 
+#include <optional>
 #include <seqan3/core/algorithm/pipeable_config_element.hpp>
 
 namespace seqan3::detail
@@ -47,7 +48,7 @@ public:
     //!\}
 
     //!\brief The maximum number of threads the algorithm can use.
-    uint32_t thread_count{1u};
+    std::optional<uint32_t> thread_count{std::nullopt};
 
     /*!\privatesection
      * \brief Internal id to check for consistent configuration settings.

--- a/include/seqan3/core/algorithm/configuration_element_parallel_mode.hpp
+++ b/include/seqan3/core/algorithm/configuration_element_parallel_mode.hpp
@@ -34,15 +34,15 @@ public:
      */
     parallel_mode() = default; //!< Defaulted.
     parallel_mode(parallel_mode const &) = default; //!< Defaulted.
-    parallel_mode(parallel_mode &&) noexcept = default; //!< Defaulted.
+    parallel_mode(parallel_mode &&) = default; //!< Defaulted.
     parallel_mode & operator=(parallel_mode const &) = default; //!< Defaulted.
-    parallel_mode & operator=(parallel_mode &&) noexcept = default; //!< Defaulted.
+    parallel_mode & operator=(parallel_mode &&) = default; //!< Defaulted.
     ~parallel_mode() = default; //!< Defaulted.
 
     /*!\brief Sets the number of threads for the parallel configuration element.
-     * \param[in] thread_c The maximum number of threads to be used by the algorithm.
+     * \param[in] thread_count_ The maximum number of threads to be used by the algorithm.
      */
-    explicit parallel_mode(uint32_t thread_c) noexcept : thread_count{thread_c}
+    explicit parallel_mode(uint32_t thread_count_) noexcept : thread_count{thread_count_}
     {}
     //!\}
 

--- a/include/seqan3/core/algorithm/configuration_element_parallel_mode.hpp
+++ b/include/seqan3/core/algorithm/configuration_element_parallel_mode.hpp
@@ -8,6 +8,7 @@
 /*!\file
  * \brief Provides seqan3::detail::parallel_mode.
  * \author Svenja Mehringer <svenja.mehringer AT fu-berlin.de>
+ * \author Jörg Winkler <j.winkler AT fu-berlin.de>
  */
 
 #pragma once
@@ -25,9 +26,32 @@ namespace seqan3::detail
  * This type is used to enable the parallel mode of the algorithms.
  */
 template <typename wrapped_config_id_t>
-struct parallel_mode : public pipeable_config_element<parallel_mode<wrapped_config_id_t>, uint32_t>
+class parallel_mode : public pipeable_config_element<parallel_mode<wrapped_config_id_t>>
 {
-    //!\brief Internal id to check for consistent configuration settings.
+public:
+    /*!\name Constructors, assignment and destructor
+     * \{
+     */
+    parallel_mode() = default; //!< Defaulted.
+    parallel_mode(parallel_mode const &) = default; //!< Defaulted.
+    parallel_mode(parallel_mode &&) noexcept = default; //!< Defaulted.
+    parallel_mode & operator=(parallel_mode const &) = default; //!< Defaulted.
+    parallel_mode & operator=(parallel_mode &&) noexcept = default; //!< Defaulted.
+    ~parallel_mode() = default; //!< Defaulted.
+
+    /*!\brief Sets the number of threads for the parallel configuration element.
+     * \param[in] thread_c The maximum number of threads to be used by the algorithm.
+     */
+    explicit parallel_mode(uint32_t thread_c) noexcept : thread_count{thread_c}
+    {}
+    //!\}
+
+    //!\brief The maximum number of threads the algorithm can use.
+    uint32_t thread_count{1u};
+
+    /*!\privatesection
+     * \brief Internal id to check for consistent configuration settings.
+     */
     static constexpr typename wrapped_config_id_t::value_type id{wrapped_config_id_t::value};
 };
 } // namespace seqan3::detail

--- a/include/seqan3/search/configuration/all.hpp
+++ b/include/seqan3/search/configuration/all.hpp
@@ -128,4 +128,12 @@
  * The following example demonstrates the usage of the dynamic configuration:
  *
  * \include test/snippet/search/dynamic_hit_configuration_example.cpp
+ *
+ * \subsection search_configuration_subsection_parallel 6: Parallel Configuration
+ *
+ * This configuration determines the maximal number of threads the search algorithm can use.
+ *
+ * The seqan3::search_cfg::parallel configuration element can be combined with any other search configuration.
+ *
+ * \include test/snippet/search/configuration_parallel.cpp
  */

--- a/test/snippet/search/configuration_parallel.cpp
+++ b/test/snippet/search/configuration_parallel.cpp
@@ -5,8 +5,13 @@
 int main()
 {
     // Enable parallel execution of the search algorithm with 8 threads (and allow 1 error of any type).
-    seqan3::configuration const cfg1 = seqan3::search_cfg::parallel{8} |
-                                       seqan3::search_cfg::max_error_total{seqan3::search_cfg::error_count{1}};
+    seqan3::configuration cfg1 = seqan3::search_cfg::parallel{8} |
+                                 seqan3::search_cfg::max_error_total{seqan3::search_cfg::error_count{1}};
+
+    // Alternative solution: assign to the member variable of the parallel configuration
+    seqan3::search_cfg::parallel par_cfg{};
+    par_cfg.thread_count = 8;
+    seqan3::configuration cfg2 = par_cfg | seqan3::search_cfg::max_error_total{seqan3::search_cfg::error_count{1}};
 
     return 0;
 }

--- a/test/unit/alignment/configuration/align_config_parallel_test.cpp
+++ b/test/unit/alignment/configuration/align_config_parallel_test.cpp
@@ -36,17 +36,17 @@ TEST(align_config_parallel, configuration)
     { // from lvalue.
         seqan3::align_cfg::parallel elem{2};
         seqan3::configuration cfg{elem};
-        EXPECT_TRUE((std::is_same_v<std::remove_reference_t<decltype(std::get<seqan3::align_cfg::parallel>(cfg).thread_count)>,
-                                    uint32_t>));
+        auto cfg_value = std::get<seqan3::align_cfg::parallel>(cfg).thread_count;
 
-        EXPECT_EQ(std::get<seqan3::align_cfg::parallel>(cfg).thread_count, 2u);
+        EXPECT_TRUE((std::is_same_v<std::remove_reference_t<decltype(cfg_value)>, uint32_t>));
+        EXPECT_EQ(cfg_value, 2u);
     }
 
     { // from rvalue.
         seqan3::configuration cfg{seqan3::align_cfg::parallel{2}};
-        EXPECT_TRUE((std::is_same_v<std::remove_reference_t<decltype(std::get<seqan3::align_cfg::parallel>(cfg).thread_count)>,
-                                    uint32_t>));
+        auto cfg_value = std::get<seqan3::align_cfg::parallel>(cfg).thread_count;
 
-        EXPECT_EQ(std::get<seqan3::align_cfg::parallel>(cfg).thread_count, 2u);
+        EXPECT_TRUE((std::is_same_v<std::remove_reference_t<decltype(cfg_value)>, uint32_t>));
+        EXPECT_EQ(cfg_value, 2u);
     }
 }

--- a/test/unit/alignment/configuration/align_config_parallel_test.cpp
+++ b/test/unit/alignment/configuration/align_config_parallel_test.cpp
@@ -23,17 +23,17 @@ TEST(align_config_parallel, configuration)
     { // from lvalue.
         seqan3::align_cfg::parallel elem{2};
         seqan3::configuration cfg{elem};
-        EXPECT_TRUE((std::is_same_v<std::remove_reference_t<decltype(std::get<seqan3::align_cfg::parallel>(cfg).value)>,
+        EXPECT_TRUE((std::is_same_v<std::remove_reference_t<decltype(std::get<seqan3::align_cfg::parallel>(cfg).thread_count)>,
                                     uint32_t>));
 
-        EXPECT_EQ(std::get<seqan3::align_cfg::parallel>(cfg).value, 2u);
+        EXPECT_EQ(std::get<seqan3::align_cfg::parallel>(cfg).thread_count, 2u);
     }
 
     { // from rvalue.
         seqan3::configuration cfg{seqan3::align_cfg::parallel{2}};
-        EXPECT_TRUE((std::is_same_v<std::remove_reference_t<decltype(std::get<seqan3::align_cfg::parallel>(cfg).value)>,
+        EXPECT_TRUE((std::is_same_v<std::remove_reference_t<decltype(std::get<seqan3::align_cfg::parallel>(cfg).thread_count)>,
                                     uint32_t>));
 
-        EXPECT_EQ(std::get<seqan3::align_cfg::parallel>(cfg).value, 2u);
+        EXPECT_EQ(std::get<seqan3::align_cfg::parallel>(cfg).thread_count, 2u);
     }
 }

--- a/test/unit/alignment/configuration/align_config_parallel_test.cpp
+++ b/test/unit/alignment/configuration/align_config_parallel_test.cpp
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 
 #include <functional>
+#include <optional>
 #include <type_traits>
 
 #include <seqan3/alignment/configuration/align_config_parallel.hpp>
@@ -38,7 +39,7 @@ TEST(align_config_parallel, configuration)
         seqan3::configuration cfg{elem};
         auto cfg_value = std::get<seqan3::align_cfg::parallel>(cfg).thread_count;
 
-        EXPECT_TRUE((std::is_same_v<std::remove_reference_t<decltype(cfg_value)>, uint32_t>));
+        EXPECT_TRUE((std::is_same_v<std::remove_reference_t<decltype(cfg_value)>, std::optional<uint32_t>>));
         EXPECT_EQ(cfg_value, 2u);
     }
 
@@ -46,7 +47,7 @@ TEST(align_config_parallel, configuration)
         seqan3::configuration cfg{seqan3::align_cfg::parallel{2}};
         auto cfg_value = std::get<seqan3::align_cfg::parallel>(cfg).thread_count;
 
-        EXPECT_TRUE((std::is_same_v<std::remove_reference_t<decltype(cfg_value)>, uint32_t>));
+        EXPECT_TRUE((std::is_same_v<std::remove_reference_t<decltype(cfg_value)>, std::optional<uint32_t>>));
         EXPECT_EQ(cfg_value, 2u);
     }
 }

--- a/test/unit/alignment/pairwise/align_pairwise_test.cpp
+++ b/test/unit/alignment/pairwise/align_pairwise_test.cpp
@@ -7,6 +7,7 @@
 
 #include <gtest/gtest.h>
 
+#include <optional>
 #include <type_traits>
 #include <utility>
 
@@ -49,9 +50,9 @@ auto call_alignment(seq_t && seq, cfg_t && cfg)
     {
         return seqan3::align_pairwise(std::forward<seq_t>(seq), std::forward<cfg_t>(cfg));
     }
-    else
+    else if constexpr (std::same_as<type_param_t, seqan3::align_cfg::parallel>)
     {
-        auto && config = cfg | type_param_t{};
+        auto && config = cfg | seqan3::align_cfg::parallel{4};
         return seqan3::align_pairwise(std::forward<seq_t>(seq), std::forward<decltype(config)>(config));
     }
 }
@@ -209,4 +210,15 @@ TYPED_TEST(align_pairwise_test, bug_1598)
 
     // Invoke the pairwise alignment which returns a lazy range over alignment results.
     auto results = seqan3::align_pairwise(std::tie(s1, s2), cfg);
+}
+
+TEST(align_pairwise_test, parallel_without_parameter)
+{
+    auto seq1 = "ACGTGATG"_dna4;
+    auto seq2 = "AGTGATACT"_dna4;
+    seqan3::configuration cfg = seqan3::align_cfg::edit |
+                                seqan3::align_cfg::result{seqan3::with_score} |
+                                seqan3::align_cfg::parallel{};
+
+    EXPECT_THROW(seqan3::align_pairwise(std::tie(seq1, seq2), cfg), std::bad_optional_access);
 }

--- a/test/unit/alignment/pairwise/align_pairwise_test.cpp
+++ b/test/unit/alignment/pairwise/align_pairwise_test.cpp
@@ -7,7 +7,7 @@
 
 #include <gtest/gtest.h>
 
-#include <optional>
+#include <stdexcept>
 #include <type_traits>
 #include <utility>
 
@@ -220,5 +220,5 @@ TEST(align_pairwise_test, parallel_without_parameter)
                                 seqan3::align_cfg::result{seqan3::with_score} |
                                 seqan3::align_cfg::parallel{};
 
-    EXPECT_THROW(seqan3::align_pairwise(std::tie(seq1, seq2), cfg), std::bad_optional_access);
+    EXPECT_THROW(seqan3::align_pairwise(std::tie(seq1, seq2), cfg), std::runtime_error);
 }

--- a/test/unit/search/configuration/CMakeLists.txt
+++ b/test/unit/search/configuration/CMakeLists.txt
@@ -1,1 +1,2 @@
 seqan3_test(hit_test.cpp)
+seqan3_test(parallel_test.cpp)

--- a/test/unit/search/configuration/parallel_test.cpp
+++ b/test/unit/search/configuration/parallel_test.cpp
@@ -7,10 +7,7 @@
 
 #include <gtest/gtest.h>
 
-#include <functional>
-#include <type_traits>
-
-#include <seqan3/alignment/configuration/align_config_parallel.hpp>
+#include <seqan3/search/configuration/parallel.hpp>
 
 #include "../../core/algorithm/pipeable_config_element_test_template.hpp"
 
@@ -18,7 +15,7 @@
 // test template : pipeable_config_element_test
 // ---------------------------------------------------------------------------------------------------------------------
 
-using test_types = ::testing::Types<seqan3::align_cfg::parallel>;
+using test_types = ::testing::Types<seqan3::search_cfg::parallel>;
 
 INSTANTIATE_TYPED_TEST_SUITE_P(parallel_elements, pipeable_config_element_test, test_types, );
 
@@ -26,27 +23,46 @@ INSTANTIATE_TYPED_TEST_SUITE_P(parallel_elements, pipeable_config_element_test, 
 // individual tests
 // ---------------------------------------------------------------------------------------------------------------------
 
-TEST(align_config_parallel, config_element_specialisation)
+TEST(search_config_parallel, member_variable)
 {
-    EXPECT_TRUE((seqan3::detail::config_element_specialisation<seqan3::align_cfg::parallel>));
+    {   // default construction
+        seqan3::search_cfg::parallel cfg{};
+        EXPECT_EQ(cfg.thread_count, 1u);
+    }
+
+    {   // construct with value
+        seqan3::search_cfg::parallel cfg{4};
+        EXPECT_EQ(cfg.thread_count, 4u);
+    }
+
+    {   // assign value
+        seqan3::search_cfg::parallel cfg{};
+        cfg.thread_count = 4;
+        EXPECT_EQ(cfg.thread_count, 4u);
+    }
 }
 
-TEST(align_config_parallel, configuration)
+TEST(search_config_parallel, config_element_specialisation)
+{
+    EXPECT_TRUE((seqan3::detail::config_element_specialisation<seqan3::search_cfg::parallel>));
+}
+
+TEST(search_config_parallel, configuration)
 {
     { // from lvalue.
-        seqan3::align_cfg::parallel elem{2};
+        seqan3::search_cfg::parallel elem{4};
         seqan3::configuration cfg{elem};
-        EXPECT_TRUE((std::is_same_v<std::remove_reference_t<decltype(std::get<seqan3::align_cfg::parallel>(cfg).thread_count)>,
-                                    uint32_t>));
+        using ret_type = decltype(std::get<seqan3::search_cfg::parallel>(cfg).thread_count);
+        EXPECT_TRUE((std::is_same_v<std::remove_reference_t<ret_type>, uint32_t>));
 
-        EXPECT_EQ(std::get<seqan3::align_cfg::parallel>(cfg).thread_count, 2u);
+        EXPECT_EQ(std::get<seqan3::search_cfg::parallel>(cfg).thread_count, 4u);
     }
 
     { // from rvalue.
-        seqan3::configuration cfg{seqan3::align_cfg::parallel{2}};
-        EXPECT_TRUE((std::is_same_v<std::remove_reference_t<decltype(std::get<seqan3::align_cfg::parallel>(cfg).thread_count)>,
-                                    uint32_t>));
+        seqan3::configuration cfg{seqan3::search_cfg::parallel{4}};
+        using ret_type = decltype(std::get<seqan3::search_cfg::parallel>(cfg).thread_count);
+        EXPECT_TRUE((std::is_same_v<std::remove_reference_t<ret_type>, uint32_t>));
 
-        EXPECT_EQ(std::get<seqan3::align_cfg::parallel>(cfg).thread_count, 2u);
+        EXPECT_EQ(std::get<seqan3::search_cfg::parallel>(cfg).thread_count, 4u);
     }
 }

--- a/test/unit/search/configuration/parallel_test.cpp
+++ b/test/unit/search/configuration/parallel_test.cpp
@@ -7,6 +7,7 @@
 
 #include <gtest/gtest.h>
 
+#include <optional>
 #include <seqan3/search/configuration/parallel.hpp>
 
 #include "../../core/algorithm/pipeable_config_element_test_template.hpp"
@@ -27,18 +28,19 @@ TEST(search_config_parallel, member_variable)
 {
     {   // default construction
         seqan3::search_cfg::parallel cfg{};
-        EXPECT_EQ(cfg.thread_count, 1u);
+        EXPECT_FALSE(cfg.thread_count);
+        EXPECT_THROW(cfg.thread_count.value(), std::bad_optional_access);
     }
 
     {   // construct with value
         seqan3::search_cfg::parallel cfg{4};
-        EXPECT_EQ(cfg.thread_count, 4u);
+        EXPECT_EQ(cfg.thread_count.value(), 4u);
     }
 
     {   // assign value
         seqan3::search_cfg::parallel cfg{};
         cfg.thread_count = 4;
-        EXPECT_EQ(cfg.thread_count, 4u);
+        EXPECT_EQ(cfg.thread_count.value(), 4u);
     }
 }
 
@@ -53,16 +55,16 @@ TEST(search_config_parallel, configuration)
         seqan3::search_cfg::parallel elem{4};
         seqan3::configuration cfg{elem};
         using ret_type = decltype(std::get<seqan3::search_cfg::parallel>(cfg).thread_count);
-        EXPECT_TRUE((std::is_same_v<std::remove_reference_t<ret_type>, uint32_t>));
+        EXPECT_TRUE((std::is_same_v<std::remove_reference_t<ret_type>, std::optional<uint32_t>>));
 
-        EXPECT_EQ(std::get<seqan3::search_cfg::parallel>(cfg).thread_count, 4u);
+        EXPECT_EQ(std::get<seqan3::search_cfg::parallel>(cfg).thread_count.value(), 4u);
     }
 
     { // from rvalue.
         seqan3::configuration cfg{seqan3::search_cfg::parallel{4}};
         using ret_type = decltype(std::get<seqan3::search_cfg::parallel>(cfg).thread_count);
-        EXPECT_TRUE((std::is_same_v<std::remove_reference_t<ret_type>, uint32_t>));
+        EXPECT_TRUE((std::is_same_v<std::remove_reference_t<ret_type>, std::optional<uint32_t>>));
 
-        EXPECT_EQ(std::get<seqan3::search_cfg::parallel>(cfg).thread_count, 4u);
+        EXPECT_EQ(std::get<seqan3::search_cfg::parallel>(cfg).thread_count.value(), 4u);
     }
 }


### PR DESCRIPTION
This PR adds a member variable `thread_count` to the parallel config (it replaces the old value member). It influences both `seqan3::align_cfg::parallel` and `seqan3::search_cfg::parallel`.

Documentation and tests are included in the second commit.

Closes https://github.com/seqan/product_backlog/issues/68 and contributes to https://github.com/seqan/product_backlog/issues/131.