### PR TITLE
[MISC] Change seqan3::option_spec enum names to lower case.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,8 @@ If possible, provide tooling that performs the changes, e.g. a shell-script.
 
 #### Argument Parser
 
-* The enum names of `seqan3::option_spec` were changed to lower case:
+* The enum names of `seqan3::option_spec` were changed to lower case
+  ([\#2285](https://github.com/seqan/seqan3/pull/2285)):
   * `seqan3::option_spec::DEFAULT` is replaced by `seqan3::option_spec::defaulted`.
   * `seqan3::option_spec::REQUIRED` is replaced by `seqan3::option_spec::required`.
   * `seqan3::option_spec::ADVANCED` is replaced by `seqan3::option_spec::advanced`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,16 @@ If possible, provide tooling that performs the changes, e.g. a shell-script.
 * The `seqan3::regex_validator` parses `std::filesystem::path`'s correctly now
   ([\#2216](https://github.com/seqan/seqan3/pull/2216)).
 
+## API changes
+
+#### Argument Parser
+
+* The enum names of `seqan3::option_spec` were changed to lower case:
+  * `seqan3::option_spec::DEFAULT` is replaced by `seqan3::option_spec::defaulted`.
+  * `seqan3::option_spec::REQUIRED` is replaced by `seqan3::option_spec::required`.
+  * `seqan3::option_spec::ADVANCED` is replaced by `seqan3::option_spec::advanced`.
+  * `seqan3::option_spec::HIDDEN` is replaced by `seqan3::option_spec::hidden`.
+
 # 3.0.2
 
 Note that 3.1.0 will be the first API stable release and interfaces in this release might still change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ If possible, provide tooling that performs the changes, e.g. a shell-script.
 
 * The enum names of `seqan3::option_spec` were changed to lower case
   ([\#2285](https://github.com/seqan/seqan3/pull/2285)):
-  * `seqan3::option_spec::DEFAULT` is replaced by `seqan3::option_spec::defaulted`.
+  * `seqan3::option_spec::DEFAULT` is replaced by `seqan3::option_spec::standard`.
   * `seqan3::option_spec::REQUIRED` is replaced by `seqan3::option_spec::required`.
   * `seqan3::option_spec::ADVANCED` is replaced by `seqan3::option_spec::advanced`.
   * `seqan3::option_spec::HIDDEN` is replaced by `seqan3::option_spec::hidden`.

--- a/doc/tutorial/argument_parser/index.md
+++ b/doc/tutorial/argument_parser/index.md
@@ -340,7 +340,7 @@ Our applications often do not allow just any value to be passed as input argumen
 
 A *validator* is a [functor](https://stackoverflow.com/questions/356950/what-are-c-functors-and-their-uses) that is called within the argument parser after retrieving and converting a command line argument. We provide several validators, which we hope cover most of the use cases, but you can always create your own validator (see section [Create your own validator](#section_create_your_own_validator)).
 
-\attention You can pass a validator to the seqan3::argument_parser::add_option function only after passing the seqan3::option_spec parameter. Pass the seqan3::option_spec::defaulted tag, if there are no further restrictions on your option.
+\attention You can pass a validator to the seqan3::argument_parser::add_option function only after passing the seqan3::option_spec parameter. Pass the seqan3::option_spec::defaulted tag if there are no further restrictions on your option.
 
 ## SeqAn validators
 

--- a/doc/tutorial/argument_parser/index.md
+++ b/doc/tutorial/argument_parser/index.md
@@ -308,12 +308,12 @@ Set an option/flag to hidden, if you want to completely hide it from the user. I
 
 Summary:
 
-| Tag        | Description                                                    |
-|:-----------|:---------------------------------------------------------------|
-| defaulted  | The default tag with no special behaviour.                     |
-| required   | Required options will cause an error if not provided.          |
-| advanced   | Advanced options are only displayed wit `-hh/--advanced-help`. |
-| hidden     | Hidden options are never displayed when exported.              |
+| Tag        | Description                                                                                       |
+|:-----------|:--------------------------------------------------------------------------------------------------|
+| standard   | The default tag (non-required and always visible).                                                |
+| required   | Required options will cause an error if not provided (required and always visible).               |
+| advanced   | Advanced options are only displayed wit `-hh/--advanced-help`. (non-required and partly visible). |
+| hidden     | Hidden options are never displayed when exported (non-required and non-visible).                  |
 
 \assignment{Assignment 5}
 
@@ -340,7 +340,7 @@ Our applications often do not allow just any value to be passed as input argumen
 
 A *validator* is a [functor](https://stackoverflow.com/questions/356950/what-are-c-functors-and-their-uses) that is called within the argument parser after retrieving and converting a command line argument. We provide several validators, which we hope cover most of the use cases, but you can always create your own validator (see section [Create your own validator](#section_create_your_own_validator)).
 
-\attention You can pass a validator to the seqan3::argument_parser::add_option function only after passing the seqan3::option_spec parameter. Pass the seqan3::option_spec::defaulted tag if there are no further restrictions on your option.
+\attention You can pass a validator to the seqan3::argument_parser::add_option function only after passing the seqan3::option_spec parameter. Pass the seqan3::option_spec::standard tag if there are no further restrictions on your option.
 
 ## SeqAn validators
 

--- a/doc/tutorial/argument_parser/index.md
+++ b/doc/tutorial/argument_parser/index.md
@@ -310,10 +310,10 @@ Summary:
 
 | Tag        | Description                                                    |
 |:-----------|:---------------------------------------------------------------|
-| DEFAULT    | The default tag with no special behaviour.                     |
-| REQUIRED   | Required options will cause an error if not provided.          |
-| ADVANCED   | Advanced options are only displayed wit `-hh/--advanced-help`. |
-| HIDDEN     | Hidden options are never displayed when exported.              |
+| defaulted  | The default tag with no special behaviour.                     |
+| required   | Required options will cause an error if not provided.          |
+| advanced   | Advanced options are only displayed wit `-hh/--advanced-help`. |
+| hidden     | Hidden options are never displayed when exported.              |
 
 \assignment{Assignment 5}
 
@@ -340,7 +340,7 @@ Our applications often do not allow just any value to be passed as input argumen
 
 A *validator* is a [functor](https://stackoverflow.com/questions/356950/what-are-c-functors-and-their-uses) that is called within the argument parser after retrieving and converting a command line argument. We provide several validators, which we hope cover most of the use cases, but you can always create your own validator (see section [Create your own validator](#section_create_your_own_validator)).
 
-\attention You can pass a validator to the seqan3::argument_parser::add_option function only after passing the seqan3::option_spec parameter. Pass the seqan3::option_spec::DEFAULT tag, if there are no further restrictions on your option.
+\attention You can pass a validator to the seqan3::argument_parser::add_option function only after passing the seqan3::option_spec parameter. Pass the seqan3::option_spec::defaulted tag, if there are no further restrictions on your option.
 
 ## SeqAn validators
 

--- a/doc/tutorial/argument_parser/index.md
+++ b/doc/tutorial/argument_parser/index.md
@@ -312,7 +312,7 @@ Summary:
 |:-----------|:--------------------------------------------------------------------------------------------------|
 | standard   | The default tag (non-required and always visible).                                                |
 | required   | Required options will cause an error if not provided (required and always visible).               |
-| advanced   | Advanced options are only displayed wit `-hh/--advanced-help`. (non-required and partly visible). |
+| advanced   | Advanced options are only displayed wit `-hh/--advanced-help`. (non-required and visible on request). |
 | hidden     | Hidden options are never displayed when exported (non-required and non-visible).                  |
 
 \assignment{Assignment 5}

--- a/doc/tutorial/argument_parser/small_snippets.cpp
+++ b/doc/tutorial/argument_parser/small_snippets.cpp
@@ -64,7 +64,7 @@ parser.add_positional_option(list_variable, "Give me one or more variables!.");
 seqan3::argument_parser parser{"Example-Parser", argc, argv};
 //![required_option]
 std::string required_variable{};
-parser.add_option(required_variable, 'n', "name", "I really need a name.", seqan3::option_spec::REQUIRED);
+parser.add_option(required_variable, 'n', "name", "I really need a name.", seqan3::option_spec::required);
 //![required_option]
 }
 

--- a/doc/tutorial/argument_parser/solution5.cpp
+++ b/doc/tutorial/argument_parser/solution5.cpp
@@ -80,7 +80,7 @@ void initialise_argument_parser(seqan3::argument_parser & parser, cmd_arguments 
     parser.add_positional_option(args.file_path, "Please provide a tab separated data file.");
 
 //![solution]
-    parser.add_option(args.seasons, 's', "season", "Choose the seasons to aggregate.", seqan3::option_spec::REQUIRED);
+    parser.add_option(args.seasons, 's', "season", "Choose the seasons to aggregate.", seqan3::option_spec::required);
 //![solution]
 
     parser.add_option(args.aggregate_by, 'a', "aggregate-by", "Choose your method of aggregation: mean or median.");

--- a/doc/tutorial/argument_parser/solution6.cpp
+++ b/doc/tutorial/argument_parser/solution6.cpp
@@ -89,7 +89,7 @@ void initialise_argument_parser(seqan3::argument_parser & parser, cmd_arguments 
 
     //![value_list_validator]
     parser.add_option(args.aggregate_by, 'a', "aggregate-by", "Choose your method of aggregation.",
-                      seqan3::option_spec::defaulted, seqan3::value_list_validator{"median", "mean"});
+                      seqan3::option_spec::standard, seqan3::value_list_validator{"median", "mean"});
     //![value_list_validator]
 
     parser.add_flag(args.header_is_set, 'H', "header-is-set", "Let us know whether your data file contains a "

--- a/doc/tutorial/argument_parser/solution6.cpp
+++ b/doc/tutorial/argument_parser/solution6.cpp
@@ -84,12 +84,12 @@ void initialise_argument_parser(seqan3::argument_parser & parser, cmd_arguments 
 
     //![arithmetic_range_validator]
     parser.add_option(args.seasons, 's', "season", "Choose the seasons to aggregate.",
-                      seqan3::option_spec::REQUIRED, seqan3::arithmetic_range_validator{1, 7});
+                      seqan3::option_spec::required, seqan3::arithmetic_range_validator{1, 7});
     //![arithmetic_range_validator]
 
     //![value_list_validator]
     parser.add_option(args.aggregate_by, 'a', "aggregate-by", "Choose your method of aggregation.",
-                      seqan3::option_spec::DEFAULT, seqan3::value_list_validator{"median", "mean"});
+                      seqan3::option_spec::defaulted, seqan3::value_list_validator{"median", "mean"});
     //![value_list_validator]
 
     parser.add_flag(args.header_is_set, 'H', "header-is-set", "Let us know whether your data file contains a "

--- a/doc/tutorial/concepts/custom_validator_solution2.cpp
+++ b/doc/tutorial/concepts/custom_validator_solution2.cpp
@@ -33,10 +33,10 @@ int main(int argc, char ** argv)
     int32_t variable{};
     int16_t variable2{};
 
-    myparser.add_option(variable, 'i', "", "An int that is a square", seqan3::option_spec::defaulted,
+    myparser.add_option(variable, 'i', "", "An int that is a square", seqan3::option_spec::standard,
                         custom_validator{}); // ← your validator is used!
 
-    myparser.add_option(variable2, 'j', "", "An int that is a square and within [0,20].", seqan3::option_spec::defaulted,
+    myparser.add_option(variable2, 'j', "", "An int that is a square and within [0,20].", seqan3::option_spec::standard,
                         custom_validator{} | seqan3::arithmetic_range_validator{0, 20}); // ← now it's chained
 
     try

--- a/doc/tutorial/concepts/custom_validator_solution2.cpp
+++ b/doc/tutorial/concepts/custom_validator_solution2.cpp
@@ -33,10 +33,10 @@ int main(int argc, char ** argv)
     int32_t variable{};
     int16_t variable2{};
 
-    myparser.add_option(variable, 'i', "", "An int that is a square", seqan3::option_spec::DEFAULT,
+    myparser.add_option(variable, 'i', "", "An int that is a square", seqan3::option_spec::defaulted,
                         custom_validator{}); // ← your validator is used!
 
-    myparser.add_option(variable2, 'j', "", "An int that is a square and within [0,20].", seqan3::option_spec::DEFAULT,
+    myparser.add_option(variable2, 'j', "", "An int that is a square and within [0,20].", seqan3::option_spec::defaulted,
                         custom_validator{} | seqan3::arithmetic_range_validator{0, 20}); // ← now it's chained
 
     try

--- a/doc/tutorial/read_mapper/read_mapper_indexer_step1.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_indexer_step1.cpp
@@ -23,7 +23,7 @@ void initialise_argument_parser(seqan3::argument_parser & parser, cmd_arguments 
                       seqan3::option_spec::required,
                       seqan3::input_file_validator{{"fa","fasta"}});
     parser.add_option(args.index_path, 'o', "output", "The output index file path.",
-                      seqan3::option_spec::defaulted,
+                      seqan3::option_spec::standard,
                       seqan3::output_file_validator{seqan3::output_file_open_options::create_new, {"index"}});
 }
 

--- a/doc/tutorial/read_mapper/read_mapper_indexer_step1.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_indexer_step1.cpp
@@ -20,10 +20,10 @@ void initialise_argument_parser(seqan3::argument_parser & parser, cmd_arguments 
     parser.info.short_description = "Creates an index over a reference.";
     parser.info.version = "1.0.0";
     parser.add_option(args.reference_path, 'r', "reference", "The path to the reference.",
-                      seqan3::option_spec::REQUIRED,
+                      seqan3::option_spec::required,
                       seqan3::input_file_validator{{"fa","fasta"}});
     parser.add_option(args.index_path, 'o', "output", "The output index file path.",
-                      seqan3::option_spec::DEFAULT,
+                      seqan3::option_spec::defaulted,
                       seqan3::output_file_validator{seqan3::output_file_open_options::create_new, {"index"}});
 }
 

--- a/doc/tutorial/read_mapper/read_mapper_indexer_step2.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_indexer_step2.cpp
@@ -47,10 +47,10 @@ void initialise_argument_parser(seqan3::argument_parser & parser, cmd_arguments 
     parser.info.short_description = "Creates an index over a reference.";
     parser.info.version = "1.0.0";
     parser.add_option(args.reference_path, 'r', "reference", "The path to the reference.",
-                      seqan3::option_spec::REQUIRED,
+                      seqan3::option_spec::required,
                       seqan3::input_file_validator{{"fa","fasta"}});
     parser.add_option(args.index_path, 'o', "output", "The output index file path.",
-                      seqan3::option_spec::DEFAULT,
+                      seqan3::option_spec::defaulted,
                       seqan3::output_file_validator{seqan3::output_file_open_options::create_new, {"index"}});
 }
 

--- a/doc/tutorial/read_mapper/read_mapper_indexer_step2.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_indexer_step2.cpp
@@ -50,7 +50,7 @@ void initialise_argument_parser(seqan3::argument_parser & parser, cmd_arguments 
                       seqan3::option_spec::required,
                       seqan3::input_file_validator{{"fa","fasta"}});
     parser.add_option(args.index_path, 'o', "output", "The output index file path.",
-                      seqan3::option_spec::defaulted,
+                      seqan3::option_spec::standard,
                       seqan3::output_file_validator{seqan3::output_file_open_options::create_new, {"index"}});
 }
 

--- a/doc/tutorial/read_mapper/read_mapper_indexer_step3.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_indexer_step3.cpp
@@ -65,7 +65,7 @@ void initialise_argument_parser(seqan3::argument_parser & parser, cmd_arguments 
                       seqan3::option_spec::required,
                       seqan3::input_file_validator{{"fa","fasta"}});
     parser.add_option(args.index_path, 'o', "output", "The output index file path.",
-                      seqan3::option_spec::defaulted,
+                      seqan3::option_spec::standard,
                       seqan3::output_file_validator{seqan3::output_file_open_options::create_new, {"index"}});
 }
 

--- a/doc/tutorial/read_mapper/read_mapper_indexer_step3.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_indexer_step3.cpp
@@ -62,10 +62,10 @@ void initialise_argument_parser(seqan3::argument_parser & parser, cmd_arguments 
     parser.info.short_description = "Creates an index over a reference.";
     parser.info.version = "1.0.0";
     parser.add_option(args.reference_path, 'r', "reference", "The path to the reference.",
-                      seqan3::option_spec::REQUIRED,
+                      seqan3::option_spec::required,
                       seqan3::input_file_validator{{"fa","fasta"}});
     parser.add_option(args.index_path, 'o', "output", "The output index file path.",
-                      seqan3::option_spec::DEFAULT,
+                      seqan3::option_spec::defaulted,
                       seqan3::output_file_validator{seqan3::output_file_open_options::create_new, {"index"}});
 }
 

--- a/doc/tutorial/read_mapper/read_mapper_step1.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_step1.cpp
@@ -38,10 +38,10 @@ void initialise_argument_parser(seqan3::argument_parser & parser, cmd_arguments 
                       seqan3::option_spec::required,
                       seqan3::input_file_validator{{"index"}});
     parser.add_option(args.sam_path, 'o', "output", "The output SAM file path.",
-                      seqan3::option_spec::defaulted,
+                      seqan3::option_spec::standard,
                       seqan3::output_file_validator{seqan3::output_file_open_options::create_new, {"sam"}});
     parser.add_option(args.errors, 'e', "error", "Maximum allowed errors.",
-                      seqan3::option_spec::defaulted,
+                      seqan3::option_spec::standard,
                       seqan3::arithmetic_range_validator{0, 4});
 }
 

--- a/doc/tutorial/read_mapper/read_mapper_step1.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_step1.cpp
@@ -29,19 +29,19 @@ void initialise_argument_parser(seqan3::argument_parser & parser, cmd_arguments 
     parser.info.short_description = "Map reads against a reference.";
     parser.info.version = "1.0.0";
     parser.add_option(args.reference_path, 'r', "reference", "The path to the reference.",
-                      seqan3::option_spec::REQUIRED,
+                      seqan3::option_spec::required,
                       seqan3::input_file_validator{{"fa","fasta"}});
     parser.add_option(args.query_path, 'q', "query", "The path to the query.",
-                      seqan3::option_spec::REQUIRED,
+                      seqan3::option_spec::required,
                       seqan3::input_file_validator{{"fq","fastq"}});
     parser.add_option(args.index_path, 'i', "index", "The path to the index.",
-                      seqan3::option_spec::REQUIRED,
+                      seqan3::option_spec::required,
                       seqan3::input_file_validator{{"index"}});
     parser.add_option(args.sam_path, 'o', "output", "The output SAM file path.",
-                      seqan3::option_spec::DEFAULT,
+                      seqan3::option_spec::defaulted,
                       seqan3::output_file_validator{seqan3::output_file_open_options::create_new, {"sam"}});
     parser.add_option(args.errors, 'e', "error", "Maximum allowed errors.",
-                      seqan3::option_spec::DEFAULT,
+                      seqan3::option_spec::defaulted,
                       seqan3::arithmetic_range_validator{0, 4});
 }
 

--- a/doc/tutorial/read_mapper/read_mapper_step2.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_step2.cpp
@@ -102,10 +102,10 @@ void initialise_argument_parser(seqan3::argument_parser & parser, cmd_arguments 
                       seqan3::option_spec::required,
                       seqan3::input_file_validator{{"index"}});
     parser.add_option(args.sam_path, 'o', "output", "The output SAM file path.",
-                      seqan3::option_spec::defaulted,
+                      seqan3::option_spec::standard,
                       seqan3::output_file_validator{seqan3::output_file_open_options::create_new, {"sam"}});
     parser.add_option(args.errors, 'e', "error", "Maximum allowed errors.",
-                      seqan3::option_spec::defaulted,
+                      seqan3::option_spec::standard,
                       seqan3::arithmetic_range_validator{0, 4});
 }
 

--- a/doc/tutorial/read_mapper/read_mapper_step2.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_step2.cpp
@@ -93,19 +93,19 @@ void initialise_argument_parser(seqan3::argument_parser & parser, cmd_arguments 
     parser.info.short_description = "Map reads against a reference.";
     parser.info.version = "1.0.0";
     parser.add_option(args.reference_path, 'r', "reference", "The path to the reference.",
-                      seqan3::option_spec::REQUIRED,
+                      seqan3::option_spec::required,
                       seqan3::input_file_validator{{"fa","fasta"}});
     parser.add_option(args.query_path, 'q', "query", "The path to the query.",
-                      seqan3::option_spec::REQUIRED,
+                      seqan3::option_spec::required,
                       seqan3::input_file_validator{{"fq","fastq"}});
     parser.add_option(args.index_path, 'i', "index", "The path to the index.",
-                      seqan3::option_spec::REQUIRED,
+                      seqan3::option_spec::required,
                       seqan3::input_file_validator{{"index"}});
     parser.add_option(args.sam_path, 'o', "output", "The output SAM file path.",
-                      seqan3::option_spec::DEFAULT,
+                      seqan3::option_spec::defaulted,
                       seqan3::output_file_validator{seqan3::output_file_open_options::create_new, {"sam"}});
     parser.add_option(args.errors, 'e', "error", "Maximum allowed errors.",
-                      seqan3::option_spec::DEFAULT,
+                      seqan3::option_spec::defaulted,
                       seqan3::arithmetic_range_validator{0, 4});
 }
 

--- a/doc/tutorial/read_mapper/read_mapper_step3.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_step3.cpp
@@ -125,10 +125,10 @@ void initialise_argument_parser(seqan3::argument_parser & parser, cmd_arguments 
                       seqan3::option_spec::required,
                       seqan3::input_file_validator{{"index"}});
     parser.add_option(args.sam_path, 'o', "output", "The output SAM file path.",
-                      seqan3::option_spec::defaulted,
+                      seqan3::option_spec::standard,
                       seqan3::output_file_validator{seqan3::output_file_open_options::create_new, {"sam"}});
     parser.add_option(args.errors, 'e', "error", "Maximum allowed errors.",
-                      seqan3::option_spec::defaulted,
+                      seqan3::option_spec::standard,
                       seqan3::arithmetic_range_validator{0, 4});
 }
 

--- a/doc/tutorial/read_mapper/read_mapper_step3.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_step3.cpp
@@ -116,19 +116,19 @@ void initialise_argument_parser(seqan3::argument_parser & parser, cmd_arguments 
     parser.info.short_description = "Map reads against a reference.";
     parser.info.version = "1.0.0";
     parser.add_option(args.reference_path, 'r', "reference", "The path to the reference.",
-                      seqan3::option_spec::REQUIRED,
+                      seqan3::option_spec::required,
                       seqan3::input_file_validator{{"fa","fasta"}});
     parser.add_option(args.query_path, 'q', "query", "The path to the query.",
-                      seqan3::option_spec::REQUIRED,
+                      seqan3::option_spec::required,
                       seqan3::input_file_validator{{"fq","fastq"}});
     parser.add_option(args.index_path, 'i', "index", "The path to the index.",
-                      seqan3::option_spec::REQUIRED,
+                      seqan3::option_spec::required,
                       seqan3::input_file_validator{{"index"}});
     parser.add_option(args.sam_path, 'o', "output", "The output SAM file path.",
-                      seqan3::option_spec::DEFAULT,
+                      seqan3::option_spec::defaulted,
                       seqan3::output_file_validator{seqan3::output_file_open_options::create_new, {"sam"}});
     parser.add_option(args.errors, 'e', "error", "Maximum allowed errors.",
-                      seqan3::option_spec::DEFAULT,
+                      seqan3::option_spec::defaulted,
                       seqan3::arithmetic_range_validator{0, 4});
 }
 

--- a/doc/tutorial/read_mapper/read_mapper_step4.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_step4.cpp
@@ -134,10 +134,10 @@ void initialise_argument_parser(seqan3::argument_parser & parser, cmd_arguments 
                       seqan3::option_spec::required,
                       seqan3::input_file_validator{{"index"}});
     parser.add_option(args.sam_path, 'o', "output", "The output SAM file path.",
-                      seqan3::option_spec::defaulted,
+                      seqan3::option_spec::standard,
                       seqan3::output_file_validator{seqan3::output_file_open_options::create_new, {"sam"}});
     parser.add_option(args.errors, 'e', "error", "Maximum allowed errors.",
-                      seqan3::option_spec::defaulted,
+                      seqan3::option_spec::standard,
                       seqan3::arithmetic_range_validator{0, 4});
 }
 

--- a/doc/tutorial/read_mapper/read_mapper_step4.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_step4.cpp
@@ -125,19 +125,19 @@ void initialise_argument_parser(seqan3::argument_parser & parser, cmd_arguments 
     parser.info.short_description = "Map reads against a reference.";
     parser.info.version = "1.0.0";
     parser.add_option(args.reference_path, 'r', "reference", "The path to the reference.",
-                      seqan3::option_spec::REQUIRED,
+                      seqan3::option_spec::required,
                       seqan3::input_file_validator{{"fa","fasta"}});
     parser.add_option(args.query_path, 'q', "query", "The path to the query.",
-                      seqan3::option_spec::REQUIRED,
+                      seqan3::option_spec::required,
                       seqan3::input_file_validator{{"fq","fastq"}});
     parser.add_option(args.index_path, 'i', "index", "The path to the index.",
-                      seqan3::option_spec::REQUIRED,
+                      seqan3::option_spec::required,
                       seqan3::input_file_validator{{"index"}});
     parser.add_option(args.sam_path, 'o', "output", "The output SAM file path.",
-                      seqan3::option_spec::DEFAULT,
+                      seqan3::option_spec::defaulted,
                       seqan3::output_file_validator{seqan3::output_file_open_options::create_new, {"sam"}});
     parser.add_option(args.errors, 'e', "error", "Maximum allowed errors.",
-                      seqan3::option_spec::DEFAULT,
+                      seqan3::option_spec::defaulted,
                       seqan3::arithmetic_range_validator{0, 4});
 }
 

--- a/include/seqan3/argument_parser/argument_parser.hpp
+++ b/include/seqan3/argument_parser/argument_parser.hpp
@@ -241,7 +241,7 @@ public:
                     char const short_id,
                     std::string const & long_id,
                     std::string const & desc,
-                    option_spec const spec = option_spec::defaulted,
+                    option_spec const spec = option_spec::standard,
                     validator_type option_validator = validator_type{}) // copy to bind rvalues
     {
         if (sub_parser != nullptr)
@@ -266,7 +266,7 @@ public:
                   char const short_id,
                   std::string const & long_id,
                   std::string const & desc,
-                  option_spec const spec = option_spec::defaulted)
+                  option_spec const spec = option_spec::standard)
     {
         verify_identifiers(short_id, long_id);
         // copy variables into the lambda because the calls are pushed to a stack
@@ -488,22 +488,22 @@ public:
 
     /*!\brief Adds an help page section to the seqan3::argument_parser.
      * \param[in] title The title of the section.
-     * \param[in] spec Whether to always display this section title (seqan3::option_spec::defaulted), only when showing
+     * \param[in] spec Whether to always display this section title (seqan3::option_spec::standard), only when showing
      *                 the advanced help page (seqan3::option_spec::advanced) or never (seqan3::option_spec::hidden).
      * \details This only affects the help page and other output formats.
      */
-    void add_section(std::string const & title, option_spec const spec = option_spec::defaulted)
+    void add_section(std::string const & title, option_spec const spec = option_spec::standard)
     {
         std::visit([&] (auto & f) { f.add_section(title, spec); }, format);
     }
 
     /*!\brief Adds an help page subsection to the seqan3::argument_parser.
      * \param[in] title The title of the subsection.
-     * \param[in] spec Whether to always display this subsection title (seqan3::option_spec::defaulted), only when showing
+     * \param[in] spec Whether to always display this subsection title (seqan3::option_spec::standard), only when showing
      *                 the advanced help page (seqan3::option_spec::advanced) or never (seqan3::option_spec::hidden).
      * \details This only affects the help page and other output formats.
      */
-    void add_subsection(std::string const & title, option_spec const spec = option_spec::defaulted)
+    void add_subsection(std::string const & title, option_spec const spec = option_spec::standard)
     {
         std::visit([&] (auto & f) { f.add_subsection(title, spec); }, format);
     }
@@ -511,13 +511,13 @@ public:
     /*!\brief Adds an help page text line to the seqan3::argument_parser.
      * \param[in] text The text to print.
      * \param[in] is_paragraph Whether to insert as paragraph or just a line (Default: false).
-     * \param[in] spec Whether to always display this line (seqan3::option_spec::defaulted), only when showing
+     * \param[in] spec Whether to always display this line (seqan3::option_spec::standard), only when showing
      *                 the advanced help page (seqan3::option_spec::advanced) or never (seqan3::option_spec::hidden).
      * \details
      * If the line is not a paragraph (false), only one line break is appended, otherwise two line breaks are appended.
      * This only affects the help page and other output formats.
      */
-    void add_line(std::string const & text, bool is_paragraph = false, option_spec const spec = option_spec::defaulted)
+    void add_line(std::string const & text, bool is_paragraph = false, option_spec const spec = option_spec::standard)
     {
         std::visit([&] (auto & f) { f.add_line(text, is_paragraph, spec); }, format);
     }
@@ -525,7 +525,7 @@ public:
     /*!\brief Adds an help page list item (key-value) to the seqan3::argument_parser.
      * \param[in] key  The key of the key-value pair of the list item.
      * \param[in] desc The value of the key-value pair of the list item.
-     * \param[in] spec Whether to always display this list item (seqan3::option_spec::defaulted), only when showing
+     * \param[in] spec Whether to always display this list item (seqan3::option_spec::standard), only when showing
      *                 the advanced help page (seqan3::option_spec::advanced) or never (seqan3::option_spec::hidden).
      *
      * \details
@@ -542,7 +542,7 @@ public:
      */
     void add_list_item(std::string const & key,
                        std::string const & desc,
-                       option_spec const spec = option_spec::defaulted)
+                       option_spec const spec = option_spec::standard)
     {
         std::visit([&] (auto & f) { f.add_list_item(key, desc, spec); }, format);
     }

--- a/include/seqan3/argument_parser/argument_parser.hpp
+++ b/include/seqan3/argument_parser/argument_parser.hpp
@@ -241,7 +241,7 @@ public:
                     char const short_id,
                     std::string const & long_id,
                     std::string const & desc,
-                    option_spec const spec = option_spec::DEFAULT,
+                    option_spec const spec = option_spec::defaulted,
                     validator_type option_validator = validator_type{}) // copy to bind rvalues
     {
         if (sub_parser != nullptr)
@@ -266,7 +266,7 @@ public:
                   char const short_id,
                   std::string const & long_id,
                   std::string const & desc,
-                  option_spec const spec = option_spec::DEFAULT)
+                  option_spec const spec = option_spec::defaulted)
     {
         verify_identifiers(short_id, long_id);
         // copy variables into the lambda because the calls are pushed to a stack
@@ -488,22 +488,22 @@ public:
 
     /*!\brief Adds an help page section to the seqan3::argument_parser.
      * \param[in] title The title of the section.
-     * \param[in] spec Whether to always display this section title (seqan3::option_spec::DEFAULT), only when showing
-     *                 the advanced help page (seqan3::option_spec::ADVANCED) or never (seqan3::option_spec::HIDDEN).
+     * \param[in] spec Whether to always display this section title (seqan3::option_spec::defaulted), only when showing
+     *                 the advanced help page (seqan3::option_spec::advanced) or never (seqan3::option_spec::hidden).
      * \details This only affects the help page and other output formats.
      */
-    void add_section(std::string const & title, option_spec const spec = option_spec::DEFAULT)
+    void add_section(std::string const & title, option_spec const spec = option_spec::defaulted)
     {
         std::visit([&] (auto & f) { f.add_section(title, spec); }, format);
     }
 
     /*!\brief Adds an help page subsection to the seqan3::argument_parser.
      * \param[in] title The title of the subsection.
-     * \param[in] spec Whether to always display this subsection title (seqan3::option_spec::DEFAULT), only when showing
-     *                 the advanced help page (seqan3::option_spec::ADVANCED) or never (seqan3::option_spec::HIDDEN).
+     * \param[in] spec Whether to always display this subsection title (seqan3::option_spec::defaulted), only when showing
+     *                 the advanced help page (seqan3::option_spec::advanced) or never (seqan3::option_spec::hidden).
      * \details This only affects the help page and other output formats.
      */
-    void add_subsection(std::string const & title, option_spec const spec = option_spec::DEFAULT)
+    void add_subsection(std::string const & title, option_spec const spec = option_spec::defaulted)
     {
         std::visit([&] (auto & f) { f.add_subsection(title, spec); }, format);
     }
@@ -511,13 +511,13 @@ public:
     /*!\brief Adds an help page text line to the seqan3::argument_parser.
      * \param[in] text The text to print.
      * \param[in] is_paragraph Whether to insert as paragraph or just a line (Default: false).
-     * \param[in] spec Whether to always display this line (seqan3::option_spec::DEFAULT), only when showing
-     *                 the advanced help page (seqan3::option_spec::ADVANCED) or never (seqan3::option_spec::HIDDEN).
+     * \param[in] spec Whether to always display this line (seqan3::option_spec::defaulted), only when showing
+     *                 the advanced help page (seqan3::option_spec::advanced) or never (seqan3::option_spec::hidden).
      * \details
      * If the line is not a paragraph (false), only one line break is appended, otherwise two line breaks are appended.
      * This only affects the help page and other output formats.
      */
-    void add_line(std::string const & text, bool is_paragraph = false, option_spec const spec = option_spec::DEFAULT)
+    void add_line(std::string const & text, bool is_paragraph = false, option_spec const spec = option_spec::defaulted)
     {
         std::visit([&] (auto & f) { f.add_line(text, is_paragraph, spec); }, format);
     }
@@ -525,8 +525,8 @@ public:
     /*!\brief Adds an help page list item (key-value) to the seqan3::argument_parser.
      * \param[in] key  The key of the key-value pair of the list item.
      * \param[in] desc The value of the key-value pair of the list item.
-     * \param[in] spec Whether to always display this list item (seqan3::option_spec::DEFAULT), only when showing
-     *                 the advanced help page (seqan3::option_spec::ADVANCED) or never (seqan3::option_spec::HIDDEN).
+     * \param[in] spec Whether to always display this list item (seqan3::option_spec::defaulted), only when showing
+     *                 the advanced help page (seqan3::option_spec::advanced) or never (seqan3::option_spec::hidden).
      *
      * \details
      *
@@ -540,7 +540,9 @@ public:
      *            Super important integer for age.
      *```
      */
-    void add_list_item(std::string const & key, std::string const & desc, option_spec const spec = option_spec::DEFAULT)
+    void add_list_item(std::string const & key,
+                       std::string const & desc,
+                       option_spec const spec = option_spec::defaulted)
     {
         std::visit([&] (auto & f) { f.add_list_item(key, desc, spec); }, format);
     }

--- a/include/seqan3/argument_parser/auxiliary.hpp
+++ b/include/seqan3/argument_parser/auxiliary.hpp
@@ -224,33 +224,33 @@ inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, opt
  *
  * \details
  *
- * All options and flags are set to option_spec::defaulted unless specified
+ * All options and flags are set to option_spec::standard unless specified
  * otherwise by the developer, e.g. when calling argument_parser::add_option().
  *
  * \include test/snippet/argument_parser/auxiliary.cpp
  */
 enum option_spec
 {
-    defaulted = 0,//!< The default were no checking or special displaying is happening.
-    required = 1,/*!< Set an option as required if you want to enforce that the user
-                  * supplies this option when calling the program via the command line.
-                  * If the option is missing, the argument_parser will automatically
-                  * detect this and throw a invalid_argument exception.
-                  */
-    advanced = 2,/*!< Set an option/flag to advanced if you do not want the option to
-                  * be displayed in the normal help page (`-h/--help`). Instead, the
-                  * advanced options are only displayed when calling `-hh/--advanced-help`
-                  */
-    hidden = 4,/*!< Set an option/flag to hidden, if you want to completely hide it from
-                  * the user. It will never appear on the help page nor any export format.
-                  * For example, this can be useful for debugging reasons.
-                  * (e.g. "A tool for mapping reads to the genome").
-                  */
+    standard = 0, //!< The default were no checking or special displaying is happening.
+    required = 1, /*!< Set an option as required if you want to enforce that the user
+                   * supplies this option when calling the program via the command line.
+                   * If the option is missing, the argument_parser will automatically
+                   * detect this and throw a invalid_argument exception.
+                   */
+    advanced = 2, /*!< Set an option/flag to advanced if you do not want the option to
+                   * be displayed in the normal help page (`-h/--help`). Instead, the
+                   * advanced options are only displayed when calling `-hh/--advanced-help`
+                   */
+    hidden = 4,   /*!< Set an option/flag to hidden, if you want to completely hide it from
+                   * the user. It will never appear on the help page nor any export format.
+                   * For example, this can be useful for debugging reasons.
+                   * (e.g. "A tool for mapping reads to the genome").
+                   */
 
-    DEFAULT SEQAN3_DEPRECATED_310  = defaulted, //!< \deprecated Use seqan3::option_spec::defaulted instead.
-    REQUIRED SEQAN3_DEPRECATED_310 = required,  //!< \deprecated Use seqan3::option_spec::required instead.
-    ADVANCED SEQAN3_DEPRECATED_310 = advanced,  //!< \deprecated Use seqan3::option_spec::advanced instead.
-    HIDDEN SEQAN3_DEPRECATED_310   = hidden,    //!< \deprecated Use seqan3::option_spec::hidden instead.
+    DEFAULT SEQAN3_DEPRECATED_310  = standard, //!< \deprecated Use seqan3::option_spec::standard instead.
+    REQUIRED SEQAN3_DEPRECATED_310 = required, //!< \deprecated Use seqan3::option_spec::required instead.
+    ADVANCED SEQAN3_DEPRECATED_310 = advanced, //!< \deprecated Use seqan3::option_spec::advanced instead.
+    HIDDEN SEQAN3_DEPRECATED_310   = hidden,   //!< \deprecated Use seqan3::option_spec::hidden instead.
 };
 
 //!\brief Indicates whether application allows automatic update notifications by the seqan3::argument_parser.

--- a/include/seqan3/argument_parser/auxiliary.hpp
+++ b/include/seqan3/argument_parser/auxiliary.hpp
@@ -224,28 +224,33 @@ inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, opt
  *
  * \details
  *
- * All options and flags are set to option_spec::DEFAULT unless specified
+ * All options and flags are set to option_spec::defaulted unless specified
  * otherwise by the developer, e.g. when calling argument_parser::add_option().
  *
  * \include test/snippet/argument_parser/auxiliary.cpp
  */
 enum option_spec
 {
-    DEFAULT  = 0, //!< The default were no checking or special displaying is happening.
-    REQUIRED = 1, /*!< Set an option as required if you want to enforce that the user
-                   * supplies this option when calling the program via the command line.
-                   * If the option is missing, the argument_parser will automatically
-                   * detect this and throw a invalid_argument exception.
-                   */
-    ADVANCED = 2, /*!< Set an option/flag to advanced if you do not want the option to
-                   * be displayed in the normal help page (`-h/--help`). Instead, the
-                   * advanced options are only displayed when calling `-hh/--advanced-help`
-                   */
-    HIDDEN   = 4, /*!< Set an option/flag to hidden, if you want to completely hide it from
-                   * the user. It will never appear on the help page nor any export format.
-                   * For example, this can be useful for debugging reasons.
-                   * (e.g. "A tool for mapping reads to the genome").
-                   */
+    defaulted = 0,//!< The default were no checking or special displaying is happening.
+    required = 1,/*!< Set an option as required if you want to enforce that the user
+                  * supplies this option when calling the program via the command line.
+                  * If the option is missing, the argument_parser will automatically
+                  * detect this and throw a invalid_argument exception.
+                  */
+    advanced = 2,/*!< Set an option/flag to advanced if you do not want the option to
+                  * be displayed in the normal help page (`-h/--help`). Instead, the
+                  * advanced options are only displayed when calling `-hh/--advanced-help`
+                  */
+    hidden = 4,/*!< Set an option/flag to hidden, if you want to completely hide it from
+                  * the user. It will never appear on the help page nor any export format.
+                  * For example, this can be useful for debugging reasons.
+                  * (e.g. "A tool for mapping reads to the genome").
+                  */
+
+    DEFAULT SEQAN3_DEPRECATED_310  = defaulted, //!< \deprecated Use seqan3::option_spec::defaulted instead.
+    REQUIRED SEQAN3_DEPRECATED_310 = required,  //!< \deprecated Use seqan3::option_spec::required instead.
+    ADVANCED SEQAN3_DEPRECATED_310 = advanced,  //!< \deprecated Use seqan3::option_spec::advanced instead.
+    HIDDEN SEQAN3_DEPRECATED_310   = hidden,    //!< \deprecated Use seqan3::option_spec::hidden instead.
 };
 
 //!\brief Indicates whether application allows automatic update notifications by the seqan3::argument_parser.

--- a/include/seqan3/argument_parser/detail/format_base.hpp
+++ b/include/seqan3/argument_parser/detail/format_base.hpp
@@ -235,7 +235,7 @@ public:
     {
         std::string id = prep_id_for_help(short_id, long_id) + " " + option_type_and_list_info(value);
         std::string info{desc};
-        info += ((spec & option_spec::REQUIRED) ? std::string{" "} : detail::to_string(" Default: ", value, ". "));
+        info += ((spec & option_spec::required) ? std::string{" "} : detail::to_string(" Default: ", value, ". "));
         info += option_validator.get_help_page_message();
         store_help_page_element([this, id, info] () { derived_t().print_list_item(id, info); }, spec);
     }
@@ -437,13 +437,13 @@ private:
      *
      * \details
      *
-     * If `spec` equals `seqan3::option_spec::HIDDEN`, the information is never added to the help page.
-     * If `spec` equals `seqan3::option_spec::ADVANCED`, the information is only added to the help page if
+     * If `spec` equals `seqan3::option_spec::hidden`, the information is never added to the help page.
+     * If `spec` equals `seqan3::option_spec::advanced`, the information is only added to the help page if
      * the advanced help page has been queried on the command line (`show_advanced_options == true`).
      */
     void store_help_page_element(std::function<void()> printer, option_spec const spec)
     {
-        if (!(spec & option_spec::HIDDEN) && (!(spec & option_spec::ADVANCED) || show_advanced_options))
+        if (!(spec & option_spec::hidden) && (!(spec & option_spec::advanced) || show_advanced_options))
             parser_set_up_calls.push_back(std::move(printer));
     }
 };

--- a/include/seqan3/argument_parser/detail/format_parse.hpp
+++ b/include/seqan3/argument_parser/detail/format_parse.hpp
@@ -679,7 +679,7 @@ private:
         else // option is not set
         {
             // check if option is required
-            if (spec & option_spec::REQUIRED)
+            if (spec & option_spec::required)
                 throw required_option_missing("Option " + combine_option_names(short_id, long_id) +
                                               " is required but not set.");
         }

--- a/include/seqan3/argument_parser/exceptions.hpp
+++ b/include/seqan3/argument_parser/exceptions.hpp
@@ -40,7 +40,7 @@ public:
  * - Unknown option/flag (not specified by developer but set by user)
  * - Too many positional options
  * - Too few positional options
- * - Option that was declared as required (option_spec::REQUIRED) was not set
+ * - Option that was declared as required (option_spec::required) was not set
  * - Option is not a list but specified multiple times
  * - Type conversion failed
  * - Validation failed (as defined by the developer)

--- a/test/snippet/argument_parser/auxiliary.cpp
+++ b/test/snippet/argument_parser/auxiliary.cpp
@@ -5,5 +5,5 @@ int main(int argc, const char ** argv)
     seqan3::argument_parser myparser{"Test", argc, argv};
     std::string myvar{"Example"};
     myparser.add_option(myvar, 's', "special-op", "You know what you doin'?",
-                        seqan3::option_spec::ADVANCED);
+                        seqan3::option_spec::advanced);
 }

--- a/test/snippet/argument_parser/custom_argument_parsing_enumeration.cpp
+++ b/test/snippet/argument_parser/custom_argument_parsing_enumeration.cpp
@@ -30,7 +30,7 @@ int main(int argc, char const * argv[])
     // Because of the argument_parsing struct and
     // the static member function enumeration_names
     // you can now add an option that takes a value of type std::errc:
-    parser.add_option(value, 'e', "errc", "Give me a std::errc value.", seqan3::option_spec::DEFAULT,
+    parser.add_option(value, 'e', "errc", "Give me a std::errc value.", seqan3::option_spec::defaulted,
                       seqan3::value_list_validator{(seqan3::enumeration_names<std::errc> | std::views::values)});
 
     try

--- a/test/snippet/argument_parser/custom_argument_parsing_enumeration.cpp
+++ b/test/snippet/argument_parser/custom_argument_parsing_enumeration.cpp
@@ -30,7 +30,7 @@ int main(int argc, char const * argv[])
     // Because of the argument_parsing struct and
     // the static member function enumeration_names
     // you can now add an option that takes a value of type std::errc:
-    parser.add_option(value, 'e', "errc", "Give me a std::errc value.", seqan3::option_spec::defaulted,
+    parser.add_option(value, 'e', "errc", "Give me a std::errc value.", seqan3::option_spec::standard,
                       seqan3::value_list_validator{(seqan3::enumeration_names<std::errc> | std::views::values)});
 
     try

--- a/test/snippet/argument_parser/custom_enumeration.cpp
+++ b/test/snippet/argument_parser/custom_enumeration.cpp
@@ -28,7 +28,7 @@ int main(int argc, char const * argv[])
 
     // Because of the enumeration_names function
     // you can now add an option that takes a value of type bar:
-    parser.add_option(value, 'f', "foo", "Give me a foo value.", seqan3::option_spec::DEFAULT,
+    parser.add_option(value, 'f', "foo", "Give me a foo value.", seqan3::option_spec::defaulted,
                       seqan3::value_list_validator{(seqan3::enumeration_names<foo::bar> | seqan3::views::get<1>)});
 
     try

--- a/test/snippet/argument_parser/custom_enumeration.cpp
+++ b/test/snippet/argument_parser/custom_enumeration.cpp
@@ -28,7 +28,7 @@ int main(int argc, char const * argv[])
 
     // Because of the enumeration_names function
     // you can now add an option that takes a value of type bar:
-    parser.add_option(value, 'f', "foo", "Give me a foo value.", seqan3::option_spec::defaulted,
+    parser.add_option(value, 'f', "foo", "Give me a foo value.", seqan3::option_spec::standard,
                       seqan3::value_list_validator{(seqan3::enumeration_names<foo::bar> | seqan3::views::get<1>)});
 
     try

--- a/test/snippet/argument_parser/validators_1.cpp
+++ b/test/snippet/argument_parser/validators_1.cpp
@@ -10,7 +10,7 @@ int main(int argc, const char ** argv)
     seqan3::arithmetic_range_validator my_validator{2, 10};
 
     myparser.add_option(myint,'i',"integer","Give me a number.",
-                        seqan3::option_spec::DEFAULT, my_validator);
+                        seqan3::option_spec::defaulted, my_validator);
     //![validator_call]
 
     // an exception will be thrown if the user specifies an integer

--- a/test/snippet/argument_parser/validators_1.cpp
+++ b/test/snippet/argument_parser/validators_1.cpp
@@ -10,7 +10,7 @@ int main(int argc, const char ** argv)
     seqan3::arithmetic_range_validator my_validator{2, 10};
 
     myparser.add_option(myint,'i',"integer","Give me a number.",
-                        seqan3::option_spec::defaulted, my_validator);
+                        seqan3::option_spec::standard, my_validator);
     //![validator_call]
 
     // an exception will be thrown if the user specifies an integer

--- a/test/snippet/argument_parser/validators_2.cpp
+++ b/test/snippet/argument_parser/validators_2.cpp
@@ -10,7 +10,7 @@ int main(int argc, const char ** argv)
     seqan3::value_list_validator my_validator{2, 4, 6, 8, 10};
 
     myparser.add_option(myint,'i',"integer","Give me a number.",
-                        seqan3::option_spec::defaulted, my_validator);
+                        seqan3::option_spec::standard, my_validator);
     //![validator_call]
 
     // an exception will be thrown if the user specifies an integer

--- a/test/snippet/argument_parser/validators_2.cpp
+++ b/test/snippet/argument_parser/validators_2.cpp
@@ -10,7 +10,7 @@ int main(int argc, const char ** argv)
     seqan3::value_list_validator my_validator{2, 4, 6, 8, 10};
 
     myparser.add_option(myint,'i',"integer","Give me a number.",
-                        seqan3::option_spec::DEFAULT, my_validator);
+                        seqan3::option_spec::defaulted, my_validator);
     //![validator_call]
 
     // an exception will be thrown if the user specifies an integer

--- a/test/snippet/argument_parser/validators_3.cpp
+++ b/test/snippet/argument_parser/validators_3.cpp
@@ -10,7 +10,7 @@ int main(int argc, const char ** argv)
     std::filesystem::path myfile;
 
     myparser.add_option(myfile,'f',"file","Give me a filename.",
-                        seqan3::option_spec::defaulted, seqan3::input_file_validator{{"fa","fasta"}});
+                        seqan3::option_spec::standard, seqan3::input_file_validator{{"fa","fasta"}});
     //![validator_call]
 
     // an exception will be thrown if the user specifies a filename

