### PR TITLE
[FIX] Reapply some changes that got lost due to seqan/seqan3#1914

### DIFF
--- a/include/seqan3/range/views/pairwise_combine.hpp
+++ b/include/seqan3/range/views/pairwise_combine.hpp
@@ -40,14 +40,13 @@ namespace seqan3::detail
 template <std::ranges::view underlying_range_type>
 //!\cond
     requires  std::ranges::forward_range<underlying_range_type> && std::ranges::common_range<underlying_range_type>
-// !\endcond
+//!\endcond
 class pairwise_combine_view : public std::ranges::view_interface<pairwise_combine_view<underlying_range_type>>
 {
 private:
 
     //!\brief The forward declared iterator type for pairwise_combine_view.
     template <typename range_type>
-
     class iterator_type;
 
     /*!\name Associated types
@@ -65,18 +64,12 @@ public:
     /*!\name Constructors, destructor and assignment
      * \{
      */
-    //!\brief Default Default-Constructor.
-    constexpr pairwise_combine_view() = default;
-    //!\brief Default Copy-Constructor.
-    constexpr pairwise_combine_view(pairwise_combine_view const &) = default;
-    //!\brief Default Move-Constructor.
-    constexpr pairwise_combine_view(pairwise_combine_view &&) = default;
-    //!\brief Default Copy-Assignment.
-    constexpr pairwise_combine_view & operator=(pairwise_combine_view const &) = default;
-    //!\brief Default Move-Assignment.
-    constexpr pairwise_combine_view & operator=(pairwise_combine_view &&) = default;
-    //!\brief Default Destructor.
-    ~pairwise_combine_view() = default;
+    pairwise_combine_view() = default; //!< Defaulted.
+    pairwise_combine_view(pairwise_combine_view const &) = default; //!< Defaulted.
+    pairwise_combine_view(pairwise_combine_view &&) = default; //!< Defaulted.
+    pairwise_combine_view & operator=(pairwise_combine_view const &) = default; //!< Defaulted.
+    pairwise_combine_view & operator=(pairwise_combine_view &&) = default; //!< Defaulted.
+    ~pairwise_combine_view() = default; //!< Defaulted.
 
     /*!\brief Constructs from a view.
      * \param[in] range The underlying range to be wrapped. Of type `underlying_range_type`.
@@ -254,7 +247,17 @@ private:
     underlying_range_type u_range{};
     //!\brief The cached iterator pointing to the last element of the underlying range.
     std::ranges::iterator_t<underlying_range_type> back_iterator{};
-}; // class pairwise_combine_view
+};
+
+/*!\name Type deduction guides
+ * \{
+ */
+
+//!\brief Deduces the correct template type from a non-view lvalue range by wrapping the range in std::views::all.
+template <std::ranges::viewable_range other_range_t>
+pairwise_combine_view(other_range_t && range) ->
+    pairwise_combine_view<std::views::all_t<other_range_t>>;
+//!\}
 
 /*!\brief The internal iterator type for pairwise_combine_view.
  * \tparam range_type The type of the range this iterator is operating on.
@@ -269,10 +272,10 @@ private:
  * Thus this iterator might not be usable with some legacy algorithms of the STL. But it is guaranteed to work with
  * the ranges algorithms.
  */
- template <std::ranges::view underlying_range_type>
- //!\cond
-     requires std::ranges::forward_range<underlying_range_type> && std::ranges::common_range<underlying_range_type>
- // !\endcond
+template <std::ranges::view underlying_range_type>
+//!\cond
+    requires std::ranges::forward_range<underlying_range_type> && std::ranges::common_range<underlying_range_type>
+//!\endcond
 template <typename range_type>
 class pairwise_combine_view<underlying_range_type>::iterator_type
 {
@@ -286,9 +289,9 @@ private:
     //!\brief Alias type for the iterator over the passed range type.
     using underlying_iterator_type = std::ranges::iterator_t<range_type>;
     //!\brief Alias for the value type of the underlying iterator type.
-    using underlying_val_t = typename std::iterator_traits<underlying_iterator_type>::value_type;
+    using underlying_val_t = std::iter_value_t<underlying_iterator_type>;
     //!\brief Alias for the reference type of the underlying iterator type.
-    using underlying_ref_t = typename std::iterator_traits<underlying_iterator_type>::reference;
+    using underlying_ref_t = std::iter_reference_t<underlying_iterator_type>;
 
 public:
     /*!\name Associated types
@@ -296,13 +299,13 @@ public:
      */
 
     //!\brief The difference type.
-    using difference_type   = std::ptrdiff_t;
+    using difference_type = std::ptrdiff_t;
     //!\brief The value type.
-    using value_type        = std::tuple<underlying_val_t, underlying_val_t>;
+    using value_type = std::tuple<underlying_val_t, underlying_val_t>;
     //!\brief The reference type.
-    using reference         = common_tuple<underlying_ref_t, underlying_ref_t>;
+    using reference = common_tuple<underlying_ref_t, underlying_ref_t>;
     //!\brief The pointer type.
-    using pointer           = void;
+    using pointer = void;
     //!\brief The iterator category tag.
     using iterator_category = iterator_tag_t<underlying_iterator_type>;
     //!\brief The iterator concept.
@@ -371,14 +374,13 @@ public:
     /*!\brief Access the element at the given index
      * \param[in] index The index of the element to be returned.
      */
-    constexpr reference operator[](size_t const index)
+    constexpr reference operator[](size_t const index) const
         noexcept(noexcept(std::declval<iterator_type &>().from_index(1)))
     //!\cond
         requires std::random_access_iterator<underlying_iterator_type>
     //!\endcond
     {
-        from_index(index);
-        return **this;
+        return *(*this + index);
     }
     //!\}
 
@@ -449,7 +451,7 @@ public:
 
     //!\brief Advances the iterator by the given offset; `underlying_iterator_type` must model
     //!\      std::random_access_iterator.
-    constexpr iterator_type operator+(difference_type const offset)
+    constexpr iterator_type operator+(difference_type const offset) const
         noexcept(noexcept(std::declval<iterator_type &>() += 1))
     //!\cond
         requires std::random_access_iterator<underlying_iterator_type>
@@ -485,7 +487,7 @@ public:
 
     //!\brief Decrements the iterator by the given offset; `underlying_iterator_type` must model
     //!\      std::random_access_iterator.
-    constexpr iterator_type operator-(difference_type const offset)
+    constexpr iterator_type operator-(difference_type const offset) const
         noexcept(noexcept(std::declval<iterator_type &>() -= 1))
     //!\cond
         requires std::random_access_iterator<underlying_iterator_type>
@@ -651,17 +653,7 @@ private:
     underlying_iterator_type begin_it{};
     //!\brief The end of the underlying range.
     underlying_iterator_type end_it{};
-}; // class pairwise_combine_view::iterator_type
-
-/*!\name Type deduction guides
- * \{
- */
-
-//!\brief Deduces the correct template type from a non-view lvalue range by wrapping the range in std::views::all.
-template <std::ranges::viewable_range other_range_t>
-pairwise_combine_view(other_range_t && range) ->
-    pairwise_combine_view<std::views::all_t<other_range_t>>;
-//!\}
+};
 
 } // namespace seqan3::detail
 

