### PR TITLE
[TEST] explicitly include debug_stream overloads

### DIFF
--- a/include/seqan3/argument_parser/validators.hpp
+++ b/include/seqan3/argument_parser/validators.hpp
@@ -18,6 +18,7 @@
 
 #include <seqan3/argument_parser/exceptions.hpp>
 #include <seqan3/core/concept/core_language.hpp>
+#include <seqan3/core/detail/debug_stream_range.hpp>
 #include <seqan3/core/detail/to_string.hpp>
 #include <seqan3/core/type_list/traits.hpp>
 #include <seqan3/core/type_traits/basic.hpp>

--- a/include/seqan3/io/alignment_file/format_bam.hpp
+++ b/include/seqan3/io/alignment_file/format_bam.hpp
@@ -22,6 +22,7 @@
 #include <seqan3/core/char_operations/predicate.hpp>
 #include <seqan3/core/concept/core_language.hpp>
 #include <seqan3/core/concept/tuple.hpp>
+#include <seqan3/core/detail/debug_stream_optional.hpp>
 #include <seqan3/core/detail/to_string.hpp>
 #include <seqan3/core/type_traits/range.hpp>
 #include <seqan3/core/type_traits/template_inspection.hpp>

--- a/include/seqan3/io/alignment_file/format_sam_base.hpp
+++ b/include/seqan3/io/alignment_file/format_sam_base.hpp
@@ -19,6 +19,7 @@
 #include <seqan3/core/char_operations/predicate.hpp>
 #include <seqan3/core/concept/core_language.hpp>
 #include <seqan3/core/concept/tuple.hpp>
+#include <seqan3/core/detail/debug_stream_range.hpp>
 #include <seqan3/core/detail/to_string.hpp>
 #include <seqan3/core/detail/type_inspection.hpp>
 #include <seqan3/core/type_traits/range.hpp>

--- a/test/unit/alignment/scoring/simd_match_mismatch_scoring_scheme_test.cpp
+++ b/test/unit/alignment/scoring/simd_match_mismatch_scoring_scheme_test.cpp
@@ -7,8 +7,8 @@
 
 #include <gtest/gtest.h>
 
-#include <seqan3/alignment/scoring/nucleotide_scoring_scheme.hpp>
 #include <seqan3/alignment/scoring/detail/simd_match_mismatch_scoring_scheme.hpp>
+#include <seqan3/alignment/scoring/nucleotide_scoring_scheme.hpp>
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/core/detail/debug_stream_range.hpp>
 #include <seqan3/core/simd/simd.hpp>

--- a/test/unit/alignment/scoring/simd_match_mismatch_scoring_scheme_test.cpp
+++ b/test/unit/alignment/scoring/simd_match_mismatch_scoring_scheme_test.cpp
@@ -10,6 +10,7 @@
 #include <seqan3/alignment/scoring/nucleotide_scoring_scheme.hpp>
 #include <seqan3/alignment/scoring/detail/simd_match_mismatch_scoring_scheme.hpp>
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
+#include <seqan3/core/detail/debug_stream_range.hpp>
 #include <seqan3/core/simd/simd.hpp>
 #include <seqan3/test/pretty_printing.hpp>
 #include <seqan3/test/simd_utility.hpp>

--- a/test/unit/alignment/scoring/simd_matrix_scoring_scheme_test.cpp
+++ b/test/unit/alignment/scoring/simd_matrix_scoring_scheme_test.cpp
@@ -10,6 +10,7 @@
 #include <seqan3/alignment/scoring/aminoacid_scoring_scheme.hpp>
 #include <seqan3/alignment/scoring/detail/simd_matrix_scoring_scheme.hpp>
 #include <seqan3/alphabet/aminoacid/aa27.hpp>
+#include <seqan3/core/detail/debug_stream_range.hpp>
 #include <seqan3/core/simd/simd.hpp>
 #include <seqan3/test/pretty_printing.hpp>
 #include <seqan3/test/simd_utility.hpp>

--- a/test/unit/alphabet/alphabet_test_template.hpp
+++ b/test/unit/alphabet/alphabet_test_template.hpp
@@ -9,6 +9,7 @@
 
 #include <seqan3/alphabet/concept.hpp>
 #include <seqan3/alphabet/exception.hpp>
+#include <seqan3/core/detail/debug_stream_alphabet.hpp>
 #include <seqan3/test/pretty_printing.hpp>
 
 template <typename T>

--- a/test/unit/alphabet/aminoacid/aa10li_test.cpp
+++ b/test/unit/alphabet/aminoacid/aa10li_test.cpp
@@ -5,14 +5,15 @@
 // shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 // -----------------------------------------------------------------------------------------------------
 
+#include <seqan3/alphabet/aminoacid/aa10li.hpp>
+#include <seqan3/core/detail/debug_stream_range.hpp>
+#include <seqan3/range/views/zip.hpp>
+
 #include "../alphabet_constexpr_test_template.hpp"
 #include "../alphabet_test_template.hpp"
 #include "../semi_alphabet_constexpr_test_template.hpp"
 #include "../semi_alphabet_test_template.hpp"
 #include "aminoacid_test_template.hpp"
-
-#include <seqan3/alphabet/aminoacid/aa10li.hpp>
-#include <seqan3/range/views/zip.hpp>
 
 using seqan3::operator""_aa10li;
 

--- a/test/unit/alphabet/aminoacid/aa10murphy_test.cpp
+++ b/test/unit/alphabet/aminoacid/aa10murphy_test.cpp
@@ -5,14 +5,15 @@
 // shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 // -----------------------------------------------------------------------------------------------------
 
+#include <seqan3/alphabet/aminoacid/aa10murphy.hpp>
+#include <seqan3/core/detail/debug_stream_range.hpp>
+#include <seqan3/range/views/zip.hpp>
+
 #include "../alphabet_constexpr_test_template.hpp"
 #include "../alphabet_test_template.hpp"
 #include "../semi_alphabet_constexpr_test_template.hpp"
 #include "../semi_alphabet_test_template.hpp"
 #include "aminoacid_test_template.hpp"
