### PR TITLE
two_dimensional_matrix::basic_iterator<bool>

### DIFF
--- a/include/seqan3/alignment/matrix/detail/two_dimensional_matrix.hpp
+++ b/include/seqan3/alignment/matrix/detail/two_dimensional_matrix.hpp
@@ -72,7 +72,7 @@ private:
 
     // Forward declaration. For definition see below.
     template <typename matrix_t>
-    class iterator_type;
+    class basic_iterator;
 
 public:
 
@@ -86,8 +86,8 @@ public:
     using const_pointer = typename storage_type::const_pointer;  //!< The pointer type.
     using difference_type = typename storage_type::difference_type; //!< The difference type.
     using size_type = typename storage_type::size_type;  //!< The difference type.
-    using iterator = iterator_type<two_dimensional_matrix>; //!< The iterator type.
-    using const_iterator = iterator_type<two_dimensional_matrix const>; //!< The const iterator type.
+    using iterator = basic_iterator<two_dimensional_matrix>; //!< The iterator type.
+    using const_iterator = basic_iterator<two_dimensional_matrix const>; //!< The const iterator type.
     //!\}
 
     /*!\name Constructors, destructor and assignment
@@ -322,17 +322,17 @@ private:
  */
 template <typename value_t, typename allocator_t, matrix_major_order order>
 template <typename matrix_t>
