### PR TITLE
[TEST] use EXPECT_SAME_TYPE macro (oneline regexp)

### DIFF
--- a/test/unit/alignment/configuration/align_config_score_type_test.cpp
+++ b/test/unit/alignment/configuration/align_config_score_type_test.cpp
@@ -11,6 +11,7 @@
 
 #include <seqan3/alignment/configuration/align_config_score_type.hpp>
 #include <seqan3/core/configuration/configuration.hpp>
+#include <seqan3/test/expect_same_type.hpp>
 #include <seqan3/utility/type_traits/basic.hpp>
 
 #include "../../core/algorithm/pipeable_config_element_test_template.hpp"
@@ -27,11 +28,11 @@ TEST(align_config_score_type, score_type)
 {
     EXPECT_TRUE((std::same_as<std::remove_cvref_t<decltype(seqan3::align_cfg::score_type<int32_t>{})>,
                               seqan3::align_cfg::score_type<int32_t>>));                            // default case
-    EXPECT_TRUE((std::same_as<decltype(seqan3::align_cfg::score_type<int32_t>{})::type, int32_t>)); // default case
+    EXPECT_SAME_TYPE(decltype(seqan3::align_cfg::score_type<int32_t>{})::type, int32_t); // default case
 
-    EXPECT_TRUE((std::same_as<decltype(seqan3::align_cfg::score_type<int16_t>{})::type, int16_t>));
-    EXPECT_TRUE((std::same_as<decltype(seqan3::align_cfg::score_type<float>{})::type, float>));
-    EXPECT_TRUE((std::same_as<decltype(seqan3::align_cfg::score_type<double>{})::type, double>));
+    EXPECT_SAME_TYPE(decltype(seqan3::align_cfg::score_type<int16_t>{})::type, int16_t);
+    EXPECT_SAME_TYPE(decltype(seqan3::align_cfg::score_type<float>{})::type, float);
+    EXPECT_SAME_TYPE(decltype(seqan3::align_cfg::score_type<double>{})::type, double);
 }
 
 TEST(align_config_score_type, score_type_exists)

--- a/test/unit/alignment/matrix/alignment_coordinate_test.cpp
+++ b/test/unit/alignment/matrix/alignment_coordinate_test.cpp
@@ -12,28 +12,29 @@
 #include <range/v3/view/iota.hpp>
 
 #include <seqan3/alignment/matrix/alignment_coordinate.hpp>
+#include <seqan3/test/expect_same_type.hpp>
 #include <seqan3/test/pretty_printing.hpp>
 
 TEST(advanceable_alignment_coordinate, column_index_type)
 {
     seqan3::detail::column_index_type ci{1u};
     EXPECT_EQ(ci.get(), 1u);
-    EXPECT_TRUE((std::same_as<std::remove_reference_t<decltype(ci.get())>, size_t>));
+    EXPECT_SAME_TYPE(std::remove_reference_t<decltype(ci.get())>, size_t);
 
     seqan3::detail::column_index_type ci2{1};
     EXPECT_EQ(ci2.get(), 1);
-    EXPECT_TRUE((std::same_as<std::remove_reference_t<decltype(ci2.get())>, std::ptrdiff_t>));
+    EXPECT_SAME_TYPE(std::remove_reference_t<decltype(ci2.get())>, std::ptrdiff_t);
 }
 
 TEST(advanceable_alignment_coordinate, row_index_type)
 {
     seqan3::detail::row_index_type ri{1u};
     EXPECT_EQ(ri.get(), 1u);
-    EXPECT_TRUE((std::same_as<std::remove_reference_t<decltype(ri.get())>, size_t>));
+    EXPECT_SAME_TYPE(std::remove_reference_t<decltype(ri.get())>, size_t);
 
     seqan3::detail::row_index_type ri2{1};
     EXPECT_EQ(ri2.get(), 1);
-    EXPECT_TRUE((std::same_as<std::remove_reference_t<decltype(ri2.get())>, std::ptrdiff_t>));
+    EXPECT_SAME_TYPE(std::remove_reference_t<decltype(ri2.get())>, std::ptrdiff_t);
 }
 
 TEST(advanceable_alignment_coordinate, construction)
@@ -263,7 +264,7 @@ TEST(advanceable_alignment_coordinate, iota_column_index)
     col_incrementable co_end{seqan3::detail::column_index_type{5u}, seqan3::detail::row_index_type{0u}};
     auto v = std::views::iota(co_begin, co_end);
 
-    EXPECT_TRUE((std::same_as<decltype(v.begin()), decltype(v.end())>));
+    EXPECT_SAME_TYPE(decltype(v.begin()), decltype(v.end()));
     EXPECT_EQ((*(--v.end())).first, 4u);
 
     size_t test = 0u;
@@ -280,7 +281,7 @@ TEST(advanceable_alignment_coordinate, iota_row_index)
     row_incrementable co_end{seqan3::detail::column_index_type{0u}, seqan3::detail::row_index_type{5u}};
     auto v = std::views::iota(co_begin, co_end);
 
-    EXPECT_TRUE((std::same_as<decltype(v.begin()), decltype(v.end())>));
+    EXPECT_SAME_TYPE(decltype(v.begin()), decltype(v.end()));
     EXPECT_EQ((*(--v.end())).second, 4u);
 
     size_t test = 0u;

--- a/test/unit/alignment/matrix/debug_matrix_test.cpp
+++ b/test/unit/alignment/matrix/debug_matrix_test.cpp
@@ -10,6 +10,7 @@
 #include <seqan3/alignment/matrix/debug_matrix.hpp>
 #include <seqan3/alignment/matrix/trace_directions.hpp>
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
+#include <seqan3/test/expect_same_type.hpp>
 
 using seqan3::operator""_dna4;
 using seqan3::operator|;
@@ -368,9 +369,9 @@ TEST_F(debug_matrix_test, construct_with_references)
     using first_sequence_type = typename debug_matrix_traits<debug_matrix_type>::first_sequence_type;
     using second_sequence_type = typename debug_matrix_traits<debug_matrix_type>::second_sequence_type;
 
-    EXPECT_TRUE((std::same_as<matrix_type, seqan3::detail::row_wise_matrix<int> &>));
-    EXPECT_TRUE((std::same_as<first_sequence_type, std::vector<seqan3::dna4> &>));
-    EXPECT_TRUE((std::same_as<second_sequence_type, std::vector<seqan3::dna4> &>));
+    EXPECT_SAME_TYPE(matrix_type, seqan3::detail::row_wise_matrix<int> &);
+    EXPECT_SAME_TYPE(first_sequence_type, std::vector<seqan3::dna4> &);
+    EXPECT_SAME_TYPE(second_sequence_type, std::vector<seqan3::dna4> &);
 }
 
 TEST_F(debug_matrix_test, construct_with_move)
@@ -381,9 +382,9 @@ TEST_F(debug_matrix_test, construct_with_move)
     using first_sequence_type = typename debug_matrix_traits<debug_matrix_type>::first_sequence_type;
     using second_sequence_type = typename debug_matrix_traits<debug_matrix_type>::second_sequence_type;
 
-    EXPECT_TRUE((std::same_as<matrix_type, seqan3::detail::row_wise_matrix<int>>));
-    EXPECT_TRUE((std::same_as<first_sequence_type, std::vector<seqan3::dna4>>));
-    EXPECT_TRUE((std::same_as<second_sequence_type, std::vector<seqan3::dna4>>));
+    EXPECT_SAME_TYPE(matrix_type, seqan3::detail::row_wise_matrix<int>);
+    EXPECT_SAME_TYPE(first_sequence_type, std::vector<seqan3::dna4>);
+    EXPECT_SAME_TYPE(second_sequence_type, std::vector<seqan3::dna4>);
 }
 
 TEST_F(score_matrix_test, other_matrix)

