### PR TITLE
[FEATURE] Add simd store function.

### DIFF
--- a/include/seqan3/utility/simd/detail/simd_algorithm_avx2.hpp
+++ b/include/seqan3/utility/simd/detail/simd_algorithm_avx2.hpp
@@ -35,7 +35,7 @@ constexpr simd_t load_avx2(void const * mem_addr);
  * \attention This is the implementation for AVX2 intrinsics.
  */
 template <simd::simd_concept simd_t>
-constexpr void store_avx2(void * mem_addr, simd_t const &);
+constexpr void store_avx2(void * mem_addr, simd_t const & simd_vec);
 
 /*!\copydoc seqan3::simd::transpose
  * \attention This is the implementation for AVX2 intrinsics.

--- a/include/seqan3/utility/simd/detail/simd_algorithm_avx2.hpp
+++ b/include/seqan3/utility/simd/detail/simd_algorithm_avx2.hpp
@@ -31,6 +31,12 @@ namespace seqan3::detail
 template <simd::simd_concept simd_t>
 constexpr simd_t load_avx2(void const * mem_addr);
 
+/*!\copydoc seqan3::simd::store
+ * \attention This is the implementation for AVX2 intrinsics.
+ */
+template <simd::simd_concept simd_t>
+constexpr void store_avx2(void * mem_addr, simd_t const &);
+
 /*!\copydoc seqan3::simd::transpose
  * \attention This is the implementation for AVX2 intrinsics.
  */
@@ -82,6 +88,12 @@ template <simd::simd_concept simd_t>
 constexpr simd_t load_avx2(void const * mem_addr)
 {
     return reinterpret_cast<simd_t>(_mm256_loadu_si256(reinterpret_cast<__m256i const *>(mem_addr)));
+}
+
+template <simd::simd_concept simd_t>
+constexpr void store_avx2(void * mem_addr, simd_t const & simd_vec)
+{
+    _mm256_storeu_si256(reinterpret_cast<__m256i *>(mem_addr), reinterpret_cast<__m256i const &>(simd_vec));
 }
 
 template <simd::simd_concept simd_t>

--- a/include/seqan3/utility/simd/detail/simd_algorithm_avx512.hpp
+++ b/include/seqan3/utility/simd/detail/simd_algorithm_avx512.hpp
@@ -31,6 +31,12 @@ namespace seqan3::detail
 template <simd::simd_concept simd_t>
 constexpr simd_t load_avx512(void const * mem_addr);
 
+/*!\copydoc seqan3::simd::store
+ * \attention This is the implementation for AVX512 intrinsics.
+ */
+template <simd::simd_concept simd_t>
+constexpr void store_avx512(void * mem_addr, simd_t const &);
+
 /*!\copydoc seqan3::simd::transpose
  * \attention This is the implementation for AVX512 intrinsics.
  */
@@ -82,6 +88,12 @@ template <simd::simd_concept simd_t>
 constexpr simd_t load_avx512(void const * mem_addr)
 {
     return reinterpret_cast<simd_t>(_mm512_loadu_si512(mem_addr));
+}
+
+template <simd::simd_concept simd_t>
+constexpr void store_avx512(void * mem_addr, simd_t const & simd_vec)
+{
+    _mm512_storeu_si512(mem_addr, reinterpret_cast<__m512i const &>(simd_vec));
 }
 
 // TODO: not implemented and used yet, if you implement it don't forget to add it to seqan3::simd::transpose

--- a/include/seqan3/utility/simd/detail/simd_algorithm_avx512.hpp
+++ b/include/seqan3/utility/simd/detail/simd_algorithm_avx512.hpp
@@ -35,7 +35,7 @@ constexpr simd_t load_avx512(void const * mem_addr);
  * \attention This is the implementation for AVX512 intrinsics.
  */
 template <simd::simd_concept simd_t>
