### PR TITLE
-DSEQAN3_REMOVE_DEPRECATED_310

### DIFF
--- a/include/seqan3/alignment/decorator/gap_decorator.hpp
+++ b/include/seqan3/alignment/decorator/gap_decorator.hpp
@@ -136,8 +136,10 @@ public:
      */
     using unaligned_sequence_type = inner_type;
 
+#ifdef SEQAN3_DEPRECATED_310
     //!\deprecated Please use seqan3::gap_decorator::unaligned_sequence_type instead.
     using unaligned_seq_type SEQAN3_DEPRECATED_310 = unaligned_sequence_type;
+#endif // SEQAN3_DEPRECATED_310
 
     /*!\name Constructors, destructor and assignment
      * \{

--- a/include/seqan3/alignment/scoring/aminoacid_scoring_scheme.hpp
+++ b/include/seqan3/alignment/scoring/aminoacid_scoring_scheme.hpp
@@ -56,11 +56,13 @@ enum class aminoacid_similarity_matrix
      */
     blosum80,
 
+#ifdef SEQAN3_DEPRECATED_310
     // deprecated uppercase:
     BLOSUM30 SEQAN3_DEPRECATED_310 = blosum30, //!< Please use the field name in lower case.
     BLOSUM45 SEQAN3_DEPRECATED_310 = blosum45, //!< Please use the field name in lower case.
     BLOSUM62 SEQAN3_DEPRECATED_310 = blosum62, //!< Please use the field name in lower case.
     BLOSUM80 SEQAN3_DEPRECATED_310 = blosum80 //!< Please use the field name in lower case.
+#endif // SEQAN3_DEPRECATED_310
 };
 
 /*!\brief A data structure for managing and computing the score of two amino acids.

--- a/include/seqan3/alphabet/aminoacid/translation.hpp
+++ b/include/seqan3/alphabet/aminoacid/translation.hpp
@@ -78,6 +78,7 @@ constexpr aa27 translate_triplet(nucl_type const & n1, nucl_type const & n2, nuc
     }
 }
 
+#ifdef SEQAN3_DEPRECATED_310
 /*!\brief Translate one nucleotide triplet into single amino acid (tuple interface).
  * \ingroup aminoacid
  * \tparam tuple_type Type of `input_tuple`. Usually std::tuple, but similar types like std::array
@@ -176,5 +177,6 @@ constexpr aa27 translate_triplet SEQAN3_DEPRECATED_310 (rng_t && input_range)
 
     return translate_triplet(input_range[0], input_range[1], input_range[2]);
 }
+#endif // SEQAN3_DEPRECATED_310
 
 } // namespace seqan3

--- a/include/seqan3/alphabet/aminoacid/translation_genetic_code.hpp
+++ b/include/seqan3/alphabet/aminoacid/translation_genetic_code.hpp
@@ -27,7 +27,9 @@ namespace seqan3
 enum struct genetic_code : uint8_t
 {
     canonical = 1, //!< [The Standard Code](https://www.ncbi.nlm.nih.gov/Taxonomy/Utils/wprintgc.cgi#SG1).
+#ifdef SEQAN3_DEPRECATED_310
     CANONICAL SEQAN3_DEPRECATED_310 = canonical, //!< \deprecated Use seqan3::genetic_code::canonical instead.
+#endif // SEQAN3_DEPRECATED_310
 //     vert_mitochondrial,
 //     yeast_mitochondrial,
 //     mold_mitochondrial,

--- a/include/seqan3/alphabet/cigar/cigar.hpp
+++ b/include/seqan3/alphabet/cigar/cigar.hpp
@@ -240,11 +240,13 @@ inline cigar::operation operator""_cigar_operation(char const c) noexcept
     return cigar::operation{}.assign_char(c);
 }
 
+#ifdef SEQAN3_DEPRECATED_310
 //!\deprecated Please use seqan3::""_cigar_operation instead.
 SEQAN3_DEPRECATED_310 inline cigar::operation operator""_cigar_op(char const c) noexcept
 {
     return cigar::operation{}.assign_char(c);
 }
+#endif // SEQAN3_DEPRECATED_310
 //!\}
 
 } // inline namespace literals

--- a/include/seqan3/alphabet/container/concatenated_sequences.hpp
+++ b/include/seqan3/alphabet/container/concatenated_sequences.hpp
@@ -795,6 +795,7 @@ public:
         return {std::as_const(data_values), std::as_const(data_delimiters)};
     }
 
+#ifdef SEQAN3_DEPRECATED_310
     //!\copydoc raw_data()
     //!\deprecated Use raw_data() instead.
     SEQAN3_DEPRECATED_310 std::pair<decltype(data_values) &, decltype(data_delimiters) &> data()
@@ -808,6 +809,7 @@ public:
     {
         return raw_data();
     }
+#endif // SEQAN3_DEPRECATED_310
     //!\}
 
     /*!\name Capacity

--- a/include/seqan3/alphabet/mask/mask.hpp
+++ b/include/seqan3/alphabet/mask/mask.hpp
@@ -60,6 +60,7 @@ public:
      * \details Similar to an Enum interface.
      */
     //!\{
+#ifdef SEQAN3_DEPRECATED_310
     /*!\brief Member for unmasked.
      * \details
      * \deprecated Please use seqan3::mask::unmasked
@@ -71,6 +72,7 @@ public:
      * \deprecated Please use seqan3::mask::masked
      */
     SEQAN3_DEPRECATED_310 static const mask MASKED;
+#endif // SEQAN3_DEPRECATED_310
 
     /*!\brief Member for unmasked.
      * \details
@@ -86,8 +88,10 @@ public:
     //!\}
 };
 
+#ifdef SEQAN3_DEPRECATED_310
 mask constexpr mask::UNMASKED{mask{}.assign_rank(0)};
 mask constexpr mask::MASKED{mask{}.assign_rank(1)};
+#endif // SEQAN3_DEPRECATED_310
 mask constexpr mask::unmasked{mask{}.assign_rank(0)};
 mask constexpr mask::masked{mask{}.assign_rank(1)};
 } // namespace seqan3

--- a/include/seqan3/alphabet/nucleotide/dna16sam.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna16sam.hpp
@@ -172,11 +172,13 @@ private:
  */
 using dna16sam_vector = std::vector<dna16sam>;
 
+#ifdef SEQAN3_DEPRECATED_310
 //!\deprecated Please use seqan3::dna16sam instead.
 using sam_dna16 SEQAN3_DEPRECATED_310 = seqan3::dna16sam;
 
 //!\deprecated Please use seqan3::dna16sam_vector instead.
 using sam_dna16_vector SEQAN3_DEPRECATED_310 = dna16sam_vector;
+#endif // SEQAN3_DEPRECATED_310
 
 // ------------------------------------------------------------------
 // literals
@@ -225,6 +227,7 @@ inline dna16sam_vector operator""_dna16sam(char const * s, size_t n)
     return r;
 }
 
+#ifdef SEQAN3_DEPRECATED_310
 //!\deprecated Please use seqan3::operator""_dna16sam instead.
 SEQAN3_DEPRECATED_310 constexpr dna16sam operator""_sam_dna16(char const c) noexcept
 {
@@ -236,6 +239,7 @@ SEQAN3_DEPRECATED_310 inline dna16sam_vector operator""_sam_dna16(char const * s
 {
     return seqan3::operator""_dna16sam(s, n);
 }
+#endif // SEQAN3_DEPRECATED_310
 //!\}
 
 } // inline namespace literals

--- a/include/seqan3/alphabet/quality/phred42.hpp
+++ b/include/seqan3/alphabet/quality/phred42.hpp
@@ -66,6 +66,7 @@ public:
     constexpr phred42 & operator=(phred42 &&)       noexcept = default; //!< Defaulted.
     ~phred42()                                      noexcept = default; //!< Defaulted.
 
+#ifdef SEQAN3_DEPRECATED_310
     /*!\brief Allow construction from the Phred score value.
      * \details
      * \deprecated This will be removed in 3.1.0. Please use seqan3::phred42::assign_phred() or '!'_phred42.
@@ -74,6 +75,7 @@ public:
     {
         assign_phred(p);
     }
+#endif // SEQAN3_DEPRECATED_310
 
     // Inherit converting constructor
     using base_t::base_t;

--- a/include/seqan3/alphabet/quality/phred63.hpp
+++ b/include/seqan3/alphabet/quality/phred63.hpp
@@ -66,6 +66,7 @@ public:
     constexpr phred63 & operator=(phred63 &&)       noexcept = default; //!< Defaulted.
     ~phred63()                                      noexcept = default; //!< Defaulted.
 
+#ifdef SEQAN3_DEPRECATED_310
     /*!\brief Allow construction from the Phred score value.
      * \details
      * \deprecated This will be removed in 3.1.0. Please use seqan3::phred63::assign_phred() or '!'_phred63.
@@ -74,6 +75,7 @@ public:
     {
         assign_phred(p);
     }
+#endif // SEQAN3_DEPRECATED_310
 
     // Inherit converting constructor
     using base_t::base_t;

--- a/include/seqan3/alphabet/quality/phred68solexa.hpp
+++ b/include/seqan3/alphabet/quality/phred68solexa.hpp
@@ -59,6 +59,7 @@ public:
     constexpr phred68solexa & operator=(phred68solexa &&)       noexcept = default; //!< Defaulted.
     ~phred68solexa()                                            noexcept = default; //!< Defaulted.
 
+#ifdef SEQAN3_DEPRECATED_310
     /*!\brief Allow construction from the Phred score value.
      * \details
      * \deprecated This will be removed in 3.1.0. Please use seqan3::phred68solexa::assign_phred() or '!'_phred68solexa.
@@ -67,6 +68,7 @@ public:
     {
         assign_phred(p);
     }
+#endif // SEQAN3_DEPRECATED_310
 
     // Inherit converting constructor
     using base_t::base_t;
@@ -89,8 +91,10 @@ public:
     //!\}
 };
 
+#ifdef SEQAN3_DEPRECATED_310
 //!\deprecated Please use seqan3::phred68solexa instead.
 using phred68legacy SEQAN3_DEPRECATED_310 = seqan3::phred68solexa;
+#endif // SEQAN3_DEPRECATED_310
 
 inline namespace literals
 {
@@ -135,6 +139,7 @@ inline std::vector<phred68solexa> operator""_phred68solexa(char const * s, std::
     return r;
 }
 
+#ifdef SEQAN3_DEPRECATED_310
 //!\deprecated Please use seqan3::operator""_phred68solexa instead.
 SEQAN3_DEPRECATED_310 constexpr phred68solexa operator""_phred68legacy(char const c) noexcept
 {
@@ -146,6 +151,7 @@ SEQAN3_DEPRECATED_310 inline std::vector<phred68solexa> operator""_phred68legacy
 {
     return seqan3::operator""_phred68solexa(s, n);
 }
+#endif // SEQAN3_DEPRECATED_310
 //!\}
 
 } // inline namespace literals

--- a/include/seqan3/alphabet/quality/phred94.hpp
+++ b/include/seqan3/alphabet/quality/phred94.hpp
@@ -63,6 +63,7 @@ public:
     constexpr phred94 & operator=(phred94 &&)       noexcept = default; //!< Defaulted.
     ~phred94()                                      noexcept = default; //!< Defaulted.
 
+#ifdef SEQAN3_DEPRECATED_310
     /*!\brief Allow construction from the Phred score value.
      * \details
      * \deprecated This will be removed in 3.1.0. Please use seqan3::phred94::assign_phred() or '!'_phred94.
@@ -71,6 +72,7 @@ public:
     {
         assign_phred(p);
     }
+#endif // SEQAN3_DEPRECATED_310
 
     // Inherit converting constructor
     using base_t::base_t;

--- a/include/seqan3/alphabet/quality/phred_base.hpp
+++ b/include/seqan3/alphabet/quality/phred_base.hpp
@@ -57,6 +57,7 @@ private:
     constexpr phred_base & operator=(phred_base &&)         noexcept = default; //!< Defaulted.
     ~phred_base()                                           noexcept = default; //!< Defaulted.
 
+#ifdef SEQAN3_DEPRECATED_310
     /*!\brief Allow construction from the Phred score value.
      * \details
      * \deprecated This will be removed in 3.1.0. Please use, e.g., seqan3::phred42{}.assign_phred(p) or '!'_phred42.
@@ -66,6 +67,7 @@ private:
         static_cast<derived_type *>(this)->assign_phred(p);
     }
     //!\}
+#endif // SEQAN3_DEPRECATED_310
 
     //!\brief Befriend the derived_type so it can instantiate.
     friend derived_type;

--- a/include/seqan3/alphabet/views/translate.hpp
+++ b/include/seqan3/alphabet/views/translate.hpp
@@ -79,6 +79,7 @@ enum class translation_frames : uint8_t
     reverse_frames = reverse_frame0 | reverse_frame1 | reverse_frame2, //!< All reverse frames
     six_frames = forward_frames | reverse_frames, //!< All frames
 
+#ifdef SEQAN3_DEPRECATED_310
     FWD_FRAME_0 SEQAN3_DEPRECATED_310 = forward_frame0, //!< \deprecated Use forward_frame0 instead.
     FWD_FRAME_1 SEQAN3_DEPRECATED_310 = forward_frame1, //!< \deprecated Use forward_frame1 instead.
     FWD_FRAME_2 SEQAN3_DEPRECATED_310 = forward_frame2, //!< \deprecated Use forward_frame2 instead.
@@ -91,6 +92,7 @@ enum class translation_frames : uint8_t
     FWD SEQAN3_DEPRECATED_310 = forward_frames, //!< \deprecated Use forward_frames instead.
     REV SEQAN3_DEPRECATED_310 = reverse_frames, //!< \deprecated Use reverse_frames instead.
     SIX_FRAME SEQAN3_DEPRECATED_310 = six_frames //!< \deprecated Use six_frames instead.
+#endif // SEQAN3_DEPRECATED_310
 };
 
 //!\cond DEV

--- a/include/seqan3/argument_parser/auxiliary.hpp
+++ b/include/seqan3/argument_parser/auxiliary.hpp
@@ -258,10 +258,12 @@ enum option_spec
                    * (e.g. "A tool for mapping reads to the genome").
                    */
 
+#ifdef SEQAN3_DEPRECATED_310
     DEFAULT SEQAN3_DEPRECATED_310  = standard, //!< \deprecated Use seqan3::option_spec::standard instead.
     REQUIRED SEQAN3_DEPRECATED_310 = required, //!< \deprecated Use seqan3::option_spec::required instead.
     ADVANCED SEQAN3_DEPRECATED_310 = advanced, //!< \deprecated Use seqan3::option_spec::advanced instead.
     HIDDEN SEQAN3_DEPRECATED_310   = hidden,   //!< \deprecated Use seqan3::option_spec::hidden instead.
+#endif // SEQAN3_DEPRECATED_310
 };
 
 //!\brief Indicates whether application allows automatic update notifications by the seqan3::argument_parser.

