### PR TITLE
clang: error: requires clause differs in template redeclaration

### DIFF
--- a/include/seqan3/alignment/matrix/detail/trace_iterator_base.hpp
+++ b/include/seqan3/alignment/matrix/detail/trace_iterator_base.hpp
@@ -68,8 +68,10 @@ private:
     //!\brief Befriend with corresponding const_iterator.
     template <typename other_derived_t, two_dimensional_matrix_iterator other_matrix_iter_t>
     //!\cond
+#if !SEQAN3_WORKAROUND_FURTHER_CONSTRAIN_FRIEND_DECLARATION
         requires std::constructible_from<derived_t, other_derived_t> &&
                  std::constructible_from<matrix_iter_t, other_matrix_iter_t>
+#endif // !SEQAN3_WORKAROUND_FURTHER_CONSTRAIN_FRIEND_DECLARATION
     //!\endcond
     friend class trace_iterator_base;
 

--- a/include/seqan3/alignment/matrix/detail/two_dimensional_matrix.hpp
+++ b/include/seqan3/alignment/matrix/detail/two_dimensional_matrix.hpp
@@ -336,7 +336,9 @@ private:
     //!\brief Befriend the base crtp class.
     template <typename derived_t, matrix_major_order other_order>
     //!\cond
+#if !SEQAN3_WORKAROUND_FURTHER_CONSTRAIN_FRIEND_DECLARATION
         requires is_value_specialisation_of_v<derived_t, basic_iterator> && (other_order == order)
+#endif // !SEQAN3_WORKAROUND_FURTHER_CONSTRAIN_FRIEND_DECLARATION
     //!\endcond
     friend class two_dimensional_matrix_iterator_base;
 

--- a/include/seqan3/alignment/matrix/detail/two_dimensional_matrix_iterator_base.hpp
+++ b/include/seqan3/alignment/matrix/detail/two_dimensional_matrix_iterator_base.hpp
@@ -82,7 +82,9 @@ private:
     //!\brief Befriend other base class types for const iterator compatibility.
     template <typename other_derived_t, matrix_major_order other_order>
     //!\cond
+#if !SEQAN3_WORKAROUND_FURTHER_CONSTRAIN_FRIEND_DECLARATION
         requires (order == other_order)
+#endif // !SEQAN3_WORKAROUND_FURTHER_CONSTRAIN_FRIEND_DECLARATION
     //!\endcond
     friend class two_dimensional_matrix_iterator_base;
 

--- a/include/seqan3/core/platform.hpp
+++ b/include/seqan3/core/platform.hpp
@@ -384,6 +384,32 @@
 #   endif
 #endif
 
+/*!\brief gcc only: Constrain friend declarations to limit access to internals.
+ *
+ * \details
+ *
+ * We have some instances where we constrain friend declarations to limit which class instance can
+ * access private information. For example
+ *
+ * ```
+ * template <typename type_t>
+ *     requires std::same_as<type_t, int>
+ * friend class std::tuple;
+ * ```
+ *
+ * would only allow `std::tuple<int>` to access the internals.
+ *
+ * It seems that this is not standard behaviour and more like a gcc-only extension, as neither clang nor msvc supports
+ * it. For now we will keep this code, but it should be removed if it turns out that this is non-standard. (i.e. a newer
+ * gcc release does not support it any more)
+ */
+#ifndef SEQAN3_WORKAROUND_FURTHER_CONSTRAIN_FRIEND_DECLARATION
+#   if defined(__clang__)
+#       define SEQAN3_WORKAROUND_FURTHER_CONSTRAIN_FRIEND_DECLARATION 1
+#   else
+#       define SEQAN3_WORKAROUND_FURTHER_CONSTRAIN_FRIEND_DECLARATION 0
+#   endif
+#endif
 
 // ============================================================================
 //  Backmatter

--- a/include/seqan3/core/range/detail/random_access_iterator.hpp
+++ b/include/seqan3/core/range/detail/random_access_iterator.hpp
@@ -51,9 +51,11 @@ protected:
     //!\brief This friend declaration is required to allow non-const to const-construction.
     template <typename range_type2, template <typename ...> typename derived_t_template2>
     //!\cond
