### PR TITLE
ci for cmake's many way to use seqan3 as a library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,17 @@ jobs:
             skip_build_tests: true
             skip_run_tests: true
 
+          - name: "CMake external project gcc7"
+            os: ubuntu-20.04
+            requires_toolchain: true
+            cxx: "g++-7"
+            cc: "gcc-7"
+            cmake: 3.14.6 # the whole test suite needs at least cmake 3.14
+            build: external_project
+            build_type: Debug
+            build_threads: 1 # output is important to be in sequential order
+            skip_run_tests: true
+
           - name: "Snippet gcc7"
             os: ubuntu-20.04
             requires_toolchain: true
@@ -250,6 +261,9 @@ jobs:
             OS="Linux"
           else
             OS="Darwin"
+          fi
+          if [ "$RUNNER_OS" == "Linux" ] && [[ "${{ matrix.build }}" =~ ^(external_project)$ ]]; then
+            sudo apt-get install libidn11 # this is needed for cmake 3.4 within the external_project test
           fi
           mkdir -p /tmp/cmake-download
           wget --retry-connrefused --waitretry=30 --read-timeout=30 --timeout=30 --tries=20 --no-clobber --quiet --directory-prefix=/tmp/cmake-download/ https://github.com/Kitware/CMake/releases/download/v${{ matrix.cmake }}/cmake-${{ matrix.cmake }}-${OS}-x86_64.tar.gz
@@ -344,6 +358,9 @@ jobs:
           fi
           if [[ "${{ matrix.build }}" =~ ^(performance|header)$ ]]; then
             make gbenchmark_build
+          fi
+          if [[ "${{ matrix.build }}" =~ ^(external_project)$ ]]; then
+            make seqan3_test_prerequisite
           fi
           if [[ "${{ matrix.build }}" =~ ^(documentation)$ ]]; then
             make download-cppreference-doxygen-web-tag

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ on:
   pull_request:
 
 env:
-  CMAKE_VERSION: 3.8.2
   DOXYGEN_VERSION: 1.9.1
   SEQAN3_NO_VERSION_CHECK: 1
   TZ: Europe/Berlin
@@ -34,6 +33,7 @@ jobs:
             requires_ccache: true
             cxx: "g++-7"
             cc: "gcc-7"
+            cmake: 3.8.2
             build: coverage
             build_type: Debug
             skip_run_tests: true # Already ran by the make call
@@ -44,6 +44,7 @@ jobs:
             requires_ccache: true
             cxx: "g++-9"
             cc: "gcc-9"
+            cmake: 3.8.2
             build: unit
             build_type: Release
             cxx_flags: "-std=c++2a"
@@ -54,6 +55,7 @@ jobs:
             requires_ccache: true
             cxx: "g++-9"
             cc: "gcc-9"
+            cmake: 3.8.2
             build: unit
             build_type: Release
             cxx_flags: "-std=c++2a"
@@ -64,6 +66,7 @@ jobs:
             requires_ccache: true
             cxx: "g++-10"
             cc: "gcc-10"
+            cmake: 3.8.2
             build: unit
             build_type: Release
             cxx_flags: "-std=c++17 -fconcepts"
@@ -74,6 +77,7 @@ jobs:
             requires_ccache: true
             cxx: "g++-10"
             cc: "gcc-10"
+            cmake: 3.8.2
             build: unit
             build_type: Release
             cxx_flags: "-std=c++17 -fconcepts"
@@ -84,6 +88,7 @@ jobs:
             requires_ccache: true
             cxx: "g++-10"
             cc: "gcc-10"
+            cmake: 3.8.2
             build: unit
             build_type: Release
 
@@ -93,6 +98,7 @@ jobs:
             requires_ccache: true
             cxx: "g++-10"
             cc: "gcc-10"
+            cmake: 3.8.2
             build: unit
             build_type: Release
 
@@ -102,6 +108,7 @@ jobs:
             requires_ccache: true
             cxx: "g++-8"
             cc: "gcc-8"
+            cmake: 3.8.2
             build: unit
             build_type: Release
 
@@ -111,6 +118,7 @@ jobs:
             requires_ccache: true
             cxx: "g++-8"
             cc: "gcc-8"
+            cmake: 3.8.2
             build: unit
             build_type: Release
 
@@ -120,6 +128,7 @@ jobs:
             requires_ccache: true
             cxx: "g++-7"
             cc: "gcc-7"
+            cmake: 3.8.2
             build: unit
             build_type: Release
 
@@ -129,6 +138,7 @@ jobs:
             requires_ccache: true
             cxx: "g++-7"
             cc: "gcc-7"
