### PR TITLE
Optimise alignment/part4 introduce alignment matrix policy

### DIFF
--- a/include/seqan3/alignment/pairwise/alignment_configurator.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_configurator.hpp
@@ -22,7 +22,9 @@
 #include <seqan3/alignment/matrix/detail/alignment_score_matrix_one_column_banded.hpp>
 #include <seqan3/alignment/matrix/detail/alignment_trace_matrix_full.hpp>
 #include <seqan3/alignment/matrix/detail/alignment_trace_matrix_full_banded.hpp>
+#include <seqan3/alignment/matrix/detail/score_matrix_single_column.hpp>
 #include <seqan3/alignment/pairwise/detail/pairwise_alignment_algorithm_banded.hpp>
+#include <seqan3/alignment/pairwise/detail/policy_alignment_matrix.hpp>
 #include <seqan3/alignment/pairwise/detail/policy_alignment_result_builder.hpp>
 #include <seqan3/alignment/pairwise/detail/policy_affine_gap_recursion.hpp>
 #include <seqan3/alignment/pairwise/detail/policy_affine_gap_recursion_banded.hpp>
@@ -540,22 +542,25 @@ private:
                                                                    seqan3::detail::method_global_tag,
                                                                    seqan3::detail::method_local_tag>;
 
+            using score_t = typename traits_t::score_type;
             using alignment_scoring_scheme_t =
                 lazy_conditional_t<traits_t::is_vectorised,
                                    lazy<simd_match_mismatch_scoring_scheme,
-                                        typename traits_t::score_type,
+                                        score_t,
                                         typename traits_t::scoring_scheme_alphabet_type,
                                         alignment_method_t>,
                                    typename traits_t::scoring_scheme_type>;
 
             using scoring_scheme_policy_t = policy_scoring_scheme<config_t, alignment_scoring_scheme_t>;
+            using alignment_matrix_policy_t = policy_alignment_matrix<traits_t, score_matrix_single_column<score_t>>;
 
             using algorithm_t = select_alignment_algorithm_t<traits_t,
                                                              config_t,
                                                              gap_cost_policy_t,
                                                              optimum_tracker_policy_t,
                                                              result_builder_policy_t,
-                                                             scoring_scheme_policy_t>;
+                                                             scoring_scheme_policy_t,
+                                                             alignment_matrix_policy_t>;
             return algorithm_t{cfg};
         }
     }

--- a/include/seqan3/alignment/pairwise/alignment_configurator.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_configurator.hpp
@@ -516,7 +516,6 @@ private:
         if constexpr (traits_t::is_local ||                                       // it is a local alignment,
                       traits_t::is_debug ||                                       // it runs in debug mode,
                       traits_t::result_type_rank > 1 ||                           // it computes more than the end position.
-                    //  (traits_t::is_banded && traits_t::with_free_end_gaps) ||     // banded and with free end gaps,
                      (traits_t::is_banded && traits_t::result_type_rank > 0) ||   // banded and end coordinate
                      (traits_t::is_vectorised && traits_t::is_banded) ||          // it is vectorised and banded,
                      (traits_t::is_vectorised && traits_t::result_type_rank > 0)) // simd and more than the score.

