### PR TITLE
[MISC] Move printing the version information to format_help_base.

### DIFF
--- a/include/seqan3/argument_parser/detail/format_base.hpp
+++ b/include/seqan3/argument_parser/detail/format_base.hpp
@@ -336,6 +336,8 @@ public:
                 print_line(example);
         }
 
+        print_version();
+
         derived_t().print_footer();
 
         std::exit(EXIT_SUCCESS); // program should not continue from here

--- a/include/seqan3/argument_parser/detail/format_base.hpp
+++ b/include/seqan3/argument_parser/detail/format_base.hpp
@@ -24,6 +24,7 @@
 #include <seqan3/argument_parser/validators.hpp>
 #include <seqan3/utility/detail/type_name_as_string.hpp>
 #include <seqan3/utility/type_list/traits.hpp>
+#include <seqan3/version.hpp>
 
 namespace seqan3::detail
 {
@@ -417,6 +418,26 @@ protected:
     void print_line(std::string const & text)
     {
         derived_t().print_line(text, true);
+    }
+
+    //!\brief Prints the version information.
+    void print_version()
+    {
+        std::string const version_str = std::to_string(SEQAN3_VERSION_MAJOR) + "." +
+                                        std::to_string(SEQAN3_VERSION_MINOR) + "." +
+                                        std::to_string(SEQAN3_VERSION_PATCH);
+
+        // Print version, date and url.
+        derived_t().print_section("Version");
+        derived_t().print_line(derived_t().in_bold("Last update: ") + meta.date, false);
+        derived_t().print_line(derived_t().in_bold(meta.app_name + " version: ") + meta.version, false);
+        derived_t().print_line(derived_t().in_bold("SeqAn version: ") + version_str, false);
+
+        if (!empty(meta.url))
+        {
+            derived_t().print_section("Url");
+            derived_t().print_line(meta.url, false);
+        }
     }
 
     //!\brief Vector of functions that stores all calls except add_positional_option.

--- a/include/seqan3/argument_parser/detail/format_help.hpp
+++ b/include/seqan3/argument_parser/detail/format_help.hpp
@@ -198,8 +198,6 @@ protected:
     //!\brief Prints a help page footer to std::cout.
     void print_footer()
     {
-        print_version();
-
         // Print legal stuff
         if ((!empty(meta.short_copyright)) || (!empty(meta.long_copyright)) || (!empty(meta.citation)))
         {

--- a/include/seqan3/argument_parser/detail/format_help.hpp
+++ b/include/seqan3/argument_parser/detail/format_help.hpp
@@ -20,7 +20,6 @@
 #include <seqan3/argument_parser/detail/format_base.hpp>
 #include <seqan3/argument_parser/detail/terminal.hpp>
 #include <seqan3/core/detail/test_accessor.hpp>
-#include <seqan3/version.hpp>
 
 namespace seqan3::detail
 {
@@ -194,27 +193,6 @@ protected:
         print_text(desc, layout.rightColumnTab);
 
         prev_was_paragraph = false;
-    }
-
-    //!\brief Prints the version information to std::cout.
-    void print_version()
-    {
-        std::string const version_str = std::to_string(SEQAN3_VERSION_MAJOR) + "." +
-                                        std::to_string(SEQAN3_VERSION_MINOR) + "." +
-                                        std::to_string(SEQAN3_VERSION_PATCH);
-
-        // Print version, date and url.
-        print_section("Version");
-        print_line(in_bold("Last update: ") + meta.date, false);
-        print_line(in_bold(meta.app_name + " version: ") + meta.version, false);
-        print_line(in_bold("SeqAn version: ") + version_str, false);
-
-        if (!empty(meta.url))
-        {
-            print_section("Url");
-            print_line(meta.url, false);
-            std::cout << "\n";
-        }
     }
 
     //!\brief Prints a help page footer to std::cout.

--- a/include/seqan3/argument_parser/detail/format_html.hpp
+++ b/include/seqan3/argument_parser/detail/format_html.hpp
@@ -163,21 +163,10 @@ private:
     //!\brief Prints a help page footer in HTML format to std::cout.
     void print_footer()
     {
+        print_version();
+
         maybe_close_list();
-
-        // Print version, date and url.
-        std::cout << "<h2>Version</h2>\n"
-                  << in_bold("Last update:") << ' ' << to_html(meta.date) << "<br>\n"
-                  << in_bold(meta.app_name + " version:") << ' ' << meta.version << "<br>\n"
-                  << in_bold("SeqAn version:") << ' ' << SEQAN3_VERSION_MAJOR << '.' <<  SEQAN3_VERSION_MINOR << '.'
-                  << SEQAN3_VERSION_PATCH << "<br>\n";
-
-        if (!meta.url.empty())
-        {
-            std::cout << "<h2>Url</h2>\n"
-                    << meta.url << "<br>\n";
-        }
-        std::cout << "<br>\n";
+        maybe_close_paragraph();
 
         // Print legal stuff
         if ((!meta.short_copyright.empty()) || (!meta.long_copyright.empty()) || (!meta.citation.empty()))

--- a/include/seqan3/argument_parser/detail/format_html.hpp
+++ b/include/seqan3/argument_parser/detail/format_html.hpp
@@ -163,8 +163,6 @@ private:
     //!\brief Prints a help page footer in HTML format to std::cout.
     void print_footer()
     {
-        print_version();
-
         maybe_close_list();
         maybe_close_paragraph();
 

--- a/include/seqan3/argument_parser/detail/format_man.hpp
+++ b/include/seqan3/argument_parser/detail/format_man.hpp
@@ -132,8 +132,6 @@ private:
     //!\brief Prints a help page footer in man page format.
     void print_footer()
     {
-        print_version();
-
         // Print legal stuff
         if ((!empty(meta.short_copyright)) || (!empty(meta.long_copyright)) || (!empty(meta.citation)))
         {

--- a/include/seqan3/argument_parser/detail/format_man.hpp
+++ b/include/seqan3/argument_parser/detail/format_man.hpp
@@ -132,6 +132,8 @@ private:
     //!\brief Prints a help page footer in man page format.
     void print_footer()
     {
+        print_version();
+
         // Print legal stuff
         if ((!empty(meta.short_copyright)) || (!empty(meta.long_copyright)) || (!empty(meta.citation)))
         {

--- a/test/unit/argument_parser/detail/format_help_test.cpp
+++ b/test/unit/argument_parser/detail/format_help_test.cpp
@@ -211,7 +211,7 @@ TEST(help_page_printing, version_call)
     // Version call with url and options.
     seqan3::argument_parser parser4{"test_parser", 2, argv3};
     test_accessor::set_terminal_width(parser4, 80);
-    parser4.info.url = "www.seqan.de";
+    parser4.info.url = "https://seqan.de";
     parser4.add_option(option_value, 'i', "int", "this is a int option.");
     parser4.add_flag(flag_value, 'f', "flag", "this is a flag.");
     parser4.add_positional_option(pos_opt_value, "this is a positional option.");
@@ -224,8 +224,7 @@ TEST(help_page_printing, version_call)
                basic_version_str +
                "\n" +
                "URL\n"
-               "    www.seqan.de\n"
-               "\n";
+               "    https://seqan.de\n";
     EXPECT_EQ(std_cout, expected);
 }
 

--- a/test/unit/argument_parser/detail/format_html_test.cpp
+++ b/test/unit/argument_parser/detail/format_html_test.cpp
@@ -48,10 +48,14 @@ TEST(html_format, empty_information)
                            "<dd>Whether to to check for the newest app version. Default: 1.</dd>\n"
                            "</dl>\n"
                            "<h2>Version</h2>\n"
-                           "<strong>Last update:</strong> <br>\n"
-                           "<strong>empty_options version:</strong> <br>\n"
-                           "<strong>SeqAn version:</strong> " + seqan3::seqan3_version + "<br>\n"
+                           "<p>\n"
+                           "<strong>Last update: </strong>\n"
                            "<br>\n"
+                           "<strong>empty_options version: </strong>\n"
+                           "<br>\n"
+                           "<strong>SeqAn version: </strong>" + seqan3::seqan3_version + "\n"
+                           "<br>\n"
+                           "</p>\n"
                            "</body></html>");
     EXPECT_EQ(my_stdout, expected);
 
@@ -80,7 +84,7 @@ TEST(html_format, full_information_information)
    parser1.info.description.push_back("description");
    parser1.info.description.push_back("description2");
    parser1.info.short_description = "short description";
-   parser1.info.url = "www.seqan.de";
+   parser1.info.url = "https://seqan.de";
    parser1.info.short_copyright = "short copyright";
    parser1.info.long_copyright = "long_copyright";
    parser1.info.citation = "citation";
@@ -158,12 +162,19 @@ TEST(html_format, full_information_information)
                           "example2\n"
                           "</p>\n"
                           "<h2>Version</h2>\n"
-                          "<strong>Last update:</strong> <br>\n"
-                          "<strong>program_full_options version:</strong> <br>\n"
-                          "<strong>SeqAn version:</strong> " + seqan3::seqan3_version + "<br>\n"
-                          "<h2>Url</h2>\n"
-                          "www.seqan.de<br>\n"
+                          "<p>\n"
+                          "<strong>Last update: </strong>\n"
                           "<br>\n"
+                          "<strong>program_full_options version: </strong>\n"
+                          "<br>\n"
+                          "<strong>SeqAn version: </strong>" + seqan3::seqan3_version + "\n"
+                          "<br>\n"
+                          "</p>\n"
+                          "<h2>Url</h2>\n"
+                          "<p>\n"
+                          "https://seqan.de\n"
+                          "<br>\n"
+                          "</p>\n"
                           "<h2>Legal</h2>\n"
                           "<strong>program_full_options Copyright: </strong>short copyright<br>\n"
                           "<strong>SeqAn Copyright:</strong> 2006-2019 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.<br>\n"

--- a/test/unit/argument_parser/detail/format_man_test.cpp
+++ b/test/unit/argument_parser/detail/format_man_test.cpp
@@ -79,7 +79,13 @@ struct format_man_test : public ::testing::Test
     R"(.SH EXAMPLES)" "\n"
     R"(example)" "\n"
     R"(.sp)" "\n"
-    R"(example2)" "\n";
+    R"(example2)" "\n"
+    R"(.SH VERSION)" "\n"
+    R"(\fBLast update: \fRDecember 01, 1994)" "\n"
+    R"(.br)" "\n"
+    R"(\fBdefault version: \fR01.01.01)" "\n"
+    R"(.br)" "\n"
+    R"(\fBSeqAn version: \fR3.0.3)" "\n";
 
     // Full info parser initialisation
     void dummy_init(seqan3::argument_parser & parser)
@@ -138,7 +144,13 @@ TEST_F(format_man_test, empty_information)
     R"(Export the help page information. Value must be one of [html, man].)" "\n"
     R"(.TP)" "\n"
     R"(\fB--version-check\fP (bool))" "\n"
-    R"(Whether to to check for the newest app version. Default: 1.)" "\n";
+    R"(Whether to to check for the newest app version. Default: 1.)" "\n"
+    R"(.SH VERSION)" "\n"
+    R"(\fBLast update: \fRDecember 01, 1994)" "\n"
+    R"(.br)" "\n"
+    R"(\fBdefault version: \fR01.01.01)" "\n"
+    R"(.br)" "\n"
+    R"(\fBSeqAn version: \fR3.0.3)" "\n";
 
     // Test the dummy parser with minimal information.
     testing::internal::CaptureStdout();


### PR DESCRIPTION
This is part of the refactoring shown in #2319 

It removes printing of the version information in the individual formats and instead puts it into `format_help_base`.
This reduces code and avoid inconsistencies between formats (e.g. format man didn't have the version information at all).