-constexpr void store_avx512(void * mem_addr, simd_t const &);
+constexpr void store_avx512(void * mem_addr, simd_t const & simd_vec);
 
 /*!\copydoc seqan3::simd::transpose
  * \attention This is the implementation for AVX512 intrinsics.

--- a/include/seqan3/utility/simd/detail/simd_algorithm_sse4.hpp
+++ b/include/seqan3/utility/simd/detail/simd_algorithm_sse4.hpp
@@ -35,7 +35,7 @@ constexpr simd_t load_sse4(void const * mem_addr);
  * \attention This is the implementation for SSE4 intrinsics.
  */
 template <simd::simd_concept simd_t>
-constexpr void store_sse4(void * mem_addr, simd_t const &);
+constexpr void store_sse4(void * mem_addr, simd_t const & simd_vec);
 
 /*!\copydoc seqan3::simd::transpose
  * \attention This is the implementation for SSE4 intrinsics.

--- a/include/seqan3/utility/simd/detail/simd_algorithm_sse4.hpp
+++ b/include/seqan3/utility/simd/detail/simd_algorithm_sse4.hpp
@@ -31,6 +31,12 @@ namespace seqan3::detail
 template <simd::simd_concept simd_t>
 constexpr simd_t load_sse4(void const * mem_addr);
 
+/*!\copydoc seqan3::simd::store
+ * \attention This is the implementation for SSE4 intrinsics.
+ */
+template <simd::simd_concept simd_t>
+constexpr void store_sse4(void * mem_addr, simd_t const &);
+
 /*!\copydoc seqan3::simd::transpose
  * \attention This is the implementation for SSE4 intrinsics.
  */
@@ -82,6 +88,12 @@ template <simd::simd_concept simd_t>
 constexpr simd_t load_sse4(void const * mem_addr)
 {
     return reinterpret_cast<simd_t>(_mm_loadu_si128(reinterpret_cast<__m128i const *>(mem_addr)));
+}
+
+template <simd::simd_concept simd_t>
+constexpr simd_t store_sse4(void * mem_addr, simd_t const & simd_vec)
+{
+    _mm_storeu_si128(reinterpret_cast<__m128i *>(mem_addr), reinterpret_cast<__m128i const &>(simd_vec));
 }
 
 template <simd::simd_concept simd_t>

--- a/test/snippet/utility/simd/simd_store.cpp
+++ b/test/snippet/utility/simd/simd_store.cpp
@@ -1,0 +1,13 @@
+#include <seqan3/core/debug_stream.hpp>
+#include <seqan3/utility/simd/all.hpp>
+
+using uint16x8_t = seqan3::simd::simd_type_t<uint16_t, 8>;
+
+int main()
+{
+    uint16x8_t a = seqan3::simd::iota<uint16x8_t>(0);
+    std::vector<uint16_t> memory(seqan3::simd::simd_traits<uint16x8_t>::length);
+    seqan3::simd::store(memory.data(), a);
+    seqan3::debug_stream << memory << '\n'; // [0,1,2,3,4,5,6,7]
+    return 0;
+}

--- a/test/unit/utility/simd/simd_algorithm_test.cpp
+++ b/test/unit/utility/simd/simd_algorithm_test.cpp
@@ -95,12 +95,12 @@ TYPED_TEST(simd_algorithm_memory, load)
 
 TYPED_TEST(simd_algorithm_memory, store)
 {
-    constexpr size_t count = seqan3::simd_traits<TypeParam>::length;
+    constexpr size_t length = seqan3::simd_traits<TypeParam>::length;
 
-    std::vector<typename TestFixture::scalar_t> out_memory(count);
+    std::vector<typename TestFixture::scalar_t> out_memory(length);
     seqan3::simd::store(out_memory.data(), seqan3::simd::iota<TypeParam>(0));
 
-    for (size_t i = 0; i < count; ++i)
+    for (size_t i = 0; i < length; ++i)
         EXPECT_EQ(static_cast<size_t>(out_memory[i]), i);
 }
 

