### PR TITLE
[TEST] iterator_test_template

### DIFF
--- a/test/unit/range/iterator_test_template.hpp
+++ b/test/unit/range/iterator_test_template.hpp
@@ -54,7 +54,7 @@ SEQAN3_CONCEPT has_expect_equal_member_function = requires(t & a)
 
 // Delegates to the test fixture member function `expect_eq` if available and falls back to EXPECT_EQ otherwise.
 template <typename T, typename A, typename B>
-void expext_eq(A && a, B && b)
+void expect_iter_value_equal(A && a, B && b)
 {
     if constexpr (has_expect_equal_member_function<iterator_fixture<T>>)
         iterator_fixture<std::remove_reference_t<T>>::expect_eq(a, b);
@@ -149,10 +149,10 @@ TYPED_TEST_P(iterator_fixture, const_non_const_compatibility)
 
 TYPED_TEST_P(iterator_fixture, dereference)
 {
-    expext_eq<TypeParam>(*std::ranges::begin(this->test_range), *std::ranges::begin(this->expected_range));
+    expect_iter_value_equal<TypeParam>(*std::ranges::begin(this->test_range), *std::ranges::begin(this->expected_range));
 
     if constexpr (TestFixture::const_iterable)
-        expext_eq<TypeParam>(*std::ranges::cbegin(this->test_range), *std::ranges::begin(this->expected_range));
+        expect_iter_value_equal<TypeParam>(*std::ranges::cbegin(this->test_range), *std::ranges::begin(this->expected_range));
 }
 
 TYPED_TEST_P(iterator_fixture, compare)
@@ -202,7 +202,7 @@ inline void move_forward_pre_test(it_begin_t && it_begin, it_sentinel_t && it_en
     auto rng_it = std::ranges::begin(rng);
     auto rng_it_end = std::ranges::end(rng);
     for (auto it = it_begin; it != it_end && rng_it != rng_it_end; ++it, ++rng_it)
-        expext_eq<test_type>(*it, *rng_it);
+        expect_iter_value_equal<test_type>(*it, *rng_it);
 }
 
 template <typename test_type, typename it_begin_t, typename it_sentinel_t, typename rng_t>
@@ -212,7 +212,7 @@ inline void move_forward_post_test(it_begin_t && it_begin, it_sentinel_t && it_e
     auto rng_it = std::ranges::begin(rng);
     auto rng_it_end = std::ranges::end(rng);
     for (auto it = it_begin; it != it_end && rng_it != rng_it_end; it++, ++rng_it)
-        expext_eq<test_type>(*it, *rng_it);
+        expect_iter_value_equal<test_type>(*it, *rng_it);
 }
 
 TYPED_TEST_P(iterator_fixture, move_forward_pre)
@@ -278,11 +278,11 @@ inline void move_backward_pre_test(it_begin_t && it_begin, it_sentinel_t && it_e
          it != it_begin && rng_it != rng_it_begin;
          --rng_it)
     {
-       expext_eq<test_type>(*it, *rng_it);
+       expect_iter_value_equal<test_type>(*it, *rng_it);
        --it;
     }
 
-    expext_eq<test_type>(*it_begin, *rng_it_begin);
+    expect_iter_value_equal<test_type>(*it_begin, *rng_it_begin);
 }
 
 template <typename test_type, typename it_begin_t, typename it_sentinel_t, typename rng_t>
@@ -297,10 +297,10 @@ inline void move_backward_post_test(it_begin_t && it_begin, it_sentinel_t && it_
          it != it_begin && rng_it != rng_it_begin;
          --rng_it)
     {
-       expext_eq<test_type>(*(it--), *rng_it);
+       expect_iter_value_equal<test_type>(*(it--), *rng_it);
     }
 
-    expext_eq<test_type>(*it_begin, *rng_it_begin);
+    expect_iter_value_equal<test_type>(*it_begin, *rng_it_begin);
 }
 
 TYPED_TEST_P(iterator_fixture, move_backward_pre)
