### PR TITLE
[MISC] fix clang-format on nucleotides

### DIFF
--- a/include/seqan3/alphabet/nucleotide/dna15.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna15.hpp
@@ -55,7 +55,8 @@ private:
 
     //!\brief Befriend seqan3::nucleotide_base.
     friend base_t;
-    //!\cond \brief Befriend seqan3::alphabet_base.
+    //!\cond
+    //!\brief Befriend seqan3::alphabet_base.
     friend base_t::base_t;
     //!\endcond
     //!\brief Befriend seqan3::rna15 so it can copy #char_to_rank.
@@ -93,67 +94,69 @@ private:
     static constexpr char_type
         rank_to_char_table[alphabet_size]{'A', 'B', 'C', 'D', 'G', 'H', 'K', 'M', 'N', 'R', 'S', 'T', 'V', 'W', 'Y'};
 
-    //!\copydoc seqan3::dna4::char_to_rank
-    static constexpr std::array<rank_type, 256> char_to_rank_table{[]() constexpr {std::array<rank_type, 256> ret{};
+    //!\copydoc seqan3::dna4::rank_complement_table
+    static constexpr rank_type rank_complement_table[alphabet_size]{
+        11, // T is complement of 'A'_dna15
+        12, // V is complement of 'B'_dna15
+        4,  // G is complement of 'C'_dna15
+        5,  // H is complement of 'D'_dna15
+        2,  // C is complement of 'G'_dna15
+        3,  // D is complement of 'H'_dna15
+        7,  // M is complement of 'K'_dna15
+        6,  // K is complement of 'M'_dna15
+        8,  // N is complement of 'N'_dna15
+        14, // Y is complement of 'R'_dna15
+        10, // S is complement of 'S'_dna15
+        0,  // A is complement of 'T'_dna15
+        1,  // B is complement of 'V'_dna15
+        13, // W is complement of 'W'_dna15
+        9   // R is complement of 'Y'_dna15
+    };
 
-    // initialize with UNKNOWN (std::array::fill unfortunately not constexpr)
-    for (auto & c : ret)
-        c = 8; // rank of 'N'
-
-    // reverse mapping for characters and their lowercase
-    for (size_t rnk = 0u; rnk < alphabet_size; ++rnk)
+    //!\copydoc seqan3::dna4::rank_complement
+    static constexpr rank_type rank_complement(rank_type const rank)
     {
-        ret[rank_to_char_table[rnk]] = rnk;
-        ret[to_lower(rank_to_char_table[rnk])] = rnk;
+        return rank_complement_table[rank];
     }
 
-    // set U equal to T
-    ret['U'] = ret['T'];
-    ret['u'] = ret['t'];
+    //!\copydoc seqan3::dna4::rank_to_char
+    static constexpr char_type rank_to_char(rank_type const rank)
+    {
+        return rank_to_char_table[rank];
+    }
 
-    return ret;
-}()
-}; // namespace seqan3
+    //!\copydoc seqan3::dna4::char_to_rank
+    static constexpr rank_type char_to_rank(char_type const chr)
+    {
+        using index_t = std::make_unsigned_t<char_type>;
+        return char_to_rank_table[static_cast<index_t>(chr)];
+    }
 
-//!\copydoc seqan3::dna4::rank_complement_table
-static constexpr rank_type rank_complement_table[alphabet_size]{
-    11, // T is complement of 'A'_dna15
-    12, // V is complement of 'B'_dna15
-    4,  // G is complement of 'C'_dna15
-    5,  // H is complement of 'D'_dna15
-    2,  // C is complement of 'G'_dna15
-    3,  // D is complement of 'H'_dna15
-    7,  // M is complement of 'K'_dna15
-    6,  // K is complement of 'M'_dna15
-    8,  // N is complement of 'N'_dna15
-    14, // Y is complement of 'R'_dna15
-    10, // S is complement of 'S'_dna15
-    0,  // A is complement of 'T'_dna15
-    1,  // B is complement of 'V'_dna15
-    13, // W is complement of 'W'_dna15
-    9   // R is complement of 'Y'_dna15
+    // clang-format off
+    //!\copydoc seqan3::dna4::char_to_rank
+    static constexpr std::array<rank_type, 256> char_to_rank_table
+    {
+        []() constexpr {
+            std::array<rank_type, 256> ret{};
+
+            ret.fill(8u); // initialize with UNKNOWN ('N')
+
+            // reverse mapping for characters and their lowercase
+            for (size_t rnk = 0u; rnk < alphabet_size; ++rnk)
+            {
+                ret[rank_to_char_table[rnk]] = rnk;
+                ret[to_lower(rank_to_char_table[rnk])] = rnk;
+            }
+
+            // set U equal to T
+            ret['U'] = ret['T'];
+            ret['u'] = ret['t'];
+
+            return ret;
+        }()
+    };
 };
