### PR TITLE
adjust deprecation and unify it

### DIFF
--- a/include/seqan3/alignment/pairwise/alignment_algorithm.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_algorithm.hpp
@@ -424,16 +424,16 @@ private:
         // Allocate and initialise first column.
         this->allocate_matrix(sequence1, sequence2, band, this->alignment_state);
         size_t last_row_index = this->score_matrix.band_row_index;
-        initialise_first_alignment_column(sequence2 | views::take(last_row_index));
+        initialise_first_alignment_column(sequence2 | std::views::take(last_row_index));
 
         // ----------------------------------------------------------------------------
         // 1st recursion phase: iterate as long as the band intersects with the first row.
         // ----------------------------------------------------------------------------
 
         size_t sequence2_size = std::ranges::distance(sequence2);
-        for (auto const & seq1_value : sequence1 | views::take(this->score_matrix.band_col_index))
+        for (auto const & seq1_value : sequence1 | std::views::take(this->score_matrix.band_col_index))
         {
-            compute_alignment_column<true>(seq1_value, sequence2 | views::take(++last_row_index));
+            compute_alignment_column<true>(seq1_value, sequence2 | std::views::take(++last_row_index));
             // Only if band reached last row of matrix the last cell might be tracked.
             finalise_last_cell_in_column(last_row_index >= sequence2_size);
         }

--- a/include/seqan3/alignment/pairwise/detail/pairwise_alignment_algorithm_banded.hpp
+++ b/include/seqan3/alignment/pairwise/detail/pairwise_alignment_algorithm_banded.hpp
@@ -99,7 +99,7 @@ public:
             // Shrink the first sequence if the band ends before its actual end.
             sequence1_size = std::min(sequence1_size, this->upper_diagonal + sequence2_size);
 
-            compute_matrix(get<0>(sequence_pair) | views::take(sequence1_size),
+            compute_matrix(get<0>(sequence_pair) | std::views::take(sequence1_size),
                            get<1>(sequence_pair),
                            alignment_matrix,
                            index_matrix);
@@ -246,7 +246,7 @@ protected:
 
         row_index_t row_size = std::max<int32_t>(0, -this->lower_diagonal);
         column_index_t const column_size = std::max<int32_t>(0, this->upper_diagonal);
-        this->initialise_column(*alignment_matrix_it, *indexed_matrix_it, sequence2 | views::take(row_size));
+        this->initialise_column(*alignment_matrix_it, *indexed_matrix_it, sequence2 | std::views::take(row_size));
 
         // ---------------------------------------------------------------------
         // 1st recursion phase: band intersects with the first row.

--- a/include/seqan3/alignment/pairwise/detail/pairwise_alignment_algorithm_banded.hpp
+++ b/include/seqan3/alignment/pairwise/detail/pairwise_alignment_algorithm_banded.hpp
@@ -99,7 +99,9 @@ public:
             // Shrink the first sequence if the band ends before its actual end.
             sequence1_size = std::min(sequence1_size, this->upper_diagonal + sequence2_size);
 
-            compute_matrix(get<0>(sequence_pair) | std::views::take(sequence1_size),
+            using sequence1_difference_t = std::ranges::range_difference_t<decltype(get<0>(sequence_pair))>;
+
+            compute_matrix(std::views::take(get<0>(sequence_pair), static_cast<sequence1_difference_t>(sequence1_size)),
                            get<1>(sequence_pair),
                            alignment_matrix,
                            index_matrix);
@@ -246,7 +248,7 @@ protected:
 
         row_index_t row_size = std::max<int32_t>(0, -this->lower_diagonal);
         column_index_t const column_size = std::max<int32_t>(0, this->upper_diagonal);
-        this->initialise_column(*alignment_matrix_it, *indexed_matrix_it, sequence2 | std::views::take(row_size));
+        this->initialise_column(*alignment_matrix_it, *indexed_matrix_it, std::views::take(sequence2, row_size));
 
         // ---------------------------------------------------------------------
         // 1st recursion phase: band intersects with the first row.

--- a/include/seqan3/io/detail/take_exactly_view.hpp
+++ b/include/seqan3/io/detail/take_exactly_view.hpp
@@ -21,6 +21,10 @@
 namespace seqan3::detail
 {
 
+//!\brief Type alias for seqan3::detail::take_fn but with exactly set to true
+template <bool or_throw>
+using take_exactly_fn = take_fn<true, or_throw>;
+
 /*!\name General purpose views
  * \{
  */
@@ -74,7 +78,7 @@ namespace seqan3::detail
  *
  * \hideinitializer
  */
-inline auto constexpr take_exactly = take_fn<true, false>{};
+inline auto constexpr take_exactly = take_exactly_fn<false>{};
 
 // ============================================================================
 //  detail::take_exactly_or_throw (adaptor instance definition)
@@ -88,7 +92,7 @@ inline auto constexpr take_exactly = take_fn<true, false>{};
  * \copydetails seqan3::detail::take_exactly
  * \hideinitializer
  */
-inline auto constexpr take_exactly_or_throw = take_fn<true, true>{};
+inline auto constexpr take_exactly_or_throw = take_exactly_fn<true>{};
 
 //!\}
 } // namespace seqan3::detail

--- a/include/seqan3/io/detail/take_line_view.hpp
+++ b/include/seqan3/io/detail/take_line_view.hpp
@@ -92,3 +92,23 @@ inline auto constexpr take_line_or_throw = detail::take_until_or_throw_and_consu
 //!\}
 
 } // namespace seqan3::detail
+
+#ifdef SEQAN3_DEPRECATED_310
+namespace seqan3::views
+{
+
+/*!\brief A view adaptor that returns a single line from the underlying range.
+ * \ingroup views
+ * \deprecated Please use `std::views::take_while([](auto && chr){ return chr != &apos;\n&apos; })`
+ */
+SEQAN3_DEPRECATED_310 inline auto constexpr take_line = detail::take_line;
+
+/*!\brief A view adaptor that returns a single line from the underlying range (throws if there is no end-of-line).
+ * \throws seqan3::unexpected_end_of_input If the underlying range contains no end-of-line marker.
+ * \ingroup views
+ * \deprecated Please use `std::views::take_while([](auto && chr){ return chr != &apos;\n&apos; })`
+ */
+SEQAN3_DEPRECATED_310 inline auto constexpr take_line_or_throw = detail::take_line_or_throw;
+
+} // namespace seqan3::views
+#endif // SEQAN3_DEPRECATED_310

--- a/include/seqan3/io/detail/take_until_view.hpp
+++ b/include/seqan3/io/detail/take_until_view.hpp
@@ -625,6 +625,7 @@ inline auto constexpr take_until_or_throw_and_consume = take_until_fn<true, true
 
 } // namespace seqan3::detail
 
