### PR TITLE
[FIX] gcc-11: error: incomplete type ‘std::numeric_limits<char>’

### DIFF
--- a/include/seqan3/core/detail/int_types.hpp
+++ b/include/seqan3/core/detail/int_types.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <seqan3/std/concepts>
+#include <limits>
 #include <type_traits>
 
 #include <seqan3/core/platform.hpp>


### PR DESCRIPTION
```c++
/seqan3/include/seqan3/core/detail/int_types.hpp: In instantiation of ‘constexpr const size_t seqan3::detail::size_in_values_v<char>’:
/seqan3/include/seqan3/core/char_operations/transform.hpp:26:38:   required from ‘constexpr char_type seqan3::to_lower(char_type) [with char_type = char]’
/seqan3/include/seqan3/alphabet/aminoacid/aa10li.hpp:138:52:   required from here
/seqan3/include/seqan3/core/detail/int_types.hpp:45:88: error: incomplete type ‘std::numeric_limits<char>’ used in nested name specifier
   45 | constexpr size_t size_in_values_v = static_cast<size_t>(std::numeric_limits<int_t>::max()) -
      |                                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
```