-class two_dimensional_matrix<value_t, allocator_t, order>::iterator_type :
-    public two_dimensional_matrix_iterator_base<iterator_type<matrix_t>, order>
+class two_dimensional_matrix<value_t, allocator_t, order>::basic_iterator :
+    public two_dimensional_matrix_iterator_base<basic_iterator<matrix_t>, order>
 {
 private:
     //!\brief The base class type.
-    using base_t = two_dimensional_matrix_iterator_base<iterator_type<matrix_t>, order>;
+    using base_t = two_dimensional_matrix_iterator_base<basic_iterator<matrix_t>, order>;
 
     //!\brief Befriend the base crtp class.
     template <typename derived_t, matrix_major_order other_order>
     //!\cond
-        requires is_type_specialisation_of_v<derived_t, iterator_type> && (other_order == order)
+        requires is_type_specialisation_of_v<derived_t, basic_iterator> && (other_order == order)
     //!\endcond
     friend class two_dimensional_matrix_iterator_base;
 
@@ -340,7 +340,7 @@ private:
     template <typename other_matrix_t>
         requires std::same_as<other_matrix_t, std::remove_const_t<matrix_t>> &&
                     std::is_const_v<matrix_t>
-    friend class iterator_type;
+    friend class basic_iterator;
 
     //!\brief The iterator of the underlying storage.
     using storage_iterator = std::ranges::iterator_t<
@@ -369,18 +369,18 @@ public:
     /*!\name Constructors, destructor and assignment
     * \{
     */
-    constexpr iterator_type() = default; //!< Defaulted.
-    constexpr iterator_type(iterator_type const &) = default; //!< Defaulted.
-    constexpr iterator_type(iterator_type &&) = default; //!< Defaulted.
-    constexpr iterator_type & operator=(iterator_type const &) = default; //!< Defaulted.
-    constexpr iterator_type & operator=(iterator_type &&) = default; //!< Defaulted.
-    ~iterator_type() = default; //!< Defaulted.
+    constexpr basic_iterator() = default; //!< Defaulted.
+    constexpr basic_iterator(basic_iterator const &) = default; //!< Defaulted.
+    constexpr basic_iterator(basic_iterator &&) = default; //!< Defaulted.
+    constexpr basic_iterator & operator=(basic_iterator const &) = default; //!< Defaulted.
+    constexpr basic_iterator & operator=(basic_iterator &&) = default; //!< Defaulted.
+    ~basic_iterator() = default; //!< Defaulted.
 
     /*!\brief Construction from the underlying matrix and the iterator over actual storage.
     * \param[in] matrix The underlying matrix to access the corresponding dimensions.
     * \param[in] iter   The underlying iterator over the actual storage; must model std::random_access_iterator.
     */
-    constexpr iterator_type(matrix_t & matrix, storage_iterator iter) :
+    constexpr basic_iterator(matrix_t & matrix, storage_iterator iter) :
         matrix_ptr{&matrix},
         host_iter{iter}
     {}
@@ -390,8 +390,8 @@ public:
     //!\cond
         requires std::same_as<other_matrix_t, std::remove_const_t<matrix_t>> && std::is_const_v<matrix_t>
     //!\endcond
-    constexpr iterator_type(
-        iterator_type<other_matrix_t> other) noexcept :
+    constexpr basic_iterator(
+        basic_iterator<other_matrix_t> other) noexcept :
         matrix_ptr{other.matrix_ptr},
         host_iter{other.host_iter}
     {}
@@ -401,7 +401,7 @@ public:
     using base_t::operator+=;
 
     //!\brief Advances the iterator by the given `offset`.
-    constexpr iterator_type & operator+=(matrix_offset const & offset) noexcept
+    constexpr basic_iterator & operator+=(matrix_offset const & offset) noexcept
     {
         assert(matrix_ptr != nullptr);
 

--- a/include/seqan3/alignment/matrix/detail/two_dimensional_matrix.hpp
+++ b/include/seqan3/alignment/matrix/detail/two_dimensional_matrix.hpp
@@ -18,6 +18,7 @@
 #include <seqan3/alignment/matrix/detail/matrix_coordinate.hpp>
 #include <seqan3/alignment/matrix/detail/two_dimensional_matrix_iterator_base.hpp>
 #include <seqan3/core/type_traits/deferred_crtp_base.hpp>
+#include <seqan3/core/type_traits/range.hpp>
 #include <seqan3/core/type_traits/template_inspection.hpp>
 #include <seqan3/std/algorithm>
 #include <seqan3/std/ranges>
@@ -71,7 +72,7 @@ private:
     //!\}
 
     // Forward declaration. For definition see below.
-    template <typename matrix_t>
+    template <bool const_range>
     class basic_iterator;
 
 public:
@@ -86,8 +87,8 @@ public:
     using const_pointer = typename storage_type::const_pointer;  //!< The pointer type.
     using difference_type = typename storage_type::difference_type; //!< The difference type.
     using size_type = typename storage_type::size_type;  //!< The difference type.
-    using iterator = basic_iterator<two_dimensional_matrix>; //!< The iterator type.
-    using const_iterator = basic_iterator<two_dimensional_matrix const>; //!< The const iterator type.
+    using iterator = basic_iterator<false>; //!< The iterator type.
+    using const_iterator = basic_iterator<true>; //!< The const iterator type.
     //!\}
 
     /*!\name Constructors, destructor and assignment
@@ -321,13 +322,16 @@ private:
  * data in a flattened one-dimensional vector.
  */
 template <typename value_t, typename allocator_t, matrix_major_order order>
-template <typename matrix_t>
+template <bool const_range>
 class two_dimensional_matrix<value_t, allocator_t, order>::basic_iterator :
-    public two_dimensional_matrix_iterator_base<basic_iterator<matrix_t>, order>
+    public two_dimensional_matrix_iterator_base<basic_iterator<const_range>, order>
 {
 private:
+    //!\brief Type of the parent range.
+    using parent_t = detail::maybe_const_range_t<const_range, two_dimensional_matrix>;
+
     //!\brief The base class type.
-    using base_t = two_dimensional_matrix_iterator_base<basic_iterator<matrix_t>, order>;
+    using base_t = two_dimensional_matrix_iterator_base<basic_iterator, order>;
 
     //!\brief Befriend the base crtp class.
     template <typename derived_t, matrix_major_order other_order>
@@ -337,17 +341,11 @@ private:
     friend class two_dimensional_matrix_iterator_base;
 
     //!\brief Befriend the corresponding const iterator.
-    template <typename other_matrix_t>
-        requires std::same_as<other_matrix_t, std::remove_const_t<matrix_t>> &&
-                    std::is_const_v<matrix_t>
+    template <bool other_const_range>
     friend class basic_iterator;
 
     //!\brief The iterator of the underlying storage.
-    using storage_iterator = std::ranges::iterator_t<
-                                std::conditional_t<
-                                    std::is_const_v<matrix_t>, storage_type const, storage_type
-                                >
-                            >;
+    using storage_iterator = detail::maybe_const_iterator_t<const_range, storage_type>;
 
 public:
 
@@ -380,20 +378,18 @@ public:
     * \param[in] matrix The underlying matrix to access the corresponding dimensions.
     * \param[in] iter   The underlying iterator over the actual storage; must model std::random_access_iterator.
     */
-    constexpr basic_iterator(matrix_t & matrix, storage_iterator iter) :
+    constexpr basic_iterator(parent_t & matrix, storage_iterator iter) :
         matrix_ptr{&matrix},
         host_iter{iter}
     {}
 
     //!\brief Construction of cons-iterator from non-const-iterator.
-    template <typename other_matrix_t>
+    constexpr basic_iterator(basic_iterator<!const_range> const & other) noexcept
     //!\cond
-        requires std::same_as<other_matrix_t, std::remove_const_t<matrix_t>> && std::is_const_v<matrix_t>
+        requires const_range
     //!\endcond
-    constexpr basic_iterator(
-        basic_iterator<other_matrix_t> other) noexcept :
-        matrix_ptr{other.matrix_ptr},
-        host_iter{other.host_iter}
+        : matrix_ptr{other.matrix_ptr},
+          host_iter{other.host_iter}
     {}
     //!\}
 
@@ -432,7 +428,7 @@ public:
 
 private:
 
-    matrix_t * matrix_ptr{nullptr};  //!< Points to the associated matrix.
+    parent_t * matrix_ptr{nullptr}; //!< Points to the associated matrix.
     storage_iterator host_iter{}; //!< The underlying storage iterator.
 };
 


### PR DESCRIPTION
1. Commit renames `two_dimensional_matrix::{iterator_type->basic_iterator}<matrix_t>` (partially solves https://github.com/seqan/product_backlog/issues/144)
2. Commit changes `renames `two_dimensional_matrix::basic_iterator<{matrix_t->bool}>`` (partially solves https://github.com/seqan/product_backlog/issues/168)

