### PR TITLE
Optimise alignment/part6 enable banded end position

### DIFF
--- a/include/seqan3/alignment/pairwise/alignment_configurator.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_configurator.hpp
@@ -523,7 +523,7 @@ private:
         if constexpr (traits_t::is_local ||                                                         // it is a local alignment,
                       traits_t::is_debug ||                                                         // it runs in debug mode,
                      (traits_t::compute_begin_positions || traits_t::compute_sequence_alignment) || // it computes more than the end position.
-                     (traits_t::is_banded && traits_t::compute_end_positions) ||                    // banded
+                     (traits_t::is_banded && traits_t::compute_begin_positions) ||                  // banded
                      (traits_t::is_vectorised && traits_t::is_banded) ||                            // it is vectorised and banded,
                      (traits_t::is_vectorised && traits_t::compute_end_positions))                  // simd and more than the score.
         {

--- a/include/seqan3/alignment/pairwise/alignment_configurator.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_configurator.hpp
@@ -536,10 +536,14 @@ private:
         }
         else  // Use new alignment algorithm implementation.
         {
+            using scalar_optimum_updater_t = std::conditional_t<traits_t::is_banded,
+                                                                max_score_banded_updater,
+                                                                max_score_updater>;
+
             using optimum_tracker_policy_t =
                 lazy_conditional_t<traits_t::is_vectorised,
                                    lazy<policy_optimum_tracker_simd, config_t, max_score_updater_simd_global>,
-                                   lazy<policy_optimum_tracker, config_t, max_score_updater>>;
+                                   lazy<policy_optimum_tracker, config_t, scalar_optimum_updater_t>>;
 
             using gap_cost_policy_t = std::conditional_t<traits_t::is_banded,
                                                          policy_affine_gap_recursion_banded<config_t>,

--- a/include/seqan3/alignment/pairwise/detail/pairwise_alignment_algorithm_banded.hpp
+++ b/include/seqan3/alignment/pairwise/detail/pairwise_alignment_algorithm_banded.hpp
@@ -88,6 +88,10 @@ public:
             size_t const sequence1_size = std::ranges::distance(get<0>(sequence_pair));
             size_t const sequence2_size = std::ranges::distance(get<1>(sequence_pair));
 
+            // Initialise the cell updater with the dimensions of the regular matrix.
+            this->compare_and_set_optimum.set_target_indices(row_index_type{sequence2_size},
+                                                             column_index_type{sequence1_size});
+
             auto && [alignment_matrix, index_matrix] = this->acquire_matrices(sequence1_size,
                                                                               sequence2_size,
                                                                               this->lowest_viable_score());

--- a/test/unit/alignment/pairwise/fixture/semi_global_affine_banded.hpp
+++ b/test/unit/alignment/pairwise/fixture/semi_global_affine_banded.hpp
@@ -27,27 +27,39 @@ using seqan3::operator""_dna4;
 namespace seqan3::test::alignment::fixture::semi_global::affine::banded
 {
 
-inline constexpr auto align_config = seqan3::align_cfg::gap{seqan3::gap_scheme{seqan3::gap_score{-1},
-                                                                               seqan3::gap_open_score{-10}}} |
-                                     seqan3::align_cfg::band_fixed_size{seqan3::align_cfg::lower_diagonal{-4},
-                                                                        seqan3::align_cfg::upper_diagonal{8}};
+inline constexpr auto config_band_m4_8 = seqan3::align_cfg::band_fixed_size{seqan3::align_cfg::lower_diagonal{-4},
+                                                                            seqan3::align_cfg::upper_diagonal{8}};
 
-inline constexpr auto align_config_semi_seq1 = align_config |
-                                               seqan3::align_cfg::method_global{
-                                                    seqan3::align_cfg::free_end_gaps_sequence1_leading{true},
-                                                    seqan3::align_cfg::free_end_gaps_sequence2_leading{false},
-                                                    seqan3::align_cfg::free_end_gaps_sequence1_trailing{true},
-                                                    seqan3::align_cfg::free_end_gaps_sequence2_trailing{false}
-                                               } |
-                                               seqan3::align_cfg::aligned_ends{seqan3::free_ends_first};
-inline constexpr auto align_config_semi_seq2 = align_config |
-                                               seqan3::align_cfg::method_global{
-                                                    seqan3::align_cfg::free_end_gaps_sequence1_leading{false},
-                                                    seqan3::align_cfg::free_end_gaps_sequence2_leading{true},
-                                                    seqan3::align_cfg::free_end_gaps_sequence1_trailing{false},
-                                                    seqan3::align_cfg::free_end_gaps_sequence2_trailing{true}
-                                               } |
-                                               seqan3::align_cfg::aligned_ends{seqan3::free_ends_second};
+inline constexpr auto config_gap = seqan3::align_cfg::gap{seqan3::gap_scheme{seqan3::gap_score{-1},
+                                                                             seqan3::gap_open_score{-10}}};
+
+inline constexpr auto config_semi_seq1 = seqan3::align_cfg::method_global{
+                                            seqan3::align_cfg::free_end_gaps_sequence1_leading{true},
+                                            seqan3::align_cfg::free_end_gaps_sequence2_leading{false},
+                                            seqan3::align_cfg::free_end_gaps_sequence1_trailing{true},
+                                            seqan3::align_cfg::free_end_gaps_sequence2_trailing{false}
+                                         } | seqan3::align_cfg::aligned_ends{seqan3::free_ends_first};
+
+inline constexpr auto config_semi_seq2 = seqan3::align_cfg::method_global{
+                                            seqan3::align_cfg::free_end_gaps_sequence1_leading{false},
+                                            seqan3::align_cfg::free_end_gaps_sequence2_leading{true},
+                                            seqan3::align_cfg::free_end_gaps_sequence1_trailing{false},
+                                            seqan3::align_cfg::free_end_gaps_sequence2_trailing{true}
+                                        } | seqan3::align_cfg::aligned_ends{seqan3::free_ends_second};
+
+// free gaps for the second leading and first trailing gaps.
+inline constexpr auto config_free_gaps_sl_ft = seqan3::align_cfg::method_global{
+                                                   seqan3::align_cfg::free_end_gaps_sequence1_leading{false},
+                                                   seqan3::align_cfg::free_end_gaps_sequence2_leading{true},
+                                                   seqan3::align_cfg::free_end_gaps_sequence1_trailing{true},
+                                                   seqan3::align_cfg::free_end_gaps_sequence2_trailing{false}
+                                               } | seqan3::align_cfg::aligned_ends{
+                                                        seqan3::end_gaps{seqan3::front_end_second{std::true_type{}},
+                                                                         seqan3::back_end_first{std::true_type{}}}};
+
+inline constexpr auto config_scoring_m4_mm5 = seqan3::align_cfg::scoring_scheme{
+                                                seqan3::nucleotide_scoring_scheme{seqan3::match_score{4},
+                                                                                  seqan3::mismatch_score{-5}}};
 
 static auto dna4_01_semi_first = []()
 {
@@ -55,9 +67,7 @@ static auto dna4_01_semi_first = []()
     {
         "TTTTTACGTATGTCCCCC"_dna4,
         "ACGTAAAACGT"_dna4,
-        align_config_semi_seq1
-            | seqan3::align_cfg::scoring_scheme{seqan3::nucleotide_scoring_scheme{seqan3::match_score{4},
-                                                                                  seqan3::mismatch_score{-5}}},
+        config_semi_seq1 | config_gap | config_band_m4_8 | config_scoring_m4_mm5,
         10,
         "ACGT---ATGT",
         "ACGTAAAACGT",
@@ -124,9 +134,7 @@ static auto dna4_03_semi_second = []()
     {
         "TTTTTACGTATGTCCCCC"_dna4,
         "ACGTAAAACGT"_dna4,
-        align_config_semi_seq2
-            | seqan3::align_cfg::scoring_scheme{seqan3::nucleotide_scoring_scheme{seqan3::match_score{4},
-                                                                                  seqan3::mismatch_score{-5}}},
+        config_semi_seq2 | config_gap | config_band_m4_8 | config_scoring_m4_mm5,
         -19,
         "TTTTTACGTATGTCCCCC",
         "GTAAAACGT---------",
@@ -173,9 +181,7 @@ static auto dna4_04_semi_second = []()
     {
         "ACGTAAAACGT"_dna4,
         "TTTTTACGTATGTCCCCC"_dna4,
-        align_config_semi_seq2
-            | seqan3::align_cfg::scoring_scheme{seqan3::nucleotide_scoring_scheme{seqan3::match_score{4},
-                                                                                  seqan3::mismatch_score{-5}}},
+        config_semi_seq2 | config_gap | config_band_m4_8 | config_scoring_m4_mm5,
         -5,
         "ACGTAAAACGT",
         "------TACGT",

--- a/test/unit/alignment/pairwise/fixture/semi_global_affine_banded.hpp
+++ b/test/unit/alignment/pairwise/fixture/semi_global_affine_banded.hpp
@@ -57,6 +57,13 @@ inline constexpr auto config_free_gaps_sl_ft = seqan3::align_cfg::method_global{
                                                         seqan3::end_gaps{seqan3::front_end_second{std::true_type{}},
                                                                          seqan3::back_end_first{std::true_type{}}}};
 
+inline constexpr auto config_free_gaps_tlbr = seqan3::align_cfg::method_global{
+                                                   seqan3::align_cfg::free_end_gaps_sequence1_leading{true},
+                                                   seqan3::align_cfg::free_end_gaps_sequence2_leading{true},
+                                                   seqan3::align_cfg::free_end_gaps_sequence1_trailing{true},
+                                                   seqan3::align_cfg::free_end_gaps_sequence2_trailing{true}
+                                               } | seqan3::align_cfg::aligned_ends{seqan3::free_ends_all};
+
 inline constexpr auto config_scoring_m4_mm5 = seqan3::align_cfg::scoring_scheme{
                                                 seqan3::nucleotide_scoring_scheme{seqan3::match_score{4},
                                                                                   seqan3::mismatch_score{-5}}};
@@ -279,6 +286,106 @@ static auto dna4_free_lb_with_band_tl2br_no_matches = []()
         /*T*/ INF,INF,INF,INF,INF,Du ,DuL,ul ,ul ,ul ,ul ,ul ,
         /*T*/ INF,INF,INF,INF,INF,INF,Du ,uL ,ul ,ul ,ul ,ul ,
         /*T*/ INF,INF,INF,INF,INF,INF,INF,u  ,uL ,ul ,ul ,ul
+        }
+    };
+}();
+
+// band starts in top left with lower diagonal exceeding size of sequence 2 and ends in the bottom.
+static auto dna4_free_tlbr_with_band_tl2b = [] ()
+{
+    return alignment_fixture
+    {
+        "AGATTTACTACGCAT"_dna4,
+        "GTAGCAT"_dna4,
+        config_free_gaps_tlbr | config_gap | config_scoring_m4_mm5 |
+        seqan3::align_cfg::band_fixed_size{seqan3::align_cfg::lower_diagonal{-10},
+                                           seqan3::align_cfg::upper_diagonal{4}},
+        5,
+        "AG-AT",
+        "AGCAT",
+        seqan3::alignment_coordinate{seqan3::detail::column_index_type{0u}, seqan3::detail::row_index_type{2u}},
+        seqan3::alignment_coordinate{seqan3::detail::column_index_type{4u}, seqan3::detail::row_index_type{7u}},
+        std::vector<std::optional<int32_t>>
+        {
+        //    e  ,A  ,G  ,A  ,T  ,T  ,T  ,A  ,C  ,T  ,A  ,C  ,G  ,C  ,A  ,T  ,
+        /*e*/ 0  ,0  ,0  ,0  ,0  ,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*G*/ 0  ,-5 ,4  ,-5 ,-5 ,-5 ,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*T*/ 0  ,-5 ,-7 ,-1 ,-1 ,-1 ,-1 ,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*A*/ 0  ,4  ,-7 ,-3 ,-6 ,-6 ,-6 ,3  ,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*G*/ 0  ,-5 ,8  ,-3 ,-4 ,-5 ,-6 ,-7 ,-2 ,INF,INF,INF,INF,INF,INF,INF,
+        /*C*/ 0  ,-5 ,-3 ,3  ,-8 ,-9 ,-10,-9 ,-3 ,-7 ,INF,INF,INF,INF,INF,INF,
+        /*A*/ 0  ,4  ,-4 ,1  ,-2 ,-10,-11,-6 ,-13,-8 ,-3 ,INF,INF,INF,INF,INF,
+        /*T*/ 0  ,-5 ,-1 ,-9 ,5  ,2  ,-6 ,-8 ,-9 ,-9 ,-11,-8 ,INF,INF,INF,INF
+        },
+        std::vector<std::optional<seqan3::detail::trace_directions>>
+        {
+        //    e  ,A  ,G  ,A  ,T  ,T  ,T  ,A  ,C  ,T  ,A  ,C  ,G  ,C  ,A  ,T  ,
+        /*e*/ N  ,N  ,N  ,N  ,N  ,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*G*/ N  ,DUL,DUl,DUL,DUl,D  ,INF,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*T*/ N  ,DuL,Ul ,Dul,DuL,DUL,D  ,INF,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*A*/ N  ,DuL,L  ,DUl,DUl,DUl,DUl,D  ,INF,INF,INF,INF,INF,INF,INF,INF,
+        /*G*/ N  ,DUL,Dul,L  ,l  ,l  ,l  ,l  ,D  ,INF,INF,INF,INF,INF,INF,INF,
+        /*C*/ N  ,DuL,Ul ,Dul,DuL,Dul,Dul,ul ,DUl,D  ,INF,INF,INF,INF,INF,INF,
+        /*A*/ N  ,DuL,uL ,DUl,Dul,l  ,l  ,Dul,l  ,DUl,D  ,INF,INF,INF,INF,INF,
+        /*T*/ N  ,DUL,Dul,DuL,DUl,DuL,Dul,l  ,l  ,Dul,l  ,D  ,INF,INF,INF,INF
+        }
+    };
+}();
+
+// band starts in top left with upper diagonal exceeding size of sequence 1 and ends in the right side.
+static auto dna4_free_tlbr_with_band_tl2r = [] ()
+{
+    return alignment_fixture
+    {
+        "GTAGCAT"_dna4,
+        "AGATTTACTACGCAT"_dna4,
+        config_free_gaps_tlbr | config_gap | config_scoring_m4_mm5 |
+        seqan3::align_cfg::band_fixed_size{seqan3::align_cfg::lower_diagonal{-3},
+                                           seqan3::align_cfg::upper_diagonal{100}},
+        5,
+        "AGCAT",
+        "AG-AT",
+        seqan3::alignment_coordinate{seqan3::detail::column_index_type{2u}, seqan3::detail::row_index_type{0u}},
+        seqan3::alignment_coordinate{seqan3::detail::column_index_type{7u}, seqan3::detail::row_index_type{4u}},
+        std::vector<std::optional<int32_t>>
+        {
+        //    e  ,G  ,T  ,A  ,G  ,C  ,A  ,T  ,
+        /*e*/ 0  ,0  ,0  ,0  ,0  ,0  ,0  ,0  ,
+        /*A*/ 0  ,-5 ,-5 ,4  ,-5 ,-5 ,4  ,-5 ,
+        /*G*/ 0  ,4  ,-7 ,-7 ,8  ,-3 ,-4 ,-1 ,
+        /*A*/ 0  ,-5 ,-1 ,-3 ,-3 ,3  ,1  ,-9 ,
+        /*T*/ INF,-5 ,-1 ,-6 ,-4 ,-8 ,-2 ,5  ,
+        /*T*/ INF,INF,-1 ,-6 ,-5 ,-9 ,-10,2  ,
+        /*T*/ INF,INF,INF,-6 ,-6 ,-10,-11,-6 ,
+        /*A*/ INF,INF,INF,INF,-7 ,-11,-6 ,-8 ,
+        /*C*/ INF,INF,INF,INF,INF,-3 ,-13,-9 ,
+        /*T*/ INF,INF,INF,INF,INF,INF,-8 ,-9 ,
+        /*A*/ INF,INF,INF,INF,INF,INF,INF,-11,
+        /*C*/ INF,INF,INF,INF,INF,INF,INF,INF,
+        /*G*/ INF,INF,INF,INF,INF,INF,INF,INF,
+        /*C*/ INF,INF,INF,INF,INF,INF,INF,INF,
+        /*A*/ INF,INF,INF,INF,INF,INF,INF,INF,
+        /*T*/ INF,INF,INF,INF,INF,INF,INF,INF
+        },
+        std::vector<std::optional<seqan3::detail::trace_directions>>
+        {
+        //    e  ,G  ,T  ,A  ,G  ,C  ,A  ,T  ,
+        /*e*/ N  ,N  ,N  ,N  ,N  ,N  ,N  ,N  ,
+        /*A*/ N  ,DUL,DUl,DUl,DUL,DUl,DUl,DUL,
+        /*G*/ N  ,DuL,L  ,Ul ,Dul,L  ,l  ,Dul,
+        /*A*/ N  ,DUL,Dul,DuL,Ul ,Dul,DuL,DUl,
+        /*T*/ INF,Du ,DUL,DuL,ul ,DUl,Dul,DuL,
+        /*T*/ INF,INF,DU ,DuL,ul ,Dul,ul ,DUl,
+        /*T*/ INF,INF,INF,Du ,uL ,DuL,ul ,Dul,
+        /*A*/ INF,INF,INF,INF,u  ,DuL,Dul,uL ,
+        /*C*/ INF,INF,INF,INF,INF,Du ,uL ,ul ,
+        /*T*/ INF,INF,INF,INF,INF,INF,Du ,DuL,
+        /*A*/ INF,INF,INF,INF,INF,INF,INF,u  ,
+        /*C*/ INF,INF,INF,INF,INF,INF,INF,INF,
+        /*G*/ INF,INF,INF,INF,INF,INF,INF,INF,
+        /*C*/ INF,INF,INF,INF,INF,INF,INF,INF,
+        /*A*/ INF,INF,INF,INF,INF,INF,INF,INF,
+        /*T*/ INF,INF,INF,INF,INF,INF,INF,INF
         }
     };
 }();

--- a/test/unit/alignment/pairwise/fixture/semi_global_affine_banded.hpp
+++ b/test/unit/alignment/pairwise/fixture/semi_global_affine_banded.hpp
@@ -236,4 +236,51 @@ static auto dna4_04_semi_second = []()
     };
 }();
 
+static auto dna4_free_lb_with_band_tl2br_no_matches = []()
+{
+    return alignment_fixture
+    {
+        "AAAAAAAAAAA"_dna4,
+        "TTTTTTTTTTT"_dna4,
+        config_free_gaps_sl_ft | config_gap | config_band_m4_8 | config_scoring_m4_mm5,
+        -34,
+        "AAAAAAA-------",
+        "-------TTTTTTT",
+        seqan3::alignment_coordinate{seqan3::detail::column_index_type{0u}, seqan3::detail::row_index_type{4u}},
+        seqan3::alignment_coordinate{seqan3::detail::column_index_type{7u}, seqan3::detail::row_index_type{11u}},
+        std::vector<std::optional<int32_t>>
+        {
+        //      e,  A,  A,  A,  A,  A,  A,  A,  A,  A,  A,  A,
+        /*e*/ 0  ,-11,-12,-13,-14,-15,-16,-17,-18,INF,INF,INF,
+        /*T*/ 0  ,-5 ,-12,-13,-14,-15,-16,-17,-18,-19,INF,INF,
+        /*T*/ 0  ,-5 ,-10,-13,-14,-15,-16,-17,-18,-19,-20,INF,
+        /*T*/ 0  ,-5 ,-10,-13,-14,-15,-16,-17,-18,-19,-20,-21,
+        /*T*/ 0  ,-5 ,-10,-13,-14,-15,-16,-17,-18,-19,-20,-21,
+        /*T*/ INF,-5 ,-10,-15,-18,-19,-20,-21,-22,-23,-24,-25,
+        /*T*/ INF,INF,-10,-15,-20,-23,-24,-25,-26,-27,-28,-29,
+        /*T*/ INF,INF,INF,-15,-20,-25,-28,-29,-30,-31,-32,-33,
+        /*T*/ INF,INF,INF,INF,-20,-25,-30,-31,-32,-33,-34,-35,
+        /*T*/ INF,INF,INF,INF,INF,-25,-30,-32,-33,-34,-35,-36,
+        /*T*/ INF,INF,INF,INF,INF,INF,-30,-33,-34,-35,-36,-37,
+        /*T*/ INF,INF,INF,INF,INF,INF,INF,-34,-35,-36,-37,-38
+        },
+        std::vector<std::optional<seqan3::detail::trace_directions>>
+        {
+        //      e,  A,  A,  A,  A,  A,  A,  A,  A,  A,  A,  A,
+        /*e*/ N  ,L  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,INF,INF,INF,
+        /*T*/ N  ,DUL,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,INF,INF,
+        /*T*/ N  ,DUL,DUl,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,INF,
+        /*T*/ N  ,DUL,DUl,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,
+        /*T*/ N  ,DUL,DUl,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,l  ,
+        /*T*/ INF,DU ,DUL,DUl,DUl,DUl,DUl,DUl,DUl,DUl,DUl,DUl,
+        /*T*/ INF,INF,DU ,DuL,Dul,Dul,Dul,Dul,Dul,Dul,Dul,Dul,
+        /*T*/ INF,INF,INF,Du ,DuL,Dul,Dul,Dul,Dul,Dul,Dul,Dul,
+        /*T*/ INF,INF,INF,INF,Du ,DuL,Dul,ul ,ul ,ul ,ul ,ul ,
+        /*T*/ INF,INF,INF,INF,INF,Du ,DuL,ul ,ul ,ul ,ul ,ul ,
+        /*T*/ INF,INF,INF,INF,INF,INF,Du ,uL ,ul ,ul ,ul ,ul ,
+        /*T*/ INF,INF,INF,INF,INF,INF,INF,u  ,uL ,ul ,ul ,ul
+        }
+    };
+}();
+
 } // namespace seqan3::test::alignment::fixture::global::affine::banded

