### PR TITLE
[FEATURE] Minor increase in FASTA performance.

### DIFF
--- a/include/seqan3/io/sequence_file/format_fasta.hpp
+++ b/include/seqan3/io/sequence_file/format_fasta.hpp
@@ -309,10 +309,11 @@ private:
 
             for (; (it != e) && ((!is_id)(*it)); ++it)
             {
-                if ((is_space || is_digit)(*it))
-                    continue;
-                else if (!is_legal_alph(*it))
+                if (!is_legal_alph(*it))
                 {
+                    if ((is_space || is_digit)(*it))
+                        continue;
+
                     throw parse_error{std::string{"Encountered an unexpected letter: "} + "char_is_valid_for<"
                                       + detail::type_name_as_string<seq_legal_alph_type>
                                       + "> evaluated to false on " + detail::make_printable(*it)};

--- a/include/seqan3/io/sequence_file/format_fasta.hpp
+++ b/include/seqan3/io/sequence_file/format_fasta.hpp
@@ -309,17 +309,21 @@ private:
 
             for (; (it != e) && ((!is_id)(*it)); ++it)
             {
-                if (!is_legal_alph(*it))
+                if (is_legal_alph(*it))
                 {
-                    if ((is_space || is_digit)(*it))
-                        continue;
+                    seq.push_back(assign_char_to(*it, std::ranges::range_value_t<seq_type>{}));
+                }
+                else if ((is_space || is_digit)(*it))
+                {
+                    continue;
+                }
+                else
+                {
 
                     throw parse_error{std::string{"Encountered an unexpected letter: "} + "char_is_valid_for<"
                                       + detail::type_name_as_string<seq_legal_alph_type>
                                       + "> evaluated to false on " + detail::make_printable(*it)};
                 }
-
-                seq.push_back(assign_char_to(*it, std::ranges::range_value_t<seq_type>{}));
             }
 
 #else  // ↑↑↑ WORKAROUND | ORIGINAL ↓↓↓

--- a/include/seqan3/utility/views/chunk.hpp
+++ b/include/seqan3/utility/views/chunk.hpp
@@ -300,7 +300,7 @@ public:
     //!\brief Allow iterator on a const range to be constructible from an iterator over a non-const range.
     constexpr explicit basic_input_iterator(basic_input_iterator<!const_range> it) noexcept
         requires const_range
-    :
+        :
         chunk_size{std::move(it.chunk_size)},
         remaining{std::move(it.remaining)},
         urng_begin{std::move(it.urng_begin)},
@@ -453,7 +453,7 @@ public:
     //!\brief Allow iterator on a const range to be constructible from an iterator over a non-const range.
     constexpr basic_iterator(basic_iterator<!const_range> const & it) noexcept
         requires const_range
-    :
+        :
         chunk_size{std::move(it.chunk_size)},
         urng_begin{std::move(it.urng_begin)},
         urng_end{std::move(it.urng_end)},


### PR DESCRIPTION
I had this lying around when cleaning up my branches.

On my PC with GCC 11.3 in was a noisy 5% performance gain on reading FASTA from stream.

I still think it's fine to merge, as it's a small change and makes sense. It avoids an if clause in case the character is an alphabet character, which in a normal FASTA file is most often the case.