### PR TITLE
[DOC,FIX] grouping of ctors

### DIFF
--- a/include/seqan3/alignment/configuration/align_config_method.hpp
+++ b/include/seqan3/alignment/configuration/align_config_method.hpp
@@ -51,6 +51,7 @@ public:
     method_local & operator=(method_local const &) = default; //!< Defaulted.
     method_local & operator=(method_local &&) = default; //!< Defaulted.
     ~method_local() = default; //!< Defaulted.
+
     //!\}
 
     //!\privatesection

--- a/include/seqan3/alignment/configuration/align_config_output.hpp
+++ b/include/seqan3/alignment/configuration/align_config_output.hpp
@@ -51,6 +51,7 @@ public:
     constexpr output_score & operator=(output_score const &) = default; //!< Defaulted.
     constexpr output_score & operator=(output_score &&) = default; //!< Defaulted.
     ~output_score() = default; //!< Defaulted.
+
     //!\}
 
     //!\privatesection
@@ -94,6 +95,7 @@ public:
     constexpr output_end_position & operator=(output_end_position const &) = default; //!< Defaulted.
     constexpr output_end_position & operator=(output_end_position &&) = default; //!< Defaulted.
     ~output_end_position() = default; //!< Defaulted.
+
     //!\}
 
     //!\privatesection
@@ -137,6 +139,7 @@ public:
     constexpr output_begin_position & operator=(output_begin_position const &) = default; //!< Defaulted.
     constexpr output_begin_position & operator=(output_begin_position &&) = default; //!< Defaulted.
     ~output_begin_position() = default; //!< Defaulted.
+
     //!\}
 
     //!\privatesection
@@ -176,6 +179,7 @@ public:
     constexpr output_alignment & operator=(output_alignment const &) = default; //!< Defaulted.
     constexpr output_alignment & operator=(output_alignment &&) = default; //!< Defaulted.
     ~output_alignment() = default; //!< Defaulted.
+
     //!\}
 
     //!\privatesection
@@ -215,6 +219,7 @@ public:
     constexpr output_sequence1_id & operator=(output_sequence1_id const &) = default; //!< Defaulted.
     constexpr output_sequence1_id & operator=(output_sequence1_id &&) = default; //!< Defaulted.
     ~output_sequence1_id() = default; //!< Defaulted.
+
     //!\}
     //!\privatesection
     //!\brief Internal id to check for consistent configuration settings.
@@ -254,6 +259,7 @@ public:
     constexpr output_sequence2_id & operator=(output_sequence2_id const &) = default; //!< Defaulted.
     constexpr output_sequence2_id & operator=(output_sequence2_id &&) = default; //!< Defaulted.
     ~output_sequence2_id() = default; //!< Defaulted.
+
     //!\}
 
     //!\privatesection

--- a/include/seqan3/alignment/configuration/align_config_result_type.hpp
+++ b/include/seqan3/alignment/configuration/align_config_result_type.hpp
@@ -57,6 +57,7 @@ public:
     constexpr result_type & operator=(result_type const &) = default; //!< Defaulted.
     constexpr result_type & operator=(result_type &&) = default; //!< Defaulted.
     ~result_type() = default; //!< Defaulted.
+
     //!\}
 
     //!\brief Internal id to check for consistent configuration settings.

--- a/include/seqan3/alignment/configuration/align_config_score_type.hpp
+++ b/include/seqan3/alignment/configuration/align_config_score_type.hpp
@@ -51,6 +51,7 @@ public:
     constexpr score_type & operator=(score_type const &) = default; //!< Defaulted.
     constexpr score_type & operator=(score_type &&) = default; //!< Defaulted.
     ~score_type() = default; //!< Defaulted.
+
     //!\}
 
     //!\privatesection

--- a/include/seqan3/alignment/configuration/align_config_vectorised.hpp
+++ b/include/seqan3/alignment/configuration/align_config_vectorised.hpp
@@ -50,6 +50,7 @@ public:
     constexpr vectorised & operator=(vectorised const &) = default; //!< Defaulted.
     constexpr vectorised & operator=(vectorised &&) = default; //!< Defaulted.
     ~vectorised() = default; //!< Defaulted.
+
     //!\}
 
     //!\privatesection

