### PR TITLE
[doc] update utility

### DIFF
--- a/include/seqan3/utility/concept/exposition_only/core_language.hpp
+++ b/include/seqan3/utility/concept/exposition_only/core_language.hpp
@@ -78,9 +78,12 @@ struct weakly_ordered_with_trait : std::integral_constant<bool, weakly_ordered_w
 
 namespace seqan3
 {
-/*!\interface   seqan3::implicitly_convertible_to <>
+/*!\interface seqan3::implicitly_convertible_to <>
  * \ingroup utility_concept
- * \brief       Resolves to `std::ranges::implicitly_convertible_to<type1, type2>()`.
+ * \brief Resolves to `std::ranges::implicitly_convertible_to<type1, type2>()`.
+ *
+ * \details
+ *
  * \noapi
  */
 //!\cond
@@ -88,9 +91,12 @@ template <typename t, typename u>
 SEQAN3_CONCEPT implicitly_convertible_to = std::is_convertible_v<t, u>;
 //!\endcond
 
-/*!\interface   seqan3::explicitly_convertible_to <>
+/*!\interface seqan3::explicitly_convertible_to <>
  * \ingroup utility_concept
- * \brief       Resolves to `std::ranges::explicitly_convertible_to<type1, type2>()`.
+ * \brief Resolves to `std::ranges::explicitly_convertible_to<type1, type2>()`.
+ *
+ * \details
+ *
  * \noapi
  */
 //!\cond
@@ -98,10 +104,14 @@ template <typename t, typename u>
 SEQAN3_CONCEPT explicitly_convertible_to = requires (t vt) { { static_cast<u>(vt)}; };
 //!\endcond
 
-/*!\interface   seqan3::arithmetic <>
+/*!\interface seqan3::arithmetic <>
  * \ingroup utility_concept
- * \brief       A type that satisfies std::is_arithmetic_v<t>.
- * \sa          https://en.cppreference.com/w/cpp/types/is_arithmetic
+ * \brief A type that satisfies std::is_arithmetic_v<t>.
+ *
+ * \details
+ *
+ * \sa https://en.cppreference.com/w/cpp/types/is_arithmetic
+ *
  * \noapi
  */
 //!\cond
@@ -109,11 +119,15 @@ template <typename t>
 SEQAN3_CONCEPT arithmetic = std::is_arithmetic_v<t>;
 //!\endcond
 
-/*!\interface   seqan3::floating_point <>
+/*!\interface seqan3::floating_point <>
  * \ingroup utility_concept
- * \extends     seqan3::arithmetic
- * \brief       An arithmetic type that also satisfies std::is_floating_point_v<t>.
- * \sa          https://en.cppreference.com/w/cpp/types/is_floating_point
+ * \extends seqan3::arithmetic
+ * \brief An arithmetic type that also satisfies std::is_floating_point_v<t>.
+ *
+ * \details
+ *
+ * \sa https://en.cppreference.com/w/cpp/types/is_floating_point
+ *
  * \noapi
  */
 //!\cond
@@ -121,11 +135,14 @@ template <typename t>
 SEQAN3_CONCEPT floating_point = arithmetic<t> && std::is_floating_point_v<t>;
 //!\endcond
 
-/*!\interface   seqan3::builtin_character <>
+/*!\interface seqan3::builtin_character <>
  * \ingroup utility_concept
- * \extends     std::integral
- * \brief       This concept encompasses exactly the types `char`, `signed char`, `unsigned char`, `wchar_t`,
- *              `char16_t` and `char32_t`.
+ * \extends std::integral
+ * \brief This concept encompasses exactly the types `char`, `signed char`, `unsigned char`, `wchar_t`,
+ *        `char16_t` and `char32_t`.
+ *
+ * \details
+ *
  * \noapi
  */
 //!\cond
@@ -139,11 +156,15 @@ SEQAN3_CONCEPT builtin_character = std::integral<t> &&
                        std::same_as<t, char16_t> || std::same_as<t, char32_t> || std::same_as<t, wchar_t>);
 //!\endcond
 
