### PR TITLE
[FIX] seqan3::complement cannot require std::same_as on the input and return type.

### DIFF
--- a/include/seqan3/alphabet/nucleotide/concept.hpp
+++ b/include/seqan3/alphabet/nucleotide/concept.hpp
@@ -43,10 +43,12 @@ public:
         {
             { impl(priority_tag<2>{}, nucl) };
             requires noexcept(impl(priority_tag<2>{}, nucl));
-            requires std::same_as<nucleotide_t, decltype(impl(priority_tag<2>{}, nucl))>;
+            // requires std::common_with<decltype(impl(priority_tag<2>{}, nucl)), nucleotide_t>; // triggers an ICE
+            requires alphabet<decltype(impl(priority_tag<2>{}, nucl))>;
+            { impl(priority_tag<2>{}, impl(priority_tag<2>{}, nucl)) }; // you can take the complement again
         }
     //!\endcond
-    constexpr nucleotide_t operator()(nucleotide_t const nucl) const noexcept
+    constexpr auto operator()(nucleotide_t const nucl) const noexcept
     {
         return impl(priority_tag<2>{}, nucl);
     }

--- a/test/unit/range/container/CMakeLists.txt
+++ b/test/unit/range/container/CMakeLists.txt
@@ -1,7 +1,7 @@
 seqan3_test(aligned_allocator_test.cpp)
 seqan3_test(container_concept_test.cpp)
 seqan3_test(container_of_container_test.cpp)
-seqan3_test(container_test.cpp)
+seqan3_test(bitcompressed_vector_test.cpp)
 seqan3_test(debug_stream_container_of_container_test.cpp)
 seqan3_test(debug_stream_container_test.cpp)
 seqan3_test(dynamic_bitset_test.cpp)

--- a/test/unit/range/container/bitcompressed_vector_test.cpp
+++ b/test/unit/range/container/bitcompressed_vector_test.cpp
@@ -1,0 +1,12 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include "container_test_template.hpp"
+
+INSTANTIATE_TYPED_TEST_SUITE_P(bitcompressed, container_over_dna4_test, seqan3::bitcompressed_vector<seqan3::dna4>, );

--- a/test/unit/range/container/bitcompressed_vector_test.cpp
+++ b/test/unit/range/container/bitcompressed_vector_test.cpp
@@ -7,6 +7,33 @@
 
 #include <gtest/gtest.h>
 
+#include <seqan3/alphabet/nucleotide/concept.hpp>
+#include <seqan3/alphabet/nucleotide/dna4.hpp>
+#include <seqan3/range/views/complement.hpp>
+#include <seqan3/test/expect_range_eq.hpp>
+
 #include "container_test_template.hpp"
 
 INSTANTIATE_TYPED_TEST_SUITE_P(bitcompressed, container_over_dna4_test, seqan3::bitcompressed_vector<seqan3::dna4>, );
+
+using seqan3::operator""_dna4;
+
+TEST(bitcompressed_vector_test, issue1743_complement_on_proxy)
+{ // https://github.com/seqan/seqan3/issues/1743
+    seqan3::bitcompressed_vector<seqan3::dna4> v{'A'_dna4};
+
+    auto proxy = *v.begin();
+    auto complement = seqan3::complement(proxy);
+
+    EXPECT_TRUE((std::same_as<decltype(complement), seqan3::dna4>));
+    EXPECT_EQ(complement, 'T'_dna4);
+}
+
+TEST(bitcompressed_vector_test, issue1743_view_combinability)
+{ // https://github.com/seqan/seqan3/issues/1743
+    seqan3::bitcompressed_vector<seqan3::dna4> v{'A'_dna4, 'C'_dna4, 'G'_dna4, 'T'_dna4};
+    auto complement = v | seqan3::views::complement;
+
+    EXPECT_EQ(v.size(), complement.size());
+    EXPECT_RANGE_EQ(complement, (seqan3::dna4_vector{'T'_dna4, 'G'_dna4, 'C'_dna4, 'A'_dna4}));
+}

