### PR TITLE
[MISC] deprecate seqan3::[bi_]fm_index[_cursor]_specialisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,13 @@ If possible, provide tooling that performs the changes, e.g. a shell-script.
     * `seqan3::get<seqan3::field::cigar>(record)` => `record.cigar_sequence()`
     * `seqan3::get<seqan3::field::tags>(record)` => `record.tags()`
 
+#### Search
+
+* We removed the concepts seqan3::[bi_]fm_index[_cursor]_specialisation. We did this, because we currently have only one
+  kind of each implementation and aren't completely sure if the current formulation of the concepts is the right one. If
+  you used those concepts, you can check whether the cursor type is seqan3::[bi_]fm_index_cursor as a substitute.
+  ([\#2348](https://github.com/seqan/seqan3/pull/2348))
+
 # 3.0.2
 
 Note that 3.1.0 will be the first API stable release and interfaces in this release might still change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,10 +152,10 @@ If possible, provide tooling that performs the changes, e.g. a shell-script.
 
 #### Search
 
-* We removed the concepts seqan3::[bi_]fm_index[_cursor]_specialisation. We did this, because we currently have only one
-  kind of each implementation and aren't completely sure if the current formulation of the concepts is the right one. If
-  you used those concepts, you can check whether the cursor type is seqan3::[bi_]fm_index_cursor as a substitute.
-  ([\#2348](https://github.com/seqan/seqan3/pull/2348))
+* We removed the concepts seqan3::[bi_]fm_index[_cursor]_specialisation. We did this because we currently have only one
+  implementation modelling each concept and are not completely sure if the current definition of the concepts is the 
+  right one. If you used those concepts, you can check whether the cursor type is seqan3::[bi_]fm_index_cursor as a 
+  substitute. ([\#2348](https://github.com/seqan/seqan3/pull/2348))
 
 # 3.0.2
 

--- a/include/seqan3/search/fm_index/concept.hpp
+++ b/include/seqan3/search/fm_index/concept.hpp
@@ -86,4 +86,226 @@ enum text_layout : bool
     collection
 };
 
+#ifdef SEQAN3_DEPRECATED_310
+// ============================================================================
+//  fm_index_specialisation
+// ============================================================================
+
+/*!\interface seqan3::fm_index_specialisation <>
+ * \brief Concept for unidirectional FM indices.
+ *
+ * This concept defines the interface for unidirectional FM indices.
+ *
+ * \deprecated Use seqan3::detail::template_specialisation_of<typename t::cursor_type, seqan3::fm_index_cursor>
+ *             instead.
+ */
+//!\cond
+namespace deprecated
+{
+template <typename t>
+SEQAN3_CONCEPT fm_index_specialisation_concept = std::semiregular<t> && requires (t index)
+{
+    typename t::alphabet_type;
+    typename t::size_type;
+    typename t::cursor_type;
+
+    // NOTE: circular dependency
+    // requires detail::template_specialisation_of<typename t::cursor_type, fm_index_cursor>;
+    requires requires (t index, std::conditional_t<t::text_layout_mode == text_layout::collection,
+                                                   std::vector<std::vector<typename t::alphabet_type>>,
+                                                   std::vector<typename t::alphabet_type>> const text)
+    {
+        { t(text) };
+    };
+
+    SEQAN3_RETURN_TYPE_CONSTRAINT(index.cursor(), std::same_as, typename t::cursor_type);
+
+    SEQAN3_RETURN_TYPE_CONSTRAINT(index.size(), std::same_as, typename t::size_type);
+    SEQAN3_RETURN_TYPE_CONSTRAINT(index.empty(), std::same_as, bool);
+};
+} // namespace seqan3::deprecated
+
+template <typename t>
+SEQAN3_DEPRECATED_310 constexpr bool fm_index_specialisation = deprecated::fm_index_specialisation_concept<t>;
+
+//!\endcond
+/*!\name Requirements for seqan3::fm_index_specialisation
+ * \relates seqan3::fm_index_specialisation
+ * \brief You can expect these member types and member functions on all types that satisfy seqan3::fm_index_specialisation.
+ * \{
+ *
+ * \typedef typename t::text_type text_type
+ * \brief Type of the indexed text.
+ *
+ * \typedef typename t::alphabet_type alphabet_type
+ * \brief Type of the underlying character of text_type.
+ *
+ * \typedef typename t::size_type size_type
+ * \brief Type for representing the size of the indexed text.
+ *
+ * \typedef typename t::cursor_type cursor_type
+ * \brief Type of the unidirectional FM index cursor.
+ * \}
+ */
+
+/*!\interface seqan3::fm_index_cursor_specialisation <>
+ * \brief Concept for unidirectional FM index cursors.
+ *
+ * This concept defines the interface for cursors for unidirectional FM indices.
+ *
+ * \deprecated Use seqan3::detail::template_specialisation_of<t, seqan3::fm_index_cursor> instead.
+ */
+//!\cond
+namespace deprecated
+{
+template <typename t>
+SEQAN3_CONCEPT fm_index_cursor_specialisation_concept = std::semiregular<t> && requires (t cur)
+{
+    typename t::index_type;
+    typename t::size_type;
+
+    requires fm_index_specialisation<typename t::index_type>;
+
+    requires requires (typename t::index_type const index) { { t(index) }; };
+
+    requires requires (t cur,
+                       typename t::index_type::alphabet_type const c,
+                       std::vector<typename t::index_type::alphabet_type> const seq,
+                       std::conditional_t<t::index_type::text_layout_mode == text_layout::collection,
+                                          std::vector<std::vector<typename t::index_type::alphabet_type>>,
+                                          std::vector<typename t::index_type::alphabet_type>> const text)
+    {
+        SEQAN3_RETURN_TYPE_CONSTRAINT(cur.extend_right(), std::same_as, bool);
+        SEQAN3_RETURN_TYPE_CONSTRAINT(cur.extend_right(c), std::same_as, bool);
+        SEQAN3_RETURN_TYPE_CONSTRAINT(cur.extend_right(seq), std::same_as, bool);
+        SEQAN3_RETURN_TYPE_CONSTRAINT(cur.cycle_back(), std::same_as, bool);
+        { cur.path_label(text) };
+    };
+
+    SEQAN3_RETURN_TYPE_CONSTRAINT(cur.last_rank(), std::same_as, typename t::size_type);
+    SEQAN3_RETURN_TYPE_CONSTRAINT(cur.query_length(), std::same_as, typename t::size_type);
+    SEQAN3_RETURN_TYPE_CONSTRAINT(cur.count(), std::same_as, typename t::size_type);
+    SEQAN3_RETURN_TYPE_CONSTRAINT(cur.locate(),
+                                  std::same_as, std::vector<std::pair<typename t::size_type, typename t::size_type>>);
+    { cur.lazy_locate() };
+};
+} // namespace seqan3::deprecated
+
+template <typename t>
+SEQAN3_DEPRECATED_310 constexpr bool fm_index_cursor_specialisation = deprecated::fm_index_cursor_specialisation_concept<t>;
+//!\endcond
+/*!\name Requirements for seqan3::fm_index_cursor_specialisation
+ * \relates seqan3::fm_index_cursor_specialisation
+ * \brief You can expect these member types and member functions on all types that satisfy seqan3::fm_index_cursor_specialisation.
+ * \{
+ *
+ * \typedef typename t::index_type index_type
+ * \brief Type of the underlying SeqAn FM index (not the underlying SDSL index).
+ *
+ * \typedef typename t::size_type size_type
+ * \brief Type for representing the size of the indexed text.
+ * \}
+ */
+
+// ============================================================================
+//  bi_fm_index_specialisation
+// ============================================================================
+
+/*!\interface seqan3::bi_fm_index_specialisation <>
+ * \brief Concept for bidirectional FM indices.
+ *
+ * This concept defines the interface for bidirectional FM indices.
+ *
+ * \deprecated Use seqan3::detail::template_specialisation_of<typename t::cursor_type, seqan3::bi_fm_index_cursor>
+ *             instead.
+ */
+//!\cond
+namespace deprecated
+{
+template <typename t>
+SEQAN3_CONCEPT bi_fm_index_specialisation_concept = fm_index_specialisation<t> && requires (t index)
+{
+    typename t::cursor_type; // already required by fm_index_specialisation but has a different documentation
+    typename t::fwd_cursor_type;
+
+    // NOTE: circular dependency
+    // requires detail::template_specialisation_of<typename t::cursor_type, bi_fm_index_cursor>;
+
+    SEQAN3_RETURN_TYPE_CONSTRAINT(index.fwd_cursor(), std::same_as, typename t::fwd_cursor_type);
+};
+} // namespace seqan3::deprecated
+
+template <typename t>
+SEQAN3_DEPRECATED_310 constexpr bool bi_fm_index_specialisation = deprecated::bi_fm_index_specialisation_concept<t>;
+
+//!\endcond
+/*!\name Requirements for seqan3::bi_fm_index_specialisation
+ * \relates seqan3::bi_fm_index_specialisation
+ * \brief You can expect these member types and member functions on all types that satisfy seqan3::bi_fm_index_specialisation.
+ * \{
+ *
+ * \typedef typename t::cursor_type cursor_type
+ * \brief Type of the bidirectional FM index cursor.
+ *
+ * \typedef typename t::fwd_cursor_type fwd_cursor_type
+ * \brief Type of the unidirectional FM index cursor based on the unidirectional FM index on the original text.
+ * \}
+ */
+
+// ============================================================================
+//  bi_fm_index_cursor_specialisation
+// ============================================================================
+
+/*!\interface seqan3::bi_fm_index_cursor_specialisation <>
+ * \brief Concept for bidirectional FM index cursors.
+ *
+ * This concept defines the interface for cursors for bidirectional FM indices.
+ *
+ * \deprecated Use seqan3::detail::template_specialisation_of<t, seqan3::bi_fm_index_cursor> instead.
+ */
+//!\cond
+namespace deprecated
+{
+template <typename t>
+SEQAN3_CONCEPT bi_fm_index_cursor_specialisation_concept = fm_index_cursor_specialisation<t> && requires (t cur)
+{
+    requires bi_fm_index_specialisation<typename t::index_type>;
+
+    requires requires (typename t::index_type const index) { { t(index) }; };
+
+    requires requires (t cur,
+                       typename t::index_type::alphabet_type const c,
+                       std::vector<typename t::index_type::alphabet_type> const seq)
+    {
+        SEQAN3_RETURN_TYPE_CONSTRAINT(cur.extend_left(), std::same_as, bool);
+        SEQAN3_RETURN_TYPE_CONSTRAINT(cur.extend_left(c), std::same_as, bool);
+        SEQAN3_RETURN_TYPE_CONSTRAINT(cur.extend_left(seq), std::same_as, bool);
+        SEQAN3_RETURN_TYPE_CONSTRAINT(cur.cycle_front(), std::same_as, bool);
+    };
+
+};
+} // namespace seqan3::deprecated
+
+template <typename t>
+SEQAN3_DEPRECATED_310 constexpr bool bi_fm_index_cursor_specialisation
+    = deprecated::bi_fm_index_cursor_specialisation_concept<t>;
+
+//!\endcond
+/*!\name Requirements for seqan3::bi_fm_index_cursor_specialisation
+ * \relates seqan3::bi_fm_index_cursor_specialisation
+ * \brief You can expect these member types and member functions on all types that satisfy
+ *        seqan3::fm_index_cursor_specialisation.
+ * \{
+ *
+ * \typedef typename t::index_type index_type
+ * \brief Type of the underlying SeqAn FM index (not the underlying SDSL index).
+ *
+ * \typedef typename t::size_type size_type
+ * \brief Type for representing the size of the indexed text.
+ * \}
+ */
+
+//!\}
+#endif // SEQAN3_DEPRECATED_310
+
 } // namespace seqan3


### PR DESCRIPTION
This PR re-introduces deleted concepts (810a135b37053940d469a03c62a6ca410865d5c0 and 68b5874b9893cdda3e7baa74c9725d407d03f2d7) and properly deprecates it.

This makes the upgrade-path from 3.0.2 to 3.0.3 easier.