### PR TITLE
[MISC] gcc-10.3 supports SEQAN3_WORKAROUND_GCC_99318 now

### DIFF
--- a/include/seqan3/core/platform.hpp
+++ b/include/seqan3/core/platform.hpp
@@ -333,8 +333,8 @@
 #endif
 
 //!\brief See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=99318
-#ifndef SEQAN3_WORKAROUND_GCC_99318 // not yet fixed, this is a regression since gcc-10
-#   if defined(__GNUC__) && (__GNUC__ >= 10)
+#ifndef SEQAN3_WORKAROUND_GCC_99318 // fixed since gcc10.3
+#   if defined(__GNUC__) && (__GNUC__ == 10 && __GNUC_MINOR__ < 3)
 #       define SEQAN3_WORKAROUND_GCC_99318 1
 #   else
 #       define SEQAN3_WORKAROUND_GCC_99318 0


### PR DESCRIPTION
Part of release checklist (https://github.com/seqan/seqan3/issues/2334)

Go through workarounds and re-evaluate them. This workaround is apparently fixes since gcc-10.3 so let's see :)