### PR TITLE
Doc/create all hpp

### DIFF
--- a/include/seqan3/alignment/aligned_sequence/all.hpp
+++ b/include/seqan3/alignment/aligned_sequence/all.hpp
@@ -10,13 +10,13 @@
  * \author Svenja Mehringer <svenja.mehringer AT fu-berlin.de>
  */
 
-#pragma once
-
-#include <seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp>
-#include <seqan3/alignment/aligned_sequence/debug_stream_alignment.hpp>
-
 /*!\defgroup alignment_aligned_sequence Aligned Sequence
  * \ingroup alignment
  * \brief Provides seqan3::aligned_sequence, as well as various ranges that model it.
  * \see alignment
  */
+
+#pragma once
+
+#include <seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp>
+#include <seqan3/alignment/aligned_sequence/debug_stream_alignment.hpp>

--- a/include/seqan3/alignment/all.hpp
+++ b/include/seqan3/alignment/all.hpp
@@ -24,11 +24,12 @@
  * is described in \ref alignment_pairwise.
  */
 
- #pragma once
+#pragma once
 
- #include <seqan3/alignment/aligned_sequence/all.hpp>
- #include <seqan3/alignment/configuration/all.hpp>
- #include <seqan3/alignment/exception.hpp>
- #include <seqan3/alignment/matrix/all.hpp>
- #include <seqan3/alignment/pairwise/all.hpp>
- #include <seqan3/alignment/scoring/all.hpp>
+#include <seqan3/alignment/aligned_sequence/all.hpp>
+#include <seqan3/alignment/configuration/all.hpp>
+#include <seqan3/alignment/decorator/all.hpp>
+#include <seqan3/alignment/exception.hpp>
+#include <seqan3/alignment/matrix/all.hpp>
+#include <seqan3/alignment/pairwise/all.hpp>
+#include <seqan3/alignment/scoring/all.hpp>

--- a/include/seqan3/alignment/configuration/all.hpp
+++ b/include/seqan3/alignment/configuration/all.hpp
@@ -10,23 +10,6 @@
  * \author Rene Rahn <rene.rahn AT fu-berlin.de>
  */
 
-#pragma once
-
-#include <seqan3/alignment/configuration/align_config_band.hpp>
-#include <seqan3/alignment/configuration/align_config_debug.hpp>
-#include <seqan3/alignment/configuration/align_config_edit.hpp>
-#include <seqan3/alignment/configuration/align_config_gap_cost_affine.hpp>
-#include <seqan3/alignment/configuration/align_config_method.hpp>
-#include <seqan3/alignment/configuration/align_config_min_score.hpp>
-#include <seqan3/alignment/configuration/align_config_on_result.hpp>
-#include <seqan3/alignment/configuration/align_config_output.hpp>
-#include <seqan3/alignment/configuration/align_config_parallel.hpp>
-#include <seqan3/alignment/configuration/align_config_result_type.hpp>
-#include <seqan3/alignment/configuration/align_config_score_type.hpp>
-#include <seqan3/alignment/configuration/align_config_scoring_scheme.hpp>
-#include <seqan3/alignment/configuration/align_config_vectorised.hpp>
-#include <seqan3/alignment/configuration/detail.hpp>
-
 /*!\namespace seqan3::align_cfg
  * \brief A special sub namespace for the alignment configurations.
  */
@@ -42,3 +25,19 @@
  * \brief Provides configuration elements for the pairwise alignment configuration.
  * \see alignment
  */
+
+#pragma once
+
+#include <seqan3/alignment/configuration/align_config_band.hpp>
+#include <seqan3/alignment/configuration/align_config_debug.hpp>
+#include <seqan3/alignment/configuration/align_config_edit.hpp>
+#include <seqan3/alignment/configuration/align_config_gap_cost_affine.hpp>
+#include <seqan3/alignment/configuration/align_config_method.hpp>
+#include <seqan3/alignment/configuration/align_config_min_score.hpp>
+#include <seqan3/alignment/configuration/align_config_on_result.hpp>
+#include <seqan3/alignment/configuration/align_config_output.hpp>
+#include <seqan3/alignment/configuration/align_config_parallel.hpp>
+#include <seqan3/alignment/configuration/align_config_result_type.hpp>
+#include <seqan3/alignment/configuration/align_config_score_type.hpp>
+#include <seqan3/alignment/configuration/align_config_scoring_scheme.hpp>
+#include <seqan3/alignment/configuration/align_config_vectorised.hpp>

--- a/include/seqan3/alignment/decorator/all.hpp
+++ b/include/seqan3/alignment/decorator/all.hpp
@@ -10,12 +10,12 @@
  * \author Svenja Mehringer <svenja.mehringer AT fu-berlin.de>
  */
 
-#pragma once
-
-#include <seqan3/alignment/decorator/gap_decorator.hpp>
-
 /*!\defgroup alignment_decorator Decorator
  * \brief The decorator submodule contains special SeqAn decorators.
  * \ingroup alignment
  * \see alignment
  */
+
+#pragma once
+
+#include <seqan3/alignment/decorator/gap_decorator.hpp>

--- a/include/seqan3/alignment/matrix/all.hpp
+++ b/include/seqan3/alignment/matrix/all.hpp
@@ -10,8 +10,6 @@
  * \author Marcel Ehrhardt <marcel.ehrhardt AT fu-berlin.de>
  */
 
-#pragma once
-
 //!\cond DEV
 
 /*!\defgroup alignment_matrix Matrix
@@ -21,4 +19,6 @@
  */
 //!\endcond
 
-#include <seqan3/core/platform.hpp> // make header test happy
+#pragma once
+
+#include <seqan3/core/platform.hpp>

--- a/include/seqan3/alignment/pairwise/all.hpp
+++ b/include/seqan3/alignment/pairwise/all.hpp
@@ -10,16 +10,6 @@
  * \author Rene Rahn <rene.rahn AT fu-berlin.de>
  */
 
-#pragma once
-
-#include <seqan3/alignment/pairwise/align_pairwise.hpp>
-#include <seqan3/alignment/pairwise/align_result_selector.hpp>
-#include <seqan3/alignment/pairwise/alignment_algorithm.hpp>
-#include <seqan3/alignment/pairwise/alignment_configurator.hpp>
-#include <seqan3/alignment/pairwise/alignment_result.hpp>
-#include <seqan3/alignment/pairwise/edit_distance_unbanded.hpp>
-#include <seqan3/alignment/pairwise/policy/all.hpp>
-
 /*!\defgroup alignment_pairwise Pairwise
  * \ingroup alignment
  * \brief Provides the algorithmic components for the computation of pairwise alignments.
@@ -272,3 +262,15 @@
  *  - [lecture script - pairwise alignment](https://www.mi.fu-berlin.de/en/inf/groups/abi/teaching/lectures/lectures_past/WS0910/V___Algorithmen_und_Datenstrukturen/scripts/alignment.pdf)\n
  *  - alignment
  */
+
+#pragma once
+
+#include <seqan3/alignment/pairwise/align_pairwise.hpp>
+#include <seqan3/alignment/pairwise/align_result_selector.hpp>
+#include <seqan3/alignment/pairwise/alignment_algorithm.hpp>
+#include <seqan3/alignment/pairwise/alignment_configurator.hpp>
+#include <seqan3/alignment/pairwise/alignment_result.hpp>
+#include <seqan3/alignment/pairwise/edit_distance_algorithm.hpp>
+#include <seqan3/alignment/pairwise/edit_distance_fwd.hpp>
+#include <seqan3/alignment/pairwise/edit_distance_unbanded.hpp>
+#include <seqan3/alignment/pairwise/policy/all.hpp>

--- a/include/seqan3/alignment/pairwise/policy/all.hpp
+++ b/include/seqan3/alignment/pairwise/policy/all.hpp
@@ -12,16 +12,6 @@
  */
 //!\endcond
 
