### PR TITLE
[MISC] deprecate seqan3::output_file_validator constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,7 +108,7 @@ If possible, provide tooling that performs the changes, e.g. a shell-script.
 
 #### Argument Parser
 
-* `seqan3::output_file_validator` can't be constructed with the extension list alone any more, you need to specify one
+* `seqan3::output_file_validator` cannot be constructed with the extension list alone anymore, you need to specify one
   of the seqan3::output_file_open_options options.
   ([\#2009](https://github.com/seqan/seqan3/pull/2009)).
 * The enum names of `seqan3::option_spec` were changed to lower case

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,9 @@ If possible, provide tooling that performs the changes, e.g. a shell-script.
 
 #### Argument Parser
 
+* `seqan3::output_file_validator` can't be constructed with the extension list alone any more, you need to specify one
+  of the seqan3::output_file_open_options options.
+  ([\#2009](https://github.com/seqan/seqan3/pull/2009)).
 * The enum names of `seqan3::option_spec` were changed to lower case
   ([\#2285](https://github.com/seqan/seqan3/pull/2285)):
   * `seqan3::option_spec::DEFAULT` is replaced by `seqan3::option_spec::standard`.

--- a/include/seqan3/argument_parser/validators.hpp
+++ b/include/seqan3/argument_parser/validators.hpp
@@ -653,6 +653,13 @@ public:
     output_file_validator & operator=(output_file_validator &&) = default; //!< Defaulted.
     virtual ~output_file_validator() = default; //!< Virtual Destructor.
 
+#ifdef SEQAN3_DEPRECATED_310
+    //!\deprecated use seqan3::output_file_validator::output_file_validator(mode, extensions)
+    SEQAN3_DEPRECATED_310 explicit output_file_validator(std::vector<std::string> extensions)
+        : output_file_validator{output_file_open_options::create_new, extensions}
+    {}
+#endif // SEQAN3_DEPRECATED_310
+
     /*!\brief Constructs from a given overwrite mode and a list of valid extensions.
      * \param[in] mode A seqan3::output_file_open_options indicating whether the validator throws if a file already
                        exists.


### PR DESCRIPTION
This PR re-introduces a deleted constructor (change made in c94d2514e5295be0e507d4a2638f5c7630962e8e) and properly deprecates it.

This makes the upgrade-path from 3.0.2 to 3.0.3 easier.