+#ifdef SEQAN3_DEPRECATED_310
 namespace seqan3::views
 {
 
@@ -660,3 +661,4 @@ SEQAN3_DEPRECATED_310 inline auto constexpr take_until_and_consume = detail::tak
 SEQAN3_DEPRECATED_310 inline auto constexpr take_until_or_throw_and_consume = detail::take_until_fn<true, true>{};
 
 } // namespace seqan3::views
+#endif // SEQAN3_DEPRECATED_310

--- a/include/seqan3/io/detail/take_view.hpp
+++ b/include/seqan3/io/detail/take_view.hpp
@@ -7,7 +7,8 @@
 
 /*!\file
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
- * \brief Provides seqan3::views::take.
+ * \brief [DEPRECATED] Provides seqan3::views::take.
+ * \deprecated This header will be removed in 3.1.
  */
 
 #pragma once
@@ -52,6 +53,9 @@ namespace seqan3::detail
 template <std::ranges::view urng_t, bool exactly, bool or_throw>
 class view_take : public std::ranges::view_interface<view_take<urng_t, exactly, or_throw>>
 {
+#if SEQAN3_VERSION_MAJOR == 3 && SEQAN3_VERSION_MINOR == 1
+    #pragma warning "Move this class to seqan3/io/detail/take_exactly_view.hpp and name it view_take_exactly; substitute exactly with = true."
+#endif
 private:
     //!\brief The underlying range.
     urng_t urange;
@@ -534,6 +538,7 @@ struct take_fn
 
 } // namespace seqan3::detail
 
+#ifdef SEQAN3_DEPRECATED_310
 // ============================================================================
 //  views::take (adaptor instance definition)
 // ============================================================================
@@ -601,8 +606,9 @@ namespace seqan3::views
  *
  * \deprecated Use std::views::take or seqan3::views::type_reduce | std::views::take.
  */
-inline auto constexpr take = detail::take_fn<false, false>{};
+SEQAN3_DEPRECATED_310 inline auto constexpr take = detail::take_fn<false, false>{};
 
 //!\}
 
 } // namespace seqan3::views
+#endif // SEQAN3_DEPRECATED_310

--- a/include/seqan3/range/container/aligned_allocator.hpp
+++ b/include/seqan3/range/container/aligned_allocator.hpp
@@ -16,4 +16,4 @@
 #include <seqan3/utility/container/aligned_allocator.hpp>
 
 SEQAN3_DEPRECATED_HEADER(
-   "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/utility/container/aligned_allocator.hpp> instead.")
+    "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/utility/container/aligned_allocator.hpp> instead.")

--- a/include/seqan3/range/container/bitcompressed_vector.hpp
+++ b/include/seqan3/range/container/bitcompressed_vector.hpp
@@ -16,4 +16,4 @@
 #include <seqan3/alphabet/container/bitpacked_sequence.hpp>
 
 SEQAN3_DEPRECATED_HEADER(
-   "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/alphabet/container/bitpacked_sequence.hpp> instead.")
+    "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/alphabet/container/bitpacked_sequence.hpp> instead.")

--- a/include/seqan3/range/container/concatenated_sequences.hpp
+++ b/include/seqan3/range/container/concatenated_sequences.hpp
@@ -16,4 +16,4 @@
 #include <seqan3/alphabet/container/concatenated_sequences.hpp>
 
 SEQAN3_DEPRECATED_HEADER(
-   "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/alphabet/container/concatenated_sequences.hpp> instead.")
+    "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/alphabet/container/concatenated_sequences.hpp> instead.")

--- a/include/seqan3/range/container/concept.hpp
+++ b/include/seqan3/range/container/concept.hpp
@@ -16,4 +16,4 @@
 #include <seqan3/utility/container/concept.hpp>
 
 SEQAN3_DEPRECATED_HEADER(
-   "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/utility/container/concept.hpp> instead.")
+    "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/utility/container/concept.hpp> instead.")

--- a/include/seqan3/range/container/dynamic_bitset.hpp
+++ b/include/seqan3/range/container/dynamic_bitset.hpp
@@ -16,4 +16,4 @@
 #include <seqan3/utility/container/dynamic_bitset.hpp>
 
 SEQAN3_DEPRECATED_HEADER(
-   "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/utility/container/dynamic_bitset.hpp> instead.")
+    "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/utility/container/dynamic_bitset.hpp> instead.")

--- a/include/seqan3/range/container/small_string.hpp
+++ b/include/seqan3/range/container/small_string.hpp
@@ -16,4 +16,4 @@
 #include <seqan3/utility/container/small_string.hpp>
 
 SEQAN3_DEPRECATED_HEADER(
-   "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/utility/container/small_string.hpp> instead.")
+    "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/utility/container/small_string.hpp> instead.")

--- a/include/seqan3/range/container/small_vector.hpp
+++ b/include/seqan3/range/container/small_vector.hpp
@@ -16,4 +16,4 @@
 #include <seqan3/utility/container/small_vector.hpp>
 
 SEQAN3_DEPRECATED_HEADER(
-   "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/utility/container/small_vector.hpp> instead.")
+    "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/utility/container/small_vector.hpp> instead.")

--- a/include/seqan3/range/decorator/gap_decorator.hpp
+++ b/include/seqan3/range/decorator/gap_decorator.hpp
@@ -17,4 +17,4 @@
 #include <seqan3/alignment/decorator/gap_decorator.hpp>
 
 SEQAN3_DEPRECATED_HEADER(
-   "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/alignment/decorator/gap_decorator.hpp> instead.")
+    "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/alignment/decorator/gap_decorator.hpp> instead.")

--- a/include/seqan3/range/shortcuts.hpp
+++ b/include/seqan3/range/shortcuts.hpp
@@ -6,8 +6,9 @@
 // -----------------------------------------------------------------------------------------------------
 
 /*!\file
- * \brief Provides various shortcuts for common std::ranges functions.
+ * \brief [DEPRECATED] Provides various shortcuts for common std::ranges functions.
  * \author Joshua Kim <joshua.kim AT fu-berlin.de>
+ * \deprecated This header will be removed in 3.1.
  */
 
 #pragma once

--- a/include/seqan3/range/views/as_const.hpp
+++ b/include/seqan3/range/views/as_const.hpp
@@ -7,7 +7,8 @@
 
 /*!\file
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
- * \brief Provides seqan3::views::as_const.
+ * \brief [DEPRECATED] Provides seqan3::views::as_const.
+ * \deprecated This header will be removed in 3.1.
  */
 
 #pragma once

