### PR TITLE
[FEATURE] implementation of a bloom filter

### DIFF
--- a/include/seqan3/utility/bloom_filter/all.hpp
+++ b/include/seqan3/utility/bloom_filter/all.hpp
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------------------------------------
-// Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
-// Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+// Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
 // This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
 // shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 // -----------------------------------------------------------------------------------------------------

--- a/include/seqan3/utility/bloom_filter/all.hpp
+++ b/include/seqan3/utility/bloom_filter/all.hpp
@@ -11,7 +11,7 @@
  *
  * \defgroup submodule_bloom_filter Bloom Filter
  * \brief Provides seqan3:bloom_filter.
- * \ingroup search
+ * \ingroup utility
  */
 
  #pragma once

--- a/include/seqan3/utility/bloom_filter/all.hpp
+++ b/include/seqan3/utility/bloom_filter/all.hpp
@@ -9,7 +9,7 @@
  * \author Tobias Loka <tobias.loka AT hpi.de>
  * \brief Meta-header for the Bloom Filter.
  *
- * \defgroup submodule_bloom_filter Bloom Filter
+ * \defgroup utility_bloom_filter Bloom Filter
  * \brief Provides seqan3:bloom_filter.
  * \ingroup utility
  */
@@ -17,3 +17,4 @@
  #pragma once
 
  #include <seqan3/utility/bloom_filter/bloom_filter.hpp>
+ 

--- a/include/seqan3/utility/bloom_filter/all.hpp
+++ b/include/seqan3/utility/bloom_filter/all.hpp
@@ -17,4 +17,3 @@
  #pragma once
 
  #include <seqan3/utility/bloom_filter/bloom_filter.hpp>
- 

--- a/include/seqan3/utility/bloom_filter/all.hpp
+++ b/include/seqan3/utility/bloom_filter/all.hpp
@@ -1,0 +1,19 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \author Tobias Loka <tobias.loka AT hpi.de>
+ * \brief Meta-header for the Bloom Filter.
+ *
+ * \defgroup submodule_bloom_filter Bloom Filter
+ * \brief Provides seqan3:bloom_filter.
+ * \ingroup search
+ */
+
+ #pragma once
+
+ #include <seqan3/utility/bloom_filter/bloom_filter.hpp>

--- a/include/seqan3/utility/bloom_filter/bloom_filter.hpp
+++ b/include/seqan3/utility/bloom_filter/bloom_filter.hpp
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------------------------------------
-// Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
-// Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+// Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
 // This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
 // shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 // -----------------------------------------------------------------------------------------------------

