### PR TITLE
[FIX] type_name_as_string: handle nullptr construction if __cxa_demangle fails

### DIFF
--- a/include/seqan3/utility/detail/type_name_as_string.hpp
+++ b/include/seqan3/utility/detail/type_name_as_string.hpp
@@ -53,7 +53,7 @@ inline std::string const type_name_as_string = [] ()
                                   [] (char * name_ptr) { free(name_ptr); }};
 
     // We exclude status != 0, because this code can't be reached normally, only if there is a defect in the compiler
-    // itself, since the type is directly given by the compiler. see https://github.com/seqan/seqan3/pull/2311
+    // itself, since the type is directly given by the compiler. See https://github.com/seqan/seqan3/pull/2311.
     // LCOV_EXCL_START
     if (status != 0)
         return std::string{typeid(type).name()} +


### PR DESCRIPTION
On gcc-9 the following type can't be demangled by type_name_as_string

```c++
inline constexpr auto on_result_caller = [] (auto &&) {};

seqan3::configuration cfg{seqan3::search_cfg::on_result<decltype(on_result_caller)>{}};

std::cout << seqan3::detail::type_name_as_string<decltype(cfg)> << std::endl;
// prints: N6seqan313configurationIJNS_10search_cfg9on_resultIKUlOT_E_EEEEE (abi::__cxa_demangle error status (-2): mangled_name is not a valid name under the C++ ABI mangling rules.)
```

Before this commit `abi::__cxa_demangle` returned a `nullptr` and that will fail to execute the binary, because `std::string` can't be constructed from a nullptr.

This commit will handle `abi::__cxa_demangle` errors and will produce a similar output to the above.