### PR TITLE
[MISC] seqan3::range_compatible deprecation should be concept-like

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,11 @@ If possible, provide tooling that performs the changes, e.g. a shell-script.
   * `seqan3::option_spec::ADVANCED` is replaced by `seqan3::option_spec::advanced`.
   * `seqan3::option_spec::HIDDEN` is replaced by `seqan3::option_spec::hidden`.
 
+#### Core
+
+* We deprecated seqan3::range_compatible_concept and it will be removed in 3.1.0.
+  ([\#2265](https://github.com/seqan/seqan3/pull/2265))
+
 #### I/O
 
 * The `seqan3::get` accessor for I/O records, e.g. `seqan3::get<seqan3::field::id>(record)`, is deprecated, please use

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,8 +117,8 @@ If possible, provide tooling that performs the changes, e.g. a shell-script.
 
 #### Core
 
-* We deprecated seqan3::range_compatible_concept and it will be removed in 3.1.0.
-  ([\#2265](https://github.com/seqan/seqan3/pull/2265))
+* We deprecated seqan3::range_compatible_concept and it will be removed in 3.1.0
+  ([\#2265](https://github.com/seqan/seqan3/pull/2265)).
 
 #### I/O
 

--- a/include/seqan3/core/range/type_traits.hpp
+++ b/include/seqan3/core/range/type_traits.hpp
@@ -269,18 +269,28 @@ constexpr size_t range_dimension_v<t> = range_dimension_v<std::ranges::range_val
 // range_compatible [DEPRECATED]
 // ----------------------------------------------------------------------------
 
+#ifdef SEQAN3_DEPRECATED_310
 /*!\interface seqan3::range_compatible <>
  * \brief Two types are "compatible" if their seqan3::range_dimension_v and their seqan3::range_innermost_value_t are
  * the same.
  * \deprecated This concept is deprecated and will be removed in SeqAn-3.1.
  */
 //!\cond
+namespace deprecated
+{
 template <typename t1, typename t2>
-SEQAN3_DEPRECATED_310 constexpr bool range_compatible = (
-    std::is_same_v<range_innermost_value_t<t1>, range_innermost_value_t<t2>> &&
-    range_dimension_v<t1> == range_dimension_v<t2>
-);
+SEQAN3_CONCEPT range_compatible_concept = requires (t1, t2)
+{
+    requires (range_dimension_v<t1> == range_dimension_v<t2>);
+
+    requires std::is_same_v<range_innermost_value_t<t1>, range_innermost_value_t<t2>>;
+};
+} // namespace seqan3::deprecated
+
+template <typename t1, typename t2>
+SEQAN3_DEPRECATED_310 constexpr bool range_compatible = deprecated::range_compatible_concept<t1, t2>;
 //!\endcond
+#endif // SEQAN3_DEPRECATED_310
 
 //!\}
 


### PR DESCRIPTION
This PR makes the old seqan3::range_compatible concept (change made in aa1ed00bd4abf8c74e9df10bf433b9442e6969fd) work again with false inputs (SFINAE-friendly).

Before, `seqan3::range_compatible<int, int>` gave a hard compiler
error.

This makes the upgrade-path from 3.0.2 to 3.0.3 easier.