### PR TITLE
[INFRA] cmake: changes to documentation

### DIFF
--- a/test/documentation/CMakeLists.txt
+++ b/test/documentation/CMakeLists.txt
@@ -1,12 +1,18 @@
+# -----------------------------------------------------------------------------------------------------
+# Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+# Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+# This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+# shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+# -----------------------------------------------------------------------------------------------------
+
 # Minimum cmake version
 cmake_minimum_required(VERSION 3.7)
-
-# Name of project
-project(seqan3_documentation NONE)
 
 ### Find seqan3
 include (../../build_system/seqan3-config-version.cmake)
 set (SEQAN3_VERSION "${PACKAGE_VERSION}")
+
+project (seqan3 LANGUAGES NONE VERSION "${SEQAN3_VERSION}")
 
 if (NOT EXISTS "${SEQAN3_INCLUDE_DIR}/seqan3/version.hpp")
     message (FATAL_ERROR "Could not find SeqAn3. Not building documentation.")
@@ -17,37 +23,12 @@ set (SEQAN3_DOXYGEN_INPUT_DIR "${CMAKE_SOURCE_DIR}")
 
 include (seqan3-doxygen.cmake)
 
-### Enable testing
-enable_testing()
-
-# doxygen does not show any warnings (doxygen prints warnings / errors to cerr)
-set (SEQAN3_DOXYGEN_FAIL_ON_WARNINGS "
-    ${DOXYGEN_EXECUTABLE} > doxygen.cout 2> doxygen.cerr;
-    cat \"doxygen.cerr\";
-    test ! -s \"doxygen.cerr\"")
-
-# We search the HTML output to ensure that no `requires` clauses are at wrong places.
-set (SEQAN3_DOXYGEN_FAIL_ON_UNCOND_REQUIRES
-     "! find . -not -name \"*_source.html\" -name \"*.html\" -print0 | xargs -0 grep \"requires\" | grep \"memname\"")
+enable_testing ()
 
 if (SEQAN3_USER_DOC)
-    message (STATUS "Add user doc test.")
-    add_test(NAME doc_usr_no_warnings_test
-             COMMAND bash -c "${SEQAN3_DOXYGEN_FAIL_ON_WARNINGS}"
-             WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/doc_usr)
-
-    add_test(NAME doc_usr_no_uncond_requires_test
-             COMMAND bash -c "${SEQAN3_DOXYGEN_FAIL_ON_UNCOND_REQUIRES}"
-             WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/doc_usr)
+    add_subdirectory(doc_usr)
 endif ()
 
 if (SEQAN3_DEV_DOC)
-    message (STATUS "Add dev doc test.")
-    add_test(NAME doc_dev_no_warnings_test
-             COMMAND bash -c "${SEQAN3_DOXYGEN_FAIL_ON_WARNINGS}"
-             WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/doc_dev)
-
-    add_test(NAME doc_dev_no_uncond_requires_test
-             COMMAND bash -c "${SEQAN3_DOXYGEN_FAIL_ON_UNCOND_REQUIRES}"
-             WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/doc_dev)
+    add_subdirectory(doc_dev)
 endif ()

--- a/test/documentation/CMakeLists.txt
+++ b/test/documentation/CMakeLists.txt
@@ -32,3 +32,5 @@ endif ()
 if (SEQAN3_DEV_DOC)
     add_subdirectory(doc_dev)
 endif ()
+
+include (seqan3-doxygen-package.cmake)

