### PR TITLE
[MISC] Move print_legal function to format_help_base.

### DIFF
--- a/include/seqan3/argument_parser/detail/format_base.hpp
+++ b/include/seqan3/argument_parser/detail/format_base.hpp
@@ -338,6 +338,8 @@ public:
 
         print_version();
 
+        print_legal();
+
         derived_t().print_footer();
 
         std::exit(EXIT_SUCCESS); // program should not continue from here

--- a/include/seqan3/argument_parser/detail/format_help.hpp
+++ b/include/seqan3/argument_parser/detail/format_help.hpp
@@ -198,7 +198,7 @@ protected:
     //!\brief Prints a help page footer to std::cout.
     void print_footer()
     {
-        print_legal();
+        // no footer
     }
 
     /*!\brief Formats text for pretty command line printing.

--- a/include/seqan3/argument_parser/detail/format_html.hpp
+++ b/include/seqan3/argument_parser/detail/format_html.hpp
@@ -166,23 +166,9 @@ private:
         maybe_close_list();
         maybe_close_paragraph();
 
-        // Print legal stuff
-        if ((!meta.short_copyright.empty()) || (!meta.long_copyright.empty()) || (!meta.citation.empty()))
-        {
-            std::cout << "<h2>Legal</h2>\n";
+        print_legal();
 
-            if (!meta.short_copyright.empty())
-                std::cout << in_bold(meta.app_name + " Copyright: ") << meta.short_copyright << "<br>\n";
-
-            std::cout << in_bold("SeqAn Copyright:")
-                      << " 2006-2019 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.<br>\n";
-
-            if (!meta.citation.empty())
-                std::cout << in_bold("In your academic works please cite:") << ' ' << meta.citation << "<br>\n";
-
-            if (!meta.long_copyright.empty())
-                std::cout << "For full copyright and/or warranty information see <tt>--copyright</tt>.\n";
-        }
+        maybe_close_paragraph();
 
         // Print HTML boilerplate footer.
         std::cout << "</body></html>";

--- a/include/seqan3/argument_parser/detail/format_html.hpp
+++ b/include/seqan3/argument_parser/detail/format_html.hpp
@@ -163,11 +163,6 @@ private:
     //!\brief Prints a help page footer in HTML format to std::cout.
     void print_footer()
     {
-        maybe_close_list();
-        maybe_close_paragraph();
-
-        print_legal();
-
         maybe_close_paragraph();
 
         // Print HTML boilerplate footer.

--- a/include/seqan3/argument_parser/detail/format_man.hpp
+++ b/include/seqan3/argument_parser/detail/format_man.hpp
@@ -132,7 +132,7 @@ private:
     //!\brief Prints a help page footer in man page format.
     void print_footer()
     {
-        print_legal();
+        // no footer
     }
 
     /*!\brief Format string as in_bold.

--- a/include/seqan3/argument_parser/detail/format_man.hpp
+++ b/include/seqan3/argument_parser/detail/format_man.hpp
@@ -132,23 +132,7 @@ private:
     //!\brief Prints a help page footer in man page format.
     void print_footer()
     {
-        // Print legal stuff
-        if ((!empty(meta.short_copyright)) || (!empty(meta.long_copyright)) || (!empty(meta.citation)))
-        {
-            std::cout << ".SH LEGAL\n";
-
-            if (!empty(meta.short_copyright))
-                std::cout << in_bold(meta.app_name + " Copyright:") << ' ' << meta.short_copyright << "\n.br\n";
-
-            std::cout << in_bold("SeqAn Copyright:")
-                      << " 2006-2015 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.\n.br\n";
-
-            if (!empty(meta.citation))
-                std::cout << in_bold("In your academic works please cite:") << ' ' << meta.citation << "\n.br\n";
-
-            if (!empty(meta.long_copyright))
-                std::cout << "For full copyright and/or warranty information see " << in_bold("--copyright") << ".\n";
-        }
+        print_legal();
     }
 
     /*!\brief Format string as in_bold.

--- a/test/unit/argument_parser/detail/format_html_test.cpp
+++ b/test/unit/argument_parser/detail/format_html_test.cpp
@@ -176,10 +176,16 @@ TEST(html_format, full_information_information)
                           "<br>\n"
                           "</p>\n"
                           "<h2>Legal</h2>\n"
-                          "<strong>program_full_options Copyright: </strong>short copyright<br>\n"
-                          "<strong>SeqAn Copyright:</strong> 2006-2019 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.<br>\n"
-                          "<strong>In your academic works please cite:</strong> citation<br>\n"
-                          "For full copyright and/or warranty information see <tt>--copyright</tt>.\n"
+                          "<p>\n"
+                          "<strong>program_full_options Copyright: </strong>short copyright\n"
+                          "<br>\n"
+                          "<strong>SeqAn Copyright: </strong>2006-2021 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.\n"
+                          "<br>\n"
+                          "<strong>In your academic works please cite: </strong>citation\n"
+                          "<br>\n"
+                          "For full copyright and/or warranty information see <strong>--copyright</strong>.\n"
+                          "<br>\n"
+                          "</p>\n"
                           "</body></html>");
    EXPECT_EQ(my_stdout, expected);
 }

--- a/test/unit/argument_parser/detail/format_man_test.cpp
+++ b/test/unit/argument_parser/detail/format_man_test.cpp
@@ -185,10 +185,9 @@ TEST_F(format_man_test, full_info_short_copyright)
     // Add a short copyright and test the dummy parser.
     parser.info.short_copyright = "short copyright";
     expected += R"(.SH LEGAL
-\fBdefault Copyright:\fR short copyright
+\fBdefault Copyright: \fRshort copyright
 .br
-\fBSeqAn Copyright:\fR 2006-2015 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.
-.br
+\fBSeqAn Copyright: \fR2006-2021 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.
 )";
     testing::internal::CaptureStdout();
     EXPECT_EXIT(parser.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
@@ -208,12 +207,11 @@ TEST_F(format_man_test, full_info_short_and_citation)
     parser.info.short_copyright = "short copyright";
     parser.info.citation = "citation";
     expected += R"(.SH LEGAL
-\fBdefault Copyright:\fR short copyright
+\fBdefault Copyright: \fRshort copyright
 .br
-\fBSeqAn Copyright:\fR 2006-2015 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.
+\fBSeqAn Copyright: \fR2006-2021 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.
 .br
-\fBIn your academic works please cite:\fR citation
-.br
+\fBIn your academic works please cite: \fRcitation
 )";
     testing::internal::CaptureStdout();
     EXPECT_EXIT(parser.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
@@ -234,11 +232,11 @@ TEST_F(format_man_test, full_info_short_long_and_citation)
     parser.info.citation = "citation";
     parser.info.long_copyright = "looong copyright";
     expected += R"(.SH LEGAL
-\fBdefault Copyright:\fR short copyright
+\fBdefault Copyright: \fRshort copyright
 .br
-\fBSeqAn Copyright:\fR 2006-2015 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.
+\fBSeqAn Copyright: \fR2006-2021 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.
 .br
-\fBIn your academic works please cite:\fR citation
+\fBIn your academic works please cite: \fRcitation
 .br
 For full copyright and/or warranty information see \fB--copyright\fR.
 )";


### PR DESCRIPTION
Last part of the refactoring.

This PR adds the print legal functionality to html and man output and then moves the function itself to the format_help_base to avoid inconsistencies later on.