### PR TITLE
[FEATURE] Make alphabets trivial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ If possible, provide tooling that performs the changes, e.g. a shell-script.
   * `seqan3::cigar` can now be assigned from `std::string_view` ([\#2966](https://github.com/seqan/seqan3/pull/2966)).
   * Added `seqan3::views::char_strictly_to`. Behaves like `seqan3::views::char_to`, but throws on invalid
     input ([\#2898](https://github.com/seqan/seqan3/pull/2898)).
+  * Improved performance of vector assignment for alphabets ([\#3038](https://github.com/seqan/seqan3/pull/3038)).
 
 #### I/O
  * Added `seqan3::sequence_file_option::fasta_ignore_blanks_before_id` to ignore blanks before IDs when reading FASTA

--- a/include/seqan3/alphabet/alphabet_base.hpp
+++ b/include/seqan3/alphabet/alphabet_base.hpp
@@ -258,7 +258,7 @@ public:
 
 private:
     //!\brief The value of the alphabet letter is stored as the rank.
-    rank_type rank{};
+    rank_type rank;
 };
 
 } // namespace seqan3

--- a/include/seqan3/alphabet/aminoacid/aminoacid_base.hpp
+++ b/include/seqan3/alphabet/aminoacid/aminoacid_base.hpp
@@ -28,7 +28,7 @@ namespace seqan3
  * \stableapi{Since version 3.1.}
  */
 template <typename derived_type, auto size>
-class aminoacid_base : public alphabet_base<derived_type, size, char>, public aminoacid_empty_base
+class aminoacid_base : public aminoacid_empty_base, public alphabet_base<derived_type, size, char>
 {
 private:
     //!\brief Type of the base class.

--- a/test/performance/range/CMakeLists.txt
+++ b/test/performance/range/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectories ()
 
+seqan3_benchmark (container_assignment_benchmark.cpp)
 seqan3_benchmark (container_push_back_benchmark.cpp)
 seqan3_benchmark (container_seq_read_benchmark.cpp)
 seqan3_benchmark (container_seq_write_benchmark.cpp)

--- a/test/performance/range/container_assignment_benchmark.cpp
+++ b/test/performance/range/container_assignment_benchmark.cpp
@@ -1,0 +1,152 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2022, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2022, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+#include <benchmark/benchmark.h>
+
+#include <seqan3/alphabet/aminoacid/aa27.hpp>
+#include <seqan3/alphabet/nucleotide/dna4.hpp>
+#include <seqan3/alphabet/nucleotide/dna5.hpp>
+#include <seqan3/test/literal/bytes.hpp>
+#include <seqan3/test/performance/sequence_generator.hpp>
+
+using namespace seqan3::test::literals;
+
+#ifndef NDEBUG
+static constexpr size_t vector_size{1_MiB};
+#else
+static constexpr size_t vector_size{16_MiB};
+#endif // NDEBUG
+
+enum tag
+{
+    assignment_operator,
+    std_copy,
+    uninitialized_copy
+};
+
+template <tag id>
+struct assignment_functor
+{
+    template <typename container_t>
+        requires (id == tag::assignment_operator)
+    static constexpr void call(container_t & to, container_t const & from) noexcept(
+        noexcept(std::is_nothrow_assignable_v<container_t, container_t>))
+    {
+        benchmark::DoNotOptimize(to = from);
+    }
+
+    template <typename container_t>
+        requires (id == tag::std_copy)
+    static constexpr void call(container_t & to, container_t const & from) noexcept
+    {
+        benchmark::DoNotOptimize(std::copy(std::ranges::begin(from), std::ranges::end(from), std::ranges::begin(to)));
+    }
+
+    template <typename container_t>
+        requires (id == tag::uninitialized_copy)
+    static constexpr void call(container_t & to, container_t const & from) noexcept
+    {
+        benchmark::DoNotOptimize(
+            std::uninitialized_copy(std::ranges::begin(from), std::ranges::end(from), std::ranges::begin(to)));
+    }
+};
+
+template <typename container_t>
+    requires requires (container_t v) { v.clear(); }
+static constexpr void clear(container_t & container) noexcept(noexcept(std::declval<container_t>().clear()))
+{
+    container.clear();
+}
+
+template <typename container_t>
+    requires requires (container_t v) { v.resize(1u); }
+static constexpr void resize(container_t & container,
+                             size_t const size) noexcept(noexcept(std::declval<container_t>().resize(1u)))
+{
+    container.resize(size);
+}
+
+#if SEQAN3_HAS_SEQAN2
+template <typename container_t>
+static constexpr void clear(container_t & container) noexcept(noexcept(seqan::clear(std::declval<container_t>())))
+{
+    seqan::clear(container);
+}
+
+template <typename container_t>
+static constexpr void resize(container_t & container,
+                             size_t const size) noexcept(noexcept(seqan::resize(std::declval<container_t>(), 1u)))
+{
+    seqan::resize(container, size);
+}
+#endif // SEQAN3_HAS_SEQAN2
+
+template <tag id, template <typename> typename container_t, typename alphabet_t>
+static void assign(benchmark::State & state)
+{
+    auto random_sequence = []() constexpr
+    {
+        if constexpr (seqan3::alphabet<alphabet_t>)
+            return seqan3::test::generate_sequence<alphabet_t>(vector_size);
+#if SEQAN3_HAS_SEQAN2
+        else
+            return seqan3::test::generate_sequence_seqan2<alphabet_t>(vector_size);
+#endif // SEQAN3_HAS_SEQAN2
+    }();
+
+    container_t<alphabet_t> from{};
+    resize(from, vector_size);
+    std::copy(std::ranges::begin(random_sequence), std::ranges::end(random_sequence), std::ranges::begin(from));
+    container_t<alphabet_t> to{};
+    resize(to, vector_size);
+    assignment_functor<id> fn{};
+
+    for (auto _ : state)
+    {
+        fn.call(to, from);
+        benchmark::ClobberMemory();
+        clear(to);
+        benchmark::ClobberMemory();
+    }
+}
+
+BENCHMARK_TEMPLATE(assign, tag::assignment_operator, std::vector, seqan3::dna4);
+BENCHMARK_TEMPLATE(assign, tag::assignment_operator, std::vector, seqan3::dna5);
+BENCHMARK_TEMPLATE(assign, tag::assignment_operator, std::vector, seqan3::aa27);
+
+BENCHMARK_TEMPLATE(assign, tag::std_copy, std::vector, seqan3::dna4);
+BENCHMARK_TEMPLATE(assign, tag::std_copy, std::vector, seqan3::dna5);
+BENCHMARK_TEMPLATE(assign, tag::std_copy, std::vector, seqan3::aa27);
+
+BENCHMARK_TEMPLATE(assign, tag::uninitialized_copy, std::vector, seqan3::dna4);
+BENCHMARK_TEMPLATE(assign, tag::uninitialized_copy, std::vector, seqan3::dna5);
+BENCHMARK_TEMPLATE(assign, tag::uninitialized_copy, std::vector, seqan3::aa27);
+
+#if SEQAN3_HAS_SEQAN2
+BENCHMARK_TEMPLATE(assign, tag::assignment_operator, std::vector, seqan::Dna);
+BENCHMARK_TEMPLATE(assign, tag::assignment_operator, std::vector, seqan::Dna5);
+BENCHMARK_TEMPLATE(assign, tag::assignment_operator, std::vector, seqan::AminoAcid);
+BENCHMARK_TEMPLATE(assign, tag::assignment_operator, seqan::String, seqan::Dna);
+BENCHMARK_TEMPLATE(assign, tag::assignment_operator, seqan::String, seqan::Dna5);
+BENCHMARK_TEMPLATE(assign, tag::assignment_operator, seqan::String, seqan::AminoAcid);
+
+BENCHMARK_TEMPLATE(assign, tag::std_copy, std::vector, seqan::Dna);
+BENCHMARK_TEMPLATE(assign, tag::std_copy, std::vector, seqan::Dna5);
+BENCHMARK_TEMPLATE(assign, tag::std_copy, std::vector, seqan::AminoAcid);
+BENCHMARK_TEMPLATE(assign, tag::std_copy, seqan::String, seqan::Dna);
+BENCHMARK_TEMPLATE(assign, tag::std_copy, seqan::String, seqan::Dna5);
+BENCHMARK_TEMPLATE(assign, tag::std_copy, seqan::String, seqan::AminoAcid);
+
+BENCHMARK_TEMPLATE(assign, tag::uninitialized_copy, std::vector, seqan::Dna);
+BENCHMARK_TEMPLATE(assign, tag::uninitialized_copy, std::vector, seqan::Dna5);
+BENCHMARK_TEMPLATE(assign, tag::uninitialized_copy, std::vector, seqan::AminoAcid);
+BENCHMARK_TEMPLATE(assign, tag::uninitialized_copy, seqan::String, seqan::Dna);
+BENCHMARK_TEMPLATE(assign, tag::uninitialized_copy, seqan::String, seqan::Dna5);
+BENCHMARK_TEMPLATE(assign, tag::uninitialized_copy, seqan::String, seqan::AminoAcid);
+#endif // SEQAN3_HAS_SEQAN2
+
+BENCHMARK_MAIN();

--- a/test/unit/alphabet/aminoacid/aminoacid_test_template.hpp
+++ b/test/unit/alphabet/aminoacid/aminoacid_test_template.hpp
@@ -20,6 +20,8 @@ TYPED_TEST_SUITE_P(aminoacid);
 
 TYPED_TEST_P(aminoacid, concept_check)
 {
+    EXPECT_TRUE(std::is_trivial_v<TypeParam>);
+
     EXPECT_TRUE(seqan3::aminoacid_alphabet<TypeParam>);
     EXPECT_TRUE(seqan3::aminoacid_alphabet<TypeParam &>);
     EXPECT_TRUE(seqan3::aminoacid_alphabet<TypeParam const>);

--- a/test/unit/alphabet/nucleotide/nucleotide_test_template.hpp
+++ b/test/unit/alphabet/nucleotide/nucleotide_test_template.hpp
@@ -19,6 +19,8 @@ TYPED_TEST_SUITE_P(nucleotide);
 
 TYPED_TEST_P(nucleotide, concept_check)
 {
+    EXPECT_TRUE(std::is_trivial_v<TypeParam>);
+
     EXPECT_TRUE(seqan3::nucleotide_alphabet<TypeParam>);
     EXPECT_TRUE(seqan3::nucleotide_alphabet<TypeParam &>);
     EXPECT_TRUE(seqan3::nucleotide_alphabet<TypeParam const>);

--- a/test/unit/alphabet/quality/phred_test_template.hpp
+++ b/test/unit/alphabet/quality/phred_test_template.hpp
@@ -17,6 +17,8 @@ TYPED_TEST_SUITE_P(phred);
 // test provision of data type `phred_type` and phred converter.
 TYPED_TEST_P(phred, concept_check)
 {
+    EXPECT_TRUE(std::is_trivial_v<TypeParam>);
+
     EXPECT_TRUE(seqan3::quality_alphabet<TypeParam>);
     EXPECT_TRUE(seqan3::quality_alphabet<TypeParam &>);
     EXPECT_TRUE(seqan3::quality_alphabet<TypeParam const>);


### PR DESCRIPTION
`std::vector` optimizes assignments to `std::copy` (basically memcpy) iff the value_type is trivial. If not, it will use `std::unintialized_copy` which will use placement-new and is around 2-3 times slower.


| Method                         | Container         | Alphabet           | Iterations before | Iterations after |
|--------------------------------|-------------------|--------------------|-------------------|------------------|
| **_tag::assignment_operator_** | **_std::vector_** | **_seqan3::aa27_** | **_705_**         | **_1853_**       |
| **_tag::assignment_operator_** | **_std::vector_** | **_seqan3::dna4_** | **_741_**         | **_1869_**       |
| **_tag::assignment_operator_** | **_std::vector_** | **_seqan3::dna5_** | **_744_**         | **_1879_**       |
| tag::std_copy                  | std::vector       | seqan3::aa27       | 1691              | 1871             |
| tag::std_copy                  | std::vector       | seqan3::dna4       | 1852              | 1800             |
| tag::std_copy                  | std::vector       | seqan3::dna5       | 1781              | 1865             |
| **_tag::uninitialized_copy_**  | **_std::vector_** | **_seqan3::aa27_** | **_711_**         | **_1789_**       |
| **_tag::uninitialized_copy_**  | **_std::vector_** | **_seqan3::dna4_** | **_705_**         | **_1856_**       |
| **_tag::uninitialized_copy_**  | **_std::vector_** | **_seqan3::dna5_** | **_727_**         | **_1859_**       |
|                                |                   |                    |                   |                  |
| tag::assignment_operator       | std::vector       | seqan::AminoAcid   | 740               | 741              |
| tag::assignment_operator       | std::vector       | seqan::Dna         | 733               | 726              |
| tag::assignment_operator       | std::vector       | seqan::Dna5        | 747               | 727              |
| tag::std_copy                  | std::vector       | seqan::AminoAcid   | 1839              | 1811             |
| tag::std_copy                  | std::vector       | seqan::Dna         | 1766              | 1837             |
| tag::std_copy                  | std::vector       | seqan::Dna5        | 1830              | 1847             |
| tag::uninitialized_copy        | std::vector       | seqan::AminoAcid   | 734               | 741              |
| tag::uninitialized_copy        | std::vector       | seqan::Dna         | 742               | 739              |
| tag::uninitialized_copy        | std::vector       | seqan::Dna5        | 731               | 735              |
|                                |                   |                    |                   |                  |
| tag::assignment_operator       | seqan::String     | seqan::AminoAcid   | 1835              | 1938             |
| tag::assignment_operator       | seqan::String     | seqan::Dna         | 1819              | 1910             |
| tag::assignment_operator       | seqan::String     | seqan::Dna5        | 1903              | 1944             |
| tag::std_copy                  | seqan::String     | seqan::AminoAcid   | 720               | 721              |
| tag::std_copy                  | seqan::String     | seqan::Dna         | 723               | 734              |
| tag::std_copy                  | seqan::String     | seqan::Dna5        | 723               | 726              |
| tag::uninitialized_copy        | seqan::String     | seqan::AminoAcid   | 721               | 719              |
| tag::uninitialized_copy        | seqan::String     | seqan::Dna         | 722               | 723              |
| tag::uninitialized_copy        | seqan::String     | seqan::Dna5        | 719               | 728              |