### PR TITLE
Fix gcc10 error

### DIFF
--- a/include/seqan3/range/views/kmer_hash.hpp
+++ b/include/seqan3/range/views/kmer_hash.hpp
@@ -241,9 +241,11 @@ public:
     //!\brief Tag this class as input iterator.
     using iterator_category = typename std::iterator_traits<it_t>::iterator_category;
     //!\brief Tag this class depending on which concept `it_t` models.
-    using iterator_concept = std::conditional_t<std::contiguous_iterator<it_t>,
+    using iterator_concept = std::conditional_t<std::random_access_iterator<it_t>,
                                                  typename std::random_access_iterator_tag,
-                                                 iterator_tag_t<it_t>>;
+                                                 std::conditional_t<std::bidirectional_iterator<it_t>, // solved #1963
+                                                    typename std::bidirectional_iterator_tag,
+                                                    iterator_tag_t<it_t>>>;
     //!\}
 
     /*!\name Constructors, destructor and assignment

--- a/test/unit/range/views/view_kmer_hash_test.cpp
+++ b/test/unit/range/views/view_kmer_hash_test.cpp
@@ -12,6 +12,7 @@
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
 #include <seqan3/range/container/bitcompressed_vector.hpp>
+#include <seqan3/range/views/complement.hpp>
 #include <seqan3/range/views/kmer_hash.hpp>
 #include <seqan3/range/views/repeat_n.hpp>
 #include <seqan3/range/views/take_until.hpp>
@@ -228,5 +229,32 @@ TYPED_TEST(kmer_hash_gapped_test, issue1754)
     if constexpr (std::ranges::bidirectional_range<TypeParam>) // excludes forward_list
     {
         EXPECT_RANGE_EQ(result_t{8}, text1 | stop_at_t | std::views::reverse | gapped_view);
+    }
+}
+
+// https://github.com/seqan/seqan3/issues/1963
+TYPED_TEST(kmer_hash_ungapped_test, issue1963)
+{
+    TypeParam text1{'A'_dna4, 'C'_dna4, 'G'_dna4, 'T'_dna4, 'A'_dna4, 'G'_dna4, 'C'_dna4}; // ACGTAGC
+    result_t ungapped{57, 36, 19, 13, 54};
+    if constexpr (std::ranges::bidirectional_range<TypeParam>) // excludes forward_list
+    {
+        auto v = text1 | seqan3::views::complement | ungapped_view;
+        EXPECT_RANGE_EQ(ungapped, v);
+        EXPECT_TRUE(std::ranges::forward_range<decltype(v)>);
+    }
+
+}
+
+// https://github.com/seqan/seqan3/issues/1963
+TYPED_TEST(kmer_hash_gapped_test, issue1963)
+{
+    TypeParam text1{'A'_dna4, 'C'_dna4, 'G'_dna4, 'T'_dna4, 'A'_dna4, 'G'_dna4, 'C'_dna4}; // ACGTAGC
+    result_t gapped{13, 8, 7, 1, 14};
+    if constexpr (std::ranges::bidirectional_range<TypeParam>) // excludes forward_list
+    {
+        auto v = text1 | seqan3::views::complement | gapped_view;
+        EXPECT_RANGE_EQ(gapped, v);
+        EXPECT_TRUE(std::ranges::forward_range<decltype(v)>);
     }
 }

--- a/test/unit/range/views/view_kmer_hash_test.cpp
+++ b/test/unit/range/views/view_kmer_hash_test.cpp
@@ -223,7 +223,7 @@ TYPED_TEST(kmer_hash_ungapped_test, issue1754)
 // https://github.com/seqan/seqan3/issues/1754
 TYPED_TEST(kmer_hash_gapped_test, issue1754)
 {
-    std::vector<seqan3::dna4> text1{'A'_dna4, 'C'_dna4, 'G'_dna4, 'T'_dna4, 'A'_dna4, 'G'_dna4, 'C'_dna4}; // ACGTAGC
+    TypeParam text1{'A'_dna4, 'C'_dna4, 'G'_dna4, 'T'_dna4, 'A'_dna4, 'G'_dna4, 'C'_dna4}; // ACGTAGC
 
     auto stop_at_t = seqan3::views::take_until([] (seqan3::dna4 const x) { return x == 'T'_dna4; });
     if constexpr (std::ranges::bidirectional_range<TypeParam>) // excludes forward_list


### PR DESCRIPTION
Resolves #1963 

Not sure, why this solves this, but this enforces that a bidirectional range stays bidirectional (and also stays a forward range). I also changed the first condition from contigous to random_access, otherwise a bitcompressed_vector would not result in a random access range, alternatively one could add another std::conditional and check first contigous, than random_access and then bidirectional, I am not sure what behaviour we want.

I also changed the parameter type in test of 1754 because the type was wrong.