-#pragma once
-
-#include <seqan3/alignment/pairwise/policy/affine_gap_init_policy.hpp>
-#include <seqan3/alignment/pairwise/policy/affine_gap_policy.hpp>
-#include <seqan3/alignment/pairwise/policy/alignment_matrix_policy.hpp>
-#include <seqan3/alignment/pairwise/policy/find_optimum_policy.hpp>
-#include <seqan3/alignment/pairwise/policy/scoring_scheme_policy.hpp>
-#include <seqan3/alignment/pairwise/policy/simd_affine_gap_policy.hpp>
-#include <seqan3/alignment/pairwise/policy/simd_find_optimum_policy.hpp>
-
 //!\cond DEV
 /*!\defgroup alignment_pairwise_policy Alignment policies
  * \ingroup alignment_pairwise
@@ -134,3 +124,13 @@
  *  - seqan3::detail::find_optimum_policy
  */
 //!\endcond
+
+#pragma once
+
+#include <seqan3/alignment/pairwise/policy/affine_gap_init_policy.hpp>
+#include <seqan3/alignment/pairwise/policy/affine_gap_policy.hpp>
+#include <seqan3/alignment/pairwise/policy/alignment_matrix_policy.hpp>
+#include <seqan3/alignment/pairwise/policy/find_optimum_policy.hpp>
+#include <seqan3/alignment/pairwise/policy/scoring_scheme_policy.hpp>
+#include <seqan3/alignment/pairwise/policy/simd_affine_gap_policy.hpp>
+#include <seqan3/alignment/pairwise/policy/simd_find_optimum_policy.hpp>

--- a/include/seqan3/alignment/scoring/all.hpp
+++ b/include/seqan3/alignment/scoring/all.hpp
@@ -10,13 +10,13 @@
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  */
 
-#pragma once
-
 /*!\defgroup alignment_scoring Scoring
  * \brief Provides the data structures used for scoring alphabets and sequences.
  * \ingroup alignment
  * \see alignment
  */
+
+#pragma once
 
 #include <seqan3/alignment/scoring/aminoacid_scoring_scheme.hpp>
 #include <seqan3/alignment/scoring/nucleotide_scoring_scheme.hpp>

--- a/include/seqan3/alphabet/adaptation/all.hpp
+++ b/include/seqan3/alphabet/adaptation/all.hpp
@@ -10,13 +10,13 @@
  * \brief Meta-header for the \link alphabet_adaptation Alphabet / Adaptation submodule \endlink.
  */
 
-#pragma once
-
-#include <seqan3/alphabet/adaptation/char.hpp>
-#include <seqan3/alphabet/adaptation/uint.hpp>
-
 /*!\defgroup alphabet_adaptation Adaptation
  * \brief Provides alphabet adaptions of some standard char and uint types.
  * \ingroup alphabet
  * \see alphabet
  */
+
+#pragma once
+
+#include <seqan3/alphabet/adaptation/char.hpp>
+#include <seqan3/alphabet/adaptation/uint.hpp>

--- a/include/seqan3/alphabet/all.hpp
+++ b/include/seqan3/alphabet/all.hpp
@@ -181,11 +181,18 @@
 #pragma once
 
 #include <seqan3/alphabet/adaptation/all.hpp>
+#include <seqan3/alphabet/alphabet_base.hpp>
 #include <seqan3/alphabet/aminoacid/all.hpp>
+#include <seqan3/alphabet/cigar/all.hpp>
 #include <seqan3/alphabet/composite/all.hpp>
 #include <seqan3/alphabet/concept.hpp>
+#include <seqan3/alphabet/container/all.hpp>
+#include <seqan3/alphabet/exception.hpp>
 #include <seqan3/alphabet/gap/all.hpp>
+#include <seqan3/alphabet/hash.hpp>
 #include <seqan3/alphabet/mask/all.hpp>
 #include <seqan3/alphabet/nucleotide/all.hpp>
 #include <seqan3/alphabet/quality/all.hpp>
+#include <seqan3/alphabet/range/all.hpp>
 #include <seqan3/alphabet/structure/all.hpp>
+#include <seqan3/alphabet/views/all.hpp>

--- a/include/seqan3/alphabet/aminoacid/all.hpp
+++ b/include/seqan3/alphabet/aminoacid/all.hpp
@@ -9,16 +9,6 @@
  * \author Sara Hetzel <sara.hetzel AT fu-berlin.de>
  * \brief Meta-header for the \link alphabet_aminoacid Alphabet / Aminoacid submodule \endlink.
  */
-#pragma once
-
-#include <seqan3/alphabet/aminoacid/aa10li.hpp>
-#include <seqan3/alphabet/aminoacid/aa10murphy.hpp>
-#include <seqan3/alphabet/aminoacid/aa20.hpp>
-#include <seqan3/alphabet/aminoacid/aa27.hpp>
-#include <seqan3/alphabet/aminoacid/concept.hpp>
-#include <seqan3/alphabet/aminoacid/translation.hpp>
-#include <seqan3/alphabet/aminoacid/translation_details.hpp>
-#include <seqan3/alphabet/aminoacid/translation_genetic_code.hpp>
 
 /*!\defgroup alphabet_aminoacid Aminoacid
  * \brief Provides the amino acid alphabets and functionality for translation from nucleotide.
@@ -74,3 +64,15 @@
  * no benefits in regard to space consumption (both need 5bits).
  * Use it only when you know you need to interface with other software of formats that only support the canonical set.
  */
+
+#pragma once
+
+#include <seqan3/alphabet/aminoacid/aa10li.hpp>
+#include <seqan3/alphabet/aminoacid/aa10murphy.hpp>
+#include <seqan3/alphabet/aminoacid/aa20.hpp>
+#include <seqan3/alphabet/aminoacid/aa27.hpp>
+#include <seqan3/alphabet/aminoacid/aminoacid_base.hpp>
+#include <seqan3/alphabet/aminoacid/concept.hpp>
+#include <seqan3/alphabet/aminoacid/translation.hpp>
+#include <seqan3/alphabet/aminoacid/translation_details.hpp>
+#include <seqan3/alphabet/aminoacid/translation_genetic_code.hpp>

--- a/include/seqan3/alphabet/cigar/all.hpp
+++ b/include/seqan3/alphabet/cigar/all.hpp
@@ -10,10 +10,6 @@
  * \brief Meta-header for the \link alphabet_cigar Alphabet / CIGAR submodule \endlink.
  */
 
- #pragma once
-
- #include <seqan3/alphabet/cigar/cigar.hpp>
-
  /*!\defgroup alphabet_cigar CIGAR
   * \brief Provides (semi-)alphabets for representing elements in CIGAR strings.
   * \ingroup alphabet
@@ -34,3 +30,7 @@
   *
   * \copydoc seqan3::doxygen::cigar_operation_table
   */
+
+#pragma once
+
+#include <seqan3/alphabet/cigar/cigar.hpp>

--- a/include/seqan3/alphabet/composite/all.hpp
+++ b/include/seqan3/alphabet/composite/all.hpp
@@ -9,11 +9,6 @@
  * \author Marcel Ehrhardt <marcel.ehrhardt AT fu-berlin.de>
  * \brief Meta-header for the \link alphabet_composite Alphabet / Composite submodule \endlink.
  */
-#pragma once
-
-#include <seqan3/alphabet/composite/alphabet_tuple_base.hpp>
-#include <seqan3/alphabet/composite/alphabet_variant.hpp>
-#include <seqan3/alphabet/composite/semialphabet_any.hpp>
 
 /*!\defgroup alphabet_composite Composite
  * \brief Provides templates for combining existing alphabets into new alphabet types.
@@ -36,3 +31,9 @@
  * * seqan3::semialphabet_any which type erases other alphabets of the same size and allows again transformation to
  *   alphabets of the same size by copying the rank.
  */
+
+#pragma once
+
+#include <seqan3/alphabet/composite/alphabet_tuple_base.hpp>
+#include <seqan3/alphabet/composite/alphabet_variant.hpp>
+#include <seqan3/alphabet/composite/semialphabet_any.hpp>

