### PR TITLE
[FEATURE] seqan3::structure_record

### DIFF
--- a/include/seqan3/io/structure_file/input.hpp
+++ b/include/seqan3/io/structure_file/input.hpp
@@ -31,13 +31,13 @@
 #include <seqan3/io/stream/concept.hpp>
 #include <seqan3/io/exception.hpp>
 #include <seqan3/std/filesystem>
-#include <seqan3/io/record.hpp>
 #include <seqan3/io/detail/in_file_iterator.hpp>
 #include <seqan3/io/detail/misc_input.hpp>
 #include <seqan3/io/detail/record.hpp>
 #include <seqan3/io/structure_file/input_format_concept.hpp>
 #include <seqan3/io/structure_file/input_options.hpp>
 #include <seqan3/io/structure_file/format_vienna.hpp>
+#include <seqan3/io/structure_file/record.hpp>
 #include <seqan3/utility/type_list/traits.hpp>
 
 namespace seqan3
@@ -546,8 +546,8 @@ public:
                                      react_type, react_type, comment_type, offset_type>;
 
     //!\brief The type of the record, a specialisation of seqan3::record; acts as a tuple of the selected field types.
-    using record_type    = record<detail::select_types_with_ids_t<field_types, field_ids, selected_field_ids>,
-                                  selected_field_ids>;
+    using record_type    = structure_record<detail::select_types_with_ids_t<field_types, field_ids, selected_field_ids>,
+                                            selected_field_ids>;
     //!\}
 
     /*!\name Range associated types

--- a/include/seqan3/io/structure_file/record.hpp
+++ b/include/seqan3/io/structure_file/record.hpp
@@ -1,0 +1,190 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides seqan3::structure_record.
+ * \author Marcel Ehrhardt <marcel.ehrhardt AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <seqan3/io/record.hpp>
+
+namespace seqan3
+{
+/*!\brief The record type of seqan3::structure_file_input.
+ * \ingroup structure_file
+ * \implements seqan3::detail::record_like
+ * \tparam field_types The types of the fields in this record as a seqan3::type_list.
+ * \tparam field_ids A seqan3::fields type with seqan3::field IDs corresponding to field_types.
+ */
+template <typename field_types, typename field_ids>
+class structure_record : public record<field_types, field_ids>
+{
+    //!\brief The base class.
+    using base_t = record<field_types, field_ids>;
+
+    //!\brief The underlying std::tuple class.
+    using tuple_base_t = typename base_t::base_type;
+
+    //!\copydoc seqan3::record::field_constant
+    template <field f>
+    using field_constant = typename base_t::template field_constant<f>;
+
+    using base_t::get_impl;
+public:
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    structure_record() = default; //!< Defaulted.
+    structure_record(structure_record const &) = default; //!< Defaulted.
+    structure_record & operator=(structure_record const &) = default; //!< Defaulted.
+    structure_record(structure_record &&) = default; //!< Defaulted.
+    structure_record & operator=(structure_record &&) = default; //!< Defaulted.
+    ~structure_record() = default; //!< Defaulted.
+
+    //!\brief Inherit std::tuple's and seqan3::record constructors.
+    using base_t::base_t;
+    //!\}
+
+    //!\brief The identifier, usually a string.
+    decltype(auto) id() &&
+    {
+        return get_impl(field_constant<seqan3::field::id>{}, static_cast<tuple_base_t &&>(*this));
+    }
+    //!\copydoc seqan3::structure_record::id
+    decltype(auto) id() const &&
+    {
+        return get_impl(field_constant<seqan3::field::id>{}, static_cast<tuple_base_t const &&>(*this));
+    }
+    //!\copydoc seqan3::structure_record::id
+    decltype(auto) id() &
+    {
+        return get_impl(field_constant<seqan3::field::id>{}, static_cast<tuple_base_t &>(*this));
+    }
+    //!\copydoc seqan3::structure_record::id
+    decltype(auto) id() const &
+    {
+        return get_impl(field_constant<seqan3::field::id>{}, static_cast<tuple_base_t const &>(*this));
+    }
+
+    //!\brief The "sequence", usually a range of nucleotides or amino acids.
+    decltype(auto) sequence() &&
+    {
+        return get_impl(field_constant<seqan3::field::seq>{}, static_cast<tuple_base_t &&>(*this));
+    }
+    //!\copydoc seqan3::structure_record::sequence
+    decltype(auto) sequence() const &&
+    {
+        return get_impl(field_constant<seqan3::field::seq>{}, static_cast<tuple_base_t const &&>(*this));
+    }
+    //!\copydoc seqan3::structure_record::sequence
+    decltype(auto) sequence() &
+    {
+        return get_impl(field_constant<seqan3::field::seq>{}, static_cast<tuple_base_t &>(*this));
+    }
+    //!\copydoc seqan3::structure_record::sequence
+    decltype(auto) sequence() const &
+    {
+        return get_impl(field_constant<seqan3::field::seq>{}, static_cast<tuple_base_t const &>(*this));
+    }
+
+    //!\brief Fixed interactions, usually a string of structure alphabet characters.
+    decltype(auto) sequence_structure() &&
+    {
+        return get_impl(field_constant<seqan3::field::structure>{}, static_cast<tuple_base_t &&>(*this));
+    }
+    //!\copydoc seqan3::structure_record::sequence_structure
+    decltype(auto) sequence_structure() const &&
+    {
+        return get_impl(field_constant<seqan3::field::structure>{}, static_cast<tuple_base_t const &&>(*this));
+    }
+    //!\copydoc seqan3::structure_record::sequence_structure
+    decltype(auto) sequence_structure() &
+    {
+        return get_impl(field_constant<seqan3::field::structure>{}, static_cast<tuple_base_t &>(*this));
+    }
+    //!\copydoc seqan3::structure_record::sequence_structure
+    decltype(auto) sequence_structure() const &
+    {
+        return get_impl(field_constant<seqan3::field::structure>{}, static_cast<tuple_base_t const &>(*this));
+    }
+
+    //!\brief Energy of a folded sequence, represented by one float number.
+    decltype(auto) energy() &&
+    {
+        return get_impl(field_constant<seqan3::field::energy>{}, static_cast<tuple_base_t &&>(*this));
+    }
+    //!\copydoc seqan3::structure_record::energy
+    decltype(auto) energy() const &&
+    {
+        return get_impl(field_constant<seqan3::field::energy>{}, static_cast<tuple_base_t const &&>(*this));
+    }
+    //!\copydoc seqan3::structure_record::energy
+    decltype(auto) energy() &
+    {
+        return get_impl(field_constant<seqan3::field::energy>{}, static_cast<tuple_base_t &>(*this));
+    }
+    //!\copydoc seqan3::structure_record::energy
+    decltype(auto) energy() const &
+    {
+        return get_impl(field_constant<seqan3::field::energy>{}, static_cast<tuple_base_t const &>(*this));
+    }
+
+    //!\brief Base pair probability matrix of interactions, usually a matrix of float numbers.
+    decltype(auto) base_pair_probability_matrix() &&
+    {
+        // this is computed
+        return get_impl(field_constant<seqan3::field::bpp>{}, static_cast<tuple_base_t &&>(*this));
+    }
+    //!\copydoc seqan3::structure_record::base_pair_probability_matrix
+    decltype(auto) base_pair_probability_matrix() const &&
+    {
+        return get_impl(field_constant<seqan3::field::bpp>{}, static_cast<tuple_base_t const &&>(*this));
+    }
+    //!\copydoc seqan3::structure_record::base_pair_probability_matrix
+    decltype(auto) base_pair_probability_matrix() &
+    {
+        return get_impl(field_constant<seqan3::field::bpp>{}, static_cast<tuple_base_t &>(*this));
+    }
+    //!\copydoc seqan3::structure_record::base_pair_probability_matrix
+    decltype(auto) base_pair_probability_matrix() const &
+    {
+        return get_impl(field_constant<seqan3::field::bpp>{}, static_cast<tuple_base_t const &>(*this));
+    }
+
+    // decltype(auto) reactivity(); // unused
+    // decltype(auto) reactivity_errors(); // unused
+    // decltype(auto) comment(); // unused
+    // decltype(auto) base_qualities(); // unused
+};
+} // namespace seqan3
+
+namespace std
+{
+
+/*!\brief Provides access to the number of elements in a tuple as a compile-time constant expression.
+ * \implements seqan3::unary_type_trait
+ * \relates seqan3::structure_record
+ * \see std::tuple_size_v
+ */
+template <typename field_types, typename field_ids>
+struct tuple_size<seqan3::structure_record<field_types, field_ids>>
+    : tuple_size<typename seqan3::structure_record<field_types, field_ids>::base_type>
+{};
+
+/*!\brief Obtains the type of the specified element.
+ * \implements seqan3::transformation_trait
+ * \relates seqan3::structure_record
+ * \see [std::tuple_element](https://en.cppreference.com/w/cpp/utility/tuple/tuple_element)
+ */
+template <size_t elem_no, typename field_types, typename field_ids>
+struct tuple_element<elem_no, seqan3::structure_record<field_types, field_ids>>
+    : tuple_element<elem_no, typename seqan3::structure_record<field_types, field_ids>::base_type>
+{};
+
+} // namespace std