--- a/test/unit/alignment/pairwise/align_pairwise_test.cpp
+++ b/test/unit/alignment/pairwise/align_pairwise_test.cpp
@@ -19,6 +19,7 @@
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/range/views/to_char.hpp>
 #include <seqan3/range/views/to.hpp>
+#include <seqan3/test/expect_same_type.hpp>
 #include <seqan3/utility/tuple/concept.hpp>
 
 using seqan3::operator""_dna4;
@@ -171,7 +172,7 @@ TYPED_TEST(align_pairwise_test, single_pair_double_score)
             for (auto && res : call_alignment<TypeParam>(p, cfg))
             {
                 EXPECT_EQ(res.score(), -4.0);
-                EXPECT_TRUE((std::same_as<decltype(res.score()), double>));
+                EXPECT_SAME_TYPE(decltype(res.score()), double);
             }
         }
 

--- a/test/unit/alignment/pairwise/alignment_configurator_test.cpp
+++ b/test/unit/alignment/pairwise/alignment_configurator_test.cpp
@@ -7,6 +7,8 @@
 
 #include <gtest/gtest.h>
 
+#include <seqan3/std/ranges>
+
 #include <range/v3/view/single.hpp>
 
 #include <seqan3/alignment/configuration/align_config_score_type.hpp>
@@ -15,7 +17,7 @@
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/range/views/chunk.hpp>
 #include <seqan3/range/views/zip.hpp>
-#include <seqan3/std/ranges>
+#include <seqan3/test/expect_same_type.hpp>
 
 using seqan3::operator""_dna4;
 
@@ -276,5 +278,5 @@ TEST(alignment_configurator, configure_result_score_type)
     EXPECT_DOUBLE_EQ(result.score(), 0.0);
     EXPECT_EQ(result.sequence1_end_position(), 4u);
     EXPECT_EQ(result.sequence2_end_position(), 4u);
-    EXPECT_TRUE((std::same_as<decltype(result.score()), double>));
+    EXPECT_SAME_TYPE(decltype(result.score()), double);
 }

--- a/test/unit/alignment/pairwise/alignment_result_test.cpp
+++ b/test/unit/alignment/pairwise/alignment_result_test.cpp
@@ -21,6 +21,7 @@
 #include <seqan3/range/views/persist.hpp>
 #include <seqan3/range/views/to_char.hpp>
 #include <seqan3/range/views/to.hpp>
+#include <seqan3/test/expect_same_type.hpp>
 
 using seqan3::operator""_dna4;
 using seqan3::operator""_rna5;
@@ -311,5 +312,5 @@ TEST(alignment_result_test, access_result_value_type)
     seqan3::alignment_result result(result_value);
 
     using result_value_t = typename seqan3::detail::alignment_result_value_type_accessor<decltype(result)>::type;
-    EXPECT_TRUE((std::same_as<result_value_t, decltype(result_value)>));
+    EXPECT_SAME_TYPE(result_value_t, decltype(result_value));
 }

--- a/test/unit/alignment/pairwise/detail/type_traits_test.cpp
+++ b/test/unit/alignment/pairwise/detail/type_traits_test.cpp
@@ -7,10 +7,11 @@
 
 #include <gtest/gtest.h>
 
+#include <seqan3/std/concepts>
 #include <string>
 
 #include <seqan3/alignment/pairwise/detail/type_traits.hpp>
-#include <seqan3/std/concepts>
+#include <seqan3/test/expect_same_type.hpp>
 
 TEST(traits, alignment_function_traits)
 {
@@ -24,7 +25,7 @@ TEST(traits, alignment_function_traits)
     using callback_t = typename function_traits_t::callback_type;
     using alignment_result_t = typename function_traits_t::alignment_result_type;
 
-    EXPECT_TRUE((std::same_as<input_t, std::string>));
-    EXPECT_TRUE((std::same_as<callback_t, result_callback_t>));
-    EXPECT_TRUE((std::same_as<alignment_result_t, int>));
+    EXPECT_SAME_TYPE(input_t, std::string);
+    EXPECT_SAME_TYPE(callback_t, result_callback_t);
+    EXPECT_SAME_TYPE(alignment_result_t, int);
 }

--- a/test/unit/alignment/pairwise/pairwise_alignment_single_callback_test_template.hpp
+++ b/test/unit/alignment/pairwise/pairwise_alignment_single_callback_test_template.hpp
@@ -13,6 +13,7 @@
 #include <seqan3/alignment/pairwise/align_pairwise.hpp>
 #include <seqan3/range/views/to_char.hpp>
 #include <seqan3/test/expect_range_eq.hpp>
+#include <seqan3/test/expect_same_type.hpp>
 
 #include "fixture/alignment_fixture.hpp"
 
@@ -57,7 +58,7 @@ TYPED_TEST_P(pairwise_alignment_callback_test, end_positions)
                                       seqan3::align_cfg::on_result{[&] (auto && result)
                                       {
                                           EXPECT_EQ(result.score(), fixture.score);
-                                          EXPECT_TRUE((std::same_as<decltype(result.score()), double>));
+                                          EXPECT_SAME_TYPE(decltype(result.score()), double);
                                           EXPECT_EQ(result.sequence1_end_position(), fixture.end_positions.first);
                                           EXPECT_EQ(result.sequence2_end_position(), fixture.end_positions.second);
                                       }};

--- a/test/unit/alignment/pairwise/pairwise_alignment_single_test_template.hpp
+++ b/test/unit/alignment/pairwise/pairwise_alignment_single_test_template.hpp
@@ -14,6 +14,7 @@
 #include <seqan3/range/views/to_char.hpp>
 #include <seqan3/range/views/to.hpp>
 #include <seqan3/test/expect_range_eq.hpp>
+#include <seqan3/test/expect_same_type.hpp>
 
 #include "fixture/alignment_fixture.hpp"
 
@@ -61,7 +62,7 @@ TYPED_TEST_P(pairwise_alignment_test, end_positions)
     auto res = *alignment_rng.begin();
 
     EXPECT_EQ(res.score(), fixture.score);
-    EXPECT_TRUE((std::same_as<decltype(res.score()), double>));
+    EXPECT_SAME_TYPE(decltype(res.score()), double);
     EXPECT_EQ(res.sequence1_end_position(), fixture.end_positions.first);
     EXPECT_EQ(res.sequence2_end_position(), fixture.end_positions.second);
 }

--- a/test/unit/core/algorithm/pipeable_config_element_test_template.hpp
+++ b/test/unit/core/algorithm/pipeable_config_element_test_template.hpp
@@ -13,6 +13,7 @@
 
 #include <seqan3/core/algorithm/pipeable_config_element.hpp>
 #include <seqan3/core/configuration/configuration.hpp>
+#include <seqan3/test/expect_same_type.hpp>
 
 #include "../configuration/configuration_mock.hpp"
 
@@ -46,13 +47,13 @@ TYPED_TEST_P(pipeable_config_element_test, base_class_construction)
 TYPED_TEST_P(pipeable_config_element_test, configuration_construction)
 {
     seqan3::configuration cfg{TypeParam{}};
-    EXPECT_TRUE((std::same_as<decltype(cfg), seqan3::configuration<TypeParam>>));
+    EXPECT_SAME_TYPE(decltype(cfg), seqan3::configuration<TypeParam>);
 }
 
 TYPED_TEST_P(pipeable_config_element_test, configuration_assignment)
 {
     seqan3::configuration cfg = TypeParam{};
-    EXPECT_TRUE((std::same_as<decltype(cfg), seqan3::configuration<TypeParam>>));
+    EXPECT_SAME_TYPE(decltype(cfg), seqan3::configuration<TypeParam>);
 }
 
 TYPED_TEST_P(pipeable_config_element_test, exists)

