### PR TITLE
[MISC] fix clang-format on masked

### DIFF
--- a/include/seqan3/alphabet/mask/masked.hpp
+++ b/include/seqan3/alphabet/mask/masked.hpp
@@ -108,10 +108,11 @@ public:
     //!\}
 
 protected:
+    // clang-format off
     //!\brief Rank to char conversion table.
-    static constexpr std::array<char_type, alphabet_size> rank_to_char{
-        []()
-        {
+    static constexpr std::array<char_type, alphabet_size> rank_to_char
+    {
+        []() constexpr {
             std::array<char_type, alphabet_size> ret{};
 
             for (size_t i = 0; i < alphabet_size; ++i)
@@ -122,28 +123,32 @@ protected:
             }
 
             return ret;
-        }()};
+        }()
+    };
 
     //!\brief Char to rank conversion table.
-    static constexpr std::array<rank_type, detail::size_in_values_v<char_type>> char_to_rank{
-        []()
-        {
+    static constexpr std::array<rank_type, detail::size_in_values_v<char_type>> char_to_rank
+    {
+        []() constexpr {
             std::array<rank_type, detail::size_in_values_v<char_type>> ret{};
 
             for (size_t i = 0; i < 256; ++i)
             {
-                char_type c = static_cast<char_type>(i);
+                char_type const c = static_cast<char_type>(i);
 
                 ret[i] = is_lower(c) ? seqan3::to_rank(seqan3::assign_char_to(c, sequence_alphabet_type{})) * 2
                                      : seqan3::to_rank(seqan3::assign_char_to(c, sequence_alphabet_type{}));
             }
 
             return ret;
-        }()};
+        }()
+    };
 };
+// clang-format on
 
 //!\brief Type deduction guide enables usage of masked without specifying template args.
 //!\relates masked
 template <typename sequence_alphabet_type>
 masked(sequence_alphabet_type &&, mask const &) -> masked<std::decay_t<sequence_alphabet_type>>;
+
 } //namespace seqan3


### PR DESCRIPTION
<!--
Please see https://github.com/seqan/seqan3/blob/master/CONTRIBUTING.md for a general overview.

Please allow edits from maintainers:
https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests

Once you create the PR, clang-format will be run on the PR, and any formatting changes will be pushed to your fork.
Subsequently, the actual CI will start.

****************************************************************************************************
** Attention: This means that you will have to `git pull` the changes before pushing new commits. **
****************************************************************************************************

Each of your commits will trigger a clang-format commit if there are formatting changes.


While the following guide on rebasing formatting changes is intended for internal use by SeqAn members, and in no way
necessary for contributors, it may still be an interesting read: https://github.com/seqan/seqan3/wiki/Rebasing-clang-format-commits-with-git-absorb
-->
