### PR TITLE
Optimise alignment/final alignment computation master

### DIFF
--- a/include/seqan3/alignment/pairwise/detail/pairwise_alignment_algorithm_banded.hpp
+++ b/include/seqan3/alignment/pairwise/detail/pairwise_alignment_algorithm_banded.hpp
@@ -39,7 +39,7 @@ protected:
     //!\brief The alignment configuration traits type with auxiliary information extracted from the configuration type.
     using base_algorithm_t = pairwise_alignment_algorithm<alignment_configuration_t, policies_t...>;
 
-    // import types from base class.
+    // Import types from base class.
     using typename base_algorithm_t::traits_type;
     using typename base_algorithm_t::alignment_result_type;
     using typename base_algorithm_t::score_type;

--- a/include/seqan3/alignment/pairwise/detail/policy_affine_gap_recursion.hpp
+++ b/include/seqan3/alignment/pairwise/detail/policy_affine_gap_recursion.hpp
@@ -50,8 +50,10 @@ protected:
     using original_score_type = typename traits_type::original_score_type;
     //!\brief The configured score type.
     using score_type = typename traits_type::score_type;
+    //!\brief The internal tuple storing the scores of an affine cell.
+    using affine_score_tuple_t = std::tuple<score_type, score_type, score_type>;
     //!\brief The affine cell type returned by the functions.
-    using affine_cell_type = affine_cell_proxy<std::tuple<score_type, score_type, score_type>>;
+    using affine_cell_type = affine_cell_proxy<affine_score_tuple_t>;
 
     //!\brief The score for a gap extension.
     score_type gap_extension_score{};
@@ -115,9 +117,6 @@ protected:
      * * \f$ M[i, j] = \max \{M[i - 1, j - 1] + \delta, H[i, j], V[i, j]\}\f$
      */
     template <typename affine_cell_t>
-    //!\cond
-        requires is_type_specialisation_of_v<affine_cell_t, affine_cell_proxy>
-    //!\endcond
     affine_cell_type compute_inner_cell(score_type diagonal_score,
                                         affine_cell_t previous_cell,
                                         score_type const sequence_score) const noexcept
@@ -172,9 +171,6 @@ protected:
      * \f$H[i, 0] = V[i, 0] + g_o\f$ to prohibit extending a gap in the horizontal matrix from \f$H[i, 0]\f$.
      */
     template <typename affine_cell_t>