+            cmake: 3.8.2
             build: unit
             build_type: Release
 
@@ -138,6 +148,7 @@ jobs:
             requires_ccache: true
             cxx: "g++-7"
             cc: "gcc-7"
+            cmake: 3.8.2
             build: performance
             build_type: Release
 
@@ -147,6 +158,7 @@ jobs:
             requires_ccache: true
             cxx: "g++-7"
             cc: "gcc-7"
+            cmake: 3.8.2
             build: header
             build_type: Release
 
@@ -156,6 +168,7 @@ jobs:
             requires_ccache: true
             cxx: "g++-7"
             cc: "gcc-7"
+            cmake: 3.8.2
             build: unit
             build_type: Debug
             use_include_dependencies: true
@@ -168,11 +181,13 @@ jobs:
             requires_ccache: true
             cxx: "g++-7"
             cc: "gcc-7"
+            cmake: 3.8.2
             build: snippet
             build_type: Release
 
           - name: "Documentation"
             os: ubuntu-20.04
+            cmake: 3.8.2
             requires_toolchain: false
             requires_ccache: false
             build: documentation
@@ -195,7 +210,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/cmake-download
-          key: ${{ runner.os }}-CMake_${{ env.CMAKE_VERSION }}
+          key: ${{ runner.os }}-CMake_${{ matrix.cmake }}
 
       - name: Setup CMake
         run: |
@@ -205,9 +220,9 @@ jobs:
             OS="Darwin"
           fi
           mkdir -p /tmp/cmake-download
-          wget --retry-connrefused --waitretry=30 --read-timeout=30 --timeout=30 --tries=20 --no-clobber --quiet --directory-prefix=/tmp/cmake-download/ https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-${OS}-x86_64.tar.gz
-          tar -C /tmp/ -zxf /tmp/cmake-download/cmake-${CMAKE_VERSION}-${OS}-x86_64.tar.gz
-          echo "/tmp/cmake-${CMAKE_VERSION}-${OS}-x86_64/bin" >> $GITHUB_PATH # Only available in subsequent steps!
+          wget --retry-connrefused --waitretry=30 --read-timeout=30 --timeout=30 --tries=20 --no-clobber --quiet --directory-prefix=/tmp/cmake-download/ https://github.com/Kitware/CMake/releases/download/v${{ matrix.cmake }}/cmake-${{ matrix.cmake }}-${OS}-x86_64.tar.gz
+          tar -C /tmp/ -zxf /tmp/cmake-download/cmake-${{ matrix.cmake }}-${OS}-x86_64.tar.gz
+          echo "/tmp/cmake-${{ matrix.cmake }}-${OS}-x86_64/bin" >> $GITHUB_PATH # Only available in subsequent steps!
 
       - name: Get cached Doxygen
         if: matrix.build == 'documentation'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
             cmake: 3.8.2
             build: coverage
             build_type: Debug
+            build_threads: 2
+            test_threads: 2
             skip_run_tests: true # Already ran by the make call
 
           - name: "Unit gcc9 (c++2a) on Linux"
@@ -47,6 +49,8 @@ jobs:
             cmake: 3.8.2
             build: unit
             build_type: Release
+            build_threads: 2
+            test_threads: 2
             cxx_flags: "-std=c++2a"
 
           - name: "Unit gcc9 (c++2a) on macOS"
@@ -58,6 +62,8 @@ jobs:
             cmake: 3.8.2
             build: unit
             build_type: Release
+            build_threads: 2
+            test_threads: 2
             cxx_flags: "-std=c++2a"
 
           - name: "Unit gcc10 (c++17) on Linux"
@@ -69,6 +75,8 @@ jobs:
             cmake: 3.8.2
             build: unit
             build_type: Release
+            build_threads: 2
+            test_threads: 2
             cxx_flags: "-std=c++17 -fconcepts"
 
           - name: "Unit gcc10 (c++17) on macOS"
@@ -80,6 +88,8 @@ jobs:
             cmake: 3.8.2
             build: unit
             build_type: Release
+            build_threads: 2
+            test_threads: 2
             cxx_flags: "-std=c++17 -fconcepts"
 
           - name: "Unit gcc10 (c++20) on Linux"
@@ -91,6 +101,8 @@ jobs:
             cmake: 3.8.2
             build: unit
             build_type: Release
+            build_threads: 2
+            test_threads: 2
 
           - name: "Unit gcc10 (c++20) on macOS"
             os: macos-10.15
@@ -101,6 +113,8 @@ jobs:
             cmake: 3.8.2
             build: unit
             build_type: Release
