### PR TITLE
[MISC] Alphabet: Move some views to alphabet views - Part 1

### DIFF
--- a/include/seqan3/alignment/aligned_sequence/debug_stream_alignment.hpp
+++ b/include/seqan3/alignment/aligned_sequence/debug_stream_alignment.hpp
@@ -18,9 +18,9 @@
 #include <range/v3/algorithm/for_each.hpp>
 
 #include <seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp>
+#include <seqan3/alphabet/views/to_char.hpp>
 #include <seqan3/core/detail/debug_stream_tuple.hpp>
 #include <seqan3/range/views/slice.hpp>
-#include <seqan3/range/views/to_char.hpp>
 #include <seqan3/utility/tuple/concept.hpp>
 #include <seqan3/utility/views/zip.hpp>
 

--- a/include/seqan3/alphabet/views/char_to.hpp
+++ b/include/seqan3/alphabet/views/char_to.hpp
@@ -65,6 +65,8 @@ namespace seqan3::views
  *
  * \include test/snippet/alphabet/views/char_to.cpp
  * \hideinitializer
+ *
+ * \stableapi{Since version 3.1.}
  */
 template <alphabet alphabet_type>
 inline auto const char_to = deep{std::views::transform([] (auto && in)

--- a/include/seqan3/alphabet/views/rank_to.hpp
+++ b/include/seqan3/alphabet/views/rank_to.hpp
@@ -1,0 +1,81 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
+ * \brief Provides seqan3::views::rank_to.
+ */
+
+#pragma once
+
+#include <seqan3/std/ranges>
+
+#include <seqan3/alphabet/concept.hpp>
+#include <seqan3/utility/views/deep.hpp>
+
+namespace seqan3::views
+{
+
+/*!\name Alphabet related views
+ * \{
+ */
+
+/*!\brief                A view over an alphabet, given a range of ranks.
+ * \tparam urng_t       The type of the range being processed. See below for requirements. [template parameter is
+ *                      omitted in pipe notation]
+ * \tparam alphabet_t   The alphabet to convert to; must satisfy seqan3::writable_semialphabet.
+ * \param[in] urange    The range being processed. [parameter is omitted in pipe notation]
+ * \returns             A range of converted elements. See below for the properties of the returned range.
+ * \ingroup views
+ *
+ * \details
+ *
+ * \header_file{seqan3/range/views/rank_to.hpp}
+ *
+ * ### View properties
+ *
+ * This view is a **deep view** Given a range-of-range as input (as opposed to just a range), it will apply
+ * the transformation on the innermost range (instead of the outermost range).
+ *
+ * | Concepts and traits              | `urng_t` (underlying range type)      | `rrng_t` (returned range type)                     |
+ * |----------------------------------|:-------------------------------------:|:--------------------------------------------------:|
+ * | std::ranges::input_range         | *required*                            | *preserved*                                        |
+ * | std::ranges::forward_range       |                                       | *preserved*                                        |
+ * | std::ranges::bidirectional_range |                                       | *preserved*                                        |
+ * | std::ranges::random_access_range |                                       | *preserved*                                        |
+ * | std::ranges::contiguous_range    |                                       | *lost*                                             |
+ * |                                  |                                       |                                                    |
+ * | std::ranges::viewable_range      | *required*                            | *guaranteed*                                       |
+ * | std::ranges::view                |                                       | *guaranteed*                                       |
+ * | std::ranges::sized_range         |                                       | *preserved*                                        |
+ * | std::ranges::common_range        |                                       | *preserved*                                        |
+ * | std::ranges::output_range        |                                       | *lost*                                             |
+ * | seqan3::const_iterable_range     |                                       | *preserved*                                        |
+ * |                                  |                                       |                                                    |
+ * | std::ranges::range_reference_t   | seqan3::alphabet_rank_t<alphabet_t>   | `alphabet_t`                                       |
+ *
+ * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.
+ *
+ * ###Example
+ * \include test/snippet/range/views/rank_to.cpp
+ * \hideinitializer
+ *
+ * \stableapi{Since version 3.1.}
+ * TODO move to seqan3/include/alphabet/views/rank_to.hpp
+ */
+template <typename alphabet_type>
+//!\cond
+    requires writable_semialphabet<alphabet_type>
+//!\endcond
+inline auto const rank_to = deep{std::views::transform([] (alphabet_rank_t<alphabet_type> const in) -> alphabet_type
+{
+    return assign_rank_to(in, alphabet_type{});
+})};
+
+//!\}
+
+} // namespace seqan3::views

--- a/include/seqan3/alphabet/views/rank_to.hpp
+++ b/include/seqan3/alphabet/views/rank_to.hpp
@@ -34,7 +34,7 @@ namespace seqan3::views
  *
  * \details
  *
- * \header_file{seqan3/range/views/rank_to.hpp}
+ * \header_file{seqan3/alphabet/views/rank_to.hpp}
  *
  * ### View properties
  *
@@ -65,7 +65,6 @@ namespace seqan3::views
  * \hideinitializer
  *
  * \stableapi{Since version 3.1.}
- * TODO move to seqan3/include/alphabet/views/rank_to.hpp
  */
 template <typename alphabet_type>
 //!\cond

--- a/include/seqan3/alphabet/views/to_char.hpp
+++ b/include/seqan3/alphabet/views/to_char.hpp
@@ -33,7 +33,7 @@ namespace seqan3::views
  *
  * \details
  *
- * \header_file{seqan3/range/views/to_char.hpp}
+ * \header_file{seqan3/alphabet/views/to_char.hpp}
  *
  * ### View properties
  *

--- a/include/seqan3/alphabet/views/to_char.hpp
+++ b/include/seqan3/alphabet/views/to_char.hpp
@@ -1,0 +1,76 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
+ * \brief Provides seqan3::views::to_char.
+ */
+
+#pragma once
+
+#include <seqan3/std/ranges>
+
+#include <seqan3/alphabet/concept.hpp>
+#include <seqan3/utility/views/deep.hpp>
+
+namespace seqan3::views
+{
+
+/*!\name Alphabet related views
+ * \{
+ */
+
+/*!\brief               A view that calls seqan3::to_char() on each element in the input range.
+ * \tparam urng_t       The type of the range being processed. See below for requirements. [template parameter is
+ *                      omitted in pipe notation]
+ * \param[in] urange    The range being processed. [parameter is omitted in pipe notation]
+ * \returns             A range of converted elements. See below for the properties of the returned range.
+ * \ingroup views
+ *
+ * \details
+ *
+ * \header_file{seqan3/range/views/to_char.hpp}
+ *
+ * ### View properties
+ *
+ * This view is a **deep view** Given a range-of-range as input (as opposed to just a range), it will apply
+ * the transformation on the innermost range (instead of the outermost range).
+ *
+ * | Concepts and traits              | `urng_t` (underlying range type)      | `rrng_t` (returned range type)                                |
+ * |----------------------------------|:-------------------------------------:|:-------------------------------------------------------------:|
+ * | std::ranges::input_range         | *required*                            | *preserved*                                                   |
+ * | std::ranges::forward_range       |                                       | *preserved*                                                   |
+ * | std::ranges::bidirectional_range |                                       | *preserved*                                                   |
+ * | std::ranges::random_access_range |                                       | *preserved*                                                   |
+ * | std::ranges::contiguous_range    |                                       | *lost*                                                        |
+ * |                                  |                                       |                                                               |
+ * | std::ranges::viewable_range      | *required*                            | *guaranteed*                                                  |
+ * | std::ranges::view                |                                       | *guaranteed*                                                  |
+ * | std::ranges::sized_range         |                                       | *preserved*                                                   |
+ * | std::ranges::common_range        |                                       | *preserved*                                                   |
+ * | std::ranges::output_range        |                                       | *lost*                                                        |
+ * | seqan3::const_iterable_range     |                                       | *preserved*                                                   |
+ * |                                  |                                       |                                                               |
+ * | std::ranges::range_reference_t   | seqan3::alphabet                      | seqan3::alphabet_char_t<std::ranges::range_value_t<urng_t>>   |
+ *
+ * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.
+ *
+ * ### Example
+ * \include test/snippet/range/views/range_view_to_char.cpp
+ * \hideinitializer
+ *
+ * \stableapi{Since version 3.1.}
+ */
+inline auto const to_char = deep{std::views::transform([] (auto const in) noexcept
+{
+    static_assert(alphabet<std::remove_cvref_t<decltype(in)>>, "The value type of seqan3::views::to_char must model the seqan3::alphabet.");
+    return seqan3::to_char(in);
+})};
+
+//!\}
+
+} // namespace seqan3::views

--- a/include/seqan3/alphabet/views/to_rank.hpp
+++ b/include/seqan3/alphabet/views/to_rank.hpp
@@ -34,7 +34,7 @@ namespace seqan3::views
  *
  * \details
  *
- * \header_file{seqan3/range/views/to_rank.hpp}
+ * \header_file{seqan3/alphabet/views/to_rank.hpp}
  *
  * ### View properties
  *

--- a/include/seqan3/alphabet/views/to_rank.hpp
+++ b/include/seqan3/alphabet/views/to_rank.hpp
@@ -1,0 +1,80 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
+ * \brief Provides seqan3::views::to_rank.
+ */
+
+#pragma once
+
+#include <cstring>
+#include <seqan3/std/ranges>
+
+#include <seqan3/alphabet/concept.hpp>
+#include <seqan3/utility/views/deep.hpp>
+
+namespace seqan3::views
+{
+
+/*!\name Alphabet related views
+ * \{
+ */
+
+/*!\brief               A view that calls seqan3::to_rank() on each element in the input range.
+ * \tparam urng_t       The type of the range being processed. See below for requirements. [template parameter is
+ *                      omitted in pipe notation]
+ * \param[in] urange    The range being processed. [parameter is omitted in pipe notation]
+ * \returns             A range of converted elements. See below for the properties of the returned range.
+ * \ingroup views
+ *
+ * \details
+ *
+ * \header_file{seqan3/range/views/to_rank.hpp}
+ *
+ * ### View properties
+ *
+ * This view is a **deep view** Given a range-of-range as input (as opposed to just a range), it will apply
+ * the transformation on the innermost range (instead of the outermost range).
+ *
+ * | Concepts and traits              | `urng_t` (underlying range type)      | `rrng_t` (returned range type)                                |
+ * |----------------------------------|:-------------------------------------:|:-------------------------------------------------------------:|
+ * | std::ranges::input_range         | *required*                            | *preserved*                                                   |
+ * | std::ranges::forward_range       |                                       | *preserved*                                                   |
+ * | std::ranges::bidirectional_range |                                       | *preserved*                                                   |
+ * | std::ranges::random_access_range |                                       | *preserved*                                                   |
+ * | std::ranges::contiguous_range    |                                       | *lost*                                                        |
+ * |                                  |                                       |                                                               |
+ * | std::ranges::viewable_range      | *required*                            | *guaranteed*                                                  |
+ * | std::ranges::view                |                                       | *guaranteed*                                                  |
+ * | std::ranges::sized_range         |                                       | *preserved*                                                   |
+ * | std::ranges::common_range        |                                       | *preserved*                                                   |
+ * | std::ranges::output_range        |                                       | *lost*                                                        |
+ * | seqan3::const_iterable_range     |                                       | *preserved*                                                   |
+ * |                                  |                                       |                                                               |
+ * | std::ranges::range_reference_t   | seqan3::alphabet                      | seqan3::alphabet_rank_t<std::ranges::range_value_t<urng_t>>   |
+ *
+ * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.
+ *
+ * ### Example
+ * \include test/snippet/range/views/range_view_to_rank.cpp
+ * We also convert to unsigned here, because the seqan3::alphabet_rank_t is often `uint8_t` which is
+ * often implemented as `unsigned char` and thus will not be printed as a number by default.
+ * \hideinitializer
+ *
+ * \stableapi{Since version 3.1.}
+ */
+inline auto const to_rank = deep{std::views::transform([] (auto const in) noexcept
+{
+    static_assert(semialphabet<decltype(in)>,
+                  "The value type of seqan3::views::to_rank must model the seqan3::alphabet.");
+    return seqan3::to_rank(in);
+})};
+
+//!\}
+
+} // namespace seqan3::views

--- a/include/seqan3/alphabet/views/trim_quality.hpp
+++ b/include/seqan3/alphabet/views/trim_quality.hpp
@@ -91,7 +91,7 @@ namespace seqan3::views
  *
  * \details
  *
- * \header_file{seqan3/range/views/trim_quality.hpp}
+ * \header_file{seqan3/alphabet/views/trim_quality.hpp}
  *
  * This view can be used to trim sequences based on quality. Only bases at the end of the sequence not meeting the
  * specified threshold are discarded.

--- a/include/seqan3/alphabet/views/trim_quality.hpp
+++ b/include/seqan3/alphabet/views/trim_quality.hpp
@@ -1,0 +1,136 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
+ * \brief Provides seqan3::views::trim_quality.
+ */
+
+#pragma once
+
+#include <seqan3/std/ranges>
+
+#include <seqan3/alphabet/quality/qualified.hpp>
+#include <seqan3/range/views/take_until.hpp>
+#include <seqan3/utility/views/deep.hpp>
+
+namespace seqan3::detail
+{
+
+/*!\brief The underlying type of seqan3::views::trim_quality.
+ * \ingroup views
+ *
+ * Under the hood, this delegates to std::views::take_while.
+ */
+struct trim_fn
+{
+    //!\brief Store the argument and return a range adaptor closure object.
+    template <typename threshold_t>
+    constexpr auto operator()(threshold_t const threshold) const
+    {
+        static_assert(quality_alphabet<threshold_t> || std::integral<threshold_t>,
+                      "The threshold must either be a quality alphabet or an integral type "
+                      "in which case it is compared with the underlying Phred score type.");
+
+        return adaptor_from_functor{*this, threshold};
+    }
+
+    /*!\brief Trim based on minimum Phred score.
+     * \tparam irng_t The type of the range being processed. See seqan3::views::trim_quality for requirements.
+     * \param irange The range being processed.
+     * \param threshold The minimum quality as a Phred score [integral type].
+     */
+    template <std::ranges::input_range irng_t, typename threshold_t>
+    constexpr auto operator()(irng_t && irange, threshold_t const threshold) const
+    {
+        static_assert(quality_alphabet<std::remove_reference_t<std::ranges::range_reference_t<irng_t>>>,
+                      "views::trim_quality can only operate on ranges over seqan3::quality_alphabet.");
+        static_assert(std::same_as<std::remove_cvref_t<threshold_t>,
+                     std::remove_cvref_t<std::ranges::range_reference_t<irng_t>>> ||
+                      std::integral<std::remove_cvref_t<threshold_t>>,
+                      "The threshold must either be a letter of the underlying alphabet or an integral type "
+                      "in which case it is compared with the underlying Phred score type.");
+
+        return views::take_until(std::forward<irng_t>(irange), [threshold] (auto const value)
+        {
+            if constexpr (std::same_as<std::remove_cvref_t<threshold_t>,
+                          std::remove_cvref_t<std::ranges::range_reference_t<irng_t>>>)
+            {
+                return to_phred(value) < to_phred(threshold);
+            }
+            else
+            {
+                using c_t = std::common_type_t<decltype(to_phred(value)), threshold_t>;
+                return static_cast<c_t>(to_phred(value)) < static_cast<c_t>(threshold);
+            }
+        });
+    }
+};
+
+} // namespace seqan3::detail
+
+namespace seqan3::views
+{
+
+/*!\name Alphabet related views
+ * \{
+ */
+
+/*!\brief               A view that does quality-threshold trimming on a range of seqan3::quality_alphabet.
+ * \tparam urng_t       The type of the range being processed. See below for requirements.
+ * \tparam threshold_t  Either std::ranges::range_value_t<urng_t> or
+ *                      seqan3::alphabet_phred_t<std::ranges::range_value_t<urng_t>>.
+ * \param[in] urange    The range being processed. [parameter is omitted in pipe notation]
+ * \param[in] threshold The minimum quality.
+ * \returns             A trimmed range. See below for the properties of the returned range.
+ * \ingroup views
+ *
+ * \details
+ *
+ * \header_file{seqan3/range/views/trim_quality.hpp}
+ *
+ * This view can be used to trim sequences based on quality. Only bases at the end of the sequence not meeting the
+ * specified threshold are discarded.
+ *
+ * ### View properties
+ *
+ * This view is a **deep view** Given a range-of-range as input (as opposed to just a range), it will apply
+ * the transformation on the innermost range (instead of the outermost range).
+ *
+ * | Concepts and traits              | `urng_t` (underlying range type)      | `rrng_t` (returned range type)         |
+ * |----------------------------------|:-------------------------------------:|:--------------------------------------:|
+ * | std::ranges::input_range         | *required*                            | *preserved*                            |
+ * | std::ranges::forward_range       |                                       | *preserved*                            |
+ * | std::ranges::bidirectional_range |                                       | *preserved*                            |
+ * | std::ranges::random_access_range |                                       | *preserved*                            |
+ * |                                  |                                       |                                        |
+ * | std::ranges::view                |                                       | *guaranteed*                           |
+ * | std::ranges::sized_range         |                                       | *lost*                                 |
+ * | std::ranges::common_range        |                                       | *lost*                                 |
+ * | std::ranges::output_range        |                                       | *preserved*                            |
+ * | seqan3::const_iterable_range     |                                       | *preserved*                            |
+ * |                                  |                                       |                                        |
+ * | std::ranges::range_reference_t   | seqan3::quality_alphabet              | std::ranges::range_reference_t<urng_t> |
+ *
+ * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.
+ *
+ * ###Example
+ *
+ * Operating on a range of seqan3::phred42:
+ * \include test/snippet/range/views/trim_quality_phred42.cpp
+ *
+ * Or operating on a range of seqan3::dna5q:
+ * \include test/snippet/range/views/trim_quality_dna5q.cpp
+ * \hideinitializer
+ *
+ * \experimentalapi{Experimental since version 3.1.}
+ */
+inline constexpr auto trim_quality = deep{seqan3::detail::trim_fn{}};
+
+//!\}
+
+} // namespace seqan3::views

--- a/include/seqan3/io/sam_file/detail/format_sam_base.hpp
+++ b/include/seqan3/io/sam_file/detail/format_sam_base.hpp
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include <seqan3/alphabet/views/char_to.hpp>
+#include <seqan3/alphabet/views/to_char.hpp>
 #include <seqan3/core/debug_stream/detail/to_string.hpp>
 #include <seqan3/core/detail/debug_stream_range.hpp>
 #include <seqan3/core/detail/template_inspection.hpp>
@@ -40,7 +41,6 @@
 #include <seqan3/range/views/slice.hpp>
 #include <seqan3/range/views/take_until.hpp>
 #include <seqan3/range/views/to.hpp>
-#include <seqan3/range/views/to_char.hpp>
 #include <seqan3/utility/detail/exposition_only_concept.hpp>
 #include <seqan3/utility/detail/type_name_as_string.hpp>
 #include <seqan3/utility/tuple/concept.hpp>

--- a/include/seqan3/io/sam_file/format_sam.hpp
+++ b/include/seqan3/io/sam_file/format_sam.hpp
@@ -21,6 +21,7 @@
 
 #include <seqan3/alphabet/concept.hpp>
 #include <seqan3/alphabet/views/char_to.hpp>
+#include <seqan3/alphabet/views/to_char.hpp>
 #include <seqan3/core/debug_stream/detail/to_string.hpp>
 #include <seqan3/core/detail/template_inspection.hpp>
 #include <seqan3/core/range/type_traits.hpp>
@@ -43,7 +44,6 @@
 #include <seqan3/range/views/slice.hpp>
 #include <seqan3/range/views/take_until.hpp>
 #include <seqan3/range/views/to.hpp>
-#include <seqan3/range/views/to_char.hpp>
 #include <seqan3/utility/char_operations/predicate.hpp>
 #include <seqan3/utility/detail/exposition_only_concept.hpp>
 #include <seqan3/utility/detail/type_name_as_string.hpp>

--- a/include/seqan3/io/sequence_file/format_embl.hpp
+++ b/include/seqan3/io/sequence_file/format_embl.hpp
@@ -22,6 +22,7 @@
 #include <seqan3/alphabet/concept.hpp>
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
 #include <seqan3/alphabet/views/char_to.hpp>
+#include <seqan3/alphabet/views/to_char.hpp>
 #include <seqan3/core/range/type_traits.hpp>
 #include <seqan3/io/detail/misc.hpp>
 #include <seqan3/io/sequence_file/input_format_concept.hpp>
@@ -31,7 +32,6 @@
 #include <seqan3/io/stream/detail/fast_ostreambuf_iterator.hpp>
 #include <seqan3/range/detail/misc.hpp>
 #include <seqan3/range/views/istreambuf.hpp>
-#include <seqan3/range/views/to_char.hpp>
 #include <seqan3/range/views/take_line.hpp>
 #include <seqan3/range/views/take_until.hpp>
 #include <seqan3/utility/char_operations/predicate.hpp>

--- a/include/seqan3/io/sequence_file/format_fasta.hpp
+++ b/include/seqan3/io/sequence_file/format_fasta.hpp
@@ -24,6 +24,7 @@
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
 #include <seqan3/alphabet/quality/aliases.hpp>
 #include <seqan3/alphabet/views/char_to.hpp>
+#include <seqan3/alphabet/views/to_char.hpp>
 #include <seqan3/core/range/type_traits.hpp>
 #include <seqan3/io/detail/ignore_output_iterator.hpp>
 #include <seqan3/io/detail/misc.hpp>
@@ -35,7 +36,6 @@
 #include <seqan3/range/detail/misc.hpp>
 #include <seqan3/range/views/istreambuf.hpp>
 #include <seqan3/range/views/join.hpp>
-#include <seqan3/range/views/to_char.hpp>
 #include <seqan3/range/views/take.hpp>
 #include <seqan3/range/views/take_exactly.hpp>
 #include <seqan3/range/views/take_line.hpp>

--- a/include/seqan3/io/sequence_file/format_fastq.hpp
+++ b/include/seqan3/io/sequence_file/format_fastq.hpp
@@ -24,6 +24,7 @@
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
 #include <seqan3/alphabet/quality/aliases.hpp>
 #include <seqan3/alphabet/views/char_to.hpp>
+#include <seqan3/alphabet/views/to_char.hpp>
 #include <seqan3/core/range/type_traits.hpp>
 #include <seqan3/io/detail/ignore_output_iterator.hpp>
 #include <seqan3/io/detail/misc.hpp>
@@ -38,7 +39,6 @@
 #include <seqan3/range/views/take_exactly.hpp>
 #include <seqan3/range/views/take_line.hpp>
 #include <seqan3/range/views/take_until.hpp>
-#include <seqan3/range/views/to_char.hpp>
 #include <seqan3/utility/char_operations/predicate.hpp>
 #include <seqan3/utility/detail/type_name_as_string.hpp>
 

--- a/include/seqan3/io/sequence_file/format_genbank.hpp
+++ b/include/seqan3/io/sequence_file/format_genbank.hpp
@@ -25,6 +25,7 @@
 #include <seqan3/alphabet/concept.hpp>
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
 #include <seqan3/alphabet/views/char_to.hpp>
+#include <seqan3/alphabet/views/to_char.hpp>
 #include <seqan3/core/range/type_traits.hpp>
 #include <seqan3/io/detail/misc.hpp>
 #include <seqan3/io/sequence_file/input_format_concept.hpp>
@@ -34,7 +35,6 @@
 #include <seqan3/range/detail/misc.hpp>
 #include <seqan3/range/views/interleave.hpp>
 #include <seqan3/range/views/istreambuf.hpp>
-#include <seqan3/range/views/to_char.hpp>
 #include <seqan3/range/views/take.hpp>
 #include <seqan3/range/views/take_line.hpp>
 #include <seqan3/range/views/take_until.hpp>

--- a/include/seqan3/io/structure_file/format_vienna.hpp
+++ b/include/seqan3/io/structure_file/format_vienna.hpp
@@ -26,6 +26,7 @@
 #include <seqan3/alphabet/concept.hpp>
 #include <seqan3/alphabet/structure/wuss.hpp>
 #include <seqan3/alphabet/views/char_to.hpp>
+#include <seqan3/alphabet/views/to_char.hpp>
 #include <seqan3/core/range/type_traits.hpp>
 #include <seqan3/io/detail/misc.hpp>
 #include <seqan3/io/structure_file/detail.hpp>
@@ -38,7 +39,6 @@
 #include <seqan3/range/views/take.hpp>
 #include <seqan3/range/views/take_line.hpp>
 #include <seqan3/range/views/take_until.hpp>
-#include <seqan3/range/views/to_char.hpp>
 #include <seqan3/range/views/to.hpp>
 #include <seqan3/utility/char_operations/predicate.hpp>
 #include <seqan3/utility/detail/type_name_as_string.hpp>

--- a/include/seqan3/range/container/bitcompressed_vector.hpp
+++ b/include/seqan3/range/container/bitcompressed_vector.hpp
@@ -21,9 +21,9 @@
 
 #include <seqan3/alphabet/detail/alphabet_proxy.hpp>
 #include <seqan3/alphabet/views/to_char.hpp>
+#include <seqan3/alphabet/views/to_rank.hpp>
 #include <seqan3/core/concept/cereal.hpp>
 #include <seqan3/range/detail/random_access_iterator.hpp>
-#include <seqan3/range/views/to_rank.hpp>
 #include <seqan3/utility/math.hpp>
 #include <seqan3/utility/views/convert.hpp>
 

--- a/include/seqan3/range/container/bitcompressed_vector.hpp
+++ b/include/seqan3/range/container/bitcompressed_vector.hpp
@@ -20,9 +20,9 @@
 #include <sdsl/int_vector.hpp>
 
 #include <seqan3/alphabet/detail/alphabet_proxy.hpp>
+#include <seqan3/alphabet/views/to_char.hpp>
 #include <seqan3/core/concept/cereal.hpp>
 #include <seqan3/range/detail/random_access_iterator.hpp>
-#include <seqan3/range/views/to_char.hpp>
 #include <seqan3/range/views/to_rank.hpp>
 #include <seqan3/utility/math.hpp>
 #include <seqan3/utility/views/convert.hpp>

--- a/include/seqan3/range/views/all.hpp
+++ b/include/seqan3/range/views/all.hpp
@@ -16,6 +16,7 @@
 #include <seqan3/alphabet/views/rank_to.hpp>
 #include <seqan3/alphabet/views/to_char.hpp>
 #include <seqan3/alphabet/views/to_rank.hpp>
+#include <seqan3/alphabet/views/trim_quality.hpp>
 #include <seqan3/range/views/complement.hpp>
 #include <seqan3/range/views/enforce_random_access.hpp>
 #include <seqan3/range/views/get.hpp>
@@ -30,7 +31,6 @@
 #include <seqan3/range/views/take_until.hpp>
 #include <seqan3/range/views/to.hpp>
 #include <seqan3/range/views/translate.hpp>
-#include <seqan3/range/views/trim_quality.hpp>
 #include <seqan3/utility/views/convert.hpp>
 #include <seqan3/utility/views/deep.hpp>
 

--- a/include/seqan3/range/views/all.hpp
+++ b/include/seqan3/range/views/all.hpp
@@ -13,6 +13,7 @@
 #pragma once
 
 #include <seqan3/alphabet/views/char_to.hpp>
+#include <seqan3/alphabet/views/to_char.hpp>
 #include <seqan3/range/views/complement.hpp>
 #include <seqan3/range/views/enforce_random_access.hpp>
 #include <seqan3/range/views/get.hpp>
@@ -27,7 +28,6 @@
 #include <seqan3/range/views/take_line.hpp>
 #include <seqan3/range/views/take_until.hpp>
 #include <seqan3/range/views/to.hpp>
-#include <seqan3/range/views/to_char.hpp>
 #include <seqan3/range/views/to_rank.hpp>
 #include <seqan3/range/views/translate.hpp>
 #include <seqan3/range/views/trim_quality.hpp>

--- a/include/seqan3/range/views/all.hpp
+++ b/include/seqan3/range/views/all.hpp
@@ -15,6 +15,7 @@
 #include <seqan3/alphabet/views/char_to.hpp>
 #include <seqan3/alphabet/views/rank_to.hpp>
 #include <seqan3/alphabet/views/to_char.hpp>
+#include <seqan3/alphabet/views/to_rank.hpp>
 #include <seqan3/range/views/complement.hpp>
 #include <seqan3/range/views/enforce_random_access.hpp>
 #include <seqan3/range/views/get.hpp>
@@ -28,7 +29,6 @@
 #include <seqan3/range/views/take_line.hpp>
 #include <seqan3/range/views/take_until.hpp>
 #include <seqan3/range/views/to.hpp>
-#include <seqan3/range/views/to_rank.hpp>
 #include <seqan3/range/views/translate.hpp>
 #include <seqan3/range/views/trim_quality.hpp>
 #include <seqan3/utility/views/convert.hpp>

--- a/include/seqan3/range/views/all.hpp
+++ b/include/seqan3/range/views/all.hpp
@@ -13,6 +13,7 @@
 #pragma once
 
 #include <seqan3/alphabet/views/char_to.hpp>
+#include <seqan3/alphabet/views/rank_to.hpp>
 #include <seqan3/alphabet/views/to_char.hpp>
 #include <seqan3/range/views/complement.hpp>
 #include <seqan3/range/views/enforce_random_access.hpp>
@@ -21,7 +22,6 @@
 #include <seqan3/range/views/istreambuf.hpp>
 #include <seqan3/range/views/move.hpp>
 #include <seqan3/range/views/pairwise_combine.hpp>
-#include <seqan3/range/views/rank_to.hpp>
 #include <seqan3/range/views/single_pass_input.hpp>
 #include <seqan3/range/views/take.hpp>
 #include <seqan3/range/views/take_exactly.hpp>

--- a/include/seqan3/range/views/rank_to.hpp
+++ b/include/seqan3/range/views/rank_to.hpp
@@ -63,6 +63,9 @@ namespace seqan3::views
  * ###Example
  * \include test/snippet/range/views/rank_to.cpp
  * \hideinitializer
+ *
+ * \stableapi{Since version 3.1.}
+ * TODO move to seqan3/include/alphabet/views/rank_to.hpp
  */
 template <typename alphabet_type>
 //!\cond

--- a/include/seqan3/range/views/rank_to.hpp
+++ b/include/seqan3/range/views/rank_to.hpp
@@ -6,76 +6,14 @@
 // -----------------------------------------------------------------------------------------------------
 
 /*!\file
+ * \brief [DEPRECATED] Provides seqan3::views::rank_to.
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
- * \brief Provides seqan3::views::rank_to.
+ * \deprecated This header will be removed in 3.1. Please use seqan3/alphabet/views/rank_to.hpp instead.
  */
 
 #pragma once
 
-#include <seqan3/std/ranges>
+#include <seqan3/alphabet/views/rank_to.hpp>
 
-#include <seqan3/alphabet/concept.hpp>
-#include <seqan3/utility/views/deep.hpp>
-
-namespace seqan3::views
-{
-
-/*!\name Alphabet related views
- * \{
- */
-
-/*!\brief                A view over an alphabet, given a range of ranks.
- * \tparam urng_t       The type of the range being processed. See below for requirements. [template parameter is
- *                      omitted in pipe notation]
- * \tparam alphabet_t   The alphabet to convert to; must satisfy seqan3::writable_semialphabet.
- * \param[in] urange    The range being processed. [parameter is omitted in pipe notation]
- * \returns             A range of converted elements. See below for the properties of the returned range.
- * \ingroup views
- *
- * \details
- *
- * \header_file{seqan3/range/views/rank_to.hpp}
- *
- * ### View properties
- *
- * This view is a **deep view** Given a range-of-range as input (as opposed to just a range), it will apply
- * the transformation on the innermost range (instead of the outermost range).
- *
- * | Concepts and traits              | `urng_t` (underlying range type)      | `rrng_t` (returned range type)                     |
- * |----------------------------------|:-------------------------------------:|:--------------------------------------------------:|
- * | std::ranges::input_range         | *required*                            | *preserved*                                        |
- * | std::ranges::forward_range       |                                       | *preserved*                                        |
- * | std::ranges::bidirectional_range |                                       | *preserved*                                        |
- * | std::ranges::random_access_range |                                       | *preserved*                                        |
- * | std::ranges::contiguous_range    |                                       | *lost*                                             |
- * |                                  |                                       |                                                    |
- * | std::ranges::viewable_range      | *required*                            | *guaranteed*                                       |
- * | std::ranges::view                |                                       | *guaranteed*                                       |
- * | std::ranges::sized_range         |                                       | *preserved*                                        |
- * | std::ranges::common_range        |                                       | *preserved*                                        |
- * | std::ranges::output_range        |                                       | *lost*                                             |
- * | seqan3::const_iterable_range     |                                       | *preserved*                                        |
- * |                                  |                                       |                                                    |
- * | std::ranges::range_reference_t   | seqan3::alphabet_rank_t<alphabet_t>   | `alphabet_t`                                       |
- *
- * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.
- *
- * ###Example
- * \include test/snippet/range/views/rank_to.cpp
- * \hideinitializer
- *
- * \stableapi{Since version 3.1.}
- * TODO move to seqan3/include/alphabet/views/rank_to.hpp
- */
-template <typename alphabet_type>
-//!\cond
-    requires writable_semialphabet<alphabet_type>
-//!\endcond
-inline auto const rank_to = deep{std::views::transform([] (alphabet_rank_t<alphabet_type> const in) -> alphabet_type
-{
-    return assign_rank_to(in, alphabet_type{});
-})};
-
-//!\}
-
-} // namespace seqan3::views
+SEQAN3_DEPRECATED_HEADER(
+   "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/alphabet/views/rank_to.hpp> instead.")

--- a/include/seqan3/range/views/to_char.hpp
+++ b/include/seqan3/range/views/to_char.hpp
@@ -62,6 +62,9 @@ namespace seqan3::views
  * ### Example
  * \include test/snippet/range/views/range_view_to_char.cpp
  * \hideinitializer
+ *
+ * \stableapi{Since version 3.1.}
+ * TODO move to seqan3/include/alphabet/views/to_char.hpp
  */
 inline auto const to_char = deep{std::views::transform([] (auto const in) noexcept
 {

--- a/include/seqan3/range/views/to_char.hpp
+++ b/include/seqan3/range/views/to_char.hpp
@@ -6,72 +6,14 @@
 // -----------------------------------------------------------------------------------------------------
 
 /*!\file
+ * \brief [DEPRECATED] Provides seqan3::views::to_char.
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
- * \brief Provides seqan3::views::to_char.
+ * \deprecated This header will be removed in 3.1. Please use seqan3/alphabet/views/to_char.hpp instead.
  */
 
 #pragma once
 
-#include <seqan3/std/ranges>
+#include <seqan3/alphabet/views/to_char.hpp>
 
-#include <seqan3/alphabet/concept.hpp>
-#include <seqan3/utility/views/deep.hpp>
-
-namespace seqan3::views
-{
-
-/*!\name Alphabet related views
- * \{
- */
-
-/*!\brief               A view that calls seqan3::to_char() on each element in the input range.
- * \tparam urng_t       The type of the range being processed. See below for requirements. [template parameter is
- *                      omitted in pipe notation]
- * \param[in] urange    The range being processed. [parameter is omitted in pipe notation]
- * \returns             A range of converted elements. See below for the properties of the returned range.
- * \ingroup views
- *
- * \details
- *
- * \header_file{seqan3/range/views/to_char.hpp}
- *
- * ### View properties
- *
- * This view is a **deep view** Given a range-of-range as input (as opposed to just a range), it will apply
- * the transformation on the innermost range (instead of the outermost range).
- *
- * | Concepts and traits              | `urng_t` (underlying range type)      | `rrng_t` (returned range type)                                |
- * |----------------------------------|:-------------------------------------:|:-------------------------------------------------------------:|
- * | std::ranges::input_range         | *required*                            | *preserved*                                                   |
- * | std::ranges::forward_range       |                                       | *preserved*                                                   |
- * | std::ranges::bidirectional_range |                                       | *preserved*                                                   |
- * | std::ranges::random_access_range |                                       | *preserved*                                                   |
- * | std::ranges::contiguous_range    |                                       | *lost*                                                        |
- * |                                  |                                       |                                                               |
- * | std::ranges::viewable_range      | *required*                            | *guaranteed*                                                  |
- * | std::ranges::view                |                                       | *guaranteed*                                                  |
- * | std::ranges::sized_range         |                                       | *preserved*                                                   |
- * | std::ranges::common_range        |                                       | *preserved*                                                   |
- * | std::ranges::output_range        |                                       | *lost*                                                        |
- * | seqan3::const_iterable_range     |                                       | *preserved*                                                   |
- * |                                  |                                       |                                                               |
- * | std::ranges::range_reference_t   | seqan3::alphabet                      | seqan3::alphabet_char_t<std::ranges::range_value_t<urng_t>>   |
- *
- * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.
- *
- * ### Example
- * \include test/snippet/range/views/range_view_to_char.cpp
- * \hideinitializer
- *
- * \stableapi{Since version 3.1.}
- * TODO move to seqan3/include/alphabet/views/to_char.hpp
- */
-inline auto const to_char = deep{std::views::transform([] (auto const in) noexcept
-{
-    static_assert(alphabet<std::remove_cvref_t<decltype(in)>>, "The value type of seqan3::views::to_char must model the seqan3::alphabet.");
-    return seqan3::to_char(in);
-})};
-
-//!\}
-
-} // namespace seqan3::views
+SEQAN3_DEPRECATED_HEADER(
+   "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/alphabet/views/to_char.hpp> instead.")

--- a/include/seqan3/range/views/to_rank.hpp
+++ b/include/seqan3/range/views/to_rank.hpp
@@ -6,75 +6,14 @@
 // -----------------------------------------------------------------------------------------------------
 
 /*!\file
+ * \brief [DEPRECATED] Provides seqan3::views::to_rank.
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
- * \brief Provides seqan3::views::to_rank.
+ * \deprecated This header will be removed in 3.1. Please use seqan3/alphabet/views/to_rank.hpp instead.
  */
 
 #pragma once
 
-#include <seqan3/std/ranges>
+#include <seqan3/alphabet/views/to_rank.hpp>
 
-#include <seqan3/alphabet/concept.hpp>
-#include <seqan3/utility/views/deep.hpp>
-
-namespace seqan3::views
-{
-
-/*!\name Alphabet related views
- * \{
- */
-
-/*!\brief               A view that calls seqan3::to_rank() on each element in the input range.
- * \tparam urng_t       The type of the range being processed. See below for requirements. [template parameter is
- *                      omitted in pipe notation]
- * \param[in] urange    The range being processed. [parameter is omitted in pipe notation]
- * \returns             A range of converted elements. See below for the properties of the returned range.
- * \ingroup views
- *
- * \details
- *
- * \header_file{seqan3/range/views/to_rank.hpp}
- *
- * ### View properties
- *
- * This view is a **deep view** Given a range-of-range as input (as opposed to just a range), it will apply
- * the transformation on the innermost range (instead of the outermost range).
- *
- * | Concepts and traits              | `urng_t` (underlying range type)      | `rrng_t` (returned range type)                                |
- * |----------------------------------|:-------------------------------------:|:-------------------------------------------------------------:|
- * | std::ranges::input_range         | *required*                            | *preserved*                                                   |
- * | std::ranges::forward_range       |                                       | *preserved*                                                   |
- * | std::ranges::bidirectional_range |                                       | *preserved*                                                   |
- * | std::ranges::random_access_range |                                       | *preserved*                                                   |
- * | std::ranges::contiguous_range    |                                       | *lost*                                                        |
- * |                                  |                                       |                                                               |
- * | std::ranges::viewable_range      | *required*                            | *guaranteed*                                                  |
- * | std::ranges::view                |                                       | *guaranteed*                                                  |
- * | std::ranges::sized_range         |                                       | *preserved*                                                   |
- * | std::ranges::common_range        |                                       | *preserved*                                                   |
- * | std::ranges::output_range        |                                       | *lost*                                                        |
- * | seqan3::const_iterable_range     |                                       | *preserved*                                                   |
- * |                                  |                                       |                                                               |
- * | std::ranges::range_reference_t   | seqan3::alphabet                      | seqan3::alphabet_rank_t<std::ranges::range_value_t<urng_t>>   |
- *
- * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.
- *
- * ### Example
- * \include test/snippet/range/views/range_view_to_rank.cpp
- * We also convert to unsigned here, because the seqan3::alphabet_rank_t is often `uint8_t` which is
- * often implemented as `unsigned char` and thus will not be printed as a number by default.
- * \hideinitializer
- *
- * \stableapi{Since version 3.1.}
- * TODO move to seqan3/include/alphabet/views/to_rank.hpp
- */
-inline auto const to_rank = deep{std::views::transform([] (auto const in) noexcept
-{
-    static_assert(semialphabet<decltype(in)>,
-                  "The value type of seqan3::views::to_rank must model the seqan3::alphabet.");
-    return seqan3::to_rank(in);
-})};
-
-//!\}
-
-} // namespace seqan3::views
+SEQAN3_DEPRECATED_HEADER(
+   "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/alphabet/views/to_rank.hpp> instead.")

--- a/include/seqan3/range/views/to_rank.hpp
+++ b/include/seqan3/range/views/to_rank.hpp
@@ -59,11 +59,14 @@ namespace seqan3::views
  *
  * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.
  *
- * ###Example
+ * ### Example
  * \include test/snippet/range/views/range_view_to_rank.cpp
  * We also convert to unsigned here, because the seqan3::alphabet_rank_t is often `uint8_t` which is
  * often implemented as `unsigned char` and thus will not be printed as a number by default.
  * \hideinitializer
+ *
+ * \stableapi{Since version 3.1.}
+ * TODO move to seqan3/include/alphabet/views/to_rank.hpp
  */
 inline auto const to_rank = deep{std::views::transform([] (auto const in) noexcept
 {

--- a/include/seqan3/range/views/trim_quality.hpp
+++ b/include/seqan3/range/views/trim_quality.hpp
@@ -6,132 +6,14 @@
 // -----------------------------------------------------------------------------------------------------
 
 /*!\file
+ * \brief [DEPRECATED] Provides seqan3::views::trim_quality.
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
- * \brief Provides seqan3::views::trim_quality.
+ * \deprecated This header will be removed in 3.1. Please use seqan3/alphabet/views/trim_quality.hpp instead.
  */
 
 #pragma once
 
-#include <seqan3/std/ranges>
+#include <seqan3/alphabet/views/trim_quality.hpp>
 
-#include <seqan3/alphabet/quality/qualified.hpp>
-#include <seqan3/range/views/take_until.hpp>
-#include <seqan3/utility/views/deep.hpp>
-
-namespace seqan3::detail
-{
-
-/*!\brief The underlying type of seqan3::views::trim_quality.
- * \ingroup views
- *
- * Under the hood, this delegates to std::views::take_while.
- */
-struct trim_fn
-{
-    //!\brief Store the argument and return a range adaptor closure object.
-    template <typename threshold_t>
-    constexpr auto operator()(threshold_t const threshold) const
-    {
-        static_assert(quality_alphabet<threshold_t> || std::integral<threshold_t>,
-                      "The threshold must either be a quality alphabet or an integral type "
-                      "in which case it is compared with the underlying Phred score type.");
-
-        return adaptor_from_functor{*this, threshold};
-    }
-
-    /*!\brief Trim based on minimum Phred score.
-     * \tparam irng_t The type of the range being processed. See seqan3::views::trim_quality for requirements.
-     * \param irange The range being processed.
-     * \param threshold The minimum quality as a Phred score [integral type].
-     */
-    template <std::ranges::input_range irng_t, typename threshold_t>
-    constexpr auto operator()(irng_t && irange, threshold_t const threshold) const
-    {
-        static_assert(quality_alphabet<std::remove_reference_t<std::ranges::range_reference_t<irng_t>>>,
-                      "views::trim_quality can only operate on ranges over seqan3::quality_alphabet.");
-        static_assert(std::same_as<std::remove_cvref_t<threshold_t>,
-                     std::remove_cvref_t<std::ranges::range_reference_t<irng_t>>> ||
-                      std::integral<std::remove_cvref_t<threshold_t>>,
-                      "The threshold must either be a letter of the underlying alphabet or an integral type "
-                      "in which case it is compared with the underlying Phred score type.");
-
-        return views::take_until(std::forward<irng_t>(irange), [threshold] (auto const value)
-        {
-            if constexpr (std::same_as<std::remove_cvref_t<threshold_t>,
-                          std::remove_cvref_t<std::ranges::range_reference_t<irng_t>>>)
-            {
-                return to_phred(value) < to_phred(threshold);
-            }
-            else
-            {
-                using c_t = std::common_type_t<decltype(to_phred(value)), threshold_t>;
-                return static_cast<c_t>(to_phred(value)) < static_cast<c_t>(threshold);
-            }
-        });
-    }
-};
-
-} // namespace seqan3::detail
-
-namespace seqan3::views
-{
-
-/*!\name Alphabet related views
- * \{
- */
-
-/*!\brief               A view that does quality-threshold trimming on a range of seqan3::quality_alphabet.
- * \tparam urng_t       The type of the range being processed. See below for requirements.
- * \tparam threshold_t  Either std::ranges::range_value_t<urng_t> or
- *                      seqan3::alphabet_phred_t<std::ranges::range_value_t<urng_t>>.
- * \param[in] urange    The range being processed. [parameter is omitted in pipe notation]
- * \param[in] threshold The minimum quality.
- * \returns             A trimmed range. See below for the properties of the returned range.
- * \ingroup views
- *
- * \details
- *
- * \header_file{seqan3/range/views/trim_quality.hpp}
- *
- * This view can be used to trim sequences based on quality. Only bases at the end of the sequence not meeting the
- * specified threshold are discarded.
- *
- * ### View properties
- *
- * This view is a **deep view** Given a range-of-range as input (as opposed to just a range), it will apply
- * the transformation on the innermost range (instead of the outermost range).
- *
- * | Concepts and traits              | `urng_t` (underlying range type)      | `rrng_t` (returned range type)         |
- * |----------------------------------|:-------------------------------------:|:--------------------------------------:|
- * | std::ranges::input_range         | *required*                            | *preserved*                            |
- * | std::ranges::forward_range       |                                       | *preserved*                            |
- * | std::ranges::bidirectional_range |                                       | *preserved*                            |
- * | std::ranges::random_access_range |                                       | *preserved*                            |
- * |                                  |                                       |                                        |
- * | std::ranges::view                |                                       | *guaranteed*                           |
- * | std::ranges::sized_range         |                                       | *lost*                                 |
- * | std::ranges::common_range        |                                       | *lost*                                 |
- * | std::ranges::output_range        |                                       | *preserved*                            |
- * | seqan3::const_iterable_range     |                                       | *preserved*                            |
- * |                                  |                                       |                                        |
- * | std::ranges::range_reference_t   | seqan3::quality_alphabet              | std::ranges::range_reference_t<urng_t> |
- *
- * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.
- *
- * ###Example
- *
- * Operating on a range of seqan3::phred42:
- * \include test/snippet/range/views/trim_quality_phred42.cpp
- *
- * Or operating on a range of seqan3::dna5q:
- * \include test/snippet/range/views/trim_quality_dna5q.cpp
- * \hideinitializer
- *
- * \experimentalapi{Experimental since version 3.1.}
- * TODO move to include/alphabet/views/trim_quality.hpp
- */
-inline constexpr auto trim_quality = deep{seqan3::detail::trim_fn{}};
-
-//!\}
-
-} // namespace seqan3::views
+SEQAN3_DEPRECATED_HEADER(
+   "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/alphabet/views/trim_quality.hpp> instead.")

--- a/include/seqan3/range/views/trim_quality.hpp
+++ b/include/seqan3/range/views/trim_quality.hpp
@@ -24,7 +24,7 @@ namespace seqan3::detail
 /*!\brief The underlying type of seqan3::views::trim_quality.
  * \ingroup views
  *
- * Under the hood this delegates to views::take_until.
+ * Under the hood, this delegates to std::views::take_while.
  */
 struct trim_fn
 {
@@ -93,7 +93,8 @@ namespace seqan3::views
  *
  * \header_file{seqan3/range/views/trim_quality.hpp}
  *
- * This view can be used to do easy quality based trimming of sequences.
+ * This view can be used to trim sequences based on quality. Only bases at the end of the sequence not meeting the
+ * specified threshold are discarded.
  *
  * ### View properties
  *
@@ -125,8 +126,10 @@ namespace seqan3::views
  * Or operating on a range of seqan3::dna5q:
  * \include test/snippet/range/views/trim_quality_dna5q.cpp
  * \hideinitializer
+ *
+ * \experimentalapi{Experimental since version 3.1.}
+ * TODO move to include/alphabet/views/trim_quality.hpp
  */
-
 inline constexpr auto trim_quality = deep{seqan3::detail::trim_fn{}};
 
 //!\}

--- a/include/seqan3/search/fm_index/fm_index.hpp
+++ b/include/seqan3/search/fm_index/fm_index.hpp
@@ -18,9 +18,9 @@
 
 #include <sdsl/suffix_trees.hpp>
 
+#include <seqan3/alphabet/views/to_rank.hpp>
 #include <seqan3/core/range/type_traits.hpp>
 #include <seqan3/range/views/join.hpp>
-#include <seqan3/range/views/to_rank.hpp>
 #include <seqan3/range/views/to.hpp>
 #include <seqan3/search/fm_index/concept.hpp>
 #include <seqan3/search/fm_index/detail/fm_index_cursor.hpp>

--- a/test/performance/io/format_vienna_benchmark.cpp
+++ b/test/performance/io/format_vienna_benchmark.cpp
@@ -11,6 +11,7 @@
 #include <benchmark/benchmark.h>
 
 #include <seqan3/alphabet/nucleotide/rna4.hpp>
+#include <seqan3/alphabet/views/to_char.hpp>
 #include <seqan3/core/detail/persist_view.hpp>
 #include <seqan3/io/structure_file/input.hpp>
 #include <seqan3/io/structure_file/output.hpp>
@@ -19,7 +20,6 @@
 #include <seqan3/test/performance/units.hpp>
 #include <seqan3/test/seqan2.hpp>
 #include <seqan3/range/views/to.hpp>
-#include <seqan3/range/views/to_char.hpp>
 
 #if SEQAN3_HAS_SEQAN2
     #include <seqan/rna_io.h>

--- a/test/performance/search/index_construction_benchmark.cpp
+++ b/test/performance/search/index_construction_benchmark.cpp
@@ -9,8 +9,8 @@
 
 #include <seqan3/alphabet/aminoacid/aa27.hpp>
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
+#include <seqan3/alphabet/views/rank_to.hpp>
 #include <seqan3/core/detail/persist_view.hpp>
-#include <seqan3/range/views/rank_to.hpp>
 #include <seqan3/search/fm_index/all.hpp>
 #include <seqan3/test/performance/sequence_generator.hpp>
 #include <seqan3/test/seqan2.hpp>

--- a/test/snippet/alignment/matrix/debug_matrix_trace.cpp
+++ b/test/snippet/alignment/matrix/debug_matrix_trace.cpp
@@ -2,8 +2,8 @@
 
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/alignment/matrix/debug_matrix.hpp>
+#include <seqan3/alphabet/views/to_char.hpp>
 #include <seqan3/core/debug_stream.hpp>
-#include <seqan3/range/views/to_char.hpp>
 
 int main()
 {

--- a/test/snippet/core/debug_stream_usage.cpp
+++ b/test/snippet/core/debug_stream_usage.cpp
@@ -1,8 +1,8 @@
 #include <iostream>
 
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
+#include <seqan3/alphabet/views/to_rank.hpp>
 #include <seqan3/core/debug_stream.hpp>
-#include <seqan3/range/views/to_rank.hpp>
 
 int main()
 {

--- a/test/snippet/core/detail/persist_view.cpp
+++ b/test/snippet/core/detail/persist_view.cpp
@@ -1,6 +1,6 @@
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
+#include <seqan3/alphabet/views/to_char.hpp>
 #include <seqan3/core/detail/persist_view.hpp>
-#include <seqan3/range/views/to_char.hpp>
 
 int main()
 {

--- a/test/snippet/io/structure_file/structure_file_input_filter_criteria.cpp
+++ b/test/snippet/io/structure_file/structure_file_input_filter_criteria.cpp
@@ -1,9 +1,9 @@
+#include <seqan3/std/ranges>
 #include <sstream>
 
+#include <seqan3/alphabet/views/to_char.hpp>
 #include <seqan3/core/debug_stream.hpp>
 #include <seqan3/io/structure_file/input.hpp>
-#include <seqan3/range/views/to_char.hpp>
-#include <seqan3/std/ranges>
 
 auto input = R"(> S.cerevisiae_tRNA-PHE M10740/1-73
 GCGGAUUUAGCUCAGUUGGGAGAGCGCCAGACUGAAGAUUUGGAGGUCCUGUGUUCGAUCCACAGAAUUCGCA

--- a/test/snippet/io/structure_file/structure_file_input_record_iter.cpp
+++ b/test/snippet/io/structure_file/structure_file_input_record_iter.cpp
@@ -1,8 +1,8 @@
 #include <sstream>
 
+#include <seqan3/alphabet/views/to_char.hpp>
 #include <seqan3/core/debug_stream.hpp>
 #include <seqan3/io/structure_file/input.hpp>
-#include <seqan3/range/views/to_char.hpp>
 #include <seqan3/utility/type_list/type_list.hpp>
 
 auto input = R"(> S.cerevisiae_tRNA-PHE M10740/1-73

--- a/test/snippet/io/structure_file/structure_file_input_skip_fields.cpp
+++ b/test/snippet/io/structure_file/structure_file_input_skip_fields.cpp
@@ -1,9 +1,9 @@
 #include <sstream>
 
+#include <seqan3/alphabet/views/to_char.hpp>
 #include <seqan3/core/debug_stream.hpp>
 #include <seqan3/io/structure_file/input.hpp>
 #include <seqan3/range/views/get.hpp>
-#include <seqan3/range/views/to_char.hpp>
 
 auto input = R"(> S.cerevisiae_tRNA-PHE M10740/1-73
 GCGGAUUUAGCUCAGUUGGGAGAGCGCCAGACUGAAGAUUUGGAGGUCCUGUGUUCGAUCCACAGAAUUCGCA

--- a/test/snippet/io/structure_file/structure_file_input_structured_bindings.cpp
+++ b/test/snippet/io/structure_file/structure_file_input_structured_bindings.cpp
@@ -1,8 +1,8 @@
 #include <sstream>
 
+#include <seqan3/alphabet/views/to_char.hpp>
 #include <seqan3/core/debug_stream.hpp>
 #include <seqan3/io/structure_file/input.hpp>
-#include <seqan3/range/views/to_char.hpp>
 #include <seqan3/utility/type_list/type_list.hpp>
 
 auto input = R"(> S.cerevisiae_tRNA-PHE M10740/1-73

--- a/test/snippet/range/views/get.cpp
+++ b/test/snippet/range/views/get.cpp
@@ -3,9 +3,9 @@
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/alphabet/quality/aliases.hpp> // includes seqan3::dna4q
 #include <seqan3/alphabet/quality/phred42.hpp>
+#include <seqan3/alphabet/views/to_char.hpp>
 #include <seqan3/core/debug_stream.hpp>
 #include <seqan3/range/views/get.hpp>
-#include <seqan3/range/views/to_char.hpp>
 
 int main()
 {

--- a/test/snippet/range/views/range_view_to_char.cpp
+++ b/test/snippet/range/views/range_view_to_char.cpp
@@ -3,8 +3,8 @@
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/alphabet/quality/aliases.hpp> // includes seqan3::dna4q
 #include <seqan3/alphabet/quality/phred42.hpp>
+#include <seqan3/alphabet/views/to_char.hpp>
 #include <seqan3/core/debug_stream.hpp>
-#include <seqan3/range/views/to_char.hpp>
 
 int main()
 {

--- a/test/snippet/range/views/range_view_to_rank.cpp
+++ b/test/snippet/range/views/range_view_to_rank.cpp
@@ -3,8 +3,8 @@
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/alphabet/quality/phred42.hpp>
 #include <seqan3/alphabet/quality/aliases.hpp>
+#include <seqan3/alphabet/views/to_rank.hpp>
 #include <seqan3/core/debug_stream.hpp>
-#include <seqan3/range/views/to_rank.hpp>
 
 int main()
 {

--- a/test/snippet/range/views/rank_to.cpp
+++ b/test/snippet/range/views/rank_to.cpp
@@ -2,7 +2,7 @@
 
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
-#include <seqan3/range/views/rank_to.hpp>
+#include <seqan3/alphabet/views/rank_to.hpp>
 
 int main()
 {

--- a/test/snippet/range/views/trim_quality_dna5q.cpp
+++ b/test/snippet/range/views/trim_quality_dna5q.cpp
@@ -5,7 +5,7 @@
 #include <seqan3/alphabet/quality/aliases.hpp>
 #include <seqan3/alphabet/quality/phred42.hpp>
 #include <seqan3/alphabet/views/to_char.hpp>
-#include <seqan3/range/views/trim_quality.hpp>
+#include <seqan3/alphabet/views/trim_quality.hpp>
 
 int main()
 {

--- a/test/snippet/range/views/trim_quality_dna5q.cpp
+++ b/test/snippet/range/views/trim_quality_dna5q.cpp
@@ -4,8 +4,8 @@
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
 #include <seqan3/alphabet/quality/aliases.hpp>
 #include <seqan3/alphabet/quality/phred42.hpp>
+#include <seqan3/alphabet/views/to_char.hpp>
 #include <seqan3/range/views/trim_quality.hpp>
-#include <seqan3/range/views/to_char.hpp>
 
 int main()
 {

--- a/test/snippet/range/views/trim_quality_phred42.cpp
+++ b/test/snippet/range/views/trim_quality_phred42.cpp
@@ -3,7 +3,7 @@
 
 #include <seqan3/alphabet/quality/phred42.hpp>
 #include <seqan3/alphabet/views/to_char.hpp>
-#include <seqan3/range/views/trim_quality.hpp>
+#include <seqan3/alphabet/views/trim_quality.hpp>
 
 using seqan3::operator""_phred42;
 

--- a/test/snippet/range/views/trim_quality_phred42.cpp
+++ b/test/snippet/range/views/trim_quality_phred42.cpp
@@ -2,8 +2,8 @@
 #include <vector>
 
 #include <seqan3/alphabet/quality/phred42.hpp>
+#include <seqan3/alphabet/views/to_char.hpp>
 #include <seqan3/range/views/trim_quality.hpp>
-#include <seqan3/range/views/to_char.hpp>
 
 using seqan3::operator""_phred42;
 

--- a/test/snippet/std/view/subrange.cpp
+++ b/test/snippet/std/view/subrange.cpp
@@ -1,7 +1,8 @@
-#include <seqan3/alphabet/nucleotide/dna4.hpp>
-#include <seqan3/core/debug_stream.hpp>
-#include <seqan3/range/views/to_char.hpp>
 #include <seqan3/std/ranges>
+
+#include <seqan3/alphabet/nucleotide/dna4.hpp>
+#include <seqan3/alphabet/views/to_char.hpp>
+#include <seqan3/core/debug_stream.hpp>
 
 int main()
 {

--- a/test/unit/alignment/matrix/detail/aligned_sequence_builder_test.cpp
+++ b/test/unit/alignment/matrix/detail/aligned_sequence_builder_test.cpp
@@ -17,7 +17,7 @@
 #include <seqan3/alignment/matrix/trace_directions.hpp>
 #include <seqan3/alphabet/nucleotide/dna15.hpp>
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
-#include <seqan3/range/views/to_char.hpp>
+#include <seqan3/alphabet/views/to_char.hpp>
 #include <seqan3/test/expect_range_eq.hpp>
 
 using seqan3::operator|;

--- a/test/unit/alignment/matrix/edit_distance_matrix/trace_matrix_path_iterator_test.cpp
+++ b/test/unit/alignment/matrix/edit_distance_matrix/trace_matrix_path_iterator_test.cpp
@@ -11,7 +11,7 @@
 
 #include <seqan3/alignment/matrix/detail/two_dimensional_matrix_iterator_concept.hpp>
 #include <seqan3/alignment/matrix/edit_distance_trace_matrix_full.hpp>
-#include <seqan3/range/views/to_char.hpp>
+#include <seqan3/alphabet/views/to_char.hpp>
 #include <seqan3/test/expect_range_eq.hpp>
 #include <seqan3/test/pretty_printing.hpp>
 

--- a/test/unit/alignment/pairwise/align_pairwise_test.cpp
+++ b/test/unit/alignment/pairwise/align_pairwise_test.cpp
@@ -18,7 +18,7 @@
 #include <seqan3/alignment/pairwise/align_pairwise.hpp>
 #include <seqan3/alphabet/gap/gapped.hpp>
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
-#include <seqan3/range/views/to_char.hpp>
+#include <seqan3/alphabet/views/to_char.hpp>
 #include <seqan3/test/expect_range_eq.hpp>
 #include <seqan3/test/expect_same_type.hpp>
 #include <seqan3/utility/tuple/concept.hpp>

--- a/test/unit/alignment/pairwise/alignment_result_test.cpp
+++ b/test/unit/alignment/pairwise/alignment_result_test.cpp
@@ -18,10 +18,10 @@
 #include <seqan3/alphabet/gap/gapped.hpp>
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/alphabet/nucleotide/rna5.hpp>
+#include <seqan3/alphabet/views/to_char.hpp>
 #include <seqan3/core/detail/debug_stream_alphabet.hpp>
 #include <seqan3/core/detail/persist_view.hpp>
 #include <seqan3/core/detail/template_inspection.hpp>
-#include <seqan3/range/views/to_char.hpp>
 #include <seqan3/test/expect_range_eq.hpp>
 #include <seqan3/test/expect_same_type.hpp>
 

--- a/test/unit/alignment/pairwise/edit_distance_unbanded_test_template.hpp
+++ b/test/unit/alignment/pairwise/edit_distance_unbanded_test_template.hpp
@@ -11,7 +11,7 @@
 
 #include <seqan3/alignment/configuration/align_config_result_type.hpp>
 #include <seqan3/alignment/pairwise/edit_distance_unbanded.hpp>
-#include <seqan3/range/views/to_char.hpp>
+#include <seqan3/alphabet/views/to_char.hpp>
 #include <seqan3/test/expect_range_eq.hpp>
 
 #include "fixture/alignment_fixture.hpp"

--- a/test/unit/alignment/pairwise/pairwise_alignment_collection_callback_test_template.hpp
+++ b/test/unit/alignment/pairwise/pairwise_alignment_collection_callback_test_template.hpp
@@ -13,7 +13,7 @@
 #include <seqan3/std/ranges>
 
 #include <seqan3/alignment/pairwise/align_pairwise.hpp>
-#include <seqan3/range/views/to_char.hpp>
+#include <seqan3/alphabet/views/to_char.hpp>
 #include <seqan3/test/expect_range_eq.hpp>
 #include <seqan3/utility/views/zip.hpp>
 

--- a/test/unit/alignment/pairwise/pairwise_alignment_collection_test_template.hpp
+++ b/test/unit/alignment/pairwise/pairwise_alignment_collection_test_template.hpp
@@ -13,7 +13,7 @@
 #include <seqan3/std/ranges>
 
 #include <seqan3/alignment/pairwise/align_pairwise.hpp>
-#include <seqan3/range/views/to_char.hpp>
+#include <seqan3/alphabet/views/to_char.hpp>
 #include <seqan3/range/views/to.hpp>
 #include <seqan3/test/expect_range_eq.hpp>
 #include <seqan3/utility/views/zip.hpp>

--- a/test/unit/alignment/pairwise/pairwise_alignment_single_callback_test_template.hpp
+++ b/test/unit/alignment/pairwise/pairwise_alignment_single_callback_test_template.hpp
@@ -11,7 +11,7 @@
 
 #include <seqan3/alignment/configuration/align_config_score_type.hpp>
 #include <seqan3/alignment/pairwise/align_pairwise.hpp>
-#include <seqan3/range/views/to_char.hpp>
+#include <seqan3/alphabet/views/to_char.hpp>
 #include <seqan3/test/expect_range_eq.hpp>
 #include <seqan3/test/expect_same_type.hpp>
 

--- a/test/unit/alignment/pairwise/pairwise_alignment_single_test_template.hpp
+++ b/test/unit/alignment/pairwise/pairwise_alignment_single_test_template.hpp
@@ -11,7 +11,7 @@
 
 #include <seqan3/alignment/configuration/align_config_score_type.hpp>
 #include <seqan3/alignment/pairwise/align_pairwise.hpp>
-#include <seqan3/range/views/to_char.hpp>
+#include <seqan3/alphabet/views/to_char.hpp>
 #include <seqan3/test/expect_range_eq.hpp>
 #include <seqan3/test/expect_same_type.hpp>
 

--- a/test/unit/range/decorator/gap_decorator_test.cpp
+++ b/test/unit/range/decorator/gap_decorator_test.cpp
@@ -14,9 +14,9 @@
 
 #include <seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp>
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
+#include <seqan3/alphabet/views/to_char.hpp>
 #include <seqan3/range/decorator/gap_decorator.hpp>
 #include <seqan3/range/views/enforce_random_access.hpp>
-#include <seqan3/range/views/to_char.hpp>
 
 #include "../iterator_test_template.hpp"
 #include "../../alignment/aligned_sequence_test_template.hpp"

--- a/test/unit/range/views/enforce_random_access_test.cpp
+++ b/test/unit/range/views/enforce_random_access_test.cpp
@@ -7,12 +7,12 @@
 
 #include <gtest/gtest.h>
 
-#include <vector>
-
-#include <seqan3/range/views/enforce_random_access.hpp>
-#include <seqan3/range/views/to_char.hpp>
 #include <seqan3/std/algorithm>
 #include <seqan3/std/ranges>
+#include <vector>
+
+#include <seqan3/alphabet/views/to_char.hpp>
+#include <seqan3/range/views/enforce_random_access.hpp>
 #include <seqan3/test/expect_range_eq.hpp>
 
 #include "../iterator_test_template.hpp"

--- a/test/unit/range/views/get_test.cpp
+++ b/test/unit/range/views/get_test.cpp
@@ -14,11 +14,11 @@
 
 #include <seqan3/alphabet/mask/masked.hpp>
 #include <seqan3/alphabet/quality/aliases.hpp>
+#include <seqan3/alphabet/views/to_char.hpp>
 #include <seqan3/core/detail/debug_stream_alphabet.hpp>
 #include <seqan3/range/concept.hpp>
 #include <seqan3/range/views/get.hpp>
 #include <seqan3/range/views/complement.hpp>
-#include <seqan3/range/views/to_char.hpp>
 #include <seqan3/test/expect_range_eq.hpp>
 #include <seqan3/utility/views/zip.hpp>
 

--- a/test/unit/range/views/rank_to_test.cpp
+++ b/test/unit/range/views/rank_to_test.cpp
@@ -10,8 +10,8 @@
 #include <seqan3/std/ranges>
 
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
+#include <seqan3/alphabet/views/rank_to.hpp>
 #include <seqan3/core/detail/debug_stream_alphabet.hpp>
-#include <seqan3/range/views/rank_to.hpp>
 #include <seqan3/range/concept.hpp>
 #include <seqan3/test/expect_range_eq.hpp>
 

--- a/test/unit/range/views/to_char_test.cpp
+++ b/test/unit/range/views/to_char_test.cpp
@@ -10,8 +10,8 @@
 #include <seqan3/std/ranges>
 
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
+#include <seqan3/alphabet/views/to_char.hpp>
 #include <seqan3/range/concept.hpp>
-#include <seqan3/range/views/to_char.hpp>
 #include <seqan3/test/expect_range_eq.hpp>
 
 using seqan3::operator""_dna5;

--- a/test/unit/range/views/to_lower_test.cpp
+++ b/test/unit/range/views/to_lower_test.cpp
@@ -10,8 +10,8 @@
 #include <seqan3/std/ranges>
 
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
+#include <seqan3/alphabet/views/to_char.hpp>
 #include <seqan3/core/detail/debug_stream_alphabet.hpp>
-#include <seqan3/range/views/to_char.hpp>
 #include <seqan3/range/views/to_lower.hpp>
 #include <seqan3/test/expect_range_eq.hpp>
 

--- a/test/unit/range/views/to_rank_test.cpp
+++ b/test/unit/range/views/to_rank_test.cpp
@@ -10,8 +10,8 @@
 #include <seqan3/std/ranges>
 
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
+#include <seqan3/alphabet/views/to_rank.hpp>
 #include <seqan3/range/concept.hpp>
-#include <seqan3/range/views/to_rank.hpp>
 #include <seqan3/test/expect_range_eq.hpp>
 
 using seqan3::operator""_dna5;

--- a/test/unit/range/views/to_upper_test.cpp
+++ b/test/unit/range/views/to_upper_test.cpp
@@ -10,8 +10,8 @@
 #include <seqan3/std/ranges>
 
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
+#include <seqan3/alphabet/views/to_char.hpp>
 #include <seqan3/core/detail/debug_stream_alphabet.hpp>
-#include <seqan3/range/views/to_char.hpp>
 #include <seqan3/range/views/to_upper.hpp>
 #include <seqan3/test/expect_range_eq.hpp>
 

--- a/test/unit/range/views/trim_quality_test.cpp
+++ b/test/unit/range/views/trim_quality_test.cpp
@@ -10,9 +10,9 @@
 #include <seqan3/std/ranges>
 
 #include <seqan3/alphabet/quality/aliases.hpp>
+#include <seqan3/alphabet/views/to_char.hpp>
 #include <seqan3/core/detail/debug_stream_alphabet.hpp>
 #include <seqan3/range/concept.hpp>
-#include <seqan3/range/views/to_char.hpp>
 #include <seqan3/range/views/trim_quality.hpp>
 #include <seqan3/test/expect_range_eq.hpp>
 

--- a/test/unit/range/views/trim_quality_test.cpp
+++ b/test/unit/range/views/trim_quality_test.cpp
@@ -11,9 +11,9 @@
 
 #include <seqan3/alphabet/quality/aliases.hpp>
 #include <seqan3/alphabet/views/to_char.hpp>
+#include <seqan3/alphabet/views/trim_quality.hpp>
 #include <seqan3/core/detail/debug_stream_alphabet.hpp>
 #include <seqan3/range/concept.hpp>
-#include <seqan3/range/views/trim_quality.hpp>
 #include <seqan3/test/expect_range_eq.hpp>
 
 using seqan3::operator""_dna5;


### PR DESCRIPTION
First part of Resolving
 https://github.com/seqan/product_backlog/issues/337 and
 https://github.com/seqan/product_backlog/issues/338 and
 https://github.com/seqan/product_backlog/issues/339 and
 https://github.com/seqan/product_backlog/issues/340 and
 https://github.com/seqan/product_backlog/issues/341 and
 https://github.com/seqan/product_backlog/issues/342.

This PR applys the patches and moves the headers (snippets & test coming in third part pr)
- Move seqan::views::to_char to seqan3/alphabet/views/
- Move seqan::views::rank_to to seqan3/alphabet/views/
- Move seqan::views::to_rank to seqan3/alphabet/views/
- Move seqan::views::trim_quality to seqan3/alphabet/views/