### PR TITLE
[FIX] use std::ranges::borrowed_range instead of seqan3::forwarding_range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ Note that 3.1.0 will be the first API stable release and interfaces in this rele
 * The `seqan3::begin()`, `seqan3::end()`, `seqan3::cbegin()`, `seqan3::cend()`, `seqan3::size()`, `seqan3::empty()`
   functions have been deprecated:
   Use `std::ranges::{begin|end|cbegin|cend|size|empty}()` instead ([\#1663](https://github.com/seqan/seqan3/pull/1663)).
+* We removed `seqan3::forward_range`. Use `std::ranges::borrowed_range` instead ([\#2038](https://github.com/seqan/seqan3/pull/2038)).
 * Added `seqan3::views::minimiser`, a view that computes the minimum in a window shifted over a range of comparable values.
   ([\#1654](https://github.com/seqan/seqan3/pull/1654)).
 * Added `seqan3::views::minimiser_hash`, a view that computes the minimisers of a range of type seqan3::semialphabet.

--- a/include/seqan3/io/alignment_file/format_bam.hpp
+++ b/include/seqan3/io/alignment_file/format_bam.hpp
@@ -814,7 +814,7 @@ inline void format_bam::write_alignment_record([[maybe_unused]] stream_type &  s
 
                         if constexpr (std::ranges::contiguous_range<decltype(id_source)> &&
                                       std::ranges::sized_range<decltype(id_source)> &&
-                                      forwarding_range<decltype(id_source)>)
+                                      std::ranges::borrowed_range<decltype(id_source)>)
                         {
                             id_it = header.ref_dict.find(std::span{std::ranges::data(id_source),
                                                                    std::ranges::size(id_source)});

--- a/include/seqan3/io/alignment_file/format_sam.hpp
+++ b/include/seqan3/io/alignment_file/format_sam.hpp
@@ -754,7 +754,7 @@ inline void format_sam::write_alignment_record(stream_type & stream,
 
             if constexpr (std::ranges::contiguous_range<decltype(ref_id)> &&
                           std::ranges::sized_range<decltype(ref_id)> &&
-                          forwarding_range<decltype(ref_id)>)
+                          std::ranges::borrowed_range<decltype(ref_id)>)
             {
                 id_it = header.ref_dict.find(std::span{std::ranges::data(ref_id), std::ranges::size(ref_id)});
             }

--- a/include/seqan3/io/alignment_file/input.hpp
+++ b/include/seqan3/io/alignment_file/input.hpp
@@ -940,7 +940,7 @@ protected:
             if constexpr (std::ranges::contiguous_range<std::ranges::range_reference_t<
                                                             typename traits_type::ref_ids>> &&
                           std::ranges::sized_range<std::ranges::range_reference_t<typename traits_type::ref_ids>> &&
-                          forwarding_range<std::ranges::range_reference_t<typename traits_type::ref_ids>>)
+                          std::ranges::borrowed_range<std::ranges::range_reference_t<typename traits_type::ref_ids>>)
             {
                 auto && id = header_ptr->ref_ids()[idx];
                 header_ptr->ref_dict[std::span{std::ranges::data(id), std::ranges::size(id)}] = idx;

--- a/include/seqan3/io/alignment_file/output.hpp
+++ b/include/seqan3/io/alignment_file/output.hpp
@@ -749,7 +749,7 @@ protected:
 
             if constexpr (std::ranges::contiguous_range<std::ranges::range_reference_t<ref_ids_type_>> &&
                           std::ranges::sized_range<std::ranges::range_reference_t<ref_ids_type_>> &&
-                          forwarding_range<std::ranges::range_reference_t<ref_ids_type_>>)
+                          std::ranges::borrowed_range<std::ranges::range_reference_t<ref_ids_type_>>)
             {
                 auto && id = header_ptr->ref_ids()[idx];
                 header_ptr->ref_dict[std::span{std::ranges::data(id), std::ranges::size(id)}] = idx;

--- a/include/seqan3/io/stream/iterator.hpp
+++ b/include/seqan3/io/stream/iterator.hpp
@@ -272,7 +272,7 @@ public:
     /*!\brief Writes a range to the associated output.
      * \tparam range_type The type of range to write; Must model std::ranges::forward_range.
      * \param[in] rng The range to write.
-     * \returns If `range_type` models `std::ranges::forwarding_range` returns an iterator pointing to end of the range
+     * \returns If `range_type` models `std::ranges::borrowed_range` returns an iterator pointing to end of the range
      *          (rng) else returns `void`.
      *
      * This function avoids the buffer-at-end check by writing the range in chunks, where a chunks has the size of
@@ -281,7 +281,7 @@ public:
      * may use memcpy if applicable. Otherwise, a simple for loop iterates over the chunk.
      *
      * \attention You can only use the return value (end iterator) if your range type models
-     *            `std::ranges::forwarding_range`.
+     *            `std::ranges::borrowed_range`.
      *
      * Example:
      *
@@ -289,7 +289,7 @@ public:
      */
     template <std::ranges::forward_range range_type>
     //!\cond
-        requires forwarding_range<range_type>
+        requires std::ranges::borrowed_range<range_type>
     //!\endcond
     auto write_range(range_type && rng)
     {
@@ -336,7 +336,7 @@ public:
     }
 
     //!\cond
-    // overload for non-forwarding_range types that return void
+    // overload for non-std::ranges::borrowed_range types that return void
     template <std::ranges::forward_range range_type>
     void write_range(range_type && rng)
     {

--- a/include/seqan3/range/concept.hpp
+++ b/include/seqan3/range/concept.hpp
@@ -48,21 +48,6 @@ SEQAN3_CONCEPT const_iterable_range =
     (std::ranges::random_access_range<std::remove_const_t<type>> == std::ranges::random_access_range<type const>);
 //!\endcond
 
-/*!\interface seqan3::forwarding_range<>
- * \ingroup range
- * \extends std::ranges::range
- * \brief Specifies a range whose iterators may outlive the range and remain valid.
- * \see https://eel.is/c++draft/range.req
- */
-//!\cond
-template <typename type>
-SEQAN3_CONCEPT forwarding_range = std::ranges::range<type> && requires (type && val)
-{
-    std::ranges::begin(std::forward<type>(val));
-    std::ranges::end(std::forward<type>(val));
-};
-//!\endcond
-
 /*!\interface seqan3::pseudo_random_access_iterator <>
  * \ingroup range
  * \extends   std::forward_iterator

--- a/include/seqan3/range/views/drop.hpp
+++ b/include/seqan3/range/views/drop.hpp
@@ -70,14 +70,14 @@ struct drop_fn
             return std::basic_string_view{std::ranges::data(urange) + drop_size, new_size};
         }
         // contiguous
-        else if constexpr (forwarding_range<urng_t> &&
+        else if constexpr (std::ranges::borrowed_range<urng_t> &&
                            std::ranges::contiguous_range<urng_t> &&
                            std::ranges::sized_range<urng_t>)
         {
             return std::span{std::ranges::data(urange) + drop_size, new_size};
         }
         // random_access
-        else if constexpr (forwarding_range<urng_t> &&
+        else if constexpr (std::ranges::borrowed_range<urng_t> &&
                            std::ranges::random_access_range<urng_t> &&
                            std::ranges::sized_range<urng_t>)
         {
@@ -145,12 +145,12 @@ namespace seqan3::views
  *
  * ### Return type
  *
- * | `urng_t` (underlying range type)                                                           | `rrng_t` (returned range type)  |
- * |:------------------------------------------------------------------------------------------:|:-------------------------------:|
- * | `std::basic_string const &` *or* `std::basic_string_view`                                  | `std::basic_string_view`        |
- * | `seqan3::forwarding_range && std::ranges::sized_range && std::ranges::contiguous_range`    | `std::span`                     |
- * | `seqan3::forwarding_range && std::ranges::sized_range && std::ranges::random_access_range` | `std::ranges::subrange`         |
- * | *else*                                                                                     | *implementation defined type*   |
+ * | `urng_t` (underlying range type)                                                              | `rrng_t` (returned range type)  |
+ * |:---------------------------------------------------------------------------------------------:|:-------------------------------:|
+ * | `std::basic_string const &` *or* `std::basic_string_view`                                     | `std::basic_string_view`        |
+ * | `std::ranges::borrowed_range && std::ranges::sized_range && std::ranges::contiguous_range`    | `std::span`                     |
+ * | `std::ranges::borrowed_range && std::ranges::sized_range && std::ranges::random_access_range` | `std::ranges::subrange`         |
+ * | *else*                                                                                        | *implementation defined type*   |
  *
  * The adaptor is different from std::views::drop in that it performs type erasure for some underlying ranges.
  * It returns exactly the type specified above.

--- a/include/seqan3/range/views/slice.hpp
+++ b/include/seqan3/range/views/slice.hpp
@@ -119,12 +119,12 @@ namespace seqan3::views
  *
  * ### Return type
  *
- * | `urng_t` (underlying range type)                                                           | `rrng_t` (returned range type)  |
- * |:------------------------------------------------------------------------------------------:|:-------------------------------:|
- * | `std::basic_string const &` *or* `std::basic_string_view`                                  | `std::basic_string_view`        |
- * | `seqan3::forwarding_range && std::ranges::sized_range && std::ranges::contiguous_range`    | `std::span`                     |
- * | `seqan3::forwarding_range && std::ranges::sized_range && std::ranges::random_access_range` | `std::ranges::subrange`         |
- * | *else*                                                                                     | *implementation defined type*   |
+ * | `urng_t` (underlying range type)                                                              | `rrng_t` (returned range type)  |
+ * |:---------------------------------------------------------------------------------------------:|:-------------------------------:|
+ * | `std::basic_string const &` *or* `std::basic_string_view`                                     | `std::basic_string_view`        |
+ * | `std::ranges::borrowed_range && std::ranges::sized_range && std::ranges::contiguous_range`    | `std::span`                     |
+ * | `std::ranges::borrowed_range && std::ranges::sized_range && std::ranges::random_access_range` | `std::ranges::subrange`         |
+ * | *else*                                                                                        | *implementation defined type*   |
  *
  * The adaptor returns exactly the type specified above.
  *

--- a/include/seqan3/range/views/take.hpp
+++ b/include/seqan3/range/views/take.hpp
@@ -507,14 +507,14 @@ struct take_fn
             return std::basic_string_view{std::ranges::data(urange), target_size};
         }
         // contiguous
-        else if constexpr (forwarding_range<urng_t> &&
+        else if constexpr (std::ranges::borrowed_range<urng_t> &&
                            std::ranges::contiguous_range<urng_t> &&
                            std::ranges::sized_range<urng_t>)
         {
             return std::span{std::ranges::data(urange), target_size};
         }
         // random_access
-        else if constexpr (forwarding_range<urng_t> &&
+        else if constexpr (std::ranges::borrowed_range<urng_t> &&
                            std::ranges::random_access_range<urng_t> &&
                            std::ranges::sized_range<urng_t>)
         {
@@ -586,12 +586,12 @@ namespace seqan3::views
  *
  * ### Return type
  *
- * | `urng_t` (underlying range type)                                                           | `rrng_t` (returned range type)  |
- * |:------------------------------------------------------------------------------------------:|:-------------------------------:|
- * | `std::basic_string const &` *or* `std::basic_string_view`                                  | `std::basic_string_view`        |
- * | `seqan3::forwarding_range && std::ranges::sized_range && std::ranges::contiguous_range`    | `std::span`                     |
- * | `seqan3::forwarding_range && std::ranges::sized_range && std::ranges::random_access_range` | `std::ranges::subrange`         |
- * | *else*                                                                                     | *implementation defined type*   |
+ * | `urng_t` (underlying range type)                                                              | `rrng_t` (returned range type)  |
+ * |:---------------------------------------------------------------------------------------------:|:-------------------------------:|
+ * | `std::basic_string const &` *or* `std::basic_string_view`                                     | `std::basic_string_view`        |
+ * | `std::ranges::borrowed_range && std::ranges::sized_range && std::ranges::contiguous_range`    | `std::span`                     |
+ * | `std::ranges::borrowed_range && std::ranges::sized_range && std::ranges::random_access_range` | `std::ranges::subrange`         |
+ * | *else*                                                                                        | *implementation defined type*   |
  *
  * This adaptor is different from std::views::take in that it performs type erasure for some underlying ranges.
  * It returns exactly the type specified above.

--- a/include/seqan3/range/views/type_reduce.hpp
+++ b/include/seqan3/range/views/type_reduce.hpp
@@ -65,14 +65,14 @@ private:
             return std::basic_string_view{std::ranges::data(urange), std::ranges::size(urange)};
         }
         // contiguous
-        else if constexpr (forwarding_range<urng_t> &&
+        else if constexpr (std::ranges::borrowed_range<urng_t> &&
                            std::ranges::contiguous_range<urng_t> &&
                            std::ranges::sized_range<urng_t>)
         {
             return std::span{std::ranges::data(urange), std::ranges::size(urange)};
         }
         // random_access
-        else if constexpr (forwarding_range<urng_t> &&
+        else if constexpr (std::ranges::borrowed_range<urng_t> &&
                            std::ranges::random_access_range<urng_t> &&
                            std::ranges::sized_range<urng_t>)
         {
@@ -138,13 +138,13 @@ namespace seqan3::views
  *
  * ### Return type
  *
- * | `urng_t` (underlying range type)                                                               | `rrng_t` (returned range type)  |
- * |:----------------------------------------------------------------------------------------------:|:-------------------------------:|
- * | `std::ranges::view`                                                                            | `urng_t`                        |
- * | `std::basic_string const &` *or* `std::basic_string_view`                                      | `std::basic_string_view`        |
- * | `seqan3::forwarding_range && std::ranges::sized_range && std::ranges::contiguous_range`        | `std::span`                     |
- * | `seqan3::forwarding_range && std::ranges::sized_range && std::ranges::random_access_range`     | `std::ranges::subrange`         |
- * | *else*                                                                                         | `std::ranges::ref_view<urng_t>` |
+ * | `urng_t` (underlying range type)                                                                  | `rrng_t` (returned range type)  |
+ * |:-------------------------------------------------------------------------------------------------:|:-------------------------------:|
+ * | `std::ranges::view`                                                                               | `urng_t`                        |
+ * | `std::basic_string const &` *or* `std::basic_string_view`                                         | `std::basic_string_view`        |
+ * | `std::ranges::borrowed_range && std::ranges::sized_range && std::ranges::contiguous_range`        | `std::span`                     |
+ * | `std::ranges::borrowed_range && std::ranges::sized_range && std::ranges::random_access_range`     | `std::ranges::subrange`         |
+ * | *else*                                                                                            | `std::ranges::ref_view<urng_t>` |
  *
  * This adaptor is different from std::views::all in that it performs type erasure for some underlying ranges;
  * std::views::all always returns `std::ranges::ref_view<urng_t>` or the type itself if it already is a view.

--- a/include/seqan3/std/ranges
+++ b/include/seqan3/std/ranges
@@ -30,6 +30,22 @@ template<class T>
     requires ::std::derived_from<T, ::std::ranges::view_base>
 //!\endcond
 inline constexpr bool enable_view<T> = true;
+
+// std::ranges::borrowed_range's are valid range-v3 borrowed_range's
+//!\cond
+template <::std::input_or_output_iterator I, ::std::sentinel_for<I> S, ::std::ranges::subrange_kind K>
+inline constexpr bool enable_borrowed_range<::std::ranges::subrange<I, S, K>> = true;
+
+template <class T>
+inline constexpr bool enable_borrowed_range<::std::ranges::empty_view<T>> = true;
+
+template <::std::weakly_incrementable W, ::std::semiregular Bound>
+inline constexpr bool enable_borrowed_range<::std::ranges::iota_view<W, Bound>> = true;
+
+template <class T>
+inline constexpr bool enable_borrowed_range<::std::ranges::ref_view<T>> = true;
+//!\endcond
+
 } // namespace ranges
 
 namespace std::ranges
@@ -40,6 +56,13 @@ template<class T>
     requires ::std::derived_from<T, ::ranges::view_base>
 //!\endcond
 inline constexpr bool enable_view<T> = true;
+
+//!\brief std::ranges::borrowed_range's are valid range-v3 borrowed_range's
+template<class T>
+//!\cond
+    requires ::ranges::enable_borrowed_range<T>
+//!\endcond
+inline constexpr bool enable_borrowed_range<T> = true;
 } // namespace std::ranges
 
 #else // implement via range-v3

--- a/include/seqan3/std/ranges
+++ b/include/seqan3/std/ranges
@@ -109,7 +109,7 @@ using ::ranges::cpp20::data;
 // [range.range], ranges
 using ::ranges::cpp20::range;
 // using ::ranges::cpp20::enable_borrowed_range;
-// using ::ranges::cpp20::borrowed_range;
+using ::ranges::cpp20::borrowed_range;
 
 using ::ranges::iterator_t;
 using ::ranges::sentinel_t;

--- a/include/seqan3/std/span
+++ b/include/seqan3/std/span
@@ -29,7 +29,6 @@
 #include <iterator>     // for iterators
 #include <type_traits>  // for remove_cv, etc
 
-#include <seqan3/range/concept.hpp>  // for forwarding_range
 #include <seqan3/std/iterator>       // for iterator concepts
 #include <seqan3/std/ranges>         // for range concepts
 
@@ -292,7 +291,7 @@ public:
                                   element_type(*)[]> &&
                  ranges::contiguous_range<range_t> &&
                  ranges::sized_range<range_t> &&
-                 (seqan3::forwarding_range<range_t> || is_const_v<element_type>)
+                 (ranges::borrowed_range<range_t> || is_const_v<element_type>)
     constexpr span(range_t && rng) : data_{ranges::data(rng)}, size_{static_cast<index_type>(ranges::size(rng))}
     {}
 

--- a/test/snippet/io/detail/iterator_write_range.cpp
+++ b/test/snippet/io/detail/iterator_write_range.cpp
@@ -31,7 +31,7 @@ int main()
         auto current_end = it;
         size_t steps = std::ranges::advance(current_end, 10u, std::ranges::end(sequence));
         using subrange_t = std::ranges::subrange<decltype(it), decltype(current_end), std::ranges::subrange_kind::sized>;
-        // Be aware that your range_type must model std::ranges::forwarding_range in order to use the return value!
+        // Be aware that your range_type must model std::ranges::borrowed_range in order to use the return value!
         it = stream_it.write_range(subrange_t{it, current_end, 10u - steps});
         stream_it = ' ';
     }


### PR DESCRIPTION
Part of https://github.com/seqan/product_backlog/issues/49