### PR TITLE
[FIX] gcc12: performance tests

### DIFF
--- a/test/performance/alphabet/alphabet_to_char_benchmark.cpp
+++ b/test/performance/alphabet/alphabet_to_char_benchmark.cpp
@@ -22,7 +22,7 @@
 template <typename alphabet_t, bool is_seqan2>
 std::array<alphabet_t, 256> create_alphabet_array()
 {
-    std::array<alphabet_t, 256> alphabet_array{};
+    std::array<alphabet_t, 256> alphabet_array;
 
     auto convert_to_alphabet = [] (auto const c, auto & a)
     {

--- a/test/performance/alphabet/alphabet_to_rank_benchmark.cpp
+++ b/test/performance/alphabet/alphabet_to_rank_benchmark.cpp
@@ -21,7 +21,7 @@
 template <typename alphabet_t, bool is_seqan2>
 std::array<alphabet_t, 256> create_alphabet_array(size_t const alphabet_size)
 {
-    std::array<alphabet_t, 256> alphabet_array{};
+    std::array<alphabet_t, 256> alphabet_array;
 
     auto convert_to_alphabet = [] (auto const rank, auto & a)
     {

--- a/test/performance/io/format_vienna_benchmark.cpp
+++ b/test/performance/io/format_vienna_benchmark.cpp
@@ -28,10 +28,8 @@
 inline constexpr size_t iterations_per_run = 1024;
 
 inline std::string const header{"seq foobar blobber"};
-auto const sequence = seqan3::test::generate_sequence<seqan3::rna4>(474, 0, 0) |
-                                                      seqan3::detail::persist |
-                                                      seqan3::views::to_char |
-                                                      seqan3::views::to<std::string>;
+inline auto const rna_sequence = seqan3::test::generate_sequence<seqan3::rna4>(474, 0, 0);
+auto const sequence =  rna_sequence | seqan3::views::to_char | seqan3::views::to<std::string>;
 
 inline std::string const structure
 {

--- a/test/performance/search/index_construction_benchmark.cpp
+++ b/test/performance/search/index_construction_benchmark.cpp
@@ -51,10 +51,11 @@ struct sequence_store_seqan3
 {
     std::vector<seqan3::dna4> const dna4_rng{seqan3::test::generate_sequence<seqan3::dna4>(max_length, 0, seed)};
     std::vector<seqan3::aa27> const aa27_rng{seqan3::test::generate_sequence<seqan3::aa27>(max_length, 0, seed)};
-    std::string const char_rng{seqan3::test::generate_numeric_sequence<uint8_t>(max_length, 0, 253, seed)
-                               | seqan3::detail::persist
-                               | seqan3::views::rank_to<char>
-                               | seqan3::views::to<std::string>};
+    std::string const char_rng{[] ()
+    {
+        std::vector<uint8_t> const ranks{seqan3::test::generate_numeric_sequence<uint8_t>(max_length, 0, 253, seed)};
+        return ranks | seqan3::views::rank_to<char> | seqan3::views::to<std::string>;
+    }()};
 };
 
 sequence_store_seqan3 store{};
@@ -100,10 +101,11 @@ struct sequence_store_seqan2
     seqan::String<seqan::AminoAcid> const aa27_rng{seqan3::test::generate_sequence_seqan2<seqan::AminoAcid>(max_length,
                                                                                                             0,
                                                                                                             seed)};
-    seqan::String<char> const char_rng{seqan3::test::generate_numeric_sequence<uint8_t>(max_length, 0, 253, seed)
-                                       | seqan3::detail::persist
-                                       | seqan3::views::rank_to<char>
-                                       | seqan3::views::to<std::string>};
+    seqan::String<char> const char_rng{[] ()
+    {
+        std::vector<uint8_t> const ranks{seqan3::test::generate_numeric_sequence<uint8_t>(max_length, 0, 253, seed)};
+        return ranks | seqan3::views::rank_to<char> | seqan3::views::to<std::string>;
+    }()};
 };
 
 sequence_store_seqan2 store2{};


### PR DESCRIPTION
* Avoid `views::persist`
* `std::array<alphabet_t, 256> alphabet_array{};` results in an unused variable warning. We initialize the array, but overwrite the values without using them.