### PR TITLE
[FIX] clang+gcc9: error: pack expansion used as argument for non-pack…

### DIFF
--- a/test/unit/std/concept/auxiliary_iterator.hpp
+++ b/test/unit/std/concept/auxiliary_iterator.hpp
@@ -66,8 +66,8 @@ struct input_or_output_iter_value
 };
 
 // ostream has std::iter_value_t void, but we want the output value type here.
-template <typename value_t, typename ...ts>
-struct input_or_output_iter_value<std::cpp20::ostream_iterator<value_t, ts...>>
+template <typename value_t, typename char_t, typename char_traits_t>
+struct input_or_output_iter_value<std::cpp20::ostream_iterator<value_t, char_t, char_traits_t>>
 {
     using type = value_t;
 };


### PR DESCRIPTION
… parameter of alias template

```
/seqan3/test/unit/std/concept/auxiliary_iterator.hpp:73:73: error: pack expansion used as argument for non-pack parameter of alias template
struct input_or_output_iter_value<std::cpp20::ostream_iterator<value_t, ts...>>
                                                                        ^~~~~
/seqan3/submodules/range-v3/include/range/v3/iterator/stream_iterators.hpp:196:39: note: template parameter is declared here
        template<typename T, typename Char = char,
                                      ^
```

Part of https://github.com/seqan/product_backlog/issues/127