### PR TITLE
[FIX] Use new cache if doxygen version changes

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: doc-build
-          key: ${{ runner.os }}-documentation
+          key: ${{ runner.os }}-documentation-${{ env.DOXYGEN_VERSION }}
 
       - name: Build documentation
         run: |


### PR DESCRIPTION
If there is a cache available, the documentation build is not configured with the changed doxygen version