### PR TITLE
[INFRA,DOC] Make snippets compile without -Wno-unused

### DIFF
--- a/doc/howto/write_an_alphabet/dna2_semialphabet.cpp
+++ b/doc/howto/write_an_alphabet/dna2_semialphabet.cpp
@@ -8,7 +8,7 @@
 //! [semialphabet]
 #include <cassert>
 
-#include <seqan3/alphabet/concept.hpp>                   // alphabet concept checks
+#include <seqan3/alphabet/concept.hpp> // alphabet concept checks
 
 struct dna2
 {
@@ -66,15 +66,16 @@ bool operator>=(dna2 const & lhs, dna2 const & rhs) noexcept
 }
 
 //! [writable_semialphabet_concept]
-static_assert(seqan3::semialphabet<dna2>);               // ok
-static_assert(seqan3::writable_semialphabet<dna2>);       // ok
+static_assert(seqan3::semialphabet<dna2>); // ok
+static_assert(seqan3::writable_semialphabet<dna2>); // ok
 //! [writable_semialphabet_concept]
 
 //! [free_functions]
 int main ()
 {
     dna2 chr{};
-    seqan3::assign_rank_to(1, chr);                      // chr is assigned rank 1
-    uint8_t rnk = seqan3::to_rank(chr);                  // query rank value  => 1
+    seqan3::assign_rank_to(1, chr); // chr is assigned rank 1
+    uint8_t rnk = seqan3::to_rank(chr); // query rank value
+    std::cout << static_cast<uint16_t>(rnk) << '\n'; // 1
 }
 //! [free_functions]

--- a/doc/tutorial/introduction/introduction_align.cpp
+++ b/doc/tutorial/introduction/introduction_align.cpp
@@ -29,9 +29,9 @@ int main()
     seqan3::sequence_file_input file_in{filename};
     std::vector<seqan3::dna5_vector> sequences;
 
-    for (auto & [ seq, id, qual ] : file_in)
+    for (auto & record : file_in)
     {
-        sequences.push_back(seq);
+        sequences.push_back(record.sequence());
     }
 
     // Call a global pairwise alignment with edit distance and traceback.

--- a/doc/tutorial/introduction/introduction_read_fasta.cpp
+++ b/doc/tutorial/introduction/introduction_read_fasta.cpp
@@ -31,9 +31,9 @@ int main(int argc, char * argv[])
 
     // Iterate through the file and store the sequences.
     seqan3::sequence_file_input file_in{filename};
-    for (auto & [ seq, id, qual ] : file_in)
+    for (auto & record : file_in)
     {
-        sequences.push_back(seq);
+        sequences.push_back(record.sequence());
     }
 
     seqan3::debug_stream << sequences << '\n';

