### PR TITLE
[MISC] Rename gap_decorator::unaligned_seq_type to gap_decorator::unaligned_sequence_type.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -218,6 +218,8 @@ regression test suite and patches at https://github.com/seqan/seqan3/tree/master
    ([\#2556](https://github.com/seqan/seqan3/pull/2556))
 * Deprecated `seqan3::views::persist`. There is no replacement, use lvalues instead of rvalues
   ([\#2553](https://github.com/seqan/seqan3/pull/2553)).
+* We renamed `seqan3::gap_decorator::unaligned_seq_type` to `seqan3::gap_decorator::unaligned_sequence_type`.
+  ([\#2564](https://github.com/seqan/seqan3/pull/2564))
 
 #### Search
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -218,8 +218,8 @@ regression test suite and patches at https://github.com/seqan/seqan3/tree/master
    ([\#2556](https://github.com/seqan/seqan3/pull/2556))
 * Deprecated `seqan3::views::persist`. There is no replacement, use lvalues instead of rvalues
   ([\#2553](https://github.com/seqan/seqan3/pull/2553)).
-* We renamed `seqan3::gap_decorator::unaligned_seq_type` to `seqan3::gap_decorator::unaligned_sequence_type`.
-  ([\#2564](https://github.com/seqan/seqan3/pull/2564))
+* Renamed `seqan3::gap_decorator::unaligned_seq_type` to `seqan3::gap_decorator::unaligned_sequence_type`
+  ([\#2564](https://github.com/seqan/seqan3/pull/2564)).
 
 #### Search
 

--- a/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
+++ b/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
@@ -54,7 +54,7 @@ struct unaligned_seq
 //!\brief Exposes the unaligned sequence type given an aligned sequence container type.
 template <typename t>
 //!\cond
-    requires (!requires { typename std::remove_reference_t<t>::unaligned_seq_type; }) &&
+    requires (!requires { typename std::remove_reference_t<t>::unaligned_sequence_type; }) &&
               requires { remove_gap_from_value_type(std::declval<t>()); }
 //!\endcond
 struct unaligned_seq<t>
@@ -64,14 +64,14 @@ struct unaligned_seq<t>
 };
 
 // customisation point for our gap decorators.
-//!\brief Exposes the unaligned sequence type if *t* exposes the type member `unaligned_seq_type`.
+//!\brief Exposes the unaligned sequence type if *t* exposes the type member `unaligned_sequence_type`.
 template <typename t>
 //!\cond
-    requires requires { typename std::remove_reference_t<t>::unaligned_seq_type; }
+    requires requires { typename std::remove_reference_t<t>::unaligned_sequence_type; }
 //!\endcond
 struct unaligned_seq<t>
 {
-    using type = typename std::remove_reference_t<t>::unaligned_seq_type; //!< The unaligned sequence type of t
+    using type = typename std::remove_reference_t<t>::unaligned_sequence_type; //!< The unaligned sequence type of t
 };
 
 //!\brief Helper type that delegates to seqan3::detail::unaligned_seq::type.

--- a/include/seqan3/range/decorator/gap_decorator.hpp
+++ b/include/seqan3/range/decorator/gap_decorator.hpp
@@ -331,11 +331,11 @@ public:
      *
      * \experimentalapi{Experimental since version 3.1.}
      */
-    template <typename unaligned_seq_t> // generic template to use forwarding reference
+    template <typename unaligned_sequence_t> // generic template to use forwarding reference
     //!\cond
-        requires std::assignable_from<gap_decorator &, unaligned_seq_t>
+        requires std::assignable_from<gap_decorator &, unaligned_sequence_t>
     //!\endcond
-    friend void assign_unaligned(gap_decorator & dec, unaligned_seq_t && unaligned)
+    friend void assign_unaligned(gap_decorator & dec, unaligned_sequence_t && unaligned)
     {
         dec = unaligned;
     }

--- a/include/seqan3/range/decorator/gap_decorator.hpp
+++ b/include/seqan3/range/decorator/gap_decorator.hpp
@@ -321,7 +321,7 @@ public:
         return iterator{*this, pos1};
     }
 
-    /*!\brief Assigns a new sequence of type seqan3::gap_decorator::unaligned_seq_type to the decorator.
+    /*!\brief Assigns a new sequence of type seqan3::gap_decorator::unaligned_sequence_type to the decorator.
      * \param[in,out] dec       The decorator to modify.
      * \param[in]     unaligned The unaligned sequence to assign.
      * \details

--- a/include/seqan3/range/decorator/gap_decorator.hpp
+++ b/include/seqan3/range/decorator/gap_decorator.hpp
@@ -139,6 +139,9 @@ public:
      */
     using unaligned_sequence_type = inner_type;
 
+    //!\deprecated Please use seqan3::gap_decorator::unaligned_sequence_type instead.   
+    using unaligned_seq_type SEQAN3_DEPRECATED_310 = unaligned_sequence_type;
+
     /*!\name Constructors, destructor and assignment
      * \{
      */

--- a/include/seqan3/range/decorator/gap_decorator.hpp
+++ b/include/seqan3/range/decorator/gap_decorator.hpp
@@ -137,7 +137,7 @@ public:
      *
      * \stableapi{Since version 3.1.}
      */
-    using unaligned_seq_type = inner_type;
+    using unaligned_sequence_type = inner_type;
 
     /*!\name Constructors, destructor and assignment
      * \{

--- a/test/unit/alignment/aligned_sequence_test_template.hpp
+++ b/test/unit/alignment/aligned_sequence_test_template.hpp
@@ -36,16 +36,16 @@ TYPED_TEST_P(aligned_sequence, fulfills_concept)
 
 TYPED_TEST_P(aligned_sequence, assign_unaligned_sequence)
 {
-    using unaligned_seq_type = std::remove_cvref_t<seqan3::detail::unaligned_seq_t<TypeParam>>;
-    unaligned_seq_type unaligned_seq{};
+    using unaligned_sequence_type = std::remove_cvref_t<seqan3::detail::unaligned_seq_t<TypeParam>>;
+    unaligned_sequence_type unaligned_seq{};
 
-    if constexpr (seqan3::sequence_container<unaligned_seq_type>)
+    if constexpr (seqan3::sequence_container<unaligned_sequence_type>)
     {
         unaligned_seq.resize(seq.size());
         std::copy(seq.begin(), seq.end(), std::ranges::begin(unaligned_seq));
     }
     else // type is view, happens for gap_decorator tests
-        unaligned_seq = unaligned_seq_type{seq};
+        unaligned_seq = unaligned_sequence_type{seq};
 
     TypeParam aligned_seq{};
 
@@ -57,8 +57,8 @@ TYPED_TEST_P(aligned_sequence, assign_unaligned_sequence)
 
 TYPED_TEST_P(aligned_sequence, assign_empty_unaligned_sequence)
 {
-    using unaligned_seq_type = std::remove_cvref_t<seqan3::detail::unaligned_seq_t<TypeParam>>;
-    unaligned_seq_type unaligned_seq{};
+    using unaligned_sequence_type = std::remove_cvref_t<seqan3::detail::unaligned_seq_t<TypeParam>>;
+    unaligned_sequence_type unaligned_seq{};
     TypeParam aligned_seq{};
 
     assign_unaligned(aligned_seq, unaligned_seq);
@@ -221,8 +221,8 @@ TYPED_TEST_P(aligned_sequence, erase_multiple_gaps)
 
 TYPED_TEST_P(aligned_sequence, insert_erase_on_empty_sequence)
 {
-    using unaligned_seq_type = std::remove_cvref_t<seqan3::detail::unaligned_seq_t<TypeParam>>;
-    unaligned_seq_type unaligned{};
+    using unaligned_sequence_type = std::remove_cvref_t<seqan3::detail::unaligned_seq_t<TypeParam>>;
+    unaligned_sequence_type unaligned{};
     TypeParam aligned_seq{};
 
     assign_unaligned(aligned_seq, unaligned);

--- a/test/unit/alignment/aligned_sequence_test_template.hpp
+++ b/test/unit/alignment/aligned_sequence_test_template.hpp
@@ -36,16 +36,16 @@ TYPED_TEST_P(aligned_sequence, fulfills_concept)
 
 TYPED_TEST_P(aligned_sequence, assign_unaligned_sequence)
 {
-    using unaligned_sequence_type = std::remove_cvref_t<seqan3::detail::unaligned_seq_t<TypeParam>>;
-    unaligned_sequence_type unaligned_seq{};
+    using unaligned_seq_type = std::remove_cvref_t<seqan3::detail::unaligned_seq_t<TypeParam>>;
+    unaligned_seq_type unaligned_seq{};
 
-    if constexpr (seqan3::sequence_container<unaligned_sequence_type>)
+    if constexpr (seqan3::sequence_container<unaligned_seq_type>)
     {
         unaligned_seq.resize(seq.size());
         std::copy(seq.begin(), seq.end(), std::ranges::begin(unaligned_seq));
     }
     else // type is view, happens for gap_decorator tests
-        unaligned_seq = unaligned_sequence_type{seq};
+        unaligned_seq = unaligned_seq_type{seq};
 
     TypeParam aligned_seq{};
 
@@ -57,8 +57,8 @@ TYPED_TEST_P(aligned_sequence, assign_unaligned_sequence)
 
 TYPED_TEST_P(aligned_sequence, assign_empty_unaligned_sequence)
 {
-    using unaligned_sequence_type = std::remove_cvref_t<seqan3::detail::unaligned_seq_t<TypeParam>>;
-    unaligned_sequence_type unaligned_seq{};
+    using unaligned_seq_type = std::remove_cvref_t<seqan3::detail::unaligned_seq_t<TypeParam>>;
+    unaligned_seq_type unaligned_seq{};
     TypeParam aligned_seq{};
 
     assign_unaligned(aligned_seq, unaligned_seq);
@@ -221,8 +221,8 @@ TYPED_TEST_P(aligned_sequence, erase_multiple_gaps)
 
 TYPED_TEST_P(aligned_sequence, insert_erase_on_empty_sequence)
 {
-    using unaligned_sequence_type = std::remove_cvref_t<seqan3::detail::unaligned_seq_t<TypeParam>>;
-    unaligned_sequence_type unaligned{};
+    using unaligned_seq_type = std::remove_cvref_t<seqan3::detail::unaligned_seq_t<TypeParam>>;
+    unaligned_seq_type unaligned{};
     TypeParam aligned_seq{};
 
     assign_unaligned(aligned_seq, unaligned);


### PR DESCRIPTION
Resolves: https://github.com/seqan/product_backlog/issues/322 