--- a/include/seqan3/argument_parser/exceptions.hpp
+++ b/include/seqan3/argument_parser/exceptions.hpp
@@ -19,6 +19,7 @@
 namespace seqan3
 {
 
+#ifdef SEQAN3_DEPRECATED_310
 //!\brief This class is deprecated.
 //!\deprecated Use seqan3::argument_parser_error instead.
 class SEQAN3_DEPRECATED_310 parser_invalid_argument : public std::invalid_argument
@@ -29,6 +30,7 @@ public:
      */
     parser_invalid_argument(std::string const & s) : std::invalid_argument(s) {}
 };
+#endif // SEQAN3_DEPRECATED_310
 
 /*!\brief Argument parser exception that is thrown whenever there is an error
  * while parsing the command line arguments.
@@ -104,6 +106,7 @@ public:
     option_declared_multiple_times(std::string const & s) : argument_parser_error(s) {}
 };
 
+#ifdef SEQAN3_DEPRECATED_310
 //!\brief This class is deprecated.
 //!\deprecated Use seqan3::user_input_error instead.
 class SEQAN3_DEPRECATED_310 type_conversion_failed : public parser_invalid_argument
@@ -125,6 +128,7 @@ public:
      */
     overflow_error_on_conversion(std::string const & s) : parser_invalid_argument(s) {}
 };
+#endif // SEQAN3_DEPRECATED_310
 
 //!\brief Argument parser exception thrown when an incorrect argument is given as (positional) option value.
 class user_input_error : public argument_parser_error
@@ -146,6 +150,7 @@ public:
     validation_error(std::string const & s) : argument_parser_error(s) {}
 };
 
+#ifdef SEQAN3_DEPRECATED_310
 //!\brief This class is deprecated.
 //!\deprecated Use seqan3::validation_error instead.
 class SEQAN3_DEPRECATED_310 validation_failed : public argument_parser_error
@@ -156,6 +161,7 @@ public:
      */
     validation_failed(std::string const & s) : argument_parser_error(s) {}
 };
+#endif // SEQAN3_DEPRECATED_310
 
 /*!\brief Argument parser exception that is thrown whenever there is an design
  * error directed at the developer of the application (e.g. Reuse of option).
@@ -176,6 +182,7 @@ public:
     design_error(std::string const & s) : argument_parser_error(s) {}
 };
 
+#ifdef SEQAN3_DEPRECATED_310
 //!\brief This class is deprecated.
 //!\deprecated Use seqan3::design_error instead.
 class SEQAN3_DEPRECATED_310 parser_design_error : std::logic_error
@@ -186,5 +193,6 @@ public:
      */
     parser_design_error(std::string const & s) : std::logic_error(s) {}
 };
+#endif // SEQAN3_DEPRECATED_310
 
 } // namespace seqan3

--- a/include/seqan3/core/detail/iterator_traits.hpp
+++ b/include/seqan3/core/detail/iterator_traits.hpp
@@ -16,7 +16,9 @@
 #include <type_traits>
 
 #include <seqan3/core/platform.hpp>
+#ifdef SEQAN3_DEPRECATED_310
 #include <seqan3/utility/type_traits/pre.hpp>
+#endif // SEQAN3_DEPRECATED_310
 
 namespace seqan3
 {

--- a/include/seqan3/core/platform.hpp
+++ b/include/seqan3/core/platform.hpp
@@ -197,12 +197,14 @@
 #endif
 
 //!\brief Deprecation message for SeqAn 3.1.0 release.
-#ifndef SEQAN3_DEPRECATED_310
-#   ifndef SEQAN3_DISABLE_DEPRECATED_WARNINGS
-#       define SEQAN3_DEPRECATED_310 [[deprecated("This will be removed in SeqAn-3.1.0; please see the documentation.")]]
-#   else
-#       define SEQAN3_DEPRECATED_310 /**/
-#   endif
+#ifndef SEQAN3_REMOVE_DEPRECATED_310
+#    ifndef SEQAN3_DEPRECATED_310
+#       ifndef SEQAN3_DISABLE_DEPRECATED_WARNINGS
+#           define SEQAN3_DEPRECATED_310 [[deprecated("This will be removed in SeqAn-3.1.0; please see the documentation.")]]
+#       else
+#           define SEQAN3_DEPRECATED_310 /**/
+#       endif
+#    endif
 #endif
 
 //!\brief Deprecation message for deprecated header.

--- a/include/seqan3/core/range/type_traits.hpp
+++ b/include/seqan3/core/range/type_traits.hpp
@@ -19,7 +19,9 @@
 #include <seqan3/core/detail/iterator_traits.hpp>
 #include <seqan3/core/platform.hpp>
 #include <seqan3/utility/type_traits/basic.hpp>
+#ifdef SEQAN3_DEPRECATED_310
 #include <seqan3/utility/type_traits/pre.hpp>
+#endif // SEQAN3_DEPRECATED_310
 
 // TODO(h-2): add innermost_reference instead of or addition to range_innermost_value?
 

--- a/include/seqan3/io/record.hpp
+++ b/include/seqan3/io/record.hpp
@@ -65,7 +65,9 @@ enum class field
     seq,            //!< The "sequence", usually a range of nucleotides or amino acids.
     id,             //!< The identifier, usually a string.
     qual,           //!< The qualities, usually in Phred score notation.
+#ifdef SEQAN3_DEPRECATED_310
     _seq_qual_deprecated, //!< [DEPRECATED] Sequence and qualities combined in one range. Use field::seq and field::qual instead.
+#endif // SEQAN3_DEPRECATED_310
 
     offset,         //!< Sequence (seqan3::field::seq) relative start position (0-based), unsigned value.
 
@@ -106,6 +108,7 @@ enum class field
     user_defined_8, //!< Identifier for user defined file formats and specialisations.
     user_defined_9, //!< Identifier for user defined file formats and specialisations.
 
+#ifdef SEQAN3_DEPRECATED_310
     // deprecated lowercase:
     seq_qual SEQAN3_DEPRECATED_310 = _seq_qual_deprecated, //!< [DEPRECATED] Sequence and qualities combined in one range. Use field::seq and field::qual instead.
 
@@ -144,6 +147,7 @@ enum class field
     USER_DEFINED_7 SEQAN3_DEPRECATED_310 = user_defined_7, //!< Please use the field name in lower case.
     USER_DEFINED_8 SEQAN3_DEPRECATED_310 = user_defined_8, //!< Please use the field name in lower case.
     USER_DEFINED_9 SEQAN3_DEPRECATED_310 = user_defined_9, //!< Please use the field name in lower case.
+#endif // SEQAN3_DEPRECATED_310
 };
 
 // ----------------------------------------------------------------------------
@@ -335,6 +339,7 @@ struct tuple_element<elem_no, seqan3::record<field_types, field_ids>>
 
 } // namespace std
 
+#ifdef SEQAN3_DEPRECATED_310
 namespace seqan3
 {
 
@@ -384,3 +389,4 @@ SEQAN3_DEPRECATED_310 auto const && get(record<field_types, field_ids> const && 
 //!\}
 
 } // namespace seqan3
+#endif // SEQAN3_DEPRECATED_310

--- a/include/seqan3/io/sam_file/format_sam.hpp
+++ b/include/seqan3/io/sam_file/format_sam.hpp
@@ -145,6 +145,7 @@ public:
     };
 
 protected:
+#ifdef SEQAN3_DEPRECATED_310
     template <typename stream_type,     // constraints checked by file
               typename seq_legal_alph_type, bool seq_qual_combined,
               typename seq_type,        // other constraints checked inside function
@@ -155,6 +156,18 @@ protected:
                               seq_type & sequence,
                               id_type & id,
                               qual_type & qualities);
+#else // ^^^ before seqan 3.1 / after seqan 3.1 vvv
+    template <typename stream_type,     // constraints checked by file
+              typename seq_legal_alph_type,
+              typename seq_type,        // other constraints checked inside function
+              typename id_type,
+              typename qual_type>
+    void read_sequence_record(stream_type & stream,
+                              sequence_file_input_options<seq_legal_alph_type> const & options,
+                              seq_type & sequence,
+                              id_type & id,
+                              qual_type & qualities);
+#endif // SEQAN3_DEPRECATED_310
 
     template <typename stream_type,     // constraints checked by file
               typename seq_type,        // other constraints checked inside function
@@ -287,6 +300,7 @@ private:
 };
 
 //!\copydoc sequence_file_input_format::read_sequence_record
+#ifdef SEQAN3_DEPRECATED_310
 template <typename stream_type,     // constraints checked by file
           typename seq_legal_alph_type, bool seq_qual_combined,
           typename seq_type,        // other constraints checked inside function
@@ -297,9 +311,22 @@ inline void format_sam::read_sequence_record(stream_type & stream,
                                              seq_type & sequence,
                                              id_type & id,
                                              qual_type & qualities)
