### PR TITLE
[INFRA] retry apt

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -40,11 +40,8 @@ jobs:
           ref: develop
           path: seqan3/submodules/seqan
 
-      - name: Add package source
-        run: |
-          sudo add-apt-repository --no-update --yes ppa:ubuntu-toolchain-r/ppa
-          sudo add-apt-repository --no-update --yes ppa:ubuntu-toolchain-r/test
-          sudo apt-get update
+      - name: Configure APT
+        run: bash ./seqan3/.github/workflows/scripts/configure_apt.sh
 
       - name: Install CMake
         run: bash ./seqan3/.github/workflows/scripts/install_cmake.sh

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -91,11 +91,8 @@ jobs:
           ref: develop
           path: seqan3/submodules/seqan
 
-      - name: Add package source
-        run: |
-          sudo add-apt-repository --no-update --yes ppa:ubuntu-toolchain-r/ppa
-          sudo add-apt-repository --no-update --yes ppa:ubuntu-toolchain-r/test
-          sudo apt-get update
+      - name: Configure APT
+        run: bash ./seqan3/.github/workflows/scripts/configure_apt.sh
 
       - name: Install CMake
         run: bash ./seqan3/.github/workflows/scripts/install_cmake.sh

--- a/.github/workflows/ci_misc.yml
+++ b/.github/workflows/ci_misc.yml
@@ -123,6 +123,9 @@ jobs:
           ref: develop
           path: seqan3/submodules/seqan
 
+      - name: Configure APT
+        run: bash ./seqan3/.github/workflows/scripts/configure_apt.sh
+
       - name: Install CMake
         env:
           BUILD: ${{ matrix.build }}

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -23,6 +23,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Configure APT
+        run: bash .github/workflows/scripts/configure_apt.sh
+
       - name: Install CMake
         run: bash .github/workflows/scripts/install_cmake.sh
 

--- a/.github/workflows/latest_libraries.yml
+++ b/.github/workflows/latest_libraries.yml
@@ -60,11 +60,8 @@ jobs:
           ref: develop
           path: seqan3/submodules/seqan
 
-      - name: Add package source
-        run: |
-          sudo add-apt-repository --no-update --yes ppa:ubuntu-toolchain-r/ppa
-          sudo add-apt-repository --no-update --yes ppa:ubuntu-toolchain-r/test
-          sudo apt-get update
+      - name: Configure APT
+        run: bash ./seqan3/.github/workflows/scripts/configure_apt.sh
 
       - name: Install CMake
         run: bash ./seqan3/.github/workflows/scripts/install_cmake.sh

--- a/.github/workflows/scripts/configure_apt.sh
+++ b/.github/workflows/scripts/configure_apt.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -x
+set -e
+
+echo 'APT::Acquire::Retries "5";' | sudo tee -a /etc/apt/apt.conf.d/80-retries > /dev/null
+sudo add-apt-repository --no-update --yes ppa:ubuntu-toolchain-r/ppa
+sudo add-apt-repository --no-update --yes ppa:ubuntu-toolchain-r/test
+sudo apt-get update


### PR DESCRIPTION
This should hopefully prevent spurious fails when running apt-related commands, e.g.
https://github.com/seqan/seqan3/pull/2624/checks?check_run_id=2553996540

```
+ sudo apt-get update
[...]
Ign:28 https://packages.microsoft.com/repos/azure-cli focal InRelease
Ign:29 https://packages.microsoft.com/ubuntu/20.04/prod focal InRelease
Err:30 https://packages.microsoft.com/repos/azure-cli focal Release
  Could not connect to packages.microsoft.com:443 (13.82.67.141), connection timed out [IP: 13.82.67.141 443]
Err:31 https://packages.microsoft.com/ubuntu/20.04/prod focal Release
  Unable to connect to packages.microsoft.com:https: [IP: 13.82.67.141 443]
Reading package lists...
E: The repository 'https://packages.microsoft.com/repos/azure-cli focal Release' no longer has a Release file.
E: The repository 'https://packages.microsoft.com/ubuntu/20.04/prod focal Release' no longer has a Release file.
##[error]Process completed with exit code 100.
```