### PR TITLE
[INFRA] fix gtest_main target for older cmake version (should propagate include)

### DIFF
--- a/test/cmake/seqan3_require_benchmark.cmake
+++ b/test/cmake/seqan3_require_benchmark.cmake
@@ -7,6 +7,12 @@
 
 # Exposes the google-benchmark target `gbenchmark`.
 macro (seqan3_require_benchmark_old gbenchmark_git_tag)
+    set (SEQAN3_BENCHMARK_CLONE_DIR "${PROJECT_BINARY_DIR}/vendor/benchmark")
+
+    # needed for add_library (seqan3::test::* INTERFACE IMPORTED)
+    # see cmake bug https://gitlab.kitware.com/cmake/cmake/issues/15052
+    file (MAKE_DIRECTORY ${SEQAN3_BENCHMARK_CLONE_DIR}/include/)
+
     set (gbenchmark_project_args ${SEQAN3_EXTERNAL_PROJECT_CMAKE_ARGS})
     list (APPEND gbenchmark_project_args "-DBENCHMARK_ENABLE_TESTING=false")
     # google-benchmarks suggest to use LTO (link-time optimisation), but we don't really need that because we are a
@@ -36,6 +42,7 @@ macro (seqan3_require_benchmark_old gbenchmark_git_tag)
     add_dependencies (gbenchmark gbenchmark_project)
     set_target_properties (gbenchmark PROPERTIES IMPORTED_LOCATION "${gbenchmark_path}")
     set_property (TARGET gbenchmark APPEND PROPERTY INTERFACE_LINK_LIBRARIES "pthread")
+    set_property (TARGET gbenchmark APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${SEQAN3_BENCHMARK_CLONE_DIR}/include/")
 
     # NOTE: google benchmarks needs Shlwapi (Shell Lightweight Utility Functions) on windows
     # see https://msdn.microsoft.com/en-us/library/windows/desktop/bb759844(v=vs.85).aspx

--- a/test/cmake/seqan3_require_test.cmake
+++ b/test/cmake/seqan3_require_test.cmake
@@ -7,6 +7,12 @@
 
 # Exposes the google-test targets `gtest` and `gtest_main`.
 macro (seqan3_require_test_old gtest_git_tag)
+    set (SEQAN3_TEST_CLONE_DIR "${PROJECT_BINARY_DIR}/vendor/googletest")
+
+    # needed for add_library (seqan3::test::* INTERFACE IMPORTED)
+    # see cmake bug https://gitlab.kitware.com/cmake/cmake/issues/15052
+    file (MAKE_DIRECTORY ${SEQAN3_TEST_CLONE_DIR}/googletest/include/)
+
     set (gtest_project_args ${SEQAN3_EXTERNAL_PROJECT_CMAKE_ARGS})
     list (APPEND gtest_project_args "-DBUILD_GMOCK=0")
 
@@ -42,9 +48,10 @@ macro (seqan3_require_test_old gtest_git_tag)
     set_target_properties (gtest_main PROPERTIES IMPORTED_LOCATION "${gtest_main_path}")
 
     add_library (gtest STATIC IMPORTED)
-    add_dependencies (gtest gtest_main)
+    add_dependencies (gtest gtest_project)
     set_target_properties (gtest PROPERTIES IMPORTED_LOCATION "${gtest_path}")
     set_property (TARGET gtest APPEND PROPERTY INTERFACE_LINK_LIBRARIES "pthread")
+    set_property (TARGET gtest APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${SEQAN3_TEST_CLONE_DIR}/googletest/include/")
 
     unset(gtest_main_path)
     unset(gtest_path)

--- a/test/seqan3-test.cmake
+++ b/test/seqan3-test.cmake
@@ -48,14 +48,6 @@ find_path (SEQAN3_TEST_INCLUDE_DIR NAMES seqan3/test/tmp_filename.hpp HINTS "${C
 find_path (SEQAN3_TEST_CMAKE_MODULE_DIR NAMES seqan3_test_component.cmake HINTS "${CMAKE_CURRENT_LIST_DIR}/cmake/")
 list(APPEND CMAKE_MODULE_PATH "${SEQAN3_TEST_CMAKE_MODULE_DIR}")
 
-set (SEQAN3_BENCHMARK_CLONE_DIR "${PROJECT_BINARY_DIR}/vendor/benchmark")
-set (SEQAN3_TEST_CLONE_DIR "${PROJECT_BINARY_DIR}/vendor/googletest")
-
-# needed for add_library (seqan3::test::* INTERFACE IMPORTED)
-# see cmake bug https://gitlab.kitware.com/cmake/cmake/issues/15052
-file(MAKE_DIRECTORY ${SEQAN3_BENCHMARK_CLONE_DIR}/include/)
-file(MAKE_DIRECTORY ${SEQAN3_TEST_CLONE_DIR}/googletest/include/)
-
 # ----------------------------------------------------------------------------
 # Interface targets for the different test modules in seqan3.
 # ----------------------------------------------------------------------------
@@ -80,7 +72,6 @@ if (NOT TARGET seqan3::test::performance)
         target_compile_options (seqan3_test_performance INTERFACE "-falign-loops=32")
     endif ()
 
-    target_include_directories (seqan3_test_performance INTERFACE "${SEQAN3_BENCHMARK_CLONE_DIR}/include/")
     add_library (seqan3::test::performance ALIAS seqan3_test_performance)
 endif ()
 
@@ -89,7 +80,6 @@ endif ()
 if (NOT TARGET seqan3::test::unit)
     add_library (seqan3_test_unit INTERFACE)
     target_link_libraries (seqan3_test_unit INTERFACE "seqan3::test" "gtest_main" "gtest")
-    target_include_directories (seqan3_test_unit INTERFACE "${SEQAN3_TEST_CLONE_DIR}/googletest/include/")
     add_library (seqan3::test::unit ALIAS seqan3_test_unit)
 endif ()
 


### PR DESCRIPTION
This PR moves out cmake stuff that belongs to the gtest/gbenchmark fall-back solution.

It also enables that directly using 

```cmake
add_library(my_target PUBLIC gtest)
```

adds the include folder of gtest in case of the fallback solution.