### PR TITLE
[FIX] chunk_view using 16 bit integers

### DIFF
--- a/test/unit/utility/views/chunk_test.cpp
+++ b/test/unit/utility/views/chunk_test.cpp
@@ -190,5 +190,5 @@ TYPED_TEST(chunk_view_test, big_chunk)
     // Check that a very big number (1ULL<<42) can be stored as chunk_size inside the chunk_view.
     // error: conversion from ‘long long unsigned int’ to ‘uint16_t’ {aka ‘short unsigned int’} changes value
     // from ‘4398046511104’ to ‘0’ [-Werror=overflow]
-    [[maybe_unused]] auto v = this->text | seqan3::views::chunk(1ULL<<42);
+    [[maybe_unused]] auto v = this->text | seqan3::views::chunk(1ULL << 42);
 }

--- a/test/unit/utility/views/chunk_test.cpp
+++ b/test/unit/utility/views/chunk_test.cpp
@@ -184,3 +184,11 @@ TYPED_TEST(chunk_view_test, use_on_temporaries)
         EXPECT_EQ(i, 4u);
     }
 }
+
+TYPED_TEST(chunk_view_test, big_chunk)
+{
+    // Check that a very big number (1ULL<<42) can be stored as chunk_size inside the chunk_view.
+    // error: conversion from ‘long long unsigned int’ to ‘uint16_t’ {aka ‘short unsigned int’} changes value
+    // from ‘4398046511104’ to ‘0’ [-Werror=overflow]
+    [[maybe_unused]] auto v = this->text | seqan3::views::chunk(1ULL<<42);
+}


### PR DESCRIPTION
```
[...]: warning: conversion from ‘long long unsigned int’ to ‘uint16_t’ {aka ‘short unsigned int’} changes value from ‘10485760’ to ‘0’ [-Woverflow]
   65 |     for (auto && chunked_records : fin | seqan3::views::chunk((1ULL<<20)*10))
```

[The draft](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2442r0.html#chunk-view-range.chunk) says that `chunk_size` should be of type `std::ranges::range_difference_t<rng_t>` (it was also in range-v3), i.e., usually signed. This is probably for conversion signed<->unsigned.
It also states that `chunk_size` must be positive, though.