@@ -346,22 +346,22 @@ inline void jump_forward_test(it_begin_t && it_begin, rng_t && rng)
     for (size_t n = 0; n < sz; ++n)
     {
         auto it = it_begin;
-        expext_eq<test_type>(rng[n], *(it += n));
-        expext_eq<test_type>(rng[n], *(it));
+        expect_iter_value_equal<test_type>(rng[n], *(it += n));
+        expect_iter_value_equal<test_type>(rng[n], *(it));
     }
 
     // Forward copy
     for (size_t n = 0; n < sz; ++n)
     {
-        expext_eq<test_type>(rng[n], *(it_begin + n));
-        expext_eq<test_type>(rng[0], *it_begin);
+        expect_iter_value_equal<test_type>(rng[n], *(it_begin + n));
+        expect_iter_value_equal<test_type>(rng[0], *it_begin);
     }
 
     // Forward copy friend
     for (size_t n = 0; n < sz; ++n)
     {
-        expext_eq<test_type>(rng[n], *(n + it_begin));
-        expext_eq<test_type>(rng[0], *it_begin);
+        expect_iter_value_equal<test_type>(rng[n], *(n + it_begin));
+        expect_iter_value_equal<test_type>(rng[0], *it_begin);
     }
 }
 
@@ -387,22 +387,22 @@ inline void jump_backward_test(it_begin_t && it_begin, rng_t && rng)
     for (size_t n = 0; n < sz; ++n)
     {
         auto it = pre_end_it;
-        expext_eq<test_type>(rng[sz - 1 - n], *(it -= n));
-        expext_eq<test_type>(rng[sz - 1 - n], *it);
+        expect_iter_value_equal<test_type>(rng[sz - 1 - n], *(it -= n));
+        expect_iter_value_equal<test_type>(rng[sz - 1 - n], *it);
     }
 
     // Backward copy
     for (size_t n = 0; n < sz; ++n)
     {
-        expext_eq<test_type>(rng[sz - n - 1], *(pre_end_it - n));
-        expext_eq<test_type>(rng[sz - 1], *pre_end_it);
+        expect_iter_value_equal<test_type>(rng[sz - n - 1], *(pre_end_it - n));
+        expect_iter_value_equal<test_type>(rng[sz - 1], *pre_end_it);
     }
 
     // Backward copy friend through (-n) + it
     for (size_t n = 0; n < sz; ++n)
     {
-        expext_eq<test_type>(rng[sz - n - 1], *((-1 * n) + pre_end_it));
-        expext_eq<test_type>(rng[sz - 1], *pre_end_it);
+        expect_iter_value_equal<test_type>(rng[sz - n - 1], *((-1 * n) + pre_end_it));
+        expect_iter_value_equal<test_type>(rng[sz - 1], *pre_end_it);
     }
 }
 
@@ -423,7 +423,7 @@ inline void jump_random_test(it_begin_t && it_begin, rng_t && rng)
     size_t sz = std::ranges::distance(rng);
 
     for (size_t n = 0; n < sz; ++n)
-        expext_eq<test_type>(rng[n], it_begin[n]);
+        expect_iter_value_equal<test_type>(rng[n], it_begin[n]);
 }
 
 TYPED_TEST_P(iterator_fixture, jump_random)

--- a/test/unit/range/iterator_test_template.hpp
+++ b/test/unit/range/iterator_test_template.hpp
@@ -245,15 +245,28 @@ TYPED_TEST_P(iterator_fixture, move_forward_pre)
                                      std::ranges::end(this->test_range),
                                      this->expected_range);
 
-    if constexpr (std::derived_from<typename TestFixture::iterator_tag, std::forward_iterator_tag>) // iterate over it again
+    // iterate over it again
+    if constexpr (std::derived_from<typename TestFixture::iterator_tag, std::forward_iterator_tag>)
         move_forward_pre_test<TypeParam>(std::ranges::begin(this->test_range),
                                          std::ranges::end(this->test_range),
                                          this->expected_range);
+}
 
+TYPED_TEST_P(iterator_fixture, move_forward_pre_const)
+{
     if constexpr (TestFixture::const_iterable)
+    {
         move_forward_pre_test<TypeParam>(std::ranges::cbegin(this->test_range),
                                          std::ranges::cend(this->test_range),
                                          this->expected_range);
+
+         // iterate over it again
+        if constexpr (std::derived_from<typename TestFixture::iterator_tag, std::forward_iterator_tag>)
+            move_forward_pre_test<TypeParam>(std::ranges::cbegin(this->test_range),
+                                             std::ranges::cend(this->test_range),
+                                             this->expected_range);
+
+    }
 }
 
 TYPED_TEST_P(iterator_fixture, move_forward_post)
