### PR TITLE
[FIX] Make char_is_valid member function public for alphabet_variant.

### DIFF
--- a/include/seqan3/alphabet/composite/alphabet_variant.hpp
+++ b/include/seqan3/alphabet/composite/alphabet_variant.hpp
@@ -433,6 +433,20 @@ public:
     }
     //!\}
 
+    //!\brief Validate whether a character is valid in the by any of the combined alphabet.
+    static constexpr bool char_is_valid(char_type const chr) noexcept
+    {
+        bool is_valid{false};
+
+        meta::for_each(alternatives{}, [&] (auto && alt)
+        {
+            if (char_is_valid_for<remove_cvref_t<decltype(alt)>>(chr))
+                is_valid = true;
+        });
+
+        return is_valid;
+    }
+
 protected:
     //!\privatesection
 
@@ -573,20 +587,6 @@ protected:
 
         return char_to_rank;
     }();
-
-    //!\brief Validate whether a character is valid in the by any of the combined alphabet.
-    static constexpr bool char_is_valid(char_type const chr) noexcept
-    {
-        bool is_valid{false};
-
-        meta::for_each(alternatives{}, [&] (auto && alt)
-        {
-            if (char_is_valid_for<remove_cvref_t<decltype(alt)>>(chr))
-                is_valid = true;
-        });
-
-        return is_valid;
-    }
 };
 
 } // namespace seqan3

--- a/include/seqan3/alphabet/composite/alphabet_variant.hpp
+++ b/include/seqan3/alphabet/composite/alphabet_variant.hpp
@@ -433,7 +433,7 @@ public:
     }
     //!\}
 
-    //!\brief Validate whether a character is valid in the by any of the combined alphabet.
+    //!\brief Validate whether a character is valid in the combined alphabet.
     static constexpr bool char_is_valid(char_type const chr) noexcept
     {
         bool is_valid{false};

--- a/test/unit/alphabet/composite/alphabet_variant_test.cpp
+++ b/test/unit/alphabet/composite/alphabet_variant_test.cpp
@@ -335,7 +335,8 @@ TEST(alphabet_variant_test, two_different_variants)
 }
 
 TEST(alphabet_variant_test, char_is_valid_for)