--- a/test/unit/utility/simd/simd_algorithm_test.cpp
+++ b/test/unit/utility/simd/simd_algorithm_test.cpp
@@ -101,7 +101,7 @@ TYPED_TEST(simd_algorithm_memory, store)
     seqan3::simd::store(out_memory.data(), seqan3::simd::iota<TypeParam>(0));
 
     for (size_t i = 0; i < count; ++i)
-        EXPECT_EQ(out_memory[i], i);
+        EXPECT_EQ(static_cast<size_t>(out_memory[i]), i);
 }
 
 //-----------------------------------------------------------------------------

--- a/test/unit/utility/simd/simd_algorithm_test.cpp
+++ b/test/unit/utility/simd/simd_algorithm_test.cpp
@@ -59,12 +59,13 @@ TEST(simd_algorithm, transpose)
 }
 
 //-----------------------------------------------------------------------------
-// Algorithm load
+// Algorithm load and store
 //-----------------------------------------------------------------------------
 
 template <typename simd_t>
-struct simd_algorithm_load : ::testing::Test
+struct simd_algorithm_memory : ::testing::Test
 {
+    using scalar_t = typename seqan3::simd::simd_traits<simd_t>::scalar_type;
 
     void SetUp()
     {
@@ -72,24 +73,35 @@ struct simd_algorithm_load : ::testing::Test
         std::iota(memory.begin(), memory.end(), 0);
     }
 
-    std::vector<typename seqan3::simd::simd_traits<simd_t>::scalar_type> memory;
+    std::vector<scalar_t> memory;
 };
 
-using simd_load_types = ::testing::Types<seqan3::simd::simd_type_t<int8_t>,
-                                         seqan3::simd::simd_type_t<uint8_t>,
-                                         seqan3::simd::simd_type_t<int16_t>,
-                                         seqan3::simd::simd_type_t<uint16_t>,
-                                         seqan3::simd::simd_type_t<int32_t>,
-                                         seqan3::simd::simd_type_t<uint32_t>,
-                                         seqan3::simd::simd_type_t<int64_t>,
-                                         seqan3::simd::simd_type_t<uint64_t>>;
+using simd_memory_types = ::testing::Types<seqan3::simd::simd_type_t<int8_t>,
+                                           seqan3::simd::simd_type_t<uint8_t>,
+                                           seqan3::simd::simd_type_t<int16_t>,
+                                           seqan3::simd::simd_type_t<uint16_t>,
+                                           seqan3::simd::simd_type_t<int32_t>,
+                                           seqan3::simd::simd_type_t<uint32_t>,
+                                           seqan3::simd::simd_type_t<int64_t>,
+                                           seqan3::simd::simd_type_t<uint64_t>>;
 
-TYPED_TEST_SUITE(simd_algorithm_load, simd_load_types, );
+TYPED_TEST_SUITE(simd_algorithm_memory, simd_memory_types, );
 
-TYPED_TEST(simd_algorithm_load, load)
+TYPED_TEST(simd_algorithm_memory, load)
 {
     SIMD_EQ(seqan3::simd::load<TypeParam>(this->memory.data()), seqan3::simd::iota<TypeParam>(0));
     SIMD_EQ(seqan3::simd::load<TypeParam>(this->memory.data() + 10), seqan3::simd::iota<TypeParam>(10));
+}
+
+TYPED_TEST(simd_algorithm_memory, store)
+{
+    constexpr size_t count = seqan3::simd_traits<TypeParam>::length;
+
+    std::vector<typename TestFixture::scalar_t> out_memory(count);
+    seqan3::simd::store(out_memory.data(), seqan3::simd::iota<TypeParam>(0));
+
+    for (size_t i = 0; i < count; ++i)
+        EXPECT_EQ(out_memory[i], i);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Adds special store function to the simd utilities.
This function allows to store a simd vector to some memory region irrespective of the underlying memory alignment.
It wraps the intrinsics for SSE4, AVX2, an AVX512 and defaults to some sequential memory write in case a non builtin simd type is used.
The code is tested and documented. It does not affect any other code so far. 