### PR TITLE
[DOC] unified spelling of FASTA and FASTQ

### DIFF
--- a/doc/fragments/sequence_file_input.md
+++ b/doc/fragments/sequence_file_input.md
@@ -1,7 +1,7 @@
 ### Reading Sequence Files
 
 Sequence files are the most generic and common biological files. Well-known formats include
-FastA and FastQ, but some may also be interested in treating SAM or BAM files as sequence
+FASTA and FASTQ, but some may also be interested in treating SAM or BAM files as sequence
 files, discarding the alignment.
 
 The Sequence file abstraction supports reading three different fields:

--- a/doc/fragments/sequence_file_output.md
+++ b/doc/fragments/sequence_file_output.md
@@ -1,7 +1,7 @@
 ### Writing Sequence Files
 
 Sequence files are the most generic and common biological files. Well-known formats include
-FastA and FastQ, but some may also be interested in treating SAM or BAM files as sequence
+FASTA and FASTQ, but some may also be interested in treating SAM or BAM files as sequence
 files, discarding the alignment.
 
 The Sequence file abstraction supports writing three different fields:
@@ -45,7 +45,7 @@ emplace_back() the seqan3::field ID of the i-th tuple-element/argument is assume
 selected_field_ids, i.e. by default the first is assumed to be seqan3::field::seq, the second seqan3::field::id
 and the third one seqan3::field::qual. You may give less fields than are selected if the actual format you are
 writing to can cope with less