--- a/doc/tutorial/read_mapper/read_mapper_indexer_step2.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_indexer_step2.cpp
@@ -17,12 +17,11 @@ void read_reference(std::filesystem::path const & reference_path,
 //! [read_reference]
 {
     seqan3::sequence_file_input reference_in{reference_path};
-    for (auto & [seq, id, qual] : reference_in)
+    for (auto && record : reference_in)
     {
-        storage.ids.push_back(std::move(id));
-        storage.seqs.push_back(std::move(seq));
+        storage.ids.push_back(record.id());
+        storage.seqs.push_back(record.sequence());
     }
-    seqan3::debug_stream << "Reference IDs: " << storage.ids << '\n';
 }
 
 void run_program(std::filesystem::path const & reference_path,

--- a/doc/tutorial/read_mapper/read_mapper_indexer_step3.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_indexer_step3.cpp
@@ -20,10 +20,10 @@ void read_reference(std::filesystem::path const & reference_path,
                     reference_storage_t & storage)
 {
     seqan3::sequence_file_input reference_in{reference_path};
-    for (auto & [seq, id, qual] : reference_in)
+    for (auto && record : reference_in)
     {
-        storage.ids.push_back(std::move(id));
-        storage.seqs.push_back(std::move(seq));
+        storage.ids.push_back(record.id());
+        storage.seqs.push_back(record.sequence());
     }
 }
 

--- a/doc/tutorial/read_mapper/read_mapper_step2.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_step2.cpp
@@ -22,10 +22,10 @@ void read_reference(std::filesystem::path const & reference_path,
                     reference_storage_t & storage)
 {
     seqan3::sequence_file_input reference_in{reference_path};
-    for (auto & [seq, id, qual] : reference_in)
+    for (auto && record : reference_in)
     {
-        storage.ids.push_back(std::move(id));
-        storage.seqs.push_back(std::move(seq));
+        storage.ids.push_back(record.id());
+        storage.seqs.push_back(record.sequence());
     }
 }
 

--- a/doc/tutorial/read_mapper/read_mapper_step3.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_step3.cpp
@@ -24,10 +24,10 @@ void read_reference(std::filesystem::path const & reference_path,
                     reference_storage_t & storage)
 {
     seqan3::sequence_file_input reference_in{reference_path};
-    for (auto & [seq, id, qual] : reference_in)
+    for (auto && record : reference_in)
     {
-        storage.ids.push_back(std::move(id));
-        storage.seqs.push_back(std::move(seq));
+        storage.ids.push_back(record.id());
+        storage.seqs.push_back(record.sequence());
     }
 }
 

--- a/doc/tutorial/read_mapper/read_mapper_step4.cpp
+++ b/doc/tutorial/read_mapper/read_mapper_step4.cpp
@@ -24,10 +24,10 @@ void read_reference(std::filesystem::path const & reference_path,
                     reference_storage_t & storage)
 {
     seqan3::sequence_file_input reference_in{reference_path};
-    for (auto & [seq, id, qual] : reference_in)
+    for (auto && record : reference_in)
     {
-        storage.ids.push_back(std::move(id));
-        storage.seqs.push_back(std::move(seq));
+        storage.ids.push_back(record.id());
+        storage.seqs.push_back(record.sequence());
     }
 }
 

--- a/doc/tutorial/sequence_file/sequence_file_record_range.cpp
+++ b/doc/tutorial/sequence_file/sequence_file_record_range.cpp
@@ -10,10 +10,13 @@ int main()
 {
     seqan3::sequence_file_input file{std::filesystem::current_path() / "my.fasta"};
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
 //![record_range]
 for (auto & record : file)
 {
     // do something with my record
 }
 //![record_range]
+#pragma GCC diagnostic pop
 }

--- a/include/seqan3/utility/type_traits/lazy_conditional.hpp
+++ b/include/seqan3/utility/type_traits/lazy_conditional.hpp
@@ -141,7 +141,7 @@ inline constexpr auto instantiate_if_v = instantiate_if_t<t, condition>::value;
  *
  * ### Example
  *
- * \include test/snippet/utility/type_traits/lazy_conditional.cpp
+ * \include test/snippet/utility/type_traits/lazy_conditional.cpp complete
  */
 template <bool decision, typename on_true_t, typename on_false_t>
 struct lazy_conditional : instantiate<std::conditional_t<decision, on_true_t, on_false_t>>

--- a/test/snippet/CMakeLists.txt
+++ b/test/snippet/CMakeLists.txt
@@ -18,7 +18,6 @@ macro (seqan3_snippet test_name_prefix snippet snippet_base_path)
 
     add_executable (${target} "${snippet_base_path}/${snippet}")
     target_link_libraries (${target} seqan3::test::unit)
-    target_compile_options (${target} PUBLIC "-Wno-unused")
     set_target_properties(${target}
         PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${snippet_target_path}"

--- a/test/snippet/alignment/configuration/align_cfg_gap_cost_affine_example.cpp
+++ b/test/snippet/alignment/configuration/align_cfg_gap_cost_affine_example.cpp
@@ -1,3 +1,5 @@
+#include <iostream>
+
 #include <seqan3/alignment/configuration/align_config_gap_cost_affine.hpp>
 
 int main()
@@ -11,6 +13,8 @@ int main()
                                                   seqan3::align_cfg::extension_score{-10}};
 
     // Accessing the members of the gap scheme
-    int open = affine_cfg.open_score; // open == -1
-    int extension = affine_cfg.extension_score; // extension == -10
+    int open = affine_cfg.open_score;
+    int extension = affine_cfg.extension_score;
+    std::cout << open << '\n'; // -1
+    std::cout << extension << '\n'; // -10
 }

--- a/test/snippet/alphabet/alphabet_size.cpp
+++ b/test/snippet/alphabet/alphabet_size.cpp
@@ -1,9 +1,15 @@
-#include <seqan3/alphabet/concept.hpp>
+#include <iostream>
+
 #include <seqan3/alphabet/adaptation/char.hpp>
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
 
 int main()
 {
-    auto r2 = seqan3::alphabet_size<char>;            // calls seqan3::custom::alphabet_size(char{}); r2 == 256
-    auto r3 = seqan3::alphabet_size<seqan3::dna5>;    // returns dna5::alphabet_size; r3 == 5
+    auto sigma_char = seqan3::alphabet_size<char>; // calls seqan3::custom::alphabet_size(char{})
+    static_assert(std::same_as<decltype(sigma_char), uint16_t>);
+    std::cout << sigma_char << '\n'; // 256
+
+    auto sigma_dna5 = seqan3::alphabet_size<seqan3::dna5>; // returns dna5::alphabet_size
+    static_assert(std::same_as<decltype(sigma_dna5), uint8_t>);
+    std::cout << static_cast<uint16_t>(sigma_dna5) << '\n'; // 5
 }

--- a/test/snippet/alphabet/char_is_valid_for.cpp
+++ b/test/snippet/alphabet/char_is_valid_for.cpp
@@ -1,16 +1,14 @@
-#include <seqan3/alphabet/concept.hpp>
 #include <seqan3/alphabet/adaptation/char.hpp>
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
 
 int main()
 {
-    bool b = seqan3::char_is_valid_for<char>('A');
-    // calls seqan3::custom::char_is_valid_for<char>('A'); always true
+    // calls seqan3::custom::char_is_valid_for<char>('A')
+    std::cout << std::boolalpha << seqan3::char_is_valid_for<char>('A') << '\n'; // always 'true'
 
-    bool c = seqan3::char_is_valid_for<seqan3::dna5>('A');
-    // calls dna5::char_is_valid('A') member; == true
+    // calls dna5::char_is_valid('A') member
+    std::cout << std::boolalpha << seqan3::char_is_valid_for<seqan3::dna5>('A') << '\n'; // true
 
     // for some alphabets, characters that are not uniquely mappable are still valid:
-    bool d = seqan3::char_is_valid_for<seqan3::dna5>('a');
-    // lower case also true
+    std::cout << std::boolalpha << seqan3::char_is_valid_for<seqan3::dna5>('a') << '\n'; // true
 }

--- a/test/snippet/alphabet/quality/qualified.cpp
+++ b/test/snippet/alphabet/quality/qualified.cpp
@@ -10,23 +10,18 @@ int main()
 
     seqan3::qualified<seqan3::dna4, seqan3::phred42> letter{'A'_dna4, '('_phred42};
 
-    seqan3::debug_stream << seqan3::to_rank(letter) << ' '
-                         << seqan3::to_rank(get<0>(letter)) << ' '
-                         << seqan3::to_rank(get<1>(letter)) << '\n';
-    // prints "7 0 7"
+    seqan3::debug_stream << seqan3::to_rank(letter) << ' ' // 7
+                         << seqan3::to_rank(get<0>(letter)) << ' ' // 0
+                         << seqan3::to_rank(get<1>(letter)) << '\n'; // 7
 
-    seqan3::debug_stream << seqan3::to_char(letter) << ' '
-                         << seqan3::to_char(get<0>(letter)) << ' '
-                         << seqan3::to_char(get<1>(letter)) << '\n';
-    // prints "A A ("
+    seqan3::debug_stream << seqan3::to_char(letter) << ' ' // A
+                         << seqan3::to_char(get<0>(letter)) << ' ' // A
+                         << seqan3::to_char(get<1>(letter)) << '\n'; // (
 
-    seqan3::debug_stream << seqan3::to_phred(letter) << ' '
-                         << seqan3::to_phred(get<1>(letter)) << '\n';
-    // prints "7 7"
+    seqan3::debug_stream << seqan3::to_phred(letter) << ' ' // 7
+                         << seqan3::to_phred(get<1>(letter)) << '\n'; // 7
 
-    // Modify via structured bindings and references:
-    auto & [ sequence_letter, quality_letter ] = letter;
-    sequence_letter = 'G'_dna4;
-    seqan3::debug_stream << seqan3::to_char(letter) << '\n';
-    // prints "G"
+    // Modify:
+    get<0>(letter) = 'G'_dna4;
+    seqan3::debug_stream << seqan3::to_char(letter) << '\n'; // G
 }