--- a/test/unit/io/structure_file/CMakeLists.txt
+++ b/test/unit/io/structure_file/CMakeLists.txt
@@ -1,3 +1,4 @@
 seqan3_test(format_vienna_test.cpp)
 seqan3_test(structure_file_input_test.cpp)
 seqan3_test(structure_file_output_test.cpp)
+seqan3_test(structure_file_record_test.cpp)

--- a/test/unit/io/structure_file/format_vienna_test.cpp
+++ b/test/unit/io/structure_file/format_vienna_test.cpp
@@ -124,25 +124,31 @@ struct read : public ::testing::Test
         for (size_t idx = 0ul; idx < expected_seq.size(); ++idx, ++it)
         {
             EXPECT_EQ(check_energy, seqan3::get<seqan3::field::energy>(*it).has_value());
+            EXPECT_EQ(check_energy, (*it).energy().has_value());
             if (check_seq)
             {
                 EXPECT_RANGE_EQ(seqan3::get<seqan3::field::seq>(*it), expected_seq[idx]);
+                EXPECT_RANGE_EQ((*it).sequence(), expected_seq[idx]);
             }
             if (check_id)
             {
                 EXPECT_RANGE_EQ(seqan3::get<seqan3::field::id>(*it), expected_id[idx]);
+                EXPECT_RANGE_EQ((*it).id(), expected_id[idx]);
             }
             if (check_structure)
             {
                 bpp_test(seqan3::get<seqan3::field::bpp>(*it), expected_interactions[idx]);
+                bpp_test((*it).base_pair_probability_matrix(), expected_interactions[idx]);
             }
             if (check_energy)
             {
                 EXPECT_DOUBLE_EQ(*seqan3::get<seqan3::field::energy>(*it), expected_energy[idx]);
+                EXPECT_DOUBLE_EQ(*(*it).energy(), expected_energy[idx]);
             }
             if (check_structure)
             {
                 EXPECT_RANGE_EQ(seqan3::get<seqan3::field::structure>(*it), expected_structure[idx]);
+                EXPECT_RANGE_EQ((*it).sequence_structure(), expected_structure[idx]);
             }
         }
     }