--- a/include/seqan3/alignment/pairwise/detail/pairwise_alignment_algorithm.hpp
+++ b/include/seqan3/alignment/pairwise/detail/pairwise_alignment_algorithm.hpp
@@ -137,11 +137,21 @@ public:
     //!\endcond
     void operator()(indexed_sequence_pairs_t && indexed_sequence_pairs, callback_t && callback)
     {
+        using matrix_index_t = typename traits_type::matrix_index_type;
         using std::get;
+
+        thread_local score_matrix_single_column<score_type> alignment_matrix{};
+        coordinate_matrix<matrix_index_t> index_matrix{};
 
         for (auto && [sequence_pair, idx] : indexed_sequence_pairs)
         {
-            compute_matrix(get<0>(sequence_pair), get<1>(sequence_pair));
+            size_t number_of_columns = std::ranges::distance(get<0>(sequence_pair)) + 1;
+            size_t number_of_rows = std::ranges::distance(get<1>(sequence_pair)) + 1;
+
+            alignment_matrix.resize(column_index_type{number_of_columns}, row_index_type{number_of_rows});
+            index_matrix.resize(column_index_type{number_of_columns}, row_index_type{number_of_rows});
+
+            compute_matrix(get<0>(sequence_pair), get<1>(sequence_pair), alignment_matrix, index_matrix);
             this->make_result_and_invoke(std::forward<decltype(sequence_pair)>(sequence_pair),
                                          std::move(idx),
                                          this->optimal_score,
@@ -160,6 +170,7 @@ public:
     {
         using simd_collection_t = std::vector<score_type, aligned_allocator<score_type, alignof(score_type)>>;
         using original_score_t = typename traits_type::original_score_type;
+        using matrix_index_t = typename traits_type::matrix_index_type;
 
         // Extract the batch of sequences for the first and the second sequence.
         auto seq1_collection = indexed_sequence_pairs | views::get<0> | views::get<0>;
@@ -174,7 +185,16 @@ public:
         convert_batch_of_sequences_to_simd_vector(simd_seq1_collection, seq1_collection, traits_type::padding_symbol);
         convert_batch_of_sequences_to_simd_vector(simd_seq2_collection, seq2_collection, traits_type::padding_symbol);
 
-        compute_matrix(simd_seq1_collection, simd_seq2_collection);
+        thread_local score_matrix_single_column<score_type> alignment_matrix{};
+        coordinate_matrix<matrix_index_t> index_matrix{};
+
+        size_t const number_of_columns = std::ranges::distance(simd_seq1_collection) + 1;
+        size_t const number_of_rows = std::ranges::distance(simd_seq2_collection) + 1;
+
+        alignment_matrix.resize(column_index_type{number_of_columns}, row_index_type{number_of_rows});
+        index_matrix.resize(column_index_type{number_of_columns}, row_index_type{number_of_rows});
+
+        compute_matrix(simd_seq1_collection, simd_seq2_collection, alignment_matrix, index_matrix);
 
         size_t index = 0;
         for (auto && [sequence_pair, idx] : indexed_sequence_pairs)
@@ -232,31 +252,37 @@ protected:
     /*!\brief Compute the actual alignment.
      * \tparam sequence1_t The type of the first sequence; must model std::ranges::forward_range.
      * \tparam sequence2_t The type of the second sequence; must model std::ranges::forward_range.
+     * \tparam alignment_matrix_t The type of the alignment matrix; must model std::ranges::input_range and its
+     *                            std::ranges::range_reference_t type must model std::ranges::forward_range.
+     * \tparam index_matrix_t The type of the index matrix; must model std::ranges::input_range and its
+     *                            std::ranges::range_reference_t type must model std::ranges::forward_range.
      *
      * \param[in] sequence1 The first sequence to compute the alignment for.
      * \param[in] sequence2 The second sequence to compute the alignment for.
+     * \param[in] alignment_matrix The alignment matrix to compute.
+     * \param[in] index_matrix The index matrix corresponding to the alignment matrix.
      */
-    template <std::ranges::forward_range sequence1_t, std::ranges::forward_range sequence2_t>
-    void compute_matrix(sequence1_t && sequence1, sequence2_t && sequence2)
+    template <std::ranges::forward_range sequence1_t,
+              std::ranges::forward_range sequence2_t,
+              std::ranges::input_range alignment_matrix_t,
+              std::ranges::input_range index_matrix_t>
+    //!\cond
+        requires std::ranges::forward_range<std::ranges::range_reference_t<alignment_matrix_t>> &&
+                 std::ranges::forward_range<std::ranges::range_reference_t<index_matrix_t>>
+    //!\endcond
+    void compute_matrix(sequence1_t && sequence1,
+                        sequence2_t && sequence2,
+                        alignment_matrix_t && alignment_matrix,
+                        index_matrix_t && index_matrix)
     {
         // ---------------------------------------------------------------------
         // Initialisation phase: allocate memory and initialise first column.
         // ---------------------------------------------------------------------
-        using matrix_index_t = typename traits_type::matrix_index_type;
 
         this->reset_optimum(); // Reset the tracker for the new alignment computation.
 
-        thread_local score_matrix_single_column<score_type> local_score_matrix{};
-        coordinate_matrix<matrix_index_t> local_index_matrix{};
-
-        size_t number_of_columns = std::ranges::distance(sequence1) + 1;
-        size_t number_of_rows = std::ranges::distance(sequence2) + 1;
-
-        local_score_matrix.resize(column_index_type{number_of_columns}, row_index_type{number_of_rows});
-        local_index_matrix.resize(column_index_type{number_of_columns}, row_index_type{number_of_rows});
-
-        auto alignment_matrix_it = local_score_matrix.begin();
-        auto indexed_matrix_it = local_index_matrix.begin();
+        auto alignment_matrix_it = alignment_matrix.begin();
+        auto indexed_matrix_it = index_matrix.begin();
 
         initialise_column(*alignment_matrix_it, *indexed_matrix_it, sequence2);
 

--- a/include/seqan3/alignment/pairwise/detail/pairwise_alignment_algorithm.hpp
+++ b/include/seqan3/alignment/pairwise/detail/pairwise_alignment_algorithm.hpp
@@ -15,18 +15,12 @@
 #include <seqan3/std/concepts>
 #include <seqan3/std/ranges>
 
-#include <seqan3/alignment/configuration/align_config_gap.hpp>
-#include <seqan3/alignment/configuration/align_config_scoring.hpp>
-#include <seqan3/alignment/matrix/detail/coordinate_matrix.hpp>
-#include <seqan3/alignment/matrix/detail/score_matrix_single_column.hpp>
 #include <seqan3/alignment/pairwise/detail/type_traits.hpp>
-#include <seqan3/alignment/scoring/gap_scheme.hpp>
 #include <seqan3/core/detail/empty_type.hpp>
 #include <seqan3/core/detail/type_inspection.hpp>
 #include <seqan3/core/simd/view_to_simd.hpp>
 #include <seqan3/range/container/aligned_allocator.hpp>
 #include <seqan3/range/views/get.hpp>
-#include <seqan3/range/views/zip.hpp>
 
 namespace seqan3::detail
 {

--- a/include/seqan3/alignment/pairwise/detail/pairwise_alignment_algorithm.hpp
+++ b/include/seqan3/alignment/pairwise/detail/pairwise_alignment_algorithm.hpp
@@ -137,19 +137,14 @@ public:
     //!\endcond
     void operator()(indexed_sequence_pairs_t && indexed_sequence_pairs, callback_t && callback)
     {
-        using matrix_index_t = typename traits_type::matrix_index_type;
         using std::get;
-
-        thread_local score_matrix_single_column<score_type> alignment_matrix{};
-        coordinate_matrix<matrix_index_t> index_matrix{};
 
         for (auto && [sequence_pair, idx] : indexed_sequence_pairs)
         {
-            size_t number_of_columns = std::ranges::distance(get<0>(sequence_pair)) + 1;
-            size_t number_of_rows = std::ranges::distance(get<1>(sequence_pair)) + 1;
+            size_t const sequence1_size = std::ranges::distance(get<0>(sequence_pair));
+            size_t const sequence2_size = std::ranges::distance(get<1>(sequence_pair));
 
-            alignment_matrix.resize(column_index_type{number_of_columns}, row_index_type{number_of_rows});
-            index_matrix.resize(column_index_type{number_of_columns}, row_index_type{number_of_rows});
+            auto && [alignment_matrix, index_matrix] = this->acquire_matrices(sequence1_size, sequence2_size);
 
             compute_matrix(get<0>(sequence_pair), get<1>(sequence_pair), alignment_matrix, index_matrix);
             this->make_result_and_invoke(std::forward<decltype(sequence_pair)>(sequence_pair),

--- a/include/seqan3/alignment/pairwise/detail/pairwise_alignment_algorithm_banded.hpp
+++ b/include/seqan3/alignment/pairwise/detail/pairwise_alignment_algorithm_banded.hpp
@@ -15,7 +15,6 @@
 #include <seqan3/std/concepts>
 #include <seqan3/std/ranges>
 
-#include <seqan3/alignment/exception.hpp>
 #include <seqan3/alignment/pairwise/detail/pairwise_alignment_algorithm.hpp>
 #include <seqan3/range/views/drop.hpp>
 #include <seqan3/range/views/take.hpp>

--- a/include/seqan3/alignment/pairwise/detail/pairwise_alignment_algorithm_banded.hpp
+++ b/include/seqan3/alignment/pairwise/detail/pairwise_alignment_algorithm_banded.hpp
@@ -111,8 +111,6 @@ public:
             size_t const sequence1_size = std::ranges::distance(get<0>(sequence_pair));
             size_t const sequence2_size = std::ranges::distance(get<1>(sequence_pair));
 
-            check_valid_band_configuration(sequence1_size, sequence2_size);
-
             auto && [alignment_matrix, index_matrix] = this->acquire_matrices(sequence1_size,
                                                                               sequence2_size,
                                                                               this->lowest_viable_score());
@@ -128,27 +126,6 @@ public:
     //!\}
 
 protected:
-    /*!\brief Checks whether the band is valid for the given sequence sizes.
-     *
-     * \param[in] sequence1_size The size of the first sequence.
-     * \param[in] sequence2_size The size of the second sequence.
-     *
-     * \throws seqan3::invalid_alignment_configuration if the band is invalid for the given sequence sizes and the
-     *         alignment configuration.
-     */
-    void check_valid_band_configuration(size_t const sequence1_size, size_t const sequence2_size) const
-    {
-        bool const upper_diagonal_ends_before_last_cell = (upper_diagonal + sequence2_size) < sequence1_size;
-        bool const lower_diagonal_ends_behind_last_cell = (-lower_diagonal + sequence1_size) < sequence2_size;
-
-        bool const invalid_band = (lower_diagonal_ends_behind_last_cell && !this->test_last_column_cell) || // band ends in last column but does not use free ends,
-                                  (upper_diagonal_ends_before_last_cell && !this->test_last_row_cell); // band ends in last row but does not use free ends.
-
-        if (invalid_band)
-            throw invalid_alignment_configuration{"The selected band [" + std::to_string(lower_diagonal) + ":" +
-                                                  std::to_string(upper_diagonal) + "] does not cover the last cell."};
-    }
-
     /*!\brief Compute the actual banded alignment.
      * \tparam sequence1_t The type of the first sequence; must model std::ranges::forward_range.
      * \tparam sequence2_t The type of the second sequence; must model std::ranges::forward_range.

--- a/include/seqan3/alignment/pairwise/detail/pairwise_alignment_algorithm_banded.hpp
+++ b/include/seqan3/alignment/pairwise/detail/pairwise_alignment_algorithm_banded.hpp
@@ -106,24 +106,16 @@ public:
     {
         using std::get;
 
-        thread_local score_matrix_single_column<score_type> alignment_matrix{};
-        coordinate_matrix<uint32_t> index_matrix{};
-        size_t const band_size = upper_diagonal - lower_diagonal + 1;
-
         for (auto && [sequence_pair, idx] : indexed_sequence_pairs)
         {
-            size_t sequence1_size = std::ranges::distance(get<0>(sequence_pair));
-            size_t sequence2_size = std::ranges::distance(get<1>(sequence_pair));
+            size_t const sequence1_size = std::ranges::distance(get<0>(sequence_pair));
+            size_t const sequence2_size = std::ranges::distance(get<1>(sequence_pair));
 
             check_valid_band_configuration(sequence1_size, sequence2_size);
 
-            size_t const number_of_columns = sequence1_size + 1;
-            size_t const number_of_rows = sequence2_size + 1;
-
-            alignment_matrix.resize(column_index_type{number_of_columns},
-                                    row_index_type{band_size + 1},
-                                    this->lowest_viable_score());
-            index_matrix.resize(column_index_type{number_of_columns}, row_index_type{number_of_rows});
+            auto && [alignment_matrix, index_matrix] = this->acquire_matrices(sequence1_size,
+                                                                              sequence2_size,
+                                                                              this->lowest_viable_score());
 
             compute_matrix(get<0>(sequence_pair), get<1>(sequence_pair), alignment_matrix, index_matrix);
             this->make_result_and_invoke(std::forward<decltype(sequence_pair)>(sequence_pair),

--- a/include/seqan3/alignment/pairwise/detail/pairwise_alignment_algorithm_banded.hpp
+++ b/include/seqan3/alignment/pairwise/detail/pairwise_alignment_algorithm_banded.hpp
@@ -48,11 +48,6 @@ protected:
     static_assert(!std::same_as<alignment_result_type, empty_type>, "Alignment result type was not configured.");
     static_assert(traits_type::is_banded, "Alignment configuration must have band configured.");
 
-    //!\brief The selected lower diagonal.
-    int32_t lower_diagonal{};
-    //!\brief The selected upper diagonal.
-    int32_t upper_diagonal{};
-
 public:
     /*!\name Constructors, destructor and assignment
      * \{
@@ -71,27 +66,10 @@ public:
      *
      * Initialises the algorithm given the user settings from the alignment configuration object.
      *
-     * \throws seqan3::invalid_alignment_configuration if the given band settings are invalid.
+     * \throws seqan3::invalid_alignment_configuration.
      */
     pairwise_alignment_algorithm_banded(alignment_configuration_t const & config) : base_algorithm_t(config)
-    {
-        using seqan3::get;
-
-        auto band = get<seqan3::align_cfg::band_fixed_size>(config);
-
-        lower_diagonal = band.lower_diagonal.get();
-        upper_diagonal = band.upper_diagonal.get();
-
-        // Band is invalid if ...
-        bool const invalid_band = upper_diagonal < lower_diagonal || // upper diagonal is smaller than lower diagonal,
-                                  (upper_diagonal < 0 && !this->first_column_is_free) || // band starts in first column but does not use free ends,
-                                  (lower_diagonal > 0 && !this->first_row_is_free); // band starts in first row but does not use free ends.
-
-        if (invalid_band)
-            throw invalid_alignment_configuration{"The selected band [" + std::to_string(lower_diagonal) + ":" +
-                                                  std::to_string(upper_diagonal) + "] is not valid for the "
-                                                  "configured alignment because the optimum cannot be computed."};
-    }
+    {}
     //!\}
 
     /*!\name Invocation
@@ -200,8 +178,8 @@ protected:
         auto alignment_matrix_it = alignment_matrix.begin();
         auto indexed_matrix_it = index_matrix.begin();
 
-        size_t row_size = std::max<int32_t>(0, -lower_diagonal);
-        size_t const column_size = std::max<int32_t>(0, upper_diagonal);
+        size_t row_size = std::max<int32_t>(0, -this->lower_diagonal);
+        size_t const column_size = std::max<int32_t>(0, this->upper_diagonal);
         this->initialise_column(*alignment_matrix_it, *indexed_matrix_it, sequence2 | views::take(row_size));
 
         // ---------------------------------------------------------------------

--- a/include/seqan3/alignment/pairwise/detail/policy_alignment_matrix.hpp
+++ b/include/seqan3/alignment/pairwise/detail/policy_alignment_matrix.hpp
@@ -49,6 +49,8 @@ class policy_alignment_matrix
 protected:
     //!\brief The configured score type.
     using score_type = typename traits_t::score_type;
+    //!\brief The configured matrix index type to store the coordinates.
+    using matrix_index_type = typename traits_t::matrix_index_type;
 
     /*!\name Constructors, destructor and assignment
      * \{
@@ -95,7 +97,7 @@ protected:
                           score_type initial_score = score_type{}) const
     {
         static thread_local alignment_matrix_t alignment_matrix{};
-        static thread_local coordinate_matrix<uint32_t> index_matrix{};
+        static thread_local coordinate_matrix<matrix_index_type> index_matrix{};
 
         // Increase dimension by one for the initialisation of the matrix.
         size_t const column_count = sequence1_size + 1;

--- a/include/seqan3/alignment/pairwise/detail/policy_alignment_matrix.hpp
+++ b/include/seqan3/alignment/pairwise/detail/policy_alignment_matrix.hpp
@@ -1,0 +1,110 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides seqan3::detail::policy_alignment_matrix.
+ * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <tuple>
+
+#include <seqan3/alignment/matrix/detail/coordinate_matrix.hpp>
+#include <seqan3/alignment/pairwise/detail/type_traits.hpp>
+#include <seqan3/core/algorithm/configuration.hpp>
+#include <seqan3/core/type_traits/template_inspection.hpp>
+
+namespace seqan3::detail
+{
+
+/*!\brief A policy that provides a common interface to acquire the correct alignment matrices.
+ * \ingroup pairwise_alignment
+ *
+ * \tparam traits_t The alignment configuration traits type; must be an instance of
+ *                  seqan3::detail::alignment_configuration_traits.
+ * \tparam alignment_matrix_t The type of the alignment matrix for this alignment configuration
+ *                            [see requirements below].
+ *
+ * \details
+ *
+ * The alignment matrix must be a matrix type that is compatible with the configured alignment algorithm. It must offer
+ * a resize member function that takes a seqan3::detail::column_index_type and seqan3::detail::row_index_type and an
+ * additional parameter to initialise the allocated matrix memory.
+ */
+template <typename traits_t, typename alignment_matrix_t>
+//!\cond
+    requires (is_type_specialisation_of_v<traits_t, alignment_configuration_traits> &&
+              requires (alignment_matrix_t & matrix, typename traits_t::score_type const initial_score)
+              {
+                  { matrix.resize(column_index_type{size_t{}}, row_index_type{size_t{}}, initial_score) };
+              })
+//!\endcond
+class policy_alignment_matrix
+{
+protected:
+    //!\brief The configured score type.
+    using score_type = typename traits_t::score_type;
+
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    policy_alignment_matrix() = default; //!< Defaulted.
+    policy_alignment_matrix(policy_alignment_matrix const &) = default; //!< Defaulted.
+    policy_alignment_matrix(policy_alignment_matrix &&) = default; //!< Defaulted.
+    policy_alignment_matrix & operator=(policy_alignment_matrix const &) = default; //!< Defaulted.
+    policy_alignment_matrix & operator=(policy_alignment_matrix &&) = default; //!< Defaulted.
+    ~policy_alignment_matrix() = default; //!< Defaulted.
+
+    /*!\brief Construction and initialisation using the alignment configuration.
+     * \param[in] config The alignment configuration [not used in this context].
+     */
+    template <typename alignment_configuration_t>
+    //!\cond
+        requires (is_type_specialisation_of_v<alignment_configuration_t, configuration>)
+    //!\endcond
+    policy_alignment_matrix(alignment_configuration_t const & SEQAN3_DOXYGEN_ONLY(config))
+    {}
+    //!\}
+
+    /*!\brief Acquires a new thread local alignment and index matrix for the given sequence sizes.
+     *
+     * \param[in] sequence1_size The size of the first sequence.
+     * \param[in] sequence2_size The size of the second sequence.
+     * \param[in] initial_score The initial score used for the acquired alignment matrix.
+     *
+     * \returns A std::tuple storing lvalue references to the thread local alignment and index matrix.
+     *
+     * \details
+     *
+     * Acquires a thread local alignment and index matrix. Initialises the matrices with the given
+     * sequence sizes and the initial score value.
+     *
+     * ### Exception
+     *
+     * Might throw std::bad_alloc if the requested matrix size exceeds the available memory.
+     *
+     * \throws std::bad_alloc
+     */
+    auto acquire_matrices(size_t const sequence1_size,
+                          size_t const sequence2_size,
+                          score_type initial_score = score_type{}) const
+    {
+        static thread_local alignment_matrix_t alignment_matrix{};
+        static thread_local coordinate_matrix<uint32_t> index_matrix{};
+
+        // Increase dimension by one for the initialisation of the matrix.
+        size_t const column_count = sequence1_size + 1;
+        size_t const row_count = sequence2_size + 1;
+
+        alignment_matrix.resize(column_index_type{column_count}, row_index_type{row_count}, initial_score);
+        index_matrix.resize(column_index_type{column_count}, row_index_type{row_count});
+
+        return std::tie(alignment_matrix, index_matrix);
+    }
+};
+} // namespace seqan3::detail


### PR DESCRIPTION
part of #1908 

Introduces a policy to configure and acquire the alignment matrices. 
It also unifies the initialisation interface for the banded and unbanded alignment algorithm.
This prepares the code to allow different alignment matrix implementations later. Thus, if the alignment is required the alignment matrix will be augmented with the trace matrix to store the trace pointer. Later we want to have different trace pointer implementations, for example to only store the trace checkpoints in the wavefront execution mode.