--- a/test/snippet/argument_parser/validators_3.cpp
+++ b/test/snippet/argument_parser/validators_3.cpp
@@ -10,7 +10,7 @@ int main(int argc, const char ** argv)
     std::filesystem::path myfile;
 
     myparser.add_option(myfile,'f',"file","Give me a filename.",
-                        seqan3::option_spec::DEFAULT, seqan3::input_file_validator{{"fa","fasta"}});
+                        seqan3::option_spec::defaulted, seqan3::input_file_validator{{"fa","fasta"}});
     //![validator_call]
 
     // an exception will be thrown if the user specifies a filename

--- a/test/snippet/argument_parser/validators_4.cpp
+++ b/test/snippet/argument_parser/validators_4.cpp
@@ -10,7 +10,7 @@ int main(int argc, const char ** argv)
     seqan3::regex_validator my_validator{"[a-zA-Z]+@[a-zA-Z]+\\.com"};
 
     myparser.add_option(my_string,'s',"str","Give me a string.",
-                        seqan3::option_spec::DEFAULT, my_validator);
+                        seqan3::option_spec::defaulted, my_validator);
     //![validator_call]
 
     // an exception will be thrown if the user specifies a string

--- a/test/snippet/argument_parser/validators_4.cpp
+++ b/test/snippet/argument_parser/validators_4.cpp
@@ -10,7 +10,7 @@ int main(int argc, const char ** argv)
     seqan3::regex_validator my_validator{"[a-zA-Z]+@[a-zA-Z]+\\.com"};
 
     myparser.add_option(my_string,'s',"str","Give me a string.",
-                        seqan3::option_spec::defaulted, my_validator);
+                        seqan3::option_spec::standard, my_validator);
     //![validator_call]
 
     // an exception will be thrown if the user specifies a string

