### PR TITLE
[TEST] Release snippets

### DIFF
--- a/test/cmake/seqan3_path_longest_stem.cmake
+++ b/test/cmake/seqan3_path_longest_stem.cmake
@@ -1,0 +1,44 @@
+# -----------------------------------------------------------------------------------------------------
+# Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
+# Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
+# This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+# shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+# -----------------------------------------------------------------------------------------------------
+
+# A compatible function for cmake <= 3.19 that basically returns `cmake_path (GET <filename> STEM LAST_ONLY <out_var>)`
+function (seqan3_path_longest_stem out_var filename)
+    if (CMAKE_VERSION VERSION_LESS 3.19)  # cmake < 3.19
+        get_filename_component (result "${filename}" NAME)
+        if (result MATCHES "\\.")
+            string (REGEX REPLACE "(.+)[.].*" "\\1" result "${result}")
+        endif ()
+    else () # cmake >= 3.19
+        cmake_path (GET filename STEM LAST_ONLY result)
+    endif ()
+
+    set ("${out_var}" "${result}" PARENT_SCOPE) # out-var
+endfunction ()
+
+# ======
+# TESTS
+# ======
+
+seqan3_path_longest_stem (seqan3_cmake_test_path "/a/b/c/")
+if (NOT seqan3_cmake_test_path STREQUAL "")
+    message (FATAL_ERROR "internal error: '${seqan3_cmake_test_path}' vs '', seqan3_path_longest_stem produces wrong result")
+endif ()
+
+seqan3_path_longest_stem (seqan3_cmake_test_path "/a/b/c/hello")
+if (NOT seqan3_cmake_test_path STREQUAL "hello")
+    message (FATAL_ERROR "internal error: '${seqan3_cmake_test_path}' vs 'hello', seqan3_path_longest_stem produces wrong result")
+endif ()
+
+seqan3_path_longest_stem (seqan3_cmake_test_path "/a/b/c/hello.cpp")
+if (NOT seqan3_cmake_test_path STREQUAL "hello")
+    message (FATAL_ERROR "internal error: '${seqan3_cmake_test_path}' vs 'hello', seqan3_path_longest_stem produces wrong result")
+endif ()
+
+seqan3_path_longest_stem (seqan3_cmake_test_path "/a/b/c/hello.world.cpp")
+if (NOT seqan3_cmake_test_path STREQUAL "hello.world")
+    message (FATAL_ERROR "internal error: '${seqan3_cmake_test_path}' vs 'hello.world', seqan3_path_longest_stem produces wrong result")
+endif ()

--- a/test/cmake/seqan3_test_component.cmake
+++ b/test/cmake/seqan3_test_component.cmake
@@ -5,6 +5,8 @@
 # shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 # -----------------------------------------------------------------------------------------------------
 
+include (seqan3_path_longest_stem)
+
 # Get a specific component of a test file which follows the seqan3 naming scheme.
 # e.g. target_source_file = "range/views/take.cpp"
 # component:
@@ -16,7 +18,7 @@ macro (seqan3_test_component VAR target_source_file component_name_)
     string (TOUPPER "${component_name_}" component_name)
 
     get_filename_component (target_relative_path "${target_source_file}" DIRECTORY)
-    get_filename_component (target_name "${target_source_file}" NAME_WE)
+    seqan3_path_longest_stem (target_name "${target_source_file}")
 
     if (component_name STREQUAL "TARGET_NAME")
         set (${VAR} "${target_name}")

--- a/test/snippet/release/3.0.0_complement-and-translate-without-copying.cpp
+++ b/test/snippet/release/3.0.0_complement-and-translate-without-copying.cpp
@@ -1,0 +1,18 @@
+#include <vector>
+
+#include <seqan3/alphabet/nucleotide/dna5.hpp>
+#include <seqan3/alphabet/views/complement.hpp>
+#include <seqan3/alphabet/views/translate.hpp>
+#include <seqan3/core/debug_stream.hpp>
+
+int main()
+{
+    using namespace seqan3::literals;
+
+    std::vector vec{"ACGTACGTACGTA"_dna5};
+    // pipe the vector through two view adaptors:
+    auto v = vec | seqan3::views::complement | seqan3::views::translate_single;
+    // v is a view of length 4, accessing the elements on-demand will return
+
+    seqan3::debug_stream << v << '\n'; // [C,M,H,A]
+}

--- a/test/snippet/release/3.0.0_file-conversion.cpp
+++ b/test/snippet/release/3.0.0_file-conversion.cpp
@@ -1,0 +1,17 @@
+//![main]
+#include <seqan3/io/sequence_file/input.hpp>
+#include <seqan3/io/sequence_file/output.hpp>
+
+int main()
+{
+    seqan3::sequence_file_input{"input.fastq"} | seqan3::sequence_file_output{"output.fasta"};
+    // no variables are created here, all input is immediately streamed to the output
+    // the format is converted on-the-fly
+}
+//![main]
+
+#include <seqan3/test/snippet/create_temporary_snippet_file.hpp>
+// std::filesystem::current_path() / "input.fastq" will be deleted after the execution
+seqan3::test::create_temporary_snippet_file input_fastq{"input.fastq", "\n"};
+// std::filesystem::current_path() / "output.fasta" will be deleted after the execution
+seqan3::test::create_temporary_snippet_file output_fasta{"output.fasta", ""};

