### PR TITLE
[FIX] cxx20: single_input_test, basic_istream_view is not known

### DIFF
--- a/include/seqan3/std/ranges
+++ b/include/seqan3/std/ranges
@@ -162,7 +162,8 @@ namespace views { using ::ranges::cpp20::views::single; }
 namespace views { using ::ranges::cpp20::views::iota; }
 
 // [range.istream], istream view
-using ::ranges::cpp20::basic_istream_view;
+template <typename Val, class CharT, class Traits>
+using basic_istream_view = ::ranges::istream_view<Val>;
 
 // [range.all], all view
 namespace views


### PR DESCRIPTION
The C++20 definition of basic_istream_view requires three template arguments, the ranges library only provides one.

See https://eel.is/c++draft/range.istream#view