--- a/test/snippet/argument_parser/validators_chaining.cpp
+++ b/test/snippet/argument_parser/validators_chaining.cpp
@@ -12,7 +12,7 @@ int main(int argc, const char ** argv)
     seqan3::input_file_validator my_file_ext_validator{{"sa", "so"}};
 
     myparser.add_option(file_name, 'f', "file","Give me a file name with an absolute path.",
-                        seqan3::option_spec::defaulted, absolute_path_validator | my_file_ext_validator);
+                        seqan3::option_spec::standard, absolute_path_validator | my_file_ext_validator);
     //![validator_call]
 
     // an exception will be thrown if the user specifies a file name

--- a/test/snippet/argument_parser/validators_chaining.cpp
+++ b/test/snippet/argument_parser/validators_chaining.cpp
@@ -12,7 +12,7 @@ int main(int argc, const char ** argv)
     seqan3::input_file_validator my_file_ext_validator{{"sa", "so"}};
 
     myparser.add_option(file_name, 'f', "file","Give me a file name with an absolute path.",
-                        seqan3::option_spec::DEFAULT, absolute_path_validator | my_file_ext_validator);
+                        seqan3::option_spec::defaulted, absolute_path_validator | my_file_ext_validator);
     //![validator_call]
 
     // an exception will be thrown if the user specifies a file name

