### PR TITLE
 [INFRA] raise minimum cmake version to 3.10 for tests

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  CMAKE_VERSION: 3.9.6
+  CMAKE_VERSION: 3.10.3
   SEQAN3_NO_VERSION_CHECK: 1
   TZ: Europe/Berlin
   ISSUE: 2746 # Issue number to use for reporting failures
@@ -112,4 +112,3 @@ jobs:
         with:
           issue-number: ${{ env.ISSUE }}
           body: ${{ steps.comment-body.outputs.body }}
-

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -10,7 +10,7 @@ on:
   pull_request:
 
 env:
-  CMAKE_VERSION: 3.9.6
+  CMAKE_VERSION: 3.10.3
   SEQAN3_NO_VERSION_CHECK: 1
   TZ: Europe/Berlin
 

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -10,7 +10,7 @@ on:
   pull_request:
 
 env:
-  CMAKE_VERSION: 3.9.6
+  CMAKE_VERSION: 3.10.3
   SEQAN3_NO_VERSION_CHECK: 1
   TZ: Europe/Berlin
 

--- a/.github/workflows/ci_misc.yml
+++ b/.github/workflows/ci_misc.yml
@@ -33,7 +33,7 @@ jobs:
             build_type: Release
             build_threads: 2
             test_threads: 1 # snippets create and delete files and some separate tests create/delete the same files
-            cmake: 3.9.6
+            cmake: 3.10.3
             requires_toolchain: true
             requires_ccache: true
             skip_build_tests: false
@@ -47,7 +47,7 @@ jobs:
             build_type: Release
             build_threads: 2
             test_threads: 2
-            cmake: 3.9.6
+            cmake: 3.10.3
             requires_toolchain: true
             requires_ccache: true
             skip_build_tests: false
@@ -61,7 +61,7 @@ jobs:
             build_type: Release
             build_threads: 2
             test_threads: 2
-            cmake: 3.9.6
+            cmake: 3.10.3
             requires_toolchain: true
             requires_ccache: true
             skip_build_tests: false
@@ -75,7 +75,7 @@ jobs:
             build_type: Debug
             build_threads: 2
             test_threads: 2
-            cmake: 3.9.6
+            cmake: 3.10.3
             requires_toolchain: true
             requires_ccache: true
             skip_build_tests: true
@@ -100,7 +100,7 @@ jobs:
             build: documentation
             build_threads: 2
             test_threads: 2
-            cmake: 3.9.6
+            cmake: 3.10.3
             doxygen: 1.9.2
             requires_toolchain: false
             requires_ccache: false

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  CMAKE_VERSION: 3.9.6
+  CMAKE_VERSION: 3.10.3
   DOXYGEN_VERSION: 1.9.2
   TZ: Europe/Berlin
 

--- a/.github/workflows/latest_libraries.yml
+++ b/.github/workflows/latest_libraries.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  CMAKE_VERSION: 3.9.6
+  CMAKE_VERSION: 3.10.3
   SEQAN3_NO_VERSION_CHECK: 1
   TZ: Europe/Berlin
   ISSUE: 2747 # Issue number to use for reporting failures

--- a/.github/workflows/ram_usage.yml
+++ b/.github/workflows/ram_usage.yml
@@ -12,7 +12,7 @@ on:
         descriptions: 'CXXFLAGS to pass to compiler'
 
 env:
-  CMAKE_VERSION: 3.9.6
+  CMAKE_VERSION: 3.10.3
   SEQAN3_NO_VERSION_CHECK: 1
   TZ: Europe/Berlin
 

--- a/test/cmake/add_subdirectories.cmake
+++ b/test/cmake/add_subdirectories.cmake
@@ -5,6 +5,8 @@
 # shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 # -----------------------------------------------------------------------------------------------------
 
+cmake_minimum_required (VERSION 3.10)
+
 # Calls add_subdirectory on all (direct) subdirectories of the given directory if they contain a `CMakeLists.txt`
 #
 # Example:

--- a/test/cmake/diagnostics/list_missing_unit_tests.cmake
+++ b/test/cmake/diagnostics/list_missing_unit_tests.cmake
@@ -5,6 +5,8 @@
 # shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 # -----------------------------------------------------------------------------------------------------
 
+cmake_minimum_required (VERSION 3.10)
+
 set(seqan3_test_include_targets "" CACHE STRING "" FORCE)
 
 function (collect_include_target include_target)

