### PR TITLE
Introduce <bit> shim-header

### DIFF
--- a/include/seqan3/alignment/matrix/edit_distance_score_matrix_full.hpp
+++ b/include/seqan3/alignment/matrix/edit_distance_score_matrix_full.hpp
@@ -109,7 +109,7 @@ public:
     static size_t max_rows(word_type const score_mask, unsigned const last_block,
                            score_type const score, score_type const max_errors) noexcept
     {
-        size_t const offset = score_mask == 0u ? 0u : most_significant_bit_set(score_mask) + 1u;
+        size_t const offset = score_mask == 0u ? 0u : std::bit_width(score_mask);
         size_t const active_row = word_size * last_block + offset;
         return active_row + (score <= max_errors);
     }

--- a/include/seqan3/alignment/matrix/edit_distance_score_matrix_full.hpp
+++ b/include/seqan3/alignment/matrix/edit_distance_score_matrix_full.hpp
@@ -109,7 +109,7 @@ public:
     static size_t max_rows(word_type const score_mask, unsigned const last_block,
                            score_type const score, score_type const max_errors) noexcept
     {
-        size_t const offset = score_mask == 0u ? 0u : std::bit_width(score_mask);
+        size_t const offset = std::bit_width(score_mask);
         size_t const active_row = word_size * last_block + offset;
         return active_row + (score <= max_errors);
     }

--- a/include/seqan3/contrib/parallel/buffer_queue.hpp
+++ b/include/seqan3/contrib/parallel/buffer_queue.hpp
@@ -14,6 +14,7 @@
 
 #include <seqan3/std/algorithm>
 #include <atomic>
+#include <seqan3/std/bit>
 #include <cmath>
 #include <seqan3/std/concepts>
 #include <mutex>
@@ -24,7 +25,6 @@
 #include <type_traits>
 #include <vector>
 
-#include <seqan3/core/bit_manipulation.hpp>
 #include <seqan3/core/range/type_traits.hpp>
 #include <seqan3/range/container/concept.hpp>
 #include <seqan3/utility/parallel/detail/spin_delay.hpp>
@@ -109,7 +109,7 @@ public:
     explicit buffer_queue(size_type const init_capacity)
     {
         buffer.resize(init_capacity + 1);
-        ring_buffer_capacity = seqan3::detail::next_power_of_two(buffer.size());
+        ring_buffer_capacity = std::bit_ceil(buffer.size());
     }
 
     template <std::ranges::input_range range_type>
