### PR TITLE
__cpp_lib_* fixes

### DIFF
--- a/include/seqan3/std/bit
+++ b/include/seqan3/std/bit
@@ -42,7 +42,17 @@
 #   endif
 #endif
 
-#ifndef __cpp_lib_endian
+//!\brief A workaround for __cpp_lib_endian for gcc version 8.x (in C++20 mode).
+//!       Those versions implemented std::endian, but did not define that feature detection macro.
+#ifndef SEQAN3_CPP_LIB_ENDIAN
+#   if defined(__cpp_lib_endian)
+#       define SEQAN3_CPP_LIB_ENDIAN 1
+#   elif defined(__GNUC__) && __GNUC__ == 8 && __cplusplus > 201703L
+#       define SEQAN3_CPP_LIB_ENDIAN 1
+#   endif
+#endif
+
+#ifndef SEQAN3_CPP_LIB_ENDIAN
 
 #include <cstddef>
 
@@ -73,7 +83,7 @@ enum class endian
 
 } //namespace std
 
-#endif // __cpp_lib_endian
+#endif // SEQAN3_CPP_LIB_ENDIAN
 
 #if !defined(SEQAN3_CPP_LIB_INT_POW2) || !defined(SEQAN3_CPP_LIB_BITOPS)
 

--- a/include/seqan3/std/bit
+++ b/include/seqan3/std/bit
@@ -20,7 +20,8 @@
 #include <climits>
 #include <type_traits>
 
-//!\brief This defines __cpp_lib_bitops.
+//!\brief A workaround for __cpp_lib_bitops for gcc version 9.x (in C++20 mode).
+//!       Those versions implemented std::countl_zero, etc, but did not define that feature detection macro.
 #ifndef SEQAN3_CPP_LIB_BITOPS
 #   if defined(__cpp_lib_bitops) && __cpp_lib_bitops >= 201907L
 #       define SEQAN3_CPP_LIB_BITOPS 1

--- a/include/seqan3/std/memory
+++ b/include/seqan3/std/memory
@@ -17,21 +17,19 @@
 #include <version> // from C++20 all feature macros should be defined here
 #endif
 
-//!\brief A workaround for __cpp_lib_to_address for gcc version on macOS >=9.0 and < 9.4 (in C++20 mode).
+//!\brief A workaround for __cpp_lib_to_address for gcc version >=8.0 and < 9.4 (in C++20 mode).
 //!       Those versions implemented std::to_address, but did not define that feature detection macro.
-#ifndef SEQAN3_WORKAROUND_CPP_LIB_TO_ADDRESS_IS_PRESENT
+#ifndef SEQAN3_CPP_LIB_TO_ADDRESS
 #   if defined(__cpp_lib_to_address)
-#       define SEQAN3_WORKAROUND_CPP_LIB_TO_ADDRESS_IS_PRESENT 1
-#   elif defined(__GNUC__) && defined(__APPLE__) && (__GNUC__ == 9) && __cplusplus > 201703L
-#       define SEQAN3_WORKAROUND_CPP_LIB_TO_ADDRESS_IS_PRESENT 1
-#   else
-#       define SEQAN3_WORKAROUND_CPP_LIB_TO_ADDRESS_IS_PRESENT 0
+#       define SEQAN3_CPP_LIB_TO_ADDRESS 1
+#   elif defined(__GNUC__) && (__GNUC__ == 8 || __GNUC__ == 9) && __cplusplus > 201703L
+#       define SEQAN3_CPP_LIB_TO_ADDRESS 1
 #   endif
 #endif
 
 #include <memory>
 
-#if !SEQAN3_WORKAROUND_CPP_LIB_TO_ADDRESS_IS_PRESENT
+#ifndef SEQAN3_CPP_LIB_TO_ADDRESS
 
 /*!\defgroup memory memory
  * \ingroup std
@@ -64,5 +62,4 @@ constexpr auto to_address(const T & p) noexcept
 
 } // namespace std
 
-#endif // SEQAN3_WORKAROUND_CPP_LIB_TO_ADDRESS_IS_PRESENT
-
+#endif // SEQAN3_CPP_LIB_TO_ADDRESS

--- a/include/seqan3/std/type_traits
+++ b/include/seqan3/std/type_traits
@@ -17,13 +17,11 @@
 
 //!\brief A workaround for __cpp_lib_remove_cvref for gcc version >=9.0 and <9.4 (in C++17 mode).
 //!       Those versions implemented std::remove_cvref_t, but did not define that feature detection macro.
-#ifndef SEQAN3_WORKAROUND_CPP_LIB_REMOVE_CVREF
+#ifndef SEQAN3_CPP_LIB_REMOVE_CVREF
 #   if defined(__cpp_lib_remove_cvref)
-#       define SEQAN3_WORKAROUND_CPP_LIB_REMOVE_CVREF 1
+#       define SEQAN3_CPP_LIB_REMOVE_CVREF 1
 #   elif defined(__GNUC__) && ((__GNUC__ == 9) && (__GNUC_MINOR__ < 4)) && __cplusplus > 201703L
-#       define SEQAN3_WORKAROUND_CPP_LIB_REMOVE_CVREF 1
-#   else
-#       define SEQAN3_WORKAROUND_CPP_LIB_REMOVE_CVREF 0
+#       define SEQAN3_CPP_LIB_REMOVE_CVREF 1
 #   endif
 #endif
 
@@ -33,7 +31,7 @@ namespace std
 // ----------------------------------------------------------------------------
 // remove_cvref_t
 // ----------------------------------------------------------------------------
-#if !SEQAN3_WORKAROUND_CPP_LIB_REMOVE_CVREF
+#ifndef SEQAN3_CPP_LIB_REMOVE_CVREF
 /*!\brief Return the input type with `const`, `volatile` and references removed.
  * \tparam t The type to operate on.
  */
@@ -54,7 +52,7 @@ struct remove_cvref<t> // needed for gcc-9, it defines std::remove_cvref but doe
  */
 template <typename t>
 using remove_cvref_t = typename remove_cvref<t>::type;
-#endif // !SEQAN3_WORKAROUND_CPP_LIB_REMOVE_CVREF
+#endif // SEQAN3_CPP_LIB_REMOVE_CVREF
 
 // ----------------------------------------------------------------------------
 // type_identity


### PR DESCRIPTION
This PR fixes the following:
* __cpp_lib_endian is not known for `g++-8 -std=c++2a`, but it still defines `std::endian`
* __cpp_lib_to_address is not known for `g++-8/9 -std=c++2a`, but it still defines `std::to_address`
* further this PR makes the workaround macro names consistent in the naming scheme and behaviour:
  * `SEQAN3_CPP_LIB_*` corresponds to the definition of `__cpp_lib_*`
  * It always has defined / undefined semantics like the original feature macro `__cpp_lib_*`
    * Hence `#ifdef SEQAN3_CPP_LIB_*` means that the functionality is already implemented by the standard library
      * Or was disabled by a library user that might have conflicts with our shim/polyfill implementation
    * and`#ifndef SEQAN3_CPP_LIB_*` means that the functionality is missing in the standard library
      * in this case we define a shim/polyfill implementation