### PR TITLE
[INFRA] Automatically add doc pages to layout.

### DIFF
--- a/test/documentation/CMakeLists.txt
+++ b/test/documentation/CMakeLists.txt
@@ -25,6 +25,8 @@ set (SEQAN3_DOXYGEN_INPUT_DIR "${CMAKE_SOURCE_DIR}")
 
 include (seqan3-doxygen.cmake)
 
+include (seqan3-doxygen-layout.cmake)
+
 enable_testing ()
 
 if (SEQAN3_USER_DOC)

--- a/test/documentation/DoxygenLayout.xml
+++ b/test/documentation/DoxygenLayout.xml
@@ -4,39 +4,18 @@
   <navindex>
     <tab type="mainpage" visible="yes" title=""/>
     <tab type="pages" visible="no" title="" intro=""/>
+    <!-- Setup pages are added in seqan3-doxygen-layout.cmake automatically for each doc/tutorial/*/index.md file -->
     <tab type="usergroup" visible="yes" title="Setup" intro="">
-      <tab type="user" visible="yes" title="Quick-Setup (CMake)" url="\ref setup" intro=""/>
-      <tab type="user" visible="yes" title="Library tests" url="\ref setup_tests" intro=""/>
     </tab>
+    <!-- Tutorials are added in seqan3-doxygen-layout.cmake automatically for each doc/tutorial/*/index.md file -->
     <tab type="usergroup" visible="yes" title="Tutorial" intro="">
-      <tab type="user" visible="yes" title="First steps"  url="@ref tutorial_first_example" intro=""/>
-      <tab type="user" visible="yes" title="Parsing command line arguments" url="@ref tutorial_argument_parser" intro=""/>
-      <tab type="user" visible="yes" title="C++ Concepts" url="@ref tutorial_concepts" intro=""/>
-      <tab type="user" visible="yes" title="Alphabets" url="@ref tutorial_alphabets" intro=""/>
-      <tab type="user" visible="yes" title="Ranges" url="@ref tutorial_ranges" intro=""/>
-      <tab type="user" visible="yes" title="Minimiser" url="@ref tutorial_minimiser" intro=""/>
-      <tab type="user" visible="yes" title="Sequence file I/O" url="@ref tutorial_sequence_file" intro=""/>
-      <tab type="user" visible="yes" title="Computing pairwise alignments" url="@ref tutorial_pairwise_alignment" intro=""/>
-      <tab type="user" visible="yes" title="Index and Search" url="@ref tutorial_index_search" intro=""/>
-      <tab type="user" visible="yes" title="SAM file I/O" url="@ref tutorial_sam_file" intro=""/>
-      <tab type="user" visible="yes" title="Implement your own read mapper" url="@ref tutorial_read_mapper" intro=""/>
     </tab>
-      <tab type="usergroup" visible="yes" title="How-To" intro="">
-      <tab type="user" visible="yes" title="Subcommand argument parsing" url="\ref subcommand_arg_parse" intro=""/>
-      <tab type="user" visible="yes" title="Serialize SeqAn data structures" url="\ref howto_use_cereal" intro=""/>
-      <tab type="user" visible="yes" title="Write your own view" url="\ref howto_write_a_view" intro=""/>
-      <tab type="user" visible="yes" title="Write your own alphabet" url="\ref howto_write_an_alphabet" intro=""/>
-      <tab type="user" visible="yes" title="Port from SeqAn2" url="\ref howto_porting" intro=""/>
+    <!-- How-To pages are added in seqan3-doxygen-layout.cmake automatically for each doc/howto/*/index.md file -->
+    <tab type="usergroup" visible="yes" title="How-To" intro="">
     </tab>
     <tab type="user" visible="yes" title="Cookbook" url="\ref cookbook" intro=""/>
+    <!-- About pages are added in seqan3-doxygen-layout.cmake automatically for each doc/about/*/index.md file -->
     <tab type="usergroup" visible="yes" title="About" intro="">
-      <tab type="user" visible="yes" title="API/ABI stability" url="\ref about_api" intro=""/>
-      <tab type="user" visible="yes" title="Changelog" url="\ref about_changelog" intro=""/>
-      <tab type="user" visible="yes" title="Citing" url="\ref about_citing" intro=""/>
-      <tab type="user" visible="yes" title="Copyright" url="\ref about_copyright" intro=""/>
-      <tab type="user" visible="yes" title="Code of Conduct" url="\ref about_code_of_conduct" intro=""/>
-      <tab type="user" visible="yes" title="Contributing" url="\ref about_contributing" intro=""/>
-      <tab type="user" visible="yes" title="Customisation" url="\ref about_customisation" intro=""/>
     </tab>
     <tab type="modules" visible="yes" title="API Reference (Modules)" intro=""/>
     <tab type="usergroup" visible="yes" title="API Reference (details)" intro="">

