### PR TITLE
[FIX] gcc-12, error: ignoring return value of [...], declared with attribute ‘nodiscard’ [-Werror=unused-result]

### DIFF
--- a/include/seqan3/io/sam_file/detail/cigar.hpp
+++ b/include/seqan3/io/sam_file/detail/cigar.hpp
@@ -151,7 +151,7 @@ inline std::tuple<std::vector<cigar>, int32_t, int32_t> parse_cigar(cigar_input_
     {
         auto buff_end = (std::ranges::copy(cigar_view | detail::take_until_or_throw(!is_digit), buffer.data())).out;
         cigar_operation = *std::ranges::begin(cigar_view);
-        std::ranges::next(std::ranges::begin(cigar_view));
+        ++std::ranges::begin(cigar_view);
 
         if (std::from_chars(buffer.begin(), buff_end, cigar_count).ec != std::errc{})
             throw format_error{"Corrupted cigar string encountered"};

--- a/include/seqan3/io/sam_file/format_bam.hpp
+++ b/include/seqan3/io/sam_file/format_bam.hpp
@@ -320,7 +320,7 @@ inline void format_bam::read_alignment_record(stream_type & stream,
 
             string_buffer.resize(l_name - 1);
             std::ranges::copy_n(std::ranges::begin(stream_view), l_name - 1, string_buffer.data()); // copy without \0 character
-            std::ranges::next(std::ranges::begin(stream_view)); // skip \0 character
+            ++std::ranges::begin(stream_view); // skip \0 character
 
             read_integral_byte_field(stream_view, l_ref);
 
@@ -407,7 +407,7 @@ inline void format_bam::read_alignment_record(stream_type & stream,
         read_forward_range_field(id_view, id); // field::id
     else
         detail::consume(id_view);
-    std::ranges::next(std::ranges::begin(stream_view)); // skip '\0'
+    ++std::ranges::begin(stream_view); // skip '\0'
 
     // read cigar string
     // -------------------------------------------------------------------------------------------------------------
@@ -442,7 +442,7 @@ inline void format_bam::read_alignment_record(stream_type & stream,
             {
                 detail::consume(seq_stream);
                 if (core.l_seq & 1)
-                    std::ranges::next(std::ranges::begin(stream_view));
+                    ++std::ranges::begin(stream_view);
             };
 
             if constexpr (!detail::decays_to_ignore_v<align_type>)
@@ -511,7 +511,7 @@ inline void format_bam::read_alignment_record(stream_type & stream,
             {
                 dna16sam d = dna16sam{}.assign_rank(std::min(15, static_cast<uint8_t>(*std::ranges::begin(stream_view)) >> 4));
                 seq.push_back(from_dna16[to_rank(d)]);
-                std::ranges::next(std::ranges::begin(stream_view));
+                ++std::ranges::begin(stream_view);
             }
 
             if constexpr (!detail::decays_to_ignore_v<align_type>)

--- a/include/seqan3/io/sam_file/format_sam.hpp
+++ b/include/seqan3/io/sam_file/format_sam.hpp
@@ -457,7 +457,7 @@ inline void format_sam::read_alignment_record(stream_type & stream,
         }
         else
         {
-            std::ranges::next(std::ranges::begin(field_view)); // skip '*'
+            ++std::ranges::begin(field_view); // skip '*'
         }
     }
     else
@@ -570,7 +570,7 @@ inline void format_sam::read_alignment_record(stream_type & stream,
     }
     else
     {
-        std::ranges::next(std::ranges::begin(field_view)); // skip '*'
+        ++std::ranges::begin(field_view); // skip '*'
     }
 
     // Field 11:  Quality
@@ -597,7 +597,7 @@ inline void format_sam::read_alignment_record(stream_type & stream,
     // -------------------------------------------------------------------------------------------------------------
     while (is_char<'\t'>(*std::ranges::begin(stream_view))) // read all tags if present
     {
-        std::ranges::next(std::ranges::begin(stream_view)); // skip tab
+        ++std::ranges::begin(stream_view); // skip tab
         auto stream_until_tab_or_end = stream_view | detail::take_until_or_throw(tab_or_end);
         if constexpr (!detail::decays_to_ignore_v<tag_dict_type>)
             read_sam_dict_field(stream_until_tab_or_end, tag_dict);
@@ -943,7 +943,7 @@ inline void format_sam::read_sam_dict_vector(seqan3::detail::sam_tag_variant & v
         tmp_vector.push_back(value);
 
         if (is_char<','>(*std::ranges::begin(stream_view)))
-            std::ranges::next(std::ranges::begin(stream_view)); // skip ','
+            ++std::ranges::begin(stream_view); // skip ','
     }
     variant = std::move(tmp_vector);
 }
@@ -1011,20 +1011,20 @@ inline void format_sam::read_sam_dict_field(stream_view_type && stream_view, sam
        VALUE's and the inner value type is identified by the character following ':', one of [cCsSiIf].
     */
     uint16_t tag = static_cast<uint16_t>(*std::ranges::begin(stream_view)) << 8;
-    std::ranges::next(std::ranges::begin(stream_view)); // skip char read before
+    ++std::ranges::begin(stream_view); // skip char read before
     tag += static_cast<uint16_t>(*std::ranges::begin(stream_view));
-    std::ranges::next(std::ranges::begin(stream_view)); // skip char read before
-    std::ranges::next(std::ranges::begin(stream_view)); // skip ':'
+    ++std::ranges::begin(stream_view); // skip char read before
+    ++std::ranges::begin(stream_view); // skip ':'
     char type_id = *std::ranges::begin(stream_view);
-    std::ranges::next(std::ranges::begin(stream_view)); // skip char read before
-    std::ranges::next(std::ranges::begin(stream_view)); // skip ':'
+    ++std::ranges::begin(stream_view); // skip char read before
+    ++std::ranges::begin(stream_view); // skip ':'
 
     switch (type_id)
     {
         case 'A' : // char
         {
             target[tag] = static_cast<char>(*std::ranges::begin(stream_view));
-            std::ranges::next(std::ranges::begin(stream_view)); // skip char that has been read
+            ++std::ranges::begin(stream_view); // skip char that has been read
             break;
         }
         case 'i' : // int32_t
@@ -1054,8 +1054,8 @@ inline void format_sam::read_sam_dict_field(stream_view_type && stream_view, sam
         case 'B' : // Array. Value type depends on second char [cCsSiIf]
         {
             char array_value_type_id = *std::ranges::begin(stream_view);
-            std::ranges::next(std::ranges::begin(stream_view)); // skip char read before
-            std::ranges::next(std::ranges::begin(stream_view)); // skip first ','
+            ++std::ranges::begin(stream_view); // skip char read before
+            ++std::ranges::begin(stream_view); // skip first ','
 
             switch (array_value_type_id)
             {


### PR DESCRIPTION
Part of https://github.com/seqan/product_backlog/issues/402

```
In file included from /seqan3/include/seqan3/io/sam_file/header.hpp:21,
                 from /seqan3/test/unit/io/sam_file/sam_file_record_test.cpp:20:
/seqan3/include/seqan3/io/sam_file/detail/cigar.hpp: In instantiation of ‘std::tuple<std::vector<seqan3::cigar, std::allocator<seqan3::cigar> >, int, int> seqan3::detail::parse_cigar(cigar_input_type&&) [with cigar_input_type = std::basic_string_view<char>]’:
/seqan3/test/include/seqan3/test/literal/cigar_literal.hpp:24:51:   required from here
/seqan3/include/seqan3/io/sam_file/detail/cigar.hpp:154:26: error: ignoring return value of ‘constexpr _It std::ranges::__next_fn::operator()(_It) const [with _It = seqan3::detail::basic_iterator<seqan3::detail::single_pass_input_view<std::basic_string_view<char> > >]’, declared with attribute ‘nodiscard’ [-Werror=unused-result]
  154 |         std::ranges::next(std::ranges::begin(cigar_view));
      |         ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```