### PR TITLE
[FIX] clang+gcc9: error: cannot increment value of type 'int __attribute__((ext_vector_type(1)))' (vector of 1 'int' value)

### DIFF
--- a/include/seqan3/alignment/matrix/detail/coordinate_matrix.hpp
+++ b/include/seqan3/alignment/matrix/detail/coordinate_matrix.hpp
@@ -259,7 +259,12 @@ public:
     //!\brief Increments the iterator to the next column.
     iterator & operator++()
     {
-        ++column_id;
+        // clang: pre-increment of a SIMD vector does not work
+        if constexpr (simd_index<index_t>)
+            column_id = column_id + simd::fill<index_t>(1);
+        else
+            ++column_id;
+
         return *this;
     }
 


### PR DESCRIPTION

```
/seqan3/include/seqan3/alignment/matrix/detail/coordinate_matrix.hpp:262:9: error: cannot increment value of type 'int __attribute__((ext_vector_type(1)))' (vector of 1 'int' value)
        ++column_id;
        ^ ~~~~~~~~~
```

Part of https://github.com/seqan/product_backlog/issues/127