### PR TITLE
[INFRA] GitHub CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,81 +18,90 @@ jobs:
           access_token: ${{ github.token }}
   build:
     needs: cancel
-    name: ${{ matrix.config.name }}
+    name: ${{ matrix.name }}
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
-        config:
-        - {
-            name: "Coverage gcc7",
-            CXX: "g++-7",
-            CC: "gcc-7",
-            build: coverage,
+        include:
+          - name: "Coverage gcc7"
+            requires_ubuntu_toolchain: true
+            requires_ccache: true
+            cxx: "g++-7"
+            cc: "gcc-7"
+            build: coverage
             build_type: Debug
-          }
-        - {
-            name: "Unit gcc9 (c++2a)",
-            CXX: "g++-9",
-            CC: "gcc-9",
-            build: unit,
-            build_type: Release,
-            CXXFLAGS: "-std=c++2a"
-          }
-        - {
-            name: "Unit gcc10 (c++17)",
-            CXX: "g++-10",
-            CC: "gcc-10",
-            build: unit,
-            build_type: Release,
-            CXXFLAGS: "-std=c++17 -fconcepts"
-          }
-        - {
-            name: "Unit gcc10 (c++20)",
-            CXX: "g++-10",
-            CC: "gcc-10",
-            build: unit,
+
+          - name: "Unit gcc9 (c++2a)"
+            requires_ubuntu_toolchain: true
+            requires_ccache: true
+            cxx: "g++-9"
+            cc: "gcc-9"
+            build: unit
             build_type: Release
-          }
-        - {
-            name: "Unit gcc8",
-            CXX: "g++-8",
-            CC: "gcc-8",
-            build: unit,
+            cxx_flags: "-std=c++2a"
+
+          - name: "Unit gcc10 (c++17)"
+            requires_ubuntu_toolchain: true
+            requires_ccache: true
+            cxx: "g++-10"
+            cc: "gcc-10"
+            build: unit
             build_type: Release
-          }
-        - {
-            name: "Unit gcc7",
-            CXX: "g++-7",
-            CC: "gcc-7",
-            build: unit,
+            cxx_flags: "-std=c++17 -fconcepts"
+
+          - name: "Unit gcc10 (c++20)"
+            requires_ubuntu_toolchain: true
+            requires_ccache: true
+            cxx: "g++-10"
+            cc: "gcc-10"
+            build: unit
             build_type: Release
-          }
-        - {
-            name: "Performance gcc7",
-            CXX: "g++-7",
-            CC: "gcc-7",
-            build: performance,
+
+          - name: "Unit gcc8"
+            requires_ubuntu_toolchain: true
+            requires_ccache: true
+            cxx: "g++-8"
+            cc: "gcc-8"
+            build: unit
             build_type: Release
-          }
-        - {
-            name: "Header gcc7",
-            CXX: "g++-7",
-            CC: "gcc-7",
-            build: header,
+
+          - name: "Unit gcc7"
+            requires_ubuntu_toolchain: true
+            requires_ccache: true
+            cxx: "g++-7"
+            cc: "gcc-7"
+            build: unit
             build_type: Release
-          }
-        - {
-            name: "Snippet gcc7",
-            CXX: "g++-7",
-            CC: "gcc-7",
-            build: snippet,
+
+          - name: "Performance gcc7"
+            requires_ubuntu_toolchain: true
+            requires_ccache: true
+            cxx: "g++-7"
+            cc: "gcc-7"
+            build: performance
             build_type: Release
-          }
-        - {
-            name: "Documentation",
+
+          - name: "Header gcc7"
+            requires_ubuntu_toolchain: true
+            requires_ccache: true
+            cxx: "g++-7"
+            cc: "gcc-7"
+            build: header
+            build_type: Release
+
+          - name: "Snippet gcc7"
+            requires_ubuntu_toolchain: true
+            requires_ccache: true
+            cxx: "g++-7"
+            cc: "gcc-7"
+            build: snippet
+            build_type: Release
+
+          - name: "Documentation"
+            requires_ubuntu_toolchain: false
+            requires_ccache: false
             build: documentation
-          }
 
     steps:
       - name: Checkout
@@ -110,7 +119,7 @@ jobs:
           echo "::add-path::/tmp/cmake-${CMAKE_VERSION}-Linux-x86_64/bin" # Only available in subsequent steps!
 
       - name: Setup Doxygen
-        if: matrix.config.build == 'documentation'
+        if: matrix.build == 'documentation'
         shell: bash
         run: |
           sudo apt-get install texlive-font-utils ghostscript texlive-latex-extra graphviz libclang-9-dev libclang-cpp9 # graphviz for dot, latex to parse formulas, libclang for doxygen
@@ -120,44 +129,29 @@ jobs:
           echo "::add-path::/tmp/doxygen-${DOXYGEN_VERSION}/bin" # Only available in subsequent steps!
 
       - name: Add package source