--- a/test/documentation/README.md
+++ b/test/documentation/README.md
@@ -1,0 +1,116 @@
+# seqan3 documentation
+
+Currently, we can only build the documentation on *nix systems.
+
+We offer two versions of our documentation, one intended for the user (doc_usr) and one intended for the
+library-developer and maintainer (doc_dev) of seqan3, which contains the documentation of internals.
+
+## How to configure:
+
+```bash
+mkdir <seqan3-build-dir>/documentation
+cd <seqan3-build-dir>/documentation
+
+cmake <seqan3-dir>/test/documentation
+```
+
+## How to build:
+
+Prerequisites: configuring the documentation
+
+```bash
+cd <seqan3-build-dir>/documentation
+
+# build user and developer documentation
+cmake --build .
+
+# or build user documentation only
+cmake --build . --target doc_usr
+
+# or build developer documentation only
+cmake --build . --target doc_dev
+```
+
+## How to test:
+
+Prerequisites: building the documentation
+
+```bash
+cd <seqan3-build-dir>/documentation
+
+# test user and developer documentation
+ctest --output-on-failure --progress
+
+# or test user documentation only
+ctest -R doc_usr --output-on-failure --progress
+
+# or test developer documentation only
+ctest -R doc_dev --output-on-failure --progress
+```
+
+## How to install:
+
+Prerequisites: building the documentation
+
+Our installation uses GNU standard installation directories provided by cmake
+[GNUInstallDirs](https://cmake.org/cmake/help/v3.19/module/GNUInstallDirs.html#module:GNUInstallDirs).
+
+That means the html documentation will be installed to `<DESTDIR>/<INSTALL_PREFIX>/<INSTALL_DOCDIR>/html/` where `<INSTALL_PREFIX>` is typically `usr/local` and `<INSTALL_DOCDIR>` is `share/doc/seqan3`.
+
+That means our html documentation will be installed to `<DESTDIR>/usr/local/share/doc/seqan3/html`.
+
+You can override the paths by specifying `-DCMAKE_INSTALL_PREFIX` and `-DCMAKE_INSTALL_DOCDIR` during configuration time
+
+```bash
+# Note that -DCMAKE_INSTALL_DOCDIR="." is important, otherwise it will install it to `share/doc/seqan3`
+cmake -DCMAKE_INSTALL_PREFIX="" -DCMAKE_INSTALL_DOCDIR="." <seqan3-dir>/test/documentation
+```
+
+which will install the documentation to `<DESTDIR>/`, i.e. without any prefixes.
+
+```bash
+cd <seqan3-build-dir>/documentation
+
+# per default we only install the user documentation
+# --prefix will set <INSTALL_PREFIX> to export
+# Note that combining DESTDIR with --prefix might result in weird output
+#
+# ./export/<INSTALL_DOCDIR>/html
+cmake --install . --prefix export # (since cmake 3.15) or
+
+# ./export/<INSTALL_PREFIX>/<INSTALL_DOCDIR>/html/
+DESTDIR="export" cmake --install . # (since cmake 3.15)
+
+# the user documentation can be installed via
+#
+# ./export/<INSTALL_DOCDIR>/html
+cmake --install . --prefix export --component doc # (since cmake 3.15) or
+
+# ./export/<INSTALL_PREFIX>/<INSTALL_DOCDIR>/html
+DESTDIR="export" cmake -DCOMPONENT=doc -P cmake_install.cmake # (for older cmake versions)
+
+# the developer documentation can be installed via
+# --prefix will set <INSTALL_PREFIX> to export-dev
+#
+# ./export-dev/<INSTALL_DOCDIR>/html
+cmake --install . --prefix export-dev --component doc-dev # (since cmake 3.15) or
+
+# ./export-dev/<INSTALL_PREFIX>/<INSTALL_DOCDIR>/html
+DESTDIR="export-dev" cmake -DCOMPONENT=doc-dev -P cmake_install.cmake # (for older cmake versions)
+```
+
+## How to package:
+
+Prerequisites: building the documentation
+
+```bash
+cd <seqan3-build-dir>/documentation
+
+# Create user documentation package, i.e. seqan3-3.0.2-Linux-doc.tar.gz{,.sha256}
+# The package will contain the following structure <INSTALL_PREFIX>/<INSTALL_DOCDIR>/html
+cpack
+
+# Create user and developer documentation package, i.e.
+# seqan3-3.0.2-Linux-{doc,doc-dev}.tar.gz{,.sha256}
+cpack -D CPACK_COMPONENTS_ALL="doc;doc-dev"
+```

--- a/test/documentation/README.md
+++ b/test/documentation/README.md
@@ -55,7 +55,8 @@ Prerequisites: building the documentation
 Our installation uses GNU standard installation directories provided by cmake
 [GNUInstallDirs](https://cmake.org/cmake/help/v3.19/module/GNUInstallDirs.html#module:GNUInstallDirs).
 
-That means the html documentation will be installed to `<DESTDIR>/<INSTALL_PREFIX>/<INSTALL_DOCDIR>/html/` where `<INSTALL_PREFIX>` is typically `usr/local` and `<INSTALL_DOCDIR>` is `share/doc/seqan3`.
+That means the html documentation will be installed to `<DESTDIR>/<INSTALL_PREFIX>/<INSTALL_DOCDIR>/html/` where 
+`<INSTALL_PREFIX>` is typically `usr/local` and `<INSTALL_DOCDIR>` is `share/doc/seqan3`.
 
 That means our html documentation will be installed to `<DESTDIR>/usr/local/share/doc/seqan3/html`.
 

--- a/test/documentation/doc_dev/CMakeLists.txt
+++ b/test/documentation/doc_dev/CMakeLists.txt
@@ -24,6 +24,18 @@ add_custom_target(doc_dev ALL
                   COMMENT "Generating developer API documentation with Doxygen"
                   VERBATIM)
 
+# Install doc_dev documentation in ./install_doc_dev folder
+# cmake --install . --prefix install_doc_dev --component doc_dev
+install (
+    DIRECTORY "${SEQAN3_DOXYGEN_OUTPUT_DIR}/html"
+    DESTINATION "${CMAKE_INSTALL_DOCDIR}"
+    COMPONENT doc-dev
+    EXCLUDE_FROM_ALL
+    PATTERN "*.md5" EXCLUDE
+    PATTERN "*.map" EXCLUDE
+    PATTERN "formula.repository" EXCLUDE
+)
+
 ### Enable testing
 
 enable_testing()

--- a/test/documentation/doc_dev/CMakeLists.txt
+++ b/test/documentation/doc_dev/CMakeLists.txt
@@ -1,0 +1,38 @@
+# -----------------------------------------------------------------------------------------------------
+# Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+# Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+# This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+# shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+# -----------------------------------------------------------------------------------------------------
+
+message (STATUS "Configuring devel doc.")
+
+set (SEQAN3_DOXYGEN_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+set (SEQAN3_DOXYGEN_SOURCE_DIR "${SEQAN3_CLONE_DIR}")
+set (SEQAN3_DOXYGEN_EXCLUDE_SYMBOLS "")
+set (SEQAN3_DOXYGEN_PREDEFINED_NDEBUG "")
+set (SEQAN3_DOXYGEN_ENABLED_SECTIONS "DEV")
+set (SEQAN3_DOXYGEN_EXTRACT_PRIVATE "YES")
+
+configure_file (${SEQAN3_DOXYFILE_IN} ${SEQAN3_DOXYGEN_OUTPUT_DIR}/Doxyfile)
+
+add_custom_target(doc_dev ALL
+                  COMMAND ${DOXYGEN_EXECUTABLE}
+                  WORKING_DIRECTORY ${SEQAN3_DOXYGEN_OUTPUT_DIR}
+                  BYPRODUCTS html/
+                  DEPENDS download-cppreference-doxygen-web-tag
+                  COMMENT "Generating developer API documentation with Doxygen"
+                  VERBATIM)
+
+### Enable testing
+
+enable_testing()
+
+message (STATUS "Add dev doc test.")
+add_test(NAME doc_dev_no_warnings_test
+         COMMAND bash -c "${SEQAN3_TEST_DOXYGEN_FAIL_ON_WARNINGS}"
+         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+add_test(NAME doc_dev_no_uncond_requires_test
+         COMMAND bash -c "${SEQAN3_TEST_DOXYGEN_FAIL_ON_UNCOND_REQUIRES}"
+         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/test/documentation/doc_usr/CMakeLists.txt
+++ b/test/documentation/doc_usr/CMakeLists.txt
@@ -24,6 +24,17 @@ add_custom_target(doc_usr ALL
                   COMMENT "Generating user API documentation with Doxygen"
                   VERBATIM)
 
+# Install doc_usr documentation in ./export folder
+# make DESTDIR=export install
+install (
+    DIRECTORY "${SEQAN3_DOXYGEN_OUTPUT_DIR}/html"
+    DESTINATION "${CMAKE_INSTALL_DOCDIR}"
+    COMPONENT doc
+    PATTERN "*.md5" EXCLUDE
+    PATTERN "*.map" EXCLUDE
+    PATTERN "formula.repository" EXCLUDE
+)
+
 ### Enable testing
 
 enable_testing()

--- a/test/documentation/doc_usr/CMakeLists.txt
+++ b/test/documentation/doc_usr/CMakeLists.txt
@@ -1,0 +1,36 @@
+# -----------------------------------------------------------------------------------------------------
+# Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+# Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+# This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+# shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+# -----------------------------------------------------------------------------------------------------
+
+message (STATUS "Configuring user doc.")
+
+set (SEQAN3_DOXYGEN_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+set (SEQAN3_DOXYGEN_SOURCE_DIR "${SEQAN3_CLONE_DIR}")
+set (SEQAN3_DOXYGEN_EXCLUDE_SYMBOLS "detail seqan3::simd") #/""
+set (SEQAN3_DOXYGEN_PREDEFINED_NDEBUG "-NDEBUG") #/""
+set (SEQAN3_DOXYGEN_ENABLED_SECTIONS "") #/"DEV"
+set (SEQAN3_DOXYGEN_EXTRACT_PRIVATE "NO") #/"YES":
+
+configure_file (${SEQAN3_DOXYFILE_IN} ${SEQAN3_DOXYGEN_OUTPUT_DIR}/Doxyfile)
+
+add_custom_target(doc_usr ALL
+                  COMMAND ${DOXYGEN_EXECUTABLE}
+                  WORKING_DIRECTORY ${SEQAN3_DOXYGEN_OUTPUT_DIR}
+                  BYPRODUCTS html/
+                  DEPENDS download-cppreference-doxygen-web-tag
+                  COMMENT "Generating user API documentation with Doxygen"
+                  VERBATIM)
+
+### Enable testing
+
+enable_testing()
+
+message (STATUS "Add user doc test.")
+add_test(NAME doc_usr_no_warnings_test
+         COMMAND bash -c "${SEQAN3_TEST_DOXYGEN_FAIL_ON_WARNINGS}")
+
+add_test(NAME doc_usr_no_uncond_requires_test
+         COMMAND bash -c "${SEQAN3_TEST_DOXYGEN_FAIL_ON_UNCOND_REQUIRES}")

--- a/test/documentation/seqan3-doxygen-package.cmake
+++ b/test/documentation/seqan3-doxygen-package.cmake
@@ -1,0 +1,21 @@
+# -----------------------------------------------------------------------------------------------------
+# Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+# Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+# This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+# shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+# -----------------------------------------------------------------------------------------------------
+
+cmake_minimum_required (VERSION 3.7)
+
+set (CPACK_GENERATOR "TXZ")
+
+set (CPACK_COMPONENTS_ALL doc)
+
+set (CPACK_ARCHIVE_COMPONENT_INSTALL ON)
+
+set (CPACK_PACKAGE_VENDOR "seqan")
+# A description of the project, used in places such as the introduction screen of CPack-generated Windows installers.
+# set (CPACK_PACKAGE_DESCRIPTION_FILE "") # TODO
+set (CPACK_PACKAGE_CHECKSUM "SHA256")
+
+include (CPack)

--- a/test/documentation/seqan3-doxygen.cmake
+++ b/test/documentation/seqan3-doxygen.cmake
@@ -59,4 +59,15 @@ set (SEQAN3_TEST_DOXYGEN_FAIL_ON_UNCOND_REQUIRES
      "! find . -not -name \"*_source.html\" -name \"*.html\" -print0 | xargs -0 grep \"requires\" | grep \"memname\"")
 
 
+### install helper
 
+# make sure that prefix path is /usr/local/share/doc/seqan3/
+if (NOT DEFINED CMAKE_SIZEOF_VOID_P)
+    # we need this to suppress GNUInstallDirs AUTHOR_WARNING:
+    #   CMake Warning (dev) at /usr/share/cmake-3.19/Modules/GNUInstallDirs.cmake:223 (message):
+    #     Unable to determine default CMAKE_INSTALL_LIBDIR directory because no
+    #     target architecture is known.  Please enable at least one language before
+    #     including GNUInstallDirs.
+    set (CMAKE_SIZEOF_VOID_P 8)
+endif ()
+include (GNUInstallDirs) # this is needed to prefix the install paths

--- a/test/documentation/seqan3-doxygen.cmake
+++ b/test/documentation/seqan3-doxygen.cmake
@@ -46,43 +46,17 @@ ExternalProject_Add (
     INSTALL_COMMAND ""
 )
 
-if (SEQAN3_USER_DOC)
-    message (STATUS "Configuring user doc.")
+### TEST HELPER
 
-    set (SEQAN3_DOXYGEN_OUTPUT_DIR "${PROJECT_BINARY_DIR}/doc_usr")
-    set (SEQAN3_DOXYGEN_SOURCE_DIR "${SEQAN3_CLONE_DIR}")
-    set (SEQAN3_DOXYGEN_EXCLUDE_SYMBOLS "detail seqan3::simd") #/""
-    set (SEQAN3_DOXYGEN_PREDEFINED_NDEBUG "-NDEBUG") #/""
-    set (SEQAN3_DOXYGEN_ENABLED_SECTIONS "") #/"DEV"
-    set (SEQAN3_DOXYGEN_EXTRACT_PRIVATE "NO") #/"YES":
+# doxygen does not show any warnings (doxygen prints warnings / errors to cerr)
+set (SEQAN3_TEST_DOXYGEN_FAIL_ON_WARNINGS "
+    ${DOXYGEN_EXECUTABLE} > doxygen.cout 2> doxygen.cerr;
+    cat \"doxygen.cerr\";
+    test ! -s \"doxygen.cerr\"")
 
-    configure_file (${SEQAN3_DOXYFILE_IN} ${SEQAN3_DOXYGEN_OUTPUT_DIR}/Doxyfile)
+# We search the HTML output to ensure that no `requires` clauses are at wrong places.
+set (SEQAN3_TEST_DOXYGEN_FAIL_ON_UNCOND_REQUIRES
+     "! find . -not -name \"*_source.html\" -name \"*.html\" -print0 | xargs -0 grep \"requires\" | grep \"memname\"")
 
-    add_custom_target(doc_usr ALL
-                      COMMAND ${DOXYGEN_EXECUTABLE}
-                      WORKING_DIRECTORY ${SEQAN3_DOXYGEN_OUTPUT_DIR}
-                      DEPENDS download-cppreference-doxygen-web-tag
-                      COMMENT "Generating user API documentation with Doxygen"
-                      VERBATIM)
-endif ()
 
-if (SEQAN3_DEV_DOC)
-    message(STATUS "Configuring devel doc.")
 
-    set(SEQAN3_DOXYGEN_OUTPUT_DIR "${PROJECT_BINARY_DIR}/doc_dev")
-    set(SEQAN3_DOXYGEN_SOURCE_DIR "${SEQAN3_CLONE_DIR}")
-    set(SEQAN3_DOXYGEN_EXCLUDE_SYMBOLS "")
-    set(SEQAN3_DOXYGEN_PREDEFINED_NDEBUG "")
-    set(SEQAN3_DOXYGEN_ENABLED_SECTIONS "DEV")
-    set(SEQAN3_DOXYGEN_EXTRACT_PRIVATE "YES")
-
-    configure_file(${SEQAN3_DOXYFILE_IN} ${SEQAN3_DOXYGEN_OUTPUT_DIR}/Doxyfile)
-
-    add_custom_target(doc_dev ALL
-                      COMMAND ${DOXYGEN_EXECUTABLE}
-                      WORKING_DIRECTORY ${SEQAN3_DOXYGEN_OUTPUT_DIR}
-                      DEPENDS download-cppreference-doxygen-web-tag
-                      COMMENT "Generating developer API documentation with Doxygen"
-                      VERBATIM)
-                      message (STATUS "Add devel doc test.")
-endif ()


### PR DESCRIPTION
This PR makes the doc_usr and doc_dev folders explicit folders instead of implicitly generated ones.

We also moved common definitions into seqan3-doxygen.cmake and all parts that were conditionally included by `SEQAN3_USER_DOC` and `SEQAN3_DEV_DOC` were moved into the `doc_{dev,usr}/CMakelists.txt` file.

That means the sub-folders `doc_{dev,usr}` do all necessary definitions of the documentations variants within their subfolder.

This PR also adds the ability to install/package our documentation via cmake. Last but not least I added a README.md to document on how to build, install and package our documentation.



