### PR TITLE
[INFRA] List unused snippets in cmake source dir correctly.

### DIFF
--- a/test/cmake/diagnostics/list_unused_snippets.cmake
+++ b/test/cmake/diagnostics/list_unused_snippets.cmake
@@ -31,13 +31,13 @@ function (list_unused_snippets snippet_base_path)
         # e.g. /seqan3/test/snippet/../../doc/tutorial/pairwise_alignment
         get_filename_component (source_dir "${source}" DIRECTORY)
         # e.g. ../../doc/tutorial/pairwise_alignment
-        file (RELATIVE_PATH source_relative_dir "${snippet_base_path}" "${source_dir}")
+        file (RELATIVE_PATH source_relative_stem "${snippet_base_path}" "${source_dir}/${source_wle}")
 
         # test_snippet_output_list adds all potential cout / cerr files even if they don't really exist
         # This list will be subtracted from the real list of files, so it can contain "more" without changing the
         # result.
-        list (APPEND test_snippet_output_list "${source_relative_dir}/${source_wle}.out")
-        list (APPEND test_snippet_output_list "${source_relative_dir}/${source_wle}.err")
+        list (APPEND test_snippet_output_list "${source_relative_stem}.out")
+        list (APPEND test_snippet_output_list "${source_relative_stem}.err")
     endforeach ()
 
     # create the difference between test_snippet_output_glob_list set and test_snippet_output_list set.


### PR DESCRIPTION
This does not affect seqan3 right now because we don't have snippets in `/test/snippet` directly. Reusing the `list_unused_snippets.cmake` in other repos (e.g. argument parser), will fail if snippets are on the `current cmake source dir`.

This PR fixes it in seqan3 so we never run into the problem in case we do have a snippet in `/test/snippet` at some point.

e.g.
if there is a snippet here
```
test/snippet/top_level.cpp
```

then in the script, 
* -> the variable `${source_relative_dir}` would be empty.
* -> the command 
  ```
  list (APPEND test_snippet_output_list "${source_relative_dir}/${source_wle}.err")
  ```
  would then faultily add `/top_level.cpp` to `test_snippet_output_list`
* -> in line (old)44/(new)49
  ```
  list (REMOVE_ITEM test_snippet_output_glob_list ${test_snippet_output_list})
  ```
  test_snippet_output_glob_list contains `top_level.cpp` (without the slash!) and the name would not be removed
* -> the connection between cpp and `.out`/`.err` cannot be made and is listed as an error