--- a/include/seqan3/range/views/repeat.hpp
+++ b/include/seqan3/range/views/repeat.hpp
@@ -88,12 +88,12 @@ public:
     /*!\name Constructors, destructor and assignment
      * \{
      */
-    constexpr repeat_view() = default;                                //!< Defaulted.
-    constexpr repeat_view(repeat_view const &) = default;             //!< Defaulted.
-    constexpr repeat_view & operator=(repeat_view const &) = default; //!< Defaulted.
-    constexpr repeat_view(repeat_view &&) = default;                  //!< Defaulted.
-    constexpr repeat_view & operator=(repeat_view &&) = default;      //!< Defaulted.
-    ~repeat_view() = default;                                         //!< Defaulted.
+    repeat_view() = default; //!< Defaulted.
+    repeat_view(repeat_view const &) = default; //!< Defaulted.
+    repeat_view & operator=(repeat_view const &) = default; //!< Defaulted.
+    repeat_view(repeat_view &&) = default; //!< Defaulted.
+    repeat_view & operator=(repeat_view &&) = default; //!< Defaulted.
+    ~repeat_view() = default; //!< Defaulted.
 
     //!\brief Construct from any type (Note: the value will be copied into views::single).
     constexpr explicit repeat_view(value_t const & value) : single_value{value}
