### PR TITLE
[FIX] BAM: Not consuming sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,11 @@ If possible, provide tooling that performs the changes, e.g. a shell-script.
 * The `seqan3::views::kmer_hash` does not return wrong values when combined with `std::views::reverse` on a text of the
   same size as the kmer ([\#2416](https://github.com/seqan/seqan3/pull/2416)).
 
+#### I/O
+
+* Requesting the alignment without also requesting the sequence for BAM files containing empty CIGAR strings does now
+  not result in erroneous parsing ([\#2418](https://github.com/seqan/seqan3/pull/2418)).
+
 ## API changes
 
 #### Alphabet

--- a/include/seqan3/io/sam_file/format_bam.hpp
+++ b/include/seqan3/io/sam_file/format_bam.hpp
@@ -444,6 +444,13 @@ inline void format_bam::read_alignment_record(stream_type & stream,
 
         if constexpr (detail::decays_to_ignore_v<seq_type>)
         {
+            auto skip_sequence_bytes = [&] ()
+            {
+                detail::consume(seq_stream);
+                if (core.l_seq & 1)
+                    std::ranges::next(std::ranges::begin(stream_view));
+            };
+
             if constexpr (!detail::decays_to_ignore_v<align_type>)
             {
                 static_assert(sequence_container<std::remove_reference_t<decltype(get<1>(align))>>,
@@ -486,14 +493,13 @@ inline void format_bam::read_alignment_record(stream_type & stream,
                 }
                 else
                 {
+                    skip_sequence_bytes();
                     get<1>(align) = std::remove_reference_t<decltype(get<1>(align))>{}; // assign empty container
                 }
             }
             else
             {
-                detail::consume(seq_stream);
-                if (core.l_seq & 1)
-                    std::ranges::next(std::ranges::begin(stream_view));
+                skip_sequence_bytes();
             }
         }
         else


### PR DESCRIPTION
Resolves #2417 

If we do not want to parse the sequence, but still want an alignment, but then have an empty CIGAR, we create a dummy alignment, but we forget to consume the sequence.