### PR TITLE
[MISC] deprecate seqan3::field::seq_qual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,10 @@ If possible, provide tooling that performs the changes, e.g. a shell-script.
   to add convenient functions that compute information based on the record itself and to provide better documentation.
   ([\#2340](https://github.com/seqan/seqan3/pull/2340), [\#2380](https://github.com/seqan/seqan3/pull/2380),
   [\#2389](https://github.com/seqan/seqan3/pull/2389))
+* Deprecated `seqan3::field::seq_qual`. Use `seqan3::fiel::seq` and `seqan3::field::qual` instead.
+  ([\#2379](https://github.com/seqan/seqan3/pull/2379)). Check out 
+  [SeqAn3 Cookbook - Write Record](https://docs.seqan.de/seqan/3.0.3/cookbook.html)
+  for usage.
 
 #### Search
 

--- a/doc/cookbook/index.md
+++ b/doc/cookbook/index.md
@@ -89,6 +89,11 @@ These work similarly to how they work on a std::vector.
 
 \include test/snippet/io/sequence_file/sequence_file_output_record_wise_iteration.cpp
 
+The class seqan3::sequence_file_output takes an extra parameter allowing to custom select the
+fields and their order.
+
+\include test/snippet/io/sequence_file/sequence_file_output_fields_trait_1.cpp
+
 # File conversion
 
 \snippet doc/tutorial/sequence_file/sequence_file_snippets.cpp file_conversion

--- a/doc/tutorial/sequence_file/index.md
+++ b/doc/tutorial/sequence_file/index.md
@@ -140,16 +140,13 @@ You can also customise this list if you want to allow different or additional fi
 
 # Fields {#section_sequence_files}
 
-The Sequence file abstraction supports reading four different fields:
+The Sequence file abstraction supports reading three different fields:
 
   1. seqan3::field::seq
   2. seqan3::field::id
   3. seqan3::field::qual
-  4. seqan3::field::seq_qual
 
-The first three fields are retrieved by default (and in that order!).
-The last field may be selected to directly store sequence and qualities in a more memory-efficient
-combined container (see seqan3::qualified).
+The three fields are retrieved by default (and in that order!).
 This is more advanced than what we cover here,
 but if you are still interested you can take a look at the tutorial \ref tutorial_sam_file
 which introduces reading a file with custom selected fields.

--- a/include/seqan3/io/record.hpp
+++ b/include/seqan3/io/record.hpp
@@ -64,7 +64,8 @@ enum class field
     seq,            //!< The "sequence", usually a range of nucleotides or amino acids.
     id,             //!< The identifier, usually a string.
     qual,           //!< The qualities, usually in Phred score notation.
-    seq_qual,       //!< Sequence and qualities combined in one range.
+    _seq_qual_deprecated, //!< [DEPRECATED] Sequence and qualities combined in one range. Use field::seq and field::qual instead.
+
     offset,         //!< Sequence (seqan3::field::seq) relative start position (0-based), unsigned value.
 
     // Fields unique to structure io ...........................................
@@ -104,11 +105,14 @@ enum class field
     user_defined_8, //!< Identifier for user defined file formats and specialisations.
     user_defined_9, //!< Identifier for user defined file formats and specialisations.
 
+    // deprecated lowercase:
+    seq_qual SEQAN3_DEPRECATED_310 = _seq_qual_deprecated, //!< [DEPRECATED] Sequence and qualities combined in one range. Use field::seq and field::qual instead.
+
     // deprecated uppercase:
     SEQ SEQAN3_DEPRECATED_310 = seq, //!< Please use the field name in lower case.
     ID SEQAN3_DEPRECATED_310 = id, //!< Please use the field name in lower case.
     QUAL SEQAN3_DEPRECATED_310 = qual, //!< Please use the field name in lower case.
-    SEQ_QUAL SEQAN3_DEPRECATED_310 = seq_qual, //!< Please use the field name in lower case.
+    SEQ_QUAL SEQAN3_DEPRECATED_310 = _seq_qual_deprecated, //!< [DEPRECATED] Sequence and qualities combined in one range. Use field::seq and field::qual instead.
     OFFSET SEQAN3_DEPRECATED_310 = offset, //!< Please use the field name in lower case.
     BPP SEQAN3_DEPRECATED_310 = bpp, //!< Please use the field name in lower case.
     STRUCTURE SEQAN3_DEPRECATED_310 = structure, //!< Please use the field name in lower case.

--- a/include/seqan3/io/sequence_file/format_fastq.hpp
+++ b/include/seqan3/io/sequence_file/format_fastq.hpp
@@ -58,9 +58,8 @@ namespace seqan3
  *
  * ### fields_specialisation
  *
- * The FastQ format provides the fields seqan3::field::seq, seqan3::field::id and seqan3::field::qual; or alternatively
- * provides seqan3::field::seq_qual as a single field of sequence and quality. All three fields (or ID + SEQ_QUAL) are
- * required when writing and the sequence and qualities are required to be of the same length.
+ * The FastQ format provides the fields seqan3::field::seq, seqan3::field::id and seqan3::field::qual. All three fields
+ * are required when writing and the sequence and qualities are required to be of the same length.
  *
  * ### Encodings
  *

--- a/include/seqan3/io/sequence_file/format_fastq.hpp
+++ b/include/seqan3/io/sequence_file/format_fastq.hpp
@@ -34,11 +34,11 @@
 #include <seqan3/range/detail/misc.hpp>
 #include <seqan3/range/views/char_to.hpp>
 #include <seqan3/range/views/istreambuf.hpp>
-#include <seqan3/range/views/to_char.hpp>
 #include <seqan3/range/views/take.hpp>
 #include <seqan3/range/views/take_exactly.hpp>
 #include <seqan3/range/views/take_line.hpp>
 #include <seqan3/range/views/take_until.hpp>
+#include <seqan3/range/views/to_char.hpp>
 #include <seqan3/utility/char_operations/predicate.hpp>
 #include <seqan3/utility/detail/type_name_as_string.hpp>
 

--- a/include/seqan3/io/sequence_file/input_format_concept.hpp
+++ b/include/seqan3/io/sequence_file/input_format_concept.hpp
@@ -114,10 +114,6 @@ SEQAN3_CONCEPT sequence_file_input_format = requires (detail::sequence_file_inpu
  *   * The function must also accept std::ignore as parameter for any of the fields.
  *     [This is enforced by the concept checker!]
  *   * In this case the data read for that field shall be discarded by the format.
- *   * Instead of passing the fields seqan3::field::seq and seqan3::field::qual, you may also pass
- *     seqan3::field::seq_qual to both parameters. If you do, the std::ranges::range_value_t of the argument must be
- *     a specialisation of seqan3::qualified and the second template parameter to
- *     seqan3::sequence_file_input_options must be set to true.
  */
  /*!\var static inline std::vector<std::string> seqan3::sequence_file_input_format::file_extensions
  * \brief The format type is required to provide a vector of all supported file extensions.

--- a/include/seqan3/io/sequence_file/input_options.hpp
+++ b/include/seqan3/io/sequence_file/input_options.hpp
@@ -19,7 +19,7 @@ namespace seqan3
 /*!\brief The options type defines various option members that influence the behaviour of all or some formats.
  * \tparam sequence_legal_alphabet_ The sequence legal alphabet exposed as type trait to the format.
  * \tparam seq_qual_combined [DEPRECATED] Trait that exposes to the format whether seq and qual arguments are
- * actually the same/combined. Will be removed in SeqAn-3.1.0.
+ *                           actually the same/combined. Will be removed in SeqAn-3.1.0.
  */
 #ifdef SEQAN3_DEPRECATED_310
 template <typename sequence_legal_alphabet, bool seq_qual_combined>

--- a/include/seqan3/io/sequence_file/input_options.hpp
+++ b/include/seqan3/io/sequence_file/input_options.hpp
@@ -18,10 +18,14 @@ namespace seqan3
 {
 /*!\brief The options type defines various option members that influence the behaviour of all or some formats.
  * \tparam sequence_legal_alphabet_ The sequence legal alphabet exposed as type trait to the format.
- * \tparam seq_qual_combined Trait that exposes to the format whether seq and qual arguments are actually the
- * same/combined.
+ * \tparam seq_qual_combined [DEPRECATED] Trait that exposes to the format whether seq and qual arguments are
+ * actually the same/combined. Will be removed in SeqAn-3.1.0.
  */
+#ifdef SEQAN3_DEPRECATED_310
 template <typename sequence_legal_alphabet, bool seq_qual_combined>
+#else // ^^^ before seqan 3.1 / after seqan 3.1 vvv
+template <typename sequence_legal_alphabet>
+#endif
 struct sequence_file_input_options
 {
     //!\brief Read the ID string only up until the first whitespace character.

--- a/include/seqan3/io/sequence_file/output.hpp
+++ b/include/seqan3/io/sequence_file/output.hpp
@@ -110,10 +110,9 @@ namespace seqan3
  *
  * You may also use the output file's iterator for writing, however, this rarely provides an advantage.
  *
-* ### Writing record-wise (custom fields)
+ * ### Writing record-wise (custom fields)
  *
- * If you want to pass a combined object for SEQ and QUAL fields to push_back() / emplace_back(), or if you want
- * to change the order of the parameters, you can pass a non-empty fields trait object to the
+ * If you want to change the order of the parameters, you can pass a non-empty fields trait object to the
  * sequence_file_output constructor to select the fields that are used for interpreting the arguments.
  *
  * The following snippets demonstrates the usage of such a fields trait object.

--- a/include/seqan3/io/sequence_file/output.hpp
+++ b/include/seqan3/io/sequence_file/output.hpp
@@ -64,12 +64,11 @@ namespace seqan3
  * FastA and FastQ, but some may also be interested in treating SAM or BAM files as sequence
  * files, discarding the alignment.
  *
- * The Sequence file abstraction supports writing four different fields:
+ * The Sequence file abstraction supports writing three different fields:
  *
  *   1. seqan3::field::seq
  *   2. seqan3::field::id
  *   3. seqan3::field::qual
- *   4. seqan3::field::seq_qual (sequence and qualities in one range)
  *
  * The member functions take any and either of these fields. If the field ID of an argument cannot be deduced, it
  * is assumed to correspond to the field ID of the respective template parameter.
@@ -182,7 +181,7 @@ public:
     //!\}
 
     //!\brief The subset of seqan3::field IDs that are valid for this file.
-    using field_ids            = fields<field::seq, field::id, field::qual, field::seq_qual>;
+    using field_ids            = fields<field::seq, field::id, field::qual, field::_seq_qual_deprecated>;
 
     static_assert([] () constexpr
                   {
@@ -196,7 +195,7 @@ public:
 
     static_assert([] () constexpr
                   {
-                      return !(selected_field_ids::contains(field::seq_qual) &&
+                      return !(selected_field_ids::contains(field::_seq_qual_deprecated) &&
                                (selected_field_ids::contains(field::seq) ||
                                (selected_field_ids::contains(field::qual))));
                   }(),
@@ -395,8 +394,7 @@ public:
         write_record(detail::get_or_ignore<field::seq>(r),
                      detail::get_or_ignore<field::id>(r),
                      detail::get_or_ignore<field::qual>(r),
-                     detail::get_or_ignore<field::seq_qual>(r));
-
+                     detail::get_or_ignore<field::_seq_qual_deprecated>(r));
     }
 
     /*!\brief           Write a record in form of a std::tuple to the file.
@@ -430,7 +428,7 @@ public:
         write_record(detail::get_or_ignore<selected_field_ids::index_of(field::seq)>(t),
                      detail::get_or_ignore<selected_field_ids::index_of(field::id)>(t),
                      detail::get_or_ignore<selected_field_ids::index_of(field::qual)>(t),
-                     detail::get_or_ignore<selected_field_ids::index_of(field::seq_qual)>(t));
+                     detail::get_or_ignore<selected_field_ids::index_of(field::_seq_qual_deprecated)>(t));
     }
 
     /*!\brief            Write a record to the file by passing individual fields.

--- a/include/seqan3/io/sequence_file/output_format_concept.hpp
+++ b/include/seqan3/io/sequence_file/output_format_concept.hpp
@@ -114,8 +114,6 @@ SEQAN3_CONCEPT sequence_file_output_format = requires (detail::sequence_file_out
  *
  *   * The format must also accept std::ignore as parameter for any of the fields, however it shall throw an exception
  * if one of the fields required for writing the format is marked as such. [this shall be checked inside the function]
- *   * The format does not handle seqan3::field::seq_qual, instead seqan3::sequence_file_output splits it into two views
- *     and passes it to the format as if they were separate.
  */
 /*!\var static inline std::vector<std::string> seqan3::sequence_file_output_format::file_extensions
  * \brief The format type is required to provide a vector of all supported file extensions.

--- a/test/snippet/io/sequence_file/sequence_file_input_custom_fields.cpp
+++ b/test/snippet/io/sequence_file/sequence_file_input_custom_fields.cpp
@@ -18,13 +18,12 @@ int main()
 
     seqan3::sequence_file_input fin{std::istringstream{input},
                                     seqan3::format_fasta{},
-                                    seqan3::fields<seqan3::field::id, seqan3::field::seq_qual>{}};
+                                    seqan3::fields<seqan3::field::id, seqan3::field::seq, seqan3::field::qual>{}};
 
-    for (auto & [id, seq_qual] : fin) // the order is now different, "id" comes first, because it was specified first
+    for (auto & [id, seq, qual] : fin) // the order is now different, "id" comes first, because it was specified first
     {
         seqan3::debug_stream << "ID:  " << id << '\n';
-        // sequence and qualities are part of the same vector, of type std::vector<dna5q>
-        seqan3::debug_stream << "SEQ: "  << (seq_qual | seqan3::views::get<0>) << '\n'; // sequence string is extracted
-        seqan3::debug_stream << "QUAL: " << (seq_qual | seqan3::views::get<1>) << '\n'; // quality string is extracted
+        seqan3::debug_stream << "SEQ: "  << seq << '\n';
+        seqan3::debug_stream << "QUAL: " << qual << '\n';
     }
 }

--- a/test/snippet/io/sequence_file/sequence_file_output_fields_trait_1.cpp
+++ b/test/snippet/io/sequence_file/sequence_file_output_fields_trait_1.cpp
@@ -7,6 +7,7 @@
 #include <seqan3/alphabet/quality/phred42.hpp>
 #include <seqan3/alphabet/quality/qualified.hpp>
 #include <seqan3/io/sequence_file/output.hpp>
+#include <seqan3/range/views/get.hpp>
 
 int main()
 {
@@ -14,19 +15,27 @@ int main()
     using seqan3::operator""_phred42;
 
     seqan3::sequence_file_output fout{std::ostringstream{},
-                                      seqan3::format_fasta{},
-                                      seqan3::fields<seqan3::field::id, seqan3::field::seq_qual>{}};
+                                      seqan3::format_fastq{},
+                                      seqan3::fields<seqan3::field::id, seqan3::field::seq, seqan3::field::qual>{}};
 
     for (int i = 0; i < 5; i++)
     {
         std::string id{"test_id"};
         // vector of combined data structure:
-        std::vector<seqan3::qualified<seqan3::dna5, seqan3::phred42>> seq_qual{{'N'_dna5, '7'_phred42}};
+        std::vector<seqan3::qualified<seqan3::dna5, seqan3::phred42>> seq_qual{{'N'_dna5, '7'_phred42},
+                                                                               {'A'_dna5, '1'_phred42},
+                                                                               {'C'_dna5, '3'_phred42}};
+
+        auto view_on_seq  = seqan3::views::get<0>(seq_qual);
+        auto view_on_qual = seqan3::views::get<1>(seq_qual);
 
         // ...
 
-        fout.emplace_back(id, seq_qual);       // note also that the order the argumets is now different, because
-        // or:                                    you specified that ID should be first in the fields template argument
-        fout.push_back(std::tie(id, seq_qual));
+        // Note that the order of the arguments is different from the default `seq, id, qual`,
+        // because you specified that ID should be first in the fields template argument.
+        fout.emplace_back(id, view_on_seq, view_on_qual);
+
+        // or:
+        fout.push_back(std::tie(id, view_on_seq, view_on_qual));
     }
 }

--- a/test/unit/io/record_test.cpp
+++ b/test/unit/io/record_test.cpp
@@ -44,7 +44,7 @@ TEST(fields, usage)
     EXPECT_TRUE(default_fields::contains(seqan3::field::seq));
     EXPECT_TRUE(default_fields::contains(seqan3::field::id));
     EXPECT_TRUE(default_fields::contains(seqan3::field::qual));
-    EXPECT_FALSE(default_fields::contains(seqan3::field::seq_qual));
+    EXPECT_FALSE(default_fields::contains(seqan3::field::_seq_qual_deprecated));
     EXPECT_EQ(default_fields::index_of(seqan3::field::seq), 0ul);
     EXPECT_EQ(default_fields::index_of(seqan3::field::id),  1ul);
     EXPECT_EQ(default_fields::index_of(seqan3::field::qual), 2ul);

--- a/test/unit/io/sequence_file/sequence_file_format_test_template.hpp
+++ b/test/unit/io/sequence_file/sequence_file_format_test_template.hpp
@@ -122,7 +122,7 @@ TYPED_TEST_P(sequence_file_read, only_id)
 TYPED_TEST_P(sequence_file_read, seq_qual)
 {
     std::stringstream istream{this->standard_input};
-    seqan3::sequence_file_input fin{istream, TypeParam{}, seqan3::fields<seqan3::field::id, seqan3::field::seq_qual>{}};
+    seqan3::sequence_file_input fin{istream, TypeParam{}, seqan3::fields<seqan3::field::id, seqan3::field::_seq_qual_deprecated>{}};
 
     auto it = fin.begin();
     for (unsigned i = 0; i < 3; ++i, ++it)
@@ -130,12 +130,13 @@ TYPED_TEST_P(sequence_file_read, seq_qual)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::id>(*it), this->ids[i]);
-        EXPECT_RANGE_EQ(seqan3::get<seqan3::field::seq_qual>(*it) | seqan3::views::convert<seqan3::dna5>,
+        EXPECT_RANGE_EQ(seqan3::get<seqan3::field::_seq_qual_deprecated>(*it) | seqan3::views::convert<seqan3::dna5>,
                         this->seqs[i]);
 #pragma GCC diagnostic pop
 
         EXPECT_RANGE_EQ((*it).id(), this->ids[i]);
     }
+
 }
 
 TYPED_TEST_P(sequence_file_read, options_truncate_ids)
@@ -198,7 +199,7 @@ TYPED_TEST_P(sequence_file_write, seq_qual)
     });
 
     seqan3::sequence_file_output fout{this->ostream, TypeParam{}, seqan3::fields<seqan3::field::id,
-                                                                                 seqan3::field::seq_qual>{}};
+                                                                                 seqan3::field::_seq_qual_deprecated>{}};
 
     for (unsigned i = 0; i < 3; ++i)
     {

--- a/test/unit/io/sequence_file/sequence_file_format_test_template.hpp
+++ b/test/unit/io/sequence_file/sequence_file_format_test_template.hpp
@@ -136,7 +136,6 @@ TYPED_TEST_P(sequence_file_read, seq_qual)
 
         EXPECT_RANGE_EQ((*it).id(), this->ids[i]);
     }
-
 }
 
 TYPED_TEST_P(sequence_file_read, options_truncate_ids)

--- a/test/unit/io/sequence_file/sequence_file_input_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_input_test.cpp
@@ -272,7 +272,7 @@ TEST_F(sequence_file_input_f, record_reading_custom_fields)
     /* record based reading */
     seqan3::sequence_file_input fin{std::istringstream{input},
                                     seqan3::format_fasta{},
-                                    seqan3::fields<seqan3::field::id, seqan3::field::seq_qual>{}};
+                                    seqan3::fields<seqan3::field::id, seqan3::field::_seq_qual_deprecated>{}};
 
     size_t counter = 0;
     for (auto & [ id, seq_qual ] : fin)

--- a/test/unit/io/sequence_file/sequence_file_input_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_input_test.cpp
@@ -12,8 +12,8 @@
 #include <seqan3/std/ranges>
 #include <sstream>
 
-#include <seqan3/io/sequence_file/input.hpp>
 #include <seqan3/core/detail/debug_stream_alphabet.hpp>
+#include <seqan3/io/sequence_file/input.hpp>
 #include <seqan3/range/views/convert.hpp>
 #include <seqan3/test/expect_range_eq.hpp>
 #include <seqan3/test/tmp_filename.hpp>

--- a/test/unit/io/sequence_file/sequence_file_output_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_output_test.cpp
@@ -360,7 +360,7 @@ TEST(row, writing_seq_qual)
 {
     seqan3::sequence_file_output fout{std::ostringstream{},
                                       seqan3::format_fasta{},
-                                      seqan3::fields<seqan3::field::id, seqan3::field::seq_qual>()};
+                                      seqan3::fields<seqan3::field::id, seqan3::field::_seq_qual_deprecated>()};
     fout.options.fasta_letters_per_line = 0;
 
     for (size_t i = 0; i < 3; ++i)
@@ -438,7 +438,7 @@ TEST(columns, writing_seq_qual)
 {
     seqan3::sequence_file_output fout{std::ostringstream{},
                                       seqan3::format_fasta{},
-                                      seqan3::fields<seqan3::field::id, seqan3::field::seq_qual>()};
+                                      seqan3::fields<seqan3::field::id, seqan3::field::_seq_qual_deprecated>()};
     fout.options.fasta_letters_per_line = 0;
 
     std::vector<std::vector<seqan3::qualified<seqan3::dna5, seqan3::phred42>>> seq_quals{3};

--- a/test/unit/io/sequence_file/sequence_file_output_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_output_test.cpp
@@ -5,17 +5,17 @@
 // shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 // -----------------------------------------------------------------------------------------------------
 
+#include <seqan3/std/iterator>
 #include <sstream>
 
 #include <gtest/gtest.h>
 
-#include <range/v3/view/zip.hpp>
 #include <range/v3/view/filter.hpp>
+#include <range/v3/view/zip.hpp>
 
 #include <seqan3/alphabet/quality/phred42.hpp>
 #include <seqan3/io/sequence_file/output.hpp>
 #include <seqan3/test/tmp_filename.hpp>
-#include <seqan3/std/iterator>
 
 using seqan3::operator""_dna5;
 using seqan3::operator""_phred42;


### PR DESCRIPTION
- adds [DEPRECATED] in many places.
- erased mentioning of seq_qual everywhere I could find
- Wrap all usages of seqan3::field::seq_qual
- referenced cookbook to usage of field::seq and field::qual
- referenced cookbook in changelog