-
-//!\copydoc seqan3::dna4::rank_complement
-static constexpr rank_type rank_complement(rank_type const rank)
-{
-    return rank_complement_table[rank];
-}
-
-//!\copydoc seqan3::dna4::rank_to_char
-static constexpr char_type rank_to_char(rank_type const rank)
-{
-    return rank_to_char_table[rank];
-}
-
-//!\copydoc seqan3::dna4::char_to_rank
-static constexpr rank_type char_to_rank(char_type const chr)
-{
-    using index_t = std::make_unsigned_t<char_type>;
-    return char_to_rank_table[static_cast<index_t>(chr)];
-}
-}
-;
+// clang-format on
 
 // ------------------------------------------------------------------
 // containers

--- a/include/seqan3/alphabet/nucleotide/dna16sam.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna16sam.hpp
@@ -52,7 +52,8 @@ private:
 
     //!\brief Befriend seqan3::nucleotide_base.
     friend base_t;
-    //!\cond \brief Befriend seqan3::alphabet_base.
+    //!\cond
+    //!\brief Befriend seqan3::alphabet_base.
     friend base_t::base_t;
     //!\endcond
 
@@ -75,71 +76,72 @@ private:
     static constexpr char_type rank_to_char_table
         [alphabet_size]{'=', 'A', 'C', 'M', 'G', 'R', 'S', 'V', 'T', 'W', 'Y', 'H', 'K', 'D', 'B', 'N'};
 
-    //!\copydoc seqan3::dna4::char_to_rank_table
-    static constexpr std::array<rank_type, 256> char_to_rank_table{[]() constexpr {std::array<rank_type, 256> ret{};
+    //!\copydoc seqan3::dna4::rank_complement_table
+    static constexpr rank_type rank_complement_table[alphabet_size]{
+        15, // N is complement of '='_dna16sam  0
+        8,  // T is complement of 'A'_dna16sam  1
+        4,  // G is complement of 'C'_dna16sam  2
+        12, // K is complement of 'M'_dna16sam  3
+        2,  // C is complement of 'G'_dna16sam  4
+        10, // Y is complement of 'R'_dna16sam  5
+        6,  // S is complement of 'S'_dna16sam  6
+        14, // B is complement of 'V'_dna16sam  7
+        1,  // A is complement of 'T'_dna16sam  8
+        9,  // W is complement of 'W'_dna16sam  9
+        5,  // R is complement of 'Y'_dna16sam 10
+        13, // D is complement of 'H'_dna16sam 11
+        3,  // M is complement of 'K'_dna16sam 12
+        11, // H is complement of 'D'_dna16sam 13
+        7,  // V is complement of 'B'_dna16sam 14
+        15  // N is complement of 'N'_dna16sam 15
+    };
 
-    // initialize with UNKNOWN (std::array::fill unfortunately not constexpr)
-    for (auto & c : ret)
-        c = 15; // rank of 'N'
-
-    // reverse mapping for characters and their lowercase
-    for (size_t rnk = 0u; rnk < alphabet_size; ++rnk)
+    //!\copydoc seqan3::dna4::rank_complement
+    static constexpr rank_type rank_complement(rank_type const rank)
     {
-        ret[rank_to_char_table[rnk]] = rnk;
-        ret[to_lower(rank_to_char_table[rnk])] = rnk;
+        return rank_complement_table[rank];
     }
 
-    // set U equal to T
-    ret['U'] = ret['T'];
-    ret['u'] = ret['t'];
-
-    return ret;
-}()
-}; // namespace seqan3
-
-//!\copydoc seqan3::dna4::rank_complement_table
-static constexpr rank_type rank_complement_table[alphabet_size]{
-    15, // N is complement of '='_dna16sam  0
-    8,  // T is complement of 'A'_dna16sam  1
-    4,  // G is complement of 'C'_dna16sam  2
-    12, // K is complement of 'M'_dna16sam  3
-    2,  // C is complement of 'G'_dna16sam  4
-    10, // Y is complement of 'R'_dna16sam  5
-    6,  // S is complement of 'S'_dna16sam  6
-    14, // B is complement of 'V'_dna16sam  7
-    1,  // A is complement of 'T'_dna16sam  8
-    9,  // W is complement of 'W'_dna16sam  9
-    5,  // R is complement of 'Y'_dna16sam 10
-    13, // D is complement of 'H'_dna16sam 11
-    3,  // M is complement of 'K'_dna16sam 12
-    11, // H is complement of 'D'_dna16sam 13
-    7,  // V is complement of 'B'_dna16sam 14
-    15  // N is complement of 'N'_dna16sam 15
-};
-
-//!\copydoc seqan3::dna4::rank_complement
-static constexpr rank_type rank_complement(rank_type const rank)
-{
-    return rank_complement_table[rank];
-}
-
-/*!\copydoc seqan3::dna4::rank_to_char
+    /*!\copydoc seqan3::dna4::rank_to_char
      *
      * The representation is the same as in the SAM specifications (which is NOT in alphabetical order).
      */