--- a/test/unit/range/container/container_test_template.hpp
+++ b/test/unit/range/container/container_test_template.hpp
@@ -20,21 +20,17 @@
 using seqan3::operator""_dna4;
 
 template <typename T>
-class container_ : public ::testing::Test
+class container_over_dna4_test : public ::testing::Test
 {};
 
-using container_types = ::testing::Types<std::vector<seqan3::dna4>,
-                                         seqan3::bitcompressed_vector<seqan3::dna4>,
-                                         seqan3::small_vector<seqan3::dna4, 1000>>;
+TYPED_TEST_SUITE_P(container_over_dna4_test);
 
-TYPED_TEST_SUITE(container_, container_types, );
-
-TYPED_TEST(container_, concepts)
+TYPED_TEST_P(container_over_dna4_test, concepts)
 {
     EXPECT_TRUE(seqan3::reservible_container<TypeParam>);
 }
 
-TYPED_TEST(container_, construction)
+TYPED_TEST_P(container_over_dna4_test, construction)
 {
     TypeParam t1;
     TypeParam t2{};
@@ -57,7 +53,7 @@ TYPED_TEST(container_, construction)
     EXPECT_EQ(t3, t7);
 }
 
-TYPED_TEST(container_, swap)
+TYPED_TEST_P(container_over_dna4_test, swapping)
 {
     TypeParam t0{};
     TypeParam t1{'A'_dna4, 'C'_dna4, 'C'_dna4, 'G'_dna4, 'T'_dna4};
@@ -71,7 +67,7 @@ TYPED_TEST(container_, swap)
     EXPECT_EQ(t1, (TypeParam{'A'_dna4, 'C'_dna4, 'C'_dna4, 'G'_dna4, 'T'_dna4}));
 }
 
-TYPED_TEST(container_, assign)
+TYPED_TEST_P(container_over_dna4_test, assign)
 {
     TypeParam t0{'C'_dna4, 'C'_dna4};
     TypeParam t1{'A'_dna4, 'C'_dna4, 'C'_dna4, 'G'_dna4, 'T'_dna4};
@@ -102,7 +98,7 @@ TYPED_TEST(container_, assign)
     }
 }
 
-TYPED_TEST(container_, iterators)
+TYPED_TEST_P(container_over_dna4_test, iterators)
 {
     TypeParam t1{'A'_dna4, 'C'_dna4, 'C'_dna4, 'G'_dna4, 'T'_dna4};
     TypeParam const t2{'A'_dna4, 'C'_dna4, 'C'_dna4, 'G'_dna4, 'T'_dna4};
@@ -127,7 +123,7 @@ TYPED_TEST(container_, iterators)
     EXPECT_TRUE((std::ranges::equal(t1, "TCCGT"_dna4)));
 }
 
-TYPED_TEST(container_, element_access)
+TYPED_TEST_P(container_over_dna4_test, element_access)
 {
     TypeParam t1{'A'_dna4, 'C'_dna4, 'C'_dna4, 'G'_dna4, 'T'_dna4};
     TypeParam const t2{'A'_dna4, 'C'_dna4, 'C'_dna4, 'G'_dna4, 'T'_dna4};
@@ -161,7 +157,7 @@ TYPED_TEST(container_, element_access)
     EXPECT_TRUE((std::ranges::equal(t1, "CCCGG"_dna4)));
 }
 
-TYPED_TEST(container_, capacity)
+TYPED_TEST_P(container_over_dna4_test, capacity)
 {
     TypeParam t0{};
     TypeParam t1{'A'_dna4, 'C'_dna4, 'C'_dna4, 'G'_dna4, 'T'_dna4};
@@ -215,7 +211,7 @@ TYPED_TEST(container_, capacity)
     }
 }
 
