### PR TITLE
IO: explicit record members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,16 @@ If possible, provide tooling that performs the changes, e.g. a shell-script.
 
 * We now use Doxygen version 1.9.1 to build our documentation ([\#2327](https://github.com/seqan/seqan3/pull/2327)).
 
+#### I/O
+
+* Explicit record-classes with explicit member accessor for our file implementations. We added `seqan3::sequence_record`
+  for `seqan3::sequence_file_(in|out)put`, `seqan3::sam_record` for `seqan3::sam_file_(in|out)put` and
+  `seqan3::structure_record` for `seqan3::structure_file_(in|out)put`. You can now access the `id` in a sequence file
+  (e.g. `fasta` file) record via `record.id()` instead of `seqan3::get<seqan3::field::id>(record)`. This will allow us
+  to add convenient functions that compute information based on the record itself and to provide better documentation.
+  ([\#2340](https://github.com/seqan/seqan3/pull/2340), [\#2380](https://github.com/seqan/seqan3/pull/2380),
+  [\#2389](https://github.com/seqan/seqan3/pull/2389))
+
 #### Search
 
 * The `seqan3::fm_index_cursor` exposes its suffix array interval ([\#2076](https://github.com/seqan/seqan3/pull/2076)).
@@ -99,6 +109,41 @@ If possible, provide tooling that performs the changes, e.g. a shell-script.
   * `seqan3::option_spec::REQUIRED` is replaced by `seqan3::option_spec::required`.
   * `seqan3::option_spec::ADVANCED` is replaced by `seqan3::option_spec::advanced`.
   * `seqan3::option_spec::HIDDEN` is replaced by `seqan3::option_spec::hidden`.
+
+#### I/O
+
+* The `seqan3::get` accessor for I/O records, e.g. `seqan3::get<seqan3::field::id>(record)`, is deprecated, please use
+  the corresponding member accessor ([\#2420](https://github.com/seqan/seqan3/pull/2420)):
+  * If you used files as views with `seqan3::views::get<seqan3::field::id>` to project a single field, e.g.
+    * `seqan3::views::get<seqan3::field::id>(fin)` => `std::views::transform(fin, [](auto && record){ return record.id(); })`
+    * `fin | seqan3::views::get<seqan3::field::id>()` => `fin | std::views::transform([](auto && record){ return record.id(); })`
+    * or per projection: `fin | std::views::transform(&decltype(fin)::record_type::id)`
+  * `seqan3::sequence_record`:
+    * `seqan3::get<seqan3::field::id>(record)` => `record.id()`
+    * `seqan3::get<seqan3::field::seq>(record)` => `record.sequence()`
+    * `seqan3::get<seqan3::field::qual>(record)` => `record.base_qualities()`
+  * `seqan3::structure_record`:
+    * `seqan3::get<seqan3::field::id>(record)` => `record.id()`
+    * `seqan3::get<seqan3::field::seq>(record)` => `record.sequence()`
+    * `seqan3::get<seqan3::field::structure>(record)` => `record.sequence_structure()`
+    * `seqan3::get<seqan3::field::energy>(record)` => `record.energy()`
+    * `seqan3::get<seqan3::field::bpp>(record)` => `record.base_pair_probability_matrix()`
+  * `seqan3::sam_record`:
+    * `seqan3::get<seqan3::field::id>(record)` => `record.id()`
+    * `seqan3::get<seqan3::field::seq>(record)` => `record.sequence()`
+    * `seqan3::get<seqan3::field::qual>(record)` => `record.base_qualities()`
+    * `seqan3::get<seqan3::field::offset>(record)` => `record.sequence_position()`
+    * `seqan3::get<seqan3::field::alignment>(record)` => `record.alignment()`
+    * `seqan3::get<seqan3::field::ref_id>(record)` => `record.reference_id()`
+    * `seqan3::get<seqan3::field::ref_offset>(record)` => `record.reference_position()`
+    * `seqan3::get<seqan3::field::header_ptr>(record)` => `record.header_ptr()`
+    * `seqan3::get<seqan3::field::flag>(record)` => `record.flag()`
+    * `std::get<0>(seqan3::get<seqan3::field::mate>(record))` => `record.mate_reference_id()`
+    * `std::get<1>(seqan3::get<seqan3::field::mate>(record))` => `record.mate_position()`
+    * `std::get<2>(seqan3::get<seqan3::field::mate>(record))` => `record.template_length()`
+    * `seqan3::get<seqan3::field::mapq>(record)` => `record.mapping_quality()`
+    * `seqan3::get<seqan3::field::cigar>(record)` => `record.cigar_sequence()`
+    * `seqan3::get<seqan3::field::tags>(record)` => `record.tags()`
 
 # 3.0.2
 

--- a/doc/tutorial/read_mapper/read_mapper_step2.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_step2.cpp
@@ -58,7 +58,7 @@ void map_reads(std::filesystem::path const & query_path,
 #endif // SEQAN3_WORKAROUND_GCC_93983
     {
         seqan3::debug_stream << "Hits:" << '\n';
-        for (auto && result : search(seqan3::get<seqan3::field::seq>(record), index, search_config))
+        for (auto && result : search(record.sequence(), index, search_config))
             seqan3::debug_stream << result << '\n';
         seqan3::debug_stream << "======================" << '\n';
     }

--- a/doc/tutorial/read_mapper/read_mapper_step3.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_step3.cpp
@@ -69,7 +69,7 @@ void map_reads(std::filesystem::path const & query_path,
     for (auto && record : query_file_in | seqan3::views::take(20))
 #endif // SEQAN3_WORKAROUND_GCC_93983
     {
-        auto & query = seqan3::get<seqan3::field::seq>(record);
+        auto & query = record.sequence();
         for (auto && result : search(query, index, search_config))
         {
             size_t start = result.reference_begin_position() ? result.reference_begin_position() - 1 : 0;
@@ -78,7 +78,7 @@ void map_reads(std::filesystem::path const & query_path,
             for (auto && alignment : seqan3::align_pairwise(std::tie(text_view, query), align_config))
             {
                 auto && [aligned_database, aligned_query] = alignment.alignment();
-                seqan3::debug_stream << "id:       " << seqan3::get<seqan3::field::id>(record) << '\n';
+                seqan3::debug_stream << "id:       " << record.id() << '\n';
                 seqan3::debug_stream << "score:    " << alignment.score() << '\n';
                 seqan3::debug_stream << "database: " << aligned_database << '\n';
                 seqan3::debug_stream << "query:    "  << aligned_query << '\n';

--- a/doc/tutorial/read_mapper/read_mapper_step4.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_step4.cpp
@@ -74,7 +74,7 @@ void map_reads(std::filesystem::path const & query_path,
 
     for (auto && record : query_file_in)
     {
-        auto & query = seqan3::get<seqan3::field::seq>(record);
+        auto & query = record.sequence();
         for (auto && result : search(query, index, search_config))
         {
             size_t start = result.reference_begin_position() ? result.reference_begin_position() - 1 : 0;
@@ -87,11 +87,11 @@ void map_reads(std::filesystem::path const & query_path,
                 size_t map_qual = 60u + alignment.score();
 
                 sam_out.emplace_back(query,
-                                     seqan3::get<seqan3::field::id>(record),
+                                     record.id(),
                                      storage.ids[result.reference_id()],
                                      ref_offset,
                                      aligned_seq,
-                                     seqan3::get<seqan3::field::qual>(record),
+                                     record.base_qualities(),
                                      map_qual);
             }
         }

--- a/doc/tutorial/sam_file/sam_file_read_cigar.cpp
+++ b/doc/tutorial/sam_file/sam_file_read_cigar.cpp
@@ -38,6 +38,6 @@ int main()
     seqan3::sam_file_input fin{tmp_dir/"my.sam"}; // default fields
 
     for (auto & rec : fin)
-        seqan3::debug_stream << seqan3::get<seqan3::field::cigar>(rec) << '\n'; // access cigar vector
+        seqan3::debug_stream << rec.cigar_sequence() << '\n'; // access cigar vector
 }
 //![code]

--- a/doc/tutorial/sam_file/sam_file_solution1.cpp
+++ b/doc/tutorial/sam_file/sam_file_solution1.cpp
@@ -43,7 +43,7 @@ int main()
 
     std::ranges::for_each(fin.begin(), fin.end(), [&sum, &c] (auto & rec)
     {
-        sum += seqan3::get<seqan3::field::mapq>(rec);
+        sum += rec.mapping_quality();
         ++c;
     });
 

--- a/doc/tutorial/sam_file/sam_file_solution2.cpp
+++ b/doc/tutorial/sam_file/sam_file_solution2.cpp
@@ -80,8 +80,8 @@ int main()
 
     for (auto && record : reference_file)
     {
-        ref_ids.push_back(std::move(seqan3::get<seqan3::field::id>(record)));
-        ref_seqs.push_back(std::move(seqan3::get<seqan3::field::seq>(record)));
+        ref_ids.push_back(std::move(record.id()));
+        ref_seqs.push_back(std::move(record.sequence()));
     }
 
     using field_type = seqan3::fields<seqan3::field::id,
@@ -92,7 +92,7 @@ int main()
     seqan3::sam_file_input mapping_file{tmp_dir/"mapping.sam", ref_ids, ref_seqs, field_type{}};
 
 #if !SEQAN3_WORKAROUND_GCC_93983
-    auto mapq_filter = std::views::filter([] (auto & rec) { return seqan3::get<seqan3::field::mapq>(rec) >= 30; });
+    auto mapq_filter = std::views::filter([] (auto & rec) { return rec.mapping_quality() >= 30; });
 #endif // !SEQAN3_WORKAROUND_GCC_93983
 
 #if SEQAN3_WORKAROUND_GCC_93983

--- a/doc/tutorial/sequence_file/sequence_file_snippets.cpp
+++ b/doc/tutorial/sequence_file/sequence_file_snippets.cpp
@@ -127,7 +127,7 @@ seqan3::sequence_file_input fin2{std::filesystem::temp_directory_path()/"my.fast
 
 for (auto && [rec1, rec2] : seqan3::views::zip(fin1, fin2)) // && is important!
 {                                                           // because seqan3::views::zip returns temporaries
-    if (seqan3::get<seqan3::field::id>(rec1) != seqan3::get<seqan3::field::id>(rec2))
+    if (rec1.id() != rec2.id())
         throw std::runtime_error("Oh oh your pairs don't match.");
 }
 //![paired_reads]
@@ -142,7 +142,7 @@ for (auto && records : fin | ranges::views::chunk(10))
 {
     // `records` contains 10 elements (or less at the end)
     seqan3::debug_stream << "Taking the next 10 sequences:\n";
-    seqan3::debug_stream << "ID:  " << seqan3::get<seqan3::field::id>(*records.begin()) << '\n';
+    seqan3::debug_stream << "ID:  " << (*records.begin()).id() << '\n';
 }                                                                                           // prints first ID in batch
 //![read_in_batches]
 }
@@ -154,14 +154,14 @@ seqan3::sequence_file_input fin{std::filesystem::temp_directory_path()/"my.fastq
 // std::views::filter takes a function object (a lambda in this case) as input that returns a boolean
 auto minimum_quality_filter = std::views::filter([] (auto const & rec)
 {
-    auto qual = seqan3::get<seqan3::field::qual>(rec) | std::views::transform([] (auto q) { return q.to_phred(); });
+    auto qual = rec.base_qualities() | std::views::transform([] (auto q) { return q.to_phred(); });
     double sum = std::accumulate(qual.begin(), qual.end(), 0);
     return sum / std::ranges::size(qual) >= 40; // minimum average quality >= 40
 });
 
 for (auto & rec : fin | minimum_quality_filter)
 {
-    seqan3::debug_stream << "ID: " << seqan3::get<seqan3::field::id>(rec) << '\n';
+    seqan3::debug_stream << "ID: " << rec.id() << '\n';
 }
 //![quality_filter]
 }

--- a/doc/tutorial/sequence_file/sequence_file_solution1.cpp
+++ b/doc/tutorial/sequence_file/sequence_file_solution1.cpp
@@ -55,9 +55,9 @@ int main()
 
     for (auto & rec : fin)
     {
-        seqan3::debug_stream << "ID:  "  << seqan3::get<seqan3::field::id>(rec) << '\n';
-        seqan3::debug_stream << "SEQ: "  << seqan3::get<seqan3::field::seq>(rec) << '\n';
-        seqan3::debug_stream << "QUAL: " << seqan3::get<seqan3::field::qual>(rec) << '\n';
+        seqan3::debug_stream << "ID:  "  << rec.id() << '\n';
+        seqan3::debug_stream << "SEQ: "  << rec.sequence() << '\n';
+        seqan3::debug_stream << "QUAL: " << rec.base_qualities() << '\n';
     }
 }
 //![solution]

--- a/doc/tutorial/sequence_file/sequence_file_solution3.cpp
+++ b/doc/tutorial/sequence_file/sequence_file_solution3.cpp
@@ -67,21 +67,26 @@ int main()
 
     auto length_filter = std::views::filter([] (auto const & rec)
     {
-        return std::ranges::size(seqan3::get<seqan3::field::seq>(rec)) >= 5;
+        return std::ranges::size(rec.sequence()) >= 5;
     });
 
     // you can use a for loop
 
     // for (auto & rec : fin | length_filter | std::views::take(2))
     // {
-    //     seqan3::debug_stream << "ID: " << seqan3::get<seqan3::field::id>(rec) << '\n';
+    //     seqan3::debug_stream << "ID: " << rec.id() << '\n';
     // }
 
     // But you can also do this to retrieve all IDs into a vector:
     std::vector<std::string> ids = fin
                                  | length_filter                                    // apply length filter
                                  | std::views::take(2)                              // take first two records
-                                 | seqan3::views::get<seqan3::field::id>            // select only ID from record
+                                 | std::views::transform(&decltype(fin)::record_type::id) // select only ID from record
+                                 // this is the same as writing:
+//                                 | std::views::transform([](auto && record)         
+//                                   {
+//                                       return record.id();
+//                                   })
                                  | seqan3::views::move                              // mark ID to be moved out of record
                                  | seqan3::views::to<std::vector<std::string>>;     // convert to container
     // Note that you need to know the type of id (std::string)

--- a/doc/tutorial/sequence_file/sequence_file_solution4.cpp
+++ b/doc/tutorial/sequence_file/sequence_file_solution4.cpp
@@ -73,7 +73,7 @@ int main()
 
     auto length_filter = std::views::filter([] (auto const & rec)
     {
-        return std::ranges::size(seqan3::get<seqan3::field::seq>(rec)) >= 5;
+        return std::ranges::size(rec.sequence()) >= 5;
     });
 
     for (auto & rec : fin | length_filter)

--- a/doc/tutorial/sequence_file/sequence_file_solution5.cpp
+++ b/doc/tutorial/sequence_file/sequence_file_solution5.cpp
@@ -74,7 +74,7 @@ int main()
 
     auto length_filter = std::views::filter([] (auto & rec)
     {
-        return std::ranges::size(seqan3::get<seqan3::field::seq>(rec)) >= 5;
+        return std::ranges::size(rec.sequence()) >= 5;
     });
 
     fout = fin | length_filter;

--- a/include/seqan3/io/record.hpp
+++ b/include/seqan3/io/record.hpp
@@ -338,7 +338,7 @@ namespace seqan3
 
 //!\brief Free function get() for seqan3::record based on seqan3::field.
 template <field f, typename field_types, typename field_ids>
-auto & get(record<field_types, field_ids> & r)
+SEQAN3_DEPRECATED_310 auto & get(record<field_types, field_ids> & r)
 {
     static_assert(field_ids::contains(f), "The record does not contain the field you wish to retrieve.");
     return std::get<field_ids::index_of(f)>(r);
@@ -346,7 +346,7 @@ auto & get(record<field_types, field_ids> & r)
 
 //!\overload
 template <field f, typename field_types, typename field_ids>
-auto const & get(record<field_types, field_ids> const & r)
+SEQAN3_DEPRECATED_310 auto const & get(record<field_types, field_ids> const & r)
 {
     static_assert(field_ids::contains(f), "The record does not contain the field you wish to retrieve.");
     return std::get<field_ids::index_of(f)>(r);
@@ -354,7 +354,7 @@ auto const & get(record<field_types, field_ids> const & r)
 
 //!\overload
 template <field f, typename field_types, typename field_ids>
-auto && get(record<field_types, field_ids> && r)
+SEQAN3_DEPRECATED_310 auto && get(record<field_types, field_ids> && r)
 {
     static_assert(field_ids::contains(f), "The record does not contain the field you wish to retrieve.");
     return std::get<field_ids::index_of(f)>(std::move(r));
@@ -362,7 +362,7 @@ auto && get(record<field_types, field_ids> && r)
 
 //!\overload
 template <field f, typename field_types, typename field_ids>
-auto const && get(record<field_types, field_ids> const && r)
+SEQAN3_DEPRECATED_310 auto const && get(record<field_types, field_ids> const && r)
 {
     static_assert(field_ids::contains(f), "The record does not contain the field you wish to retrieve.");
 #if SEQAN3_WORKAROUND_GCC_94967

--- a/test/snippet/io/record_1.cpp
+++ b/test/snippet/io/record_1.cpp
@@ -22,7 +22,6 @@ int main()
 
     auto record = fin.front(); // get current record, in this case the first
 
-    // record is tuple-like type, but allows access via field identifiers:
-    auto & id = get<seqan3::field::id>(record);
-    auto & seq = get<seqan3::field::seq>(record);
+    auto & id = record.id();
+    auto & seq = record.sequence();
 }

--- a/test/snippet/io/record_2.cpp
+++ b/test/snippet/io/record_2.cpp
@@ -20,6 +20,9 @@ int main()
 
     record_type my_record{};
     get<1>(my_record) = "the most important sequence in the database";            // access via index
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     get<seqan3::field::seq>(my_record) = "ACGT"_dna4;                             // access via seqan3::field
+#pragma GCC diagnostic pop
     get<std::string>(my_record) = "the least important sequence in the database"; // access via type
 }

--- a/test/snippet/io/sam_file/sam_file_input_reading_custom_fields.cpp
+++ b/test/snippet/io/sam_file/sam_file_input_reading_custom_fields.cpp
@@ -14,15 +14,13 @@ r001	147	ref	237	30	9M	=	7	-39	CAGCGGCAT	*	NM:i:1
 
 int main()
 {
-    using seqan3::get;
-
     seqan3::sam_file_input fin{std::istringstream{sam_file_raw},
                                seqan3::format_sam{},
                                seqan3::fields<seqan3::field::flag, seqan3::field::mapq>{}};
 
     for (auto & rec : fin)
     {
-        seqan3::debug_stream << "flag:  "            << get<seqan3::field::flag>(rec) << '\n';
-        seqan3::debug_stream << "mapping quality:  " << get<seqan3::field::mapq>(rec) << '\n';
+        seqan3::debug_stream << "flag:  "            << rec.flag() << '\n';
+        seqan3::debug_stream << "mapping quality:  " << rec.mapping_quality() << '\n';
     }
 }

--- a/test/snippet/io/sam_file/sam_file_input_reading_filter.cpp
+++ b/test/snippet/io/sam_file/sam_file_input_reading_filter.cpp
@@ -15,14 +15,12 @@ r001	147	ref	237	30	9M	=	7	-39	CAGCGGCAT	*	NM:i:1
 
 int main()
 {
-    using seqan3::get;
-
     seqan3::sam_file_input fin{std::istringstream{sam_file_raw}, seqan3::format_sam{}};
 
 #if !SEQAN3_WORKAROUND_GCC_93983
     auto minimum_length10_filter = std::views::filter([] (auto const & rec)
     {
-        return std::ranges::size(get<seqan3::field::seq>(rec)) >= 10;
+        return std::ranges::size(rec.sequence()) >= 10;
     });
 #endif // !SEQAN3_WORKAROUND_GCC_93983
 
@@ -31,5 +29,5 @@ int main()
 #else // ^^^ workaround / no workaround vvv
     for (auto & rec : fin | minimum_length10_filter) // only records with sequence length >= 10 will "appear"
 #endif // SEQAN3_WORKAROUND_GCC_93983
-        seqan3::debug_stream << get<seqan3::field::id>(rec) << '\n';
+        seqan3::debug_stream << rec.id() << '\n';
 }

--- a/test/snippet/io/sam_file/sam_file_input_reading_range_based_for_loop.cpp
+++ b/test/snippet/io/sam_file/sam_file_input_reading_range_based_for_loop.cpp
@@ -14,16 +14,14 @@ r001	147	ref	237	30	9M	=	7	-39	CAGCGGCAT	*	NM:i:1
 
 int main()
 {
-    using seqan3::get;
-
     seqan3::sam_file_input fin{std::istringstream{sam_file_raw}, seqan3::format_sam{}};
 
     for (auto & rec : fin)
     {
-        seqan3::debug_stream << "id:  "              << get<seqan3::field::id>(rec)         << '\n';
-        seqan3::debug_stream << "read sequence: "    << get<seqan3::field::seq>(rec)        << '\n';
-        seqan3::debug_stream << "mapping position: " << get<seqan3::field::ref_offset>(rec) << '\n';
-        seqan3::debug_stream << "mapping quality: "  << get<seqan3::field::mapq>(rec)       << '\n';
+        seqan3::debug_stream << "id:  " << rec.id() << '\n';
+        seqan3::debug_stream << "read sequence: " << rec.sequence() << '\n';
+        seqan3::debug_stream << "mapping position: " << rec.reference_position() << '\n';
+        seqan3::debug_stream << "mapping quality: " << rec.mapping_quality() << '\n';
 
         // there are more fields read on default
     }

--- a/test/snippet/io/sam_file/sam_flags.cpp
+++ b/test/snippet/io/sam_file/sam_flags.cpp
@@ -18,18 +18,18 @@ int main()
     for (auto & rec : fin)
     {
         // Check if a certain flag value (bit) is set:
-        if (static_cast<bool>(seqan3::get<seqan3::field::flag>(rec) & seqan3::sam_flag::unmapped))
-            std::cout << "Read " << seqan3::get<seqan3::field::id>(rec) << " is unmapped\n";
+        if (static_cast<bool>(rec.flag() & seqan3::sam_flag::unmapped))
+            std::cout << "Read " << rec.id() << " is unmapped\n";
 
-        if (seqan3::get<seqan3::field::qual>(rec)[0] < seqan3::assign_char_to('@', seqan3::phred42{})) // low quality
+        if (rec.base_qualities()[0] < seqan3::assign_char_to('@', seqan3::phred42{})) // low quality
         {
             // Set a flag value (bit):
-            seqan3::get<seqan3::field::flag>(rec) |= seqan3::sam_flag::failed_filter;
+            rec.flag() |= seqan3::sam_flag::failed_filter;
             // Note that this does not affect other flag values (bits),
-            // e.g. `seqan3::get<seqan3::field::flag>(rec) & seqan3::sam_flag::unmapped` may still be true
+            // e.g. `rec.flag() & seqan3::sam_flag::unmapped` may still be true
         }
 
         // Unset a flag value (bit):
-        seqan3::get<seqan3::field::flag>(rec) &= ~seqan3::sam_flag::duplicate; // not marked as a duplicate anymore
+        rec.flag() &= ~seqan3::sam_flag::duplicate; // not marked as a duplicate anymore
     }
 }

--- a/test/snippet/io/sequence_file/sequence_file_input_file_view.cpp
+++ b/test/snippet/io/sequence_file/sequence_file_input_file_view.cpp
@@ -13,14 +13,12 @@ GGAGTATAATATATATATATATAT)";
 
 int main()
 {
-    using seqan3::get;
-
     seqan3::sequence_file_input fin{std::istringstream{}, seqan3::format_fasta{}};
 
 #if !SEQAN3_WORKAROUND_GCC_93983
     auto minimum_length5_filter = std::views::filter([] (auto const & rec)
     {
-        return std::ranges::size(get<seqan3::field::seq>(rec)) >= 5;
+        return std::ranges::size(rec.sequence()) >= 5;
     });
 #endif // !SEQAN3_WORKAROUND_GCC_93983
 
@@ -30,7 +28,7 @@ int main()
     for (auto & rec : fin | minimum_length5_filter) // only record with sequence length >= 5 will "appear"
 #endif // SEQAN3_WORKAROUND_GCC_93983
     {
-        seqan3::debug_stream << "IDs of seq_length >= 5: " << get<seqan3::field::id>(rec) << '\n';
+        seqan3::debug_stream << "IDs of seq_length >= 5: " << rec.id() << '\n';
         // ...
     }
 }

--- a/test/snippet/io/sequence_file/sequence_file_input_record_iter.cpp
+++ b/test/snippet/io/sequence_file/sequence_file_input_record_iter.cpp
@@ -12,13 +12,12 @@ GGAGTATAATATATATATATATAT)";
 
 int main()
 {
-
     seqan3::sequence_file_input fin{std::istringstream{input}, seqan3::format_fasta{}};
 
     for (auto & rec : fin)
     {
-        seqan3::debug_stream << "ID:  " << seqan3::get<seqan3::field::id>(rec) << '\n';
-        seqan3::debug_stream << "SEQ: " << seqan3::get<seqan3::field::seq>(rec) << '\n';
+        seqan3::debug_stream << "ID:  " << rec.id() << '\n';
+        seqan3::debug_stream << "SEQ: " << rec.sequence() << '\n';
         // a quality field also exists, but is not printed, because we know it's empty for FastA files.
     }
 }

--- a/test/snippet/io/sequence_file/sequence_file_output_view_pipeline.cpp
+++ b/test/snippet/io/sequence_file/sequence_file_output_view_pipeline.cpp
@@ -22,22 +22,20 @@ GGAGTATAATATATATATATATAT
 int main()
 {
 #if !SEQAN3_WORKAROUND_GCC_96070
-    using seqan3::get;
-
     // minimum_average_quality_filter and minimum_sequence_length_filter need to be implemented first
     auto minimum_sequence_length_filter = std::views::filter([] (auto rec)
     {
-        return std::ranges::distance(get<seqan3::field::seq>(rec)) >= 50;
+        return std::ranges::distance(rec.sequence()) >= 50;
     });
 
     auto minimum_average_quality_filter = std::views::filter([] (auto const & rec)
     {
         double qual_sum{0}; // summation of the qualities
-        for (auto chr : get<seqan3::field::qual>(rec))
+        for (auto chr : rec.qualities())
             qual_sum += chr.to_phred();
 
                            // check if average quality is greater than 20.
-        return qual_sum / (std::ranges::distance(get<seqan3::field::qual>(rec))) >= 20;
+        return qual_sum / (std::ranges::distance(rec.qualities())) >= 20;
     });
 
     seqan3::sequence_file_input{std::istringstream{input}, seqan3::format_fastq{}}

--- a/test/snippet/io/structure_file/structure_file_input_filter_criteria.cpp
+++ b/test/snippet/io/structure_file/structure_file_input_filter_criteria.cpp
@@ -14,14 +14,12 @@ UUGGAGUACACAACCUGUACACUCUUUC
 
 int main()
 {
-    using seqan3::get;
-
     seqan3::structure_file_input fin{std::istringstream{input}, seqan3::format_vienna{}};
 
 #if !SEQAN3_WORKAROUND_GCC_93983
     auto minimum_length5_filter = std::views::filter([] (auto const & rec)
     {
-        return std::ranges::size(get<seqan3::field::seq>(rec)) >= 5;
+        return std::ranges::size(rec.sequence()) >= 5;
     });
 #endif // !SEQAN3_WORKAROUND_GCC_93983
 
@@ -30,5 +28,5 @@ int main()
 #else // ^^^ workaround / no workaround vvv
     for (auto & rec : fin | minimum_length5_filter) // only record with sequence length >= 5 will "appear"
 #endif // SEQAN3_WORKAROUND_GCC_93983
-        seqan3::debug_stream << (get<0>(rec) | seqan3::views::to_char) << '\n';
+        seqan3::debug_stream << (rec.sequence() | seqan3::views::to_char) << '\n';
 }

--- a/test/snippet/io/structure_file/structure_file_input_record_iter.cpp
+++ b/test/snippet/io/structure_file/structure_file_input_record_iter.cpp
@@ -14,8 +14,6 @@ HGEBHHHHHGEBHHHH)";
 
 int main()
 {
-    using seqan3::get;
-
     using structure_file_input_t = seqan3::structure_file_input<seqan3::structure_file_input_default_traits_aa,
                                                                 seqan3::fields<seqan3::field::seq,
                                                                                seqan3::field::id,
@@ -26,9 +24,9 @@ int main()
 
     for (auto & rec : fin)
     {
-        seqan3::debug_stream << "ID: "        << get<seqan3::field::id>(rec)                                  << '\n';
+        seqan3::debug_stream << "ID: "        << rec.id()                                  << '\n';
         // sequence and structure are converted to char on-the-fly
-        seqan3::debug_stream << "SEQ: "       << (get<seqan3::field::seq>(rec) | seqan3::views::to_char)       << '\n';
-        seqan3::debug_stream << "STRUCTURE: " << (get<seqan3::field::structure>(rec) | seqan3::views::to_char) << '\n';
+        seqan3::debug_stream << "SEQ: "       << (rec.sequence() | seqan3::views::to_char)       << '\n';
+        seqan3::debug_stream << "STRUCTURE: " << (rec.sequence_structure() | seqan3::views::to_char) << '\n';
     }
 }

--- a/test/snippet/range/views/async_input_buffer.cpp
+++ b/test/snippet/range/views/async_input_buffer.cpp
@@ -56,7 +56,7 @@ int main()
             std::this_thread::sleep_for(std::chrono::milliseconds(std::rand() % 1000));
             // print current thread and sequence ID
             seqan3::debug_stream << "Thread: " << std::this_thread::get_id()             << '\t'
-                                 << "Seq:    " << seqan3::get<seqan3::field::id>(record) << '\n';
+                                 << "Seq:    " << record.id() << '\n';
 
         }
     };

--- a/test/unit/io/record_test.cpp
+++ b/test/unit/io/record_test.cpp
@@ -100,15 +100,21 @@ TEST_F(record, get_by_field)
 {
     record_type r{"MY ID", "ACGT"_dna4};
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     EXPECT_EQ(seqan3::get<seqan3::field::id>(r), "MY ID");
     EXPECT_RANGE_EQ(seqan3::get<seqan3::field::seq>(r), "ACGT"_dna4);
+#pragma GCC diagnostic pop
 }
 
 TEST_F(record, gcc_issue_94967)
 {
     record_type r{"MY ID", "ACGT"_dna4};
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     // gcc 7 implemented a different std::get(const &&) definition which was later changed by
     // https://wg21.link/lwg2485
     EXPECT_SAME_TYPE(std::string const &&, decltype(seqan3::get<seqan3::field::id>(std::move(std::as_const(r)))));
+#pragma GCC diagnostic pop
 }

--- a/test/unit/io/sam_file/format_bam_test.cpp
+++ b/test/unit/io/sam_file/format_bam_test.cpp
@@ -507,11 +507,14 @@ TEST_F(bam_format, too_long_cigar_string_read)
 
         seqan3::sam_file_input fin{stream, this->ref_ids, this->ref_sequences, seqan3::format_bam{}};
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         EXPECT_RANGE_EQ(std::get<0>(seqan3::get<seqan3::field::alignment>(*fin.begin())),
                         std::get<0>(this->alignments[0]));
         EXPECT_RANGE_EQ(std::get<1>(seqan3::get<seqan3::field::alignment>(*fin.begin())),
                         std::get<1>(this->alignments[0]));
         EXPECT_EQ(seqan3::get<seqan3::field::tags>(*fin.begin()).size(), 0u); // redundant CG tag is removed
+#pragma GCC diagnostic pop
 
         EXPECT_RANGE_EQ(std::get<0>((*fin.begin()).alignment()),
                         std::get<0>(this->alignments[0]));

--- a/test/unit/io/sam_file/format_sam_test.cpp
+++ b/test/unit/io/sam_file/format_sam_test.cpp
@@ -191,7 +191,10 @@ TEST_F(sam_format, no_hd_line_in_header)
     std::istringstream istream{std::string{"@SQ\tSN:ref\tLN:34\nread1\t41\tref\t1\t61\t*\tref\t10\t300\tACGT\t!##$\n"}};
     seqan3::sam_file_input fin{istream, seqan3::format_sam{}, seqan3::fields<seqan3::field::id>{}};
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     EXPECT_EQ(seqan3::get<seqan3::field::id>(*fin.begin()), std::string{"read1"});
+#pragma GCC diagnostic pop
 
     EXPECT_EQ((*fin.begin()).id(), std::string{"read1"});
 }
@@ -201,7 +204,10 @@ TEST_F(sam_format, windows_file)
     std::istringstream istream(std::string("read1\t41\tref\t1\t61\t*\tref\t10\t300\tACGT\t!##$\r\n"));
     seqan3::sam_file_input fin{istream, seqan3::format_sam{}, seqan3::fields<seqan3::field::id>{}};
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     EXPECT_EQ(seqan3::get<seqan3::field::id>(*fin.begin()), std::string{"read1"});
+#pragma GCC diagnostic pop
 
     EXPECT_EQ((*fin.begin()).id(), std::string{"read1"});
 }
@@ -358,8 +364,11 @@ TEST_F(sam_format, issue2195)
         using seqan3::operator""_phred42;
         std::vector<seqan3::phred42> expected_quality = "*9<9;"_phred42;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::id>(*fin.begin()), std::string{"*r1"});
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::qual>(*fin.begin()), expected_quality);
+#pragma GCC diagnostic pop
 
         EXPECT_RANGE_EQ((*fin.begin()).id(), std::string{"*r1"});
         EXPECT_RANGE_EQ((*fin.begin()).base_qualities(), expected_quality);
@@ -375,8 +384,11 @@ TEST_F(sam_format, issue2195)
         using seqan3::operator""_phred42;
         std::vector<seqan3::phred42> expected_quality = "*1"_phred42;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::id>(*fin.begin()), std::string{""});
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::qual>(*fin.begin()), expected_quality);
+#pragma GCC diagnostic pop
 
         EXPECT_RANGE_EQ((*fin.begin()).id(), std::string{""});
         EXPECT_RANGE_EQ((*fin.begin()).base_qualities(), expected_quality);

--- a/test/unit/io/sam_file/sam_file_format_test_template.hpp
+++ b/test/unit/io/sam_file/sam_file_format_test_template.hpp
@@ -213,6 +213,8 @@ TYPED_TEST_P(sam_file_read, read_in_all_data)
     size_t i{0};
     for (auto & rec : fin)
     {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         EXPECT_EQ(seqan3::get<seqan3::field::seq>(rec), this->seqs[i]);
         EXPECT_EQ(seqan3::get<seqan3::field::id>(rec), this->ids[i]);
         EXPECT_EQ(seqan3::get<seqan3::field::qual>(rec), this->quals[i]);
@@ -225,6 +227,7 @@ TYPED_TEST_P(sam_file_read, read_in_all_data)
         EXPECT_EQ(seqan3::get<seqan3::field::mapq>(rec), this->mapqs[i]);
         EXPECT_EQ(seqan3::get<seqan3::field::mate>(rec), this->mates[i]);
         EXPECT_EQ(seqan3::get<seqan3::field::tags>(rec), this->tag_dicts[i]);
+#pragma GCC diagnostic pop
 
         EXPECT_EQ(rec.sequence(), this->seqs[i]);
         EXPECT_EQ(rec.id(), this->ids[i]);
@@ -249,6 +252,8 @@ TYPED_TEST_P(sam_file_read, read_in_all_but_empty_data)
     typename TestFixture::stream_type istream{this->empty_input};
     seqan3::sam_file_input fin{istream, this->ref_ids, this->ref_sequences, TypeParam{}};
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     EXPECT_TRUE(seqan3::get<seqan3::field::seq>(*fin.begin()).empty());
     EXPECT_TRUE(seqan3::get<seqan3::field::id>(*fin.begin()).empty());
     EXPECT_TRUE(seqan3::get<seqan3::field::qual>(*fin.begin()).empty());
@@ -263,6 +268,7 @@ TYPED_TEST_P(sam_file_read, read_in_all_but_empty_data)
     EXPECT_TRUE(!std::get<1>(seqan3::get<seqan3::field::mate>(*fin.begin())).has_value());
     EXPECT_EQ(std::get<2>(seqan3::get<seqan3::field::mate>(*fin.begin())), int32_t{});
     EXPECT_TRUE(seqan3::get<seqan3::field::tags>(*fin.begin()).empty());
+#pragma GCC diagnostic pop
 
     EXPECT_TRUE((*fin.begin()).sequence().empty());
     EXPECT_TRUE((*fin.begin()).id().empty());
@@ -317,8 +323,11 @@ TYPED_TEST_P(sam_file_read, read_in_alignment_only_with_ref)
                                    TypeParam{},
                                    seqan3::fields<seqan3::field::alignment>{}};
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         EXPECT_TRUE(std::ranges::empty(std::get<0>(seqan3::get<seqan3::field::alignment>(*fin.begin()))));
         EXPECT_TRUE(std::ranges::empty(std::get<1>(seqan3::get<seqan3::field::alignment>(*fin.begin()))));
+#pragma GCC diagnostic pop
 
         EXPECT_TRUE(std::ranges::empty(std::get<0>((*fin.begin()).alignment())));
         EXPECT_TRUE(std::ranges::empty(std::get<1>((*fin.begin()).alignment())));
@@ -344,8 +353,11 @@ TYPED_TEST_P(sam_file_read, read_in_alignment_only_without_ref)
         typename TestFixture::stream_type istream{this->empty_cigar};
         seqan3::sam_file_input fin{istream, TypeParam{}, seqan3::fields<seqan3::field::alignment>{}};
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         EXPECT_TRUE(std::ranges::empty(std::get<0>(seqan3::get<seqan3::field::alignment>(*fin.begin()))));
         EXPECT_TRUE(std::ranges::empty(std::get<1>(seqan3::get<seqan3::field::alignment>(*fin.begin()))));
+#pragma GCC diagnostic pop
 
         EXPECT_TRUE(std::ranges::empty(std::get<0>((*fin.begin()).alignment())));
         EXPECT_TRUE(std::ranges::empty(std::get<1>((*fin.begin()).alignment())));

--- a/test/unit/io/sam_file/sam_file_input_test.cpp
+++ b/test/unit/io/sam_file/sam_file_input_test.cpp
@@ -260,9 +260,12 @@ TEST_F(sam_file_input_f, record_reading)
     size_t counter = 0;
     for (auto & rec : fin)
     {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::seq>(rec), seq_comp[counter]);
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::id>(rec), id_comp[counter]);
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::qual>(rec), qual_comp[counter]);
+#pragma GCC diagnostic pop
 
         EXPECT_RANGE_EQ(rec.sequence(), seq_comp[counter]);
         EXPECT_RANGE_EQ(rec.id(), id_comp[counter]);
@@ -314,9 +317,12 @@ TEST_F(sam_file_input_f, file_view)
     for (auto & rec : fin | minimum_length_filter)
     {
 #endif // SEQAN3_WORKAROUND_GCC_93983
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::seq>(rec), seq_comp[counter]);
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::id>(rec), id_comp[counter]);
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::qual>(rec), qual_comp[counter]);
+#pragma GCC diagnostic pop
 
         EXPECT_RANGE_EQ(rec.sequence(), seq_comp[counter]);
         EXPECT_RANGE_EQ(rec.id(), id_comp[counter]);
@@ -338,9 +344,12 @@ void decompression_impl(fixture_t & fix, input_file_t & fin)
     size_t counter = 0;
     for (auto & rec : fin)
     {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::seq>(rec), fix.seq_comp[counter]);
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::id>(rec), fix.id_comp[counter]);
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::qual>(rec), fix.qual_comp[counter]);
+#pragma GCC diagnostic pop
 
         EXPECT_RANGE_EQ(rec.sequence(), fix.seq_comp[counter]);
         EXPECT_RANGE_EQ(rec.id(), fix.id_comp[counter]);

--- a/test/unit/io/sam_file/sam_file_record_test.cpp
+++ b/test/unit/io/sam_file/sam_file_record_test.cpp
@@ -188,6 +188,8 @@ TEST_F(sam_record, get_by_field)
 {
     record_type r{construct()};
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     EXPECT_EQ(seqan3::get<seqan3::field::id>(r), "MY ID");
     EXPECT_RANGE_EQ(seqan3::get<seqan3::field::seq>(r), "ACGT"_dna5);
     EXPECT_RANGE_EQ(seqan3::get<seqan3::field::qual>(r), "!##$"_phred42);
@@ -204,6 +206,7 @@ TEST_F(sam_record, get_by_field)
                                                 {1, 'D'_cigar_operation}, {1, 'M'_cigar_operation},
                                                 {1, 'I'_cigar_operation}}));
     EXPECT_EQ(seqan3::get<seqan3::field::tags>(r), seqan3::sam_tag_dictionary{});