@@ -251,6 +257,7 @@ TEST_F(read_fields, only_seq)
     for (size_t idx = 0ul; idx < expected_seq.size(); ++idx, ++it)
     {
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::seq>(*it), expected_seq[idx]);
+        EXPECT_RANGE_EQ((*it).sequence(), expected_seq[idx]);
     }
 }
 
@@ -262,6 +269,7 @@ TEST_F(read_fields, only_id)
     for (size_t idx = 0ul; idx < expected_seq.size(); ++idx, ++it)
     {
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::id>(*it), expected_id[idx]);
+        EXPECT_RANGE_EQ((*it).id(), expected_id[idx]);
     }
 }
 
@@ -273,6 +281,7 @@ TEST_F(read_fields, only_structure)
     for (size_t idx = 0ul; idx < expected_seq.size(); ++idx, ++it)
     {
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::structure>(*it), expected_structure[idx]);
+        EXPECT_RANGE_EQ((*it).sequence_structure(), expected_structure[idx]);
     }
 }
 
@@ -284,7 +293,9 @@ TEST_F(read_fields, only_energy)
     for (size_t idx = 0ul; idx < expected_seq.size(); ++idx, ++it)
     {
         EXPECT_TRUE(seqan3::get<seqan3::field::energy>(*it));
+        EXPECT_TRUE((*it).energy());
         EXPECT_DOUBLE_EQ(*seqan3::get<seqan3::field::energy>(*it), expected_energy[idx]);
+        EXPECT_DOUBLE_EQ(*(*it).energy(), expected_energy[idx]);
     }
 }
 