--- a/test/unit/core/configuration/configuration_test.cpp
+++ b/test/unit/core/configuration/configuration_test.cpp
@@ -11,6 +11,7 @@
 
 #include <seqan3/core/configuration/configuration.hpp>
 #include <seqan3/test/expect_range_eq.hpp>
+#include <seqan3/test/expect_same_type.hpp>
 
 #include "configuration_mock.hpp"
 
@@ -243,28 +244,28 @@ TEST(configuration, remove_by_type)
         seqan3::configuration<foo, bax, bar> cfg{};
 
         // remove middle
-        EXPECT_TRUE((std::same_as<decltype(cfg.template remove<bax>()), seqan3::configuration<foo, bar>>));
+        EXPECT_SAME_TYPE(decltype(cfg.template remove<bax>()), (seqan3::configuration<foo, bar>));
         // remove head
-        EXPECT_TRUE((std::same_as<decltype(cfg.template remove<bar>()), seqan3::configuration<foo, bax>>));
+        EXPECT_SAME_TYPE(decltype(cfg.template remove<bar>()), (seqan3::configuration<foo, bax>));
         // remove tail
-        EXPECT_TRUE((std::same_as<decltype(cfg.template remove<foo>()), seqan3::configuration<bax, bar>>));
+        EXPECT_SAME_TYPE(decltype(cfg.template remove<foo>()), (seqan3::configuration<bax, bar>));
 
         seqan3::configuration<foo> single_cfg{};
-        EXPECT_TRUE((std::same_as<decltype(single_cfg.template remove<foo>()), seqan3::configuration<>>));
+        EXPECT_SAME_TYPE(decltype(single_cfg.template remove<foo>()), seqan3::configuration<>);
     }
 
     {   // const cfg
         seqan3::configuration<foo, bax, bar> const cfg{};
 
         // remove middle
-        EXPECT_TRUE((std::same_as<decltype(cfg.template remove<bax>()), seqan3::configuration<foo, bar>>));
+        EXPECT_SAME_TYPE(decltype(cfg.template remove<bax>()), (seqan3::configuration<foo, bar>));
         // remove head
-        EXPECT_TRUE((std::same_as<decltype(cfg.template remove<bar>()), seqan3::configuration<foo, bax>>));
+        EXPECT_SAME_TYPE(decltype(cfg.template remove<bar>()), (seqan3::configuration<foo, bax>));
         // remove tail
-        EXPECT_TRUE((std::same_as<decltype(cfg.template remove<foo>()), seqan3::configuration<bax, bar>>));
+        EXPECT_SAME_TYPE(decltype(cfg.template remove<foo>()), (seqan3::configuration<bax, bar>));
 
         seqan3::configuration<foo> const single_cfg{};
-        EXPECT_TRUE((std::same_as<decltype(single_cfg.template remove<foo>()), seqan3::configuration<>>));
+        EXPECT_SAME_TYPE(decltype(single_cfg.template remove<foo>()), seqan3::configuration<>);
     }
 }
 
@@ -273,19 +274,19 @@ TEST(configuration, remove_by_type_template)
     {
         seqan3::configuration<foo, foobar<>, bar> cfg{};
 
-        EXPECT_TRUE((std::same_as<decltype(cfg.template remove<foobar>()), seqan3::configuration<foo, bar>>));
+        EXPECT_SAME_TYPE(decltype(cfg.template remove<foobar>()), (seqan3::configuration<foo, bar>));
 
         seqan3::configuration<foobar<>> single_cfg{};
-        EXPECT_TRUE((std::same_as<decltype(single_cfg.template remove<foobar>()), seqan3::configuration<>>));
+        EXPECT_SAME_TYPE(decltype(single_cfg.template remove<foobar>()), seqan3::configuration<>);
     }
 
     {   //const cfg
         seqan3::configuration<foo, foobar<>, bar> const cfg{};
 
-        EXPECT_TRUE((std::same_as<decltype(cfg.template remove<foobar>()), seqan3::configuration<foo, bar>>));
+        EXPECT_SAME_TYPE(decltype(cfg.template remove<foobar>()), (seqan3::configuration<foo, bar>));
 
         seqan3::configuration<foobar<>> const single_cfg{};
-        EXPECT_TRUE((std::same_as<decltype(single_cfg.template remove<foobar>()), seqan3::configuration<>>));
+        EXPECT_SAME_TYPE(decltype(single_cfg.template remove<foobar>()), seqan3::configuration<>);
     }
 }
 
@@ -295,19 +296,19 @@ TEST(configuration, get_or_by_type)
 
     { // l-value
         EXPECT_FLOAT_EQ(cfg.get_or(bax{1.3}).value, 2.2);
-        EXPECT_TRUE((std::same_as<decltype(cfg.get_or(bax{1.3})), bax &>));
+        EXPECT_SAME_TYPE(decltype(cfg.get_or(bax{1.3})), bax &);
         EXPECT_EQ(cfg.get_or(foo{"test"}).value, "test");
     }
 
     { // const l-value
         EXPECT_FLOAT_EQ(std::as_const(cfg).get_or(bax{1.3}).value, 2.2);
-        EXPECT_TRUE((std::same_as<decltype(std::as_const(cfg).get_or(bax{1.3})), bax const &>));
+        EXPECT_SAME_TYPE(decltype(std::as_const(cfg).get_or(bax{1.3})), bax const &);
         EXPECT_EQ(std::as_const(cfg).get_or(foo{"test"}).value, "test");
     }
 
     { // r-value
         EXPECT_FLOAT_EQ(std::move(seqan3::configuration<bax, bar>{cfg}).get_or(bax{1.3}).value, 2.2);
-        EXPECT_TRUE((std::same_as<decltype(seqan3::configuration<bax, bar>{cfg}.get_or(bax{1.3})), bax &&>));
+        EXPECT_SAME_TYPE(decltype(seqan3::configuration<bax, bar>{cfg}.get_or(bax{1.3})), bax &&);
         EXPECT_EQ(std::move(seqan3::configuration<bax, bar>{cfg}).get_or(foo{"test"}).value, "test");
     }
 
@@ -316,7 +317,7 @@ TEST(configuration, get_or_by_type)
         EXPECT_FLOAT_EQ(std::move(cfg_cr).get_or(bax{1.3}).value, 2.2);
         // TODO: Enable when gcc7 support is dropped or seqan3::get is implemented as CPO.
         // seqan3::configuration<bax, bar> const cfg_cr2{cfg};
-        // EXPECT_TRUE((std::same_as<decltype(std::move(cfg_cr2).get_or(bax{1.3})), bax const &&>));
+        // EXPECT_SAME_TYPE(decltype(std::move(cfg_cr2).get_or(bax{1.3})), bax const &&);
         seqan3::configuration<bax, bar> const cfg_cr3{cfg};
         EXPECT_EQ(std::move(cfg_cr3).get_or(foo{"test"}).value, "test");
     }
@@ -360,14 +361,14 @@ TEST(configuration, get_or_by_type_template)
         EXPECT_RANGE_EQ(cfg.get_or(alternative_t{double_vec_t{3.3}}).value, (std::vector{0, 1, 2, 3}));
         EXPECT_RANGE_EQ(cfg.get_or(alternative).value, (std::vector{0, 1, 2, 3}));
         EXPECT_EQ(cfg.get_or(foo{"test"}).value, "test");
