### PR TITLE
[MISC] add minimiser_view::basic_iterator::base

### DIFF
--- a/include/seqan3/search/views/minimiser.hpp
+++ b/include/seqan3/search/views/minimiser.hpp
@@ -379,6 +379,18 @@ public:
         return minimiser_value;
     }
 
+    //!\brief Return the underlying iterator. It will point to the last element in the current window.
+    constexpr urng1_iterator_t const & base() const & noexcept
+    {
+        return urng1_iterator;
+    }
+
+    //!\brief Return the underlying iterator. It will point to the last element in the current window.
+    constexpr urng1_iterator_t base() &&
+    {
+        return std::move(urng1_iterator);
+    }
+
 private:
     //!\brief The minimiser value.
     value_type minimiser_value{};


### PR DESCRIPTION
This PR adds a `base()` function to `minimiser_view::basic_iterator` which returns the underlying iterator of that view. This is in line with the standard which offers the same `base` function for view iterators, e.g. https://eel.is/c++draft/range.filter#iterator-5.

The use case is that @eaasna needs to know the position of the "minimiser" window and the only viable way was to completely copy the complete class and add a position member (see https://github.com/eaasna/sliding-window/blob/master/include/indexed_minimiser.hpp) as one can't infer from the public API where a certain minimiser value comes from.

This introduces a lot of unnecessary duplicated code. The change allows the following much shorter implementation which only relies on public API:

```c++
std::vector<size_t> hashes{/*...*/};
using hash_iterator_t = typename std::vector<size_t>::iterator;

hash_iterator_t hash_begin = hashes.begin();

size_t window_size = 5;
auto minimiser = seqan3::views::minimiser(hashes, window_size);
auto minimiser_it = minimiser.begin();

// hash iterator is at position window_size - 1 and
// points to the last element in the window
// [h0, h1, h2, h3, h4], h5, h6, h7, h8
//                   ^
hash_iterator_t hash_it = minimiser_it.base(); 
assert(hash_it - hash_begin == window_size - 1);

++minimiser_it;

// points to the last element in the window
// h0, h1, h2, [h3, h4, h5, h6, h7], h8
//                               ^
hash_it = minimiser_it.base(); 
assert(hash_it - hash_begin == 7);
```

-----

Some further considerations:

If we made `minimiser_position_offset` (maybe `minimiser_offset` might be a better name?) public too, one could infer the exact position which hash element was the minimiser for the current window.