+#else // ^^^ before seqan 3.1 / after seqan 3.1 vvv
+template <typename stream_type,     // constraints checked by file
+          typename seq_legal_alph_type,
+          typename seq_type,        // other constraints checked inside function
+          typename id_type,
+          typename qual_type>
+inline void format_sam::read_sequence_record(stream_type & stream,
+                                             sequence_file_input_options<seq_legal_alph_type> const & options,
+                                             seq_type & sequence,
+                                             id_type & id,
+                                             qual_type & qualities)
+#endif // SEQAN3_DEPRECATED_310
 {
     sam_file_input_options<seq_legal_alph_type> align_options;
 
+#ifdef SEQAN3_DEPRECATED_310
     if constexpr (seq_qual_combined)
     {
         tmp_qual.clear();
@@ -311,6 +338,7 @@ inline void format_sam::read_sequence_record(stream_type & stream,
             get<1>(*dit).assign_char(*sit);
     }
     else
+#endif // SEQAN3_DEPRECATED_310
     {
         read_alignment_record(stream, align_options, std::ignore, default_header, sequence, qualities, id,
                               std::ignore, std::ignore, std::ignore, std::ignore, std::ignore, std::ignore,

--- a/include/seqan3/io/sam_file/input.hpp
+++ b/include/seqan3/io/sam_file/input.hpp
@@ -432,10 +432,12 @@ public:
     using cigar_type               = std::vector<cigar>;
     //!\brief The type of field::mate is fixed to std::tuple<ref_id_type, ref_offset_type, int32_t>).
     using mate_type                = std::tuple<ref_id_type, ref_offset_type, int32_t>;
+#ifdef SEQAN3_DEPRECATED_310
     //!\brief The type of field::evalue is fixed to double.
     using e_value_type             = double;
     //!\brief The type of field::bitscore is fixed to double.
     using bitscore_type            = double;
+#endif // SEQAN3_DEPRECATED_310
     //!\brief The type of field::header_ptr (default: sam_file_header<typename traits_type::ref_ids>).
     using header_type              = sam_file_header<typename traits_type::ref_ids>;
 
@@ -456,7 +458,9 @@ public:
     using field_types = type_list<sequence_type,
                                   id_type,
                                   offset_type,
+#ifdef SEQAN3_DEPRECATED_310
                                   ref_sequence_type,
+#endif // SEQAN3_DEPRECATED_310
                                   ref_id_type,
                                   ref_offset_type,
                                   alignment_type,
@@ -466,8 +470,10 @@ public:
                                   flag_type,
                                   mate_type,
                                   sam_tag_dictionary,
+#ifdef SEQAN3_DEPRECATED_310
                                   e_value_type,
                                   bitscore_type,
+#endif // SEQAN3_DEPRECATED_310
                                   header_type *>;
 
     /*!\brief The subset of seqan3::field tags valid for this file; order corresponds to the types in \ref field_types.

--- a/include/seqan3/io/sequence_file/format_embl.hpp
+++ b/include/seqan3/io/sequence_file/format_embl.hpp
@@ -92,6 +92,7 @@ public:
 
 protected:
     //!\copydoc sequence_file_input_format::read_sequence_record
+#ifdef SEQAN3_DEPRECATED_310
     template <typename stream_type,     // constraints checked by file
               typename seq_legal_alph_type, bool seq_qual_combined,
               typename seq_type,        // other constraints checked inside function
@@ -102,6 +103,18 @@ protected:
                               seq_type    & sequence,
                               id_type     & id,
                               qual_type   & SEQAN3_DOXYGEN_ONLY(qualities))
+#else // ^^^ before seqan 3.1 / after seqan 3.1 vvv
+    template <typename stream_type,     // constraints checked by file
+              typename seq_legal_alph_type,
+              typename seq_type,        // other constraints checked inside function
+              typename id_type,
+              typename qual_type>
+    void read_sequence_record(stream_type & stream,
+                              sequence_file_input_options<seq_legal_alph_type> const & options,
+                              seq_type    & sequence,
+                              id_type     & id,
+                              qual_type   & SEQAN3_DOXYGEN_ONLY(qualities))
+#endif // SEQAN3_DEPRECATED_310
     {
         auto stream_view = detail::istreambuf(stream);
         auto stream_it = std::ranges::begin(stream_view);

--- a/include/seqan3/io/sequence_file/format_fasta.hpp
+++ b/include/seqan3/io/sequence_file/format_fasta.hpp
@@ -106,6 +106,7 @@ public:
 
 protected:
     //!\copydoc sequence_file_input_format::read_sequence_record
+#ifdef SEQAN3_DEPRECATED_310
     template <typename stream_type,     // constraints checked by file
               typename legal_alph_type, bool seq_qual_combined,
               typename seq_type,        // other constraints checked inside function
@@ -116,6 +117,18 @@ protected:
                               seq_type & sequence,
                               id_type & id,
                               qual_type & SEQAN3_DOXYGEN_ONLY(qualities))
+#else // ^^^ before seqan 3.1 / after seqan 3.1 vvv
+    template <typename stream_type,     // constraints checked by file
+              typename legal_alph_type,
+              typename seq_type,        // other constraints checked inside function
+              typename id_type,
+              typename qual_type>
+    void read_sequence_record(stream_type & stream,
+                              sequence_file_input_options<legal_alph_type> const & options,
+                              seq_type & sequence,
+                              id_type & id,
+                              qual_type & SEQAN3_DOXYGEN_ONLY(qualities))
+#endif // SEQAN3_DEPRECATED_310
     {
         auto stream_view = detail::istreambuf(stream);
 
@@ -169,12 +182,21 @@ protected:
 private:
     //!\privatesection
     //!\brief Implementation of reading the ID.
+#ifdef SEQAN3_DEPRECATED_310
     template <typename stream_view_t,
               typename seq_legal_alph_type, bool seq_qual_combined,
               typename id_type>
     void read_id(stream_view_t & stream_view,
                   sequence_file_input_options<seq_legal_alph_type, seq_qual_combined> const & options,
                   id_type & id)
+#else // ^^^ before seqan 3.1 / after seqan 3.1 vvv
+    template <typename stream_view_t,
+              typename seq_legal_alph_type,
+              typename id_type>
+    void read_id(stream_view_t & stream_view,
+                  sequence_file_input_options<seq_legal_alph_type> const & options,
+                  id_type & id)
+#endif // SEQAN3_DEPRECATED_310
     {
         auto const is_id = is_char<'>'> || is_char<';'>;
 
@@ -260,12 +282,21 @@ private:
     }
 
     //!\brief Implementation of reading the sequence.
+#ifdef SEQAN3_DEPRECATED_310
     template <typename stream_view_t,
               typename seq_legal_alph_type, bool seq_qual_combined,
               typename seq_type>
     void read_seq(stream_view_t & stream_view,
                    sequence_file_input_options<seq_legal_alph_type, seq_qual_combined> const &,
                    seq_type & seq)
+#else // ^^^ before seqan 3.1 / after seqan 3.1 vvv
+    template <typename stream_view_t,
+              typename seq_legal_alph_type,
+              typename seq_type>
+    void read_seq(stream_view_t & stream_view,
+                   sequence_file_input_options<seq_legal_alph_type> const &,
+                   seq_type & seq)
+#endif // SEQAN3_DEPRECATED_310
     {
         auto constexpr is_id = is_char<'>'> || is_char<';'>;
 

--- a/include/seqan3/io/sequence_file/format_fastq.hpp
+++ b/include/seqan3/io/sequence_file/format_fastq.hpp
@@ -99,6 +99,7 @@ public:
 
 protected:
     //!\copydoc sequence_file_input_format::read_sequence_record
+#ifdef SEQAN3_DEPRECATED_310
     template <typename stream_type,     // constraints checked by file
               typename seq_legal_alph_type, bool seq_qual_combined,
               typename seq_type,        // other constraints checked inside function
@@ -109,6 +110,18 @@ protected:
                               seq_type                                                                  & sequence,
                               id_type                                                                   & id,
                               qual_type                                                                 & qualities)
+#else // ^^^ before seqan 3.1 / after seqan 3.1 vvv
+    template <typename stream_type,     // constraints checked by file
+              typename seq_legal_alph_type,
+              typename seq_type,        // other constraints checked inside function
+              typename id_type,
+              typename qual_type>
+    void read_sequence_record(stream_type                                                               & stream,
+                              sequence_file_input_options<seq_legal_alph_type> const & options,
+                              seq_type                                                                  & sequence,
+                              id_type                                                                   & id,
+                              qual_type                                                                 & qualities)
+#endif // SEQAN3_DEPRECATED_310
     {
         auto stream_view = detail::istreambuf(stream);
         auto stream_it = begin(stream_view);
@@ -186,6 +199,7 @@ protected:
         /* Qualities */
         auto qview = stream_view | std::views::filter(!is_space)                  // this consumes trailing newline
                                  | detail::take_exactly_or_throw(sequence_size_after - sequence_size_before);
+#ifdef SEQAN3_DEPRECATED_310
         if constexpr (seq_qual_combined)
         {
             // seq_qual field implies that they are the same variable
@@ -194,6 +208,9 @@ protected:
                               begin(qualities) + sequence_size_before);
         }
         else if constexpr (!detail::decays_to_ignore_v<qual_type>)
+#else // ^^^ before seqan 3.1 / after seqan 3.1 vvv
+        if constexpr (!detail::decays_to_ignore_v<qual_type>)
+#endif // SEQAN3_DEPRECATED_310
         {
             std::ranges::copy(qview | views::char_to<std::ranges::range_value_t<qual_type>>,
                               std::cpp20::back_inserter(qualities));

--- a/include/seqan3/io/sequence_file/format_genbank.hpp
+++ b/include/seqan3/io/sequence_file/format_genbank.hpp
@@ -94,6 +94,7 @@ public:
 
 protected:
     //!\copydoc sequence_file_input_format::read_sequence_record
+#ifdef SEQAN3_DEPRECATED_310
     template <typename stream_type,     // constraints checked by file
               typename seq_legal_alph_type, bool seq_qual_combined,
               typename seq_type,        // other constraints checked inside function
@@ -104,6 +105,18 @@ protected:
                               seq_type    & sequence,
                               id_type     & id,
                               qual_type   & SEQAN3_DOXYGEN_ONLY(qualities))
+#else // ^^^ before seqan 3.1 / after seqan 3.1 vvv
+    template <typename stream_type,     // constraints checked by file
+              typename seq_legal_alph_type,
+              typename seq_type,        // other constraints checked inside function
+              typename id_type,
+              typename qual_type>
+    void read_sequence_record(stream_type & stream,
+                              sequence_file_input_options<seq_legal_alph_type> const & options,
+                              seq_type    & sequence,
+                              id_type     & id,
+                              qual_type   & SEQAN3_DOXYGEN_ONLY(qualities))
+#endif // SEQAN3_DEPRECATED_310
     {
         auto stream_view = detail::istreambuf(stream);
         auto stream_it = std::ranges::begin(stream_view);

--- a/include/seqan3/io/sequence_file/input.hpp
+++ b/include/seqan3/io/sequence_file/input.hpp
@@ -325,7 +325,11 @@ public:
    /*!\brief The subset of seqan3::field IDs that are valid for this file; order corresponds to the types in
      * \ref field_types.
      */
+#ifdef SEQAN3_DEPRECATED_310
     using field_ids            = fields<field::seq, field::id, field::qual, field::_seq_qual_deprecated>;
+#else // ^^^ before seqan 3.1 / after seqan 3.1 vvv
+    using field_ids            = fields<field::seq, field::id, field::qual>;
+#endif // SEQAN3_DEPRECATED_310
 
     static_assert([] () constexpr
                   {
@@ -337,6 +341,7 @@ public:
                   "You selected a field that is not valid for sequence files, please refer to the documentation "
                   "of sequence_file_input::field_ids for the accepted values.");
 
+#ifdef SEQAN3_DEPRECATED_310
     static_assert([] () constexpr
                   {
                       return !(selected_field_ids::contains(field::_seq_qual_deprecated) &&
@@ -344,6 +349,7 @@ public:
                                (selected_field_ids::contains(field::qual))));
                   }(),
                   "You may not select field::seq_qual and either of field::seq and field::qual at the same time.");
+#endif // SEQAN3_DEPRECATED_310
 
     /*!\name Field types and record type
      * \brief These types are relevant for record/row-based reading; they may be manipulated via the \ref traits_type
@@ -366,10 +372,13 @@ public:
     using sequence_quality_type = typename traits_type::
                                     template sequence_container<qualified<typename traits_type::sequence_alphabet,
                                                                           typename traits_type::quality_alphabet>>;
-#endif // SEQAN3_DEPRECATED_310
 
     //!\brief The previously defined types aggregated in a seqan3::type_list.
     using field_types           = type_list<sequence_type, id_type, quality_type, sequence_quality_type>;
+#else // ^^^ before seqan 3.1 / after seqan 3.1 vvv
+    //!\brief The previously defined types aggregated in a seqan3::type_list.
+    using field_types           = type_list<sequence_type, id_type, quality_type>;
+#endif // SEQAN3_DEPRECATED_310
 
     //!\brief The type of the record, a specialisation of seqan3::record; acts as a tuple of the selected field types.
     using record_type           = sequence_record<detail::select_types_with_ids_t<field_types,
@@ -595,9 +604,13 @@ public:
     //!\}
 
     //!\brief The input file options type.
+#ifdef SEQAN3_DEPRECATED_310
     using sequence_file_input_options_type
         = sequence_file_input_options<typename traits_type::sequence_legal_alphabet,
                                       selected_field_ids::contains(field::_seq_qual_deprecated)>;
+#else // ^^^ before seqan 3.1 / after seqan 3.1 vvv
+    using sequence_file_input_options_type = sequence_file_input_options<typename traits_type::sequence_legal_alphabet>;
+#endif // SEQAN3_DEPRECATED_310
     //!\brief The options are public and its members can be set directly.
     sequence_file_input_options_type options;
 
@@ -721,6 +734,7 @@ private:
                                   sequence_file_input_options_type const & options) override
         {
             // read new record
+#ifdef SEQAN3_DEPRECATED_310
             if constexpr (selected_field_ids::contains(field::_seq_qual_deprecated))
             {
                 _format.read_sequence_record(instream,
@@ -730,6 +744,7 @@ private:
                                              detail::get_or_ignore<field::_seq_qual_deprecated>(record_buffer));
             }
             else
+#endif // SEQAN3_DEPRECATED_310
             {
                 _format.read_sequence_record(instream,
                                              options,

--- a/include/seqan3/io/sequence_file/input_format_concept.hpp
+++ b/include/seqan3/io/sequence_file/input_format_concept.hpp
@@ -70,7 +70,11 @@ namespace seqan3
 template <typename t>
 SEQAN3_CONCEPT sequence_file_input_format = requires (detail::sequence_file_input_format_exposer<t> & v,
                                                       std::ifstream                                 & f,
+#ifdef SEQAN3_DEPRECATED_310
                                                       sequence_file_input_options<dna5, false>      & options,
+#else // ^^^ before seqan 3.1 / after seqan 3.1 vvv
+                                                      sequence_file_input_options<dna5>             & options,
+#endif // SEQAN3_DEPRECATED_310
                                                       std::vector<dna5>                             & seq,
                                                       std::string                                   & id,
                                                       std::vector<phred42>                          & qual,

--- a/include/seqan3/io/sequence_file/input_options.hpp
+++ b/include/seqan3/io/sequence_file/input_options.hpp
@@ -25,7 +25,7 @@ namespace seqan3
 template <typename sequence_legal_alphabet, bool seq_qual_combined>
 #else // ^^^ before seqan 3.1 / after seqan 3.1 vvv
 template <typename sequence_legal_alphabet>
-#endif
+#endif // SEQAN3_DEPRECATED_310
 struct sequence_file_input_options
 {
     //!\brief Read the ID string only up until the first whitespace character.

--- a/include/seqan3/io/sequence_file/output.hpp
+++ b/include/seqan3/io/sequence_file/output.hpp
@@ -180,7 +180,11 @@ public:
     //!\}
 
     //!\brief The subset of seqan3::field IDs that are valid for this file.
+#ifdef SEQAN3_DEPRECATED_310
     using field_ids            = fields<field::seq, field::id, field::qual, field::_seq_qual_deprecated>;
+#else // ^^^ before seqan 3.1 / after seqan 3.1 vvv
+    using field_ids            = fields<field::seq, field::id, field::qual>;
+#endif // SEQAN3_DEPRECATED_310
 
     static_assert([] () constexpr
                   {
@@ -192,6 +196,7 @@ public:
                   "You selected a field that is not valid for sequence files, please refer to the documentation "
                   "of sequence_file_output::field_ids for the accepted values.");
 
+#ifdef SEQAN3_DEPRECATED_310
     static_assert([] () constexpr
                   {
                       return !(selected_field_ids::contains(field::_seq_qual_deprecated) &&
@@ -199,6 +204,7 @@ public:
                                (selected_field_ids::contains(field::qual))));
                   }(),
                   "You may not select field::seq_qual and either of field::seq and field::qual at the same time.");
+#endif // SEQAN3_DEPRECATED_310
 
     /*!\name Range associated types
      * \brief Most of the range associated types are `void` for output ranges.
@@ -390,10 +396,16 @@ public:
         requires detail::record_like<record_t>
     //!\endcond
     {
+#ifdef SEQAN3_DEPRECATED_310
         write_record(detail::get_or_ignore<field::seq>(r),
                      detail::get_or_ignore<field::id>(r),
                      detail::get_or_ignore<field::qual>(r),
                      detail::get_or_ignore<field::_seq_qual_deprecated>(r));
+#else // ^^^ before seqan 3.1 / after seqan 3.1 vvv
+        write_record(detail::get_or_ignore<field::seq>(r),
+                     detail::get_or_ignore<field::id>(r),
+                     detail::get_or_ignore<field::qual>(r));
+#endif // SEQAN3_DEPRECATED_310
     }
 
     /*!\brief           Write a record in form of a std::tuple to the file.
@@ -424,10 +436,16 @@ public:
     //!\endcond
     {
         // index_of might return npos, but this will be handled well by get_or_ignore (and just return ignore)
+#ifdef SEQAN3_DEPRECATED_310
         write_record(detail::get_or_ignore<selected_field_ids::index_of(field::seq)>(t),
                      detail::get_or_ignore<selected_field_ids::index_of(field::id)>(t),
                      detail::get_or_ignore<selected_field_ids::index_of(field::qual)>(t),
                      detail::get_or_ignore<selected_field_ids::index_of(field::_seq_qual_deprecated)>(t));
+#else // ^^^ before seqan 3.1 / after seqan 3.1 vvv
+        write_record(detail::get_or_ignore<selected_field_ids::index_of(field::seq)>(t),
+                     detail::get_or_ignore<selected_field_ids::index_of(field::id)>(t),
+                     detail::get_or_ignore<selected_field_ids::index_of(field::qual)>(t));
+#endif // SEQAN3_DEPRECATED_310
     }
 
     /*!\brief            Write a record to the file by passing individual fields.
@@ -585,9 +603,15 @@ protected:
     //!\}
 
     //!\brief Write record to format.
+#ifdef SEQAN3_DEPRECATED_310
     template <typename seq_t, typename id_t, typename qual_t, typename seq_qual_t>
     void write_record(seq_t && seq, id_t && id, qual_t && qual, seq_qual_t && seq_qual)
+#else // ^^^ before seqan 3.1 / after seqan 3.1 vvv
+    template <typename seq_t, typename id_t, typename qual_t>
+    void write_record(seq_t && seq, id_t && id, qual_t && qual)
+#endif // SEQAN3_DEPRECATED_310
     {
+#ifdef SEQAN3_DEPRECATED_310
         static_assert(detail::decays_to_ignore_v<seq_qual_t> ||
                       (detail::decays_to_ignore_v<seq_t> && detail::decays_to_ignore_v<qual_t>),
                       "You may not select field::seq_qual and either of field::seq and field::qual at the same time.");
@@ -595,10 +619,12 @@ protected:
         if constexpr (!detail::decays_to_ignore_v<seq_qual_t>)
             static_assert(detail::is_type_specialisation_of_v<std::ranges::range_value_t<seq_qual_t>, qualified>,
                           "The SEQ_QUAL field must contain a range over the seqan3::qualified alphabet.");
+#endif // SEQAN3_DEPRECATED_310
 
         assert(!format.valueless_by_exception());
         std::visit([&] (auto & f)
         {
+#ifdef SEQAN3_DEPRECATED_310
             if constexpr (!detail::decays_to_ignore_v<seq_qual_t>)
             {
                 f.write_sequence_record(*secondary_stream,
@@ -608,6 +634,7 @@ protected:
                                         seq_qual | views::elements<1>);
             }
             else
+#endif // SEQAN3_DEPRECATED_310
             {
                 f.write_sequence_record(*secondary_stream,
                                         options,

--- a/include/seqan3/utility/char_operations/predicate.hpp
+++ b/include/seqan3/utility/char_operations/predicate.hpp
@@ -48,6 +48,7 @@ template <uint8_t interval_first, uint8_t interval_last>
 //!\endcond
 inline constexpr auto is_in_interval = detail::is_in_interval_type<interval_first, interval_last>{};
 
+#ifdef SEQAN3_DEPRECATED_310
 /*!\brief Checks whether a given letter is valid for the specified seqan3::alphabet.
  * \tparam alphabet_t The alphabet to check; must model seqan3::alphabet.
  * \ingroup char_operations
@@ -63,6 +64,7 @@ inline constexpr auto is_in_interval = detail::is_in_interval_type<interval_firs
  */
 template <alphabet alphabet_t>
 SEQAN3_DEPRECATED_310 inline constexpr auto is_in_alphabet = detail::is_in_alphabet_type<alphabet_t>{};
+#endif // SEQAN3_DEPRECATED_310
 
 /*!\brief Checks whether a given letter is the same as the template non-type argument.
  * \tparam char_v The letter to compare against.

--- a/include/seqan3/utility/type_traits/basic.hpp
+++ b/include/seqan3/utility/type_traits/basic.hpp
@@ -33,7 +33,7 @@ namespace seqan3
 /*!\addtogroup type_traits
  * \{
  */
-
+#ifdef SEQAN3_DEPRECATED_310
 // ----------------------------------------------------------------------------
 // remove_cvref_t
 // ----------------------------------------------------------------------------
@@ -43,6 +43,7 @@ namespace seqan3
  */
 template <typename t>
 using remove_cvref_t SEQAN3_DEPRECATED_310 = std::remove_cv_t<std::remove_reference_t<t>>;
+#endif // SEQAN3_DEPRECATED_310
 
 // ----------------------------------------------------------------------------
 // remove_rvalue_reference

--- a/include/seqan3/utility/type_traits/pre.hpp
+++ b/include/seqan3/utility/type_traits/pre.hpp
@@ -14,6 +14,8 @@
 
 #include <seqan3/core/platform.hpp>
 
+#ifdef SEQAN3_DEPRECATED_310
+
 namespace seqan3
 {
 
@@ -25,7 +27,6 @@ namespace seqan3
 // value_type
 // ----------------------------------------------------------------------------
 
-#ifdef SEQAN3_DEPRECATED_310
 namespace detail
 {
 //!\brief This is helper structure to deprecate seqan3::value_type and will be removed before SeqAn 3.1.
@@ -36,7 +37,6 @@ struct value_type;
 template <typename t>
 using value_type_t = typename value_type<t>::type;
 } // namespace seqan3::detail
-#endif
 
 /*!\brief Exposes the `value_type` of another type.
  * \implements seqan3::transformation_trait
@@ -73,7 +73,6 @@ using value_type_t SEQAN3_DEPRECATED_310 = typename detail::value_type_t<t>;
 // reference
 // ----------------------------------------------------------------------------
 
-#ifdef SEQAN3_DEPRECATED_310
 namespace detail
 {
 //!\brief This is helper structure to deprecate seqan3::reference and will be removed before SeqAn 3.1.
@@ -84,7 +83,6 @@ struct reference;
 template <typename t>
 using reference_t = typename reference<t>::type;
 } // namespace seqan3::detail
-#endif
 
 /*!\brief Exposes the `reference` of another type.
  * \implements seqan3::transformation_trait
@@ -121,7 +119,6 @@ using reference_t SEQAN3_DEPRECATED_310 = typename detail::reference_t<t>;
 // rvalue_reference
 // ----------------------------------------------------------------------------
 
-#ifdef SEQAN3_DEPRECATED_310
 namespace detail
 {
 //!\brief This is helper structure to deprecate seqan3::rvalue_reference and will be removed before SeqAn 3.1.
@@ -132,7 +129,6 @@ struct rvalue_reference;
 template <typename t>
 using rvalue_reference_t = typename rvalue_reference<t>::type;
 } // namespace seqan3::detail
-#endif
 
 /*!\brief Exposes the `rvalue_reference` of another type.
  * \implements seqan3::transformation_trait
@@ -169,7 +165,6 @@ using rvalue_reference_t SEQAN3_DEPRECATED_310 = typename detail::rvalue_referen
 // const_reference
 // ----------------------------------------------------------------------------
 
-#ifdef SEQAN3_DEPRECATED_310
 namespace detail
 {
 //!\brief This is helper structure to deprecate seqan3::const_reference and will be removed before SeqAn 3.1.
@@ -180,7 +175,6 @@ struct const_reference;
 template <typename t>
 using const_reference_t = typename const_reference<t>::type;
 } // namespace seqan3::detail
-#endif
 
 /*!\brief Exposes the `const_reference` of another type.
  * \implements seqan3::transformation_trait
@@ -221,7 +215,6 @@ using const_reference_t SEQAN3_DEPRECATED_310 = typename detail::const_reference
 // difference_type
 // ----------------------------------------------------------------------------
 
-#ifdef SEQAN3_DEPRECATED_310
 namespace detail
 {
 //!\brief This is helper structure to deprecate seqan3::difference_type and will be removed before SeqAn 3.1.
@@ -232,7 +225,6 @@ struct difference_type;
 template <typename t>
 using difference_type_t = typename difference_type<t>::type;
 } // namespace seqan3::detail
-#endif
 
 /*!\brief Exposes the `difference_type` of another type.
  * \implements seqan3::transformation_trait
@@ -271,7 +263,6 @@ using difference_type_t SEQAN3_DEPRECATED_310 = typename detail::difference_type
 // size_type
 // ----------------------------------------------------------------------------
 
-#ifdef SEQAN3_DEPRECATED_310
 namespace detail
 {
 //!\brief This is helper structure to deprecate seqan3::size_type and will be removed before SeqAn 3.1.
@@ -282,7 +273,6 @@ struct size_type;
 template <typename t>
 using size_type_t = typename size_type<t>::type;
 } // namespace seqan3::detail
-#endif
 
 /*!\brief Exposes the `size_type` of another type.
  * \implements seqan3::transformation_trait
@@ -321,3 +311,5 @@ using size_type_t SEQAN3_DEPRECATED_310 = typename detail::size_type_t<t>;
 //!\}
 
 } // namespace seqan3
+
+#endif // SEQAN3_DEPRECATED_310

--- a/include/seqan3/utility/views/elements.hpp
+++ b/include/seqan3/utility/views/elements.hpp
@@ -102,6 +102,7 @@ inline constexpr auto elements = std::views::transform([] (auto && in) -> declty
 
 } // namespace seqan3::views
 
+#ifdef SEQAN3_DEPRECATED_310
 namespace seqan3::views
 {
 
@@ -113,3 +114,4 @@ template <auto index>
 SEQAN3_DEPRECATED_310 inline constexpr auto get = views::elements<index>;
 
 } // namespace seqan3::views
+#endif // SEQAN3_DEPRECATED_310

--- a/include/seqan3/utility/views/join_with.hpp
+++ b/include/seqan3/utility/views/join_with.hpp
@@ -21,11 +21,13 @@
 namespace seqan3::views
 {
 
+#ifdef SEQAN3_DEPRECATED_310
 /*!\brief A join view.
  * \ingroup views
  * \deprecated Please use std::views::join or seqan3::views::join_with (if a separator is needed)
  */
 SEQAN3_DEPRECATED_310 inline constexpr auto join = ::ranges::views::join;
+#endif // SEQAN3_DEPRECATED_310
 
 /*!\brief A join view, please use std::views::join if you don't need a separator.
  * \ingroup views

--- a/test/snippet/io/record_2.cpp
+++ b/test/snippet/io/record_2.cpp
@@ -9,7 +9,6 @@
 int main()
 {
     using namespace seqan3::literals;
-    using seqan3::get;
 
     // The order of the types below represent a mapping between the type and the key.
     using types        = seqan3::type_list<seqan3::dna4_vector, std::string, std::vector<seqan3::phred42>>;
@@ -20,9 +19,13 @@ int main()
 
     record_type my_record{};
     get<1>(my_record) = "the most important sequence in the database";            // access via index
+    get<std::string>(my_record) = "the least important sequence in the database"; // access via type
+
+#ifdef SEQAN3_DEPRECATED_310
+    using seqan3::get;
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     get<seqan3::field::seq>(my_record) = "ACGT"_dna4;                             // access via seqan3::field
 #pragma GCC diagnostic pop
-    get<std::string>(my_record) = "the least important sequence in the database"; // access via type
+#endif //SEQAN3_DEPRECATED_310
 }

--- a/test/snippet/io/record_2.cpp
+++ b/test/snippet/io/record_2.cpp
@@ -18,8 +18,8 @@ int main()
     // the order also depends on selected_ids
 
     record_type my_record{};
-    get<1>(my_record) = "the most important sequence in the database";            // access via index
-    get<std::string>(my_record) = "the least important sequence in the database"; // access via type
+    std::get<1>(my_record) = "the most important sequence in the database";            // access via index
+    std::get<std::string>(my_record) = "the least important sequence in the database"; // access via type
 
 #ifdef SEQAN3_DEPRECATED_310
     using seqan3::get;

--- a/test/unit/alphabet/aminoacid/aminoacid_translation_test.cpp
+++ b/test/unit/alphabet/aminoacid/aminoacid_translation_test.cpp
@@ -40,6 +40,7 @@ TEST(translate_triplets, dna15)
     EXPECT_EQ(t1, c);
 }
 
+#ifdef SEQAN3_DEPRECATED_310
 TEST(translate_triplets, random_access_range)
 {
     seqan3::dna15 n1{'C'_dna15};
@@ -69,3 +70,4 @@ TEST(translate_triplets, tuple)
 
     EXPECT_EQ(t3, c);
 }
+#endif // SEQAN3_DEPRECATED_310

--- a/test/unit/io/detail/take_view_test.cpp
+++ b/test/unit/io/detail/take_view_test.cpp
@@ -21,6 +21,7 @@
 #include <seqan3/utility/range/concept.hpp>
 #include <seqan3/utility/views/single_pass_input.hpp>
 
+#ifdef SEQAN3_DEPRECATED_310
 inline auto constexpr seqan3_views_take = seqan3::detail::take_fn<false, false>{};
 
 // ============================================================================
@@ -213,3 +214,4 @@ TEST(view_take, type_erasure)
         EXPECT_RANGE_EQ(v2, (std::vector{1, 2, 3}));
     }
 }
+#endif // SEQAN3_DEPRECATED_310

--- a/test/unit/io/record_test.cpp
+++ b/test/unit/io/record_test.cpp
@@ -44,7 +44,9 @@ TEST(fields, usage)
     EXPECT_TRUE(default_fields::contains(seqan3::field::seq));
     EXPECT_TRUE(default_fields::contains(seqan3::field::id));
     EXPECT_TRUE(default_fields::contains(seqan3::field::qual));
+#ifdef SEQAN3_DEPRECATED_310
     EXPECT_FALSE(default_fields::contains(seqan3::field::_seq_qual_deprecated));
+#endif // SEQAN3_DEPRECATED_310
     EXPECT_EQ(default_fields::index_of(seqan3::field::seq), 0ul);
     EXPECT_EQ(default_fields::index_of(seqan3::field::id),  1ul);
     EXPECT_EQ(default_fields::index_of(seqan3::field::qual), 2ul);
@@ -96,6 +98,7 @@ TEST_F(record, get_by_type)
     EXPECT_RANGE_EQ(std::get<seqan3::dna4_vector>(r), "ACGT"_dna4);
 }
 
+#ifdef SEQAN3_DEPRECATED_310
 TEST_F(record, get_by_field)
 {
     record_type r{"MY ID", "ACGT"_dna4};
@@ -118,3 +121,4 @@ TEST_F(record, gcc_issue_94967)
     EXPECT_SAME_TYPE(std::string const &&, decltype(seqan3::get<seqan3::field::id>(std::move(std::as_const(r)))));
 #pragma GCC diagnostic pop
 }
+#endif // SEQAN3_DEPRECATED_310

--- a/test/unit/io/sam_file/format_bam_test.cpp
+++ b/test/unit/io/sam_file/format_bam_test.cpp
@@ -506,6 +506,7 @@ TEST_F(bam_format, too_long_cigar_string_read)
 
         seqan3::sam_file_input fin{stream, this->ref_ids, this->ref_sequences, seqan3::format_bam{}};
 
+#ifdef SEQAN3_DEPRECATED_310
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         EXPECT_RANGE_EQ(std::get<0>(seqan3::get<seqan3::field::alignment>(*fin.begin())),
@@ -514,6 +515,7 @@ TEST_F(bam_format, too_long_cigar_string_read)
                         std::get<1>(this->alignments[0]));
         EXPECT_EQ(seqan3::get<seqan3::field::tags>(*fin.begin()).size(), 0u); // redundant CG tag is removed
 #pragma GCC diagnostic pop
+#endif // SEQAN3_DEPRECATED_310
 
         EXPECT_RANGE_EQ(std::get<0>((*fin.begin()).alignment()),
                         std::get<0>(this->alignments[0]));

--- a/test/unit/io/sam_file/format_sam_test.cpp
+++ b/test/unit/io/sam_file/format_sam_test.cpp
@@ -191,10 +191,12 @@ TEST_F(sam_format, no_hd_line_in_header)
     std::istringstream istream{std::string{"@SQ\tSN:ref\tLN:34\nread1\t41\tref\t1\t61\t*\tref\t10\t300\tACGT\t!##$\n"}};
     seqan3::sam_file_input fin{istream, seqan3::format_sam{}, seqan3::fields<seqan3::field::id>{}};
 
+#ifdef SEQAN3_DEPRECATED_310
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     EXPECT_EQ(seqan3::get<seqan3::field::id>(*fin.begin()), std::string{"read1"});
 #pragma GCC diagnostic pop
+#endif // SEQAN3_DEPRECATED_310
 
     EXPECT_EQ((*fin.begin()).id(), std::string{"read1"});
 }
@@ -204,10 +206,12 @@ TEST_F(sam_format, windows_file)
     std::istringstream istream(std::string("read1\t41\tref\t1\t61\t*\tref\t10\t300\tACGT\t!##$\r\n"));
     seqan3::sam_file_input fin{istream, seqan3::format_sam{}, seqan3::fields<seqan3::field::id>{}};
 
+#ifdef SEQAN3_DEPRECATED_310
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     EXPECT_EQ(seqan3::get<seqan3::field::id>(*fin.begin()), std::string{"read1"});
 #pragma GCC diagnostic pop
+#endif // SEQAN3_DEPRECATED_310
 
     EXPECT_EQ((*fin.begin()).id(), std::string{"read1"});
 }
@@ -364,11 +368,13 @@ TEST_F(sam_format, issue2195)
         using seqan3::operator""_phred42;
         std::vector<seqan3::phred42> expected_quality = "*9<9;"_phred42;
 
+#ifdef SEQAN3_DEPRECATED_310
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::id>(*fin.begin()), std::string{"*r1"});
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::qual>(*fin.begin()), expected_quality);
 #pragma GCC diagnostic pop
+#endif // SEQAN3_DEPRECATED_310
 
         EXPECT_RANGE_EQ((*fin.begin()).id(), std::string{"*r1"});
         EXPECT_RANGE_EQ((*fin.begin()).base_qualities(), expected_quality);
@@ -384,11 +390,13 @@ TEST_F(sam_format, issue2195)
         using seqan3::operator""_phred42;
         std::vector<seqan3::phred42> expected_quality = "*1"_phred42;
 
+#ifdef SEQAN3_DEPRECATED_310
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::id>(*fin.begin()), std::string{""});
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::qual>(*fin.begin()), expected_quality);
 #pragma GCC diagnostic pop
+#endif // SEQAN3_DEPRECATED_310
 
         EXPECT_RANGE_EQ((*fin.begin()).id(), std::string{""});
         EXPECT_RANGE_EQ((*fin.begin()).base_qualities(), expected_quality);

--- a/test/unit/io/sam_file/sam_file_format_test_template.hpp
+++ b/test/unit/io/sam_file/sam_file_format_test_template.hpp
@@ -212,6 +212,7 @@ TYPED_TEST_P(sam_file_read, read_in_all_data)
     size_t i{0};
     for (auto & rec : fin)
     {
+#ifdef SEQAN3_DEPRECATED_310
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         EXPECT_EQ(seqan3::get<seqan3::field::seq>(rec), this->seqs[i]);
@@ -227,6 +228,7 @@ TYPED_TEST_P(sam_file_read, read_in_all_data)
         EXPECT_EQ(seqan3::get<seqan3::field::mate>(rec), this->mates[i]);
         EXPECT_EQ(seqan3::get<seqan3::field::tags>(rec), this->tag_dicts[i]);
 #pragma GCC diagnostic pop
+#endif // SEQAN3_DEPRECATED_310
 
         EXPECT_EQ(rec.sequence(), this->seqs[i]);
         EXPECT_EQ(rec.id(), this->ids[i]);
@@ -251,6 +253,7 @@ TYPED_TEST_P(sam_file_read, read_in_all_but_empty_data)
     typename TestFixture::stream_type istream{this->empty_input};
     seqan3::sam_file_input fin{istream, this->ref_ids, this->ref_sequences, TypeParam{}};
 
+#ifdef SEQAN3_DEPRECATED_310
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     EXPECT_TRUE(seqan3::get<seqan3::field::seq>(*fin.begin()).empty());
@@ -268,6 +271,7 @@ TYPED_TEST_P(sam_file_read, read_in_all_but_empty_data)
     EXPECT_EQ(std::get<2>(seqan3::get<seqan3::field::mate>(*fin.begin())), int32_t{});
     EXPECT_TRUE(seqan3::get<seqan3::field::tags>(*fin.begin()).empty());
 #pragma GCC diagnostic pop
+#endif // SEQAN3_DEPRECATED_310
 
     EXPECT_TRUE((*fin.begin()).sequence().empty());
     EXPECT_TRUE((*fin.begin()).id().empty());
@@ -322,11 +326,13 @@ TYPED_TEST_P(sam_file_read, read_in_alignment_only_with_ref)
                                    TypeParam{},
                                    seqan3::fields<seqan3::field::alignment>{}};
 
+#ifdef SEQAN3_DEPRECATED_310
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         EXPECT_TRUE(std::ranges::empty(std::get<0>(seqan3::get<seqan3::field::alignment>(*fin.begin()))));
         EXPECT_TRUE(std::ranges::empty(std::get<1>(seqan3::get<seqan3::field::alignment>(*fin.begin()))));
 #pragma GCC diagnostic pop
+#endif // SEQAN3_DEPRECATED_310
 
         EXPECT_TRUE(std::ranges::empty(std::get<0>((*fin.begin()).alignment())));
         EXPECT_TRUE(std::ranges::empty(std::get<1>((*fin.begin()).alignment())));
@@ -352,11 +358,13 @@ TYPED_TEST_P(sam_file_read, read_in_alignment_only_without_ref)
         typename TestFixture::stream_type istream{this->empty_cigar};
         seqan3::sam_file_input fin{istream, TypeParam{}, seqan3::fields<seqan3::field::alignment>{}};
 
+#ifdef SEQAN3_DEPRECATED_310
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         EXPECT_TRUE(std::ranges::empty(std::get<0>(seqan3::get<seqan3::field::alignment>(*fin.begin()))));
         EXPECT_TRUE(std::ranges::empty(std::get<1>(seqan3::get<seqan3::field::alignment>(*fin.begin()))));
 #pragma GCC diagnostic pop
+#endif // SEQAN3_DEPRECATED_310
 
         EXPECT_TRUE(std::ranges::empty(std::get<0>((*fin.begin()).alignment())));
         EXPECT_TRUE(std::ranges::empty(std::get<1>((*fin.begin()).alignment())));

--- a/test/unit/io/sam_file/sam_file_input_test.cpp
+++ b/test/unit/io/sam_file/sam_file_input_test.cpp
@@ -152,7 +152,9 @@ TEST_F(sam_file_input_f, default_template_args_and_deduction_guides)
     using comp1 = seqan3::fields<seqan3::field::seq,
                                  seqan3::field::id,
                                  seqan3::field::offset,
+#ifdef SEQAN3_DEPRECATED_310
                                  seqan3::field::ref_seq,
+#endif // SEQAN3_DEPRECATED_310
                                  seqan3::field::ref_id,
                                  seqan3::field::ref_offset,
                                  seqan3::field::alignment,
@@ -162,8 +164,10 @@ TEST_F(sam_file_input_f, default_template_args_and_deduction_guides)
                                  seqan3::field::flag,
                                  seqan3::field::mate,
                                  seqan3::field::tags,
+#ifdef SEQAN3_DEPRECATED_310
                                  seqan3::field::evalue,
                                  seqan3::field::bit_score,
+#endif // SEQAN3_DEPRECATED_310
                                  seqan3::field::header_ptr>;
     using comp2 = seqan3::type_list<seqan3::format_sam, seqan3::format_bam>;
     using comp3 = char;
@@ -260,12 +264,14 @@ TEST_F(sam_file_input_f, record_reading)
     size_t counter = 0;
     for (auto & rec : fin)
     {
+#ifdef SEQAN3_DEPRECATED_310
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::seq>(rec), seq_comp[counter]);
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::id>(rec), id_comp[counter]);
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::qual>(rec), qual_comp[counter]);
 #pragma GCC diagnostic pop
+#endif // SEQAN3_DEPRECATED_310
 
         EXPECT_RANGE_EQ(rec.sequence(), seq_comp[counter]);
         EXPECT_RANGE_EQ(rec.id(), id_comp[counter]);
@@ -308,12 +314,14 @@ TEST_F(sam_file_input_f, file_view)
     size_t counter = 1; // the first record will be filtered out
     for (auto & rec : fin | minimum_length_filter)
     {
+#ifdef SEQAN3_DEPRECATED_310
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::seq>(rec), seq_comp[counter]);
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::id>(rec), id_comp[counter]);
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::qual>(rec), qual_comp[counter]);
 #pragma GCC diagnostic pop
+#endif // SEQAN3_DEPRECATED_310
 
         EXPECT_RANGE_EQ(rec.sequence(), seq_comp[counter]);
         EXPECT_RANGE_EQ(rec.id(), id_comp[counter]);
@@ -335,12 +343,14 @@ void decompression_impl(fixture_t & fix, input_file_t & fin)
     size_t counter = 0;
     for (auto & rec : fin)
     {
+#ifdef SEQAN3_DEPRECATED_310
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::seq>(rec), fix.seq_comp[counter]);
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::id>(rec), fix.id_comp[counter]);
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::qual>(rec), fix.qual_comp[counter]);
 #pragma GCC diagnostic pop
+#endif // SEQAN3_DEPRECATED_310
 
         EXPECT_RANGE_EQ(rec.sequence(), fix.seq_comp[counter]);
         EXPECT_RANGE_EQ(rec.id(), fix.id_comp[counter]);

--- a/test/unit/io/sam_file/sam_file_record_test.cpp
+++ b/test/unit/io/sam_file/sam_file_record_test.cpp
@@ -184,6 +184,7 @@ TEST_F(sam_record, get_by_type)
     EXPECT_EQ(std::get<seqan3::sam_tag_dictionary>(r), seqan3::sam_tag_dictionary{});
 }
 
+#ifdef SEQAN3_DEPRECATED_310
 TEST_F(sam_record, get_by_field)
 {
     record_type r{construct()};
@@ -208,6 +209,7 @@ TEST_F(sam_record, get_by_field)
     EXPECT_EQ(seqan3::get<seqan3::field::tags>(r), seqan3::sam_tag_dictionary{});
 #pragma GCC diagnostic pop
 }
+#endif // SEQAN3_DEPRECATED_310
 
 TEST_F(sam_record, get_by_member)
 {
@@ -233,6 +235,7 @@ TEST_F(sam_record, get_by_member)
     EXPECT_EQ(r.tags(), seqan3::sam_tag_dictionary{});
 }
 
+#ifdef SEQAN3_DEPRECATED_310
 TEST_F(sam_record, get_types)
 {
     record_type r{construct()};
@@ -309,6 +312,7 @@ TEST_F(sam_record, get_types)
                      decltype(seqan3::get<seqan3::field::tags>(std::move(std::as_const(r)))));
 #pragma GCC diagnostic pop
 }
+#endif // SEQAN3_DEPRECATED_310
 
 TEST_F(sam_record, member_types)
 {

--- a/test/unit/io/sequence_file/sequence_file_format_embl_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_format_embl_test.cpp
@@ -104,7 +104,11 @@ SQ Sequence 1859 BP; 609 A; 314 C; 355 G; 581 T; 0 other;
 //)"
     };
 
+#ifdef SEQAN3_DEPRECATED_310
     seqan3::sequence_file_input_options<seqan3::dna15, false> options{};
+#else // ^^^ before seqan 3.1 / after seqan 3.1 vvv
+    seqan3::sequence_file_input_options<seqan3::dna15> options{};
+#endif // SEQAN3_DEPRECATED_310
 
     void do_read_test(std::string const & input)
     {
@@ -117,11 +121,13 @@ SQ Sequence 1859 BP; 609 A; 314 C; 355 G; 581 T; 0 other;
         auto it = fin.begin();
         for (unsigned i = 0; i < 3; ++i, ++it)
         {
+#ifdef SEQAN3_DEPRECATED_310
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
             EXPECT_EQ(seqan3::get<seqan3::field::id>(*it), ids[i]);
             EXPECT_EQ(seqan3::get<seqan3::field::seq>(*it), seqs[i]);
 #pragma GCC diagnostic pop
+#endif // SEQAN3_DEPRECATED_310
 
             EXPECT_EQ((*it).id(), ids[i]);
             EXPECT_EQ((*it).sequence(), seqs[i]);

--- a/test/unit/io/sequence_file/sequence_file_format_fasta_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_format_fasta_test.cpp
@@ -70,7 +70,11 @@ INSTANTIATE_TYPED_TEST_SUITE_P(fasta, sequence_file_write, seqan3::format_fasta,
 
 struct read : public sequence_file_data
 {
+#ifdef SEQAN3_DEPRECATED_310
     seqan3::sequence_file_input_options<seqan3::dna15, false> options{};
+#else // ^^^ before seqan 3.1 / after seqan 3.1 vvv
+    seqan3::sequence_file_input_options<seqan3::dna15> options{};
+#endif // SEQAN3_DEPRECATED_310
 
     std::string id;
     seqan3::dna5_vector seq;
@@ -86,11 +90,13 @@ struct read : public sequence_file_data
         auto it = fin.begin();
         for (unsigned i = 0; i < 3; ++i, ++it)
         {
+#ifdef SEQAN3_DEPRECATED_310
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
             EXPECT_RANGE_EQ(seqan3::get<seqan3::field::seq>(*it), seqs[i]);
             EXPECT_EQ(seqan3::get<seqan3::field::id>(*it), ids[i]);
 #pragma GCC diagnostic pop
+#endif // SEQAN3_DEPRECATED_310
 
             EXPECT_EQ((*it).id(), ids[i]);
             EXPECT_RANGE_EQ((*it).sequence(), seqs[i]);

--- a/test/unit/io/sequence_file/sequence_file_format_fastq_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_format_fastq_test.cpp
@@ -104,7 +104,11 @@ struct read : public sequence_file_data
         "!!!!!!!\n"
     };
 
+#ifdef SEQAN3_DEPRECATED_310
     seqan3::sequence_file_input_options<seqan3::dna15, false> options{};
+#else // ^^^ before seqan 3.1 / after seqan 3.1 vvv
+    seqan3::sequence_file_input_options<seqan3::dna15> options{};
+#endif // SEQAN3_DEPRECATED_310
 
     void do_read_test(std::string const & input)
     {
@@ -115,12 +119,14 @@ struct read : public sequence_file_data
         auto it = fin.begin();
         for (unsigned i = 0; i < 3; ++i, ++it)
         {
+#ifdef SEQAN3_DEPRECATED_310
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
             EXPECT_RANGE_EQ(seqan3::get<seqan3::field::seq>(*it), seqs[i]);
             EXPECT_RANGE_EQ(seqan3::get<seqan3::field::id>(*it), ids[i]);
             EXPECT_RANGE_EQ(seqan3::get<seqan3::field::qual>(*it), quals[i]);
 #pragma GCC diagnostic pop
+#endif // SEQAN3_DEPRECATED_310
 
             EXPECT_RANGE_EQ((*it).id(), ids[i]);
             EXPECT_RANGE_EQ((*it).sequence(), seqs[i]);

--- a/test/unit/io/sequence_file/sequence_file_format_genbank_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_format_genbank_test.cpp
@@ -108,7 +108,11 @@ INSTANTIATE_TYPED_TEST_SUITE_P(genbank, sequence_file_write, seqan3::format_genb
 
 struct read : public sequence_file_read<seqan3::format_genbank>
 {
+#ifdef SEQAN3_DEPRECATED_310
     seqan3::sequence_file_input_options<seqan3::dna15, false> options{};
+#else // ^^^ before seqan 3.1 / after seqan 3.1 vvv
+    seqan3::sequence_file_input_options<seqan3::dna15> options{};
+#endif // SEQAN3_DEPRECATED_310
 
     void do_read_test(std::string const & input)
     {
@@ -120,11 +124,13 @@ struct read : public sequence_file_read<seqan3::format_genbank>
         auto it = fin.begin();
         for (unsigned i = 0; i < 3; ++i, ++it)
         {
+#ifdef SEQAN3_DEPRECATED_310
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
             EXPECT_EQ(seqan3::get<seqan3::field::id>(*it), ids[i]);
             EXPECT_EQ(seqan3::get<seqan3::field::seq>(*it), seqs[i]);
 #pragma GCC diagnostic pop
+#endif // SEQAN3_DEPRECATED_310
 
             EXPECT_EQ((*it).id(), ids[i]);
             EXPECT_EQ((*it).sequence(), seqs[i]);

--- a/test/unit/io/sequence_file/sequence_file_format_sam_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_format_sam_test.cpp
@@ -62,7 +62,11 @@ INSTANTIATE_TYPED_TEST_SUITE_P(sam, sequence_file_write, seqan3::format_sam, );
 // ----------------------------------------------------------------------------
 struct read_sam : sequence_file_read<seqan3::format_sam>
 {
+#ifdef SEQAN3_DEPRECATED_310
     seqan3::sequence_file_input_options<seqan3::dna5, false> options{};
+#else // ^^^ before seqan 3.1 / after seqan 3.1 vvv
+    seqan3::sequence_file_input_options<seqan3::dna5> options{};
+#endif // SEQAN3_DEPRECATED_310
 
     void do_read_test(std::string const & input)
     {
@@ -72,12 +76,14 @@ struct read_sam : sequence_file_read<seqan3::format_sam>
         auto it = fin.begin();
         for (unsigned i = 0; i < 3; ++i, it++)
         {
+#ifdef SEQAN3_DEPRECATED_310
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
             EXPECT_EQ(seqan3::get<seqan3::field::seq>(*it), seqs[i]);
             EXPECT_EQ(seqan3::get<seqan3::field::id>(*it), ids[i]);
             EXPECT_EQ(seqan3::get<seqan3::field::qual>(*it), quals[i]);
 #pragma GCC diagnostic pop
+#endif // SEQAN3_DEPRECATED_310
 
             EXPECT_EQ((*it).id(), ids[i]);
             EXPECT_EQ((*it).sequence(), seqs[i]);

--- a/test/unit/io/sequence_file/sequence_file_format_test_template.hpp
+++ b/test/unit/io/sequence_file/sequence_file_format_test_template.hpp
@@ -80,6 +80,7 @@ TYPED_TEST_P(sequence_file_read, standard)
     auto it = fin.begin();
     for (unsigned i = 0; i < 3; ++i, ++it)
     {
+#ifdef SEQAN3_DEPRECATED_310
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::seq>(*it), this->seqs[i]);
@@ -89,6 +90,7 @@ TYPED_TEST_P(sequence_file_read, standard)
             EXPECT_RANGE_EQ(seqan3::get<seqan3::field::qual>(*it), this->quals[i]);
         }
 #pragma GCC diagnostic pop
+#endif // SEQAN3_DEPRECATED_310
 
         EXPECT_RANGE_EQ((*it).sequence(), this->seqs[i]);
         EXPECT_EQ((*it).id(), this->ids[i]);
@@ -119,6 +121,7 @@ TYPED_TEST_P(sequence_file_read, only_id)
         EXPECT_EQ(std::get<0>(*it), this->ids[i]);
 }
 
+#ifdef SEQAN3_DEPRECATED_310
 TYPED_TEST_P(sequence_file_read, seq_qual)
 {
     std::stringstream istream{this->standard_input};
@@ -137,6 +140,7 @@ TYPED_TEST_P(sequence_file_read, seq_qual)
         EXPECT_RANGE_EQ((*it).id(), this->ids[i]);
     }
 }
+#endif // SEQAN3_DEPRECATED_310
 
 TYPED_TEST_P(sequence_file_read, options_truncate_ids)
 {
@@ -190,6 +194,7 @@ TYPED_TEST_P(sequence_file_write, standard)
     EXPECT_EQ(this->ostream.str(), this->standard_output);
 }
 
+#ifdef SEQAN3_DEPRECATED_310
 TYPED_TEST_P(sequence_file_write, seq_qual)
 {
     auto convert_to_qualified = std::views::transform([] (auto const in)
@@ -210,6 +215,7 @@ TYPED_TEST_P(sequence_file_write, seq_qual)
 
     EXPECT_EQ(this->ostream.str(), this->standard_output);
 }
+#endif // SEQAN3_DEPRECATED_310
 
 TYPED_TEST_P(sequence_file_write, arg_handling_id_missing)
 {
@@ -249,6 +255,7 @@ TYPED_TEST_P(sequence_file_write, arg_handling_seq_empty)
     }
 }
 
+#ifdef SEQAN3_DEPRECATED_310
 REGISTER_TYPED_TEST_SUITE_P(sequence_file_read,
                             concept_check,
                             standard,
@@ -258,7 +265,18 @@ REGISTER_TYPED_TEST_SUITE_P(sequence_file_read,
                             illegal_alphabet_character,
                             options_truncate_ids,
                             no_or_ill_formatted_id);
+#else // ^^^ before seqan 3.1 / after seqan 3.1 vvv
+REGISTER_TYPED_TEST_SUITE_P(sequence_file_read,
+                            concept_check,
+                            standard,
+                            only_seq,
+                            only_id,
+                            illegal_alphabet_character,
+                            options_truncate_ids,
+                            no_or_ill_formatted_id);
+#endif // SEQAN3_DEPRECATED_310
 
+#ifdef SEQAN3_DEPRECATED_310
 REGISTER_TYPED_TEST_SUITE_P(sequence_file_write,
                             concept_check,
                             standard,
@@ -267,3 +285,12 @@ REGISTER_TYPED_TEST_SUITE_P(sequence_file_write,
                             arg_handling_id_empty,
                             arg_handling_seq_missing,
                             arg_handling_seq_empty);
+#else // ^^^ before seqan 3.1 / after seqan 3.1 vvv
+REGISTER_TYPED_TEST_SUITE_P(sequence_file_write,
+                            concept_check,
+                            standard,
+                            arg_handling_id_missing,
+                            arg_handling_id_empty,
+                            arg_handling_seq_missing,
+                            arg_handling_seq_empty);
+#endif // SEQAN3_DEPRECATED_310

--- a/test/unit/io/sequence_file/sequence_file_input_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_input_test.cpp
@@ -232,12 +232,14 @@ TEST_F(sequence_file_input_f, record_reading)
     size_t counter = 0;
     for (auto & rec : fin)
     {
+#ifdef SEQAN3_DEPRECATED_310
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::seq>(rec), seq_comp[counter]);
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::id>(rec),  id_comp[counter]);
         EXPECT_TRUE(empty(seqan3::get<seqan3::field::qual>(rec)));
 #pragma GCC diagnostic pop
+#endif // SEQAN3_DEPRECATED_310
 
         EXPECT_RANGE_EQ(rec.id(),  id_comp[counter]);
         EXPECT_RANGE_EQ(rec.sequence(), seq_comp[counter]);
@@ -267,6 +269,7 @@ TEST_F(sequence_file_input_f, record_reading_struct_bind)
     EXPECT_EQ(counter, 3u);
 }
 
+#ifdef SEQAN3_DEPRECATED_310
 TEST_F(sequence_file_input_f, record_reading_custom_fields)
 {
     /* record based reading */
@@ -285,6 +288,7 @@ TEST_F(sequence_file_input_f, record_reading_custom_fields)
 
     EXPECT_EQ(counter, 3u);
 }
+#endif // SEQAN3_DEPRECATED_310
 
 TEST_F(sequence_file_input_f, record_reading_custom_options)
 {
@@ -303,22 +307,28 @@ TEST_F(sequence_file_input_f, record_reading_custom_options)
     fin.options.truncate_ids = true;
 
     auto it = fin.begin();
+#ifdef SEQAN3_DEPRECATED_310
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     EXPECT_EQ(seqan3::get<seqan3::field::id>(*it), "ID1");
 #pragma GCC diagnostic pop
+#endif // SEQAN3_DEPRECATED_310
     EXPECT_EQ((*it).id(), "ID1");
     ++it;
+#ifdef SEQAN3_DEPRECATED_310
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     EXPECT_EQ(seqan3::get<seqan3::field::id>(*it), "ID2");
 #pragma GCC diagnostic pop
+#endif // SEQAN3_DEPRECATED_310
     EXPECT_EQ((*it).id(), "ID2");
     ++it;
+#ifdef SEQAN3_DEPRECATED_310
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     EXPECT_EQ(seqan3::get<seqan3::field::id>(*it), "ID3");
 #pragma GCC diagnostic pop
+#endif // SEQAN3_DEPRECATED_310
     EXPECT_EQ((*it).id(), "ID3");
 }
 
@@ -334,12 +344,14 @@ TEST_F(sequence_file_input_f, file_view)
     size_t counter = 1; // the first record will be filtered out
     for (auto & rec : fin | minimum_length_filter)
     {
+#ifdef SEQAN3_DEPRECATED_310
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::seq>(rec), seq_comp[counter]);
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::id>(rec),  id_comp[counter]);
         EXPECT_TRUE(empty(seqan3::get<seqan3::field::qual>(rec)));
 #pragma GCC diagnostic pop
+#endif // SEQAN3_DEPRECATED_310
 
         EXPECT_RANGE_EQ(rec.id(),  id_comp[counter]);
         EXPECT_RANGE_EQ(rec.sequence(), seq_comp[counter]);
@@ -361,12 +373,14 @@ void decompression_impl(fixture_t & fix, input_file_t & fin)
     size_t counter = 0;
     for (auto & rec : fin)
     {
+#ifdef SEQAN3_DEPRECATED_310
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::seq>(rec), fix.seq_comp[counter]);
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::id>(rec),  fix.id_comp[counter]);
         EXPECT_TRUE(empty(seqan3::get<seqan3::field::qual>(rec)));
 #pragma GCC diagnostic pop
+#endif // SEQAN3_DEPRECATED_310
 
         EXPECT_RANGE_EQ(rec.sequence(), fix.seq_comp[counter]);
         EXPECT_RANGE_EQ(rec.id(),  fix.id_comp[counter]);

--- a/test/unit/io/sequence_file/sequence_file_output_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_output_test.cpp
@@ -354,6 +354,7 @@ TEST(row, different_fields_in_record_and_file)
     EXPECT_EQ(reinterpret_cast<std::ostringstream&>(fout.get_stream()).str(), expected_out);
 }
 
+#ifdef SEQAN3_DEPRECATED_310
 TEST(row, writing_seq_qual)
 {
     seqan3::sequence_file_output fout{std::ostringstream{},
@@ -373,6 +374,7 @@ TEST(row, writing_seq_qual)
 
     EXPECT_EQ(reinterpret_cast<std::ostringstream&>(fout.get_stream()).str(), output_comp);
 }
+#endif // SEQAN3_DEPRECATED_310
 
 // ----------------------------------------------------------------------------
 // rows
@@ -432,6 +434,7 @@ TEST(columns, writing_id_seq_qual)
     EXPECT_EQ(reinterpret_cast<std::ostringstream&>(fout.get_stream()).str(), output_comp);
 }
 
+#ifdef SEQAN3_DEPRECATED_310
 TEST(columns, writing_seq_qual)
 {
     seqan3::sequence_file_output fout{std::ostringstream{},
@@ -452,6 +455,7 @@ TEST(columns, writing_seq_qual)
     fout.get_stream().flush();
     EXPECT_EQ(reinterpret_cast<std::ostringstream&>(fout.get_stream()).str(), output_comp);
 }
+#endif // SEQAN3_DEPRECATED_310
 
 // ----------------------------------------------------------------------------
 // compression

--- a/test/unit/io/sequence_file/sequence_file_record_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_record_test.cpp
@@ -67,6 +67,7 @@ TEST_F(sequence_record, get_by_type)
     EXPECT_RANGE_EQ(std::get<seqan3::dna4_vector>(r), "ACGT"_dna4);
 }
 
+#ifdef SEQAN3_DEPRECATED_310
 TEST_F(sequence_record, get_by_field)
 {
     record_type r{"MY ID", "ACGT"_dna4};
@@ -77,6 +78,7 @@ TEST_F(sequence_record, get_by_field)
     EXPECT_RANGE_EQ(seqan3::get<seqan3::field::seq>(r), "ACGT"_dna4);
 #pragma GCC diagnostic pop
 }
+#endif // SEQAN3_DEPRECATED_310
 
 TEST_F(sequence_record, get_by_member)
 {
@@ -86,6 +88,7 @@ TEST_F(sequence_record, get_by_member)
     EXPECT_RANGE_EQ(r.sequence(), "ACGT"_dna4);
 }
 
+#ifdef SEQAN3_DEPRECATED_310
 TEST_F(sequence_record, get_types)
 {
     record_type r{"MY ID", "ACGT"_dna4};
@@ -106,6 +109,7 @@ TEST_F(sequence_record, get_types)
                      decltype(seqan3::get<seqan3::field::seq>(std::move(std::as_const(r)))));
 #pragma GCC diagnostic pop
 }
