### PR TITLE
[FEATURE] Allow overwrite existing files, add flags for permission handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ Note that 3.1.0 will be the first API stable release and interfaces in this rele
   * `seqan3::argument_parser::add_line`
   * `seqan3::argument_parser::add_list_item`
   Note that other `seqan3::argument_parser::option_spec`s like `REQUIRED` are ignored.
+* We expanded the `seqan3::output_file_validator`, with a parameter `seqan3::output_file_open_options` to allow overwriting
+  output files ([\#2009](https://github.com/seqan/seqan3/pull/2009)).
 
 #### I/O
 

--- a/doc/tutorial/argument_parser/index.md
+++ b/doc/tutorial/argument_parser/index.md
@@ -390,8 +390,8 @@ of the parsed option value.
 The validator throws a seqan3::validation_error exception whenever a given filename's extension is not in the
 given list of valid extensions. In addition, the seqan3::input_file_validator checks if the file exists, is a regular
 file and is readable.
-The seqan3::output_file_validator on the other hand ensures that the output does not already exist (in order to prevent
-overwriting an already existing file) and that it can be created.
+Moreover, you have to add an additional flag seqan3::output_file_open_options to the seqan3::output_file_validator,
+which you can use to indicate whether you want to allow the output files to be overwritten.
 
 \note If you want to allow any extension just use a default constructed file validator.
 

--- a/doc/tutorial/read_mapper/read_mapper_indexer_step1.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_indexer_step1.cpp
@@ -24,7 +24,7 @@ void initialise_argument_parser(seqan3::argument_parser & parser, cmd_arguments 
                       seqan3::input_file_validator{{"fa","fasta"}});
     parser.add_option(args.index_path, 'o', "output", "The output index file path.",
                       seqan3::option_spec::DEFAULT,
-                      seqan3::output_file_validator{{"index"}});
+                      seqan3::output_file_validator{seqan3::output_file_open_options::create_new, {"index"}});
 }
 
 //![main]

--- a/doc/tutorial/read_mapper/read_mapper_indexer_step2.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_indexer_step2.cpp
@@ -51,7 +51,7 @@ void initialise_argument_parser(seqan3::argument_parser & parser, cmd_arguments 
                       seqan3::input_file_validator{{"fa","fasta"}});
     parser.add_option(args.index_path, 'o', "output", "The output index file path.",
                       seqan3::option_spec::DEFAULT,
-                      seqan3::output_file_validator{{"index"}});
+                      seqan3::output_file_validator{seqan3::output_file_open_options::create_new, {"index"}});
 }
 
 int main(int argc, char const ** argv)

--- a/doc/tutorial/read_mapper/read_mapper_indexer_step3.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_indexer_step3.cpp
@@ -66,7 +66,7 @@ void initialise_argument_parser(seqan3::argument_parser & parser, cmd_arguments 
                       seqan3::input_file_validator{{"fa","fasta"}});
     parser.add_option(args.index_path, 'o', "output", "The output index file path.",
                       seqan3::option_spec::DEFAULT,
-                      seqan3::output_file_validator{{"index"}});
+                      seqan3::output_file_validator{seqan3::output_file_open_options::create_new, {"index"}});
 }
 
 int main(int argc, char const ** argv)

--- a/doc/tutorial/read_mapper/read_mapper_step1.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_step1.cpp
@@ -39,7 +39,7 @@ void initialise_argument_parser(seqan3::argument_parser & parser, cmd_arguments 
                       seqan3::input_file_validator{{"index"}});
     parser.add_option(args.sam_path, 'o', "output", "The output SAM file path.",
                       seqan3::option_spec::DEFAULT,
-                      seqan3::output_file_validator{{"sam"}});
+                      seqan3::output_file_validator{seqan3::output_file_open_options::create_new, {"sam"}});
     parser.add_option(args.errors, 'e', "error", "Maximum allowed errors.",
                       seqan3::option_spec::DEFAULT,
                       seqan3::arithmetic_range_validator{0, 4});

--- a/doc/tutorial/read_mapper/read_mapper_step2.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_step2.cpp
@@ -103,7 +103,7 @@ void initialise_argument_parser(seqan3::argument_parser & parser, cmd_arguments 
                       seqan3::input_file_validator{{"index"}});
     parser.add_option(args.sam_path, 'o', "output", "The output SAM file path.",
                       seqan3::option_spec::DEFAULT,
-                      seqan3::output_file_validator{{"sam"}});
+                      seqan3::output_file_validator{seqan3::output_file_open_options::create_new, {"sam"}});
     parser.add_option(args.errors, 'e', "error", "Maximum allowed errors.",
                       seqan3::option_spec::DEFAULT,
                       seqan3::arithmetic_range_validator{0, 4});

--- a/doc/tutorial/read_mapper/read_mapper_step3.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_step3.cpp
@@ -127,7 +127,7 @@ void initialise_argument_parser(seqan3::argument_parser & parser, cmd_arguments 
                       seqan3::input_file_validator{{"index"}});
     parser.add_option(args.sam_path, 'o', "output", "The output SAM file path.",
                       seqan3::option_spec::DEFAULT,
-                      seqan3::output_file_validator{{"sam"}});
+                      seqan3::output_file_validator{seqan3::output_file_open_options::create_new, {"sam"}});
     parser.add_option(args.errors, 'e', "error", "Maximum allowed errors.",
                       seqan3::option_spec::DEFAULT,
                       seqan3::arithmetic_range_validator{0, 4});

