### PR TITLE
[FIX] #2234: latest googletest (1.10.0.20201025-1) doesn't like the *test_template.hpp

### DIFF
--- a/test/unit/alphabet/cigar/cigar_test.cpp
+++ b/test/unit/alphabet/cigar/cigar_test.cpp
@@ -9,7 +9,6 @@
 
 #include <seqan3/alphabet/cigar/cigar.hpp>
 
-#include "../alphabet_test_template.hpp"
 #include "../semi_alphabet_test_template.hpp"
 #include "../semi_alphabet_constexpr_test_template.hpp"
 

--- a/test/unit/alphabet/composite/semialphabet_any_test.cpp
+++ b/test/unit/alphabet/composite/semialphabet_any_test.cpp
@@ -7,9 +7,6 @@
 
 #include <gtest/gtest.h>
 
-#include "../alphabet_test_template.hpp"
-#include "../alphabet_constexpr_test_template.hpp"
-
 #include <seqan3/alphabet/aminoacid/aa10li.hpp>
 #include <seqan3/alphabet/aminoacid/aa10murphy.hpp>
 #include <seqan3/alphabet/composite/semialphabet_any.hpp>


### PR DESCRIPTION
This removes unused headers and fixes #2234.