-static constexpr char_type rank_to_char(rank_type const rank)
-{
-    return rank_to_char_table[rank];
-}
+    static constexpr char_type rank_to_char(rank_type const rank)
+    {
+        return rank_to_char_table[rank];
+    }
 
-//!\copydoc seqan3::dna4::char_to_rank
-static constexpr rank_type char_to_rank(char_type const chr)
-{
-    using index_t = std::make_unsigned_t<char_type>;
-    return char_to_rank_table[static_cast<index_t>(chr)];
-}
-}
-;
+    //!\copydoc seqan3::dna4::char_to_rank
+    static constexpr rank_type char_to_rank(char_type const chr)
+    {
+        using index_t = std::make_unsigned_t<char_type>;
+        return char_to_rank_table[static_cast<index_t>(chr)];
+    }
+
+    // clang-format off
+    //!\copydoc seqan3::dna4::char_to_rank_table
+    static constexpr std::array<rank_type, 256> char_to_rank_table{
+        []() constexpr {
+            std::array<rank_type, 256> ret{};
+
+            ret.fill(15u); // initialize with UNKNOWN ('N')
+
+            // reverse mapping for characters and their lowercase
+            for (size_t rnk = 0u; rnk < alphabet_size; ++rnk)
+            {
+                ret[rank_to_char_table[rnk]] = rnk;
+                ret[to_lower(rank_to_char_table[rnk])] = rnk;
+            }
+
+            // set U equal to T
+            ret['U'] = ret['T'];
+            ret['u'] = ret['t'];
+
+            return ret;
+        }()
+    };
+};
+// clang-format on
 
 // ------------------------------------------------------------------
 // containers

--- a/include/seqan3/alphabet/nucleotide/dna3bs.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna3bs.hpp
@@ -65,7 +65,8 @@ private:
 
     //!\brief Befriend seqan3::nucleotide_base.
     friend base_t;
-    //!\cond \brief Befriend seqan3::alphabet_base.
+    //!\cond
+    //!\brief Befriend seqan3::alphabet_base.
     friend base_t::base_t;
     //!\endcond
 
@@ -87,75 +88,79 @@ private:
     //!\copydoc seqan3::dna4::rank_to_char_table
     static constexpr char_type rank_to_char_table[alphabet_size]{'A', 'G', 'T'};
 