--- a/test/snippet/argument_parser/validators_input_directory.cpp
+++ b/test/snippet/argument_parser/validators_input_directory.cpp
@@ -10,7 +10,7 @@ int main(int argc, const char ** argv)
     std::filesystem::path mydir{};
 
     myparser.add_option(mydir, 'd', "dir", "The directory containing the input files.",
-                        seqan3::option_spec::defaulted, seqan3::input_directory_validator{});
+                        seqan3::option_spec::standard, seqan3::input_directory_validator{});
     //! [validator_call]
 
     // an exception will be thrown if the user specifies a directory that does not exists or has insufficient

--- a/test/snippet/argument_parser/validators_input_directory.cpp
+++ b/test/snippet/argument_parser/validators_input_directory.cpp
@@ -10,7 +10,7 @@ int main(int argc, const char ** argv)
     std::filesystem::path mydir{};
 
     myparser.add_option(mydir, 'd', "dir", "The directory containing the input files.",
-                        seqan3::option_spec::DEFAULT, seqan3::input_directory_validator{});
+                        seqan3::option_spec::defaulted, seqan3::input_directory_validator{});
     //! [validator_call]
 
     // an exception will be thrown if the user specifies a directory that does not exists or has insufficient

--- a/test/snippet/argument_parser/validators_input_file.cpp
+++ b/test/snippet/argument_parser/validators_input_file.cpp
@@ -10,7 +10,7 @@ int main(int argc, const char ** argv)
     std::filesystem::path myfile{};
 
     myparser.add_option(myfile,'f',"file","The input file containing the sequences.",
-                        seqan3::option_spec::DEFAULT, seqan3::input_file_validator{{"fa","fasta"}});
+                        seqan3::option_spec::defaulted, seqan3::input_file_validator{{"fa","fasta"}});
     //! [validator_call]
 
     // an exception will be thrown if the user specifies a filename

