### PR TITLE
[TEST] Repair seqan2 tests

### DIFF
--- a/test/performance/alignment/global_affine_alignment_parallel_benchmark.cpp
+++ b/test/performance/alignment/global_affine_alignment_parallel_benchmark.cpp
@@ -65,14 +65,14 @@ auto generate_data_seqan3()
 template <typename alphabet_t>
 auto generate_data_seqan2()
 {
-    using sequence_t = decltype(generate_sequence_seqan2<alphabet_t>());
+    using sequence_t = decltype(seqan3::test::generate_sequence_seqan2<alphabet_t>());
 
     seqan::StringSet<sequence_t> vec1;
     seqan::StringSet<sequence_t> vec2;
     for (unsigned i = 0; i < set_size; ++i)
     {
-        appendValue(vec1, generate_sequence_seqan2<alphabet_t>(sequence_length, variance, i));
-        appendValue(vec2, generate_sequence_seqan2<alphabet_t>(sequence_length, variance, i + set_size));
+        appendValue(vec1, seqan3::test::generate_sequence_seqan2<alphabet_t>(sequence_length, variance, i));
+        appendValue(vec2, seqan3::test::generate_sequence_seqan2<alphabet_t>(sequence_length, variance, i + set_size));
     }
     return std::pair{vec1, vec2};
 }
