### PR TITLE
[INFRA] Refactor coverage builds

### DIFF
--- a/.github/workflows/ci_coverage.yml
+++ b/.github/workflows/ci_coverage.yml
@@ -14,9 +14,10 @@ on:
   # Enables a manual trigger, may run on any branch
   workflow_dispatch:
 
+# Do not cancel on push events
 concurrency:
-  group: linux-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: coverage-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
 
 env:
   CMAKE_VERSION: 3.10.3
@@ -37,30 +38,23 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          - name: "Unit gcc12"
+          - name: "Coverage gcc12"
             cxx: "g++-12"
             cc: "gcc-12"
-            build: unit
-            build_type: Release
-
-          - name: "Unit gcc11"
-            cxx: "g++-11"
-            cc: "gcc-11"
-            build: unit
-            build_type: Release
-
-          - name: "Unit gcc10"
-            cxx: "g++-10"
-            cc: "gcc-10"
-            build: unit
-            build_type: Release
+            build: coverage
+            build_type: Debug
 
     steps:
+      # How many commits do we need to fetch to also fetch the branch point?
+      - name: Get fetch depth
+        id: fetch_depth
+        run: echo "::set-output name=depth::$(( ${{ github.event.pull_request.commits }} + 1 ))"
+
       - name: Checkout SeqAn3
         uses: actions/checkout@v2
         with:
           path: seqan3
-          fetch-depth: 1
+          fetch-depth: ${{ steps.fetch_depth.outputs.depth }}
           submodules: true
 
       - name: Checkout SeqAn2
@@ -86,6 +80,13 @@ jobs:
       - name: Install compiler ${{ matrix.cxx }}
         run: sudo apt-get install --yes ${{ matrix.cxx }}
 
+      - name: Install gcovr
+        env:
+            CC: ${{ matrix.cc }}
+        run: |
+          sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/${CC/gcc/gcov} 100
+          pip install gcovr==5.0
+
       - name: Load ccache
         uses: actions/cache@v2
         with:
@@ -104,8 +105,8 @@ jobs:
 
       - name: Configure tests
         env:
-          CXX: ${{ matrix.cxx }}
-          CC: ${{ matrix.cc }}
+            CXX: ${{ matrix.cxx }}
+            CC: ${{ matrix.cc }}
         run: |
           mkdir seqan3-build
           cd seqan3-build
@@ -122,7 +123,7 @@ jobs:
           CCACHE_DIR: ${{ github.workspace }}/.ccache
           CCACHE_COMPRESS: true
           CCACHE_COMPRESSLEVEL: 12
-          CCACHE_MAXSIZE: ${{ matrix.build == 'coverage' && '525M' || '75M' }}
+          CCACHE_MAXSIZE: 525M
           CCACHE_IGNOREOPTIONS: "-fprofile-abs-path"
           GCOV: ${{ github.workspace }}/seqan3/.github/workflows/scripts/gcov.sh
         run: |
@@ -131,8 +132,8 @@ jobs:
           make -k -j2
           ccache -sv
 
-      - name: Run tests
-        run: |
-          cd seqan3-build
-          ctest . -j2 --output-on-failure
-
+      - name: Submit coverage build
+        uses: codecov/codecov-action@v2
+        with:
+          files: ${{ github.workspace }}/seqan3-build/seqan3_coverage.xml
+          root_dir: ${{ github.workspace }}/seqan3

--- a/.github/workflows/ci_coverage.yml
+++ b/.github/workflows/ci_coverage.yml
@@ -17,7 +17,7 @@ on:
 # Do not cancel on push events
 concurrency:
   group: coverage-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: false # PRs will be canceled by the clang-format CI
 
 env:
   CMAKE_VERSION: 3.10.3

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -16,7 +16,7 @@ on:
 
 concurrency:
   group: linux-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'push' }}
 
 env:
   CMAKE_VERSION: 3.10.3

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -124,7 +124,6 @@ jobs:
           CCACHE_COMPRESSLEVEL: 12
           CCACHE_MAXSIZE: ${{ matrix.build == 'coverage' && '525M' || '75M' }}
           CCACHE_IGNOREOPTIONS: "-fprofile-abs-path"
-          GCOV: ${{ github.workspace }}/seqan3/.github/workflows/scripts/gcov.sh
         run: |
           ccache -z
           cd seqan3-build

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -16,7 +16,7 @@ on:
 
 concurrency:
   group: macos-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'push' }}
 
 env:
   CMAKE_VERSION: 3.10.3

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -124,6 +124,7 @@ jobs:
           CCACHE_COMPRESS: true
           CCACHE_COMPRESSLEVEL: 12
           CCACHE_MAXSIZE: 75M
+          CCACHE_IGNOREOPTIONS: "-fprofile-abs-path"
         run: |
           ccache -z
           cd seqan3-build

--- a/.github/workflows/ci_misc.yml
+++ b/.github/workflows/ci_misc.yml
@@ -233,6 +233,7 @@ jobs:
           CCACHE_COMPRESS: true
           CCACHE_COMPRESSLEVEL: 12
           CCACHE_MAXSIZE: 75M
+          CCACHE_IGNOREOPTIONS: "-fprofile-abs-path"
         run: |
           ccache -z || true
           cd seqan3-build

--- a/.github/workflows/ci_misc.yml
+++ b/.github/workflows/ci_misc.yml
@@ -16,7 +16,7 @@ on:
 
 concurrency:
   group: misc-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'push' }}
 
 env:
   SEQAN3_NO_VERSION_CHECK: 1

--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -39,6 +39,15 @@ jobs:
     steps:
       - name: "Cancel Misc"
         run: echo "Cancelling Misc"
+  cancel_coverage:
+    name: Cancel Coverage
+    concurrency:
+      group: coverage-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    runs-on: ubuntu-22.04
+    steps:
+      - name: "Cancel Coverage"
+        run: echo "Cancelling Coverage"
   lint:
     name: clang-format
     concurrency:

--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -53,6 +53,7 @@ jobs:
     concurrency:
       group: clang-format-${{ github.event.pull_request.number }}
       cancel-in-progress: true
+    needs: [cancel_linux, cancel_macos, cancel_misc, cancel_coverage]
     runs-on: ubuntu-22.04
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
Not sure if it does what I indent it to.

Idea is:
* Never cancel coverage builds on pushes to master. This should improve codecov reports because the base is always analysed.
* Determine the fetch depth of the PR. This should improve codecov because the base is always visible.