### PR TITLE
[MISC] Use doxygen 1.8.19

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   deploy_documentation:
     name: Deploy Documentation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -19,7 +19,7 @@ jobs:
 
       - name: Setup Doxygen
         env:
-          DOXYGEN_VER: 1.8.17
+          DOXYGEN_VER: 1.8.19
         shell: bash
         run: |
           mkdir -p /tmp/doxygen-download
@@ -37,8 +37,8 @@ jobs:
           tar -C /tmp/ -zxf /tmp/cmake-download/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz
           echo "::add-path::/tmp/cmake-${CMAKE_VERSION}-Linux-x86_64/bin" # Only available in subsequent steps!
 
-      - name: Install Dependencies
-        run: sudo apt-get install texlive-font-utils ghostscript texlive-latex-extra graphviz # graphviz for dot, latex to parse formulas
+      - name: Install Dependencies # graphviz for dot, latex to parse formulas, libclang for doxygen
+        run: sudo apt-get install texlive-font-utils ghostscript texlive-latex-extra graphviz libclang-9-dev libclang-cpp9
 
       - name: Build documentation
         env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 version: ~> 1.0
 os: linux
-dist: bionic
+dist: focal
 language: cpp
 
 git:
@@ -13,7 +13,7 @@ cache:
 addons:
   apt:
     sources:
-      - sourceline: 'ppa:ubuntu-toolchain-r/test'
+      - sourceline: 'ppa:ubuntu-toolchain-r/ppa'
     packages:
       - g++-7
       - g++-8
@@ -84,15 +84,15 @@ jobs:
       compiler: 'doxygen'
       addons:
         apt:
-          # adds epstopdf, ghostscript, latex
-          packages: ['texlive-font-utils', 'ghostscript', 'texlive-latex-extra']
+          # adds epstopdf, ghostscript, latex, libclang
+          packages: ['texlive-font-utils', 'ghostscript', 'texlive-latex-extra', 'libclang-9-dev', 'libclang-cpp9']
       env:
         - BUILD=documentation
       cache:
         directories:
           - /tmp/doxygen-download
       before_install:
-        - DOXYGEN_VER=1.8.17
+        - DOXYGEN_VER=1.8.19
         - DOXYGEN_FOLDER=doxygen-${DOXYGEN_VER}
         - mkdir -p /tmp/doxygen-download
         - wget --no-clobber --directory-prefix=/tmp/doxygen-download/ https://sourceforge.net/projects/doxygen/files/rel-${DOXYGEN_VER}/${DOXYGEN_FOLDER}.linux.bin.tar.gz


### PR DESCRIPTION
The prebuilt doxygen we use now needs libclang and glib>=2.29 (i.e. ubuntu 20.04).
Technically, focal is only provided as preview for github actions...

Fixes #2015