### PR TITLE
[FIX] Adjust benchmark for view_take_until

### DIFF
--- a/test/performance/io/detail/view_take_until_benchmark.cpp
+++ b/test/performance/io/detail/view_take_until_benchmark.cpp
@@ -46,7 +46,8 @@ void sequential_read(benchmark::State & state)
         {
             single_pass_or_ref_t single_pass_or_ref{container};
             for (auto elem : single_pass_or_ref)
-                sum += elem;
+                if(sum += elem; elem >= 101)
+                    break;
         }
     }
     else // {seqan3,std}::views::take* adaptor


### PR DESCRIPTION
This patch addresses the performance regression between 3.0.2 and 3.0.3.

The view_take_until benchmark was refactored after the 3.0.2 release.
The benchmark code was accidentally changed in its semantics, causing
a false indication of increased run time. This patch restores the
benchmark to its original test.