### PR TITLE
[MISC] Use <seqan3/std/xxx> instead of range-v3 header

### DIFF
--- a/include/seqan3/alignment/pairwise/edit_distance_unbanded.hpp
+++ b/include/seqan3/alignment/pairwise/edit_distance_unbanded.hpp
@@ -13,10 +13,10 @@
 #pragma once
 
 #include <algorithm>
+#include <seqan3/std/algorithm>
 #include <bitset>
+#include <seqan3/std/ranges>
 #include <utility>
-
-#include <range/v3/algorithm/copy.hpp>
 
 #include <seqan3/alignment/matrix/alignment_coordinate.hpp>
 #include <seqan3/alignment/matrix/alignment_trace_algorithms.hpp>
@@ -25,7 +25,6 @@
 #include <seqan3/alignment/pairwise/alignment_result.hpp>
 #include <seqan3/alignment/pairwise/edit_distance_fwd.hpp>
 #include <seqan3/core/algorithm/configuration.hpp>
-#include <seqan3/std/ranges>
 
 namespace seqan3::detail
 {

--- a/include/seqan3/alignment/scoring/aminoacid_scoring_scheme.hpp
+++ b/include/seqan3/alignment/scoring/aminoacid_scoring_scheme.hpp
@@ -13,11 +13,10 @@
 
 #pragma once
 
-#include <range/v3/algorithm/copy.hpp>
+#include <seqan3/std/algorithm>
 
 #include <seqan3/alignment/scoring/scoring_scheme_base.hpp>
 #include <seqan3/alphabet/aminoacid/aa27.hpp>
-#include <seqan3/std/algorithm>
 
 namespace seqan3
 {

--- a/include/seqan3/alignment/scoring/scoring_scheme_base.hpp
+++ b/include/seqan3/alignment/scoring/scoring_scheme_base.hpp
@@ -13,13 +13,12 @@
 
 #pragma once
 
-#include <range/v3/algorithm/copy.hpp>
+#include <seqan3/std/algorithm>
 
 #include <seqan3/alphabet/concept.hpp>
 #include <seqan3/core/concept/cereal.hpp>
 #include <seqan3/core/concept/core_language.hpp>
 #include <seqan3/core/detail/strong_type.hpp>
-#include <seqan3/std/algorithm>
 
 #if SEQAN3_WITH_CEREAL
 #include <cereal/types/array.hpp>

--- a/include/seqan3/io/detail/in_file_iterator.hpp
+++ b/include/seqan3/io/detail/in_file_iterator.hpp
@@ -13,12 +13,9 @@
 #pragma once
 
 #include <cassert>
-
-#include <range/v3/range_fwd.hpp>
+#include <seqan3/std/ranges>
 
 #include <seqan3/core/platform.hpp>
-
-#include <seqan3/std/ranges>
 
 namespace seqan3::detail
 {

--- a/include/seqan3/io/detail/out_file_iterator.hpp
+++ b/include/seqan3/io/detail/out_file_iterator.hpp
@@ -13,12 +13,9 @@
 #pragma once
 
 #include <cassert>
-
-#include <range/v3/range_fwd.hpp>
+#include <seqan3/std/ranges>
 
 #include <seqan3/core/platform.hpp>
-
-#include <seqan3/std/ranges>
 
 namespace seqan3::detail
 {

--- a/include/seqan3/range/views/persist.hpp
+++ b/include/seqan3/range/views/persist.hpp
@@ -12,7 +12,9 @@
 
 #pragma once
 
-#include <range/v3/algorithm/copy.hpp>
+#include <seqan3/std/algorithm>
+#include <seqan3/std/concepts>
+#include <seqan3/std/ranges>
 
 #include <seqan3/core/type_traits/iterator.hpp>
 #include <seqan3/core/type_traits/range.hpp>
@@ -21,9 +23,6 @@
 #include <seqan3/range/concept.hpp>
 #include <seqan3/range/container/concept.hpp>
 #include <seqan3/range/views/detail.hpp>
-#include <seqan3/std/algorithm>
-#include <seqan3/std/concepts>
-#include <seqan3/std/ranges>
 
 namespace seqan3::detail
 {
@@ -58,7 +57,7 @@ private:
     //!\brief The const_iterator type is equal to the iterator type.
     using const_iterator    = iterator;
     //!\}
-    
+
 public:
     /*!\name Constructors, destructor and assignment
      * \{

--- a/include/seqan3/range/views/repeat.hpp
+++ b/include/seqan3/range/views/repeat.hpp
@@ -12,12 +12,12 @@
 
 #pragma once
 
-#include <range/v3/view/single.hpp>
+#include <seqan3/std/algorithm>
+#include <seqan3/std/ranges>
 
 #include <seqan3/core/type_traits/iterator.hpp>
 #include <seqan3/core/type_traits/range.hpp>
 #include <seqan3/range/detail/random_access_iterator.hpp>
-#include <seqan3/std/ranges>
 
 namespace seqan3::detail
 {

--- a/include/seqan3/range/views/take.hpp
+++ b/include/seqan3/range/views/take.hpp
@@ -12,7 +12,12 @@
 
 #pragma once
 
-#include <range/v3/algorithm/copy.hpp>
+#include <seqan3/std/algorithm>
+#include <seqan3/std/concepts>
+#include <seqan3/std/iterator>
+#include <seqan3/std/ranges>
+#include <seqan3/std/span>
+#include <seqan3/std/type_traits>
 
 #include <seqan3/core/type_traits/iterator.hpp>
 #include <seqan3/core/type_traits/range.hpp>
@@ -23,12 +28,6 @@
 #include <seqan3/range/container/concept.hpp>
 #include <seqan3/range/views/detail.hpp>
 #include <seqan3/range/detail/inherited_iterator_base.hpp>
-#include <seqan3/std/algorithm>
-#include <seqan3/std/concepts>
-#include <seqan3/std/iterator>
-#include <seqan3/std/ranges>
-#include <seqan3/std/span>
-#include <seqan3/std/type_traits>
 
 namespace seqan3::detail
 {

--- a/include/seqan3/search/fm_index/fm_index_cursor.hpp
+++ b/include/seqan3/search/fm_index/fm_index_cursor.hpp
@@ -13,11 +13,10 @@
 #pragma once
 
 #include <array>
+#include <seqan3/std/ranges>
 #include <type_traits>
 
 #include <sdsl/suffix_trees.hpp>
-
-#include <range/v3/view/slice.hpp>
 
 #include <seqan3/alphabet/adaptation/char.hpp>
 #include <seqan3/alphabet/concept.hpp>
@@ -25,7 +24,6 @@
 #include <seqan3/range/views/slice.hpp>
 #include <seqan3/search/fm_index/detail/fm_index_cursor.hpp>
 #include <seqan3/search/fm_index/fm_index.hpp>
-#include <seqan3/std/ranges>
 
 namespace seqan3
 {


### PR DESCRIPTION
Fixes part of https://github.com/seqan/product_backlog/issues/124

A step closer towards A Life Without range-v3: replaces range-v3 headers by <seqan3/std/xxx> where possible/removes unnecessary imports.