--- a/test/documentation/seqan3-doxygen-layout.cmake
+++ b/test/documentation/seqan3-doxygen-layout.cmake
@@ -1,0 +1,66 @@
+# -----------------------------------------------------------------------------------------------------
+# Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
+# Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
+# This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+# shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+# -----------------------------------------------------------------------------------------------------
+
+cmake_minimum_required (VERSION 3.10)
+
+include(${SEQAN3_INCLUDE_DIR}/../test/cmake/seqan3_test_files.cmake)
+
+# Repalces documentation entries in variable `DOXYGEN_LAYOUT`
+#
+# Important: the variable of the parten scope must be called DOXYGEN_LAYOUT for this function to work properly.
+#
+# Example:
+# replace_in_doxygen_layout ("${SEQAN3_INCLUDE_DIR}/../doc/about/" "About")
+#
+# (1) Find all 'index.md' files in ${SEQAN3_INCLUDE_DIR}/../doc/about/
+# (2) For each 'index.md'
+#     (a) Use the very first line, e.g. `# FOOOMOO {#fooooo_bar_ref}`,
+#         for the title, e.g. "FOOOMOO" and doxygen reference, e.g. "fooooo_bar_ref".
+#     (b) Generate doxygen html layout entry, e.g.
+#         "      <tab type=\"user\" visible=\"yes\" title=\"FOOOMOO" url=\"\\\\ref fooooo_bar_ref\" intro=\"\"/>\n"
+#         and append it to a list
+# (3) Replace the doxygen html layout entry list from (2) in the ${DOXYGEN_LAYOUT} input variable
+#
+function (replace_in_doxygen_layout doc_path doxygen_layout_tag)
+    set(DOXYGEN_LAYOUT_TAG_LINE "<tab type=\"usergroup\" visible=\"yes\" title=\"${doxygen_layout_tag}\" intro=\"\">\n")
+    set(DOXYGEN_LAYOUT_DOC_PAGES ${DOXYGEN_LAYOUT_TAG_LINE}) # append header line
+
+    # iterate over all index.md
+    seqan3_test_files (doc_how_to_filenames "${doc_path}" "index.md")
+    foreach (doc_how_to_filename ${doc_how_to_filenames})
+        set(doc_howto_filepath "${doc_path}/${doc_how_to_filename}")
+        execute_process(COMMAND head -n 1 ${doc_howto_filepath} OUTPUT_VARIABLE DOC_HEADER_LINE)
+        string(REGEX MATCH "^# \(.*\) {#\(.*\)}" DUMMY ${DOC_HEADER_LINE})
+        set(doc_title ${CMAKE_MATCH_1})
+        set(doc_ref_name ${CMAKE_MATCH_2})
+        string(APPEND DOXYGEN_LAYOUT_DOC_PAGES "      <tab type=\"user\" visible=\"yes\" title=\"${doc_title}\" url=\"\\\\ref ${doc_ref_name}\" intro=\"\"/>\n")
+
+        unset(doc_howto_filepath)
+        unset(doc_title)
+        unset(doc_ref_name)
+    endforeach ()
+
+    # Replace header line and appended list of doc entries with header line
+    string(REGEX REPLACE "${DOXYGEN_LAYOUT_TAG_LINE}" "${DOXYGEN_LAYOUT_DOC_PAGES}" NEW_DOXYGEN_LAYOUT ${DOXYGEN_LAYOUT})
+
+    set(DOXYGEN_LAYOUT ${NEW_DOXYGEN_LAYOUT} PARENT_SCOPE) # replace new Doxygen layout
+
+    unset(DOXYGEN_LAYOUT_TAG_LINE)
+    unset(DOXYGEN_LAYOUT_DOC_PAGES)
+endfunction ()
+
+### Add all documentation pages to DoxygenLayout.xml
+### ------------------------------------------------
+# Note: variable name DOXYGEN_LAYOUT must not be changed because it is directly used within `replace_in_doxygen_layout`
+file(READ "${CMAKE_SOURCE_DIR}/DoxygenLayout.xml" DOXYGEN_LAYOUT)
+
+replace_in_doxygen_layout("${SEQAN3_INCLUDE_DIR}/../doc/about/" "About")
+replace_in_doxygen_layout("${SEQAN3_INCLUDE_DIR}/../doc/setup/" "Setup")
+replace_in_doxygen_layout("${SEQAN3_INCLUDE_DIR}/../doc/tutorial/" "Tutorial")
+replace_in_doxygen_layout("${SEQAN3_INCLUDE_DIR}/../doc/howto/" "How-To")
+
+file(WRITE "${CMAKE_BINARY_DIR}/DoxygenLayout.xml" ${DOXYGEN_LAYOUT})

