### PR TITLE
[DOC] beginner friendly cmake documentation

### DIFF
--- a/doc/setup/library_tests/index.md
+++ b/doc/setup/library_tests/index.md
@@ -26,11 +26,11 @@ cd /home/me/devel/seqan3-build/debug
 Invoke CMake (this is often referred to as the "Configure" step):
 
 ```bash
-cmake ../../seqan3/test/unit -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=g++-7
+cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=g++-7 ../../seqan3/test/unit
 ```
 
-The build type could be "Release", but stick to "Debug" for now. Specifying the compiler is optional; depending on
-your setup, you may need to give the full path.
+The build type could be "Release", but stick to "Debug" if you aim to make contributions to the SeqAn3 codebase. 
+Specifying the compiler is optional; depending on your setup, you may need to give the full path.
 
 ### Building all unit tests
 
@@ -99,7 +99,7 @@ This will setup snippet tests:
 mkdir -p /home/me/devel/seqan3-build/snippet
 cd /home/me/devel/seqan3-build/snippet
 
-cmake ../../seqan3/test/snippet -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=g++-7
+cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=g++-7 ../../seqan3/test/snippet
 
 make -j 4
 

--- a/doc/setup/quickstart_cmake/index.md
+++ b/doc/setup/quickstart_cmake/index.md
@@ -134,14 +134,17 @@ tutorial
 Now we can switch to the directory `build` and run:
 
 ```bash
-cmake ../source
+cmake -DCMAKE_BUILD_TYPE=Release ../source
 make
 ./hello_world
 ```
 
-The output should be `Hello world`.
+The output should be `Hello world`. Note that the build type is specified with `-DCMAKE_BUILD_TYPE=Release`. 
+Specifying `Release` enables an optimized build where no debug information is available. Release mode is therefore 
+suitable for the end user. There is an example of a `Debug` build that is suitable for contributors in the next tutorial.
 
-\remark Depending on the standard C++ on your system, you may need to specify the compiler via `-DCMAKE_CXX_COMPILER=`, for example:
+\remark Depending on the standard C++ on your system, you may need to specify the compiler via `-DCMAKE_CXX_COMPILER=`, 
+for example:
 ```bash
 cmake -DCMAKE_CXX_COMPILER=/path/to/executable/g++-7 ../source
 ```

--- a/doc/setup/quickstart_cmake/index.md
+++ b/doc/setup/quickstart_cmake/index.md
@@ -143,7 +143,7 @@ The output should be `Hello world`.
 
 \remark Depending on the standard C++ on your system, you may need to specify the compiler via `-DCMAKE_CXX_COMPILER=`, for example:
 ```bash
-cmake ../source -DCMAKE_CXX_COMPILER=/path/to/executable/g++-7
+cmake -DCMAKE_CXX_COMPILER=/path/to/executable/g++-7 ../source
 ```
 
 \note In some situations it can happen that the correct assembler is not found.


### PR DESCRIPTION
This PR resolves  #2017

- `cmake` options now come before arguments in the example bash commands
- added explanation about `Release` vs `Debug` builds