--- a/include/seqan3/alignment/matrix/detail/combined_score_and_trace_matrix.hpp
+++ b/include/seqan3/alignment/matrix/detail/combined_score_and_trace_matrix.hpp
@@ -70,6 +70,7 @@ public:
     combined_score_and_trace_matrix & operator=(combined_score_and_trace_matrix const &) = default; //!< Defaulted.
     combined_score_and_trace_matrix & operator=(combined_score_and_trace_matrix &&) = default; //!< Defaulted.
     ~combined_score_and_trace_matrix() = default; //!< Defaulted.
+
     //!\}
 
     /*!\brief Resizes the matrix.

--- a/include/seqan3/alignment/matrix/detail/score_matrix_single_column.hpp
+++ b/include/seqan3/alignment/matrix/detail/score_matrix_single_column.hpp
@@ -81,6 +81,7 @@ public:
     score_matrix_single_column & operator=(score_matrix_single_column const &) = default; //!< Defaulted.
     score_matrix_single_column & operator=(score_matrix_single_column &&) = default; //!< Defaulted.
     ~score_matrix_single_column() = default; //!< Defaulted.
+
     //!\}
 
     /*!\brief Resizes the matrix.

--- a/include/seqan3/alignment/matrix/detail/trace_matrix_full.hpp
+++ b/include/seqan3/alignment/matrix/detail/trace_matrix_full.hpp
@@ -86,6 +86,7 @@ public:
     trace_matrix_full & operator=(trace_matrix_full const &) = default; //!< Defaulted.
     trace_matrix_full & operator=(trace_matrix_full &&) = default; //!< Defaulted.
     ~trace_matrix_full() = default; //!< Defaulted.
+
     //!\}
 
     /*!\brief Resizes the matrix.

--- a/include/seqan3/alignment/pairwise/alignment_result.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_result.hpp
@@ -203,6 +203,7 @@ public:
     alignment_result & operator=(alignment_result const &) = default; //!< Defaulted.
     alignment_result & operator=(alignment_result &&) = default;      //!< Defaulted.
     ~alignment_result() = default;                                    //!< Defaulted.
+
     //!\}
 
     /*!\name Access functions

--- a/include/seqan3/alignment/pairwise/edit_distance_unbanded.hpp
+++ b/include/seqan3/alignment/pairwise/edit_distance_unbanded.hpp
@@ -56,6 +56,7 @@ protected:
     edit_distance_unbanded_max_errors_policy & operator=(edit_distance_unbanded_max_errors_policy &&) noexcept
         = default; //!< Defaulted.
     ~edit_distance_unbanded_max_errors_policy() noexcept = default; //!< Defaulted.
+
     //!\}
 
     using typename edit_traits::word_type;
@@ -225,6 +226,7 @@ protected:
     edit_distance_unbanded_global_policy & operator=(edit_distance_unbanded_global_policy &&) noexcept
         = default; //!< Defaulted.
     ~edit_distance_unbanded_global_policy() noexcept = default; //!< Defaulted.
+
     //!\}
 
     //!\copydoc default_edit_distance_trait_type::score_type
@@ -349,6 +351,7 @@ protected:
     edit_distance_unbanded_semi_global_policy & operator=(edit_distance_unbanded_semi_global_policy &&) noexcept
         = default; //!< Defaulted.
     ~edit_distance_unbanded_semi_global_policy() noexcept = default; //!< Defaulted.
+
     //!\}
 
     //!\brief The base policy of this policy.
@@ -438,6 +441,7 @@ protected:
     edit_distance_unbanded_score_matrix_policy & operator=(edit_distance_unbanded_score_matrix_policy &&) noexcept
         = default; //!< Defaulted.
     ~edit_distance_unbanded_score_matrix_policy() noexcept = default; //!< Defaulted.
+
     //!\}
 
     using typename edit_traits::score_matrix_type;
@@ -517,6 +521,7 @@ protected:
     edit_distance_unbanded_trace_matrix_policy & operator=(edit_distance_unbanded_trace_matrix_policy &&) noexcept
         = default; //!< Defaulted.
     ~edit_distance_unbanded_trace_matrix_policy() noexcept = default; //!< Defaulted.
+
     //!\}
 
     using typename edit_traits::word_type;

--- a/include/seqan3/alphabet/alphabet_base.hpp
+++ b/include/seqan3/alphabet/alphabet_base.hpp
@@ -84,6 +84,7 @@ public:
     constexpr alphabet_base & operator=(alphabet_base const &)  noexcept = default; //!< Defaulted.
     constexpr alphabet_base & operator=(alphabet_base &&)       noexcept = default; //!< Defaulted.
     ~alphabet_base()                                            noexcept = default; //!< Defaulted.
+
     //!\}
 
     /*!\name Read functions

--- a/include/seqan3/alphabet/aminoacid/aminoacid_base.hpp
+++ b/include/seqan3/alphabet/aminoacid/aminoacid_base.hpp
@@ -46,6 +46,7 @@ private:
     constexpr aminoacid_base & operator=(aminoacid_base const &) noexcept = default; //!< Defaulted.
     constexpr aminoacid_base & operator=(aminoacid_base &&)      noexcept = default; //!< Defaulted.
     ~aminoacid_base()                                            noexcept = default; //!< Defaulted.
+
     //!\}
 
     //!\brief Befriend the derived class so it can instantiate.

--- a/include/seqan3/alphabet/cigar/cigar_op.hpp
+++ b/include/seqan3/alphabet/cigar/cigar_op.hpp
@@ -69,6 +69,7 @@ public:
     constexpr cigar_op & operator=(cigar_op const &) noexcept = default; //!< Defaulted.
     constexpr cigar_op & operator=(cigar_op &&)      noexcept = default; //!< Defaulted.
     ~cigar_op()                                      noexcept = default; //!< Defaulted.
+
     //!\}
 
 protected:

--- a/include/seqan3/alphabet/mask/mask.hpp
+++ b/include/seqan3/alphabet/mask/mask.hpp
@@ -50,6 +50,7 @@ public:
     constexpr mask & operator=(mask const &) = default; //!< Defaulted.
     constexpr mask & operator=(mask &&) = default;      //!< Defaulted.
     ~mask() = default;                                  //!< Defaulted.
+
     //!\}
 
     /*!\name Boolean values

--- a/include/seqan3/alphabet/nucleotide/nucleotide_base.hpp
+++ b/include/seqan3/alphabet/nucleotide/nucleotide_base.hpp
@@ -52,6 +52,7 @@ private:
     constexpr nucleotide_base & operator=(nucleotide_base const &) noexcept = default; //!< Defaulted.
     constexpr nucleotide_base & operator=(nucleotide_base &&)      noexcept = default; //!< Defaulted.
     ~nucleotide_base()                                             noexcept = default; //!< Defaulted.
+
     //!\}
 
     //! Befriend the derived_type so it can instantiate.

--- a/include/seqan3/alphabet/structure/dot_bracket3.hpp
+++ b/include/seqan3/alphabet/structure/dot_bracket3.hpp
@@ -67,6 +67,7 @@ public:
     constexpr dot_bracket3 & operator=(dot_bracket3 const &) noexcept = default; //!< Defaulted.
     constexpr dot_bracket3 & operator=(dot_bracket3 &&)      noexcept = default; //!< Defaulted.
     ~dot_bracket3()                                          noexcept = default; //!< Defaulted.
+
     //!\}
 
     //!\name RNA structure properties

--- a/include/seqan3/alphabet/structure/dssp9.hpp
+++ b/include/seqan3/alphabet/structure/dssp9.hpp
@@ -76,6 +76,7 @@ public:
     constexpr dssp9 & operator=(dssp9 const &)  noexcept = default; //!< Defaulted.
     constexpr dssp9 & operator=(dssp9 &&)       noexcept = default; //!< Defaulted.
     ~dssp9()                                    noexcept = default; //!< Defaulted.
+
     //!\}
 
 protected:

--- a/include/seqan3/alphabet/structure/wuss.hpp
+++ b/include/seqan3/alphabet/structure/wuss.hpp
@@ -82,6 +82,7 @@ public:
     constexpr wuss & operator=(wuss const &) noexcept = default; //!< Defaulted.
     constexpr wuss & operator=(wuss &&)      noexcept = default; //!< Defaulted.
     ~wuss()                                  noexcept = default; //!< Defaulted.
+
     //!\}
 
     /*!\name RNA structure properties

--- a/include/seqan3/core/algorithm/detail/execution_handler_parallel.hpp
+++ b/include/seqan3/core/algorithm/detail/execution_handler_parallel.hpp
@@ -44,7 +44,7 @@ namespace seqan3::detail
  * submit new algorithm tasks.
  *
  * \note Instances of this class are not copyable.
- * 
+ *
  * \warning This class is only thread-safe in a single producer context. Multiple consumers are allowed.
  *          Concurrent invocation of the interfaces are undefined behaviour.
  *
@@ -92,15 +92,15 @@ public:
     /*!\brief Constructs the execution handler spawning 1 thread.
      *
      * \details
-     * 
+     *
      * ### Why only 1 thread?
-     * 
-     * This class is not public. It handles the thread pool when, e.g., using the alignment or search algorithms in 
-     * parallel via the config. This config requires a value (no default), hence the number of threads is always 
+     *
+     * This class is not public. It handles the thread pool when, e.g., using the alignment or search algorithms in
+     * parallel via the config. This config requires a value (no default), hence the number of threads is always
      * set by the user.
-     * 
-     * When we use an algorithm in parallel, we also default construct a execution_handler_parallel along the way. If 
-     * the default is set to use all threads, we have to generate the thread pool and a queue. However, this default 
+     *
+     * When we use an algorithm in parallel, we also default construct a execution_handler_parallel along the way. If
+     * the default is set to use all threads, we have to generate the thread pool and a queue. However, this default
      * constructed execution_handler_parallel is immediately moved away and destructed.
      */
     execution_handler_parallel() : execution_handler_parallel{1u}