--- a/test/snippet/argument_parser/validators_input_file.cpp
+++ b/test/snippet/argument_parser/validators_input_file.cpp
@@ -10,7 +10,7 @@ int main(int argc, const char ** argv)
     std::filesystem::path myfile{};
 
     myparser.add_option(myfile,'f',"file","The input file containing the sequences.",
-                        seqan3::option_spec::defaulted, seqan3::input_file_validator{{"fa","fasta"}});
+                        seqan3::option_spec::standard, seqan3::input_file_validator{{"fa","fasta"}});
     //! [validator_call]
 
     // an exception will be thrown if the user specifies a filename

--- a/test/snippet/argument_parser/validators_output_directory.cpp
+++ b/test/snippet/argument_parser/validators_output_directory.cpp
@@ -10,7 +10,7 @@ int main(int argc, const char ** argv)
     std::filesystem::path mydir{};
 
     myparser.add_option(mydir, 'd', "dir", "The output directory for storing the files.",
-                        seqan3::option_spec::DEFAULT,
+                        seqan3::option_spec::defaulted,
                         seqan3::output_file_validator{seqan3::output_file_open_options::create_new});
     //! [validator_call]
 

--- a/test/snippet/argument_parser/validators_output_directory.cpp
+++ b/test/snippet/argument_parser/validators_output_directory.cpp
@@ -10,7 +10,7 @@ int main(int argc, const char ** argv)
     std::filesystem::path mydir{};
 
     myparser.add_option(mydir, 'd', "dir", "The output directory for storing the files.",
-                        seqan3::option_spec::defaulted,
+                        seqan3::option_spec::standard,
                         seqan3::output_file_validator{seqan3::output_file_open_options::create_new});
     //! [validator_call]
 

--- a/test/snippet/argument_parser/validators_output_file.cpp
+++ b/test/snippet/argument_parser/validators_output_file.cpp
@@ -11,12 +11,12 @@ int main(int argc, const char ** argv)
 
     // Use the seqan3::output_file_open_options to indicate that you allow overwriting existing output files, ...
     myparser.add_option(myfile, 'f', "file", "Output file containing the processed sequences.",
-                        seqan3::option_spec::DEFAULT,
+                        seqan3::option_spec::defaulted,
                         seqan3::output_file_validator{seqan3::output_file_open_options::open_or_create, {"fa","fasta"}});
 
     // ... or that you will throw a seqan3::validation_error if the user specified output file already exists
     myparser.add_option(myfile, 'g', "file2", "Output file containing the processed sequences.",
-                        seqan3::option_spec::DEFAULT,
+                        seqan3::option_spec::defaulted,
                         seqan3::output_file_validator{seqan3::output_file_open_options::create_new, {"fa","fasta"}});
     //! [validator_call]
 

--- a/test/snippet/argument_parser/validators_output_file.cpp
+++ b/test/snippet/argument_parser/validators_output_file.cpp
@@ -11,12 +11,12 @@ int main(int argc, const char ** argv)
 
     // Use the seqan3::output_file_open_options to indicate that you allow overwriting existing output files, ...
     myparser.add_option(myfile, 'f', "file", "Output file containing the processed sequences.",
-                        seqan3::option_spec::defaulted,
+                        seqan3::option_spec::standard,
                         seqan3::output_file_validator{seqan3::output_file_open_options::open_or_create, {"fa","fasta"}});
 
     // ... or that you will throw a seqan3::validation_error if the user specified output file already exists
     myparser.add_option(myfile, 'g', "file2", "Output file containing the processed sequences.",
-                        seqan3::option_spec::defaulted,
+                        seqan3::option_spec::standard,
                         seqan3::output_file_validator{seqan3::output_file_open_options::create_new, {"fa","fasta"}});
     //! [validator_call]
 

--- a/test/unit/argument_parser/detail/format_help_test.cpp
+++ b/test/unit/argument_parser/detail/format_help_test.cpp
@@ -232,8 +232,8 @@ TEST(help_page_printing, do_not_print_hidden_options)
     // Add an option and request help.
     seqan3::argument_parser parser5{"test_parser", 2, argv1};
     test_accessor::set_terminal_width(parser5, 80);
