### PR TITLE
[FIX] gcc-11: std::views::drop expects std::ranges::range_difference_t<urng_t>

### DIFF
--- a/include/seqan3/range/views/drop.hpp
+++ b/include/seqan3/range/views/drop.hpp
@@ -92,7 +92,8 @@ struct drop_fn
         // std::views::drop
         else
         {
-            return std::forward<urng_t>(urange) | std::views::drop(drop_size);
+            using drop_size_t = std::ranges::range_difference_t<urng_t>;
+            return std::views::drop(std::forward<urng_t>(urange), static_cast<drop_size_t>(drop_size));
         }
     }
 };

--- a/include/seqan3/range/views/drop.hpp
+++ b/include/seqan3/range/views/drop.hpp
@@ -93,6 +93,7 @@ struct drop_fn
         else
         {
             using drop_size_t = std::ranges::range_difference_t<urng_t>;
+            // urange | std::views::drop(drop_size);
             return std::views::drop(std::forward<urng_t>(urange), static_cast<drop_size_t>(drop_size));
         }
     }


### PR DESCRIPTION
```
seqan3/include/seqan3/range/views/drop.hpp:95:49: error: no match for ‘operator|’ (operand types are ‘std::ranges::ref_view<std::__cxx11::list<seqan3::dna4> >’ and ‘std::ranges::views::__adaptor::_Partial<std::ranges::views::_Drop, long unsigned int>’)
   95 |             return std::forward<urng_t>(urange) | std::views::drop(drop_size);
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```