--- a/test/snippet/release/3.0.0_read-fasta-and-print-entities.cpp
+++ b/test/snippet/release/3.0.0_read-fasta-and-print-entities.cpp
@@ -1,0 +1,22 @@
+//![main]
+#include <seqan3/core/debug_stream.hpp>
+#include <seqan3/io/sequence_file/input.hpp>
+
+int main()
+{
+    seqan3::sequence_file_input fin{"my.fasta"};
+
+    // iterate over every record in the file and split it into fields:
+    for (auto & [ seq, id, qual ] : fin)
+    {
+        // print the fields:
+        seqan3::debug_stream << "ID:  " << id << '\n';
+        seqan3::debug_stream << "SEQ: " << seq << '\n';
+        seqan3::debug_stream << "QUAL:" << qual << '\n'; // qual is empty for FastA files
+    }
+}
+//![main]
+
+#include <seqan3/test/snippet/create_temporary_snippet_file.hpp>
+// std::filesystem::current_path() / "my.fasta" will be deleted after the execution
+seqan3::test::create_temporary_snippet_file my_fastq{"my.fasta", "\n"};

--- a/test/snippet/release/3.0.1_parallel-alignments.cpp
+++ b/test/snippet/release/3.0.1_parallel-alignments.cpp
@@ -1,0 +1,20 @@
+#include <iostream>
+
+#include <seqan3/alphabet/nucleotide/dna4.hpp>
+#include <seqan3/alignment/pairwise/all.hpp>
+
+int main()
+{
+    using seqan3::operator""_dna4;
+
+    auto sequence1{"ACCA"_dna4};
+    auto sequence2{"ATTA"_dna4};
+
+    seqan3::configuration alignment_config = seqan3::align_cfg::method_global{} |
+                                             seqan3::align_cfg::edit_scheme |
+                                             seqan3::align_cfg::parallel{4};
+
+    for (auto const & res : seqan3::align_pairwise(std::tie(sequence1, sequence2),
+                                                   alignment_config))
+        std::cout << "Score: " << res.score() << '\n';
+}

--- a/test/snippet/release/3.0.2_dynamic-hit-configuration.cpp
+++ b/test/snippet/release/3.0.2_dynamic-hit-configuration.cpp
@@ -1,0 +1,35 @@
+#include <vector>
+
+#include <seqan3/alphabet/nucleotide/dna4.hpp>
+#include <seqan3/core/debug_stream.hpp>
+#include <seqan3/search/configuration/max_error.hpp>
+#include <seqan3/search/configuration/hit.hpp>
+#include <seqan3/search/fm_index/fm_index.hpp>
+#include <seqan3/search/search.hpp>
+
+int main()
+{
+    using seqan3::operator""_dna4;
+
+    std::vector<seqan3::dna4_vector> text{"CGCTGTCTGAAGGATGAGTGTCAGCCAGTGTA"_dna4,
+                                          "ACCCGATGAGCTACCCAGTAGTCGAACTG"_dna4,
+                                          "GGCCAGACAACCCGGCGCTAATGCACTCA"_dna4};
+    seqan3::dna4_vector query{"GCT"_dna4};
+    seqan3::fm_index index{text};
+
+    // Use the dynamic hit configuration to set hit_all_best mode.
+    seqan3::configuration search_config = seqan3::search_cfg::max_error_total{seqan3::search_cfg::error_count{1}} |
+                                          seqan3::search_cfg::hit{seqan3::search_cfg::hit_all_best{}};
+
+    seqan3::debug_stream << "All single best hits:\n";
+    for (auto && hit : search(query, index, search_config)) // Find all best hits:
+        seqan3::debug_stream << hit << '\n';
+
+    // Change the hit configuration to the strata mode with a stratum of 1.
+    using seqan3::get;
+    get<seqan3::search_cfg::hit>(search_config).hit_variant = seqan3::search_cfg::hit_strata{1};
+
+    seqan3::debug_stream << "\nAll x+1 hits:\n";
+    for (auto && hit : search(query, index, search_config)) // Find all strata hits.
+        seqan3::debug_stream << hit << '\n';
+}

