### PR TITLE
[FIX] clang+gcc9: error: cannot initialize return object of type

### DIFF
--- a/include/seqan3/alignment/matrix/detail/trace_iterator_base.hpp
+++ b/include/seqan3/alignment/matrix/detail/trace_iterator_base.hpp
@@ -119,7 +119,7 @@ public:
      */
     using value_type = trace_directions; //!< The value type.
     using reference = trace_directions const &; //!< The reference type.
-    using pointer = value_type *; //!< The pointer type.
+    using pointer = value_type const *; //!< The pointer type.
     using difference_type = std::ptrdiff_t; //!< The difference type.
     using iterator_category = std::forward_iterator_tag; //!< Forward iterator tag.
     //!\}


### PR DESCRIPTION
```
seqan3/include/seqan3/alignment/matrix/detail/trace_iterator_base.hpp:139:16: error: cannot initialize return object of type 'seqan3::detail::trace_iterator_base::pointer' (aka 'seqan3::detail::trace_directions *') with an rvalue of type 'const seqan3::detail::trace_directions *'
        return &current_direction;
               ^~~~~~~~~~~~~~~~~~
```

Part of https://github.com/seqan/product_backlog/issues/127