-    parser5.add_option(option_value, 'i', "int", "this is a int option.", seqan3::option_spec::HIDDEN);
-    parser5.add_flag(flag_value, 'f', "flag", "this is a flag.", seqan3::option_spec::HIDDEN);
+    parser5.add_option(option_value, 'i', "int", "this is a int option.", seqan3::option_spec::hidden);
+    parser5.add_flag(flag_value, 'f', "flag", "this is a flag.", seqan3::option_spec::hidden);
     testing::internal::CaptureStdout();
     EXPECT_EXIT(parser5.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
     std_cout = testing::internal::GetCapturedStdout();
@@ -254,28 +254,28 @@ TEST(help_page_printing, advanced_options)
     auto set_up = [&option_value, &flag_value] (seqan3::argument_parser & parser)
     {
         // default or required information are always displayed
-        parser.add_section("default section", seqan3::option_spec::REQUIRED);
-        parser.add_subsection("default subsection", seqan3::option_spec::REQUIRED); // same as DEFAULT
-        parser.add_option(option_value, 'i', "int", "this is a int option.", seqan3::option_spec::REQUIRED);
-        parser.add_flag(flag_value, 'g', "goo", "this is a flag.", seqan3::option_spec::REQUIRED); // same as DEFAULT
-        parser.add_list_item("-s, --some", "list item.", seqan3::option_spec::REQUIRED); // same as DEFAULT
-        parser.add_line("some line.", true, seqan3::option_spec::REQUIRED); // same as DEFAULT
+        parser.add_section("default section", seqan3::option_spec::required);
+        parser.add_subsection("default subsection", seqan3::option_spec::required); // same as DEFAULT
+        parser.add_option(option_value, 'i', "int", "this is a int option.", seqan3::option_spec::required);
+        parser.add_flag(flag_value, 'g', "goo", "this is a flag.", seqan3::option_spec::required); // same as DEFAULT
+        parser.add_list_item("-s, --some", "list item.", seqan3::option_spec::required); // same as DEFAULT
+        parser.add_line("some line.", true, seqan3::option_spec::required); // same as DEFAULT
 
         // advanced information
-        parser.add_section("advanced section", seqan3::option_spec::ADVANCED);
-        parser.add_subsection("advanced subsection", seqan3::option_spec::ADVANCED);
-        parser.add_option(option_value, 'j', "jnt", "this is a int option.", seqan3::option_spec::ADVANCED);
-        parser.add_flag(flag_value, 'f', "flag", "this is a flag.", seqan3::option_spec::ADVANCED);
-        parser.add_list_item("-s, --some", "list item.", seqan3::option_spec::ADVANCED);
-        parser.add_line("some line.", true, seqan3::option_spec::ADVANCED);
+        parser.add_section("advanced section", seqan3::option_spec::advanced);
+        parser.add_subsection("advanced subsection", seqan3::option_spec::advanced);
+        parser.add_option(option_value, 'j', "jnt", "this is a int option.", seqan3::option_spec::advanced);
+        parser.add_flag(flag_value, 'f', "flag", "this is a flag.", seqan3::option_spec::advanced);
+        parser.add_list_item("-s, --some", "list item.", seqan3::option_spec::advanced);
+        parser.add_line("some line.", true, seqan3::option_spec::advanced);
 
         // hidden information (never displayed, normally used for options not section information)
-        parser.add_section("hidden section", seqan3::option_spec::HIDDEN);
-        parser.add_subsection("hidden subsection", seqan3::option_spec::HIDDEN);
-        parser.add_option(option_value, 'd', "dnt", "hidden option.", seqan3::option_spec::HIDDEN);
-        parser.add_flag(flag_value, 'l', "lflag", "hidden a flag.", seqan3::option_spec::HIDDEN);
-        parser.add_list_item("-s, --some", "hidden list item.", seqan3::option_spec::HIDDEN);
-        parser.add_line("hidden line.", true, seqan3::option_spec::HIDDEN);
+        parser.add_section("hidden section", seqan3::option_spec::hidden);
+        parser.add_subsection("hidden subsection", seqan3::option_spec::hidden);
+        parser.add_option(option_value, 'd', "dnt", "hidden option.", seqan3::option_spec::hidden);
+        parser.add_flag(flag_value, 'l', "lflag", "hidden a flag.", seqan3::option_spec::hidden);
+        parser.add_list_item("-s, --some", "hidden list item.", seqan3::option_spec::hidden);
+        parser.add_line("hidden line.", true, seqan3::option_spec::hidden);
     };
 
     // without -hh, only the non/advanced information are shown
@@ -367,10 +367,10 @@ TEST(help_page_printing, full_information)
     parser6.info.description.push_back("description2");
     parser6.info.short_description = "so short";
     parser6.add_option(option_value, 'i', "int", "this is a int option.");
-    parser6.add_option(enum_option_value, 'e', "enum", "this is an enum option.", seqan3::option_spec::DEFAULT,
+    parser6.add_option(enum_option_value, 'e', "enum", "this is an enum option.", seqan3::option_spec::defaulted,
                        seqan3::value_list_validator{seqan3::enumeration_names<foo> | std::views::values});
     parser6.add_option(required_option, 'r', "required-int", "this is another int option.",
-                       seqan3::option_spec::REQUIRED);
+                       seqan3::option_spec::required);
     parser6.add_section("Flags");
     parser6.add_subsection("SubFlags");
     parser6.add_line("here come all the flags");

--- a/test/unit/argument_parser/detail/format_help_test.cpp
+++ b/test/unit/argument_parser/detail/format_help_test.cpp
@@ -367,7 +367,7 @@ TEST(help_page_printing, full_information)
     parser6.info.description.push_back("description2");
     parser6.info.short_description = "so short";
     parser6.add_option(option_value, 'i', "int", "this is a int option.");
-    parser6.add_option(enum_option_value, 'e', "enum", "this is an enum option.", seqan3::option_spec::defaulted,
+    parser6.add_option(enum_option_value, 'e', "enum", "this is an enum option.", seqan3::option_spec::standard,
                        seqan3::value_list_validator{seqan3::enumeration_names<foo> | std::views::values});
     parser6.add_option(required_option, 'r', "required-int", "this is another int option.",
                        seqan3::option_spec::required);

--- a/test/unit/argument_parser/detail/format_html_test.cpp
+++ b/test/unit/argument_parser/detail/format_html_test.cpp
@@ -86,7 +86,7 @@ TEST(html_format, full_information_information)
    parser1.info.long_copyright = "long_copyright";
    parser1.info.citation = "citation";
    parser1.add_option(option_value, 'i', "int", "this is a int option.");
-   parser1.add_option(option_value, 'j', "jint", "this is a required int option.", seqan3::option_spec::REQUIRED);
+   parser1.add_option(option_value, 'j', "jint", "this is a required int option.", seqan3::option_spec::required);
    parser1.add_flag(flag_value, 'f', "flag", "this is a flag.");
    parser1.add_flag(flag_value, 'k', "kflag", "this is a flag.");
    parser1.add_positional_option(non_list_pos_opt_value, "this is a positional option.");

--- a/test/unit/argument_parser/detail/format_man_test.cpp
+++ b/test/unit/argument_parser/detail/format_man_test.cpp
@@ -94,7 +94,7 @@ struct format_man_test : public ::testing::Test
         parser.info.description.push_back("description");
         parser.info.description.push_back("description2");
         parser.add_option(option_value, 'i', "int", "this is a int option.");
-        parser.add_option(option_value, 'j', "jint", "this is a required int option.", seqan3::option_spec::REQUIRED);
+        parser.add_option(option_value, 'j', "jint", "this is a required int option.", seqan3::option_spec::required);
         parser.add_section("Flags");
         parser.add_subsection("SubFlags");
         parser.add_line("here come all the flags");

--- a/test/unit/argument_parser/format_parse_test.cpp
+++ b/test/unit/argument_parser/format_parse_test.cpp
@@ -759,7 +759,7 @@ TEST(parse_test, required_option_missing)
     const char * argv[] = {"./argument_parser_test", "5", "-i", "15"};
     seqan3::argument_parser parser{"test_parser", 4, argv, seqan3::update_notifications::off};
     parser.add_option(option_value, 'i', "int-option", "this is an int option.");
-    parser.add_option(option_value, 'a', "req-option", "I am required.", seqan3::option_spec::REQUIRED);
+    parser.add_option(option_value, 'a', "req-option", "I am required.", seqan3::option_spec::required);
     parser.add_positional_option(option_value, "this is an int option.");
 
     EXPECT_THROW(parser.parse(), seqan3::required_option_missing);

--- a/test/unit/argument_parser/format_parse_validators_test.cpp
+++ b/test/unit/argument_parser/format_parse_validators_test.cpp
@@ -138,7 +138,7 @@ TEST(validator_test, input_file)
         seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
         parser.add_option(file_in_path, 'i', "int-option", "desc",
-                          seqan3::option_spec::DEFAULT, seqan3::input_file_validator{formats});
+                          seqan3::option_spec::defaulted, seqan3::input_file_validator{formats});
 
         EXPECT_NO_THROW(parser.parse());
         EXPECT_EQ(file_in_path.string(), path);
@@ -256,7 +256,7 @@ TEST(validator_test, output_file)
         seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
         parser.add_option(file_out_path, 'o', "out-option", "desc",
-                          seqan3::option_spec::DEFAULT,
+                          seqan3::option_spec::defaulted,
                           seqan3::output_file_validator{seqan3::output_file_open_options::create_new, formats});
 
         EXPECT_NO_THROW(parser.parse());
@@ -391,7 +391,7 @@ TEST(validator_test, input_directory)
             seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
             test_accessor::set_terminal_width(parser, 80);
             parser.add_option(dir_in_path, 'i', "input-option", "desc",
-                              seqan3::option_spec::DEFAULT, seqan3::input_directory_validator{});
+                              seqan3::option_spec::defaulted, seqan3::input_directory_validator{});
 
             EXPECT_NO_THROW(parser.parse());
             EXPECT_EQ(path, dir_in_path.string());
@@ -443,7 +443,7 @@ TEST(validator_test, output_directory)
         seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
         parser.add_option(dir_out_path, 'o', "output-option", "desc",
-                          seqan3::option_spec::DEFAULT,
+                          seqan3::option_spec::defaulted,
                           seqan3::output_directory_validator{});
 
         EXPECT_NO_THROW(parser.parse());
@@ -644,7 +644,7 @@ TEST(validator_test, arithmetic_range_validator_success)
     seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser, 80);
     parser.add_option(option_value, 'i', "int-option", "desc",
-                      seqan3::option_spec::DEFAULT, seqan3::arithmetic_range_validator{1, 20});
+                      seqan3::option_spec::defaulted, seqan3::arithmetic_range_validator{1, 20});
 
     testing::internal::CaptureStderr();
     EXPECT_NO_THROW(parser.parse());
@@ -656,7 +656,7 @@ TEST(validator_test, arithmetic_range_validator_success)
     seqan3::argument_parser parser2{"test_parser", 3, argv2, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser2, 80);
     parser2.add_option(option_value, 'i', "int-option", "desc",
-                       seqan3::option_spec::DEFAULT, seqan3::arithmetic_range_validator{-20, 20});
+                       seqan3::option_spec::defaulted, seqan3::arithmetic_range_validator{-20, 20});
 
     testing::internal::CaptureStderr();
     EXPECT_NO_THROW(parser2.parse());
@@ -690,7 +690,7 @@ TEST(validator_test, arithmetic_range_validator_success)
     seqan3::argument_parser parser5{"test_parser", 5, argv5, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser5, 80);
     parser5.add_option(option_vector, 'i', "int-option", "desc",
-                       seqan3::option_spec::DEFAULT, seqan3::arithmetic_range_validator{-50,50});
+                       seqan3::option_spec::defaulted, seqan3::arithmetic_range_validator{-50,50});
 
     testing::internal::CaptureStderr();
     EXPECT_NO_THROW(parser5.parse());
@@ -739,7 +739,7 @@ TEST(validator_test, arithmetic_range_validator_success)
     seqan3::argument_parser parser8{"test_parser", 3, argv8, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser8, 80);
     parser8.add_option(double_option_value, 'i', "double-option", "desc",
-                       seqan3::option_spec::DEFAULT, seqan3::arithmetic_range_validator{1, 20});
+                       seqan3::option_spec::defaulted, seqan3::arithmetic_range_validator{1, 20});
 
     testing::internal::CaptureStderr();
     EXPECT_NO_THROW(parser8.parse());
@@ -757,7 +757,7 @@ TEST(validator_test, arithmetic_range_validator_error)
     seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser, 80);
     parser.add_option(option_value, 'i', "int-option", "desc",
-                      seqan3::option_spec::DEFAULT, seqan3::arithmetic_range_validator{1, 20});
+                      seqan3::option_spec::defaulted, seqan3::arithmetic_range_validator{1, 20});
 
     EXPECT_THROW(parser.parse(), seqan3::validation_error);
 
@@ -766,7 +766,7 @@ TEST(validator_test, arithmetic_range_validator_error)
     seqan3::argument_parser parser2{"test_parser", 3, argv2, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser2, 80);
     parser2.add_option(option_value, 'i', "int-option", "desc",
-                       seqan3::option_spec::DEFAULT, seqan3::arithmetic_range_validator{-20, 20});
+                       seqan3::option_spec::defaulted, seqan3::arithmetic_range_validator{-20, 20});
 
     EXPECT_THROW(parser2.parse(), seqan3::validation_error);
 
@@ -791,7 +791,7 @@ TEST(validator_test, arithmetic_range_validator_error)
     seqan3::argument_parser parser5{"test_parser", 3, argv5, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser5, 80);
     parser5.add_option(option_vector, 'i', "int-option", "desc",
-                       seqan3::option_spec::DEFAULT, seqan3::arithmetic_range_validator{-50, 50});
+                       seqan3::option_spec::defaulted, seqan3::arithmetic_range_validator{-50, 50});
 
     EXPECT_THROW(parser5.parse(), seqan3::validation_error);
 
@@ -810,7 +810,7 @@ TEST(validator_test, arithmetic_range_validator_error)
     seqan3::argument_parser parser7{"test_parser", 3, argv7, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser7, 80);
     parser7.add_option(double_option_value, 'i', "double-option", "desc",
-                       seqan3::option_spec::DEFAULT, seqan3::arithmetic_range_validator{1, 20});
+                       seqan3::option_spec::defaulted, seqan3::arithmetic_range_validator{1, 20});
 
     EXPECT_THROW(parser7.parse(), seqan3::validation_error);
 }
@@ -870,7 +870,7 @@ TEST(validator_test, value_list_validator_success)
     seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser, 80);
     parser.add_option(option_value, 's', "string-option", "desc",
-                      seqan3::option_spec::DEFAULT,
+                      seqan3::option_spec::defaulted,
                       seqan3::value_list_validator{valid_str_values | std::views::take(2)});
 
     testing::internal::CaptureStderr();
@@ -883,7 +883,7 @@ TEST(validator_test, value_list_validator_success)
     seqan3::argument_parser parser2{"test_parser", 3, argv2, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser2, 80);
     parser2.add_option(option_value_int, 'i', "int-option", "desc",
-                       seqan3::option_spec::DEFAULT, seqan3::value_list_validator<int>{0, -21, 10});
+                       seqan3::option_spec::defaulted, seqan3::value_list_validator<int>{0, -21, 10});
 
     testing::internal::CaptureStderr();
     EXPECT_NO_THROW(parser2.parse());
