### PR TITLE
[FIX] Fix unhelpful message with help_page_message of the validator

### DIFF
--- a/include/seqan3/argument_parser/detail/format_parse.hpp
+++ b/include/seqan3/argument_parser/detail/format_parse.hpp
@@ -313,8 +313,8 @@ private:
      * \tparam option_t Must model seqan3::named_enumeration.
      * \param[out] value Stores the parsed value.
      * \param[in] in The input argument to be parsed.
-     * \returns seqan3::option_parse_result::error if `in` could not be found in the
-     *          seqan3::enumeration_names<option_t> map and otherwise seqan3::option_parse_result::success.
+     * \throws seqan3::user_input_error if `in` is not a key in seqan3::enumeration_names<option_t>.
+     * \returns seqan3::option_parse_result::success.
      */
     template <named_enumeration option_t>
     option_parse_result parse_option_value(option_t & value, std::string const & in)
@@ -322,9 +322,14 @@ private:
         auto map = seqan3::enumeration_names<option_t>;
 
         if (auto it = map.find(in); it == map.end())
-            return option_parse_result::error;
+        {
+            throw user_input_error{detail::to_string("You have chosen an invalid input value: ", in,
+                                                     ". Please use one of: ", map | std::views::keys)};
+        }
         else
+        {
             value = it->second;
+        }
 
         return option_parse_result::success;
     }

--- a/include/seqan3/std/ranges
+++ b/include/seqan3/std/ranges
@@ -246,7 +246,7 @@ namespace views { using ::ranges::cpp20::views::reverse; }
 namespace views
 {
 // using ::ranges::cpp20::views::elements;
-// using ::ranges::cpp20::views::keys;
+using ::ranges::cpp20::views::keys;
 using ::ranges::cpp20::views::values;
 } // namespace views
 

--- a/test/unit/argument_parser/format_parse_test.cpp
+++ b/test/unit/argument_parser/format_parse_test.cpp
@@ -569,78 +569,6 @@ TEST(parse_type_test, parse_error_double_option)
     EXPECT_THROW(parser2.parse(), seqan3::argument_parser_error);
 }
 