+#pragma GCC diagnostic pop
 }
 
 TEST_F(sam_record, get_by_member)
@@ -234,6 +237,8 @@ TEST_F(sam_record, get_types)
 {
     record_type r{construct()};
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     EXPECT_SAME_TYPE(std::string &, decltype(seqan3::get<seqan3::field::id>(r)));
     EXPECT_SAME_TYPE(seqan3::dna5_vector &, decltype(seqan3::get<seqan3::field::seq>(r)));
     EXPECT_SAME_TYPE(std::vector<seqan3::phred42> &, decltype(seqan3::get<seqan3::field::qual>(r)));
@@ -302,6 +307,7 @@ TEST_F(sam_record, get_types)
                      decltype(seqan3::get<seqan3::field::cigar>(std::move(std::as_const(r)))));
     EXPECT_SAME_TYPE(seqan3::sam_tag_dictionary const &&,
                      decltype(seqan3::get<seqan3::field::tags>(std::move(std::as_const(r)))));
+#pragma GCC diagnostic pop
 }
 
 TEST_F(sam_record, member_types)

--- a/test/unit/io/sequence_file/sequence_file_format_embl_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_format_embl_test.cpp
@@ -117,8 +117,11 @@ SQ Sequence 1859 BP; 609 A; 314 C; 355 G; 581 T; 0 other;
         auto it = fin.begin();
         for (unsigned i = 0; i < 3; ++i, ++it)
         {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
             EXPECT_EQ(seqan3::get<seqan3::field::id>(*it), ids[i]);
             EXPECT_EQ(seqan3::get<seqan3::field::seq>(*it), seqs[i]);
+#pragma GCC diagnostic pop
 
             EXPECT_EQ((*it).id(), ids[i]);
             EXPECT_EQ((*it).sequence(), seqs[i]);

--- a/test/unit/io/sequence_file/sequence_file_format_fasta_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_format_fasta_test.cpp
@@ -86,8 +86,11 @@ struct read : public sequence_file_data
         auto it = fin.begin();
         for (unsigned i = 0; i < 3; ++i, ++it)
         {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
             EXPECT_RANGE_EQ(seqan3::get<seqan3::field::seq>(*it), seqs[i]);
             EXPECT_EQ(seqan3::get<seqan3::field::id>(*it), ids[i]);
+#pragma GCC diagnostic pop
 
             EXPECT_EQ((*it).id(), ids[i]);
             EXPECT_RANGE_EQ((*it).sequence(), seqs[i]);

--- a/test/unit/io/sequence_file/sequence_file_format_fastq_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_format_fastq_test.cpp
@@ -115,9 +115,12 @@ struct read : public sequence_file_data
         auto it = fin.begin();
         for (unsigned i = 0; i < 3; ++i, ++it)
         {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
             EXPECT_RANGE_EQ(seqan3::get<seqan3::field::seq>(*it), seqs[i]);
             EXPECT_RANGE_EQ(seqan3::get<seqan3::field::id>(*it), ids[i]);
             EXPECT_RANGE_EQ(seqan3::get<seqan3::field::qual>(*it), quals[i]);
+#pragma GCC diagnostic pop
 
             EXPECT_RANGE_EQ((*it).id(), ids[i]);
             EXPECT_RANGE_EQ((*it).sequence(), seqs[i]);

--- a/test/unit/io/sequence_file/sequence_file_format_genbank_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_format_genbank_test.cpp
@@ -120,8 +120,11 @@ struct read : public sequence_file_read<seqan3::format_genbank>
         auto it = fin.begin();
         for (unsigned i = 0; i < 3; ++i, ++it)
         {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
             EXPECT_EQ(seqan3::get<seqan3::field::id>(*it), ids[i]);
             EXPECT_EQ(seqan3::get<seqan3::field::seq>(*it), seqs[i]);
+#pragma GCC diagnostic pop
 
             EXPECT_EQ((*it).id(), ids[i]);
             EXPECT_EQ((*it).sequence(), seqs[i]);

--- a/test/unit/io/sequence_file/sequence_file_format_sam_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_format_sam_test.cpp
@@ -72,9 +72,12 @@ struct read_sam : sequence_file_read<seqan3::format_sam>
         auto it = fin.begin();
         for (unsigned i = 0; i < 3; ++i, it++)
         {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
             EXPECT_EQ(seqan3::get<seqan3::field::seq>(*it), seqs[i]);
             EXPECT_EQ(seqan3::get<seqan3::field::id>(*it), ids[i]);
             EXPECT_EQ(seqan3::get<seqan3::field::qual>(*it), quals[i]);
+#pragma GCC diagnostic pop
 
             EXPECT_EQ((*it).id(), ids[i]);
             EXPECT_EQ((*it).sequence(), seqs[i]);

--- a/test/unit/io/sequence_file/sequence_file_format_test_template.hpp
+++ b/test/unit/io/sequence_file/sequence_file_format_test_template.hpp
@@ -80,12 +80,15 @@ TYPED_TEST_P(sequence_file_read, standard)
     auto it = fin.begin();
     for (unsigned i = 0; i < 3; ++i, ++it)
     {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::seq>(*it), this->seqs[i]);
         EXPECT_EQ(seqan3::get<seqan3::field::id>(*it), this->ids[i]);
         if constexpr (std::same_as<TypeParam, seqan3::format_fastq> || std::same_as<TypeParam, seqan3::format_sam>)
         {
             EXPECT_RANGE_EQ(seqan3::get<seqan3::field::qual>(*it), this->quals[i]);
         }
+#pragma GCC diagnostic pop
 
         EXPECT_RANGE_EQ((*it).sequence(), this->seqs[i]);
         EXPECT_EQ((*it).id(), this->ids[i]);
@@ -124,9 +127,12 @@ TYPED_TEST_P(sequence_file_read, seq_qual)
     auto it = fin.begin();
     for (unsigned i = 0; i < 3; ++i, ++it)
     {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::id>(*it), this->ids[i]);
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::seq_qual>(*it) | seqan3::views::convert<seqan3::dna5>,
                         this->seqs[i]);
+#pragma GCC diagnostic pop
 
         EXPECT_RANGE_EQ((*it).id(), this->ids[i]);
     }

--- a/test/unit/io/sequence_file/sequence_file_input_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_input_test.cpp
@@ -232,9 +232,12 @@ TEST_F(sequence_file_input_f, record_reading)
     size_t counter = 0;
     for (auto & rec : fin)
     {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::seq>(rec), seq_comp[counter]);
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::id>(rec),  id_comp[counter]);
         EXPECT_TRUE(empty(seqan3::get<seqan3::field::qual>(rec)));
+#pragma GCC diagnostic pop
 
         EXPECT_RANGE_EQ(rec.id(),  id_comp[counter]);
         EXPECT_RANGE_EQ(rec.sequence(), seq_comp[counter]);
@@ -300,13 +303,22 @@ TEST_F(sequence_file_input_f, record_reading_custom_options)
     fin.options.truncate_ids = true;
 
     auto it = fin.begin();
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     EXPECT_EQ(seqan3::get<seqan3::field::id>(*it), "ID1");
+#pragma GCC diagnostic pop
     EXPECT_EQ((*it).id(), "ID1");
     ++it;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     EXPECT_EQ(seqan3::get<seqan3::field::id>(*it), "ID2");
+#pragma GCC diagnostic pop
     EXPECT_EQ((*it).id(), "ID2");
     ++it;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     EXPECT_EQ(seqan3::get<seqan3::field::id>(*it), "ID3");
+#pragma GCC diagnostic pop
     EXPECT_EQ((*it).id(), "ID3");
 }
 
@@ -331,9 +343,12 @@ TEST_F(sequence_file_input_f, file_view)
     for (auto & rec : fin | minimum_length_filter)
     {
 #endif // SEQAN3_WORKAROUND_GCC_93983
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::seq>(rec), seq_comp[counter]);
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::id>(rec),  id_comp[counter]);
         EXPECT_TRUE(empty(seqan3::get<seqan3::field::qual>(rec)));
