### PR TITLE
[DOC] Deprecate seqan3::static_band documentation.

### DIFF
--- a/include/seqan3/alignment/band/static_band.hpp
+++ b/include/seqan3/alignment/band/static_band.hpp
@@ -22,8 +22,9 @@
 namespace seqan3
 {
 
-/*!\brief Data structure for a static band.
+/*!\brief [DEPRECATED] Data structure for a static band.
  * \ingroup alignment_band
+ * \deprecated use seqan3::align_cfg::band_fixed_size instead.
  */
 class SEQAN3_DEPRECATED_310 static_band
 {


### PR DESCRIPTION
In #2272 only the header was marked as deprecated in doxygen but not the entity itself. This way you don't really see the deprecation in the API documentation.