-namespace foo
-{
-enum class bar
-{
-    one,
-    two,
-    three
-};
-
-auto enumeration_names(bar)
-{
-    return std::unordered_map<std::string_view, bar>{{"one", bar::one}, {"two", bar::two}, {"three", bar::three}};
-}
-} // namespace foo
-
-namespace Other
-{
-enum class bar
-{
-    one,
-    two
-};
-} // namespace Other
-
-namespace seqan3::custom
-{
-template <>
-struct argument_parsing<Other::bar>
-{
-    static inline std::unordered_map<std::string_view, Other::bar> const enumeration_names
-    {
-        {"one", Other::bar::one}, {"two", Other::bar::two}
-    };
-};
-} // namespace seqan3::custom
-
-TEST(parse_type_test, parse_success_enum_option)
-{
-    {
-        foo::bar option_value{};
-
-        const char * argv[] = {"./argument_parser_test", "-e", "two"};
-        seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
-        parser.add_option(option_value, 'e', "enum-option", "this is an enum option.");
-
-        EXPECT_NO_THROW(parser.parse());
-        EXPECT_TRUE(option_value == foo::bar::two);
-    }
-
-    {
-        Other::bar option_value{};
-
-        const char * argv[] = {"./argument_parser_test", "-e", "two"};
-        seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
-        parser.add_option(option_value, 'e', "enum-option", "this is an enum option.");
-
-        EXPECT_NO_THROW(parser.parse());
-        EXPECT_TRUE(option_value == Other::bar::two);
-    }
-}
-
-TEST(parse_type_test, parse_error_enum_option)
-{
-    foo::bar option_value{};
-
-    const char * argv[] = {"./argument_parser_test", "-e", "four"};
-    seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
-    parser.add_option(option_value, 'e', "enum-option", "this is an enum option.");
-
-    EXPECT_THROW(parser.parse(), seqan3::argument_parser_error);
-}
-
 TEST(parse_test, too_many_arguments_error)
 {
     int option_value;
@@ -911,10 +839,10 @@ TEST(parse_test, subcommand_argument_parser_success)
     {
         const char * argv[]{"./top_level", "-f", "sub1", "-h"};
         seqan3::argument_parser top_level_parser{"top_level",
-                                          4,
-                                          argv,
-                                          seqan3::update_notifications::off,
-                                          {"sub1", "sub2"}};
+                                                 4,
+                                                 argv,
+                                                 seqan3::update_notifications::off,
+                                                 {"sub1", "sub2"}};
         top_level_parser.add_flag(flag_value, 'f', "foo", "foo bar");
 
         EXPECT_NO_THROW(top_level_parser.parse());
@@ -1026,6 +954,118 @@ TEST(parse_test, is_option_set)
     EXPECT_THROW(parser.is_option_set('-'), seqan3::design_error);
     EXPECT_THROW(parser.is_option_set('_'), seqan3::design_error);
     EXPECT_THROW(parser.is_option_set('\0'), seqan3::design_error);
+}
+
+namespace foo
+{
+enum class bar
+{
+    one,
+    two,
+    three
+};
+
+auto enumeration_names(bar)
+{
+    return std::unordered_map<std::string_view, bar>{{"one", bar::one}, {"two", bar::two}, {"three", bar::three}};
+}
+} // namespace foo
+
+namespace Other
+{
+enum class bar
+{
+    one,
+    two
+};
+} // namespace Other
+
+namespace seqan3::custom
+{
+template <>
+struct argument_parsing<Other::bar>
+{
+    static inline std::unordered_map<std::string_view, Other::bar> const enumeration_names
+    {
+        {"one", Other::bar::one}, {"two", Other::bar::two}
+    };
+};
+} // namespace seqan3::custom
+
+TEST(parse_type_test, parse_success_enum_option)
+{
+    {
+        foo::bar option_value{};
+
+        const char * argv[] = {"./argument_parser_test", "-e", "two"};
+        seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
+        parser.add_option(option_value, 'e', "enum-option", "this is an enum option.");
+
+        EXPECT_NO_THROW(parser.parse());
+        EXPECT_TRUE(option_value == foo::bar::two);
+    }
+
+    {
+        Other::bar option_value{};
+
+        const char * argv[] = {"./argument_parser_test", "-e", "two"};
+        seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
+        parser.add_option(option_value, 'e', "enum-option", "this is an enum option.");
+
+        EXPECT_NO_THROW(parser.parse());
+        EXPECT_TRUE(option_value == Other::bar::two);
+    }
+}
+
+TEST(parse_type_test, parse_error_enum_option)
+{
+    foo::bar option_value{};
+
+    const char * argv[] = {"./argument_parser_test", "-e", "four"};
+    seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
+    parser.add_option(option_value, 'e', "enum-option", "this is an enum option.");
+
+    EXPECT_THROW(parser.parse(), seqan3::user_input_error);
+}
+
+// https://github.com/seqan/seqan3/issues/2464
+TEST(parse_test, issue2464)
+{
+    using option_t = foo::bar;
+
+    seqan3::value_list_validator enum_validator{(seqan3::enumeration_names<option_t> | std::views::values)};
+    option_t option_value{};
+    std::vector<option_t> option_values{};
+
+    // Using a non-existing value of foo::bar should throw.
+    {
+        const char * argv[] = {"./argument_parser_test", "-e", "nine"};
+        seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
+        parser.add_option(option_value, 'e', "enum-option", "this is an enum option.");
+        EXPECT_THROW(parser.parse(), seqan3::user_input_error);
+    }
+    {
+        const char * argv[] = {"./argument_parser_test", "-e", "one", "-e", "nine"};
+        seqan3::argument_parser parser{"test_parser", 5, argv, seqan3::update_notifications::off};
+        parser.add_option(option_values, 'e', "enum-option", "this is an enum option.");
+        EXPECT_THROW(parser.parse(), seqan3::user_input_error);
+    }
+
+    // The validator does not handle invalid inputs for enums. (No seqan3::validation_error)
+    {
+        const char * argv[] = {"./argument_parser_test", "-e", "nine"};
+        seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
+        parser.add_option(option_value, 'e', "enum-option", "this is an enum option.", seqan3::option_spec::advanced,
+                          enum_validator);
+        EXPECT_THROW(parser.parse(), seqan3::user_input_error);
+    }
+    {
+        const char * argv[] = {"./argument_parser_test", "-e", "one", "-e", "nine"};
+        seqan3::argument_parser parser{"test_parser", 5, argv, seqan3::update_notifications::off};
+        parser.add_option(option_values, 'e', "enum-option", "this is an enum option.", seqan3::option_spec::advanced,
+                          enum_validator);
+        EXPECT_THROW(parser.parse(), seqan3::user_input_error);
+    }
 }
 
 // https://github.com/seqan/seqan3/pull/2381