+#pragma GCC diagnostic pop
 
         EXPECT_RANGE_EQ(rec.id(),  id_comp[counter]);
         EXPECT_RANGE_EQ(rec.sequence(), seq_comp[counter]);
@@ -355,9 +370,12 @@ void decompression_impl(fixture_t & fix, input_file_t & fin)
     size_t counter = 0;
     for (auto & rec : fin)
     {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::seq>(rec), fix.seq_comp[counter]);
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::id>(rec),  fix.id_comp[counter]);
         EXPECT_TRUE(empty(seqan3::get<seqan3::field::qual>(rec)));
+#pragma GCC diagnostic pop
 
         EXPECT_RANGE_EQ(rec.sequence(), fix.seq_comp[counter]);
         EXPECT_RANGE_EQ(rec.id(),  fix.id_comp[counter]);

--- a/test/unit/io/sequence_file/sequence_file_record_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_record_test.cpp
@@ -71,8 +71,11 @@ TEST_F(sequence_record, get_by_field)
 {
     record_type r{"MY ID", "ACGT"_dna4};
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     EXPECT_EQ(seqan3::get<seqan3::field::id>(r), "MY ID");
     EXPECT_RANGE_EQ(seqan3::get<seqan3::field::seq>(r), "ACGT"_dna4);
+#pragma GCC diagnostic pop
 }
 
 TEST_F(sequence_record, get_by_member)
