### PR TITLE
No base class construction pipeable_config_element

### DIFF
--- a/include/seqan3/alignment/configuration/align_config_aligned_ends.hpp
+++ b/include/seqan3/alignment/configuration/align_config_aligned_ends.hpp
@@ -547,6 +547,20 @@ template <typename end_gaps_t>
 //!\endcond
 struct aligned_ends : public pipeable_config_element<aligned_ends<end_gaps_t>, end_gaps_t>
 {
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    aligned_ends() = default; //!< Defaulted.
+    aligned_ends(aligned_ends const &) = default; //!< Defaulted.
+    aligned_ends(aligned_ends &&) = default; //!< Defaulted.
+    aligned_ends & operator=(aligned_ends const &) = default; //!< Defaulted.
+    aligned_ends & operator=(aligned_ends &&) = default; //!< Defaulted.
+    ~aligned_ends() = default; //!< Defaulted.
+
+    //!\brief Construct from base type.
+    constexpr aligned_ends(end_gaps_t const & e) : pipeable_config_element<aligned_ends<end_gaps_t>, end_gaps_t>(e) {}
+    //!\}
+
     //!\privatesection
     //!\brief Internal id to check for consistent configuration settings.
     static constexpr seqan3::detail::align_config_id id{seqan3::detail::align_config_id::aligned_ends};

--- a/include/seqan3/alignment/configuration/align_config_alignment_result_capture.hpp
+++ b/include/seqan3/alignment/configuration/align_config_alignment_result_capture.hpp
@@ -40,6 +40,22 @@ struct alignment_result_capture_element :
     public pipeable_config_element<alignment_result_capture_element<alignment_result_t>,
                                    std::type_identity<alignment_result_t>>
 {
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    alignment_result_capture_element() = default; //!< Defaulted.
+    alignment_result_capture_element(alignment_result_capture_element const &) = default; //!< Defaulted.
+    alignment_result_capture_element(alignment_result_capture_element &&) = default; //!< Defaulted.
+    alignment_result_capture_element & operator=(alignment_result_capture_element const &) = default; //!< Defaulted.
+    alignment_result_capture_element & operator=(alignment_result_capture_element &&) = default; //!< Defaulted.
+    ~alignment_result_capture_element() = default; //!< Defaulted.
+
+    //!\brief Construct from base type.
+    constexpr alignment_result_capture_element(alignment_result_t const & e) :
+        pipeable_config_element<alignment_result_capture_element<alignment_result_t>,
+                                std::type_identity<alignment_result_t>>(e) {}
+    //!\}
+
     //!\brief Internal id to check for consistent configuration settings.
     static constexpr detail::align_config_id id{detail::align_config_id::alignment_result_capture};
 };

--- a/include/seqan3/alignment/configuration/align_config_gap.hpp
+++ b/include/seqan3/alignment/configuration/align_config_gap.hpp
@@ -43,6 +43,21 @@ struct gap : public pipeable_config_element<gap<gap_scheme_t>, gap_scheme_t>
 {
     static_assert(seqan3::detail::is_type_specialisation_of_v<gap_scheme_t, gap_scheme>,
                   "Expects seqan3::gap_scheme class.");
+
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    gap() = default; //!< Defaulted.
+    gap(gap const &) = default; //!< Defaulted.
+    gap(gap &&) = default; //!< Defaulted.
+    gap & operator=(gap const &) = default; //!< Defaulted.
+    gap & operator=(gap &&) = default; //!< Defaulted.
+    ~gap() = default; //!< Defaulted.
+
+    //!\brief Construct from base type.
+    constexpr gap(gap_scheme_t const & s) : pipeable_config_element<gap<gap_scheme_t>, gap_scheme_t>(s) {}
+    //!\}
+
     //!\privatesection
     //!\brief Internal id to check for consistent configuration settings.
     static constexpr seqan3::detail::align_config_id id{seqan3::detail::align_config_id::gap};

--- a/include/seqan3/alignment/configuration/align_config_max_error.hpp
+++ b/include/seqan3/alignment/configuration/align_config_max_error.hpp
@@ -35,6 +35,20 @@ namespace seqan3::align_cfg
  */
 struct max_error : public pipeable_config_element<max_error, uint32_t>
 {
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    max_error() = default; //!< Defaulted.
+    max_error(max_error const &) = default; //!< Defaulted.
+    max_error(max_error &&) = default; //!< Defaulted.
+    max_error & operator=(max_error const &) = default; //!< Defaulted.
+    max_error & operator=(max_error &&) = default; //!< Defaulted.
+    ~max_error() = default; //!< Defaulted.
+
+    //!\brief Construct from base type.
+    constexpr max_error(uint32_t const & i) : pipeable_config_element<max_error, uint32_t>(i) {}
+    //!\}
+
     //!\privatesection
     //!\brief Internal id to check for consistent configuration settings.
     static constexpr seqan3::detail::align_config_id id{seqan3::detail::align_config_id::max_error};

--- a/include/seqan3/alignment/configuration/align_config_method.hpp
+++ b/include/seqan3/alignment/configuration/align_config_method.hpp
@@ -27,6 +27,17 @@ namespace seqan3::detail
 //!\ingroup alignment_configuration
 struct method_local_tag : public pipeable_config_element<method_local_tag>
 {
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    method_local_tag() = default; //!< Defaulted.
+    method_local_tag(method_local_tag const &) = default; //!< Defaulted.
+    method_local_tag(method_local_tag &&) = default; //!< Defaulted.
+    method_local_tag & operator=(method_local_tag const &) = default; //!< Defaulted.
+    method_local_tag & operator=(method_local_tag &&) = default; //!< Defaulted.
+    ~method_local_tag() = default; //!< Defaulted.
+    //!\}
+
     //!\privatesection
     //!\brief An internal id used to check for a valid alignment configuration.
     static constexpr detail::align_config_id id{detail::align_config_id::local};

--- a/include/seqan3/alignment/configuration/align_config_scoring.hpp
+++ b/include/seqan3/alignment/configuration/align_config_scoring.hpp
@@ -40,6 +40,21 @@ namespace seqan3::align_cfg
 template <typename scoring_scheme_t>
 struct scoring : public pipeable_config_element<scoring<scoring_scheme_t>, scoring_scheme_t>
 {
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    scoring() = default; //!< Defaulted.
+    scoring(scoring const &) = default; //!< Defaulted.
+    scoring(scoring &&) = default; //!< Defaulted.
+    scoring & operator=(scoring const &) = default; //!< Defaulted.
+    scoring & operator=(scoring &&) = default; //!< Defaulted.
+    ~scoring() = default; //!< Defaulted.
+
+    //!\brief Construct from base type.
+    constexpr scoring(scoring_scheme_t const & s) : pipeable_config_element<scoring<scoring_scheme_t>,
+                                                                                    scoring_scheme_t>(s) {}
+    //!\}
+
     //!\privatesection
     //!\brief Internal id to check for consistent configuration settings.
     static constexpr seqan3::detail::align_config_id id{seqan3::detail::align_config_id::scoring};

--- a/include/seqan3/alignment/configuration/align_config_vectorised.hpp
+++ b/include/seqan3/alignment/configuration/align_config_vectorised.hpp
@@ -25,6 +25,17 @@ namespace seqan3::detail
  */
 struct vectorised_tag : public pipeable_config_element<vectorised_tag>
 {
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    vectorised_tag() = default; //!< Defaulted.
+    vectorised_tag(vectorised_tag const &) = default; //!< Defaulted.
+    vectorised_tag(vectorised_tag &&) = default; //!< Defaulted.
+    vectorised_tag & operator=(vectorised_tag const &) = default; //!< Defaulted.
+    vectorised_tag & operator=(vectorised_tag &&) = default; //!< Defaulted.
+    ~vectorised_tag() = default; //!< Defaulted.
+    //!\}
+
     //!\brief Internal id to check for consistent configuration settings.
     static constexpr detail::align_config_id id{detail::align_config_id::vectorised};
 };

--- a/include/seqan3/core/algorithm/configuration.hpp
+++ b/include/seqan3/core/algorithm/configuration.hpp
@@ -479,7 +479,7 @@ private:
 
         return configuration<configs_t..., std::remove_reference_t<config_element_t>>{
             std::tuple_cat(static_cast<base_type>(*this),
-            std::tuple{std::move(elem)})};
+                           std::tuple{std::move(elem)})};
     }
 
     //!\copydoc push_back
@@ -493,7 +493,7 @@ private:
 
         return configuration<configs_t..., std::remove_reference_t<config_element_t>>{
             std::tuple_cat(std::move(static_cast<base_type>(*this)),
-            std::tuple{std::move(elem)})};
+                           std::tuple{std::move(elem)})};
     }
 
     /*!\brief Remove a config element from the configuration.

--- a/include/seqan3/core/algorithm/configuration_element_debug_mode.hpp
+++ b/include/seqan3/core/algorithm/configuration_element_debug_mode.hpp
@@ -28,6 +28,21 @@ namespace seqan3::detail
 template <typename wrapped_config_id_t>
 struct debug_mode : public pipeable_config_element<debug_mode<wrapped_config_id_t>, bool>
 {
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    debug_mode() = default; //!< Defaulted.
+    debug_mode(debug_mode const &) = default; //!< Defaulted.
+    debug_mode(debug_mode &&) = default; //!< Defaulted.
+    debug_mode & operator=(debug_mode const &) = default; //!< Defaulted.
+    debug_mode & operator=(debug_mode &&) = default; //!< Defaulted.
+    ~debug_mode() = default; //!< Defaulted.
+
+    //!\brief Construct from base type.
+    constexpr debug_mode(wrapped_config_id_t const & e) : pipeable_config_element<debug_mode<wrapped_config_id_t>,
+                                                                                  bool>(e) {}
+    //!\}
+
     //!\brief Internal id to check for consistent configuration settings.
     static constexpr typename wrapped_config_id_t::value_type id{wrapped_config_id_t::value};
 };

--- a/include/seqan3/core/algorithm/pipeable_config_element.hpp
+++ b/include/seqan3/core/algorithm/pipeable_config_element.hpp
@@ -29,14 +29,46 @@ namespace seqan3
  */
 template <typename derived_t>
 struct pipeable_config_element<derived_t, void>
