### PR TITLE
[FIX] Restrict seqan3::alphabet_variant.

### DIFF
--- a/include/seqan3/alphabet/composite/alphabet_variant.hpp
+++ b/include/seqan3/alphabet/composite/alphabet_variant.hpp
@@ -124,8 +124,8 @@ template <typename ...alternative_types>
              (sizeof...(alternative_types) >= 2)
 //!\endcond
 class alphabet_variant : public alphabet_base<alphabet_variant<alternative_types...>,
-                                               (static_cast<size_t>(alphabet_size<alternative_types>) + ...),
-                                               char>
+                                              (static_cast<size_t>(alphabet_size<alternative_types>) + ...),
+                                              char>
 {
 private:
     //!\brief The base type.

--- a/include/seqan3/alphabet/composite/alphabet_variant.hpp
+++ b/include/seqan3/alphabet/composite/alphabet_variant.hpp
@@ -122,18 +122,21 @@ template <typename ...alternative_types>
     requires (detail::writable_constexpr_alphabet<alternative_types> && ...) &&
              (std::regular<alternative_types> && ...) &&
              (sizeof...(alternative_types) >= 2)
-             //TODO same char_type
 //!\endcond
 class alphabet_variant : public alphabet_base<alphabet_variant<alternative_types...>,
                                                (static_cast<size_t>(alphabet_size<alternative_types>) + ...),
-                                               char> //TODO underlying char t
-
+                                               char>
 {
 private:
     //!\brief The base type.
     using base_t = alphabet_base<alphabet_variant<alternative_types...>,
-                                                   (static_cast<size_t>(alphabet_size<alternative_types>) + ...),
-                                                   char>;
+                                                  (static_cast<size_t>(alphabet_size<alternative_types>) + ...),
+                                                  char>;
+
+    static_assert((std::is_same_v<alphabet_char_t<alternative_types>, char> && ...),
+                  "The alphabet_variant is currently only tested for alphabets with char_type char. "
+                  "Contact us on GitHub if you have a different use case: https://github.com/seqan/seqan3 .");
+
     //!\brief Befriend the base type.
     friend base_t;
 

--- a/include/seqan3/alphabet/composite/detail.hpp
+++ b/include/seqan3/alphabet/composite/detail.hpp
@@ -200,7 +200,6 @@ template <typename ...alternative_types>
     requires (detail::writable_constexpr_alphabet<alternative_types> && ...) &&
              (std::regular<alternative_types> && ...) &&
              (sizeof...(alternative_types) >= 2)
-             //TODO same char_type
 //!\endcond
 class alphabet_variant;
 


### PR DESCRIPTION
to only accept alphabets with the same underlying char type.

This cannot be tested, since incorrect code would not compile.

since all our alphabets have `char` as underlying type, this did not break anything.

Fixes #2867 