### PR TITLE
[TEST] test_sized_sentinel<output_iterator> might not fulfill std::semiregular

### DIFF
--- a/test/unit/std/concept/iterator_test.cpp
+++ b/test/unit/std/concept/iterator_test.cpp
@@ -71,6 +71,8 @@ TEST(iterator_concepts, Iterator)
 
 TEST(iterator_concepts, sentinel_for)
 {
+    EXPECT_TRUE((std::is_same_v<char, input_or_output_iter_value_t<std::cpp20::ostream_iterator<char>>>));
+
     EXPECT_TRUE((std::sentinel_for<test_sentinel<char>,
                                           input_iterator>));
     EXPECT_TRUE((std::sentinel_for<test_sentinel<char>,
@@ -91,10 +93,6 @@ TEST(iterator_concepts, sentinel_for)
     EXPECT_TRUE((std::sentinel_for<test_sized_sentinel<
                                           input_iterator>,
                                           input_iterator>));
-    EXPECT_TRUE((std::is_same_v<char, input_or_output_iter_value_t<std::cpp20::ostream_iterator<char>>>));
-    EXPECT_TRUE((std::sentinel_for<test_sized_sentinel<
-                                          output_iterator>,
-                                          output_iterator>));
     EXPECT_TRUE((std::sentinel_for<test_sized_sentinel<
                                           forward_iterator>,
                                           forward_iterator>));


### PR DESCRIPTION
Part of https://github.com/seqan/product_backlog/issues/403

`std::ostream_iterator<char>` does not have a default constructor and thus `test_sized_sentinel<...>` can't be `std::semiregular`.

```
/seqan3/test/unit/std/concept/iterator_test.cpp:95:25: error: static assertion failed
   95 |     static_assert((std::sentinel_for<test_sized_sentinel<
      |                   ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   96 |                                           output_iterator>,
      |                                           ~~~~~~~~~~~~~~~~~
   97 |                                           output_iterator>));
      |                                           ~~~~~~~~~~~~~~~~~
/seqan3/test/unit/std/concept/iterator_test.cpp:95:25: note: constraints not satisfied
In file included from /opt/gcc/gcc-git/include/c++/12.0.0/compare:39,
                 from /opt/gcc/gcc-git/include/c++/12.0.0/bits/stl_pair.h:65,
                 from /opt/gcc/gcc-git/include/c++/12.0.0/bits/stl_algobase.h:64,
                 from /opt/gcc/gcc-git/include/c++/12.0.0/memory:63,
                 from /seqan3-build/gcc-git-debug-std20/_deps/gtest_fetch_content-src/googletest/include/gtest/gtest.h:57,
                 from /seqan3/test/unit/std/concept/iterator_test.cpp:8:
/opt/gcc/gcc-git/include/c++/12.0.0/concepts:136:13:   required for the satisfaction of ‘constructible_from<_Tp>’ [with _Tp = test_sized_sentinel<std::ostream_iterator<char, char, std::char_traits<char> > >]
/opt/gcc/gcc-git/include/c++/12.0.0/concepts:141:13:   required for the satisfaction of ‘default_initializable<_Tp>’ [with _Tp = test_sized_sentinel<std::ostream_iterator<char, char, std::char_traits<char> > >]
/opt/gcc/gcc-git/include/c++/12.0.0/concepts:256:13:   required for the satisfaction of ‘semiregular<_Sent>’ [with _Sent = test_sized_sentinel<std::ostream_iterator<char, char, std::char_traits<char> > >]
/opt/gcc/gcc-git/include/c++/12.0.0/concepts:137:30: note: the expression ‘is_constructible_v<_Tp, _Args ...> [with _Tp = test_sized_sentinel<std::ostream_iterator<char, char, std::char_traits<char> > >; _Args = {}]’ evaluated to ‘false’
  137 |       = destructible<_Tp> && is_constructible_v<_Tp, _Args...>;
      |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```