### PR TITLE
[FIX] error: testing if a concept-id is a valid expression; add ‘requires’ to check satisfaction [-Werror=missing-requires]

### DIFF
--- a/include/seqan3/utility/concept/exposition_only/core_language.hpp
+++ b/include/seqan3/utility/concept/exposition_only/core_language.hpp
@@ -31,10 +31,10 @@ SEQAN3_CONCEPT weakly_equality_comparable_with =
     requires(std::remove_reference_t<T> const & t,
              std::remove_reference_t<U> const & u)
     {
-        std::convertible_to<decltype(t == u), bool>;
-        std::convertible_to<decltype(t != u), bool>;
-        std::convertible_to<decltype(u == t), bool>;
-        std::convertible_to<decltype(u != t), bool>;
+        requires std::convertible_to<decltype(t == u), bool>;
+        requires std::convertible_to<decltype(t != u), bool>;
+        requires std::convertible_to<decltype(u == t), bool>;
+        requires std::convertible_to<decltype(u != t), bool>;
     };
 //!\endcond
 
@@ -56,15 +56,15 @@ template <typename t1, typename t2>
 SEQAN3_CONCEPT weakly_ordered_with = requires (std::remove_reference_t<t1> const & v1,
                                                std::remove_reference_t<t2> const & v2)
 {
-    std::convertible_to<decltype(v1 <  v2), bool>;
-    std::convertible_to<decltype(v1 <= v2), bool>;
-    std::convertible_to<decltype(v1 >  v2), bool>;
-    std::convertible_to<decltype(v1 >= v2), bool>;
+    requires std::convertible_to<decltype(v1 <  v2), bool>;
+    requires std::convertible_to<decltype(v1 <= v2), bool>;
+    requires std::convertible_to<decltype(v1 >  v2), bool>;
+    requires std::convertible_to<decltype(v1 >= v2), bool>;
 
-    std::convertible_to<decltype(v2 <  v1), bool>;
-    std::convertible_to<decltype(v2 <= v1), bool>;
-    std::convertible_to<decltype(v2 >  v1), bool>;
-    std::convertible_to<decltype(v2 >= v1), bool>;
+    requires std::convertible_to<decltype(v2 <  v1), bool>;
+    requires std::convertible_to<decltype(v2 <= v1), bool>;
+    requires std::convertible_to<decltype(v2 >  v1), bool>;
+    requires std::convertible_to<decltype(v2 >= v1), bool>;
 };
 //!\endcond
 

--- a/include/seqan3/utility/range/concept.hpp
+++ b/include/seqan3/utility/range/concept.hpp
@@ -91,14 +91,14 @@ SEQAN3_CONCEPT pseudo_random_access_iterator =
     std::sized_sentinel_for<iterator_t, iterator_t> &&
     requires (iterator_t i, iterator_t const j, std::iter_difference_t<iterator_t> const n)
 {
-    std::same_as<decltype( i += n ), iterator_t &>;
-    std::same_as<decltype( j +  n ), iterator_t>;
-    std::same_as<decltype( n +  j ), iterator_t>;
-    std::same_as<decltype(   --i  ), iterator_t &>;
-    std::same_as<decltype(   i--  ), iterator_t>;
-    std::same_as<decltype( i -= n ), iterator_t &>;
-    std::same_as<decltype( j -  n ), iterator_t>;
-    std::same_as<decltype(  j[n]  ), std::iter_reference_t<iterator_t>>;
+    requires std::same_as<decltype( i += n ), iterator_t &>;
+    requires std::same_as<decltype( j +  n ), iterator_t>;
+    requires std::same_as<decltype( n +  j ), iterator_t>;
+    requires std::same_as<decltype(   --i  ), iterator_t &>;
+    requires std::same_as<decltype(   i--  ), iterator_t>;
+    requires std::same_as<decltype( i -= n ), iterator_t &>;
+    requires std::same_as<decltype( j -  n ), iterator_t>;
+    requires std::same_as<decltype(  j[n]  ), std::iter_reference_t<iterator_t>>;
 };
 //!\endcond
 


### PR DESCRIPTION
Part of https://github.com/seqan/product_backlog/issues/402

```
/seqan3/include/seqan3/utility/concept/exposition_only/core_language.hpp:59:5: error: testing if a concept-id is a valid expression; add ‘requires’ to check satisfaction [-Werror=missing-requires]
   59 |     std::convertible_to<decltype(v1 <  v2), bool>;
      |     ^
      |     requires
```