### PR TITLE
[DOC] Hide BUG_WORKAROUND in Tutorial

### DIFF
--- a/test/documentation/seqan3_doxygen_cfg.in
+++ b/test/documentation/seqan3_doxygen_cfg.in
@@ -52,6 +52,7 @@ PREDEFINED             = "CEREAL_SERIALIZE_FUNCTION_NAME=serialize" \
                          "CEREAL_LOAD_MINIMAL_FUNCTION_NAME=load_minimal" \
                          "CEREAL_SAVE_MINIMAL_FUNCTION_NAME=save_minimal" \
                          "SEQAN3_DOXYGEN_ONLY(x)= x" \
+                         "SEQAN3_WORKAROUND_GCC_93983=0" \
                          "${SEQAN3_DOXYGEN_PREDEFINED_NDEBUG}"
 
 EXPAND_AS_DEFINED      = SEQAN3_CPO_IMPL SEQAN3_CPO_OVERLOAD_BODY SEQAN3_CPO_OVERLOAD SEQAN3_DEPRECATED_310


### PR DESCRIPTION
I realised that some WORKAROUND macros are leaking into our tutorial which they shouldn't. This small change should prevent that.