@@ -420,7 +420,7 @@ inline bool buffer_queue<value_t, buffer_t, buffer_policy>::overflow(value2_t &&
 
         // increase capacity by one and move all elements from current pop_front_position one to the right.
         buffer.resize(old_size + 1);
-        ring_buffer_capacity = seqan3::detail::next_power_of_two(buffer.size());
+        ring_buffer_capacity = std::bit_ceil(buffer.size());
         std::ranges::move_backward(std::span{buffer.data() + front_buffer_position, buffer.data() + old_size},
                                    buffer.data() + buffer.size());
 

--- a/include/seqan3/core/bit_manipulation.hpp
+++ b/include/seqan3/core/bit_manipulation.hpp
@@ -125,7 +125,7 @@ SEQAN3_DEPRECATED_310 constexpr uint8_t popcount(unsigned_t const n) noexcept
 * Constant.
 */
 template <std::unsigned_integral unsigned_t>
-constexpr uint8_t count_leading_zeros(unsigned_t const n) noexcept
+SEQAN3_DEPRECATED_310 constexpr uint8_t count_leading_zeros(unsigned_t const n) noexcept
 {
     assert(n > 0); // n == 0 might have undefined behaviour
     return std::countl_zero(n);

--- a/include/seqan3/core/bit_manipulation.hpp
+++ b/include/seqan3/core/bit_manipulation.hpp
@@ -48,6 +48,7 @@ constexpr auto sizeof_bits = min_viable_uint_v<CHAR_BIT * sizeof(type_t)>;
  * \returns True if *n* is a power of two. False otherwise.
  *
  * \sa https://graphics.stanford.edu/~seander/bithacks.html#DetermineIfPowerOf2
+ * \deprecated Use std::has_single_bit instead.
  */
 SEQAN3_DEPRECATED_310 constexpr bool is_power_of_two(size_t const n)
 {
@@ -64,6 +65,7 @@ SEQAN3_DEPRECATED_310 constexpr bool is_power_of_two(size_t const n)
  * \returns The next power of two of *n*. If *n* is already a power of two, returns *n*.
  *
  * \sa https://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
+ * \deprecated Use std::bit_ceil instead.
  */
 SEQAN3_DEPRECATED_310 constexpr size_t next_power_of_two(size_t n)
 {
@@ -71,28 +73,30 @@ SEQAN3_DEPRECATED_310 constexpr size_t next_power_of_two(size_t n)
 }
 
 /*!\brief Returns the number of 1-bits.
-* \ingroup core
-*
-* \param[in] n An unsigned integer.
-*
-* \returns The number of 1-bits.
-*
-* ### Example
-*
-* \include test/snippet/core/detail/popcount.cpp
-*
-* ### Exception
-*
-* No-throw guarantee.
-*
-* ### Thread-safety
-*
-* Thread safe.
-*
-* ### Complexity
-*
-* Constant.
-*/
+ * \ingroup core
+ *
+ * \param[in] n An unsigned integer.
+ *
+ * \returns The number of 1-bits.
+ *
+ * ### Example
+ *
+ * \include test/snippet/core/detail/popcount.cpp
+ *
+ * ### Exception
+ *
+ * No-throw guarantee.
+ *
+ * ### Thread-safety
+ *
+ * Thread safe.
+ *
+ * ### Complexity
+ *
+ * Constant.
+ *
+ * \deprecated Use std::popcount instead.
+ */
 template <std::unsigned_integral unsigned_t>
 SEQAN3_DEPRECATED_310 constexpr uint8_t popcount(unsigned_t const n) noexcept
 {
@@ -100,30 +104,32 @@ SEQAN3_DEPRECATED_310 constexpr uint8_t popcount(unsigned_t const n) noexcept
 }
 
 /*!\brief Returns the number of leading 0-bits, starting at the most significant bit position.
-* \ingroup core
-*
-* \param[in] n An unsigned integer.
-*
-* \attention *n = 0* is a special case and is undefined behaviour.
-*
-* \returns The number of leading 0-bits.
-*
-* ### Example
-*
-* \include test/snippet/core/detail/count_leading_zeros.cpp
-*
-* ### Exception
-*
-* No-throw guarantee.
-*
-* ### Thread-safety
-*
-* Thread safe.
-*
-* ### Complexity
-*
-* Constant.
-*/
+ * \ingroup core
+ *
+ * \param[in] n An unsigned integer.
+ *
+ * \attention *n = 0* is a special case and is undefined behaviour.
+ *
+ * \returns The number of leading 0-bits.
+ *
+ * ### Example
+ *
+ * \include test/snippet/core/detail/count_leading_zeros.cpp
+ *
+ * ### Exception
+ *
+ * No-throw guarantee.
+ *
+ * ### Thread-safety
+ *
+ * Thread safe.
+ *
+ * ### Complexity
+ *
+ * Constant.
+ *
+ * \deprecated Use std::countl_zero instead.
+ */
 template <std::unsigned_integral unsigned_t>
 SEQAN3_DEPRECATED_310 constexpr uint8_t count_leading_zeros(unsigned_t const n) noexcept
 {
@@ -155,6 +161,8 @@ SEQAN3_DEPRECATED_310 constexpr uint8_t count_leading_zeros(unsigned_t const n) 
  * ### Complexity
  *
  * Constant.
+ *
+ * \deprecated Use std::countr_zero instead.
  */
 template <std::unsigned_integral unsigned_t>
 SEQAN3_DEPRECATED_310 constexpr uint8_t count_trailing_zeros(unsigned_t const n) noexcept
@@ -187,6 +195,8 @@ SEQAN3_DEPRECATED_310 constexpr uint8_t count_trailing_zeros(unsigned_t const n)
  * ### Complexity
  *
  * Constant.
+ *
+ * \deprecated Use std::bit_width(n) - 1 instead.
  */
 template <std::unsigned_integral unsigned_t>
 SEQAN3_DEPRECATED_310 constexpr uint8_t most_significant_bit_set(unsigned_t const n) noexcept

--- a/include/seqan3/core/bit_manipulation.hpp
+++ b/include/seqan3/core/bit_manipulation.hpp
@@ -65,7 +65,7 @@ SEQAN3_DEPRECATED_310 constexpr bool is_power_of_two(size_t const n)
  *
  * \sa https://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
  */
-constexpr size_t next_power_of_two(size_t n)
+SEQAN3_DEPRECATED_310 constexpr size_t next_power_of_two(size_t n)
 {
     return std::bit_ceil(n);
 }

--- a/include/seqan3/core/bit_manipulation.hpp
+++ b/include/seqan3/core/bit_manipulation.hpp
@@ -15,8 +15,6 @@
 
 #include <meta/meta.hpp>
 
-#include <sdsl/bits.hpp>
-
 #include <seqan3/std/bit>
 #include <climits>
 #include <seqan3/std/concepts>
@@ -53,7 +51,7 @@ constexpr auto sizeof_bits = min_viable_uint_v<CHAR_BIT * sizeof(type_t)>;
  */
 constexpr bool is_power_of_two(size_t const n)
 {
-    return n > 0 && (n & (n-1)) == 0;
+    return std::has_single_bit(n);
 }
 
 /*!\brief Returns \f$2^{\lceil\log_2(n)\rceil}\f$ for an \f$n\f$.
@@ -69,14 +67,7 @@ constexpr bool is_power_of_two(size_t const n)
  */
 constexpr size_t next_power_of_two(size_t n)
 {
-    if (n == 0)
-        return 1;
-
-    --n;
-    for (size_t shift = 1; !is_power_of_two(n + 1); shift <<= 1)
-        n |= n >> shift;
-
-    return n + 1;
+    return std::bit_ceil(n);
 }
 
 /*!\brief Returns the number of 1-bits.
@@ -105,16 +96,7 @@ constexpr size_t next_power_of_two(size_t n)
 template <std::unsigned_integral unsigned_t>
 constexpr uint8_t popcount(unsigned_t const n) noexcept
 {
-#if defined(__GNUC__)
-    if constexpr (sizeof(unsigned_t) == sizeof(unsigned long long))
-        return __builtin_popcountll(n);
-    else if constexpr (sizeof(unsigned_t) == sizeof(unsigned long))
-        return __builtin_popcountl(n);
-    else
-        return __builtin_popcount(n);
-#else
-    return sdsl::bits::cnt(n);
-#endif
+    return std::popcount(n);
 }
 
 /*!\brief Returns the number of leading 0-bits, starting at the most significant bit position.
@@ -146,16 +128,7 @@ template <std::unsigned_integral unsigned_t>
 constexpr uint8_t count_leading_zeros(unsigned_t const n) noexcept
 {
     assert(n > 0); // n == 0 might have undefined behaviour
-#if defined(__GNUC__)
-    if constexpr (sizeof(unsigned_t) == sizeof(unsigned long long))
-        return __builtin_clzll(n);
-    else if constexpr (sizeof(unsigned_t) == sizeof(unsigned long))
-        return __builtin_clzl(n);
-    else
-        return __builtin_clz(n) + sizeof_bits<unsigned_t> - sizeof_bits<unsigned int>;
-#else
-    return sizeof_bits<unsigned_t> - sdsl::bits::hi(n) - 1;
-#endif
+    return std::countl_zero(n);
 }
 
 /*!\brief Returns the number of trailing 0-bits, starting at the least significant bit position.
@@ -187,16 +160,7 @@ template <std::unsigned_integral unsigned_t>
 constexpr uint8_t count_trailing_zeros(unsigned_t const n) noexcept
 {
     assert(n > 0); // n == 0 might have undefined behaviour
-#if defined(__GNUC__)
-    if constexpr (sizeof(unsigned_t) == sizeof(unsigned long long))
-        return __builtin_ctzll(n);
-    else if constexpr (sizeof(unsigned_t) == sizeof(unsigned long))
-        return __builtin_ctzl(n);
-    else
-        return __builtin_ctz(n);
-#else
-    return sdsl::bits::lo(n);
-#endif
+    return std::countr_zero(n);
 }
 
 /*!\brief Returns the position (0-based) of the most significant bit.
@@ -228,11 +192,7 @@ template <std::unsigned_integral unsigned_t>
 constexpr uint8_t most_significant_bit_set(unsigned_t const n) noexcept
 {
     assert(n > 0); // n == 0 might have undefined behaviour
-#if defined(__GNUC__)
-    return sizeof_bits<unsigned_t> - count_leading_zeros(n) - 1;
-#else
-    return sdsl::bits::hi(n);
-#endif
+    return std::bit_width(n) - 1;
 }
 
 /*!\brief Convert the byte encoding of integer values to little-endian byte order.

--- a/include/seqan3/core/bit_manipulation.hpp
+++ b/include/seqan3/core/bit_manipulation.hpp
@@ -189,7 +189,7 @@ SEQAN3_DEPRECATED_310 constexpr uint8_t count_trailing_zeros(unsigned_t const n)
  * Constant.
  */
 template <std::unsigned_integral unsigned_t>
-constexpr uint8_t most_significant_bit_set(unsigned_t const n) noexcept
+SEQAN3_DEPRECATED_310 constexpr uint8_t most_significant_bit_set(unsigned_t const n) noexcept
 {
     assert(n > 0); // n == 0 might have undefined behaviour
     return std::bit_width(n) - 1;

--- a/include/seqan3/core/bit_manipulation.hpp
+++ b/include/seqan3/core/bit_manipulation.hpp
@@ -157,7 +157,7 @@ SEQAN3_DEPRECATED_310 constexpr uint8_t count_leading_zeros(unsigned_t const n) 
  * Constant.
  */
 template <std::unsigned_integral unsigned_t>
-constexpr uint8_t count_trailing_zeros(unsigned_t const n) noexcept
+SEQAN3_DEPRECATED_310 constexpr uint8_t count_trailing_zeros(unsigned_t const n) noexcept
 {
     assert(n > 0); // n == 0 might have undefined behaviour
     return std::countr_zero(n);

--- a/include/seqan3/core/bit_manipulation.hpp
+++ b/include/seqan3/core/bit_manipulation.hpp
@@ -49,7 +49,7 @@ constexpr auto sizeof_bits = min_viable_uint_v<CHAR_BIT * sizeof(type_t)>;
  *
  * \sa https://graphics.stanford.edu/~seander/bithacks.html#DetermineIfPowerOf2
  */
-constexpr bool is_power_of_two(size_t const n)
+SEQAN3_DEPRECATED_310 constexpr bool is_power_of_two(size_t const n)
 {
     return std::has_single_bit(n);
 }
@@ -218,7 +218,7 @@ constexpr type to_little_endian(type const in) noexcept
     {
         static_assert(sizeof(type) <= 8,
                       "Can only convert the byte encoding for integral numbers with a size of up to 8 bytes.");
-        static_assert(is_power_of_two(sizeof(type)),
+        static_assert(std::has_single_bit(sizeof(type)),
                       "Can only convert the byte encoding for integral numbers whose byte size is a power of two.");
 
         if constexpr (sizeof(type) == 2)

--- a/include/seqan3/core/bit_manipulation.hpp
+++ b/include/seqan3/core/bit_manipulation.hpp
@@ -94,7 +94,7 @@ SEQAN3_DEPRECATED_310 constexpr size_t next_power_of_two(size_t n)
 * Constant.
 */
 template <std::unsigned_integral unsigned_t>
-constexpr uint8_t popcount(unsigned_t const n) noexcept
+SEQAN3_DEPRECATED_310 constexpr uint8_t popcount(unsigned_t const n) noexcept
 {
     return std::popcount(n);
 }

--- a/include/seqan3/io/alignment_file/format_bam.hpp
+++ b/include/seqan3/io/alignment_file/format_bam.hpp
@@ -12,6 +12,7 @@
 
 #pragma once
 
+#include <seqan3/std/bit>
 #include <seqan3/std/concepts>
 #include <iterator>
 #include <seqan3/std/ranges>
@@ -20,7 +21,6 @@
 
 #include <seqan3/alphabet/detail/convert.hpp>
 #include <seqan3/alphabet/nucleotide/sam_dna16.hpp>
-#include <seqan3/core/bit_manipulation.hpp>
 #include <seqan3/core/concept/core_language.hpp>
 #include <seqan3/core/debug_stream/detail/to_string.hpp>
 #include <seqan3/core/detail/debug_stream_optional.hpp>
@@ -1147,7 +1147,8 @@ inline std::string format_bam::get_tag_dict_str(sam_tag_dictionary const & tag_d
         {
             // always choose the smallest possible representation [cCsSiI]
             bool negative = arg < 0;
-            auto n = __builtin_ctz(detail::next_power_of_two(((negative) ? arg * -1 : arg) + 1) >> 1) / 8;
+            size_t absolute_arg = ((negative) ? arg * -1 : arg);
+            auto n = std::countr_zero(std::bit_ceil(absolute_arg + 1u) >> 1u) / 8u;
             n = n * n + 2 * negative; // for switch case order
 
             switch (n)

--- a/include/seqan3/io/alignment_file/format_bam.hpp
+++ b/include/seqan3/io/alignment_file/format_bam.hpp
@@ -1146,9 +1146,9 @@ inline std::string format_bam::get_tag_dict_str(sam_tag_dictionary const & tag_d
         if constexpr (std::same_as<T, int32_t>)
         {
             // always choose the smallest possible representation [cCsSiI]
-            bool negative = arg < 0;
-            size_t absolute_arg = ((negative) ? arg * -1 : arg);
+            size_t const absolute_arg = std::abs(arg);
             auto n = std::countr_zero(std::bit_ceil(absolute_arg + 1u) >> 1u) / 8u;
+            bool const negative = arg < 0;
             n = n * n + 2 * negative; // for switch case order
 
             switch (n)

--- a/include/seqan3/range/container/dynamic_bitset.hpp
+++ b/include/seqan3/range/container/dynamic_bitset.hpp
@@ -211,7 +211,7 @@ public:
      */
     constexpr dynamic_bitset(uint64_t const value)
     {
-        if (detail::popcount(value >> 58) != 0)
+        if (std::popcount(value >> 58u) != 0u)
             throw std::invalid_argument{"The dynamic_bitset can be at most 58 long."};
         data.bits |= value;
         data.size |= value ? detail::most_significant_bit_set(value) + 1 : 0u;
@@ -953,7 +953,7 @@ public:
     //!\brief Returns the number of set bits.
     constexpr size_type count() const noexcept
     {
-        return detail::popcount(data.bits);
+        return std::popcount(data.bits);
     }
 
     /*!\brief Returns the i-th element.

--- a/include/seqan3/range/container/dynamic_bitset.hpp
+++ b/include/seqan3/range/container/dynamic_bitset.hpp
@@ -12,12 +12,14 @@
 
 #pragma once
 
-#include <seqan3/core/bit_manipulation.hpp>
+#include <seqan3/std/bit>
+
 #include <seqan3/core/concept/cereal.hpp>
 #include <seqan3/core/detail/debug_stream_type.hpp>
 #include <seqan3/range/views/interleave.hpp>
 #include <seqan3/range/views/repeat_n.hpp>
 #include <seqan3/range/views/to.hpp>
+#include <seqan3/utility/detail/integer_traits.hpp>
 
 namespace seqan3
 {
@@ -214,7 +216,7 @@ public:
         if (std::popcount(value >> 58u) != 0u)
             throw std::invalid_argument{"The dynamic_bitset can be at most 58 long."};
         data.bits |= value;
-        data.size |= value ? detail::most_significant_bit_set(value) + 1 : 0u;
+        data.size |= value ? std::bit_width(value) : 0u;
     }
 
     /*!\brief Construct from two iterators.

--- a/include/seqan3/range/container/dynamic_bitset.hpp
+++ b/include/seqan3/range/container/dynamic_bitset.hpp
@@ -216,7 +216,7 @@ public:
         if (std::popcount(value >> 58u) != 0u)
             throw std::invalid_argument{"The dynamic_bitset can be at most 58 long."};
         data.bits |= value;
-        data.size |= value ? std::bit_width(value) : 0u;
+        data.size |= std::bit_width(value);
     }
 
     /*!\brief Construct from two iterators.

--- a/include/seqan3/search/dream_index/interleaved_bloom_filter.hpp
+++ b/include/seqan3/search/dream_index/interleaved_bloom_filter.hpp
@@ -678,7 +678,7 @@ public:
                 while (tmp > 0)
                 {
                     // Jump to the next 1 and increment the corresponding vector entry.
-                    uint8_t step = detail::count_trailing_zeros(tmp);
+                    uint8_t step = std::countr_zero(tmp);
                     bin += step++;
                     tmp >>= step;
                     ++(*this)[bin++];

--- a/include/seqan3/search/dream_index/interleaved_bloom_filter.hpp
+++ b/include/seqan3/search/dream_index/interleaved_bloom_filter.hpp
@@ -227,7 +227,7 @@ public:
         if (bin_size_ == 0)
             throw std::logic_error{"The size of a bin must be > 0."};
 
-        hash_shift = detail::count_leading_zeros(bin_size_);
+        hash_shift = std::countl_zero(bin_size_);
         bin_words = (bins + 63) >> 6; // = ceil(bins/64)
         technical_bins  = bin_words << 6; // = bin_words * 64
         data = sdsl::bit_vector(technical_bins * bin_size_);

--- a/include/seqan3/std/bit
+++ b/include/seqan3/std/bit
@@ -65,6 +65,9 @@ template <typename type_t>
 constexpr auto sizeof_bits = CHAR_BIT * sizeof(type_t);
 } // namespace std::detail
 
+// forward declare
+template<class T> constexpr int countl_zero(T x) noexcept;
+
 // // bit_­cast
 // template<class To, class From> constexpr To bit_cast(const From& from) noexcept;
 //
@@ -91,7 +94,12 @@ template<class T> constexpr T bit_ceil(T x) noexcept
 }
 
 // template<class T> constexpr T bit_floor(T x) noexcept;
-// template<class T> constexpr T bit_width(T x) noexcept;
+template<class T> constexpr T bit_width(T x) noexcept
+{
+    static_assert(std::is_unsigned_v<T>, "Input should be unsigned.");
+
+    return detail::sizeof_bits<T> - countl_zero(x);
+}
 //
 // // rotating
 // template<class T> [[nodiscard]] constexpr T rotl(T x, int s) noexcept;

--- a/include/seqan3/std/bit
+++ b/include/seqan3/std/bit
@@ -25,10 +25,14 @@
 //!       Those versions implemented std::{rotl, rotr, countl_zero, countl_one, countr_zero, countr_one, popcount}, but
 //!       did not define that feature detection macro.
 #ifndef SEQAN3_CPP_LIB_BITOPS
-#   if defined(__cpp_lib_bitops)
+#   if defined(__cpp_lib_bitops) && __cpp_lib_bitops >= 201907L
 #       define SEQAN3_CPP_LIB_BITOPS 1
-#   elif defined(__GNUC__) && (__GNUC__ == 9) && __cplusplus > 201703L /*C++2a*/
-// #       define SEQAN3_CPP_LIB_BITOPS 1
+#   endif
+#endif
+
+#ifndef SEQAN3_CPP_LIB_INT_POW2
+#   if defined(__cpp_lib_int_pow2) && __cpp_lib_int_pow2 >= 202002L
+#       define SEQAN3_CPP_LIB_INT_POW2 1
 #   endif
 #endif
 
@@ -65,7 +69,7 @@ enum class endian
 
 #endif // __cpp_lib_endian
 
-#if !defined(__cpp_lib_int_pow2) || !defined(SEQAN3_CPP_LIB_BITOPS)
+#if !defined(SEQAN3_CPP_LIB_INT_POW2) || !defined(SEQAN3_CPP_LIB_BITOPS)
 
 namespace std::detail
 {
@@ -77,9 +81,9 @@ template <typename type_t>
 constexpr auto sizeof_bits = CHAR_BIT * sizeof(type_t);
 } // namespace std::detail
 
-#endif // !defined(__cpp_lib_int_pow2) || !defined(SEQAN3_CPP_LIB_BITOPS)
+#endif // !defined(SEQAN3_CPP_LIB_INT_POW2) || !defined(SEQAN3_CPP_LIB_BITOPS)
 
-#ifndef __cpp_lib_int_pow2
+#ifndef SEQAN3_CPP_LIB_INT_POW2
 
 namespace std
 {
@@ -144,7 +148,7 @@ template<class T> constexpr T bit_width(T x) noexcept
 
 } // namespace std
 
-#endif // __cpp_lib_int_pow2
+#endif // SEQAN3_CPP_LIB_INT_POW2
 
 #ifndef SEQAN3_CPP_LIB_BITOPS
 

--- a/include/seqan3/std/bit
+++ b/include/seqan3/std/bit
@@ -28,7 +28,7 @@
 #   if defined(__cpp_lib_bitops)
 #       define SEQAN3_CPP_LIB_BITOPS 1
 #   elif defined(__GNUC__) && (__GNUC__ == 9) && __cplusplus > 201703L /*C++2a*/
-#       define SEQAN3_CPP_LIB_BITOPS 1
+// #       define SEQAN3_CPP_LIB_BITOPS 1
 #   endif
 #endif
 
@@ -84,6 +84,9 @@ constexpr auto sizeof_bits = CHAR_BIT * sizeof(type_t);
 namespace std
 {
 
+namespace
+{
+
 #ifndef SEQAN3_CPP_LIB_BITOPS
 // forward declare
 template<class T> constexpr int countl_zero(T x) noexcept;
@@ -137,6 +140,8 @@ template<class T> constexpr T bit_width(T x) noexcept
     return detail::sizeof_bits<T> - countl_zero(x);
 }
 
+} // anonymous namespace
+
 } // namespace std
 
 #endif // __cpp_lib_int_pow2
@@ -145,6 +150,10 @@ template<class T> constexpr T bit_width(T x) noexcept
 
 namespace std
 {
+
+namespace
+{
+
 //
 // // rotating
 // template<class T> [[nodiscard]] constexpr T rotl(T x, int s) noexcept;
@@ -202,6 +211,8 @@ template<class T> constexpr int popcount(T x) noexcept
     else
         return __builtin_popcount(x);
 }
+
+} // anonymous namespace
 
 } // namespace std
 

--- a/include/seqan3/std/bit
+++ b/include/seqan3/std/bit
@@ -54,11 +54,15 @@ enum class endian
 
 #endif // __cpp_lib_endian
 
+#if !defined(__cpp_lib_int_pow2) || !defined(__cpp_lib_bitops)
+
 namespace std::detail
 {
 template <typename type_t>
 constexpr auto sizeof_bits = CHAR_BIT * sizeof(type_t);
 } // namespace std::detail
+
+#endif // !defined(__cpp_lib_int_pow2) || !defined(__cpp_lib_bitops)
 
 #ifndef __cpp_lib_int_pow2
 

--- a/include/seqan3/std/bit
+++ b/include/seqan3/std/bit
@@ -24,6 +24,8 @@
 #ifndef SEQAN3_CPP_LIB_BITOPS
 #   if defined(__cpp_lib_bitops) && __cpp_lib_bitops >= 201907L
 #       define SEQAN3_CPP_LIB_BITOPS 1
+#   elif defined(__GNUC__) && (__GNUC__ == 9) && __cplusplus > 201703L
+#       define SEQAN3_CPP_LIB_BITOPS 1
 #   endif
 #endif
 

--- a/include/seqan3/std/bit
+++ b/include/seqan3/std/bit
@@ -17,6 +17,8 @@
 #if __has_include(<bit>)
 #include <bit>
 #endif // __has_include(<bit>)
+#include <climits>
+#include <type_traits>
 
 #ifndef __cpp_lib_endian
 
@@ -56,6 +58,12 @@ enum class endian
 namespace std
 {
 
+namespace detail
+{
+template <typename type_t>
+constexpr auto sizeof_bits = CHAR_BIT * sizeof(type_t);
+} // namespace std::detail
+
 // // bit_­cast
 // template<class To, class From> constexpr To bit_cast(const From& from) noexcept;
 //
@@ -89,7 +97,19 @@ template<class T> constexpr T bit_ceil(T x) noexcept
 // template<class T> [[nodiscard]] constexpr T rotr(T x, int s) noexcept;
 //
 // // counting
-// template<class T> constexpr int countl_zero(T x) noexcept;
+template<class T> constexpr int countl_zero(T x) noexcept
+{
+    static_assert(std::is_unsigned_v<T>, "Input should be unsigned.");
+    assert(x > 0); // n == 0 might have undefined behaviour
+
+    if constexpr (sizeof(T) == sizeof(unsigned long long))
+        return __builtin_clzll(x);
+    else if constexpr (sizeof(T) == sizeof(unsigned long))
+        return __builtin_clzl(x);
+    else
+        return __builtin_clz(x) + detail::sizeof_bits<T> - detail::sizeof_bits<unsigned int>;
+}
+
 // template<class T> constexpr int countl_one(T x) noexcept;
 // template<class T> constexpr int countr_zero(T x) noexcept;
 // template<class T> constexpr int countr_one(T x) noexcept;

--- a/include/seqan3/std/bit
+++ b/include/seqan3/std/bit
@@ -125,7 +125,17 @@ template<class T> constexpr int countr_zero(T x) noexcept
         return __builtin_ctz(x);
 }
 // template<class T> constexpr int countr_one(T x) noexcept;
-// template<class T> constexpr int popcount(T x) noexcept;
+template<class T> constexpr int popcount(T x) noexcept
+{
+    static_assert(std::is_unsigned_v<T>, "Input should be unsigned.");
+
+    if constexpr (sizeof(T) == sizeof(unsigned long long))
+        return __builtin_popcountll(x);
+    else if constexpr (sizeof(T) == sizeof(unsigned long))
+        return __builtin_popcountl(x);
+    else
+        return __builtin_popcount(x);
+}
 
 } // namespace std
 

--- a/include/seqan3/std/bit
+++ b/include/seqan3/std/bit
@@ -9,6 +9,7 @@
 /*!\file
  * \brief Provides the C++20 \<bit\> header if it is not already available.
  * \author Enrico Seiler <enrico.seiler AT fu-berlin.de>
+ * \author Marcel Ehrhardt <marcel.ehrhardt AT fu-berlin.de>
  */
 
 #pragma once
@@ -49,3 +50,32 @@ enum class endian
 } //namespace std
 
 #endif // __cpp_lib_endian
+
+#ifndef __cpp_lib_int_pow2
+
+namespace std
+{
+
+// // bit_­cast
+// template<class To, class From> constexpr To bit_cast(const From& from) noexcept;
+//
+// // integral powers of 2
+// template<class T> constexpr bool has_single_bit(T x) noexcept;
+// template<class T> constexpr T bit_ceil(T x) noexcept;
+// template<class T> constexpr T bit_floor(T x) noexcept;
+// template<class T> constexpr T bit_width(T x) noexcept;
+//
+// // rotating
+// template<class T> [[nodiscard]] constexpr T rotl(T x, int s) noexcept;
+// template<class T> [[nodiscard]] constexpr T rotr(T x, int s) noexcept;
+//
+// // counting
+// template<class T> constexpr int countl_zero(T x) noexcept;
+// template<class T> constexpr int countl_one(T x) noexcept;
+// template<class T> constexpr int countr_zero(T x) noexcept;
+// template<class T> constexpr int countr_one(T x) noexcept;
+// template<class T> constexpr int popcount(T x) noexcept;
+
+} // namespace std
+
+#endif // __cpp_lib_int_pow2

--- a/include/seqan3/std/bit
+++ b/include/seqan3/std/bit
@@ -17,6 +17,7 @@
 #if __has_include(<bit>)
 #include <bit>
 #endif // __has_include(<bit>)
+#include <cassert>
 #include <climits>
 #include <type_traits>
 
@@ -111,7 +112,18 @@ template<class T> constexpr int countl_zero(T x) noexcept
 }
 
 // template<class T> constexpr int countl_one(T x) noexcept;
-// template<class T> constexpr int countr_zero(T x) noexcept;
+template<class T> constexpr int countr_zero(T x) noexcept
+{
+    static_assert(std::is_unsigned_v<T>, "Input should be unsigned.");
+    assert(x > 0); // x == 0 might have undefined behaviour
+
+    if constexpr (sizeof(T) == sizeof(unsigned long long))
+        return __builtin_ctzll(x);
+    else if constexpr (sizeof(T) == sizeof(unsigned long))
+        return __builtin_ctzl(x);
+    else
+        return __builtin_ctz(x);
+}
 // template<class T> constexpr int countr_one(T x) noexcept;
 // template<class T> constexpr int popcount(T x) noexcept;
 

--- a/include/seqan3/std/bit
+++ b/include/seqan3/std/bit
@@ -17,7 +17,6 @@
 #if __has_include(<bit>)
 #include <bit>
 #endif // __has_include(<bit>)
-#include <cassert>
 #include <climits>
 #include <type_traits>
 

--- a/include/seqan3/std/bit
+++ b/include/seqan3/std/bit
@@ -21,6 +21,17 @@
 #include <climits>
 #include <type_traits>
 
+//!\brief This defines __cpp_lib_bitops for gcc version >=9.0 (in C++2a mode).
+//!       Those versions implemented std::{rotl, rotr, countl_zero, countl_one, countr_zero, countr_one, popcount}, but
+//!       did not define that feature detection macro.
+#ifndef SEQAN3_CPP_LIB_BITOPS
+#   if defined(__cpp_lib_bitops)
+#       define SEQAN3_CPP_LIB_BITOPS 1
+#   elif defined(__GNUC__) && (__GNUC__ == 9) && __cplusplus > 201703L /*C++2a*/
+#       define SEQAN3_CPP_LIB_BITOPS 1
+#   endif
+#endif
+
 #ifndef __cpp_lib_endian
 
 #include <cstddef>
@@ -54,7 +65,7 @@ enum class endian
 
 #endif // __cpp_lib_endian
 
-#if !defined(__cpp_lib_int_pow2) || !defined(__cpp_lib_bitops)
+#if !defined(__cpp_lib_int_pow2) || !defined(SEQAN3_CPP_LIB_BITOPS)
 
 namespace std::detail
 {
@@ -66,15 +77,17 @@ template <typename type_t>
 constexpr auto sizeof_bits = CHAR_BIT * sizeof(type_t);
 } // namespace std::detail
 
-#endif // !defined(__cpp_lib_int_pow2) || !defined(__cpp_lib_bitops)
+#endif // !defined(__cpp_lib_int_pow2) || !defined(SEQAN3_CPP_LIB_BITOPS)
 
 #ifndef __cpp_lib_int_pow2
 
 namespace std
 {
 
+#ifndef SEQAN3_CPP_LIB_BITOPS
 // forward declare
 template<class T> constexpr int countl_zero(T x) noexcept;
+#endif // SEQAN3_CPP_LIB_BITOPS
 
 // // bit_­cast
 // template<class To, class From> constexpr To bit_cast(const From& from) noexcept;
@@ -128,7 +141,7 @@ template<class T> constexpr T bit_width(T x) noexcept
 
 #endif // __cpp_lib_int_pow2
 
-#ifndef __cpp_lib_bitops
+#ifndef SEQAN3_CPP_LIB_BITOPS
 
 namespace std
 {
@@ -192,4 +205,4 @@ template<class T> constexpr int popcount(T x) noexcept
 
 } // namespace std
 
-#endif // __cpp_lib_bitops
+#endif // SEQAN3_CPP_LIB_BITOPS

--- a/include/seqan3/std/bit
+++ b/include/seqan3/std/bit
@@ -66,7 +66,21 @@ template<class T> constexpr bool has_single_bit(T x) noexcept
 
     return x > 0 && (x & (x-1)) == 0;
 }
-// template<class T> constexpr T bit_ceil(T x) noexcept;
+
+template<class T> constexpr T bit_ceil(T x) noexcept
+{
+    static_assert(std::is_unsigned_v<T>, "Input should be unsigned.");
+
+    if (x == 0)
+        return 1;
+
+    --x;
+    for (size_t shift = 1; !has_single_bit(x + 1); shift <<= 1)
+        x |= x >> shift;
+
+    return x + 1;
+}
+
 // template<class T> constexpr T bit_floor(T x) noexcept;
 // template<class T> constexpr T bit_width(T x) noexcept;
 //

--- a/include/seqan3/std/bit
+++ b/include/seqan3/std/bit
@@ -109,28 +109,26 @@ template<class T> constexpr T bit_width(T x) noexcept
 template<class T> constexpr int countl_zero(T x) noexcept
 {
     static_assert(std::is_unsigned_v<T>, "Input should be unsigned.");
-    assert(x > 0); // n == 0 might have undefined behaviour
 
     if constexpr (sizeof(T) == sizeof(unsigned long long))
-        return __builtin_clzll(x);
+        return x == 0u ? detail::sizeof_bits<T> : __builtin_clzll(x);
     else if constexpr (sizeof(T) == sizeof(unsigned long))
-        return __builtin_clzl(x);
+        return x == 0u ? detail::sizeof_bits<T> : __builtin_clzl(x);
     else
-        return __builtin_clz(x) + detail::sizeof_bits<T> - detail::sizeof_bits<unsigned int>;
+        return detail::sizeof_bits<T> + (x == 0u ? 0u : __builtin_clz(x) - detail::sizeof_bits<unsigned int>);
 }
 
 // template<class T> constexpr int countl_one(T x) noexcept;
 template<class T> constexpr int countr_zero(T x) noexcept
 {
     static_assert(std::is_unsigned_v<T>, "Input should be unsigned.");
-    assert(x > 0); // x == 0 might have undefined behaviour
 
     if constexpr (sizeof(T) == sizeof(unsigned long long))
-        return __builtin_ctzll(x);
+        return x == 0u ? detail::sizeof_bits<T> : __builtin_ctzll(x);
     else if constexpr (sizeof(T) == sizeof(unsigned long))
-        return __builtin_ctzl(x);
+        return x == 0u ? detail::sizeof_bits<T> : __builtin_ctzl(x);
     else
-        return __builtin_ctz(x);
+        return x == 0u ? detail::sizeof_bits<T> : __builtin_ctz(x);
 }
 // template<class T> constexpr int countr_one(T x) noexcept;
 template<class T> constexpr int popcount(T x) noexcept

--- a/include/seqan3/std/bit
+++ b/include/seqan3/std/bit
@@ -60,7 +60,12 @@ namespace std
 // template<class To, class From> constexpr To bit_cast(const From& from) noexcept;
 //
 // // integral powers of 2
-// template<class T> constexpr bool has_single_bit(T x) noexcept;
+template<class T> constexpr bool has_single_bit(T x) noexcept
+{
+    static_assert(std::is_unsigned_v<T>, "Input should be unsigned.");
+
+    return x > 0 && (x & (x-1)) == 0;
+}
 // template<class T> constexpr T bit_ceil(T x) noexcept;
 // template<class T> constexpr T bit_floor(T x) noexcept;
 // template<class T> constexpr T bit_width(T x) noexcept;

--- a/include/seqan3/std/bit
+++ b/include/seqan3/std/bit
@@ -92,9 +92,6 @@ constexpr auto sizeof_bits = CHAR_BIT * sizeof(type_t);
 namespace std
 {
 
-// namespace
-// {
-
 #ifndef SEQAN3_CPP_LIB_BITOPS
 // forward declare
 template<class T> constexpr int countl_zero(T x) noexcept;
@@ -148,8 +145,6 @@ template<class T> constexpr T bit_width(T x) noexcept
     return detail::sizeof_bits<T> - countl_zero(x);
 }
 
-// } // anonymous namespace
-
 } // namespace std
 
 #endif // SEQAN3_CPP_LIB_INT_POW2
@@ -158,9 +153,6 @@ template<class T> constexpr T bit_width(T x) noexcept
 
 namespace std
 {
-
-// namespace
-// {
 
 //
 // // rotating
@@ -219,8 +211,6 @@ template<class T> constexpr int popcount(T x) noexcept
     else
         return __builtin_popcount(x);
 }
-
-// } // anonymous namespace
 
 } // namespace std
 

--- a/include/seqan3/std/bit
+++ b/include/seqan3/std/bit
@@ -58,6 +58,10 @@ enum class endian
 
 namespace std::detail
 {
+/*!\brief How many bits has a type?
+ * \ingroup bit
+ * \tparam type_t The type to determine the number of bits.
+ */
 template <typename type_t>
 constexpr auto sizeof_bits = CHAR_BIT * sizeof(type_t);
 } // namespace std::detail
@@ -76,6 +80,11 @@ template<class T> constexpr int countl_zero(T x) noexcept;
 // template<class To, class From> constexpr To bit_cast(const From& from) noexcept;
 //
 // // integral powers of 2
+
+/*!\brief Checks if x is an integral power of two.
+ * \sa https://en.cppreference.com/w/cpp/numeric/has_single_bit
+ * \ingroup bit
+ */
 template<class T> constexpr bool has_single_bit(T x) noexcept
 {
     static_assert(std::is_unsigned_v<T>, "Input should be unsigned.");
@@ -83,6 +92,10 @@ template<class T> constexpr bool has_single_bit(T x) noexcept
     return x > 0 && (x & (x-1)) == 0;
 }
 
+/*!\brief Calculates the smallest integral power of two that is not smaller than x.
+ * \sa https://en.cppreference.com/w/cpp/numeric/bit_ceil
+ * \ingroup bit
+ */
 template<class T> constexpr T bit_ceil(T x) noexcept
 {
     static_assert(std::is_unsigned_v<T>, "Input should be unsigned.");
@@ -98,6 +111,12 @@ template<class T> constexpr T bit_ceil(T x) noexcept
 }
 
 // template<class T> constexpr T bit_floor(T x) noexcept;
+
+/*!\brief If x is not zero, calculates the number of bits needed to store the value x, that is,
+ *        1 + floor(log2(x)). If x is zero, returns zero.
+ * \sa https://en.cppreference.com/w/cpp/numeric/bit_width
+ * \ingroup bit
+ */
 template<class T> constexpr T bit_width(T x) noexcept
 {
     static_assert(std::is_unsigned_v<T>, "Input should be unsigned.");
@@ -119,6 +138,11 @@ namespace std
 // template<class T> [[nodiscard]] constexpr T rotr(T x, int s) noexcept;
 //
 // // counting
+
+/*!\brief Returns the number of consecutive 0 bits in the value of x, starting from the most significant bit ("left").
+ * \sa https://en.cppreference.com/w/cpp/numeric/countl_zero
+ * \ingroup bit
+ */
 template<class T> constexpr int countl_zero(T x) noexcept
 {
     static_assert(std::is_unsigned_v<T>, "Input should be unsigned.");
@@ -132,6 +156,11 @@ template<class T> constexpr int countl_zero(T x) noexcept
 }
 
 // template<class T> constexpr int countl_one(T x) noexcept;
+
+/*!\brief Returns the number of consecutive 0 bits in the value of x, starting from the least significant bit ("right").
+ * \sa https://en.cppreference.com/w/cpp/numeric/countr_zero
+ * \ingroup bit
+ */
 template<class T> constexpr int countr_zero(T x) noexcept
 {
     static_assert(std::is_unsigned_v<T>, "Input should be unsigned.");
@@ -144,6 +173,11 @@ template<class T> constexpr int countr_zero(T x) noexcept
         return x == 0u ? detail::sizeof_bits<T> : __builtin_ctz(x);
 }
 // template<class T> constexpr int countr_one(T x) noexcept;
+
+/*!\brief Returns the number of 1 bits in the value of x.
+ * \sa https://en.cppreference.com/w/cpp/numeric/popcount
+ * \ingroup bit
+ */
 template<class T> constexpr int popcount(T x) noexcept
 {
     static_assert(std::is_unsigned_v<T>, "Input should be unsigned.");

--- a/include/seqan3/std/bit
+++ b/include/seqan3/std/bit
@@ -54,16 +54,16 @@ enum class endian
 
 #endif // __cpp_lib_endian
 
-#ifndef __cpp_lib_int_pow2
-
-namespace std
-{
-
-namespace detail
+namespace std::detail
 {
 template <typename type_t>
 constexpr auto sizeof_bits = CHAR_BIT * sizeof(type_t);
 } // namespace std::detail
+
+#ifndef __cpp_lib_int_pow2
+
+namespace std
+{
 
 // forward declare
 template<class T> constexpr int countl_zero(T x) noexcept;
@@ -100,6 +100,15 @@ template<class T> constexpr T bit_width(T x) noexcept
 
     return detail::sizeof_bits<T> - countl_zero(x);
 }
+
+} // namespace std
+
+#endif // __cpp_lib_int_pow2
+
+#ifndef __cpp_lib_bitops
+
+namespace std
+{
 //
 // // rotating
 // template<class T> [[nodiscard]] constexpr T rotl(T x, int s) noexcept;
@@ -145,4 +154,4 @@ template<class T> constexpr int popcount(T x) noexcept
 
 } // namespace std
 
-#endif // __cpp_lib_int_pow2
+#endif // __cpp_lib_bitops

--- a/include/seqan3/std/bit
+++ b/include/seqan3/std/bit
@@ -20,15 +20,20 @@
 #include <climits>
 #include <type_traits>
 
-//!\brief This defines __cpp_lib_bitops for gcc version >=9.0 (in C++2a mode).
-//!       Those versions implemented std::{rotl, rotr, countl_zero, countl_one, countr_zero, countr_one, popcount}, but
-//!       did not define that feature detection macro.
+//!\brief This defines __cpp_lib_bitops.
 #ifndef SEQAN3_CPP_LIB_BITOPS
 #   if defined(__cpp_lib_bitops) && __cpp_lib_bitops >= 201907L
 #       define SEQAN3_CPP_LIB_BITOPS 1
 #   endif
 #endif
 
+/*!\brief This defines __cpp_lib_int_pow2.
+ * Note: g++-9.3 -std=c++2a on ubuntu 20.04 did `#define __cpp_lib_int_pow2 201806L`, which is an older implementation
+ * of the __cpp_lib_int_pow2 proposal.
+ *
+ * \sa http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0556r3.html (__cpp_lib_int_pow2 >= 201806L)
+ * \sa http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p1956r1.pdf (__cpp_lib_int_pow2 >= 202002L)
+ */
 #ifndef SEQAN3_CPP_LIB_INT_POW2
 #   if defined(__cpp_lib_int_pow2) && __cpp_lib_int_pow2 >= 202002L
 #       define SEQAN3_CPP_LIB_INT_POW2 1

--- a/include/seqan3/std/bit
+++ b/include/seqan3/std/bit
@@ -92,8 +92,8 @@ constexpr auto sizeof_bits = CHAR_BIT * sizeof(type_t);
 namespace std
 {
 
-namespace
-{
+// namespace
+// {
 
 #ifndef SEQAN3_CPP_LIB_BITOPS
 // forward declare
@@ -148,7 +148,7 @@ template<class T> constexpr T bit_width(T x) noexcept
     return detail::sizeof_bits<T> - countl_zero(x);
 }
 
-} // anonymous namespace
+// } // anonymous namespace
 
 } // namespace std
 
@@ -159,8 +159,8 @@ template<class T> constexpr T bit_width(T x) noexcept
 namespace std
 {
 
-namespace
-{
+// namespace
+// {
 
 //
 // // rotating
@@ -220,7 +220,7 @@ template<class T> constexpr int popcount(T x) noexcept
         return __builtin_popcount(x);
 }
 
-} // anonymous namespace
+// } // anonymous namespace
 
 } // namespace std
 

--- a/include/seqan3/utility/math.hpp
+++ b/include/seqan3/utility/math.hpp
@@ -12,9 +12,9 @@
 
 #pragma once
 
+#include <seqan3/std/bit>
 #include <cassert>
 #include <cmath>
-#include <seqan3/std/bit>
 #include <seqan3/std/concepts>
 #include <stdexcept>
 

--- a/include/seqan3/utility/math.hpp
+++ b/include/seqan3/utility/math.hpp
@@ -12,6 +12,7 @@
 
 #pragma once
 
+#include <cassert>
 #include <cmath>
 #include <seqan3/std/bit>
 #include <seqan3/std/concepts>

--- a/include/seqan3/utility/math.hpp
+++ b/include/seqan3/utility/math.hpp
@@ -13,10 +13,11 @@
 #pragma once
 
 #include <cmath>
+#include <seqan3/std/bit>
 #include <seqan3/std/concepts>
 #include <stdexcept>
 
-#include <seqan3/core/bit_manipulation.hpp>
+#include <seqan3/core/platform.hpp>
 
 namespace seqan3::detail
 {
@@ -52,7 +53,7 @@ template <std::unsigned_integral unsigned_t>
 constexpr unsigned_t floor_log2(unsigned_t const n) noexcept
 {
     assert(n > 0u); // n == 0 is undefined behaviour
-    return most_significant_bit_set(n);
+    return std::bit_width(n) - 1;
 }
 
 /*!\brief Computes the ceil of the logarithm to the base of two for unsigned integers.

--- a/include/seqan3/utility/simd/detail/builtin_simd.hpp
+++ b/include/seqan3/utility/simd/detail/builtin_simd.hpp
@@ -13,9 +13,9 @@
 
 #pragma once
 
+#include <seqan3/std/bit>
 #include <type_traits>
 
-#include <seqan3/core/bit_manipulation.hpp>
 #include <seqan3/utility/detail/integer_traits.hpp>
 #include <seqan3/utility/simd/detail/default_simd_length.hpp>
 #include <seqan3/utility/simd/simd_traits.hpp>
@@ -56,7 +56,7 @@ struct builtin_simd;
 //!\ingroup simd
 template <typename scalar_t, size_t length>
 //!\cond
-    requires (is_power_of_two(length))
+    requires (std::has_single_bit(length))
 //!\endcond
 struct builtin_simd<scalar_t, length>
 {
@@ -97,11 +97,11 @@ struct builtin_simd_traits_helper<builtin_simd_t>
     //!\brief The scalar type of builtin_simd_t
     using scalar_type = std::remove_reference_t<decltype(std::declval<builtin_simd_t>()[0])>;
     //!\brief The length of builtin_simd_t
-    static constexpr auto length = min_viable_uint_v<sizeof(builtin_simd_t) / sizeof(scalar_type)>;
+    static constexpr auto length = sizeof(builtin_simd_t) / sizeof(scalar_type);
 
     //!\brief Whether builtin_simd_t is a builtin type or not?
     //!\hideinitializer
-    static constexpr bool value = is_power_of_two(length) &&
+    static constexpr bool value = std::has_single_bit(length) &&
                                   std::is_same_v<builtin_simd_t,
                                                  transformation_trait_or_t<builtin_simd<scalar_type, length>, void>>;
 };

--- a/test/performance/core/bit_manipulation_benchmark.cpp
+++ b/test/performance/core/bit_manipulation_benchmark.cpp
@@ -43,6 +43,8 @@ static void is_power_of_two_arithmetic(benchmark::State & state) {
 }
 BENCHMARK(is_power_of_two_arithmetic);
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 static void is_power_of_two_seqan3(benchmark::State & state) {
     std::srand(0);
     size_t n = 0;
@@ -53,6 +55,7 @@ static void is_power_of_two_seqan3(benchmark::State & state) {
     }
 }
 BENCHMARK(is_power_of_two_seqan3);
+#pragma GCC diagnostic pop
 
 static void is_power_of_two_std(benchmark::State & state) {
     std::srand(0);
@@ -65,6 +68,8 @@ static void is_power_of_two_std(benchmark::State & state) {
 }
 BENCHMARK(is_power_of_two_std);
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 static void next_power_of_two_seqan3(benchmark::State & state) {
     std::srand(0);
     size_t n = 0;
@@ -75,6 +80,7 @@ static void next_power_of_two_seqan3(benchmark::State & state) {
     }
 }
 BENCHMARK(next_power_of_two_seqan3);
+#pragma GCC diagnostic pop
 
 static void next_power_of_two_std(benchmark::State & state) {
     std::srand(0);

--- a/test/performance/core/bit_manipulation_benchmark.cpp
+++ b/test/performance/core/bit_manipulation_benchmark.cpp
@@ -54,6 +54,17 @@ static void is_power_of_two_seqan3(benchmark::State & state) {
 }
 BENCHMARK(is_power_of_two_seqan3);
 
+static void is_power_of_two_std(benchmark::State & state) {
+    std::srand(0);
+    size_t n = 0;
+    for (auto _ : state)
+    {
+        n = std::rand();
+        benchmark::DoNotOptimize(std::has_single_bit(n));
+    }
+}
+BENCHMARK(is_power_of_two_std);
+
 static void next_power_of_two_seqan3(benchmark::State & state) {
     std::srand(0);
     size_t n = 0;
@@ -64,5 +75,16 @@ static void next_power_of_two_seqan3(benchmark::State & state) {
     }
 }
 BENCHMARK(next_power_of_two_seqan3);
+
+static void next_power_of_two_std(benchmark::State & state) {
+    std::srand(0);
+    size_t n = 0;
+    for (auto _ : state)
+    {
+        n = std::rand();
+        benchmark::DoNotOptimize(std::bit_ceil(n));
+    }
+}
+BENCHMARK(next_power_of_two_std);
 
 BENCHMARK_MAIN();

--- a/test/snippet/core/detail/count_leading_zeros.cpp
+++ b/test/snippet/core/detail/count_leading_zeros.cpp
@@ -1,4 +1,4 @@
-#include <seqan3/core/bit_manipulation.hpp>
+#include <seqan3/std/bit>
 #include <seqan3/core/debug_stream.hpp>
 
 int main()
@@ -8,10 +8,10 @@ int main()
     uint32_t t2 = 0b0000'0000'0000'0000'1000'0000'0000'0000;
     uint64_t t3 = 0b0000'0000'0000'0000'0000'0000'0000'0000'0000'0000'0000'0000'0000'0000'0000'0001;
 
-    seqan3::debug_stream << seqan3::detail::count_leading_zeros(t0) << '\n'; // 4
-    seqan3::debug_stream << seqan3::detail::count_leading_zeros(t1) << '\n'; // 1
-    seqan3::debug_stream << seqan3::detail::count_leading_zeros(t2) << '\n'; // 16
-    seqan3::debug_stream << seqan3::detail::count_leading_zeros(t3) << '\n'; // 63
+    seqan3::debug_stream << std::countl_zero(t0) << '\n'; // 4
+    seqan3::debug_stream << std::countl_zero(t1) << '\n'; // 1
+    seqan3::debug_stream << std::countl_zero(t2) << '\n'; // 16
+    seqan3::debug_stream << std::countl_zero(t3) << '\n'; // 63
 
     return 0;
 }

--- a/test/snippet/core/detail/count_trailing_zeros.cpp
+++ b/test/snippet/core/detail/count_trailing_zeros.cpp
@@ -1,4 +1,4 @@
-#include <seqan3/core/bit_manipulation.hpp>
+#include <seqan3/std/bit>
 #include <seqan3/core/debug_stream.hpp>
 
 int main()
@@ -8,10 +8,10 @@ int main()
     uint32_t t2 = 0b0000'0000'0000'0000'1000'0000'0000'0000;
     uint64_t t3 = 0b0000'0000'0000'0000'0010'0000'0000'0000'0000'0000'0000'0000'0000'0000'0000'0000;
 
-    seqan3::debug_stream << seqan3::detail::count_trailing_zeros(t0) << '\n'; // 0
-    seqan3::debug_stream << seqan3::detail::count_trailing_zeros(t1) << '\n'; // 3
-    seqan3::debug_stream << seqan3::detail::count_trailing_zeros(t2) << '\n'; // 15
-    seqan3::debug_stream << seqan3::detail::count_trailing_zeros(t3) << '\n'; // 45
+    seqan3::debug_stream << std::countr_zero(t0) << '\n'; // 0
+    seqan3::debug_stream << std::countr_zero(t1) << '\n'; // 3
+    seqan3::debug_stream << std::countr_zero(t2) << '\n'; // 15
+    seqan3::debug_stream << std::countr_zero(t3) << '\n'; // 45
 
     return 0;
 }

--- a/test/snippet/core/detail/most_significant_bit_set.cpp
+++ b/test/snippet/core/detail/most_significant_bit_set.cpp
@@ -1,4 +1,4 @@
-#include <seqan3/core/bit_manipulation.hpp>
+#include <seqan3/std/bit>
 #include <seqan3/core/debug_stream.hpp>
 
 int main()
@@ -8,10 +8,10 @@ int main()
     uint32_t t2 = 0b0000'0000'0000'0000'0000'0000'0000'0001;
     uint64_t t3 = 0b0100'0000'0000'0000'0000'0000'0000'0000'0000'0000'0000'0000'0000'0000'0000'0000;
 
-    seqan3::debug_stream << seqan3::detail::most_significant_bit_set(t0) << '\n'; // 3
-    seqan3::debug_stream << seqan3::detail::most_significant_bit_set(t1) << '\n'; // 14
-    seqan3::debug_stream << seqan3::detail::most_significant_bit_set(t2) << '\n'; // 0
-    seqan3::debug_stream << seqan3::detail::most_significant_bit_set(t3) << '\n'; // 62
+    seqan3::debug_stream << std::bit_width(t0) << '\n'; // 4
+    seqan3::debug_stream << std::bit_width(t1) << '\n'; // 15
+    seqan3::debug_stream << std::bit_width(t2) << '\n'; // 1
+    seqan3::debug_stream << std::bit_width(t3) << '\n'; // 63
 
     return 0;
 }

--- a/test/snippet/core/detail/popcount.cpp
+++ b/test/snippet/core/detail/popcount.cpp
@@ -1,4 +1,4 @@
-#include <seqan3/core/bit_manipulation.hpp>
+#include <seqan3/std/bit>
 #include <seqan3/core/debug_stream.hpp>
 
 int main()
@@ -8,10 +8,10 @@ int main()
     uint32_t t2 = 0b0000'0000'0000'0000'0000'0000'0000'0000;
     uint64_t t3 = 0b1000'0000'1111'0000'0000'0000'0000'0110'0000'0000'0000'0000'1110'0000'0000'0001;
 
-    seqan3::debug_stream << seqan3::detail::popcount(t0) << '\n'; // 4
-    seqan3::debug_stream << seqan3::detail::popcount(t1) << '\n'; // 7
-    seqan3::debug_stream << seqan3::detail::popcount(t2) << '\n'; // 0
-    seqan3::debug_stream << seqan3::detail::popcount(t3) << '\n'; // 11
+    seqan3::debug_stream << std::popcount(t0) << '\n'; // 4
+    seqan3::debug_stream << std::popcount(t1) << '\n'; // 7
+    seqan3::debug_stream << std::popcount(t2) << '\n'; // 0
+    seqan3::debug_stream << std::popcount(t3) << '\n'; // 11
 
     return 0;
 }

--- a/test/unit/core/bit_manipulation_test.cpp
+++ b/test/unit/core/bit_manipulation_test.cpp
@@ -118,12 +118,12 @@ TYPED_TEST(unsigned_operations, most_significant_bit_set)
 TYPED_TEST(unsigned_operations, count_leading_zeros)
 {
     using unsigned_t = TypeParam;
-    constexpr size_t t1 = seqan3::detail::count_leading_zeros<unsigned_t>(0b0001);
-    constexpr size_t t2 = seqan3::detail::count_leading_zeros<unsigned_t>(0b0101);
-    constexpr size_t t3 = seqan3::detail::count_leading_zeros<unsigned_t>(0b0010);
-    constexpr size_t t4 = seqan3::detail::count_leading_zeros<unsigned_t>(0b0110);
-    constexpr size_t t5 = seqan3::detail::count_leading_zeros<unsigned_t>(0b0100);
-    constexpr size_t t6 = seqan3::detail::count_leading_zeros<unsigned_t>(0b10100000);
+    constexpr size_t t1 = std::countl_zero<unsigned_t>(0b0001u);
+    constexpr size_t t2 = std::countl_zero<unsigned_t>(0b0101u);
+    constexpr size_t t3 = std::countl_zero<unsigned_t>(0b0010u);
+    constexpr size_t t4 = std::countl_zero<unsigned_t>(0b0110u);
+    constexpr size_t t5 = std::countl_zero<unsigned_t>(0b0100u);
+    constexpr size_t t6 = std::countl_zero<unsigned_t>(0b10100000u);
     EXPECT_EQ(t1, seqan3::detail::sizeof_bits<unsigned_t> - 1u);
     EXPECT_EQ(t2, seqan3::detail::sizeof_bits<unsigned_t> - 3u);
     EXPECT_EQ(t3, seqan3::detail::sizeof_bits<unsigned_t> - 2u);
@@ -140,7 +140,7 @@ TYPED_TEST(unsigned_operations, count_leading_zeros)
             EXPECT_EQ(seqan3::detail::sizeof_bits<unsigned_t> - sdsl::bits::hi(n) - 1, n) << "[SDSL] n " << n
                                                                                           << " should have " << cnt
                                                                                           << " leading zeros.";
-            EXPECT_EQ(seqan3::detail::count_leading_zeros(n), cnt) << "n " << n << " should have " << cnt
+            EXPECT_EQ(std::countl_zero(n), cnt) << "n " << n << " should have " << cnt
                                                                    << " leading zeros.";
             EXPECT_EQ(std::countl_zero(n), cnt);
         }

--- a/test/unit/core/bit_manipulation_test.cpp
+++ b/test/unit/core/bit_manipulation_test.cpp
@@ -87,18 +87,18 @@ TYPED_TEST_SUITE(unsigned_operations, unsigned_types, );
 TYPED_TEST(unsigned_operations, most_significant_bit_set)
 {
     using unsigned_t = TypeParam;
-    constexpr size_t zero  = seqan3::detail::most_significant_bit_set<unsigned_t>(0b0001);
-    constexpr size_t one1  = seqan3::detail::most_significant_bit_set<unsigned_t>(0b0010);
-    constexpr size_t one2  = seqan3::detail::most_significant_bit_set<unsigned_t>(0b0011);
-    constexpr size_t two1  = seqan3::detail::most_significant_bit_set<unsigned_t>(0b0101);
-    constexpr size_t two2  = seqan3::detail::most_significant_bit_set<unsigned_t>(0b0111);
-    constexpr size_t seven = seqan3::detail::most_significant_bit_set<unsigned_t>(0b10010010);
-    EXPECT_EQ(zero, 0u);
-    EXPECT_EQ(one1, 1u);
-    EXPECT_EQ(one2, 1u);
+    constexpr size_t one = std::bit_width<unsigned_t>(0b0001);
+    constexpr size_t two1 = std::bit_width<unsigned_t>(0b0010);
+    constexpr size_t two2 = std::bit_width<unsigned_t>(0b0011);
+    constexpr size_t three1 = std::bit_width<unsigned_t>(0b0101);
+    constexpr size_t three2 = std::bit_width<unsigned_t>(0b0111);
+    constexpr size_t eight = std::bit_width<unsigned_t>(0b10010010);
+    EXPECT_EQ(one, 1u);
     EXPECT_EQ(two1, 2u);
     EXPECT_EQ(two2, 2u);
-    EXPECT_EQ(seven, 7u);
+    EXPECT_EQ(three1, 3u);
+    EXPECT_EQ(three2, 3u);
+    EXPECT_EQ(eight, 8u);
 
     for (uint8_t position = 0; position < seqan3::detail::sizeof_bits<unsigned_t>; ++position)
     {
@@ -108,9 +108,8 @@ TYPED_TEST(unsigned_operations, most_significant_bit_set)
         {
             EXPECT_EQ(sdsl::bits::hi(n), position) << "[SDSL] The position of the msb of " << n << " should be "
                                                    << position;
-            EXPECT_EQ(seqan3::detail::most_significant_bit_set(n), position) << "The position of the msb of " << n
-                                                                             << " should be " << position;
-            EXPECT_EQ(std::bit_width(n), position + 1u);
+            EXPECT_EQ(std::bit_width(n), position + 1u) << "The position of the msb of " << n << " should be "
+                                                        << position;
         }
     }
 }

--- a/test/unit/core/bit_manipulation_test.cpp
+++ b/test/unit/core/bit_manipulation_test.cpp
@@ -195,18 +195,18 @@ unsigned_t permute_bits(unsigned_t v)
 TYPED_TEST(unsigned_operations, popcount)
 {
     using unsigned_t = TypeParam;
-    constexpr size_t zero  = std::popcount<unsigned_t>(0b0000);
-    constexpr size_t one   = std::popcount<unsigned_t>(0b0100);
-    constexpr size_t two   = std::popcount<unsigned_t>(0b1100);
+    constexpr size_t zero = std::popcount<unsigned_t>(0b0000);
+    constexpr size_t one = std::popcount<unsigned_t>(0b0100);
+    constexpr size_t two = std::popcount<unsigned_t>(0b1100);
     constexpr size_t three = std::popcount<unsigned_t>(0b1110);
-    constexpr size_t four  = std::popcount<unsigned_t>(0b1111);
-    constexpr size_t five  = std::popcount<unsigned_t>(0b10011011);
-    EXPECT_EQ(zero,  0u);
-    EXPECT_EQ(one,   1u);
-    EXPECT_EQ(two,   2u);
+    constexpr size_t four = std::popcount<unsigned_t>(0b1111);
+    constexpr size_t five = std::popcount<unsigned_t>(0b10011011);
+    EXPECT_EQ(zero, 0u);
+    EXPECT_EQ(one, 1u);
+    EXPECT_EQ(two, 2u);
     EXPECT_EQ(three, 3u);
-    EXPECT_EQ(four,  4u);
-    EXPECT_EQ(five,  5u);
+    EXPECT_EQ(four, 4u);
+    EXPECT_EQ(five, 5u);
 
     for (uint8_t position = 0; position < seqan3::detail::sizeof_bits<unsigned_t>; ++position)
     {

--- a/test/unit/core/bit_manipulation_test.cpp
+++ b/test/unit/core/bit_manipulation_test.cpp
@@ -150,12 +150,12 @@ TYPED_TEST(unsigned_operations, count_leading_zeros)
 TYPED_TEST(unsigned_operations, count_trailing_zeros)
 {
     using unsigned_t = TypeParam;
-    constexpr size_t zero  = seqan3::detail::count_trailing_zeros<unsigned_t>(0b0001);
-    constexpr size_t zero2 = seqan3::detail::count_trailing_zeros<unsigned_t>(0b0101);
-    constexpr size_t one1  = seqan3::detail::count_trailing_zeros<unsigned_t>(0b0010);
-    constexpr size_t one2  = seqan3::detail::count_trailing_zeros<unsigned_t>(0b0110);
-    constexpr size_t two   = seqan3::detail::count_trailing_zeros<unsigned_t>(0b0100);
-    constexpr size_t five  = seqan3::detail::count_trailing_zeros<unsigned_t>(0b10100000);
+    constexpr size_t zero  = std::countr_zero<unsigned_t>(0b0001);
+    constexpr size_t zero2 = std::countr_zero<unsigned_t>(0b0101);
+    constexpr size_t one1  = std::countr_zero<unsigned_t>(0b0010);
+    constexpr size_t one2  = std::countr_zero<unsigned_t>(0b0110);
+    constexpr size_t two   = std::countr_zero<unsigned_t>(0b0100);
+    constexpr size_t five  = std::countr_zero<unsigned_t>(0b10100000);
     EXPECT_EQ(zero,  0u);
     EXPECT_EQ(zero2, 0u);
     EXPECT_EQ(one1,  1u);
@@ -170,9 +170,7 @@ TYPED_TEST(unsigned_operations, count_trailing_zeros)
         for (unsigned_t n = start, k = 0u; n < end && k < max_iterations; ++n, ++k)
         {
             EXPECT_EQ(sdsl::bits::lo(n), cnt) << "[SDSL] n " << n << " should have " << cnt << " trailing zeros.";
-            EXPECT_EQ(seqan3::detail::count_trailing_zeros(n), cnt) << "n " << n << " should have " << cnt
-                                                                    << " trailing zeros.";
-            EXPECT_EQ(std::countr_zero(n), cnt);
+            EXPECT_EQ(std::countr_zero(n), cnt) << "n " << n << " should have " << cnt << " trailing zeros.";
         }
     }
 }
@@ -185,7 +183,7 @@ unsigned_t permute_bits(unsigned_t v)
         return v;
 
     unsigned_t t = v | (v - 1);
-    unsigned_t w = (t + 1) | (((~t & -~t) - 1) >> (seqan3::detail::count_trailing_zeros(v) + 1));
+    unsigned_t w = (t + 1) | (((~t & -~t) - 1) >> (std::countr_zero(v) + 1));
     return w;
 }
 

--- a/test/unit/core/bit_manipulation_test.cpp
+++ b/test/unit/core/bit_manipulation_test.cpp
@@ -5,13 +5,10 @@
 // shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 // -----------------------------------------------------------------------------------------------------
 
+#include <seqan3/std/bit>
 #include <cmath>
 #include <type_traits>
 #include <version>
-
-#ifdef __cpp_lib_int_pow2
-#include <bit>
-#endif
 
 #include <gtest/gtest.h>
 
@@ -45,17 +42,13 @@ TEST(bit_manipulation, is_power_of_two)
     for (size_t power_of_two = 1; power_of_two <= (size_t{1u} << 31); power_of_two <<= 1)
     {
         EXPECT_TRUE(seqan3::detail::is_power_of_two(power_of_two));
-#ifdef __cpp_lib_int_pow2
         EXPECT_TRUE(std::has_single_bit(power_of_two));
-#endif // __cpp_lib_int_pow2
 
         size_t next_power = (power_of_two << 1);
         for (size_t i = power_of_two + 1, k = 0; i < next_power && k < max_iterations; ++i, ++k)
         {
             EXPECT_FALSE(seqan3::detail::is_power_of_two(i)) << i << " should not be a power of two.";
-#ifdef __cpp_lib_int_pow2
             EXPECT_FALSE(std::has_single_bit(i));
-#endif // __cpp_lib_int_pow2
         }
     }
 }

--- a/test/unit/core/bit_manipulation_test.cpp
+++ b/test/unit/core/bit_manipulation_test.cpp
@@ -228,9 +228,7 @@ TYPED_TEST(unsigned_operations, popcount)
             EXPECT_EQ(seqan3::detail::popcount(n),
                       sizeof_bits_of_unsigned_t - position) << "The pocount of " << n << " should be "
                                                             << sizeof_bits_of_unsigned_t - position;
-#ifdef __cpp_lib_int_pow2
             EXPECT_EQ(std::popcount(n), sizeof_bits_of_unsigned_t - position);
-#endif // __cpp_lib_int_pow2
         }
     }
 }

--- a/test/unit/core/bit_manipulation_test.cpp
+++ b/test/unit/core/bit_manipulation_test.cpp
@@ -55,10 +55,10 @@ TEST(bit_manipulation, is_power_of_two)
 
 TEST(bit_manipulation, next_power_of_two)
 {
-    constexpr size_t next_power_of_two0 = seqan3::detail::next_power_of_two(0);
-    constexpr size_t next_power_of_two1 = seqan3::detail::next_power_of_two(1);
-    constexpr size_t next_power_of_two2 = seqan3::detail::next_power_of_two(2);
-    constexpr size_t next_power_of_two3 = seqan3::detail::next_power_of_two(3);
+    constexpr size_t next_power_of_two0 = std::bit_ceil(0u);
+    constexpr size_t next_power_of_two1 = std::bit_ceil(1u);
+    constexpr size_t next_power_of_two2 = std::bit_ceil(2u);
+    constexpr size_t next_power_of_two3 = std::bit_ceil(3u);
     EXPECT_EQ(next_power_of_two0, 1u);
     EXPECT_EQ(next_power_of_two1, 1u);
     EXPECT_EQ(next_power_of_two2, 2u);
@@ -66,15 +66,12 @@ TEST(bit_manipulation, next_power_of_two)
 
     for (size_t power_of_two = 1; power_of_two <= (size_t{1u} << 31); power_of_two <<= 1)
     {
-        EXPECT_EQ(seqan3::detail::next_power_of_two(power_of_two), power_of_two);
         EXPECT_EQ(std::bit_ceil(power_of_two), power_of_two);
 
         size_t next_power = (power_of_two << 1);
         for (size_t i = power_of_two + 1, k = 0; i < next_power && k < max_iterations; ++i, ++k)
         {
-            EXPECT_EQ(seqan3::detail::next_power_of_two(i), next_power) << "The next power of two of " << i
-                                                                        << " should be " << next_power;
-            EXPECT_EQ(std::bit_ceil(i), next_power);
+            EXPECT_EQ(std::bit_ceil(i), next_power) << "The next power of two of " << i << " should be " << next_power;
         }
     }
 }

--- a/test/unit/core/bit_manipulation_test.cpp
+++ b/test/unit/core/bit_manipulation_test.cpp
@@ -32,10 +32,10 @@ TEST(bit_manipulation, sizeof_bits)
 
 TEST(bit_manipulation, is_power_of_two)
 {
-    constexpr bool is_power_of_two0 = seqan3::detail::is_power_of_two(0);
-    constexpr bool is_power_of_two1 = seqan3::detail::is_power_of_two(1);
-    constexpr bool is_power_of_two2 = seqan3::detail::is_power_of_two(2);
-    constexpr bool is_power_of_two3 = seqan3::detail::is_power_of_two(3);
+    constexpr bool is_power_of_two0 = std::has_single_bit(0u);
+    constexpr bool is_power_of_two1 = std::has_single_bit(1u);
+    constexpr bool is_power_of_two2 = std::has_single_bit(2u);
+    constexpr bool is_power_of_two3 = std::has_single_bit(3u);
     EXPECT_FALSE(is_power_of_two0);
     EXPECT_TRUE(is_power_of_two1);
     EXPECT_TRUE(is_power_of_two2);
@@ -43,14 +43,12 @@ TEST(bit_manipulation, is_power_of_two)
 
     for (size_t power_of_two = 1; power_of_two <= (size_t{1u} << 31); power_of_two <<= 1)
     {
-        EXPECT_TRUE(seqan3::detail::is_power_of_two(power_of_two));
         EXPECT_TRUE(std::has_single_bit(power_of_two));
 
         size_t next_power = (power_of_two << 1);
         for (size_t i = power_of_two + 1, k = 0; i < next_power && k < max_iterations; ++i, ++k)
         {
-            EXPECT_FALSE(seqan3::detail::is_power_of_two(i)) << i << " should not be a power of two.";
-            EXPECT_FALSE(std::has_single_bit(i));
+            EXPECT_FALSE(std::has_single_bit(i)) << i << " should not be a power of two.";
         }
     }
 }

--- a/test/unit/core/bit_manipulation_test.cpp
+++ b/test/unit/core/bit_manipulation_test.cpp
@@ -154,19 +154,19 @@ TYPED_TEST(unsigned_operations, count_trailing_zeros)
 {
     using unsigned_t = TypeParam;
     constexpr size_t sizeof_bits = std::countr_zero<unsigned_t>(0b0000);
-    constexpr size_t zero  = std::countr_zero<unsigned_t>(0b0001);
+    constexpr size_t zero = std::countr_zero<unsigned_t>(0b0001);
     constexpr size_t zero2 = std::countr_zero<unsigned_t>(0b0101);
-    constexpr size_t one1  = std::countr_zero<unsigned_t>(0b0010);
-    constexpr size_t one2  = std::countr_zero<unsigned_t>(0b0110);
-    constexpr size_t two   = std::countr_zero<unsigned_t>(0b0100);
-    constexpr size_t five  = std::countr_zero<unsigned_t>(0b10100000);
+    constexpr size_t one1 = std::countr_zero<unsigned_t>(0b0010);
+    constexpr size_t one2 = std::countr_zero<unsigned_t>(0b0110);
+    constexpr size_t two = std::countr_zero<unsigned_t>(0b0100);
+    constexpr size_t five = std::countr_zero<unsigned_t>(0b10100000);
     EXPECT_EQ(sizeof_bits, seqan3::detail::sizeof_bits<unsigned_t>);
-    EXPECT_EQ(zero,  0u);
+    EXPECT_EQ(zero, 0u);
     EXPECT_EQ(zero2, 0u);
-    EXPECT_EQ(one1,  1u);
-    EXPECT_EQ(one2,  1u);
-    EXPECT_EQ(two,   2u);
-    EXPECT_EQ(five,  5u);
+    EXPECT_EQ(one1, 1u);
+    EXPECT_EQ(one2, 1u);
+    EXPECT_EQ(two, 2u);
+    EXPECT_EQ(five, 5u);
 
     for (uint8_t cnt = 0; cnt < seqan3::detail::sizeof_bits<unsigned_t>; ++cnt)
     {

--- a/test/unit/core/bit_manipulation_test.cpp
+++ b/test/unit/core/bit_manipulation_test.cpp
@@ -67,18 +67,14 @@ TEST(bit_manipulation, next_power_of_two)
     for (size_t power_of_two = 1; power_of_two <= (size_t{1u} << 31); power_of_two <<= 1)
     {
         EXPECT_EQ(seqan3::detail::next_power_of_two(power_of_two), power_of_two);
-#ifdef __cpp_lib_int_pow2
         EXPECT_EQ(std::bit_ceil(power_of_two), power_of_two);
-#endif // __cpp_lib_int_pow2
 
         size_t next_power = (power_of_two << 1);
         for (size_t i = power_of_two + 1, k = 0; i < next_power && k < max_iterations; ++i, ++k)
         {
             EXPECT_EQ(seqan3::detail::next_power_of_two(i), next_power) << "The next power of two of " << i
                                                                         << " should be " << next_power;
-#ifdef __cpp_lib_int_pow2
             EXPECT_EQ(std::bit_ceil(i), next_power);
-#endif // __cpp_lib_int_pow2
         }
     }
 }

--- a/test/unit/core/bit_manipulation_test.cpp
+++ b/test/unit/core/bit_manipulation_test.cpp
@@ -5,7 +5,13 @@
 // shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 // -----------------------------------------------------------------------------------------------------
 
+#include <cmath>
 #include <type_traits>
+#include <version>
+
+#ifdef __cpp_lib_int_pow2
+#include <bit>
+#endif
 
 #include <gtest/gtest.h>
 
@@ -39,11 +45,17 @@ TEST(bit_manipulation, is_power_of_two)
     for (size_t power_of_two = 1; power_of_two <= (size_t{1u} << 31); power_of_two <<= 1)
     {
         EXPECT_TRUE(seqan3::detail::is_power_of_two(power_of_two));
+#ifdef __cpp_lib_int_pow2
+        EXPECT_TRUE(std::has_single_bit(power_of_two));
+#endif // __cpp_lib_int_pow2
 
         size_t next_power = (power_of_two << 1);
         for (size_t i = power_of_two + 1, k = 0; i < next_power && k < max_iterations; ++i, ++k)
         {
             EXPECT_FALSE(seqan3::detail::is_power_of_two(i)) << i << " should not be a power of two.";
+#ifdef __cpp_lib_int_pow2
+            EXPECT_FALSE(std::has_single_bit(i));
+#endif // __cpp_lib_int_pow2
         }
     }
 }
@@ -62,12 +74,18 @@ TEST(bit_manipulation, next_power_of_two)
     for (size_t power_of_two = 1; power_of_two <= (size_t{1u} << 31); power_of_two <<= 1)
     {
         EXPECT_EQ(seqan3::detail::next_power_of_two(power_of_two), power_of_two);
+#ifdef __cpp_lib_int_pow2
+        EXPECT_EQ(std::bit_ceil(power_of_two), power_of_two);
+#endif // __cpp_lib_int_pow2
 
         size_t next_power = (power_of_two << 1);
         for (size_t i = power_of_two + 1, k = 0; i < next_power && k < max_iterations; ++i, ++k)
         {
             EXPECT_EQ(seqan3::detail::next_power_of_two(i), next_power) << "The next power of two of " << i
                                                                         << " should be " << next_power;
+#ifdef __cpp_lib_int_pow2
+            EXPECT_EQ(std::bit_ceil(i), next_power);
+#endif // __cpp_lib_int_pow2
         }
     }
 }
@@ -106,6 +124,9 @@ TYPED_TEST(unsigned_operations, most_significant_bit_set)
                                                    << position;
             EXPECT_EQ(seqan3::detail::most_significant_bit_set(n), position) << "The position of the msb of " << n
                                                                              << " should be " << position;
+#ifdef __cpp_lib_int_pow2
+            EXPECT_EQ(std::bit_width(n), position + 1u);
+#endif // __cpp_lib_int_pow2
         }
     }
 }
@@ -137,6 +158,9 @@ TYPED_TEST(unsigned_operations, count_leading_zeros)
                                                                                           << " leading zeros.";
             EXPECT_EQ(seqan3::detail::count_leading_zeros(n), cnt) << "n " << n << " should have " << cnt
                                                                    << " leading zeros.";
+#ifdef __cpp_lib_int_pow2
+            EXPECT_EQ(std::countl_zero(n), cnt);
+#endif // __cpp_lib_int_pow2
         }
     }
 }
@@ -166,6 +190,9 @@ TYPED_TEST(unsigned_operations, count_trailing_zeros)
             EXPECT_EQ(sdsl::bits::lo(n), cnt) << "[SDSL] n " << n << " should have " << cnt << " trailing zeros.";
             EXPECT_EQ(seqan3::detail::count_trailing_zeros(n), cnt) << "n " << n << " should have " << cnt
                                                                     << " trailing zeros.";
+#ifdef __cpp_lib_int_pow2
+            EXPECT_EQ(std::countr_zero(n), cnt);
+#endif // __cpp_lib_int_pow2
         }
     }
 }
@@ -216,6 +243,9 @@ TYPED_TEST(unsigned_operations, popcount)
             EXPECT_EQ(seqan3::detail::popcount(n),
                       sizeof_bits_of_unsigned_t - position) << "The pocount of " << n << " should be "
                                                             << sizeof_bits_of_unsigned_t - position;
+#ifdef __cpp_lib_int_pow2
+            EXPECT_EQ(std::popcount(n), sizeof_bits_of_unsigned_t - position);
+#endif // __cpp_lib_int_pow2
         }
     }
 }

--- a/test/unit/core/bit_manipulation_test.cpp
+++ b/test/unit/core/bit_manipulation_test.cpp
@@ -177,9 +177,7 @@ TYPED_TEST(unsigned_operations, count_trailing_zeros)
             EXPECT_EQ(sdsl::bits::lo(n), cnt) << "[SDSL] n " << n << " should have " << cnt << " trailing zeros.";
             EXPECT_EQ(seqan3::detail::count_trailing_zeros(n), cnt) << "n " << n << " should have " << cnt
                                                                     << " trailing zeros.";
-#ifdef __cpp_lib_int_pow2
             EXPECT_EQ(std::countr_zero(n), cnt);
-#endif // __cpp_lib_int_pow2
         }
     }
 }

--- a/test/unit/core/bit_manipulation_test.cpp
+++ b/test/unit/core/bit_manipulation_test.cpp
@@ -192,12 +192,12 @@ unsigned_t permute_bits(unsigned_t v)
 TYPED_TEST(unsigned_operations, popcount)
 {
     using unsigned_t = TypeParam;
-    constexpr size_t zero  = seqan3::detail::popcount<unsigned_t>(0b0000);
-    constexpr size_t one   = seqan3::detail::popcount<unsigned_t>(0b0100);
-    constexpr size_t two   = seqan3::detail::popcount<unsigned_t>(0b1100);
-    constexpr size_t three = seqan3::detail::popcount<unsigned_t>(0b1110);
-    constexpr size_t four  = seqan3::detail::popcount<unsigned_t>(0b1111);
-    constexpr size_t five  = seqan3::detail::popcount<unsigned_t>(0b10011011);
+    constexpr size_t zero  = std::popcount<unsigned_t>(0b0000);
+    constexpr size_t one   = std::popcount<unsigned_t>(0b0100);
+    constexpr size_t two   = std::popcount<unsigned_t>(0b1100);
+    constexpr size_t three = std::popcount<unsigned_t>(0b1110);
+    constexpr size_t four  = std::popcount<unsigned_t>(0b1111);
+    constexpr size_t five  = std::popcount<unsigned_t>(0b10011011);
     EXPECT_EQ(zero,  0u);
     EXPECT_EQ(one,   1u);
     EXPECT_EQ(two,   2u);
@@ -210,7 +210,7 @@ TYPED_TEST(unsigned_operations, popcount)
         unsigned_t start = std::numeric_limits<unsigned_t>::max() >> position;
         auto sizeof_bits_of_unsigned_t = seqan3::detail::sizeof_bits<unsigned_t>;
 
-        EXPECT_EQ(seqan3::detail::popcount(start),
+        EXPECT_EQ(std::popcount(start),
                   sizeof_bits_of_unsigned_t - position) << "The pocount of " << start << " should be "
                                                         << sizeof_bits_of_unsigned_t - position;
         for (unsigned_t n = permute_bits(start), k = 0u;
@@ -220,7 +220,7 @@ TYPED_TEST(unsigned_operations, popcount)
             EXPECT_EQ(static_cast<uint8_t>(sdsl::bits::cnt(n)),
                       sizeof_bits_of_unsigned_t - position) << "[SDSL] The pocount of " << n << " should be "
                                                             << sizeof_bits_of_unsigned_t - position;
-            EXPECT_EQ(seqan3::detail::popcount(n),
+            EXPECT_EQ(std::popcount(n),
                       sizeof_bits_of_unsigned_t - position) << "The pocount of " << n << " should be "
                                                             << sizeof_bits_of_unsigned_t - position;
             EXPECT_EQ(std::popcount(n), sizeof_bits_of_unsigned_t - position);

--- a/test/unit/core/bit_manipulation_test.cpp
+++ b/test/unit/core/bit_manipulation_test.cpp
@@ -12,6 +12,8 @@
 
 #include <gtest/gtest.h>
 
+#include <sdsl/bits.hpp>
+
 #include <seqan3/core/bit_manipulation.hpp>
 
 static constexpr size_t max_iterations = 1 << 15;

--- a/test/unit/core/bit_manipulation_test.cpp
+++ b/test/unit/core/bit_manipulation_test.cpp
@@ -113,9 +113,7 @@ TYPED_TEST(unsigned_operations, most_significant_bit_set)
                                                    << position;
             EXPECT_EQ(seqan3::detail::most_significant_bit_set(n), position) << "The position of the msb of " << n
                                                                              << " should be " << position;
-#ifdef __cpp_lib_int_pow2
             EXPECT_EQ(std::bit_width(n), position + 1u);
-#endif // __cpp_lib_int_pow2
         }
     }
 }

--- a/test/unit/core/bit_manipulation_test.cpp
+++ b/test/unit/core/bit_manipulation_test.cpp
@@ -147,9 +147,7 @@ TYPED_TEST(unsigned_operations, count_leading_zeros)
                                                                                           << " leading zeros.";
             EXPECT_EQ(seqan3::detail::count_leading_zeros(n), cnt) << "n " << n << " should have " << cnt
                                                                    << " leading zeros.";
-#ifdef __cpp_lib_int_pow2
             EXPECT_EQ(std::countl_zero(n), cnt);
-#endif // __cpp_lib_int_pow2
         }
     }
 }

--- a/test/unit/core/bit_manipulation_test.cpp
+++ b/test/unit/core/bit_manipulation_test.cpp
@@ -8,7 +8,6 @@
 #include <seqan3/std/bit>
 #include <cmath>
 #include <type_traits>
-#include <version>
 
 #include <gtest/gtest.h>
 

--- a/test/unit/core/bit_manipulation_test.cpp
+++ b/test/unit/core/bit_manipulation_test.cpp
@@ -87,12 +87,14 @@ TYPED_TEST_SUITE(unsigned_operations, unsigned_types, );
 TYPED_TEST(unsigned_operations, most_significant_bit_set)
 {
     using unsigned_t = TypeParam;
+    constexpr size_t zero = std::bit_width<unsigned_t>(0b0000);
     constexpr size_t one = std::bit_width<unsigned_t>(0b0001);
     constexpr size_t two1 = std::bit_width<unsigned_t>(0b0010);
     constexpr size_t two2 = std::bit_width<unsigned_t>(0b0011);
     constexpr size_t three1 = std::bit_width<unsigned_t>(0b0101);
     constexpr size_t three2 = std::bit_width<unsigned_t>(0b0111);
     constexpr size_t eight = std::bit_width<unsigned_t>(0b10010010);
+    EXPECT_EQ(zero, 0u);
     EXPECT_EQ(one, 1u);
     EXPECT_EQ(two1, 2u);
     EXPECT_EQ(two2, 2u);
@@ -117,12 +119,14 @@ TYPED_TEST(unsigned_operations, most_significant_bit_set)
 TYPED_TEST(unsigned_operations, count_leading_zeros)
 {
     using unsigned_t = TypeParam;
+    constexpr size_t t0 = std::countl_zero<unsigned_t>(0b0000u);
     constexpr size_t t1 = std::countl_zero<unsigned_t>(0b0001u);
     constexpr size_t t2 = std::countl_zero<unsigned_t>(0b0101u);
     constexpr size_t t3 = std::countl_zero<unsigned_t>(0b0010u);
     constexpr size_t t4 = std::countl_zero<unsigned_t>(0b0110u);
     constexpr size_t t5 = std::countl_zero<unsigned_t>(0b0100u);
     constexpr size_t t6 = std::countl_zero<unsigned_t>(0b10100000u);
+    EXPECT_EQ(t0, seqan3::detail::sizeof_bits<unsigned_t>);
     EXPECT_EQ(t1, seqan3::detail::sizeof_bits<unsigned_t> - 1u);
     EXPECT_EQ(t2, seqan3::detail::sizeof_bits<unsigned_t> - 3u);
     EXPECT_EQ(t3, seqan3::detail::sizeof_bits<unsigned_t> - 2u);
@@ -149,12 +153,14 @@ TYPED_TEST(unsigned_operations, count_leading_zeros)
 TYPED_TEST(unsigned_operations, count_trailing_zeros)
 {
     using unsigned_t = TypeParam;
+    constexpr size_t sizeof_bits = std::countr_zero<unsigned_t>(0b0000);
     constexpr size_t zero  = std::countr_zero<unsigned_t>(0b0001);
     constexpr size_t zero2 = std::countr_zero<unsigned_t>(0b0101);
     constexpr size_t one1  = std::countr_zero<unsigned_t>(0b0010);
     constexpr size_t one2  = std::countr_zero<unsigned_t>(0b0110);
     constexpr size_t two   = std::countr_zero<unsigned_t>(0b0100);
     constexpr size_t five  = std::countr_zero<unsigned_t>(0b10100000);
+    EXPECT_EQ(sizeof_bits, seqan3::detail::sizeof_bits<unsigned_t>);
     EXPECT_EQ(zero,  0u);
     EXPECT_EQ(zero2, 0u);
     EXPECT_EQ(one1,  1u);

--- a/test/unit/range/container/aligned_allocator_test.cpp
+++ b/test/unit/range/container/aligned_allocator_test.cpp
@@ -7,12 +7,12 @@
 
 #include <gtest/gtest.h>
 
+#include <seqan3/std/bit>
 #include <deque>
 #include <list>
 #include <map>
 #include <vector>
 
-#include <seqan3/core/bit_manipulation.hpp>
 #include <seqan3/range/container/aligned_allocator.hpp>
 
 // standard construction.
@@ -89,7 +89,7 @@ TEST(aligned_allocator, memory_alignment)
 TEST(aligned_allocator, memory_alignment_bigger_than_default_new_alignment)
 {
     size_t size = 10;
-    constexpr size_t alignment = seqan3::detail::next_power_of_two(__STDCPP_DEFAULT_NEW_ALIGNMENT__ + 1);
+    constexpr size_t alignment = std::bit_ceil(__STDCPP_DEFAULT_NEW_ALIGNMENT__ + 1u);
     seqan3::aligned_allocator<int, alignment> alloc{};
 
     int * begin = alloc.allocate(size);

--- a/test/unit/range/container/dynamic_bitset_test.cpp
+++ b/test/unit/range/container/dynamic_bitset_test.cpp
@@ -7,6 +7,7 @@
 
 #include <gtest/gtest.h>
 
+#include <seqan3/core/bit_manipulation.hpp>
 #include <seqan3/range/container/dynamic_bitset.hpp>
 #include <seqan3/test/cereal.hpp>
 

--- a/test/unit/utility/math_test.cpp
+++ b/test/unit/utility/math_test.cpp
@@ -7,9 +7,10 @@
 
 #include <gtest/gtest.h>
 
+#include <seqan3/core/bit_manipulation.hpp>
 #include <seqan3/utility/math.hpp>
 
-static constexpr size_t max_iterations = 1;//1 << 15;
+static constexpr size_t max_iterations = 1 << 15;
 
 using unsigned_types = ::testing::Types<uint8_t, uint16_t, uint32_t, uint64_t>;
 


### PR DESCRIPTION
Fixes Partially https://github.com/seqan/product_backlog/issues/199

gcc-9 comparison:

| Benchmark                                                  | gcc-9-before Time | gcc-9-after Time | After-before Time | (After-Before)/Before Time |
| ---------------------------------------------------------- | ----------------- | ---------------- | ----------------- | -------------------------- |
| _is\_power\_of\_two\_popcount\<unsigned>\_median_           | 8.610 ns          | 9.170 ns         | 0.560 ns          | **+6.50%**                 |
| _is\_power\_of\_two\_popcount\<unsigned long>\_median_      | 7.880 ns          | 8.290 ns         | 0.410 ns          | **+5.20%**                 |
| _is\_power\_of\_two\_popcount\<unsigned long long>\_median_ | 9.070 ns          | 8.860 ns         | \-0.210 ns        | \-2.32%                    |
| _is\_power\_of\_two\_arithmetic\_median_                   | 6.950 ns          | 6.920 ns         | \-0.030 ns        | \-0.43%                    |
| **is\_power\_of\_two\_seqan3\_median**                     | 6.870 ns          | 6.960 ns         | 0.090 ns          | +1.31%                     |
| _is\_power\_of\_two\_std\_median_                          |                   | 6.950 ns         |                   |                            |
| **next\_power\_of\_two\_seqan3\_median**                   | 14.400 ns         | 14.100 ns        | \-0.300 ns        | \-2.08%                    |
| **next\_power\_of\_two\_std\_median**                      |                   | 14.000 ns        |                   |                            |

<details><summary>Click for complete table</summary>

| Benchmark                                                  | gcc-9-before Time | gcc-9-after Time | After-before Time | (After-Before)/Before Time |
| ---------------------------------------------------------- | ----------------- | ---------------- | ----------------- | -------------------------- |
| _is\_power\_of\_two\_popcount\<unsigned>_                   | 8.540 ns          | 9.180 ns         | 0.640 ns          | **+7.49%**                 |
| _is\_power\_of\_two\_popcount\<unsigned>_                   | 8.610 ns          | 9.160 ns         | 0.550 ns          | **+6.39%**                 |
| _is\_power\_of\_two\_popcount\<unsigned>_                   | 8.650 ns          | 9.170 ns         | 0.520 ns          | **+6.01%**                 |
| _is\_power\_of\_two\_popcount\<unsigned>\_mean_             | 8.600 ns          | 9.170 ns         | 0.570 ns          | **+6.63%**                 |
| _is\_power\_of\_two\_popcount\<unsigned>\_median_           | 8.610 ns          | 9.170 ns         | 0.560 ns          | **+6.50%**                 |
| _is\_power\_of\_two\_popcount\<unsigned>\_stddev_           | 0.056 ns          | 0.008 ns         | \-0.048 ns        | **\-85.71%**               |
| _is\_power\_of\_two\_popcount\<unsigned long>_              | 7.860 ns          | 8.350 ns         | 0.490 ns          | **+6.23%**                 |
| _is\_power\_of\_two\_popcount\<unsigned long>_              | 7.880 ns          | 8.280 ns         | 0.400 ns          | **+5.08%**                 |
| _is\_power\_of\_two\_popcount\<unsigned long>_              | 7.950 ns          | 8.290 ns         | 0.340 ns          | +4.28%                     |
| _is\_power\_of\_two\_popcount\<unsigned long>\_mean_        | 7.900 ns          | 8.310 ns         | 0.410 ns          | **+5.19%**                 |
| _is\_power\_of\_two\_popcount\<unsigned long>\_median_      | 7.880 ns          | 8.290 ns         | 0.410 ns          | **+5.20%**                 |
| _is\_power\_of\_two\_popcount\<unsigned long>\_stddev_      | 0.046 ns          | 0.036 ns         | \-0.010 ns        | **\-21.74%**               |
| _is\_power\_of\_two\_popcount\<unsigned long long>_         | 8.900 ns          | 8.840 ns         | \-0.060 ns        | \-0.67%                    |
| _is\_power\_of\_two\_popcount\<unsigned long long>_         | 9.100 ns          | 8.860 ns         | \-0.240 ns        | \-2.64%                    |
| _is\_power\_of\_two\_popcount\<unsigned long long>_         | 9.070 ns          | 8.940 ns         | \-0.130 ns        | \-1.43%                    |
| _is\_power\_of\_two\_popcount\<unsigned long long>\_mean_   | 9.020 ns          | 8.880 ns         | \-0.140 ns        | \-1.55%                    |
| _is\_power\_of\_two\_popcount\<unsigned long long>\_median_ | 9.070 ns          | 8.860 ns         | \-0.210 ns        | \-2.32%                    |
| _is\_power\_of\_two\_popcount\<unsigned long long>\_stddev_ | 0.107 ns          | 0.054 ns         | \-0.053 ns        | **\-49.53%**               |
| _is\_power\_of\_two\_arithmetic_                           | 7.040 ns          | 6.910 ns         | \-0.130 ns        | \-1.85%                    |
| _is\_power\_of\_two\_arithmetic_                           | 6.950 ns          | 6.950 ns         | 0.000 ns          | +0.00%                     |
| _is\_power\_of\_two\_arithmetic_                           | 6.910 ns          | 6.920 ns         | 0.010 ns          | +0.14%                     |
| _is\_power\_of\_two\_arithmetic\_mean_                     | 6.970 ns          | 6.920 ns         | \-0.050 ns        | \-0.72%                    |
| _is\_power\_of\_two\_arithmetic\_median_                   | 6.950 ns          | 6.920 ns         | \-0.030 ns        | \-0.43%                    |
| _is\_power\_of\_two\_arithmetic\_stddev_                   | 0.067 ns          | 0.020 ns         | \-0.047 ns        | **\-70.15%**               |
| **is\_power\_of\_two\_seqan3**                             | 6.870 ns          | 6.940 ns         | 0.070 ns          | +1.02%                     |
| **is\_power\_of\_two\_seqan3**                             | 6.870 ns          | 6.960 ns         | 0.090 ns          | +1.31%                     |
| **is\_power\_of\_two\_seqan3**                             | 6.890 ns          | 6.970 ns         | 0.080 ns          | +1.16%                     |
| **is\_power\_of\_two\_seqan3\_mean**                       | 6.880 ns          | 6.960 ns         | 0.080 ns          | +1.16%                     |
| **is\_power\_of\_two\_seqan3\_median**                     | 6.870 ns          | 6.960 ns         | 0.090 ns          | +1.31%                     |
| **is\_power\_of\_two\_seqan3\_stddev**                     | 0.012 ns          | 0.016 ns         | 0.004 ns          | **+33.33%**                |
| _is\_power\_of\_two\_std_                                  |                   | 6.940 ns         |                   |                            |
| _is\_power\_of\_two\_std_                                  |                   | 6.990 ns         |                   |                            |
| _is\_power\_of\_two\_std_                                  |                   | 6.950 ns         |                   |                            |
| _is\_power\_of\_two\_std\_mean_                            |                   | 6.960 ns         |                   |                            |
| _is\_power\_of\_two\_std\_median_                          |                   | 6.950 ns         |                   |                            |
| _is\_power\_of\_two\_std\_stddev_                          |                   | 0.022 ns         |                   |                            |
| **next\_power\_of\_two\_seqan3**                           | 14.300 ns         | 14.100 ns        | \-0.200 ns        | \-1.40%                    |
| **next\_power\_of\_two\_seqan3**                           | 14.400 ns         | 14.100 ns        | \-0.300 ns        | \-2.08%                    |
| **next\_power\_of\_two\_seqan3**                           | 14.400 ns         | 14.100 ns        | \-0.300 ns        | \-2.08%                    |
| **next\_power\_of\_two\_seqan3\_mean**                     | 14.400 ns         | 14.100 ns        | \-0.300 ns        | \-2.08%                    |
| **next\_power\_of\_two\_seqan3\_median**                   | 14.400 ns         | 14.100 ns        | \-0.300 ns        | \-2.08%                    |
| **next\_power\_of\_two\_seqan3\_stddev**                   | 0.036 ns          | 0.012 ns         | \-0.024 ns        | **\-66.67%**               |
| **next\_power\_of\_two\_std**                              |                   | 13.900 ns        |                   |                            |
| **next\_power\_of\_two\_std**                              |                   | 14.000 ns        |                   |                            |
| **next\_power\_of\_two\_std**                              |                   | 14.000 ns        |                   |                            |
| **next\_power\_of\_two\_std\_mean**                        |                   | 14.000 ns        |                   |                            |
| **next\_power\_of\_two\_std\_median**                      |                   | 14.000 ns        |                   |                            |

</details>

gcc-10 comparison:

| Benchmark                                                  | gcc-10-before Time | gcc-10-after Time | After-before Time | (After-Before)/Before Time |
| ---------------------------------------------------------- | ------------------ | ----------------- | ----------------- | -------------------------- |
| _is\_power\_of\_two\_popcount\<unsigned>\_median_           | 7.710 ns           | 8.290 ns          | 0.580 ns          | **+7.52%**                 |
| _is\_power\_of\_two\_popcount\<unsigned long>\_median_      | 7.770 ns           | 8.410 ns          | 0.640 ns          | **+8.24%**                 |
| _is\_power\_of\_two\_popcount\<unsigned long long>\_median_ | 8.060 ns           | 8.360 ns          | 0.300 ns          | +3.72%                     |
| _is\_power\_of\_two\_arithmetic\_median_                   | 6.190 ns           | 6.350 ns          | 0.160 ns          | +2.58%                     |
| **is\_power\_of\_two\_seqan3\_median**                     | 6.160 ns           | 8.360 ns          | 2.200 ns          | **+35.71%**                |
| **is\_power\_of\_two\_std\_median**                        | 8.13               | 8.380 ns          | 0.250 ns          | +3.08%                     |
| **next\_power\_of\_two\_seqan3\_median**                   | 13.700 ns          | 6.700 ns          | \-7.000 ns        | **\-51.09%**               |
| _next\_power\_of\_two\_std\_median_                        | 6.54               | 6.680 ns          | 0.140 ns          | +2.14%                     |

<details><summary>Click for complete table</summary>

| Benchmark                                                  | gcc-10-before Time | gcc-10-after Time | After-before Time | (After-Before)/Before Time |
| ---------------------------------------------------------- | ------------------ | ----------------- | ----------------- | -------------------------- |
| _is\_power\_of\_two\_popcount\<unsigned>_                   | 7.700 ns           | 8.290 ns          | 0.590 ns          | **+7.66%**                 |
| _is\_power\_of\_two\_popcount\<unsigned>_                   | 7.710 ns           | 8.290 ns          | 0.580 ns          | **+7.52%**                 |
| _is\_power\_of\_two\_popcount\<unsigned>_                   | 7.740 ns           | 8.290 ns          | 0.550 ns          | **+7.11%**                 |
| _is\_power\_of\_two\_popcount\<unsigned>\_mean_             | 7.720 ns           | 8.290 ns          | 0.570 ns          | **+7.38%**                 |
| _is\_power\_of\_two\_popcount\<unsigned>\_median_           | 7.710 ns           | 8.290 ns          | 0.580 ns          | **+7.52%**                 |
| _is\_power\_of\_two\_popcount\<unsigned>\_stddev_           | 0.018 ns           | 0.002 ns          | \-0.016 ns        | **\-88.89%**               |
| _is\_power\_of\_two\_popcount\<unsigned long>_              | 7.710 ns           | 8.420 ns          | 0.710 ns          | **+9.21%**                 |
| _is\_power\_of\_two\_popcount\<unsigned long>_              | 7.770 ns           | 8.400 ns          | 0.630 ns          | **+8.11%**                 |
| _is\_power\_of\_two\_popcount\<unsigned long>_              | 7.920 ns           | 8.410 ns          | 0.490 ns          | **+6.19%**                 |
| _is\_power\_of\_two\_popcount\<unsigned long>\_mean_        | 7.800 ns           | 8.410 ns          | 0.610 ns          | **+7.82%**                 |
| _is\_power\_of\_two\_popcount\<unsigned long>\_median_      | 7.770 ns           | 8.410 ns          | 0.640 ns          | **+8.24%**                 |
| _is\_power\_of\_two\_popcount\<unsigned long>\_stddev_      | 0.110 ns           | 0.007 ns          | \-0.103 ns        | **\-93.64%**               |
| _is\_power\_of\_two\_popcount\<unsigned long long>_         | 7.960 ns           | 8.370 ns          | 0.410 ns          | **+5.15%**                 |
| _is\_power\_of\_two\_popcount\<unsigned long long>_         | 8.060 ns           | 8.350 ns          | 0.290 ns          | +3.60%                     |
| _is\_power\_of\_two\_popcount\<unsigned long long>_         | 8.150 ns           | 8.360 ns          | 0.210 ns          | +2.58%                     |
| _is\_power\_of\_two\_popcount\<unsigned long long>\_mean_   | 8.060 ns           | 8.360 ns          | 0.300 ns          | +3.72%                     |
| _is\_power\_of\_two\_popcount\<unsigned long long>\_median_ | 8.060 ns           | 8.360 ns          | 0.300 ns          | +3.72%                     |
| _is\_power\_of\_two\_popcount\<unsigned long long>\_stddev_ | 0.094 ns           | 0.010 ns          | \-0.084 ns        | **\-89.36%**               |
| _is\_power\_of\_two\_arithmetic_                           | 6.170 ns           | 6.350 ns          | 0.180 ns          | +2.92%                     |
| _is\_power\_of\_two\_arithmetic_                           | 6.190 ns           | 6.360 ns          | 0.170 ns          | +2.75%                     |
| _is\_power\_of\_two\_arithmetic_                           | 6.200 ns           | 6.350 ns          | 0.150 ns          | +2.42%                     |
| _is\_power\_of\_two\_arithmetic\_mean_                     | 6.190 ns           | 6.350 ns          | 0.160 ns          | +2.58%                     |
| _is\_power\_of\_two\_arithmetic\_median_                   | 6.190 ns           | 6.350 ns          | 0.160 ns          | +2.58%                     |
| _is\_power\_of\_two\_arithmetic\_stddev_                   | 0.013 ns           | 0.008 ns          | \-0.005 ns        | **\-38.46%**               |
| **is\_power\_of\_two\_seqan3**                             | 6.160 ns           | 8.350 ns          | 2.190 ns          | **+35.55%**                |
| **is\_power\_of\_two\_seqan3**                             | 6.160 ns           | 8.380 ns          | 2.220 ns          | **+36.04%**                |
| **is\_power\_of\_two\_seqan3**                             | 6.180 ns           | 8.360 ns          | 2.180 ns          | **+35.28%**                |
| **is\_power\_of\_two\_seqan3\_mean**                       | 6.170 ns           | 8.370 ns          | 2.200 ns          | **+35.66%**                |
| **is\_power\_of\_two\_seqan3\_median**                     | 6.160 ns           | 8.360 ns          | 2.200 ns          | **+35.71%**                |
| **is\_power\_of\_two\_seqan3\_stddev**                     | 0.010 ns           | 0.016 ns          | 0.006 ns          | **+60.00%**                |
| **is\_power\_of\_two\_std**                                | 8.17               | 8.470 ns          | 0.300 ns          | +3.67%                     |
| **is\_power\_of\_two\_std**                                | 8.13               | 8.380 ns          | 0.250 ns          | +3.08%                     |
| **is\_power\_of\_two\_std**                                | 8.02               | 8.370 ns          | 0.350 ns          | +4.36%                     |
| **is\_power\_of\_two\_std\_mean**                          | 8.11               | 8.410 ns          | 0.300 ns          | +3.70%                     |
| **is\_power\_of\_two\_std\_median**                        | 8.13               | 8.380 ns          | 0.250 ns          | +3.08%                     |
| **is\_power\_of\_two\_std\_stddev**                        | 0.077              | 0.055 ns          | \-0.022 ns        | **\-28.57%**               |
| **next\_power\_of\_two\_seqan3**                           | 13.700 ns          | 6.700 ns          | \-7.000 ns        | **\-51.09%**               |
| **next\_power\_of\_two\_seqan3**                           | 13.700 ns          | 6.700 ns          | \-7.000 ns        | **\-51.09%**               |
| **next\_power\_of\_two\_seqan3**                           | 13.800 ns          | 6.720 ns          | \-7.080 ns        | **\-51.30%**               |
| **next\_power\_of\_two\_seqan3\_mean**                     | 13.700 ns          | 6.710 ns          | \-6.990 ns        | **\-51.02%**               |
| **next\_power\_of\_two\_seqan3\_median**                   | 13.700 ns          | 6.700 ns          | \-7.000 ns        | **\-51.09%**               |
| **next\_power\_of\_two\_seqan3\_stddev**                   | 0.050 ns           | 0.015 ns          | \-0.035 ns        | **\-70.00%**               |
| _next\_power\_of\_two\_std_                                | 6.44               | 6.650 ns          | 0.210 ns          | +3.26%                     |
| _next\_power\_of\_two\_std_                                | 6.54               | 6.680 ns          | 0.140 ns          | +2.14%                     |
| _next\_power\_of\_two\_std_                                | 6.66               | 6.680 ns          | 0.020 ns          | +0.30%                     |
| _next\_power\_of\_two\_std\_mean_                          | 6.55               | 6.670 ns          | 0.120 ns          | +1.83%                     |
| _next\_power\_of\_two\_std\_median_                        | 6.54               | 6.680 ns          | 0.140 ns          | +2.14%                     |
| _next\_power\_of\_two\_std\_stddev_                        | 0.107              | 0.018             | \-0.089 ns        | **\-83.18%**               |

</details>

Note:
* _cursive_ Benchmarks: no change in implementation
* **bold** Benchmarks: change in implementation
* **bold** Time Percentage changes: has significant percentage change

For some reason the popcount benchmark (independent of seqan3) did
increase the runtime. I'm not sure what happened here. This is
consistent between gcc-9 and gcc-10.

Looking at the number:
* gcc-9 has the same runtimes (same implementation used)
* gcc-10 -std=c++2a has a better next_power_of_two implementation (std::bit_ceil), we should use the same implementation in <= gcc-9.
* gcc-10 -std=c++2a seems to have a worser implementation of is_power_of_two (std::has_single_bit), I need to report that upstream.