-/*!\interface   seqan3::trivially_destructible <>
+/*!\interface seqan3::trivially_destructible <>
  * \ingroup utility_concept
- * \extends     std::destructible
- * \brief       A type that satisfies std::is_trivially_destructible_v<t>.
- * \sa          https://en.cppreference.com/w/cpp/types/is_destructible
+ * \extends std::destructible
+ * \brief A type that satisfies std::is_trivially_destructible_v<t>.
+ *
+ * \details
+ *
+ * \sa https://en.cppreference.com/w/cpp/types/is_destructible
+ *
  * \noapi
  */
 //!\cond
@@ -151,11 +172,15 @@ template <typename t>
 SEQAN3_CONCEPT trivially_destructible = std::destructible<t> && std::is_trivially_destructible_v<t>;
 //!\endcond
 
-/*!\interface   seqan3::trivially_copyable
+/*!\interface seqan3::trivially_copyable
  * \ingroup utility_concept
- * \brief       A type that satisfies std::is_trivially_copyable_v<t>.
- * \extends     std::copyable
- * \sa          https://en.cppreference.com/w/cpp/types/is_trivially_copyable
+ * \brief A type that satisfies std::is_trivially_copyable_v<t>.
+ * \extends std::copyable
+ *
+ * \details
+ *
+ * \sa https://en.cppreference.com/w/cpp/types/is_trivially_copyable
+ *
  * \noapi
  */
 //!\cond
@@ -163,12 +188,16 @@ template <typename t>
 SEQAN3_CONCEPT trivially_copyable = std::copyable<t> && std::is_trivially_copyable_v<t>;
 //!\endcond
 
-/*!\interface   seqan3::trivial
+/*!\interface seqan3::trivial
  * \ingroup utility_concept
- * \brief       A type that satisfies seqan3::trivially_copyable and seqan3::trivially_destructible.
- * \extends     seqan3::trivially_copyable
- * \extends     seqan3::trivially_destructible
- * \sa          https://en.cppreference.com/w/cpp/types/is_trivial
+ * \brief A type that satisfies seqan3::trivially_copyable and seqan3::trivially_destructible.
+ * \extends seqan3::trivially_copyable
+ * \extends seqan3::trivially_destructible
+ *
+ * \details
+ *
+ * \sa https://en.cppreference.com/w/cpp/types/is_trivial
+ *
  * \noapi
  */
 //!\cond
@@ -176,10 +205,14 @@ template <typename t>
 SEQAN3_CONCEPT trivial = trivially_copyable<t> && trivially_destructible<t> && std::is_trivial_v<t>;
 //!\endcond
 
-/*!\interface   seqan3::standard_layout
+/*!\interface seqan3::standard_layout
  * \ingroup utility_concept
- * \brief       Resolves to std::is_standard_layout_v<t>.
- * \sa          https://en.cppreference.com/w/cpp/types/is_standard_layout
+ * \brief Resolves to std::is_standard_layout_v<t>.
+ *
+ * \details
+ *
+ * \sa https://en.cppreference.com/w/cpp/types/is_standard_layout
+ *
  * \noapi
  */
 //!\cond
@@ -187,16 +220,18 @@ template <typename t>
 SEQAN3_CONCEPT standard_layout = std::is_standard_layout_v<t>;
 //!\endcond
 
-/*!\interface   seqan3::weakly_assignable_from
+/*!\interface seqan3::weakly_assignable_from
  * \ingroup utility_concept
- * \brief       Resolves to std::is_assignable_v<t>.
- * \sa          https://en.cppreference.com/w/cpp/types/is_assignable
- * \noapi
+ * \brief Resolves to std::is_assignable_v<t>.
  *
  * \details
  *
- * Note that this requires less than std::assignable_from, it simply tests if the expression
- * `std::declval<T>() = std::declval<U>()` is well-formed.
+ * \note This requires less than std::assignable_from, it simply tests if the expression `std::declval<T>() =
+ *       std::declval<U>()` is well-formed.
+ *
+ * \sa https://en.cppreference.com/w/cpp/types/is_assignable
+ *
+ * \noapi
  */
 //!\cond
 template <typename t, typename u>

--- a/include/seqan3/utility/container/all.hpp
+++ b/include/seqan3/utility/container/all.hpp
@@ -19,7 +19,7 @@
 #include <seqan3/utility/container/small_vector.hpp>
 
 /*!\defgroup utility_container Container
- * \brief Provides various general purpose container.
+ * \brief Provides various general purpose container and concepts.
  * \ingroup utility
  * \see utility
  */