--- a/test/unit/argument_parser/format_parse_test.cpp
+++ b/test/unit/argument_parser/format_parse_test.cpp
@@ -1034,26 +1034,34 @@ TEST(parse_test, issue2464)
     using option_t = foo::bar;
 
     seqan3::value_list_validator enum_validator{(seqan3::enumeration_names<option_t> | std::views::values)};
-    option_t option_value{};
-    std::vector<option_t> option_values{};
 
     // Using a non-existing value of foo::bar should throw.
     {
         const char * argv[] = {"./argument_parser_test", "-e", "nine"};
+
+        option_t option_value{};
+
         seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
         parser.add_option(option_value, 'e', "enum-option", "this is an enum option.");
         EXPECT_THROW(parser.parse(), seqan3::user_input_error);
     }
     {
         const char * argv[] = {"./argument_parser_test", "-e", "one", "-e", "nine"};
+
+        std::vector<option_t> option_values{};
+
         seqan3::argument_parser parser{"test_parser", 5, argv, seqan3::update_notifications::off};
         parser.add_option(option_values, 'e', "enum-option", "this is an enum option.");
         EXPECT_THROW(parser.parse(), seqan3::user_input_error);
     }
 
-    // The validator does not handle invalid inputs for enums. (No seqan3::validation_error)
+    // Invalid inputs for enums are handled before any validator is evaluated.
+    // Thus the exception will be seqan3::user_input_error and not seqan3::validation_error.
     {
         const char * argv[] = {"./argument_parser_test", "-e", "nine"};
+
+        option_t option_value{};
+
         seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
         parser.add_option(option_value, 'e', "enum-option", "this is an enum option.", seqan3::option_spec::advanced,
                           enum_validator);
@@ -1061,6 +1069,9 @@ TEST(parse_test, issue2464)
     }
     {
         const char * argv[] = {"./argument_parser_test", "-e", "one", "-e", "nine"};
+
+        std::vector<option_t> option_values{};
+
         seqan3::argument_parser parser{"test_parser", 5, argv, seqan3::update_notifications::off};
         parser.add_option(option_values, 'e', "enum-option", "this is an enum option.", seqan3::option_spec::advanced,
                           enum_validator);

--- a/test/unit/argument_parser/format_parse_test.cpp
+++ b/test/unit/argument_parser/format_parse_test.cpp
@@ -1032,9 +1032,6 @@ TEST(parse_type_test, parse_error_enum_option)
 TEST(parse_test, issue2464)
 {
     using option_t = foo::bar;
-
-    seqan3::value_list_validator enum_validator{(seqan3::enumeration_names<option_t> | std::views::values)};
-
     // Using a non-existing value of foo::bar should throw.
     {
         const char * argv[] = {"./argument_parser_test", "-e", "nine"};
@@ -1060,6 +1057,7 @@ TEST(parse_test, issue2464)
     {
         const char * argv[] = {"./argument_parser_test", "-e", "nine"};
 
+        seqan3::value_list_validator enum_validator{(seqan3::enumeration_names<option_t> | std::views::values)};
         option_t option_value{};
 
         seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
@@ -1070,6 +1068,7 @@ TEST(parse_test, issue2464)
     {
         const char * argv[] = {"./argument_parser_test", "-e", "one", "-e", "nine"};
 
+        seqan3::value_list_validator enum_validator{(seqan3::enumeration_names<option_t> | std::views::values)};
         std::vector<option_t> option_values{};
 
         seqan3::argument_parser parser{"test_parser", 5, argv, seqan3::update_notifications::off};


### PR DESCRIPTION
Resolves https://github.com/seqan/seqan3/issues/2464

The resolving test looks like:
```cpp
TEST_F(detect_breakends, test_unknown_argument)
{
    cli_test_result result = execute_app("iGenVar",
                                         "-j", data(default_alignment_long_reads_file_path),
                                         fasta_out_file_path,
                                         "-m 9");
    std::string expected_err
    {
        // Old message: "[Error] Value parse failed for -m: Argument 9 could not be parsed as type std::string.\n"
        "[Error] Validation failed for value 9.\n"
        "Value must be one of (method name or number) [cigar_string,0,split_read,1,read_pairs,2,read_depth,3].\n"
    };
    EXPECT_EQ(result.exit_code, 65280);
    EXPECT_EQ(result.out, std::string{});
    EXPECT_EQ(result.err, expected_err);
}
```