### PR TITLE
[FIX] Remove invisible characters 👻 

### DIFF
--- a/include/seqan3/core/all.hpp
+++ b/include/seqan3/core/all.hpp
@@ -50,7 +50,7 @@
   * state to express a general intend of the API without being explicit about it.
   *
   * For example, see https://eel.is/c++draft/iterator.concept.readable where `indirectly-readable-impl` describes the
-  * general intention of the concept, but does not name it since it is a helper-entity for the std::indirectly_­readable
+  * general intention of the concept, but does not name it since it is a helper-entity for the std::indirectly_readable
   * concept.
   */
 

--- a/include/seqan3/core/detail/iterator_traits.hpp
+++ b/include/seqan3/core/detail/iterator_traits.hpp
@@ -44,10 +44,10 @@ struct maybe_iterator_category
     /*!\brief The iterator category tag. (not always present!)
      * \details
      *
-     * This member is only defined if and only if std::iterator_­traits<underlying_iterator_t>::​iterator_­category is
+     * This member is only defined if and only if std::iterator_traits<underlying_iterator_t>::iterator_category is
      * valid and denotes a type.
      */
-    using iterator_category = MAYBE_PRESENT(std::iterator_­traits<underlying_iterator_t>::​iterator_­category);
+    using iterator_category = MAYBE_PRESENT(std::iterator_traits<underlying_iterator_t>::iterator_category);
 #endif // SEQAN3_DOXYGEN_ONLY(1)0
 };
 

--- a/include/seqan3/core/platform.hpp
+++ b/include/seqan3/core/platform.hpp
@@ -309,7 +309,7 @@
 #   endif // SEQAN3_DISABLE_LEGACY_STD_DIAGNOSTIC
 #endif // _GLIBCXX_USE_CXX11_ABI == 0
 
-/*!\brief https://eel.is/c++draft/range.take#view defines e.g. `constexpr auto size() requires sized_­range<V>` without
+/*!\brief https://eel.is/c++draft/range.take#view defines e.g. `constexpr auto size() requires sized_range<V>` without
  *        any template. This syntax works since gcc-10, before that a dummy `template <typename = ...>` must be used.
  */
 #ifndef SEQAN3_WORKAROUND_GCC_NON_TEMPLATE_REQUIRES

--- a/include/seqan3/std/bit
+++ b/include/seqan3/std/bit
@@ -139,7 +139,7 @@ namespace std
 template<class T> constexpr int countl_zero(T x) noexcept;
 #endif // SEQAN3_CPP_LIB_BITOPS
 
-// // bit_­cast
+// // bit_cast
 // template<class To, class From> constexpr To bit_cast(const From& from) noexcept;
 //
 // // integral powers of 2

--- a/include/seqan3/std/concepts
+++ b/include/seqan3/std/concepts
@@ -68,7 +68,7 @@ using ::concepts::derived_from;
 // [concept.convertible], concept convertible_to
 using ::concepts::convertible_to;
 
-// [concept.commonref], concept common_­reference_­with
+// [concept.commonref], concept common_reference_with
 using ::concepts::common_reference_with;
 
 // [concept.common], concept common_with

--- a/include/seqan3/std/iterator
+++ b/include/seqan3/std/iterator
@@ -122,7 +122,7 @@ using ::ranges::cpp20::forward_iterator;
 // [iterator.concept.bidir], concept bidirectional_iterator
 using ::ranges::cpp20::bidirectional_iterator;
 
-// [iterator.concept.random.access], concept random_­access_­iterator
+// [iterator.concept.random.access], concept random_access_iterator
 using ::ranges::cpp20::random_access_iterator;
 
 // [iterator.concept.contiguous], concept contiguous_iterator


### PR DESCRIPTION
```
include/seqan3/core/detail/iterator_traits.hpp:50:50: error: extended character ­ is not valid in an identifier
   50 |     using iterator_category = MAYBE_PRESENT(std::iterator_­traits<underlying_iterator_t>::​iterator_­category);
      |                                                  ^
```