### PR TITLE
[FIX] clang+gcc9: error: use of undeclared identifier '__builtin_ia32…

### DIFF
--- a/include/seqan3/utility/parallel/detail/spin_delay.hpp
+++ b/include/seqan3/utility/parallel/detail/spin_delay.hpp
@@ -14,14 +14,14 @@
 
 #include <thread>
 
+//!\cond
 #ifndef SEQAN3_HAS_MM_PAUSE
 #   if defined(__SSE2__) && __has_include(<xmmintrin.h>)
 #       include <xmmintrin.h> // _mm_pause()
 #       define SEQAN3_HAS_MM_PAUSE 1
-#   else
-#       define SEQAN3_HAS_MM_PAUSE 0
 #   endif // defined(__SSE2__) && __has_include(<xmmintrin.h>)
 #endif // SEQAN3_HAS_MM_PAUSE
+//!\endcond
 
 #include <seqan3/core/platform.hpp>
 

--- a/include/seqan3/utility/parallel/detail/spin_delay.hpp
+++ b/include/seqan3/utility/parallel/detail/spin_delay.hpp
@@ -14,9 +14,14 @@
 
 #include <thread>
 
-#if defined(__SSE2__)  // AMD and Intel
-#include <xmmintrin.h>  // _mm_pause()
-#endif
+#ifndef SEQAN3_HAS_MM_PAUSE
+#   if defined(__SSE2__) && __has_include(<xmmintrin.h>)
+#       include <xmmintrin.h> // _mm_pause()
+#       define SEQAN3_HAS_MM_PAUSE 1
+#   else
+#       define SEQAN3_HAS_MM_PAUSE 0
+#   endif // defined(__SSE2__) && __has_include(<xmmintrin.h>)
+#endif // SEQAN3_HAS_MM_PAUSE
 
 #include <seqan3/core/platform.hpp>
 
@@ -74,7 +79,7 @@ private:
     //!\brief Efficient instruction to pause the CPU.
     void pause_processor()
     {
-        #if defined(__SSE2__)  // AMD and Intel
+        #if SEQAN3_HAS_MM_PAUSE  // AMD and Intel
             _mm_pause();
         #elif defined(__armel__) || defined(__ARMEL__) // arm, but broken? ; repeat of default case as armel also defines __arm__
             asm volatile ("nop" ::: "memory");  // default operation - does nothing => Might lead to passive spinning.


### PR DESCRIPTION
…_addss'

This is more a problem how I call clang right now. clang finds
xmmintrin.h from a gcc-11 install which uses __builtin's that seem not
be implemented yet by clang.

```
/usr/lib64/gcc/x86_64-pc-linux-gnu/11.1.0/include/xmmintrin.h:130:19: error: use of undeclared identifier '__builtin_ia32_addss'
  return (__m128) __builtin_ia32_addss ((__v4sf)__A, (__v4sf)__B);
                  ^
```