### PR TITLE
[FIX] Fixes the spurious fails of the buffer queue.

### DIFF
--- a/include/seqan3/contrib/parallel/buffer_queue.hpp
+++ b/include/seqan3/contrib/parallel/buffer_queue.hpp
@@ -217,12 +217,13 @@ public:
      */
     void close() noexcept
     {
-        closed_flag.store(true, std::memory_order_release);
+        std::unique_lock write_lock{mutex};
+        closed_flag = true;
     }
 
     bool is_closed() const noexcept
     {
-        return closed_flag.load(std::memory_order_acquire);
+        return closed_flag;
     }
 
     bool is_empty() const noexcept
@@ -339,7 +340,7 @@ private:
     alignas(std::hardware_destructive_interference_size) std::atomic<size_type>    push_back_position{0};
     alignas(std::hardware_destructive_interference_size) std::atomic<size_type>    pending_push_back_position{0};
     alignas(std::hardware_destructive_interference_size) std::atomic<size_type>    ring_buffer_capacity{0};
-    alignas(std::hardware_destructive_interference_size) std::atomic<bool>         closed_flag{false};
+    alignas(std::hardware_destructive_interference_size) bool                      closed_flag{false};
 };
 
 // Specifies a fixed size buffer queue.


### PR DESCRIPTION
Big thanks to @eseiler for figuring out the actual problem!

When calling the close operation a write lock must be acquired
to prevent concurrent read access on the shared closed_flag by consumer
threads. The atomic used so far was not sufficient enough to prevent
a data race between the closing thread and producers that currently
acquired the shared read lock on the same mutex.
In particular, it could happen that one producer thread adds an
item to the empty queue and closes the queue  immediately. In the
meantime a consumer could have observed the empty queue right before
the element was added and then checked the closed_flag shortly after
it has beend updated by the other thread. In this state the consumer
falsely interprets the queue as empty and closed, while there is
still an item left.