@@ -310,6 +321,7 @@ TEST_F(read_fields, only_bpp)
     for (size_t idx = 0ul; idx < expected_seq.size(); ++idx, ++it)
     {
         bpp_test(seqan3::get<seqan3::field::bpp>(*it), expected_interactions[idx]);
+        bpp_test((*it).base_pair_probability_matrix(), expected_interactions[idx]);
     }
 }
 

--- a/test/unit/io/structure_file/structure_file_input_test.cpp
+++ b/test/unit/io/structure_file/structure_file_input_test.cpp
@@ -269,6 +269,11 @@ struct structure_file_input_read : public ::testing::Test
             EXPECT_RANGE_EQ(seqan3::get<seqan3::field::seq>(rec), seq_comp[counter]);
             EXPECT_RANGE_EQ(seqan3::get<seqan3::field::id>(rec), id_comp[counter]);
             EXPECT_RANGE_EQ(seqan3::get<seqan3::field::structure>(rec), structure_comp[counter]);
+
+            EXPECT_RANGE_EQ(rec.sequence(), seq_comp[counter]);
+            EXPECT_RANGE_EQ(rec.id(), id_comp[counter]);
+            EXPECT_RANGE_EQ(rec.sequence_structure(), structure_comp[counter]);
+
             ++counter;
         }
 
@@ -305,6 +310,11 @@ TEST_F(structure_file_input_read, record_general)
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::seq>(rec), seq_comp[counter]);
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::id>(rec), id_comp[counter]);
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::structure>(rec), structure_comp[counter]);
+
+        EXPECT_RANGE_EQ(rec.sequence(), seq_comp[counter]);
+        EXPECT_RANGE_EQ(rec.id(), id_comp[counter]);
+        EXPECT_RANGE_EQ(rec.sequence_structure(), structure_comp[counter]);
+
         ++counter;
     }
     EXPECT_EQ(counter, num_records);
@@ -365,7 +375,7 @@ TEST_F(structure_file_input_read, record_file_view)
 #if !SEQAN3_WORKAROUND_GCC_93983
     auto minimum_length_filter = std::views::filter([] (auto const & rec)
     {
-        return size(seqan3::get<seqan3::field::seq>(rec)) >= 5;
+        return size(rec.sequence()) >= 5;
     });
 #endif
 
@@ -381,6 +391,13 @@ TEST_F(structure_file_input_read, record_file_view)
         bpp_test(seqan3::get<seqan3::field::bpp>(rec), interaction_comp[counter]);
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::structure>(rec), structure_comp[counter]);
         EXPECT_DOUBLE_EQ(seqan3::get<seqan3::field::energy>(rec).value(), energy_comp[counter]);
+
+        EXPECT_RANGE_EQ(rec.sequence(), seq_comp[counter]);
+        EXPECT_RANGE_EQ(rec.id(), id_comp[counter]);
+        bpp_test(rec.base_pair_probability_matrix(), interaction_comp[counter]);
+        EXPECT_RANGE_EQ(rec.sequence_structure(), structure_comp[counter]);
+        EXPECT_DOUBLE_EQ(rec.energy().value(), energy_comp[counter]);
+
         ++counter;
     }
     EXPECT_EQ(counter, num_records);