-        if: matrix.config.build != 'documentation'
+        if: matrix.requires_ubuntu_toolchain
         shell: bash
         run: sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/ppa && sudo apt-get update
 
       - name: Install ccache
-        if: matrix.config.build != 'documentation'
+        if: matrix.requires_ccache
         shell: bash
         run: sudo apt-get install --yes ccache
 
-      - name: Install GCC 7
-        if: matrix.config.cxx == 'g++-7'
+      - name: Install compiler ${{ matrix.cxx }}
+        if: matrix.requires_ubuntu_toolchain
         shell: bash
-        run: sudo apt-get install --yes g++-7
-
-      - name: Install GCC 8
-        if: matrix.config.cxx == 'g++-8'
-        shell: bash
-        run: sudo apt-get install --yes g++-8
-
-      - name: Install GCC 9
-        if: matrix.config.cxx == 'g++-9'
-        shell: bash
-        run: sudo apt-get install --yes g++-9
-
-      - name: Install GCC 10
-        if: matrix.config.cxx == 'g++-10'
-        shell: bash
-        run: sudo apt-get install --yes g++-10
+        run: sudo apt-get install --yes ${{ matrix.cxx }}
 
       - name: Install lcov
-        if: matrix.config.build == 'coverage'
+        if: matrix.build == 'coverage'
         shell: bash
         run: |
           sudo apt-get install --yes lcov
           sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-7 100
 
       - name: Prepare ccache
-        if: matrix.config.build != 'documentation'
+        if: matrix.requires_ccache
         id: ccache_prepare
         shell: cmake -P {0}
         run: |
@@ -165,36 +159,32 @@ jobs:
           message("::set-output name=timestamp::${current_date}")
 
       - name: Load ccache
-        if: matrix.config.build != 'documentation'
+        if: matrix.requires_ccache
         uses: actions/cache@v1.1.0
         with:
           path: .ccache
-          key: ${{ matrix.config.name }}-ccache-${{ steps.ccache_prepare.outputs.timestamp }}
+          key: ${{ matrix.name }}-ccache-${{ steps.ccache_prepare.outputs.timestamp }}
           restore-keys: |
-            ${{ matrix.config.name }}-ccache-
+            ${{ matrix.name }}-ccache-
 
       - name: Configure tests
         env:
-          CXX: ${{ matrix.config.cxx }}
-          CC: ${{ matrix.config.cc }}
-          CXXFLAGS: ${{ matrix.config.cxxflags }}
-          BUILD: ${{ matrix.config.build }}
-          BUILD_TYPE: ${{ matrix.config.build_type }}
+          CXX: ${{ matrix.cxx }}
+          CC: ${{ matrix.cc }}
         shell: bash
         run: |
           mkdir seqan3-build
           cd seqan3-build
-          cmake ../seqan3/test/${BUILD} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_CXX_FLAGS="${CXXFLAGS}"
-          if [[ "${BUILD}" =~ ^(unit|header|snippet|coverage)$ ]]; then
+          cmake ../seqan3/test/${{ matrix.build }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_CXX_FLAGS="${{ matrix.cxx_flags }}"
+          if [[ "${{ matrix.build }}" =~ ^(unit|header|snippet|coverage)$ ]]; then
             make gtest_project
           fi
-          if [[ "${BUILD}" =~ ^(performance)$ ]]; then
+          if [[ "${{ matrix.build }}" =~ ^(performance)$ ]]; then
             make gbenchmark_project
           fi
 
-      - name: Build and run tests
+      - name: Build tests
         env:
-          BUILD: ${{ matrix.config.build }}
           CCACHE_BASEDIR: ${{ github.workspace }}
           CCACHE_DIR: ${{ github.workspace }}/.ccache
           CCACHE_COMPRESS: true
@@ -205,26 +195,33 @@ jobs:
           ccache -p || true
           cd seqan3-build
           make -k -j2
-          if [[ "${BUILD}" =~ ^(coverage)$ ]]; then
+          ccache -s || true
+
+      - name: Run tests
+        shell: bash
+        run: |
+          cd seqan3-build
+          if [[ "${{ matrix.build }}" =~ ^(coverage)$ ]]; then
             : ; else
-            if [[ "${BUILD}" =~ ^(snippet)$ ]]; then
+            if [[ "${{ matrix.build }}" =~ ^(snippet)$ ]]; then
               ctest . --output-on-failure]; else
               ctest . -j2 --output-on-failure
             fi
           fi
-          ccache -s || true
 
       - name: Submit coverage build
