### PR TITLE
[FIX] the in/out parameter order of convert_through_char_representation

### DIFF
--- a/include/seqan3/alphabet/aminoacid/aminoacid_base.hpp
+++ b/include/seqan3/alphabet/aminoacid/aminoacid_base.hpp
@@ -81,7 +81,7 @@ public:
                       detail::writable_constexpr_alphabet<other_aa_type>)
         {
             static_cast<derived_type &>(*this) =
-                detail::convert_through_char_representation<derived_type, other_aa_type>[seqan3::to_rank(other)];
+                detail::convert_through_char_representation<other_aa_type, derived_type>[seqan3::to_rank(other)];
         }
         else
         {

--- a/include/seqan3/alphabet/detail/convert.hpp
+++ b/include/seqan3/alphabet/detail/convert.hpp
@@ -27,11 +27,11 @@ namespace seqan3::detail
 
 /*!\brief A precomputed conversion table for two alphabets based on their char representations.
  * \ingroup alphabet
- * \tparam out_t The type of the output, must satisfy seqan3::alphabet.
  * \tparam in_t The type of the input, must satisfy seqan3::alphabet.
+ * \tparam out_t The type of the output, must satisfy seqan3::alphabet.
  * \hideinitializer
  */
-template <alphabet out_t, alphabet in_t>
+template <alphabet in_t, alphabet out_t>
 constexpr std::array<out_t, alphabet_size<in_t>> convert_through_char_representation
 {
     [] () constexpr

--- a/include/seqan3/alphabet/nucleotide/nucleotide_base.hpp
+++ b/include/seqan3/alphabet/nucleotide/nucleotide_base.hpp
@@ -86,7 +86,7 @@ public:
     explicit constexpr nucleotide_base(other_nucl_type const & other) noexcept
     {
         static_cast<derived_type &>(*this) =
-            detail::convert_through_char_representation<derived_type, other_nucl_type>[seqan3::to_rank(other)];
+            detail::convert_through_char_representation<other_nucl_type, derived_type>[seqan3::to_rank(other)];
     }
     //!\}
 

--- a/include/seqan3/io/sam_file/format_bam.hpp
+++ b/include/seqan3/io/sam_file/format_bam.hpp
@@ -457,7 +457,7 @@ inline void format_bam::read_alignment_record(stream_type & stream,
                 {
                     assert(core.l_seq == (seq_length + offset_tmp + soft_clipping_end)); // sanity check
                     using alph_t = std::ranges::range_value_t<decltype(get<1>(align))>;
-                    constexpr auto from_dna16 = detail::convert_through_char_representation<alph_t, dna16sam>;
+                    constexpr auto from_dna16 = detail::convert_through_char_representation<dna16sam, alph_t>;
 
                     get<1>(align).reserve(seq_length);
 
@@ -501,7 +501,7 @@ inline void format_bam::read_alignment_record(stream_type & stream,
         else
         {
             using alph_t = std::ranges::range_value_t<decltype(seq)>;
-            constexpr auto from_dna16 = detail::convert_through_char_representation<alph_t, dna16sam>;
+            constexpr auto from_dna16 = detail::convert_through_char_representation<dna16sam, alph_t>;
 
             for (auto [d1, d2] : seq_stream)
             {
@@ -891,7 +891,7 @@ inline void format_bam::write_alignment_record([[maybe_unused]] stream_type &  s
 
         // write seq (bit-compressed: dna16sam characters go into one byte)
         using alph_t = std::ranges::range_value_t<seq_type>;
-        constexpr auto to_dna16 = detail::convert_through_char_representation<dna16sam, alph_t>;
+        constexpr auto to_dna16 = detail::convert_through_char_representation<alph_t, dna16sam>;
 
         auto sit = std::ranges::begin(seq);
         for (int32_t sidx = 0; sidx < ((core.l_seq & 1) ? core.l_seq - 1 : core.l_seq); ++sidx, ++sit)


### PR DESCRIPTION
This fixes the in/out parameter order. First all input parameters, than all output parameters.
