### PR TITLE
[FIX] Broken parallel search

### DIFF
--- a/include/seqan3/core/algorithm/detail/algorithm_executor_blocking.hpp
+++ b/include/seqan3/core/algorithm/detail/algorithm_executor_blocking.hpp
@@ -166,7 +166,7 @@ public:
         algorithm{std::move(algorithm)}
     {
         if constexpr (std::same_as<execution_handler_t, execution_handler_parallel>)
-            buffer_size = std::ranges::distance(resource);
+            buffer_size = static_cast<size_t>(std::ranges::distance(resource));
 
         buffer.resize(buffer_size);
         buffer_it = buffer.end();

--- a/include/seqan3/search/search.hpp
+++ b/include/seqan3/search/search.hpp
@@ -128,13 +128,21 @@ inline auto search(queries_t && queries,
                                                            algorithm_result_t,
                                                            execution_handler_t>;
 
-    // Select the execution handler for the alignment configuration.
+    // Select the execution handler for the search configuration.
     auto select_execution_handler = [&] ()
     {
         if constexpr (std::same_as<execution_handler_t, detail::execution_handler_parallel>)
-            return execution_handler_t{get<search_cfg::parallel>(complete_config).value};
+        {
+            auto thread_count = get<search_cfg::parallel>(complete_config).thread_count;
+            if (!thread_count)
+                throw std::runtime_error{"You must configure the number of threads in seqan3::search_cfg::parallel."};
+
+            return execution_handler_t{*thread_count};
+        }
         else
+        {
             return execution_handler_t{};
+        }
     };
 
     return search_result_range{executor_t{std::move(indexed_queries),

--- a/test/unit/search/search_test.cpp
+++ b/test/unit/search/search_test.cpp
@@ -106,6 +106,22 @@ TYPED_TEST(search_test, multiple_queries)
     EXPECT_RANGE_EQ(search(queries, this->index, cfg) | position, (std::vector{0, 0, 4}));
 }
 
+TYPED_TEST(search_test, parallel_queries)
+{
+    constexpr size_t num_queries{100u};
+    std::vector<std::vector<seqan3::dna4>> const queries{num_queries, {"ACGTACGTACGT"_dna4}};
+
+    seqan3::configuration const cfg = seqan3::search_cfg::max_error_total{seqan3::search_cfg::error_rate{.0}} |
+                                      seqan3::search_cfg::max_error_substitution{seqan3::search_cfg::error_rate{.0}} |
+                                      seqan3::search_cfg::max_error_insertion{seqan3::search_cfg::error_rate{.0}} |
+                                      seqan3::search_cfg::max_error_deletion{seqan3::search_cfg::error_rate{.0}} |
+                                      seqan3::search_cfg::parallel{
+                                          std::min<uint32_t>(2, std::thread::hardware_concurrency())};
+
+    EXPECT_RANGE_EQ(search(queries, this->index, cfg) | query_id, std::views::iota(0u, num_queries));
+    EXPECT_RANGE_EQ(search(queries, this->index, cfg) | position, std::vector(num_queries, 0));
+}
+
 TYPED_TEST(search_test, invalid_error_configuration)
 {
     seqan3::configuration const cfg1 = seqan3::search_cfg::max_error_total{seqan3::search_cfg::error_rate{-0.5}};
@@ -436,6 +452,13 @@ TYPED_TEST(search_test, search_strategy_strata)
     //     EXPECT_RANGE_EQ(search(this->index, "CCGT"_dna4, cfg) | position, (std::vector{0, 1, 2, 3, 4, 5, 6, 7,
     //                                                                                    8, 9, 1, 0}));
     // }
+}
+
+TYPED_TEST(search_test, parallel_without_parameter)
+{
+    seqan3::configuration cfg = seqan3::search_cfg::parallel{};
+
+    EXPECT_THROW(search("AAAA"_dna4, this->index, cfg), std::runtime_error);
 }
 
 TYPED_TEST(search_string_test, error_free_string)


### PR DESCRIPTION
Resolves https://github.com/seqan/seqan3/issues/1962

When the parallel search was added in #1880, no tests were added. Consequently, #1917 did not trigger errors for the wrong config.