### PR TITLE
[INFRA] gcc12: Disable warning about ABI

### DIFF
--- a/test/seqan3-test.cmake
+++ b/test/seqan3-test.cmake
@@ -57,6 +57,14 @@ list(APPEND CMAKE_MODULE_PATH "${SEQAN3_TEST_CMAKE_MODULE_DIR}")
 if (NOT TARGET seqan3::test)
     add_library (seqan3_test INTERFACE)
     target_compile_options (seqan3_test INTERFACE "-pedantic"  "-Wall" "-Wextra" "-Werror")
+
+    # GCC12 and above: Disable warning about std::hardware_destructive_interference_size not being ABI-stable.
+    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+        if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 12)
+            target_compile_options (seqan3_test INTERFACE "-Wno-interference-size")
+        endif ()
+    endif ()
+
     target_link_libraries (seqan3_test INTERFACE "seqan3::seqan3" "pthread")
     target_include_directories (seqan3_test INTERFACE "${SEQAN3_TEST_INCLUDE_DIR}")
     add_library (seqan3::test ALIAS seqan3_test)


### PR DESCRIPTION
```
include/seqan3/contrib/parallel/buffer_queue.hpp:354:18: error: use of ‘std::hardware_destructive_interference_size’ [-Werror=interference-size]
  354 |     alignas(std::hardware_destructive_interference_size) std::shared_mutex mutable mutex{};
      |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
include/seqan3/contrib/parallel/buffer_queue.hpp:354:18: note: its value can vary between compiler versions or with different ‘-mtune’ or ‘-mcpu’ flags
include/seqan3/contrib/parallel/buffer_queue.hpp:354:18: note: if this use is part of a public ABI, change it to instead use a constant variable you define
include/seqan3/contrib/parallel/buffer_queue.hpp:354:18: note: the default value for the current CPU tuning is 128 bytes
include/seqan3/contrib/parallel/buffer_queue.hpp:354:18: note: you can stabilize this value with ‘--param hardware_destructive_interference_size=128’, or disable this warning with ‘-Wno-interference-size’
```

We're header-only, so we do not care about this warning as we only encounter it when we build tests.