+#endif // SEQAN3_DEPRECATED_310
 
 TEST_F(sequence_record, member_types)
 {

--- a/test/unit/io/structure_file/format_vienna_test.cpp
+++ b/test/unit/io/structure_file/format_vienna_test.cpp
@@ -123,47 +123,61 @@ struct read : public ::testing::Test
         auto it = fin.begin();
         for (size_t idx = 0ul; idx < expected_seq.size(); ++idx, ++it)
         {
+#ifdef SEQAN3_DEPRECATED_310
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
             EXPECT_EQ(check_energy, seqan3::get<seqan3::field::energy>(*it).has_value());
 #pragma GCC diagnostic pop
+#endif // SEQAN3_DEPRECATED_310
             EXPECT_EQ(check_energy, (*it).energy().has_value());
             if (check_seq)
             {
+#ifdef SEQAN3_DEPRECATED_310
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
                 EXPECT_RANGE_EQ(seqan3::get<seqan3::field::seq>(*it), expected_seq[idx]);
 #pragma GCC diagnostic pop
+#endif // SEQAN3_DEPRECATED_310
                 EXPECT_RANGE_EQ((*it).sequence(), expected_seq[idx]);
             }
             if (check_id)
             {
+#ifdef SEQAN3_DEPRECATED_310
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
                 EXPECT_RANGE_EQ(seqan3::get<seqan3::field::id>(*it), expected_id[idx]);
 #pragma GCC diagnostic pop
+#endif // SEQAN3_DEPRECATED_310
                 EXPECT_RANGE_EQ((*it).id(), expected_id[idx]);
             }
             if (check_structure)
             {
+#ifdef SEQAN3_DEPRECATED_310
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
                 bpp_test(seqan3::get<seqan3::field::bpp>(*it), expected_interactions[idx]);
                 bpp_test((*it).base_pair_probability_matrix(), expected_interactions[idx]);
+#pragma GCC diagnostic pop
+#endif // SEQAN3_DEPRECATED_310
             }
             if (check_energy)
             {
+#ifdef SEQAN3_DEPRECATED_310
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
                 EXPECT_DOUBLE_EQ(*seqan3::get<seqan3::field::energy>(*it), expected_energy[idx]);
 #pragma GCC diagnostic pop
+#endif // SEQAN3_DEPRECATED_310
                 EXPECT_DOUBLE_EQ(*(*it).energy(), expected_energy[idx]);
             }
             if (check_structure)
             {
+#ifdef SEQAN3_DEPRECATED_310
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
                 EXPECT_RANGE_EQ(seqan3::get<seqan3::field::structure>(*it), expected_structure[idx]);
+#pragma GCC diagnostic pop
+#endif // SEQAN3_DEPRECATED_310
                 EXPECT_RANGE_EQ((*it).sequence_structure(), expected_structure[idx]);
             }
         }
@@ -272,10 +286,12 @@ TEST_F(read_fields, only_seq)
     auto it = fin.begin();
     for (size_t idx = 0ul; idx < expected_seq.size(); ++idx, ++it)
     {
+#ifdef SEQAN3_DEPRECATED_310
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::seq>(*it), expected_seq[idx]);
 #pragma GCC diagnostic pop
+#endif // SEQAN3_DEPRECATED_310
         EXPECT_RANGE_EQ((*it).sequence(), expected_seq[idx]);
     }
 }
