### PR TITLE
[INFRA] new api_stability test

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -106,6 +106,7 @@ assignees: ''
 
 - [ ] Merge release branch into master.
 - [ ] Bump succeeding version number in master. ([include/seqan3/version.hpp](https://github.com/seqan/seqan3/blob/3.0.2/include/seqan3/version.hpp#L19-L24))
+- [ ] Bump latest stable version number of the API-Stability test in master. ([test/api_stability/CMakeLists.txt](https://github.com/seqan/seqan3/blob/3.0.3/test/api_stability/CMakeLists.txt#L10))
 - [ ] Update the SeqAn version [here](https://github.com/OpenMS/usage_plots/blob/master/seqan_versions.txt) to ensure
       that the server in Tübingen, which takes care of the argument parser update notifications, is aware of it
       (@smehringer).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,13 @@ If possible, provide tooling that performs the changes, e.g. a shell-script.
 
 ## API changes
 
+Most of our API or header file changes will trigger a deprecation warning to let you know if something changed and, if 
+applicable, when it will be removed. We recommend upgrading version-by-version to check whether you need to change code. 
+You can either directly check the reported code or verify with our documentation how the new API should be used.
+
+For a complete list of behavioural changes in our public and internal API, you can consult our API stability
+regression test suite and patches at https://github.com/seqan/seqan3/tree/master/test/api_stablility/3.0.2/.
+
 #### Alphabet
 
 * Removed seqan3::char_is_valid_for requirement from seqan3::writable_alphabet and

--- a/test/api_stability/3.0.2/0001-NOAPI-Disable-Werror.patch
+++ b/test/api_stability/3.0.2/0001-NOAPI-Disable-Werror.patch
@@ -1,0 +1,25 @@
+From 50198c4d13acedbc74e4e1e81b9433625f7d75ac Mon Sep 17 00:00:00 2001
+From: marehr <marehr-github@marehr.dialup.fu-berlin.de>
+Date: Wed, 17 Feb 2021 20:05:23 +0100
+Subject: [PATCH 01/22] [NOAPI] Disable -Werror
+
+---
+ test/seqan3-test.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/test/seqan3-test.cmake b/test/seqan3-test.cmake
+index 4ae8b274c..875755466 100644
+--- a/test/seqan3-test.cmake
++++ b/test/seqan3-test.cmake
+@@ -49,7 +49,7 @@ file(MAKE_DIRECTORY ${SEQAN3_TEST_CLONE_DIR}/googletest/include/)
+ # seqan3::test exposes a base set of required flags, includes, definitions and
+ # libraries which are in common for **all** seqan3 tests
+ add_library (seqan3_test INTERFACE)
+-target_compile_options (seqan3_test INTERFACE "-pedantic"  "-Wall" "-Wextra" "-Werror")
++target_compile_options (seqan3_test INTERFACE "-pedantic"  "-Wall" "-Wextra")
+ target_link_libraries (seqan3_test INTERFACE "seqan3::seqan3" "pthread")
+ target_include_directories (seqan3_test INTERFACE "${SEQAN3_TEST_INCLUDE_DIR}")
+ add_library (seqan3::test ALIAS seqan3_test)
+-- 
+2.31.0
+

--- a/test/api_stability/3.0.2/0002-NOAPI-DETAIL-MISC-Remove-top-level-scoring-scheme-de.patch
+++ b/test/api_stability/3.0.2/0002-NOAPI-DETAIL-MISC-Remove-top-level-scoring-scheme-de.patch
@@ -1,0 +1,88 @@
+From 23d8e9fa2ec1376116fc7e6c93e4676afacf3533 Mon Sep 17 00:00:00 2001
+From: rrahn <rene.rahn@fu-berlin.de>
+Date: Fri, 11 Sep 2020 16:41:13 +0200
+Subject: [PATCH 02/22] [NOAPI] [DETAIL] [MISC] Remove top-level scoring scheme
+ dependency from simd scoring matrix class.
+
+Makes the class template independent of the scoring scheme since it will be transformed into another memory layput internally.
+---
+ .../simd_matrix_scoring_scheme_test.cpp       | 21 +++++++------------
+ 1 file changed, 7 insertions(+), 14 deletions(-)
+
+diff --git a/test/unit/alignment/scoring/simd_matrix_scoring_scheme_test.cpp b/test/unit/alignment/scoring/simd_matrix_scoring_scheme_test.cpp
+index ef141a7e9..7b0927215 100644
+--- a/test/unit/alignment/scoring/simd_matrix_scoring_scheme_test.cpp
++++ b/test/unit/alignment/scoring/simd_matrix_scoring_scheme_test.cpp
+@@ -33,8 +33,7 @@ TYPED_TEST(simd_matrix_scoring_scheme_test, basic_construction)
+ {
+     using scheme_t = seqan3::detail::simd_matrix_scoring_scheme<TypeParam,
+                                                                 seqan3::aa27,
+-                                                                seqan3::align_cfg::method_global,
+-                                                                seqan3::aminoacid_scoring_scheme<>>;
++                                                                seqan3::align_cfg::method_global>;
+ 
+     EXPECT_TRUE(std::is_nothrow_default_constructible_v<scheme_t>);
+     EXPECT_TRUE(std::is_nothrow_copy_constructible_v<scheme_t>);
+@@ -50,8 +49,7 @@ TYPED_TEST(simd_matrix_scoring_scheme_test, construct_from_scoring_scheme_nothro
+ {
+     using scheme_t = seqan3::detail::simd_matrix_scoring_scheme<TypeParam,
+                                                                 seqan3::aa27,
+-                                                                seqan3::align_cfg::method_global,
+-                                                                seqan3::aminoacid_scoring_scheme<>>;
++                                                                seqan3::align_cfg::method_global>;
+ 
+     scheme_t simd_scheme{seqan3::aminoacid_scoring_scheme{seqan3::aminoacid_similarity_matrix::BLOSUM30}};
+ 
+@@ -68,8 +66,7 @@ TYPED_TEST(simd_matrix_scoring_scheme_test, construct_from_scoring_scheme_throw_
+     using scalar_t = typename seqan3::simd_traits<TypeParam>::scalar_type;
+     using scheme_t = seqan3::detail::simd_matrix_scoring_scheme<TypeParam,
+                                                                 seqan3::aa27,
+-                                                                seqan3::align_cfg::method_global,
+-                                                                seqan3::aminoacid_scoring_scheme<int64_t>>;
++                                                                seqan3::align_cfg::method_global>;
+ 
+     int64_t too_big = static_cast<int64_t>(std::numeric_limits<scalar_t>::max()) + 1;
+     int64_t too_small = static_cast<int64_t>(std::numeric_limits<scalar_t>::lowest()) - 1;
+@@ -98,8 +95,7 @@ TYPED_TEST(simd_matrix_scoring_scheme_test, score_global)
+ {
+     using scheme_t = seqan3::detail::simd_matrix_scoring_scheme<TypeParam,
+                                                                 seqan3::aa27,
+-                                                                seqan3::align_cfg::method_global,
+-                                                                seqan3::aminoacid_scoring_scheme<>>;
++                                                                seqan3::align_cfg::method_global>;
+ 
+     scheme_t scheme{seqan3::aminoacid_scoring_scheme{seqan3::aminoacid_similarity_matrix::BLOSUM30}};
+ 
+@@ -131,8 +127,7 @@ TYPED_TEST(simd_matrix_scoring_scheme_test, score_global_with_padding)
+ {
+     using scheme_t = seqan3::detail::simd_matrix_scoring_scheme<TypeParam,
+                                                                 seqan3::aa27,
+-                                                                seqan3::align_cfg::method_global,
+-                                                                seqan3::aminoacid_scoring_scheme<>>;
++                                                                seqan3::align_cfg::method_global>;
+ 
+     scheme_t scheme{seqan3::aminoacid_scoring_scheme{seqan3::aminoacid_similarity_matrix::BLOSUM30}};
+ 
+@@ -161,8 +156,7 @@ TYPED_TEST(simd_matrix_scoring_scheme_test, score_local)
+     // In local alignment we always want to mismatch.
+     using scheme_t = seqan3::detail::simd_matrix_scoring_scheme<TypeParam,
+                                                                 seqan3::aa27,
+-                                                                seqan3::align_cfg::method_local,
+-                                                                seqan3::aminoacid_scoring_scheme<>>;
++                                                                seqan3::align_cfg::method_local>;
+ 
+     scheme_t scheme{seqan3::aminoacid_scoring_scheme{seqan3::aminoacid_similarity_matrix::BLOSUM30}};
+ 
+@@ -195,8 +189,7 @@ TYPED_TEST(simd_matrix_scoring_scheme_test, score_local_with_padding)
+     // In local alignment we always want to mismatch.
+     using scheme_t = seqan3::detail::simd_matrix_scoring_scheme<TypeParam,
+                                                                 seqan3::aa27,
+-                                                                seqan3::align_cfg::method_local,
+-                                                                seqan3::aminoacid_scoring_scheme<>>;
++                                                                seqan3::align_cfg::method_local>;
+ 
+     scheme_t scheme{seqan3::aminoacid_scoring_scheme{seqan3::aminoacid_similarity_matrix::BLOSUM30}};
+ 
+-- 
+2.31.0
+

--- a/test/api_stability/3.0.2/0003-NOAPI-INCLUDE-add-missing-include-bi_fm_index.patch
+++ b/test/api_stability/3.0.2/0003-NOAPI-INCLUDE-add-missing-include-bi_fm_index.patch
@@ -1,0 +1,37 @@
+From 20e9f2c4aaf0ccb350c0097cc4cf9b084d22e4e5 Mon Sep 17 00:00:00 2001
+From: marehr <marehr-github@marehr.dialup.fu-berlin.de>
+Date: Thu, 18 Feb 2021 02:17:26 +0100
+Subject: [PATCH 03/22] [NOAPI] [INCLUDE] add missing include bi_fm_index
+
+---
+ .../bi_fm_index_cursor_collection_test_template.hpp              | 1 +
+ .../search/fm_index_cursor/bi_fm_index_cursor_test_template.hpp  | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/test/unit/search/fm_index_cursor/bi_fm_index_cursor_collection_test_template.hpp b/test/unit/search/fm_index_cursor/bi_fm_index_cursor_collection_test_template.hpp
+index 81020c0af..8cb0a8c01 100644
+--- a/test/unit/search/fm_index_cursor/bi_fm_index_cursor_collection_test_template.hpp
++++ b/test/unit/search/fm_index_cursor/bi_fm_index_cursor_collection_test_template.hpp
+@@ -10,6 +10,7 @@
+ 
+ #include <seqan3/range/views/slice.hpp>
+ #include <seqan3/search/fm_index/bi_fm_index_cursor.hpp>
++#include <seqan3/search/fm_index/bi_fm_index.hpp>
+ #include <seqan3/std/algorithm>
+ #include <seqan3/test/expect_range_eq.hpp>
+ 
+diff --git a/test/unit/search/fm_index_cursor/bi_fm_index_cursor_test_template.hpp b/test/unit/search/fm_index_cursor/bi_fm_index_cursor_test_template.hpp
+index 3b6bd69aa..e4f2a869b 100644
+--- a/test/unit/search/fm_index_cursor/bi_fm_index_cursor_test_template.hpp
++++ b/test/unit/search/fm_index_cursor/bi_fm_index_cursor_test_template.hpp
+@@ -10,6 +10,7 @@
+ 
+ #include <seqan3/range/views/slice.hpp>
+ #include <seqan3/search/fm_index/bi_fm_index_cursor.hpp>
++#include <seqan3/search/fm_index/bi_fm_index.hpp>
+ #include <seqan3/std/algorithm>
+ #include <seqan3/test/expect_range_eq.hpp>
+ 
+-- 
+2.31.0
+

--- a/test/api_stability/3.0.2/0004-NOAPI-INCLUDE-add-missing-include-gap-gapped.patch
+++ b/test/api_stability/3.0.2/0004-NOAPI-INCLUDE-add-missing-include-gap-gapped.patch
@@ -1,0 +1,24 @@
+From 089bf1cbfc54a474565c878e2a6ee7bf3fcf65e4 Mon Sep 17 00:00:00 2001
+From: marehr <marehr-github@marehr.dialup.fu-berlin.de>
+Date: Wed, 17 Feb 2021 20:43:19 +0100
+Subject: [PATCH 04/22] [NOAPI] [INCLUDE] add missing include gap::gapped
+
+---
+ test/unit/alphabet/composite/alphabet_variant_test.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/test/unit/alphabet/composite/alphabet_variant_test.cpp b/test/unit/alphabet/composite/alphabet_variant_test.cpp
+index b7f5f58cd..acbe102d7 100644
+--- a/test/unit/alphabet/composite/alphabet_variant_test.cpp
++++ b/test/unit/alphabet/composite/alphabet_variant_test.cpp
+@@ -12,6 +12,7 @@
+ #include <seqan3/alphabet/adaptation/char.hpp>
+ #include <seqan3/alphabet/composite/alphabet_variant.hpp>
+ #include <seqan3/alphabet/gap/gap.hpp>
++#include <seqan3/alphabet/gap/gapped.hpp>
+ #include <seqan3/alphabet/nucleotide/all.hpp>
+ #include <seqan3/core/detail/pack_algorithm.hpp>
+ 
+-- 
+2.31.0
+

--- a/test/api_stability/3.0.2/0005-NOAPI-DETAIL-MISC-rename-detail-char_predicate_-comb.patch
+++ b/test/api_stability/3.0.2/0005-NOAPI-DETAIL-MISC-rename-detail-char_predicate_-comb.patch
@@ -1,0 +1,41 @@
+From fae1f68cbe5320f5dc337ace99ee6cde031ce095 Mon Sep 17 00:00:00 2001
+From: marehr <marehr-github@marehr.dialup.fu-berlin.de>
+Date: Tue, 22 Dec 2020 14:24:55 +0100
+Subject: [PATCH 05/22] [NOAPI] [DETAIL] [MISC] rename
+ detail::char_predicate_{combiner,disjunction}
+
+---
+ test/unit/core/char_operations/char_predicate_test.cpp | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/test/unit/core/char_operations/char_predicate_test.cpp b/test/unit/core/char_operations/char_predicate_test.cpp
+index e4a1fdcae..af9c846e3 100644
+--- a/test/unit/core/char_operations/char_predicate_test.cpp
++++ b/test/unit/core/char_operations/char_predicate_test.cpp
+@@ -70,9 +70,9 @@ TEST(char_predicate, concept)
+     EXPECT_FALSE(seqan3::detail::char_predicate<int>);
+ }
+ 
+-TEST(char_predicate, char_predicate_combiner)
++TEST(char_predicate, char_predicate_disjunction)
+ {
+-    using cond_t = seqan3::detail::char_predicate_combiner<foo<'a'>, foo<'A'>, foo<'0'>>;
++    using cond_t = seqan3::detail::char_predicate_disjunction<foo<'a'>, foo<'A'>, foo<'0'>>;
+     EXPECT_TRUE(cond_t{}('a'));
+     EXPECT_TRUE(cond_t{}('A'));
+     EXPECT_TRUE(cond_t{}('0'));
+@@ -89,9 +89,9 @@ TEST(char_predicate, char_predicate_combiner)
+     EXPECT_FALSE(p('1'));
+ }
+ 
+-TEST(char_predicate, char_predicate_combiner_msg)
++TEST(char_predicate, char_predicate_disjunction_msg)
+ {
+-    using or_t = seqan3::detail::char_predicate_combiner<foo<'a'>, foo<'A'>, foo<'0'>>;
++    using or_t = seqan3::detail::char_predicate_disjunction<foo<'a'>, foo<'A'>, foo<'0'>>;
+     EXPECT_EQ(or_t::msg,   "(foo_a || foo_A || foo_0)"s);
+ }
+ 
+-- 
+2.31.0
+

--- a/test/api_stability/3.0.2/0006-NOAPI-DETAIL-FIX-renaming-config_element_specialisat.patch
+++ b/test/api_stability/3.0.2/0006-NOAPI-DETAIL-FIX-renaming-config_element_specialisat.patch
@@ -1,0 +1,179 @@
+From fe4a447e5a1e8d0d60e6618257a1bc1f653c3670 Mon Sep 17 00:00:00 2001
+From: Evelin Aasna <evelin.aasna@fu-berlin.de>
+Date: Wed, 6 Jan 2021 17:41:00 +0100
+Subject: [PATCH 06/22] [NOAPI] [DETAIL] [FIX] renaming
+ config_element_specialisation to config_element
+
+---
+ test/unit/alignment/configuration/align_config_band_test.cpp  | 4 ++--
+ .../unit/alignment/configuration/align_config_common_test.cpp | 4 ++--
+ .../configuration/align_config_gap_cost_affine_test.cpp       | 4 ++--
+ .../alignment/configuration/align_config_min_score_test.cpp   | 4 ++--
+ .../alignment/configuration/align_config_parallel_test.cpp    | 4 ++--
+ .../alignment/configuration/align_config_scoring_test.cpp     | 4 ++--
+ test/unit/core/algorithm/configuration_test.cpp               | 4 ++--
+ .../core/algorithm/pipeable_config_element_test_template.hpp  | 2 +-
+ test/unit/search/configuration/parallel_test.cpp              | 4 ++--
+ test/unit/search/search_configuration_test.cpp                | 4 ++--
+ 10 files changed, 19 insertions(+), 19 deletions(-)
+
+diff --git a/test/unit/alignment/configuration/align_config_band_test.cpp b/test/unit/alignment/configuration/align_config_band_test.cpp
+index ca53af334..473c4931b 100644
+--- a/test/unit/alignment/configuration/align_config_band_test.cpp
++++ b/test/unit/alignment/configuration/align_config_band_test.cpp
+@@ -18,9 +18,9 @@ using test_types = ::testing::Types<seqan3::align_cfg::band_fixed_size>;
+ 
+ INSTANTIATE_TYPED_TEST_SUITE_P(band_elements, pipeable_config_element_test, test_types, );
+ 
+-TEST(band_fixed_size, config_element_specialisation)
++TEST(band_fixed_size, config_element)
+ {
+-    EXPECT_TRUE((seqan3::detail::config_element_specialisation<seqan3::align_cfg::band_fixed_size>));
++    EXPECT_TRUE((seqan3::detail::config_element<seqan3::align_cfg::band_fixed_size>));
+ }
+ 
+ TEST(band_fixed_size, construct)
+diff --git a/test/unit/alignment/configuration/align_config_common_test.cpp b/test/unit/alignment/configuration/align_config_common_test.cpp
+index 942ab64ce..7f6d7dc0a 100644
+--- a/test/unit/alignment/configuration/align_config_common_test.cpp
++++ b/test/unit/alignment/configuration/align_config_common_test.cpp
+@@ -55,9 +55,9 @@ TEST(alignment_configuration_test, number_of_configs)
+     EXPECT_EQ(static_cast<uint8_t>(seqan3::detail::align_config_id::SIZE), 18);
+ }
+ 
+-TYPED_TEST(alignment_configuration_test, config_element_specialisation)
++TYPED_TEST(alignment_configuration_test, config_element)
+ {
+-    EXPECT_TRUE((seqan3::detail::config_element_specialisation<TypeParam>));
++    EXPECT_TRUE((seqan3::detail::config_element<TypeParam>));
+ }
+ 
+ TYPED_TEST(alignment_configuration_test, configuration_exists)
+diff --git a/test/unit/alignment/configuration/align_config_gap_cost_affine_test.cpp b/test/unit/alignment/configuration/align_config_gap_cost_affine_test.cpp
+index 3ee3923ae..7e927c6fa 100644
+--- a/test/unit/alignment/configuration/align_config_gap_cost_affine_test.cpp
++++ b/test/unit/alignment/configuration/align_config_gap_cost_affine_test.cpp
+@@ -11,9 +11,9 @@
+ #include <seqan3/core/algorithm/configuration.hpp>
+ #include <seqan3/std/concepts>
+ 
+-TEST(align_config_gap, config_element_specialisation)
++TEST(align_config_gap, config_element)
+ {
+-    EXPECT_TRUE((seqan3::detail::config_element_specialisation<seqan3::align_cfg::gap_cost_affine>));
++    EXPECT_TRUE((seqan3::detail::config_element<seqan3::align_cfg::gap_cost_affine>));
+ }
+ 
+ TEST(align_config_gap, configuration)
+diff --git a/test/unit/alignment/configuration/align_config_min_score_test.cpp b/test/unit/alignment/configuration/align_config_min_score_test.cpp
+index d06b0e0e5..8c6e87bfd 100644
+--- a/test/unit/alignment/configuration/align_config_min_score_test.cpp
++++ b/test/unit/alignment/configuration/align_config_min_score_test.cpp
+@@ -13,9 +13,9 @@
+ #include <seqan3/alignment/configuration/align_config_min_score.hpp>
+ #include <seqan3/core/algorithm/configuration.hpp>
+ 
+-TEST(align_config_min_score, config_element_specialisation)
++TEST(align_config_min_score, config_element)
+ {
+-    EXPECT_TRUE((seqan3::detail::config_element_specialisation<seqan3::align_cfg::min_score>));
++    EXPECT_TRUE((seqan3::detail::config_element<seqan3::align_cfg::min_score>));
+ }
+ 
+ TEST(align_config_min_score, configuration)
+diff --git a/test/unit/alignment/configuration/align_config_parallel_test.cpp b/test/unit/alignment/configuration/align_config_parallel_test.cpp
+index a77983173..e731bd210 100644
+--- a/test/unit/alignment/configuration/align_config_parallel_test.cpp
++++ b/test/unit/alignment/configuration/align_config_parallel_test.cpp
+@@ -27,9 +27,9 @@ INSTANTIATE_TYPED_TEST_SUITE_P(parallel_elements, pipeable_config_element_test,
+ // individual tests
+ // ---------------------------------------------------------------------------------------------------------------------
+ 
+-TEST(align_config_parallel, config_element_specialisation)
++TEST(align_config_parallel, config_element)
+ {
+-    EXPECT_TRUE((seqan3::detail::config_element_specialisation<seqan3::align_cfg::parallel>));
++    EXPECT_TRUE((seqan3::detail::config_element<seqan3::align_cfg::parallel>));
+ }
+ 
+ TEST(align_config_parallel, configuration)
+diff --git a/test/unit/alignment/configuration/align_config_scoring_test.cpp b/test/unit/alignment/configuration/align_config_scoring_test.cpp
+index 0e9ff45fc..f9e771d35 100644
+--- a/test/unit/alignment/configuration/align_config_scoring_test.cpp
++++ b/test/unit/alignment/configuration/align_config_scoring_test.cpp
+@@ -26,10 +26,10 @@ using test_types = ::testing::Types<std::tuple<seqan3::aminoacid_scoring_scheme<
+                                     std::tuple<seqan3::nucleotide_scoring_scheme<int8_t>, seqan3::dna15>>;
+ TYPED_TEST_SUITE(align_confg_scoring_test, test_types, );
+ 
+-TYPED_TEST(align_confg_scoring_test, config_element_specialisation)
++TYPED_TEST(align_confg_scoring_test, config_element)
+ {
+     using scheme_t = typename TestFixture::scheme_t;
+-    EXPECT_TRUE((seqan3::detail::config_element_specialisation<seqan3::align_cfg::scoring_scheme<scheme_t>>));
++    EXPECT_TRUE((seqan3::detail::config_element<seqan3::align_cfg::scoring_scheme<scheme_t>>));
+ }
+ 
+ TYPED_TEST(align_confg_scoring_test, configuration)
+diff --git a/test/unit/core/algorithm/configuration_test.cpp b/test/unit/core/algorithm/configuration_test.cpp
+index ef8952d2f..9494b6e61 100644
+--- a/test/unit/core/algorithm/configuration_test.cpp
++++ b/test/unit/core/algorithm/configuration_test.cpp
+@@ -16,8 +16,8 @@
+ 
+ TEST(configuration, concept_check)
+ {
+-    EXPECT_TRUE(seqan3::detail::config_element_specialisation<bar>);
+-    EXPECT_FALSE(seqan3::detail::config_element_specialisation<int>);
++    EXPECT_TRUE(seqan3::detail::config_element<bar>);
++    EXPECT_FALSE(seqan3::detail::config_element<int>);
+ 
+     EXPECT_TRUE((seqan3::tuple_like<seqan3::configuration<bax, bar>>));
+ }
+diff --git a/test/unit/core/algorithm/pipeable_config_element_test_template.hpp b/test/unit/core/algorithm/pipeable_config_element_test_template.hpp
+index e113e478d..695d118a7 100644
+--- a/test/unit/core/algorithm/pipeable_config_element_test_template.hpp
++++ b/test/unit/core/algorithm/pipeable_config_element_test_template.hpp
+@@ -22,7 +22,7 @@ TYPED_TEST_SUITE_P(pipeable_config_element_test);
+ 
+ TYPED_TEST_P(pipeable_config_element_test, concept_check)
+ {
+-    EXPECT_TRUE((seqan3::detail::config_element_specialisation<TypeParam>));
++    EXPECT_TRUE((seqan3::detail::config_element<TypeParam>));
+ }
+ 
+ TYPED_TEST_P(pipeable_config_element_test, standard_construction)
+diff --git a/test/unit/search/configuration/parallel_test.cpp b/test/unit/search/configuration/parallel_test.cpp
+index 9b1937d14..a477c8a19 100644
+--- a/test/unit/search/configuration/parallel_test.cpp
++++ b/test/unit/search/configuration/parallel_test.cpp
+@@ -44,9 +44,9 @@ TEST(search_config_parallel, member_variable)
+     }
+ }
+ 
+-TEST(search_config_parallel, config_element_specialisation)
++TEST(search_config_parallel, config_element)
+ {
+-    EXPECT_TRUE((seqan3::detail::config_element_specialisation<seqan3::search_cfg::parallel>));
++    EXPECT_TRUE((seqan3::detail::config_element<seqan3::search_cfg::parallel>));
+ }
+ 
+ TEST(search_config_parallel, configuration)
+diff --git a/test/unit/search/search_configuration_test.cpp b/test/unit/search/search_configuration_test.cpp
+index 69ab8364e..ce07aea48 100644
+--- a/test/unit/search/search_configuration_test.cpp
++++ b/test/unit/search/search_configuration_test.cpp
+@@ -62,9 +62,9 @@ TEST(search_configuration_test, symmetric_configuration)
+     }
+ }
+ 
+-TYPED_TEST(search_configuration_test, config_element_specialisation)
++TYPED_TEST(search_configuration_test, config_element)
+ {
+-    EXPECT_TRUE((seqan3::detail::config_element_specialisation<TypeParam>));
++    EXPECT_TRUE((seqan3::detail::config_element<TypeParam>));
+ }
+ 
+ TYPED_TEST(search_configuration_test, configuration_exists)
+-- 
+2.31.0
+

--- a/test/api_stability/3.0.2/0007-NOAPI-DETAIL-FIX-renaming-strong_type_specialisation.patch
+++ b/test/api_stability/3.0.2/0007-NOAPI-DETAIL-FIX-renaming-strong_type_specialisation.patch
@@ -1,0 +1,32 @@
+From c8798ca403aa9968e8843b517e0c726bc34ef8e2 Mon Sep 17 00:00:00 2001
+From: Evelin Aasna <evelin.aasna@fu-berlin.de>
+Date: Wed, 6 Jan 2021 17:40:03 +0100
+Subject: [PATCH 07/22] [NOAPI] [DETAIL] [FIX] renaming
+ strong_type_specialisation to derived_from_strong_type
+
+---
+ test/unit/core/detail/strong_type_test.cpp | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/test/unit/core/detail/strong_type_test.cpp b/test/unit/core/detail/strong_type_test.cpp
+index 3011aa52f..45313be2a 100644
+--- a/test/unit/core/detail/strong_type_test.cpp
++++ b/test/unit/core/detail/strong_type_test.cpp
+@@ -101,10 +101,10 @@ struct multi_skill_type : seqan3::detail::strong_type<int,
+ 
+ TEST(strong_type, concept)
+ {
+-    EXPECT_TRUE(seqan3::detail::strong_type_specialisation<pure_type &>);
+-    EXPECT_TRUE(seqan3::detail::strong_type_specialisation<pure_type const &>);
+-    EXPECT_TRUE(seqan3::detail::strong_type_specialisation<pure_type &&>);
+-    EXPECT_TRUE(seqan3::detail::strong_type_specialisation<pure_type const &&>);
++    EXPECT_TRUE(seqan3::detail::derived_from_strong_type<pure_type &>);
++    EXPECT_TRUE(seqan3::detail::derived_from_strong_type<pure_type const &>);
++    EXPECT_TRUE(seqan3::detail::derived_from_strong_type<pure_type &&>);
++    EXPECT_TRUE(seqan3::detail::derived_from_strong_type<pure_type const &&>);
+ }
+ 
+ TEST(strong_type, pure_type)
+-- 
+2.31.0
+

--- a/test/api_stability/3.0.2/0008-NOAPI-INCLUDE-add-missing-include-detail-sizeof_bits.patch
+++ b/test/api_stability/3.0.2/0008-NOAPI-INCLUDE-add-missing-include-detail-sizeof_bits.patch
@@ -1,0 +1,38 @@
+From 3701c0c5ac39fef893f1fe495d54092048a43c6b Mon Sep 17 00:00:00 2001
+From: marehr <marehr-github@marehr.dialup.fu-berlin.de>
+Date: Thu, 18 Feb 2021 13:13:30 +0100
+Subject: [PATCH 08/22] [NOAPI] [INCLUDE] add missing include
+ detail::sizeof_bits
+
+---
+ test/unit/core/math_test.cpp                      | 1 +
+ test/unit/range/container/dynamic_bitset_test.cpp | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/test/unit/core/math_test.cpp b/test/unit/core/math_test.cpp
+index 8a2189390..8623b22d5 100644
+--- a/test/unit/core/math_test.cpp
++++ b/test/unit/core/math_test.cpp
+@@ -7,6 +7,7 @@
+ 
+ #include <gtest/gtest.h>
+ 
++#include <seqan3/core/bit_manipulation.hpp>
+ #include <seqan3/core/math.hpp>
+ 
+ static constexpr size_t max_iterations = 1;//1 << 15;
+diff --git a/test/unit/range/container/dynamic_bitset_test.cpp b/test/unit/range/container/dynamic_bitset_test.cpp
+index e9735767f..fe12a3036 100644
+--- a/test/unit/range/container/dynamic_bitset_test.cpp
++++ b/test/unit/range/container/dynamic_bitset_test.cpp
+@@ -7,6 +7,7 @@
+ 
+ #include <gtest/gtest.h>
+ 
++#include <seqan3/core/bit_manipulation.hpp>
+ #include <seqan3/core/debug_stream.hpp>
+ #include <seqan3/range/container/dynamic_bitset.hpp>
+ #include <seqan3/test/cereal.hpp>
+-- 
+2.31.0
+

--- a/test/api_stability/3.0.2/0009-NOAPI-INCLUDE-add-missing-include-sdsl-bits.patch
+++ b/test/api_stability/3.0.2/0009-NOAPI-INCLUDE-add-missing-include-sdsl-bits.patch
@@ -1,0 +1,25 @@
+From 3623ded92f807c6f662645c82815d21c37f08116 Mon Sep 17 00:00:00 2001
+From: marehr <marehr-github@marehr.dialup.fu-berlin.de>
+Date: Wed, 17 Feb 2021 22:18:25 +0100
+Subject: [PATCH 09/22] [NOAPI] [INCLUDE] add missing include sdsl::bits
+
+---
+ test/unit/core/bit_manipulation_test.cpp | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/test/unit/core/bit_manipulation_test.cpp b/test/unit/core/bit_manipulation_test.cpp
+index 4a1329287..315369924 100644
+--- a/test/unit/core/bit_manipulation_test.cpp
++++ b/test/unit/core/bit_manipulation_test.cpp
+@@ -11,6 +11,8 @@
+ 
+ #include <seqan3/core/bit_manipulation.hpp>
+ 
++#include <sdsl/bits.hpp>
++
+ static constexpr size_t max_iterations = 1 << 15;
+ 
+ TEST(bit_manipulation, sizeof_bits)
+-- 
+2.31.0
+

--- a/test/api_stability/3.0.2/0010-API-WRONG-USAGE-MISC-Simplify-the-pipe-operator-for-.patch
+++ b/test/api_stability/3.0.2/0010-API-WRONG-USAGE-MISC-Simplify-the-pipe-operator-for-.patch
@@ -1,0 +1,74 @@
+From 70e77c3d54a62393cdfb9ad0fa33bda6337f6503 Mon Sep 17 00:00:00 2001
+From: rrahn <rene.rahn@fu-berlin.de>
+Date: Sat, 10 Oct 2020 17:01:38 +0200
+Subject: [PATCH 10/22] [API] [WRONG-USAGE] [MISC] Simplify the pipe operator
+ for the configurations.
+
+This merges the pipe-operator overloads into a single free function, which is implemented by means of the new append function.
+Futher, the pipe-operator uses concepts for to check for eligible types and does not cast to the base class of the configuration elements anymore.
+
+The pipeability test in the pipeable_config_test_template had to be removed since it was testing an invalid scenario.
+Later a better test template infrastructure will be introduced.
+---
+ .../pipeable_config_element_test_template.hpp | 43 +------------------
+ 1 file changed, 1 insertion(+), 42 deletions(-)
+
+diff --git a/test/unit/core/algorithm/pipeable_config_element_test_template.hpp b/test/unit/core/algorithm/pipeable_config_element_test_template.hpp
+index 695d118a7..0ac9010af 100644
+--- a/test/unit/core/algorithm/pipeable_config_element_test_template.hpp
++++ b/test/unit/core/algorithm/pipeable_config_element_test_template.hpp
+@@ -53,50 +53,9 @@ TYPED_TEST_P(pipeable_config_element_test, exists)
+     EXPECT_TRUE(configuration_t::template exists<TypeParam>());
+ }
+ 
+-// make mock config element foo always pipeable with any other config element
+-namespace seqan3::detail
+-{
+-
+-template <typename t>
+-struct is_configuration_valid<t, foo> : public std::true_type
+-{};
+-
+-template <typename t>
+-struct is_configuration_valid<foo, t> : public std::true_type
+-{};
+-
+-}
+-
+-TYPED_TEST_P(pipeable_config_element_test, pipeability)
+-{
+-    TypeParam elem{};
+-    foo dummy{};
+-
+-    {   // lvalue | lvalue
+-        auto cfg = dummy | elem;
+-        EXPECT_TRUE((std::is_same_v<decltype(cfg), seqan3::configuration<foo, TypeParam>>));
+-    }
+-
+-    {   // rvalue | lvalue
+-        auto cfg = TypeParam{} | dummy;
+-        EXPECT_TRUE((std::is_same_v<decltype(cfg), seqan3::configuration<TypeParam, foo>>));
+-    }
+-
+-    {   // lvalue | rvalue
+-        auto cfg = dummy | TypeParam{};
+-        EXPECT_TRUE((std::is_same_v<decltype(cfg), seqan3::configuration<foo, TypeParam>>));
+-    }
+-
+-    {   // rvalue | rvalue
+-        auto cfg = foo{} | TypeParam{};
+-        EXPECT_TRUE((std::is_same_v<decltype(cfg), seqan3::configuration<foo, TypeParam>>));
+-    }
+-}
+-
+ REGISTER_TYPED_TEST_SUITE_P(pipeable_config_element_test,
+                             concept_check,
+                             standard_construction,
+                             configuration_construction,
+                             configuration_assignment,
+-                            exists,
+-                            pipeability);
++                            exists);
+-- 
+2.31.0
+

--- a/test/api_stability/3.0.2/0011-API-BREAKAGE-MISC-adjusting-seqan3_version-semantics.patch
+++ b/test/api_stability/3.0.2/0011-API-BREAKAGE-MISC-adjusting-seqan3_version-semantics.patch
@@ -1,0 +1,116 @@
+From afbe87931ad253ca2830313d4fb8f0130b3d9b69 Mon Sep 17 00:00:00 2001
+From: Simon Gene Gottlieb <simon@gottliebtfreitag.de>
+Date: Wed, 27 Jan 2021 16:46:04 +0100
+Subject: [PATCH 11/22] [API] [BREAKAGE] [MISC] adjusting seqan3_version
+ semantics (#2350)
+
+* [MISC] adjusting seqan3_version to have the same value as SEQAN3_VERSION
+
+- Adjusting seqan3_version to be the constexpr version of SEQAN_VERSION which is
+  an integer.
+- Added SEQAN3_VERSION_CSTRING which is a null terminated string of the version.
+- Added seqan3_version_cstring which is a constexpr version of
+  SEQAN3_VERSION_CSTRING.
+- Adjusted all files to use seqan3_version_cstring instead of seqan3_version.
+
+* [FIX] use brace-intialisation
+
+* [FIX] remove helper macros
+---
+ test/unit/argument_parser/detail/format_help_test.cpp     | 2 +-
+ test/unit/argument_parser/detail/format_html_test.cpp     | 4 ++--
+ test/unit/argument_parser/detail/version_check_test.hpp   | 8 ++++----
+ .../unit/argument_parser/format_parse_validators_test.cpp | 2 +-
+ 4 files changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/test/unit/argument_parser/detail/format_help_test.cpp b/test/unit/argument_parser/detail/format_help_test.cpp
+index 6c2a985e1..5064efe4a 100644
+--- a/test/unit/argument_parser/detail/format_help_test.cpp
++++ b/test/unit/argument_parser/detail/format_help_test.cpp
+@@ -45,7 +45,7 @@ std::string const basic_options_str = "OPTIONS\n"
+ std::string const basic_version_str = "VERSION\n"
+                                       "    Last update: \n"
+                                       "    test_parser version: \n"
+-                                      "    SeqAn version: " + seqan3::seqan3_version + "\n";
++                                      "    SeqAn version: " + std::string{seqan3::seqan3_version_cstring} + "\n";
+ 
+ std::string license_text()
+ {
+diff --git a/test/unit/argument_parser/detail/format_html_test.cpp b/test/unit/argument_parser/detail/format_html_test.cpp
+index 3c95ed37e..887fbbe4d 100644
+--- a/test/unit/argument_parser/detail/format_html_test.cpp
++++ b/test/unit/argument_parser/detail/format_html_test.cpp
+@@ -51,7 +51,7 @@ TEST(html_format, empty_information)
+                            "<h2>Version</h2>\n"
+                            "<strong>Last update:</strong> <br>\n"
+                            "<strong>empty_options version:</strong> <br>\n"
+-                           "<strong>SeqAn version:</strong> " + seqan3::seqan3_version + "<br>\n"
++                           "<strong>SeqAn version:</strong> " + std::string{seqan3::seqan3_version_cstring} + "<br>\n"
+                            "<br>\n"
+                            "</body></html>");
+     EXPECT_EQ(my_stdout, expected);
+@@ -164,7 +164,7 @@ TEST(html_format, full_information_information)
+                           "<h2>Version</h2>\n"
+                           "<strong>Last update:</strong> <br>\n"
+                           "<strong>program_full_options version:</strong> <br>\n"
+-                          "<strong>SeqAn version:</strong> " + seqan3::seqan3_version + "<br>\n"
++                          "<strong>SeqAn version:</strong> " + std::string{seqan3::seqan3_version_cstring} + "<br>\n"
+                           "<h2>Url</h2>\n"
+                           "www.seqan.de<br>\n"
+                           "<br>\n"
+diff --git a/test/unit/argument_parser/detail/version_check_test.hpp b/test/unit/argument_parser/detail/version_check_test.hpp
+index c32ce3c78..e4e4f710d 100644
+--- a/test/unit/argument_parser/detail/version_check_test.hpp
++++ b/test/unit/argument_parser/detail/version_check_test.hpp
+@@ -390,7 +390,7 @@ TEST_F(version_check, greater_app_version)
+     const char * argv[3] = {app_name.c_str(), OPTION_VERSION_CHECK, OPTION_ON};
+ 
+     // create version file with equal seqan version and a smaller app version than the current
+-    ASSERT_TRUE(create_file(app_version_filename(), std::string{"1.5.9\n" + seqan3::seqan3_version}));
++    ASSERT_TRUE(create_file(app_version_filename(), std::string{"1.5.9\n"} + seqan3::seqan3_version_cstring));
+ 
+     // create timestamp file that dates one day before current to trigger a message
+     ASSERT_TRUE(create_file(app_timestamp_filename(), current_unix_timestamp() - 100401)); // one day = 86400 seconds
+@@ -411,7 +411,7 @@ TEST_F(version_check, unregistered_app)
+     const char * argv[3] = {app_name.c_str(), OPTION_VERSION_CHECK, OPTION_ON};
+ 
+     // create version file with equal seqan version and a smaller app version than the current
+-    ASSERT_TRUE(create_file(app_version_filename(), std::string{ "UNREGISTERED_APP\n" + seqan3::seqan3_version}));
++    ASSERT_TRUE(create_file(app_version_filename(), std::string{"UNREGISTERED_APP\n"} + seqan3::seqan3_version_cstring));
+ 
+     // create timestamp file that dates one day before current to trigger a message
+     ASSERT_TRUE(create_file(app_timestamp_filename(), current_unix_timestamp() - 100401)); // one day = 86400 seconds
+@@ -435,7 +435,7 @@ TEST_F(version_check, smaller_app_version)
+     const char * argv[3] = {app_name.c_str(), OPTION_VERSION_CHECK, OPTION_ON};
+ 
+     // create version file with equal seqan version and a greater app version than the current
+-    ASSERT_TRUE(create_file(app_version_filename(), std::string{"20.5.9\n" + seqan3::seqan3_version}));
++    ASSERT_TRUE(create_file(app_version_filename(), std::string{"20.5.9\n"} + seqan3::seqan3_version_cstring));
+ 
+     // create timestamp file that dates one day before current to trigger a message (one day = 86400 seconds)
+     ASSERT_TRUE(create_file(app_timestamp_filename(), current_unix_timestamp() - 100401));
+@@ -463,7 +463,7 @@ TEST_F(version_check, smaller_app_version_custom_url)
+     const char * argv[3] = {app_name.c_str(), OPTION_VERSION_CHECK, OPTION_ON};
+ 
+     // create version file with equal seqan version and a greater app version than the current
+-    ASSERT_TRUE(create_file(app_version_filename(), std::string{"20.5.9\n" + seqan3::seqan3_version}));
++    ASSERT_TRUE(create_file(app_version_filename(), std::string{"20.5.9\n"} + seqan3::seqan3_version_cstring));
+ 
+     // create timestamp file that dates one day before current to trigger a message (one day = 86400 seconds)
+     ASSERT_TRUE(create_file(app_timestamp_filename(), current_unix_timestamp() - 100401));
+diff --git a/test/unit/argument_parser/format_parse_validators_test.cpp b/test/unit/argument_parser/format_parse_validators_test.cpp
+index e2105d37e..616c8e603 100644
+--- a/test/unit/argument_parser/format_parse_validators_test.cpp
++++ b/test/unit/argument_parser/format_parse_validators_test.cpp
+@@ -49,7 +49,7 @@ std::string const basic_options_str = "OPTIONS\n"
+ std::string const basic_version_str = "VERSION\n"
+                                       "    Last update: \n"
+                                       "    test_parser version: \n"
+-                                      "    SeqAn version: " + seqan3::seqan3_version + "\n";
++                                      "    SeqAn version: " + std::string{seqan3::seqan3_version_cstring} + "\n";
+ 
+ namespace seqan3::detail
+ {
+-- 
+2.31.0
+

--- a/test/api_stability/3.0.2/0012-NOAPI-INCLUDE-add-missing-include-seqan3-debug_strea.patch
+++ b/test/api_stability/3.0.2/0012-NOAPI-INCLUDE-add-missing-include-seqan3-debug_strea.patch
@@ -1,0 +1,58 @@
+From c285a9fa69198ad4f83f27581b336030539a8eca Mon Sep 17 00:00:00 2001
+From: marehr <marehr-github@marehr.dialup.fu-berlin.de>
+Date: Thu, 18 Feb 2021 15:21:44 +0100
+Subject: [PATCH 12/22] [NOAPI] [INCLUDE] add missing include
+ seqan3::debug_stream
+
+---
+ doc/howto/subcommand_argument_parser/subcommand_arg_parse.cpp | 1 +
+ doc/tutorial/concepts/custom_validator_solution2.cpp          | 1 +
+ doc/tutorial/introduction/introduction_file_input.cpp         | 1 +
+ doc/tutorial/ranges/range_solution4.cpp                       | 1 +
+ 4 files changed, 4 insertions(+)
+
+diff --git a/doc/howto/subcommand_argument_parser/subcommand_arg_parse.cpp b/doc/howto/subcommand_argument_parser/subcommand_arg_parse.cpp
+index 49ecb1dc1..66fbc759e 100644
+--- a/doc/howto/subcommand_argument_parser/subcommand_arg_parse.cpp
++++ b/doc/howto/subcommand_argument_parser/subcommand_arg_parse.cpp
+@@ -1,4 +1,5 @@
+ #include <seqan3/argument_parser/all.hpp>
++#include <seqan3/core/debug_stream.hpp>
+ 
+ // =====================================================================================================================
+ // pull
+diff --git a/doc/tutorial/concepts/custom_validator_solution2.cpp b/doc/tutorial/concepts/custom_validator_solution2.cpp
+index 1b76ac5a3..c31712cd7 100644
+--- a/doc/tutorial/concepts/custom_validator_solution2.cpp
++++ b/doc/tutorial/concepts/custom_validator_solution2.cpp
+@@ -1,4 +1,5 @@
+ #include <seqan3/argument_parser/all.hpp>
++#include <seqan3/core/debug_stream.hpp>
+ //![validator]
+ #include <cmath>
+ 
+diff --git a/doc/tutorial/introduction/introduction_file_input.cpp b/doc/tutorial/introduction/introduction_file_input.cpp
+index 180bd0764..10fa47ba0 100644
+--- a/doc/tutorial/introduction/introduction_file_input.cpp
++++ b/doc/tutorial/introduction/introduction_file_input.cpp
+@@ -1,4 +1,5 @@
+ #include <seqan3/alphabet/nucleotide/dna4.hpp>  // to create right datastructure in tmp file
++#include <seqan3/core/debug_stream.hpp>
+ #include <seqan3/io/sequence_file/output.hpp>   // to create tmp file
+ #include <seqan3/std/filesystem>                // to create tmp directory
+ 
+diff --git a/doc/tutorial/ranges/range_solution4.cpp b/doc/tutorial/ranges/range_solution4.cpp
+index 29d006d70..554225a0c 100644
+--- a/doc/tutorial/ranges/range_solution4.cpp
++++ b/doc/tutorial/ranges/range_solution4.cpp
+@@ -2,6 +2,7 @@
+ 
+ #include <seqan3/alphabet/nucleotide/dna4.hpp>
+ #include <seqan3/argument_parser/all.hpp>                       // include argument parser
++#include <seqan3/core/debug_stream.hpp>
+ #include <seqan3/range/container/bitcompressed_vector.hpp>      // include bitcompressed vector
+ 
+ using seqan3::operator""_dna4;
+-- 
+2.31.0
+

--- a/test/api_stability/3.0.2/0013-NOAPI-BREAKAGE-We-changed-the-behaviour-of-seqan3-de.patch
+++ b/test/api_stability/3.0.2/0013-NOAPI-BREAKAGE-We-changed-the-behaviour-of-seqan3-de.patch
@@ -1,0 +1,149 @@
+From 5b9cb28d7c4f5391080cb584add3c934480eba69 Mon Sep 17 00:00:00 2001
+From: marehr <marehr-github@marehr.dialup.fu-berlin.de>
+Date: Fri, 19 Feb 2021 00:22:49 +0100
+Subject: [PATCH 13/22] [NOAPI] [BREAKAGE] We changed the behaviour of
+ seqan3::detail::simd_matrix_scoring_scheme::score
+
+This behaviour changed in ef51ed80f6e6ed0e90dcf2db8b0697d5a60060b1
+---
+ .../simd_matrix_scoring_scheme_test.cpp       | 40 +++++++++----------
+ 1 file changed, 20 insertions(+), 20 deletions(-)
+
+diff --git a/test/unit/alignment/scoring/simd_matrix_scoring_scheme_test.cpp b/test/unit/alignment/scoring/simd_matrix_scoring_scheme_test.cpp
+index 7b0927215..14a26829d 100644
+--- a/test/unit/alignment/scoring/simd_matrix_scoring_scheme_test.cpp
++++ b/test/unit/alignment/scoring/simd_matrix_scoring_scheme_test.cpp
+@@ -36,9 +36,9 @@ TYPED_TEST(simd_matrix_scoring_scheme_test, basic_construction)
+                                                                 seqan3::align_cfg::method_global>;
+ 
+     EXPECT_TRUE(std::is_nothrow_default_constructible_v<scheme_t>);
+-    EXPECT_TRUE(std::is_nothrow_copy_constructible_v<scheme_t>);
++    // EXPECT_TRUE(std::is_nothrow_copy_constructible_v<scheme_t>);
+     EXPECT_TRUE(std::is_nothrow_move_constructible_v<scheme_t>);
+-    EXPECT_TRUE(std::is_nothrow_copy_assignable_v<scheme_t>);
++    // EXPECT_TRUE(std::is_nothrow_copy_assignable_v<scheme_t>);
+     EXPECT_TRUE(std::is_nothrow_move_assignable_v<scheme_t>);
+     EXPECT_TRUE(std::is_nothrow_destructible_v<scheme_t>);
+     EXPECT_TRUE((std::is_constructible_v<scheme_t, seqan3::aminoacid_scoring_scheme<>>));
+@@ -55,10 +55,10 @@ TYPED_TEST(simd_matrix_scoring_scheme_test, construct_from_scoring_scheme_nothro
+ 
+     TypeParam simd_value1 = seqan3::simd::fill<TypeParam>(2);
+     TypeParam simd_value2 = seqan3::simd::fill<TypeParam>(2);
+-    SIMD_EQ(simd_scheme.score(simd_value1, simd_value2), seqan3::simd::fill<TypeParam>(17));
++    // SIMD_EQ(simd_scheme.score(simd_value1, simd_value2), seqan3::simd::fill<TypeParam>(17));
+ 
+     simd_value2 = seqan3::simd::fill<TypeParam>(1);
+-    SIMD_EQ(simd_scheme.score(simd_value1, simd_value2), seqan3::simd::fill<TypeParam>(-2));
++    // SIMD_EQ(simd_scheme.score(simd_value1, simd_value2), seqan3::simd::fill<TypeParam>(-2));
+ }
+ 
+ TYPED_TEST(simd_matrix_scoring_scheme_test, construct_from_scoring_scheme_throw_on_overflow)
+@@ -103,24 +103,24 @@ TYPED_TEST(simd_matrix_scoring_scheme_test, score_global)
+     TypeParam simd_value2 = seqan3::simd::fill<TypeParam>(2);
+ 
+     // all match
+-    SIMD_EQ(scheme.score(simd_value1, simd_value2), seqan3::simd::fill<TypeParam>(17));
++    // SIMD_EQ(scheme.score(simd_value1, simd_value2), seqan3::simd::fill<TypeParam>(17));
+ 
+     // all mismatch
+     simd_value2 = seqan3::simd::fill<TypeParam>(3);
+-    SIMD_EQ(scheme.score(simd_value1, simd_value2), seqan3::simd::fill<TypeParam>(-3));
++    // SIMD_EQ(scheme.score(simd_value1, simd_value2), seqan3::simd::fill<TypeParam>(-3));
+ 
+     // first matches, remaining mismatches.
+     simd_value2[0] = 2;
+     TypeParam result = seqan3::simd::fill<TypeParam>(-3);
+     result[0] = 17;
+-    SIMD_EQ(scheme.score(simd_value1, simd_value2), result);
++    // SIMD_EQ(scheme.score(simd_value1, simd_value2), result);
+ 
+     // first mismatches, remaining matches.
+     simd_value1 = simd_value2;
+     simd_value1[0] = 3;
+     result = seqan3::simd::fill<TypeParam>(9);
+     result[0] = -3;
+-    SIMD_EQ(scheme.score(simd_value1, simd_value2), result);
++    // SIMD_EQ(scheme.score(simd_value1, simd_value2), result);
+ }
+ 
+ TYPED_TEST(simd_matrix_scoring_scheme_test, score_global_with_padding)
+@@ -135,20 +135,20 @@ TYPED_TEST(simd_matrix_scoring_scheme_test, score_global_with_padding)
+     TypeParam simd_value2 = seqan3::simd::fill<TypeParam>(3);
+     TypeParam result = seqan3::simd::fill<TypeParam>(-3);
+ 
+-    SIMD_EQ(scheme.score(simd_value1, simd_value2), result);
++    // SIMD_EQ(scheme.score(simd_value1, simd_value2), result);
+ 
+     // First value is regular symbol; second value is padded symbol => score of 1.
+     simd_value2[0] = this->padded_value1;
+     result[0] = 1;
+-    SIMD_EQ(scheme.score(simd_value1, simd_value2), result);
++    // SIMD_EQ(scheme.score(simd_value1, simd_value2), result);
+ 
+     // First value is padded symbol; second value is padded symbol => score of 1.
+     simd_value1[0] = this->padded_value1;
+-    SIMD_EQ(scheme.score(simd_value1, simd_value2), result);
++    // SIMD_EQ(scheme.score(simd_value1, simd_value2), result);
+ 
+     // First value is padded symbol; second value is regular symbol => score of 1.
+     simd_value2[0] = 2;
+-    SIMD_EQ(scheme.score(simd_value1, simd_value2), result);
++    // SIMD_EQ(scheme.score(simd_value1, simd_value2), result);
+ }
+ 
+ TYPED_TEST(simd_matrix_scoring_scheme_test, score_local)
+@@ -164,24 +164,24 @@ TYPED_TEST(simd_matrix_scoring_scheme_test, score_local)
+     TypeParam simd_value2 = seqan3::simd::fill<TypeParam>(2);
+ 
+     // all match
+-    SIMD_EQ(scheme.score(simd_value1, simd_value2), seqan3::simd::fill<TypeParam>(17));
++    // SIMD_EQ(scheme.score(simd_value1, simd_value2), seqan3::simd::fill<TypeParam>(17));
+ 
+     // all mismatch
+     simd_value2 = seqan3::simd::fill<TypeParam>(3);
+-    SIMD_EQ(scheme.score(simd_value1, simd_value2), seqan3::simd::fill<TypeParam>(-3));
++    // SIMD_EQ(scheme.score(simd_value1, simd_value2), seqan3::simd::fill<TypeParam>(-3));
+ 
+     // first matches, remaining mismatches.
+     simd_value2[0] = 2;
+     TypeParam result = seqan3::simd::fill<TypeParam>(-3);
+     result[0] = 17;
+-    SIMD_EQ(scheme.score(simd_value1, simd_value2), result);
++    // SIMD_EQ(scheme.score(simd_value1, simd_value2), result);
+ 
+     // first mismatches, remaining matches.
+     simd_value1 = simd_value2;
+     simd_value1[0] = 3;
+     result = seqan3::simd::fill<TypeParam>(9);
+     result[0] = -3;
+-    SIMD_EQ(scheme.score(simd_value1, simd_value2), result);
++    // SIMD_EQ(scheme.score(simd_value1, simd_value2), result);
+ }
+ 
+ TYPED_TEST(simd_matrix_scoring_scheme_test, score_local_with_padding)
+@@ -197,18 +197,18 @@ TYPED_TEST(simd_matrix_scoring_scheme_test, score_local_with_padding)
+     TypeParam simd_value2 = seqan3::simd::fill<TypeParam>(2);
+     TypeParam result = seqan3::simd::fill<TypeParam>(17);
+ 
+-    SIMD_EQ(scheme.score(simd_value1, simd_value2), result);
++    // SIMD_EQ(scheme.score(simd_value1, simd_value2), result);
+ 
+     // First value is regular symbol; second value is padded symbol => score of -1.
+     simd_value2[0] = this->padded_value2;
+     result[0] = -1;
+-    SIMD_EQ(scheme.score(simd_value1, simd_value2), result);
++    // SIMD_EQ(scheme.score(simd_value1, simd_value2), result);
+ 
+     // First value is padded symbol; second value is padded symbol => score of -1.
+     simd_value1[0] = this->padded_value1;
+-    SIMD_EQ(scheme.score(simd_value1, simd_value2), result);
++    // SIMD_EQ(scheme.score(simd_value1, simd_value2), result);
+ 
+     // First value is padded symbol; second value is regular symbol => score of -1.
+     simd_value2[0] = 3;
+-    SIMD_EQ(scheme.score(simd_value1, simd_value2), result);
++    // SIMD_EQ(scheme.score(simd_value1, simd_value2), result);
+ }
+-- 
+2.31.0
+

--- a/test/api_stability/3.0.2/0014-API-FIX-constructor-will-not-throw-any-more.patch
+++ b/test/api_stability/3.0.2/0014-API-FIX-constructor-will-not-throw-any-more.patch
@@ -1,0 +1,27 @@
+From 97ccaccf31c495955cafb08233db25b26d0a14fb Mon Sep 17 00:00:00 2001
+From: marehr <marehr-github@marehr.dialup.fu-berlin.de>
+Date: Fri, 19 Feb 2021 00:25:36 +0100
+Subject: [PATCH 14/22] [API] [FIX] constructor will not throw any more
+
+Commit 11bfdef7de4cd785a920f822c338c04d2538e5a0
+---
+ test/unit/argument_parser/format_parse_test.cpp | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/test/unit/argument_parser/format_parse_test.cpp b/test/unit/argument_parser/format_parse_test.cpp
+index ca4f9f95c..ad0576458 100644
+--- a/test/unit/argument_parser/format_parse_test.cpp
++++ b/test/unit/argument_parser/format_parse_test.cpp
+@@ -922,8 +922,7 @@ TEST(parse_test, subcommand_argument_parser_success)
+     // incorrect sub command
+     {
+         const char * argv[]{"./top_level", "-f", "2", "subiddysub", "foo"};
+-        EXPECT_THROW((seqan3::argument_parser{"top_level", 5, argv, false, {"sub1", "sub2"}}),
+-                     seqan3::argument_parser_error);
++        EXPECT_NO_THROW((seqan3::argument_parser{"top_level", 5, argv, false, {"sub1", "sub2"}}));
+     }
+ }
+ 
+-- 
+2.31.0
+

--- a/test/api_stability/3.0.2/0015-API-FIX-subcommand-is-now-allowed-to-contain-a-dash.patch
+++ b/test/api_stability/3.0.2/0015-API-FIX-subcommand-is-now-allowed-to-contain-a-dash.patch
@@ -1,0 +1,26 @@
+From 0fa3eaa9f15ac2ae22ce4ca55bdf80d94d0cf626 Mon Sep 17 00:00:00 2001
+From: marehr <marehr-github@marehr.dialup.fu-berlin.de>
+Date: Fri, 19 Feb 2021 00:25:36 +0100
+Subject: [PATCH 15/22] [API] [FIX] subcommand is now allowed to contain a dash
+
+Commit: f048ef6730b134c1c729c754046569d0f83c4d93
+---
+ test/unit/argument_parser/argument_parser_design_error_test.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/test/unit/argument_parser/argument_parser_design_error_test.cpp b/test/unit/argument_parser/argument_parser_design_error_test.cpp
+index f7101d760..ddf9c1efd 100644
+--- a/test/unit/argument_parser/argument_parser_design_error_test.cpp
++++ b/test/unit/argument_parser/argument_parser_design_error_test.cpp
+@@ -134,7 +134,7 @@ TEST(parse_test, subcommand_argument_parser_error)
+     {
+         const char * argv[]{"./top_level", "-f"};
+         EXPECT_THROW((seqan3::argument_parser{"top_level", 2, argv, false, {"with space"}}), seqan3::design_error);
+-        EXPECT_THROW((seqan3::argument_parser{"top_level", 2, argv, false, {"-dash"}}), seqan3::design_error);
++        EXPECT_NO_THROW((seqan3::argument_parser{"top_level", 2, argv, false, {"-dash"}}));
+     }
+ 
+     // no positional/options are allowed
+-- 
+2.31.0
+

--- a/test/api_stability/3.0.2/0016-API-FIX-std-cout-of-argument_parser-changed.patch
+++ b/test/api_stability/3.0.2/0016-API-FIX-std-cout-of-argument_parser-changed.patch
@@ -1,0 +1,278 @@
+From 634fd0f15ff036a8170c557a8d4c55213bd821c3 Mon Sep 17 00:00:00 2001
+From: marehr <marehr-github@marehr.dialup.fu-berlin.de>
+Date: Fri, 19 Feb 2021 00:31:41 +0100
+Subject: [PATCH 16/22] [API] [FIX] std::cout of argument_parser changed
+
+---
+ .../detail/format_help_test.cpp               | 24 +++++++++----------
+ .../detail/format_html_test.cpp               |  6 ++---
+ .../detail/format_man_test.cpp                | 10 ++++----
+ .../format_parse_validators_test.cpp          | 16 ++++++-------
+ 4 files changed, 28 insertions(+), 28 deletions(-)
+
+diff --git a/test/unit/argument_parser/detail/format_help_test.cpp b/test/unit/argument_parser/detail/format_help_test.cpp
+index 5064efe4a..338e4ce70 100644
+--- a/test/unit/argument_parser/detail/format_help_test.cpp
++++ b/test/unit/argument_parser/detail/format_help_test.cpp
+@@ -109,7 +109,7 @@ TEST(help_page_printing, no_information)
+                basic_options_str +
+                "\n" +
+                basic_version_str;
+-    EXPECT_EQ(std_cout, expected);
++    // EXPECT_EQ(std_cout, expected);
+ }
+ 
+ TEST(help_page_printing, with_short_copyright)
+@@ -130,7 +130,7 @@ TEST(help_page_printing, with_short_copyright)
+                "LEGAL\n"
+                "    test_parser Copyright: short\n"
+                "    SeqAn Copyright: 2006-2015 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.\n";
+-    EXPECT_EQ(std_cout, expected);
++    // EXPECT_EQ(std_cout, expected);
+ }
+ 
+ TEST(help_page_printing, with_long_copyright)
+@@ -150,7 +150,7 @@ TEST(help_page_printing, with_long_copyright)
+                "LEGAL\n"
+                "    SeqAn Copyright: 2006-2015 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.\n"
+                "    For full copyright and/or warranty information see --copyright.\n";
+-    EXPECT_EQ(std_cout, expected);
++    // EXPECT_EQ(std_cout, expected);
+ }
+ 
+ TEST(help_page_printing, with_citation)
+@@ -170,7 +170,7 @@ TEST(help_page_printing, with_citation)
+                "LEGAL\n"
+                "    SeqAn Copyright: 2006-2015 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.\n"
+                "    In your academic works please cite: citation\n";
+-    EXPECT_EQ(std_cout, expected);
++    // EXPECT_EQ(std_cout, expected);
+ }
+ 
+ TEST(help_page_printing, empty_advanced_help)
+@@ -187,7 +187,7 @@ TEST(help_page_printing, empty_advanced_help)
+                basic_options_str +
+                "\n" +
+                basic_version_str;
+-    EXPECT_EQ(std_cout, expected);
++    // EXPECT_EQ(std_cout, expected);
+ }
+ 
+ TEST(help_page_printing, empty_version_call)
+@@ -202,7 +202,7 @@ TEST(help_page_printing, empty_version_call)
+                "===========\n"
+                "\n" +
+                basic_version_str;
+-    EXPECT_EQ(std_cout, expected);
++    // EXPECT_EQ(std_cout, expected);
+ }
+ 
+ TEST(help_page_printing, version_call)
+@@ -224,7 +224,7 @@ TEST(help_page_printing, version_call)
+                "URL\n"
+                "    www.seqan.de\n"
+                "\n";
+-    EXPECT_EQ(std_cout, expected);
++    // EXPECT_EQ(std_cout, expected);
+ }
+ 
+ TEST(help_page_printing, do_not_print_hidden_options)
+@@ -243,7 +243,7 @@ TEST(help_page_printing, do_not_print_hidden_options)
+                basic_options_str +
+                "\n" +
+                basic_version_str;
+-    EXPECT_EQ(std_cout, expected);
++    // EXPECT_EQ(std_cout, expected);
+ }
+ 
+ TEST(help_page_printing, advanced_options)
+@@ -301,7 +301,7 @@ TEST(help_page_printing, advanced_options)
+                "    some line.\n"
+                "\n" +
+                basic_version_str;
+-    EXPECT_EQ(std_cout, expected);
++    // EXPECT_EQ(std_cout, expected);
+ 
+     // with -hh everything is shown
+     seqan3::argument_parser parser_advanced_help{"test_parser", 2, argv2};
+@@ -337,7 +337,7 @@ TEST(help_page_printing, advanced_options)
+                "    some line.\n"
+                "\n"+
+                basic_version_str;
+-    EXPECT_EQ(std_cout, expected);
++    // EXPECT_EQ(std_cout, expected);
+ }
+ 
+ enum class foo
+@@ -422,7 +422,7 @@ TEST(help_page_printing, full_information)
+                "    example2\n"
+                "\n" +
+                basic_version_str;
+-    EXPECT_EQ(std_cout, expected);
++    // EXPECT_EQ(std_cout, expected);
+ }
+ 
+ TEST(help_page_printing, copyright)
+@@ -531,5 +531,5 @@ TEST(parse_test, subcommand_argument_parser)
+                            "\n" +
+                            basic_version_str;
+ 
+-    EXPECT_EQ(std_cout, expected);
++    // EXPECT_EQ(std_cout, expected);
+ }
+diff --git a/test/unit/argument_parser/detail/format_html_test.cpp b/test/unit/argument_parser/detail/format_html_test.cpp
+index 887fbbe4d..e001ec000 100644
+--- a/test/unit/argument_parser/detail/format_html_test.cpp
++++ b/test/unit/argument_parser/detail/format_html_test.cpp
+@@ -54,14 +54,14 @@ TEST(html_format, empty_information)
+                            "<strong>SeqAn version:</strong> " + std::string{seqan3::seqan3_version_cstring} + "<br>\n"
+                            "<br>\n"
+                            "</body></html>");
+-    EXPECT_EQ(my_stdout, expected);
++    // EXPECT_EQ(my_stdout, expected);
+ 
+     const char * argv1[] = {"./help_add_test --version-check 0", "--export-help=html"};
+     seqan3::argument_parser parser1{"empty_options", 2, argv1};
+     testing::internal::CaptureStdout();
+     EXPECT_EXIT(parser1.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
+     my_stdout = testing::internal::GetCapturedStdout();
+-    EXPECT_EQ(my_stdout, expected);
++    // EXPECT_EQ(my_stdout, expected);
+ }
+ 
+ TEST(html_format, full_information_information)
+@@ -174,7 +174,7 @@ TEST(html_format, full_information_information)
+                           "<strong>In your academic works please cite:</strong> citation<br>\n"
+                           "For full copyright and/or warranty information see <tt>--copyright</tt>.\n"
+                           "</body></html>");
+-   EXPECT_EQ(my_stdout, expected);
++   // EXPECT_EQ(my_stdout, expected);
+ }
+ 
+ TEST(export_help, parse_error)
+diff --git a/test/unit/argument_parser/detail/format_man_test.cpp b/test/unit/argument_parser/detail/format_man_test.cpp
+index c7907da33..259519f24 100644
+--- a/test/unit/argument_parser/detail/format_man_test.cpp
++++ b/test/unit/argument_parser/detail/format_man_test.cpp
+@@ -147,7 +147,7 @@ TEST_F(format_man_test, empty_information)
+     EXPECT_EXIT(parser.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
+ 
+     my_stdout = testing::internal::GetCapturedStdout();
+-    EXPECT_EQ(my_stdout, expected_short);
++    // EXPECT_EQ(my_stdout, expected_short);
+ }
+ 
+ TEST_F(format_man_test, full_information)
+@@ -162,7 +162,7 @@ TEST_F(format_man_test, full_information)
+     EXPECT_EXIT(parser.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
+ 
+     my_stdout = testing::internal::GetCapturedStdout();
+-    EXPECT_EQ(my_stdout, expected);
++    // EXPECT_EQ(my_stdout, expected);
+ }
+ 
+ TEST_F(format_man_test, full_info_short_copyright)
+@@ -184,7 +184,7 @@ TEST_F(format_man_test, full_info_short_copyright)
+     EXPECT_EXIT(parser.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
+ 
+     my_stdout = testing::internal::GetCapturedStdout();
+-    EXPECT_EQ(my_stdout, expected);
++    // EXPECT_EQ(my_stdout, expected);
+ }
+ 
+ TEST_F(format_man_test, full_info_short_and_citation)
+@@ -209,7 +209,7 @@ TEST_F(format_man_test, full_info_short_and_citation)
+     EXPECT_EXIT(parser.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
+ 
+     my_stdout = testing::internal::GetCapturedStdout();
+-    EXPECT_EQ(my_stdout, expected);
++    // EXPECT_EQ(my_stdout, expected);
+ }
+ 
+ TEST_F(format_man_test, full_info_short_long_and_citation)
+@@ -236,5 +236,5 @@ For full copyright and/or warranty information see \fB--copyright\fR.
+     EXPECT_EXIT(parser.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");
+ 
+     my_stdout = testing::internal::GetCapturedStdout();
+-    EXPECT_EQ(my_stdout, expected);
++    // EXPECT_EQ(my_stdout, expected);
+ }
+diff --git a/test/unit/argument_parser/format_parse_validators_test.cpp b/test/unit/argument_parser/format_parse_validators_test.cpp
+index 616c8e603..45ecfea3a 100644
+--- a/test/unit/argument_parser/format_parse_validators_test.cpp
++++ b/test/unit/argument_parser/format_parse_validators_test.cpp
+@@ -183,7 +183,7 @@ TEST(validator_test, input_file)
+                                basic_options_str +
+                                "\n" +
+                                basic_version_str;
+-        EXPECT_EQ(my_stdout, expected);
++        // EXPECT_EQ(my_stdout, expected);
+     }
+ }
+ 
+@@ -291,7 +291,7 @@ TEST(validator_test, output_file)
+                                basic_options_str +
+                                "\n" +
+                                basic_version_str;
+-        EXPECT_EQ(my_stdout, expected);
++        // EXPECT_EQ(my_stdout, expected);
+     }
+ }
+ 
+@@ -364,7 +364,7 @@ TEST(validator_test, input_directory)
+                                "\n" +
+                                basic_version_str;
+ 
+-        EXPECT_EQ(my_stdout, expected);
++        // EXPECT_EQ(my_stdout, expected);
+     }
+ }
+ 
+@@ -415,7 +415,7 @@ TEST(validator_test, output_directory)
+                                            "\n" +
+                                            basic_version_str;
+ 
+-        EXPECT_EQ(my_stdout, expected);
++        // EXPECT_EQ(my_stdout, expected);
+     }
+ }
+ 
+@@ -675,7 +675,7 @@ TEST(validator_test, arithmetic_range_validator_success)
+                            basic_options_str +
+                            "\n" +
+                            basic_version_str);
+-    EXPECT_EQ(my_stdout, expected);
++    // EXPECT_EQ(my_stdout, expected);
+ 
+     // option - double value
+     double double_option_value;
+@@ -890,7 +890,7 @@ TEST(validator_test, value_list_validator_success)
+                            "          desc Default: []. Value must be one of [-10,48,50].\n"
+                            "\n" +
+                            basic_version_str);
+-    EXPECT_EQ(my_stdout, expected);
++    // EXPECT_EQ(my_stdout, expected);
+ }
+ 
+ TEST(validator_test, value_list_validator_error)
+@@ -1016,7 +1016,7 @@ TEST(validator_test, regex_validator_success)
+                            "          '[a-zA-Z]+@[a-zA-Z]+\\.com'.\n"
+                            "\n" +
+                            basic_version_str);
+-    EXPECT_EQ(my_stdout, expected);
++    // EXPECT_EQ(my_stdout, expected);
+ }
+ 
+ TEST(validator_test, regex_validator_error)
+@@ -1171,7 +1171,7 @@ TEST(validator_test, chaining_validators)
+                                "          pattern '.*'.\n"
+                                "\n"} +
+                                basic_version_str;
+-        EXPECT_EQ(my_stdout, expected);
++        // EXPECT_EQ(my_stdout, expected);
+     }
+ 
+     // chaining with a container option value type
+-- 
+2.31.0
+

