### PR TITLE
[TEST] add concept checks for deep views::char_to

### DIFF
--- a/include/seqan3/alphabet/views/char_to.hpp
+++ b/include/seqan3/alphabet/views/char_to.hpp
@@ -64,12 +64,12 @@ namespace seqan3::views
  * \stableapi{Since version 3.1.}
  */
 template <alphabet alphabet_type>
-inline auto const char_to = deep{std::views::transform([] (auto && in)
+inline auto const char_to = deep{detail::semiregular_functor_wrapper{std::bind(std::views::transform, std::placeholders::_1, [] (auto && in)
 {
     static_assert(std::common_reference_with<decltype(in), alphabet_char_t<alphabet_type>>,
                   "The innermost value type must have a common reference to underlying char type of alphabet_type.");
     // call element-wise assign_char from the alphabet
     return assign_char_to(in, alphabet_type{});
-})};
+})}};
 
 } // namespace seqan3::views

--- a/test/unit/alphabet/views/char_to_test.cpp
+++ b/test/unit/alphabet/views/char_to_test.cpp
@@ -58,6 +58,7 @@ TEST(view_char_to, concepts)
     EXPECT_TRUE(std::ranges::common_range<decltype(vec)>);
     EXPECT_TRUE(seqan3::const_iterable_range<decltype(vec)>);
     EXPECT_TRUE((std::ranges::output_range<decltype(vec), char>));
+    EXPECT_TRUE(std::semiregular<decltype(vec)>);
 
     auto v1 = vec | seqan3::views::char_to<seqan3::dna5>;
     EXPECT_TRUE(std::ranges::input_range<decltype(v1)>);
@@ -70,4 +71,23 @@ TEST(view_char_to, concepts)
     EXPECT_TRUE(seqan3::const_iterable_range<decltype(v1)>);
     EXPECT_FALSE((std::ranges::output_range<decltype(v1), seqan3::dna5>));
     EXPECT_FALSE((std::ranges::output_range<decltype(v1), char>));
+    EXPECT_TRUE(std::semiregular<decltype(v1)>);
+}
+
+TEST(view_char_to, deep_view_concepts)
+{
+    std::vector<std::string> foo{"ACGTA", "TGCAT"};
+    auto v1 = foo | seqan3::views::char_to<seqan3::dna5>;
+
+    EXPECT_TRUE(std::ranges::input_range<decltype(v1)>);
+    EXPECT_TRUE(std::ranges::forward_range<decltype(v1)>);
+    EXPECT_TRUE(std::ranges::bidirectional_range<decltype(v1)>);
+    EXPECT_TRUE(std::ranges::random_access_range<decltype(v1)>);
+    EXPECT_TRUE(std::ranges::view<decltype(v1)>);
+    EXPECT_TRUE(std::ranges::sized_range<decltype(v1)>);
+    EXPECT_TRUE(std::ranges::common_range<decltype(v1)>);
+    EXPECT_TRUE(seqan3::const_iterable_range<decltype(v1)>);
+    EXPECT_FALSE((std::ranges::output_range<decltype(v1), seqan3::dna5>));
+    EXPECT_FALSE((std::ranges::output_range<decltype(v1), char>));
+    EXPECT_TRUE(std::semiregular<decltype(v1)>);
 }


### PR DESCRIPTION
There is a regression in GCC11.3 and GCC12.1 where multidimensional deep views are no longer default-constructible. I have done some investigating but could not yet fix it. Can someone have a look?

This PR adds the required test. It builds on all compilers, but line 93 fails on  GCC>=11.3.

Note that prior to GCC11.3 **all** views were required to be default-constructible. This is no longer the case, but something else broke at the same time (the thing is still considered a view, but not semiregular any more).

P.S.: I would recommend adding semiregular checks to all views and also documenting this property in the doxygen tables for views, but that would be a different issue.