### PR TITLE
[FIX] properly guard ZLIB and BZIP2 

### DIFF
--- a/doc/cookbook/compression_threads.cpp
+++ b/doc/cookbook/compression_threads.cpp
@@ -1,4 +1,4 @@
-#if SEQAN3_HAS_ZLIB
+#if defined(SEQAN3_HAS_ZLIB)
 //![example]
 #include <seqan3/io/all.hpp>
 
@@ -15,4 +15,4 @@ int main()
     return 0;
 }
 //![example]
-#endif // SEQAN3_HAS_ZLIB
+#endif // defined(SEQAN3_HAS_ZLIB)

--- a/include/seqan3/contrib/stream/bgzf_istream.hpp
+++ b/include/seqan3/contrib/stream/bgzf_istream.hpp
@@ -28,6 +28,11 @@
 #include <seqan3/contrib/stream/bgzf_stream_util.hpp>
 #include <seqan3/utility/parallel/detail/reader_writer_manager.hpp>
 
+#if !defined(SEQAN3_HAS_ZLIB) && !defined(SEQAN3_HEADER_TEST)
+#   error "This file cannot be used when building without GZip-support."
+#endif // !defined(SEQAN3_HAS_ZLIB) && !defined(SEQAN3_HEADER_TEST)
+
+#if defined(SEQAN3_HAS_ZLIB)
 namespace seqan3::contrib
 {
 
@@ -619,3 +624,5 @@ typedef basic_bgzf_istream<char> bgzf_istream;
 typedef basic_bgzf_istream<wchar_t> bgzf_wistream;
 
 } // namespace seqan3::conrib
+
+#endif // defined(SEQAN3_HAS_ZLIB)

--- a/include/seqan3/contrib/stream/bgzf_ostream.hpp
+++ b/include/seqan3/contrib/stream/bgzf_ostream.hpp
@@ -24,6 +24,12 @@
 #include <seqan3/contrib/parallel/suspendable_queue.hpp>
 #include <seqan3/contrib/stream/bgzf_stream_util.hpp>
 
+#if !defined(SEQAN3_HAS_ZLIB) && !defined(SEQAN3_HEADER_TEST)
+#   error "This file cannot be used when building without GZip-support."
+#endif // !defined(SEQAN3_HAS_ZLIB) && !defined(SEQAN3_HEADER_TEST)
+
+#if defined(SEQAN3_HAS_ZLIB)
+
 namespace seqan3::contrib
 {
 
@@ -380,3 +386,5 @@ typedef basic_bgzf_ostream<char> bgzf_ostream;
 typedef basic_bgzf_ostream<wchar_t> bgzf_wostream;
 
 } // namespace seqan3::contrib
+
+#endif // defined(SEQAN3_HAS_ZLIB)

--- a/include/seqan3/contrib/stream/bgzf_stream_util.hpp
+++ b/include/seqan3/contrib/stream/bgzf_stream_util.hpp
@@ -19,17 +19,18 @@
 #include <seqan3/std/span>
 #include <thread>
 
-#if SEQAN3_HAS_ZLIB
-// Zlib headers
-#include <zlib.h>
-#else
-#error "This file cannot be used when building without GZip-support."
-#endif  // SEQAN3_HAS_ZLIB
-
 #include <seqan3/core/range/type_traits.hpp>
 #include <seqan3/io/detail/magic_header.hpp>
 #include <seqan3/io/exception.hpp>
 #include <seqan3/utility/detail/to_little_endian.hpp>
+
+#if !defined(SEQAN3_HAS_ZLIB) && !defined(SEQAN3_HEADER_TEST)
+#   error "This file cannot be used when building without GZip-support."
+#endif // !defined(SEQAN3_HAS_ZLIB) && !defined(SEQAN3_HEADER_TEST)
+
+#if defined(SEQAN3_HAS_ZLIB)
+// Zlib headers
+#include <zlib.h>
 
 namespace seqan3::contrib
 {
@@ -320,3 +321,5 @@ _decompressBlock(TDestValue *dstBegin,   TDestCapacity dstCapacity,
 }
 
 }  // namespace seqan3::contrib
+
+#endif // defined(SEQAN3_HAS_ZLIB)

--- a/include/seqan3/contrib/stream/bz2_istream.hpp
+++ b/include/seqan3/contrib/stream/bz2_istream.hpp
@@ -19,14 +19,16 @@
 
 #pragma once
 
-#ifndef SEQAN3_HAS_BZIP2
-#error "This file cannot be used when building without BZIP2-support."
-#endif
-
 #include <algorithm>
 #include <cstring>
 #include <iostream>
 #include <vector>
