### PR TITLE
[FIX] Explicit return type in transform lambda to avoid hard compiler error.

### DIFF
--- a/include/seqan3/alignment/matrix/detail/score_matrix_single_column.hpp
+++ b/include/seqan3/alignment/matrix/detail/score_matrix_single_column.hpp
@@ -168,6 +168,7 @@ private:
 
     //!\brief The transform adaptor to convert the tuple from the zip view into a seqan3::detail::affine_cell_type.
     static constexpr auto transform_to_affine_cell = std::views::transform([] (auto && tpl)
+        -> affine_cell_proxy<remove_cvref_t<decltype(tpl)>>
     {
         using fwd_tuple_t = decltype(tpl);
         return affine_cell_proxy<remove_cvref_t<fwd_tuple_t>>{std::forward<fwd_tuple_t>(tpl)};


### PR DESCRIPTION
Part of #1908 

When the return type for the lambda is not given the entire body must be evaluated in the overload resolution of the transform view.
There also the const qualified version is checked by the compiler. If inside the body of the lambda function is
an expression that results in a constraint error the compiler will omit an hard error because he cannot deduce the return type.
To fix this, the return type is given explicitly in order to allow SFINAE friendly substituion errors due to incomplete types in the return type.