-(e.g. for FastA it is sufficient to write seqan3::field::seq and seqan3::field::id, even if selected_field_ids
+(e.g. for FASTA it is sufficient to write seqan3::field::seq and seqan3::field::id, even if selected_field_ids
 also contains seqan3::field::qual at the third position).
 You may also use the output file's iterator for writing, however, this rarely provides an advantage.
 

--- a/doc/tutorial/introduction/index.md
+++ b/doc/tutorial/introduction/index.md
@@ -108,7 +108,7 @@ Can you imagine anything easier? After you have initialised the instance with a 
 you can simply step through the file in a for loop and retrieve the fields via
 [structured bindings](https://en.cppreference.com/w/cpp/language/structured_binding).
 The returned fields are `SEQ`, `ID` and `QUAL` to retrieve sequences, ids and qualities, respectively.
-The latter is empty unless you read FastQ files. The appropriate file format is detected by SeqAn from
+The latter is empty unless you read FASTQ files. The appropriate file format is detected by SeqAn from
 your filename's suffix.
 
 Here is the content of `seq.fasta`, so you can try it out!
@@ -120,8 +120,8 @@ ACGTGATG
 AGTGATACT
 ~~~
 
-\assignment{Assignment 2: Read a FastA file}
-Combine the code from above to read a FastA file and store its sequences in a std::vector of type seqan3::dna5_vector
+\assignment{Assignment 2: Read a FASTA file}
+Combine the code from above to read a FASTA file and store its sequences in a std::vector of type seqan3::dna5_vector
 (which is a common DNA sequence type in SeqAn). Use the argument parser for obtaining the filename as command line
 argument to your program (e.g. call `./myprogram seq.fasta`).
 \endassignment
@@ -129,7 +129,7 @@ argument to your program (e.g. call `./myprogram seq.fasta`).
 \snippet introduction_read_fasta.cpp read
 \endsolution
 
-Note that the same code can also read FastQ files and the `qual` variable will not be empty then. If you like, try it!
+Note that the same code can also read FASTQ files and the `qual` variable will not be empty then. If you like, try it!
 
 \note
 SeqAn3 uses `snake_case` for almost everything, also class names. Only C++ concepts are named using `CamelCase`.

--- a/doc/tutorial/introduction/introduction_file_input.cpp
+++ b/doc/tutorial/introduction/introduction_file_input.cpp
@@ -47,7 +47,7 @@ int main ()
 {
     std::filesystem::path tmp_dir = std::filesystem::temp_directory_path(); // get the tmp directory
 
-    // Initialise a file input object with a FastA file.
+    // Initialise a file input object with a FASTA file.
     seqan3::sequence_file_input file_in{tmp_dir/"seq.fasta"};
 
     // Retrieve the sequences and ids.
@@ -55,7 +55,7 @@ int main ()
     {
         seqan3::debug_stream << "ID:     " << id << '\n';
         seqan3::debug_stream << "SEQ:    " << seq << '\n';
-        seqan3::debug_stream << "Empty Qual." << qual << '\n';  // qual is empty for FastAfiles
+        seqan3::debug_stream << "Empty Qual." << qual << '\n';  // qual is empty for FASTA files
     }
 
     return 0;

--- a/include/seqan3/io/all.hpp
+++ b/include/seqan3/io/all.hpp
@@ -55,12 +55,12 @@
  *   * You can iterate over a seqan3::sequence_file_input just like you iterate over a std::vector.
  *   * The element type is seqan3::record and for seqan3::sequence_file_input the records typically consist of three
  *     fields: ID, sequence and qualities.
- *   * Not every *format* may provide every field (e.g. all three fields can be extracted from a FastQ file, but only
- *     ID and sequence can be extracted from a FastA file).
+ *   * Not every *format* may provide every field (e.g. all three fields can be extracted from a FASTQ file, but only
+ *     ID and sequence can be extracted from a FASTA file).
  *   * This is not a problem when reading files; the format is detected at run-time and either it provides all desired
  *     fields, or some of them will be empty.
  *   * When writing files it depends on the format whether it allows certain fields to be unset; e.g. you can convert
- *     a FastQ file to a FastA file, but not the other way around (at least not without providing placeholders for the
+ *     a FASTQ file to a FASTA file, but not the other way around (at least not without providing placeholders for the
  *     qualitites).
  *
  * Please have a look the tutorial for \ref tutorial_sequence_file and the API docs for seqan3::sequence_file_input

--- a/include/seqan3/io/sequence_file/format_fasta.hpp
+++ b/include/seqan3/io/sequence_file/format_fasta.hpp
@@ -43,7 +43,7 @@
 namespace seqan3
 {
 
-/*!\brief The FastA format.
+/*!\brief The FASTA format.
  * \implements sequence_file_input_format
  * \implements sequence_file_output_format
  * \ingroup io_sequence_file
@@ -52,12 +52,12 @@ namespace seqan3
  *
  * ### Introduction
  *
- * FastA is the de-facto-standard for sequence storage in bionformatics. See the
+ * FASTA is the de-facto-standard for sequence storage in bionformatics. See the
  * [article on wikipedia](https://en.wikipedia.org/wiki/FASTA_format) for a an in-depth description of the format.
  *
  * ### fields_specialisation
  *
- * The FastA format provides the fields seqan3::field::seq and seqan3::field::id. Both fields are required when writing.
+ * The FASTA format provides the fields seqan3::field::seq and seqan3::field::id. Both fields are required when writing.
  *
  * ### Implementation notes
  *
@@ -209,7 +209,7 @@ private:
                 }
 
                 if (!at_delimiter)
-                    throw unexpected_end_of_input{"FastA ID line did not end in newline."};
+                    throw unexpected_end_of_input{"FASTA ID line did not end in newline."};
 
                 for (; (it != e) && ((!is_char<'\n'>)(*it)); ++it)
                 {}
@@ -246,7 +246,7 @@ private:
                 }
 
                 if (!at_delimiter)
-                    throw unexpected_end_of_input{"FastA ID line did not end in newline."};
+                    throw unexpected_end_of_input{"FASTA ID line did not end in newline."};
 
             #else // ↑↑↑ WORKAROUND | ORIGINAL ↓↓↓
 

--- a/include/seqan3/io/sequence_file/format_fastq.hpp
+++ b/include/seqan3/io/sequence_file/format_fastq.hpp
@@ -44,7 +44,7 @@
 namespace seqan3
 {
 
-/*!\brief The FastQ format.
+/*!\brief The FASTQ format.
  * \implements SequenceFileFormat
  * \ingroup io_sequence_file
  *
@@ -52,12 +52,12 @@ namespace seqan3
  *
  * ### Introduction
  *
- * FastQ is the de-facto-standard for storing sequences together with quality information. See the
+ * FASTQ is the de-facto-standard for storing sequences together with quality information. See the
  * [article on wikipedia](https://en.wikipedia.org/wiki/FASTQ_format) for a an in-depth description of the format.
  *
  * ### fields_specialisation
  *
- * The FastQ format provides the fields seqan3::field::seq, seqan3::field::id and seqan3::field::qual. All three fields
+ * The FASTQ format provides the fields seqan3::field::seq, seqan3::field::id and seqan3::field::qual. All three fields
  * are required when writing and the sequence and qualities are required to be of the same length.
  *
  * ### Encodings

--- a/include/seqan3/io/sequence_file/input_format_concept.hpp
+++ b/include/seqan3/io/sequence_file/input_format_concept.hpp
@@ -120,7 +120,7 @@ SEQAN3_CONCEPT sequence_file_input_format = requires (detail::sequence_file_inpu
  * \param[in,out] position_buffer The buffer to store the current record's file position.
  * \param[in]     options   File specific options passed to the format.
  * \param[out]    sequence  The buffer for seqan3::field::seq input, i.e. the "sequence".
- * \param[out]    id        The buffer for seqan3::field::id input, e.g. the header line in FastA.
+ * \param[out]    id        The buffer for seqan3::field::id input, e.g. the header line in FASTA .
  * \param[out]    qualities The buffer for seqan3::field::qual input.
  *
  * \details

--- a/include/seqan3/io/sequence_file/output_format_concept.hpp
+++ b/include/seqan3/io/sequence_file/output_format_concept.hpp
@@ -107,7 +107,7 @@ SEQAN3_CONCEPT sequence_file_output_format = requires (detail::sequence_file_out
  * \param[in,out] stream    The output stream to write into.
  * \param[in]     options   File specific options passed to the format.
  * \param[in]     sequence  The data for seqan3::field::seq, i.e. the "sequence".
- * \param[in]     id        The data for seqan3::field::id, e.g. the header line in FastA.
+ * \param[in]     id        The data for seqan3::field::id, e.g. the header line in FASTA.
  * \param[in]     qualities The data for seqan3::field::qual.
  *
  * \details

--- a/include/seqan3/io/structure_file/format_vienna.hpp
+++ b/include/seqan3/io/structure_file/format_vienna.hpp
@@ -56,7 +56,7 @@ namespace seqan3
  * Dot Bracket or Vienna Notation is widely used for secondary structure annotation. Is is a very simple format,
  * containing one or more sequences. Each sequence must appear as a single line in the file.
  * A sequence may be preceded by a special line starting with the '>' character followed by a sequence name
- * (like FastA). After each sequence line there is usually a line containing
+ * (like FASTA). After each sequence line there is usually a line containing
  * secondary structure, using brackets to denote interacting nucleotides or amino acids, and dots for unpaired sites.
  * The length of the struture must equal the length of the sequence.
  * Optionally, the structure may be followed by a space character and the minimum free energy value enclosed

--- a/test/performance/io/format_fastq_benchmark.cpp
+++ b/test/performance/io/format_fastq_benchmark.cpp
@@ -27,11 +27,11 @@
 constexpr unsigned default_seed = 1234u;
 
 // ============================================================================
-// generate fastq file
+// generate FASTQ file
 // ============================================================================
 
 inline constexpr size_t default_sequence_length = 50; //length of nucleotide and quality sequence
-inline std::string const fastq_id{"the fastq file"};
+inline std::string const fastq_id{"the FASTQ file"};
 
 std::string generate_fastq_string(size_t const entries_size)
 {
@@ -62,7 +62,7 @@ auto create_fastq_file_for(std::string const & fastq_string)
     seqan3::test::tmp_filename fastq_file{"format_fastq_benchmark_test_file.fastq"};
     auto fastq_file_path = fastq_file.get_path();
 
-    // fill temporary file with a fastq file
+    // fill temporary file with a FASTQ file
     std::ofstream ostream{fastq_file_path};
     ostream << fastq_string;
     ostream.close();
@@ -70,11 +70,11 @@ auto create_fastq_file_for(std::string const & fastq_string)
 }
 
 // ============================================================================
-// seqan3 fastq output benchmark
+// seqan3 FASTQ output benchmark
 // ============================================================================
 
 // ----------------------------------------------------------------------------
-// write dummy fastq file to a string stream
+// write dummy FASTQ file to a string stream
 // ----------------------------------------------------------------------------
 
 void fastq_write_to_stream_seqan3(benchmark::State & state)
@@ -107,11 +107,11 @@ void fastq_write_to_stream_seqan3(benchmark::State & state)
 BENCHMARK(fastq_write_to_stream_seqan3)->Arg(100)->Arg(1000)->Arg(10000);
 
 // ============================================================================
-// seqan3 fastq input benchmark
+// seqan3 FASTQ input benchmark
 // ============================================================================
 
 // ----------------------------------------------------------------------------
-// read dummy fastq file from a stream
+// read dummy FASTQ file from a stream
 // ----------------------------------------------------------------------------
 
 void fastq_read_from_stream_seqan3(benchmark::State & state)
@@ -138,7 +138,7 @@ void fastq_read_from_stream_seqan3(benchmark::State & state)
 }
 
 // ----------------------------------------------------------------------------
-// read dummy fastq file from temporary file on disk
+// read dummy FASTQ file from temporary file on disk
 // ----------------------------------------------------------------------------
 
 void fastq_read_from_disk_seqan3(benchmark::State & state)
@@ -162,13 +162,13 @@ void fastq_read_from_disk_seqan3(benchmark::State & state)
 }
 
 // ============================================================================
-// seqan2 fastq input benchmark
+// seqan2 FASTQ input benchmark
 // ============================================================================
 
 #if SEQAN3_HAS_SEQAN2
 
 // ----------------------------------------------------------------------------
-// read dummy fastq file from a stream
+// read dummy FASTQ file from a stream
 // ----------------------------------------------------------------------------
 
 void fastq_read_from_stream_seqan2(benchmark::State & state)
@@ -203,7 +203,7 @@ void fastq_read_from_stream_seqan2(benchmark::State & state)
 }
 
 // ----------------------------------------------------------------------------
-// read dummy fastq file from temporary file on disk
+// read dummy FASTQ file from temporary file on disk
 // ----------------------------------------------------------------------------
 
 void fastq_read_from_disk_seqan2(benchmark::State & state)

--- a/test/snippet/io/sequence_file/sequence_file_input_decomposed.cpp
+++ b/test/snippet/io/sequence_file/sequence_file_input_decomposed.cpp
@@ -16,6 +16,6 @@ int main()
     {
         seqan3::debug_stream << "ID: "        << id       << '\n';
         seqan3::debug_stream << "SEQ: "       << sequence << '\n';
-        seqan3::debug_stream << "EMPTY QUAL." << quality  << '\n'; // quality is empty for FastA files
+        seqan3::debug_stream << "EMPTY QUAL." << quality  << '\n'; // quality is empty for FASTA files
     }
 }

--- a/test/snippet/io/sequence_file/sequence_file_input_record_iter.cpp
+++ b/test/snippet/io/sequence_file/sequence_file_input_record_iter.cpp
@@ -18,6 +18,6 @@ int main()
     {
         seqan3::debug_stream << "ID:  " << record.id() << '\n';
         seqan3::debug_stream << "SEQ: " << record.sequence() << '\n';
-        // a quality field also exists, but is not printed, because we know it's empty for FastA files.
+        // a quality field also exists, but is not printed, because we know it's empty for FASTA files.
     }
 }

--- a/test/snippet/io/sequence_file/sequence_file_input_template_deduction.cpp
+++ b/test/snippet/io/sequence_file/sequence_file_input_template_deduction.cpp
@@ -23,7 +23,7 @@ int main()
         fout.emplace_back("GGAGTATAATATATATATATATAT"_dna4, "Test3");
     }
 
-    // FastA with DNA sequences assumed, regular std::ifstream taken as stream
+    // FASTA with DNA sequences assumed, regular std::ifstream taken as stream
     seqan3::sequence_file_input fin{fasta_file};
 }
 //![main]

--- a/test/snippet/io/sequence_file/sequence_file_output_template_deduction.cpp
+++ b/test/snippet/io/sequence_file/sequence_file_output_template_deduction.cpp
@@ -11,7 +11,7 @@ int main()
 {
     auto fasta_file = std::filesystem::current_path() / "my.fasta";
 
-    // FastA format detected, std::ofstream opened for file
+    // FASTA format detected, std::ofstream opened for file
     seqan3::sequence_file_output fin{fasta_file};
 }
 //![main]

--- a/test/snippet/release/3.0.0_read-fasta-and-print-entities.cpp
+++ b/test/snippet/release/3.0.0_read-fasta-and-print-entities.cpp
@@ -12,7 +12,7 @@ int main()
         // print the fields:
         seqan3::debug_stream << "ID:  " << id << '\n';
         seqan3::debug_stream << "SEQ: " << seq << '\n';
-        seqan3::debug_stream << "QUAL:" << qual << '\n'; // qual is empty for FastA files
+        seqan3::debug_stream << "QUAL:" << qual << '\n'; // qual is empty for FASTA files
     }
 }
 //![main]


### PR DESCRIPTION
We mixed spellings like fasta, Fasta, FastA and FASTA (same for FASTQ). I have unified this to complete capital letters, as it is done on wikipedia and other websites.