-    //!\copydoc seqan3::dna4::char_to_rank_table
-    static constexpr std::array<rank_type, 256> char_to_rank_table{[]() constexpr {std::array<rank_type, 256> ret{};
+    //!\copydoc seqan3::dna4::rank_complement_table
+    static constexpr rank_type rank_complement_table[alphabet_size]{
+        2, // T is complement of 'A'_dna3bs
+        2, // T is complement of 'G'_dna3bs
+        0  // A is complement of 'T'_dna3bs
+    };
 
-    // reverse mapping for characters and their lowercase
-    for (size_t rnk = 0u; rnk < alphabet_size; ++rnk)
+    //!\copydoc seqan3::dna4::rank_complement
+    static constexpr rank_type rank_complement(rank_type const rank)
     {
-        ret[rank_to_char_table[rnk]] = rnk;
-        ret[to_lower(rank_to_char_table[rnk])] = rnk;
+        return rank_complement_table[rank];
     }
 
-    // set C and U equal to T
-    ret['C'] = ret['T'];
-    ret['c'] = ret['t'];
-    ret['U'] = ret['T'];
-    ret['u'] = ret['t'];
+    //!\copydoc seqan3::dna4::rank_to_char
+    static constexpr char_type rank_to_char(rank_type const rank)
+    {
+        return rank_to_char_table[rank];
+    }
 
-    // iupac characters get special treatment, because there is no N
-    ret['R'] = ret['A'];
-    ret['r'] = ret['A']; // A or G becomes A
-    ret['Y'] = ret['T'];
-    ret['y'] = ret['T']; // C or T becomes T
-    ret['S'] = ret['T'];
-    ret['s'] = ret['T']; // C or G becomes T
-    ret['W'] = ret['A'];
-    ret['w'] = ret['A']; // A or T becomes A
-    ret['K'] = ret['G'];
-    ret['k'] = ret['G']; // G or T becomes G
-    ret['M'] = ret['A'];
-    ret['m'] = ret['A']; // A or C becomes A
-    ret['B'] = ret['T'];
-    ret['b'] = ret['T']; // C or G or T becomes T
-    ret['D'] = ret['A'];
-    ret['d'] = ret['A']; // A or G or T becomes A
-    ret['H'] = ret['A'];
-    ret['h'] = ret['A']; // A or C or T becomes A
-    ret['V'] = ret['A'];
-    ret['v'] = ret['A']; // A or C or G  becomes A
+    //!\copydoc seqan3::dna4::char_to_rank
+    static constexpr rank_type char_to_rank(char_type const chr)
+    {
+        using index_t = std::make_unsigned_t<char_type>;
+        return char_to_rank_table[static_cast<index_t>(chr)];
+    }
 
-    return ret;
-}()
-}; // namespace seqan3
+    // clang-format off
+    //!\copydoc seqan3::dna4::char_to_rank_table
+    static constexpr std::array<rank_type, 256> char_to_rank_table
+    {
+        []() constexpr {
+            std::array<rank_type, 256> ret{};
 
-//!\copydoc seqan3::dna4::rank_complement_table
-static constexpr rank_type rank_complement_table[alphabet_size]{
-    2, // T is complement of 'A'_dna3bs
-    2, // T is complement of 'G'_dna3bs
-    0  // A is complement of 'T'_dna3bs
+            // reverse mapping for characters and their lowercase
+            for (size_t rnk = 0u; rnk < alphabet_size; ++rnk)
+            {
+                ret[rank_to_char_table[rnk]] = rnk;
+                ret[to_lower(rank_to_char_table[rnk])] = rnk;
+            }
+
+            // set C and U equal to T
+            ret['C'] = ret['T'];
+            ret['c'] = ret['t'];
+            ret['U'] = ret['T'];
+            ret['u'] = ret['t'];
+
+            // iupac characters get special treatment, because there is no N
+            ret['R'] = ret['A'];
+            ret['r'] = ret['A']; // A or G becomes A
+            ret['Y'] = ret['T'];
+            ret['y'] = ret['T']; // C or T becomes T
+            ret['S'] = ret['T'];
+            ret['s'] = ret['T']; // C or G becomes T
+            ret['W'] = ret['A'];
+            ret['w'] = ret['A']; // A or T becomes A
+            ret['K'] = ret['G'];
+            ret['k'] = ret['G']; // G or T becomes G
+            ret['M'] = ret['A'];
+            ret['m'] = ret['A']; // A or C becomes A
+            ret['B'] = ret['T'];
+            ret['b'] = ret['T']; // C or G or T becomes T
+            ret['D'] = ret['A'];
+            ret['d'] = ret['A']; // A or G or T becomes A
+            ret['H'] = ret['A'];
+            ret['h'] = ret['A']; // A or C or T becomes A
+            ret['V'] = ret['A'];
+            ret['v'] = ret['A']; // A or C or G  becomes A
+
+            return ret;
+        }()
+    };
 };
