### PR TITLE
[FIX] use proper workaround syntax

### DIFF
--- a/include/seqan3/alphabet/concept.hpp
+++ b/include/seqan3/alphabet/concept.hpp
@@ -649,12 +649,11 @@ public:
     }
 };
 
-//!\cond
-// required to prevent https://gcc.gnu.org/bugzilla/show_bug.cgi?id=89953
+#if SEQAN3_WORKAROUND_GCC_89953
 template <typename alph_t>
     requires requires { { alphabet_size_fn<alph_t>{} }; }
 inline constexpr auto alphabet_size_obj = alphabet_size_fn<alph_t>{};
-//!\endcond
+#endif // SEQAN3_WORKAROUND_GCC_89953
 
 } // namespace seqan3::detail::adl_only
 
@@ -699,12 +698,20 @@ namespace seqan3
  * This is a customisation point (see \ref about_customisation). To specify the behaviour for your own alphabet type,
  * simply provide one of the three functions specified above.
  */
+#if SEQAN3_WORKAROUND_GCC_89953
 template <typename alph_t>
 //!\cond
     requires requires { { detail::adl_only::alphabet_size_fn<alph_t>{} }; } &&
              requires { { detail::adl_only::alphabet_size_obj<alph_t>() }; } // ICE workarounds
 //!\endcond
 inline constexpr auto alphabet_size = detail::adl_only::alphabet_size_obj<alph_t>();
+#else // ^^^ workaround / no workaround vvv
+template <typename alph_t>
+//!\cond
+    requires requires { { detail::adl_only::alphabet_size_fn<alph_t>{}() }; }
+//!\endcond
+inline constexpr auto alphabet_size = detail::adl_only::alphabet_size_fn<alph_t>{}();
+#endif // SEQAN3_WORKAROUND_GCC_89953
 
 // ============================================================================
 // semialphabet

--- a/include/seqan3/alphabet/structure/concept.hpp
+++ b/include/seqan3/alphabet/structure/concept.hpp
@@ -303,12 +303,11 @@ public:
     }
 };
 
-//!\cond
-// required to prevent https://gcc.gnu.org/bugzilla/show_bug.cgi?id=89953
+#if SEQAN3_WORKAROUND_GCC_89953
 template <typename alph_t>
     requires requires { { max_pseudoknot_depth_fn<alph_t>{} }; }
 inline constexpr auto max_pseudoknot_depth_obj = max_pseudoknot_depth_fn<alph_t>{};
-//!\endcond
+#endif // SEQAN3_WORKAROUND_GCC_89953
 
 } // namespace seqan3::detail::adl_only
 
@@ -357,12 +356,20 @@ namespace seqan3
  * This is a customisation point (see \ref about_customisation). To specify the behaviour for your own alphabet type,
  * simply provide one of the three functions specified above.
  */
+#if SEQAN3_WORKAROUND_GCC_89953
 template <typename alph_t>
 //!\cond
     requires requires { { detail::adl_only::max_pseudoknot_depth_fn<alph_t>{} }; } &&
              requires { { detail::adl_only::max_pseudoknot_depth_obj<alph_t>() }; }
 //!\endcond
 inline constexpr auto max_pseudoknot_depth = detail::adl_only::max_pseudoknot_depth_obj<alph_t>();
+#else // ^^^ workaround / no workaround vvv
+template <typename alph_t>
+//!\cond
+    requires requires { { detail::adl_only::max_pseudoknot_depth_fn<alph_t>{}() }; }
+//!\endcond
+inline constexpr auto max_pseudoknot_depth = detail::adl_only::max_pseudoknot_depth_fn<alph_t>{}();
+#endif // SEQAN3_WORKAROUND_GCC_89953
 
 } // namespace seqan3
 

--- a/include/seqan3/core/platform.hpp
+++ b/include/seqan3/core/platform.hpp
@@ -230,6 +230,15 @@
 #   endif
 #endif
 
+//!\brief See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=89953
+#ifndef SEQAN3_WORKAROUND_GCC_89953
+#   if defined(__GNUC_MINOR__) && (__GNUC__ == 9 && __GNUC_MINOR__ < 3)
+#       define SEQAN3_WORKAROUND_GCC_89953 1
+#   else
+#       define SEQAN3_WORKAROUND_GCC_89953 0
+#   endif
+#endif
+
 //!\brief See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90897
 #ifndef SEQAN3_WORKAROUND_GCC_90897
 #   if defined(__GNUC__) && (__GNUC__ == 8)


### PR DESCRIPTION
This PR adapts older code to how we handle workarounds now. At some point we started to bundle our workarounds in one place (include/seqan3/core/platform.hpp) and made them available to all header instead of just leaving a comment.