--- a/include/seqan3/alphabet/container/all.hpp
+++ b/include/seqan3/alphabet/container/all.hpp
@@ -9,13 +9,14 @@
  * \author Marcel Ehrhardt <marcel.ehrhardt AT fu-berlin.de>
  * \brief Meta-header for the \link alphabet_container Alphabet / Container submodule \endlink.
  */
-#pragma once
-
-#include <seqan3/alphabet/container/bitpacked_sequence.hpp>
-#include <seqan3/alphabet/container/concatenated_sequences.hpp>
 
 /*!\defgroup alphabet_container Container
  * \brief Alphabet related container.
  * \ingroup alphabet
  * \see alphabet
  */
+
+#pragma once
+
+#include <seqan3/alphabet/container/bitpacked_sequence.hpp>
+#include <seqan3/alphabet/container/concatenated_sequences.hpp>

--- a/include/seqan3/alphabet/gap/all.hpp
+++ b/include/seqan3/alphabet/gap/all.hpp
@@ -10,11 +10,6 @@
  * \brief Meta-header for the \link alphabet_gap Alphabet / Gap submodule \endlink.
  */
 
-#pragma once
-
-#include <seqan3/alphabet/gap/gap.hpp>
-#include <seqan3/alphabet/gap/gapped.hpp>
-
 /*!\defgroup alphabet_gap Gap
  * \brief Provides the gap alphabet and functionality to make an alphabet a gapped alphabet.
  * \ingroup alphabet
@@ -32,3 +27,8 @@
  * seqan3::gapped<> template which transforms any other alphabet to be a composite of that alphabet + the gap
  * character.
  */
+
+#pragma once
+
+#include <seqan3/alphabet/gap/gap.hpp>
+#include <seqan3/alphabet/gap/gapped.hpp>

--- a/include/seqan3/alphabet/mask/all.hpp
+++ b/include/seqan3/alphabet/mask/all.hpp
@@ -11,11 +11,6 @@
  * \author Lydia Buntrock <lydia.buntrock AT fu-berlin.de>
  */
 
-#pragma once
-
-#include <seqan3/alphabet/mask/mask.hpp>
-#include <seqan3/alphabet/mask/masked.hpp>
-
 /*!\defgroup alphabet_mask Mask
  * \brief Provides the mask alphabet and functionality for creating masked composites.
  * \ingroup alphabet
@@ -46,3 +41,8 @@
  * denoted by lowercase characters. Note that larger repeats, such as segmental duplications, large tandem repeats and
  * whole gene duplications are generally not masked.
  */
+
+#pragma once
+
+#include <seqan3/alphabet/mask/mask.hpp>
+#include <seqan3/alphabet/mask/masked.hpp>

--- a/include/seqan3/alphabet/nucleotide/all.hpp
+++ b/include/seqan3/alphabet/nucleotide/all.hpp
@@ -10,17 +10,6 @@
  * \brief Meta-header for the \link alphabet_nucleotide Alphabet / Nucleotide submodule \endlink.
  */
 
-#pragma once
-
-#include <seqan3/alphabet/nucleotide/concept.hpp>
-#include <seqan3/alphabet/nucleotide/dna4.hpp>
-#include <seqan3/alphabet/nucleotide/dna5.hpp>
-#include <seqan3/alphabet/nucleotide/dna15.hpp>
-#include <seqan3/alphabet/nucleotide/dna3bs.hpp>
-#include <seqan3/alphabet/nucleotide/rna4.hpp>
-#include <seqan3/alphabet/nucleotide/rna5.hpp>
-#include <seqan3/alphabet/nucleotide/rna15.hpp>
-
 /*!\defgroup alphabet_nucleotide Nucleotide
  * \brief Provides the different DNA and RNA alphabet types.
  * \ingroup alphabet
@@ -148,3 +137,16 @@
  * individual complements.
  *
  */
+
+#pragma once
+
+#include <seqan3/alphabet/nucleotide/concept.hpp>
+#include <seqan3/alphabet/nucleotide/dna15.hpp>
+#include <seqan3/alphabet/nucleotide/dna16sam.hpp>
+#include <seqan3/alphabet/nucleotide/dna3bs.hpp>
+#include <seqan3/alphabet/nucleotide/dna4.hpp>
+#include <seqan3/alphabet/nucleotide/dna5.hpp>
+#include <seqan3/alphabet/nucleotide/nucleotide_base.hpp>
+#include <seqan3/alphabet/nucleotide/rna15.hpp>
+#include <seqan3/alphabet/nucleotide/rna4.hpp>
+#include <seqan3/alphabet/nucleotide/rna5.hpp>

--- a/include/seqan3/alphabet/quality/all.hpp
+++ b/include/seqan3/alphabet/quality/all.hpp
@@ -11,16 +11,6 @@
  * \brief Meta-header for the \link alphabet_quality Alphabet / Quality submodule \endlink.
  */
 
-#pragma once
-
-#include <seqan3/alphabet/quality/aliases.hpp>
-#include <seqan3/alphabet/quality/concept.hpp>
-#include <seqan3/alphabet/quality/qualified.hpp>
-#include <seqan3/alphabet/quality/phred42.hpp>
-#include <seqan3/alphabet/quality/phred63.hpp>
-#include <seqan3/alphabet/quality/phred68solexa.hpp>
-#include <seqan3/alphabet/quality/phred94.hpp>
-
 /*!\defgroup alphabet_quality Quality
  * \brief Provides the various quality score types.
  * \ingroup alphabet
@@ -123,3 +113,14 @@
  * one alphabet are mapped to the closest value in the target alphabet (e.g. a `seqan3::phred63` letter with value 60
  * will convert to a `seqan3::phred42` letter of score 41, this also applies to `seqan3::phred94`).
  */
+
+#pragma once
+
+#include <seqan3/alphabet/quality/aliases.hpp>
+#include <seqan3/alphabet/quality/concept.hpp>
+#include <seqan3/alphabet/quality/phred42.hpp>
+#include <seqan3/alphabet/quality/phred63.hpp>
+#include <seqan3/alphabet/quality/phred68solexa.hpp>
+#include <seqan3/alphabet/quality/phred94.hpp>
+#include <seqan3/alphabet/quality/phred_base.hpp>
+#include <seqan3/alphabet/quality/qualified.hpp>

--- a/include/seqan3/alphabet/range/all.hpp
+++ b/include/seqan3/alphabet/range/all.hpp
@@ -9,13 +9,14 @@
  * \author Marcel Ehrhardt <marcel.ehrhardt AT fu-berlin.de>
  * \brief Meta-header for the \link alphabet_range Alphabet / Range submodule \endlink.
  */
-#pragma once
-
-#include <seqan3/alphabet/range/hash.hpp>
-#include <seqan3/alphabet/range/sequence.hpp>
 
 /*!\defgroup alphabet_range Range
  * \brief Alphabet related ranges.
  * \ingroup alphabet
  * \see alphabet
  */
+
+#pragma once
+
+#include <seqan3/alphabet/range/hash.hpp>
+#include <seqan3/alphabet/range/sequence.hpp>

--- a/include/seqan3/alphabet/structure/all.hpp
+++ b/include/seqan3/alphabet/structure/all.hpp
@@ -10,15 +10,6 @@
  * \brief Meta-header for the \link alphabet_structure Alphabet / Structure submodule \endlink.
  */
 
-#pragma once
-
-#include <seqan3/alphabet/structure/concept.hpp>
-#include <seqan3/alphabet/structure/dot_bracket3.hpp>
-#include <seqan3/alphabet/structure/dssp9.hpp>
-#include <seqan3/alphabet/structure/structured_aa.hpp>
-#include <seqan3/alphabet/structure/structured_rna.hpp>
-#include <seqan3/alphabet/structure/wuss.hpp>
-
 /*!\defgroup alphabet_structure Structure
  * \brief Provides types to represent single elements of RNA and protein structures.
  * \ingroup alphabet
@@ -34,3 +25,12 @@
  * [WUSS](@ref seqan3::wuss)                | `.<>:,-_~;()[]{}AaBb...` | Annotation that provides further markups and pseudoknots.
  * [DSSP](@ref seqan3::dssp9)               | `HBEGITSCX`              | Structure encoding for proteins.
  */
