### PR TITLE
[MISC] Lower case seqan3::detail::translation_table::value

### DIFF
--- a/include/seqan3/alphabet/aminoacid/translation.hpp
+++ b/include/seqan3/alphabet/aminoacid/translation.hpp
@@ -57,7 +57,7 @@ constexpr aa27 translate_triplet(nucl_type const & n1, nucl_type const & n2, nuc
     if constexpr (std::same_as<nucl_type, dna4> || std::same_as<nucl_type, dna5> || std::same_as<nucl_type, dna15>)
     {
         // table exists for dna15 and is generated for dna4 and dna5 (compile time ok, because small)
-        return seqan3::detail::translation_table<nucl_type, gc>::VALUE[to_rank(n1)][to_rank(n2)][to_rank(n3)];
+        return seqan3::detail::translation_table<nucl_type, gc>::value[to_rank(n1)][to_rank(n2)][to_rank(n3)];
     }
     else if constexpr (std::same_as<nucl_type, rna4> || std::same_as<nucl_type, rna5> || std::same_as<nucl_type, rna15>)
     {
@@ -66,13 +66,13 @@ constexpr aa27 translate_triplet(nucl_type const & n1, nucl_type const & n2, nuc
                           std::conditional_t<std::same_as<nucl_type, rna15>, dna15, void>>>;
 
         // we can use dna's tables, because ranks are identical
-        return seqan3::detail::translation_table<rna2dna_t, gc>::VALUE[to_rank(n1)][to_rank(n2)][to_rank(n3)];
+        return seqan3::detail::translation_table<rna2dna_t, gc>::value[to_rank(n1)][to_rank(n2)][to_rank(n3)];
     }
     else // composites or user defined nucleotide
     {
         // we cast to dna15; slightly slower run-time, but lot's of compile time saved for large alphabets.
         // (nucleotide types can be converted to dna15 by definition)
-        return seqan3::detail::translation_table<dna15, gc>::VALUE[to_rank(static_cast<dna15>(n1))]
+        return seqan3::detail::translation_table<dna15, gc>::value[to_rank(static_cast<dna15>(n1))]
                                                                   [to_rank(static_cast<dna15>(n2))]
                                                                   [to_rank(static_cast<dna15>(n3))];
     }

--- a/include/seqan3/alphabet/aminoacid/translation_details.hpp
+++ b/include/seqan3/alphabet/aminoacid/translation_details.hpp
@@ -60,7 +60,7 @@ template <typename void_type>
 struct translation_table<dna15, seqan3::genetic_code::canonical, void_type>
 {
     //!\brief Holds the translation table for canonical genetic code and nucl16 alphabet.
-    static constexpr aa27 VALUE[dna15::alphabet_size][dna15::alphabet_size][dna15::alphabet_size]
+    static constexpr aa27 value[dna15::alphabet_size][dna15::alphabet_size][dna15::alphabet_size]
     {
         { // a??
             // a,        b,        c,        d,        g,        h,        k,        m,        n,        r,        s,        t,        v,        w,        y

--- a/include/seqan3/alphabet/aminoacid/translation_details.hpp
+++ b/include/seqan3/alphabet/aminoacid/translation_details.hpp
@@ -29,7 +29,7 @@ struct translation_table
 {
     //!\brief Holds the generic translation table.
     static constexpr std::array<std::array<std::array<aa27, alphabet_size<nucl_type>>, alphabet_size<nucl_type>>,
-                                                      alphabet_size<nucl_type>> VALUE
+                                                      alphabet_size<nucl_type>> value
     {
         [] () constexpr
         {
@@ -46,7 +46,7 @@ struct translation_table
                     for (size_t k = 0; k < alphabet_size<nucl_type>; ++k)
                     {
                         dna15 n3(assign_rank_to(k, nucl_type{}));
-                        table[i][j][k] = translation_table<dna15, gc, void_type>::VALUE[to_rank(n1)][to_rank(n2)][to_rank(n3)];
+                        table[i][j][k] = translation_table<dna15, gc, void_type>::value[to_rank(n1)][to_rank(n2)][to_rank(n3)];
                     }
                 }
             }


### PR DESCRIPTION
Lowercase `seqan3::detail::translation_table<dna15, gc>::value` and `seqan3::detail::translation_table::value`.

Resolves: https://github.com/seqan/product_backlog/issues/318 