### PR TITLE
[MISC] Move print_legal() to format_help_base and fix copyright year

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -14,8 +14,8 @@ The contents of this repository/directory, in particular the library
 source code of SeqAn3, are licensed under the following terms:
 
 ```
-Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
-Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
+Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/include/seqan3/argument_parser/detail/format_base.hpp
+++ b/include/seqan3/argument_parser/detail/format_base.hpp
@@ -442,6 +442,38 @@ protected:
         }
     }
 
+    //!\brief Prints the legal information.
+    void print_legal()
+    {
+        // Print legal stuff
+        if ((!empty(meta.short_copyright)) || (!empty(meta.long_copyright)) || (!empty(meta.citation)))
+        {
+            derived_t().print_section("Legal");
+
+            if (!empty(meta.short_copyright))
+            {
+                derived_t().print_line(derived_t().in_bold(meta.app_name + " Copyright: ") + meta.short_copyright,
+                                       false);
+            }
+
+            derived_t().print_line(derived_t().in_bold("SeqAn Copyright: ") +
+                                   "2006-2015 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.", false);
+
+            if (!empty(meta.citation))
+            {
+                derived_t().print_line(derived_t().in_bold("In your academic works please cite: ") + meta.citation,
+                                       false);
+            }
+
+            if (!empty(meta.long_copyright))
+            {
+                derived_t().print_line("For full copyright and/or warranty information see " +
+                                       derived_t().in_bold("--copyright") + ".",
+                                       false);
+            }
+        }
+    }
+
     //!\brief Vector of functions that stores all calls except add_positional_option.
     std::vector<std::function<void()>> parser_set_up_calls;
     //!\brief Vector of functions that stores add_positional_option calls.

--- a/include/seqan3/argument_parser/detail/format_base.hpp
+++ b/include/seqan3/argument_parser/detail/format_base.hpp
@@ -457,7 +457,7 @@ protected:
             }
 
             derived_t().print_line(derived_t().in_bold("SeqAn Copyright: ") +
-                                   "2006-2015 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.", false);
+                                   "2006-2021 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.", false);
 
             if (!empty(meta.citation))
             {

--- a/include/seqan3/argument_parser/detail/format_help.hpp
+++ b/include/seqan3/argument_parser/detail/format_help.hpp
@@ -458,8 +458,8 @@ public:
         meta = parser_meta;
         debug_stream_type stream{std::cout};
         std::string seqan_license{
-R"(Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
-Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+R"(Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
+Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/include/seqan3/argument_parser/detail/format_help.hpp
+++ b/include/seqan3/argument_parser/detail/format_help.hpp
@@ -198,23 +198,7 @@ protected:
     //!\brief Prints a help page footer to std::cout.
     void print_footer()
     {
-        // Print legal stuff
-        if ((!empty(meta.short_copyright)) || (!empty(meta.long_copyright)) || (!empty(meta.citation)))
-        {
-            print_section("Legal");
-
-            if (!empty(meta.short_copyright))
-                print_line(in_bold(meta.app_name + " Copyright: ") + meta.short_copyright, false);
-
-            print_line(in_bold("SeqAn Copyright: ") +
-                       "2006-2015 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.", false);
-
-            if (!empty(meta.citation))
-                print_line(in_bold("In your academic works please cite: ") + meta.citation, false);
-
-            if (!empty(meta.long_copyright))
-                print_line("For full copyright and/or warranty information see " + in_bold("--copyright") + ".", false);
-        }
+        print_legal();
     }
 
     /*!\brief Formats text for pretty command line printing.

--- a/test/unit/argument_parser/detail/format_help_test.cpp
+++ b/test/unit/argument_parser/detail/format_help_test.cpp
@@ -127,7 +127,7 @@ TEST(help_page_printing, with_short_copyright)
                "\n" +
                "LEGAL\n"
                "    test_parser Copyright: short\n"
-               "    SeqAn Copyright: 2006-2015 Knut Reinert, FU-Berlin; released under the\n"
+               "    SeqAn Copyright: 2006-2021 Knut Reinert, FU-Berlin; released under the\n"
                "    3-clause BSDL.\n";
     EXPECT_EQ(std_cout, expected);
 }
@@ -147,7 +147,7 @@ TEST(help_page_printing, with_long_copyright)
                basic_version_str +
                "\n" +
                "LEGAL\n"
-               "    SeqAn Copyright: 2006-2015 Knut Reinert, FU-Berlin; released under the\n"
+               "    SeqAn Copyright: 2006-2021 Knut Reinert, FU-Berlin; released under the\n"
                "    3-clause BSDL.\n"
                "    For full copyright and/or warranty information see --copyright.\n";
     EXPECT_EQ(std_cout, expected);
@@ -168,7 +168,7 @@ TEST(help_page_printing, with_citation)
                basic_version_str +
                "\n" +
                "LEGAL\n"
-               "    SeqAn Copyright: 2006-2015 Knut Reinert, FU-Berlin; released under the\n"
+               "    SeqAn Copyright: 2006-2021 Knut Reinert, FU-Berlin; released under the\n"
                "    3-clause BSDL.\n"
                "    In your academic works please cite: citation\n";
     EXPECT_EQ(std_cout, expected);


### PR DESCRIPTION
See #2319 for the full lost of commits.

This PR 
* moves `print_legal()` to format_help_base, s.t. format_man and format_html can use it later on.
* fixes the copyright year to 2021