### PR TITLE
[Alignment Configuration] Rename align_cfg::alignment_result_capture to align_cfg::detail::result_type

### DIFF
--- a/include/seqan3/alignment/configuration/align_config_result_type.hpp
+++ b/include/seqan3/alignment/configuration/align_config_result_type.hpp
@@ -6,7 +6,7 @@
 // -----------------------------------------------------------------------------------------------------
 
 /*!\file
- * \brief Provides seqan3::align_cfg::alignment_result_capture.
+ * \brief Provides seqan3::align_cfg::detail::result_type and seqan3::detail::result_type_tag.
  * \author Rene Rahn <rene.rahn AT fu-berlin.de>
  */
 
@@ -28,25 +28,23 @@ namespace seqan3::detail
  *
  * \details
  *
- * Implementation of the alignment result capture config.
+ * Implementation of the alignment result type config.
  *
- * \see seqan3::align_cfg::alignment_result_capture
+ * \see seqan3::align_cfg::detail::result_type
  */
 template <typename alignment_result_t>
 //!\cond
     requires is_type_specialisation_of_v<alignment_result_t, alignment_result>
 //!\endcond
-struct alignment_result_capture_element :
-    public pipeable_config_element<alignment_result_capture_element<alignment_result_t>,
-                                   std::type_identity<alignment_result_t>>
+struct result_type_tag :
+    public pipeable_config_element<result_type_tag<alignment_result_t>, std::type_identity<alignment_result_t>>
 {
     //!\brief Internal id to check for consistent configuration settings.
-    static constexpr detail::align_config_id id{detail::align_config_id::alignment_result_capture};
+    static constexpr detail::align_config_id id{detail::align_config_id::result_type};
 };
-
 } // namespace seqan3::detail
 
