### PR TITLE
[FIX] gcc-11: error: loop variable binds to a temporary [-Werror=rang…

### DIFF
--- a/include/seqan3/argument_parser/validators.hpp
+++ b/include/seqan3/argument_parser/validators.hpp
@@ -933,12 +933,15 @@ public:
      */
     template <std::ranges::forward_range range_type>
     //!\cond
-        requires std::convertible_to<std::ranges::range_value_t<range_type>, option_value_type const &>
+        requires std::convertible_to<std::ranges::range_reference_t<range_type>, option_value_type const &>
     //!\endcond
     void operator()(range_type const & v) const
     {
-        for (option_value_type const & file_name : v)
-            (*this)(file_name);
+        for (auto && file_name : v)
+        {
+            // note: we explicitly copy/construct any reference type other than `std::string &`
+            (*this)(static_cast<option_value_type const &>(file_name));
+        }
     }
 
     //!\brief Returns a message that can be appended to the (positional) options help page info.


### PR DESCRIPTION
…e-loop-construct]

```
/seqan3/include/seqan3/argument_parser/validators.hpp:918:40: error: loop variable ‘file_name’ of type ‘const option_value_type&’ {aka ‘const std::__cxx11::basic_string<char>&’} binds to a temporary constructed from type ‘const std::filesystem::__cxx11::path’ [-Werror=range-loop-construct]
  918 |         for (option_value_type const & file_name : v)
      |                                        ^~~~~~~~~
/seqan3/include/seqan3/argument_parser/validators.hpp:918:40: note: use non-reference type ‘const option_value_type’ {aka ‘const std::__cxx11::basic_string<char>’} to make the copy explicit or ‘const std::filesystem::__cxx11::path&’ to prevent copying
cc1plus: all warnings being treated as errors
```

Edit (@eseiler):
The warning is about constructing a string in the loop over filesystem::paths, i.e. we are constructing/copying something even though we bind by reference.
Hence, the warning suggest to use non-reference to make it clear that a copy is happening; the warning would also suggest using a reference if an unnecessary copy is made.
The fix is to bind the paths via `&&` and then explicitly construct a string.