### PR TITLE
[FIX] parsing containers of enums not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@ If possible, provide tooling that performs the changes, e.g. a shell-script.
   ([\#2216](https://github.com/seqan/seqan3/pull/2216)).
 * The `seqan3::input_file_validator` and `seqan3::input_file_validator` support extensions containing a dot
   ([\#2363](https://github.com/seqan/seqan3/pull/2363)).
+* The Argument Parser accepts containers of all values it is able to parse, e.g. a `std::vector` of enums or `bool`
+  ([\#2381](https://github.com/seqan/seqan3/pull/2381)).
 
 ## API changes
 

--- a/include/seqan3/argument_parser/detail/format_parse.hpp
+++ b/include/seqan3/argument_parser/detail/format_parse.hpp
@@ -317,7 +317,7 @@ private:
      *          seqan3::enumeration_names<option_t> map and otherwise seqan3::option_parse_result::success.
      */
     template <named_enumeration option_t>
-    option_parse_result parse_option_value(option_t & value, std::string_view const in)
+    option_parse_result parse_option_value(option_t & value, std::string const & in)
     {
         auto map = seqan3::enumeration_names<option_t>;
 
@@ -339,7 +339,7 @@ private:
 
     /*!\brief Parses the given option value and appends it to the target container.
      * \tparam container_option_t Must model the seqan3::sequence_container and
-     *                            its value_type must model seqan3::input_stream_over or seqan3::named_enumeration
+     *                            its value_type must be parseable via parse_option_value
      *
      * \param[out] value The container that stores the parsed value.
      * \param[in] in The input argument to be parsed.
@@ -347,8 +347,10 @@ private:
      */
     template <sequence_container container_option_t>
     //!\cond
-        requires input_stream_over<std::istringstream, typename container_option_t::value_type> ||
-                 named_enumeration<typename container_option_t::value_type>
+        requires requires (format_parse fp, typename container_option_t::value_type & container_value, std::string const & in)
+        {
+            SEQAN3_RETURN_TYPE_CONSTRAINT(fp.parse_option_value(container_value, in), std::same_as, option_parse_result);
+        }
     //!\endcond
     option_parse_result parse_option_value(container_option_t & value, std::string const & in)
     {

--- a/include/seqan3/argument_parser/detail/format_parse.hpp
+++ b/include/seqan3/argument_parser/detail/format_parse.hpp
@@ -339,7 +339,7 @@ private:
 
     /*!\brief Parses the given option value and appends it to the target container.
      * \tparam container_option_t Must model the seqan3::sequence_container and
-     *                            its value_type must model the seqan3::input_stream_over
+     *                            its value_type must model seqan3::input_stream_over or seqan3::named_enumeration
      *
      * \param[out] value The container that stores the parsed value.
      * \param[in] in The input argument to be parsed.
@@ -347,7 +347,8 @@ private:
      */
     template <sequence_container container_option_t>
     //!\cond
-        requires input_stream_over<std::istringstream, typename container_option_t::value_type>
+        requires input_stream_over<std::istringstream, typename container_option_t::value_type> ||
+                 named_enumeration<typename container_option_t::value_type>
     //!\endcond
     option_parse_result parse_option_value(container_option_t & value, std::string const & in)
     {

--- a/test/unit/argument_parser/format_parse_test.cpp
+++ b/test/unit/argument_parser/format_parse_test.cpp
@@ -619,6 +619,18 @@ TEST(parse_type_test, parse_success_enum_option)
     }
 
     {
+        std::vector<foo::bar> option_value{};
+
+        const char * argv[] = {"./argument_parser_test", "-e", "two", "-e", "one", "-e", "three"};
+        seqan3::argument_parser parser{"test_parser", 7, argv, seqan3::update_notifications::off};
+        parser.add_option(option_value, 'e', "enum-option", "this is an enum option.");
+
+        EXPECT_NO_THROW(parser.parse());
+
+        EXPECT_TRUE(option_value == (std::vector<foo::bar>{foo::bar::two, foo::bar::one, foo::bar::three}));
+    }
+
+    {
         Other::bar option_value{};
 
         const char * argv[] = {"./argument_parser_test", "-e", "two"};

--- a/test/unit/argument_parser/format_parse_test.cpp
+++ b/test/unit/argument_parser/format_parse_test.cpp
@@ -619,18 +619,6 @@ TEST(parse_type_test, parse_success_enum_option)
     }
 
     {
-        std::vector<foo::bar> option_value{};
-
-        const char * argv[] = {"./argument_parser_test", "-e", "two", "-e", "one", "-e", "three"};
-        seqan3::argument_parser parser{"test_parser", 7, argv, seqan3::update_notifications::off};
-        parser.add_option(option_value, 'e', "enum-option", "this is an enum option.");
-
-        EXPECT_NO_THROW(parser.parse());
-
-        EXPECT_TRUE(option_value == (std::vector<foo::bar>{foo::bar::two, foo::bar::one, foo::bar::three}));
-    }
-
-    {
         Other::bar option_value{};
 
         const char * argv[] = {"./argument_parser_test", "-e", "two"};
@@ -1038,4 +1026,43 @@ TEST(parse_test, is_option_set)
     EXPECT_THROW(parser.is_option_set('-'), seqan3::design_error);
     EXPECT_THROW(parser.is_option_set('_'), seqan3::design_error);
     EXPECT_THROW(parser.is_option_set('\0'), seqan3::design_error);
+}
+
+TEST(parse_test, container_options)
+{
+    {
+        std::vector<foo::bar> option_values{};
+
+        const char * argv[] = {"./argument_parser_test", "-e", "two", "-e", "one", "-e", "three"};
+        seqan3::argument_parser parser{"test_parser", 7, argv, seqan3::update_notifications::off};
+        parser.add_option(option_values, 'e', "enum-option", "this is an enum option.");
+
+        EXPECT_NO_THROW(parser.parse());
+
+        EXPECT_TRUE(option_values == (std::vector<foo::bar>{foo::bar::two, foo::bar::one, foo::bar::three}));
+    }
+
+    {
+        std::vector<int> option_values{};
+
+        const char * argv[] = {"./argument_parser_test", "-i", "2", "-i", "1", "-i", "3"};
+        seqan3::argument_parser parser{"test_parser", 7, argv, seqan3::update_notifications::off};
+        parser.add_option(option_values, 'i', "int-option", "this is an int option.");
+
+        EXPECT_NO_THROW(parser.parse());
+
+        EXPECT_TRUE(option_values == (std::vector<int>{2, 1, 3}));
+    }
+
+    {
+        std::vector<bool> option_values{};
+
+        const char * argv[] = {"./argument_parser_test", "-b", "true", "-b", "false", "-b", "true"};
+        seqan3::argument_parser parser{"test_parser", 7, argv, seqan3::update_notifications::off};
+        parser.add_option(option_values, 'b', "bool-option", "this is a bool option.");
+
+        EXPECT_NO_THROW(parser.parse());
+
+        EXPECT_TRUE(option_values == (std::vector<bool>{true, false, true}));
+    }
 }


### PR DESCRIPTION
In https://github.com/seqan/seqan3/pull/1196, we forgot to allow for, e.g. `std::vector<foo::bar>`, where `foo::bar` is an enum. 