### PR TITLE
[FIX] fix internal compiler error on gcc-7

### DIFF
--- a/test/unit/alphabet/composite/alphabet_variant_detail_test.cpp
+++ b/test/unit/alphabet/composite/alphabet_variant_detail_test.cpp
@@ -21,6 +21,7 @@ public:
     using seqan3::alphabet_variant<alphabet_types...>::partial_sum_sizes;
     using seqan3::alphabet_variant<alphabet_types...>::rank_to_char;
     using seqan3::alphabet_variant<alphabet_types...>::char_to_rank;
+    using seqan3::alphabet_variant<alphabet_types...>::first_valid_char_table;
 };
 
 TEST(alphabet_variant_detail_test, partial_sum_sizes)
@@ -122,4 +123,49 @@ TEST(alphabet_variant_detail_test, char_to_rank)
     EXPECT_EQ(char_to_rank4['C'], 1);
     EXPECT_EQ(char_to_rank4['G'], 2);
     EXPECT_EQ(char_to_rank4['T'], 4);
+}
+
+TEST(alphabet_variant_detail_test, first_valid_char_table)
+{
+    constexpr std::array first_valid_char_table2 = detail_alphabet_variant<seqan3::dna4,
+                                                                           seqan3::gap>::first_valid_char_table;
+    EXPECT_EQ(first_valid_char_table2.size(), 256u);
+    EXPECT_EQ(first_valid_char_table2['A'], 0);
+    EXPECT_EQ(first_valid_char_table2['C'], 0);
+    EXPECT_EQ(first_valid_char_table2['G'], 0);
+    EXPECT_EQ(first_valid_char_table2['T'], 0);
+    EXPECT_EQ(first_valid_char_table2['-'], 1);
+    EXPECT_EQ(first_valid_char_table2['X'], 2); // invalid char
+
+    constexpr std::array first_valid_char_table3 = detail_alphabet_variant<seqan3::dna4,
+                                                                           seqan3::gap,
+                                                                           seqan3::dna5>::first_valid_char_table;
+    EXPECT_EQ(first_valid_char_table3.size(), 256u);
+    EXPECT_EQ(first_valid_char_table3['A'], 0);
+    EXPECT_EQ(first_valid_char_table3['C'], 0);
+    EXPECT_EQ(first_valid_char_table3['G'], 0);
+    EXPECT_EQ(first_valid_char_table3['T'], 0);
+    EXPECT_EQ(first_valid_char_table3['-'], 1);
+    EXPECT_EQ(first_valid_char_table3['A'], 0);
+    EXPECT_EQ(first_valid_char_table3['C'], 0);
+    EXPECT_EQ(first_valid_char_table3['G'], 0);
+    EXPECT_EQ(first_valid_char_table3['N'], 2);
+    EXPECT_EQ(first_valid_char_table3['T'], 0);
+    EXPECT_EQ(first_valid_char_table3['X'], 3); // invalid char
+
+    constexpr std::array first_valid_char_table4 = detail_alphabet_variant<seqan3::dna5,
+                                                                           seqan3::gap,
+                                                                           seqan3::dna4>::first_valid_char_table;
+    EXPECT_EQ(first_valid_char_table4.size(), 256u);
+    EXPECT_EQ(first_valid_char_table4['A'], 0);
+    EXPECT_EQ(first_valid_char_table4['C'], 0);
+    EXPECT_EQ(first_valid_char_table4['G'], 0);
+    EXPECT_EQ(first_valid_char_table4['N'], 0);
+    EXPECT_EQ(first_valid_char_table4['T'], 0);
+    EXPECT_EQ(first_valid_char_table4['-'], 1);
+    EXPECT_EQ(first_valid_char_table4['A'], 0);
+    EXPECT_EQ(first_valid_char_table4['C'], 0);
+    EXPECT_EQ(first_valid_char_table4['G'], 0);
+    EXPECT_EQ(first_valid_char_table4['T'], 0);
+    EXPECT_EQ(first_valid_char_table4['X'], 3); // invalid char
 }


### PR DESCRIPTION
Changes in https://github.com/seqan/seqan3/pull/2427 triggered an ICE (in Fact the same one that @MitraDarja had in https://github.com/seqan/seqan3/pull/2337).

This is an attempt to fix this ICE once and for all by using an "easier" way of using is_valid_char at compile time.

Also part of https://github.com/seqan/product_backlog/issues/124, since it throws away some meta-library functionality.