### PR TITLE
[INFRA] cmake-format action

### DIFF
--- a/.cmake-format.yaml
+++ b/.cmake-format.yaml
@@ -1,7 +1,7 @@
 _seqan3_cmake_format_documentation_only:
   install:
     command:
-      - pip install cmakelang
+      - pip install cmakelang[YAML]
     repo:
       - https://github.com/cheshirekow/cmake_format
   example:

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -26,6 +26,7 @@ jobs:
     name: API-Stability gcc${{ matrix.compiler }}
     runs-on: ubuntu-20.04
     timeout-minutes: 300
+    if: github.repository_owner == 'seqan' || github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/avx2.yml
+++ b/.github/workflows/avx2.yml
@@ -26,6 +26,7 @@ jobs:
     name: ${{ matrix.build }} gcc${{ matrix.compiler }}
     runs-on: ubuntu-20.04
     timeout-minutes: 300
+    if: github.repository_owner == 'seqan' || github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -8,6 +8,8 @@ on:
       # Push events to branches matching refs/heads/release*
       - 'release*'
   pull_request:
+  # Enables a manual trigger, may run on any branch
+  workflow_dispatch:
 
 concurrency:
   group: linux-${{ github.event.pull_request.number || github.ref }}
@@ -27,6 +29,7 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ubuntu-20.04
     timeout-minutes: 120
+    if: github.repository_owner == 'seqan' || github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -8,6 +8,8 @@ on:
       # Push events to branches matching refs/heads/release*
       - 'release*'
   pull_request:
+  # Enables a manual trigger, may run on any branch
+  workflow_dispatch:
 
 concurrency:
   group: macos-${{ github.event.pull_request.number || github.ref }}
@@ -27,6 +29,7 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: macos-10.15
     timeout-minutes: 120
+    if: github.repository_owner == 'seqan' || github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/ci_misc.yml
+++ b/.github/workflows/ci_misc.yml
@@ -8,6 +8,8 @@ on:
       # Push events to branches matching refs/heads/release*
       - 'release*'
   pull_request:
+  # Enables a manual trigger, may run on any branch
+  workflow_dispatch:
 
 concurrency:
   group: misc-${{ github.event.pull_request.number || github.ref }}
@@ -26,6 +28,7 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ubuntu-20.04
     timeout-minutes: 120
+    if: github.repository_owner == 'seqan' || github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/cmake_format.yml
+++ b/.github/workflows/cmake_format.yml
@@ -1,0 +1,72 @@
+name: SeqAn3 cmake-format
+
+on:
+  # Will always run on the default branch
+  schedule:
+    - cron: "0 7 * * SUN"
+  # Enables a manual trigger, may run on any branch. Only works on seqan/seqan3.
+  workflow_dispatch:
+
+concurrency:
+  group: cmake-format-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CMAKE_VERSION: 3.10.3
+  SEQAN3_NO_VERSION_CHECK: 1
+  TZ: Europe/Berlin
+
+defaults:
+  run:
+    shell: bash -exo pipefail {0}
+
+jobs:
+  build:
+    name: cmake-format
+    runs-on: ubuntu-20.04
+    timeout-minutes: 300
+    if: github.repository_owner == 'seqan'
+    steps:
+      - name: Checkout SeqAn3
+        uses: actions/checkout@v2
+        with:
+          path: seqan3
+          submodules: false
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install Python dependencies
+        run: pip install cmakelang[YAML]
+
+      - name: Run cmake-format
+        run: |
+          find seqan3 \( -iname CMakeLists.txt -or -iname "*.cmake" \) \
+          -and -not -path "./submodules/*" \
+          -and -not -path "./build/*" | \
+          xargs cmake-format --config-files seqan3/.cmake-format.yaml --in-place
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v4
+        with:
+          workdir: seqan3
+          gpg_private_key: ${{ secrets.SEQAN_ACTIONS_GPG_KEY }}
+          passphrase: ${{ secrets.SEQAN_ACTIONS_GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          path: seqan3
+          token: ${{ secrets.SEQAN_ACTIONS_PAT }}
+          push-to-fork: seqan-actions/seqan3
+          commit-message: '[CRON] cmake-format'
+          committer: seqan-actions[bot] <seqan-actions@users.noreply.github.com>
+          author: seqan-actions[bot] <seqan-actions@users.noreply.github.com>
+          branch: actions/cmake-format/${{github.repository}}
+          delete-branch: true
+          title: '[CRON] cmake-format'
+          body: Auto-generated cmake-format changes

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-  # Enables a manual trigger.
+  # Enables a manual trigger, may run on any branch
   workflow_dispatch:
 
 concurrency:
@@ -25,6 +25,7 @@ jobs:
     name: Deploy Documentation
     runs-on: ubuntu-20.04
     timeout-minutes: 30
+    if: github.repository_owner == 'seqan' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/latest_libraries.yml
+++ b/.github/workflows/latest_libraries.yml
@@ -26,6 +26,7 @@ jobs:
     name: ${{ matrix.build }} gcc${{ matrix.compiler }}
     runs-on: ubuntu-20.04
     timeout-minutes: 300
+    if: github.repository_owner == 'seqan' || github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ram_usage.yml
+++ b/.github/workflows/ram_usage.yml
@@ -29,6 +29,7 @@ jobs:
     name: RAM-Usage gcc${{ github.event.inputs.compiler }}
     runs-on: ubuntu-20.04
     timeout-minutes: 300
+    if: github.repository_owner == 'seqan' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Checkout SeqAn3
         uses: actions/checkout@v2


### PR DESCRIPTION
## First commit
Adds/Adapts the job requirement to:
```yaml
if: github.repository_owner == 'seqan' || github.event_name == 'workflow_dispatch'
```
Also adds the `workflow_dispatch` (manual trigger) to all actions that did not have one.

This means that actions run *automatically* only on `seqan/seqan3`. Previously, all workflows (including Crons) were also run on Forks - which is kind of wasteful.

However, the workflows are still able to be triggered manually.

## Second commit
Adds an action to run `cmake-format` and create a PR. The branch is created on the fork of [a machine account](https://github.com/seqan-actions), such that we do not have to create a PR branch on `seqan/seqan3`. It's also a bit more secure because it uses fewer privileges than doing it on the main repo.

The `cmake_format` workflow does have a manual trigger. However, it can only be used on `seqan/seqan3`, because we can only create a PR for the base repository. That is, `seqan-actions/seqan3` can create a PR for `seqan/seqan3`, but not for any other `seqan3` fork.