### PR TITLE
Cbegin cend

### DIFF
--- a/include/seqan3/alignment/matrix/detail/alignment_matrix_column_major_range_base.hpp
+++ b/include/seqan3/alignment/matrix/detail/alignment_matrix_column_major_range_base.hpp
@@ -257,9 +257,6 @@ private:
         //!\brief Deleted begin for const-qualified alignment-columns.
         constexpr auto begin() const noexcept = delete; // Not needed by the alignment algorithm
 
-        //!\brief Deleted begin for const-qualified alignment-columns.
-        constexpr auto cbegin() const noexcept = delete;  // Not needed by the alignment algorithm
-
         //!\brief Returns an iterator to the end of the column.
         constexpr sentinel end() noexcept
         {
@@ -268,9 +265,6 @@ private:
 
         //!\brief Deleted end for const-qualified alignment-columns.
         constexpr sentinel end() const noexcept = delete; // Not needed by the alignment algorithm
-
-        //!\brief Deleted end for const-qualified alignment-columns.
-        constexpr sentinel cend() const noexcept = delete; // Not needed by the alignment algorithm
         //!\}
 
         //!\brief Returns the size the alignment column.
@@ -504,9 +498,6 @@ public:
     //!\brief Deleted begin for const-qualified alignment matrix.
     constexpr iterator begin() const noexcept = delete; // not needed for the alignment algorithm
 
-    //!\brief Deleted begin for const-qualified alignment matrix.
-    constexpr iterator cbegin() const noexcept = delete; // not needed for the alignment algorithm
-
     //!\brief Returns a sentinel marking the end of the matrix.
     constexpr sentinel end() noexcept
     {
@@ -515,9 +506,6 @@ public:
 
     //!\brief Deleted end for const-qualified alignment matrix.
     constexpr sentinel end() const noexcept = delete; // not needed for the alignment algorithm
-
-    //!\brief Deleted end for const-qualified alignment matrix.
-    constexpr sentinel cend() const noexcept = delete; // not needed for the alignment algorithm
     //!\}
 };
 } // namespace seqan3::detail

--- a/include/seqan3/core/simd/view_to_simd.hpp
+++ b/include/seqan3/core/simd/view_to_simd.hpp
@@ -151,8 +151,6 @@ public:
 
     //!\brief Const iteration is disabled.
     constexpr void begin() const noexcept = delete;
-    //!\brief Const iteration is disabled.
-    constexpr void cbegin() const noexcept = delete;
 
     //!\brief A sentinel representing the end of this range.
     constexpr std::default_sentinel_t end() noexcept
@@ -162,8 +160,6 @@ public:
 
     //!\brief Const iteration is disabled.
     constexpr void end() const noexcept = delete;
-    //!\brief Const iteration is disabled.
-    constexpr void cend() const noexcept = delete;
     //!\}
 
     //!\brief Checks whether the range is empty.

--- a/include/seqan3/range/views/async_input_buffer.hpp
+++ b/include/seqan3/range/views/async_input_buffer.hpp
@@ -149,9 +149,6 @@ public:
     //!\brief Const-qualified async_input_buffer_view::begin() is deleted, because iterating changes the view.
     async_input_buffer_iterator begin() const = delete;
 
-    //!\copydoc async_input_buffer_view::begin() const
-    async_input_buffer_iterator cbegin() const = delete;
-
     //!\brief Returns a sentinel.
     std::default_sentinel_t end()
     {
@@ -160,9 +157,6 @@ public:
 
     //!\brief Const-qualified async_input_buffer_view::end() is deleted, because iterating changes the view.
     std::default_sentinel_t end() const = delete;
-
-    //!\copydoc async_input_buffer_view::end() const
-    std::default_sentinel_t cend() const = delete;
     //!\}
 };
 

--- a/include/seqan3/range/views/enforce_random_access.hpp
+++ b/include/seqan3/range/views/enforce_random_access.hpp
@@ -94,15 +94,6 @@ public:
         return enforced_random_access_iterator<decltype(std::ranges::cbegin(urng))>{std::ranges::cbegin(urng)};
     }
 