--- a/include/seqan3/utility/bloom_filter/bloom_filter.hpp
+++ b/include/seqan3/utility/bloom_filter/bloom_filter.hpp
@@ -1,0 +1,385 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \author Tobias Loka <tobias.loka AT hpi.de>
+ * \brief Provides seqan3::bloom_filter.
+ */
+
+#pragma once
+
+#include <seqan3/std/algorithm>
+#include <seqan3/std/bit>
+#include <seqan3/search/dream_index/interleaved_bloom_filter.hpp>
+
+#include <sdsl/bit_vectors.hpp>
+
+#include <seqan3/core/concept/cereal.hpp>
+#include <seqan3/core/detail/strong_type.hpp>
+
+namespace seqan3
+{
+
+/*!\brief The bloom filter. A data structure that efficiently answers set-membership queries.
+ * \tparam data_layout_mode_ Indicates whether the underlying data type is compressed. See seqan3::data_layout.
+ * \implements seqan3::cerealisable
+ *
+ * \details
+ *
+ * ### Bloom Filter (BF)
+ *
+ * The [Bloom Filter](https://en.wikipedia.org/wiki/Bloom_filter) is a probabilistic data structure.
+ * A Bloom Filter can be thought of as a bitvector of length `n` and `h` hash functions and is used to determine set
+ * membership. To insert data, the data is hashed by the `h` hash functions (returning values in `[0, n)`) and the
+ * corresponding `h` positions in the bitvector are set to `1`. To query data, i.e. to determine whether the query
+ * belongs to the set the Bloom Filter was built for, the query is hashed by the same `h` hash functions and the
+ * corresponding positions are checked. If all `h` positions contain a `1`, the query is (probably) in the data set.
+ * Since the Bloom Filter has variable length, the hashing is not bijective, i.e. it may return true for a set
+ * membership query even though the query was never inserted into the Bloom Filter. Note that the Bloom Filter
+ * will always return `true` if the query was inserted, i.e. there may be false positives, but no false negatives.
+ * 
+ * ### Querying
+ * To query the Bloom Filter for a value, call seqan3::bloom_filter::contains(value) which returns
+ * true if the k-mer hash is present in the index, and false if the hash is not present.
+ * The value is a hash value of the k-mer to check membership for.
+ * 
+ * To query the Bloom Filter for a range of values, call seqan3::bloom_filter::count(values) which returns the
+ * number of k-mer hits in the Bloom Filter for the given range of values.
+ * 
+ * Please note the results are based on a heuristic data structure and with a certain probability (depending on 
+ * the selected size of the bit vector) you may receive a false positive result.
+ *
+ * Compared to the interleaved bloom filter implementation, the bloom filter does not make use of
+ * agents to determine and count membership.
+ *
+ * ### Compression
+ *
+ * The Bloom Filter can be compressed by passing `data_layout::compressed` as template argument.
+ * The compressed `seqan3::bloom_filter<seqan3::data_layout::compressed>` can only be constructed from a
+ * `seqan3::bloom_filter`, in which case the underlying bitvector is compressed.
+ * The compressed Bloom Filter is immutable, i.e. only querying is supported.
+ *
+ * ### Thread safety
+ *
+ * The Bloom Filter promises the basic thread-safety by the STL that all
+ * calls to `const` member functions are safe from multiple threads (as long as no thread calls
+ * a non-`const` member function at the same time).
+ *
+ */
+template <data_layout data_layout_mode_ = data_layout::uncompressed>
+class bloom_filter
+{
+private:
+    //!\cond
+    template <data_layout data_layout_mode>
+    friend class bloom_filter;
+    //!\endcond
+
+    //!\brief The underlying datatype to use.
+    using data_type = std::conditional_t<data_layout_mode_ == data_layout::uncompressed,
+                                         sdsl::bit_vector,
+                                         sdsl::sd_vector<>>;
+
+    //!\brief The size of the underlying bit vector in bits.
+    size_t size_in_bits{};
+    //!\brief The number of bits to shift the hash value before doing multiplicative hashing.
+    size_t hash_shift{};
+    //!\brief The number of hash functions.
+    size_t hash_funs{};
+    //!\brief The bitvector.
+    data_type data{};
+    //!\brief Precalculated seeds for multiplicative hashing. We use large irrational numbers for a uniform hashing.
+    static constexpr std::array<size_t, 5> hash_seeds{13572355802537770549ULL, // 2**64 / (e/2)
+                                                      13043817825332782213ULL, // 2**64 / sqrt(2)
+                                                      10650232656628343401ULL, // 2**64 / sqrt(3)
+                                                      16499269484942379435ULL, // 2**64 / (sqrt(5)/2)
+                                                      4893150838803335377ULL}; // 2**64 / (3*pi/5)
+
+    /*!\brief Perturbs a value and fits it into the vector.
+     * \param h The value to process.
+     * \param seed The seed to use.
+     * \returns A hashed value representing a position within the bounds of `data`.
+     * \sa https://probablydance.com/2018/06/16/
+     * \sa https://lemire.me/blog/2016/06/27
+     */
+    inline constexpr size_t hash_and_fit(size_t h, size_t const seed) const
+    {
+        h *= seed;
+        h ^= h >> hash_shift; // XOR and shift higher bits into lower bits
+        h *= 11400714819323198485ULL; // = 2^64 / golden_ration, to expand h to 64 bit range
+        // Use fastrange (integer modulo without division) if possible.
+#ifdef __SIZEOF_INT128__
+        h = static_cast<uint64_t>((static_cast<__uint128_t>(h) * static_cast<__uint128_t>(size_in_bits)) >> 64);
+#else
+        h %= size_in_bits;
+#endif
+        return h;
+    }
+
+public:
+    //!\brief Indicates whether the Bloom Filter is compressed.
+    static constexpr data_layout data_layout_mode = data_layout_mode_;
+
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    bloom_filter() = default; //!< Defaulted.
+    bloom_filter(bloom_filter const &) = default; //!< Defaulted.
+    bloom_filter & operator=(bloom_filter const &) = default; //!< Defaulted.
+    bloom_filter(bloom_filter &&) = default; //!< Defaulted.
+    bloom_filter & operator=(bloom_filter &&) = default; //!< Defaulted.
+    ~bloom_filter() = default; //!< Defaulted.
+
+    /*!\brief Construct an uncompressed Bloom Filter.
+     * \param size The bit vector size (in bits).
+     * \param funs The number of hash functions. Default 2. At least 1, at most 5.
+     *
+     * \attention This constructor can only be used to construct **uncompressed** Bloom Filters.
+     *
+     * \details
+     *
+     * ### Example
+     *
+     * \include test/snippet/utility/bloom_filter/bloom_filter_constructor.cpp
+     */
+    bloom_filter(seqan3::bin_size size,
+                 seqan3::hash_function_count funs = seqan3::hash_function_count{2u})
+    //!\cond
+        requires (data_layout_mode == data_layout::uncompressed)
+    //!\endcond
+    {
+        size_in_bits = size.get();
+        hash_funs = funs.get();
+
+        if (hash_funs == 0 || hash_funs > 5)
+            throw std::logic_error{"The number of hash functions must be > 0 and <= 5."};
+        if (size_in_bits == 0)
+            throw std::logic_error{"The size of a bloom filter must be > 0."};
+
+        hash_shift = std::countl_zero(size_in_bits);
+        data = sdsl::bit_vector(size_in_bits);
+    }
+
+    /*!\brief Construct a compressed Bloom Filter.
+     * \param[in] bf The uncompressed seqan3::bloom_filter.
+     *
+     * \attention This constructor can only be used to construct **compressed** Bloom Filters.
+     *
+     * \details
+     *
+     * ### Example
+     *
+     * \include test/snippet/utility/bloom_filter/bloom_filter_constructor_compressed.cpp
+     */
+    bloom_filter(bloom_filter<data_layout::uncompressed> const & bf)
+    //!\cond
+        requires (data_layout_mode == data_layout::compressed)
+    //!\endcond
+    {
+        std::tie(size_in_bits, hash_shift, hash_funs) =
+            std::tie(bf.size_in_bits, bf.hash_shift, bf.hash_funs);
+
+        data = sdsl::sd_vector<>{bf.data};
+    }
+    //!\}
+
+    /*!\name Modifiers
+     * \{
+     */
+    /*!\brief Inserts a value into the bloom filter.
+     * \param[in] value The raw numeric value to process.
+     *
+     * \attention This function is only available for **uncompressed** Bloom Filters.
+     *
+     * \details
+     *
+     * ### Example
+     *
+     * \include test/snippet/utility/bloom_filter/bloom_filter_emplace.cpp
+     */
+    void emplace(size_t const value) noexcept
+    //!\cond
+        requires (data_layout_mode == data_layout::uncompressed)
+    //!\endcond
+    {
+        for (size_t i = 0; i < hash_funs; ++i)
+        {
+            size_t idx = hash_and_fit(value, hash_seeds[i]);
+            assert(idx < data.size());
+            data[idx] = 1;
+        };
+    }
+
+    /*!\brief Remove all values from the Bloom Filter by setting all bits to 0.
+     *
+     * \attention This function is only available for **uncompressed** Bloom Filters.
+     *
+     * \details
+     *
+     * While all values are removed from the vector, the size of the Bloom Filter is not changed.
+     * 
+     * ### Example
+     *
+     * \include test/snippet/utility/bloom_filter/bloom_filter_clear.cpp
+     */
+    void clear() noexcept
+    //!\cond
+        requires (data_layout_mode == data_layout::uncompressed)
+    //!\endcond
+    {
+        sdsl::util::_set_zero_bits(data);
+    }
+    //!\}
+    
+    /*!\name Lookup
+     * \{
+     */
+    /*!\brief Check whether a value is present in the Bloom Filter.
+     * \param[in] value The raw numeric value to process.
+     *
+     * \attention This function is only available for **uncompressed** Bloom Filters.
+     *
+     * \details
+     *
+     * ### Example
+     *
+     * \include test/snippet/utility/bloom_filter/bloom_filter_contains.cpp
+     */
+    bool contains(size_t const value) const noexcept
+    {
+        for ( size_t i = 0; i < hash_funs; i++ )
+        {
+            size_t idx = hash_and_fit(value, hash_seeds[i]);
+            assert(idx < data.size());
+            if ( data[idx] == 0 )
+                return false;
+        }
+        return true;
+    }
+    //!\}
+
+    /*!\name Counting
+     * \{
+     */
+    /*!\brief Counts the occurrences in each bin for all values in a range.
+     * \tparam value_t The type of the return value. Must model std::integral. Defaults to uint16_t.
+     * \tparam value_range_t The type of the range of values. Must model std::ranges::input_range. The reference type
+     *                       must model std::unsigned_integral.
+     * \param[in] values The range of values to process.
+     *
+     * \details
+     *
+     * ### Example
+     *
+     * \include test/snippet/utility/bloom_filter/bloom_filter_count.cpp
+     *
+     * ### Thread safety
+     *
+     * Concurrent invocations of this function are thread safe.
+     */
+    template <std::ranges::range value_range_t>
+    size_t count(value_range_t && values) const noexcept
+    {
+        static_assert(std::ranges::input_range<value_range_t>, "The values must model input_range.");
+        static_assert(std::unsigned_integral<std::ranges::range_value_t<value_range_t>>,
+                      "An individual value must be an unsigned integral.");
+
+        size_t result = 0;
+
+        for (auto && value : values)
+            result += contains(value);
+
+        return result;
+    }
+    //!\}
+
+    /*!\name Capacity
+     * \{
+     */
+    /*!\brief Returns the number of hash functions used in the Bloom Filter.
+     * \returns The number of hash functions.
+     */
+    size_t hash_function_count() const noexcept
+    {
+        return hash_funs;
+    }
+
+    /*!\brief Returns the size that the Bloom Filter manages.
+     * \returns The size in bits.
+     */
+    size_t size() const noexcept
+    {
+        return size_in_bits;
+    }
+    //!\}
+
+    /*!\name Comparison operators
+     * \{
+     */
+    /*!\brief Test for equality.
+     * \param[in] lhs A `seqan3::bloom_filter`.
+     * \param[in] rhs `seqan3::bloom_filter` to compare to.
+     * \returns `true` if equal, `false` otherwise.
+     */
+    friend bool operator==(bloom_filter const & lhs, bloom_filter const & rhs) noexcept
+    {
+        return std::tie(lhs.size_in_bits, lhs.hash_shift, lhs.hash_funs, lhs.data) ==
+               std::tie(rhs.size_in_bits, rhs.hash_shift, rhs.hash_funs, rhs.data);
+    }
+
+    /*!\brief Test for inequality.
+     * \param[in] lhs A `seqan3::bloom_filter`.
+     * \param[in] rhs `seqan3::bloom_filter` to compare to.
+     * \returns `true` if unequal, `false` otherwise.
+     */
+    friend bool operator!=(bloom_filter const & lhs, bloom_filter const & rhs) noexcept
+    {
+        return !(lhs == rhs);
+    }
+    //!\}
+
+    /*!\name Access
+     * \{
+     */
+    /*!\brief Provides direct, unsafe access to the underlying data structure.
+     * \returns A reference to an SDSL bitvector.
+     *
+     * \details
+     *
+     * \noapi{The exact representation of the data is implementation defined.}
+     */
+    constexpr data_type & raw_data() noexcept
+    {
+        return data;
+    }
+
+    //!\copydoc raw_data()
+    constexpr data_type const & raw_data() const noexcept
+    {
+        return data;
+    }
+    //!\}
+
+    /*!\cond DEV
+     * \brief Serialisation support function.
+     * \tparam archive_t Type of `archive`; must satisfy seqan3::cereal_archive.
+     * \param[in] archive The archive being serialised from/to.
+     *
+     * \attention These functions are never called directly, see \ref serialisation for more details.
+     */
+    template <cereal_archive archive_t>
+    void CEREAL_SERIALIZE_FUNCTION_NAME(archive_t & archive)
+    {
+        archive(size_in_bits);
+        archive(hash_shift);
+        archive(hash_funs);
+        archive(data);
+    }
+    //!\endcond
+};
+
+} // namespace seqan3

