### PR TITLE
Protein alignment/part2 gather scoring matrix using gather

### DIFF
--- a/include/seqan3/alignment/pairwise/alignment_algorithm.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_algorithm.hpp
@@ -398,9 +398,9 @@ private:
         // Recursion phase: compute column-wise the alignment matrix.
         // ----------------------------------------------------------------------------
 
-        for (auto const & seq1_value : sequence1)
+        for (auto const & alphabet1 : sequence1)
         {
-            compute_alignment_column<true>(seq1_value, sequence2);
+            compute_alignment_column<true>(this->scoring_scheme_profile_column(alphabet1), sequence2);
             finalise_last_cell_in_column(true);
         }
 

--- a/include/seqan3/alignment/pairwise/alignment_algorithm.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_algorithm.hpp
@@ -250,7 +250,7 @@ private:
 
         std::vector<simd_score_t, aligned_allocator<simd_score_t, alignof(simd_score_t)>> simd_sequence{};
 
-        for (auto && simd_vector_chunk : sequences | views::to_simd<simd_score_t>(traits_t::padding_symbol))
+        for (auto && simd_vector_chunk : sequences | views::to_simd<simd_score_t>(this->scoring_scheme.padding_symbol))
             for (auto && simd_vector : simd_vector_chunk)
                 simd_sequence.push_back(std::move(simd_vector));
 

--- a/include/seqan3/alignment/pairwise/alignment_configurator.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_configurator.hpp
@@ -510,8 +510,7 @@ private:
                                                             lazy<simd_matrix_scoring_scheme,
                                                                  score_t,
                                                                  typename traits_t::scoring_scheme_alphabet_type,
-                                                                 alignment_method_t,
-                                                                 scoring_scheme_t>,
+                                                                 alignment_method_t>,
                                                             void>;
 
             using alignment_scoring_scheme_t = std::conditional_t<traits_t::is_vectorised,
@@ -566,8 +565,7 @@ constexpr function_wrapper_t alignment_configurator::configure_scoring_scheme(co
                                                     lazy<simd_matrix_scoring_scheme,
                                                          typename traits_t::score_type,
                                                          typename traits_t::scoring_scheme_alphabet_type,
-                                                         alignment_type_t,
-                                                         scoring_scheme_t>,
+                                                         alignment_type_t>,
                                                     void>;
 
     using alignment_scoring_scheme_t = std::conditional_t<traits_t::is_vectorised,

--- a/include/seqan3/alignment/pairwise/detail/pairwise_alignment_algorithm.hpp
+++ b/include/seqan3/alignment/pairwise/detail/pairwise_alignment_algorithm.hpp
@@ -169,8 +169,12 @@ public:
         thread_local simd_collection_t simd_seq1_collection{};
         thread_local simd_collection_t simd_seq2_collection{};
 
-        convert_batch_of_sequences_to_simd_vector(simd_seq1_collection, seq1_collection, traits_type::padding_symbol);
-        convert_batch_of_sequences_to_simd_vector(simd_seq2_collection, seq2_collection, traits_type::padding_symbol);
+        convert_batch_of_sequences_to_simd_vector(simd_seq1_collection,
+                                                  seq1_collection,
+                                                  this->scoring_scheme.padding_symbol);
+        convert_batch_of_sequences_to_simd_vector(simd_seq2_collection,
+                                                  seq2_collection,
+                                                  this->scoring_scheme.padding_symbol);
 
         size_t const sequence1_size = std::ranges::distance(simd_seq1_collection);
         size_t const sequence2_size = std::ranges::distance(simd_seq2_collection);

--- a/include/seqan3/alignment/pairwise/detail/pairwise_alignment_algorithm_banded.hpp
+++ b/include/seqan3/alignment/pairwise/detail/pairwise_alignment_algorithm_banded.hpp
@@ -133,10 +133,10 @@ public:
 
         this->convert_batch_of_sequences_to_simd_vector(simd_seq1_collection,
                                                         seq1_collection,
-                                                        traits_type::padding_symbol);
+                                                        this->scoring_scheme.padding_symbol);
         this->convert_batch_of_sequences_to_simd_vector(simd_seq2_collection,
                                                         seq2_collection,
-                                                        traits_type::padding_symbol);
+                                                        this->scoring_scheme.padding_symbol);
 
         size_t const sequence1_size = std::ranges::distance(simd_seq1_collection);
         size_t const sequence2_size = std::ranges::distance(simd_seq2_collection);

--- a/include/seqan3/alignment/pairwise/detail/pairwise_alignment_algorithm_banded.hpp
+++ b/include/seqan3/alignment/pairwise/detail/pairwise_alignment_algorithm_banded.hpp
@@ -247,11 +247,11 @@ protected:
         // 1st recursion phase: band intersects with the first row.
         // ---------------------------------------------------------------------
 
-        for (auto sequence1_value : sequence1 | views::take(column_size))
+        for (auto alphabet1 : sequence1 | views::take(column_size))
         {
             this->compute_column(*++alignment_matrix_it,
                                  *++indexed_matrix_it,
-                                 sequence1_value,
+                                 alphabet1,
                                  sequence2 | views::take(++row_size));
         }
 
@@ -260,11 +260,11 @@ protected:
         // ---------------------------------------------------------------------
 
         size_t first_row_index = 0u;
-        for (auto sequence1_value : sequence1 | views::drop(column_size))
+        for (auto alphabet1 : sequence1 | views::drop(column_size))
         {
             compute_band_column(*++alignment_matrix_it,
                                 *++indexed_matrix_it | views::drop(first_row_index + 1),
-                                sequence1_value,
+                                alphabet1,
                                 sequence2 | views::slice(first_row_index, ++row_size));
             ++first_row_index;
         }
@@ -292,13 +292,13 @@ protected:
     /*!\brief Computes a column of the band that does not start in the first row of the alignment matrix.
      * \tparam alignment_column_t The type of the alignment column; must model std::ranges::forward_range.
      * \tparam cell_index_column_t The type of the indexed column; must model std::ranges::input_range.
-     * \tparam sequence1_value_t The value type of sequence1; must model seqan3::semialphabet.
+     * \tparam alphabet1_t The type of the current symbol of sequence1.
      * \tparam sequence2_t The type of the second sequence; must model std::ranges::input_range.
      *
      * \param[in] alignment_column The current alignment matrix column to compute.
      * \param[in] cell_index_column The current index matrix column to get the respective cell indices.
-     * \param[in] sequence1_value The current symbol of sequence1.
-     * \param[in] sequence2 The second sequence to align against `sequence1_value`.
+     * \param[in] alphabet1 The current symbol of sequence1.
+     * \param[in] sequence2 The second sequence to align against `alphabet1`.
      *
      * \details
      *
@@ -342,11 +342,11 @@ protected:
      */
     template <std::ranges::forward_range alignment_column_t,
               std::ranges::input_range cell_index_column_t,
