### PR TITLE
[INFRA] CMake version number check to be the minimum version

### DIFF
--- a/build_system/seqan3-install.cmake
+++ b/build_system/seqan3-install.cmake
@@ -7,7 +7,7 @@
 
 # This file describes where and which parts of SeqAn3 should be installed to.
 
-cmake_minimum_required (VERSION 3.7)
+cmake_minimum_required (VERSION 3.14)
 
 include (GNUInstallDirs)
 


### PR DESCRIPTION
Fix CMake version number check to be the minimum version for the features that are in the CMakeFiles.
`install (
    FILES
    ....
    TYPE DOC
)`
The use of TYPE was released in cmake 3.14, and will fail on any prior version

Edit (@smehringer): Resolves #2227 