### PR TITLE
[FIX] gcc10: use std::variant::emplace instead of implicit assignment

### DIFF
--- a/include/seqan3/io/detail/misc.hpp
+++ b/include/seqan3/io/detail/misc.hpp
@@ -82,7 +82,7 @@ void set_format(format_variant_type & format,
             {
                 if (std::ranges::equal(ext, extension))
                 {
-                    format = fm_type{};
+                    format.template emplace<fm_type>();
                     format_found = true;
                     return;
                 }


### PR DESCRIPTION
Our PPC CI uses 10.1.0 release from source and it triggered an error
which most distros seems to have hot-patched.

I encountered that problem in the past and used this workaround, but the
problem was fixed in the meantime so that I did not need to submit this
patch.

The patch is confirmed to work by @eseiler
