### PR TITLE
[FIX] gcc-11: error: parameter ‘seed’ may not appear in this context

### DIFF
--- a/include/seqan3/range/views/minimiser_hash.hpp
+++ b/include/seqan3/range/views/minimiser_hash.hpp
@@ -73,7 +73,7 @@ struct minimiser_hash_fn
     constexpr auto operator()(urng_t && urange,
                               shape const & shape,
                               window_size const window_size,
-                              seed const seed = seed{0x8F3F73B5CF1C9ADE}) const
+                              seed const seed = seqan3::seed{0x8F3F73B5CF1C9ADE}) const
     {
         static_assert(std::ranges::viewable_range<urng_t>,
             "The range parameter to views::minimiser_hash cannot be a temporary of a non-view range.");


### PR DESCRIPTION
```
seqan3/include/seqan3/range/views/minimiser_hash.hpp:76:49: error: parameter ‘seed’ may not appear in this context
   76 |                               seed const seed = seed{0x8F3F73B5CF1C9ADE}) const
      |                                                 ^~~~
```