### PR TITLE
[FIX] Make argument_parser-ctor boolean parameter into an proper enum.

### DIFF
--- a/doc/howto/subcommand_argument_parser/subcommand_arg_parse.cpp
+++ b/doc/howto/subcommand_argument_parser/subcommand_arg_parse.cpp
@@ -74,7 +74,11 @@ int run_git_push(seqan3::argument_parser & parser)
 int main(int argc, char const ** argv)
 {
     //![construction]
-    seqan3::argument_parser top_level_parser{"mygit", argc, argv, true, {"push", "pull"}};
+    seqan3::argument_parser top_level_parser{"mygit",
+                                             argc,
+                                             argv,
+                                             seqan3::update_notifications::on,
+                                             {"push", "pull"}};
     //![construction]
 
     // Add information and flags, but no (positional) options to your top-level parser.

--- a/doc/tutorial/argument_parser/disable_version_check.cpp
+++ b/doc/tutorial/argument_parser/disable_version_check.cpp
@@ -2,6 +2,6 @@
 
 int main(int argc, char ** argv)
 {
-    seqan3::argument_parser myparser{"Game-of-Parsing", argc, argv, false};
-    // disable version checks permanently ----------------------------^
+    seqan3::argument_parser myparser{"Game-of-Parsing", argc, argv, seqan3::update_notifications::off};
+    // disable update notifications permanently ----------------------------^
 }

--- a/include/seqan3/argument_parser/argument_parser.hpp
+++ b/include/seqan3/argument_parser/argument_parser.hpp
@@ -164,11 +164,11 @@ public:
 
     /*!\brief Initializes an seqan3::argument_parser object from the command line arguments.
      *
-     * \param[in] app_name       The name of the app that is displayed on the help page.
-     * \param[in] argc           The number of command line arguments.
-     * \param[in] argv           The command line arguments to parse.
-     * \param[in] version_check  Notify users about app version updates (default true).
-     * \param[in] subcommands    A list of subcommands (see \link subcommand_arg_parse subcommand parsing \endlink).
+     * \param[in] app_name The name of the app that is displayed on the help page.
+     * \param[in] argc The number of command line arguments.
+     * \param[in] argv The command line arguments to parse.
+     * \param[in] version_updates Notify users about version updates (default seqan3::update_notifications::on).
+     * \param[in] subcommands A list of subcommands (see \link subcommand_arg_parse subcommand parsing \endlink).
      *
      * \throws seqan3::design_error if the application name contains illegal characters.
      *
@@ -181,9 +181,9 @@ public:
     argument_parser(std::string const app_name,
                     int const argc,
                     char const * const * const  argv,
-                    bool version_check = true,
+                    update_notifications version_updates = update_notifications::on,
                     std::vector<std::string> subcommands = {}) :
-        version_check_dev_decision{version_check},
+        version_check_dev_decision{version_updates},
         subcommands{std::move(subcommands)}
     {
         if (!std::regex_match(app_name, app_name_regex))
@@ -546,7 +546,7 @@ private:
     bool has_positional_list_option{false};
 
     //!\brief Set on construction and indicates whether the developer deactivates the version check calls completely.
-    bool version_check_dev_decision{};
+    update_notifications version_check_dev_decision{};
 
     //!\brief Whether the **user** specified to perform the version check (true) or not (false), default unset.
     std::optional<bool> version_check_user_decision;
@@ -618,7 +618,10 @@ private:
 
             if (std::ranges::find(subcommands, arg) != subcommands.end())
             {
-                sub_parser = std::make_unique<argument_parser>(info.app_name + "-" + arg, argc - i, argv + i, false);
+                sub_parser = std::make_unique<argument_parser>(info.app_name + "-" + arg,
+                                                               argc - i,
+                                                               argv + i,
+                                                               update_notifications::off);
                 break;
             }
 
@@ -711,7 +714,7 @@ private:
         add_list_item("\\fB--copyright\\fP", "Prints the copyright/license information.");
         add_list_item("\\fB--export-help\\fP (std::string)",
                                     "Export the help page information. Value must be one of [html, man].");
-        if (version_check_dev_decision)
+        if (version_check_dev_decision == update_notifications::on)
             add_list_item("\\fB--version-check\\fP (bool)", "Whether to to check for the newest app version. Default: 1.");
         add_subsection(""); // add a new line (todo smehringer) add a add_newline() function
     }

--- a/include/seqan3/argument_parser/auxiliary.hpp
+++ b/include/seqan3/argument_parser/auxiliary.hpp
@@ -248,6 +248,13 @@ enum option_spec
                    */
 };
 
+//!\brief Indicates whether application allows automatic update notifications by the seqan3::argument_parser.
+enum class update_notifications
+{
+    on, //!< Automatic update notifications should be enabled.
+    off //!< Automatic update notifications should be disabled.
+};
+
 /*!\brief Stores all parser related meta information of the seqan3::argument_parser.
  * \ingroup argument_parser
  *

--- a/include/seqan3/argument_parser/detail/version_check.hpp
+++ b/include/seqan3/argument_parser/detail/version_check.hpp
@@ -20,6 +20,7 @@
 #include <iostream>
 #include <regex>
 
+#include <seqan3/argument_parser/auxiliary.hpp>
 #include <seqan3/argument_parser/detail/terminal.hpp>
 #include <seqan3/io/detail/misc.hpp>
 #include <seqan3/io/detail/safe_filesystem_entry.hpp>
@@ -268,7 +269,8 @@ public:
     }
 
     /*!\brief The central decision whether to perform the version check or not.
-     * \param[in] developer_approval Whether the developer approved (true) or not (false).
+     * \param[in] developer_approval Whether the developer approved (update_notifications::on) or not
+     *                               (update_notifications::off).
      * \param[in] user_approval      Whether the user approved (true) or not (false) or did not decide (unset optional).
      *
      * The following rules apply:
@@ -291,9 +293,9 @@ public:
      * if possible (seqan3::detail::is_terminal()), what he wants to do, set the according cookie for the next time
      * and continue. If we cannot ask the user, the default kicks in (do the check).
      */