--- a/test/snippet/alphabet/structure/structured_aa.cpp
+++ b/test/snippet/alphabet/structure/structured_aa.cpp
@@ -10,19 +10,15 @@ int main()
 
     seqan3::structured_aa<seqan3::aa27, seqan3::dssp9> letter{'W'_aa27, 'B'_dssp9};
 
-    seqan3::debug_stream << seqan3::to_rank(letter) << ' '
-                         << seqan3::to_rank(get<0>(letter)) << ' '
-                         << seqan3::to_rank(get<1>(letter)) << '\n';
-    // prints "199 22 1"
+    seqan3::debug_stream << seqan3::to_rank(letter) << ' ' // 199
+                         << seqan3::to_rank(get<0>(letter)) << ' ' // 22
+                         << seqan3::to_rank(get<1>(letter)) << '\n'; // 1
 
-    seqan3::debug_stream << seqan3::to_char(letter) << ' '
-                         << seqan3::to_char(get<0>(letter)) << ' '
-                         << seqan3::to_char(get<1>(letter)) << '\n';
-    // prints "W W B"
+    seqan3::debug_stream << seqan3::to_char(letter) << ' ' // W
+                         << seqan3::to_char(get<0>(letter)) << ' ' // W
+                         << seqan3::to_char(get<1>(letter)) << '\n'; // B
 
-    // Modify via structured bindings and references:
-    auto & [ sequence_letter, structure_letter ] = letter;
-    sequence_letter = 'V'_aa27;
-    seqan3::debug_stream << seqan3::to_char(letter) << '\n';
-    // prints "V"
+    // Modify:
+    get<0>(letter) = 'V'_aa27;
+    seqan3::debug_stream << seqan3::to_char(letter) << '\n'; // V
 }

--- a/test/snippet/alphabet/structure/structured_rna.cpp
+++ b/test/snippet/alphabet/structure/structured_rna.cpp
@@ -10,19 +10,15 @@ int main()
 
     seqan3::structured_rna<seqan3::rna4, seqan3::dot_bracket3> letter{'G'_rna4, '('_db3};
 
-    seqan3::debug_stream << seqan3::to_rank(letter) << ' '
-                         << seqan3::to_rank(get<0>(letter)) << ' '
-                         << seqan3::to_rank(get<1>(letter)) << '\n';
-    // prints "7 2 1"
+    seqan3::debug_stream << seqan3::to_rank(letter) << ' ' // 7
+                         << seqan3::to_rank(get<0>(letter)) << ' ' // 2
+                         << seqan3::to_rank(get<1>(letter)) << '\n'; // 1
 
-    seqan3::debug_stream << seqan3::to_char(letter) << ' '
-                         << seqan3::to_char(get<0>(letter)) << ' '
-                         << seqan3::to_char(get<1>(letter)) << '\n';
-    // prints "G G (""
+    seqan3::debug_stream << seqan3::to_char(letter) << ' ' // G
+                         << seqan3::to_char(get<0>(letter)) << ' ' // G
+                         << seqan3::to_char(get<1>(letter)) << '\n'; // (
 
-    // modify via structured bindings and references:
-    auto & [ sequence_letter, structure_letter ] = letter;
-    sequence_letter = 'U'_rna4;
-    seqan3::debug_stream << seqan3::to_char(letter) << '\n';
-    // prints "U"
+    // Modify:
+    get<0>(letter) = 'U'_rna4;
+    seqan3::debug_stream << seqan3::to_char(letter) << '\n'; // U
 }

--- a/test/snippet/alphabet/structure/wuss_is_pair_close.cpp
+++ b/test/snippet/alphabet/structure/wuss_is_pair_close.cpp
@@ -1,9 +1,14 @@
+#include <iostream>
+
 #include <seqan3/alphabet/structure/wuss.hpp>
 
 int main()
 {
     using namespace seqan3::literals;
 
-    bool is_closing_char = '}'_wuss51.is_pair_close();               // true
-    bool is_closing_char_alt = seqan3::is_pair_close('.'_wuss51);    // false
+    bool is_closing_char_member = '}'_wuss51.is_pair_close();
+    bool is_closing_char_free = seqan3::is_pair_close('.'_wuss51);
+
+    std::cout << std::boolalpha << is_closing_char_member << '\n'; // true
+    std::cout << std::boolalpha << is_closing_char_free << '\n'; // false
 }

--- a/test/snippet/alphabet/structure/wuss_is_pair_open.cpp
+++ b/test/snippet/alphabet/structure/wuss_is_pair_open.cpp
@@ -1,9 +1,14 @@
+#include <iostream>
+
 #include <seqan3/alphabet/structure/wuss.hpp>
 
 int main()
 {
     using namespace seqan3::literals;
 
-    bool is_opening_char = '{'_wuss51.is_pair_open();                // true
-    bool is_opening_char_alt = seqan3::is_pair_open('.'_wuss51);     // false
+    bool is_opening_char_member = '{'_wuss51.is_pair_open();
+    bool is_opening_char_free = seqan3::is_pair_open('.'_wuss51);
+
+    std::cout << std::boolalpha << is_opening_char_member << '\n'; // true
+    std::cout << std::boolalpha << is_opening_char_free << '\n'; // false
 }

--- a/test/snippet/alphabet/structure/wuss_is_unpaired.cpp
+++ b/test/snippet/alphabet/structure/wuss_is_unpaired.cpp
@@ -1,9 +1,14 @@
+#include <iostream>
+
 #include <seqan3/alphabet/structure/wuss.hpp>
 
 int main()
 {
     using namespace seqan3::literals;
 
-    bool is_unpaired_char = '.'_wuss51.is_unpaired();                // true
-    bool is_unpaired_char_alt = seqan3::is_unpaired('{'_wuss51);     // false
+    bool is_unpaired_char_member = '.'_wuss51.is_unpaired();
+    bool is_unpaired_char_free = seqan3::is_unpaired('{'_wuss51);
+
+    std::cout << std::boolalpha << is_unpaired_char_member << '\n'; // true
+    std::cout << std::boolalpha << is_unpaired_char_free << '\n'; // false
 }