@@ -111,6 +111,7 @@ public:
     execution_handler_parallel & operator=(execution_handler_parallel const &) = delete; //!< Deleted.
     execution_handler_parallel & operator=(execution_handler_parallel &&) = default; //!< Defaulted.
     ~execution_handler_parallel() = default; //!< Defaulted.
+
     //!\}
 
     /*!\brief Asynchronously schedules a new algorithm task with the given input and callback.
@@ -206,9 +207,9 @@ private:
     /*!\brief An internal state stored on the heap to allow safe move construction/assignment of the class.
      *
      * \details
-     * 
+     *
      * ### Thread safety
-     * 
+     *
      * This class is only intended for use with a single producer model.
      */
     class internal_state
@@ -234,9 +235,9 @@ private:
         /*!\brief Waits until all threads have been joined.
          *
          * \details
-         * 
+         *
          * ### Thread safety
-         * 
+         *
          * This function is not thread-safe.
          */
         void stop_and_wait()

--- a/include/seqan3/core/algorithm/pipeable_config_element.hpp
+++ b/include/seqan3/core/algorithm/pipeable_config_element.hpp
@@ -42,6 +42,7 @@ private:
     constexpr pipeable_config_element & operator=(pipeable_config_element const &) = default; //!< Defaulted.
     constexpr pipeable_config_element & operator=(pipeable_config_element &&) = default; //!< Defaulted.
     ~pipeable_config_element() = default; //!< Defaulted.