--- a/test/unit/io/structure_file/structure_file_record_test.cpp
+++ b/test/unit/io/structure_file/structure_file_record_test.cpp
@@ -1,0 +1,155 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <seqan3/alphabet/nucleotide/rna5.hpp>
+#include <seqan3/alphabet/structure/wuss.hpp>
+#include <seqan3/core/detail/debug_stream_alphabet.hpp>
+#include <seqan3/io/detail/record_like.hpp>
+#include <seqan3/io/structure_file/record.hpp>
+#include <seqan3/test/expect_range_eq.hpp>
+#include <seqan3/test/expect_same_type.hpp>
+#include <seqan3/utility/tuple/concept.hpp>
+#include <seqan3/utility/type_list/type_list.hpp>
+
+using seqan3::operator""_rna5;
+using seqan3::operator""_wuss51;
+
+// ----------------------------------------------------------------------------
+// record
+// ----------------------------------------------------------------------------
+
+struct structure_record : public ::testing::Test
+{
+    using types = seqan3::type_list<std::string,
+                                    seqan3::rna5_vector,
+                                    std::vector<seqan3::wuss51>,
+                                    double>;
+    using types_as_ids = seqan3::fields<seqan3::field::id,
+                                        seqan3::field::seq,
+                                        seqan3::field::structure,
+                                        seqan3::field::energy>;
+    using record_type  = seqan3::structure_record<types, types_as_ids>;
+};
+
+TEST_F(structure_record, concept)
+{
+    EXPECT_TRUE((seqan3::detail::record_like<record_type>));
+}
+
+TEST_F(structure_record, definition_tuple_traits)
+{
+    EXPECT_SAME_TYPE((std::tuple<std::string, seqan3::rna5_vector, std::vector<seqan3::wuss51>, double>),
+                     typename record_type::base_type);
+
+    EXPECT_SAME_TYPE(std::string, (std::tuple_element_t<0, record_type>));
+    EXPECT_SAME_TYPE(seqan3::rna5_vector, (std::tuple_element_t<1, record_type>));
+    EXPECT_SAME_TYPE(std::vector<seqan3::wuss51>, (std::tuple_element_t<2, record_type>));
+    EXPECT_SAME_TYPE(double, (std::tuple_element_t<3, record_type>));
+    EXPECT_EQ(std::tuple_size_v<record_type>, 4ul);
+
+    EXPECT_TRUE(seqan3::tuple_like<record_type>);
+}
+
+TEST_F(structure_record, construction)
+{
+    [[maybe_unused]] record_type r{"MY ID", "ACGU"_rna5, "(())"_wuss51, 1.5};
+}
+
+TEST_F(structure_record, get_by_index)
+{
+    record_type r{"MY ID", "ACGU"_rna5, "(())"_wuss51, 1.5};
+
+    EXPECT_EQ(std::get<0>(r), "MY ID");
+    EXPECT_RANGE_EQ(std::get<1>(r), "ACGU"_rna5);
+    EXPECT_RANGE_EQ(std::get<2>(r), "(())"_wuss51);
+    EXPECT_DOUBLE_EQ(std::get<3>(r), 1.5);
+}
+
+TEST_F(structure_record, get_by_type)
+{
+    record_type r{"MY ID", "ACGU"_rna5, "(())"_wuss51, 1.5};
+
+    EXPECT_EQ(std::get<std::string>(r), "MY ID");
+    EXPECT_RANGE_EQ(std::get<seqan3::rna5_vector>(r), "ACGU"_rna5);
+    EXPECT_RANGE_EQ(std::get<std::vector<seqan3::wuss51>>(r), "(())"_wuss51);
+    EXPECT_DOUBLE_EQ(std::get<double>(r), 1.5);
+}
+
+TEST_F(structure_record, get_by_field)
+{
+    record_type r{"MY ID", "ACGU"_rna5, "(())"_wuss51, 1.5};
+
+    EXPECT_EQ(seqan3::get<seqan3::field::id>(r), "MY ID");
+    EXPECT_RANGE_EQ(seqan3::get<seqan3::field::seq>(r), "ACGU"_rna5);
+    EXPECT_RANGE_EQ(seqan3::get<seqan3::field::structure>(r), "(())"_wuss51);
+    EXPECT_DOUBLE_EQ(seqan3::get<seqan3::field::energy>(r), 1.5);
+}
+
+TEST_F(structure_record, get_by_member)
+{
+    record_type r{"MY ID", "ACGU"_rna5, "(())"_wuss51, 1.5};
+
+    EXPECT_EQ(r.id(), "MY ID");
+    EXPECT_RANGE_EQ(r.sequence(), "ACGU"_rna5);
+    EXPECT_RANGE_EQ(r.sequence_structure(), "(())"_wuss51);
+    EXPECT_DOUBLE_EQ(r.energy(), 1.5);
+}
+
+TEST_F(structure_record, get_types)
+{
+    record_type r{"MY ID", "ACGU"_rna5, "(())"_wuss51, 1.5};
+
+    EXPECT_SAME_TYPE(std::string &, decltype(seqan3::get<seqan3::field::id>(r)));
+    EXPECT_SAME_TYPE(seqan3::rna5_vector &, decltype(seqan3::get<seqan3::field::seq>(r)));
+    EXPECT_SAME_TYPE(std::vector<seqan3::wuss51> &, decltype(seqan3::get<seqan3::field::structure>(r)));
+    EXPECT_SAME_TYPE(double &, decltype(seqan3::get<seqan3::field::energy>(r)));
+
+    EXPECT_SAME_TYPE(std::string const &, decltype(seqan3::get<seqan3::field::id>(std::as_const(r))));
+    EXPECT_SAME_TYPE(seqan3::rna5_vector const &, decltype(seqan3::get<seqan3::field::seq>(std::as_const(r))));
+    EXPECT_SAME_TYPE(std::vector<seqan3::wuss51> const &,
+                     decltype(seqan3::get<seqan3::field::structure>(std::as_const(r))));
+    EXPECT_SAME_TYPE(double const &, decltype(seqan3::get<seqan3::field::energy>(std::as_const(r))));
+
+    EXPECT_SAME_TYPE(std::string &&, decltype(seqan3::get<seqan3::field::id>(std::move(r))));
+    EXPECT_SAME_TYPE(seqan3::rna5_vector &&, decltype(seqan3::get<seqan3::field::seq>(std::move(r))));
+    EXPECT_SAME_TYPE(std::vector<seqan3::wuss51> &&, decltype(seqan3::get<seqan3::field::structure>(std::move(r))));
+    EXPECT_SAME_TYPE(double &&, decltype(seqan3::get<seqan3::field::energy>(std::move(r))));
+
+    EXPECT_SAME_TYPE(std::string const &&, decltype(seqan3::get<seqan3::field::id>(std::move(std::as_const(r)))));
+    EXPECT_SAME_TYPE(seqan3::rna5_vector const &&,
+                     decltype(seqan3::get<seqan3::field::seq>(std::move(std::as_const(r)))));
+    EXPECT_SAME_TYPE(std::vector<seqan3::wuss51> const &&,
+                     decltype(seqan3::get<seqan3::field::structure>(std::move(std::as_const(r)))));
+    EXPECT_SAME_TYPE(double const &&, decltype(seqan3::get<seqan3::field::energy>(std::move(std::as_const(r)))));
+}
+
+TEST_F(structure_record, member_types)
+{
+    record_type r{"MY ID", "ACGU"_rna5, "(())"_wuss51, 1.5};
+
+    EXPECT_SAME_TYPE(std::string &, decltype(r.id()));
+    EXPECT_SAME_TYPE(seqan3::rna5_vector &, decltype(r.sequence()));
+    EXPECT_SAME_TYPE(std::vector<seqan3::wuss51> &, decltype(r.sequence_structure()));
+    EXPECT_SAME_TYPE(double &, decltype(r.energy()));
+
+    EXPECT_SAME_TYPE(std::string const &, decltype(std::as_const(r).id()));
+    EXPECT_SAME_TYPE(seqan3::rna5_vector const &, decltype(std::as_const(r).sequence()));
+    EXPECT_SAME_TYPE(std::vector<seqan3::wuss51> const &, decltype(std::as_const(r).sequence_structure()));
+    EXPECT_SAME_TYPE(double const &, decltype(std::as_const(r).energy()));
+
+    EXPECT_SAME_TYPE(std::string &&, decltype(std::move(r).id()));
+    EXPECT_SAME_TYPE(seqan3::rna5_vector &&, decltype(std::move(r).sequence()));
+    EXPECT_SAME_TYPE(std::vector<seqan3::wuss51> &&, decltype(std::move(r).sequence_structure()));
+    EXPECT_SAME_TYPE(double &&, decltype(std::move(r).energy()));
+
+    EXPECT_SAME_TYPE(std::string const &&, decltype(std::move(std::as_const(r)).id()));
+    EXPECT_SAME_TYPE(seqan3::rna5_vector const &&, decltype(std::move(std::as_const(r)).sequence()));
+    EXPECT_SAME_TYPE(std::vector<seqan3::wuss51> const &&, decltype(std::move(std::as_const(r)).sequence_structure()));
+    EXPECT_SAME_TYPE(double const &&, decltype(std::move(std::as_const(r)).energy()));
+}


### PR DESCRIPTION
This implements the Resolution:

* [1. Step one record type with all member functions.](https://docs.google.com/document/d/1EuGAtT0X5tDbBNFdHeuRfU2RRVOne8CSOJt3lI0U5UY/edit#bookmark=id.c1bmao8g76c5)

This implements
* structure_record
* adds member to structure_record, names were decided here: https://docs.google.com/document/d/1EuGAtT0X5tDbBNFdHeuRfU2RRVOne8CSOJt3lI0U5UY/edit#heading=h.vha98e10523x
* and does some infrastructure