### PR TITLE
[FIX] gcc-11 ICE by removing range/v3/view/concat.hpp (#2210)

### DIFF
--- a/test/unit/alphabet/aminoacid/aminoacid_translation_test.cpp
+++ b/test/unit/alphabet/aminoacid/aminoacid_translation_test.cpp
@@ -7,8 +7,6 @@
 
 #include <gtest/gtest.h>
 
-#include <range/v3/view/concat.hpp>
-
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/alphabet/nucleotide/dna15.hpp>
 #include <seqan3/alphabet/aminoacid/aa27.hpp>
@@ -49,8 +47,8 @@ TEST(translate_triplets, random_access_range)
     seqan3::dna15 n3{'A'_dna15};
     seqan3::aa27 c{'L'_aa27};
 
-    auto range_triplet = ranges::views::concat(std::views::single(n1), std::views::single(n2),
-                                               std::views::single(n3));
+    std::vector range_triplet{n1, n2, n3};
+
     #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     seqan3::aa27 t2{seqan3::translate_triplet(range_triplet)};
 


### PR DESCRIPTION
This fixes the following gcc-11 ICE:

```
In file included from /seqan3/test/unit/alphabet/aminoacid/aminoacid_translation_test.cpp:10:
/seqan3/submodules/range-v3/include/range/v3/view/concat.hpp: In substitution of ‘template<class ... Rngs> template<bool IsConst> template<class T> using constify_if = meta::const_if_c<IsConst, T> [with T = ranges::concat_view<Rngs>; bool IsConst = IsConst; Rngs = {Rngs ...}]’:
/seqan3/submodules/range-v3/include/range/v3/view/concat.hpp:88:58:   required from here
/seqan3/submodules/range-v3/include/range/v3/view/concat.hpp:88:58: internal compiler error: Segmentation fault
   88 |             using concat_view_t = constify_if<concat_view>;
      |                                                          ^
```

which was also reported by https://github.com/seqan/seqan3/issues/2210

Fixes https://github.com/seqan/seqan3/issues/2210