--- a/test/snippet/alphabet/structure/wuss_max_pseudoknot_depth.cpp
+++ b/test/snippet/alphabet/structure/wuss_max_pseudoknot_depth.cpp
@@ -1,7 +1,11 @@
+#include <iostream>
+
 #include <seqan3/alphabet/structure/wuss.hpp>
 
 int main()
 {
-    uint8_t max_depth = seqan3::wuss51::max_pseudoknot_depth;             // 22
-    uint8_t max_depth_alt = seqan3::max_pseudoknot_depth<seqan3::wuss51>; // 22
+    uint8_t max_depth_member = seqan3::wuss51::max_pseudoknot_depth;
+    uint8_t max_depth_meta = seqan3::max_pseudoknot_depth<seqan3::wuss51>;
+    std::cout << static_cast<uint16_t>(max_depth_member) << '\n'; // 22
+    std::cout << static_cast<uint16_t>(max_depth_meta) << '\n'; // 22
 }

--- a/test/snippet/alphabet/views/char_to.cpp
+++ b/test/snippet/alphabet/views/char_to.cpp
@@ -1,12 +1,11 @@
-#include <string>
-
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
 #include <seqan3/alphabet/views/char_to.hpp>
+#include <seqan3/core/debug_stream.hpp>
 
 int main()
 {
-    std::string s{"ACTTTGATAN"};
-    auto v1 = s | seqan3::views::char_to<seqan3::dna4>; // == "ACTTTGATAA"_dna4
-    auto v2 = s | seqan3::views::char_to<seqan3::dna5>; // == "ACTTTGATAN"_dna5
+    std::string str{"ACTTTGATAN"};
+    seqan3::debug_stream << (str | seqan3::views::char_to<seqan3::dna4>) << '\n'; // ACTTTGATAA
+    seqan3::debug_stream << (str | seqan3::views::char_to<seqan3::dna5>) << '\n'; // ACTTTGATAN
 }

--- a/test/snippet/alphabet/views/complement.cpp
+++ b/test/snippet/alphabet/views/complement.cpp
@@ -1,7 +1,6 @@
-#include <seqan3/std/ranges>
-
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
 #include <seqan3/alphabet/views/complement.hpp>
+#include <seqan3/core/debug_stream.hpp>
 
 int main()
 {
@@ -10,11 +9,14 @@ int main()
     seqan3::dna5_vector foo{"ACGTA"_dna5};
 
     // pipe notation
-    auto v = foo | seqan3::views::complement;                        // == "TGCAT"
+    auto v = foo | seqan3::views::complement;
+    seqan3::debug_stream << v << '\n'; // TGCAT
 
     // function notation
-    auto v2(seqan3::views::complement(foo));                         // == "TGCAT"
+    auto v2(seqan3::views::complement(foo));
+    seqan3::debug_stream << v2 << '\n'; // TGCAT
 
     // generate the reverse complement:
-    auto v3 = foo | seqan3::views::complement | std::views::reverse; // == "TACGT"
+    auto v3 = foo | seqan3::views::complement | std::views::reverse;
+    seqan3::debug_stream << v3 << '\n'; // TACGT
 }

--- a/test/snippet/alphabet/views/rank_to.cpp
+++ b/test/snippet/alphabet/views/rank_to.cpp
@@ -3,10 +3,11 @@
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
 #include <seqan3/alphabet/views/rank_to.hpp>
+#include <seqan3/core/debug_stream.hpp>
 
 int main()
 {
     std::vector<int> vec{0, 1, 3, 3, 3, 2, 0, 3, 0};
-    auto v1 = vec | seqan3::views::rank_to<seqan3::dna4>; // == "ACTTTGATA"_dna4
-    auto v2 = vec | seqan3::views::rank_to<seqan3::dna5>; // == "ACTTTGATA"_dna5
+    seqan3::debug_stream << (vec | seqan3::views::rank_to<seqan3::dna4>) << '\n'; // ACTTTGATA
+    seqan3::debug_stream << (vec | seqan3::views::rank_to<seqan3::dna5>) << '\n'; // ACNNNGANA
 }

--- a/test/snippet/alphabet/views/to_char.cpp
+++ b/test/snippet/alphabet/views/to_char.cpp
@@ -1,11 +1,14 @@
+#include <iostream>
+
 #include <seqan3/alphabet/adaptation/char.hpp>
-#include <seqan3/alphabet/concept.hpp>
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
 
 int main()
 {
     using namespace seqan3::literals;
 
-    auto r2 = seqan3::to_char('A');         // calls seqan3::custom::to_char('A'); r2 == 'A'
-    auto r3 = seqan3::to_char('A'_dna5);    // calls .to_char() member; r3 == 'A'
+    auto char_to_char = seqan3::to_char('A'); // calls seqan3::custom::to_char('A')
+    auto dna5_to_char = seqan3::to_char('A'_dna5); // calls .to_char() member
+    std::cout << char_to_char << '\n'; // A
+    std::cout << dna5_to_char << '\n'; // A
 }

--- a/test/snippet/alphabet/views/to_rank.cpp
+++ b/test/snippet/alphabet/views/to_rank.cpp
@@ -1,11 +1,17 @@
+#include <iostream>
+
 #include <seqan3/alphabet/adaptation/char.hpp>
-#include <seqan3/alphabet/concept.hpp>
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
 
 int main()
 {
     using namespace seqan3::literals;
 
-    auto r2 = seqan3::to_rank('A');         // calls seqan3::custom::to_rank('A'); r2 == 65
-    auto r3 = seqan3::to_rank('A'_dna5);    // calls .to_char() member; r3 == 0
+    auto char_to_rank = seqan3::to_rank('A'); // calls seqan3::custom::to_rank('A')
+    static_assert(std::same_as<decltype(char_to_rank), uint8_t>);
+    std::cout << static_cast<uint16_t>(char_to_rank) << '\n'; // 65
+
+    auto dna5_to_rank = seqan3::to_rank('A'_dna5); // calls .to_char() member
+    static_assert(std::same_as<decltype(dna5_to_rank), uint8_t>);
+    std::cout << static_cast<uint16_t>(dna5_to_rank) << '\n'; // 0
 }

