### PR TITLE
[FIX] gcc7: seqan3::get<seqan3::field>(record const &&)

### DIFF
--- a/include/seqan3/alignment/matrix/detail/affine_cell_proxy.hpp
+++ b/include/seqan3/alignment/matrix/detail/affine_cell_proxy.hpp
@@ -215,9 +215,14 @@ public:
     decltype(auto) best_score() && noexcept { return get_score_impl<0>(std::move(*this)); }
     //!\overload
     decltype(auto) best_score() const && noexcept
-    { //Unfortunately gcc7 does not preserve the const && type: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94967
+    {
+#if SEQAN3_WORKAROUND_GCC_94967
+        // A simple std::move(...) does not work, because it would mess up tuple_element types like `int const &`
         using return_t = std::tuple_element_t<0, score_cell_type>;
         return static_cast<return_t const &&>(get_score_impl<0>(std::move(*this)));
+#else // ^^^ workaround / no workaround vvv
+        return get_score_impl<0>(std::move(*this));
+#endif // SEQAN3_WORKAROUND_GCC_94967
     }
 
     //!\brief Access the horizontal score of the wrapped score matrix cell.
@@ -227,10 +232,15 @@ public:
     //!\overload
     decltype(auto) horizontal_score() && noexcept { return get_score_impl<1>(std::move(*this)); }
     //!\overload
-     decltype(auto) horizontal_score() const && noexcept
-    { //Unfortunately gcc7 does not preserve the const && type: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94967
+    decltype(auto) horizontal_score() const && noexcept
+    {
+#if SEQAN3_WORKAROUND_GCC_94967
+        // A simple std::move(...) does not work, because it would mess up tuple_element types like `int const &`
         using return_t = std::tuple_element_t<1, score_cell_type>;
         return static_cast<return_t const &&>(get_score_impl<1>(std::move(*this)));
+#else // ^^^ workaround / no workaround vvv
+        return get_score_impl<1>(std::move(*this));
+#endif // SEQAN3_WORKAROUND_GCC_94967
     }
 
     //!\brief Access the vertical score of the wrapped score matrix cell.
@@ -241,9 +251,14 @@ public:
     decltype(auto) vertical_score() && noexcept { return get_score_impl<2>(std::move(*this)); }
     //!\overload
     decltype(auto) vertical_score() const && noexcept
-    { //Unfortunately gcc7 does not preserve the const && type: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94967
+    {
+#if SEQAN3_WORKAROUND_GCC_94967
+        // A simple std::move(...) does not work, because it would mess up tuple_element types like `int const &`
         using return_t = std::tuple_element_t<2, score_cell_type>;
         return static_cast<return_t const &&>(get_score_impl<2>(std::move(*this)));
+#else // ^^^ workaround / no workaround vvv
+        return get_score_impl<2>(std::move(*this));
+#endif // SEQAN3_WORKAROUND_GCC_94967
     }
     //!\}
 
@@ -280,9 +295,14 @@ public:
     //!\cond
         requires affine_score_and_trace_cell<tuple_t>
     //!\endcond
-    { //Unfortunately gcc7 does not preserve the const && type: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94967
+    {
+#if SEQAN3_WORKAROUND_GCC_94967
+        // A simple std::move(...) does not work, because it would mess up tuple_element types like `int const &`
         using return_t = std::tuple_element_t<0, trace_cell_type>;
         return static_cast<return_t const &&>(get_trace_impl<0>(std::move(*this)));
+#else // ^^^ workaround / no workaround vvv
+        return get_trace_impl<0>(std::move(*this));
+#endif // SEQAN3_WORKAROUND_GCC_94967
     }
 
     //!\brief Access the horizontal score of the wrapped score matrix cell.
@@ -314,9 +334,14 @@ public:
     //!\cond
         requires affine_score_and_trace_cell<tuple_t>
     //!\endcond
-    { //Unfortunately gcc7 does not preserve the const && type: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94967
+    {
+#if SEQAN3_WORKAROUND_GCC_94967
+        // A simple std::move(...) does not work, because it would mess up tuple_element types like `int const &`
         using return_t = std::tuple_element_t<1, trace_cell_type>;
         return static_cast<return_t const &&>(get_trace_impl<1>(std::move(*this)));
+#else // ^^^ workaround / no workaround vvv
+        return get_trace_impl<1>(std::move(*this));
+#endif // SEQAN3_WORKAROUND_GCC_94967
     }
 
     //!\brief Access the vertical score of the wrapped score matrix cell.
@@ -348,9 +373,14 @@ public:
     //!\cond
         requires affine_score_and_trace_cell<tuple_t>
     //!\endcond
-    { //Unfortunately gcc7 does not preserve the const && type: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94967
+    {
+#if SEQAN3_WORKAROUND_GCC_94967
+        // A simple std::move(...) does not work, because it would mess up tuple_element types like `int const &`
         using return_t = std::tuple_element_t<2, trace_cell_type>;
         return static_cast<return_t const &&>(get_trace_impl<2>(std::move(*this)));
+#else // ^^^ workaround / no workaround vvv
+        return get_trace_impl<2>(std::move(*this));
+#endif // SEQAN3_WORKAROUND_GCC_94967
     }
     //!\}
 

--- a/include/seqan3/core/platform.hpp
+++ b/include/seqan3/core/platform.hpp
@@ -293,6 +293,16 @@
 #   endif
 #endif
 
+//!\brief See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94967
+//!       gcc7 does not preserve the const && type using std::get
+#ifndef SEQAN3_WORKAROUND_GCC_94967 // fixed since gcc8
+#   if defined(__GNUC__) && (__GNUC__ <= 7)
+#       define SEQAN3_WORKAROUND_GCC_94967 1
+#   else
+#       define SEQAN3_WORKAROUND_GCC_94967 0
+#   endif
+#endif
+
 //!\brief See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96070 and https://github.com/seqan/product_backlog/issues/151
 #ifndef SEQAN3_WORKAROUND_GCC_96070 // not yet fixed, this is a defect within the standard lib
 #   if defined(__GNUC__)

--- a/include/seqan3/io/record.hpp
+++ b/include/seqan3/io/record.hpp
@@ -339,7 +339,13 @@ template <field f, typename field_types, typename field_ids>
 auto const && get(record<field_types, field_ids> const && r)
 {
     static_assert(field_ids::contains(f), "The record does not contain the field you wish to retrieve.");
+#if SEQAN3_WORKAROUND_GCC_94967
+    // A simple std::move(...) does not work, because it would mess up tuple_element types like `int const &`
+    using return_t = std::tuple_element_t<field_ids::index_of(f), record<field_types, field_ids>>;
+    return static_cast<return_t const &&>(std::get<field_ids::index_of(f)>(std::move(r)));
+#else // ^^^ workaround / no workaround vvv
     return std::get<field_ids::index_of(f)>(std::move(r));
+#endif // SEQAN3_WORKAROUND_GCC_94967
 }
 //!\}
 

--- a/test/unit/alignment/matrix/detail/affine_cell_proxy_test.cpp
+++ b/test/unit/alignment/matrix/detail/affine_cell_proxy_test.cpp
@@ -7,10 +7,9 @@
 
 #include "gtest/gtest.h"
 
-#include <seqan3/test/expect_same_type.hpp>
-
 #include <seqan3/alignment/matrix/detail/affine_cell_proxy.hpp>
 #include <seqan3/core/tuple/common_tuple.hpp>
+#include <seqan3/test/expect_same_type.hpp>
 
 //------------------------------------------------------------------------------
 // score cell proxy

--- a/test/unit/alignment/matrix/detail/affine_cell_proxy_test.cpp
+++ b/test/unit/alignment/matrix/detail/affine_cell_proxy_test.cpp
@@ -7,6 +7,8 @@
 
 #include "gtest/gtest.h"
 
+#include <seqan3/test/expect_same_type.hpp>
+
 #include <seqan3/alignment/matrix/detail/affine_cell_proxy.hpp>
 #include <seqan3/core/tuple/common_tuple.hpp>
 
@@ -62,10 +64,10 @@ TEST_F(affine_cell_proxy_test, best_score)
     EXPECT_EQ(std::as_const(affine_cell).best_score(), best_score);
     EXPECT_EQ(std::move(affine_cell).best_score(), best_score);
     EXPECT_EQ(std::move(std::as_const(affine_cell)).best_score(), best_score);
-    EXPECT_TRUE((std::same_as<decltype(affine_cell.best_score()), int &>));
-    EXPECT_TRUE((std::same_as<decltype(std::as_const(affine_cell).best_score()), int const &>));
-    EXPECT_TRUE((std::same_as<decltype(std::move(affine_cell).best_score()), int &&>));
-    EXPECT_TRUE((std::same_as<decltype(std::move(std::as_const(affine_cell)).best_score()), int const &&>));
+    EXPECT_SAME_TYPE(decltype(affine_cell.best_score()), int &);
+    EXPECT_SAME_TYPE(decltype(std::as_const(affine_cell).best_score()), int const &);
+    EXPECT_SAME_TYPE(decltype(std::move(affine_cell).best_score()), int &&);
+    EXPECT_SAME_TYPE(decltype(std::move(std::as_const(affine_cell)).best_score()), int const &&);
 }
 
 TEST_F(affine_cell_proxy_test, horizontal_score)
@@ -74,10 +76,10 @@ TEST_F(affine_cell_proxy_test, horizontal_score)
     EXPECT_EQ(std::as_const(affine_cell).horizontal_score(), horizontal_score);
     EXPECT_EQ(std::move(affine_cell).horizontal_score(), horizontal_score);
     EXPECT_EQ(std::move(std::as_const(affine_cell)).horizontal_score(), horizontal_score);
-    EXPECT_TRUE((std::same_as<decltype(affine_cell.horizontal_score()), int const &>));
-    EXPECT_TRUE((std::same_as<decltype(std::as_const(affine_cell).horizontal_score()), int const &>));
-    EXPECT_TRUE((std::same_as<decltype(std::move(affine_cell).horizontal_score()), int const &>));
-    EXPECT_TRUE((std::same_as<decltype(std::move(std::as_const(affine_cell)).horizontal_score()), int const &>));
+    EXPECT_SAME_TYPE(decltype(affine_cell.horizontal_score()), int const &);
+    EXPECT_SAME_TYPE(decltype(std::as_const(affine_cell).horizontal_score()), int const &);
+    EXPECT_SAME_TYPE(decltype(std::move(affine_cell).horizontal_score()), int const &);
+    EXPECT_SAME_TYPE(decltype(std::move(std::as_const(affine_cell)).horizontal_score()), int const &);
 }
 
 TEST_F(affine_cell_proxy_test, vertical_score)
@@ -86,10 +88,10 @@ TEST_F(affine_cell_proxy_test, vertical_score)
     EXPECT_EQ(std::as_const(affine_cell).vertical_score(), vertical_score);
     EXPECT_EQ(std::move(affine_cell).vertical_score(), vertical_score);
     EXPECT_EQ(std::move(std::as_const(affine_cell)).vertical_score(), vertical_score);
-    EXPECT_TRUE((std::same_as<decltype(affine_cell.vertical_score()), int &>));
-    EXPECT_TRUE((std::same_as<decltype(std::as_const(affine_cell).vertical_score()), int &>));
-    EXPECT_TRUE((std::same_as<decltype(std::move(affine_cell).vertical_score()), int &>));
-    EXPECT_TRUE((std::same_as<decltype(std::move(std::as_const(affine_cell)).vertical_score()), int &>));
+    EXPECT_SAME_TYPE(decltype(affine_cell.vertical_score()), int &);
+    EXPECT_SAME_TYPE(decltype(std::as_const(affine_cell).vertical_score()), int &);
+    EXPECT_SAME_TYPE(decltype(std::move(affine_cell).vertical_score()), int &);
+    EXPECT_SAME_TYPE(decltype(std::move(std::as_const(affine_cell)).vertical_score()), int &);
 }
 
 TEST_F(affine_cell_proxy_test, tuple_size)
@@ -99,9 +101,9 @@ TEST_F(affine_cell_proxy_test, tuple_size)
 
 TEST_F(affine_cell_proxy_test, tuple_element)
 {
-    EXPECT_TRUE((std::same_as<std::tuple_element_t<0, cell_type>, int>));
-    EXPECT_TRUE((std::same_as<std::tuple_element_t<1, cell_type>, int const &>));
-    EXPECT_TRUE((std::same_as<std::tuple_element_t<2, cell_type>, int &>));
+    EXPECT_SAME_TYPE((std::tuple_element_t<0, cell_type>), int);
+    EXPECT_SAME_TYPE((std::tuple_element_t<1, cell_type>), int const &);
+    EXPECT_SAME_TYPE((std::tuple_element_t<2, cell_type>), int &);
 }
 
 TEST_F(affine_cell_proxy_test, tuple_like_concept)
@@ -179,10 +181,10 @@ TEST_F(trace_cell_proxy_test, best_trace)
     EXPECT_TRUE(std::as_const(trace_cell).best_trace() == best_trace);
     EXPECT_TRUE(cell_type{trace_cell}.best_trace() == best_trace);
     EXPECT_TRUE(std::move(std::as_const(trace_cell)).best_trace() == best_trace);
-    EXPECT_TRUE((std::same_as<decltype(trace_cell.best_trace()), trace_type &>));
-    EXPECT_TRUE((std::same_as<decltype(std::as_const(trace_cell).best_trace()), trace_type const &>));
-    EXPECT_TRUE((std::same_as<decltype(cell_type{trace_cell}.best_trace()), trace_type &&>));
-    EXPECT_TRUE((std::same_as<decltype(std::move(std::as_const(trace_cell)).best_trace()), trace_type const &&>));
+    EXPECT_SAME_TYPE(decltype(trace_cell.best_trace()), trace_type &);
+    EXPECT_SAME_TYPE(decltype(std::as_const(trace_cell).best_trace()), trace_type const &);
+    EXPECT_SAME_TYPE(decltype(cell_type{trace_cell}.best_trace()), trace_type &&);
+    EXPECT_SAME_TYPE(decltype(std::move(std::as_const(trace_cell)).best_trace()), trace_type const &&);
 }
 
 TEST_F(trace_cell_proxy_test, horizontal_trace)
@@ -191,10 +193,10 @@ TEST_F(trace_cell_proxy_test, horizontal_trace)
     EXPECT_TRUE(std::as_const(trace_cell).horizontal_trace() == horizontal_trace);
     EXPECT_TRUE(cell_type{trace_cell}.horizontal_trace() == horizontal_trace);
     EXPECT_TRUE(std::move(std::as_const(trace_cell)).horizontal_trace() == horizontal_trace);
-    EXPECT_TRUE((std::same_as<decltype(trace_cell.horizontal_trace()), trace_type const &>));
-    EXPECT_TRUE((std::same_as<decltype(std::as_const(trace_cell).horizontal_trace()), trace_type const &>));
-    EXPECT_TRUE((std::same_as<decltype(cell_type{trace_cell}.horizontal_trace()), trace_type const &>));
-    EXPECT_TRUE((std::same_as<decltype(std::move(std::as_const(trace_cell)).horizontal_trace()), trace_type const &>));
+    EXPECT_SAME_TYPE(decltype(trace_cell.horizontal_trace()), trace_type const &);
+    EXPECT_SAME_TYPE(decltype(std::as_const(trace_cell).horizontal_trace()), trace_type const &);
+    EXPECT_SAME_TYPE(decltype(cell_type{trace_cell}.horizontal_trace()), trace_type const &);
+    EXPECT_SAME_TYPE(decltype(std::move(std::as_const(trace_cell)).horizontal_trace()), trace_type const &);
 }
 
 TEST_F(trace_cell_proxy_test, vertical_trace)
@@ -203,10 +205,10 @@ TEST_F(trace_cell_proxy_test, vertical_trace)
     EXPECT_TRUE(std::as_const(trace_cell).vertical_trace() == vertical_trace);
     EXPECT_TRUE(cell_type{trace_cell}.vertical_trace() == vertical_trace);
     EXPECT_TRUE(std::move(std::as_const(trace_cell)).vertical_trace() == vertical_trace);
-    EXPECT_TRUE((std::same_as<decltype(trace_cell.vertical_trace()), trace_type &>));
-    EXPECT_TRUE((std::same_as<decltype(std::as_const(trace_cell).vertical_trace()), trace_type &>));
-    EXPECT_TRUE((std::same_as<decltype(cell_type{trace_cell}.vertical_trace()), trace_type &>));
-    EXPECT_TRUE((std::same_as<decltype(std::move(std::as_const(trace_cell)).vertical_trace()), trace_type &>));
+    EXPECT_SAME_TYPE(decltype(trace_cell.vertical_trace()), trace_type &);
+    EXPECT_SAME_TYPE(decltype(std::as_const(trace_cell).vertical_trace()), trace_type &);
+    EXPECT_SAME_TYPE(decltype(cell_type{trace_cell}.vertical_trace()), trace_type &);
+    EXPECT_SAME_TYPE(decltype(std::move(std::as_const(trace_cell)).vertical_trace()), trace_type &);
 }
 
 //------------------------------------------------------------------------------