@@ -262,15 +275,27 @@ TYPED_TEST_P(iterator_fixture, move_forward_post)
                                       std::ranges::end(this->test_range),
                                       this->expected_range);
 
-    if constexpr (std::derived_from<typename TestFixture::iterator_tag, std::forward_iterator_tag>) // iterate over it again
+    // iterate over it again
+    if constexpr (std::derived_from<typename TestFixture::iterator_tag, std::forward_iterator_tag>)
         move_forward_post_test<TypeParam>(std::ranges::begin(this->test_range),
                                           std::ranges::end(this->test_range),
                                           this->expected_range);
+}
 
+TYPED_TEST_P(iterator_fixture, move_forward_post_const)
+{
     if constexpr (TestFixture::const_iterable)
+    {
         move_forward_post_test<TypeParam>(std::ranges::cbegin(this->test_range),
                                           std::ranges::cend(this->test_range),
                                           this->expected_range);
+
+        // iterate over it again
+        if constexpr (std::derived_from<typename TestFixture::iterator_tag, std::forward_iterator_tag>)
+            move_forward_post_test<TypeParam>(std::ranges::cbegin(this->test_range),
+                                              std::ranges::cend(this->test_range),
+                                              this->expected_range);
+    }
 }
 
 // ---------------------------------------------------------------------------------------------------------------------
@@ -623,7 +648,9 @@ REGISTER_TYPED_TEST_SUITE_P(iterator_fixture,
                             dereference,
                             compare,
                             move_forward_pre,
+                            move_forward_pre_const,
                             move_forward_post,
+                            move_forward_post_const,
                             move_backward_pre,
                             move_backward_post,
                             jump_forward,

--- a/test/unit/range/iterator_test_template.hpp
+++ b/test/unit/range/iterator_test_template.hpp
@@ -88,43 +88,28 @@ TYPED_TEST_P(iterator_fixture, concept_check)
                   "the returned iterator must model std::input_iterator.");
     EXPECT_TRUE(std::input_iterator<iterator_type>);
 
-    if constexpr (std::derived_from<typename TestFixture::iterator_tag, std::forward_iterator_tag>)
+    EXPECT_EQ(std::forward_iterator<iterator_type>,
+              (std::derived_from<typename TestFixture::iterator_tag, std::forward_iterator_tag>));
+
+    EXPECT_EQ(std::bidirectional_iterator<iterator_type>,
+              (std::derived_from<typename TestFixture::iterator_tag, std::bidirectional_iterator_tag>));
+
+    EXPECT_EQ(std::random_access_iterator<iterator_type>,
+              (std::derived_from<typename TestFixture::iterator_tag, std::random_access_iterator_tag>));
+
+    if constexpr (TestFixture::const_iterable)
     {
-        static_assert(std::forward_iterator<decltype(std::ranges::begin(this->expected_range))>,
-                      "expected_range must have a begin member function and "
-                      "the returned iterator must model std::forward_iterator.");
-        EXPECT_TRUE(std::forward_iterator<iterator_type>);
+        using const_iterator_type = decltype(std::ranges::cbegin(this->test_range));
+        EXPECT_TRUE(std::input_iterator<const_iterator_type>);
 
-        if constexpr (TestFixture::const_iterable)
-        {
-            EXPECT_TRUE(std::forward_iterator<decltype(std::ranges::cbegin(this->test_range))>);
-        }
-    }
+        EXPECT_EQ(std::forward_iterator<const_iterator_type>,
+                  (std::derived_from<typename TestFixture::iterator_tag, std::forward_iterator_tag>));
 