+            build_threads: 2
+            test_threads: 2
 
           - name: "Unit gcc8 on Linux"
             os: ubuntu-20.04
@@ -111,6 +125,8 @@ jobs:
             cmake: 3.8.2
             build: unit
             build_type: Release
+            build_threads: 2
+            test_threads: 2
 
           - name: "Unit gcc8 on macOS"
             os: macos-10.15
@@ -121,6 +137,8 @@ jobs:
             cmake: 3.8.2
             build: unit
             build_type: Release
+            build_threads: 2
+            test_threads: 2
 
           - name: "Unit gcc7 on Linux"
             os: ubuntu-20.04
@@ -131,6 +149,8 @@ jobs:
             cmake: 3.8.2
             build: unit
             build_type: Release
+            build_threads: 2
+            test_threads: 2
 
           - name: "Unit gcc7 on macOS"
             os: macos-10.15
@@ -141,6 +161,8 @@ jobs:
             cmake: 3.8.2
             build: unit
             build_type: Release
+            build_threads: 2
+            test_threads: 2
 
           - name: "Performance gcc7"
             os: ubuntu-20.04
@@ -151,6 +173,8 @@ jobs:
             cmake: 3.8.2
             build: performance
             build_type: Release
+            build_threads: 2
+            test_threads: 2
 
           - name: "Header gcc7"
             os: ubuntu-20.04
@@ -161,6 +185,8 @@ jobs:
             cmake: 3.8.2
             build: header
             build_type: Release
+            build_threads: 2
+            test_threads: 2
 
           - name: "Non-cyclic tests gcc7"
             os: ubuntu-20.04
@@ -171,6 +197,7 @@ jobs:
             cmake: 3.8.2
             build: unit
             build_type: Debug
+            build_threads: 2
             use_include_dependencies: true
             skip_build_tests: true
             skip_run_tests: true
@@ -184,6 +211,9 @@ jobs:
             cmake: 3.8.2
             build: snippet
             build_type: Release
+            build_threads: 2
+            test_threads: 1 # snippets create and delete files and some separate tests create/delete the same files,
+                            # they are not safe to run in parallel
 
           - name: "Documentation"
             os: ubuntu-20.04
@@ -191,6 +221,8 @@ jobs:
             requires_toolchain: false
             requires_ccache: false
             build: documentation
+            test_threads: 2
+            skip_build_tests: true
 
     steps:
       - name: Checkout SeqAn3
@@ -313,6 +345,9 @@ jobs:
           if [[ "${{ matrix.build }}" =~ ^(performance|header)$ ]]; then
             make gbenchmark_build
           fi
+          if [[ "${{ matrix.build }}" =~ ^(documentation)$ ]]; then
+            make download-cppreference-doxygen-web-tag
+          fi
           if [[ "${{ matrix.use_include_dependencies }}" == "true" ]]; then
             cmake -DSEQAN3_USE_INCLUDE_DEPENDENCIES=1 .
             make all_dependencies
@@ -330,22 +365,14 @@ jobs:
         run: |
           ccache -p || true
           cd seqan3-build
-          if [[ "${{ matrix.build }}" =~ ^(documentation)$ ]]; then
-            make download-cppreference-doxygen-web-tag
-          else
-            make -k -j2
-          fi
+          make -k -j${{ matrix.build_threads }}
           ccache -s || true
 
       - name: Run tests
         if: ${{!matrix.skip_run_tests}}
         run: |
           cd seqan3-build
-          if [[ "${{ matrix.build }}" =~ ^(snippet)$ ]]; then
-            ctest . --output-on-failure
-          else
-            ctest . -j2 --output-on-failure
-          fi
+          ctest . -j${{ matrix.test_threads }} --output-on-failure
 
       - name: Submit coverage build
         if: matrix.build == 'coverage'

--- a/doc/setup/quickstart_cmake/index.md
+++ b/doc/setup/quickstart_cmake/index.md
@@ -102,7 +102,7 @@ To test whether everything works, we will now compile and run a small example.
 
 First we create the file `hello_world.cpp` in the `source` directory with the following contents:
 
-\include hello_world.cpp
+\include doc/setup/quickstart_cmake/hello_world.cpp
 
 To compile it we first create a `CMakeLists.txt` file in the `source` directory:
 