@@ -918,7 +918,7 @@ TEST(validator_test, value_list_validator_success)
     seqan3::argument_parser parser5{"test_parser", 5, argv5, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser5, 80);
     parser5.add_option(option_vector_int, 'i', "int-option", "desc",
-                       seqan3::option_spec::DEFAULT, seqan3::value_list_validator<int>{-10, 48, 50});
+                       seqan3::option_spec::defaulted, seqan3::value_list_validator<int>{-10, 48, 50});
 
     testing::internal::CaptureStderr();
     EXPECT_NO_THROW(parser5.parse());
@@ -932,7 +932,7 @@ TEST(validator_test, value_list_validator_success)
     seqan3::argument_parser parser7{"test_parser", 2, argv7, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser7, 80);
     parser7.add_option(option_vector_int, 'i', "int-option", "desc",
-                       seqan3::option_spec::DEFAULT, seqan3::value_list_validator<int>{-10, 48, 50});
+                       seqan3::option_spec::defaulted, seqan3::value_list_validator<int>{-10, 48, 50});
 
     option_vector_int.clear();
     testing::internal::CaptureStdout();
@@ -961,7 +961,7 @@ TEST(validator_test, value_list_validator_error)
     seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser, 80);
     parser.add_option(option_value, 's', "string-option", "desc",
-                      seqan3::option_spec::DEFAULT, seqan3::value_list_validator{"ha", "ba", "ma"});
+                      seqan3::option_spec::defaulted, seqan3::value_list_validator{"ha", "ba", "ma"});
 
     EXPECT_THROW(parser.parse(), seqan3::validation_error);
 
@@ -987,7 +987,7 @@ TEST(validator_test, value_list_validator_error)
     seqan3::argument_parser parser5{"test_parser", 5, argv5, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser5, 80);
     parser5.add_option(option_vector_int, 'i', "int-option", "desc",
-                       seqan3::option_spec::DEFAULT, seqan3::value_list_validator<int>{-10, 48, 50});
+                       seqan3::option_spec::defaulted, seqan3::value_list_validator<int>{-10, 48, 50});
 
     EXPECT_THROW(parser5.parse(), seqan3::validation_error);
 }
@@ -1004,7 +1004,7 @@ TEST(validator_test, regex_validator_success)
         seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
         parser.add_option(option_value, 's', "string-option", "desc",
-                          seqan3::option_spec::DEFAULT, email_validator);
+                          seqan3::option_spec::defaulted, email_validator);
 
         testing::internal::CaptureStderr();
         EXPECT_NO_THROW(parser.parse());
@@ -1046,7 +1046,7 @@ TEST(validator_test, regex_validator_success)
         seqan3::argument_parser parser{"test_parser", 5, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
         parser.add_option(option_vector, 's', "string-option", "desc",
-                           seqan3::option_spec::DEFAULT, email_vector_validator);
+                           seqan3::option_spec::defaulted, email_vector_validator);
 
         testing::internal::CaptureStderr();
         EXPECT_NO_THROW(parser.parse());
@@ -1061,7 +1061,7 @@ TEST(validator_test, regex_validator_success)
         seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
         parser.add_option(path_option, 's', "string-option", "desc",
-                          seqan3::option_spec::DEFAULT, email_vector_validator);
+                          seqan3::option_spec::defaulted, email_vector_validator);
 
         testing::internal::CaptureStderr();
         EXPECT_NO_THROW(parser.parse());
@@ -1075,7 +1075,7 @@ TEST(validator_test, regex_validator_success)
         seqan3::argument_parser parser{"test_parser", 2, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
         parser.add_option(option_vector, 's', "string-option", "desc",
-                           seqan3::option_spec::DEFAULT, email_vector_validator);
+                           seqan3::option_spec::defaulted, email_vector_validator);
 
         option_vector.clear();
         testing::internal::CaptureStdout();
@@ -1104,7 +1104,7 @@ TEST(validator_test, regex_validator_error)
     seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser, 80);
     parser.add_option(option_value, '\0', "string-option", "desc",
-                      seqan3::option_spec::DEFAULT, seqan3::regex_validator{"tt"});
+                      seqan3::option_spec::defaulted, seqan3::regex_validator{"tt"});
 
     EXPECT_THROW(parser.parse(), seqan3::validation_error);
 
@@ -1132,7 +1132,7 @@ TEST(validator_test, regex_validator_error)
     seqan3::argument_parser parser4{"test_parser", 5, argv4, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser4, 80);
     parser4.add_option(option_vector, 's', "", "desc",
-                       seqan3::option_spec::DEFAULT, seqan3::regex_validator{"tt"});
+                       seqan3::option_spec::defaulted, seqan3::regex_validator{"tt"});
 
     EXPECT_THROW(parser4.parse(), seqan3::validation_error);
 }
@@ -1155,7 +1155,7 @@ TEST(validator_test, chaining_validators)
         seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
         parser.add_option(option_value, 's', "string-option", "desc",
-                          seqan3::option_spec::DEFAULT, absolute_path_validator | my_file_ext_validator);
+                          seqan3::option_spec::defaulted, absolute_path_validator | my_file_ext_validator);
 
         testing::internal::CaptureStderr();
         EXPECT_NO_THROW(parser.parse());
@@ -1169,7 +1169,7 @@ TEST(validator_test, chaining_validators)
         seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
         parser.add_option(option_value, 's', "string-option", "desc",
-                          seqan3::option_spec::DEFAULT, absolute_path_validator | my_file_ext_validator);
+                          seqan3::option_spec::defaulted, absolute_path_validator | my_file_ext_validator);
 
         EXPECT_THROW(parser.parse(), seqan3::validation_error);
     }
@@ -1180,7 +1180,7 @@ TEST(validator_test, chaining_validators)
         seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
         parser.add_option(option_value, 's', "string-option", "desc",
-                          seqan3::option_spec::DEFAULT, absolute_path_validator | my_file_ext_validator);
+                          seqan3::option_spec::defaulted, absolute_path_validator | my_file_ext_validator);
 
         EXPECT_THROW(parser.parse(), seqan3::validation_error);
     }
@@ -1192,7 +1192,7 @@ TEST(validator_test, chaining_validators)
         seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
         parser.add_option(option_value, 's', "string-option", "desc",
-                          seqan3::option_spec::DEFAULT,
+                          seqan3::option_spec::defaulted,
                           seqan3::regex_validator{"(/[^/]+)+/.*\\.[^/\\.]+$"} |
                           seqan3::output_file_validator{seqan3::output_file_open_options::create_new, {"sa", "so"}});
 
@@ -1209,7 +1209,7 @@ TEST(validator_test, chaining_validators)
         seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
         parser.add_option(option_value, 's', "string-option", "desc",
-                          seqan3::option_spec::DEFAULT,
+                          seqan3::option_spec::defaulted,
                           seqan3::regex_validator{"(/[^/]+)+/.*\\.[^/\\.]+$"} |
                           seqan3::output_file_validator{seqan3::output_file_open_options::create_new, {"sa", "so"}} |
                           seqan3::regex_validator{".*"});
@@ -1227,7 +1227,7 @@ TEST(validator_test, chaining_validators)
         seqan3::argument_parser parser{"test_parser", 2, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
         parser.add_option(option_value, 's', "string-option", "desc",
-                          seqan3::option_spec::DEFAULT,
+                          seqan3::option_spec::defaulted,
                           seqan3::regex_validator{"(/[^/]+)+/.*\\.[^/\\.]+$"} |
                           seqan3::output_file_validator{seqan3::output_file_open_options::create_new, {"sa", "so"}} |
                           seqan3::regex_validator{".*"});
@@ -1256,7 +1256,7 @@ TEST(validator_test, chaining_validators)
         seqan3::argument_parser parser{"test_parser", 2, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
         parser.add_option(option_value, 's', "string-option", "desc",
-                          seqan3::option_spec::DEFAULT,
+                          seqan3::option_spec::defaulted,
                           seqan3::regex_validator{"(/[^/]+)+/.*\\.[^/\\.]+$"} |
                           seqan3::output_file_validator{seqan3::output_file_open_options::open_or_create, {"sa", "so"}} |
                           seqan3::regex_validator{".*"});
@@ -1285,7 +1285,7 @@ TEST(validator_test, chaining_validators)
         seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
         parser.add_option(option_list_value, 's', "string-option", "desc",
-                          seqan3::option_spec::DEFAULT,
+                          seqan3::option_spec::defaulted,
                           seqan3::regex_validator{"(/[^/]+)+/.*\\.[^/\\.]+$"} |
                           seqan3::output_file_validator{seqan3::output_file_open_options::create_new, {"sa", "so"}});
 

--- a/test/unit/argument_parser/format_parse_validators_test.cpp
+++ b/test/unit/argument_parser/format_parse_validators_test.cpp
@@ -138,7 +138,7 @@ TEST(validator_test, input_file)
         seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
         parser.add_option(file_in_path, 'i', "int-option", "desc",
-                          seqan3::option_spec::defaulted, seqan3::input_file_validator{formats});
+                          seqan3::option_spec::standard, seqan3::input_file_validator{formats});
 
         EXPECT_NO_THROW(parser.parse());
         EXPECT_EQ(file_in_path.string(), path);
@@ -256,7 +256,7 @@ TEST(validator_test, output_file)
         seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
         parser.add_option(file_out_path, 'o', "out-option", "desc",
-                          seqan3::option_spec::defaulted,
+                          seqan3::option_spec::standard,
                           seqan3::output_file_validator{seqan3::output_file_open_options::create_new, formats});
 
         EXPECT_NO_THROW(parser.parse());
@@ -391,7 +391,7 @@ TEST(validator_test, input_directory)
             seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
             test_accessor::set_terminal_width(parser, 80);
             parser.add_option(dir_in_path, 'i', "input-option", "desc",
-                              seqan3::option_spec::defaulted, seqan3::input_directory_validator{});
+                              seqan3::option_spec::standard, seqan3::input_directory_validator{});
 
             EXPECT_NO_THROW(parser.parse());
             EXPECT_EQ(path, dir_in_path.string());
@@ -443,7 +443,7 @@ TEST(validator_test, output_directory)
         seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
         parser.add_option(dir_out_path, 'o', "output-option", "desc",
-                          seqan3::option_spec::defaulted,
+                          seqan3::option_spec::standard,
                           seqan3::output_directory_validator{});
 
         EXPECT_NO_THROW(parser.parse());
@@ -644,7 +644,7 @@ TEST(validator_test, arithmetic_range_validator_success)
     seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser, 80);
     parser.add_option(option_value, 'i', "int-option", "desc",
-                      seqan3::option_spec::defaulted, seqan3::arithmetic_range_validator{1, 20});
+                      seqan3::option_spec::standard, seqan3::arithmetic_range_validator{1, 20});
 
     testing::internal::CaptureStderr();
     EXPECT_NO_THROW(parser.parse());
@@ -656,7 +656,7 @@ TEST(validator_test, arithmetic_range_validator_success)
     seqan3::argument_parser parser2{"test_parser", 3, argv2, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser2, 80);
     parser2.add_option(option_value, 'i', "int-option", "desc",
-                       seqan3::option_spec::defaulted, seqan3::arithmetic_range_validator{-20, 20});
+                       seqan3::option_spec::standard, seqan3::arithmetic_range_validator{-20, 20});
 
     testing::internal::CaptureStderr();
     EXPECT_NO_THROW(parser2.parse());
@@ -690,7 +690,7 @@ TEST(validator_test, arithmetic_range_validator_success)
     seqan3::argument_parser parser5{"test_parser", 5, argv5, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser5, 80);
     parser5.add_option(option_vector, 'i', "int-option", "desc",
-                       seqan3::option_spec::defaulted, seqan3::arithmetic_range_validator{-50,50});
+                       seqan3::option_spec::standard, seqan3::arithmetic_range_validator{-50,50});
 
     testing::internal::CaptureStderr();
     EXPECT_NO_THROW(parser5.parse());
@@ -739,7 +739,7 @@ TEST(validator_test, arithmetic_range_validator_success)
     seqan3::argument_parser parser8{"test_parser", 3, argv8, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser8, 80);
     parser8.add_option(double_option_value, 'i', "double-option", "desc",
-                       seqan3::option_spec::defaulted, seqan3::arithmetic_range_validator{1, 20});
+                       seqan3::option_spec::standard, seqan3::arithmetic_range_validator{1, 20});
 
     testing::internal::CaptureStderr();
     EXPECT_NO_THROW(parser8.parse());
