### PR TITLE
[INFRA] configure cpack for source builds

### DIFF
--- a/build_system/seqan3-package.cmake
+++ b/build_system/seqan3-package.cmake
@@ -9,7 +9,7 @@
 
 cmake_minimum_required (VERSION 3.7)
 
-set (CPACK_GENERATOR "ZIP" "TXZ")
+set (CPACK_GENERATOR "TXZ")
 
 set (CPACK_PACKAGE_VENDOR "seqan")
 # A description of the project, used in places such as the introduction screen of CPack-generated Windows installers.
@@ -18,5 +18,9 @@ set (CPACK_PACKAGE_CHECKSUM "SHA256")
 set (CPACK_PACKAGE_ICON "${SEQAN3_CLONE_DIR}/test/documentation/seqan_logo.png")
 set (CPACK_RESOURCE_FILE_LICENSE "${SEQAN3_CLONE_DIR}/LICENSE.md")
 set (CPACK_RESOURCE_FILE_README "${SEQAN3_CLONE_DIR}/README.md")
+
+# Source Package
+set (CPACK_SOURCE_GENERATOR "TXZ")
+set (CPACK_SOURCE_IGNORE_FILES "\\\\.git($|/)")
 
 include (CPack)


### PR DESCRIPTION
Usage:

Make a fresh clone of the repository and create a build folder (out-of-source).

```bash
mkdir package-build

git clone https://github.com/seqan/seqan3.git
cd seqan3

git checkout 3.0.2 # version to pack

git submodule init
git submodule update

cd ../package-build

cmake ../seqan3 # configure

cpack # builds binary package, e.g. seqan3-3.0.2-Linux.tar.xz{,.sha265}

cmake --build . --target package_source # builds source package, e.g. seqan3-3.0.2-Source.tar.xz{,.sha265}
```

Note: Do not do `git clone -recurse-submodules https://github.com/seqan/seqan3.git` because it will recursively
pull sub-submodules which we do not want!