@@ -205,14 +205,14 @@ public:
 
 private:
     //!\brief A std::views::single over the input.
-    decltype(std::views::single(std::declval<value_t &>())) single_value;
-}; //class repeat_view
+    single_value_t single_value;
+};
 
 //!\brief The iterator type for views::repeat (a random access iterator).
 template <std::copy_constructible value_t>
 template <typename parent_type>
-class repeat_view<value_t>::repeat_view_iterator : public detail::random_access_iterator_base<parent_type,
-                                                                                              repeat_view_iterator>
+class repeat_view<value_t>::repeat_view_iterator :
+    public detail::random_access_iterator_base<parent_type, repeat_view_iterator>
 {
     //!\brief The CRTP base type.
     using base_t = detail::random_access_iterator_base<parent_type, repeat_view_iterator>;
@@ -235,12 +235,12 @@ public:
     /*!\name Constructors, destructor and assignment
      * \{
      */
-    constexpr repeat_view_iterator() = default;                                         //!< Defaulted.
-    constexpr repeat_view_iterator(repeat_view_iterator const &) = default;             //!< Defaulted.
-    constexpr repeat_view_iterator & operator=(repeat_view_iterator const &) = default; //!< Defaulted.
-    constexpr repeat_view_iterator (repeat_view_iterator &&) = default;                 //!< Defaulted.
-    constexpr repeat_view_iterator & operator=(repeat_view_iterator &&) = default;      //!< Defaulted.
-    ~repeat_view_iterator() = default;                                                  //!< Defaulted.
+    repeat_view_iterator() = default; //!< Defaulted.
+    repeat_view_iterator(repeat_view_iterator const &) = default; //!< Defaulted.
+    repeat_view_iterator & operator=(repeat_view_iterator const &) = default; //!< Defaulted.
+    repeat_view_iterator (repeat_view_iterator &&) = default; //!< Defaulted.
+    repeat_view_iterator & operator=(repeat_view_iterator &&) = default; //!< Defaulted.
+    ~repeat_view_iterator() = default; //!< Defaulted.
 
     /*!\brief Construct by host range.
      * \param host The host range.
@@ -294,7 +294,7 @@ public:
         return true;
     }
     //!\}
-}; // class repeat_view::repeat_view_iterator
+};
 
 // ---------------------------------------------------------------------------------------------------------------------
 // repeat (factory)

--- a/include/seqan3/range/views/take.hpp
+++ b/include/seqan3/range/views/take.hpp
@@ -69,25 +69,25 @@ private:
      * \{
      */
     //!\brief The iterator type of this view (a random access iterator).
-    using iterator          = iterator_type<urng_t>;
+    using iterator = iterator_type<urng_t>;
     /*!\brief Note that this declaration does not give any compiler errors for non-const iterable ranges. Although
      * `iterator_type` inherits from std::ranges::iterator_t which is not defined on a const-range, i.e. `urng_t const,
      *  if it is not const-iterable. We only just declare this type and never instantiate it, i.e. use this type within
      *  this class, if the underlying range is not const-iterable.
      */
-    using const_iterator    = iterator_type<urng_t const>;
+    using const_iterator = iterator_type<urng_t const>;
     //!\}
 
 public:
     /*!\name Constructors, destructor and assignment
      * \{
      */
-    constexpr view_take()                                  = default; //!< Defaulted.
-    constexpr view_take(view_take const & rhs)             = default; //!< Defaulted.
-    constexpr view_take(view_take && rhs)                  = default; //!< Defaulted.
-    constexpr view_take & operator=(view_take const & rhs) = default; //!< Defaulted.
-    constexpr view_take & operator=(view_take && rhs)      = default; //!< Defaulted.
-    ~view_take()                                           = default; //!< Defaulted.
+    view_take() = default; //!< Defaulted.
+    view_take(view_take const & rhs) = default; //!< Defaulted.
+    view_take(view_take && rhs) = default; //!< Defaulted.
+    view_take & operator=(view_take const & rhs) = default; //!< Defaulted.
+    view_take & operator=(view_take && rhs) = default; //!< Defaulted.
+    ~view_take() = default; //!< Defaulted.
 
     /*!\brief Construct from another View.
      * \param[in] _urange The underlying range.
@@ -238,22 +238,27 @@ public:
     {
         return target_size;
     }
-}; // class view_take
+};
+
+//!\brief Template argument type deduction guide that strips references.
+//!\relates seqan3::detail::view_take
+template <typename urng_t,
+          bool exactly = false,
+          bool or_throw = false>
+view_take(urng_t && , size_t) -> view_take<std::views::all_t<urng_t>, exactly, or_throw>;
 
 //!\brief The iterator for the view_take. It inherits from the underlying type, but overwrites several operators.
 //!\tparam rng_t Should be `urng_t` for defining #iterator and `urng_t const` for defining #const_iterator.
 template <std::ranges::view urng_t, bool exactly, bool or_throw>
 template <typename rng_t>
-class view_take<urng_t,
-                exactly,
-                or_throw>::iterator_type : public inherited_iterator_base<iterator_type<rng_t>,
-                                                                          std::ranges::iterator_t<rng_t>>
+class view_take<urng_t, exactly, or_throw>::iterator_type :
+    public inherited_iterator_base<iterator_type<rng_t>, std::ranges::iterator_t<rng_t>>
 {
 private:
     //!\brief The iterator type of the underlying range.
     using base_base_t = std::ranges::iterator_t<rng_t>;
     //!\brief The CRTP wrapper type.
-    using base_t      = inherited_iterator_base<iterator_type, std::ranges::iterator_t<rng_t>>;
+    using base_t = inherited_iterator_base<iterator_type, std::ranges::iterator_t<rng_t>>;
 
     //!\brief The sentinel type is identical to that of the underlying range.
     using sentinel_type = std::ranges::sentinel_t<urng_t>;
@@ -272,12 +277,12 @@ public:
      * \brief Exceptions specification is implicitly inherited.
      * \{
      */
-    constexpr iterator_type()                                      = default; //!< Defaulted.
-    constexpr iterator_type(iterator_type const & rhs)             = default; //!< Defaulted.
-    constexpr iterator_type(iterator_type && rhs)                  = default; //!< Defaulted.
-    constexpr iterator_type & operator=(iterator_type const & rhs) = default; //!< Defaulted.
-    constexpr iterator_type & operator=(iterator_type && rhs)      = default; //!< Defaulted.
-    ~iterator_type()                                               = default; //!< Defaulted.
+    iterator_type() = default; //!< Defaulted.
+    iterator_type(iterator_type const & rhs) = default; //!< Defaulted.
+    iterator_type(iterator_type && rhs) = default; //!< Defaulted.
+    iterator_type & operator=(iterator_type const & rhs) = default; //!< Defaulted.
+    iterator_type & operator=(iterator_type && rhs) = default; //!< Defaulted.
+    ~iterator_type() = default; //!< Defaulted.
 
     //!\brief Constructor that delegates to the CRTP layer.
     constexpr iterator_type(base_base_t const & it) noexcept(noexcept(base_t{it})) :
@@ -288,9 +293,8 @@ public:
     constexpr iterator_type(base_base_t it,
                             size_t const _pos,
                             size_t const _max_pos,
-                            view_take * host = nullptr) noexcept(noexcept(base_t{it})) : base_t{std::move(it)},
-                                                                                                pos{_pos},
-                                                                                                max_pos(_max_pos)
+                            view_take * host = nullptr) noexcept(noexcept(base_t{it})) :
+        base_t{std::move(it)}, pos{_pos}, max_pos(_max_pos)
     {
         host_ptr = host;
     }
@@ -466,14 +470,7 @@ public:
         return base_base_t::operator[](n);
     }
     //!\}
-}; // class view_take::iterator_type
-
-//!\brief Template argument type deduction guide that strips references.
-//!\relates seqan3::detail::view_take
-template <typename urng_t,
-          bool exactly = false,
-          bool or_throw = false>
-view_take(urng_t && , size_t) -> view_take<std::views::all_t<urng_t>, exactly, or_throw>;
+};
 
 // ============================================================================
 //  take_fn (adaptor definition)


### PR DESCRIPTION
It seems that https://github.com/seqan/seqan3/pull/1914 unfortunately didn't start from a fresh checkout of `upstream/master`. It seems that some of my previous changes / fixes got lost due to merge-conflicts.

This PR is re-applying fix

* https://github.com/seqan/seqan3/pull/1900 and
* https://github.com/seqan/seqan3/pull/1885.

Furthermore, I did some code clean-up.