### PR TITLE
[FIX] Removing instances of [...]_index_specialisation

### DIFF
--- a/include/seqan3/search/detail/search_configurator.hpp
+++ b/include/seqan3/search/detail/search_configurator.hpp
@@ -78,7 +78,7 @@ private:
     {
         //!\brief The selected algorithm type based on the index.
         using type =
-            lazy_conditional_t<bi_fm_index_specialisation<index_t>,
+            lazy_conditional_t<template_specialisation_of<typename index_t::cursor_type, bi_fm_index_cursor>,
                                lazy<search_scheme_algorithm, configuration_t, index_t, policies_t...>,
                                lazy<unidirectional_search_algorithm, configuration_t, index_t, policies_t...>>;
     };
@@ -159,8 +159,8 @@ public:
      *
      * \details
      *
-     * If the `index_t` models seqan3::bi_fm_index_specialisation, then the
-     * seqan3::detail::search_scheme_algorithm is chosen. Otherwise, the
+     * If the cursor of `index_t` models seqan3::detail::template_specialisation_of a seqan3::bi_fm_index_cursor,
+     * then the seqan3::detail::search_scheme_algorithm is chosen. Otherwise, the
      * seqan3::detail::unidirectional_search_algorithm is chosen.
      */
     template <typename query_t, typename configuration_t, typename index_t>

--- a/include/seqan3/search/detail/search_scheme_algorithm.hpp
+++ b/include/seqan3/search/detail/search_scheme_algorithm.hpp
@@ -32,11 +32,11 @@ namespace seqan3::detail
 /*!\brief The algorithm that performs a bidirectional search on a bidirectional FM index using (optimal) search schemes.
  * \tparam configuration_t The search configuration type.
  * \tparam index_t The type of index; index_t::cursor_type must model seqan3::detail::template_specialisation_of
- * a seqan3::bi_fm_index_cursor.
+ *                 a seqan3::bi_fm_index_cursor.
  */
 template <typename configuration_t, typename index_t, typename ...policies_t>
 //!\cond
