### PR TITLE
Borrowed range

### DIFF
--- a/include/seqan3/std/ranges
+++ b/include/seqan3/std/ranges
@@ -64,7 +64,7 @@ inline constexpr bool enable_borrowed_range<::std::ranges::iota_view<W, Bound>> 
 template <class T>
 inline constexpr bool enable_borrowed_range<::std::ranges::ref_view<T>> = true;
 
-// Note: in gcc-10 enable_borrowed_range wasn't defined for the take_view and the other following views.
+// Note: in gcc-10 enable_borrowed_range wasn't defined for the take_view and the other following views. (gcc-10.3 fixed this)
 // Explictly defining this here will have the side-effect that we override the definition of
 // std::ranges::enable_borrowed_range for all those views.
 template <class T>
@@ -132,8 +132,9 @@ inline constexpr bool enable_borrowed_range<T> = true;
 #include <seqan3/std/iterator>
 #include <string_view>
 
-// until range <= 0.11.0 release, std::basic_string_view was not recognised as view or borrowed_range
-#if RANGE_V3_VERSION <= 1100
+// After the range release 0.11.0, std::basic_string_view was not recognised as view or borrowed_range any more for
+// gcc <= 9. Remove this if https://github.com/ericniebler/range-v3/pull/1625 was merged before the next release.
+#if RANGE_V3_VERSION >= 1100
 #if defined(__cpp_lib_string_view) && __cpp_lib_string_view == 201603L
 namespace ranges
 {
@@ -146,7 +147,7 @@ template<class CharT, class Traits>
 inline constexpr bool enable_borrowed_range<std::basic_string_view<CharT, Traits>> = true;
 } // namespace ranges
 #endif // defined(__cpp_lib_string_view) && __cpp_lib_string_view >= 201603L
-#endif // RANGE_V3_VERSION <= 1100
+#endif // RANGE_V3_VERSION >= 1100
 
 // ============================================================================
 //  namespace aliasing

--- a/include/seqan3/std/ranges
+++ b/include/seqan3/std/ranges
@@ -42,11 +42,13 @@
 namespace ranges
 {
 //!\brief std::ranges::views are valid range-v3 views
-template<class T>
-//!\cond
-    requires ::std::derived_from<T, ::std::ranges::view_base>
-//!\endcond
+template<::std::derived_from<::std::ranges::view_base> T>
 inline constexpr bool enable_view<T> = true;
+
+//!\cond
+template<class T>
+inline constexpr bool enable_view<::std::ranges::empty_view<T>> = true;
+//!\endcond
 
 // std::ranges::borrowed_range's are valid range-v3 borrowed_range's
 //!\cond
@@ -61,6 +63,27 @@ inline constexpr bool enable_borrowed_range<::std::ranges::iota_view<W, Bound>> 
 
 template <class T>
 inline constexpr bool enable_borrowed_range<::std::ranges::ref_view<T>> = true;
+
+// note: in gcc-10 enable_borrowed_range wasn't defined for the take_view and the other following views.
+// Explictly defining this here will have the side-effect that we override the definition of
+// std::ranges::enable_borrowed_range for all those views.
+template <class T>
+inline constexpr bool enable_borrowed_range<::std::ranges::take_view<T>> = enable_borrowed_range<T>;
+
+template <class T>
+inline constexpr bool enable_borrowed_range<::std::ranges::drop_view<T>> = enable_borrowed_range<T>;
+
+template <class T, class Pred>
+inline constexpr bool enable_borrowed_range<::std::ranges::drop_while_view<T, Pred>> = enable_borrowed_range<T>;
+
+template <class T>
+inline constexpr bool enable_borrowed_range<::std::ranges::common_view<T>> = enable_borrowed_range<T>;
+
+template <class T>
+inline constexpr bool enable_borrowed_range<::std::ranges::reverse_view<T>> = enable_borrowed_range<T>;
+
+template <class T, size_t N>
+inline constexpr bool enable_borrowed_range<::std::ranges::elements_view<T, N>> = enable_borrowed_range<T>;
 //!\endcond
 
 } // namespace ranges

--- a/include/seqan3/std/ranges
+++ b/include/seqan3/std/ranges
@@ -64,7 +64,7 @@ inline constexpr bool enable_borrowed_range<::std::ranges::iota_view<W, Bound>> 
 template <class T>
 inline constexpr bool enable_borrowed_range<::std::ranges::ref_view<T>> = true;
 
