### PR TITLE
[MISC] Increase search coverage to 100%

### DIFF
--- a/test/unit/search/search_test.cpp
+++ b/test/unit/search/search_test.cpp
@@ -277,6 +277,11 @@ TYPED_TEST(search_test, error_levenshtein)
         EXPECT_RANGE_EQ(search("CCGT"_dna4, this->index, cfg) | position,
                         (std::vector{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}));
     }
+    {
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error_total{seqan3::search_cfg::error_count{4}};
+        EXPECT_RANGE_EQ(search("CCGT"_dna4, this->index, cfg) | position,
+                        (std::vector{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}));
+    }
 }
 
 TYPED_TEST(search_test, error_indel_no_substitution)
@@ -407,6 +412,16 @@ TYPED_TEST(search_test, search_strategy_best)
         std::vector result = search("AGTAGT"_dna4, this->index, cfg) | position | seqan3::views::to<std::vector>;
         ASSERT_EQ(result.size(), 1u);
         EXPECT_TRUE(std::find(possible_hits2d.begin(), possible_hits2d.end(), result[0]) != possible_hits2d.end());
+    }
+
+    {  // Find best match with at most 2 of every error type.
+        seqan3::configuration const cfg = seqan3::search_cfg::max_error_deletion{seqan3::search_cfg::error_count{2}} |
+                                          seqan3::search_cfg::max_error_insertion{seqan3::search_cfg::error_count{2}} |
+                                          seqan3::search_cfg::max_error_substitution{
+                                              seqan3::search_cfg::error_count{2}} |
+                                          seqan3::search_cfg::hit_single_best;
+
+        EXPECT_RANGE_EQ(search("TATTA"_dna4, this->index, cfg) | position, (std::vector{3}));
     }
 }
 


### PR DESCRIPTION
We have some branches in the search algorithm that are never tested...

This adds two tests that cover the last few lines - after this, the search module has 100% coverage (and currently would be the only one to achieve this....).

One test just uses 4 errors instead of 3. This activates all the cases where a dynamic search scheme is used (up to and including 3 errors we know the optimal search scheme at compile time, i.e. we never use dynamic search schemes for errors <= 3).

Another one adds a test that covers two `if`s very deep inside the algorithm that handle a case where you do deletions at the end of the block after having done substitutions/insertions; I just enumerated over all error type counts from 1 to 5 and over all queries of length 5 and took one that hit the lines.