--- a/test/external_project/CMakeLists.txt
+++ b/test/external_project/CMakeLists.txt
@@ -1,0 +1,93 @@
+# -----------------------------------------------------------------------------------------------------
+# Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+# Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+# This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+# shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+# -----------------------------------------------------------------------------------------------------
+
+cmake_minimum_required (VERSION 3.4)
+project (seqan3_test_external_project CXX)
+
+include (../seqan3-test.cmake) # for SEQAN3_EXTERNAL_PROJECT_CMAKE_ARGS, SEQAN3_VERSION
+include (ExternalProject)
+
+set (SEQAN3_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../")
+include (install-seqan3.cmake)
+
+option (SEQAN3_EXTERNAL_PROJECT_FIND_DEBUG_MODE
+        "Enable this option if you want to get a detailed list which paths were considered for find_package(...)"
+        false)
+
+# 1) This tests test/external_project/seqan3_submodule_add_subdirectory/CMakeLists.txt
+#    That means we use add_subdirectory directly on seqan3's top level CMakeLists.txt.
+#    This will automatically call find_package and expose our seqan3::seqan3 target.
+#    This is expected to work with CMake >= 3.4.
+# (ExternalProject_Add simulates a fresh and separate invocation of cmake ../)
+ExternalProject_Add (
+    seqan3_submodule_add_subdirectory
+    PREFIX seqan3_submodule_add_subdirectory
+    SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/seqan3_submodule_add_subdirectory"
+    CMAKE_ARGS
+        ${SEQAN3_EXTERNAL_PROJECT_CMAKE_ARGS}
+        "-DSEQAN3_ROOT=${SEQAN3_ROOT}"
+        "-DCMAKE_FIND_DEBUG_MODE=${SEQAN3_EXTERNAL_PROJECT_FIND_DEBUG_MODE}"
+)
+
+# 2) This tests test/external_project/seqan3_submodule_find_package/CMakeLists.txt
+#    We have a seqan3 checkout somewhere and we point CMAKE_PREFIX_PATH to <checkout>/seqan3/build_system
+#    and then use `find_package` to find `seqan3-config.cmake` which exposes our `seqan3::seqan3` target.
+#    This is expected to work with CMake >= 3.4.
+# (ExternalProject_Add simulates a fresh and separate invocation of cmake ../)
+ExternalProject_Add (
+    seqan3_submodule_find_package
+    PREFIX seqan3_submodule_find_package
+    SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/seqan3_submodule_find_package"
+    CMAKE_ARGS
+        ${SEQAN3_EXTERNAL_PROJECT_CMAKE_ARGS}
+        "-DCMAKE_PREFIX_PATH=${SEQAN3_ROOT}/build_system"
+        "-DCMAKE_FIND_DEBUG_MODE=${SEQAN3_EXTERNAL_PROJECT_FIND_DEBUG_MODE}"
+)
+
+# 3) This tests test/external_project/seqan3_installed/CMakeLists.txt
+#    This test assumes that seqan3 was installed by make install (e.g. system-wide).
+#    This is the way most upstream packages, like debian, provide our library.
+#    This test assumes that `seqan3-config.cmake` can be found by cmake in some global paths like /usr/share/cmake/.
+#
+#    We simulate this by using our `make package` release, e.g. the one we release under
+#    https://github.com/seqan/seqan3/releases, and unzipping it to some folder and making
+#    that path globally accessible by CMAKE_SYSTEM_PREFIX_PATH.
+#    We need CMake >= 3.14 to be able to package seqan3, but we actually expect that this
+#    test works with CMake >= 3.4.
+# (ExternalProject_Add simulates a fresh and separate invocation of cmake ../)
+if (NOT ${CMAKE_VERSION} VERSION_LESS 3.14) # cmake 3.14 version is needed to install seqan3.
+    ExternalProject_Add (
+        seqan3_installed
+        PREFIX seqan3_installed
+        SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/seqan3_installed"
+        CMAKE_ARGS
+            ${SEQAN3_EXTERNAL_PROJECT_CMAKE_ARGS}
+            "-DCMAKE_SYSTEM_PREFIX_PATH=${SEQAN3_SYSTEM_PREFIX}"
+            "-DCMAKE_FIND_DEBUG_MODE=${SEQAN3_EXTERNAL_PROJECT_FIND_DEBUG_MODE}"
+    )
+    add_dependencies(seqan3_installed seqan3_test_prerequisite)
+endif ()
+
+# 4) This tests test/external_project/seqan3_fetch_content_zip/CMakeLists.txt
+#    It uses fetch_content (a CMake 3.14 feature) to download our zip-release (e.g. zip, tar.xz) from
+#    https://github.com/seqan/seqan3/releases. fetch_content will automatically download, verify, extract it.
+#    The user only needs to define CMAKE_PREFIX_PATH to be able to find our `seqan3-config.cmake`.
+#    Note that FetchContent is a CMake >= 3.14 feature.
+#    This is expected to work with CMake >= 3.14.
+# (ExternalProject_Add simulates a fresh and separate invocation of cmake ../)
+if (NOT ${CMAKE_VERSION} VERSION_LESS 3.14)
+    ExternalProject_Add (
+        seqan3_fetch_content_zip
+        PREFIX seqan3_fetch_content_zip
+        SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/seqan3_fetch_content_zip"
+        CMAKE_ARGS
+            ${SEQAN3_EXTERNAL_PROJECT_CMAKE_ARGS}
+            "-DSEQAN3_PACKAGE_ZIP_URL=${SEQAN3_PACKAGE_ZIP_URL}"
+            "-DCMAKE_FIND_DEBUG_MODE=${SEQAN3_EXTERNAL_PROJECT_FIND_DEBUG_MODE}"
+    )
+    add_dependencies(seqan3_fetch_content_zip seqan3_test_prerequisite)
+endif ()

--- a/test/external_project/CMakeLists.txt
+++ b/test/external_project/CMakeLists.txt
@@ -12,11 +12,38 @@ include (../seqan3-test.cmake) # for SEQAN3_EXTERNAL_PROJECT_CMAKE_ARGS, SEQAN3_
 include (ExternalProject)
 
 set (SEQAN3_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../")
-include (install-seqan3.cmake)
+
+if (NOT ${CMAKE_VERSION} VERSION_LESS 3.14) # cmake 3.14 version is needed to install seqan3.
+    include (install-seqan3.cmake)
+endif ()
 
 option (SEQAN3_EXTERNAL_PROJECT_FIND_DEBUG_MODE
         "Enable this option if you want to get a detailed list which paths were considered for find_package(...)"
         false)
+
+if (NOT ${CMAKE_VERSION} VERSION_LESS 3.14) # cmake 3.14 version is needed to install cmake 3.4.
+    set (SEQAN3_EXTERNAL_PROJECT_CMAKE_COMMAND "${CMAKE_COMMAND}")
+    include (use-cmake3.4.cmake) # ensure that seqan3 can be used with cmake 3.4
+else ()
+    set (SEQAN3_EXTERNAL_PROJECT_CMAKE_COMMAND "${CMAKE_COMMAND}")
+endif ()
+
+# Here is an explanation of what happens:
+#
+# If your current CMake version is < 3.14, we
+#  * test test/external_project/seqan3_submodule_add_subdirectory/CMakeLists.txt with your current CMake version
+#  * test test/external_project/seqan3_submodule_find_package/CMakeLists.txt with your current CMake version
+#  * DO NOT test test/external_project/seqan3_installed/CMakeLists.txt, because we need 3.14 to be able to
+#    package seqan3 to execute the test.
+#  * DO NOT test test/external_project/seqan3_fetch_content_zip/CMakeLists.txt, because we need 3.14 in order to use
+#    fetch_content
+#
+# If your current CMake version is >= 3.14, we
+#  * download CMake  3.4
+#  * test test/external_project/seqan3_submodule_add_subdirectory/CMakeLists.txt with CMake 3.4
+#  * test test/external_project/seqan3_submodule_find_package/CMakeLists.txt with CMake 3.4
+#  * test test/external_project/seqan3_installed/CMakeLists.txt with CMake 3.4
+#  * test test/external_project/seqan3_fetch_content_zip/CMakeLists.txt with your current CMake version
 
 # 1) This tests test/external_project/seqan3_submodule_add_subdirectory/CMakeLists.txt
 #    That means we use add_subdirectory directly on seqan3's top level CMakeLists.txt.
@@ -27,6 +54,7 @@ ExternalProject_Add (
     seqan3_submodule_add_subdirectory
     PREFIX seqan3_submodule_add_subdirectory
     SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/seqan3_submodule_add_subdirectory"
+    CMAKE_COMMAND "${SEQAN3_EXTERNAL_PROJECT_CMAKE_COMMAND}"
     CMAKE_ARGS
         ${SEQAN3_EXTERNAL_PROJECT_CMAKE_ARGS}
         "-DSEQAN3_ROOT=${SEQAN3_ROOT}"
@@ -42,6 +70,7 @@ ExternalProject_Add (
     seqan3_submodule_find_package
     PREFIX seqan3_submodule_find_package
     SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/seqan3_submodule_find_package"
+    CMAKE_COMMAND "${SEQAN3_EXTERNAL_PROJECT_CMAKE_COMMAND}"
     CMAKE_ARGS
         ${SEQAN3_EXTERNAL_PROJECT_CMAKE_ARGS}
         "-DCMAKE_PREFIX_PATH=${SEQAN3_ROOT}/build_system"
@@ -64,6 +93,7 @@ if (NOT ${CMAKE_VERSION} VERSION_LESS 3.14) # cmake 3.14 version is needed to in
         seqan3_installed
         PREFIX seqan3_installed
         SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/seqan3_installed"
+        CMAKE_COMMAND "${SEQAN3_EXTERNAL_PROJECT_CMAKE_COMMAND}"
         CMAKE_ARGS
             ${SEQAN3_EXTERNAL_PROJECT_CMAKE_ARGS}
             "-DCMAKE_SYSTEM_PREFIX_PATH=${SEQAN3_SYSTEM_PREFIX}"
@@ -79,7 +109,7 @@ endif ()
 #    Note that FetchContent is a CMake >= 3.14 feature.
 #    This is expected to work with CMake >= 3.14.
 # (ExternalProject_Add simulates a fresh and separate invocation of cmake ../)
-if (NOT ${CMAKE_VERSION} VERSION_LESS 3.14)
+if (NOT ${CMAKE_VERSION} VERSION_LESS 3.14) # cmake 3.14 version is needed to use fetch_content.
     ExternalProject_Add (
         seqan3_fetch_content_zip
         PREFIX seqan3_fetch_content_zip

--- a/test/external_project/find-package-diagnostics.cmake
+++ b/test/external_project/find-package-diagnostics.cmake
@@ -1,0 +1,40 @@
+# -----------------------------------------------------------------------------------------------------
+# Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+# Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+# This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+# shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+# -----------------------------------------------------------------------------------------------------
+
+# list all search places
+# NOTE: this can be enabled globally by -DSEQAN3_EXTERNAL_PROJECT_FIND_DEBUG_MODE=1 to help debug search paths
+# set (CMAKE_FIND_DEBUG_MODE ${SEQAN3_EXTERNAL_PROJECT_FIND_DEBUG_MODE})
+
+message (STATUS "CMAKE_COMMAND: ${CMAKE_COMMAND}")
+message (STATUS "CMAKE_VERSION: ${CMAKE_VERSION}")
+message (STATUS "CMAKE_SYSTEM_NAME: ${CMAKE_SYSTEM_NAME}")
+
+message (STATUS "search paths: (see https://cmake.org/cmake/help/latest/command/find_package.html#search-procedure)")
+message (STATUS "1) CMAKE_FIND_USE_PACKAGE_ROOT_PATH: ${CMAKE_FIND_USE_CMAKE_PATH}")
+message (STATUS "   SeqAn3_ROOT: ${SeqAn3_ROOT}")
+
+message (STATUS "2) CMAKE_FIND_USE_CMAKE_PATH: ${CMAKE_FIND_USE_CMAKE_PATH}")
+message (STATUS "   CMAKE_PREFIX_PATH: ${CMAKE_PREFIX_PATH}")
+message (STATUS "   CMAKE_FRAMEWORK_PATH: ${CMAKE_FRAMEWORK_PATH}")
+message (STATUS "   CMAKE_APPBUNDLE_PATH: ${CMAKE_APPBUNDLE_PATH}")
+
+message (STATUS "3) CMAKE_FIND_USE_CMAKE_ENVIRONMENT_PATH: ${CMAKE_FIND_USE_CMAKE_ENVIRONMENT_PATH}")
+message (STATUS "   SeqAn3_DIR: ${SeqAn3_DIR}")
+
+# 4) with hints. See point 4 in https://cmake.org/cmake/help/latest/command/find_package.html#search-procedure.
+# There is no output.
+
+message (STATUS "5) CMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH: ${CMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH}")
+
+message (STATUS "6) CMAKE_FIND_USE_PACKAGE_REGISTRY: ${CMAKE_FIND_USE_PACKAGE_REGISTRY}")
+
+message (STATUS "7) CMAKE_FIND_USE_CMAKE_SYSTEM_PATH: ${CMAKE_FIND_USE_CMAKE_SYSTEM_PATH}")
+message (STATUS "   CMAKE_SYSTEM_PREFIX_PATH: ${CMAKE_SYSTEM_PREFIX_PATH}")
+message (STATUS "   CMAKE_SYSTEM_FRAMEWORK_PATH: ${CMAKE_SYSTEM_FRAMEWORK_PATH}")
+message (STATUS "   CMAKE_SYSTEM_APPBUNDLE_PATH: ${CMAKE_SYSTEM_APPBUNDLE_PATH}")
+
+message (STATUS "8) CMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY: ${CMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY}")

--- a/test/external_project/install-seqan3.cmake
+++ b/test/external_project/install-seqan3.cmake
@@ -1,0 +1,33 @@
+# -----------------------------------------------------------------------------------------------------
+# Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+# Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+# This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+# shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+# -----------------------------------------------------------------------------------------------------
+
+cmake_minimum_required (VERSION 3.14)
+
+# install and package seqan3 library
+ExternalProject_Add (
+    seqan3_test_prerequisite
+    PREFIX seqan3_test_prerequisite
+    SOURCE_DIR "${SEQAN3_ROOT}"
+    CMAKE_ARGS
+        ${SEQAN3_EXTERNAL_PROJECT_CMAKE_ARGS}
+        "-DCMAKE_INSTALL_PREFIX=<BINARY_DIR>/usr"
+    STEP_TARGETS configure install
+    BUILD_BYPRODUCTS "<BINARY_DIR>/include"
+)
+set (SEQAN3_PACKAGE_ZIP_URL "${PROJECT_BINARY_DIR}/seqan3-${SEQAN3_VERSION}-${CMAKE_SYSTEM_NAME}.zip")
+ExternalProject_Add_Step (
+    seqan3_test_prerequisite
+    package
+    COMMAND ${CMAKE_CPACK_COMMAND} -G ZIP -B "${PROJECT_BINARY_DIR}"
+    DEPENDEES configure install
+    WORKING_DIRECTORY "<BINARY_DIR>"
+    BYPRODUCTS
+        ${SEQAN3_PACKAGE_ZIP_URL}
+        "${SEQAN3_PACKAGE_ZIP_URL}.sha256"
+)
+ExternalProject_Get_property(seqan3_test_prerequisite BINARY_DIR)
+set (SEQAN3_SYSTEM_PREFIX "${BINARY_DIR}/usr")

--- a/test/external_project/seqan3_fetch_content_zip/CMakeLists.txt
+++ b/test/external_project/seqan3_fetch_content_zip/CMakeLists.txt
@@ -1,0 +1,36 @@
+# -----------------------------------------------------------------------------------------------------
+# Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+# Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+# This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+# shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+# -----------------------------------------------------------------------------------------------------
+
+cmake_minimum_required (VERSION 3.14)
+project (seqan3_app CXX)
+
+# --- helper scripts
+include (../find-package-diagnostics.cmake)
+file (SHA256 "${SEQAN3_PACKAGE_ZIP_URL}" SEQAN3_PACKAGE_ZIP_HASH)
+message (STATUS "SEQAN3_PACKAGE_ZIP_URL: ${SEQAN3_PACKAGE_ZIP_URL}")
+message (STATUS "SEQAN3_PACKAGE_ZIP_HASH: SHA256=${SEQAN3_PACKAGE_ZIP_HASH}")
+# ---
+
+# fetch seqan3 sources (requires >= cmake 3.14)
+include (FetchContent)
+FetchContent_Declare (
+    seqan3
+    URL "${SEQAN3_PACKAGE_ZIP_URL}" # change these values
+    URL_HASH "SHA256=${SEQAN3_PACKAGE_ZIP_HASH}" # change these values
+)
+FetchContent_MakeAvailable(seqan3)
+
+# add seqan3 to search path
+list(APPEND CMAKE_PREFIX_PATH "${seqan3_SOURCE_DIR}")
+
+# require seqan3 with a version between >=3.0.0 and <4.0.0
+find_package (seqan3 3.0 REQUIRED)
+
+# build app with seqan3
+add_executable (hello_world ../src/hello_world.cpp)
+target_link_libraries (hello_world seqan3::seqan3)
+install (TARGETS hello_world)

--- a/test/external_project/seqan3_installed/CMakeLists.txt
+++ b/test/external_project/seqan3_installed/CMakeLists.txt
@@ -1,0 +1,25 @@
+# -----------------------------------------------------------------------------------------------------
+# Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+# Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+# This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+# shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+# -----------------------------------------------------------------------------------------------------
+
+cmake_minimum_required (VERSION 3.4)
+project (seqan3_app CXX)
+
+# --- helper scripts
+include (../find-package-diagnostics.cmake)
+# ---
+
+# require seqan3 with a version between >=3.0.0 and <4.0.0
+find_package (seqan3 3.0 REQUIRED)
+
+# build app with seqan3
+add_executable (hello_world ../src/hello_world.cpp)
+target_link_libraries (hello_world seqan3::seqan3)
+if (CMAKE_VERSION VERSION_LESS 3.14)
+    install (TARGETS hello_world RUNTIME DESTINATION bin)
+else ()
+    install (TARGETS hello_world) # RUNTIME DESTINATION not needed anymore since cmake 3.14
+endif ()

--- a/test/external_project/seqan3_submodule_add_subdirectory/CMakeLists.txt
+++ b/test/external_project/seqan3_submodule_add_subdirectory/CMakeLists.txt
@@ -1,0 +1,26 @@
+# -----------------------------------------------------------------------------------------------------
+# Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+# Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+# This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+# shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+# -----------------------------------------------------------------------------------------------------
+
+cmake_minimum_required (VERSION 3.4)
+project (seqan3_app CXX)
+
+# --- helper scripts
+include (../find-package-diagnostics.cmake)
+# ---
+
+# use git checkout of seqan3
+option (INSTALL_SEQAN3 "" OFF) # we don't need to install seqan3
+add_subdirectory ("${SEQAN3_ROOT}" "seqan3_build")
+
+# build app with seqan3
+add_executable (hello_world ../src/hello_world.cpp)
+target_link_libraries (hello_world seqan3::seqan3)
+if (CMAKE_VERSION VERSION_LESS 3.14)
+    install (TARGETS hello_world RUNTIME DESTINATION bin)
+else ()
+    install (TARGETS hello_world) # RUNTIME DESTINATION not needed anymore since cmake 3.14
+endif ()

--- a/test/external_project/seqan3_submodule_find_package/CMakeLists.txt
+++ b/test/external_project/seqan3_submodule_find_package/CMakeLists.txt
@@ -1,0 +1,28 @@
+# -----------------------------------------------------------------------------------------------------
+# Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+# Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+# This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+# shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+# -----------------------------------------------------------------------------------------------------
+
+cmake_minimum_required (VERSION 3.4)
+project (seqan3_app CXX)
+
+# --- helper scripts
+include (../find-package-diagnostics.cmake)
+# ---
+
+# add seqan3 to search path
+list(APPEND CMAKE_PREFIX_PATH "${CMAKE_CURRENT_SOURCE_DIR}/submodules/seqan3/build_system") # change this value
+
+# require seqan3 with a version between >=3.0.0 and <4.0.0
+find_package (seqan3 3.0 REQUIRED)
+
+# build app with seqan3
+add_executable (hello_world ../src/hello_world.cpp)
+target_link_libraries (hello_world seqan3::seqan3)
+if (CMAKE_VERSION VERSION_LESS 3.14)
+    install (TARGETS hello_world RUNTIME DESTINATION bin)
+else ()
+    install (TARGETS hello_world) # RUNTIME DESTINATION not needed anymore since cmake 3.14
+endif ()

--- a/test/external_project/src/hello_world.cpp
+++ b/test/external_project/src/hello_world.cpp
@@ -1,0 +1,7 @@
+#include <seqan3/core/debug_stream.hpp>
+
+int main()
+{
+    seqan3::debug_stream << "Hello World!\n";
+    return 0;
+}

--- a/test/external_project/use-cmake3.4.cmake
+++ b/test/external_project/use-cmake3.4.cmake
@@ -1,0 +1,36 @@
+# -----------------------------------------------------------------------------------------------------
+# Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+# Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+# This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+# shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+# -----------------------------------------------------------------------------------------------------
+
+cmake_minimum_required (VERSION 3.14)
+project (seqan3_test_seqan3_config CXX)
+
+# require Linux and x86_64
+if (NOT (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SIZEOF_VOID_P EQUAL 8))
+    message (STATUS "cmake 3.4 test requires Linux and x86_64")
+    return ()
+endif ()
+
+include (FetchContent)
+FetchContent_Declare (
+    cmake34
+    URL "https://github.com/Kitware/CMake/releases/download/v3.4.3/cmake-3.4.3-Linux-x86_64.tar.gz"
+    URL_HASH "SHA256=66b8d315c852908be9f79e1a18b8778714659fce4ddb2d041af8680a239202fc"
+)
+FetchContent_MakeAvailable(cmake34)
+
+set (cmake34_command "${cmake34_SOURCE_DIR}/bin/cmake")
+
+execute_process(COMMAND ${cmake34_command} --version
+                RESULT_VARIABLE cmake34_result
+                OUTPUT_VARIABLE cmake34_output)
+
+if("${cmake34_result}" STREQUAL "0" AND cmake34_output MATCHES "cmake version 3.4.3")
+    set (SEQAN3_EXTERNAL_PROJECT_CMAKE_COMMAND "${cmake34_command}")
+    message (STATUS "Use cmake3.4 in tests [${cmake34_command}]")
+else ()
+    message (AUTHOR_WARNING "Couldn't execute cmake3.4 --version [${cmake34_command}]")
+endif ()


### PR DESCRIPTION
This PR adds CI tests to ensure that https://github.com/seqan/seqan3/issues/1203 does always work and fixes https://github.com/seqan/product_backlog/issues/140.