### PR TITLE
[FIX] chunk_view operator+=

### DIFF
--- a/test/unit/range/iterator_test_template.hpp
+++ b/test/unit/range/iterator_test_template.hpp
@@ -557,10 +557,16 @@ inline void difference_test(iterator_t && it_begin, iterator_t && it_end, rng_t 
     difference_t size = std::ranges::distance(rng);
 
     for (difference_t n = 0; n <= size; ++n)
+    {
         EXPECT_EQ(n, (it_begin + n) - it_begin);
+        EXPECT_EQ(-n, it_begin - (it_begin + n));
+    }
 
     for (difference_t n = 0; n <= size; ++n)
+    {
         EXPECT_EQ(n, it_end - (it_end - n));
+        EXPECT_EQ(-n, (it_end - n) - it_end);
+    }
 }
 
 TYPED_TEST_P(iterator_fixture, difference_common)


### PR DESCRIPTION
https://cdash.seqan.de/test/29778657

<details><summary>Log</summary>

```
[==========] Running 56 tests from 7 test suites.
[----------] Global test environment set-up.
[----------] 20 tests from iterator_fixture/iterator_fixture/0, where TypeParam = seqan3::detail::chunk_view<std::ranges::ref_view<std::vector<int, std::allocator<int> > > >::basic_iterator<false>
[ RUN      ] iterator_fixture/iterator_fixture/0.concept_check
[       OK ] iterator_fixture/iterator_fixture/0.concept_check (0 ms)
[ RUN      ] iterator_fixture/iterator_fixture/0.const_non_const_compatibility
[       OK ] iterator_fixture/iterator_fixture/0.const_non_const_compatibility (0 ms)
[ RUN      ] iterator_fixture/iterator_fixture/0.dereference
[       OK ] iterator_fixture/iterator_fixture/0.dereference (0 ms)
[ RUN      ] iterator_fixture/iterator_fixture/0.compare
[       OK ] iterator_fixture/iterator_fixture/0.compare (0 ms)
[ RUN      ] iterator_fixture/iterator_fixture/0.move_forward_pre
[       OK ] iterator_fixture/iterator_fixture/0.move_forward_pre (0 ms)
[ RUN      ] iterator_fixture/iterator_fixture/0.move_forward_pre_const
[       OK ] iterator_fixture/iterator_fixture/0.move_forward_pre_const (0 ms)
[ RUN      ] iterator_fixture/iterator_fixture/0.move_forward_post
[       OK ] iterator_fixture/iterator_fixture/0.move_forward_post (0 ms)
[ RUN      ] iterator_fixture/iterator_fixture/0.move_forward_post_const
[       OK ] iterator_fixture/iterator_fixture/0.move_forward_post_const (0 ms)
[ RUN      ] iterator_fixture/iterator_fixture/0.move_backward_pre
[       OK ] iterator_fixture/iterator_fixture/0.move_backward_pre (0 ms)
[ RUN      ] iterator_fixture/iterator_fixture/0.move_backward_post
[       OK ] iterator_fixture/iterator_fixture/0.move_backward_post (0 ms)
[ RUN      ] iterator_fixture/iterator_fixture/0.jump_forward
[       OK ] iterator_fixture/iterator_fixture/0.jump_forward (0 ms)
[ RUN      ] iterator_fixture/iterator_fixture/0.jump_backward
[       OK ] iterator_fixture/iterator_fixture/0.jump_backward (0 ms)
[ RUN      ] iterator_fixture/iterator_fixture/0.jump_random
[       OK ] iterator_fixture/iterator_fixture/0.jump_random (0 ms)
[ RUN      ] iterator_fixture/iterator_fixture/0.difference_common
/usr/local/include/c++/11/bits/ranges_base.h:732: constexpr std::iter_difference_t<_Iter> std::ranges::__advance_fn::operator()(_It&, std::iter_difference_t<_Iter>, _Sent) const [with _It = __gnu_cxx::__normal_iterator<int*, std::vector<int> >; _Sent = __gnu_cxx::__normal_iterator<int*, std::vector<int> >; std::iter_difference_t<_Iter> = long int]: Assertion '__n == 0 || __diff == 0 || (__n < 0 == __diff < 0)' failed.
```
</details>

The Fedora nightlies use `-Wp,-D_GLIBCXX_ASSERTIONS`, which activates some assertions:

https://github.com/gcc-mirror/gcc/blob/releases/gcc-12.1.0/libstdc++-v3/include/bits/ranges_base.h#L780-L781
```cpp
    // n and bound must not lead in opposite directions:
    __glibcxx_assert(__n < 0 == __diff < 0);
```

When doing
```cpp
auto new_start_it = current_chunk.begin() + (chunk_size * skip);
```
`new_start_it` might be behind `urng_end`.
When we then call `get_next_end_of_chunk(new_start_it)`, we have a call like
```cpp
std::ranges::next(new_start_it, chunk_size, urng_end);
```
Which then means that the bound `urng_end` is in front of `new_start_it`, but `chunk_size` says to move in the opposite direction.

```
=========X===========Y============
         ^           ^
       urng_end   new_start_it
         <-----------              // direction from iterator to bound
                     --------->    // direction from chunk_size
```

Hence, I need to confine it to never cross `urng_end`.

Similar problem when `skip` is negative:
```
=========X===========Y============
         ^           ^
     new_start_it  urng_end   
<---------                         // direction from chunk_size
          --------->               // direction from iterator to bound
```

Here, I need to delegate to `operator-=`.

This change led to the iterator_test for `operator-` to fail. 
Adapting `operator-(basic_iterator const & lhs, basic_iterator const & rhs)` to behave like `operator-(sentinel_t const & /* lhs */, basic_iterator const & rhs)` (i.e., rounding up) fixed this, but I haven't put much thought in this. However, it makes sense since we now have a bound for `operator+=`.

I expected to run into a similar problem with `operator-=` after these changes, but it appears to be fine.

I am uncertain if there is a more elegant solution to this.

Requesting @smehringer because she is familiar with the code.
