### PR TITLE
Factor out bold formatting of help page export into separate function.

### DIFF
--- a/include/seqan3/argument_parser/detail/format_help.hpp
+++ b/include/seqan3/argument_parser/detail/format_help.hpp
@@ -138,9 +138,9 @@ protected:
     void print_subsection(std::string const & title)
     {
         std::ostream_iterator<char> out(std::cout);
-        std::cout << '\n' << to_text("\\fB");
+        std::cout << '\n';
         std::fill_n(out, layout.leftPadding / 2, ' ');
-        std::cout << title << to_text("\\fP") << '\n';
+        std::cout << in_bold(title) << '\n';
         prev_was_paragraph = false;
     }
 
@@ -202,18 +202,18 @@ protected:
         std::ostream_iterator<char> out(std::cout);
 
         // Print version, date and url.
-        std::cout << "\n" << to_text("\\fB") << "VERSION" << to_text("\\fP") << "\n";
+        std::cout << "\n" << in_bold("VERSION") << "\n";
         std::fill_n(out, layout.leftPadding, ' ');
-        std::cout << to_text("\\fB") << "Last update: " << to_text("\\fP") << meta.date << "\n";
+        std::cout << in_bold("Last update: ") << meta.date << "\n";
         std::fill_n(out, layout.leftPadding, ' ');
-        std::cout << to_text("\\fB") << meta.app_name << " version: " << to_text("\\fP") << meta.version << "\n";
+        std::cout << in_bold(meta.app_name + " version: ") << meta.version << "\n";
         std::fill_n(out, layout.leftPadding, ' ');
-        std::cout << to_text("\\fB") << "SeqAn version: " << to_text("\\fP") << SEQAN3_VERSION_MAJOR << '.'
+        std::cout << in_bold("SeqAn version: ") << SEQAN3_VERSION_MAJOR << '.'
                   <<  SEQAN3_VERSION_MINOR << '.' << SEQAN3_VERSION_PATCH;
 
         if (!empty(meta.url))
         {
-            std::cout <<  "\n" << to_text("\\fB") << "URL" << to_text("\\fP") << "\n";
+            std::cout << "\n" << in_bold("URL") << "\n";
             std::fill_n(out, layout.leftPadding, ' ');
             std::cout << meta.url << "\n";
         }
@@ -230,28 +230,25 @@ protected:
         // Print legal stuff
         if ((!empty(meta.short_copyright)) || (!empty(meta.long_copyright)) || (!empty(meta.citation)))
         {
-            std::cout << "\n" << to_text("\\fB") << "LEGAL" << to_text("\\fP") << "\n";
+            std::cout << "\n" << in_bold("LEGAL") << "\n";
 
             if (!empty(meta.short_copyright))
             {
                 std::fill_n(out, layout.leftPadding, ' ');
-                std::cout << to_text("\\fB") << meta.app_name << " Copyright: "
-                          << to_text("\\fP") << meta.short_copyright << "\n";
+                std::cout << in_bold(meta.app_name + " Copyright: ") << meta.short_copyright << "\n";
             }
             std::fill_n(out, layout.leftPadding, ' ');
-            std::cout << to_text("\\fB") << "SeqAn Copyright: " << to_text("\\fP")
+            std::cout << in_bold("SeqAn Copyright: ")
                       << "2006-2015 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.\n";
             if (!empty(meta.citation))
             {
                 std::fill_n(out, layout.leftPadding, ' ');
-                std::cout << to_text("\\fB") << "In your academic works please cite: " << to_text("\\fP")
-                          << meta.citation << "\n";
+                std::cout << in_bold("In your academic works please cite: ") << meta.citation << "\n";
             }
             if (!empty(meta.long_copyright))
             {
                 std::fill_n(out, layout.leftPadding, ' ');
-                std::cout << "For full copyright and/or warranty information see " << to_text("\\fB")
-                          << "--copyright" << to_text("\\fP") << ".\n";
+                std::cout << "For full copyright and/or warranty information see " << in_bold("--copyright") << ".\n";
             }
         }
     }
@@ -418,6 +415,15 @@ protected:
             std::cout << '\n';
     }
 
+    /*!\brief Format string in bold.
+     * \param[in] str The input string to format in bold.
+     * \returns The string `str` wrapped in bold formatting.
+     */
+    std::string in_bold(std::string const & str)
+    {
+        return to_text("\\fB") + str + to_text("\\fP");
+    }
+
     //!\brief Needed for correct formatting while calling different print functions.
     bool prev_was_paragraph{false};
 
@@ -532,8 +538,9 @@ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
 OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 DAMAGE.)"};
 
-        stream << std::string(80, '=') << to_text("\n\\fB") << "Copyright information for "
-               << meta.app_name << ":\n" << to_text("\\fP") << std::string(80, '-') << '\n';
+        stream << std::string(80, '=') << "\n"
+               << in_bold("Copyright information for " + meta.app_name + ":\n")
+               << std::string(80, '-') << '\n';
 
         if (!empty(meta.long_copyright))
         {
@@ -541,17 +548,18 @@ DAMAGE.)"};
         }
         else if (!empty(meta.short_copyright))
         {
-            stream << to_text("\\fP") << meta.app_name << " full copyright information not available. Displaying"
-                  << " short copyright information instead:\n" << to_text("\\fP") << meta.short_copyright << "\n";
+            stream << in_bold(meta.app_name + " full copyright information not available. " +
+                              "Displaying short copyright information instead:\n" )
+                   << meta.short_copyright << "\n";
         }
         else
         {
             stream << to_text("\\fP") << meta.app_name << " copyright information not available.\n";
         }
 