--- a/include/seqan3/range/views/async_input_buffer.hpp
+++ b/include/seqan3/range/views/async_input_buffer.hpp
@@ -8,6 +8,7 @@
 /*!\file
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  * \brief [DEPRECATED] Provides seqan3::views::async_input_buffer.
+ * \deprecated This header will be removed in 3.1. Please use seqan3/io/views/async_input_buffer.hpp instead.
  */
 
 #pragma once
@@ -15,4 +16,4 @@
 #include <seqan3/io/views/async_input_buffer.hpp>
 
 SEQAN3_DEPRECATED_HEADER(
-   "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/io/views/async_input_buffer.hpp> instead.")
+    "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/io/views/async_input_buffer.hpp> instead.")

--- a/include/seqan3/range/views/char_to.hpp
+++ b/include/seqan3/range/views/char_to.hpp
@@ -16,4 +16,4 @@
 #include <seqan3/alphabet/views/char_to.hpp>
 
 SEQAN3_DEPRECATED_HEADER(
-   "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/alphabet/views/char_to.hpp> instead.")
+    "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/alphabet/views/char_to.hpp> instead.")

--- a/include/seqan3/range/views/complement.hpp
+++ b/include/seqan3/range/views/complement.hpp
@@ -16,4 +16,4 @@
 #include <seqan3/alphabet/views/complement.hpp>
 
 SEQAN3_DEPRECATED_HEADER(
-   "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/alphabet/views/complement.hpp> instead.")
+    "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/alphabet/views/complement.hpp> instead.")

--- a/include/seqan3/range/views/convert.hpp
+++ b/include/seqan3/range/views/convert.hpp
@@ -16,4 +16,4 @@
 #include <seqan3/utility/views/convert.hpp>
 
 SEQAN3_DEPRECATED_HEADER(
-   "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/utility/views/convert.hpp> instead.")
+    "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/utility/views/convert.hpp> instead.")

--- a/include/seqan3/range/views/drop.hpp
+++ b/include/seqan3/range/views/drop.hpp
@@ -7,7 +7,8 @@
 
 /*!\file
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
- * \brief Provides seqan3::views::drop.
+ * \brief [DEPRECATED] Provides seqan3::views::drop.
+ * \deprecated This header will be removed in 3.1.
  */
 
 #pragma once

--- a/include/seqan3/range/views/drop.hpp
+++ b/include/seqan3/range/views/drop.hpp
@@ -23,6 +23,7 @@
 #include <seqan3/io/exception.hpp>
 #include <seqan3/range/views/detail.hpp>
 
+#ifdef SEQAN3_DEPRECATED_310
 namespace seqan3::detail
 {
 
@@ -176,10 +177,9 @@ namespace seqan3::views
  *
  * \deprecated Use std::views::drop or seqan3::views::type_reduce | std::views::drop.
  */
-#ifdef SEQAN3_DEPRECATED_310
 SEQAN3_DEPRECATED_310 inline constexpr auto drop = detail::drop_fn{};
-#endif // SEQAN3_DEPRECATED_310
 
 //!\}
 
 } // namespace seqan3::views
+#endif // SEQAN3_DEPRECATED_310

--- a/include/seqan3/range/views/enforce_random_access.hpp
+++ b/include/seqan3/range/views/enforce_random_access.hpp
@@ -15,4 +15,5 @@
 
 #include <seqan3/utility/views/enforce_random_access.hpp>
 
-SEQAN3_DEPRECATED_HEADER("This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/utility/views/enforce_random_access.hpp> instead.")
+SEQAN3_DEPRECATED_HEADER(
+    "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/utility/views/enforce_random_access.hpp> instead.")

--- a/include/seqan3/range/views/get.hpp
+++ b/include/seqan3/range/views/get.hpp
@@ -15,17 +15,5 @@
 
 #include <seqan3/utility/views/elements.hpp>
 
-namespace seqan3::views
-{
-
-/*!\brief A view calling `get` on each element in a range.
- * \ingroup views
- * \deprecated Please use `seqan3::views::elements` instead.
- */
-template <auto index>
-SEQAN3_DEPRECATED_310 inline constexpr auto get = views::elements<index>;
-
-} // namespace seqan3::views
-
 SEQAN3_DEPRECATED_HEADER(
     "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/utility/views/elements.hpp> instead.")

--- a/include/seqan3/range/views/istreambuf.hpp
+++ b/include/seqan3/range/views/istreambuf.hpp
@@ -8,6 +8,7 @@
 /*!\file
  * \brief [DEPRECATED] Provides seqan3::detail::istreambuf.
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
+ * \deprecated This header will be removed in 3.1.
  */
 
 #pragma once
@@ -15,4 +16,4 @@
 #include <seqan3/io/detail/istreambuf_view.hpp>
 
 SEQAN3_DEPRECATED_HEADER(
-  "This header is deprecated and will be removed along all its content in SeqAn-3.1.0.")
+    "This header is deprecated and will be removed along all its content in SeqAn-3.1.0.")

--- a/include/seqan3/range/views/join.hpp
+++ b/include/seqan3/range/views/join.hpp
@@ -8,6 +8,7 @@
 /*!\file
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  * \brief [DEPRECATED] Provides seqan3::views::join.
+ * \deprecated This header will be removed in 3.1. Please use seqan3/utility/views/join_with.hpp instead.
  */
 
 #pragma once
@@ -15,4 +16,4 @@
 #include <seqan3/utility/views/join_with.hpp>
 
 SEQAN3_DEPRECATED_HEADER(
-   "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/utility/views/join_with.hpp> instead.")
+    "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/utility/views/join_with.hpp> instead.")

--- a/include/seqan3/range/views/kmer_hash.hpp
+++ b/include/seqan3/range/views/kmer_hash.hpp
@@ -8,6 +8,7 @@
 /*!\file
  * \author Enrico Seiler <enrico.seiler AT fu-berlin.de>
  * \brief [DEPRECATED] Provides seqan3::views::kmer_hash.
+ * \deprecated This header will be removed in 3.1. Please use seqan3/search/views/kmer_hash.hpp instead.
  */
 
 #pragma once
@@ -15,4 +16,4 @@
 #include <seqan3/search/views/kmer_hash.hpp>
 
 SEQAN3_DEPRECATED_HEADER(
-   "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/search/views/kmer_hash.hpp> instead.")
+    "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/search/views/kmer_hash.hpp> instead.")

--- a/include/seqan3/range/views/minimiser.hpp
+++ b/include/seqan3/range/views/minimiser.hpp
@@ -8,6 +8,7 @@
 /*!\file
  * \author Mitra Darvish <mitra.darvish AT fu-berlin.de>
  * \brief [DEPRECATED] Provides seqan3::views::minimiser.
+ * \deprecated This header will be removed in 3.1. Please use seqan3/search/views/minimiser.hpp instead.
  */
 
 #pragma once