@@ -757,7 +757,7 @@ TEST(validator_test, arithmetic_range_validator_error)
     seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser, 80);
     parser.add_option(option_value, 'i', "int-option", "desc",
-                      seqan3::option_spec::defaulted, seqan3::arithmetic_range_validator{1, 20});
+                      seqan3::option_spec::standard, seqan3::arithmetic_range_validator{1, 20});
 
     EXPECT_THROW(parser.parse(), seqan3::validation_error);
 
@@ -766,7 +766,7 @@ TEST(validator_test, arithmetic_range_validator_error)
     seqan3::argument_parser parser2{"test_parser", 3, argv2, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser2, 80);
     parser2.add_option(option_value, 'i', "int-option", "desc",
-                       seqan3::option_spec::defaulted, seqan3::arithmetic_range_validator{-20, 20});
+                       seqan3::option_spec::standard, seqan3::arithmetic_range_validator{-20, 20});
 
     EXPECT_THROW(parser2.parse(), seqan3::validation_error);
 
@@ -791,7 +791,7 @@ TEST(validator_test, arithmetic_range_validator_error)
     seqan3::argument_parser parser5{"test_parser", 3, argv5, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser5, 80);
     parser5.add_option(option_vector, 'i', "int-option", "desc",
-                       seqan3::option_spec::defaulted, seqan3::arithmetic_range_validator{-50, 50});
+                       seqan3::option_spec::standard, seqan3::arithmetic_range_validator{-50, 50});
 
     EXPECT_THROW(parser5.parse(), seqan3::validation_error);
 
@@ -810,7 +810,7 @@ TEST(validator_test, arithmetic_range_validator_error)
     seqan3::argument_parser parser7{"test_parser", 3, argv7, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser7, 80);
     parser7.add_option(double_option_value, 'i', "double-option", "desc",
-                       seqan3::option_spec::defaulted, seqan3::arithmetic_range_validator{1, 20});
+                       seqan3::option_spec::standard, seqan3::arithmetic_range_validator{1, 20});
 
     EXPECT_THROW(parser7.parse(), seqan3::validation_error);
 }
@@ -870,7 +870,7 @@ TEST(validator_test, value_list_validator_success)
     seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser, 80);
     parser.add_option(option_value, 's', "string-option", "desc",
-                      seqan3::option_spec::defaulted,
+                      seqan3::option_spec::standard,
                       seqan3::value_list_validator{valid_str_values | std::views::take(2)});
 
     testing::internal::CaptureStderr();
@@ -883,7 +883,7 @@ TEST(validator_test, value_list_validator_success)
     seqan3::argument_parser parser2{"test_parser", 3, argv2, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser2, 80);
     parser2.add_option(option_value_int, 'i', "int-option", "desc",
-                       seqan3::option_spec::defaulted, seqan3::value_list_validator<int>{0, -21, 10});
+                       seqan3::option_spec::standard, seqan3::value_list_validator<int>{0, -21, 10});
 
     testing::internal::CaptureStderr();
     EXPECT_NO_THROW(parser2.parse());
@@ -918,7 +918,7 @@ TEST(validator_test, value_list_validator_success)
     seqan3::argument_parser parser5{"test_parser", 5, argv5, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser5, 80);
     parser5.add_option(option_vector_int, 'i', "int-option", "desc",
-                       seqan3::option_spec::defaulted, seqan3::value_list_validator<int>{-10, 48, 50});
+                       seqan3::option_spec::standard, seqan3::value_list_validator<int>{-10, 48, 50});
 
     testing::internal::CaptureStderr();
     EXPECT_NO_THROW(parser5.parse());
@@ -932,7 +932,7 @@ TEST(validator_test, value_list_validator_success)
     seqan3::argument_parser parser7{"test_parser", 2, argv7, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser7, 80);
     parser7.add_option(option_vector_int, 'i', "int-option", "desc",
-                       seqan3::option_spec::defaulted, seqan3::value_list_validator<int>{-10, 48, 50});
+                       seqan3::option_spec::standard, seqan3::value_list_validator<int>{-10, 48, 50});
 
     option_vector_int.clear();
     testing::internal::CaptureStdout();
@@ -961,7 +961,7 @@ TEST(validator_test, value_list_validator_error)
     seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser, 80);
     parser.add_option(option_value, 's', "string-option", "desc",
-                      seqan3::option_spec::defaulted, seqan3::value_list_validator{"ha", "ba", "ma"});
+                      seqan3::option_spec::standard, seqan3::value_list_validator{"ha", "ba", "ma"});
 
     EXPECT_THROW(parser.parse(), seqan3::validation_error);
 
@@ -987,7 +987,7 @@ TEST(validator_test, value_list_validator_error)
     seqan3::argument_parser parser5{"test_parser", 5, argv5, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser5, 80);
     parser5.add_option(option_vector_int, 'i', "int-option", "desc",
-                       seqan3::option_spec::defaulted, seqan3::value_list_validator<int>{-10, 48, 50});
+                       seqan3::option_spec::standard, seqan3::value_list_validator<int>{-10, 48, 50});
 
     EXPECT_THROW(parser5.parse(), seqan3::validation_error);
 }
@@ -1004,7 +1004,7 @@ TEST(validator_test, regex_validator_success)
         seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
         parser.add_option(option_value, 's', "string-option", "desc",
-                          seqan3::option_spec::defaulted, email_validator);
+                          seqan3::option_spec::standard, email_validator);
 
         testing::internal::CaptureStderr();
         EXPECT_NO_THROW(parser.parse());
@@ -1046,7 +1046,7 @@ TEST(validator_test, regex_validator_success)
         seqan3::argument_parser parser{"test_parser", 5, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
         parser.add_option(option_vector, 's', "string-option", "desc",
-                           seqan3::option_spec::defaulted, email_vector_validator);
+                           seqan3::option_spec::standard, email_vector_validator);
 
         testing::internal::CaptureStderr();
         EXPECT_NO_THROW(parser.parse());
@@ -1061,7 +1061,7 @@ TEST(validator_test, regex_validator_success)
         seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
         parser.add_option(path_option, 's', "string-option", "desc",
-                          seqan3::option_spec::defaulted, email_vector_validator);
+                          seqan3::option_spec::standard, email_vector_validator);
 
         testing::internal::CaptureStderr();
         EXPECT_NO_THROW(parser.parse());
@@ -1075,7 +1075,7 @@ TEST(validator_test, regex_validator_success)
         seqan3::argument_parser parser{"test_parser", 2, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
         parser.add_option(option_vector, 's', "string-option", "desc",
-                           seqan3::option_spec::defaulted, email_vector_validator);
+                           seqan3::option_spec::standard, email_vector_validator);
 
         option_vector.clear();
         testing::internal::CaptureStdout();
@@ -1104,7 +1104,7 @@ TEST(validator_test, regex_validator_error)
     seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser, 80);
     parser.add_option(option_value, '\0', "string-option", "desc",
-                      seqan3::option_spec::defaulted, seqan3::regex_validator{"tt"});
+                      seqan3::option_spec::standard, seqan3::regex_validator{"tt"});
 
     EXPECT_THROW(parser.parse(), seqan3::validation_error);
 
@@ -1132,7 +1132,7 @@ TEST(validator_test, regex_validator_error)
     seqan3::argument_parser parser4{"test_parser", 5, argv4, seqan3::update_notifications::off};
     test_accessor::set_terminal_width(parser4, 80);
     parser4.add_option(option_vector, 's', "", "desc",
-                       seqan3::option_spec::defaulted, seqan3::regex_validator{"tt"});
+                       seqan3::option_spec::standard, seqan3::regex_validator{"tt"});
 
     EXPECT_THROW(parser4.parse(), seqan3::validation_error);
 }
@@ -1155,7 +1155,7 @@ TEST(validator_test, chaining_validators)
         seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
         parser.add_option(option_value, 's', "string-option", "desc",
-                          seqan3::option_spec::defaulted, absolute_path_validator | my_file_ext_validator);
+                          seqan3::option_spec::standard, absolute_path_validator | my_file_ext_validator);
 
         testing::internal::CaptureStderr();
         EXPECT_NO_THROW(parser.parse());
@@ -1169,7 +1169,7 @@ TEST(validator_test, chaining_validators)
         seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
         parser.add_option(option_value, 's', "string-option", "desc",
-                          seqan3::option_spec::defaulted, absolute_path_validator | my_file_ext_validator);
+                          seqan3::option_spec::standard, absolute_path_validator | my_file_ext_validator);
 
         EXPECT_THROW(parser.parse(), seqan3::validation_error);
     }
@@ -1180,7 +1180,7 @@ TEST(validator_test, chaining_validators)
         seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
         parser.add_option(option_value, 's', "string-option", "desc",
-                          seqan3::option_spec::defaulted, absolute_path_validator | my_file_ext_validator);
+                          seqan3::option_spec::standard, absolute_path_validator | my_file_ext_validator);
 
         EXPECT_THROW(parser.parse(), seqan3::validation_error);
     }
@@ -1192,7 +1192,7 @@ TEST(validator_test, chaining_validators)
         seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
         parser.add_option(option_value, 's', "string-option", "desc",
-                          seqan3::option_spec::defaulted,
+                          seqan3::option_spec::standard,
                           seqan3::regex_validator{"(/[^/]+)+/.*\\.[^/\\.]+$"} |
                           seqan3::output_file_validator{seqan3::output_file_open_options::create_new, {"sa", "so"}});
 
@@ -1209,7 +1209,7 @@ TEST(validator_test, chaining_validators)
         seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
         parser.add_option(option_value, 's', "string-option", "desc",
-                          seqan3::option_spec::defaulted,
+                          seqan3::option_spec::standard,
                           seqan3::regex_validator{"(/[^/]+)+/.*\\.[^/\\.]+$"} |
                           seqan3::output_file_validator{seqan3::output_file_open_options::create_new, {"sa", "so"}} |
                           seqan3::regex_validator{".*"});
@@ -1227,7 +1227,7 @@ TEST(validator_test, chaining_validators)
         seqan3::argument_parser parser{"test_parser", 2, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
         parser.add_option(option_value, 's', "string-option", "desc",
-                          seqan3::option_spec::defaulted,
+                          seqan3::option_spec::standard,
                           seqan3::regex_validator{"(/[^/]+)+/.*\\.[^/\\.]+$"} |
                           seqan3::output_file_validator{seqan3::output_file_open_options::create_new, {"sa", "so"}} |
                           seqan3::regex_validator{".*"});
@@ -1256,7 +1256,7 @@ TEST(validator_test, chaining_validators)
         seqan3::argument_parser parser{"test_parser", 2, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
         parser.add_option(option_value, 's', "string-option", "desc",
-                          seqan3::option_spec::defaulted,
+                          seqan3::option_spec::standard,
                           seqan3::regex_validator{"(/[^/]+)+/.*\\.[^/\\.]+$"} |
                           seqan3::output_file_validator{seqan3::output_file_open_options::open_or_create, {"sa", "so"}} |
                           seqan3::regex_validator{".*"});
@@ -1285,7 +1285,7 @@ TEST(validator_test, chaining_validators)
         seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
         parser.add_option(option_list_value, 's', "string-option", "desc",
-                          seqan3::option_spec::defaulted,
+                          seqan3::option_spec::standard,
                           seqan3::regex_validator{"(/[^/]+)+/.*\\.[^/\\.]+$"} |
                           seqan3::output_file_validator{seqan3::output_file_open_options::create_new, {"sa", "so"}});
 


### PR DESCRIPTION
I had some free time to tackle other stuff and this was something API relevant that needed to be done for a while.

Part of https://github.com/seqan/product_backlog/issues/246

The enum names of `seqan3::option_spec` were changed to lower case:
  * `seqan3::option_spec::DEFAULT` is replaced by `seqan3::option_spec::defaulted`.
  * `seqan3::option_spec::REQUIRED` is replaced by `seqan3::option_spec::required`.
  * `seqan3::option_spec::ADVANCED` is replaced by `seqan3::option_spec::advanced`.
  * `seqan3::option_spec::HIDDEN` is replaced by `seqan3::option_spec::hidden`.