--- a/include/seqan3/utility/range/all.hpp
+++ b/include/seqan3/utility/range/all.hpp
@@ -16,7 +16,7 @@
 
 /*!\defgroup utility_range Range
  * \ingroup utility
- * \brief The range module provides general purpose containers, decorators and views.
+ * \brief The range module provides general purpose range concepts.
  *
  * ### Introduction
  *
@@ -71,12 +71,11 @@
  * does not) and you can have views or decorators that do so or don't. For some combinations of iterator capabilities
  * and storage behaviour there are extra concept definitions, e.g. seqan3::random_access_container.
  *
- * \attention
- *
- * There are ranges in SeqAn that fit neither of these storage categories, e.g. all the files are
- * \link std::ranges::input_range input ranges \endlink (if they are input files) and
- * \link std::ranges::output_range output ranges \endlink (if they are output files), but they are neither
- * containers, decorators nor views.
+ * \attention There are ranges in SeqAn that fit neither of these storage categories, e.g. all the files are
+ *            \link std::ranges::input_range input ranges \endlink (if they are input files) and
+ *            \link std::ranges::output_range output ranges \endlink (if they are output files), but they are neither
+ *            containers, decorators nor views.
  *
  * \sa https://ericniebler.github.io/range-v3/index.html
+ * \see utility
  */

--- a/include/seqan3/utility/range/concept.hpp
+++ b/include/seqan3/utility/range/concept.hpp
@@ -76,7 +76,6 @@ SEQAN3_CONCEPT const_iterable_range =
  *
  * ### Concepts and doxygen
  *
- * The requirements for this concept are given as related functions and type traits.
  * Types that model this concept are shown as "implementing this interface".
  *
  * \noapi{Exposition only.}
@@ -113,7 +112,6 @@ SEQAN3_CONCEPT pseudo_random_access_iterator =
  *
  * ### Concepts and doxygen
  *
- * The requirements for this concept are given as related functions and type traits.
  * Types that model this concept are shown as "implementing this interface".
  *
  * \noapi{Exposition only.}

--- a/include/seqan3/utility/tuple/all.hpp
+++ b/include/seqan3/utility/tuple/all.hpp
@@ -17,10 +17,6 @@
  *        specific to a SeqAn module.
  * \ingroup utility
  * \see utility
- *
- * \details
- *
- * \todo write me.
  */
 
 #include <seqan3/utility/tuple/concept.hpp>

--- a/include/seqan3/utility/tuple/pod_tuple.hpp
+++ b/include/seqan3/utility/tuple/pod_tuple.hpp
@@ -103,7 +103,7 @@ struct pod_tuple<type0, types...>
     //!\}
 };
 
-/*!\brief Recursion anchor for pod_tuple.
+/*!\brief Recursion anchor for seqan3::pod_tuple.
  * \ingroup utility_tuple
  * \tparam type0 The value's type (every tuple must contain at least one type).
  */

--- a/include/seqan3/utility/type_list/all.hpp
+++ b/include/seqan3/utility/type_list/all.hpp
@@ -26,5 +26,4 @@
 
 /*!\namespace seqan3::list_traits
  * \brief Namespace containing traits for working on seqan3::type_list.
- * \ingroup utility_type_list
  */

--- a/include/seqan3/utility/type_pack/all.hpp
+++ b/include/seqan3/utility/type_pack/all.hpp
@@ -26,5 +26,4 @@
 
 /*!\namespace seqan3::pack_traits
  * \brief Namespace containing traits for working on type packs.
- * \ingroup utility_type_pack
  */

--- a/include/seqan3/utility/type_traits/basic.hpp
+++ b/include/seqan3/utility/type_traits/basic.hpp
@@ -21,11 +21,13 @@
 // is_constexpr
 // ----------------------------------------------------------------------------
 
+//!\cond DEV
 /*!\brief Returns true if the expression passed to this macro can be evaluated at compile time, false otherwise.
  * \ingroup utility_type_traits
  * \returns true or false.
  */
 #define SEQAN3_IS_CONSTEXPR(...) std::integral_constant<bool, __builtin_constant_p((__VA_ARGS__, 0))>::value
