### PR TITLE
[MISC] Rename view::some_iterator_name to view::[basic_]iterator

### DIFF
--- a/include/seqan3/range/views/async_input_buffer.hpp
+++ b/include/seqan3/range/views/async_input_buffer.hpp
@@ -24,7 +24,7 @@
 // This is the path a value takes when using this views::
 //   urange
 // → async_input_buffer_view.buffer               [size n]
-// → async_input_buffer_iterator.cached_value     [size 1]
+// → iterator.cached_value     [size 1]
 // → user
 //-----------------------------------------------------------------------------
 
@@ -71,7 +71,7 @@ private:
     std::shared_ptr<state> state_ptr = nullptr;
 
     //!\brief The iterator of the seqan3::detail::async_input_buffer_view.
-    class async_input_buffer_iterator;
+    class iterator;
 
 public:
     /*!\name Constructor, destructor, and assignment.
@@ -140,14 +140,14 @@ public:
      * from different threads (however it is not thread-safe to operate on a single iterator from different
      * threads).
      */
-    async_input_buffer_iterator begin()
+    iterator begin()
     {
         assert(state_ptr != nullptr);
         return {state_ptr->buffer};
     }
 
     //!\brief Const-qualified async_input_buffer_view::begin() is deleted, because iterating changes the view.
-    async_input_buffer_iterator begin() const = delete;
+    iterator begin() const = delete;
 
     //!\brief Returns a sentinel.
     std::default_sentinel_t end()
@@ -162,7 +162,7 @@ public:
 
 //!\brief The iterator of the seqan3::detail::async_input_buffer_view.
 template <typename urng_t>
