### PR TITLE
[FIX] argument_parser/file_validator_base accept derivatives of filesystem::path

### DIFF
--- a/include/seqan3/argument_parser/validators.hpp
+++ b/include/seqan3/argument_parser/validators.hpp
@@ -351,7 +351,8 @@ public:
      */
     template <std::ranges::forward_range range_type>
     //!\cond
-        requires std::convertible_to<std::ranges::range_value_t<range_type>, std::filesystem::path const &>
+        requires (std::convertible_to<std::ranges::range_value_t<range_type>, std::filesystem::path const &>
+                 && !std::convertible_to<range_type, std::filesystem::path const &>)
     //!\endcond
     void operator()(range_type const & v) const
     {


### PR DESCRIPTION
I want to hand over `sandboxed_path` to the validators. The
file_validator_base accidentally identifies `sandboxed_path` as a
useful forward_range to iterate over. It is sufficient if the
`std::filesystem::path const&` c'tor accepts the `sandboxed_path`.