### PR TITLE
[MISC] Increase coverage in argument_parser/validator

### DIFF
--- a/include/seqan3/argument_parser/validators.hpp
+++ b/include/seqan3/argument_parser/validators.hpp
@@ -576,10 +576,12 @@ public:
             // Check extension.
             validate_filename(file);
         }
+        // LCOV_EXCL_START
         catch (std::filesystem::filesystem_error & ex)
         {
             std::throw_with_nested(validation_error{"Unhandled filesystem error!"});
         }
+        // LCOV_EXCL_STOP
         catch (...)
         {
             std::rethrow_exception(std::current_exception());
@@ -705,10 +707,12 @@ public:
 
             validate_filename(file);
         }
+        // LCOV_EXCL_START
         catch (std::filesystem::filesystem_error & ex)
         {
             std::throw_with_nested(validation_error{"Unhandled filesystem error!"});
         }
+        // LCOV_EXCL_STOP
         catch (...)
         {
             std::rethrow_exception(std::current_exception());
@@ -785,10 +789,12 @@ public:
             // Check if directory has any read permissions.
             validate_readability(dir);
         }
+        // LCOV_EXCL_START
         catch (std::filesystem::filesystem_error & ex)
         {
             std::throw_with_nested(validation_error{"Unhandled filesystem error!"});
         }
+        // LCOV_EXCL_STOP
         catch (...)
         {
             std::rethrow_exception(std::current_exception());
@@ -867,10 +873,12 @@ public:
                 validate_writeability(dir / "dummy.txt");
             }
         }
+        // LCOV_EXCL_START
         catch (std::filesystem::filesystem_error & ex)
         {
             std::throw_with_nested(validation_error{"Unhandled filesystem error!"});
         }
+        // LCOV_EXCL_STOP
         catch (...)
         {
             std::rethrow_exception(std::current_exception());

--- a/test/unit/argument_parser/format_parse_validators_test.cpp
+++ b/test/unit/argument_parser/format_parse_validators_test.cpp
@@ -477,8 +477,7 @@ TEST(validator_test, output_directory)
         EXPECT_EQ(path, dir_out_path.string());
     }
 
-    { // create output directory in next level, when parent directory exists.
-        // Parent path exists and is writable
+    { // Parent path exists and is writable.
         seqan3::test::tmp_filename tmp_child_name{"dir/child_dir"};
         std::filesystem::path tmp_child_dir{tmp_child_name.get_path()};
         std::filesystem::path tmp_parent_path{tmp_child_dir.parent_path()};
@@ -542,7 +541,6 @@ TEST(validator_test, inputfile_not_readable)
 TEST(validator_test, inputfile_not_regular)
 {
     seqan3::test::tmp_filename tmp{"my_file.test"};
-    // std::string filename     = "my_file.test";
     std::filesystem::path filename = tmp.get_path();
     mkfifo(filename.c_str(), 0644); 
 


### PR DESCRIPTION
Part of: https://github.com/seqan/product_backlog/issues/222 

I was not able to close one coverage gap. I think some code blocks will almost never be executed or only if the OS seriously messes something up.

Here is the Codecov report I used: https://codecov.io/gh/seqan/seqan3/src/master/include/seqan3/argument_parser/validators.hpp