--- a/include/seqan3/utility/bloom_filter/bloom_filter.hpp
+++ b/include/seqan3/utility/bloom_filter/bloom_filter.hpp
@@ -35,27 +35,27 @@ namespace seqan3
  * Since the Bloom Filter has variable length, the hashing is not bijective, i.e. it may return true for a set
  * membership query even though the query was never inserted into the Bloom Filter. Note that the Bloom Filter
  * will always return `true` if the query was inserted, i.e. there may be false positives, but no false negatives.
- * 
+ *
  * ### Querying
- * 
+ *
  * To query the Bloom Filter for a value, call `seqan3::bloom_filter::contains` which returns
  * true if the k-mer hash is present in the index, and false if the hash is not present.
  * The value is a hash value of the k-mer to check membership for.
- * 
+ *
  * To query the Bloom Filter for a range of values, call `seqan3::bloom_filter::count` which returns the
  * number of k-mer hits in the Bloom Filter for the given range of values.
- * 
- * Please note the results are based on a heuristic data structure and with a certain probability (depending on 
+ *
+ * Please note the results are based on a heuristic data structure and with a certain probability (depending on
  * the selected size of the bit vector) you may receive a false positive result.
  *
  * ### Differences to the Interleaved Bloom Filter (IBF)
- * 
+ *
  * While the Bloom Filter provides a single linear bit vector to represent the underlying data, the Interleaved Bloom
  * Filter provides a data structure that combines a set of Bloom Filters to enable efficient queries to multiple
- * fractions of the data. In doing so, the Interleaved Bloom Filter can not only answer the question whether a hash
+ * fractions of the data. In doing so, the Interleaved Bloom Filter can not only answer whether a hash
  * value is present in the data, but also provides information in which fraction of the data it occurs.
- * The design of the Interleaved Bloom Filter is particulary useful when the underlying data is systematically 
- * structured; for example, if each fraction of the data represents a specific set of organisms. Important 
+ * The design of the Interleaved Bloom Filter is particularly useful when the underlying data is systematically
+ * structured; for example, if each fraction of the data represents a specific set of organisms. Important
  * applications of the Interleaved Bloom Filter include taxonomic classification of sequencing data, or prefiltering
  * of specific fractions of an input data set to enable more efficient in-depth analysis.
  * The Bloom Filter, on the other hand, is useful if the database does not contain any underlying structure, or it is
@@ -78,7 +78,7 @@ namespace seqan3
  * a non-`const` member function at the same time).
  *
  * \sa seqan3::interleaved_bloom_filter
- * 
+ *
  */
 template <data_layout data_layout_mode_ = data_layout::uncompressed>
 class bloom_filter
@@ -231,7 +231,7 @@ public:
      * \details
      *
      * While all values are removed from the vector, the size of the Bloom Filter is not changed.
-     * 
+     *
      * ### Example
      *
      * \include test/snippet/utility/bloom_filter/bloom_filter_reset.cpp
@@ -244,7 +244,7 @@ public:
         sdsl::util::_set_zero_bits(data);
     }
     //!\}
-    
+
     /*!\name Lookup
      * \{
      */