-
-#include <seqan3/alphabet/aminoacid/aa10murphy.hpp>
-#include <seqan3/range/views/zip.hpp>
 
 using seqan3::operator""_aa10murphy;
 

--- a/test/unit/alphabet/aminoacid/aa20_test.cpp
+++ b/test/unit/alphabet/aminoacid/aa20_test.cpp
@@ -5,14 +5,15 @@
 // shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 // -----------------------------------------------------------------------------------------------------
 
+#include <seqan3/alphabet/aminoacid/aa20.hpp>
+#include <seqan3/core/detail/debug_stream_range.hpp>
+#include <seqan3/range/views/zip.hpp>
+
 #include "../alphabet_constexpr_test_template.hpp"
 #include "../alphabet_test_template.hpp"
 #include "../semi_alphabet_constexpr_test_template.hpp"
 #include "../semi_alphabet_test_template.hpp"
 #include "aminoacid_test_template.hpp"
-
-#include <seqan3/alphabet/aminoacid/aa20.hpp>
-#include <seqan3/range/views/zip.hpp>
 
 using seqan3::operator""_aa20;
 

--- a/test/unit/alphabet/aminoacid/aa27_test.cpp
+++ b/test/unit/alphabet/aminoacid/aa27_test.cpp
@@ -5,14 +5,15 @@
 // shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 // -----------------------------------------------------------------------------------------------------
 
+#include <seqan3/alphabet/aminoacid/aa27.hpp>
+#include <seqan3/core/detail/debug_stream_range.hpp>
+#include <seqan3/range/views/zip.hpp>
+
 #include "../alphabet_constexpr_test_template.hpp"
 #include "../alphabet_test_template.hpp"
 #include "../semi_alphabet_constexpr_test_template.hpp"
 #include "../semi_alphabet_test_template.hpp"
 #include "aminoacid_test_template.hpp"
-
-#include <seqan3/alphabet/aminoacid/aa27.hpp>
-#include <seqan3/range/views/zip.hpp>
 
 using seqan3::operator""_aa27;
 

--- a/test/unit/alphabet/composite/alphabet_tuple_base_test.cpp
+++ b/test/unit/alphabet/composite/alphabet_tuple_base_test.cpp
@@ -10,6 +10,7 @@
 #include <seqan3/alphabet/composite/alphabet_tuple_base.hpp>
 #include <seqan3/alphabet/nucleotide/rna4.hpp>
 #include <seqan3/alphabet/nucleotide/rna5.hpp>
+#include <seqan3/core/detail/debug_stream_tuple.hpp>
 
 #include "../semi_alphabet_test_template.hpp"
 #include "alphabet_tuple_base_test_template.hpp"

--- a/test/unit/alphabet/nucleotide/dna15_test.cpp
+++ b/test/unit/alphabet/nucleotide/dna15_test.cpp
@@ -7,6 +7,7 @@
 
 #include <seqan3/alphabet/nucleotide/dna15.hpp>
 #include <seqan3/core/char_operations/predicate.hpp>
+#include <seqan3/core/detail/debug_stream_range.hpp>
 
 #include "../alphabet_constexpr_test_template.hpp"
 #include "../alphabet_test_template.hpp"

--- a/test/unit/alphabet/nucleotide/dna3bs_test.cpp
+++ b/test/unit/alphabet/nucleotide/dna3bs_test.cpp
@@ -7,6 +7,7 @@
 
 #include <seqan3/alphabet/nucleotide/dna3bs.hpp>
 #include <seqan3/core/char_operations/predicate.hpp>
+#include <seqan3/core/detail/debug_stream_range.hpp>
 
 #include "../alphabet_constexpr_test_template.hpp"
 #include "../alphabet_test_template.hpp"

--- a/test/unit/alphabet/nucleotide/dna4_test.cpp
+++ b/test/unit/alphabet/nucleotide/dna4_test.cpp
@@ -7,6 +7,7 @@
 
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/core/char_operations/predicate.hpp>
+#include <seqan3/core/detail/debug_stream_range.hpp>
 
 #include "../alphabet_constexpr_test_template.hpp"
 #include "../alphabet_test_template.hpp"

--- a/test/unit/alphabet/nucleotide/dna5_test.cpp
+++ b/test/unit/alphabet/nucleotide/dna5_test.cpp
@@ -7,6 +7,7 @@
 
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
 #include <seqan3/core/char_operations/predicate.hpp>
+#include <seqan3/core/detail/debug_stream_range.hpp>
 
 #include "../alphabet_constexpr_test_template.hpp"
 #include "../alphabet_test_template.hpp"

--- a/test/unit/alphabet/nucleotide/rna15_test.cpp
+++ b/test/unit/alphabet/nucleotide/rna15_test.cpp
@@ -7,6 +7,7 @@
 
 #include <seqan3/alphabet/nucleotide/rna15.hpp>
 #include <seqan3/core/char_operations/predicate.hpp>
+#include <seqan3/core/detail/debug_stream_range.hpp>
 
 #include "../alphabet_constexpr_test_template.hpp"
 #include "../alphabet_test_template.hpp"

--- a/test/unit/alphabet/nucleotide/rna4_test.cpp
+++ b/test/unit/alphabet/nucleotide/rna4_test.cpp
@@ -7,6 +7,7 @@
 
 #include <seqan3/alphabet/nucleotide/rna4.hpp>
 #include <seqan3/core/char_operations/predicate.hpp>
+#include <seqan3/core/detail/debug_stream_range.hpp>
 
 #include "../alphabet_constexpr_test_template.hpp"
 #include "../alphabet_test_template.hpp"

--- a/test/unit/alphabet/nucleotide/rna5_test.cpp
+++ b/test/unit/alphabet/nucleotide/rna5_test.cpp
@@ -7,6 +7,7 @@
 
 #include <seqan3/alphabet/nucleotide/rna5.hpp>
 #include <seqan3/core/char_operations/predicate.hpp>
