### PR TITLE
Allow including certain cmake files more than once

### DIFF
--- a/build_system/seqan3-config.cmake
+++ b/build_system/seqan3-config.cmake
@@ -516,26 +516,6 @@ else ()
 endif ()
 
 # ----------------------------------------------------------------------------
-# Export targets
-# ----------------------------------------------------------------------------
-
-separate_arguments (SEQAN3_CXX_FLAGS_LIST UNIX_COMMAND "${SEQAN3_CXX_FLAGS}")
-
-add_library (seqan3_seqan3 INTERFACE)
-target_compile_definitions (seqan3_seqan3 INTERFACE ${SEQAN3_DEFINITIONS})
-target_compile_options (seqan3_seqan3 INTERFACE ${SEQAN3_CXX_FLAGS_LIST})
-target_link_libraries (seqan3_seqan3 INTERFACE "${SEQAN3_LIBRARIES}")
-# include seqan3/include/ as -I, because seqan3 should never produce warnings.
-target_include_directories (seqan3_seqan3 INTERFACE "${SEQAN3_INCLUDE_DIR}")
-# include everything except seqan3/include/ as -isystem, i.e.
-# a system header which suppresses warnings of external libraries.
-target_include_directories (seqan3_seqan3 SYSTEM INTERFACE "${SEQAN3_DEPENDENCY_INCLUDE_DIRS}")
-add_library (seqan3::seqan3 ALIAS seqan3_seqan3)
-
-# propagate SEQAN3_INCLUDE_DIR into SEQAN3_INCLUDE_DIRS
-set (SEQAN3_INCLUDE_DIRS ${SEQAN3_INCLUDE_DIR} ${SEQAN3_DEPENDENCY_INCLUDE_DIRS})
-
-# ----------------------------------------------------------------------------
 # Finish find_package call
 # ----------------------------------------------------------------------------
 
