### PR TITLE
[FIX] clang+gcc9: error: clang frontend command failed with exit code 139 (ICE)

### DIFF
--- a/include/seqan3/alignment/matrix/detail/coordinate_matrix.hpp
+++ b/include/seqan3/alignment/matrix/detail/coordinate_matrix.hpp
@@ -86,7 +86,7 @@ private:
          */
         auto operator()(index_t const row_index) noexcept
         {
-            return matrix_index{row_index_type{row_index}, column_index_type{column_index}};
+            return matrix_index<index_t>{row_index_type{row_index}, column_index_type{column_index}};
         }
     };
 


### PR DESCRIPTION
Part of https://github.com/seqan/product_backlog/issues/127