### PR TITLE
Refactor affine cell proxy

### DIFF
--- a/include/seqan3/alignment/matrix/detail/affine_cell_proxy.hpp
+++ b/include/seqan3/alignment/matrix/detail/affine_cell_proxy.hpp
@@ -13,11 +13,42 @@
 #pragma once
 
 #include <tuple>
+#include <type_traits>
 
+#include <seqan3/core/concept/core_language.hpp>
+#include <seqan3/core/simd/concept.hpp>
 #include <seqan3/core/tuple_utility.hpp>
 
 namespace seqan3::detail
 {
+
+/*!\interface seqan3::detail::arithmetic_or_simd <>
+ * \brief The concept for an type that models either seqan3::arithmetic or seqan3::simd::simd_concept.
+ * \ingroup alignment_matrix
+ */
+//!\cond
+template <typename t>
+SEQAN3_CONCEPT arithmetic_or_simd = arithmetic<t> || simd_concept<t>;
+//!\endcond
+
+/*!\interface seqan3::detail::affine_score_cell <>
+ * \extends seqan3::tuple_like
+ * \brief The concept for an type that models an affine cell of the score matrix.
+ * \ingroup alignment_matrix
+ *
+ * \details
+ *
+ * This concept describes the requirements an alignment matrix cell must fulfil to represent an affine score
+ * matrix entry.
+ */
+//!\cond
+template <typename t>
+SEQAN3_CONCEPT affine_score_cell = tuple_like<t> &&
+                                   std::tuple_size_v<t> == 3 &&
+                                   arithmetic_or_simd<std::remove_reference_t<std::tuple_element_t<0, t>>> &&
+                                   arithmetic_or_simd<std::remove_reference_t<std::tuple_element_t<1, t>>> &&
+                                   arithmetic_or_simd<std::remove_reference_t<std::tuple_element_t<2, t>>>;
+//!\endcond
 
 /*!\brief A wrapper for an affine score matrix cell.
  * \implements seqan3::tuple_like
@@ -28,7 +59,7 @@ namespace seqan3::detail
  * This wrapper provides a uniform access to the different elements of the cell within an affine score matrix. This
  * includes the optimal score, the horizontal gap score and the vertical gap score.
  */
-template <tuple_like tuple_t>
+template <affine_score_cell tuple_t>
 //!\cond
     requires (std::tuple_size_v<tuple_t> == 3)
 //!\endcond

--- a/include/seqan3/alignment/matrix/detail/affine_cell_proxy.hpp
+++ b/include/seqan3/alignment/matrix/detail/affine_cell_proxy.hpp
@@ -50,56 +50,69 @@ public:
     using tuple_t::operator=;
     //!\}
 
-    /*!\name Optimal score
+    /*!\name Score value accessor
+     * \brief Specific accessor function to get the respective score value from an affine matrix cell.
      * \{
      */
-    //!\brief Access the optimal score of the wrapped score matrix cell.
-    decltype(auto) best_score() & { using std::get; return get<0>(*this); }
+    //!\brief Access the best score of the wrapped score matrix cell.
+    decltype(auto) best_score() & noexcept { return get_score_impl<0>(*this); }
     //!\overload
-    decltype(auto) best_score() const & { using std::get; return get<0>(*this); }
+    decltype(auto) best_score() const & noexcept { return get_score_impl<0>(*this); }
     //!\overload
-    decltype(auto) best_score() && { using std::get; return get<0>(std::move(*this)); }
+    decltype(auto) best_score() && noexcept { return get_score_impl<0>(std::move(*this)); }
     //!\overload
-    decltype(auto) best_score() const &&
+    decltype(auto) best_score() const && noexcept
     { //Unfortunately gcc7 does not preserve the const && type: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94967
-        using std::get;
-        return static_cast<std::tuple_element_t<0, tuple_t> const &&>(get<0>(std::move(*this)));
+        using return_t = std::tuple_element_t<0, tuple_t>;
+        return static_cast<return_t const &&>(get_score_impl<0>(std::move(*this)));
     }
-    //!\}
 
-    /*!\name Horizontal score
-     * \{
-     */
     //!\brief Access the horizontal score of the wrapped score matrix cell.
-    decltype(auto) horizontal_score() & { using std::get; return get<1>(*this); }
+    decltype(auto) horizontal_score() & noexcept { return get_score_impl<1>(*this); }
     //!\overload
-    decltype(auto) horizontal_score() const & { using std::get; return get<1>(*this); }
+    decltype(auto) horizontal_score() const & noexcept { return get_score_impl<1>(*this); }
     //!\overload
-    decltype(auto) horizontal_score() && { using std::get; return get<1>(std::move(*this)); }
+    decltype(auto) horizontal_score() && noexcept { return get_score_impl<1>(std::move(*this)); }
     //!\overload
-     decltype(auto) horizontal_score() const &&
+     decltype(auto) horizontal_score() const && noexcept
     { //Unfortunately gcc7 does not preserve the const && type: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94967
-        using std::get;
-        return static_cast<std::tuple_element_t<1, tuple_t> const &&>(get<1>(std::move(*this)));
+        using return_t = std::tuple_element_t<1, tuple_t>;
+        return static_cast<return_t const &&>(get_score_impl<1>(std::move(*this)));
+    }
+
+    //!\brief Access the vertical score of the wrapped score matrix cell.
+    decltype(auto) vertical_score() & noexcept { return get_score_impl<2>(*this); }
+    //!\overload
+    decltype(auto) vertical_score() const & noexcept { return get_score_impl<2>(*this); }
+    //!\overload
+    decltype(auto) vertical_score() && noexcept { return get_score_impl<2>(std::move(*this)); }
+    //!\overload
+    decltype(auto) vertical_score() const && noexcept
+    { //Unfortunately gcc7 does not preserve the const && type: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94967
+        using return_t = std::tuple_element_t<2, tuple_t>;
+        return static_cast<return_t const &&>(get_score_impl<2>(std::move(*this)));
     }
     //!\}
 
-    /*!\name Vertical score
-     * \{
+private:
+    /*!\brief Implements the get interface for the various calls to receive the score value.
+     * \tparam index The index of the tuple element to get; must be smaller than 3.
+     * \tparam this_t The perfectly forwarded type of `*this`.
+     *
+     * \param[in] me The instance of `*this`.
+     *
+     * \returns The score value from the given tuple index.
      */
-    //!\brief Access the vertical score of the wrapped score matrix cell.
-    decltype(auto) vertical_score() & { using std::get; return get<2>(*this); }
-    //!\overload
-    decltype(auto) vertical_score() const & { using std::get; return get<2>(*this); }
-    //!\overload
-    decltype(auto) vertical_score() && { using std::get; return get<2>(std::move(*this)); }
-    //!\overload
-    decltype(auto) vertical_score() const &&
-    { //Unfortunately gcc7 does not preserve the const && type: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94967
+    template <size_t index, typename this_t>
+    //!\cond
+        requires (index < 3)
+    //!\endcond
+    static constexpr decltype(auto) get_score_impl(this_t && me) noexcept
+    {
         using std::get;
-        return static_cast<std::tuple_element_t<2, tuple_t> const &&>(get<2>(std::move(*this)));
+
+        return get<index>(std::forward<this_t>(me));
     }
-    //!\}
 };
 } // namespace seqan3::detail
 

