### PR TITLE
Feature/avx512 transform

### DIFF
--- a/include/seqan3/utility/simd/algorithm.hpp
+++ b/include/seqan3/utility/simd/algorithm.hpp
@@ -432,6 +432,10 @@ constexpr void transpose(std::array<simd_t, simd_traits<simd_t>::length> & matri
         detail::transpose_matrix_sse4(matrix);
     else if constexpr (simd_traits<simd_t>::length == 32) // AVX2 implementation
         detail::transpose_matrix_avx2(matrix);
+#if defined(__AVX512BW__) // Requires byte-word extension of AVX512 instruction set.
+    else if constexpr (simd_traits<simd_t>::length == 64) // AVX512 implementation
+        detail::transpose_matrix_avx512(matrix);
+#endif // defined(__AVX512BW__)
     else
         detail::transpose(matrix);
 }

--- a/include/seqan3/utility/simd/algorithm.hpp
+++ b/include/seqan3/utility/simd/algorithm.hpp
@@ -262,6 +262,19 @@ constexpr simd_t extract_eighth(simd_t const & src)
 }
 //!\endcond
 
+//!\cond
+template <simd::simd_concept simd_t>
+constexpr void transpose(std::array<simd_t, simd_traits<simd_t>::length> & matrix)
+{
+    std::array<simd_t, simd_traits<simd_t>::length> tmp{};
+
+    for (size_t i = 0; i < matrix.size(); ++i)
+        for (size_t j = 0; j < matrix.size(); ++j)
+            tmp[j][i] = matrix[i][j];
+
+    std::swap(tmp, matrix);
+}
+//!\endcond
 } // namespace seqan3::detail
 
 namespace seqan3
@@ -404,13 +417,7 @@ constexpr void store(void * mem_addr, simd_t const & simd_vec)
 template <simd::simd_concept simd_t>
 constexpr void transpose(std::array<simd_t, simd_traits<simd_t>::length> & matrix)
 {
-    std::array<simd_t, simd_traits<simd_t>::length> tmp{};
-
-    for (size_t i = 0; i < matrix.size(); ++i)
-        for (size_t j = 0; j < matrix.size(); ++j)
-            tmp[j][i] = matrix[i][j];
-
-    std::swap(tmp, matrix);
+    detail::transpose(matrix);
 }
 
 //!\cond
@@ -426,7 +433,7 @@ constexpr void transpose(std::array<simd_t, simd_traits<simd_t>::length> & matri
     else if constexpr (simd_traits<simd_t>::length == 32) // AVX2 implementation
         detail::transpose_matrix_avx2(matrix);
     else
-        transpose(matrix);
+        detail::transpose(matrix);
 }
 //!\endcond
 

--- a/include/seqan3/utility/simd/detail/simd_algorithm_avx512.hpp
+++ b/include/seqan3/utility/simd/detail/simd_algorithm_avx512.hpp
@@ -96,9 +96,108 @@ constexpr void store_avx512(void * mem_addr, simd_t const & simd_vec)
     _mm512_storeu_si512(mem_addr, reinterpret_cast<__m512i const &>(simd_vec));
 }
 
-// TODO: not implemented and used yet, if you implement it don't forget to add it to seqan3::simd::transpose
+#if defined(__AVX512BW__)
 template <simd::simd_concept simd_t>
