### PR TITLE
[FIX] Wrong ranks in search algorithm

### DIFF
--- a/test/unit/search/search_collection_test.cpp
+++ b/test/unit/search/search_collection_test.cpp
@@ -211,6 +211,29 @@ TYPED_TEST(search_test, parallel_without_parameter)
     EXPECT_THROW(search("AAAA"_dna4, this->index, cfg), std::runtime_error);
 }
 
+// https://github.com/seqan/seqan3/issues/2115
+TYPED_TEST(search_test, issue_2115)
+{
+    std::vector<std::vector<seqan3::dna4>> const genomes{"ACAG"_dna4};
+    TypeParam const index{genomes};
+
+    // One substitution error, report all best hits
+    seqan3::configuration const cfg = seqan3::search_cfg::max_error_total{seqan3::search_cfg::error_count{1}} |
+                                      seqan3::search_cfg::max_error_substitution{seqan3::search_cfg::error_count{1}} |
+                                      seqan3::search_cfg::max_error_insertion{seqan3::search_cfg::error_count{0}} |
+                                      seqan3::search_cfg::max_error_deletion{seqan3::search_cfg::error_count{0}} |
+                                      seqan3::search_cfg::hit_all_best;
+
+    std::vector<seqan3::dna4> const dna4_query{"ACGG"_dna4};
+    std::vector<seqan3::qualified<seqan3::dna4, seqan3::phred42>> const dna4q_query{{'A'_dna4, seqan3::phred42{0}},
+                                                                                    {'C'_dna4, seqan3::phred42{15}},
+                                                                                    {'G'_dna4, seqan3::phred42{30}},
+                                                                                    {'G'_dna4, seqan3::phred42{41}}};
+
+    // Quality should not alter search results.
+    EXPECT_RANGE_EQ(seqan3::search(dna4q_query, index, cfg), seqan3::search(dna4_query, index, cfg));
+}
+
 TYPED_TEST(search_string_test, error_free_string)
 {
     typename TestFixture::hits_result_t empty_result{};

--- a/test/unit/search/search_collection_test.cpp
+++ b/test/unit/search/search_collection_test.cpp
@@ -211,6 +211,17 @@ TYPED_TEST(search_test, parallel_without_parameter)
     EXPECT_THROW(search("AAAA"_dna4, this->index, cfg), std::runtime_error);
 }
 
+TYPED_TEST(search_test, debug_streaming)
+{
+    std::ostringstream oss;
+    seqan3::debug_stream_type stream{oss};
+    stream << search("TAC"_dna4, this->index);
+    EXPECT_EQ(oss.str(), "[<query_id:0, reference_id:0, reference_pos:3>"
+                         ",<query_id:0, reference_id:0, reference_pos:7>"
+                         ",<query_id:0, reference_id:1, reference_pos:3>"
+                         ",<query_id:0, reference_id:1, reference_pos:7>]");
+}
+
 // https://github.com/seqan/seqan3/issues/2115
 TYPED_TEST(search_test, issue_2115)
 {

--- a/test/unit/search/search_test.cpp
+++ b/test/unit/search/search_test.cpp
@@ -483,6 +483,15 @@ TYPED_TEST(search_test, parallel_without_parameter)
     EXPECT_THROW(search("AAAA"_dna4, this->index, cfg), std::runtime_error);
 }
 
+TYPED_TEST(search_test, debug_streaming)
+{
+    std::ostringstream oss;
+    seqan3::debug_stream_type stream{oss};
+    stream << search("TAC"_dna4, this->index);
+    EXPECT_EQ(oss.str(), "[<query_id:0, reference_id:0, reference_pos:3>"
+                         ",<query_id:0, reference_id:0, reference_pos:7>]");
+}
+
 // https://github.com/seqan/seqan3/issues/2115
 TYPED_TEST(search_test, issue_2115)
 {

--- a/test/unit/search/search_test.cpp
+++ b/test/unit/search/search_test.cpp
@@ -483,6 +483,29 @@ TYPED_TEST(search_test, parallel_without_parameter)
     EXPECT_THROW(search("AAAA"_dna4, this->index, cfg), std::runtime_error);
 }
 
+// https://github.com/seqan/seqan3/issues/2115
+TYPED_TEST(search_test, issue_2115)
+{
+    std::vector<seqan3::dna4> const genome{"ACAG"_dna4};
+    TypeParam const index{genome};
+
+    // One substitution error, report all best hits
+    seqan3::configuration const cfg = seqan3::search_cfg::max_error_total{seqan3::search_cfg::error_count{1}} |
+                                      seqan3::search_cfg::max_error_substitution{seqan3::search_cfg::error_count{1}} |
+                                      seqan3::search_cfg::max_error_insertion{seqan3::search_cfg::error_count{0}} |
+                                      seqan3::search_cfg::max_error_deletion{seqan3::search_cfg::error_count{0}} |
+                                      seqan3::search_cfg::hit_all_best;
+
+    std::vector<seqan3::dna4> const dna4_query{"ACGG"_dna4};
+    std::vector<seqan3::qualified<seqan3::dna4, seqan3::phred42>> const dna4q_query{{'A'_dna4, seqan3::phred42{0}},
+                                                                                    {'C'_dna4, seqan3::phred42{15}},
+                                                                                    {'G'_dna4, seqan3::phred42{30}},
+                                                                                    {'G'_dna4, seqan3::phred42{41}}};
+
+    // Quality should not alter search results.
+    EXPECT_RANGE_EQ(seqan3::search(dna4q_query, index, cfg), seqan3::search(dna4_query, index, cfg));
+}
+
 TYPED_TEST(search_string_test, error_free_string)
 {
     // successful and unsuccesful exact search without cfg


### PR DESCRIPTION
Resolves https://github.com/seqan/seqan3/issues/2115

The search algorithm uses the ranks of the given query. If the alphabet type of the query does not equal the alphabet type of the index, hits may be missed.
The index already converts the query, i.e. ,for the given example, `extend_right` on the cursor correctly returned true, but the search did not find the hits, because it used the ranks of the qualified query instead of the normal, unqualified query that the index uses.


The second commit adds a test for debug_streaming, as there was none before and coverage dropped because of this.