### PR TITLE
[FIX] missing latex package for docs

### DIFF
--- a/test/documentation/seqan3_doxygen_cfg.in
+++ b/test/documentation/seqan3_doxygen_cfg.in
@@ -44,6 +44,7 @@ TOC_INCLUDE_HEADINGS   = 2
 HTML_EXTRA_STYLESHEET  = ${SEQAN3_DOXYGEN_SOURCE_DIR}/test/documentation/seqan3.css
 HTML_FOOTER            = ${SEQAN3_DOXYGEN_SOURCE_DIR}/test/documentation/seqan3_footer.html
 INPUT_ENCODING         = UTF-8
+EXTRA_PACKAGES         = {amsfonts}
 
 PREDEFINED             = "CEREAL_SERIALIZE_FUNCTION_NAME=serialize" \
                          "CEREAL_LOAD_FUNCTION_NAME=load" \


### PR DESCRIPTION
We introduced some formula with `mathbb` which requires `amsfonts` to be available. (33cc9b012cca3c69d38c1faeff001b6c2b12e2e5)