+
+#if !defined(SEQAN3_HAS_BZIP2) && !defined(SEQAN3_HEADER_TEST)
+#error "This file cannot be used when building without BZIP2-support."
+#endif // !defined(SEQAN3_HAS_BZIP2) && !defined(SEQAN3_HEADER_TEST)
+
+#if defined(SEQAN3_HAS_BZIP2)
 
 #define BZ_NO_STDIO
 #include <bzlib.h>
@@ -361,3 +363,5 @@ typedef basic_bz2_istream<char> bz2_istream;
 typedef basic_bz2_istream<wchar_t> bz2_wistream;
 
 } // namespace seqan3::contrib
+
+#endif // defined(SEQAN3_HAS_BZIP2)

--- a/include/seqan3/contrib/stream/bz2_ostream.hpp
+++ b/include/seqan3/contrib/stream/bz2_ostream.hpp
@@ -24,9 +24,11 @@
 #include <iostream>
 #include <vector>
 
-#ifndef SEQAN3_HAS_BZIP2
+#if !defined(SEQAN3_HAS_BZIP2) && !defined(SEQAN3_HEADER_TEST)
 #error "This file cannot be used when building without BZIP2-support."
-#endif
+#endif // !defined(SEQAN3_HAS_BZIP2) && !defined(SEQAN3_HEADER_TEST)
+
+#if defined(SEQAN3_HAS_BZIP2)
 
 #define BZ_NO_STDIO
 #include <bzlib.h>
@@ -421,3 +423,5 @@ typedef basic_bz2_ostream<char>    bz2_ostream;
 typedef basic_bz2_ostream<wchar_t> bz2_wostream;
 
 } // namespace seqan3::contrib
+
+#endif // defined(SEQAN3_HAS_BZIP2)

--- a/include/seqan3/contrib/stream/gz_istream.hpp
+++ b/include/seqan3/contrib/stream/gz_istream.hpp
@@ -25,9 +25,11 @@
 #include <cstring>
 #include <vector>
 
-#ifndef SEQAN3_HAS_ZLIB
+#if !defined(SEQAN3_HAS_ZLIB) && !defined(SEQAN3_HEADER_TEST)
 #error "This file cannot be used when building without ZLIB-support."
-#endif
+#endif // !defined(SEQAN3_HAS_ZLIB) && !defined(SEQAN3_HEADER_TEST)
+
+#if defined(SEQAN3_HAS_ZLIB)
 
 #include <zlib.h>
 
@@ -336,3 +338,5 @@ typedef basic_gz_istream<char>     gz_istream;
 typedef basic_gz_istream<wchar_t>  gz_wistream;
 
 } // namespace seqan3::contrib
+
+#endif // defined(SEQAN3_HAS_ZLIB)

--- a/include/seqan3/contrib/stream/gz_ostream.hpp
+++ b/include/seqan3/contrib/stream/gz_ostream.hpp
@@ -21,13 +21,15 @@
 
 #pragma once
 
-#ifndef SEQAN3_HAS_ZLIB
-#error "This file cannot be used when building without ZLIB-support."
-#endif
-
 #include <iostream>
 #include <cstring>
 #include <vector>
+
+#if !defined(SEQAN3_HAS_ZLIB) && !defined(SEQAN3_HEADER_TEST)
+#error "This file cannot be used when building without ZLIB-support."
+#endif // !defined(SEQAN3_HAS_ZLIB) && !defined(SEQAN3_HEADER_TEST)
+
+#if defined(SEQAN3_HAS_ZLIB)
 
 #include <zlib.h>
 
@@ -450,3 +452,5 @@ typedef basic_gz_ostream<char>     gz_ostream;
 typedef basic_gz_ostream<wchar_t>  gz_wostream;
 
 } // namespace seqan3::contrib
+
+#endif // defined(SEQAN3_HAS_ZLIB)

--- a/include/seqan3/io/detail/magic_header.hpp
+++ b/include/seqan3/io/detail/magic_header.hpp
@@ -118,9 +118,9 @@ using compression_formats = pack_traits::drop_front<void
                                                     , gz_compression
                                                     , bgzf_compression
                                                     #endif // defined(SEQAN3_HAS_ZLIB)
-                                                    #if SEQAN3_HAS_BZIP2
+                                                    #if defined(SEQAN3_HAS_BZIP2)
                                                     , bz2_compression
-                                                    #endif // SEQAN3_HAS_BZIP2
+                                                    #endif // defined(SEQAN3_HAS_BZIP2)
                                                     #if SEQAN3_HAS_ZSTD
                                                     , zstd_compression
                                                     #endif // SEQAN3_HAS_ZSTD