-        EXPECT_TRUE((std::same_as<decltype(cfg.get_or(alternative)), foobar<std::vector<int>> &>));
+        EXPECT_SAME_TYPE(decltype(cfg.get_or(alternative)), foobar<std::vector<int>> &);
     }
 
     { // const l-value
         EXPECT_RANGE_EQ(std::as_const(cfg).get_or(alternative_t{double_vec_t{3.3}}).value, (std::vector{0, 1, 2, 3}));
         EXPECT_RANGE_EQ(std::as_const(cfg).get_or(alternative).value, (std::vector{0, 1, 2, 3}));
         EXPECT_EQ(std::as_const(cfg).get_or(foo{"test"}).value, "test");
-        EXPECT_TRUE((std::same_as<decltype(std::as_const(cfg).get_or(alternative)), foobar<std::vector<int>> const &>));
+        EXPECT_SAME_TYPE(decltype(std::as_const(cfg).get_or(alternative)), foobar<std::vector<int>> const &);
     }
 
     { // r-value;
@@ -429,8 +430,8 @@ TEST(configuration, get_or_perfectly_forwarded_alternative)
     alternative_t const const_alternative{alternative};
 
     EXPECT_RANGE_EQ(cfg.get_or(alternative_t{std::vector<double>{3.3}}).value, (std::vector<double>{3.3}));
-    EXPECT_TRUE((std::same_as<decltype(cfg.get_or(alternative)), alternative_t &>));
-    EXPECT_TRUE((std::same_as<decltype(cfg.get_or(const_alternative)), alternative_t const &>));
-    EXPECT_TRUE((std::same_as<decltype(cfg.get_or(alternative_t{std::vector<double>{3.3}})), alternative_t>));
-    EXPECT_TRUE((std::same_as<decltype(cfg.get_or(std::move(const_alternative))), alternative_t const>));
+    EXPECT_SAME_TYPE(decltype(cfg.get_or(alternative)), alternative_t &);
+    EXPECT_SAME_TYPE(decltype(cfg.get_or(const_alternative)), alternative_t const &);
+    EXPECT_SAME_TYPE(decltype(cfg.get_or(alternative_t{std::vector<double>{3.3}})), alternative_t);
+    EXPECT_SAME_TYPE(decltype(cfg.get_or(std::move(const_alternative))), alternative_t const);
 }

--- a/test/unit/core/detail/iterator_traits_test.cpp
+++ b/test/unit/core/detail/iterator_traits_test.cpp
@@ -15,6 +15,7 @@
 #include <vector>
 
 #include <seqan3/core/detail/iterator_traits.hpp>
+#include <seqan3/test/expect_same_type.hpp>
 
 template <typename iterator_t>
 SEQAN3_CONCEPT iterator_traits_has_iterator_category = requires()
@@ -73,7 +74,7 @@ TEST(iterator_category_tag_t, no_legacy_iterator)
         using view_t = std::ranges::basic_istream_view<char, char, std::char_traits<char>>;
         using iterator_t = std::ranges::iterator_t<view_t>;
 #if SEQAN3_WORKAROUND_GCC_96070
-        EXPECT_TRUE((std::same_as<seqan3::detail::iterator_category_tag_t<iterator_t>, void>));
+        EXPECT_SAME_TYPE(seqan3::detail::iterator_category_tag_t<iterator_t>, void);
 #else // ^^^ workaround / no workaround vvv
         EXPECT_FALSE(has_iterator_category_tag_t<iterator_t>);
 #endif // SEQAN3_WORKAROUND_GCC_96070
@@ -84,8 +85,8 @@ TEST(iterator_category_tag_t, no_legacy_iterator)
         using view_t = std::ranges::basic_istream_view<char, char, std::char_traits<char>>;
         using iterator_t = my_iterator<std::ranges::iterator_t<view_t>>;
 #if SEQAN3_WORKAROUND_GCC_96070
-        EXPECT_TRUE((std::same_as<seqan3::detail::iterator_category_tag_t<iterator_t>, void>));
-        EXPECT_TRUE((std::same_as<std::iterator_traits<iterator_t>::iterator_category, void>));
+        EXPECT_SAME_TYPE(seqan3::detail::iterator_category_tag_t<iterator_t>, void);
+        EXPECT_SAME_TYPE(std::iterator_traits<iterator_t>::iterator_category, void);
 #else // ^^^ workaround / no workaround vvv
         EXPECT_FALSE(has_iterator_category_tag_t<iterator_t>);
         EXPECT_FALSE(iterator_traits_has_iterator_category<iterator_t>);

--- a/test/unit/io/alignment_file/sam_tag_dictionary_test.cpp
+++ b/test/unit/io/alignment_file/sam_tag_dictionary_test.cpp
@@ -7,10 +7,11 @@
 
 #include <gtest/gtest.h>
 
+#include <seqan3/std/concepts>
 #include <type_traits>
 
 #include <seqan3/io/alignment_file/sam_tag_dictionary.hpp>
-#include <seqan3/std/concepts>
+#include <seqan3/test/expect_same_type.hpp>
 
 using seqan3::operator""_tag;
 
@@ -30,61 +31,61 @@ TEST(sam_tag_type, type_member_of_known_tags)
 {
     // types according to the SAM specifications
     // (see https://samtools.github.io/hts-specs/SAMtags.pdf)
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"AM"_tag>::type, int32_t>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"AS"_tag>::type, int32_t>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"BC"_tag>::type, std::string>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"BQ"_tag>::type, std::string>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"BZ"_tag>::type, std::string>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"CB"_tag>::type, std::string>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"CC"_tag>::type, std::string>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"CG"_tag>::type, std::vector<int32_t>>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"CM"_tag>::type, int32_t>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"CO"_tag>::type, std::string>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"CP"_tag>::type, int32_t>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"CQ"_tag>::type, std::string>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"CR"_tag>::type, std::string>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"CS"_tag>::type, std::string>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"CT"_tag>::type, std::string>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"CY"_tag>::type, std::string>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"E2"_tag>::type, std::string>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"FI"_tag>::type, int32_t>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"FS"_tag>::type, std::string>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"FZ"_tag>::type, std::vector<uint16_t>>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"H0"_tag>::type, int32_t>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"H1"_tag>::type, int32_t>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"H2"_tag>::type, int32_t>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"HI"_tag>::type, int32_t>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"IH"_tag>::type, int32_t>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"LB"_tag>::type, std::string>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"MC"_tag>::type, std::string>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"MD"_tag>::type, std::string>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"MI"_tag>::type, std::string>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"MQ"_tag>::type, int32_t>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"NH"_tag>::type, int32_t>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"NM"_tag>::type, int32_t>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"OC"_tag>::type, std::string>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"OP"_tag>::type, int32_t>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"OQ"_tag>::type, std::string>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"OX"_tag>::type, std::string>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"PG"_tag>::type, std::string>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"PQ"_tag>::type, int32_t>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"PT"_tag>::type, std::string>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"PU"_tag>::type, std::string>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"Q2"_tag>::type, std::string>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"QT"_tag>::type, std::string>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"QX"_tag>::type, std::string>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"R2"_tag>::type, std::string>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"RG"_tag>::type, std::string>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"RT"_tag>::type, std::string>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"RX"_tag>::type, std::string>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"SA"_tag>::type, std::string>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"SM"_tag>::type, int32_t>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"TC"_tag>::type, int32_t>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"U2"_tag>::type, std::string>));
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type<"UQ"_tag>::type, int32_t>));
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"AM"_tag>::type, int32_t);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"AS"_tag>::type, int32_t);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"BC"_tag>::type, std::string);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"BQ"_tag>::type, std::string);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"BZ"_tag>::type, std::string);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"CB"_tag>::type, std::string);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"CC"_tag>::type, std::string);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"CG"_tag>::type, std::vector<int32_t>);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"CM"_tag>::type, int32_t);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"CO"_tag>::type, std::string);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"CP"_tag>::type, int32_t);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"CQ"_tag>::type, std::string);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"CR"_tag>::type, std::string);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"CS"_tag>::type, std::string);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"CT"_tag>::type, std::string);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"CY"_tag>::type, std::string);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"E2"_tag>::type, std::string);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"FI"_tag>::type, int32_t);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"FS"_tag>::type, std::string);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"FZ"_tag>::type, std::vector<uint16_t>);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"H0"_tag>::type, int32_t);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"H1"_tag>::type, int32_t);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"H2"_tag>::type, int32_t);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"HI"_tag>::type, int32_t);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"IH"_tag>::type, int32_t);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"LB"_tag>::type, std::string);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"MC"_tag>::type, std::string);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"MD"_tag>::type, std::string);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"MI"_tag>::type, std::string);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"MQ"_tag>::type, int32_t);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"NH"_tag>::type, int32_t);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"NM"_tag>::type, int32_t);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"OC"_tag>::type, std::string);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"OP"_tag>::type, int32_t);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"OQ"_tag>::type, std::string);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"OX"_tag>::type, std::string);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"PG"_tag>::type, std::string);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"PQ"_tag>::type, int32_t);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"PT"_tag>::type, std::string);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"PU"_tag>::type, std::string);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"Q2"_tag>::type, std::string);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"QT"_tag>::type, std::string);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"QX"_tag>::type, std::string);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"R2"_tag>::type, std::string);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"RG"_tag>::type, std::string);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"RT"_tag>::type, std::string);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"RX"_tag>::type, std::string);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"SA"_tag>::type, std::string);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"SM"_tag>::type, int32_t);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"TC"_tag>::type, int32_t);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"U2"_tag>::type, std::string);
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type<"UQ"_tag>::type, int32_t);
 
     // test the short cut helper
