### PR TITLE
[TASK] support gcc10.2

### DIFF
--- a/include/seqan3/alignment/matrix/alignment_coordinate.hpp
+++ b/include/seqan3/alignment/matrix/alignment_coordinate.hpp
@@ -396,7 +396,7 @@ public:
  *
  * Prints the alignment coordinate as a tuple.
  */
-template <typename coordinate_type, typename char_t>
+template <typename char_t, typename coordinate_type>
 //!\cond
     requires std::same_as<remove_cvref_t<coordinate_type>, alignment_coordinate> ||
              detail::is_value_specialisation_of_v<remove_cvref_t<coordinate_type>,

--- a/include/seqan3/alignment/matrix/debug_matrix.hpp
+++ b/include/seqan3/alignment/matrix/debug_matrix.hpp
@@ -487,7 +487,7 @@ namespace seqan3
  *
  * This prints out an alignment matrix which can be a score matrix or a trace matrix.
  */
-template <detail::matrix alignment_matrix_t, typename char_t>
+template <typename char_t, detail::matrix alignment_matrix_t>
 inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, alignment_matrix_t && matrix)
 {
     detail::debug_matrix debug{std::forward<alignment_matrix_t>(matrix)};
@@ -499,7 +499,7 @@ inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, ali
 }
 
 //!\overload
-template <std::ranges::input_range alignment_matrix_t, typename char_t>
+template <typename char_t, std::ranges::input_range alignment_matrix_t>
 //!\cond
     requires detail::debug_stream_range_guard<alignment_matrix_t> && detail::matrix<alignment_matrix_t>
 //!\endcond

--- a/include/seqan3/core/detail/debug_stream_alphabet.hpp
+++ b/include/seqan3/core/detail/debug_stream_alphabet.hpp
@@ -28,8 +28,8 @@ namespace seqan3
  * \param l The alphabet letter.
  * \relates seqan3::debug_stream_type
  */
-template <alphabet alphabet_t, typename char_t>
-inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, alphabet_t const l)
+template <typename char_t, alphabet alphabet_t>
+inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, alphabet_t && l)
 //!\cond
     requires (!output_stream_over<std::basic_ostream<char_t>, alphabet_t>)
 //!\endcond

--- a/include/seqan3/core/detail/debug_stream_optional.hpp
+++ b/include/seqan3/core/detail/debug_stream_optional.hpp
@@ -29,11 +29,8 @@ namespace seqan3
  * \param[in] arg           This is std::nullopt.
  * \relates seqan3::debug_stream_type
  */
-template <typename optional_type, typename char_t>
-//!\cond
-   requires std::same_as<remove_cvref_t<optional_type>, std::nullopt_t>
-//!\endcond
-inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, optional_type && SEQAN3_DOXYGEN_ONLY(arg))
+template <typename char_t>
+inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, std::nullopt_t SEQAN3_DOXYGEN_ONLY(arg))
 {
    s << "<VALUELESS_OPTIONAL>";
    return s;
@@ -45,7 +42,7 @@ inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, opt
  * \param[in] arg           The std::optional.
  * \relates seqan3::debug_stream_type
  */
-template <typename optional_type, typename char_t>
+template <typename char_t, typename optional_type>
 //!\cond
     requires detail::is_type_specialisation_of_v<remove_cvref_t<optional_type>, std::optional>
 //!\endcond

--- a/include/seqan3/core/detail/debug_stream_range.hpp
+++ b/include/seqan3/core/detail/debug_stream_range.hpp
@@ -89,7 +89,7 @@ namespace seqan3
  * to avoid ambiguous function calls.
  * \endif
  */
-template <std::ranges::input_range rng_t, typename char_t>
+template <typename char_t, std::ranges::input_range rng_t>
 inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, rng_t && r)
 //!\cond
     requires detail::debug_stream_range_guard<rng_t>
@@ -118,7 +118,7 @@ inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, rng
 }
 
 //!\overload
-template <sequence rng_t, typename char_t>
+template <typename char_t, sequence rng_t>
 inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, rng_t && r)
 //!\cond
     requires detail::debug_stream_range_guard<rng_t> &&

--- a/include/seqan3/core/detail/debug_stream_type.hpp
+++ b/include/seqan3/core/detail/debug_stream_type.hpp
@@ -116,12 +116,8 @@ public:
      * \{
      */
     //!\brief Forwards to the underlying stream object.
-    template <typename t>
-    debug_stream_type & operator<<(t && v)
-    {
-        *stream << v;
-        return *this;
-    }
+    template <typename other_char_t, typename t>
+    friend debug_stream_type<other_char_t> & operator<<(debug_stream_type<other_char_t> & s, t && v);
 
     //!\brief This overloads enables forwarding std::endl and other manipulators.
     debug_stream_type & operator<<(std::ostream&(*fp)(std::ostream&))
@@ -234,5 +230,13 @@ private:
     //!\brief The SeqAn specific flags to the stream.
     fmtflags2 flgs2{fmtflags2::default_};
 };
+
+//!\brief Forwards to the underlying stream object.
+template <typename char_t, typename t>
+debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, t && v)
+{
+    (*s.stream) << v;
+    return s;
+}
 
 } // namespace seqan3

--- a/include/seqan3/core/detail/debug_stream_variant.hpp
+++ b/include/seqan3/core/detail/debug_stream_variant.hpp
@@ -33,7 +33,7 @@ namespace seqan3
  *
  * Note that in case the variant is valueless(_by_exception), nothing is printed.
  */
