### PR TITLE
[TEST] snippet: don't link in the gtest main

### DIFF
--- a/test/snippet/CMakeLists.txt
+++ b/test/snippet/CMakeLists.txt
@@ -13,6 +13,9 @@ include (../cmake/diagnostics/list_unused_snippets.cmake)
 
 option (seqan3_generate_snippets "Whether seqan3 snippets should be generated and overwritten within the source tree." ON)
 
+add_library (snippet_main snippet_main.cpp)
+target_link_libraries (snippet_main PUBLIC seqan3::test gtest)
+
 macro (seqan3_snippet test_name_prefix snippet snippet_base_path)
     seqan3_test_component (snippet_target_name "${snippet}" TARGET_NAME)
     seqan3_test_component (snippet_test_name "${snippet}" TEST_NAME)
@@ -20,7 +23,7 @@ macro (seqan3_snippet test_name_prefix snippet snippet_base_path)
     set (target "${snippet_target_name}_snippet")
 
     add_executable (${target} "${snippet_base_path}/${snippet}")
-    target_link_libraries (${target} seqan3::test::unit)
+    target_link_libraries (${target} PUBLIC snippet_main)
     set_target_properties(${target}
         PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${snippet_target_path}"

--- a/test/snippet/snippet_main.cpp
+++ b/test/snippet/snippet_main.cpp
@@ -1,0 +1,4 @@
+int main()
+{
+    return 0;
+}


### PR DESCRIPTION
This has the effect that if a snippet does not define a `int main() {}` function, it will use the fallback main-function from `snippet_main`.

The problem right now is, that `gtest_main` will be used and thus adds output that is unrelated to the snippet.

E.g. `./utility/type_traits/function_traits_snippet` has no `main`-function and thus will output `gtest_main`

https://github.com/seqan/seqan3/blob/e438f79b761de8e834bb90e5941d21f1b4455a6a/test/snippet/utility/type_traits/function_traits.cpp#L1-L17

```
[==========] Running 0 tests from 0 test suites.
[==========] 0 tests from 0 test suites ran. (0 ms total)
[  PASSED  ] 0 tests.
```

after the change it will not output anything as it uses `snippet_main`:

```
```