### PR TITLE
[FIX] undocumented macro

### DIFF
--- a/include/seqan3/std/iterator
+++ b/include/seqan3/std/iterator
@@ -35,9 +35,11 @@ using ::std::ostreambuf_iterator;
 
 #ifndef __cpp_lib_ranges // implement C++20 iterators via range-v3
 
+//!\cond
 #ifndef RANGES_DEEP_STL_INTEGRATION
 #define RANGES_DEEP_STL_INTEGRATION 1
 #endif
+//!\endcond
 
 #include <range/v3/iterator/access.hpp>
 #include <range/v3/iterator/concepts.hpp>


### PR DESCRIPTION
Part of https://github.com/seqan/product_backlog/issues/107

See also `std/ranges` where it is done correclty

https://github.com/seqan/seqan3/blob/8c2d524207be3ff8029801551e78c8a5b0fa0777/include/seqan3/std/ranges#L62-L66