### PR TITLE
[FEATURE] cmake: specify build-order by include-graph

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
   pull_request:
 
 env:
-  CMAKE_VERSION: 3.7.2
+  CMAKE_VERSION: 3.8.2
   DOXYGEN_VERSION: 1.8.20
   SEQAN3_NO_VERSION_CHECK: 1
   TZ: Europe/Berlin
@@ -36,6 +36,7 @@ jobs:
             cc: "gcc-7"
             build: coverage
             build_type: Debug
+            skip_run_tests: true # Already ran by the make call
 
           - name: "Unit gcc9 (c++2a) on Linux"
             os: ubuntu-20.04
@@ -148,6 +149,18 @@ jobs:
             cc: "gcc-7"
             build: header
             build_type: Release
+
+          - name: "Non-cyclic tests gcc7"
+            os: ubuntu-20.04
+            requires_toolchain: true
+            requires_ccache: true
+            cxx: "g++-7"
+            cc: "gcc-7"
+            build: unit
+            build_type: Debug
+            use_include_dependencies: true
+            skip_build_tests: true
+            skip_run_tests: true
 
           - name: "Snippet gcc7"
             os: ubuntu-20.04
@@ -263,6 +276,14 @@ jobs:
             ${{ matrix.name }}-ccache-${{ github.base_ref }}
             ${{ matrix.name }}-ccache-
 
+      - name: Tool versions
+        env:
+          CXX: ${{ matrix.cxx }}
+        run: |
+          env cmake --version
+          env doxygen --version || true
+          env $CXX --version || true
+
       - name: Configure tests
         env:
           CXX: ${{ matrix.cxx }}
@@ -277,8 +298,14 @@ jobs:
           if [[ "${{ matrix.build }}" =~ ^(performance|header)$ ]]; then
             make gbenchmark_build
           fi
+          if [[ "${{ matrix.use_include_dependencies }}" == "true" ]]; then
+            cmake -DSEQAN3_USE_INCLUDE_DEPENDENCIES=1 .
+            make all_dependencies
+            cmake . # are tests cyclic?
+          fi
 
       - name: Build tests
+        if: ${{!matrix.skip_build_tests}}
         env:
           CCACHE_BASEDIR: ${{ github.workspace }}
           CCACHE_DIR: ${{ github.workspace }}/.ccache
@@ -296,7 +323,7 @@ jobs:
           ccache -s || true
 
       - name: Run tests
-        if: matrix.build != 'coverage' # Already ran by the make call
+        if: ${{!matrix.skip_run_tests}}
         run: |
           cd seqan3-build
           if [[ "${{ matrix.build }}" =~ ^(snippet)$ ]]; then

--- a/test/cmake/diagnostics/list_missing_unit_tests.cmake
+++ b/test/cmake/diagnostics/list_missing_unit_tests.cmake
@@ -1,0 +1,46 @@
+# -----------------------------------------------------------------------------------------------------
+# Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+# Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+# This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+# shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+# -----------------------------------------------------------------------------------------------------
+
+set(seqan3_test_include_targets "" CACHE STRING "" FORCE)
+
+function (collect_include_target include_target)
+    set(seqan3_test_include_targets "${seqan3_test_include_targets};${include_target}" CACHE STRING "" FORCE)
+endfunction ()
+
+function (list_missing_unit_tests)
+    if (CMAKE_VERSION VERSION_LESS 3.8) # MANUALLY_ADDED_DEPENDENCIES since cmake >= 3.8
+        message (WARNING "list_missing_unit_tests requires at least cmake >= 3.8")
+        return ()
+    endif ()
+
+    list (SORT seqan3_test_include_targets)
+    foreach (include_target ${seqan3_test_include_targets})
+        if (NOT TARGET ${include_target})
+            continue ()
+        endif ()
+
+        get_target_property (dependencies ${include_target} MANUALLY_ADDED_DEPENDENCIES)
+
+        # if include_target has dependencies that means a test must be associated with it
+        # => so this include_target has no missing tests
+        if (dependencies)
+            continue ()
+        endif ()
+
+        string(REPLACE "-" "/" header ${include_target})
+        string(REPLACE "_test" ".hpp" header ${header})
+
+        get_filename_component(header_filename "${header}" NAME)
+
+        # skip these headers
+        if (header_filename MATCHES "all.hpp|concept.hpp")
+            continue ()
+        endif ()
+
+        message (STATUS "header '${header}' is missing a test")
+    endforeach ()
+endfunction ()

--- a/test/cmake/include_dependencies/add_include_dependencies.cmake
+++ b/test/cmake/include_dependencies/add_include_dependencies.cmake
@@ -5,6 +5,8 @@
 # shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 # -----------------------------------------------------------------------------------------------------
 
+include (diagnostics/list_missing_unit_tests)
+
 # get_include_target (<VAR> TARGET dna4_test)
 # get_include_target (<VAR> SOURCE "[test/unit/]alphabet/nucleotide/dna4_test.cpp")
 # get_include_target (<VAR> HEADER "[include/seqan3/]alphabet/nucleotide/dna4.hpp")
