### PR TITLE
[FIX] MacOS gcc8 CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,7 +232,9 @@ jobs:
           if [ "$RUNNER_OS" == "Linux" ]; then
             sudo apt-get install --yes ${{ matrix.cxx }}
           else
-            brew install --force-bottle $(echo "${{ matrix.cxx }}" | sed "s/++-/cc@/g")
+            cxx_macos_name=$(echo "${{ matrix.cxx }}" | sed "s/++-/cc@/g")
+            brew install --force-bottle $cxx_macos_name
+            brew link $cxx_macos_name
           fi
 
       - name: Install lcov


### PR DESCRIPTION
Apparently the image has changed and now the globally installed version of 8.4.0 is used instead of the brew one.
The globally installed one has some errors....