### PR TITLE
[FIX] use std::remove_cvref instead of seqan3::remove_cvref

### DIFF
--- a/include/seqan3/alignment/matrix/detail/affine_cell_proxy.hpp
+++ b/include/seqan3/alignment/matrix/detail/affine_cell_proxy.hpp
@@ -41,7 +41,7 @@ SEQAN3_CONCEPT arithmetic_or_simd = arithmetic<t> || simd_concept<t>;
  */
 //!\cond
 template <typename t>
-SEQAN3_CONCEPT tracedirections_or_simd = std::same_as<remove_cvref_t<t>, trace_directions> || simd_concept<t>;
+SEQAN3_CONCEPT tracedirections_or_simd = std::same_as<std::remove_cvref_t<t>, trace_directions> || simd_concept<t>;
 //!\endcond
 
 /*!\interface seqan3::detail::affine_score_cell <>

--- a/include/seqan3/alignment/matrix/detail/combined_score_and_trace_matrix.hpp
+++ b/include/seqan3/alignment/matrix/detail/combined_score_and_trace_matrix.hpp
@@ -50,7 +50,7 @@ class combined_score_and_trace_matrix
 {
 private:
     //!\brief The score type extracted from the score matrix. (TODO: make this less complicated by exposing the score type).
-    using score_type = remove_cvref_t<std::tuple_element_t<0, range_innermost_value_t<score_matrix_t>>>;
+    using score_type = std::remove_cvref_t<std::tuple_element_t<0, range_innermost_value_t<score_matrix_t>>>;
 
     class iterator;
     class sentinel;
@@ -189,10 +189,10 @@ private:
 
     //!\brief The transform adaptor to convert the tuple from the zip view into a seqan3::detail::affine_cell_type.
     static constexpr auto transform_to_combined_matrix_cell = std::views::transform([] (auto && tpl)
-        -> affine_cell_proxy<remove_cvref_t<decltype(tpl)>>
+        -> affine_cell_proxy<std::remove_cvref_t<decltype(tpl)>>
     {
         using fwd_tuple_t = decltype(tpl);
-        return affine_cell_proxy<remove_cvref_t<fwd_tuple_t>>{std::forward<fwd_tuple_t>(tpl)};
+        return affine_cell_proxy<std::remove_cvref_t<fwd_tuple_t>>{std::forward<fwd_tuple_t>(tpl)};
     });
 
     //!\brief The current iterator over the score matrix.


### PR DESCRIPTION
Some left-over of #2079 