### PR TITLE
[INFRA] header test: gcc11 -> gcc12

### DIFF
--- a/.github/workflows/ci_misc.yml
+++ b/.github/workflows/ci_misc.yml
@@ -66,9 +66,9 @@ jobs:
             skip_run_tests: false
             use_include_dependencies: "OFF"
 
-          - name: "Header gcc11"
-            cxx: "g++-11"
-            cc: "gcc-11"
+          - name: "Header gcc12"
+            cxx: "g++-12"
+            cc: "gcc-12"
             build: header
             build_type: Release
             build_threads: 2


### PR DESCRIPTION
gcc12 is stricter than gcc11 regarding includes, so it should be fine to just replace it. the gcc10 header test should take care of the other stuff.