### PR TITLE
[FIX] too many columns in doxygen class list

### DIFF
--- a/test/documentation/seqan3_doxygen_cfg.in
+++ b/test/documentation/seqan3_doxygen_cfg.in
@@ -63,6 +63,8 @@ EXCLUDE_SYMBOLS        = seqan3::contrib
 FORMULA_FONTSIZE       = 14
 HTML_DYNAMIC_SECTIONS  = YES
 
+COLS_IN_ALPHA_INDEX    = 1
+
 ## detect headers without extensions (in std module)
 EXTENSION_MAPPING      = .no_extension=C++
 FILE_PATTERNS          = *


### PR DESCRIPTION
@Irallia noticed that our doxygen class list is not well formatted:

https://docs.seqan.de/seqan/3-master-dev/classes.html


After this PR:

![fix_doxy](https://user-images.githubusercontent.com/12967715/101912116-9d606800-3bc1-11eb-8950-135b8fee6d94.png)


See https://www.doxygen.nl/manual/config.html#cfg_cols_in_alpha_index