-
-//!\copydoc seqan3::dna4::rank_complement
-static constexpr rank_type rank_complement(rank_type const rank)
-{
-    return rank_complement_table[rank];
-}
-
-//!\copydoc seqan3::dna4::rank_to_char
-static constexpr char_type rank_to_char(rank_type const rank)
-{
-    return rank_to_char_table[rank];
-}
-
-//!\copydoc seqan3::dna4::char_to_rank
-static constexpr rank_type char_to_rank(char_type const chr)
-{
-    using index_t = std::make_unsigned_t<char_type>;
-    return char_to_rank_table[static_cast<index_t>(chr)];
-}
-}
-;
+// clang-format on
 
 // ------------------------------------------------------------------
 // containers

--- a/include/seqan3/alphabet/nucleotide/dna4.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna4.hpp
@@ -57,7 +57,8 @@ private:
 
     //!\brief Befriend seqan3::nucleotide_base.
     friend base_t;
-    //!\cond \brief Befriend seqan3::alphabet_base.
+    //!\cond
+    //!\brief Befriend seqan3::alphabet_base.
     friend base_t::base_t;
     //!\endcond
     //!\brief Befriend seqan3::rna4 so it can copy #char_to_rank.
@@ -116,85 +117,89 @@ private:
      */
     static constexpr char_type rank_to_char_table[alphabet_size]{'A', 'C', 'G', 'T'};
 
-    /*!\brief The lookup table used in #char_to_rank.
-     * \copydetails seqan3::dna4::rank_to_char_table
-     */
-    static constexpr std::array<rank_type, 256> char_to_rank_table{[]() constexpr {std::array<rank_type, 256> ret{};
+    //!\brief The rank complement table.
+    static constexpr rank_type rank_complement_table[alphabet_size]{
+        3, // T is complement of 'A'_dna4
+        2, // G is complement of 'C'_dna4
+        1, // C is complement of 'G'_dna4
+        0  // A is complement of 'T'_dna4
+    };
 
-    // reverse mapping for characters and their lowercase
-    for (size_t rnk = 0u; rnk < alphabet_size; ++rnk)
-    {
-        ret[rank_to_char_table[rnk]] = rnk;
-        ret[to_lower(rank_to_char_table[rnk])] = rnk;
-    }
-
-    // set U equal to T
-    ret['U'] = ret['T'];
-    ret['u'] = ret['t'];
-
-    // iupac characters get special treatment, because there is no N
-    ret['R'] = ret['A'];
-    ret['r'] = ret['A']; // A or G
-    ret['Y'] = ret['C'];
-    ret['y'] = ret['C']; // C or T
-    ret['S'] = ret['C'];
-    ret['s'] = ret['C']; // C or G
-    ret['W'] = ret['A'];
-    ret['w'] = ret['A']; // A or T
-    ret['K'] = ret['G'];
-    ret['k'] = ret['G']; // G or T
-    ret['M'] = ret['A'];
-    ret['m'] = ret['A']; // A or T
-    ret['B'] = ret['C'];
-    ret['b'] = ret['C']; // C or G or T
-    ret['D'] = ret['A'];
-    ret['d'] = ret['A']; // A or G or T
-    ret['H'] = ret['A'];
-    ret['h'] = ret['A']; // A or C or T
-    ret['V'] = ret['A'];
-    ret['v'] = ret['A']; // A or C or G
-
-    return ret;
-}()
-}; // namespace seqan3
-
-//!\brief The rank complement table.
-static constexpr rank_type rank_complement_table[alphabet_size]{
-    3, // T is complement of 'A'_dna4
-    2, // G is complement of 'C'_dna4
-    1, // C is complement of 'G'_dna4
-    0  // A is complement of 'T'_dna4
-};
-
-/*!\brief Returns the complement by rank.
+    /*!\brief Returns the complement by rank.
      * \details
      * This function is required by seqan3::nucleotide_base.
      */
