### PR TITLE
[TEST] Remove prefixes / suffices in test suites that are not necessary

### DIFF
--- a/test/performance/alignment/edit_distance_unbanded_benchmark.cpp
+++ b/test/performance/alignment/edit_distance_unbanded_benchmark.cpp
@@ -240,7 +240,7 @@ void seqan2_edit_distance_dna4_generic_collection(benchmark::State & state)
     for (auto _ : state)
     {
         for (int score_: seqan::globalAlignmentScore(vec1, vec2, seqan::Score<int>{0, -1, -1}))
-            score += score_;
+            score += score;
     }
 
     state.counters["score"] = score;

--- a/test/performance/alphabet/alphabet_assign_char_benchmark.cpp
+++ b/test/performance/alphabet/alphabet_assign_char_benchmark.cpp
@@ -21,7 +21,7 @@
 #endif
 
 template <seqan3::alphabet alphabet_t>
-void assign_char_(benchmark::State & state)
+void assign_char(benchmark::State & state)
 {
     using char_t = seqan3::alphabet_char_t<alphabet_t>;
 
@@ -35,29 +35,29 @@ void assign_char_(benchmark::State & state)
 }
 
 /* regular alphabets, sorted by size */
-BENCHMARK_TEMPLATE(assign_char_, seqan3::gap);
-BENCHMARK_TEMPLATE(assign_char_, seqan3::dna4);
-BENCHMARK_TEMPLATE(assign_char_, seqan3::rna4);
-BENCHMARK_TEMPLATE(assign_char_, seqan3::dna5);
-BENCHMARK_TEMPLATE(assign_char_, seqan3::rna5);
-BENCHMARK_TEMPLATE(assign_char_, seqan3::dna15);
-BENCHMARK_TEMPLATE(assign_char_, seqan3::rna15);
-BENCHMARK_TEMPLATE(assign_char_, seqan3::aa20);
-BENCHMARK_TEMPLATE(assign_char_, seqan3::aa27);
-BENCHMARK_TEMPLATE(assign_char_, seqan3::phred42);
-BENCHMARK_TEMPLATE(assign_char_, seqan3::phred63);
+BENCHMARK_TEMPLATE(assign_char, seqan3::gap);
+BENCHMARK_TEMPLATE(assign_char, seqan3::dna4);
+BENCHMARK_TEMPLATE(assign_char, seqan3::rna4);
+BENCHMARK_TEMPLATE(assign_char, seqan3::dna5);
+BENCHMARK_TEMPLATE(assign_char, seqan3::rna5);
+BENCHMARK_TEMPLATE(assign_char, seqan3::dna15);
+BENCHMARK_TEMPLATE(assign_char, seqan3::rna15);
+BENCHMARK_TEMPLATE(assign_char, seqan3::aa20);
+BENCHMARK_TEMPLATE(assign_char, seqan3::aa27);
+BENCHMARK_TEMPLATE(assign_char, seqan3::phred42);
+BENCHMARK_TEMPLATE(assign_char, seqan3::phred63);
 /* adaptations */
-BENCHMARK_TEMPLATE(assign_char_, char);
-BENCHMARK_TEMPLATE(assign_char_, char32_t);
+BENCHMARK_TEMPLATE(assign_char, char);
+BENCHMARK_TEMPLATE(assign_char, char32_t);
 /* alphabet variant */
-BENCHMARK_TEMPLATE(assign_char_, seqan3::gapped<seqan3::dna4>);
-BENCHMARK_TEMPLATE(assign_char_, seqan3::alphabet_variant<seqan3::gap, seqan3::dna4, seqan3::dna5, seqan3::dna15,
-                                                          seqan3::rna15, seqan3::rna4, seqan3::rna5>);
-BENCHMARK_TEMPLATE(assign_char_, seqan3::alphabet_variant<seqan3::dna4, char>);
+BENCHMARK_TEMPLATE(assign_char, seqan3::gapped<seqan3::dna4>);
+BENCHMARK_TEMPLATE(assign_char, seqan3::alphabet_variant<seqan3::gap, seqan3::dna4, seqan3::dna5, seqan3::dna15,
+                                                         seqan3::rna15, seqan3::rna4, seqan3::rna5>);
+BENCHMARK_TEMPLATE(assign_char, seqan3::alphabet_variant<seqan3::dna4, char>);
 /* alphabet tuple */
-BENCHMARK_TEMPLATE(assign_char_, seqan3::masked<seqan3::dna4>);
-BENCHMARK_TEMPLATE(assign_char_, seqan3::qualified<seqan3::dna4, seqan3::phred42>);
-BENCHMARK_TEMPLATE(assign_char_, seqan3::qualified<seqan3::dna5, seqan3::phred63>);
+BENCHMARK_TEMPLATE(assign_char, seqan3::masked<seqan3::dna4>);
+BENCHMARK_TEMPLATE(assign_char, seqan3::qualified<seqan3::dna4, seqan3::phred42>);
+BENCHMARK_TEMPLATE(assign_char, seqan3::qualified<seqan3::dna5, seqan3::phred63>);
 
 #if SEQAN3_HAS_SEQAN2
 template <typename alphabet_t>

--- a/test/performance/alphabet/alphabet_assign_rank_benchmark.cpp
+++ b/test/performance/alphabet/alphabet_assign_rank_benchmark.cpp
@@ -28,7 +28,7 @@ void fill_rank_array(std::array<rank_t, 256> & ranks, size_t const alphabet_size
 }
 
 template <seqan3::semialphabet alphabet_t>
-void assign_rank_(benchmark::State & state)
+void assign_rank(benchmark::State & state)
 {
     using rank_t = seqan3::alphabet_rank_t<alphabet_t>;
 
@@ -42,29 +42,29 @@ void assign_rank_(benchmark::State & state)
 }
 
 /* regular alphabets, sorted by size */
-BENCHMARK_TEMPLATE(assign_rank_, seqan3::gap);
-BENCHMARK_TEMPLATE(assign_rank_, seqan3::dna4);
-BENCHMARK_TEMPLATE(assign_rank_, seqan3::rna4);
-BENCHMARK_TEMPLATE(assign_rank_, seqan3::dna5);
-BENCHMARK_TEMPLATE(assign_rank_, seqan3::rna5);
-BENCHMARK_TEMPLATE(assign_rank_, seqan3::dna15);
-BENCHMARK_TEMPLATE(assign_rank_, seqan3::rna15);
-BENCHMARK_TEMPLATE(assign_rank_, seqan3::aa20);
-BENCHMARK_TEMPLATE(assign_rank_, seqan3::aa27);
-BENCHMARK_TEMPLATE(assign_rank_, seqan3::phred42);
-BENCHMARK_TEMPLATE(assign_rank_, seqan3::phred63);
+BENCHMARK_TEMPLATE(assign_rank, seqan3::gap);
+BENCHMARK_TEMPLATE(assign_rank, seqan3::dna4);
+BENCHMARK_TEMPLATE(assign_rank, seqan3::rna4);
+BENCHMARK_TEMPLATE(assign_rank, seqan3::dna5);
+BENCHMARK_TEMPLATE(assign_rank, seqan3::rna5);
+BENCHMARK_TEMPLATE(assign_rank, seqan3::dna15);
+BENCHMARK_TEMPLATE(assign_rank, seqan3::rna15);
+BENCHMARK_TEMPLATE(assign_rank, seqan3::aa20);
+BENCHMARK_TEMPLATE(assign_rank, seqan3::aa27);
+BENCHMARK_TEMPLATE(assign_rank, seqan3::phred42);
+BENCHMARK_TEMPLATE(assign_rank, seqan3::phred63);
 /* adaptations */
-BENCHMARK_TEMPLATE(assign_rank_, char);
-BENCHMARK_TEMPLATE(assign_rank_, char32_t);
+BENCHMARK_TEMPLATE(assign_rank, char);
+BENCHMARK_TEMPLATE(assign_rank, char32_t);
 /* alphabet variant */
-BENCHMARK_TEMPLATE(assign_rank_, seqan3::gapped<seqan3::dna4>);
-BENCHMARK_TEMPLATE(assign_rank_, seqan3::alphabet_variant<seqan3::gap, seqan3::dna4, seqan3::dna5, seqan3::dna15,
-                                                          seqan3::rna15, seqan3::rna4, seqan3::rna5>);
-BENCHMARK_TEMPLATE(assign_rank_, seqan3::alphabet_variant<seqan3::dna4, char>);
+BENCHMARK_TEMPLATE(assign_rank, seqan3::gapped<seqan3::dna4>);
+BENCHMARK_TEMPLATE(assign_rank, seqan3::alphabet_variant<seqan3::gap, seqan3::dna4, seqan3::dna5, seqan3::dna15,
+                                                         seqan3::rna15, seqan3::rna4, seqan3::rna5>);
+BENCHMARK_TEMPLATE(assign_rank, seqan3::alphabet_variant<seqan3::dna4, char>);
 /* alphabet tuple */
-BENCHMARK_TEMPLATE(assign_rank_, seqan3::masked<seqan3::dna4>);
-BENCHMARK_TEMPLATE(assign_rank_, seqan3::qualified<seqan3::dna4, seqan3::phred42>);
-BENCHMARK_TEMPLATE(assign_rank_, seqan3::qualified<seqan3::dna5, seqan3::phred63>);
+BENCHMARK_TEMPLATE(assign_rank, seqan3::masked<seqan3::dna4>);
+BENCHMARK_TEMPLATE(assign_rank, seqan3::qualified<seqan3::dna4, seqan3::phred42>);
+BENCHMARK_TEMPLATE(assign_rank, seqan3::qualified<seqan3::dna5, seqan3::phred63>);
 
 #if SEQAN3_HAS_SEQAN2
 template <typename alphabet_t>

--- a/test/performance/alphabet/alphabet_to_char_benchmark.cpp
+++ b/test/performance/alphabet/alphabet_to_char_benchmark.cpp
@@ -45,7 +45,7 @@ std::array<alphabet_t, 256> create_alphabet_array()
 }
 
 template <seqan3::alphabet alphabet_t>
-void to_char_(benchmark::State & state)
+void to_char(benchmark::State & state)
 {
     std::array<alphabet_t, 256> alphs = create_alphabet_array<alphabet_t, false>();
 
@@ -55,29 +55,29 @@ void to_char_(benchmark::State & state)
 }
 
 /* regular alphabets, sorted by size */