-        stream << std::string(80, '=') << to_text("\n\\fB")
-              << "This program contains SeqAn code licensed under the following terms:\n" << to_text("\\fP")
-              << std::string(80, '-') << '\n' << seqan_license << '\n';
+        stream << std::string(80, '=') << '\n'
+               << in_bold("This program contains SeqAn code licensed under the following terms:\n")
+               << std::string(80, '-') << '\n' << seqan_license << '\n';
 
         std::exit(EXIT_SUCCESS);
     }

--- a/include/seqan3/argument_parser/detail/format_html.hpp
+++ b/include/seqan3/argument_parser/detail/format_html.hpp
@@ -167,9 +167,9 @@ private:
 
         // Print version, date and url.
         std::cout << "<h2>Version</h2>\n"
-                  << "<strong>Last update:</strong> " << to_html(meta.date) << "<br>\n<strong>"
-                  << meta.app_name << " version:</strong> " << meta.version << "<br>\n"
-                  << "<strong>SeqAn version:</strong> " << SEQAN3_VERSION_MAJOR << '.' <<  SEQAN3_VERSION_MINOR << '.'
+                  << in_bold("Last update:") << ' ' << to_html(meta.date) << "<br>\n"
+                  << in_bold(meta.app_name + " version:") << ' ' << meta.version << "<br>\n"
+                  << in_bold("SeqAn version:") << ' ' << SEQAN3_VERSION_MAJOR << '.' <<  SEQAN3_VERSION_MINOR << '.'
                   << SEQAN3_VERSION_PATCH << "<br>\n";
 
         if (!meta.url.empty())
@@ -182,18 +182,16 @@ private:
         // Print legal stuff
         if ((!meta.short_copyright.empty()) || (!meta.long_copyright.empty()) || (!meta.citation.empty()))
         {
-            std::cout << "<h2>Legal</h2>\n<strong>";
+            std::cout << "<h2>Legal</h2>\n";
 
             if (!meta.short_copyright.empty())
-                std::cout << meta.app_name << " Copyright: </strong>"
-                       << meta.short_copyright << "<br>\n<strong>";
+                std::cout << in_bold(meta.app_name + " Copyright: ") << meta.short_copyright << "<br>\n";
 
-            std::cout << "SeqAn Copyright:</strong> 2006-2019 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.<br>\n<strong>";
+            std::cout << in_bold("SeqAn Copyright:")
+                      << " 2006-2019 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.<br>\n";
 
             if (!meta.citation.empty())
-                std::cout << "In your academic works please cite:</strong> " << meta.citation << "<br>\n";
-            else
-                std::cout << "</strong>";
+                std::cout << in_bold("In your academic works please cite:") << ' ' << meta.citation << "<br>\n";
 
             if (!meta.long_copyright.empty())
                 std::cout << "For full copyright and/or warranty information see <tt>--copyright</tt>.\n";
@@ -265,6 +263,15 @@ private:
         }
 
         return result;
+    }
+
+    /*!\brief Format string as in_bold.
+     * \param[in] str The input string to format in bold.
+     * \returns The string `str` wrapped in bold formatting.
+     */
+    std::string in_bold(std::string const & str)
+    {
+        return "<strong>" + str + "</strong>";
     }
 
     //!\brief Current state is either inside a html \<dl\> tag (true) or not (false).

--- a/include/seqan3/argument_parser/detail/format_man.hpp
+++ b/include/seqan3/argument_parser/detail/format_man.hpp
@@ -138,16 +138,26 @@ private:
             std::cout << ".SH LEGAL\n";
 
             if (!empty(meta.short_copyright))
-                std::cout << "\\fB" << meta.app_name << " Copyright:\\fR " << meta.short_copyright << "\n.br\n";
+                std::cout << in_bold(meta.app_name + " Copyright:") << ' ' << meta.short_copyright << "\n.br\n";
 
-            std::cout << "\\fBSeqAn Copyright:\\fR 2006-2015 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.\n.br\n";
+            std::cout << in_bold("SeqAn Copyright:")
+                      << " 2006-2015 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.\n.br\n";
 
             if (!empty(meta.citation))
-                std::cout << "\\fBIn your academic works please cite:\\fR " << meta.citation << "\n.br\n";
+                std::cout << in_bold("In your academic works please cite:") << ' ' << meta.citation << "\n.br\n";
 
             if (!empty(meta.long_copyright))
-                std::cout << "For full copyright and/or warranty information see \\fB--copyright\\fR.\n";
+                std::cout << "For full copyright and/or warranty information see " << in_bold("--copyright") << ".\n";
         }
+    }
+
+    /*!\brief Format string as in_bold.
+     * \param[in] str The input string to format in bold.
+     * \returns The string `str` wrapped in bold formatting.
+     */
+    std::string in_bold(std::string const & str)
+    {
+        return "\\fB" + str + "\\fR";
     }
 
     //!\brief Needed for correct indentation and line breaks.


### PR DESCRIPTION
Feel free to comment on the name of the function `in_bold`. I didn't think a lot about the naming.

See #2319 for every commit that is planned for some refactoring. It will make it easier to keep the help page export features in synch. 