-    bool decide_if_check_is_performed(bool developer_approval, std::optional<bool> user_approval)
+    bool decide_if_check_is_performed(update_notifications developer_approval, std::optional<bool> user_approval)
     {
-        if (!developer_approval)
+        if (developer_approval == update_notifications::off)
             return false;
 
         if (std::getenv("SEQAN3_NO_VERSION_CHECK") != nullptr) // environment variable was set

--- a/test/unit/argument_parser/argument_parser_design_error_test.cpp
+++ b/test/unit/argument_parser/argument_parser_design_error_test.cpp
@@ -121,7 +121,7 @@ TEST(parse_test, subcommand_argument_parser_error)
     // subcommand parsing was not enabled on construction but get_sub_parser() is called
     {
         const char * argv[]{"./top_level", "-f"};
-        seqan3::argument_parser top_level_parser{"top_level", 2, argv, false};
+        seqan3::argument_parser top_level_parser{"top_level", 2, argv, seqan3::update_notifications::off};
         top_level_parser.add_flag(flag_value, 'f', "foo", "foo bar");
 
         EXPECT_NO_THROW(top_level_parser.parse());
@@ -133,14 +133,22 @@ TEST(parse_test, subcommand_argument_parser_error)
     // subcommand key word must only contain alpha numeric characters
     {
         const char * argv[]{"./top_level", "-f"};
-        EXPECT_THROW((seqan3::argument_parser{"top_level", 2, argv, false, {"with space"}}), seqan3::design_error);
-        EXPECT_THROW((seqan3::argument_parser{"top_level", 2, argv, false, {"-dash"}}), seqan3::design_error);
+        EXPECT_THROW((seqan3::argument_parser{"top_level",
+                                              2,
+                                              argv,
+                                              seqan3::update_notifications::off,
+                                              {"with space"}}), seqan3::design_error);
+        EXPECT_THROW((seqan3::argument_parser{"top_level",
+                                              2,
+                                              argv,
+                                              seqan3::update_notifications::off,
+                                              {"-dash"}}), seqan3::design_error);
     }
 
     // no positional/options are allowed
     {
         const char * argv[]{"./top_level", "foo"};
-        seqan3::argument_parser top_level_parser{"top_level", 2, argv, false, {"foo"}};
+        seqan3::argument_parser top_level_parser{"top_level", 2, argv, seqan3::update_notifications::off, {"foo"}};
 
         EXPECT_THROW((top_level_parser.add_option(flag_value, 'f', "foo", "foo bar")), seqan3::design_error);
         EXPECT_THROW((top_level_parser.add_positional_option(flag_value, "foo bar")), seqan3::design_error);

--- a/test/unit/argument_parser/detail/format_help_test.cpp
+++ b/test/unit/argument_parser/detail/format_help_test.cpp
@@ -499,7 +499,11 @@ TEST(parse_test, subcommand_argument_parser)
     std::string option_value2{};
 
     const char * argv[]{"./test_parser", "-h"};
-    seqan3::argument_parser top_level_parser{"test_parser", 2, argv, true, {"sub1", "sub2"}};
+    seqan3::argument_parser top_level_parser{"test_parser",
+                                             2,
+                                             argv,
+                                             seqan3::update_notifications::on,
+                                             {"sub1", "sub2"}};
     test_accessor::set_terminal_width(top_level_parser, 80);
     top_level_parser.info.description.push_back("description");
     top_level_parser.add_option(option_value, 'f', "foo", "foo bar.");

--- a/test/unit/argument_parser/format_parse_test.cpp
+++ b/test/unit/argument_parser/format_parse_test.cpp
@@ -14,7 +14,7 @@ TEST(parse_type_test, add_option_short_id)
     std::string option_value;
 
     const char * argv[] = {"./argument_parser_test", "-s", "option_string"};
-    seqan3::argument_parser parser{"test_parser", 3, argv, false};
+    seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
     parser.add_section("My options");       // no-op for code coverage
     parser.add_subsection("My suboptions"); // no-op for code coverage
     parser.add_line("line");                // no-op for code coverage
@@ -28,7 +28,7 @@ TEST(parse_type_test, add_option_short_id)
 
     // add with no space
     const char * argv2[] = {"./argument_parser_test", "-Soption_string"};
-    seqan3::argument_parser parser2{"test_parser", 2, argv2, false};
+    seqan3::argument_parser parser2{"test_parser", 2, argv2, seqan3::update_notifications::off};
     parser2.add_option(option_value, 'S', "string-option", "this is a string option.");
 
     testing::internal::CaptureStderr();
@@ -38,7 +38,7 @@ TEST(parse_type_test, add_option_short_id)
 
     // ad with = sign
     const char * argv3[] = {"./argument_parser_test", "-s=option_string"};
-    seqan3::argument_parser parser3{"test_parser", 2, argv3, false};
+    seqan3::argument_parser parser3{"test_parser", 2, argv3, seqan3::update_notifications::off};
     parser3.add_option(option_value, 's', "string-option", "this is a string option.");
 
     testing::internal::CaptureStderr();
@@ -52,7 +52,7 @@ TEST(parse_type_test, add_option_long_id)
     std::string option_value;
 
     const char * argv[] = {"./argument_parser_test", "--string-option", "option_string"};
-    seqan3::argument_parser parser{"test_parser", 3, argv, false};
+    seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
     parser.add_option(option_value, 's', "string-option", "this is a string option.");
 
     testing::internal::CaptureStderr();
@@ -61,7 +61,7 @@ TEST(parse_type_test, add_option_long_id)
     EXPECT_EQ(option_value, "option_string");
 
     const char * argv3[] = {"./argument_parser_test", "--string-option=option_string"};
-    seqan3::argument_parser parser3{"test_parser", 2, argv3, false};
+    seqan3::argument_parser parser3{"test_parser", 2, argv3, seqan3::update_notifications::off};
     parser3.add_option(option_value, 's', "string-option", "this is a string option.");
 
     testing::internal::CaptureStderr();
@@ -76,7 +76,7 @@ TEST(parse_type_test, add_flag_short_id_single)
     bool option_value2{true};
 
     const char * argv[] = {"./argument_parser_test", "-t"};
-    seqan3::argument_parser parser{"test_parser", 2, argv, false};
+    seqan3::argument_parser parser{"test_parser", 2, argv, seqan3::update_notifications::off};
     parser.add_flag(option_value1, 't', "true-flag", "this is a flag.");
     parser.add_flag(option_value2, 'f', "false-flag", "this is a flag.");
 
@@ -95,7 +95,7 @@ TEST(parse_type_test, add_flag_short_id_multiple)
     bool option_value4{false};
 
     const char * argv[] = {"./argument_parser_test", "-tab"};
-    seqan3::argument_parser parser{"test_parser", 2, argv, false};
+    seqan3::argument_parser parser{"test_parser", 2, argv, seqan3::update_notifications::off};
     parser.add_flag(option_value1, 't', "true-flag", "this is a flag.");
     parser.add_flag(option_value2, 'f', "false-flag", "this is a flag.");
     parser.add_flag(option_value3, 'a', "additional-flag", "this is a flag.");
@@ -116,7 +116,7 @@ TEST(parse_type_test, add_flag_long_id)
     bool option_value2{true};
 
     const char * argv[] = {"./argument_parser_test", "--true-flag"};
-    seqan3::argument_parser parser{"test_parser", 2, argv, false};
+    seqan3::argument_parser parser{"test_parser", 2, argv, seqan3::update_notifications::off};
     parser.add_flag(option_value1, 't', "true-flag", "this is a flag.");
     parser.add_flag(option_value2, 'f', "false-flag", "this is a flag.");
 
@@ -132,7 +132,7 @@ TEST(parse_type_test, add_positional_option)
     std::string positional_value;
 
     const char * argv[] = {"./argument_parser_test", "positional_string"};
-    seqan3::argument_parser parser{"test_parser", 2, argv, false};
+    seqan3::argument_parser parser{"test_parser", 2, argv, seqan3::update_notifications::off};
     parser.add_positional_option(positional_value, "this is a string positional.");
 
     testing::internal::CaptureStderr();
@@ -151,7 +151,7 @@ TEST(parse_type_test, independent_add_order)
 
     // Order 1: option, flag, positional
     const char * argv[] = {"./argument_parser_test", "-i", "2", "-b", "arg"};
-    seqan3::argument_parser parser{"test_parser", 5, argv, false};
+    seqan3::argument_parser parser{"test_parser", 5, argv, seqan3::update_notifications::off};
     parser.add_option(option_value, 'i', "int-option", "this is a int option.");
     parser.add_flag(flag_value, 'b', "flag", "this is a flag.");
     parser.add_positional_option(positional_value, "this is a string positional.");
@@ -164,7 +164,7 @@ TEST(parse_type_test, independent_add_order)
     EXPECT_EQ(flag_value, true);
 
     // Order 1: flag, option, positional
-    seqan3::argument_parser parser2{"test_parser", 5, argv, false};
+    seqan3::argument_parser parser2{"test_parser", 5, argv, seqan3::update_notifications::off};
     parser2.add_flag(flag_value, 'b', "flag", "this is a flag.");
     parser2.add_option(option_value, 'i', "int-option", "this is a int option.");
     parser2.add_positional_option(positional_value, "this is a string positional.");
@@ -177,7 +177,7 @@ TEST(parse_type_test, independent_add_order)
     EXPECT_EQ(flag_value, true);
 
     // Order 1: option, positional, flag
-    seqan3::argument_parser parser3{"test_parser", 5, argv, false};
+    seqan3::argument_parser parser3{"test_parser", 5, argv, seqan3::update_notifications::off};
     parser3.add_option(option_value, 'i', "int-option", "this is a int option.");
     parser3.add_positional_option(positional_value, "this is a string positional.");
     parser3.add_flag(flag_value, 'b', "flag", "this is a flag.");
@@ -190,7 +190,7 @@ TEST(parse_type_test, independent_add_order)
     EXPECT_EQ(flag_value, true);
 
     // Order 1: flag, positional, option
-    seqan3::argument_parser parser4{"test_parser", 5, argv, false};
+    seqan3::argument_parser parser4{"test_parser", 5, argv, seqan3::update_notifications::off};
     parser4.add_flag(flag_value, 'b', "flag", "this is a flag.");
     parser4.add_positional_option(positional_value, "this is a string positional.");
     parser4.add_option(option_value, 'i', "int-option", "this is a int option.");
@@ -203,7 +203,7 @@ TEST(parse_type_test, independent_add_order)
     EXPECT_EQ(flag_value, true);
 
     // Order 1: positional, flag, option
-    seqan3::argument_parser parser5{"test_parser", 5, argv, false};
+    seqan3::argument_parser parser5{"test_parser", 5, argv, seqan3::update_notifications::off};
     parser5.add_positional_option(positional_value, "this is a string positional.");
     parser5.add_flag(flag_value, 'b', "flag", "this is a flag.");
     parser5.add_option(option_value, 'i', "int-option", "this is a int option.");
@@ -216,7 +216,7 @@ TEST(parse_type_test, independent_add_order)
     EXPECT_EQ(flag_value, true);
 
     // Order 1: positional, option, flag
-    seqan3::argument_parser parser6{"test_parser", 5, argv, false};
+    seqan3::argument_parser parser6{"test_parser", 5, argv, seqan3::update_notifications::off};
     parser6.add_positional_option(positional_value, "this is a string positional.");
     parser6.add_option(option_value, 'i', "int-option", "this is a int option.");
     parser6.add_flag(flag_value, 'b', "flag", "this is a flag.");
@@ -239,7 +239,7 @@ TEST(parse_type_test, independent_cmd_order)
 
     // Order 1: option, flag, positional (POSIX conform)
     const char * argv[] = {"./argument_parser_test", "-i", "2", "-b", "arg"};
-    seqan3::argument_parser parser{"test_parser", 5, argv, false};
+    seqan3::argument_parser parser{"test_parser", 5, argv, seqan3::update_notifications::off};
     parser.add_option(option_value, 'i', "int-option", "this is a int option.");
     parser.add_flag(flag_value, 'b', "flag", "this is a flag.");
     parser.add_positional_option(positional_value, "this is a string positional.");
@@ -253,7 +253,7 @@ TEST(parse_type_test, independent_cmd_order)
 
     // Order 1: flag, option, positional (POSIX conform)
     const char * argv2[] = {"./argument_parser_test", "-b", "-i", "2", "arg"};
-    seqan3::argument_parser parser2{"test_parser", 5, argv2, false};
+    seqan3::argument_parser parser2{"test_parser", 5, argv2, seqan3::update_notifications::off};
     parser2.add_option(option_value, 'i', "int-option", "this is a int option.");
     parser2.add_flag(flag_value, 'b', "flag", "this is a flag.");
     parser2.add_positional_option(positional_value, "this is a string positional.");
@@ -267,7 +267,7 @@ TEST(parse_type_test, independent_cmd_order)
 
     // Order 1: option, positional, flag
     const char * argv3[] = {"./argument_parser_test", "-i", "2", "arg", "-b"};
-    seqan3::argument_parser parser3{"test_parser", 5, argv3, false};
+    seqan3::argument_parser parser3{"test_parser", 5, argv3, seqan3::update_notifications::off};
     parser3.add_option(option_value, 'i', "int-option", "this is a int option.");
     parser3.add_flag(flag_value, 'b', "flag", "this is a flag.");
     parser3.add_positional_option(positional_value, "this is a string positional.");
@@ -281,7 +281,7 @@ TEST(parse_type_test, independent_cmd_order)
 
     // Order 1: flag, positional, option
     const char * argv4[] = {"./argument_parser_test", "-b", "arg", "-i", "2"};
-    seqan3::argument_parser parser4{"test_parser", 5, argv4, false};
+    seqan3::argument_parser parser4{"test_parser", 5, argv4, seqan3::update_notifications::off};
     parser4.add_option(option_value, 'i', "int-option", "this is a int option.");
     parser4.add_flag(flag_value, 'b', "flag", "this is a flag.");
     parser4.add_positional_option(positional_value, "this is a string positional.");
@@ -295,7 +295,7 @@ TEST(parse_type_test, independent_cmd_order)
 
     // Order 1: positional, flag, option
     const char * argv5[] = {"./argument_parser_test", "arg", "-b", "-i", "2"};
-    seqan3::argument_parser parser5{"test_parser", 5, argv5, false};
+    seqan3::argument_parser parser5{"test_parser", 5, argv5, seqan3::update_notifications::off};
     parser5.add_option(option_value, 'i', "int-option", "this is a int option.");
     parser5.add_flag(flag_value, 'b', "flag", "this is a flag.");
     parser5.add_positional_option(positional_value, "this is a string positional.");
@@ -309,7 +309,7 @@ TEST(parse_type_test, independent_cmd_order)
 
     // Order 1: positional, option, flag
     const char * argv6[] = {"./argument_parser_test", "arg", "-i", "2", "-b"};
-    seqan3::argument_parser parser6{"test_parser", 5, argv6, false};
+    seqan3::argument_parser parser6{"test_parser", 5, argv6, seqan3::update_notifications::off};
     parser6.add_option(option_value, 'i', "int-option", "this is a int option.");
     parser6.add_flag(flag_value, 'b', "flag", "this is a flag.");
     parser6.add_positional_option(positional_value, "this is a string positional.");
@@ -328,7 +328,7 @@ TEST(parse_test, double_dash_separation_success)
 
     // string option with dash
     const char * argv[] = {"./argument_parser_test", "--", "-strange"};
-    seqan3::argument_parser parser{"test_parser", 3, argv, false};
+    seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
     parser.add_positional_option(option_value, "this is a string option.");
 
     testing::internal::CaptureStderr();
@@ -339,7 +339,7 @@ TEST(parse_test, double_dash_separation_success)
     // negative integer option
     int option_value_int;
     const char * argv2[] = {"./argument_parser_test", "--", "-120"};
-    seqan3::argument_parser parser2{"test_parser", 3, argv2, false};
+    seqan3::argument_parser parser2{"test_parser", 3, argv2, seqan3::update_notifications::off};
     parser2.add_positional_option(option_value_int, "this is a int option.");
 
     testing::internal::CaptureStderr();
@@ -355,7 +355,7 @@ TEST(parse_test, special_characters_as_value_success)
     // weird option value. But since r/regex option is parsed and with it's
     // value should work correct
     const char * argv[] = {"./argument_parser_test", "--regex", "-i=/45*&//--"};
-    seqan3::argument_parser parser{"test_parser", 3, argv, false};
+    seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
     parser.add_option(option_value, 'r', "regex", "strange option value.");
 
     testing::internal::CaptureStderr();
@@ -370,28 +370,28 @@ TEST(parse_test, empty_value_error)
 
     // short option
     const char * argv[] = {"./argument_parser_test", "-i"};
-    seqan3::argument_parser parser{"test_parser", 2, argv, false};
+    seqan3::argument_parser parser{"test_parser", 2, argv, seqan3::update_notifications::off};
     parser.add_option(option_value, 'i', "long", "this is a int option.");
 
     EXPECT_THROW(parser.parse(), seqan3::argument_parser_error);
 
     // long option
     const char * argv2[] = {"./argument_parser_test", "--long"};
-    seqan3::argument_parser parser2{"test_parser", 2, argv2, false};
+    seqan3::argument_parser parser2{"test_parser", 2, argv2, seqan3::update_notifications::off};
     parser2.add_option(option_value, 'i', "long", "this is an int option.");
 
     EXPECT_THROW(parser2.parse(), seqan3::argument_parser_error);
 
     // short option
     const char * argv3[] = {"./argument_parser_test", "-i="};
-    seqan3::argument_parser parser3{"test_parser", 2, argv3, false};
+    seqan3::argument_parser parser3{"test_parser", 2, argv3, seqan3::update_notifications::off};
     parser3.add_option(option_value, 'i', "long", "this is an int option.");
 
     EXPECT_THROW(parser3.parse(), seqan3::argument_parser_error);
 
     // short option
     const char * argv4[] = {"./argument_parser_test", "--long="};
-    seqan3::argument_parser parser4{"test_parser", 2, argv4, false};
+    seqan3::argument_parser parser4{"test_parser", 2, argv4, seqan3::update_notifications::off};
     parser4.add_option(option_value, 'i', "long", "this is an int option.");
 
     EXPECT_THROW(parser4.parse(), seqan3::argument_parser_error);
@@ -405,7 +405,7 @@ TEST(parse_type_test, parse_success_bool_option)
     // numbers 0 and 1
     {
         const char * argv[] = {"./argument_parser_test", "-b", "1", "0"};
-        seqan3::argument_parser parser{"test_parser", 4, argv, false};
+        seqan3::argument_parser parser{"test_parser", 4, argv, seqan3::update_notifications::off};
         parser.add_option(option_value, 'b', "bool-option", "this is a bool option.");
         parser.add_positional_option(positional_value, "this is a bool positional.");
 
@@ -420,7 +420,7 @@ TEST(parse_type_test, parse_success_bool_option)
     // true and false
     {
         const char * argv[] = {"./argument_parser_test", "-b", "true", "false"};
-        seqan3::argument_parser parser{"test_parser", 4, argv, false};
+        seqan3::argument_parser parser{"test_parser", 4, argv, seqan3::update_notifications::off};
         parser.add_option(option_value, 'b', "bool-option", "this is a bool option.");
         parser.add_positional_option(positional_value, "this is a bool positional.");
 
@@ -439,7 +439,7 @@ TEST(parse_type_test, parse_success_int_option)
     size_t positional_value;
 
     const char * argv[] = {"./argument_parser_test", "-i", "-2", "278"};
-    seqan3::argument_parser parser{"test_parser", 4, argv, false};
+    seqan3::argument_parser parser{"test_parser", 4, argv, seqan3::update_notifications::off};
     parser.add_option(option_value, 'i', "int-option", "this is a int option.");
     parser.add_positional_option(positional_value, "this is a int positional.");
 
@@ -457,7 +457,7 @@ TEST(parse_type_test, parse_success_double_option)
     double positional_value;
 
     const char * argv[] = {"./argument_parser_test", "-d", "12.457", "0.123"};
-    seqan3::argument_parser parser{"test_parser", 4, argv, false};
+    seqan3::argument_parser parser{"test_parser", 4, argv, seqan3::update_notifications::off};
     parser.add_option(option_value, 'd', "double-option", "this is a double option.");
     parser.add_positional_option(positional_value, "this is a double positional.");
 
@@ -470,7 +470,7 @@ TEST(parse_type_test, parse_success_double_option)
 
     // double expression with e
     const char * argv2[] = {"./argument_parser_test", "-d", "6.0221418e23"};
-    seqan3::argument_parser parser2{"test_parser", 3, argv2, false};
+    seqan3::argument_parser parser2{"test_parser", 3, argv2, seqan3::update_notifications::off};
     parser2.add_option(option_value, 'd', "double-option", "this is a double option.");
 
     testing::internal::CaptureStderr();
@@ -488,14 +488,14 @@ TEST(parse_type_test, parse_error_bool_option)
 
     // fail on character input
     const char * argv[] = {"./argument_parser_test", "-b", "a"};
-    seqan3::argument_parser parser{"test_parser", 3, argv, false};
+    seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
     parser.add_option(option_value, 'b', "bool-option", "this is a bool option.");
 
     EXPECT_THROW(parser.parse(), seqan3::argument_parser_error);
 
     // fail on number input expect 0 and 1
     const char * argv2[] = {"./argument_parser_test", "-b", "124"};
-    seqan3::argument_parser parser2{"test_parser", 3, argv2, false};
+    seqan3::argument_parser parser2{"test_parser", 3, argv2, seqan3::update_notifications::off};
     parser2.add_option(option_value, 'b', "bool-option", "this is a bool option.");
 
     EXPECT_THROW(parser2.parse(), seqan3::argument_parser_error);
@@ -507,21 +507,21 @@ TEST(parse_type_test, parse_error_int_option)
 
     // fail on character
     const char * argv[] = {"./argument_parser_test", "-i", "abc"};
-    seqan3::argument_parser parser{"test_parser", 3, argv, false};
+    seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
     parser.add_option(option_value, 'i', "int-option", "this is a int option.");
 
     EXPECT_THROW(parser.parse(), seqan3::argument_parser_error);
 
     // fail on number followed by character
     const char * argv2[] = {"./argument_parser_test", "-i", "2abc"};
-    seqan3::argument_parser parser2{"test_parser", 3, argv2, false};
+    seqan3::argument_parser parser2{"test_parser", 3, argv2, seqan3::update_notifications::off};
     parser2.add_option(option_value, 'i', "int-option", "this is a int option.");
 
     EXPECT_THROW(parser2.parse(), seqan3::argument_parser_error);
 
     // fail on double
     const char * argv3[] = {"./argument_parser_test", "-i", "3.12"};
-    seqan3::argument_parser parser3{"test_parser", 3, argv3, false};
+    seqan3::argument_parser parser3{"test_parser", 3, argv3, seqan3::update_notifications::off};
     parser3.add_option(option_value, 'i', "int-option", "this is a int option.");
 
     EXPECT_THROW(parser3.parse(), seqan3::argument_parser_error);
@@ -529,7 +529,7 @@ TEST(parse_type_test, parse_error_int_option)
     // fail on negative number for unsigned
     unsigned option_value_u;
     const char * argv4[] = {"./argument_parser_test", "-i", "-1"};
-    seqan3::argument_parser parser4{"test_parser", 3, argv4, false};
+    seqan3::argument_parser parser4{"test_parser", 3, argv4, seqan3::update_notifications::off};
     parser4.add_option(option_value_u, 'i', "int-option", "this is a int option.");
 
     EXPECT_THROW(parser4.parse(), seqan3::argument_parser_error);
@@ -537,14 +537,14 @@ TEST(parse_type_test, parse_error_int_option)
     // fail on overflow
     int8_t option_value_int8;
     const char * argv5[] = {"./argument_parser_test", "-i", "129"};
-    seqan3::argument_parser parser5{"test_parser", 3, argv5, false};
+    seqan3::argument_parser parser5{"test_parser", 3, argv5, seqan3::update_notifications::off};
     parser5.add_option(option_value_int8, 'i', "int-option", "this is a int option.");
 
     EXPECT_THROW(parser5.parse(), seqan3::argument_parser_error);
 
     uint8_t option_value_uint8;
     const char * argv6[] = {"./argument_parser_test", "-i", "267"};
-    seqan3::argument_parser parser6{"test_parser", 3, argv6, false};
+    seqan3::argument_parser parser6{"test_parser", 3, argv6, seqan3::update_notifications::off};
     parser6.add_option(option_value_uint8, 'i', "int-option", "this is a int option.");
 
     EXPECT_THROW(parser6.parse(), seqan3::argument_parser_error);
@@ -556,14 +556,14 @@ TEST(parse_type_test, parse_error_double_option)
 
     // fail on character
     const char * argv[] = {"./argument_parser_test", "-i", "abc"};
-    seqan3::argument_parser parser{"test_parser", 3, argv, false};
+    seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
     parser.add_option(option_value, 'd', "double-option", "this is a double option.");
 
     EXPECT_THROW(parser.parse(), seqan3::argument_parser_error);
 
     // fail on number followed by character
     const char * argv2[] = {"./argument_parser_test", "-d", "12.457a"};
-    seqan3::argument_parser parser2{"test_parser", 3, argv2, false};
+    seqan3::argument_parser parser2{"test_parser", 3, argv2, seqan3::update_notifications::off};
     parser2.add_option(option_value, 'd', "double-option", "this is a double option.");
 
     EXPECT_THROW(parser2.parse(), seqan3::argument_parser_error);
@@ -611,7 +611,7 @@ TEST(parse_type_test, parse_success_enum_option)
         foo::bar option_value{};
 
         const char * argv[] = {"./argument_parser_test", "-e", "two"};
-        seqan3::argument_parser parser{"test_parser", 3, argv, false};
+        seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
         parser.add_option(option_value, 'e', "enum-option", "this is an enum option.");
 
         EXPECT_NO_THROW(parser.parse());
@@ -622,7 +622,7 @@ TEST(parse_type_test, parse_success_enum_option)
         Other::bar option_value{};
 
         const char * argv[] = {"./argument_parser_test", "-e", "two"};
-        seqan3::argument_parser parser{"test_parser", 3, argv, false};
+        seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
         parser.add_option(option_value, 'e', "enum-option", "this is an enum option.");
 
         EXPECT_NO_THROW(parser.parse());
@@ -635,7 +635,7 @@ TEST(parse_type_test, parse_error_enum_option)
     foo::bar option_value{};
 
     const char * argv[] = {"./argument_parser_test", "-e", "four"};
-    seqan3::argument_parser parser{"test_parser", 3, argv, false};
+    seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
     parser.add_option(option_value, 'e', "enum-option", "this is an enum option.");
 
     EXPECT_THROW(parser.parse(), seqan3::argument_parser_error);
@@ -646,14 +646,14 @@ TEST(parse_test, too_many_arguments_error)
     int option_value;
 
     const char * argv[] = {"./argument_parser_test", "5", "15"};
-    seqan3::argument_parser parser{"test_parser", 3, argv, false};
+    seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
     parser.add_positional_option(option_value, "this is an int option.");
 
     EXPECT_THROW(parser.parse(), seqan3::too_many_arguments);
 
     // since -- indicates -i as a positional argument, this causes a too many args error
     const char * argv2[] = {"./argument_parser_test", "2", "--", "-i"};
-    seqan3::argument_parser parser2{"test_parser", 4, argv2, false};
+    seqan3::argument_parser parser2{"test_parser", 4, argv2, seqan3::update_notifications::off};
     parser2.add_positional_option(option_value, "normal int positional argument.");
     parser2.add_option(option_value, 'i', "int-option", "this is an int option.");
 
@@ -665,7 +665,7 @@ TEST(parse_test, too_few_arguments_error)
     int option_value;
 
     const char * argv[] = {"./argument_parser_test", "15"};
-    seqan3::argument_parser parser{"test_parser", 2, argv, false};
+    seqan3::argument_parser parser{"test_parser", 2, argv, seqan3::update_notifications::off};
     parser.add_positional_option(option_value, "this is an int option.");
     parser.add_positional_option(option_value, "this is another option.");
 
@@ -673,7 +673,7 @@ TEST(parse_test, too_few_arguments_error)
 
     // since -- indicates -i as a positional argument, this causes a too many args error
     const char * argv2[] = {"./argument_parser_test", "-i", "2"};
-    seqan3::argument_parser parser2{"test_parser", 3, argv2, false};
+    seqan3::argument_parser parser2{"test_parser", 3, argv2, seqan3::update_notifications::off};
     parser2.add_positional_option(option_value, "normal int positional argument.");
     parser2.add_option(option_value, 'i', "int-option", "this is an int option.");
 
@@ -684,31 +684,31 @@ TEST(parse_test, unknown_option_error)
 {
     // unknown short option
     const char * argv[] = {"./argument_parser_test", "-i", "15"};
-    seqan3::argument_parser parser{"test_parser", 3, argv, false};
+    seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
 
     EXPECT_THROW(parser.parse(), seqan3::unknown_option);
 
     // unknown long option
     const char * argv2[] = {"./argument_parser_test", "--arg", "8"};
-    seqan3::argument_parser parser2{"test_parser", 3, argv2, false};
+    seqan3::argument_parser parser2{"test_parser", 3, argv2, seqan3::update_notifications::off};
 
     EXPECT_THROW(parser2.parse(), seqan3::unknown_option);
 
     // unknown short flag
     const char * argv3[] = {"./argument_parser_test", "-a"};
-    seqan3::argument_parser parser3{"test_parser", 2, argv3, false};
+    seqan3::argument_parser parser3{"test_parser", 2, argv3, seqan3::update_notifications::off};
 
     EXPECT_THROW(parser3.parse(), seqan3::unknown_option);
 
     // unknown long flag
     const char * argv4[] = {"./argument_parser_test", "--arg"};
-    seqan3::argument_parser parser4{"test_parser", 2, argv4, false};
+    seqan3::argument_parser parser4{"test_parser", 2, argv4, seqan3::update_notifications::off};
 
     EXPECT_THROW(parser4.parse(), seqan3::unknown_option);
 
     // negative numbers are seen as options
     const char * argv5[] = {"./argument_parser_test", "-5"};
-    seqan3::argument_parser parser5{"test_parser", 2, argv5, false};
+    seqan3::argument_parser parser5{"test_parser", 2, argv5, seqan3::update_notifications::off};
 
     EXPECT_THROW(parser5.parse(), seqan3::unknown_option);
 
@@ -717,7 +717,7 @@ TEST(parse_test, unknown_option_error)
     std::string option_value_a;
     std::string positional_option;
     const char * argv6[] = {"./argument_parser_test", "-i", "129", "arg1", "-b", "bcd", "-a", "abc"};
-    seqan3::argument_parser parser6{"test_parser", 8, argv6, false};
+    seqan3::argument_parser parser6{"test_parser", 8, argv6, seqan3::update_notifications::off};
     parser6.add_option(option_value_i, 'i', "int-option", "this is a int option.");
     parser6.add_option(option_value_a, 'a', "string-option", "this is a string option.");
     parser6.add_positional_option(positional_option, "normal int positional argument.");
@@ -731,21 +731,21 @@ TEST(parse_test, option_declared_multiple_times_error)
 
     // short option
     const char * argv[] = {"./argument_parser_test", "-i", "15", "-i", "3"};
-    seqan3::argument_parser parser{"test_parser", 5, argv, false};
+    seqan3::argument_parser parser{"test_parser", 5, argv, seqan3::update_notifications::off};
     parser.add_option(option_value, 'i', "long", "this is a int option.");
 
     EXPECT_THROW(parser.parse(), seqan3::option_declared_multiple_times);
 
     // since -- indicates -i as a positional argument, this causes a too many args error
     const char * argv2[] = {"./argument_parser_test", "--long", "5", "--long", "6"};
-    seqan3::argument_parser parser2{"test_parser", 5, argv2, false};
+    seqan3::argument_parser parser2{"test_parser", 5, argv2, seqan3::update_notifications::off};
     parser2.add_option(option_value, 'i', "long", "this is an int option.");
 
     EXPECT_THROW(parser2.parse(), seqan3::option_declared_multiple_times);
 
     // since -- indicates -i as a positional argument, this causes a too many args error
     const char * argv3[] = {"./argument_parser_test", "-i", "5", "--long", "6"};
-    seqan3::argument_parser parser3{"test_parser", 5, argv3, false};
+    seqan3::argument_parser parser3{"test_parser", 5, argv3, seqan3::update_notifications::off};
     parser3.add_option(option_value, 'i', "long", "this is an int option.");
 
     EXPECT_THROW(parser3.parse(), seqan3::option_declared_multiple_times);
@@ -757,7 +757,7 @@ TEST(parse_test, required_option_missing)
 
     // option is required
     const char * argv[] = {"./argument_parser_test", "5", "-i", "15"};
-    seqan3::argument_parser parser{"test_parser", 4, argv, false};
+    seqan3::argument_parser parser{"test_parser", 4, argv, seqan3::update_notifications::off};
     parser.add_option(option_value, 'i', "int-option", "this is an int option.");
     parser.add_option(option_value, 'a', "req-option", "I am required.", seqan3::option_spec::REQUIRED);
     parser.add_positional_option(option_value, "this is an int option.");
@@ -775,7 +775,7 @@ TEST(parse_test, argv_const_combinations)
 
     // all const*
     char const * const * const argv_all_const{argv};
-    seqan3::argument_parser parser{"test_parser", 2, argv_all_const, false};
+    seqan3::argument_parser parser{"test_parser", 2, argv_all_const, seqan3::update_notifications::off};
     parser.add_flag(flag_value, 'f', "flag", "this is a flag.");
 
     EXPECT_NO_THROW(parser.parse());
@@ -783,7 +783,7 @@ TEST(parse_test, argv_const_combinations)
 
     // none const
     flag_value = false;
-    parser = seqan3::argument_parser{"test_parser", 2, argv, false};
+    parser = seqan3::argument_parser{"test_parser", 2, argv, seqan3::update_notifications::off};
     parser.add_flag(flag_value, 'f', "flag", "this is a flag.");
 
     EXPECT_NO_THROW(parser.parse());
@@ -792,7 +792,7 @@ TEST(parse_test, argv_const_combinations)
     // const 1
     flag_value = false;
     char const * argv_const1[] = {"./argument_parser_test", "-f"};
-    parser = seqan3::argument_parser{"test_parser", 2, argv_const1, false};
+    parser = seqan3::argument_parser{"test_parser", 2, argv_const1, seqan3::update_notifications::off};
     parser.add_flag(flag_value, 'f', "flag", "this is a flag.");
 
     EXPECT_NO_THROW(parser.parse());
@@ -801,7 +801,7 @@ TEST(parse_test, argv_const_combinations)
     // const 2
     flag_value = false;
     char * const argv_const2[] = {arg1, arg2};
-    parser = seqan3::argument_parser{"test_parser", 2, argv_const2, false};
+    parser = seqan3::argument_parser{"test_parser", 2, argv_const2, seqan3::update_notifications::off};
     parser.add_flag(flag_value, 'f', "flag", "this is a flag.");
 
     EXPECT_NO_THROW(parser.parse());
@@ -810,7 +810,7 @@ TEST(parse_test, argv_const_combinations)
     // const 12
     flag_value = false;
     char const * const argv_const12[] = {arg1, arg2};
-    parser = seqan3::argument_parser{"test_parser", 2, argv_const12, false};
+    parser = seqan3::argument_parser{"test_parser", 2, argv_const12, seqan3::update_notifications::off};
     parser.add_flag(flag_value, 'f', "flag", "this is a flag.");
 
     EXPECT_NO_THROW(parser.parse());
@@ -823,7 +823,7 @@ TEST(parse_test, multiple_empty_options)
 
     {
         const char * argv[]{"./empty_long", "-s=1"};
-        seqan3::argument_parser parser{"empty_long", 2, argv, false};
+        seqan3::argument_parser parser{"empty_long", 2, argv, seqan3::update_notifications::off};
         parser.add_option(option_value, 'i', "", "no long");
         parser.add_option(option_value, 's', "", "no long");
 
@@ -833,7 +833,7 @@ TEST(parse_test, multiple_empty_options)
 
     {
         const char * argv[]{"./empty_long", "-s=1", "--unknown"};
-        seqan3::argument_parser parser{"empty_long", 3, argv, false};
+        seqan3::argument_parser parser{"empty_long", 3, argv, seqan3::update_notifications::off};
         parser.add_option(option_value, 'i', "", "no long");
         parser.add_option(option_value, 's', "", "no long");
 
@@ -842,7 +842,7 @@ TEST(parse_test, multiple_empty_options)
 
     {
         const char * argv[]{"./empty_short", "--long=2"};
-        seqan3::argument_parser parser{"empty_short", 2, argv, false};
+        seqan3::argument_parser parser{"empty_short", 2, argv, seqan3::update_notifications::off};
         parser.add_option(option_value, '\0', "longi", "no short");
         parser.add_option(option_value, '\0', "long", "no short");
 
@@ -872,7 +872,11 @@ TEST(parse_test, subcommand_argument_parser_success)
     // parsing
     {
         const char * argv[]{"./top_level", "-f", "sub1", "foo"};
-        seqan3::argument_parser top_level_parser{"top_level", 4, argv, false, {"sub1", "sub2"}};
+        seqan3::argument_parser top_level_parser{"top_level",
+                                                 4,
+                                                 argv,
+                                                 seqan3::update_notifications::off,
+                                                 {"sub1", "sub2"}};
         top_level_parser.add_flag(flag_value, 'f', "foo", "foo bar");
 
         EXPECT_NO_THROW(top_level_parser.parse());
@@ -891,7 +895,11 @@ TEST(parse_test, subcommand_argument_parser_success)
     // top-level help page
     {
         const char * argv[]{"./top_level", "-h", "-f", "sub1", "foo"};
-        seqan3::argument_parser top_level_parser{"top_level", 5, argv, false, {"sub1", "sub2"}};
+        seqan3::argument_parser top_level_parser{"top_level",
+                                          5,
+                                          argv,
+                                          seqan3::update_notifications::off,
+                                          {"sub1", "sub2"}};
         top_level_parser.add_flag(flag_value, 'f', "foo", "foo bar");
 
         testing::internal::CaptureStdout();
@@ -902,7 +910,11 @@ TEST(parse_test, subcommand_argument_parser_success)
     // sub-parser help page
     {
         const char * argv[]{"./top_level", "-f", "sub1", "-h"};
-        seqan3::argument_parser top_level_parser{"top_level", 4, argv, false, {"sub1", "sub2"}};
+        seqan3::argument_parser top_level_parser{"top_level",
+                                          4,
+                                          argv,
+                                          seqan3::update_notifications::off,
+                                          {"sub1", "sub2"}};
         top_level_parser.add_flag(flag_value, 'f', "foo", "foo bar");
 
         EXPECT_NO_THROW(top_level_parser.parse());
@@ -922,7 +934,11 @@ TEST(parse_test, subcommand_argument_parser_success)
     // incorrect sub command
     { // see issue https://github.com/seqan/seqan3/issues/2172
         const char * argv[]{"./top_level", "subiddysub", "-f"};
-        seqan3::argument_parser top_level_parser{"top_level", 3, argv, false, {"sub1", "sub2"}};
+        seqan3::argument_parser top_level_parser{"top_level",
+                                                 3,
+                                                 argv,
+                                                 seqan3::update_notifications::off,
+                                                 {"sub1", "sub2"}};
 
         EXPECT_THROW(top_level_parser.parse(), seqan3::argument_parser_error);
     }
@@ -933,7 +949,7 @@ TEST(parse_test, issue1544)
     {   // wrong separation of long value:
         std::string option_value;
         const char * argv[] = {"./argument_parser_test", "--foohallo"};
-        seqan3::argument_parser parser{"test_parser", 2, argv, false};
+        seqan3::argument_parser parser{"test_parser", 2, argv, seqan3::update_notifications::off};
         parser.add_option(option_value, 'f', "foo", "this is a string option.");
 
         EXPECT_THROW(parser.parse(), seqan3::unknown_option);
@@ -942,7 +958,7 @@ TEST(parse_test, issue1544)
     {   // unknown option (`--foo-bar`) that has a prefix of a known option (`--foo`)
         std::string option_value;
         const char * argv[] = {"./argument_parser_test", "--foo", "hallo", "--foo-bar", "ballo"};
-        seqan3::argument_parser parser{"test_parser", 5, argv, false};
+        seqan3::argument_parser parser{"test_parser", 5, argv, seqan3::update_notifications::off};
         parser.add_option(option_value, 'f', "foo", "this is a string option.");
 
         EXPECT_THROW(parser.parse(), seqan3::unknown_option);
@@ -951,7 +967,7 @@ TEST(parse_test, issue1544)
     {   // known option (`--foo-bar`) that has a prefix of a unknown option (`--foo`)
         std::string option_value;
         const char * argv[] = {"./argument_parser_test", "--foo", "hallo", "--foo-bar", "ballo"};
-        seqan3::argument_parser parser{"test_parser", 5, argv, false};
+        seqan3::argument_parser parser{"test_parser", 5, argv, seqan3::update_notifications::off};
         parser.add_option(option_value, 'f', "foo-bar", "this is a string option.");
 
         EXPECT_THROW(parser.parse(), seqan3::unknown_option);
@@ -961,7 +977,7 @@ TEST(parse_test, issue1544)
         std::string foo_option_value;
         std::string foobar_option_value;
         const char * argv[] = {"./argument_parser_test", "--foo", "hallo", "--foo-bar", "ballo"};
-        seqan3::argument_parser parser{"test_parser", 5, argv, false};
+        seqan3::argument_parser parser{"test_parser", 5, argv, seqan3::update_notifications::off};
         parser.add_option(foo_option_value, 'f', "foo", "this is a prefix of foobar.");
         parser.add_option(foobar_option_value, 'b', "foo-bar", "this has prefix foo.");
 

--- a/test/unit/argument_parser/format_parse_validators_test.cpp
+++ b/test/unit/argument_parser/format_parse_validators_test.cpp
@@ -135,7 +135,7 @@ TEST(validator_test, input_file)
         // option
         std::string const & path = tmp_name.get_path().string();
         const char * argv[] = {"./argument_parser_test", "-i", path.c_str()};
-        seqan3::argument_parser parser{"test_parser", 3, argv, false};
+        seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
         parser.add_option(file_in_path, 'i', "int-option", "desc",
                           seqan3::option_spec::DEFAULT, seqan3::input_file_validator{formats});
@@ -152,7 +152,7 @@ TEST(validator_test, input_file)
         std::string const & path_2 = tmp_name_2.get_path().string();
 
         const char * argv[] = {"./argument_parser_test", path.c_str(), path_2.c_str()};
-        seqan3::argument_parser parser{"test_parser", 3, argv, false};
+        seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
         parser.add_positional_option(input_files, "desc", seqan3::input_file_validator{formats});
 
@@ -165,7 +165,7 @@ TEST(validator_test, input_file)
     { // get help page message
         std::filesystem::path path;
         const char * argv[] = {"./argument_parser_test", "-h"};
-        seqan3::argument_parser parser{"test_parser", 2, argv, false};
+        seqan3::argument_parser parser{"test_parser", 2, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
         parser.add_positional_option(path, "desc", seqan3::input_file_validator{formats});
 
@@ -253,7 +253,7 @@ TEST(validator_test, output_file)
         // option
         std::string const & path = tmp_name.get_path().string();
         const char * argv[] = {"./argument_parser_test", "-o", path.c_str()};
-        seqan3::argument_parser parser{"test_parser", 3, argv, false};
+        seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
         parser.add_option(file_out_path, 'o', "out-option", "desc",
                           seqan3::option_spec::DEFAULT,
@@ -271,7 +271,7 @@ TEST(validator_test, output_file)
         std::string const & path_3 = tmp_name_3.get_path().string();
 
         const char * argv[] = {"./argument_parser_test", path.c_str(), path_3.c_str()};
-        seqan3::argument_parser parser{"test_parser", 3, argv, false};
+        seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
         parser.add_positional_option(output_files, "desc",
                                      seqan3::output_file_validator{seqan3::output_file_open_options::create_new, formats});
@@ -286,7 +286,7 @@ TEST(validator_test, output_file)
     {
         std::filesystem::path path;
         const char * argv[] = {"./argument_parser_test", "-h"};
-        seqan3::argument_parser parser{"test_parser", 2, argv, false};
+        seqan3::argument_parser parser{"test_parser", 2, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
         parser.add_positional_option(path, "desc",
                                      seqan3::output_file_validator{seqan3::output_file_open_options::create_new, formats});
@@ -312,7 +312,7 @@ TEST(validator_test, output_file)
     {
         std::filesystem::path path;
         const char * argv[] = {"./argument_parser_test", "-h"};
-        seqan3::argument_parser parser{"test_parser", 2, argv, false};
+        seqan3::argument_parser parser{"test_parser", 2, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
         parser.add_positional_option(path, "desc",
                                      seqan3::output_file_validator{seqan3::output_file_open_options::open_or_create,
@@ -388,7 +388,7 @@ TEST(validator_test, input_directory)
             // option
             std::string const & path = p.string();
             const char * argv[] = {"./argument_parser_test", "-i", path.c_str()};
-            seqan3::argument_parser parser{"test_parser", 3, argv, false};
+            seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
             test_accessor::set_terminal_width(parser, 80);
             parser.add_option(dir_in_path, 'i', "input-option", "desc",
                               seqan3::option_spec::DEFAULT, seqan3::input_directory_validator{});
@@ -402,7 +402,7 @@ TEST(validator_test, input_directory)
         // get help page message
         std::filesystem::path path;
         const char * argv[] = {"./argument_parser_test", "-h"};
-        seqan3::argument_parser parser{"test_parser", 2, argv, false};
+        seqan3::argument_parser parser{"test_parser", 2, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
         parser.add_positional_option(path, "desc", seqan3::input_directory_validator{});
 
@@ -440,7 +440,7 @@ TEST(validator_test, output_directory)
         // option
         std::string const & path = p.string();
         const char * argv[] = {"./argument_parser_test", "-o", path.c_str()};
-        seqan3::argument_parser parser{"test_parser", 3, argv, false};
+        seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
         parser.add_option(dir_out_path, 'o', "output-option", "desc",
                           seqan3::option_spec::DEFAULT,
@@ -454,7 +454,7 @@ TEST(validator_test, output_directory)
         // get help page message
         std::filesystem::path path;
         const char * argv[] = {"./argument_parser_test", "-h"};
-        seqan3::argument_parser parser{"test_parser", 2, argv, false};
+        seqan3::argument_parser parser{"test_parser", 2, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
         parser.add_positional_option(path, "desc", seqan3::output_directory_validator{});
 
@@ -645,7 +645,7 @@ TEST(validator_test, arithmetic_range_validator_success)
 
     // option
     const char * argv[] = {"./argument_parser_test", "-i", "10"};
-    seqan3::argument_parser parser{"test_parser", 3, argv, false};
+    seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser, 80);
     parser.add_option(option_value, 'i', "int-option", "desc",
                       seqan3::option_spec::DEFAULT, seqan3::arithmetic_range_validator{1, 20});
@@ -657,7 +657,7 @@ TEST(validator_test, arithmetic_range_validator_success)
 
     // option - negative values
     const char * argv2[] = {"./argument_parser_test", "-i", "-10"};
-    seqan3::argument_parser parser2{"test_parser", 3, argv2, false};
+    seqan3::argument_parser parser2{"test_parser", 3, argv2, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser2, 80);
     parser2.add_option(option_value, 'i', "int-option", "desc",
                        seqan3::option_spec::DEFAULT, seqan3::arithmetic_range_validator{-20, 20});
@@ -669,7 +669,7 @@ TEST(validator_test, arithmetic_range_validator_success)
 
     // positional option
     const char * argv3[] = {"./argument_parser_test", "10"};
-    seqan3::argument_parser parser3{"test_parser", 2, argv3, false};
+    seqan3::argument_parser parser3{"test_parser", 2, argv3, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser3, 80);
     parser3.add_positional_option(option_value, "desc", seqan3::arithmetic_range_validator{1, 20});
 
@@ -680,7 +680,7 @@ TEST(validator_test, arithmetic_range_validator_success)
 
     // positional option - negative values
     const char * argv4[] = {"./argument_parser_test", "--", "-10"};
-    seqan3::argument_parser parser4{"test_parser", 3, argv4, false};
+    seqan3::argument_parser parser4{"test_parser", 3, argv4, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser4, 80);
     parser4.add_positional_option(option_value, "desc", seqan3::arithmetic_range_validator{-20, 20});
 
@@ -691,7 +691,7 @@ TEST(validator_test, arithmetic_range_validator_success)
 
     // option - vector
     const char * argv5[] = {"./argument_parser_test", "-i", "-10", "-i", "48"};
-    seqan3::argument_parser parser5{"test_parser", 5, argv5, false};
+    seqan3::argument_parser parser5{"test_parser", 5, argv5, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser5, 80);
     parser5.add_option(option_vector, 'i', "int-option", "desc",
                        seqan3::option_spec::DEFAULT, seqan3::arithmetic_range_validator{-50,50});
@@ -705,7 +705,7 @@ TEST(validator_test, arithmetic_range_validator_success)
     // positional option - vector
     option_vector.clear();
     const char * argv6[] = {"./argument_parser_test", "--", "-10", "1"};
-    seqan3::argument_parser parser6{"test_parser", 4, argv6, false};
+    seqan3::argument_parser parser6{"test_parser", 4, argv6, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser6, 80);
     parser6.add_positional_option(option_vector, "desc", seqan3::arithmetic_range_validator{-20,20});
 
@@ -718,7 +718,7 @@ TEST(validator_test, arithmetic_range_validator_success)
     // get help page message
     option_vector.clear();
     const char * argv7[] = {"./argument_parser_test", "-h"};
-    seqan3::argument_parser parser7{"test_parser", 2, argv7, false};
+    seqan3::argument_parser parser7{"test_parser", 2, argv7, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser7, 80);
     parser7.add_positional_option(option_vector, "desc", seqan3::arithmetic_range_validator{-20,20});
 
@@ -740,7 +740,7 @@ TEST(validator_test, arithmetic_range_validator_success)
     // option - double value
     double double_option_value;
     const char * argv8[] = {"./argument_parser_test", "-i", "10.9"};
-    seqan3::argument_parser parser8{"test_parser", 3, argv8, false};
+    seqan3::argument_parser parser8{"test_parser", 3, argv8, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser8, 80);
     parser8.add_option(double_option_value, 'i', "double-option", "desc",
                        seqan3::option_spec::DEFAULT, seqan3::arithmetic_range_validator{1, 20});
@@ -758,7 +758,7 @@ TEST(validator_test, arithmetic_range_validator_error)
 
     // option - above max
     const char * argv[] = {"./argument_parser_test", "-i", "30"};
-    seqan3::argument_parser parser{"test_parser", 3, argv, false};
+    seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser, 80);
     parser.add_option(option_value, 'i', "int-option", "desc",
                       seqan3::option_spec::DEFAULT, seqan3::arithmetic_range_validator{1, 20});
@@ -767,7 +767,7 @@ TEST(validator_test, arithmetic_range_validator_error)
 
     // option - below min
     const char * argv2[] = {"./argument_parser_test", "-i", "-21"};
-    seqan3::argument_parser parser2{"test_parser", 3, argv2, false};
+    seqan3::argument_parser parser2{"test_parser", 3, argv2, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser2, 80);
     parser2.add_option(option_value, 'i', "int-option", "desc",
                        seqan3::option_spec::DEFAULT, seqan3::arithmetic_range_validator{-20, 20});
@@ -776,7 +776,7 @@ TEST(validator_test, arithmetic_range_validator_error)
 
     // positional option - above max
     const char * argv3[] = {"./argument_parser_test", "30"};
-    seqan3::argument_parser parser3{"test_parser", 2, argv3, false};
+    seqan3::argument_parser parser3{"test_parser", 2, argv3, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser3, 80);
     parser3.add_positional_option(option_value, "desc", seqan3::arithmetic_range_validator{1, 20});
 
@@ -784,7 +784,7 @@ TEST(validator_test, arithmetic_range_validator_error)
 
     // positional option - below min
     const char * argv4[] = {"./argument_parser_test", "--", "-21"};
-    seqan3::argument_parser parser4{"test_parser", 3, argv4, false};
+    seqan3::argument_parser parser4{"test_parser", 3, argv4, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser4, 80);
     parser4.add_positional_option(option_value, "desc", seqan3::arithmetic_range_validator{-20, 20});
 
@@ -792,7 +792,7 @@ TEST(validator_test, arithmetic_range_validator_error)
 
     // option - vector
     const char * argv5[] = {"./argument_parser_test", "-i", "-100"};
-    seqan3::argument_parser parser5{"test_parser", 3, argv5, false};
+    seqan3::argument_parser parser5{"test_parser", 3, argv5, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser5, 80);
     parser5.add_option(option_vector, 'i', "int-option", "desc",
                        seqan3::option_spec::DEFAULT, seqan3::arithmetic_range_validator{-50, 50});
@@ -802,7 +802,7 @@ TEST(validator_test, arithmetic_range_validator_error)
     // positional option - vector
     option_vector.clear();
     const char * argv6[] = {"./argument_parser_test", "--", "-10", "100"};
-    seqan3::argument_parser parser6{"test_parser", 4, argv6, false};
+    seqan3::argument_parser parser6{"test_parser", 4, argv6, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser6, 80);
     parser6.add_positional_option(option_vector, "desc", seqan3::arithmetic_range_validator{-20, 20});
 
@@ -811,7 +811,7 @@ TEST(validator_test, arithmetic_range_validator_error)
     // option - double value
     double double_option_value;
     const char * argv7[] = {"./argument_parser_test", "-i", "0.9"};
-    seqan3::argument_parser parser7{"test_parser", 3, argv7, false};
+    seqan3::argument_parser parser7{"test_parser", 3, argv7, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser7, 80);
     parser7.add_option(double_option_value, 'i', "double-option", "desc",
                        seqan3::option_spec::DEFAULT, seqan3::arithmetic_range_validator{1, 20});
@@ -871,7 +871,7 @@ TEST(validator_test, value_list_validator_success)
     // option
     std::vector<std::string> valid_str_values{"ha", "ba", "ma"};
     const char * argv[] = {"./argument_parser_test", "-s", "ba"};
-    seqan3::argument_parser parser{"test_parser", 3, argv, false};
+    seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser, 80);
     parser.add_option(option_value, 's', "string-option", "desc",
                       seqan3::option_spec::DEFAULT,
@@ -884,7 +884,7 @@ TEST(validator_test, value_list_validator_success)
 
     // option with integers
     const char * argv2[] = {"./argument_parser_test", "-i", "-21"};
-    seqan3::argument_parser parser2{"test_parser", 3, argv2, false};
+    seqan3::argument_parser parser2{"test_parser", 3, argv2, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser2, 80);
     parser2.add_option(option_value_int, 'i', "int-option", "desc",
                        seqan3::option_spec::DEFAULT, seqan3::value_list_validator<int>{0, -21, 10});
@@ -896,7 +896,7 @@ TEST(validator_test, value_list_validator_success)
 
     // positional option
     const char * argv3[] = {"./argument_parser_test", "ma"};
-    seqan3::argument_parser parser3{"test_parser", 2, argv3, false};
+    seqan3::argument_parser parser3{"test_parser", 2, argv3, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser3, 80);
     parser3.add_positional_option(option_value, "desc", seqan3::value_list_validator{valid_str_values});
 
@@ -907,7 +907,7 @@ TEST(validator_test, value_list_validator_success)
 
     // positional option - vector
     const char * argv4[] = {"./argument_parser_test", "ha", "ma"};
-    seqan3::argument_parser parser4{"test_parser", 3, argv4, false};
+    seqan3::argument_parser parser4{"test_parser", 3, argv4, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser4, 80);
     parser4.add_positional_option(option_vector, "desc", seqan3::value_list_validator{"ha", "ba", "ma"});
 
@@ -919,7 +919,7 @@ TEST(validator_test, value_list_validator_success)
 
     // option - vector
     const char * argv5[] = {"./argument_parser_test", "-i", "-10", "-i", "48"};
-    seqan3::argument_parser parser5{"test_parser", 5, argv5, false};
+    seqan3::argument_parser parser5{"test_parser", 5, argv5, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser5, 80);
     parser5.add_option(option_vector_int, 'i', "int-option", "desc",
                        seqan3::option_spec::DEFAULT, seqan3::value_list_validator<int>{-10, 48, 50});
@@ -933,7 +933,7 @@ TEST(validator_test, value_list_validator_success)
     // get help page message
     option_vector_int.clear();
     const char * argv7[] = {"./argument_parser_test", "-h"};
-    seqan3::argument_parser parser7{"test_parser", 2, argv7, false};
+    seqan3::argument_parser parser7{"test_parser", 2, argv7, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser7, 80);
     parser7.add_option(option_vector_int, 'i', "int-option", "desc",
                        seqan3::option_spec::DEFAULT, seqan3::value_list_validator<int>{-10, 48, 50});
@@ -962,7 +962,7 @@ TEST(validator_test, value_list_validator_error)
 
     // option
     const char * argv[] = {"./argument_parser_test", "-s", "sa"};
-    seqan3::argument_parser parser{"test_parser", 3, argv, false};
+    seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser, 80);
     parser.add_option(option_value, 's', "string-option", "desc",
                       seqan3::option_spec::DEFAULT, seqan3::value_list_validator{"ha", "ba", "ma"});
@@ -971,7 +971,7 @@ TEST(validator_test, value_list_validator_error)
 
     // positional option
     const char * argv3[] = {"./argument_parser_test", "30"};
-    seqan3::argument_parser parser3{"test_parser", 2, argv3, false};
+    seqan3::argument_parser parser3{"test_parser", 2, argv3, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser3, 80);
     parser3.add_positional_option(option_value_int, "desc", seqan3::value_list_validator{0, 5, 10});
 
@@ -979,7 +979,7 @@ TEST(validator_test, value_list_validator_error)
 
     // positional option - vector
     const char * argv4[] = {"./argument_parser_test", "fo", "ma"};
-    seqan3::argument_parser parser4{"test_parser", 3, argv4, false};
+    seqan3::argument_parser parser4{"test_parser", 3, argv4, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser4, 80);
     parser4.add_positional_option(option_vector, "desc",
                                   seqan3::value_list_validator{"ha", "ba", "ma"});
@@ -988,7 +988,7 @@ TEST(validator_test, value_list_validator_error)
 
     // option - vector
     const char * argv5[] = {"./argument_parser_test", "-i", "-10", "-i", "488"};
-    seqan3::argument_parser parser5{"test_parser", 5, argv5, false};
+    seqan3::argument_parser parser5{"test_parser", 5, argv5, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser5, 80);
     parser5.add_option(option_vector_int, 'i', "int-option", "desc",
                        seqan3::option_spec::DEFAULT, seqan3::value_list_validator<int>{-10, 48, 50});
@@ -1005,7 +1005,7 @@ TEST(validator_test, regex_validator_success)
 
     // option
     const char * argv[] = {"./argument_parser_test", "-s", "ballo@rollo.com"};
-    seqan3::argument_parser parser{"test_parser", 3, argv, false};
+    seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser, 80);
     parser.add_option(option_value, 's', "string-option", "desc",
                       seqan3::option_spec::DEFAULT, email_validator);
@@ -1017,7 +1017,7 @@ TEST(validator_test, regex_validator_success)
 
     // positional option
     const char * argv2[] = {"./argument_parser_test", "chr1"};
-    seqan3::argument_parser parser2{"test_parser", 2, argv2, false};
+    seqan3::argument_parser parser2{"test_parser", 2, argv2, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser2, 80);
     parser2.add_positional_option(option_value, "desc",
                                   seqan3::regex_validator{"^chr[0-9]+"});
@@ -1029,7 +1029,7 @@ TEST(validator_test, regex_validator_success)
 
     // positional option - vector
     const char * argv3[] = {"./argument_parser_test", "rollo", "bollo", "lollo"};
-    seqan3::argument_parser parser3{"test_parser", 4, argv3, false};
+    seqan3::argument_parser parser3{"test_parser", 4, argv3, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser3, 80);
     parser3.add_positional_option(option_vector, "desc",
                                   seqan3::regex_validator{".*oll.*"});
@@ -1044,7 +1044,7 @@ TEST(validator_test, regex_validator_success)
     // option - vector
     option_vector.clear();
     const char * argv4[] = {"./argument_parser_test", "-s", "rita@rambo.com", "-s", "tina@rambo.com"};
-    seqan3::argument_parser parser4{"test_parser", 5, argv4, false};
+    seqan3::argument_parser parser4{"test_parser", 5, argv4, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser4, 80);
     parser4.add_option(option_vector, 's', "string-option", "desc",
                        seqan3::option_spec::DEFAULT, email_vector_validator);
@@ -1058,7 +1058,7 @@ TEST(validator_test, regex_validator_success)
     // get help page message
     option_vector.clear();
     const char * argv7[] = {"./argument_parser_test", "-h"};
-    seqan3::argument_parser parser7{"test_parser", 2, argv7, false};
+    seqan3::argument_parser parser7{"test_parser", 2, argv7, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser7, 80);
     parser7.add_option(option_vector, 's', "string-option", "desc",
                        seqan3::option_spec::DEFAULT, email_vector_validator);
@@ -1086,7 +1086,7 @@ TEST(validator_test, regex_validator_error)
 
     // option
     const char * argv[] = {"./argument_parser_test", "--string-option", "sally"};
-    seqan3::argument_parser parser{"test_parser", 3, argv, false};
+    seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser, 80);
     parser.add_option(option_value, '\0', "string-option", "desc",
                       seqan3::option_spec::DEFAULT, seqan3::regex_validator{"tt"});
@@ -1095,7 +1095,7 @@ TEST(validator_test, regex_validator_error)
 
     // positional option
     const char * argv2[] = {"./argument_parser_test", "jessy"};
-    seqan3::argument_parser parser2{"test_parser", 2, argv2, false};
+    seqan3::argument_parser parser2{"test_parser", 2, argv2, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser2, 80);
     parser2.add_positional_option(option_value, "desc",
                                   seqan3::regex_validator{"[0-9]"});
@@ -1104,7 +1104,7 @@ TEST(validator_test, regex_validator_error)
 
     // positional option - vector
     const char * argv3[] = {"./argument_parser_test", "rollo", "bttllo", "lollo"};
-    seqan3::argument_parser parser3{"test_parser", 4, argv3, false};
+    seqan3::argument_parser parser3{"test_parser", 4, argv3, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser3, 80);
     parser3.add_positional_option(option_vector, "desc",
                                   seqan3::regex_validator{".*oll.*"});
@@ -1114,7 +1114,7 @@ TEST(validator_test, regex_validator_error)
     // option - vector
     option_vector.clear();
     const char * argv4[] = {"./argument_parser_test", "-s", "gh", "-s", "tt"};
-    seqan3::argument_parser parser4{"test_parser", 5, argv4, false};
+    seqan3::argument_parser parser4{"test_parser", 5, argv4, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser4, 80);
     parser4.add_option(option_vector, 's', "", "desc",
                        seqan3::option_spec::DEFAULT, seqan3::regex_validator{"tt"});
@@ -1137,7 +1137,7 @@ TEST(validator_test, chaining_validators)
     {
         std::string const & path = tmp_name.get_path().string();
         const char * argv[] = {"./argument_parser_test", "-s", path.c_str()};
-        seqan3::argument_parser parser{"test_parser", 3, argv, false};
+        seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
         parser.add_option(option_value, 's', "string-option", "desc",
                           seqan3::option_spec::DEFAULT, absolute_path_validator | my_file_ext_validator);
@@ -1151,7 +1151,7 @@ TEST(validator_test, chaining_validators)
     {
         auto rel_path = tmp_name.get_path().relative_path().string();
         const char * argv[] = {"./argument_parser_test", "-s", rel_path.c_str()};
-        seqan3::argument_parser parser{"test_parser", 3, argv, false};
+        seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
         parser.add_option(option_value, 's', "string-option", "desc",
                           seqan3::option_spec::DEFAULT, absolute_path_validator | my_file_ext_validator);
@@ -1162,7 +1162,7 @@ TEST(validator_test, chaining_validators)
     {
         std::string const & path = invalid_extension.string();
         const char * argv[] = {"./argument_parser_test", "-s", path.c_str()};
-        seqan3::argument_parser parser{"test_parser", 3, argv, false};
+        seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
         parser.add_option(option_value, 's', "string-option", "desc",
                           seqan3::option_spec::DEFAULT, absolute_path_validator | my_file_ext_validator);
@@ -1174,7 +1174,7 @@ TEST(validator_test, chaining_validators)
     {
         std::string const & path = tmp_name.get_path().string();
         const char * argv[] = {"./argument_parser_test", "-s", path.c_str()};
-        seqan3::argument_parser parser{"test_parser", 3, argv, false};
+        seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
         parser.add_option(option_value, 's', "string-option", "desc",
                           seqan3::option_spec::DEFAULT,
@@ -1191,7 +1191,7 @@ TEST(validator_test, chaining_validators)
     {
         std::string const & path = tmp_name.get_path().string();
         const char * argv[] = {"./argument_parser_test", "-s", path.c_str()};
-        seqan3::argument_parser parser{"test_parser", 3, argv, false};
+        seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
         parser.add_option(option_value, 's', "string-option", "desc",
                           seqan3::option_spec::DEFAULT,
@@ -1209,7 +1209,7 @@ TEST(validator_test, chaining_validators)
     {
         option_value.clear();
         const char * argv[] = {"./argument_parser_test", "-h"};
-        seqan3::argument_parser parser{"test_parser", 2, argv, false};
+        seqan3::argument_parser parser{"test_parser", 2, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
         parser.add_option(option_value, 's', "string-option", "desc",
                           seqan3::option_spec::DEFAULT,
@@ -1238,7 +1238,7 @@ TEST(validator_test, chaining_validators)
     {
         option_value.clear();
         const char * argv[] = {"./argument_parser_test", "-h"};
-        seqan3::argument_parser parser{"test_parser", 2, argv, false};
+        seqan3::argument_parser parser{"test_parser", 2, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
         parser.add_option(option_value, 's', "string-option", "desc",
                           seqan3::option_spec::DEFAULT,
@@ -1267,7 +1267,7 @@ TEST(validator_test, chaining_validators)
         std::vector<std::string> option_list_value{};
         std::string const & path = tmp_name.get_path().string();
         const char * argv[] = {"./argument_parser_test", "-s", path.c_str()};
-        seqan3::argument_parser parser{"test_parser", 3, argv, false};
+        seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
         parser.add_option(option_list_value, 's', "string-option", "desc",
                           seqan3::option_spec::DEFAULT,


### PR DESCRIPTION
This resolves an error I recently encountered, namely that

```cpp
seqan3::argument_parser parser{"test_parser", argc, argv, {"subparser1", "subparser2"}};
```

compiles because the list of subparser is implicitely converted to bool and taken as the version_check boolean parameter. :see_no_evil: 

This is fixed by making the boolean parameter into a proper enum (which should have been done anyway).