-    //!\copydoc seqan3::detail::view_enforce_random_access::begin
-    constexpr auto cbegin() const noexcept
-    //!\cond
-        requires const_iterable_range<urng_t>
-    //!\endcond
-    {
-        return begin();
-    }
-
     /*!\brief Returns the sentinel to the end of the range.
      *
      * \details
@@ -129,15 +120,6 @@ public:
             return enforced_random_access_iterator<decltype(std::ranges::cend(urng))>{std::ranges::cend(urng)};
         else
             return std::ranges::cend(urng);
-    }
-
-    //!\copydoc seqan3::detail::view_enforce_random_access::end
-    constexpr auto cend() const noexcept
-    //!\cond
-        requires const_iterable_range<urng_t>
-    //!\endcond
-    {
-        return end();
     }
     //!\}
 

--- a/include/seqan3/range/views/interleave.hpp
+++ b/include/seqan3/range/views/interleave.hpp
@@ -155,12 +155,6 @@ public:
         return {*this, 0};
     }
 
-    //!\overload
-    const_iterator cbegin() const noexcept
-    {
-        return begin();
-    }
-
     /*!\brief Returns an iterator to the element following the last element of the container.
      * \returns Iterator to the first element.
      *
@@ -183,12 +177,6 @@ public:
     const_iterator end() const noexcept
     {
         return {*this, size()};
-    }
-
-    //!\overload
-    const_iterator cend() const noexcept
-    {
-        return end();
     }
     //!\}
 

--- a/include/seqan3/range/views/kmer_hash.hpp
+++ b/include/seqan3/range/views/kmer_hash.hpp
@@ -124,7 +124,7 @@ public:
         requires const_iterable_range<urng_t>
     //!\endcond
     {
-        return shape_iterator<urng_t const>{std::ranges::begin(urange), std::ranges::end(urange), shape_};
+        return shape_iterator<urng_t const>{std::ranges::cbegin(urange), std::ranges::cend(urange), shape_};
     }
 
     /*!\brief Returns an iterator to the element following the last element of the range.
@@ -159,9 +159,9 @@ public:
     {
         // Assigning the end iterator to the text_right iterator of the shape_iterator only works for common ranges.
         if constexpr (std::ranges::common_range<urng_t const>)
-            return shape_iterator<urng_t const>{std::ranges::begin(urange), std::ranges::end(urange), shape_, true};
+            return shape_iterator<urng_t const>{std::ranges::cbegin(urange), std::ranges::cend(urange), shape_, true};
         else
-            return std::ranges::end(urange);
+            return std::ranges::cend(urange);
     }
     //!\}
 

--- a/include/seqan3/range/views/pairwise_combine.hpp
+++ b/include/seqan3/range/views/pairwise_combine.hpp
@@ -182,15 +182,6 @@ public:
         return {std::ranges::begin(u_range), std::ranges::begin(u_range), std::ranges::end(u_range)};
     }
 
-    //!\copydoc begin()
-    constexpr const_iterator cbegin() const noexcept
-    //!\cond
-        requires const_iterable_range<underlying_range_type>
-    //!\endcond
-    {
-        return begin();
-    }
-
     /*!\brief Returns an iterator to the element following the last element of the range.
      * \returns Iterator to the end.
      *
@@ -216,15 +207,6 @@ public:
     //!\endcond
     {
         return {back_iterator, std::ranges::begin(u_range), std::ranges::end(u_range)};
-    }
-
-    //!\copydoc end()
-    constexpr const_iterator cend() const noexcept
-    //!\cond
-        requires const_iterable_range<underlying_range_type>
-    //!\endcond
-    {
-        return end();
     }
     //!\}
 

--- a/include/seqan3/range/views/pairwise_combine.hpp
+++ b/include/seqan3/range/views/pairwise_combine.hpp
@@ -179,7 +179,7 @@ public:
         requires const_iterable_range<underlying_range_type>
     //!\endcond
     {
-        return {std::ranges::begin(u_range), std::ranges::begin(u_range), std::ranges::end(u_range)};
+        return {std::ranges::cbegin(u_range), std::ranges::cbegin(u_range), std::ranges::cend(u_range)};
     }
 
     /*!\brief Returns an iterator to the element following the last element of the range.
@@ -206,7 +206,7 @@ public:
         requires const_iterable_range<underlying_range_type>
     //!\endcond
     {
-        return {back_iterator, std::ranges::begin(u_range), std::ranges::end(u_range)};
+        return {back_iterator, std::ranges::cbegin(u_range), std::ranges::cend(u_range)};
     }
     //!\}
 

--- a/include/seqan3/range/views/persist.hpp
+++ b/include/seqan3/range/views/persist.hpp
@@ -49,15 +49,6 @@ private:
     //!\brief Shared storage of the underlying range.
     std::shared_ptr<urng_t> urange;
 
-    /*!\name Associated types
-     * \{
-     */
-    //!\brief The iterator type of this view (a random access iterator).
-    using iterator          = std::ranges::iterator_t<urng_t>;
-    //!\brief The const_iterator type is equal to the iterator type.
-    using const_iterator    = iterator;
-    //!\}
-
 public:
     /*!\name Constructors, destructor and assignment
      * \{
@@ -93,15 +84,18 @@ public:
      *
      * No-throw guarantee.
      */