-inline void transpose_matrix_avx512(std::array<simd_t, simd_traits<simd_t>::length> & matrix);
+inline void transpose_matrix_avx512(std::array<simd_t, simd_traits<simd_t>::length> & matrix)
+{
+    // Transposing a 64x64 byte matrix in 6x64 instructions using AVX512 intrinsics.
+    // Step 1: Unpack 8-bit operands.
+
+    // Note: _mm512_unpack* operates on 128-bit lanes, i.e. the following pattern applies:
+    //  * for lower half ('lo')
+    //       d[127:0]   = interleave(a[63:0],    b[63:0])
+    //       d[255:128] = interleave(a[191:128], b[191:128])
+    //       d[383:256] = interleave(a[319:256], b[319:256])
+    //       d[511:384] = interleave(a[447:384], b[447:384])
+    //  * for higher half ('hi')
+    //       d[127:0]   = interleave(a[127:64],  b[127:64])
+    //       d[255:128] = interleave(a[255:192], b[255:192])
+    //       d[383:256] = interleave(a[319:320], b[383:320])
+    //       d[511:384] = interleave(a[511:448], b[511:448])
+    __m512i tmp1[64];
+    for (int i = 0; i < 32; ++i)
+    {
+        tmp1[i]    = _mm512_unpacklo_epi8(
+            reinterpret_cast<const __m512i &>(matrix[2*i]),
+            reinterpret_cast<const __m512i &>(matrix[2*i+1])
+        );
+        tmp1[i+32] = _mm512_unpackhi_epi8(
+            reinterpret_cast<const __m512i &>(matrix[2*i]),
+            reinterpret_cast<const __m512i &>(matrix[2*i+1])
+        );
+    }
+
+    // Step 2: Unpack 16-bit operands.
+    __m512i tmp2[64];
+    for (int i = 0; i < 32; ++i)
+    {
+        tmp2[i]    = _mm512_unpacklo_epi16(tmp1[2*i], tmp1[2*i+1]);
+        tmp2[i+32] = _mm512_unpackhi_epi16(tmp1[2*i], tmp1[2*i+1]);
+    }
+    // Step 3: Unpack 32-bit operands.
+    for (int i = 0; i < 32; ++i)
+    {
+        tmp1[i]    = _mm512_unpacklo_epi32(tmp2[2*i], tmp2[2*i+1]);
+        tmp1[i+32] = _mm512_unpackhi_epi32(tmp2[2*i], tmp2[2*i+1]);
+    }
+    // Step 4: Unpack 64-bit operands.
+    for (int i = 0; i < 32; ++i)
+    {
+        tmp2[i]    = _mm512_unpacklo_epi64(tmp1[2*i], tmp1[2*i+1]);
+        tmp2[i+32] = _mm512_unpackhi_epi64(tmp1[2*i], tmp1[2*i+1]);
+    }
+
+    // Step 5: Unpack 128-bit operands.
+    // Helper function to emulate unpack of 128-bit across lanes using _mm512_permutex2var_epi64.
+    auto _mm512_unpacklo_epi128 = [] (__m512i const & a, __m512i const & b)
+    {
+        constexpr std::array<uint64_t, 8> lo_mask{ 0, 1, 8, 9, 2, 3, 10, 11};
+        return _mm512_permutex2var_epi64(a, reinterpret_cast<__m512i const &>(*lo_mask.data()), b);
+    };
+
+    auto _mm521_unpackhi_epi128 = [] (__m512i const & a, __m512i const & b)
+    {
+        constexpr std::array<uint64_t, 8> hi_mask{ 4, 5, 12, 13, 6, 7, 14, 15};
+        return _mm512_permutex2var_epi64(a, reinterpret_cast<__m512i const &>(*hi_mask.data()), b);
+    };
+
+    for (int i = 0; i < 32; ++i)
+    {
+        tmp1[i]    = _mm512_unpacklo_epi128(tmp2[2*i], tmp2[2*i+1]);
+        tmp1[i+32] = _mm521_unpackhi_epi128(tmp2[2*i], tmp2[2*i+1]);
+    }
+    // Step 6: Unpack 128-bit operands.
+    // Helper function to emulate unpack of 256-bit across lanes using _mm512_shuffle_i64x2.
+    auto _mm512_unpacklo_epi256 = [] (__m512i const & a, __m512i const & b)
+    {
+        return _mm512_shuffle_i64x2(a, b, 0b0100'0100);
+    };
+
+    auto _mm521_unpackhi_epi256 = [] (__m512i const & a, __m512i const & b)
+    {
+        return _mm512_shuffle_i64x2(a, b, 0b1110'1110);
+    };
+
+    // A look-up table to place the final transposed vector to the correct position in the
+    // original matrix.
+    constexpr std::array<uint32_t, 64> reverse_idx_mask{
+    // 00  01  02  03  04  05  06  07  08  09  10  11  12  13  14  15
+        0, 16,  8, 24,  4, 20, 12, 28,  2, 18, 10, 26,  6, 22, 14, 30,
+    // 16  17  18  19  20  21  22  23  24  25  26  27  28  29  30  31
+        1, 17,  9, 25,  5, 21, 13, 29,  3, 19, 11, 27,  7, 23, 15, 31,
+    // 32  33  34  35  36  37  38  39  40  41  42  43  44  45  46  47
+       32, 48, 40, 56, 36, 52, 44, 60, 34, 50, 42, 58, 38, 54, 46, 62,
+    // 48  49  50  51  52  53  54  55  56  57  58  59  60  61  62  63
+       33, 49, 41, 57, 37, 53, 45, 61, 35, 51, 43, 59, 39, 55, 47, 63};
+
+    for (int i = 0; i < 32; ++i)
+    {
+        int const idx = i * 2;
+        matrix[reverse_idx_mask[idx]]   = reinterpret_cast<simd_t>(_mm512_unpacklo_epi256(tmp1[idx], tmp1[idx+1]));
+        matrix[reverse_idx_mask[idx+1]] = reinterpret_cast<simd_t>(_mm521_unpackhi_epi256(tmp1[idx], tmp1[idx+1]));
+    }
+}
+#endif // defined(__AVX512BW__)
 
 template <simd::simd_concept target_simd_t, simd::simd_concept source_simd_t>
 constexpr target_simd_t upcast_signed_avx512(source_simd_t const & src)


### PR DESCRIPTION
This PR fixes issues with AVX512 transform and adds an efficient transform operation of a 64x64 matrix using AVX512 instructions. 
This feature has a great impact on the performance of the SIMD alignment code on AVX512.
It is only available for CPUs with `__AVX512BW__` support and otherwise falls back to the less efficient transform operation.