### PR TITLE
[MISC] deprecate gap_scheme

### DIFF
--- a/include/seqan3/alignment/pairwise/policy/all.hpp
+++ b/include/seqan3/alignment/pairwise/policy/all.hpp
@@ -60,7 +60,6 @@
  * Function name     | Arguments                              | Return value                         |
  * ----------------- | -------------------------------------- | ------------------------------------ |
  * `compute_cell`    | `cell &&`, `cache &`, `score const &`  | `void`                               |
- * `make_cache`      | `gap_scheme const &`                   | alignment_algorithm_state            |
  *
  * - compute_cell:
  *
@@ -68,11 +67,6 @@
  *    It gets as an input the dereferenced value of the scoring matrix (see above), the current alignment algorithm
  *    cache and the score of comparing two letter of the used alphabet using the passed scoring scheme.
  *
- * - make_cache:
- *
- *     Initialises and returns the cache used in the alignment algorithm. It must return a type that allows structured
- *     bindings, with the first argument being of the same type as the allocator value type used in the matrix policy,
- *     the second argument being the costs for gap opening + gap and the third argument being the costs for a gap.
  *
  * ### Existing gap policies:
  *

--- a/include/seqan3/alignment/scoring/gap_scheme.hpp
+++ b/include/seqan3/alignment/scoring/gap_scheme.hpp
@@ -26,8 +26,8 @@ namespace seqan3
 // seqan3::gap_score
 // ------------------------------------------------------------------
 
-/*!\brief A strong type of underlying type `score_type` that represents the score of any character against a gap
- *        character. 
+/*!\brief [DEPRECATED] A strong type of underlying type `score_type` that
+ *        represents the score of any character against a gap character.
  * \deprecated This type is deprecated and will be removed in SeqAn3.1.
  * \tparam score_type The underlying type.
  * \ingroup scoring
@@ -53,8 +53,9 @@ gap_score(score_type) -> gap_score<score_type>;
 // seqan3::gap_open_score
 // ------------------------------------------------------------------
 
-/*!\brief A strong type of underlying type `score_type` that represents an additional score (usually negative) that
- *        is incurred once additionaly per stretch of consecutive gaps.
+/*!\brief [DEPRECATED] A strong type of underlying type `score_type` that
+ *        represents an additional score (usually negative) that is incurred
+ *        once additionaly per stretch of consecutive gaps.
  * \deprecated This type is deprecated and will be removed in SeqAn3.1.
  * \tparam score_type The underlying type.
  * \ingroup scoring
@@ -80,10 +81,11 @@ gap_open_score(score_type) -> gap_open_score<score_type>;
 // seqan3::gap_scheme
 // ------------------------------------------------------------------
 
-/*!\brief A scheme for representing and computing scores against gap characters.
+/*!\brief [DEPRECATED] A scheme for representing and computing scores against gap characters.
  * \tparam score_type Type of the score values saved internally.
  * \implements seqan3::cerealisable
  * \ingroup scoring
+ * \deprecated This type is deprecated and will be removed in SeqAn3.1.
  */
 template <arithmetic score_t = int8_t>
 class SEQAN3_DEPRECATED_310 gap_scheme

--- a/include/seqan3/alignment/scoring/gap_scheme.hpp
+++ b/include/seqan3/alignment/scoring/gap_scheme.hpp
@@ -34,7 +34,7 @@ namespace seqan3
  * \see seqan3::gap_scheme
  */
 template <arithmetic score_type>
-struct gap_score : detail::strong_type<score_type, gap_score<score_type>, detail::strong_type_skill::convert>
+struct SEQAN3_DEPRECATED_310 gap_score : detail::strong_type<score_type, gap_score<score_type>, detail::strong_type_skill::convert>
 {
      using detail::strong_type<score_type, gap_score<score_type>, detail::strong_type_skill::convert>::strong_type;
 };
@@ -62,7 +62,7 @@ gap_score(score_type) -> gap_score<score_type>;
  * \see seqan3::gap_scheme
  */
 template <arithmetic score_type>
-struct gap_open_score : detail::strong_type<score_type, gap_open_score<score_type>, detail::strong_type_skill::convert>
+struct SEQAN3_DEPRECATED_310 gap_open_score : detail::strong_type<score_type, gap_open_score<score_type>, detail::strong_type_skill::convert>
 {
      using detail::strong_type<score_type, gap_open_score<score_type>, detail::strong_type_skill::convert>::strong_type;
 };

--- a/include/seqan3/alignment/scoring/gap_scheme.hpp
+++ b/include/seqan3/alignment/scoring/gap_scheme.hpp
@@ -301,3 +301,6 @@ gap_scheme(gap_score<score_arg_type>) -> gap_scheme<int8_t>;
 
 #pragma GCC diagnostic pop
 } // namespace seqan3
+
+SEQAN3_DEPRECATED_HEADER(
+    "This header and its provided functions are deprecated and will be removed in SeqAn-3.1.0.")


### PR DESCRIPTION
This adds [DEPRECATE] and \deprecate annotation to gap_scheme or related
classes.
Also removed gap policy "make_cache" since it didn't exist and is using
gap_scheme.