### PR TITLE
[FIX] clang+gcc9: error: default initialization of an object of const type

### DIFF
--- a/include/seqan3/search/detail/search_scheme_precomputed.hpp
+++ b/include/seqan3/search/detail/search_scheme_precomputed.hpp
@@ -84,7 +84,7 @@ using search_scheme_dyn_type = std::vector<search_dyn>;
  *          seems to be a good greedy approach.
  */
 template <uint8_t min_error, uint8_t max_error>
-inline int constexpr optimum_search_scheme;
+inline int constexpr optimum_search_scheme{0};
 
 //!\cond
 


### PR DESCRIPTION
```
/seqan3/include/seqan3/search/detail/search_scheme_precomputed.hpp:87:22: error: default initialization of an object of const type 'const int'
inline int constexpr optimum_search_scheme;
                     ^
                                           = 0
```

part of https://github.com/seqan/product_backlog/issues/127