--- a/test/unit/alignment/pairwise/semi_global_affine_banded_test.cpp
+++ b/test/unit/alignment/pairwise/semi_global_affine_banded_test.cpp
@@ -17,7 +17,9 @@ using pairwise_semiglobal_affine_banded_testing_types = ::testing::Types<
         // pairwise_alignment_fixture<&seqan3::test::alignment::fixture::semi_global::affine::banded::dna4_02_semi_first>,
         pairwise_alignment_fixture<&seqan3::test::alignment::fixture::semi_global::affine::banded::dna4_03_semi_second>,
         pairwise_alignment_fixture<&seqan3::test::alignment::fixture::semi_global::affine::banded::dna4_04_semi_second>,
-        pairwise_alignment_fixture<&seqan3::test::alignment::fixture::semi_global::affine::banded::dna4_free_lb_with_band_tl2br_no_matches>
+        pairwise_alignment_fixture<&seqan3::test::alignment::fixture::semi_global::affine::banded::dna4_free_lb_with_band_tl2br_no_matches>,
+        pairwise_alignment_fixture<&seqan3::test::alignment::fixture::semi_global::affine::banded::dna4_free_tlbr_with_band_tl2b>,
+        pairwise_alignment_fixture<&seqan3::test::alignment::fixture::semi_global::affine::banded::dna4_free_tlbr_with_band_tl2r>
     >;
 
 INSTANTIATE_TYPED_TEST_SUITE_P(pairwise_semiglobal_affine_banded,

--- a/test/unit/alignment/pairwise/semi_global_affine_banded_test.cpp
+++ b/test/unit/alignment/pairwise/semi_global_affine_banded_test.cpp
@@ -16,7 +16,8 @@ using pairwise_semiglobal_affine_banded_testing_types = ::testing::Types<
         pairwise_alignment_fixture<&seqan3::test::alignment::fixture::semi_global::affine::banded::dna4_01_semi_first>,
         // pairwise_alignment_fixture<&seqan3::test::alignment::fixture::semi_global::affine::banded::dna4_02_semi_first>,
         pairwise_alignment_fixture<&seqan3::test::alignment::fixture::semi_global::affine::banded::dna4_03_semi_second>,
-        pairwise_alignment_fixture<&seqan3::test::alignment::fixture::semi_global::affine::banded::dna4_04_semi_second>
+        pairwise_alignment_fixture<&seqan3::test::alignment::fixture::semi_global::affine::banded::dna4_04_semi_second>,
+        pairwise_alignment_fixture<&seqan3::test::alignment::fixture::semi_global::affine::banded::dna4_free_lb_with_band_tl2br_no_matches>
     >;
 
 INSTANTIATE_TYPED_TEST_SUITE_P(pairwise_semiglobal_affine_banded,


### PR DESCRIPTION
Enables the banded global alignment using end-positions. This is a first part of making the banded alignment vectorised.
See seqan/product_backlog#114