### PR TITLE
[INFRA] Add manual trigger for doc deployment

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+  # Enables a manual trigger.
+  workflow_dispatch:
 
 env:
   CMAKE_VERSION: 3.8.2


### PR DESCRIPTION
When we merge the release branch into master, this is often just a fast-forward.
GitHub Actions won't trigger on such pushes. This is good in the sense that the CI that already ran on the release branch doesn't need to run again on the master branch.
However, for actions that only run on master, i.e. deploying the documentation, this also means that the updated documentation is never deployed.

With this PR, we can manually trigger deploying the documentation if we have such a fast-forward-merge case.