--- a/include/seqan3/utility/bloom_filter/bloom_filter.hpp
+++ b/include/seqan3/utility/bloom_filter/bloom_filter.hpp
@@ -276,8 +276,7 @@ public:
     /*!\name Counting
      * \{
      */
-    /*!\brief Counts the occurrences in each bin for all values in a range.
-
+    /*!\brief Counts the occurrences for all values in a range.
      * \tparam value_range_t The type of the range of values. Must model std::ranges::input_range. The reference type
      *                       must model std::unsigned_integral.
      * \param[in] values The range of values to process.

--- a/include/seqan3/utility/bloom_filter/bloom_filter.hpp
+++ b/include/seqan3/utility/bloom_filter/bloom_filter.hpp
@@ -17,12 +17,10 @@
 namespace seqan3
 {
 
-/*!\addtogroup submodule_bloom_filter
- * \{
- */
 /*!\brief The Bloom Filter. A data structure that efficiently answers set-membership queries.
  * \tparam data_layout_mode_ Indicates whether the underlying data type is compressed. See seqan3::data_layout.
  * \implements seqan3::cerealisable
+ * \ingroup utility_bloom_filter
  *
  * \details
  *
@@ -39,6 +37,7 @@ namespace seqan3
  * will always return `true` if the query was inserted, i.e. there may be false positives, but no false negatives.
  * 
  * ### Querying
+ * 
  * To query the Bloom Filter for a value, call `seqan3::bloom_filter::contains` which returns
  * true if the k-mer hash is present in the index, and false if the hash is not present.
  * The value is a hash value of the k-mer to check membership for.
@@ -318,10 +317,10 @@ public:
         return hash_funs;
     }
 
-    /*!\brief Returns the size that the Bloom Filter manages.
-     * \returns The size in bits.
+    /*!\brief Returns the size of the underlying bitvector.
+     * \returns The size in bits of the underlying bitvector.
      */
-    size_t size() const noexcept
+    size_t bit_size() const noexcept
     {
         return size_in_bits;
     }
@@ -391,7 +390,5 @@ public:
     }
     //!\endcond
 };
-
-//!\}
 
 } // namespace seqan3

--- a/test/performance/utility/bloom_filter/CMakeLists.txt
+++ b/test/performance/utility/bloom_filter/CMakeLists.txt
@@ -1,0 +1,1 @@
+seqan3_benchmark(bloom_filter_benchmark.cpp)

--- a/test/performance/utility/bloom_filter/bloom_filter_benchmark.cpp
+++ b/test/performance/utility/bloom_filter/bloom_filter_benchmark.cpp
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------------------------------------
-// Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
-// Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+// Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
 // This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
 // shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 // -----------------------------------------------------------------------------------------------------

--- a/test/performance/utility/bloom_filter/bloom_filter_benchmark.cpp
+++ b/test/performance/utility/bloom_filter/bloom_filter_benchmark.cpp
@@ -7,10 +7,8 @@
 
 #include <benchmark/benchmark.h>
 
-#include <seqan3/range/views/to.hpp>
-#include <seqan3/range/views/zip.hpp>
-#include <seqan3/utility/bloom_filter/bloom_filter.hpp>
 #include <seqan3/test/performance/sequence_generator.hpp>