--- a/test/snippet/argument_parser/validators_input_file_ext_from_file.cpp
+++ b/test/snippet/argument_parser/validators_input_file_ext_from_file.cpp
@@ -1,20 +1,20 @@
 #include <seqan3/argument_parser/validators.hpp>
-#include <seqan3/io/sequence_file/input.hpp>
 #include <seqan3/core/debug_stream.hpp>
+#include <seqan3/io/sequence_file/input.hpp>
 
-int main(int argc, const char ** argv)
+int main()
 {
     // Default constructed validator has an empty extension list.
     seqan3::input_file_validator validator1{};
-    seqan3::debug_stream << validator1.get_help_page_message() << "\n";
+    seqan3::debug_stream << validator1.get_help_page_message() << '\n';
 
     // Specify your own extensions for the input file.
     seqan3::input_file_validator validator2{std::vector{std::string{"exe"}, std::string{"fasta"}}};
-    seqan3::debug_stream << validator2.get_help_page_message() << "\n";
+    seqan3::debug_stream << validator2.get_help_page_message() << '\n';
 
     // Give the seqan3 file type as a template argument to get all valid extensions for this file.
     seqan3::input_file_validator<seqan3::sequence_file_input<>> validator3{};
-    seqan3::debug_stream << validator3.get_help_page_message() << "\n";
+    seqan3::debug_stream << validator3.get_help_page_message() << '\n';
 
     return 0;
 }

--- a/test/snippet/argument_parser/validators_output_file_ext_from_file.cpp
+++ b/test/snippet/argument_parser/validators_output_file_ext_from_file.cpp
@@ -1,24 +1,24 @@
 #include <seqan3/argument_parser/validators.hpp>
-#include <seqan3/io/sequence_file/output.hpp>
 #include <seqan3/core/debug_stream.hpp>
+#include <seqan3/io/sequence_file/output.hpp>
 
-int main(int argc, const char ** argv)
+int main()
 {
     // Default constructed validator has an empty extension list.
     seqan3::output_file_validator validator1{seqan3::output_file_open_options::create_new};
-    seqan3::debug_stream << validator1.get_help_page_message() << "\n";
+    seqan3::debug_stream << validator1.get_help_page_message() << '\n';
 
     // Specify your own extensions for the output file.
     seqan3::output_file_validator validator2{seqan3::output_file_open_options::create_new,
                                              std::vector{std::string{"exe"}, std::string{"fasta"}}};
-    seqan3::debug_stream << validator2.get_help_page_message() << "\n";
+    seqan3::debug_stream << validator2.get_help_page_message() << '\n';
 
     // Give the seqan3 file type as a template argument to get all valid extensions for this file.
     seqan3::output_file_validator<seqan3::sequence_file_output<>> validator3
     {
         seqan3::output_file_open_options::create_new
     };
-    seqan3::debug_stream << validator3.get_help_page_message() << "\n";
+    seqan3::debug_stream << validator3.get_help_page_message() << '\n';
 
     return 0;
 }

--- a/test/snippet/core/add_enum_bitwise_operators.cpp
+++ b/test/snippet/core/add_enum_bitwise_operators.cpp
@@ -1,3 +1,5 @@
+#include <iostream>
+
 #include <seqan3/core/add_enum_bitwise_operators.hpp>
 
 enum class my_enum
@@ -13,9 +15,9 @@ constexpr bool seqan3::add_enum_bitwise_operators<my_enum> = true;
 int main()
 {
     using seqan3::operator|;
-    
+
     my_enum e = my_enum::VAL1;
     my_enum e2 = e | my_enum::VAL2;
 
-    // e2 == my_enum::COMB;
+    std::cout << std::boolalpha << (e2 == my_enum::COMB) << '\n'; // true
 }

--- a/test/snippet/core/detail/persist_view.cpp
+++ b/test/snippet/core/detail/persist_view.cpp
@@ -8,12 +8,12 @@ int main()
 
     // explicitly create an l-value of our dna vector:
     auto vec = "ACGT"_dna4;
-    auto v = vec | seqan3::views::to_char;
+    [[maybe_unused]]  auto v = vec | seqan3::views::to_char;
 
     // using seqan3::detail::persist you can bind the temporary directly:
-    auto v2 = "ACGT"_dna4 | seqan3::detail::persist | seqan3::views::to_char;
+    [[maybe_unused]]  auto v2 = "ACGT"_dna4 | seqan3::detail::persist | seqan3::views::to_char;
 
     // note that seqan3::detail::persist must follow immediately after the temporary,
     // thus the function notation might be more intuitive:
-    auto v3 = seqan3::detail::persist("ACGT"_dna4) | seqan3::views::to_char;
+    [[maybe_unused]]  auto v3 = seqan3::detail::persist("ACGT"_dna4) | seqan3::views::to_char;
 }

--- a/test/snippet/core/detail/persist_view.cpp
+++ b/test/snippet/core/detail/persist_view.cpp
@@ -8,12 +8,12 @@ int main()
 
     // explicitly create an l-value of our dna vector:
     auto vec = "ACGT"_dna4;
-    [[maybe_unused]]  auto v = vec | seqan3::views::to_char;
+    [[maybe_unused]] auto v = vec | seqan3::views::to_char;
 
     // using seqan3::detail::persist you can bind the temporary directly:
-    [[maybe_unused]]  auto v2 = "ACGT"_dna4 | seqan3::detail::persist | seqan3::views::to_char;
+    [[maybe_unused]] auto v2 = "ACGT"_dna4 | seqan3::detail::persist | seqan3::views::to_char;
 
     // note that seqan3::detail::persist must follow immediately after the temporary,
     // thus the function notation might be more intuitive:
-    [[maybe_unused]]  auto v3 = seqan3::detail::persist("ACGT"_dna4) | seqan3::views::to_char;
+    [[maybe_unused]] auto v3 = seqan3::detail::persist("ACGT"_dna4) | seqan3::views::to_char;
 }

--- a/test/snippet/core/detail/template_inspection_usage.cpp
+++ b/test/snippet/core/detail/template_inspection_usage.cpp
@@ -3,7 +3,8 @@
 
 int main()
 {
-    using tl = seqan3::type_list<int, char, double>;
-    using t = seqan3::detail::transfer_template_args_onto_t<tl, std::tuple>;
-    // t is std::tuple<int, char, double>
+    using list_to_transfer = seqan3::type_list<int, char, double>;
+    using resulting_t = seqan3::detail::transfer_template_args_onto_t<list_to_transfer, std::tuple>;
+
+    static_assert(std::same_as<resulting_t, std::tuple<int, char, double>>);
 }

--- a/test/snippet/io/detail/detail_record.cpp
+++ b/test/snippet/io/detail/detail_record.cpp
@@ -13,5 +13,6 @@ int main()
     using selected_ids  = seqan3::fields<seqan3::field::qual, seqan3::field::id>;
 
     using selected_types = seqan3::detail::select_types_with_ids_t<types, types_as_ids, selected_ids>;
-    // resolves to type_list<std::vector<phred42>, std::string>>
+    // resolves to type_list<std::vector<phred42>, std::string>
+    static_assert(std::same_as<selected_types, seqan3::type_list<std::vector<seqan3::phred42>, std::string>>);
 }

--- a/test/snippet/io/record_1.cpp
+++ b/test/snippet/io/record_1.cpp
@@ -1,5 +1,6 @@
 #include <sstream>
 
+#include <seqan3/core/debug_stream.hpp>
 #include <seqan3/io/record.hpp>
 #include <seqan3/io/sequence_file/input.hpp>
 #include <seqan3/io/sequence_file/output.hpp>
@@ -13,8 +14,6 @@ GGAGTATAATATATATATATATAT)";
 
 int main()
 {
-    using seqan3::get;
-
     // specify custom field combination/order to file:
     seqan3::sequence_file_input fin{std::istringstream{input},
                                     seqan3::format_fasta{},
@@ -23,5 +22,7 @@ int main()
     auto record = fin.front(); // get current record, in this case the first
 
     auto & id = record.id();
+    seqan3::debug_stream << id << '\n'; // TEST1
     auto & seq = record.sequence();
+    seqan3::debug_stream << seq << '\n'; // ACGT
 }

--- a/test/snippet/io/sam_file/sam_file_input_begin_and_front.cpp
+++ b/test/snippet/io/sam_file/sam_file_input_begin_and_front.cpp
@@ -1,7 +1,6 @@
 #include <sstream>
 
 #include <seqan3/io/sam_file/input.hpp>
-#include <seqan3/utility/type_list/type_list.hpp>
 
 auto sam_file_raw = R"(@HD	VN:1.6	SO:coordinate	GO:none
 @SQ	SN:ref	LN:45
@@ -20,5 +19,6 @@ int main()
     // the following are equivalent:
     auto & rec0 = *it;
     auto & rec1 = fin.front();
+    std::cout << std::boolalpha << (rec0.id() == rec1.id()) << '\n'; // true
     // Note: both become invalid after incrementing "it"!
 }

--- a/test/snippet/io/sequence_file/sequence_file_input_return_record.cpp
+++ b/test/snippet/io/sequence_file/sequence_file_input_return_record.cpp
@@ -1,7 +1,6 @@
 #include <sstream>
 
 #include <seqan3/io/sequence_file/input.hpp>
-#include <seqan3/std/ranges>
 
 auto input = R"(> TEST1
 ACGT
@@ -18,6 +17,6 @@ int main()
     // the following are equivalent:
     auto & rec0 = *it;
     auto & rec1 = fin.front();
-
+    std::cout << std::boolalpha << (rec0.id() == rec1.id()) << '\n'; // true
     // Note: rec0 and rec1 are references and become invalid after incrementing "it"!
 }

--- a/test/snippet/io/structure_file/structure_file_input_ref_return.cpp
+++ b/test/snippet/io/structure_file/structure_file_input_ref_return.cpp
@@ -1,8 +1,6 @@
 #include <sstream>
 
-#include <seqan3/core/debug_stream.hpp>
 #include <seqan3/io/structure_file/input.hpp>
-#include <seqan3/std/ranges>
 
 auto input = R"(> S.cerevisiae_tRNA-PHE M10740/1-73
 GCGGAUUUAGCUCAGUUGGGAGAGCGCCAGACUGAAGAUUUGGAGGUCCUGUGUUCGAUCCACAGAAUUCGCA
@@ -19,6 +17,6 @@ int main()
     // the following are equivalent:
     auto & rec0 = *it;
     auto & rec1 = fin.front();
-
+    std::cout << std::boolalpha << (rec0.id() == rec1.id()) << '\n'; // true
     // both become invalid after incrementing "it"!
 }

--- a/test/snippet/range/views/range_view_all_composability.cpp
+++ b/test/snippet/range/views/range_view_all_composability.cpp
@@ -2,6 +2,7 @@
 
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/alphabet/views/complement.hpp>
+#include <seqan3/core/debug_stream.hpp>
 
 int main()
 {
@@ -16,4 +17,6 @@ int main()
     auto vec_view5 = vec | seqan3::views::complement | std::views::reverse;
 
     // vec_view4 and vec_view5 are the reverse complement of "ACGGTC": "GACCGT"
+    seqan3::debug_stream << vec_view4 << '\n'; // GACCGT
+    seqan3::debug_stream << vec_view5 << '\n'; // GACCGT
 }

--- a/test/snippet/range/views/range_view_all_notation.cpp
+++ b/test/snippet/range/views/range_view_all_notation.cpp
@@ -1,3 +1,5 @@
+#include <seqan3/std/algorithm>
+
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/alphabet/views/complement.hpp>
 
@@ -10,7 +12,7 @@ int main()
     // these are synonymous:
     auto vec_view1 = vec | seqan3::views::complement;
     auto vec_view2 = seqan3::views::complement(vec);