--- a/test/api_stability/3.0.2/0017-API-FIX-type-deduction-for-seqan3-value_list_validat.patch
+++ b/test/api_stability/3.0.2/0017-API-FIX-type-deduction-for-seqan3-value_list_validat.patch
@@ -1,0 +1,38 @@
+From 68cbeceeaceb90980294a3eb5523153233662d92 Mon Sep 17 00:00:00 2001
+From: marehr <marehr-github@marehr.dialup.fu-berlin.de>
+Date: Fri, 19 Feb 2021 00:32:59 +0100
+Subject: [PATCH 17/22] [API] [FIX] type deduction for
+ seqan3::value_list_validator changed
+
+Commit d61d796efdaf904135b8050f44663ec844703011
+---
+ test/unit/argument_parser/format_parse_validators_test.cpp | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/test/unit/argument_parser/format_parse_validators_test.cpp b/test/unit/argument_parser/format_parse_validators_test.cpp
+index 45ecfea3a..c2f051dac 100644
+--- a/test/unit/argument_parser/format_parse_validators_test.cpp
++++ b/test/unit/argument_parser/format_parse_validators_test.cpp
+@@ -771,16 +771,16 @@ TEST(validator_test, value_list_validator_success)
+     // type deduction
+     // --------------
+     // all arithmetic types are deduced to double in order to easily allow chaining of arithmetic validators
+-    EXPECT_TRUE((std::same_as<seqan3::value_list_validator<double>,
++    EXPECT_TRUE((std::same_as<seqan3::value_list_validator<int>,
+                  decltype(seqan3::value_list_validator{1})>));
+     // except char
+     EXPECT_TRUE((std::same_as<seqan3::value_list_validator<char>,
+                  decltype(seqan3::value_list_validator{'c'})>));
+     // The same holds for a range of arithmetic types
+     std::vector v{1, 2, 3};
+-    EXPECT_TRUE((std::same_as<seqan3::value_list_validator<double>,
++    EXPECT_TRUE((std::same_as<seqan3::value_list_validator<int>,
+                  decltype(seqan3::value_list_validator{v})>));
+-    EXPECT_TRUE((std::same_as<seqan3::value_list_validator<double>,
++    EXPECT_TRUE((std::same_as<seqan3::value_list_validator<int>,
+                  decltype(seqan3::value_list_validator{v | std::views::take(2)})>));
+     std::vector v_char{'1', '2', '3'};
+     EXPECT_TRUE((std::same_as<seqan3::value_list_validator<char>,
+-- 
+2.31.0
+

--- a/test/api_stability/3.0.2/0018-API-FIX-the-internal-order-of-piping-seqan3-configur.patch
+++ b/test/api_stability/3.0.2/0018-API-FIX-the-internal-order-of-piping-seqan3-configur.patch
@@ -1,0 +1,48 @@
+From 43a5455c055be92c286b0f7f28ecf41a0083f7f5 Mon Sep 17 00:00:00 2001
+From: marehr <marehr-github@marehr.dialup.fu-berlin.de>
+Date: Fri, 19 Feb 2021 00:36:51 +0100
+Subject: [PATCH 18/22] [API] [FIX] the internal order of piping
+ seqan3::configuration changed
+
+Commit: ec2bd8a9ddf07a6cb749e2df712acd4ae8dccf15
+---
+ test/unit/core/algorithm/pipeable_config_element_test.cpp | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/test/unit/core/algorithm/pipeable_config_element_test.cpp b/test/unit/core/algorithm/pipeable_config_element_test.cpp
+index 2feeb214f..88beaf91d 100644
+--- a/test/unit/core/algorithm/pipeable_config_element_test.cpp
++++ b/test/unit/core/algorithm/pipeable_config_element_test.cpp
+@@ -79,25 +79,25 @@ TEST(pipeable_config_element, element_with_configuration)
+     // lvalue | lvalue
+     {
+         auto cfg = b2 | tmp;
+-        EXPECT_TRUE((std::is_same_v<decltype(cfg), seqan3::configuration<bar, bax>>));
++        EXPECT_TRUE((std::is_same_v<decltype(cfg), seqan3::configuration<bax, bar>>));
+     }
+ 
+     // rvalue | lvalue
+     {
+         auto cfg = bax{} | tmp;
+-        EXPECT_TRUE((std::is_same_v<decltype(cfg), seqan3::configuration<bar, bax>>));
++        EXPECT_TRUE((std::is_same_v<decltype(cfg), seqan3::configuration<bax, bar>>));
+     }
+ 
+     // lvalue | rvalue
+     {
+         auto cfg = b2 | seqan3::configuration<bar>{};
+-        EXPECT_TRUE((std::is_same_v<decltype(cfg), seqan3::configuration<bar, bax>>));
++        EXPECT_TRUE((std::is_same_v<decltype(cfg), seqan3::configuration<bax, bar>>));
+     }
+ 
+     // rvalue | rvalue
+     {
+         auto cfg = bax{} | seqan3::configuration<bar>{};
+-        EXPECT_TRUE((std::is_same_v<decltype(cfg), seqan3::configuration<bar, bax>>));
++        EXPECT_TRUE((std::is_same_v<decltype(cfg), seqan3::configuration<bax, bar>>));
+     }
+ }
+ 
+-- 
+2.31.0
+

--- a/test/api_stability/3.0.2/0019-API-FIX-arithmetic_range_validator-should-take-any-i.patch
+++ b/test/api_stability/3.0.2/0019-API-FIX-arithmetic_range_validator-should-take-any-i.patch
@@ -1,0 +1,33 @@
+From 1da6d887ff29653271ea326f5f465a62062c3432 Mon Sep 17 00:00:00 2001
+From: Marcel <marehr@users.noreply.github.com>
+Date: Thu, 25 Feb 2021 09:08:18 +0100
+Subject: [PATCH 19/22] [API] [FIX] arithmetic_range_validator should take any
+ integer type (#2391)
+
+* [FIX] arithmetic_range_validator should take any integer type
+
+* [DOC] value_list_validator: remove section that it decays to double
+
+* Apply suggestions from code review
+
+Co-authored-by: Enrico Seiler <eseiler@users.noreply.github.com>
+---
+ test/unit/argument_parser/format_parse_validators_test.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/test/unit/argument_parser/format_parse_validators_test.cpp b/test/unit/argument_parser/format_parse_validators_test.cpp
+index c2f051dac..3be81ab94 100644
+--- a/test/unit/argument_parser/format_parse_validators_test.cpp
++++ b/test/unit/argument_parser/format_parse_validators_test.cpp
+@@ -77,7 +77,7 @@ TEST(validator_test, fullfill_concept)
+     EXPECT_TRUE(seqan3::validator<seqan3::detail::default_validator<int> &>);
+ 
+     EXPECT_TRUE(seqan3::validator<seqan3::detail::default_validator<std::vector<int>>>);
+-    EXPECT_TRUE(seqan3::validator<seqan3::arithmetic_range_validator>);
++    EXPECT_TRUE(seqan3::validator<seqan3::arithmetic_range_validator<int>>);
+     EXPECT_TRUE(seqan3::validator<seqan3::value_list_validator<double>>);
+     EXPECT_TRUE(seqan3::validator<seqan3::value_list_validator<std::string>>);
+     EXPECT_TRUE(seqan3::validator<seqan3::input_file_validator<>>);
+-- 
+2.31.0
+

--- a/test/api_stability/3.0.2/0020-NOAPI-DEPRECATED-MISC-remove-seqan3-stream_REMOVEME.patch
+++ b/test/api_stability/3.0.2/0020-NOAPI-DEPRECATED-MISC-remove-seqan3-stream_REMOVEME.patch
@@ -1,0 +1,43 @@
+From 082b1e365c8e4a81be6c912681fc2f9c7707f66d Mon Sep 17 00:00:00 2001
+From: Enrico Seiler <enrico.seiler@hotmail.de>
+Date: Sat, 20 Feb 2021 17:44:37 +0100
+Subject: [PATCH 20/22] [NOAPI] [DEPRECATED] [MISC] remove
+ seqan3::stream_REMOVEME
+
+---
+ test/unit/io/concept_test.cpp | 19 -------------------
+ 1 file changed, 19 deletions(-)
+
+diff --git a/test/unit/io/concept_test.cpp b/test/unit/io/concept_test.cpp
+index 3220ef265..95707cb4f 100644
+--- a/test/unit/io/concept_test.cpp
++++ b/test/unit/io/concept_test.cpp
+@@ -16,25 +16,6 @@
+ 
+ #include <seqan3/io/stream/concept.hpp>
+ 
+-TEST(io, stream_REMOVEME)
+-{
+-    EXPECT_FALSE((seqan3::stream_REMOVEME<std::istream, char>));
+-    EXPECT_FALSE((seqan3::stream_REMOVEME<std::ostream, char>));
+-    EXPECT_TRUE((seqan3::stream_REMOVEME<std::iostream, char>));
+-    EXPECT_FALSE((seqan3::stream_REMOVEME<std::ifstream, char>));
+-    EXPECT_FALSE((seqan3::stream_REMOVEME<std::ofstream, char>));
+-    EXPECT_TRUE((seqan3::stream_REMOVEME<std::fstream, char>));
+-    EXPECT_FALSE((seqan3::stream_REMOVEME<std::istringstream, char>));
+-    EXPECT_FALSE((seqan3::stream_REMOVEME<std::ostringstream, char>));
+-    EXPECT_TRUE((seqan3::stream_REMOVEME<std::stringstream, char>));
+-    EXPECT_FALSE((seqan3::stream_REMOVEME<std::vector<char>, char>));
+-    EXPECT_FALSE((seqan3::stream_REMOVEME<std::vector<char>, char>));
+-    EXPECT_FALSE((seqan3::stream_REMOVEME<std::vector<char>, char>));
+-    EXPECT_FALSE((seqan3::stream_REMOVEME<std::string, char>));
+-    EXPECT_FALSE((seqan3::stream_REMOVEME<std::string, char>));
+-    EXPECT_FALSE((seqan3::stream_REMOVEME<std::string, char>));
+-}
+-
+ TEST(io, input_stream_over)
+ {
+     EXPECT_TRUE((seqan3::input_stream_over<std::istream, char>));
+-- 
+2.31.0
+

--- a/test/api_stability/3.0.2/0021-NOAPI-DETAIL-MISC-introduce-alphabet_variant-rank_to.patch
+++ b/test/api_stability/3.0.2/0021-NOAPI-DETAIL-MISC-introduce-alphabet_variant-rank_to.patch
@@ -1,0 +1,96 @@
+From 69c44e99f400f47db91d84eef7da837fa488e2bd Mon Sep 17 00:00:00 2001
+From: marehr <marehr-github@marehr.dialup.fu-berlin.de>
+Date: Thu, 25 Feb 2021 11:08:18 +0100
+Subject: [PATCH 21/22] [NOAPI] [DETAIL] [MISC] introduce
+ alphabet_variant::{rank_to_char, char_to_rank} function
+
+---
+ .../alphabet_variant_detail_test.cpp          | 28 ++++++++++++-------
+ 1 file changed, 18 insertions(+), 10 deletions(-)
+
+diff --git a/test/unit/alphabet/composite/alphabet_variant_detail_test.cpp b/test/unit/alphabet/composite/alphabet_variant_detail_test.cpp
+index 658544d1e..1506b7a75 100644
+--- a/test/unit/alphabet/composite/alphabet_variant_detail_test.cpp
++++ b/test/unit/alphabet/composite/alphabet_variant_detail_test.cpp
+@@ -19,8 +19,8 @@ class detail_alphabet_variant : public seqan3::alphabet_variant<alphabet_types..
+ {
+ public:
+     using seqan3::alphabet_variant<alphabet_types...>::partial_sum_sizes;
+-    using seqan3::alphabet_variant<alphabet_types...>::rank_to_char;
+-    using seqan3::alphabet_variant<alphabet_types...>::char_to_rank;
++    using seqan3::alphabet_variant<alphabet_types...>::rank_to_char_table;
++    using seqan3::alphabet_variant<alphabet_types...>::char_to_rank_table;
+ };
+ 
+ TEST(alphabet_variant_detail_test, partial_sum_sizes)
+@@ -50,9 +50,9 @@ TEST(alphabet_variant_detail_test, partial_sum_sizes)
+     EXPECT_EQ(partial_sum4[3], 10);
+ }
+ 
+-TEST(alphabet_variant_detail_test, rank_to_char)
++TEST(alphabet_variant_detail_test, rank_to_char_table)
+ {
+-    constexpr std::array rank_to_char2 = detail_alphabet_variant<seqan3::dna4, seqan3::gap>::rank_to_char;
++    constexpr std::array rank_to_char2 = detail_alphabet_variant<seqan3::dna4, seqan3::gap>::rank_to_char_table;
+     EXPECT_EQ(rank_to_char2.size(), 5u);
+     EXPECT_EQ(rank_to_char2[0], 'A');
+     EXPECT_EQ(rank_to_char2[1], 'C');
+@@ -60,7 +60,9 @@ TEST(alphabet_variant_detail_test, rank_to_char)
+     EXPECT_EQ(rank_to_char2[3], 'T');
+     EXPECT_EQ(rank_to_char2[4], '-');
+ 
+-    constexpr std::array rank_to_char3 = detail_alphabet_variant<seqan3::dna4, seqan3::gap, seqan3::dna5>::rank_to_char;
++    constexpr std::array rank_to_char3 = detail_alphabet_variant<seqan3::dna4,
++                                                                 seqan3::gap,
++                                                                 seqan3::dna5>::rank_to_char_table;
+     EXPECT_EQ(rank_to_char3.size(), 10u);
+     EXPECT_EQ(rank_to_char3[0], 'A');
+     EXPECT_EQ(rank_to_char3[1], 'C');
+@@ -73,7 +75,9 @@ TEST(alphabet_variant_detail_test, rank_to_char)
+     EXPECT_EQ(rank_to_char3[8], 'N');
+     EXPECT_EQ(rank_to_char3[9], 'T');
+ 
+-    constexpr std::array rank_to_char4 = detail_alphabet_variant<seqan3::dna5, seqan3::gap, seqan3::dna4>::rank_to_char;
++    constexpr std::array rank_to_char4 = detail_alphabet_variant<seqan3::dna5,
++                                                                 seqan3::gap,
++                                                                 seqan3::dna4>::rank_to_char_table;
+     EXPECT_EQ(rank_to_char4.size(), 10u);
+     EXPECT_EQ(rank_to_char4[0], 'A');
+     EXPECT_EQ(rank_to_char4[1], 'C');
+@@ -87,9 +91,9 @@ TEST(alphabet_variant_detail_test, rank_to_char)
+     EXPECT_EQ(rank_to_char4[9], 'T');
+ }
+ 
+-TEST(alphabet_variant_detail_test, char_to_rank)
++TEST(alphabet_variant_detail_test, char_to_rank_table)
+ {
+-    constexpr std::array char_to_rank2 = detail_alphabet_variant<seqan3::dna4, seqan3::gap>::char_to_rank;
++    constexpr std::array char_to_rank2 = detail_alphabet_variant<seqan3::dna4, seqan3::gap>::char_to_rank_table;
+     EXPECT_EQ(char_to_rank2.size(), 256u);
+     EXPECT_EQ(char_to_rank2['A'], 0);
+     EXPECT_EQ(char_to_rank2['C'], 1);
+@@ -97,7 +101,9 @@ TEST(alphabet_variant_detail_test, char_to_rank)
+     EXPECT_EQ(char_to_rank2['T'], 3);
+     EXPECT_EQ(char_to_rank2['-'], 4);
+ 
+-    constexpr std::array char_to_rank3 = detail_alphabet_variant<seqan3::dna4, seqan3::gap, seqan3::dna5>::char_to_rank;
++    constexpr std::array char_to_rank3 = detail_alphabet_variant<seqan3::dna4,
++                                                                 seqan3::gap,
++                                                                 seqan3::dna5>::char_to_rank_table;
+     EXPECT_EQ(char_to_rank3.size(), 256u);
+     EXPECT_EQ(char_to_rank3['A'], 0);
+     EXPECT_EQ(char_to_rank3['C'], 1);
+@@ -110,7 +116,9 @@ TEST(alphabet_variant_detail_test, char_to_rank)
+     EXPECT_EQ(char_to_rank3['N'], 8);
+     EXPECT_EQ(char_to_rank3['T'], 3);
+ 
+-    constexpr std::array char_to_rank4 = detail_alphabet_variant<seqan3::dna5, seqan3::gap, seqan3::dna4>::char_to_rank;
++    constexpr std::array char_to_rank4 = detail_alphabet_variant<seqan3::dna5,
++                                                                 seqan3::gap,
++                                                                 seqan3::dna4>::char_to_rank_table;
+     EXPECT_EQ(char_to_rank4.size(), 256u);
+     EXPECT_EQ(char_to_rank4['A'], 0);
+     EXPECT_EQ(char_to_rank4['C'], 1);
+-- 
+2.31.0
+

--- a/test/api_stability/3.0.2/0022-API-FIX-compression-streams-writing-wrong-format.patch
+++ b/test/api_stability/3.0.2/0022-API-FIX-compression-streams-writing-wrong-format.patch
@@ -1,0 +1,53 @@
+From 9426763cd3e300a0367e4acfd048060fc327efba Mon Sep 17 00:00:00 2001
+From: Enrico Seiler <enrico.seiler@hotmail.de>
+Date: Tue, 23 Mar 2021 11:59:03 +0100
+Subject: [PATCH 22/22] [API] [FIX] compression streams writing wrong format
+
+---
+ test/unit/io/alignment_file/alignment_file_output_test.cpp | 2 +-
+ test/unit/io/sequence_file/sequence_file_output_test.cpp   | 2 +-
+ test/unit/io/structure_file/structure_file_output_test.cpp | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/test/unit/io/alignment_file/alignment_file_output_test.cpp b/test/unit/io/alignment_file/alignment_file_output_test.cpp
+index 1a0984025..489c78b7f 100644
+--- a/test/unit/io/alignment_file/alignment_file_output_test.cpp
++++ b/test/unit/io/alignment_file/alignment_file_output_test.cpp
+@@ -653,7 +653,7 @@ TEST(compression, by_filename_gz)
+ 
+     std::string buffer = compression_by_filename_impl(filename);
+     buffer[9] = '\x00'; // zero out OS byte.
+-    EXPECT_EQ(buffer, expected_bgzf);
++    EXPECT_EQ(buffer, expected_gz);
+ }
+ 
+ TEST(compression, by_stream_gz)
+diff --git a/test/unit/io/sequence_file/sequence_file_output_test.cpp b/test/unit/io/sequence_file/sequence_file_output_test.cpp
+index 0367538f1..d5cb90fd5 100644
+--- a/test/unit/io/sequence_file/sequence_file_output_test.cpp
++++ b/test/unit/io/sequence_file/sequence_file_output_test.cpp
+@@ -528,7 +528,7 @@ TEST(compression, by_filename_gz)
+ 
+     std::string buffer = compression_by_filename_impl(filename);
+     buffer[9] = '\x00'; // zero out OS byte
+-    EXPECT_EQ(buffer, expected_bgzf);
++    EXPECT_EQ(buffer, expected_gz);
+ }
+ 
+ TEST(compression, by_stream_gz)
+diff --git a/test/unit/io/structure_file/structure_file_output_test.cpp b/test/unit/io/structure_file/structure_file_output_test.cpp
+index 2a710a204..40d58b9b1 100644
+--- a/test/unit/io/structure_file/structure_file_output_test.cpp
++++ b/test/unit/io/structure_file/structure_file_output_test.cpp
+@@ -481,7 +481,7 @@ TEST_F(structure_file_output_compression, by_filename_gz)
+     seqan3::test::tmp_filename filename{"structure_file_output_test.dbn.gz"};
+     std::string buffer = compression_by_filename_impl(filename);
+     buffer[9] = '\x00'; // zero out OS byte
+-    EXPECT_EQ(buffer, expected_bgzf);
++    EXPECT_EQ(buffer, expected_gz);
+ }
+ 
+ TEST_F(structure_file_output_compression, by_stream_gz)
+-- 
+2.31.0
+

--- a/test/api_stability/CMakeLists.txt
+++ b/test/api_stability/CMakeLists.txt
@@ -1,0 +1,47 @@
+cmake_minimum_required(VERSION 3.8)
+
+project (api_stability)
+
+find_package(Git)
+
+include (../seqan3-test.cmake)
+
+include (ExternalProject)
+set (SEQAN3_LAST_STABLE_VERSION "3.0.2")
+set (SEQAN3_LAST_STABLE_SOURCE_URL "https://github.com/seqan/seqan3/releases/download/${SEQAN3_LAST_STABLE_VERSION}/seqan3-${SEQAN3_LAST_STABLE_VERSION}-Source.tar.xz")
+set (SEQAN3_LAST_STABLE_SOURCE_SHA256 "bab1a9cd0c01fd486842e0fa7a5b41c1bf6d2c43fdadf4c543956923deb62ee9")
+
+ExternalProject_Add(api_stability_unit
+  URL               ${SEQAN3_LAST_STABLE_SOURCE_URL}
+  URL_HASH          SHA256=${SEQAN3_LAST_STABLE_SOURCE_SHA256}
+  SOURCE_SUBDIR     "test/unit"
+  CMAKE_ARGS        ${SEQAN3_EXTERNAL_PROJECT_CMAKE_ARGS}
+                    -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+                    -DCMAKE_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER}
+                    -DCMAKE_PREFIX_PATH=${CMAKE_CURRENT_LIST_DIR}/../../build_system # use current build_system
+  PATCH_COMMAND     ${CMAKE_COMMAND} -E echo "<SOURCE_DIR>"
+  COMMAND           ${CMAKE_COMMAND} -E remove_directory "<SOURCE_DIR>/include"
+  COMMAND           ${CMAKE_COMMAND} -E remove_directory "<SOURCE_DIR>/submodules"
+  COMMAND           ${CMAKE_COMMAND} -E remove_directory "<SOURCE_DIR>/build_system"
+  COMMAND           sh -c "${GIT_EXECUTABLE} apply -v ${CMAKE_CURRENT_LIST_DIR}/${SEQAN3_LAST_STABLE_VERSION}/*.patch"
+  TEST_BEFORE_INSTALL TRUE
+  INSTALL_COMMAND   ""
+)
+
+# Same as above, but with snippet instead of unit
+ExternalProject_Add(api_stability_snippet
+  URL               ${SEQAN3_LAST_STABLE_SOURCE_URL}
+  URL_HASH          SHA256=${SEQAN3_LAST_STABLE_SOURCE_SHA256}
+  SOURCE_SUBDIR     "test/snippet"
+  CMAKE_ARGS        ${SEQAN3_EXTERNAL_PROJECT_CMAKE_ARGS}
+                    -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+                    -DCMAKE_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER}
+                    -DCMAKE_PREFIX_PATH=${CMAKE_CURRENT_LIST_DIR}/../../build_system # use current build_system
+  PATCH_COMMAND     ${CMAKE_COMMAND} -E echo "<SOURCE_DIR>"
+  COMMAND           ${CMAKE_COMMAND} -E remove_directory "<SOURCE_DIR>/include"
+  COMMAND           ${CMAKE_COMMAND} -E remove_directory "<SOURCE_DIR>/submodules"
+  COMMAND           ${CMAKE_COMMAND} -E remove_directory "<SOURCE_DIR>/build_system"
+  COMMAND           sh -c "${GIT_EXECUTABLE} apply -v ${CMAKE_CURRENT_LIST_DIR}/${SEQAN3_LAST_STABLE_VERSION}/*.patch"
+  TEST_BEFORE_INSTALL TRUE
+  INSTALL_COMMAND   ""
+)

--- a/test/api_stability/README.md
+++ b/test/api_stability/README.md
@@ -1,0 +1,150 @@
+# SeqAn3 API Stability
+
+This test suite will check whether the current version of seqan3 (e.g. git checkout) can be used to build the test cases
+of the latest stable version of seqan3 (https://github.com/seqan/seqan3/releases/latest).
+
+By seeing which of our own previous test cases break, we can estimate how difficult it is to upgrade an external app and
+adapt our changelog accordingly.
+
+### Usage
+
+```bash
+cd <build_dir> # e.g. seqan3-builds/api_stability/
+
+# we recommend to disable deprecation warnings in CI
+cmake -DCMAKE_CXX_FLAGS="-DSEQAN3_DISABLE_DEPRECATED_WARNINGS=1" <seqan3_git_checkout>
+
+# if you want to build with 40 threads, you need to use CMAKE_BUILD_PARALLEL_LEVEL to specify the threads
+# a normal `make -j 40` or `cmake --build . -j 40` will not work
+CMAKE_BUILD_PARALLEL_LEVEL=40 cmake --build .
+```
+
+### How does this work?
+
+In the following we will use `3.0.2` as the latest stable release (LSR).
+
+The workflow entails these steps:
+1. Download and unzip the LSR.
+2. Remove everything from the LSR except the tests in `<seqan3_lsr_source>/test/`.
+3. Apply patches from the current git version on the LSR, i.e., patches found in
+   `<seqan3_git_source>/test/api_stability/3.0.2`.
+  * These patches will only apply changes on the tests.
+  * This step is necessary as some of our tests also test non-public / non-stable API.
+3. Use the current version of `find_package (SeqAn3)` found in `<seqan3_git_source>/build_system`.
+4. Configure the tests `<seqan3_lsr_source>/test/unit` with our current seqan3 header-library
+   (e.g. `<seqan3_git_source>/include` and `<seqan3_git_source>/submodules/*/include`).
+  * But use the test cases from the LSR.
+5. Build all tests.
+6. Run all tests.
+7. If any of the above steps fail, the complete build will fail.
+
+We can apply this workflow to every kind of test (e.g., `test/unit`, `test/snippet`, `test/performance`) that we have.
+Currently, we only test `test/unit` and `test/snippet` as both of them test most of our public API.
+
+### When to create patches and what is the naming scheme?
+
+Patches should only be created if API changed in a way that we cannot give an "automatic" upgrade path by, for example,
+defining a type alias, a compatible function that perfectly forwards to the new API or some other means that provide the
+old API which then uses the new API. Please try your hardest to provide "compatible" API, as this is the easiest for the
+user.
+
+There are two categories of API changes that are reflected in the patches (prefixes in the commit message):
+
+* `[API]` are patches that changed the public API in some way (regardless of whether this is `stable` or `experimental`
+  API), like the behaviour, the return type or the call convention. These patches should always have a `CHANGELOG.md` 
+  entry explaining what the change did. `[API]` changes are further divided into these subcategories:
+  * `[API] [BREAKAGE]` An API that existed and has a completely different meaning now, such a change MUST have a really
+    good reason and should be avoided or documented extremely well.
+  * `[API] [FIX]` The change was necessary, as it fixed a defect. Some examples:
+    * A function does not throw anymore / will throw now.
+    * Format of output (e.g., `std::cout`) changed.
+    * CTAD changed (e.g., `some_class{0}` will now be of type `some_class<int>` instead of `some_class<double>`).
+    * The return type changed / order within template parameters changed.
+  * `[API] [WRONG-USAGE]` An API was misused in the test or tested some invalid scenarios.
+* `[NOAPI]` are patches that change internal (e.g., `seqan3::detail` or `private` member) or non-public API (e.g., 
+  marked `\noapi`). These changes do not need an upgrade path. We differentiate between the following subcategories:
+  * `[NOAPI] [INCLUDE]` Some header file was moved, or an unnecessary include was removed in some header,
+    which caused a test to explicitly include that header. As there are tools like [Include What You
+    Use](https://github.com/include-what-you-use/include-what-you-use), we do not consider these changes as API 
+    stability issues. We will still try to add an upgrade path if possible (like when we split `/include/seqan3/core` 
+    and `/include/seqan3/utility`) and add `CHANGELOG.md` entries for every header change.
+  * `[NOAPI] [DETAIL]` Some `seqan3::detail` code changed, like a rename, or template parameter change.
+  * `[NOAPI] [DEPRECATED]` Some deprecated code was removed.
+  * `[NOAPI] [BREAKAGE]` The same API has a considerable different behaviour. E.g., it accepted some
+    input before, but now it would segfault on the same input.
+
+
+### How to create patches?
+
+In the following, we will use `3.0.2` as the latest stable release (LSR).
+
+Create a new branch based on the LSR and apply all existing patches in `<seqan3_git_source>/test/api_stability/3.0.2`.
+
+```
+cd <seqan3_git_source>
+
+# assume that your current branch you are working on is fix_api_stability
+git checkout fix_api_stability
+
+# copy over patches to a tmp directory (`git am` seems to not support applying patches onto a different branch)
+mkdir -p /tmp/seqan3-api-stability-patches
+cp test/api_stability/3.0.2/*.patch /tmp/seqan3-api-stability-patches
+
+# create a new branch based on the LSR and switch to it
+git checkout -b api-stability-patches 3.0.2
+
+# apply all patches onto 3.0.2 (--keep-non-patch will keep `[NOAPI]` tags in the commit message)
+git am --keep-non-patch /tmp/seqan3-api-stability-patches/*.patch
+
+# clean up applied patches
+rm /tmp/seqan3-api-stability-patches/*.patch
+```
+
+Now re-apply the commit(s) that changed the API.
+
+```
+git cherry-pick <commit>
+
+# fix possible merge conflicts and continue cherry-picking
+git cherry-pick --continue
+
+# remove everything except test/unit and test/snippet
+
+# commit everything to the current cherry-picked commit
+git commit --amend
+```
+
+You will most likely get merge conflicts, you can ignore all merge conflicts in any folder other than
+`<seqan3_lsr_source>/test/unit` or `<seqan3_lsr_source>/test/snippet` (as only those kinds of tests are currently
+tested by the api_stability test).
+
+It is also important that you double check if the patch only contains changes that apply to
+`<seqan3_lsr_source>/test/{unit, snippet}`, any other change must be discarded.
+
+After that, we can export all patches.
+
+```
+# export all patches since 3.0.2
+git format-patch 3.0.2
+
+# move them to tmp directory
+mv *.patch /tmp/seqan3-api-stability-patches
+```
+
+Now change to your branch that you were working on and check-in the patches.
+
+```
+git checkout fix_api_stability
+
+cp /tmp/seqan3-api-stability-patches/*.patch test/api_stability/3.0.2/
+
+rm -rf /tmp/seqan3-api-stability-patches
+
+# add new patches
+git add test/api_stability/3.0.2/
+
+# commit changes
+git commit
+```
+
+Before pushing, try whether the patches work as intended.


### PR DESCRIPTION
This is a new infrastructure to test API stability on the basis of our tests from our latest stable release.

Most of the included patches are cherry-picked on top of the 3.0.2 release.