### PR TITLE
[MISC] Remove dependency on seqan3::sequence_container.

### DIFF
--- a/include/seqan3/argument_parser/argument_parser.hpp
+++ b/include/seqan3/argument_parser/argument_parser.hpp
@@ -316,7 +316,7 @@ public:
             throw design_error{"You added a positional option with a list value before so you cannot add "
                                       "any other positional options."};
 
-        if constexpr (sequence_container<option_type> && !std::same_as<option_type, std::string>)
+        if constexpr (detail::is_container_option<option_type>)
             has_positional_list_option = true; // keep track of a list option because there must be only one!
 
         // copy variables into the lambda because the calls are pushed to a stack

--- a/include/seqan3/argument_parser/detail/concept.hpp
+++ b/include/seqan3/argument_parser/detail/concept.hpp
@@ -26,9 +26,10 @@ namespace seqan3::detail
  * \brief Whether the option type is considered to be a container.
  * \details
  *
- * When adding options or positionial arguments, a distinction needs to be made between container and non-container `option_type`s.
+ * When adding options or positionial arguments, a distinction needs to be made between container and non-container
+ * `option_type`s.
  *
- * In general, all standard library containers except std::string can be considered  containers.
+ * In general, all standard library containers except std::string can be considered containers.
  *
  * In order to be considered a container, the `option_type` must:
  * * not be `std::string`
@@ -40,8 +41,8 @@ namespace seqan3::detail
 //!\cond
 template <typename option_type>
 concept is_container_option = !std::is_same_v<std::remove_cvref_t<option_type>, std::string> &&
-                                     requires (option_type container,
-                                               typename std::remove_reference_t<option_type>::value_type value)
+                              requires (option_type container,
+                                        typename std::remove_reference_t<option_type>::value_type value)
 {
     { container.push_back(value) };
 };

--- a/include/seqan3/argument_parser/detail/concept.hpp
+++ b/include/seqan3/argument_parser/detail/concept.hpp
@@ -1,0 +1,53 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \author Svenja Mehringer <svenja.mehringer AT fu-berlin.de>
+ * \brief Provides the concept seqan3::detail::is_container_option.
+ */
+
+#pragma once
+
+#include <seqan3/std/concepts>
+#include <string>
+#include <seqan3/std/type_traits>
+
+#include <seqan3/core/platform.hpp>
+
+namespace seqan3::detail
+{
+
+/*!\interface seqan3::detail::is_container_option <>
+ * \ingroup argument_parser
+ * \brief Decides whether an option type is considered a list.
+ * \details
+ *
+ * In the seqan3::argument_parser::add_option or seqan3::argument_parser::add_positional_argument calls,
+ * it is important whether the type of the value, in which the respective option is stored (option_type),
+ * is a container or not because nternal handling of option containers is different.
+ *
+ * This concept decides whether an option type is considered a container or not.
+ * In general, all standard library containers except std::string can be considered option containers.
+ *
+ * In order to be considered an option container, the `option_type` as to fulfil the following:
+ * * `option_type` may not be `std::string`
+ * * Member type `option_type::value_type` must exist
+ * * Member function `option_type::push_back(typename option_type::value_type) -> void` must exist.
+ *
+ * \noapi{Exposition only.}
+ */
+//!\cond
+template <typename option_type>
+concept is_container_option = !std::is_same_v<std::remove_cvref_t<option_type>, std::string> &&
+                                     requires (option_type container,
+                                               typename std::remove_reference_t<option_type>::value_type value)
+{
+    { container.push_back(value) };
+};
+//!\endcond
+
+} // namespace seqan3::detail

