### PR TITLE
cmake: Use CMAKE_CURRENT_{BINARY,SOURCE}_DIR

### DIFF
--- a/test/cmake/seqan3_test_files.cmake
+++ b/test/cmake/seqan3_test_files.cmake
@@ -21,7 +21,7 @@
 macro (seqan3_test_files VAR test_base_path_ extension_wildcards)
     # test_base_path is /home/.../seqan3/test/
     get_filename_component(test_base_path "${test_base_path_}" ABSOLUTE)
-    file (RELATIVE_PATH test_base_path_relative "${CMAKE_SOURCE_DIR}" "${test_base_path}")
+    file (RELATIVE_PATH test_base_path_relative "${CMAKE_CURRENT_SOURCE_DIR}" "${test_base_path}")
     # ./ is a hack to deal with empty test_base_path_relative
     set (test_base_path_relative "./${test_base_path_relative}")
     # collect all cpp files

--- a/test/snippet/CMakeLists.txt
+++ b/test/snippet/CMakeLists.txt
@@ -20,7 +20,7 @@ macro (seqan3_snippet test_name_prefix snippet snippet_base_path)
     target_link_libraries (${target} seqan3::test::unit)
     set_target_properties(${target}
         PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${snippet_target_path}"
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${snippet_target_path}"
     )
 
     add_test (NAME "${test_name_prefix}/${snippet_test_name}_snippet" COMMAND ${target})
@@ -41,8 +41,8 @@ endmacro ()
 seqan3_require_ccache ()
 seqan3_require_test ()
 
-seqan3_snippets ("doc/snippet" "${CMAKE_SOURCE_DIR}/../../doc")
-seqan3_snippets ("snippet" "${CMAKE_SOURCE_DIR}")
+seqan3_snippets ("doc/snippet" "${CMAKE_CURRENT_SOURCE_DIR}/../../doc")
+seqan3_snippets ("snippet" "${CMAKE_CURRENT_SOURCE_DIR}")
 
 include (seqan3_generate_snippet)
 


### PR DESCRIPTION
This change allows using `add_subdirectory` in an umbrella `CMakeLists.txt` to combine multiple tests into one.

(See: https://stackoverflow.com/questions/15662497/difference-between-cmake-current-source-dir-and-cmake-current-list-dir)