### PR TITLE
[TEST] new EXPECT_SAME_TYPE test macro

### DIFF
--- a/test/include/seqan3/test/expect_same_type.hpp
+++ b/test/include/seqan3/test/expect_same_type.hpp
@@ -1,0 +1,62 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides EXPECT_SAME_TYPE.
+ * \author Marcel Ehrhardt <marcel.ehrhardt AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <seqan3/std/type_traits>
+
+#include <seqan3/utility/detail/type_name_as_string.hpp>
+
+namespace seqan3::test
+{
+// https://stackoverflow.com/a/62984543
+#define EXPECT_SAME_TYPE_DEPAREN(X) EXPECT_SAME_TYPE_ESC(EXPECT_SAME_TYPE_ISH X)
+#define EXPECT_SAME_TYPE_ISH(...) EXPECT_SAME_TYPE_ISH __VA_ARGS__
+#define EXPECT_SAME_TYPE_ESC(...) EXPECT_SAME_TYPE_ESC_(__VA_ARGS__)
+#define EXPECT_SAME_TYPE_ESC_(...) EXPECT_SAME_TYPE_VAN##__VA_ARGS__
+#define EXPECT_SAME_TYPE_VANEXPECT_SAME_TYPE_ISH
+
+#define EXPECT_SAME_TYPE(val1, val2) \
+    EXPECT_PRED_FORMAT2(::seqan3::test::expect_same_type{},(std::type_identity<EXPECT_SAME_TYPE_DEPAREN(val1)>{}),(std::type_identity<EXPECT_SAME_TYPE_DEPAREN(val2)>{}));
+
+struct expect_same_type
+{
+    template <typename lhs_t, typename rhs_t>
+    ::testing::AssertionResult operator()(std::string lhs_expression, std::string rhs_expression,
+                                          std::type_identity<lhs_t>, std::type_identity<rhs_t>)
+    {
+        auto remove_wrap_type_identity = [](std::string str)
+        {
+            // EXPECT_SAME_TYPE_DEPAREN adds a space after the prefix
+            std::string prefix = "std::type_identity< ";
+            std::string suffix = ">{}";
+
+            size_t str_start = str.find(prefix) + prefix.size();
+            size_t str_end = str.rfind(suffix);
+            assert(str_end >= str_start);
+
+            return str.substr(str_start, str_end - str_start);
+        };
+
+        if (std::is_same_v<lhs_t, rhs_t>)
+            return ::testing::AssertionSuccess();
+
+        return ::testing::internal::CmpHelperEQFailure(remove_wrap_type_identity(lhs_expression).c_str(),
+                                                       remove_wrap_type_identity(rhs_expression).c_str(),
+                                                       seqan3::detail::type_name_as_string<lhs_t>,
+                                                       seqan3::detail::type_name_as_string<rhs_t>);
+    }
+};
+
+} // namespace seqan3::test

--- a/test/unit/test/CMakeLists.txt
+++ b/test/unit/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 seqan3_test(expect_range_eq_test.cpp)
+seqan3_test(expect_same_type_test.cpp)
 seqan3_test(pretty_printing_test.cpp)
 seqan3_test(seqan2_test.cpp)
 seqan3_test(sequence_generator_test.cpp)