@@ -141,7 +141,7 @@ template <typename result_t>
 void seqan2_affine_dna4_parallel(benchmark::State & state)
 {
     auto [vec1, vec2] = generate_data_seqan2<seqan::Dna>();
-    ExecutionPolicy<Parallel, Serial> exec{};
+    seqan::ExecutionPolicy<seqan::Parallel, seqan::Serial> exec{};
     setNumThreads(exec, std::thread::hardware_concurrency());
 
     int64_t total = 0;

--- a/test/performance/alignment/local_affine_alignment_benchmark.cpp
+++ b/test/performance/alignment/local_affine_alignment_benchmark.cpp
@@ -62,8 +62,8 @@ BENCHMARK(seqan3_affine_dna4);
 
 void seqan2_affine_dna4(benchmark::State & state)
 {
-    auto seq1 = generate_sequence_seqan2<seqan::Dna>(500, 0, 0);
-    auto seq2 = generate_sequence_seqan2<seqan::Dna>(250, 0, 1);
+    auto seq1 = seqan3::test::generate_sequence_seqan2<seqan::Dna>(500, 0, 0);
+    auto seq2 = seqan3::test::generate_sequence_seqan2<seqan::Dna>(250, 0, 1);
 
     for (auto _ : state)
     {
@@ -106,8 +106,8 @@ BENCHMARK(seqan3_affine_dna4_trace);
 
 void seqan2_affine_dna4_trace(benchmark::State & state)
 {
-    auto seq1 = generate_sequence_seqan2<seqan::Dna>(500, 0, 0);
-    auto seq2 = generate_sequence_seqan2<seqan::Dna>(250, 0, 1);
+    auto seq1 = seqan3::test::generate_sequence_seqan2<seqan::Dna>(500, 0, 0);
+    auto seq2 = seqan3::test::generate_sequence_seqan2<seqan::Dna>(250, 0, 1);
 
     seqan::Gaps<decltype(seq1)> gap1{seq1};
     seqan::Gaps<decltype(seq2)> gap2{seq2};
@@ -157,14 +157,14 @@ BENCHMARK(seqan3_affine_dna4_collection);
 
 void seqan2_affine_dna4_collection(benchmark::State & state)
 {
-    using sequence_t = decltype(generate_sequence_seqan2<seqan::Dna>());
+    using sequence_t = decltype(seqan3::test::generate_sequence_seqan2<seqan::Dna>());
 
     seqan::StringSet<sequence_t> vec1;
     seqan::StringSet<sequence_t> vec2;
     for (unsigned i = 0; i < 100; ++i)
     {
-        sequence_t seq1 = generate_sequence_seqan2<seqan::Dna>(100, 0, i);
-        sequence_t seq2 = generate_sequence_seqan2<seqan::Dna>(50, 0, i + 100);
+        sequence_t seq1 = seqan3::test::generate_sequence_seqan2<seqan::Dna>(100, 0, i);
+        sequence_t seq2 = seqan3::test::generate_sequence_seqan2<seqan::Dna>(50, 0, i + 100);
         appendValue(vec1, seq1);
         appendValue(vec2, seq2);
     }
@@ -211,14 +211,14 @@ BENCHMARK(seqan3_affine_dna4_trace_collection);
 
 void seqan2_affine_dna4_trace_collection(benchmark::State & state)
 {
-    using sequence_t = decltype(generate_sequence_seqan2<seqan::Dna>());
+    using sequence_t = decltype(seqan3::test::generate_sequence_seqan2<seqan::Dna>());
 
     seqan::StringSet<sequence_t> vec1;
     seqan::StringSet<sequence_t> vec2;
     for (unsigned i = 0; i < 100; ++i)
     {
-        sequence_t seq1 = generate_sequence_seqan2<seqan::Dna>(100, 0, i);
-        sequence_t seq2 = generate_sequence_seqan2<seqan::Dna>(50, 0, i + 100);
+        sequence_t seq1 = seqan3::test::generate_sequence_seqan2<seqan::Dna>(100, 0, i);
+        sequence_t seq2 = seqan3::test::generate_sequence_seqan2<seqan::Dna>(50, 0, i + 100);
         appendValue(vec1, seq1);
         appendValue(vec2, seq2);
     }

--- a/test/performance/range/views/view_translate_1D_benchmark.cpp
+++ b/test/performance/range/views/view_translate_1D_benchmark.cpp
@@ -133,7 +133,7 @@ void copy(benchmark::State & state)
     std::vector<seqan3::dna4> seqan3_dna_sequence{seqan3::test::generate_sequence<seqan3::dna4>(1000, 0, 0)};
 
 #ifdef SEQAN3_HAS_SEQAN2
-    seqan::DnaString seqan2_dna_sequence{generate_sequence_seqan2<seqan::Dna>(1000, 0, 0)};
+    seqan::DnaString seqan2_dna_sequence{seqan3::test::generate_sequence_seqan2<seqan::Dna>(1000, 0, 0)};
 #endif // SEQAN3_HAS_SEQAN2
 
     if constexpr (std::is_same_v<tag_t, translate_tag>)

--- a/test/performance/range/views/view_translate_2D_1D_benchmark.cpp
+++ b/test/performance/range/views/view_translate_2D_1D_benchmark.cpp
@@ -192,7 +192,7 @@ void copy(benchmark::State & state)
 
     for (size_t i = 0; i < length(dna_sequence_collection); ++i)
     {
-        dna_sequence_collection[i] = generate_sequence_seqan2<seqan::Dna>(100, 0, 0);
+        dna_sequence_collection[i] = seqan3::test::generate_sequence_seqan2<seqan::Dna>(100, 0, 0);
     }
 
     copy_impl_seqan2<tag_t, stringset_t>(state, dna_sequence_collection);


### PR DESCRIPTION
This PR is part of https://github.com/seqan/product_backlog/issues/12.
It resolves the errors with seqan2, such as
```bash
.../seqan3/test/performance/range/views/view_translate_2D_1D_benchmark.cpp: In function 'void copy(benchmark::State&)':
.../seqan3/test/performance/range/views/view_translate_2D_1D_benchmark.cpp:195:38: error: 'generate_sequence_seqan' was not declared in this scope; did you mean 'seqan3::test::generate_sequence_seqan2'?
  195 |         dna_sequence_collection[i] = generate_sequence_seqan2<seqan::Dna>(100, 0, 0);
      |                                      ^~~~~~~~~~~~~~~~~~~~~~~~
      |                                      seqan3::test::generate_sequence_seqan2
```
and
```bash
.../seqan3/test/performance/alignment/global_affine_alignment_parallel_benchmark.cpp: In function 'void seqan2_affine_dna4_parallel(benchmark::State&)':
.../seqan3/test/performance/alignment/global_affine_alignment_parallel_benchmark.cpp:144:5: error: 'ExecutionPolic' was not declared in this scope; did you mean 'seqan::ExecutionPolicy'?
  144 |     ExecutionPolicy<Parallel, Serial> exec{};
      |     ^~~~~~~~~~~~~~~
      |     seqan::ExecutionPolicy
```
when the seqan submodule is available.