### PR TITLE
[FIX] clang+gcc9: error: call to non-static member function without an object argument

### DIFF
--- a/include/seqan3/alphabet/composite/alphabet_tuple_base.hpp
+++ b/include/seqan3/alphabet/composite/alphabet_tuple_base.hpp
@@ -686,7 +686,7 @@ private:
     //!\brief The implementation updates the rank in the parent object.
     constexpr void on_update() noexcept
     {
-        parent->assign_component_rank<index>(to_rank());
+        parent->assign_component_rank<index>(this->to_rank());
     }
 
 public:

--- a/include/seqan3/utility/simd/views/to_simd.hpp
+++ b/include/seqan3/utility/simd/views/to_simd.hpp
@@ -96,7 +96,7 @@ private:
     //!\brief The total number of chunks that can be cached.
     static constexpr uint8_t total_chunks = fast_load ? (chunks_per_load * chunks_per_load) : 1;
     //!\brief The alphabet size.
-    static constexpr auto alphabet_size = alphabet_size<std::ranges::range_value_t<inner_range_type>>;
+    static constexpr auto alphabet_size = seqan3::alphabet_size<std::ranges::range_value_t<inner_range_type>>;
     //!\}
 
     // Forward declare class' iterator type. See definition below.


### PR DESCRIPTION
```
/seqan3/include/seqan3/utility/simd/views/to_simd.hpp:97:43: error: variable 'alphabet_size' declared with deduced type 'const auto' cannot appear in its own initializer
    static constexpr auto alphabet_size = alphabet_size<std::ranges::range_value_t<inner_range_type>>;
                                          ^
```

```
/seqan3/include/seqan3/alphabet/composite/alphabet_tuple_base.hpp:691:46: error: call to non-static member function without an object argument
        parent->assign_component_rank<index>(to_rank());
                                             ^~~~~~~
```


Part of https://github.com/seqan/product_backlog/issues/127