@@ -87,6 +90,8 @@ TEST_F(sequence_record, get_types)
 {
     record_type r{"MY ID", "ACGT"_dna4};
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     EXPECT_SAME_TYPE(std::string &, decltype(seqan3::get<seqan3::field::id>(r)));
     EXPECT_SAME_TYPE(seqan3::dna4_vector &, decltype(seqan3::get<seqan3::field::seq>(r)));
 
@@ -99,6 +104,7 @@ TEST_F(sequence_record, get_types)
     EXPECT_SAME_TYPE(std::string const &&, decltype(seqan3::get<seqan3::field::id>(std::move(std::as_const(r)))));
     EXPECT_SAME_TYPE(seqan3::dna4_vector const &&,
                      decltype(seqan3::get<seqan3::field::seq>(std::move(std::as_const(r)))));
+#pragma GCC diagnostic pop
 }
 
 TEST_F(sequence_record, member_types)

--- a/test/unit/io/structure_file/format_vienna_test.cpp
+++ b/test/unit/io/structure_file/format_vienna_test.cpp
@@ -123,30 +123,46 @@ struct read : public ::testing::Test
         auto it = fin.begin();
         for (size_t idx = 0ul; idx < expected_seq.size(); ++idx, ++it)
         {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
             EXPECT_EQ(check_energy, seqan3::get<seqan3::field::energy>(*it).has_value());
+#pragma GCC diagnostic pop
             EXPECT_EQ(check_energy, (*it).energy().has_value());
             if (check_seq)
             {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
                 EXPECT_RANGE_EQ(seqan3::get<seqan3::field::seq>(*it), expected_seq[idx]);
+#pragma GCC diagnostic pop
                 EXPECT_RANGE_EQ((*it).sequence(), expected_seq[idx]);
             }
             if (check_id)
             {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
                 EXPECT_RANGE_EQ(seqan3::get<seqan3::field::id>(*it), expected_id[idx]);
+#pragma GCC diagnostic pop
                 EXPECT_RANGE_EQ((*it).id(), expected_id[idx]);
             }
             if (check_structure)
             {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
                 bpp_test(seqan3::get<seqan3::field::bpp>(*it), expected_interactions[idx]);
                 bpp_test((*it).base_pair_probability_matrix(), expected_interactions[idx]);
             }
             if (check_energy)
             {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
                 EXPECT_DOUBLE_EQ(*seqan3::get<seqan3::field::energy>(*it), expected_energy[idx]);
+#pragma GCC diagnostic pop
                 EXPECT_DOUBLE_EQ(*(*it).energy(), expected_energy[idx]);
             }
             if (check_structure)
             {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
                 EXPECT_RANGE_EQ(seqan3::get<seqan3::field::structure>(*it), expected_structure[idx]);
                 EXPECT_RANGE_EQ((*it).sequence_structure(), expected_structure[idx]);
             }
@@ -256,7 +272,10 @@ TEST_F(read_fields, only_seq)
     auto it = fin.begin();
     for (size_t idx = 0ul; idx < expected_seq.size(); ++idx, ++it)
     {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::seq>(*it), expected_seq[idx]);
+#pragma GCC diagnostic pop
         EXPECT_RANGE_EQ((*it).sequence(), expected_seq[idx]);
     }
 }