+#include <seqan3/core/detail/debug_stream_range.hpp>
 
 #include "../alphabet_constexpr_test_template.hpp"
 #include "../alphabet_test_template.hpp"

--- a/test/unit/alphabet/nucleotide/sam_dna16_test.cpp
+++ b/test/unit/alphabet/nucleotide/sam_dna16_test.cpp
@@ -7,6 +7,7 @@
 
 #include <seqan3/alphabet/nucleotide/sam_dna16.hpp>
 #include <seqan3/core/char_operations/predicate.hpp>
+#include <seqan3/core/detail/debug_stream_range.hpp>
 
 #include "../alphabet_constexpr_test_template.hpp"
 #include "../alphabet_test_template.hpp"

--- a/test/unit/alphabet/quality/phred42_test.cpp
+++ b/test/unit/alphabet/quality/phred42_test.cpp
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 
 #include <seqan3/alphabet/quality/phred42.hpp>
+#include <seqan3/core/detail/debug_stream_range.hpp>
 
 #include "../alphabet_constexpr_test_template.hpp"
 #include "../alphabet_test_template.hpp"

--- a/test/unit/alphabet/quality/phred63_test.cpp
+++ b/test/unit/alphabet/quality/phred63_test.cpp
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 
 #include <seqan3/alphabet/quality/phred63.hpp>
+#include <seqan3/core/detail/debug_stream_range.hpp>
 
 #include "../alphabet_constexpr_test_template.hpp"
 #include "../alphabet_test_template.hpp"

--- a/test/unit/alphabet/quality/phred68legacy_test.cpp
+++ b/test/unit/alphabet/quality/phred68legacy_test.cpp
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 
 #include <seqan3/alphabet/quality/phred68legacy.hpp>
+#include <seqan3/core/detail/debug_stream_range.hpp>
 
 #include "../alphabet_constexpr_test_template.hpp"
 #include "../alphabet_test_template.hpp"

--- a/test/unit/alphabet/semi_alphabet_test_template.hpp
+++ b/test/unit/alphabet/semi_alphabet_test_template.hpp
@@ -10,6 +10,7 @@
 #include <seqan3/alphabet/concept.hpp>
 #include <seqan3/alphabet/exception.hpp>
 #include <seqan3/core/concept/core_language.hpp>
+#include <seqan3/core/detail/debug_stream_alphabet.hpp>
 #include <seqan3/test/pretty_printing.hpp>
 
 template <typename T>

--- a/test/unit/alphabet/structure/dot_bracket3_test.cpp
+++ b/test/unit/alphabet/structure/dot_bracket3_test.cpp
@@ -7,6 +7,7 @@
 
 #include <seqan3/alphabet/structure/concept.hpp>
 #include <seqan3/alphabet/structure/dot_bracket3.hpp>
+#include <seqan3/core/detail/debug_stream_range.hpp>
 #include <seqan3/range/views/zip.hpp>
 
 #include "../alphabet_constexpr_test_template.hpp"

--- a/test/unit/alphabet/structure/dssp9_test.cpp
+++ b/test/unit/alphabet/structure/dssp9_test.cpp
@@ -6,6 +6,7 @@
 // -----------------------------------------------------------------------------------------------------
 
 #include <seqan3/alphabet/structure/dssp9.hpp>
+#include <seqan3/core/detail/debug_stream_range.hpp>
 #include <seqan3/range/views/zip.hpp>
 
 #include "../alphabet_constexpr_test_template.hpp"

--- a/test/unit/alphabet/structure/wuss_test.cpp
+++ b/test/unit/alphabet/structure/wuss_test.cpp
@@ -7,6 +7,8 @@
 
 #include <seqan3/alphabet/structure/concept.hpp>
 #include <seqan3/alphabet/structure/wuss.hpp>
+#include <seqan3/core/detail/debug_stream_optional.hpp>
+#include <seqan3/core/detail/debug_stream_range.hpp>
 #include <seqan3/range/views/zip.hpp>
 
 #include "../alphabet_constexpr_test_template.hpp"

--- a/test/unit/core/simd/view_to_simd_test.cpp
+++ b/test/unit/core/simd/view_to_simd_test.cpp
@@ -5,11 +5,15 @@
 // shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 // -----------------------------------------------------------------------------------------------------
 
+#include <gtest/gtest.h>
+
+#include <seqan3/std/algorithm>
+#include <seqan3/std/concepts>
 #include <deque>
+#include <seqan3/std/iterator>
+#include <seqan3/std/ranges>
 #include <tuple>
 #include <vector>
-
-#include <gtest/gtest.h>
 
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/core/bit_manipulation.hpp>
@@ -19,11 +23,6 @@
 #include <seqan3/core/simd/view_to_simd.hpp>
 #include <seqan3/range/container/aligned_allocator.hpp>
 #include <seqan3/range/views/type_reduce.hpp>
-#include <seqan3/std/algorithm>
-#include <seqan3/std/concepts>
-#include <seqan3/std/iterator>
-#include <seqan3/std/ranges>
-
 #include <seqan3/test/performance/sequence_generator.hpp>
 #include <seqan3/test/pretty_printing.hpp>
 #include <seqan3/test/simd_utility.hpp>

--- a/test/unit/core/simd/view_to_simd_test.cpp
+++ b/test/unit/core/simd/view_to_simd_test.cpp
@@ -13,6 +13,7 @@
 
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/core/bit_manipulation.hpp>
+#include <seqan3/core/simd/debug_stream_simd.hpp>
 #include <seqan3/core/simd/simd_traits.hpp>
 #include <seqan3/core/simd/simd.hpp>
 #include <seqan3/core/simd/view_to_simd.hpp>

--- a/test/unit/io/alignment_file/alignment_file_format_test_template.hpp
+++ b/test/unit/io/alignment_file/alignment_file_format_test_template.hpp
@@ -15,8 +15,8 @@
 #include <seqan3/core/detail/debug_stream_tuple.hpp>
 #include <seqan3/core/detail/debug_stream_variant.hpp>
 #include <seqan3/io/alignment_file/input_format_concept.hpp>
