### PR TITLE
[MISC] Remove unnecessary second transform from lazy_locate.

### DIFF
--- a/include/seqan3/search/fm_index/bi_fm_index_cursor.hpp
+++ b/include/seqan3/search/fm_index/bi_fm_index_cursor.hpp
@@ -1014,10 +1014,7 @@ public:
         return std::views::iota(fwd_lb, fwd_lb + count())
              | std::views::transform([*this, _offset = offset()] (auto sa_pos)
                {
-                   return _offset - index->fwd_fm.index[sa_pos];
-               })
-             | std::views::transform([*this] (auto loc)
-               {
+                   auto loc = _offset - index->fwd_fm.index[sa_pos];
                    size_type sequence_rank = index->fwd_fm.text_begin_rs.rank(loc + 1);
                    size_type sequence_position = loc - index->fwd_fm.text_begin_ss.select(sequence_rank);
                    return locate_result_value_type{sequence_rank-1, sequence_position};

--- a/include/seqan3/search/fm_index/fm_index_cursor.hpp
+++ b/include/seqan3/search/fm_index/fm_index_cursor.hpp
@@ -613,10 +613,7 @@ public:
         return std::views::iota(node.lb, node.lb + count())
              | std::views::transform([*this, _offset = offset()] (auto sa_pos)
                {
-                   return _offset - index->index[sa_pos];
-               })
-             | std::views::transform([*this] (auto loc)
-               {
+                   auto loc = _offset - index->index[sa_pos];
                    size_type sequence_rank = index->text_begin_rs.rank(loc + 1);
                    size_type sequence_position = loc - index->text_begin_ss.select(sequence_rank);
                    return locate_result_value_type{sequence_rank - 1, sequence_position};


### PR DESCRIPTION
I found another patch I did when investigating the search performance. I think it didn't have an significant impact but either way it is unnecessary to use two transform views if using one is equivalent.