### PR TITLE
[FIX] Ignore bogus memcpy warning on gcc12

### DIFF
--- a/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
+++ b/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
@@ -388,12 +388,12 @@ inline void assign_unaligned(aligned_seq_t & aligned_seq, unaligned_sequence_typ
     aligned_seq_t tmp;
     tmp.resize(std::ranges::distance(unaligned_seq));
 #if SEQAN3_WORKAROUND_GCC_BOGUS_MEMCPY
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wstringop-overflow"
 #endif // SEQAN3_WORKAROUND_GCC_BOGUS_MEMCPY
     std::ranges::copy(unaligned_seq, std::ranges::begin(tmp));
 #if SEQAN3_WORKAROUND_GCC_BOGUS_MEMCPY
-#pragma GCC diagnostic pop
+#    pragma GCC diagnostic pop
 #endif // SEQAN3_WORKAROUND_GCC_BOGUS_MEMCPY
     swap(aligned_seq, tmp);
 }

--- a/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
+++ b/include/seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp
@@ -387,7 +387,14 @@ inline void assign_unaligned(aligned_seq_t & aligned_seq, unaligned_sequence_typ
     using std::swap;
     aligned_seq_t tmp;
     tmp.resize(std::ranges::distance(unaligned_seq));
+#if SEQAN3_WORKAROUND_GCC_BOGUS_MEMCPY
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif // SEQAN3_WORKAROUND_GCC_BOGUS_MEMCPY
     std::ranges::copy(unaligned_seq, std::ranges::begin(tmp));
+#if SEQAN3_WORKAROUND_GCC_BOGUS_MEMCPY
+#pragma GCC diagnostic pop
+#endif // SEQAN3_WORKAROUND_GCC_BOGUS_MEMCPY
     swap(aligned_seq, tmp);
 }
 //!\}


### PR DESCRIPTION
Resolves https://github.com/seqan/seqan3/issues/2905