@@ -41,6 +43,7 @@ function (add_include_target include_target)
     if (NOT TARGET ${include_target})
         # add_library(${include_target} STATIC IMPORTED)
         add_custom_target (${include_target})
+        collect_include_target (${include_target})
     endif ()
 endfunction ()
 

--- a/test/cmake/include_dependencies/add_include_dependencies.cmake
+++ b/test/cmake/include_dependencies/add_include_dependencies.cmake
@@ -1,0 +1,119 @@
+# -----------------------------------------------------------------------------------------------------
+# Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+# Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+# This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+# shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+# -----------------------------------------------------------------------------------------------------
+
+# get_include_target (<VAR> TARGET dna4_test)
+# get_include_target (<VAR> SOURCE "[test/unit/]alphabet/nucleotide/dna4_test.cpp")
+# get_include_target (<VAR> HEADER "[include/seqan3/]alphabet/nucleotide/dna4.hpp")
+function (get_include_target VAR source_type source)
+    if (source_type STREQUAL "TARGET")
+        # e.g. dna4_test.cpp
+        get_target_property(target_source "${source}" SOURCES)
+        # e.g. <seqan3-root>/test/unit/alphabet/nucleotide
+        get_target_property(target_source_dir "${source}" SOURCE_DIR)
+        # e.g. alphabet/nucleotide/dna4_test.cpp
+        file (RELATIVE_PATH target_source_file "${CMAKE_SOURCE_DIR}" "${target_source_dir}/${target_source}")
+    elseif (source_type STREQUAL "SOURCE")
+        # e.g. alphabet/nucleotide/dna4_test.cpp
+        set (target_source_file "${source}")
+    elseif (source_type STREQUAL "HEADER")
+        # e.g. alphabet/nucleotide
+        get_filename_component (directory "${source}" DIRECTORY)
+        # e.g. alphabet/nucleotide/dna4.hpp
+        get_filename_component (filename_without_extension "${source}" NAME_WE)
+        # e.g. alphabet/nucleotide/dna4_test.cpp
+        set (target_source_file "${directory}/${filename_without_extension}_test.cpp")
+    else ()
+        message (STATUS "get_include_target: source_type ${source_type} unknown")
+    endif ()
+
+    string (REGEX REPLACE "\_test.cpp$" ".hpp" target_header_file "include/seqan3/${target_source_file}")
+    seqan3_test_component (include_target "${target_header_file}" TARGET_UNIQUE_NAME)
+
+    # e.g. include-seqan3-alphabet-nucleotide-dna4.hpp
+    set (${VAR} "${include_target}.hpp" PARENT_SCOPE)
+endfunction ()
+
+function (add_include_target include_target)
+    if (NOT TARGET ${include_target})
+        # add_library(${include_target} STATIC IMPORTED)
+        add_custom_target (${include_target})
+    endif ()
+endfunction ()
+
+function (add_include_dependencies target target_cyclic_depending_includes)
+    if (NOT SEQAN3_USE_INCLUDE_DEPENDENCIES)
+        return ()
+    endif ()
+
+    if (NOT CMAKE_GENERATOR STREQUAL "Unix Makefiles")
+        message (STATUS "add_include_dependencies: only works for Unix Makefiles")
+        return ()
+    endif ()
+
+    get_include_target (include_target TARGET "${target}")
+    add_include_target ("${include_target}")
+    add_dependencies (${include_target} ${target})
+
+    # an include target can't depend on itself, we get a dependency cycle otherwise
+    list (APPEND target_cyclic_depending_includes "${include_target}")
+
+    # e.g. alphabet/nucleotide/dna4_test
+    set (target_file "${CMAKE_CURRENT_BINARY_DIR}/${target}")
+    # e.g. alphabet/nucleotide/dna4_test_dependencies_include.cmake
+    set (target_dependencies_include_file "${target_file}_dependencies_include.cmake")
+    # e.g. alphabet/nucleotide/dna4_test_dependencies.cmake
+    set (target_dependencies_file "${target_file}_dependencies.cmake")
+
+    file (WRITE "${target_dependencies_include_file}"
+                "if (EXISTS \"${target_dependencies_file}\")" "\n"
+                "  include (\"${target_dependencies_file}\")" "\n"
+                "endif ()\n")
+
+    # e.g. alphabet/nucleotide/CMakeFiles/dna4_test.dir which is internally used by CMake Makefiles
+    get_filename_component (target_internal_dir "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/${target}.dir/${CMAKE_CFG_INTDIR}" REALPATH)
+    set (target_internal_dependency_file "${target_internal_dir}/depend.internal")
+
+    add_custom_command (OUTPUT "${target_internal_dependency_file}" "${target_dependencies_file}"
+                        # generate alphabet/nucleotide/CMakeFiles/dna4_test.dir/depend.internal
+                        COMMAND "${CMAKE_COMMAND}"
+                                "-E" "cmake_depends"
+                                "${CMAKE_GENERATOR}"
+                                "${CMAKE_SOURCE_DIR}"
+                                "${CMAKE_CURRENT_SOURCE_DIR}"
+                                "${CMAKE_BINARY_DIR}"
+                                "${CMAKE_CURRENT_BINARY_DIR}"
+                                "${target_internal_dir}/DependInfo.cmake"
+                        # generate alphabet/nucleotide/dna4_test_dependencies.cmake
+                        COMMAND "${CMAKE_COMMAND}"
+                                "-DTARGET=${target}"
+                                "-DTARGET_INTERNAL_DEPENDENCY_MAKE_FILE=${target_internal_dir}/depend.make"
+                                "-DSEQAN3_INCLUDE_DIR=${SEQAN3_INCLUDE_DIR}"
+                                "-DSEQAN3_TEST_CMAKE_MODULE_DIR=${SEQAN3_TEST_CMAKE_MODULE_DIR}"
+                                "-DTARGET_DEPENDENCIES_FILE=${target_dependencies_file}"
+                                "-DTARGET_CYCLIC_DEPENDING_INCLUDES=${target_cyclic_depending_includes}"
+                                "-P"
+                                "${SEQAN3_TEST_CMAKE_MODULE_DIR}/include_dependencies/generate_include_dependencies.cmake"
+                        # touch alphabet/nucleotide/dna4_test_dependencies_include.cmake to "refresh" dependencies
+                        COMMAND "${CMAKE_COMMAND}"
+                                "-E"
+                                "touch_nocreate"
+                                "${target_dependencies_include_file}"
+                        BYPRODUCTS "${target_internal_dependency_file}" "${target_dependencies_file}"
+                        DEPENDS "${SEQAN3_TEST_CMAKE_MODULE_DIR}/include_dependencies/generate_include_dependencies.cmake"
+                        VERBATIM)
+
+    add_custom_target ("${target}_dependencies" DEPENDS "${target_internal_dependency_file}")
+    add_dependencies (${target} "${target}_dependencies")
+
+    if (NOT TARGET all_dependencies)
+        # custom target to build / collect all dependencies
+        add_custom_target (all_dependencies)
+    endif ()
+    add_dependencies (all_dependencies "${target}_dependencies")
+
+    include (${target_dependencies_include_file})
+endfunction ()