-    //!\cond
-        requires is_type_specialisation_of_v<affine_cell_t, affine_cell_proxy>
-    //!\endcond
     affine_cell_type initialise_first_column_cell(affine_cell_t previous_cell) const noexcept
     {
         score_type new_vertical = previous_cell.vertical_score() + gap_extension_score;
@@ -198,9 +194,6 @@ protected:
      * \f$V[0,j] = H[0, j] + g_o\f$ to prohibit extending a gap in the vertical matrix from \f$V[0, j]\f$.
      */
     template <typename affine_cell_t>
-    //!\cond
-        requires is_type_specialisation_of_v<affine_cell_t, affine_cell_proxy>
-    //!\endcond
     affine_cell_type initialise_first_row_cell(affine_cell_t previous_cell) const noexcept
     {
         score_type new_horizontal_score = previous_cell.horizontal_score() + gap_extension_score;

--- a/include/seqan3/alignment/pairwise/detail/policy_affine_gap_recursion_banded.hpp
+++ b/include/seqan3/alignment/pairwise/detail/policy_affine_gap_recursion_banded.hpp
@@ -12,13 +12,7 @@
 
 #pragma once
 
-#include <tuple>
-
-#include <seqan3/alignment/configuration/align_config_gap_cost_affine.hpp>
-#include <seqan3/alignment/matrix/detail/affine_cell_proxy.hpp>
 #include <seqan3/alignment/pairwise/detail/policy_affine_gap_recursion.hpp>
-#include <seqan3/alignment/pairwise/detail/type_traits.hpp>
-#include <seqan3/core/type_traits/template_inspection.hpp>
 
 namespace seqan3::detail
 {
@@ -32,15 +26,15 @@ class policy_affine_gap_recursion_banded : protected policy_affine_gap_recursion
 {
 protected:
     //!\brief The type of the base policy.
-    using base_policy_t = policy_affine_gap_recursion<alignment_configuration_t>;
+    using base_t = policy_affine_gap_recursion<alignment_configuration_t>;
     // Import base types
-    using typename base_policy_t::traits_type;
-    using typename base_policy_t::score_type;
-    using typename base_policy_t::affine_cell_type;
+    using typename base_t::traits_type;
+    using typename base_t::score_type;
+    using typename base_t::affine_cell_type;
 
     //Import member types.
-    using base_policy_t::gap_extension_score;
-    using base_policy_t::gap_open_score;
+    using base_t::gap_extension_score;
+    using base_t::gap_open_score;
 
     /*!\name Constructors, destructor and assignment
      * \{
@@ -61,7 +55,7 @@ protected:
      * If no gap cost model was provided by the user the default gap costs `-10` and `-1` are set for the gap open score
      * and the gap extension score respectively.
      */
-    explicit policy_affine_gap_recursion_banded(alignment_configuration_t const & config) : base_policy_t{config}
+    explicit policy_affine_gap_recursion_banded(alignment_configuration_t const & config) : base_t{config}
     {}
     //!\}
 
@@ -82,18 +76,13 @@ protected:
      * * \f$ M[i, j] = \max \{M[i - 1, j - 1] + \delta, H[i, j]\}\f$
      */
     template <typename affine_cell_t>
-    //!\cond
-        requires is_type_specialisation_of_v<affine_cell_t, affine_cell_proxy>
-    //!\endcond
     affine_cell_type initialise_band_first_cell(score_type diagonal_score,
                                                 affine_cell_t previous_cell,
                                                 score_type const sequence_score) const noexcept
     {
         diagonal_score += sequence_score;
         score_type horizontal_score = previous_cell.horizontal_score();
-
         diagonal_score = (diagonal_score < horizontal_score) ? horizontal_score : diagonal_score;
-
         score_type from_optimal_score = diagonal_score + gap_open_score;
         horizontal_score += gap_extension_score;
         horizontal_score = (horizontal_score < from_optimal_score) ? from_optimal_score : horizontal_score;

--- a/include/seqan3/alignment/pairwise/detail/policy_affine_gap_with_trace_recursion.hpp
+++ b/include/seqan3/alignment/pairwise/detail/policy_affine_gap_with_trace_recursion.hpp
@@ -1,0 +1,133 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides seqan3::detail::policy_affine_gap_with_trace_recursion.
+ * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <seqan3/alignment/pairwise/detail/policy_affine_gap_recursion.hpp>
+
+namespace seqan3::detail
+{
+
+/*!\brief Implements the alignment recursion function for the alignment algorithm using affine gap costs with trace
+ *        information.
+ * \ingroup pairwise_alignment
+ * \copydetails seqan3::detail::policy_affine_gap_recursion
+ */
+template <typename alignment_configuration_t>
+class policy_affine_gap_with_trace_recursion : protected policy_affine_gap_recursion<alignment_configuration_t>
+{
+protected:
+    //!\brief The type of the base policy.
+    using base_t = policy_affine_gap_recursion<alignment_configuration_t>;
+
+    // Import base types.
+    using typename base_t::traits_type;
+    using typename base_t::score_type;
+    using typename base_t::affine_score_tuple_t;
+
+    //!\brief The trace type to use.
+    using trace_type = typename traits_type::trace_type;
+    //!\brief The internal tuple storing the trace directions of an affine cell.
+    using affine_trace_tuple_t = std::tuple<trace_type, trace_type, trace_type>;
+    //!\brief The affine cell type returned by the functions.
+    using affine_cell_type = affine_cell_proxy<std::pair<affine_score_tuple_t, affine_trace_tuple_t>>;
+
+    // Import base member.
+    using base_t::gap_extension_score;
+    using base_t::gap_open_score;
+    using base_t::first_row_is_free;
+    using base_t::first_column_is_free;
+
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    policy_affine_gap_with_trace_recursion() = default; //!< Defaulted.
+    policy_affine_gap_with_trace_recursion(policy_affine_gap_with_trace_recursion const &) = default; //!< Defaulted.
+    policy_affine_gap_with_trace_recursion(policy_affine_gap_with_trace_recursion &&) = default; //!< Defaulted.
+    policy_affine_gap_with_trace_recursion & operator=(policy_affine_gap_with_trace_recursion const &)
+        = default; //!< Defaulted.
+    policy_affine_gap_with_trace_recursion & operator=(policy_affine_gap_with_trace_recursion &&)
+        = default; //!< Defaulted.
+    ~policy_affine_gap_with_trace_recursion() = default; //!< Defaulted.
+
+    //!\copydoc seqan3::detail::policy_affine_gap_recursion::policy_affine_gap_recursion
+    explicit policy_affine_gap_with_trace_recursion(alignment_configuration_t const & config) : base_t{config}
+    {}
+    //!\}
+
+    //!\copydoc seqan3::detail::policy_affine_gap_recursion::compute_inner_cell
+    template <typename affine_cell_t>
+    affine_cell_type compute_inner_cell(score_type diagonal_score,
+                                        affine_cell_t previous_cell,
+                                        score_type const sequence_score) const noexcept
+    {
+        diagonal_score += sequence_score;
+        score_type horizontal_score = previous_cell.horizontal_score();
+        score_type vertical_score = previous_cell.vertical_score();
+        trace_directions best_trace = trace_directions::diagonal;
+
+        diagonal_score = (diagonal_score < vertical_score)
+                       ? (best_trace = previous_cell.vertical_trace(), vertical_score)
+                       : (best_trace |= previous_cell.vertical_trace(), diagonal_score);
+        diagonal_score = (diagonal_score < horizontal_score)
+                       ? (best_trace = previous_cell.horizontal_trace(), horizontal_score)
+                       : (best_trace |= previous_cell.horizontal_trace(), diagonal_score);
+
+        score_type tmp = diagonal_score + gap_open_score;
+        vertical_score += gap_extension_score;
+        horizontal_score += gap_extension_score;
+
+        // store the vertical_score and horizontal_score value in the next path
+        trace_directions next_vertical_trace = trace_directions::up;
+        trace_directions next_horizontal_trace = trace_directions::left;
+
+        vertical_score = (vertical_score < tmp)
+                       ? (next_vertical_trace = trace_directions::up_open, tmp)
+                       : vertical_score;
+        horizontal_score = (horizontal_score < tmp)
+                         ? (next_horizontal_trace = trace_directions::left_open, tmp)
+                         : horizontal_score;
+
+        return {{diagonal_score, horizontal_score, vertical_score},
+                {best_trace, next_horizontal_trace, next_vertical_trace}};
+    }
+
+    //!\copydoc seqan3::detail::policy_affine_gap_recursion::initialise_origin_cell
+    affine_cell_type initialise_origin_cell() const noexcept
+    {
+        return {base_t::initialise_origin_cell(),
+                {trace_directions::none,
+                 first_row_is_free ? trace_directions::none : trace_directions::left_open,
+                 first_column_is_free ? trace_directions::none : trace_directions::up_open}};
+    }
+
+    //!\copydoc seqan3::detail::policy_affine_gap_recursion::initialise_first_column_cell
+    template <typename affine_cell_t>
+    affine_cell_type initialise_first_column_cell(affine_cell_t previous_cell) const noexcept
+    {
+        return {base_t::initialise_first_column_cell(previous_cell),
+                {previous_cell.vertical_trace(),
+                 trace_directions::left_open,
+                 first_column_is_free ? trace_directions::none : trace_directions::up}};
+    }
+
+    //!\copydoc seqan3::detail::policy_affine_gap_recursion::initialise_first_row_cell
+    template <typename affine_cell_t>
+    affine_cell_type initialise_first_row_cell(affine_cell_t previous_cell) const noexcept
+    {
+        return {base_t::initialise_first_row_cell(previous_cell),
+                {previous_cell.horizontal_trace(),
+                 first_row_is_free ? trace_directions::none : trace_directions::left,
+                 trace_directions::up_open}};
+    }
+};
+} // namespace seqan3::detail

--- a/include/seqan3/alignment/pairwise/detail/policy_affine_gap_with_trace_recursion_banded.hpp
+++ b/include/seqan3/alignment/pairwise/detail/policy_affine_gap_with_trace_recursion_banded.hpp
@@ -1,0 +1,87 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides seqan3::detail::policy_affine_gap_with_trace_recursion_banded.
+ * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <seqan3/alignment/pairwise/detail/policy_affine_gap_with_trace_recursion.hpp>
+
+namespace seqan3::detail
+{
+
+/*!\brief Implements the alignment recursion function for the banded alignment algorithm using affine gap costs with
+ *        trace information.
+ * \ingroup pairwise_alignment
+ * \copydetails seqan3::detail::policy_affine_gap_recursion
+ */
+template <typename alignment_configuration_t>
+class policy_affine_gap_with_trace_recursion_banded :
+    protected policy_affine_gap_with_trace_recursion<alignment_configuration_t>
+{
+protected:
+    //!\brief The type of the base policy.
+    using base_t = policy_affine_gap_with_trace_recursion<alignment_configuration_t>;
+    // Import base types.
+    using typename base_t::traits_type;
+    using typename base_t::score_type;
+    using typename base_t::affine_cell_type;
+
+    // Import base member.
+    using base_t::gap_extension_score;
+    using base_t::gap_open_score;
+
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    policy_affine_gap_with_trace_recursion_banded() = default; //!< Defaulted.
+    //!\brief Defaulted.
+    policy_affine_gap_with_trace_recursion_banded(policy_affine_gap_with_trace_recursion_banded const &) = default;
+    //!\brief Defaulted.
+    policy_affine_gap_with_trace_recursion_banded(policy_affine_gap_with_trace_recursion_banded &&) = default;
+    policy_affine_gap_with_trace_recursion_banded & operator=(policy_affine_gap_with_trace_recursion_banded const &)
+        = default; //!< Defaulted.
+    policy_affine_gap_with_trace_recursion_banded & operator=(policy_affine_gap_with_trace_recursion_banded &&)
+        = default; //!< Defaulted.
+    ~policy_affine_gap_with_trace_recursion_banded() = default; //!< Defaulted.
+
+    //!\copydoc seqan3::detail::policy_affine_gap_recursion::policy_affine_gap_recursion
+    explicit policy_affine_gap_with_trace_recursion_banded(alignment_configuration_t const & config) : base_t{config}
+    {}
+    //!\}
+
+    //!\copydoc seqan3::detail::policy_affine_gap_recursion_banded::initialise_band_first_cell
+    template <typename affine_cell_t>
+    affine_cell_type initialise_band_first_cell(score_type diagonal_score,
+                                                affine_cell_t previous_cell,
+                                                score_type const sequence_score) const noexcept
+    {
+        diagonal_score += sequence_score;
+        score_type horizontal_score = previous_cell.horizontal_score();
+        trace_directions best_trace{};
+
+        best_trace = previous_cell.horizontal_trace();
+        diagonal_score = (diagonal_score < horizontal_score)
+                       ? horizontal_score
+                       : (best_trace |= trace_directions::diagonal, diagonal_score);
+
+        score_type from_optimal_score = diagonal_score + gap_open_score;
+        trace_directions next_horizontal_trace = trace_directions::left;
+
+        horizontal_score += gap_extension_score;
+        horizontal_score = (horizontal_score < from_optimal_score)
+                         ? (next_horizontal_trace = trace_directions::left_open, from_optimal_score)
+                         : horizontal_score;
+
+        return {{diagonal_score, horizontal_score, from_optimal_score},
+                {best_trace, next_horizontal_trace, trace_directions::up_open}};
+    }
+};
+} // namespace seqan3::detail

--- a/include/seqan3/alignment/pairwise/detail/type_traits.hpp
+++ b/include/seqan3/alignment/pairwise/detail/type_traits.hpp
@@ -186,6 +186,8 @@ public:
                                                      compute_sequence_alignment ||
                                                      output_sequence1_id ||
                                                      output_sequence2_id;
+    //!\brief Flag indicating whether the trace matrix needs to be computed.
+    static constexpr bool requires_trace_information = compute_begin_positions || compute_sequence_alignment;
 };
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Implements additional policies for the seqan affine recursion including the trace information.
The overwriting policies do not provide any extra data but merely override the interfaces to compute the cells inside of the alignment matrix. In these functions they use the additional trace values given by the combined score and trace matrix.
A affine policy selector in the configuration makes sure that the algorithm is configured correctly.

These are the first four commits of the original branch: https://github.com/rrahn/seqan3/tree/optimise_alignment/final_alignment_computation