### PR TITLE
[FIX] clang+gcc9: error: no matching function for call to 'forward'

### DIFF
--- a/include/seqan3/core/algorithm/detail/execution_handler_parallel.hpp
+++ b/include/seqan3/core/algorithm/detail/execution_handler_parallel.hpp
@@ -155,7 +155,9 @@ public:
         // https://stackoverflow.com/questions/26831382/capturing-perfectly-forwarded-variable-in-lambda/
 
         // Asynchronously pushes the algorithm job as a task to the queue.
-        task_type task = [=, input_tpl = std::tuple<algorithm_input_t>{std::forward<algorithm_input_t>(input)}] ()
+        // Note: that lambda is mutable, s.t. we can move out the content of input_tpl
+        task_type task = [=,
+                          input_tpl = std::tuple<algorithm_input_t>{std::forward<algorithm_input_t>(input)}] () mutable
         {
             using forward_input_t = std::tuple_element_t<0, decltype(input_tpl)>;
             algorithm(std::forward<forward_input_t>(std::get<0>(input_tpl)), std::move(callback));


### PR DESCRIPTION
```
/seqan3/include/seqan3/core/algorithm/detail/execution_handler_parallel.hpp:161:23: error: no matching function for call to 'forward'
            algorithm(std::forward<forward_input_t>(std::get<0>(input_tpl)), std::move(callback));
                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Part of https://github.com/seqan/product_backlog/issues/127