### PR TITLE
[MISC] Add field::alignment deprecation to sam_file_output.

### DIFF
--- a/include/seqan3/io/sam_file/input.hpp
+++ b/include/seqan3/io/sam_file/input.hpp
@@ -361,8 +361,9 @@ public:
                              field::header_ptr>;
 
     static_assert(!selected_field_ids::contains(field::alignment),
-                  "The field::alignment is deprecated and only field::cigar is supported. Please see "
-                  "seqan3::alignment_from_cigar on how to get an alignment from the cigar information.");
+                  "The seqan3::field::alignment was removed from the allowed fields for seqan::sam_file_input. "
+                  "Only seqan3::field::cigar is supported. Please see seqan3::alignment_from_cigar on how to get an "
+                  "alignment from the cigar information.");
 
     static_assert(!selected_field_ids::contains(field::offset),
                   "The field::offset is deprecated. Please access field::cigar and retrieve the soft clipping (S) "

--- a/include/seqan3/io/sam_file/output.hpp
+++ b/include/seqan3/io/sam_file/output.hpp
@@ -102,6 +102,10 @@ public:
                   "The field::offset is deprecated. It is already stored in the field::cigar as soft clipping (S) "
                   "at the front and not needed otherwise.");
 
+    static_assert(!selected_field_ids::contains(field::alignment),
+                  "The field::alignment is deprecated and only field::cigar is supported. Please see "
+                  "seqan3::cigar_from_alignment on how to get a CIGAR string from an alignment.");
+
     static_assert(
         []() constexpr
         {

--- a/include/seqan3/io/sam_file/output.hpp
+++ b/include/seqan3/io/sam_file/output.hpp
@@ -103,8 +103,9 @@ public:
                   "at the front and not needed otherwise.");
 
     static_assert(!selected_field_ids::contains(field::alignment),
-                  "The field::alignment is deprecated and only field::cigar is supported. Please see "
-                  "seqan3::cigar_from_alignment on how to get a CIGAR string from an alignment.");
+                  "The seqan3::field::alignment was removed from the allowed fields for seqan::sam_file_output. "
+                  "Only seqan3::field::cigar is supported. seqan3::cigar_from_alignment on how to get a CIGAR string "
+                  "from an alignment.");
 
     static_assert(
         []() constexpr


### PR DESCRIPTION
I forgot to add the static assert to the output file :see_no_evil: 