-// note: in gcc-10 enable_borrowed_range wasn't defined for the take_view and the other following views.
+// Note: in gcc-10 enable_borrowed_range wasn't defined for the take_view and the other following views.
 // Explictly defining this here will have the side-effect that we override the definition of
 // std::ranges::enable_borrowed_range for all those views.
 template <class T>

--- a/include/seqan3/std/ranges
+++ b/include/seqan3/std/ranges
@@ -130,6 +130,23 @@ inline constexpr bool enable_borrowed_range<T> = true;
 
 #include <seqan3/std/concepts>
 #include <seqan3/std/iterator>
+#include <string_view>
+
+// until range <= 0.11.0 release, std::basic_string_view was not recognised as view or borrowed_range
+#if RANGE_V3_VERSION <= 1100
+#if defined(__cpp_lib_string_view) && __cpp_lib_string_view == 201603L
+namespace ranges
+{
+template<typename Char, typename Traits>
+    requires true
+inline constexpr bool enable_view<std::basic_string_view<Char, Traits>> = true;
+
+template<class CharT, class Traits>
+    requires true
+inline constexpr bool enable_borrowed_range<std::basic_string_view<CharT, Traits>> = true;
+} // namespace ranges
+#endif // defined(__cpp_lib_string_view) && __cpp_lib_string_view >= 201603L
+#endif // RANGE_V3_VERSION <= 1100
 
 // ============================================================================
 //  namespace aliasing

--- a/test/unit/std/ranges_test.cpp
+++ b/test/unit/std/ranges_test.cpp
@@ -8,9 +8,35 @@
 #include <gtest/gtest.h>
 
 #include <seqan3/std/ranges>
+#include <seqan3/std/span>
 #include <string>
+#include <string_view>
 
 #include <range/v3/view/take.hpp>
