### PR TITLE
[FIX] Non boolean option in cmake

### DIFF
--- a/test/performance/CMakeLists.txt
+++ b/test/performance/CMakeLists.txt
@@ -10,7 +10,7 @@ project (seqan3_test_performance CXX)
 
 include (../seqan3-test.cmake)
 
-option (SEQAN3_BENCHMARK_MIN_TIME "Set --benchmark_min_time= for each bechmark. Timings are unreliable in CI." 1)
+set (SEQAN3_BENCHMARK_MIN_TIME "1" CACHE STRING "Set --benchmark_min_time= for each bechmark. Timings are unreliable in CI.")
 
 macro (seqan3_benchmark benchmark_cpp)
     file (RELATIVE_PATH benchmark "${CMAKE_SOURCE_DIR}" "${CMAKE_CURRENT_LIST_DIR}/${benchmark_cpp}")


### PR DESCRIPTION
When not set, `SEQAN3_BENCHMARK_MIN_TIME ` will be evaluated to `ON` and then passed as `--benchmark_min_time=ON`