### PR TITLE
[FIX] uninitialised warning

### DIFF
--- a/test/unit/alignment/matrix/debug_matrix_test.cpp
+++ b/test/unit/alignment/matrix/debug_matrix_test.cpp
@@ -287,7 +287,7 @@ struct debug_matrix_test : public ::testing::Test
     };
 
     template <typename score_matrix_t>
-    void test_score_matrix(score_matrix_t matrix)
+    void test_score_matrix(score_matrix_t && matrix)
     {
         EXPECT_EQ(matrix.cols(), 17u);
         EXPECT_EQ(matrix.rows(), 9u);
@@ -315,7 +315,7 @@ struct debug_matrix_test : public ::testing::Test
     }
 
     template <typename trace_matrix_t>
-    void test_trace_matrix(trace_matrix_t matrix)
+    void test_trace_matrix(trace_matrix_t && matrix)
     {
         EXPECT_EQ(matrix.cols(), 17u);
         EXPECT_EQ(matrix.rows(), 9u);


### PR DESCRIPTION
See https://cdash.seqan.de/viewBuildError.php?buildid=149537

It gets moved here:
https://github.com/seqan/seqan3/blob/5bf6e251ffb6bcc5ebfd44b0cf502a88b90a359d/test/unit/alignment/matrix/debug_matrix_test.cpp#L404