### PR TITLE
[FIX] chain_validator: use common_type to chain

### DIFF
--- a/include/seqan3/argument_parser/validators.hpp
+++ b/include/seqan3/argument_parser/validators.hpp
@@ -973,13 +973,14 @@ struct default_validator
  */
 template <validator validator1_type, validator validator2_type>
 //!\cond
-    requires std::same_as<typename validator1_type::option_value_type, typename validator2_type::option_value_type>
+    requires std::common_with<typename validator1_type::option_value_type, typename validator2_type::option_value_type>
 //!\endcond
 class validator_chain_adaptor
 {
 public:
     //!\brief The underlying type in both validators.
-    using option_value_type = typename validator1_type::option_value_type;
+    using option_value_type = std::common_type_t<typename validator1_type::option_value_type,
+                                                 typename validator2_type::option_value_type>;
 
     /*!\name Constructors, destructor and assignment
      * \{
@@ -1064,8 +1065,8 @@ private:
  */
 template <validator validator1_type, validator validator2_type>
 //!\cond
-    requires std::same_as<typename std::remove_reference_t<validator1_type>::option_value_type,
-                       typename std::remove_reference_t<validator2_type>::option_value_type>
+    requires std::common_with<typename std::remove_reference_t<validator1_type>::option_value_type,
+                              typename std::remove_reference_t<validator2_type>::option_value_type>
 //!\endcond
 auto operator|(validator1_type && vali1, validator2_type && vali2)
 {

--- a/include/seqan3/argument_parser/validators.hpp
+++ b/include/seqan3/argument_parser/validators.hpp
@@ -273,23 +273,6 @@ private:
  * \relates seqan3::value_list_validator
  * \{
  */
-//!\brief Deduction guide for a parameter pack over an arithmetic type.
-template <typename option_type, typename ...option_types>
-//!\cond
-    requires ((arithmetic<option_types> && ... && arithmetic<option_type>) &&
-              !(detail::is_char_adaptation_v<option_types> || ... || detail::is_char_adaptation_v<option_type>))
-//!\endcond
-value_list_validator(option_type, option_types...) -> value_list_validator<double>;
-
-//!\brief Deduction guide for ranges over an arithmetic type.
-template <typename range_type>
-//!\cond
-    requires std::ranges::forward_range<std::decay_t<range_type>> &&
-             arithmetic<std::ranges::range_value_t<range_type>> &&
-             (!seqan3::detail::is_char_adaptation_v<std::ranges::range_value_t<range_type>>)
-//!\endcond
-value_list_validator(range_type && rng) -> value_list_validator<double>;
-
 //!\brief Given a parameter pack of types that are convertible to std::string, delegate to value type std::string.
 template <typename option_type, typename ...option_types>
 //!\cond

--- a/test/unit/argument_parser/format_parse_validators_test.cpp
+++ b/test/unit/argument_parser/format_parse_validators_test.cpp
@@ -824,17 +824,17 @@ TEST(validator_test, value_list_validator_success)
 {
     // type deduction
     // --------------
-    // all arithmetic types are deduced to double in order to easily allow chaining of arithmetic validators
-    EXPECT_TRUE((std::same_as<seqan3::value_list_validator<double>,
+    // all arithmetic types are deduced to their common type in order to easily allow chaining of arithmetic validators
+    EXPECT_TRUE((std::same_as<seqan3::value_list_validator<int>,
                  decltype(seqan3::value_list_validator{1})>));
     // except char
     EXPECT_TRUE((std::same_as<seqan3::value_list_validator<char>,
                  decltype(seqan3::value_list_validator{'c'})>));
     // The same holds for a range of arithmetic types
     std::vector v{1, 2, 3};
-    EXPECT_TRUE((std::same_as<seqan3::value_list_validator<double>,
+    EXPECT_TRUE((std::same_as<seqan3::value_list_validator<int>,
                  decltype(seqan3::value_list_validator{v})>));
-    EXPECT_TRUE((std::same_as<seqan3::value_list_validator<double>,
+    EXPECT_TRUE((std::same_as<seqan3::value_list_validator<int>,
                  decltype(seqan3::value_list_validator{v | std::views::take(2)})>));
     std::vector v_char{'1', '2', '3'};
     EXPECT_TRUE((std::same_as<seqan3::value_list_validator<char>,


### PR DESCRIPTION
Part of https://github.com/seqan/product_backlog/issues/246 and https://github.com/seqan/product_backlog/issues/40

This reduces dependencies on seqan3 by removing `seqan3::detail::is_char_adaptation_v`.

Blocked by #2307 