### PR TITLE
[FIX] performance test: missing include for cpp20 gcc10

### DIFF
--- a/test/performance/range/views/view_all_benchmark.cpp
+++ b/test/performance/range/views/view_all_benchmark.cpp
@@ -7,12 +7,13 @@
 
 #include <deque>
 #include <list>
+#include <seqan3/std/ranges>
 #include <string>
 #include <vector>
 
 #include <benchmark/benchmark.h>
 
-#include <seqan3/std/ranges>
+#include <range/v3/view/all.hpp>
 
 #include <seqan3/range/views/type_reduce.hpp>
 

--- a/test/performance/range/views/view_all_benchmark.cpp
+++ b/test/performance/range/views/view_all_benchmark.cpp
@@ -13,8 +13,6 @@
 
 #include <benchmark/benchmark.h>
 
-#include <range/v3/view/all.hpp>
-
 #include <seqan3/range/views/type_reduce.hpp>
 
 // ============================================================================
@@ -57,22 +55,18 @@ void sequential_read(benchmark::State & state)
 
 BENCHMARK_TEMPLATE(sequential_read, std::string, void);
 BENCHMARK_TEMPLATE(sequential_read, std::string, decltype(std::views::all));
-BENCHMARK_TEMPLATE(sequential_read, std::string, decltype(::ranges::view::all));
 BENCHMARK_TEMPLATE(sequential_read, std::string, decltype(seqan3::views::type_reduce));
 
 BENCHMARK_TEMPLATE(sequential_read, std::vector<uint8_t>, void);
 BENCHMARK_TEMPLATE(sequential_read, std::vector<uint8_t>, decltype(std::views::all));
-BENCHMARK_TEMPLATE(sequential_read, std::vector<uint8_t>, decltype(::ranges::view::all));
 BENCHMARK_TEMPLATE(sequential_read, std::vector<uint8_t>, decltype(seqan3::views::type_reduce));
 
 BENCHMARK_TEMPLATE(sequential_read, std::deque<uint8_t>, void);
 BENCHMARK_TEMPLATE(sequential_read, std::deque<uint8_t>, decltype(std::views::all));
-BENCHMARK_TEMPLATE(sequential_read, std::deque<uint8_t>, decltype(::ranges::view::all));
 BENCHMARK_TEMPLATE(sequential_read, std::deque<uint8_t>, decltype(seqan3::views::type_reduce));
 
 BENCHMARK_TEMPLATE(sequential_read, std::list<uint8_t>, void);
 BENCHMARK_TEMPLATE(sequential_read, std::list<uint8_t>, decltype(std::views::all));
-BENCHMARK_TEMPLATE(sequential_read, std::list<uint8_t>, decltype(::ranges::view::all));
 BENCHMARK_TEMPLATE(sequential_read, std::list<uint8_t>, decltype(seqan3::views::type_reduce));
 
 // ============================================================================


### PR DESCRIPTION
This adds a missing include.
In cpp20 mode, we do not include the ranges header, but use the STL `<ranges>`, so we need to explicitly include the ranges header.

With this, unit, snippet and performance tests work in cpp20 mode.