--- a/doc/tutorial/read_mapper/read_mapper_step4.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_step4.cpp
@@ -136,7 +136,7 @@ void initialise_argument_parser(seqan3::argument_parser & parser, cmd_arguments 
                       seqan3::input_file_validator{{"index"}});
     parser.add_option(args.sam_path, 'o', "output", "The output SAM file path.",
                       seqan3::option_spec::DEFAULT,
-                      seqan3::output_file_validator{{"sam"}});
+                      seqan3::output_file_validator{seqan3::output_file_open_options::create_new, {"sam"}});
     parser.add_option(args.errors, 'e', "error", "Maximum allowed errors.",
                       seqan3::option_spec::DEFAULT,
                       seqan3::arithmetic_range_validator{0, 4});

--- a/test/snippet/argument_parser/validators_output_directory.cpp
+++ b/test/snippet/argument_parser/validators_output_directory.cpp
@@ -10,7 +10,8 @@ int main(int argc, const char ** argv)
     std::filesystem::path mydir{};
 
     myparser.add_option(mydir, 'd', "dir", "The output directory for storing the files.",
-                        seqan3::option_spec::DEFAULT, seqan3::output_directory_validator{});
+                        seqan3::option_spec::DEFAULT,
+                        seqan3::output_file_validator{seqan3::output_file_open_options::create_new});
     //! [validator_call]
 
     // an exception will be thrown if the user specifies a directory that cannot be created by the filesystem either

--- a/test/snippet/argument_parser/validators_output_file.cpp
+++ b/test/snippet/argument_parser/validators_output_file.cpp
@@ -9,8 +9,15 @@ int main(int argc, const char ** argv)
     //! [validator_call]
     std::filesystem::path myfile{};
 
-    myparser.add_option(myfile,'f',"file","Output file containing the processed sequences.",
-                        seqan3::option_spec::DEFAULT, seqan3::output_file_validator{{"fa","fasta"}});
+    // Use the seqan3::output_file_open_options to indicate that you allow overwriting existing output files, ...
+    myparser.add_option(myfile, 'f', "file", "Output file containing the processed sequences.",
+                        seqan3::option_spec::DEFAULT,
+                        seqan3::output_file_validator{seqan3::output_file_open_options::open_or_create, {"fa","fasta"}});
+
+    // ... or that you will throw a seqan3::validation_error if the user specified output file already exists
+    myparser.add_option(myfile, 'g', "file2", "Output file containing the processed sequences.",
+                        seqan3::option_spec::DEFAULT,
+                        seqan3::output_file_validator{seqan3::output_file_open_options::create_new, {"fa","fasta"}});
     //! [validator_call]
 
     // an exception will be thrown if the user specifies a filename

--- a/test/snippet/argument_parser/validators_output_file_ext_from_file.cpp
+++ b/test/snippet/argument_parser/validators_output_file_ext_from_file.cpp
@@ -5,15 +5,19 @@
 int main(int argc, const char ** argv)
 {
     // Default constructed validator has an empty extension list.
-    seqan3::output_file_validator validator1{};
+    seqan3::output_file_validator validator1{seqan3::output_file_open_options::create_new};
     seqan3::debug_stream << validator1.get_help_page_message() << "\n";
 
     // Specify your own extensions for the output file.
-    seqan3::output_file_validator validator2{std::vector{std::string{"exe"}, std::string{"fasta"}}};
+    seqan3::output_file_validator validator2{seqan3::output_file_open_options::create_new,
+                                             std::vector{std::string{"exe"}, std::string{"fasta"}}};
     seqan3::debug_stream << validator2.get_help_page_message() << "\n";
 
     // Give the seqan3 file type as a template argument to get all valid extensions for this file.
-    seqan3::output_file_validator<seqan3::sequence_file_output<>> validator3{};
+    seqan3::output_file_validator<seqan3::sequence_file_output<>> validator3
+    {
+        seqan3::output_file_open_options::create_new
+    };
     seqan3::debug_stream << validator3.get_help_page_message() << "\n";
 
     return 0;


### PR DESCRIPTION
Resolves https://github.com/seqan/product_backlog/issues/50.

Please do not merge before the naming discussion of the enum on gitter has ended.

Existing Ideas:

```cpp
enum output_file_open_mode
{
   overwritable / rewritable,
   exclusive
};
```

There is something in system.io from Microsoft that sounds good: https://docs.microsoft.com/de-de/dotnet/api/system.io.filemode?view=netcore-3.1 :
```cpp
enum FileMode
{
    open_or_create,
    create_new
};
```

```cpp
enum accept_existing_file
{
    true / yes,
    false / no
};
```

Rust:
```cpp
enum OpenOptions
{
    create,
    create_new
};
```
-----

2020-08-31

Discussion result:
```cpp
enum output_file_open_options
{
    open_or_create,
    create_new
};
```
You call this validator like:
```cpp
seqan3::output_file_validator{seqan3::output_file_open_options::open_or_create});
```