### PR TITLE
[FIX,MISC] Fix configuration pipe operator and remove method global from edit config.

### DIFF
--- a/doc/tutorial/introduction/introduction_align.cpp
+++ b/doc/tutorial/introduction/introduction_align.cpp
@@ -34,9 +34,10 @@ int main()
         sequences.push_back(seq);
     }
 
-    // Call a pairwise alignment with edit distance and traceback.
+    // Call a global pairwise alignment with edit distance and traceback.
     for (auto && res : align_pairwise(std::tie(sequences[0], sequences[1]),
-                                      seqan3::align_cfg::edit | seqan3::align_cfg::result{seqan3::with_alignment}))
+                                      seqan3::align_cfg::method_global |
+                                      seqan3::align_cfg::edit_scheme | seqan3::align_cfg::result{seqan3::with_alignment}))
     {
         // Print the resulting score and the alignment.
         seqan3::debug_stream << res.score() << '\n';      // => -4

--- a/doc/tutorial/pairwise_alignment/configurations.cpp
+++ b/doc/tutorial/pairwise_alignment/configurations.cpp
@@ -101,7 +101,7 @@ auto cfg = seqan3::align_cfg::band_fixed_size{seqan3::align_cfg::lower_diagonal{
 //! [edit]
 
 // Configure an edit distance alignment.
-auto cfg = seqan3::align_cfg::edit;
+auto cfg = seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme;
 //! [edit]
 (void) cfg;
 }

--- a/doc/tutorial/pairwise_alignment/index.md
+++ b/doc/tutorial/pairwise_alignment/index.md
@@ -294,7 +294,7 @@ used to compute the edit distance. This happens in SeqAn automatically if the re
 To do so, you need a scoring scheme initialised with Manhattan distance (at the moment only
 seqan3::nucleotide_scoring_scheme supports this) and a gap scheme initialised with `-1` for a gap and `0`
 for a gap open score and computing a seqan3::global_alignment.
-To make the configuration easier, we added a shortcut called seqan3::align_cfg::edit.
+To make the configuration easier, we added a shortcut called seqan3::align_cfg::edit_scheme.
 
 \snippet doc/tutorial/pairwise_alignment/configurations.cpp include_edit
 \snippet doc/tutorial/pairwise_alignment/configurations.cpp edit

--- a/doc/tutorial/pairwise_alignment/pairwise_alignment_solution_6.cpp
+++ b/doc/tutorial/pairwise_alignment/pairwise_alignment_solution_6.cpp
@@ -18,7 +18,8 @@ int main()
                     "AGGTACGAGCGACACT"_dna4};
 
     // Configure the alignment kernel.
-    auto config = seqan3::align_cfg::edit |
+    auto config = seqan3::align_cfg::method_global |
+                  seqan3::align_cfg::edit_scheme |
                   seqan3::align_cfg::max_error{7u} |
                   seqan3::align_cfg::result{seqan3::with_score};
 

--- a/doc/tutorial/read_mapper/read_mapper_step3.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_step3.cpp
@@ -53,7 +53,8 @@ void map_reads(std::filesystem::path const & query_path,
                                                 seqan3::search_cfg::hit_all_best;
 
 //! [alignment_config]
-    seqan3::configuration const align_config = seqan3::align_cfg::edit |
+    seqan3::configuration const align_config = seqan3::align_cfg::method_global |
+                                               seqan3::align_cfg::edit_scheme |
                                                seqan3::align_cfg::aligned_ends{seqan3::free_ends_first} |
                                                seqan3::align_cfg::result{seqan3::with_alignment};
 //! [alignment_config]

--- a/doc/tutorial/read_mapper/read_mapper_step4.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_step4.cpp
@@ -62,7 +62,8 @@ void map_reads(std::filesystem::path const & query_path,
                                                     seqan3::search_cfg::error_count{errors}} |
                                                 seqan3::search_cfg::hit_all_best;
 
-    seqan3::configuration const align_config = seqan3::align_cfg::edit |
+    seqan3::configuration const align_config = seqan3::align_cfg::method_global |
+                                               seqan3::align_cfg::edit_scheme |
                                                seqan3::align_cfg::aligned_ends{seqan3::free_ends_first} |
                                                seqan3::align_cfg::result{seqan3::with_alignment};
 

--- a/doc/tutorial/search/search_solution5.cpp
+++ b/doc/tutorial/search/search_solution5.cpp
@@ -19,7 +19,8 @@ void run_text_single()
 
     seqan3::configuration const search_config = seqan3::search_cfg::max_error_total{seqan3::search_cfg::error_count{1}} |
                                                 seqan3::search_cfg::hit_all_best;
-    seqan3::configuration const align_config = seqan3::align_cfg::edit |
+    seqan3::configuration const align_config = seqan3::align_cfg::method_global |
+                                               seqan3::align_cfg::edit_scheme |
                                                seqan3::align_cfg::aligned_ends{seqan3::free_ends_first} |
                                                seqan3::align_cfg::result{seqan3::with_alignment};
 
@@ -55,7 +56,8 @@ void run_text_collection()
 
     seqan3::configuration const search_config = seqan3::search_cfg::max_error_total{seqan3::search_cfg::error_count{1}} |
                                                 seqan3::search_cfg::hit_all_best;
-    seqan3::configuration const align_config = seqan3::align_cfg::edit |
+    seqan3::configuration const align_config = seqan3::align_cfg::method_global |
+                                               seqan3::align_cfg::edit_scheme |
                                                seqan3::align_cfg::aligned_ends{seqan3::free_ends_first} |
                                                seqan3::align_cfg::result{seqan3::with_alignment};
 

--- a/include/seqan3/alignment/all.hpp
+++ b/include/seqan3/alignment/all.hpp
@@ -196,8 +196,8 @@
  *  * Edit distance scoring for \ref nucleotide "nucleotide alphabets", i.e. seqan3::align_cfg::scoring is initialised with default initialised seqan3::nucleotide_scoring_scheme.
  *  * Global alignment, i.e. seqan3::align_cfg::method_global.
  *
- * There is a special shortcut for the above required configs called seqan3::align_cfg::edit, which can be used to
- * safe some typing.
+ * There is a special shortcut for the above required scoring/gap configs called seqan3::align_cfg::edit_scheme,
+ * which can be used to safe some typing.
  *
  * The edit configuration can be further specialised with following configs:
  *  * Allow maximal number of errors, i.e specify the seqan3::align_cfg::max_error configuration

--- a/include/seqan3/alignment/configuration/align_config_edit.hpp
+++ b/include/seqan3/alignment/configuration/align_config_edit.hpp
@@ -6,14 +6,13 @@
 // -----------------------------------------------------------------------------------------------------
 
 /*!\file
- * \brief Provides seqan3::align_cfg::edit.
+ * \brief Provides seqan3::align_cfg::edit_scheme.
  * \author Rene Rahn <rene.rahn AT fu-berlin.de>
  */
 
 #pragma once
 
 #include <seqan3/alignment/configuration/align_config_gap.hpp>
-#include <seqan3/alignment/configuration/align_config_method.hpp>
 #include <seqan3/alignment/configuration/align_config_scoring.hpp>
 #include <seqan3/alignment/scoring/gap_scheme.hpp>
 #include <seqan3/alignment/scoring/nucleotide_scoring_scheme.hpp>
@@ -49,7 +48,6 @@ namespace seqan3::align_cfg
  * trigger the slower algorithm which can handle the case if the ends are free in the second sequence instead of the
  * first sequence.
  */
-inline constexpr configuration edit = method_global | scoring{nucleotide_scoring_scheme{}} |
-                                      gap{gap_scheme{gap_score{-1}}};
+inline constexpr configuration edit_scheme = scoring{nucleotide_scoring_scheme{}} | gap{gap_scheme{gap_score{-1}}};
 
 } // namespace seqan3

--- a/include/seqan3/alignment/configuration/align_config_max_error.hpp
+++ b/include/seqan3/alignment/configuration/align_config_max_error.hpp
@@ -22,7 +22,7 @@ namespace seqan3::align_cfg
  *
  * \details
  *
- * This configuration can only be used for computing the \ref seqan3::align_cfg::edit "edit distance".
+ * This configuration can only be used for computing the \ref seqan3::align_cfg::edit_scheme "edit distance".
  * It restricts the number of substitutions, insertions, and deletions within the alignment to the given value and
  * can thereby speed up the edit distance computation.
  * A typical use case is to verify a candidate region during read mapping where the number of maximal errors is given

--- a/include/seqan3/alignment/pairwise/align_pairwise.hpp
+++ b/include/seqan3/alignment/pairwise/align_pairwise.hpp
@@ -92,7 +92,7 @@ namespace seqan3
  *
  * ### Complexity
  *
- * The complexity depends on the configured algorithm. For the \ref seqan3::align_cfg::edit "edit distance"
+ * The complexity depends on the configured algorithm. For the \ref seqan3::align_cfg::edit_scheme "edit distance"
  * the following worst case over two input sequences of size \f$ N \f$ can be assumed:
  *
  * | Computing        | Runtime           | Space            |

--- a/include/seqan3/core/algorithm/configuration.hpp
+++ b/include/seqan3/core/algorithm/configuration.hpp
@@ -301,6 +301,44 @@ public:
         return lhs.push_back(static_cast<rhs_derived_t const &>(rhs));
     }
 