-    EXPECT_TRUE((std::same_as<seqan3::sam_tag_type_t<"AM"_tag>, seqan3::sam_tag_type<"AM"_tag>::type>));
+    EXPECT_SAME_TYPE(seqan3::sam_tag_type_t<"AM"_tag>, seqan3::sam_tag_type<"AM"_tag>::type);
 }
 
 TEST(sam_tag_dictionary, get_function_known_tag)

--- a/test/unit/io/stream/detail/fast_ostreambuf_iterator_test.cpp
+++ b/test/unit/io/stream/detail/fast_ostreambuf_iterator_test.cpp
@@ -10,6 +10,7 @@
 #include <seqan3/std/iterator>
 
 #include <seqan3/io/stream/detail/fast_ostreambuf_iterator.hpp>
+#include <seqan3/test/expect_same_type.hpp>
 
 TEST(fast_ostreambuf_iterator, concept)
 {
@@ -109,7 +110,7 @@ TEST(fast_ostreambuf_iterator, write_range_unsafe_range)
     std::ostringstream ostr{};
     seqan3::detail::fast_ostreambuf_iterator<char> it{*ostr.rdbuf()};
 
-    EXPECT_TRUE((std::same_as<void, decltype(it.write_range(std::string{"foo"}))>));
+    EXPECT_SAME_TYPE(void, decltype(it.write_range(std::string{"foo"})));
 
     it.write_range(std::string{"foo"});
 

--- a/test/unit/range/container/bitcompressed_vector_test.cpp
+++ b/test/unit/range/container/bitcompressed_vector_test.cpp
@@ -12,6 +12,7 @@
 #include <seqan3/range/container/bitcompressed_vector.hpp>
 #include <seqan3/range/views/complement.hpp>
 #include <seqan3/test/expect_range_eq.hpp>
+#include <seqan3/test/expect_same_type.hpp>
 
 #include "container_test_template.hpp"
 
@@ -26,7 +27,7 @@ TEST(bitcompressed_vector_test, issue1743_complement_on_proxy)
     auto proxy = *v.begin();
     auto complement = seqan3::complement(proxy);
 
-    EXPECT_TRUE((std::same_as<decltype(complement), seqan3::dna4>));
+    EXPECT_SAME_TYPE(decltype(complement), seqan3::dna4);
     EXPECT_EQ(complement, 'T'_dna4);
 }
 

--- a/test/unit/range/container/small_vector_test.cpp
+++ b/test/unit/range/container/small_vector_test.cpp
@@ -7,13 +7,14 @@
 
 #include <gtest/gtest.h>
 
+#include <seqan3/std/ranges>
 #include <string>
 #include <utility>
 
 #include <seqan3/range/container/concept.hpp>
 #include <seqan3/range/container/small_vector.hpp>
-#include <seqan3/std/ranges>
 #include <seqan3/test/cereal.hpp>
+#include <seqan3/test/expect_same_type.hpp>
 
 #include "container_test_template.hpp"
 #include "../iterator_test_template.hpp"
@@ -76,16 +77,16 @@ TEST(small_vector, construct_from_built_in_array)
 {
     // Deduce value type and N
     int arr[3] = {1, 2, 3};
-    EXPECT_TRUE((std::same_as<decltype(seqan3::small_vector{arr}), seqan3::small_vector<int, 3>>));
+    EXPECT_SAME_TYPE(decltype(seqan3::small_vector{arr}), (seqan3::small_vector<int, 3>));
 
     // Deduce value type and N
-    EXPECT_TRUE((std::same_as<decltype(seqan3::small_vector<int, 5>{arr}), seqan3::small_vector<int, 5>>));
+    EXPECT_SAME_TYPE(decltype(seqan3::small_vector<int, 5>{arr}), (seqan3::small_vector<int, 5>));
 
     // char const *
-    EXPECT_TRUE((std::same_as<decltype(seqan3::small_vector{"hi"}), seqan3::small_vector<char, 3>>));
+    EXPECT_SAME_TYPE(decltype(seqan3::small_vector{"hi"}), (seqan3::small_vector<char, 3>));
 
     // parameter pack
-    EXPECT_TRUE((std::same_as<decltype(seqan3::small_vector<char, 3>{'A', 'C', 'X'}), seqan3::small_vector<char, 3>>));
+    EXPECT_SAME_TYPE(decltype(seqan3::small_vector<char, 3>{'A', 'C', 'X'}), (seqan3::small_vector<char, 3>));
 }
 
 // ---------------------------------------------------------------------------------------------------------------------

--- a/test/unit/range/views/drop_test.cpp
+++ b/test/unit/range/views/drop_test.cpp
@@ -5,13 +5,16 @@
 // shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 // -----------------------------------------------------------------------------------------------------
 
+#include <gtest/gtest.h>
+
+#include <seqan3/std/algorithm>
+#include <seqan3/std/concepts>
 #include <deque>
 #include <iostream>
 #include <list>
+#include <seqan3/std/ranges>
 #include <string>
 #include <vector>
-
-#include <gtest/gtest.h>
 
 #include <range/v3/view/unique.hpp>
 
@@ -20,10 +23,8 @@
 #include <seqan3/range/views/drop.hpp>
 #include <seqan3/range/views/single_pass_input.hpp>
 #include <seqan3/range/views/to.hpp>
-#include <seqan3/std/algorithm>
-#include <seqan3/std/concepts>
-#include <seqan3/std/ranges>
 #include <seqan3/test/expect_range_eq.hpp>
+#include <seqan3/test/expect_same_type.hpp>
 
 // ============================================================================
 //  test templates
@@ -131,7 +132,7 @@ TEST(view_drop, type_erasure)
 
         auto v = seqan3::views::drop(urange, 3);
 