@@ -287,10 +303,12 @@ TEST_F(read_fields, only_id)
     auto it = fin.begin();
     for (size_t idx = 0ul; idx < expected_seq.size(); ++idx, ++it)
     {
+#ifdef SEQAN3_DEPRECATED_310
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::id>(*it), expected_id[idx]);
 #pragma GCC diagnostic pop
+#endif // SEQAN3_DEPRECATED_310
         EXPECT_RANGE_EQ((*it).id(), expected_id[idx]);
     }
 }
@@ -302,9 +320,12 @@ TEST_F(read_fields, only_structure)
     auto it = fin.begin();
     for (size_t idx = 0ul; idx < expected_seq.size(); ++idx, ++it)
     {
+#ifdef SEQAN3_DEPRECATED_310
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::structure>(*it), expected_structure[idx]);
+#pragma GCC diagnostic pop
+#endif // SEQAN3_DEPRECATED_310
         EXPECT_RANGE_EQ((*it).sequence_structure(), expected_structure[idx]);
     }
 }
@@ -316,19 +337,24 @@ TEST_F(read_fields, only_energy)
     auto it = fin.begin();
     for (size_t idx = 0ul; idx < expected_seq.size(); ++idx, ++it)
     {
+#ifdef SEQAN3_DEPRECATED_310
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         EXPECT_TRUE(seqan3::get<seqan3::field::energy>(*it));
 #pragma GCC diagnostic pop
+#endif // SEQAN3_DEPRECATED_310
         EXPECT_TRUE((*it).energy());
+#ifdef SEQAN3_DEPRECATED_310
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         EXPECT_DOUBLE_EQ(*seqan3::get<seqan3::field::energy>(*it), expected_energy[idx]);
 #pragma GCC diagnostic pop
+#endif // SEQAN3_DEPRECATED_310
         EXPECT_DOUBLE_EQ(*(*it).energy(), expected_energy[idx]);
     }
 }
 