+    /*!\brief Combines a seqan3::pipeable_config_element with a seqan3::configuration.
+     * \tparam lhs_derived_t The derived type of the left hand side operand.
+     * \tparam lhs_value_t   The value type of the left hand side operand.
+     * \param[in] lhs     The left hand operand.
+     * \param[in] rhs     The right hand operand.
+     * \returns A new seqan3::configuration adding `lhs` to the passed `rhs` object.
+     */
+    template <typename lhs_derived_t, typename lhs_value_t>
+    friend constexpr auto operator|(pipeable_config_element<lhs_derived_t, lhs_value_t> && lhs,
+                                    configuration && rhs)
+    {
+        return std::move(rhs) | std::move(lhs);
+    }
+
+    //!\overload
+    template <typename lhs_derived_t, typename lhs_value_t>
+    friend constexpr auto operator|(pipeable_config_element<lhs_derived_t, lhs_value_t> && lhs,
+                                    configuration const & rhs)
+    {
+        return rhs | std::move(lhs);
+    }
+
+    //!\overload
+    template <typename lhs_derived_t, typename lhs_value_t>
+    friend constexpr auto operator|(pipeable_config_element<lhs_derived_t, lhs_value_t> const & lhs,
+                                    configuration && rhs)
+    {
+        return std::move(rhs) | lhs;
+    }
+
+    //!\overload
+    template <typename lhs_derived_t, typename lhs_value_t>
+    friend constexpr auto operator|(pipeable_config_element<lhs_derived_t, lhs_value_t> const & lhs,
+                                    configuration const & rhs)
+    {
+        return rhs | lhs;
+    }
+
     /*!\brief Combines two seqan3::configuration objects.
      * \tparam rhs_configs_t  A template parameter pack for the second seqan3::configuration operand.
      * \param[in] lhs         The left hand operand.

--- a/test/performance/alignment/edit_distance_unbanded_benchmark.cpp
+++ b/test/performance/alignment/edit_distance_unbanded_benchmark.cpp
@@ -27,7 +27,8 @@
 #include <seqan/sequence.h>
 #endif
 
-constexpr auto edit_distance_cfg = seqan3::align_cfg::edit |
+constexpr auto edit_distance_cfg = seqan3::align_cfg::method_global |
+                                   seqan3::align_cfg::edit_scheme |
                                    seqan3::align_cfg::result{seqan3::with_score};
 
 // Shortcut to determine the alignment result type.

--- a/test/snippet/alignment/configuration/align_cfg_edit_example.cpp
+++ b/test/snippet/alignment/configuration/align_cfg_edit_example.cpp
@@ -1,15 +1,22 @@
 #include <seqan3/alignment/configuration/align_config_aligned_ends.hpp>
 #include <seqan3/alignment/configuration/align_config_edit.hpp>
 #include <seqan3/alignment/configuration/align_config_max_error.hpp>
+#include <seqan3/alignment/configuration/align_config_method.hpp>
 
 int main()
 {
     // Computes semi global edit distance using fast-bit vector algorithm.
-    auto cfg_fast = seqan3::align_cfg::edit | seqan3::align_cfg::aligned_ends{seqan3::free_ends_first};
+    auto cfg_fast = seqan3::align_cfg::method_global |
+                    seqan3::align_cfg::edit_scheme |
+                    seqan3::align_cfg::aligned_ends{seqan3::free_ends_first};
 
     // Computes semi global edit distance using slower standard pairwise algorithm.
-    auto cfg_slow = seqan3::align_cfg::edit | seqan3::align_cfg::aligned_ends{seqan3::free_ends_second};
+    auto cfg_slow = seqan3::align_cfg::method_global |
+                    seqan3::align_cfg::edit_scheme |
+                    seqan3::align_cfg::aligned_ends{seqan3::free_ends_second};
 
     // Computes global edit distance allowing maximal 3 errors.
-    auto cfg_errors = seqan3::align_cfg::edit | seqan3::align_cfg::max_error{3u};
+    auto cfg_errors = seqan3::align_cfg::method_global |
+                      seqan3::align_cfg::edit_scheme |
+                      seqan3::align_cfg::max_error{3u};
 }

--- a/test/snippet/alignment/pairwise/align_pairwise.cpp
+++ b/test/snippet/alignment/pairwise/align_pairwise.cpp
@@ -12,7 +12,7 @@ int main()
 //![start]
 
     // Configure the alignment kernel.
-    auto config = seqan3::align_cfg::edit;
+    auto config = seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme;
 
     {
     //![example1]
@@ -34,11 +34,13 @@ int main()
                     std::pair{"AGTTACGAC"_dna4, "AGTAGCGATCG"_dna4}};
 
     // Compute the alignment of a single pair.
-    for (auto const & res : seqan3::align_pairwise(std::tie(vec[0].first, vec[0].second), seqan3::align_cfg::edit))
+    auto edit_config = seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme;
+
+    for (auto const & res : seqan3::align_pairwise(std::tie(vec[0].first, vec[0].second), edit_config))
         seqan3::debug_stream << "The score: " << res.score() << "\n";
 
     // Compute the alignment over a range of pairs.
-    for (auto const & res : seqan3::align_pairwise(vec, seqan3::align_cfg::edit))
+    for (auto const & res : seqan3::align_pairwise(vec, edit_config))
         seqan3::debug_stream << "The score: " << res.score() << "\n";
     //![example3]
 //![end]

--- a/test/snippet/alignment/pairwise/alignment_configurator.cpp
+++ b/test/snippet/alignment/pairwise/alignment_configurator.cpp
@@ -3,7 +3,9 @@
 int main()
 {
     using sequences_t = std::vector<std::pair<std::string, std::string>>;
-    using config_t = decltype(seqan3::align_cfg::edit | seqan3::align_cfg::result{seqan3::with_score});
+    using config_t = decltype(seqan3::align_cfg::method_global |
+                              seqan3::align_cfg::edit_scheme |
+                              seqan3::align_cfg::result{seqan3::with_score});
 
     using first_seq_t = std::tuple_element_t<0, std::ranges::range_value_t<sequences_t>>;
     using second_seq_t = std::tuple_element_t<1, std::ranges::range_value_t<sequences_t>>;

--- a/test/snippet/alignment/pairwise/parallel_align_pairwise_with_callback.cpp
+++ b/test/snippet/alignment/pairwise/parallel_align_pairwise_with_callback.cpp
@@ -14,7 +14,9 @@ int main()
     std::vector<sequence_pair_t> sequences{100, {"AGTGCTACG"_dna4, "ACGTGCGACTAG"_dna4}};
 
     // Use edit distance with 4 threads.
-    auto const alignment_config = seqan3::align_cfg::edit | seqan3::align_cfg::parallel{4};
+    auto const alignment_config = seqan3::align_cfg::method_global |
+                                  seqan3::align_cfg::edit_scheme |
+                                  seqan3::align_cfg::parallel{4};
 
     // Compute the alignments in parallel and output them in order based on the input.
     for (auto && result : seqan3::align_pairwise(sequences, alignment_config))

--- a/test/unit/alignment/configuration/align_config_edit_test.cpp
+++ b/test/unit/alignment/configuration/align_config_edit_test.cpp
@@ -8,16 +8,11 @@
 #include <gtest/gtest.h>
 
 #include <seqan3/alignment/configuration/align_config_edit.hpp>
-
-TEST(align_cfg_edit, is_global)
-{
-    auto config = seqan3::align_cfg::edit;
-    EXPECT_TRUE(config.template exists<seqan3::detail::method_global_tag>());
-}
+#include <seqan3/alignment/configuration/align_config_method.hpp>
 
 TEST(align_cfg_edit, is_hamming)
 {
-    auto scheme = seqan3::get<seqan3::align_cfg::scoring>(seqan3::align_cfg::edit).value;
+    auto scheme = seqan3::get<seqan3::align_cfg::scoring>(seqan3::align_cfg::edit_scheme).value;
 
     for (unsigned i = 0; i < decltype(scheme)::matrix_size; ++i)
     {
@@ -35,7 +30,7 @@ TEST(align_cfg_edit, is_hamming)
 
 TEST(align_cfg_edit, is_simple_gap)
 {
-    auto scheme = seqan3::get<seqan3::align_cfg::gap>(seqan3::align_cfg::edit).value;
+    auto scheme = seqan3::get<seqan3::align_cfg::gap>(seqan3::align_cfg::edit_scheme).value;
     EXPECT_EQ(scheme.get_gap_score(), -1);
     EXPECT_EQ(scheme.get_gap_open_score(), 0);
 }

--- a/test/unit/alignment/pairwise/align_pairwise_test.cpp
+++ b/test/unit/alignment/pairwise/align_pairwise_test.cpp
@@ -33,7 +33,7 @@ struct align_pairwise_test : ::testing::Test
     using dummy_cfg_t = std::conditional_t<std::is_same_v<void, t>,
                                            decltype(seqan3::align_cfg::max_error{1}),
                                            t>;
-    using config_t = decltype(seqan3::align_cfg::edit | dummy_cfg_t{});
+    using config_t = decltype(seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme | dummy_cfg_t{});
 
     static constexpr bool is_vectorised = config_t::template exists<seqan3::detail::vectorise_tag>();
 };
@@ -66,7 +66,9 @@ TYPED_TEST(align_pairwise_test, single_pair)
     auto p1 = std::tie(seq1, seq2);
 
     {  // the score
-        seqan3::configuration cfg = seqan3::align_cfg::edit | seqan3::align_cfg::result{seqan3::with_score};
+        seqan3::configuration cfg = seqan3::align_cfg::method_global |
+                                    seqan3::align_cfg::edit_scheme |
+                                    seqan3::align_cfg::result{seqan3::with_score};
 
         for (auto && res : call_alignment<TypeParam>(p1, cfg))
         {
@@ -75,7 +77,9 @@ TYPED_TEST(align_pairwise_test, single_pair)
     }
 
     {  // the alignment
-        seqan3::configuration cfg = seqan3::align_cfg::edit | seqan3::align_cfg::result{seqan3::with_alignment};
+        seqan3::configuration cfg = seqan3::align_cfg::method_global |
+                                    seqan3::align_cfg::edit_scheme |
+                                    seqan3::align_cfg::result{seqan3::with_alignment};
         unsigned idx = 0;
         for (auto && res : call_alignment<TypeParam>(p1, cfg))
         {
@@ -93,7 +97,9 @@ TYPED_TEST(align_pairwise_test, single_pair)
     std::pair sequences{"ACGTGATG"_dna4,"AGTGATACT"_dna4};
 
     {  // the score
-        seqan3::configuration cfg = seqan3::align_cfg::edit | seqan3::align_cfg::result{seqan3::with_score};
+        seqan3::configuration cfg = seqan3::align_cfg::method_global |
+                                    seqan3::align_cfg::edit_scheme |
+                                    seqan3::align_cfg::result{seqan3::with_score};
 
         for (auto && res : call_alignment<TypeParam>(sequences, cfg))
         {
@@ -102,7 +108,9 @@ TYPED_TEST(align_pairwise_test, single_pair)
     }
 
     {  // the alignment
-        seqan3::configuration cfg = seqan3::align_cfg::edit | seqan3::align_cfg::result{seqan3::with_alignment};
+        seqan3::configuration cfg = seqan3::align_cfg::method_global |
+                                    seqan3::align_cfg::edit_scheme |
+                                    seqan3::align_cfg::result{seqan3::with_alignment};
         unsigned idx = 0;
         for (auto && res : call_alignment<TypeParam>(sequences, cfg))
         {
@@ -120,7 +128,9 @@ TYPED_TEST(align_pairwise_test, single_pair)
     auto p2 = std::make_pair(seq1, seq2);
 
     {  // the score
-        seqan3::configuration cfg = seqan3::align_cfg::edit | seqan3::align_cfg::result{seqan3::with_score};
+        seqan3::configuration cfg = seqan3::align_cfg::method_global |
+                                    seqan3::align_cfg::edit_scheme |
+                                    seqan3::align_cfg::result{seqan3::with_score};
 
         for (auto && res : call_alignment<TypeParam>(p2, cfg))
         {
@@ -129,7 +139,9 @@ TYPED_TEST(align_pairwise_test, single_pair)
     }
 
     {  // the alignment
-        seqan3::configuration cfg = seqan3::align_cfg::edit | seqan3::align_cfg::result{seqan3::with_alignment};
+        seqan3::configuration cfg = seqan3::align_cfg::method_global |
+                                    seqan3::align_cfg::edit_scheme |
+                                    seqan3::align_cfg::result{seqan3::with_alignment};
         unsigned idx = 0;
         for (auto && res : call_alignment<TypeParam>(p2, cfg))
         {
@@ -154,8 +166,9 @@ TYPED_TEST(align_pairwise_test, single_pair_double_score)
         auto p = std::tie(seq1, seq2);
 
         {  // the score
-            seqan3::configuration cfg = seqan3::align_cfg::edit
-                                      | seqan3::align_cfg::result{seqan3::with_score, seqan3::using_score_type<double>};
+            seqan3::configuration cfg = seqan3::align_cfg::method_global |
+                                        seqan3::align_cfg::edit_scheme |
+                                        seqan3::align_cfg::result{seqan3::with_score, seqan3::using_score_type<double>};
 
             for (auto && res : call_alignment<TypeParam>(p, cfg))
             {
@@ -165,7 +178,8 @@ TYPED_TEST(align_pairwise_test, single_pair_double_score)
         }
 
         {  // the alignment
-            seqan3::configuration cfg = seqan3::align_cfg::edit |
+            seqan3::configuration cfg = seqan3::align_cfg::method_global |
+                                        seqan3::align_cfg::edit_scheme |
                                         seqan3::align_cfg::result{seqan3::with_alignment,
                                                                   seqan3::using_score_type<double>};
             unsigned idx = 0;
@@ -191,14 +205,18 @@ TYPED_TEST(align_pairwise_test, single_view)
     auto v = std::views::single(std::tie(seq1, seq2)) | std::views::common;
 
     {  // the score
-        seqan3::configuration cfg = seqan3::align_cfg::edit | seqan3::align_cfg::result{seqan3::with_score};
+        seqan3::configuration cfg = seqan3::align_cfg::method_global |
+                                    seqan3::align_cfg::edit_scheme |
+                                    seqan3::align_cfg::result{seqan3::with_score};
         for (auto && res : call_alignment<TypeParam>(v, cfg))
         {
              EXPECT_EQ(res.score(), -4);
         }
     }
     {  // the alignment
-        seqan3::configuration cfg = seqan3::align_cfg::edit | seqan3::align_cfg::result{seqan3::with_alignment};
+        seqan3::configuration cfg = seqan3::align_cfg::method_global |
+                                    seqan3::align_cfg::edit_scheme |
+                                    seqan3::align_cfg::result{seqan3::with_alignment};
 
         for (auto && res : call_alignment<TypeParam>(v, cfg))
         {
@@ -218,7 +236,9 @@ TYPED_TEST(align_pairwise_test, collection)
     auto p = std::tie(seq1, seq2);
     std::vector<decltype(p)> vec{10, p};
 
-    seqan3::configuration cfg = seqan3::align_cfg::edit | seqan3::align_cfg::result{seqan3::with_alignment};
+    seqan3::configuration cfg = seqan3::align_cfg::method_global |
+                                seqan3::align_cfg::edit_scheme |
+                                seqan3::align_cfg::result{seqan3::with_alignment};
     for (auto && res : call_alignment<TypeParam>(vec, cfg))
     {
         EXPECT_EQ(res.score(), -4);
@@ -238,7 +258,8 @@ TYPED_TEST(align_pairwise_test, collection_with_double_score_type)
         auto p = std::tie(seq1, seq2);
         std::vector<decltype(p)> vec{10, p};
 
-        seqan3::configuration cfg = seqan3::align_cfg::edit |
+        seqan3::configuration cfg = seqan3::align_cfg::method_global |
+                                    seqan3::align_cfg::edit_scheme |
                                     seqan3::align_cfg::result{seqan3::with_alignment, seqan3::using_score_type<double>};
         for (auto && res : call_alignment<TypeParam>(vec, cfg))
         {
@@ -271,7 +292,8 @@ TEST(align_pairwise_test, parallel_without_parameter)
 {
     auto seq1 = "ACGTGATG"_dna4;
     auto seq2 = "AGTGATACT"_dna4;
-    seqan3::configuration cfg = seqan3::align_cfg::edit |
+    seqan3::configuration cfg = seqan3::align_cfg::method_global |
+                                seqan3::align_cfg::edit_scheme |
                                 seqan3::align_cfg::result{seqan3::with_score} |
                                 seqan3::align_cfg::parallel{};
 

--- a/test/unit/alignment/pairwise/align_result_selector_test.cpp
+++ b/test/unit/alignment/pairwise/align_result_selector_test.cpp
@@ -28,7 +28,9 @@ TEST(alignment_selector, align_result_selector_with_list)
     using seq2_t = std::list<seqan3::dna4>;
 
     {
-        auto cfg = seqan3::align_cfg::edit | seqan3::align_cfg::result{seqan3::with_score};
+        auto cfg = seqan3::align_cfg::method_global |
+                   seqan3::align_cfg::edit_scheme |
+                   seqan3::align_cfg::result{seqan3::with_score};
         using _t = seqan3::alignment_result<typename seqan3::detail::align_result_selector<seq1_t,
                                                                                            seq2_t,
                                                                                            decltype(cfg)>::type>;
@@ -38,7 +40,9 @@ TEST(alignment_selector, align_result_selector_with_list)
     }
 
     {
-        auto cfg = seqan3::align_cfg::edit | seqan3::align_cfg::result{seqan3::with_alignment};
+        auto cfg = seqan3::align_cfg::method_global |
+                   seqan3::align_cfg::edit_scheme |
+                   seqan3::align_cfg::result{seqan3::with_alignment};
         using _t = seqan3::alignment_result<typename seqan3::detail::align_result_selector<seq1_t,
                                                                                            seq2_t,
                                                                                            decltype(cfg)>::type>;
@@ -62,8 +66,9 @@ TEST(alignment_selector, align_result_selector_using_score_type)
     using seq1_t = std::vector<seqan3::dna4>;
     using seq2_t = std::list<seqan3::dna4>;
 
-    auto cfg = seqan3::align_cfg::edit | seqan3::align_cfg::result{seqan3::with_end_positions,
-                                                                   seqan3::using_score_type<double>};
+    auto cfg = seqan3::align_cfg::method_global |
+               seqan3::align_cfg::edit_scheme |
+               seqan3::align_cfg::result{seqan3::with_end_positions, seqan3::using_score_type<double>};
     using _t = seqan3::alignment_result<typename seqan3::detail::align_result_selector<seq1_t,
                                                                                        seq2_t,
                                                                                        decltype(cfg)>::type>;
@@ -77,7 +82,9 @@ TEST(alignment_selector, align_result_selector_with_vector)
 {
     using seq_t = std::vector<seqan3::dna4>;
 
-    auto cfg = seqan3::align_cfg::edit | seqan3::align_cfg::result{seqan3::with_alignment};
+    auto cfg = seqan3::align_cfg::method_global |
+               seqan3::align_cfg::edit_scheme |
+               seqan3::align_cfg::result{seqan3::with_alignment};
     using _t = seqan3::alignment_result<typename seqan3::detail::align_result_selector<seq_t,
                                                                                        seq_t,
                                                                                        decltype(cfg)>::type>;

--- a/test/unit/alignment/pairwise/alignment_configurator_test.cpp
+++ b/test/unit/alignment/pairwise/alignment_configurator_test.cpp
@@ -47,32 +47,41 @@ auto run_test(config_t const & cfg)
 
 TEST(alignment_configurator, configure_edit)
 {
-    EXPECT_EQ(run_test(seqan3::align_cfg::edit).score(), 0);
+    EXPECT_EQ(run_test(seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme).score(), 0);
 }
 
 TEST(alignment_configurator, configure_edit_end_position)
 {
-    EXPECT_EQ(run_test(seqan3::align_cfg::edit | seqan3::align_cfg::result{seqan3::with_end_positions}).score(), 0);
+    EXPECT_EQ(run_test(seqan3::align_cfg::method_global |
+                       seqan3::align_cfg::edit_scheme |
+                       seqan3::align_cfg::result{seqan3::with_end_positions}).score(), 0);
 }
 
 TEST(alignment_configurator, configure_edit_begin_position)
 {
-    EXPECT_EQ(run_test(seqan3::align_cfg::edit | seqan3::align_cfg::result{seqan3::with_begin_positions}).score(), 0);
+    EXPECT_EQ(run_test(seqan3::align_cfg::method_global |
+                       seqan3::align_cfg::edit_scheme |
+                       seqan3::align_cfg::result{seqan3::with_begin_positions}).score(), 0);
 }
 
 TEST(alignment_configurator, configure_edit_trace)
 {
-    EXPECT_EQ(run_test(seqan3::align_cfg::edit | seqan3::align_cfg::result{seqan3::with_alignment}).score(), 0);
+    EXPECT_EQ(run_test(seqan3::align_cfg::method_global |
+                       seqan3::align_cfg::edit_scheme |
+                       seqan3::align_cfg::result{seqan3::with_alignment}).score(), 0);
 }
 
 TEST(alignment_configurator, configure_edit_semi)
 {
-    EXPECT_EQ(run_test(seqan3::align_cfg::edit | seqan3::align_cfg::aligned_ends{seqan3::free_ends_first}).score(), 0);
+    EXPECT_EQ(run_test(seqan3::align_cfg::method_global |
+                       seqan3::align_cfg::edit_scheme |
+                       seqan3::align_cfg::aligned_ends{seqan3::free_ends_first}).score(), 0);
 }
 
 TEST(alignment_configurator, configure_edit_banded)
 {
-    EXPECT_THROW((run_test(seqan3::align_cfg::edit |
+    EXPECT_THROW((run_test(seqan3::align_cfg::method_global |
+                           seqan3::align_cfg::edit_scheme |
                            seqan3::align_cfg::band_fixed_size{seqan3::align_cfg::lower_diagonal{-1},
                                                               seqan3::align_cfg::upper_diagonal{1}})),
                  seqan3::invalid_alignment_configuration);
@@ -80,7 +89,9 @@ TEST(alignment_configurator, configure_edit_banded)
 
 TEST(alignment_configurator, configure_edit_max_error)
 {
-    EXPECT_EQ(run_test(seqan3::align_cfg::edit | seqan3::align_cfg::max_error{3u}).score(), 0);
+    EXPECT_EQ(run_test(seqan3::align_cfg::method_global |
+                       seqan3::align_cfg::edit_scheme |
+                       seqan3::align_cfg::max_error{3u}).score(), 0);
 }
 
 TEST(alignment_configurator, configure_affine_global)
@@ -224,8 +235,9 @@ TEST(alignment_configurator, configure_affine_local_alignment)
 
 TEST(alignment_configurator, configure_result_score_type)
 {
-    auto cfg = seqan3::align_cfg::edit | seqan3::align_cfg::result{seqan3::with_end_positions,
-                                                                   seqan3::using_score_type<double>};
+    auto cfg = seqan3::align_cfg::method_global |
+               seqan3::align_cfg::edit_scheme |
+               seqan3::align_cfg::result{seqan3::with_end_positions, seqan3::using_score_type<double>};
     auto result = run_test(cfg);
 
     EXPECT_DOUBLE_EQ(result.score(), 0.0);

--- a/test/unit/alignment/pairwise/fixture/global_edit_distance_max_errors_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/global_edit_distance_max_errors_unbanded.hpp
@@ -39,7 +39,7 @@ static auto dna4_01_e255 = []()
     {
         "AACCGGTTAACCGGTT"_dna4,
         "ACGTACGTA"_dna4,
-        seqan3::align_cfg::edit | seqan3::align_cfg::max_error{255},
+        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme | seqan3::align_cfg::max_error{255},
         -8,
         "AACCGGTTAACCGGTT",
         "A-C-G-T-A-C-G-TA",
@@ -56,7 +56,7 @@ static auto dna4_01T_e255 = []()
     {
         "ACGTACGTA"_dna4,
         "AACCGGTTAACCGGTT"_dna4,
-        seqan3::align_cfg::edit | seqan3::align_cfg::max_error{255},
+        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme | seqan3::align_cfg::max_error{255},
         -8,
         "A-C-G-T-A-C-G-TA",
         "AACCGGTTAACCGGTT",
@@ -89,7 +89,7 @@ static auto dna4_01_e8 = []()
     {
         "AACCGGTTAACCGGTT"_dna4,
         "ACGTACGTA"_dna4,
-        seqan3::align_cfg::edit | seqan3::align_cfg::max_error{8},
+        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme | seqan3::align_cfg::max_error{8},
         -8,
         "AACCGGTTAACCGGTT",
         "A-C-G-T-A-C-G-TA",
@@ -122,7 +122,7 @@ static auto dna4_01_e7 = []()
     {
         "AACCGGTTAACCGGTT"_dna4,
         "ACGTACGTA"_dna4,
-        seqan3::align_cfg::edit | seqan3::align_cfg::max_error{7},
+        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme | seqan3::align_cfg::max_error{7},
         INF,
         "",
         "",
@@ -155,7 +155,7 @@ static auto dna4_01_e5 = []()
     {
         "AACCGGTTAACCGGTT"_dna4,
         "ACGTACGTA"_dna4,
-        seqan3::align_cfg::edit | seqan3::align_cfg::max_error{5},
+        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme | seqan3::align_cfg::max_error{5},
         INF,
         "",
         "",
@@ -172,7 +172,7 @@ static auto dna4_02_e255 = []()
     {
         "AACCGGTAAACCGGTT"_dna4,
         "ACGTACGTA"_dna4,
-        seqan3::align_cfg::edit | seqan3::align_cfg::max_error{255},
+        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme | seqan3::align_cfg::max_error{255},
         -8,
         "AACCGGTAAACCGGTT",
         "A-C-G-TA--C-G-TA",
@@ -204,7 +204,7 @@ static auto dna4_02_e8 = []()
     {
         "AACCGGTAAACCGGTT"_dna4,
         "ACGTACGTA"_dna4,
-        seqan3::align_cfg::edit | seqan3::align_cfg::max_error{8},
+        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme | seqan3::align_cfg::max_error{8},
         -8,
         "AACCGGTAAACCGGTT",
         "A-C-G-TA--C-G-TA",
@@ -236,7 +236,7 @@ static auto dna4_02_e4 = []()
     {
         "AACCGGTAAACCGGTT"_dna4,
         "ACGTACGTA"_dna4,
-        seqan3::align_cfg::edit | seqan3::align_cfg::max_error{4},
+        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme | seqan3::align_cfg::max_error{4},
         INF,
         "",
         "",
@@ -269,7 +269,7 @@ static auto dna4_02_s10u_15u_e7 = []()
     {
         "AACCGGTAAACCGG"_dna4,
         "ACGTACGTA"_dna4,
-        seqan3::align_cfg::edit | seqan3::align_cfg::max_error{7},
+        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme | seqan3::align_cfg::max_error{7},
         INF,
         "",
         "",
@@ -291,7 +291,7 @@ static auto dna4_02_s1u_15u_e255 = []()
         // --------------
         "AACCGGTAAACCGG"_dna4,
         ""_dna4,
-        seqan3::align_cfg::edit | seqan3::align_cfg::max_error{255},
+        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme | seqan3::align_cfg::max_error{255},
         -14,
         "AACCGGTAAACCGG",
         "--------------",
@@ -315,7 +315,7 @@ static auto dna4_02_s1u_15u_e5 = []()
         // score is inf and has no alignment
         "AACCGGTAAACCGG"_dna4,
         ""_dna4,
-        seqan3::align_cfg::edit | seqan3::align_cfg::max_error{5},
+        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme | seqan3::align_cfg::max_error{5},
         INF,
         "",
         "",
@@ -337,7 +337,7 @@ static auto dna4_02T_s15u_1u_e255 = []()
         // AACCGGTAAACCGG
         ""_dna4,
         "AACCGGTAAACCGG"_dna4,
-        seqan3::align_cfg::edit | seqan3::align_cfg::max_error{255},
+        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme | seqan3::align_cfg::max_error{255},
         -14,
         "--------------",
         "AACCGGTAAACCGG",
@@ -375,7 +375,7 @@ static auto dna4_02T_s15u_1u_e5 = []()
         // score is inf and has no alignment
         ""_dna4,
         "AACCGGTAAACCGG"_dna4,
-        seqan3::align_cfg::edit | seqan3::align_cfg::max_error{5},
+        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme | seqan3::align_cfg::max_error{5},
         INF,
         "",
         "",
@@ -393,7 +393,7 @@ static auto dna4_03_e255 = []()
         // score: 0
         ""_dna4,
         ""_dna4,
-        seqan3::align_cfg::edit | seqan3::align_cfg::max_error{255},
+        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme | seqan3::align_cfg::max_error{255},
         -0,
         "",
         "",
@@ -410,7 +410,7 @@ static auto aa27_01_e255 = []()
     {
         "UUWWRRIIUUWWRRII"_aa27,
         "UWRIUWRIU"_aa27,
-        seqan3::align_cfg::edit | seqan3::align_cfg::max_error{255},
+        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme | seqan3::align_cfg::max_error{255},
         -8,
         "UUWWRRIIUUWWRRII",
         "U-W-R-I-U-W-R-IU",
@@ -427,7 +427,7 @@ static auto aa27_01T_e255 = []()
     {
         "UWRIUWRIU"_aa27,
         "UUWWRRIIUUWWRRII"_aa27,
-        seqan3::align_cfg::edit | seqan3::align_cfg::max_error{255},
+        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme | seqan3::align_cfg::max_error{255},
         -8,
         "U-W-R-I-U-W-R-IU",
         "UUWWRRIIUUWWRRII",

--- a/test/unit/alignment/pairwise/fixture/global_edit_distance_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/global_edit_distance_unbanded.hpp
@@ -34,7 +34,7 @@ static auto dna4_01 = []()
         // A-C-G-T-A-C-G-TA
         "AACCGGTTAACCGGTT"_dna4,
         "ACGTACGTA"_dna4,
-        seqan3::align_cfg::edit,
+        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme,
         -8,
         "AACCGGTTAACCGGTT",
         "A-C-G-T-A-C-G-TA",
@@ -82,7 +82,7 @@ static auto dna4_01T = []()
         // AACCGGTTAACCGGTT
         "ACGTACGTA"_dna4,
         "AACCGGTTAACCGGTT"_dna4,
-        seqan3::align_cfg::edit,
+        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme,
         -8,
         "A-C-G-T-A-C-G-TA",
         "AACCGGTTAACCGGTT",
@@ -104,7 +104,7 @@ static auto dna4_02 = []()
         // A-C-G-TA--C-G-TA
         "AACCGGTAAACCGGTT"_dna4,
         "ACGTACGTA"_dna4,
-        seqan3::align_cfg::edit,
+        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme,
         -8,
         "AACCGGTAAACCGGTT",
         "A-C-G-TA--C-G-TA",
@@ -152,7 +152,7 @@ static auto dna4_02_s10u_15u = []()
         // A-C-G-TA--C-GTA
         "AACCGGTAAACCGG"_dna4,
         "ACGTACGTA"_dna4,
-        seqan3::align_cfg::edit,
+        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme,
         -8,
         "AACCGGTAAACCGG-",
         "A-C-G-TA--C-GTA",
@@ -174,7 +174,7 @@ static auto dna4_02_s3u_15u = []()
         // A-C-----------
         "AACCGGTAAACCGG"_dna4,
         "AC"_dna4,
-        seqan3::align_cfg::edit,
+        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme,
         -12,
         "AACCGGTAAACCGG",
         "A-C-----------",
@@ -196,7 +196,7 @@ static auto dna4_02_s1u_15u = []()
         // --------------
         "AACCGGTAAACCGG"_dna4,
         ""_dna4,
-        seqan3::align_cfg::edit,
+        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme,
         -14,
         "AACCGGTAAACCGG",
         "--------------",
@@ -218,7 +218,7 @@ static auto dna4_02T_s15u_1u = []()
         // AACCGGTAAACCGG
         ""_dna4,
         "AACCGGTAAACCGG"_dna4,
-        seqan3::align_cfg::edit,
+        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme,
         -14,
         "--------------",
         "AACCGGTAAACCGG",
@@ -236,7 +236,7 @@ static auto dna4_03 = []()
         // score: 0
         ""_dna4,
         ""_dna4,
-        seqan3::align_cfg::edit,
+        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme,
         -0,
         "",
         "",
@@ -258,7 +258,7 @@ static auto aa27_01 = []()
         // U-W-R-I-U-W-R-IU
         "UUWWRRIIUUWWRRII"_aa27,
         "UWRIUWRIU"_aa27,
-        seqan3::align_cfg::edit,
+        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme,
         -8,
         "UUWWRRIIUUWWRRII",
         "U-W-R-I-U-W-R-IU",
@@ -306,7 +306,7 @@ static auto aa27_01T = []()
         // UUWWRRIIUUWWRRII
         "UWRIUWRIU"_aa27,
         "UUWWRRIIUUWWRRII"_aa27,
-        seqan3::align_cfg::edit,
+        seqan3::align_cfg::method_global | seqan3::align_cfg::edit_scheme,
         -8,
         "U-W-R-I-U-W-R-IU",
         "UUWWRRIIUUWWRRII",

--- a/test/unit/alignment/pairwise/fixture/semi_global_edit_distance_max_errors_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/semi_global_edit_distance_max_errors_unbanded.hpp
@@ -33,8 +33,7 @@ static auto dna4_01_e255 = []()
     {
         "AACCGGTTAACCGGTT"_dna4,
         "ACGTACGTA"_dna4,
-        seqan3::align_cfg::edit | seqan3::align_cfg::max_error{255}
-                                | seqan3::align_cfg::aligned_ends{seqan3::free_ends_first},
+        semi_global_edit_distance | seqan3::align_cfg::max_error{255},
         -5,
         "AC---CGGTT",
         "ACGTACG-TA",
@@ -66,8 +65,7 @@ static auto dna4_01_e5 = []()
     {
         "AACCGGTTAACCGGTT"_dna4,
         "ACGTACGTA"_dna4,
-        seqan3::align_cfg::edit | seqan3::align_cfg::max_error{5}
-                                | seqan3::align_cfg::aligned_ends{seqan3::free_ends_first},
+        semi_global_edit_distance | seqan3::align_cfg::max_error{5},
         -5,
         "AC---CGGTT",
         "ACGTACG-TA",
@@ -99,8 +97,7 @@ static auto dna4_01_e2 = []()
     {
         "AACCGGTTAACCGGTT"_dna4,
         "ACGTACGTA"_dna4,
-        seqan3::align_cfg::edit | seqan3::align_cfg::max_error{2}
-                                | seqan3::align_cfg::aligned_ends{seqan3::free_ends_first},
+        semi_global_edit_distance | seqan3::align_cfg::max_error{2},
         INF,
         "",
         "",
@@ -117,8 +114,7 @@ static auto dna4_01T_e255 = []()
     {
         "ACGTACGTA"_dna4,
         "AACCGGTTAACCGGTT"_dna4,
-        seqan3::align_cfg::edit | seqan3::align_cfg::max_error{255}
-                                | seqan3::align_cfg::aligned_ends{seqan3::free_ends_first},
+        semi_global_edit_distance | seqan3::align_cfg::max_error{255},
         -8,
         "A-C-G-T-A-C-G-TA",
         "AACCGGTTAACCGGTT",
@@ -135,8 +131,7 @@ static auto dna4_02_e255 = []()
     {
         "AACCGGTAAACCGGTT"_dna4,
         "ACGTACGTA"_dna4,
-        seqan3::align_cfg::edit | seqan3::align_cfg::max_error{255}
-                                | seqan3::align_cfg::aligned_ends{seqan3::free_ends_first},
+        semi_global_edit_distance | seqan3::align_cfg::max_error{255},
         -4,
         "AC---CGGTA",
         "ACGTACG-TA",
@@ -158,8 +153,7 @@ static auto dna4_02_s10u_15u_e255 = []()
         // -ACGTACG-TA-----------
         "AACCGGTAAACCGG"_dna4,
         "ACGTACGTA"_dna4,
-        seqan3::align_cfg::edit | seqan3::align_cfg::max_error{255}
-                                | seqan3::align_cfg::aligned_ends{seqan3::free_ends_first},
+        semi_global_edit_distance | seqan3::align_cfg::max_error{255},
         -4,
         "AC---CGGTA",
         "ACGTACG-TA",
@@ -192,8 +186,7 @@ static auto dna4_02_s10u_15u_e4 = []()
         // score: INF no alignment
         "AACCGGTAAACCGG"_dna4,
         "ACGTACGTA"_dna4,
-        seqan3::align_cfg::edit | seqan3::align_cfg::max_error{4}
-                                | seqan3::align_cfg::aligned_ends{seqan3::free_ends_first},
+        semi_global_edit_distance | seqan3::align_cfg::max_error{4},
         -4,
         "AC---CGGTA",
         "ACGTACG-TA",
@@ -226,8 +219,7 @@ static auto dna4_02_s10u_15u_e3 = []()
         // score: INF no alignment
         "AACCGGTAAACCGG"_dna4,
         "ACGTACGTA"_dna4,
-        seqan3::align_cfg::edit | seqan3::align_cfg::max_error{3}
-                                | seqan3::align_cfg::aligned_ends{seqan3::free_ends_first},
+        semi_global_edit_distance | seqan3::align_cfg::max_error{3},
         INF,
         "",
         "",
@@ -249,8 +241,7 @@ static auto dna4_02_s3u_15u_e255 = []()
         // ---------AC-----
         "AACCGGTAAACCGG"_dna4,
         "AC"_dna4,
-        seqan3::align_cfg::edit | seqan3::align_cfg::max_error{255}
-                                | seqan3::align_cfg::aligned_ends{seqan3::free_ends_first},
+        semi_global_edit_distance | seqan3::align_cfg::max_error{255},
         -0,
         "AC",
         "AC",
@@ -280,8 +271,7 @@ static auto dna4_02_s3u_15u_e0 = []()
         // ---------AC-----
         "AACCGGTAAACCGG"_dna4,
         "AC"_dna4,
-        seqan3::align_cfg::edit | seqan3::align_cfg::max_error{0}
-                                | seqan3::align_cfg::aligned_ends{seqan3::free_ends_first},
+        semi_global_edit_distance | seqan3::align_cfg::max_error{0},
         -0,
         "AC",
         "AC",
@@ -299,8 +289,7 @@ static auto dna4_02_s1u_15u_e255 = []()
         // score: 0 - empty alignment
         "AACCGGTAAACCGG"_dna4,
         ""_dna4,
-        seqan3::align_cfg::edit | seqan3::align_cfg::max_error{255}
-                                | seqan3::align_cfg::aligned_ends{seqan3::free_ends_first},
+        semi_global_edit_distance | seqan3::align_cfg::max_error{255},
         -0,
         "",
         "",
@@ -318,8 +307,7 @@ static auto dna4_02_s1u_15u_e0 = []()
         // score: 0 - empty alignment
         "AACCGGTAAACCGG"_dna4,
         ""_dna4,
-        seqan3::align_cfg::edit | seqan3::align_cfg::max_error{0}
-                                | seqan3::align_cfg::aligned_ends{seqan3::free_ends_first},
+        semi_global_edit_distance | seqan3::align_cfg::max_error{0},
         -0,
         "",
         "",
@@ -341,8 +329,7 @@ static auto dna4_01T_s17u_1u_e255 = []()
         // AACCGGTTAACCGGTT
         ""_dna4,
         "AACCGGTTAACCGGTT"_dna4,
-        seqan3::align_cfg::edit | seqan3::align_cfg::max_error{255}
-                                | seqan3::align_cfg::aligned_ends{seqan3::free_ends_first},
+        semi_global_edit_distance | seqan3::align_cfg::max_error{255},
         -16,
         "----------------",
         "AACCGGTTAACCGGTT",
@@ -381,8 +368,7 @@ static auto dna4_01T_s17u_1u_e5 = []()
         // score: INF - empty alignment
         ""_dna4,
         "AACCGGTTAACCGGTT"_dna4,
-        seqan3::align_cfg::edit | seqan3::align_cfg::max_error{5}
-                                | seqan3::align_cfg::aligned_ends{seqan3::free_ends_first},
+        semi_global_edit_distance | seqan3::align_cfg::max_error{5},
         INF,
         "",
         "",
@@ -400,8 +386,7 @@ static auto dna4_03_e255 = []()
         // score: 0
         ""_dna4,
         ""_dna4,
-        seqan3::align_cfg::edit | seqan3::align_cfg::max_error{255}
-                                | seqan3::align_cfg::aligned_ends{seqan3::free_ends_first},
+        semi_global_edit_distance | seqan3::align_cfg::max_error{255},
         -0,
         "",
         "",
@@ -419,8 +404,7 @@ static auto dna4_03_e0 = []()
         // score: 0
         ""_dna4,
         ""_dna4,
-        seqan3::align_cfg::edit | seqan3::align_cfg::max_error{0}
-                                | seqan3::align_cfg::aligned_ends{seqan3::free_ends_first},
+        semi_global_edit_distance | seqan3::align_cfg::max_error{0},
         -0,
         "",
         "",
@@ -437,8 +421,7 @@ static auto aa27_01_e255 = []()
     {
         "UUWWRRIIUUWWRRII"_aa27,
         "UWRIUWRIU"_aa27,
-        seqan3::align_cfg::edit | seqan3::align_cfg::max_error{255}
-                                | seqan3::align_cfg::aligned_ends{seqan3::free_ends_first},
+        semi_global_edit_distance | seqan3::align_cfg::max_error{255},
         -5,
         "UW---WRRII",
         "UWRIUWR-IU",
@@ -455,8 +438,7 @@ static auto aa27_01T_e255 = []()
     {
         "UWRIUWRIU"_aa27,
         "UUWWRRIIUUWWRRII"_aa27,
-        seqan3::align_cfg::edit | seqan3::align_cfg::max_error{255}
-                                | seqan3::align_cfg::aligned_ends{seqan3::free_ends_first},
+        semi_global_edit_distance | seqan3::align_cfg::max_error{255},
         -8,
         "U-W-R-I-U-W-R-IU",
         "UUWWRRIIUUWWRRII",

--- a/test/unit/alignment/pairwise/fixture/semi_global_edit_distance_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/semi_global_edit_distance_unbanded.hpp
@@ -13,6 +13,7 @@
 
 #include <seqan3/alignment/configuration/align_config_aligned_ends.hpp>
 #include <seqan3/alignment/configuration/align_config_edit.hpp>
+#include <seqan3/alignment/configuration/align_config_method.hpp>
 #include <seqan3/alphabet/aminoacid/aa27.hpp>
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 
@@ -23,6 +24,10 @@ namespace seqan3::test::alignment::fixture::semi_global::edit_distance::unbanded
 
 using seqan3::detail::column_index_type;
 using seqan3::detail::row_index_type;
+
+static constexpr auto semi_global_edit_distance = seqan3::align_cfg::method_global |
+                                                  seqan3::align_cfg::edit_scheme |
+                                                  seqan3::align_cfg::aligned_ends{seqan3::free_ends_first};
 
 static auto dna4_01 = []()
 {
@@ -35,7 +40,7 @@ static auto dna4_01 = []()
         // ---------ACGTACG-TA
         "AACCGGTTAACCGGTT"_dna4,
         "ACGTACGTA"_dna4,
-        seqan3::align_cfg::edit | seqan3::align_cfg::aligned_ends{seqan3::free_ends_first},
+        semi_global_edit_distance,
         -5,
         "AC---CGGTT",
         "ACGTACG-TA",
@@ -83,7 +88,7 @@ static auto dna4_01T = []()
         // AACCGGTTAACCGGTT
         "ACGTACGTA"_dna4,
         "AACCGGTTAACCGGTT"_dna4,
-        seqan3::align_cfg::edit | seqan3::align_cfg::aligned_ends{seqan3::free_ends_first},
+        semi_global_edit_distance,
         -8,
         "A-C-G-T-A-C-G-TA",
         "AACCGGTTAACCGGTT",
@@ -145,7 +150,7 @@ static auto dna4_02 = []()
         // -ACGTACG-TA-----------
         "AACCGGTAAACCGGTT"_dna4,
         "ACGTACGTA"_dna4,
-        seqan3::align_cfg::edit | seqan3::align_cfg::aligned_ends{seqan3::free_ends_first},
+        semi_global_edit_distance,
         -4,
         "AC---CGGTA",
         "ACGTACG-TA",
@@ -193,7 +198,7 @@ static auto dna4_02_s10u_15u = []()
         // -ACGTACG-TA-----------
         "AACCGGTAAACCGG"_dna4,
         "ACGTACGTA"_dna4,
-        seqan3::align_cfg::edit | seqan3::align_cfg::aligned_ends{seqan3::free_ends_first},
+        semi_global_edit_distance,
         -4,
         "AC---CGGTA",
         "ACGTACG-TA",
@@ -215,7 +220,7 @@ static auto dna4_02_s3u_15u = []()
         // ---------AC-----
         "AACCGGTAAACCGG"_dna4,
         "AC"_dna4,
-        seqan3::align_cfg::edit | seqan3::align_cfg::aligned_ends{seqan3::free_ends_first},
+        semi_global_edit_distance,
         -0,
         "AC",
         "AC",
@@ -233,7 +238,7 @@ static auto dna4_02_s1u_15u = []()
         // score: 0 - empty alignment
         "AACCGGTAAACCGG"_dna4,
         ""_dna4,
-        seqan3::align_cfg::edit | seqan3::align_cfg::aligned_ends{seqan3::free_ends_first},
+        semi_global_edit_distance,
         -0,
         "",
         "",
@@ -255,7 +260,7 @@ static auto dna4_01T_s17u_1u = []()
         // AACCGGTTAACCGGTT
         ""_dna4,
         "AACCGGTTAACCGGTT"_dna4,
-        seqan3::align_cfg::edit | seqan3::align_cfg::aligned_ends{seqan3::free_ends_first},
+        semi_global_edit_distance,
         -16,
         "----------------",
         "AACCGGTTAACCGGTT",
@@ -273,7 +278,7 @@ static auto dna4_03 = []()
         // score: 0
         ""_dna4,
         ""_dna4,
-        seqan3::align_cfg::edit | seqan3::align_cfg::aligned_ends{seqan3::free_ends_first},
+        semi_global_edit_distance,
         -0,
         "",
         "",
@@ -295,7 +300,7 @@ static auto aa27_01 = []()
         // ---------UWRIUWR-IU
         "UUWWRRIIUUWWRRII"_aa27,
         "UWRIUWRIU"_aa27,
-        seqan3::align_cfg::edit | seqan3::align_cfg::aligned_ends{seqan3::free_ends_first},
+        semi_global_edit_distance,
         -5,
         "UW---WRRII",
         "UWRIUWR-IU",
@@ -343,7 +348,7 @@ static auto aa27_01T = []()
         // UUWWRRIIUUWWRRII
         "UWRIUWRIU"_aa27,
         "UUWWRRIIUUWWRRII"_aa27,
-        seqan3::align_cfg::edit | seqan3::align_cfg::aligned_ends{seqan3::free_ends_first},
+        semi_global_edit_distance,
         -8,
         "U-W-R-I-U-W-R-IU",
         "UUWWRRIIUUWWRRII",

--- a/test/unit/core/algorithm/pipeable_config_element_test.cpp
+++ b/test/unit/core/algorithm/pipeable_config_element_test.cpp
@@ -71,6 +71,36 @@ TEST(pipeable_config_element, configuration_with_element)
     }
 }
 
+TEST(pipeable_config_element, element_with_configuration)
+{
+    seqan3::configuration<bar> tmp{};
+    bax b2{};
+
+    // lvalue | lvalue
+    {
+        auto cfg = b2 | tmp;
+        EXPECT_TRUE((std::is_same_v<decltype(cfg), seqan3::configuration<bar, bax>>));
+    }
+
+    // rvalue | lvalue
+    {
+        auto cfg = bax{} | tmp;
+        EXPECT_TRUE((std::is_same_v<decltype(cfg), seqan3::configuration<bar, bax>>));
+    }
+
+    // lvalue | rvalue
+    {
+        auto cfg = b2 | seqan3::configuration<bar>{};
+        EXPECT_TRUE((std::is_same_v<decltype(cfg), seqan3::configuration<bar, bax>>));
+    }
+
+    // rvalue | rvalue
+    {
+        auto cfg = bax{} | seqan3::configuration<bar>{};
+        EXPECT_TRUE((std::is_same_v<decltype(cfg), seqan3::configuration<bar, bax>>));
+    }
+}
+
 TEST(pipeable_config_element, configuration_with_configuration)
 {
     seqan3::configuration<bar> tmp{};


### PR DESCRIPTION
This PR does the following (one commit per bullet point)
* Introduces a test for the pipe operator in `configuration_test.cpp` which wasn't tested before
* Fixes the pipe operator for configurations to allow `config_element | config` (Before only `config | config`, `config | config_element`, and `config_element | config_element` were allowed).
* Removes the `method_global` config from the edit config and adjusts all code parts where edit was used.
