### PR TITLE
[MISC] cleanup compiler support

### DIFF
--- a/include/seqan3/alignment/matrix/detail/trace_iterator_base.hpp
+++ b/include/seqan3/alignment/matrix/detail/trace_iterator_base.hpp
@@ -68,12 +68,8 @@ private:
 
     //!\brief Befriend with corresponding const_iterator.
     template <typename other_derived_t, two_dimensional_matrix_iterator other_matrix_iter_t>
-    //!\cond
-#if !SEQAN3_WORKAROUND_FURTHER_CONSTRAIN_FRIEND_DECLARATION
         requires std::constructible_from<derived_t, other_derived_t>
               && std::constructible_from<matrix_iter_t, other_matrix_iter_t>
-#endif // !SEQAN3_WORKAROUND_FURTHER_CONSTRAIN_FRIEND_DECLARATION
-    //!\endcond
     friend class trace_iterator_base;
 
     //!\brief Befriend the derived iterator class to allow calling the private constructors.

--- a/include/seqan3/alignment/matrix/detail/two_dimensional_matrix.hpp
+++ b/include/seqan3/alignment/matrix/detail/two_dimensional_matrix.hpp
@@ -331,11 +331,7 @@ private:
 
     //!\brief Befriend the base crtp class.
     template <typename derived_t, matrix_major_order other_order>
-    //!\cond
-#if !SEQAN3_WORKAROUND_FURTHER_CONSTRAIN_FRIEND_DECLARATION
         requires is_value_specialisation_of_v<derived_t, basic_iterator> && (other_order == order)
-#endif // !SEQAN3_WORKAROUND_FURTHER_CONSTRAIN_FRIEND_DECLARATION
-    //!\endcond
     friend class two_dimensional_matrix_iterator_base;
 
     //!\brief Befriend the corresponding const iterator.

--- a/include/seqan3/alignment/matrix/detail/two_dimensional_matrix_iterator_base.hpp
+++ b/include/seqan3/alignment/matrix/detail/two_dimensional_matrix_iterator_base.hpp
@@ -81,11 +81,7 @@ private:
 
     //!\brief Befriend other base class types for const iterator compatibility.
     template <typename other_derived_t, matrix_major_order other_order>
-    //!\cond
-#if !SEQAN3_WORKAROUND_FURTHER_CONSTRAIN_FRIEND_DECLARATION
         requires (order == other_order)
-#endif // !SEQAN3_WORKAROUND_FURTHER_CONSTRAIN_FRIEND_DECLARATION
-    //!\endcond
     friend class two_dimensional_matrix_iterator_base;
 
     /*!\name Constructors, destructor and assignment

--- a/include/seqan3/alignment/pairwise/alignment_result.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_result.hpp
@@ -24,9 +24,7 @@ namespace seqan3::detail
 
 // forward declaration for friend declaration in alignment_result.
 template <typename configuration_t>
-#if !SEQAN3_WORKAROUND_GCC_93467
     requires is_type_specialisation_of_v<configuration_t, configuration>
-#endif // !SEQAN3_WORKAROUND_GCC_93467
 class policy_alignment_result_builder;
 
 /*!\brief A struct that contains the actual alignment result data.
@@ -172,9 +170,7 @@ private:
 
     //!\brief Befriend alignment result builder.
     template <typename configuration_t>
-#if !SEQAN3_WORKAROUND_GCC_93467
         requires detail::is_type_specialisation_of_v<configuration_t, configuration>
-#endif // !SEQAN3_WORKAROUND_GCC_93467
     friend class detail::policy_alignment_result_builder;
 
 public:

--- a/include/seqan3/alignment/pairwise/detail/policy_alignment_result_builder.hpp
+++ b/include/seqan3/alignment/pairwise/detail/policy_alignment_result_builder.hpp
@@ -32,9 +32,7 @@ namespace seqan3::detail
  * Implements the interfaces to build the alignment result based on the previously selected output configurations.
  */
 template <typename alignment_configuration_t>
