### PR TITLE
[INFRA] Add missing includes for gcc11 -std=c++17

### DIFF
--- a/include/seqan3/io/sam_file/input_format_concept.hpp
+++ b/include/seqan3/io/sam_file/input_format_concept.hpp
@@ -13,6 +13,7 @@
 #pragma once
 
 #include <fstream>
+#include <optional>
 #include <string>
 #include <vector>
 

--- a/include/seqan3/io/sam_file/output_format_concept.hpp
+++ b/include/seqan3/io/sam_file/output_format_concept.hpp
@@ -13,6 +13,7 @@
 #pragma once
 
 #include <fstream>
+#include <optional>
 #include <string>
 #include <vector>
 

--- a/test/cmake/seqan3_require_benchmark.cmake
+++ b/test/cmake/seqan3_require_benchmark.cmake
@@ -62,9 +62,20 @@ macro (seqan3_require_benchmark)
     set (gbenchmark_git_tag "v1.6.0")
 
     if (NOT CMAKE_VERSION VERSION_LESS 3.14)
-        # NOTE: setting the standard prevents an ICE involving passing -fconcepts through CMAKE_CXX_FLAGS
-        set (CMAKE_CXX_STANDARD 17)
         message (STATUS "Fetch Google Benchmark:")
+
+        # We clear the CXX_FLAGS while initialising Google Benchmark, and restore them afterwards.
+        # Google Benchmark wants to compile with `-std=c++11`.
+        # If we pass `-DCMAKE_CXX_FLAGS=-std=c++17 -fconcepts`, it will append the `-std=c++11`:
+        # `-std=c++17 -fconcepts -std=c++11`, flags are evaluated left to right and may overwrite the previous flag:
+        # `-fconcepts -std=c++11`: This results in an ICE, because `-fconcepts` needs `-std=c++17`.
+        #
+        # The same behaviour is applied when compiling with `-std=c++20`, but as there is no `-fconcepts` passed,
+        # the flag is just overwritten with `-std=c++11`.
+        #
+        # The version that uses ExternalProject is not affected, because we do not pass our `CMAKE_CXX_FLAGS`.
+        set (SEQAN3_BACKUP_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+        set (CMAKE_CXX_FLAGS "" CACHE INTERNAL "")
 
         include (FetchContent)
         FetchContent_Declare (
@@ -75,9 +86,11 @@ macro (seqan3_require_benchmark)
         option (BENCHMARK_ENABLE_TESTING "" OFF)
         FetchContent_MakeAvailable(gbenchmark_fetch_content)
 
+        set (CMAKE_CXX_FLAGS "${SEQAN3_BACKUP_CXX_FLAGS}" CACHE INTERNAL "")
+        unset (SEQAN3_BACKUP_CXX_FLAGS)
+
         # NOTE: google benchmark's CMakeLists.txt already defines Shlwapi
         add_library (gbenchmark ALIAS benchmark_main)
-        unset (CMAKE_CXX_STANDARD)
     else ()
         message (STATUS "Use Google Benchmark as external project:")
 


### PR DESCRIPTION
Resolves #2913 

The first commit is needed to allow `-DCMAKE_CXX_FLAGS=-std=c++17 -fconcepts` with gcc11.
Previously, we set the `CMAKE_CXX_STANDARD`, which works for some cases but not all.
Clearing `CMAKE_CXX_FLAGS` is more general and equivalent to what happens when using the `ExternalProject` approach/fallback.

The second commit adds two missing includes for gcc11 in cpp17 mode.

After this PR is merged, I can add nightlies for gcc11 cpp17 header tests.