--- a/test/cmake/diagnostics/list_missing_unit_tests.cmake
+++ b/test/cmake/diagnostics/list_missing_unit_tests.cmake
@@ -14,11 +14,6 @@ function (collect_include_target include_target)
 endfunction ()
 
 function (list_missing_unit_tests)
-    if (CMAKE_VERSION VERSION_LESS 3.8) # MANUALLY_ADDED_DEPENDENCIES since cmake >= 3.8
-        message (WARNING "list_missing_unit_tests requires at least cmake >= 3.8")
-        return ()
-    endif ()
-
     list (SORT seqan3_test_include_targets)
     foreach (include_target ${seqan3_test_include_targets})
         if (NOT TARGET ${include_target})

--- a/test/cmake/diagnostics/list_unused_snippets.cmake
+++ b/test/cmake/diagnostics/list_unused_snippets.cmake
@@ -5,7 +5,7 @@
 # shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 # -----------------------------------------------------------------------------------------------------
 
-cmake_minimum_required (VERSION 3.7)
+cmake_minimum_required (VERSION 3.10)
 
 set(seqan3_test_snippets "" CACHE STRING "" FORCE)
 

--- a/test/cmake/diagnostics/list_unused_unit_tests.cmake
+++ b/test/cmake/diagnostics/list_unused_unit_tests.cmake
@@ -5,7 +5,7 @@
 # shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 # -----------------------------------------------------------------------------------------------------
 
-cmake_minimum_required (VERSION 3.7)
+cmake_minimum_required (VERSION 3.10)
 
 set(seqan3_test_targets "" CACHE STRING "" FORCE)
 

--- a/test/cmake/include_dependencies/add_include_dependencies.cmake
+++ b/test/cmake/include_dependencies/add_include_dependencies.cmake
@@ -5,6 +5,8 @@
 # shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 # -----------------------------------------------------------------------------------------------------
 
+cmake_minimum_required (VERSION 3.10)
+
 include (diagnostics/list_missing_unit_tests)
 
 # get_include_target (<VAR> TARGET dna4_test)

--- a/test/cmake/include_dependencies/generate_include_dependencies.cmake
+++ b/test/cmake/include_dependencies/generate_include_dependencies.cmake
@@ -5,7 +5,7 @@
 # shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 # -----------------------------------------------------------------------------------------------------
 