--- a/test/snippet/release/3.0.2_lazy-search-result-range.cpp
+++ b/test/snippet/release/3.0.2_lazy-search-result-range.cpp
@@ -1,0 +1,32 @@
+#include <vector>
+
+#include <seqan3/alphabet/nucleotide/dna4.hpp>
+#include <seqan3/core/debug_stream.hpp>
+#include <seqan3/search/configuration/max_error.hpp>
+#include <seqan3/search/configuration/hit.hpp>
+#include <seqan3/search/fm_index/fm_index.hpp>
+#include <seqan3/search/search.hpp>
+
+int main()
+{
+    using seqan3::operator""_dna4;
+
+    std::vector<seqan3::dna4_vector> text{"CGCTGTCTGAAGGATGAGTGTCAGCCAGTGTA"_dna4,
+                                          "ACCCGATGAGCTACCCAGTAGTCGAACTG"_dna4,
+                                          "GGCCAGACAACCCGGCGCTAATGCACTCA"_dna4};
+    seqan3::dna4_vector query{"GCT"_dna4};
+
+    seqan3::configuration const search_config = seqan3::search_cfg::max_error_total{seqan3::search_cfg::error_count{1}} |
+                                                seqan3::search_cfg::hit_all_best{};
+
+    // Always provide a unified interface over the found hits independent of the index its text layout.
+    seqan3::debug_stream << "Search in text collection:\n";
+    seqan3::fm_index index_collection{text};
+    for (auto && hit : search(query, index_collection, search_config)) // Over a text collection.
+        seqan3::debug_stream << hit << '\n';
+
+    seqan3::debug_stream << "\nSearch in single text:\n";
+    seqan3::fm_index index_single{text[0]};
+    for (auto && hit : search(query, index_single, search_config)) // Over a single text.
+        seqan3::debug_stream << hit << '\n';
+}

--- a/test/snippet/release/3.0.2_user-callback-in-alignment-and-search.cpp
+++ b/test/snippet/release/3.0.2_user-callback-in-alignment-and-search.cpp
@@ -1,0 +1,33 @@
+#include <mutex>
+#include <vector>
+
+#include <seqan3/alignment/configuration/align_config_edit.hpp>
+#include <seqan3/alignment/configuration/align_config_method.hpp>
+#include <seqan3/alignment/configuration/align_config_on_result.hpp>
+#include <seqan3/alignment/configuration/align_config_parallel.hpp>
+#include <seqan3/alignment/pairwise/align_pairwise.hpp>
+#include <seqan3/alphabet/nucleotide/dna4.hpp>
+#include <seqan3/core/debug_stream.hpp>
+
+int main()
+{
+    // Generate some sequences.
+    using seqan3::operator""_dna4;
+    using sequence_pair_t = std::pair<seqan3::dna4_vector, seqan3::dna4_vector>;
+    std::vector<sequence_pair_t> sequences{100, {"AGTGCTACG"_dna4, "ACGTGCGACTAG"_dna4}};
+
+    std::mutex write_to_debug_stream{}; // Need mutex to synchronise the output.
+
+    // Use edit distance with 4 threads.
+    auto const alignment_config = seqan3::align_cfg::method_global{} |
+                                  seqan3::align_cfg::edit_scheme |
+                                  seqan3::align_cfg::parallel{4} |
+                                  seqan3::align_cfg::on_result{[&] (auto && result)
+                                  {
+                                      std::lock_guard sync{write_to_debug_stream}; // critical section
+                                      seqan3::debug_stream << result << '\n';
+                                  }};
+
+    // Compute the alignments in parallel, and output them unordered using the callback (order is not deterministic).
+    seqan3::align_pairwise(sequences, alignment_config);  // seqan3::align_pairwise is now declared void.
+}

--- a/test/snippet/release/3.0.3_io-record.cpp
+++ b/test/snippet/release/3.0.3_io-record.cpp
@@ -1,0 +1,20 @@
+//![main]
+#include <seqan3/core/debug_stream.hpp>
+#include <seqan3/io/sequence_file/input.hpp>
+
+int main()
+{
+    seqan3::sequence_file_input fin{"my.fastq"};
+
+    for (auto && record: fin)
+    {
+        seqan3::debug_stream << "id: " << record.id() << '\n';
+        seqan3::debug_stream << "sequence: " << record.sequence() << '\n';
+        seqan3::debug_stream << "base_qualities: " << record.base_qualities() << '\n';
+    }
+}
+//![main]
+
+#include <seqan3/test/snippet/create_temporary_snippet_file.hpp>
+// std::filesystem::current_path() / "my.fastq" will be deleted after the execution
+seqan3::test::create_temporary_snippet_file input_fastq{"my.fastq", "\n"};

--- a/test/snippet/release/3.0.3_literals-namespace.cpp
+++ b/test/snippet/release/3.0.3_literals-namespace.cpp
@@ -1,0 +1,8 @@
+#include <seqan3/alphabet/nucleotide/dna4.hpp>
+
+int main()
+{
+    using namespace seqan3::literals;
+
+    seqan3::dna4 ade = 'A'_dna4;
+}

--- a/test/snippet/release/README.md
+++ b/test/snippet/release/README.md
@@ -1,0 +1,8 @@
+Snippets contained in this folder are part of our release announcement.
+
+If anything breaks in here, please mark the existing snippets in the release announcement as out-dated and link to the
+updated snippet.
+
+Current Places:
+* Website: https://github.com/seqan/www.seqan.de/ or
+* Release Notes: https://github.com/seqan/seqan3/releases


### PR DESCRIPTION
The cmake change will allow dots (i.e. `.`) in test names, e.g. "foo3.3_test.cpp" or "3.0.1_some-message.cpp". Before this change the test names would have been `foo3` and `3` instead of `foo3.3` and `3.0.1_some-message`.

The main part of the PR adds (updated) snippets of our release notes.