### PR TITLE
[FIX] Constructing large fm_indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,15 @@ The following API changes should be documented as such:
 If possible, provide tooling that performs the changes, e.g. a shell-script.
 -->
 
+# 3.1.0
+
+## Notable Bug-fixes
+
+#### Search
+
+* Resolved an issue that prevented the FM-Index from being constructed correctly for inputs larger than 4 GiB
+  ([\#2756](https://github.com/seqan/seqan3/pull/2756)).
+
 # 3.0.3
 
 Note that 3.1.0 will be the first API stable release and interfaces in this release might still change.

--- a/include/seqan3/search/fm_index/fm_index.hpp
+++ b/include/seqan3/search/fm_index/fm_index.hpp
@@ -293,7 +293,7 @@ private:
         size_t const number_of_texts{text_sizes.size()};
 
         // text size including delimiters
-        size_t const text_size = std::accumulate(text_sizes.begin(), text_sizes.end(), 0) + number_of_texts;
+        size_t const text_size = std::accumulate(text_sizes.begin(), text_sizes.end(), number_of_texts);
 
         if (number_of_texts == text_size)
             throw std::invalid_argument("A text collection that only contains empty texts cannot be indexed.");


### PR DESCRIPTION
Fixes unsigned vs signed int bug. This causes to limit the fm_index to
work for any text sizes above 2^31-1 base pairs.
This fix now allows up to 2^32-2 which is required for the human genome.
Correction: it should work with 2^63-2 base pairs.