### PR TITLE
Simplify take_until

### DIFF
--- a/include/seqan3/io/views/detail/take_until_view.hpp
+++ b/include/seqan3/io/views/detail/take_until_view.hpp
@@ -292,7 +292,7 @@ public:
      * \{
      */
     //!\brief Return the saved at_end state.
-    bool operator==(underlying_sentinel_t const & rhs) const
+    bool operator==(basic_consume_sentinel<const_range> const &) const
         noexcept(!or_throw &&
                  noexcept(std::declval<underlying_iterator_t &>() != std::declval<underlying_sentinel_t &>()) &&
                  noexcept(fun(std::declval<reference>())))
@@ -300,7 +300,7 @@ public:
         if (at_end_gracefully)
             return true;
 
-        if (this->base() == rhs)
+        if (this->base() == underlying_sentinel)
         {
             if constexpr (or_throw)
                 throw unexpected_end_of_input{"Reached end of input before functor evaluated to true."};
@@ -312,21 +312,21 @@ public:
     }
 
     //!\brief Return the saved at_end state.
-    friend bool operator==(underlying_sentinel_t const & lhs, basic_consume_iterator const & rhs)
+    friend bool operator==(basic_consume_sentinel<const_range> const & lhs, basic_consume_iterator const & rhs)
         noexcept(noexcept(rhs == lhs))
     {
         return rhs == lhs;
     }
 
     //!\brief Return the saved at_end state.
-    bool operator!=(underlying_sentinel_t const & rhs) const
+    bool operator!=(basic_consume_sentinel<const_range> const & rhs) const
         noexcept(noexcept(std::declval<basic_consume_iterator &>() == rhs))
     {
         return !(*this == rhs);
     }
 
     //!\brief Return the saved at_end state.
-    friend bool operator!=(underlying_sentinel_t const & lhs, basic_consume_iterator const & rhs)
+    friend bool operator!=(basic_consume_sentinel<const_range> const & lhs, basic_consume_iterator const & rhs)
         noexcept(noexcept(rhs != lhs))
     {
         return rhs != lhs;

--- a/include/seqan3/io/views/detail/take_until_view.hpp
+++ b/include/seqan3/io/views/detail/take_until_view.hpp
@@ -134,7 +134,7 @@ public:
         if constexpr (and_consume && !std::ranges::forward_range<urng_t>)
             return basic_consume_iterator<urng_t>{std::ranges::begin(urange), static_cast<fun_t &>(fun), std::ranges::end(urange)};
         else
-            return basic_iterator<urng_t>{std::ranges::begin(urange), static_cast<fun_t &>(fun), std::ranges::end(urange)};
+            return basic_iterator<urng_t>{std::ranges::begin(urange)};
     }
 
     //!\copydoc begin()
@@ -144,7 +144,7 @@ public:
         if constexpr (and_consume && !std::ranges::forward_range<urng_t const>)
             return basic_consume_iterator<urng_t const>{std::ranges::cbegin(urange), static_cast<fun_t const &>(fun), std::ranges::cend(urange)};
         else
-            return basic_iterator<urng_t const>{std::ranges::cbegin(urange), static_cast<fun_t const &>(fun), std::ranges::cend(urange)};
+            return basic_iterator<urng_t const>{std::ranges::cbegin(urange)};
     }
 
     /*!\brief Returns an iterator to the element following the last element of the range.
@@ -197,14 +197,6 @@ private:
     using base_base_t = std::ranges::iterator_t<rng_t>;
     //!\brief The CRTP wrapper type.
     using base_t = inherited_iterator_base<basic_iterator, std::ranges::iterator_t<rng_t>>;
-    //!\brief The sentinel type is identical to that of the underlying range.
-    using sentinel_type = std::ranges::sentinel_t<rng_t>;
-    //!\brief Auxiliary type.
-    using fun_ref_t = std::conditional_t<std::is_const_v<rng_t>,
-                                         std::remove_reference_t<fun_t> const &,
-                                         std::remove_reference_t<fun_t> &>;
-    //!\brief Reference to the functor stored in the view.
-    seqan3::semiregular_box_t<fun_ref_t> fun;
 
 public:
     /*!\name Constructors, destructor and assignment
@@ -221,13 +213,6 @@ public:
     //!\brief Constructor that delegates to the CRTP layer.
     basic_iterator(base_base_t it) noexcept(noexcept(base_t{it})) :
         base_t{std::move(it)}
-    {}
-
-    //!\brief Constructor that delegates to the CRTP layer and initialises the callable.
-    basic_iterator(base_base_t it,
-                   fun_ref_t _fun,
-                   sentinel_type /*only used by the consuming iterator*/) noexcept(noexcept(base_t{it})) :
-        base_t{std::move(it)}, fun{_fun}
     {}
     //!\}
 };

