### PR TITLE
[FIX] relax seqan3::detail::algorithm_executor_blocking requirements to be C++20 compatible

### DIFF
--- a/include/seqan3/core/algorithm/detail/algorithm_executor_blocking.hpp
+++ b/include/seqan3/core/algorithm/detail/algorithm_executor_blocking.hpp
@@ -366,7 +366,7 @@ private:
     execution_handler_t exec_handler{};
 
     //!\brief The underlying resource.
-    resource_type resource; // this is a std::ranges::view
+    resource_type resource; // a std::ranges::view
     //!\brief The iterator over the resource that stores the current state of the executor.
     resource_iterator_type resource_it{};
     //!\brief The algorithm to invoke.


### PR DESCRIPTION
Part of https://github.com/seqan/product_backlog/issues/403

Note this needed some more changes to the move- assignment and constructor, as we otherwise would do operations on a possible stale iterator.