+
     //!\}
 };
 

--- a/include/seqan3/core/configuration/detail/configuration_element_debug_mode.hpp
+++ b/include/seqan3/core/configuration/detail/configuration_element_debug_mode.hpp
@@ -38,6 +38,7 @@ public:
     constexpr debug_mode & operator=(debug_mode const &) = default; //!< Defaulted.
     constexpr debug_mode & operator=(debug_mode &&) = default; //!< Defaulted.
     ~debug_mode() = default; //!< Defaulted.
+
     //!\}
 
     //!\brief Internal id to check for consistent configuration settings.

--- a/include/seqan3/io/sam_file/format_bam.hpp
+++ b/include/seqan3/io/sam_file/format_bam.hpp
@@ -72,6 +72,7 @@ public:
     format_bam(format_bam &&) = default; //!< Defaulted.
     format_bam & operator=(format_bam &&) = default; //!< Defaulted.
     ~format_bam() = default; //!< Defaulted.
+
     //!\}
 
     //!\brief The valid file extensions for this format; note that you can modify this value.

--- a/include/seqan3/io/sam_file/format_sam.hpp
+++ b/include/seqan3/io/sam_file/format_sam.hpp
@@ -137,6 +137,7 @@ public:
     format_sam(format_sam &&) = default; //!< Defaulted.
     format_sam & operator=(format_sam &&) = default; //!< Defaulted.
     ~format_sam() = default; //!< Defaulted.
