### PR TITLE
Replacing ranges::to with a custom minimal implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,11 @@ If possible, provide tooling that performs the changes, e.g. a shell-script.
    entire program. Formerly, this variable was specific to each translation unit
    ([\#2752](https://github.com/seqan/seqan3/pull/2752)).
 
+#### Range
+  * Replaced `seqan3::views::to` (implemented via range-v3) with `seqan3::ranges::to` (implemented in SeqAn3).
+    `seqan3::ranges::to` provides a subset of C++23's `std::ranges::to` and will be replaced with the STL-equivalent
+    in a future version ([\#2969](https://github.com/seqan/seqan3/pull/2969)).
+
 # 3.1.0
 
 ## New features

--- a/doc/tutorial/04_alphabet/alphabet_gc_content.cpp
+++ b/doc/tutorial/04_alphabet/alphabet_gc_content.cpp
@@ -32,7 +32,9 @@ int main(int argc, char * argv[])
         sequence.push_back(seqan3::assign_char_to(c, seqan3::dna5{}));
 
     // Optional: use views for the conversion. Views will be introduced in the next chapter.
-    //std::vector<seqan3::dna5> sequence = input | seqan3::views::char_to<seqan3::dna5> | seqan3::views::to<std::vector>;
+    // std::vector<seqan3::dna5> sequence = input
+    //                                    | seqan3::views::char_to<seqan3::dna5>
+    //                                    | seqan3::ranges::to<std::vector>();
 
     // Initialise an array with count values for dna5 symbols.
     std::array<size_t, seqan3::dna5::alphabet_size> count{}; // default initialised with zeroes
@@ -56,5 +58,6 @@ void alternatively()
 {
     std::string input{};
     // if something changes in here, please update above:
-    std::vector<seqan3::dna5> sequence = input | seqan3::views::char_to<seqan3::dna5> | seqan3::views::to<std::vector>;
+    std::vector<seqan3::dna5> sequence =
+        input | seqan3::views::char_to<seqan3::dna5> | seqan3::ranges::to<std::vector>();
 }

--- a/doc/tutorial/05_ranges/to.cpp
+++ b/doc/tutorial/05_ranges/to.cpp
@@ -1,0 +1,39 @@
+#include <deque>
+#include <forward_list>
+#include <list>
+#include <vector>
+
+#include <seqan3/utility/range/to.hpp>
+
+int main()
+{
+    auto lst = std::views::iota(1, 10); // some range over the numbers 1-10
+
+    // convert range to vector using pipe syntax
+    auto vec0 = lst | seqan3::ranges::to<std::vector<int>>();
+    static_assert(std::same_as<decltype(vec0), std::vector<int>>);
+
+    // convert range to vector but auto deducing the element type
+    auto vec1 = lst | seqan3::ranges::to<std::vector>();
+    static_assert(std::same_as<decltype(vec1), std::vector<int>>);
+
+    // convert range to vector using function call syntax
+    auto vec2 = seqan3::ranges::to<std::vector<int>>(lst);
+    static_assert(std::same_as<decltype(vec2), std::vector<int>>);
+
+    // using function call syntax and auto deducing element type
+    auto vec3 = seqan3::ranges::to<std::vector>(lst);
+    static_assert(std::same_as<decltype(vec3), std::vector<int>>);
+
+    // convert nested ranges into nested containers
+    auto nested_lst = std::list<std::forward_list<int>>{{1, 2, 3}, {4, 5, 6, 7}};
+    auto vec4 = nested_lst | seqan3::ranges::to<std::vector<std::vector<int>>>();
+    static_assert(std::same_as<decltype(vec4), std::vector<std::vector<int>>>);
+
+    // different supported container types
+    auto vec5 = lst | seqan3::ranges::to<std::list>();
+    static_assert(std::same_as<decltype(vec5), std::list<int>>);
+
+    auto vec6 = lst | seqan3::ranges::to<std::deque>();
+    static_assert(std::same_as<decltype(vec6), std::deque<int>>);
+}

--- a/include/seqan3/io/sam_file/format_sam.hpp
+++ b/include/seqan3/io/sam_file/format_sam.hpp
@@ -32,9 +32,9 @@
 #include <seqan3/io/views/detail/istreambuf_view.hpp>
 #include <seqan3/io/views/detail/take_until_view.hpp>
 #include <seqan3/utility/detail/type_name_as_string.hpp>
+#include <seqan3/utility/range/to.hpp>
 #include <seqan3/utility/tuple/concept.hpp>
 #include <seqan3/utility/views/slice.hpp>
-#include <seqan3/utility/views/to.hpp>
 
 namespace seqan3
 {
@@ -323,7 +323,7 @@ inline void format_sam::read_sequence_record(stream_type & stream,
             throw parse_error{"The id information must not be empty."};
 
     if (options.truncate_ids)
-        id = id | detail::take_until_and_consume(is_space) | views::to<id_type>;
+        id = id | detail::take_until_and_consume(is_space) | ranges::to<id_type>();
 }
 
 //!\copydoc sequence_file_output_format::write_sequence_record
@@ -1063,7 +1063,7 @@ inline void format_sam::read_sam_dict_field(stream_view_type && stream_view, sam
     }
     case 'Z': // string
     {
-        target[tag] = stream_view | views::to<std::string>;
+        target[tag] = stream_view | ranges::to<std::string>();
         break;
     }
     case 'H':

--- a/include/seqan3/io/structure_file/format_vienna.hpp
+++ b/include/seqan3/io/structure_file/format_vienna.hpp
@@ -40,7 +40,7 @@
 #include <seqan3/io/views/detail/take_until_view.hpp>
 #include <seqan3/utility/char_operations/predicate.hpp>
 #include <seqan3/utility/detail/type_name_as_string.hpp>
-#include <seqan3/utility/views/to.hpp>
+#include <seqan3/utility/range/to.hpp>
 
 namespace seqan3
 {
@@ -241,7 +241,7 @@ protected:
         {
             std::string e_str = stream_view | detail::take_line
                               | std::views::filter(!(is_space || is_char<'('> || is_char<')'>))
-                              | views::to<std::string>;
+                              | ranges::to<std::string>();
             if (!e_str.empty())
             {
                 size_t num_processed;

--- a/include/seqan3/utility/container/dynamic_bitset.hpp
+++ b/include/seqan3/utility/container/dynamic_bitset.hpp
@@ -17,9 +17,9 @@
 #include <seqan3/core/concept/cereal.hpp>
 #include <seqan3/core/debug_stream/debug_stream_type.hpp>
 #include <seqan3/utility/detail/integer_traits.hpp>
+#include <seqan3/utility/range/to.hpp>
 #include <seqan3/utility/views/interleave.hpp>
 #include <seqan3/utility/views/repeat_n.hpp>
-#include <seqan3/utility/views/to.hpp>
 
 namespace seqan3
 {
@@ -1947,7 +1947,8 @@ public:
     template <typename char_t>
     friend debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, dynamic_bitset arg)
     {
-        s << (std::string_view{arg.to_string()} | views::interleave(4, std::string_view{"'"}) | views::to<std::string>);
+        s << (std::string_view{arg.to_string()} | views::interleave(4, std::string_view{"'"})
+              | ranges::to<std::string>());
         return s;
     }
     //!\}

--- a/include/seqan3/utility/range/all.hpp
+++ b/include/seqan3/utility/range/all.hpp
@@ -79,3 +79,4 @@
 #pragma once
 
 #include <seqan3/utility/range/concept.hpp>
+#include <seqan3/utility/range/to.hpp>

--- a/include/seqan3/utility/range/to.hpp
+++ b/include/seqan3/utility/range/to.hpp
@@ -1,0 +1,196 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2022, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2022, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \author Simon Gene Gottlieb <simon.gottlieb AT fu-berlin.de>
+ * \brief Provides seqan3::ranges::to.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <seqan3/std/ranges>
+
+#include <seqan3/core/range/detail/adaptor_from_functor.hpp>
+#include <seqan3/utility/concept.hpp>
+
+namespace seqan3::detail
+{
+
+//!\brief Function object to convert a std::ranges::input_range to a fully defined container.
+template <typename container_t>
+    requires (!std::ranges::view<container_t>)
+struct to_fn
+{
+private:
+    /*!\brief Copies a range into a container.
+     * \tparam rng_t       Type of the range.
+     * \tparam container_t Type of the target container.
+     */
+    template <std::ranges::input_range rng_t>
+        requires std::convertible_to<std::ranges::range_reference_t<rng_t>, std::ranges::range_value_t<container_t>>
+    auto impl(rng_t && rng, container_t & container) const
+    {
+        std::ranges::copy(rng, std::back_inserter(container));
+    }
+
+    //!\overload
+    template <std::ranges::input_range rng_t>
+    auto impl(rng_t && rng, container_t & container) const
+        requires std::ranges::input_range<std::ranges::range_value_t<rng_t>>
+    {
+        auto adaptor = to_fn<std::ranges::range_value_t<container_t>>{};
+        auto inner_rng = rng | std::views::transform(adaptor);
+        std::ranges::copy(inner_rng, std::back_inserter(container));
+    }
+
+public:
+    /*!\brief Converts a template-template into a container.
+     * \tparam rng_t  The type of the range being processed.
+     * \tparam args_t The types of the arguments for the constructor.
+     * \param  rng    The range being processed.
+     * \param  args   Arguments to pass to the constructor of the container.
+     */
+    template <std::ranges::input_range rng_t, typename... args_t>
+    constexpr auto operator()(rng_t && rng, args_t &&... args) const
+    {
+        auto new_container = container_t(std::forward<args_t>(args)...);
+
+        // reserve memory if functionality is available
+        if constexpr (std::ranges::sized_range<rng_t> && requires (container_t c) { c.reserve(size_t{}); })
+            new_container.reserve(std::ranges::size(rng));
+
+        impl(std::forward<rng_t>(rng), new_container);
+        return new_container;
+    }
+};
+
+/*!\brief Similar to to_fn, but accepts a template-template as argument,
+ *        e.g.: to_fn<vector> instead of to_fn<vector<int>>.
+ */
+template <template <typename> typename container_t>
+struct to_template_template_fn
+{
+    /*!\brief Converts a template-template into a container.
+     * \tparam rng_t  The type of the range being processed.
+     * \tparam args_t The types of the arguments for the constructor.
+     * \param  rng    The range being processed.
+     * \param  args   Arguments to pass to the constructor of the container.
+     */
+    template <std::ranges::input_range rng_t, typename... args_t>
+    constexpr auto operator()(rng_t && rng, args_t &&... args) const
+    {
+        auto adaptor = to_fn<container_t<std::ranges::range_value_t<rng_t>>>{};
+        return adaptor(std::forward<rng_t>(rng), std::forward<args_t>(args)...);
+    }
+};
+
+} // namespace seqan3::detail
+
+namespace seqan3::ranges
+{
+
+/*!\brief Converts a range to a container.
+ * \ingroup utility_range
+ * \details
+ * To convert a range to a container, either the "pipe syntax" or the "function call" syntax can be used.
+ * Both syntaxes support the explicit specification of the target container or
+ * a specification with a deduced value type.
+ *
+ * Currently supported containers are:
+ * - `std::vector`
+ * - `std::list`
+ * - `std::deque`
+ *
+ * \include doc/tutorial/05_ranges/to.cpp
+ *
+ * \noapi{This is a implementation of the C++23 ranges::to. It will be replaced with std::ranges::to.}
+ */
+template <typename container_t, typename... args_t>
+constexpr auto to(args_t &&... args)
+{
+    return detail::adaptor_from_functor{detail::to_fn<container_t>{}, std::forward<args_t>(args)...};
+}
+
+/*!\brief Converts a range to a container.
+ * \ingroup utility_range
+ * \overload
+ */
+template <template <typename...> typename container_t, typename... args_t>
+constexpr auto to(args_t &&... args)
+{
+    return detail::adaptor_from_functor{detail::to_template_template_fn<container_t>{}, std::forward<args_t>(args)...};
+}
+
+/*!\brief Converts a range to a container.
+ * \ingroup utility_range
+ * \overload
+ */
+template <typename container_t, std::ranges::input_range rng_t, typename... args_t>
+constexpr auto to(rng_t && rng, args_t &&... args)
+{
+    return detail::adaptor_from_functor{detail::to_fn<container_t>{},
+                                        std::forward<args_t>(args)...}(std::forward<rng_t>(rng));
+}
+
+/*!\brief Converts a range to a container.
+ * \ingroup utility_range
+ * \overload
+ */
+template <template <class...> typename container_t, std::ranges::input_range rng_t, typename... args_t>
+constexpr auto to(rng_t && rng, args_t &&... args)
+{
+    return detail::adaptor_from_functor{detail::to_template_template_fn<container_t>{},
+                                        std::forward<args_t>(args)...}(std::forward<rng_t>(rng));
+}
+
+} // namespace seqan3::ranges
+
+namespace seqan3::views
+{
+
+/*!\brief Converts a range to a container.
+ * \ingroup utility_views
+ * \deprecated Use seqan3::ranges::to instead.
+ */
+template <typename container_t, typename... args_t>
+SEQAN3_DEPRECATED_330 constexpr auto to(args_t &&... args)
+{
+    return ranges::to<container_t>(std::forward<args_t>(args)...);
+}
+
+/*!\brief Converts a range to a container.
+ * \ingroup utility_views
+ * \deprecated Use seqan3::ranges::to instead.
+ */
+template <template <typename...> typename container_t, typename... args_t>
+SEQAN3_DEPRECATED_330 constexpr auto to(args_t &&... args)
+{
+    return ranges::to<container_t>(std::forward<args_t>(args)...);
+}
+
+/*!\brief Converts a range to a container.
+ * \ingroup utility_views
+ * \deprecated Use seqan3::ranges::to instead.
+ */
+template <typename container_t, std::ranges::input_range rng_t, typename... args_t>
+SEQAN3_DEPRECATED_330 constexpr auto to(rng_t && rng, args_t &&... args)
+{
+    return ranges::to<container_t>(std::forward<rng_t>(rng), std::forward<args_t>(args)...);
+}
+
+/*!\brief Converts a range to a container.
+ * \ingroup utility_views
+ * \deprecated Use seqan3::ranges::to instead.
+ */
+template <template <typename...> typename container_t, std::ranges::input_range rng_t, typename... args_t>
+SEQAN3_DEPRECATED_330 constexpr auto to(rng_t && rng, args_t &&... args)
+{
+    return ranges::to<container_t>(std::forward<rng_t>(rng), std::forward<args_t>(args)...);
+}
+
+} // namespace seqan3::views

--- a/include/seqan3/utility/views/all.hpp
+++ b/include/seqan3/utility/views/all.hpp
@@ -167,6 +167,7 @@
 
 #pragma once
 
+#include <seqan3/utility/range/to.hpp>
 #include <seqan3/utility/views/chunk.hpp>
 #include <seqan3/utility/views/convert.hpp>
 #include <seqan3/utility/views/deep.hpp>
@@ -179,6 +180,5 @@
 #include <seqan3/utility/views/repeat_n.hpp>
 #include <seqan3/utility/views/single_pass_input.hpp>
 #include <seqan3/utility/views/slice.hpp>
-#include <seqan3/utility/views/to.hpp>
 #include <seqan3/utility/views/type_reduce.hpp>
 #include <seqan3/utility/views/zip.hpp>

--- a/include/seqan3/utility/views/to.hpp
+++ b/include/seqan3/utility/views/to.hpp
@@ -12,24 +12,9 @@
 
 #pragma once
 
-#include <seqan3/std/ranges>
+#include <seqan3/utility/range/to.hpp>
 
-#include <seqan3/core/platform.hpp>
-
-#include <range/v3/range/conversion.hpp>
-
-namespace seqan3::views
-{
-
-/*!\brief A to view
- * \ingroup utility_views
- * \details
- * \noapi{This is currently range-v3's to implementation.}
- */
-#if SEQAN3_DOXYGEN_ONLY(1) 0
-inline constexpr auto to;
-#else  // ^^^ doxygen only / real import vvv
-using ::ranges::to;
-#endif // SEQAN3_DOXYGEN_ONLY(1)0
-
-} // namespace seqan3::views
+// clang-format off
+SEQAN3_DEPRECATED_HEADER(
+    "This header is deprecated and will be removed in SeqAn-3.3.0; Please #include <seqan3/utility/range/to.hpp> instead.")
+// clang-format on

--- a/test/performance/alignment/global_affine_alignment_parallel_benchmark.cpp
+++ b/test/performance/alignment/global_affine_alignment_parallel_benchmark.cpp
@@ -22,7 +22,7 @@
 #include <seqan3/test/performance/sequence_generator.hpp>
 #include <seqan3/test/performance/units.hpp>
 #include <seqan3/test/seqan2.hpp>
-#include <seqan3/utility/views/to.hpp>
+#include <seqan3/utility/range/to.hpp>
 #include <seqan3/utility/views/zip.hpp>
 
 #ifdef SEQAN3_HAS_SEQAN2
@@ -86,7 +86,7 @@ void seqan3_affine_dna4_parallel(benchmark::State & state)
 {
     auto [vec1, vec2] = generate_data_seqan3<seqan3::dna4>();
 
-    auto data = seqan3::views::zip(vec1, vec2) | seqan3::views::to<std::vector>;
+    auto data = seqan3::views::zip(vec1, vec2) | seqan3::ranges::to<std::vector>();
 
     int64_t total = 0;
     for (auto _ : state)

--- a/test/performance/alphabet/views/view_translate_1D_benchmark.cpp
+++ b/test/performance/alphabet/views/view_translate_1D_benchmark.cpp
@@ -14,7 +14,7 @@
 #include <seqan3/alphabet/views/translate.hpp>
 #include <seqan3/test/performance/sequence_generator.hpp>
 #include <seqan3/test/seqan2.hpp>
-#include <seqan3/utility/views/to.hpp>
+#include <seqan3/utility/range/to.hpp>
 
 #ifdef SEQAN3_HAS_SEQAN2
 #    include <seqan/seq_io.h>
@@ -48,7 +48,7 @@ void sequential_read(benchmark::State & state)
     if constexpr (std::is_same_v<tag_t, baseline_tag>)
     {
         seqan3::aa27_vector translated_aa_sequence =
-            dna_sequence | seqan3::views::translate_single | seqan3::views::to<seqan3::aa27_vector>;
+            dna_sequence | seqan3::views::translate_single | seqan3::ranges::to<seqan3::aa27_vector>();
         sequential_read_impl(state, translated_aa_sequence);
     }
     else if constexpr (std::is_same_v<tag_t, translate_tag>)
@@ -89,7 +89,7 @@ void random_access(benchmark::State & state)
     if constexpr (std::is_same_v<tag_t, baseline_tag>)
     {
         seqan3::aa27_vector translated_aa_sequence =
-            dna_sequence | seqan3::views::translate_single | seqan3::views::to<seqan3::aa27_vector>;
+            dna_sequence | seqan3::views::translate_single | seqan3::ranges::to<seqan3::aa27_vector>();
         random_access_impl(state, translated_aa_sequence, access_positions);
     }
     else
@@ -113,7 +113,7 @@ void copy_impl(benchmark::State & state, std::vector<seqan3::dna4> const & dna_s
     {
         seqan3::aa27_vector translated_aa_sequence{};
         benchmark::DoNotOptimize(translated_aa_sequence =
-                                     dna_sequence | adaptor | seqan3::views::to<seqan3::aa27_vector>);
+                                     dna_sequence | adaptor | seqan3::ranges::to<seqan3::aa27_vector>());
     }
 }
 

--- a/test/performance/alphabet/views/view_translate_2D_1D_benchmark.cpp
+++ b/test/performance/alphabet/views/view_translate_2D_1D_benchmark.cpp
@@ -15,8 +15,8 @@
 #include <seqan3/alphabet/views/translate_join.hpp>
 #include <seqan3/test/performance/sequence_generator.hpp>
 #include <seqan3/test/seqan2.hpp>
+#include <seqan3/utility/range/to.hpp>
 #include <seqan3/utility/views/join_with.hpp>
-#include <seqan3/utility/views/to.hpp>
 
 #ifdef SEQAN3_HAS_SEQAN2
 #    include <seqan/seq_io.h>
@@ -56,9 +56,9 @@ void sequential_read(benchmark::State & state)
 
     if constexpr (std::is_same_v<tag_t, baseline_tag>)
     {
-        std::vector<seqan3::aa27_vector> translated_aa_sequences = dna_sequence_collection
-                                                                 | seqan3::views::translate_join
-                                                                 | seqan3::views::to<std::vector<seqan3::aa27_vector>>;
+        std::vector<seqan3::aa27_vector> translated_aa_sequences =
+            dna_sequence_collection | seqan3::views::translate_join
+            | seqan3::ranges::to<std::vector<seqan3::aa27_vector>>();
         sequential_read_impl(state, translated_aa_sequences);
     }
     else if constexpr (std::is_same_v<tag_t, translate_tag>)
@@ -121,9 +121,9 @@ void random_access(benchmark::State & state)
 
     if constexpr (std::is_same_v<tag_t, baseline_tag>)
     {
-        std::vector<seqan3::aa27_vector> translated_aa_sequences = dna_sequence_collection
-                                                                 | seqan3::views::translate_join
-                                                                 | seqan3::views::to<std::vector<seqan3::aa27_vector>>;
+        std::vector<seqan3::aa27_vector> translated_aa_sequences =
+            dna_sequence_collection | seqan3::views::translate_join
+            | seqan3::ranges::to<std::vector<seqan3::aa27_vector>>();
         random_access_impl(state, translated_aa_sequences, access_positions_outer, access_positions_inner);
     }
     else
@@ -149,7 +149,7 @@ void copy_impl(benchmark::State & state,
     {
         std::vector<seqan3::aa27_vector> translated_aa_sequences{};
         benchmark::DoNotOptimize(translated_aa_sequences = dna_sequence_collection | adaptor
-                                                         | seqan3::views::to<std::vector<seqan3::aa27_vector>>);
+                                                         | seqan3::ranges::to<std::vector<seqan3::aa27_vector>>());
     }
 }
 

--- a/test/performance/alphabet/views/view_translate_2D_benchmark.cpp
+++ b/test/performance/alphabet/views/view_translate_2D_benchmark.cpp
@@ -15,8 +15,8 @@
 #include <seqan3/alphabet/views/translate_join.hpp>
 #include <seqan3/test/performance/sequence_generator.hpp>
 #include <seqan3/test/seqan2.hpp>
+#include <seqan3/utility/range/to.hpp>
 #include <seqan3/utility/views/join_with.hpp>
-#include <seqan3/utility/views/to.hpp>
 
 #ifdef SEQAN3_HAS_SEQAN2
 #    include <seqan/seq_io.h>
@@ -55,9 +55,9 @@ void sequential_read(benchmark::State & state)
 
     if constexpr (std::is_same_v<tag_t, baseline_tag>)
     {
-        std::vector<seqan3::aa27_vector> translated_aa_sequences = dna_sequence_collection
-                                                                 | seqan3::views::translate_join
-                                                                 | seqan3::views::to<std::vector<seqan3::aa27_vector>>;
+        std::vector<seqan3::aa27_vector> translated_aa_sequences =
+            dna_sequence_collection | seqan3::views::translate_join
+            | seqan3::ranges::to<std::vector<seqan3::aa27_vector>>();
         sequential_read_impl(state, translated_aa_sequences);
     }
     else if constexpr (std::is_same_v<tag_t, translate_tag>)
@@ -107,9 +107,9 @@ void random_access(benchmark::State & state)
 
     if constexpr (std::is_same_v<tag_t, baseline_tag>)
     {
-        std::vector<seqan3::aa27_vector> translated_aa_sequences = dna_sequence_collection
-                                                                 | seqan3::views::translate_join
-                                                                 | seqan3::views::to<std::vector<seqan3::aa27_vector>>;
+        std::vector<seqan3::aa27_vector> translated_aa_sequences =
+            dna_sequence_collection | seqan3::views::translate_join
+            | seqan3::ranges::to<std::vector<seqan3::aa27_vector>>();
         random_access_impl(state, translated_aa_sequences, access_positions);
     }
     else

--- a/test/performance/io/format_vienna_benchmark.cpp
+++ b/test/performance/io/format_vienna_benchmark.cpp
@@ -19,7 +19,7 @@
 #include <seqan3/test/performance/sequence_generator.hpp>
 #include <seqan3/test/performance/units.hpp>
 #include <seqan3/test/seqan2.hpp>
-#include <seqan3/utility/views/to.hpp>
+#include <seqan3/utility/range/to.hpp>
 
 #if SEQAN3_HAS_SEQAN2
 #    include <seqan/rna_io.h>
@@ -29,7 +29,7 @@ inline constexpr size_t iterations_per_run = 1024;
 
 inline std::string const header{"seq foobar blobber"};
 inline auto const rna_sequence = seqan3::test::generate_sequence<seqan3::rna4>(474, 0, 0);
-auto const sequence = rna_sequence | seqan3::views::to_char | seqan3::views::to<std::string>;
+auto const sequence = rna_sequence | seqan3::views::to_char | seqan3::ranges::to<std::string>();
 
 inline std::string const structure{"(((((((..((((........)))).((((.........)))).....(((((.......))))))))))))......."
                                    "(((((((..((((........)))).((((.........)))).....(((((.......))))))))))))......."

--- a/test/performance/search/dream_index/interleaved_bloom_filter_benchmark.cpp
+++ b/test/performance/search/dream_index/interleaved_bloom_filter_benchmark.cpp
@@ -125,8 +125,8 @@ void bulk_contains_benchmark(::benchmark::State & state)
     auto agent = ibf.membership_agent();
     for (auto _ : state)
     {
-        for (auto hash : hash_values)
-            [[maybe_unused]] auto & res = agent.bulk_contains(hash);
+        for (auto hash : hash_values) [[maybe_unused]]
+            auto & res = agent.bulk_contains(hash);
     }
 
     state.counters["hashes/sec"] = hashes_per_second(std::ranges::size(hash_values));

--- a/test/performance/search/dream_index/interleaved_bloom_filter_benchmark.cpp
+++ b/test/performance/search/dream_index/interleaved_bloom_filter_benchmark.cpp
@@ -9,7 +9,7 @@
 
 #include <seqan3/search/dream_index/interleaved_bloom_filter.hpp>
 #include <seqan3/test/performance/sequence_generator.hpp>
-#include <seqan3/utility/views/to.hpp>
+#include <seqan3/utility/range/to.hpp>
 #include <seqan3/utility/views/zip.hpp>
 
 inline benchmark::Counter hashes_per_second(size_t const count)
@@ -80,7 +80,7 @@ void clear_benchmark(::benchmark::State & state)
                                                    {
                                                        return seqan3::bin_index{i};
                                                    })
-                                             | seqan3::views::to<std::vector>;
+                                             | seqan3::ranges::to<std::vector>();
 
     for (auto _ : state)
     {
@@ -105,7 +105,7 @@ void clear_range_benchmark(::benchmark::State & state)
                                                    {
                                                        return seqan3::bin_index{i};
                                                    })
-                                             | seqan3::views::to<std::vector>;
+                                             | seqan3::ranges::to<std::vector>();
 
     for (auto _ : state)
     {

--- a/test/performance/search/index_construction_benchmark.cpp
+++ b/test/performance/search/index_construction_benchmark.cpp
@@ -14,8 +14,8 @@
 #include <seqan3/search/fm_index/all.hpp>
 #include <seqan3/test/performance/sequence_generator.hpp>
 #include <seqan3/test/seqan2.hpp>
+#include <seqan3/utility/range/to.hpp>
 #include <seqan3/utility/type_traits/lazy_conditional.hpp>
-#include <seqan3/utility/views/to.hpp>
 
 #if SEQAN3_HAS_SEQAN2
 #    include <seqan/index.h>
@@ -55,7 +55,7 @@ struct sequence_store_seqan3
                                {
                                    std::vector<uint8_t> const ranks{
                                        seqan3::test::generate_numeric_sequence<uint8_t>(max_length, 0, 253, seed)};
-                                   return ranks | seqan3::views::rank_to<char> | seqan3::views::to<std::string>;
+                                   return ranks | seqan3::views::rank_to<char> | seqan3::ranges::to<std::string>();
                                }()};
 };
 
@@ -71,11 +71,11 @@ void index_benchmark_seqan3(benchmark::State & state)
     rng_t sequence;
     inner_rng_t inner_sequence;
     if constexpr (std::same_as<alphabet_t, seqan3::dna4>)
-        inner_sequence = store.dna4_rng | std::views::take(state.range(0)) | seqan3::views::to<inner_rng_t>;
+        inner_sequence = store.dna4_rng | std::views::take(state.range(0)) | seqan3::ranges::to<inner_rng_t>();
     else if constexpr (std::same_as<alphabet_t, seqan3::aa27>)
-        inner_sequence = store.aa27_rng | std::views::take(state.range(0)) | seqan3::views::to<inner_rng_t>;
+        inner_sequence = store.aa27_rng | std::views::take(state.range(0)) | seqan3::ranges::to<inner_rng_t>();
     else
-        inner_sequence = store.char_rng | std::views::take(state.range(0)) | seqan3::views::to<inner_rng_t>;
+        inner_sequence = store.char_rng | std::views::take(state.range(0)) | seqan3::ranges::to<inner_rng_t>();
 
     if constexpr (seqan3::range_dimension_v<rng_t> == 1)
     {
@@ -107,7 +107,7 @@ struct sequence_store_seqan2
         {
             std::vector<uint8_t> const ranks{
                 seqan3::test::generate_numeric_sequence<uint8_t>(max_length, 0, 253, seed)};
-            return ranks | seqan3::views::rank_to<char> | seqan3::views::to<std::string>;
+            return ranks | seqan3::views::rank_to<char> | seqan3::ranges::to<std::string>();
         }()};
 };
 

--- a/test/performance/search/search_benchmark.cpp
+++ b/test/performance/search/search_benchmark.cpp
@@ -13,8 +13,8 @@
 #include <seqan3/search/fm_index/fm_index.hpp>
 #include <seqan3/search/search.hpp>
 #include <seqan3/test/performance/sequence_generator.hpp>
+#include <seqan3/utility/range/to.hpp>
 #include <seqan3/utility/views/join_with.hpp>
-#include <seqan3/utility/views/to.hpp>
 
 struct options
 {
@@ -144,7 +144,7 @@ std::vector<alphabet_t> generate_repeating_sequence(size_t const template_length
     len = (len + simulated_errors > template_length) ? template_length - simulated_errors : len;
 
     return generate_reads(seq_template, repeats, len, simulated_errors, 0.15, 0.15) | seqan3::detail::persist
-         | std::views::join | seqan3::views::to<std::vector>;
+         | std::views::join | seqan3::ranges::to<std::vector>();
 }
 
 //============================================================================

--- a/test/performance/utility/simd/views/to_simd_benchmark.cpp
+++ b/test/performance/utility/simd/views/to_simd_benchmark.cpp
@@ -18,11 +18,11 @@
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/test/performance/sequence_generator.hpp>
 #include <seqan3/utility/container/aligned_allocator.hpp>
+#include <seqan3/utility/range/to.hpp>
 #include <seqan3/utility/simd/concept.hpp>
 #include <seqan3/utility/simd/simd.hpp>
 #include <seqan3/utility/simd/simd_traits.hpp>
 #include <seqan3/utility/simd/views/to_simd.hpp>
-#include <seqan3/utility/views/to.hpp>
 #include <seqan3/utility/views/zip.hpp>
 
 // ============================================================================
@@ -50,7 +50,7 @@ void to_simd_naive_wo_condition(benchmark::State & state)
                                   {
                                       return std::pair{std::ranges::size(std::get<0>(tpl)), std::get<1>(tpl)};
                                   })
-            | seqan3::views::to<std::vector<std::pair<size_t, size_t>>>;
+            | seqan3::ranges::to<std::vector<std::pair<size_t, size_t>>>();
 
         std::ranges::sort(sorted_sequences);
 

--- a/test/snippet/alphabet/composite/semialphabet_any.cpp
+++ b/test/snippet/alphabet/composite/semialphabet_any.cpp
@@ -9,7 +9,7 @@
 #include <seqan3/alphabet/aminoacid/all.hpp>
 #include <seqan3/alphabet/composite/semialphabet_any.hpp>
 #include <seqan3/core/debug_stream.hpp>
-#include <seqan3/utility/views/to.hpp>
+#include <seqan3/utility/range/to.hpp>
 
 using namespace seqan3::literals;
 
@@ -56,7 +56,7 @@ void algo_pre(seqan3::aa10li_vector const & v)
                                                         {
                                                             return static_cast<seqan3::semialphabet_any<10>>(in);
                                                         })
-                                                  | seqan3::views::to<std::vector>;
+                                                  | seqan3::ranges::to<std::vector>();
     algorithm(tmp, false);
 }
 
@@ -68,7 +68,7 @@ void algo_pre(seqan3::aa10murphy_vector const & v)
                                                         {
                                                             return static_cast<seqan3::semialphabet_any<10>>(in);
                                                         })
-                                                  | seqan3::views::to<std::vector>;
+                                                  | seqan3::ranges::to<std::vector>();
     algorithm(tmp, true);
 }
 

--- a/test/snippet/range/views/range_view_all_retransform.cpp
+++ b/test/snippet/range/views/range_view_all_retransform.cpp
@@ -2,7 +2,7 @@
 
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/alphabet/views/complement.hpp>
-#include <seqan3/utility/views/to.hpp>
+#include <seqan3/utility/range/to.hpp>
 
 int main()
 {
@@ -12,10 +12,10 @@ int main()
     auto vec_view2 = seqan3::views::complement(vec);
 
     // re-convert to container
-    seqan3::dna4_vector complemented = vec_view2 | seqan3::views::to<seqan3::dna4_vector>;
+    seqan3::dna4_vector complemented = vec_view2 | seqan3::ranges::to<seqan3::dna4_vector>();
     assert(complemented == "TGCCAG"_dna4);
 
     // also possible in one step
-    seqan3::dna4_vector reversed = vec | std::views::reverse | seqan3::views::to<seqan3::dna4_vector>;
+    seqan3::dna4_vector reversed = vec | std::views::reverse | seqan3::ranges::to<seqan3::dna4_vector>();
     assert(reversed == "CTGGCA"_dna4);
 }

--- a/test/snippet/utility/views/convert_int_to_bool.cpp
+++ b/test/snippet/utility/views/convert_int_to_bool.cpp
@@ -2,8 +2,8 @@
 #include <vector>
 
 #include <seqan3/core/debug_stream.hpp>
+#include <seqan3/utility/range/to.hpp>
 #include <seqan3/utility/views/convert.hpp>
-#include <seqan3/utility/views/to.hpp>
 
 int main()
 {
@@ -17,7 +17,7 @@ int main()
     seqan3::debug_stream << (vec | seqan3::views::convert<bool> | std::views::reverse) << '\n'; // [1,1,1,0,0,1,0,1,1]
 
     // function notation and immediate conversion to vector again
-    auto bool_vec = seqan3::views::convert<bool>(vec) | seqan3::views::to<std::vector<bool>>;
+    auto bool_vec = seqan3::views::convert<bool>(vec) | seqan3::ranges::to<std::vector<bool>>();
     seqan3::debug_stream << std::boolalpha << (bool_vec == std::vector<bool>{1, 1, 0, 1, 0, 0, 1, 1, 1})
                          << '\n'; // true
 }

--- a/test/unit/alignment/aligned_sequence/debug_stream_alignment_test.cpp
+++ b/test/unit/alignment/aligned_sequence/debug_stream_alignment_test.cpp
@@ -11,7 +11,7 @@
 #include <seqan3/alphabet/gap/gapped.hpp>
 #include <seqan3/alphabet/nucleotide/dna4.hpp>
 #include <seqan3/alphabet/nucleotide/rna5.hpp>
-#include <seqan3/utility/views/to.hpp>
+#include <seqan3/utility/range/to.hpp>
 
 using seqan3::operator""_dna4;
 using seqan3::operator""_rna5;
@@ -44,13 +44,13 @@ TEST(debug_stream_test, multiple_alignment_without_gaps)
                std::vector<seqan3::gapped<seqan3::dna4>>> const alignment{
         "GCGGGTCACTGAGGGCTGGGATGAGGACGGCCACCACTTCGAGGAGTCCCTTCACTACGAGGGCAGGGCCGTGGACATCACCACGTCAGACAGGGACAAGAGCAAGTA"
         "CGGCACCCTGTCCAGACTGGCGGTGGAAGCTG"_dna4
-            | seqan3::views::to<std::vector<seqan3::gapped<seqan3::dna4>>>,
+            | seqan3::ranges::to<std::vector<seqan3::gapped<seqan3::dna4>>>(),
         "CTACGGCAGAAGAAGACATCCGAAAAAGCTGACACCTCTCGCCTACAAGCAGTTCATACCTAATGTCGCGGAGAAGACCTTAGGGGCCAGCGGCAGATACGAGGGCAA"
         "GATAACGCGCAATTCGGAGAGATTTAAAGAAC"_dna4
-            | seqan3::views::to<std::vector<seqan3::gapped<seqan3::dna4>>>,
+            | seqan3::ranges::to<std::vector<seqan3::gapped<seqan3::dna4>>>(),
         "CTACGGCAGAAGAAGACATCCCAAGAAGCTGACACCTCTCGCCTACAAGCAGTTTATACCTAATGTCGCGGAGAAGACCTTAGGGGCCAGCGGCAGATACGAGGGCAA"
         "GATCACGCGCAATTCGGAGAGATTTAAAGAAC"_dna4
-            | seqan3::views::to<std::vector<seqan3::gapped<seqan3::dna4>>>};
+            | seqan3::ranges::to<std::vector<seqan3::gapped<seqan3::dna4>>>()};
 
     std::ostringstream oss;
     seqan3::debug_stream_type stream{oss};

