### PR TITLE
[DOC] Replace the word 'defaulted' with better/correct alternative.

### DIFF
--- a/doc/tutorial/alignment_file/index.md
+++ b/doc/tutorial/alignment_file/index.md
@@ -171,7 +171,7 @@ A read with name `r003` has been mapped to a reference with name `ref` at positi
 (in the reference, counting from 1) with a quality of `17` (Phred scaled).
 The flag has a value of `73` which indicates that the read is paired, the first in pair, but the mate is unmapped
 (see [this website](https://broadinstitute.github.io/picard/explain-flags.html) for a nice explanation of SAM flags).
-Fields set to `0` or `*` are defaulted and contain no information.
+Fields set to `0` or `*` indicate empty fields and contain no valuable information.
 
 The cigar string is `1M1D4M` which represents the following alignment:
 

--- a/include/seqan3/alignment/all.hpp
+++ b/include/seqan3/alignment/all.hpp
@@ -180,7 +180,7 @@
  * assertion is raised.
  *
  * The scoring scheme can be configured with the seqan3::align_cfg::scoring_scheme element. Since the scoring scheme is
- * strongly coupled on the sequences to be aligned there is no default for it. Thus, it is mandatory for
+ * strongly coupled on the sequences to be aligned, there is no default for it. Thus, it is mandatory for
  * the developer to specify this configuration.
  *
  * ### Scoring gaps

--- a/include/seqan3/alignment/all.hpp
+++ b/include/seqan3/alignment/all.hpp
@@ -180,7 +180,7 @@
  * assertion is raised.
  *
  * The scoring scheme can be configured with the seqan3::align_cfg::scoring_scheme element. Since the scoring scheme is
- * strongly coupled on the sequences to be aligned it can not be defaulted. Thus, it is mandatory for
+ * strongly coupled on the sequences to be aligned there is no default for it. Thus, it is mandatory for
  * the developer to specify this configuration.
  *
  * ### Scoring gaps

--- a/include/seqan3/alignment/configuration/align_config_method.hpp
+++ b/include/seqan3/alignment/configuration/align_config_method.hpp
@@ -32,8 +32,8 @@ namespace seqan3::align_cfg
  * \ref seqan3::align_cfg::method_local "local" and the
  * \ref seqan3::align_cfg::method_global "global" alignment are two different methods, while the semi-global alignment
  * is a variation of the global alignment. This differentiation makes it possible to define a subset of configurations
- * that can work with a particular method. Since it is not possible to guess what the desired method for a user is, this
- * configuration must be provided for the alignment algorithm and cannot be defaulted.
+ * that can work with a particular method. Since it is not possible to guess what the desired method for a user is,
+ * there is no default and this configuration must always be provided for the alignment algorithm.
  *
  * ### Example
  *

--- a/include/seqan3/alignment/configuration/align_config_scoring_scheme.hpp
+++ b/include/seqan3/alignment/configuration/align_config_scoring_scheme.hpp
@@ -33,7 +33,7 @@ namespace seqan3::align_cfg
  * The scheme depends on the alphabet type of the passed sequences and must be chosen accordingly.
  * During the configuration of the pairwise alignment algorithm a static assert is triggered if the scoring scheme
  * is not compatible with the given alphabet types (see seqan3::scoring_scheme_for). Accordingly,
- * this configuration cannot be defaulted since it depends on the sequences and must be given as a minimal
+ * there is no default for this configuration since it depends on the sequences and it must be given as a minimal
  * configuration.
  *
  * ### Example

--- a/include/seqan3/alphabet/composite/alphabet_variant.hpp
+++ b/include/seqan3/alphabet/composite/alphabet_variant.hpp
@@ -268,7 +268,7 @@ public:
      *
      * \details
      *
-     * Most assignments happen through implicit conversion and the defaulted assignment operator. This is for the rest.
+     * Most assignments happen through implicit conversion and the default assignment operator. This is for the rest.
      */
     template <typename indirect_alternative_t>
     //!\cond

--- a/include/seqan3/alphabet/composite/alphabet_variant.hpp
+++ b/include/seqan3/alphabet/composite/alphabet_variant.hpp
@@ -268,7 +268,7 @@ public:
      *
      * \details
      *
-     * Most assignments happen through implicit conversion and the default assignment operator. This is for the rest.
+     * Most assignments happen through implicit conversion and the default assignment operator. This constructor is for the rest.
      */
     template <typename indirect_alternative_t>
     //!\cond

--- a/include/seqan3/core/detail/debug_stream_type.hpp
+++ b/include/seqan3/core/detail/debug_stream_type.hpp
@@ -71,7 +71,7 @@ class debug_stream_type
 {
 public:
     /*!\name Constructor, destructor and assignment.
-     * \brief The standard functions are explicitly defaulted.
+     * \brief The standard functions are explicitly set to default.
      * \{
      */
     debug_stream_type() = default;                                       //!< Defaulted

--- a/include/seqan3/core/detail/strong_type.hpp
+++ b/include/seqan3/core/detail/strong_type.hpp
@@ -183,7 +183,7 @@ public:
     using value_type = value_t;
 
     /*!\name Constructor, destructor and assignment.
-     * \brief The standard functions are explicitly defaulted.
+     * \brief The standard functions are explicitly set to default.
      * \{
      */
     constexpr strong_type()                                 noexcept = default; //!< Defaulted.

--- a/include/seqan3/io/alignment_file/format_sam.hpp
+++ b/include/seqan3/io/alignment_file/format_sam.hpp
@@ -77,8 +77,8 @@ namespace seqan3
  * In addition there is the seqan3::field::header_ptr, which is usually only used internally
  * to provide the range-based functionality of the file.
  *
- * **None of the fields are required** when writing but will be defaulted
- * to '0' for numeric fields and '*' for other fields.
+ * **None of the fields are required** when writing. If they are not given, a default value of '0' for numeric fields
+ * and '*' for other fields is used.
  *
  * ### SAM format columns -> fields
  *

--- a/include/seqan3/io/alignment_file/output.hpp
+++ b/include/seqan3/io/alignment_file/output.hpp
@@ -114,7 +114,7 @@ namespace seqan3
  * \include test/snippet/io/alignment_file/alignment_file_output_custom_fields.cpp
  *
  * This will copy the FLAG and REF_OFFSET value into the new output file. Note that the other SAM columns in the
- * output file will be defaulted, so unless you specify to read all SAM columns (see seqan3::format_sam)
+ * output file will have a default value, so unless you specify to read all SAM columns (see seqan3::format_sam)
  * the output file will not be equal to the input file.
  *
  * ### Writing record-wise in batches
@@ -806,7 +806,7 @@ protected:
  */
 
 /*!\brief Deduces selected_field_ids from input and sets alignment_file_output::ref_ids_type to
- *        seqan3::detail::ref_info_not_given. valid_formats is defaulted.
+ *        seqan3::detail::ref_info_not_given. valid_formats is set to the default.
  */
 template <detail::fields_specialisation selected_field_ids>
 alignment_file_output(std::filesystem::path, selected_field_ids const &)
@@ -837,7 +837,7 @@ alignment_file_output(stream_type &, file_format const &, selected_field_ids con
                              ref_info_not_given>;
 
 /*!\brief Deduces the valid format from input and sets alignment_file_output::ref_ids_type to
- *        seqan3::detail::ref_info_not_given. selected_field_ids is defaulted.
+ *        seqan3::detail::ref_info_not_given. selected_field_ids is set to the default.
  */
 template <output_stream stream_type,
           alignment_file_output_format file_format>
@@ -847,7 +847,7 @@ alignment_file_output(stream_type &&, file_format const &)
                              ref_info_not_given>;
 
 /*!\brief Deduces the valid format from input and sets alignment_file_output::ref_ids_type to
- *        seqan3::detail::ref_info_not_given. selected_field_ids is defaulted.
+ *        seqan3::detail::ref_info_not_given. selected_field_ids is set to the default.
  */
 template <output_stream stream_type,
           alignment_file_output_format file_format>
@@ -856,7 +856,7 @@ alignment_file_output(stream_type &, file_format const &)
                              type_list<file_format>,
                              ref_info_not_given>;
 
-//!\brief Deduces selected_field_ids and ref_ids_type from input. valid_formats is defaulted.
+//!\brief Deduces selected_field_ids and ref_ids_type from input. valid_formats is set to the default.
 template <detail::fields_specialisation selected_field_ids,
           std::ranges::forward_range ref_ids_type,
           std::ranges::forward_range ref_lengths_type>
@@ -868,7 +868,7 @@ alignment_file_output(std::filesystem::path const &,
                              typename alignment_file_output<>::valid_formats,
                              std::remove_reference_t<ref_ids_type>>;
 
-//!\brief Deduces ref_ids_type from input. Valid formats, and selected_field_ids are defaulted.
+//!\brief Deduces ref_ids_type from input. Valid formats, and selected_field_ids are set to the default.
 template <std::ranges::forward_range ref_ids_type,
           std::ranges::forward_range ref_lengths_type>
 alignment_file_output(std::filesystem::path const &,
@@ -908,7 +908,7 @@ alignment_file_output(stream_type &,
                              type_list<file_format>,
                              std::remove_reference_t<ref_ids_type>>;
 
-//!\brief Deduces the valid format, and the ref_ids_type from input. selected_field_ids is defaulted.
+//!\brief Deduces the valid format, and the ref_ids_type from input. selected_field_ids set to the default.
 template <output_stream stream_type,
           std::ranges::forward_range ref_ids_type,
           std::ranges::forward_range ref_lengths_type,
@@ -921,7 +921,7 @@ alignment_file_output(stream_type &&,
                              type_list<file_format>,
                              std::remove_reference_t<ref_ids_type>>;
 
-//!\brief Deduces the valid format, and the ref_ids_type from input. selected_field_ids is defaulted.
+//!\brief Deduces the valid format, and the ref_ids_type from input. selected_field_ids set to the default.
 template <output_stream stream_type,
           std::ranges::forward_range ref_ids_type,
           std::ranges::forward_range ref_lengths_type,

--- a/include/seqan3/io/detail/misc_input.hpp
+++ b/include/seqan3/io/detail/misc_input.hpp
@@ -71,7 +71,7 @@ inline bool starts_with(ref_t && reference, query_t && query)
 /*!\brief Depending on the magic bytes of the given stream, return a decompression stream or forward the primary stream.
  * \param[in] primary_stream The primary (device) stream for reading.
  * \param[in,out] filename  The associated filename; compression extensions will be stripped. [optional]
- * \returns A pointer to the secondary stream with a default deleter or a NOP'ed deleter.
+ * \returns A pointer to the secondary stream with a default deleter or a nop-deleter.
  * \throws seqan3::file_open_error If the magic bytes suggest compression, but is not supported/available.
  */
 template <builtin_character char_t>

--- a/include/seqan3/io/detail/misc_input.hpp
+++ b/include/seqan3/io/detail/misc_input.hpp
@@ -71,7 +71,7 @@ inline bool starts_with(ref_t && reference, query_t && query)
 /*!\brief Depending on the magic bytes of the given stream, return a decompression stream or forward the primary stream.
  * \param[in] primary_stream The primary (device) stream for reading.
  * \param[in,out] filename  The associated filename; compression extensions will be stripped. [optional]
- * \returns A pointer to the secondary stream with defaulted or NOP'ed deleter.
+ * \returns A pointer to the secondary stream with a default deleter or a NOP'ed deleter.
  * \throws seqan3::file_open_error If the magic bytes suggest compression, but is not supported/available.
  */
 template <builtin_character char_t>

--- a/include/seqan3/io/detail/misc_output.hpp
+++ b/include/seqan3/io/detail/misc_output.hpp
@@ -32,7 +32,7 @@ namespace seqan3::detail
 /*!\brief Depending on the given filename/extension, create a compression stream or just forward the primary stream.
  * \param[in] primary_stream The primary (uncompressed) stream for writing.
  * \param[in,out] filename  The associated filename; compression extensions will be stripped.
- * \returns A pointer to the secondary stream with defaulted or NOP'ed deleter.
+ * \returns A pointer to the secondary stream with a default deleter or a NOP'ed deleter.
  * \throws seqan3::file_open_error If a compression-extension is used, but is not supported/available.
  */
 template <builtin_character char_t>

--- a/include/seqan3/io/detail/misc_output.hpp
+++ b/include/seqan3/io/detail/misc_output.hpp
@@ -32,7 +32,7 @@ namespace seqan3::detail
 /*!\brief Depending on the given filename/extension, create a compression stream or just forward the primary stream.
  * \param[in] primary_stream The primary (uncompressed) stream for writing.
  * \param[in,out] filename  The associated filename; compression extensions will be stripped.
- * \returns A pointer to the secondary stream with a default deleter or a NOP'ed deleter.
+ * \returns A pointer to the secondary stream with a default deleter or a nop-deleter.
  * \throws seqan3::file_open_error If a compression-extension is used, but is not supported/available.
  */
 template <builtin_character char_t>

--- a/include/seqan3/range/views/deep.hpp
+++ b/include/seqan3/range/views/deep.hpp
@@ -202,7 +202,7 @@ public:
     {
         // Proto-adaptors require arguments by definition, but some support defaulting those (e.g. views::translate).
         // This extracts the proto adaptor and invokes it without args which yields a different object, the closure
-        // with defaulted arguments.
+        // with default arguments.
         auto adaptor_closure = std::get<0>(this->arguments)();
         // Now we wrap this closure object back into a views::deep to get the deep behaviour.
         return deep<decltype(adaptor_closure)>{std::move(adaptor_closure)};

--- a/include/seqan3/range/views/single_pass_input.hpp
+++ b/include/seqan3/range/views/single_pass_input.hpp
@@ -71,7 +71,7 @@ private:
 public:
     /*!\name Constructor, destructor, and assignment.
      * \{
-     * \brief All standard functions are explicitly defaulted.
+     * \brief All standard functions are explicitly set to default.
      */
     //!\brief Default default-constructor.
     constexpr single_pass_input_view() = default;

--- a/test/snippet/core/simd/view_to_simd.cpp
+++ b/test/snippet/core/simd/view_to_simd.cpp
@@ -10,7 +10,7 @@ int main()
 {
     using seqan3::operator""_dna4;
 
-    // Adds 7 sequences. The eighth will be defaulted.
+    // Adds 7 sequences. The eighth will be set to a default value.
     std::vector<seqan3::dna4_vector> batch;
     batch.push_back("ACGTACGTACGTACGATCG"_dna4);
     batch.push_back("AGTGAGCTACGGACTAGCTACGACT"_dna4);


### PR DESCRIPTION
`defaulted` as an adjective means something like `fails to fulfil an obligation`. 
We sometimes do not use this word correctly (since we always mean `set to default`).

Only `to be defaulted` actually means `set to default`. To avoid this possible confusing, some correct sentences were also changed.