+
     //!\}
 
     //!\brief The valid file extensions for this format; note that you can modify this value.

--- a/include/seqan3/io/sam_file/format_sam_base.hpp
+++ b/include/seqan3/io/sam_file/format_sam_base.hpp
@@ -71,6 +71,7 @@ protected:
     format_sam_base(format_sam_base &&) = default; //!< Defaulted.
     format_sam_base & operator=(format_sam_base &&) = default; //!< Defaulted.
     ~format_sam_base() = default; //!< Defaulted.
+
     //!\}
 
     //!\brief The format version string.

--- a/include/seqan3/io/sequence_file/format_embl.hpp
+++ b/include/seqan3/io/sequence_file/format_embl.hpp
@@ -81,6 +81,7 @@ public:
     format_embl(format_embl &&) noexcept = default; //!< Defaulted.
     format_embl & operator=(format_embl &&) noexcept = default; //!< Defaulted.
     ~format_embl() noexcept = default; //!< Defaulted.
+
     //!\}
 
     //!\brief The valid file extensions for this format; note that you can modify this value.

--- a/include/seqan3/io/sequence_file/format_fasta.hpp
+++ b/include/seqan3/io/sequence_file/format_fasta.hpp
@@ -90,6 +90,7 @@ public:
     format_fasta(format_fasta &&) noexcept = default; //!< Defaulted.
     format_fasta & operator=(format_fasta &&) noexcept = default; //!< Defaulted.
     ~format_fasta() noexcept = default; //!< Defaulted.
+
     //!\}
 
     //!\brief The valid file extensions for this format; note that you can modify this value.

--- a/include/seqan3/io/sequence_file/format_fastq.hpp
+++ b/include/seqan3/io/sequence_file/format_fastq.hpp
@@ -88,6 +88,7 @@ public:
     format_fastq(format_fastq &&) noexcept = default; //!< Defaulted.
     format_fastq & operator=(format_fastq &&) noexcept = default; //!< Defaulted.
     ~format_fastq() noexcept = default; //!< Defaulted.
+
     //!\}
 
     //!\brief The valid file extensions for this format; note that you can modify this value.

--- a/include/seqan3/io/sequence_file/format_genbank.hpp
+++ b/include/seqan3/io/sequence_file/format_genbank.hpp
@@ -82,6 +82,7 @@ public:
     format_genbank(format_genbank &&) noexcept = default; //!< Defaulted.
     format_genbank & operator=(format_genbank &&) noexcept = default; //!< Defaulted.
     ~format_genbank() noexcept = default; //!< Defaulted.
+
     //!\}
 
     //!\brief The valid file extensions for this format; note that you can modify this value.

--- a/include/seqan3/io/structure_file/format_vienna.hpp
+++ b/include/seqan3/io/structure_file/format_vienna.hpp
@@ -93,6 +93,7 @@ public:
     format_vienna(format_vienna &&) noexcept = default; //!< Defaulted.
     format_vienna & operator=(format_vienna &&) noexcept = default; //!< Defaulted.
     ~format_vienna() noexcept = default; //!< Defaulted.
+
     //!\}
 
     //!\brief The valid file extensions for this format; note that you can modify this value.

--- a/include/seqan3/range/container/dynamic_bitset.hpp
+++ b/include/seqan3/range/container/dynamic_bitset.hpp
@@ -93,6 +93,7 @@ private:
         }
 
         ~reference_proxy_type() noexcept = default; //!< Defaulted.
+
         //!\}
 
         //!\brief Initialise from seqan3::dynamic_bitset's underlying data and a bit position.

--- a/include/seqan3/search/configuration/hit.hpp
+++ b/include/seqan3/search/configuration/hit.hpp
@@ -41,6 +41,7 @@ public:
     constexpr hit_all & operator=(hit_all const &) = default; //!< Defaulted.
     constexpr hit_all & operator=(hit_all &&) = default; //!< Defaulted.
     ~hit_all() = default; //!< Defaulted.
+
     //!\}
 
     //!\privatesection
@@ -64,6 +65,7 @@ public:
     constexpr hit_all_best & operator=(hit_all_best const &) = default; //!< Defaulted.
     constexpr hit_all_best & operator=(hit_all_best &&) = default; //!< Defaulted.
     ~hit_all_best() = default; //!< Defaulted.
