### PR TITLE
[TEST] remove some range-v3 ranges

### DIFF
--- a/test/unit/range/views/persist_test.cpp
+++ b/test/unit/range/views/persist_test.cpp
@@ -13,9 +13,6 @@
 #include <seqan3/std/ranges>
 #include <string>
 
-#include <range/v3/algorithm/copy.hpp>
-#include <range/v3/view/unique.hpp>
-
 #include <seqan3/range/views/persist.hpp>
 #include <seqan3/range/concept.hpp>
 #include <seqan3/test/expect_range_eq.hpp>
@@ -38,11 +35,11 @@ TEST(view_persist, delegate_to_view_all)
     EXPECT_RANGE_EQ("foo"sv, seqan3::views::persist(vec));
 
     // combinability
-    EXPECT_RANGE_EQ("fo"sv, vec | seqan3::views::persist | ranges::views::unique);
-    EXPECT_RANGE_EQ("of"sv, vec | std::views::reverse | seqan3::views::persist | ranges::views::unique);
+    EXPECT_RANGE_EQ("fo"sv, vec | seqan3::views::persist | std::views::take(2));
+    EXPECT_RANGE_EQ("of"sv, vec | std::views::reverse | seqan3::views::persist | std::views::drop(1));
 
     // store combined
-    auto a1 = seqan3::views::persist | ranges::views::unique;
+    auto a1 = seqan3::views::persist | std::views::take(2);
     EXPECT_RANGE_EQ("fo"sv, vec | a1);
 }
 
@@ -57,10 +54,10 @@ TEST(view_persist, wrap_temporary)
     EXPECT_RANGE_EQ("foo"sv, seqan3::views::persist(std::string{"foo"}));
 
     // combinability
-    EXPECT_RANGE_EQ("fo"sv, std::string{"foo"} | seqan3::views::persist | ranges::views::unique);
+    EXPECT_RANGE_EQ("fo"sv, std::string{"foo"} | seqan3::views::persist | std::views::take(2));
     EXPECT_RANGE_EQ("o"sv, std::string{"foo"} | seqan3::views::persist
                                               | std::views::filter([](char const chr){return chr == 'o';})
-                                              | ranges::views::unique);
+                                              | std::views::take(1));
 }
 
 TEST(view_persist, const)

--- a/test/unit/range/views/slice_test.cpp
+++ b/test/unit/range/views/slice_test.cpp
@@ -14,8 +14,6 @@
 #include <string>
 #include <vector>
 
-#include <range/v3/view/unique.hpp>
-
 #include <seqan3/range/views/single_pass_input.hpp>
 #include <seqan3/range/views/slice.hpp>
 #include <seqan3/test/expect_range_eq.hpp>
@@ -38,19 +36,19 @@ TEST(view_slice, regular)
     EXPECT_RANGE_EQ("oob"sv, seqan3::views::slice(vec, 1, 4));
 
     // combinability
-    EXPECT_RANGE_EQ("o"sv, vec | seqan3::views::slice(0, 4) | seqan3::views::slice(1, 3) | ranges::views::unique);
-    EXPECT_RANGE_EQ("abo"sv, vec | std::views::reverse | seqan3::views::slice(1, 4) | ranges::views::unique);
+    EXPECT_RANGE_EQ("o"sv, vec | seqan3::views::slice(0, 4) | seqan3::views::slice(1, 3) | std::views::take(1));
+    EXPECT_RANGE_EQ("abo"sv, vec | std::views::reverse | seqan3::views::slice(1, 4) | std::views::take(3));
 
     // store arg
     auto a0 = seqan3::views::slice(1, 4);
     EXPECT_RANGE_EQ("oob"sv, vec | a0);
 
     // store combined
-    auto a1 = seqan3::views::slice(0, 4) | seqan3::views::slice(1, 3) | ranges::views::unique;
+    auto a1 = seqan3::views::slice(0, 4) | seqan3::views::slice(1, 3) | std::views::take(1);
     EXPECT_RANGE_EQ("o"sv, vec | a1);
 
     // store combined in middle
