### PR TITLE
[MISC] adjusting seqan3_version semantics

### DIFF
--- a/include/seqan3/version.hpp
+++ b/include/seqan3/version.hpp
@@ -28,6 +28,23 @@
                      + SEQAN3_VERSION_MINOR * 100 \
                      + SEQAN3_VERSION_PATCH)
 
+/*!\brief Converts a number to a string. Preprocessor needs this indirection to
+ * properly expand the values to strings.
+ */
+#define SEQAN3_VERSION_CSTRING_HELPER_STR(str) #str
+
+//!\brief Converts version numbers to string.
+#define SEQAN3_VERSION_CSTRING_HELPER_FUNC(MAJOR, MINOR, PATCH) \
+    SEQAN3_VERSION_CSTRING_HELPER_STR(MAJOR) "."\
+    SEQAN3_VERSION_CSTRING_HELPER_STR(MINOR) "."\
+    SEQAN3_VERSION_CSTRING_HELPER_STR(PATCH)
+
+//!\brief The full version as null terminated string.
+#define SEQAN3_VERSION_CSTRING \
+    SEQAN3_VERSION_CSTRING_HELPER_FUNC(SEQAN3_VERSION_MAJOR, \
+                                       SEQAN3_VERSION_MINOR, \
+                                       SEQAN3_VERSION_PATCH)
+
 namespace seqan3
 {
 
@@ -38,9 +55,10 @@ constexpr uint8_t seqan3_version_minor = SEQAN3_VERSION_MINOR;
 //!\brief The patch version.
 constexpr uint8_t seqan3_version_patch = SEQAN3_VERSION_PATCH;
 
-//!\brief The full version as `std::string`.
-std::string const seqan3_version = std::to_string(seqan3_version_major) + "." +
-                                   std::to_string(seqan3_version_minor) + "." +
-                                   std::to_string(seqan3_version_patch);
+//!\brief The full version as `std::size_t`.
+constexpr std::size_t seqan3_version = SEQAN3_VERSION;
+
+//!\brief The full version as null terminated string.
+constexpr char const* seqan3_version_cstring = SEQAN3_VERSION_CSTRING;
 
 } // namespace seqan3

--- a/include/seqan3/version.hpp
+++ b/include/seqan3/version.hpp
@@ -62,3 +62,6 @@ constexpr std::size_t seqan3_version = SEQAN3_VERSION;
 constexpr char const* seqan3_version_cstring = SEQAN3_VERSION_CSTRING;
 
 } // namespace seqan3
+
+#undef SEQAN3_VERSION_CSTRING_HELPER_STR
+#undef SEQAN3_VERSION_CSTRING_HELPER_FUNC

--- a/test/unit/argument_parser/detail/format_help_test.cpp
+++ b/test/unit/argument_parser/detail/format_help_test.cpp
@@ -43,7 +43,7 @@ std::string const basic_options_str = "OPTIONS\n"
 std::string const basic_version_str = "VERSION\n"
                                       "    Last update:\n"
                                       "    test_parser version:\n"
-                                      "    SeqAn version: " + std::string(seqan3::seqan3_version_cstring) + "\n";
+                                      "    SeqAn version: " + std::string{seqan3::seqan3_version_cstring} + "\n";
 
 std::string license_text()
 {

--- a/test/unit/argument_parser/detail/format_help_test.cpp
+++ b/test/unit/argument_parser/detail/format_help_test.cpp
@@ -43,7 +43,7 @@ std::string const basic_options_str = "OPTIONS\n"
 std::string const basic_version_str = "VERSION\n"
                                       "    Last update:\n"
                                       "    test_parser version:\n"
-                                      "    SeqAn version: " + seqan3::seqan3_version + "\n";
+                                      "    SeqAn version: " + std::string(seqan3::seqan3_version_cstring) + "\n";
 
 std::string license_text()
 {

--- a/test/unit/argument_parser/detail/format_html_test.cpp
+++ b/test/unit/argument_parser/detail/format_html_test.cpp
@@ -53,7 +53,7 @@ TEST(html_format, empty_information)
                            "<br>\n"
                            "<strong>empty_options version: </strong>\n"
                            "<br>\n"
-                           "<strong>SeqAn version: </strong>" + std::string(seqan3::seqan3_version_cstring) + "\n"
+                           "<strong>SeqAn version: </strong>" + std::string{seqan3::seqan3_version_cstring} + "\n"
                            "<br>\n"
                            "</p>\n"
                            "</body></html>");
@@ -167,7 +167,7 @@ TEST(html_format, full_information_information)
                           "<br>\n"
                           "<strong>program_full_options version: </strong>\n"
                           "<br>\n"
-                          "<strong>SeqAn version: </strong>" + std::string(seqan3::seqan3_version_cstring) + "\n"
+                          "<strong>SeqAn version: </strong>" + std::string{seqan3::seqan3_version_cstring} + "\n"
                           "<br>\n"
                           "</p>\n"
                           "<h2>Url</h2>\n"

--- a/test/unit/argument_parser/detail/format_html_test.cpp
+++ b/test/unit/argument_parser/detail/format_html_test.cpp
@@ -53,7 +53,7 @@ TEST(html_format, empty_information)
                            "<br>\n"
                            "<strong>empty_options version: </strong>\n"
                            "<br>\n"
-                           "<strong>SeqAn version: </strong>" + seqan3::seqan3_version + "\n"
+                           "<strong>SeqAn version: </strong>" + std::string(seqan3::seqan3_version_cstring) + "\n"
                            "<br>\n"
                            "</p>\n"
                            "</body></html>");