-
+    std::cout << std::boolalpha << (std::ranges::equal(vec_view1, vec_view2)) << '\n'; // true
     // both views "behave" like a collection of the elements 'T', 'G', 'C', 'C', 'A', 'G'
     // but can be copied cheaply et cetera
 }

--- a/test/snippet/utility/char_operations/char_predicate_is_operator.cpp
+++ b/test/snippet/utility/char_operations/char_predicate_is_operator.cpp
@@ -1,8 +1,11 @@
+#include <iostream>
+
 #include <seqan3/utility/char_operations/predicate.hpp>
 
 int main()
 {
     char chr{'1'};
     auto constexpr my_cond = seqan3::is_char<'%'> || seqan3::is_digit;
-    bool is_percent = my_cond(chr); // is_percent == true
+    bool is_percent = my_cond(chr);
+    std::cout << std::boolalpha << is_percent << '\n'; // true
 }

--- a/test/snippet/utility/tuple/pod_tuple.cpp
+++ b/test/snippet/utility/tuple/pod_tuple.cpp
@@ -3,14 +3,15 @@
 
 int main()
 {
-    seqan3::pod_tuple<int, float> t{3, 4.7};
+    seqan3::pod_tuple<int, float> tuple1{3, 4.7};
     static_assert(std::is_standard_layout_v<seqan3::pod_tuple<int, float>>);
     static_assert(std::is_trivial_v<seqan3::pod_tuple<int, float>>);
+    seqan3::debug_stream << std::get<int>(tuple1) << '\n'; // 3
 
     // template parameters are automatically deduced:
-    seqan3::pod_tuple t2{17, 3.7f, 19l};
+    seqan3::pod_tuple tuple2{17, 3.7f, 19l};
+    seqan3::debug_stream << std::get<0>(tuple2) << '\n'; // 17
 
-    seqan3::debug_stream << std::get<0>(t2) << '\n'; // 17
-
-    auto [ i, f, l ] = t2; // creates an int i with value 17, float f...
+    auto [ i, f, l ] = tuple2; // creates an int i with value 17, float f...
+    seqan3::debug_stream << i << ',' << f << ',' << l << '\n'; // 17,3.7,19
 }

--- a/test/snippet/utility/tuple_utility.cpp
+++ b/test/snippet/utility/tuple_utility.cpp
@@ -5,13 +5,16 @@ int main()
     // Split at position 2.
     std::tuple<int, char, float, std::string> t{1, 'c', 0.3, "hello"};
     auto [left, right] = seqan3::tuple_split<2>(t);
-    // decltype(left) -> std::tuple<int, char>; decltype(right) -> std::tuple<float, std::string>;
+    static_assert(std::same_as<decltype(left), std::tuple<int, char>>);
+    static_assert(std::same_as<decltype(right), std::tuple<float, std::string>>);
 
     // Split at position 0.
     auto [left1, right1] = seqan3::tuple_split<0>(t);
-    // decltype(left1) -> std::tuple<>; decltype(right1) -> std::tuple<int, char, float, std::string>;
+    static_assert(std::same_as<decltype(left1), std::tuple<>>);
+    static_assert(std::same_as<decltype(right1), std::tuple<int, char, float, std::string>>);
 
     // Split at position 4.
     auto [left2, right2] = seqan3::tuple_split<4>(t);
-    // decltype(left2) -> std::tuple<int, char, float, std::string>; decltype(right2) -> std::tuple<>;
+    static_assert(std::same_as<decltype(left2), std::tuple<int, char, float, std::string>>);
+    static_assert(std::same_as<decltype(right2), std::tuple<>>);
 }

--- a/test/snippet/utility/type_traits/lazy_conditional.cpp
+++ b/test/snippet/utility/type_traits/lazy_conditional.cpp
@@ -1,3 +1,8 @@
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wunused-local-typedefs"
+
+//![complete]
 #include <forward_list>                                    // std::forward_list
 #include <seqan3/std/ranges>                               // std::ranges::input_range
 #include <vector>                                          // std::vector
@@ -32,3 +37,6 @@ int main()
     foobar(std::vector<int>{});         // sized
     foobar(std::forward_list<int>{});   // not sized
 }
+//![complete]
+
+#pragma GCC diagnostic pop

--- a/test/snippet/utility/views/convert_15_to_5.cpp
+++ b/test/snippet/utility/views/convert_15_to_5.cpp
@@ -1,5 +1,6 @@
 #include <seqan3/alphabet/nucleotide/dna15.hpp>
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
+#include <seqan3/core/debug_stream.hpp>
 #include <seqan3/utility/views/convert.hpp>
 
 int main()
@@ -7,5 +8,5 @@ int main()
     using namespace seqan3::literals;
 
     seqan3::dna15_vector vec2{"ACYGTN"_dna15};
-    auto v4 = vec2 | seqan3::views::convert<seqan3::dna5>; // == "ACNGTN"_dna5
+    seqan3::debug_stream << (vec2 | seqan3::views::convert<seqan3::dna5>) << '\n'; // ACNGTN
 }

--- a/test/snippet/utility/views/convert_int_to_bool.cpp
+++ b/test/snippet/utility/views/convert_int_to_bool.cpp
@@ -1,8 +1,7 @@
 #include <seqan3/std/ranges>
 #include <vector>
 
-#include <seqan3/alphabet/nucleotide/dna15.hpp>
-#include <seqan3/alphabet/nucleotide/dna5.hpp>
+#include <seqan3/core/debug_stream.hpp>
 #include <seqan3/utility/views/convert.hpp>
 #include <seqan3/utility/views/to.hpp>
 
@@ -12,11 +11,12 @@ int main()
     std::vector<int>  vec{7, 5, 0, 5, 0, 0, 4, 8, -3};
 
     // pipe notation
-    auto v = vec | seqan3::views::convert<bool>; // == [1, 1, 0, 1, 0, 0, 1, 1, 1];
-
-    // function notation and immediate conversion to vector again
-    auto v2 = seqan3::views::convert<bool>(vec) | seqan3::views::to<std::vector<bool>>;
+    seqan3::debug_stream << (vec | seqan3::views::convert<bool>) << '\n'; // [1,1,0,1,0,0,1,1,1]
 
     // combinability
