### PR TITLE
[MISC] gcc-12 support: Fix enable_view for ranges-v3 compatibility.

### DIFF
--- a/include/seqan3/std/ranges
+++ b/include/seqan3/std/ranges
@@ -46,8 +46,10 @@
 
 namespace ranges
 {
-//!\brief std::ranges::views are valid range-v3 views
-template<::std::derived_from<::std::ranges::view_base> T>
+//!\brief std::ranges::views are valid range-v3 views.
+template<typename T>
+    requires ::std::derived_from<T, ::std::ranges::view_base> ||
+             ::std::derived_from<T, ::std::ranges::view_interface<T>>
 inline constexpr bool enable_view<T> = true;
 
 //!\cond


### PR DESCRIPTION
Part of gcc12 support https://github.com/seqan/product_backlog/issues/402

**Problem:** `view_interface` is not derived from `view_base` any more.

See change in stl:

* https://github.com/gcc-mirror/gcc/commit/53b1c382d5a6fe8dec394a7ff820d77cda02af81
* https://cplusplus.github.io/LWG/issue3549

This affects our `enable_view` comptatibility here:
https://github.com/seqan/seqan3/blob/75de3b1df8cf38df521f939e499d84ecf3100d8c/include/seqan3/std/ranges#L49-L51

Workaround:

Set `enable_view` to true if view is derived from `view_interface`.
```cpp
//!\brief std::ranges::views are valid range-v3 views
template<typename T>
    requires ::std::derived_from<T, ::std::ranges::view_base> ||
             ::std::derived_from<T, ::std::ranges::view_interface<T>>
inline constexpr bool enable_view<T> = true;
```