### PR TITLE
[FIX] Missing include

### DIFF
--- a/include/seqan3/core/detail/all_view.hpp
+++ b/include/seqan3/core/detail/all_view.hpp
@@ -15,6 +15,9 @@
 #include <seqan3/std/ranges>
 
 #if __cpp_lib_ranges >= 202110L
+
+#    include <seqan3/core/platform.hpp>
+
 namespace seqan3::detail
 {
 using std::ranges::owning_view;


### PR DESCRIPTION
When using the gcc12 implementation, we need to include `platform.hpp`. Otherwise, the header test will fail.

Resolves https://github.com/seqan/seqan3/issues/2747
Resolves https://github.com/seqan/seqan3/issues/2905