### PR TITLE
[FIX] clang+gcc9: error: reference to local binding 'complete_config' declared in enclosing function 'seqan3::search'

### DIFF
--- a/include/seqan3/alignment/pairwise/align_pairwise.hpp
+++ b/include/seqan3/alignment/pairwise/align_pairwise.hpp
@@ -191,11 +191,11 @@ constexpr auto align_pairwise(sequence_t && sequences,
                                                            execution_handler_t>;
 
     // Select the execution handler for the alignment configuration.
-    auto select_execution_handler = [&] ()
+    auto select_execution_handler = [parallel = complete_config.get_or(align_cfg::parallel{})] ()
     {
         if constexpr (std::same_as<execution_handler_t, detail::execution_handler_parallel>)
         {
-            auto thread_count = get<align_cfg::parallel>(complete_config).thread_count;
+            auto thread_count = parallel.thread_count;
             if (!thread_count)
                 throw std::runtime_error{"You must configure the number of threads in seqan3::align_cfg::parallel."};
 

--- a/include/seqan3/search/search.hpp
+++ b/include/seqan3/search/search.hpp
@@ -126,11 +126,11 @@ inline auto search(queries_t && queries,
                                     detail::execution_handler_sequential>;
 
     // Select the execution handler for the search configuration.
-    auto select_execution_handler = [&] ()
+    auto select_execution_handler = [parallel = complete_config.get_or(search_cfg::parallel{})] ()
     {
         if constexpr (std::same_as<execution_handler_t, detail::execution_handler_parallel>)
         {
-            auto thread_count = get<search_cfg::parallel>(complete_config).thread_count;
+            auto thread_count = parallel.thread_count;
             if (!thread_count)
                 throw std::runtime_error{"You must configure the number of threads in seqan3::search_cfg::parallel."};
 


### PR DESCRIPTION
Part of https://github.com/seqan/product_backlog/issues/127