### PR TITLE
[FIX] Workaround for gcc13

### DIFF
--- a/include/seqan3/utility/views/chunk.hpp
+++ b/include/seqan3/utility/views/chunk.hpp
@@ -250,11 +250,20 @@ private:
             return tmp;
         }
 
+// https://github.com/seqan/seqan3/pull/3102
+#if SEQAN3_COMPILER_IS_GCC && (__GNUC__ > 12)
+        //!\brief Compare to the sentinel type (same as sentinel type of the underlying range).
+        friend constexpr bool operator==(input_helper_iterator const & lhs, sentinel_t const &) noexcept
+        {
+            return lhs.outer_it->remaining == 0u || lhs.outer_it->urng_begin == lhs.outer_it->urng_end;
+        }
+#else
         //!\brief Compare to the sentinel type (same as sentinel type of the underlying range).
         bool operator==(sentinel_t const & /* rhs */) noexcept
         {
             return this->outer_it->remaining == 0u || this->outer_it->urng_begin == this->outer_it->urng_end;
         }
+#endif
 
         //!\brief Pointer to the outer iterator (basic_input_iterator).
         outer_it_type * outer_it{nullptr};
@@ -300,7 +309,7 @@ public:
     //!\brief Allow iterator on a const range to be constructible from an iterator over a non-const range.
     constexpr explicit basic_input_iterator(basic_input_iterator<!const_range> it) noexcept
         requires const_range
-    :
+        :
         chunk_size{std::move(it.chunk_size)},
         remaining{std::move(it.remaining)},
         urng_begin{std::move(it.urng_begin)},
@@ -453,7 +462,7 @@ public:
     //!\brief Allow iterator on a const range to be constructible from an iterator over a non-const range.
     constexpr basic_iterator(basic_iterator<!const_range> const & it) noexcept
         requires const_range
-    :
+        :
         chunk_size{std::move(it.chunk_size)},
         urng_begin{std::move(it.urng_begin)},
         urng_end{std::move(it.urng_end)},

--- a/include/seqan3/utility/views/chunk.hpp
+++ b/include/seqan3/utility/views/chunk.hpp
@@ -253,7 +253,7 @@ private:
 // https://github.com/seqan/seqan3/pull/3102
 #if SEQAN3_COMPILER_IS_GCC && (__GNUC__ > 12)
         //!\brief Compare to the sentinel type (same as sentinel type of the underlying range).
-        friend constexpr bool operator==(input_helper_iterator const & lhs, sentinel_t const &) noexcept
+        friend constexpr bool operator==(input_helper_iterator const & lhs, sentinel_t) noexcept
         {
             return lhs.outer_it->remaining == 0u || lhs.outer_it->urng_begin == lhs.outer_it->urng_end;
         }


### PR DESCRIPTION
```
[ RUN      ] chunk_view_test/5.underlying_input_range_test
../../../../../../../develop/seqan3/test/unit/utility/views/chunk_test.cpp:157: Failure
Expected equality of these values:
  *v_it
    Which is: [1,4,10,2,7]
  *expected_it
    Which is: [1,4]
```

The `input_helper_iterator::operator==`, when following the usual definitions in the STL, should be a `friend` function. However, it is not because in GCC<13 friend functions cannot access members of classes their befriended class befriended.
It is an open [question](https://cplusplus.github.io/CWG/issues/1699.html) whether hidden friends are class members when it comes to friendship.
[Godbolt example](https://godbolt.org/z/oe8f7ej9a)

LLVM views hidden friends as memberly enough, GCC did not. [Recently](https://gcc.gnu.org/git/gitweb.cgi?p=gcc.git;h=4df735e01e319997841574f353d2aa076a0335c2), GCC changed this.

I have not tracked down the overload resolution, but GCC 13 prefers the hidden friend `friend constexpr basic_input_iterator::operator==(basic_input_iterator, sentinel_t)` (possibly via implicit conversion from the `input_helper_iterator` to its base class `basic_input_iterator`). GCC 12 and below used the member comparison operator of the `input_helper_iterator`.
Consequently, the complete range is consumed at once instead of in chunks in this test case:
https://github.com/seqan/seqan3/blob/954471ba90bdbe589c8a79eec641735a771c39c0/test/unit/utility/views/chunk_test.cpp#L149-L158

In some other cases, e.g., views::zip, we just made the members public such that we could access them with befriended operators. Notably, the GCC `std::views::zip` implementation uses hidden friends and private members, as the view was implemented after the friendship change (and was a motivation for this change).

### General good-to-know information about CPP20 comparisons/hidden friends
* Comparison operators can be defaulted: `bool operator==(some_type) = default;`
* Missing comparison operators will be synthesized from existing ones. E.g., the compiler will synthesize `operator!=` from `operator==`, and vice versa.
* The compiler will also synthesize the operator with its arguments reversed if it is a binary operator. I.e., the operators are symmetric. [Example](https://stackoverflow.com/a/61935676)
* There is also a spaceship operator `<=>` :)
* Hidden friends allow for implicit conversion. Hidden friend functions are free functions and can be found via ADL. [Example](https://quuxplusone.github.io/blog/2021/10/22/hidden-friend-outlives-spaceship/)