-{};
+{
+private:
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    pipeable_config_element() = default; //!< Defaulted.
+    pipeable_config_element(pipeable_config_element const &) = default; //!< Defaulted.
+    pipeable_config_element(pipeable_config_element &&) = default; //!< Defaulted.
+    pipeable_config_element & operator=(pipeable_config_element const &) = default; //!< Defaulted.
+    pipeable_config_element & operator=(pipeable_config_element &&) = default; //!< Defaulted.
+    ~pipeable_config_element() = default; //!< Defaulted.
+    //!\}
+
+    //!\brief Only the derived class is allowed to construct the element
+    friend derived_t;
+};
 
 //! \overload
 template <typename derived_t, typename value_t>
 struct pipeable_config_element
 {
     //!\brief The stored config value.
-    value_t value;
+    value_t value{};
+private:
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    pipeable_config_element() = default; //!< Defaulted.
+    pipeable_config_element(pipeable_config_element const &) = default; //!< Defaulted.
+    pipeable_config_element(pipeable_config_element &&) = default; //!< Defaulted.
+    pipeable_config_element & operator=(pipeable_config_element const &) = default; //!< Defaulted.
+    pipeable_config_element & operator=(pipeable_config_element &&) = default; //!< Defaulted.
+    ~pipeable_config_element() = default; //!< Defaulted.
+
+    //!\brief Construction from the value type.
+    constexpr pipeable_config_element(value_t const & val) : value(val) {}
+    //!\}
+
+    //!\brief Only the derived class is allowed to construct the element
+    friend derived_t;
 };
 
 } // namespace seqan3

