### PR TITLE
[TEST] Add missing hard-clipping to be consistent.

### DIFF
--- a/test/unit/io/sam_file/format_sam_test.cpp
+++ b/test/unit/io/sam_file/format_sam_test.cpp
@@ -46,7 +46,7 @@ read3	43	ref	3	63	1S1M1P1M1I1M1I1D1M1S	ref	10	300	GGAGTATA	!!*+,-./
                                     "\tzz:Z:str"
                                     "\tCC:i:300"
                                     "\tcc:i:-300\n"
-                                    "read2\t42\tref\t2\t62\t1H7M1D1M1S\tref\t10\t300\tAGGCTGNAG\t!##$&'()*\tbc:B:c,-3"
+                                    "read2\t42\tref\t2\t62\t1H7M1D1M1S2H\tref\t10\t300\tAGGCTGNAG\t!##$&'()*\tbc:B:c,-3"
                                     "\tbC:B:C,3,200"
                                     "\tbs:B:s,-3,200,-300"
                                     "\tbS:B:S,300,40,500"


### PR DESCRIPTION
The string `verbose_reads_input` is the same as `simple_three_reads_input` (line 34) with some extra information but the hard-clipping information at the end of the cigar string of read2 was missing (`H2`). 
This went by unnoticed because currently the tests read in an alignment and in an alignment hard-clipping is lost. When we read in a cigar instead, this will cause an error in the tests but should not. 
Since we will remove the `field::alignment` this is a pre-commit that reduces complexity of the large PR that will remove the `field::alignment`.