### PR TITLE
[DOC] Put scoring scheme config into correct doxygen group.

### DIFF
--- a/include/seqan3/alignment/configuration/align_config_scoring_scheme.hpp
+++ b/include/seqan3/alignment/configuration/align_config_scoring_scheme.hpp
@@ -24,7 +24,7 @@ namespace seqan3::align_cfg
 {
 
 /*!\brief Sets the scoring scheme for the alignment algorithm.
- * \ingroup configuration
+ * \ingroup alignment_configuration
  * \tparam scoring_scheme_t The type of the scoring scheme; must model std::semiregular.
  *
  * \details


### PR DESCRIPTION
The scoring scheme configuration documentation did not appear in the alignment/configuration module.