### PR TITLE
[FIX] clang-format fetch depth

### DIFF
--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -69,7 +69,7 @@ jobs:
         id: fetch_depth
         env:
           GITHUB_TOKEN: ${{ secrets.SEQAN_ACTIONS_PAT }}
-          COMMIT_RANGE: ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}
+          COMMIT_RANGE: ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.base.ref }}
         run: |
           QUERY="/repos/${{ github.repository }}/compare/${COMMIT_RANGE}"
           ANSWER=$(gh api -H "Accept: application/vnd.github.v3+json" ${QUERY})


### PR DESCRIPTION
`COMMIT_RANGE: ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}` means that I compare the base of the PR with the head of the PR. This is the number of commits in the PR (the same as `${{ github.event.pull_request.commits }}`).

I actually want to compare the base of the PR (where did it branch from master/the base ref) to the current master/base ref. This will tell me how many commits the branch point lacks behind the current base ref.