@@ -268,7 +287,10 @@ TEST_F(read_fields, only_id)
     auto it = fin.begin();
     for (size_t idx = 0ul; idx < expected_seq.size(); ++idx, ++it)
     {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::id>(*it), expected_id[idx]);
+#pragma GCC diagnostic pop
         EXPECT_RANGE_EQ((*it).id(), expected_id[idx]);
     }
 }
@@ -280,6 +302,8 @@ TEST_F(read_fields, only_structure)
     auto it = fin.begin();
     for (size_t idx = 0ul; idx < expected_seq.size(); ++idx, ++it)
     {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::structure>(*it), expected_structure[idx]);
         EXPECT_RANGE_EQ((*it).sequence_structure(), expected_structure[idx]);
     }
@@ -292,9 +316,15 @@ TEST_F(read_fields, only_energy)
     auto it = fin.begin();
     for (size_t idx = 0ul; idx < expected_seq.size(); ++idx, ++it)
     {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         EXPECT_TRUE(seqan3::get<seqan3::field::energy>(*it));
+#pragma GCC diagnostic pop
         EXPECT_TRUE((*it).energy());
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         EXPECT_DOUBLE_EQ(*seqan3::get<seqan3::field::energy>(*it), expected_energy[idx]);
+#pragma GCC diagnostic pop
         EXPECT_DOUBLE_EQ(*(*it).energy(), expected_energy[idx]);
     }
 }
