### PR TITLE
[FIX,DOC] documented empty return type

### DIFF
--- a/include/seqan3/alignment/pairwise/edit_distance_algorithm.hpp
+++ b/include/seqan3/alignment/pairwise/edit_distance_algorithm.hpp
@@ -82,8 +82,6 @@ public:
      * \param[in] callback The callback function to be invoked with the alignment result; must model
      *                     std::invocable with the respective seqan3::alignment_result type.
      *
-     * \returns A std::vector over seqan3::alignment_result.
-     *
      * \details
      *
      * Computes for each contained sequence pair the respective alignment and invokes the given callback for each

--- a/include/seqan3/alignment/pairwise/policy/affine_gap_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/affine_gap_policy.hpp
@@ -171,7 +171,6 @@ private:
     /*!\brief Initialise the alignment state for affine gap computation.
      * \tparam alignment_configuration_t The type of alignment configuration.
      * \param[in] config The alignment configuration.
-     * \returns The initialised seqan3::detail::alignment_algorithm_state.
      *
      * \details
      *

--- a/include/seqan3/alignment/pairwise/policy/simd_affine_gap_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/simd_affine_gap_policy.hpp
@@ -149,7 +149,6 @@ private:
     /*!\brief Initialise the alignment state for affine gap computation.
      * \tparam alignment_configuration_t The type of alignment configuration.
      * \param[in] config The alignment configuration.
-     * \returns The initialised seqan3::detail::alignment_algorithm_state.
      *
      * \details
      *

--- a/include/seqan3/alphabet/container/bitpacked_sequence.hpp
+++ b/include/seqan3/alphabet/container/bitpacked_sequence.hpp
@@ -730,7 +730,6 @@ public:
      * \{
      */
     /*!\brief Removes all elements from the container.
-     * \returns The number of elements in the container.
      *
      * ### Complexity
      *

--- a/include/seqan3/alphabet/container/concatenated_sequences.hpp
+++ b/include/seqan3/alphabet/container/concatenated_sequences.hpp
@@ -1001,7 +1001,6 @@ public:
      * \{
      */
     /*!\brief Removes all elements from the container.
-     * \returns The number of elements in the container.
      *
      * ### Complexity
      *

--- a/include/seqan3/argument_parser/validators.hpp
+++ b/include/seqan3/argument_parser/validators.hpp
@@ -408,7 +408,6 @@ protected:
 
     /*!\brief Checks if the given path is readable.
      * \param path The path to check.
-     * \returns `true` if readable, otherwise `false`.
      * \throws seqan3::validation_error if the path is not readable, or
      *         std::filesystem::filesystem_error on underlying OS API errors.
      */
@@ -436,7 +435,6 @@ protected:
 
     /*!\brief Checks if the given path is writable.
      * \param path The path to check.
-     * \returns `true` if writable, otherwise `false`.
      * \throws seqan3::validation_error if the file could not be opened for writing, or
      *         std::filesystem::filesystem_error on underlying OS API errors.
      */


### PR DESCRIPTION
See https://cdash.seqan.de/testDetails.php?test=60807415&build=212179

Doxygen-trunk warns when `\returns` is used for a function returning `void`.