-    if constexpr (std::derived_from<typename TestFixture::iterator_tag, std::bidirectional_iterator_tag>)
-    {
-        static_assert(std::bidirectional_iterator<decltype(std::ranges::begin(this->expected_range))>,
-                      "expected_range must have a begin member function and "
-                      "the returned iterator must model std::bidirectional_iterator.");
-        EXPECT_TRUE(std::bidirectional_iterator<iterator_type>);
+        EXPECT_EQ(std::bidirectional_iterator<const_iterator_type>,
+                  (std::derived_from<typename TestFixture::iterator_tag, std::bidirectional_iterator_tag>));
 
-        if constexpr (TestFixture::const_iterable)
-        {
-            EXPECT_TRUE(std::bidirectional_iterator<decltype(std::ranges::cbegin(this->test_range))>);
-        }
-    }
-
-    if constexpr (std::derived_from<typename TestFixture::iterator_tag, std::random_access_iterator_tag>)
-    {
-        static_assert(std::random_access_iterator<decltype(std::ranges::begin(this->expected_range))>,
-                      "expected_range must have a begin member function and "
-                      "the returned iterator must model std::random_access_iterator.");
-        EXPECT_TRUE(std::random_access_iterator<iterator_type>);
-
-        if constexpr (TestFixture::const_iterable)
-        {
-            EXPECT_TRUE(std::random_access_iterator<decltype(std::ranges::cbegin(this->test_range))>);
-        }
+        EXPECT_EQ(std::random_access_iterator<const_iterator_type>,
+                  (std::derived_from<typename TestFixture::iterator_tag, std::random_access_iterator_tag>));
     }
 
     if (!std::derived_from<typename TestFixture::iterator_tag, std::input_iterator_tag>)

--- a/test/unit/range/iterator_test_template.hpp
+++ b/test/unit/range/iterator_test_template.hpp
@@ -149,40 +149,40 @@ TYPED_TEST_P(iterator_fixture, dereference)
 TYPED_TEST_P(iterator_fixture, compare)
 {
     EXPECT_FALSE(std::ranges::begin(this->test_range) == std::ranges::end(this->test_range));
-    EXPECT_TRUE(std::ranges::begin(this->test_range)  != std::ranges::end(this->test_range));
-    EXPECT_FALSE(std::ranges::end(this->test_range)   == std::ranges::begin(this->test_range));
-    EXPECT_TRUE(std::ranges::end(this->test_range)    != std::ranges::begin(this->test_range));
+    EXPECT_TRUE(std::ranges::begin(this->test_range) != std::ranges::end(this->test_range));
+    EXPECT_FALSE(std::ranges::end(this->test_range) == std::ranges::begin(this->test_range));
+    EXPECT_TRUE(std::ranges::end(this->test_range) != std::ranges::begin(this->test_range));
 
     if constexpr (std::derived_from<typename TestFixture::iterator_tag, std::forward_iterator_tag>) // iterate over it again
     {
-        EXPECT_TRUE(std::ranges::begin(this->test_range)  == std::ranges::begin(this->test_range));
+        EXPECT_TRUE(std::ranges::begin(this->test_range) == std::ranges::begin(this->test_range));
         EXPECT_FALSE(std::ranges::begin(this->test_range) != std::ranges::begin(this->test_range));
     }
 
     if constexpr (TestFixture::const_iterable)
     {
-        EXPECT_TRUE(std::ranges::cbegin(this->test_range)  == std::ranges::cbegin(this->test_range));
+        EXPECT_TRUE(std::ranges::cbegin(this->test_range) == std::ranges::cbegin(this->test_range));
         EXPECT_FALSE(std::ranges::cbegin(this->test_range) != std::ranges::cbegin(this->test_range));
         EXPECT_FALSE(std::ranges::cbegin(this->test_range) == std::ranges::cend(this->test_range));
-        EXPECT_TRUE(std::ranges::cbegin(this->test_range)  != std::ranges::cend(this->test_range));
-        EXPECT_FALSE(std::ranges::cend(this->test_range)   == std::ranges::cbegin(this->test_range));
-        EXPECT_TRUE(std::ranges::cend(this->test_range)    != std::ranges::cbegin(this->test_range));
+        EXPECT_TRUE(std::ranges::cbegin(this->test_range) != std::ranges::cend(this->test_range));
+        EXPECT_FALSE(std::ranges::cend(this->test_range) == std::ranges::cbegin(this->test_range));
+        EXPECT_TRUE(std::ranges::cend(this->test_range) != std::ranges::cbegin(this->test_range));
 
         // (non-const lhs)
-        EXPECT_TRUE(std::ranges::begin(this->test_range)  == std::ranges::cbegin(this->test_range));
+        EXPECT_TRUE(std::ranges::begin(this->test_range) == std::ranges::cbegin(this->test_range));
         EXPECT_FALSE(std::ranges::begin(this->test_range) != std::ranges::cbegin(this->test_range));
         EXPECT_FALSE(std::ranges::begin(this->test_range) == std::ranges::cend(this->test_range));
-        EXPECT_TRUE(std::ranges::begin(this->test_range)  != std::ranges::cend(this->test_range));
-        EXPECT_FALSE(std::ranges::end(this->test_range)   == std::ranges::cbegin(this->test_range));
-        EXPECT_TRUE(std::ranges::end(this->test_range)    != std::ranges::cbegin(this->test_range));
+        EXPECT_TRUE(std::ranges::begin(this->test_range) != std::ranges::cend(this->test_range));
+        EXPECT_FALSE(std::ranges::end(this->test_range) == std::ranges::cbegin(this->test_range));
+        EXPECT_TRUE(std::ranges::end(this->test_range) != std::ranges::cbegin(this->test_range));
 
         // (non-const rhs)
-        EXPECT_TRUE(std::ranges::cbegin(this->test_range)  == std::ranges::begin(this->test_range));
+        EXPECT_TRUE(std::ranges::cbegin(this->test_range) == std::ranges::begin(this->test_range));
         EXPECT_FALSE(std::ranges::cbegin(this->test_range) != std::ranges::begin(this->test_range));
-        EXPECT_FALSE(std::ranges::cend(this->test_range)   == std::ranges::begin(this->test_range));
-        EXPECT_TRUE(std::ranges::cend(this->test_range)    != std::ranges::begin(this->test_range));
+        EXPECT_FALSE(std::ranges::cend(this->test_range) == std::ranges::begin(this->test_range));
+        EXPECT_TRUE(std::ranges::cend(this->test_range) != std::ranges::begin(this->test_range));
         EXPECT_FALSE(std::ranges::cbegin(this->test_range) == std::ranges::end(this->test_range));
-        EXPECT_TRUE(std::ranges::cbegin(this->test_range)  != std::ranges::end(this->test_range));
+        EXPECT_TRUE(std::ranges::cbegin(this->test_range) != std::ranges::end(this->test_range));
     }
 }
 
