### PR TITLE
[FIX] sandboxed_path shall not resolve symlinks

### DIFF
--- a/test/include/seqan3/test/sandboxed_path.hpp
+++ b/test/include/seqan3/test/sandboxed_path.hpp
@@ -221,7 +221,7 @@ private:
 
         std::filesystem::path::operator=(normalised_path);
 #else
-        auto normalised_path = std::filesystem::weakly_canonical(sandbox_directory / *this);
+        auto normalised_path = (sandbox_directory / *this).lexically_normal();
         std::filesystem::path::operator=(normalised_path);
 #endif
     }

--- a/test/unit/test/sandboxed_path_test.cpp
+++ b/test/unit/test/sandboxed_path_test.cpp
@@ -296,7 +296,7 @@ TEST(sandboxed_path_symbolic_link, symbolic_link)
     }
 
     // create symlink and a sandboxed_path
-    create_directory_symlink(tmp_base_dir, tmp_dir);
+    std::filesystem::create_directory_symlink(tmp_base_dir, tmp_dir);
     sandboxed_path path{tmp_dir};
 
     // check the sandboxed path did not resolve the symlink

--- a/test/unit/test/sandboxed_path_test.cpp
+++ b/test/unit/test/sandboxed_path_test.cpp
@@ -281,3 +281,27 @@ TEST(sandboxed_path_free_operator_append, free_operator_append)
 
     EXPECT_THROW(path / "../../../", fs::filesystem_error);
 }
+
+// Test special case when symbolic links are involved
+TEST(sandboxed_path_symbolic_link, symbolic_link)
+{
+    // We create a symbolic link from /tmp/seqan3_sandboxed_path_symbolic_link_test -> /tmp
+    auto tmp_base_dir = std::filesystem::temp_directory_path();
+    auto tmp_dir = tmp_base_dir / "seqan3_sandboxed_path_symbolic_link_test";
+
+    // if link already exists, remove it
+    if (std::filesystem::exists(tmp_dir))
+    {
+        std::filesystem::remove_all(tmp_dir);
+    }
+
+    // create symlink and a sandboxed_path
+    create_directory_symlink(tmp_base_dir, tmp_dir);
+    sandboxed_path path{tmp_dir};
+
+    // check the sandboxed path did not resolve the symlink
+    EXPECT_EQ(tmp_dir, path);
+
+    // Cleanup, remove link
+    std::filesystem::remove_all(tmp_dir);
+}


### PR DESCRIPTION
The old behaviour of `sandboxed_path` resolved symlinks if they existed on
the filesystem. This is not the indented behaviour.
`sandboxed_path` should not change behaviour depending on the physical
existence of symlinks.
This commits also adds a test preventing any regression bugs.