-BENCHMARK_TEMPLATE(to_char_, seqan3::gap);
-BENCHMARK_TEMPLATE(to_char_, seqan3::dna4);
-BENCHMARK_TEMPLATE(to_char_, seqan3::rna4);
-BENCHMARK_TEMPLATE(to_char_, seqan3::dna5);
-BENCHMARK_TEMPLATE(to_char_, seqan3::rna5);
-BENCHMARK_TEMPLATE(to_char_, seqan3::dna15);
-BENCHMARK_TEMPLATE(to_char_, seqan3::rna15);
-BENCHMARK_TEMPLATE(to_char_, seqan3::aa20);
-BENCHMARK_TEMPLATE(to_char_, seqan3::aa27);
-BENCHMARK_TEMPLATE(to_char_, seqan3::phred42);
-BENCHMARK_TEMPLATE(to_char_, seqan3::phred63);
+BENCHMARK_TEMPLATE(to_char, seqan3::gap);
+BENCHMARK_TEMPLATE(to_char, seqan3::dna4);
+BENCHMARK_TEMPLATE(to_char, seqan3::rna4);
+BENCHMARK_TEMPLATE(to_char, seqan3::dna5);
+BENCHMARK_TEMPLATE(to_char, seqan3::rna5);
+BENCHMARK_TEMPLATE(to_char, seqan3::dna15);
+BENCHMARK_TEMPLATE(to_char, seqan3::rna15);
+BENCHMARK_TEMPLATE(to_char, seqan3::aa20);
+BENCHMARK_TEMPLATE(to_char, seqan3::aa27);
+BENCHMARK_TEMPLATE(to_char, seqan3::phred42);
+BENCHMARK_TEMPLATE(to_char, seqan3::phred63);
 /* adaptations */
-BENCHMARK_TEMPLATE(to_char_, char);
-BENCHMARK_TEMPLATE(to_char_, char32_t);
+BENCHMARK_TEMPLATE(to_char, char);
+BENCHMARK_TEMPLATE(to_char, char32_t);
 /* alphabet variant */
-BENCHMARK_TEMPLATE(to_char_, seqan3::gapped<seqan3::dna4>);
-BENCHMARK_TEMPLATE(to_char_, seqan3::alphabet_variant<seqan3::gap, seqan3::dna4, seqan3::dna5, seqan3::dna15,
-                                                      seqan3::rna15, seqan3::rna4, seqan3::rna5>);
-BENCHMARK_TEMPLATE(to_char_, seqan3::alphabet_variant<seqan3::dna4, char>);
+BENCHMARK_TEMPLATE(to_char, seqan3::gapped<seqan3::dna4>);
+BENCHMARK_TEMPLATE(to_char, seqan3::alphabet_variant<seqan3::gap, seqan3::dna4, seqan3::dna5, seqan3::dna15,
+                                                     seqan3::rna15, seqan3::rna4, seqan3::rna5>);
+BENCHMARK_TEMPLATE(to_char, seqan3::alphabet_variant<seqan3::dna4, char>);
 /* alphabet tuple */
-BENCHMARK_TEMPLATE(to_char_, seqan3::masked<seqan3::dna4>);
-BENCHMARK_TEMPLATE(to_char_, seqan3::qualified<seqan3::dna4, seqan3::phred42>);
-BENCHMARK_TEMPLATE(to_char_, seqan3::qualified<seqan3::dna5, seqan3::phred63>);
+BENCHMARK_TEMPLATE(to_char, seqan3::masked<seqan3::dna4>);
+BENCHMARK_TEMPLATE(to_char, seqan3::qualified<seqan3::dna4, seqan3::phred42>);
+BENCHMARK_TEMPLATE(to_char, seqan3::qualified<seqan3::dna5, seqan3::phred63>);
 
 #if SEQAN3_HAS_SEQAN2
 template <typename alphabet_t>

--- a/test/performance/alphabet/alphabet_to_rank_benchmark.cpp
+++ b/test/performance/alphabet/alphabet_to_rank_benchmark.cpp
@@ -39,7 +39,7 @@ std::array<alphabet_t, 256> create_alphabet_array(size_t const alphabet_size)
 }
 
 template <seqan3::semialphabet alphabet_t>
-void to_rank_(benchmark::State & state)
+void to_rank(benchmark::State & state)
 {
     std::array<alphabet_t, 256> alphs = create_alphabet_array<alphabet_t, false>(seqan3::alphabet_size<alphabet_t>);
 
@@ -49,29 +49,29 @@ void to_rank_(benchmark::State & state)
 }
 
 /* regular alphabets, sorted by size */
-BENCHMARK_TEMPLATE(to_rank_, seqan3::gap);
-BENCHMARK_TEMPLATE(to_rank_, seqan3::dna4);
-BENCHMARK_TEMPLATE(to_rank_, seqan3::rna4);
-BENCHMARK_TEMPLATE(to_rank_, seqan3::dna5);
-BENCHMARK_TEMPLATE(to_rank_, seqan3::rna5);
-BENCHMARK_TEMPLATE(to_rank_, seqan3::dna15);
-BENCHMARK_TEMPLATE(to_rank_, seqan3::rna15);
-BENCHMARK_TEMPLATE(to_rank_, seqan3::aa20);
-BENCHMARK_TEMPLATE(to_rank_, seqan3::aa27);
-BENCHMARK_TEMPLATE(to_rank_, seqan3::phred42);
-BENCHMARK_TEMPLATE(to_rank_, seqan3::phred63);
+BENCHMARK_TEMPLATE(to_rank, seqan3::gap);
+BENCHMARK_TEMPLATE(to_rank, seqan3::dna4);
+BENCHMARK_TEMPLATE(to_rank, seqan3::rna4);
+BENCHMARK_TEMPLATE(to_rank, seqan3::dna5);
+BENCHMARK_TEMPLATE(to_rank, seqan3::rna5);
+BENCHMARK_TEMPLATE(to_rank, seqan3::dna15);
+BENCHMARK_TEMPLATE(to_rank, seqan3::rna15);
+BENCHMARK_TEMPLATE(to_rank, seqan3::aa20);
+BENCHMARK_TEMPLATE(to_rank, seqan3::aa27);
+BENCHMARK_TEMPLATE(to_rank, seqan3::phred42);
+BENCHMARK_TEMPLATE(to_rank, seqan3::phred63);
 /* adaptations */
-BENCHMARK_TEMPLATE(to_rank_, char);
-BENCHMARK_TEMPLATE(to_rank_, char32_t);
+BENCHMARK_TEMPLATE(to_rank, char);
+BENCHMARK_TEMPLATE(to_rank, char32_t);
 /* alphabet variant */
-BENCHMARK_TEMPLATE(to_rank_, seqan3::gapped<seqan3::dna4>);
-BENCHMARK_TEMPLATE(to_rank_, seqan3::alphabet_variant<seqan3::gap, seqan3::dna4, seqan3::dna5, seqan3::dna15,
-                                                      seqan3::rna15, seqan3::rna4, seqan3::rna5>);
-BENCHMARK_TEMPLATE(to_rank_, seqan3::alphabet_variant<seqan3::dna4, char>);
+BENCHMARK_TEMPLATE(to_rank, seqan3::gapped<seqan3::dna4>);
+BENCHMARK_TEMPLATE(to_rank, seqan3::alphabet_variant<seqan3::gap, seqan3::dna4, seqan3::dna5, seqan3::dna15,
+                                                     seqan3::rna15, seqan3::rna4, seqan3::rna5>);
+BENCHMARK_TEMPLATE(to_rank, seqan3::alphabet_variant<seqan3::dna4, char>);
 /* alphabet tuple */
-BENCHMARK_TEMPLATE(to_rank_, seqan3::masked<seqan3::dna4>);
-BENCHMARK_TEMPLATE(to_rank_, seqan3::qualified<seqan3::dna4, seqan3::phred42>);
-BENCHMARK_TEMPLATE(to_rank_, seqan3::qualified<seqan3::dna5, seqan3::phred63>);
+BENCHMARK_TEMPLATE(to_rank, seqan3::masked<seqan3::dna4>);
+BENCHMARK_TEMPLATE(to_rank, seqan3::qualified<seqan3::dna4, seqan3::phred42>);
+BENCHMARK_TEMPLATE(to_rank, seqan3::qualified<seqan3::dna5, seqan3::phred63>);
 
 #if SEQAN3_HAS_SEQAN2
 template <typename alphabet_t>

--- a/test/performance/range/container_seq_read_benchmark.cpp
+++ b/test/performance/range/container_seq_read_benchmark.cpp
@@ -25,13 +25,13 @@ using small_vec = seqan3::small_vector<t, 10'000>;
 //  sequential_read
 // ============================================================================
 