-#include <seqan3/io/alignment_file/output_format_concept.hpp>
 #include <seqan3/io/alignment_file/input.hpp>
+#include <seqan3/io/alignment_file/output_format_concept.hpp>
 #include <seqan3/io/alignment_file/output.hpp>
 #include <seqan3/range/views/take.hpp>
 #include <seqan3/test/expect_range_eq.hpp>

--- a/test/unit/io/alignment_file/alignment_file_format_test_template.hpp
+++ b/test/unit/io/alignment_file/alignment_file_format_test_template.hpp
@@ -10,6 +10,10 @@
 #include <gtest/gtest.h>
 
 #include <seqan3/alphabet/quality/all.hpp>
+#include <seqan3/core/detail/debug_stream_alphabet.hpp>
+#include <seqan3/core/detail/debug_stream_optional.hpp>
+#include <seqan3/core/detail/debug_stream_tuple.hpp>
+#include <seqan3/core/detail/debug_stream_variant.hpp>
 #include <seqan3/io/alignment_file/input_format_concept.hpp>
 #include <seqan3/io/alignment_file/output_format_concept.hpp>
 #include <seqan3/io/alignment_file/input.hpp>

--- a/test/unit/io/alignment_file/alignment_file_input_test.cpp
+++ b/test/unit/io/alignment_file/alignment_file_input_test.cpp
@@ -5,17 +5,17 @@
 // shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 // -----------------------------------------------------------------------------------------------------
 
-#include <sstream>
-
 #include <gtest/gtest.h>
+
+#include <seqan3/std/algorithm>
+#include <seqan3/std/iterator>
+#include <seqan3/std/ranges>
+#include <sstream>
 
 #include <seqan3/alphabet/quality/phred42.hpp>
 #include <seqan3/core/detail/debug_stream_alphabet.hpp>
 #include <seqan3/io/alignment_file/input.hpp>
 #include <seqan3/range/views/convert.hpp>
-#include <seqan3/std/algorithm>
-#include <seqan3/std/iterator>
-#include <seqan3/std/ranges>
 #include <seqan3/test/tmp_filename.hpp>
 
 using seqan3::operator""_dna4;

--- a/test/unit/io/alignment_file/alignment_file_input_test.cpp
+++ b/test/unit/io/alignment_file/alignment_file_input_test.cpp
@@ -10,6 +10,7 @@
 #include <gtest/gtest.h>
 
 #include <seqan3/alphabet/quality/phred42.hpp>
+#include <seqan3/core/detail/debug_stream_alphabet.hpp>
 #include <seqan3/io/alignment_file/input.hpp>
 #include <seqan3/range/views/convert.hpp>
 #include <seqan3/std/algorithm>

--- a/test/unit/io/record_test.cpp
+++ b/test/unit/io/record_test.cpp
@@ -13,6 +13,7 @@
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/alphabet/quality/phred42.hpp>
 #include <seqan3/core/concept/tuple.hpp>
+#include <seqan3/core/detail/debug_stream_alphabet.hpp>
 #include <seqan3/io/detail/record.hpp>
 #include <seqan3/io/record.hpp>
 #include <seqan3/test/expect_range_eq.hpp>

--- a/test/unit/io/sequence_file/sequence_file_format_test_template.hpp
+++ b/test/unit/io/sequence_file/sequence_file_format_test_template.hpp
@@ -14,6 +14,7 @@
 
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
 #include <seqan3/alphabet/quality/all.hpp>
+#include <seqan3/core/detail/debug_stream_alphabet.hpp>
 #include <seqan3/io/sequence_file/all.hpp>
 #include <seqan3/range/views/convert.hpp>
 #include <seqan3/range/views/zip.hpp>

--- a/test/unit/io/sequence_file/sequence_file_format_test_template.hpp
+++ b/test/unit/io/sequence_file/sequence_file_format_test_template.hpp
@@ -5,12 +5,14 @@
 // shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 // -----------------------------------------------------------------------------------------------------
 
+#include <gtest/gtest.h>
+
+#include <seqan3/std/concepts>
+#include <seqan3/std/ranges>
 #include <sstream>
 #include <stdexcept>
 #include <string>
 #include <vector>
-
-#include <gtest/gtest.h>
 
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
 #include <seqan3/alphabet/quality/all.hpp>
@@ -18,8 +20,6 @@
 #include <seqan3/io/sequence_file/all.hpp>
 #include <seqan3/range/views/convert.hpp>
 #include <seqan3/range/views/zip.hpp>
-#include <seqan3/std/ranges>
-#include <seqan3/std/concepts>
 #include <seqan3/test/pretty_printing.hpp>
 
 using seqan3::operator""_dna5;

--- a/test/unit/io/sequence_file/sequence_file_input_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_input_test.cpp
@@ -10,6 +10,7 @@
 #include <gtest/gtest.h>
 
 #include <seqan3/io/sequence_file/input.hpp>
+#include <seqan3/core/detail/debug_stream_alphabet.hpp>
 #include <seqan3/range/views/convert.hpp>
 #include <seqan3/std/algorithm>
 #include <seqan3/std/iterator>

--- a/test/unit/io/sequence_file/sequence_file_input_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_input_test.cpp
@@ -5,16 +5,16 @@
 // shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 // -----------------------------------------------------------------------------------------------------
 
-#include <sstream>
-
 #include <gtest/gtest.h>
+
+#include <seqan3/std/algorithm>
+#include <seqan3/std/iterator>
+#include <seqan3/std/ranges>
+#include <sstream>
 
 #include <seqan3/io/sequence_file/input.hpp>
 #include <seqan3/core/detail/debug_stream_alphabet.hpp>
 #include <seqan3/range/views/convert.hpp>
-#include <seqan3/std/algorithm>
-#include <seqan3/std/iterator>
-#include <seqan3/std/ranges>
 #include <seqan3/test/tmp_filename.hpp>
 
 using seqan3::operator""_dna5;