--- a/include/seqan3/alignment/matrix/detail/affine_cell_proxy.hpp
+++ b/include/seqan3/alignment/matrix/detail/affine_cell_proxy.hpp
@@ -23,7 +23,7 @@ namespace seqan3::detail
 {
 
 /*!\interface seqan3::detail::arithmetic_or_simd <>
- * \brief The concept for an type that models either seqan3::arithmetic or seqan3::simd::simd_concept.
+ * \brief The concept for a type that models either seqan3::arithmetic or seqan3::simd::simd_concept.
  * \ingroup alignment_matrix
  */
 //!\cond
@@ -33,7 +33,7 @@ SEQAN3_CONCEPT arithmetic_or_simd = arithmetic<t> || simd_concept<t>;
 
 /*!\interface seqan3::detail::affine_score_cell <>
  * \extends seqan3::tuple_like
- * \brief The concept for an type that models an affine cell of the score matrix.
+ * \brief The concept for a type that models an affine cell of the score matrix.
  * \ingroup alignment_matrix
  *
  * \details
@@ -52,7 +52,10 @@ SEQAN3_CONCEPT affine_score_cell = tuple_like<t> &&
 
 /*!\brief A wrapper for an affine score matrix cell.
  * \implements seqan3::tuple_like
- * \ingroup pairwise_alignment
+ * \ingroup alignment_matrix
+ *
+ * \tparam tuple_t The underlying cell type of the affine alignment matrix; must model
+ *                 seqan3::detail::affine_score_cell.
  *
  * \details
  *

--- a/include/seqan3/alignment/matrix/detail/affine_cell_proxy.hpp
+++ b/include/seqan3/alignment/matrix/detail/affine_cell_proxy.hpp
@@ -54,13 +54,13 @@ public:
      * \{
      */
     //!\brief Access the optimal score of the wrapped score matrix cell.
-    decltype(auto) optimal_score() & { using std::get; return get<0>(*this); }
+    decltype(auto) best_score() & { using std::get; return get<0>(*this); }
     //!\overload
-    decltype(auto) optimal_score() const & { using std::get; return get<0>(*this); }
+    decltype(auto) best_score() const & { using std::get; return get<0>(*this); }
     //!\overload
-    decltype(auto) optimal_score() && { using std::get; return get<0>(std::move(*this)); }
+    decltype(auto) best_score() && { using std::get; return get<0>(std::move(*this)); }
     //!\overload
-    decltype(auto) optimal_score() const &&
+    decltype(auto) best_score() const &&
     { //Unfortunately gcc7 does not preserve the const && type: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94967
         using std::get;
         return static_cast<std::tuple_element_t<0, tuple_t> const &&>(get<0>(std::move(*this)));

--- a/include/seqan3/alignment/pairwise/detail/pairwise_alignment_algorithm.hpp
+++ b/include/seqan3/alignment/pairwise/detail/pairwise_alignment_algorithm.hpp
@@ -296,7 +296,7 @@ protected:
         auto cell_index_column_it = cell_index_column.begin();
 
         auto cell = *alignment_column_it;
-        score_type diagonal = cell.optimal_score();
+        score_type diagonal = cell.best_score();
         *alignment_column_it = this->track_cell(this->initialise_first_row_cell(cell), *cell_index_column_it);
 
         // ---------------------------------------------------------------------
@@ -306,7 +306,7 @@ protected:
         for (auto && sequence2_value : sequence2)
         {
             auto cell = *++alignment_column_it;
-            score_type next_diagonal = cell.optimal_score();
+            score_type next_diagonal = cell.best_score();
             *alignment_column_it = this->track_cell(
                 this->compute_inner_cell(diagonal, cell, m_scoring_scheme.score(sequence1_value, sequence2_value)),
                 *++cell_index_column_it);

--- a/include/seqan3/alignment/pairwise/detail/pairwise_alignment_algorithm_banded.hpp
+++ b/include/seqan3/alignment/pairwise/detail/pairwise_alignment_algorithm_banded.hpp
@@ -296,7 +296,7 @@ protected:
 
         auto cell = *alignment_column_it;
         cell = this->track_cell(
-                this->initialise_band_first_cell(cell.optimal_score(),
+                this->initialise_band_first_cell(cell.best_score(),
                                                  *++alignment_column_it,
                                                  this->m_scoring_scheme.score(sequence1_value,
                                                                               *std::ranges::begin(sequence2))),
@@ -310,7 +310,7 @@ protected:
         {
             auto cell = *alignment_column_it;
             cell = this->track_cell(
-                this->compute_inner_cell(cell.optimal_score(),
+                this->compute_inner_cell(cell.best_score(),
                                          *++alignment_column_it,
                                          this->m_scoring_scheme.score(sequence1_value, sequence2_value)),
                 *++cell_index_column_it);

--- a/include/seqan3/alignment/pairwise/detail/policy_optimum_tracker.hpp
+++ b/include/seqan3/alignment/pairwise/detail/policy_optimum_tracker.hpp
@@ -65,7 +65,7 @@ private:
 
     /*!\brief Find the new maximum for a given cell of the alignment matrix.
      *
-     * \tparam cell_t The cell type of the alignment matrix; must have a member function `optimal_score()`.
+     * \tparam cell_t The cell type of the alignment matrix; must have a member function `best_score()`.
      *
      * \param[in] cell The current cell to be tracked.
      * \param[in] coordinate The matrix coordinate of the current cell.
@@ -80,8 +80,8 @@ private:
     template <typename cell_t>
     void find_new_optimum(cell_t && cell, matrix_coordinate coordinate) noexcept
     {
-        bool const is_better_score = cell.optimal_score() >= optimal_score;
-        optimal_score = is_better_score ? cell.optimal_score() : optimal_score;
+        bool const is_better_score = cell.best_score() >= optimal_score;
+        optimal_score = is_better_score ? cell.best_score() : optimal_score;
         optimal_coordinate = is_better_score ? std::move(coordinate) : optimal_coordinate;
     }
 
@@ -118,7 +118,7 @@ protected:
 
     /*!\brief Tracks any cell within the alignment matrix.
      *
-     * \tparam cell_t The cell type of the alignment matrix; must have a member function `optimal_score()`.
+     * \tparam cell_t The cell type of the alignment matrix; must have a member function `best_score()`.
      *
      * \param[in] cell The current cell to be tracked.
      * \param[in] coordinate The matrix coordinate of the current cell.
@@ -138,7 +138,7 @@ protected:
 
     /*!\brief Tracks the last cell of a row within the alignment matrix.
      *
-     * \tparam cell_t The cell type of the alignment matrix; must have a member function `optimal_score()`.
+     * \tparam cell_t The cell type of the alignment matrix; must have a member function `best_score()`.
      *
      * \param[in] cell The current cell to be tracked.
      * \param[in] coordinate The matrix coordinate of the current cell.
@@ -161,7 +161,7 @@ protected:
 
     /*!\brief Tracks the last cell of a column within the alignment matrix.
      *
-     * \tparam cell_t The cell type of the alignment matrix; must have a member function `optimal_score()`.
+     * \tparam cell_t The cell type of the alignment matrix; must have a member function `best_score()`.
      *
      * \param[in] cell The current cell to be tracked.
      * \param[in] coordinate The matrix coordinate of the current cell.
@@ -184,7 +184,7 @@ protected:
 
     /*!\brief Tracks the final cell of the alignment matrix.
      *
-     * \tparam cell_t The cell type of the alignment matrix; must have a member function `optimal_score()`.
+     * \tparam cell_t The cell type of the alignment matrix; must have a member function `best_score()`.
      *
      * \param[in] cell The current cell to be tracked.
      * \param[in] coordinate The matrix coordinate of the current cell.

--- a/test/unit/alignment/matrix/detail/affine_cell_proxy_test.cpp
+++ b/test/unit/alignment/matrix/detail/affine_cell_proxy_test.cpp
@@ -102,4 +102,5 @@ TEST_F(affine_cell_proxy_test, tuple_element)
 TEST_F(affine_cell_proxy_test, tuple_like_concept)
 {
     EXPECT_TRUE(seqan3::tuple_like<cell_t>);
+    EXPECT_TRUE(seqan3::detail::affine_score_cell<cell_t>);
 }

--- a/test/unit/alignment/matrix/detail/affine_cell_proxy_test.cpp
+++ b/test/unit/alignment/matrix/detail/affine_cell_proxy_test.cpp
@@ -52,16 +52,16 @@ TEST_F(affine_cell_proxy_test, assignment)
     EXPECT_EQ(std::get<2>(other_cell), 10);
 }
 
-TEST_F(affine_cell_proxy_test, optimal_score)
+TEST_F(affine_cell_proxy_test, best_score)
 {
-    EXPECT_EQ(affine_cell.optimal_score(), 4);
-    EXPECT_EQ(const_affine_cell.optimal_score(), 4);
-    EXPECT_EQ(std::move(affine_cell).optimal_score(), 4);
-    EXPECT_EQ(std::move(const_affine_cell).optimal_score(), 4);
-    EXPECT_TRUE((std::same_as<decltype(affine_cell.optimal_score()), int &>));
-    EXPECT_TRUE((std::same_as<decltype(const_affine_cell.optimal_score()), int const &>));
-    EXPECT_TRUE((std::same_as<decltype(std::move(affine_cell).optimal_score()), int &&>));
-    EXPECT_TRUE((std::same_as<decltype(std::move(const_affine_cell).optimal_score()), int const &&>));
+    EXPECT_EQ(affine_cell.best_score(), 4);
+    EXPECT_EQ(const_affine_cell.best_score(), 4);
+    EXPECT_EQ(std::move(affine_cell).best_score(), 4);
+    EXPECT_EQ(std::move(const_affine_cell).best_score(), 4);
+    EXPECT_TRUE((std::same_as<decltype(affine_cell.best_score()), int &>));
+    EXPECT_TRUE((std::same_as<decltype(const_affine_cell.best_score()), int const &>));
+    EXPECT_TRUE((std::same_as<decltype(std::move(affine_cell).best_score()), int &&>));
+    EXPECT_TRUE((std::same_as<decltype(std::move(const_affine_cell).best_score()), int const &&>));
 }
 
 TEST_F(affine_cell_proxy_test, horizontal_score)

--- a/test/unit/alignment/matrix/detail/affine_cell_proxy_test.cpp
+++ b/test/unit/alignment/matrix/detail/affine_cell_proxy_test.cpp
@@ -19,7 +19,6 @@ struct affine_cell_proxy_test : public ::testing::Test
     int vertical{10};
 
     cell_t affine_cell{optimal, horizontal, vertical};
-    cell_t const const_affine_cell{affine_cell};
 };
 
 TEST_F(affine_cell_proxy_test, construction)
@@ -55,37 +54,37 @@ TEST_F(affine_cell_proxy_test, assignment)
 TEST_F(affine_cell_proxy_test, best_score)
 {
     EXPECT_EQ(affine_cell.best_score(), 4);
-    EXPECT_EQ(const_affine_cell.best_score(), 4);
+    EXPECT_EQ(std::as_const(affine_cell).best_score(), 4);
     EXPECT_EQ(std::move(affine_cell).best_score(), 4);
-    EXPECT_EQ(std::move(const_affine_cell).best_score(), 4);
+    EXPECT_EQ(std::move(std::as_const(affine_cell)).best_score(), 4);
     EXPECT_TRUE((std::same_as<decltype(affine_cell.best_score()), int &>));
-    EXPECT_TRUE((std::same_as<decltype(const_affine_cell.best_score()), int const &>));
+    EXPECT_TRUE((std::same_as<decltype(std::as_const(affine_cell).best_score()), int const &>));
     EXPECT_TRUE((std::same_as<decltype(std::move(affine_cell).best_score()), int &&>));
-    EXPECT_TRUE((std::same_as<decltype(std::move(const_affine_cell).best_score()), int const &&>));
+    EXPECT_TRUE((std::same_as<decltype(std::move(std::as_const(affine_cell)).best_score()), int const &&>));
 }
 
 TEST_F(affine_cell_proxy_test, horizontal_score)
 {
     EXPECT_EQ(affine_cell.horizontal_score(), -1);
-    EXPECT_EQ(const_affine_cell.horizontal_score(), -1);
+    EXPECT_EQ(std::as_const(affine_cell).horizontal_score(), -1);
     EXPECT_EQ(std::move(affine_cell).horizontal_score(), -1);
-    EXPECT_EQ(std::move(const_affine_cell).horizontal_score(), -1);
+    EXPECT_EQ(std::move(std::as_const(affine_cell)).horizontal_score(), -1);
     EXPECT_TRUE((std::same_as<decltype(affine_cell.horizontal_score()), int const &>));
-    EXPECT_TRUE((std::same_as<decltype(const_affine_cell.horizontal_score()), int const &>));
+    EXPECT_TRUE((std::same_as<decltype(std::as_const(affine_cell).horizontal_score()), int const &>));
     EXPECT_TRUE((std::same_as<decltype(std::move(affine_cell).horizontal_score()), int const &>));
-    EXPECT_TRUE((std::same_as<decltype(std::move(const_affine_cell).horizontal_score()), int const &>));
+    EXPECT_TRUE((std::same_as<decltype(std::move(std::as_const(affine_cell)).horizontal_score()), int const &>));
 }
 
 TEST_F(affine_cell_proxy_test, vertical_score)
 {
     EXPECT_EQ(affine_cell.vertical_score(), 10);
-    EXPECT_EQ(const_affine_cell.vertical_score(), 10);
+    EXPECT_EQ(std::as_const(affine_cell).vertical_score(), 10);
     EXPECT_EQ(std::move(affine_cell).vertical_score(), 10);
-    EXPECT_EQ(std::move(const_affine_cell).vertical_score(), 10);
+    EXPECT_EQ(std::move(std::as_const(affine_cell)).vertical_score(), 10);
     EXPECT_TRUE((std::same_as<decltype(affine_cell.vertical_score()), int &>));
-    EXPECT_TRUE((std::same_as<decltype(const_affine_cell.vertical_score()), int &>));
+    EXPECT_TRUE((std::same_as<decltype(std::as_const(affine_cell).vertical_score()), int &>));
     EXPECT_TRUE((std::same_as<decltype(std::move(affine_cell).vertical_score()), int &>));
-    EXPECT_TRUE((std::same_as<decltype(std::move(const_affine_cell).vertical_score()), int &>));
+    EXPECT_TRUE((std::same_as<decltype(std::move(std::as_const(affine_cell)).vertical_score()), int &>));
 }
 
 TEST_F(affine_cell_proxy_test, tuple_size)

--- a/test/unit/alignment/matrix/detail/score_matrix_single_column_simd_test.cpp
+++ b/test/unit/alignment/matrix/detail/score_matrix_single_column_simd_test.cpp
@@ -48,7 +48,7 @@ struct iterator_fixture<matrix_iterator_t> : public ::testing::Test
             auto actual_cell = *actual_it;
             auto expected_cell = *expected_it;
 
-            SIMD_EQ(actual_cell.optimal_score(), std::get<0>(expected_cell));
+            SIMD_EQ(actual_cell.best_score(), std::get<0>(expected_cell));
             SIMD_EQ(actual_cell.horizontal_score(), std::get<1>(expected_cell));
             SIMD_EQ(actual_cell.vertical_score(), std::get<2>(expected_cell));
         }

--- a/test/unit/alignment/matrix/detail/score_matrix_single_column_test.cpp
+++ b/test/unit/alignment/matrix/detail/score_matrix_single_column_test.cpp
@@ -49,7 +49,7 @@ struct iterator_fixture<matrix_iterator_t> : public ::testing::Test
             auto actual_cell = *actual_it;
             auto expected_cell = *expected_it;
 
-            EXPECT_EQ(actual_cell.optimal_score(), std::get<0>(expected_cell));
+            EXPECT_EQ(actual_cell.best_score(), std::get<0>(expected_cell));
             EXPECT_EQ(actual_cell.horizontal_score(), std::get<1>(expected_cell));
             EXPECT_EQ(actual_cell.vertical_score(), std::get<2>(expected_cell));
         }


### PR DESCRIPTION
part of #1908 

Some preparations before we add the pairwise matrix which is a combination of the score and the trace matrix. 
The proxy will then be extended to model both versions: only the score matrix and the combined score and trace matrix.