+
+TEST(ranges_test, string_view)
+{
+    std::string_view s{};
+    EXPECT_TRUE(std::ranges::borrowed_range<decltype(s)>);
+    EXPECT_TRUE(std::ranges::viewable_range<decltype(s)>);
+    EXPECT_TRUE(std::ranges::view<decltype(s)>);
+
+    EXPECT_TRUE(ranges::cpp20::borrowed_range<decltype(s)>);
+    EXPECT_TRUE(ranges::cpp20::viewable_range<decltype(s)>);
+    EXPECT_TRUE(ranges::cpp20::view<decltype(s)>);
+}
+
+TEST(ranges_test, span)
+{
+    std::span<int> s{};
+    EXPECT_TRUE(std::ranges::borrowed_range<decltype(s)>);
+    EXPECT_TRUE(std::ranges::viewable_range<decltype(s)>);
+    EXPECT_TRUE(std::ranges::view<decltype(s)>);
+
+    EXPECT_TRUE(ranges::cpp20::borrowed_range<decltype(s)>);
+    EXPECT_TRUE(ranges::cpp20::viewable_range<decltype(s)>);
+    EXPECT_TRUE(ranges::cpp20::view<decltype(s)>);
+}
 
 TEST(ranges_test, subrange)
 {

--- a/test/unit/std/ranges_test.cpp
+++ b/test/unit/std/ranges_test.cpp
@@ -12,6 +12,8 @@
 #include <string>
 #include <string_view>
 
+#include <seqan3/test/expect_same_type.hpp>
+
 #include <range/v3/view/take.hpp>
 
 TEST(ranges_test, string_view)
@@ -88,6 +90,17 @@ TEST(ranges_test, ref_view)
 TEST(ranges_test, take_view)
 {
     std::string s{};
+
+#if !SEQAN3_WORKAROUND_GCC_100139
+    EXPECT_SAME_TYPE(decltype(std::views::take(std::span<int>{}, 0)), std::span<int>);
+    EXPECT_SAME_TYPE(decltype(std::views::take(std::string_view{}, 0)), std::string_view);
+    EXPECT_SAME_TYPE(decltype(std::views::take(std::views::empty<int>, 0)), std::ranges::empty_view<int>);
+    EXPECT_SAME_TYPE(decltype(std::views::take(std::views::iota(0, 1), 0)), decltype(std::views::iota(0, 1)));
+
+    EXPECT_SAME_TYPE(decltype(std::views::take(s, 0)),
+                     (std::ranges::subrange<std::string::iterator, std::string::iterator>));
+#endif // !SEQAN3_WORKAROUND_GCC_100139
+
     EXPECT_TRUE(std::ranges::borrowed_range<decltype(std::views::take(s, 0))>);
     EXPECT_TRUE(std::ranges::viewable_range<decltype(std::views::take(s, 0))>);
     EXPECT_TRUE(std::ranges::view<decltype(std::views::take(s, 0))>);
@@ -100,6 +113,17 @@ TEST(ranges_test, take_view)
 TEST(ranges_test, drop_view)
 {
     std::string s{};
+
+#if !SEQAN3_WORKAROUND_GCC_100139
+    EXPECT_SAME_TYPE(decltype(std::views::drop(std::span<int>{}, 0)), std::span<int>);
+    EXPECT_SAME_TYPE(decltype(std::views::drop(std::string_view{}, 0)), std::string_view);
+    EXPECT_SAME_TYPE(decltype(std::views::drop(std::views::empty<int>, 0)), std::ranges::empty_view<int>);
+    EXPECT_SAME_TYPE(decltype(std::views::drop(std::views::iota(0, 1), 0)), decltype(std::views::iota(0, 1)));
+
+    EXPECT_SAME_TYPE(decltype(std::views::drop(s, 0)),
+                     (std::ranges::subrange<std::string::iterator, std::string::iterator>));
+#endif // !SEQAN3_WORKAROUND_GCC_100139
+
     EXPECT_TRUE(std::ranges::borrowed_range<decltype(std::views::drop(s, 0))>);
     EXPECT_TRUE(std::ranges::viewable_range<decltype(std::views::drop(s, 0))>);
     EXPECT_TRUE(std::ranges::view<decltype(std::views::drop(s, 0))>);

--- a/test/unit/std/ranges_test.cpp
+++ b/test/unit/std/ranges_test.cpp
@@ -12,6 +12,114 @@
 
 #include <range/v3/view/take.hpp>
 
+TEST(ranges_test, subrange)
+{
+    std::string s{};
+    std::ranges::subrange<std::string::iterator, std::string::iterator> v{s.begin(), s.end(), 0};
+    EXPECT_TRUE(std::ranges::borrowed_range<decltype(v)>);
+    EXPECT_TRUE(std::ranges::viewable_range<decltype(v)>);
+    EXPECT_TRUE(std::ranges::view<decltype(v)>);
+
+    EXPECT_TRUE(ranges::cpp20::borrowed_range<decltype(v)>);
+    EXPECT_TRUE(ranges::cpp20::viewable_range<decltype(v)>);
+    EXPECT_TRUE(ranges::cpp20::view<decltype(v)>);
+}
+
+TEST(ranges_test, empty_view)
+{
+    EXPECT_TRUE(std::ranges::borrowed_range<std::ranges::empty_view<int>>);
+    EXPECT_TRUE(std::ranges::viewable_range<std::ranges::empty_view<int>>);
+    EXPECT_TRUE(std::ranges::view<std::ranges::empty_view<int>>);
+
+    EXPECT_TRUE(ranges::cpp20::borrowed_range<std::ranges::empty_view<int>>);
+    EXPECT_TRUE(ranges::cpp20::viewable_range<std::ranges::empty_view<int>>);
+    EXPECT_TRUE(ranges::cpp20::view<std::ranges::empty_view<int>>);
+}
+
+TEST(ranges_test, iota_view)
+{
+    EXPECT_TRUE(std::ranges::borrowed_range<decltype(std::views::iota(0))>);
+    EXPECT_TRUE(std::ranges::viewable_range<decltype(std::views::iota(0))>);
+    EXPECT_TRUE(std::ranges::view<decltype(std::views::iota(0))>);
+
+    EXPECT_TRUE(ranges::cpp20::borrowed_range<decltype(std::views::iota(0))>);
+    EXPECT_TRUE(ranges::cpp20::viewable_range<decltype(std::views::iota(0))>);
+    EXPECT_TRUE(ranges::cpp20::view<decltype(std::views::iota(0))>);
+}
+
+TEST(ranges_test, ref_view)
+{
+    std::string s{};
+    EXPECT_TRUE(std::ranges::borrowed_range<decltype(std::views::all(s))>);
+    EXPECT_TRUE(std::ranges::viewable_range<decltype(std::views::all(s))>);
+    EXPECT_TRUE(std::ranges::view<decltype(std::views::all(s))>);
+
+    EXPECT_TRUE(ranges::cpp20::borrowed_range<decltype(std::views::all(s))>);
+    EXPECT_TRUE(ranges::cpp20::viewable_range<decltype(std::views::all(s))>);
+    EXPECT_TRUE(ranges::cpp20::view<decltype(std::views::all(s))>);
+}
+
+TEST(ranges_test, take_view)
+{
+    std::string s{};
+    EXPECT_TRUE(std::ranges::borrowed_range<decltype(std::views::take(s, 0))>);
+    EXPECT_TRUE(std::ranges::viewable_range<decltype(std::views::take(s, 0))>);
+    EXPECT_TRUE(std::ranges::view<decltype(std::views::take(s, 0))>);
+
+    EXPECT_TRUE(ranges::cpp20::borrowed_range<decltype(std::views::take(s, 0))>);
+    EXPECT_TRUE(ranges::cpp20::viewable_range<decltype(std::views::take(s, 0))>);
+    EXPECT_TRUE(ranges::cpp20::view<decltype(std::views::take(s, 0))>);
+}
+
+TEST(ranges_test, drop_view)
+{
+    std::string s{};
+    EXPECT_TRUE(std::ranges::borrowed_range<decltype(std::views::drop(s, 0))>);
+    EXPECT_TRUE(std::ranges::viewable_range<decltype(std::views::drop(s, 0))>);
+    EXPECT_TRUE(std::ranges::view<decltype(std::views::drop(s, 0))>);
+
+    EXPECT_TRUE(ranges::cpp20::borrowed_range<decltype(std::views::drop(s, 0))>);
+    EXPECT_TRUE(ranges::cpp20::viewable_range<decltype(std::views::drop(s, 0))>);
+    EXPECT_TRUE(ranges::cpp20::view<decltype(std::views::drop(s, 0))>);
+}
+
+TEST(ranges_test, filter_view)
+{
+    std::string s{};
+    auto lambda = [](auto &&) { return true; };
+    EXPECT_FALSE(std::ranges::borrowed_range<decltype(std::views::filter(s, lambda))>);
+    EXPECT_TRUE(std::ranges::viewable_range<decltype(std::views::filter(s, lambda))>);
+    EXPECT_TRUE(std::ranges::view<decltype(std::views::filter(s, lambda))>);
+
+    EXPECT_FALSE(ranges::cpp20::borrowed_range<decltype(std::views::filter(s, lambda))>);
+    EXPECT_TRUE(ranges::cpp20::viewable_range<decltype(std::views::filter(s, lambda))>);
+    EXPECT_TRUE(ranges::cpp20::view<decltype(std::views::filter(s, lambda))>);
+}
+
+TEST(ranges_test, common_view)
+{
+    std::string s{};
+    EXPECT_TRUE(std::ranges::borrowed_range<decltype(std::views::common(s))>);
+    EXPECT_TRUE(std::ranges::viewable_range<decltype(std::views::common(s))>);
+    EXPECT_TRUE(std::ranges::view<decltype(std::views::common(s))>);
+
+    EXPECT_TRUE(ranges::cpp20::borrowed_range<decltype(std::views::common(s))>);
+    EXPECT_TRUE(ranges::cpp20::viewable_range<decltype(std::views::common(s))>);
+    EXPECT_TRUE(ranges::cpp20::view<decltype(std::views::common(s))>);
+}
+
+TEST(ranges_test, reverse_view)
+{
+    std::string s{};
+    EXPECT_TRUE(std::ranges::borrowed_range<decltype(std::views::reverse(s))>);
+    EXPECT_TRUE(std::ranges::viewable_range<decltype(std::views::reverse(s))>);
+    EXPECT_TRUE(std::ranges::view<decltype(std::views::reverse(s))>);
+
+    EXPECT_TRUE(ranges::cpp20::borrowed_range<decltype(std::views::reverse(s))>);
+    EXPECT_TRUE(ranges::cpp20::viewable_range<decltype(std::views::reverse(s))>);
+    EXPECT_TRUE(ranges::cpp20::view<decltype(std::views::reverse(s))>);
+}
+
 TEST(ranges_test, combine_std_with_range_v3)
 {
     std::string str{"foo"};


### PR DESCRIPTION
https://eel.is/c++draft/ranges.syn defines more views to be `std::ranges::borrowed_range`s.

This PR adds all of them.

Doing this showed that std::views::take isn't a borrowed range in gcc-10, this PR will define that property also for gcc-10.

gcc-10.3 does this anyway.