@@ -15,4 +16,4 @@
 #include <seqan3/search/views/minimiser.hpp>
 
 SEQAN3_DEPRECATED_HEADER(
-   "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/search/views/minimiser.hpp> instead.")
+    "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/search/views/minimiser.hpp> instead.")

--- a/include/seqan3/range/views/minimiser_hash.hpp
+++ b/include/seqan3/range/views/minimiser_hash.hpp
@@ -8,6 +8,7 @@
 /*!\file
  * \author Mitra Darvish <mitra.darvish AT fu-berlin.de>
  * \brief [DEPRECATED] Provides seqan3::views::minimiser_hash.
+ * \deprecated This header will be removed in 3.1. Please use seqan3/search/views/minimiser_hash.hpp instead.
  */
 
 #pragma once
@@ -15,4 +16,4 @@
 #include <seqan3/search/views/minimiser_hash.hpp>
 
 SEQAN3_DEPRECATED_HEADER(
-   "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/search/views/minimiser_hash.hpp> instead.")
+    "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/search/views/minimiser_hash.hpp> instead.")

--- a/include/seqan3/range/views/move.hpp
+++ b/include/seqan3/range/views/move.hpp
@@ -7,7 +7,8 @@
 
 /*!\file
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
- * \brief Provides seqan3::views::move.
+ * \brief [DEPRECATED] Provides seqan3::views::move.
+ * \deprecated This header will be removed in 3.1.
  */
 
 #pragma once

--- a/include/seqan3/range/views/persist.hpp
+++ b/include/seqan3/range/views/persist.hpp
@@ -8,6 +8,7 @@
 /*!\file
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  * \brief [DEPRECATED] Provides seqan3::views::persist.
+ * \deprecated This header will be removed in 3.1.
  */
 
 #pragma once
@@ -15,4 +16,4 @@
 #include <seqan3/core/detail/persist_view.hpp>
 
 SEQAN3_DEPRECATED_HEADER(
-  "This header is deprecated and will be removed along all its content in SeqAn-3.1.0.")
+    "This header is deprecated and will be removed along all its content in SeqAn-3.1.0.")

--- a/include/seqan3/range/views/rank_to.hpp
+++ b/include/seqan3/range/views/rank_to.hpp
@@ -16,4 +16,4 @@
 #include <seqan3/alphabet/views/rank_to.hpp>
 
 SEQAN3_DEPRECATED_HEADER(
-   "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/alphabet/views/rank_to.hpp> instead.")
+    "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/alphabet/views/rank_to.hpp> instead.")

--- a/include/seqan3/range/views/repeat.hpp
+++ b/include/seqan3/range/views/repeat.hpp
@@ -7,7 +7,7 @@
 
 /*!\file
  * \author Svenja Mehringer <svenja.mehringer AT fu-berlin.de>
- * \brief [DEPRECATED] Provides the views::repeat_view.
+ * \brief [DEPRECATED] Provides the seqan3::views::repeat.
  * \deprecated This header will be removed in 3.1. Please use seqan3/utility/views/repeat.hpp instead.
  */
 
@@ -15,4 +15,5 @@
 
 #include <seqan3/utility/views/repeat.hpp>
 
-SEQAN3_DEPRECATED_HEADER("This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/utility/views/repeat.hpp> instead.")
+SEQAN3_DEPRECATED_HEADER(
+    "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/utility/views/repeat.hpp> instead.")

--- a/include/seqan3/range/views/repeat_n.hpp
+++ b/include/seqan3/range/views/repeat_n.hpp
@@ -15,4 +15,5 @@
 
 #include <seqan3/utility/views/repeat_n.hpp>
 
-SEQAN3_DEPRECATED_HEADER("This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/utility/views/repeat_n.hpp> instead.")
+SEQAN3_DEPRECATED_HEADER(
+    "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/utility/views/repeat_n.hpp> instead.")

--- a/include/seqan3/range/views/single_pass_input.hpp
+++ b/include/seqan3/range/views/single_pass_input.hpp
@@ -7,7 +7,7 @@
 
 /*!\file
  * \author Rene Rahn <rene.rahn AT fu-berlin.de>
- * \brief [DEPRECATED]Provides seqan3::single_pass_input_view
+ * \brief [DEPRECATED] Provides seqan3::views::single_pass_input
  * \deprecated This header will be removed in 3.1. Please use seqan3/utility/views/single_pass_input.hpp instead.
  */
 
@@ -15,4 +15,5 @@
 
 #include <seqan3/utility/views/single_pass_input.hpp>
 
-SEQAN3_DEPRECATED_HEADER("This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/utility/views/single_pass_input.hpp> instead.")
+SEQAN3_DEPRECATED_HEADER(
+    "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/utility/views/single_pass_input.hpp> instead.")

--- a/include/seqan3/range/views/take.hpp
+++ b/include/seqan3/range/views/take.hpp
@@ -8,11 +8,11 @@
 /*!\file
  * \brief [DEPRECATED] Provides seqan3::views::take.
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
+ * \deprecated This header will be removed in 3.1.
  */
 
 #pragma once
 
 #include <seqan3/io/detail/take_view.hpp>
 
-SEQAN3_DEPRECATED_HEADER(
-    "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/io/detail/take_view.hpp> instead.")
+SEQAN3_DEPRECATED_HEADER("This header is deprecated and will be removed along all its content in SeqAn-3.1.0.")

--- a/include/seqan3/range/views/take_exactly.hpp
+++ b/include/seqan3/range/views/take_exactly.hpp
@@ -8,13 +8,11 @@
 /*!\file
  * \brief [DEPRECATED] Provides seqan3::views::take_exactly and seqan3::views::take_exactly_or_throw.
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
+ * \deprecated This header will be removed in 3.1.
  */
 
 #pragma once
 
 #include <seqan3/io/detail/take_exactly_view.hpp>
 
-
-SEQAN3_DEPRECATED_HEADER(
-    "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/io/detail/take_exactly_view.hpp> instead.")
-
+SEQAN3_DEPRECATED_HEADER("This header is deprecated and will be removed along all its content in SeqAn-3.1.0.")

--- a/include/seqan3/range/views/take_line.hpp
+++ b/include/seqan3/range/views/take_line.hpp
@@ -16,21 +16,3 @@
 #include <seqan3/io/detail/take_line_view.hpp>
 
 SEQAN3_DEPRECATED_HEADER("This header is deprecated and will be removed along all its content in SeqAn-3.1.0.")
