### PR TITLE
[FIX] coverage report on atomic lock

### DIFF
--- a/include/seqan3/utility/parallel/detail/latch.hpp
+++ b/include/seqan3/utility/parallel/detail/latch.hpp
@@ -53,7 +53,7 @@ public:
     {
         spin_delay delay{};
         while (num_waiting.load(std::memory_order_acquire) > 0)
-            delay.wait();
+            delay.wait(); // LCOV_EXCL_LINE
     }
 
     /*!\brief Constructs the latch with the expected number of threads.


### PR DESCRIPTION
It might need to spin or not. It's rather random whether it will be free in the tests. Causes spurious coverage drops when there was no need to wait.