-              typename sequence1_value_t,
+              typename alphabet1_t,
               std::ranges::input_range sequence2_t>
     void compute_band_column(alignment_column_t && alignment_column,
                              cell_index_column_t && cell_index_column,
-                             sequence1_value_t const & sequence1_value,
+                             alphabet1_t const & alphabet1,
                              sequence2_t && sequence2)
     {
         // ---------------------------------------------------------------------
@@ -362,22 +362,21 @@ protected:
         cell = this->track_cell(
                 this->initialise_band_first_cell(cell.best_score(),
                                                  *++next_alignment_column_it,
-                                                 this->scoring_scheme.score(sequence1_value,
-                                                                            *std::ranges::begin(sequence2))),
+                                                 this->scoring_scheme.score(alphabet1, *std::ranges::begin(sequence2))),
                 *cell_index_column_it);
 
         // ---------------------------------------------------------------------
         // Iteration phase: iterate over column and compute each cell
         // ---------------------------------------------------------------------
 
-        for (auto && sequence2_value : sequence2 | views::drop(1))
+        for (auto && alphabet2 : sequence2 | views::drop(1))
         {
             current_alignment_column_it = next_alignment_column_it;
             auto cell = *current_alignment_column_it;
             cell = this->track_cell(
                 this->compute_inner_cell(cell.best_score(),
                                          *++next_alignment_column_it,
-                                         this->scoring_scheme.score(sequence1_value, sequence2_value)),
+                                         this->scoring_scheme.score(alphabet1, alphabet2)),
                 *++cell_index_column_it);
         }
 

--- a/include/seqan3/alignment/pairwise/detail/type_traits.hpp
+++ b/include/seqan3/alignment/pairwise/detail/type_traits.hpp
@@ -186,9 +186,6 @@ public:
                                                      compute_sequence_alignment ||
                                                      output_sequence1_id ||
                                                      output_sequence2_id;
-    //!\brief The padding symbol to use for the computation of the alignment.
-    static constexpr original_score_type padding_symbol =
-        static_cast<original_score_type>(1u << (sizeof_bits<original_score_type> - 1));
 };
 
 //------------------------------------------------------------------------------

--- a/include/seqan3/alignment/pairwise/policy/scoring_scheme_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/scoring_scheme_policy.hpp
@@ -38,17 +38,17 @@ private:
      * \{
      */
     //!\brief Defaulted.
-    constexpr scoring_scheme_policy() noexcept = default;
+    constexpr scoring_scheme_policy() = default;
     //!\brief Defaulted.
-    constexpr scoring_scheme_policy(scoring_scheme_policy const &) noexcept = default;
+    constexpr scoring_scheme_policy(scoring_scheme_policy const &) = default;
     //!\brief Defaulted.
-    constexpr scoring_scheme_policy(scoring_scheme_policy &&) noexcept = default;
+    constexpr scoring_scheme_policy(scoring_scheme_policy &&) = default;
     //!\brief Defaulted.
-    constexpr scoring_scheme_policy & operator=(scoring_scheme_policy const &) noexcept = default;
+    constexpr scoring_scheme_policy & operator=(scoring_scheme_policy const &) = default;
     //!\brief Defaulted.
-    constexpr scoring_scheme_policy & operator=(scoring_scheme_policy &&) noexcept = default;
+    constexpr scoring_scheme_policy & operator=(scoring_scheme_policy &&) = default;
     //!\brief Defaulted.
-    ~scoring_scheme_policy() noexcept = default;
+    ~scoring_scheme_policy() = default;
 
     //!\brief Initialise the policy.
     template <typename configuration_t>

--- a/include/seqan3/alignment/pairwise/policy/scoring_scheme_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/scoring_scheme_policy.hpp
@@ -12,7 +12,9 @@
 
 #pragma once
 
-#include <seqan3/core/platform.hpp>
+#include <seqan3/alphabet/concept.hpp>
+#include <seqan3/core/simd/concept.hpp>
+#include <seqan3/core/type_traits/basic.hpp>
 
 namespace seqan3::detail
 {
@@ -58,6 +60,33 @@ private:
 
     //!\brief The scoring scheme used for this alignment algorithm.
     scoring_scheme_t scoring_scheme{};
+
+    /*!\brief Maybe converts the given sequence value to a specific profile used by the underlying scoring scheme.
+     *
+     * \details
+     *
+     * In the vectorised alignment the scoring scheme might transform the sequence values of the first sequence into
+     * a profile for a more efficient comparison of the sequence characters in simd mode.
+     *
+     * If the given sequence type models seqan3::semialphabet the function becomes a no-op function and returns the
+     * unmodified value.
+     */
+    template <typename alphabet_t>
+    //!\cond
+        requires simd_concept<std::remove_cvref_t<alphabet_t>>
+    //!\endcond
+    auto scoring_scheme_profile_column(alphabet_t && alphabet) const noexcept
+    {
+        return scoring_scheme.make_score_profile(std::forward<alphabet_t>(alphabet));
+    }
+
+    //!\overload
+    template <semialphabet alphabet_t>
+    alphabet_t scoring_scheme_profile_column(alphabet_t && alphabet) const
+        noexcept
+    {
+        return std::forward<alphabet_t>(alphabet);
+    }
 };
 
 } // namespace seqan3::detail

--- a/include/seqan3/alignment/scoring/detail/simd_match_mismatch_scoring_scheme.hpp
+++ b/include/seqan3/alignment/scoring/detail/simd_match_mismatch_scoring_scheme.hpp
@@ -15,6 +15,7 @@
 #include <seqan3/alignment/configuration/align_config_method.hpp>
 #include <seqan3/alignment/scoring/scoring_scheme_concept.hpp>
 #include <seqan3/alphabet/concept.hpp>
+#include <seqan3/core/bit_manipulation.hpp>
 #include <seqan3/core/concept/cereal.hpp>
 #include <seqan3/core/simd/concept.hpp>
 #include <seqan3/core/simd/simd_algorithm.hpp>