+#if !SEQAN3_WORKAROUND_FURTHER_CONSTRAIN_FRIEND_DECLARATION
         requires std::is_const_v<range_type> && (!std::is_const_v<range_type2>) &&
                  std::is_same_v<std::remove_const_t<range_type>, range_type2> &&
                  std::is_same_v<derived_t_template2, derived_t_template>
+#endif // !SEQAN3_WORKAROUND_FURTHER_CONSTRAIN_FRIEND_DECLARATION
     //!\endcond
     friend class random_access_iterator_base;
 

--- a/include/seqan3/utility/views/pairwise_combine.hpp
+++ b/include/seqan3/utility/views/pairwise_combine.hpp
@@ -271,7 +271,11 @@ private:
 
     //!\brief Friend declaration for iterator with different range const-ness.
     template <typename other_range_type>
+    //!\cond
+#if !SEQAN3_WORKAROUND_FURTHER_CONSTRAIN_FRIEND_DECLARATION
         requires std::same_as<std::remove_const_t<range_type>, std::remove_const_t<other_range_type>>
+#endif // !SEQAN3_WORKAROUND_FURTHER_CONSTRAIN_FRIEND_DECLARATION
+    //!\endcond
     friend class basic_iterator;
 
     //!\brief Alias type for the iterator over the passed range type.


### PR DESCRIPTION
Part of https://github.com/seqan/product_backlog/issues/127

Comparing template template?

```
In file included from /seqan3/test/unit/range/detail/random_access_iterator_test.cpp:13:
/seqan3/include/seqan3/range/detail/random_access_iterator.hpp:56:33: error: use of template template parameter 'derived_t_template2' requires template arguments
                 std::is_same_v<derived_t_template2, derived_t_template>
                                ^
/seqan3/include/seqan3/range/detail/random_access_iterator.hpp:52:70: note: template is declared here
    template <typename range_type2, template <typename ...> typename derived_t_template2>
                                    ~~~~~~~~~~~~~~~~~~~~~~~          ^
```

clang: Constraining friends is now allowed?

```
In file included from /seqan3/test/unit/range/detail/random_access_iterator_test.cpp:13:
/seqan3/include/seqan3/range/detail/random_access_iterator.hpp:54:18: error: requires clause differs in template redeclaration
        requires std::is_const_v<range_type> && (!std::is_const_v<range_type2>) &&
                 ^
/seqan3/include/seqan3/range/detail/random_access_iterator.hpp:309:12: note: in instantiation of template class 'seqan3::detail::random_access_iterator_base<std::vector<int>, random_access_iterator>' requested here
    public random_access_iterator_base<range_type, random_access_iterator>
           ^
/seqan3/test/unit/range/detail/random_access_iterator_test.cpp:34:23: note: in instantiation of template class 'seqan3::detail::random_access_iterator<std::vector<int>>' requested here
        iterator_type begin() { return iterator_type{rng}; }
                      ^
```

```
/seqan3/include/seqan3/alignment/matrix/detail/two_dimensional_matrix_iterator_base.hpp:85:18: error: requires clause differs in template redeclaration
        requires (order == other_order)
                 ^
```

```
/seqan3/include/seqan3/alignment/matrix/detail/two_dimensional_matrix.hpp:339:18: error: requires clause differs in template redeclaration
        requires is_value_specialisation_of_v<derived_t, basic_iterator> && (other_order == order)
                 ^
```

```
/seqan3/include/seqan3/alignment/matrix/detail/trace_iterator_base.hpp:71:23: error: requires clause differs in template redeclaration
        requires std::constructible_from<derived_t, other_derived_t> &&
                      ^

```

```
/seqan3/include/seqan3/utility/views/pairwise_combine.hpp:274:23: error: requires clause differs in template redeclaration
        requires std::same_as<std::remove_const_t<range_type>, std::remove_const_t<other_range_type>>
                      ^
```