+//!\endcond
 
 namespace seqan3
 {
@@ -59,7 +61,7 @@ using remove_rvalue_reference_t = typename remove_rvalue_reference<t>::type;
 // is_constexpr_default_constructible
 // ----------------------------------------------------------------------------
 
-/*!\brief Whether a type std::is_default_constructible in `constexpr`-context.
+/*!\brief Whether a type std::is_default_constructible in `constexpr`-context (unary_type_trait specialisation).
  * \ingroup utility_type_traits
  * \implements seqan3::unary_type_trait
  * \tparam t The type to operate on.
@@ -68,17 +70,12 @@ template <typename t>
 struct is_constexpr_default_constructible : std::false_type
 {};
 
-/*!\brief Whether a type std::is_default_constructible in `constexpr`-context (unary_type_trait specialisation).
- * \ingroup utility_type_traits
- * \tparam t A type that std::is_default_constructible.
- * \see seqan3::is_constexpr_default_constructible
- */
-template <typename t>
 //!\cond
+template <typename t>
     requires std::is_default_constructible_v<t>
-//!\endcond
 struct is_constexpr_default_constructible<t> : std::integral_constant<bool, SEQAN3_IS_CONSTEXPR(t{})>
 {};
+//!\endcond
 
 /*!\brief Whether a type std::is_default_constructible in `constexpr`-context (unary_type_trait shortcut).
  * \tparam t The type to operate on.
@@ -142,6 +139,7 @@ constexpr bool decays_to_ignore_v = std::is_same_v<std::remove_cvref_t<t>, ignor
 // SEQAN3_IS_SAME
 // ----------------------------------------------------------------------------
 
+//!\cond DEV
 /*!\brief A macro that behaves like std::is_same_v, except that it doesn't need to instantiate the template on GCC and
  *        Clang.
  * \ingroup utility_type_traits
@@ -153,3 +151,4 @@ constexpr bool decays_to_ignore_v = std::is_same_v<std::remove_cvref_t<t>, ignor
 #else
 #   define SEQAN3_IS_SAME(...)              std::is_same_v<__VA_ARGS__>
 #endif
+//!\endcond

--- a/include/seqan3/utility/views/all.hpp
+++ b/include/seqan3/utility/views/all.hpp
@@ -50,8 +50,8 @@
  *
  * ### Namespaces
  *
- *   * [All views from the range-v3 libary](https://ericniebler.github.io/range-v3/index.html#range-views) are available
- * in the namespace `ranges::view`.
+ *   * [All views from the std libary](https://en.cppreference.com/w/cpp/ranges#Range_adaptors) are available
+ * in the namespace `std::ranges::views` or in the namespace alias `std::views`.
  *
  *   * All SeqAn views are available in the namespace `seqan3::views`.
  *
@@ -73,7 +73,7 @@
  *   1. the view (this is the type that is a range and meets std::ranges::view; it is what we refer to with
  * `auto vec_view` above)
  *   2. the view adaptor (this is the functor that returns the actual view based on it's parameters, including the
- * underlying range; in the above example `views::reverse` and `views::complement` are view adaptors)
+ * underlying range; in the above example `std::views::reverse` and `seqan3::views::complement` are view adaptors)
  *
  * The view adaptor also facilitates the piping behaviour. It is the only entity that is publicly documented and
  * the actual view type (the range type returned by the adaptor) is considered implementation defined.
@@ -88,20 +88,23 @@
  *
  * ### View properties
  *
- * There are three view properties that are documented for a view, **only if that view fulfills them:**
+ * There are three view properties that are documented for a view, **only if that view fulfils them:**
  *
  * **Source-only views:** Most views operate on an underlying range and return a (modified) range, i.e. they can be placed
  * at the beginning, middle or end of a "pipe" of view operations. However, some views are limited to being at
- * the front ("source"), e.g. `std::views::single`, `ranges::view::concat` and `std::views::ints`. These views
- * are marked as "source-only" and have no `urng_t` column in the second table.
+ * the front ("source"), e.g. `std::views::empty`, `std::view::single` and `std::views::iota`. These views
+ * are marked as "source-only" and have no `urng_t` column in the second table. The C++ standard calls these [Range
+ * factories](https://eel.is/c++draft/range.factories), which are utilities to create a view.
  *
  * **Sink-only views:** The opposite of a *source-only view*. It can only be placed at the end of a pipe, i.e.
  * it operates on views, but does not actually return a range (has no `rrng_t` column in the second table).
+ * The C++ standard doesn't have this concept yet.
  *
  * **Deep views:** Some views are declared as "deeps views". This means, that in case they are given a range-of-range
  * as input (as opposed to just a range), they will apply their transformation on the innermost range (instead of
  * the outermost range which would be default). Most alphabet-based transformations are defined as deep, but
  * you can use seqan3::views::deep to make any view (adaptor) deep. See seqan3::views::deep for more details.
+ * The C++ standard doesn't have this concept yet.
  *
  * **For all views the following are documented:**
  *
@@ -149,7 +152,7 @@
  * (since dereferencing an iterator or calling operator[] returns the reference type). The reference type may or may
  * not actually contain a `&` (see below). For many SeqAn specific views additional concept requirements are defined
  * for the input range's reference type, e.g. seqan3::views::complement can only operate on ranges whose elements are
- * nucleotides (meet seqan3::nucleotide_alphabet_check). In some case the type may even be a specific type or the result
+ * nucleotides (meet seqan3::nucleotide_alphabet). In some case the type may even be a specific type or the result
  * of a type trait.
  *
  * **Returned range's reference type:** Conversely certain views make guarantees on the concepts satisfied by the
@@ -159,13 +162,14 @@
  * of seqan3::views::complement has any actual `&` removed from the underlying ranges' reference type (if originally present),
  * this goes hand-in-hand with std::ranges::output_range being lost → original elements cannot be written to through
  * this view.
- * This is because *new elements* are being generated. Other views like `views::reverse` also preserve the
+ * This is because *new elements* are being generated. Other views like `std::views::reverse` also preserve the
  * `&` (if originally present), because the elements in the return view still point to the elements in the original
  * range (just in different order). This has the effect that through some combinations of views you can modify the
  * elements in the original range (if all views in the pipe preserve std::ranges::output_range), but through others
  * you can't.
  *
  * \sa https://ericniebler.github.io/range-v3/index.html#range-views
+ * \sa https://en.cppreference.com/w/cpp/ranges
  */
 
 /*!

--- a/include/seqan3/utility/views/all.hpp
+++ b/include/seqan3/utility/views/all.hpp
@@ -98,13 +98,13 @@
  *
  * **Sink-only views:** The opposite of a *source-only view*. It can only be placed at the end of a pipe, i.e.
  * it operates on views, but does not actually return a range (has no `rrng_t` column in the second table).
- * The C++ standard doesn't have this concept yet.
+ * The C++20 standard doesn't have this concept.
  *
  * **Deep views:** Some views are declared as "deeps views". This means, that in case they are given a range-of-range
  * as input (as opposed to just a range), they will apply their transformation on the innermost range (instead of
  * the outermost range which would be default). Most alphabet-based transformations are defined as deep, but
  * you can use seqan3::views::deep to make any view (adaptor) deep. See seqan3::views::deep for more details.
- * The C++ standard doesn't have this concept yet.
+ * The C++20 standard doesn't have this concept.
  *
  * **For all views the following are documented:**
  *

--- a/include/seqan3/utility/views/interleave.hpp
+++ b/include/seqan3/utility/views/interleave.hpp
@@ -367,7 +367,8 @@ namespace seqan3::views
  *
  * * `urng_t` is the type of the range modified by this view (input).
  * * `rrng_t` is the type of the range returned by this view.
- * * for more details, see \ref views.
+ *
+ * See the \link views views submodule documentation \endlink for detailed descriptions of the view properties.
  *
  * ### Example
  *


### PR DESCRIPTION
This is my first sweep for https://github.com/seqan/product_backlog/issues/393

I didn't put any `\remark` yet, because most entities are stand-alone and don't really have anything "globally" explained at the submodule page.

Maybe the tuple documentation could have this, but I'm not sure. A draft for this is here: https://github.com/marehr/seqan3/pull/new/doc_utility2