-        EXPECT_TRUE((std::same_as<decltype(v), std::string_view>));
+        EXPECT_SAME_TYPE(decltype(v), std::string_view);
         EXPECT_RANGE_EQ(v, urange.substr(3,3));
     }
 
@@ -140,7 +141,7 @@ TEST(view_drop, type_erasure)
 
         auto v = seqan3::views::drop(urange, 3);
 
-        EXPECT_TRUE((std::same_as<decltype(v), std::string_view>));
+        EXPECT_SAME_TYPE(decltype(v), std::string_view);
         EXPECT_RANGE_EQ(v, urange.substr(3,3));
     }
 
@@ -149,7 +150,7 @@ TEST(view_drop, type_erasure)
 
         auto v = seqan3::views::drop(urange, 3);
 
-        EXPECT_TRUE((std::same_as<decltype(v), std::span<int, std::dynamic_extent>>));
+        EXPECT_SAME_TYPE(decltype(v), (std::span<int, std::dynamic_extent>));
         EXPECT_RANGE_EQ(v, (std::vector{4, 5, 6}));
     }
 
@@ -158,7 +159,7 @@ TEST(view_drop, type_erasure)
 
         auto v = seqan3::views::drop(urange, 3);
 
-        EXPECT_TRUE((std::same_as<decltype(v), std::span<int, std::dynamic_extent>>));
+        EXPECT_SAME_TYPE(decltype(v), (std::span<int, std::dynamic_extent>));
         EXPECT_RANGE_EQ(v, (std::vector{4, 5, 6}));
     }
 
@@ -177,7 +178,7 @@ TEST(view_drop, type_erasure)
 
         auto v = seqan3::views::drop(urange, 3);
 
-        EXPECT_TRUE((std::same_as<decltype(v), decltype(std::views::drop(urange, 3))>));
+        EXPECT_SAME_TYPE(decltype(v), decltype(std::views::drop(urange, 3)));
         EXPECT_RANGE_EQ(v, (std::vector{4, 5, 6}));
     }
 
@@ -187,7 +188,7 @@ TEST(view_drop, type_erasure)
         auto v = urange | std::views::filter([] (int) { return true; });
         auto v2 = seqan3::views::drop(v, 3);
 
-        EXPECT_TRUE((std::same_as<decltype(v2), decltype(std::views::drop(v, 3))>));
+        EXPECT_SAME_TYPE(decltype(v2), decltype(std::views::drop(v, 3)));
         EXPECT_RANGE_EQ(v2, (std::vector{4, 5, 6}));
     }
 }

--- a/test/unit/range/views/repeat_test.cpp
+++ b/test/unit/range/views/repeat_test.cpp
@@ -17,6 +17,7 @@
 #include <seqan3/range/views/take.hpp>
 #include <seqan3/range/views/take_exactly.hpp>
 #include <seqan3/test/expect_range_eq.hpp>
+#include <seqan3/test/expect_same_type.hpp>
 
 TEST(repeat_view, deduction_guide)
 {
@@ -24,10 +25,10 @@ TEST(repeat_view, deduction_guide)
     int const & value_cref = value;
 
     seqan3::detail::repeat_view repeat_view1{value};
-    EXPECT_TRUE((std::same_as<decltype(repeat_view1), seqan3::detail::repeat_view<int>>));
+    EXPECT_SAME_TYPE(decltype(repeat_view1), seqan3::detail::repeat_view<int>);
 
     seqan3::detail::repeat_view repeat_view2{value_cref};
-    EXPECT_TRUE((std::same_as<decltype(repeat_view2), seqan3::detail::repeat_view<int>>));
+    EXPECT_SAME_TYPE(decltype(repeat_view2), seqan3::detail::repeat_view<int>);
 }
 
 TEST(general, construction)

--- a/test/unit/range/views/single_pass_input_test.cpp
+++ b/test/unit/range/views/single_pass_input_test.cpp
@@ -7,15 +7,16 @@
 
 #include <gtest/gtest.h>
 
-#include <vector>
+#include <seqan3/std/ranges>
 #include <type_traits>
+#include <vector>
 
 #include <range/v3/view/slice.hpp>
 
 #include <seqan3/range/views/single_pass_input.hpp>
 #include <seqan3/range/views/persist.hpp>
 #include <seqan3/range/views/zip.hpp>
-#include <seqan3/std/ranges>
+#include <seqan3/test/expect_same_type.hpp>
 
 template <typename rng_type>
 class single_pass_input : public ::testing::Test
@@ -93,7 +94,7 @@ TYPED_TEST(single_pass_input, deduction_guide_lvalue)
     // same as
     seqan3::detail::single_pass_input_view v2{data_container};
 
-    EXPECT_TRUE((std::same_as<decltype(v1), decltype(v2)>));
+    EXPECT_SAME_TYPE(decltype(v1), decltype(v2));
 }
 
 TYPED_TEST(single_pass_input, deduction_guide_view)
@@ -111,7 +112,7 @@ TYPED_TEST(single_pass_input, deduction_guide_view)
     seqan3::detail::single_pass_input_view<decltype(data_all_view)> v1{data_all_view};
     seqan3::detail::single_pass_input_view v2{std::move(data_view)};
 
-    EXPECT_TRUE((std::same_as<decltype(v1), decltype(v2)>));
+    EXPECT_SAME_TYPE(decltype(v1), decltype(v2));
 }
 
 TYPED_TEST(single_pass_input, view_construction)

--- a/test/unit/range/views/slice_test.cpp
+++ b/test/unit/range/views/slice_test.cpp
@@ -5,13 +5,16 @@
 // shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 // -----------------------------------------------------------------------------------------------------
 
+#include <gtest/gtest.h>
+
+#include <seqan3/std/algorithm>
+#include <seqan3/std/concepts>
 #include <deque>
 #include <iostream>
 #include <list>
+#include <seqan3/std/ranges>
 #include <string>
 #include <vector>
-
-#include <gtest/gtest.h>
 
 #include <range/v3/view/unique.hpp>
 
@@ -20,10 +23,8 @@
 #include <seqan3/range/views/single_pass_input.hpp>
 #include <seqan3/range/views/slice.hpp>
 #include <seqan3/range/views/to.hpp>
-#include <seqan3/std/algorithm>
-#include <seqan3/std/concepts>
-#include <seqan3/std/ranges>
 #include <seqan3/test/expect_range_eq.hpp>
+#include <seqan3/test/expect_same_type.hpp>
 
 // ============================================================================
 //  test templates
@@ -142,7 +143,7 @@ TEST(view_slice, type_erasure)
 
         auto v = seqan3::views::slice(urange, 1, 4);
 
-        EXPECT_TRUE((std::same_as<decltype(v), std::string_view>));
+        EXPECT_SAME_TYPE(decltype(v), std::string_view);
         EXPECT_RANGE_EQ(v, urange.substr(1,3));
     }
 
@@ -151,7 +152,7 @@ TEST(view_slice, type_erasure)
 
         auto v = seqan3::views::slice(urange, 1, 4);
 
-        EXPECT_TRUE((std::same_as<decltype(v), std::string_view>));
+        EXPECT_SAME_TYPE(decltype(v), std::string_view);
         EXPECT_RANGE_EQ(v, urange.substr(1,3));
     }
 
@@ -160,7 +161,7 @@ TEST(view_slice, type_erasure)
 
         auto v = seqan3::views::slice(urange, 1, 4);
 
-        EXPECT_TRUE((std::same_as<decltype(v), std::span<int, std::dynamic_extent>>));
+        EXPECT_SAME_TYPE(decltype(v), (std::span<int, std::dynamic_extent>));
         EXPECT_RANGE_EQ(v, (std::vector{2, 3, 4}));
     }
 