-    auto v3 = vec | seqan3::views::convert<bool> | std::views::reverse; // == [1, 1, 1, 0, 0, 1, 0, 1, 1];
+    seqan3::debug_stream << (vec | seqan3::views::convert<bool> | std::views::reverse) << '\n'; // [1,1,1,0,0,1,0,1,1]
+
+    // function notation and immediate conversion to vector again
+    auto bool_vec = seqan3::views::convert<bool>(vec) | seqan3::views::to<std::vector<bool>>;
+    seqan3::debug_stream << std::boolalpha << (bool_vec == std::vector<bool>{1,1,0,1,0,0,1,1,1}) << '\n'; // true
 }

--- a/test/snippet/utility/views/deep_no_param.cpp
+++ b/test/snippet/utility/views/deep_no_param.cpp
@@ -2,6 +2,7 @@
 #include <vector>
 
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
+#include <seqan3/core/debug_stream.hpp>
 #include <seqan3/utility/views/deep.hpp>
 
 namespace my
@@ -14,11 +15,11 @@ int main()
 {
     using namespace seqan3::literals;
 
-    std::vector<seqan3::dna5_vector> foo{"AAATTT"_dna5, "CCCGGG"_dna5};
+    std::vector<seqan3::dna5_vector> sequences{"AAATTT"_dna5, "CCCGGG"_dna5};
 
-    auto r = foo | std::views::reverse;                     // == [ [C,C,C,G,G,G], [A,A,A,T,T,T] ]
+    seqan3::debug_stream << (sequences | std::views::reverse) << '\n'; // [CCCGGG,AAATTT]
 
     // These two are equivalent:
-    auto e = foo | my::deep_reverse;                       // == [ [T,T,T,A,A,A], [G,G,G,C,C,C] ]
-    auto d = foo | seqan3::views::deep{std::views::reverse}; // == [ [T,T,T,A,A,A], [G,G,G,C,C,C] ]
+    seqan3::debug_stream << (sequences | my::deep_reverse) << '\n'; // [TTTAAA,GGGCCC]
+    seqan3::debug_stream << (sequences | seqan3::views::deep{std::views::reverse}) << '\n'; // [TTTAAA,GGGCCC]
 }

--- a/test/snippet/utility/views/deep_pass_ref.cpp
+++ b/test/snippet/utility/views/deep_pass_ref.cpp
@@ -2,6 +2,7 @@
 #include <vector>
 
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
+#include <seqan3/core/debug_stream.hpp>
 #include <seqan3/utility/views/deep.hpp>
 
 namespace my
@@ -13,8 +14,9 @@ int main()
 {
     using namespace seqan3::literals;
 
-    std::vector<seqan3::dna5_vector> foo{"AAATTT"_dna5, "CCCGGG"_dna5};
+    std::vector<seqan3::dna5_vector> sequences{"AAATTT"_dna5, "CCCGGG"_dna5};
 
     int i = 3;
-    auto f = foo | my::deep_take(i); // takes `i` as a reference!
+    // takes `i` as a reference:
+    seqan3::debug_stream << (sequences | my::deep_take(i)) << '\n'; // [AAA,CCC]
 }

--- a/test/snippet/utility/views/deep_with_param.cpp
+++ b/test/snippet/utility/views/deep_with_param.cpp
@@ -2,6 +2,7 @@
 #include <vector>
 
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
+#include <seqan3/core/debug_stream.hpp>
 #include <seqan3/utility/views/deep.hpp>
 
 namespace my
@@ -13,13 +14,13 @@ int main()
 {
     using namespace seqan3::literals;
 
-    std::vector<seqan3::dna5_vector> foo{"AAATTT"_dna5, "CCCGGG"_dna5};
+    std::vector<seqan3::dna5_vector> sequences{"AAATTT"_dna5, "CCCGGG"_dna5};
 
-    auto t = foo | std::views::take(1);                   // == [ [A,A,A,T,T,T] ]
+    seqan3::debug_stream << (sequences | std::views::take(1))  << '\n'; // [A,A,A,T,T,T]
 
-    auto d = foo | seqan3::views::deep{std::views::take}(1); // == [ [A], [C] ]
+    seqan3::debug_stream << (sequences | seqan3::views::deep{std::views::take(1)}) << '\n'; // [A,C]
     // constructor arguments passed via {} and arguments to underlying view passed via ()
 
     // In this case especially, an alias improves readability:
-    auto e = foo | my::deep_take(1);                         // == [ [A], [C] ]
+    seqan3::debug_stream << (sequences | my::deep_take(1)) << '\n'; // [A,C]
 }

--- a/test/snippet/utility/views/deep_wrap_args.cpp
+++ b/test/snippet/utility/views/deep_wrap_args.cpp
@@ -2,6 +2,7 @@
 #include <vector>
 
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
+#include <seqan3/core/debug_stream.hpp>
 #include <seqan3/utility/views/deep.hpp>
 
 namespace my
@@ -13,13 +14,13 @@ int main()
 {
     using namespace seqan3::literals;
 
-    std::vector<seqan3::dna5_vector> foo{"AAATTT"_dna5, "CCCGGG"_dna5};
+    std::vector<seqan3::dna5_vector> sequences{"AAATTT"_dna5, "CCCGGG"_dna5};
 
-    auto t = foo | std::views::take(1);                      // == [ [A,A,A,T,T,T] ]
+    seqan3::debug_stream << (sequences | std::views::take(1)) << '\n'; // [A,A,A,T,T,T]
 
-    auto d = foo | seqan3::views::deep{std::views::take(1)}; // == [ [A], [C] ]
+    seqan3::debug_stream << (sequences | seqan3::views::deep{std::views::take(1)}) << '\n'; // [A,C]
     // constructor arguments passed via {} and arguments to underlying view hardcoded inside
 
     // or with an alias defined previously
-    auto e = foo | my::deep_take1;                           // == [ [A], [C] ]
+    seqan3::debug_stream << (sequences | my::deep_take1) << '\n'; // [A,C]
 }


### PR DESCRIPTION
Resolves https://github.com/seqan/product_backlog/issues/398

This also "fixes":
* `// modify via structured bindings and references:` Doesn't work as advertised.
* Some places where we used structural bindings instead of the record's member functions