### PR TITLE
[FIX] clang-format: SEQAN3_DEPRECATED_HEADER

### DIFF
--- a/include/seqan3/core/semiregular_box.hpp
+++ b/include/seqan3/core/semiregular_box.hpp
@@ -14,8 +14,10 @@
 
 #include <seqan3/core/detail/copyable_wrapper.hpp>
 
-SEQAN3_DEPRECATED_HEADER("This header is deprecated and will be removed in SeqAn-3.3.0; Please #include "
-                         "<seqan3/core/detail/copyable_wrapper.hpp> instead.")
+// clang-format off
+SEQAN3_DEPRECATED_HEADER(
+    "This header is deprecated and will be removed in SeqAn-3.3.0; Please #include <seqan3/core/detail/copyable_wrapper.hpp> instead.")
+// clang-format on
 
 namespace seqan3
 {

--- a/include/seqan3/utility/concept/exposition_only/core_language.hpp
+++ b/include/seqan3/utility/concept/exposition_only/core_language.hpp
@@ -14,5 +14,7 @@
 
 #include <seqan3/utility/concept.hpp>
 
-SEQAN3_DEPRECATED_HEADER("This header is deprecated and will be removed in SeqAn-3.3.0; Please #include "
-                         "<seqan3/utility/concept.hpp> instead.")
+// clang-format off
+SEQAN3_DEPRECATED_HEADER(
+    "This header is deprecated and will be removed in SeqAn-3.3.0; Please #include <seqan3/utility/concept.hpp> instead.")
+// clang-format on


### PR DESCRIPTION
The `WhitespaceSensitiveMacros` setting doesn't seem to work when the macro uses more than 2 lines.