### PR TITLE
[INFRA] Reduce benchmark set sizes in debug mode

### DIFF
--- a/test/performance/alignment/global_affine_alignment_simd_benchmark_template.hpp
+++ b/test/performance/alignment/global_affine_alignment_simd_benchmark_template.hpp
@@ -29,7 +29,7 @@
 // Globally defined constants to ensure same test data.
 inline constexpr size_t sequence_length = 150;
 #ifndef NDEBUG
-inline constexpr size_t set_size        = 128;
+inline constexpr size_t set_size        = 16;
 #else
 inline constexpr size_t set_size        = 1024;
 #endif // NDEBUG

--- a/test/performance/io/stream_input_benchmark.cpp
+++ b/test/performance/io/stream_input_benchmark.cpp
@@ -45,13 +45,19 @@
     #include <seqan/stream.h>
 #endif
 
+#ifndef NDEBUG
+inline constexpr size_t input_size = 10'000;
+#else
+inline constexpr size_t input_size = 10'000'000;
+#endif // NDEBUG
+
 std::string input
 {
     [] ()
     {
         std::string line{"The quick brown fox jumps over the lazy dog"};
         std::string ret;
-        for (size_t i = 0; i < 10'000'000; ++i)
+        for (size_t i = 0; i < input_size; ++i)
             ret += line;
         return ret;
     } ()

--- a/test/performance/search/index_construction_benchmark.cpp
+++ b/test/performance/search/index_construction_benchmark.cpp
@@ -25,7 +25,11 @@ static constexpr size_t seed{0x6126f};
 
 static void arguments(benchmark::internal::Benchmark * b)
 {
+#ifndef NDEBUG
+    for (int32_t length : {50, 5000})
+#else
     for (int32_t length : {50, 5000, 50'000})
+#endif  // NDEBUG
     {
         if (length > max_length)
             throw std::logic_error{"Increase max_length to at least " + std::to_string(length)};

--- a/test/performance/search/search_benchmark.cpp
+++ b/test/performance/search/search_benchmark.cpp
@@ -287,86 +287,96 @@ void bidirectional_search_stratified(benchmark::State & state, options && o)
     benchmark::DoNotOptimize(sum);
 }
 
+#ifndef NDEBUG
+inline constexpr size_t small_size = 1'000;
+inline constexpr size_t medium_size = 5'000;
+inline constexpr size_t big_size = 10'000;
+#else
+inline constexpr size_t small_size = 10'000;
+inline constexpr size_t medium_size = 50'000;
+inline constexpr size_t big_size = 100'000;
+#endif // NDEBUG
+
 BENCHMARK_CAPTURE(unidirectional_search_all_collection, highErrorReadsSearch0,
-                  options{10'000, false, 10, 50, 0.18, 0.18, 0, 0, 0, 1.75});
+                  options{small_size, false, 10, 50, 0.18, 0.18, 0, 0, 0, 1.75});
 BENCHMARK_CAPTURE(unidirectional_search_all_collection, highErrorReadsSearch1,
-                  options{10'000, false, 10, 50, 0.18, 0.18, 0, 1, 0, 1.75});
+                  options{small_size, false, 10, 50, 0.18, 0.18, 0, 1, 0, 1.75});
 BENCHMARK_CAPTURE(unidirectional_search_all_collection, highErrorReadsSearch2,
-                  options{10'000, false, 10, 50, 0.18, 0.18, 0, 2, 0, 1.75});
+                  options{small_size, false, 10, 50, 0.18, 0.18, 0, 2, 0, 1.75});
 BENCHMARK_CAPTURE(unidirectional_search_all_collection, highErrorReadsSearch3,
-                  options{10'000, false, 10, 50, 0.18, 0.18, 0, 3, 0, 1.75});
+                  options{small_size, false, 10, 50, 0.18, 0.18, 0, 3, 0, 1.75});
 
 BENCHMARK_CAPTURE(unidirectional_search_all, lowErrorReadsSearch3,
-                  options{100'000, false, 50, 50, 0.18, 0.18, 0, 3, 0, 1});
+                  options{big_size, false, 50, 50, 0.18, 0.18, 0, 3, 0, 1});
 BENCHMARK_CAPTURE(unidirectional_search_all, highErrorReadsSearch0,
-                  options{100'000, false, 50, 50, 0.18, 0.18, 0, 0, 0, 1.75});
+                  options{big_size, false, 50, 50, 0.18, 0.18, 0, 0, 0, 1.75});
 BENCHMARK_CAPTURE(unidirectional_search_all, highErrorReadsSearch1,
-                  options{100'000, false, 50, 50, 0.18, 0.18, 0, 1, 1, 1.75});
+                  options{big_size, false, 50, 50, 0.18, 0.18, 0, 1, 1, 1.75});
 BENCHMARK_CAPTURE(unidirectional_search_all, highErrorReadsSearch2,
-                  options{100'000, false, 50, 50, 0.18, 0.18, 0, 2, 2, 1.75});
+                  options{big_size, false, 50, 50, 0.18, 0.18, 0, 2, 2, 1.75});
 BENCHMARK_CAPTURE(unidirectional_search_all, highErrorReadsSearch3,
-                  options{100'000, false, 50, 50, 0.18, 0.18, 0, 3, 3, 1.75});
+                  options{big_size, false, 50, 50, 0.18, 0.18, 0, 3, 3, 1.75});
 BENCHMARK_CAPTURE(unidirectional_search_all, highErrorReadsSearch0Rep,
-                  options{100'000, true, 50, 50, 0.18, 0.18, 0, 0, 0, 1.75});
+                  options{big_size, true, 50, 50, 0.18, 0.18, 0, 0, 0, 1.75});
 BENCHMARK_CAPTURE(unidirectional_search_all, highErrorReadsSearch1Rep,
-                  options{100'000, true, 50, 50, 0.18, 0.18, 0, 1, 1, 1.75});
+                  options{big_size, true, 50, 50, 0.18, 0.18, 0, 1, 1, 1.75});
 BENCHMARK_CAPTURE(unidirectional_search_all, highErrorReadsSearch2Rep,
-                  options{100'000, true, 50, 50, 0.18, 0.18, 0, 2, 2, 1.75});
+                  options{big_size, true, 50, 50, 0.18, 0.18, 0, 2, 2, 1.75});
 BENCHMARK_CAPTURE(unidirectional_search_all, highErrorReadsSearch3Rep,
-                  options{100'000, true, 50, 50, 0.18, 0.18, 0, 3, 3, 1.75});
+                  options{big_size, true, 50, 50, 0.18, 0.18, 0, 3, 3, 1.75});
 BENCHMARK_CAPTURE(unidirectional_search_all, highErrorReadsSearch3Rep,
-                  options{100'000, true, 50, 50, 0.30, 0.30, 0, 3, 3, 1.75});
+                  options{big_size, true, 50, 50, 0.30, 0.30, 0, 3, 3, 1.75});
 
 BENCHMARK_CAPTURE(bidirectional_search_all, lowErrorReadsSearch3,
-                  options{100'000, false, 50, 50, 0.18, 0.18, 0, 3, 0, 1});
+                  options{big_size, false, 50, 50, 0.18, 0.18, 0, 3, 0, 1});
 BENCHMARK_CAPTURE(bidirectional_search_all, highErrorReadsSearch0,
-                  options{100'000, false, 50, 50, 0.18, 0.18, 0, 0, 0, 1.75});
+                  options{big_size, false, 50, 50, 0.18, 0.18, 0, 0, 0, 1.75});
 BENCHMARK_CAPTURE(bidirectional_search_all, highErrorReadsSearch1,
-                  options{100'000, false, 50, 50, 0.18, 0.18, 0, 1, 1, 1.75});
+                  options{big_size, false, 50, 50, 0.18, 0.18, 0, 1, 1, 1.75});
 BENCHMARK_CAPTURE(bidirectional_search_all, highErrorReadsSearch2,
-                  options{100'000, false, 50, 50, 0.18, 0.18, 0, 2, 2, 1.75});
+                  options{big_size, false, 50, 50, 0.18, 0.18, 0, 2, 2, 1.75});
 BENCHMARK_CAPTURE(bidirectional_search_all, highErrorReadsSearch3,
-                  options{100'000, false, 50, 50, 0.18, 0.18, 0, 3, 3, 1.75});
+                  options{big_size, false, 50, 50, 0.18, 0.18, 0, 3, 3, 1.75});
 BENCHMARK_CAPTURE(bidirectional_search_all, highErrorReadsSearch0Rep,
-                  options{100'000, true, 50, 50, 0.18, 0.18, 0, 0, 0, 1.75});
+                  options{big_size, true, 50, 50, 0.18, 0.18, 0, 0, 0, 1.75});
 BENCHMARK_CAPTURE(bidirectional_search_all, highErrorReadsSearch1Rep,
-                  options{100'000, true, 50, 50, 0.18, 0.18, 0, 1, 1, 1.75});
+                  options{big_size, true, 50, 50, 0.18, 0.18, 0, 1, 1, 1.75});
 BENCHMARK_CAPTURE(bidirectional_search_all, highErrorReadsSearch2Rep,
-                  options{100'000, true, 50, 50, 0.18, 0.18, 0, 2, 2, 1.75});
+                  options{big_size, true, 50, 50, 0.18, 0.18, 0, 2, 2, 1.75});
 BENCHMARK_CAPTURE(bidirectional_search_all, highErrorReadsSearch3Rep,
-                  options{100'000, true, 50, 50, 0.18, 0.18, 0, 3, 3, 1.75});
+                  options{big_size, true, 50, 50, 0.18, 0.18, 0, 3, 3, 1.75});
 BENCHMARK_CAPTURE(bidirectional_search_all, highErrorReadsSearch3Rep,
-                  options{100'000, true, 50, 50, 0.30, 0.30, 0, 3, 3, 1.75});
+                  options{big_size, true, 50, 50, 0.30, 0.30, 0, 3, 3, 1.75});
 
 BENCHMARK_CAPTURE(unidirectional_search_stratified, lowErrorReadsSearch3Strata0Rep,
-                  options{50'000, true, 50, 50, 0.18, 0.18, 0, 3, 0, 1});
+                  options{medium_size, true, 50, 50, 0.18, 0.18, 0, 3, 0, 1});
 BENCHMARK_CAPTURE(unidirectional_search_stratified, lowErrorReadsSearch3Strata1Rep,
-                  options{50'000, true, 50, 50, 0.18, 0.18, 0, 3, 1, 1});
+                  options{medium_size, true, 50, 50, 0.18, 0.18, 0, 3, 1, 1});
 BENCHMARK_CAPTURE(unidirectional_search_stratified, lowErrorReadsSearch3Strata2Rep,
-                  options{50'000, true, 50, 50, 0.18, 0.18, 0, 3, 2, 1});
+                  options{medium_size, true, 50, 50, 0.18, 0.18, 0, 3, 2, 1});
 BENCHMARK_CAPTURE(unidirectional_search_stratified, highErrorReadsSearch3Strata0Rep,
-                  options{50'000, true, 50, 50, 0.30, 0.30, 0, 3, 0, 1.75});
+                  options{medium_size, true, 50, 50, 0.30, 0.30, 0, 3, 0, 1.75});
 BENCHMARK_CAPTURE(unidirectional_search_stratified, highErrorReadsSearch3Strata1Rep,
-                  options{50'000, true, 50, 50, 0.30, 0.30, 0, 3, 1, 1.75});
+                  options{medium_size, true, 50, 50, 0.30, 0.30, 0, 3, 1, 1.75});
 BENCHMARK_CAPTURE(unidirectional_search_stratified, highErrorReadsSearch3Strata2Rep,
-                  options{50'000, true, 50, 50, 0.30, 0.30, 0, 3, 2, 1.75});
+                  options{medium_size, true, 50, 50, 0.30, 0.30, 0, 3, 2, 1.75});
 BENCHMARK_CAPTURE(unidirectional_search_stratified, highErrorReadsSearch3Strata2RepLong,
-                  options{100'000, true, 50, 50, 0.30, 0.30, 0, 3, 2, 1.75});
+                  options{big_size, true, 50, 50, 0.30, 0.30, 0, 3, 2, 1.75});
 
 BENCHMARK_CAPTURE(bidirectional_search_stratified, lowErrorReadsSearch3Strata0Rep,
-                  options{50'000, true, 50, 50, 0.18, 0.18, 0, 3, 0, 1});
+                  options{medium_size, true, 50, 50, 0.18, 0.18, 0, 3, 0, 1});
 BENCHMARK_CAPTURE(bidirectional_search_stratified, lowErrorReadsSearch3Strata1Rep,
-                  options{50'000, true, 50, 50, 0.18, 0.18, 0, 3, 1, 1});
+                  options{medium_size, true, 50, 50, 0.18, 0.18, 0, 3, 1, 1});
 BENCHMARK_CAPTURE(bidirectional_search_stratified, lowErrorReadsSearch3Strata2Rep,
-                  options{50'000, true, 50, 50, 0.18, 0.18, 0, 3, 2, 1});
+                  options{medium_size, true, 50, 50, 0.18, 0.18, 0, 3, 2, 1});
 BENCHMARK_CAPTURE(bidirectional_search_stratified, highErrorReadsSearch3Strata0Rep,
-                  options{50'000, true, 50, 50, 0.30, 0.30, 0, 3, 0, 1.75});
+                  options{medium_size, true, 50, 50, 0.30, 0.30, 0, 3, 0, 1.75});
 BENCHMARK_CAPTURE(bidirectional_search_stratified, highErrorReadsSearch3Strata1Rep,
-                  options{50'000, true, 50, 50, 0.30, 0.30, 0, 3, 1, 1.75});
+                  options{medium_size, true, 50, 50, 0.30, 0.30, 0, 3, 1, 1.75});
 BENCHMARK_CAPTURE(bidirectional_search_stratified, highErrorReadsSearch3Strata2Rep,
-                  options{50'000, true, 50, 50, 0.30, 0.30, 0, 3, 2, 1.75});
+                  options{medium_size, true, 50, 50, 0.30, 0.30, 0, 3, 2, 1.75});
 BENCHMARK_CAPTURE(bidirectional_search_stratified, highErrorReadsSearch3Strata2RepLong,
-                  options{100'000, true, 50, 50, 0.30, 0.30, 0, 3, 2, 1.75});
+                  options{big_size, true, 50, 50, 0.30, 0.30, 0, 3, 2, 1.75});
 
 // ============================================================================
 //  instantiate tests


### PR DESCRIPTION
This reduces the set sizes in debug mode and will prevent timeouts in the nightlies.

There does not seem to be a performance regression between 3.0.2 and now, this might have to do something with the new way of fetching google benchmark and propagating our build flags?