-class async_input_buffer_view<urng_t>::async_input_buffer_iterator
+class async_input_buffer_view<urng_t>::iterator
 {
     //!\brief The sentinel type to compare to.
     using sentinel_type = std::default_sentinel_t;
@@ -199,18 +199,17 @@ public:
      * \brief Not explicitly `noexcept` because this depends on construction/copy/... of value_type.
      * \{
      */
-    async_input_buffer_iterator() = default; //!< Defaulted.
+    iterator() = default; //!< Defaulted.
     //TODO: delete:
-    async_input_buffer_iterator(async_input_buffer_iterator const & rhs) = default; //!< Defaulted.
-    async_input_buffer_iterator(async_input_buffer_iterator && rhs) = default; //!< Defaulted.
+    iterator(iterator const & rhs) = default; //!< Defaulted.
+    iterator(iterator && rhs) = default; //!< Defaulted.
     //TODO: delete:
-    async_input_buffer_iterator & operator=(async_input_buffer_iterator const & rhs) = default; //!< Defaulted.
-    async_input_buffer_iterator & operator=(async_input_buffer_iterator && rhs) = default; //!< Defaulted.
-    ~async_input_buffer_iterator() noexcept = default; //!< Defaulted.
+    iterator & operator=(iterator const & rhs) = default; //!< Defaulted.
+    iterator & operator=(iterator && rhs) = default; //!< Defaulted.
+    ~iterator() noexcept = default; //!< Defaulted.
 
     //!\brief Constructing from the underlying seqan3::async_input_buffer_view.
-    async_input_buffer_iterator(contrib::fixed_buffer_queue<std::ranges::range_value_t<urng_t>> & buffer) noexcept :
-        buffer_ptr{&buffer}
+    iterator(contrib::fixed_buffer_queue<std::ranges::range_value_t<urng_t>> & buffer) noexcept : buffer_ptr{&buffer}
     {
         ++(*this); // cache first value
     }
@@ -236,7 +235,7 @@ public:
      * \{
      */
     //!\brief Pre-increment.
-    async_input_buffer_iterator & operator++() noexcept
+    iterator & operator++() noexcept
     {
         if (at_end) // TODO unlikely
             return *this;
@@ -260,29 +259,25 @@ public:
      * \{
      */
     //!\brief Compares for equality with sentinel.
-    friend constexpr bool operator==(async_input_buffer_iterator const & lhs,
-                                     std::default_sentinel_t const &) noexcept
+    friend constexpr bool operator==(iterator const & lhs, std::default_sentinel_t const &) noexcept
     {
         return lhs.at_end;
     }
 
     //!\copydoc operator==
-    friend constexpr bool operator==(std::default_sentinel_t const &,
-                                     async_input_buffer_iterator const & rhs) noexcept
+    friend constexpr bool operator==(std::default_sentinel_t const &, iterator const & rhs) noexcept
     {
         return rhs == std::default_sentinel_t{};
     }
 
     //!\brief Compares for inequality with sentinel.
-    friend constexpr bool operator!=(async_input_buffer_iterator const & lhs,
-                                     std::default_sentinel_t const &) noexcept
+    friend constexpr bool operator!=(iterator const & lhs, std::default_sentinel_t const &) noexcept
     {
         return !(lhs == std::default_sentinel_t{});
     }
 
     //!\copydoc operator!=
-    friend constexpr bool operator!=(std::default_sentinel_t const &,
-                                     async_input_buffer_iterator const & rhs) noexcept
+    friend constexpr bool operator!=(std::default_sentinel_t const &, iterator const & rhs) noexcept
     {
         return rhs != std::default_sentinel_t{};
     }

--- a/include/seqan3/range/views/async_input_buffer.hpp
+++ b/include/seqan3/range/views/async_input_buffer.hpp
@@ -24,7 +24,7 @@
 // This is the path a value takes when using this views::
 //   urange
 // → async_input_buffer_view.buffer               [size n]
-// → iterator.cached_value     [size 1]
+// → iterator.cached_value [size 1]
 // → user
 //-----------------------------------------------------------------------------
 

--- a/include/seqan3/range/views/async_input_buffer.hpp
+++ b/include/seqan3/range/views/async_input_buffer.hpp
@@ -23,7 +23,7 @@
 //-----------------------------------------------------------------------------
 // This is the path a value takes when using this views::
 //   urange
-// → async_input_buffer_view.buffer               [size n]
+// → async_input_buffer_view.buffer [size n]
 // → iterator.cached_value [size 1]
 // → user
 //-----------------------------------------------------------------------------

--- a/include/seqan3/range/views/enforce_random_access.hpp
+++ b/include/seqan3/range/views/enforce_random_access.hpp
@@ -46,7 +46,7 @@ private:
 
     // Iterator declaration.
     template <typename underlying_iter_t>
-    class enforced_random_access_iterator;
+    class basic_iterator;
 
 public:
 
@@ -82,7 +82,7 @@ public:
     //!\brief Returns the iterator to the begin of the range.
     constexpr auto begin() noexcept
     {
-        return enforced_random_access_iterator<decltype(std::ranges::begin(urng))>{std::ranges::begin(urng)};
+        return basic_iterator<decltype(std::ranges::begin(urng))>{std::ranges::begin(urng)};
     }
 
     //!\copydoc seqan3::detail::view_enforce_random_access::begin
@@ -91,7 +91,7 @@ public:
         requires const_iterable_range<urng_t>
     //!\endcond
     {
-        return enforced_random_access_iterator<decltype(std::ranges::cbegin(urng))>{std::ranges::cbegin(urng)};
+        return basic_iterator<decltype(std::ranges::cbegin(urng))>{std::ranges::cbegin(urng)};
     }
 
     /*!\brief Returns the sentinel to the end of the range.
@@ -99,13 +99,13 @@ public:
      * \details
      *
      * If the underlying range is a common range this functions returns
-     * seqan3::detail::view_enforce_random_access::enforced_random_access_iterator initialised with the end of the
+     * seqan3::detail::view_enforce_random_access::basic_iterator initialised with the end of the
      * underlying range. Otherwise it returns the sentinel of the underlying range.
      */
     constexpr auto end() noexcept
     {
         if constexpr (std::ranges::common_range<urng_t>)
-            return enforced_random_access_iterator<decltype(std::ranges::end(urng))>{std::ranges::end(urng)};
+            return basic_iterator<decltype(std::ranges::end(urng))>{std::ranges::end(urng)};
         else
             return urng.end();
     }
@@ -117,7 +117,7 @@ public:
     //!\endcond
     {
         if constexpr (std::ranges::common_range<urng_t>)
-            return enforced_random_access_iterator<decltype(std::ranges::cend(urng))>{std::ranges::cend(urng)};
+            return basic_iterator<decltype(std::ranges::cend(urng))>{std::ranges::cend(urng)};
         else
             return std::ranges::cend(urng);
     }
@@ -139,12 +139,12 @@ template <std::ranges::view urng_t>
     requires pseudo_random_access_range<urng_t>
 //!\endcond
 template <typename underlying_iter_t>
-class view_enforce_random_access<urng_t>::enforced_random_access_iterator :
-    public inherited_iterator_base<enforced_random_access_iterator<underlying_iter_t>, underlying_iter_t>
+class view_enforce_random_access<urng_t>::basic_iterator :
+    public inherited_iterator_base<basic_iterator<underlying_iter_t>, underlying_iter_t>
 {
 private:
     //!\brief The type of the base class.
-    using base_t = inherited_iterator_base<enforced_random_access_iterator<underlying_iter_t>, underlying_iter_t>;
+    using base_t = inherited_iterator_base<basic_iterator<underlying_iter_t>, underlying_iter_t>;
 
 public:
 
@@ -159,17 +159,17 @@ public:
     // Importing base's constructors.
     using base_t::base_t;
     //!\brief Defaulted.
-    constexpr enforced_random_access_iterator() = default;
+    constexpr basic_iterator() = default;
     //!\brief Defaulted.
-    constexpr enforced_random_access_iterator(enforced_random_access_iterator const &) = default;
+    constexpr basic_iterator(basic_iterator const &) = default;
     //!\brief Defaulted.
-    constexpr enforced_random_access_iterator(enforced_random_access_iterator &&) = default;
+    constexpr basic_iterator(basic_iterator &&) = default;
     //!\brief Defaulted.
-    constexpr enforced_random_access_iterator & operator=(enforced_random_access_iterator const &) = default;
+    constexpr basic_iterator & operator=(basic_iterator const &) = default;
     //!\brief Defaulted.
-    constexpr enforced_random_access_iterator & operator=(enforced_random_access_iterator &&) = default;
+    constexpr basic_iterator & operator=(basic_iterator &&) = default;
     //!\brief Defaulted.
-    ~enforced_random_access_iterator() = default;
+    ~basic_iterator() = default;
     //!\}
 
     /*!\name Comparison operators
@@ -180,8 +180,7 @@ public:
     using base_t::operator==;
     using base_t::operator!=;
     //!\brief Tests if iterator is at the end.
-    friend constexpr bool operator==(enforced_random_access_iterator const & lhs,
-                                     std::ranges::sentinel_t<urng_t> const & rhs)
+    friend constexpr bool operator==(basic_iterator const & lhs, std::ranges::sentinel_t<urng_t> const & rhs)
         noexcept(noexcept(std::declval<underlying_iter_t const &>() ==
                           std::declval<std::ranges::sentinel_t<urng_t> const &>()))
     {
@@ -189,8 +188,7 @@ public:
     }
 
     //!\brief Tests if iterator is at the end.
-    friend constexpr bool operator==(std::ranges::sentinel_t<urng_t> const & lhs,
-                                     enforced_random_access_iterator const & rhs)
+    friend constexpr bool operator==(std::ranges::sentinel_t<urng_t> const & lhs, basic_iterator const & rhs)
         noexcept(noexcept(std::declval<underlying_iter_t const &>() ==
                           std::declval<std::ranges::sentinel_t<urng_t> const &>()))
     {
@@ -198,8 +196,7 @@ public:
     }
 
     //!\brief Tests if iterator is not at the end.
-    friend constexpr bool operator!=(enforced_random_access_iterator const & lhs,
-                                     std::ranges::sentinel_t<urng_t> const & rhs)
+    friend constexpr bool operator!=(basic_iterator const & lhs, std::ranges::sentinel_t<urng_t> const & rhs)
         noexcept(noexcept(std::declval<underlying_iter_t const &>() !=
                           std::declval<std::ranges::sentinel_t<urng_t> const &>()))
     {
@@ -207,8 +204,7 @@ public:
     }
 
     //!\brief Tests if iterator is not at the end.
-    friend constexpr bool operator!=(std::ranges::sentinel_t<urng_t> const & lhs,
-                                     enforced_random_access_iterator const & rhs)
+    friend constexpr bool operator!=(std::ranges::sentinel_t<urng_t> const & lhs, basic_iterator const & rhs)
         noexcept(noexcept(std::declval<underlying_iter_t const &>() !=
                           std::declval<std::ranges::sentinel_t<urng_t> const &>()))
     {
@@ -233,7 +229,7 @@ public:
 
     //!\brief Computes the distance betwen this iterator and the sentinel of the underlying range.
     constexpr friend typename base_t::difference_type operator-(std::ranges::sentinel_t<urng_t> const & lhs,
-                                                                enforced_random_access_iterator const & rhs)
+                                                                basic_iterator const & rhs)
         noexcept(noexcept(std::declval<std::ranges::sentinel_t<urng_t> const &>() -
                           std::declval<underlying_iter_t const &>()))
         requires std::sized_sentinel_for<std::ranges::sentinel_t<urng_t>, underlying_iter_t>

--- a/include/seqan3/range/views/kmer_hash.hpp
+++ b/include/seqan3/range/views/kmer_hash.hpp
@@ -50,7 +50,7 @@ private:
     shape shape_;
 
     template <typename rng_t>
-    class shape_iterator;
+    class basic_iterator;
 
 public:
     /*!\name Constructors, destructor and assignment
@@ -115,7 +115,7 @@ public:
      */
     auto begin() noexcept
     {
-        return shape_iterator<urng_t>{std::ranges::begin(urange), std::ranges::end(urange), shape_};
+        return basic_iterator<urng_t>{std::ranges::begin(urange), std::ranges::end(urange), shape_};
     }
 
     //!\copydoc begin()
@@ -124,7 +124,7 @@ public:
         requires const_iterable_range<urng_t>
     //!\endcond
     {
-        return shape_iterator<urng_t const>{std::ranges::cbegin(urange), std::ranges::cend(urange), shape_};
+        return basic_iterator<urng_t const>{std::ranges::cbegin(urange), std::ranges::cend(urange), shape_};
     }
 
     /*!\brief Returns an iterator to the element following the last element of the range.
@@ -144,9 +144,9 @@ public:
      */
     auto end() noexcept
     {
-        // Assigning the end iterator to the text_right iterator of the shape_iterator only works for common ranges.
+        // Assigning the end iterator to the text_right iterator of the basic_iterator only works for common ranges.
         if constexpr (std::ranges::common_range<urng_t>)
-            return shape_iterator<urng_t>{std::ranges::begin(urange), std::ranges::end(urange), shape_, true};
+            return basic_iterator<urng_t>{std::ranges::begin(urange), std::ranges::end(urange), shape_, true};
         else
             return std::ranges::end(urange);
     }
@@ -157,9 +157,9 @@ public:
         requires const_iterable_range<urng_t>
     //!\endcond
     {
-        // Assigning the end iterator to the text_right iterator of the shape_iterator only works for common ranges.
+        // Assigning the end iterator to the text_right iterator of the basic_iterator only works for common ranges.
         if constexpr (std::ranges::common_range<urng_t const>)
-            return shape_iterator<urng_t const>{std::ranges::cbegin(urange), std::ranges::cend(urange), shape_, true};
+            return basic_iterator<urng_t const>{std::ranges::cbegin(urange), std::ranges::cend(urange), shape_, true};
         else
             return std::ranges::cend(urange);
     }
@@ -193,29 +193,29 @@ public:
  *
  * \details
  *
- * The shape_iterator can be used to iterate over the hash values of a text. A shape_iterator needs an iterator of
+ * The basic_iterator can be used to iterate over the hash values of a text. The basic_iterator needs an iterator of
  * the text and a seqan3::shape that defines how to hash the text.
  *
- * Depending on the type of the iterator passed to the shape_iterator, different functionality is available:
+ * Depending on the type of the iterator passed to the basic_iterator, different functionality is available:
  *
  * | Concept modelled by passed text iterator | Available functions             |
  * |------------------------------------------|---------------------------------|
- * | std::forward_iterator                    | \ref shape_iterator_comparison "Comparison operators"<br>\ref operator++ "Pre-increment (++it)"<br>\ref operator++(int) "Post-increment (it++)"<br>\ref operator* "Indirection operator (*it)" |
+ * | std::forward_iterator                    | \ref basic_iterator_comparison_kmer_hash "Comparison operators"<br>\ref operator++ "Pre-increment (++it)"<br>\ref operator++(int) "Post-increment (it++)"<br>\ref operator* "Indirection operator (*it)" |
  * | std::bidirectional_iterator              | \ref operator-- "Pre-decrement (--it)"<br>\ref operator--(int) "Post-decrement (it--)" |
- * | std::random_access_iterator              | \ref operator+= "Forward (it +=)"<br>\ref operator+ "Forward copy (it +)"<br>\ref operator-= "Decrement(it -=)"<br>\ref shape_iterator_operator-decrement "Decrement copy (it -)"<br>\ref shape_iterator_operator-difference "Difference (it1 - it2)"<br>\ref operator[] "Subscript (it[])" |
+ * | std::random_access_iterator              | \ref operator+= "Forward (it +=)"<br>\ref operator+ "Forward copy (it +)"<br>\ref operator-= "Decrement(it -=)"<br>\ref basic_iterator_operator-decrement "Decrement copy (it -)"<br>\ref basic_iterator_operator-difference "Difference (it1 - it2)"<br>\ref operator[] "Subscript (it[])" |
  *
  * When using a gapped seqan3::shape, the `0`s of the seqan3::shape are virtually removed from the hashed k-mer.
  * Note that any shape is expected to start with a `1` and end with a `1`.
  *
  * ### Implementation detail
  *
- * To avoid dereferencing the sentinel when iterating, the shape_iterator computes the hash value up until
+ * To avoid dereferencing the sentinel when iterating, the basic_iterator computes the hash value up until
  * the second to last position and performs the addition of the last position upon
  * access (\ref operator* and \ref operator[]).
  */
 template <std::ranges::view urng_t>
 template <typename rng_t>
-class kmer_hash_view<urng_t>::shape_iterator
+class kmer_hash_view<urng_t>::basic_iterator
 {
 private:
     //!\brief The iterator type of the underlying range.
@@ -224,7 +224,7 @@ private:
     using sentinel_t = std::ranges::sentinel_t<rng_t>;
 
     template <typename urng2_t>
-    friend class shape_iterator;
+    friend class basic_iterator;
 
 public:
     /*!\name Associated types
@@ -249,19 +249,19 @@ public:
     /*!\name Constructors, destructor and assignment
      * \{
      */
-    constexpr shape_iterator()                                   = default; //!< Defaulted.
-    constexpr shape_iterator(shape_iterator const &)             = default; //!< Defaulted.
-    constexpr shape_iterator(shape_iterator &&)                  = default; //!< Defaulted.
-    constexpr shape_iterator & operator=(shape_iterator const &) = default; //!< Defaulted.
-    constexpr shape_iterator & operator=(shape_iterator &&)      = default; //!< Defaulted.
-    ~shape_iterator()                                            = default; //!< Defaulted.
+    constexpr basic_iterator()                                   = default; //!< Defaulted.
+    constexpr basic_iterator(basic_iterator const &)             = default; //!< Defaulted.
+    constexpr basic_iterator(basic_iterator &&)                  = default; //!< Defaulted.
+    constexpr basic_iterator & operator=(basic_iterator const &) = default; //!< Defaulted.
+    constexpr basic_iterator & operator=(basic_iterator &&)      = default; //!< Defaulted.
+    ~basic_iterator()                                            = default; //!< Defaulted.
 
     //!\brief Allow iterator on a const range to be constructible from an iterator over a non-const range.
     template <typename urng2_t>
     //!\cond
         requires std::same_as<std::remove_const_t<urng_t>, urng2_t>
     //!\endcond
-    shape_iterator(shape_iterator<urng2_t> it) :
+    basic_iterator(basic_iterator<urng2_t> it) :
         hash_value{std::move(it.hash_value)},
         roll_factor{std::move(it.roll_factor)},
         shape_{std::move(it.shape_)},
@@ -280,7 +280,7 @@ public:
     *
     * Linear in size of shape.
     */
-    shape_iterator(it_t it_start, sentinel_t it_end, shape s_) :
+    basic_iterator(it_t it_start, sentinel_t it_end, shape s_) :
         shape_{s_}, text_left{it_start}, text_right{std::ranges::next(text_left, shape_.size() - 1, it_end)}
     {
         assert(std::ranges::size(shape_) > 0);
@@ -306,7 +306,7 @@ public:
     * \details
     *
     * If we have a common_range as underlying range, we want to preserve this property.
-    * This means that we need to have a shape_iterator that can act as end for the kmer_hash_view, i.e.
+    * This means that we need to have a basic_iterator that can act as end for the kmer_hash_view, i.e.
     * the text_right iterator is equal to the end iterator of the underlying range.
     * However, we still need to do some initialisation via hash_full:
     * When using `std::views::reverse`, we start iterating from the end and decrement the iterator.
@@ -320,7 +320,7 @@ public:
     *
     * Linear in size of shape.
     */
-    shape_iterator(it_t it_start, sentinel_t it_end, shape s_, bool SEQAN3_DOXYGEN_ONLY(is_end)) : shape_{s_}
+    basic_iterator(it_t it_start, sentinel_t it_end, shape s_, bool SEQAN3_DOXYGEN_ONLY(is_end)) : shape_{s_}
     {
         assert(std::ranges::size(shape_) > 0);
 
@@ -344,66 +344,66 @@ public:
     }
     //!\}
 
-    //!\anchor shape_iterator_comparison
+    //!\anchor basic_iterator_comparison_kmer_hash
     //!\name Comparison operators
     //!\{
 
     //!\brief Compare to iterator on text.
-    friend bool operator==(shape_iterator const & lhs, sentinel_t const & rhs) noexcept
+    friend bool operator==(basic_iterator const & lhs, sentinel_t const & rhs) noexcept
     {
         return lhs.text_right == rhs;
     }
 
     //!\brief Compare to iterator on text.
-    friend bool operator==(sentinel_t const & lhs, shape_iterator const & rhs) noexcept
+    friend bool operator==(sentinel_t const & lhs, basic_iterator const & rhs) noexcept
     {
         return lhs == rhs.text_right;
     }
 
-    //!\brief Compare to another shape_iterator.
-    friend bool operator==(shape_iterator const & lhs, shape_iterator const & rhs) noexcept
+    //!\brief Compare to another basic_iterator.
+    friend bool operator==(basic_iterator const & lhs, basic_iterator const & rhs) noexcept
     {
         return std::tie(lhs.text_right, lhs.shape_) == std::tie(rhs.text_right, rhs.shape_);
     }
 
     //!\brief Compare to iterator on text.
-    friend bool operator!=(shape_iterator const & lhs, sentinel_t const & rhs) noexcept
+    friend bool operator!=(basic_iterator const & lhs, sentinel_t const & rhs) noexcept
     {
         return !(lhs == rhs);
     }
 
     //!\brief Compare to iterator on text.
-    friend bool operator!=(sentinel_t const & lhs, shape_iterator const & rhs) noexcept
+    friend bool operator!=(sentinel_t const & lhs, basic_iterator const & rhs) noexcept
     {
         return !(lhs == rhs);
     }
 
-    //!\brief Compare to another shape_iterator.
-    friend bool operator!=(shape_iterator const & lhs, shape_iterator const & rhs) noexcept
+    //!\brief Compare to another basic_iterator.
+    friend bool operator!=(basic_iterator const & lhs, basic_iterator const & rhs) noexcept
     {
         return !(lhs == rhs);
     }
 
-    //!\brief Compare to another shape_iterator.
-    friend bool operator<(shape_iterator const & lhs, shape_iterator const & rhs) noexcept
+    //!\brief Compare to another basic_iterator.
+    friend bool operator<(basic_iterator const & lhs, basic_iterator const & rhs) noexcept
     {
         return (lhs.shape_ <= rhs.shape_) && (lhs.text_right < rhs.text_right);
     }
 
-    //!\brief Compare to another shape_iterator.
-    friend bool operator>(shape_iterator const & lhs, shape_iterator const & rhs) noexcept
+    //!\brief Compare to another basic_iterator.
+    friend bool operator>(basic_iterator const & lhs, basic_iterator const & rhs) noexcept
     {
         return (lhs.shape_ >= rhs.shape_) && (lhs.text_right > rhs.text_right);
     }
 
-    //!\brief Compare to another shape_iterator.
-    friend bool operator<=(shape_iterator const & lhs, shape_iterator const & rhs) noexcept
+    //!\brief Compare to another basic_iterator.
+    friend bool operator<=(basic_iterator const & lhs, basic_iterator const & rhs) noexcept
     {
         return (lhs.shape_ <= rhs.shape_) && (lhs.text_right <= rhs.text_right);
     }
 
-    //!\brief Compare to another shape_iterator.
-    friend bool operator>=(shape_iterator const & lhs, shape_iterator const & rhs) noexcept
+    //!\brief Compare to another basic_iterator.
+    friend bool operator>=(basic_iterator const & lhs, basic_iterator const & rhs) noexcept
     {
         return (lhs.shape_ >= rhs.shape_) && (lhs.text_right >= rhs.text_right);
     }
@@ -411,16 +411,16 @@ public:
     //!\}
 
     //!\brief Pre-increment.
-    shape_iterator & operator++() noexcept
+    basic_iterator & operator++() noexcept
     {
         hash_forward();
         return *this;
     }
 
     //!\brief Post-increment.
-    shape_iterator operator++(int) noexcept
+    basic_iterator operator++(int) noexcept
     {
-        shape_iterator tmp{*this};
+        basic_iterator tmp{*this};
         hash_forward();
         return tmp;
     }
@@ -428,7 +428,7 @@ public:
     /*!\brief Pre-decrement.
      * \attention This function is only available if `it_t` models std::bidirectional_iterator.
      */
-    shape_iterator & operator--() noexcept
+    basic_iterator & operator--() noexcept
     //!\cond
         requires std::bidirectional_iterator<it_t>
     //!\endcond
@@ -440,12 +440,12 @@ public:
     /*!\brief Post-decrement.
      * \attention This function is only available if `it_t` models std::bidirectional_iterator.
      */
-    shape_iterator operator--(int) noexcept
+    basic_iterator operator--(int) noexcept
     //!\cond
         requires std::bidirectional_iterator<it_t>
     //!\endcond
     {
-        shape_iterator tmp{*this};
+        basic_iterator tmp{*this};
         hash_backward();
         return tmp;
     }
@@ -453,7 +453,7 @@ public:
     /*!\brief Forward this iterator.
      * \attention This function is only available if `it_t` models std::random_access_iterator.
      */
-    shape_iterator & operator+=(difference_type const skip) noexcept
+    basic_iterator & operator+=(difference_type const skip) noexcept
     //!\cond
         requires std::random_access_iterator<it_t>
     //!\endcond
@@ -465,19 +465,19 @@ public:
     /*!\brief Forward copy of this iterator.
      * \attention This function is only available if `it_t` models std::random_access_iterator.
      */
-    shape_iterator operator+(difference_type const skip) const noexcept
+    basic_iterator operator+(difference_type const skip) const noexcept
     //!\cond
         requires std::random_access_iterator<it_t>
     //!\endcond
     {
-        shape_iterator tmp{*this};
+        basic_iterator tmp{*this};
         return tmp += skip;
     }
 
     /*!\brief Non-member operator+ delegates to non-friend operator+.
      * \attention This function is only available if `it_t` models std::random_access_iterator.
      */
-    friend shape_iterator operator+(difference_type const skip, shape_iterator const & it) noexcept
+    friend basic_iterator operator+(difference_type const skip, basic_iterator const & it) noexcept
     //!\cond
         requires std::random_access_iterator<it_t>
     //!\endcond
@@ -488,7 +488,7 @@ public:
     /*!\brief Decrement iterator by `skip`.
      * \attention This function is only available if `it_t` models std::random_access_iterator.
      */
-    shape_iterator & operator-=(difference_type const skip) noexcept
+    basic_iterator & operator-=(difference_type const skip) noexcept
     //!\cond
         requires std::random_access_iterator<it_t>
     //!\endcond
@@ -497,23 +497,23 @@ public:
         return *this;
     }
 
-    /*!\anchor shape_iterator_operator-decrement
+    /*!\anchor basic_iterator_operator-decrement
      * \brief Return decremented copy of this iterator.
      * \attention This function is only available if `it_t` models std::random_access_iterator.
      */
-    shape_iterator operator-(difference_type const skip) const noexcept
+    basic_iterator operator-(difference_type const skip) const noexcept
     //!\cond
         requires std::random_access_iterator<it_t>
     //!\endcond
     {
-        shape_iterator tmp{*this};
+        basic_iterator tmp{*this};
         return tmp -= skip;
     }
 
     /*!\brief Non-member operator- delegates to non-friend operator-.
      * \attention This function is only available if `it_t` models std::random_access_iterator.
      */
-    friend shape_iterator operator-(difference_type const skip, shape_iterator const & it) noexcept
+    friend basic_iterator operator-(difference_type const skip, basic_iterator const & it) noexcept
     //!\cond
         requires std::random_access_iterator<it_t>
     //!\endcond
@@ -521,11 +521,11 @@ public:
         return it - skip;
     }
 
-    /*!\anchor shape_iterator_operator-difference
+    /*!\anchor basic_iterator_operator-difference
      * \brief Return offset between two iterator's positions.
      * \attention This function is only available if `it_t` models std::random_access_iterator.
      */
-    friend difference_type operator-(shape_iterator const & lhs, shape_iterator const & rhs) noexcept
+    friend difference_type operator-(basic_iterator const & lhs, basic_iterator const & rhs) noexcept
     //!\cond
         requires std::random_access_iterator<it_t>
     //!\endcond
@@ -536,7 +536,7 @@ public:
     /*!\brief Return offset between remote sentinel's position and this.
      * \attention This function is only available if sentinel_t and it_t model std::sized_sentinel_for.
      */
-    friend difference_type operator-(sentinel_t const & lhs, shape_iterator const & rhs) noexcept
+    friend difference_type operator-(sentinel_t const & lhs, basic_iterator const & rhs) noexcept
     //!\cond
         requires std::sized_sentinel_for<sentinel_t, it_t>
     //!\endcond
@@ -547,7 +547,7 @@ public:
     /*!\brief Return offset this and remote sentinel's position.
      * \attention This function is only available if it_t and sentinel_t model std::sized_sentinel_for.
      */
-    friend difference_type operator-(shape_iterator const & lhs, sentinel_t const & rhs) noexcept
+    friend difference_type operator-(basic_iterator const & lhs, sentinel_t const & rhs) noexcept
     //!\cond
         requires std::sized_sentinel_for<it_t, sentinel_t>
     //!\endcond

--- a/include/seqan3/range/views/pairwise_combine.hpp
+++ b/include/seqan3/range/views/pairwise_combine.hpp
@@ -47,16 +47,16 @@ private:
 
     //!\brief The forward declared iterator type for pairwise_combine_view.
     template <typename range_type>
-    class iterator_type;
+    class basic_iterator;
 
     /*!\name Associated types
      * \{
      */
 
     //!\brief The iterator type.
-    using iterator = iterator_type<underlying_range_type>;
+    using iterator = basic_iterator<underlying_range_type>;
     //!\brief The const iterator type. Evaluates to void if the underlying range is not const iterable.
-    using const_iterator = transformation_trait_or_t<std::type_identity<iterator_type<underlying_range_type const>>,
+    using const_iterator = transformation_trait_or_t<std::type_identity<basic_iterator<underlying_range_type const>>,
                                                      void>;
     //!\}
 
@@ -259,14 +259,14 @@ template <std::ranges::view underlying_range_type>
     requires std::ranges::forward_range<underlying_range_type> && std::ranges::common_range<underlying_range_type>
 //!\endcond
 template <typename range_type>
-class pairwise_combine_view<underlying_range_type>::iterator_type
+class pairwise_combine_view<underlying_range_type>::basic_iterator
 {
 private:
 
     //!\brief Friend declaration for iterator with different range const-ness.
     template <typename other_range_type>
         requires std::same_as<std::remove_const_t<range_type>, std::remove_const_t<other_range_type>>
-    friend class iterator_type;
+    friend class basic_iterator;
 
     //!\brief Alias type for the iterator over the passed range type.
     using underlying_iterator_type = std::ranges::iterator_t<range_type>;
@@ -297,12 +297,12 @@ public:
     /*!\name Constructors, destructor and assignment
      * \{
      */
-    iterator_type() = default; //!< Defaulted.
-    iterator_type(iterator_type const &) = default; //!< Defaulted.
-    iterator_type(iterator_type &&) = default; //!< Defaulted.
-    iterator_type & operator=(iterator_type const &) = default; //!< Defaulted.
-    iterator_type & operator=(iterator_type &&) = default; //!< Defaulted.
-    ~iterator_type() = default; //!< Defaulted.
+    basic_iterator() = default; //!< Defaulted.
+    basic_iterator(basic_iterator const &) = default; //!< Defaulted.
+    basic_iterator(basic_iterator &&) = default; //!< Defaulted.
+    basic_iterator & operator=(basic_iterator const &) = default; //!< Defaulted.
+    basic_iterator & operator=(basic_iterator &&) = default; //!< Defaulted.
+    ~basic_iterator() = default; //!< Defaulted.
 
     /*!\brief Constructs the iterator from the current underlying iterator and the end iterator of the underlying
      *        range.
@@ -316,9 +316,9 @@ public:
      * Constructs the iterator by caching the end of the underlying range and setting the first iterator to the
      * given position and the second to the first incremented by one.
      */
-    constexpr iterator_type(underlying_iterator_type iter,
-                            underlying_iterator_type begin_it,
-                            underlying_iterator_type end_it) noexcept :
+    constexpr basic_iterator(underlying_iterator_type iter,
+                             underlying_iterator_type begin_it,
+                             underlying_iterator_type end_it) noexcept :
         first_it{iter},
         second_it{std::ranges::next(iter, 1, end_it)},
         begin_it{begin_it},
@@ -338,8 +338,8 @@ public:
         requires std::convertible_to<other_range_type, range_type &> &&
                  std::same_as<std::remove_const_t<other_range_type>, std::remove_const_t<range_type>>
     //!\endcond
-    constexpr iterator_type(iterator_type<other_range_type> other) noexcept :
-        iterator_type{std::move(other.first_it), std::move(other.begin_it), std::move(other.end_it)}
+    constexpr basic_iterator(basic_iterator<other_range_type> other) noexcept :
+        basic_iterator{std::move(other.first_it), std::move(other.begin_it), std::move(other.end_it)}
     {}
     //!\}
 
@@ -357,7 +357,7 @@ public:
      * \param[in] index The index of the element to be returned.
      */
     constexpr reference operator[](size_t const index) const
-        noexcept(noexcept(std::declval<iterator_type &>().from_index(1)))
+        noexcept(noexcept(std::declval<basic_iterator &>().from_index(1)))
     //!\cond
         requires std::random_access_iterator<underlying_iterator_type>
     //!\endcond
@@ -370,7 +370,7 @@ public:
      * \{
      */
     //!\brief Pre-increment operator.
-    constexpr iterator_type & operator++(/*pre-increment*/)
+    constexpr basic_iterator & operator++(/*pre-increment*/)
         noexcept(noexcept(++std::declval<underlying_iterator_type &>()))
     {
         if (++second_it == end_it)
@@ -383,16 +383,16 @@ public:
     }
 
     //!\brief Post-increment operator.
-    constexpr iterator_type operator++(int /*post-increment*/)
+    constexpr basic_iterator operator++(int /*post-increment*/)
         noexcept(noexcept(std::declval<underlying_iterator_type &>()++))
     {
-        iterator_type tmp{*this};
+        basic_iterator tmp{*this};
         ++*this;
         return tmp;
     }
 
     //!\brief Pre-decrement operator; `underlying_iterator_type` must model std::bidirectional_iterator.
-    constexpr iterator_type & operator--(/*pre-decrement*/)
+    constexpr basic_iterator & operator--(/*pre-decrement*/)
         noexcept(noexcept(--std::declval<underlying_iterator_type &>()))
     //!\cond
         requires std::bidirectional_iterator<underlying_iterator_type>
@@ -408,21 +408,21 @@ public:
     }
 
     //!\brief Post-decrement operator; `underlying_iterator_type` must model std::bidirectional_iterator.
-    constexpr iterator_type operator--(int /*post-decrement*/)
+    constexpr basic_iterator operator--(int /*post-decrement*/)
         noexcept(noexcept(std::declval<underlying_iterator_type &>()--))
     //!\cond
         requires std::bidirectional_iterator<underlying_iterator_type>
     //!\endcond
     {
-        iterator_type tmp{*this};
+        basic_iterator tmp{*this};
         --*this;
         return tmp;
     }
 
     //!\brief Advances the iterator by the given offset; `underlying_iterator_type` must model
     //!\      std::random_access_iterator.
-    constexpr iterator_type & operator+=(difference_type const offset)
-        noexcept(noexcept(std::declval<iterator_type &>().from_index(1)))
+    constexpr basic_iterator & operator+=(difference_type const offset)
+        noexcept(noexcept(std::declval<basic_iterator &>().from_index(1)))
     //!\cond
         requires std::random_access_iterator<underlying_iterator_type>
     //!\endcond
@@ -433,20 +433,20 @@ public:
 
     //!\brief Advances the iterator by the given offset; `underlying_iterator_type` must model
     //!\      std::random_access_iterator.
-    constexpr iterator_type operator+(difference_type const offset) const
-        noexcept(noexcept(std::declval<iterator_type &>() += 1))
+    constexpr basic_iterator operator+(difference_type const offset) const
+        noexcept(noexcept(std::declval<basic_iterator &>() += 1))
     //!\cond
         requires std::random_access_iterator<underlying_iterator_type>
     //!\endcond
     {
-        iterator_type tmp{*this};
+        basic_iterator tmp{*this};
         return (tmp += offset);
     }
 
     //!\brief Advances the iterator by the given offset; `underlying_iterator_type` must model
     //!\      std::random_access_iterator.
-    constexpr friend iterator_type operator+(difference_type const offset, iterator_type iter)
-        noexcept(noexcept(std::declval<iterator_type<range_type> &>().from_index(1)))
+    constexpr friend basic_iterator operator+(difference_type const offset, basic_iterator iter)
+        noexcept(noexcept(std::declval<basic_iterator<range_type> &>().from_index(1)))
     //!\cond
         requires std::random_access_iterator<underlying_iterator_type>
     //!\endcond
@@ -457,8 +457,8 @@ public:
 
     //!\brief Decrements the iterator by the given offset; `underlying_iterator_type` must model
     //!\      std::random_access_iterator.
-    constexpr iterator_type & operator-=(difference_type const offset)
-        noexcept(noexcept(std::declval<iterator_type &>().from_index(1)))
+    constexpr basic_iterator & operator-=(difference_type const offset)
+        noexcept(noexcept(std::declval<basic_iterator &>().from_index(1)))
     //!\cond
         requires std::random_access_iterator<underlying_iterator_type>
     //!\endcond
@@ -469,13 +469,13 @@ public:
 
     //!\brief Decrements the iterator by the given offset; `underlying_iterator_type` must model
     //!\      std::random_access_iterator.
-    constexpr iterator_type operator-(difference_type const offset) const
-        noexcept(noexcept(std::declval<iterator_type &>() -= 1))
+    constexpr basic_iterator operator-(difference_type const offset) const
+        noexcept(noexcept(std::declval<basic_iterator &>() -= 1))
     //!\cond
         requires std::random_access_iterator<underlying_iterator_type>
     //!\endcond
     {
-        iterator_type tmp{*this};
+        basic_iterator tmp{*this};
         return (tmp -= offset);
     }
 
@@ -486,8 +486,8 @@ public:
         requires std::random_access_iterator<underlying_iterator_type> &&
                  std::same_as<std::remove_const_t<range_type>, std::remove_const_t<other_range_type>>
     //!\endcond
-    constexpr difference_type operator-(iterator_type<other_range_type> const & rhs) const
-        noexcept(noexcept(std::declval<iterator_type &>().to_index()))
+    constexpr difference_type operator-(basic_iterator<other_range_type> const & rhs) const
+        noexcept(noexcept(std::declval<basic_iterator &>().to_index()))
     {
         return static_cast<difference_type>(to_index() - rhs.to_index());
     }
@@ -508,7 +508,7 @@ public:
         requires std::equality_comparable_with<underlying_iterator_type, std::ranges::iterator_t<other_range_type>> &&
                  std::same_as<std::remove_const_t<range_type>, std::remove_const_t<other_range_type>>
     //!\endcond
-    constexpr bool operator==(iterator_type<other_range_type> const & rhs) const
+    constexpr bool operator==(basic_iterator<other_range_type> const & rhs) const
         noexcept(noexcept(std::declval<underlying_iterator_type &>() == std::declval<underlying_iterator_type &>()))
     {
         return std::tie(first_it, second_it) == std::tie(rhs.first_it, rhs.second_it);
@@ -520,7 +520,7 @@ public:
         requires std::equality_comparable_with<underlying_iterator_type, std::ranges::iterator_t<other_range_type>> &&
                  std::same_as<std::remove_const_t<range_type>, std::remove_const_t<other_range_type>>
     //!\endcond
-    constexpr bool operator!=(iterator_type<other_range_type> const & rhs) const
+    constexpr bool operator!=(basic_iterator<other_range_type> const & rhs) const
         noexcept(noexcept(std::declval<underlying_iterator_type &>() != std::declval<underlying_iterator_type &>()))
     {
         return !(*this == rhs);
@@ -533,7 +533,7 @@ public:
                                                std::ranges::iterator_t<other_range_type>> &&
                  std::same_as<std::remove_const_t<range_type>, std::remove_const_t<other_range_type>>
     //!\endcond
-    constexpr bool operator<(iterator_type<other_range_type> const & rhs) const
+    constexpr bool operator<(basic_iterator<other_range_type> const & rhs) const
         noexcept(noexcept(std::declval<underlying_iterator_type &>() < std::declval<underlying_iterator_type &>()))
     {
         return std::tie(first_it, second_it) < std::tie(rhs.first_it, rhs.second_it);
@@ -546,7 +546,7 @@ public:
                                                std::ranges::iterator_t<other_range_type>> &&
                  std::same_as<std::remove_const_t<range_type>, std::remove_const_t<other_range_type>>
     //!\endcond
-    constexpr bool operator>(iterator_type<other_range_type> const & rhs) const
+    constexpr bool operator>(basic_iterator<other_range_type> const & rhs) const
         noexcept(noexcept(std::declval<underlying_iterator_type &>() > std::declval<underlying_iterator_type &>()))
 
     {
@@ -560,7 +560,7 @@ public:
                                                std::ranges::iterator_t<other_range_type>> &&
                  std::same_as<std::remove_const_t<range_type>, std::remove_const_t<other_range_type>>
     //!\endcond
-    constexpr bool operator<=(iterator_type<other_range_type> const & rhs) const
+    constexpr bool operator<=(basic_iterator<other_range_type> const & rhs) const
         noexcept(noexcept(std::declval<underlying_iterator_type &>() <= std::declval<underlying_iterator_type &>()))
     {
         return std::tie(first_it, second_it) <= std::tie(rhs.first_it, rhs.second_it);
@@ -573,7 +573,7 @@ public:
                                                std::ranges::iterator_t<other_range_type>> &&
                  std::same_as<std::remove_const_t<range_type>, std::remove_const_t<other_range_type>>
     //!\endcond
-    constexpr bool operator>=(iterator_type<other_range_type> const & rhs) const
+    constexpr bool operator>=(basic_iterator<other_range_type> const & rhs) const
         noexcept(noexcept(std::declval<underlying_iterator_type &>() >= std::declval<underlying_iterator_type &>()))
     {
         return std::tie(first_it, second_it) >= std::tie(rhs.first_it, rhs.second_it);

--- a/include/seqan3/range/views/repeat.hpp
+++ b/include/seqan3/range/views/repeat.hpp
@@ -69,15 +69,15 @@ private:
 
     //!\brief The forward declared iterator type for views::repeat (a random access iterator).
     template <typename parent_type>
-    class repeat_view_iterator;
+    class basic_iterator;
 
     /*!\name Associated types
     * \{
     */
     //!\brief The iterator type of this view (a random access iterator).
-    using iterator = repeat_view_iterator<repeat_view>;
+    using iterator = basic_iterator<repeat_view>;
     //!\brief The const_iterator type is equal to the iterator type but over the const qualified type.
-    using const_iterator = repeat_view_iterator<repeat_view const>;
+    using const_iterator = basic_iterator<repeat_view const>;
     //!\}
 
     //!\brief Befriend the following class s.t. iterator and const_iterator can be defined for this type.
@@ -199,11 +199,11 @@ private:
 //!\brief The iterator type for views::repeat (a random access iterator).
 template <std::copy_constructible value_t>
 template <typename parent_type>
-class repeat_view<value_t>::repeat_view_iterator :
-    public detail::random_access_iterator_base<parent_type, repeat_view_iterator>
+class repeat_view<value_t>::basic_iterator :
+    public detail::random_access_iterator_base<parent_type, basic_iterator>
 {
     //!\brief The CRTP base type.
-    using base_t = detail::random_access_iterator_base<parent_type, repeat_view_iterator>;
+    using base_t = detail::random_access_iterator_base<parent_type, basic_iterator>;
 
     //!\brief The base position type.
     using typename base_t::position_type;
@@ -223,27 +223,27 @@ public:
     /*!\name Constructors, destructor and assignment
      * \{
      */
-    repeat_view_iterator() = default; //!< Defaulted.
-    repeat_view_iterator(repeat_view_iterator const &) = default; //!< Defaulted.
-    repeat_view_iterator & operator=(repeat_view_iterator const &) = default; //!< Defaulted.
-    repeat_view_iterator (repeat_view_iterator &&) = default; //!< Defaulted.
-    repeat_view_iterator & operator=(repeat_view_iterator &&) = default; //!< Defaulted.
-    ~repeat_view_iterator() = default; //!< Defaulted.
+    basic_iterator() = default; //!< Defaulted.
+    basic_iterator(basic_iterator const &) = default; //!< Defaulted.
+    basic_iterator & operator=(basic_iterator const &) = default; //!< Defaulted.
+    basic_iterator (basic_iterator &&) = default; //!< Defaulted.
+    basic_iterator & operator=(basic_iterator &&) = default; //!< Defaulted.
+    ~basic_iterator() = default; //!< Defaulted.
 
     /*!\brief Construct by host range.
      * \param host The host range.
      */
-    explicit constexpr repeat_view_iterator(parent_type & host) noexcept : base_t{host} {}
+    explicit constexpr basic_iterator(parent_type & host) noexcept : base_t{host} {}
 
     /*!\brief Constructor for const version from non-const version.
-     * \param rhs a non-const version of repeat_view_iterator to construct from.
+     * \param rhs a non-const version of basic_iterator to construct from.
      */
     template <typename parent_type2>
     //!\cond
         requires std::is_const_v<parent_type> && (!std::is_const_v<parent_type2>) &&
                  std::is_same_v<std::remove_const_t<parent_type>, parent_type2>
     //!\endcond
-    constexpr repeat_view_iterator(repeat_view_iterator<parent_type2> const & rhs) noexcept :
+    constexpr basic_iterator(basic_iterator<parent_type2> const & rhs) noexcept :
         base_t{rhs}
     {}
     //!\}
@@ -270,14 +270,14 @@ public:
 
     //!\brief Equality comparison to the sentinel always returns false on an infinite view.
     friend constexpr bool operator==(std::default_sentinel_t const &,
-                                     repeat_view_iterator const &) noexcept
+                                     basic_iterator const &) noexcept
     {
         return false;
     }
 
     //!\brief Inequality comparison to the sentinel always returns true on an infinite view.
     friend constexpr bool operator!=(std::default_sentinel_t const &,
-                                     repeat_view_iterator const &) noexcept
+                                     basic_iterator const &) noexcept
     {
         return true;
     }

--- a/include/seqan3/range/views/single_pass_input.hpp
+++ b/include/seqan3/range/views/single_pass_input.hpp
@@ -26,7 +26,7 @@ namespace seqan3::detail
 
 //!\brief Forward declaration.
 template <typename view_t>
-class single_pass_input_iterator;
+class basic_iterator;
 
 /*!\brief Adds single_pass_input behavior to the underlying range.
  * \tparam urng_t The underlying range type.
@@ -43,9 +43,9 @@ private:
     //!\brief The iterator type for the underlying range.
     using urng_iterator_type = std::ranges::iterator_t<urng_t>;
 
-    //!\brief Friend declaration for seqan3::detail::single_pass_input_iterator.
+    //!\brief Friend declaration for seqan3::detail::basic_iterator.
     template <typename view_t>
-    friend class single_pass_input_iterator;
+    friend class basic_iterator;
 
     //!\brief An internal state to capture the underlying range and a cached iterator.
     struct state
@@ -63,7 +63,7 @@ private:
      * \{
      */
     //!\brief Iterator type.
-    using iterator = single_pass_input_iterator<single_pass_input_view>;
+    using iterator = basic_iterator<single_pass_input_view>;
     //!\brief The sentinel type.
     using sentinel = std::ranges::sentinel_t<urng_t>;
     //\}
@@ -158,7 +158,7 @@ namespace seqan3::detail
  * This iterator reduces every iterator type of the associated view to an single pass input iterator.
  */
 template <typename view_type>
-class single_pass_input_iterator<single_pass_input_view<view_type>>
+class basic_iterator<single_pass_input_view<view_type>>
 {
     //!\brief The pointer to the associated view.
     using base_iterator_type = typename single_pass_input_view<view_type>::urng_iterator_type;
@@ -170,7 +170,7 @@ class single_pass_input_iterator<single_pass_input_view<view_type>>
 
     //!\brief Friend declaration to give seqan3::detail::single_pass_input_sentinel access to members of this class.
     template <typename input_view_type>
-    friend class single_pass_input_iterator;
+    friend class basic_iterator;
 
     //!\brief Test that the sentinel fulfills the std::sentinel_for for the underlying iterator.
     static_assert(std::sentinel_for<sentinel_type, base_iterator_type>);
@@ -196,20 +196,20 @@ public:
      * \{
      */
     //!\brief Default construction.
-    single_pass_input_iterator() = default;
+    basic_iterator() = default;
     //!\brief Copy construction.
-    constexpr single_pass_input_iterator(single_pass_input_iterator const & rhs) = default;
+    constexpr basic_iterator(basic_iterator const & rhs) = default;
     //!\brief Move construction.
-    constexpr single_pass_input_iterator(single_pass_input_iterator && rhs) = default;
+    constexpr basic_iterator(basic_iterator && rhs) = default;
     //!\brief Copy assignment.
-    constexpr single_pass_input_iterator & operator=(single_pass_input_iterator const & rhs) = default;
+    constexpr basic_iterator & operator=(basic_iterator const & rhs) = default;
     //!\brief Move assignment.
-    constexpr single_pass_input_iterator & operator=(single_pass_input_iterator && rhs) = default;
+    constexpr basic_iterator & operator=(basic_iterator && rhs) = default;
     //!\brief Destruction.
-    ~single_pass_input_iterator() = default;
+    ~basic_iterator() = default;
 
     //!\brief Constructing from the underlying seqan3::single_pass_input_view.
-    single_pass_input_iterator(single_pass_input_view<view_type> & view) noexcept : view_ptr{&view}
+    basic_iterator(single_pass_input_view<view_type> & view) noexcept : view_ptr{&view}
     {}
     //!\}
 
@@ -236,7 +236,7 @@ public:
      * \{
      */
     //!\brief Pre-increment.
-    single_pass_input_iterator & operator++() noexcept
+    basic_iterator & operator++() noexcept
     {
         ++cached();
         return *this;
@@ -248,7 +248,7 @@ public:
         if constexpr (std::output_iterator<base_iterator_type, reference> &&
                       std::copy_constructible<base_iterator_type>)
         {
-            single_pass_input_iterator tmp{*this};
+            basic_iterator tmp{*this};
             ++(*this);
             return tmp;
         }
@@ -270,7 +270,7 @@ public:
 
     //!\copydoc operator==
     friend constexpr bool
-    operator==(sentinel_type const & s, single_pass_input_iterator const & rhs) noexcept
+    operator==(sentinel_type const & s, basic_iterator const & rhs) noexcept
     {
         return rhs == s;
     }
@@ -283,7 +283,7 @@ public:
 
     //!\copydoc operator!=
     friend constexpr bool
-    operator!=(sentinel_type const & s, single_pass_input_iterator const & rhs) noexcept
+    operator!=(sentinel_type const & s, basic_iterator const & rhs) noexcept
     {
         return rhs != s;
     }

--- a/include/seqan3/range/views/take.hpp
+++ b/include/seqan3/range/views/take.hpp
@@ -315,7 +315,7 @@ public:
 
     //!\brief Returns an iterator incremented by one.
     constexpr basic_iterator operator++(int) noexcept(noexcept(++std::declval<basic_iterator &>()) &&
-                                             std::is_nothrow_copy_constructible_v<basic_iterator>)
+                                                      std::is_nothrow_copy_constructible_v<basic_iterator>)
     {
         basic_iterator cpy{*this};
         ++(*this);
@@ -335,7 +335,7 @@ public:
 
     //!\brief Returns an iterator decremented by one.
     constexpr basic_iterator operator--(int) noexcept(noexcept(--std::declval<basic_iterator &>()) &&
-                                             std::is_nothrow_copy_constructible_v<basic_iterator>)
+                                                      std::is_nothrow_copy_constructible_v<basic_iterator>)
     //!\cond
         requires std::bidirectional_iterator<base_base_t>
     //!\endcond

--- a/include/seqan3/range/views/take.hpp
+++ b/include/seqan3/range/views/take.hpp
@@ -61,20 +61,20 @@ private:
 
     //!\brief The forward declared iterator type.
     template <typename rng_t>
-    class iterator_type;
+    class basic_iterator;
 
 private:
     /*!\name Associated types
      * \{
      */
     //!\brief The iterator type of this view (a random access iterator).
-    using iterator = iterator_type<urng_t>;
+    using iterator = basic_iterator<urng_t>;
     /*!\brief Note that this declaration does not give any compiler errors for non-const iterable ranges. Although
-     * `iterator_type` inherits from std::ranges::iterator_t which is not defined on a const-range, i.e. `urng_t const,
+     * `basic_iterator` inherits from std::ranges::iterator_t which is not defined on a const-range, i.e. `urng_t const,
      *  if it is not const-iterable. We only just declare this type and never instantiate it, i.e. use this type within
      *  this class, if the underlying range is not const-iterable.
      */
-    using const_iterator = iterator_type<urng_t const>;
+    using const_iterator = basic_iterator<urng_t const>;
     //!\}
 
 public:
@@ -230,14 +230,14 @@ view_take(urng_t && , size_t) -> view_take<std::views::all_t<urng_t>, exactly, o
 //!\tparam rng_t Should be `urng_t` for defining #iterator and `urng_t const` for defining #const_iterator.
 template <std::ranges::view urng_t, bool exactly, bool or_throw>
 template <typename rng_t>
-class view_take<urng_t, exactly, or_throw>::iterator_type :
-    public inherited_iterator_base<iterator_type<rng_t>, std::ranges::iterator_t<rng_t>>
+class view_take<urng_t, exactly, or_throw>::basic_iterator :
+    public inherited_iterator_base<basic_iterator<rng_t>, std::ranges::iterator_t<rng_t>>
 {
 private:
     //!\brief The iterator type of the underlying range.
     using base_base_t = std::ranges::iterator_t<rng_t>;
     //!\brief The CRTP wrapper type.
-    using base_t = inherited_iterator_base<iterator_type, std::ranges::iterator_t<rng_t>>;
+    using base_t = inherited_iterator_base<basic_iterator, std::ranges::iterator_t<rng_t>>;
 
     //!\brief The sentinel type is identical to that of the underlying range.
     using sentinel_type = std::ranges::sentinel_t<urng_t>;
@@ -256,23 +256,23 @@ public:
      * \brief Exceptions specification is implicitly inherited.
      * \{
      */
-    iterator_type() = default; //!< Defaulted.
-    iterator_type(iterator_type const & rhs) = default; //!< Defaulted.
-    iterator_type(iterator_type && rhs) = default; //!< Defaulted.
-    iterator_type & operator=(iterator_type const & rhs) = default; //!< Defaulted.
-    iterator_type & operator=(iterator_type && rhs) = default; //!< Defaulted.
-    ~iterator_type() = default; //!< Defaulted.
+    basic_iterator() = default; //!< Defaulted.
+    basic_iterator(basic_iterator const & rhs) = default; //!< Defaulted.
+    basic_iterator(basic_iterator && rhs) = default; //!< Defaulted.
+    basic_iterator & operator=(basic_iterator const & rhs) = default; //!< Defaulted.
+    basic_iterator & operator=(basic_iterator && rhs) = default; //!< Defaulted.
+    ~basic_iterator() = default; //!< Defaulted.
 
     //!\brief Constructor that delegates to the CRTP layer.
-    constexpr iterator_type(base_base_t const & it) noexcept(noexcept(base_t{it})) :
+    constexpr basic_iterator(base_base_t const & it) noexcept(noexcept(base_t{it})) :
         base_t{std::move(it)}
     {}
 
     //!\brief Constructor that delegates to the CRTP layer and initialises the members.
-    constexpr iterator_type(base_base_t it,
-                            size_t const _pos,
-                            size_t const _max_pos,
-                            view_take * host = nullptr) noexcept(noexcept(base_t{it})) :
+    constexpr basic_iterator(base_base_t it,
+                             size_t const _pos,
+                             size_t const _max_pos,
+                             view_take * host = nullptr) noexcept(noexcept(base_t{it})) :
         base_t{std::move(it)}, pos{_pos}, max_pos(_max_pos)
     {
         host_ptr = host;
@@ -304,7 +304,7 @@ public:
      */
 
     //!\brief Increments the iterator by one.
-    constexpr iterator_type & operator++() noexcept(noexcept(++std::declval<base_t &>()))
+    constexpr basic_iterator & operator++() noexcept(noexcept(++std::declval<base_t &>()))
     {
         base_t::operator++();
         ++pos;
@@ -314,16 +314,16 @@ public:
     }
 
     //!\brief Returns an iterator incremented by one.
-    constexpr iterator_type operator++(int) noexcept(noexcept(++std::declval<iterator_type &>()) &&
-                                           std::is_nothrow_copy_constructible_v<iterator_type>)
+    constexpr basic_iterator operator++(int) noexcept(noexcept(++std::declval<basic_iterator &>()) &&
+                                             std::is_nothrow_copy_constructible_v<basic_iterator>)
     {
-        iterator_type cpy{*this};
+        basic_iterator cpy{*this};
         ++(*this);
         return cpy;
     }
 
     //!\brief Decrements the iterator by one.
-    constexpr iterator_type & operator--() noexcept(noexcept(--std::declval<base_base_t &>()))
+    constexpr basic_iterator & operator--() noexcept(noexcept(--std::declval<base_base_t &>()))
     //!\cond
         requires std::bidirectional_iterator<base_base_t>
     //!\endcond
@@ -334,19 +334,20 @@ public:
     }
 
     //!\brief Returns an iterator decremented by one.
-    constexpr iterator_type operator--(int) noexcept(noexcept(--std::declval<iterator_type &>()) &&
-                                           std::is_nothrow_copy_constructible_v<iterator_type>)
+    constexpr basic_iterator operator--(int) noexcept(noexcept(--std::declval<basic_iterator &>()) &&
+                                             std::is_nothrow_copy_constructible_v<basic_iterator>)
     //!\cond
         requires std::bidirectional_iterator<base_base_t>
     //!\endcond
     {
-        iterator_type cpy{*this};
+        basic_iterator cpy{*this};
         --(*this);
         return cpy;
     }
 
     //!\brief Advances the iterator by skip positions.
-    constexpr iterator_type & operator+=(difference_type const skip) noexcept(noexcept(std::declval<base_t &>() += skip))
+    constexpr basic_iterator & operator+=(difference_type const skip)
+        noexcept(noexcept(std::declval<base_t &>() += skip))
     //!\cond
         requires std::random_access_iterator<base_base_t>
     //!\endcond
@@ -357,7 +358,8 @@ public:
     }
 
     //!\brief Advances the iterator by -skip positions.
-    constexpr iterator_type & operator-=(difference_type const skip) noexcept(noexcept(std::declval<base_t &>() -= skip))
+    constexpr basic_iterator & operator-=(difference_type const skip)
+        noexcept(noexcept(std::declval<base_t &>() -= skip))
     //!\cond
         requires std::random_access_iterator<base_base_t>
     //!\endcond
@@ -374,7 +376,7 @@ public:
      */
 
     //!\brief Checks whether `*this` is equal to `rhs`.
-    constexpr bool operator==(iterator_type const & rhs) const
+    constexpr bool operator==(basic_iterator const & rhs) const
         noexcept(!or_throw && noexcept(std::declval<base_base_t &>() == std::declval<base_base_t &>()))
     //!\cond
         requires std::forward_iterator<base_base_t>
@@ -404,21 +406,22 @@ public:
     }
 
     //!\brief Checks whether `lhs` is equal to `rhs`.
-    constexpr friend bool operator==(sentinel_type const & lhs, iterator_type const & rhs) noexcept(noexcept(rhs == lhs))
+    constexpr friend bool operator==(sentinel_type const & lhs, basic_iterator const & rhs)
+        noexcept(noexcept(rhs == lhs))
     {
         return rhs == lhs;
     }
 
     //!\brief Checks whether `*this` is not equal to `rhs`.
     constexpr bool operator!=(sentinel_type const & rhs) const
-        noexcept(noexcept(std::declval<iterator_type &>() == rhs))
+        noexcept(noexcept(std::declval<basic_iterator &>() == rhs))
     {
         return !(*this == rhs);
     }
 
     //!\copydoc operator!=()
-    constexpr bool operator!=(iterator_type const & rhs) const
-        noexcept(noexcept(std::declval<iterator_type &>() == rhs))
+    constexpr bool operator!=(basic_iterator const & rhs) const
+        noexcept(noexcept(std::declval<basic_iterator &>() == rhs))
     //!\cond
         requires std::forward_iterator<base_base_t>
     //!\endcond
@@ -427,7 +430,8 @@ public:
     }
 
     //!\brief Checks whether `lhs` is not equal to `rhs`.
-    constexpr friend bool operator!=(sentinel_type const & lhs, iterator_type const & rhs) noexcept(noexcept(rhs != lhs))
+    constexpr friend bool operator!=(sentinel_type const & lhs, basic_iterator const & rhs) 
+        noexcept(noexcept(rhs != lhs))
     {
         return rhs != lhs;
     }


### PR DESCRIPTION
Fixes https://github.com/seqan/product_backlog/issues/144.

Templated view iterators are renamed to 'basic_iterator', non-templated ones to 'iterator'