--- a/include/seqan3/search/configuration/hit.hpp
+++ b/include/seqan3/search/configuration/hit.hpp
@@ -30,6 +30,17 @@ namespace seqan3::detail
  */
 struct hit_all_tag : public pipeable_config_element<hit_all_tag>
 {
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    hit_all_tag() = default; //!< Defaulted.
+    hit_all_tag(hit_all_tag const &) = default; //!< Defaulted.
+    hit_all_tag(hit_all_tag &&) = default; //!< Defaulted.
+    hit_all_tag & operator=(hit_all_tag const &) = default; //!< Defaulted.
+    hit_all_tag & operator=(hit_all_tag &&) = default; //!< Defaulted.
+    ~hit_all_tag() = default; //!< Defaulted.
+    //!\}
+
     //!\privatesection
     //!\brief Internal id to check for consistent configuration settings.
     static constexpr detail::search_config_id id{detail::search_config_id::hit};
@@ -40,6 +51,17 @@ struct hit_all_tag : public pipeable_config_element<hit_all_tag>
  */
 struct hit_all_best_tag : public pipeable_config_element<hit_all_best_tag>
 {
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    hit_all_best_tag() = default; //!< Defaulted.
+    hit_all_best_tag(hit_all_best_tag const &) = default; //!< Defaulted.
+    hit_all_best_tag(hit_all_best_tag &&) = default; //!< Defaulted.
+    hit_all_best_tag & operator=(hit_all_best_tag const &) = default; //!< Defaulted.
+    hit_all_best_tag & operator=(hit_all_best_tag &&) = default; //!< Defaulted.
+    ~hit_all_best_tag() = default; //!< Defaulted.
+    //!\}
+
     //!\privatesection
     //!\brief Internal id to check for consistent configuration settings.
     static constexpr detail::search_config_id id{detail::search_config_id::hit};
@@ -50,6 +72,17 @@ struct hit_all_best_tag : public pipeable_config_element<hit_all_best_tag>
  */
 struct hit_single_best_tag : public pipeable_config_element<hit_single_best_tag>
 {
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    constexpr hit_single_best_tag() = default; //!< Defaulted.
+    constexpr hit_single_best_tag(hit_single_best_tag const &) = default; //!< Defaulted.
+    constexpr hit_single_best_tag(hit_single_best_tag &&) = default; //!< Defaulted.
+    constexpr hit_single_best_tag & operator=(hit_single_best_tag const &) = default; //!< Defaulted.
+    constexpr hit_single_best_tag & operator=(hit_single_best_tag &&) = default; //!< Defaulted.
+    ~hit_single_best_tag() = default; //!< Defaulted.
+    //!\}
+
     //!\privatesection
     //!\brief Internal id to check for consistent configuration settings.
     static constexpr detail::search_config_id id{detail::search_config_id::hit};
@@ -88,6 +121,20 @@ inline constexpr detail::hit_single_best_tag hit_single_best{};
  */
 struct hit_strata : public pipeable_config_element<hit_strata, uint8_t>
 {
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    constexpr hit_strata() = default; //!< Defaulted.
+    constexpr hit_strata(hit_strata const &) = default; //!< Defaulted.
+    constexpr hit_strata(hit_strata &&) = default; //!< Defaulted.
+    constexpr hit_strata & operator=(hit_strata const &) = default; //!< Defaulted.
+    constexpr hit_strata & operator=(hit_strata &&) = default; //!< Defaulted.
+    ~hit_strata() = default; //!< Defaulted.
+
+    //!\brief Construct from base type.
+    constexpr hit_strata(uint8_t const & u) : pipeable_config_element<hit_strata, uint8_t>(u) {}
+    //!\}
+
     //!\privatesection
     //!\brief Internal id to check for consistent configuration settings.
     static constexpr detail::search_config_id id{detail::search_config_id::hit};

--- a/include/seqan3/search/configuration/max_error.hpp
+++ b/include/seqan3/search/configuration/max_error.hpp
@@ -35,6 +35,21 @@ namespace seqan3::search_cfg
 class max_error_total : public pipeable_config_element<max_error_total, std::variant<error_count, error_rate>>
 {
 public:
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    max_error_total() = default; //!< Defaulted.
+    max_error_total(max_error_total const &) = default; //!< Defaulted.
+    max_error_total(max_error_total &&) = default; //!< Defaulted.
+    max_error_total & operator=(max_error_total const &) = default; //!< Defaulted.
+    max_error_total & operator=(max_error_total &&) = default; //!< Defaulted.
+    ~max_error_total() = default; //!< Defaulted.
+
+    //!\brief Construct from base type.
+    max_error_total(std::variant<error_count, error_rate> const & e) :
+        pipeable_config_element<max_error_total, std::variant<error_count, error_rate>>(e) {}
+    //!\}
+
     //!\privatesection
     //!\brief Internal id to check for consistent configuration settings.
     static constexpr detail::search_config_id id{detail::search_config_id::max_error_total};
@@ -55,6 +70,21 @@ class max_error_substitution : public pipeable_config_element<max_error_substitu
                                                               error_rate>>
 {
 public:
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    max_error_substitution() = default; //!< Defaulted.
+    max_error_substitution(max_error_substitution const &) = default; //!< Defaulted.
+    max_error_substitution(max_error_substitution &&) = default; //!< Defaulted.
+    max_error_substitution & operator=(max_error_substitution const &) = default; //!< Defaulted.
+    max_error_substitution & operator=(max_error_substitution &&) = default; //!< Defaulted.
+    ~max_error_substitution() = default; //!< Defaulted.
+
+    //!\brief Construct from base type.
+    max_error_substitution(std::variant<error_count, error_rate> const & e) :
+        pipeable_config_element<max_error_substitution, std::variant<error_count, error_rate>>(e) {}
+    //!\}
+
     //!\privatesection
     //!\brief Internal id to check for consistent configuration settings.
     static constexpr detail::search_config_id id{detail::search_config_id::max_error_substitution};
@@ -73,6 +103,21 @@ public:
 class max_error_insertion : public pipeable_config_element<max_error_insertion, std::variant<error_count, error_rate>>
 {
 public:
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    max_error_insertion() = default; //!< Defaulted.
+    max_error_insertion(max_error_insertion const &) = default; //!< Defaulted.
+    max_error_insertion(max_error_insertion &&) = default; //!< Defaulted.
+    max_error_insertion & operator=(max_error_insertion const &) = default; //!< Defaulted.
+    max_error_insertion & operator=(max_error_insertion &&) = default; //!< Defaulted.
+    ~max_error_insertion() = default; //!< Defaulted.
+
+    //!\brief Construct from base type.
+    max_error_insertion(std::variant<error_count, error_rate> const & e) :
+        pipeable_config_element<max_error_insertion, std::variant<error_count, error_rate>>(e) {}
+    //!\}
+
     //!\privatesection
     //!\brief Internal id to check for consistent configuration settings.
     static constexpr detail::search_config_id id{detail::search_config_id::max_error_insertion};
@@ -92,6 +137,21 @@ public:
 class max_error_deletion : public pipeable_config_element<max_error_deletion, std::variant<error_count, error_rate>>
 {
 public:
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    max_error_deletion() = default; //!< Defaulted.
+    max_error_deletion(max_error_deletion const &) = default; //!< Defaulted.
+    max_error_deletion(max_error_deletion &&) = default; //!< Defaulted.
+    max_error_deletion & operator=(max_error_deletion const &) = default; //!< Defaulted.
+    max_error_deletion & operator=(max_error_deletion &&) = default; //!< Defaulted.
+    ~max_error_deletion() = default; //!< Defaulted.
+
+    //!\brief Construct from base type.
+    constexpr max_error_deletion(std::variant<error_count, error_rate> const & e) :
+        pipeable_config_element<max_error_deletion, std::variant<error_count, error_rate>>(e) {}
+    //!\}
+
     //!\privatesection
     //!\brief Internal id to check for consistent configuration settings.
     static constexpr detail::search_config_id id{detail::search_config_id::max_error_deletion};

--- a/include/seqan3/search/configuration/output.hpp
+++ b/include/seqan3/search/configuration/output.hpp
@@ -26,6 +26,17 @@ namespace seqan3::detail
 //!\ingroup search_configuration
 struct output_query_id_tag : public pipeable_config_element<output_query_id_tag>
 {
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    output_query_id_tag() = default; //!< Defaulted.
+    output_query_id_tag(output_query_id_tag const &) = default; //!< Defaulted.
+    output_query_id_tag(output_query_id_tag &&) = default; //!< Defaulted.
+    output_query_id_tag & operator=(output_query_id_tag const &) = default; //!< Defaulted.
+    output_query_id_tag & operator=(output_query_id_tag &&) = default; //!< Defaulted.
+    ~output_query_id_tag() = default; //!< Defaulted.
+    //!\}
+
     //!\privatesection
     //!\brief Internal id to check for consistent configuration settings.
     static constexpr detail::search_config_id id{detail::search_config_id::output_query_id};
@@ -35,6 +46,17 @@ struct output_query_id_tag : public pipeable_config_element<output_query_id_tag>
 //!\ingroup search_configuration
 struct output_reference_id_tag : public pipeable_config_element<output_reference_id_tag>
 {
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    output_reference_id_tag() = default; //!< Defaulted.
+    output_reference_id_tag(output_reference_id_tag const &) = default; //!< Defaulted.
+    output_reference_id_tag(output_reference_id_tag &&) = default; //!< Defaulted.
+    output_reference_id_tag & operator=(output_reference_id_tag const &) = default; //!< Defaulted.
+    output_reference_id_tag & operator=(output_reference_id_tag &&) = default; //!< Defaulted.
+    ~output_reference_id_tag() = default; //!< Defaulted.
+    //!\}
+
     //!\privatesection
     //!\brief Internal id to check for consistent configuration settings.
     static constexpr detail::search_config_id id{detail::search_config_id::output_reference_id};
@@ -44,6 +66,19 @@ struct output_reference_id_tag : public pipeable_config_element<output_reference
 //!\ingroup search_configuration
 struct output_reference_begin_position_tag : public pipeable_config_element<output_reference_begin_position_tag>
 {
+
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    output_reference_begin_position_tag() = default; //!< Defaulted.
+    output_reference_begin_position_tag(output_reference_begin_position_tag const &) = default; //!< Defaulted.
+    output_reference_begin_position_tag(output_reference_begin_position_tag &&) = default; //!< Defaulted.
+    output_reference_begin_position_tag & operator=(output_reference_begin_position_tag const &) =
+     default; //!< Defaulted.
+    output_reference_begin_position_tag & operator=(output_reference_begin_position_tag &&) = default; //!< Defaulted.
+    ~output_reference_begin_position_tag() = default; //!< Defaulted.
+    //!\}
+
     //!\privatesection
     //!\brief Internal id to check for consistent configuration settings.
     static constexpr detail::search_config_id id{detail::search_config_id::output_reference_begin_position};
@@ -53,6 +88,17 @@ struct output_reference_begin_position_tag : public pipeable_config_element<outp
 //!\ingroup search_configuration
 struct output_index_cursor_tag : public pipeable_config_element<output_index_cursor_tag>
 {
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    output_index_cursor_tag() = default; //!< Defaulted.
+    output_index_cursor_tag(output_index_cursor_tag const &) = default; //!< Defaulted.
+    output_index_cursor_tag(output_index_cursor_tag &&) = default; //!< Defaulted.
+    output_index_cursor_tag & operator=(output_index_cursor_tag const &) = default; //!< Defaulted.
+    output_index_cursor_tag & operator=(output_index_cursor_tag &&) = default; //!< Defaulted.
+    ~output_index_cursor_tag() = default; //!< Defaulted.
+    //!\}
+
     //!\privatesection
     //!\brief Internal id to check for consistent configuration settings.
     static constexpr detail::search_config_id id{detail::search_config_id::output_index_cursor};

--- a/include/seqan3/search/configuration/result_type.hpp
+++ b/include/seqan3/search/configuration/result_type.hpp
@@ -40,6 +40,21 @@ template <typename search_result_t>
 //!\endcond
 struct result_type_tag : public pipeable_config_element<result_type_tag<search_result_t>, seqan3::detail::empty_type>
 {
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    result_type_tag() = default; //!< Defaulted.
+    result_type_tag(result_type_tag const &) = default; //!< Defaulted.
+    result_type_tag(result_type_tag &&) = default; //!< Defaulted.
+    result_type_tag & operator=(result_type_tag const &) = default; //!< Defaulted.
+    result_type_tag & operator=(result_type_tag &&) = default; //!< Defaulted.
+    ~result_type_tag() = default; //!< Defaulted.
+
+    //!\brief Construct from base type.
+    constexpr result_type_tag(search_result_t const & r) : pipeable_config_element<result_type_tag<search_result_t>,
+                                                                                   seqan3::detail::empty_type>(r) {}
+    //!\}
+
     //!\brief The configured seqan3::search_result type.
     using type = search_result_t;
 

--- a/test/snippet/core/algorithm/configuration_get_or.cpp
+++ b/test/snippet/core/algorithm/configuration_get_or.cpp
@@ -11,12 +11,40 @@ enum struct my_id : int
 
 struct bar : public seqan3::pipeable_config_element<bar, float>
 {
+    /*!\name Constructor, destructor and assignment
+     * \{
+     */
+    constexpr bar() = default; //!< Defaulted.
+    constexpr bar(bar const &) = default; //!< Defaulted.
+    constexpr bar(bar &&) = default; //!< Defaulted.
+    constexpr bar & operator=(bar const &) = default; //!< Defaulted.
+    constexpr bar & operator=(bar &&) = default; //!< Defaulted.
+    ~bar() = default; //!< Defaulted.
+
+    //!\brief Construct from base type.
+    constexpr bar(float const & val) : seqan3::pipeable_config_element<bar, float>(val) {}
+    //!\}
+
     static constexpr my_id id{my_id::bar_id};
 };
 
 template <typename t>
 struct foo : public seqan3::pipeable_config_element<foo<t>, t>
 {
+    /*!\name Constructor, destructor and assignment
+     * \{
+     */
+    constexpr foo() = default; //!< Defaulted.
+    constexpr foo(foo const &) = default; //!< Defaulted.
+    constexpr foo(foo &&) = default; //!< Defaulted.
+    constexpr foo & operator=(foo const &) = default; //!< Defaulted.
+    constexpr foo & operator=(foo &&) = default; //!< Defaulted.
+    ~foo() = default; //!< Defaulted.
+
+    //!\brief Construct from base type.
+    constexpr foo(t const & val) : seqan3::pipeable_config_element<foo<t>, t>(val) {}
+    //!\}
+
     static constexpr my_id id{my_id::foo_id};
 };
 

--- a/test/unit/alignment/configuration/align_config_aligned_ends_test.cpp
+++ b/test/unit/alignment/configuration/align_config_aligned_ends_test.cpp
@@ -132,9 +132,9 @@ TEST(back_end_second, deduction)
     }
 }
 
-TYPED_TEST(static_end_gap_test, aggreagte)
+TYPED_TEST(static_end_gap_test, is_standard_layout)
 {
-    EXPECT_TRUE((std::is_aggregate_v<TypeParam>));
+    EXPECT_TRUE((std::is_standard_layout_v<TypeParam>));
 }
 
 TYPED_TEST(static_end_gap_test, get_value)
@@ -145,7 +145,7 @@ TYPED_TEST(static_end_gap_test, get_value)
 
 TYPED_TEST(dynamic_end_gap_test, construction)
 {
-    EXPECT_TRUE((std::is_aggregate_v<TypeParam>));
+    EXPECT_TRUE((std::is_standard_layout_v<TypeParam>));
 }
 
 TYPED_TEST(dynamic_end_gap_test, get_value)
@@ -344,9 +344,9 @@ TEST(end_gaps, free_ends_second)
     EXPECT_EQ((std::is_same_v<std::remove_const_t<decltype(seqan3::free_ends_second)>, test>), true);
 }
 
-TEST(align_cfg_aligned_ends, is_aggregate)
+TEST(align_cfg_aligned_ends, is_standard_layout)
 {
-    EXPECT_TRUE((std::is_aggregate_v<seqan3::align_cfg::aligned_ends<seqan3::end_gaps<>>>));
+    EXPECT_TRUE((std::is_standard_layout_v<seqan3::align_cfg::aligned_ends<seqan3::end_gaps<>>>));
 }
 
 TEST(align_cfg_aligned_ends, id)

--- a/test/unit/core/algorithm/configuration_mock.hpp
+++ b/test/unit/core/algorithm/configuration_mock.hpp
@@ -38,21 +38,78 @@ inline constexpr std::array<std::array<bool, static_cast<uint8_t>(::test_algo_id
 
 struct bar : public seqan3::pipeable_config_element<bar, int>
 {
+
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    bar() = default; //!< Defaulted.
+    bar(bar const &) = default; //!< Defaulted.
+    bar(bar &&) = default; //!< Defaulted.
+    bar & operator=(bar const &) = default; //!< Defaulted.
+    bar & operator=(bar &&) = default; //!< Defaulted.
+    ~bar() = default; //!< Defaulted.
+
+    //!\brief Construct from base type.
+    constexpr bar(int const & i) : seqan3::pipeable_config_element<bar, int>(i) {}
+    //!\}
+
     static constexpr test_algo_id id{test_algo_id::bar_id};
 };
 
 struct bax : public seqan3::pipeable_config_element<bax, float>
 {
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    bax() = default; //!< Defaulted.
+    bax(bax const &) = default; //!< Defaulted.
+    bax(bax &&) = default; //!< Defaulted.
+    bax & operator=(bax const &) = default; //!< Defaulted.
+    bax & operator=(bax &&) = default; //!< Defaulted.
+    ~bax() = default; //!< Defaulted.
+
+    //!\brief Construct from base type.
+    constexpr bax(float const & f) : seqan3::pipeable_config_element<bax, float>(f) {}
+    //!\}
+
     static constexpr test_algo_id id{test_algo_id::bax_id};
 };
 
 struct foo : public seqan3::pipeable_config_element<foo, std::string>
 {
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    foo() = default; //!< Defaulted.
+    foo(foo const &) = default; //!< Defaulted.
+    foo(foo &&) = default; //!< Defaulted.
+    foo & operator=(foo const &) = default; //!< Defaulted.
+    foo & operator=(foo &&) = default; //!< Defaulted.
+    ~foo() = default; //!< Defaulted.
+
+    //!\brief Construct from base type.
+    constexpr foo(std::string const & s) : seqan3::pipeable_config_element<foo, std::string>(s) {}
+    //!\}
+
     static constexpr test_algo_id id{test_algo_id::foo_id};
 };
 
 template <typename t = std::vector<int>>
 struct foobar : public seqan3::pipeable_config_element<foobar<t>, t>
 {
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    foobar() = default; //!< Defaulted.
+    foobar(foobar const &) = default; //!< Defaulted.
+    foobar(foobar &&) = default; //!< Defaulted.
+    foobar & operator=(foobar const &) = default; //!< Defaulted.
+    foobar & operator=(foobar &&) = default; //!< Defaulted.
+    ~foobar() = default; //!< Defaulted.
+
+    //!\brief Construct from base type.
+    constexpr foobar(t const & e) : seqan3::pipeable_config_element<foobar<t>, t>(e) {}
+    //!\}
+
     static constexpr test_algo_id id{test_algo_id::foobar_id};
 };

--- a/test/unit/core/algorithm/pipeable_config_element_test.cpp
+++ b/test/unit/core/algorithm/pipeable_config_element_test.cpp
@@ -154,3 +154,10 @@ TEST(pipeable_config_element, const_config)
         EXPECT_TRUE((std::is_same_v<decltype(cfg), seqan3::configuration<foobar<>, foo, bar>>));
     }
 }
+
+TEST(pipeable_config_element, base_class_construction)
+{
+    EXPECT_FALSE(std::default_initializable<seqan3::pipeable_config_element<bar>>);
+    EXPECT_FALSE(std::copy_constructible<seqan3::pipeable_config_element<bar>>);
+    EXPECT_FALSE(std::move_constructible<seqan3::pipeable_config_element<bar>>);
+}

--- a/test/unit/core/algorithm/pipeable_config_element_test_template.hpp
+++ b/test/unit/core/algorithm/pipeable_config_element_test_template.hpp
@@ -34,6 +34,13 @@ TYPED_TEST_P(pipeable_config_element_test, standard_construction)
     EXPECT_TRUE((std::is_move_assignable_v<TypeParam>));
 }
 
+TYPED_TEST_P(pipeable_config_element_test, base_class_construction)
+{
+    EXPECT_FALSE(std::default_initializable<seqan3::pipeable_config_element<TypeParam>>);
+    EXPECT_FALSE(std::copy_constructible<seqan3::pipeable_config_element<TypeParam>>);
+    EXPECT_FALSE(std::move_constructible<seqan3::pipeable_config_element<TypeParam>>);
+}
+
 TYPED_TEST_P(pipeable_config_element_test, configuration_construction)
 {
     seqan3::configuration cfg{TypeParam{}};
@@ -96,6 +103,7 @@ TYPED_TEST_P(pipeable_config_element_test, pipeability)
 REGISTER_TYPED_TEST_SUITE_P(pipeable_config_element_test,
                             concept_check,
                             standard_construction,
+                            base_class_construction,
                             configuration_construction,
                             configuration_assignment,
                             exists,


### PR DESCRIPTION
Resolves https://github.com/seqan/product_backlog/issues/118

The only class which is allowed to construct `pipeable_config_element<...>{}` is the derived class of `pipeable_config_element<...>{}`. `pipeable_config_element<...>{}` befriends the derived class (this makes private members accessible for the derived class).