### PR TITLE
[FIX] Throw missing subcommand argument on parse() and adapt misleading tutorial.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,14 @@ If possible, provide tooling that performs the changes, e.g. a shell-script.
 
 * The `seqan3::fm_index_cursor` exposes its suffix array interval ([\#2076](https://github.com/seqan/seqan3/pull/2076)).
 
+## Notable Bug-fixes
+
+### Argument Parser
+
+* Argument parsing with subcommands: If the user forgets or misspells the subcommand, the error is thrown when calling
+  `seqan3::argument_parser::parse()` and not on construction of the `seqan3::argument_parser`
+  ([\#2179](https://github.com/seqan/seqan3/pull/2179)).
+
 # 3.0.2
 
 Note that 3.1.0 will be the first API stable release and interfaces in this release might still change.

--- a/doc/howto/subcommand_argument_parser/subcommand_arg_parse.cpp
+++ b/doc/howto/subcommand_argument_parser/subcommand_arg_parse.cpp
@@ -77,8 +77,7 @@ int main(int argc, char const ** argv)
     seqan3::argument_parser top_level_parser{"mygit", argc, argv, true, {"push", "pull"}};
     //![construction]
 
-    // Add information and flags to your top-level parser just as you would do with a normal one.
-    // Note that all flags directed at the top-level parser must be specified BEFORE the subcommand key word.
+    // Add information and flags, but no (positional) options to your top-level parser.
     // Because of ambiguity, we do not allow any (positional) options for the top-level parser.
     top_level_parser.info.description.push_back("You can push or pull from a remote repository.");
     bool flag{false};
@@ -101,9 +100,12 @@ int main(int argc, char const ** argv)
     std::cout << "Proceed to sub parser.\n";
 
     if (sub_parser.info.app_name == std::string_view{"mygit-pull"})
-        run_git_pull(sub_parser);
+        return run_git_pull(sub_parser);
     else if (sub_parser.info.app_name == std::string_view{"mygit-push"})
-        run_git_push(sub_parser);
+        return run_git_push(sub_parser);
     else
-        throw std::logic_error{"I do not know sub parser " + sub_parser.info.app_name};
+        std::cout << "Unhandled subparser named " << sub_parser.info.app_name << '\n';
+        // Note: Arriving in this else branch means you did not handle all sub_parsers in the if branches above.
+
+    return 0;
 }

--- a/include/seqan3/argument_parser/argument_parser.hpp
+++ b/include/seqan3/argument_parser/argument_parser.hpp
@@ -186,8 +186,9 @@ public:
         version_check_dev_decision{version_check}
     {
         if (!std::regex_match(app_name, app_name_regex))
-            throw design_error{"The application name must only contain alpha-numeric characters "
-                                               "or '_' and '-' (regex: \"^[a-zA-Z0-9_-]+$\")."};
+            throw design_error{"The application name must only contain alpha-numeric characters or '_' and '-' "
+                               "(regex: \"^[a-zA-Z0-9_-]+$\")."};
+
         for (auto & sub : subcommands)
             if (!std::regex_match(sub, std::regex{"^[a-zA-Z0-9_]+$"}))
                 throw design_error{"The subcommand name must only contain alpha-numeric characters or '_'."};
@@ -409,8 +410,7 @@ public:
     {
         if (sub_parser == nullptr)
         {
-            throw design_error("You did not enable subcommand parsing on construction "
-                                      "so you cannot access the sub-parser!");
+            throw design_error("No subcommand was provided at the construction of the argument parser!");
         }
 
         return *sub_parser;
@@ -600,7 +600,8 @@ private:
 
         bool special_format_was_set{false};
 
-        for(int i = 1, argv_len = argc; i < argv_len; ++i) // start at 1 to skip binary name
+
+        for (int i = 1, argv_len = argc; i < argv_len; ++i) // start at 1 to skip binary name
         {
             std::string arg{argv[i]};
 
@@ -609,6 +610,7 @@ private:
                 sub_parser = std::make_unique<argument_parser>(info.app_name + "-" + arg, argc - i, argv + i, false);
                 break;
             }
+
             if (arg == "-h" || arg == "--help")
             {
                 format = detail::format_help{subcommands, false};

--- a/include/seqan3/argument_parser/argument_parser.hpp
+++ b/include/seqan3/argument_parser/argument_parser.hpp
@@ -183,18 +183,20 @@ public:
                     char const * const * const  argv,
                     bool version_check = true,
                     std::vector<std::string> subcommands = {}) :
-        version_check_dev_decision{version_check}
+        version_check_dev_decision{version_check},
+        subcommands{std::move(subcommands)}
     {
         if (!std::regex_match(app_name, app_name_regex))
             throw design_error{"The application name must only contain alpha-numeric characters or '_' and '-' "
                                "(regex: \"^[a-zA-Z0-9_-]+$\")."};
 
-        for (auto & sub : subcommands)
+        for (auto & sub : this->subcommands)
             if (!std::regex_match(sub, std::regex{"^[a-zA-Z0-9_]+$"}))
                 throw design_error{"The subcommand name must only contain alpha-numeric characters or '_'."};
 
         info.app_name = std::move(app_name);
-        init(argc, argv, std::move(subcommands));
+
+        init(argc, argv);
     }
 
     //!\brief The destructor.
@@ -392,6 +394,13 @@ public:
 
         detail::version_checker app_version{info.app_name, info.version, info.url};
 
+        if (std::holds_alternative<detail::format_parse>(format) && !subcommands.empty() && sub_parser == nullptr)
+        {
+            throw too_few_arguments{detail::to_string("You either forgot or misspelled the subcommand! Please specify"
+                                                      " which sub-program you want to use: one of ", subcommands,
+                                                      ". Use -h/--help for more information.")};
+        }
+
         if (app_version.decide_if_check_is_performed(version_check_dev_decision, version_check_user_decision))
         {
             // must be done before calling parse on the format because this might std::exit
@@ -554,11 +563,13 @@ private:
     //!\brief Stores the sub-parser in case \link subcommand_arg_parse subcommand parsing \endlink is enabled.
     std::unique_ptr<argument_parser> sub_parser{nullptr};
 
+    //!\brief Stores the sub-parser names in case \link subcommand_arg_parse subcommand parsing \endlink is enabled.
+    std::vector<std::string> subcommands{};
+
     /*!\brief Initializes the seqan3::argument_parser class on construction.
      *
      * \param[in] argc        The number of command line arguments.
      * \param[in] argv        The command line arguments.
-     * \param[in] subcommands The subcommand key words to split command line arguments into top-level and sub-parser.
      *
      * \throws seqan3::too_few_arguments if option --export-help was specified without a value
      * \throws seqan3::too_few_arguments if option --version-check was specified without a value
@@ -587,7 +598,7 @@ private:
      * If `--export-help` is specified with a value other than html/man or ctd
      * an seqan3::argument_parser_error is thrown.
      */
-    void init(int argc, char const * const * const argv, std::vector<std::string> const & subcommands)
+    void init(int argc, char const * const * const argv)
     {
         // cash command line input, in case --version-check is specified but shall not be passed to format_parse()
         std::vector<std::string> argv_new{};
@@ -685,12 +696,6 @@ private:
 
         if (!special_format_was_set)
         {
-            if (!subcommands.empty() && sub_parser == nullptr)
-            {
-                throw too_few_arguments{detail::to_string("Please specify which sub program you want to use ",
-                                        "(one of ", subcommands, "). Use -h/--help for more information.")};
-            }
-
             format = detail::format_parse(argc, std::move(argv_new));
         }
     }

--- a/test/unit/argument_parser/format_parse_test.cpp
+++ b/test/unit/argument_parser/format_parse_test.cpp
@@ -920,10 +920,11 @@ TEST(parse_test, subcommand_argument_parser_success)
     }
 
     // incorrect sub command
-    {
-        const char * argv[]{"./top_level", "-f", "2", "subiddysub", "foo"};
-        EXPECT_THROW((seqan3::argument_parser{"top_level", 5, argv, false, {"sub1", "sub2"}}),
-                     seqan3::argument_parser_error);
+    { // see issue https://github.com/seqan/seqan3/issues/2172
+        const char * argv[]{"./top_level", "subiddysub", "-f"};
+        seqan3::argument_parser top_level_parser{"top_level", 3, argv, false, {"sub1", "sub2"}};
+
+        EXPECT_THROW(top_level_parser.parse(), seqan3::argument_parser_error);
     }
 }
 


### PR DESCRIPTION
Resolves #2172 