### PR TITLE
[FIX] relax seqan3::views::kmer_hash requirements to be C++20 compatible

### DIFF
--- a/include/seqan3/search/views/kmer_hash.hpp
+++ b/include/seqan3/search/views/kmer_hash.hpp
@@ -56,12 +56,12 @@ public:
     /*!\name Constructors, destructor and assignment
      * \{
      */
-    kmer_hash_view()                                       = default; //!< Defaulted.
-    kmer_hash_view(kmer_hash_view const & rhs)             = default; //!< Defaulted.
-    kmer_hash_view(kmer_hash_view && rhs)                  = default; //!< Defaulted.
+    kmer_hash_view() requires std::default_initializable<urng_t> = default; //!< Defaulted.
+    kmer_hash_view(kmer_hash_view const & rhs) = default; //!< Defaulted.
+    kmer_hash_view(kmer_hash_view && rhs) = default; //!< Defaulted.
     kmer_hash_view & operator=(kmer_hash_view const & rhs) = default; //!< Defaulted.
-    kmer_hash_view & operator=(kmer_hash_view && rhs)      = default; //!< Defaulted.
-    ~kmer_hash_view()                                      = default; //!< Defaulted.
+    kmer_hash_view & operator=(kmer_hash_view && rhs) = default; //!< Defaulted.
+    ~kmer_hash_view() = default; //!< Defaulted.
 
     /*!\brief Construct from a view and a given shape.
      * \throws std::invalid_argument if hashes resulting from the shape/alphabet combination cannot be represented in

--- a/test/unit/search/views/minimiser_test.cpp
+++ b/test/unit/search/views/minimiser_test.cpp
@@ -75,7 +75,9 @@ struct iterator_fixture<two_ranges_iterator_type> : public ::testing::Test
 
     using reverse_kmer_hash_view_t = decltype(rev_kmer_view(text));
 
-    using test_range_t = decltype(seqan3::detail::minimiser_view{kmer_hash_view_t{}, reverse_kmer_hash_view_t{}, 5});
+    using test_range_t = decltype(seqan3::detail::minimiser_view{std::declval<kmer_hash_view_t &>(),
+                                                                 std::declval<reverse_kmer_hash_view_t &>(),
+                                                                 5});
     test_range_t test_range = seqan3::detail::minimiser_view{vec, rev_kmer_view(text), 5};
 };
 


### PR DESCRIPTION
https://github.com/seqan/product_backlog/issues/403