### PR TITLE
[FIX] use absolute paths in codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,8 +388,8 @@ jobs:
         if: matrix.build == 'coverage'
         uses: codecov/codecov-action@v1
         with:
-          files: ./seqan3-build/seqan3_coverage
-          root_dir: ./seqan3
+          files: ${{ github.workspace }}/seqan3-build/seqan3_coverage
+          root_dir: ${{ github.workspace }}/seqan3
 
       - name: Package documentation
         if: matrix.build == 'documentation'


### PR DESCRIPTION
The wild coverage change is due to https://docs.codecov.io/docs/fixing-reports now working,

coverage is now not reported for lines like
```cpp
{
```
, i.e., lines only containing a single symbol from `{}()`.

we apparently had 614 such occurrences.
One of them was apparently a miss.
So we "lost" 613 hits and 1 miss.

All in all that means that our coverage did not decrease, because we did not gain any misses.
But from a relative POV, we had `(10867 - 188) / 10867 = 0.9827` coverage before, but now only have `(10254 - 187) / 10254 = 0.9817` coverage.
See also: https://docs.codecov.io/docs/coverage-offset


TLDR; the coverage dropped because our coverage code base shrunk.