### PR TITLE
Missing seqan3::field::cigar.

### DIFF
--- a/test/snippet/io/sam_file/sam_file_input_construction_without_automatic_type_deduction.cpp
+++ b/test/snippet/io/sam_file/sam_file_input_construction_without_automatic_type_deduction.cpp
@@ -15,6 +15,7 @@ int main()
                                           seqan3::field::ref_id,
                                           seqan3::field::ref_offset,
                                           seqan3::field::alignment,
+                                          seqan3::field::cigar,
                                           seqan3::field::mapq,
                                           seqan3::field::qual,
                                           seqan3::field::flag,


### PR DESCRIPTION
The field `seqan3::field::cigar` was missing from the list of default_fields in the SAM snippet.