### PR TITLE
[FEATURE] Add std::string overload for alignment_from_cigar.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ If possible, provide tooling that performs the changes, e.g. a shell-script.
 
 ## New features
 
+#### Alignment
+* The function `seqan3::alignment_from_cigar` creates an alignment (tuple of 2 aligned sequences) from a
+  CIGAR vector (`std::vector<seqan3::cigar>`) ([\#3057](https://github.com/seqan/seqan3/pull/3057)) or a
+  CIGAR string (`std::string`) ([\#3077](https://github.com/seqan/seqan3/pull/3077)).
+* The function `seqan3::cigar_from_alignment` creates a CIGAR vector (`std::vector<seqan3::cigar>`) from an alignment
+  (tuple of 2 aligned sequences) ([\#3057](https://github.com/seqan/seqan3/pull/3057)).
+
 #### Alphabet
   * Improved performance of vector assignment for alphabets ([\#3038](https://github.com/seqan/seqan3/pull/3038)).
   * Improved performance of `seqan3::dna4::complement()` ([\#3026](https://github.com/seqan/seqan3/pull/3026)).

--- a/include/seqan3/alignment/cigar_conversion/alignment_from_cigar.hpp
+++ b/include/seqan3/alignment/cigar_conversion/alignment_from_cigar.hpp
@@ -17,6 +17,7 @@
 #include <seqan3/alignment/aligned_sequence/aligned_sequence_concept.hpp>
 #include <seqan3/alignment/decorator/gap_decorator.hpp>
 #include <seqan3/alphabet/cigar/cigar.hpp>
+#include <seqan3/io/sam_file/detail/cigar.hpp>
 #include <seqan3/utility/views/slice.hpp>
 
 namespace seqan3
@@ -221,6 +222,18 @@ inline auto alignment_from_cigar(std::vector<cigar> const & cigar_vector,
     }
 
     return alignment;
+}
+
+/*!\overload
+ * \ingroup cigar_conversion
+ */
+template <typename reference_type, typename sequence_type>
+inline auto alignment_from_cigar(std::string const & cigar_string,
+                                 reference_type const & reference,
+                                 uint32_t const zero_based_reference_start_position,
+                                 sequence_type const & query)
+{
+    alignment_from_cigar(detail::parse_cigar(cigar_string), reference, zero_based_reference_start_position, query);
 }
 
 } // namespace seqan3


### PR DESCRIPTION
You might have read a CIGAR string from elsewhere, used our IO with a std::string as type for `field::cigar` or want to get the alignment for a secondary alignment which is stores as a string in the tag dictionary.

In all those cases, you want to create an alignment from a CIGAR string not a vector, so I added an overload.

Note that the overload currently is not the most efficient one, because it allocates a `std::vector<seqan3::cigar>` for convenient use of the other overload. This can be improved by directly parsing the CIGAR string.


Alternatively, we could make the function `detail::parse_cigar` (not a good name right now), which creates a CIGAR vector out of a CIGAR string, public. 