### PR TITLE
Configuration/better config base master

### DIFF
--- a/include/seqan3/alignment/configuration/align_config_band.hpp
+++ b/include/seqan3/alignment/configuration/align_config_band.hpp
@@ -68,7 +68,7 @@ struct upper_diagonal : public seqan3::detail::strong_type<int32_t, upper_diagon
  *
  * \include test/snippet/alignment/configuration/align_cfg_band_example.cpp
  */
-class band_fixed_size : public pipeable_config_element<band_fixed_size>
+class band_fixed_size : private pipeable_config_element
 {
 public:
     //!\brief The selected lower diagonal. Defaults to `std::%numeric_limits<int32_t>::%lowest()`.

--- a/include/seqan3/alignment/configuration/align_config_gap_cost_affine.hpp
+++ b/include/seqan3/alignment/configuration/align_config_gap_cost_affine.hpp
@@ -70,7 +70,7 @@ struct open_score : seqan3::detail::strong_type<int32_t, open_score, seqan3::det
  * \include test/snippet/alignment/configuration/align_cfg_gap_cost_affine_example.cpp
  *
  */
-class gap_cost_affine : public pipeable_config_element<gap_cost_affine>
+class gap_cost_affine : private pipeable_config_element
 {
 public:
     //!\brief The score per consecutive sequence of gaps. Defaults to 0.

--- a/include/seqan3/alignment/configuration/align_config_method.hpp
+++ b/include/seqan3/alignment/configuration/align_config_method.hpp
@@ -39,7 +39,7 @@ namespace seqan3::align_cfg
  *
  * \include test/snippet/alignment/configuration/align_cfg_method_local.cpp
  */
-class method_local : public pipeable_config_element<method_local>
+class method_local : private pipeable_config_element
 {
 public:
     /*!\name Constructors, destructor and assignment
@@ -102,7 +102,7 @@ struct free_end_gaps_sequence2_trailing : public seqan3::detail::strong_type<boo
  * \ingroup alignment_configuration
  * \copydetails seqan3::align_cfg::method_local
  */
-class method_global : public pipeable_config_element<method_global>
+class method_global : private pipeable_config_element
 {
 public:
     /*!\name Constructors, destructor and assignment

--- a/include/seqan3/alignment/configuration/align_config_min_score.hpp
+++ b/include/seqan3/alignment/configuration/align_config_min_score.hpp
@@ -33,7 +33,7 @@ namespace seqan3::align_cfg
  *
  * \include test/snippet/alignment/configuration/align_cfg_min_score_example.cpp
  */
-class min_score : public pipeable_config_element<min_score>
+class min_score : private pipeable_config_element
 {
 public:
     //!\brief Minimal score for the distance computation [default: -infinity].

--- a/include/seqan3/alignment/configuration/align_config_on_result.hpp
+++ b/include/seqan3/alignment/configuration/align_config_on_result.hpp
@@ -51,7 +51,7 @@ namespace seqan3::align_cfg
  * \include test/snippet/alignment/configuration/align_cfg_on_result.cpp
  */
 template <std::move_constructible callback_t>
-class on_result : public seqan3::pipeable_config_element<on_result<callback_t>>
+class on_result : private seqan3::pipeable_config_element
 {
 public:
     //!\brief The stored callable which will be invoked with the alignment result.

--- a/include/seqan3/alignment/configuration/align_config_output.hpp
+++ b/include/seqan3/alignment/configuration/align_config_output.hpp
@@ -39,7 +39,7 @@ namespace seqan3::align_cfg
  * \see seqan3::align_cfg::output_sequence1_id
  * \see seqan3::align_cfg::output_sequence2_id
  */
-class output_score : public pipeable_config_element<output_score>
+class output_score : private pipeable_config_element
 {
 public:
     /*!\name Constructor, destructor and assignment
@@ -82,7 +82,7 @@ public:
  * \see seqan3::align_cfg::output_sequence1_id
  * \see seqan3::align_cfg::output_sequence2_id
  */
-class output_end_position : public pipeable_config_element<output_end_position>
+class output_end_position : private pipeable_config_element
 {
 public:
     /*!\name Constructor, destructor and assignment
@@ -125,7 +125,7 @@ public:
  * \see seqan3::align_cfg::output_sequence1_id
  * \see seqan3::align_cfg::output_sequence2_id
  */
-class output_begin_position : public pipeable_config_element<output_begin_position>
+class output_begin_position : private pipeable_config_element
 {
 public:
     /*!\name Constructor, destructor and assignment
@@ -164,7 +164,7 @@ public:
  * \see seqan3::align_cfg::output_sequence1_id
  * \see seqan3::align_cfg::output_sequence2_id
  */
-class output_alignment : public pipeable_config_element<output_alignment>
+class output_alignment : private pipeable_config_element
 {
 public:
     /*!\name Constructor, destructor and assignment
@@ -203,7 +203,7 @@ public:
  * \see seqan3::align_cfg::output_alignment
  * \see seqan3::align_cfg::output_sequence2_id
  */
-class output_sequence1_id : public pipeable_config_element<output_sequence1_id>
+class output_sequence1_id : private pipeable_config_element
 {
 public:
     /*!\name Constructor, destructor and assignment
@@ -242,7 +242,7 @@ public:
  * \see seqan3::align_cfg::output_alignment
  * \see seqan3::align_cfg::output_sequence1_id
  */
-class output_sequence2_id : public pipeable_config_element<output_sequence2_id>
+class output_sequence2_id : private pipeable_config_element
 {
 public:
     /*!\name Constructor, destructor and assignment

--- a/include/seqan3/alignment/configuration/align_config_result_type.hpp
+++ b/include/seqan3/alignment/configuration/align_config_result_type.hpp
@@ -42,7 +42,7 @@ template <typename alignment_result_t>
 //!\cond
     requires seqan3::detail::is_type_specialisation_of_v<alignment_result_t, seqan3::alignment_result>
 //!\endcond
-class result_type : public pipeable_config_element<result_type<alignment_result_t>>
+class result_type : private pipeable_config_element
 {
 public:
     //!\brief The result type.

--- a/include/seqan3/alignment/configuration/align_config_score_type.hpp
+++ b/include/seqan3/alignment/configuration/align_config_score_type.hpp
@@ -32,7 +32,7 @@ namespace seqan3::align_cfg
  * \include test/snippet/alignment/configuration/align_cfg_score_type.cpp
  */
 template <arithmetic score_t>
-class score_type : public pipeable_config_element<score_type<score_t>>
+class score_type : private pipeable_config_element
 {
 public:
 

--- a/include/seqan3/alignment/configuration/align_config_scoring_scheme.hpp
+++ b/include/seqan3/alignment/configuration/align_config_scoring_scheme.hpp
@@ -41,8 +41,9 @@ namespace seqan3::align_cfg
  * \include test/snippet/alignment/configuration/minimal_alignment_config.cpp
  */
 template <std::semiregular scoring_scheme_t>
-struct scoring_scheme : public pipeable_config_element<scoring_scheme<scoring_scheme_t>>
+class scoring_scheme : private pipeable_config_element
 {
+public:
     //!\brief The scoring scheme to be used in the alignment algorithm.
     scoring_scheme_t scheme{};
 

--- a/include/seqan3/alignment/configuration/align_config_vectorised.hpp
+++ b/include/seqan3/alignment/configuration/align_config_vectorised.hpp
@@ -38,7 +38,7 @@ namespace seqan3::align_cfg
  *
  * \include test/snippet/alignment/configuration/align_cfg_vectorised_example.cpp
  */
-class vectorised : public pipeable_config_element<vectorised>
+class vectorised : private pipeable_config_element
 {
 public:
     /*!\name Constructor, destructor and assignment

--- a/include/seqan3/alignment/configuration/detail.hpp
+++ b/include/seqan3/alignment/configuration/detail.hpp
@@ -12,7 +12,7 @@
 
 #pragma once
 
-#include <seqan3/core/algorithm/configuration_utility.hpp>
+#include <seqan3/core/algorithm/concept.hpp>
 
 namespace seqan3::detail
 {

--- a/include/seqan3/alignment/pairwise/detail/policy_scoring_scheme.hpp
+++ b/include/seqan3/alignment/pairwise/detail/policy_scoring_scheme.hpp
@@ -13,6 +13,7 @@
 #pragma once
 
 #include <seqan3/alignment/configuration/align_config_scoring_scheme.hpp>
+#include <seqan3/core/algorithm/configuration.hpp>
 
 namespace seqan3::detail
 {

--- a/include/seqan3/core/algorithm/all.hpp
+++ b/include/seqan3/core/algorithm/all.hpp
@@ -26,7 +26,7 @@
  * ### Usage
  *
  * The basis of any algorithm configuration are configuration elements. These are objects that handle a specific
- * setting and must satisfy the seqan3::detail::config_element_specialisation. The following snippet demonstrates a
+ * setting and must satisfy the seqan3::config_element_specialisation. The following snippet demonstrates a
  * basic setup for such configuration elements.
  *
  * \include test/snippet/core/algorithm/configuration_setup.cpp

--- a/include/seqan3/core/algorithm/concept.hpp
+++ b/include/seqan3/core/algorithm/concept.hpp
@@ -33,6 +33,18 @@ namespace seqan3::detail
 {
 
 // ----------------------------------------------------------------------------
+// compatibility_table
+// ----------------------------------------------------------------------------
+
+/*!\brief Declaration of algorithm specific compatibility table.
+ * \ingroup algorithm
+ * \tparam algorithm_id_type The type of the algorithm specific id. Algorithm configurations must maintain
+ *                           this table to allow validation checks.
+ */
+template <typename algorithm_id_type>
+inline constexpr std::array<std::array<void, 0>, 0> compatibility_table;
+
+// ----------------------------------------------------------------------------
 // Concept config_element_specialisation
 // ----------------------------------------------------------------------------
 

--- a/include/seqan3/core/algorithm/concept.hpp
+++ b/include/seqan3/core/algorithm/concept.hpp
@@ -192,8 +192,8 @@ class configuration;
  *        or configuration.
  * \ingroup algorithm
  *
- * \tparam config1_t The type of the configuration element to test.
- * \tparam config2_t Either the type of another configuration element or another configuration.
+ * \tparam config1_t Either the type of a configuration element or a configuration.
+ * \tparam config2_t Either the type of a configuration element or a configuration.
  *
  * \details
  *
@@ -202,16 +202,28 @@ class configuration;
  * be expanded to every configuration element contained in the configuration type. Only if `config1_t` is combineable
  * with every element stored inside of the given configuration, this helper variable template evaluates to `true`,
  * otherwise `false`.
+ * If `config1_t` is a seqan3::configuration the same applies in combination with the configuration element `config2_t`.
+ * If both `config1_t` and `config2_t` are seqan3::configuration types, then the cartesian product between the
+ * configuration elements of the first configuration and the second configuration are tested.
  */
 template <typename config1_t, typename config2_t>
 inline constexpr bool is_config_element_combineable_v = detail::config_element_pipeable_with<config1_t, config2_t>;
 
 //!\cond
-// Specialised for configs2_t == seqan3::configuration
-template <typename config1_t, typename ...configs_t>
-    requires (sizeof...(configs_t) > 0)
-inline constexpr bool is_config_element_combineable_v<config1_t, configuration<configs_t...>> =
-    (detail::config_element_pipeable_with<config1_t, configs_t> && ...);
+// Specialised for config2_t == seqan3::configuration
+template <typename config1_t, typename ...configs2_t>
+inline constexpr bool is_config_element_combineable_v<config1_t, configuration<configs2_t...>> =
+    (detail::config_element_pipeable_with<config1_t, configs2_t> && ...);
+
+// Specialised for config1_t == seqan3::configuration
+template <typename ...configs1_t, typename config2_t>
+inline constexpr bool is_config_element_combineable_v<configuration<configs1_t...>, config2_t> =
+    (detail::config_element_pipeable_with<configs1_t, config2_t> && ...);
+
+// Specialised for config1_t == seqan3::configuration && config2_t == seqan3::configuration
+template <typename ...configs1_t, typename ...configs2_t>
+inline constexpr bool is_config_element_combineable_v<configuration<configs1_t...>, configuration<configs2_t...>> =
+    (is_config_element_combineable_v<configs1_t, configuration<configs2_t...>> && ...);
 //!\endcond
 
 } // namespace seqan3

--- a/include/seqan3/core/algorithm/concept.hpp
+++ b/include/seqan3/core/algorithm/concept.hpp
@@ -179,3 +179,39 @@ SEQAN3_CONCEPT config_element_pipeable_with =
 //!\endcond
 
 } // namespace seqan3::detail
+
+namespace seqan3
+{
+//!\cond
+// Forward declaration.
+template <detail::config_element_specialisation ... configs_t>
+class configuration;
+//!\endcond
+
+/*!\brief Helper variable template to test if a configuration element is combineable with another configuration element
+ *        or configuration.
+ * \ingroup algorithm
+ *
+ * \tparam config1_t The type of the configuration element to test.
+ * \tparam config2_t Either the type of another configuration element or another configuration.
+ *
+ * \details
+ *
+ * This helper variable template checks if `config1_t` fulfills the concept requirements
+ * seqan3::detail::config_element_pipeable_with `config2_t`. If `config2_t` is a seqan3::configuration, the check will
+ * be expanded to every configuration element contained in the configuration type. Only if `config1_t` is combineable
+ * with every element stored inside of the given configuration, this helper variable template evaluates to `true`,
+ * otherwise `false`.
+ */
+template <typename config1_t, typename config2_t>
+inline constexpr bool is_config_element_combineable_v = detail::config_element_pipeable_with<config1_t, config2_t>;
+
+//!\cond
+// Specialised for configs2_t == seqan3::configuration
+template <typename config1_t, typename ...configs_t>
+    requires (sizeof...(configs_t) > 0)
+inline constexpr bool is_config_element_combineable_v<config1_t, configuration<configs_t...>> =
+    (detail::config_element_pipeable_with<config1_t, configs_t> && ...);
+//!\endcond
+
+} // namespace seqan3

--- a/include/seqan3/core/algorithm/concept.hpp
+++ b/include/seqan3/core/algorithm/concept.hpp
@@ -12,13 +12,12 @@
 
 #pragma once
 
+#include <array>
+#include <seqan3/std/concepts>
 #include <functional>
 #include <type_traits>
 
-#include <meta/meta.hpp>
-
 #include <seqan3/core/type_traits/template_inspection.hpp>
-#include <seqan3/std/concepts>
 
 namespace seqan3::detail
 {

--- a/include/seqan3/core/algorithm/concept.hpp
+++ b/include/seqan3/core/algorithm/concept.hpp
@@ -24,7 +24,6 @@ namespace seqan3
 {
 //!\cond
 // Forward declarations
-template <typename derived_t, typename value_t = void>
 struct pipeable_config_element;
 //!\endcond
 }
@@ -138,7 +137,7 @@ public:
 template <typename config_t>
 SEQAN3_CONCEPT config_element_specialisation = requires
 {
-    requires std::is_base_of_v<seqan3::pipeable_config_element<config_t>, config_t>;
+    requires std::is_base_of_v<seqan3::pipeable_config_element, config_t>;
     requires std::semiregular<config_t>;
 #ifdef SEQAN3_WORKAROUND_GCC_PIPEABLE_CONFIG_CONCEPT
     requires config_id_accessor::has_id<config_t>;

--- a/include/seqan3/core/algorithm/concept.hpp
+++ b/include/seqan3/core/algorithm/concept.hpp
@@ -61,6 +61,10 @@ inline constexpr std::array<std::array<void, 0>, 0> compatibility_table;
 struct config_id_accessor
 {
 private:
+    //!\brief Helper variable template to convert the configuration enum identifier to an integer.
+    template <typename config_t>
+    static constexpr int32_t as_int = static_cast<int32_t>(std::remove_cvref_t<config_t>::id);
+
     //!\brief Helper function to check if static id member exists.
     template <typename config_t>
     static constexpr auto has_id_member(int) -> decltype((static_cast<void>(config_t::id), true))
@@ -76,6 +80,37 @@ private:
     }
 
 public:
+    //!\brief Type alias for the internal enumeration type that represents the id.
+    template <typename config_t>
+    using id_type = std::remove_cvref_t<decltype(config_t::id)>;
+
+    /*!\brief Checks if two configuration types are compatible.
+     *
+     * \tparam config1_t The type of the first configuration to check against the second.
+     * \tparam config2_t The type of the second configuration.
+     *
+     * \details
+     *
+     * Uses the seqan3::detail::compatibility_table of the corresponding configuration element domain to check
+     * if both configurations can be combined.
+     */
+    template <typename config1_t, typename config2_t>
+    static constexpr auto is_compatible()
+    {
+        if constexpr (has_id_member<config1_t>(0) && has_id_member<config2_t>(0)) // needed for gcc-9 -stc=c++2a
+        {
+            if constexpr (std::same_as<id_type<config1_t>, id_type<config2_t>>) // needed for gcc-7 and gcc-8
+                return std::bool_constant<compatibility_table<id_type<config1_t>>[as_int<config1_t>]
+                                                                                 [as_int<config2_t>]>{};
+            else
+                return std::false_type{};
+        }
+        else
+        {
+            return std::false_type{};
+        }
+    }
+
     //!\brief Variable template that evaluates to `true` if the type has a static id member, otherwise `false`.
     template <typename config_t>
     static constexpr bool has_id = has_id_member<config_t>(0);
@@ -111,6 +146,36 @@ SEQAN3_CONCEPT config_element_specialisation = requires
     { config_t::id };
 #endif // SEQAN3_WORKAROUND_GCC_PIPEABLE_CONFIG_CONCEPT
 };
+//!\endcond
+
+/*!\interface seqan3::detail::config_element_pipeable_with <>
+ * \brief Concept to check if one configuration element can be combined with another configuration element.
+ * \ingroup algorithm
+ *
+ * \tparam config1_t The type of the first configuration element.
+ * \tparam config2_t The type of the second configuration element.
+ *
+ * \details
+ *
+ * This concept is fulfilled if:
+ *  * both configurations model seqan3::detail::config_element_specialisation,
+ *  * are defined within the same algorithm configuration domain,
+ *  * a seqan3::detail::compatibility_table is defined for the configuration elements and
+ *    returns `true` for both configurations.
+ */
+//!\cond
+template <typename config1_t, typename config2_t>
+SEQAN3_CONCEPT config_element_pipeable_with =
+    config_element_specialisation<config1_t> &&
+    config_element_specialisation<config2_t> &&
+#ifdef SEQAN3_WORKAROUND_GCC_PIPEABLE_CONFIG_CONCEPT
+    std::same_as<config_id_accessor::id_type<config1_t>, config_id_accessor::id_type<config2_t>> &&
+    decltype(config_id_accessor::is_compatible<config1_t, config2_t>())::value;
+#else // ^^^ workaround / no workaround vvv
+    std::same_as<std::remove_cvref_t<decltype(config1_t::id)>, std::remove_cvref_t<decltype(config2_t::id)>> &&
+    compatibility_table<std::remove_cvref_t<decltype(config1_t::id)>>[static_cast<int32_t>(config1_t::id)]
+                                                                     [static_cast<int32_t>(config2_t::id)];
+#endif // SEQAN3_WORKAROUND_GCC_PIPEABLE_CONFIG_CONCEPT
 //!\endcond
 
 } // namespace seqan3::detail

--- a/include/seqan3/core/algorithm/configuration.hpp
+++ b/include/seqan3/core/algorithm/configuration.hpp
@@ -12,18 +12,15 @@
 
 #pragma once
 
+#include <seqan3/std/concepts>
 #include <tuple>
-
-#include <meta/meta.hpp>
 
 #include <seqan3/core/algorithm/concept.hpp>
 #include <seqan3/core/algorithm/configuration_utility.hpp>
-#include <seqan3/core/algorithm/pipeable_config_element.hpp>
 #include <seqan3/core/tuple_utility.hpp>
 #include <seqan3/core/type_list/type_list.hpp>
 #include <seqan3/core/type_list/traits.hpp>
 #include <seqan3/core/type_traits/template_inspection.hpp>
-#include <seqan3/std/concepts>
 
 namespace seqan3
 {

--- a/include/seqan3/core/algorithm/configuration.hpp
+++ b/include/seqan3/core/algorithm/configuration.hpp
@@ -36,7 +36,7 @@ namespace seqan3
  * \ingroup algorithm
  *
  * \tparam configs_t Template parameter pack containing all configuration elements; Must model
- *                   seqan3::detail::config_element_specialisation
+ *                   seqan3::config_element_specialisation
  *
  * \details
  *
@@ -44,11 +44,11 @@ namespace seqan3
  * configurations for a specific algorithm. It extends the standard tuple interface with some useful functions to modify
  * and query the user configurations.
  */
-template <detail::config_element_specialisation ... configs_t>
+template <config_element_specialisation ... configs_t>
 class configuration : public std::tuple<configs_t...>
 {
     //!\brief Friend declaration for other instances of the configuration.
-    template <detail::config_element_specialisation ... _configs_t>
+    template <config_element_specialisation ... _configs_t>
     friend class configuration;
 
 public:
@@ -69,13 +69,13 @@ public:
 
     /*!\brief Constructs a configuration from a single configuration element.
      * \tparam config_element_t The configuration element to add; must model
-     *                          seqan3::detail::config_element_specialisation.
+     *                          seqan3::config_element_specialisation.
      * \param[in] config_element The configuration element to construct the configuration from.
      */
     template <typename config_element_t>
     //!\cond
         requires (!std::same_as<std::remove_cvref_t<config_element_t>, configuration>) &&
-                 detail::config_element_specialisation<std::remove_cvref_t<config_element_t>>
+                 config_element_specialisation<std::remove_cvref_t<config_element_t>>
     //!\endcond
     constexpr configuration(config_element_t && config_element) :
         base_type{std::forward<config_element_t>(config_element)}
@@ -200,7 +200,7 @@ public:
     /*!\brief Returns a new configuration by appending the given configuration to the current one.
      *
      * \tparam other_configuration_t Another configuration type or configuration element type; each configuration
-     *                               element must model seqan3::detail::config_element_pipeable_with each of the
+     *                               element must model seqan3::config_element_pipeable_with each of the
      *                               configurations elements of the current configuration.
      *
      * \param[in] other_config The other configuration to append to the current one.
@@ -218,7 +218,7 @@ public:
     //!\endcond
     constexpr auto append(other_configuration_t && other_config) const
     {
-        if constexpr (detail::config_element_specialisation<std::remove_cvref_t<other_configuration_t>>)
+        if constexpr (config_element_specialisation<std::remove_cvref_t<other_configuration_t>>)
         {
             return configuration<configs_t..., std::remove_cvref_t<other_configuration_t>>
             {
@@ -358,7 +358,7 @@ private:
  * \details
  *
  * The the two operands can be either a seqan3::configuration object or a
- * \ref seqan3::detail::config_element_specialisation "configuration element". The right hand side operand is then
+ * \ref seqan3::config_element_specialisation "configuration element". The right hand side operand is then
  * appended to the left hand side operand by creating a new seqan3::configuration object. Neither `lhs` nor `rhs` will
  * be modified.
  */
@@ -371,8 +371,8 @@ constexpr auto operator|(lhs_config_t && lhs, rhs_config_t && rhs)
     using pure_lhs_t = std::remove_cvref_t<lhs_config_t>;
     using pure_rhs_t = std::remove_cvref_t<rhs_config_t>;
 
-    constexpr bool lhs_is_config_element = detail::config_element_specialisation<pure_lhs_t>;
-    constexpr bool rhs_is_config_element = detail::config_element_specialisation<pure_rhs_t>;
+    constexpr bool lhs_is_config_element = config_element_specialisation<pure_lhs_t>;
+    constexpr bool rhs_is_config_element = config_element_specialisation<pure_rhs_t>;
 
     if constexpr (lhs_is_config_element && rhs_is_config_element)
         return configuration{std::forward<lhs_config_t>(lhs)}.append(std::forward<rhs_config_t>(rhs));
@@ -393,7 +393,7 @@ constexpr auto operator|(lhs_config_t && lhs, rhs_config_t && rhs)
  */
 template <typename config_t>
 //!\cond
-    requires detail::config_element_specialisation<std::remove_cvref_t<config_t>>
+    requires config_element_specialisation<std::remove_cvref_t<config_t>>
 //!\endcond
 configuration(config_t &&) -> configuration<std::remove_cvref_t<config_t>>;
 //!\}
@@ -482,7 +482,7 @@ namespace std
  * \see std::tuple_size_v
  * \ingroup algorithm
  */
-template <seqan3::detail::config_element_specialisation ... configs_t>
+template <seqan3::config_element_specialisation ... configs_t>
 struct tuple_size<seqan3::configuration<configs_t...>>
 {
     //!\brief The number of elements.
@@ -494,7 +494,7 @@ struct tuple_size<seqan3::configuration<configs_t...>>
  * \see [std::tuple_element](https://en.cppreference.com/w/cpp/utility/tuple/tuple_element)
  * \ingroup algorithm
  */
-template <size_t pos, seqan3::detail::config_element_specialisation ... configs_t>
+template <size_t pos, seqan3::config_element_specialisation ... configs_t>
 struct tuple_element<pos, seqan3::configuration<configs_t...>>
 {
     //!\brief The type of the config at position `pos`

--- a/include/seqan3/core/algorithm/configuration.hpp
+++ b/include/seqan3/core/algorithm/configuration.hpp
@@ -27,40 +27,6 @@
 namespace seqan3
 {
 
-//!\cond
-// Forward declaration for friend declaration definitions below.
-template <detail::config_element_specialisation ... configs_t>
-class configuration;
-
-template <typename lhs_derived_t, typename lhs_value_t, typename rhs_derived_t, typename rhs_value_t>
-constexpr auto operator|(pipeable_config_element<lhs_derived_t, lhs_value_t> && lhs,
-                         pipeable_config_element<rhs_derived_t, rhs_value_t> && rhs)
-{
-    return configuration{static_cast<lhs_derived_t &&>(lhs)}.push_back(static_cast<rhs_derived_t &&>(rhs));
-}
-
-template <typename lhs_derived_t, typename lhs_value_t, typename rhs_derived_t, typename rhs_value_t>
-constexpr auto operator|(pipeable_config_element<lhs_derived_t, lhs_value_t> && lhs,
-                         pipeable_config_element<rhs_derived_t, rhs_value_t> const & rhs)
-{
-    return configuration{static_cast<lhs_derived_t &&>(lhs)}.push_back(static_cast<rhs_derived_t const &>(rhs));
-}
-
-template <typename lhs_derived_t, typename lhs_value_t, typename rhs_derived_t, typename rhs_value_t>
-constexpr auto operator|(pipeable_config_element<lhs_derived_t, lhs_value_t> const & lhs,
-                         pipeable_config_element<rhs_derived_t, rhs_value_t> && rhs)
-{
-    return configuration{static_cast<lhs_derived_t const &>(lhs)}.push_back(static_cast<rhs_derived_t &&>(rhs));
-}
-
-template <typename lhs_derived_t, typename lhs_value_t, typename rhs_derived_t, typename rhs_value_t>
-constexpr auto operator|(pipeable_config_element<lhs_derived_t, lhs_value_t> const & lhs,
-                         pipeable_config_element<rhs_derived_t, rhs_value_t> const & rhs)
-{
-    return configuration{static_cast<lhs_derived_t const &>(lhs)}.push_back(static_cast<rhs_derived_t const &>(rhs));
-}
-//!\endcond
-
 // ----------------------------------------------------------------------------
 // configuration
 // ----------------------------------------------------------------------------
@@ -281,169 +247,7 @@ public:
         }
     }
 
-    /*!\name Pipe operator
-     * \{
-     */
-    /*!\brief Combines two seqan3::pipeable_config_element objects to a seqan3::configuration.
-     * \tparam lhs_derived_t The derived type of the left hand side operand.
-     * \tparam lhs_value_t   The value type of the left hand side operand.
-     * \tparam rhs_derived_t The derived type of the right hand side operand.
-     * \tparam rhs_value_t   The value type of the right hand side operand.
-     * \param[in] lhs        The left hand operand.
-     * \param[in] rhs        The right hand operand.
-     * \returns A new seqan3::configuration containing `lhs` and `rhs`.
-     */
-    template <typename lhs_derived_t, typename lhs_value_t, typename rhs_derived_t, typename rhs_value_t>
-    friend constexpr auto operator|(pipeable_config_element<lhs_derived_t, lhs_value_t> && lhs,
-                                    pipeable_config_element<rhs_derived_t, rhs_value_t> && rhs);
-
-    //!\overload
-    template <typename lhs_derived_t, typename lhs_value_t, typename rhs_derived_t, typename rhs_value_t>
-    friend constexpr auto operator|(pipeable_config_element<lhs_derived_t, lhs_value_t> && lhs,
-                                    pipeable_config_element<rhs_derived_t, rhs_value_t> const & rhs);
-
-    //!\overload
-    template <typename lhs_derived_t, typename lhs_value_t, typename rhs_derived_t, typename rhs_value_t>
-    friend constexpr auto operator|(pipeable_config_element<lhs_derived_t, lhs_value_t> const & lhs,
-                                    pipeable_config_element<rhs_derived_t, rhs_value_t> && rhs);
-
-    //!\overload
-    template <typename lhs_derived_t, typename lhs_value_t, typename rhs_derived_t, typename rhs_value_t>
-    friend constexpr auto operator|(pipeable_config_element<lhs_derived_t, lhs_value_t> const & lhs,
-                                    pipeable_config_element<rhs_derived_t, rhs_value_t> const & rhs);
-
-    /*!\brief Combines a seqan3::configuration with a seqan3::pipeable_config_element.
-     * \tparam rhs_derived_t The derived type of the right hand side operand.
-     * \tparam rhs_value_t   The value type of the right hand side operand.
-     * \param[in] lhs     The left hand operand.
-     * \param[in] rhs     The right hand operand.
-     * \returns A new seqan3::configuration adding `rhs` to the passed `lhs` object.
-     */
-    template <typename rhs_derived_t, typename rhs_value_t>
-    friend constexpr auto operator|(configuration && lhs,
-                                    pipeable_config_element<rhs_derived_t, rhs_value_t> && rhs)
-    {
-        return std::move(lhs).push_back(static_cast<rhs_derived_t &&>(rhs));
-    }
-
-    //!\overload
-    template <typename rhs_derived_t, typename rhs_value_t>
-    friend constexpr auto operator|(configuration const & lhs,
-                                    pipeable_config_element<rhs_derived_t, rhs_value_t> && rhs)
-    {
-        return lhs.push_back(static_cast<rhs_derived_t &&>(rhs));
-    }
-
-    //!\overload
-    template <typename rhs_derived_t, typename rhs_value_t>
-    friend constexpr auto operator|(configuration && lhs,
-                                    pipeable_config_element<rhs_derived_t, rhs_value_t> const & rhs)
-    {
-        return std::move(lhs).push_back(static_cast<rhs_derived_t const &>(rhs));
-    }
-
-    //!\overload
-    template <typename rhs_derived_t, typename rhs_value_t>
-    friend constexpr auto operator|(configuration const & lhs,
-                                    pipeable_config_element<rhs_derived_t, rhs_value_t> const & rhs)
-    {
-        return lhs.push_back(static_cast<rhs_derived_t const &>(rhs));
-    }
-
-    /*!\brief Combines a seqan3::pipeable_config_element with a seqan3::configuration.
-     * \tparam lhs_derived_t The derived type of the left hand side operand.
-     * \tparam lhs_value_t   The value type of the left hand side operand.
-     * \param[in] lhs     The left hand operand.
-     * \param[in] rhs     The right hand operand.
-     * \returns A new seqan3::configuration adding `lhs` to the passed `rhs` object.
-     */
-    template <typename lhs_derived_t, typename lhs_value_t>
-    friend constexpr auto operator|(pipeable_config_element<lhs_derived_t, lhs_value_t> && lhs,
-                                    configuration && rhs)
-    {
-        return std::move(rhs) | std::move(lhs);
-    }
-
-    //!\overload
-    template <typename lhs_derived_t, typename lhs_value_t>
-    friend constexpr auto operator|(pipeable_config_element<lhs_derived_t, lhs_value_t> && lhs,
-                                    configuration const & rhs)
-    {
-        return rhs | std::move(lhs);
-    }
-
-    //!\overload
-    template <typename lhs_derived_t, typename lhs_value_t>
-    friend constexpr auto operator|(pipeable_config_element<lhs_derived_t, lhs_value_t> const & lhs,
-                                    configuration && rhs)
-    {
-        return std::move(rhs) | lhs;
-    }
-
-    //!\overload
-    template <typename lhs_derived_t, typename lhs_value_t>
-    friend constexpr auto operator|(pipeable_config_element<lhs_derived_t, lhs_value_t> const & lhs,
-                                    configuration const & rhs)
-    {
-        return rhs | lhs;
-    }
-
-    /*!\brief Combines two seqan3::configuration objects.
-     * \tparam rhs_configs_t  A template parameter pack for the second seqan3::configuration operand.
-     * \param[in] lhs         The left hand operand.
-     * \param[in] rhs         The right hand operand.
-     * \returns A new seqan3::configuration as the result of concatenating `lhs` and `rhs`.
-     */
-    template <typename ...rhs_configs_t>
-    friend constexpr auto operator|(configuration && lhs,
-                                    configuration<rhs_configs_t...> && rhs)
-    {
-        using lhs_base_t = typename configuration::base_type;
-        using rhs_base_t = typename configuration<rhs_configs_t...>::base_type;
-
-        return make_configuration(std::tuple_cat(static_cast<lhs_base_t>(std::move(lhs)),
-                                                 static_cast<rhs_base_t>(std::move(rhs))));
-    }
-
-    //!\overload
-    template <typename ...rhs_configs_t>
-    friend constexpr auto operator|(configuration const & lhs,
-                                    configuration<rhs_configs_t...> && rhs)
-    {
-        using lhs_base_t = typename configuration::base_type;
-        using rhs_base_t = typename configuration<rhs_configs_t...>::base_type;
-
-        return make_configuration(std::tuple_cat(static_cast<lhs_base_t>(lhs),
-                                                 static_cast<rhs_base_t>(std::move(rhs))));
-    }
-
-    //!\overload
-    template <typename ...rhs_configs_t>
-    friend constexpr auto operator|(configuration && lhs,
-                                    configuration<rhs_configs_t...> const & rhs)
-    {
-        using lhs_base_t = typename configuration::base_type;
-        using rhs_base_t = typename configuration<rhs_configs_t...>::base_type;
-
-        return make_configuration(std::tuple_cat(static_cast<lhs_base_t>(std::move(lhs)),
-                                                 static_cast<rhs_base_t>(rhs)));
-    }
-
-    //!\overload
-    template <typename ...rhs_configs_t>
-    friend constexpr auto operator|(configuration const & lhs,
-                                    configuration<rhs_configs_t...> const & rhs)
-    {
-        using lhs_base_t = typename configuration::base_type;
-        using rhs_base_t = typename configuration<rhs_configs_t...>::base_type;
-
-        return make_configuration(std::tuple_cat(static_cast<lhs_base_t>(lhs),
-                                                 static_cast<rhs_base_t>(rhs)));
-    }
-    //!\}
-
 private:
-
     /*!\name Internal constructor
      * \{
      */
@@ -613,6 +417,48 @@ private:
         }
     }
 };
+
+/*!\brief Combines configuration and configuration elements to create a new configuration object.
+ * \relates seqan3::configuration
+ *
+ * \tparam lhs_config_t The type of the left hand side operand; the seqan3::is_config_element_combineable_v variable
+ *                      template must evaluate to true for both operand types.
+ * \tparam rhs_config_t The type of the right hand side operand; the seqan3::is_config_element_combineable_v variable
+ *                      template must evaluate to true for both operand types.
+ *
+ * \param[in] lhs The left hand operand.
+ * \param[in] rhs The right hand operand.
+ *
+ * \returns A new seqan3::configuration containing `lhs` and `rhs`.
+ *
+ * \details
+ *
+ * The the two operands can be either a seqan3::configuration object or a
+ * \ref seqan3::detail::config_element_specialisation "configuration element". The right hand side operand is then
+ * appended to the left hand side operand by creating a new seqan3::configuration object. Neither `lhs` nor `rhs` will
+ * be modified.
+ */
+template <typename lhs_config_t, typename rhs_config_t>
+//!\cond
+    requires (is_config_element_combineable_v<std::remove_cvref_t<lhs_config_t>, std::remove_cvref_t<rhs_config_t>>)
+//!\endcond
+constexpr auto operator|(lhs_config_t && lhs, rhs_config_t && rhs)
+{
+    using pure_lhs_t = std::remove_cvref_t<lhs_config_t>;
+    using pure_rhs_t = std::remove_cvref_t<rhs_config_t>;
+
+    constexpr bool lhs_is_config_element = detail::config_element_specialisation<pure_lhs_t>;
+    constexpr bool rhs_is_config_element = detail::config_element_specialisation<pure_rhs_t>;
+
+    if constexpr (lhs_is_config_element && rhs_is_config_element)
+        return configuration{std::forward<lhs_config_t>(lhs)}.append(std::forward<rhs_config_t>(rhs));
+    else if constexpr (lhs_is_config_element && !rhs_is_config_element)
+        return configuration{std::forward<lhs_config_t>(lhs)}.append(std::forward<rhs_config_t>(rhs));
+    else if constexpr (!lhs_is_config_element && rhs_is_config_element)
+        return std::forward<lhs_config_t>(lhs).append(std::forward<rhs_config_t>(rhs));
+    else
+        return lhs.append(rhs);
+}
 
 /*!\name Type deduction guides
  * \{

--- a/include/seqan3/core/algorithm/configuration.hpp
+++ b/include/seqan3/core/algorithm/configuration.hpp
@@ -101,19 +101,17 @@ public:
     ~configuration()                                           = default; //!< Defaulted.
 
     /*!\brief Constructs a configuration from a single configuration element.
-     * \param elem The element to store.
+     * \tparam config_element_t The configuration element to add; must model
+     *                          seqan3::detail::config_element_specialisation.
+     * \param[in] config_element The configuration element to construct the configuration from.
      */
-    template <typename derived_t, typename value_t>
-    constexpr configuration(pipeable_config_element<derived_t, value_t> && elem) :
-        base_type{static_cast<derived_t &&>(std::move(elem))}
-    {}
-
-    /*!\brief Constructs a configuration from a single configuration element.
-     * \param elem The element to store.
-     */
-    template <typename derived_t, typename value_t>
-    constexpr configuration(pipeable_config_element<derived_t, value_t> const & elem) :
-        base_type{static_cast<derived_t const &>(elem)}
+    template <typename config_element_t>
+    //!\cond
+        requires (!std::same_as<std::remove_cvref_t<config_element_t>, configuration>) &&
+                 detail::config_element_specialisation<std::remove_cvref_t<config_element_t>>
+    //!\endcond
+    constexpr configuration(config_element_t && config_element) :
+        base_type{std::forward<config_element_t>(config_element)}
     {}
     //!\}
 
@@ -572,14 +570,11 @@ private:
 /*!\brief Deduces the correct configuration element type from the passed seqan3::pipeable_config_element.
  * \relates seqan3::configuration
  */
-template <typename derived_t, typename value_t>
-configuration(pipeable_config_element<derived_t, value_t> &&) -> configuration<std::remove_cvref_t<derived_t>>;
-
-/*!\brief Deduces the correct configuration element type from the passed seqan3::pipeable_config_element.
- * \relates seqan3::configuration
- */
-template <typename derived_t, typename value_t>
-configuration(pipeable_config_element<derived_t, value_t> const &) -> configuration<std::remove_cvref_t<derived_t>>;
+template <typename config_t>
+//!\cond
+    requires detail::config_element_specialisation<std::remove_cvref_t<config_t>>
+//!\endcond
+configuration(config_t &&) -> configuration<std::remove_cvref_t<config_t>>;
 //!\}
 
 /*!\name Tuple interface

--- a/include/seqan3/core/algorithm/configuration_element_debug_mode.hpp
+++ b/include/seqan3/core/algorithm/configuration_element_debug_mode.hpp
@@ -26,7 +26,7 @@ namespace seqan3::detail
  * trace matrix of the alignment algorithm.
  */
 template <typename wrapped_config_id_t>
-class debug_mode : public pipeable_config_element<debug_mode<wrapped_config_id_t>>
+class debug_mode : private pipeable_config_element
 {
 public:
     /*!\name Constructors, assignment and destructor

--- a/include/seqan3/core/algorithm/configuration_element_parallel_mode.hpp
+++ b/include/seqan3/core/algorithm/configuration_element_parallel_mode.hpp
@@ -27,7 +27,7 @@ namespace seqan3::detail
  * This type is used to enable the parallel mode of the algorithms.
  */
 template <typename wrapped_config_id_t>
-class parallel_mode : public pipeable_config_element<parallel_mode<wrapped_config_id_t>>
+class parallel_mode : private pipeable_config_element
 {
 public:
     /*!\name Constructors, assignment and destructor

--- a/include/seqan3/core/algorithm/configuration_utility.hpp
+++ b/include/seqan3/core/algorithm/configuration_utility.hpp
@@ -6,57 +6,16 @@
 // -----------------------------------------------------------------------------------------------------
 
 /*!\file
- * \brief Provides functionality to access get function by enum values.
+ * \brief Provides functionality to access get function by template template configs.
  * \author Rene Rahn <rene.rahn AT fu-berlin.de>
  */
 
 #pragma once
 
-#include <array>
-#include <type_traits>
-
-#include <meta/meta.hpp>
-
-#include <seqan3/core/algorithm/concept.hpp>
-#include <seqan3/core/type_list/type_list.hpp>
-#include <seqan3/core/concept/tuple.hpp>
+#include <seqan3/core/type_traits/template_inspection.hpp>
 
 namespace seqan3::detail
 {
-
-// ----------------------------------------------------------------------------
-// Type trait is_configuration_valid
-// ----------------------------------------------------------------------------
-
-/*!\brief Checks if a given type is compatible with a list of other types.
- * \implements seqan3::unary_type_trait
- * \ingroup algorithm
- * \tparam query_t       The type to check for compatibility.
- * \tparam compare_types The types to compare against.
- *
- * \details
- *
- * Checks if the type is from the same algorithm configuration and if it can be combined with any of the
- * existing elements in the current configuration.
- */
-template <config_element_specialisation query_t, config_element_specialisation ... compare_types>
-struct is_configuration_valid :
-    public std::conditional_t<
-        (std::is_same_v<std::remove_cvref_t<decltype(query_t::id)>, std::remove_cvref_t<decltype(compare_types::id)>> && ...) &&
-        (compatibility_table<std::remove_cvref_t<decltype(query_t::id)>>
-                [static_cast<std::underlying_type_t<std::remove_cvref_t<decltype(query_t::id)>>>(query_t::id)]
-                [static_cast<std::underlying_type_t<std::remove_cvref_t<decltype(query_t::id)>>>(compare_types::id)] && ...),
-        std::true_type,  // If condition is true.
-        std::false_type  // If condition is false.
-    >
-{};
-
-/*!\brief Helper variable template to check for valid configuration composites (unary_type_trait shortcut).
- * \relates seqan3::detail::is_configuration_valid
- * \ingroup algorithm
- */
-template <typename query_t, typename ...compare_types>
-inline constexpr bool is_configuration_valid_v = is_configuration_valid<query_t, compare_types...>::value;
 
 // ----------------------------------------------------------------------------
 // Metafunction is_same_configuration_f

--- a/include/seqan3/core/algorithm/configuration_utility.hpp
+++ b/include/seqan3/core/algorithm/configuration_utility.hpp
@@ -25,18 +25,6 @@ namespace seqan3::detail
 {
 
 // ----------------------------------------------------------------------------
-// compatibility_table
-// ----------------------------------------------------------------------------
-
-/*!\brief Declaration of algorithm specific compatibility table.
- * \ingroup algorithm
- * \tparam algorithm_id_type The type of the algorithm specific id. Algorithm configurations must maintain
- *                           this table to allow validation checks.
- */
-template <typename algorithm_id_type>
-inline constexpr std::array<std::array<void, 0>, 0> compatibility_table;
-
-// ----------------------------------------------------------------------------
 // Type trait is_configuration_valid
 // ----------------------------------------------------------------------------
 

--- a/include/seqan3/core/algorithm/pipeable_config_element.hpp
+++ b/include/seqan3/core/algorithm/pipeable_config_element.hpp
@@ -13,36 +13,20 @@
 
 #pragma once
 
-#include <tuple>
-#include <type_traits>
-
-#include <seqan3/core/algorithm/concept.hpp>
-#include <seqan3/core/type_traits/basic.hpp>
+#include <seqan3/core/platform.hpp>
 
 namespace seqan3
 {
 
 /*!\brief Adds pipe interface to configuration elements.
  * \ingroup algorithm
- * \tparam derived_t The type of the derived class.
+ *
+ * \details
+ *
+ * An empty base class which is used by the algorithm configurations to be identified as a configuration element and
+ * to compose an algorithm configuration using the pipe-operator.
  */
-template <typename derived_t>
-class pipeable_config_element<derived_t>
-{
-private:
-    //!\brief Befriend the derived class.
-    friend derived_t;
-
-    /*!\name Constructor, destructor and assignment
-     * \{
-     */
-    constexpr pipeable_config_element() = default; //!< Defaulted.
-    constexpr pipeable_config_element(pipeable_config_element const &) = default; //!< Defaulted.
-    constexpr pipeable_config_element(pipeable_config_element &&) = default; //!< Defaulted.
-    constexpr pipeable_config_element & operator=(pipeable_config_element const &) = default; //!< Defaulted.
-    constexpr pipeable_config_element & operator=(pipeable_config_element &&) = default; //!< Defaulted.
-    ~pipeable_config_element() = default; //!< Defaulted.
-    //!\}
-};
+struct pipeable_config_element
+{};
 
 } // namespace seqan3

--- a/include/seqan3/core/platform.hpp
+++ b/include/seqan3/core/platform.hpp
@@ -275,6 +275,16 @@
 #   endif
 #endif
 
+//!\brief Workaround to access the static id of the configuration elements inside of the concept definition
+//!       (fixed in gcc11).
+#ifndef SEQAN3_WORKAROUND_GCC_PIPEABLE_CONFIG_CONCEPT
+#   if defined(__GNUC__) && (__GNUC__ < 11)
+#       define SEQAN3_WORKAROUND_GCC_PIPEABLE_CONFIG_CONCEPT 1
+#   else
+#       define SEQAN3_WORKAROUND_GCC_PIPEABLE_CONFIG_CONCEPT 0
+#   endif
+#endif
+
 // ============================================================================
 //  Backmatter
 // ============================================================================

--- a/include/seqan3/search/configuration/detail.hpp
+++ b/include/seqan3/search/configuration/detail.hpp
@@ -13,7 +13,7 @@
 
 #pragma once
 
-#include <seqan3/core/algorithm/configuration_utility.hpp>
+#include <seqan3/core/algorithm/concept.hpp>
 
 namespace seqan3::detail
 {

--- a/include/seqan3/search/configuration/hit.hpp
+++ b/include/seqan3/search/configuration/hit.hpp
@@ -29,7 +29,7 @@ namespace seqan3::search_cfg
  * \ingroup search_configuration
  * \sa \ref search_configuration_subsection_hit_strategy "Section on Hit Strategy"
  */
-class hit_all : public pipeable_config_element<hit_all>
+class hit_all : private pipeable_config_element
 {
 public:
     /*!\name Constructors, assignment and destructor
@@ -52,7 +52,7 @@ public:
  * \ingroup search_configuration
  * \sa \ref search_configuration_subsection_hit_strategy "Section on Hit Strategy"
  */
-class hit_all_best : public pipeable_config_element<hit_all_best>
+class hit_all_best : private pipeable_config_element
 {
 public:
     /*!\name Constructors, assignment and destructor
@@ -75,7 +75,7 @@ public:
  * \ingroup search_configuration
  * \sa \ref search_configuration_subsection_hit_strategy "Section on Hit Strategy"
  */
-class hit_single_best : public pipeable_config_element<hit_single_best>
+class hit_single_best : private pipeable_config_element
 {
 public:
     /*!\name Constructors, assignment and destructor
@@ -99,7 +99,7 @@ public:
  * \ingroup search_configuration
  * \sa \ref search_configuration_subsection_hit_strategy "Section on Hit Strategy"
  */
-class hit_strata : public pipeable_config_element<hit_strata>
+class hit_strata : private pipeable_config_element
 {
 public:
     //!\brief The stratum value [default: 0].
@@ -131,7 +131,7 @@ public:
  * \ingroup search_configuration
  * \sa \ref search_configuration_subsection_hit_strategy "Section on Hit Strategy"
  */
-class hit : public pipeable_config_element<hit>
+class hit : private pipeable_config_element
 {
 public:
     /*!\brief The type of the std::variant holding the hit configuration element alternatives

--- a/include/seqan3/search/configuration/max_error.hpp
+++ b/include/seqan3/search/configuration/max_error.hpp
@@ -32,7 +32,7 @@ namespace seqan3::search_cfg
  * ### Example
  * \include test/snippet/search/configuration_error.cpp
  */
-class max_error_total : public pipeable_config_element<max_error_total>
+class max_error_total : public pipeable_config_element
 {
 public:
     //!\brief The error count or error rate.
@@ -76,7 +76,7 @@ public:
  * ### Example
  * \include test/snippet/search/configuration_error.cpp
  */
-class max_error_substitution : public pipeable_config_element<max_error_substitution>
+class max_error_substitution : public pipeable_config_element
 {
 public:
     //!\brief The error count or error rate.
@@ -120,7 +120,7 @@ public:
  * ### Example
  * \include test/snippet/search/configuration_error.cpp
  */
-class max_error_insertion : public pipeable_config_element<max_error_insertion>
+class max_error_insertion : public pipeable_config_element
 {
 public:
     //!\brief The error count or error rate.
@@ -165,7 +165,7 @@ public:
  * ### Example
  * \include test/snippet/search/configuration_error.cpp
  */
-class max_error_deletion : public pipeable_config_element<max_error_deletion>
+class max_error_deletion : public pipeable_config_element
 {
 public:
     //!\brief The error count or error rate.

--- a/include/seqan3/search/configuration/on_result.hpp
+++ b/include/seqan3/search/configuration/on_result.hpp
@@ -51,7 +51,7 @@ namespace seqan3::search_cfg
  * \include test/snippet/search/configuration_on_result.cpp
  */
 template <std::move_constructible callback_t>
-class on_result : public seqan3::pipeable_config_element<on_result<callback_t>>
+class on_result : public seqan3::pipeable_config_element
 {
 public:
     //!\brief The stored callable which will be invoked with the search result.

--- a/include/seqan3/search/configuration/output.hpp
+++ b/include/seqan3/search/configuration/output.hpp
@@ -26,7 +26,7 @@ namespace seqan3::search_cfg
  * \ingroup search_configuration
  * \sa \ref search_configuration_subsection_output "Section on Output"
  */
-class output_query_id : public pipeable_config_element<output_query_id>
+class output_query_id : public pipeable_config_element
 {
 public:
     /*!\name Constructors, destructor and assignment
@@ -49,7 +49,7 @@ public:
  * \ingroup search_configuration
  * \sa \ref search_configuration_subsection_output "Section on Output"
  */
-class output_reference_id : public pipeable_config_element<output_reference_id>
+class output_reference_id : public pipeable_config_element
 {
 public:
     /*!\name Constructors, destructor and assignment
@@ -72,7 +72,7 @@ public:
  * \ingroup search_configuration
  * \sa \ref search_configuration_subsection_output "Section on Output"
  */
-class output_reference_begin_position : public pipeable_config_element<output_reference_begin_position>
+class output_reference_begin_position : public pipeable_config_element
 {
 public:
     /*!\name Constructors, destructor and assignment
@@ -95,7 +95,7 @@ public:
  * \ingroup search_configuration
  * \sa \ref search_configuration_subsection_output "Section on Output"
  */
-class output_index_cursor : public pipeable_config_element<output_index_cursor>
+class output_index_cursor : public pipeable_config_element
 {
 public:
     /*!\name Constructors, destructor and assignment

--- a/include/seqan3/search/configuration/result_type.hpp
+++ b/include/seqan3/search/configuration/result_type.hpp
@@ -42,7 +42,7 @@ template <typename search_result_t>
 //!\cond
     requires seqan3::detail::is_type_specialisation_of_v<search_result_t, search_result>
 //!\endcond
-class result_type : public pipeable_config_element<result_type<search_result_t>>
+class result_type : public pipeable_config_element
 {
 public:
     //!\brief The configured seqan3::search_result type.

--- a/test/snippet/core/algorithm/configuration_get_or.cpp
+++ b/test/snippet/core/algorithm/configuration_get_or.cpp
@@ -9,7 +9,7 @@ enum struct my_id : int
     foo_id
 };
 
-struct bar : public seqan3::pipeable_config_element<bar>
+struct bar : private seqan3::pipeable_config_element
 {
 public:
     float value{};
@@ -28,7 +28,7 @@ public:
 };
 
 template <typename t>
-class foo : public seqan3::pipeable_config_element<foo<t>>
+class foo : private seqan3::pipeable_config_element
 {
 public:
     t value{};

--- a/test/snippet/core/algorithm/configuration_setup.cpp
+++ b/test/snippet/core/algorithm/configuration_setup.cpp
@@ -7,7 +7,7 @@ enum struct my_id : int
     foo_id
 };
 
-class bar : public seqan3::pipeable_config_element<bar>
+class bar : private seqan3::pipeable_config_element
 {
 public:
 
@@ -22,7 +22,7 @@ public:
 };
 
 template <typename t>
-struct foo : public seqan3::pipeable_config_element<foo<t>>
+struct foo : private seqan3::pipeable_config_element
 {
 public:
 

--- a/test/unit/alignment/configuration/align_config_band_test.cpp
+++ b/test/unit/alignment/configuration/align_config_band_test.cpp
@@ -20,7 +20,7 @@ INSTANTIATE_TYPED_TEST_SUITE_P(band_elements, pipeable_config_element_test, test
 
 TEST(band_fixed_size, config_element_specialisation)
 {
-    EXPECT_TRUE((seqan3::detail::config_element_specialisation<seqan3::align_cfg::band_fixed_size>));
+    EXPECT_TRUE((seqan3::config_element_specialisation<seqan3::align_cfg::band_fixed_size>));
 }
 
 TEST(band_fixed_size, construct)

--- a/test/unit/alignment/configuration/align_config_band_test.cpp
+++ b/test/unit/alignment/configuration/align_config_band_test.cpp
@@ -12,12 +12,6 @@
 #include <seqan3/alignment/configuration/align_config_band.hpp>
 #include <seqan3/core/algorithm/configuration.hpp>
 
-#include "../../core/algorithm/pipeable_config_element_test_template.hpp"
-
-using test_types = ::testing::Types<seqan3::align_cfg::band_fixed_size>;
-
-INSTANTIATE_TYPED_TEST_SUITE_P(band_elements, pipeable_config_element_test, test_types, );
-
 TEST(band_fixed_size, config_element_specialisation)
 {
     EXPECT_TRUE((seqan3::config_element_specialisation<seqan3::align_cfg::band_fixed_size>));

--- a/test/unit/alignment/configuration/align_config_common_test.cpp
+++ b/test/unit/alignment/configuration/align_config_common_test.cpp
@@ -65,7 +65,7 @@ TEST(alignment_configuration_test, number_of_configs)
 
 TYPED_TEST(alignment_configuration_test, config_element_specialisation)
 {
-    EXPECT_TRUE((seqan3::detail::config_element_specialisation<TypeParam>));
+    EXPECT_TRUE((seqan3::config_element_specialisation<TypeParam>));
 }
 
 TYPED_TEST(alignment_configuration_test, configuration_exists)

--- a/test/unit/alignment/configuration/align_config_common_test.cpp
+++ b/test/unit/alignment/configuration/align_config_common_test.cpp
@@ -14,80 +14,83 @@
 #include <seqan3/alignment/configuration/align_config_gap_cost_affine.hpp>
 #include <seqan3/alignment/configuration/align_config_method.hpp>
 #include <seqan3/alignment/configuration/align_config_min_score.hpp>
+#include <seqan3/alignment/configuration/align_config_on_result.hpp>
+#include <seqan3/alignment/configuration/align_config_output.hpp>
 #include <seqan3/alignment/configuration/align_config_parallel.hpp>
 #include <seqan3/alignment/configuration/align_config_result_type.hpp>
+#include <seqan3/alignment/configuration/align_config_score_type.hpp>
 #include <seqan3/alignment/configuration/align_config_scoring_scheme.hpp>
 #include <seqan3/alignment/configuration/align_config_vectorised.hpp>
 #include <seqan3/alignment/scoring/nucleotide_scoring_scheme.hpp>
+#include <seqan3/core/detail/pack_algorithm.hpp>
+#include <seqan3/core/type_list/traits.hpp>
 
-template <typename T>
-class alignment_configuration_test : public ::testing::Test
-{};
+#include "../../core/algorithm/pipeable_config_element_test_template.hpp"
+
+// Define some aliases to make the list below more readable.
+namespace cfg = seqan3::align_cfg;
 
 using alignment_result_t = seqan3::alignment_result<seqan3::detail::alignment_result_value_type<int, int, int>>;
+using nt_scheme = seqan3::nucleotide_scoring_scheme<int8_t>;
 
-using test_types = ::testing::Types<seqan3::align_cfg::band_fixed_size,
-                                    seqan3::align_cfg::gap_cost_affine,
-                                    seqan3::align_cfg::min_score,
-                                    seqan3::align_cfg::method_global,
-                                    seqan3::align_cfg::method_local,
-                                    seqan3::align_cfg::parallel,
-                                    seqan3::align_cfg::scoring_scheme<seqan3::nucleotide_scoring_scheme<int8_t>>,
-                                    seqan3::align_cfg::vectorised,
-                                    seqan3::align_cfg::detail::result_type<alignment_result_t>,
-                                    seqan3::align_cfg::detail::debug>;
+// Needed for the on result config
+auto on_result_callback = [] ([[maybe_unused]] auto && res) { };
+using callback_t = decltype(on_result_callback);
 
-TYPED_TEST_SUITE(alignment_configuration_test, test_types, );
+// A list of config types to test, associated with their incompatible config classes defined as a tabu-list.
+// We later use this tabu-list to generate a configuration object containing only the valid combinations for each
+// test type.
+using align_config_and_tabu_types = seqan3::type_list<
+    // method configs
+    std::pair<cfg::method_global, seqan3::type_list<cfg::method_global, cfg::method_local>>,
+    std::pair<cfg::method_local, seqan3::type_list<cfg::method_local, cfg::method_global, cfg::min_score>>,
+    // output configs
+    std::pair<cfg::output_sequence1_id, seqan3::type_list<cfg::output_sequence1_id>>,
+    std::pair<cfg::output_sequence2_id, seqan3::type_list<cfg::output_sequence2_id>>,
+    std::pair<cfg::output_score, seqan3::type_list<cfg::output_score>>,
+    std::pair<cfg::output_begin_position, seqan3::type_list<cfg::output_begin_position>>,
+    std::pair<cfg::output_end_position, seqan3::type_list<cfg::output_end_position>>,
+    std::pair<cfg::output_alignment, seqan3::type_list<cfg::output_alignment>>,
+    // other configs
+    std::pair<cfg::band_fixed_size, seqan3::type_list<cfg::band_fixed_size>>,
+    std::pair<cfg::detail::debug, seqan3::type_list<cfg::detail::debug>>,
+    std::pair<cfg::gap_cost_affine, seqan3::type_list<cfg::gap_cost_affine>>,
+    std::pair<cfg::min_score, seqan3::type_list<cfg::min_score, cfg::method_local>>,
+    std::pair<cfg::on_result<callback_t>, seqan3::type_list<cfg::on_result<callback_t>>>,
+    std::pair<cfg::parallel, seqan3::type_list<cfg::parallel>>,
+    std::pair<cfg::detail::result_type<alignment_result_t>, seqan3::type_list<cfg::detail::result_type<alignment_result_t>>>,
+    std::pair<cfg::score_type<int32_t>, seqan3::type_list<cfg::score_type<int32_t>>>,
+    std::pair<cfg::scoring_scheme<nt_scheme>, seqan3::type_list<cfg::scoring_scheme<nt_scheme>>>,
+    std::pair<cfg::vectorised, seqan3::type_list<cfg::vectorised>>
+    >;
 
-// TODO: this should go to a typed configuration test that also checks the alignment configuration
-TEST(alignment_configuration_test, symmetric_configuration)
+// The pure list of configuration elements to instantiate the typed test case with.
+using align_config_types = pure_config_type_list<align_config_and_tabu_types>;
+
+template <typename config_t>
+class test_fixture
 {
-    for (uint8_t i = 0; i < static_cast<uint8_t>(seqan3::detail::align_config_id::SIZE); ++i)
-    {
-        // no element can occur twice in a configuration
-        EXPECT_FALSE(seqan3::detail::compatibility_table<seqan3::detail::align_config_id>[i][i])
-            << "There is a TRUE value on the diagonal of the search configuration matrix.";
-        for (uint8_t j = 0; j < i; ++j)
-        {
-            // symmetric matrix
-            EXPECT_EQ(seqan3::detail::compatibility_table<seqan3::detail::align_config_id>[i][j],
-                      seqan3::detail::compatibility_table<seqan3::detail::align_config_id>[j][i])
-                << "Search configuration matrix is not symmetric.";
-        }
-    }
-}
+public:
+    // The actual config type that is tested.
+    using config_type = config_t;
+    // The tabu list associated with the given TypeParam element.
+    using tabu_list_type =
+        typename seqan3::list_traits::at<seqan3::list_traits::find<config_type, align_config_types>, // determine the index
+                                         align_config_and_tabu_types>::second_type; // extract the tabu list.
 
-TEST(alignment_configuration_test, number_of_configs)
-{
-    // NOTE(rrahn): You must update this test if you add a new value to seqan3::align_cfg::id
-    EXPECT_EQ(static_cast<uint8_t>(seqan3::detail::align_config_id::SIZE), 18);
-}
+    // A compatible configuration type for the current configuration element to test.
+    using compatible_configuration_type = make_pipeable_configuration<align_config_types, tabu_list_type>;
 
-TYPED_TEST(alignment_configuration_test, config_element_specialisation)
-{
-    EXPECT_TRUE((seqan3::config_element_specialisation<TypeParam>));
-}
+    using config_id_type = seqan3::detail::align_config_id;
 
-TYPED_TEST(alignment_configuration_test, configuration_exists)
-{
-    seqan3::configuration cfg{TypeParam{}};
-    EXPECT_TRUE(decltype(cfg)::template exists<TypeParam>());
-}
+    // NOTE: You must update this number if you add a new entity to seqan3::align_cfg::id.
+    static constexpr int8_t config_count = 18;
+};
 
-template <typename t, typename cfg_t>
-void helper_exists()
-{
-    EXPECT_TRUE(cfg_t::template exists<t>());
-}
+// Configuration element type list as gtest suitable testing::Types
+using fixture_types = seqan3::list_traits::transform<test_fixture, align_config_types>;
+using test_types = seqan3::detail::transfer_template_args_onto_t<fixture_types, ::testing::Types>;
 
-template <template <typename ...> typename t, typename cfg_t>
-void helper_exists()
-{
-    EXPECT_TRUE(cfg_t::template exists<t>());
-}
+TYPED_TEST_SUITE(alignment_configuration_fixture, test_types, );
 
-TYPED_TEST(alignment_configuration_test, configuration_exists_template)
-{
-    seqan3::configuration cfg{TypeParam{}};
-    helper_exists<TypeParam, decltype(cfg)>();
-}
+INSTANTIATE_TYPED_TEST_SUITE_P(alignment_configuration_test, pipeable_config_element_test, test_types, );

--- a/test/unit/alignment/configuration/align_config_gap_cost_affine_test.cpp
+++ b/test/unit/alignment/configuration/align_config_gap_cost_affine_test.cpp
@@ -13,7 +13,7 @@
 
 TEST(align_config_gap, config_element_specialisation)
 {
-    EXPECT_TRUE((seqan3::detail::config_element_specialisation<seqan3::align_cfg::gap_cost_affine>));
+    EXPECT_TRUE((seqan3::config_element_specialisation<seqan3::align_cfg::gap_cost_affine>));
 }
 
 TEST(align_config_gap, configuration)

--- a/test/unit/alignment/configuration/align_config_method_test.cpp
+++ b/test/unit/alignment/configuration/align_config_method_test.cpp
@@ -12,17 +12,6 @@
 #include <seqan3/alignment/configuration/align_config_method.hpp>
 #include <seqan3/core/algorithm/configuration.hpp>
 
-#include "../../core/algorithm/pipeable_config_element_test_template.hpp"
-
-// ---------------------------------------------------------------------------------------------------------------------
-// pipeable_config_element_test template
-// ---------------------------------------------------------------------------------------------------------------------
-
-using config_element_types = ::testing::Types<seqan3::align_cfg::method_global,
-                                              seqan3::align_cfg::method_local>;
-
-INSTANTIATE_TYPED_TEST_SUITE_P(method, pipeable_config_element_test, config_element_types, );
-
 TEST(method_global, access_member_variables)
 {
     seqan3::align_cfg::method_global opt{}; // default construction

--- a/test/unit/alignment/configuration/align_config_min_score_test.cpp
+++ b/test/unit/alignment/configuration/align_config_min_score_test.cpp
@@ -15,7 +15,7 @@
 
 TEST(align_config_min_score, config_element_specialisation)
 {
-    EXPECT_TRUE((seqan3::detail::config_element_specialisation<seqan3::align_cfg::min_score>));
+    EXPECT_TRUE((seqan3::config_element_specialisation<seqan3::align_cfg::min_score>));
 }
 
 TEST(align_config_min_score, configuration)

--- a/test/unit/alignment/configuration/align_config_on_result_test.cpp
+++ b/test/unit/alignment/configuration/align_config_on_result_test.cpp
@@ -12,16 +12,6 @@
 
 #include <seqan3/alignment/configuration/align_config_on_result.hpp>
 
-#include "../../core/algorithm/pipeable_config_element_test_template.hpp"
-
-// -----------------------------------------------------------------------------
-// test template : pipeable_config_element_test
-// -----------------------------------------------------------------------------
-
-using test_types = ::testing::Types<seqan3::align_cfg::on_result<std::function<void(int)>>>;
-
-INSTANTIATE_TYPED_TEST_SUITE_P(on_result_element, pipeable_config_element_test, test_types, );
-
 // -----------------------------------------------------------------------------
 // Test capturing various callbacks
 // -----------------------------------------------------------------------------

--- a/test/unit/alignment/configuration/align_config_output_test.cpp
+++ b/test/unit/alignment/configuration/align_config_output_test.cpp
@@ -13,21 +13,6 @@
 #include <seqan3/core/algorithm/configuration.hpp>
 #include <seqan3/core/type_traits/basic.hpp>
 
-#include "../../core/algorithm/pipeable_config_element_test_template.hpp"
-
-template <typename test_t>
-struct align_cfg_output_test : public ::testing::Test
-{};
-
-using test_types = ::testing::Types<seqan3::align_cfg::output_score,
-                                    seqan3::align_cfg::output_end_position,
-                                    seqan3::align_cfg::output_begin_position,
-                                    seqan3::align_cfg::output_alignment,
-                                    seqan3::align_cfg::output_sequence1_id,
-                                    seqan3::align_cfg::output_sequence2_id>;
-
-INSTANTIATE_TYPED_TEST_SUITE_P(output, pipeable_config_element_test, test_types, );
-
 TEST(align_config_output, score)
 {
     EXPECT_TRUE((std::same_as<std::remove_cvref_t<decltype(seqan3::align_cfg::output_score{})>,

--- a/test/unit/alignment/configuration/align_config_parallel_test.cpp
+++ b/test/unit/alignment/configuration/align_config_parallel_test.cpp
@@ -12,16 +12,7 @@
 #include <type_traits>
 
 #include <seqan3/alignment/configuration/align_config_parallel.hpp>
-
-#include "../../core/algorithm/pipeable_config_element_test_template.hpp"
-
-// ---------------------------------------------------------------------------------------------------------------------
-// test template : pipeable_config_element_test
-// ---------------------------------------------------------------------------------------------------------------------
-
-using test_types = ::testing::Types<seqan3::align_cfg::parallel>;
-
-INSTANTIATE_TYPED_TEST_SUITE_P(parallel_elements, pipeable_config_element_test, test_types, );
+#include <seqan3/core/algorithm/configuration.hpp>
 
 // ---------------------------------------------------------------------------------------------------------------------
 // individual tests

--- a/test/unit/alignment/configuration/align_config_parallel_test.cpp
+++ b/test/unit/alignment/configuration/align_config_parallel_test.cpp
@@ -29,7 +29,7 @@ INSTANTIATE_TYPED_TEST_SUITE_P(parallel_elements, pipeable_config_element_test, 
 
 TEST(align_config_parallel, config_element_specialisation)
 {
-    EXPECT_TRUE((seqan3::detail::config_element_specialisation<seqan3::align_cfg::parallel>));
+    EXPECT_TRUE((seqan3::config_element_specialisation<seqan3::align_cfg::parallel>));
 }
 
 TEST(align_config_parallel, configuration)

--- a/test/unit/alignment/configuration/align_config_score_type_test.cpp
+++ b/test/unit/alignment/configuration/align_config_score_type_test.cpp
@@ -13,16 +13,6 @@
 #include <seqan3/core/algorithm/configuration.hpp>
 #include <seqan3/core/type_traits/basic.hpp>
 
-#include "../../core/algorithm/pipeable_config_element_test_template.hpp"
-
-template <typename test_t>
-struct align_cfg_output_test : public ::testing::Test
-{};
-
-using test_types = ::testing::Types<seqan3::align_cfg::score_type<int32_t>>;
-
-INSTANTIATE_TYPED_TEST_SUITE_P(score_type, pipeable_config_element_test, test_types, );
-
 TEST(align_config_score_type, score_type)
 {
     EXPECT_TRUE((std::same_as<std::remove_cvref_t<decltype(seqan3::align_cfg::score_type<int32_t>{})>,

--- a/test/unit/alignment/configuration/align_config_scoring_test.cpp
+++ b/test/unit/alignment/configuration/align_config_scoring_test.cpp
@@ -29,7 +29,7 @@ TYPED_TEST_SUITE(align_confg_scoring_test, test_types, );
 TYPED_TEST(align_confg_scoring_test, config_element_specialisation)
 {
     using scheme_t = typename TestFixture::scheme_t;
-    EXPECT_TRUE((seqan3::detail::config_element_specialisation<seqan3::align_cfg::scoring_scheme<scheme_t>>));
+    EXPECT_TRUE((seqan3::config_element_specialisation<seqan3::align_cfg::scoring_scheme<scheme_t>>));
 }
 
 TYPED_TEST(align_confg_scoring_test, configuration)

--- a/test/unit/core/algorithm/configuration_mock.hpp
+++ b/test/unit/core/algorithm/configuration_mock.hpp
@@ -9,7 +9,7 @@
 
 #include <array>
 
-#include <seqan3/core/algorithm/configuration_utility.hpp>
+#include <seqan3/core/algorithm/concept.hpp>
 #include <seqan3/core/algorithm/pipeable_config_element.hpp>
 
 enum class test_algo_id : uint8_t

--- a/test/unit/core/algorithm/configuration_mock.hpp
+++ b/test/unit/core/algorithm/configuration_mock.hpp
@@ -36,7 +36,7 @@ inline constexpr std::array<std::array<bool, static_cast<uint8_t>(::test_algo_id
 
 }  // namespace seqan3::detail
 
-class bar : public seqan3::pipeable_config_element<bar>
+class bar : private seqan3::pipeable_config_element
 {
 public:
     int value{};
@@ -54,7 +54,7 @@ public:
     static constexpr test_algo_id id{test_algo_id::bar_id};
 };
 
-class bax : public seqan3::pipeable_config_element<bax>
+class bax : private seqan3::pipeable_config_element
 {
 public:
     float value{};
@@ -72,7 +72,7 @@ public:
     static constexpr test_algo_id id{test_algo_id::bax_id};
 };
 
-class foo : public seqan3::pipeable_config_element<foo>
+class foo : private seqan3::pipeable_config_element
 {
 public:
     std::string value{};
@@ -91,7 +91,7 @@ public:
 };
 
 template <typename t = std::vector<int>>
-class foobar : public seqan3::pipeable_config_element<foobar<t>>
+class foobar : private seqan3::pipeable_config_element
 {
 public:
     t value{};

--- a/test/unit/core/algorithm/configuration_test.cpp
+++ b/test/unit/core/algorithm/configuration_test.cpp
@@ -16,8 +16,8 @@
 
 TEST(configuration, concept_check)
 {
-    EXPECT_TRUE(seqan3::detail::config_element_specialisation<bar>);
-    EXPECT_FALSE(seqan3::detail::config_element_specialisation<int>);
+    EXPECT_TRUE(seqan3::config_element_specialisation<bar>);
+    EXPECT_FALSE(seqan3::config_element_specialisation<int>);
 
     EXPECT_TRUE((seqan3::tuple_like<seqan3::configuration<bax, bar>>));
 }

--- a/test/unit/core/algorithm/configuration_test.cpp
+++ b/test/unit/core/algorithm/configuration_test.cpp
@@ -171,6 +171,72 @@ TEST(configuration, exists_by_type_template)
     EXPECT_FALSE(decltype(cfg)::exists<foo>());
 }
 
+TEST(configuration, append_configuration_element)
+{
+    {
+        seqan3::configuration<foo, bar> cfg{};
+        auto new_cfg = cfg.append(bax{});
+        EXPECT_TRUE((std::same_as<decltype(new_cfg), seqan3::configuration<foo, bar, bax>>));
+    }
+
+    {
+        seqan3::configuration<foo, bar> cfg{};
+        bax b{};
+        auto new_cfg = cfg.append(b);
+        EXPECT_TRUE((std::same_as<decltype(new_cfg), seqan3::configuration<foo, bar, bax>>));
+    }
+
+    {
+        seqan3::configuration<foo, bar> cfg{};
+        bax b{};
+        auto new_cfg = cfg.append(std::as_const(b));
+        EXPECT_TRUE((std::same_as<decltype(new_cfg), seqan3::configuration<foo, bar, bax>>));
+    }
+
+    {
+        seqan3::configuration<> cfg{};
+        bax b{};
+        auto new_cfg = cfg.append(std::as_const(b));
+        EXPECT_TRUE((std::same_as<decltype(new_cfg), seqan3::configuration<bax>>));
+    }
+}
+
+TEST(configuration, append_configuration)
+{
+    {
+        seqan3::configuration<foo, bar> cfg{};
+        auto new_cfg = cfg.append(seqan3::configuration{bax{}});
+        EXPECT_TRUE((std::same_as<decltype(new_cfg), seqan3::configuration<foo, bar, bax>>));
+    }
+
+    {
+        seqan3::configuration<foo, bar> cfg{};
+        seqan3::configuration cfg2{bax{}};
+        auto new_cfg = cfg.append(cfg2);
+        EXPECT_TRUE((std::same_as<decltype(new_cfg), seqan3::configuration<foo, bar, bax>>));
+    }
+
+    {
+        seqan3::configuration<foo, bar> cfg{};
+        seqan3::configuration cfg2{bax{}};
+        auto new_cfg = cfg.append(std::as_const(cfg2));
+        EXPECT_TRUE((std::same_as<decltype(new_cfg), seqan3::configuration<foo, bar, bax>>));
+    }
+
+    {
+        seqan3::configuration<> cfg{};
+        seqan3::configuration cfg2{bax{}};
+        auto new_cfg = cfg.append(std::as_const(cfg2));
+        EXPECT_TRUE((std::same_as<decltype(new_cfg), seqan3::configuration<bax>>));
+    }
+
+    {
+        seqan3::configuration<> cfg{};
+        auto new_cfg = cfg.append(seqan3::configuration<>{});
+        EXPECT_TRUE((std::same_as<decltype(new_cfg), seqan3::configuration<>>));
+    }
+}
+
 TEST(configuration, remove_by_type)
 {
     {

--- a/test/unit/core/algorithm/pipeable_config_element_test.cpp
+++ b/test/unit/core/algorithm/pipeable_config_element_test.cpp
@@ -14,9 +14,9 @@
 
 TEST(pipeable_config_element, two_elements)
 {
-    // lvalue | lvalue
     bar b1{};
     bax b2{};
+    // lvalue | lvalue
     {
         auto cfg = b1 | b2;
         EXPECT_TRUE((std::is_same_v<decltype(cfg), seqan3::configuration<bar, bax>>));
@@ -79,25 +79,25 @@ TEST(pipeable_config_element, element_with_configuration)
     // lvalue | lvalue
     {
         auto cfg = b2 | tmp;
-        EXPECT_TRUE((std::is_same_v<decltype(cfg), seqan3::configuration<bar, bax>>));
+        EXPECT_TRUE((std::is_same_v<decltype(cfg), seqan3::configuration<bax, bar>>));
     }
 
     // rvalue | lvalue
     {
         auto cfg = bax{} | tmp;
-        EXPECT_TRUE((std::is_same_v<decltype(cfg), seqan3::configuration<bar, bax>>));
+        EXPECT_TRUE((std::is_same_v<decltype(cfg), seqan3::configuration<bax, bar>>));
     }
 
     // lvalue | rvalue
     {
         auto cfg = b2 | seqan3::configuration<bar>{};
-        EXPECT_TRUE((std::is_same_v<decltype(cfg), seqan3::configuration<bar, bax>>));
+        EXPECT_TRUE((std::is_same_v<decltype(cfg), seqan3::configuration<bax, bar>>));
     }
 
     // rvalue | rvalue
     {
         auto cfg = bax{} | seqan3::configuration<bar>{};
-        EXPECT_TRUE((std::is_same_v<decltype(cfg), seqan3::configuration<bar, bax>>));
+        EXPECT_TRUE((std::is_same_v<decltype(cfg), seqan3::configuration<bax, bar>>));
     }
 }
 
@@ -127,6 +127,39 @@ TEST(pipeable_config_element, configuration_with_configuration)
     {
         auto cfg = seqan3::configuration<bar>{} | seqan3::configuration<bax>{};
         EXPECT_TRUE((std::is_same_v<decltype(cfg), seqan3::configuration<bar, bax>>));
+    }
+}
+
+TEST(pipeable_config_element, special_cases)
+{
+    // with empty configuration on left hand side
+    {
+        auto cfg = seqan3::configuration<>{} | bax{};
+        EXPECT_TRUE((std::is_same_v<decltype(cfg), seqan3::configuration<bax>>));
+    }
+
+    // with empty configuration on left hand side
+    {
+        auto cfg = seqan3::configuration<>{} | seqan3::configuration{bax{}};
+        EXPECT_TRUE((std::is_same_v<decltype(cfg), seqan3::configuration<bax>>));
+    }
+
+    // with empty configuration on right hand side
+    {
+        auto cfg = bax{} | seqan3::configuration<>{};
+        EXPECT_TRUE((std::is_same_v<decltype(cfg), seqan3::configuration<bax>>));
+    }
+
+    // with empty configuration on right hand side
+    {
+        auto cfg = seqan3::configuration{bax{}} | seqan3::configuration<>{};
+        EXPECT_TRUE((std::is_same_v<decltype(cfg), seqan3::configuration<bax>>));
+    }
+
+    // with two empty configurations
+    {
+        auto cfg = seqan3::configuration<>{} | seqan3::configuration<>{};
+        EXPECT_TRUE((std::is_same_v<decltype(cfg), seqan3::configuration<>>));
     }
 }
 

--- a/test/unit/core/algorithm/pipeable_config_element_test.cpp
+++ b/test/unit/core/algorithm/pipeable_config_element_test.cpp
@@ -12,6 +12,38 @@
 #include <seqan3/core/algorithm/configuration.hpp>
 #include <seqan3/core/algorithm/pipeable_config_element.hpp>
 
+namespace seqan3::detail
+{
+enum struct incompatible_id : uint8_t
+{
+    incompatible
+};
+} // namespace seqan3::detail
+
+class incompatible_config : private seqan3::pipeable_config_element
+{
+public:
+
+    incompatible_config() = default;
+    incompatible_config(incompatible_config const &) = default;
+    incompatible_config(incompatible_config &&) = default;
+    incompatible_config & operator=(incompatible_config const &) = default;
+    incompatible_config & operator=(incompatible_config &&) = default;
+    ~incompatible_config() = default;
+
+    static constexpr seqan3::detail::incompatible_id id = seqan3::detail::incompatible_id::incompatible;
+};
+
+TEST(pipeable_config_element, pipeable_concepts)
+{
+    EXPECT_TRUE(seqan3::config_element_specialisation<bar>);
+    EXPECT_TRUE(seqan3::config_element_specialisation<bax>);
+    EXPECT_TRUE(seqan3::config_element_specialisation<incompatible_config>);
+    EXPECT_TRUE((seqan3::config_element_pipeable_with<bar, bax>));
+    EXPECT_FALSE((seqan3::config_element_pipeable_with<bar, incompatible_config>));
+    EXPECT_FALSE((seqan3::config_element_pipeable_with<incompatible_config, bax>));
+}
+
 TEST(pipeable_config_element, two_elements)
 {
     bar b1{};

--- a/test/unit/core/algorithm/pipeable_config_element_test.cpp
+++ b/test/unit/core/algorithm/pipeable_config_element_test.cpp
@@ -187,10 +187,3 @@ TEST(pipeable_config_element, const_config)
         EXPECT_TRUE((std::is_same_v<decltype(cfg), seqan3::configuration<foobar<>, foo, bar>>));
     }
 }
-
-TEST(pipeable_config_element, base_class_construction)
-{
-    EXPECT_FALSE(std::default_initializable<seqan3::pipeable_config_element<bar>>);
-    EXPECT_FALSE(std::copy_constructible<seqan3::pipeable_config_element<bar>>);
-    EXPECT_FALSE(std::move_constructible<seqan3::pipeable_config_element<bar>>);
-}

--- a/test/unit/core/algorithm/pipeable_config_element_test_template.hpp
+++ b/test/unit/core/algorithm/pipeable_config_element_test_template.hpp
@@ -22,7 +22,7 @@ TYPED_TEST_SUITE_P(pipeable_config_element_test);
 
 TYPED_TEST_P(pipeable_config_element_test, concept_check)
 {
-    EXPECT_TRUE((seqan3::detail::config_element_specialisation<TypeParam>));
+    EXPECT_TRUE((seqan3::config_element_specialisation<TypeParam>));
 }
 
 TYPED_TEST_P(pipeable_config_element_test, standard_construction)

--- a/test/unit/core/algorithm/pipeable_config_element_test_template.hpp
+++ b/test/unit/core/algorithm/pipeable_config_element_test_template.hpp
@@ -14,43 +14,266 @@
 
 #include "configuration_mock.hpp"
 
-template <typename format_t>
-struct pipeable_config_element_test : public ::testing::Test
+// The function is given a list of pairs with the configuration element and the associated tabu list.
+// This list is only deefined once per test case. This function allows to extract a list containing only the
+// configuration element types without their associated tabu lists. This list is then used to
+// instantiate the typed tests.
+template <typename target_list_t, typename config_tabu_pair_list_t>
+constexpr auto generate_config_element_list()
+{
+    if constexpr (seqan3::list_traits::size<config_tabu_pair_list_t> == 0u)
+    {
+        return target_list_t{};
+    }
+    else
+    {
+        using config_element_t = typename seqan3::list_traits::front<config_tabu_pair_list_t>::first_type;
+        return generate_config_element_list<seqan3::list_traits::concat<target_list_t,
+                                                                         seqan3::type_list<config_element_t>>,
+                                            seqan3::list_traits::drop_front<config_tabu_pair_list_t>>();
+    }
+}
+
+// Defines a type list with the tabu list information stripped away.
+template <typename config_tabu_pair_list_t>
+using pure_config_type_list = decltype(generate_config_element_list<seqan3::type_list<>,
+                                                                    config_tabu_pair_list_t>());
+
+// Generates a seqan3::configuration object that does not contain the configuration elements given
+// by the tabu_list.
+// The function recursively steps through the tabu list and removes the element from the config_list_t.
+// The first element of the tabu list is cut of before every recursive call.
+// If the tabu list is empty, a configuration object with only valid configuration elements will be returned.
+template <typename config_list_t, typename tabu_list_t>
+constexpr auto make_configuration()
+{
+    if constexpr (seqan3::list_traits::size<tabu_list_t> == 0u)
+    {
+        return seqan3::detail::transfer_template_args_onto_t<config_list_t, seqan3::configuration>{};
+    }
+    else
+    {
+        using tabu_config_t = seqan3::list_traits::front<tabu_list_t>;
+        constexpr std::ptrdiff_t pos = seqan3::list_traits::find<tabu_config_t, config_list_t>;
+        using split_list_t = seqan3::list_traits::split_after<pos, config_list_t>;
+        using new_config_list_t =
+            seqan3::list_traits::concat<typename split_list_t::first_type,
+                                        seqan3::list_traits::drop_front<typename split_list_t::second_type>>;
+
+        return make_configuration<new_config_list_t, seqan3::list_traits::drop_front<tabu_list_t>>();
+    }
+}
+
+template <typename config_list_t, typename tabu_list_t>
+using make_pipeable_configuration = decltype(make_configuration<config_list_t, tabu_list_t>());
+
+template <typename config_fixture_t>
+struct pipeable_config_element_test : public ::testing::Test, public config_fixture_t
 {};
 
 TYPED_TEST_SUITE_P(pipeable_config_element_test);
 
 TYPED_TEST_P(pipeable_config_element_test, concept_check)
 {
-    EXPECT_TRUE((seqan3::config_element_specialisation<TypeParam>));
+    EXPECT_TRUE((seqan3::config_element_specialisation<typename TestFixture::config_type>));
 }
 
 TYPED_TEST_P(pipeable_config_element_test, standard_construction)
 {
-    EXPECT_TRUE((std::is_default_constructible_v<TypeParam>));
-    EXPECT_TRUE((std::is_copy_constructible_v<TypeParam>));
-    EXPECT_TRUE((std::is_move_constructible_v<TypeParam>));
-    EXPECT_TRUE((std::is_copy_assignable_v<TypeParam>));
-    EXPECT_TRUE((std::is_move_assignable_v<TypeParam>));
+    using config_t = typename TestFixture::config_type;
+
+    EXPECT_TRUE((std::is_default_constructible_v<config_t>));
+    EXPECT_TRUE((std::is_copy_constructible_v<config_t>));
+    EXPECT_TRUE((std::is_move_constructible_v<config_t>));
+    EXPECT_TRUE((std::is_copy_assignable_v<config_t>));
+    EXPECT_TRUE((std::is_move_assignable_v<config_t>));
 }
 
 TYPED_TEST_P(pipeable_config_element_test, configuration_construction)
 {
-    seqan3::configuration cfg{TypeParam{}};
-    EXPECT_TRUE((std::same_as<decltype(cfg), seqan3::configuration<TypeParam>>));
+    using config_t = typename TestFixture::config_type;
+
+    seqan3::configuration cfg{config_t{}};
+    EXPECT_TRUE((std::same_as<decltype(cfg), seqan3::configuration<config_t>>));
 }
 
 TYPED_TEST_P(pipeable_config_element_test, configuration_assignment)
 {
-    seqan3::configuration cfg = TypeParam{};
-    EXPECT_TRUE((std::same_as<decltype(cfg), seqan3::configuration<TypeParam>>));
+    using config_t = typename TestFixture::config_type;
+
+    seqan3::configuration cfg = config_t{};
+    EXPECT_TRUE((std::same_as<decltype(cfg), seqan3::configuration<config_t>>));
+}
+
+TYPED_TEST_P(pipeable_config_element_test, symmetric_configuration)
+{
+    using config_id_t = typename TestFixture::config_id_type;
+    for (uint8_t i = 0; i < static_cast<uint8_t>(config_id_t::SIZE); ++i)
+    {
+        // no element can occur twice in a configuration
+        EXPECT_FALSE(seqan3::detail::compatibility_table<config_id_t>[i][i])
+            << "There is a TRUE value on the diagonal of the search configuration matrix.";
+        for (uint8_t j = 0; j < i; ++j)
+        {
+            // symmetric matrix
+            EXPECT_EQ(seqan3::detail::compatibility_table<config_id_t>[i][j],
+                      seqan3::detail::compatibility_table<config_id_t>[j][i])
+                << "Search configuration matrix is not symmetric.";
+        }
+    }
+}
+
+TYPED_TEST_P(pipeable_config_element_test, number_of_configs)
+{
+    using config_id_t = typename TestFixture::config_id_type;
+
+    EXPECT_EQ(static_cast<uint8_t>(config_id_t::SIZE), TestFixture::config_count);
 }
 
 TYPED_TEST_P(pipeable_config_element_test, exists)
 {
-    using configuration_t = seqan3::configuration<TypeParam>;
+    using config_t = typename TestFixture::config_type;
+    using configuration_t = seqan3::configuration<config_t>;
 
-    EXPECT_TRUE(configuration_t::template exists<TypeParam>());
+    EXPECT_TRUE(configuration_t::template exists<config_t>());
+}
+
+template <typename t, typename cfg_t>
+void helper_exists()
+{
+    EXPECT_TRUE(cfg_t::template exists<t>());
+}
+
+template <template <typename ...> typename t, typename cfg_t>
+void helper_exists()
+{
+    EXPECT_TRUE(cfg_t::template exists<t>());
+}
+
+TYPED_TEST_P(pipeable_config_element_test, exists_template)
+{
+    using config_t = typename TestFixture::config_type;
+
+    seqan3::configuration cfg{config_t{}};
+    helper_exists<config_t, decltype(cfg)>();
+}
+
+TYPED_TEST_P(pipeable_config_element_test, combineable_with)
+{
+    using configs_list_t =
+        seqan3::detail::transfer_template_args_onto_t<typename TestFixture::compatible_configuration_type,
+                                                      seqan3::type_list>;
+
+    // Test combineability with every config that can be combined with.
+    seqan3::detail::for_each<configs_list_t>([&](auto other_config)
+    {
+        using other_config_t = typename decltype(other_config)::type;
+
+        EXPECT_TRUE((seqan3::config_element_pipeable_with<typename TestFixture::config_type, other_config_t>));
+    });
+}
+
+TYPED_TEST_P(pipeable_config_element_test, pipeability)
+{
+    using config_t = typename TestFixture::config_type;
+    using configuration_t = typename TestFixture::compatible_configuration_type;
+
+    // Test actual pipe operation.
+    configuration_t compatible_configuration{};
+    config_t elem{};
+
+    { // Test with config element on the right hand side.
+        using expected_config_types_t =
+            seqan3::list_traits::concat<seqan3::detail::transfer_template_args_onto_t<configuration_t,
+                                                                                      seqan3::type_list>,
+                                        seqan3::type_list<config_t>>;
+        using expected_configuration_t =
+            seqan3::detail::transfer_template_args_onto_t<expected_config_types_t, seqan3::configuration>;
+
+        {   // lvalue | lvalue
+            auto cfg = compatible_configuration | elem;
+            EXPECT_TRUE((std::is_same_v<decltype(cfg), expected_configuration_t>));
+        }
+
+        {   // lvalue | rvalue
+            auto cfg = compatible_configuration | config_t{};
+            EXPECT_TRUE((std::is_same_v<decltype(cfg), expected_configuration_t>));
+        }
+
+        {   // rvalue | lvalue
+            auto cfg = configuration_t{} | elem;
+            EXPECT_TRUE((std::is_same_v<decltype(cfg), expected_configuration_t>));
+        }
+
+        {   // rvalue | rvalue
+            auto cfg = configuration_t{} | config_t{};
+            EXPECT_TRUE((std::is_same_v<decltype(cfg), expected_configuration_t>));
+        }
+    }
+
+    { // Test with config element on the left hand side.
+            using expected_config_types_t =
+                    seqan3::list_traits::concat<seqan3::type_list<config_t>,
+                                                seqan3::detail::transfer_template_args_onto_t<configuration_t,
+                                                                                              seqan3::type_list>>;
+            using expected_configuration_t =
+                    seqan3::detail::transfer_template_args_onto_t<expected_config_types_t, seqan3::configuration>;
+
+        {   // lvalue | lvalue
+            auto cfg = elem | compatible_configuration;
+            EXPECT_TRUE((std::is_same_v<decltype(cfg), expected_configuration_t>));
+        }
+
+        {   // rvalue | lvalue
+            auto cfg = config_t{} | compatible_configuration;
+            EXPECT_TRUE((std::is_same_v<decltype(cfg), expected_configuration_t>));
+        }
+
+        {   // lvalue | rvalue
+            auto cfg = elem | configuration_t{};
+            EXPECT_TRUE((std::is_same_v<decltype(cfg), expected_configuration_t>));
+        }
+
+        {   // rvalue | rvalue
+            auto cfg = config_t{} | configuration_t{};
+            EXPECT_TRUE((std::is_same_v<decltype(cfg), expected_configuration_t>));
+        }
+    }
+
+    { // Test with empty configuration.
+        using expected_configuration_t = seqan3::configuration<config_t>;
+
+        {   // lvalue | empty
+            auto cfg = elem | seqan3::configuration<>{};
+            EXPECT_TRUE((std::is_same_v<decltype(cfg), expected_configuration_t>));
+        }
+
+        {   // rvalue | empty
+            auto cfg = config_t{} | seqan3::configuration<>{};
+            EXPECT_TRUE((std::is_same_v<decltype(cfg), expected_configuration_t>));
+        }
+
+        {   // empty | lvalue
+            auto cfg = seqan3::configuration<>{} | elem;
+            EXPECT_TRUE((std::is_same_v<decltype(cfg), expected_configuration_t>));
+        }
+
+        {   // empty | rvalue
+            auto cfg = seqan3::configuration<>{} | config_t{};
+            EXPECT_TRUE((std::is_same_v<decltype(cfg), expected_configuration_t>));
+        }
+    }
+}
+
+TYPED_TEST_P(pipeable_config_element_test, invalid_pipeability)
+{
+    using config_t = typename TestFixture::config_type;
+    using incompatible_config_same_domain_t = seqan3::list_traits::front<typename TestFixture::tabu_list_type>;
+
+    EXPECT_FALSE((seqan3::config_element_pipeable_with<config_t, incompatible_config_same_domain_t>));
+    EXPECT_FALSE((seqan3::config_element_pipeable_with<incompatible_config_same_domain_t, config_t>));
+    EXPECT_FALSE((seqan3::config_element_pipeable_with<config_t, foo>));
+    EXPECT_FALSE((seqan3::config_element_pipeable_with<foo, config_t>));
 }
 
 REGISTER_TYPED_TEST_SUITE_P(pipeable_config_element_test,
@@ -58,4 +281,10 @@ REGISTER_TYPED_TEST_SUITE_P(pipeable_config_element_test,
                             standard_construction,
                             configuration_construction,
                             configuration_assignment,
-                            exists);
+                            symmetric_configuration,
+                            number_of_configs,
+                            exists,
+                            exists_template,
+                            combineable_with,
+                            pipeability,
+                            invalid_pipeability);

--- a/test/unit/core/algorithm/pipeable_config_element_test_template.hpp
+++ b/test/unit/core/algorithm/pipeable_config_element_test_template.hpp
@@ -34,13 +34,6 @@ TYPED_TEST_P(pipeable_config_element_test, standard_construction)
     EXPECT_TRUE((std::is_move_assignable_v<TypeParam>));
 }
 
-TYPED_TEST_P(pipeable_config_element_test, base_class_construction)
-{
-    EXPECT_FALSE(std::default_initializable<seqan3::pipeable_config_element<TypeParam>>);
-    EXPECT_FALSE(std::copy_constructible<seqan3::pipeable_config_element<TypeParam>>);
-    EXPECT_FALSE(std::move_constructible<seqan3::pipeable_config_element<TypeParam>>);
-}
-
 TYPED_TEST_P(pipeable_config_element_test, configuration_construction)
 {
     seqan3::configuration cfg{TypeParam{}};
@@ -63,7 +56,6 @@ TYPED_TEST_P(pipeable_config_element_test, exists)
 REGISTER_TYPED_TEST_SUITE_P(pipeable_config_element_test,
                             concept_check,
                             standard_construction,
-                            base_class_construction,
                             configuration_construction,
                             configuration_assignment,
                             exists);

--- a/test/unit/core/algorithm/pipeable_config_element_test_template.hpp
+++ b/test/unit/core/algorithm/pipeable_config_element_test_template.hpp
@@ -60,51 +60,10 @@ TYPED_TEST_P(pipeable_config_element_test, exists)
     EXPECT_TRUE(configuration_t::template exists<TypeParam>());
 }
 
-// make mock config element foo always pipeable with any other config element
-namespace seqan3::detail
-{
-
-template <typename t>
-struct is_configuration_valid<t, foo> : public std::true_type
-{};
-
-template <typename t>
-struct is_configuration_valid<foo, t> : public std::true_type
-{};
-
-}
-
-TYPED_TEST_P(pipeable_config_element_test, pipeability)
-{
-    TypeParam elem{};
-    foo dummy{};
-
-    {   // lvalue | lvalue
-        auto cfg = dummy | elem;
-        EXPECT_TRUE((std::is_same_v<decltype(cfg), seqan3::configuration<foo, TypeParam>>));
-    }
-
-    {   // rvalue | lvalue
-        auto cfg = TypeParam{} | dummy;
-        EXPECT_TRUE((std::is_same_v<decltype(cfg), seqan3::configuration<TypeParam, foo>>));
-    }
-
-    {   // lvalue | rvalue
-        auto cfg = dummy | TypeParam{};
-        EXPECT_TRUE((std::is_same_v<decltype(cfg), seqan3::configuration<foo, TypeParam>>));
-    }
-
-    {   // rvalue | rvalue
-        auto cfg = foo{} | TypeParam{};
-        EXPECT_TRUE((std::is_same_v<decltype(cfg), seqan3::configuration<foo, TypeParam>>));
-    }
-}
-
 REGISTER_TYPED_TEST_SUITE_P(pipeable_config_element_test,
                             concept_check,
                             standard_construction,
                             base_class_construction,
                             configuration_construction,
                             configuration_assignment,
-                            exists,
-                            pipeability);
+                            exists);

--- a/test/unit/search/configuration/CMakeLists.txt
+++ b/test/unit/search/configuration/CMakeLists.txt
@@ -1,3 +1,4 @@
 seqan3_test(hit_test.cpp)
 seqan3_test(on_result_test.cpp)
 seqan3_test(parallel_test.cpp)
+seqan3_test(search_config_common_test.cpp)

--- a/test/unit/search/configuration/hit_test.cpp
+++ b/test/unit/search/configuration/hit_test.cpp
@@ -7,22 +7,9 @@
 
 #include <gtest/gtest.h>
 
+#include <seqan3/core/algorithm/configuration.hpp>
 #include <seqan3/core/detail/pack_algorithm.hpp>
 #include <seqan3/search/configuration/hit.hpp>
-
-#include "../../core/algorithm/pipeable_config_element_test_template.hpp"
-
-// ---------------------------------------------------------------------------------------------------------------------
-// test template : pipeable_config_element_test
-// ---------------------------------------------------------------------------------------------------------------------
-
-using test_types = ::testing::Types<seqan3::search_cfg::hit_all,
-                                    seqan3::search_cfg::hit_all_best,
-                                    seqan3::search_cfg::hit_single_best,
-                                    seqan3::search_cfg::hit_strata,
-                                    seqan3::search_cfg::hit>;
-
-INSTANTIATE_TYPED_TEST_SUITE_P(mode_elements, pipeable_config_element_test, test_types, );
 
 // ---------------------------------------------------------------------------------------------------------------------
 // individual tests

--- a/test/unit/search/configuration/parallel_test.cpp
+++ b/test/unit/search/configuration/parallel_test.cpp
@@ -8,21 +8,9 @@
 #include <gtest/gtest.h>
 
 #include <optional>
+
+#include <seqan3/core/algorithm/configuration.hpp>
 #include <seqan3/search/configuration/parallel.hpp>
-
-#include "../../core/algorithm/pipeable_config_element_test_template.hpp"
-
-// ---------------------------------------------------------------------------------------------------------------------
-// test template : pipeable_config_element_test
-// ---------------------------------------------------------------------------------------------------------------------
-
-using test_types = ::testing::Types<seqan3::search_cfg::parallel>;
-
-INSTANTIATE_TYPED_TEST_SUITE_P(parallel_elements, pipeable_config_element_test, test_types, );
-
-// ---------------------------------------------------------------------------------------------------------------------
-// individual tests
-// ---------------------------------------------------------------------------------------------------------------------
 
 TEST(search_config_parallel, member_variable)
 {

--- a/test/unit/search/configuration/parallel_test.cpp
+++ b/test/unit/search/configuration/parallel_test.cpp
@@ -46,7 +46,7 @@ TEST(search_config_parallel, member_variable)
 
 TEST(search_config_parallel, config_element_specialisation)
 {
-    EXPECT_TRUE((seqan3::detail::config_element_specialisation<seqan3::search_cfg::parallel>));
+    EXPECT_TRUE((seqan3::config_element_specialisation<seqan3::search_cfg::parallel>));
 }
 
 TEST(search_config_parallel, configuration)

--- a/test/unit/search/configuration/search_config_common_test.cpp
+++ b/test/unit/search/configuration/search_config_common_test.cpp
@@ -1,0 +1,88 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <type_traits>
+
+#include <seqan3/search/configuration/all.hpp>
+#include <seqan3/search/search_result.hpp>
+#include <seqan3/core/detail/pack_algorithm.hpp>
+#include <seqan3/core/type_list/traits.hpp>
+
+#include "../../core/algorithm/pipeable_config_element_test_template.hpp"
+
+// Define some aliases to make the list below more readable.
+namespace cfg = seqan3::search_cfg;
+
+using nil_t = seqan3::detail::empty_type;
+using search_result_t = seqan3::search_result<nil_t, nil_t, nil_t, nil_t>;
+using all_hit_configs_t = seqan3::type_list<cfg::hit,
+                                            cfg::hit_all,
+                                            cfg::hit_all_best,
+                                            cfg::hit_single_best,
+                                            cfg::hit_strata>;
+// Needed for the on result config
+auto on_result_callback = [] ([[maybe_unused]] auto && res) { };
+using callback_t = decltype(on_result_callback);
+
+// A list of config types to test, associated with their incompatible config classes defined as a tabu-list.
+// We later use this tabu-list to generate a configuration object containing only the valid combinations for each
+// test type.
+using search_config_and_tabu_types = seqan3::type_list<
+    // hit configs
+    std::pair<cfg::hit, all_hit_configs_t>,
+    std::pair<cfg::hit_all, all_hit_configs_t>,
+    std::pair<cfg::hit_all_best, all_hit_configs_t>,
+    std::pair<cfg::hit_single_best, all_hit_configs_t>,
+    std::pair<cfg::hit_strata, all_hit_configs_t>,
+    // max error configs
+    std::pair<cfg::max_error_total, seqan3::type_list<cfg::max_error_total>>,
+    std::pair<cfg::max_error_substitution, seqan3::type_list<cfg::max_error_substitution>>,
+    std::pair<cfg::max_error_deletion, seqan3::type_list<cfg::max_error_deletion>>,
+    std::pair<cfg::max_error_insertion, seqan3::type_list<cfg::max_error_insertion>>,
+    // output configs
+    std::pair<cfg::output_query_id, seqan3::type_list<cfg::output_query_id>>,
+    std::pair<cfg::output_reference_id, seqan3::type_list<cfg::output_reference_id>>,
+    std::pair<cfg::output_reference_begin_position, seqan3::type_list<cfg::output_reference_begin_position>>,
+    std::pair<cfg::output_index_cursor, seqan3::type_list<cfg::output_index_cursor>>,
+    // other configs
+    std::pair<cfg::parallel, seqan3::type_list<cfg::parallel>>,
+    std::pair<cfg::on_result<callback_t>, seqan3::type_list<cfg::on_result<callback_t>>>,
+    std::pair<cfg::detail::result_type<search_result_t>, seqan3::type_list<cfg::detail::result_type<search_result_t>>>
+>;
+
+// The pure list of configuration elements to instantiate the typed test case with.
+using search_config_types = pure_config_type_list<search_config_and_tabu_types>;
+
+template <typename config_t>
+class test_fixture
+{
+public:
+    // The actual config type that is tested.
+    using config_type = config_t;
+
+    // The tabu list associated with the given TypeParam element.
+    using tabu_list_type =
+        typename seqan3::list_traits::at<seqan3::list_traits::find<config_t, search_config_types>, // determine the index
+                                         search_config_and_tabu_types>::second_type; // extract the tabu list.
+
+    // A compatible configuration type for the current configuration element to test.
+    using compatible_configuration_type = make_pipeable_configuration<search_config_types, tabu_list_type>;
+
+    // The type of the configuration element ids.
+    using config_id_type = seqan3::detail::search_config_id;
+
+    // NOTE: You must update this number if you add a new entity to seqan3::align_cfg::id.
+    static constexpr int8_t config_count = 12;
+};
+
+// Configuration element type list as gtest suitable testing::Types
+using fixture_types = seqan3::list_traits::transform<test_fixture, search_config_types>;
+using test_types = seqan3::detail::transfer_template_args_onto_t<fixture_types, ::testing::Types>;
+
+INSTANTIATE_TYPED_TEST_SUITE_P(search_configuration_test, pipeable_config_element_test, test_types, );

--- a/test/unit/search/search_configuration_test.cpp
+++ b/test/unit/search/search_configuration_test.cpp
@@ -64,7 +64,7 @@ TEST(search_configuration_test, symmetric_configuration)
 
 TYPED_TEST(search_configuration_test, config_element_specialisation)
 {
-    EXPECT_TRUE((seqan3::detail::config_element_specialisation<TypeParam>));
+    EXPECT_TRUE((seqan3::config_element_specialisation<TypeParam>));
 }
 
 TYPED_TEST(search_configuration_test, configuration_exists)


### PR DESCRIPTION
This is the final cleanup PR for the configuration backend.
It removes a lot of code and makes the pipe-interface cleaner. 
It also removes the template from the pipeable base class which is not necessary anymore.
Some problems arose with older compiler versions which are fixed by a workaround.

This is blocked by the next merge from release branch into master.
It can already be reviewed, and the first commit is `[MISC] Make config_element_specialisation more restrictive.`
The commits are logically separated and can be reviewed commit by commit.
