### PR TITLE
[MISC] Move the  compatibility_table  declaration into the algorithm/concept header.

### DIFF
--- a/include/seqan3/core/algorithm/concept.hpp
+++ b/include/seqan3/core/algorithm/concept.hpp
@@ -33,6 +33,18 @@ namespace seqan3::detail
 {
 
 // ----------------------------------------------------------------------------
+// compatibility_table
+// ----------------------------------------------------------------------------
+
+/*!\brief Declaration of algorithm specific compatibility table.
+ * \ingroup algorithm
+ * \tparam algorithm_id_type The type of the algorithm specific id. Algorithm configurations must maintain
+ *                           this table to allow validation checks.
+ */
+template <typename algorithm_id_type>
+inline constexpr std::array<std::array<void, 0>, 0> compatibility_table;
+
+// ----------------------------------------------------------------------------
 // Concept config_element_specialisation
 // ----------------------------------------------------------------------------
 

--- a/include/seqan3/core/algorithm/configuration_utility.hpp
+++ b/include/seqan3/core/algorithm/configuration_utility.hpp
@@ -25,18 +25,6 @@ namespace seqan3::detail
 {
 
 // ----------------------------------------------------------------------------
-// compatibility_table
-// ----------------------------------------------------------------------------
-
-/*!\brief Declaration of algorithm specific compatibility table.
- * \ingroup algorithm
- * \tparam algorithm_id_type The type of the algorithm specific id. Algorithm configurations must maintain
- *                           this table to allow validation checks.
- */
-template <typename algorithm_id_type>
-inline constexpr std::array<std::array<void, 0>, 0> compatibility_table;
-
-// ----------------------------------------------------------------------------
 // Type trait is_configuration_valid
 // ----------------------------------------------------------------------------
 


### PR DESCRIPTION
This declaration is needed later for the config_element_pipeable_with concept defintion.

second commit of #2198 