-
-namespace seqan3::views
-{
-
-/*!\brief A view adaptor that returns a single line from the underlying range.
- * \ingroup views
- * \deprecated Please use `std::views::take_while([](auto && chr){ return chr != &apos;\n&apos; })`
- */
-SEQAN3_DEPRECATED_310 inline auto constexpr take_line = detail::take_line;
-
-/*!\brief A view adaptor that returns a single line from the underlying range (throws if there is no end-of-line).
- * \throws seqan3::unexpected_end_of_input If the underlying range contains no end-of-line marker.
- * \ingroup views
- * \deprecated Please use `std::views::take_while([](auto && chr){ return chr != &apos;\n&apos; })`
- */
-SEQAN3_DEPRECATED_310 inline auto constexpr take_line_or_throw = detail::take_line_or_throw;
-
-} // namespace seqan3::views

--- a/include/seqan3/range/views/take_line.hpp
+++ b/include/seqan3/range/views/take_line.hpp
@@ -8,14 +8,14 @@
 /*!\file
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  * \brief [DEPRECATED] Provides seqan3::views::take_line and seqan3::views::take_line_or_throw.
+ * \deprecated This header will be removed in 3.1.
  */
 
 #pragma once
 
 #include <seqan3/io/detail/take_line_view.hpp>
 
-SEQAN3_DEPRECATED_HEADER(
-  "This header is deprecated and will be removed along all its content in SeqAn-3.1.0.")
+SEQAN3_DEPRECATED_HEADER("This header is deprecated and will be removed along all its content in SeqAn-3.1.0.")
 
 namespace seqan3::views
 {

--- a/include/seqan3/range/views/take_until.hpp
+++ b/include/seqan3/range/views/take_until.hpp
@@ -8,11 +8,11 @@
 /*!\file
  * \brief [DEPRECATED] Provides seqan3::views::take_until.
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
+ * \deprecated This header will be removed in 3.1.
  */
 
 #pragma once
 
 #include <seqan3/io/detail/take_until_view.hpp>
 
-SEQAN3_DEPRECATED_HEADER(
-    "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/io/detail/take_until_view.hpp> instead.")
+SEQAN3_DEPRECATED_HEADER("This header is deprecated and will be removed along all its content in SeqAn-3.1.0.")

--- a/include/seqan3/range/views/to_lower.hpp
+++ b/include/seqan3/range/views/to_lower.hpp
@@ -8,6 +8,7 @@
 /*!\file
  * \author Tobias Loka <LokaT AT rki.de>
  * \brief [DEPRECATED] Provides seqan3::views::to_lower.
+ * \deprecated This header will be removed in 3.1.
  */
 
 #pragma once

--- a/include/seqan3/range/views/to_upper.hpp
+++ b/include/seqan3/range/views/to_upper.hpp
@@ -8,6 +8,7 @@
 /*!\file
  * \author Tobias Loka <LokaT AT rki.de>
  * \brief [DEPRECATED] Provides seqan3::views::to_upper.
+ * \deprecated This header will be removed in 3.1.
  */
 
 #pragma once

--- a/include/seqan3/range/views/translate.hpp
+++ b/include/seqan3/range/views/translate.hpp
@@ -16,4 +16,4 @@
 #include <seqan3/alphabet/views/translate.hpp>
 
 SEQAN3_DEPRECATED_HEADER(
-   "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/alphabet/views/translate.hpp> instead.")
+    "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/alphabet/views/translate.hpp> instead.")

--- a/include/seqan3/range/views/translate_join.hpp
+++ b/include/seqan3/range/views/translate_join.hpp
@@ -16,4 +16,4 @@
 #include <seqan3/alphabet/views/translate_join.hpp>
 
 SEQAN3_DEPRECATED_HEADER(
-   "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/alphabet/views/translate_join.hpp> instead.")
+    "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/alphabet/views/translate_join.hpp> instead.")

--- a/include/seqan3/range/views/trim_quality.hpp
+++ b/include/seqan3/range/views/trim_quality.hpp
@@ -16,4 +16,4 @@
 #include <seqan3/alphabet/views/trim_quality.hpp>
 
 SEQAN3_DEPRECATED_HEADER(
-   "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/alphabet/views/trim_quality.hpp> instead.")
+    "This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/alphabet/views/trim_quality.hpp> instead.")

--- a/include/seqan3/utility/views/elements.hpp
+++ b/include/seqan3/utility/views/elements.hpp
@@ -101,3 +101,15 @@ inline constexpr auto elements = std::views::transform([] (auto && in) -> declty
 //!\}
 
 } // namespace seqan3::views
+
+namespace seqan3::views
+{
+
+/*!\brief A view calling `get` on each element in a range.
+ * \ingroup views
+ * \deprecated Please use `seqan3::views::elements` instead.
+ */
+template <auto index>
+SEQAN3_DEPRECATED_310 inline constexpr auto get = views::elements<index>;
+
+} // namespace seqan3::views

--- a/include/seqan3/utility/views/single_pass_input.hpp
+++ b/include/seqan3/utility/views/single_pass_input.hpp
@@ -7,7 +7,7 @@
 
 /*!\file
  * \author Rene Rahn <rene.rahn AT fu-berlin.de>
- * \brief Provides seqan3::single_pass_input_view
+ * \brief Provides seqan3::views::single_pass_input
  */
 
 #pragma once

--- a/test/performance/range/views/view_drop_view_take_benchmark.cpp
+++ b/test/performance/range/views/view_drop_view_take_benchmark.cpp
@@ -62,34 +62,35 @@ void sequential_read(benchmark::State & state)
 
 //!brief Instance for usage until removed.
 inline constexpr auto seqan3_views_drop = seqan3::detail::drop_fn{};
+inline constexpr auto seqan3_views_take = seqan3::detail::take_fn<false, false>{};
 
 BENCHMARK_TEMPLATE(sequential_read, std::string,         void,                              void);
 BENCHMARK_TEMPLATE(sequential_read, std::string,         decltype(std::views::drop), decltype(std::views::take));
-BENCHMARK_TEMPLATE(sequential_read, std::string,         decltype(seqan3_views_drop),      decltype(seqan3::views::take));
+BENCHMARK_TEMPLATE(sequential_read, std::string,         decltype(seqan3_views_drop),      decltype(seqan3_views_take));
 
 BENCHMARK_TEMPLATE(sequential_read, std::vector<uint8_t>, void,                              void);
 BENCHMARK_TEMPLATE(sequential_read, std::vector<uint8_t>, decltype(std::views::drop), decltype(std::views::take));
-BENCHMARK_TEMPLATE(sequential_read, std::vector<uint8_t>, decltype(seqan3_views_drop),      decltype(seqan3::views::take));
+BENCHMARK_TEMPLATE(sequential_read, std::vector<uint8_t>, decltype(seqan3_views_drop),      decltype(seqan3_views_take));
 
 BENCHMARK_TEMPLATE(sequential_read, std::deque<uint8_t>,  void,                              void);
 BENCHMARK_TEMPLATE(sequential_read, std::deque<uint8_t>,  decltype(std::views::drop), decltype(std::views::take));
