### PR TITLE
[INFRA] API-Stability cronjob

### DIFF
--- a/.github/ISSUE_TEMPLATE/api_cron_template.md
+++ b/.github/ISSUE_TEMPLATE/api_cron_template.md
@@ -1,0 +1,8 @@
+---
+title: '[CRON] API Stability Failure'
+labels: 'bug'
+---
+
+[API-Stability](https://github.com/seqan/seqan3/blob/master/test/api_stability/README.md) failed.
+
+See {{ env.GITHUB_SERVER_URL }}/{{ env.GITHUB_REPOSITORY }}/actions/runs/{{ env.GITHUB_RUN_ID }} for more information.

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -1,0 +1,95 @@
+name: SeqAn3 API-Stability
+
+# Will always run on the default branch
+on:
+  schedule:
+    - cron: "0 4 * * SUN"
+
+env:
+  CC: gcc-10
+  CXX: g++-10
+  CMAKE_VERSION: 3.8.2
+  SEQAN3_NO_VERSION_CHECK: 1
+  TZ: Europe/Berlin
+
+defaults:
+  run:
+    shell: bash -ex {0}
+
+jobs:
+  build:
+    name: API-Stability
+    runs-on: ubuntu-20.04
+    timeout-minutes: 300
+    steps:
+      - name: Checkout SeqAn3
+        uses: actions/checkout@v2
+        with:
+          path: seqan3
+          submodules: true
+
+      - name: Checkout SeqAn2
+        uses: actions/checkout@v2
+        with:
+          repository: seqan/seqan
+          ref: develop
+          path: seqan3/submodules/seqan
+
+      - name: Get cached CMake
+        uses: actions/cache@v2
+        with:
+          path: /tmp/cmake-download
+          key: ${{ runner.os }}-CMake_${{ env.CMAKE_VERSION }}
+
+      - name: Setup CMake
+        run: |
+          mkdir -p /tmp/cmake-download
+          wget --retry-connrefused --waitretry=30 --read-timeout=30 --timeout=30 --tries=20 --no-clobber --quiet --directory-prefix=/tmp/cmake-download/ https://github.com/Kitware/CMake/releases/download/v${{ env.CMAKE_VERSION }}/cmake-${{ env.CMAKE_VERSION }}-Linux-x86_64.tar.gz
+          tar -C /tmp/ -zxf /tmp/cmake-download/cmake-${{ env.CMAKE_VERSION }}-Linux-x86_64.tar.gz
+          echo "/tmp/cmake-${{ env.CMAKE_VERSION }}-Linux-x86_64/bin" >> $GITHUB_PATH # Only available in subsequent steps!
+
+      - name: Add package source
+        shell: bash
+        run: sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/ppa && sudo apt-get update
+
+      - name: Install ccache
+        run: sudo apt-get install --yes ccache
+
+      - name: Install compiler g++-10
+        run: sudo apt-get install --yes g++-10
+
+      - name: Load ccache
+        uses: actions/cache@v2
+        with:
+          path: .ccache
+          key: API-ccache-${{ github.run_number }}
+          restore-keys: |
+            API-ccache
+
+      - name: Configure tests
+        run: |
+          mkdir seqan3-build
+          cd seqan3-build
+          cmake ../seqan3/test/api_stability -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-DSEQAN3_DISABLE_DEPRECATED_WARNINGS=1"
+
+      - name: Build tests
+        env:
+          CCACHE_BASEDIR: ${{ github.workspace }}
+          CCACHE_DIR: ${{ github.workspace }}/.ccache
+          CCACHE_COMPRESS: true
+          CCACHE_COMPRESSLEVEL: 6
+          CCACHE_MAXSIZE: 5G
+        run: |
+          ccache -p || true
+          cd seqan3-build
+          CMAKE_BUILD_PARALLEL_LEVEL=2 cmake --build . -- -k
+          ccache -s || true
+
+      - name: Create issue
+        if: ${{ failure() }}
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          filename: seqan3/.github/ISSUE_TEMPLATE/api_cron_template.md
+          update_existing: true

--- a/include/seqan3/core/bit_manipulation.hpp
+++ b/include/seqan3/core/bit_manipulation.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <cassert>
+
 #include <seqan3/utility/detail/bits_of.hpp>
 #include <seqan3/utility/detail/to_little_endian.hpp>
 


### PR DESCRIPTION
Resolves https://github.com/seqan/product_backlog/issues/310

Open:
- [x] Question: Make a seqan/api team that gets assigned, core might be too much, and we can always change the team members. Answer: No assignment
- [x] Should other compilers also run? The issue would be updated for each job failure, but the URL would always be the same, so it is possible. Answer: Nope
- [x] Remove `if` in workflow.
- [x] Remove `matrix` stuff
- [x] only one restore key
- [x] "[CRON]" in title
- [x] Link to api-stab README

See https://github.com/eseiler/seqan3/issues/7 for example