-requires (template_specialisation_of<typename index_t::cursor_type, bi_fm_index_cursor>)
+    requires (template_specialisation_of<typename index_t::cursor_type, bi_fm_index_cursor>)
 //!\endcond
 class search_scheme_algorithm : protected policies_t...
 {
@@ -62,7 +62,7 @@ public:
     /*!\brief Constructs from a configuration object and an index.
      * \tparam configuration_t The search configuration type.
      * \tparam index_t The type of index; index_t::cursor_type must model seqan3::detail::template_specialisation_of
-     * a seqan3::bi_fm_index_cursor.
+     *                 a seqan3::bi_fm_index_cursor.
      * \param[in] cfg The configuration object that guides the search algorithm.
      * \param[in] index The index used in the algorithm.
      *
@@ -588,7 +588,7 @@ inline bool search_ss(cursor_t cur, query_t & query,
 /*!\brief Searches a query sequence in a bidirectional index using search schemes.
  * \tparam abort_on_hit     If the flag is set, the search aborts on the first hit.
  * \tparam index_t          index_t::cursor_type must model seqan3::detail::template_specialisation_of
- * a seqan3::bi_fm_index_cursor.
+ *                          a seqan3::bi_fm_index_cursor.
  * \tparam query_t          Must model std::ranges::random_access_range over the index's alphabet.
  * \tparam search_scheme_t  Is of type `seqan3::detail::search_scheme_type` or `seqan3::detail::search_scheme_dyn_type`.
  * \tparam delegate_t       Takes `typename index_t::cursor_type` as argument.

--- a/include/seqan3/search/detail/search_scheme_algorithm.hpp
+++ b/include/seqan3/search/detail/search_scheme_algorithm.hpp
@@ -18,6 +18,7 @@
 #include <seqan3/search/detail/search_common.hpp>
 #include <seqan3/search/detail/search_scheme_precomputed.hpp>
 #include <seqan3/search/detail/search_traits.hpp>
+#include <seqan3/search/fm_index/bi_fm_index.hpp>
 #include <seqan3/search/fm_index/concept.hpp>
 #include <seqan3/utility/type_traits/detail/transformation_trait_or.hpp>
 
@@ -28,11 +29,15 @@ namespace seqan3::detail
  * \{
  */
 
-/*!\brief The algorithm that performs a unidirectional search on an FM index using trivial backtracking.
+/*!\brief The algorithm that performs a bidirectional search on a bidirectional FM index using (optimal) search schemes.
  * \tparam configuration_t The search configuration type.
- * \tparam index_t The type of index; must model seqan3::bi_fm_index_specialisation.
+ * \tparam index_t The type of index; index_t::cursor_type must model seqan3::detail::template_specialisation_of
+ * a seqan3::bi_fm_index_cursor.
  */
-template <typename configuration_t, bi_fm_index_specialisation index_t, typename ...policies_t>
+template <typename configuration_t, typename index_t, typename ...policies_t>
+//!\cond
+requires (template_specialisation_of<typename index_t::cursor_type, bi_fm_index_cursor>)
+//!\endcond
 class search_scheme_algorithm : protected policies_t...
 {
 private:
@@ -56,7 +61,8 @@ public:
 
     /*!\brief Constructs from a configuration object and an index.
      * \tparam configuration_t The search configuration type.
-     * \tparam index_t The type of index; must model seqan3::bi_fm_index_specialisation.
+     * \tparam index_t The type of index; index_t::cursor_type must model seqan3::detail::template_specialisation_of
+     * a seqan3::bi_fm_index_cursor.
      * \param[in] cfg The configuration object that guides the search algorithm.
      * \param[in] index The index used in the algorithm.
      *
@@ -116,7 +122,7 @@ public:
     }
 
 private:
-    //!\brief A pointer to the fm index which is used to perform the unidirectional search.
+    //!\brief A pointer to the bidirectional fm index which is used to perform the bidirectional search.
     index_t const * index_ptr{nullptr};
 
     //!\brief The stratum value if set.
@@ -581,7 +587,8 @@ inline bool search_ss(cursor_t cur, query_t & query,
 
 /*!\brief Searches a query sequence in a bidirectional index using search schemes.
  * \tparam abort_on_hit     If the flag is set, the search aborts on the first hit.
- * \tparam index_t          Must model seqan3::bi_fm_index_specialisation.
+ * \tparam index_t          index_t::cursor_type must model seqan3::detail::template_specialisation_of
+ * a seqan3::bi_fm_index_cursor.
  * \tparam query_t          Must model std::ranges::random_access_range over the index's alphabet.
  * \tparam search_scheme_t  Is of type `seqan3::detail::search_scheme_type` or `seqan3::detail::search_scheme_dyn_type`.
  * \tparam delegate_t       Takes `typename index_t::cursor_type` as argument.

--- a/include/seqan3/search/detail/unidirectional_search_algorithm.hpp
+++ b/include/seqan3/search/detail/unidirectional_search_algorithm.hpp
@@ -24,7 +24,6 @@
 #include <seqan3/range/concept.hpp>
 #include <seqan3/range/views/drop.hpp>
 
-
 namespace seqan3::detail
 {
 
@@ -43,7 +42,7 @@ enum class error_type : uint8_t
 
 /*!\brief The algorithm that performs a unidirectional search on an FM index using trivial backtracking.
  * \tparam configuration_t The search configuration type.
- * \tparam index_t The type of index;
+ * \tparam index_t The type of index.
  */
 template <typename configuration_t, typename index_t, typename ...policies_t>
 class unidirectional_search_algorithm : protected policies_t...
@@ -69,7 +68,7 @@ public:
 
     /*!\brief Constructs from a configuration object and an index.
      * \tparam configuration_t The search configuration type.
-     * \tparam index_t The type of index;
+     * \tparam index_t The type of index.
      * \param[in] cfg The configuration object that guides the search algorithm.
      * \param[in] index The index used in the algorithm.
      *

--- a/include/seqan3/search/detail/unidirectional_search_algorithm.hpp
+++ b/include/seqan3/search/detail/unidirectional_search_algorithm.hpp
@@ -24,6 +24,7 @@
 #include <seqan3/range/concept.hpp>
 #include <seqan3/range/views/drop.hpp>
 
+
 namespace seqan3::detail
 {
 
@@ -42,9 +43,13 @@ enum class error_type : uint8_t
 
 /*!\brief The algorithm that performs a unidirectional search on an FM index using trivial backtracking.
  * \tparam configuration_t The search configuration type.
- * \tparam index_t The type of index; must model seqan3::fm_index_specialisation.
+ * \tparam index_t The type of index; index_t::cursor_type must model seqan3::detail::template_specialisation_of
+ * a seqan3::fm_index_cursor.
  */
-template <typename configuration_t, fm_index_specialisation index_t, typename ...policies_t>
+template <typename configuration_t, typename index_t, typename ...policies_t>
+//!\cond
+requires (template_specialisation_of<typename index_t::cursor_type, fm_index_cursor>)
+//!\endcond
 class unidirectional_search_algorithm : protected policies_t...
 {
 private:
@@ -68,7 +73,8 @@ public:
 
     /*!\brief Constructs from a configuration object and an index.
      * \tparam configuration_t The search configuration type.
-     * \tparam index_t The type of index; must model seqan3::fm_index_specialisation.
+     * \tparam index_t The type of index; index_t::cursor_type must model seqan3::detail::template_specialisation_of
+     * a seqan3::fm_index_cursor.
      * \param[in] cfg The configuration object that guides the search algorithm.
      * \param[in] index The index used in the algorithm.
      *

--- a/include/seqan3/search/detail/unidirectional_search_algorithm.hpp
+++ b/include/seqan3/search/detail/unidirectional_search_algorithm.hpp
@@ -43,13 +43,9 @@ enum class error_type : uint8_t
 
 /*!\brief The algorithm that performs a unidirectional search on an FM index using trivial backtracking.
  * \tparam configuration_t The search configuration type.
- * \tparam index_t The type of index; index_t::cursor_type must model seqan3::detail::template_specialisation_of
- * a seqan3::fm_index_cursor.
+ * \tparam index_t The type of index;
  */
 template <typename configuration_t, typename index_t, typename ...policies_t>
-//!\cond
-requires (template_specialisation_of<typename index_t::cursor_type, fm_index_cursor>)
-//!\endcond
 class unidirectional_search_algorithm : protected policies_t...
 {
 private:
@@ -73,8 +69,7 @@ public:
 
     /*!\brief Constructs from a configuration object and an index.
      * \tparam configuration_t The search configuration type.
-     * \tparam index_t The type of index; index_t::cursor_type must model seqan3::detail::template_specialisation_of
-     * a seqan3::fm_index_cursor.
+     * \tparam index_t The type of index;
      * \param[in] cfg The configuration object that guides the search algorithm.
      * \param[in] index The index used in the algorithm.
      *

--- a/include/seqan3/search/fm_index/bi_fm_index.hpp
+++ b/include/seqan3/search/fm_index/bi_fm_index.hpp
@@ -29,7 +29,6 @@ namespace seqan3
  */
 
 /*!\brief The SeqAn Bidirectional FM Index
- * \implements seqan3::bi_fm_index_specialisation
  * \tparam alphabet_t        The alphabet type; must model seqan3::semialphabet.
  * \tparam text_layout_mode_ Indicates whether this index works on a text collection or a single text.
  *                           See seqan3::text_layout.

--- a/include/seqan3/search/fm_index/bi_fm_index_cursor.hpp
+++ b/include/seqan3/search/fm_index/bi_fm_index_cursor.hpp
@@ -33,7 +33,8 @@ namespace seqan3
  */
 
 /*!\brief The SeqAn Bidirectional FM Index Cursor.
- * \tparam index_t The type of the underlying index; must model seqan3::bi_fm_index_specialisation.
+ * \tparam index_t The type of the underlying index; index_t::cursor_type must model
+ * seqan3::detail::template_specialisation_of a seqan3::bi_fm_index_cursor.
  * \implements seqan3::cerealisable
  * \details
  *

--- a/include/seqan3/search/fm_index/bi_fm_index_cursor.hpp
+++ b/include/seqan3/search/fm_index/bi_fm_index_cursor.hpp
@@ -33,8 +33,7 @@ namespace seqan3
  */
 
 /*!\brief The SeqAn Bidirectional FM Index Cursor.
- * \tparam index_t The type of the underlying index; index_t::cursor_type must model
- *                 seqan3::detail::template_specialisation_of a seqan3::bi_fm_index_cursor.
+ * \tparam index_t The type of the underlying index; This is normally seqan3::bi_fm_index.
  * \implements seqan3::cerealisable
  * \details
  *

--- a/include/seqan3/search/fm_index/bi_fm_index_cursor.hpp
+++ b/include/seqan3/search/fm_index/bi_fm_index_cursor.hpp
@@ -34,7 +34,7 @@ namespace seqan3
 
 /*!\brief The SeqAn Bidirectional FM Index Cursor.
  * \tparam index_t The type of the underlying index; index_t::cursor_type must model
- * seqan3::detail::template_specialisation_of a seqan3::bi_fm_index_cursor.
+ *                 seqan3::detail::template_specialisation_of a seqan3::bi_fm_index_cursor.
  * \implements seqan3::cerealisable
  * \details
  *

--- a/include/seqan3/search/fm_index/concept.hpp
+++ b/include/seqan3/search/fm_index/concept.hpp
@@ -78,12 +78,12 @@ namespace seqan3
  */
 
 //!\brief The possible text layouts (single, collection) the seqan3::fm_index and seqan3::bi_fm_index can support.
-    enum text_layout : bool
-    {
-        //!\brief The text is a single range.
-        single,
-        //!\brief The text is a range of ranges.
-        collection
-    };
+enum text_layout : bool
+{
+    //!\brief The text is a single range.
+    single,
+    //!\brief The text is a range of ranges.
+    collection
+};
 
 } // namespace seqan3

--- a/include/seqan3/search/fm_index/concept.hpp
+++ b/include/seqan3/search/fm_index/concept.hpp
@@ -7,7 +7,7 @@
 
 /*!\file
  * \author Christopher Pockrandt <christopher.pockrandt AT fu-berlin.de>
- * \brief Provides the concepts for seqan3::fm_index and seqan3::bi_fm_index and its traits and cursors.
+ * \brief Provides the concept for seqan3::detail::sdsl_index.
  */
 
 #pragma once
@@ -78,98 +78,12 @@ namespace seqan3
  */
 
 //!\brief The possible text layouts (single, collection) the seqan3::fm_index and seqan3::bi_fm_index can support.
-enum text_layout : bool
-{
-    //!\brief The text is a single range.
-    single,
-    //!\brief The text is a range of ranges.
-    collection
-};
-
-// ============================================================================
-//  fm_index_specialisation
-// ============================================================================
-
-/*!\interface seqan3::fm_index_specialisation <>
- * \brief Concept for unidirectional FM indices.
- *
- * This concept defines the interface for unidirectional FM indices.
- */
-//!\cond
-template <typename t>
-SEQAN3_CONCEPT fm_index_specialisation = std::semiregular<t> && requires (t index)
-{
-    typename t::alphabet_type;
-    typename t::size_type;
-    typename t::cursor_type;
-
-    // NOTE: circular dependency
-    // requires detail::template_specialisation_of<typename t::cursor_type, fm_index_cursor>;
-    requires requires (t index, std::conditional_t<t::text_layout_mode == text_layout::collection,
-                                                   std::vector<std::vector<typename t::alphabet_type>>,
-                                                   std::vector<typename t::alphabet_type>> const text)
+    enum text_layout : bool
     {
-        { t(text) };
+        //!\brief The text is a single range.
+        single,
+        //!\brief The text is a range of ranges.
+        collection
     };
-
-    SEQAN3_RETURN_TYPE_CONSTRAINT(index.cursor(), std::same_as, typename t::cursor_type);
-
-    SEQAN3_RETURN_TYPE_CONSTRAINT(index.size(), std::same_as, typename t::size_type);
-    SEQAN3_RETURN_TYPE_CONSTRAINT(index.empty(), std::same_as, bool);
-};
-//!\endcond
-/*!\name Requirements for seqan3::fm_index_specialisation
- * \relates seqan3::fm_index_specialisation
- * \brief You can expect these member types and member functions on all types that satisfy seqan3::fm_index_specialisation.
- * \{
- *
- * \typedef typename t::text_type text_type
- * \brief Type of the indexed text.
- *
- * \typedef typename t::alphabet_type alphabet_type
- * \brief Type of the underlying character of text_type.
- *
- * \typedef typename t::size_type size_type
- * \brief Type for representing the size of the indexed text.
- *
- * \typedef typename t::cursor_type cursor_type
- * \brief Type of the unidirectional FM index cursor.
- * \}
- */
-
-// ============================================================================
-//  bi_fm_index_specialisation
-// ============================================================================
-
-/*!\interface seqan3::bi_fm_index_specialisation <>
- * \brief Concept for bidirectional FM indices.
- *
- * This concept defines the interface for bidirectional FM indices.
- */
-//!\cond
-template <typename t>
-SEQAN3_CONCEPT bi_fm_index_specialisation = fm_index_specialisation<t> && requires (t index)
-{
-    typename t::cursor_type; // already required by fm_index_specialisation but has a different documentation
-    typename t::fwd_cursor_type;
-
-    // NOTE: circular dependency
-    // requires detail::template_specialisation_of<typename t::cursor_type, bi_fm_index_cursor>;
-
-    SEQAN3_RETURN_TYPE_CONSTRAINT(index.fwd_cursor(), std::same_as, typename t::fwd_cursor_type);
-};
-//!\endcond
-/*!\name Requirements for seqan3::bi_fm_index_specialisation
- * \relates seqan3::bi_fm_index_specialisation
- * \brief You can expect these member types and member functions on all types that satisfy seqan3::bi_fm_index_specialisation.
- * \{
- *
- * \typedef typename t::cursor_type cursor_type
- * \brief Type of the bidirectional FM index cursor.
- *
- * \typedef typename t::fwd_cursor_type fwd_cursor_type
- * \brief Type of the unidirectional FM index cursor based on the unidirectional FM index on the original text.
- * \}
- */
 
 } // namespace seqan3

--- a/include/seqan3/search/fm_index/detail/fm_index_cursor.hpp
+++ b/include/seqan3/search/fm_index/detail/fm_index_cursor.hpp
@@ -26,7 +26,8 @@ namespace seqan3::detail
 
 /*!\brief Internal representation of the node of an FM index cursor.
  * \ingroup fm_index
- * \tparam index_t The type of the underlying index; must satisfy seqan3::fm_index_specialisation.
+ * \tparam index_t The type of the underlying index; index_t::cursor_type must model
+ * seqan3::detail::template_specialisation_of a seqan3::fm_index_cursor.
  * \implements seqan3::cerealisable
  */
 template <typename index_t>

--- a/include/seqan3/search/fm_index/detail/fm_index_cursor.hpp
+++ b/include/seqan3/search/fm_index/detail/fm_index_cursor.hpp
@@ -26,8 +26,7 @@ namespace seqan3::detail
 
 /*!\brief Internal representation of the node of an FM index cursor.
  * \ingroup fm_index
- * \tparam index_t The type of the underlying index; index_t::cursor_type must model
- * seqan3::detail::template_specialisation_of a seqan3::fm_index_cursor.
+ * \tparam index_t The type of the underlying index.
  * \implements seqan3::cerealisable
  */
 template <typename index_t>

--- a/include/seqan3/search/fm_index/fm_index.hpp
+++ b/include/seqan3/search/fm_index/fm_index.hpp
@@ -151,7 +151,6 @@ using sdsl_wt_index_type =
 using default_sdsl_index_type = sdsl_wt_index_type;
 
 /*!\brief The SeqAn FM Index.
- * \implements seqan3::fm_index_specialisation
  * \tparam alphabet_t        The alphabet type; must model seqan3::semialphabet.
  * \tparam text_layout_mode_ Indicates whether this index works on a text collection or a single text.
  *                           See seqan3::text_layout.
@@ -587,7 +586,6 @@ namespace seqan3::detail
 {
 
 /*!\brief An FM Index specialisation that handles reversing the given text.
- * \implements seqan3::fm_index_specialisation
  * \tparam alphabet_t        The alphabet type; must model seqan3::semialphabet.
  * \tparam text_layout_mode  Indicates whether this index works on a text collection or a single text.
  *                           See seqan3::text_layout.

--- a/include/seqan3/search/fm_index/fm_index_cursor.hpp
+++ b/include/seqan3/search/fm_index/fm_index_cursor.hpp
@@ -66,7 +66,8 @@ struct suffix_array_interval
 };
 
 /*!\brief The SeqAn FM Index Cursor.
- * \tparam index_t The type of the underlying index; must model seqan3::fm_index_specialisation.
+ * \tparam index_t The type of the underlying index; index_t::cursor_type must
+ * model seqan3::detail::template_specialisation_of a seqan3::fm_index_cursor.
  * \implements seqan3::cerealisable
  * \details
  *

--- a/include/seqan3/search/fm_index/fm_index_cursor.hpp
+++ b/include/seqan3/search/fm_index/fm_index_cursor.hpp
@@ -66,7 +66,7 @@ struct suffix_array_interval
 };
 
 /*!\brief The SeqAn FM Index Cursor.
- * \tparam index_t The type of the underlying index.
+ * \tparam index_t The type of the underlying index. This is normally seqan3::fm_index.
  * \implements seqan3::cerealisable
  * \details
  *

--- a/include/seqan3/search/fm_index/fm_index_cursor.hpp
+++ b/include/seqan3/search/fm_index/fm_index_cursor.hpp
@@ -66,7 +66,7 @@ struct suffix_array_interval
 };
 
 /*!\brief The SeqAn FM Index Cursor.
- * \tparam index_t The type of the underlying index;
+ * \tparam index_t The type of the underlying index.
  * \implements seqan3::cerealisable
  * \details
  *

--- a/include/seqan3/search/fm_index/fm_index_cursor.hpp
+++ b/include/seqan3/search/fm_index/fm_index_cursor.hpp
@@ -66,8 +66,7 @@ struct suffix_array_interval
 };
 
 /*!\brief The SeqAn FM Index Cursor.
- * \tparam index_t The type of the underlying index; index_t::cursor_type must
- * model seqan3::detail::template_specialisation_of a seqan3::fm_index_cursor.
+ * \tparam index_t The type of the underlying index;
  * \implements seqan3::cerealisable
  * \details
  *

--- a/include/seqan3/search/search.hpp
+++ b/include/seqan3/search/search.hpp
@@ -98,7 +98,8 @@ namespace seqan3
  *
  * \include test/snippet/search/search.cpp
  */
-template <typename index_t, std::ranges::forward_range queries_t,
+template <typename index_t,
+          std::ranges::forward_range queries_t,
           typename configuration_t = decltype(search_cfg::default_configuration)>
 //!\cond
     requires std::ranges::forward_range<std::ranges::range_reference_t<queries_t>> &&
@@ -169,7 +170,8 @@ inline auto search(queries_t && queries,
 //!\cond DEV
 // Convert query sequence if it does not match the alphabet type of the index.
 //!\overload
-template <typename index_t, std::ranges::forward_range queries_t,
+template <typename index_t,
+          std::ranges::forward_range queries_t,
           typename configuration_t = decltype(search_cfg::default_configuration)>
     requires std::ranges::forward_range<std::ranges::range_reference_t<queries_t>> &&
              (!std::same_as<range_innermost_value_t<queries_t>, typename index_t::alphabet_type>)
@@ -188,7 +190,8 @@ inline auto search(queries_t && queries,
 
 // Overload for a single query (not a collection of queries)
 //!\overload
-template <typename index_t, std::ranges::forward_range query_t,
+template <typename index_t,
+          std::ranges::forward_range query_t,
           typename configuration_t = decltype(search_cfg::default_configuration)>
 inline auto search(query_t && query,
                    index_t const & index,

--- a/include/seqan3/search/search.hpp
+++ b/include/seqan3/search/search.hpp
@@ -70,7 +70,7 @@ namespace seqan3
  */
 
 /*!\brief Search a query or a range of queries in an index.
- * \tparam index_t    index_t::cursor_type model seqan3::detail::template_specialisation_of a seqan3::fm_index_cursor.
+ * \tparam index_t    Type of the index.
  * \tparam queries_t  Must model std::ranges::random_access_range over the index's alphabet and std::ranges::sized_range.
  *                    A range of queries must additionally model std::ranges::forward_range and std::ranges::sized_range.
  * \param[in] queries A single query or a range of queries.
@@ -101,8 +101,7 @@ namespace seqan3
 template <typename index_t, std::ranges::forward_range queries_t,
           typename configuration_t = decltype(search_cfg::default_configuration)>
 //!\cond
-    requires detail::template_specialisation_of<typename index_t::cursor_type, fm_index_cursor> &&
-            std::ranges::forward_range<std::ranges::range_reference_t<queries_t>> &&
+    requires std::ranges::forward_range<std::ranges::range_reference_t<queries_t>> &&
              std::same_as<range_innermost_value_t<queries_t>, typename index_t::alphabet_type>
 //!\endcond
 inline auto search(queries_t && queries,
@@ -173,7 +172,6 @@ inline auto search(queries_t && queries,
 template <typename index_t, std::ranges::forward_range queries_t,
           typename configuration_t = decltype(search_cfg::default_configuration)>
     requires std::ranges::forward_range<std::ranges::range_reference_t<queries_t>> &&
-            (detail::template_specialisation_of<typename index_t::cursor_type, fm_index_cursor>) &&
              (!std::same_as<range_innermost_value_t<queries_t>, typename index_t::alphabet_type>)
 inline auto search(queries_t && queries,
                    index_t const & index,
@@ -192,7 +190,6 @@ inline auto search(queries_t && queries,
 //!\overload
 template <typename index_t, std::ranges::forward_range query_t,
           typename configuration_t = decltype(search_cfg::default_configuration)>
-    requires (detail::template_specialisation_of<typename index_t::cursor_type, fm_index_cursor>)
 inline auto search(query_t && query,
                    index_t const & index,
                    configuration_t const & cfg = search_cfg::default_configuration)
@@ -202,7 +199,6 @@ inline auto search(query_t && query,
 
 //!\overload
 template <typename index_t, typename configuration_t = decltype(search_cfg::default_configuration)>
-    requires (detail::template_specialisation_of<typename index_t::cursor_type, fm_index_cursor>)
 inline auto search(char const * const queries,
                    index_t const & index,
                    configuration_t const & cfg = search_cfg::default_configuration)
@@ -212,7 +208,6 @@ inline auto search(char const * const queries,
 
 //!\overload
 template <typename index_t, typename configuration_t = decltype(search_cfg::default_configuration)>
-    requires (detail::template_specialisation_of<typename index_t::cursor_type, fm_index_cursor>)
 inline auto search(std::initializer_list<char const * const> const & queries,
                    index_t const & index,
                    configuration_t const & cfg = search_cfg::default_configuration)

--- a/include/seqan3/search/search.hpp
+++ b/include/seqan3/search/search.hpp
@@ -70,7 +70,7 @@ namespace seqan3
  */
 
 /*!\brief Search a query or a range of queries in an index.
- * \tparam index_t    Must model seqan3::fm_index_specialisation.
+ * \tparam index_t    index_t::cursor_type model seqan3::detail::template_specialisation_of a seqan3::fm_index_cursor.
  * \tparam queries_t  Must model std::ranges::random_access_range over the index's alphabet and std::ranges::sized_range.
  *                    A range of queries must additionally model std::ranges::forward_range and std::ranges::sized_range.
  * \param[in] queries A single query or a range of queries.
@@ -98,11 +98,11 @@ namespace seqan3
  *
  * \include test/snippet/search/search.cpp
  */
-template <fm_index_specialisation index_t,
-          std::ranges::forward_range queries_t,
+template <typename index_t, std::ranges::forward_range queries_t,
           typename configuration_t = decltype(search_cfg::default_configuration)>
 //!\cond
-    requires std::ranges::forward_range<std::ranges::range_reference_t<queries_t>> &&
+    requires detail::template_specialisation_of<typename index_t::cursor_type, fm_index_cursor> &&
+            std::ranges::forward_range<std::ranges::range_reference_t<queries_t>> &&
              std::same_as<range_innermost_value_t<queries_t>, typename index_t::alphabet_type>
 //!\endcond
 inline auto search(queries_t && queries,
@@ -170,10 +170,10 @@ inline auto search(queries_t && queries,
 //!\cond DEV
 // Convert query sequence if it does not match the alphabet type of the index.
 //!\overload
-template <fm_index_specialisation index_t,
-          std::ranges::forward_range queries_t,
+template <typename index_t, std::ranges::forward_range queries_t,
           typename configuration_t = decltype(search_cfg::default_configuration)>
     requires std::ranges::forward_range<std::ranges::range_reference_t<queries_t>> &&
+            (detail::template_specialisation_of<typename index_t::cursor_type, fm_index_cursor>) &&
              (!std::same_as<range_innermost_value_t<queries_t>, typename index_t::alphabet_type>)
 inline auto search(queries_t && queries,
                    index_t const & index,
@@ -190,9 +190,9 @@ inline auto search(queries_t && queries,
 
 // Overload for a single query (not a collection of queries)
 //!\overload
-template <fm_index_specialisation index_t,
-          std::ranges::forward_range query_t,
+template <typename index_t, std::ranges::forward_range query_t,
           typename configuration_t = decltype(search_cfg::default_configuration)>
+    requires (detail::template_specialisation_of<typename index_t::cursor_type, fm_index_cursor>)
 inline auto search(query_t && query,
                    index_t const & index,
                    configuration_t const & cfg = search_cfg::default_configuration)
@@ -201,7 +201,8 @@ inline auto search(query_t && query,
 }
 
 //!\overload
-template <fm_index_specialisation index_t, typename configuration_t = decltype(search_cfg::default_configuration)>
+template <typename index_t, typename configuration_t = decltype(search_cfg::default_configuration)>
+    requires (detail::template_specialisation_of<typename index_t::cursor_type, fm_index_cursor>)
 inline auto search(char const * const queries,
                    index_t const & index,
                    configuration_t const & cfg = search_cfg::default_configuration)
@@ -210,7 +211,8 @@ inline auto search(char const * const queries,
 }
 
 //!\overload
-template <fm_index_specialisation index_t, typename configuration_t = decltype(search_cfg::default_configuration)>
+template <typename index_t, typename configuration_t = decltype(search_cfg::default_configuration)>
+    requires (detail::template_specialisation_of<typename index_t::cursor_type, fm_index_cursor>)
 inline auto search(std::initializer_list<char const * const> const & queries,
                    index_t const & index,
                    configuration_t const & cfg = search_cfg::default_configuration)

--- a/test/unit/search/fm_index/fm_index_collection_test_template.hpp
+++ b/test/unit/search/fm_index/fm_index_collection_test_template.hpp
@@ -11,6 +11,8 @@
 #include <seqan3/std/ranges>
 
 #include <seqan3/search/fm_index/bi_fm_index.hpp>
+#include <seqan3/search/fm_index/bi_fm_index_cursor.hpp>
+#include <seqan3/search/fm_index/fm_index_cursor.hpp>
 #include <seqan3/search/fm_index/concept.hpp>
 #include <seqan3/test/cereal.hpp>
 
@@ -121,11 +123,11 @@ TYPED_TEST_P(fm_index_collection_test, concept_check)
 {
     using index_t = typename TypeParam::first_type;
 
-    EXPECT_TRUE((seqan3::fm_index_specialisation<index_t>));
+    EXPECT_TRUE((seqan3::detail::template_specialisation_of<typename index_t::cursor_type, seqan3::fm_index_cursor>));
     if constexpr (std::same_as<index_t, seqan3::bi_fm_index<typename index_t::alphabet_type,
                                                             seqan3::text_layout::collection>>)
     {
-        EXPECT_TRUE(seqan3::bi_fm_index_specialisation<index_t>);
+        EXPECT_TRUE((seqan3::detail::template_specialisation_of<typename index_t::cursor_type, seqan3::bi_fm_index_cursor>));
     }
 }
 

--- a/test/unit/search/fm_index/fm_index_collection_test_template.hpp
+++ b/test/unit/search/fm_index/fm_index_collection_test_template.hpp
@@ -11,8 +11,6 @@
 #include <seqan3/std/ranges>
 
 #include <seqan3/search/fm_index/bi_fm_index.hpp>
-#include <seqan3/search/fm_index/bi_fm_index_cursor.hpp>
-#include <seqan3/search/fm_index/fm_index_cursor.hpp>
 #include <seqan3/search/fm_index/concept.hpp>
 #include <seqan3/test/cereal.hpp>
 
@@ -119,18 +117,6 @@ TYPED_TEST_P(fm_index_collection_test, size)
     EXPECT_EQ(fm.size(), 10u); // including a sentinel character and a delimiter
 }
 
-TYPED_TEST_P(fm_index_collection_test, concept_check)
-{
-    using index_t = typename TypeParam::first_type;
-
-    EXPECT_TRUE((seqan3::detail::template_specialisation_of<typename index_t::cursor_type, seqan3::fm_index_cursor>));
-    if constexpr (std::same_as<index_t, seqan3::bi_fm_index<typename index_t::alphabet_type,
-                                                            seqan3::text_layout::collection>>)
-    {
-        EXPECT_TRUE((seqan3::detail::template_specialisation_of<typename index_t::cursor_type, seqan3::bi_fm_index_cursor>));
-    }
-}
-
 TYPED_TEST_P(fm_index_collection_test, empty_text)
 {
     using index_t = typename TypeParam::first_type;
@@ -158,4 +144,4 @@ TYPED_TEST_P(fm_index_collection_test, serialisation)
     seqan3::test::do_serialisation(fm);
 }
 
-REGISTER_TYPED_TEST_SUITE_P(fm_index_collection_test, ctr, swap, size, serialisation, concept_check, empty_text);
+REGISTER_TYPED_TEST_SUITE_P(fm_index_collection_test, ctr, swap, size, serialisation, empty_text);

--- a/test/unit/search/fm_index/fm_index_test_template.hpp
+++ b/test/unit/search/fm_index/fm_index_test_template.hpp
@@ -10,9 +10,7 @@
 #include <type_traits>
 
 #include <seqan3/search/fm_index/bi_fm_index.hpp>
-#include <seqan3/search/fm_index/bi_fm_index_cursor.hpp>
 #include <seqan3/search/fm_index/concept.hpp>
-#include <seqan3/search/fm_index/fm_index_cursor.hpp>
 #include <seqan3/test/cereal.hpp>
 
 template <typename T>
@@ -89,17 +87,6 @@ TYPED_TEST_P(fm_index_test, size)
     EXPECT_EQ(fm.size(), 9u); // including a sentinel character
 }
 
-TYPED_TEST_P(fm_index_test, concept_check)
-{
-    using index_t = typename TypeParam::first_type;
-    EXPECT_TRUE((seqan3::detail::template_specialisation_of<typename index_t::cursor_type, seqan3::fm_index_cursor>));
-    if constexpr (std::same_as<index_t, seqan3::bi_fm_index<typename index_t::alphabet_type,
-                                                            seqan3::text_layout::single>>)
-    {
-        EXPECT_TRUE((seqan3::detail::template_specialisation_of<typename index_t::cursor_type, seqan3::bi_fm_index_cursor>));
-    }
-}
-
 TYPED_TEST_P(fm_index_test, empty_text)
 {
     using index_t = typename TypeParam::first_type;
@@ -120,4 +107,4 @@ TYPED_TEST_P(fm_index_test, serialisation)
     seqan3::test::do_serialisation(fm);
 }
 
-REGISTER_TYPED_TEST_SUITE_P(fm_index_test, ctr, swap, size, concept_check, empty_text, serialisation);
+REGISTER_TYPED_TEST_SUITE_P(fm_index_test, ctr, swap, size, empty_text, serialisation);

--- a/test/unit/search/fm_index/fm_index_test_template.hpp
+++ b/test/unit/search/fm_index/fm_index_test_template.hpp
@@ -9,8 +9,10 @@
 
 #include <type_traits>
 
-#include <seqan3/search/fm_index/concept.hpp>
 #include <seqan3/search/fm_index/bi_fm_index.hpp>
+#include <seqan3/search/fm_index/bi_fm_index_cursor.hpp>
+#include <seqan3/search/fm_index/concept.hpp>
+#include <seqan3/search/fm_index/fm_index_cursor.hpp>
 #include <seqan3/test/cereal.hpp>
 
 template <typename T>
@@ -90,11 +92,11 @@ TYPED_TEST_P(fm_index_test, size)
 TYPED_TEST_P(fm_index_test, concept_check)
 {
     using index_t = typename TypeParam::first_type;
-    EXPECT_TRUE(seqan3::fm_index_specialisation<index_t>);
+    EXPECT_TRUE((seqan3::detail::template_specialisation_of<typename index_t::cursor_type, seqan3::fm_index_cursor>));
     if constexpr (std::same_as<index_t, seqan3::bi_fm_index<typename index_t::alphabet_type,
                                                             seqan3::text_layout::single>>)
     {
-        EXPECT_TRUE(seqan3::bi_fm_index_specialisation<index_t>);
+        EXPECT_TRUE((seqan3::detail::template_specialisation_of<typename index_t::cursor_type, seqan3::bi_fm_index_cursor>));
     }
 }
 

--- a/test/unit/search/fm_index_cursor/fm_index_cursor_collection_test.cpp
+++ b/test/unit/search/fm_index_cursor/fm_index_cursor_collection_test.cpp
@@ -29,8 +29,8 @@ struct fm_index_cursor_collection_test : public ::testing::Test
     using alphabet_type = typename index_type::alphabet_type;
     using text_type = std::vector<alphabet_type>;
 
-    static constexpr bool is_bi_fm_index = seqan3::detail::template_specialisation_of<typename index_type::cursor_type,
-        seqan3::bi_fm_index_cursor>;
+static constexpr bool is_bi_fm_index = seqan3::detail::template_specialisation_of<typename index_type::cursor_type,
+                                                                                  seqan3::bi_fm_index_cursor>;
     static constexpr auto convert = seqan3::views::char_to<alphabet_type> | seqan3::views::to<text_type>;
 
     text_type text1{convert(std::string_view{"ACGACG"})};

--- a/test/unit/search/fm_index_cursor/fm_index_cursor_collection_test.cpp
+++ b/test/unit/search/fm_index_cursor/fm_index_cursor_collection_test.cpp
@@ -29,7 +29,8 @@ struct fm_index_cursor_collection_test : public ::testing::Test
     using alphabet_type = typename index_type::alphabet_type;
     using text_type = std::vector<alphabet_type>;
 
-    static constexpr bool is_bi_fm_index = seqan3::bi_fm_index_specialisation<index_type>;
+    static constexpr bool is_bi_fm_index = seqan3::detail::template_specialisation_of<typename index_type::cursor_type,
+        seqan3::bi_fm_index_cursor>;
     static constexpr auto convert = seqan3::views::char_to<alphabet_type> | seqan3::views::to<text_type>;
 
     text_type text1{convert(std::string_view{"ACGACG"})};

--- a/test/unit/search/fm_index_cursor/fm_index_cursor_collection_test.cpp
+++ b/test/unit/search/fm_index_cursor/fm_index_cursor_collection_test.cpp
@@ -29,8 +29,8 @@ struct fm_index_cursor_collection_test : public ::testing::Test
     using alphabet_type = typename index_type::alphabet_type;
     using text_type = std::vector<alphabet_type>;
 
-static constexpr bool is_bi_fm_index = seqan3::detail::template_specialisation_of<typename index_type::cursor_type,
-                                                                                  seqan3::bi_fm_index_cursor>;
+    static constexpr bool is_bi_fm_index = seqan3::detail::template_specialisation_of<typename index_type::cursor_type,
+                                                                                      seqan3::bi_fm_index_cursor>;
     static constexpr auto convert = seqan3::views::char_to<alphabet_type> | seqan3::views::to<text_type>;
 
     text_type text1{convert(std::string_view{"ACGACG"})};

--- a/test/unit/search/fm_index_cursor/fm_index_cursor_test.cpp
+++ b/test/unit/search/fm_index_cursor/fm_index_cursor_test.cpp
@@ -28,7 +28,8 @@ struct fm_index_cursor_test : public ::testing::Test
     using alphabet_type = typename index_type::alphabet_type;
     using text_type = std::vector<alphabet_type>;
 
-    static constexpr bool is_bi_fm_index = seqan3::bi_fm_index_specialisation<index_type>;
+    static constexpr bool is_bi_fm_index = seqan3::detail::template_specialisation_of<typename index_type::cursor_type,
+        seqan3::bi_fm_index_cursor>;
     static constexpr auto convert = seqan3::views::char_to<alphabet_type> | seqan3::views::to<text_type>;
 
     text_type text1{convert(std::string_view{"ACGACG"})};

--- a/test/unit/search/fm_index_cursor/fm_index_cursor_test.cpp
+++ b/test/unit/search/fm_index_cursor/fm_index_cursor_test.cpp
@@ -28,8 +28,8 @@ struct fm_index_cursor_test : public ::testing::Test
     using alphabet_type = typename index_type::alphabet_type;
     using text_type = std::vector<alphabet_type>;
 
-    static constexpr bool is_bi_fm_index = seqan3::detail::template_specialisation_of<typename index_type::cursor_type,
-        seqan3::bi_fm_index_cursor>;
+static constexpr bool is_bi_fm_index = seqan3::detail::template_specialisation_of<typename index_type::cursor_type,
+                                                                                  seqan3::bi_fm_index_cursor>;
     static constexpr auto convert = seqan3::views::char_to<alphabet_type> | seqan3::views::to<text_type>;
 
     text_type text1{convert(std::string_view{"ACGACG"})};

--- a/test/unit/search/fm_index_cursor/fm_index_cursor_test.cpp
+++ b/test/unit/search/fm_index_cursor/fm_index_cursor_test.cpp
@@ -28,8 +28,8 @@ struct fm_index_cursor_test : public ::testing::Test
     using alphabet_type = typename index_type::alphabet_type;
     using text_type = std::vector<alphabet_type>;
 
-static constexpr bool is_bi_fm_index = seqan3::detail::template_specialisation_of<typename index_type::cursor_type,
-                                                                                  seqan3::bi_fm_index_cursor>;
+    static constexpr bool is_bi_fm_index = seqan3::detail::template_specialisation_of<typename index_type::cursor_type,
+                                                                                      seqan3::bi_fm_index_cursor>;
     static constexpr auto convert = seqan3::views::char_to<alphabet_type> | seqan3::views::to<text_type>;
 
     text_type text1{convert(std::string_view{"ACGACG"})};


### PR DESCRIPTION
This PR is part of [seqan/product_backlog/issues/259](https://github.com/seqan/product_backlog/issues/259)

- Removes concept `fm_index_specialisation` and uses unconstrained types instead
- Removes concept `bi_fm_index_specialisation` and checks for `seqan3::detail::template_specialisation_of<typename mytype::cursor_type, seqan3::bi_fm_index_cursor>` instead
- Removes `concept_check` unit tests for `fm_index_specialisation` and `bi_fm_index_specialisation` 
