### PR TITLE
[MISC] Reuse functionality we already have in format_help.

### DIFF
--- a/include/seqan3/argument_parser/detail/format_help.hpp
+++ b/include/seqan3/argument_parser/detail/format_help.hpp
@@ -199,25 +199,22 @@ protected:
     //!\brief Prints the version information to std::cout.
     void print_version()
     {
-        std::ostream_iterator<char> out(std::cout);
+        std::string const version_str = std::to_string(SEQAN3_VERSION_MAJOR) + "." +
+                                        std::to_string(SEQAN3_VERSION_MINOR) + "." +
+                                        std::to_string(SEQAN3_VERSION_PATCH);
 
         // Print version, date and url.
-        std::cout << "\n" << in_bold("VERSION") << "\n";
-        std::fill_n(out, layout.leftPadding, ' ');
-        std::cout << in_bold("Last update: ") << meta.date << "\n";
-        std::fill_n(out, layout.leftPadding, ' ');
-        std::cout << in_bold(meta.app_name + " version: ") << meta.version << "\n";
-        std::fill_n(out, layout.leftPadding, ' ');
-        std::cout << in_bold("SeqAn version: ") << SEQAN3_VERSION_MAJOR << '.'
-                  <<  SEQAN3_VERSION_MINOR << '.' << SEQAN3_VERSION_PATCH;
+        print_section("Version");
+        print_line(in_bold("Last update: ") + meta.date, false);
+        print_line(in_bold(meta.app_name + " version: ") + meta.version, false);
+        print_line(in_bold("SeqAn version: ") + version_str, false);
 
         if (!empty(meta.url))
         {
-            std::cout << "\n" << in_bold("URL") << "\n";
-            std::fill_n(out, layout.leftPadding, ' ');
-            std::cout << meta.url << "\n";
+            print_section("Url");
+            print_line(meta.url, false);
+            std::cout << "\n";
         }
-        std::cout << "\n";
     }
 
     //!\brief Prints a help page footer to std::cout.
@@ -225,31 +222,22 @@ protected:
     {
         print_version();
 
-        std::ostream_iterator<char> out(std::cout);
-
         // Print legal stuff
         if ((!empty(meta.short_copyright)) || (!empty(meta.long_copyright)) || (!empty(meta.citation)))
         {
-            std::cout << "\n" << in_bold("LEGAL") << "\n";
+            print_section("Legal");
 
             if (!empty(meta.short_copyright))
-            {
-                std::fill_n(out, layout.leftPadding, ' ');
-                std::cout << in_bold(meta.app_name + " Copyright: ") << meta.short_copyright << "\n";
-            }
-            std::fill_n(out, layout.leftPadding, ' ');
-            std::cout << in_bold("SeqAn Copyright: ")
-                      << "2006-2015 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.\n";
+                print_line(in_bold(meta.app_name + " Copyright: ") + meta.short_copyright, false);
+
+            print_line(in_bold("SeqAn Copyright: ") +
+                       "2006-2015 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.", false);
+
             if (!empty(meta.citation))
-            {
-                std::fill_n(out, layout.leftPadding, ' ');
-                std::cout << in_bold("In your academic works please cite: ") << meta.citation << "\n";
-            }
+                print_line(in_bold("In your academic works please cite: ") + meta.citation, false);
+
             if (!empty(meta.long_copyright))
-            {
-                std::fill_n(out, layout.leftPadding, ' ');
-                std::cout << "For full copyright and/or warranty information see " << in_bold("--copyright") << ".\n";
-            }
+                print_line("For full copyright and/or warranty information see " + in_bold("--copyright") + ".", false);
         }
     }
 

--- a/test/unit/argument_parser/detail/format_help_test.cpp
+++ b/test/unit/argument_parser/detail/format_help_test.cpp
@@ -41,8 +41,8 @@ std::string const basic_options_str = "OPTIONS\n"
                                       "          Whether to to check for the newest app version. Default: 1.\n";
 
 std::string const basic_version_str = "VERSION\n"
-                                      "    Last update: \n"
-                                      "    test_parser version: \n"
+                                      "    Last update:\n"
+                                      "    test_parser version:\n"
                                       "    SeqAn version: " + seqan3::seqan3_version + "\n";
 
 std::string license_text()
@@ -127,7 +127,8 @@ TEST(help_page_printing, with_short_copyright)
                "\n" +
                "LEGAL\n"
                "    test_parser Copyright: short\n"
-               "    SeqAn Copyright: 2006-2015 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.\n";
+               "    SeqAn Copyright: 2006-2015 Knut Reinert, FU-Berlin; released under the\n"
+               "    3-clause BSDL.\n";
     EXPECT_EQ(std_cout, expected);
 }
 
@@ -146,7 +147,8 @@ TEST(help_page_printing, with_long_copyright)
                basic_version_str +
                "\n" +
                "LEGAL\n"
-               "    SeqAn Copyright: 2006-2015 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.\n"
+               "    SeqAn Copyright: 2006-2015 Knut Reinert, FU-Berlin; released under the\n"
+               "    3-clause BSDL.\n"
                "    For full copyright and/or warranty information see --copyright.\n";
     EXPECT_EQ(std_cout, expected);
 }
@@ -166,7 +168,8 @@ TEST(help_page_printing, with_citation)
                basic_version_str +
                "\n" +
                "LEGAL\n"
-               "    SeqAn Copyright: 2006-2015 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.\n"
+               "    SeqAn Copyright: 2006-2015 Knut Reinert, FU-Berlin; released under the\n"
+               "    3-clause BSDL.\n"
                "    In your academic works please cite: citation\n";
     EXPECT_EQ(std_cout, expected);
 }
@@ -219,6 +222,7 @@ TEST(help_page_printing, version_call)
                "===========\n"
                "\n" +
                basic_version_str +
+               "\n" +
                "URL\n"
                "    www.seqan.de\n"
                "\n";

--- a/test/unit/argument_parser/format_parse_validators_test.cpp
+++ b/test/unit/argument_parser/format_parse_validators_test.cpp
@@ -45,8 +45,8 @@ std::string const basic_options_str = "OPTIONS\n"
                                      "          Export the help page information. Value must be one of [html, man].\n";
 
 std::string const basic_version_str = "VERSION\n"
-                                      "    Last update: \n"
-                                      "    test_parser version: \n"
+                                      "    Last update:\n"
+                                      "    test_parser version:\n"
                                       "    SeqAn version: " + seqan3::seqan3_version + "\n";
 
 namespace seqan3::detail


### PR DESCRIPTION
The next commit being part of some argument parser refactoring (all changes shown in #2319).

In this commit we reuse member functions of format_help, like `print_line`, that we already have to DRY out code. 