### PR TITLE
[MISC] deprecate seqan3::argument_parser constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,8 @@ If possible, provide tooling that performs the changes, e.g. a shell-script.
 
 #### Argument Parser
 
-* The `seqan3::argument_parser` constructor was changed to accept a strong-type seqan3::update_notifications::on/off
-  instead of a simple bool (which was suspect to unexpected implicit conversion)
+* The `seqan3::argument_parser` constructor was changed to accept a strong-type `seqan3::update_notifications::(on|off)`
+  instead of a simple bool (which was subject to unexpected implicit conversion)
   ([\#2180](https://github.com/seqan/seqan3/pull/2180)).
 * We expanded the `seqan3::output_file_validator`, with a parameter `seqan3::output_file_open_options` to allow overwriting
   output files ([\#2009](https://github.com/seqan/seqan3/pull/2009)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ If possible, provide tooling that performs the changes, e.g. a shell-script.
 
 #### Argument Parser
 
+* The `seqan3::argument_parser` constructor was changed to accept a strong-type seqan3::update_notifications::on/off
+  instead of a simple bool (which was suspect to unexpected implicit conversion)
+  ([\#2180](https://github.com/seqan/seqan3/pull/2180)).
 * We expanded the `seqan3::output_file_validator`, with a parameter `seqan3::output_file_open_options` to allow overwriting
   output files ([\#2009](https://github.com/seqan/seqan3/pull/2009)).
 * The `seqan3::argument_parser` has a new member function `seqan3::argument_parser::is_option_set` that

--- a/include/seqan3/argument_parser/argument_parser.hpp
+++ b/include/seqan3/argument_parser/argument_parser.hpp
@@ -163,7 +163,7 @@ public:
     argument_parser & operator=(argument_parser &&) = default;      //!< Defaulted.
 
 #ifdef SEQAN3_DEPRECATED_310
-    //!\deprecated Please use seqan3::update_notifications::on if version_updates == true.
+    //!\deprecated Please use seqan3::update_notifications::on or seqan3::update_notifications::off for `version_updates`.
     SEQAN3_DEPRECATED_310
     argument_parser(std::string const app_name,
                     int const argc,

--- a/include/seqan3/argument_parser/argument_parser.hpp
+++ b/include/seqan3/argument_parser/argument_parser.hpp
@@ -162,6 +162,25 @@ public:
     argument_parser(argument_parser &&) = default;                  //!< Defaulted.
     argument_parser & operator=(argument_parser &&) = default;      //!< Defaulted.
 
+#ifdef SEQAN3_DEPRECATED_310
+    //!\deprecated Please use seqan3::update_notifications::on if version_updates == true.
+    SEQAN3_DEPRECATED_310
+    argument_parser(std::string const app_name,
+                    int const argc,
+                    char const * const * const  argv,
+                    bool version_updates,
+                    std::vector<std::string> subcommands = {}) :
+        argument_parser
+        {
+            app_name,
+            argc,
+            argv,
+            version_updates ? update_notifications::on : update_notifications::off,
+            subcommands
+        }
+    {}
+#endif // SEQAN3_DEPRECATED_310
+
     /*!\brief Initializes an seqan3::argument_parser object from the command line arguments.
      *
      * \param[in] app_name The name of the app that is displayed on the help page.


### PR DESCRIPTION
This PR re-introduces a deleted constructor (change made in 6d2e7635e21597066cbcd3bb1dbcf77aeb7884f1) and properly deprecates it.

This makes the upgrade-path from 3.0.2 to 3.0.3 easier.