-static constexpr rank_type rank_complement(rank_type const rank)
-{
-    return rank_complement_table[rank];
-}
+    static constexpr rank_type rank_complement(rank_type const rank)
+    {
+        return rank_complement_table[rank];
+    }
 
-/*!\brief Returns the character representation of rank.
+    /*!\brief Returns the character representation of rank.
      * \details
      * This function is required by seqan3::alphabet_base.
      */
-static constexpr char_type rank_to_char(rank_type const rank)
-{
-    return rank_to_char_table[rank];
-}
+    static constexpr char_type rank_to_char(rank_type const rank)
+    {
+        return rank_to_char_table[rank];
+    }
 
-/*!\brief Returns the rank representation of character.
+    /*!\brief Returns the rank representation of character.
      * \details
      * This function is required by seqan3::alphabet_base.
      */
-static constexpr rank_type char_to_rank(char_type const chr)
-{
-    using index_t = std::make_unsigned_t<char_type>;
-    return char_to_rank_table[static_cast<index_t>(chr)];
-}
-}
-;
+    static constexpr rank_type char_to_rank(char_type const chr)
+    {
+        using index_t = std::make_unsigned_t<char_type>;
+        return char_to_rank_table[static_cast<index_t>(chr)];
+    }
+
+    // clang-format off
+    /*!\brief The lookup table used in #char_to_rank.
+     * \copydetails seqan3::dna4::rank_to_char_table
+     */
+    static constexpr std::array<rank_type, 256> char_to_rank_table
+    {
+        []() constexpr {
+            std::array<rank_type, 256> ret{};
+
+            // reverse mapping for characters and their lowercase
+            for (size_t rnk = 0u; rnk < alphabet_size; ++rnk)
+            {
+                ret[rank_to_char_table[rnk]] = rnk;
+                ret[to_lower(rank_to_char_table[rnk])] = rnk;
+            }
+
+            // set U equal to T
+            ret['U'] = ret['T'];
+            ret['u'] = ret['t'];
+
+            // iupac characters get special treatment, because there is no N
+            ret['R'] = ret['A'];
+            ret['r'] = ret['A']; // A or G
+            ret['Y'] = ret['C'];
+            ret['y'] = ret['C']; // C or T
+            ret['S'] = ret['C'];
+            ret['s'] = ret['C']; // C or G
+            ret['W'] = ret['A'];
+            ret['w'] = ret['A']; // A or T
+            ret['K'] = ret['G'];
+            ret['k'] = ret['G']; // G or T
+            ret['M'] = ret['A'];
+            ret['m'] = ret['A']; // A or T
+            ret['B'] = ret['C'];
+            ret['b'] = ret['C']; // C or G or T
+            ret['D'] = ret['A'];
+            ret['d'] = ret['A']; // A or G or T
+            ret['H'] = ret['A'];
+            ret['h'] = ret['A']; // A or C or T
+            ret['V'] = ret['A'];
+            ret['v'] = ret['A']; // A or C or G
+
+            return ret;
+        }()
+    };
+};
+// clang-format on
 
 // ------------------------------------------------------------------
 // containers

--- a/include/seqan3/alphabet/nucleotide/dna5.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna5.hpp
@@ -55,7 +55,8 @@ private:
 
     //!\brief Befriend seqan3::nucleotide_base.
     friend base_t;
