### PR TITLE
[DOC] Refactor phred snippets. The int cast is not needed.

### DIFF
--- a/test/snippet/alphabet/quality/phred42.cpp
+++ b/test/snippet/alphabet/quality/phred42.cpp
@@ -5,12 +5,11 @@ int main()
 {
     seqan3::phred42 phred;
     phred.assign_rank(2); // wrapper for assign_phred(2)
-    seqan3::debug_stream << (int) phred.to_phred() << "\n"; // 2
+    seqan3::debug_stream << phred.to_phred() << "\n"; // 2
     seqan3::debug_stream << phred.to_char() << "\n";        // '#'
-    seqan3::debug_stream << (int) phred.to_rank() << "\n";  // 2
+    seqan3::debug_stream << phred.to_rank() << "\n";  // 2
 
     seqan3::phred42 another_phred;
     another_phred.assign_phred(49); // converted down to 41
     seqan3::debug_stream << another_phred.to_phred() << "\n"; // 41
-    // we need to cast to(int)for human readable console output
 }

--- a/test/snippet/alphabet/quality/phred63.cpp
+++ b/test/snippet/alphabet/quality/phred63.cpp
@@ -5,13 +5,12 @@ int main()
 {
     seqan3::phred63 phred;
     phred.assign_rank(2); // wrapper for assign_phred(2)
-    seqan3::debug_stream << static_cast<int>(phred.to_phred()) << "\n"; // 2
+    seqan3::debug_stream << phred.to_phred() << "\n"; // 2
     seqan3::debug_stream << phred.to_char() << "\n";        // '#'
-    seqan3::debug_stream << static_cast<int>(phred.to_rank()) << "\n";  // 2
+    seqan3::debug_stream << phred.to_rank() << "\n";  // 2
 
     seqan3::phred63 another_phred{49};
     seqan3::debug_stream << another_phred.to_phred() << "\n"; // 49
-    // we need to cast to (int) for human readable console output
 
     seqan3::phred63 a_third_phred;
     another_phred.assign_phred(75); // converted down to 62


### PR DESCRIPTION
This is a follow up of https://github.com/seqan/seqan3/pull/2290
and connected to https://github.com/seqan/product_backlog/issues/266.
The cast to integer is not needed for a better output. This is automaticly done with the debug_stream.