-BENCHMARK_TEMPLATE(sequential_read, std::deque<uint8_t>,  decltype(seqan3_views_drop),      decltype(seqan3::views::take));
+BENCHMARK_TEMPLATE(sequential_read, std::deque<uint8_t>,  decltype(seqan3_views_drop),      decltype(seqan3_views_take));
 
 BENCHMARK_TEMPLATE(sequential_read, std::list<uint8_t>,   void,                              void);
 BENCHMARK_TEMPLATE(sequential_read, std::list<uint8_t>,   decltype(std::views::drop), decltype(std::views::take));
-BENCHMARK_TEMPLATE(sequential_read, std::list<uint8_t>,   decltype(seqan3_views_drop),      decltype(seqan3::views::take));
+BENCHMARK_TEMPLATE(sequential_read, std::list<uint8_t>,   decltype(seqan3_views_drop),      decltype(seqan3_views_take));
 
 BENCHMARK_TEMPLATE(sequential_read, std::forward_list<uint8_t>,   void,                              void);
 BENCHMARK_TEMPLATE(sequential_read, std::forward_list<uint8_t>,   decltype(std::views::drop), decltype(std::views::take));
-BENCHMARK_TEMPLATE(sequential_read, std::forward_list<uint8_t>,   decltype(seqan3_views_drop),      decltype(seqan3::views::take));
+BENCHMARK_TEMPLATE(sequential_read, std::forward_list<uint8_t>,   decltype(seqan3_views_drop),      decltype(seqan3_views_take));
 
 BENCHMARK_TEMPLATE(sequential_read, std::vector<uint8_t>, void,                              void,                              true);
 BENCHMARK_TEMPLATE(sequential_read, std::vector<uint8_t>, decltype(std::views::drop), decltype(std::views::take), true);
-BENCHMARK_TEMPLATE(sequential_read, std::vector<uint8_t>, decltype(seqan3_views_drop),      decltype(seqan3::views::take),      true);
+BENCHMARK_TEMPLATE(sequential_read, std::vector<uint8_t>, decltype(seqan3_views_drop),      decltype(seqan3_views_take),      true);
 
 BENCHMARK_TEMPLATE(sequential_read, std::forward_list<uint8_t>, void,                              void,                              true);
 BENCHMARK_TEMPLATE(sequential_read, std::forward_list<uint8_t>, decltype(std::views::drop), decltype(std::views::take), true);
-BENCHMARK_TEMPLATE(sequential_read, std::forward_list<uint8_t>, decltype(seqan3_views_drop),      decltype(seqan3::views::take),      true);
+BENCHMARK_TEMPLATE(sequential_read, std::forward_list<uint8_t>, decltype(seqan3_views_drop),      decltype(seqan3_views_take),      true);
 
 // ============================================================================
 //  random access
@@ -140,15 +141,15 @@ void random_access(benchmark::State & state)
 
 BENCHMARK_TEMPLATE(random_access, std::string,          void,                              void);
 BENCHMARK_TEMPLATE(random_access, std::string,          decltype(std::views::drop), decltype(std::views::take));
-BENCHMARK_TEMPLATE(random_access, std::string,          decltype(seqan3_views_drop),      decltype(seqan3::views::take));
+BENCHMARK_TEMPLATE(random_access, std::string,          decltype(seqan3_views_drop),      decltype(seqan3_views_take));
 
 BENCHMARK_TEMPLATE(random_access, std::vector<uint8_t>, void,                              void);
 BENCHMARK_TEMPLATE(random_access, std::vector<uint8_t>, decltype(std::views::drop), decltype(std::views::take));
-BENCHMARK_TEMPLATE(random_access, std::vector<uint8_t>, decltype(seqan3_views_drop),      decltype(seqan3::views::take));
+BENCHMARK_TEMPLATE(random_access, std::vector<uint8_t>, decltype(seqan3_views_drop),      decltype(seqan3_views_take));
 
 BENCHMARK_TEMPLATE(random_access, std::deque<uint8_t>,  void,                              void);
 BENCHMARK_TEMPLATE(random_access, std::deque<uint8_t>,  decltype(std::views::drop), decltype(std::views::take));
-BENCHMARK_TEMPLATE(random_access, std::deque<uint8_t>,  decltype(seqan3_views_drop),      decltype(seqan3::views::take));
+BENCHMARK_TEMPLATE(random_access, std::deque<uint8_t>,  decltype(seqan3_views_drop),      decltype(seqan3_views_take));
 
 // ============================================================================
 //  run

--- a/test/performance/range/views/view_take_benchmark.cpp
+++ b/test/performance/range/views/view_take_benchmark.cpp
@@ -62,45 +62,48 @@ void sequential_read(benchmark::State & state)
     [[maybe_unused]] volatile uint8_t dummy2 = dummy;
 }
 
+//!brief Instance for usage until removed.
+inline constexpr auto seqan3_views_take = seqan3::detail::take_fn<false, false>{};
+
 BENCHMARK_TEMPLATE(sequential_read, std::string, void);
 BENCHMARK_TEMPLATE(sequential_read, std::string, decltype(std::views::take));
-BENCHMARK_TEMPLATE(sequential_read, std::string, decltype(seqan3::views::take));
+BENCHMARK_TEMPLATE(sequential_read, std::string, decltype(seqan3_views_take));
 BENCHMARK_TEMPLATE(sequential_read, std::string, decltype(seqan3::detail::take_exactly));
 BENCHMARK_TEMPLATE(sequential_read, std::string, decltype(seqan3::detail::take_exactly_or_throw));
 
 BENCHMARK_TEMPLATE(sequential_read, std::vector<uint8_t>, void);
 BENCHMARK_TEMPLATE(sequential_read, std::vector<uint8_t>, decltype(std::views::take));
-BENCHMARK_TEMPLATE(sequential_read, std::vector<uint8_t>, decltype(seqan3::views::take));
+BENCHMARK_TEMPLATE(sequential_read, std::vector<uint8_t>, decltype(seqan3_views_take));
 BENCHMARK_TEMPLATE(sequential_read, std::vector<uint8_t>, decltype(seqan3::detail::take_exactly));
 BENCHMARK_TEMPLATE(sequential_read, std::vector<uint8_t>, decltype(seqan3::detail::take_exactly_or_throw));
 
 BENCHMARK_TEMPLATE(sequential_read, std::deque<uint8_t>, void);
 BENCHMARK_TEMPLATE(sequential_read, std::deque<uint8_t>, decltype(std::views::take));