@@ -352,7 +352,7 @@ inline void jump_forward_test(it_begin_t && it_begin, rng_t && rng)
     // Forward copy friend
     for (size_t n = 0; n < sz; ++n)
     {
-        expect_iter_equal<test_type>((n + it_begin), rng_it_begin + n);
+        expect_iter_equal<test_type>(n + it_begin, rng_it_begin + n);
         expect_iter_equal<test_type>(it_begin, rng_it_begin);
     }
 }
@@ -501,20 +501,20 @@ TYPED_TEST_P(iterator_fixture, compare_less)
     if constexpr (std::derived_from<typename TestFixture::iterator_tag, std::random_access_iterator_tag>)
     {
         EXPECT_FALSE(std::ranges::begin(this->test_range) < std::ranges::begin(this->test_range));
-        EXPECT_TRUE(std::ranges::begin(this->test_range)  < std::ranges::next(std::ranges::begin(this->test_range)));
+        EXPECT_TRUE(std::ranges::begin(this->test_range) < std::ranges::next(std::ranges::begin(this->test_range)));
     }
 
     if constexpr (std::derived_from<typename TestFixture::iterator_tag, std::random_access_iterator_tag> &&
                   TestFixture::const_iterable)
     {
         EXPECT_FALSE(std::ranges::cbegin(this->test_range) < std::ranges::cbegin(this->test_range));
-        EXPECT_TRUE(std::ranges::cbegin(this->test_range)  < std::ranges::next(std::ranges::cbegin(this->test_range)));
+        EXPECT_TRUE(std::ranges::cbegin(this->test_range) < std::ranges::next(std::ranges::cbegin(this->test_range)));
 
         // mix
-        EXPECT_FALSE(std::ranges::begin(this->test_range)  < std::ranges::cbegin(this->test_range));
-        EXPECT_TRUE(std::ranges::begin(this->test_range)   < std::ranges::next(std::ranges::cbegin(this->test_range)));
+        EXPECT_FALSE(std::ranges::begin(this->test_range) < std::ranges::cbegin(this->test_range));
+        EXPECT_TRUE(std::ranges::begin(this->test_range) < std::ranges::next(std::ranges::cbegin(this->test_range)));
         EXPECT_FALSE(std::ranges::cbegin(this->test_range) < std::ranges::begin(this->test_range));
-        EXPECT_TRUE(std::ranges::cbegin(this->test_range)  < std::ranges::next(std::ranges::begin(this->test_range)));
+        EXPECT_TRUE(std::ranges::cbegin(this->test_range) < std::ranges::next(std::ranges::begin(this->test_range)));
     }
 }
 
