### PR TITLE
[DOC] Escape quote in HTML table

### DIFF
--- a/include/seqan3/utility/char_operations/predicate.hpp
+++ b/include/seqan3/utility/char_operations/predicate.hpp
@@ -572,7 +572,7 @@ inline auto constexpr is_xdigit = is_in_interval<'0', '9'> ||
  *</td>
  *<td style="border: 1px solid black"> <code>\41</code>–<code>\57</code>
  *</td>
- *<td style="border: 1px solid black"> <code>!"#$%&amp;'()*+,-./</code>
+ *<td style="border: 1px solid black"> <code>!\"#$%&amp;'()*+,-./</code>
  *</td>
  *<td style="background:#ff9090; color:black; vertical-align: middle; text-align: center; border: 1px solid black;" class="table-no"> <b><code>0</code></b>
  *</td>


### PR DESCRIPTION
```
src/include/seqan3/utility/char_operations/predicate.hpp:577: warning: explicit link request to 'ff9090' could not be resolved
```

https://cdash.seqan.de/testDetails.php?test=43188671&build=146060