### PR TITLE
[FIX,INFRA] sporadic vercel build cache failures

### DIFF
--- a/test/documentation/.vercel/install.sh
+++ b/test/documentation/.vercel/install.sh
@@ -15,7 +15,10 @@ tar -C ${CACHE_DIR}/doxygen-download -zxf ${CACHE_DIR}/doxygen-download/doxygen-
 
 pushd ${CACHE_DIR}/doxygen-download/doxygen-${DOXYGEN_VERSION}
 mkdir -p build && cd build
-cmake3 -G "Unix Makefiles" ..
+if ! cmake3 -G "Unix Makefiles" ..; then
+    rm -rf *
+    cmake3 -G "Unix Makefiles" ..
+fi
 make -j 4
 make install DESTDIR=${CACHE_DIR}/doxygen-${DOXYGEN_VERSION}
 popd


### PR DESCRIPTION
Sometimes the path is different (some directory in the path is `workpath0` instead of `path0` or vice versa).

If that happens, we clean the build directory and reconfigure.