### PR TITLE
[MISC] Use tmp_directory instead of tmp_filename

### DIFF
--- a/doc/howto/use_cereal/load.hpp
+++ b/doc/howto/use_cereal/load.hpp
@@ -7,29 +7,30 @@
 #include <cereal/types/vector.hpp>    // includes cerealisation support for std::vector
 
 #include <seqan3/core/debug_stream.hpp>
-#include <seqan3/test/tmp_filename.hpp>
+#include <seqan3/test/tmp_directory.hpp>
 
 // Written for std::vector, other types also work.
-void load(std::vector<int16_t> & data, seqan3::test::tmp_filename & tmp_file)
+void load(std::vector<int16_t> & data, std::filesystem::path const & tmp_file)
 {
-    std::ifstream is(tmp_file.get_path(), std::ios::binary); // Where input can be found.
-    cereal::BinaryInputArchive archive(is);                  // Create an input archive from the input stream.
-    archive(data);                                           // Load data.
+    std::ifstream is(tmp_file, std::ios::binary); // Where input can be found.
+    cereal::BinaryInputArchive archive(is);       // Create an input archive from the input stream.
+    archive(data);                                // Load data.
 }
 
 // Written for std::vector, other types also work.
-void store(std::vector<int16_t> const & data, seqan3::test::tmp_filename & tmp_file)
+void store(std::vector<int16_t> const & data, std::filesystem::path const & tmp_file)
 {
-    std::ofstream os(tmp_file.get_path(), std::ios::binary); // Where output should be stored.
-    cereal::BinaryOutputArchive archive(os);                 // Create an output archive from the output stream.
-    archive(data);                                           // Store data.
+    std::ofstream os(tmp_file, std::ios::binary); // Where output should be stored.
+    cereal::BinaryOutputArchive archive(os);      // Create an output archive from the output stream.
+    archive(data);                                // Store data.
 }
 
 int main()
 {
     // The following example is for a std::vector but any seqan3 data structure that is documented as serialisable
     // could be used, e.g. seqan3::fm_index.
-    seqan3::test::tmp_filename tmp_file{"data.out"}; // This is a temporary file, use any other filename.
+    seqan3::test::tmp_directory tmp{};
+    auto tmp_file = tmp.path() / "data.out"; // This is a temporary file name, use any other filename.
 
     std::vector<int16_t> vec{1,2,3,4};
     store(vec, tmp_file);                            // Calls store on a std::vector.

--- a/doc/howto/use_cereal/store.hpp
+++ b/doc/howto/use_cereal/store.hpp
@@ -9,21 +9,22 @@
 //! [vector_include]
 
 #include <seqan3/core/debug_stream.hpp>
-#include <seqan3/test/tmp_filename.hpp>
+#include <seqan3/test/tmp_directory.hpp>
 
 // Written for std::vector, other types also work.
-void store(std::vector<int16_t> const & data, seqan3::test::tmp_filename & tmp_file)
+void store(std::vector<int16_t> const & data, std::filesystem::path const & tmp_file)
 {
-    std::ofstream os(tmp_file.get_path(), std::ios::binary); // Where output should be stored.
-    cereal::BinaryOutputArchive archive(os);                 // Create an output archive from the output stream.
-    archive(data);                                           // Store data.
+    std::ofstream os(tmp_file, std::ios::binary); // Where output should be stored.
+    cereal::BinaryOutputArchive archive(os);      // Create an output archive from the output stream.
+    archive(data);                                // Store data.
 }
 
 int main()
 {
     // The following example is for a std::vector but any seqan3 data structure that is documented as serialisable
     // could be used, e.g. seqan3::fm_index.
-    seqan3::test::tmp_filename tmp_file{"data.out"}; // This is a temporary file, use any other filename.
+    seqan3::test::tmp_directory tmp{};
+    auto tmp_file = tmp.path() / "data.out"; // This is a temporary file name, use any other filename.
 
     std::vector<int16_t> vec{1,2,3,4};
     store(vec, tmp_file);                            // Calls store on a std::vector.

--- a/test/include/seqan3/test/cereal.hpp
+++ b/test/include/seqan3/test/cereal.hpp
@@ -18,7 +18,7 @@
 
 #include <seqan3/core/concept/cereal.hpp>
 #include <seqan3/core/platform.hpp>
-#include <seqan3/test/tmp_filename.hpp>
+#include <seqan3/test/tmp_directory.hpp>
 #include <seqan3/utility/type_traits/basic.hpp>
 
 #if SEQAN3_WITH_CEREAL
@@ -47,17 +47,18 @@ template <cereal_input_archive in_archive_t, cereal_output_archive out_archive_t
 //!\endcond
 void do_cerealisation(value_t && value)
 {
-    tmp_filename filename{"cereal_test"};
+    tmp_directory tmp{};
+    auto filename = tmp.path() / "cereal_test";
 
     {
-        std::ofstream os{filename.get_path(), std::ios::binary};
+        std::ofstream os{filename, std::ios::binary};
         out_archive_t oarchive{os};
         oarchive(value);
     }
 
     {
         std::remove_cvref_t<value_t> value_from_archive{};
-        std::ifstream is{filename.get_path(), std::ios::binary};
+        std::ifstream is{filename, std::ios::binary};
         in_archive_t iarchive{is};
         iarchive(value_from_archive);
         EXPECT_TRUE(value == value_from_archive);

--- a/test/performance/io/format_fastq_benchmark.cpp
+++ b/test/performance/io/format_fastq_benchmark.cpp
@@ -18,7 +18,7 @@
 #include <seqan3/test/performance/sequence_generator.hpp>
 #include <seqan3/test/performance/units.hpp>
 #include <seqan3/test/seqan2.hpp>
-#include <seqan3/test/tmp_filename.hpp>
+#include <seqan3/test/tmp_directory.hpp>
 
 #if SEQAN3_HAS_SEQAN2
 #include <seqan/seq_io.h>
@@ -56,17 +56,12 @@ std::string generate_fastq_string(size_t const entries_size)
 // save file on disc temporarily
 // ============================================================================
 
-auto create_fastq_file_for(std::string const & fastq_string)
+void create_fastq_file_for(std::filesystem::path const & fastq_file, std::string const & fastq_content)
 {
-    // create temporary file, automatically removed on destruction
-    seqan3::test::tmp_filename fastq_file{"format_fastq_benchmark_test_file.fastq"};
-    auto fastq_file_path = fastq_file.get_path();
-
     // fill temporary file with a FASTQ file
-    std::ofstream ostream{fastq_file_path};
-    ostream << fastq_string;
+    std::ofstream ostream{fastq_file};
+    ostream << fastq_content;
     ostream.close();
-    return fastq_file;
 }
 
 // ============================================================================
@@ -145,11 +140,13 @@ void fastq_read_from_disk_seqan3(benchmark::State & state)
 {
     size_t const iterations_per_run = state.range(0);
     std::string fastq_file = generate_fastq_string(iterations_per_run);
-    auto file_name = create_fastq_file_for(fastq_file);
+    seqan3::test::tmp_directory tmp{};
+    auto filename = tmp.path() / "format_fastq_benchmark_test_file.fastq";
+    create_fastq_file_for(filename, fastq_file);
 
     for (auto _ : state)
     {
-        seqan3::sequence_file_input fastq_file_in{file_name.get_path()};
+        seqan3::sequence_file_input fastq_file_in{filename};
         auto it = fastq_file_in.begin();
         for (size_t i = 0; i < iterations_per_run; ++i)
             it++;
@@ -159,6 +156,7 @@ void fastq_read_from_disk_seqan3(benchmark::State & state)
     state.counters["iterations_per_run"] = iterations_per_run;
     state.counters["bytes_per_run"] = bytes_per_run;
     state.counters["bytes_per_second"] = seqan3::test::bytes_per_second(bytes_per_run);
+    tmp.clean();
 }
 
 // ============================================================================
@@ -209,8 +207,10 @@ void fastq_read_from_stream_seqan2(benchmark::State & state)
 void fastq_read_from_disk_seqan2(benchmark::State & state)
 {
     size_t const iterations_per_run = state.range(0);
-    std::string fastq_file = generate_fastq_string(iterations_per_run);
-    auto file_name = create_fastq_file_for(fastq_file);
+    std::string fastq_content = generate_fastq_string(iterations_per_run);
+    seqan3::test::tmp_directory tmp{};
+    auto filename = tmp.path() / "format_fastq_benchmark_test_file.fastq";
+    create_fastq_file_for(filename, fastq_content);
 
     seqan::CharString id{};
     seqan::Dna5String seq{};
@@ -218,7 +218,7 @@ void fastq_read_from_disk_seqan2(benchmark::State & state)
 
     for (auto _ : state)
     {
-        seqan::SeqFileIn seqFileIn(file_name.get_path().c_str());
+        seqan::SeqFileIn seqFileIn(filename.c_str());
         auto it = seqFileIn.iter;
 
         for (size_t i = 0; i < iterations_per_run; ++i)
@@ -230,10 +230,11 @@ void fastq_read_from_disk_seqan2(benchmark::State & state)
         }
     }
 
-    size_t bytes_per_run = fastq_file.size();
+    size_t bytes_per_run = fastq_content.size();
     state.counters["iterations_per_run"] = iterations_per_run;
     state.counters["bytes_per_run"] = bytes_per_run;
     state.counters["bytes_per_second"] = seqan3::test::bytes_per_second(bytes_per_run);
+    tmp.clean();
 }
 #endif // SEQAN3_HAS_SEQAN2
 

--- a/test/performance/io/format_sam_benchmark.cpp
+++ b/test/performance/io/format_sam_benchmark.cpp
@@ -11,7 +11,7 @@
 #include <seqan3/io/sam_file/input.hpp>
 #include <seqan3/io/sam_file/output.hpp>
 #include <seqan3/test/performance/sequence_generator.hpp>
-#include <seqan3/test/tmp_filename.hpp>
+#include <seqan3/test/tmp_directory.hpp>
 
 #if SEQAN3_HAS_SEQAN2
 #include <seqan/bam_io.h>
@@ -118,8 +118,9 @@ void sam_file_read_from_stream(benchmark::State &state)
 void sam_file_read_from_disk(benchmark::State &state)
 {
     size_t const n_queries = state.range(0);
-    seqan3::test::tmp_filename file_name{"tmp.sam"};
-    auto tmp_path = file_name.get_path();
+
+    seqan3::test::tmp_directory tmp{};
+    auto tmp_path = tmp.path() / "tmp.sam";
 
     write_file(tmp_path, n_queries);
 
@@ -132,6 +133,7 @@ void sam_file_read_from_disk(benchmark::State &state)
         while (it != fin.end())
             ++it;
     }
+    tmp.clean();
 }
 
 #if SEQAN3_HAS_SEQAN2
@@ -142,13 +144,15 @@ void sam_file_read_from_disk(benchmark::State &state)
 void seqan2_sam_file_read_from_stream(benchmark::State &state)
 {
     size_t const n_queries = state.range(0);
-    seqan3::test::tmp_filename file_name{"tmp.sam"};
+    seqan3::test::tmp_directory tmp{};
+    auto filename = tmp.path() / "tmp.sam";
+
     std::string sam_file = create_sam_file_string(n_queries);
 
     // create temporary BamFileIn and read from disk to get the context...
-    write_file(file_name.get_path(), n_queries);
+    write_file(filename, n_queries);
     seqan::BamHeader tmp_header;
-    seqan::BamFileIn tmp_bam_file_in(file_name.get_path().c_str());
+    seqan::BamFileIn tmp_bam_file_in(filename.c_str());
     seqan::readHeader(tmp_header, tmp_bam_file_in);
     auto cxt = seqan::context(tmp_bam_file_in);
 
@@ -174,13 +178,15 @@ void seqan2_sam_file_read_from_stream(benchmark::State &state)
 
         clear(header);
     }
+    tmp.clean();
 }
 
 void seqan2_sam_file_read_from_disk(benchmark::State &state)
 {
     size_t const n_queries = state.range(0);
-    seqan3::test::tmp_filename file_name{"tmp.sam"};
-    auto tmp_path = file_name.get_path();
+
+    seqan3::test::tmp_directory tmp{};
+    auto tmp_path = tmp.path() / "tmp.sam";
 
     write_file(tmp_path, n_queries);
 
@@ -199,6 +205,7 @@ void seqan2_sam_file_read_from_disk(benchmark::State &state)
         seqan::clear(header);
         seqan::clear(record);
     }
+    tmp.clean();
 }
 
 #endif // SEQAN3_HAS_SEQAN2

--- a/test/performance/io/lowlevel_stream_input_benchmark.cpp
+++ b/test/performance/io/lowlevel_stream_input_benchmark.cpp
@@ -15,7 +15,7 @@
 #include <seqan3/io/stream/detail/fast_istreambuf_iterator.hpp>
 #include <seqan3/test/performance/sequence_generator.hpp>
 #include <seqan3/test/seqan2.hpp>
-#include <seqan3/test/tmp_filename.hpp>
+#include <seqan3/test/tmp_directory.hpp>
 
 #if SEQAN3_HAS_SEQAN2
 #include <seqan/stream.h>
@@ -33,10 +33,11 @@ template <tag id>
 void read_all(benchmark::State & state)
 {
     /* prepare file for reading */
-    seqan3::test::tmp_filename filename{"foo"};
+    seqan3::test::tmp_directory tmp{};
+    auto filename = tmp.path() / "foo";
 
     {
-        std::ofstream os{filename.get_path(), std::ios::binary};
+        std::ofstream os{filename, std::ios::binary};
 
         std::vector<seqan3::aa27> cont_rando = seqan3::test::generate_sequence<seqan3::aa27>(10'000, 0, 0);
 
@@ -51,7 +52,7 @@ void read_all(benchmark::State & state)
     {
         for (auto _ : state)
         {
-            std::ifstream s{filename.get_path(), std::ios::binary};
+            std::ifstream s{filename, std::ios::binary};
             std::istream_iterator<char> it{s};
             std::istream_iterator<char> e{};
 
@@ -63,7 +64,7 @@ void read_all(benchmark::State & state)
     {
         for (auto _ : state)
         {
-            std::ifstream s{filename.get_path(), std::ios::binary};
+            std::ifstream s{filename, std::ios::binary};
             std::istreambuf_iterator<char> it{s};
             std::istreambuf_iterator<char> e{};
 
@@ -75,7 +76,7 @@ void read_all(benchmark::State & state)
     {
         for (auto _ : state)
         {
-            std::ifstream s{filename.get_path(), std::ios::binary};
+            std::ifstream s{filename, std::ios::binary};
             seqan3::detail::fast_istreambuf_iterator<char> it{*s.rdbuf()};
             std::default_sentinel_t e{};
 
@@ -88,7 +89,7 @@ void read_all(benchmark::State & state)
     {
         for (auto _ : state)
         {
-            std::ifstream s{filename.get_path(), std::ios::binary};
+            std::ifstream s{filename, std::ios::binary};
             auto it = seqan::Iter<std::ifstream, seqan::StreamIterator<seqan::Input>>{s};
 
             for (; !seqan::atEnd(it); ++it)
@@ -96,6 +97,7 @@ void read_all(benchmark::State & state)
         }
     }
 #endif
+    tmp.clean();
 }
 
 BENCHMARK_TEMPLATE(read_all, tag::std_stream_it);

--- a/test/performance/io/lowlevel_stream_output_benchmark.cpp
+++ b/test/performance/io/lowlevel_stream_output_benchmark.cpp
@@ -15,7 +15,7 @@
 #include <seqan3/io/stream/detail/fast_ostreambuf_iterator.hpp>
 #include <seqan3/test/performance/sequence_generator.hpp>
 #include <seqan3/test/seqan2.hpp>
-#include <seqan3/test/tmp_filename.hpp>
+#include <seqan3/test/tmp_directory.hpp>
 
 #if SEQAN3_HAS_SEQAN2
 #include <seqan/stream.h>
@@ -35,8 +35,9 @@ template <tag id>
 void write_all(benchmark::State & state)
 {
     /* prepare file for writing */
-    seqan3::test::tmp_filename filename{"foo"};
-    std::ofstream os{filename.get_path(), std::ios::binary};
+    seqan3::test::tmp_directory tmp{};
+    auto filename = tmp.path() / "foo";
+    std::ofstream os{filename, std::ios::binary};
 
     // sequence to write:
     std::vector<char> sequence = seqan3::test::generate_sequence<char>(10'000, 0, 0);
@@ -47,7 +48,7 @@ void write_all(benchmark::State & state)
     /* start benchmark */
     for (auto _ : state)
     {
-        std::ofstream os{filename.get_path(), std::ios::binary};
+        std::ofstream os{filename, std::ios::binary};
 
         auto it = [&os]()
         {
@@ -87,6 +88,7 @@ void write_all(benchmark::State & state)
                 *it = chr;
         }
     }
+    tmp.clean();
 }
 
 BENCHMARK_TEMPLATE(write_all, tag::std_stream_it);

--- a/test/snippet/core/cereal_example.cpp
+++ b/test/snippet/core/cereal_example.cpp
@@ -6,29 +6,30 @@
 #include <cereal/types/vector.hpp>    // includes cerealisation support for std::vector
 
 #include <seqan3/core/debug_stream.hpp>
-#include <seqan3/test/tmp_filename.hpp>
+#include <seqan3/test/tmp_directory.hpp>
 
 // Written for std::vector, other types also work.
-void load(std::vector<int16_t> & data, seqan3::test::tmp_filename & tmp_file)
+void load(std::vector<int16_t> & data, std::filesystem::path const & tmp_file)
 {
-    std::ifstream is(tmp_file.get_path(), std::ios::binary); // Where input can be found.
-    cereal::BinaryInputArchive archive(is);                  // Create an input archive from the input stream.
-    archive(data);                                           // Load data.
+    std::ifstream is(tmp_file, std::ios::binary); // Where input can be found.
+    cereal::BinaryInputArchive archive(is);       // Create an input archive from the input stream.
+    archive(data);                                // Load data.
 }
 
 // Written for std::vector, other types also work.
-void store(std::vector<int16_t> const & data, seqan3::test::tmp_filename & tmp_file)
+void store(std::vector<int16_t> const & data, std::filesystem::path const & tmp_file)
 {
-    std::ofstream os(tmp_file.get_path(), std::ios::binary); // Where output should be stored.
-    cereal::BinaryOutputArchive archive(os);                 // Create an ouput archive from the output stream.
-    archive(data);                                           // Store data.
+    std::ofstream os(tmp_file, std::ios::binary); // Where output should be stored.
+    cereal::BinaryOutputArchive archive(os);      // Create an output archive from the output stream.
+    archive(data);                                // Store data.
 }
 
 int main()
 {
     // The following example is for a std::vector but any seqan3 data structure that is documented as serialisable
     // could be used, e.g. fm_index.
-    seqan3::test::tmp_filename tmp_file{"data.out"}; // This is a temporary file, use any other filename.
+    seqan3::test::tmp_directory tmp{};
+    auto tmp_file = tmp.path() / "data.out"; // this is a temporary file path, use any other filename.
 
     std::vector<int16_t> vec{1,2,3,4};
     store(vec, tmp_file);                            // Calls store on a std::vector.

--- a/test/unit/argument_parser/detail/version_check_test.hpp
+++ b/test/unit/argument_parser/detail/version_check_test.hpp
@@ -13,7 +13,7 @@
 #include <stdlib.h>
 
 #include <seqan3/argument_parser/argument_parser.hpp>
-#include <seqan3/test/tmp_filename.hpp>
+#include <seqan3/test/tmp_directory.hpp>
 
 //------------------------------------------------------------------------------
 // test fixtures
@@ -47,13 +47,18 @@ struct version_check : public ::testing::Test
 
     std::string const app_name = std::string{"test_version_check"};
 
-    // This tmp_filename will create the file "version_checker.tmpfile" in a unique folder.
-    seqan3::test::tmp_filename tmp_file{"version_checker.tmpfile"};
+    // This will generate a filename "version_checker.tmpfile" in a unique folder.
+    seqan3::test::tmp_directory tmp;
+    seqan3::test::sandboxed_path tmp_file = tmp.path() / "version_checker.tmpfile";
+
+    ~version_check() {
+        tmp.clean();
+    }
 
     void randomise_home_folder()
     {
         using namespace std::string_literals;
-        auto tmp_directory = tmp_file.get_path().parent_path();
+        auto tmp_directory = tmp_file.parent_path();
 
         int result = setenv(seqan3::detail::version_checker::home_env_name, tmp_directory.c_str(), 1);
         if (result != 0)

--- a/test/unit/argument_parser/format_parse_validators_test.cpp
+++ b/test/unit/argument_parser/format_parse_validators_test.cpp
@@ -13,7 +13,7 @@
 
 #include <seqan3/argument_parser/argument_parser.hpp>
 #include <seqan3/test/file_access.hpp>
-#include <seqan3/test/tmp_filename.hpp>
+#include <seqan3/test/tmp_directory.hpp>
 
 struct dummy_file
 {
@@ -90,27 +90,28 @@ TEST(validator_test, fullfill_concept)
 
 TEST(validator_test, input_file)
 {
-    seqan3::test::tmp_filename tmp_name{"testbox.fasta"};
-    seqan3::test::tmp_filename tmp_name_2{"testbox_2.fasta"};
-    seqan3::test::tmp_filename tmp_name_hidden{".testbox.fasta"};
-    seqan3::test::tmp_filename tmp_name_multiple{"testbox.fasta.txt"};
+    seqan3::test::tmp_directory tmp;
+    auto tmp_name = tmp.path() / "testbox.fasta";
+    auto tmp_name_2 = tmp.path() / "testbox_2.fasta";
+    auto tmp_name_hidden = tmp.path() / ".testbox.fasta";
+    auto tmp_name_multiple = tmp.path() / "testbox.fasta.txt";
 
     std::vector formats{std::string{"fa"}, std::string{"sam"}, std::string{"fasta"}, std::string{"fasta.txt"}};
 
-    std::ofstream tmp_file(tmp_name.get_path());
-    std::ofstream tmp_file_2(tmp_name_2.get_path());
-    std::ofstream tmp_file_hidden(tmp_name_hidden.get_path());
-    std::ofstream tmp_file_multiple(tmp_name_multiple.get_path());
+    std::ofstream tmp_file(tmp_name);
+    std::ofstream tmp_file_2(tmp_name_2);
+    std::ofstream tmp_file_hidden(tmp_name_hidden);
+    std::ofstream tmp_file_multiple(tmp_name_multiple);
 
     { // single file
 
         { // empty list of file.
             seqan3::input_file_validator my_validator{};
-            EXPECT_NO_THROW(my_validator(tmp_name.get_path()));
+            EXPECT_NO_THROW(my_validator(tmp_name));
         }
 
         { // file already exists.
-            std::filesystem::path does_not_exist{tmp_name.get_path()};
+            std::filesystem::path does_not_exist{tmp_name};
             does_not_exist.replace_extension(".bam");
             seqan3::input_file_validator my_validator{formats};
             EXPECT_THROW(my_validator(does_not_exist), seqan3::validation_error);
@@ -118,11 +119,11 @@ TEST(validator_test, input_file)
 
         { // file has wrong format.
             seqan3::input_file_validator my_validator{std::vector{std::string{"sam"}}};
-            EXPECT_THROW(my_validator(tmp_name.get_path()), seqan3::validation_error);
+            EXPECT_THROW(my_validator(tmp_name), seqan3::validation_error);
         }
 
         { // file has no extension.
-            std::filesystem::path does_not_exist{tmp_name.get_path()};
+            std::filesystem::path does_not_exist{tmp_name};
             does_not_exist.replace_extension();
             seqan3::input_file_validator my_validator{formats};
             EXPECT_THROW(my_validator(does_not_exist), seqan3::validation_error);
@@ -130,23 +131,23 @@ TEST(validator_test, input_file)
 
         { // filename starts with dot.
             seqan3::input_file_validator my_validator{formats};
-            EXPECT_NO_THROW(my_validator(tmp_name_hidden.get_path()));
+            EXPECT_NO_THROW(my_validator(tmp_name_hidden));
         }
 
         { // file has multiple extensions.
             seqan3::input_file_validator my_validator{formats};
-            EXPECT_NO_THROW(my_validator(tmp_name_multiple.get_path()));
+            EXPECT_NO_THROW(my_validator(tmp_name_multiple));
         }
 
         {  // read from file
             seqan3::input_file_validator<dummy_file> my_validator{};
-            EXPECT_NO_THROW(my_validator(tmp_name.get_path()));
+            EXPECT_NO_THROW(my_validator(tmp_name));
         }
 
         std::filesystem::path file_in_path;
 
         // option
-        std::string const & path = tmp_name.get_path().string();
+        std::string const & path = tmp_name.string();
         const char * argv[] = {"./argument_parser_test", "-i", path.c_str()};
         seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
@@ -161,8 +162,8 @@ TEST(validator_test, input_file)
         std::vector<std::filesystem::path> input_files;
 
         // option
-        std::string const & path = tmp_name.get_path().string();
-        std::string const & path_2 = tmp_name_2.get_path().string();
+        std::string const & path = tmp_name.string();
+        std::string const & path_2 = tmp_name_2.string();
 
         const char * argv[] = {"./argument_parser_test", path.c_str(), path_2.c_str()};
         seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
@@ -198,6 +199,7 @@ TEST(validator_test, input_file)
                                basic_version_str;
         EXPECT_EQ(my_stdout, expected);
     }
+    tmp.clean();
 }
 
 TEST(validator_test, input_file_ext_from_file)
@@ -213,13 +215,14 @@ TEST(validator_test, input_file_ext_from_file)
 
 TEST(validator_test, output_file)
 {
-    seqan3::test::tmp_filename tmp_name{"testbox.fasta"};
-    std::filesystem::path not_existing_path{tmp_name.get_path()};
-    seqan3::test::tmp_filename tmp_name_2{"testbox_2.fasta"};
-    std::ofstream tmp_file_2(tmp_name_2.get_path());    // create file
-    std::filesystem::path existing_path{tmp_name_2.get_path()};
-    seqan3::test::tmp_filename tmp_name_3{"testbox_3.fa"};
-    seqan3::test::tmp_filename hidden_name{".testbox.fasta"};
+    seqan3::test::tmp_directory tmp;
+    auto tmp_name = tmp.path() / "testbox.fasta";
+    auto not_existing_path = tmp_name;
+    auto tmp_name_2 = tmp.path() / "testbox_2.fasta";
+    std::ofstream tmp_file_2(tmp_name_2);    // create file
+    auto existing_path = tmp_name_2;
+    auto tmp_name_3 = tmp.path() / "testbox_3.fasta";
+    auto hidden_name = tmp.path() / ".testbox.fasta";
 
     std::vector formats{std::string{"fa"}, std::string{"sam"}, std::string{"fasta"}, std::string{"fasta.txt"}};
 
@@ -247,11 +250,11 @@ TEST(validator_test, output_file)
         { // file has wrong format.
             seqan3::output_file_validator my_validator{seqan3::output_file_open_options::create_new,
                                                        std::vector{std::string{"sam"}}};
-            EXPECT_THROW(my_validator(tmp_name.get_path()), seqan3::validation_error);
+            EXPECT_THROW(my_validator(tmp_name), seqan3::validation_error);
         }
 
         { // file has no extension.
-            std::filesystem::path no_extension{tmp_name.get_path()};
+            std::filesystem::path no_extension{tmp_name};
             no_extension.replace_extension();
             seqan3::output_file_validator my_validator{seqan3::output_file_open_options::create_new, formats};
             EXPECT_THROW(my_validator(no_extension), seqan3::validation_error);
@@ -259,11 +262,11 @@ TEST(validator_test, output_file)
 
         { // filename starts with dot.
             seqan3::output_file_validator my_validator{seqan3::output_file_open_options::create_new, formats};
-            EXPECT_NO_THROW(my_validator(hidden_name.get_path()));
+            EXPECT_NO_THROW(my_validator(hidden_name));
         }
 
         { // file has multiple extensions.
-            std::filesystem::path multiple_extension{tmp_name.get_path()};
+            std::filesystem::path multiple_extension{tmp_name};
             multiple_extension.replace_extension("fasta.txt");
             seqan3::output_file_validator my_validator{seqan3::output_file_open_options::create_new, formats};
             EXPECT_NO_THROW(my_validator(multiple_extension));
@@ -271,13 +274,13 @@ TEST(validator_test, output_file)
 
         {  // read from file
             seqan3::output_file_validator<dummy_file> my_validator{};
-            EXPECT_NO_THROW(my_validator(tmp_name.get_path()));
+            EXPECT_NO_THROW(my_validator(tmp_name));
         }
 
         std::filesystem::path file_out_path;
 
         // option
-        std::string const & path = tmp_name.get_path().string();
+        std::string const & path = tmp_name.string();
         const char * argv[] = {"./argument_parser_test", "-o", path.c_str()};
         seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
@@ -293,8 +296,8 @@ TEST(validator_test, output_file)
         std::vector<std::filesystem::path> output_files;
 
         // option
-        std::string const & path = tmp_name.get_path().string();
-        std::string const & path_3 = tmp_name_3.get_path().string();
+        std::string const & path = tmp_name.string();
+        std::string const & path_3 = tmp_name_3.string();
 
         const char * argv[] = {"./argument_parser_test", path.c_str(), path_3.c_str()};
         seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
@@ -361,6 +364,7 @@ TEST(validator_test, output_file)
                                basic_version_str;
         EXPECT_EQ(my_stdout, expected);
     }
+    tmp.clean();
 }
 
 TEST(validator_test, output_file_ext_from_file)
@@ -392,18 +396,19 @@ TEST(validator_test, output_file_ext_from_file)
 
 TEST(validator_test, input_directory)
 {
-    seqan3::test::tmp_filename tmp_name{"testbox.fasta"};
+    seqan3::test::tmp_directory tmp{};
+    auto tmp_name = tmp.path() / "testbox.fasta";
 
     { // directory
 
         { // has filename
-            std::ofstream tmp_dir(tmp_name.get_path());
+            std::ofstream tmp_dir(tmp_name);
             seqan3::input_directory_validator my_validator{};
-            EXPECT_THROW(my_validator(tmp_name.get_path()), seqan3::validation_error);
+            EXPECT_THROW(my_validator(tmp_name), seqan3::validation_error);
         }
 
         { // read directory
-            std::filesystem::path p = tmp_name.get_path();
+            std::filesystem::path p = tmp_name;
             p.remove_filename();
             std::ofstream tmp_dir(p);
             seqan3::input_directory_validator my_validator{};
@@ -449,14 +454,15 @@ TEST(validator_test, input_directory)
 
         EXPECT_EQ(my_stdout, expected);
     }
+    tmp.clean();
 }
 
 TEST(validator_test, output_directory)
 {
-    seqan3::test::tmp_filename tmp_name{"testbox.fasta"};
+    seqan3::test::tmp_directory tmp{};
 
     { // read directory
-        std::filesystem::path p = tmp_name.get_path();
+        std::filesystem::path p = tmp.path() / "testbox.fasta";
         p.remove_filename();
         seqan3::output_directory_validator my_validator{};
         my_validator(p);
@@ -478,8 +484,8 @@ TEST(validator_test, output_directory)
     }
 
     { // Parent path exists and is writable.
-        seqan3::test::tmp_filename tmp_child_name{"dir/child_dir"};
-        std::filesystem::path tmp_child_dir{tmp_child_name.get_path()};
+        std::filesystem::path tmp_child_name = tmp.path() / "dir/child_dir";
+        std::filesystem::path tmp_child_dir{tmp_child_name};
         std::filesystem::path tmp_parent_path{tmp_child_dir.parent_path()};
 
         std::filesystem::create_directory(tmp_parent_path);
@@ -516,9 +522,10 @@ TEST(validator_test, output_directory)
 
 TEST(validator_test, inputfile_not_readable)
 {
-    seqan3::test::tmp_filename tmp_name{"my_file.test"};
-    std::filesystem::path tmp_file{tmp_name.get_path()};
-    std::ofstream str{tmp_name.get_path()};
+    seqan3::test::tmp_directory tmp;
+    auto tmp_name = tmp.path() / "my_file.test";
+    std::filesystem::path tmp_file{tmp_name};
+    std::ofstream str{tmp_name};
 
     EXPECT_NO_THROW(seqan3::input_file_validator{}(tmp_file));
 
@@ -536,12 +543,13 @@ TEST(validator_test, inputfile_not_readable)
                                  std::filesystem::perms::owner_read | std::filesystem::perms::group_read |
                                  std::filesystem::perms::others_read,
                                  std::filesystem::perm_options::add);
+    tmp.clean();
 }
 
 TEST(validator_test, inputfile_not_regular)
 {
-    seqan3::test::tmp_filename tmp{"my_file.test"};
-    std::filesystem::path filename = tmp.get_path();
+    seqan3::test::tmp_directory tmp;
+    std::filesystem::path filename = tmp.path() / "my_file.test";
     mkfifo(filename.c_str(), 0644);
 
     EXPECT_THROW(seqan3::input_file_validator{}(filename), seqan3::validation_error);
@@ -549,16 +557,18 @@ TEST(validator_test, inputfile_not_regular)
 
 TEST(validator_test, inputdir_not_existing)
 {
-    seqan3::test::tmp_filename tmp_name{"dir"};
-    std::filesystem::path not_existing_dir{tmp_name.get_path()};
+    seqan3::test::tmp_directory tmp;
+    std::filesystem::path tmp_name = tmp.path() / "dir";
+
+    std::filesystem::path not_existing_dir{tmp_name};
 
     EXPECT_THROW(seqan3::input_directory_validator{}(not_existing_dir), seqan3::validation_error);
 }
 
 TEST(validator_test, inputdir_not_readable)
 {
-    seqan3::test::tmp_filename tmp_name{"dir"};
-    std::filesystem::path tmp_dir{tmp_name.get_path()};
+    seqan3::test::tmp_directory tmp;
+    auto tmp_dir = tmp.path() / "dir";
 
     std::filesystem::create_directory(tmp_dir);
 
@@ -578,12 +588,13 @@ TEST(validator_test, inputdir_not_readable)
                                  std::filesystem::perms::owner_read | std::filesystem::perms::group_read |
                                  std::filesystem::perms::others_read,
                                  std::filesystem::perm_options::add);
+    tmp.clean();
 }
 
 TEST(validator_test, outputfile_not_writable)
 {
-    seqan3::test::tmp_filename tmp_name{"my_file.test"};
-    std::filesystem::path tmp_file{tmp_name.get_path()};
+    seqan3::test::tmp_directory tmp;
+    auto tmp_file = tmp.path() / "my_file.test";
 
     EXPECT_NO_THROW(seqan3::output_file_validator{seqan3::output_file_open_options::create_new}(tmp_file));
 
@@ -604,20 +615,20 @@ TEST(validator_test, outputfile_not_writable)
                                  std::filesystem::perms::owner_write | std::filesystem::perms::group_write |
                                  std::filesystem::perms::others_write,
                                  std::filesystem::perm_options::add);
+    tmp.clean();
 }
 
 TEST(validator_test, outputdir_not_writable)
 {
     { // parent dir is not writable.
-        seqan3::test::tmp_filename tmp_name{"dir"};
-        std::filesystem::path tmp_dir{tmp_name.get_path()};
+        seqan3::test::tmp_directory tmp;
+        auto tmp_dir = tmp.path() / "dir";
 
         EXPECT_NO_THROW(seqan3::output_file_validator{seqan3::output_file_open_options::create_new}(tmp_dir));
         EXPECT_FALSE(std::filesystem::exists(tmp_dir));
 
         // parent dir does not exist
-        seqan3::test::tmp_filename tmp_child_name{"dir/child_dir"};
-        std::filesystem::path tmp_child_dir{tmp_child_name.get_path()};
+        std::filesystem::path tmp_child_dir{tmp.path() / "dir/child_dir"};
         std::filesystem::path tmp_parent_dir{tmp_child_dir.parent_path()};
 
         EXPECT_THROW(seqan3::output_directory_validator{}(tmp_child_dir), seqan3::validation_error);
@@ -656,11 +667,12 @@ TEST(validator_test, outputdir_not_writable)
                                      std::filesystem::perms::owner_write | std::filesystem::perms::group_write |
                                      std::filesystem::perms::others_write,
                                      std::filesystem::perm_options::add);
+        tmp.clean();
     }
 
     {  // this dir is not writable
-        seqan3::test::tmp_filename tmp_name{"dir"};
-        std::filesystem::path tmp_dir{tmp_name.get_path()};
+        seqan3::test::tmp_directory tmp;
+        auto tmp_dir = tmp.path() / "dir";
 
         std::filesystem::create_directory(tmp_dir);
         EXPECT_NO_THROW(seqan3::output_directory_validator{}(tmp_dir));
@@ -682,6 +694,7 @@ TEST(validator_test, outputdir_not_writable)
                                      std::filesystem::perms::owner_write | std::filesystem::perms::group_write |
                                      std::filesystem::perms::others_write,
                                      std::filesystem::perm_options::add);
+        tmp.clean();
     }
 }
 
@@ -1272,13 +1285,15 @@ TEST(validator_test, chaining_validators)
     seqan3::regex_validator absolute_path_validator{"(/[^/]+)+/.*\\.[^/\\.]+$"};
     seqan3::output_file_validator my_file_ext_validator{seqan3::output_file_open_options::create_new, {"sa", "so"}};
 
-    seqan3::test::tmp_filename tmp_name{"file.sa"};
-    std::filesystem::path invalid_extension{tmp_name.get_path()};
+    seqan3::test::tmp_directory tmp;
+    auto tmp_name = tmp.path() / "file.sa";
+
+    std::filesystem::path invalid_extension{tmp_name};
     invalid_extension.replace_extension(".invalid");
 
     // option
     {
-        std::string const & path = tmp_name.get_path().string();
+        std::string const & path = tmp_name.string();
         const char * argv[] = {"./argument_parser_test", "-s", path.c_str()};
         seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
@@ -1292,7 +1307,7 @@ TEST(validator_test, chaining_validators)
     }
 
     {
-        auto rel_path = tmp_name.get_path().relative_path().string();
+        auto rel_path = tmp_name.relative_path().string();
         const char * argv[] = {"./argument_parser_test", "-s", rel_path.c_str()};
         seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
@@ -1315,7 +1330,7 @@ TEST(validator_test, chaining_validators)
 
     // with temporary validators
     {
-        std::string const & path = tmp_name.get_path().string();
+        std::string const & path = tmp_name.string();
         const char * argv[] = {"./argument_parser_test", "-s", path.c_str()};
         seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
@@ -1332,7 +1347,7 @@ TEST(validator_test, chaining_validators)
 
     // three validators
     {
-        std::string const & path = tmp_name.get_path().string();
+        std::string const & path = tmp_name.string();
         const char * argv[] = {"./argument_parser_test", "-s", path.c_str()};
         seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);
@@ -1408,7 +1423,7 @@ TEST(validator_test, chaining_validators)
     // chaining with a container option value type
     {
         std::vector<std::string> option_list_value{};
-        std::string const & path = tmp_name.get_path().string();
+        std::string const & path = tmp_name.string();
         const char * argv[] = {"./argument_parser_test", "-s", path.c_str()};
         seqan3::argument_parser parser{"test_parser", 3, argv, seqan3::update_notifications::off};
         test_accessor::set_terminal_width(parser, 80);

--- a/test/unit/io/detail/safe_filesystem_entry_test.cpp
+++ b/test/unit/io/detail/safe_filesystem_entry_test.cpp
@@ -10,12 +10,12 @@
 #include <fstream>
 
 #include <seqan3/io/detail/safe_filesystem_entry.hpp>
-#include <seqan3/test/tmp_filename.hpp>
+#include <seqan3/test/tmp_directory.hpp>
 
 TEST(safe_filesystem_entry, file)
 {
-    seqan3::test::tmp_filename tmp_file{"dummy.txt"};
-    std::filesystem::path my_file = tmp_file.get_path();
+    seqan3::test::tmp_directory tmp;
+    auto my_file = tmp.path() / "dummy.txt";
     {
         std::ofstream file{my_file};
         EXPECT_TRUE(std::filesystem::exists(my_file));
@@ -23,12 +23,13 @@ TEST(safe_filesystem_entry, file)
     }
 
     EXPECT_FALSE(std::filesystem::exists(my_file));
+    tmp.clean();
 }
 
 TEST(safe_filesystem_entry, file_already_removed)
 {
-    seqan3::test::tmp_filename tmp_file{"dummy.txt"};
-    std::filesystem::path my_file = tmp_file.get_path();
+    seqan3::test::tmp_directory tmp;
+    auto my_file = tmp.path() / "dummy.txt";
     {
         EXPECT_FALSE(std::filesystem::exists(my_file));
         seqan3::detail::safe_filesystem_entry file_guard{my_file};
@@ -39,8 +40,8 @@ TEST(safe_filesystem_entry, file_already_removed)
 
 TEST(safe_filesystem_entry, directory)
 {
-    seqan3::test::tmp_filename tmp_file{"dummy.txt"};
-    std::filesystem::path my_dir = tmp_file.get_path();
+    seqan3::test::tmp_directory tmp;
+    auto my_dir = tmp.path() / "dummy.txt";
     {
         std::filesystem::create_directory(my_dir);
         EXPECT_TRUE(std::filesystem::exists(my_dir));
@@ -52,8 +53,8 @@ TEST(safe_filesystem_entry, directory)
 
 TEST(safe_filesystem_entry, directory_already_removed)
 {
-    seqan3::test::tmp_filename tmp_file{"dummy.txt"};
-    std::filesystem::path my_dir = tmp_file.get_path();
+    seqan3::test::tmp_directory tmp;
+    auto my_dir = tmp.path() / "dummy.txt";
     {
         EXPECT_FALSE(std::filesystem::exists(my_dir));
         seqan3::detail::safe_filesystem_entry dir_guard{my_dir};
@@ -64,8 +65,8 @@ TEST(safe_filesystem_entry, directory_already_removed)
 
 TEST(safe_filesystem_entry, remove)
 {
-    seqan3::test::tmp_filename tmp_file{"dummy.txt"};
-    std::filesystem::path my_file = tmp_file.get_path();
+    seqan3::test::tmp_directory tmp;
+    auto my_file = tmp.path() / "dummy.txt";
     {
         std::ofstream file{my_file};
         EXPECT_TRUE(std::filesystem::exists(my_file));
@@ -78,8 +79,8 @@ TEST(safe_filesystem_entry, remove)
 
 TEST(safe_filesystem_entry, remove_all)
 {
-    seqan3::test::tmp_filename tmp_file{"dummy.txt"};
-    std::filesystem::path my_dir = tmp_file.get_path();
+    seqan3::test::tmp_directory tmp;
+    auto my_dir = tmp.path() / "dummy.txt";
     {
         std::filesystem::create_directory(my_dir);
         EXPECT_TRUE(std::filesystem::exists(my_dir));

--- a/test/unit/io/sequence_file/sequence_file_integration_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_integration_test.cpp
@@ -13,7 +13,6 @@
 #include <seqan3/core/detail/persist_view.hpp>
 #include <seqan3/io/sequence_file/input.hpp>
 #include <seqan3/io/sequence_file/output.hpp>
-#include <seqan3/test/tmp_filename.hpp>
 
 TEST(rows, assign_sequence_files)
 {

--- a/test/unit/io/sequence_file/sequence_file_output_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_output_test.cpp
@@ -12,7 +12,7 @@
 
 #include <seqan3/alphabet/quality/phred42.hpp>
 #include <seqan3/io/sequence_file/output.hpp>
-#include <seqan3/test/tmp_filename.hpp>
+#include <seqan3/test/tmp_directory.hpp>
 #include <seqan3/utility/views/zip.hpp>
 
 using seqan3::operator""_dna5;
@@ -78,31 +78,38 @@ TEST(general, construct_by_filename)
 {
     /* just the filename */
     {
-        seqan3::test::tmp_filename filename{"sequence_file_output_constructor.fasta"};
-        EXPECT_NO_THROW( seqan3::sequence_file_output<>{filename.get_path()} );
+        seqan3::test::tmp_directory tmp;
+        auto filename = tmp.path() / "sequence_file_output_constructor.fasta";
+        EXPECT_NO_THROW( seqan3::sequence_file_output<>{filename} );
+        tmp.clean();
     }
 
     /* wrong extension */
     {
-        seqan3::test::tmp_filename filename{"sequence_file_output_constructor.xyz"};
-        std::ofstream filecreator{filename.get_path(), std::ios::out | std::ios::binary};
-        EXPECT_THROW( seqan3::sequence_file_output<>{filename.get_path()} ,
+        seqan3::test::tmp_directory tmp;
+        auto filename = tmp.path() / "sequence_file_output_constructor.xyz";
+        std::ofstream filecreator{filename, std::ios::out | std::ios::binary};
+        EXPECT_THROW( seqan3::sequence_file_output<>{filename} ,
                       seqan3::unhandled_extension_error );
+        tmp.clean();
     }
 
     /* unknown file */
     {
-        seqan3::test::tmp_filename filename{"I/do/not/exist.fasta"};
-        EXPECT_THROW( seqan3::sequence_file_output<>{filename.get_path()}, seqan3::file_open_error );
+        seqan3::test::tmp_directory tmp;
+        auto filename = tmp.path() / "I/do/not/exist.fasta";
+        EXPECT_THROW( seqan3::sequence_file_output<>{filename}, seqan3::file_open_error );
     }
 
     /* filename + fields */
     using fields_seq = seqan3::fields<seqan3::field::seq>;
     {
-        seqan3::test::tmp_filename filename{"sequence_file_output_constructor.fasta"};
+        seqan3::test::tmp_directory tmp;
+        auto filename = tmp.path() / "sequence_file_output_constructor.fasta";
         EXPECT_NO_THROW(( seqan3::sequence_file_output<fields_seq,
-                                                       seqan3::type_list<seqan3::format_fasta>>{filename.get_path(),
+                                                       seqan3::type_list<seqan3::format_fasta>>{filename,
                                                                                                 fields_seq{}}));
+        tmp.clean();
     }
 }
 
@@ -140,26 +147,30 @@ TEST(general, default_template_args_and_deduction_guides)
 
     /* guided filename constructor */
     {
-        seqan3::test::tmp_filename filename{"sequence_file_output_constructor.fasta"};
+        seqan3::test::tmp_directory tmp;
+        auto filename = tmp.path() / "sequence_file_output_constructor.fasta";
 
-        seqan3::sequence_file_output fout{filename.get_path()};
+        seqan3::sequence_file_output fout{filename};
 
         using t = decltype(fout);
         EXPECT_TRUE((std::is_same_v<typename t::selected_field_ids, default_fields>));
         EXPECT_TRUE((std::is_same_v<typename t::valid_formats,      comp2>));
         EXPECT_TRUE((std::is_same_v<typename t::stream_char_type,   comp3>));
+        tmp.clean();
     }
 
     /* guided filename constructor + custom fields */
     {
-        seqan3::test::tmp_filename filename{"sequence_file_output_constructor.fasta"};
+        seqan3::test::tmp_directory tmp;
+        auto filename = tmp.path() / "sequence_file_output_constructor.fasta";
 
-        seqan3::sequence_file_output fout{filename.get_path(), seqan3::fields<seqan3::field::seq>{}};
+        seqan3::sequence_file_output fout{filename, seqan3::fields<seqan3::field::seq>{}};
 
         using t = decltype(fout);
         EXPECT_TRUE((std::is_same_v<typename t::selected_field_ids, seqan3::fields<seqan3::field::seq>>)); // changed
         EXPECT_TRUE((std::is_same_v<typename t::valid_formats,      comp2>));
         EXPECT_TRUE((std::is_same_v<typename t::stream_char_type,   comp3>));
+        tmp.clean();
     }
 
     /* guided stream constructor */
@@ -416,10 +427,10 @@ TEST(columns, writing_id_seq_qual)
 // compression
 // ----------------------------------------------------------------------------
 
-std::string compression_by_filename_impl([[maybe_unused]]seqan3::test::tmp_filename & filename)
+std::string compression_by_filename_impl(seqan3::test::sandboxed_path const & filename)
 {
     {
-        seqan3::sequence_file_output fout{filename.get_path()};
+        seqan3::sequence_file_output fout{filename};
         fout.options.fasta_letters_per_line = 0;
 
         for (size_t i = 0; i < 3; ++i)
@@ -435,7 +446,7 @@ std::string compression_by_filename_impl([[maybe_unused]]seqan3::test::tmp_filen
     std::string buffer;
 
     {
-        std::ifstream fi{filename.get_path(), std::ios::binary};
+        std::ifstream fi{filename, std::ios::binary};
 
         buffer = std::string{std::istreambuf_iterator<char>{fi}, std::istreambuf_iterator<char>{}};
     }
@@ -481,11 +492,13 @@ std::string expected_bgzf
 
 TEST(compression, by_filename_gz)
 {
-    seqan3::test::tmp_filename filename{"sequence_file_output_test.fasta.gz"};
+    seqan3::test::tmp_directory tmp;
+    auto filename = tmp.path() / "sequence_file_output_test.fasta.gz";
 
     std::string buffer = compression_by_filename_impl(filename);
     buffer[9] = '\x00'; // zero out OS byte
     EXPECT_EQ(buffer, expected_gz);
+    tmp.clean();
 }
 
 TEST(compression, by_stream_gz)
@@ -504,11 +517,13 @@ TEST(compression, by_stream_gz)
 
 TEST(compression, by_filename_bgzf)
 {
-    seqan3::test::tmp_filename filename{"sequence_file_output_test.fasta.bgzf"};
+    seqan3::test::tmp_directory tmp;
+    auto filename = tmp.path() / "sequence_file_output_test.fasta.bgzf";
 
     std::string buffer = compression_by_filename_impl(filename);
     buffer[9] = '\x00'; // zero out OS byte
     EXPECT_EQ(buffer, expected_bgzf);
+    tmp.clean();
 }
 
 TEST(compression, by_stream_bgzf)
@@ -540,10 +555,12 @@ std::string expected_bz2
 
 TEST(compression, by_filename_bz2)
 {
-    seqan3::test::tmp_filename filename{"sequence_file_output_test.fasta.bz2"};
+    seqan3::test::tmp_directory tmp;
+    auto filename = tmp.path() / "sequence_file_output_test.fasta.bz2";
 
     std::string buffer = compression_by_filename_impl(filename);
     EXPECT_EQ(buffer, expected_bz2);
+    tmp.clean();
 }
 
 TEST(compression, by_stream_bz2)

--- a/test/unit/io/stream/istream_test_template.hpp
+++ b/test/unit/io/stream/istream_test_template.hpp
@@ -12,8 +12,7 @@
 #include <string>
 
 #include <seqan3/io/stream/concept.hpp>
-
-#include <seqan3/test/tmp_filename.hpp>
+#include <seqan3/test/tmp_directory.hpp>
 
 template <typename T>
 class istream : public ::testing::Test
@@ -30,36 +29,40 @@ TYPED_TEST_P(istream, concept_check)
 
 TYPED_TEST_P(istream, input)
 {
-    seqan3::test::tmp_filename filename{"istream_test"};
+    seqan3::test::tmp_directory tmp{};
+    auto filename = tmp.path() / "istream_test";
 
     {
-        std::ofstream fi{filename.get_path()};
+        std::ofstream fi{filename};
 
         fi << TestFixture::compressed;
     }
 
-    std::ifstream fi{filename.get_path(), std::ios::binary};
+    std::ifstream fi{filename, std::ios::binary};
     TypeParam comp{fi};
     std::string buffer{std::istreambuf_iterator<char>{comp}, std::istreambuf_iterator<char>{}};
 
     EXPECT_EQ(buffer, uncompressed);
+    tmp.clean();
 }
 
 TYPED_TEST_P(istream, input_type_erased)
 {
-    seqan3::test::tmp_filename filename{"istream_test"};
+    seqan3::test::tmp_directory tmp{};
+    auto filename = tmp.path() / "istream_test";
 
     {
-        std::ofstream fi{filename.get_path()};
+        std::ofstream fi{filename};
 
         fi << TestFixture::compressed;
     }
 
-    std::ifstream fi{filename.get_path(), std::ios::binary};
+    std::ifstream fi{filename, std::ios::binary};
     std::unique_ptr<std::istream> comp{new TypeParam{fi}};
     std::string buffer{std::istreambuf_iterator<char>{*comp}, std::istreambuf_iterator<char>{}};
 
     EXPECT_EQ(buffer, uncompressed);
+    tmp.clean();
 }
 
 REGISTER_TYPED_TEST_SUITE_P(istream, concept_check, input, input_type_erased);

--- a/test/unit/io/stream/ostream_test_template.hpp
+++ b/test/unit/io/stream/ostream_test_template.hpp
@@ -7,13 +7,13 @@
 
 #include <gtest/gtest.h>
 
+#include <seqan3/std/concepts>
 #include <fstream>
 #include <iostream>
 #include <string>
 
 #include <seqan3/io/stream/concept.hpp>
-#include <seqan3/std/concepts>
-#include <seqan3/test/tmp_filename.hpp>
+#include <seqan3/test/tmp_directory.hpp>
 
 template <typename T>
 class ostream : public ::testing::Test
@@ -30,43 +30,47 @@ TYPED_TEST_P(ostream, concept_check)
 
 TYPED_TEST_P(ostream, output)
 {
-    seqan3::test::tmp_filename filename{"ostream_test"};
+    seqan3::test::tmp_directory tmp{};
+    auto filename = tmp.path() / "ostream_test";
 
     {
-        std::ofstream of{filename.get_path()};
+        std::ofstream of{filename};
         TypeParam ogzf{of};
 
         ogzf << uncompressed << std::flush;
     }
 
-    std::ifstream fi{filename.get_path(), std::ios::binary};
+    std::ifstream fi{filename, std::ios::binary};
     std::string buffer{std::istreambuf_iterator<char>{fi}, std::istreambuf_iterator<char>{}};
 
     if constexpr (TestFixture::zero_out_os_byte)
         buffer[9] = '\x00'; // zero-out the OS byte.
 
     EXPECT_EQ(buffer, TestFixture::compressed);
+    tmp.clean();
 }
 
 TYPED_TEST_P(ostream, output_type_erased)
 {
-    seqan3::test::tmp_filename filename{"ostream_test"};
+    seqan3::test::tmp_directory tmp{};
+    auto filename = tmp.path() / "ostream_test";
 
     {
-        std::ofstream of{filename.get_path()};
+        std::ofstream of{filename};
 
         std::unique_ptr<std::ostream> ogzf{new TypeParam{of}};
 
         *ogzf << uncompressed << std::flush;
     }
 
-    std::ifstream fi{filename.get_path(), std::ios::binary};
+    std::ifstream fi{filename, std::ios::binary};
     std::string buffer{std::istreambuf_iterator<char>{fi}, std::istreambuf_iterator<char>{}};
 
     if constexpr (TestFixture::zero_out_os_byte)
         buffer[9] = '\x00'; // zero-out the OS byte.
 
     EXPECT_EQ(buffer, TestFixture::compressed);
+    tmp.clean();
 }
 
 REGISTER_TYPED_TEST_SUITE_P(ostream, concept_check, output, output_type_erased);

--- a/test/unit/io/structure_file/structure_file_input_test.cpp
+++ b/test/unit/io/structure_file/structure_file_input_test.cpp
@@ -17,7 +17,7 @@
 #include <seqan3/alphabet/nucleotide/rna4.hpp>
 #include <seqan3/io/structure_file/input.hpp>
 #include <seqan3/test/expect_range_eq.hpp>
-#include <seqan3/test/tmp_filename.hpp>
+#include <seqan3/test/tmp_directory.hpp>
 #include <seqan3/utility/views/convert.hpp>
 
 using seqan3::operator""_rna5;
@@ -39,14 +39,16 @@ struct structure_file_input_class : public ::testing::Test
     using comp2 = seqan3::type_list<seqan3::format_vienna>;
     using comp3 = char;
 
-    seqan3::test::tmp_filename create_file(char const * contents)
-    {
-        seqan3::test::tmp_filename filename{"structure_file_input_constructor.dbn"};
+    seqan3::test::tmp_directory directory_tmp{};
 
-        {
-            std::ofstream filecreator{filename.get_path(), std::ios::out | std::ios::binary};
-            filecreator << contents; // must contain at least one record
-        }
+    ~structure_file_input_class() {
+        directory_tmp.clean();
+    }
+    seqan3::test::sandboxed_path create_file(char const * contents)
+    {
+        auto filename = directory_tmp.path() / "structure_file_input_constructor.dbn";
+        std::ofstream filecreator{filename, std::ios::out | std::ios::binary};
+        filecreator << contents; // must contain at least one record
         return filename;
     }
 };
@@ -65,22 +67,27 @@ TEST_F(structure_file_input_class, construct_by_filename)
 {
     /* just the filename */
     {
-        seqan3::test::tmp_filename filename{"structure_file_input_constructor.dbn"};
+        seqan3::test::tmp_directory tmp{};
+        auto filename = tmp.path() / "structure_file_input_constructor.dbn";
 
         {
-            std::ofstream filecreator{filename.get_path(), std::ios::out | std::ios::binary};
+            std::ofstream filecreator{filename, std::ios::out | std::ios::binary};
         }
 
-        EXPECT_NO_THROW(seqan3::structure_file_input<>{filename.get_path()});
+        EXPECT_NO_THROW(seqan3::structure_file_input<>{filename});
+        tmp.clean();
     }
 
     // correct format check is done by tests of that format
 
     /* wrong extension */
     {
-        seqan3::test::tmp_filename filename{"structure_file_input_constructor.xyz"};
-        std::ofstream filecreator{filename.get_path(), std::ios::out | std::ios::binary};
-        EXPECT_THROW(seqan3::structure_file_input<>{filename.get_path()}, seqan3::unhandled_extension_error);
+        seqan3::test::tmp_directory tmp{};
+        auto filename = tmp.path() / "structure_file_input_constructor.xyz";
+
+        std::ofstream filecreator{filename, std::ios::out | std::ios::binary};
+        EXPECT_THROW(seqan3::structure_file_input<>{filename}, seqan3::unhandled_extension_error);
+        tmp.clean();
     }
 
     /* non-existent file*/
@@ -92,10 +99,10 @@ TEST_F(structure_file_input_class, construct_by_filename)
     {
         using fields_seq = seqan3::fields<seqan3::field::seq>;
 
-        seqan3::test::tmp_filename filename = create_file("> ID\nACGU\n....\n");
+        auto filename = create_file("> ID\nACGU\n....\n");
         EXPECT_NO_THROW((seqan3::structure_file_input<seqan3::structure_file_input_default_traits_rna,
                                                       fields_seq,
-                                                      seqan3::type_list<seqan3::format_vienna>>{filename.get_path(),
+                                                      seqan3::type_list<seqan3::format_vienna>>{filename,
                                                                                                 fields_seq{}}));
     }
 }
@@ -132,8 +139,8 @@ TEST_F(structure_file_input_class, default_template_args)
 TEST_F(structure_file_input_class, guided_filename_constructor)
 {
     /* guided filename constructor */
-    seqan3::test::tmp_filename filename = create_file("> ID\nACGU\n....\n");
-    seqan3::structure_file_input fin{filename.get_path()};
+    auto filename = create_file("> ID\nACGU\n....\n");
+    seqan3::structure_file_input fin{filename};
 
     using t = decltype(fin);
     EXPECT_TRUE((std::is_same_v<typename t::traits_type,        comp0>));
@@ -145,8 +152,8 @@ TEST_F(structure_file_input_class, guided_filename_constructor)
 TEST_F(structure_file_input_class, guided_filename_constructor_and_custom_fields)
 {
     /* guided filename constructor + custom fields */
-    seqan3::test::tmp_filename filename = create_file("> ID\nACGU\n....\n");
-    seqan3::structure_file_input fin{filename.get_path(), seqan3::fields<seqan3::field::seq>{}};
+    auto filename = create_file("> ID\nACGU\n....\n");
+    seqan3::structure_file_input fin{filename, seqan3::fields<seqan3::field::seq>{}};
 
     using t = decltype(fin);
     EXPECT_TRUE((std::is_same_v<typename t::traits_type,        comp0>));
@@ -169,8 +176,8 @@ TEST_F(structure_file_input_class, guided_stream_constructor)
 
 TEST_F(structure_file_input_class, amino_acids_traits)
 {
-    seqan3::test::tmp_filename filename = create_file("> ID\nACEW\nHHHH\n");
-    seqan3::structure_file_input<seqan3::structure_file_input_default_traits_aa> fin{filename.get_path()};
+    auto filename = create_file("> ID\nACEW\nHHHH\n");
+    seqan3::structure_file_input<seqan3::structure_file_input_default_traits_aa> fin{filename};
 
     using t = decltype(fin);
     EXPECT_TRUE((std::is_same_v<typename t::traits_type,        seqan3::structure_file_input_default_traits_aa>));
@@ -181,14 +188,14 @@ TEST_F(structure_file_input_class, amino_acids_traits)
 
 TEST_F(structure_file_input_class, modified_traits)
 {
-    seqan3::test::tmp_filename filename = create_file("> ID\nACGU\n....\n");
+    auto filename = create_file("> ID\nACGU\n....\n");
     //! [structure_file_input_class mod_traits]
     struct my_traits : seqan3::structure_file_input_default_traits_rna
     {
         using seq_alphabet = seqan3::rna4; // instead of rna5
     };
 
-    seqan3::structure_file_input<my_traits> fin{filename.get_path()};
+    seqan3::structure_file_input<my_traits> fin{filename};
     //! [structure_file_input_class mod_traits]
 
     using t = decltype(fin);
@@ -280,12 +287,14 @@ struct structure_file_input_read : public ::testing::Test
 
 TEST_F(structure_file_input_read, empty_file)
 {
-    seqan3::test::tmp_filename filename{"empty.dbn"};
-    std::ofstream filecreator{filename.get_path(), std::ios::out | std::ios::binary};
+    seqan3::test::tmp_directory tmp{};
+    auto filename = tmp.path() / "empty.dbn";
+    std::ofstream filecreator{filename, std::ios::out | std::ios::binary};
 
-    seqan3::structure_file_input fin{filename.get_path()};
+    seqan3::structure_file_input fin{filename};
 
     EXPECT_EQ(fin.begin(), fin.end());
+    tmp.clean();
 }
 
 TEST_F(structure_file_input_read, empty_stream)
@@ -405,17 +414,19 @@ std::string input_gz
 
 TEST_F(structure_file_input_read, decompression_by_filename_gz)
 {
-    seqan3::test::tmp_filename filename{"structure_file_input_test.dbn.gz"};
+    seqan3::test::tmp_directory tmp{};
+    auto filename = tmp.path() / "structure_file_input_test.dbn.gz";
 
     {
-        std::ofstream of{filename.get_path(), std::ios::binary};
+        std::ofstream of{filename, std::ios::binary};
 
         std::copy(input_gz.begin(), input_gz.end(), std::ostreambuf_iterator<char>{of});
     }
 
-    seqan3::structure_file_input fin{filename.get_path()};
+    seqan3::structure_file_input fin{filename};
 
     decompression_impl(fin);
+    tmp.clean();
 }
 
 TEST_F(structure_file_input_read, decompression_by_stream_gz)
@@ -460,17 +471,19 @@ std::string input_bgzf
 
 TEST_F(structure_file_input_read, decompression_by_filename_bgzf)
 {
-    seqan3::test::tmp_filename filename{"structure_file_input_test.dbn.bgzf"};
+    seqan3::test::tmp_directory tmp{};
+    auto filename = tmp.path() / "structure_file_input_test.dbn.bgzf";
 
     {
-        std::ofstream of{filename.get_path(), std::ios::binary};
+        std::ofstream of{filename, std::ios::binary};
 
         std::copy(input_gz.begin(), input_gz.end(), std::ostreambuf_iterator<char>{of});
     }
 
-    seqan3::structure_file_input fin{filename.get_path()};
+    seqan3::structure_file_input fin{filename};
 
     decompression_impl(fin);
+    tmp.clean();
 }
 
 TEST_F(structure_file_input_read, decompression_by_stream_bgzf)
@@ -515,17 +528,19 @@ std::string input_bz2
 
 TEST_F(structure_file_input_read, decompression_by_filename_bz2)
 {
-    seqan3::test::tmp_filename filename{"structure_file_input_test.dbn.bz2"};
+    seqan3::test::tmp_directory tmp{};
+    auto filename = tmp.path() / "structure_file_input_test.dbn.bz2";
 
     {
-        std::ofstream of{filename.get_path(), std::ios::binary};
+        std::ofstream of{filename, std::ios::binary};
 
         std::copy(input_bz2.begin(), input_bz2.end(), std::ostreambuf_iterator<char>{of});
     }
 
-    seqan3::structure_file_input fin{filename.get_path()};
+    seqan3::structure_file_input fin{filename};
 
     decompression_impl(fin);
+    tmp.clean();
 }
 
 TEST_F(structure_file_input_read, decompression_by_stream_bz2)

--- a/test/unit/io/structure_file/structure_file_output_test.cpp
+++ b/test/unit/io/structure_file/structure_file_output_test.cpp
@@ -15,7 +15,7 @@
 
 #include <seqan3/io/structure_file/output.hpp>
 #include <seqan3/io/structure_file/input.hpp>
-#include <seqan3/test/tmp_filename.hpp>
+#include <seqan3/test/tmp_directory.hpp>
 
 using seqan3::operator""_rna5;
 using seqan3::operator""_wuss51;
@@ -43,20 +43,25 @@ TEST(structure_file_output_class, construct_by_filename)
 {
     /* just the filename */
     {
-        seqan3::test::tmp_filename filename{"structure_file_output_constructor.dbn"};
-        EXPECT_NO_THROW(seqan3::structure_file_output<>{filename.get_path()});
+        seqan3::test::tmp_directory tmp;
+        auto filename = tmp.path() / "structure_file_output_constructor.dbn";
+        EXPECT_NO_THROW(seqan3::structure_file_output<>{filename});
+        tmp.clean();
     }
 
     /* wrong extension */
     {
-        seqan3::test::tmp_filename filename{"structure_file_output_constructor.xyz"};
-        EXPECT_THROW(seqan3::structure_file_output<>{filename.get_path()}, seqan3::unhandled_extension_error);
+        seqan3::test::tmp_directory tmp;
+        auto filename = tmp.path() / "structure_file_output_constructor.xyz";
+        EXPECT_THROW(seqan3::structure_file_output<>{filename}, seqan3::unhandled_extension_error);
+        tmp.clean();
     }
 
     /* unknown file */
     {
-        seqan3::test::tmp_filename filename{"I/do/not/exist.dbn"};
-        EXPECT_THROW(seqan3::structure_file_output<>{filename.get_path()}, seqan3::file_open_error);
+        seqan3::test::tmp_directory tmp;
+        auto filename = tmp.path() / "I/do/not/exist.dbn";
+        EXPECT_THROW(seqan3::structure_file_output<>{filename}, seqan3::file_open_error);
     }
 
     /* non-existent file*/
@@ -66,10 +71,12 @@ TEST(structure_file_output_class, construct_by_filename)
 
     /* filename + fields */
     {
-        seqan3::test::tmp_filename filename{"structure_file_output_constructor.dbn"};
+        seqan3::test::tmp_directory tmp;
+        auto filename = tmp.path() / "structure_file_output_constructor.dbn";
         EXPECT_NO_THROW((seqan3::structure_file_output<seqan3::fields<seqan3::field::seq>,
                                                        seqan3::type_list<seqan3::format_vienna>>
-                         {filename.get_path(), seqan3::fields<seqan3::field::seq>{}}));
+                         {filename, seqan3::fields<seqan3::field::seq>{}}));
+        tmp.clean();
     }
 }
 
@@ -102,24 +109,28 @@ TEST(structure_file_output_class, default_template_args_and_deduction_guides)
 
     /* guided filename constructor */
     {
-        seqan3::test::tmp_filename filename{"structure_file_output_constructor.dbn"};
-        seqan3::structure_file_output fout{filename.get_path()};
+        seqan3::test::tmp_directory tmp;
+        auto filename = tmp.path() / "structure_file_output_constructor.dbn";
+        seqan3::structure_file_output fout{filename};
 
         using t = decltype(fout);
         EXPECT_TRUE((std::is_same_v<typename t::selected_field_ids, comp1>));
         EXPECT_TRUE((std::is_same_v<typename t::valid_formats,      comp2>));
         EXPECT_TRUE((std::is_same_v<typename t::stream_char_type,   comp3>));
+        tmp.clean();
     }
 
     /* guided filename constructor + custom fields */
     {
-        seqan3::test::tmp_filename filename{"structure_file_output_constructor.dbn"};
-        seqan3::structure_file_output fout{filename.get_path(), seqan3::fields<seqan3::field::seq>{}};
+        seqan3::test::tmp_directory tmp;
+        auto filename = tmp.path() / "structure_file_output_constructor.dbn";
+        seqan3::structure_file_output fout{filename, seqan3::fields<seqan3::field::seq>{}};
 
         using t = decltype(fout);
         EXPECT_TRUE((std::is_same_v<typename t::selected_field_ids, seqan3::fields<seqan3::field::seq>>));
         EXPECT_TRUE((std::is_same_v<typename t::valid_formats,      comp2>));
         EXPECT_TRUE((std::is_same_v<typename t::stream_char_type,   comp3>));
+        tmp.clean();
     }
 
     /* guided stream constructor */
@@ -397,10 +408,10 @@ TEST_F(structure_file_output_columns, assign_columns)
 #if defined(SEQAN3_HAS_ZLIB) || defined(SEQAN3_HAS_BZIP2)
 struct structure_file_output_compression : public structure_file_output_write
 {
-    std::string compression_by_filename_impl(seqan3::test::tmp_filename & filename)
+    std::string compression_by_filename_impl(seqan3::test::sandboxed_path const & filename)
     {
         {
-            seqan3::structure_file_output fout{filename.get_path()};
+            seqan3::structure_file_output fout{filename};
 
             for (size_t idx = 0ul; idx < num_records; ++idx)
             {
@@ -413,7 +424,7 @@ struct structure_file_output_compression : public structure_file_output_write
         }
         std::string buffer{};
         {
-            std::ifstream fi{filename.get_path(), std::ios::binary};
+            std::ifstream fi{filename, std::ios::binary};
             buffer = std::string{std::istreambuf_iterator<char>{fi}, std::istreambuf_iterator<char>{}};
         }
         return buffer;
@@ -472,10 +483,13 @@ std::string expected_bgzf
 
 TEST_F(structure_file_output_compression, by_filename_gz)
 {
-    seqan3::test::tmp_filename filename{"structure_file_output_test.dbn.gz"};
+    seqan3::test::tmp_directory tmp;
+    auto filename = tmp.path() / "structure_file_output_test.dbn.gz";
+
     std::string buffer = compression_by_filename_impl(filename);
     buffer[9] = '\x00'; // zero out OS byte
     EXPECT_EQ(buffer, expected_gz);
+    tmp.clean();
 }
 
 TEST_F(structure_file_output_compression, by_stream_gz)
@@ -492,10 +506,12 @@ TEST_F(structure_file_output_compression, by_stream_gz)
 
 TEST_F(structure_file_output_compression, by_filename_bgzf)
 {
-    seqan3::test::tmp_filename filename{"structure_file_output_test.dbn.bgzf"};
+    seqan3::test::tmp_directory tmp;
+    auto filename = tmp.path() / "structure_file_output_test.dbn.bgzf";
     std::string buffer = compression_by_filename_impl(filename);
     buffer[9] = '\x00'; // zero out OS byte
     EXPECT_EQ(buffer, expected_bgzf);
+    tmp.clean();
 }
 
 TEST_F(structure_file_output_compression, by_stream_bgzf)
@@ -531,9 +547,11 @@ std::string expected_bz2
 
 TEST_F(structure_file_output_compression, by_filename_bz2)
 {
-    seqan3::test::tmp_filename filename{"structure_file_output_test.dbn.bz2"};
+    seqan3::test::tmp_directory tmp;
+    auto filename = tmp.path() / "structure_file_output_test.dbn.bz2";
     std::string buffer = compression_by_filename_impl(filename);
     EXPECT_EQ(buffer, expected_bz2);
+    tmp.clean();
 }
 
 TEST_F(structure_file_output_compression, by_stream_bz2)

--- a/test/unit/io/views/detail/istreambuf_view_test.cpp
+++ b/test/unit/io/views/detail/istreambuf_view_test.cpp
@@ -18,7 +18,7 @@
 #include <seqan3/io/views/detail/istreambuf_view.hpp>
 #include <seqan3/io/views/detail/take_until_view.hpp>
 #include <seqan3/test/expect_range_eq.hpp>
-#include <seqan3/test/tmp_filename.hpp>
+#include <seqan3/test/tmp_directory.hpp>
 #include <seqan3/utility/char_operations/predicate.hpp>
 
 #include "../../../range/iterator_test_template.hpp"
@@ -94,15 +94,16 @@ TEST(view_istreambuf, big_file_stram)
 {
     using namespace std::literals;
 
-    seqan3::test::tmp_filename file_name{"istream_storage"};
+    seqan3::test::tmp_directory tmp_dir{};
+    auto file_name = tmp_dir.path() / "istream_storage";
 
     {
-        std::ofstream os{file_name.get_path()};
+        std::ofstream os{file_name};
         for (size_t idx = 0; idx < 11000 ; ++idx)
             os << "halloballo\n";
     }
 
-    std::ifstream istream{file_name.get_path()};
+    std::ifstream istream{file_name};
     auto v = seqan3::detail::istreambuf(istream);
     while (v.begin() != v.end())
     {

--- a/test/unit/search/fm_index/fm_index_dna4_test.cpp
+++ b/test/unit/search/fm_index/fm_index_dna4_test.cpp
@@ -7,6 +7,7 @@
 
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
+#include <seqan3/test/tmp_directory.hpp>
 
 #include "fm_index_collection_test_template.hpp"
 #include "fm_index_test_template.hpp"
@@ -29,26 +30,28 @@ TEST(fm_index_test, cerealisation_errors)
 
     seqan3::fm_index<seqan3::dna4, seqan3::text_layout::single> index{"AGTCTGATGCTGCTAC"_dna4};
 
-    seqan3::test::tmp_filename filename{"cereal_test"};
+    seqan3::test::tmp_directory tmp;
+    auto filename = tmp.path() / "cereal_test";
 
     {
-        std::ofstream os{filename.get_path(), std::ios::binary};
+        std::ofstream os{filename, std::ios::binary};
         cereal::BinaryOutputArchive oarchive{os};
         oarchive(index);
     }
 
     {
         seqan3::fm_index<seqan3::dna5, seqan3::text_layout::single> in;
-        std::ifstream is{filename.get_path(), std::ios::binary};
+        std::ifstream is{filename, std::ios::binary};
         cereal::BinaryInputArchive iarchive{is};
         EXPECT_THROW(iarchive(in), std::logic_error);
     }
 
     {
         seqan3::fm_index<seqan3::dna4, seqan3::text_layout::collection> in;
-        std::ifstream is{filename.get_path(), std::ios::binary};
+        std::ifstream is{filename, std::ios::binary};
         cereal::BinaryInputArchive iarchive{is};
         EXPECT_THROW(iarchive(in), std::logic_error);
     }
+    tmp.clean();
 #endif
 }


### PR DESCRIPTION
Moves forward https://github.com/seqan/product_backlog/issues/281

This replaces occurrences of `tmp_filename` and replaces them with `tmp_directory`.

This PR doesn't remove `tmp_filename`, because it is unclear how the *.patch files must be updated to not break.