### PR TITLE
[FIX] Renaming [...]_specialisation concepts

### DIFF
--- a/include/seqan3/alphabet/composite/alphabet_tuple_base.hpp
+++ b/include/seqan3/alphabet/composite/alphabet_tuple_base.hpp
@@ -303,7 +303,7 @@ public:
                                                        meta::list<>>...>;
     //!\brief Make specialisations of this template identifiable in metapgrogramming contexts.
     //!\private
-    static constexpr bool seqan3_alphabet_tuple_base_specialisation = true;
+    static constexpr bool seqan3_alphabet_tuple_like = true;
 
     /*!\name Constructors, destructor and assignment
      * \{
@@ -742,7 +742,7 @@ namespace std
  * \ingroup composite
  * \see [std::tuple_element](https://en.cppreference.com/w/cpp/utility/tuple/tuple_element)
  */
-template <std::size_t i, seqan3::detail::alphabet_tuple_base_specialisation tuple_t>
+template <std::size_t i, seqan3::detail::alphabet_tuple_like tuple_t>
 struct tuple_element<i, tuple_t>
 {
     //!\brief Element type.
@@ -754,7 +754,7 @@ struct tuple_element<i, tuple_t>
  * \ingroup composite
  * \see std::tuple_size_v
  */
-template <seqan3::detail::alphabet_tuple_base_specialisation tuple_t>
+template <seqan3::detail::alphabet_tuple_like tuple_t>
 struct tuple_size<tuple_t> :
     public std::integral_constant<size_t, seqan3::list_traits::size<typename tuple_t::seqan3_required_types>>
 {};

--- a/include/seqan3/alphabet/composite/detail.hpp
+++ b/include/seqan3/alphabet/composite/detail.hpp
@@ -21,10 +21,10 @@ namespace seqan3::detail
 {
 
 // ------------------------------------------------------------------
-// alphabet_tuple_base_specialisation
+// alphabet_tuple_like
 // ------------------------------------------------------------------
 
-/*!\interface seqan3::detail::alphabet_tuple_base_specialisation <>
+/*!\interface seqan3::detail::alphabet_tuple_like <>
  * \brief seqan3::alphabet_tuple_base and its derivates model this concept.
  * \ingroup composite
  *
@@ -35,9 +35,9 @@ namespace seqan3::detail
  */
 //!\cond
 template <typename t>
-SEQAN3_CONCEPT alphabet_tuple_base_specialisation = requires
+SEQAN3_CONCEPT alphabet_tuple_like = requires
 {
-    requires t::seqan3_alphabet_tuple_base_specialisation;
+    requires t::seqan3_alphabet_tuple_like;
 };
 //!\endcond
 

--- a/include/seqan3/core/configuration/all.hpp
+++ b/include/seqan3/core/configuration/all.hpp
@@ -19,7 +19,7 @@
  * ### Usage
  *
  * The basis of any algorithm configuration are configuration elements. These are objects that handle a specific
- * setting and must satisfy the seqan3::detail::config_element_specialisation. The following snippet demonstrates a
+ * setting and must satisfy the seqan3::detail::config_element. The following snippet demonstrates a
  * basic setup for such configuration elements.
  *
  * \include test/snippet/core/configuration/configuration_setup.cpp

--- a/include/seqan3/core/configuration/configuration.hpp
+++ b/include/seqan3/core/configuration/configuration.hpp
@@ -26,7 +26,7 @@ namespace seqan3
 
 //!\cond
 // Forward declaration for friend declaration definitions below.
-template <detail::config_element_specialisation ... configs_t>
+template <detail::config_element ... configs_t>
 class configuration;
 
 template <typename lhs_derived_t, typename lhs_value_t, typename rhs_derived_t, typename rhs_value_t>
@@ -66,7 +66,7 @@ constexpr auto operator|(pipeable_config_element<lhs_derived_t, lhs_value_t> con
  * \ingroup algorithm
  *
  * \tparam configs_t Template parameter pack containing all configuration elements; Must model
- *                   seqan3::detail::config_element_specialisation
+ *                   seqan3::detail::config_element
  *
  * \details
  *
@@ -74,11 +74,11 @@ constexpr auto operator|(pipeable_config_element<lhs_derived_t, lhs_value_t> con
  * configurations for a specific algorithm. It extends the standard tuple interface with some useful functions to modify
  * and query the user configurations.
  */
-template <detail::config_element_specialisation ... configs_t>
+template <detail::config_element ... configs_t>
 class configuration : public std::tuple<configs_t...>
 {
     //!\brief Friend declaration for other instances of the configuration.
-    template <detail::config_element_specialisation ... _configs_t>
+    template <detail::config_element ... _configs_t>
     friend class configuration;
 
 public:
@@ -99,13 +99,13 @@ public:
 
     /*!\brief Constructs a configuration from a single configuration element.
      * \tparam config_element_t The configuration element to add; must model
-     *                          seqan3::detail::config_element_specialisation.
+     *                          seqan3::detail::config_element.
      * \param[in] config_element The configuration element to construct the configuration from.
      */
     template <typename config_element_t>
     //!\cond
         requires (!std::same_as<std::remove_cvref_t<config_element_t>, configuration>) &&
-                 detail::config_element_specialisation<std::remove_cvref_t<config_element_t>>
+                 detail::config_element<std::remove_cvref_t<config_element_t>>
     //!\endcond
     constexpr configuration(config_element_t && config_element) :
         base_type{std::forward<config_element_t>(config_element)}
@@ -464,7 +464,7 @@ private:
      *
      * Strong exception guarantee.
      */
-    template <detail::config_element_specialisation config_element_t>
+    template <detail::config_element config_element_t>
     constexpr auto push_back(config_element_t elem) const &
     {
         static_assert(detail::is_configuration_valid_v<std::remove_cvref_t<config_element_t>,
@@ -478,7 +478,7 @@ private:
     }
 
     //!\copydoc push_back
-    template <detail::config_element_specialisation config_element_t>
+    template <detail::config_element config_element_t>
     constexpr auto push_back(config_element_t elem) &&
     {
         static_assert(detail::is_configuration_valid_v<std::remove_cvref_t<config_element_t>,
@@ -567,7 +567,7 @@ private:
 /*!\brief Deduces the correct configuration element type from the passed seqan3::pipeable_config_element.
  * \relates seqan3::configuration
  */
-template <detail::config_element_specialisation config_t>
+template <detail::config_element config_t>
 configuration(config_t) -> configuration<config_t>;
 //!\}
 
@@ -655,7 +655,7 @@ namespace std
  * \see std::tuple_size_v
  * \ingroup algorithm
  */
-template <seqan3::detail::config_element_specialisation ... configs_t>
+template <seqan3::detail::config_element ... configs_t>
 struct tuple_size<seqan3::configuration<configs_t...>>
 {
     //!\brief The number of elements.
@@ -667,7 +667,7 @@ struct tuple_size<seqan3::configuration<configs_t...>>
  * \see [std::tuple_element](https://en.cppreference.com/w/cpp/utility/tuple/tuple_element)
  * \ingroup algorithm
  */
-template <size_t pos, seqan3::detail::config_element_specialisation ... configs_t>
+template <size_t pos, seqan3::detail::config_element ... configs_t>
 struct tuple_element<pos, seqan3::configuration<configs_t...>>
 {
     //!\brief The type of the config at position `pos`

--- a/include/seqan3/core/configuration/detail/concept.hpp
+++ b/include/seqan3/core/configuration/detail/concept.hpp
@@ -45,7 +45,7 @@ template <typename algorithm_id_type>
 inline constexpr std::array<std::array<void, 0>, 0> compatibility_table;
 
 // ----------------------------------------------------------------------------
-// Concept config_element_specialisation
+// Concept config_element
 // ----------------------------------------------------------------------------
 
 #ifdef SEQAN3_WORKAROUND_GCC_PIPEABLE_CONFIG_CONCEPT
@@ -82,7 +82,7 @@ public:
 };
 #endif // SEQAN3_WORKAROUND_GCC_PIPEABLE_CONFIG_CONCEPT
 
-/*!\interface seqan3::detail::config_element_specialisation <>
+/*!\interface seqan3::detail::config_element <>
  * \brief Concept for an algorithm configuration element.
  * \ingroup algorithm
  *
@@ -90,9 +90,9 @@ public:
  * \implements seqan3::pipeable_config_element
  */
 
-/*!\name Requirements for seqan3::detail::config_element_specialisation
- * \relates seqan3::detail::config_element_specialisation
- * \brief   You can expect this member on all types that satisfy seqan3::detail::config_element_specialisation.
+/*!\name Requirements for seqan3::detail::config_element
+ * \relates seqan3::detail::config_element
+ * \brief   You can expect this member on all types that satisfy seqan3::detail::config_element.
  * \{
  */
 /*!\var id
@@ -101,7 +101,7 @@ public:
 //!\}
 //!\cond
 template <typename config_t>
-SEQAN3_CONCEPT config_element_specialisation = requires
+SEQAN3_CONCEPT config_element = requires
 {
     requires std::is_base_of_v<seqan3::pipeable_config_element<config_t>, config_t>;
     requires std::semiregular<config_t>;

--- a/include/seqan3/core/configuration/detail/configuration_utility.hpp
+++ b/include/seqan3/core/configuration/detail/configuration_utility.hpp
@@ -38,7 +38,7 @@ namespace seqan3::detail
  * Checks if the type is from the same algorithm configuration and if it can be combined with any of the
  * existing elements in the current configuration.
  */
-template <config_element_specialisation query_t, config_element_specialisation ... compare_types>
+template <config_element query_t, config_element ... compare_types>
 struct is_configuration_valid :
     public std::conditional_t<
         (std::is_same_v<std::remove_cvref_t<decltype(query_t::id)>, std::remove_cvref_t<decltype(compare_types::id)>> && ...) &&

--- a/include/seqan3/core/detail/strong_type.hpp
+++ b/include/seqan3/core/detail/strong_type.hpp
@@ -74,26 +74,26 @@ class strong_type;
 //!\endcond
 
 //------------------------------------------------------------------------------
-// concept strong_type_specialisation
+// concept derived_from_strong_type
 //------------------------------------------------------------------------------
 
-/*!\interface seqan3::detail::strong_type_specialisation <>
+/*!\interface seqan3::detail::derived_from_strong_type <>
  * \brief Defines the requirements of a seqan::detail::strong_type specialisation.
  * \tparam strong_type_t The type the concept check is performed on (the putative strong type).
  * \ingroup core
  */
-/*!\name Requirements for seqan3::detail::strong_type_specialisation
- * \brief You can expect these members on all types that implement seqan3::detail::strong_type_specialisation.
- * \relates seqan3::detail::strong_type_specialisation
+/*!\name Requirements for seqan3::detail::derived_from_strong_type
+ * \brief You can expect these members on all types that implement seqan3::detail::derived_from_strong_type.
+ * \relates seqan3::detail::derived_from_strong_type
  *
  * \details
  *
- * A type that implements strong_type_specialisation must be a derived class of seqan3::detail::strong_type.
+ * A type that implements derived_from_strong_type must be a derived class of seqan3::detail::strong_type.
  * \{
  */
 //!\cond
 template <typename strong_type_t>
-SEQAN3_CONCEPT strong_type_specialisation = requires (strong_type_t && obj)
+SEQAN3_CONCEPT derived_from_strong_type = requires (strong_type_t && obj)
 {
 //!\endcond
 
@@ -511,7 +511,7 @@ private:
 
 /*!\brief Formatted output to a seqan3::detail::debug_stream_type.
  * \tparam char_t The char type of the seqan3::detail::debug_stream_type.
- * \tparam strong_type_t The strong type to print; must model seqan3::detail::strong_type_specialisation.
+ * \tparam strong_type_t The strong type to print; must model seqan3::detail::derived_from_strong_type.
  *
  * \param[in,out] stream The output stream.
  * \param[in] value The strong typed value to print.
@@ -522,7 +522,7 @@ private:
  *
  * \returns `stream_t &` A reference to the given stream.
  */
-template <typename char_t, strong_type_specialisation strong_type_t>
+template <typename char_t, derived_from_strong_type strong_type_t>
 debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & stream, strong_type_t && value)
 {
     stream << value.get();

--- a/test/unit/alignment/configuration/align_config_band_test.cpp
+++ b/test/unit/alignment/configuration/align_config_band_test.cpp
@@ -18,9 +18,9 @@ using test_types = ::testing::Types<seqan3::align_cfg::band_fixed_size>;
 
 INSTANTIATE_TYPED_TEST_SUITE_P(band_elements, pipeable_config_element_test, test_types, );
 
-TEST(band_fixed_size, config_element_specialisation)
+TEST(band_fixed_size, config_element)
 {
-    EXPECT_TRUE((seqan3::detail::config_element_specialisation<seqan3::align_cfg::band_fixed_size>));
+    EXPECT_TRUE((seqan3::detail::config_element<seqan3::align_cfg::band_fixed_size>));
 }
 
 TEST(band_fixed_size, construct)

--- a/test/unit/alignment/configuration/align_config_common_test.cpp
+++ b/test/unit/alignment/configuration/align_config_common_test.cpp
@@ -63,9 +63,9 @@ TEST(alignment_configuration_test, number_of_configs)
     EXPECT_EQ(static_cast<uint8_t>(seqan3::detail::align_config_id::SIZE), 18);
 }
 
-TYPED_TEST(alignment_configuration_test, config_element_specialisation)
+TYPED_TEST(alignment_configuration_test, config_element)
 {
-    EXPECT_TRUE((seqan3::detail::config_element_specialisation<TypeParam>));
+    EXPECT_TRUE((seqan3::detail::config_element<TypeParam>));
 }
 
 TYPED_TEST(alignment_configuration_test, configuration_exists)

--- a/test/unit/alignment/configuration/align_config_gap_cost_affine_test.cpp
+++ b/test/unit/alignment/configuration/align_config_gap_cost_affine_test.cpp
@@ -12,9 +12,9 @@
 #include <seqan3/alignment/configuration/align_config_gap_cost_affine.hpp>
 #include <seqan3/core/configuration/configuration.hpp>
 
-TEST(align_config_gap, config_element_specialisation)
+TEST(align_config_gap, config_element)
 {
-    EXPECT_TRUE((seqan3::detail::config_element_specialisation<seqan3::align_cfg::gap_cost_affine>));
+    EXPECT_TRUE((seqan3::detail::config_element<seqan3::align_cfg::gap_cost_affine>));
 }
 
 TEST(align_config_gap, configuration)

--- a/test/unit/alignment/configuration/align_config_min_score_test.cpp
+++ b/test/unit/alignment/configuration/align_config_min_score_test.cpp
@@ -13,9 +13,9 @@
 #include <seqan3/alignment/configuration/align_config_min_score.hpp>
 #include <seqan3/core/configuration/configuration.hpp>
 
-TEST(align_config_min_score, config_element_specialisation)
+TEST(align_config_min_score, config_element)
 {
-    EXPECT_TRUE((seqan3::detail::config_element_specialisation<seqan3::align_cfg::min_score>));
+    EXPECT_TRUE((seqan3::detail::config_element<seqan3::align_cfg::min_score>));
 }
 
 TEST(align_config_min_score, configuration)

--- a/test/unit/alignment/configuration/align_config_parallel_test.cpp
+++ b/test/unit/alignment/configuration/align_config_parallel_test.cpp
@@ -27,9 +27,9 @@ INSTANTIATE_TYPED_TEST_SUITE_P(parallel_elements, pipeable_config_element_test, 
 // individual tests
 // ---------------------------------------------------------------------------------------------------------------------
 
-TEST(align_config_parallel, config_element_specialisation)
+TEST(align_config_parallel, config_element)
 {
-    EXPECT_TRUE((seqan3::detail::config_element_specialisation<seqan3::align_cfg::parallel>));
+    EXPECT_TRUE((seqan3::detail::config_element<seqan3::align_cfg::parallel>));
 }
 
 TEST(align_config_parallel, configuration)

--- a/test/unit/alignment/configuration/align_config_scoring_scheme_test.cpp
+++ b/test/unit/alignment/configuration/align_config_scoring_scheme_test.cpp
@@ -27,10 +27,10 @@ using test_types = ::testing::Types<std::tuple<seqan3::aminoacid_scoring_scheme<
                                     std::tuple<seqan3::nucleotide_scoring_scheme<int8_t>, seqan3::dna15>>;
 TYPED_TEST_SUITE(align_config_scoring_scheme_test, test_types, );
 
-TYPED_TEST(align_config_scoring_scheme_test, config_element_specialisation)
+TYPED_TEST(align_config_scoring_scheme_test, config_element)
 {
     using scheme_t = typename TestFixture::scheme_t;
-    EXPECT_TRUE((seqan3::detail::config_element_specialisation<seqan3::align_cfg::scoring_scheme<scheme_t>>));
+    EXPECT_TRUE((seqan3::detail::config_element<seqan3::align_cfg::scoring_scheme<scheme_t>>));
 }
 
 TYPED_TEST(align_config_scoring_scheme_test, configuration)

--- a/test/unit/core/algorithm/pipeable_config_element_test_template.hpp
+++ b/test/unit/core/algorithm/pipeable_config_element_test_template.hpp
@@ -24,7 +24,7 @@ TYPED_TEST_SUITE_P(pipeable_config_element_test);
 
 TYPED_TEST_P(pipeable_config_element_test, concept_check)
 {
-    EXPECT_TRUE((seqan3::detail::config_element_specialisation<TypeParam>));
+    EXPECT_TRUE((seqan3::detail::config_element<TypeParam>));
 }
 
 TYPED_TEST_P(pipeable_config_element_test, standard_construction)

--- a/test/unit/core/configuration/configuration_test.cpp
+++ b/test/unit/core/configuration/configuration_test.cpp
@@ -16,8 +16,8 @@
 
 TEST(configuration, concept_check)
 {
-    EXPECT_TRUE(seqan3::detail::config_element_specialisation<bar>);
-    EXPECT_FALSE(seqan3::detail::config_element_specialisation<int>);
+    EXPECT_TRUE(seqan3::detail::config_element<bar>);
+    EXPECT_FALSE(seqan3::detail::config_element<int>);
 
     EXPECT_TRUE((seqan3::tuple_like<seqan3::configuration<bax, bar>>));
 }

--- a/test/unit/core/detail/strong_type_test.cpp
+++ b/test/unit/core/detail/strong_type_test.cpp
@@ -101,10 +101,10 @@ struct multi_skill_type : seqan3::detail::strong_type<int,
 
 TEST(strong_type, concept)
 {
-    EXPECT_TRUE(seqan3::detail::strong_type_specialisation<pure_type &>);
-    EXPECT_TRUE(seqan3::detail::strong_type_specialisation<pure_type const &>);
-    EXPECT_TRUE(seqan3::detail::strong_type_specialisation<pure_type &&>);
-    EXPECT_TRUE(seqan3::detail::strong_type_specialisation<pure_type const &&>);
+    EXPECT_TRUE(seqan3::detail::derived_from_strong_type<pure_type &>);
+    EXPECT_TRUE(seqan3::detail::derived_from_strong_type<pure_type const &>);
+    EXPECT_TRUE(seqan3::detail::derived_from_strong_type<pure_type &&>);
+    EXPECT_TRUE(seqan3::detail::derived_from_strong_type<pure_type const &&>);
 }
 
 TEST(strong_type, pure_type)

--- a/test/unit/search/configuration/parallel_test.cpp
+++ b/test/unit/search/configuration/parallel_test.cpp
@@ -44,9 +44,9 @@ TEST(search_config_parallel, member_variable)
     }
 }
 
-TEST(search_config_parallel, config_element_specialisation)
+TEST(search_config_parallel, config_element)
 {
-    EXPECT_TRUE((seqan3::detail::config_element_specialisation<seqan3::search_cfg::parallel>));
+    EXPECT_TRUE((seqan3::detail::config_element<seqan3::search_cfg::parallel>));
 }
 
 TEST(search_config_parallel, configuration)

--- a/test/unit/search/search_configuration_test.cpp
+++ b/test/unit/search/search_configuration_test.cpp
@@ -62,9 +62,9 @@ TEST(search_configuration_test, symmetric_configuration)
     }
 }
 
-TYPED_TEST(search_configuration_test, config_element_specialisation)
+TYPED_TEST(search_configuration_test, config_element)
 {
-    EXPECT_TRUE((seqan3::detail::config_element_specialisation<TypeParam>));
+    EXPECT_TRUE((seqan3::detail::config_element<TypeParam>));
 }
 
 TYPED_TEST(search_configuration_test, configuration_exists)


### PR DESCRIPTION
This PR is part of [seqan/product_backlog/issues/259](https://github.com/seqan/product_backlog/issues/259)

- Renames strong_type_specialisation to derived_from_strong_type
- Renames config_element_specialisation to config_element
- Renames alphabet_tuple_base_specialisation to alphabet_tuple_like