@@ -306,10 +336,13 @@ TEST_F(read_fields, structured_seq)
     auto it = fin.begin();
     for (size_t idx = 0ul; idx < expected_seq.size(); ++idx, ++it)
     {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::structured_seq>(*it) | seqan3::views::convert<seqan3::rna5>,
                         expected_seq[idx]);
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::structured_seq>(*it) | seqan3::views::convert<seqan3::wuss<51>>,
                         expected_structure[idx]);
+#pragma GCC diagnostic pop
     }
 }
 
@@ -320,6 +353,8 @@ TEST_F(read_fields, only_bpp)
     auto it = fin.begin();
     for (size_t idx = 0ul; idx < expected_seq.size(); ++idx, ++it)
     {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         bpp_test(seqan3::get<seqan3::field::bpp>(*it), expected_interactions[idx]);
         bpp_test((*it).base_pair_probability_matrix(), expected_interactions[idx]);
     }

--- a/test/unit/io/structure_file/structure_file_input_test.cpp
+++ b/test/unit/io/structure_file/structure_file_input_test.cpp
@@ -266,9 +266,12 @@ struct structure_file_input_read : public ::testing::Test
         counter = 0ul;
         for (auto & rec : fin)
         {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
             EXPECT_RANGE_EQ(seqan3::get<seqan3::field::seq>(rec), seq_comp[counter]);
             EXPECT_RANGE_EQ(seqan3::get<seqan3::field::id>(rec), id_comp[counter]);
             EXPECT_RANGE_EQ(seqan3::get<seqan3::field::structure>(rec), structure_comp[counter]);
+#pragma GCC diagnostic pop
 
             EXPECT_RANGE_EQ(rec.sequence(), seq_comp[counter]);
             EXPECT_RANGE_EQ(rec.id(), id_comp[counter]);
@@ -307,9 +310,12 @@ TEST_F(structure_file_input_read, record_general)
     size_t counter = 0ul;
     for (auto & rec : fin)
     {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::seq>(rec), seq_comp[counter]);
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::id>(rec), id_comp[counter]);
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::structure>(rec), structure_comp[counter]);
+#pragma GCC diagnostic pop
 
         EXPECT_RANGE_EQ(rec.sequence(), seq_comp[counter]);
         EXPECT_RANGE_EQ(rec.id(), id_comp[counter]);
