### PR TITLE
[FIX] kmer_hash size works even with take_until | reverse

### DIFF
--- a/include/seqan3/range/views/kmer_hash.hpp
+++ b/include/seqan3/range/views/kmer_hash.hpp
@@ -181,9 +181,19 @@ public:
     auto size()
     //!\cond
         requires std::ranges::sized_range<urng_t>
+     //!\endcond
+    {
+        using size_type = std::ranges::range_size_t<urng_t>;
+        return std::max<size_type>(std::ranges::size(urange) + 1, shape_.size()) - shape_.size();
+    }
+
+    //!\copydoc size()
+    auto size() const
+    //!\cond
+        requires std::ranges::sized_range<urng_t const>
     //!\endcond
     {
-        using size_type = decltype(std::ranges::size(urange));
+        using size_type = std::ranges::range_size_t<urng_t const>;
         return std::max<size_type>(std::ranges::size(urange) + 1, shape_.size()) - shape_.size();
     }
 };

--- a/include/seqan3/range/views/kmer_hash.hpp
+++ b/include/seqan3/range/views/kmer_hash.hpp
@@ -178,7 +178,7 @@ public:
     /*!\brief Returns the size of the range, if the underlying range is a std::ranges::sized_range.
      * \returns Size of range.
      */
-    auto size() const
+    auto size()
     //!\cond
         requires std::ranges::sized_range<urng_t>
     //!\endcond

--- a/test/unit/range/views/view_kmer_hash_test.cpp
+++ b/test/unit/range/views/view_kmer_hash_test.cpp
@@ -230,3 +230,19 @@ TYPED_TEST(kmer_hash_gapped_test, issue1754)
         EXPECT_RANGE_EQ(result_t{8}, text1 | stop_at_t | std::views::reverse | gapped_view);
     }
 }
+
+// https://github.com/seqan/seqan3/issues/1953
+TEST(kmer_hash_ungapped_test, issue1953)
+{
+    std::vector<seqan3::dna4> text1{'A'_dna4, 'C'_dna4, 'G'_dna4, 'T'_dna4, 'A'_dna4, 'G'_dna4, 'C'_dna4}; // ACGTAGC
+    auto v = text1 | prefix_until_first_thymine | std::views::reverse | ungapped_view;
+    EXPECT_EQ(1u, v.size());
+}
+
+// https://github.com/seqan/seqan3/issues/1953
+TEST(kmer_hash_gapped_test, issue1953)
+{
+    std::vector<seqan3::dna4> text1{'A'_dna4, 'C'_dna4, 'G'_dna4, 'T'_dna4, 'A'_dna4, 'G'_dna4, 'C'_dna4}; // ACGTAGC
+    auto v = text1 | prefix_until_first_thymine | std::views::reverse | gapped_view;
+    EXPECT_EQ(1u, v.size());
+}


### PR DESCRIPTION
resolves #1953