-#if !SEQAN3_WORKAROUND_GCC_93467
     requires is_type_specialisation_of_v<alignment_configuration_t, configuration>
-#endif // !SEQAN3_WORKAROUND_GCC_93467
 class policy_alignment_result_builder
 {
 protected:

--- a/include/seqan3/core/platform.hpp
+++ b/include/seqan3/core/platform.hpp
@@ -208,6 +208,7 @@ static_assert(sdsl::sdsl_version_major == 3, "Only version 3 of the SDSL is supp
  * * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=93983
  * * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95371
  * * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95578
+ * * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=99318
  */
 #if defined(__GNUC__) && (__GNUC__ == 10 && __GNUC_MINOR__ <= 2)
 #    pragma GCC warning                                                                                                \
@@ -234,15 +235,6 @@ static_assert(sdsl::sdsl_version_major == 3, "Only version 3 of the SDSL is supp
 #        define SEQAN3_WORKAROUND_GCC_96070 1
 #    else
 #        define SEQAN3_WORKAROUND_GCC_96070 0
-#    endif
-#endif
-
-//!\brief See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=99318
-#ifndef SEQAN3_WORKAROUND_GCC_99318 // fixed since gcc10.3
-#    if defined(__GNUC__) && (__GNUC__ == 10 && __GNUC_MINOR__ < 3)
-#        define SEQAN3_WORKAROUND_GCC_99318 1
-#    else
-#        define SEQAN3_WORKAROUND_GCC_99318 0
 #    endif
 #endif
 

--- a/include/seqan3/core/platform.hpp
+++ b/include/seqan3/core/platform.hpp
@@ -240,16 +240,6 @@ static_assert(sdsl::sdsl_version_major == 3, "Only version 3 of the SDSL is supp
 #    endif
 #endif
 
-//!\brief See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100252
-//!       ICE in template instantiation.
-#ifndef SEQAN3_WORKAROUND_GCC_100252 // not yet fixed
-#    if defined(__GNUC__) && (__GNUC__ >= 12)
-#        define SEQAN3_WORKAROUND_GCC_100252 1
-#    else
-#        define SEQAN3_WORKAROUND_GCC_100252 0
-#    endif
-#endif
-
 /*!\brief This is needed to support CentOS 7 or RHEL 7; Newer CentOS's include a more modern default-gcc version making
  *        this macro obsolete.
  *

--- a/include/seqan3/core/platform.hpp
+++ b/include/seqan3/core/platform.hpp
@@ -209,6 +209,7 @@ static_assert(sdsl::sdsl_version_major == 3, "Only version 3 of the SDSL is supp
  * * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95371
  * * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95578
  * * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=99318
+ * * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=93467
  */
 #if defined(__GNUC__) && (__GNUC__ == 10 && __GNUC_MINOR__ <= 2)
 #    pragma GCC warning                                                                                                \
@@ -218,15 +219,6 @@ static_assert(sdsl::sdsl_version_major == 3, "Only version 3 of the SDSL is supp
 #ifndef SEQAN3_WORKAROUND_VIEW_PERFORMANCE
 //!\brief Performance of views, especially filter and join is currently bad, especially in I/O.
 #    define SEQAN3_WORKAROUND_VIEW_PERFORMANCE 1
-#endif
-
-//!\brief See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=93467
-#ifndef SEQAN3_WORKAROUND_GCC_93467 // fixed since gcc10.2
-#    if defined(__GNUC__) && ((__GNUC__ <= 9) || (__GNUC__ == 10 && __GNUC_MINOR__ < 2))
-#        define SEQAN3_WORKAROUND_GCC_93467 1
-#    else
-#        define SEQAN3_WORKAROUND_GCC_93467 0
-#    endif
 #endif
 
 //!\brief See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96070 and https://github.com/seqan/product_backlog/issues/151

--- a/include/seqan3/core/platform.hpp
+++ b/include/seqan3/core/platform.hpp
@@ -270,17 +270,6 @@ static_assert(sdsl::sdsl_version_major == 3, "Only version 3 of the SDSL is supp
 #    endif // SEQAN3_DISABLE_LEGACY_STD_DIAGNOSTIC
 #endif     // _GLIBCXX_USE_CXX11_ABI == 0
 
-/*!\brief https://eel.is/c++draft/range.take#view defines e.g. `constexpr auto size() requires sized_range<V>` without
- *        any template. This syntax works since gcc-10, before that a dummy `template <typename = ...>` must be used.
- */
-#ifndef SEQAN3_WORKAROUND_GCC_NON_TEMPLATE_REQUIRES
-#    if defined(__GNUC_MINOR__) && (__GNUC__ < 10) // fixed since gcc-10
-#        define SEQAN3_WORKAROUND_GCC_NON_TEMPLATE_REQUIRES 1
-#    else
-#        define SEQAN3_WORKAROUND_GCC_NON_TEMPLATE_REQUIRES 0
-#    endif
-#endif
-
 //!\brief Workaround to access the static id of the configuration elements inside of the concept definition
 //!       (fixed in gcc11).
 #ifndef SEQAN3_WORKAROUND_GCC_PIPEABLE_CONFIG_CONCEPT

--- a/include/seqan3/core/platform.hpp
+++ b/include/seqan3/core/platform.hpp
@@ -40,6 +40,18 @@
 #    error "SeqAn 3.1.x is the last version that supports GCC 7, 8, and 9. Please upgrade your compiler or use 3.1.x."
 #endif // defined(__GNUC__) && (__GNUC__ < 10)
 
+#if SEQAN3_DOXYGEN_ONLY(1) 0
+//!\brief This disables the warning you would get if your compiler is newer than the latest supported version.
+#    define SEQAN3_DISABLE_NEWER_COMPILER_DIAGNOSTIC
+#endif // SEQAN3_DOXYGEN_ONLY(1)0
+
+#ifndef SEQAN3_DISABLE_NEWER_COMPILER_DIAGNOSTIC
+#    if defined(__GNUC__) && (__GNUC__ > 12)
+#        pragma message                                                                                                \
+            "Your compiler is newer than the latest supported compiler of this SeqAn version (gcc-12). It might be that SeqAn does not compile due to this. You can disable this warning by setting -DSEQAN3_DISABLE_NEWER_COMPILER_DIAGNOSTIC."
+#    endif // defined(__GNUC__) && (__GNUC__ > 12)
+#endif     // SEQAN3_DISABLE_NEWER_COMPILER_DIAGNOSTIC
+
 // ============================================================================
 //  C++ standard and features
 // ============================================================================

--- a/include/seqan3/core/platform.hpp
+++ b/include/seqan3/core/platform.hpp
@@ -38,7 +38,7 @@
 
 #if defined(__GNUC__) && (__GNUC__ == 7 || __GNUC__ == 8 || __GNUC__ == 9)
 #    error "SeqAn 3.1.x is the last version that supports GCC 7, 8, and 9. Please upgrade your compiler or use 3.1.x."
-#endif // defined(__GNUC__) && (__GNUC__ == 7 || __GNUC__ == 8)
+#endif // defined(__GNUC__) && (__GNUC__ < 10)
 
 // ============================================================================
 //  C++ standard and features
@@ -209,9 +209,9 @@ static_assert(sdsl::sdsl_version_major == 3, "Only version 3 of the SDSL is supp
  * * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95371
  * * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95578
  */
-#if defined(__GNUC__) && (__GNUC__ == 10 && __GNUC_MINOR__ <= 1)
+#if defined(__GNUC__) && (__GNUC__ == 10 && __GNUC_MINOR__ <= 2)
 #    pragma GCC warning                                                                                                \
-        "Be aware that gcc 10.0 and 10.1 are known to have several bugs that might make SeqAn3 fail to compile. Please use gcc >= 10.2."
+        "Be aware that gcc 10.0, 10.1 and 10.2 are known to have several bugs that might make SeqAn3 fail to compile. Please use gcc >= 10.3."
 #endif // defined(__GNUC__) && (__GNUC__ == 10 && __GNUC_MINOR__ <= 1)
 
 #ifndef SEQAN3_WORKAROUND_VIEW_PERFORMANCE

--- a/include/seqan3/core/platform.hpp
+++ b/include/seqan3/core/platform.hpp
@@ -300,33 +300,6 @@ static_assert(sdsl::sdsl_version_major == 3, "Only version 3 of the SDSL is supp
 #    endif
 #endif
 
-/*!\brief gcc only: Constrain friend declarations to limit access to internals.
- *
- * \details
- *
- * We have some instances where we constrain friend declarations to limit which class instance can
- * access private information. For example
- *
- * ```
- * template <typename type_t>
- *     requires std::same_as<type_t, int>
- * friend class std::tuple;
- * ```
- *
- * would only allow `std::tuple<int>` to access the internals.
- *
- * It seems that this is not standard behaviour and more like a gcc-only extension, as neither clang nor msvc supports
- * it. For now we will keep this code, but it should be removed if it turns out that this is non-standard. (i.e. a newer
- * gcc release does not support it any more)
- */
-#ifndef SEQAN3_WORKAROUND_FURTHER_CONSTRAIN_FRIEND_DECLARATION
-#    if defined(__clang__)
-#        define SEQAN3_WORKAROUND_FURTHER_CONSTRAIN_FRIEND_DECLARATION 1
-#    else
-#        define SEQAN3_WORKAROUND_FURTHER_CONSTRAIN_FRIEND_DECLARATION 0
-#    endif
-#endif
-
 // ============================================================================
 //  Backmatter
 // ============================================================================

--- a/include/seqan3/core/platform.hpp
+++ b/include/seqan3/core/platform.hpp
@@ -231,9 +231,9 @@ static_assert(sdsl::sdsl_version_major == 3, "Only version 3 of the SDSL is supp
 #endif
 
 //!\brief See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100139
-//!       std::views::{take, drop} do not type-erase. This is a defect within the standard lib.
-#ifndef SEQAN3_WORKAROUND_GCC_100139 // not yet fixed
-#    if defined(__GNUC__)
+//!       std::views::{take, drop} do not type-erase. This is a defect within the standard lib (fixed in gcc12).
+#ifndef SEQAN3_WORKAROUND_GCC_100139
+#    if defined(__GNUC__) && (__GNUC__ < 12)
 #        define SEQAN3_WORKAROUND_GCC_100139 1
 #    else
 #        define SEQAN3_WORKAROUND_GCC_100139 0

--- a/include/seqan3/core/range/detail/random_access_iterator.hpp
+++ b/include/seqan3/core/range/detail/random_access_iterator.hpp
@@ -37,7 +37,7 @@ namespace seqan3::detail
  * Since the CRTP parameter is in fact a template template, CRTP instantiation looks a little different, e.g.:
  * \include test/snippet/range/detail/random_access_iterator.cpp
  */
-template <typename range_type, template <typename...> typename derived_t_template>
+template <typename range_type, template <typename...> typename derived_t_template, typename... args_t>
 class random_access_iterator_base
 {
 protected:
@@ -49,14 +49,10 @@ protected:
     position_type pos{static_cast<position_type>(0)};
 
     //!\brief This friend declaration is required to allow non-const to const-construction.
-    template <typename range_type2, template <typename...> typename derived_t_template2>
-    //!\cond
-#if !SEQAN3_WORKAROUND_FURTHER_CONSTRAIN_FRIEND_DECLARATION
+    template <typename range_type2, template <typename...> typename derived_t_template2, typename... args2_t>
         requires std::is_const_v<range_type>
               && (!std::is_const_v<range_type2>) && std::is_same_v<std::remove_const_t<range_type>, range_type2>
-              && std::is_same_v<derived_t_template2, derived_t_template>
-#endif // !SEQAN3_WORKAROUND_FURTHER_CONSTRAIN_FRIEND_DECLARATION
-    //!\endcond
+              && std::is_same_v<derived_t_template2<args2_t...>, derived_t_template<args_t...>>
     friend class random_access_iterator_base;
 
     //!\brief Because this is CRTP, we know the full derived type:

--- a/include/seqan3/search/detail/policy_search_result_builder.hpp
+++ b/include/seqan3/search/detail/policy_search_result_builder.hpp
@@ -23,9 +23,7 @@ namespace seqan3::detail
 //!\brief Provides the function `make_results` if inherited by a search algorithm.
 //!\ingroup search
 template <typename search_configuration_t>
-#if !SEQAN3_WORKAROUND_GCC_93467
     requires is_type_specialisation_of_v<search_configuration_t, configuration>
-#endif // !SEQAN3_WORKAROUND_GCC_93467
 struct policy_search_result_builder
 {
 protected:

--- a/include/seqan3/search/search_result.hpp
+++ b/include/seqan3/search/search_result.hpp
@@ -28,9 +28,7 @@ namespace seqan3::detail
 {
 // forward declaration
 template <typename search_configuration_t>
-#if !SEQAN3_WORKAROUND_GCC_93467
     requires is_type_specialisation_of_v<search_configuration_t, configuration>
-#endif // !SEQAN3_WORKAROUND_GCC_93467
 struct policy_search_result_builder;
 } // namespace seqan3::detail
 
@@ -91,9 +89,7 @@ private:
 
     // Grant the policy access to private constructors.
     template <typename search_configuration_t>
-#if !SEQAN3_WORKAROUND_GCC_93467
         requires detail::is_type_specialisation_of_v<search_configuration_t, configuration>
-#endif // !SEQAN3_WORKAROUND_GCC_93467
     friend struct detail::policy_search_result_builder;
 
 public:

--- a/include/seqan3/utility/views/pairwise_combine.hpp
+++ b/include/seqan3/utility/views/pairwise_combine.hpp
@@ -254,11 +254,7 @@ class pairwise_combine_view<underlying_range_type>::basic_iterator :
 private:
     //!\brief Friend declaration for iterator with different range const-ness.
     template <typename other_range_type>
-    //!\cond
-#if !SEQAN3_WORKAROUND_FURTHER_CONSTRAIN_FRIEND_DECLARATION
         requires std::same_as<std::remove_const_t<range_type>, std::remove_const_t<other_range_type>>
-#endif // !SEQAN3_WORKAROUND_FURTHER_CONSTRAIN_FRIEND_DECLARATION
-    //!\endcond
     friend class basic_iterator;
 
     //!\brief Alias type for the iterator over the passed range type.

--- a/include/seqan3/utility/views/pairwise_combine.hpp
+++ b/include/seqan3/utility/views/pairwise_combine.hpp
@@ -208,9 +208,6 @@ public:
      * \{
      */
     //!\brief Computes the size based on the size of the underlying range.
-#if SEQAN3_WORKAROUND_GCC_NON_TEMPLATE_REQUIRES
-    template <typename = underlying_range_type>
-#endif // SEQAN3_WORKAROUND_GCC_NON_TEMPLATE_REQUIRES
     constexpr auto size() const noexcept
         requires std::ranges::sized_range<underlying_range_type>
     {

--- a/include/seqan3/utility/views/type_reduce.hpp
+++ b/include/seqan3/utility/views/type_reduce.hpp
@@ -53,8 +53,8 @@ private:
             std::ranges::viewable_range<urng_t>,
             "The views::type_reduce adaptor can only be passed viewable_ranges, i.e. Views or &-to-non-View.");
 
-        // views are always passed as-is
-        if constexpr (std::ranges::view<std::remove_cvref_t<urng_t>>)
+        // string_view
+        if constexpr (is_type_specialisation_of_v<std::remove_cvref_t<urng_t>, std::basic_string_view>)
         {
             return std::views::all(std::forward<urng_t>(urange));
         }
@@ -79,7 +79,7 @@ private:
                 std::ranges::begin(urange) + std::ranges::size(urange),
                 std::ranges::size(urange)};
         }
-        // pass to std::views::all (will return ref-view)
+        // pass to std::views::all (will return a view or ref-view)
         else
         {
             return std::views::all(std::forward<urng_t>(urange));

--- a/test/include/seqan3/test/fixture/io/sam_file/simple_three_verbose_reads_fixture.hpp
+++ b/test/include/seqan3/test/fixture/io/sam_file/simple_three_verbose_reads_fixture.hpp
@@ -143,14 +143,7 @@ struct simple_three_verbose_reads_fixture
                         /*.cigar_sequence =*/"1S1M1P1M1I1M1I1D1M1S"_cigar,
                         /*.tags =*/seqan3::sam_tag_dictionary{}};
 
-#if SEQAN3_WORKAROUND_GCC_100252
-    std::vector<record_type> records = [this]()
-    {
-        return std::vector<record_type>{record1, record2, record3};
-    }();
-#else
     std::vector<record_type> records{record1, record2, record3};
-#endif
 };
 
 } // namespace seqan3::test::fixture::io::sam_file

--- a/test/include/seqan3/test/fixture/io/sequence_file/standard_fixture.hpp
+++ b/test/include/seqan3/test/fixture/io/sequence_file/standard_fixture.hpp
@@ -42,14 +42,7 @@ struct standard_fixture
                         /*.sequence =*/"ACGTTTA"_dna5,
                         /*.base_qualities =*/"!!!!!!!"_phred42};
 
-#if SEQAN3_WORKAROUND_GCC_100252
-    std::vector<record_type> records = [this]()
-    {
-        return std::vector<record_type>{record1, record2, record3};
-    }();
-#else
     std::vector<record_type> records{record1, record2, record3};
-#endif
 };
 
 } // namespace seqan3::test::fixture::io::sequence_file

--- a/test/unit/std/ranges_test.cpp
+++ b/test/unit/std/ranges_test.cpp
@@ -23,9 +23,6 @@ TEST(ranges_test, take_view)
     EXPECT_SAME_TYPE(decltype(std::views::take(std::string_view{}, 0)), std::string_view);
     EXPECT_SAME_TYPE(decltype(std::views::take(std::views::empty<int>, 0)), std::ranges::empty_view<int>);
     EXPECT_SAME_TYPE(decltype(std::views::take(std::views::iota(0, 1), 0)), decltype(std::views::iota(0, 1)));
-
-    EXPECT_SAME_TYPE(decltype(std::views::take(s, 0)),
-                     (std::ranges::subrange<std::string::iterator, std::string::iterator>));
 #endif // !SEQAN3_WORKAROUND_GCC_100139
 
     EXPECT_TRUE(std::ranges::borrowed_range<decltype(std::views::take(s, 0))>);
@@ -42,9 +39,6 @@ TEST(ranges_test, drop_view)
     EXPECT_SAME_TYPE(decltype(std::views::drop(std::string_view{}, 0)), std::string_view);
     EXPECT_SAME_TYPE(decltype(std::views::drop(std::views::empty<int>, 0)), std::ranges::empty_view<int>);
     EXPECT_SAME_TYPE(decltype(std::views::drop(std::views::iota(0, 1), 0)), decltype(std::views::iota(0, 1)));
-
-    EXPECT_SAME_TYPE(decltype(std::views::drop(s, 0)),
-                     (std::ranges::subrange<std::string::iterator, std::string::iterator>));
 #endif // !SEQAN3_WORKAROUND_GCC_100139
 
     EXPECT_TRUE(std::ranges::borrowed_range<decltype(std::views::drop(s, 0))>);


### PR DESCRIPTION
I checked which workarounds are still necessary and updated them.
I had to do a small change in `views::type_reduce` such that we reduce it the way we actually want (we can only test this now with gcc12).