--- a/test/cmake/include_dependencies/generate_include_dependencies.cmake
+++ b/test/cmake/include_dependencies/generate_include_dependencies.cmake
@@ -1,0 +1,74 @@
+# -----------------------------------------------------------------------------------------------------
+# Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+# Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+# This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+# shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+# -----------------------------------------------------------------------------------------------------
+
+cmake_minimum_required (VERSION 3.7)
+
+function (generate_include_dependencies_impl)
+    cmake_parse_arguments(
+        ""
+        ""
+        "TARGET;TARGET_INTERNAL_DEPENDENCY_MAKE_FILE;SEQAN3_INCLUDE_DIR;TARGET_DEPENDENCIES_FILE"
+        "TARGET_CYCLIC_DEPENDING_INCLUDES"
+        ${ARGN}
+    )
+
+    if (NOT EXISTS "${_TARGET_INTERNAL_DEPENDENCY_MAKE_FILE}")
+        return ()
+    endif ()
+
+    # read in file and filter out linebreaks
+    file (STRINGS "${_TARGET_INTERNAL_DEPENDENCY_MAKE_FILE}" header_files)
+    list (FILTER header_files INCLUDE REGEX "${_SEQAN3_INCLUDE_DIR}/seqan3")
+    if (CMAKE_VERSION VERSION_LESS 3.12)
+        set (_header_files "${header_files}")
+        set (header_files "")
+        foreach (header_file ${_header_files})
+            string(REGEX REPLACE "^.+: " "" header_file "${header_file}")
+            list (APPEND header_files "${header_file}")
+        endforeach ()
+    else () # ^^^ workaround / no workaround vvv
+        # list (TRANSFORM) needs cmake >= 3.12
+        list (TRANSFORM header_files REPLACE "^.+: " "")
+    endif ()
+
+    set (script "")
+    foreach (header_file ${header_files})
+        file (RELATIVE_PATH relative_header_file "${_SEQAN3_INCLUDE_DIR}/seqan3" "${header_file}")
+        get_include_target (include_depended_target HEADER "${relative_header_file}")
+
+        string (APPEND script "add_include_target (\"${include_depended_target}\")\n")
+        # exclude known cyclic header
+        if (NOT "${include_depended_target}" IN_LIST _TARGET_CYCLIC_DEPENDING_INCLUDES)
+            string (APPEND script "add_dependencies (${_TARGET} \"${include_depended_target}\")\n")
+        else ()
+            string (APPEND script "# add_dependencies (${_TARGET} \"${include_depended_target}\") # known cycle\n")
+        endif ()
+        string (APPEND script "\n")
+    endforeach ()
+
+    file (WRITE "${_TARGET_DEPENDENCIES_FILE}" "${script}")
+endfunction ()
+
+if (CMAKE_SCRIPT_MODE_FILE)
+    list (APPEND CMAKE_MODULE_PATH "${SEQAN3_TEST_CMAKE_MODULE_DIR}")
+    include (include_dependencies/add_include_dependencies)
+    include (seqan3_test_component)
+
+    message (STATUS "Generate include dependencies of target ${TARGET}")
+
+    generate_include_dependencies_impl (
+        # e.g. dna4_test
+        TARGET "${TARGET}"
+        # e.g. alphabet/nucleotide/CMakeFiles/dna4_test.dir/depend.make
+        TARGET_INTERNAL_DEPENDENCY_MAKE_FILE "${TARGET_INTERNAL_DEPENDENCY_MAKE_FILE}"
+        # e.g. /seqan3-repo/include
+        SEQAN3_INCLUDE_DIR "${SEQAN3_INCLUDE_DIR}"
+        # e.g. alphabet/nucleotide/dna4_test_dependencies.cmake (will be generated)
+        TARGET_DEPENDENCIES_FILE "${TARGET_DEPENDENCIES_FILE}"
+        TARGET_CYCLIC_DEPENDING_INCLUDES "${TARGET_CYCLIC_DEPENDING_INCLUDES}"
+    )
+endif ()

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -11,6 +11,7 @@ project (seqan3_test_unit CXX)
 include (../seqan3-test.cmake)
 include (GoogleTest OPTIONAL)
 
