### PR TITLE
[FIX] Change iteration base return type

### DIFF
--- a/include/seqan3/core/range/detail/inherited_iterator_base.hpp
+++ b/include/seqan3/core/range/detail/inherited_iterator_base.hpp
@@ -110,17 +110,20 @@ public:
     {}
     //!\}
 
-    //!\brief Get a copy of the base.
-    constexpr base_t base() const &
-    //!\cond
-        requires std::copyable<base_t>
-    //!\endcond
+    //!\brief Get a const reference to the base.
+    constexpr base_t const & base() const & noexcept
+    {
+        return as_base();
+    }
+
+    //!\brief Get a reference to the base.
+    constexpr base_t & base() & noexcept
     {
         return as_base();
     }
 
     //!\brief Returns an [rvalue](https://en.cppreference.com/w/cpp/language/value_category) of the base.
-    constexpr base_t base() &&
+    constexpr base_t base() && noexcept
     {
         return std::move(as_base());
     }


### PR DESCRIPTION
This patch addresses the performance regression between 3.0.2 and 3.0.3.

gcc-10 and gcc-11 have different opinions on how this code can be
optimized. Having references instead of copies lead to the lowest run
time overhead.

Closes https://github.com/seqan/seqan3/issues/2675