@@ -533,8 +533,8 @@ TYPED_TEST_P(iterator_fixture, compare_greater)
         EXPECT_FALSE(std::ranges::cbegin(this->test_range) > std::ranges::next(std::ranges::cbegin(this->test_range)));
 
         // mix
-        EXPECT_FALSE(std::ranges::begin(this->test_range)  > std::ranges::cbegin(this->test_range));
-        EXPECT_FALSE(std::ranges::begin(this->test_range)  > std::ranges::next(std::ranges::cbegin(this->test_range)));
+        EXPECT_FALSE(std::ranges::begin(this->test_range) > std::ranges::cbegin(this->test_range));
+        EXPECT_FALSE(std::ranges::begin(this->test_range) > std::ranges::next(std::ranges::cbegin(this->test_range)));
         EXPECT_FALSE(std::ranges::cbegin(this->test_range) > std::ranges::begin(this->test_range));
         EXPECT_FALSE(std::ranges::cbegin(this->test_range) > std::ranges::next(std::ranges::begin(this->test_range)));
     }
@@ -555,8 +555,8 @@ TYPED_TEST_P(iterator_fixture, compare_leq)
         EXPECT_TRUE(std::ranges::cbegin(this->test_range) <= std::ranges::next(std::ranges::cbegin(this->test_range)));
 
         // mix
-        EXPECT_TRUE(std::ranges::begin(this->test_range)  <= std::ranges::cbegin(this->test_range));
-        EXPECT_TRUE(std::ranges::begin(this->test_range)  <= std::ranges::next(std::ranges::cbegin(this->test_range)));
+        EXPECT_TRUE(std::ranges::begin(this->test_range) <= std::ranges::cbegin(this->test_range));
+        EXPECT_TRUE(std::ranges::begin(this->test_range) <= std::ranges::next(std::ranges::cbegin(this->test_range)));
         EXPECT_TRUE(std::ranges::cbegin(this->test_range) <= std::ranges::begin(this->test_range));
         EXPECT_TRUE(std::ranges::cbegin(this->test_range) <= std::ranges::next(std::ranges::begin(this->test_range)));
     }
@@ -566,20 +566,20 @@ TYPED_TEST_P(iterator_fixture, compare_geq)
 {
     if constexpr (std::derived_from<typename TestFixture::iterator_tag, std::random_access_iterator_tag>)
     {
-        EXPECT_TRUE(std::ranges::begin(this->test_range)  >= std::ranges::begin(this->test_range));
+        EXPECT_TRUE(std::ranges::begin(this->test_range) >= std::ranges::begin(this->test_range));
         EXPECT_FALSE(std::ranges::begin(this->test_range) >= std::ranges::next(std::ranges::begin(this->test_range)));
     }
 
     if constexpr (std::derived_from<typename TestFixture::iterator_tag, std::random_access_iterator_tag> &&
                   TestFixture::const_iterable)
     {
-        EXPECT_TRUE(std::ranges::cbegin(this->test_range)  >= std::ranges::cbegin(this->test_range));
+        EXPECT_TRUE(std::ranges::cbegin(this->test_range) >= std::ranges::cbegin(this->test_range));
         EXPECT_FALSE(std::ranges::cbegin(this->test_range) >= std::ranges::next(std::ranges::cbegin(this->test_range)));
 
         // mix
-        EXPECT_TRUE(std::ranges::begin(this->test_range)   >= std::ranges::cbegin(this->test_range));
-        EXPECT_FALSE(std::ranges::begin(this->test_range)  >= std::ranges::next(std::ranges::cbegin(this->test_range)));
-        EXPECT_TRUE(std::ranges::cbegin(this->test_range)  >= std::ranges::begin(this->test_range));
+        EXPECT_TRUE(std::ranges::begin(this->test_range) >= std::ranges::cbegin(this->test_range));
+        EXPECT_FALSE(std::ranges::begin(this->test_range) >= std::ranges::next(std::ranges::cbegin(this->test_range)));
+        EXPECT_TRUE(std::ranges::cbegin(this->test_range) >= std::ranges::begin(this->test_range));
         EXPECT_FALSE(std::ranges::cbegin(this->test_range) >= std::ranges::next(std::ranges::begin(this->test_range)));
     }
 }