@@ -167,7 +167,7 @@ TEST(html_format, full_information_information)
                           "<br>\n"
                           "<strong>program_full_options version: </strong>\n"
                           "<br>\n"
-                          "<strong>SeqAn version: </strong>" + seqan3::seqan3_version + "\n"
+                          "<strong>SeqAn version: </strong>" + std::string(seqan3::seqan3_version_cstring) + "\n"
                           "<br>\n"
                           "</p>\n"
                           "<h2>Url</h2>\n"

--- a/test/unit/argument_parser/detail/version_check_test.hpp
+++ b/test/unit/argument_parser/detail/version_check_test.hpp
@@ -390,7 +390,7 @@ TEST_F(version_check, greater_app_version)
     const char * argv[3] = {app_name.c_str(), OPTION_VERSION_CHECK, OPTION_ON};
 
     // create version file with equal seqan version and a smaller app version than the current
-    ASSERT_TRUE(create_file(app_version_filename(), std::string{"1.5.9\n" + seqan3::seqan3_version}));
+    ASSERT_TRUE(create_file(app_version_filename(), std::string{"1.5.9\n" + std::string(seqan3::seqan3_version_cstring)}));
 
     // create timestamp file that dates one day before current to trigger a message
     ASSERT_TRUE(create_file(app_timestamp_filename(), current_unix_timestamp() - 100401)); // one day = 86400 seconds
@@ -411,7 +411,7 @@ TEST_F(version_check, unregistered_app)
     const char * argv[3] = {app_name.c_str(), OPTION_VERSION_CHECK, OPTION_ON};
 
     // create version file with equal seqan version and a smaller app version than the current
-    ASSERT_TRUE(create_file(app_version_filename(), std::string{ "UNREGISTERED_APP\n" + seqan3::seqan3_version}));
+    ASSERT_TRUE(create_file(app_version_filename(), std::string{ "UNREGISTERED_APP\n" + std::string(seqan3::seqan3_version_cstring)}));
 
     // create timestamp file that dates one day before current to trigger a message
     ASSERT_TRUE(create_file(app_timestamp_filename(), current_unix_timestamp() - 100401)); // one day = 86400 seconds
@@ -435,7 +435,7 @@ TEST_F(version_check, smaller_app_version)
     const char * argv[3] = {app_name.c_str(), OPTION_VERSION_CHECK, OPTION_ON};
 
     // create version file with equal seqan version and a greater app version than the current
-    ASSERT_TRUE(create_file(app_version_filename(), std::string{"20.5.9\n" + seqan3::seqan3_version}));
+    ASSERT_TRUE(create_file(app_version_filename(), std::string{"20.5.9\n" + std::string(seqan3::seqan3_version_cstring)}));
 
     // create timestamp file that dates one day before current to trigger a message (one day = 86400 seconds)
     ASSERT_TRUE(create_file(app_timestamp_filename(), current_unix_timestamp() - 100401));
@@ -463,7 +463,7 @@ TEST_F(version_check, smaller_app_version_custom_url)
     const char * argv[3] = {app_name.c_str(), OPTION_VERSION_CHECK, OPTION_ON};
 
     // create version file with equal seqan version and a greater app version than the current
-    ASSERT_TRUE(create_file(app_version_filename(), std::string{"20.5.9\n" + seqan3::seqan3_version}));
+    ASSERT_TRUE(create_file(app_version_filename(), std::string{"20.5.9\n" + std::string(seqan3::seqan3_version_cstring)}));
 
     // create timestamp file that dates one day before current to trigger a message (one day = 86400 seconds)
     ASSERT_TRUE(create_file(app_timestamp_filename(), current_unix_timestamp() - 100401));

