### PR TITLE
[FIX] Redundant move

### DIFF
--- a/include/seqan3/io/views/detail/take_exactly_view.hpp
+++ b/include/seqan3/io/views/detail/take_exactly_view.hpp
@@ -255,7 +255,7 @@ public:
     ~basic_iterator() = default;                                      //!< Defaulted.
 
     //!\brief Constructor that delegates to the CRTP layer.
-    constexpr basic_iterator(base_base_t const & it) noexcept(noexcept(base_t{it})) : base_t{std::move(it)}
+    constexpr basic_iterator(base_base_t it) noexcept(noexcept(base_t{it})) : base_t{std::move(it)}
     {}
 
     //!\brief Constructor that delegates to the CRTP layer and initialises the members.


### PR DESCRIPTION
Occurs on gcc 13

See https://cdash.seqan.de/viewBuildError.php?buildid=11951

E.g.,

```
include/seqan3/io/views/detail/take_exactly_view.hpp:258:107: error: redundant move in return statement [-Werror=redundant-move]
  258 |     constexpr basic_iterator(base_base_t const & it) noexcept(noexcept(base_t{it})) : base_t{std::move(it)}
      |                                                                                                           ^
include/seqan3/io/views/detail/take_exactly_view.hpp:258:107: note: remove ‘std::move’ call
```