### PR TITLE
Alignment configuration free end gaps

### DIFF
--- a/doc/tutorial/introduction/introduction_align.cpp
+++ b/doc/tutorial/introduction/introduction_align.cpp
@@ -36,7 +36,7 @@ int main()
 
     // Call a global pairwise alignment with edit distance and traceback.
     for (auto && res : align_pairwise(std::tie(sequences[0], sequences[1]),
-                                      seqan3::align_cfg::method_global |
+                                      seqan3::align_cfg::method_global{} |
                                       seqan3::align_cfg::edit_scheme | seqan3::align_cfg::result{seqan3::with_alignment}))
     {
         // Print the resulting score and the alignment.

--- a/doc/tutorial/pairwise_alignment/configurations.cpp
+++ b/doc/tutorial/pairwise_alignment/configurations.cpp
@@ -101,7 +101,7 @@ auto cfg = seqan3::align_cfg::band_fixed_size{seqan3::align_cfg::lower_diagonal{
 //! [edit]
 
 // Configure an edit distance alignment.
-auto cfg = seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme;
+auto cfg = seqan3::align_cfg::method_global{} | seqan3::align_cfg::edit_scheme;
 //! [edit]
 (void) cfg;
 }

--- a/doc/tutorial/pairwise_alignment/pa_assignment_3_solution.cpp
+++ b/doc/tutorial/pairwise_alignment/pa_assignment_3_solution.cpp
@@ -27,7 +27,7 @@ int main()
     }
 
     // Configure the alignment kernel.
-    auto config = seqan3::align_cfg::method_global |
+    auto config = seqan3::align_cfg::method_global{} |
                   seqan3::align_cfg::scoring{seqan3::aminoacid_scoring_scheme{
                       seqan3::aminoacid_similarity_matrix::BLOSUM62}} |
                   seqan3::align_cfg::aligned_ends{seqan3::free_ends_second};

--- a/doc/tutorial/pairwise_alignment/pairwise_alignment_first_global.cpp
+++ b/doc/tutorial/pairwise_alignment/pairwise_alignment_first_global.cpp
@@ -13,7 +13,7 @@ int main()
     seqan3::dna4_vector s2 = "ACGAAGACCGAT"_dna4;
 
     // Configure the alignment kernel.
-    auto config = seqan3::align_cfg::method_global |
+    auto config = seqan3::align_cfg::method_global{} |
                   seqan3::align_cfg::scoring{seqan3::nucleotide_scoring_scheme{}};
 
     // Invoke the pairwise alignment which returns a lazy range over alignment results.

--- a/doc/tutorial/pairwise_alignment/pairwise_alignment_solution_1.cpp
+++ b/doc/tutorial/pairwise_alignment/pairwise_alignment_solution_1.cpp
@@ -17,7 +17,7 @@ int main()
                     "AGGTACGAGCGACACT"_dna4};
 
     // Configure the alignment kernel.
-    auto config = seqan3::align_cfg::method_global |
+    auto config = seqan3::align_cfg::method_global{} |
                   seqan3::align_cfg::scoring{seqan3::nucleotide_scoring_scheme{}};
 
     for (auto const & res : seqan3::align_pairwise(seqan3::views::pairwise_combine(vec), config))

--- a/doc/tutorial/pairwise_alignment/pairwise_alignment_solution_2.cpp
+++ b/doc/tutorial/pairwise_alignment/pairwise_alignment_solution_2.cpp
@@ -17,7 +17,7 @@ int main()
                     "AGGTACGAGCGACACT"_dna4};
 
     // Configure the alignment kernel.
-    auto config = seqan3::align_cfg::method_global |
+    auto config = seqan3::align_cfg::method_global{} |
                   seqan3::align_cfg::scoring{seqan3::nucleotide_scoring_scheme{}} |
                   seqan3::align_cfg::aligned_ends{seqan3::free_ends_first};
 

--- a/doc/tutorial/pairwise_alignment/pairwise_alignment_solution_3.cpp
+++ b/doc/tutorial/pairwise_alignment/pairwise_alignment_solution_3.cpp
@@ -13,7 +13,7 @@ int main()
     auto seq2 = "AFLPGWQEENKLSKIWMKDCGCLW"_aa27;
 
     // Configure the alignment kernel.
-    auto config = seqan3::align_cfg::method_global |
+    auto config = seqan3::align_cfg::method_global{} |
                   seqan3::align_cfg::scoring{seqan3::aminoacid_scoring_scheme{
                       seqan3::aminoacid_similarity_matrix::BLOSUM62}} |
                   seqan3::align_cfg::gap{seqan3::gap_scheme{seqan3::gap_score{-2}, seqan3::gap_open_score{-9}}};

--- a/doc/tutorial/pairwise_alignment/pairwise_alignment_solution_4.cpp
+++ b/doc/tutorial/pairwise_alignment/pairwise_alignment_solution_4.cpp
@@ -13,7 +13,7 @@ int main()
     auto seq2 = "GGACGACATGACGTACGACTTTACGTACGACTAGC"_dna4;
 
     // Configure the alignment kernel.
-    auto config = seqan3::align_cfg::method_global |
+    auto config = seqan3::align_cfg::method_global{} |
                   seqan3::align_cfg::scoring{seqan3::nucleotide_scoring_scheme{
                       seqan3::match_score{4}, seqan3::mismatch_score{-2}}} |
                   seqan3::align_cfg::gap{seqan3::gap_scheme{seqan3::gap_score{-4}}} |

--- a/doc/tutorial/pairwise_alignment/pairwise_alignment_solution_5.cpp
+++ b/doc/tutorial/pairwise_alignment/pairwise_alignment_solution_5.cpp
@@ -13,7 +13,7 @@ int main()
     auto seq2 = "GGACGACATGACGTACGACTTTACGTACGACTAGC"_dna4;
 
     // Configure the alignment kernel.
-    auto config = seqan3::align_cfg::method_global |
+    auto config = seqan3::align_cfg::method_global{} |
                   seqan3::align_cfg::scoring{seqan3::nucleotide_scoring_scheme{
                       seqan3::match_score{4}, seqan3::mismatch_score{-2}}} |
                   seqan3::align_cfg::gap{seqan3::gap_scheme{seqan3::gap_score{-4}}} |

--- a/doc/tutorial/pairwise_alignment/pairwise_alignment_solution_6.cpp
+++ b/doc/tutorial/pairwise_alignment/pairwise_alignment_solution_6.cpp
@@ -18,7 +18,7 @@ int main()
                     "AGGTACGAGCGACACT"_dna4};
 
     // Configure the alignment kernel.
-    auto config = seqan3::align_cfg::method_global |
+    auto config = seqan3::align_cfg::method_global{} |
                   seqan3::align_cfg::edit_scheme |
                   seqan3::align_cfg::max_error{7u} |
                   seqan3::align_cfg::result{seqan3::with_score};