+include (diagnostics/list_missing_unit_tests)
 include (diagnostics/list_unused_unit_tests)
 include (include_dependencies/add_include_dependencies)
 
@@ -48,4 +49,5 @@ seqan3_require_test ()
 
 add_subdirectories ()
 
+list_missing_unit_tests()
 list_unused_unit_tests ()

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -12,16 +12,25 @@ include (../seqan3-test.cmake)
 include (GoogleTest OPTIONAL)
 
 include (diagnostics/list_unused_unit_tests)
+include (include_dependencies/add_include_dependencies)
 
 option (SEQAN3_VERBOSE_TESTS "Run each test case individually" ON)
+option (SEQAN3_USE_INCLUDE_DEPENDENCIES "Build tests in an hierarchical order (by an include graph, i.e. tests with less dependencies are build first)" OFF)
+
+if (SEQAN3_USE_INCLUDE_DEPENDENCIES)
+    cmake_minimum_required (VERSION 3.8)
+endif ()
 
 macro (seqan3_test unit_test_cpp)
+    cmake_parse_arguments(SEQAN3_TEST "" "" "CYCLIC_DEPENDING_INCLUDES" ${ARGN})
+
     file (RELATIVE_PATH unit_test "${CMAKE_SOURCE_DIR}" "${CMAKE_CURRENT_LIST_DIR}/${unit_test_cpp}")
     seqan3_test_component (target "${unit_test}" TARGET_NAME)
     seqan3_test_component (test_name "${unit_test}" TEST_NAME)
 
     add_executable (${target} ${unit_test_cpp})
     target_link_libraries (${target} seqan3::test::unit)
+    add_include_dependencies (${target} "${SEQAN3_TEST_CYCLIC_DEPENDING_INCLUDES}")
     collect_used_test (${target})
     if (SEQAN3_VERBOSE_TESTS AND NOT CMAKE_VERSION VERSION_LESS 3.10) # cmake >= 3.10
         gtest_discover_tests(${target} TEST_PREFIX "${test_name}::" PROPERTIES TIMEOUT "30")

--- a/test/unit/alphabet/composite/composite_integration_test.cpp
+++ b/test/unit/alphabet/composite/composite_integration_test.cpp
@@ -15,6 +15,11 @@
 #include <seqan3/alphabet/quality/phred63.hpp>
 #include <seqan3/alphabet/quality/qualified.hpp>
 
+#include "../alphabet_constexpr_test_template.hpp"
+#include "../alphabet_test_template.hpp"
+#include "../semi_alphabet_constexpr_test_template.hpp"
+#include "../semi_alphabet_test_template.hpp"
+
 using seqan3::operator""_aa27;
 using seqan3::operator""_dna4;
 using seqan3::operator""_rna4;
@@ -25,6 +30,17 @@ using qualified_gapped_dna_phred42 = seqan3::qualified<seqan3::gapped<seqan3::dn
 using gapped_qualified_dna_phred42 = seqan3::gapped<qualified_dna_phred42>;
 using qualified_qualified_gapped_dna_phred42_phred42 = seqan3::qualified<qualified_gapped_dna_phred42, seqan3::phred42>;
 using gapped_alphabet_variant_dna_phred42 = seqan3::gapped<seqan3::alphabet_variant<seqan3::dna4, seqan3::phred42>>;