-cmake_minimum_required (VERSION 3.7)
+cmake_minimum_required (VERSION 3.10)
 
 function (generate_include_dependencies_impl)
     cmake_parse_arguments(

--- a/test/cmake/seqan3_generate_snippet.cmake
+++ b/test/cmake/seqan3_generate_snippet.cmake
@@ -25,8 +25,8 @@ cmake_minimum_required (VERSION 3.10)
 # * all ${placeholder} will be replaced by the specified `-Dplaceholder=value` value
 # * see `cmake`s [configure_file](https://cmake.org/cmake/help/latest/command/configure_file.html) for more detail
 function (seqan3_generate_snippet source_snippet)
-    if (NOT SEQAN3_CLONE_DIR OR CMAKE_VERSION VERSION_LESS 3.9.0)
-        message (AUTHOR_WARNING "seqan3_generate_snippet needs at least cmake 3.9.0.")
+    if (NOT SEQAN3_CLONE_DIR)
+        message (AUTHOR_WARNING "seqan3_generate_snippet can't be used if SEQAN3_CLONE_DIR (i.e. no git checkout) is not defined.")
         return ()
     endif ()
     # e.g. source_snippet: <...>/@target_alphabet@_implicit_conversion_from_@source_alphabet@.cpp.in

--- a/test/cmake/seqan3_generate_snippet.cmake
+++ b/test/cmake/seqan3_generate_snippet.cmake
@@ -5,6 +5,8 @@
 # shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 # -----------------------------------------------------------------------------------------------------
 
+cmake_minimum_required (VERSION 3.10)
+
 # Generate snippets from a source_snippet
 #
 # Example:

--- a/test/cmake/seqan3_macro_benchmark.cmake
+++ b/test/cmake/seqan3_macro_benchmark.cmake
@@ -5,6 +5,8 @@
 # shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 # -----------------------------------------------------------------------------------------------------
 
+cmake_minimum_required (VERSION 3.10)
+
 # Adds a macro benchmark target and a test which executes that macro benchmark
 #
 # Example:

--- a/test/cmake/seqan3_path_longest_stem.cmake
+++ b/test/cmake/seqan3_path_longest_stem.cmake
@@ -5,6 +5,8 @@
 # shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 # -----------------------------------------------------------------------------------------------------
 
+cmake_minimum_required (VERSION 3.10)
+
 # A compatible function for cmake < 3.20 that basically returns `cmake_path (GET <filename> STEM LAST_ONLY <out_var>)`
 function (seqan3_path_longest_stem out_var filename)
     if (CMAKE_VERSION VERSION_LESS 3.20)  # cmake < 3.20

--- a/test/cmake/seqan3_require_benchmark.cmake
+++ b/test/cmake/seqan3_require_benchmark.cmake
@@ -5,6 +5,8 @@
 # shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 # -----------------------------------------------------------------------------------------------------
 
+cmake_minimum_required (VERSION 3.10)
+
 # Exposes the google-benchmark target `gbenchmark`.
 macro (seqan3_require_benchmark_old gbenchmark_git_tag)
     set (SEQAN3_BENCHMARK_CLONE_DIR "${PROJECT_BINARY_DIR}/vendor/benchmark")

--- a/test/cmake/seqan3_require_ccache.cmake
+++ b/test/cmake/seqan3_require_ccache.cmake
@@ -5,6 +5,8 @@
 # shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 # -----------------------------------------------------------------------------------------------------
 
+cmake_minimum_required (VERSION 3.10)
+
 # Uses `ccache` to cache build results.
 #
 # See also

--- a/test/cmake/seqan3_require_test.cmake
+++ b/test/cmake/seqan3_require_test.cmake
@@ -5,6 +5,8 @@
 # shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 # -----------------------------------------------------------------------------------------------------
 
+cmake_minimum_required (VERSION 3.10)
+
 # Exposes the google-test targets `gtest` and `gtest_main`.
 macro (seqan3_require_test_old gtest_git_tag)
     set (SEQAN3_TEST_CLONE_DIR "${PROJECT_BINARY_DIR}/vendor/googletest")

--- a/test/cmake/seqan3_test_component.cmake
+++ b/test/cmake/seqan3_test_component.cmake
@@ -5,6 +5,8 @@
 # shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 # -----------------------------------------------------------------------------------------------------
 
+cmake_minimum_required (VERSION 3.10)
+
 include (seqan3_path_longest_stem)
 
 # Get a specific component of a test file which follows the seqan3 naming scheme.

--- a/test/cmake/seqan3_test_files.cmake
+++ b/test/cmake/seqan3_test_files.cmake
@@ -5,6 +5,8 @@
 # shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 # -----------------------------------------------------------------------------------------------------
 
+cmake_minimum_required (VERSION 3.10)
+
 # Finds all files relative to the `test_base_path_` which satisfy the given file pattern.
 #
 # Example:

--- a/test/coverage/CMakeLists.txt
+++ b/test/coverage/CMakeLists.txt
@@ -5,7 +5,7 @@
 # shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 # -----------------------------------------------------------------------------------------------------
 
-cmake_minimum_required (VERSION 3.7)
+cmake_minimum_required (VERSION 3.10)
 project (seqan3_test_coverage CXX)
 
 include (../seqan3-test.cmake)

--- a/test/documentation/seqan3-doxygen-package.cmake
+++ b/test/documentation/seqan3-doxygen-package.cmake
@@ -5,7 +5,7 @@
 # shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 # -----------------------------------------------------------------------------------------------------
 
-cmake_minimum_required (VERSION 3.7)
+cmake_minimum_required (VERSION 3.10)
 
 set (CPACK_GENERATOR "TXZ")
 

--- a/test/documentation/seqan3-doxygen.cmake
+++ b/test/documentation/seqan3-doxygen.cmake
@@ -5,7 +5,7 @@
 # shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 # -----------------------------------------------------------------------------------------------------
 
-cmake_minimum_required (VERSION 3.7)
+cmake_minimum_required (VERSION 3.10)
 
 ### Find doxygen and dependency to DOT tool
 message (STATUS "Searching for doxygen.")

--- a/test/header/CMakeLists.txt
+++ b/test/header/CMakeLists.txt
@@ -5,7 +5,7 @@
 # shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 # -----------------------------------------------------------------------------------------------------
 
-cmake_minimum_required (VERSION 3.7)
+cmake_minimum_required (VERSION 3.10)
 project (seqan3_header_test CXX)
 
 include (../seqan3-test.cmake)

--- a/test/header/generate_header_source.cmake
+++ b/test/header/generate_header_source.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.7)
+cmake_minimum_required (VERSION 3.10)
 
 option (HEADER_FILE_ABSOLUTE "")
 option (HEADER_FILE_INCLUDE "")

