### PR TITLE
[FIX] gcc11: missing include

### DIFF
--- a/include/seqan3/alignment/configuration/align_config_band.hpp
+++ b/include/seqan3/alignment/configuration/align_config_band.hpp
@@ -13,6 +13,8 @@
 
 #pragma once
 
+#include <limits>
+
 #include <seqan3/alignment/configuration/detail.hpp>
 #include <seqan3/alignment/exception.hpp>
 #include <seqan3/core/algorithm/pipeable_config_element.hpp>


### PR DESCRIPTION
```
[ 50%] Building CXX object CMakeFiles/align_cfg_band_example_snippet.dir/alignment/configuration/align_cfg_band_example.cpp.o
In file included from src/test/snippet/alignment/configuration/align_cfg_band_example.cpp:1:
src/include/seqan3/alignment/configuration/align_config_band.hpp:75:58: error: incomplete type ‘std::numeric_limits<int>’ used in nested name specifier
   75 |     int32_t lower_diagonal{std::numeric_limits<int32_t>::lowest()};
      |                                                          ^~~~~~
src/include/seqan3/alignment/configuration/align_config_band.hpp:75:66: error: cannot convert ‘<brace-enclosed initializer list>’ to ‘int32_t’ {aka ‘int’} in initialization
   75 |     int32_t lower_diagonal{std::numeric_limits<int32_t>::lowest()};
      |                                                                  ^
src/include/seqan3/alignment/configuration/align_config_band.hpp:77:58: error: incomplete type ‘std::numeric_limits<int>’ used in nested name specifier
   77 |     int32_t upper_diagonal{std::numeric_limits<int32_t>::max()};
      |                                                          ^~~
src/include/seqan3/alignment/configuration/align_config_band.hpp:77:63: error: cannot convert ‘<brace-enclosed initializer list>’ to ‘int32_t’ {aka ‘int’} in initialization
   77 |     int32_t upper_diagonal{std::numeric_limits<int32_t>::max()};
      |                                                               ^
```