+
+#pragma once
+
+#include <seqan3/alphabet/structure/concept.hpp>
+#include <seqan3/alphabet/structure/dot_bracket3.hpp>
+#include <seqan3/alphabet/structure/dssp9.hpp>
+#include <seqan3/alphabet/structure/structured_aa.hpp>
+#include <seqan3/alphabet/structure/structured_rna.hpp>
+#include <seqan3/alphabet/structure/wuss.hpp>

--- a/include/seqan3/alphabet/views/all.hpp
+++ b/include/seqan3/alphabet/views/all.hpp
@@ -10,6 +10,12 @@
  * \author Lydia Buntrock <lydia.buntrock AT fu-berlin.de>
  */
 
+/*!\defgroup alphabet_views Views
+ * \brief Alphabet related views.
+ * \ingroup alphabet
+ * \see alphabet
+ */
+
 #pragma once
 
 #include <seqan3/alphabet/views/char_to.hpp>
@@ -18,10 +24,5 @@
 #include <seqan3/alphabet/views/to_char.hpp>
 #include <seqan3/alphabet/views/to_rank.hpp>
 #include <seqan3/alphabet/views/translate.hpp>
+#include <seqan3/alphabet/views/translate_join.hpp>
 #include <seqan3/alphabet/views/trim_quality.hpp>
-
-/*!\defgroup alphabet_views Views
- * \brief Alphabet related views.
- * \ingroup alphabet
- * \see alphabet
- */

--- a/include/seqan3/argument_parser/all.hpp
+++ b/include/seqan3/argument_parser/all.hpp
@@ -10,14 +10,6 @@
  * \brief Meta-header for the \link argument_parser Argument Parser module \endlink.
  */
 
-#pragma once
-
-#include <seqan3/argument_parser/argument_parser.hpp>
-#include <seqan3/argument_parser/auxiliary.hpp>
-#include <seqan3/argument_parser/exceptions.hpp>
-#include <seqan3/argument_parser/validators.hpp>
-
-
 /*!\file
  * \brief The Argument Parser Module
  * \defgroup argument_parser Argument Parser
@@ -45,3 +37,10 @@
  * - seqan3::input_directory_validator
  * - seqan3::output_directory_validator
  */
+
+#pragma once
+
+#include <seqan3/argument_parser/argument_parser.hpp>
+#include <seqan3/argument_parser/auxiliary.hpp>
+#include <seqan3/argument_parser/exceptions.hpp>
+#include <seqan3/argument_parser/validators.hpp>

--- a/include/seqan3/core/algorithm/all.hpp
+++ b/include/seqan3/core/algorithm/all.hpp
@@ -10,12 +10,12 @@
  * \author Rene Rahn <rene.rahn AT fu-berlin.de>
  */
 
-#pragma once
-
-#include <seqan3/core/algorithm/algorithm_result_generator_range.hpp>
-
 /*!\defgroup core_algorithm Algorithm
  * \ingroup core
  * \see core
  * \brief Provides core functionality used for algorithms.
  */
+
+#pragma once
+
+#include <seqan3/core/algorithm/algorithm_result_generator_range.hpp>

--- a/include/seqan3/core/all.hpp
+++ b/include/seqan3/core/all.hpp
@@ -11,20 +11,9 @@
  * \author Rene Rahn <rene.rahn AT fu-berlin.de>
  */
 
-#pragma once
-
 // ============================================================================
 // External concept implementations
 // ============================================================================
-
-#include <seqan3/core/add_enum_bitwise_operators.hpp>
-#include <seqan3/core/algorithm/all.hpp>
-#include <seqan3/core/concept/all.hpp>
-#include <seqan3/core/configuration/all.hpp>
-#include <seqan3/core/debug_stream.hpp>
-#include <seqan3/core/detail/all.hpp>
-#include <seqan3/core/platform.hpp>
-#include <seqan3/core/range/type_traits.hpp>
 
 /*!\defgroup core Core
  * \brief Provides core functionality used by multiple modules.
@@ -78,3 +67,15 @@
 /*!\namespace std
  * \brief SeqAn specific customisations in the standard namespace.
  */
+
+#pragma once
+
+#include <seqan3/core/add_enum_bitwise_operators.hpp>
+#include <seqan3/core/algorithm/all.hpp>
+#include <seqan3/core/concept/all.hpp>
+#include <seqan3/core/configuration/all.hpp>
+#include <seqan3/core/debug_stream/all.hpp>
+#include <seqan3/core/debug_stream.hpp>
+#include <seqan3/core/platform.hpp>
+#include <seqan3/core/range/all.hpp>
+#include <seqan3/core/semiregular_box.hpp>

--- a/include/seqan3/core/configuration/all.hpp
+++ b/include/seqan3/core/configuration/all.hpp
@@ -10,12 +10,6 @@
  * \author Rene Rahn <rene.rahn AT fu-berlin.de>
  */
 
-#pragma once
-
-#include <seqan3/core/configuration/configuration.hpp>
-#include <seqan3/core/configuration/detail/all.hpp>
-#include <seqan3/core/configuration/pipeable_config_element.hpp>
-
 /*!\defgroup core_configuration Configuration
  * \ingroup core
  * \see core
@@ -77,3 +71,8 @@
  *
  * \include test/snippet/core/configuration/configuration_get_or.cpp
  */
+
+#pragma once
+
+#include <seqan3/core/configuration/configuration.hpp>
+#include <seqan3/core/configuration/pipeable_config_element.hpp>

--- a/include/seqan3/core/debug_stream/all.hpp
+++ b/include/seqan3/core/debug_stream/all.hpp
@@ -10,6 +10,12 @@
  * \author Marcel Ehrhardt <marcel.ehrhardt AT fu-berlin.de>
  */
 
+/*!\defgroup core_debug_stream Debug Stream
+ * \ingroup core
+ * \see core
+ * \brief Provides core functionality used to print seqan3 and std types.
+ */
+
 #pragma once
 
 #include <seqan3/core/debug_stream/byte.hpp>
@@ -18,9 +24,3 @@
 #include <seqan3/core/debug_stream/range.hpp>
 #include <seqan3/core/debug_stream/tuple.hpp>
 #include <seqan3/core/debug_stream/variant.hpp>
-
-/*!\defgroup core_debug_stream Debug Stream
- * \ingroup core
- * \see core
- * \brief Provides core functionality used to print seqan3 and std types.
- */

--- a/include/seqan3/core/range/all.hpp
+++ b/include/seqan3/core/range/all.hpp
@@ -10,12 +10,12 @@
  * \author Marcel Ehrhardt <marcel.ehrhardt AT fu-berlin.de>
  */
 
-#pragma once
-
-#include <seqan3/core/range/type_traits.hpp>
-
 /*!\defgroup core_range Range
  * \ingroup core
  * \see core
  * \brief Provides seqan3 general purpose range functionality.
  */
+
+#pragma once
+
+#include <seqan3/core/range/type_traits.hpp>

--- a/include/seqan3/io/all.hpp
+++ b/include/seqan3/io/all.hpp
@@ -109,3 +109,4 @@
 #include <seqan3/io/sequence_file/all.hpp>
 #include <seqan3/io/stream/all.hpp>
 #include <seqan3/io/structure_file/all.hpp>
+#include <seqan3/io/views/all.hpp>

--- a/include/seqan3/io/sam_file/all.hpp
+++ b/include/seqan3/io/sam_file/all.hpp
@@ -10,8 +10,6 @@
  * \author Svenja Mehringer <svenja.mehringer AT fu-berlin.de>
  */
 
