### PR TITLE
[FIX] clang: error: 'auto' deduced as 'seqan3::detail::random_access_iterator...'

### DIFF
--- a/test/unit/range/iterator_test_template.hpp
+++ b/test/unit/range/iterator_test_template.hpp
@@ -332,9 +332,9 @@ inline void move_backward_pre_test(it_begin_t && it_begin, it_sentinel_t && it_e
     auto const rng_it_begin = std::ranges::begin(rng);
 
     // pre-decrement
-    for (auto it = last_it, rng_it = rng_last_it;
-         it != it_begin && rng_it != rng_it_begin;
-         --rng_it)
+    auto it = last_it;
+    auto rng_it = rng_last_it;
+    for (; it != it_begin && rng_it != rng_it_begin; --rng_it)
     {
        expect_iter_equal<test_type>(it, rng_it);
        --it;
@@ -351,9 +351,9 @@ inline void move_backward_post_test(it_begin_t && it_begin, it_sentinel_t && it_
     auto const rng_it_begin = std::ranges::begin(rng);
 
     // post-decrement
-    for (auto it = last_it, rng_it = rng_last_it;
-         it != it_begin && rng_it != rng_it_begin;
-         --rng_it)
+    auto it = last_it;
+    auto rng_it = rng_last_it;
+    for (; it != it_begin && rng_it != rng_it_begin; --rng_it)
     {
        expect_iter_equal<test_type>(it--, rng_it);
     }


### PR DESCRIPTION
Paert of https://github.com/seqan/product_backlog/issues/127

```
seqan3/test/unit/range/detail/../iterator_test_template.hpp:335:10: error: 'auto' deduced as 'seqan3::detail::random_access_iterator<std::vector<int>>' in declaration of 'it' and deduced as 'std::__wrap_iter<int *>' in declaration of 'rng_it'
    for (auto it = last_it, rng_it = rng_last_it;
         ^         ~~~~~~~           ~~~~~~~~~~~
```