### PR TITLE
[DOC] link core entities to submodule page

### DIFF
--- a/include/seqan3/core/algorithm/algorithm_result_generator_range.hpp
+++ b/include/seqan3/core/algorithm/algorithm_result_generator_range.hpp
@@ -38,6 +38,8 @@ namespace seqan3
  * Note that the required type is not enforced in order to test this class without adding the entire machinery for
  * the seqan3::detail::algorithm_executor_blocking.
  * \endif
+ *
+ * \see core_algorithm
  */
 template <typename algorithm_executor_type>
 class algorithm_result_generator_range

--- a/include/seqan3/core/concept/cereal.hpp
+++ b/include/seqan3/core/concept/cereal.hpp
@@ -34,6 +34,8 @@ namespace seqan3
  *
  * \attention
  * The cereal library is an optional dependency of SeqAn, if it is not found **no types** satisfy this concept.
+ *
+ * \see core_concept
  */
 //!\cond
 #if SEQAN3_WITH_CEREAL
@@ -55,6 +57,8 @@ SEQAN3_CONCEPT cereal_output_archive = false;
  *
  * \attention
  * The cereal library is an optional dependency of SeqAn, if it is not found **no types** satisfy this concept.
+ *
+ * \see core_concept
  */
 //!\cond
 #if SEQAN3_WITH_CEREAL
@@ -72,6 +76,8 @@ SEQAN3_CONCEPT cereal_input_archive = false;
  *
  * \attention
  * The cereal library is an optional dependency of SeqAn, if it is not found **no types** satisfy this concept.
+ *
+ * \see core_concept
  */
 //!\cond
 #if SEQAN3_WITH_CEREAL
@@ -93,6 +99,8 @@ SEQAN3_CONCEPT cereal_archive = false;
  *
  * \attention
  * The cereal library is an optional dependency of SeqAn, if it is not found **no types** satisfy this concept.
+ *
+ * \see core_concept
  */
 //!\cond
 #if SEQAN3_WITH_CEREAL

--- a/include/seqan3/core/configuration/pipeable_config_element.hpp
+++ b/include/seqan3/core/configuration/pipeable_config_element.hpp
@@ -25,6 +25,8 @@ namespace seqan3
  *
  * An empty base class which is used by the algorithm configurations to be identified as a configuration element and
  * to compose an algorithm configuration using the pipe-operator.
+ *
+ * \see core_configuration
  */
 struct pipeable_config_element
 {};

--- a/include/seqan3/core/debug_stream/debug_stream_type.hpp
+++ b/include/seqan3/core/debug_stream/debug_stream_type.hpp
@@ -57,6 +57,8 @@ constexpr bool add_enum_bitwise_operators<fmtflags2> = true;
  * data structures are visualised more elaborately via the debug stream and there are extra flags to configure it
  * (seqan3::fmtflags2).
  *
+ * \see core_debug_stream
+ *
  * # Example
  *
  *  Simple usage:

--- a/include/seqan3/core/range/type_traits.hpp
+++ b/include/seqan3/core/range/type_traits.hpp
@@ -64,6 +64,7 @@ namespace seqan3
  * \details
  *
  * Attention, this transformation trait implicitly removes cv-qualifiers on all value_types except the one returned.
+ * \see core_range
  */
 template <typename t>
 //!\cond


### PR DESCRIPTION
Part of https://github.com/seqan/product_backlog/issues/393

Nothing to be done:
1. There is no public API in core
2. Landing page has description
3. Checked and didn't find any entries appearing twice

PR changes:
4. Linked entities to their submodule page with `\see`. Did this to every entry aside from `cerealisable` which links to external repo