-#pragma once
-
 /*!\defgroup io_sam_file SAM File
  * \ingroup io
  * \brief Provides files and formats for handling read mapping data.
@@ -31,6 +29,8 @@
  * \include{doc} doc/fragments/io_sam_file_output.md
  */
 
+#pragma once
+
 #include <seqan3/io/sam_file/format_bam.hpp>
 #include <seqan3/io/sam_file/format_sam.hpp>
 #include <seqan3/io/sam_file/header.hpp>
@@ -40,4 +40,6 @@
 #include <seqan3/io/sam_file/output.hpp>
 #include <seqan3/io/sam_file/output_format_concept.hpp>
 #include <seqan3/io/sam_file/output_options.hpp>
+#include <seqan3/io/sam_file/record.hpp>
+#include <seqan3/io/sam_file/sam_flag.hpp>
 #include <seqan3/io/sam_file/sam_tag_dictionary.hpp>

--- a/include/seqan3/io/sequence_file/all.hpp
+++ b/include/seqan3/io/sequence_file/all.hpp
@@ -10,8 +10,6 @@
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  */
 
-#pragma once
-
 /*!\defgroup io_sequence_file Sequence File
  * \brief Provides files and formats for handling sequence data.
  * \ingroup io
@@ -24,8 +22,16 @@
  * \see \ref tutorial_sequence_file
  */
 
+#pragma once
+
+#include <seqan3/io/sequence_file/format_embl.hpp>
 #include <seqan3/io/sequence_file/format_fasta.hpp>
-#include <seqan3/io/sequence_file/input_format_concept.hpp>
+#include <seqan3/io/sequence_file/format_fastq.hpp>
+#include <seqan3/io/sequence_file/format_genbank.hpp>
 #include <seqan3/io/sequence_file/input.hpp>
-#include <seqan3/io/sequence_file/output_format_concept.hpp>
+#include <seqan3/io/sequence_file/input_format_concept.hpp>
+#include <seqan3/io/sequence_file/input_options.hpp>
 #include <seqan3/io/sequence_file/output.hpp>
+#include <seqan3/io/sequence_file/output_format_concept.hpp>
+#include <seqan3/io/sequence_file/output_options.hpp>
+#include <seqan3/io/sequence_file/record.hpp>

--- a/include/seqan3/io/structure_file/all.hpp
+++ b/include/seqan3/io/structure_file/all.hpp
@@ -10,8 +10,6 @@
  * \author Jörg Winkler <j.winkler AT fu-berlin.de>
  */
 
-#pragma once
-
 /*!\defgroup io_structure_file Structure File
  * \ingroup io
  * \brief Provides files and formats for handling structure data.
@@ -21,6 +19,8 @@
  * \include{doc} doc/fragments/io_structure_output.md
  */
 
+#pragma once
+
 #include <seqan3/io/structure_file/format_vienna.hpp>
 #include <seqan3/io/structure_file/input.hpp>
 #include <seqan3/io/structure_file/input_format_concept.hpp>
@@ -28,3 +28,4 @@
 #include <seqan3/io/structure_file/output.hpp>
 #include <seqan3/io/structure_file/output_format_concept.hpp>
 #include <seqan3/io/structure_file/output_options.hpp>
+#include <seqan3/io/structure_file/record.hpp>

--- a/include/seqan3/io/views/all.hpp
+++ b/include/seqan3/io/views/all.hpp
@@ -10,12 +10,12 @@
  * \author Marcel Ehrhardt <marcel.ehrhardt AT fu-berlin.de>
  */
 
-#pragma once
-
-#include <seqan3/io/views/async_input_buffer.hpp>
-
 /*!\defgroup io_views Views
  * \brief IO related views.
  * \ingroup io
  * \see io
  */
+
+#pragma once
+
+#include <seqan3/io/views/async_input_buffer.hpp>

--- a/include/seqan3/search/all.hpp
+++ b/include/seqan3/search/all.hpp
@@ -10,12 +10,6 @@
  * \brief Meta-header for the \link search Search module \endlink.
  */
 
-#pragma once
-
-#include <seqan3/search/configuration/all.hpp>
-#include <seqan3/search/fm_index/all.hpp>
-#include <seqan3/search/search.hpp>
-
 /*!\defgroup search Search
  * \brief Data structures and approximate string search algorithms for large collection of text (e.g. DNA).
  * \brief Meta-header for the \link search Search module \endlink.
@@ -104,3 +98,13 @@
  * The approximate string search algorithm can be configured in multiple ways.
  * See \ref search_configuration for details.
  */
+
+#pragma once
+
+#include <seqan3/search/configuration/all.hpp>
+#include <seqan3/search/dream_index/all.hpp>
+#include <seqan3/search/fm_index/all.hpp>
+#include <seqan3/search/kmer_index/all.hpp>
+#include <seqan3/search/search.hpp>
+#include <seqan3/search/search_result.hpp>
+#include <seqan3/search/views/all.hpp>

--- a/include/seqan3/search/configuration/all.hpp
+++ b/include/seqan3/search/configuration/all.hpp
@@ -11,18 +11,6 @@
  * \author Lydia Buntrock <lydia.buntrock AT fu-berlin.de>
  */
 
-#pragma once
-
-#include <seqan3/core/configuration/configuration.hpp>
-#include <seqan3/search/configuration/default_configuration.hpp>
-#include <seqan3/search/configuration/detail.hpp>
-#include <seqan3/search/configuration/hit.hpp>
-#include <seqan3/search/configuration/max_error.hpp>
-#include <seqan3/search/configuration/on_result.hpp>
-#include <seqan3/search/configuration/output.hpp>
-#include <seqan3/search/configuration/parallel.hpp>
-#include <seqan3/search/configuration/result_type.hpp>
-
 /*!\namespace seqan3::search_cfg
  * \brief A special sub namespace for the search configurations.
  */
@@ -188,3 +176,14 @@
  *
  * \include test/snippet/search/search_with_user_callback.cpp
  */
+
+#pragma once
+
+#include <seqan3/search/configuration/default_configuration.hpp>
+#include <seqan3/search/configuration/hit.hpp>
+#include <seqan3/search/configuration/max_error.hpp>
+#include <seqan3/search/configuration/max_error_common.hpp>
+#include <seqan3/search/configuration/on_result.hpp>
+#include <seqan3/search/configuration/output.hpp>
+#include <seqan3/search/configuration/parallel.hpp>
+#include <seqan3/search/configuration/result_type.hpp>

--- a/include/seqan3/search/dream_index/all.hpp
+++ b/include/seqan3/search/dream_index/all.hpp
@@ -10,12 +10,12 @@
  * \brief Meta-header for the \link search_dream_index Search / DREAM Index submodule \endlink.
  */
 
-#pragma once
-
-#include <seqan3/search/dream_index/interleaved_bloom_filter.hpp>
-
 /*!\defgroup search_dream_index DREAM Index
  * \brief Provides seqan3::interleaved_bloom_filter.
  * \ingroup search
  * \see search
  */
+
+#pragma once
+
+#include <seqan3/search/dream_index/interleaved_bloom_filter.hpp>

--- a/include/seqan3/search/fm_index/all.hpp
+++ b/include/seqan3/search/fm_index/all.hpp
@@ -10,11 +10,6 @@
  * \brief Meta-header for the \link search_fm_index Search / FM Index submodule \endlink.
  */
 
-#pragma once
-
-#include <seqan3/search/fm_index/bi_fm_index.hpp>
-#include <seqan3/search/fm_index/fm_index.hpp>
-
 /*!\defgroup search_fm_index FM Index
  * \brief Provides seqan3::fm_index and seqan3::bi_fm_index as well as respective cursors.
  * \ingroup search
@@ -47,3 +42,11 @@
  * Note that the SeqAn index cursor, although having similar behaviour, doesn't model any of the standard library
  * iterator concepts, not even std::input_or_output_iterator.
  */