@@ -169,7 +170,7 @@ TEST(view_slice, type_erasure)
 
         auto v = seqan3::views::slice(urange, 1, 4);
 
-        EXPECT_TRUE((std::same_as<decltype(v), std::span<int, std::dynamic_extent>>));
+        EXPECT_SAME_TYPE(decltype(v), (std::span<int, std::dynamic_extent>));
         EXPECT_RANGE_EQ(v, (std::vector{2, 3, 4}));
     }
 

--- a/test/unit/range/views/take_test.cpp
+++ b/test/unit/range/views/take_test.cpp
@@ -5,13 +5,16 @@
 // shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 // -----------------------------------------------------------------------------------------------------
 
+#include <gtest/gtest.h>
+
+#include <seqan3/std/algorithm>
+#include <seqan3/std/concepts>
 #include <deque>
 #include <iostream>
 #include <list>
+#include <seqan3/std/ranges>
 #include <string>
 #include <vector>
-
-#include <gtest/gtest.h>
 
 #include <range/v3/view/unique.hpp>
 
@@ -21,10 +24,8 @@
 #include <seqan3/range/views/take.hpp>
 #include <seqan3/range/views/take_exactly.hpp>
 #include <seqan3/range/views/to.hpp>
-#include <seqan3/std/algorithm>
-#include <seqan3/std/concepts>
-#include <seqan3/std/ranges>
 #include <seqan3/test/expect_range_eq.hpp>
+#include <seqan3/test/expect_same_type.hpp>
 
 // ============================================================================
 //  test templates
@@ -155,7 +156,7 @@ TEST(view_take, type_erasure)
 
         auto v = seqan3::views::take(urange, 3);
 
-        EXPECT_TRUE((std::same_as<decltype(v), std::string_view>));
+        EXPECT_SAME_TYPE(decltype(v), std::string_view);
         EXPECT_RANGE_EQ(v, urange.substr(0,3));
     }
 
@@ -164,7 +165,7 @@ TEST(view_take, type_erasure)
 
         auto v = seqan3::views::take(urange, 3);
 
-        EXPECT_TRUE((std::same_as<decltype(v), std::string_view>));
+        EXPECT_SAME_TYPE(decltype(v), std::string_view);
         EXPECT_RANGE_EQ(v, urange.substr(0,3));
     }
 
@@ -173,7 +174,7 @@ TEST(view_take, type_erasure)
 
         auto v = seqan3::views::take(urange, 3);
 
-        EXPECT_TRUE((std::same_as<decltype(v), std::span<int, std::dynamic_extent>>));
+        EXPECT_SAME_TYPE(decltype(v), (std::span<int, std::dynamic_extent>));
         EXPECT_RANGE_EQ(v, (std::vector{1, 2, 3}));
     }
 
@@ -182,7 +183,7 @@ TEST(view_take, type_erasure)
 
         auto v = seqan3::views::take(urange, 3);
 
-        EXPECT_TRUE((std::same_as<decltype(v), std::span<int, std::dynamic_extent>>));
+        EXPECT_SAME_TYPE(decltype(v), (std::span<int, std::dynamic_extent>));
         EXPECT_RANGE_EQ(v, (std::vector{1, 2, 3}));
     }
 
@@ -212,7 +213,7 @@ TEST(view_take, type_erasure)
         auto v = urange | std::views::filter([] (int) { return true; });
         auto v2 = seqan3::views::take(v, 3);
 
-        EXPECT_TRUE((std::same_as<decltype(v2), seqan3::detail::view_take<decltype(v), false, false>>));
+        EXPECT_SAME_TYPE(decltype(v2), (seqan3::detail::view_take<decltype(v), false, false>));
         EXPECT_RANGE_EQ(v2, (std::vector{1, 2, 3}));
     }
 
@@ -223,7 +224,7 @@ TEST(view_take, type_erasure)
         auto v1 = v0 | std::views::take_while([] (int i) { return i < 6; });
         auto v2 = seqan3::views::take(v1, 3);
 
-        EXPECT_TRUE((std::same_as<decltype(v2), seqan3::detail::view_take<decltype(v1), false, false>>));
+        EXPECT_SAME_TYPE(decltype(v2), (seqan3::detail::view_take<decltype(v1), false, false>));
         EXPECT_RANGE_EQ(v2, (std::vector{1, 2, 3}));
     }
 }

--- a/test/unit/range/views/type_reduce_test.cpp
+++ b/test/unit/range/views/type_reduce_test.cpp
@@ -5,19 +5,20 @@
 // shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 // -----------------------------------------------------------------------------------------------------
 
-#include <iostream>
+#include <gtest/gtest.h>
+
+#include <seqan3/std/algorithm>
+#include <seqan3/std/concepts>
 #include <deque>
+#include <iostream>
 #include <list>
+#include <seqan3/std/ranges>
 #include <string>
 #include <vector>
 
-#include <gtest/gtest.h>
-
 #include <seqan3/range/views/type_reduce.hpp>
-#include <seqan3/std/concepts>
-#include <seqan3/std/algorithm>
-#include <seqan3/std/ranges>
 #include <seqan3/test/expect_range_eq.hpp>
+#include <seqan3/test/expect_same_type.hpp>
 
 // ============================================================================
 //  test templates
@@ -40,7 +41,7 @@ TEST(type_reduce, string_overload)
 
         auto v = seqan3::views::type_reduce(urange);
 
-        EXPECT_TRUE((std::same_as<decltype(v), std::string_view>));
+        EXPECT_SAME_TYPE(decltype(v), std::string_view);
         EXPECT_RANGE_EQ(v, urange);
     }
 
@@ -49,7 +50,7 @@ TEST(type_reduce, string_overload)
 
         auto v = seqan3::views::type_reduce(urange);
 
-        EXPECT_TRUE((std::same_as<decltype(v), std::string_view>));
+        EXPECT_SAME_TYPE(decltype(v), std::string_view);
         EXPECT_RANGE_EQ(v, urange);
     }
 }
@@ -61,7 +62,7 @@ TEST(type_reduce, contiguous_overload)
 
         auto v = seqan3::views::type_reduce(urange);
 
-        EXPECT_TRUE((std::same_as<decltype(v), std::span<int, std::dynamic_extent>>));
+        EXPECT_SAME_TYPE(decltype(v), (std::span<int, std::dynamic_extent>));
         EXPECT_RANGE_EQ(v, urange);
     }
 
@@ -70,7 +71,7 @@ TEST(type_reduce, contiguous_overload)
 
         auto v = seqan3::views::type_reduce(urange);
 
-        EXPECT_TRUE((std::same_as<decltype(v), std::span<int, std::dynamic_extent>>));
+        EXPECT_SAME_TYPE(decltype(v), (std::span<int, std::dynamic_extent>));
         EXPECT_RANGE_EQ(v, urange);
     }
 }
@@ -93,7 +94,7 @@ TEST(type_reduce, generic_overload)
 
         auto v = seqan3::views::type_reduce(urange);
 
-        EXPECT_TRUE((std::same_as<decltype(v), std::views::all_t<std::list<int> &>>));
+        EXPECT_SAME_TYPE(decltype(v), std::views::all_t<std::list<int> &>);
         EXPECT_RANGE_EQ(v, urange);
     }
 
@@ -103,7 +104,7 @@ TEST(type_reduce, generic_overload)
         auto v = urange | std::views::filter([] (int) { return true; });
         auto v2 = seqan3::views::type_reduce(v);
 
-        EXPECT_TRUE((std::same_as<decltype(v2), std::views::all_t<decltype(v)>>));
+        EXPECT_SAME_TYPE(decltype(v2), std::views::all_t<decltype(v)>);
         EXPECT_RANGE_EQ(v2, urange);
     }
 }