--- a/include/seqan3/io/detail/magic_header.hpp
+++ b/include/seqan3/io/detail/magic_header.hpp
@@ -114,10 +114,10 @@ struct bgzf_compression
  * \ingroup io
  */
 using compression_formats = pack_traits::drop_front<void
-                                                    #if SEQAN3_HAS_ZLIB
+                                                    #if defined(SEQAN3_HAS_ZLIB)
                                                     , gz_compression
                                                     , bgzf_compression
-                                                    #endif // SEQAN3_HAS_ZLIB
+                                                    #endif // defined(SEQAN3_HAS_ZLIB)
                                                     #if SEQAN3_HAS_BZIP2
                                                     , bz2_compression
                                                     #endif // SEQAN3_HAS_BZIP2

--- a/include/seqan3/io/detail/misc_input.hpp
+++ b/include/seqan3/io/detail/misc_input.hpp
@@ -21,7 +21,7 @@
 #include <string>
 #include <tuple>
 
-#ifdef SEQAN3_HAS_BZIP2
+#if defined(SEQAN3_HAS_BZIP2)
     #include <seqan3/contrib/stream/bz2_istream.hpp>
 #endif
 #if defined(SEQAN3_HAS_ZLIB)

--- a/include/seqan3/io/detail/misc_input.hpp
+++ b/include/seqan3/io/detail/misc_input.hpp
@@ -24,7 +24,7 @@
 #ifdef SEQAN3_HAS_BZIP2
     #include <seqan3/contrib/stream/bz2_istream.hpp>
 #endif
-#ifdef SEQAN3_HAS_ZLIB
+#if defined(SEQAN3_HAS_ZLIB)
     #include <seqan3/contrib/stream/bgzf_istream.hpp>
     #include <seqan3/contrib/stream/bgzf_stream_util.hpp>
     #include <seqan3/contrib/stream/gz_istream.hpp>
