### PR TITLE
[MISC] Replace `seqan3::views::join` with `seqan3::views::join_with`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -216,6 +216,8 @@ regression test suite and patches at https://github.com/seqan/seqan3/tree/master
   ([\#2567](https://github.com/seqan/seqan3/pull/2567)).
 * Deprecated `seqan3::views::drop`, use `std::views::drop` or `seqan3::views::type_reduce | std::views::drop`.
   ([\#2540](https://github.com/seqan/seqan3/pull/2540))
+* We deprecated `seqan3::views::join`. Please use `std::views::join` or `seqan3::views::join_with` instead
+  [\#2526](https://github.com/seqan/seqan3/pull/2526).
 * Deprecated `seqan3::views::move`, use the `std::ranges::move` algorithm, `std::[cpp20::]move_iterator` or an explicit
   for loop where you move the value.
   ([\#2563](https://github.com/seqan/seqan3/pull/2563))

--- a/include/seqan3/alphabet/views/translate_join.hpp
+++ b/include/seqan3/alphabet/views/translate_join.hpp
@@ -14,8 +14,8 @@
 
 #include <seqan3/std/concepts>
 #include <seqan3/std/ranges>
-#include <vector>
 #include <stdexcept>
+#include <vector>
 
 #include <seqan3/alphabet/views/translate.hpp>
 #include <seqan3/core/range/type_traits.hpp>

--- a/include/seqan3/alphabet/views/translate_join.hpp
+++ b/include/seqan3/alphabet/views/translate_join.hpp
@@ -350,7 +350,7 @@ namespace seqan3::views
  *
  * ```cpp
  * std::vector<std::vector<dna5>> vec {...};
- * auto v = vec | views::translate | views::join;
+ * auto v = vec | views::translate | std::views::join;
  * ```
  *
  * Except that the performance is better and the returned range still models std::ranges::random_access_range and std::ranges::sized_range.

--- a/include/seqan3/argument_parser/validators.hpp
+++ b/include/seqan3/argument_parser/validators.hpp
@@ -26,11 +26,11 @@
 #include <seqan3/io/detail/misc.hpp>
 #include <seqan3/io/detail/safe_filesystem_entry.hpp>
 #include <seqan3/range/container/concept.hpp>
-#include <seqan3/range/views/join.hpp>
 #include <seqan3/utility/detail/exposition_only_concept.hpp>
 #include <seqan3/utility/type_list/traits.hpp>
 #include <seqan3/utility/type_pack/traits.hpp>
 #include <seqan3/utility/type_traits/basic.hpp>
+#include <seqan3/utility/views/join_with.hpp>
 
 namespace seqan3
 {
@@ -454,7 +454,7 @@ protected:
         if (extensions.empty())
             return "";
         else
-            return detail::to_string(" Valid file extensions are: [", extensions | views::join(std::string{", "}), "].");
+            return detail::to_string(" Valid file extensions are: [", extensions | views::join_with(std::string{", "}), "].");
     }
 
     /*!\brief Helper function that checks if a string is a suffix of another string. Case insensitive.

--- a/include/seqan3/io/sequence_file/format_fasta.hpp
+++ b/include/seqan3/io/sequence_file/format_fasta.hpp
@@ -35,7 +35,6 @@
 #include <seqan3/io/sequence_file/output_options.hpp>
 #include <seqan3/io/stream/detail/fast_ostreambuf_iterator.hpp>
 #include <seqan3/range/detail/misc.hpp>
-#include <seqan3/range/views/join.hpp>
 #include <seqan3/range/views/take.hpp>
 #include <seqan3/range/views/take_exactly.hpp>
 #include <seqan3/range/views/take_line.hpp>

--- a/include/seqan3/range/container/concatenated_sequences.hpp
+++ b/include/seqan3/range/container/concatenated_sequences.hpp
@@ -21,7 +21,6 @@
 #include <seqan3/range/container/concept.hpp>
 #include <seqan3/range/detail/random_access_iterator.hpp>
 #include <seqan3/range/views/as_const.hpp>
-#include <seqan3/range/views/join.hpp>
 #include <seqan3/utility/views/repeat_n.hpp>
 #include <seqan3/utility/views/slice.hpp>
 
@@ -1111,7 +1110,7 @@ public:
             return begin() + pos_as_num;
 
         /* TODO implement views::flat_repeat_n that is like
-         *  views::repeat_n(value, count) | views::join | ranges::views::bounded;
+         *  views::repeat_n(value, count) | std::views::join | ranges::views::bounded;
          * but preserves random access and size.
          *
          * then do

--- a/include/seqan3/search/fm_index/fm_index.hpp
+++ b/include/seqan3/search/fm_index/fm_index.hpp
@@ -20,11 +20,11 @@
 
 #include <seqan3/alphabet/views/to_rank.hpp>
 #include <seqan3/core/range/type_traits.hpp>
-#include <seqan3/range/views/join.hpp>
 #include <seqan3/range/views/to.hpp>
 #include <seqan3/search/fm_index/concept.hpp>
 #include <seqan3/search/fm_index/detail/fm_index_cursor.hpp>
 #include <seqan3/search/fm_index/fm_index_cursor.hpp>
+#include <seqan3/utility/views/join_with.hpp>
 
 namespace seqan3::detail
 {
@@ -340,7 +340,7 @@ private:
                                   return r + 1;
                               })
                           }
-                          | views::join(delimiter),
+                          | views::join_with(delimiter),
                           std::ranges::begin(tmp_text));
 
         if (!reverse)

--- a/include/seqan3/utility/views/interleave.hpp
+++ b/include/seqan3/utility/views/interleave.hpp
@@ -21,10 +21,10 @@
 #include <seqan3/core/detail/persist_view.hpp>
 #include <seqan3/range/detail/random_access_iterator.hpp>
 #include <seqan3/range/views/detail.hpp>
-#include <seqan3/range/views/join.hpp>
 #include <seqan3/range/views/type_reduce.hpp>
 #include <seqan3/utility/type_traits/detail/transformation_trait_or.hpp>
 #include <seqan3/utility/type_traits/pre.hpp>
+#include <seqan3/utility/views/join_with.hpp>
 
 namespace seqan3::detail
 {
@@ -295,7 +295,7 @@ struct interleave_fn
         else
         {
             return std::forward<urng_t>(urange) | ranges::views::chunk(static_cast<size_t>(size))
-                                                | views::join(std::forward<inserted_rng_t>(i));
+                                                | views::join_with(std::forward<inserted_rng_t>(i));
         }
     }
 };
@@ -327,7 +327,7 @@ namespace seqan3::views
  * \header_file{seqan3/utility/views/interleave.hpp}
  *
  * This view can be used to insert one range into another range at regular intervals. It behaves essentially like
- * `| std::views::chunk(step_size) | views::join(inserted_range)` except that for input that models
+ * `| std::views::chunk(step_size) | std::views::join(inserted_range)` except that for input that models
  * std::ranges::random_access_range and std::ranges::sized_range a more efficient data structure is returned
  * (otherwise it returns exactly the above combination of views).
  *

--- a/include/seqan3/utility/views/join_with.hpp
+++ b/include/seqan3/utility/views/join_with.hpp
@@ -7,12 +7,29 @@
 
 /*!\file
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
- * \brief [DEPRECATED] Provides seqan3::views::join.
+ * \brief Provides seqan3::views::join_with.
  */
 
 #pragma once
 
-#include <seqan3/utility/views/join_with.hpp>
+#include <range/v3/view/join.hpp>
 
-SEQAN3_DEPRECATED_HEADER(
-   "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/utility/views/join_with.hpp> instead.")
+#include <seqan3/core/platform.hpp>
+
+namespace seqan3::views
+{
+
+/*!\brief A join view.
+ * \ingroup views
+ * \deprecated Please use std::views::join or seqan3::views::join_with (if a separator is needed)
+ */
+SEQAN3_DEPRECATED_310 inline constexpr auto join = ::ranges::views::join;
+
+/*!\brief A join view, please use std::views::join if you don't need a separator.
+ * \ingroup views
+ * \details
+ * \noapi{This is currently range-v3's join implementation.}
+ */
+inline constexpr auto join_with = ::ranges::views::join;
+
+} // namespace seqan3::views

--- a/test/performance/alphabet/views/view_translate_2D_1D_benchmark.cpp
+++ b/test/performance/alphabet/views/view_translate_2D_1D_benchmark.cpp
@@ -19,8 +19,8 @@
 #include <seqan3/utility/views/join_with.hpp>
 
 #ifdef SEQAN3_HAS_SEQAN2
-#include <seqan/sequence.h>
 #include <seqan/seq_io.h>
+#include <seqan/sequence.h>
 #include <seqan/translation.h>
 #endif
 

--- a/test/performance/alphabet/views/view_translate_2D_1D_benchmark.cpp
+++ b/test/performance/alphabet/views/view_translate_2D_1D_benchmark.cpp
@@ -13,10 +13,10 @@
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/alphabet/views/translate.hpp>
 #include <seqan3/alphabet/views/translate_join.hpp>
-#include <seqan3/range/views/join.hpp>
 #include <seqan3/range/views/to.hpp>
 #include <seqan3/test/performance/sequence_generator.hpp>
 #include <seqan3/test/seqan2.hpp>
+#include <seqan3/utility/views/join_with.hpp>
 
 #ifdef SEQAN3_HAS_SEQAN2
 #include <seqan/sequence.h>
@@ -26,7 +26,7 @@
 
 // Tags used to define the benchmark type
 struct baseline_tag{}; // Baseline where view is applied and only iterating the output range is benchmarked
-struct translate_tag{}; // Benchmark view_translate followed by seqan3::views::join
+struct translate_tag{}; // Benchmark view_translate followed by std::views::join
 struct translate_join_tag{}; // Benchmark seqan3::views::translate_join
 
 // ============================================================================
@@ -60,7 +60,7 @@ void sequential_read(benchmark::State & state)
     }
     else if constexpr (std::is_same_v<tag_t, translate_tag>)
     {
-        auto translated_aa_view = dna_sequence_collection | seqan3::views::translate | seqan3::views::join;
+        auto translated_aa_view = dna_sequence_collection | seqan3::views::translate | std::views::join;
         sequential_read_impl(state, translated_aa_view);
     }
     else
@@ -173,7 +173,7 @@ void copy(benchmark::State & state)
 
     if constexpr (std::is_same_v<tag_t, translate_tag>)
     {
-        auto adaptor = seqan3::views::translate | seqan3::views::join;
+        auto adaptor = seqan3::views::translate | std::views::join;
         copy_impl(state, dna_sequence_collection, adaptor);
     }
     else if constexpr (std::is_same_v<tag_t, translate_join_tag>)

--- a/test/performance/alphabet/views/view_translate_2D_benchmark.cpp
+++ b/test/performance/alphabet/views/view_translate_2D_benchmark.cpp
@@ -13,10 +13,10 @@
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/alphabet/views/translate.hpp>
 #include <seqan3/alphabet/views/translate_join.hpp>
-#include <seqan3/range/views/join.hpp>
 #include <seqan3/range/views/to.hpp>
 #include <seqan3/test/performance/sequence_generator.hpp>
 #include <seqan3/test/seqan2.hpp>
+#include <seqan3/utility/views/join_with.hpp>
 
 #ifdef SEQAN3_HAS_SEQAN2
 #include <seqan/sequence.h>
@@ -26,7 +26,7 @@
 
 // Tags used to define the benchmark type
 struct baseline_tag{}; // Baseline where view is applied and only iterating the output range is benchmarked
-struct translate_tag{}; // Benchmark view_translate followed by seqan3::views::join
+struct translate_tag{}; // Benchmark view_translate followed by std::views::join
 struct translate_join_tag{}; // Benchmark seqan3::views::translate_join
 
 // ============================================================================
@@ -59,7 +59,7 @@ void sequential_read(benchmark::State & state)
     }
     else if constexpr (std::is_same_v<tag_t, translate_tag>)
     {
-        auto translated_aa_view = dna_sequence_collection | seqan3::views::translate | seqan3::views::join;
+        auto translated_aa_view = dna_sequence_collection | seqan3::views::translate | std::views::join;
         sequential_read_impl(state, translated_aa_view);
     }
     else

--- a/test/performance/alphabet/views/view_translate_2D_benchmark.cpp
+++ b/test/performance/alphabet/views/view_translate_2D_benchmark.cpp
@@ -19,8 +19,8 @@
 #include <seqan3/utility/views/join_with.hpp>
 
 #ifdef SEQAN3_HAS_SEQAN2
-#include <seqan/sequence.h>
 #include <seqan/seq_io.h>
+#include <seqan/sequence.h>
 #include <seqan/translation.h>
 #endif
 

--- a/test/performance/search/search_benchmark.cpp
+++ b/test/performance/search/search_benchmark.cpp
@@ -9,12 +9,12 @@
 
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/core/detail/persist_view.hpp>
-#include <seqan3/range/views/join.hpp>
 #include <seqan3/range/views/to.hpp>
 #include <seqan3/search/fm_index/bi_fm_index.hpp>
 #include <seqan3/search/fm_index/fm_index.hpp>
 #include <seqan3/search/search.hpp>
 #include <seqan3/test/performance/sequence_generator.hpp>
+#include <seqan3/utility/views/join_with.hpp>
 
 struct options
 {
@@ -144,7 +144,7 @@ std::vector<alphabet_t> generate_repeating_sequence(size_t const template_length
 
     return generate_reads(seq_template, repeats, len, simulated_errors, 0.15, 0.15)
          | seqan3::detail::persist
-         | seqan3::views::join
+         | std::views::join
          | seqan3::views::to<std::vector>;
 }
 


### PR DESCRIPTION
- Deprecates `seqan3::views::join` use `seqan3::views::join_with` or `std::views::join` instead.
- Adds `seqan3::views::join_with`
- Move files from seqan3/ranges/views/join.hpp to seqan3/utility/views/join_with.hpp

resolves https://github.com/seqan/product_backlog/issues/351