--- a/test/unit/test/expect_same_type_test.cpp
+++ b/test/unit/test/expect_same_type_test.cpp
@@ -1,0 +1,181 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+#include <gtest/gtest-spi.h> // provides test utility to test google test itself
+
+#include <seqan3/test/expect_same_type.hpp>
+
+TEST(expect_same_type, braces_with_many_commas)
+{
+    EXPECT_SAME_TYPE(decltype(std::tuple<int, float>{}), (std::tuple<int, float>));
+    EXPECT_SAME_TYPE((decltype(std::tuple<int, float>{})), (std::tuple<int, float>));
+
+    EXPECT_SAME_TYPE((std::tuple<int, float>), decltype(std::tuple<int, float>{}));
+    EXPECT_SAME_TYPE((std::tuple<int, float>), (decltype(std::tuple<int, float>{})));
+}
+
+TEST(int, same_type_pass)
+{
+    auto && expect_result = seqan3::test::expect_same_type{}("std::type_identity< decltype(0)>{}",
+                                                             "std::type_identity< int>{}",
+                                                             std::type_identity<decltype(0)>{},
+                                                             std::type_identity<int>{});
+    EXPECT_TRUE(expect_result);
+    EXPECT_SAME_TYPE(decltype(0), int);
+}
+
+TEST(int, same_type_fail)
+{
+    char const * error_message = "Expected equality of these values:\n"
+                                 "  decltype(0)\n"
+                                 "    Which is: \"int\"\n"
+                                 "  unsigned\n"
+                                 "    Which is: \"unsigned int\"";
+
+    auto && expect_result = seqan3::test::expect_same_type{}("std::type_identity< decltype(0)>{}",
+                                                             "std::type_identity< unsigned>{}",
+                                                             std::type_identity<decltype(0)>{},
+                                                             std::type_identity<unsigned>{});
+    EXPECT_FALSE(expect_result);
+    EXPECT_STREQ(error_message, expect_result.message());
+    EXPECT_NONFATAL_FAILURE(EXPECT_SAME_TYPE(decltype(0), unsigned), error_message);
+
+    // with parentheses has the same output
+    EXPECT_NONFATAL_FAILURE(EXPECT_SAME_TYPE((decltype(0)), (unsigned)), error_message);
+}
+
+TEST(int_ref, same_type_pass)
+{
+    int a{};
+    int & i = a;
+    auto && expect_result = seqan3::test::expect_same_type{}("std::type_identity< decltype(i)>{}",
+                                                             "std::type_identity< int &>{}",
+                                                             std::type_identity<decltype(i)>{},
+                                                             std::type_identity<int &>{});
+    EXPECT_TRUE(expect_result);
+    EXPECT_SAME_TYPE(decltype(i), int &);
+}
+
+TEST(int_ref, same_type_fail)
+{
+    char const * error_message = "Expected equality of these values:\n"
+                                 "  decltype(i)\n"
+                                 "    Which is: \"int &\"\n"
+                                 "  unsigned &\n"
+                                 "    Which is: \"unsigned int &\"";
+
+    int a{};
+    int & i = a;
+    auto && expect_result = seqan3::test::expect_same_type{}("std::type_identity< decltype(i)>{}",
+                                                             "std::type_identity< unsigned &>{}",
+                                                             std::type_identity<decltype(i)>{},
+                                                             std::type_identity<unsigned &>{});
+    EXPECT_FALSE(expect_result);
+    EXPECT_STREQ(error_message, expect_result.message());
+    EXPECT_NONFATAL_FAILURE(EXPECT_SAME_TYPE(decltype(i), unsigned &), error_message);
+
+    // with parentheses has the same output
+    EXPECT_NONFATAL_FAILURE(EXPECT_SAME_TYPE((decltype(i)), (unsigned &)), error_message);
+}
+
+TEST(int_const_ref, same_type_pass)
+{
+    int const & i = 0;
+    auto && expect_result = seqan3::test::expect_same_type{}("std::type_identity< decltype(i)>{}",
+                                                             "std::type_identity< int const &>{}",
+                                                             std::type_identity<decltype(i)>{},
+                                                             std::type_identity<int const &>{});
+    EXPECT_TRUE(expect_result);
+    EXPECT_SAME_TYPE(decltype(i), int const &);
+}
+
+TEST(int_const_ref, same_type_fail)
+{
+    char const * error_message = "Expected equality of these values:\n"
+                                 "  decltype(i)\n"
+                                 "    Which is: \"int const &\"\n"
+                                 "  unsigned const &\n"
+                                 "    Which is: \"unsigned int const &\"";
+
+    int const & i = 0;
+    auto && expect_result = seqan3::test::expect_same_type{}("std::type_identity< decltype(i)>{}",
+                                                             "std::type_identity< unsigned const &>{}",
+                                                             std::type_identity<decltype(i)>{},
+                                                             std::type_identity<unsigned const &>{});
+    EXPECT_FALSE(expect_result);
+    EXPECT_STREQ(error_message, expect_result.message());
+    EXPECT_NONFATAL_FAILURE(EXPECT_SAME_TYPE(decltype(i), unsigned const &), error_message);
+
+    // with parentheses has the same output
+    EXPECT_NONFATAL_FAILURE(EXPECT_SAME_TYPE((decltype(i)), (unsigned const &)), error_message);
+}
+
+TEST(int_rvalue_ref, same_type_pass)
+{
+    int && i = 0;
+    auto && expect_result = seqan3::test::expect_same_type{}("std::type_identity< decltype(i)>{}",
+                                                             "std::type_identity< int &&>{}",
+                                                             std::type_identity<decltype(i)>{},
+                                                             std::type_identity<int &&>{});
+    EXPECT_TRUE(expect_result);
+    EXPECT_SAME_TYPE(decltype(i), int &&);
+}
+
+TEST(int_rvalue_ref, same_type_fail)
+{
+    char const * error_message = "Expected equality of these values:\n"
+                                 "  decltype(i)\n"
+                                 "    Which is: \"int &&\"\n"
+                                 "  unsigned &&\n"
+                                 "    Which is: \"unsigned int &&\"";
+
+    int && i = 0;
+    auto && expect_result = seqan3::test::expect_same_type{}("std::type_identity< decltype(i)>{}",
+                                                             "std::type_identity< unsigned &&>{}",
+                                                             std::type_identity<decltype(i)>{},
+                                                             std::type_identity<unsigned &&>{});
+    EXPECT_FALSE(expect_result);
+    EXPECT_STREQ(error_message, expect_result.message());
+    EXPECT_NONFATAL_FAILURE(EXPECT_SAME_TYPE(decltype(i), unsigned &&), error_message);
+
+    // with parentheses has the same output
+    EXPECT_NONFATAL_FAILURE(EXPECT_SAME_TYPE((decltype(i)), (unsigned &&)), error_message);
+}
+
+TEST(tuple, same_type_pass)
+{
+    auto && expect_result = seqan3::test::expect_same_type{}(
+        "std::type_identity< decltype(std::tuple{0, .0f, .0, 0u})>{}",
+        "std::type_identity< std::tuple<int, float, double, unsigned>>{}",
+        std::type_identity<decltype(std::tuple{0, .0f, .0, 0u})>{},
+        std::type_identity<std::tuple<int, float, double, unsigned>>{});
+
+    EXPECT_TRUE(expect_result);
+    EXPECT_SAME_TYPE(decltype(std::tuple{0, .0f, .0, 0u}), (std::tuple<int, float, double, unsigned>));
+}
+
+TEST(tuple, same_type_fail)
+{
+    char const * error_message = "Expected equality of these values:\n"
+                                 "  decltype(std::tuple{0, .0f, .0, 0u})\n"
+                                 "    Which is: \"std::tuple<int, float, double, unsigned int>\"\n"
+                                 "  std::tuple<int, float, unsigned, double>\n"
+                                 "    Which is: \"std::tuple<int, float, unsigned int, double>\"";
+
+    auto && expect_result = seqan3::test::expect_same_type{}(
+        "std::type_identity< decltype(std::tuple{0, .0f, .0, 0u})>{}",
+        "std::type_identity< std::tuple<int, float, unsigned, double>>{}",
+        std::type_identity<decltype(std::tuple{0, .0f, .0, 0u})>{},
+        std::type_identity<std::tuple<int, float, unsigned, double>>{});
+
+    EXPECT_FALSE(expect_result);
+    EXPECT_STREQ(error_message, expect_result.message());
+    EXPECT_NONFATAL_FAILURE(EXPECT_SAME_TYPE(decltype(std::tuple{0, .0f, .0, 0u}),
+                                             (std::tuple<int, float, unsigned, double>)),
+                            error_message);
+}


### PR DESCRIPTION
New EXPECT_SAME_TYPE test macro, see seqan/product_backlog#46

```c++
EXPECT_SAME_TYPE(int, float);
```

has the same semantic as writing

```c++
EXPECT_TRUE((std::same_as<int, float>))
```

but it will produce better diagnostics if the test failed:

```
Expected equality of these values:
  int
    Which is: "int"
  float
    Which is: "float"
```