### PR TITLE
[API] Rename scoring_scheme to scoring_scheme_for

### DIFF
--- a/include/seqan3/alignment/pairwise/alignment_configurator.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_configurator.hpp
@@ -123,9 +123,9 @@ public:
             using scoring_type = std::remove_reference_t<
                                     decltype(get<align_cfg::scoring_scheme>(std::declval<alignment_config_type>()).value)
                                  >;
-            return static_cast<bool>(scoring_scheme<scoring_type,
-                                                   std::ranges::range_value_t<first_seq_t>,
-                                                   std::ranges::range_value_t<second_seq_t>>);
+            return static_cast<bool>(scoring_scheme_for<scoring_type,
+                                                        std::ranges::range_value_t<first_seq_t>,
+                                                        std::ranges::range_value_t<second_seq_t>>);
         }
         else
         {

--- a/include/seqan3/alignment/scoring/detail/simd_match_mismatch_scoring_scheme.hpp
+++ b/include/seqan3/alignment/scoring/detail/simd_match_mismatch_scoring_scheme.hpp
@@ -88,7 +88,7 @@ public:
     //!\copydoc seqan3::detail::simd_match_mismatch_scoring_scheme::initialise_from_scalar_scoring_scheme
     template <typename scoring_scheme_t>
     //!\cond
-        requires scoring_scheme<scoring_scheme_t, alphabet_t>
+        requires scoring_scheme_for<scoring_scheme_t, alphabet_t>
     //!\endcond
     constexpr explicit simd_match_mismatch_scoring_scheme(scoring_scheme_t const & scoring_scheme)
     {
@@ -98,7 +98,7 @@ public:
     //!\copydoc seqan3::detail::simd_match_mismatch_scoring_scheme::initialise_from_scalar_scoring_scheme
     template <typename scoring_scheme_t>
     //!\cond
-        requires scoring_scheme<scoring_scheme_t, alphabet_t>
+        requires scoring_scheme_for<scoring_scheme_t, alphabet_t>
     //!\endcond
     constexpr simd_match_mismatch_scoring_scheme & operator=(scoring_scheme_t const & scoring_scheme)
     {

--- a/include/seqan3/alignment/scoring/detail/simd_matrix_scoring_scheme.hpp
+++ b/include/seqan3/alignment/scoring/detail/simd_matrix_scoring_scheme.hpp
@@ -42,7 +42,7 @@ namespace seqan3::detail
  */
 template <simd_concept simd_score_t, semialphabet alphabet_t, typename alignment_t, typename scoring_scheme_t>
 //!\cond
-    requires scoring_scheme<scoring_scheme_t, alphabet_t> &&
+    requires scoring_scheme_for<scoring_scheme_t, alphabet_t> &&
              (std::same_as<alignment_t, detail::method_local_tag> ||
               std::same_as<alignment_t, align_cfg::method_global>)
 //!\endcond

--- a/include/seqan3/alignment/scoring/scoring_scheme_concept.hpp
+++ b/include/seqan3/alignment/scoring/scoring_scheme_concept.hpp
@@ -6,7 +6,7 @@
 // -----------------------------------------------------------------------------------------------------
 
 /*!\file
- * \brief Provides seqan3::scoring_scheme.
+ * \brief Provides seqan3::scoring_scheme_for.
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  */
 
@@ -17,7 +17,7 @@
 namespace seqan3
 {
 
-/*!\interface seqan3::scoring_scheme <>
+/*!\interface seqan3::scoring_scheme_for <>
  * \brief A concept that requires that type be able to score two letters.
  * \tparam t            The type the concept check is performed on (the putative scoring scheme).
  * \tparam alphabet_t   The type of the first letter that you wish to score; must model seqan3::alphabet.
@@ -31,14 +31,14 @@ namespace seqan3
  * ability to score the two letters is required.
  *
  */
-/*!\name Requirements for seqan3::scoring_scheme
- * \brief You can expect these members on all types that implement seqan3::scoring_scheme.
- * \memberof seqan3::scoring_scheme
+/*!\name Requirements for seqan3::scoring_scheme_for
+ * \brief You can expect these members on all types that implement seqan3::scoring_scheme_for.
+ * \memberof seqan3::scoring_scheme_for
  * \{
  */
 
 /*!\typedef     typedef IMPLEMENTATION_DEFINED score_type;
- * \brief       The type returned by seqan3::scoring_scheme::score(), usually a seqan3::arithmetic.
+ * \brief       The type returned by seqan3::scoring_scheme_for::score(), usually a seqan3::arithmetic.
  *
  * \details
  * \attention This is a concept requirement, not an actual typedef (however types satisfying this concept
@@ -58,9 +58,9 @@ namespace seqan3
 
 //!\cond
 template <typename t, typename alphabet_t, typename alphabet2_t = alphabet_t>
-SEQAN3_CONCEPT scoring_scheme = requires (t scheme,
-                                          alphabet_t const alph1,
-                                          alphabet2_t const alph2)
+SEQAN3_CONCEPT scoring_scheme_for = requires (t scheme,
+                                              alphabet_t const alph1,
+                                              alphabet2_t const alph2)
 {
     requires alphabet<alphabet_t>;
     requires alphabet<alphabet2_t>;

--- a/test/unit/alignment/scoring/scoring_scheme_test.cpp
+++ b/test/unit/alignment/scoring/scoring_scheme_test.cpp
@@ -103,10 +103,10 @@ TEST(aminoacid_scoring_scheme, template_argument_deduction)
 TYPED_TEST(generic, concept_check)
 {
     using alph_t = typename TestFixture::alph_t;
-    EXPECT_TRUE((seqan3::scoring_scheme<TypeParam, alph_t>));
-    EXPECT_TRUE((seqan3::scoring_scheme<TypeParam const, alph_t>));
-    EXPECT_TRUE((seqan3::scoring_scheme<TypeParam const &, alph_t>));
-    EXPECT_FALSE((seqan3::scoring_scheme<TypeParam const &, char>));
+    EXPECT_TRUE((seqan3::scoring_scheme_for<TypeParam, alph_t>));
+    EXPECT_TRUE((seqan3::scoring_scheme_for<TypeParam const, alph_t>));
+    EXPECT_TRUE((seqan3::scoring_scheme_for<TypeParam const &, alph_t>));
+    EXPECT_FALSE((seqan3::scoring_scheme_for<TypeParam const &, char>));
 }
 
 TYPED_TEST(generic, member_types)


### PR DESCRIPTION
Renames the scoring scheme concept to scoring_scheme_for to adhere the standard's naming conventions for concepts with additional template arguments.

resolves seqan/product_backlog#196