### PR TITLE
[FIX] too many threads used in unit tests

### DIFF
--- a/include/seqan3/core/algorithm/detail/execution_handler_parallel.hpp
+++ b/include/seqan3/core/algorithm/detail/execution_handler_parallel.hpp
@@ -89,7 +89,20 @@ public:
         }
     }
 
-    //!\brief Constructs the execution handler spawning std::thread::hardware_concurrency many threads.
+    /*!\brief Constructs the execution handler spawning 1 thread.
+     *
+     * \details
+     * 
+     * ### Why only 1 thread?
+     * 
+     * This class is not public. It handles the thread pool when, e.g., using the alignment or search algorithms in 
+     * parallel via the config. This config requires a value (no default), hence the number of threads is always 
+     * set by the user.
+     * 
+     * When we use an algorithm in parallel, we also default construct a execution_handler_parallel along the way. If 
+     * the default is set to use all threads, we have to generate the thread pool and a queue. However, this default 
+     * constructed execution_handler_parallel is immediately moved away and destructed.
+     */
     execution_handler_parallel() : execution_handler_parallel{1u}
     {}
 

--- a/include/seqan3/core/algorithm/detail/execution_handler_parallel.hpp
+++ b/include/seqan3/core/algorithm/detail/execution_handler_parallel.hpp
@@ -90,7 +90,7 @@ public:
     }
 
     //!\brief Constructs the execution handler spawning std::thread::hardware_concurrency many threads.
-    execution_handler_parallel() : execution_handler_parallel{std::thread::hardware_concurrency()}
+    execution_handler_parallel() : execution_handler_parallel{1u}
     {}
 
     execution_handler_parallel(execution_handler_parallel const &) = delete; //!< Deleted.


### PR DESCRIPTION
This sets the default number of threads for the `execution_handler_parallel` to `1`.
All the tests were the handler was expected to use multiple threads were adjusted to explicitly request not more than 4 threads.

The `execution_handler_parallel` is detail and hence not used in public code. It handles the thread pool when, e.g., using the alignment or search algorithms in parallel via the config. This config requires a value (no default), hence the number of threads is always set by the user.

When we use an algorithm in parallel, we also default construct a `execution_handler_parallel` along the way. If the default is set to use all threads, we have to generate the thread pool and a queue. However, this default constructed `execution_handler_parallel` is also moved away and practically immediately destructed, hence we need to close the queue.
Closing a queue when using many threads currently may lead to a live/deadlock. 