@@ -69,10 +70,15 @@ template <simd_concept simd_score_t, semialphabet alphabet_t, typename alignment
 class simd_match_mismatch_scoring_scheme
 {
 private:
+    //!\brief The underlying scalar type of the simd vector.
+    using scalar_type = typename simd_traits<simd_score_t>::scalar_type;
     //!\brief The type of the simd vector representing the alphabet ranks of one sequence batch.
     using alphabet_ranks_type = simd_score_t;
 
 public:
+    //!\brief The padding symbol used to fill up smaller sequences in a simd batch.
+    static constexpr scalar_type padding_symbol = static_cast<scalar_type>(1u << (sizeof_bits<scalar_type> - 1));
+
     /*!\name Constructors, destructor and assignment
      * \{
      */

--- a/include/seqan3/alignment/scoring/detail/simd_matrix_scoring_scheme.hpp
+++ b/include/seqan3/alignment/scoring/detail/simd_matrix_scoring_scheme.hpp
@@ -23,7 +23,7 @@
 namespace seqan3::detail
 {
 
-/*!\brief A vectorised scoring scheme to handle scoring matrices.
+/*!\brief A vectorised scoring scheme to handle scoring matrices using gather strategy.
  * \ingroup scoring
  * \tparam simd_score_t The type of the simd vector; must model seqan3::simd::simd_concept.
  * \tparam alphabet_t The type of the alphabet over which to define the scoring scheme; must model seqan3::semialphabet.
@@ -67,6 +67,10 @@ private:
     using simd_alphabet_ranks_type = simd_score_t;
 
     static_assert(seqan3::alphabet_size<alphabet_t> <= std::numeric_limits<scalar_type>::max(),
+                  "The selected simd scalar type is not large enough to represent the given alphabet including an "
+                  "additional padding symbol!");
+
+    static_assert(seqan3::alphabet_size<alphabet_t> < std::numeric_limits<scalar_type>::max(),
                   "The selected simd scalar type is not large enough to represent the given alphabet including an "
                   "additional padding symbol!");
 

--- a/include/seqan3/alignment/scoring/detail/simd_matrix_scoring_scheme.hpp
+++ b/include/seqan3/alignment/scoring/detail/simd_matrix_scoring_scheme.hpp
@@ -81,6 +81,9 @@ private:
     std::vector<scalar_type> scoring_scheme_data{};
 
 public:
+    //!\brief The padding symbol used to fill up smaller sequences in a simd batch.
+    static constexpr scalar_type padding_symbol = static_cast<scalar_type>(seqan3::alphabet_size<alphabet_t>);
+
     /*!\name Constructors, destructor and assignment
      * \{
      */
@@ -147,7 +150,7 @@ public:
     //!\brief Returns the score used when aligning a padding symbol.
     constexpr scalar_type padding_match_score() const noexcept
     {
-        return 1;
+        return score_for_padding_symbol;
     }
 
     /*!\brief Converts the simd alphabet ranks into a score profile used for scoring it later with the alphabet ranks

--- a/include/seqan3/alignment/scoring/detail/simd_matrix_scoring_scheme.hpp
+++ b/include/seqan3/alignment/scoring/detail/simd_matrix_scoring_scheme.hpp
@@ -29,8 +29,6 @@ namespace seqan3::detail
  * \tparam alphabet_t The type of the alphabet over which to define the scoring scheme; must model seqan3::semialphabet.
  * \tparam alignment_t The type of the alignment to compute; must be either seqan3::align_cfg::method_global or
  *                     seqan3::align_cfg::method_local.
- * \tparam scoring_scheme_t The type of the scoring scheme which will be used. Must model seqan3::scoring_scheme with
- *                          the given `alphabet_t`.
  *
  * \details
  *
@@ -54,11 +52,9 @@ namespace seqan3::detail
  * \note Note that the alphabet type information is lost during the conversion to the simd vectors and
  * only the ranks of the alphabet are used.
  */
-template <simd_concept simd_score_t, semialphabet alphabet_t, typename alignment_t, typename scoring_scheme_t>
+template <simd_concept simd_score_t, semialphabet alphabet_t, typename alignment_t>
 //!\cond
-    requires scoring_scheme_for<scoring_scheme_t, alphabet_t> &&
-             (std::same_as<alignment_t, align_cfg::method_local> ||
-              std::same_as<alignment_t, align_cfg::method_global>)
+    requires (std::same_as<alignment_t, align_cfg::method_local> || std::same_as<alignment_t, align_cfg::method_global>)
 //!\endcond
 class simd_matrix_scoring_scheme
 {
@@ -96,12 +92,14 @@ public:
     ~simd_matrix_scoring_scheme() = default; //!< Defaulted.
 
     //!\copydoc seqan3::detail::simd_matrix_scoring_scheme::initialise_from_scalar_scoring_scheme
+    template <typename scoring_scheme_t>
     constexpr explicit simd_matrix_scoring_scheme(scoring_scheme_t const & scoring_scheme)
     {
         initialise_from_scalar_scoring_scheme(scoring_scheme);
     }
 
     //!\copydoc seqan3::detail::simd_matrix_scoring_scheme::initialise_from_scalar_scoring_scheme
+    template <typename scoring_scheme_t>
     constexpr simd_matrix_scoring_scheme & operator=(scoring_scheme_t const & scoring_scheme)
     {
         initialise_from_scalar_scoring_scheme(scoring_scheme);
@@ -176,6 +174,10 @@ private:
      * \throws std::invalid_argument if the score of the given scoring scheme exceeds the score range covered by the
      *         selected simd vector type.
      */
+    template <typename scoring_scheme_t>
+    //!\cond
+        requires scoring_scheme_for<scoring_scheme_t, alphabet_t>
+    //!\endcond
     constexpr void initialise_from_scalar_scoring_scheme(scoring_scheme_t const & scoring_scheme)
     {
         using score_t = decltype(std::declval<scoring_scheme_t const &>().score(alphabet_t{}, alphabet_t{}));

--- a/include/seqan3/alignment/scoring/detail/simd_matrix_scoring_scheme.hpp
+++ b/include/seqan3/alignment/scoring/detail/simd_matrix_scoring_scheme.hpp
@@ -35,7 +35,21 @@ namespace seqan3::detail
  * \details
  *
  * When scoring two seqan3::detail::simd vectors, this performs element-wise lookups of the compared simd vectors
- * using the underlying scoring matrix and returns the result in another seqan3::detail::simd vector.
+ * using a [gather operation](https://en.wikipedia.org/wiki/Gather-scatter_(vector_addressing)) on the scoring scheme.
+ * The given scoring scheme is first transferred into linear memory such that a simple index gather can be used to
+ * retrieve the actual score.
+ * The index for the column vector of the alignment matrix must be precomputed using the
+ * seqan3::detail::simd_matrix_scoring_scheme::make_score_profile member function.
+ * This function computes the starting index of the respective matrix entry within the linearised
+ * scoring scheme. To improve the performance this is only done once per column inside of the alignment algorithm.
+ *
+ * This simd scoring scheme matrix only needs one padding symbol, whose rank is initialised with the size of the
+ * alphabet. Accordingly, the internal alphabet size increases by one.
+ * Depending on the selected algorithm method the corresponding score values are either set to `1` for the global
+ * alignment or `-1` for the local alignment. In the global alignment the score with a padding symbol will always
+ * increase, and the projected maximum will be rescaled with the number of matches added.
+ * In the local alignment the score with a padding symbol will always decrease, and the optimum can only be found inside
+ * of the valid score matrix area.
  *
  * \note Note that the alphabet type information is lost during the conversion to the simd vectors and
  * only the ranks of the alphabet are used.
@@ -48,6 +62,28 @@ template <simd_concept simd_score_t, semialphabet alphabet_t, typename alignment
 //!\endcond
 class simd_matrix_scoring_scheme
 {
+private:
+    //!\brief The underlying scalar type of the simd vector.
+    using scalar_type = typename simd_traits<simd_score_t>::scalar_type;
+    //!\brief The score profile type used for this scoring scheme, which is the same as the simd score type.
+    using simd_score_profile_type = simd_score_t;
+    //!\brief The type of the simd vector representing the alphabet ranks of one sequence batch.
+    using simd_alphabet_ranks_type = simd_score_t;
+
+    static_assert(seqan3::alphabet_size<alphabet_t> <= std::numeric_limits<scalar_type>::max(),
+                  "The selected simd scalar type is not large enough to represent the given alphabet including an "
+                  "additional padding symbol!");
+
+    //!\brief A flag that indicates wether the alignment mode is global.
+    static constexpr bool is_global = std::same_as<alignment_t, align_cfg::method_global>;
+    //!\brief The offset used to jump to the correct index in the linearised scoring scheme data.
+    static constexpr size_t index_offset = seqan3::alphabet_size<alphabet_t> + 1; // scheme is extended by one.
+    //!\brief The score used for the padding symbol (global -> increases score; local -> decreases score).
+    static constexpr scalar_type score_for_padding_symbol = (is_global) ? 1 : -1;
+
+    //!\brief The scoring scheme stored as a linear array.
+    std::vector<scalar_type> scoring_scheme_data{};
+
 public:
     /*!\name Constructors, destructor and assignment
      * \{
@@ -77,9 +113,9 @@ public:
      *\{
      */
     /*!\brief Given two simd vectors, compute an element-wise score and return another simd vector.
-     * \param[in] lhs The left operand to compare.
-     * \param[in] rhs The right operand to compare.
-     * \returns A simd vector of the same type as the input, with scores computed between both inputs.
+     * \param[in] score_profile The precomputed score profile.
+     * \param[in] ranks A simd vector over alphabet ranks.
+     * \returns A score simd vector computed based on the given score profile and alphabet ranks.
      *
      * ### Exception
      *
@@ -87,105 +123,98 @@ public:
      *
      * ### Complexity
      *
-     * Linear in the length of one input vector (`lhs` and `rhs` are equally sized).
+     * Linear in the length of one input vector (`score_profile` and `ranks` are equally sized).
      *
      * ### Thread safety
      *
      * Thread-safe.
+     *
+     * \attention You need to call seqan3::detail::simd_matrix_scoring_scheme::make_score_profile before invoking
+     *            the score interface to convert the column alphabet ranks into a column profile. Not doing this cannot
+     *            be detected by the program and can lead to wrong results.
      */
-    constexpr simd_score_t score(simd_score_t const & lhs, simd_score_t const & rhs) const noexcept
+    constexpr simd_score_t score(simd_score_profile_type const & score_profile,
+                                 simd_alphabet_ranks_type const & ranks) const noexcept
     {
+        simd_score_t const matrix_index = score_profile + ranks; // Compute the matrix indices for the lookup.
         simd_score_t result{};
 
-        for (size_t i = 0; i < simd_traits<simd_score_t>::length; ++i)
-        {
-            if (is_padded(lhs[i]) || is_padded(rhs[i]))
-            {
-                if constexpr (std::same_as<alignment_t, align_cfg::method_global>)
-                    result[i] = 1;
-                else
-                    result[i] = -1;
-            }
-            else
-            {
-                result[i] = internal_scoring_scheme.score(assign_rank_to(lhs[i], alphabet_t{}),
-                                                          assign_rank_to(rhs[i], alphabet_t{}));
-            }
-        }
+        for (size_t idx = 0; idx < simd_traits<simd_score_t>::length; ++idx)
+            result[idx] = scoring_scheme_data.data()[matrix_index[idx]];
 
         return result;
     }
     //!\}
 
-    //!\brief Returns the match score used for padded symbols.
-    constexpr typename scoring_scheme_t::score_type padding_match_score() noexcept
+    //!\brief Returns the score used when aligning a padding symbol.
+    constexpr scalar_type padding_match_score() const noexcept
     {
         return 1;
     }
 
-private:
-    //!\brief Internally stores the given scalar scoring scheme matrix.
-    scoring_scheme_t internal_scoring_scheme;
+    /*!\brief Converts the simd alphabet ranks into a score profile used for scoring it later with the alphabet ranks
+     *        of another sequence batch.
+     *
+     * \details
+     *
+     * In this implementation of the simd matrix gather operations are used to select the score values from the
+     * underlying scoring scheme. Since the scoring scheme matrix is represented as a linear vector, the corresponding
+     * indices are computed by the alphabet rank of one sequence batch times the alphabet size plus the alphabet rank
+     * of another sequence batch.
+     */
+    constexpr simd_score_profile_type make_score_profile(simd_alphabet_ranks_type const & ranks) const noexcept
+    {
+        return ranks * simd::fill<simd_score_t>(index_offset);
+    }
 
+private:
     /*!\brief Store the given scoring scheme matrix into a private member variable.
+     * \tparam scoring_scheme_t The type of the scoring scheme; must model seqan3::scoring_scheme_for the given
+     *                          alphabet type.
      * \param[in] scoring_scheme The scoring scheme to initialise the vectorised match and mismatch score with.
+     *
+     * \throws std::invalid_argument if the score of the given scoring scheme exceeds the score range covered by the
+     *         selected simd vector type.
      */
     constexpr void initialise_from_scalar_scoring_scheme(scoring_scheme_t const & scoring_scheme)
     {
         using score_t = decltype(std::declval<scoring_scheme_t const &>().score(alphabet_t{}, alphabet_t{}));
-        using simd_scalar_t = typename simd_traits<simd_score_t>::scalar_type;
 
-        // Check if the scoring scheme match and mismatch scores do not overflow with the respective scalar type.
-        if constexpr (sizeof(simd_scalar_t) < sizeof(score_t))
+        // Helper function to check if the matrix score is in the value range representable by the selected simd vector.
+        [[maybe_unused]] auto check_score_range = [&] ([[maybe_unused]] score_t score)
         {
-            if (min_or_max_exceeded<score_t, simd_scalar_t>(scoring_scheme))
-                throw std::invalid_argument{"The selected scoring scheme score overflows "
-                                            "for the selected scalar type of the simd type."};
-        }
-
-        internal_scoring_scheme = scoring_scheme;
-    }
-
-    /*!\brief Check if any score in the scoring scheme matrix exceeds the min or max value allowed by the simd vector.
-     * \param[in] scoring_scheme The scoring scheme to check for min or max violations.
-     * \tparam score_t The type of the scores in the scoring scheme matrix.
-     * \tparam simd_scalar_t The type of the simd vector.
-     * \returns Returns `true` if it encounters a value larger than the maximum or lower than the minimum allowed by
-     *          the simd vector, and `false` if otherwise.
-     */
-    template <typename score_t, typename simd_scalar_t>
-    constexpr bool min_or_max_exceeded(scoring_scheme_t const & scoring_scheme)
-    {
-        score_t max_val = static_cast<score_t>(std::numeric_limits<simd_scalar_t>::max());
-        score_t min_val = static_cast<score_t>(std::numeric_limits<simd_scalar_t>::lowest());
-
-        for (uint8_t i = 0; i < alphabet_size<alphabet_t>; ++i)
-        {
-            for (uint8_t j = 0; j < alphabet_size<alphabet_t>; ++j)
+            // Note only if the size of the scalar type of the simd vector is smaller than the size of the score type
+            // of the original scoring scheme, the score might exceed the valid value range of the scalar type. In this
+            // case an exception will be thrown.
+            if constexpr (sizeof(scalar_type) < sizeof(score_t))
             {
-                score_t tmp_score = scoring_scheme.score(assign_rank_to(i, alphabet_t{}),
-                                                         assign_rank_to(j, alphabet_t{}));
+                constexpr score_t max_score_value = static_cast<score_t>(std::numeric_limits<scalar_type>::max());
+                constexpr score_t min_score_value = static_cast<score_t>(std::numeric_limits<scalar_type>::lowest());
 
-                if (tmp_score > max_val || tmp_score < min_val)
-                    return true;
+                if (score > max_score_value || score < min_score_value)
+                    throw std::invalid_argument{"The selected scoring scheme score overflows "
+                                                "for the selected scalar type of the simd type."};
             }
+        };
+
+        // For the global alignment we extend the alphabet by one symbol to handle sequences with different size.
+        scoring_scheme_data.resize(index_offset * index_offset, score_for_padding_symbol);
+
+        // Convert the scoring matrix into a linear vector to allow gather operations later on.
+        using alphabet_size_t = std::remove_const_t<decltype(seqan3::alphabet_size<alphabet_t>)>;
+        auto data_it = scoring_scheme_data.begin();
+        for (alphabet_size_t lhs_rank = 0; lhs_rank < seqan3::alphabet_size<alphabet_t>; ++lhs_rank)
+        {
+            for (alphabet_size_t rhs_rank = 0; rhs_rank < seqan3::alphabet_size<alphabet_t>; ++rhs_rank, ++data_it)
+            {
+                score_t tmp_score = scoring_scheme.score(seqan3::assign_rank_to(lhs_rank, alphabet_t{}),
+                                                         seqan3::assign_rank_to(rhs_rank, alphabet_t{}));
+
+                check_score_range(tmp_score);
+                *data_it = tmp_score;
+            }
+            ++data_it; // skip one for the padded symbol.
         }
-
-        return false;
-    }
-
-    /*!\brief Checks whether the given value is a padded value or not.
-     * \param[in] value The value to check if it is padded.
-     * \returns Returns `true` if the value is padded and `false` otherwise.
-     *
-     * \details This check is done by casting the scalar type of the value into an unsigned value, and then checking
-     *          to see if this is larger than the alphabet size, which would imply that it is a padded value.
-     */
-    constexpr bool is_padded(typename simd_traits<simd_score_t>::scalar_type const & value) const
-    {
-        using unsigned_scalar_t = typename std::make_unsigned<typename simd_traits<simd_score_t>::scalar_type>::type;
-
-        return static_cast<unsigned_scalar_t>(value) >= alphabet_size<alphabet_t>;
     }
 };
 

--- a/test/unit/alignment/pairwise/fixture/global_affine_unbanded.hpp
+++ b/test/unit/alignment/pairwise/fixture/global_affine_unbanded.hpp
@@ -503,4 +503,138 @@ static auto aa27_blosum62_gap_1_open_10 = [] ()
     };
 }();
 
+static auto aa27_blosum62_gap_1_open_10_small = [] ()
+{
+    using seqan3::operator""_aa27;
+    return seqan3::test::alignment::fixture::alignment_fixture
+    {
+        "RKFCYMD"_aa27,
+        "GAYQW"_aa27,
+        align_config | config_blosum62_scheme,
+        -11,
+        "RKFCYMD",
+        "G--AYQW",
+        seqan3::alignment_coordinate{seqan3::detail::column_index_type{0u}, seqan3::detail::row_index_type{0u}},
+        seqan3::alignment_coordinate{seqan3::detail::column_index_type{7u}, seqan3::detail::row_index_type{5u}},
+        std::vector
+        {
+        //    e  ,R  ,K  ,F  ,C  ,Y  ,M  ,D  ,
+        /*e*/  0 ,-11,-12,-13,-14,-15,-16,-17,
+        /*G*/ -11,-2 ,-13,-14,-15,-16,-17,-17,
+        /*A*/ -12,-12,-3 ,-14,-14,-16,-17,-18,
+        /*Y*/ -13,-14,-14,0  ,-11,-7 ,-13,-14,
+        /*Q*/ -14,-12,-13,-11,-3 ,-12,-7 ,-13,
+        /*W*/ -15,-16,-15,-12,-13,-1 ,-12,-11
+        },
+        std::vector
+        {
+        //    e  ,R  ,K  ,F  ,C  ,Y  ,M  ,D  ,
+        /*e*/ N  ,L  ,l  ,l  ,l  ,l  ,l  ,l  ,
+        /*G*/ U  ,DUL,DUL,l  ,l  ,l  ,l  ,DUl,
+        /*A*/ u  ,DUL,DuL,L  ,Dul,l  ,Dul,l  ,
+        /*Y*/ u  ,DuL,DUl,DUL,L  ,DUl,l  ,l  ,
+        /*Q*/ u  ,DuL,DuL,Ul ,DUL,DUL,DUl,DUl,
+        /*W*/ u  ,uL ,Dul,DuL,DUL,Dul,L  ,DUl
+        }
+    };
+}();
+
+static auto aa27_blosum62_gap_1_open_10_empty_first = [] ()
+{
+    using seqan3::operator""_aa27;
+    return seqan3::test::alignment::fixture::alignment_fixture
+    {
+        "PPAMDYIRPW"_aa27,
+        ""_aa27,
+        align_config | config_blosum62_scheme,
+        -20,
+        "PPAMDYIRPW",
+        "----------",
+        seqan3::alignment_coordinate{seqan3::detail::column_index_type{0u}, seqan3::detail::row_index_type{0u}},
+        seqan3::alignment_coordinate{seqan3::detail::column_index_type{10u}, seqan3::detail::row_index_type{0u}},
+        std::vector
+        {
+        //    e  ,P  ,P  ,A  ,M  ,D  ,Y  ,I  ,R  ,P  ,W  ,
+        /*e*/ 0  ,-11,-12,-13,-14,-15,-16,-17,-18,-19,-20
+        },
+        std::vector
+        {
+        //    e,P,P,A,M,D,Y,I,R,P,W,
+        /*e*/ N,L,l,l,l,l,l,l,l,l,l
+        }
+    };
+}();
+
+static auto aa27_blosum62_gap_1_open_10_empty_second = [] ()
+{
+    using seqan3::operator""_aa27;
+    return seqan3::test::alignment::fixture::alignment_fixture
+    {
+        ""_aa27,
+        "PPAMDYIRPW"_aa27,
+        align_config | config_blosum62_scheme,
+        -20,
+        "----------",
+        "PPAMDYIRPW",
+        seqan3::alignment_coordinate{seqan3::detail::column_index_type{0u}, seqan3::detail::row_index_type{0u}},
+        seqan3::alignment_coordinate{seqan3::detail::column_index_type{0u}, seqan3::detail::row_index_type{10u}},
+        std::vector
+        {
+        //    e
+        /*e*/ 0  ,
+        /*P*/ -11,
+        /*P*/ -12,
+        /*A*/ -13,
+        /*M*/ -14,
+        /*D*/ -15,
+        /*Y*/ -16,
+        /*I*/ -17,
+        /*R*/ -18,
+        /*P*/ -19,
+        /*W*/ -20
+        },
+        std::vector
+        {
+        //    e
+        /*e*/ N,
+        /*P*/ U,
+        /*P*/ u,
+        /*A*/ u,
+        /*M*/ u,
+        /*D*/ u,
+        /*Y*/ u,
+        /*I*/ u,
+        /*R*/ u,
+        /*P*/ u,
+        /*W*/ u
+        }
+    };
+}();
+
+static auto aa27_blosum62_gap_1_open_10_empty_both = [] ()
+{
+    using seqan3::operator""_aa27;
+    return seqan3::test::alignment::fixture::alignment_fixture
+    {
+        ""_aa27,
+        ""_aa27,
+        align_config | config_blosum62_scheme,
+        0,
+        "",
+        "",
+        seqan3::alignment_coordinate{seqan3::detail::column_index_type{0u}, seqan3::detail::row_index_type{0u}},
+        seqan3::alignment_coordinate{seqan3::detail::column_index_type{0u}, seqan3::detail::row_index_type{0u}},
+        std::vector
+        {
+        //     e
+        /*e*/  0
+        },
+        std::vector
+        {
+        //    e
+        /*e*/ N
+        }
+    };
+}();
+
 } // namespace seqan3::test::alignment::fixture::global::affine::unbanded

--- a/test/unit/alignment/pairwise/global_affine_unbanded_aa27_test.cpp
+++ b/test/unit/alignment/pairwise/global_affine_unbanded_aa27_test.cpp
@@ -13,7 +13,11 @@
 #include "pairwise_alignment_single_test_template.hpp"
 
 using pairwise_global_affine_unbanded_testing_types = ::testing::Types<
-        pairwise_alignment_fixture<&seqan3::test::alignment::fixture::global::affine::unbanded::aa27_blosum62_gap_1_open_10>
+        pairwise_alignment_fixture<&seqan3::test::alignment::fixture::global::affine::unbanded::aa27_blosum62_gap_1_open_10>,
+        pairwise_alignment_fixture<&seqan3::test::alignment::fixture::global::affine::unbanded::aa27_blosum62_gap_1_open_10_small>,
+        pairwise_alignment_fixture<&seqan3::test::alignment::fixture::global::affine::unbanded::aa27_blosum62_gap_1_open_10_empty_first>,
+        pairwise_alignment_fixture<&seqan3::test::alignment::fixture::global::affine::unbanded::aa27_blosum62_gap_1_open_10_empty_second>,
+        pairwise_alignment_fixture<&seqan3::test::alignment::fixture::global::affine::unbanded::aa27_blosum62_gap_1_open_10_empty_both>
     >;
 
 INSTANTIATE_TYPED_TEST_SUITE_P(pairwise_global_affine_unbanded_aa27,

--- a/test/unit/alignment/pairwise/global_affine_unbanded_collection_simd_aa27_test.cpp
+++ b/test/unit/alignment/pairwise/global_affine_unbanded_collection_simd_aa27_test.cpp
@@ -28,10 +28,36 @@ static auto aa27_all_same = []()
 
     return alignment_fixture_collection{base_fixture.config | seqan3::align_cfg::vectorised{}, data};
 }();
+
+static auto aa27_different_lengths = []()
+{
+
+    auto base_fixture_01 = fixture::global::affine::unbanded::aa27_blosum62_gap_1_open_10;
+    auto base_fixture_02 = fixture::global::affine::unbanded::aa27_blosum62_gap_1_open_10_small;
+    auto base_fixture_03 = fixture::global::affine::unbanded::aa27_blosum62_gap_1_open_10_empty_first;
+    auto base_fixture_04 = fixture::global::affine::unbanded::aa27_blosum62_gap_1_open_10_empty_second;
+    auto base_fixture_05 = fixture::global::affine::unbanded::aa27_blosum62_gap_1_open_10_empty_both;
+
+    using fixture_t = decltype(base_fixture_01);
+
+    std::vector<fixture_t> data{};
+    for (size_t i = 0; i < 25; ++i)
+    {
+        data.push_back(base_fixture_01);
+        data.push_back(base_fixture_02);
+        data.push_back(base_fixture_03);
+        data.push_back(base_fixture_04);
+        data.push_back(base_fixture_05);
+    }
+
+    return alignment_fixture_collection{base_fixture_01.config | seqan3::align_cfg::vectorised{}, data};
+}();
+
 } // namespace seqan3::test::alignment::collection::simd::global::affine::unbanded
 
 using pairwise_collection_simd_global_affine_unbanded_testing_types = ::testing::Types<
-        pairwise_alignment_fixture<&seqan3::test::alignment::collection::simd::global::affine::unbanded::aa27_all_same>
+        pairwise_alignment_fixture<&seqan3::test::alignment::collection::simd::global::affine::unbanded::aa27_all_same>,
+        pairwise_alignment_fixture<&seqan3::test::alignment::collection::simd::global::affine::unbanded::aa27_different_lengths>
     >;
 
 INSTANTIATE_TYPED_TEST_SUITE_P(pairwise_collection_simd_global_affine_unbanded_aa27,

--- a/test/unit/alignment/scoring/simd_match_mismatch_scoring_scheme_test.cpp
+++ b/test/unit/alignment/scoring/simd_match_mismatch_scoring_scheme_test.cpp
@@ -46,6 +46,18 @@ TYPED_TEST(simd_match_mismatch_scoring_scheme_test, basic_construction)
     EXPECT_TRUE(std::semiregular<scheme_t>);
 }
 
+TYPED_TEST(simd_match_mismatch_scoring_scheme_test, make_score_profile)
+{
+    using scheme_t = seqan3::detail::simd_match_mismatch_scoring_scheme<TypeParam,
+                                                                        seqan3::dna4,
+                                                                        seqan3::align_cfg::method_global>;
+
+    scheme_t simd_scheme{seqan3::nucleotide_scoring_scheme{seqan3::match_score{4}, seqan3::mismatch_score{-5}}};
+
+    TypeParam original = seqan3::simd::fill<TypeParam>(2);
+    SIMD_EQ(simd_scheme.make_score_profile(original), original);
+}
+
 TYPED_TEST(simd_match_mismatch_scoring_scheme_test, construct_from_scoring_scheme_nothrow)
 {
     using scheme_t = seqan3::detail::simd_match_mismatch_scoring_scheme<TypeParam,

--- a/test/unit/alignment/scoring/simd_matrix_scoring_scheme_test.cpp
+++ b/test/unit/alignment/scoring/simd_matrix_scoring_scheme_test.cpp
@@ -24,8 +24,8 @@ struct simd_matrix_scoring_scheme_test : public ::testing::Test
     scalar_t padded_value2 = std::numeric_limits<scalar_t>::lowest() >> 1; // sets the bit before most significant bit.
 };
 
-using simd_test_types = ::testing::Types<//seqan3::simd::simd_type_t<int8_t>,
-                                         //seqan3::simd::simd_type_t<int16_t>,
+using simd_test_types = ::testing::Types<seqan3::simd::simd_type_t<int8_t>,
+                                         seqan3::simd::simd_type_t<int16_t>,
                                          seqan3::simd::simd_type_t<int32_t>>;
 
 TYPED_TEST_SUITE(simd_matrix_scoring_scheme_test, simd_test_types, );
@@ -34,8 +34,7 @@ TYPED_TEST(simd_matrix_scoring_scheme_test, basic_construction)
 {
     using scheme_t = seqan3::detail::simd_matrix_scoring_scheme<TypeParam,
                                                                 seqan3::aa27,
-                                                                seqan3::align_cfg::method_global,
-                                                                seqan3::aminoacid_scoring_scheme<>>;
+                                                                seqan3::align_cfg::method_global>;
 
     EXPECT_TRUE(std::is_nothrow_default_constructible_v<scheme_t>);
     EXPECT_TRUE(std::is_copy_constructible_v<scheme_t>);
@@ -51,8 +50,7 @@ TYPED_TEST(simd_matrix_scoring_scheme_test, make_score_profile)
 {
     using scheme_t = seqan3::detail::simd_matrix_scoring_scheme<TypeParam,
                                                                 seqan3::aa27,
-                                                                seqan3::align_cfg::method_global,
-                                                                seqan3::aminoacid_scoring_scheme<>>;
+                                                                seqan3::align_cfg::method_global>;
 
     scheme_t simd_scheme{seqan3::aminoacid_scoring_scheme{seqan3::aminoacid_similarity_matrix::BLOSUM30}};
 
@@ -65,8 +63,7 @@ TYPED_TEST(simd_matrix_scoring_scheme_test, construct_from_scoring_scheme_nothro
 {
     using scheme_t = seqan3::detail::simd_matrix_scoring_scheme<TypeParam,
                                                                 seqan3::aa27,
-                                                                seqan3::align_cfg::method_global,
-                                                                seqan3::aminoacid_scoring_scheme<>>;
+                                                                seqan3::align_cfg::method_global>;
 
     scheme_t simd_scheme{seqan3::aminoacid_scoring_scheme{seqan3::aminoacid_similarity_matrix::BLOSUM30}};
 
@@ -85,8 +82,7 @@ TYPED_TEST(simd_matrix_scoring_scheme_test, construct_from_scoring_scheme_throw_
     using scalar_t = typename seqan3::simd_traits<TypeParam>::scalar_type;
     using scheme_t = seqan3::detail::simd_matrix_scoring_scheme<TypeParam,
                                                                 seqan3::aa27,
-                                                                seqan3::align_cfg::method_global,
-                                                                seqan3::aminoacid_scoring_scheme<int64_t>>;
+                                                                seqan3::align_cfg::method_global>;
 
     int64_t too_big = static_cast<int64_t>(std::numeric_limits<scalar_t>::max()) + 1;
     int64_t too_small = static_cast<int64_t>(std::numeric_limits<scalar_t>::lowest()) - 1;
@@ -115,8 +111,7 @@ TYPED_TEST(simd_matrix_scoring_scheme_test, score_global)
 {
     using scheme_t = seqan3::detail::simd_matrix_scoring_scheme<TypeParam,
                                                                 seqan3::aa27,
-                                                                seqan3::align_cfg::method_global,
-                                                                seqan3::aminoacid_scoring_scheme<>>;
+                                                                seqan3::align_cfg::method_global>;
 
     scheme_t scheme{seqan3::aminoacid_scoring_scheme{seqan3::aminoacid_similarity_matrix::BLOSUM30}};
 
@@ -148,8 +143,7 @@ TYPED_TEST(simd_matrix_scoring_scheme_test, score_global_with_padding)
 {
     using scheme_t = seqan3::detail::simd_matrix_scoring_scheme<TypeParam,
                                                                 seqan3::aa27,
-                                                                seqan3::align_cfg::method_global,
-                                                                seqan3::aminoacid_scoring_scheme<>>;
+                                                                seqan3::align_cfg::method_global>;
 
     scheme_t scheme{seqan3::aminoacid_scoring_scheme{seqan3::aminoacid_similarity_matrix::BLOSUM30}};
 
@@ -180,8 +174,7 @@ TYPED_TEST(simd_matrix_scoring_scheme_test, score_local)
     // In local alignment we always want to mismatch.
     using scheme_t = seqan3::detail::simd_matrix_scoring_scheme<TypeParam,
                                                                 seqan3::aa27,
-                                                                seqan3::align_cfg::method_local,
-                                                                seqan3::aminoacid_scoring_scheme<>>;
+                                                                seqan3::align_cfg::method_local>;
 
     scheme_t scheme{seqan3::aminoacid_scoring_scheme{seqan3::aminoacid_similarity_matrix::BLOSUM30}};
 
@@ -214,8 +207,7 @@ TYPED_TEST(simd_matrix_scoring_scheme_test, score_local_with_padding)
     // In local alignment we always want to mismatch.
     using scheme_t = seqan3::detail::simd_matrix_scoring_scheme<TypeParam,
                                                                 seqan3::aa27,
-                                                                seqan3::align_cfg::method_local,
-                                                                seqan3::aminoacid_scoring_scheme<>>;
+                                                                seqan3::align_cfg::method_local>;
 
     scheme_t scheme{seqan3::aminoacid_scoring_scheme{seqan3::aminoacid_similarity_matrix::BLOSUM30}};
 


### PR DESCRIPTION
Enables gather based amino acid scoring scheme for faster vectorised alignments using amino acids.
The current implementation uses unoptimised gather and works well for sse4. 
The specific instructions for avx2 and avx512 need to be extended as well. 
Also the current solution is not stable for 8-bit scores.
Here is an initial benchmark for sse4:

```
--------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                Time             CPU   Iterations UserCounters...
--------------------------------------------------------------------------------------------------------------------------
// SeqAn3 current
seqan3_affine_accelerated/simd_with_score/0/real_time             22836870 ns     22687323 ns           31 CUPS=1022.39M/s cells=23.3482M total=-3.19874M
seqan3_affine_accelerated/simd_with_score/8/real_time             25640430 ns     25340680 ns           25 CUPS=907.8M/s cells=23.2764M total=-2.57653M
seqan3_affine_accelerated/simd_with_score/16/real_time            27565517 ns     27391440 ns           25 CUPS=842.062M/s cells=23.2119M total=-2.58685M
seqan3_affine_accelerated/simd_with_score/24/real_time            29793213 ns     29599292 ns           24 CUPS=776.824M/s cells=23.1441M total=-2.499M
seqan3_affine_accelerated/simd_with_score/32/real_time            31894229 ns     31670455 ns           22 CUPS=723.753M/s cells=23.0835M total=-2.31768M
seqan3_affine_accelerated/simd_with_score/40/real_time            34392811 ns     34091476 ns           21 CUPS=669.226M/s cells=23.0166M total=-2.23807M
seqan3_affine_accelerated/simd_with_score/48/real_time            36043692 ns     35808750 ns           20 CUPS=636.875M/s cells=22.9553M total=-2.15584M
seqan3_affine_accelerated/simd_with_score/56/real_time            37993100 ns     37760333 ns           18 CUPS=602.554M/s cells=22.8929M total=-1.97105M
seqan3_affine_accelerated/simd_with_score/64/real_time            40269473 ns     39947882 ns           17 CUPS=566.918M/s cells=22.8295M total=-1.8898M

// SeqAn3 new
seqan3_affine_accelerated/simd_with_score/0/real_time             18041207 ns     17946128 ns           39 CUPS=1.29416G/s cells=23.3482M total=-4.02421M
seqan3_affine_accelerated/simd_with_score/8/real_time             17044260 ns     16947024 ns           42 CUPS=1.36564G/s cells=23.2764M total=-4.32856M
seqan3_affine_accelerated/simd_with_score/16/real_time            18251074 ns     18156421 ns           38 CUPS=1.27181G/s cells=23.2119M total=-3.93201M
seqan3_affine_accelerated/simd_with_score/24/real_time            22867803 ns     22733677 ns           31 CUPS=1012.08M/s cells=23.1441M total=-3.22788M
seqan3_affine_accelerated/simd_with_score/32/real_time            24747823 ns     24579750 ns           28 CUPS=932.75M/s cells=23.0835M total=-2.94977M
seqan3_affine_accelerated/simd_with_score/40/real_time            26537992 ns     26381481 ns           27 CUPS=867.306M/s cells=23.0166M total=-2.87752M
seqan3_affine_accelerated/simd_with_score/48/real_time            24523143 ns     24336172 ns           29 CUPS=936.068M/s cells=22.9553M total=-3.12597M
seqan3_affine_accelerated/simd_with_score/56/real_time            25683794 ns     25538440 ns           25 CUPS=891.336M/s cells=22.8929M total=-2.73757M
seqan3_affine_accelerated/simd_with_score/64/real_time            27103291 ns     26968520 ns           25 CUPS=842.314M/s cells=22.8295M total=-2.77913M

// SeqAn 2
seqan2_affine_accelerated/simd_with_score/0/real_time             15146541 ns     15034065 ns           46 CUPS=1.54149G/s cells=23.3482M total=-4.73763M
seqan2_affine_accelerated/simd_with_score/8/real_time             23655168 ns     23445000 ns           30 CUPS=983.987M/s cells=23.2764M total=-3.08964M
seqan2_affine_accelerated/simd_with_score/16/real_time            26666394 ns     26191464 ns           28 CUPS=870.454M/s cells=23.2119M total=-2.89534M
seqan2_affine_accelerated/simd_with_score/24/real_time            27193327 ns     27082400 ns           25 CUPS=851.094M/s cells=23.1441M total=-2.59895M
seqan2_affine_accelerated/simd_with_score/32/real_time            29160092 ns     29039625 ns           24 CUPS=791.614M/s cells=23.0835M total=-2.52245M
seqan2_affine_accelerated/simd_with_score/40/real_time            31102820 ns     30865182 ns           22 CUPS=740.015M/s cells=23.0166M total=-2.33592M
seqan2_affine_accelerated/simd_with_score/48/real_time            34514153 ns     33976650 ns           20 CUPS=665.099M/s cells=22.9553M total=-2.15138M
seqan2_affine_accelerated/simd_with_score/56/real_time            36198992 ns     35936895 ns           19 CUPS=632.418M/s cells=22.8929M total=-2.07809M
seqan2_affine_accelerated/simd_with_score/64/real_time            39219167 ns     38371167 ns           18 CUPS=582.1M/s cells=22.8295M total=-1.99917M
```

Part of seqan/product_backlog#209