+#ifdef SEQAN3_DEPRECATED_310
 TEST_F(read_fields, structured_seq)
 {
     std::stringstream istream{input};
@@ -345,6 +371,7 @@ TEST_F(read_fields, structured_seq)
 #pragma GCC diagnostic pop
     }
 }
+#endif // SEQAN3_DEPRECATED_310
 
 TEST_F(read_fields, only_bpp)
 {
@@ -353,9 +380,12 @@ TEST_F(read_fields, only_bpp)
     auto it = fin.begin();
     for (size_t idx = 0ul; idx < expected_seq.size(); ++idx, ++it)
     {
+#ifdef SEQAN3_DEPRECATED_310
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         bpp_test(seqan3::get<seqan3::field::bpp>(*it), expected_interactions[idx]);
+#pragma GCC diagnostic pop
+#endif // SEQAN3_DEPRECATED_310
         bpp_test((*it).base_pair_probability_matrix(), expected_interactions[idx]);
     }
 }

--- a/test/unit/io/structure_file/structure_file_input_test.cpp
+++ b/test/unit/io/structure_file/structure_file_input_test.cpp
@@ -266,12 +266,15 @@ struct structure_file_input_read : public ::testing::Test
         counter = 0ul;
         for (auto & rec : fin)
         {
+
+#ifdef SEQAN3_DEPRECATED_310
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
             EXPECT_RANGE_EQ(seqan3::get<seqan3::field::seq>(rec), seq_comp[counter]);
             EXPECT_RANGE_EQ(seqan3::get<seqan3::field::id>(rec), id_comp[counter]);
             EXPECT_RANGE_EQ(seqan3::get<seqan3::field::structure>(rec), structure_comp[counter]);
 #pragma GCC diagnostic pop
+#endif // SEQAN3_DEPRECATED_310
 
             EXPECT_RANGE_EQ(rec.sequence(), seq_comp[counter]);
             EXPECT_RANGE_EQ(rec.id(), id_comp[counter]);
@@ -310,12 +313,15 @@ TEST_F(structure_file_input_read, record_general)
     size_t counter = 0ul;
     for (auto & rec : fin)
     {
+
+#ifdef SEQAN3_DEPRECATED_310
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::seq>(rec), seq_comp[counter]);
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::id>(rec), id_comp[counter]);
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::structure>(rec), structure_comp[counter]);
 #pragma GCC diagnostic pop