@@ -386,11 +392,14 @@ TEST_F(structure_file_input_read, record_file_view)
     for (auto & rec : fin | minimum_length_filter)
 #endif // SEQAN3_WORKAROUND_GCC_93983
     {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::seq>(rec), seq_comp[counter]);
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::id>(rec),  id_comp[counter]);
         bpp_test(seqan3::get<seqan3::field::bpp>(rec), interaction_comp[counter]);
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::structure>(rec), structure_comp[counter]);
         EXPECT_DOUBLE_EQ(seqan3::get<seqan3::field::energy>(rec).value(), energy_comp[counter]);
+#pragma GCC diagnostic pop
 
         EXPECT_RANGE_EQ(rec.sequence(), seq_comp[counter]);
         EXPECT_RANGE_EQ(rec.id(), id_comp[counter]);

--- a/test/unit/io/structure_file/structure_file_record_test.cpp
+++ b/test/unit/io/structure_file/structure_file_record_test.cpp
@@ -85,10 +85,13 @@ TEST_F(structure_record, get_by_field)
 {
     record_type r{"MY ID", "ACGU"_rna5, "(())"_wuss51, 1.5};
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     EXPECT_EQ(seqan3::get<seqan3::field::id>(r), "MY ID");
     EXPECT_RANGE_EQ(seqan3::get<seqan3::field::seq>(r), "ACGU"_rna5);
     EXPECT_RANGE_EQ(seqan3::get<seqan3::field::structure>(r), "(())"_wuss51);
     EXPECT_DOUBLE_EQ(seqan3::get<seqan3::field::energy>(r), 1.5);
+#pragma GCC diagnostic pop
 }
 
 TEST_F(structure_record, get_by_member)
@@ -105,6 +108,8 @@ TEST_F(structure_record, get_types)
 {
     record_type r{"MY ID", "ACGU"_rna5, "(())"_wuss51, 1.5};
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     EXPECT_SAME_TYPE(std::string &, decltype(seqan3::get<seqan3::field::id>(r)));
     EXPECT_SAME_TYPE(seqan3::rna5_vector &, decltype(seqan3::get<seqan3::field::seq>(r)));
     EXPECT_SAME_TYPE(std::vector<seqan3::wuss51> &, decltype(seqan3::get<seqan3::field::structure>(r)));
@@ -127,6 +132,7 @@ TEST_F(structure_record, get_types)
     EXPECT_SAME_TYPE(std::vector<seqan3::wuss51> const &&,
                      decltype(seqan3::get<seqan3::field::structure>(std::move(std::as_const(r)))));
     EXPECT_SAME_TYPE(double const &&, decltype(seqan3::get<seqan3::field::energy>(std::move(std::as_const(r)))));
+#pragma GCC diagnostic pop
 }
 
 TEST_F(structure_record, member_types)


### PR DESCRIPTION
This PR deprecated old `seqan3::get<field>(record)` and changes last examples to `record.field`.

Part of https://github.com/seqan/product_backlog/issues/289