### PR TITLE
[FIX] header test: missing includes for cpp20 gcc10

### DIFF
--- a/include/seqan3/alignment/pairwise/alignment_range.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_range.hpp
@@ -15,6 +15,8 @@
 #include <seqan3/std/concepts>
 #include <seqan3/std/ranges>
 
+#include <seqan3/core/platform.hpp>
+
 namespace seqan3
 {
 

--- a/include/seqan3/range/detail/misc.hpp
+++ b/include/seqan3/range/detail/misc.hpp
@@ -14,6 +14,8 @@
 
 #include <seqan3/std/ranges>
 
+#include <seqan3/core/platform.hpp>
+
 namespace seqan3::detail
 {
 

--- a/include/seqan3/range/detail/random_access_iterator.hpp
+++ b/include/seqan3/range/detail/random_access_iterator.hpp
@@ -13,9 +13,10 @@
 #pragma once
 
 #include <cassert>
+#include <seqan3/std/iterator>
 #include <type_traits>
 
-#include <seqan3/std/iterator>
+#include <seqan3/core/platform.hpp>
 
 namespace seqan3::detail
 {


### PR DESCRIPTION
With cpp20 support, we do not use our `seqan3/std/...` headers but the stl headers.
This may lead to missing `seqan3/core/platform.hpp` includes if nothing else from seqan3 is included.