### PR TITLE
[FIX] gcc-11: error: no match for ‘operator|’

### DIFF
--- a/include/seqan3/search/detail/unidirectional_search_algorithm.hpp
+++ b/include/seqan3/search/detail/unidirectional_search_algorithm.hpp
@@ -223,7 +223,9 @@ inline bool unidirectional_search_algorithm<configuration_t, index_t, policies_t
     if (query_pos == std::ranges::size(query) || error_left.total == 0)
     {
         // If not at end of query sequence, try searching the remaining suffix without any errors.
-        if (query_pos == std::ranges::size(query) || cur.extend_right(std::views::drop(query, query_pos)))
+        using drop_size_t = std::ranges::range_difference_t<query_t>;
+        if (query_pos == std::ranges::size(query) ||
+            cur.extend_right(std::views::drop(query, static_cast<drop_size_t>(query_pos))))
         {
             delegate(cur);
             return true;


### PR DESCRIPTION
Workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=99433#c7

```
seqan3/include/seqan3/alignment/pairwise/detail/pairwise_alignment_algorithm_banded.hpp:265:41: error: no match for ‘operator|’ (operand types are ‘std::vector<__vector(1) int, seqan3::aligned_allocator<__vector(1) int, 4> >’ and ‘std::ranges::views::__adaptor::_Partial<std::ranges::views::_Drop, long unsigned int>’)
  265 |         for (auto alphabet1 : sequence1 | std::views::drop(column_size))
      |                               ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```