### PR TITLE
[MISC] Update search_cfg::max_error_substitution to recent config design changes.

### DIFF
--- a/include/seqan3/search/configuration/max_error.hpp
+++ b/include/seqan3/search/configuration/max_error.hpp
@@ -52,7 +52,7 @@ public:
  */
 struct max_error_substitution : public pipeable_config_element<max_error_substitution>
 {
-    //!\brief  The number of substitution errors allowed for the search.
+    //!\brief The error count or error rate.
     std::variant<error_count, error_rate> error{error_count{0}};
 
     /*!\name Constructors, destructor and assignment
@@ -66,13 +66,13 @@ struct max_error_substitution : public pipeable_config_element<max_error_substit
     ~max_error_substitution() = default; //!< Defaulted.
 
     /*!\brief Initialises the substitution error with the given seqan3::search_cfg::error_count.
-     * \param[in] error The error count used for the search.
+     * \param[in] error The maximal number of substitution errors allowed in the search.
      */
     explicit max_error_substitution(error_count error) : error{std::move(error)}
     {}
 
     /*!\brief Initialises the substitution error with the given seqan3::search_cfg::error_rate.
-     * \param[in] error The error rate used for the search.
+     * \param[in] error The maximal error rate for substitutions allowed in the search.
      */
     explicit max_error_substitution(error_rate error) : error{std::move(error)}
     {}

--- a/include/seqan3/search/configuration/max_error.hpp
+++ b/include/seqan3/search/configuration/max_error.hpp
@@ -50,11 +50,34 @@ public:
  * ### Example
  * \include test/snippet/search/configuration_error.cpp
  */
-class max_error_substitution : public pipeable_config_element<max_error_substitution,
-                                                              std::variant<error_count,
-                                                              error_rate>>
+struct max_error_substitution : public pipeable_config_element<max_error_substitution>
 {
-public:
+    //!\brief  The number of substitution errors allowed for the search.
+    std::variant<error_count, error_rate> error{error_count{0}};
+
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    max_error_substitution() = default; //!< Defaulted.
+    max_error_substitution(max_error_substitution const &) = default; //!< Defaulted.
+    max_error_substitution(max_error_substitution &&) = default; //!< Defaulted.
+    max_error_substitution & operator=(max_error_substitution const &) = default; //!< Defaulted.
+    max_error_substitution & operator=(max_error_substitution &&) = default; //!< Defaulted.
+    ~max_error_substitution() = default; //!< Defaulted.
+
+    /*!\brief Initialises the substitution error with the given seqan3::search_cfg::error_count.
+     * \param[in] error The error count used for the search.
+     */
+    explicit max_error_substitution(error_count error) : error{std::move(error)}
+    {}
+
+    /*!\brief Initialises the substitution error with the given seqan3::search_cfg::error_rate.
+     * \param[in] error The error rate used for the search.
+     */
+    explicit max_error_substitution(error_rate error) : error{std::move(error)}
+    {}
+    //!\}
+
     //!\privatesection
     //!\brief Internal id to check for consistent configuration settings.
     static constexpr detail::search_config_id id{detail::search_config_id::max_error_substitution};

--- a/include/seqan3/search/detail/policy_max_error.hpp
+++ b/include/seqan3/search/detail/policy_max_error.hpp
@@ -92,7 +92,7 @@ protected:
         [[maybe_unused]] auto query_size = std::ranges::size(query);
 
         errors.total = to_error_count(total.value, query_size);
-        errors.substitution = to_error_count(substitution.value, query_size);
+        errors.substitution = to_error_count(substitution.error, query_size);
         errors.insertion = to_error_count(insertion.value, query_size);
         errors.deletion = to_error_count(deletion.value, query_size);
 

--- a/test/unit/search/search_configuration_test.cpp
+++ b/test/unit/search/search_configuration_test.cpp
@@ -79,8 +79,8 @@ TEST(search_configuration_test, max_error_defaults)
     EXPECT_EQ((seqan3::search_cfg::max_error_total{}.value),
               (seqan3::search_cfg::max_error_total{seqan3::search_cfg::error_count{0}}.value));
 
-    EXPECT_EQ((seqan3::search_cfg::max_error_substitution{}.value),
-              (seqan3::search_cfg::max_error_substitution{seqan3::search_cfg::error_count{0}}.value));
+    EXPECT_EQ((seqan3::search_cfg::max_error_substitution{}.error),
+              (seqan3::search_cfg::max_error_substitution{seqan3::search_cfg::error_count{0}}.error));
 
     EXPECT_EQ((seqan3::search_cfg::max_error_insertion{}.value),
               (seqan3::search_cfg::max_error_insertion{seqan3::search_cfg::error_count{0}}.value));
@@ -92,8 +92,8 @@ TEST(search_configuration_test, max_error_defaults)
     EXPECT_EQ((seqan3::search_cfg::max_error_total{seqan3::search_cfg::error_count{}}.value),
               (seqan3::search_cfg::max_error_total{seqan3::search_cfg::error_count{0}}.value));
 
-    EXPECT_EQ((seqan3::search_cfg::max_error_substitution{seqan3::search_cfg::error_count{}}.value),
-              (seqan3::search_cfg::max_error_substitution{seqan3::search_cfg::error_count{0}}.value));
+    EXPECT_EQ((seqan3::search_cfg::max_error_substitution{seqan3::search_cfg::error_count{}}.error),
+              (seqan3::search_cfg::max_error_substitution{seqan3::search_cfg::error_count{0}}.error));
 
     EXPECT_EQ((seqan3::search_cfg::max_error_insertion{seqan3::search_cfg::error_count{}}.value),
               (seqan3::search_cfg::max_error_insertion{seqan3::search_cfg::error_count{0}}.value));
@@ -105,8 +105,8 @@ TEST(search_configuration_test, max_error_defaults)
     EXPECT_EQ((seqan3::search_cfg::max_error_total{seqan3::search_cfg::error_rate{}}.value),
               (seqan3::search_cfg::max_error_total{seqan3::search_cfg::error_rate{0}}.value));
 
-    EXPECT_EQ((seqan3::search_cfg::max_error_substitution{seqan3::search_cfg::error_rate{}}.value),
-              (seqan3::search_cfg::max_error_substitution{seqan3::search_cfg::error_rate{0}}.value));
+    EXPECT_EQ((seqan3::search_cfg::max_error_substitution{seqan3::search_cfg::error_rate{}}.error),
+              (seqan3::search_cfg::max_error_substitution{seqan3::search_cfg::error_rate{0}}.error));
 
     EXPECT_EQ((seqan3::search_cfg::max_error_insertion{seqan3::search_cfg::error_rate{}}.value),
               (seqan3::search_cfg::max_error_insertion{seqan3::search_cfg::error_rate{0}}.value));


### PR DESCRIPTION
part of seqan/product_backlog#217 