### PR TITLE
[DOC] Added more documentation for the mask submodule

### DIFF
--- a/include/seqan3/alphabet/mask/all.hpp
+++ b/include/seqan3/alphabet/mask/all.hpp
@@ -24,20 +24,24 @@
  *
  * ### Introduction
  *
- * Masks are useful as tuple composites when one wants to create a masked alphabet with don't care positions, but does
- * not want to use the seqan3::dna15 **N** or seqan3::aa27 **X** because of loss of information. It will instead mark
- * the specified characters as masked, and display them as lowercase representations when printed.\n
+ * Masks are useful in cases where an alphabet needs to be augmented with additional information.
+ * A common use case is the introduction of don't-care positions (*masking*) in \link nucleotide nucleotide \endlink or
+ * \link aminoacid aminoacid \endlink sequences without using ``'N'`` or ``'X'``, respectively.
+ * Instead, the original alphabet is combined with seqan3::mask to create a seqan3::masked composite.
+ * When printed via the seqan3::debug_stream, masked characters are displayed in lowercase.
  *
- * There are two types of masking: "hard-masking" which converts to the UNKNOWN character and "soft-masking", which is
- * visualised by using lower-case instead of upper-case.
+ * \include test/snippet/alphabet/mask/masked.cpp
  *
- * These usage of lower case letters is a convention popularised by ([RepeatMasker](http://www.repeatmasker.org/)) (last
- * access 03.05.2021), where interspersed repeats (which covers transposons, retrotransposons and processed pseudogenes)
- * and low complexity sequences are marked with lower case letters. Note that larger repeats, such as segmental
- * duplications, large tandem repeats and whole gene duplications are generally not masked.
+ * ### Types of masking
  *
- * However because regular nucleotide and aminoacid alphabets discard case on assignment, one needs to create additional
- * alphabets to preserve this information (if desired).\n
- * This alphabet in itself is not useful to users directly, but instead the composite seqan3::masked may be used to
- * transform another alphabet into a new alphabet that can represent the original alphabet plus masking information.
+ * There are two types of masking:
+ *  * **hard-masking**, which converts masked characters to the ambiguous/unknown character (``'N'`` or ``'X'``)
+ *  * **soft-masking**, which uses lowercase for masked characters
+ *
+ * ### Repeat masking
+ *
+ * The use of soft-masking was popularised by [RepeatMasker](https://www.repeatmasker.org/).
+ * Interspersed repeats (transposons, retrotransposons and processed pseudogenes) and low complexity sequences are
+ * denoted by lowercase characters. Note that larger repeats, such as segmental duplications, large tandem repeats and
+ * whole gene duplications are generally not masked.
  */

--- a/include/seqan3/alphabet/mask/all.hpp
+++ b/include/seqan3/alphabet/mask/all.hpp
@@ -6,8 +6,9 @@
 // -----------------------------------------------------------------------------------------------------
 
 /*!\file
- * \author Joshua Kim <joshua.kim AT fu-berlin.de>
  * \brief Meta-header for the mask submodule; includes all headers from alphabet/mask/.
+ * \author Joshua Kim <joshua.kim AT fu-berlin.de>
+ * \author Lydia Buntrock <lydia.buntrock AT fu-berlin.de>
  */
 
 #pragma once
@@ -23,14 +24,20 @@
  *
  * ### Introduction
  *
- * Masks are useful as tuple composites when one wants to create a masked alphabet with
- * don't care positions, but does not want to use the seqan3::dna15 **N** or
- * seqan3::aa27 **X** because of loss of information. It will instead mark the specified characters as masked,
- * and display them as lowercase representations when printed.\n
- * There are two types of masking: "hard-masking" which converts to the UNKNOWN character and
- * "soft-masking", which is visualised by using lower-case instead of upper-case.
- * However because regular nucleotide and aminoacid alphabets discard case on assignment,
- * one needs to create additional alphabets to preserve this information (if desired).\n
+ * Masks are useful as tuple composites when one wants to create a masked alphabet with don't care positions, but does
+ * not want to use the seqan3::dna15 **N** or seqan3::aa27 **X** because of loss of information. It will instead mark
+ * the specified characters as masked, and display them as lowercase representations when printed.\n
+ *
+ * There are two types of masking: "hard-masking" which converts to the UNKNOWN character and "soft-masking", which is
+ * visualised by using lower-case instead of upper-case.
+ *
+ * These usage of lower case letters is a convention popularised by ([RepeatMasker](http://www.repeatmasker.org/)) (last
+ * access 03.05.2021), where interspersed repeats (which covers transposons, retrotransposons and processed pseudogenes)
+ * and low complexity sequences are marked with lower case letters. Note that larger repeats, such as segmental
+ * duplications, large tandem repeats and whole gene duplications are generally not masked.
+ *
+ * However because regular nucleotide and aminoacid alphabets discard case on assignment, one needs to create additional
+ * alphabets to preserve this information (if desired).\n
  * This alphabet in itself is not useful to users directly, but instead the composite seqan3::masked may be used to
  * transform another alphabet into a new alphabet that can represent the original alphabet plus masking information.
  */

--- a/include/seqan3/alphabet/mask/mask.hpp
+++ b/include/seqan3/alphabet/mask/mask.hpp
@@ -18,10 +18,9 @@
 namespace seqan3
 {
 /*!\brief Implementation of a masked alphabet to be used for tuple composites.
+ * \ingroup mask
  * \implements seqan3::writable_semialphabet
  * \if DEV \implements seqan3::detail::writable_constexpr_alphabet \endif
- *
- * \ingroup mask
  *
  * \details
  *
@@ -29,7 +28,7 @@ namespace seqan3
  *
  * \include test/snippet/alphabet/mask/mask.cpp
  *
- * \see \link mask Mask submodule \endlink, it contains an explanation of hard-masking (UNKNOWN character) and
+ * \see \link mask Mask submodule \endlink, it contains an explanation of hard-masking (unknown character) and
  *      soft-masking (lower/upper case letters).
  *
  * \stableapi{Since version 3.1.}

--- a/include/seqan3/alphabet/mask/mask.hpp
+++ b/include/seqan3/alphabet/mask/mask.hpp
@@ -6,8 +6,8 @@
 // -----------------------------------------------------------------------------------------------------
 
 /*!\file
- * \author Joshua Kim <joshua.kim AT fu-berlin.de>
  * \brief Create a mask composite which can be applied with another alphabet.
+ * \author Joshua Kim <joshua.kim AT fu-berlin.de>
  */
 
 #pragma once
@@ -18,15 +18,19 @@
 namespace seqan3
 {
 /*!\brief Implementation of a masked alphabet to be used for tuple composites.
- * \ingroup mask
  * \implements seqan3::writable_semialphabet
  * \if DEV \implements seqan3::detail::writable_constexpr_alphabet \endif
  *
+ * \ingroup mask
+ *
  * \details
+ *
  * This alphabet is not usually used directly, but instead via seqan3::masked.
- * For more information see the \link mask Mask submodule \endlink.
  *
  * \include test/snippet/alphabet/mask/mask.cpp
+ *
+ * \see \link mask Mask submodule \endlink, it contains an explanation of hard-masking (UNKNOWN character) and
+ *      soft-masking (lower/upper case letters).
  *
  * \stableapi{Since version 3.1.}
  */

--- a/include/seqan3/alphabet/mask/masked.hpp
+++ b/include/seqan3/alphabet/mask/masked.hpp
@@ -6,8 +6,8 @@
 // -----------------------------------------------------------------------------------------------------
 
 /*!\file
- * \author Joshua Kim <joshua.kim AT fu-berlin.de>
  * \brief Extends a given alphabet with the mask alphabet.
+ * \author Joshua Kim <joshua.kim AT fu-berlin.de>
  */
 
 #pragma once
@@ -19,20 +19,24 @@
 
 namespace seqan3
 {
-/*!\brief Implementation of a masked composite, which extends a given alphabet
- * with a mask.
- * \ingroup mask
+/*!\brief Implementation of a masked composite, which extends a given alphabet with a mask.
  * \implements seqan3::writable_alphabet
  * \if DEV \implements seqan3::detail::writable_constexpr_alphabet \endif
  *
  * \tparam sequence_alphabet_t Type of the first letter; must satisfy seqan3::writable_alphabet and std::regular.
  *
+ * \ingroup mask
+ *
  * \details
- * The masked composite represents a seqan3::alphabet_tuple_base of any given alphabet with the
- * masked alphabet. It allows one to specify which portions of a sequence should be masked,
- * without losing additional information by replacing the sequence directly.
+ *
+ * The masked composite represents a seqan3::alphabet_tuple_base of any given alphabet with the masked alphabet. It
+ * allows one to specify which portions of a sequence should be masked, without losing additional information by
+ * replacing the sequence directly.
  *
  * \include test/snippet/alphabet/mask/masked.cpp
+ *
+ * \see \link mask Mask submodule \endlink, it contains an explanation of hard-masking (UNKNOWN character) and
+ *      soft-masking (lower/upper case letters).
  *
  * \stableapi{Since version 3.1.}
  */

--- a/include/seqan3/alphabet/mask/masked.hpp
+++ b/include/seqan3/alphabet/mask/masked.hpp
@@ -20,12 +20,11 @@
 namespace seqan3
 {
 /*!\brief Implementation of a masked composite, which extends a given alphabet with a mask.
+ * \ingroup mask
  * \implements seqan3::writable_alphabet
  * \if DEV \implements seqan3::detail::writable_constexpr_alphabet \endif
  *
  * \tparam sequence_alphabet_t Type of the first letter; must satisfy seqan3::writable_alphabet and std::regular.
- *
- * \ingroup mask
  *
  * \details
  *


### PR DESCRIPTION
Resolves https://github.com/seqan/product_backlog/issues/313

Since there was already documentation, I just expanded it a bit and created links. I hope this corresponds to the desired result.

The new documentation looks like:

![Bildschirmfoto 2021-05-03 um 16 34 32](https://user-images.githubusercontent.com/5746285/116890812-4faad180-ac2e-11eb-94ef-14b7764a1c89.png)
![Bildschirmfoto 2021-05-03 um 16 34 59](https://user-images.githubusercontent.com/5746285/116890815-50dbfe80-ac2e-11eb-8ac0-ef9353770306.png)
![Bildschirmfoto 2021-05-03 um 16 35 52](https://user-images.githubusercontent.com/5746285/116890824-52a5c200-ac2e-11eb-86ea-019cbfb0f795.png)