--- a/test/unit/io/structure_file/format_vienna_test.cpp
+++ b/test/unit/io/structure_file/format_vienna_test.cpp
@@ -5,12 +5,14 @@
 // shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 // -----------------------------------------------------------------------------------------------------
 
+#include <gtest/gtest.h>
+
+#include <seqan3/std/algorithm>
+#include <seqan3/std/iterator>
 #include <set>
 #include <sstream>
 #include <tuple>
 #include <vector>
-
-#include <gtest/gtest.h>
 
 #include <seqan3/alphabet/nucleotide/rna15.hpp>
 #include <seqan3/alphabet/nucleotide/rna5.hpp>
@@ -19,8 +21,6 @@
 #include <seqan3/core/detail/debug_stream_alphabet.hpp>
 #include <seqan3/io/structure_file/all.hpp>
 #include <seqan3/range/views/convert.hpp>
-#include <seqan3/std/algorithm>
-#include <seqan3/std/iterator>
 #include <seqan3/test/expect_range_eq.hpp>
 
 using seqan3::operator""_rna5;

--- a/test/unit/io/structure_file/format_vienna_test.cpp
+++ b/test/unit/io/structure_file/format_vienna_test.cpp
@@ -14,8 +14,8 @@
 
 #include <seqan3/alphabet/nucleotide/rna15.hpp>
 #include <seqan3/alphabet/nucleotide/rna5.hpp>
-#include <seqan3/alphabet/structure/wuss.hpp>
 #include <seqan3/alphabet/structure/structured_rna.hpp>
+#include <seqan3/alphabet/structure/wuss.hpp>
 #include <seqan3/core/detail/debug_stream_alphabet.hpp>
 #include <seqan3/io/structure_file/all.hpp>
 #include <seqan3/range/views/convert.hpp>

--- a/test/unit/io/structure_file/format_vienna_test.cpp
+++ b/test/unit/io/structure_file/format_vienna_test.cpp
@@ -16,6 +16,7 @@
 #include <seqan3/alphabet/nucleotide/rna5.hpp>
 #include <seqan3/alphabet/structure/wuss.hpp>
 #include <seqan3/alphabet/structure/structured_rna.hpp>
+#include <seqan3/core/detail/debug_stream_alphabet.hpp>
 #include <seqan3/io/structure_file/all.hpp>
 #include <seqan3/range/views/convert.hpp>
 #include <seqan3/std/algorithm>

--- a/test/unit/io/structure_file/structure_file_input_test.cpp
+++ b/test/unit/io/structure_file/structure_file_input_test.cpp
@@ -14,6 +14,7 @@
 #include <range/v3/view/map.hpp>
 
 #include <seqan3/alphabet/nucleotide/rna4.hpp>
+#include <seqan3/core/detail/debug_stream_alphabet.hpp>
 #include <seqan3/io/structure_file/input.hpp>
 #include <seqan3/range/views/convert.hpp>
 #include <seqan3/std/algorithm>

--- a/test/unit/io/structure_file/structure_file_input_test.cpp
+++ b/test/unit/io/structure_file/structure_file_input_test.cpp
@@ -5,21 +5,18 @@
 // shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 // -----------------------------------------------------------------------------------------------------
 
-#include <iterator>
-#include <fstream>
-#include <sstream>
-
 #include <gtest/gtest.h>
 
-#include <range/v3/view/map.hpp>
+#include <seqan3/std/algorithm>
+#include <fstream>
+#include <seqan3/std/iterator>
+#include <seqan3/std/ranges>
+#include <sstream>
 
 #include <seqan3/alphabet/nucleotide/rna4.hpp>
 #include <seqan3/core/detail/debug_stream_alphabet.hpp>
 #include <seqan3/io/structure_file/input.hpp>
 #include <seqan3/range/views/convert.hpp>
-#include <seqan3/std/algorithm>
-#include <seqan3/std/iterator>
-#include <seqan3/std/ranges>
 #include <seqan3/test/tmp_filename.hpp>
 
 using seqan3::operator""_rna5;

--- a/test/unit/range/container/container_of_container_test.cpp
+++ b/test/unit/range/container/container_of_container_test.cpp
@@ -10,6 +10,7 @@
 #include <range/v3/range_traits.hpp>
 
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
+#include <seqan3/core/detail/debug_stream_alphabet.hpp>
 #include <seqan3/range/container/bitcompressed_vector.hpp>
 #include <seqan3/range/container/concatenated_sequences.hpp>
 #include <seqan3/test/cereal.hpp>

--- a/test/unit/range/container/container_test_template.hpp
+++ b/test/unit/range/container/container_test_template.hpp
@@ -12,6 +12,8 @@
 #include <range/v3/view/take.hpp>
 
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
+#include <seqan3/core/detail/debug_stream_alphabet.hpp>
+#include <seqan3/core/detail/debug_stream_range.hpp>
 #include <seqan3/range/container/bitcompressed_vector.hpp>
 #include <seqan3/range/container/small_vector.hpp>
 #include <seqan3/test/cereal.hpp>

--- a/test/unit/range/views/view_as_const_test.cpp
+++ b/test/unit/range/views/view_as_const_test.cpp
@@ -5,9 +5,11 @@
 // shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 // -----------------------------------------------------------------------------------------------------
 
-#include <iostream>
-
 #include <gtest/gtest.h>
+
+#include <seqan3/std/algorithm>
+#include <iostream>
+#include <seqan3/std/ranges>
 
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
 #include <seqan3/core/detail/debug_stream_alphabet.hpp>
@@ -16,8 +18,6 @@
 #include <seqan3/range/views/complement.hpp>
 #include <seqan3/range/views/to.hpp>
 #include <seqan3/range/views/to_lower.hpp>
-#include <seqan3/std/algorithm>
-#include <seqan3/std/ranges>
 
 using seqan3::operator""_dna5;
 