-    //!\cond \brief Befriend seqan3::alphabet_base.
+    //!\cond
+    //!\brief Befriend seqan3::alphabet_base.
     friend base_t::base_t;
     //!\endcond
     //!\brief Befriend seqan3::rna5 so it can copy #char_to_rank.
@@ -92,58 +93,60 @@ private:
     //!\copydoc seqan3::dna4::rank_to_char_table
     static constexpr char_type rank_to_char_table[alphabet_size]{'A', 'C', 'G', 'N', 'T'};
 
-    //!\copydoc seqan3::dna4::char_to_rank_table
-    static constexpr std::array<rank_type, 256> char_to_rank_table{[]() constexpr {std::array<rank_type, 256> ret{};
+    //!\copydoc seqan3::dna4::rank_complement_table
+    static constexpr rank_type rank_complement_table[alphabet_size]{
+        4, // T is complement of 'A'_dna5
+        2, // G is complement of 'C'_dna5
+        1, // C is complement of 'G'_dna5
+        3, // N is complement of 'N'_dna5
+        0  // A is complement of 'T'_dna5
+    };
 
-    // initialize with UNKNOWN (std::array::fill unfortunately not constexpr)
-    for (auto & c : ret)
-        c = 3; // == 'N'
-
-    // reverse mapping for characters and their lowercase
-    for (size_t rnk = 0u; rnk < alphabet_size; ++rnk)
+    //!\copydoc seqan3::dna4::rank_complement
+    static constexpr rank_type rank_complement(rank_type const rank)
     {
-        ret[rank_to_char_table[rnk]] = rnk;
-        ret[to_lower(rank_to_char_table[rnk])] = rnk;
+        return rank_complement_table[rank];
     }
 
-    // set U equal to T
-    ret['U'] = ret['T'];
-    ret['u'] = ret['t'];
+    //!\copydoc seqan3::dna4::rank_to_char
+    static constexpr char_type rank_to_char(rank_type const rank)
+    {
+        return rank_to_char_table[rank];
+    }
 
-    // iupac characters are implicitly "UNKNOWN"
-    return ret;
-}()
-}; // namespace seqan3
+    //!\copydoc seqan3::dna4::char_to_rank
+    static constexpr rank_type char_to_rank(char_type const chr)
+    {
+        using index_t = std::make_unsigned_t<char_type>;
+        return char_to_rank_table[static_cast<index_t>(chr)];
+    }
 
-//!\copydoc seqan3::dna4::rank_complement_table
-static constexpr rank_type rank_complement_table[alphabet_size]{
-    4, // T is complement of 'A'_dna5
-    2, // G is complement of 'C'_dna5
-    1, // C is complement of 'G'_dna5
-    3, // N is complement of 'N'_dna5
-    0  // A is complement of 'T'_dna5
+    // clang-format off
+    //!\copydoc seqan3::dna4::char_to_rank_table
+    static constexpr std::array<rank_type, 256> char_to_rank_table
+    {
+        []() constexpr {
+            std::array<rank_type, 256> ret{};
+
+            ret.fill(3u); // initialize with UNKNOWN ('N')
+
+            // reverse mapping for characters and their lowercase
+            for (size_t rnk = 0u; rnk < alphabet_size; ++rnk)
+            {
+                ret[rank_to_char_table[rnk]] = rnk;
+                ret[to_lower(rank_to_char_table[rnk])] = rnk;
+            }
+
+            // set U equal to T
+            ret['U'] = ret['T'];
+            ret['u'] = ret['t'];
+
+            // iupac characters are implicitly "UNKNOWN"
+            return ret;
+        }()
+    };
 };
-
-//!\copydoc seqan3::dna4::rank_complement
-static constexpr rank_type rank_complement(rank_type const rank)
-{
-    return rank_complement_table[rank];
-}
-
-//!\copydoc seqan3::dna4::rank_to_char
-static constexpr char_type rank_to_char(rank_type const rank)
-{
-    return rank_to_char_table[rank];
-}
-
-//!\copydoc seqan3::dna4::char_to_rank
-static constexpr rank_type char_to_rank(char_type const chr)
-{
-    using index_t = std::make_unsigned_t<char_type>;
-    return char_to_rank_table[static_cast<index_t>(chr)];
-}
-}
-;
+// clang-format on
 
 // ------------------------------------------------------------------
 // containers