-    auto a2 = std::views::reverse | seqan3::views::slice(1, 4) | ranges::views::unique;
+    auto a2 = std::views::reverse | seqan3::views::slice(1, 4) | std::views::take(3);
     EXPECT_RANGE_EQ("abo"sv, vec | a2);
 }
 

--- a/test/unit/range/views/take_line_test.cpp
+++ b/test/unit/range/views/take_line_test.cpp
@@ -9,9 +9,6 @@
 
 #include <seqan3/std/ranges>
 
-#include <range/v3/algorithm/copy.hpp>
-#include <range/v3/view/unique.hpp>
-
 #include <seqan3/range/views/single_pass_input.hpp>
 #include <seqan3/range/views/take_line.hpp>
 #include <seqan3/test/expect_range_eq.hpp>
@@ -32,8 +29,8 @@ void do_test(adaptor_t const & adaptor, std::string const & vec)
     EXPECT_RANGE_EQ("foo"sv, adaptor(vec));
 
     // combinability
-    EXPECT_RANGE_EQ("fo"sv, vec | adaptor | ranges::views::unique);
-    EXPECT_RANGE_EQ("rab"sv, vec | std::views::reverse | adaptor | ranges::views::unique);
+    EXPECT_RANGE_EQ("fo"sv, vec | adaptor | std::views::take(2));
+    EXPECT_RANGE_EQ("rab"sv, vec | std::views::reverse | adaptor | std::views::take(3));
 
     // consuming behaviour
     auto v4 = vec | seqan3::views::single_pass_input;

--- a/test/unit/range/views/take_test.cpp
+++ b/test/unit/range/views/take_test.cpp
@@ -15,8 +15,6 @@
 #include <string>
 #include <vector>
 
-#include <range/v3/view/unique.hpp>
-
 #include <seqan3/range/concept.hpp>
 #include <seqan3/range/container/concept.hpp>
 #include <seqan3/range/views/single_pass_input.hpp>
@@ -41,8 +39,8 @@ void do_test(adaptor_t const & adaptor, std::string const & vec)
     EXPECT_RANGE_EQ("foo"sv, adaptor(vec, 3));
 
     // combinability
-    EXPECT_RANGE_EQ("fo"sv, vec | adaptor(3) | adaptor(3) | ranges::views::unique);
-    EXPECT_RANGE_EQ("rab"sv, vec | std::views::reverse | adaptor(3) | ranges::views::unique);
+    EXPECT_RANGE_EQ("fo"sv, vec | adaptor(3) | adaptor(3) | std::views::take(2));
+    EXPECT_RANGE_EQ("rab"sv, vec | std::views::reverse | adaptor(3) | std::views::take(3));
 }
 
 template <typename adaptor_t>

--- a/test/unit/range/views/take_until_test.cpp
+++ b/test/unit/range/views/take_until_test.cpp
@@ -11,8 +11,6 @@
 #include <seqan3/std/ranges>
 #include <seqan3/std/span>
 
-#include <range/v3/view/unique.hpp>
-
 #include <seqan3/range/views/single_pass_input.hpp>
 #include <seqan3/range/views/take_until.hpp>
 #include <seqan3/test/expect_range_eq.hpp>
@@ -33,8 +31,8 @@ void do_test(adaptor_t const & adaptor, fun_t && fun, std::string const & vec)
     EXPECT_RANGE_EQ("foo"sv, adaptor(vec, fun));
 
     // combinability
-    EXPECT_RANGE_EQ("fo"sv, vec | adaptor(fun) | ranges::views::unique);
-    EXPECT_RANGE_EQ("rab"sv, vec | std::views::reverse | adaptor(fun) | ranges::views::unique);
+    EXPECT_RANGE_EQ("fo"sv, vec | adaptor(fun) | std::views::take(2));
+    EXPECT_RANGE_EQ("rab"sv, vec | std::views::reverse | adaptor(fun) | std::views::take(3));
 
     // Test combinability of take_until with std::reverse as second view, this caused a problem here:
     // https://github.com/seqan/seqan3/issues/1754


### PR DESCRIPTION
This exchanges some range-v3 exclusive views by std::views that produce the same result.

Part of https://github.com/seqan/product_backlog/issues/124