### PR TITLE
[FEATURE] Add counting_vector::operator+=(counting_vector)

### DIFF
--- a/include/seqan3/search/dream_index/interleaved_bloom_filter.hpp
+++ b/include/seqan3/search/dream_index/interleaved_bloom_filter.hpp
@@ -693,6 +693,25 @@ public:
         return *this;
     }
 
+    /*!\brief Bin-wise addition of two `seqan3::counting_vector`s.
+     * \param rhs The other seqan3::counting_vector.
+     * \attention The seqan3::counting_vector must be at least as big as `rhs`.
+     *
+     * \details
+     *
+     * ### Example
+     *
+     * \include test/snippet/search/dream_index/counting_vector.cpp
+     */
+    counting_vector & operator+=(counting_vector const & rhs)
+    {
+        assert(this->size() >= rhs.size()); // The counting vector may be bigger than what we need.
+
+        std::transform(this->begin(), this->end(), rhs.begin(), this->begin(), std::plus<value_t>());
+
+        return *this;
+    }
+
 };
 
 //!\}

--- a/test/snippet/search/dream_index/counting_vector.cpp
+++ b/test/snippet/search/dream_index/counting_vector.cpp
@@ -23,4 +23,7 @@ int main()
 
     counts += agent.bulk_contains(126); // `counts` contains the number of occurrences of 712, 237 and 126 in each bin.
     seqan3::debug_stream << counts << '\n'; // prints [1,0,0,2,0,0,0,0,0,2,0,0]
+
+    counts += counts; // multiple counts can also be added together
+    seqan3::debug_stream << counts << '\n'; // prints [2,0,0,4,0,0,0,0,0,4,0,0]
 }

--- a/test/unit/search/dream_index/interleaved_bloom_filter_test.cpp
+++ b/test/unit/search/dream_index/interleaved_bloom_filter_test.cpp
@@ -157,6 +157,11 @@ TYPED_TEST(interleaved_bloom_filter_test, counting)
     }
     std::vector<size_t> expected(128, 128);
     EXPECT_EQ(counting, expected);
+
+    // Counting vectors can be added together
+    std::vector<size_t> expected2(128, 256);
+    counting += counting;
+    EXPECT_EQ(counting, expected2);
 }
 
 // Check special case where there is only one `1` in the bitvector.
@@ -183,6 +188,13 @@ TYPED_TEST(interleaved_bloom_filter_test, counting_no_ub)
     expected[63] = 128;
     expected[127] = 128;
     EXPECT_EQ(counting, expected);
+
+    // Counting vectors can be added together
+    std::vector<size_t> expected2(128, 0);
+    expected2[63] = 256;
+    expected2[127] = 256;
+    counting += counting;
+    EXPECT_EQ(counting, expected2);
 }
 
 TYPED_TEST(interleaved_bloom_filter_test, increase_bin_number_to)


### PR DESCRIPTION
Part of https://github.com/seqan/seqan3/pull/1911

#1911 is quite self-contained except the one change in `interleaved_bloom_filter.hpp`, which makes it harder to work with a current seqan version (e.g. when developing the HIBF).