+
+#pragma once
+
+#include <seqan3/search/fm_index/bi_fm_index.hpp>
+#include <seqan3/search/fm_index/bi_fm_index_cursor.hpp>
+#include <seqan3/search/fm_index/concept.hpp>
+#include <seqan3/search/fm_index/fm_index.hpp>
+#include <seqan3/search/fm_index/fm_index_cursor.hpp>

--- a/include/seqan3/search/kmer_index/all.hpp
+++ b/include/seqan3/search/kmer_index/all.hpp
@@ -10,10 +10,6 @@
  * \brief Meta-header for the \link search_kmer_index Search / k-mer Index submodule \endlink.
  */
 
-#pragma once
-
-#include <seqan3/search/kmer_index/shape.hpp>
-
 /*!\defgroup search_kmer_index k-mer Index
  * \ingroup search
  * \brief Implementation of shapes for a k-mer Index.
@@ -31,3 +27,7 @@
  * The parameter k and the position(s) of wildcards must be fixed at index creation with
  * seqan3::ungapped or seqan3::shape.
  */
+
+#pragma once
+
+#include <seqan3/search/kmer_index/shape.hpp>

--- a/include/seqan3/search/views/all.hpp
+++ b/include/seqan3/search/views/all.hpp
@@ -10,14 +10,14 @@
  * \author Marcel Ehrhardt <marcel.ehrhardt AT fu-berlin.de>
  */
 
-#pragma once
-
-#include <seqan3/search/views/kmer_hash.hpp>
-#include <seqan3/search/views/minimiser_hash.hpp>
-#include <seqan3/search/views/minimiser.hpp>
-
 /*!\defgroup search_views Views
  * \brief Search related views.
  * \ingroup search
  * \see search
  */
+
+#pragma once
+
+#include <seqan3/search/views/kmer_hash.hpp>
+#include <seqan3/search/views/minimiser.hpp>
+#include <seqan3/search/views/minimiser_hash.hpp>

--- a/include/seqan3/utility/all.hpp
+++ b/include/seqan3/utility/all.hpp
@@ -12,14 +12,6 @@
  * \author Rene Rahn <rene.rahn AT fu-berlin.de>
  */
 
-#pragma once
-
-#include <seqan3/utility/math.hpp>
-#include <seqan3/utility/tuple/all.hpp>
-#include <seqan3/utility/type_list/all.hpp>
-#include <seqan3/utility/type_pack/all.hpp>
-#include <seqan3/utility/type_traits/all.hpp>
-
 /*!\defgroup utility Utility
  * \brief Provides additional utility functionality used by multiple modules.
  *
@@ -32,3 +24,18 @@
  * The utility module has no dependency to any other module except the \ref core
  * module.
  */
+
+#pragma once
+
+#include <seqan3/utility/char_operations/all.hpp>
+#include <seqan3/utility/concept/all.hpp>
+#include <seqan3/utility/container/all.hpp>
+#include <seqan3/utility/math.hpp>
+#include <seqan3/utility/parallel/all.hpp>
+#include <seqan3/utility/range/all.hpp>
+#include <seqan3/utility/simd/all.hpp>
+#include <seqan3/utility/tuple/all.hpp>
+#include <seqan3/utility/type_list/all.hpp>
+#include <seqan3/utility/type_pack/all.hpp>
+#include <seqan3/utility/type_traits/all.hpp>
+#include <seqan3/utility/views/all.hpp>

--- a/include/seqan3/utility/char_operations/all.hpp
+++ b/include/seqan3/utility/char_operations/all.hpp
@@ -11,14 +11,15 @@
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  */
 
-#pragma once
-
-#include <seqan3/utility/char_operations/predicate.hpp>
-#include <seqan3/utility/char_operations/pretty_print.hpp>
-#include <seqan3/utility/char_operations/transform.hpp>
-
 /*!\defgroup utility_char_operations Builtin Character Operations
  * \brief Provides various operations on character types.
  * \ingroup utility
  * \see utility
  */
+
+#pragma once
+
+#include <seqan3/utility/char_operations/predicate.hpp>
+#include <seqan3/utility/char_operations/predicate_detail.hpp>
+#include <seqan3/utility/char_operations/pretty_print.hpp>
+#include <seqan3/utility/char_operations/transform.hpp>

--- a/include/seqan3/utility/container/all.hpp
+++ b/include/seqan3/utility/container/all.hpp
@@ -10,6 +10,12 @@
  * \author Marcel Ehrhardt <marcel.ehrhardt AT fu-berlin.de>
  */
 
+/*!\defgroup utility_container Container
+ * \brief Provides various general purpose container and concepts.
+ * \ingroup utility
+ * \see utility
+ */
+
 #pragma once
 
 #include <seqan3/utility/container/aligned_allocator.hpp>
@@ -17,9 +23,3 @@
 #include <seqan3/utility/container/dynamic_bitset.hpp>
 #include <seqan3/utility/container/small_string.hpp>
 #include <seqan3/utility/container/small_vector.hpp>
-
-/*!\defgroup utility_container Container
- * \brief Provides various general purpose container and concepts.
- * \ingroup utility
- * \see utility
- */

--- a/include/seqan3/utility/parallel/all.hpp
+++ b/include/seqan3/utility/parallel/all.hpp
@@ -10,8 +10,6 @@
  * \author Rene Rahn <rene.rahn AT fu-berlin.de>
  */
 
-#pragma once
-
 //!\cond DEV
 
 /*!\defgroup utility_parallel Parallel
@@ -31,6 +29,6 @@
  */
 //!\endcond
 
- #include <seqan3/utility/parallel/detail/latch.hpp>
- #include <seqan3/utility/parallel/detail/reader_writer_manager.hpp>
- #include <seqan3/utility/parallel/detail/spin_delay.hpp>
+#pragma once
+
+#include <seqan3/core/platform.hpp>

--- a/include/seqan3/utility/range/all.hpp
+++ b/include/seqan3/utility/range/all.hpp
@@ -10,10 +10,6 @@
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  */
 
-#pragma once
-
-#include <seqan3/utility/range/concept.hpp>
-
 /*!\defgroup utility_range Range
  * \ingroup utility
  * \brief The range module provides general purpose range concepts.
@@ -79,3 +75,7 @@
  * \sa https://ericniebler.github.io/range-v3/index.html
  * \see utility
  */
+
+#pragma once
+
+#include <seqan3/utility/range/concept.hpp>

--- a/include/seqan3/utility/simd/all.hpp
+++ b/include/seqan3/utility/simd/all.hpp
@@ -10,16 +10,6 @@
  * \brief Meta-header for the \cond DEV \link utility_simd Utility / SIMD submodule \endlink \endcond.
  */
 
-#pragma once
-
-#include <seqan3/utility/simd/algorithm.hpp>
-#include <seqan3/utility/simd/concept.hpp>
-#include <seqan3/utility/simd/detail/debug_stream_simd.hpp>
-#include <seqan3/utility/simd/simd_traits.hpp>
-#include <seqan3/utility/simd/simd.hpp>
-#include <seqan3/utility/simd/views/iota_simd.hpp>
-#include <seqan3/utility/simd/views/to_simd.hpp>
-
 //!\cond DEV
 
 /*!\defgroup utility_simd SIMD
@@ -46,3 +36,11 @@
  * \sa https://en.wikipedia.org/wiki/Streaming_SIMD_Extensions Which SIMD architectures exist?
  */
 //!\endcond
+
+#pragma once
+
+#include <seqan3/utility/simd/algorithm.hpp>
+#include <seqan3/utility/simd/concept.hpp>
+#include <seqan3/utility/simd/simd.hpp>
+#include <seqan3/utility/simd/simd_traits.hpp>
+#include <seqan3/utility/simd/views/all.hpp>

--- a/include/seqan3/utility/simd/views/all.hpp
+++ b/include/seqan3/utility/simd/views/all.hpp
@@ -10,11 +10,6 @@
  * \author Marcel Ehrhardt <marcel.ehrhardt AT fu-berlin.de>
  */
 