--- a/test/unit/io/record_test.cpp
+++ b/test/unit/io/record_test.cpp
@@ -10,12 +10,11 @@
 
 #include <gtest/gtest.h>
 
-#include <seqan3/test/expect_range_eq.hpp>
-#include <seqan3/test/expect_same_type.hpp>
-
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/core/detail/debug_stream_alphabet.hpp>
 #include <seqan3/io/record.hpp>
+#include <seqan3/test/expect_range_eq.hpp>
+#include <seqan3/test/expect_same_type.hpp>
 #include <seqan3/utility/tuple/concept.hpp>
 
 using seqan3::operator""_dna4;

--- a/test/unit/io/record_test.cpp
+++ b/test/unit/io/record_test.cpp
@@ -10,10 +10,12 @@
 
 #include <gtest/gtest.h>
 
+#include <seqan3/test/expect_range_eq.hpp>
+#include <seqan3/test/expect_same_type.hpp>
+
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/core/detail/debug_stream_alphabet.hpp>
 #include <seqan3/io/record.hpp>
-#include <seqan3/test/expect_range_eq.hpp>
 #include <seqan3/utility/tuple/concept.hpp>
 
 using seqan3::operator""_dna4;
@@ -101,4 +103,13 @@ TEST_F(record, get_by_field)
 
     EXPECT_EQ(seqan3::get<seqan3::field::id>(r), "MY ID");
     EXPECT_RANGE_EQ(seqan3::get<seqan3::field::seq>(r), "ACGT"_dna4);
+}
+
+TEST_F(record, gcc_issue_94967)
+{
+    record_type r{"MY ID", "ACGT"_dna4};
+
+    // gcc 7 implemented a different std::get(const &&) definition which was later changed by
+    // https://wg21.link/lwg2485
+    EXPECT_SAME_TYPE(std::string const &&, decltype(seqan3::get<seqan3::field::id>(std::move(std::as_const(r)))));
 }


### PR DESCRIPTION
This PR introduces
* a workaround macro `SEQAN3_WORKAROUND_GCC_94967`
* uses it on known places
* adds a test to check that `seqan3::get<seqan3::field>(record const &&)` works