### PR TITLE
[FIX]  correct parsing of IDs in fasta files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ If possible, provide tooling that performs the changes, e.g. a shell-script.
 
 ## Notable Bug-fixes
 
+#### IO
+
+* Fixed an issue parsing FASTA files containing sequence IDs that start with `>`
+ ([\#2869](https://github.com/seqan/seqan3/pull/2869)).
+
 #### Utility
 
 * `seqan3::views::single_pass_input` cannot propagate the `std::ranges::output_range` property, because it cannot

--- a/test/performance/io/CMakeLists.txt
+++ b/test/performance/io/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_subdirectories ()
 
 seqan3_benchmark (format_fasta_benchmark.cpp)
+seqan3_benchmark (format_fasta_no_performance_benchmark.cpp)
 seqan3_benchmark (format_fastq_benchmark.cpp)
 seqan3_benchmark (format_sam_benchmark.cpp)
 seqan3_benchmark (format_vienna_benchmark.cpp)

--- a/test/performance/io/format_fasta_no_performance_benchmark.cpp
+++ b/test/performance/io/format_fasta_no_performance_benchmark.cpp
@@ -1,0 +1,13 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/* This file includes the same performance tests as format_fasta_benchmark.cpp
+ * but sets the `SEQAN3_WORKAROUND_VIEW_PERFORMANCE` variable first.
+ * This assures that different definitions of functions are used.
+ */
+#define SEQAN3_WORKAROUND_VIEW_PERFORMANCE 0
+#include "format_fasta_benchmark.cpp"

--- a/test/unit/io/sequence_file/CMakeLists.txt
+++ b/test/unit/io/sequence_file/CMakeLists.txt
@@ -1,5 +1,6 @@
 seqan3_test (sequence_file_input_test.cpp)
 seqan3_test (sequence_file_integration_test.cpp)
+seqan3_test (sequence_file_integration_no_performance_test.cpp)
 seqan3_test (sequence_file_output_test.cpp)
 seqan3_test (sequence_file_format_embl_test.cpp)
 seqan3_test (sequence_file_format_fasta_test.cpp)

--- a/test/unit/io/sequence_file/sequence_file_integration_no_performance_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_integration_no_performance_test.cpp
@@ -1,0 +1,14 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/* This file includes the same unit tests as sequence_file_integration_test.cpp
+ * but sets the `SEQAN3_WORKAROUND_VIEW_PERFORMANCE` variable first.
+ * This assures that different definitions of functions are used.
+ */
+
+#define SEQAN3_WORKAROUND_VIEW_PERFORMANCE 0
+#include "sequence_file_integration_test.cpp"

--- a/test/unit/io/sequence_file/sequence_file_integration_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_integration_test.cpp
@@ -135,3 +135,28 @@ TEST(integration, convert_fastq_to_fasta)
     fout.get_stream().flush();
     EXPECT_EQ(reinterpret_cast<std::ostringstream&>(fout.get_stream()).str(), fasta_out);
 }
+
+TEST(integration, sequence_name_contains_id_tag)
+{
+    // The sequence id is '>TEST 1'.
+    std::string const input
+    {
+        "> >TEST 1\n"
+        "ACGT\n"
+    };
+
+    std::string const expected_output
+    {
+        ">>TEST 1\n"
+        "ACGT\n"
+    };
+
+    seqan3::sequence_file_input fin{std::istringstream{input}, seqan3::format_fasta{}};
+    seqan3::sequence_file_output fout{std::ostringstream{}, seqan3::format_fasta{}};
+    fout = fin;
+
+    fout.get_stream().flush();
+
+    std::string const output = static_cast<std::ostringstream&>(fout.get_stream()).str();
+    EXPECT_EQ(output, expected_output);
+}


### PR DESCRIPTION
Fasta has the following structure:
```
> MyID
MySeq
```

This should be parsed into 'MyID' and 'MySeq' (This works fine).

If the sequence id has '>' as a character, this might fail:

```
> >MyID
MySeq
```
This will be parsed into 'MyId' and 'MySeq', which does not meet the
specification. It should be parsed to '>MyID' and 'MySeq'.

This PR fixes this.
