### PR TITLE
[MISC] Lower case seqan3::mask::(UN)MASKED

### DIFF
--- a/include/seqan3/alphabet/mask/mask.hpp
+++ b/include/seqan3/alphabet/mask/mask.hpp
@@ -20,16 +20,15 @@ namespace seqan3
 /*!\brief Implementation of a masked alphabet to be used for tuple composites.
  * \ingroup mask
  * \implements seqan3::writable_semialphabet
- * \if DEV \implements seqan3::detail::Constexprwritable_semialphabet \endif
- * \implements seqan3::trivially_copyable
- * \implements seqan3::standard_layout
- * \implements std::regular
+ * \if DEV \implements seqan3::detail::writable_constexpr_alphabet \endif
  *
  * \details
  * This alphabet is not usually used directly, but instead via seqan3::masked.
  * For more information see the \link mask Mask submodule \endlink.
  *
  * \include test/snippet/alphabet/mask/mask.cpp
+ *
+ * \stableapi{Since version 3.1.}
  */
 class mask : public alphabet_base<mask, 2, void>
 {
@@ -58,11 +57,34 @@ public:
      * \details Similar to an Enum interface.
      */
     //!\{
-    static const mask UNMASKED; //!< Member for UNMASKED.
-    static const mask MASKED;   //!< Member for MASKED.
+    /*!\brief Member for unmasked.
+     * \details
+     * \deprecated Please use seqan3::mask::unmasked
+     */
+    SEQAN3_DEPRECATED_310 static const mask UNMASKED;
+
+    /*!\brief Member for masked.
+     * \details
+     * \deprecated Please use seqan3::mask::masked
+     */
+    SEQAN3_DEPRECATED_310 static const mask MASKED;
+
+    /*!\brief Member for unmasked.
+     * \details
+     * \stableapi{Since version 3.1.}
+     */
+    static const mask unmasked;
+
+    /*!\brief Member for masked.
+     * \details
+     * \stableapi{Since version 3.1.}
+     */
+    static const mask masked;
     //!\}
 };
 
 mask constexpr mask::UNMASKED{mask{}.assign_rank(0)};
-mask constexpr mask::MASKED  {mask{}.assign_rank(1)};
+mask constexpr mask::MASKED{mask{}.assign_rank(1)};
+mask constexpr mask::unmasked{mask{}.assign_rank(0)};
+mask constexpr mask::masked{mask{}.assign_rank(1)};
 } // namespace seqan3

--- a/include/seqan3/core/detail/debug_stream_alphabet.hpp
+++ b/include/seqan3/core/detail/debug_stream_alphabet.hpp
@@ -45,7 +45,7 @@ inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, alp
 template <typename char_t>
 inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, mask const l)
 {
-    return s << (l == mask::MASKED ? "MASKED" : "UNMASKED");
+    return s << (l == mask::masked ? "MASKED" : "UNMASKED");
 }
 
 //!\}

