### PR TITLE
[MISC] Adjust default options when outputing FastA-Files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,11 +42,9 @@ If possible, provide tooling that performs the changes, e.g. a shell-script.
 
 ## API changes
 
-The files deprecated in [3.0.3](#3.0.3-api) (denoted by `[deleted without replacement]`) have been removed.
-=======
 #### I/O
- * **Breaking change**: Changed default of `output_options::fasta_blank_before_id` to `false`
-    ([\#2769](https://github.com/seqan/seqan3/pull/2769)).
+ * Changed default of `output_options::fasta_blank_before_id` to `false`
+   ([\#2769](https://github.com/seqan/seqan3/pull/2769)).
 
 # 3.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,14 @@ If possible, provide tooling that performs the changes, e.g. a shell-script.
   ++it; *it = value;
   ```
 
+## API changes
+
+The files deprecated in [3.0.3](#3.0.3-api) (denoted by `[deleted without replacement]`) have been removed.
+=======
+#### I/O
+ * **Breaking change**: Changed default of `output_options::fasta_blank_before_id` to `false`
+    ([\#2769](https://github.com/seqan/seqan3/pull/2769)).
+
 # 3.1.0
 
 ## New features

--- a/doc/tutorial/sequence_file/sequence_file_output_record.out
+++ b/doc/tutorial/sequence_file/sequence_file_output_record.out
@@ -1,10 +1,10 @@
-> test_id
+>test_id
 ACGT
-> test_id
+>test_id
 ACGT
-> test_id
+>test_id
 ACGT
-> test_id
+>test_id
 ACGT
-> test_id
+>test_id
 ACGT

--- a/include/seqan3/alphabet/gap/gapped.hpp
+++ b/include/seqan3/alphabet/gap/gapped.hpp
@@ -56,7 +56,7 @@ namespace seqan3::detail
 template <typename t>
 constexpr bool is_gapped_alphabet = false;
 
-//!\brief Helper variable to determine if an alphabet is gapped, true for specilisations of seqan3::gapped.
+//!\brief Helper variable to determine if an alphabet is gapped, true for specialisations of seqan3::gapped.
 //!\ingroup alphabet_gap
 template <typename t>
 constexpr bool is_gapped_alphabet<gapped<t>> = true;

--- a/include/seqan3/io/sam_file/output.hpp
+++ b/include/seqan3/io/sam_file/output.hpp
@@ -640,7 +640,7 @@ protected:
     format_type format;
     //!\}
 
-    //!\brief The header type, which specilised with ref_ids_type if reference information are given.
+    //!\brief The header type, which specialised with ref_ids_type if reference information are given.
     using header_type = sam_file_header<std::conditional_t<std::same_as<ref_ids_type, ref_info_not_given>,
                                         std::vector<std::string>,
                                         ref_ids_type>>;

--- a/include/seqan3/io/sequence_file/format_fasta.hpp
+++ b/include/seqan3/io/sequence_file/format_fasta.hpp
@@ -52,7 +52,7 @@ namespace seqan3
  *
  * ### Introduction
  *
- * FASTA is the de-facto-standard for sequence storage in bionformatics. See the
+ * FASTA is the de-facto-standard for sequence storage in bioinformatics. See the
  * [article on wikipedia](https://en.wikipedia.org/wiki/FASTA_format) for a an in-depth description of the format.
  *
  * ### fields_specialisation

--- a/include/seqan3/io/sequence_file/output_options.hpp
+++ b/include/seqan3/io/sequence_file/output_options.hpp
@@ -27,7 +27,7 @@ struct sequence_file_output_options
     //!\brief Begin the ID line with ";" instead of ">" (not recommended).
     bool        fasta_legacy_id_marker  = false;
     //!\brief Insert a single space after ">" (or ";") before the actual ID.
-    bool        fasta_blank_before_id   = true;
+    bool        fasta_blank_before_id   = false;
     //!\brief Inserts linebreaks after every n-th letter in the sequence; 0 means no linebreaks.
     uint32_t    fasta_letters_per_line  = 80;
     //TODO:

--- a/test/snippet/io/sequence_file/sequence_file_input_aminoacid.cpp
+++ b/test/snippet/io/sequence_file/sequence_file_input_aminoacid.cpp
@@ -2,11 +2,11 @@
 
 #include <seqan3/io/sequence_file/input.hpp>
 
-auto input = R"(> TEST1
+auto input = R"(>TEST1
 ACGT
-> Test2
+>Test2
 AGGCTGA
-> Test3
+>Test3
 GGAGTATAATATATATATATATAT)";
 
 int main()

--- a/test/snippet/io/sequence_file/sequence_file_input_auto_ref.cpp
+++ b/test/snippet/io/sequence_file/sequence_file_input_auto_ref.cpp
@@ -4,11 +4,11 @@
 
 #include <seqan3/io/sequence_file/input.hpp>
 
-auto input = R"(> TEST1
+auto input = R"(>TEST1
 ACGT
-> Test2
+>Test2
 AGGCTGA
-> Test3
+>Test3
 GGAGTATAATATATATATATATAT)";
 
 int main()

--- a/test/snippet/io/sequence_file/sequence_file_input_custom_fields.cpp
+++ b/test/snippet/io/sequence_file/sequence_file_input_custom_fields.cpp
@@ -4,11 +4,11 @@
 #include <seqan3/core/debug_stream.hpp>
 #include <seqan3/io/sequence_file/input.hpp>
 
-auto input = R"(> TEST1
+auto input = R"(>TEST1
 ACGT
-> Test2
+>Test2
 AGGCTGA
-> Test3
+>Test3
 GGAGTATAATATATATATATATAT)";
 
 int main()

--- a/test/snippet/io/sequence_file/sequence_file_input_decomposed.cpp
+++ b/test/snippet/io/sequence_file/sequence_file_input_decomposed.cpp
@@ -1,11 +1,11 @@
 #include <seqan3/core/debug_stream.hpp>
 #include <seqan3/io/sequence_file/input.hpp>
 
-auto input = R"(> TEST1
+auto input = R"(>TEST1
 ACGT
-> Test2
+>Test2
 AGGCTGA
-> Test3
+>Test3
 GGAGTATAATATATATATATATAT)";
 
 int main()

--- a/test/snippet/io/sequence_file/sequence_file_input_file_view.cpp
+++ b/test/snippet/io/sequence_file/sequence_file_input_file_view.cpp
@@ -4,11 +4,11 @@
 #include <seqan3/io/sequence_file/input.hpp>
 #include <seqan3/std/ranges>
 
-auto input = R"(> TEST1
+auto input = R"(>TEST1
 ACGT
-> Test2
+>Test2
 AGGCTGA
-> Test3
+>Test3
 GGAGTATAATATATATATATATAT)";
 
 int main()

--- a/test/snippet/io/sequence_file/sequence_file_input_istringstream.cpp
+++ b/test/snippet/io/sequence_file/sequence_file_input_istringstream.cpp
@@ -3,11 +3,11 @@
 
 #include <seqan3/io/sequence_file/input.hpp>
 
-auto input = R"(> TEST1
+auto input = R"(>TEST1
 ACGT
-> Test2
+>Test2
 AGGCTGA
-> Test3
+>Test3
 GGAGTATAATATATATATATATAT)";
 
 int main()

--- a/test/snippet/io/sequence_file/sequence_file_input_record_iter.cpp
+++ b/test/snippet/io/sequence_file/sequence_file_input_record_iter.cpp
@@ -3,11 +3,11 @@
 #include <seqan3/core/debug_stream.hpp>
 #include <seqan3/io/sequence_file/input.hpp>
 
-auto input = R"(> TEST1
+auto input = R"(>TEST1
 ACGT
-> Test2
+>Test2
 AGGCTGA
-> Test3
+>Test3
 GGAGTATAATATATATATATATAT)";
 
 int main()

--- a/test/snippet/io/sequence_file/sequence_file_input_record_move.cpp
+++ b/test/snippet/io/sequence_file/sequence_file_input_record_move.cpp
@@ -3,11 +3,11 @@
 
 #include <seqan3/io/sequence_file/input.hpp>
 
-auto input = R"(> TEST1
+auto input = R"(>TEST1
 ACGT
-> Test2
+>Test2
 AGGCTGA
-> Test3
+>Test3
 GGAGTATAATATATATATATATAT)";
 
 int main()

--- a/test/snippet/io/sequence_file/sequence_file_input_return_record.cpp
+++ b/test/snippet/io/sequence_file/sequence_file_input_return_record.cpp
@@ -2,11 +2,11 @@
 
 #include <seqan3/io/sequence_file/input.hpp>
 
-auto input = R"(> TEST1
+auto input = R"(>TEST1
 ACGT
-> Test2
+>Test2
 AGGCTGA
-> Test3
+>Test3
 GGAGTATAATATATATATATATAT)";
 
 int main()

--- a/test/snippet/io/sequence_file/sequence_file_input_template_specification.cpp
+++ b/test/snippet/io/sequence_file/sequence_file_input_template_specification.cpp
@@ -4,11 +4,11 @@
 #include <seqan3/utility/type_list/type_list.hpp>
 
 // ... input had amino acid sequences
-auto input = R"(> TEST1
+auto input = R"(>TEST1
 FQTWE
-> Test2
+>Test2
 KYRTW
-> Test3
+>Test3
 EEYQTWEEFARAAEKLYLTDPMKV)";
 
 int main()

--- a/test/snippet/io/sequence_file/sequence_file_input_trait_overwrite.cpp
+++ b/test/snippet/io/sequence_file/sequence_file_input_trait_overwrite.cpp
@@ -4,11 +4,11 @@
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/io/sequence_file/input.hpp>
 
-auto input = R"(> TEST1
+auto input = R"(>TEST1
 ACGT
-> Test2
+>Test2
 AGGCTGA
-> Test3
+>Test3
 GGAGTATAATATATATATATATAT)";
 
 struct my_traits : seqan3::sequence_file_input_default_traits_dna

--- a/test/unit/io/sequence_file/sequence_file_format_fasta_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_format_fasta_test.cpp
@@ -21,32 +21,32 @@ struct sequence_file_read<seqan3::format_fasta> : public sequence_file_data
 {
     std::string standard_input
     {
-        "> ID1\n"
+        ">ID1\n"
         "ACGTTTTTTTTTTTTTTT\n"
-        "> ID2\n"
+        ">ID2\n"
         "ACGTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT\n"
-        "> ID3 lala\n"
+        ">ID3 lala\n"
         "ACGTTTA\n"
     };
 
     std::string illegal_alphabet_character_input
     {
-        "> ID1\n"
+        ">ID1\n"
         "ACGPTTTTTTTTTTTTTT\n"
-        "> ID2\n"
+        ">ID2\n"
         "ACGTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT\n"
-        "> ID3 lala\n"
+        ">ID3 lala\n"
         "ACGTTTA\n"
     };
 
     std::string standard_output
     {
-        "> ID1\n"
+        ">ID1\n"
         "ACGTTTTTTTTTTTTTTT\n"
-        "> ID2\n"
+        ">ID2\n"
         "ACGTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT\nTT\n"
         //                                             linebreak inserted after 80 char  ^
-        "> ID3 lala\n"
+        ">ID3 lala\n"
         "ACGTTTA\n"
     };
 
@@ -96,11 +96,11 @@ TEST_F(read, newline_before_eof)
 {
     std::string input
     {
-        "> ID1\n"
+        ">ID1\n"
         "ACGTTTTTTTTTTTTTTT\n"
-        "> ID2\n"
+        ">ID2\n"
         "ACGTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT\n"
-        "> ID3 lala\n"
+        ">ID3 lala\n"
         "ACGTTTA"
     };
     do_read_test(input);
@@ -124,12 +124,12 @@ TEST_F(read, whitespace_in_seq)
 {
     std::string input
     {
-        "> ID1\n"
+        ">ID1\n"
         "ACGTTTT\n\nTTTTTTTTTTT\n"
         "\n"
-        "> ID2\n"
+        ">ID2\n"
         "ACGTTTT\t\tTTTTTTTTTTT\t\nTTTTTTTTTTT\vTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT\rTTTTTTTTTTTTTTTTT\n"
-        "> ID3 lala\n"
+        ">ID3 lala\n"
         "ACGT\fTTA\n"
     };
     do_read_test(input);
@@ -139,12 +139,12 @@ TEST_F(read, digits_in_seq)
 {
     std::string input
     {
-        "> ID1\n"
+        ">ID1\n"
         "10  ACGTTTTTTTTTTTTTTT\n"
-        "> ID2\n"
+        ">ID2\n"
         "  80 ACGTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT  900"
         "1000 TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT\n"
-        "> ID3 lala\n"
+        ">ID3 lala\n"
         "ACGT9T5T2A\n"
     };
     do_read_test(input);
@@ -169,12 +169,12 @@ TEST_F(read, mixed_issues)
 {
     std::string input
     {
-        "> ID1\n"
+        ">ID1\n"
         "ACGTTTT\n\nTTTTTTTTTTT\n"
         "\n"
         ";ID2\n"
         "ACGTTTT\t75\tTTTTTTTTTTT\t\nTTTTTTTTTTT9\vTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT\rTTTTTTTTTTTTTTTTT\n"
-        "> ID3 lala\n"
+        ">ID3 lala\n"
         "ACGT\fTTA"
     };
     do_read_test(input);
@@ -248,12 +248,12 @@ TEST_F(write, options_letters_per_line)
 
     std::string comp
     {
-        "> TEST 1\n"
+        ">TEST 1\n"
         "ACGT\n"
-        "> Test2\n"
+        ">Test2\n"
         "AGGCTGN\nAGGCTGN\nAGGCTGN\nAGGCTGN\nAGGCTGN\nAGGCTGN\nAGGCTGN\nAGGCTGN\nAGGCTGN\nAGGCTGN\nAGGCTGN\nAGGCTGN\n"
         "AGGCTGN\n"
-        "> Test3\n"
+        ">Test3\n"
         "GGAGTAT\nAATATAT\nATATATA\nTAT\n"
     };
 
@@ -268,12 +268,12 @@ TEST_F(write, options_legacy_id_marker)
 
     std::string comp
     {
-        "; TEST 1\n"
+        ";TEST 1\n"
         "ACGT\n"
-        "; Test2\n"
+        ";Test2\n"
         "AGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGG\nCTGNAGGCTGN\n"
         //                                             linebreak inserted after 80 char  ^
-        "; Test3\n"
+        ";Test3\n"
         "GGAGTATAATATATATATATATAT\n"
     };
 
@@ -284,16 +284,16 @@ TEST_F(write, options_legacy_id_marker)
 
 TEST_F(write, options_blank_before_id)
 {
-    options.fasta_blank_before_id = false;
+    options.fasta_blank_before_id = true;
 
     std::string comp
     {
-        ">TEST 1\n"
+        "> TEST 1\n"
         "ACGT\n"
-        ">Test2\n"
+        "> Test2\n"
         "AGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGG\nCTGNAGGCTGN\n"
         //                                             linebreak inserted after 80 char  ^
-        ">Test3\n"
+        "> Test3\n"
         "GGAGTATAATATATATATATATAT\n"
     };
 
@@ -308,12 +308,12 @@ TEST_F(write, options_add_carriage_return)
 
     std::string comp
     {
-        "> TEST 1\r\n"
+        ">TEST 1\r\n"
         "ACGT\r\n"
-        "> Test2\r\n"
+        ">Test2\r\n"
         "AGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGG\r\nCTGNAGGCTGN\r\n"
         //                                             linebreak inserted after 80 char  ^
-        "> Test3\r\n"
+        ">Test3\r\n"
         "GGAGTATAATATATATATATATAT\r\n"
     };
 
@@ -325,18 +325,18 @@ TEST_F(write, options_add_carriage_return)
 TEST_F(write, options_all)
 {
     options.add_carriage_return = true;
-    options.fasta_blank_before_id = false;
+    options.fasta_blank_before_id = true;
     options.fasta_legacy_id_marker = true;
     options.fasta_letters_per_line = 21;
 
     std::string comp
     {
-        ";TEST 1\r\n"
+        "; TEST 1\r\n"
         "ACGT\r\n"
-        ";Test2\r\n"
+        "; Test2\r\n"
         "AGGCTGNAGGCTGNAGGCTGN\r\nAGGCTGNAGGCTGNAGGCTGN\r\nAGGCTGNAGGCTGNAGGCTGN\r\nAGGCTGNAGGCTGNAGGCTGN\r\n"
         "AGGCTGN\r\n"
-        ";Test3\r\n"
+        "; Test3\r\n"
         "GGAGTATAATATATATATATA\r\nTAT\r\n"
     };
     do_write_test();

--- a/test/unit/io/sequence_file/sequence_file_input_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_input_test.cpp
@@ -35,11 +35,11 @@ struct sequence_file_input_f : public ::testing::Test
 {
     std::string input
     {
-        "> TEST 1\n"
+        ">TEST 1\n"
         "ACGT\n"
         ">Test2\n"
         "AGGCTGN\n"
-        "> Test3\n"
+        ">Test3\n"
         "GGAGTATAATATATATATATATAT\n"
     };
 
@@ -264,11 +264,11 @@ TEST_F(sequence_file_input_f, record_reading_custom_options)
 {
     std::istringstream istream{std::string
     {
-        "> ID1 lala\n"
+        ">ID1 lala\n"
         "ACGTTTTTTTTTTTTTTT\n"
-        "> ID2\n"
+        ">ID2\n"
         "ACGTTTTTTT\n"
-        "> ID3 lala\n"
+        ">ID3 lala\n"
         "ACGTTTA\n"
     }};
 

--- a/test/unit/io/sequence_file/sequence_file_integration_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_integration_test.cpp
@@ -21,19 +21,19 @@ TEST(rows, assign_sequence_files)
     {
         ">TEST 1\n"
         "ACGT\n"
-        "> Test2\n"
+        ">Test2\n"
         "AGGCTGN AGGCTGN AGGCTGN AGGCTGN AGGCTGN AGGCTGN AGGCTGN AGGCTGN AGGCTGN AGGCTGN AGGCTGN AGGCTGN AGGCTGN\n\n"
-        "> Test3\n"
+        ">Test3\n"
         "GGAGTATAATATATATATATATAT\n"
     };
 
     std::string const output_comp
     {
-        "> TEST 1\n"
+        ">TEST 1\n"
         "ACGT\n"
-        "> Test2\n"
+        ">Test2\n"
         "AGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGN\n"
-        "> Test3\n"
+        ">Test3\n"
         "GGAGTATAATATATATATATATAT\n"
     };
 
@@ -51,11 +51,11 @@ TEST(integration, assign_sequence_file_pipes)
 {
     std::string const input
     {
-        "> TEST1\n"
+        ">TEST1\n"
         "ACGT\n"
-        "> Test2\n"
+        ">Test2\n"
         "AGGCTGNAGGCTGAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGN\n"
-        "> Test3\n"
+        ">Test3\n"
         "GGAGTATAATATATATATATATAT\n"
     };
 
@@ -75,19 +75,19 @@ TEST(integration, view)
 {
     std::string const input
     {
-        "> TEST1\n"
+        ">TEST1\n"
         "ACGT\n"
-        "> Test2\n"
+        ">Test2\n"
         "AGGCTGNAGGCTGAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGN\n"
-        "> Test3\n"
+        ">Test3\n"
         "GGAGTATAATATATATATATATAT\n"
     };
 
     std::string const output
     {
-        "> TEST1\n"
+        ">TEST1\n"
         "ACGT\n"
-        "> Test2\n"
+        ">Test2\n"
         "AGGCTGNAGGCTGAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGN\n"
     };
 
@@ -124,9 +124,9 @@ TEST(integration, convert_fastq_to_fasta)
 
     std::string const fasta_out
     {
-        "> ID1\n"
+        ">ID1\n"
         "ACGTT\n"
-        "> ID2\n"
+        ">ID2\n"
         "TATTA\n"
     };
 

--- a/test/unit/io/sequence_file/sequence_file_output_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_output_test.cpp
@@ -45,11 +45,11 @@ std::vector<std::string> ids
 
 std::string const output_comp
 {
-    "> TEST 1\n"
+    ">TEST 1\n"
     "ACGT\n"
-    "> Test2\n"
+    ">Test2\n"
     "AGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGN\n"
-    "> Test3\n"
+    ">Test3\n"
     "GGAGTATAATATATATATATATAT\n"
 };
 
@@ -347,7 +347,7 @@ TEST(row, different_fields_in_record_and_file)
 
     std::string const expected_out
     {
-        "> Test2\n"
+        ">Test2\n"
         "AGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGG\n"
         "CTGNAGGCTGN\n"
     };
@@ -420,6 +420,7 @@ std::string compression_by_filename_impl([[maybe_unused]]seqan3::test::tmp_filen
 {
     {
         seqan3::sequence_file_output fout{filename.get_path()};
+        fout.options.fasta_blank_before_id = true;
         fout.options.fasta_letters_per_line = 0;
 
         for (size_t i = 0; i < 3; ++i)
@@ -446,6 +447,7 @@ template <typename comp_stream_t>
 void compression_by_stream_impl(comp_stream_t & stream)
 {
     seqan3::sequence_file_output fout{stream, seqan3::format_fasta{}};
+    fout.options.fasta_blank_before_id = true;
     fout.options.fasta_letters_per_line = 0;
 
     for (size_t i = 0; i < 3; ++i)


### PR DESCRIPTION
Most programs output fasta files in this format:
```
>Test1
AACCGGTT
```
By default `seqan3` puts a whitespace in between '>' and 'Test1'. This default is being changed with this PR to meet the standard of most other programs out there.
seqan3 default:
```
> Test1
AACCGGTT
```
