### PR TITLE
[FIX] author and email not showing in argument_parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@ If possible, provide tooling that performs the changes, e.g. a shell-script.
   ([\#2363](https://github.com/seqan/seqan3/pull/2363)).
 * The Argument Parser accepts containers of all values it is able to parse, e.g. a `std::vector` of enums or `bool`
   ([\#2381](https://github.com/seqan/seqan3/pull/2381)).
+* The Argument Parser's help pages now contain author and email information
+  ([\#2374](https://github.com/seqan/seqan3/pull/2374)).
 
 ## API changes
 

--- a/include/seqan3/argument_parser/detail/format_base.hpp
+++ b/include/seqan3/argument_parser/detail/format_base.hpp
@@ -448,7 +448,11 @@ protected:
     void print_legal()
     {
         // Print legal stuff
-        if ((!empty(meta.short_copyright)) || (!empty(meta.long_copyright)) || (!empty(meta.citation)))
+        if ((!empty(meta.short_copyright)) ||
+            (!empty(meta.long_copyright)) ||
+            (!empty(meta.citation)) ||
+            (!empty(meta.author)) ||
+            (!empty(meta.email)))
         {
             derived_t().print_section("Legal");
 
@@ -456,6 +460,16 @@ protected:
             {
                 derived_t().print_line(derived_t().in_bold(meta.app_name + " Copyright: ") + meta.short_copyright,
                                        false);
+            }
+
+            if (!empty(meta.author))
+            {
+                derived_t().print_line(derived_t().in_bold("Author: ") + meta.author, false);
+            }
+
+            if (!empty(meta.email))
+            {
+                derived_t().print_line(derived_t().in_bold("Contact: ") + meta.email, false);
             }
 
             derived_t().print_line(derived_t().in_bold("SeqAn Copyright: ") +

--- a/test/unit/argument_parser/detail/format_help_test.cpp
+++ b/test/unit/argument_parser/detail/format_help_test.cpp
@@ -114,6 +114,7 @@ TEST(help_page_printing, with_short_copyright)
 {
     // Again, but with short copyright, long copyright, and citation.
     seqan3::argument_parser short_copy("test_parser", 2, argv1);
+    test_accessor::set_terminal_width(short_copy, 80);
     short_copy.info.short_copyright = "short";
     testing::internal::CaptureStdout();
     EXPECT_EXIT(short_copy.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
@@ -135,6 +136,7 @@ TEST(help_page_printing, with_short_copyright)
 TEST(help_page_printing, with_long_copyright)
 {
     seqan3::argument_parser long_copy("test_parser", 2, argv1);
+    test_accessor::set_terminal_width(long_copy, 80);
     long_copy.info.long_copyright = "long";
     testing::internal::CaptureStdout();
     EXPECT_EXIT(long_copy.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
@@ -156,6 +158,7 @@ TEST(help_page_printing, with_long_copyright)
 TEST(help_page_printing, with_citation)
 {
     seqan3::argument_parser citation("test_parser", 2, argv1);
+    test_accessor::set_terminal_width(citation, 80);
     citation.info.citation = "citation";
     testing::internal::CaptureStdout();
     EXPECT_EXIT(citation.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
@@ -177,6 +180,7 @@ TEST(help_page_printing, with_citation)
 TEST(help_page_printing, with_author)
 {
     seqan3::argument_parser author("test_parser", 2, argv1);
+    test_accessor::set_terminal_width(author, 80);
     author.info.author = "author";
     testing::internal::CaptureStdout();
     EXPECT_EXIT(author.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
@@ -198,6 +202,7 @@ TEST(help_page_printing, with_author)
 TEST(help_page_printing, with_email)
 {
     seqan3::argument_parser email("test_parser", 2, argv1);
+    test_accessor::set_terminal_width(email, 80);
     email.info.email = "email";
     testing::internal::CaptureStdout();
     EXPECT_EXIT(email.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
@@ -323,6 +328,7 @@ TEST(help_page_printing, advanced_options)
 
     // without -hh, only the non/advanced information are shown
     seqan3::argument_parser parser_normal_help{"test_parser", 2, argv1};
+    test_accessor::set_terminal_width(parser_normal_help, 80);
     set_up(parser_normal_help);
     testing::internal::CaptureStdout();
     EXPECT_EXIT(parser_normal_help.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
@@ -348,6 +354,7 @@ TEST(help_page_printing, advanced_options)
 
     // with -hh everything is shown
     seqan3::argument_parser parser_advanced_help{"test_parser", 2, argv2};
+    test_accessor::set_terminal_width(parser_advanced_help, 80);
     set_up(parser_advanced_help);
     testing::internal::CaptureStdout();
     EXPECT_EXIT(parser_advanced_help.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");

--- a/test/unit/argument_parser/detail/format_help_test.cpp
+++ b/test/unit/argument_parser/detail/format_help_test.cpp
@@ -174,6 +174,48 @@ TEST(help_page_printing, with_citation)
     EXPECT_EQ(std_cout, expected);
 }
 
+TEST(help_page_printing, with_author)
+{
+    seqan3::argument_parser author("test_parser", 2, argv1);
+    author.info.author = "author";
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(author.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
+    std_cout = testing::internal::GetCapturedStdout();
+    expected = "test_parser\n"
+               "===========\n"
+               "\n" +
+               basic_options_str +
+               "\n" +
+               basic_version_str +
+               "\n" +
+               "LEGAL\n"
+               "    Author: author\n"
+               "    SeqAn Copyright: 2006-2021 Knut Reinert, FU-Berlin; released under the\n"
+               "    3-clause BSDL.\n";
+    EXPECT_EQ(std_cout, expected);
+}
+
+TEST(help_page_printing, with_email)
+{
+    seqan3::argument_parser email("test_parser", 2, argv1);
+    email.info.email = "email";
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(email.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
+    std_cout = testing::internal::GetCapturedStdout();
+    expected = "test_parser\n"
+               "===========\n"
+               "\n" +
+               basic_options_str +
+               "\n" +
+               basic_version_str +
+               "\n" +
+               "LEGAL\n"
+               "    Contact: email\n"
+               "    SeqAn Copyright: 2006-2021 Knut Reinert, FU-Berlin; released under the\n"
+               "    3-clause BSDL.\n";
+    EXPECT_EQ(std_cout, expected);
+}
+
 TEST(help_page_printing, empty_advanced_help)
 {
     // Empty help call with -hh

--- a/test/unit/argument_parser/detail/format_html_test.cpp
+++ b/test/unit/argument_parser/detail/format_html_test.cpp
@@ -88,6 +88,8 @@ TEST(html_format, full_information_information)
    parser1.info.short_copyright = "short copyright";
    parser1.info.long_copyright = "long_copyright";
    parser1.info.citation = "citation";
+   parser1.info.author = "author";
+   parser1.info.email = "email";
    parser1.add_option(option_value, 'i', "int", "this is a int option.");
    parser1.add_option(option_value, 'j', "jint", "this is a required int option.", seqan3::option_spec::required);
    parser1.add_flag(flag_value, 'f', "flag", "this is a flag.");
@@ -178,6 +180,10 @@ TEST(html_format, full_information_information)
                           "<h2>Legal</h2>\n"
                           "<p>\n"
                           "<strong>program_full_options Copyright: </strong>short copyright\n"
+                          "<br>\n"
+                          "<strong>Author: </strong>author\n"
+                          "<br>\n"
+                          "<strong>Contact: </strong>email\n"
                           "<br>\n"
                           "<strong>SeqAn Copyright: </strong>2006-2021 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.\n"
                           "<br>\n"

--- a/test/unit/argument_parser/detail/format_man_test.cpp
+++ b/test/unit/argument_parser/detail/format_man_test.cpp
@@ -246,3 +246,45 @@ For full copyright and/or warranty information see \fB--copyright\fR.
     my_stdout = testing::internal::GetCapturedStdout();
     EXPECT_EQ(my_stdout, expected);
 }
+
+TEST_F(format_man_test, full_info_author)
+{
+    // Create the dummy parser.
+    seqan3::argument_parser parser{"default", 3, argv};
+
+    // Fill out the dummy parser with options and flags and sections and subsections.
+    dummy_init(parser);
+    // Add a short copyright and test the dummy parser.
+    parser.info.author = "author";
+    expected += R"(.SH LEGAL
+\fBAuthor: \fRauthor
+.br
+\fBSeqAn Copyright: \fR2006-2021 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.
+)";
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(parser.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
+
+    my_stdout = testing::internal::GetCapturedStdout();
+    EXPECT_EQ(my_stdout, expected);
+}
+
+TEST_F(format_man_test, full_info_email)
+{
+    // Create the dummy parser.
+    seqan3::argument_parser parser{"default", 3, argv};
+
+    // Fill out the dummy parser with options and flags and sections and subsections.
+    dummy_init(parser);
+    // Add a short copyright and test the dummy parser.
+    parser.info.email = "email";
+    expected += R"(.SH LEGAL
+\fBContact: \fRemail
+.br
+\fBSeqAn Copyright: \fR2006-2021 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.
+)";
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(parser.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
+
+    my_stdout = testing::internal::GetCapturedStdout();
+    EXPECT_EQ(my_stdout, expected);
+}


### PR DESCRIPTION
Resolves https://github.com/seqan/seqan3/issues/2173