--- a/test/snippet/alphabet/mask/mask.cpp
+++ b/test/snippet/alphabet/mask/mask.cpp
@@ -3,11 +3,11 @@
 
 int main()
 {
-    seqan3::mask my_mask = seqan3::mask::MASKED;
+    seqan3::mask my_mask = seqan3::mask::masked;
     seqan3::mask another_mask{};
 
-    my_mask.assign_rank(false);  // will assign my_mask the value mask::UNMASKED
-    another_mask.assign_rank(0); // will also assign another_mask the value mask::UNMASKED
+    my_mask.assign_rank(false);  // will assign my_mask the value mask::unmasked
+    another_mask.assign_rank(0); // will also assign another_mask the value mask::unmasked
 
     if (my_mask.to_rank() == another_mask.to_rank())
         seqan3::debug_stream << "Both are UNMASKED!\n";

--- a/test/snippet/alphabet/mask/masked.cpp
+++ b/test/snippet/alphabet/mask/masked.cpp
@@ -7,7 +7,7 @@ int main()
     using namespace seqan3::literals;
 
     seqan3::masked<seqan3::dna4> dna4_masked{};
-    seqan3::masked<seqan3::dna4> dna4_another_masked{'A'_dna4, seqan3::mask::UNMASKED};
+    seqan3::masked<seqan3::dna4> dna4_another_masked{'A'_dna4, seqan3::mask::unmasked};
     // create a dna4 masked alphabet with an unmasked A
 
     dna4_masked.assign_char('a'); // assigns a masked 'A'_dna4

--- a/test/unit/alphabet/mask/mask_test.cpp
+++ b/test/unit/alphabet/mask/mask_test.cpp
@@ -19,12 +19,12 @@ TEST(mask, assign_rank)
 {
     // l-value
     seqan3::mask lmask;
-    EXPECT_EQ(lmask.assign_rank(1), seqan3::mask::MASKED);
+    EXPECT_EQ(lmask.assign_rank(1), seqan3::mask::masked);
     EXPECT_TRUE(lmask.to_rank());
-    EXPECT_EQ(lmask.assign_rank(0), seqan3::mask::UNMASKED);
+    EXPECT_EQ(lmask.assign_rank(0), seqan3::mask::unmasked);
     EXPECT_FALSE(lmask.to_rank());
-    EXPECT_EQ(lmask.assign_rank(true), seqan3::mask::MASKED);
-    EXPECT_EQ(lmask.assign_rank(false), seqan3::mask::UNMASKED);
+    EXPECT_EQ(lmask.assign_rank(true), seqan3::mask::masked);
+    EXPECT_EQ(lmask.assign_rank(false), seqan3::mask::unmasked);
 
     // const l-value
     lmask.assign_rank(1);
@@ -35,12 +35,12 @@ TEST(mask, assign_rank)
     seqan3::mask rmask{lmask};
     EXPECT_EQ(std::move(rmask).to_rank(), lmask.to_rank());
     EXPECT_TRUE((std::is_same_v<decltype(std::move(rmask)), seqan3::mask &&>));
-    EXPECT_EQ(std::move(rmask).assign_rank(1), seqan3::mask::MASKED);
+    EXPECT_EQ(std::move(rmask).assign_rank(1), seqan3::mask::masked);
     EXPECT_TRUE(std::move(rmask).to_rank());
-    EXPECT_EQ(std::move(rmask).assign_rank(0), seqan3::mask::UNMASKED);
+    EXPECT_EQ(std::move(rmask).assign_rank(0), seqan3::mask::unmasked);
     EXPECT_FALSE(std::move(rmask).to_rank());
-    EXPECT_EQ(std::move(rmask).assign_rank(true), seqan3::mask::MASKED);
-    EXPECT_EQ(std::move(rmask).assign_rank(false), seqan3::mask::UNMASKED);
+    EXPECT_EQ(std::move(rmask).assign_rank(true), seqan3::mask::masked);
+    EXPECT_EQ(std::move(rmask).assign_rank(false), seqan3::mask::unmasked);
 
     // const r-value
     seqan3::mask const crmask{lmask};

--- a/test/unit/core/debug_stream_test.cpp
+++ b/test/unit/core/debug_stream_test.cpp
@@ -107,11 +107,11 @@ TEST(debug_stream_test, mask_semialphabet)
     std::ostringstream o;
     seqan3::debug_stream_type my_stream{o};
 
-    my_stream << seqan3::mask::MASKED;
+    my_stream << seqan3::mask::masked;
     o.flush();
     EXPECT_EQ(o.str(), "MASKED");
 
-    my_stream << seqan3::mask::UNMASKED;
+    my_stream << seqan3::mask::unmasked;
     o.flush();
     EXPECT_EQ(o.str(), "MASKEDUNMASKED");
 }

--- a/test/unit/utility/views/elements_test.cpp
+++ b/test/unit/utility/views/elements_test.cpp
@@ -49,16 +49,16 @@ TEST(view_get, advanced)
 {
     // TODO remove const-ness from input vector once alphabet_proxy inherits it's alphabet
     std::vector<seqan3::qualified<seqan3::masked<seqan3::dna4>,
-                                  seqan3::phred42>> const t{{{'A'_dna4, seqan3::mask::MASKED}, '!'_phred42},
-                                                            {{'C'_dna4, seqan3::mask::UNMASKED}, '"'_phred42},
-                                                            {{'G'_dna4, seqan3::mask::MASKED}, '#'_phred42},
-                                                            {{'T'_dna4, seqan3::mask::UNMASKED}, '$'_phred42}};
+                                  seqan3::phred42>> const t{{{'A'_dna4, seqan3::mask::masked}, '!'_phred42},
+                                                            {{'C'_dna4, seqan3::mask::unmasked}, '"'_phred42},
+                                                            {{'G'_dna4, seqan3::mask::masked}, '#'_phred42},
+                                                            {{'T'_dna4, seqan3::mask::unmasked}, '$'_phred42}};
 
     // functor notation
-    std::vector<seqan3::masked<seqan3::dna4>> expected_sequence{{'A'_dna4, seqan3::mask::MASKED},
-                                                                {'C'_dna4, seqan3::mask::UNMASKED},
-                                                                {'G'_dna4, seqan3::mask::MASKED},
-                                                                {'T'_dna4, seqan3::mask::UNMASKED}};
+    std::vector<seqan3::masked<seqan3::dna4>> expected_sequence{{'A'_dna4, seqan3::mask::masked},
+                                                                {'C'_dna4, seqan3::mask::unmasked},
+                                                                {'G'_dna4, seqan3::mask::masked},
+                                                                {'T'_dna4, seqan3::mask::unmasked}};
 
     EXPECT_RANGE_EQ(expected_sequence, seqan3::views::elements<0>(t));
     EXPECT_RANGE_EQ("!\"#$"_phred42, seqan3::views::elements<1>(t));


### PR DESCRIPTION
Converts `seqan3::mask::(UN)MASKED` to `seqan3::mask::(un)masked`.

As done in the patch in https://github.com/seqan/product_backlog/issues/311 the strings in `seqan3/core/detail/debug_stream_alphabet.hpp` remain uppercase.

Resolves: https://github.com/seqan/product_backlog/issues/311