### PR TITLE
[INFRA] pass benchmark_min_time to performance tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,7 +270,7 @@ jobs:
         run: |
           mkdir seqan3-build
           cd seqan3-build
-          cmake ../seqan3/test/${{ matrix.build }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_CXX_FLAGS="${{ matrix.cxx_flags }}" -DSEQAN3_VERBOSE_TESTS=OFF
+          cmake ../seqan3/test/${{ matrix.build }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_CXX_FLAGS="${{ matrix.cxx_flags }}" -DSEQAN3_VERBOSE_TESTS=OFF -DSEQAN3_BENCHMARK_MIN_TIME=0.01
           if [[ "${{ matrix.build }}" =~ ^(unit|header|snippet|coverage)$ ]]; then
             make gtest_project
           fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ install:
 before_script:
   - mkdir ../seqan3-build
   - cd ../seqan3-build
-  - cmake ../seqan3/test/${BUILD} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_CXX_FLAGS="-fcompare-debug-second ${CXXFLAGS}" -DSEQAN3_VERBOSE_TESTS=OFF
+  - cmake ../seqan3/test/${BUILD} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_CXX_FLAGS="-fcompare-debug-second ${CXXFLAGS}" -DSEQAN3_VERBOSE_TESTS=OFF -DSEQAN3_BENCHMARK_MIN_TIME=0.01
   - |
     if [[ "${BUILD}" =~ ^(unit|header|snippet|coverage)$ ]]; then
       make gtest_project

--- a/test/performance/CMakeLists.txt
+++ b/test/performance/CMakeLists.txt
@@ -10,6 +10,8 @@ project (seqan3_test_performance CXX)
 
 include (../seqan3-test.cmake)
 
+option (SEQAN3_BENCHMARK_MIN_TIME "Set --benchmark_min_time= for each bechmark. Timings are unreliable in CI." 1)
+
 macro (seqan3_benchmark benchmark_cpp)
     file (RELATIVE_PATH benchmark "${CMAKE_SOURCE_DIR}" "${CMAKE_CURRENT_LIST_DIR}/${benchmark_cpp}")
     seqan3_test_component (target "${benchmark}" TARGET_NAME)
@@ -17,7 +19,7 @@ macro (seqan3_benchmark benchmark_cpp)
 
     add_executable (${target} ${benchmark_cpp})
     target_link_libraries (${target} seqan3::test::performance)
-    add_test (NAME "${test_name}" COMMAND ${target})
+    add_test (NAME "${test_name}" COMMAND ${target} "--benchmark_min_time=${SEQAN3_BENCHMARK_MIN_TIME}")
 
     unset (benchmark)
     unset (target)


### PR DESCRIPTION
This should decrease the time needed for performance CI. (16m -> 2m)

I added an option to enable/disable this.