--- a/test/unit/range/views/view_as_const_test.cpp
+++ b/test/unit/range/views/view_as_const_test.cpp
@@ -10,6 +10,7 @@
 #include <gtest/gtest.h>
 
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
+#include <seqan3/core/detail/debug_stream_alphabet.hpp>
 #include <seqan3/range/concept.hpp>
 #include <seqan3/range/views/as_const.hpp>
 #include <seqan3/range/views/complement.hpp>

--- a/test/unit/range/views/view_async_input_buffer_test.cpp
+++ b/test/unit/range/views/view_async_input_buffer_test.cpp
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include <seqan3/alphabet/nucleotide/all.hpp>
+#include <seqan3/core/detail/debug_stream_alphabet.hpp>
 #include <seqan3/range/concept.hpp>
 #include <seqan3/range/views/async_input_buffer.hpp>
 #include <seqan3/range/views/single_pass_input.hpp>

--- a/test/unit/range/views/view_async_input_buffer_test.cpp
+++ b/test/unit/range/views/view_async_input_buffer_test.cpp
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 
 #include <iostream>
+#include <seqan3/std/ranges>
 #include <string>
 #include <vector>
 
@@ -17,7 +18,6 @@
 #include <seqan3/range/views/async_input_buffer.hpp>
 #include <seqan3/range/views/single_pass_input.hpp>
 #include <seqan3/range/views/take.hpp>
-#include <seqan3/std/ranges>
 #include <seqan3/test/expect_range_eq.hpp>
 
 #include "../iterator_test_template.hpp"

--- a/test/unit/range/views/view_char_to_test.cpp
+++ b/test/unit/range/views/view_char_to_test.cpp
@@ -5,17 +5,17 @@
 // shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 // -----------------------------------------------------------------------------------------------------
 
-#include <iostream>
-
 #include <gtest/gtest.h>
+
+#include <seqan3/std/algorithm>
+#include <iostream>
+#include <seqan3/std/ranges>
 
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
 #include <seqan3/core/detail/debug_stream_alphabet.hpp>
 #include <seqan3/range/concept.hpp>
 #include <seqan3/range/views/char_to.hpp>
 #include <seqan3/range/views/to.hpp>
-#include <seqan3/std/algorithm>
-#include <seqan3/std/ranges>
 
 using seqan3::operator""_dna5;
 

--- a/test/unit/range/views/view_char_to_test.cpp
+++ b/test/unit/range/views/view_char_to_test.cpp
@@ -10,6 +10,7 @@
 #include <gtest/gtest.h>
 
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
+#include <seqan3/core/detail/debug_stream_alphabet.hpp>
 #include <seqan3/range/concept.hpp>
 #include <seqan3/range/views/char_to.hpp>
 #include <seqan3/range/views/to.hpp>

--- a/test/unit/range/views/view_complement_test.cpp
+++ b/test/unit/range/views/view_complement_test.cpp
@@ -5,17 +5,17 @@
 // shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 // -----------------------------------------------------------------------------------------------------
 
-#include <iostream>
-
 #include <gtest/gtest.h>
+
+#include <seqan3/std/algorithm>
+#include <iostream>
+#include <seqan3/std/ranges>
 
 #include <seqan3/alphabet/nucleotide/all.hpp>
 #include <seqan3/core/detail/debug_stream_alphabet.hpp>
 #include <seqan3/range/concept.hpp>
 #include <seqan3/range/views/complement.hpp>
 #include <seqan3/range/views/to.hpp>
-#include <seqan3/std/algorithm>
-#include <seqan3/std/ranges>
 
 using seqan3::operator""_dna5;
 

--- a/test/unit/range/views/view_complement_test.cpp
+++ b/test/unit/range/views/view_complement_test.cpp
@@ -10,6 +10,7 @@
 #include <gtest/gtest.h>
 
 #include <seqan3/alphabet/nucleotide/all.hpp>
+#include <seqan3/core/detail/debug_stream_alphabet.hpp>
 #include <seqan3/range/concept.hpp>
 #include <seqan3/range/views/complement.hpp>
 #include <seqan3/range/views/to.hpp>

--- a/test/unit/range/views/view_deep_test.cpp
+++ b/test/unit/range/views/view_deep_test.cpp
@@ -5,17 +5,17 @@
 // shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 // -----------------------------------------------------------------------------------------------------
 
-#include <iostream>
-
 #include <gtest/gtest.h>
+
+#include <seqan3/std/algorithm>
+#include <iostream>
+#include <seqan3/std/ranges>
 
 #include <seqan3/alphabet/nucleotide/all.hpp>
 #include <seqan3/core/detail/debug_stream_alphabet.hpp>
 #include <seqan3/range/concept.hpp>
 #include <seqan3/range/views/deep.hpp>
 #include <seqan3/range/views/to.hpp>