-    const_iterator begin() const noexcept
+    auto begin() noexcept
     {
         return std::ranges::begin(*urange);
     }
 
     //!\copydoc begin()
-    const_iterator cbegin() const noexcept
+    auto begin() const noexcept
+    //!\cond
+        requires const_iterable_range<urng_t>
+    //!\endcond
     {
-        return begin();
+        return std::ranges::cbegin(*urange);
     }
 
     /*!\brief Returns an iterator to the element following the last element of the range.
@@ -117,15 +111,18 @@ public:
      *
      * No-throw guarantee.
      */
-    auto end() const noexcept
+    auto end() noexcept
     {
         return std::ranges::end(*urange);
     }
 
     //!\copydoc end()
-    auto cend() const noexcept
+    auto end() const noexcept
+    //!\cond
+        requires const_iterable_range<urng_t>
+    //!\endcond
     {
-        return end();
+        return std::ranges::cend(*urange);
     }
     //!\}
 };

--- a/include/seqan3/range/views/repeat.hpp
+++ b/include/seqan3/range/views/repeat.hpp
@@ -133,12 +133,6 @@ public:
         return const_iterator{*this};
     }
 
-    //!\copydoc begin()
-    constexpr const_iterator cbegin() const noexcept
-    {
-        return const_iterator{*this};
-    }
-
     /*!\brief Returns an iterator to the element following the last element of the range.
      * \returns Iterator to the end.
      *
@@ -161,12 +155,6 @@ public:
 
     //!\copydoc end()
     constexpr sentinel_type end() const noexcept
-    {
-        return {};
-    }
-
-    //!\copydoc end()
-    constexpr sentinel_type cend() const noexcept
     {
         return {};
     }

--- a/include/seqan3/range/views/single_pass_input.hpp
+++ b/include/seqan3/range/views/single_pass_input.hpp
@@ -121,9 +121,6 @@ public:
     //!\brief Const version of begin is deleted, since the underlying view_state must be mutable.
     iterator begin() const = delete;
 
-    //!\copydoc single_pass_input_view::begin() const
-    iterator cbegin() const = delete;
-
     //!\brief Returns a sentinel.
     sentinel end()
     {
@@ -132,9 +129,6 @@ public:
 
     //!\brief Const version of end is deleted, since the underlying view_state must be mutable.
     sentinel end() const = delete;
-
-    //!\copydoc single_pass_input_view::end() const
-    sentinel cend() const = delete;
     //!\}
 };
 

--- a/include/seqan3/range/views/take.hpp
+++ b/include/seqan3/range/views/take.hpp
@@ -165,16 +165,6 @@ public:
             return const_iterator{std::ranges::cbegin(urange), 0, target_size};
     }
 
-    //!\copydoc begin()
-    constexpr auto cbegin() const noexcept
-        requires const_iterable_range<urng_t>
-    {
-        if constexpr (std::ranges::random_access_range<urng_t> && std::ranges::sized_range<urng_t>)
-            return std::ranges::cbegin(urange);
-        else
-            return const_iterator{std::ranges::cbegin(urange), 0, target_size};
-    }
-
     /*!\brief Returns an iterator to the element following the last element of the range.
      * \returns Iterator to the end.
      *
@@ -198,16 +188,6 @@ public:
 
     //!\copydoc end()
     constexpr auto end() const noexcept
-        requires const_iterable_range<urng_t>
-    {
-        if constexpr (std::ranges::random_access_range<urng_t> && std::ranges::sized_range<urng_t>)
-            return std::ranges::cbegin(urange) + target_size;
-        else
-            return std::ranges::cend(urange);
-    }
-
-    //!\copydoc end()
-    constexpr auto cend() const noexcept
         requires const_iterable_range<urng_t>
     {
         if constexpr (std::ranges::random_access_range<urng_t> && std::ranges::sized_range<urng_t>)

--- a/include/seqan3/range/views/take_until.hpp
+++ b/include/seqan3/range/views/take_until.hpp
@@ -152,13 +152,6 @@ public:
         return {std::ranges::begin(urange), static_cast<fun_t const &>(fun), std::ranges::end(urange)};
     }
 
-    //!\copydoc begin()
-    const_iterator cbegin() const noexcept
-        requires const_iterable
-    {
-        return {std::ranges::begin(urange), static_cast<fun_t const &>(fun), std::ranges::end(urange)};
-    }
-
     /*!\brief Returns an iterator to the element following the last element of the range.
      * \returns Iterator to the end.
      *
@@ -188,13 +181,6 @@ public:
             return std::ranges::cend(urange);
         else
             return basic_sentinel<true>{std::ranges::cend(urange), static_cast<fun_t const &>(fun)};
-    }
-
-    //!\copydoc end()
-    auto cend() const noexcept
-        requires const_iterable
-    {
-        return end();
     }
     //!\}
 };

--- a/include/seqan3/range/views/take_until.hpp
+++ b/include/seqan3/range/views/take_until.hpp
@@ -149,7 +149,7 @@ public:
     const_iterator begin() const noexcept
         requires const_iterable
     {
-        return {std::ranges::begin(urange), static_cast<fun_t const &>(fun), std::ranges::end(urange)};
+        return {std::ranges::cbegin(urange), static_cast<fun_t const &>(fun), std::ranges::cend(urange)};
     }
 
     /*!\brief Returns an iterator to the element following the last element of the range.

--- a/include/seqan3/range/views/translate.hpp
+++ b/include/seqan3/range/views/translate.hpp
@@ -259,12 +259,6 @@ public:
         return {*this, 0};
     }
 
-    //!\overload
-    const_iterator cbegin() const noexcept
-    {
-        return begin();
-    }
-
     /*!\brief Returns an iterator to the element following the last element of the container.
      * \returns Iterator to the first element.
      *
@@ -287,12 +281,6 @@ public:
     const_iterator end() const noexcept
     {
         return {*this, size()};
-    }
-
-    //!\overload
-    const_iterator cend() const noexcept
-    {
-        return end();
     }
     //!\}
 
@@ -646,12 +634,6 @@ public:
         return {*this, 0};
     }
 
-    //!\overload
-    const_iterator cbegin() const noexcept
-    {
-        return begin();
-    }
-
     /*!\brief Returns an iterator to the element following the last element of the container.
      * \returns Iterator to the first element.
      *
@@ -675,13 +657,6 @@ public:
     {
         return {*this, size()};
     }
-
-    //!\overload
-    const_iterator cend() const noexcept
-    {
-        return end();
-    }
-    //!\}
 
     /*!\brief Returns the number of elements in the view.
      * \returns The number of elements in the container.

--- a/include/seqan3/range/views/translate_join.hpp
+++ b/include/seqan3/range/views/translate_join.hpp
@@ -169,13 +169,6 @@ public:
         return {*this, 0};
     }
 
-    //!\overload
-    const_iterator cbegin() const noexcept
-        requires const_iterable_range<urng_t>
-    {
-        return begin();
-    }
-
     /*!\brief Returns an iterator to the element following the last element of the container.
      * \returns Iterator to the first element.
      *
@@ -199,13 +192,6 @@ public:
         requires const_iterable_range<urng_t>
     {
         return {*this, size()};
-    }
-
-    //!\overload
-    const_iterator cend() const noexcept
-        requires const_iterable_range<urng_t>
-    {
-        return end();
     }
     //!\}
 

--- a/test/unit/range/views/view_pairwise_combine_test.cpp
+++ b/test/unit/range/views/view_pairwise_combine_test.cpp
@@ -389,7 +389,7 @@ TYPED_TEST(pairwise_combine_test, begin)
 
     EXPECT_EQ(*v.begin(), (std::tuple{'a', 'b'}));
     EXPECT_EQ(*cv.begin(), (std::tuple{'a', 'b'}));
-    EXPECT_EQ(*v.cbegin(), (std::tuple{'a', 'b'}));
+    EXPECT_EQ(*std::ranges::cbegin(v), (std::tuple{'a', 'b'}));
 }
 
 TYPED_TEST(pairwise_combine_test, end)
@@ -399,7 +399,7 @@ TYPED_TEST(pairwise_combine_test, end)
 
     EXPECT_TRUE(v.begin() != v.end());
     EXPECT_TRUE(cv.begin() != cv.end());
-    EXPECT_TRUE(v.cbegin() != v.cend());
+    EXPECT_TRUE(std::ranges::cbegin(v) != std::ranges::cend(v));
 }
 
 TYPED_TEST(pairwise_combine_test, iterate)

--- a/test/unit/range/views/view_persist_test.cpp
+++ b/test/unit/range/views/view_persist_test.cpp
@@ -91,7 +91,6 @@ TEST(view_persist, const)
 
 TEST(view_persist, concepts)
 {
-    std::string vec{"foobar"};
     EXPECT_TRUE(std::ranges::input_range<decltype(std::string{"foo"})>);
     EXPECT_TRUE(std::ranges::forward_range<decltype(std::string{"foo"})>);
     EXPECT_TRUE(std::ranges::bidirectional_range<decltype(std::string{"foo"})>);

--- a/test/unit/range/views/view_repeat_test.cpp
+++ b/test/unit/range/views/view_repeat_test.cpp
@@ -80,10 +80,10 @@ TEST(general, iterator)
     EXPECT_TRUE(v.begin() != v.end());
     EXPECT_TRUE(v.end() != v.begin());
 
-    EXPECT_FALSE(v.cbegin() == v.cend());
-    EXPECT_FALSE(v.cend() == v.cbegin());
-    EXPECT_TRUE(v.cbegin() != v.cend());
-    EXPECT_TRUE(v.cend() != v.cbegin());
+    EXPECT_FALSE(std::ranges::cbegin(v) == std::ranges::cend(v));
+    EXPECT_FALSE(std::ranges::cend(v) == std::ranges::cbegin(v));
+    EXPECT_TRUE(std::ranges::cbegin(v) != std::ranges::cend(v));
+    EXPECT_TRUE(std::ranges::cend(v) != std::ranges::cbegin(v));
 
     auto it = v.begin();
     EXPECT_EQ(*it, 'A');
@@ -116,7 +116,7 @@ TEST(general, iterator)
     *it = 'X';
     EXPECT_EQ(*it, 'X');
 
-    auto cit = v.cbegin();
+    auto cit = std::ranges::cbegin(v);
     cit = v.begin(); // assign it from const it
 }
 


### PR DESCRIPTION
Resolves https://github.com/seqan/product_backlog/issues/143 and  https://github.com/seqan/product_backlog/issues/142.

* `cbegin()` and `cend()` are removed from views, because standard views don't have them.
*  For all views `std::ranges::cbegin` and `std::ranges::cend` are used in the const overload of `begin()` and `end()`.

For `persist_view` a const overload of `begin()` and `end()` with return type `auto` were required to make this work. 