+
+using alphabet_types = ::testing::Types<qualified_dna_phred42,
+                                        qualified_gapped_dna_phred42,
+                                        gapped_qualified_dna_phred42,
+                                        qualified_qualified_gapped_dna_phred42_phred42,
+                                        gapped_alphabet_variant_dna_phred42>;
+
+INSTANTIATE_TYPED_TEST_SUITE_P(alphabet_composite_integration, alphabet, alphabet_types, );
+INSTANTIATE_TYPED_TEST_SUITE_P(alphabet_composite_integration, semi_alphabet_test, alphabet_types, );
+INSTANTIATE_TYPED_TEST_SUITE_P(alphabet_composite_integration, alphabet_constexpr, alphabet_types, );
+INSTANTIATE_TYPED_TEST_SUITE_P(alphabet_composite_integration, semi_alphabet_constexpr, alphabet_types, );
 
 TEST(composite, custom_constructors)
 {

--- a/test/unit/alphabet/gap/gapped_test.cpp
+++ b/test/unit/alphabet/gap/gapped_test.cpp
@@ -15,8 +15,6 @@
 #include <seqan3/alphabet/gap/gapped.hpp>
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/alphabet/nucleotide/dna15.hpp>
-#include <seqan3/alphabet/quality/phred42.hpp>
-#include <seqan3/alphabet/quality/qualified.hpp>
 
 #include "../alphabet_constexpr_test_template.hpp"
 #include "../alphabet_test_template.hpp"
@@ -26,8 +24,7 @@
 using seqan3::operator""_dna4;
 
 using gapped_types = ::testing::Types<seqan3::gapped<seqan3::dna4>,
-                                      seqan3::gapped<seqan3::dna15>,
-                                      seqan3::gapped<seqan3::qualified<seqan3::dna4, seqan3::phred42>>>;
+                                      seqan3::gapped<seqan3::dna15>>;
 
 INSTANTIATE_TYPED_TEST_SUITE_P(gapped, alphabet, gapped_types, );
 INSTANTIATE_TYPED_TEST_SUITE_P(gapped, semi_alphabet_test, gapped_types, );

--- a/test/unit/argument_parser/detail/CMakeLists.txt
+++ b/test/unit/argument_parser/detail/CMakeLists.txt
@@ -1,8 +1,13 @@
 find_path (SEQAN3_TEST_LICENSE_DIR NAMES LICENSE.md HINTS "${SEQAN3_CLONE_DIR}")
 
 add_definitions(-DSEQAN3_TEST_LICENSE_DIR="${SEQAN3_TEST_LICENSE_DIR}")
-seqan3_test(format_help_test.cpp)
-seqan3_test(format_html_test.cpp)
+
+seqan3_test(format_help_test.cpp CYCLIC_DEPENDING_INCLUDES
+            include-seqan3-argument_parser-detail-format_html.hpp
+            include-seqan3-argument_parser-detail-format_man.hpp)
+seqan3_test(format_html_test.cpp CYCLIC_DEPENDING_INCLUDES
+            include-seqan3-argument_parser-detail-format_help.hpp
+            include-seqan3-argument_parser-detail-format_man.hpp)
 seqan3_test(format_man_test.cpp)
 seqan3_test(version_check_debug_test.cpp)
 seqan3_test(version_check_release_test.cpp)

--- a/test/unit/core/algorithm/CMakeLists.txt
+++ b/test/unit/core/algorithm/CMakeLists.txt
@@ -1,4 +1,4 @@
-seqan3_test(algorithm_result_generator_range_test.cpp)
-seqan3_test (pipeable_config_element_test.cpp)
+seqan3_test (algorithm_result_generator_range_test.cpp)
+seqan3_test (pipeable_config_element_test.cpp CYCLIC_DEPENDING_INCLUDES include-seqan3-core-configuration-configuration.hpp)
 
 add_subdirectories()

--- a/test/unit/core/detail/template_inspection_test.cpp
+++ b/test/unit/core/detail/template_inspection_test.cpp
@@ -10,8 +10,10 @@
 #include <gtest/gtest.h>
 
 #include <seqan3/core/detail/template_inspection.hpp>
-#include <seqan3/utility/type_list/type_list.hpp>
 #include <seqan3/utility/type_traits/concept.hpp>
+
+template <typename ...args_t>
+struct my_list;
 
 template <std::integral t>
 struct constraint_bar
@@ -21,17 +23,17 @@ struct constraint_bar
 
 TEST(template_inspect, concept_check)
 {
-    using tl = seqan3::type_list<int, char, double>;
+    using tl = my_list<int, char, double>;
 
     EXPECT_FALSE((seqan3::transformation_trait<seqan3::detail::transfer_template_args_onto<int, std::tuple>>));
     EXPECT_TRUE((seqan3::transformation_trait<seqan3::detail::transfer_template_args_onto<tl, std::tuple>>));
 
-    EXPECT_TRUE((seqan3::unary_type_trait<seqan3::detail::is_type_specialisation_of<int, seqan3::type_list>>));
+    EXPECT_TRUE((seqan3::unary_type_trait<seqan3::detail::is_type_specialisation_of<int, my_list>>));
 }
 
 TEST(template_inspect, transfer_template_args_onto_t)
 {
-    using tl = seqan3::type_list<int, char, double>;
+    using tl = my_list<int, char, double>;
     using t = seqan3::detail::transfer_template_args_onto<tl, std::tuple>::type;
     EXPECT_TRUE((std::is_same_v<t, std::tuple<int, char, double>>));
 
@@ -49,32 +51,32 @@ TEST(template_inspect, transfer_template_args_onto_with_constraint)
     using bar_int = constraint_bar<int>;
 
     // float does not fulfil integral constraint
-    using bar_float_identity = seqan3::detail::transfer_template_args_onto<seqan3::type_list<float>, constraint_bar>;
+    using bar_float_identity = seqan3::detail::transfer_template_args_onto<my_list<float>, constraint_bar>;
     EXPECT_FALSE(seqan3::transformation_trait<bar_float_identity>);
 
     // int fulfils integral constraint and static_assert
-    using bar_int_identity = seqan3::detail::transfer_template_args_onto<seqan3::type_list<int>, constraint_bar>;
+    using bar_int_identity = seqan3::detail::transfer_template_args_onto<my_list<int>, constraint_bar>;
     EXPECT_TRUE(seqan3::transformation_trait<bar_int_identity>);
     EXPECT_TRUE((std::is_same_v<typename bar_int_identity::type, bar_int>));
 
     // char fulfils integral constraint, but not static_assert
-    using bar_char_identity = seqan3::detail::transfer_template_args_onto<seqan3::type_list<char>, constraint_bar>;
+    using bar_char_identity = seqan3::detail::transfer_template_args_onto<my_list<char>, constraint_bar>;
     EXPECT_TRUE(seqan3::transformation_trait<bar_char_identity>);
     EXPECT_TRUE((std::is_same_v<typename bar_char_identity::type, bar_char>));
 }
 
 TEST(template_inspect, is_type_specialisation_of)
 {
-    using tl = seqan3::type_list<int, char, double>;
-    EXPECT_TRUE((seqan3::detail::is_type_specialisation_of<tl, seqan3::type_list>::value));
-    EXPECT_FALSE((seqan3::detail::is_type_specialisation_of<int, seqan3::type_list>::value));
+    using tl = my_list<int, char, double>;
+    EXPECT_TRUE((seqan3::detail::is_type_specialisation_of<tl, my_list>::value));
+    EXPECT_FALSE((seqan3::detail::is_type_specialisation_of<int, my_list>::value));
 }
 
 TEST(template_inspect, is_type_specialisation_of_v)
 {
-    using tl = seqan3::type_list<int, char, double>;
-    EXPECT_TRUE((seqan3::detail::is_type_specialisation_of_v<tl, seqan3::type_list>));
-    EXPECT_FALSE((seqan3::detail::is_type_specialisation_of_v<int, seqan3::type_list>));
+    using tl = my_list<int, char, double>;
+    EXPECT_TRUE((seqan3::detail::is_type_specialisation_of_v<tl, my_list>));
+    EXPECT_FALSE((seqan3::detail::is_type_specialisation_of_v<int, my_list>));
 }
 
 TEST(template_inspect, is_type_specialisation_with_constraint)
@@ -193,6 +195,6 @@ TEST(template_inspect, is_type_specialisation_of_with_ill_formed_non_type_templa
 
 TEST(template_inspect, template_specialisation_of)
 {
-    EXPECT_TRUE((seqan3::detail::template_specialisation_of<seqan3::type_list<float>, seqan3::type_list>));
-    EXPECT_FALSE((seqan3::detail::template_specialisation_of<seqan3::type_list<int>, std::tuple>));
+    EXPECT_TRUE((seqan3::detail::template_specialisation_of<my_list<float>, my_list>));
+    EXPECT_FALSE((seqan3::detail::template_specialisation_of<my_list<int>, std::tuple>));
 }

--- a/test/unit/io/alignment_file/CMakeLists.txt
+++ b/test/unit/io/alignment_file/CMakeLists.txt
@@ -1,5 +1,5 @@
 seqan3_test(sam_tag_dictionary_test.cpp)
-seqan3_test(format_bam_test.cpp)
-seqan3_test(format_sam_test.cpp)
+seqan3_test(format_bam_test.cpp CYCLIC_DEPENDING_INCLUDES include-seqan3-io-alignment_file-format_sam.hpp)
+seqan3_test(format_sam_test.cpp CYCLIC_DEPENDING_INCLUDES include-seqan3-io-alignment_file-format_bam.hpp)
 seqan3_test(alignment_file_output_test.cpp)
 seqan3_test(alignment_file_input_test.cpp)


### PR DESCRIPTION
This PR introduces `-DSEQAN3_USE_INCLUDE_DEPENDENCIES` which creates a dependency graph by using the include-graph.

The main idea is to have a bi-partite graph where the left nodes are the header and the right nodes the test cases. Each test case is associated with it's corresponding header, e.g. gap_test has a directed edge to include/seqan3/alphabet/gap/gap.hpp. This has the effect that a header can be marked as "known-to-work" if a test case could be built. Furthermore, add an edge for each include a test case uses (from include to test).

For example gap_test uses these headers:
* include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
* include/seqan3/alignment/exception.hpp
* include/seqan3/alphabet/alphabet_base.hpp
* [...]
* include/seqan3/std/concepts.hpp
* include/seqan3/std/iterator.hpp
* include/seqan3/std/ranges.hpp
* include/seqan3/std/type_traits.hpp

That means that for example `include/seqan3/std/concepts.hpp` must be known to be good (i.e. the test for that header must be buildable) in order to build `gap_test`.

This provides us some nice properties (assuming that every header has a good test case):
* that means that headers have acyclic includes (we test that already in our header tests)
* you see an error (introduced by seqan3) only once; and the test that fails will tell you which header is at fault
* tests only use features that are known to work (otherwise you would get a cyclic dependency error, see below for an example). This reflects that classes are constructed by (smaller) building blocks that are known to work and ensures that every component of seqan3 is testable
* this is great for doing migrations to a new compiler version or library upgrades

### General workflow:

* enable this feature by `cmake -DSEQAN3_USE_INCLUDE_DEPENDENCIES=1 <...>`
* use `make all_dependencies` to generate all dependencies for each target before building the first target
* use `cmake .` to make sure that the cmake dependency graph is properly constructed
  * this step can fail if tests have cyclic dependencies
  * if that happens try to read the diagnostic to see how the cycle works and try to resolve it
* build your target(s)
  * This will build targets according to the order of the include-graph: targets with fewer includes are build first
* use `make clean` if the cmake configuration step can't be executed and you have resolved the cycle (sometimes, cmake does not recognise that a change happened), followed by `make all_dependencies`

### Example:

```bash
make gap_test
```

will output

```
[ 14%] Built target gtest_project
Scanning dependencies of target include-seqan3-std-iterator.hpp
[ 14%] Built target include-seqan3-std-iterator.hpp
Scanning dependencies of target include-seqan3-std-concepts.hpp
[ 14%] Built target include-seqan3-std-concepts.hpp
Scanning dependencies of target include-seqan3-core-char_operations-pretty_print.hpp
[ 14%] Built target include-seqan3-core-char_operations-pretty_print.hpp
Scanning dependencies of target include-seqan3-std-type_traits.hpp
[ 14%] Built target include-seqan3-std-type_traits.hpp
Scanning dependencies of target include-seqan3-alphabet-exception.hpp
[ 14%] Built target include-seqan3-alphabet-exception.hpp
[ 14%] Built target cereal_test_dependencies
Scanning dependencies of target include-seqan3-core-platform.hpp
[ 14%] Built target include-seqan3-core-platform.hpp
[ 14%] Building CXX object core/concept/CMakeFiles/cereal_test.dir/cereal_test.cpp.o
[ 28%] Linking CXX executable cereal_test
[ 28%] Built target cereal_test
Scanning dependencies of target include-seqan3-core-concept-cereal.hpp
[ 28%] Built target include-seqan3-core-concept-cereal.hpp
[ 28%] Built target basic_test_dependencies
[ 42%] Building CXX object core/type_traits/CMakeFiles/basic_test.dir/basic_test.cpp.o
[ 42%] Linking CXX executable basic_test
[ 42%] Built target basic_test
Scanning dependencies of target include-seqan3-core-type_traits-basic.hpp
[ 42%] Built target include-seqan3-core-type_traits-basic.hpp
Scanning dependencies of target include-seqan3-core-detail-debug_stream_alphabet.hpp
[ 42%] Built target include-seqan3-core-detail-debug_stream_alphabet.hpp
[ 42%] Built target int_types_test_dependencies
[ 42%] Building CXX object core/detail/CMakeFiles/int_types_test.dir/int_types_test.cpp.o
[ 42%] Linking CXX executable int_types_test
[ 42%] Built target int_types_test
Scanning dependencies of target include-seqan3-core-detail-int_types.hpp
[ 42%] Built target include-seqan3-core-detail-int_types.hpp
[ 42%] Built target mask_test_dependencies
[ 57%] Built target add_enum_bitwise_operators_test_dependencies
[ 57%] Building CXX object core/CMakeFiles/add_enum_bitwise_operators_test.dir/add_enum_bitwise_operators_test.cpp.o
[ 57%] Linking CXX executable add_enum_bitwise_operators_test
[ 57%] Built target add_enum_bitwise_operators_test
Scanning dependencies of target include-seqan3-core-add_enum_bitwise_operators.hpp
[ 57%] Built target include-seqan3-core-add_enum_bitwise_operators.hpp
Scanning dependencies of target include-seqan3-alphabet-concept.hpp
[ 57%] Built target include-seqan3-alphabet-concept.hpp
Scanning dependencies of target include-seqan3-alphabet-alphabet_base.hpp
[ 57%] Built target include-seqan3-alphabet-alphabet_base.hpp
Scanning dependencies of target include-seqan3-core-concept-core_language.hpp
[ 57%] Built target include-seqan3-core-concept-core_language.hpp
Scanning dependencies of target include-seqan3-core-detail-customisation_point.hpp
[ 57%] Built target include-seqan3-core-detail-customisation_point.hpp
Scanning dependencies of target include-seqan3-core-detail-debug_stream_type.hpp
[ 57%] Built target include-seqan3-core-detail-debug_stream_type.hpp
[ 57%] Built target type_inspection_test_dependencies
[ 57%] Built target transformation_trait_or_test_dependencies
Scanning dependencies of target include-seqan3-core-type_traits-concept.hpp
[ 57%] Built target include-seqan3-core-type_traits-concept.hpp
[ 57%] Building CXX object core/type_traits/CMakeFiles/transformation_trait_or_test.dir/transformation_trait_or_test.cpp.o
[ 71%] Linking CXX executable transformation_trait_or_test
[ 71%] Built target transformation_trait_or_test
Scanning dependencies of target include-seqan3-core-type_traits-transformation_trait_or.hpp
[ 71%] Built target include-seqan3-core-type_traits-transformation_trait_or.hpp
[ 71%] Built target template_inspection_test_dependencies
Scanning dependencies of target include-seqan3-core-type_list-type_list.hpp
[ 71%] Built target include-seqan3-core-type_list-type_list.hpp
[ 85%] Building CXX object core/type_traits/CMakeFiles/template_inspection_test.dir/template_inspection_test.cpp.o
[ 85%] Linking CXX executable template_inspection_test
[ 85%] Built target template_inspection_test
Scanning dependencies of target include-seqan3-core-type_traits-template_inspection.hpp
[ 85%] Built target include-seqan3-core-type_traits-template_inspection.hpp
Scanning dependencies of target include-seqan3-core-type_list-traits.hpp
[ 85%] Built target include-seqan3-core-type_list-traits.hpp
[ 85%] Building CXX object core/detail/CMakeFiles/type_inspection_test.dir/type_inspection_test.cpp.o
[100%] Linking CXX executable type_inspection_test
[100%] Built target type_inspection_test
Scanning dependencies of target include-seqan3-core-detail-type_inspection.hpp
[100%] Built target include-seqan3-core-detail-type_inspection.hpp
Scanning dependencies of target include-seqan3-io-stream-concept.hpp
[100%] Built target include-seqan3-io-stream-concept.hpp
[100%] Building CXX object alphabet/mask/CMakeFiles/mask_test.dir/mask_test.cpp.o
[100%] Linking CXX executable mask_test
[100%] Built target mask_test
Scanning dependencies of target include-seqan3-alphabet-mask-mask.hpp
[100%] Built target include-seqan3-alphabet-mask-mask.hpp
[100%] Building CXX object alphabet/gap/CMakeFiles/gap_test.dir/gap_test.cpp.o
[100%] Linking CXX executable gap_test
[100%] Built target gap_test
```

### Cyclic Dependencies:

```
CMake Error: The inter-target dependency graph contains the following strongly connected component (cycle):
[1]  "include-seqan3-alphabet-gap-gapped.hpp" of type UTILITY
       depends on "gapped_test" (strong)
[2]  "include-seqan3-alphabet-quality-qualified.hpp" of type UTILITY
       depends on "qualified_test" (strong)
[3]  "gapped_test" of type EXECUTABLE
       depends on "include-seqan3-alphabet-quality-qualified.hpp" (strong)
[4]  "qualified_test" of type EXECUTABLE
       depends on "include-seqan3-alphabet-gap-gapped.hpp" (strong)
At least one of these targets is not a STATIC_LIBRARY.  Cyclic dependencies are allowed only among static libraries.
CMake Generate step failed.  Build files cannot be regenerated correctly.
```

Can be read as:

* include/seqan3/alphabet/gap/gapped.hpp [1] depends on
* gapped_test depends [3] on
* include/seqan3/alphabet/quality/qualified.hpp [2] depends on
* qualified_test [4] depends on
* include/seqan3/alphabet/gap/gapped.hpp [1]

That means that gapped_test and qualified_test each use `seqan3::gapped` and `seqan3::qualified` in their test. This must be avoided, because the gapped header can only be marked as working if the qualified header was marked as working, but the qualified header can only be marked as working when the gapped header was marked.