@@ -117,7 +117,7 @@ inline auto make_secondary_istream(std::basic_istream<char_t> & primary_stream, 
     // set return value appropriately
     if (read_chars == magic_number.size() && bgzf_compression::validate_header(std::span{magic_number})) // BGZF
     {
-    #ifdef SEQAN3_HAS_ZLIB
+    #if defined(SEQAN3_HAS_ZLIB)
         if (contains_extension(gz_compression{}, extension) || contains_extension(bgzf_compression{}, extension))
             filename.replace_extension();
 
@@ -129,7 +129,7 @@ inline auto make_secondary_istream(std::basic_istream<char_t> & primary_stream, 
     }
     else if (starts_with(magic_number, gz_compression::magic_header)) // GZIP
     {
-    #ifdef SEQAN3_HAS_ZLIB
+    #if defined(SEQAN3_HAS_ZLIB)
         if (contains_extension(gz_compression{}, extension) || contains_extension(bgzf_compression{}, extension))
             filename.replace_extension();
 
@@ -140,7 +140,7 @@ inline auto make_secondary_istream(std::basic_istream<char_t> & primary_stream, 
     }
     else if (starts_with(magic_number, bz2_compression::magic_header)) // BZip2
     {
-    #ifdef SEQAN3_HAS_BZIP2
+    #if defined(SEQAN3_HAS_BZIP2)
         if (contains_extension(bz2_compression{}, extension))
             filename.replace_extension();
 

--- a/include/seqan3/io/detail/misc_output.hpp
+++ b/include/seqan3/io/detail/misc_output.hpp
@@ -21,7 +21,7 @@
 #ifdef SEQAN3_HAS_BZIP2
     #include <seqan3/contrib/stream/bz2_ostream.hpp>
 #endif
-#ifdef SEQAN3_HAS_ZLIB
+#if defined(SEQAN3_HAS_ZLIB)
     #include <seqan3/contrib/stream/bgzf_ostream.hpp>
     #include <seqan3/contrib/stream/gz_ostream.hpp>
 #endif
@@ -50,7 +50,7 @@ inline auto make_secondary_ostream(std::basic_ostream<char_t> & primary_stream, 
 
     if (extension == ".gz")
     {
-#ifdef SEQAN3_HAS_ZLIB
+#if defined(SEQAN3_HAS_ZLIB)
         filename.replace_extension("");
         return {new contrib::basic_gz_ostream<char_t>{primary_stream}, stream_deleter_default};
 #else
@@ -59,7 +59,7 @@ inline auto make_secondary_ostream(std::basic_ostream<char_t> & primary_stream, 
     }
     else if ((extension == ".bgzf") || (extension == ".bam"))
     {
-#ifdef SEQAN3_HAS_ZLIB
+#if defined(SEQAN3_HAS_ZLIB)
         if (extension != ".bam") // remove extension except for bam
             filename.replace_extension("");
 

--- a/include/seqan3/io/detail/misc_output.hpp
+++ b/include/seqan3/io/detail/misc_output.hpp
@@ -13,6 +13,7 @@
 #pragma once
 
 #include <seqan3/std/filesystem>
+#include <functional>
 #include <iostream>
 #include <string>
 #include <tuple>

--- a/include/seqan3/io/detail/misc_output.hpp
+++ b/include/seqan3/io/detail/misc_output.hpp
@@ -18,7 +18,7 @@
 #include <string>
 #include <tuple>
 
-#ifdef SEQAN3_HAS_BZIP2
+#if defined(SEQAN3_HAS_BZIP2)
     #include <seqan3/contrib/stream/bz2_ostream.hpp>
 #endif
 #if defined(SEQAN3_HAS_ZLIB)
@@ -70,7 +70,7 @@ inline auto make_secondary_ostream(std::basic_ostream<char_t> & primary_stream, 
     }
     else if (extension == ".bz2")
     {
-#ifdef SEQAN3_HAS_BZIP2
+#if defined(SEQAN3_HAS_BZIP2)
         filename.replace_extension("");
         return {new contrib::basic_bz2_ostream<char_t>{primary_stream}, stream_deleter_default};
 #else

--- a/include/seqan3/io/structure_file/input.hpp
+++ b/include/seqan3/io/structure_file/input.hpp
@@ -13,6 +13,7 @@
 #pragma once
 
 #include <cassert>
+#include <seqan3/std/filesystem>
 #include <fstream>
 #include <limits>
 #include <optional>
@@ -30,7 +31,6 @@
 #include <seqan3/alphabet/structure/structured_aa.hpp>
 #include <seqan3/io/stream/concept.hpp>
 #include <seqan3/io/exception.hpp>
-#include <seqan3/std/filesystem>
 #include <seqan3/io/detail/in_file_iterator.hpp>
 #include <seqan3/io/detail/misc_input.hpp>
 #include <seqan3/io/detail/record.hpp>
@@ -38,6 +38,7 @@
 #include <seqan3/io/structure_file/input_options.hpp>
 #include <seqan3/io/structure_file/format_vienna.hpp>
 #include <seqan3/io/structure_file/record.hpp>
+#include <seqan3/utility/container/concept.hpp>
 #include <seqan3/utility/type_list/traits.hpp>
 
 namespace seqan3

--- a/test/performance/io/stream_input_benchmark.cpp
+++ b/test/performance/io/stream_input_benchmark.cpp
@@ -25,7 +25,7 @@
     #undef SEQAN3_HAS_BZIP2
 #endif
 
-#ifdef SEQAN3_HAS_BZIP2
+#if defined(SEQAN3_HAS_BZIP2)
     #include <seqan3/contrib/stream/bz2_istream.hpp>
     #include <seqan3/contrib/stream/bz2_ostream.hpp>
 #endif
@@ -38,7 +38,7 @@
         #define SEQAN_HAS_ZLIB 1
     #endif
 
-    #ifdef SEQAN3_HAS_BZIP2
+    #if defined(SEQAN3_HAS_BZIP2)
         #define SEQAN_HAS_BZIP2 1
     #endif
 
@@ -108,7 +108,7 @@ std::string const & input_comp<seqan::BgzfFile> = input_comp<seqan3::contrib::bg
 #endif
 #endif
 
-#ifdef SEQAN3_HAS_BZIP2
+#if defined(SEQAN3_HAS_BZIP2)
 template <>
 std::string const input_comp<seqan3::contrib::bz2_istream>
 {
@@ -183,7 +183,7 @@ BENCHMARK_TEMPLATE(compressed, seqan3::contrib::gz_istream);
 BENCHMARK_TEMPLATE(compressed, seqan3::contrib::bgzf_istream);
 #endif
 
-#ifdef SEQAN3_HAS_BZIP2
+#if defined(SEQAN3_HAS_BZIP2)
 BENCHMARK_TEMPLATE(compressed, seqan3::contrib::bz2_istream);
 #endif
 
@@ -217,7 +217,7 @@ void compressed_type_erased(benchmark::State & state)
 BENCHMARK_TEMPLATE(compressed_type_erased, seqan3::contrib::gz_istream);
 BENCHMARK_TEMPLATE(compressed_type_erased, seqan3::contrib::bgzf_istream);
 #endif
-#ifdef SEQAN3_HAS_BZIP2
+#if defined(SEQAN3_HAS_BZIP2)
 BENCHMARK_TEMPLATE(compressed_type_erased, seqan3::contrib::bz2_istream);
 #endif
 
@@ -251,7 +251,7 @@ void compressed_type_erased2(benchmark::State & state)
 BENCHMARK_TEMPLATE(compressed_type_erased2, seqan3::contrib::gz_istream);
 BENCHMARK_TEMPLATE(compressed_type_erased2, seqan3::contrib::bgzf_istream);
 #endif
-#ifdef SEQAN3_HAS_BZIP2
+#if defined(SEQAN3_HAS_BZIP2)
 BENCHMARK_TEMPLATE(compressed_type_erased2, seqan3::contrib::bz2_istream);
 #endif
 

--- a/test/performance/io/stream_input_benchmark.cpp
+++ b/test/performance/io/stream_input_benchmark.cpp
@@ -13,7 +13,7 @@
 
 #include <seqan3/io/stream/detail/fast_istreambuf_iterator.hpp>
 
-#ifdef SEQAN3_HAS_ZLIB
+#if defined(SEQAN3_HAS_ZLIB)
     #include <seqan3/contrib/stream/bgzf_istream.hpp>
     #include <seqan3/contrib/stream/bgzf_ostream.hpp>
     #include <seqan3/contrib/stream/gz_istream.hpp>
@@ -34,7 +34,7 @@
 #if __has_include(<seqan/stream.h>)
     #define SEQAN3_HAS_SEQAN2 1
 
-    #ifdef SEQAN3_HAS_ZLIB
+    #if defined(SEQAN3_HAS_ZLIB)
         #define SEQAN_HAS_ZLIB 1
     #endif
 
@@ -71,7 +71,7 @@ template <>
 std::string const & input_comp<seqan::Nothing> = input;
 #endif
 
-#ifdef SEQAN3_HAS_ZLIB
+#if defined(SEQAN3_HAS_ZLIB)
 template <>
 std::string const input_comp<seqan3::contrib::gz_istream>
 {
@@ -178,7 +178,7 @@ void compressed(benchmark::State & state)
     state.counters["iterations_per_run"] = i;
 }
 
-#ifdef SEQAN3_HAS_ZLIB
+#if defined(SEQAN3_HAS_ZLIB)
 BENCHMARK_TEMPLATE(compressed, seqan3::contrib::gz_istream);
 BENCHMARK_TEMPLATE(compressed, seqan3::contrib::bgzf_istream);
 #endif
@@ -213,7 +213,7 @@ void compressed_type_erased(benchmark::State & state)
     state.counters["iterations_per_run"] = i;
 }
 
-#ifdef SEQAN3_HAS_ZLIB
+#if defined(SEQAN3_HAS_ZLIB)
 BENCHMARK_TEMPLATE(compressed_type_erased, seqan3::contrib::gz_istream);
 BENCHMARK_TEMPLATE(compressed_type_erased, seqan3::contrib::bgzf_istream);
 #endif
@@ -247,7 +247,7 @@ void compressed_type_erased2(benchmark::State & state)
     state.counters["iterations_per_run"] = i;
 }
 
-#ifdef SEQAN3_HAS_ZLIB
+#if defined(SEQAN3_HAS_ZLIB)
 BENCHMARK_TEMPLATE(compressed_type_erased2, seqan3::contrib::gz_istream);
 BENCHMARK_TEMPLATE(compressed_type_erased2, seqan3::contrib::bgzf_istream);
 #endif

--- a/test/performance/io/stream_output_benchmark.cpp
+++ b/test/performance/io/stream_output_benchmark.cpp
@@ -11,7 +11,7 @@
 #include <memory>
 #include <sstream>
 
-#ifdef SEQAN3_HAS_ZLIB
+#if defined(SEQAN3_HAS_ZLIB)
     #include <seqan3/contrib/stream/bgzf_ostream.hpp>
     #include <seqan3/contrib/stream/gz_ostream.hpp>
 #endif
@@ -24,7 +24,7 @@
 #if __has_include(<seqan/stream.h>)
     #define SEQAN3_HAS_SEQAN2 1
 
-    #ifdef SEQAN3_HAS_ZLIB
+    #if defined(SEQAN3_HAS_ZLIB)
         #define SEQAN_HAS_ZLIB 1
     #endif
 
@@ -69,7 +69,7 @@ void compressed(benchmark::State & state)
         oit = static_cast<char>(i++ % 128);
 }
 
-#ifdef SEQAN3_HAS_ZLIB
+#if defined(SEQAN3_HAS_ZLIB)
 BENCHMARK_TEMPLATE(compressed, seqan3::contrib::gz_ostream);
 BENCHMARK_TEMPLATE(compressed, seqan3::contrib::bgzf_ostream);
 #endif
@@ -95,7 +95,7 @@ void compressed_type_erased(benchmark::State & state)
         oit = static_cast<char>(i++ % 128);
 }
 
-#ifdef SEQAN3_HAS_ZLIB
+#if defined(SEQAN3_HAS_ZLIB)
 BENCHMARK_TEMPLATE(compressed_type_erased, seqan3::contrib::gz_ostream);
 BENCHMARK_TEMPLATE(compressed_type_erased, seqan3::contrib::bgzf_ostream);
 #endif
@@ -121,7 +121,7 @@ void compressed_type_erased2(benchmark::State & state)
         oit = static_cast<char>(i++ % 128);
 }
 
-#ifdef SEQAN3_HAS_ZLIB
+#if defined(SEQAN3_HAS_ZLIB)
 BENCHMARK_TEMPLATE(compressed_type_erased2, seqan3::contrib::gz_ostream);
 BENCHMARK_TEMPLATE(compressed_type_erased2, seqan3::contrib::bgzf_ostream);
 #endif

--- a/test/performance/io/stream_output_benchmark.cpp
+++ b/test/performance/io/stream_output_benchmark.cpp
@@ -16,7 +16,7 @@
     #include <seqan3/contrib/stream/gz_ostream.hpp>
 #endif
 
-#ifdef SEQAN3_HAS_BZIP2
+#if defined(SEQAN3_HAS_BZIP2)
     #include <seqan3/contrib/stream/bz2_ostream.hpp>
 #endif
 
@@ -28,7 +28,7 @@
         #define SEQAN_HAS_ZLIB 1
     #endif
 
-    #ifdef SEQAN3_HAS_BZIP2
+    #if defined(SEQAN3_HAS_BZIP2)
         #define SEQAN_HAS_BZIP2 1
     #endif
 
@@ -73,7 +73,7 @@ void compressed(benchmark::State & state)
 BENCHMARK_TEMPLATE(compressed, seqan3::contrib::gz_ostream);
 BENCHMARK_TEMPLATE(compressed, seqan3::contrib::bgzf_ostream);
 #endif
-#ifdef SEQAN3_HAS_BZIP2
+#if defined(SEQAN3_HAS_BZIP2)
 BENCHMARK_TEMPLATE(compressed, seqan3::contrib::bz2_ostream);
 #endif
 
@@ -99,7 +99,7 @@ void compressed_type_erased(benchmark::State & state)
 BENCHMARK_TEMPLATE(compressed_type_erased, seqan3::contrib::gz_ostream);
 BENCHMARK_TEMPLATE(compressed_type_erased, seqan3::contrib::bgzf_ostream);
 #endif
-#ifdef SEQAN3_HAS_BZIP2
+#if defined(SEQAN3_HAS_BZIP2)
 BENCHMARK_TEMPLATE(compressed_type_erased, seqan3::contrib::bz2_ostream);
 #endif
 
@@ -125,7 +125,7 @@ void compressed_type_erased2(benchmark::State & state)
 BENCHMARK_TEMPLATE(compressed_type_erased2, seqan3::contrib::gz_ostream);
 BENCHMARK_TEMPLATE(compressed_type_erased2, seqan3::contrib::bgzf_ostream);
 #endif
-#ifdef SEQAN3_HAS_BZIP2
+#if defined(SEQAN3_HAS_BZIP2)
 BENCHMARK_TEMPLATE(compressed_type_erased2, seqan3::contrib::bz2_ostream);
 #endif
 

--- a/test/unit/io/detail/misc_output_test.cpp
+++ b/test/unit/io/detail/misc_output_test.cpp
@@ -37,7 +37,7 @@ inline std::vector<char> read_file_content(std::filesystem::path const & path)
     return {std::istreambuf_iterator{filestream}, std::istreambuf_iterator<char_t>{}};
 }
 
-#ifdef SEQAN3_HAS_ZLIB
+#if defined(SEQAN3_HAS_ZLIB)
 TEST(misc_output, issue2455_gz)
 {
     seqan3::test::tmp_filename const compressed_file = tmp_compressed_file("gz");

--- a/test/unit/io/detail/misc_output_test.cpp
+++ b/test/unit/io/detail/misc_output_test.cpp
@@ -57,7 +57,7 @@ TEST(misc_output, issue2455_bgzf)
 }
 #endif
 
-#ifdef SEQAN3_HAS_BZIP2
+#if defined(SEQAN3_HAS_BZIP2)
 TEST(misc_output, issue2455_bz)
 {
     seqan3::test::tmp_filename const compressed_file = tmp_compressed_file("bz2");

--- a/test/unit/io/sam_file/sam_file_input_test.cpp
+++ b/test/unit/io/sam_file/sam_file_input_test.cpp
@@ -328,7 +328,7 @@ void decompression_impl(fixture_t & fix, input_file_t & fin)
     EXPECT_EQ(counter, 3u);
 }
 
-#ifdef SEQAN3_HAS_ZLIB
+#if defined(SEQAN3_HAS_ZLIB)
 
 std::string input_gz
 {
@@ -617,7 +617,7 @@ struct sam_file_input_bam_format_f : public sam_file_input_sam_format_f
     };
 };
 
-#if SEQAN3_HAS_ZLIB
+#if defined(SEQAN3_HAS_ZLIB)
 TEST_F(sam_file_input_bam_format_f, construct_by_filename)
 {
     seqan3::test::tmp_filename filename{"sam_file_input_constructor.bam"};
@@ -681,4 +681,4 @@ TEST_F(sam_file_input_bam_format_f, construct_by_stream)
 
     EXPECT_EQ(counter, 3u);
 }
-#endif // SEQAN3_HAS_ZLIB
+#endif // defined(SEQAN3_HAS_ZLIB)

--- a/test/unit/io/sam_file/sam_file_input_test.cpp
+++ b/test/unit/io/sam_file/sam_file_input_test.cpp
@@ -441,7 +441,7 @@ TEST_F(sam_file_input_f, read_empty_bgzf_file)
 
 #endif
 
-#ifdef SEQAN3_HAS_BZIP2
+#if defined(SEQAN3_HAS_BZIP2)
 std::string input_bz2
 {
     '\x42','\x5A','\x68','\x39','\x31','\x41','\x59','\x26','\x53','\x59','\x7B','\xE2','\xE1','\x92','\x00','\x00',

--- a/test/unit/io/sam_file/sam_file_output_test.cpp
+++ b/test/unit/io/sam_file/sam_file_output_test.cpp
@@ -531,7 +531,7 @@ read3	43	ref	3	63	1S1M1D1M1I1M1I1D1M1S	ref	10	300	GGAGTATA	!!*+,-./
     EXPECT_EQ(reinterpret_cast<std::ostringstream &>(fout.get_stream()).str(), comp);
 }
 
-#if SEQAN3_HAS_ZLIB
+#if defined(SEQAN3_HAS_ZLIB)
 TEST(rows, write_bam_file)
 {
     seqan3::test::tmp_filename const filename{"in_out.bam"};
@@ -564,7 +564,7 @@ read3	43	ref	3	63	1S1M1D1M1I1M1I1D1M1S	ref	10	300	GGAGTATA	!!*+,-./
 
     EXPECT_EQ(reinterpret_cast<std::ostringstream &>(fout2.get_stream()).str(), comp);
 }
-#endif // SEQAN3_HAS_ZLIB
+#endif // defined(SEQAN3_HAS_ZLIB)
 
 TEST(rows, convert_sam_to_blast)
 {
@@ -618,7 +618,7 @@ void compression_by_stream_impl(comp_stream_t & stream)
     }
 }
 
-#ifdef SEQAN3_HAS_ZLIB
+#if defined(SEQAN3_HAS_ZLIB)
 std::string expected_gz
 {
     '\x1F', '\x8B', '\x08', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x2B', '\x4A', '\x4D',

--- a/test/unit/io/sam_file/sam_file_output_test.cpp
+++ b/test/unit/io/sam_file/sam_file_output_test.cpp
@@ -686,7 +686,7 @@ TEST(compression, by_stream_bgzf)
 }
 #endif
 
-#ifdef SEQAN3_HAS_BZIP2
+#if defined(SEQAN3_HAS_BZIP2)
 std::string expected_bz2
 {
     '\x42', '\x5A', '\x68', '\x39', '\x31', '\x41', '\x59', '\x26', '\x53', '\x59', '\xEA', '\x2B', '\x97',

--- a/test/unit/io/sequence_file/sequence_file_input_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_input_test.cpp
@@ -326,7 +326,7 @@ void decompression_impl(fixture_t & fix, input_file_t & fin)
     EXPECT_EQ(counter, 3u);
 }
 
-#ifdef SEQAN3_HAS_ZLIB
+#if defined(SEQAN3_HAS_ZLIB)
 std::string input_gz
 {
     '\x1F','\x8B','\x08','\x00','\x33','\xBF','\x13','\x5C','\x00','\x03','\xB3','\x53','\x08','\x71','\x0D','\x0E',

--- a/test/unit/io/sequence_file/sequence_file_input_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_input_test.cpp
@@ -432,7 +432,7 @@ TEST_F(sequence_file_input_f, read_empty_bgzf_file)
 }
 #endif
 
-#ifdef SEQAN3_HAS_BZIP2
+#if defined(SEQAN3_HAS_BZIP2)
 std::string input_bz2
 {
     '\x42','\x5A','\x68','\x39','\x31','\x41','\x59','\x26','\x53','\x59','\x8D','\xD7','\xE7','\xD6','\x00','\x00',

--- a/test/unit/io/sequence_file/sequence_file_output_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_output_test.cpp
@@ -527,7 +527,7 @@ TEST(compression, by_stream_bgzf)
 
 #endif
 
-#ifdef SEQAN3_HAS_BZIP2
+#if defined(SEQAN3_HAS_BZIP2)
 std::string expected_bz2
 {
     '\x42','\x5A','\x68','\x39','\x31','\x41','\x59','\x26','\x53','\x59','\xB4','\x68','\xEA','\xE3','\x00','\x00',

--- a/test/unit/io/sequence_file/sequence_file_output_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_output_test.cpp
@@ -457,7 +457,7 @@ void compression_by_stream_impl(comp_stream_t & stream)
     }
 }
 
-#ifdef SEQAN3_HAS_ZLIB
+#if defined(SEQAN3_HAS_ZLIB)
 std::string expected_gz
 {
     '\x1F','\x8B','\x08','\x00','\x00','\x00','\x00','\x00','\x00','\x00','\xB3','\x53','\x08','\x71','\x0D','\x0E',

--- a/test/unit/io/structure_file/structure_file_input_test.cpp
+++ b/test/unit/io/structure_file/structure_file_input_test.cpp
@@ -495,7 +495,7 @@ TEST_F(structure_file_input_read, read_empty_bgzf_file)
 
 #endif
 
-#ifdef SEQAN3_HAS_BZIP2
+#if defined(SEQAN3_HAS_BZIP2)
 std::string input_bz2
 {
     '\x42','\x5A','\x68','\x39','\x31','\x41','\x59','\x26','\x53','\x59','\xC7','\x0B','\xB5','\x7F','\x00','\x00',

--- a/test/unit/io/structure_file/structure_file_input_test.cpp
+++ b/test/unit/io/structure_file/structure_file_input_test.cpp
@@ -387,7 +387,7 @@ TEST_F(structure_file_input_read, record_file_view)
 // decompression
 // ----------------------------------------------------------------------------
 
-#ifdef SEQAN3_HAS_ZLIB
+#if defined(SEQAN3_HAS_ZLIB)
 std::string input_gz
 {
     '\x1F','\x8B','\x08','\x00','\x00','\x00','\x00','\x00','\x00','\x03','\x55','\x8E','\xC1','\x0A','\xC2','\x40',

--- a/test/unit/io/structure_file/structure_file_output_test.cpp
+++ b/test/unit/io/structure_file/structure_file_output_test.cpp
@@ -511,7 +511,7 @@ TEST_F(structure_file_output_compression, by_stream_bgzf)
 }
 #endif
 
-#ifdef SEQAN3_HAS_BZIP2
+#if defined(SEQAN3_HAS_BZIP2)
 std::string expected_bz2
 {
     '\x42','\x5A','\x68','\x39','\x31','\x41','\x59','\x26','\x53','\x59','\xC7','\x0B','\xB5','\x7F','\x00','\x00',

--- a/test/unit/io/structure_file/structure_file_output_test.cpp
+++ b/test/unit/io/structure_file/structure_file_output_test.cpp
@@ -435,7 +435,7 @@ struct structure_file_output_compression : public structure_file_output_write
 };
 #endif
 
-#ifdef SEQAN3_HAS_ZLIB
+#if defined(SEQAN3_HAS_ZLIB)
 std::string expected_gz
 {
     '\x1F','\x8B','\x08','\x00','\x00','\x00','\x00','\x00','\x00','\x00','\x55','\x8E','\xC1','\x0A','\xC2','\x40',


### PR DESCRIPTION
In https://github.com/seqan/seqan3/issues/2726#issuecomment-856603031 we noticed that the current header tests can't be build via

```
cmake -DSEQAN3_NO_ZLIB=1 -DSEQAN3_NO_BZIP2=1 <seqan3>/test/header
```

This PR fixes that.