-BENCHMARK_TEMPLATE(sequential_read, std::deque<uint8_t>, decltype(seqan3::views::take));
+BENCHMARK_TEMPLATE(sequential_read, std::deque<uint8_t>, decltype(seqan3_views_take));
 BENCHMARK_TEMPLATE(sequential_read, std::deque<uint8_t>, decltype(seqan3::detail::take_exactly));
 BENCHMARK_TEMPLATE(sequential_read, std::deque<uint8_t>, decltype(seqan3::detail::take_exactly_or_throw));
 
 BENCHMARK_TEMPLATE(sequential_read, std::list<uint8_t>, void);
 BENCHMARK_TEMPLATE(sequential_read, std::list<uint8_t>, decltype(std::views::take));
-BENCHMARK_TEMPLATE(sequential_read, std::list<uint8_t>, decltype(seqan3::views::take));
+BENCHMARK_TEMPLATE(sequential_read, std::list<uint8_t>, decltype(seqan3_views_take));
 BENCHMARK_TEMPLATE(sequential_read, std::list<uint8_t>, decltype(seqan3::detail::take_exactly));
 BENCHMARK_TEMPLATE(sequential_read, std::list<uint8_t>, decltype(seqan3::detail::take_exactly_or_throw));
 
 BENCHMARK_TEMPLATE(sequential_read, std::forward_list<uint8_t>, void);
 BENCHMARK_TEMPLATE(sequential_read, std::forward_list<uint8_t>, decltype(std::views::take));
-BENCHMARK_TEMPLATE(sequential_read, std::forward_list<uint8_t>, decltype(seqan3::views::take));
+BENCHMARK_TEMPLATE(sequential_read, std::forward_list<uint8_t>, decltype(seqan3_views_take));
 BENCHMARK_TEMPLATE(sequential_read, std::forward_list<uint8_t>, decltype(seqan3::detail::take_exactly));
 BENCHMARK_TEMPLATE(sequential_read, std::forward_list<uint8_t>, decltype(seqan3::detail::take_exactly_or_throw));
 
 BENCHMARK_TEMPLATE(sequential_read, std::vector<uint8_t>, void,                                            true);
 BENCHMARK_TEMPLATE(sequential_read, std::vector<uint8_t>, decltype(std::views::take),                      true);
-BENCHMARK_TEMPLATE(sequential_read, std::vector<uint8_t>, decltype(seqan3::views::take),                   true);
+BENCHMARK_TEMPLATE(sequential_read, std::vector<uint8_t>, decltype(seqan3_views_take),                   true);
 BENCHMARK_TEMPLATE(sequential_read, std::vector<uint8_t>, decltype(seqan3::detail::take_exactly),          true);
 BENCHMARK_TEMPLATE(sequential_read, std::vector<uint8_t>, decltype(seqan3::detail::take_exactly_or_throw), true);
 
 BENCHMARK_TEMPLATE(sequential_read, std::forward_list<uint8_t>, void,                                            true);
 BENCHMARK_TEMPLATE(sequential_read, std::forward_list<uint8_t>, decltype(std::views::take),                      true);
-BENCHMARK_TEMPLATE(sequential_read, std::forward_list<uint8_t>, decltype(seqan3::views::take),                   true);
+BENCHMARK_TEMPLATE(sequential_read, std::forward_list<uint8_t>, decltype(seqan3_views_take),                   true);
 BENCHMARK_TEMPLATE(sequential_read, std::forward_list<uint8_t>, decltype(seqan3::detail::take_exactly),          true);
 BENCHMARK_TEMPLATE(sequential_read, std::forward_list<uint8_t>, decltype(seqan3::detail::take_exactly_or_throw), true);
 
@@ -153,19 +156,19 @@ void random_access(benchmark::State & state)
 
 BENCHMARK_TEMPLATE(random_access, std::string, void);
 BENCHMARK_TEMPLATE(random_access, std::string, decltype(std::views::take));
-BENCHMARK_TEMPLATE(random_access, std::string, decltype(seqan3::views::take));
+BENCHMARK_TEMPLATE(random_access, std::string, decltype(seqan3_views_take));
 BENCHMARK_TEMPLATE(random_access, std::string, decltype(seqan3::detail::take_exactly));
 BENCHMARK_TEMPLATE(random_access, std::string, decltype(seqan3::detail::take_exactly_or_throw));
 
 BENCHMARK_TEMPLATE(random_access, std::vector<uint8_t>, void);
 BENCHMARK_TEMPLATE(random_access, std::vector<uint8_t>, decltype(std::views::take));
-BENCHMARK_TEMPLATE(random_access, std::vector<uint8_t>, decltype(seqan3::views::take));
+BENCHMARK_TEMPLATE(random_access, std::vector<uint8_t>, decltype(seqan3_views_take));
 BENCHMARK_TEMPLATE(random_access, std::vector<uint8_t>, decltype(seqan3::detail::take_exactly));
 BENCHMARK_TEMPLATE(random_access, std::vector<uint8_t>, decltype(seqan3::detail::take_exactly_or_throw));
 
 BENCHMARK_TEMPLATE(random_access, std::deque<uint8_t>, void);
 BENCHMARK_TEMPLATE(random_access, std::deque<uint8_t>, decltype(std::views::take));
-BENCHMARK_TEMPLATE(random_access, std::deque<uint8_t>, decltype(seqan3::views::take));
+BENCHMARK_TEMPLATE(random_access, std::deque<uint8_t>, decltype(seqan3_views_take));
 BENCHMARK_TEMPLATE(random_access, std::deque<uint8_t>, decltype(seqan3::detail::take_exactly));
 BENCHMARK_TEMPLATE(random_access, std::deque<uint8_t>, decltype(seqan3::detail::take_exactly_or_throw));
 

--- a/test/performance/search/index_construction_benchmark.cpp
+++ b/test/performance/search/index_construction_benchmark.cpp
@@ -68,11 +68,11 @@ void index_benchmark_seqan3(benchmark::State & state)
     rng_t sequence;
     inner_rng_t inner_sequence;
     if constexpr (std::same_as<alphabet_t, seqan3::dna4>)
-        inner_sequence = store.dna4_rng | seqan3::views::take(state.range(0)) | seqan3::views::to<inner_rng_t>;
+        inner_sequence = store.dna4_rng | std::views::take(state.range(0)) | seqan3::views::to<inner_rng_t>;
     else if constexpr (std::same_as<alphabet_t, seqan3::aa27>)
-        inner_sequence = store.aa27_rng | seqan3::views::take(state.range(0)) | seqan3::views::to<inner_rng_t>;
+        inner_sequence = store.aa27_rng | std::views::take(state.range(0)) | seqan3::views::to<inner_rng_t>;
     else