+#endif // SEQAN3_DEPRECATED_310
 
         EXPECT_RANGE_EQ(rec.sequence(), seq_comp[counter]);
         EXPECT_RANGE_EQ(rec.id(), id_comp[counter]);
@@ -386,6 +392,8 @@ TEST_F(structure_file_input_read, record_file_view)
     size_t counter = 0ul; // the first record will be filtered out
     for (auto & rec : fin | minimum_length_filter)
     {
+
+#ifdef SEQAN3_DEPRECATED_310
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::seq>(rec), seq_comp[counter]);
@@ -394,6 +402,7 @@ TEST_F(structure_file_input_read, record_file_view)
         EXPECT_RANGE_EQ(seqan3::get<seqan3::field::structure>(rec), structure_comp[counter]);
         EXPECT_DOUBLE_EQ(seqan3::get<seqan3::field::energy>(rec).value(), energy_comp[counter]);
 #pragma GCC diagnostic pop
+#endif // SEQAN3_DEPRECATED_310
 
         EXPECT_RANGE_EQ(rec.sequence(), seq_comp[counter]);
         EXPECT_RANGE_EQ(rec.id(), id_comp[counter]);

--- a/test/unit/io/structure_file/structure_file_record_test.cpp
+++ b/test/unit/io/structure_file/structure_file_record_test.cpp
@@ -81,6 +81,7 @@ TEST_F(structure_record, get_by_type)
     EXPECT_DOUBLE_EQ(std::get<double>(r), 1.5);
 }
 
