### PR TITLE
[FIX] parallel config ending up ignored

### DIFF
--- a/include/seqan3/core/algorithm/detail/algorithm_executor_blocking.hpp
+++ b/include/seqan3/core/algorithm/detail/algorithm_executor_blocking.hpp
@@ -313,6 +313,7 @@ private:
     {
         algorithm = std::move(other.algorithm);
         buffer_size = std::move(other.buffer_size);
+        exec_handler = std::move(other.exec_handler);
         // Get the old resource position.
         auto old_resource_position = std::ranges::distance(std::ranges::begin(other.resource),
                                                            other.resource_it);


### PR DESCRIPTION
Resolves https://github.com/seqan/seqan3/issues/2278

We need to fix some things such that `move` works.

* lhs => default constructed => 160 threads
* rhs => custom construced => 4 threads
* lhs = std::move(rhs) => lhs.reset(rhs.release())
* rhs.release() => return ptr to resource and set ptr = nullptr => destructor ist not called, but not a problem here
* lhs.reset(new_ptr) => old_ptr = lhs.ptr; lhs.ptr = new_ptr; lhs.deleter(old_ptr) => problem! The destructor destoys the internal state with the thread pool before alle the threads have been joined since `wait()` hasn't been called.