--- a/include/seqan3/argument_parser/detail/concept.hpp
+++ b/include/seqan3/argument_parser/detail/concept.hpp
@@ -23,22 +23,19 @@ namespace seqan3::detail
 
 /*!\interface seqan3::detail::is_container_option <>
  * \ingroup argument_parser
- * \brief Decides whether an option type is considered a list.
+ * \brief Whether the option type is considered to be a container.
  * \details
  *
- * In the seqan3::argument_parser::add_option or seqan3::argument_parser::add_positional_argument calls,
- * it is important whether the type of the value, in which the respective option is stored (option_type),
- * is a container or not because nternal handling of option containers is different.
+ * When adding options or positionial arguments, a distinction needs to be made between container and non-container `option_type`s.
  *
- * This concept decides whether an option type is considered a container or not.
- * In general, all standard library containers except std::string can be considered option containers.
+ * In general, all standard library containers except std::string can be considered  containers.
  *
- * In order to be considered an option container, the `option_type` as to fulfil the following:
- * * `option_type` may not be `std::string`
- * * Member type `option_type::value_type` must exist
- * * Member function `option_type::push_back(typename option_type::value_type) -> void` must exist.
+ * In order to be considered a container, the `option_type` must:
+ * * not be `std::string`
+ * * define a member type `value_type`
+ * * provide a member function `push_back(value_type)`
  *
- * \noapi{Exposition only.}
+ * \noapi
  */
 //!\cond
 template <typename option_type>

--- a/include/seqan3/argument_parser/detail/format_base.hpp
+++ b/include/seqan3/argument_parser/detail/format_base.hpp
@@ -22,7 +22,7 @@
 #include <seqan3/argument_parser/auxiliary.hpp>
 #include <seqan3/argument_parser/exceptions.hpp>
 #include <seqan3/argument_parser/validators.hpp>
-#include <seqan3/utility/container/concept.hpp>
+#include <seqan3/argument_parser/detail/concept.hpp>
 #include <seqan3/utility/detail/type_name_as_string.hpp>
 #include <seqan3/version.hpp>
 
@@ -83,10 +83,7 @@ protected:
      * \tparam container_type The container type for which to query it's value_type.
      * \returns The type of the container value_type as a string.
      */
-    template <sequence_container container_type>
-    //!\cond
-        requires (!std::is_same_v<container_type, std::string>)
-    //!\endcond
+    template <detail::is_container_option container_type>
     static std::string get_type_name_as_string(container_type const & /**/)
     {
         typename container_type::value_type tmp{};
@@ -105,15 +102,12 @@ protected:
     }
 
     /*!\brief Formats the container and its value_type for the help page printing.
-     * \tparam container_type A type that must satisfy the seqan3::sequence_container.
+     * \tparam container_type A type that must satisfy the seqan3::detail::is_container_option.
      * \param[in] container The container to deduct the type from.
      *
      * \returns The type of the container value type as a string, encapsulated in "List of".
      */
-    template <typename container_type>
-    //!\cond
-        requires sequence_container<container_type> && (!std::is_same_v<container_type, std::string>)
-    //!\endcond
+    template <detail::is_container_option container_type>
     static std::string option_type_and_list_info(container_type const & container)
     {
         return ("(\\fIList\\fP of \\fI" + get_type_name_as_string(container) + "\\fP)");
@@ -273,7 +267,7 @@ public:
                                                           option_type_and_list_info(value)),
                                         desc +
                                         // a list at the end may be empty and thus have a default value
-                                        ((sequence_container<option_type> && !std::same_as<option_type, std::string>)
+                                        ((detail::is_container_option<option_type>)
                                             ? detail::to_string(" Default: ", value, ". ")
                                             : std::string{" "}) +
                                         msg);

--- a/include/seqan3/argument_parser/detail/format_base.hpp
+++ b/include/seqan3/argument_parser/detail/format_base.hpp
@@ -20,9 +20,9 @@
 #include <string>
 
 #include <seqan3/argument_parser/auxiliary.hpp>
+#include <seqan3/argument_parser/detail/concept.hpp>
 #include <seqan3/argument_parser/exceptions.hpp>
 #include <seqan3/argument_parser/validators.hpp>
-#include <seqan3/argument_parser/detail/concept.hpp>
 #include <seqan3/utility/detail/type_name_as_string.hpp>
 #include <seqan3/version.hpp>
 

--- a/include/seqan3/argument_parser/detail/format_parse.hpp
+++ b/include/seqan3/argument_parser/detail/format_parse.hpp
@@ -355,7 +355,7 @@ private:
     //!\endcond
 
     /*!\brief Parses the given option value and appends it to the target container.
-     * \tparam container_option_t Must model the seqan3::sequence_container and
+     * \tparam container_option_t Must model seqan3::detail::is_container_option and
      *                            its value_type must be parseable via parse_option_value
      * \tparam format_parse_t Needed to make the function "dependent" (i.e. do instantiation in the second phase of
      *                        two-phase lookup) as the requires clause needs to be able to access the other
@@ -365,7 +365,7 @@ private:
      * \param[in] in The input argument to be parsed.
      * \returns A seqan3::option_parse_result whether parsing was successful or not.
      */