+#include <seqan3/utility/bloom_filter/bloom_filter.hpp>
 
 inline benchmark::Counter hashes_per_second(size_t const count)
 {
@@ -51,8 +49,8 @@ template <typename ibf_type>
 void emplace_benchmark(::benchmark::State & state)
 {
     auto && [ hash_values, bf ] = set_up<ibf_type>(state.range(0),
-                                                    state.range(1),
-                                                    state.range(2));
+                                                   state.range(1),
+                                                   state.range(2));
 
     for (auto _ : state)
     {
@@ -64,7 +62,7 @@ void emplace_benchmark(::benchmark::State & state)
 }
 
 template <typename bf_type>
-void clear_benchmark(::benchmark::State & state)
+void reset_benchmark(::benchmark::State & state)
 {
     auto && [ hash_values, bf ] = set_up<bf_type>(state.range(0),
                                                   state.range(1),
@@ -73,7 +71,7 @@ void clear_benchmark(::benchmark::State & state)
 
     for (auto _ : state)
     {
-        bf.clear();
+        bf.reset();
     }
 }
 
@@ -110,7 +108,7 @@ void count_benchmark(::benchmark::State & state)
 
 BENCHMARK_TEMPLATE(emplace_benchmark,
                    seqan3::bloom_filter<seqan3::data_layout::uncompressed>)->Apply(arguments);
-BENCHMARK_TEMPLATE(clear_benchmark,
+BENCHMARK_TEMPLATE(reset_benchmark,
                    seqan3::bloom_filter<seqan3::data_layout::uncompressed>)->Apply(arguments);
 
 BENCHMARK_TEMPLATE(contains_benchmark,

--- a/test/performance/utility/bloom_filter/bloom_filter_benchmark.cpp
+++ b/test/performance/utility/bloom_filter/bloom_filter_benchmark.cpp
@@ -1,0 +1,126 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+#include <benchmark/benchmark.h>
+
+#include <seqan3/range/views/to.hpp>
+#include <seqan3/range/views/zip.hpp>
+#include <seqan3/utility/bloom_filter/bloom_filter.hpp>
+#include <seqan3/test/performance/sequence_generator.hpp>
+
+inline benchmark::Counter hashes_per_second(size_t const count)
+{
+    return benchmark::Counter(count,
+                              benchmark::Counter::kIsIterationInvariantRate,
+                              benchmark::Counter::OneK::kIs1000);
+}
+
+static void arguments(benchmark::internal::Benchmark* b)
+{
+    // Size of the IBF will be 2^bits bits
+    for (int32_t bits = 15; bits <= 20; bits += 5)
+    {
+        // The bits must fit in an int32_t
+        if (bits < 32)
+        {
+            for (int32_t hash_num = 2; hash_num < 3; ++hash_num)
+            {
+                b->Args({(1LL << bits), hash_num, 1'000});
+            }
+        }
+    }
+}
+
+template <typename bf_type>
+auto set_up(size_t bits, size_t hash_num, size_t sequence_length)
+{
+    auto hash_values = seqan3::test::generate_numeric_sequence<size_t>(sequence_length);
+    seqan3::bloom_filter tmp_bf(seqan3::bin_size{bits},
+                                seqan3::hash_function_count{hash_num});
+
+    bf_type bf{std::move(tmp_bf)};
+
+    return std::make_tuple(hash_values, bf);
+}
+
+template <typename ibf_type>
+void emplace_benchmark(::benchmark::State & state)
+{
+    auto && [ hash_values, bf ] = set_up<ibf_type>(state.range(0),
+                                                    state.range(1),
+                                                    state.range(2));
+
+    for (auto _ : state)
+    {
+        for (auto hash : hash_values)
+            bf.emplace(hash);
+    }
+
+    state.counters["hashes/sec"] = hashes_per_second(std::ranges::size(hash_values));
+}
+
+template <typename bf_type>
+void clear_benchmark(::benchmark::State & state)
+{
+    auto && [ hash_values, bf ] = set_up<bf_type>(state.range(0),
+                                                  state.range(1),
+                                                  state.range(2));
+    (void) hash_values;
+
+    for (auto _ : state)
+    {
+        bf.clear();
+    }
+}
+
+template <typename bf_type>
+void contains_benchmark(::benchmark::State & state)
+{
+    auto && [ hash_values, bf ] = set_up<bf_type>(state.range(0),
+                                                  state.range(1),
+                                                  state.range(2));
+
+    for (auto _ : state)
+    {
+        for (auto hash : hash_values)
+            benchmark::DoNotOptimize(bf.contains(hash));
+    }
+
+    state.counters["hashes/sec"] = hashes_per_second(std::ranges::size(hash_values));
+}
+
+template <typename bf_type>
+void count_benchmark(::benchmark::State & state)
+{
+    auto && [ hash_values, bf ] = set_up<bf_type>(state.range(0),
+                                                  state.range(1),
+                                                  state.range(2));
+
+    for (auto _ : state)
+    {
+        benchmark::DoNotOptimize(bf.count(hash_values));
+    }
+
+    state.counters["hashes/sec"] = hashes_per_second(std::ranges::size(hash_values));
+}
+
+BENCHMARK_TEMPLATE(emplace_benchmark,
+                   seqan3::bloom_filter<seqan3::data_layout::uncompressed>)->Apply(arguments);
+BENCHMARK_TEMPLATE(clear_benchmark,
+                   seqan3::bloom_filter<seqan3::data_layout::uncompressed>)->Apply(arguments);
+
+BENCHMARK_TEMPLATE(contains_benchmark,
+                   seqan3::bloom_filter<seqan3::data_layout::uncompressed>)->Apply(arguments);
+BENCHMARK_TEMPLATE(contains_benchmark,
+                   seqan3::bloom_filter<seqan3::data_layout::compressed>)->Apply(arguments);
+
+BENCHMARK_TEMPLATE(count_benchmark,
+                   seqan3::bloom_filter<seqan3::data_layout::uncompressed>)->Apply(arguments);
+BENCHMARK_TEMPLATE(count_benchmark,
+                   seqan3::bloom_filter<seqan3::data_layout::compressed>)->Apply(arguments);
+
+BENCHMARK_MAIN();

--- a/test/snippet/utility/bloom_filter/bloom_filter_clear.cpp
+++ b/test/snippet/utility/bloom_filter/bloom_filter_clear.cpp
@@ -1,0 +1,35 @@
+#include <seqan3/alphabet/nucleotide/dna4.hpp>
+#include <seqan3/core/debug_stream.hpp>
+#include <seqan3/range/views/kmer_hash.hpp>
+#include <seqan3/utility/bloom_filter/bloom_filter.hpp>
+
+using seqan3::operator""_dna4;
+
+int main()
+{
+    seqan3::bloom_filter bf{seqan3::bin_size{8192u},
+                            seqan3::hash_function_count{2u}};
+
+    auto const sequence1 = "ACTGACTGACTGATC"_dna4;
+    auto const sequence2 = "GTGACTGACTGACTCG"_dna4;
+    auto const sequence3 = "AAAAAAACGATCGACA"_dna4;
+    auto hash_adaptor = seqan3::views::kmer_hash(seqan3::ungapped{5u});
+
+    // Insert all 5-mers of sequence1
+    for (auto && value : sequence1 | hash_adaptor)
+        bf.emplace(value);
+
+    // Insert all 5-mers of sequence3
+    for (auto && value : sequence3 | hash_adaptor)
+        bf.emplace(value);
+
+    // Count all 5-mers of sequence2
+    seqan3::debug_stream << bf.count(sequence2 | hash_adaptor) << '\n'; // 9
+
+    // Clear the Bloom Filter
+    bf.clear();
+
+    // After clearing, no 5-mers are found
+    seqan3::debug_stream << bf.count(sequence2 | hash_adaptor) << '\n'; // 0
+
+}

--- a/test/snippet/utility/bloom_filter/bloom_filter_constructor.cpp
+++ b/test/snippet/utility/bloom_filter/bloom_filter_constructor.cpp
@@ -1,0 +1,12 @@
+#include <seqan3/utility/bloom_filter/bloom_filter.hpp>
+
+int main()
+{
+    // Construct a Bloom Filter that contains 8192 bits and 3 hash functions.
+    seqan3::bloom_filter bf{seqan3::bin_size{8192u},
+                            seqan3::hash_function_count{3}};
+
+    // Construct a Bloom Filter that contains 256 KiBits and the default of 2 
+    // hash functions.
+    seqan3::bloom_filter bf2{seqan3::bin_size{1ULL<<20}};
+}

--- a/test/snippet/utility/bloom_filter/bloom_filter_constructor.cpp
+++ b/test/snippet/utility/bloom_filter/bloom_filter_constructor.cpp
@@ -6,7 +6,7 @@ int main()
     seqan3::bloom_filter bf{seqan3::bin_size{8192u},
                             seqan3::hash_function_count{3}};
 
-    // Construct a Bloom Filter that contains 256 KiBits and the default of 2 
+    // Construct a Bloom Filter that contains 256 KiBits and the default of 2
     // hash functions.
     seqan3::bloom_filter bf2{seqan3::bin_size{1ULL<<20}};
 }

--- a/test/snippet/utility/bloom_filter/bloom_filter_constructor_compressed.cpp
+++ b/test/snippet/utility/bloom_filter/bloom_filter_constructor_compressed.cpp
@@ -1,0 +1,12 @@
+#include <seqan3/utility/bloom_filter/bloom_filter.hpp>
+
+int main()
+{
+    // Construct an uncompressed Bloom Filter.
+    seqan3::bloom_filter bf{seqan3::bin_size{128u}, seqan3::hash_function_count{3}};
+
+    // Fill `bf` with data.
+
+    // Construct an immutable, compressed Bloom Filter.
+    seqan3::bloom_filter<seqan3::data_layout::compressed> bf2{bf};
+}

--- a/test/snippet/utility/bloom_filter/bloom_filter_contains.cpp
+++ b/test/snippet/utility/bloom_filter/bloom_filter_contains.cpp
@@ -8,9 +8,9 @@ int main()
     bf.emplace(712);
     bf.emplace(237);
 
-    // Query the Bloom Filter. 
+    // Query the Bloom Filter.
     // A return of `false` guarantees the query not being present in the Bloom Filter.
-    // A return of `true` indicates the (probable) presence of the query in the Bloom Filter. 
+    // A return of `true` indicates the (probable) presence of the query in the Bloom Filter.
     // Note that there may be false positive results!
     bool result = bf.contains(712);
     seqan3::debug_stream << result << '\n'; // prints 1

--- a/test/snippet/utility/bloom_filter/bloom_filter_contains.cpp
+++ b/test/snippet/utility/bloom_filter/bloom_filter_contains.cpp
@@ -1,0 +1,15 @@
+#include <seqan3/core/debug_stream.hpp>
+#include <seqan3/utility/bloom_filter/bloom_filter.hpp>
+
+int main()
+{
+    seqan3::bloom_filter bf{seqan3::bin_size{1024u}};
+    bf.emplace(126);
+    bf.emplace(712);
+    bf.emplace(237);
+
+    // Query the Bloom Filter. Note that there may be false positive results!
+    // A return of `true` indicates the (probable) presence of the query in the Bloom Filter.
+    bool result = bf.contains(712);
+    seqan3::debug_stream << result << '\n'; // prints 1
+}

--- a/test/snippet/utility/bloom_filter/bloom_filter_contains.cpp
+++ b/test/snippet/utility/bloom_filter/bloom_filter_contains.cpp
@@ -8,8 +8,10 @@ int main()
     bf.emplace(712);
     bf.emplace(237);
 
-    // Query the Bloom Filter. Note that there may be false positive results!
-    // A return of `true` indicates the (probable) presence of the query in the Bloom Filter.
+    // Query the Bloom Filter. 
+    // A return of `false` guarantees the query not being present in the Bloom Filter.
+    // A return of `true` indicates the (probable) presence of the query in the Bloom Filter. 
+    // Note that there may be false positive results!
     bool result = bf.contains(712);
     seqan3::debug_stream << result << '\n'; // prints 1
 }

--- a/test/snippet/utility/bloom_filter/bloom_filter_count.cpp
+++ b/test/snippet/utility/bloom_filter/bloom_filter_count.cpp
@@ -1,12 +1,13 @@
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/core/debug_stream.hpp>
-#include <seqan3/range/views/kmer_hash.hpp>
+#include <seqan3/search/views/kmer_hash.hpp>
 #include <seqan3/utility/bloom_filter/bloom_filter.hpp>
 
-using seqan3::operator""_dna4;
 
 int main()
 {
+    using namespace seqan3::literals;
+
     seqan3::bloom_filter bf{seqan3::bin_size{8192u},
                             seqan3::hash_function_count{2u}};
 

--- a/test/snippet/utility/bloom_filter/bloom_filter_count.cpp
+++ b/test/snippet/utility/bloom_filter/bloom_filter_count.cpp
@@ -3,7 +3,6 @@
 #include <seqan3/search/views/kmer_hash.hpp>
 #include <seqan3/utility/bloom_filter/bloom_filter.hpp>
 
-
 int main()
 {
     using namespace seqan3::literals;

--- a/test/snippet/utility/bloom_filter/bloom_filter_count.cpp
+++ b/test/snippet/utility/bloom_filter/bloom_filter_count.cpp
@@ -14,16 +14,16 @@ int main()
     auto const sequence1 = "ACTGACTGACTGATC"_dna4;
     auto const sequence2 = "GTGACTGACTGACTCG"_dna4;
     auto const sequence3 = "AAAAAAACGATCGACA"_dna4;
-    auto hash_adaptor = seqan3::views::kmer_hash(seqan3::ungapped{5u});
+    auto kmers = seqan3::views::kmer_hash(seqan3::ungapped{5u});
 
     // Insert all 5-mers of sequence1
-    for (auto && value : sequence1 | hash_adaptor)
+    for (auto && value : sequence1 | kmers)
         bf.emplace(value);
 
     // Insert all 5-mers of sequence3
-    for (auto && value : sequence3 | hash_adaptor)
+    for (auto && value : sequence3 | kmers)
         bf.emplace(value);
 
     // Count all 5-mers of sequence2
-    seqan3::debug_stream << bf.count(sequence2 | hash_adaptor) << '\n'; // 9
+    seqan3::debug_stream << bf.count(sequence2 | kmers) << '\n'; // 9
 }

--- a/test/snippet/utility/bloom_filter/bloom_filter_count.cpp
+++ b/test/snippet/utility/bloom_filter/bloom_filter_count.cpp
@@ -1,0 +1,28 @@
+#include <seqan3/alphabet/nucleotide/dna4.hpp>
+#include <seqan3/core/debug_stream.hpp>
+#include <seqan3/range/views/kmer_hash.hpp>
+#include <seqan3/utility/bloom_filter/bloom_filter.hpp>
+
+using seqan3::operator""_dna4;
+
+int main()
+{
+    seqan3::bloom_filter bf{seqan3::bin_size{8192u},
+                            seqan3::hash_function_count{2u}};
+
+    auto const sequence1 = "ACTGACTGACTGATC"_dna4;
+    auto const sequence2 = "GTGACTGACTGACTCG"_dna4;
+    auto const sequence3 = "AAAAAAACGATCGACA"_dna4;
+    auto hash_adaptor = seqan3::views::kmer_hash(seqan3::ungapped{5u});
+
+    // Insert all 5-mers of sequence1
+    for (auto && value : sequence1 | hash_adaptor)
+        bf.emplace(value);
+
+    // Insert all 5-mers of sequence3
+    for (auto && value : sequence3 | hash_adaptor)
+        bf.emplace(value);
+
+    // Count all 5-mers of sequence2
+    seqan3::debug_stream << bf.count(sequence2 | hash_adaptor) << '\n'; // 9
+}

--- a/test/snippet/utility/bloom_filter/bloom_filter_emplace.cpp
+++ b/test/snippet/utility/bloom_filter/bloom_filter_emplace.cpp
@@ -1,0 +1,11 @@
+#include <seqan3/utility/bloom_filter/bloom_filter.hpp>
+
+int main()
+{
+    seqan3::bloom_filter bf{seqan3::bin_size{8192u}};
+
+    // Insert the values `126`, `712` and `237` into the Bloom Filter.
+    bf.emplace(126);
+    bf.emplace(712);
+    bf.emplace(237);
+}

--- a/test/snippet/utility/bloom_filter/bloom_filter_reset.cpp
+++ b/test/snippet/utility/bloom_filter/bloom_filter_reset.cpp
@@ -26,10 +26,9 @@ int main()
     // Count all 5-mers of sequence2
     seqan3::debug_stream << bf.count(sequence2 | hash_adaptor) << '\n'; // 9
 
-    // Clear the Bloom Filter
-    bf.clear();
+    // Reset the Bloom Filter
+    bf.reset();
 
-    // After clearing, no 5-mers are found
+    // After reset, no 5-mers are found
     seqan3::debug_stream << bf.count(sequence2 | hash_adaptor) << '\n'; // 0
-
 }

--- a/test/snippet/utility/bloom_filter/bloom_filter_reset.cpp
+++ b/test/snippet/utility/bloom_filter/bloom_filter_reset.cpp
@@ -1,12 +1,12 @@
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/core/debug_stream.hpp>
-#include <seqan3/range/views/kmer_hash.hpp>
+#include <seqan3/search/views/kmer_hash.hpp>
 #include <seqan3/utility/bloom_filter/bloom_filter.hpp>
-
-using seqan3::operator""_dna4;
 
 int main()
 {
+    using namespace seqan3::literals;
+
     seqan3::bloom_filter bf{seqan3::bin_size{8192u},
                             seqan3::hash_function_count{2u}};
 

--- a/test/snippet/utility/bloom_filter/bloom_filter_reset.cpp
+++ b/test/snippet/utility/bloom_filter/bloom_filter_reset.cpp
@@ -13,22 +13,22 @@ int main()
     auto const sequence1 = "ACTGACTGACTGATC"_dna4;
     auto const sequence2 = "GTGACTGACTGACTCG"_dna4;
     auto const sequence3 = "AAAAAAACGATCGACA"_dna4;
-    auto hash_adaptor = seqan3::views::kmer_hash(seqan3::ungapped{5u});
+    auto kmers = seqan3::views::kmer_hash(seqan3::ungapped{5u});
 
     // Insert all 5-mers of sequence1
-    for (auto && value : sequence1 | hash_adaptor)
+    for (auto && value : sequence1 | kmers)
         bf.emplace(value);
 
     // Insert all 5-mers of sequence3
-    for (auto && value : sequence3 | hash_adaptor)
+    for (auto && value : sequence3 | kmers)
         bf.emplace(value);
 
     // Count all 5-mers of sequence2
-    seqan3::debug_stream << bf.count(sequence2 | hash_adaptor) << '\n'; // 9
+    seqan3::debug_stream << bf.count(sequence2 | kmers) << '\n'; // 9
 
     // Reset the Bloom Filter
     bf.reset();
 
     // After reset, no 5-mers are found
-    seqan3::debug_stream << bf.count(sequence2 | hash_adaptor) << '\n'; // 0
+    seqan3::debug_stream << bf.count(sequence2 | kmers) << '\n'; // 0
 }

--- a/test/unit/utility/bloom_filter/CMakeLists.txt
+++ b/test/unit/utility/bloom_filter/CMakeLists.txt
@@ -1,0 +1,1 @@
+seqan3_test(bloom_filter_test.cpp)

--- a/test/unit/utility/bloom_filter/bloom_filter_test.cpp
+++ b/test/unit/utility/bloom_filter/bloom_filter_test.cpp
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------------------------------------
-// Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
-// Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+// Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
 // This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
 // shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 // -----------------------------------------------------------------------------------------------------

--- a/test/unit/utility/bloom_filter/bloom_filter_test.cpp
+++ b/test/unit/utility/bloom_filter/bloom_filter_test.cpp
@@ -45,7 +45,7 @@ TYPED_TEST(bloom_filter_test, construction)
                                        seqan3::hash_function_count{2u})};
     EXPECT_TRUE(bf1 == bf2);
 
-     // bin_size parameter is too small
+    // bin_size parameter is too small
     EXPECT_THROW((TestFixture::make_bf(seqan3::bin_size{0u})), std::logic_error);
     // not enough hash functions
     EXPECT_THROW((TestFixture::make_bf(seqan3::bin_size{32u},
@@ -60,12 +60,12 @@ TYPED_TEST(bloom_filter_test, construction)
 TYPED_TEST(bloom_filter_test, member_getter)
 {
     TypeParam t1{TestFixture::make_bf(seqan3::bin_size{1024u})};
-    EXPECT_EQ(t1.size(), 1024u);
+    EXPECT_EQ(t1.bit_size(), 1024u);
     EXPECT_EQ(t1.hash_function_count(), 2u);
 
     TypeParam t2{TestFixture::make_bf(seqan3::bin_size{1019u},
                                        seqan3::hash_function_count{3u})};
-    EXPECT_EQ(t2.size(), 1019u);
+    EXPECT_EQ(t2.bit_size(), 1019u);
     EXPECT_EQ(t2.hash_function_count(), 3u);
 }
 

--- a/test/unit/utility/bloom_filter/bloom_filter_test.cpp
+++ b/test/unit/utility/bloom_filter/bloom_filter_test.cpp
@@ -1,0 +1,144 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <seqan3/utility/bloom_filter/bloom_filter.hpp>
+#include <seqan3/test/cereal.hpp>
+#include <seqan3/test/expect_range_eq.hpp>
+
+template <typename bf_type>
+struct bloom_filter_test : public ::testing::Test
+{
+    static bf_type make_bf(seqan3::bin_size bits)
+    {
+        return bf_type{seqan3::bloom_filter{bits}};
+    }
+
+    static bf_type make_bf(seqan3::bin_size bits, seqan3::hash_function_count funs)
+    {
+        return bf_type{seqan3::bloom_filter{bits, funs}};
+    }
+};
+
+using bf_types = ::testing::Types<seqan3::bloom_filter<seqan3::data_layout::uncompressed>,
+                                  seqan3::bloom_filter<seqan3::data_layout::compressed>>;
+
+TYPED_TEST_SUITE(bloom_filter_test, bf_types, );
+
+TYPED_TEST(bloom_filter_test, construction)
+{
+    EXPECT_TRUE(std::is_default_constructible_v<TypeParam>);
+    EXPECT_TRUE(std::is_copy_constructible_v<TypeParam>);
+    EXPECT_TRUE(std::is_move_constructible_v<TypeParam>);
+    EXPECT_TRUE(std::is_copy_assignable_v<TypeParam>);
+    EXPECT_TRUE(std::is_move_assignable_v<TypeParam>);
+    EXPECT_TRUE(std::is_destructible_v<TypeParam>);
+
+    // num hash functions defaults to two
+    TypeParam bf1{TestFixture::make_bf(seqan3::bin_size{1024u})};
+    TypeParam bf2{TestFixture::make_bf(seqan3::bin_size{1024u},
+                                       seqan3::hash_function_count{2u})};
+    EXPECT_TRUE(bf1 == bf2);
+
+     // bin_size parameter is too small
+    EXPECT_THROW((TestFixture::make_bf(seqan3::bin_size{0u})), std::logic_error);
+    // not enough hash functions
+    EXPECT_THROW((TestFixture::make_bf(seqan3::bin_size{32u},
+                                       seqan3::hash_function_count{0u})),
+                 std::logic_error);
+    // too many hash functions
+    EXPECT_THROW((TestFixture::make_bf(seqan3::bin_size{32u},
+                                       seqan3::hash_function_count{6u})),
+                 std::logic_error);
+}
+
+TYPED_TEST(bloom_filter_test, member_getter)
+{
+    TypeParam t1{TestFixture::make_bf(seqan3::bin_size{1024u})};
+    EXPECT_EQ(t1.size(), 1024u);
+    EXPECT_EQ(t1.hash_function_count(), 2u);
+
+    TypeParam t2{TestFixture::make_bf(seqan3::bin_size{1019u},
+                                       seqan3::hash_function_count{3u})};
+    EXPECT_EQ(t2.size(), 1019u);
+    EXPECT_EQ(t2.hash_function_count(), 3u);
+}
+
+TYPED_TEST(bloom_filter_test, contains)
+{
+    TypeParam bf{TestFixture::make_bf(seqan3::bin_size{1024u})};
+
+    for (size_t hash : std::views::iota(0u, 64u)) // test some hashes
+    {
+        // Expect false for all queries since we did not insert anything
+        EXPECT_FALSE(bf.contains(hash)); 
+    }
+}
+
+TYPED_TEST(bloom_filter_test, counting)
+{
+    // 1. Test uncompressed bloom_filter directly because the compressed one is not mutable.
+    seqan3::bloom_filter bf{seqan3::bin_size{1024u},
+                            seqan3::hash_function_count{2u}};
+
+    for (size_t hash : std::views::iota(0u, 128u))
+        bf.emplace(hash);
+
+    // 2. Construct either the uncompressed or compressed bloom_filter and test set with bulk_contains
+    TypeParam bf2{bf};
+    
+    // Test counting with all elements
+    EXPECT_EQ(bf2.count(std::views::iota(0u, 128u)), 128u);
+
+    // Test counting with some elements
+    EXPECT_EQ(bf2.count(std::views::iota(22u, 42u)), 20u);
+}
+
+TYPED_TEST(bloom_filter_test, emplace)
+{
+    // 1. Test uncompressed bloom_filter directly because the compressed one is not mutable.
+    seqan3::bloom_filter bf{seqan3::bin_size{1024u},
+                            seqan3::hash_function_count{2u}};
+
+    for (size_t hash : std::views::iota(0u, 64u))
+        bf.emplace(hash);
+
+    // 2. Construct either the uncompressed or compressed bloom_filter and test via hit counts
+    TypeParam bf2{bf};
+    EXPECT_EQ(bf.count(std::views::iota(0u, 64u)), 64u); // test inserted hashes
+}
+
+TYPED_TEST(bloom_filter_test, clear)
+{
+    // 1. Test uncompressed bloom_filter directly because the compressed one is not mutable.
+    seqan3::bloom_filter bf{seqan3::bin_size{1024u},
+                            seqan3::hash_function_count{2u}};
+
+    for (size_t hash : std::views::iota(0u, 64u))
+        bf.emplace(hash);
+
+    // 2. Clear the Bloom Filter
+    bf.clear();
+
+    // 3. Construct either the uncompressed or compressed bloom_filter and test set with contains
+    TypeParam bf2{bf};
+    EXPECT_EQ(bf.count(std::views::iota(0u, 64u)), 0u); // nothing should be present in the bloom filter
+}
+
+TYPED_TEST(bloom_filter_test, data_access)
+{
+    seqan3::bloom_filter bf{seqan3::bin_size{1024u}};
+    EXPECT_LE(sdsl::size_in_mega_bytes(bf.raw_data()), 0.001f);
+}
+
+TYPED_TEST(bloom_filter_test, serialisation)
+{
+    TypeParam bf{TestFixture::make_bf(seqan3::bin_size{1024u})};
+    seqan3::test::do_serialisation(bf);
+}
+

--- a/test/unit/utility/bloom_filter/bloom_filter_test.cpp
+++ b/test/unit/utility/bloom_filter/bloom_filter_test.cpp
@@ -76,7 +76,7 @@ TYPED_TEST(bloom_filter_test, contains)
     for (size_t hash : std::views::iota(0u, 64u)) // test some hashes
     {
         // Expect false for all queries since we did not insert anything
-        EXPECT_FALSE(bf.contains(hash)); 
+        EXPECT_FALSE(bf.contains(hash));
     }
 }
 
@@ -106,7 +106,7 @@ TYPED_TEST(bloom_filter_test, counting)
 
     // 2. Construct either the uncompressed or compressed Bloom Filter and test set with bulk_contains
     TypeParam bf2{bf};
-    
+
     // Test counting with all elements
     EXPECT_EQ(bf2.count(std::views::iota(0u, 128u)), 128u);
 


### PR DESCRIPTION
Resolves #2490.

Implementation of a simple (not interleaved) bloom filter.  
This is a basic data structure, so I think it makes sense to include it to the library (for discussion, see #2490). It can, e.g., be used as an alternative to a k-mer index if the k-mer size needed is too high. In my application, I use the proposed implementation for the filtering of human reads.

# Implementation
The Bloom Filter was implemented based on the existing code for the Interleaved Bloom Filter with the following modifications:
 - All binning-related code was adapted or removed.
 - No agents are used for querying and counting, as the return types are native, thus I think there are no advantages when using agents in this case.
   - For querying a single hash value, use `bool bloom_filter::contains(value)`
   - For counting k-mer hits of an input range, use `std::integral bloom_filter::count(values)` (where the return value defaults to `uint16_t`).

# Notes
Some things to consider during review:
 - I didn't want to touch the IBF for now, but also tried to avoid redundant implementation of underlying types (such as `data_layout`). Thus, for now, I included the IBF to use the data types defined there, until you make a design decision to this. I think, it generally would make sense to remove this dependency / include.
 - As stated above, I decided to not use agents. If you want to have the same design as with the IBF, this probably needs to be changed (but would imply a less convenient usage, I guess).
 - I didn't implement any performance tests yet. If required, these need to be added.
- I am not sure whether it makes sense to have the BF implementation fully separated from the IBF, or if some parts of the code could actually be redesigned for common use (e.g., the hash seeds etc.).

If any changes are requested during review, I am happy to contribute these until finally merged.