+#ifdef SEQAN3_DEPRECATED_310
 TEST_F(structure_record, get_by_field)
 {
     record_type r{"MY ID", "ACGU"_rna5, "(())"_wuss51, 1.5};
@@ -93,6 +94,7 @@ TEST_F(structure_record, get_by_field)
     EXPECT_DOUBLE_EQ(seqan3::get<seqan3::field::energy>(r), 1.5);
 #pragma GCC diagnostic pop
 }
+#endif // SEQAN3_DEPRECATED_310
 
 TEST_F(structure_record, get_by_member)
 {
@@ -104,6 +106,7 @@ TEST_F(structure_record, get_by_member)
     EXPECT_DOUBLE_EQ(r.energy(), 1.5);
 }
 
+#ifdef SEQAN3_DEPRECATED_310
 TEST_F(structure_record, get_types)
 {
     record_type r{"MY ID", "ACGU"_rna5, "(())"_wuss51, 1.5};
@@ -134,6 +137,7 @@ TEST_F(structure_record, get_types)
     EXPECT_SAME_TYPE(double const &&, decltype(seqan3::get<seqan3::field::energy>(std::move(std::as_const(r)))));
 #pragma GCC diagnostic pop
 }
+#endif // SEQAN3_DEPRECATED_310
 
 TEST_F(structure_record, member_types)
 {

--- a/test/unit/range/views/to_lower_test.cpp
+++ b/test/unit/range/views/to_lower_test.cpp
@@ -12,7 +12,9 @@
 #include <seqan3/alphabet/detail/debug_stream_alphabet.hpp>
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
 #include <seqan3/alphabet/views/to_char.hpp>
+#ifdef SEQAN3_DEPRECATED_310
 #include <seqan3/range/views/to_lower.hpp>
+#endif // SEQAN3_DEPRECATED_310
 #include <seqan3/test/expect_range_eq.hpp>
 #include <seqan3/utility/range/concept.hpp>
 

--- a/test/unit/range/views/to_upper_test.cpp
+++ b/test/unit/range/views/to_upper_test.cpp
@@ -12,7 +12,9 @@
 #include <seqan3/alphabet/detail/debug_stream_alphabet.hpp>
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
 #include <seqan3/alphabet/views/to_char.hpp>
+#ifdef SEQAN3_DEPRECATED_310
 #include <seqan3/range/views/to_upper.hpp>
+#endif // SEQAN3_DEPRECATED_310
 #include <seqan3/test/expect_range_eq.hpp>
 #include <seqan3/utility/range/concept.hpp>
 


### PR DESCRIPTION
This adds an option to simulate the removal of deprecated API. Sometimes some entities won't trigger a good deprecation notice and the only option is to see the build fail.