### PR TITLE
[TEST] Force compiler to actually execute the search algorithm.

### DIFF
--- a/test/performance/search/search_benchmark.cpp
+++ b/test/performance/search/search_benchmark.cpp
@@ -166,8 +166,9 @@ void unidirectional_search_all_collection(benchmark::State & state, options && o
     for (auto _ : state)
     {
         auto results = search(reads, index, cfg);
-        benchmark::DoNotOptimize(sum += std::ranges::distance(results));
+        sum += std::ranges::distance(results);
     }
+    benchmark::DoNotOptimize(sum);
 }
 
 //============================================================================
@@ -191,8 +192,9 @@ void unidirectional_search_all(benchmark::State & state, options && o)
     for (auto _ : state)
     {
         auto results = search(reads, index, cfg);
-        benchmark::DoNotOptimize(sum += std::ranges::distance(results));
+        sum += std::ranges::distance(results);
     }
+    benchmark::DoNotOptimize(sum);
 }
 
 //============================================================================
@@ -216,8 +218,9 @@ void bidirectional_search_all(benchmark::State & state, options && o)
     for (auto _ : state)
     {
         auto results = search(reads, index, cfg);
-        benchmark::DoNotOptimize(sum += std::ranges::distance(results));
+        sum += std::ranges::distance(results);
     }
+    benchmark::DoNotOptimize(sum);
 }
 
 //============================================================================
@@ -242,8 +245,9 @@ void unidirectional_search_stratified(benchmark::State & state, options && o)
     for (auto _ : state)
     {
         auto results = search(reads, index, cfg);
-        benchmark::DoNotOptimize(sum += std::ranges::distance(results));
+        sum += std::ranges::distance(results);
     }
+    benchmark::DoNotOptimize(sum);
 }
 
 //============================================================================
@@ -268,8 +272,9 @@ void bidirectional_search_stratified(benchmark::State & state, options && o)
     for (auto _ : state)
     {
         auto results = search(reads, index, cfg);
-        benchmark::DoNotOptimize(sum += std::ranges::distance(results));
+        sum += std::ranges::distance(results);
     }
+    benchmark::DoNotOptimize(sum);
 }
 
 BENCHMARK_CAPTURE(unidirectional_search_all_collection, highErrorReadsSearch0,

--- a/test/performance/search/search_benchmark.cpp
+++ b/test/performance/search/search_benchmark.cpp
@@ -144,6 +144,9 @@ std::vector<alphabet_t> generate_repeating_sequence(size_t const template_length
 //  undirectional; trivial_search, collection, dna4, all-mapping
 //============================================================================
 
+// Note: We force the actual computation of the search() by going through the lazy algorithm result range (input_range)
+//       using std::ranges::distance within the for loop.
+
 void unidirectional_search_all_collection(benchmark::State & state, options && o)
 {
     size_t set_size = 10;

--- a/test/performance/search/search_benchmark.cpp
+++ b/test/performance/search/search_benchmark.cpp
@@ -162,8 +162,12 @@ void unidirectional_search_all_collection(benchmark::State & state, options && o
     seqan3::fm_index index{collection};
     seqan3::configuration cfg = seqan3::search_cfg::max_error_total{seqan3::search_cfg::error_count{o.searched_errors}};
 
+    size_t sum{};
     for (auto _ : state)
+    {
         auto results = search(reads, index, cfg);
+        benchmark::DoNotOptimize(sum += std::ranges::distance(results));
+    }
 }
 
 //============================================================================
@@ -183,8 +187,12 @@ void unidirectional_search_all(benchmark::State & state, options && o)
                                                                   o.prob_deletion, o.stddev);
     seqan3::configuration cfg = seqan3::search_cfg::max_error_total{seqan3::search_cfg::error_count{o.searched_errors}};
 
+    size_t sum{};
     for (auto _ : state)
+    {
         auto results = search(reads, index, cfg);
+        benchmark::DoNotOptimize(sum += std::ranges::distance(results));
+    }
 }
 
 //============================================================================
@@ -204,8 +212,12 @@ void bidirectional_search_all(benchmark::State & state, options && o)
                                                                   o.prob_deletion, o.stddev);
     seqan3::configuration cfg = seqan3::search_cfg::max_error_total{seqan3::search_cfg::error_count{o.searched_errors}};
 
+    size_t sum{};
     for (auto _ : state)
+    {
         auto results = search(reads, index, cfg);
+        benchmark::DoNotOptimize(sum += std::ranges::distance(results));
+    }
 }
 
 //============================================================================
@@ -226,8 +238,12 @@ void unidirectional_search_stratified(benchmark::State & state, options && o)
     seqan3::configuration cfg = seqan3::search_cfg::max_error_total{seqan3::search_cfg::error_count{o.searched_errors}} |
                                 seqan3::search_cfg::hit_strata{o.strata};
 
+    size_t sum{};
     for (auto _ : state)
+    {
         auto results = search(reads, index, cfg);
+        benchmark::DoNotOptimize(sum += std::ranges::distance(results));
+    }
 }
 
 //============================================================================
@@ -248,8 +264,12 @@ void bidirectional_search_stratified(benchmark::State & state, options && o)
     seqan3::configuration cfg = seqan3::search_cfg::max_error_total{seqan3::search_cfg::error_count{o.searched_errors}} |
                                 seqan3::search_cfg::hit_strata{o.strata};
 
+    size_t sum{};
     for (auto _ : state)
+    {
         auto results = search(reads, index, cfg);
+        benchmark::DoNotOptimize(sum += std::ranges::distance(results));
+    }
 }
 
 BENCHMARK_CAPTURE(unidirectional_search_all_collection, highErrorReadsSearch0,


### PR DESCRIPTION
On my personal laptop (Linux, Ubuntu 18, GCC 7) the search algorithm was not executed in the benchmarks.