--- a/test/unit/range/iterator_test_template.hpp
+++ b/test/unit/range/iterator_test_template.hpp
@@ -437,24 +437,31 @@ TYPED_TEST_P(iterator_fixture, jump_random)
     }
 }
 
-template <typename it_begin_t, typename rng_t>
-inline void difference_test(it_begin_t && it_begin, rng_t && rng)
+template <typename it_begin_t, typename it_sentinel_t, typename rng_t>
+inline void difference_test(it_begin_t && it_begin, it_sentinel_t && it_end, rng_t && rng)
 {
-    size_t sz = std::ranges::distance(rng);
     using difference_t = std::iter_difference_t<it_begin_t>;
+    difference_t sz = std::ranges::distance(rng);
 
-    for (size_t n = 0; n < sz; ++n)
-        EXPECT_EQ(static_cast<difference_t>(n), ((it_begin + n) - it_begin));
+    it_begin_t last_it = std::get<0>(last_iterators(it_begin, it_end, rng));
+
+    for (difference_t n = 0; n < sz; ++n)
+        EXPECT_EQ(n, (it_begin + n) - it_begin);
+
+    for (difference_t n = 0; n < sz; ++n)
+        EXPECT_EQ(n, last_it - (last_it - n));
 }
 
 TYPED_TEST_P(iterator_fixture, difference_common)
 {
     if constexpr (std::derived_from<typename TestFixture::iterator_tag, std::random_access_iterator_tag>)
     {
-        difference_test(std::ranges::begin(this->test_range), this->expected_range);
+        difference_test(std::ranges::begin(this->test_range), std::ranges::end(this->test_range), this->expected_range);
 
         if constexpr (TestFixture::const_iterable)
-            difference_test(std::ranges::cbegin(this->test_range), std::as_const(this->expected_range));
+            difference_test(std::ranges::cbegin(this->test_range),
+                            std::ranges::cend(this->test_range),
+                            std::as_const(this->expected_range));
     }
 }
 

--- a/test/unit/range/iterator_test_template.hpp
+++ b/test/unit/range/iterator_test_template.hpp
@@ -372,7 +372,7 @@ TYPED_TEST_P(iterator_fixture, jump_forward)
         jump_forward_test<TypeParam>(std::ranges::begin(this->test_range), this->expected_range);
 
         if constexpr (TestFixture::const_iterable)
-            jump_forward_test<TypeParam>(std::ranges::cbegin(this->test_range), this->expected_range);
+            jump_forward_test<TypeParam>(std::ranges::cbegin(this->test_range), std::as_const(this->expected_range));
     }
 }
 
@@ -413,7 +413,7 @@ TYPED_TEST_P(iterator_fixture, jump_backward)
         jump_backward_test<TypeParam>(std::ranges::begin(this->test_range), this->expected_range);
 
         if constexpr (TestFixture::const_iterable)
-            jump_backward_test<TypeParam>(std::ranges::cbegin(this->test_range), this->expected_range);
+            jump_backward_test<TypeParam>(std::ranges::cbegin(this->test_range), std::as_const(this->expected_range));
     }
 }
 
@@ -433,7 +433,7 @@ TYPED_TEST_P(iterator_fixture, jump_random)
         jump_random_test<TypeParam>(std::ranges::begin(this->test_range), this->expected_range);
 
         if constexpr (TestFixture::const_iterable)
-            jump_random_test<TypeParam>(std::ranges::cbegin(this->test_range), this->expected_range);
+            jump_random_test<TypeParam>(std::ranges::cbegin(this->test_range), std::as_const(this->expected_range));
     }
 }
 
@@ -454,7 +454,7 @@ TYPED_TEST_P(iterator_fixture, difference_common)
         difference_test(std::ranges::begin(this->test_range), this->expected_range);
 
         if constexpr (TestFixture::const_iterable)
-            difference_test(std::ranges::cbegin(this->test_range), this->expected_range);
+            difference_test(std::ranges::cbegin(this->test_range), std::as_const(this->expected_range));
     }
 }
 


### PR DESCRIPTION
This PR is collection of changes to the iterator_test_template.

It
* introduces new functions `expect_iter_equal` and `expect_iter_value_equal` which allows to compare the iterator instead of only the value of the iterator.
* improves some tests with regard to C++20 input_iterators.
* improves some tests by testing more cases.

This is part of seqan/product_backlog#62