### PR TITLE
Remove range-v3 `take` and `single`

### DIFF
--- a/test/unit/alignment/pairwise/alignment_configurator_test.cpp
+++ b/test/unit/alignment/pairwise/alignment_configurator_test.cpp
@@ -9,8 +9,6 @@
 
 #include <seqan3/std/ranges>
 
-#include <range/v3/view/single.hpp>
-
 #include <seqan3/alignment/configuration/align_config_score_type.hpp>
 #include <seqan3/alignment/pairwise/alignment_configurator.hpp>
 #include <seqan3/alignment/pairwise/detail/type_traits.hpp>

--- a/test/unit/std/ranges_test.cpp
+++ b/test/unit/std/ranges_test.cpp
@@ -14,8 +14,6 @@
 
 #include <seqan3/test/expect_same_type.hpp>
 
-#include <range/v3/view/take.hpp>
-
 TEST(ranges_test, take_view)
 {
     std::string s{};
@@ -54,13 +52,6 @@ TEST(ranges_test, drop_view)
     EXPECT_TRUE(std::ranges::view<decltype(std::views::drop(s, 0))>);
 }
 
-TEST(ranges_test, combine_std_with_range_v3)
-{
-    std::string str{"foo"};
-    auto take_first = str | std::views::take(5) | ranges::view::take(1);
-
-    EXPECT_EQ(*std::ranges::begin(take_first), 'f');
-}
 
 // https://github.com/ericniebler/range-v3/issues/1514
 TEST(ranges_test, gcc10bug_rangev3_1514)


### PR DESCRIPTION
This PR does two things:
1. Remove `ranges/v3/take.hpp` by removing an obsolete unit test.
2. Remove an obsolete include of `ranges/v3/single.hpp` which wasn't used.

This is part of https://github.com/seqan/product_backlog/issues/124
-A life Without Range-v3-