--- a/include/seqan3/io/views/detail/take_until_view.hpp
+++ b/include/seqan3/io/views/detail/take_until_view.hpp
@@ -78,7 +78,7 @@ private:
     class basic_consume_iterator;
 
     template <bool const_range>
-    using basic_consume_sentinel = seqan3::detail::maybe_const_sentinel_t<const_range, urng_t>;
+    using basic_consume_sentinel = std::default_sentinel_t;
 
 public:
     /*!\name Constructors, destructor and assignment
@@ -167,7 +167,7 @@ public:
     auto end() noexcept
     {
         if constexpr (and_consume && !std::ranges::forward_range<urng_t>)
-            return basic_consume_sentinel<false>{std::ranges::end(urange)};
+            return basic_consume_sentinel<false>{};
         else
             return basic_sentinel<false>{std::ranges::end(urange), fun};
     }
@@ -177,7 +177,7 @@ public:
         requires const_iterable
     {
         if constexpr (and_consume && !std::ranges::forward_range<urng_t const>)
-            return basic_consume_sentinel<true>{std::ranges::cend(urange)};
+            return basic_consume_sentinel<true>{};
         else
             return basic_sentinel<true>{std::ranges::cend(urange), static_cast<fun_t const &>(fun)};
     }

--- a/include/seqan3/io/views/detail/take_until_view.hpp
+++ b/include/seqan3/io/views/detail/take_until_view.hpp
@@ -68,15 +68,23 @@ private:
     static constexpr bool const_iterable = const_iterable_range<urng_t> &&
                                            std::regular_invocable<fun_t, std::ranges::range_reference_t<urng_t>>;
 
+    //!\brief Iterator of the underlying range (urng_t).
+    //!\tparam const_range Whether iterator is a const iterator (const_range = true) or a non-const iterator.
     template <bool const_range>
     using basic_iterator = seqan3::detail::maybe_const_iterator_t<const_range, urng_t>;
 
+    //!\brief The sentinel type of take_until, provides the comparison operators.
+    //!\tparam const_range Whether sentinel is a const sentinel (const_range = true) or a non-const sentinel.
     template <bool const_range>
     class basic_sentinel;
 
+    //!\brief Special iterator type used when consuming behaviour is selected.
+    //!\tparam const_range Whether iterator is a const iterator (const_range = true) or a non-const iterator.
     template <bool const_range>
     class basic_consume_iterator;
 
+    //!\brief The sentinel type of take_until when consuming behaviour is selected.
+    //!\tparam const_range Whether sentinel is a const sentinel (const_range = true) or a non-const sentinel.
     template <bool const_range>
     using basic_consume_sentinel = std::default_sentinel_t;
 
@@ -189,8 +197,6 @@ public:
 template <typename urng_t, typename fun_t, bool or_throw = false, bool and_consume = false>
 view_take_until(urng_t &&, fun_t) -> view_take_until<std::views::all_t<urng_t>, fun_t, or_throw, and_consume>;
 
-//!\brief Special iterator type used when consuming behaviour is selected.
-//!\tparam rng_t Should be `urng_t` for defining #iterator and `urng_t const` for defining #const_iterator.
 template <std::ranges::view urng_t, typename fun_t, bool or_throw, bool and_consume>
 template <bool const_range>
 class view_take_until<urng_t, fun_t, or_throw, and_consume>::basic_consume_iterator :
@@ -334,7 +340,6 @@ public:
     //!\}
 };
 
-//!\brief The sentinel type of take_until, provides the comparison operators.
 template <std::ranges::view urng_t, typename fun_t, bool or_throw, bool and_consume>
 template <bool const_range>
 class view_take_until<urng_t, fun_t, or_throw, and_consume>::basic_sentinel


### PR DESCRIPTION
This simplifies take_until and does two things

* differentiates between basic_iterator and basic_consume_iterator (two different modes of take_until)
* uses `basic_[consume_]iterator/sentinel<bool>` https://github.com/seqan/product_backlog/issues/168