--- a/doc/tutorial/read_mapper/read_mapper_step3.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_step3.cpp
@@ -53,7 +53,7 @@ void map_reads(std::filesystem::path const & query_path,
                                                 seqan3::search_cfg::hit_all_best;
 
 //! [alignment_config]
-    seqan3::configuration const align_config = seqan3::align_cfg::method_global |
+    seqan3::configuration const align_config = seqan3::align_cfg::method_global{} |
                                                seqan3::align_cfg::edit_scheme |
                                                seqan3::align_cfg::aligned_ends{seqan3::free_ends_first} |
                                                seqan3::align_cfg::result{seqan3::with_alignment};

--- a/doc/tutorial/read_mapper/read_mapper_step4.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_step4.cpp
@@ -62,7 +62,7 @@ void map_reads(std::filesystem::path const & query_path,
                                                     seqan3::search_cfg::error_count{errors}} |
                                                 seqan3::search_cfg::hit_all_best;
 
-    seqan3::configuration const align_config = seqan3::align_cfg::method_global |
+    seqan3::configuration const align_config = seqan3::align_cfg::method_global{} |
                                                seqan3::align_cfg::edit_scheme |
                                                seqan3::align_cfg::aligned_ends{seqan3::free_ends_first} |
                                                seqan3::align_cfg::result{seqan3::with_alignment};

--- a/doc/tutorial/search/search_solution5.cpp
+++ b/doc/tutorial/search/search_solution5.cpp
@@ -19,7 +19,7 @@ void run_text_single()
 
     seqan3::configuration const search_config = seqan3::search_cfg::max_error_total{seqan3::search_cfg::error_count{1}} |
                                                 seqan3::search_cfg::hit_all_best;
-    seqan3::configuration const align_config = seqan3::align_cfg::method_global |
+    seqan3::configuration const align_config = seqan3::align_cfg::method_global{} |
                                                seqan3::align_cfg::edit_scheme |
                                                seqan3::align_cfg::aligned_ends{seqan3::free_ends_first} |
                                                seqan3::align_cfg::result{seqan3::with_alignment};
@@ -56,7 +56,7 @@ void run_text_collection()
 
     seqan3::configuration const search_config = seqan3::search_cfg::max_error_total{seqan3::search_cfg::error_count{1}} |
                                                 seqan3::search_cfg::hit_all_best;
-    seqan3::configuration const align_config = seqan3::align_cfg::method_global |
+    seqan3::configuration const align_config = seqan3::align_cfg::method_global{} |
                                                seqan3::align_cfg::edit_scheme |
                                                seqan3::align_cfg::aligned_ends{seqan3::free_ends_first} |
                                                seqan3::align_cfg::result{seqan3::with_alignment};

--- a/include/seqan3/alignment/configuration/align_config_method.hpp
+++ b/include/seqan3/alignment/configuration/align_config_method.hpp
@@ -18,6 +18,7 @@
 #include <seqan3/alignment/configuration/detail.hpp>
 #include <seqan3/core/algorithm/pipeable_config_element.hpp>
 #include <seqan3/core/detail/empty_type.hpp>
+#include <seqan3/core/detail/strong_type.hpp>
 
 namespace seqan3::detail
 {
@@ -62,6 +63,46 @@ namespace seqan3::align_cfg
  * \include test/snippet/alignment/configuration/minimal_alignment_config.cpp
  */
 inline constexpr seqan3::detail::method_local_tag method_local{};
+
+/*!\brief A strong type representing free_end_gaps_sequence1_leading of the seqan3::align_cfg::method_global.
+ * \ingroup alignment_configuration
+ */
+struct free_end_gaps_sequence1_leading : public seqan3::detail::strong_type<bool, free_end_gaps_sequence1_leading>
+{
+    //!\brief The type of the strong type base class.
+    using base_t = seqan3::detail::strong_type<bool, free_end_gaps_sequence1_leading>;
+    using base_t::base_t; // Import the base class constructors
+};
+
+/*!\brief A strong type representing free_end_gaps_sequence2_leading of the seqan3::align_cfg::method_global.
+ * \ingroup alignment_configuration
+ */
+struct free_end_gaps_sequence2_leading : public seqan3::detail::strong_type<bool, free_end_gaps_sequence2_leading>
+{
+    //!\brief The type of the strong type base class.
+    using base_t = seqan3::detail::strong_type<bool, free_end_gaps_sequence2_leading>;
+    using base_t::base_t; // Import the base class constructors
+};
+
+/*!\brief A strong type representing free_end_gaps_sequence1_trailing of the seqan3::align_cfg::method_global.
+ * \ingroup alignment_configuration
+ */
+struct free_end_gaps_sequence1_trailing : public seqan3::detail::strong_type<bool, free_end_gaps_sequence1_trailing>
+{
+    //!\brief The type of the strong type base class.
+    using base_t = seqan3::detail::strong_type<bool, free_end_gaps_sequence1_trailing>;
+    using base_t::base_t; // Import the base class constructors
+};
+
+/*!\brief A strong type representing free_end_gaps_sequence2_trailing of the seqan3::align_cfg::method_global.
+ * \ingroup alignment_configuration
+ */
+struct free_end_gaps_sequence2_trailing : public seqan3::detail::strong_type<bool, free_end_gaps_sequence2_trailing>
+{
+    //!\brief The type of the strong type base class.
+    using base_t = seqan3::detail::strong_type<bool, free_end_gaps_sequence2_trailing>;
+    using base_t::base_t; // Import the base class constructors
+};
 
 /*!\brief Sets the global alignment method.
  * \ingroup alignment_configuration

--- a/include/seqan3/alignment/configuration/align_config_method.hpp
+++ b/include/seqan3/alignment/configuration/align_config_method.hpp
@@ -23,15 +23,6 @@
 namespace seqan3::detail
 {
 
-//!\brief A strong type to select the global alignment method.
-//!\ingroup alignment_configuration
-struct method_global_tag : public pipeable_config_element<method_global_tag>
-{
-    //!\privatesection
-    //!\brief An internal id used to check for a valid alignment configuration.
-    static constexpr detail::align_config_id id{detail::align_config_id::global};
-};
-
 //!\brief A strong type to select the local alignment method.
 //!\ingroup alignment_configuration
 struct method_local_tag : public pipeable_config_element<method_local_tag>
@@ -108,6 +99,51 @@ struct free_end_gaps_sequence2_trailing : public seqan3::detail::strong_type<boo
  * \ingroup alignment_configuration
  * \copydetails seqan3::align_cfg::method_local
  */
-inline constexpr seqan3::detail::method_global_tag method_global{};
+struct method_global : public pipeable_config_element<method_global>
+{
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    method_global() = default; //!< Defaulted.
+    method_global(method_global const &) = default; //!< Defaulted.
+    method_global(method_global &&) = default; //!< Defaulted.
+    method_global & operator=(method_global const &) = default; //!< Defaulted.
+    method_global & operator=(method_global &&) = default; //!< Defaulted.
+    ~method_global() = default; //!< Defaulted.
+
+    /*!\brief Construct method_global with a specific free end gap configuration.
+     * \param[in] free_sequence1_leading An instance of seqan3::align_cfg::free_end_gaps_sequence1_leading that
+     *                                   indicates whether leading gaps in sequence1 should be free (not penalised).
+     * \param[in] free_sequence2_leading An instance of seqan3::align_cfg::free_end_gaps_sequence2_leading that
+     *                                   indicates whether leading gaps in sequence2 should be free (not penalised).
+     * \param[in] free_sequence1_trailing An instance of seqan3::align_cfg::free_end_gaps_sequence1_trailing that
+     *                                   indicates whether trailing gaps in sequence1 should be free (not penalised).
+     * \param[in] free_sequence2_trailing An instance of seqan3::align_cfg::free_end_gaps_sequence2_trailing that
+     *                                   indicates whether trailing gaps in sequence2 should be free (not penalised).
+     */
+    constexpr method_global(seqan3::align_cfg::free_end_gaps_sequence1_leading free_sequence1_leading,
+                            seqan3::align_cfg::free_end_gaps_sequence2_leading free_sequence2_leading,
+                            seqan3::align_cfg::free_end_gaps_sequence1_trailing free_sequence1_trailing,
+                            seqan3::align_cfg::free_end_gaps_sequence2_trailing free_sequence2_trailing) noexcept :
+        free_end_gaps_sequence1_leading{free_sequence1_leading.get()},
+        free_end_gaps_sequence2_leading{free_sequence2_leading.get()},
+        free_end_gaps_sequence1_trailing{free_sequence1_trailing.get()},
+        free_end_gaps_sequence2_trailing{free_sequence2_trailing.get()}
+    {}
+    //!\}
+
+    //!\brief If set to `true`, leading gaps in sequence1 are not penalized when computing the optimal alignment.
+    seqan3::align_cfg::free_end_gaps_sequence1_leading free_end_gaps_sequence1_leading{false};
+    //!\brief If set to `true`, leading gaps in sequence2 are not penalized when computing the optimal alignment.
+    seqan3::align_cfg::free_end_gaps_sequence2_leading free_end_gaps_sequence2_leading{false};
+    //!\brief If set to `true`, trailing gaps in sequence1 are not penalized when computing the optimal alignment.
+    seqan3::align_cfg::free_end_gaps_sequence1_trailing free_end_gaps_sequence1_trailing{false};
+    //!\brief If set to `true`, trailing gaps in sequence2 are not penalized when computing the optimal alignment.
+    seqan3::align_cfg::free_end_gaps_sequence2_trailing free_end_gaps_sequence2_trailing{false};
+
+    //!\privatesection
+    //!\brief An internal id used to check for a valid alignment configuration.
+    static constexpr detail::align_config_id id{detail::align_config_id::global};
+};
 
 } // namespace seqan3::align_cfg

--- a/include/seqan3/alignment/configuration/align_config_method.hpp
+++ b/include/seqan3/alignment/configuration/align_config_method.hpp
@@ -21,48 +21,52 @@
 
 namespace seqan3::detail
 {
-    //!\brief A strong type to select the global alignment method.
-    //!\ingroup alignment_configuration
-    struct method_global_tag : public pipeable_config_element<method_global_tag>
-    {
-        //!\privatesection
-        //!\brief An internal id used to check for a valid alignment configuration.
-        static constexpr detail::align_config_id id{detail::align_config_id::global};
-    };
 
-    //!\brief A strong type to select the local alignment method.
-    //!\ingroup alignment_configuration
-    struct method_local_tag : public pipeable_config_element<method_local_tag>
-    {
-        //!\privatesection
-        //!\brief An internal id used to check for a valid alignment configuration.
-        static constexpr detail::align_config_id id{detail::align_config_id::local};
-    };
+//!\brief A strong type to select the global alignment method.
+//!\ingroup alignment_configuration
+struct method_global_tag : public pipeable_config_element<method_global_tag>
+{
+    //!\privatesection
+    //!\brief An internal id used to check for a valid alignment configuration.
+    static constexpr detail::align_config_id id{detail::align_config_id::global};
+};
+
+//!\brief A strong type to select the local alignment method.
+//!\ingroup alignment_configuration
+struct method_local_tag : public pipeable_config_element<method_local_tag>
+{
+    //!\privatesection
+    //!\brief An internal id used to check for a valid alignment configuration.
+    static constexpr detail::align_config_id id{detail::align_config_id::local};
+};
+
 } // namespace seqan3::detail
 
 namespace seqan3::align_cfg
 {
-    /*!\brief Sets the global alignment method.
-     * \ingroup alignment_configuration
-     *
-     * \details
-     *
-     * The alignment algorithm can be categorised in different methods. For example, the
-     * \ref seqan3::align_cfg::method_local "local" and the
-     * \ref seqan3::align_cfg::method_global "global" alignment are two different methods, while the semi-global alignment
-     * is a variation of the global alignment. This differentiation makes it possible to define a subset of configurations
-     * that can work with a particular method. Since it is not possible to guess what the desired method for a user is, this
-     * configuration must be provided for the alignment algorithm and cannot be defaulted.
-     *
-     * ### Example
-     *
-     * \include test/snippet/alignment/configuration/minimal_alignment_config.cpp
-     */
-    inline constexpr seqan3::detail::method_global_tag method_global{};
 
-    /*!\brief Sets the local alignment method.
-     * \ingroup alignment_configuration
-     * \copydetails seqan3::align_cfg::method_global
-     */
-    inline constexpr seqan3::detail::method_local_tag method_local{};
+/*!\brief Sets the global alignment method.
+ * \ingroup alignment_configuration
+ *
+ * \details
+ *
+ * The alignment algorithm can be categorised in different methods. For example, the
+ * \ref seqan3::align_cfg::method_local "local" and the
+ * \ref seqan3::align_cfg::method_global "global" alignment are two different methods, while the semi-global alignment
+ * is a variation of the global alignment. This differentiation makes it possible to define a subset of configurations
+ * that can work with a particular method. Since it is not possible to guess what the desired method for a user is, this
+ * configuration must be provided for the alignment algorithm and cannot be defaulted.
+ *
+ * ### Example
+ *
+ * \include test/snippet/alignment/configuration/minimal_alignment_config.cpp
+ */
+inline constexpr seqan3::detail::method_global_tag method_global{};
+
+/*!\brief Sets the local alignment method.
+ * \ingroup alignment_configuration
+ * \copydetails seqan3::align_cfg::method_global
+ */
+inline constexpr seqan3::detail::method_local_tag method_local{};
+
 } // namespace seqan3::align_cfg

--- a/include/seqan3/alignment/configuration/align_config_method.hpp
+++ b/include/seqan3/alignment/configuration/align_config_method.hpp
@@ -45,7 +45,7 @@ struct method_local_tag : public pipeable_config_element<method_local_tag>
 namespace seqan3::align_cfg
 {
 
-/*!\brief Sets the global alignment method.
+/*!\brief Sets the local alignment method.
  * \ingroup alignment_configuration
  *
  * \details
@@ -61,12 +61,12 @@ namespace seqan3::align_cfg
  *
  * \include test/snippet/alignment/configuration/minimal_alignment_config.cpp
  */
-inline constexpr seqan3::detail::method_global_tag method_global{};
-
-/*!\brief Sets the local alignment method.
- * \ingroup alignment_configuration
- * \copydetails seqan3::align_cfg::method_global
- */
 inline constexpr seqan3::detail::method_local_tag method_local{};
+
+/*!\brief Sets the global alignment method.
+ * \ingroup alignment_configuration
+ * \copydetails seqan3::align_cfg::method_local
+ */
+inline constexpr seqan3::detail::method_global_tag method_global{};
 
 } // namespace seqan3::align_cfg

--- a/include/seqan3/alignment/pairwise/alignment_configurator.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_configurator.hpp
@@ -135,7 +135,7 @@ public:
     //!\brief Expects alignment configurations.
     constexpr static bool expects_alignment_configuration()
     {
-        const bool is_global = alignment_config_type::template exists<seqan3::detail::method_global_tag>();
+        const bool is_global = alignment_config_type::template exists<seqan3::align_cfg::method_global>();
         const bool is_local = alignment_config_type::template exists<seqan3::detail::method_local_tag>();
 
         return (is_global || is_local);
@@ -321,7 +321,7 @@ public:
             auto const & scoring_scheme = get<align_cfg::scoring>(cfg).value;
             auto align_ends_cfg = config_with_result_type.get_or(align_cfg::aligned_ends{free_ends_none}).value;
 
-            if constexpr (config_t::template exists<seqan3::detail::method_global_tag>())
+            if constexpr (config_t::template exists<seqan3::align_cfg::method_global>())
             {
                 // Only use edit distance if ...
                 if (gaps.get_gap_open_score() == 0 &&  // gap open score is not set,
@@ -538,7 +538,7 @@ private:
             using result_builder_policy_t = policy_alignment_result_builder<config_t>;
 
             using alignment_method_t = typename std::conditional_t<traits_t::is_global,
-                                                                   seqan3::detail::method_global_tag,
+                                                                   seqan3::align_cfg::method_global,
                                                                    seqan3::detail::method_local_tag>;
 
             using score_t = typename traits_t::score_type;
@@ -577,7 +577,7 @@ constexpr function_wrapper_t alignment_configurator::configure_scoring_scheme(co
                                 typename traits_t::score_type,
                                 typename traits_t::scoring_scheme_alphabet_type,
                                 typename std::conditional_t<traits_t::is_global,
-                                                            seqan3::detail::method_global_tag,
+                                                            seqan3::align_cfg::method_global,
                                                             seqan3::detail::method_local_tag>>,
                             typename traits_t::scoring_scheme_type>;
 

--- a/include/seqan3/alignment/pairwise/detail/type_traits.hpp
+++ b/include/seqan3/alignment/pairwise/detail/type_traits.hpp
@@ -122,7 +122,7 @@ public:
     static constexpr bool is_parallel = configuration_t::template exists<align_cfg::parallel>();
     //!\brief Flag indicating whether global alignment method is enabled.
     static constexpr bool is_global =
-        configuration_t::template exists<seqan3::detail::method_global_tag>();
+        configuration_t::template exists<seqan3::align_cfg::method_global>();
     //!\brief Flag indicating whether global alignment mode with free ends is enabled.
     static constexpr bool with_free_end_gaps = configuration_t::template exists<align_cfg::aligned_ends>();
     //!\brief Flag indicating whether local alignment mode is enabled.

--- a/include/seqan3/alignment/scoring/detail/simd_match_mismatch_scoring_scheme.hpp
+++ b/include/seqan3/alignment/scoring/detail/simd_match_mismatch_scoring_scheme.hpp
@@ -28,7 +28,7 @@ namespace seqan3::detail
  * \tparam simd_score_t The type of the simd vector; must model seqan3::detail::simd_concept.
  * \tparam alphabet_t The type of the alphabet over which to define the scoring scheme; must model seqan3::semialphabet
  *                    and must have an alphabet size of at least 2.
- * \tparam alignment_t The type of the alignment to compute; must be either seqan3::detail::method_global_tag or
+ * \tparam alignment_t The type of the alignment to compute; must be either seqan3::align_cfg::method_global or
  *                     seqan3::detail::method_local_tag.
  *
  * \details
@@ -64,7 +64,7 @@ template <simd_concept simd_score_t, semialphabet alphabet_t, typename alignment
 //!\cond
     requires (seqan3::alphabet_size<alphabet_t> > 1) &&
              (std::same_as<alignment_t, detail::method_local_tag> ||
-              std::same_as<alignment_t, detail::method_global_tag>)
+              std::same_as<alignment_t, align_cfg::method_global>)
 //!\endcond
 class simd_match_mismatch_scoring_scheme
 {
@@ -141,7 +141,7 @@ public:
         typename simd_traits<simd_score_t>::mask_type mask;
         // For global and local alignment there are slightly different formulas because
         // in global alignment padded characters always match
-        if constexpr (std::same_as<alignment_t, detail::method_global_tag>)
+        if constexpr (std::same_as<alignment_t, align_cfg::method_global>)
             mask = (lhs ^ rhs) <= simd::fill<simd_score_t>(0);
         else // and in local alignment type padded characters always mismatch.
             mask = (lhs ^ rhs) == simd::fill<simd_score_t>(0);

--- a/include/seqan3/alignment/scoring/detail/simd_matrix_scoring_scheme.hpp
+++ b/include/seqan3/alignment/scoring/detail/simd_matrix_scoring_scheme.hpp
@@ -27,7 +27,7 @@ namespace seqan3::detail
  * \ingroup scoring
  * \tparam simd_score_t The type of the simd vector; must model seqan3::simd::simd_concept.
  * \tparam alphabet_t The type of the alphabet over which to define the scoring scheme; must model seqan3::semialphabet.
- * \tparam alignment_t The type of the alignment to compute; must be either seqan3::detail::method_global_tag or
+ * \tparam alignment_t The type of the alignment to compute; must be either seqan3::align_cfg::method_global or
  *                     seqan3::detail::method_local_tag.
  * \tparam scoring_scheme_t The type of the scoring scheme which will be used. Must model seqan3::scoring_scheme with
  *                          the given `alphabet_t`.
@@ -44,7 +44,7 @@ template <simd_concept simd_score_t, semialphabet alphabet_t, typename alignment
 //!\cond
     requires scoring_scheme<scoring_scheme_t, alphabet_t> &&
              (std::same_as<alignment_t, detail::method_local_tag> ||
-              std::same_as<alignment_t, detail::method_global_tag>)
+              std::same_as<alignment_t, align_cfg::method_global>)
 //!\endcond
 class simd_matrix_scoring_scheme
 {
@@ -101,7 +101,7 @@ public:
         {
             if (is_padded(lhs[i]) || is_padded(rhs[i]))
             {
-                if constexpr (std::same_as<alignment_t, detail::method_global_tag>)
+                if constexpr (std::same_as<alignment_t, align_cfg::method_global>)
                     result[i] = 1;
                 else
                     result[i] = -1;

--- a/test/performance/alignment/edit_distance_unbanded_benchmark.cpp
+++ b/test/performance/alignment/edit_distance_unbanded_benchmark.cpp
@@ -27,7 +27,7 @@
 #include <seqan/sequence.h>
 #endif
 
-constexpr auto edit_distance_cfg = seqan3::align_cfg::method_global |
+constexpr auto edit_distance_cfg = seqan3::align_cfg::method_global{} |
                                    seqan3::align_cfg::edit_scheme |
                                    seqan3::align_cfg::result{seqan3::with_score};
 

--- a/test/performance/alignment/global_affine_alignment_benchmark.cpp
+++ b/test/performance/alignment/global_affine_alignment_benchmark.cpp
@@ -26,7 +26,7 @@
     #include <seqan/align.h>
 #endif
 
-constexpr auto affine_cfg = seqan3::align_cfg::method_global |
+constexpr auto affine_cfg = seqan3::align_cfg::method_global{} |
                             seqan3::align_cfg::gap{seqan3::gap_scheme{seqan3::gap_score{-1},
                                                                       seqan3::gap_open_score{-10}}} |
                             seqan3::align_cfg::scoring{seqan3::nucleotide_scoring_scheme{seqan3::match_score{4},

--- a/test/performance/alignment/global_affine_alignment_parallel_benchmark.cpp
+++ b/test/performance/alignment/global_affine_alignment_parallel_benchmark.cpp
@@ -31,7 +31,7 @@
     #include <seqan/align_parallel.h>
 #endif
 
-constexpr auto affine_cfg = seqan3::align_cfg::method_global |
+constexpr auto affine_cfg = seqan3::align_cfg::method_global{} |
                             seqan3::align_cfg::gap{seqan3::gap_scheme{seqan3::gap_score{-1},
                                                                       seqan3::gap_open_score{-10}}} |
                             seqan3::align_cfg::scoring{seqan3::nucleotide_scoring_scheme{seqan3::match_score{4},

--- a/test/performance/alignment/global_affine_alignment_simd_benchmark.cpp
+++ b/test/performance/alignment/global_affine_alignment_simd_benchmark.cpp
@@ -26,7 +26,7 @@
     #include <seqan/align_parallel.h>
 #endif
 
-constexpr auto affine_cfg = seqan3::align_cfg::method_global |
+constexpr auto affine_cfg = seqan3::align_cfg::method_global{} |
                             seqan3::align_cfg::gap{seqan3::gap_scheme{seqan3::gap_score{-1},
                                                                       seqan3::gap_open_score{-10}}} |
                             seqan3::align_cfg::scoring{seqan3::nucleotide_scoring_scheme{seqan3::match_score{4},

--- a/test/performance/io/format_sam_benchmark.cpp
+++ b/test/performance/io/format_sam_benchmark.cpp
@@ -38,7 +38,7 @@ static std::string create_sam_file_string(size_t const n_queries)
         auto reference = seqan3::test::generate_sequence<seqan3::dna4>(reference_size, length_variance, seed);
 
         // align
-        auto config = seqan3::align_cfg::method_global |
+        auto config = seqan3::align_cfg::method_global{} |
                       seqan3::align_cfg::scoring{seqan3::nucleotide_scoring_scheme{seqan3::match_score{4},
                                                                                    seqan3::mismatch_score{-2}}} |
                       seqan3::align_cfg::gap{seqan3::gap_scheme{seqan3::gap_score{-1}, seqan3::gap_open_score{-10}}} |

--- a/test/snippet/alignment/configuration/align_cfg_edit_example.cpp
+++ b/test/snippet/alignment/configuration/align_cfg_edit_example.cpp
@@ -6,17 +6,17 @@
 int main()
 {
     // Computes semi global edit distance using fast-bit vector algorithm.
-    auto cfg_fast = seqan3::align_cfg::method_global |
+    auto cfg_fast = seqan3::align_cfg::method_global{} |
                     seqan3::align_cfg::edit_scheme |
                     seqan3::align_cfg::aligned_ends{seqan3::free_ends_first};
 
     // Computes semi global edit distance using slower standard pairwise algorithm.
-    auto cfg_slow = seqan3::align_cfg::method_global |
+    auto cfg_slow = seqan3::align_cfg::method_global{} |
                     seqan3::align_cfg::edit_scheme |
                     seqan3::align_cfg::aligned_ends{seqan3::free_ends_second};
 
     // Computes global edit distance allowing maximal 3 errors.
-    auto cfg_errors = seqan3::align_cfg::method_global |
+    auto cfg_errors = seqan3::align_cfg::method_global{} |
                       seqan3::align_cfg::edit_scheme |
                       seqan3::align_cfg::max_error{3u};
 }

--- a/test/snippet/alignment/configuration/minimal_alignment_config.cpp
+++ b/test/snippet/alignment/configuration/minimal_alignment_config.cpp
@@ -9,7 +9,7 @@ using seqan3::operator""_dna4;
 
 int main()
 {
-    auto min_cfg = seqan3::align_cfg::method_global |
+    auto min_cfg = seqan3::align_cfg::method_global{} |
                    seqan3::align_cfg::scoring{seqan3::nucleotide_scoring_scheme{seqan3::match_score{4}, seqan3::mismatch_score{-5}}};
 
     auto seq1 = "ACGT"_dna4;

--- a/test/snippet/alignment/pairwise/align_pairwise.cpp
+++ b/test/snippet/alignment/pairwise/align_pairwise.cpp
@@ -12,7 +12,7 @@ int main()
 //![start]
 
     // Configure the alignment kernel.
-    auto config = seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme;
+    auto config = seqan3::align_cfg::method_global{} | seqan3::align_cfg::edit_scheme;
 
     {
     //![example1]
@@ -34,7 +34,7 @@ int main()
                     std::pair{"AGTTACGAC"_dna4, "AGTAGCGATCG"_dna4}};
 
     // Compute the alignment of a single pair.
-    auto edit_config = seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme;
+    auto edit_config = seqan3::align_cfg::method_global{} | seqan3::align_cfg::edit_scheme;
 
     for (auto const & res : seqan3::align_pairwise(std::tie(vec[0].first, vec[0].second), edit_config))
         seqan3::debug_stream << "The score: " << res.score() << "\n";

--- a/test/snippet/alignment/pairwise/align_pairwise_range.cpp
+++ b/test/snippet/alignment/pairwise/align_pairwise_range.cpp
@@ -14,7 +14,7 @@ int main()
     std::vector data2{"ACGTGCGACTAG"_dna4, "ACGTACGACACG"_dna4, "AGTAGCGATCG"_dna4};
 
     // Configure the alignment kernel.
-    auto config = seqan3::align_cfg::method_global |
+    auto config = seqan3::align_cfg::method_global{} |
                   seqan3::align_cfg::scoring{seqan3::nucleotide_scoring_scheme{}};
 
     // Compute the alignment over a range of pairs.

--- a/test/snippet/alignment/pairwise/alignment_configurator.cpp
+++ b/test/snippet/alignment/pairwise/alignment_configurator.cpp
@@ -3,7 +3,7 @@
 int main()
 {
     using sequences_t = std::vector<std::pair<std::string, std::string>>;
-    using config_t = decltype(seqan3::align_cfg::method_global |
+    using config_t = decltype(seqan3::align_cfg::method_global{} |
                               seqan3::align_cfg::edit_scheme |
                               seqan3::align_cfg::result{seqan3::with_score});
 

--- a/test/snippet/alignment/pairwise/parallel_align_pairwise_with_callback.cpp
+++ b/test/snippet/alignment/pairwise/parallel_align_pairwise_with_callback.cpp
@@ -14,7 +14,7 @@ int main()
     std::vector<sequence_pair_t> sequences{100, {"AGTGCTACG"_dna4, "ACGTGCGACTAG"_dna4}};
 
     // Use edit distance with 4 threads.
-    auto const alignment_config = seqan3::align_cfg::method_global |
+    auto const alignment_config = seqan3::align_cfg::method_global{} |
                                   seqan3::align_cfg::edit_scheme |
                                   seqan3::align_cfg::parallel{4};
 

--- a/test/snippet/core/algorithm/configuration_combine.cpp
+++ b/test/snippet/core/algorithm/configuration_combine.cpp
@@ -6,7 +6,7 @@
 int main()
 {
     // Here we use the global and banded alignment configurations to show how they can be combined.
-    seqan3::configuration my_cfg = seqan3::align_cfg::method_global |
+    seqan3::configuration my_cfg = seqan3::align_cfg::method_global{} |
                                    seqan3::align_cfg::band_fixed_size{seqan3::align_cfg::lower_diagonal{-4},
                                                                       seqan3::align_cfg::upper_diagonal{4}};
 }

--- a/test/unit/alignment/configuration/align_config_common_test.cpp
+++ b/test/unit/alignment/configuration/align_config_common_test.cpp
@@ -22,7 +22,7 @@ using test_types = ::testing::Types<seqan3::align_cfg::aligned_ends<std::remove_
                                     seqan3::align_cfg::band_fixed_size,
                                     seqan3::align_cfg::gap<seqan3::gap_scheme<>>,
                                     seqan3::align_cfg::max_error,
-                                    seqan3::detail::method_global_tag,
+                                    seqan3::align_cfg::method_global,
                                     seqan3::detail::method_local_tag,
                                     seqan3::align_cfg::parallel,
                                     seqan3::align_cfg::result<>,

--- a/test/unit/alignment/configuration/align_config_method_test.cpp
+++ b/test/unit/alignment/configuration/align_config_method_test.cpp
@@ -18,7 +18,28 @@
 // pipeable_config_element_test template
 // ---------------------------------------------------------------------------------------------------------------------
 
-using config_element_types = ::testing::Types<seqan3::detail::method_global_tag,
+using config_element_types = ::testing::Types<seqan3::align_cfg::method_global,
                                               seqan3::detail::method_local_tag>;
 
 INSTANTIATE_TYPED_TEST_SUITE_P(method, pipeable_config_element_test, config_element_types, );
+
+TEST(method_global, access_member_variables)
+{
+    seqan3::align_cfg::method_global opt{}; // default construction
+
+    // all default to false
+    EXPECT_FALSE(opt.free_end_gaps_sequence1_leading.get());
+    EXPECT_FALSE(opt.free_end_gaps_sequence2_leading.get());
+    EXPECT_FALSE(opt.free_end_gaps_sequence1_trailing.get());
+    EXPECT_FALSE(opt.free_end_gaps_sequence2_trailing.get());
+
+    opt.free_end_gaps_sequence1_leading = seqan3::align_cfg::free_end_gaps_sequence1_leading{true};
+    opt.free_end_gaps_sequence2_leading = seqan3::align_cfg::free_end_gaps_sequence2_leading{true};
+    opt.free_end_gaps_sequence1_trailing = seqan3::align_cfg::free_end_gaps_sequence1_trailing{true};
+    opt.free_end_gaps_sequence2_trailing = seqan3::align_cfg::free_end_gaps_sequence2_trailing{true};
+
+    EXPECT_TRUE(opt.free_end_gaps_sequence1_leading.get());
+    EXPECT_TRUE(opt.free_end_gaps_sequence2_leading.get());
+    EXPECT_TRUE(opt.free_end_gaps_sequence1_trailing.get());
+    EXPECT_TRUE(opt.free_end_gaps_sequence2_trailing.get());
+}

--- a/test/unit/alignment/pairwise/align_pairwise_test.cpp
+++ b/test/unit/alignment/pairwise/align_pairwise_test.cpp
@@ -33,7 +33,7 @@ struct align_pairwise_test : ::testing::Test
     using dummy_cfg_t = std::conditional_t<std::is_same_v<void, t>,
                                            decltype(seqan3::align_cfg::max_error{1}),
                                            t>;
-    using config_t = decltype(seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme | dummy_cfg_t{});
+    using config_t = decltype(seqan3::align_cfg::method_global{} | seqan3::align_cfg::edit_scheme | dummy_cfg_t{});
 
     static constexpr bool is_vectorised = config_t::template exists<seqan3::detail::vectorise_tag>();
 };
@@ -66,7 +66,7 @@ TYPED_TEST(align_pairwise_test, single_pair)
     auto p1 = std::tie(seq1, seq2);
 
     {  // the score
-        seqan3::configuration cfg = seqan3::align_cfg::method_global |
+        seqan3::configuration cfg = seqan3::align_cfg::method_global{} |
                                     seqan3::align_cfg::edit_scheme |
                                     seqan3::align_cfg::result{seqan3::with_score};
 
@@ -77,7 +77,7 @@ TYPED_TEST(align_pairwise_test, single_pair)
     }
 
     {  // the alignment
-        seqan3::configuration cfg = seqan3::align_cfg::method_global |
+        seqan3::configuration cfg = seqan3::align_cfg::method_global{} |
                                     seqan3::align_cfg::edit_scheme |
                                     seqan3::align_cfg::result{seqan3::with_alignment};
         unsigned idx = 0;
@@ -97,7 +97,7 @@ TYPED_TEST(align_pairwise_test, single_pair)
     std::pair sequences{"ACGTGATG"_dna4,"AGTGATACT"_dna4};
 
     {  // the score
-        seqan3::configuration cfg = seqan3::align_cfg::method_global |
+        seqan3::configuration cfg = seqan3::align_cfg::method_global{} |
                                     seqan3::align_cfg::edit_scheme |
                                     seqan3::align_cfg::result{seqan3::with_score};
 
@@ -108,7 +108,7 @@ TYPED_TEST(align_pairwise_test, single_pair)
     }
 
     {  // the alignment
-        seqan3::configuration cfg = seqan3::align_cfg::method_global |
+        seqan3::configuration cfg = seqan3::align_cfg::method_global{} |
                                     seqan3::align_cfg::edit_scheme |
                                     seqan3::align_cfg::result{seqan3::with_alignment};
         unsigned idx = 0;
@@ -128,7 +128,7 @@ TYPED_TEST(align_pairwise_test, single_pair)
     auto p2 = std::make_pair(seq1, seq2);
 
     {  // the score
-        seqan3::configuration cfg = seqan3::align_cfg::method_global |
+        seqan3::configuration cfg = seqan3::align_cfg::method_global{} |
                                     seqan3::align_cfg::edit_scheme |
                                     seqan3::align_cfg::result{seqan3::with_score};
 
@@ -139,7 +139,7 @@ TYPED_TEST(align_pairwise_test, single_pair)
     }
 
     {  // the alignment
-        seqan3::configuration cfg = seqan3::align_cfg::method_global |
+        seqan3::configuration cfg = seqan3::align_cfg::method_global{} |
                                     seqan3::align_cfg::edit_scheme |
                                     seqan3::align_cfg::result{seqan3::with_alignment};
         unsigned idx = 0;
@@ -166,7 +166,7 @@ TYPED_TEST(align_pairwise_test, single_pair_double_score)
         auto p = std::tie(seq1, seq2);
 
         {  // the score
-            seqan3::configuration cfg = seqan3::align_cfg::method_global |
+            seqan3::configuration cfg = seqan3::align_cfg::method_global{} |
                                         seqan3::align_cfg::edit_scheme |
                                         seqan3::align_cfg::result{seqan3::with_score, seqan3::using_score_type<double>};
 
@@ -178,7 +178,7 @@ TYPED_TEST(align_pairwise_test, single_pair_double_score)
         }
 
         {  // the alignment
-            seqan3::configuration cfg = seqan3::align_cfg::method_global |
+            seqan3::configuration cfg = seqan3::align_cfg::method_global{} |
                                         seqan3::align_cfg::edit_scheme |
                                         seqan3::align_cfg::result{seqan3::with_alignment,
                                                                   seqan3::using_score_type<double>};
@@ -205,7 +205,7 @@ TYPED_TEST(align_pairwise_test, single_view)
     auto v = std::views::single(std::tie(seq1, seq2)) | std::views::common;
 
     {  // the score
-        seqan3::configuration cfg = seqan3::align_cfg::method_global |
+        seqan3::configuration cfg = seqan3::align_cfg::method_global{} |
                                     seqan3::align_cfg::edit_scheme |
                                     seqan3::align_cfg::result{seqan3::with_score};
         for (auto && res : call_alignment<TypeParam>(v, cfg))
@@ -214,7 +214,7 @@ TYPED_TEST(align_pairwise_test, single_view)
         }
     }
     {  // the alignment
-        seqan3::configuration cfg = seqan3::align_cfg::method_global |
+        seqan3::configuration cfg = seqan3::align_cfg::method_global{} |
                                     seqan3::align_cfg::edit_scheme |
                                     seqan3::align_cfg::result{seqan3::with_alignment};
 
@@ -236,7 +236,7 @@ TYPED_TEST(align_pairwise_test, collection)
     auto p = std::tie(seq1, seq2);
     std::vector<decltype(p)> vec{10, p};
 
-    seqan3::configuration cfg = seqan3::align_cfg::method_global |
+    seqan3::configuration cfg = seqan3::align_cfg::method_global{} |
                                 seqan3::align_cfg::edit_scheme |
                                 seqan3::align_cfg::result{seqan3::with_alignment};
     for (auto && res : call_alignment<TypeParam>(vec, cfg))
@@ -258,7 +258,7 @@ TYPED_TEST(align_pairwise_test, collection_with_double_score_type)
         auto p = std::tie(seq1, seq2);
         std::vector<decltype(p)> vec{10, p};
 
-        seqan3::configuration cfg = seqan3::align_cfg::method_global |
+        seqan3::configuration cfg = seqan3::align_cfg::method_global{} |
                                     seqan3::align_cfg::edit_scheme |
                                     seqan3::align_cfg::result{seqan3::with_alignment, seqan3::using_score_type<double>};
         for (auto && res : call_alignment<TypeParam>(vec, cfg))
@@ -280,7 +280,7 @@ TYPED_TEST(align_pairwise_test, bug_1598)
     auto s2 = g | std::views::drop(2);
 
     // Configure the alignment kernel.
-    seqan3::configuration cfg = seqan3::align_cfg::method_global |
+    seqan3::configuration cfg = seqan3::align_cfg::method_global{} |
                                 seqan3::align_cfg::scoring{seqan3::nucleotide_scoring_scheme{}} |
                                 seqan3::align_cfg::result{seqan3::with_alignment};
 
@@ -292,7 +292,7 @@ TEST(align_pairwise_test, parallel_without_parameter)
 {
     auto seq1 = "ACGTGATG"_dna4;
     auto seq2 = "AGTGATACT"_dna4;
-    seqan3::configuration cfg = seqan3::align_cfg::method_global |
+    seqan3::configuration cfg = seqan3::align_cfg::method_global{} |
                                 seqan3::align_cfg::edit_scheme |
                                 seqan3::align_cfg::result{seqan3::with_score} |
                                 seqan3::align_cfg::parallel{};

--- a/test/unit/alignment/pairwise/align_result_selector_test.cpp
+++ b/test/unit/alignment/pairwise/align_result_selector_test.cpp
@@ -28,7 +28,7 @@ TEST(alignment_selector, align_result_selector_with_list)
     using seq2_t = std::list<seqan3::dna4>;
 
     {
-        auto cfg = seqan3::align_cfg::method_global |
+        auto cfg = seqan3::align_cfg::method_global{} |
                    seqan3::align_cfg::edit_scheme |
                    seqan3::align_cfg::result{seqan3::with_score};
         using _t = seqan3::alignment_result<typename seqan3::detail::align_result_selector<seq1_t,
@@ -40,7 +40,7 @@ TEST(alignment_selector, align_result_selector_with_list)
     }
 
     {
-        auto cfg = seqan3::align_cfg::method_global |
+        auto cfg = seqan3::align_cfg::method_global{} |
                    seqan3::align_cfg::edit_scheme |
                    seqan3::align_cfg::result{seqan3::with_alignment};
         using _t = seqan3::alignment_result<typename seqan3::detail::align_result_selector<seq1_t,
@@ -66,7 +66,7 @@ TEST(alignment_selector, align_result_selector_using_score_type)
     using seq1_t = std::vector<seqan3::dna4>;
     using seq2_t = std::list<seqan3::dna4>;
 
-    auto cfg = seqan3::align_cfg::method_global |
+    auto cfg = seqan3::align_cfg::method_global{} |
                seqan3::align_cfg::edit_scheme |
                seqan3::align_cfg::result{seqan3::with_end_positions, seqan3::using_score_type<double>};
     using _t = seqan3::alignment_result<typename seqan3::detail::align_result_selector<seq1_t,
@@ -82,7 +82,7 @@ TEST(alignment_selector, align_result_selector_with_vector)
 {
     using seq_t = std::vector<seqan3::dna4>;
 
-    auto cfg = seqan3::align_cfg::method_global |
+    auto cfg = seqan3::align_cfg::method_global{} |
                seqan3::align_cfg::edit_scheme |
                seqan3::align_cfg::result{seqan3::with_alignment};
     using _t = seqan3::alignment_result<typename seqan3::detail::align_result_selector<seq_t,

--- a/test/unit/alignment/pairwise/alignment_configurator_test.cpp
+++ b/test/unit/alignment/pairwise/alignment_configurator_test.cpp
@@ -47,40 +47,40 @@ auto run_test(config_t const & cfg)
 
 TEST(alignment_configurator, configure_edit)
 {
-    EXPECT_EQ(run_test(seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme).score(), 0);
+    EXPECT_EQ(run_test(seqan3::align_cfg::method_global{} | seqan3::align_cfg::edit_scheme).score(), 0);
 }
 
 TEST(alignment_configurator, configure_edit_end_position)
 {
-    EXPECT_EQ(run_test(seqan3::align_cfg::method_global |
+    EXPECT_EQ(run_test(seqan3::align_cfg::method_global{} |
                        seqan3::align_cfg::edit_scheme |
                        seqan3::align_cfg::result{seqan3::with_end_positions}).score(), 0);
 }
 
 TEST(alignment_configurator, configure_edit_begin_position)
 {
-    EXPECT_EQ(run_test(seqan3::align_cfg::method_global |
+    EXPECT_EQ(run_test(seqan3::align_cfg::method_global{} |
                        seqan3::align_cfg::edit_scheme |
                        seqan3::align_cfg::result{seqan3::with_begin_positions}).score(), 0);
 }
 
 TEST(alignment_configurator, configure_edit_trace)
 {
-    EXPECT_EQ(run_test(seqan3::align_cfg::method_global |
+    EXPECT_EQ(run_test(seqan3::align_cfg::method_global{} |
                        seqan3::align_cfg::edit_scheme |
                        seqan3::align_cfg::result{seqan3::with_alignment}).score(), 0);
 }
 
 TEST(alignment_configurator, configure_edit_semi)
 {
-    EXPECT_EQ(run_test(seqan3::align_cfg::method_global |
+    EXPECT_EQ(run_test(seqan3::align_cfg::method_global{} |
                        seqan3::align_cfg::edit_scheme |
                        seqan3::align_cfg::aligned_ends{seqan3::free_ends_first}).score(), 0);
 }
 
 TEST(alignment_configurator, configure_edit_banded)
 {
-    EXPECT_THROW((run_test(seqan3::align_cfg::method_global |
+    EXPECT_THROW((run_test(seqan3::align_cfg::method_global{} |
                            seqan3::align_cfg::edit_scheme |
                            seqan3::align_cfg::band_fixed_size{seqan3::align_cfg::lower_diagonal{-1},
                                                               seqan3::align_cfg::upper_diagonal{1}})),
@@ -89,14 +89,14 @@ TEST(alignment_configurator, configure_edit_banded)
 
 TEST(alignment_configurator, configure_edit_max_error)
 {
-    EXPECT_EQ(run_test(seqan3::align_cfg::method_global |
+    EXPECT_EQ(run_test(seqan3::align_cfg::method_global{} |
                        seqan3::align_cfg::edit_scheme |
                        seqan3::align_cfg::max_error{3u}).score(), 0);
 }
 
 TEST(alignment_configurator, configure_affine_global)
 {
-    auto cfg = seqan3::align_cfg::method_global |
+    auto cfg = seqan3::align_cfg::method_global{} |
                seqan3::align_cfg::gap{seqan3::gap_scheme{seqan3::gap_score{-1}, seqan3::gap_open_score{-10}}} |
                seqan3::align_cfg::scoring{seqan3::nucleotide_scoring_scheme{}};
 
@@ -105,7 +105,7 @@ TEST(alignment_configurator, configure_affine_global)
 
 TEST(alignment_configurator, configure_affine_global_max_error)
 {
-    auto cfg = seqan3::align_cfg::method_global |
+    auto cfg = seqan3::align_cfg::method_global{} |
                seqan3::align_cfg::gap{seqan3::gap_scheme{seqan3::gap_score{-1}, seqan3::gap_open_score{-10}}} |
                seqan3::align_cfg::scoring{seqan3::nucleotide_scoring_scheme{}} |
                seqan3::align_cfg::max_error{5u};
@@ -115,7 +115,7 @@ TEST(alignment_configurator, configure_affine_global_max_error)
 
 TEST(alignment_configurator, configure_affine_global_end_position)
 {
-    auto cfg = seqan3::align_cfg::method_global |
+    auto cfg = seqan3::align_cfg::method_global{} |
                seqan3::align_cfg::gap{seqan3::gap_scheme{seqan3::gap_score{-1}, seqan3::gap_open_score{-10}}} |
                seqan3::align_cfg::scoring{seqan3::nucleotide_scoring_scheme{}} |
                seqan3::align_cfg::result{seqan3::with_end_positions};
@@ -125,7 +125,7 @@ TEST(alignment_configurator, configure_affine_global_end_position)
 
 TEST(alignment_configurator, configure_affine_global_begin_position)
 {
-    auto cfg = seqan3::align_cfg::method_global |
+    auto cfg = seqan3::align_cfg::method_global{} |
                seqan3::align_cfg::gap{seqan3::gap_scheme{seqan3::gap_score{-1}, seqan3::gap_open_score{-10}}} |
                seqan3::align_cfg::scoring{seqan3::nucleotide_scoring_scheme{}} |
                seqan3::align_cfg::result{seqan3::with_begin_positions};
@@ -135,7 +135,7 @@ TEST(alignment_configurator, configure_affine_global_begin_position)
 
 TEST(alignment_configurator, configure_affine_global_trace)
 {
-    auto cfg = seqan3::align_cfg::method_global |
+    auto cfg = seqan3::align_cfg::method_global{} |
                seqan3::align_cfg::gap{seqan3::gap_scheme{seqan3::gap_score{-1}, seqan3::gap_open_score{-10}}} |
                seqan3::align_cfg::scoring{seqan3::nucleotide_scoring_scheme{}} |
                seqan3::align_cfg::result{seqan3::with_alignment};
@@ -146,7 +146,7 @@ TEST(alignment_configurator, configure_affine_global_trace)
 TEST(alignment_configurator, configure_affine_global_banded)
 {
     {
-        auto cfg = seqan3::align_cfg::method_global |
+        auto cfg = seqan3::align_cfg::method_global{} |
                    seqan3::align_cfg::scoring{seqan3::nucleotide_scoring_scheme{}} |
                    seqan3::align_cfg::gap{seqan3::gap_scheme{seqan3::gap_score{-1}, seqan3::gap_open_score{-10}}} |
           seqan3::align_cfg::band_fixed_size{seqan3::align_cfg::lower_diagonal{-1}, seqan3::align_cfg::upper_diagonal{1}};
@@ -155,7 +155,7 @@ TEST(alignment_configurator, configure_affine_global_banded)
     }
 
     {  // invalid band
-        auto cfg_base = seqan3::align_cfg::method_global |
+        auto cfg_base = seqan3::align_cfg::method_global{} |
                         seqan3::align_cfg::scoring{seqan3::nucleotide_scoring_scheme{}} |
                         seqan3::align_cfg::gap{seqan3::gap_scheme{seqan3::gap_score{-1}, seqan3::gap_open_score{-10}}};
         auto cfg_lower = cfg_base | seqan3::align_cfg::band_fixed_size{seqan3::align_cfg::lower_diagonal{-10},
@@ -170,7 +170,7 @@ TEST(alignment_configurator, configure_affine_global_banded)
 
 TEST(alignment_configurator, configure_affine_global_banded_with_alignment)
 {
-    auto cfg = seqan3::align_cfg::method_global |
+    auto cfg = seqan3::align_cfg::method_global{} |
                seqan3::align_cfg::gap{seqan3::gap_scheme{seqan3::gap_score{-1}, seqan3::gap_open_score{-10}}} |
                seqan3::align_cfg::scoring{seqan3::nucleotide_scoring_scheme{}} |
       seqan3::align_cfg::band_fixed_size{seqan3::align_cfg::lower_diagonal{-1}, seqan3::align_cfg::upper_diagonal{1}};
@@ -186,7 +186,7 @@ TEST(alignment_configurator, configure_affine_global_banded_with_alignment)
 
 TEST(alignment_configurator, configure_affine_global_semi)
 {
-    auto cfg = seqan3::align_cfg::method_global |
+    auto cfg = seqan3::align_cfg::method_global{} |
                seqan3::align_cfg::scoring{seqan3::nucleotide_scoring_scheme{}} |
                seqan3::align_cfg::gap{seqan3::gap_scheme{seqan3::gap_score{-1}, seqan3::gap_open_score{-10}}} |
                seqan3::align_cfg::aligned_ends{seqan3::free_ends_all};
@@ -235,7 +235,7 @@ TEST(alignment_configurator, configure_affine_local_alignment)
 
 TEST(alignment_configurator, configure_result_score_type)
 {
-    auto cfg = seqan3::align_cfg::method_global |
+    auto cfg = seqan3::align_cfg::method_global{} |
                seqan3::align_cfg::edit_scheme |
                seqan3::align_cfg::result{seqan3::with_end_positions, seqan3::using_score_type<double>};
     auto result = run_test(cfg);

--- a/test/unit/alignment/pairwise/fixture/global_affine_banded.hpp
+++ b/test/unit/alignment/pairwise/fixture/global_affine_banded.hpp
@@ -27,7 +27,7 @@ using seqan3::operator""_dna4;
 namespace seqan3::test::alignment::fixture::global::affine::banded
 {
 
-inline constexpr auto align_config = seqan3::align_cfg::method_global |
+inline constexpr auto align_config = seqan3::align_cfg::method_global{} |
                                      seqan3::align_cfg::gap{seqan3::gap_scheme{seqan3::gap_score{-1},
                                                                                seqan3::gap_open_score{-10}}};
 

--- a/test/unit/alignment/pairwise/fixture/global_affine_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/global_affine_unbanded.hpp
@@ -26,7 +26,7 @@ using seqan3::operator""_dna4;
 namespace seqan3::test::alignment::fixture::global::affine::unbanded
 {
 
-inline constexpr auto align_config = seqan3::align_cfg::method_global
+inline constexpr auto align_config = seqan3::align_cfg::method_global{}
                                    | seqan3::align_cfg::gap{seqan3::gap_scheme{seqan3::gap_score{-1},
                                                             seqan3::gap_open_score{-10}}};
 inline constexpr auto align_config_dna_score = align_config

--- a/test/unit/alignment/pairwise/fixture/global_edit_distance_max_errors_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/global_edit_distance_max_errors_unbanded.hpp
@@ -39,7 +39,7 @@ static auto dna4_01_e255 = []()
     {
         "AACCGGTTAACCGGTT"_dna4,
         "ACGTACGTA"_dna4,
-        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme | seqan3::align_cfg::max_error{255},
+        seqan3::align_cfg::method_global{} | seqan3::align_cfg::edit_scheme | seqan3::align_cfg::max_error{255},
         -8,
         "AACCGGTTAACCGGTT",
         "A-C-G-T-A-C-G-TA",
@@ -56,7 +56,7 @@ static auto dna4_01T_e255 = []()
     {
         "ACGTACGTA"_dna4,
         "AACCGGTTAACCGGTT"_dna4,
-        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme | seqan3::align_cfg::max_error{255},
+        seqan3::align_cfg::method_global{} | seqan3::align_cfg::edit_scheme | seqan3::align_cfg::max_error{255},
         -8,
         "A-C-G-T-A-C-G-TA",
         "AACCGGTTAACCGGTT",
@@ -89,7 +89,7 @@ static auto dna4_01_e8 = []()
     {
         "AACCGGTTAACCGGTT"_dna4,
         "ACGTACGTA"_dna4,
-        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme | seqan3::align_cfg::max_error{8},
+        seqan3::align_cfg::method_global{} | seqan3::align_cfg::edit_scheme | seqan3::align_cfg::max_error{8},
         -8,
         "AACCGGTTAACCGGTT",
         "A-C-G-T-A-C-G-TA",
@@ -122,7 +122,7 @@ static auto dna4_01_e7 = []()
     {
         "AACCGGTTAACCGGTT"_dna4,
         "ACGTACGTA"_dna4,
-        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme | seqan3::align_cfg::max_error{7},
+        seqan3::align_cfg::method_global{} | seqan3::align_cfg::edit_scheme | seqan3::align_cfg::max_error{7},
         INF,
         "",
         "",
@@ -155,7 +155,7 @@ static auto dna4_01_e5 = []()
     {
         "AACCGGTTAACCGGTT"_dna4,
         "ACGTACGTA"_dna4,
-        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme | seqan3::align_cfg::max_error{5},
+        seqan3::align_cfg::method_global{} | seqan3::align_cfg::edit_scheme | seqan3::align_cfg::max_error{5},
         INF,
         "",
         "",
@@ -172,7 +172,7 @@ static auto dna4_02_e255 = []()
     {
         "AACCGGTAAACCGGTT"_dna4,
         "ACGTACGTA"_dna4,
-        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme | seqan3::align_cfg::max_error{255},
+        seqan3::align_cfg::method_global{} | seqan3::align_cfg::edit_scheme | seqan3::align_cfg::max_error{255},
         -8,
         "AACCGGTAAACCGGTT",
         "A-C-G-TA--C-G-TA",
@@ -204,7 +204,7 @@ static auto dna4_02_e8 = []()
     {
         "AACCGGTAAACCGGTT"_dna4,
         "ACGTACGTA"_dna4,
-        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme | seqan3::align_cfg::max_error{8},
+        seqan3::align_cfg::method_global{} | seqan3::align_cfg::edit_scheme | seqan3::align_cfg::max_error{8},
         -8,
         "AACCGGTAAACCGGTT",
         "A-C-G-TA--C-G-TA",
@@ -236,7 +236,7 @@ static auto dna4_02_e4 = []()
     {
         "AACCGGTAAACCGGTT"_dna4,
         "ACGTACGTA"_dna4,
-        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme | seqan3::align_cfg::max_error{4},
+        seqan3::align_cfg::method_global{} | seqan3::align_cfg::edit_scheme | seqan3::align_cfg::max_error{4},
         INF,
         "",
         "",
@@ -269,7 +269,7 @@ static auto dna4_02_s10u_15u_e7 = []()
     {
         "AACCGGTAAACCGG"_dna4,
         "ACGTACGTA"_dna4,
-        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme | seqan3::align_cfg::max_error{7},
+        seqan3::align_cfg::method_global{} | seqan3::align_cfg::edit_scheme | seqan3::align_cfg::max_error{7},
         INF,
         "",
         "",
@@ -291,7 +291,7 @@ static auto dna4_02_s1u_15u_e255 = []()
         // --------------
         "AACCGGTAAACCGG"_dna4,
         ""_dna4,
-        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme | seqan3::align_cfg::max_error{255},
+        seqan3::align_cfg::method_global{} | seqan3::align_cfg::edit_scheme | seqan3::align_cfg::max_error{255},
         -14,
         "AACCGGTAAACCGG",
         "--------------",
@@ -315,7 +315,7 @@ static auto dna4_02_s1u_15u_e5 = []()
         // score is inf and has no alignment
         "AACCGGTAAACCGG"_dna4,
         ""_dna4,
-        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme | seqan3::align_cfg::max_error{5},
+        seqan3::align_cfg::method_global{} | seqan3::align_cfg::edit_scheme | seqan3::align_cfg::max_error{5},
         INF,
         "",
         "",
@@ -337,7 +337,7 @@ static auto dna4_02T_s15u_1u_e255 = []()
         // AACCGGTAAACCGG
         ""_dna4,
         "AACCGGTAAACCGG"_dna4,
-        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme | seqan3::align_cfg::max_error{255},
+        seqan3::align_cfg::method_global{} | seqan3::align_cfg::edit_scheme | seqan3::align_cfg::max_error{255},
         -14,
         "--------------",
         "AACCGGTAAACCGG",
@@ -375,7 +375,7 @@ static auto dna4_02T_s15u_1u_e5 = []()
         // score is inf and has no alignment
         ""_dna4,
         "AACCGGTAAACCGG"_dna4,
-        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme | seqan3::align_cfg::max_error{5},
+        seqan3::align_cfg::method_global{} | seqan3::align_cfg::edit_scheme | seqan3::align_cfg::max_error{5},
         INF,
         "",
         "",
@@ -393,7 +393,7 @@ static auto dna4_03_e255 = []()
         // score: 0
         ""_dna4,
         ""_dna4,
-        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme | seqan3::align_cfg::max_error{255},
+        seqan3::align_cfg::method_global{} | seqan3::align_cfg::edit_scheme | seqan3::align_cfg::max_error{255},
         -0,
         "",
         "",
@@ -410,7 +410,7 @@ static auto aa27_01_e255 = []()
     {
         "UUWWRRIIUUWWRRII"_aa27,
         "UWRIUWRIU"_aa27,
-        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme | seqan3::align_cfg::max_error{255},
+        seqan3::align_cfg::method_global{} | seqan3::align_cfg::edit_scheme | seqan3::align_cfg::max_error{255},
         -8,
         "UUWWRRIIUUWWRRII",
         "U-W-R-I-U-W-R-IU",
@@ -427,7 +427,7 @@ static auto aa27_01T_e255 = []()
     {
         "UWRIUWRIU"_aa27,
         "UUWWRRIIUUWWRRII"_aa27,
-        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme | seqan3::align_cfg::max_error{255},
+        seqan3::align_cfg::method_global{} | seqan3::align_cfg::edit_scheme | seqan3::align_cfg::max_error{255},
         -8,
         "U-W-R-I-U-W-R-IU",
         "UUWWRRIIUUWWRRII",

--- a/test/unit/alignment/pairwise/fixture/global_edit_distance_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/global_edit_distance_unbanded.hpp
@@ -34,7 +34,7 @@ static auto dna4_01 = []()
         // A-C-G-T-A-C-G-TA
         "AACCGGTTAACCGGTT"_dna4,
         "ACGTACGTA"_dna4,
-        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme,
+        seqan3::align_cfg::method_global{} | seqan3::align_cfg::edit_scheme,
         -8,
         "AACCGGTTAACCGGTT",
         "A-C-G-T-A-C-G-TA",
@@ -82,7 +82,7 @@ static auto dna4_01T = []()
         // AACCGGTTAACCGGTT
         "ACGTACGTA"_dna4,
         "AACCGGTTAACCGGTT"_dna4,
-        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme,
+        seqan3::align_cfg::method_global{} | seqan3::align_cfg::edit_scheme,
         -8,
         "A-C-G-T-A-C-G-TA",
         "AACCGGTTAACCGGTT",
@@ -104,7 +104,7 @@ static auto dna4_02 = []()
         // A-C-G-TA--C-G-TA
         "AACCGGTAAACCGGTT"_dna4,
         "ACGTACGTA"_dna4,
-        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme,
+        seqan3::align_cfg::method_global{} | seqan3::align_cfg::edit_scheme,
         -8,
         "AACCGGTAAACCGGTT",
         "A-C-G-TA--C-G-TA",
@@ -152,7 +152,7 @@ static auto dna4_02_s10u_15u = []()
         // A-C-G-TA--C-GTA
         "AACCGGTAAACCGG"_dna4,
         "ACGTACGTA"_dna4,
-        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme,
+        seqan3::align_cfg::method_global{} | seqan3::align_cfg::edit_scheme,
         -8,
         "AACCGGTAAACCGG-",
         "A-C-G-TA--C-GTA",
@@ -174,7 +174,7 @@ static auto dna4_02_s3u_15u = []()
         // A-C-----------
         "AACCGGTAAACCGG"_dna4,
         "AC"_dna4,
-        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme,
+        seqan3::align_cfg::method_global{} | seqan3::align_cfg::edit_scheme,
         -12,
         "AACCGGTAAACCGG",
         "A-C-----------",
@@ -196,7 +196,7 @@ static auto dna4_02_s1u_15u = []()
         // --------------
         "AACCGGTAAACCGG"_dna4,
         ""_dna4,
-        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme,
+        seqan3::align_cfg::method_global{} | seqan3::align_cfg::edit_scheme,
         -14,
         "AACCGGTAAACCGG",
         "--------------",
@@ -218,7 +218,7 @@ static auto dna4_02T_s15u_1u = []()
         // AACCGGTAAACCGG
         ""_dna4,
         "AACCGGTAAACCGG"_dna4,
-        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme,
+        seqan3::align_cfg::method_global{} | seqan3::align_cfg::edit_scheme,
         -14,
         "--------------",
         "AACCGGTAAACCGG",
@@ -236,7 +236,7 @@ static auto dna4_03 = []()
         // score: 0
         ""_dna4,
         ""_dna4,
-        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme,
+        seqan3::align_cfg::method_global{} | seqan3::align_cfg::edit_scheme,
         -0,
         "",
         "",
@@ -258,7 +258,7 @@ static auto aa27_01 = []()
         // U-W-R-I-U-W-R-IU
         "UUWWRRIIUUWWRRII"_aa27,
         "UWRIUWRIU"_aa27,
-        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme,
+        seqan3::align_cfg::method_global{} | seqan3::align_cfg::edit_scheme,
         -8,
         "UUWWRRIIUUWWRRII",
         "U-W-R-I-U-W-R-IU",
@@ -306,7 +306,7 @@ static auto aa27_01T = []()
         // UUWWRRIIUUWWRRII
         "UWRIUWRIU"_aa27,
         "UUWWRRIIUUWWRRII"_aa27,
-        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme,
+        seqan3::align_cfg::method_global{} | seqan3::align_cfg::edit_scheme,
         -8,
         "U-W-R-I-U-W-R-IU",
         "UUWWRRIIUUWWRRII",

--- a/test/unit/alignment/pairwise/fixture/semi_global_affine_banded.hpp
+++ b/test/unit/alignment/pairwise/fixture/semi_global_affine_banded.hpp
@@ -27,7 +27,7 @@ using seqan3::operator""_dna4;
 namespace seqan3::test::alignment::fixture::semi_global::affine::banded
 {
 
-inline constexpr auto align_config = seqan3::align_cfg::method_global |
+inline constexpr auto align_config = seqan3::align_cfg::method_global{} |
                                      seqan3::align_cfg::gap{seqan3::gap_scheme{seqan3::gap_score{-1},
                                                                                seqan3::gap_open_score{-10}}} |
                                      seqan3::align_cfg::band_fixed_size{seqan3::align_cfg::lower_diagonal{-4},

--- a/test/unit/alignment/pairwise/fixture/semi_global_affine_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/semi_global_affine_unbanded.hpp
@@ -26,7 +26,7 @@ using seqan3::operator""_dna4;
 namespace seqan3::test::alignment::fixture::semi_global::affine::unbanded
 {
 
-inline constexpr auto align_config = seqan3::align_cfg::method_global |
+inline constexpr auto align_config = seqan3::align_cfg::method_global{} |
                                      seqan3::align_cfg::gap{seqan3::gap_scheme{seqan3::gap_score{-1},
                                                                                seqan3::gap_open_score{-10}}};
 

--- a/test/unit/alignment/pairwise/fixture/semi_global_edit_distance_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/semi_global_edit_distance_unbanded.hpp
@@ -25,7 +25,7 @@ namespace seqan3::test::alignment::fixture::semi_global::edit_distance::unbanded
 using seqan3::detail::column_index_type;
 using seqan3::detail::row_index_type;
 
-static constexpr auto semi_global_edit_distance = seqan3::align_cfg::method_global |
+static constexpr auto semi_global_edit_distance = seqan3::align_cfg::method_global{} |
                                                   seqan3::align_cfg::edit_scheme |
                                                   seqan3::align_cfg::aligned_ends{seqan3::free_ends_first};
 

--- a/test/unit/alignment/pairwise/semi_global_affine_banded_test.cpp
+++ b/test/unit/alignment/pairwise/semi_global_affine_banded_test.cpp
@@ -32,7 +32,7 @@ struct pairwise_semiglobal_affine_banded : public ::testing::Test
 
     auto base_config() const
     {
-        return seqan3::align_cfg::method_global |
+        return seqan3::align_cfg::method_global{} |
                seqan3::align_cfg::gap{seqan3::gap_scheme{seqan3::gap_score{-1},
                                                          seqan3::gap_open_score{-10}}} |
                seqan3::align_cfg::scoring{seqan3::nucleotide_scoring_scheme{seqan3::match_score{4},

--- a/test/unit/alignment/scoring/simd_match_mismatch_scoring_scheme_test.cpp
+++ b/test/unit/alignment/scoring/simd_match_mismatch_scoring_scheme_test.cpp
@@ -33,7 +33,7 @@ TYPED_TEST(simd_match_mismatch_scoring_scheme_test, basic_construction)
 {
     using scheme_t = seqan3::detail::simd_match_mismatch_scoring_scheme<TypeParam,
                                                                         seqan3::dna4,
-                                                                        seqan3::detail::method_global_tag>;
+                                                                        seqan3::align_cfg::method_global>;
 
     EXPECT_TRUE(std::is_nothrow_default_constructible_v<scheme_t>);
     EXPECT_TRUE(std::is_nothrow_copy_constructible_v<scheme_t>);
@@ -49,7 +49,7 @@ TYPED_TEST(simd_match_mismatch_scoring_scheme_test, construct_from_scoring_schem
 {
     using scheme_t = seqan3::detail::simd_match_mismatch_scoring_scheme<TypeParam,
                                                                         seqan3::dna4,
-                                                                        seqan3::detail::method_global_tag>;
+                                                                        seqan3::align_cfg::method_global>;
 
     scheme_t simd_scheme{seqan3::nucleotide_scoring_scheme{seqan3::match_score{4}, seqan3::mismatch_score{-5}}};
 
@@ -66,7 +66,7 @@ TYPED_TEST(simd_match_mismatch_scoring_scheme_test, construct_from_scoring_schem
     using scalar_t = typename seqan3::simd_traits<TypeParam>::scalar_type;
     using scheme_t = seqan3::detail::simd_match_mismatch_scoring_scheme<TypeParam,
                                                                         seqan3::dna4,
-                                                                        seqan3::detail::method_global_tag>;
+                                                                        seqan3::align_cfg::method_global>;
 
     int64_t too_big = static_cast<int64_t>(std::numeric_limits<scalar_t>::max()) + 1;
     int64_t too_small = static_cast<int64_t>(std::numeric_limits<scalar_t>::lowest()) - 1;
@@ -82,7 +82,7 @@ TYPED_TEST(simd_match_mismatch_scoring_scheme_test, score_global)
 {
     using scheme_t = seqan3::detail::simd_match_mismatch_scoring_scheme<TypeParam,
                                                                         seqan3::dna4,
-                                                                        seqan3::detail::method_global_tag>;
+                                                                        seqan3::align_cfg::method_global>;
 
     scheme_t scheme{seqan3::nucleotide_scoring_scheme{seqan3::match_score{4}, seqan3::mismatch_score{-5}}};
 
@@ -114,7 +114,7 @@ TYPED_TEST(simd_match_mismatch_scoring_scheme_test, score_global_with_padding)
 {
     using scheme_t = seqan3::detail::simd_match_mismatch_scoring_scheme<TypeParam,
                                                                         seqan3::dna4,
-                                                                        seqan3::detail::method_global_tag>;
+                                                                        seqan3::align_cfg::method_global>;
 
     scheme_t scheme{seqan3::nucleotide_scoring_scheme{seqan3::match_score{4}, seqan3::mismatch_score{-5}}};
 

--- a/test/unit/alignment/scoring/simd_matrix_scoring_scheme_test.cpp
+++ b/test/unit/alignment/scoring/simd_matrix_scoring_scheme_test.cpp
@@ -33,7 +33,7 @@ TYPED_TEST(simd_matrix_scoring_scheme_test, basic_construction)
 {
     using scheme_t = seqan3::detail::simd_matrix_scoring_scheme<TypeParam,
                                                                 seqan3::aa27,
-                                                                seqan3::detail::method_global_tag,
+                                                                seqan3::align_cfg::method_global,
                                                                 seqan3::aminoacid_scoring_scheme<>>;
 
     EXPECT_TRUE(std::is_nothrow_default_constructible_v<scheme_t>);
@@ -50,7 +50,7 @@ TYPED_TEST(simd_matrix_scoring_scheme_test, construct_from_scoring_scheme_nothro
 {
     using scheme_t = seqan3::detail::simd_matrix_scoring_scheme<TypeParam,
                                                                 seqan3::aa27,
-                                                                seqan3::detail::method_global_tag,
+                                                                seqan3::align_cfg::method_global,
                                                                 seqan3::aminoacid_scoring_scheme<>>;
 
     scheme_t simd_scheme{seqan3::aminoacid_scoring_scheme{seqan3::aminoacid_similarity_matrix::BLOSUM30}};
@@ -68,7 +68,7 @@ TYPED_TEST(simd_matrix_scoring_scheme_test, construct_from_scoring_scheme_throw_
     using scalar_t = typename seqan3::simd_traits<TypeParam>::scalar_type;
     using scheme_t = seqan3::detail::simd_matrix_scoring_scheme<TypeParam,
                                                                 seqan3::aa27,
-                                                                seqan3::detail::method_global_tag,
+                                                                seqan3::align_cfg::method_global,
                                                                 seqan3::aminoacid_scoring_scheme<int64_t>>;
 
     int64_t too_big = static_cast<int64_t>(std::numeric_limits<scalar_t>::max()) + 1;
@@ -98,7 +98,7 @@ TYPED_TEST(simd_matrix_scoring_scheme_test, score_global)
 {
     using scheme_t = seqan3::detail::simd_matrix_scoring_scheme<TypeParam,
                                                                 seqan3::aa27,
-                                                                seqan3::detail::method_global_tag,
+                                                                seqan3::align_cfg::method_global,
                                                                 seqan3::aminoacid_scoring_scheme<>>;
 
     scheme_t scheme{seqan3::aminoacid_scoring_scheme{seqan3::aminoacid_similarity_matrix::BLOSUM30}};
@@ -131,7 +131,7 @@ TYPED_TEST(simd_matrix_scoring_scheme_test, score_global_with_padding)
 {
     using scheme_t = seqan3::detail::simd_matrix_scoring_scheme<TypeParam,
                                                                 seqan3::aa27,
-                                                                seqan3::detail::method_global_tag,
+                                                                seqan3::align_cfg::method_global,
                                                                 seqan3::aminoacid_scoring_scheme<>>;
 
     scheme_t scheme{seqan3::aminoacid_scoring_scheme{seqan3::aminoacid_similarity_matrix::BLOSUM30}};


### PR DESCRIPTION
Part of https://github.com/seqan/product_backlog/issues/96

I split the tasks such that the PR doesn't become too large.

Fixes tasks 1 & 2:
- [x]  Introduce strong types free_end_gaps_sequence[1/2]_[leading/trailing]
- [x] Make seqan3::method_global a pipeable ocnfig element (not a tag), that is constructible from the 4 strong_types