### PR TITLE
[TEST] simplify overly complicated decltype in single_pass_input_test

### DIFF
--- a/test/unit/range/views/view_single_pass_input_test.cpp
+++ b/test/unit/range/views/view_single_pass_input_test.cpp
@@ -28,7 +28,7 @@ class single_pass_input : public ::testing::Test
         cmp_data = get_data();
     }
 
-    auto get_data()
+    static auto get_data()
     {
         if constexpr (std::is_same_v<std::remove_cv_t<rng_type>, std::vector<char>>)
         {
@@ -51,8 +51,8 @@ class single_pass_input : public ::testing::Test
 
 public:
 
-    decltype(std::declval<single_pass_input>().get_data()) data;
-    decltype(std::declval<single_pass_input>().get_data()) cmp_data;
+    decltype(get_data()) data;
+    decltype(get_data()) cmp_data;
 };
 
 // add all <out_rng,in_rng> pairs here.


### PR DESCRIPTION
clang complained:

```c++
error: member access into incomplete type 'single_pass_input<std::__1::vector<char, std::__1::allocator<char>>>'
    decltype(std::declval<single_pass_input>().get_data()) data;
                                              ^
```