### PR TITLE
[INFRA] Replace pragma once with header guards in std module

### DIFF
--- a/include/seqan3/std/charconv
+++ b/include/seqan3/std/charconv
@@ -11,7 +11,9 @@
  * \author Svenja Mehringer <svenja.mehringer AT fu-berlin.de>
  */
 
-#pragma once
+// File might be included from multiple libraries.
+#ifndef SEQAN_STD_CHARCONV_SHIM
+#define SEQAN_STD_CHARCONV_SHIM
 
 #include <charconv>
 #include <utility> // __cpp_lib_to_chars may be defined here as currently documented.
@@ -270,3 +272,5 @@ using ::seqan3::contrib::charconv_float::from_chars; // import our shim-float ve
 } // namespace std
 
 #endif // __cpp_lib_to_chars < 201611
+
+#endif // SEQAN_STD_CHARCONV_SHIM

--- a/include/seqan3/std/new
+++ b/include/seqan3/std/new
@@ -11,7 +11,9 @@
  * \author Rene Rahn <rene.rahn AT fu-berlin.de>
  */
 
-#pragma once
+// File might be included from multiple libraries.
+#ifndef SEQAN_STD_NEW_SHIM
+#define SEQAN_STD_NEW_SHIM
 
 #include <new>
 
@@ -40,3 +42,5 @@ inline constexpr std::size_t hardware_constructive_interference_size = 64;
 } // namespace std
 
 #endif // __cpp_lib_hardware_interference_size
+
+#endif // SEQAN_STD_NEW_SHIM

--- a/include/seqan3/std/ranges
+++ b/include/seqan3/std/ranges
@@ -11,7 +11,9 @@
  * \author Hannes Hauswedell <hannes.hauswedell AT fu-berlin.de>
  */
 
-#pragma once
+// File might be included from multiple libraries.
+#ifndef SEQAN_STD_RANGES_SHIM
+#define SEQAN_STD_RANGES_SHIM
 
 #include <iterator>
 #include <ranges>
@@ -112,3 +114,5 @@ template<class T>
 //!\endcond
 inline constexpr bool enable_borrowed_range<T> = true;
 } // namespace std::ranges
+
+#endif // SEQAN_STD_RANGES_SHIM


### PR DESCRIPTION
From https://github.com/seqan/seqan3/pull/2954/commits/37a5e79ba7719a46859fedd057bc9d3c26c3c19a

When combining seqan3 and sharg, we have this situation:

```cpp
// seqan3/std/some_struct.hpp
#pragma once

struct some_struct{};
```

and 

```cpp
// sharg-parser/std/some_struct.hpp
#pragma once

struct some_struct{};
```

This will result in multiple definitions of `some_struct` (not allowed).

`#pragma once` only checks that exactly `seqan3/std/some_struct.hpp` is included once.

Hence, we need a header guard that is the same in sharg and seqan3.