-TYPED_TEST(container_, clear)
+TYPED_TEST_P(container_over_dna4_test, clear)
 {
     TypeParam t0{};
     TypeParam t1{'A'_dna4, 'C'_dna4, 'C'_dna4, 'G'_dna4, 'T'_dna4};
@@ -224,7 +220,7 @@ TYPED_TEST(container_, clear)
     EXPECT_EQ(t0, t1);
 }
 
-TYPED_TEST(container_, insert)
+TYPED_TEST_P(container_over_dna4_test, insert)
 {
     TypeParam t0{};
     TypeParam t1{'A'_dna4, 'C'_dna4, 'C'_dna4, 'G'_dna4, 'T'_dna4};
@@ -260,7 +256,7 @@ TYPED_TEST(container_, insert)
     EXPECT_EQ(t0, t1);
 }
 
-TYPED_TEST(container_, erase)
+TYPED_TEST_P(container_over_dna4_test, erase)
 {
     TypeParam t1{'A'_dna4, 'C'_dna4, 'C'_dna4, 'G'_dna4, 'T'_dna4};
 
@@ -277,7 +273,7 @@ TYPED_TEST(container_, erase)
     EXPECT_EQ(t1, (TypeParam{'C'_dna4, 'T'_dna4}));
 }
 
-TYPED_TEST(container_, push_pop)
+TYPED_TEST_P(container_over_dna4_test, push_pop)
 {
     TypeParam t0{};
 
@@ -294,7 +290,7 @@ TYPED_TEST(container_, push_pop)
     EXPECT_EQ(t0, (TypeParam{}));
 }
 
-TYPED_TEST(container_, resize)
+TYPED_TEST_P(container_over_dna4_test, resize)
 {
     TypeParam t0{};
 
@@ -315,8 +311,23 @@ TYPED_TEST(container_, resize)
     EXPECT_EQ(t0, (TypeParam{'A'_dna4, 'A'_dna4}));
 }
 
-TYPED_TEST(container_, serialisation)
+TYPED_TEST_P(container_over_dna4_test, serialisation)
 {
     TypeParam t1{'A'_dna4, 'C'_dna4, 'C'_dna4, 'G'_dna4, 'T'_dna4};
     seqan3::test::do_serialisation(t1);
 }
+
+REGISTER_TYPED_TEST_SUITE_P(container_over_dna4_test,
+                            concepts,
+                            construction,
+                            swapping,
+                            assign,
+                            iterators,
+                            element_access,
+                            capacity,
+                            clear,
+                            insert,
+                            erase,
+                            push_pop,
+                            resize,
+                            serialisation);

--- a/test/unit/range/container/small_vector_test.cpp
+++ b/test/unit/range/container/small_vector_test.cpp
@@ -15,6 +15,11 @@
 #include <seqan3/std/ranges>
 #include <seqan3/test/cereal.hpp>
 
+#include "container_test_template.hpp"
+
+using small_vector_over_dna4_t = seqan3::small_vector<seqan3::dna4, 1000>;
+INSTANTIATE_TYPED_TEST_SUITE_P(small_vector, container_over_dna4_test, small_vector_over_dna4_t, );
+
 // standard construction.
 TEST(small_vector, standard_construction)
 {


### PR DESCRIPTION
Fixes #1743 

Before this was not possible (now it is):
```cpp
    seqan3::bitcompressed_vector<seqan3::dna4> v{seqan3::dna4{}, seqan3::dna4{}};
    auto proxy = *v.begin();
    auto complement = seqan3::complement(proxy);

    // or working with views:
    auto complement = v | seqan3::views::complement; 
```
**Reason**: The `seqan3::complement` cpo had the requirement that the return type is the same as the type of the parameter. But the complement of the proxy returned a `seqan3::dna4` again.
I removed this requirement from the concept.

I also thought about making the complement of a proxy return a proxy again but then where would this proxy point to?
So I think changing the requirement of the concept was the right way.

mentioning @h-2, just in case you want to take a look.