### PR TITLE
[DOC] Add a cookbook entry for an enum validator

### DIFF
--- a/doc/cookbook/enum_validator_for_arg_parse.cpp
+++ b/doc/cookbook/enum_validator_for_arg_parse.cpp
@@ -34,7 +34,7 @@ return std::unordered_map<std::string, my_methods>{{"0", my_methods::method_a}, 
 };
 
 template <typename option_value_t>
-class EnumValidator
+class EnumValidator : public seqan3::value_list_validator<option_value_t>
 {
 public:
     //!\brief Type of values that are tested by validator
@@ -43,12 +43,6 @@ public:
     /*!\name Constructors, destructor and assignment
      * \{
      */
-    EnumValidator() = default;                                  //!< Defaulted.
-    EnumValidator(EnumValidator const &) = default;             //!< Defaulted.
-    EnumValidator(EnumValidator &&) = default;                  //!< Defaulted.
-    EnumValidator & operator=(EnumValidator const &) = default; //!< Defaulted.
-    EnumValidator & operator=(EnumValidator &&) = default;      //!< Defaulted.
-    ~EnumValidator() = default;                                 //!< Defaulted.
 
     /*!\brief Constructing from a range.
      * \tparam range_type - the type of range; must model std::ranges::forward_range and
@@ -69,30 +63,13 @@ public:
     }
     //!\}
 
-    /*!\brief Tests whether cmp lies inside values.
-     * \param cmp The input value to check.
-     * \throws seqan3::validation_error
-     */
-    void operator()(option_value_type const & cmp) const
-    {
-        if (!(std::find(values.begin(), values.end(), cmp) != values.end()))
-            throw seqan3::validation_error{seqan3::detail::to_string("Value ", cmp, " is not one of ",
-                                                                     std::views::all(values), ".")};
-    }
+    void operator()(option_value_type const & cmp) const {};
 
-    /*!\brief Tests whether every element in \p range lies inside values.
-     * \tparam range_type The type of range to check; must model std::ranges::forward_range.
-     * \param  range      The input range to iterate over and check every element.
-     * \throws seqan3::validation_error
-     */
     template <std::ranges::forward_range range_type>
     //!\cond
         requires std::convertible_to<std::ranges::range_value_t<range_type>, option_value_type>
     //!\endcond
-    void operator()(range_type const & range) const
-    {
-        std::for_each(std::ranges::begin(range), std::ranges::end(range), [&] (auto cmp) { (*this)(cmp); });
-    }
+    void operator()(range_type const & range) const {};
 
     //!\brief Returns a message that can be appended to the (positional) options help page info.
     std::string get_help_page_message() const
@@ -126,7 +103,7 @@ void initialize_argument_parser(seqan3::argument_parser & parser, cmd_arguments 
     EnumValidator<my_methods> method_validator{seqan3::enumeration_names<my_methods> | std::views::values};
 
     // Options:
-    parser.add_option(args.methods, 'm', "method", "Choose the method(s) to be used.",
+    parser.add_option(args.methods, 'm', "method", "Choose the method(s) to be used. ",
                       seqan3::option_spec::standard, method_validator);
 }
 

--- a/doc/cookbook/enum_validator_for_arg_parse.cpp
+++ b/doc/cookbook/enum_validator_for_arg_parse.cpp
@@ -1,0 +1,162 @@
+#include <seqan3/std/algorithm>                         // for std::ranges::move
+#include <unordered_map>                                // for std::unordered_map
+
+#include <seqan3/argument_parser/argument_parser.hpp>   // for seqan3::argument_parser
+#include <seqan3/argument_parser/auxiliary.hpp>         // for enumeration_names
+#include <seqan3/argument_parser/exceptions.hpp>        // for seqan3::validation_error
+#include <seqan3/core/debug_stream.hpp>                 // for seqan3::debug_stream
+
+//!\brief An enum for the different methods.
+enum my_methods
+{
+    method_a = 0,
+    method_b = 1,
+    method_c = 2,
+
+    // Also add new methods to the default values in the argument parser
+
+    //!\cond
+    // ATTENTION: Must always be the last item; will be used to determine the number of ids.
+    SIZE //!< Determines the size of the enum.
+    //!\endcond
+};
+
+struct cmd_arguments
+{
+    std::vector<my_methods> methods{method_a, method_c};   // default: method a and c
+};
+
+std::unordered_map<std::string, my_methods> enumeration_names(my_methods)
+{
+return std::unordered_map<std::string, my_methods>{{"0", my_methods::method_a}, {"method_a", my_methods::method_a},
+                                                   {"1", my_methods::method_b}, {"method_b", my_methods::method_b},
+                                                   {"2", my_methods::method_c}, {"method_c", my_methods::method_c}};
+};
+
+template <typename option_value_t>
+class EnumValidator
+{
+public:
+    //!\brief Type of values that are tested by validator
+    using option_value_type = option_value_t;
+
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    EnumValidator() = default;                                  //!< Defaulted.
+    EnumValidator(EnumValidator const &) = default;             //!< Defaulted.
+    EnumValidator(EnumValidator &&) = default;                  //!< Defaulted.
+    EnumValidator & operator=(EnumValidator const &) = default; //!< Defaulted.
+    EnumValidator & operator=(EnumValidator &&) = default;      //!< Defaulted.
+    ~EnumValidator() = default;                                 //!< Defaulted.
+
+    /*!\brief Constructing from a range.
+     * \tparam range_type - the type of range; must model std::ranges::forward_range and
+     *                      EnumValidator::option_value_type must be constructible from the rvalue reference type of the
+     *                      given range
+     * \param[in] rng - the range of valid values to test
+     */
+    template <std::ranges::forward_range range_type>
+    //!\cond
+        requires std::constructible_from<option_value_type, std::ranges::range_rvalue_reference_t<range_type>>
+    //!\endcond
+    EnumValidator(range_type rng)
+    {
+        values.clear();
+        std::ranges::move(std::move(rng), std::cpp20::back_inserter(values));
+        std::ranges::sort(values);
+        values.erase(std::unique(values.begin(), values.end()), values.end());
+    }
+    //!\}
+
+    /*!\brief Tests whether cmp lies inside values.
+     * \param cmp The input value to check.
+     * \throws seqan3::validation_error
+     */
+    void operator()(option_value_type const & cmp) const
+    {
+        if (!(std::find(values.begin(), values.end(), cmp) != values.end()))
+            throw seqan3::validation_error{seqan3::detail::to_string("Value ", cmp, " is not one of ",
+                                                                     std::views::all(values), ".")};
+    }
+
+    /*!\brief Tests whether every element in \p range lies inside values.
+     * \tparam range_type The type of range to check; must model std::ranges::forward_range.
+     * \param  range      The input range to iterate over and check every element.
+     * \throws seqan3::validation_error
+     */
+    template <std::ranges::forward_range range_type>
+    //!\cond
+        requires std::convertible_to<std::ranges::range_value_t<range_type>, option_value_type>
+    //!\endcond
+    void operator()(range_type const & range) const
+    {
+        std::for_each(std::ranges::begin(range), std::ranges::end(range), [&] (auto cmp) { (*this)(cmp); });
+    }
+
+    //!\brief Returns a message that can be appended to the (positional) options help page info.
+    std::string get_help_page_message() const
+    {
+        auto map = seqan3::enumeration_names<option_value_t>;
+        std::vector<std::pair<std::string_view, option_value_t>> key_value_pairs(map.begin(), map.end());
+        std::ranges::sort(key_value_pairs, [] (auto pair1, auto pair2)
+            {
+                if constexpr (std::totally_ordered<option_value_t>)
+                {
+                    if (pair1.second != pair2.second)
+                        return pair1.second < pair2.second;
+                }
+                return pair1.first < pair2.first;
+            });
+
+        return seqan3::detail::to_string("Value must be one of (method name or number) ",
+                                         key_value_pairs | std::views::keys,
+                                         ".");
+    }
+
+private:
+
+    //!\brief Minimum of the range to test.
+    std::vector<option_value_type> values{};
+};
+
+void initialize_argument_parser(seqan3::argument_parser & parser, cmd_arguments & args)
+{
+    // Validatiors:
+    EnumValidator<my_methods> method_validator{seqan3::enumeration_names<my_methods> | std::views::values};
+
+    // Options:
+    parser.add_option(args.methods, 'm', "method", "Choose the method(s) to be used.",
+                      seqan3::option_spec::standard, method_validator);
+}
+
+int main(int argc, char ** argv)
+{
+    seqan3::argument_parser myparser{"myTool", argc, argv};             // initialise myparser
+    cmd_arguments args{};
+    initialize_argument_parser(myparser, args);
+
+    // Parse the given arguments and catch possible errors.
+    try
+    {
+        myparser.parse();                                               // trigger command line parsing
+    }
+    catch (seqan3::argument_parser_error const & ext)                   // catch user errors
+    {
+        seqan3::debug_stream << "[Error] " << ext.what() << '\n';       // customise your error message
+        return -1;
+    }
+
+    // Check that method selection contains no duplicates.
+    std::vector<my_methods> unique_methods{args.methods};
+    std::ranges::sort(unique_methods);
+    unique_methods.erase(std::unique(unique_methods.begin(), unique_methods.end()), unique_methods.end());
+    if (args.methods.size() > unique_methods.size())
+    {
+        seqan3::debug_stream << "[Error] The same method was selected multiple times.\n";
+        seqan3::debug_stream << "Methods to be used: " << args.methods << '\n';
+        return -1;
+    }
+
+    return 0;
+}

--- a/doc/cookbook/index.md
+++ b/doc/cookbook/index.md
@@ -167,6 +167,41 @@ For a full recipe on creating your own readmapper, see the very end of the tutor
 
 \include doc/howto/subcommand_argument_parser/subcommand_arg_parse.cpp
 
+# Constructing an own validator for enum parameter (argument parser)
+
+If you want to have more specific input parameters, you can construct this with an enum. For this you can also develop
+your own validator, so that the parameters are first evaluated as desired and secondly your help page looks reasonable.
+
+In this example, we want to pass one or more methods to our tool to use. We would like to offer the possibility of a
+short input (method number) or a detailed input (method name). For this we have created an enum `my_methods`.
+
+With this parameter we can call our tool like this: `./myTool -m 1 -m 2` or `./myTool -m method_a -m method_b`.
+
+\include doc/cookbook/enum_validator_for_arg_parse.cpp
+
+The help page options would then look like this:
+
+```bash
+OPTIONS
+
+  Basic options:
+    -h, --help
+          Prints the help page.
+    -hh, --advanced-help
+          Prints the help page including advanced options.
+    --version
+          Prints the version information.
+    --copyright
+          Prints the copyright/license information.
+    --export-help (std::string)
+          Export the help page information. Value must be one of [html, man].
+    --version-check (bool)
+          Whether to check for the newest app version. Default: true.
+    -m, --method (List of my_methods)
+          Choose the method(s) to be used. Default: [method_a,method_c]. Value must be one of (method name or number)
+          [0,method_a,1,method_b,2,method_c].
+```
+
 # Serialise data structures with cereal
 
 \include doc/howto/use_cereal/load.hpp

--- a/include/seqan3/argument_parser/all.hpp
+++ b/include/seqan3/argument_parser/all.hpp
@@ -38,6 +38,7 @@
  *
  * - seqan3::regex_validator
  * - seqan3::value_list_validator
+ * - seqan3::enum_validator
  * - seqan3::arithmetic_range_validator
  * - seqan3::input_file_validator
  * - seqan3::output_file_validator


### PR DESCRIPTION
After creating my own enum validator in iGenVar, has @eseiler suggested to add this as a cookbook entry into the seqan3 documentation.
I have collected all the necessary changes for this pr and put them together in a single file.