-{ // see issue https://github.com/seqan/seqan3/issues/1972
+{
+    // see issue https://github.com/seqan/seqan3/issues/1972
     EXPECT_TRUE(seqan3::char_is_valid_for<seqan3::gapped<seqan3::rna5>>('A')); // valid seqan3::rna5 char
     EXPECT_TRUE(seqan3::char_is_valid_for<seqan3::gapped<seqan3::rna5>>('a')); // valid seqan3::rna5 char
     EXPECT_TRUE(seqan3::char_is_valid_for<seqan3::gapped<seqan3::rna5>>('-')); // valid seqan3::gap char

--- a/test/unit/alphabet/composite/alphabet_variant_test.cpp
+++ b/test/unit/alphabet/composite/alphabet_variant_test.cpp
@@ -336,38 +336,28 @@ TEST(alphabet_variant_test, two_different_variants)
 
 TEST(alphabet_variant_test, char_is_valid_for)
 {
-    EXPECT_TRUE(seqan3::char_is_valid_for<seqan3::gapped<seqan3::rna5>>('A'));
-    EXPECT_TRUE(seqan3::char_is_valid_for<seqan3::gapped<seqan3::rna5>>('C'));
-    EXPECT_TRUE(seqan3::char_is_valid_for<seqan3::gapped<seqan3::rna5>>('G'));
-    EXPECT_TRUE(seqan3::char_is_valid_for<seqan3::gapped<seqan3::rna5>>('U'));
-    EXPECT_TRUE(seqan3::char_is_valid_for<seqan3::gapped<seqan3::rna5>>('T'));
-    EXPECT_TRUE(seqan3::char_is_valid_for<seqan3::gapped<seqan3::rna5>>('N'));
-    EXPECT_FALSE(seqan3::char_is_valid_for<seqan3::gapped<seqan3::rna5>>('S'));
-    EXPECT_TRUE(seqan3::char_is_valid_for<seqan3::gapped<seqan3::rna5>>('a'));
-    EXPECT_TRUE(seqan3::char_is_valid_for<seqan3::gapped<seqan3::rna5>>('c'));
-    EXPECT_TRUE(seqan3::char_is_valid_for<seqan3::gapped<seqan3::rna5>>('g'));
-    EXPECT_TRUE(seqan3::char_is_valid_for<seqan3::gapped<seqan3::rna5>>('u'));
-    EXPECT_TRUE(seqan3::char_is_valid_for<seqan3::gapped<seqan3::rna5>>('t'));
-    EXPECT_TRUE(seqan3::char_is_valid_for<seqan3::gapped<seqan3::rna5>>('-'));
-    EXPECT_TRUE(seqan3::char_is_valid_for<seqan3::gapped<seqan3::rna5>>('n'));
-    EXPECT_FALSE(seqan3::char_is_valid_for<seqan3::gapped<seqan3::rna5>>('s'));
+    using char_t = seqan3::alphabet_char_t<seqan3::gapped<seqan3::rna5>>;
+
+    char_t i = std::numeric_limits<char_t>::min();
+    char_t j = std::numeric_limits<char_t>::max();
+
+    for (; i < j; ++i)
+    {
+        EXPECT_EQ(seqan3::char_is_valid_for<seqan3::gapped<seqan3::rna5>>(i),
+                  seqan3::char_is_valid_for<seqan3::gap>(i) || seqan3::char_is_valid_for<seqan3::rna5>(i));
+    }
 }
 
 TEST(alphabet_variant_test, is_in_alphabet)
 { // see issue https://github.com/seqan/seqan3/issues/1972
-    EXPECT_TRUE(seqan3::is_in_alphabet<seqan3::gapped<seqan3::rna5>>('A'));
-    EXPECT_TRUE(seqan3::is_in_alphabet<seqan3::gapped<seqan3::rna5>>('C'));
-    EXPECT_TRUE(seqan3::is_in_alphabet<seqan3::gapped<seqan3::rna5>>('G'));
-    EXPECT_TRUE(seqan3::is_in_alphabet<seqan3::gapped<seqan3::rna5>>('U'));
-    EXPECT_TRUE(seqan3::is_in_alphabet<seqan3::gapped<seqan3::rna5>>('T'));
-    EXPECT_TRUE(seqan3::is_in_alphabet<seqan3::gapped<seqan3::rna5>>('N'));
-    EXPECT_FALSE(seqan3::is_in_alphabet<seqan3::gapped<seqan3::rna5>>('S'));
-    EXPECT_TRUE(seqan3::is_in_alphabet<seqan3::gapped<seqan3::rna5>>('a'));
-    EXPECT_TRUE(seqan3::is_in_alphabet<seqan3::gapped<seqan3::rna5>>('c'));
-    EXPECT_TRUE(seqan3::is_in_alphabet<seqan3::gapped<seqan3::rna5>>('g'));
-    EXPECT_TRUE(seqan3::is_in_alphabet<seqan3::gapped<seqan3::rna5>>('u'));
-    EXPECT_TRUE(seqan3::is_in_alphabet<seqan3::gapped<seqan3::rna5>>('t'));
-    EXPECT_TRUE(seqan3::is_in_alphabet<seqan3::gapped<seqan3::rna5>>('-'));
-    EXPECT_TRUE(seqan3::is_in_alphabet<seqan3::gapped<seqan3::rna5>>('n'));
-    EXPECT_FALSE(seqan3::is_in_alphabet<seqan3::gapped<seqan3::rna5>>('s'));
+    using char_t = seqan3::alphabet_char_t<seqan3::gapped<seqan3::rna5>>;
+
+    char_t i = std::numeric_limits<char_t>::min();
+    char_t j = std::numeric_limits<char_t>::max();
+
+    for (; i < j; ++i)
+    {
+        EXPECT_EQ(seqan3::is_in_alphabet<seqan3::gapped<seqan3::rna5>>(i),
+                  seqan3::is_in_alphabet<seqan3::gap>(i) || seqan3::is_in_alphabet<seqan3::rna5>(i));
+    }
 }

--- a/test/unit/alphabet/composite/alphabet_variant_test.cpp
+++ b/test/unit/alphabet/composite/alphabet_variant_test.cpp
@@ -336,12 +336,18 @@ TEST(alphabet_variant_test, two_different_variants)
 
 TEST(alphabet_variant_test, char_is_valid_for)
 {
+    EXPECT_TRUE(seqan3::char_is_valid_for<seqan3::gapped<seqan3::rna5>>('A')); // valid seqan3::rna5 char
+    EXPECT_TRUE(seqan3::char_is_valid_for<seqan3::gapped<seqan3::rna5>>('a')); // valid seqan3::rna5 char
+    EXPECT_TRUE(seqan3::char_is_valid_for<seqan3::gapped<seqan3::rna5>>('-')); // valid seqan3::gap char
+    EXPECT_FALSE(seqan3::char_is_valid_for<seqan3::gapped<seqan3::rna5>>('S')); // neither seqan3::rna5 nor seqan3::gap
+
     using char_t = seqan3::alphabet_char_t<seqan3::gapped<seqan3::rna5>>;
 
     char_t i = std::numeric_limits<char_t>::min();
-    char_t j = std::numeric_limits<char_t>::max();
+    char_t end = std::numeric_limits<char_t>::max();
 
-    for (; i < j; ++i)
+    // note that without the cast i <= end would result in an ininite loop
+    for (; static_cast<int64>(i) <= static_cast<int64>(end); ++i)
     {
         EXPECT_EQ(seqan3::char_is_valid_for<seqan3::gapped<seqan3::rna5>>(i),
                   seqan3::char_is_valid_for<seqan3::gap>(i) || seqan3::char_is_valid_for<seqan3::rna5>(i));
@@ -350,12 +356,18 @@ TEST(alphabet_variant_test, char_is_valid_for)
 
 TEST(alphabet_variant_test, is_in_alphabet)
 { // see issue https://github.com/seqan/seqan3/issues/1972
+    EXPECT_TRUE(seqan3::is_in_alphabet<seqan3::gapped<seqan3::rna5>>('A')); // valid seqan3::rna5 char
+    EXPECT_TRUE(seqan3::is_in_alphabet<seqan3::gapped<seqan3::rna5>>('a')); // valid seqan3::rna5 char
+    EXPECT_TRUE(seqan3::is_in_alphabet<seqan3::gapped<seqan3::rna5>>('-')); // valid seqan3::gap char
+    EXPECT_FALSE(seqan3::is_in_alphabet<seqan3::gapped<seqan3::rna5>>('S')); // neither seqan3::rna5 nor seqan3::gap
+
     using char_t = seqan3::alphabet_char_t<seqan3::gapped<seqan3::rna5>>;
 
     char_t i = std::numeric_limits<char_t>::min();
     char_t j = std::numeric_limits<char_t>::max();
 
-    for (; i < j; ++i)
+    // note that without the cast i <= end would result in an ininite loop
+    for (; static_cast<int64>(i) <= static_cast<int64>(end); ++i)
     {
         EXPECT_EQ(seqan3::is_in_alphabet<seqan3::gapped<seqan3::rna5>>(i),
                   seqan3::is_in_alphabet<seqan3::gap>(i) || seqan3::is_in_alphabet<seqan3::rna5>(i));

--- a/test/unit/alphabet/composite/alphabet_variant_test.cpp
+++ b/test/unit/alphabet/composite/alphabet_variant_test.cpp
@@ -13,6 +13,7 @@
 #include <seqan3/alphabet/composite/alphabet_variant.hpp>
 #include <seqan3/alphabet/gap/gap.hpp>
 #include <seqan3/alphabet/nucleotide/all.hpp>
+#include <seqan3/core/char_operations/predicate.hpp>
 
 #include "../alphabet_constexpr_test_template.hpp"
 #include "../alphabet_test_template.hpp"
@@ -331,4 +332,42 @@ TEST(alphabet_variant_test, two_different_variants)
 
     seqan3::alphabet_variant<seqan3::rna4, seqan3::gap> r2{'A'_rna4};
     EXPECT_EQ(l, r2); // this works because rna4 and dna4 are implicitly convertible to each other
+}
+
+TEST(alphabet_variant_test, char_is_valid_for)
+{
+    EXPECT_TRUE(seqan3::char_is_valid_for<seqan3::gapped<seqan3::rna5>>('A'));
+    EXPECT_TRUE(seqan3::char_is_valid_for<seqan3::gapped<seqan3::rna5>>('C'));
+    EXPECT_TRUE(seqan3::char_is_valid_for<seqan3::gapped<seqan3::rna5>>('G'));
+    EXPECT_TRUE(seqan3::char_is_valid_for<seqan3::gapped<seqan3::rna5>>('U'));
+    EXPECT_TRUE(seqan3::char_is_valid_for<seqan3::gapped<seqan3::rna5>>('T'));
+    EXPECT_TRUE(seqan3::char_is_valid_for<seqan3::gapped<seqan3::rna5>>('N'));
+    EXPECT_FALSE(seqan3::char_is_valid_for<seqan3::gapped<seqan3::rna5>>('S'));
+    EXPECT_TRUE(seqan3::char_is_valid_for<seqan3::gapped<seqan3::rna5>>('a'));
+    EXPECT_TRUE(seqan3::char_is_valid_for<seqan3::gapped<seqan3::rna5>>('c'));
+    EXPECT_TRUE(seqan3::char_is_valid_for<seqan3::gapped<seqan3::rna5>>('g'));
+    EXPECT_TRUE(seqan3::char_is_valid_for<seqan3::gapped<seqan3::rna5>>('u'));
+    EXPECT_TRUE(seqan3::char_is_valid_for<seqan3::gapped<seqan3::rna5>>('t'));
+    EXPECT_TRUE(seqan3::char_is_valid_for<seqan3::gapped<seqan3::rna5>>('-'));
+    EXPECT_TRUE(seqan3::char_is_valid_for<seqan3::gapped<seqan3::rna5>>('n'));
+    EXPECT_FALSE(seqan3::char_is_valid_for<seqan3::gapped<seqan3::rna5>>('s'));
+}
+
+TEST(alphabet_variant_test, is_in_alphabet)
+{ // see issue https://github.com/seqan/seqan3/issues/1972
+    EXPECT_TRUE(seqan3::is_in_alphabet<seqan3::gapped<seqan3::rna5>>('A'));
+    EXPECT_TRUE(seqan3::is_in_alphabet<seqan3::gapped<seqan3::rna5>>('C'));
+    EXPECT_TRUE(seqan3::is_in_alphabet<seqan3::gapped<seqan3::rna5>>('G'));
+    EXPECT_TRUE(seqan3::is_in_alphabet<seqan3::gapped<seqan3::rna5>>('U'));
+    EXPECT_TRUE(seqan3::is_in_alphabet<seqan3::gapped<seqan3::rna5>>('T'));
+    EXPECT_TRUE(seqan3::is_in_alphabet<seqan3::gapped<seqan3::rna5>>('N'));
+    EXPECT_FALSE(seqan3::is_in_alphabet<seqan3::gapped<seqan3::rna5>>('S'));
+    EXPECT_TRUE(seqan3::is_in_alphabet<seqan3::gapped<seqan3::rna5>>('a'));
+    EXPECT_TRUE(seqan3::is_in_alphabet<seqan3::gapped<seqan3::rna5>>('c'));
+    EXPECT_TRUE(seqan3::is_in_alphabet<seqan3::gapped<seqan3::rna5>>('g'));
+    EXPECT_TRUE(seqan3::is_in_alphabet<seqan3::gapped<seqan3::rna5>>('u'));
+    EXPECT_TRUE(seqan3::is_in_alphabet<seqan3::gapped<seqan3::rna5>>('t'));
+    EXPECT_TRUE(seqan3::is_in_alphabet<seqan3::gapped<seqan3::rna5>>('-'));
+    EXPECT_TRUE(seqan3::is_in_alphabet<seqan3::gapped<seqan3::rna5>>('n'));
+    EXPECT_FALSE(seqan3::is_in_alphabet<seqan3::gapped<seqan3::rna5>>('s'));
 }

--- a/test/unit/alphabet/composite/alphabet_variant_test.cpp
+++ b/test/unit/alphabet/composite/alphabet_variant_test.cpp
@@ -343,12 +343,7 @@ TEST(alphabet_variant_test, char_is_valid_for)
     EXPECT_FALSE(seqan3::char_is_valid_for<seqan3::gapped<seqan3::rna5>>('S')); // neither seqan3::rna5 nor seqan3::gap
 }
 
-template <typename T>
-using alphabet_variant_typed_test = ::testing::Test;
-
-TYPED_TEST_SUITE(alphabet_variant_typed_test, alphabet_variant_types, );
-
-TYPED_TEST(alphabet_variant_typed_test, char_is_valid_for)
+TYPED_TEST(alphabet_variant_test, char_is_valid_for)
 {
     using gapped_alphabet_t = TypeParam;
     using gapped_alphabet_bases_t = typename gapped_alphabet_t::seqan3_required_types;

--- a/test/unit/alphabet/composite/alphabet_variant_test.cpp
+++ b/test/unit/alphabet/composite/alphabet_variant_test.cpp
@@ -13,7 +13,7 @@
 #include <seqan3/alphabet/composite/alphabet_variant.hpp>
 #include <seqan3/alphabet/gap/gap.hpp>
 #include <seqan3/alphabet/nucleotide/all.hpp>
-#include <seqan3/core/char_operations/predicate.hpp>
+#include <seqan3/core/detail/pack_algorithm.hpp>
 
 #include "../alphabet_constexpr_test_template.hpp"
 #include "../alphabet_test_template.hpp"
@@ -335,41 +335,36 @@ TEST(alphabet_variant_test, two_different_variants)
 }
 
 TEST(alphabet_variant_test, char_is_valid_for)
-{
+{ // see issue https://github.com/seqan/seqan3/issues/1972
     EXPECT_TRUE(seqan3::char_is_valid_for<seqan3::gapped<seqan3::rna5>>('A')); // valid seqan3::rna5 char
     EXPECT_TRUE(seqan3::char_is_valid_for<seqan3::gapped<seqan3::rna5>>('a')); // valid seqan3::rna5 char
     EXPECT_TRUE(seqan3::char_is_valid_for<seqan3::gapped<seqan3::rna5>>('-')); // valid seqan3::gap char
     EXPECT_FALSE(seqan3::char_is_valid_for<seqan3::gapped<seqan3::rna5>>('S')); // neither seqan3::rna5 nor seqan3::gap
+}
 
-    using char_t = seqan3::alphabet_char_t<seqan3::gapped<seqan3::rna5>>;
+template <typename T>
+using alphabet_variant_typed_test = ::testing::Test;
+
+TYPED_TEST_SUITE(alphabet_variant_typed_test, alphabet_variant_types, );
+
+TYPED_TEST(alphabet_variant_typed_test, char_is_valid_for)
+{
+    using gapped_alphabet_t = TypeParam;
+    using gapped_alphabet_bases_t = typename gapped_alphabet_t::seqan3_required_types;
+    using char_t = seqan3::alphabet_char_t<gapped_alphabet_t>;
 
     char_t i = std::numeric_limits<char_t>::min();
     char_t end = std::numeric_limits<char_t>::max();
+    uint64_t i_no_overflow = std::numeric_limits<char_t>::min();
 
-    // note that without the cast i <= end would result in an ininite loop
-    for (; static_cast<int64>(i) <= static_cast<int64>(end); ++i)
+    for (; i_no_overflow <= static_cast<uint64_t>(end); ++i, ++i_no_overflow)
     {
-        EXPECT_EQ(seqan3::char_is_valid_for<seqan3::gapped<seqan3::rna5>>(i),
-                  seqan3::char_is_valid_for<seqan3::gap>(i) || seqan3::char_is_valid_for<seqan3::rna5>(i));
-    }
-}
-
-TEST(alphabet_variant_test, is_in_alphabet)
-{ // see issue https://github.com/seqan/seqan3/issues/1972
-    EXPECT_TRUE(seqan3::is_in_alphabet<seqan3::gapped<seqan3::rna5>>('A')); // valid seqan3::rna5 char
-    EXPECT_TRUE(seqan3::is_in_alphabet<seqan3::gapped<seqan3::rna5>>('a')); // valid seqan3::rna5 char
-    EXPECT_TRUE(seqan3::is_in_alphabet<seqan3::gapped<seqan3::rna5>>('-')); // valid seqan3::gap char
-    EXPECT_FALSE(seqan3::is_in_alphabet<seqan3::gapped<seqan3::rna5>>('S')); // neither seqan3::rna5 nor seqan3::gap
-
-    using char_t = seqan3::alphabet_char_t<seqan3::gapped<seqan3::rna5>>;
-
-    char_t i = std::numeric_limits<char_t>::min();
-    char_t j = std::numeric_limits<char_t>::max();
-
-    // note that without the cast i <= end would result in an ininite loop
-    for (; static_cast<int64>(i) <= static_cast<int64>(end); ++i)
-    {
-        EXPECT_EQ(seqan3::is_in_alphabet<seqan3::gapped<seqan3::rna5>>(i),
-                  seqan3::is_in_alphabet<seqan3::gap>(i) || seqan3::is_in_alphabet<seqan3::rna5>(i));
+        bool is_valid{};
+        seqan3::detail::for_each<gapped_alphabet_bases_t>([&is_valid, i](auto id)
+        {
+             using type = typename decltype(id)::type;
+             is_valid = is_valid || seqan3::char_is_valid_for<type>(i);
+        });
+        EXPECT_EQ(seqan3::char_is_valid_for<gapped_alphabet_t>(i), is_valid);
     }
 }

--- a/test/unit/alphabet/composite/alphabet_variant_test.cpp
+++ b/test/unit/alphabet/composite/alphabet_variant_test.cpp
@@ -334,7 +334,7 @@ TEST(alphabet_variant_test, two_different_variants)
     EXPECT_EQ(l, r2); // this works because rna4 and dna4 are implicitly convertible to each other
 }
 
-TEST(alphabet_variant_test, char_is_valid_for)
+TEST(alphabet_variant_test, char_is_valid_for_issue_1972)
 {
     // see issue https://github.com/seqan/seqan3/issues/1972
     EXPECT_TRUE(seqan3::char_is_valid_for<seqan3::gapped<seqan3::rna5>>('A')); // valid seqan3::rna5 char

--- a/test/unit/core/char_operations/char_predicate_test.cpp
+++ b/test/unit/core/char_operations/char_predicate_test.cpp
@@ -441,41 +441,11 @@ TEST(char_predicate_, char_types)
     }
 }
 
-TEST(char_predicate_, is_in_alphabet_alphabet_variant)
-{ // see issue https://github.com/seqan/seqan3/issues/1972
+// see issue https://github.com/seqan/seqan3/issues/1972
+TEST(char_predicate_, issue1972)
+{
     EXPECT_TRUE(seqan3::is_in_alphabet<seqan3::gapped<seqan3::rna5>>('A')); // valid seqan3::rna5 char
     EXPECT_TRUE(seqan3::is_in_alphabet<seqan3::gapped<seqan3::rna5>>('a')); // valid seqan3::rna5 char
     EXPECT_TRUE(seqan3::is_in_alphabet<seqan3::gapped<seqan3::rna5>>('-')); // valid seqan3::gap char
     EXPECT_FALSE(seqan3::is_in_alphabet<seqan3::gapped<seqan3::rna5>>('S')); // neither seqan3::rna5 nor seqan3::gap
-}
-
-template <typename T>
-using char_predicate_typed_test = ::testing::Test;
-
-using alphabet_variant_types = ::testing::Types<seqan3::alphabet_variant<seqan3::dna4, seqan3::gap>,
-                                                seqan3::alphabet_variant<seqan3::dna4, seqan3::dna5, seqan3::gap>,
-                                                seqan3::alphabet_variant<char, seqan3::gap>>;
-
-TYPED_TEST_SUITE(char_predicate_typed_test, alphabet_variant_types, );
-
-TYPED_TEST(char_predicate_typed_test, is_in_alphabet_alphabet_variant)
-{
-    using gapped_alphabet_t = TypeParam;
-    using gapped_alphabet_bases_t = typename gapped_alphabet_t::seqan3_required_types;
-    using char_t = seqan3::alphabet_char_t<gapped_alphabet_t>;
-
-    char_t i = std::numeric_limits<char_t>::min();
-    char_t end = std::numeric_limits<char_t>::max();
-    uint64_t i_no_overflow = std::numeric_limits<char_t>::min();
-
-    for (; i_no_overflow <= static_cast<uint64_t>(end); ++i, ++i_no_overflow)
-    {
-        bool is_valid{};
-        seqan3::detail::for_each<gapped_alphabet_bases_t>([&is_valid, i](auto id)
-        {
-             using type = typename decltype(id)::type;
-             is_valid = is_valid || seqan3::is_in_alphabet<type>(i);
-        });
-        EXPECT_EQ(seqan3::is_in_alphabet<gapped_alphabet_t>(i), is_valid);
-    }
 }


### PR DESCRIPTION
Fixes #1972 

Note that `char_is_valid` is public in all other alphabets. I double checked.