-namespace seqan3::align_cfg
+namespace seqan3::align_cfg::detail
 {
 /*!\if DEV
  * \brief Configuration element capturing the configured seqan3::alignment_result for the alignment algorithm.
@@ -73,5 +71,5 @@ template <typename alignment_result_t>
 //!\cond
     requires seqan3::detail::is_type_specialisation_of_v<alignment_result_t, alignment_result>
 //!\endcond
-inline constexpr seqan3::detail::alignment_result_capture_element<alignment_result_t> alignment_result_capture{};
-}  // namespace seqan3::align_cfg
+inline constexpr seqan3::detail::result_type_tag<alignment_result_t> result_type{};
+} // namespace seqan3::align_cfg::detail

--- a/include/seqan3/alignment/configuration/align_config_vectorised.hpp
+++ b/include/seqan3/alignment/configuration/align_config_vectorised.hpp
@@ -26,7 +26,7 @@ namespace seqan3::detail
 struct vectorised_tag : public pipeable_config_element<vectorised_tag>
 {
     //!\brief Internal id to check for consistent configuration settings.
-    static constexpr detail::align_config_id id{detail::align_config_id::vectorised};
+    static constexpr align_config_id id{align_config_id::vectorised};
 };
 
 } // namespace seqan3::detail

--- a/include/seqan3/alignment/configuration/align_config_vectorised.hpp
+++ b/include/seqan3/alignment/configuration/align_config_vectorised.hpp
@@ -26,7 +26,7 @@ namespace seqan3::detail
 struct vectorised_tag : public pipeable_config_element<vectorised_tag>
 {
     //!\brief Internal id to check for consistent configuration settings.
-    static constexpr align_config_id id{align_config_id::vectorised};
+    static constexpr detail::align_config_id id{detail::align_config_id::vectorised};
 };
 
 } // namespace seqan3::detail

--- a/include/seqan3/alignment/configuration/all.hpp
+++ b/include/seqan3/alignment/configuration/all.hpp
@@ -13,7 +13,7 @@
  #pragma once
 
 #include <seqan3/alignment/configuration/align_config_aligned_ends.hpp>
-#include <seqan3/alignment/configuration/align_config_alignment_result_capture.hpp>
+#include <seqan3/alignment/configuration/align_config_result_type.hpp>
 #include <seqan3/alignment/configuration/align_config_band.hpp>
 #include <seqan3/alignment/configuration/align_config_debug.hpp>
 #include <seqan3/alignment/configuration/align_config_edit.hpp>

--- a/include/seqan3/alignment/configuration/detail.hpp
+++ b/include/seqan3/alignment/configuration/detail.hpp
@@ -22,8 +22,7 @@ namespace seqan3::detail
  */
 enum struct align_config_id : uint8_t
 {
-    //!\brief ID for the \ref seqan3::align_cfg::alignment_result_capture "alignment_result_capture" option.
-    alignment_result_capture,
+
     aligned_ends,          //!< ID for the \ref seqan3::align_cfg::aligned_ends "aligned_ends" option.
     band,                  //!< ID for the \ref seqan3::align_cfg::band_fixed_size "band" option.
     debug,                 //!< ID for the \ref seqan3::align_cfg::detail::debug "debug" option.
@@ -40,6 +39,7 @@ enum struct align_config_id : uint8_t
     output_score,          //!< ID for the \ref seqan3::align_cfg::output_score "score output" option.
     parallel,              //!< ID for the \ref seqan3::align_cfg::parallel "parallel" option.
     result,                //!< ID for the \ref seqan3::align_cfg::result "result" option.
+    result_type,           //!< ID for the \ref seqan3::align_cfg::detail::result_type "result_type" option.
     scoring,               //!< ID for the \ref seqan3::align_cfg::scoring_scheme "scoring_scheme" option.
     vectorised,            //!< ID for the \ref seqan3::align_cfg::vectorised "vectorised" option.
     SIZE                   //!< Represents the number of configuration elements.
@@ -58,42 +58,42 @@ template <>
 inline constexpr std::array<std::array<bool, static_cast<uint8_t>(align_config_id::SIZE)>,
                             static_cast<uint8_t>(align_config_id::SIZE)> compatibility_table<align_config_id>
 {
-    {   //alignment_result_capture
-        //|  aligned_ends
-        //|  |  band
-        //|  |  |  debug
-        //|  |  |  |  gap
-        //|  |  |  |  |  global
-        //|  |  |  |  |  |  local
-        //|  |  |  |  |  |  |  max_error
-        //|  |  |  |  |  |  |  |  on_result
-        //|  |  |  |  |  |  |  |  |  output_alignment
-        //|  |  |  |  |  |  |  |  |  |  output_begin_position
-        //|  |  |  |  |  |  |  |  |  |  |  output_end_position
-        //|  |  |  |  |  |  |  |  |  |  |  |  output_sequence1_id
-        //|  |  |  |  |  |  |  |  |  |  |  |  |  output_sequence2_id
-        //|  |  |  |  |  |  |  |  |  |  |  |  |  |  output_score
-        //|  |  |  |  |  |  |  |  |  |  |  |  |  |  |  parallel
-        //|  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  result
+    {   //aligned_ends
+        //|  band
+        //|  |  debug
+        //|  |  |  gap
+        //|  |  |  |  global
+        //|  |  |  |  |  local
+        //|  |  |  |  |  |  max_error
+        //|  |  |  |  |  |  |  on_result
+        //|  |  |  |  |  |  |  |  output_alignment
+        //|  |  |  |  |  |  |  |  |  output_begin_position
+        //|  |  |  |  |  |  |  |  |  |  output_end_position
+        //|  |  |  |  |  |  |  |  |  |  |  output_sequence1_id
+        //|  |  |  |  |  |  |  |  |  |  |  |  output_sequence2_id
+        //|  |  |  |  |  |  |  |  |  |  |  |  |  output_score
+        //|  |  |  |  |  |  |  |  |  |  |  |  |  |  parallel
+        //|  |  |  |  |  |  |  |  |  |  |  |  |  |  |  result
+        //|  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  result_type
         //|  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  scoring
         //|  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  vectorised
-        { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, //  0: alignment_result_capture
-        { 1, 0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, //  1: aligned_ends
-        { 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, //  2: band
-        { 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, //  3: debug
-        { 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, //  4: gap
-        { 1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, //  5: global
-        { 1, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, //  6: local
-        { 1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, //  7: max_error
-        { 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, //  8: on_result
-        { 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1}, //  9: output_alignment
-        { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1}, // 10: output_begin_position
-        { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1}, // 11: output_end_position
-        { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1}, // 12: output_sequence1_id
-        { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1}, // 13: output_sequence2_id
-        { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1}, // 14: output_score
-        { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1}, // 15: parallel
-        { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1}, // 16: result
+        { 0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, //  0: aligned_ends
+        { 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, //  1: band
+        { 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, //  2: debug
+        { 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, //  3: gap
+        { 1, 1, 1, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, //  4: global
+        { 0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, //  5: local
+        { 1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, //  6: max_error
+        { 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, //  7: on_result
+        { 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, //  8: output_alignment
+        { 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1}, //  9: output_begin_position
+        { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1}, // 10: output_end_position
+        { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1}, // 11: output_sequence1_id
+        { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1}, // 12: output_sequence2_id
+        { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1}, // 13: output_score
+        { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1}, // 14: parallel
+        { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1}, // 15: result
+        { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1}, // 16: result_type
         { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1}, // 17: scoring
         { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0}  // 18: vectorised
     }

--- a/include/seqan3/alignment/pairwise/alignment_configurator.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_configurator.hpp
@@ -17,8 +17,9 @@
 #include <utility>
 #include <vector>
 
-#include <seqan3/alignment/configuration/align_config_alignment_result_capture.hpp>
+
 #include <seqan3/alignment/configuration/align_config_output.hpp>
+#include <seqan3/alignment/configuration/align_config_result_type.hpp>
 #include <seqan3/alignment/matrix/detail/alignment_score_matrix_one_column.hpp>
 #include <seqan3/alignment/matrix/detail/alignment_score_matrix_one_column_banded.hpp>
 #include <seqan3/alignment/matrix/detail/alignment_trace_matrix_full.hpp>
@@ -295,7 +296,7 @@ public:
             using function_wrapper_t = std::function<void(indexed_sequence_pair_chunk_t, callback_on_result_t)>;
 
             // Capture the alignment result type.
-            auto config_with_result_type = config_with_output | align_cfg::alignment_result_capture<alignment_result_t>;
+            auto config_with_result_type = config_with_output | align_cfg::detail::result_type<alignment_result_t>;
 
             // ----------------------------------------------------------------------------
             // Test some basic preconditions

--- a/include/seqan3/alignment/pairwise/detail/type_traits.hpp
+++ b/include/seqan3/alignment/pairwise/detail/type_traits.hpp
@@ -15,7 +15,7 @@
 #include <type_traits>
 
 #include <seqan3/alignment/configuration/align_config_aligned_ends.hpp>
-#include <seqan3/alignment/configuration/align_config_alignment_result_capture.hpp>
+#include <seqan3/alignment/configuration/align_config_result_type.hpp>
 #include <seqan3/alignment/configuration/align_config_band.hpp>
 #include <seqan3/alignment/configuration/align_config_debug.hpp>
 #include <seqan3/alignment/configuration/align_config_method.hpp>
@@ -103,10 +103,10 @@ private:
     //!\brief Helper function to determine the alignment result type.
     static constexpr auto determine_alignment_result_type() noexcept
     {
-        if constexpr (configuration_t::template exists<alignment_result_capture_element>())
+        if constexpr (configuration_t::template exists<result_type_tag>())
         {
             using wrapped_result_t =
-                decltype(seqan3::get<alignment_result_capture_element>(std::declval<configuration_t>()).value);
+                decltype(seqan3::get<result_type_tag>(std::declval<configuration_t>()).value);
             return typename wrapped_result_t::type{};  // Unwrap the type_identity.
         }
         else

--- a/test/performance/alignment/edit_distance_unbanded_benchmark.cpp
+++ b/test/performance/alignment/edit_distance_unbanded_benchmark.cpp
@@ -71,7 +71,7 @@ void seqan3_edit_distance_dna4(benchmark::State & state)
     using alignment_result_t = alignment_result_type_t<seq1_ref_t, seq2_ref_t, decltype(edit_distance_cfg)>;
 
     auto edit_distance_cfg_with_result_type = edit_distance_cfg |
-                                              seqan3::align_cfg::alignment_result_capture<alignment_result_t>;
+                                              seqan3::align_cfg::detail::result_type<alignment_result_t>;
 
     using edit_traits_t = seqan3::detail::default_edit_distance_trait_type<seq1_ref_t,
                                                                            seq2_ref_t,
@@ -167,7 +167,7 @@ void seqan3_edit_distance_dna4_collection(benchmark::State & state)
     using alignment_result_t = alignment_result_type_t<seq1_ref_t, seq2_ref_t, decltype(edit_distance_cfg)>;
 
     auto edit_distance_cfg_with_result_type = edit_distance_cfg |
-                                              seqan3::align_cfg::alignment_result_capture<alignment_result_t>;
+                                              seqan3::align_cfg::detail::result_type<alignment_result_t>;
 
     using edit_traits_t = seqan3::detail::default_edit_distance_trait_type<seq1_ref_t,
                                                                            seq2_ref_t,

--- a/test/unit/alignment/configuration/align_config_common_test.cpp
+++ b/test/unit/alignment/configuration/align_config_common_test.cpp
@@ -28,7 +28,7 @@ using test_types = ::testing::Types<seqan3::align_cfg::aligned_ends<std::remove_
                                     seqan3::align_cfg::result<>,
                                     seqan3::align_cfg::scoring_scheme<seqan3::nucleotide_scoring_scheme<int8_t>>,
                                     seqan3::detail::vectorised_tag,
-                                    seqan3::detail::alignment_result_capture_element<alignment_result_t>>;
+                                    seqan3::detail::result_type_tag<alignment_result_t>>;
 
 TYPED_TEST_SUITE(alignment_configuration_test, test_types, );
 

--- a/test/unit/alignment/pairwise/edit_distance_unbanded_test_template.hpp
+++ b/test/unit/alignment/pairwise/edit_distance_unbanded_test_template.hpp
@@ -9,7 +9,7 @@
 
 #include <gtest/gtest.h>
 
-#include <seqan3/alignment/configuration/align_config_alignment_result_capture.hpp>
+#include <seqan3/alignment/configuration/align_config_result_type.hpp>
 #include <seqan3/alignment/pairwise/edit_distance_unbanded.hpp>
 
 #include <seqan3/range/views/to_char.hpp>
@@ -94,7 +94,7 @@ auto edit_distance(database_t && database, query_t && query, align_cfg_t && alig
                                                        std::remove_reference_t<align_cfg_with_score_type_t>>::type;
     using alignment_result_t = seqan3::alignment_result<alignment_result_value_t>;
     auto align_cfg_with_result_type = align_cfg_with_score_type |
-                                      seqan3::align_cfg::alignment_result_capture<alignment_result_t>;
+                                      seqan3::align_cfg::detail::result_type<alignment_result_t>;
     using align_config_with_result_type_t = decltype(align_cfg_with_result_type);
     using edit_traits = edit_traits_type<compute_score_matrix,
                                          database_t,


### PR DESCRIPTION
Resolves seqan/product_backlog#183

This moves the alignment_result_capture to a new namespace seqan3::align_cfg::detail and then renames it to result_type.
I needed to specify the whole namespace path seqan3::detail::XX for most of the view files. This is due to the newly created seqan3::align_cfg::detail which had a name clash with seqan3::detail.

Merging this PR closes #2018 because it has the same intention.

Blocked by #2033