-        if: matrix.config.build == 'coverage'
+        if: matrix.build == 'coverage'
         shell: bash
         run: bash <(curl -s https://codecov.io/bash) -f ./seqan3-build/seqan3_coverage -R ./seqan3 || echo 'Codecov failed to upload'
 
-      - name: Tar documentation
-        if: matrix.config.build == 'documentation'
+      - name: Package documentation
+        if: matrix.build == 'documentation'
+        continue-on-error: true
         run: tar -zcf documentation.tar.gz seqan3-build
 
       - name: Upload documentation
-        if: matrix.config.build == 'documentation'
+        if: matrix.build == 'documentation'
+        continue-on-error: true
         uses: actions/upload-artifact@v2
         with:
           name: documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,231 @@
+name: SeqAn3 CI
+
+on: [push, pull_request]
+
+env:
+  CMAKE_VERSION: 3.7.2
+  DOXYGEN_VERSION: 1.8.19
+  SEQAN3_NO_VERSION_CHECK: 1
+  TZ: Europe/Berlin
+
+jobs:
+  cancel:
+    name: "Cancel previous runs"
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: styfle/cancel-workflow-action@0.4.1
+        with:
+          access_token: ${{ github.token }}
+  build:
+    needs: cancel
+    name: ${{ matrix.config.name }}
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+        - {
+            name: "Coverage gcc7",
+            CXX: "g++-7",
+            CC: "gcc-7",
+            build: coverage,
+            build_type: Debug
+          }
+        - {
+            name: "Unit gcc9 (c++2a)",
+            CXX: "g++-9",
+            CC: "gcc-9",
+            build: unit,
+            build_type: Release,
+            CXXFLAGS: "-std=c++2a"
+          }
+        - {
+            name: "Unit gcc10 (c++17)",
+            CXX: "g++-10",
+            CC: "gcc-10",
+            build: unit,
+            build_type: Release,
+            CXXFLAGS: "-std=c++17 -fconcepts"
+          }
+        - {
+            name: "Unit gcc10 (c++20)",
+            CXX: "g++-10",
+            CC: "gcc-10",
+            build: unit,
+            build_type: Release
+          }
+        - {
+            name: "Unit gcc8",
+            CXX: "g++-8",
+            CC: "gcc-8",
+            build: unit,
+            build_type: Release
+          }
+        - {
+            name: "Unit gcc7",
+            CXX: "g++-7",
+            CC: "gcc-7",
+            build: unit,
+            build_type: Release
+          }
+        - {
+            name: "Performance gcc7",
+            CXX: "g++-7",
+            CC: "gcc-7",
+            build: performance,
+            build_type: Release
+          }
+        - {
+            name: "Header gcc7",
+            CXX: "g++-7",
+            CC: "gcc-7",
+            build: header,
+            build_type: Release
+          }
+        - {
+            name: "Snippet gcc7",
+            CXX: "g++-7",
+            CC: "gcc-7",
+            build: snippet,
+            build_type: Release
+          }
+        - {
+            name: "Documentation",
+            build: documentation
+          }
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          path: seqan3
+          submodules: true
+
+      - name: Setup CMake
+        shell: bash
+        run: |
+          mkdir -p /tmp/cmake-download
+          wget --no-clobber --quiet --directory-prefix=/tmp/cmake-download/ https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz
+          tar -C /tmp/ -zxf /tmp/cmake-download/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz
+          echo "::add-path::/tmp/cmake-${CMAKE_VERSION}-Linux-x86_64/bin" # Only available in subsequent steps!
+
+      - name: Setup Doxygen
+        if: matrix.config.build == 'documentation'
+        shell: bash
+        run: |
+          sudo apt-get install texlive-font-utils ghostscript texlive-latex-extra graphviz libclang-9-dev libclang-cpp9 # graphviz for dot, latex to parse formulas, libclang for doxygen
+          mkdir -p /tmp/doxygen-download
+          wget --no-clobber --quiet --directory-prefix=/tmp/doxygen-download/ https://sourceforge.net/projects/doxygen/files/rel-${DOXYGEN_VERSION}/doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz
+          tar -C /tmp/ -zxf /tmp/doxygen-download/doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz
+          echo "::add-path::/tmp/doxygen-${DOXYGEN_VERSION}/bin" # Only available in subsequent steps!
+
+      - name: Add package source
+        if: matrix.config.build != 'documentation'
+        shell: bash
+        run: sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/ppa && sudo apt-get update
+
+      - name: Install ccache
+        if: matrix.config.build != 'documentation'
+        shell: bash
+        run: sudo apt-get install --yes ccache
+
+      - name: Install GCC 7
+        if: matrix.config.cxx == 'g++-7'
+        shell: bash
+        run: sudo apt-get install --yes g++-7
+
+      - name: Install GCC 8
+        if: matrix.config.cxx == 'g++-8'
+        shell: bash
+        run: sudo apt-get install --yes g++-8
+
+      - name: Install GCC 9
+        if: matrix.config.cxx == 'g++-9'
+        shell: bash
+        run: sudo apt-get install --yes g++-9
+
+      - name: Install GCC 10
+        if: matrix.config.cxx == 'g++-10'
+        shell: bash
+        run: sudo apt-get install --yes g++-10
+
+      - name: Install lcov
+        if: matrix.config.build == 'coverage'
+        shell: bash
+        run: |
+          sudo apt-get install --yes lcov
+          sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-7 100
+
+      - name: Prepare ccache
+        if: matrix.config.build != 'documentation'
+        id: ccache_prepare
+        shell: cmake -P {0}
+        run: |
+          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S")
+          message("::set-output name=timestamp::${current_date}")
+
+      - name: Load ccache
+        if: matrix.config.build != 'documentation'
+        uses: actions/cache@v1.1.0
+        with:
+          path: .ccache
+          key: ${{ matrix.config.name }}-ccache-${{ steps.ccache_prepare.outputs.timestamp }}
+          restore-keys: |
+            ${{ matrix.config.name }}-ccache-
+
+      - name: Configure tests
+        env:
+          CXX: ${{ matrix.config.cxx }}
+          CC: ${{ matrix.config.cc }}
+          CXXFLAGS: ${{ matrix.config.cxxflags }}
+          BUILD: ${{ matrix.config.build }}
+          BUILD_TYPE: ${{ matrix.config.build_type }}
+        shell: bash
+        run: |
+          mkdir seqan3-build
+          cd seqan3-build
+          cmake ../seqan3/test/${BUILD} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_CXX_FLAGS="${CXXFLAGS}"
+          if [[ "${BUILD}" =~ ^(unit|header|snippet|coverage)$ ]]; then
+            make gtest_project
+          fi
+          if [[ "${BUILD}" =~ ^(performance)$ ]]; then
+            make gbenchmark_project
+          fi
+
+      - name: Build and run tests
+        env:
+          BUILD: ${{ matrix.config.build }}
+          CCACHE_BASEDIR: ${{ github.workspace }}
+          CCACHE_DIR: ${{ github.workspace }}/.ccache
+          CCACHE_COMPRESS: true
+          CCACHE_COMPRESSLEVEL: 6
+          CCACHE_MAXSIZE: 5G
+        shell: bash
+        run: |
+          ccache -p || true
+          cd seqan3-build
+          make -k -j2
+          if [[ "${BUILD}" =~ ^(coverage)$ ]]; then
+            : ; else
+            if [[ "${BUILD}" =~ ^(snippet)$ ]]; then
+              ctest . --output-on-failure]; else
+              ctest . -j2 --output-on-failure
+            fi
+          fi
+          ccache -s || true
+
+      - name: Submit coverage build
+        if: matrix.config.build == 'coverage'
+        shell: bash
+        run: bash <(curl -s https://codecov.io/bash) -f ./seqan3-build/seqan3_coverage -R ./seqan3 || echo 'Codecov failed to upload'
+
+      - name: Tar documentation
+        if: matrix.config.build == 'documentation'
+        run: tar -zcf documentation.tar.gz seqan3-build
+
+      - name: Upload documentation
+        if: matrix.config.build == 'documentation'
+        uses: actions/upload-artifact@v2
+        with:
+          name: documentation
+          path: documentation.tar.gz

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SeqAn3 -- the modern C++ library for sequence analysis
 
-[![build status](https://img.shields.io/travis/seqan/seqan3/master.svg?logo=travis)](https://travis-ci.org/seqan/seqan3)
+[![build status](https://github.com/seqan/seqan3/workflows/SeqAn3%20CI/badge.svg?branch=master)](https://github.com/seqan/seqan3/actions)
 [![codecov](https://codecov.io/gh/seqan/seqan3/branch/master/graph/badge.svg?logo=codecov)](https://codecov.io/gh/seqan/seqan3)
 [![license](https://img.shields.io/badge/license-BSD-green.svg)](https://docs.seqan.de/seqan/3-master-user/about_copyright.html)
 [![latest release](https://img.shields.io/github/release/seqan/seqan3.svg)](https://github.com/seqan/seqan3/releases/latest)


### PR DESCRIPTION
We can set travis to not build on pushed branches and pull requests. 
I would then maybe use travis to run the CI as a nightly on multiple CPU architectures.


Note:
The build-folder of the documentation (containing doc_dev and doc_usr) is provided as an artefact after the job ran. You can download it from the `checks` tab and then click `artifacts` on the top right or `SeqAn3 CI` on the left and find it there.

The artefact is only available after the **whole** (all test suites / compilers - not just the documentation job) GitHub actions run is complete - this is a limitation on GitHub's side.

The artifact will always be zipped (also a limitation on GitHub's side). That means the documentation will be provided as `documentation.tar.gz.zip`.