-#pragma once
-
-#include <seqan3/utility/simd/views/iota_simd.hpp>
-#include <seqan3/utility/simd/views/to_simd.hpp>
-
 //!\cond DEV
 
 /*!\defgroup utility_simd_views Views
@@ -24,3 +19,8 @@
  */
 
 //!\endcond
+
+#pragma once
+
+#include <seqan3/utility/simd/views/iota_simd.hpp>
+#include <seqan3/utility/simd/views/to_simd.hpp>

--- a/include/seqan3/utility/tuple/all.hpp
+++ b/include/seqan3/utility/tuple/all.hpp
@@ -10,8 +10,6 @@
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  */
 
-#pragma once
-
 /*!\defgroup utility_tuple Tuple
  * \brief Additional helper utilities for "tuple" types like std::tuple, std::pair, seqan3::pod_tuple that are not
  *        specific to a SeqAn module.
@@ -19,6 +17,10 @@
  * \see utility
  */
 
+#pragma once
+
+#include <seqan3/utility/tuple/common_tuple.hpp>
 #include <seqan3/utility/tuple/concept.hpp>
+#include <seqan3/utility/tuple/pod_tuple.hpp>
 #include <seqan3/utility/tuple/pop_front.hpp>
 #include <seqan3/utility/tuple/split.hpp>

--- a/include/seqan3/utility/type_list/all.hpp
+++ b/include/seqan3/utility/type_list/all.hpp
@@ -10,9 +10,6 @@
  * \brief Meta-header for the \link utility_type_list Utility / Type List submodule \endlink.
  */
 
-#include <seqan3/utility/type_list/traits.hpp>
-#include <seqan3/utility/type_list/type_list.hpp>
-
 /*!\defgroup utility_type_list Type List
  * \brief Provides seqan3::type_list and metaprogramming utilities for working on type lists.
  * \ingroup utility
@@ -27,3 +24,8 @@
 /*!\namespace seqan3::list_traits
  * \brief Namespace containing traits for working on seqan3::type_list.
  */
+
+#pragma once
+
+#include <seqan3/utility/type_list/traits.hpp>
+#include <seqan3/utility/type_list/type_list.hpp>

--- a/include/seqan3/utility/type_pack/all.hpp
+++ b/include/seqan3/utility/type_pack/all.hpp
@@ -10,8 +10,6 @@
  * \brief Meta-header for the \link utility_type_pack Utility / Type Pack submodule \endlink.
  */
 
-#include <seqan3/utility/type_pack/traits.hpp>
-
 /*!\defgroup utility_type_pack Type Pack
  * \brief Provides metaprogramming utilities for working on template parameter packs.
  * \ingroup utility
@@ -27,3 +25,7 @@
 /*!\namespace seqan3::pack_traits
  * \brief Namespace containing traits for working on type packs.
  */
+
+#pragma once
+
+#include <seqan3/utility/type_pack/traits.hpp>

--- a/include/seqan3/utility/type_traits/all.hpp
+++ b/include/seqan3/utility/type_traits/all.hpp
@@ -20,6 +20,5 @@
 
 #include <seqan3/utility/type_traits/basic.hpp>
 #include <seqan3/utility/type_traits/concept.hpp>
-#include <seqan3/utility/type_traits/detail/transformation_trait_or.hpp>
 #include <seqan3/utility/type_traits/function_traits.hpp>
 #include <seqan3/utility/type_traits/lazy_conditional.hpp>

--- a/include/seqan3/utility/views/all.hpp
+++ b/include/seqan3/utility/views/all.hpp
@@ -10,23 +10,6 @@
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  */
 
-#pragma once
-
-#include <seqan3/utility/views/chunk.hpp>
-#include <seqan3/utility/views/convert.hpp>
-#include <seqan3/utility/views/deep.hpp>
-#include <seqan3/utility/views/elements.hpp>
-#include <seqan3/utility/views/enforce_random_access.hpp>
-#include <seqan3/utility/views/interleave.hpp>
-#include <seqan3/utility/views/join_with.hpp>
-#include <seqan3/utility/views/pairwise_combine.hpp>
-#include <seqan3/utility/views/repeat_n.hpp>
-#include <seqan3/utility/views/repeat.hpp>
-#include <seqan3/utility/views/single_pass_input.hpp>
-#include <seqan3/utility/views/to.hpp>
-#include <seqan3/utility/views/type_reduce.hpp>
-#include <seqan3/utility/views/zip.hpp>
-
 /*!\defgroup utility_views Views
  * \brief Views are "lazy range combinators" that offer modified views onto other ranges.
  * \ingroup utility
@@ -181,3 +164,21 @@
  *
  * See the \link views views submodule \endlink of the range module for more details.
  */
+
+#pragma once
+
+#include <seqan3/utility/views/chunk.hpp>
+#include <seqan3/utility/views/convert.hpp>
+#include <seqan3/utility/views/deep.hpp>
+#include <seqan3/utility/views/elements.hpp>
+#include <seqan3/utility/views/enforce_random_access.hpp>
+#include <seqan3/utility/views/interleave.hpp>
+#include <seqan3/utility/views/join_with.hpp>
+#include <seqan3/utility/views/pairwise_combine.hpp>
+#include <seqan3/utility/views/repeat.hpp>
+#include <seqan3/utility/views/repeat_n.hpp>
+#include <seqan3/utility/views/single_pass_input.hpp>
+#include <seqan3/utility/views/slice.hpp>
+#include <seqan3/utility/views/to.hpp>
+#include <seqan3/utility/views/type_reduce.hpp>
+#include <seqan3/utility/views/zip.hpp>