-template <template <typename> typename container_t, typename alphabet_t, bool const_ = false>
+template <template <typename> typename container_t, typename alphabet_t, bool const_qualified = false>
 void sequential_read(benchmark::State & state)
 {
     auto cont_rando = seqan3::test::generate_sequence<alphabet_t>(10'000, 0, 0);
     container_t<alphabet_t> source(cont_rando.begin(), cont_rando.end());
 
-    using source_ref_t = std::conditional_t<const_,
+    using source_ref_t = std::conditional_t<const_qualified,
                                             container_t<alphabet_t> const &,
                                             container_t<alphabet_t> &>;
 
@@ -45,7 +45,7 @@ void sequential_read(benchmark::State & state)
     state.counters["sizeof"] = sizeof(alphabet_t);
     if constexpr (seqan3::alphabet<alphabet_t>)
         state.counters["alph_size"] = seqan3::alphabet_size<alphabet_t>;
-    state.counters["const"] = const_;
+    state.counters["const"] = const_qualified;
 }
 
 BENCHMARK_TEMPLATE(sequential_read, std::vector, char);

--- a/test/performance/range/views/view_kmer_hash_benchmark.cpp
+++ b/test/performance/range/views/view_kmer_hash_benchmark.cpp
@@ -26,14 +26,14 @@ inline benchmark::Counter bp_per_second(size_t const basepairs)
 
 inline seqan3::shape make_gapped_shape(size_t const k)
 {
-    seqan3::shape shape_{};
+    seqan3::shape shape{};
 
     for (size_t i{0}; i < k - 1; ++i)
-        shape_.push_back((i + 1) % 2);
+        shape.push_back((i + 1) % 2);
 
-    shape_.push_back(1u);
-    shape_.push_back(0u);
-    return shape_;
+    shape.push_back(1u);
+    shape.push_back(0u);
+    return shape;
 }
 
 

--- a/test/performance/range/views/view_minimiser_hash_benchmark.cpp
+++ b/test/performance/range/views/view_minimiser_hash_benchmark.cpp
@@ -27,14 +27,14 @@ inline benchmark::Counter bp_per_second(size_t const basepairs)
 
 inline seqan3::shape make_gapped_shape(size_t const k)
 {
-    seqan3::shape shape_{};
+    seqan3::shape shape{};
 
     for (size_t i{0}; i < k - 1; ++i)
-        shape_.push_back((i + 1) % 2);
+        shape.push_back((i + 1) % 2);
 
-    shape_.push_back(1u);
-    shape_.push_back(0u);
-    return shape_;
+    shape.push_back(1u);
+    shape.push_back(0u);
+    return shape;
 }
 
 static void arguments(benchmark::internal::Benchmark* b)
@@ -112,13 +112,13 @@ void compute_minimisers(benchmark::State & state)
                                                seqan::Shape<seqan::Dna, seqan::SimpleShape>,
                                                seqan::Shape<seqan::Dna, seqan::GenericShape>>;
 
-            shape_t shape_;
+            shape_t shape;
             if constexpr (tag == method_tag::seqan2_ungapped)
-               seqan::resize(shape_, k);
+               seqan::resize(shape, k);
             else
-                shape_ = make_gapped_shape_seqan2(k);
+                shape = make_gapped_shape_seqan2(k);
 
-            minimiser<decltype(shape_)> seqan_minimiser(window{w}, kmer{k}, shape_);
+            minimiser<decltype(shape)> seqan_minimiser(window{w}, kmer{k}, shape);
             seqan_minimiser.compute(seqan2_seq);
 
             for (auto h : seqan_minimiser.minimiser_hash)

--- a/test/performance/search/search_benchmark.cpp
+++ b/test/performance/search/search_benchmark.cpp
@@ -8,12 +8,12 @@
 #include <benchmark/benchmark.h>
 
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
+#include <seqan3/range/views/join.hpp>
+#include <seqan3/range/views/to.hpp>
 #include <seqan3/search/fm_index/bi_fm_index.hpp>
 #include <seqan3/search/fm_index/fm_index.hpp>
 #include <seqan3/search/search.hpp>
 #include <seqan3/test/performance/sequence_generator.hpp>
-#include <seqan3/range/views/join.hpp>
-#include <seqan3/range/views/to.hpp>
 
 struct options
 {
@@ -55,7 +55,7 @@ template <seqan3::alphabet alphabet_t>
 std::vector<std::vector<alphabet_t>> generate_reads(std::vector<alphabet_t> const & ref,
                                                     size_t const number_of_reads,
                                                     size_t const read_length,
-                                                    uint8_t const simulated_errors_,
+                                                    uint8_t simulated_errors,
                                                     double const prob_insertion,
                                                     double const prob_deletion,
                                                     double const stddev = 0,
@@ -64,7 +64,7 @@ std::vector<std::vector<alphabet_t>> generate_reads(std::vector<alphabet_t> cons
     std::vector<std::vector<alphabet_t>> reads;
     std::mt19937_64 gen{seed};
 
-    std::normal_distribution<> dis_error_count{static_cast<double>(simulated_errors_), stddev};
+    std::normal_distribution<> dis_error_count{static_cast<double>(simulated_errors), stddev};
 
     // mutation distributions
     std::uniform_real_distribution<double> mutation_type_prob{0.0, 1.0};
@@ -78,8 +78,7 @@ std::vector<std::vector<alphabet_t>> generate_reads(std::vector<alphabet_t> cons
     for (size_t i = 0; i < number_of_reads; ++i)
     {
         // simulate concrete error number or use normal distribution
-        uint8_t simulated_errors = (stddev == 0) ? simulated_errors_ :
-                                                   std::abs(std::round(dis_error_count(gen)));
+        simulated_errors = (stddev == 0) ? simulated_errors : std::abs(std::round(dis_error_count(gen)));
 
         std::uniform_int_distribution<size_t> random_read_pos{0, std::ranges::size(ref) - read_length - simulated_errors};
         size_t rpos = random_read_pos(gen);

--- a/test/unit/alignment/aligned_sequence_test.cpp
+++ b/test/unit/alignment/aligned_sequence_test.cpp
@@ -16,17 +16,17 @@
 
 template <typename container_type>
     requires seqan3::aligned_sequence<container_type>
-class aligned_sequence_<container_type> : public ::testing::Test
+class aligned_sequence<container_type> : public ::testing::Test
 {
 public:
     // Initializer function is needed for the typed test because the gapped_decorator
     // will be initialized differently than the naive std::vector<seqan3::gapped<dna>>.
-    void initialise_typed_test_container(container_type & container_, seqan3::dna4_vector const & target)
+    void initialise_typed_test_container(container_type & container, seqan3::dna4_vector const & target)
     {
-        container_.clear();
+        container.clear();
         for (auto & val : target)
         {
-            container_.push_back(seqan3::assign_char_to(seqan3::to_char(val), typename container_type::value_type{}));
+            container.push_back(seqan3::assign_char_to(seqan3::to_char(val), typename container_type::value_type{}));
         }
     }
 };
@@ -34,4 +34,4 @@ public:
 using test_types = ::testing::Types<std::vector<seqan3::gapped<seqan3::dna4>>,
                                     std::vector<seqan3::gapped<seqan3::qualified<seqan3::dna4, seqan3::phred42>>>>;
 
-INSTANTIATE_TYPED_TEST_SUITE_P(container_of_gapped_alphabets, aligned_sequence_, test_types, );
+INSTANTIATE_TYPED_TEST_SUITE_P(container_of_gapped_alphabets, aligned_sequence, test_types, );

--- a/test/unit/alignment/aligned_sequence_test_template.hpp
+++ b/test/unit/alignment/aligned_sequence_test_template.hpp
@@ -7,7 +7,7 @@
 
 #include <gtest/gtest.h>
 
-#include <seqan3/std/iterator>
+#include <iterator>
 #include <string>
 
 #include <seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp>
@@ -19,7 +19,7 @@
 
 using seqan3::operator""_dna4;
 
-template <typename T>
+template <typename t>
 class aligned_sequence : public ::testing::Test
 {};
 

--- a/test/unit/alignment/aligned_sequence_test_template.hpp
+++ b/test/unit/alignment/aligned_sequence_test_template.hpp
@@ -20,20 +20,20 @@
 using seqan3::operator""_dna4;
 
 template <typename T>
-class aligned_sequence_ : public ::testing::Test
+class aligned_sequence : public ::testing::Test
 {};
 
 seqan3::dna4_vector const seq = "ACTA"_dna4;
 
-TYPED_TEST_SUITE_P(aligned_sequence_);
+TYPED_TEST_SUITE_P(aligned_sequence);
 
-TYPED_TEST_P(aligned_sequence_, fulfills_concept)
+TYPED_TEST_P(aligned_sequence, fulfills_concept)
 {
     EXPECT_TRUE((seqan3::aligned_sequence<TypeParam>));
     EXPECT_FALSE((seqan3::aligned_sequence<std::vector<seqan3::dna4>>));
 }
 
-TYPED_TEST_P(aligned_sequence_, assign_unaligned_sequence)
+TYPED_TEST_P(aligned_sequence, assign_unaligned_sequence)
 {
     using unaligned_seq_type = seqan3::remove_cvref_t<seqan3::detail::unaligned_seq_t<TypeParam>>;
     unaligned_seq_type unaligned_seq{};
@@ -54,7 +54,7 @@ TYPED_TEST_P(aligned_sequence_, assign_unaligned_sequence)
     EXPECT_TRUE((std::ranges::equal(aligned_seq, unaligned_seq)));
 }
 
-TYPED_TEST_P(aligned_sequence_, assign_empty_unaligned_sequence)
+TYPED_TEST_P(aligned_sequence, assign_empty_unaligned_sequence)
 {
     using unaligned_seq_type = seqan3::remove_cvref_t<seqan3::detail::unaligned_seq_t<TypeParam>>;
     unaligned_seq_type unaligned_seq{};
@@ -66,7 +66,7 @@ TYPED_TEST_P(aligned_sequence_, assign_empty_unaligned_sequence)
     EXPECT_EQ(aligned_seq.size(), 0u);
 }
 
-TYPED_TEST_P(aligned_sequence_, insert_one_gap)
+TYPED_TEST_P(aligned_sequence, insert_one_gap)
 {
     TypeParam aligned_seq;
     TestFixture::initialise_typed_test_container(aligned_seq, seq);
@@ -87,7 +87,7 @@ TYPED_TEST_P(aligned_sequence_, insert_one_gap)
     EXPECT_EQ(seqan3::detail::to_string(aligned_seq), "A--CTA");
 }
 
-TYPED_TEST_P(aligned_sequence_, insert_multiple_gaps)
+TYPED_TEST_P(aligned_sequence, insert_multiple_gaps)
 {
     TypeParam aligned_seq;
     TestFixture::initialise_typed_test_container(aligned_seq, seq);
@@ -113,7 +113,7 @@ TYPED_TEST_P(aligned_sequence_, insert_multiple_gaps)
     EXPECT_EQ(seqan3::detail::to_string(aligned_seq), "--A------CTA--");
 }
 
-TYPED_TEST_P(aligned_sequence_, insert_zero_gaps)
+TYPED_TEST_P(aligned_sequence, insert_zero_gaps)
 {
     TypeParam aligned_seq;
     TestFixture::initialise_typed_test_container(aligned_seq, seq);
@@ -125,7 +125,7 @@ TYPED_TEST_P(aligned_sequence_, insert_zero_gaps)
     EXPECT_EQ(seqan3::detail::to_string(aligned_seq), "ACTA");
 }
 
-TYPED_TEST_P(aligned_sequence_, erase_one_gap)
+TYPED_TEST_P(aligned_sequence, erase_one_gap)
 {
     // 1) Removing an actual gap
     TypeParam aligned_seq;
@@ -151,7 +151,7 @@ TYPED_TEST_P(aligned_sequence_, erase_one_gap)
     EXPECT_EQ(seqan3::detail::to_string(aligned_seq), "ACTA");
 }
 
-TYPED_TEST_P(aligned_sequence_, erase_multiple_gaps)
+TYPED_TEST_P(aligned_sequence, erase_multiple_gaps)
 {
     TypeParam aligned_seq;
 
@@ -218,7 +218,7 @@ TYPED_TEST_P(aligned_sequence_, erase_multiple_gaps)
     EXPECT_EQ(seqan3::detail::to_string(aligned_seq), "A---CTA");
 }
 
-TYPED_TEST_P(aligned_sequence_, insert_erase_on_empty_sequence)
+TYPED_TEST_P(aligned_sequence, insert_erase_on_empty_sequence)
 {
     using unaligned_seq_type = seqan3::remove_cvref_t<seqan3::detail::unaligned_seq_t<TypeParam>>;
     unaligned_seq_type unaligned{};
@@ -249,7 +249,7 @@ TYPED_TEST_P(aligned_sequence_, insert_erase_on_empty_sequence)
     EXPECT_EQ(seqan3::detail::to_string(aligned_seq), "");
 }
 
-TYPED_TEST_P(aligned_sequence_, cigar_string)
+TYPED_TEST_P(aligned_sequence, cigar_string)
 {
     {   // default_parameters
         auto seq_ref = "ACGTGATCTG"_dna4;
@@ -330,7 +330,7 @@ TYPED_TEST_P(aligned_sequence_, cigar_string)
     }
 }
 
-REGISTER_TYPED_TEST_SUITE_P(aligned_sequence_,
+REGISTER_TYPED_TEST_SUITE_P(aligned_sequence,
                             fulfills_concept,
                             assign_unaligned_sequence,
                             assign_empty_unaligned_sequence,

--- a/test/unit/alignment/aligned_sequence_test_template.hpp
+++ b/test/unit/alignment/aligned_sequence_test_template.hpp
@@ -7,7 +7,7 @@
 
 #include <gtest/gtest.h>
 
-#include <iterator>
+#include <seqan3/std/iterator>
 #include <string>
 
 #include <seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp>

--- a/test/unit/alignment/pairwise/align_result_selector_test.cpp
+++ b/test/unit/alignment/pairwise/align_result_selector_test.cpp
@@ -31,32 +31,32 @@ TEST(alignment_selector, align_result_selector_with_list)
         auto cfg = seqan3::align_cfg::method_global{} |
                    seqan3::align_cfg::edit_scheme |
                    seqan3::align_cfg::result{seqan3::with_score};
-        using _t = seqan3::alignment_result<typename seqan3::detail::align_result_selector<seq1_t,
-                                                                                           seq2_t,
-                                                                                           decltype(cfg)>::type>;
+        using t = seqan3::alignment_result<typename seqan3::detail::align_result_selector<seq1_t,
+                                                                                          seq2_t,
+                                                                                          decltype(cfg)>::type>;
 
-        EXPECT_TRUE((std::is_same_v<decltype(std::declval<_t>().id()), uint32_t>));
-        EXPECT_TRUE((std::is_same_v<decltype(std::declval<_t>().score()), int32_t>));
+        EXPECT_TRUE((std::is_same_v<decltype(std::declval<t>().id()), uint32_t>));
+        EXPECT_TRUE((std::is_same_v<decltype(std::declval<t>().score()), int32_t>));
     }
 
     {
         auto cfg = seqan3::align_cfg::method_global{} |
                    seqan3::align_cfg::edit_scheme |
                    seqan3::align_cfg::result{seqan3::with_alignment};
-        using _t = seqan3::alignment_result<typename seqan3::detail::align_result_selector<seq1_t,
-                                                                                           seq2_t,
-                                                                                           decltype(cfg)>::type>;
+        using t = seqan3::alignment_result<typename seqan3::detail::align_result_selector<seq1_t,
+                                                                                          seq2_t,
+                                                                                          decltype(cfg)>::type>;
 
         using gapped_seq1_t = seqan3::gap_decorator<seqan3::type_reduce_view<std::vector<seqan3::dna4> &>>;
         using gapped_seq2_t = std::vector<seqan3::gapped<seqan3::dna4>>;
 
-        EXPECT_TRUE((std::is_same_v<decltype(std::declval<_t>().id()), uint32_t>));
-        EXPECT_TRUE((std::is_same_v<decltype(std::declval<_t>().score()), int32_t>));
-        EXPECT_TRUE((std::is_same_v<decltype(std::declval<_t>().sequence1_end_position()), size_t>));
-        EXPECT_TRUE((std::is_same_v<decltype(std::declval<_t>().sequence2_end_position()), size_t>));
-        EXPECT_TRUE((std::is_same_v<decltype(std::declval<_t>().sequence1_begin_position()), size_t>));
-        EXPECT_TRUE((std::is_same_v<decltype(std::declval<_t>().sequence2_begin_position()), size_t>));
-        EXPECT_TRUE((std::is_same_v<decltype(std::declval<_t>().alignment()),
+        EXPECT_TRUE((std::is_same_v<decltype(std::declval<t>().id()), uint32_t>));
+        EXPECT_TRUE((std::is_same_v<decltype(std::declval<t>().score()), int32_t>));
+        EXPECT_TRUE((std::is_same_v<decltype(std::declval<t>().sequence1_end_position()), size_t>));
+        EXPECT_TRUE((std::is_same_v<decltype(std::declval<t>().sequence2_end_position()), size_t>));
+        EXPECT_TRUE((std::is_same_v<decltype(std::declval<t>().sequence1_begin_position()), size_t>));
+        EXPECT_TRUE((std::is_same_v<decltype(std::declval<t>().sequence2_begin_position()), size_t>));
+        EXPECT_TRUE((std::is_same_v<decltype(std::declval<t>().alignment()),
                                     std::tuple<gapped_seq1_t, gapped_seq2_t> const &>));
     }
 }
@@ -69,13 +69,13 @@ TEST(alignment_selector, align_result_selector_using_score_type)
     auto cfg = seqan3::align_cfg::method_global{} |
                seqan3::align_cfg::edit_scheme |
                seqan3::align_cfg::result{seqan3::with_end_positions, seqan3::using_score_type<double>};
-    using _t = seqan3::alignment_result<typename seqan3::detail::align_result_selector<seq1_t,
-                                                                                       seq2_t,
-                                                                                       decltype(cfg)>::type>;
+    using t = seqan3::alignment_result<typename seqan3::detail::align_result_selector<seq1_t,
+                                                                                      seq2_t,
+                                                                                      decltype(cfg)>::type>;
 
-    EXPECT_TRUE((std::is_same_v<decltype(std::declval<_t>().score()), double>));
-    EXPECT_TRUE((std::is_same_v<decltype(std::declval<_t>().sequence1_end_position()), size_t>));
-    EXPECT_TRUE((std::is_same_v<decltype(std::declval<_t>().sequence2_end_position()), size_t>));
+    EXPECT_TRUE((std::is_same_v<decltype(std::declval<t>().score()), double>));
+    EXPECT_TRUE((std::is_same_v<decltype(std::declval<t>().sequence1_end_position()), size_t>));
+    EXPECT_TRUE((std::is_same_v<decltype(std::declval<t>().sequence2_end_position()), size_t>));
 }
 
 TEST(alignment_selector, align_result_selector_with_vector)
@@ -85,18 +85,18 @@ TEST(alignment_selector, align_result_selector_with_vector)
     auto cfg = seqan3::align_cfg::method_global{} |
                seqan3::align_cfg::edit_scheme |
                seqan3::align_cfg::result{seqan3::with_alignment};
-    using _t = seqan3::alignment_result<typename seqan3::detail::align_result_selector<seq_t,
-                                                                                       seq_t,
-                                                                                       decltype(cfg)>::type>;
+    using t = seqan3::alignment_result<typename seqan3::detail::align_result_selector<seq_t,
+                                                                                      seq_t,
+                                                                                      decltype(cfg)>::type>;
 
     using gapped_seq_t = seqan3::gap_decorator<seqan3::type_reduce_view<std::vector<seqan3::dna4> &>>;
 
-    EXPECT_TRUE((std::is_same_v<decltype(std::declval<_t>().id()), uint32_t>));
-    EXPECT_TRUE((std::is_same_v<decltype(std::declval<_t>().score()), int32_t>));
-    EXPECT_TRUE((std::is_same_v<decltype(std::declval<_t>().sequence1_end_position()), size_t>));
-    EXPECT_TRUE((std::is_same_v<decltype(std::declval<_t>().sequence2_end_position()), size_t>));
-    EXPECT_TRUE((std::is_same_v<decltype(std::declval<_t>().sequence1_begin_position()), size_t>));
-    EXPECT_TRUE((std::is_same_v<decltype(std::declval<_t>().sequence2_begin_position()), size_t>));
-    EXPECT_TRUE((std::is_same_v<decltype(std::declval<_t>().alignment()),
+    EXPECT_TRUE((std::is_same_v<decltype(std::declval<t>().id()), uint32_t>));
+    EXPECT_TRUE((std::is_same_v<decltype(std::declval<t>().score()), int32_t>));
+    EXPECT_TRUE((std::is_same_v<decltype(std::declval<t>().sequence1_end_position()), size_t>));
+    EXPECT_TRUE((std::is_same_v<decltype(std::declval<t>().sequence2_end_position()), size_t>));
+    EXPECT_TRUE((std::is_same_v<decltype(std::declval<t>().sequence1_begin_position()), size_t>));
+    EXPECT_TRUE((std::is_same_v<decltype(std::declval<t>().sequence2_begin_position()), size_t>));
+    EXPECT_TRUE((std::is_same_v<decltype(std::declval<t>().alignment()),
                                 std::tuple<gapped_seq_t, gapped_seq_t> const &>));
 }

--- a/test/unit/alphabet/alphabet_cereal_test.cpp
+++ b/test/unit/alphabet/alphabet_cereal_test.cpp
@@ -13,7 +13,7 @@
 #include <seqan3/alphabet/quality/qualified.hpp>
 #include <seqan3/test/cereal.hpp>
 
-template <typename T>
+template <typename t>
 using alphabet_cereal = ::testing::Test;
 
 using test_types = ::testing::Types<seqan3::dna4,

--- a/test/unit/alphabet/alphabet_constexpr_test_template.hpp
+++ b/test/unit/alphabet/alphabet_constexpr_test_template.hpp
@@ -9,7 +9,7 @@
 
 #include <seqan3/alphabet/concept.hpp>
 
-template <typename T>
+template <typename t>
 using alphabet_constexpr = ::testing::Test;
 
 TYPED_TEST_SUITE_P(alphabet_constexpr);

--- a/test/unit/alphabet/alphabet_constexpr_test_template.hpp
+++ b/test/unit/alphabet/alphabet_constexpr_test_template.hpp
@@ -29,12 +29,12 @@ TYPED_TEST_P(alphabet_constexpr, concept_check)
     EXPECT_FALSE(seqan3::detail::writable_constexpr_alphabet<TypeParam const & >);
 }
 
-TYPED_TEST_P(alphabet_constexpr, global_assign_char)
+TYPED_TEST_P(alphabet_constexpr, assign_char)
 {
     [[maybe_unused]] constexpr TypeParam t0{seqan3::assign_char_to('A', TypeParam{})};
 }
 
-TYPED_TEST_P(alphabet_constexpr, global_to_char)
+TYPED_TEST_P(alphabet_constexpr, to_char)
 {
     constexpr TypeParam t0{TypeParam{}};
     [[maybe_unused]] constexpr seqan3::alphabet_char_t<TypeParam> c = seqan3::to_char(t0);
@@ -42,5 +42,5 @@ TYPED_TEST_P(alphabet_constexpr, global_to_char)
 
 REGISTER_TYPED_TEST_SUITE_P(alphabet_constexpr,
                             concept_check,
-                            global_assign_char,
-                            global_to_char);
+                            assign_char,
+                            to_char);

--- a/test/unit/alphabet/composite/alphabet_variant_test.cpp
+++ b/test/unit/alphabet/composite/alphabet_variant_test.cpp
@@ -259,7 +259,7 @@ TEST(alphabet_variant_test, rank_type)
     EXPECT_TRUE((std::is_same_v<seqan3::alphabet_rank_t<alphabet3_t>, uint16_t>));
 }
 
-TEST(alphabet_variant_test, alphabet_size_)
+TEST(alphabet_variant_test, alphabet_size)
 {
     using alphabet1_t = seqan3::alphabet_variant<seqan3::dna4, seqan3::dna5, seqan3::gap>;
     using alphabet2_t = seqan3::alphabet_variant<seqan3::gap, seqan3::dna5, seqan3::dna4>;

--- a/test/unit/alphabet/composite/composite_integration_test.cpp
+++ b/test/unit/alphabet/composite/composite_integration_test.cpp
@@ -394,7 +394,7 @@ TEST(composite, custom_comparison)
     EXPECT_GT(seqan3::phred42{0}, t61); // *
 }
 
-TEST(composite, get_)
+TEST(composite, get)
 {
     using seqan3::get;
 

--- a/test/unit/alphabet/custom_alphabet2_test.cpp
+++ b/test/unit/alphabet/custom_alphabet2_test.cpp
@@ -20,20 +20,20 @@ namespace my_namespace
 class my_alph
 {
 public:
-    bool b;
+    bool rank;
 
     my_alph() = delete;
     constexpr my_alph(my_alph const &) = default;
     constexpr my_alph & operator=(my_alph const &) = default;
 
-    constexpr my_alph(bool _b) : b{_b} {}
+    constexpr my_alph(bool rank) : rank{rank} {}
 
-    constexpr friend bool operator==(my_alph lhs, my_alph rhs) { return lhs.b == rhs.b; }
-    constexpr friend bool operator!=(my_alph lhs, my_alph rhs) { return lhs.b != rhs.b; }
-    constexpr friend bool operator<=(my_alph lhs, my_alph rhs) { return lhs.b <= rhs.b; }
-    constexpr friend bool operator>=(my_alph lhs, my_alph rhs) { return lhs.b >= rhs.b; }
-    constexpr friend bool operator< (my_alph lhs, my_alph rhs) { return lhs.b <  rhs.b; }
-    constexpr friend bool operator> (my_alph lhs, my_alph rhs) { return lhs.b >  rhs.b; }
+    constexpr friend bool operator==(my_alph lhs, my_alph rhs) { return lhs.rank == rhs.rank; }
+    constexpr friend bool operator!=(my_alph lhs, my_alph rhs) { return lhs.rank != rhs.rank; }
+    constexpr friend bool operator<=(my_alph lhs, my_alph rhs) { return lhs.rank <= rhs.rank; }
+    constexpr friend bool operator>=(my_alph lhs, my_alph rhs) { return lhs.rank >= rhs.rank; }
+    constexpr friend bool operator< (my_alph lhs, my_alph rhs) { return lhs.rank <  rhs.rank; }
+    constexpr friend bool operator> (my_alph lhs, my_alph rhs) { return lhs.rank >  rhs.rank; }
 };
 
 
@@ -44,18 +44,18 @@ constexpr size_t alphabet_size(std::type_identity<my_alph> const &) noexcept
 
 constexpr bool to_rank(my_alph const a) noexcept
 {
-    return a.b;
+    return a.rank;
 }
 
 constexpr my_alph & assign_rank_to(bool const r, my_alph & a) noexcept
 {
-    a.b = r;
+    a.rank = r;
     return a;
 }
 
 constexpr char to_char(my_alph const a) noexcept
 {
-    if (a.b)
+    if (a.rank)
         return '1';
     else
         return '0';
@@ -65,8 +65,8 @@ constexpr my_alph & assign_char_to(char const c, my_alph & a) noexcept
 {
     switch (c)
     {
-        case '0': case 'F': case 'f': a.b = 0; return a;
-        default: a.b = 1; return a;
+        case '0': case 'F': case 'f': a.rank = 0; return a;
+        default: a.rank = 1; return a;
     }
 }
 

--- a/test/unit/alphabet/detail/alphabet_proxy_test.cpp
+++ b/test/unit/alphabet/detail/alphabet_proxy_test.cpp
@@ -53,20 +53,20 @@ namespace my_namespace
 class my_alph
 {
 public:
-    bool b{};
+    bool rank{};
 
     constexpr my_alph() noexcept = default;
     constexpr my_alph(my_alph const &) = default;
     constexpr my_alph & operator=(my_alph const &) = default;
 
-    constexpr my_alph(bool _b) : b{_b} {}
+    constexpr my_alph(bool rank) : rank{rank} {}
 
-    constexpr friend bool operator==(my_alph lhs, my_alph rhs) { return lhs.b == rhs.b; }
-    constexpr friend bool operator!=(my_alph lhs, my_alph rhs) { return lhs.b != rhs.b; }
-    constexpr friend bool operator<=(my_alph lhs, my_alph rhs) { return lhs.b <= rhs.b; }
-    constexpr friend bool operator>=(my_alph lhs, my_alph rhs) { return lhs.b >= rhs.b; }
-    constexpr friend bool operator< (my_alph lhs, my_alph rhs) { return lhs.b <  rhs.b; }
-    constexpr friend bool operator> (my_alph lhs, my_alph rhs) { return lhs.b >  rhs.b; }
+    constexpr friend bool operator==(my_alph lhs, my_alph rhs) { return lhs.rank == rhs.rank; }
+    constexpr friend bool operator!=(my_alph lhs, my_alph rhs) { return lhs.rank != rhs.rank; }
+    constexpr friend bool operator<=(my_alph lhs, my_alph rhs) { return lhs.rank <= rhs.rank; }
+    constexpr friend bool operator>=(my_alph lhs, my_alph rhs) { return lhs.rank >= rhs.rank; }
+    constexpr friend bool operator< (my_alph lhs, my_alph rhs) { return lhs.rank <  rhs.rank; }
+    constexpr friend bool operator> (my_alph lhs, my_alph rhs) { return lhs.rank >  rhs.rank; }
 };
 
 
@@ -77,18 +77,18 @@ constexpr size_t alphabet_size(my_alph const &) noexcept
 
 constexpr bool to_rank(my_alph const a) noexcept
 {
-    return a.b;
+    return a.rank;
 }
 
 constexpr my_alph & assign_rank_to(bool const r, my_alph & a) noexcept
 {
-    a.b = r;
+    a.rank = r;
     return a;
 }
 
 constexpr char to_char(my_alph const a) noexcept
 {
-    if (a.b)
+    if (a.rank)
         return '1';
     else
         return '0';
@@ -98,8 +98,8 @@ constexpr my_alph & assign_char_to(char const c, my_alph & a) noexcept
 {
     switch (c)
     {
-        case '0': case 'F': case 'f': a.b = 0; return a;
-        default: a.b = 1; return a;
+        case '0': case 'F': case 'f': a.rank = 0; return a;
+        default: a.rank = 1; return a;
     }
 }
 

--- a/test/unit/alphabet/nucleotide/dna3bs_test.cpp
+++ b/test/unit/alphabet/nucleotide/dna3bs_test.cpp
@@ -28,7 +28,7 @@ TEST(dna3bs, concept_check)
     EXPECT_TRUE(seqan3::nucleotide_alphabet<seqan3::dna3bs const &>);
 }
 
-TEST(dna3bs, global_complement)
+TEST(dna3bs, complement)
 {
     EXPECT_EQ(seqan3::complement(seqan3::dna3bs{}.assign_char('A')), seqan3::dna3bs{}.assign_char('T'));
     EXPECT_EQ(seqan3::complement(seqan3::dna3bs{}.assign_char('C')), seqan3::dna3bs{}.assign_char('A'));

--- a/test/unit/alphabet/nucleotide/nucleotide_test_template.hpp
+++ b/test/unit/alphabet/nucleotide/nucleotide_test_template.hpp
@@ -12,7 +12,7 @@
 #include <seqan3/alphabet/concept.hpp>
 #include <seqan3/alphabet/nucleotide/concept.hpp>
 
-template <typename T>
+template <typename t>
 using nucleotide = ::testing::Test;
 
 TYPED_TEST_SUITE_P(nucleotide);

--- a/test/unit/alphabet/nucleotide/nucleotide_test_template.hpp
+++ b/test/unit/alphabet/nucleotide/nucleotide_test_template.hpp
@@ -25,7 +25,7 @@ TYPED_TEST_P(nucleotide, concept_check)
     EXPECT_TRUE(seqan3::nucleotide_alphabet<TypeParam const &>);
 }
 
-TYPED_TEST_P(nucleotide, global_complement)
+TYPED_TEST_P(nucleotide, complement)
 {
     EXPECT_EQ(seqan3::complement(TypeParam{}.assign_char('A')), TypeParam{}.assign_char('T'));
     EXPECT_EQ(seqan3::complement(TypeParam{}.assign_char('C')), TypeParam{}.assign_char('G'));
@@ -42,4 +42,4 @@ TYPED_TEST_P(nucleotide, global_complement)
     }
 }
 
-REGISTER_TYPED_TEST_SUITE_P(nucleotide, concept_check, global_complement);
+REGISTER_TYPED_TEST_SUITE_P(nucleotide, concept_check, complement);

--- a/test/unit/alphabet/semi_alphabet_constexpr_test_template.hpp
+++ b/test/unit/alphabet/semi_alphabet_constexpr_test_template.hpp
@@ -9,7 +9,7 @@
 
 #include <seqan3/alphabet/concept.hpp>
 
-template <typename T>
+template <typename t>
 using semi_alphabet_constexpr = ::testing::Test;
 
 TYPED_TEST_SUITE_P(semi_alphabet_constexpr);

--- a/test/unit/alphabet/semi_alphabet_constexpr_test_template.hpp
+++ b/test/unit/alphabet/semi_alphabet_constexpr_test_template.hpp
@@ -34,13 +34,13 @@ TYPED_TEST_P(semi_alphabet_constexpr, default_value_constructor)
     [[maybe_unused]] constexpr TypeParam t0{};
 }
 
-TYPED_TEST_P(semi_alphabet_constexpr, global_assign_rank)
+TYPED_TEST_P(semi_alphabet_constexpr, assign_rank)
 {
     constexpr size_t rank = 1 % seqan3::alphabet_size<TypeParam>;
     [[maybe_unused]] constexpr TypeParam t0{seqan3::assign_rank_to(rank, TypeParam{})};
 }
 
-TYPED_TEST_P(semi_alphabet_constexpr, global_to_rank)
+TYPED_TEST_P(semi_alphabet_constexpr, to_rank)
 {
     constexpr size_t rank = 1 % seqan3::alphabet_size<TypeParam>;
     constexpr TypeParam t0{seqan3::assign_rank_to(rank, TypeParam{})};
@@ -148,8 +148,8 @@ TYPED_TEST_P(semi_alphabet_constexpr, comparison_operators)
 REGISTER_TYPED_TEST_SUITE_P(semi_alphabet_constexpr,
                             concept_check,
                             default_value_constructor,
-                            global_assign_rank,
-                            global_to_rank,
+                            assign_rank,
+                            to_rank,
                             copy_constructor,
                             move_constructor,
                             copy_assignment,

--- a/test/unit/alphabet/semi_alphabet_test_template.hpp
+++ b/test/unit/alphabet/semi_alphabet_test_template.hpp
@@ -40,7 +40,7 @@ TYPED_TEST_P(semi_alphabet_test, type_properties)
     EXPECT_TRUE((seqan3::standard_layout<TypeParam>));
 }
 
-TYPED_TEST_P(semi_alphabet_test, alphabet_size_)
+TYPED_TEST_P(semi_alphabet_test, alphabet_size)
 {
     EXPECT_GT(seqan3::alphabet_size<TypeParam>, 0u);
 }
@@ -50,7 +50,7 @@ TYPED_TEST_P(semi_alphabet_test, default_value_constructor)
     EXPECT_TRUE((std::is_nothrow_default_constructible_v<TypeParam>));
 }
 
-TYPED_TEST_P(semi_alphabet_test, global_assign_rank_to)
+TYPED_TEST_P(semi_alphabet_test, assign_rank_to)
 {
     // this double checks the value initialisation
     EXPECT_EQ((seqan3::assign_rank_to(0, TypeParam{})), TypeParam{});
@@ -63,7 +63,7 @@ TYPED_TEST_P(semi_alphabet_test, global_assign_rank_to)
     EXPECT_TRUE((std::is_same_v<decltype(seqan3::assign_rank_to(0, TypeParam{})), TypeParam>));
 }
 
-TYPED_TEST_P(semi_alphabet_test, global_to_rank)
+TYPED_TEST_P(semi_alphabet_test, to_rank)
 {
     // this double checks the value initialisation
     EXPECT_EQ(seqan3::to_rank(TypeParam{}), 0u);
@@ -169,10 +169,10 @@ TYPED_TEST_P(semi_alphabet_test, comparison_operators)
 REGISTER_TYPED_TEST_SUITE_P(semi_alphabet_test,
                             concept_check,
                             type_properties,
-                            alphabet_size_,
+                            alphabet_size,
                             default_value_constructor,
-                            global_assign_rank_to,
-                            global_to_rank,
+                            assign_rank_to,
+                            to_rank,
                             copy_constructor,
                             move_constructor,
                             copy_assignment,

--- a/test/unit/core/algorithm/detail/execution_handler_template.hpp
+++ b/test/unit/core/algorithm/detail/execution_handler_template.hpp
@@ -6,7 +6,7 @@
 // -----------------------------------------------------------------------------------------------------
 
 #include <seqan3/std/algorithm>
-#include <iterator>
+#include <seqan3/std/iterator>
 #include <seqan3/std/ranges>
 #include <utility>
 #include <vector>

--- a/test/unit/core/algorithm/detail/execution_handler_template.hpp
+++ b/test/unit/core/algorithm/detail/execution_handler_template.hpp
@@ -5,21 +5,21 @@
 // shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 // -----------------------------------------------------------------------------------------------------
 
+#include <seqan3/std/algorithm>
+#include <iterator>
+#include <seqan3/std/ranges>
 #include <utility>
 #include <vector>
 
 #include <gtest/gtest.h>
 
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
-#include <seqan3/range/views/type_reduce.hpp>
 #include <seqan3/range/views/chunk.hpp>
+#include <seqan3/range/views/type_reduce.hpp>
 #include <seqan3/range/views/zip.hpp>
 #include <seqan3/test/performance/sequence_generator.hpp>
-#include <seqan3/std/iterator>
-#include <seqan3/std/algorithm>
-#include <seqan3/std/ranges>
 
-template <typename T>
+template <typename t>
 struct execution_handler : public ::testing::Test
 {
     static constexpr size_t total_size = 10000;
@@ -77,7 +77,7 @@ TYPED_TEST_P(execution_handler, execute_as_indexed_sequence_pairs)
          it += chunk_size, pos += chunk_size)
     {
         std::ranges::subrange<range_iterator_t, range_iterator_t> chunk{it, std::next(it, chunk_size)};
-        exec_handler.execute(simulate_alignment_with_range, std::move(chunk), [pos = pos, &buffer] (auto && res) mutable
+        exec_handler.execute(simulate_alignment_with_range, std::move(chunk), [pos, &buffer] (auto && res) mutable
         {
             *(buffer.begin() + pos) = std::forward<decltype(res)>(res);
             ++pos;

--- a/test/unit/core/algorithm/detail/execution_handler_template.hpp
+++ b/test/unit/core/algorithm/detail/execution_handler_template.hpp
@@ -77,10 +77,10 @@ TYPED_TEST_P(execution_handler, execute_as_indexed_sequence_pairs)
          it += chunk_size, pos += chunk_size)
     {
         std::ranges::subrange<range_iterator_t, range_iterator_t> chunk{it, std::next(it, chunk_size)};
-        exec_handler.execute(simulate_alignment_with_range, std::move(chunk), [_pos = pos, &buffer] (auto && res) mutable
+        exec_handler.execute(simulate_alignment_with_range, std::move(chunk), [pos = pos, &buffer] (auto && res) mutable
         {
-            *(buffer.begin() + _pos) = std::forward<decltype(res)>(res);
-            ++_pos;
+            *(buffer.begin() + pos) = std::forward<decltype(res)>(res);
+            ++pos;
         });
     }
 

--- a/test/unit/core/char_operations/char_predicate_test.cpp
+++ b/test/unit/core/char_operations/char_predicate_test.cpp
@@ -37,19 +37,19 @@ struct bar
     }
 };
 
-TEST(char_predicate_, basic)
+TEST(char_predicate, basic)
 {
     foo<'a'> p{};
     EXPECT_TRUE(p('a'));
     EXPECT_FALSE(p('f'));
 }
 
-TEST(char_predicate_, char_predicate_msg)
+TEST(char_predicate, char_predicate_msg)
 {
     EXPECT_EQ(foo<'o'>::msg, "foo_o"s);
 }
 
-TEST(char_predicate_, concept_)
+TEST(char_predicate, concept)
 {
     using seqan3::operator""_aa27;
 
@@ -70,7 +70,7 @@ TEST(char_predicate_, concept_)
     EXPECT_FALSE(seqan3::detail::char_predicate<int>);
 }
 
-TEST(char_predicate_, char_predicate_combiner)
+TEST(char_predicate, char_predicate_combiner)
 {
     using cond_t = seqan3::detail::char_predicate_combiner<foo<'a'>, foo<'A'>, foo<'0'>>;
     EXPECT_TRUE(cond_t{}('a'));
@@ -89,13 +89,13 @@ TEST(char_predicate_, char_predicate_combiner)
     EXPECT_FALSE(p('1'));
 }
 
-TEST(char_predicate_, char_predicate_combiner_msg)
+TEST(char_predicate, char_predicate_combiner_msg)
 {
     using or_t = seqan3::detail::char_predicate_combiner<foo<'a'>, foo<'A'>, foo<'0'>>;
     EXPECT_EQ(or_t::msg,   "(foo_a || foo_A || foo_0)"s);
 }
 
-TEST(char_predicate_, is_not)
+TEST(char_predicate, is_not)
 {
     using cond_t = seqan3::detail::char_predicate_negator<foo<'a'>>;
     EXPECT_FALSE(cond_t{}('a'));
@@ -108,13 +108,13 @@ TEST(char_predicate_, is_not)
     EXPECT_TRUE(p('0'));
 }
 
-TEST(char_predicate_, is_not_msg)
+TEST(char_predicate, is_not_msg)
 {
     using fn = decltype(!seqan3::is_alpha);
     EXPECT_EQ(fn::msg, "!(is_in_interval<'A', 'Z'> || is_in_interval<'a', 'z'>)"s);
 }
 
-TEST(char_predicate_, is_in_interval)
+TEST(char_predicate, is_in_interval)
 {
     auto constexpr cond = seqan3::is_in_interval<'a', 'z'>;
     EXPECT_TRUE(cond('a'));
@@ -125,12 +125,12 @@ TEST(char_predicate_, is_in_interval)
     EXPECT_FALSE(cond('!'));
 }
 
-TEST(char_predicate_, is_in_interval_msg)
+TEST(char_predicate, is_in_interval_msg)
 {
     EXPECT_EQ((seqan3::detail::is_in_interval_type<'a', 'z'>::msg), "is_in_interval<'a', 'z'>"s);
 }
 
-TEST(char_predicate_, is_in_alphabet)
+TEST(char_predicate, is_in_alphabet)
 {
     {
         auto constexpr cond = seqan3::is_in_alphabet<seqan3::dna4>;
@@ -160,12 +160,12 @@ TEST(char_predicate_, is_in_alphabet)
     }
 }
 
-TEST(char_predicate_, is_in_alphabet_msg)
+TEST(char_predicate, is_in_alphabet_msg)
 {
     EXPECT_EQ((seqan3::detail::is_in_alphabet_type<seqan3::dna4>::msg), "is_in_alphabet<seqan3::dna4>"s);
 }
 
-TEST(char_predicate_, is_char)
+TEST(char_predicate, is_char)
 {
     using seqan3::operator""_aa27;
     {
@@ -181,14 +181,14 @@ TEST(char_predicate_, is_char)
     }
 }
 
-TEST(char_predicate_, is_char_msg)
+TEST(char_predicate, is_char_msg)
 {
     using seqan3::operator""_dna4;
     EXPECT_EQ((seqan3::is_char<seqan3::to_char('A'_dna4)>.msg), "is_char<'A'>"s);
     EXPECT_EQ((seqan3::is_char<'\t'>.msg), "is_char<'\t'>"s);
 }
 
-TEST(char_predicate_, is_cntrl)
+TEST(char_predicate, is_cntrl)
 {
     EXPECT_TRUE(seqan3::is_cntrl('\0'));
     EXPECT_TRUE(seqan3::is_cntrl(static_cast<char>(31)));
@@ -197,7 +197,7 @@ TEST(char_predicate_, is_cntrl)
     EXPECT_FALSE(seqan3::is_cntrl('A'));
 }
 
-TEST(char_predicate_, is_print)
+TEST(char_predicate, is_print)
 {
     EXPECT_FALSE(seqan3::is_print('\0'));
     EXPECT_FALSE(seqan3::is_print(static_cast<char>(31)));
@@ -207,13 +207,13 @@ TEST(char_predicate_, is_print)
     EXPECT_TRUE(seqan3::is_print('~'));
 }
 
-TEST(char_predicate_, is_print_msg)
+TEST(char_predicate, is_print_msg)
 {
     EXPECT_EQ((seqan3::is_print.message()), "is_in_interval<' ', '~'>"s);
 }
 
 
-TEST(char_predicate_, is_blank)
+TEST(char_predicate, is_blank)
 {
     EXPECT_TRUE(seqan3::is_blank(' '));
     EXPECT_TRUE(seqan3::is_blank('\t'));
@@ -221,12 +221,12 @@ TEST(char_predicate_, is_blank)
     EXPECT_FALSE(seqan3::is_blank('\n'));
 }
 
-TEST(char_predicate_, is_blank_msg)
+TEST(char_predicate, is_blank_msg)
 {
     EXPECT_EQ((seqan3::is_blank.message()), "(is_char<'\t'> || is_char<' '>)"s);
 }
 
-TEST(char_predicate_, is_space)
+TEST(char_predicate, is_space)
 {
     EXPECT_TRUE(seqan3::is_space('\n'));
     EXPECT_TRUE(seqan3::is_space('\r'));
@@ -238,13 +238,13 @@ TEST(char_predicate_, is_space)
     EXPECT_FALSE(seqan3::is_space('\0'));
 }
 
-TEST(char_predicate_, is_space_msg)
+TEST(char_predicate, is_space_msg)
 {
     EXPECT_EQ((seqan3::is_space.message()),
               "(is_in_interval<'\t', '\r'> || is_char<' '>)"s);
 }
 
-TEST(char_predicate_, is_punct)
+TEST(char_predicate, is_punct)
 {
     EXPECT_TRUE(seqan3::is_punct('!'));
     EXPECT_TRUE(seqan3::is_punct('"'));
@@ -261,13 +261,13 @@ TEST(char_predicate_, is_punct)
     EXPECT_FALSE(seqan3::is_punct('\0'));
 }
 
-TEST(char_predicate_, is_punct_msg)
+TEST(char_predicate, is_punct_msg)
 {
     EXPECT_EQ((seqan3::is_punct.message()),
               "(((is_in_interval<'!', '/'> || is_in_interval<':', '@'>) || is_in_interval<'[', '`'>) || is_in_interval<'{', '~'>)"s);
 }
 
-TEST(char_predicate_, is_alpha)
+TEST(char_predicate, is_alpha)
 {
     EXPECT_FALSE(seqan3::is_alpha('\n'));
     EXPECT_FALSE(seqan3::is_alpha('\r'));
@@ -279,13 +279,13 @@ TEST(char_predicate_, is_alpha)
     EXPECT_TRUE(seqan3::is_alpha('Z'));
 }
 
-TEST(char_predicate_, is_alpha_msg)
+TEST(char_predicate, is_alpha_msg)
 {
     EXPECT_EQ((seqan3::is_alpha.message()),
               "(is_in_interval<'A', 'Z'> || is_in_interval<'a', 'z'>)"s);
 }
 
-TEST(char_predicate_, is_upper)
+TEST(char_predicate, is_upper)
 {
     EXPECT_FALSE(seqan3::is_upper('\n'));
     EXPECT_FALSE(seqan3::is_upper('\r'));
@@ -298,12 +298,12 @@ TEST(char_predicate_, is_upper)
     EXPECT_FALSE(seqan3::is_upper('z'));
 }
 
-TEST(char_predicate_, is_upper_msg)
+TEST(char_predicate, is_upper_msg)
 {
     EXPECT_EQ((seqan3::is_upper.message()), "is_in_interval<'A', 'Z'>"s);
 }
 
-TEST(char_predicate_, is_lower)
+TEST(char_predicate, is_lower)
 {
     EXPECT_FALSE(seqan3::is_lower('\n'));
     EXPECT_FALSE(seqan3::is_lower('\r'));
@@ -316,12 +316,12 @@ TEST(char_predicate_, is_lower)
     EXPECT_TRUE(seqan3::is_lower('z'));
 }
 
-TEST(char_predicate_, is_lower_msg)
+TEST(char_predicate, is_lower_msg)
 {
     EXPECT_EQ((seqan3::is_lower.message()), "is_in_interval<'a', 'z'>"s);
 }
 
-TEST(char_predicate_, is_digit)
+TEST(char_predicate, is_digit)
 {
     EXPECT_FALSE(seqan3::is_digit('\n'));
     EXPECT_FALSE(seqan3::is_digit('\r'));
@@ -334,12 +334,12 @@ TEST(char_predicate_, is_digit)
     EXPECT_FALSE(seqan3::is_digit('Z'));
 }
 
-TEST(char_predicate_, is_digit_msg)
+TEST(char_predicate, is_digit_msg)
 {
     EXPECT_EQ((seqan3::is_digit.message()), "is_in_interval<'0', '9'>"s);
 }
 
-TEST(char_predicate_, is_xdigit)
+TEST(char_predicate, is_xdigit)
 {
     EXPECT_TRUE(seqan3::is_xdigit('0'));
     EXPECT_TRUE(seqan3::is_xdigit('9'));
@@ -357,12 +357,12 @@ TEST(char_predicate_, is_xdigit)
     EXPECT_FALSE(seqan3::is_xdigit(' '));
 }
 
-TEST(char_predicate_, is_xdigit_msg)
+TEST(char_predicate, is_xdigit_msg)
 {
     EXPECT_EQ((seqan3::is_xdigit.message()), "((is_in_interval<'0', '9'> || is_in_interval<'A', 'F'>) || is_in_interval<'a', 'f'>)"s);
 }
 
-TEST(char_predicate_, is_alnum)
+TEST(char_predicate, is_alnum)
 {
     EXPECT_FALSE(seqan3::is_alnum('\n'));
     EXPECT_FALSE(seqan3::is_alnum('\r'));
@@ -375,12 +375,12 @@ TEST(char_predicate_, is_alnum)
     EXPECT_TRUE(seqan3::is_alnum('Z'));
 }
 
-TEST(char_predicate_, is_alnum_msg)
+TEST(char_predicate, is_alnum_msg)
 {
     EXPECT_EQ((seqan3::is_alnum.message()), "((is_in_interval<'0', '9'> || is_in_interval<'A', 'Z'>) || is_in_interval<'a', 'z'>)"s);
 }
 
-TEST(char_predicate_, is_graph)
+TEST(char_predicate, is_graph)
 {
     EXPECT_FALSE(seqan3::is_graph('\n'));
     EXPECT_FALSE(seqan3::is_graph('\r'));
@@ -394,12 +394,12 @@ TEST(char_predicate_, is_graph)
     EXPECT_TRUE(seqan3::is_graph('~'));
 }
 
-TEST(char_predicate_, is_graph_msg)
+TEST(char_predicate, is_graph_msg)
 {
     EXPECT_EQ((seqan3::is_graph.message()), "is_in_interval<'!', '~'>"s);
 }
 
-TEST(char_predicate_, char_types)
+TEST(char_predicate, char_types)
 {
     {  // is_char
         char c1 = '\t';
@@ -442,7 +442,7 @@ TEST(char_predicate_, char_types)
 }
 
 // see issue https://github.com/seqan/seqan3/issues/1972
-TEST(char_predicate_, issue1972)
+TEST(char_predicate, issue1972)
 {
     EXPECT_TRUE(seqan3::is_in_alphabet<seqan3::gapped<seqan3::rna5>>('A')); // valid seqan3::rna5 char
     EXPECT_TRUE(seqan3::is_in_alphabet<seqan3::gapped<seqan3::rna5>>('a')); // valid seqan3::rna5 char

--- a/test/unit/core/type_traits/range_iterator_test.cpp
+++ b/test/unit/core/type_traits/range_iterator_test.cpp
@@ -20,7 +20,7 @@
 #include <seqan3/range/views/take_exactly.hpp>
 #include <seqan3/std/ranges>
 
-TEST(range_and_iterator, iterator_)
+TEST(range_and_iterator, iterator)
 {
     EXPECT_TRUE((std::is_same_v<std::ranges::iterator_t<std::vector<int>>,
                                 typename std::vector<int>::iterator>));
@@ -34,7 +34,7 @@ TEST(range_and_iterator, iterator_)
                                  decltype(std::ranges::end(v))>));
 }
 
-TEST(range_and_iterator, sentinel_)
+TEST(range_and_iterator, sentinel)
 {
     EXPECT_TRUE((std::is_same_v<std::ranges::sentinel_t<std::vector<int>>,
                                 typename std::vector<int>::iterator>));
@@ -66,7 +66,7 @@ void expect_same_types()
         expect_same_types<list1, list2, pos + 1>();
 }
 
-TEST(range_and_iterator, value_type_)
+TEST(range_and_iterator, value_type)
 {
     using iterator_of_int_vector = std::ranges::iterator_t<std::vector<int>>;
     using foreign_iterator = seqan3::detail::random_access_iterator<std::vector<int>>;
@@ -89,7 +89,7 @@ TEST(range_and_iterator, value_type_)
     expect_same_types<type_list_example, comp_list>();
 }
 
-TEST(range_and_iterator, reference_)
+TEST(range_and_iterator, reference)
 {
     using iterator_of_int_vector = std::ranges::iterator_t<std::vector<int>>;
     using foreign_iterator = seqan3::detail::random_access_iterator<std::vector<int>>;
@@ -111,7 +111,7 @@ TEST(range_and_iterator, reference_)
     expect_same_types<type_list_example, comp_list>();
 }
 
-TEST(range_and_iterator, rvalue_reference_)
+TEST(range_and_iterator, rvalue_reference)
 {
     using iterator_of_int_vector = std::ranges::iterator_t<std::vector<int>>;
     using foreign_iterator = seqan3::detail::random_access_iterator<std::vector<int>>;
@@ -134,7 +134,7 @@ TEST(range_and_iterator, rvalue_reference_)
     expect_same_types<type_list_example, comp_list>();
 }
 
-TEST(range_and_iterator, const_reference_)
+TEST(range_and_iterator, const_reference)
 {
     using const_iterator_of_int_vector = std::ranges::iterator_t<std::vector<int> const>;
     using const_foreign_iterator = seqan3::detail::random_access_iterator<std::vector<int> const>;
@@ -154,7 +154,7 @@ TEST(range_and_iterator, const_reference_)
     expect_same_types<type_list_example, comp_list>();
 }
 
-TEST(range_and_iterator, difference_type_)
+TEST(range_and_iterator, difference_type)
 {
     //TODO(h-2): add something that actually has a different difference_type
     using iterator_of_int_vector = std::ranges::iterator_t<std::vector<int>>;
@@ -187,7 +187,7 @@ TEST(range_and_iterator, difference_type_)
     expect_same_types<type_list_example, comp_list>();
 }
 
-TEST(range_and_iterator, size_type_)
+TEST(range_and_iterator, size_type)
 {
     //TODO(h-2): add something that actually has a different size_type
 // iota is not a sized range, but take_exactly is

--- a/test/unit/core/type_traits/range_iterator_test.cpp
+++ b/test/unit/core/type_traits/range_iterator_test.cpp
@@ -6,6 +6,7 @@
 // -----------------------------------------------------------------------------------------------------
 
 #include <list>
+#include <seqan3/std/ranges>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -13,12 +14,11 @@
 #include <meta/meta.hpp>
 
 
+#include <seqan3/core/detail/type_inspection.hpp>
 #include <seqan3/core/type_list/all.hpp>
 #include <seqan3/core/type_traits/all.hpp>
-#include <seqan3/core/detail/type_inspection.hpp>
 #include <seqan3/range/detail/random_access_iterator.hpp>
 #include <seqan3/range/views/take_exactly.hpp>
-#include <seqan3/std/ranges>
 
 TEST(range_and_iterator, iterator)
 {

--- a/test/unit/io/record_test.cpp
+++ b/test/unit/io/record_test.cpp
@@ -54,14 +54,14 @@ TEST(fields, usage)
 // record
 // ----------------------------------------------------------------------------
 
-struct record_ : public ::testing::Test
+struct record : public ::testing::Test
 {
     using types        = seqan3::type_list<std::string, seqan3::dna4_vector>;
     using types_as_ids = seqan3::fields<seqan3::field::id, seqan3::field::seq>;
     using record_type  = seqan3::record<types, types_as_ids>;
 };
 
-TEST_F(record_, definition_tuple_traits)
+TEST_F(record, definition_tuple_traits)
 {
     EXPECT_TRUE((std::is_same_v<typename record_type::base_type,
                                 std::tuple<std::string, seqan3::dna4_vector>>));
@@ -75,12 +75,12 @@ TEST_F(record_, definition_tuple_traits)
     EXPECT_TRUE(seqan3::tuple_like<record_type>);
 }
 
-TEST_F(record_, construction)
+TEST_F(record, construction)
 {
     [[maybe_unused]] record_type r{"MY ID", "ACGT"_dna4};
 }
 
-TEST_F(record_, get_by_index)
+TEST_F(record, get_by_index)
 {
     record_type r{"MY ID", "ACGT"_dna4};
 
@@ -88,7 +88,7 @@ TEST_F(record_, get_by_index)
     EXPECT_RANGE_EQ(std::get<1>(r), "ACGT"_dna4);
 }
 
-TEST_F(record_, get_by_type)
+TEST_F(record, get_by_type)
 {
     record_type r{"MY ID", "ACGT"_dna4};
 
@@ -96,7 +96,7 @@ TEST_F(record_, get_by_type)
     EXPECT_RANGE_EQ(std::get<seqan3::dna4_vector>(r), "ACGT"_dna4);
 }
 
-TEST_F(record_, get_by_field)
+TEST_F(record, get_by_field)
 {
     record_type r{"MY ID", "ACGT"_dna4};
 

--- a/test/unit/io/record_test.cpp
+++ b/test/unit/io/record_test.cpp
@@ -5,16 +5,16 @@
 // shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 // -----------------------------------------------------------------------------------------------------
 
+#include <algorithm>
 #include <sstream>
 
 #include <gtest/gtest.h>
 
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/alphabet/quality/phred42.hpp>
-#include <seqan3/io/record.hpp>
-#include <seqan3/io/detail/record.hpp>
 #include <seqan3/core/concept/tuple.hpp>
-#include <seqan3/std/algorithm>
+#include <seqan3/io/detail/record.hpp>
+#include <seqan3/io/record.hpp>
 #include <seqan3/test/expect_range_eq.hpp>
 
 using seqan3::operator""_dna4;

--- a/test/unit/io/record_test.cpp
+++ b/test/unit/io/record_test.cpp
@@ -5,7 +5,7 @@
 // shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 // -----------------------------------------------------------------------------------------------------
 
-#include <algorithm>
+#include <seqan3/std/algorithm>
 #include <sstream>
 
 #include <gtest/gtest.h>

--- a/test/unit/range/container/container_concept_test.cpp
+++ b/test/unit/range/container/container_concept_test.cpp
@@ -7,20 +7,20 @@
 
 #include <gtest/gtest.h>
 
-#include <vector>
 #include <array>
-#include <list>
-#include <forward_list>
 #include <deque>
+#include <forward_list>
+#include <list>
 #include <string>
+#include <vector>
 
 #include <sdsl/int_vector.hpp>
 
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/alphabet/quality/phred42.hpp>
 #include <seqan3/alphabet/quality/qualified.hpp>
-#include <seqan3/range/container/concatenated_sequences.hpp>
 #include <seqan3/range/container/bitcompressed_vector.hpp>
+#include <seqan3/range/container/concatenated_sequences.hpp>
 #include <seqan3/range/container/concept.hpp>
 
 TEST(range_concept, forward_range)

--- a/test/unit/range/container/container_concept_test.cpp
+++ b/test/unit/range/container/container_concept_test.cpp
@@ -39,7 +39,7 @@ TEST(range_concept, forward_range)
                                                                                            seqan3::phred42>>>));
 }
 
-TEST(container_, container)
+TEST(container, container)
 {
     EXPECT_TRUE((seqan3::container<std::array<char, 2>>));
     EXPECT_TRUE((seqan3::container<std::list<char>>));
@@ -52,7 +52,7 @@ TEST(container_, container)
     EXPECT_TRUE((seqan3::container<seqan3::concatenated_sequences<std::vector<char>>>));
 }
 
-TEST(container_, sequence_container_former_travis_bug)
+TEST(container, sequence_container_former_travis_bug)
 {
     // This tests a bug with const iterators on strings which was there in a
     // special gcc 7.2 build (ppa) for ubuntu 14.04 and 16.04. We leave it as
@@ -100,7 +100,7 @@ TEST(container_, sequence_container_former_travis_bug)
     EXPECT_EQ("Exemplar is an:== example string.", s);
 }
 
-TEST(container_, sequence_container)
+TEST(container, sequence_container)
 {
     EXPECT_FALSE((seqan3::sequence_container<std::array<char, 2>>));
     EXPECT_TRUE((seqan3::sequence_container<std::list<char>>));
@@ -113,7 +113,7 @@ TEST(container_, sequence_container)
     EXPECT_TRUE((seqan3::sequence_container<seqan3::concatenated_sequences<std::vector<char>>>));
 }
 
-TEST(container_, random_access_container)
+TEST(container, random_access_container)
 {
     EXPECT_FALSE((seqan3::random_access_container<std::array<char, 2>>));
     EXPECT_FALSE((seqan3::random_access_container<std::list<char>>));
@@ -126,7 +126,7 @@ TEST(container_, random_access_container)
     EXPECT_TRUE((seqan3::random_access_container<seqan3::concatenated_sequences<std::vector<char>>>));
 }
 
-TEST(container_, reservible_container)
+TEST(container, reservible_container)
 {
     EXPECT_FALSE((seqan3::reservible_container<std::array<char, 2>>));
     EXPECT_FALSE((seqan3::reservible_container<std::list<char>>));

--- a/test/unit/range/decorator/gap_decorator_test.cpp
+++ b/test/unit/range/decorator/gap_decorator_test.cpp
@@ -36,8 +36,8 @@ using test_types = ::testing::Types<decorator_t, decorator_t2>;
 // test templates
 // ---------------------------------------------------------------------------------------------------------------------
 
-template <typename inner_type_>
-class aligned_sequence<seqan3::gap_decorator<inner_type_>> : public ::testing::Test
+template <typename inner_type>
+class aligned_sequence<seqan3::gap_decorator<inner_type>> : public ::testing::Test
 {
 public:
     // Initialiser function is needed for the typed test because the gapped_decorator

--- a/test/unit/range/decorator/gap_decorator_test.cpp
+++ b/test/unit/range/decorator/gap_decorator_test.cpp
@@ -37,26 +37,26 @@ using test_types = ::testing::Types<decorator_t, decorator_t2>;
 // ---------------------------------------------------------------------------------------------------------------------
 
 template <typename inner_type_>
-class aligned_sequence_<seqan3::gap_decorator<inner_type_>> : public ::testing::Test
+class aligned_sequence<seqan3::gap_decorator<inner_type_>> : public ::testing::Test
 {
 public:
     // Initialiser function is needed for the typed test because the gapped_decorator
     // will be initialised differently than the naive vector<seqan3::gapped<seqan3::dna>>.
-    void initialise_typed_test_container(decorator_t & container_, seqan3::dna4_vector const & target)
+    void initialise_typed_test_container(decorator_t & container, seqan3::dna4_vector const & target)
     {
-        container_ = target;
+        container = target;
     }
 
     // Initialiser function is needed for the typed test because the gapped_decorator
     // will be initialised differently than the naive vector<seqan3::gapped<seqan3::dna>>.
-    void initialise_typed_test_container(decorator_t2 & container_, seqan3::dna4_vector const & target)
+    void initialise_typed_test_container(decorator_t2 & container, seqan3::dna4_vector const & target)
     {
-        container_ = std::ranges::subrange<decltype(target.begin()),
+        container = std::ranges::subrange<decltype(target.begin()),
                                            decltype(target.end())>{target.begin(), target.end()};
     }
 };
 
-INSTANTIATE_TYPED_TEST_SUITE_P(gap_decorator, aligned_sequence_, test_types, );
+INSTANTIATE_TYPED_TEST_SUITE_P(gap_decorator, aligned_sequence, test_types, );
 
 template <>
 struct iterator_fixture<std::ranges::iterator_t<decorator_t>> : public ::testing::Test

--- a/test/unit/range/views/view_persist_test.cpp
+++ b/test/unit/range/views/view_persist_test.cpp
@@ -72,7 +72,7 @@ TEST(view_persist, wrap_temporary)
     EXPECT_EQ("o", v3b);
 }
 
-TEST(view_persist, const_)
+TEST(view_persist, const)
 {
     // inner const
     using t = std::string const;

--- a/test/unit/std/concept/auxiliary_iterator.hpp
+++ b/test/unit/std/concept/auxiliary_iterator.hpp
@@ -7,14 +7,13 @@
 
 #pragma once
 
+#include <forward_list>
 #include <iterator>
 #include <list>
-#include <forward_list>
+#include <seqan3/std/ranges>
 #include <vector>
 
 #include <seqan3/io/stream/iterator.hpp>
-#include <seqan3/std/iterator>
-#include <seqan3/std/ranges>
 
 using input_iterator = std::istream_iterator<char>;
 using output_iterator = std::cpp20::ostream_iterator<char>;

--- a/test/unit/std/concept/auxiliary_iterator.hpp
+++ b/test/unit/std/concept/auxiliary_iterator.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <forward_list>
-#include <iterator>
+#include <seqan3/std/iterator>
 #include <list>
 #include <seqan3/std/ranges>
 #include <vector>

--- a/test/unit/std/concept/auxiliary_iterator.hpp
+++ b/test/unit/std/concept/auxiliary_iterator.hpp
@@ -84,7 +84,7 @@ struct test_sized_sentinel : public test_sentinel<input_or_output_iter_value_t<i
 {
     using difference_type = typename iterator_type::difference_type;
 
-    iterator_type _pos;
+    iterator_type pos;
 };
 
 template <typename iterator_t>
@@ -93,7 +93,7 @@ inline typename test_sized_sentinel<iterator_t>::difference_type
 operator-(test_sized_sentinel<iterator_t> const & s,
           iterator_t const & i)
 {
-    return s._pos - i;
+    return s.pos - i;
 }
 
 template <typename iterator_t>
@@ -102,5 +102,5 @@ inline typename test_sized_sentinel<iterator_t>::difference_type
 operator-(iterator_t const & i,
           test_sized_sentinel<iterator_t> const & s)
 {
-    return i - s._pos;
+    return i - s.pos;
 }


### PR DESCRIPTION
Please double check that I have not deleted too much. (I've also renamed a few variables, but I'm not sure if they were meant aswell.)

I don't know if there are "other common prefixes".

I left the prefix `global_` if there was also a `local_` prefix.