--- a/test/unit/search/configuration/hit_test.cpp
+++ b/test/unit/search/configuration/hit_test.cpp
@@ -9,6 +9,7 @@
 
 #include <seqan3/core/detail/pack_algorithm.hpp>
 #include <seqan3/search/configuration/hit.hpp>
+#include <seqan3/test/expect_same_type.hpp>
 
 #include "../../core/algorithm/pipeable_config_element_test_template.hpp"
 
@@ -31,13 +32,13 @@ INSTANTIATE_TYPED_TEST_SUITE_P(mode_elements, pipeable_config_element_test, test
 TEST(config_element_test, tags)
 {
     seqan3::configuration elem_all = seqan3::search_cfg::hit_all{};
-    EXPECT_TRUE((std::same_as<decltype(elem_all), seqan3::configuration<seqan3::search_cfg::hit_all>>));
+    EXPECT_SAME_TYPE(decltype(elem_all), seqan3::configuration<seqan3::search_cfg::hit_all>);
 
     seqan3::configuration elem_all_best = seqan3::search_cfg::hit_all_best{};
-    EXPECT_TRUE((std::same_as<decltype(elem_all_best), seqan3::configuration<seqan3::search_cfg::hit_all_best>>));
+    EXPECT_SAME_TYPE(decltype(elem_all_best), seqan3::configuration<seqan3::search_cfg::hit_all_best>);
 
     seqan3::configuration elem_single_best = seqan3::search_cfg::hit_single_best{};
-    EXPECT_TRUE((std::same_as<decltype(elem_single_best), seqan3::configuration<seqan3::search_cfg::hit_single_best>>));
+    EXPECT_SAME_TYPE(decltype(elem_single_best), seqan3::configuration<seqan3::search_cfg::hit_single_best>);
 }
 
 TEST(hit_strata_test, member_variable)

--- a/test/unit/test/seqan2_test.cpp
+++ b/test/unit/test/seqan2_test.cpp
@@ -8,6 +8,8 @@
 #include <gtest/gtest.h>
 
 #include <seqan3/std/ranges>
+
+#include <seqan3/test/expect_same_type.hpp>
 #include <seqan3/test/seqan2.hpp>
 
 // Note: this file will only test regressions encountered with seqan2 compatibility and has no claim to be complete
@@ -49,8 +51,8 @@ TYPED_TEST(seqan2_container, std_ranges_begin_end)
     auto it = std::ranges::begin(container);
     auto it_end = std::ranges::end(container);
 
-    EXPECT_TRUE((std::same_as<decltype(it), decltype(seqan::begin(container))>));
-    EXPECT_TRUE((std::same_as<decltype(it_end), decltype(seqan::end(container))>));
+    EXPECT_SAME_TYPE(decltype(it), decltype(seqan::begin(container)));
+    EXPECT_SAME_TYPE(decltype(it_end), decltype(seqan::end(container)));
 
     for (int i = 0; it != it_end; ++it, ++i)
     {
@@ -64,10 +66,10 @@ TYPED_TEST(seqan2_container, std_ranges_iterator)
     using iterator_t = decltype(std::ranges::begin(std::declval<container_t &>()));
     using const_iterator_t = decltype(std::ranges::begin(std::declval<container_t const &>()));
 
-    EXPECT_TRUE((std::same_as<std::ranges::iterator_t<container_t>, iterator_t>));
-    EXPECT_TRUE((std::same_as<std::ranges::iterator_t<container_t &>, iterator_t>));
-    EXPECT_TRUE((std::same_as<std::ranges::iterator_t<container_t const>, const_iterator_t>));
-    EXPECT_TRUE((std::same_as<std::ranges::iterator_t<container_t const &>, const_iterator_t>));
+    EXPECT_SAME_TYPE(std::ranges::iterator_t<container_t>, iterator_t);
+    EXPECT_SAME_TYPE(std::ranges::iterator_t<container_t &>, iterator_t);
+    EXPECT_SAME_TYPE(std::ranges::iterator_t<container_t const>, const_iterator_t);
+    EXPECT_SAME_TYPE(std::ranges::iterator_t<container_t const &>, const_iterator_t);
 }
 
 TYPED_TEST(seqan2_container, std_iterator_traits)
@@ -75,7 +77,7 @@ TYPED_TEST(seqan2_container, std_iterator_traits)
     using container_t = TypeParam;
     using iterator_t = std::ranges::iterator_t<container_t>;
     using value_type = typename std::iterator_traits<iterator_t>::value_type;
-    EXPECT_TRUE((std::same_as<value_type, int>));
+    EXPECT_SAME_TYPE(value_type, int);
 }
 
 TYPED_TEST(seqan2_container, std_iterator)
@@ -113,7 +115,7 @@ TYPED_TEST(seqan2_container, seqan3_value_type)
 {
     using container_t = TypeParam;
     using value_type = std::ranges::range_value_t<container_t>;
-    EXPECT_TRUE((std::same_as<value_type, int>));
+    EXPECT_SAME_TYPE(value_type, int);
 }
 
 #endif

--- a/test/unit/utility/type_traits/function_traits_test.cpp
+++ b/test/unit/utility/type_traits/function_traits_test.cpp
@@ -10,6 +10,7 @@
 #include <string>
 
 #include <seqan3/utility/type_traits/function_traits.hpp>
+#include <seqan3/test/expect_same_type.hpp>
 
 std::function test_function_object = [] (size_t arg1, std::string & arg2)
 {
@@ -29,16 +30,16 @@ TEST(function_traits, argument_count)
 TEST(function_traits, result_type)
 {
     using function_t = decltype(test_function_object);
-    EXPECT_TRUE((std::same_as<seqan3::function_traits<function_t>::result_type, char>));
-    EXPECT_TRUE((std::same_as<seqan3::function_traits<function_ptr_t>::result_type, std::string>));
+    EXPECT_SAME_TYPE(seqan3::function_traits<function_t>::result_type, char);
+    EXPECT_SAME_TYPE(seqan3::function_traits<function_ptr_t>::result_type, std::string);
 }
 
 TEST(function_traits, argument_type_at)
 {
     using function_t = decltype(test_function_object);
-    EXPECT_TRUE((std::same_as<seqan3::function_traits<function_t>::argument_type_at<0>, size_t>));
-    EXPECT_TRUE((std::same_as<seqan3::function_traits<function_t>::argument_type_at<1>, std::string &>));
-    EXPECT_TRUE((std::same_as<seqan3::function_traits<function_ptr_t>::argument_type_at<0>, int>));
-    EXPECT_TRUE((std::same_as<seqan3::function_traits<function_ptr_t>::argument_type_at<1>, const double &&>));
-    EXPECT_TRUE((std::same_as<seqan3::function_traits<function_ptr_t>::argument_type_at<2>, bool &>));
+    EXPECT_SAME_TYPE(seqan3::function_traits<function_t>::argument_type_at<0>, size_t);
+    EXPECT_SAME_TYPE(seqan3::function_traits<function_t>::argument_type_at<1>, std::string &);
+    EXPECT_SAME_TYPE(seqan3::function_traits<function_ptr_t>::argument_type_at<0>, int);
+    EXPECT_SAME_TYPE(seqan3::function_traits<function_ptr_t>::argument_type_at<1>, const double &&);
+    EXPECT_SAME_TYPE(seqan3::function_traits<function_ptr_t>::argument_type_at<2>, bool &);
 }


### PR DESCRIPTION
Search and replace with `EXPECT_TRUE\(\(std::same_as<(.+)>\)\);` and `EXPECT_SAME_TYPE($1);`