### PR TITLE
[FIX] some deprecations

### DIFF
--- a/include/seqan3/core/bit_manipulation.hpp
+++ b/include/seqan3/core/bit_manipulation.hpp
@@ -21,6 +21,7 @@
 
 SEQAN3_DEPRECATED_HEADER("This header is deprecated and will be removed in SeqAn-3.1.0; Please #include <seqan3/std/bit> XOR <seqan3/utility/detail/bits_of.hpp> XOR <seqan3/utility/detail/to_little_endian.hpp> instead.")
 
+#ifdef SEQAN3_DEPRECATED_310
 namespace seqan3::detail
 {
 /*!\brief How many bits has a type?
@@ -198,3 +199,4 @@ SEQAN3_DEPRECATED_310 constexpr uint8_t most_significant_bit_set(unsigned_t cons
 }
 
 } // namespace seqan3::detail
+#endif // SEQAN3_DEPRECATED_310

--- a/test/performance/range/views/view_drop_benchmark.cpp
+++ b/test/performance/range/views/view_drop_benchmark.cpp
@@ -60,36 +60,52 @@ void sequential_read(benchmark::State & state)
     [[maybe_unused]] volatile uint8_t dummy2 = dummy;
 }
 
+#ifdef SEQAN3_DEPRECATED_310
 //!brief Instance for usage until removed.
 inline constexpr auto seqan3_views_drop = seqan3::detail::drop_fn{};
+#endif // SEQAN3_DEPRECATED_310
 
 BENCHMARK_TEMPLATE(sequential_read, std::string, void);
 BENCHMARK_TEMPLATE(sequential_read, std::string, decltype(std::views::drop));
+#ifdef SEQAN3_DEPRECATED_310
 BENCHMARK_TEMPLATE(sequential_read, std::string, decltype(seqan3_views_drop));
+#endif // SEQAN3_DEPRECATED_310
 
 BENCHMARK_TEMPLATE(sequential_read, std::vector<uint8_t>, void);
 BENCHMARK_TEMPLATE(sequential_read, std::vector<uint8_t>, decltype(std::views::drop));
+#ifdef SEQAN3_DEPRECATED_310
 BENCHMARK_TEMPLATE(sequential_read, std::vector<uint8_t>, decltype(seqan3_views_drop));
+#endif // SEQAN3_DEPRECATED_310
 
 BENCHMARK_TEMPLATE(sequential_read, std::deque<uint8_t>, void);
 BENCHMARK_TEMPLATE(sequential_read, std::deque<uint8_t>, decltype(std::views::drop));
+#ifdef SEQAN3_DEPRECATED_310
 BENCHMARK_TEMPLATE(sequential_read, std::deque<uint8_t>, decltype(seqan3_views_drop));
+#endif // SEQAN3_DEPRECATED_310
 
 BENCHMARK_TEMPLATE(sequential_read, std::list<uint8_t>, void);
 BENCHMARK_TEMPLATE(sequential_read, std::list<uint8_t>, decltype(std::views::drop));
+#ifdef SEQAN3_DEPRECATED_310
 BENCHMARK_TEMPLATE(sequential_read, std::list<uint8_t>, decltype(seqan3_views_drop));
+#endif // SEQAN3_DEPRECATED_310
 
 BENCHMARK_TEMPLATE(sequential_read, std::forward_list<uint8_t>, void);
 BENCHMARK_TEMPLATE(sequential_read, std::forward_list<uint8_t>, decltype(std::views::drop));
+#ifdef SEQAN3_DEPRECATED_310
 BENCHMARK_TEMPLATE(sequential_read, std::forward_list<uint8_t>, decltype(seqan3_views_drop));
+#endif // SEQAN3_DEPRECATED_310
 
-BENCHMARK_TEMPLATE(sequential_read, std::vector<uint8_t>, void,                              true);
+BENCHMARK_TEMPLATE(sequential_read, std::vector<uint8_t>, void, true);
 BENCHMARK_TEMPLATE(sequential_read, std::vector<uint8_t>, decltype(std::views::drop), true);
-BENCHMARK_TEMPLATE(sequential_read, std::vector<uint8_t>, decltype(seqan3_views_drop),      true);
+#ifdef SEQAN3_DEPRECATED_310
+BENCHMARK_TEMPLATE(sequential_read, std::vector<uint8_t>, decltype(seqan3_views_drop), true);
+#endif // SEQAN3_DEPRECATED_310
 
-BENCHMARK_TEMPLATE(sequential_read, std::forward_list<uint8_t>, void,                              true);
+BENCHMARK_TEMPLATE(sequential_read, std::forward_list<uint8_t>, void, true);
 BENCHMARK_TEMPLATE(sequential_read, std::forward_list<uint8_t>, decltype(std::views::drop), true);
-BENCHMARK_TEMPLATE(sequential_read, std::forward_list<uint8_t>, decltype(seqan3_views_drop),      true);
+#ifdef SEQAN3_DEPRECATED_310
+BENCHMARK_TEMPLATE(sequential_read, std::forward_list<uint8_t>, decltype(seqan3_views_drop), true);
+#endif // SEQAN3_DEPRECATED_310
 
 // ============================================================================
 //  random access
@@ -139,15 +155,21 @@ void random_access(benchmark::State & state)
 
 BENCHMARK_TEMPLATE(random_access, std::string, void);
 BENCHMARK_TEMPLATE(random_access, std::string, decltype(std::views::drop));
+#ifdef SEQAN3_DEPRECATED_310
 BENCHMARK_TEMPLATE(random_access, std::string, decltype(seqan3_views_drop));
+#endif // SEQAN3_DEPRECATED_310
 
 BENCHMARK_TEMPLATE(random_access, std::vector<uint8_t>, void);
 BENCHMARK_TEMPLATE(random_access, std::vector<uint8_t>, decltype(std::views::drop));
+#ifdef SEQAN3_DEPRECATED_310
 BENCHMARK_TEMPLATE(random_access, std::vector<uint8_t>, decltype(seqan3_views_drop));
+#endif // SEQAN3_DEPRECATED_310
 
 BENCHMARK_TEMPLATE(random_access, std::deque<uint8_t>, void);
 BENCHMARK_TEMPLATE(random_access, std::deque<uint8_t>, decltype(std::views::drop));
+#ifdef SEQAN3_DEPRECATED_310
 BENCHMARK_TEMPLATE(random_access, std::deque<uint8_t>, decltype(seqan3_views_drop));
+#endif // SEQAN3_DEPRECATED_310
 
 // ============================================================================
 //  run

--- a/test/performance/range/views/view_drop_view_take_benchmark.cpp
+++ b/test/performance/range/views/view_drop_view_take_benchmark.cpp
@@ -60,37 +60,53 @@ void sequential_read(benchmark::State & state)
     [[maybe_unused]] volatile uint8_t dummy2 = dummy;
 }
 
+#ifdef SEQAN3_DEPRECATED_310
 //!brief Instance for usage until removed.
 inline constexpr auto seqan3_views_drop = seqan3::detail::drop_fn{};
 inline constexpr auto seqan3_views_take = seqan3::detail::take_fn<false, false>{};
+#endif // SEQAN3_DEPRECATED_310
 
 BENCHMARK_TEMPLATE(sequential_read, std::string,         void,                              void);
 BENCHMARK_TEMPLATE(sequential_read, std::string,         decltype(std::views::drop), decltype(std::views::take));
+#ifdef SEQAN3_DEPRECATED_310
 BENCHMARK_TEMPLATE(sequential_read, std::string,         decltype(seqan3_views_drop),      decltype(seqan3_views_take));
+#endif // SEQAN3_DEPRECATED_310
 
 BENCHMARK_TEMPLATE(sequential_read, std::vector<uint8_t>, void,                              void);
 BENCHMARK_TEMPLATE(sequential_read, std::vector<uint8_t>, decltype(std::views::drop), decltype(std::views::take));
+#ifdef SEQAN3_DEPRECATED_310
 BENCHMARK_TEMPLATE(sequential_read, std::vector<uint8_t>, decltype(seqan3_views_drop),      decltype(seqan3_views_take));
+#endif // SEQAN3_DEPRECATED_310
 
 BENCHMARK_TEMPLATE(sequential_read, std::deque<uint8_t>,  void,                              void);
 BENCHMARK_TEMPLATE(sequential_read, std::deque<uint8_t>,  decltype(std::views::drop), decltype(std::views::take));
+#ifdef SEQAN3_DEPRECATED_310
 BENCHMARK_TEMPLATE(sequential_read, std::deque<uint8_t>,  decltype(seqan3_views_drop),      decltype(seqan3_views_take));
+#endif // SEQAN3_DEPRECATED_310
 
 BENCHMARK_TEMPLATE(sequential_read, std::list<uint8_t>,   void,                              void);
 BENCHMARK_TEMPLATE(sequential_read, std::list<uint8_t>,   decltype(std::views::drop), decltype(std::views::take));
+#ifdef SEQAN3_DEPRECATED_310
 BENCHMARK_TEMPLATE(sequential_read, std::list<uint8_t>,   decltype(seqan3_views_drop),      decltype(seqan3_views_take));
+#endif // SEQAN3_DEPRECATED_310
 
 BENCHMARK_TEMPLATE(sequential_read, std::forward_list<uint8_t>,   void,                              void);
 BENCHMARK_TEMPLATE(sequential_read, std::forward_list<uint8_t>,   decltype(std::views::drop), decltype(std::views::take));
+#ifdef SEQAN3_DEPRECATED_310
 BENCHMARK_TEMPLATE(sequential_read, std::forward_list<uint8_t>,   decltype(seqan3_views_drop),      decltype(seqan3_views_take));
+#endif // SEQAN3_DEPRECATED_310
 
 BENCHMARK_TEMPLATE(sequential_read, std::vector<uint8_t>, void,                              void,                              true);
 BENCHMARK_TEMPLATE(sequential_read, std::vector<uint8_t>, decltype(std::views::drop), decltype(std::views::take), true);
+#ifdef SEQAN3_DEPRECATED_310
 BENCHMARK_TEMPLATE(sequential_read, std::vector<uint8_t>, decltype(seqan3_views_drop),      decltype(seqan3_views_take),      true);
+#endif // SEQAN3_DEPRECATED_310
 
 BENCHMARK_TEMPLATE(sequential_read, std::forward_list<uint8_t>, void,                              void,                              true);
 BENCHMARK_TEMPLATE(sequential_read, std::forward_list<uint8_t>, decltype(std::views::drop), decltype(std::views::take), true);
+#ifdef SEQAN3_DEPRECATED_310
 BENCHMARK_TEMPLATE(sequential_read, std::forward_list<uint8_t>, decltype(seqan3_views_drop),      decltype(seqan3_views_take),      true);
+#endif // SEQAN3_DEPRECATED_310
 
 // ============================================================================
 //  random access
@@ -141,15 +157,21 @@ void random_access(benchmark::State & state)
 
 BENCHMARK_TEMPLATE(random_access, std::string,          void,                              void);
 BENCHMARK_TEMPLATE(random_access, std::string,          decltype(std::views::drop), decltype(std::views::take));
+#ifdef SEQAN3_DEPRECATED_310
 BENCHMARK_TEMPLATE(random_access, std::string,          decltype(seqan3_views_drop),      decltype(seqan3_views_take));
+#endif // SEQAN3_DEPRECATED_310
 
 BENCHMARK_TEMPLATE(random_access, std::vector<uint8_t>, void,                              void);
 BENCHMARK_TEMPLATE(random_access, std::vector<uint8_t>, decltype(std::views::drop), decltype(std::views::take));
+#ifdef SEQAN3_DEPRECATED_310
 BENCHMARK_TEMPLATE(random_access, std::vector<uint8_t>, decltype(seqan3_views_drop),      decltype(seqan3_views_take));
+#endif // SEQAN3_DEPRECATED_310
 
 BENCHMARK_TEMPLATE(random_access, std::deque<uint8_t>,  void,                              void);
 BENCHMARK_TEMPLATE(random_access, std::deque<uint8_t>,  decltype(std::views::drop), decltype(std::views::take));
+#ifdef SEQAN3_DEPRECATED_310
 BENCHMARK_TEMPLATE(random_access, std::deque<uint8_t>,  decltype(seqan3_views_drop),      decltype(seqan3_views_take));
+#endif // SEQAN3_DEPRECATED_310
 
 // ============================================================================
 //  run

--- a/test/performance/std/bit_benchmark.cpp
+++ b/test/performance/std/bit_benchmark.cpp
@@ -48,6 +48,7 @@ static void is_power_of_two_arithmetic(benchmark::State & state) {
 }
 BENCHMARK(is_power_of_two_arithmetic);
 
+#ifdef SEQAN3_DEPRECATED_310
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 static void is_power_of_two_seqan3(benchmark::State & state) {
@@ -61,6 +62,7 @@ static void is_power_of_two_seqan3(benchmark::State & state) {
 }
 BENCHMARK(is_power_of_two_seqan3);
 #pragma GCC diagnostic pop
+#endif // SEQAN3_DEPRECATED_310
 
 static void is_power_of_two_std(benchmark::State & state) {
     std::srand(0);
@@ -73,6 +75,7 @@ static void is_power_of_two_std(benchmark::State & state) {
 }
 BENCHMARK(is_power_of_two_std);
 
+#ifdef SEQAN3_DEPRECATED_310
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 static void next_power_of_two_seqan3(benchmark::State & state) {
@@ -86,6 +89,7 @@ static void next_power_of_two_seqan3(benchmark::State & state) {
 }
 BENCHMARK(next_power_of_two_seqan3);
 #pragma GCC diagnostic pop
+#endif // SEQAN3_DEPRECATED_310
 
 static void next_power_of_two_std(benchmark::State & state) {
     std::srand(0);


### PR DESCRIPTION
Some guards were missing in the benchmarks for `-DSEQAN3_REMOVE_DEPRECATED_310` to work