### PR TITLE
[INFRA] Deactivate jenkins

### DIFF
--- a/.jenkinsfile
+++ b/.jenkinsfile
@@ -280,9 +280,12 @@ for (int h = 0; h < axis_agent.size(); ++h)
 // This is the main stage that executes all jobs registered in the tasks map
 // All steps are executed in parallel. If the contention on the agents are to high
 // consider moving some tasks out into another stage that runs after this one.
-stage ("matrix")
+if (is_nightly)
 {
-    parallel tasks
+    stage ("matrix")
+    {
+        parallel tasks
+    }
 }
 
 // ============================================================================


### PR DESCRIPTION
Blocked by https://github.com/seqan/seqan3/pull/2071

This skips the execution of the jobs if it is not a nightly build, hence the CI just returns `success`.
Once this is in master, we can disable jenkins for PRs altogether.