### PR TITLE
[MISC] Remove weird try catch block.

### DIFF
--- a/include/seqan3/alignment/configuration/align_config_band.hpp
+++ b/include/seqan3/alignment/configuration/align_config_band.hpp
@@ -58,7 +58,7 @@ struct upper_diagonal : public seqan3::detail::strong_type<int32_t, upper_diagon
  * If this configuration is default constructed or not set during the algorithm configuration the full alignment
  * matrix will be computed.
  *
- * During the construction of this configuration element or before the execution of the alignment algorithm the
+ * Before the execution of the alignment algorithm the
  * band configuration is validated. If the user provided an invalid band, e.g. the upper diagonal is smaller than
  * the lower diagonal, the alignment matrix would be ill configured such that the requested alignment method cannot
  * be computed (because the global alignment requires the first cell and the last cell of the matrix to be reachable),

--- a/test/snippet/alignment/configuration/align_cfg_band_example.cpp
+++ b/test/snippet/alignment/configuration/align_cfg_band_example.cpp
@@ -2,8 +2,6 @@
 
 int main()
 {
-try
-{
     // A symmetric band around the main diagonal.
     seqan3::align_cfg::band_fixed_size band_cfg{seqan3::align_cfg::lower_diagonal{-4},
                                                 seqan3::align_cfg::upper_diagonal{4}};
@@ -17,10 +15,7 @@ try
                                                    seqan3::align_cfg::upper_diagonal{-3}};
 
     // An invalid band configuration.
+    // Using this band as a configuration in seqan3::align_pairwise would cause the algorithm to throw an exception.
     seqan3::align_cfg::band_fixed_size band_cfg_invalid{seqan3::align_cfg::lower_diagonal{7},
                                                         seqan3::align_cfg::upper_diagonal{3}};
-}
-catch(...)
-{
-}
 }


### PR DESCRIPTION
Just came across this while checking the documentation on banded alignments.
I guess before this was inlcuded via `\snippet` where the wird try catch did not show. Now it shows int he documentation but the band does not throw anyway.