-template <typename variant_type, typename char_t>
+template <typename char_t, typename variant_type>
 //!\cond
     requires detail::is_type_specialisation_of_v<remove_cvref_t<variant_type>, std::variant>
 //!\endcond

--- a/include/seqan3/core/simd/debug_stream_simd.hpp
+++ b/include/seqan3/core/simd/debug_stream_simd.hpp
@@ -27,7 +27,7 @@ namespace seqan3
  * the API was not in shape yet. Remove the `private` and `todo` commands and remove `seqan3::simd` from
  * SEQAN3_DOXYGEN_EXCLUDE_SYMBOLS in `seqan3-doxygen.cmake`.
  */
-template <typename simd_t, typename char_t>
+template <typename char_t, typename simd_t>
 //!\cond
     requires simd::simd_concept<remove_cvref_t<simd_t>>
 //!\endcond

--- a/include/seqan3/search/fm_index/bi_fm_index_cursor.hpp
+++ b/include/seqan3/search/fm_index/bi_fm_index_cursor.hpp
@@ -421,14 +421,14 @@ public:
      * No-throw guarantee.
      */
     template <typename char_t>
+    //!\cond
+        requires std::convertible_to<char_t, index_alphabet_type>
+    //!\endcond
     bool extend_right(char_t const c) noexcept
     {
     #ifndef NDEBUG
         fwd_cursor_last_used = true;
     #endif
-
-        static_assert(std::convertible_to<char_t, index_alphabet_type>,
-                     "The character must be convertible to the alphabet of the index.");
 
         assert(index != nullptr);
         // The rank cannot exceed 255 for single text and 254 for text collections as they are reserved as sentinels
@@ -476,14 +476,14 @@ public:
      * No-throw guarantee.
      */
     template <typename char_t>
+    //!\cond
+        requires std::convertible_to<char_t, index_alphabet_type>
+    //!\endcond
     bool extend_left(char_t const c) noexcept
     {
     #ifndef NDEBUG
         fwd_cursor_last_used = false;
     #endif
-
-        static_assert(std::convertible_to<char_t, index_alphabet_type>,
-                      "The character must be convertible to the alphabet of the index.");
 
         assert(index != nullptr);
         // The rank cannot exceed 255 for single text and 254 for text collections as they are reserved as sentinels

--- a/include/seqan3/search/fm_index/fm_index_cursor.hpp
+++ b/include/seqan3/search/fm_index/fm_index_cursor.hpp
@@ -267,11 +267,11 @@ public:
      * No-throw guarantee.
      */
     template <typename char_t>
+    //!\cond
+        requires std::convertible_to<char_t, index_alphabet_type>
+    //!\endcond
     bool extend_right(char_t const c) noexcept
     {
-        static_assert(std::convertible_to<char_t, index_alphabet_type>,
-                     "The character must be convertible to the alphabet of the index.");
-
         assert(index != nullptr);
         // The rank cannot exceed 255 for single text and 254 for text collections as they are reserved as sentinels
         // for the indexed text.

--- a/include/seqan3/search/search.hpp
+++ b/include/seqan3/search/search.hpp
@@ -157,11 +157,11 @@ inline auto search(queries_t && queries,
 template <fm_index_specialisation index_t,
           std::ranges::forward_range query_t,
           typename configuration_t = decltype(search_cfg::default_configuration)>
-inline auto search(query_t query,
+inline auto search(query_t && query,
                    index_t const & index,
                    configuration_t const & cfg = search_cfg::default_configuration)
 {
-    return search(std::views::single(std::move(query)), index, cfg);
+    return search(std::views::single(std::forward<query_t>(query)), index, cfg);
 }
 
 //!\overload

--- a/test/unit/core/debug_stream_test.cpp
+++ b/test/unit/core/debug_stream_test.cpp
@@ -11,7 +11,8 @@
 #include <string>
 
 #include <seqan3/alphabet/mask/mask.hpp>
-#include <seqan3/alphabet/nucleotide/all.hpp>
+#include <seqan3/alphabet/nucleotide/dna4.hpp>
+#include <seqan3/alphabet/nucleotide/dna5.hpp>
 #include <seqan3/argument_parser/auxiliary.hpp>
 #include <seqan3/core/debug_stream.hpp>
 #include <seqan3/io/alignment_file/misc.hpp>

--- a/test/unit/test/pretty_printing_test.cpp
+++ b/test/unit/test/pretty_printing_test.cpp
@@ -119,7 +119,7 @@ struct my_type
 namespace seqan3
 {
 
-template <typename my_type, typename char_t>
+template <typename char_t, typename my_type>
     requires std::same_as<std::decay_t<my_type>, detail::my_type>
 inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, my_type && m)
 {
@@ -143,7 +143,7 @@ namespace seqan3
 struct your_type : public detail::my_type
 {};
 
-template <typename your_type, typename char_t>
+template <typename char_t, typename your_type>
     requires std::same_as<std::decay_t<your_type>, ::seqan3::your_type>
 inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, your_type && m)
 {


### PR DESCRIPTION
Fixes #1993

A change to the standard [1] seems to disallow the following, at least gcc [2] interprets it this way:

```c++
template <typename T> int f(T);
template <typename T> requires true int f(T const&);

int i = f(42);
```

That means constraint functions are only more specialised if they have the same argument "structure".

If you changed the first signature to "int f(T const &);", it would compile again.

This PR unifies the argument "structure"
* for `operator<<(debug_stream, any_type)`,
* for `[bi_]fm_index_cursor::extend_(left|right)`, and
* for `seqan3::search`.


[1] - http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p2113r0.html
[2] - https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96333
