### PR TITLE
[FIX] relax seqan3::views::to_simd requirements to be C++20 compatible

### DIFF
--- a/include/seqan3/utility/simd/views/to_simd.hpp
+++ b/include/seqan3/utility/simd/views/to_simd.hpp
@@ -64,8 +64,10 @@ private:
                   "The underlying range must model forward_range.");
     static_assert(std::ranges::input_range<std::ranges::range_value_t<urng_t>>,
                   "Expects the value type of the underlying range to be an input_range.");
-    static_assert(std::default_initializable<std::ranges::range_value_t<urng_t>>,
-                  "Expects the inner range to be default constructible.");
+    static_assert(std::default_initializable<std::ranges::iterator_t<std::ranges::range_value_t<urng_t>>>,
+                  "Expects the inner range iterator to be default initializable.");
+    static_assert(std::default_initializable<std::ranges::sentinel_t<std::ranges::range_value_t<urng_t>>>,
+                  "Expects the inner range sentinel to be default initializable.");
     static_assert(semialphabet<std::ranges::range_value_t<std::ranges::range_value_t<urng_t>>>,
                   "Expects semi-alphabet as value type of the inner range.");
 
@@ -106,7 +108,7 @@ public:
     /*!\name Constructors, destructor and assignment
      * \{
      */
-    constexpr view_to_simd() = default; //!< Defaulted.
+    constexpr view_to_simd() requires std::default_initializable<urng_t> = default; //!< Defaulted.
     constexpr view_to_simd(view_to_simd const &) = default; //!< Defaulted.
     constexpr view_to_simd(view_to_simd &&) = default; //!< Defaulted.
     constexpr view_to_simd & operator=(view_to_simd const &) = default; //!< Defaulted.


### PR DESCRIPTION
Part of https://github.com/seqan/product_backlog/issues/403

```
/seqan3/test/unit/utility/simd/views/to_simd_test.cpp:349:48:   required from ‘void view_to_simd_test_issue_1813_Test<gtest_TypeParam_>::TestBody() [with gtest_TypeParam_ = std::tuple<std::deque<seqan3::dna4, std::allocator<seqan3::dna4> >, __vector(1) signed char>]’
/seqan3/test/unit/utility/simd/views/to_simd_test.cpp:326:1:   required from here
/seqan3/include/seqan3/utility/simd/views/to_simd.hpp:67:24: error: static assertion failed: Expects the inner range to be default constructible.
   67 |     static_assert(std::default_initializable<std::ranges::range_value_t<urng_t>>,
      |                   ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/seqan3/include/seqan3/utility/simd/views/to_simd.hpp:67:24: note: ‘default_initializable<std::ranges::take_view<std::ranges::ref_view<std::deque<seqan3::dna4, std::allocator<seqan3::dna4> > > > >’ evaluates to false
/seqan3/include/seqan3/utility/simd/views/to_simd.hpp:67:24: note: constraints not satisfied
In file included from /opt/gcc/gcc-git/include/c++/12.0.0/compare:39,
                 from /opt/gcc/gcc-git/include/c++/12.0.0/bits/stl_pair.h:65,
                 from /opt/gcc/gcc-git/include/c++/12.0.0/bits/stl_algobase.h:64,
                 from /opt/gcc/gcc-git/include/c++/12.0.0/memory:63,
                 from /seqan3-build/gcc-git-debug-std20/_deps/gtest_fetch_content-src/googletest/include/gtest/gtest.h:57,
                 from /seqan3/test/unit/utility/simd/views/to_simd_test.cpp:8:
/opt/gcc/gcc-git/include/c++/12.0.0/concepts:138:13:   required for the satisfaction of ‘constructible_from<_Tp>’ [with _Tp = std::ranges::take_view<std::ranges::ref_view<std::deque<seqan3::dna4, std::allocator<seqan3::dna4> > > >]
/opt/gcc/gcc-git/include/c++/12.0.0/concepts:139:30: note: the expression ‘is_constructible_v<_Tp, _Args ...> [with _Tp = std::ranges::take_view<std::ranges::ref_view<std::deque<seqan3::dna4, std::allocator<seqan3::dna4> > > >; _Args = {}]’ evaluated to ‘false’
  139 |       = destructible<_Tp> && is_constructible_v<_Tp, _Args...>;
      |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```