--- a/test/scripts/create_all_hpp.sh
+++ b/test/scripts/create_all_hpp.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# -----------------------------------------------------------------------------------------------------
+# Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
+# Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
+# This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+# shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+# -----------------------------------------------------------------------------------------------------
+#
+# Usage: create_all_hpp.sh <SeqAn3 root directory>
+# Will create all.hpp in all subdirectories
+
+# Directories (+ subdirectories) to ignore (not creating any all.hpp files in these folders)
+exceptionList=(
+    include/seqan3/std
+    include/seqan3/contrib
+    /detail
+    /exposition_only
+    include/seqan3/core/concept
+    include/seqan3/utility/concept
+)
+
+# prints the header of a typical all.hpp file
+print_header()
+{
+CURRENT_YEAR=$1
+cat << EOF
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-${CURRENT_YEAR}, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-${CURRENT_YEAR}, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+EOF
+}
+
+# prints a list of "#include <file>" lines, typical for all.hpp files
+print_includes()
+{
+    directory="$1"
+    echo -ne "\n#pragma once\n\n"
+    hasIncludes=0
+
+    for path in $(find "${directory}"/* -maxdepth 0); do
+        incl_path="$(realpath --relative-to include "${path}")"
+        if [ "${path}" == "${directory}/all.hpp" ]; then
+            continue
+        elif [ -f "${path}" ]; then
+            if ([[ "${path}" == *.hpp ]] || [[ "${path}" == *.h ]]) && [[ ! "${path}" == */detail.hpp ]]; then
+                hasIncludes=1
+               echo "#include <${incl_path}>"
+            fi
+        elif [[ "${path}" == */detail ]] || [[ "${path}" == */exposition_only ]]; then
+            continue
+        else
+            # In every subdirectory (excluding detail) we generate a all.hpp file
+            echo "#include <${incl_path}/all.hpp>"
+            hasIncludes=1
+        fi
+    done
+    if [[ "${hasIncludes}" -eq "0" ]]; then
+        echo "#include <seqan3/core/platform.hpp>"
+    fi
+}
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: create_all_hpp.sh <SeqAn3 root directory>"
+    exit 1
+fi
+
+if [[ ! -d $1 ]]; then
+    echo "The directory $1 does not exist."
+    exit 1
+fi
+
+if [[ ! -f $1/include/seqan3/version.hpp ]]; then
+    echo "The directory $1 does not seem to be the SeqAn3 root directory."
+    echo "Cannot find $1/include/seqan3/version.hpp."
+    exit 1
+fi
+CURRENT_YEAR=$(date "+%Y")
+
+# Iterate through all folders
+for directory in $(find include/seqan3/* -type d); do
+    # check if directory is in the exception list
+    found=0
+    for entry in "${exceptionList[@]}"; do
+        if [ ! -z $(echo "${directory}" | grep $entry) ]; then
+            found=1;
+            break;
+        fi
+    done
+    if [ ${found} -eq 1 ]; then
+        continue
+    fi
+
+    # create all.hpp
+    if [ ! -f "${directory}/all.hpp" ]; then
+        echo "missing all.hpp file in ${directory}"
+        (
+            print_header ${CURRENT_YEAR}
+            print_includes "${directory}"
+
+        ) > "${directory}/all.hpp"
+    else
+        # check if license text has changed
+        HEADER_LINES=$(print_header ${CURRENT_YEAR} | wc -l)
+        licence_changes=$(head -n ${HEADER_LINES} "${directory}/all.hpp" | diff /dev/stdin <( print_header ${CURRENT_YEAR}) | wc -c)
+
+        # check if include list has changed
+        INCLUDE_LINES=$(print_includes "${directory}" | wc -l)
+        include_changes=$(tail -n ${INCLUDE_LINES} "${directory}/all.hpp" | diff /dev/stdin <( print_includes "${directory}" ) | wc -c)
+
+        if [ "$licence_changes" -gt 0 ] || [ "$include_changes" -gt 0 ]; then
+            echo "License text or includes changed, updating ${directory}/all.hpp"
+            tmp_file=$(mktemp);
+            # create new license text and include list, but keep doxygen documentation
+            cp "${directory}/all.hpp" "${tmp_file}"
+            (
+                PRAGMA_LINE=$(cat "${tmp_file}" | grep -n "#pragma once" | cut -f 1 -d ':')
+                print_header ${CURRENT_YEAR}
+                tail ${tmp_file} -n +$(expr 1 + ${HEADER_LINES}) | grep -v "#include" | grep -v "#pragma once"
+                print_includes "${directory}"
+            ) | cat -s | sed -e :a -e '/^\n*$/{$d;N;};/\n$/ba' >  "${directory}/all.hpp"
+            rm $tmp_file
+        fi
+    fi
+done

--- a/test/snippet/utility/simd/detail/default_simd_max_length.cpp
+++ b/test/snippet/utility/simd/detail/default_simd_max_length.cpp
@@ -1,5 +1,6 @@
 #include <seqan3/core/debug_stream.hpp>
 #include <seqan3/utility/simd/all.hpp>
+#include <seqan3/utility/simd/detail/debug_stream_simd.hpp>
 
 int main()
 {

--- a/test/snippet/utility/simd/fill.cpp
+++ b/test/snippet/utility/simd/fill.cpp
@@ -1,5 +1,6 @@
 #include <seqan3/core/debug_stream.hpp>
 #include <seqan3/utility/simd/all.hpp>
+#include <seqan3/utility/simd/detail/debug_stream_simd.hpp>
 
 using uint16x8_t = seqan3::simd::simd_type_t<uint16_t, 8>;
 

--- a/test/snippet/utility/simd/iota.cpp
+++ b/test/snippet/utility/simd/iota.cpp
@@ -1,5 +1,6 @@
 #include <seqan3/core/debug_stream.hpp>
 #include <seqan3/utility/simd/all.hpp>
+#include <seqan3/utility/simd/detail/debug_stream_simd.hpp>
 
 using uint16x8_t = seqan3::simd::simd_type_t<uint16_t, 8>;
 

--- a/test/snippet/utility/simd/simd.cpp
+++ b/test/snippet/utility/simd/simd.cpp
@@ -1,5 +1,6 @@
 #include <seqan3/core/debug_stream.hpp>
 #include <seqan3/utility/simd/all.hpp>
+#include <seqan3/utility/simd/detail/debug_stream_simd.hpp>
 
 using uint16x8_t = seqan3::simd::simd_type_t<uint16_t, 8>;
 

--- a/test/snippet/utility/simd/simd_extract.cpp
+++ b/test/snippet/utility/simd/simd_extract.cpp
@@ -1,5 +1,6 @@
 #include <seqan3/core/debug_stream.hpp>
 #include <seqan3/utility/simd/all.hpp>
+#include <seqan3/utility/simd/detail/debug_stream_simd.hpp>
 
 using int16x8_t = seqan3::simd::simd_type_t<int16_t, 8>;
 

--- a/test/snippet/utility/simd/simd_load.cpp
+++ b/test/snippet/utility/simd/simd_load.cpp
@@ -1,5 +1,6 @@
 #include <seqan3/core/debug_stream.hpp>
 #include <seqan3/utility/simd/all.hpp>
+#include <seqan3/utility/simd/detail/debug_stream_simd.hpp>
 
 using uint16x8_t = seqan3::simd::simd_type_t<uint16_t, 8>;
 

--- a/test/snippet/utility/simd/simd_transpose.cpp
+++ b/test/snippet/utility/simd/simd_transpose.cpp
@@ -2,6 +2,7 @@
 
 #include <seqan3/core/debug_stream.hpp>
 #include <seqan3/utility/simd/all.hpp>
+#include <seqan3/utility/simd/detail/debug_stream_simd.hpp>
 
 using uint8x4_t = seqan3::simd::simd_type_t<uint8_t, 4>;
 

--- a/test/snippet/utility/simd/simd_upcast.cpp
+++ b/test/snippet/utility/simd/simd_upcast.cpp
@@ -1,5 +1,6 @@
 #include <seqan3/core/debug_stream.hpp>
 #include <seqan3/utility/simd/all.hpp>
+#include <seqan3/utility/simd/detail/debug_stream_simd.hpp>
 
 using int16x8_t = seqan3::simd::simd_type_t<int16_t, 8>;
 using int32x4_t = seqan3::simd::simd_type_t<int32_t, 4>;

--- a/test/snippet/utility/simd/views/iota_simd.cpp
+++ b/test/snippet/utility/simd/views/iota_simd.cpp
@@ -1,5 +1,6 @@
 #include <seqan3/core/debug_stream.hpp>
 #include <seqan3/utility/simd/all.hpp>
+#include <seqan3/utility/simd/detail/debug_stream_simd.hpp>
 
 // The simd type with 8 unsigned shorts.
 using uint16x8_t = seqan3::simd_type_t<uint16_t, 8>;

--- a/test/snippet/utility/simd/views/iota_simd_transform.cpp
+++ b/test/snippet/utility/simd/views/iota_simd_transform.cpp
@@ -2,6 +2,7 @@
 
 #include <seqan3/core/debug_stream.hpp>
 #include <seqan3/utility/simd/all.hpp>
+#include <seqan3/utility/simd/detail/debug_stream_simd.hpp>
 
 // The simd type with 8 unsigned shorts.
 using uint16x8_t = seqan3::simd_type_t<uint16_t, 8>;

--- a/test/snippet/utility/simd/views/to_simd.cpp
+++ b/test/snippet/utility/simd/views/to_simd.cpp
@@ -3,6 +3,7 @@
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/core/debug_stream.hpp>
 #include <seqan3/utility/simd/all.hpp>
+#include <seqan3/utility/simd/detail/debug_stream_simd.hpp>
 
 using uint16x8_t = seqan3::simd_type_t<uint16_t, 8>;
 


### PR DESCRIPTION
Part of: https://github.com/seqan/product_backlog/issues/400


Added a script that creates `all.hpp` file. It also checks already checked scripts.
The structure of an all.hpp files is assumed to be as follow:
```
<License text>
<Doxygen description of the modules>
#pragma once

#include <xyz/subpath1>
...
```

This PR has 3 big changes (=commits)
- 1. add a script that could generate proper all.hpp files
- 2. changing a few snippets that otherwise would break when using the new correct all.hpp files
- 3. adjusting all all.hpp by using the script from the first commit.