### PR TITLE
[INFRA] Cache more efficiently

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,11 +252,14 @@ jobs:
 
       - name: Load ccache
         if: matrix.requires_ccache
-        uses: actions/cache@v1.1.0
+        uses: actions/cache@v2
         with:
           path: .ccache
-          key: ${{ matrix.name }}-ccache-${{ steps.ccache_prepare.outputs.timestamp }}
+          key: ${{ matrix.name }}-ccache-${{ github.ref }}-${{ steps.ccache_prepare.outputs.timestamp }}
+          # Restoring: From current branch, otherwise from base branch, otherwise from any branch.
           restore-keys: |
+            ${{ matrix.name }}-ccache-${{ github.ref }}
+            ${{ matrix.name }}-ccache-${{ github.base_ref }}
             ${{ matrix.name }}-ccache-
 
       - name: Configure tests


### PR DESCRIPTION
This introduces hierarchical caching:

1. Try to restore cache from current branch.
2. Try to restore cache from base branch, i.e. `release-3.0.2` or `master`.
3. Try to restore any available cache, i.e. from any other branch.


Will look like this:

```console
with:
    path: .ccache
    key: Unit gcc9 (c++2a) on Linux-ccache-refs/pull/2085/merge-2020-08-31-13;28;29
    restore-keys: Unit gcc9 (c++2a) on Linux-ccache-refs/pull/2085/merge
  Unit gcc9 (c++2a) on Linux-ccache-release-3.0.2
  Unit gcc9 (c++2a) on Linux-ccache-
  
  env:
    CMAKE_VERSION: 3.7.2
    DOXYGEN_VERSION: 1.8.20
    SEQAN3_NO_VERSION_CHECK: 1
    TZ: Europe/Berlin
Cache not found for input keys: Unit gcc9 (c++2a) on Linux-ccache-refs/pull/2085/merge-2020-08-31-13;28;29, Unit gcc9 (c++2a) on Linux-ccache-refs/pull/2085/merge, Unit gcc9 (c++2a) on Linux-ccache-release-3.0.2, Unit gcc9 (c++2a) on Linux-ccache-
```
There is currently no cache because I bumped the `actions/cache` version from 1.1.0 to 2