### PR TITLE
[MISC] relax kmer_hash_view::iterator difference requirement

### DIFF
--- a/include/seqan3/search/views/kmer_hash.hpp
+++ b/include/seqan3/search/views/kmer_hash.hpp
@@ -526,7 +526,7 @@ public:
      */
     friend difference_type operator-(basic_iterator const & lhs, basic_iterator const & rhs) noexcept
     //!\cond
-        requires std::random_access_iterator<it_t>
+        requires std::sized_sentinel_for<it_t, it_t>
     //!\endcond
     {
         return static_cast<difference_type>(lhs.text_right - rhs.text_right);


### PR DESCRIPTION
The difference operator on iterators only needs the requirement `std::sized_sentinel_for<it_t, it_t>`, i.e. the underlying iterator has a difference operator, instead of the full `std::random_access_iterator`.

The [random_access_iterator](https://en.cppreference.com/w/cpp/iterator/random_access_iterator) requires that as a subclause

```c++
    std::totally_ordered<I> &&
    std::sized_sentinel_for<I, I> && // here
    requires(I i, const I j, const std::iter_difference_t<I> n) {
```

An example from the standard would be here: https://eel.is/c++draft/range.adaptors#range.transform.iterator-22 where it also only requires `std::sized_sentinel_for`.