### PR TITLE
Optimise alignment/part4 enable computation of end position

### DIFF
--- a/include/seqan3/alignment/pairwise/alignment_configurator.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_configurator.hpp
@@ -513,7 +513,7 @@ private:
                       (traits_t::is_banded && traits_t::with_free_end_gaps) || // banded and with free end gaps,
                       traits_t::is_vectorised ||                               // it is vectorised,
                       traits_t::is_debug ||                                    // it runs in debug mode,
-                      traits_t::result_type_rank > 0)                          // it computes more than the score.
+                      traits_t::result_type_rank > 1)                          // it computes more than the end position.
         {
             using matrix_policy_t = typename select_matrix_policy<traits_t>::type;
             using gap_policy_t = typename select_gap_policy<traits_t>::type;

--- a/include/seqan3/alignment/pairwise/detail/pairwise_alignment_algorithm.hpp
+++ b/include/seqan3/alignment/pairwise/detail/pairwise_alignment_algorithm.hpp
@@ -146,7 +146,8 @@ public:
             compute_matrix(get<0>(sequence_pair), get<1>(sequence_pair));
             this->make_result_and_invoke(std::forward<decltype(sequence_pair)>(sequence_pair),
                                          std::move(idx),
-                                         this->tracked_optimum(),
+                                         this->optimal_score,
+                                         this->optimal_coordinate,
                                          callback);
         }
     }

--- a/include/seqan3/alignment/pairwise/detail/pairwise_alignment_algorithm_banded.hpp
+++ b/include/seqan3/alignment/pairwise/detail/pairwise_alignment_algorithm_banded.hpp
@@ -106,7 +106,8 @@ public:
             compute_matrix(get<0>(sequence_pair), get<1>(sequence_pair));
             this->make_result_and_invoke(std::forward<decltype(sequence_pair)>(sequence_pair),
                                          std::move(idx),
-                                         this->tracked_optimum(),
+                                         this->optimal_score,
+                                         this->optimal_coordinate,
                                          callback);
         }
     }

--- a/include/seqan3/alignment/pairwise/detail/policy_alignment_result_builder.hpp
+++ b/include/seqan3/alignment/pairwise/detail/policy_alignment_result_builder.hpp
@@ -69,11 +69,13 @@ protected:
      * \tparam sequence_pair_t The type of the sequence pair.
      * \tparam id_t The type of the id.
      * \tparam score_t The type of the score.
+     * \tparam matrix_coordinate_t The type of the matrix coordinate.
      * \tparam callback_t The type of the callback to invoke.
      *
      * \param[in] sequence_pair The indexed sequence pair.
      * \param[in] id The associated id.
      * \param[in] score The best alignment score.
+     * \param[in] end_positions The matrix coordinate of the best alignment score.
      * \param[in] callback The callback to invoke with the generated result.
      *
      * \details
@@ -83,13 +85,18 @@ protected:
      * work is done to generate the requested result. For example computing the associated alignment from the traceback
      * matrix.
      */
-    template <typename sequence_pair_t, typename index_t, typename score_t, typename callback_t>
+    template <typename sequence_pair_t,
+              typename index_t,
+              typename score_t,
+              typename matrix_coordinate_t,
+              typename callback_t>
     //!\cond
         requires std::invocable<callback_t, result_type>
     //!\endcond
     void make_result_and_invoke([[maybe_unused]] sequence_pair_t && sequence_pair,
                                 [[maybe_unused]] index_t && id,
                                 [[maybe_unused]] score_t score,
+                                [[maybe_unused]] matrix_coordinate_t end_positions,
                                 callback_t && callback)
     {
         using std::get;
@@ -106,6 +113,15 @@ protected:
             static_assert(!std::same_as<decltype(result.data.score), invalid_t>,
                           "Invalid configuration. Expected result with score!");
             result.data.score = std::move(score);
+        }
+
+        if constexpr (traits_type::compute_back_coordinate)
+        {
+            static_assert(!std::same_as<decltype(result.data.back_coordinate), invalid_t>,
+                          "Invalid configuration. Expected result with end positions!");
+
+            result.data.back_coordinate.first = end_positions.col;
+            result.data.back_coordinate.second = end_positions.row;
         }
 
        // TODO: Add other result.data like sequence1_begin_position, sequence1_end_position, and so on.

--- a/include/seqan3/alignment/pairwise/detail/policy_optimum_tracker.hpp
+++ b/include/seqan3/alignment/pairwise/detail/policy_optimum_tracker.hpp
@@ -47,7 +47,7 @@ template <typename alignment_configuration_t>
 //!\endcond
 class policy_optimum_tracker
 {
-private:
+protected:
     //!\brief The configuration traits type.
     using traits_type = alignment_configuration_traits<alignment_configuration_t>;
     //!\brief The configured score type.
@@ -85,7 +85,6 @@ private:
         optimal_coordinate = is_better_score ? std::move(coordinate) : optimal_coordinate;
     }
 
-protected:
     /*!\name Constructors, destructor and assignment
      * \{
      */


### PR DESCRIPTION
part of #1908 

resolves seqan/product_backlog#73

Enables the computation of the end position in the new optimised alignment algorithm.