--- a/test/unit/argument_parser/detail/version_check_test.hpp
+++ b/test/unit/argument_parser/detail/version_check_test.hpp
@@ -390,7 +390,7 @@ TEST_F(version_check, greater_app_version)
     const char * argv[3] = {app_name.c_str(), OPTION_VERSION_CHECK, OPTION_ON};
 
     // create version file with equal seqan version and a smaller app version than the current
-    ASSERT_TRUE(create_file(app_version_filename(), std::string{"1.5.9\n" + std::string(seqan3::seqan3_version_cstring)}));
+    ASSERT_TRUE(create_file(app_version_filename(), std::string{"1.5.9\n"} + seqan3::seqan3_version_cstring));
 
     // create timestamp file that dates one day before current to trigger a message
     ASSERT_TRUE(create_file(app_timestamp_filename(), current_unix_timestamp() - 100401)); // one day = 86400 seconds
@@ -411,7 +411,7 @@ TEST_F(version_check, unregistered_app)
     const char * argv[3] = {app_name.c_str(), OPTION_VERSION_CHECK, OPTION_ON};
 
     // create version file with equal seqan version and a smaller app version than the current
-    ASSERT_TRUE(create_file(app_version_filename(), std::string{ "UNREGISTERED_APP\n" + std::string(seqan3::seqan3_version_cstring)}));
+    ASSERT_TRUE(create_file(app_version_filename(), std::string{"UNREGISTERED_APP\n"} + seqan3::seqan3_version_cstring));
 
     // create timestamp file that dates one day before current to trigger a message
     ASSERT_TRUE(create_file(app_timestamp_filename(), current_unix_timestamp() - 100401)); // one day = 86400 seconds
@@ -435,7 +435,7 @@ TEST_F(version_check, smaller_app_version)
     const char * argv[3] = {app_name.c_str(), OPTION_VERSION_CHECK, OPTION_ON};
 
     // create version file with equal seqan version and a greater app version than the current
-    ASSERT_TRUE(create_file(app_version_filename(), std::string{"20.5.9\n" + std::string(seqan3::seqan3_version_cstring)}));
+    ASSERT_TRUE(create_file(app_version_filename(), std::string{"20.5.9\n"} + seqan3::seqan3_version_cstring));
 
     // create timestamp file that dates one day before current to trigger a message (one day = 86400 seconds)
     ASSERT_TRUE(create_file(app_timestamp_filename(), current_unix_timestamp() - 100401));
@@ -463,7 +463,7 @@ TEST_F(version_check, smaller_app_version_custom_url)
     const char * argv[3] = {app_name.c_str(), OPTION_VERSION_CHECK, OPTION_ON};
 
     // create version file with equal seqan version and a greater app version than the current
-    ASSERT_TRUE(create_file(app_version_filename(), std::string{"20.5.9\n" + std::string(seqan3::seqan3_version_cstring)}));
+    ASSERT_TRUE(create_file(app_version_filename(), std::string{"20.5.9\n"} + seqan3::seqan3_version_cstring));
 
     // create timestamp file that dates one day before current to trigger a message (one day = 86400 seconds)
     ASSERT_TRUE(create_file(app_timestamp_filename(), current_unix_timestamp() - 100401));

--- a/test/unit/argument_parser/format_parse_validators_test.cpp
+++ b/test/unit/argument_parser/format_parse_validators_test.cpp
@@ -47,7 +47,7 @@ std::string const basic_options_str = "OPTIONS\n"
 std::string const basic_version_str = "VERSION\n"
                                       "    Last update:\n"
                                       "    test_parser version:\n"
-                                      "    SeqAn version: " + seqan3::seqan3_version + "\n";
+                                      "    SeqAn version: " + std::string(seqan3::seqan3_version_cstring) + "\n";
 
 namespace seqan3::detail
 {

--- a/test/unit/argument_parser/format_parse_validators_test.cpp
+++ b/test/unit/argument_parser/format_parse_validators_test.cpp
@@ -47,7 +47,7 @@ std::string const basic_options_str = "OPTIONS\n"
 std::string const basic_version_str = "VERSION\n"
                                       "    Last update:\n"
                                       "    test_parser version:\n"
-                                      "    SeqAn version: " + std::string(seqan3::seqan3_version_cstring) + "\n";
+                                      "    SeqAn version: " + std::string{seqan3::seqan3_version_cstring} + "\n";
 
 namespace seqan3::detail
 {


### PR DESCRIPTION
- Adjusting seqan3_version to be the constexpr version of SEQAN_VERSION which is
  an integer.
- Added SEQAN3_VERSION_CSTRING which is a null terminated string of the version.
- Added seqan3_version_cstring which is a constexpr version of
  SEQAN3_VERSION_CSTRING.
- Adjusted all files to use seqan3_version_cstring instead of seqan3_version.