### PR TITLE
[INFRA] build documentation only once

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,7 +289,11 @@ jobs:
         run: |
           ccache -p || true
           cd seqan3-build
-          make -k -j2
+          if [[ "${{ matrix.build }}" =~ ^(documentation)$ ]]; then
+            make download-cppreference-doxygen-web-tag
+          else
+            make -k -j2
+          fi
           ccache -s || true
 
       - name: Run tests


### PR DESCRIPTION
~~Blocked by https://github.com/seqan/seqan3/pull/2205~~ (Works as expected: Failed before #2205 was merged and succeeds now)

For the documentation we do `make` and then `ctest`. This obscures errors that may occur during the build via `make`.