### PR TITLE
[FEATURE] Adds missing extract implementations for AVX512.

### DIFF
--- a/include/seqan3/utility/simd/algorithm.hpp
+++ b/include/seqan3/utility/simd/algorithm.hpp
@@ -161,6 +161,8 @@ constexpr simd_t extract_half(simd_t const & src)
         return detail::extract_half_sse4<index>(src);
     else if constexpr (simd_traits<simd_t>::max_length == 32) // AVX2
         return detail::extract_half_avx2<index>(src);
+    else if constexpr (simd_traits<simd_t>::max_length == 64) // AVX512
+        return detail::extract_half_avx512<index>(src);
     else // Anything else
         return detail::extract_impl<2>(src, index);
 }
@@ -210,6 +212,10 @@ constexpr simd_t extract_quarter(simd_t const & src)
         return detail::extract_quarter_sse4<index>(src);
     else if constexpr (simd_traits<simd_t>::max_length == 32) // AVX2
         return detail::extract_quarter_avx2<index>(src);
+#if defined(__AVX512DQ__)
+    else if constexpr (simd_traits<simd_t>::max_length == 64) // AVX512
+        return detail::extract_quarter_avx512<index>(src);
+#endif // defined(__AVX512DQ__)
     else // Anything else
         return detail::extract_impl<4>(src, index);
 }
@@ -257,6 +263,10 @@ constexpr simd_t extract_eighth(simd_t const & src)
         return detail::extract_eighth_sse4<index>(src);
     else if constexpr (simd_traits<simd_t>::max_length == 32) // AVX2
         return detail::extract_eighth_avx2<index>(src);
+#if defined(__AVX512DQ__)
+    else if constexpr (simd_traits<simd_t>::max_length == 64) // AVX512
+        return detail::extract_eighth_avx512<index>(src);
+#endif // defined(__AVX512DQ__)
     else  // Anything else
         return detail::extract_impl<8>(src, index);
 }


### PR DESCRIPTION
This PR adds the missing implementations for the family of extract functions specific to the AVX512 instruction set, as they are much faster then the default implementation. 

A bit on the background: 
These functions allow to extract only a part (half, i.e. 2x256 bit, quarter, i.e. 4x128 bit, or eighth, i.e. 8x64 bit) of the given simd vector and are used in combination with the upcast function in order to sign/zero extend a simd vector to a set of simd vectors with larger operand types, e.g. one vint_8x64_t vector to 2 vint_16x32_t vectors, with 8 (16) being the bit-size of the operands and 64 (32) being the number of operands that fit into a single __m512i vector type.

The extracted bytes will be placed in the lower bits of the target simd vector. There is no dedicated intrinsic to extract only 64 bits, so I had to emulate it with the intrinsic to extract 128 bit and using an additional shuffle operation for the uneven indices. This shuffle operation exchanges the higher 64 bits with the lower 64 bits of each of the four 128 bit lanes of the source simd vector. When  upcasting this vector, only the first 64 bits are considered (Note this is only needed when going from 8-bit operands to 64-bit operands) 