--- a/test/unit/alignment/pairwise/pairwise_alignment_collection_test_template.hpp
+++ b/test/unit/alignment/pairwise/pairwise_alignment_collection_test_template.hpp
@@ -15,7 +15,7 @@
 #include <seqan3/alignment/pairwise/align_pairwise.hpp>
 #include <seqan3/alphabet/views/to_char.hpp>
 #include <seqan3/test/expect_range_eq.hpp>
-#include <seqan3/utility/views/to.hpp>
+#include <seqan3/utility/range/to.hpp>
 #include <seqan3/utility/views/zip.hpp>
 
 #include "fixture/alignment_fixture.hpp"
@@ -65,7 +65,7 @@ TYPED_TEST_P(pairwise_alignment_collection_test, end_positions)
     {
         auto [database, query] = fixture.get_sequences();
         auto res_vec =
-            seqan3::align_pairwise(seqan3::views::zip(database, query), align_cfg) | seqan3::views::to<std::vector>;
+            seqan3::align_pairwise(seqan3::views::zip(database, query), align_cfg) | seqan3::ranges::to<std::vector>();
 
         EXPECT_RANGE_EQ(res_vec
                             | std::views::transform(
@@ -97,7 +97,7 @@ TYPED_TEST_P(pairwise_alignment_collection_test, begin_positions)
     {
         auto [database, query] = fixture.get_sequences();
         auto res_vec =
-            seqan3::align_pairwise(seqan3::views::zip(database, query), align_cfg) | seqan3::views::to<std::vector>;
+            seqan3::align_pairwise(seqan3::views::zip(database, query), align_cfg) | seqan3::ranges::to<std::vector>();
 
         EXPECT_RANGE_EQ(res_vec
                             | std::views::transform(
@@ -138,7 +138,7 @@ TYPED_TEST_P(pairwise_alignment_collection_test, alignment)
     {
         auto [database, query] = fixture.get_sequences();
         auto res_vec =
-            seqan3::align_pairwise(seqan3::views::zip(database, query), align_cfg) | seqan3::views::to<std::vector>;
+            seqan3::align_pairwise(seqan3::views::zip(database, query), align_cfg) | seqan3::ranges::to<std::vector>();
 
         EXPECT_RANGE_EQ(res_vec
                             | std::views::transform(
@@ -168,7 +168,7 @@ TYPED_TEST_P(pairwise_alignment_collection_test, alignment)
                                 [](auto res)
                                 {
                                     return std::get<0>(res.alignment()) | seqan3::views::to_char
-                                         | seqan3::views::to<std::string>;
+                                         | seqan3::ranges::to<std::string>();
                                 }),
                         fixture.get_aligned_sequences1());
         EXPECT_RANGE_EQ(res_vec
@@ -176,7 +176,7 @@ TYPED_TEST_P(pairwise_alignment_collection_test, alignment)
                                 [](auto res)
                                 {
                                     return std::get<1>(res.alignment()) | seqan3::views::to_char
-                                         | seqan3::views::to<std::string>;
+                                         | seqan3::ranges::to<std::string>();
                                 }),
                         fixture.get_aligned_sequences2());
     }

--- a/test/unit/search/fm_index_cursor/bi_fm_index_cursor_collection_test.cpp
+++ b/test/unit/search/fm_index_cursor/bi_fm_index_cursor_collection_test.cpp
@@ -11,8 +11,8 @@
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
 #include <seqan3/alphabet/views/char_to.hpp>
 #include <seqan3/search/fm_index/bi_fm_index.hpp>
+#include <seqan3/utility/range/to.hpp>
 #include <seqan3/utility/views/slice.hpp>
-#include <seqan3/utility/views/to.hpp>
 
 #include "bi_fm_index_cursor_collection_test_template.hpp"
 
@@ -24,13 +24,13 @@ struct bi_fm_index_cursor_collection_test : public ::testing::Test
     using alphabet_type = typename index_type::alphabet_type;
     using text_type = std::vector<alphabet_type>;
 
-    static constexpr auto convert = seqan3::views::char_to<alphabet_type> | seqan3::views::to<text_type>;
+    static constexpr auto convert = seqan3::views::char_to<alphabet_type> | seqan3::ranges::to<text_type>();
 
     text_type text{convert(std::string_view{"ACGGTAGGACGTAGC"})};
     text_type text1{convert(std::string_view{"AACGATCGGA"})};
     text_type text2{convert(std::string_view{"TGCTACGATCC"})};
-    text_type text3 = seqan3::views::slice(text, 0, 11) | seqan3::views::to<text_type>; // "ACGGTAGGACG"
-    text_type text4 = seqan3::views::slice(text, 0, 14) | seqan3::views::to<text_type>; // "ACGGTAGGACGTAG"
+    text_type text3 = seqan3::views::slice(text, 0, 11) | seqan3::ranges::to<text_type>(); // "ACGGTAGGACG"
+    text_type text4 = seqan3::views::slice(text, 0, 14) | seqan3::ranges::to<text_type>(); // "ACGGTAGGACGTAG"
 
     std::vector<text_type> text_col1{text1, text1};
     std::vector<text_type> text_col2{text3, text2};
@@ -38,9 +38,9 @@ struct bi_fm_index_cursor_collection_test : public ::testing::Test
     std::vector<text_type> text_col4{text, text2};
 
     std::vector<text_type> rev_text1 =
-        text_col1 | seqan3::views::deep{std::views::reverse} | seqan3::views::to<std::vector<text_type>>;
+        text_col1 | seqan3::views::deep{std::views::reverse} | seqan3::ranges::to<std::vector<text_type>>();
     std::vector<text_type> rev_text2 = text_col4 | seqan3::views::deep{std::views::reverse} | std::views::reverse
-                                     | seqan3::views::to<std::vector<text_type>>;
+                                     | seqan3::ranges::to<std::vector<text_type>>();
 
     text_type pattern1{convert(std::string_view{"CAG"})};
     text_type pattern2{convert(std::string_view{"TT"})};

--- a/test/unit/search/fm_index_cursor/bi_fm_index_cursor_test.cpp
+++ b/test/unit/search/fm_index_cursor/bi_fm_index_cursor_test.cpp
@@ -13,7 +13,7 @@
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
 #include <seqan3/alphabet/views/char_to.hpp>
 #include <seqan3/search/fm_index/bi_fm_index.hpp>
-#include <seqan3/utility/views/to.hpp>
+#include <seqan3/utility/range/to.hpp>
 
 #include "bi_fm_index_cursor_test_template.hpp"
 
@@ -25,13 +25,13 @@ struct bi_fm_index_cursor_test : public ::testing::Test
     using alphabet_type = typename index_type::alphabet_type;
     using text_type = std::vector<alphabet_type>;
 
-    static constexpr auto convert = seqan3::views::char_to<alphabet_type> | seqan3::views::to<text_type>;
+    static constexpr auto convert = seqan3::views::char_to<alphabet_type> | seqan3::ranges::to<text_type>();
 
     text_type text{convert(std::string_view{"ACGGTAGGACGTAGC"})};
     text_type text1{convert(std::string_view{"AACGATCGGA"})};
 
-    text_type rev_text1 = text | std::views::reverse | seqan3::views::to<text_type>;
-    text_type rev_text2 = text1 | std::views::reverse | seqan3::views::to<text_type>;
+    text_type rev_text1 = text | std::views::reverse | seqan3::ranges::to<text_type>();
+    text_type rev_text2 = text1 | std::views::reverse | seqan3::ranges::to<text_type>();
 
     text_type pattern1{convert(std::string_view{"CAG"})};
     text_type pattern2{convert(std::string_view{"TT"})};

--- a/test/unit/search/fm_index_cursor/fm_index_cursor_collection_test.cpp
+++ b/test/unit/search/fm_index_cursor/fm_index_cursor_collection_test.cpp
@@ -31,7 +31,7 @@ struct fm_index_cursor_collection_test : public ::testing::Test
 
     static constexpr bool is_bi_fm_index =
         seqan3::detail::template_specialisation_of<typename index_type::cursor_type, seqan3::bi_fm_index_cursor>;
-    static constexpr auto convert = seqan3::views::char_to<alphabet_type> | seqan3::views::to<text_type>;
+    static constexpr auto convert = seqan3::views::char_to<alphabet_type> | seqan3::ranges::to<text_type>();
 
     text_type text1{convert(std::string_view{"ACGACG"})};
     text_type text2{convert(std::string_view{"ACGAACGC"})};

--- a/test/unit/search/fm_index_cursor/fm_index_cursor_test.cpp
+++ b/test/unit/search/fm_index_cursor/fm_index_cursor_test.cpp
@@ -30,7 +30,7 @@ struct fm_index_cursor_test : public ::testing::Test
 
     static constexpr bool is_bi_fm_index =
         seqan3::detail::template_specialisation_of<typename index_type::cursor_type, seqan3::bi_fm_index_cursor>;
-    static constexpr auto convert = seqan3::views::char_to<alphabet_type> | seqan3::views::to<text_type>;
+    static constexpr auto convert = seqan3::views::char_to<alphabet_type> | seqan3::ranges::to<text_type>();
 
     text_type text1{convert(std::string_view{"ACGACG"})};
     text_type text2{convert(std::string_view{"ACGAACGC"})};

--- a/test/unit/search/helper.hpp
+++ b/test/unit/search/helper.hpp
@@ -14,7 +14,7 @@
 #include <seqan3/core/debug_stream/debug_stream_type.hpp>
 #include <seqan3/search/fm_index/bi_fm_index_cursor.hpp>
 #include <seqan3/search/fm_index/fm_index_cursor.hpp>
-#include <seqan3/utility/views/to.hpp>
+#include <seqan3/utility/range/to.hpp>
 
 namespace seqan3
 {
@@ -34,7 +34,7 @@ inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s,
 template <typename result_range_t>
 std::vector<std::ranges::range_value_t<result_range_t>> uniquify(result_range_t && result_range)
 {
-    auto unique_res = result_range | views::to<std::vector>;
+    auto unique_res = result_range | ranges::to<std::vector>();
     std::sort(unique_res.begin(), unique_res.end());
     unique_res.erase(std::unique(unique_res.begin(), unique_res.end()), unique_res.end());
     return unique_res;

--- a/test/unit/search/search_scheme_algorithm_test.cpp
+++ b/test/unit/search/search_scheme_algorithm_test.cpp
@@ -21,8 +21,8 @@
 #include <seqan3/search/detail/unidirectional_search_algorithm.hpp>
 #include <seqan3/search/fm_index/bi_fm_index.hpp>
 #include <seqan3/test/performance/sequence_generator.hpp>
+#include <seqan3/utility/range/to.hpp>
 #include <seqan3/utility/views/slice.hpp>
-#include <seqan3/utility/views/to.hpp>
 
 #include "helper.hpp"
 #include "helper_search_scheme.hpp"
@@ -71,7 +71,7 @@ inline void test_search_hamming(auto index,
     using char_t = typename text_t::value_type;
 
     uint64_t const pos = std::rand() % (text.size() - query_length + 1);
-    text_t const orig_query = text | seqan3::views::slice(pos, pos + query_length) | seqan3::views::to<text_t>;
+    text_t const orig_query = text | seqan3::views::slice(pos, pos + query_length) | seqan3::ranges::to<text_t>();
 
     // Modify query s.t. it has errors matching error_distribution.
     auto query = orig_query;
@@ -132,7 +132,7 @@ inline void test_search_hamming(auto index,
     auto remove_predicate_ss = [&text, &orig_query, query_length](uint64_t const hit)
     {
         seqan3::dna4_vector matched_seq =
-            text | seqan3::views::slice(hit, hit + query_length) | seqan3::views::to<seqan3::dna4_vector>;
+            text | seqan3::views::slice(hit, hit + query_length) | seqan3::ranges::to<seqan3::dna4_vector>();
         return (matched_seq != orig_query);
     };
 
@@ -140,7 +140,8 @@ inline void test_search_hamming(auto index,
     {
         // filter only correct error distributions
         seqan3::dna4_vector matched_seq =
-            text | seqan3::views::slice(hit, hit + query_length) | seqan3::views::to<seqan3::dna4_vector>;
+            text | seqan3::views::slice(hit, hit + query_length) | seqan3::ranges::to<seqan3::dna4_vector>();
+
         if (orig_query != matched_seq)
             return true;
 

--- a/test/unit/search/search_test.cpp
+++ b/test/unit/search/search_test.cpp
@@ -343,7 +343,7 @@ TYPED_TEST(search_test, search_strategy_best)
         seqan3::configuration const cfg = seqan3::search_cfg::max_error_total{seqan3::search_cfg::error_count{1}}
                                         | seqan3::search_cfg::hit_single_best{};
 
-        std::vector result = search("ACGT"_dna4, this->index, cfg) | position | seqan3::views::to<std::vector>;
+        std::vector result = search("ACGT"_dna4, this->index, cfg) | position | seqan3::ranges::to<std::vector>();
         ASSERT_EQ(result.size(), 1u);
         EXPECT_TRUE(std::find(possible_hits.begin(), possible_hits.end(), result[0]) != possible_hits.end());
 
@@ -354,7 +354,7 @@ TYPED_TEST(search_test, search_strategy_best)
         seqan3::configuration const cfg = seqan3::search_cfg::max_error_insertion{seqan3::search_cfg::error_count{1}}
                                         | seqan3::search_cfg::hit_single_best{};
 
-        std::vector result = search("ACGTT"_dna4, this->index, cfg) | position | seqan3::views::to<std::vector>;
+        std::vector result = search("ACGTT"_dna4, this->index, cfg) | position | seqan3::ranges::to<std::vector>();
         ASSERT_EQ(result.size(), 1u);
         EXPECT_TRUE(std::find(possible_hits.begin(), possible_hits.end(), result[0]) != possible_hits.end());
     }
@@ -363,7 +363,7 @@ TYPED_TEST(search_test, search_strategy_best)
         seqan3::configuration const cfg = seqan3::search_cfg::max_error_insertion{seqan3::search_cfg::error_count{1}}
                                         | seqan3::search_cfg::hit_single_best{};
 
-        std::vector result = search("ACGT"_dna4, this->index, cfg) | position | seqan3::views::to<std::vector>;
+        std::vector result = search("ACGT"_dna4, this->index, cfg) | position | seqan3::ranges::to<std::vector>();
         ASSERT_EQ(result.size(), 1u);
         EXPECT_TRUE(std::find(possible_hits.begin(), possible_hits.end(), result[0]) != possible_hits.end());
     }
@@ -372,7 +372,7 @@ TYPED_TEST(search_test, search_strategy_best)
         seqan3::configuration const cfg = seqan3::search_cfg::max_error_deletion{seqan3::search_cfg::error_count{1}}
                                         | seqan3::search_cfg::hit_single_best{};
 
-        std::vector result = search("AGT"_dna4, this->index, cfg) | position | seqan3::views::to<std::vector>;
+        std::vector result = search("AGT"_dna4, this->index, cfg) | position | seqan3::ranges::to<std::vector>();
         ASSERT_EQ(result.size(), 1u);
         EXPECT_TRUE(std::find(possible_hits.begin(), possible_hits.end(), result[0]) != possible_hits.end());
     }
@@ -381,7 +381,7 @@ TYPED_TEST(search_test, search_strategy_best)
         seqan3::configuration const cfg = seqan3::search_cfg::max_error_deletion{seqan3::search_cfg::error_count{1}}
                                         | seqan3::search_cfg::hit_single_best{};
 
-        std::vector result = search("ACGT"_dna4, this->index, cfg) | position | seqan3::views::to<std::vector>;
+        std::vector result = search("ACGT"_dna4, this->index, cfg) | position | seqan3::ranges::to<std::vector>();
         ASSERT_EQ(result.size(), 1u);
         EXPECT_TRUE(std::find(possible_hits.begin(), possible_hits.end(), result[0]) != possible_hits.end());
     }
@@ -390,7 +390,7 @@ TYPED_TEST(search_test, search_strategy_best)
         seqan3::configuration const cfg = seqan3::search_cfg::max_error_substitution{seqan3::search_cfg::error_count{1}}
                                         | seqan3::search_cfg::hit_single_best{};
 
-        std::vector result = search("ACGC"_dna4, this->index, cfg) | position | seqan3::views::to<std::vector>;
+        std::vector result = search("ACGC"_dna4, this->index, cfg) | position | seqan3::ranges::to<std::vector>();
         ASSERT_EQ(result.size(), 1u);
         EXPECT_TRUE(std::find(possible_hits.begin(), possible_hits.end(), result[0]) != possible_hits.end());
     }
@@ -399,7 +399,7 @@ TYPED_TEST(search_test, search_strategy_best)
         seqan3::configuration const cfg = seqan3::search_cfg::max_error_substitution{seqan3::search_cfg::error_count{1}}
                                         | seqan3::search_cfg::hit_single_best{};
 
-        std::vector result = search("ACGT"_dna4, this->index, cfg) | position | seqan3::views::to<std::vector>;
+        std::vector result = search("ACGT"_dna4, this->index, cfg) | position | seqan3::ranges::to<std::vector>();
         ASSERT_EQ(result.size(), 1u);
         EXPECT_TRUE(std::find(possible_hits.begin(), possible_hits.end(), result[0]) != possible_hits.end());
     }
@@ -409,7 +409,7 @@ TYPED_TEST(search_test, search_strategy_best)
         seqan3::configuration const cfg = seqan3::search_cfg::max_error_deletion{seqan3::search_cfg::error_count{2}}
                                         | seqan3::search_cfg::hit_single_best{};
 
-        std::vector result = search("AGTAGT"_dna4, this->index, cfg) | position | seqan3::views::to<std::vector>;
+        std::vector result = search("AGTAGT"_dna4, this->index, cfg) | position | seqan3::ranges::to<std::vector>();
         ASSERT_EQ(result.size(), 1u);
         EXPECT_TRUE(std::find(possible_hits2d.begin(), possible_hits2d.end(), result[0]) != possible_hits2d.end());
     }
@@ -419,7 +419,7 @@ TYPED_TEST(search_test, search_strategy_best)
         seqan3::configuration const cfg = seqan3::search_cfg::max_error_deletion{seqan3::search_cfg::error_count{2}}
                                         | seqan3::search_cfg::hit{seqan3::search_cfg::hit_single_best{}};
 
-        std::vector result = search("AGTAGT"_dna4, this->index, cfg) | position | seqan3::views::to<std::vector>;
+        std::vector result = search("AGTAGT"_dna4, this->index, cfg) | position | seqan3::ranges::to<std::vector>();
         ASSERT_EQ(result.size(), 1u);
         EXPECT_TRUE(std::find(possible_hits2d.begin(), possible_hits2d.end(), result[0]) != possible_hits2d.end());
     }

--- a/test/unit/utility/range/CMakeLists.txt
+++ b/test/unit/utility/range/CMakeLists.txt
@@ -1,0 +1,1 @@
+seqan3_test (to_test.cpp)

--- a/test/unit/utility/range/to_test.cpp
+++ b/test/unit/utility/range/to_test.cpp
@@ -1,0 +1,168 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <deque>
+#include <forward_list>
+#include <list>
+#include <seqan3/std/ranges>
+#include <vector>
+
+#include <seqan3/utility/range/to.hpp>
+
+/* These test cases are taken from the proposal https://wg21.link/p1206r7.
+ * This demonstrates the subset of syntaxes constructs that compile.
+ */
+TEST(to_test, overview)
+{
+    auto l = std::views::iota(1, 10);
+
+    // create a vector with the elements of l
+    auto vec = seqan3::ranges::to<std::vector<int>>(l);
+
+    // Specify an allocator
+    auto b = seqan3::ranges::to<std::vector<int, std::allocator<int>>>(l, std::allocator<int>{});
+
+    // deducing value_type
+    auto c = seqan3::ranges::to<std::vector>(l);
+
+    // explicit conversion int -> long
+    auto d = seqan3::ranges::to<std::vector<long>>(l);
+
+    // Supports converting associative container to sequence containers
+    //auto f = seqan3::ranges::to<std::vector>(m); // Not supported by seqan3
+
+    // Supports converting sequence containers to associative ones
+    //auto g = seqan3::ranges::to<std::map>(f); // Not supported by seqan3
+
+    // Pipe syntaxe
+    auto g = l | std::ranges::views::take(42) | seqan3::ranges::to<std::vector>();
+
+    // Pipe syntax with allocator
+    auto h = l | std::ranges::views::take(42) | seqan3::ranges::to<std::vector>(std::allocator<int>{});
+
+    // The pipe syntax also support specifying the type and conversions
+    auto i = l | std::ranges::views::take(42) | seqan3::ranges::to<std::vector<long>>();
+
+    // Nested ranges
+    std::list<std::forward_list<int>> lst = {{0, 1, 2, 3}, {4, 5, 6, 7}};
+    auto vec1 = seqan3::ranges::to<std::vector<std::vector<int>>>(lst);
+    auto vec2 = seqan3::ranges::to<std::vector<std::deque<double>>>(lst);
+}
+
+// Check that converting a range to `std::vector<int>` works with the function call syntax.
+TEST(to_test, function_call_explicit_vector)
+{
+    auto lst = std::views::iota(1, 10);
+    auto vec = seqan3::ranges::to<std::vector<int>>(lst);
+    auto expected = std::vector<int>{1, 2, 3, 4, 5, 6, 7, 8, 9};
+    EXPECT_EQ(vec, expected);
+}
+
+/* Check that converting a range to `std::vector<int, UserDefinedAllocator>` works with the function call
+ * syntax and an user-defined allocator.
+ */
+TEST(to_test, function_call_explicit_vector_with_allocator)
+{
+    auto lst = std::views::iota(1, 10);
+    auto vec = seqan3::ranges::to<std::vector<int, std::allocator<int>>>(lst, std::allocator<int>{});
+    auto expected = std::vector<int>{1, 2, 3, 4, 5, 6, 7, 8, 9};
+    EXPECT_EQ(vec, expected);
+}
+
+// Check that converting a range to `std::vector` works with the function call syntax.
+TEST(to_test, function_call_implicit_vector)
+{
+    auto lst = std::views::iota(1, 10);
+    auto vec = seqan3::ranges::to<std::vector>(lst);
+    auto expected = std::vector<int>{1, 2, 3, 4, 5, 6, 7, 8, 9};
+    EXPECT_EQ(vec, expected);
+}
+
+// Check that converting a range to `std::vector` works with the function call syntax and an user-defined allocator.
+TEST(to_test, function_call_implicit_vector_with_allocator)
+{
+    auto lst = std::views::iota(1, 10);
+    auto vec = seqan3::ranges::to<std::vector>(lst, std::allocator<int>{});
+    auto expected = std::vector<int>{1, 2, 3, 4, 5, 6, 7, 8, 9};
+    EXPECT_EQ(vec, expected);
+}
+
+// Check that converting a range to `std::vector<int>` works with the function call syntax.
+TEST(to_test, function_call_explicit_vector_with_conversion)
+{
+    auto lst = std::views::iota(1, 10);
+    auto vec = seqan3::ranges::to<std::vector<double>>(lst);
+    auto expected = std::vector<double>{1, 2, 3, 4, 5, 6, 7, 8, 9};
+    EXPECT_EQ(vec, expected);
+}
+
+// Check that converting a range to `std::vector<int>` works using pipe syntax.
+TEST(to_test, pipe_syntax_explicit_vector)
+{
+    auto lst = std::views::iota(1, 10);
+    auto vec = lst | seqan3::ranges::to<std::vector<int>>();
+    auto expected = std::vector<int>{1, 2, 3, 4, 5, 6, 7, 8, 9};
+    EXPECT_EQ(vec, expected);
+}
+
+/* Check that converting a range to `std::vector<int, UserDefinedAllocator>` works with pipe
+ * syntax and an user-defined allocator.
+ */
+TEST(to_test, pipe_syntax_explicit_vector_with_allocator)
+{
+    auto lst = std::views::iota(1, 10);
+    auto vec = lst | seqan3::ranges::to<std::vector<int, std::allocator<int>>>(std::allocator<int>{});
+    auto expected = std::vector<int>{1, 2, 3, 4, 5, 6, 7, 8, 9};
+    EXPECT_EQ(vec, expected);
+}
+
+// Check that converting a range to `std::vector` works using pipe syntax.
+TEST(to_test, pipe_syntax_implicit_vector)
+{
+    auto lst = std::views::iota(1, 10);
+    auto vec = lst | seqan3::ranges::to<std::vector>();
+    auto expected = std::vector<int>{1, 2, 3, 4, 5, 6, 7, 8, 9};
+    EXPECT_EQ(vec, expected);
+}
+
+// Check that converting a range to `std::vector` works with pipe syntax and an user-defined allocator.
+TEST(to_test, pipe_syntax_implicit_vector_with_allocator)
+{
+    auto lst = std::views::iota(1, 10);
+    auto vec = lst | seqan3::ranges::to<std::vector>(std::allocator<int>{});
+    auto expected = std::vector<int>{1, 2, 3, 4, 5, 6, 7, 8, 9};
+    EXPECT_EQ(vec, expected);
+}
+
+// Check that converting a range to `std::vector<int>` works using pipe syntax.
+TEST(to_test, pipe_syntax_explicit_vector_with_conversion)
+{
+    auto lst = std::views::iota(1, 10);
+    auto vec = lst | seqan3::ranges::to<std::vector<double>>();
+    auto expected = std::vector<double>{1, 2, 3, 4, 5, 6, 7, 8, 9};
+    EXPECT_EQ(vec, expected);
+}
+
+// Check that converting nested ranges can be converted to nested containers using function call syntax.
+TEST(to_test, syntax_explicit_vector)
+{
+    auto lst = std::list<std::forward_list<int>>{{1, 2, 3}, {4, 5, 6, 7}};
+    auto vec = seqan3::ranges::to<std::vector<std::vector<int>>>(lst);
+    auto expected = std::vector<std::vector<int>>{{1, 2, 3}, {4, 5, 6, 7}};
+    EXPECT_EQ(vec, expected);
+}
+
+// Check other converting types.
+TEST(to_test, various_types)
+{
+    auto lst = std::views::iota(1, 10);
+    EXPECT_EQ(lst | seqan3::ranges::to<std::vector<int>>(), (std::vector<int>{1, 2, 3, 4, 5, 6, 7, 8, 9}));
+    EXPECT_EQ(lst | seqan3::ranges::to<std::list<int>>(), (std::list<int>{1, 2, 3, 4, 5, 6, 7, 8, 9}));
+    EXPECT_EQ(lst | seqan3::ranges::to<std::deque<int>>(), (std::deque<int>{1, 2, 3, 4, 5, 6, 7, 8, 9}));
+}


### PR DESCRIPTION
Follow-up: https://github.com/seqan/product_backlog/issues/420

Replace ranges::to with a minimal custom implementation seqan3::ranges::to

Todo:
* [x] Improve Documentation (ranges::to should have 4 entries, but only has 2)
* [x] cleanup commits
* [x] Add Changelog
* [x] Add example
* [x] fix MacOS :/ (not caused by this PR)

Part of https://github.com/seqan/product_backlog/issues/124

-A Life Without range-v3-