### PR TITLE
[INFRA] Always use upstream .clang-format

### DIFF
--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -94,6 +94,12 @@ jobs:
           git config user.email "$(git log -1 --format='%ce' ${{ github.event.pull_request.head.sha }})"
           git rebase upstream/${{ github.event.pull_request.base.ref }}
 
+      - name: Copy upstream .clang-format
+        run: |
+          cd seqan3
+          git show upstream/${{ github.event.pull_request.base.ref }}:.clang-format | \
+          tee ${{ github.workspace }}/.clang-format
+
       # Get filenames (--name-only) of added, copied, modified, renamed, changed (ACMRT) files relative to the base
       # branch (github.event.pull_request.base.sha).
       # Exclude contrib include folder, exclude submodules folder.
@@ -122,7 +128,8 @@ jobs:
         run: |
           cd seqan3
           git checkout ${{ github.event.pull_request.head.ref }}
-          echo "${{ steps.changed_files.outputs.list }}" | xargs clang-format-15 --style=file:.clang-format -i
+          echo "${{ steps.changed_files.outputs.list }}" | \
+          xargs clang-format-15 --style=file:${{ github.workspace }}/.clang-format -i
 
       - name: Import GPG key
         if: ${{ steps.changed_files.outputs.list }}


### PR DESCRIPTION
<!--
Please see https://github.com/seqan/seqan3/blob/master/CONTRIBUTING.md for a general overview.

Please allow edits from maintainers:
https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests

Once you create the PR, clang-format will be run on the PR, and any formatting changes will be pushed to your fork.
Subsequently, the actual CI will start.

****************************************************************************************************
** Attention: This means that you will have to `git pull` the changes before pushing new commits. **
****************************************************************************************************

Each of your commits will trigger a clang-format commit if there are formatting changes.


While the following guide on rebasing formatting changes is intended for internal use by SeqAn members, and in no way
necessary for contributors, it may still be an interesting read: https://github.com/seqan/seqan3/wiki/Rebasing-clang-format-commits-with-git-absorb
-->
