### PR TITLE
[MISC] Enable computation of begin position in alignment result builder.

### DIFF
--- a/include/seqan3/alignment/pairwise/detail/pairwise_alignment_algorithm.hpp
+++ b/include/seqan3/alignment/pairwise/detail/pairwise_alignment_algorithm.hpp
@@ -144,6 +144,7 @@ public:
                                          std::move(idx),
                                          this->optimal_score,
                                          this->optimal_coordinate,
+                                         alignment_matrix,
                                          callback);
         }
     }
@@ -194,6 +195,7 @@ public:
                                          std::move(idx),
                                          std::move(score),
                                          std::move(coordinate),
+                                         alignment_matrix,
                                          callback);
             ++index;
         }

--- a/include/seqan3/alignment/pairwise/detail/pairwise_alignment_algorithm_banded.hpp
+++ b/include/seqan3/alignment/pairwise/detail/pairwise_alignment_algorithm_banded.hpp
@@ -107,6 +107,7 @@ public:
                                          std::move(idx),
                                          this->optimal_score,
                                          this->optimal_coordinate,
+                                         alignment_matrix,
                                          callback);
         }
     }
@@ -158,6 +159,7 @@ public:
                                          std::move(idx),
                                          std::move(score),
                                          std::move(coordinate),
+                                         alignment_matrix,
                                          callback);
             ++index;
         }


### PR DESCRIPTION
Enables the computation of the begin position inside of the refactored alignment.
Before, only the score and end position could be computed. Now it is also possible to compute the begin positions. 
In the upcoming PRs also the trace computation will be enabled including the logging mechanism.