-#include <seqan3/std/algorithm>
-#include <seqan3/std/ranges>
 
 namespace seqan3::views
 {

--- a/test/unit/range/views/view_deep_test.cpp
+++ b/test/unit/range/views/view_deep_test.cpp
@@ -10,6 +10,7 @@
 #include <gtest/gtest.h>
 
 #include <seqan3/alphabet/nucleotide/all.hpp>
+#include <seqan3/core/detail/debug_stream_alphabet.hpp>
 #include <seqan3/range/concept.hpp>
 #include <seqan3/range/views/deep.hpp>
 #include <seqan3/range/views/to.hpp>

--- a/test/unit/range/views/view_interleave_test.cpp
+++ b/test/unit/range/views/view_interleave_test.cpp
@@ -8,6 +8,7 @@
 #include <forward_list>
 
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
+#include <seqan3/core/detail/debug_stream_alphabet.hpp>
 #include <seqan3/range/views/interleave.hpp>
 #include <seqan3/range/views/take.hpp>
 #include <seqan3/range/views/type_reduce.hpp>

--- a/test/unit/range/views/view_interleave_test.cpp
+++ b/test/unit/range/views/view_interleave_test.cpp
@@ -5,18 +5,17 @@
 // shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 // -----------------------------------------------------------------------------------------------------
 
+#include <gtest/gtest.h>
+
 #include <forward_list>
+#include <seqan3/std/ranges>
 
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/core/detail/debug_stream_alphabet.hpp>
 #include <seqan3/range/views/interleave.hpp>
 #include <seqan3/range/views/take.hpp>
 #include <seqan3/range/views/type_reduce.hpp>
-#include <seqan3/std/ranges>
-
 #include <seqan3/test/pretty_printing.hpp>
-
-#include <gtest/gtest.h>
 
 using seqan3::operator""_dna4;
 

--- a/test/unit/range/views/view_istreambuf_test.cpp
+++ b/test/unit/range/views/view_istreambuf_test.cpp
@@ -13,6 +13,7 @@
 
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
 #include <seqan3/core/char_operations/predicate.hpp>
+#include <seqan3/core/detail/debug_stream_alphabet.hpp>
 #include <seqan3/range/views/char_to.hpp>
 #include <seqan3/range/views/complement.hpp>
 #include <seqan3/range/views/istreambuf.hpp>

--- a/test/unit/range/views/view_minimiser_test.cpp
+++ b/test/unit/range/views/view_minimiser_test.cpp
@@ -10,6 +10,7 @@
 #include <type_traits>
 
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
+#include <seqan3/core/detail/debug_stream_alphabet.hpp>
 #include <seqan3/range/container/bitcompressed_vector.hpp>
 #include <seqan3/range/views/complement.hpp>
 #include <seqan3/range/views/drop.hpp>

--- a/test/unit/range/views/view_move_test.cpp
+++ b/test/unit/range/views/view_move_test.cpp
@@ -5,9 +5,11 @@
 // shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 // -----------------------------------------------------------------------------------------------------
 
-#include <iostream>
-
 #include <gtest/gtest.h>
+
+#include <seqan3/std/algorithm>
+#include <iostream>
+#include <seqan3/std/ranges>
 
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
 #include <seqan3/core/detail/debug_stream_alphabet.hpp>
@@ -16,8 +18,6 @@
 #include <seqan3/range/views/complement.hpp>
 #include <seqan3/range/views/to.hpp>
 #include <seqan3/range/views/to_lower.hpp>
-#include <seqan3/std/algorithm>
-#include <seqan3/std/ranges>
 
 using seqan3::operator""_dna5;
 

--- a/test/unit/range/views/view_move_test.cpp
+++ b/test/unit/range/views/view_move_test.cpp
@@ -10,6 +10,7 @@
 #include <gtest/gtest.h>
 
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
+#include <seqan3/core/detail/debug_stream_alphabet.hpp>
 #include <seqan3/range/concept.hpp>
 #include <seqan3/range/views/move.hpp>
 #include <seqan3/range/views/complement.hpp>

--- a/test/unit/range/views/view_pairwise_combine_test.cpp
+++ b/test/unit/range/views/view_pairwise_combine_test.cpp
@@ -16,6 +16,7 @@
 #include <range/v3/view/filter.hpp>
 
 #include <seqan3/core/type_traits/range.hpp>
+#include <seqan3/core/detail/debug_stream_tuple.hpp>
 #include <seqan3/range/views/pairwise_combine.hpp>
 #include <seqan3/range/views/take.hpp>
 #include <seqan3/test/pretty_printing.hpp>

--- a/test/unit/range/views/view_translate_join_test.cpp
+++ b/test/unit/range/views/view_translate_join_test.cpp
@@ -14,6 +14,7 @@
 
 #include <seqan3/alphabet/nucleotide/all.hpp>
 #include <seqan3/alphabet/aminoacid/aa27.hpp>
+#include <seqan3/core/detail/debug_stream_alphabet.hpp>
 #include <seqan3/range/concept.hpp>
 #include <seqan3/range/views/char_to.hpp>
 #include <seqan3/range/views/complement.hpp>

--- a/test/unit/range/views/view_translate_join_test.cpp
+++ b/test/unit/range/views/view_translate_join_test.cpp
@@ -12,8 +12,8 @@
 #include <string>
 #include <vector>
 
-#include <seqan3/alphabet/nucleotide/all.hpp>
 #include <seqan3/alphabet/aminoacid/aa27.hpp>
+#include <seqan3/alphabet/nucleotide/all.hpp>
 #include <seqan3/core/detail/debug_stream_alphabet.hpp>
 #include <seqan3/range/concept.hpp>
 #include <seqan3/range/views/char_to.hpp>

--- a/test/unit/range/views/view_translate_test.cpp
+++ b/test/unit/range/views/view_translate_test.cpp
@@ -7,7 +7,9 @@
 
 #include <gtest/gtest.h>
 
+#include <seqan3/std/algorithm>
 #include <iostream>
+#include <seqan3/std/ranges>
 #include <string>
 #include <vector>
 
@@ -20,8 +22,6 @@
 #include <seqan3/range/views/complement.hpp>
 #include <seqan3/range/views/to.hpp>
 #include <seqan3/range/views/translate.hpp>
-#include <seqan3/std/algorithm>
-#include <seqan3/std/ranges>
 
 using seqan3::operator""_aa27;
 

--- a/test/unit/range/views/view_translate_test.cpp
+++ b/test/unit/range/views/view_translate_test.cpp
@@ -13,6 +13,7 @@
 
 #include <seqan3/alphabet/nucleotide/all.hpp>
 #include <seqan3/alphabet/aminoacid/aa27.hpp>
+#include <seqan3/core/detail/debug_stream_alphabet.hpp>
 #include <seqan3/range/concept.hpp>
 #include <seqan3/range/container/concatenated_sequences.hpp>
 #include <seqan3/range/views/char_to.hpp>

--- a/test/unit/range/views/view_translate_test.cpp
+++ b/test/unit/range/views/view_translate_test.cpp
@@ -11,8 +11,8 @@
 #include <string>
 #include <vector>
 
-#include <seqan3/alphabet/nucleotide/all.hpp>
 #include <seqan3/alphabet/aminoacid/aa27.hpp>
+#include <seqan3/alphabet/nucleotide/all.hpp>
 #include <seqan3/core/detail/debug_stream_alphabet.hpp>
 #include <seqan3/range/concept.hpp>
 #include <seqan3/range/container/concatenated_sequences.hpp>

--- a/test/unit/search/fm_index_cursor/bi_fm_index_cursor_collection_test_template.hpp
+++ b/test/unit/search/fm_index_cursor/bi_fm_index_cursor_collection_test_template.hpp
@@ -6,13 +6,14 @@
 // -----------------------------------------------------------------------------------------------------
 
 #include <gtest/gtest.h>
+
+#include <seqan3/std/algorithm>
 #include <type_traits>
 
 #include <seqan3/core/detail/debug_stream_alphabet.hpp>
 #include <seqan3/core/detail/debug_stream_tuple.hpp>
 #include <seqan3/range/views/slice.hpp>
 #include <seqan3/search/fm_index/bi_fm_index_cursor.hpp>
-#include <seqan3/std/algorithm>
 #include <seqan3/test/expect_range_eq.hpp>
 
 #include "../helper.hpp"

--- a/test/unit/search/fm_index_cursor/bi_fm_index_cursor_collection_test_template.hpp
+++ b/test/unit/search/fm_index_cursor/bi_fm_index_cursor_collection_test_template.hpp
@@ -8,6 +8,8 @@
 #include <gtest/gtest.h>
 #include <type_traits>
 
+#include <seqan3/core/detail/debug_stream_alphabet.hpp>
+#include <seqan3/core/detail/debug_stream_tuple.hpp>
 #include <seqan3/range/views/slice.hpp>
 #include <seqan3/search/fm_index/bi_fm_index_cursor.hpp>
 #include <seqan3/std/algorithm>

--- a/test/unit/search/fm_index_cursor/bi_fm_index_cursor_test_template.hpp
+++ b/test/unit/search/fm_index_cursor/bi_fm_index_cursor_test_template.hpp
@@ -6,13 +6,14 @@
 // -----------------------------------------------------------------------------------------------------
 
 #include <gtest/gtest.h>
+
+#include <seqan3/std/algorithm>
 #include <type_traits>
 
 #include <seqan3/core/detail/debug_stream_alphabet.hpp>
 #include <seqan3/core/detail/debug_stream_tuple.hpp>
 #include <seqan3/range/views/slice.hpp>
 #include <seqan3/search/fm_index/bi_fm_index_cursor.hpp>
-#include <seqan3/std/algorithm>
 #include <seqan3/test/expect_range_eq.hpp>
 
 #include "../helper.hpp"

--- a/test/unit/search/fm_index_cursor/bi_fm_index_cursor_test_template.hpp
+++ b/test/unit/search/fm_index_cursor/bi_fm_index_cursor_test_template.hpp
@@ -8,6 +8,8 @@
 #include <gtest/gtest.h>
 #include <type_traits>
 
+#include <seqan3/core/detail/debug_stream_alphabet.hpp>
+#include <seqan3/core/detail/debug_stream_tuple.hpp>
 #include <seqan3/range/views/slice.hpp>
 #include <seqan3/search/fm_index/bi_fm_index_cursor.hpp>
 #include <seqan3/std/algorithm>

--- a/test/unit/search/fm_index_cursor/fm_index_cursor_collection_test.cpp
+++ b/test/unit/search/fm_index_cursor/fm_index_cursor_collection_test.cpp
@@ -11,6 +11,8 @@
 
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
+#include <seqan3/core/detail/debug_stream_alphabet.hpp>
+#include <seqan3/core/detail/debug_stream_tuple.hpp>
 #include <seqan3/range/views/char_to.hpp>
 
 #include "fm_index_cursor_collection_test_template.hpp"

--- a/test/unit/search/fm_index_cursor/fm_index_cursor_test.cpp
+++ b/test/unit/search/fm_index_cursor/fm_index_cursor_test.cpp
@@ -10,6 +10,8 @@
 
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
+#include <seqan3/core/detail/debug_stream_alphabet.hpp>
+#include <seqan3/core/detail/debug_stream_tuple.hpp>
 #include <seqan3/range/views/char_to.hpp>
 
 #include "fm_index_cursor_test_template.hpp"

--- a/test/unit/search/search_collection_test.cpp
+++ b/test/unit/search/search_collection_test.cpp
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <type_traits>
 
+#include <seqan3/core/detail/debug_stream_tuple.hpp>
 #include <seqan3/range/views/persist.hpp>
 #include <seqan3/search/fm_index/bi_fm_index.hpp>
 #include <seqan3/search/fm_index/fm_index.hpp>

--- a/test/unit/test/pretty_printing_test.cpp
+++ b/test/unit/test/pretty_printing_test.cpp
@@ -11,6 +11,11 @@
 #include <variant>
 
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
+#include <seqan3/core/detail/debug_stream_alphabet.hpp>
+#include <seqan3/core/detail/debug_stream_optional.hpp>
+#include <seqan3/core/detail/debug_stream_range.hpp>
+#include <seqan3/core/detail/debug_stream_tuple.hpp>
+#include <seqan3/core/detail/debug_stream_variant.hpp>
 #include <seqan3/test/pretty_printing.hpp>
 
 using seqan3::operator""_dna4;


### PR DESCRIPTION
Part of https://github.com/seqan/product_backlog/issues/167

----

Note that currently all of these includes are redundant, because they are implicitly included via 

https://github.com/seqan/seqan3/blob/b2c11071fda50e32dff2b0a88af86e08c8c30780/include/seqan3/core/debug_stream.hpp#L17-L23

which in most cases are included by

https://github.com/seqan/seqan3/blob/b2c11071fda50e32dff2b0a88af86e08c8c30780/test/include/seqan3/test/pretty_printing.hpp#L17

or by

https://github.com/seqan/seqan3/blob/b2c11071fda50e32dff2b0a88af86e08c8c30780/include/seqan3/core/detail/to_string.hpp#L15

But, this will change in a later PR that changes the includes above to `#include <seqan3/core/detail/debug_stream_type.hpp>`. 

This split in the patch series was done to make the review process easier.