### PR TITLE
[TEST] Increase coverage for tmp_filename

### DIFF
--- a/include/seqan3/std/filesystem
+++ b/include/seqan3/std/filesystem
@@ -9,9 +9,11 @@
 /*!\file
  * \brief This header includes C++17 filesystem support and imports it into namespace std::filesystem (independent of
  *        whether it is marked as "experimental").
- * \author Vitor C. Piro <pirov AT zedat.fu-berlin.de >
+ * \author Vitor C. Piro <pirov AT zedat.fu-berlin.de>
+ * \author Enrico Seiler <enricoseiler AT fu-berlin.de>
  */
 
+//!\cond
 #pragma once
 
 #if __has_include(<filesystem>)
@@ -19,9 +21,101 @@
 #else
 #include <experimental/filesystem>
 
+namespace std::experimental::filesystem
+{
+
+enum class perm_options : uint32_t
+{
+    replace = 1u,
+    add = 1u<<1,
+    remove = 1u<<2,
+    nofollow = 1u<<3
+};
+
+constexpr perm_options operator& (perm_options lhs, perm_options rhs) noexcept
+{
+    using underlying_t = std::underlying_type_t<perm_options>;
+    return static_cast<perm_options>(static_cast<underlying_t>(lhs) & static_cast<underlying_t>(rhs));
+}
+
+constexpr perm_options operator| (perm_options lhs, perm_options rhs) noexcept
+{
+    using underlying_t = std::underlying_type_t<perm_options>;
+    return static_cast<perm_options>(static_cast<underlying_t>(lhs) | static_cast<underlying_t>(rhs));
+}
+
+constexpr perm_options operator^ (perm_options lhs, perm_options rhs) noexcept
+{
+    using underlying_t = std::underlying_type_t<perm_options>;
+    return static_cast<perm_options>(static_cast<underlying_t>(lhs) ^ static_cast<underlying_t>(rhs));
+}
+
+constexpr perm_options operator~ (perm_options lhs) noexcept
+{
+    using underlying_t = std::underlying_type_t<perm_options>;
+    return static_cast<perm_options>(~static_cast<underlying_t>(lhs));
+}
+
+constexpr perm_options & operator&= (perm_options & lhs, perm_options rhs) noexcept
+{
+    lhs = lhs & rhs;
+    return lhs;
+}
+
+constexpr perm_options & operator|= (perm_options & lhs, perm_options rhs) noexcept
+{
+    lhs = lhs | rhs;
+    return lhs;
+}
+
+constexpr perm_options & operator^= (perm_options & lhs, perm_options rhs) noexcept
+{
+    lhs = lhs ^ rhs;
+    return lhs;
+}
+
+inline void permissions(path const & p,
+                        perms prms,
+                        perm_options opts,
+                        error_code & ec)
+{
+    auto follow_symlinks = (static_cast<bool>(opts & perm_options::nofollow)) ? perms::symlink_nofollow : perms::none;
+
+    switch (opts)
+    {
+        case perm_options::replace :
+            permissions(p, perms::remove_perms | follow_symlinks | perms::all, ec);
+            permissions(p, perms::add_perms | follow_symlinks | prms, ec);
+            break;
+        case perm_options::add :
+            permissions(p, perms::add_perms | follow_symlinks | prms, ec);
+            break;
+        case perm_options::remove :
+            permissions(p, perms::remove_perms | follow_symlinks | prms, ec);
+            break;
+        default :
+            break; // Actually UB
+    }
+}
+
+inline void permissions(path const & p,
+                        perms prms,
+                        perm_options opts)
+{
+    error_code ec;
+    permissions(p, prms, opts, ec);
+    if (ec.value())
+        throw filesystem_error("Cannot set permissions", p, ec);
+}
+
+} // namespace std::experimental::filesystem
+
 namespace std
 {
+
 namespace filesystem = std::experimental::filesystem;
+
 } // namespace std
 
 #endif // __has_include(experimental/filesystem)
+//!\endcond

--- a/test/unit/argument_parser/format_parse_validators_test.cpp
+++ b/test/unit/argument_parser/format_parse_validators_test.cpp
@@ -476,9 +476,6 @@ TEST(validator_test, output_directory)
     }
 }
 
-#if __has_include(<filesystem>)
-// Setting the permissions with perm_options is not available in the experimental/filesystem branch.
-
 // In case this test is built as `root`, we want to exclude tests that check if certain missing permissions cause
 // specific exceptions. For this, we check if read/write permissions are still available after the permissions were
 // revoked. Note that `root` can always read/write even if user/group/all permissions are not set.
@@ -636,7 +633,6 @@ TEST(validator_test, outputdir_not_writable)
                                      std::filesystem::perm_options::add);
     }
 }
-#endif // __has_include(<filesystem>)
 
 TEST(validator_test, arithmetic_range_validator_success)
 {


### PR DESCRIPTION
Just changing the env variable is not enough, because `std::filesystem::temp_directory_path()` already checks if the returned path exists and is valid. 
That means the `std::filesystem::filesystem_error` was always thrown inside the `temp_directory_path()` instead of inside our `tmp_filename` constructor.