### PR TITLE
[INFRA] Ignore apt failures

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -41,6 +41,7 @@ jobs:
           path: seqan3/submodules/seqan
 
       - name: Configure APT
+        continue-on-error: true
         run: bash ./seqan3/.github/workflows/scripts/configure_apt.sh
 
       - name: Install CMake

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -92,6 +92,7 @@ jobs:
           path: seqan3/submodules/seqan
 
       - name: Configure APT
+        continue-on-error: true
         run: bash ./seqan3/.github/workflows/scripts/configure_apt.sh
 
       - name: Install CMake

--- a/.github/workflows/ci_misc.yml
+++ b/.github/workflows/ci_misc.yml
@@ -124,6 +124,7 @@ jobs:
           path: seqan3/submodules/seqan
 
       - name: Configure APT
+        continue-on-error: true
         run: bash ./seqan3/.github/workflows/scripts/configure_apt.sh
 
       - name: Install CMake

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Configure APT
+        continue-on-error: true
         run: bash .github/workflows/scripts/configure_apt.sh
 
       - name: Install CMake

--- a/.github/workflows/latest_libraries.yml
+++ b/.github/workflows/latest_libraries.yml
@@ -61,6 +61,7 @@ jobs:
           path: seqan3/submodules/seqan
 
       - name: Configure APT
+        continue-on-error: true
         run: bash ./seqan3/.github/workflows/scripts/configure_apt.sh
 
       - name: Install CMake


### PR DESCRIPTION
This should be cherry-picked into master afterwards

:( 

```
Reading package lists...
E: Failed to fetch https://packages.microsoft.com/ubuntu/20.04/prod/dists/focal/main/binary-amd64/Packages.bz2  File has unexpected size (73402 != 73160). Mirror sync in progress? [IP: 40.74.238.15 443]
   Hashes of expected file:
    - Filesize:73160 [weak]
    - SHA512:782bf0315c8de4314049e599009430053b75a5015491b3d383b09239fcf31857d52bac3399cef8e813f7b2131dce09b03eaf89d79c5ebd2849402cee7aa9d228
    - SHA256:dbf4bf81b4a0a17dae53f2aff3edd4cf5bb1dcd5dcd216ce5c5c8ab7c507a26a
    - SHA1:0e1b47276cae4168a08d8fd981891d4773f053b9 [weak]
    - MD5Sum:0fcf3ed335cd4efde65300bb48c05afe [weak]
   Release file created at: Sat, 15 May 2021 00:38:08 +0000
E: Some index files failed to download. They have been ignored, or old ones used instead.
Error: Process completed with exit code 100.
```