### PR TITLE
[TEST] add new test case and make existing ones more fool-proof

### DIFF
--- a/include/seqan3/alignment/matrix/detail/two_dimensional_matrix_iterator_base.hpp
+++ b/include/seqan3/alignment/matrix/detail/two_dimensional_matrix_iterator_base.hpp
@@ -287,9 +287,9 @@ public:
 
     //!\brief Returns the distance between two iterators.
     template <typename dummy_t = derived_t>
-    constexpr std::iter_difference_t<dummy_t> operator-(derived_t const rhs) const noexcept
+    friend constexpr std::iter_difference_t<dummy_t> operator-(derived_t const lhs, derived_t const rhs) noexcept
     {
-        return as_derived().host_iter - rhs.host_iter;
+        return lhs.as_host_iter() - rhs.as_host_iter();
     }
     //!\}
 
@@ -359,6 +359,12 @@ public:
     }
     //!\}
 private:
+
+    //!\brief Return the host_iter of the derived type.
+    constexpr auto const & as_host_iter() const
+    {
+        return as_derived().host_iter;
+    }
 
     //!\brief Cast this to derived type.
     constexpr derived_t & as_derived()

--- a/include/seqan3/range/detail/random_access_iterator.hpp
+++ b/include/seqan3/range/detail/random_access_iterator.hpp
@@ -251,9 +251,9 @@ public:
     }
 
     //!\brief Return offset between this and remote iterator's position.
-    constexpr difference_type operator-(derived_t const lhs) const noexcept
+    constexpr friend difference_type operator-(derived_t const & lhs, derived_t const & rhs) noexcept
     {
-        return static_cast<difference_type>(pos - lhs.pos);
+        return static_cast<difference_type>(lhs.pos - rhs.pos);
     }
     //!\}
 


### PR DESCRIPTION
Part of https://github.com/seqan/product_backlog/issues/62

---

If ranges were not correctly implemented, the tests

* move_forward_pre_test
* move_forward_post_test
* move_backward_pre_test (split from move_backward_test)
* move_backward_post_test (split from move_backward_test)

could have an infinite loop, if the iterators didn't move to their end.

We now iterate over the expected range to make sure the test terminates.

This commit further adds the test case `difference_sentinel` which tests
`begin - end` and `end - begin` with all const/non-const combinations.