+
     //!\}
 
     //!\privatesection
@@ -87,6 +89,7 @@ public:
     constexpr hit_single_best & operator=(hit_single_best const &) = default; //!< Defaulted.
     constexpr hit_single_best & operator=(hit_single_best &&) = default; //!< Defaulted.
     ~hit_single_best() = default; //!< Defaulted.
+
     //!\}
 
     //!\privatesection

--- a/include/seqan3/search/configuration/output.hpp
+++ b/include/seqan3/search/configuration/output.hpp
@@ -38,6 +38,7 @@ public:
     constexpr output_query_id & operator=(output_query_id const &) = default; //!< Defaulted.
     constexpr output_query_id & operator=(output_query_id &&) = default; //!< Defaulted.
     ~output_query_id() = default; //!< Defaulted.
+
     //!\}
 
     //!\privatesection
@@ -61,6 +62,7 @@ public:
     constexpr output_reference_id & operator=(output_reference_id const &) = default; //!< Defaulted.
     constexpr output_reference_id & operator=(output_reference_id &&) = default; //!< Defaulted.
     ~output_reference_id() = default; //!< Defaulted.
+
     //!\}
 
     //!\privatesection
@@ -84,6 +86,7 @@ public:
     constexpr output_reference_begin_position & operator=(output_reference_begin_position const &) = default; //!< Defaulted.
     constexpr output_reference_begin_position & operator=(output_reference_begin_position &&) = default; //!< Defaulted.
     ~output_reference_begin_position() = default; //!< Defaulted.
+
     //!\}
 
     //!\privatesection
@@ -107,6 +110,7 @@ public:
     constexpr output_index_cursor & operator=(output_index_cursor const &) = default; //!< Defaulted.
     constexpr output_index_cursor & operator=(output_index_cursor &&) = default; //!< Defaulted.
     ~output_index_cursor() = default; //!< Defaulted.
+
     //!\}
 
     //!\privatesection

--- a/include/seqan3/search/configuration/result_type.hpp
+++ b/include/seqan3/search/configuration/result_type.hpp
@@ -57,6 +57,7 @@ public:
     constexpr result_type & operator=(result_type const &) = default; //!< Defaulted.
     constexpr result_type & operator=(result_type &&) = default; //!< Defaulted.
     ~result_type() = default; //!< Defaulted.
+
     //!\}
 
     //!\brief Internal id to check for consistent configuration settings.

--- a/include/seqan3/search/dream_index/interleaved_bloom_filter.hpp
+++ b/include/seqan3/search/dream_index/interleaved_bloom_filter.hpp
@@ -594,6 +594,7 @@ public:
     binning_bitvector(binning_bitvector &&) = default; //!< Defaulted.
     binning_bitvector & operator=(binning_bitvector &&) = default; //!< Defaulted.
     ~binning_bitvector() = default; //!< Defaulted.
+
     //!\}
 
     using sdsl::bit_vector::begin;

--- a/include/seqan3/search/search_result.hpp
+++ b/include/seqan3/search/search_result.hpp
@@ -109,6 +109,7 @@ public:
     search_result & operator=(search_result const &) = default; //!< Defaulted.
     search_result & operator=(search_result &&) = default; //!< Defaulted.
     ~search_result() = default; //!< Defaulted.
+
     //!\}
 
     /*!\name Accessors

--- a/include/seqan3/utility/parallel/detail/spin_delay.hpp
+++ b/include/seqan3/utility/parallel/detail/spin_delay.hpp
@@ -45,6 +45,7 @@ public:
     constexpr spin_delay & operator=(spin_delay const &) noexcept = default;  //!< Defaulted.
     constexpr spin_delay & operator=(spin_delay &&)      noexcept = default;  //!< Defaulted.
     ~spin_delay()                                        noexcept = default;  //!< Defaulted.
+
     //!\}
 
     /*!\brief Delays the calling thread by either using active spinning or passive spinning.


### PR DESCRIPTION
See https://github.com/doxygen/doxygen/issues/8374

Closing a group after an inline comment makes some problems.

Also removes trailing whitespaces in `core/algorithm/detail/execution_handler_parallel.hpp`