-        inner_sequence = store.char_rng | seqan3::views::take(state.range(0)) | seqan3::views::to<inner_rng_t>;
+        inner_sequence = store.char_rng | std::views::take(state.range(0)) | seqan3::views::to<inner_rng_t>;
 
     if constexpr (seqan3::range_dimension_v<rng_t> == 1)
     {

--- a/test/snippet/io/detail/take_view.cpp
+++ b/test/snippet/io/detail/take_view.cpp
@@ -4,6 +4,9 @@
 #include <seqan3/core/debug_stream.hpp>
 #include <seqan3/io/detail/take_view.hpp>
 
+#ifdef SEQAN3_DEPRECATED_310
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 int main()
 {
     std::string vec{"foobar"};
@@ -13,3 +16,5 @@ int main()
     auto v2 = vec | std::views::reverse | seqan3::views::take(3);
     seqan3::debug_stream << v2 << '\n'; // [r,a,b]
 }
+#pragma GCC diagnostic pop
+#endif // SEQAN3_DEPRECATED_310

--- a/test/unit/io/detail/take_view_test.cpp
+++ b/test/unit/io/detail/take_view_test.cpp
@@ -22,6 +22,8 @@
 #include <seqan3/utility/range/concept.hpp>
 #include <seqan3/utility/views/single_pass_input.hpp>
 
+inline auto constexpr seqan3_views_take = seqan3::detail::take_fn<false, false>{};
+
 // ============================================================================
 //  test templates
 // ============================================================================
@@ -113,12 +115,12 @@ void do_concepts(adaptor_t && adaptor, bool const exactly)
 
 TEST(view_take, regular)
 {
-    do_test(seqan3::views::take, "foobar");
+    do_test(seqan3_views_take, "foobar");
 }
 
 TEST(view_take, concepts)
 {
-    do_concepts(seqan3::views::take(3), false);
+    do_concepts(seqan3_views_take(3), false);
 }
 
 TEST(view_take, underlying_is_shorter)
@@ -126,11 +128,11 @@ TEST(view_take, underlying_is_shorter)
     using namespace std::literals;
 
     std::string vec{"foo"};
-    EXPECT_NO_THROW(( seqan3::views::take(vec, 4) )); // no parsing
+    EXPECT_NO_THROW(( seqan3_views_take(vec, 4) )); // no parsing
 
     std::string v;
     // full parsing on conversion
-    EXPECT_RANGE_EQ("foo"sv, vec | seqan3::views::single_pass_input | seqan3::views::take(4));
+    EXPECT_RANGE_EQ("foo"sv, vec | seqan3::views::single_pass_input | seqan3_views_take(4));
 }
 
 TEST(view_take, type_erasure)
@@ -138,7 +140,7 @@ TEST(view_take, type_erasure)
     {   // string const overload
         std::string const urange{"foobar"};
 
-        auto v = seqan3::views::take(urange, 3);
+        auto v = seqan3_views_take(urange, 3);
 
         EXPECT_SAME_TYPE(decltype(v), std::string_view);
         EXPECT_RANGE_EQ(v, urange.substr(0,3));
@@ -147,7 +149,7 @@ TEST(view_take, type_erasure)
     {   // stringview overload
         std::string_view urange{"foobar"};
 
-        auto v = seqan3::views::take(urange, 3);
+        auto v = seqan3_views_take(urange, 3);
 
         EXPECT_SAME_TYPE(decltype(v), std::string_view);
         EXPECT_RANGE_EQ(v, urange.substr(0,3));
@@ -156,7 +158,7 @@ TEST(view_take, type_erasure)
     {   // contiguous overload
         std::vector<int> urange{1, 2, 3, 4, 5, 6};
 
-        auto v = seqan3::views::take(urange, 3);
+        auto v = seqan3_views_take(urange, 3);
 
         EXPECT_SAME_TYPE(decltype(v), (std::span<int, std::dynamic_extent>));
         EXPECT_RANGE_EQ(v, (std::vector{1, 2, 3}));
@@ -165,7 +167,7 @@ TEST(view_take, type_erasure)
     {   // contiguous overload
         std::array<int, 6> urange{1, 2, 3, 4, 5, 6};
 
-        auto v = seqan3::views::take(urange, 3);
+        auto v = seqan3_views_take(urange, 3);
 
         EXPECT_SAME_TYPE(decltype(v), (std::span<int, std::dynamic_extent>));
         EXPECT_RANGE_EQ(v, (std::vector{1, 2, 3}));
@@ -174,7 +176,7 @@ TEST(view_take, type_erasure)
     {   // random-access overload
         std::deque<int> urange{1, 2, 3, 4, 5, 6};
 
-        auto v = seqan3::views::take(urange, 3);
+        auto v = seqan3_views_take(urange, 3);
 
         EXPECT_TRUE((std::same_as<decltype(v), std::ranges::subrange<typename std::deque<int>::iterator,
                                                                      typename std::deque<int>::iterator>>));
@@ -184,7 +186,7 @@ TEST(view_take, type_erasure)
     {   // generic overload (bidirectional container)
         std::list<int> urange{1, 2, 3, 4, 5, 6};
 
-        auto v = seqan3::views::take(urange, 3);
+        auto v = seqan3_views_take(urange, 3);
 
         EXPECT_TRUE((std::same_as<decltype(v), seqan3::detail::view_take<std::views::all_t<std::list<int> &>,
                                                                          false, false>>));
@@ -195,7 +197,7 @@ TEST(view_take, type_erasure)
         std::array<int, 6> urange{1, 2, 3, 4, 5, 6};
 
         auto v = urange | std::views::filter([] (int) { return true; });
-        auto v2 = seqan3::views::take(v, 3);
+        auto v2 = seqan3_views_take(v, 3);
 
         EXPECT_SAME_TYPE(decltype(v2), (seqan3::detail::view_take<decltype(v), false, false>));
         EXPECT_RANGE_EQ(v2, (std::vector{1, 2, 3}));
@@ -206,7 +208,7 @@ TEST(view_take, type_erasure)
 
         auto v0 = std::span{urange};
         auto v1 = v0 | std::views::take_while([] (int i) { return i < 6; });
-        auto v2 = seqan3::views::take(v1, 3);
+        auto v2 = seqan3_views_take(v1, 3);
 
         EXPECT_SAME_TYPE(decltype(v2), (seqan3::detail::view_take<decltype(v1), false, false>));
         EXPECT_RANGE_EQ(v2, (std::vector{1, 2, 3}));


### PR DESCRIPTION
Only seqan3::views::take wasn't deprecated, it is now.