@@ -547,6 +527,28 @@ find_package_handle_standard_args (${CMAKE_FIND_PACKAGE_NAME} REQUIRED_VARS SEQA
 foreach (package_var FOUND DIR ROOT CONFIG VERSION VERSION_MAJOR VERSION_MINOR VERSION_PATCH VERSION_TWEAK VERSION_COUNT)
     set (SEQAN3_${package_var} "${${CMAKE_FIND_PACKAGE_NAME}_${package_var}}")
 endforeach ()
+
+# propagate SEQAN3_INCLUDE_DIR into SEQAN3_INCLUDE_DIRS
+set (SEQAN3_INCLUDE_DIRS ${SEQAN3_INCLUDE_DIR} ${SEQAN3_DEPENDENCY_INCLUDE_DIRS})
+
+# ----------------------------------------------------------------------------
+# Export targets
+# ----------------------------------------------------------------------------
+
+if (SEQAN3_FOUND AND NOT TARGET seqan3::seqan3)
+    separate_arguments (SEQAN3_CXX_FLAGS_LIST UNIX_COMMAND "${SEQAN3_CXX_FLAGS}")
+
+    add_library (seqan3_seqan3 INTERFACE)
+    target_compile_definitions (seqan3_seqan3 INTERFACE ${SEQAN3_DEFINITIONS})
+    target_compile_options (seqan3_seqan3 INTERFACE ${SEQAN3_CXX_FLAGS_LIST})
+    target_link_libraries (seqan3_seqan3 INTERFACE "${SEQAN3_LIBRARIES}")
+    # include seqan3/include/ as -I, because seqan3 should never produce warnings.
+    target_include_directories (seqan3_seqan3 INTERFACE "${SEQAN3_INCLUDE_DIR}")
+    # include everything except seqan3/include/ as -isystem, i.e.
+    # a system header which suppresses warnings of external libraries.
+    target_include_directories (seqan3_seqan3 SYSTEM INTERFACE "${SEQAN3_DEPENDENCY_INCLUDE_DIRS}")
+    add_library (seqan3::seqan3 ALIAS seqan3_seqan3)
+endif ()
 
 set (CMAKE_REQUIRED_QUIET ${CMAKE_REQUIRED_QUIET_SAVE})
 

--- a/test/cmake/seqan3_require_test.cmake
+++ b/test/cmake/seqan3_require_test.cmake
@@ -72,5 +72,7 @@ macro (seqan3_require_test)
         seqan3_require_test_old ("${gtest_git_tag}")
     endif ()
 
-    add_custom_target (gtest_build DEPENDS gtest_main gtest)
+    if (NOT TARGET gtest_build)
+        add_custom_target (gtest_build DEPENDS gtest_main gtest)
+    endif ()
 endmacro ()

--- a/test/seqan3-test.cmake
+++ b/test/seqan3-test.cmake
@@ -62,46 +62,56 @@ file(MAKE_DIRECTORY ${SEQAN3_TEST_CLONE_DIR}/googletest/include/)
 
 # seqan3::test exposes a base set of required flags, includes, definitions and
 # libraries which are in common for **all** seqan3 tests
-add_library (seqan3_test INTERFACE)
-target_compile_options (seqan3_test INTERFACE "-pedantic"  "-Wall" "-Wextra" "-Werror")
-target_link_libraries (seqan3_test INTERFACE "seqan3::seqan3" "pthread")
-target_include_directories (seqan3_test INTERFACE "${SEQAN3_TEST_INCLUDE_DIR}")
-add_library (seqan3::test ALIAS seqan3_test)
+if (NOT TARGET seqan3::test)
+    add_library (seqan3_test INTERFACE)
+    target_compile_options (seqan3_test INTERFACE "-pedantic"  "-Wall" "-Wextra" "-Werror")
+    target_link_libraries (seqan3_test INTERFACE "seqan3::seqan3" "pthread")
+    target_include_directories (seqan3_test INTERFACE "${SEQAN3_TEST_INCLUDE_DIR}")
+    add_library (seqan3::test ALIAS seqan3_test)
+endif ()
 
 # seqan3::test::performance specifies required flags, includes and libraries
 # needed for performance test cases in seqan3/test/performance
-add_library (seqan3_test_performance INTERFACE)
-target_link_libraries (seqan3_test_performance INTERFACE "seqan3::test" "gbenchmark")
+if (NOT TARGET seqan3::test::performance)
+    add_library (seqan3_test_performance INTERFACE)
+    target_link_libraries (seqan3_test_performance INTERFACE "seqan3::test" "gbenchmark")
 
-if (SEQAN3_BENCHMARK_ALIGN_LOOPS)
-    target_compile_options (seqan3_test_performance INTERFACE "-falign-loops=32")
+    if (SEQAN3_BENCHMARK_ALIGN_LOOPS)
+        target_compile_options (seqan3_test_performance INTERFACE "-falign-loops=32")
+    endif ()
+
+    target_include_directories (seqan3_test_performance INTERFACE "${SEQAN3_BENCHMARK_CLONE_DIR}/include/")
+    add_library (seqan3::test::performance ALIAS seqan3_test_performance)
 endif ()
-
-target_include_directories (seqan3_test_performance INTERFACE "${SEQAN3_BENCHMARK_CLONE_DIR}/include/")
-add_library (seqan3::test::performance ALIAS seqan3_test_performance)
 
 # seqan3::test::unit specifies required flags, includes and libraries
 # needed for unit test cases in seqan3/test/unit
-add_library (seqan3_test_unit INTERFACE)
-target_link_libraries (seqan3_test_unit INTERFACE "seqan3::test" "gtest_main" "gtest")
-target_include_directories (seqan3_test_unit INTERFACE "${SEQAN3_TEST_CLONE_DIR}/googletest/include/")
-add_library (seqan3::test::unit ALIAS seqan3_test_unit)
+if (NOT TARGET seqan3::test::unit)
+    add_library (seqan3_test_unit INTERFACE)
+    target_link_libraries (seqan3_test_unit INTERFACE "seqan3::test" "gtest_main" "gtest")
+    target_include_directories (seqan3_test_unit INTERFACE "${SEQAN3_TEST_CLONE_DIR}/googletest/include/")
+    add_library (seqan3::test::unit ALIAS seqan3_test_unit)
+endif ()
 
 # seqan3::test::coverage specifies required flags, includes and libraries
 # needed for coverage test cases in seqan3/test/coverage
-add_library (seqan3_test_coverage INTERFACE)
-target_compile_options (seqan3_test_coverage INTERFACE "--coverage" "-fprofile-arcs" "-ftest-coverage")
-target_link_libraries (seqan3_test_coverage INTERFACE "seqan3::test::unit" "gcov")
-add_library (seqan3::test::coverage ALIAS seqan3_test_coverage)
+if (NOT TARGET seqan3::test::coverage)
+    add_library (seqan3_test_coverage INTERFACE)
+    target_compile_options (seqan3_test_coverage INTERFACE "--coverage" "-fprofile-arcs" "-ftest-coverage")
+    target_link_libraries (seqan3_test_coverage INTERFACE "seqan3::test::unit" "gcov")
+    add_library (seqan3::test::coverage ALIAS seqan3_test_coverage)
+endif ()
 
 # seqan3::test::header specifies required flags, includes and libraries
 # needed for header test cases in seqan3/test/header
-add_library (seqan3_test_header INTERFACE)
-target_link_libraries (seqan3_test_header INTERFACE "seqan3::test::unit")
-target_link_libraries (seqan3_test_header INTERFACE "seqan3::test::performance")
-target_compile_definitions (seqan3_test_header INTERFACE -DSEQAN3_DISABLE_DEPRECATED_WARNINGS)
-target_compile_definitions (seqan3_test_header INTERFACE -DSEQAN3_HEADER_TEST)
-add_library (seqan3::test::header ALIAS seqan3_test_header)
+if (NOT TARGET seqan3::test::header)
+    add_library (seqan3_test_header INTERFACE)
+    target_link_libraries (seqan3_test_header INTERFACE "seqan3::test::unit")
+    target_link_libraries (seqan3_test_header INTERFACE "seqan3::test::performance")
+    target_compile_definitions (seqan3_test_header INTERFACE -DSEQAN3_DISABLE_DEPRECATED_WARNINGS)
+    target_compile_definitions (seqan3_test_header INTERFACE -DSEQAN3_HEADER_TEST)
+    add_library (seqan3::test::header ALIAS seqan3_test_header)
+endif ()
 
 # ----------------------------------------------------------------------------
 # Commonly shared options for external projects.


### PR DESCRIPTION
The main problem with 

```cmake
find_package(SeqAn3)
find_package(SeqAn3)
```

and

```cmake
include (seqan3_require_test.cmake)
include (seqan3_require_test.cmake)
```

is that cmake targets would be re-defined.

This can be fixed by adding an explicit check if the target already exists.