--- a/test/documentation/seqan3-doxygen-layout.cmake
+++ b/test/documentation/seqan3-doxygen-layout.cmake
@@ -25,7 +25,6 @@ include(${SEQAN3_INCLUDE_DIR}/../test/cmake/seqan3_test_files.cmake)
 #         and append it to a list
 # (3) Replace the doxygen html layout entry list from (2) in the ${DOXYGEN_LAYOUT} input variable
 #
-``
 function (replace_in_doxygen_layout doc_path doxygen_layout_tag)
     set(DOXYGEN_LAYOUT_TAG_LINE "<tab type=\"usergroup\" visible=\"yes\" title=\"${doxygen_layout_tag}\" intro=\"\">\n")
     set(DOXYGEN_LAYOUT_DOC_PAGES ${DOXYGEN_LAYOUT_TAG_LINE}) # append header line

--- a/test/documentation/seqan3-doxygen-layout.cmake
+++ b/test/documentation/seqan3-doxygen-layout.cmake
@@ -9,9 +9,9 @@ cmake_minimum_required (VERSION 3.10)
 
 include(${SEQAN3_INCLUDE_DIR}/../test/cmake/seqan3_test_files.cmake)
 
-# Repalces documentation entries in variable `DOXYGEN_LAYOUT`
+# Replaces documentation entries in variable `DOXYGEN_LAYOUT`
 #
-# Important: the variable of the parten scope must be called DOXYGEN_LAYOUT for this function to work properly.
+# Important: the variable of the parent scope must be named `DOXYGEN_LAYOUT` for this function to work properly.
 #
 # Example:
 # replace_in_doxygen_layout ("${SEQAN3_INCLUDE_DIR}/../doc/about/" "About")
@@ -25,6 +25,7 @@ include(${SEQAN3_INCLUDE_DIR}/../test/cmake/seqan3_test_files.cmake)
 #         and append it to a list
 # (3) Replace the doxygen html layout entry list from (2) in the ${DOXYGEN_LAYOUT} input variable
 #
+``
 function (replace_in_doxygen_layout doc_path doxygen_layout_tag)
     set(DOXYGEN_LAYOUT_TAG_LINE "<tab type=\"usergroup\" visible=\"yes\" title=\"${doxygen_layout_tag}\" intro=\"\">\n")
     set(DOXYGEN_LAYOUT_DOC_PAGES ${DOXYGEN_LAYOUT_TAG_LINE}) # append header line

--- a/test/documentation/seqan3_doxygen_cfg.in
+++ b/test/documentation/seqan3_doxygen_cfg.in
@@ -2,7 +2,7 @@ PROJECT_NAME           = "SeqAn3"
 PROJECT_BRIEF          = "The Modern C++ library for sequence analysis."
 PROJECT_LOGO           = ${SEQAN3_DOXYGEN_SOURCE_DIR}/test/documentation/seqan_logo.png
 PROJECT_NUMBER         = ${SEQAN3_VERSION}
-LAYOUT_FILE            = ${SEQAN3_DOXYGEN_SOURCE_DIR}/test/documentation/DoxygenLayout.xml
+LAYOUT_FILE            = ${CMAKE_BINARY_DIR}/DoxygenLayout.xml
 
 ## PATHS
 OUTPUT_DIRECTORY       = ${SEQAN3_DOXYGEN_OUTPUT_DIR}


### PR DESCRIPTION
When working on #2954 and replacing the documentation, I think it's important that we can include stuff like howtos and tutorials automatically. Otherwise we will have trouble to keep everything up to date.

For this purpose I tried to work out a cmake script that adds a reference for the Tutorial/How-To pages automatically to the `DoxygenLayout.xml` (while generating a new one in the build folder).

Take a look at the vercel preview to see the difference. All tutorials/how_tos/about pages should be present but might have a different name now. If you think the titles are too verbose, we can change the titles. (IMHO verbose titles are good)