-    template <sequence_container container_option_t, typename format_parse_t = format_parse>
+    template <detail::is_container_option container_option_t, typename format_parse_t = format_parse>
     //!\cond
         requires requires (format_parse_t fp,
                            typename container_option_t::value_type & container_value,
@@ -578,10 +578,7 @@ private:
      * multiple times.
      *
      */
-    template <sequence_container option_type, typename id_type>
-    //!\cond
-        requires (!std::is_same_v<option_type, std::string>)
-    //!\endcond
+    template <detail::is_container_option option_type, typename id_type>
     bool get_option_by_id(option_type & value, id_type const & id)
     {
         auto it = find_option_id(argv.begin(), end_of_options_it, id);
@@ -689,8 +686,7 @@ private:
         bool long_id_is_set{get_option_by_id(value, long_id)};
 
         // if value is no container we need to check for multiple declarations
-        if (short_id_is_set && long_id_is_set &&
-            !(sequence_container<option_type> && !std::is_same_v<option_type, std::string>))
+        if (short_id_is_set && long_id_is_set && !detail::is_container_option<option_type>)
             throw option_declared_multiple_times("Option " + combine_option_names(short_id, long_id) +
                                                  " is no list/container but specified multiple times");
 
@@ -763,7 +759,7 @@ private:
                                     std::to_string(positional_option_calls.size()) +
                                     "). See -h/--help for more information.");
 
-        if constexpr (sequence_container<option_type> && !std::is_same_v<option_type, std::string>) // vector/list will be filled with all remaining arguments
+        if constexpr (detail::is_container_option<option_type>) // vector/list will be filled with all remaining arguments
         {
             assert(positional_option_count == positional_option_calls.size()); // checked on set up.
 

--- a/test/unit/argument_parser/detail/CMakeLists.txt
+++ b/test/unit/argument_parser/detail/CMakeLists.txt
@@ -11,3 +11,4 @@ seqan3_test(format_html_test.cpp CYCLIC_DEPENDING_INCLUDES
 seqan3_test(format_man_test.cpp)
 seqan3_test(version_check_debug_test.cpp)
 seqan3_test(version_check_release_test.cpp)
+seqan3_test(concept_is_container_option_test.cpp)

--- a/test/unit/argument_parser/detail/concept_is_container_option_test.cpp
+++ b/test/unit/argument_parser/detail/concept_is_container_option_test.cpp
@@ -5,7 +5,6 @@
 // shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
 // -----------------------------------------------------------------------------------------------------
 
-
 #include <gtest/gtest.h>
 
 #include <seqan3/argument_parser/detail/concept.hpp>

--- a/test/unit/argument_parser/detail/concept_is_container_option_test.cpp
+++ b/test/unit/argument_parser/detail/concept_is_container_option_test.cpp
@@ -1,0 +1,25 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+
+#include <gtest/gtest.h>
+
+#include <seqan3/argument_parser/detail/concept.hpp>
+
+TEST(is_container_option_concept_test, std_vector)
+{
+    EXPECT_TRUE(seqan3::detail::is_container_option<std::vector<int>>);
+    EXPECT_TRUE(seqan3::detail::is_container_option<std::vector<char>>);
+    EXPECT_TRUE(seqan3::detail::is_container_option<std::vector<int> &>);
+    EXPECT_TRUE(seqan3::detail::is_container_option<std::vector<char> &>);
+}
+
+TEST(is_container_option_concept_test, std_string)
+{
+    EXPECT_FALSE(seqan3::detail::is_container_option<std::string>);
+    EXPECT_FALSE(seqan3::detail::is_container_option<std::string &>);
+}


### PR DESCRIPTION
This could also be considered a fix, because the `sequence_container` concept is something we shouldn't use anymore. The concept basically requires everything that a resizable vector has, but in most cases you do not need ALL of resizable vector interface but just e.g. `push_back()`.

The concept now is much more light weight and adapted to the needs of the argument parser.

It also reduces the dependency of the argument parser to other seqan3 utilities and is one step further for https://github.com/seqan/seqan3/issues/1272