### PR TITLE
[FEAT] Option to ignore blanks before ids when reading FastA-Files

### DIFF
--- a/include/seqan3/io/sequence_file/input_options.hpp
+++ b/include/seqan3/io/sequence_file/input_options.hpp
@@ -29,6 +29,8 @@ struct sequence_file_input_options
     bool truncate_ids = false;
     //!\brief Read the complete_header into the seqan3::field::id for embl or genbank format.
     bool embl_genbank_complete_header = false;
+    //!\brief Remove spaces after ">" (or ";") before the actual ID.
+    bool fasta_ignore_blanks_before_id = true;
 };
 
 } // namespace seqan3

--- a/test/unit/io/sequence_file/sequence_file_integration_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_integration_test.cpp
@@ -47,6 +47,33 @@ TEST(rows, assign_sequence_files)
     EXPECT_EQ(reinterpret_cast<std::ostringstream&>(fout.get_stream()).str(), output_comp);
 }
 
+TEST(rows, assign_sequence_files_read_blanks)
+{
+    std::string const input
+    {
+        ">TEST 1\n"
+        "ACGT\n"
+        "> Test2\n"
+        "AGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGNAGGCTGN\n"
+        ">  Test3\n"
+        "GGAGTATAATATATATATATATAT\n"
+    };
+
+    std::string const expected_output = input;
+
+    seqan3::sequence_file_input fin{std::istringstream{input}, seqan3::format_fasta{}};
+    fin.options.fasta_ignore_blanks_before_id = false;
+
+    seqan3::sequence_file_output fout{std::ostringstream{}, seqan3::format_fasta{}};
+    fout.options.fasta_letters_per_line = 0;
+
+    fout = fin;
+
+    fout.get_stream().flush();
+    std::string const output = reinterpret_cast<std::ostringstream&>(fout.get_stream()).str();
+    EXPECT_EQ(output, expected_output);
+}
+
 TEST(integration, assign_sequence_file_pipes)
 {
     std::string const input


### PR DESCRIPTION
A simple roundtrip through seqan3 (reading and writing a fasta file) should not introduce any changes with the default options
```
auto fout = seqan3::sequence_file_input{std::istringstream{input}, seqan3::format_fasta{}} |
                  seqan3::sequence_file_output{std::ostringstream{}, seqan3::format_fasta{}};
```

The PR https://github.com/seqan/seqan3/pull/2769 fixes the forced introduction of spaces before the sequence ids.
This PR fixes the removal of whitespaces when reading a fasta file.
This changes the default behavior. To achieve the old behavior a new flag is introduced:
```fin.options.fasta_ignore_blank_before_id``` which is by default `true`.


Example:
File
```
> seq1
ACTG
```
seqan3 now: `id="seq1"`
some others: `id=" seq1"`