### PR TITLE
[FIX] clang+gcc9: error: member access into incomplete type

### DIFF
--- a/include/seqan3/alignment/pairwise/alignment_algorithm.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_algorithm.hpp
@@ -80,8 +80,22 @@ private:
 
     //!\brief The alignment configuration traits type with auxiliary information extracted from the configuration type.
     using traits_t = alignment_configuration_traits<config_t>;
+
+    /*!\brief Helper function to access ((some_policy *)this)->current_alignment_column().
+     *
+     * This works around an issue of accessing inherited members during declaration time by defering the access by using
+     * two-phase lookup.
+     *
+     * During the declaration time this class is still an incomplete type and we are technically not allowed to access
+     * its inherited members. gcc will allow that anyway, but clang rightfully doesn't.
+     *
+     * \see http://blog.llvm.org/2009/12/dreaded-two-phase-name-lookup.html
+     */
+    template <typename alignment_algorithm_t = alignment_algorithm>
+    static auto _alignment_column_t() -> decltype(std::declval<alignment_algorithm_t>().current_alignment_column());
+
     //!\brief The type of an alignment column as defined by the respective matrix policy.
-    using alignment_column_t = decltype(std::declval<alignment_algorithm>().current_alignment_column());
+    using alignment_column_t = decltype(_alignment_column_t());
     //!\brief The iterator type over the alignment column.
     using alignment_column_iterator_t = std::ranges::iterator_t<alignment_column_t>;
     //!\brief The alignment result type.


### PR DESCRIPTION
```
/seqan3/include/seqan3/alignment/pairwise/alignment_algorithm.hpp:84:76: error: member access into incomplete type 'seqan3::detail::alignment_algorithm<seqan3::configuration<seqan3::align_cfg::method_global, seqan3::align_cfg::scoring_scheme<seqan3::nucleotide_scoring_scheme<>>, seqan3::align_cfg::gap_cost_affine, seqan3::align_cfg::output_score, seqan3::align_cfg::output_begin_position, seqan3::align_cfg::output_end_position, seqan3::align_cfg::output_alignment, seqan3::align_cfg::output_sequence1_id, seqan3::align_cfg::output_sequence2_id, seqan3::align_cfg::detail::result_type<seqan3::alignment_result<seqan3::detail::alignment_result_value_type<unsigned int, unsigned int, int, seqan3::detail::advanceable_alignment_coordinate<seqan3::detail::advanceable_alignment_coordinate_state::none>, seqan3::detail::advanceable_alignment_coordinate<seqan3::detail::advanceable_alignment_coordinate_state::none>, std::tuple<seqan3::gap_decorator<std::span<seqan3::dna4, 18446744073709551615>>, seqan3::gap_decorator<std::span<seqan3::dna4, 18446744073709551615>>>>>>>, seqan3::detail::deferred_crtp_base<alignment_matrix_policy, seqan3::detail::alignment_score_matrix_one_column<int>, seqan3::detail::alignment_trace_matrix_full<seqan3::detail::trace_directions, false>>, seqan3::detail::deferred_crtp_base<affine_gap_policy, int, std::integral_constant<bool, false>>, seqan3::detail::deferred_crtp_base<find_optimum_policy>, seqan3::detail::deferred_crtp_base<affine_gap_init_policy>, seqan3::detail::deferred_crtp_base<scoring_scheme_policy, seqan3::nucleotide_scoring_scheme<>>>'
    using alignment_column_t = decltype(std::declval<alignment_algorithm>().current_alignment_column());
                                                                           ^
```