--- a/include/seqan3/alphabet/nucleotide/nucleotide_base.hpp
+++ b/include/seqan3/alphabet/nucleotide/nucleotide_base.hpp
@@ -142,28 +142,34 @@ public:
     }
 
 private:
+    // clang-format off
     //!\brief Implementation of #char_is_valid().
-    static constexpr std::array<bool, 256> valid_char_table{[]() constexpr {// init with false
-                                                                            std::array<bool, 256> ret{};
-
-    // the original valid chars and their lower cases
-    for (size_t rank = 0u; rank < derived_type::alphabet_size; ++rank)
+    static constexpr std::array<bool, 256> valid_char_table
     {
-        uint8_t c = derived_type::rank_to_char(rank);
-        ret[c] = true;
-        ret[to_lower(c)] = true;
-    }
+        []() constexpr {
+            std::array<bool, 256> ret{};
 
-    // U and T shall be accepted for all
-    ret['U'] = true;
-    ret['T'] = true;
-    ret['u'] = true;
-    ret['t'] = true;
+            // Value-initialisation of std::array does usually initialise. `fill` is explicit.
+            ret.fill(false);
 
-    return ret;
-}()
-}; // namespace seqan3
-}
-;
+            // the original valid chars and their lower cases
+            for (size_t rank = 0u; rank < derived_type::alphabet_size; ++rank)
+            {
+                uint8_t c = derived_type::rank_to_char(rank);
+                ret[c] = true;
+                ret[to_lower(c)] = true;
+            }
+
+            // U and T shall be accepted for all
+            ret['U'] = true;
+            ret['T'] = true;
+            ret['u'] = true;
+            ret['t'] = true;
+
+            return ret;
+        }()
+    };
+};
+    // clang-format off
 
 } // namespace seqan3

--- a/include/seqan3/alphabet/nucleotide/rna15.hpp
+++ b/include/seqan3/alphabet/nucleotide/rna15.hpp
@@ -55,7 +55,8 @@ private:
 
     //!\brief Befriend seqan3::nucleotide_base.
     friend base_t;
-    //!\cond \brief Befriend seqan3::alphabet_base.
+    //!\cond
+    //!\brief Befriend seqan3::alphabet_base.
     friend base_t::base_t;
     //!\endcond
 

--- a/include/seqan3/alphabet/nucleotide/rna4.hpp
+++ b/include/seqan3/alphabet/nucleotide/rna4.hpp
@@ -53,7 +53,8 @@ private:
 
     //!\brief Befriend seqan3::nucleotide_base.
     friend base_t;
-    //!\cond \brief Befriend seqan3::alphabet_base.
+    //!\cond
+    //!\brief Befriend seqan3::alphabet_base.
     friend base_t::base_t;
     //!\endcond
 

--- a/include/seqan3/alphabet/nucleotide/rna5.hpp
+++ b/include/seqan3/alphabet/nucleotide/rna5.hpp
@@ -53,7 +53,8 @@ private:
 
     //!\brief Befriend nucleotide_base.
     friend base_t;
-    //!\cond \brief Befriend seqan3::alphabet_base.
+    //!\cond
+    //!\brief Befriend seqan3::alphabet_base.
     friend base_t::base_t;
     //!\endcond
 


### PR DESCRIPTION
Apparently, constexpr immediately invoked initializing lambda expressions are clang-format's bane of existence.

I moved the `char_to_rank_table` down because clang-format only bounces back when the class is over (`};` of the class).

Alternatively, I could also exclude everything in between...

Other alphabets will follow this one.

```cpp
static constexpr std::array<rank_type, 256> char_to_rank_table
{
```

or

```cpp
static constexpr std::array<rank_type, 256> char_to_rank_table{
```

?