--- a/test/macro_benchmark/CMakeLists.txt
+++ b/test/macro_benchmark/CMakeLists.txt
@@ -5,7 +5,7 @@
 # shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 # -----------------------------------------------------------------------------------------------------
 
-cmake_minimum_required (VERSION 3.7)
+cmake_minimum_required (VERSION 3.10)
 project (seqan3_test_unit CXX)
 
 include (../seqan3-test.cmake)

--- a/test/performance/CMakeLists.txt
+++ b/test/performance/CMakeLists.txt
@@ -5,7 +5,7 @@
 # shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 # -----------------------------------------------------------------------------------------------------
 
-cmake_minimum_required (VERSION 3.7)
+cmake_minimum_required (VERSION 3.10)
 project (seqan3_test_performance CXX)
 
 include (../seqan3-test.cmake)

--- a/test/seqan3-test.cmake
+++ b/test/seqan3-test.cmake
@@ -9,7 +9,7 @@
 # SeqAn3. To build tests, run cmake on one of the sub-folders in this directory
 # which contain a CMakeLists.txt.
 
-cmake_minimum_required (VERSION 3.7)
+cmake_minimum_required (VERSION 3.10)
 
 # require SeqAn3 package
 find_package (SeqAn3 REQUIRED

--- a/test/snippet/CMakeLists.txt
+++ b/test/snippet/CMakeLists.txt
@@ -5,7 +5,7 @@
 # shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 # -----------------------------------------------------------------------------------------------------
 
-cmake_minimum_required (VERSION 3.7)
+cmake_minimum_required (VERSION 3.10)
 project (seqan3_test_snippet CXX)
 
 include (../seqan3-test.cmake)

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -5,7 +5,7 @@
 # shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 # -----------------------------------------------------------------------------------------------------
 
-cmake_minimum_required (VERSION 3.7)
+cmake_minimum_required (VERSION 3.10)
 project (seqan3_test_unit CXX)
 
 include (../seqan3-test.cmake)
@@ -17,10 +17,6 @@ include (include_dependencies/add_include_dependencies)
 
 option (SEQAN3_VERBOSE_TESTS "Run each test case individually" ON)
 option (SEQAN3_USE_INCLUDE_DEPENDENCIES "Build tests in an hierarchical order (by an include graph, i.e. tests with less dependencies are build first)" OFF)
-
-if (SEQAN3_USE_INCLUDE_DEPENDENCIES)
-    cmake_minimum_required (VERSION 3.8)
-endif ()
 
 macro (seqan3_test unit_test_cpp)
     cmake_parse_arguments(SEQAN3_TEST "" "" "CYCLIC_DEPENDING_INCLUDES" ${ARGN})

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -29,7 +29,7 @@ macro (seqan3_test unit_test_cpp)
     target_link_libraries (${target} seqan3::test::unit)
     add_include_dependencies (${target} "${SEQAN3_TEST_CYCLIC_DEPENDING_INCLUDES}")
     collect_used_test (${target})
-    if (SEQAN3_VERBOSE_TESTS AND NOT CMAKE_VERSION VERSION_LESS 3.10) # cmake >= 3.10
+    if (SEQAN3_VERBOSE_TESTS)
         gtest_discover_tests(${target} TEST_PREFIX "${test_name}::" PROPERTIES TIMEOUT "30")
     else ()
         add_test (NAME "${test_name}" COMMAND ${target})


### PR DESCRIPTION
Rational: cmake 3.10 was released on 20 November 2017.

https://pkgs.org/download/cmake showed us that only 2 major linux distributions offer cmake versions below 3.10:

* CentOS-7: cmake-3.3
* Debian-9 (Stretch): cmake-3.7

As cmake is pretty easy to upgrade as a local user (just download and extract it), we increased the minimum version to 3.10.

This change only effects users that want to build our tests.