### PR TITLE
Io bam performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ If possible, provide tooling that performs the changes, e.g. a shell-script.
 #### I/O
 * Empty SAM/BAM files must at least write a header to ensure a valid file
   ([\#3081](https://github.com/seqan/seqan3/pull/3081)).
+* Reading SAM/BAM files is 2x faster than before
+  ([\#3106](https://github.com/seqan/seqan3/pull/3106)).
 
 ## API changes
 

--- a/include/seqan3/io/detail/misc_input.hpp
+++ b/include/seqan3/io/detail/misc_input.hpp
@@ -105,7 +105,9 @@ inline auto make_secondary_istream(std::basic_istream<char_t> & primary_stream, 
 
     // unget all read chars.
     for (size_t i = 0; i < read_chars; ++i)
-        primary_stream.unget();
+        primary_stream.unget(); // If you unget() more characters than are present in the get area, badbit is set.
+
+    assert(primary_stream.good() && "`unget()` was called too many times on primary_stream.");
 
     std::string extension{};
     if (filename.has_extension())

--- a/include/seqan3/io/sam_file/detail/cigar.hpp
+++ b/include/seqan3/io/sam_file/detail/cigar.hpp
@@ -78,46 +78,39 @@ inline void update_alignment_lengths(int32_t & ref_length,
 
 /*!\brief Parses a cigar string into a vector of operation-count pairs (e.g. (M, 3)).
  * \ingroup io_sam_file
- * \tparam cigar_input_type The type of a single pass input view over the cigar string; must model
- *                          std::ranges::input_range.
- * \param[in]  cigar_input  The single pass input view over the cigar string to parse.
+ * \param[in]  cigar_str  The cigar string to parse.
  *
- * \returns A tuple of size three containing (1) std::vector over seqan3::cigar, that describes
- *          the alignment, (2) the aligned reference length, (3) the aligned query sequence length.
+ * \returns A std::vector over seqan3::cigar that describes the alignment.
  *
  * \details
  *
  * For example, the view over the cigar string "1H4M1D2M2S" will return
  * `{[(H,1), (M,4), (D,1), (M,2), (S,2)], 7, 6}`.
  */
-template <typename cigar_input_type>
-SEQAN3_WORKAROUND_LITERAL std::tuple<std::vector<cigar>, int32_t, int32_t> parse_cigar(cigar_input_type && cigar_input)
+SEQAN3_WORKAROUND_LITERAL std::vector<cigar> parse_cigar(std::string_view const cigar_str)
 {
-    std::vector<cigar> operations{};
-    std::array<char, 20> buffer{}; // buffer to parse numbers with from_chars. Biggest number should fit in uint64_t
-    char cigar_operation{};
+    std::vector<seqan3::cigar> cigar_vector{};
+
+    if (cigar_str == "*")
+        return cigar_vector;
+
     uint32_t cigar_count{};
-    int32_t ref_length{}, seq_length{}; // length of aligned part for ref and query
+    char const * ptr = cigar_str.data();
+    char const * const end = ptr + cigar_str.size();
 
-    // transform input into a single input view if it isn't already
-    auto cigar_view = cigar_input | views::single_pass_input;
-
-    // parse the rest of the cigar
-    // -------------------------------------------------------------------------------------------------------------
-    while (std::ranges::begin(cigar_view) != std::ranges::end(cigar_view)) // until stream is not empty
+    while (ptr < end)
     {
-        auto buff_end = (std::ranges::copy(cigar_view | detail::take_until_or_throw(!is_digit), buffer.data())).out;
-        cigar_operation = *std::ranges::begin(cigar_view);
-        ++std::ranges::begin(cigar_view);
+        auto const res = std::from_chars(ptr, end, cigar_count); // reads number up to next character
 
-        if (std::from_chars(buffer.begin(), buff_end, cigar_count).ec != std::errc{})
-            throw format_error{"Corrupted cigar string encountered"};
+        if (res.ec != std::errc{})
+            throw format_error{"Corrupted cigar string."};
 
-        update_alignment_lengths(ref_length, seq_length, cigar_operation, cigar_count);
-        operations.emplace_back(cigar_count, cigar::operation{}.assign_char(cigar_operation));
+        ptr = res.ptr + 1; // skip cigar operation character
+
+        cigar_vector.emplace_back(cigar_count, seqan3::assign_char_strictly_to(*res.ptr, seqan3::cigar::operation{}));
     }
 
-    return {operations, ref_length, seq_length};
+    return cigar_vector;
 }
 
 /*!\brief Transforms a vector of cigar elements into a string representation.

--- a/include/seqan3/io/sam_file/format_bam.hpp
+++ b/include/seqan3/io/sam_file/format_bam.hpp
@@ -13,6 +13,7 @@
 #pragma once
 
 #include <bit>
+#include <cstring>
 #include <iterator>
 #include <ranges>
 #include <string>
@@ -213,6 +214,13 @@ private:
         std::ranges::copy_n(std::ranges::begin(stream_view), sizeof(target), reinterpret_cast<char *>(&target));
     }
 
+    //!\overload
+    template <std::integral number_type>
+    void read_integral_byte_field(std::string_view const str, number_type & target)
+    {
+        std::memcpy(&target, str.data(), sizeof(target));
+    }
+
     /*!\brief Reads a float field from binary stream by directly reinterpreting the bits.
      * \tparam stream_view_type  The type of the stream as a view.
      * \param[in, out] stream_view  The stream view to read from.
@@ -224,16 +232,14 @@ private:
         std::ranges::copy_n(std::ranges::begin(stream_view), sizeof(int32_t), reinterpret_cast<char *>(&target));
     }
 
-    template <typename stream_view_type, typename value_type>
-    void read_sam_dict_vector(seqan3::detail::sam_tag_variant & variant,
-                              stream_view_type && stream_view,
-                              value_type const & SEQAN3_DOXYGEN_ONLY(value));
+    template <typename value_type>
+    int32_t read_sam_dict_vector(seqan3::detail::sam_tag_variant & variant,
+                                 std::string_view const str,
+                                 value_type const & SEQAN3_DOXYGEN_ONLY(value));
 
-    template <typename stream_view_type>
-    void read_sam_dict_field(stream_view_type && stream_view, sam_tag_dictionary & target);
+    void read_sam_dict(std::string_view const tag_str, sam_tag_dictionary & target);
 
-    template <typename cigar_input_type>
-    auto parse_binary_cigar(cigar_input_type && cigar_input, uint16_t n_cigar_op) const;
+    std::vector<cigar> parse_binary_cigar(std::string_view const cigar_str) const;
 
     static std::string get_tag_dict_str(sam_tag_dictionary const & tag_dict);
 };
@@ -288,8 +294,6 @@ format_bam::read_alignment_record(stream_type & stream,
                   "The type of field::flag must be seqan3::sam_flag.");
 
     auto stream_view = seqan3::detail::istreambuf(stream);
-
-    [[maybe_unused]] int32_t ref_length{}; // needed in case the cigar string was stored in the tag dictionary
 
     // Header
     // -------------------------------------------------------------------------------------------------------------
@@ -376,8 +380,12 @@ format_bam::read_alignment_record(stream_type & stream,
     // read alignment record into buffer
     // -------------------------------------------------------------------------------------------------------------
     position_buffer = stream.tellg();
+
+    auto stream_it = detail::fast_istreambuf_iterator{*stream.rdbuf()};
+
     alignment_record_core core;
-    std::ranges::copy(stream_view | detail::take_exactly_or_throw(sizeof(core)), reinterpret_cast<char *>(&core));
+    std::string_view const core_str = stream_it.cache_bytes(sizeof(core));
+    std::ranges::copy(core_str, reinterpret_cast<char *>(&core));
 
     if (core.refID >= static_cast<int32_t>(header.ref_ids().size()) || core.refID < -1) // [[unlikely]]
     {
@@ -412,96 +420,65 @@ format_bam::read_alignment_record(stream_type & stream,
 
     // read id
     // -------------------------------------------------------------------------------------------------------------
-    auto id_view = stream_view | detail::take_exactly_or_throw(core.l_read_name - 1);
+    std::string_view record_str = stream_it.cache_bytes(core.block_size - (sizeof(alignment_record_core) - 4));
+    size_t considered_bytes{0};
+
     if constexpr (!detail::decays_to_ignore_v<id_type>)
-        read_forward_range_field(id_view, id); // field::id
-    else
-        detail::consume(id_view);
-    ++std::ranges::begin(stream_view); // skip '\0'
+        read_forward_range_field(record_str.substr(0, core.l_read_name - 1), id);
+
+    considered_bytes += core.l_read_name;
 
     // read cigar string
     // -------------------------------------------------------------------------------------------------------------
     if constexpr (!detail::decays_to_ignore_v<cigar_type>)
-    {
-        int32_t seq_length{};
-        std::tie(cigar_vector, ref_length, seq_length) = parse_binary_cigar(stream_view, core.n_cigar_op);
-    }
-    else
-    {
-        detail::consume(stream_view | detail::take_exactly_or_throw(core.n_cigar_op * 4));
-    }
+        cigar_vector = parse_binary_cigar(record_str.substr(considered_bytes, core.n_cigar_op * 4));
+
+    considered_bytes += core.n_cigar_op * 4;
 
     // read sequence
     // -------------------------------------------------------------------------------------------------------------
-    if (core.l_seq > 0) // sequence information is given
+    if constexpr (!detail::decays_to_ignore_v<seq_type>)
     {
-        auto seq_stream = stream_view | detail::take_exactly_or_throw(core.l_seq / 2) // one too short if uneven
-                        | std::views::transform(
-                              [](char c) -> std::pair<dna16sam, dna16sam>
-                              {
-                                  return {dna16sam{}.assign_rank(std::min(15, static_cast<uint8_t>(c) >> 4)),
-                                          dna16sam{}.assign_rank(std::min(15, static_cast<uint8_t>(c) & 0x0f))};
-                              });
+        size_t const number_of_bytes = (core.l_seq + 1) / 2;
+        std::string_view const seq_str = record_str.substr(considered_bytes, number_of_bytes);
 
-        if constexpr (detail::decays_to_ignore_v<seq_type>)
+        seq.resize(
+            core.l_seq
+            + 1 /* reserve one more in case size is uneven. will be corrected */); // TODO: .resize() is not generic
+
+        using alph_t = std::ranges::range_value_t<decltype(seq)>;
+        constexpr auto from_dna16 = detail::convert_through_char_representation<dna16sam, alph_t>;
+
+        // 1 byte encodes two sequence characters
+        for (size_t i = 0, j = 0; i < number_of_bytes; ++i, j += 2)
         {
-            auto skip_sequence_bytes = [&]()
-            {
-                detail::consume(seq_stream);
-                if (core.l_seq & 1)
-                    ++std::ranges::begin(stream_view);
-            };
-
-            skip_sequence_bytes();
+            seq[j] = from_dna16[to_rank(dna16sam{}.assign_rank(std::min(15, static_cast<uint8_t>(seq_str[i]) >> 4)))];
+            seq[j + 1] =
+                from_dna16[to_rank(dna16sam{}.assign_rank(std::min(15, static_cast<uint8_t>(seq_str[i]) & 0x0f)))];
         }
-        else
-        {
-            using alph_t = std::ranges::range_value_t<decltype(seq)>;
-            constexpr auto from_dna16 = detail::convert_through_char_representation<dna16sam, alph_t>;
 
-            for (auto [d1, d2] : seq_stream)
-            {
-                seq.push_back(from_dna16[to_rank(d1)]);
-                seq.push_back(from_dna16[to_rank(d2)]);
-            }
-
-            if (core.l_seq & 1)
-            {
-                dna16sam d =
-                    dna16sam{}.assign_rank(std::min(15, static_cast<uint8_t>(*std::ranges::begin(stream_view)) >> 4));
-                seq.push_back(from_dna16[to_rank(d)]);
-                ++std::ranges::begin(stream_view);
-            }
-        }
+        seq.resize(core.l_seq); // remove extra letter
     }
+
+    considered_bytes += (core.l_seq + 1) / 2;
 
     // read qual string
     // -------------------------------------------------------------------------------------------------------------
-    auto qual_view = stream_view | detail::take_exactly_or_throw(core.l_seq)
-                   | std::views::transform(
-                         [](char chr)
-                         {
-                             return static_cast<char>(chr + 33);
-                         });
     if constexpr (!detail::decays_to_ignore_v<qual_type>)
-        read_forward_range_field(qual_view, qual);
-    else
-        detail::consume(qual_view);
+    {
+        std::string_view const qual_str = record_str.substr(considered_bytes, core.l_seq);
+        qual.resize(core.l_seq); // TODO: this is not generic
+
+        for (int32_t i = 0; i < core.l_seq; ++i)
+            qual[i] = assign_char_to(static_cast<char>(qual_str[i] + 33), std::ranges::range_value_t<qual_type>{});
+    }
+
+    considered_bytes += core.l_seq;
 
     // All remaining optional fields if any: SAM tags dictionary
     // -------------------------------------------------------------------------------------------------------------
-    int32_t remaining_bytes = core.block_size - (sizeof(alignment_record_core) - 4 /*block_size excluded*/)
-                            - core.l_read_name - core.n_cigar_op * 4 - (core.l_seq + 1) / 2 - core.l_seq;
-    assert(remaining_bytes >= 0);
-    auto tags_view = stream_view | detail::take_exactly_or_throw(remaining_bytes);
-
-    while (tags_view.size() > 0)
-    {
-        if constexpr (!detail::decays_to_ignore_v<tag_dict_type>)
-            read_sam_dict_field(tags_view, tag_dict);
-        else
-            detail::consume(tags_view);
-    }
+    if constexpr (!detail::decays_to_ignore_v<tag_dict_type>)
+        read_sam_dict(record_str.substr(considered_bytes), tag_dict);
 
     // DONE READING - wrap up
     // -------------------------------------------------------------------------------------------------------------
@@ -518,10 +495,8 @@ format_bam::read_alignment_record(stream_type & stream,
             { // maybe only throw in debug mode and otherwise return an empty alignment?
                 throw format_error{
                     detail::to_string("The cigar string '",
-                                      sc_front,
-                                      "S",
-                                      ref_length,
-                                      "N' suggests that the cigar string exceeded 65535 elements and was therefore ",
+                                      detail::get_cigar_string(cigar_vector),
+                                      "' suggests that the cigar string exceeded 65535 elements and was therefore ",
                                       "stored in the optional field CG. You need to read in the field::tags and "
                                       "field::seq in order to access this information.")};
             }
@@ -530,18 +505,14 @@ format_bam::read_alignment_record(stream_type & stream,
                 auto it = tag_dict.find("CG"_tag);
 
                 if (it == tag_dict.end())
-                    throw format_error{detail::to_string(
-                        "The cigar string '",
-                        sc_front,
-                        "S",
-                        ref_length,
-                        "N' suggests that the cigar string exceeded 65535 elements and was therefore ",
-                        "stored in the optional field CG but this tag is not present in the given ",
-                        "record.")};
+                    throw format_error{
+                        detail::to_string("The cigar string '",
+                                          detail::get_cigar_string(cigar_vector),
+                                          "' suggests that the cigar string exceeded 65535 elements and was therefore ",
+                                          "stored in the optional field CG but this tag is not present in the given ",
+                                          "record.")};
 
-                auto cigar_view = std::views::all(std::get<std::string>(it->second));
-                int32_t seq_length{};
-                std::tie(cigar_vector, ref_length, seq_length) = detail::parse_cigar(cigar_view);
+                cigar_vector = detail::parse_cigar(std::get<std::string>(it->second));
                 tag_dict.erase(it); // remove redundant information
             }
         }
@@ -878,43 +849,68 @@ inline void format_bam::write_header(stream_t & stream, sam_file_output_options 
     }
 }
 
-//!\copydoc seqan3::format_sam::read_sam_dict_vector
-template <typename stream_view_type, typename value_type>
-inline void format_bam::read_sam_dict_vector(seqan3::detail::sam_tag_variant & variant,
-                                             stream_view_type && stream_view,
-                                             value_type const & SEQAN3_DOXYGEN_ONLY(value))
+/*!\brief Reads a list of values separated by comma as it is the case for SAM tag arrays.
+ * \tparam value_type       The type of values to be stored in the tag array.
+ *
+ * \param[in, out] variant      A std::variant object to store the tag arrays.
+ * \param[in, out] str          The string_view to parse.
+ * \param[in]      value        A temporary value that determines the underlying type of the tag array.
+ *
+ * \returns The length of the vector processed.
+ *
+ * \details
+ *
+ * Reading the tags is done according to the official
+ * [SAM format specifications](https://samtools.github.io/hts-specs/SAMv1.pdf).
+ *
+ * The function throws a seqan3::format_error if any unknown tag type was encountered. It will also fail if the
+ * format is not in a correct state (e.g. required fields are not given), but throwing might occur downstream of
+ * the actual error.
+ */
+template <typename value_type>
+inline int32_t format_bam::read_sam_dict_vector(seqan3::detail::sam_tag_variant & variant,
+                                                std::string_view const str,
+                                                value_type const & SEQAN3_DOXYGEN_ONLY(value))
 {
-    int32_t count;
-    read_integral_byte_field(stream_view, count); // read length of vector
-    std::vector<value_type> tmp_vector;
-    tmp_vector.reserve(count);
+    auto it = str.begin();
 
-    while (count > 0)
+    // Read vector size from string_view and advance `it`.
+    int32_t const vector_size = [&]()
     {
-        value_type tmp{};
+        int32_t size{};
+        read_integral_byte_field(std::string_view{it, str.end()}, size);
+        it += sizeof(size);
+        return size;
+    }();
+
+    int32_t bytes_left{vector_size};
+
+    std::vector<value_type> tmp_vector;
+    tmp_vector.reserve(vector_size);
+
+    value_type tmp{};
+
+    while (bytes_left > 0)
+    {
         if constexpr (std::integral<value_type>)
-        {
-            read_integral_byte_field(stream_view, tmp);
-        }
+            read_integral_byte_field(std::string_view{it, str.end()}, tmp);
         else if constexpr (std::same_as<value_type, float>)
-        {
-            read_float_byte_field(stream_view, tmp);
-        }
+            read_float_byte_field(std::string_view{it, str.end()}, tmp);
         else
-        {
-            constexpr bool always_false = std::is_same_v<value_type, void>;
-            static_assert(always_false, "format_bam::read_sam_dict_vector: unsupported value_type");
-        }
+            static_assert(std::is_same_v<value_type, void>, "format_bam::read_sam_dict_vector: unsupported value_type");
+
+        it += sizeof(tmp);
         tmp_vector.push_back(std::move(tmp));
-        --count;
+        --bytes_left;
     }
+
     variant = std::move(tmp_vector);
+
+    return vector_size;
 }
 
 /*!\brief Reads the optional tag fields into the seqan3::sam_tag_dictionary.
- * \tparam stream_view_type   The type of the stream as a view.
- *
- * \param[in, out] stream_view  The stream view to iterate over.
+ * \param[in, out] tag_str      The string_view to parse.
  * \param[out]     target       The seqan3::sam_tag_dictionary to store the tag information.
  *
  * \throws seqan3::format_error if any unexpected character or format is encountered.
@@ -928,205 +924,213 @@ inline void format_bam::read_sam_dict_vector(seqan3::detail::sam_tag_variant & v
  * format is not in a correct state (e.g. required fields are not given), but throwing might occur downstream of
  * the actual error.
  */
-template <typename stream_view_type>
-inline void format_bam::read_sam_dict_field(stream_view_type && stream_view, sam_tag_dictionary & target)
+inline void format_bam::read_sam_dict(std::string_view const tag_str, sam_tag_dictionary & target)
 {
-    /* Every BA< tag has the format "[TAG][TYPE_ID][VALUE]", where TAG is a two letter
+    /* Every BAM tag has the format "[TAG][TYPE_ID][VALUE]", where TAG is a two letter
        name tag which is converted to a unique integer identifier and TYPE_ID is one character in [A,i,Z,H,B,f]
        describing the type for the upcoming VALUES. If TYPE_ID=='B' it signals an array of
        VALUE's and the inner value type is identified by the next character, one of [cCsSiIf], followed
        by the length (int32_t) of the array, followed by the values.
     */
-    auto it = std::ranges::begin(stream_view);
-    uint16_t tag = static_cast<uint16_t>(*it) << 8;
-    ++it; // skip char read before
+    auto it = tag_str.begin();
 
-    tag += static_cast<uint16_t>(*it);
-    ++it; // skip char read before
+    // Deduces int_t from passed argument.
+    auto parse_integer_into_target = [&]<std::integral int_t>(uint16_t const tag, int_t)
+    {
+        int_t tmp{};
+        read_integral_byte_field(std::string_view{it, tag_str.end()}, tmp);
+        target[tag] = static_cast<int32_t>(tmp); // readable sam format only allows int32_t
+        it += sizeof(tmp);
+    };
 
-    char type_id = *it;
-    ++it; // skip char read before
+    // Deduces array_value_t from passed argument.
+    auto parse_array_into_target = [&]<arithmetic array_value_t>(uint16_t const tag, array_value_t)
+    {
+        int32_t const count = read_sam_dict_vector(target[tag], std::string_view{it, tag_str.end()}, array_value_t{});
+        it += sizeof(int32_t) /*length is stored within the vector*/ + sizeof(array_value_t) * count;
+    };
 
-    switch (type_id)
+    // Read uint16_t from string_view and advance `it`.
+    auto parse_tag = [&]()
     {
-    case 'A': // char
-    {
-        target[tag] = *it;
-        ++it; // skip char that has been read
-        break;
-    }
-    // all integer sizes are possible
-    case 'c': // int8_t
-    {
-        int8_t tmp;
-        read_integral_byte_field(stream_view, tmp);
-        target[tag] = static_cast<int32_t>(tmp); // readable sam format only allows int32_t
-        break;
-    }
-    case 'C': // uint8_t
-    {
-        uint8_t tmp;
-        read_integral_byte_field(stream_view, tmp);
-        target[tag] = static_cast<int32_t>(tmp); // readable sam format only allows int32_t
-        break;
-    }
-    case 's': // int16_t
-    {
-        int16_t tmp;
-        read_integral_byte_field(stream_view, tmp);
-        target[tag] = static_cast<int32_t>(tmp); // readable sam format only allows int32_t
-        break;
-    }
-    case 'S': // uint16_t
-    {
-        uint16_t tmp;
-        read_integral_byte_field(stream_view, tmp);
-        target[tag] = static_cast<int32_t>(tmp); // readable sam format only allows int32_t
-        break;
-    }
-    case 'i': // int32_t
-    {
-        int32_t tmp;
-        read_integral_byte_field(stream_view, tmp);
-        target[tag] = std::move(tmp); // readable sam format only allows int32_t
-        break;
-    }
-    case 'I': // uint32_t
-    {
-        uint32_t tmp;
-        read_integral_byte_field(stream_view, tmp);
-        target[tag] = static_cast<int32_t>(tmp); // readable sam format only allows int32_t
-        break;
-    }
-    case 'f': // float
-    {
-        float tmp;
-        read_float_byte_field(stream_view, tmp);
-        target[tag] = tmp;
-        break;
-    }
-    case 'Z': // string
-    {
-        string_buffer.clear();
-        while (!is_char<'\0'>(*it))
-        {
-            string_buffer.push_back(*it);
-            ++it;
-        }
-        ++it; // skip \0
-        target[tag] = string_buffer;
-        break;
-    }
-    case 'H': // byte array, represented as null-terminated string; specification requires even number of bytes
-    {
-        std::vector<std::byte> byte_array;
-        std::byte value;
-        while (!is_char<'\0'>(*it))
-        {
-            string_buffer.clear();
-            string_buffer.push_back(*it);
-            ++it;
+        uint16_t tag = static_cast<uint16_t>(*it) << 8;
+        ++it; // skip char read before
+        tag |= static_cast<uint16_t>(*it);
+        ++it; // skip char read before
+        return tag;
+    };
 
-            if (*it == '\0')
-                throw format_error{"Hexadecimal tag has an uneven number of digits!"};
-
-            string_buffer.push_back(*it);
-            ++it;
-            read_byte_field(string_buffer, value);
-            byte_array.push_back(value);
-        }
-        ++it; // skip \0
-        target[tag] = byte_array;
-        break;
-    }
-    case 'B': // Array. Value type depends on second char [cCsSiIf]
+    while (it != tag_str.end())
     {
-        char array_value_type_id = *it;
+        uint16_t const tag = parse_tag();
+
+        char const type_id{*it};
         ++it; // skip char read before
 
-        switch (array_value_type_id)
+        switch (type_id)
         {
+        case 'A': // char
+        {
+            target[tag] = *it;
+            ++it; // skip char that has been read
+            break;
+        }
+        // all integer sizes are possible
         case 'c': // int8_t
-            read_sam_dict_vector(target[tag], stream_view, int8_t{});
+        {
+            parse_integer_into_target(tag, int8_t{});
             break;
+        }
         case 'C': // uint8_t
-            read_sam_dict_vector(target[tag], stream_view, uint8_t{});
+        {
+            parse_integer_into_target(tag, uint8_t{});
             break;
+        }
         case 's': // int16_t
-            read_sam_dict_vector(target[tag], stream_view, int16_t{});
+        {
+            parse_integer_into_target(tag, int16_t{});
             break;
+        }
         case 'S': // uint16_t
-            read_sam_dict_vector(target[tag], stream_view, uint16_t{});
+        {
+            parse_integer_into_target(tag, uint16_t{});
             break;
+        }
         case 'i': // int32_t
-            read_sam_dict_vector(target[tag], stream_view, int32_t{});
+        {
+            parse_integer_into_target(tag, int32_t{});
             break;
+        }
         case 'I': // uint32_t
-            read_sam_dict_vector(target[tag], stream_view, uint32_t{});
+        {
+            parse_integer_into_target(tag, uint32_t{});
             break;
+        }
         case 'f': // float
-            read_sam_dict_vector(target[tag], stream_view, float{});
+        {
+            float tmp{};
+            read_float_byte_field(std::string_view{it, tag_str.end()}, tmp);
+            target[tag] = tmp;
+            it += sizeof(float);
             break;
+        }
+        case 'Z': // string
+        {
+            std::string const v{static_cast<char const *>(it)}; // parses until '\0'
+            it += v.size() + 1;
+            target[tag] = std::move(v);
+            break;
+        }
+        case 'H': // byte array, represented as null-terminated string; specification requires even number of bytes
+        {
+            std::string_view const str{static_cast<char const *>(it)}; // parses until '\0'
+
+            std::vector<std::byte> tmp_vector{};
+            // std::from_chars cannot directly parse into a std::byte
+            uint8_t dummy_byte{};
+
+            if (str.size() % 2 != 0)
+                throw format_error{"[CORRUPTED BAM FILE]  Hexadecimal tag must have even number of digits."};
+
+            // H encodes bytes in a hexadecimal format. Two hex values are stored for each byte as characters.
+            // E.g., '1' and 'A' need one byte each and are read as `\x1A`, which is 27 in decimal.
+            for (auto hex_begin = str.begin(), hex_end = str.begin() + 2; hex_begin != str.end();
+                 hex_begin += 2, hex_end += 2)
+            {
+                auto res = std::from_chars(hex_begin, hex_end, dummy_byte, 16);
+
+                if (res.ec == std::errc::invalid_argument)
+                    throw format_error{std::string("[CORRUPTED BAM FILE] The string '")
+                                       + std::string(hex_begin, hex_end) + "' could not be cast into type uint8_t."};
+
+                if (res.ec == std::errc::result_out_of_range)
+                    throw format_error{std::string("[CORRUPTED BAM FILE] Casting '") + std::string(str)
+                                       + "' into type uint8_t would cause an overflow."};
+
+                tmp_vector.push_back(std::byte{dummy_byte});
+            }
+
+            target[tag] = std::move(tmp_vector);
+
+            it += str.size() + 1;
+
+            break;
+        }
+        case 'B': // Array. Value type depends on second char [cCsSiIf]
+        {
+            char array_value_type_id = *it;
+            ++it; // skip char read before
+
+            switch (array_value_type_id)
+            {
+            case 'c': // int8_t
+                parse_array_into_target(tag, int8_t{});
+                break;
+            case 'C': // uint8_t
+                parse_array_into_target(tag, uint8_t{});
+                break;
+            case 's': // int16_t
+                parse_array_into_target(tag, int16_t{});
+                break;
+            case 'S': // uint16_t
+                parse_array_into_target(tag, uint16_t{});
+                break;
+            case 'i': // int32_t
+                parse_array_into_target(tag, int32_t{});
+                break;
+            case 'I': // uint32_t
+                parse_array_into_target(tag, uint32_t{});
+                break;
+            case 'f': // float
+                parse_array_into_target(tag, float{});
+                break;
+            default:
+                throw format_error{detail::to_string("The first character in the numerical id of a SAM tag ",
+                                                     "must be one of [cCsSiIf] but '",
+                                                     array_value_type_id,
+                                                     "' was given.")};
+            }
+            break;
+        }
         default:
-            throw format_error{detail::to_string("The first character in the numerical id of a SAM tag ",
-                                                 "must be one of [cCsSiIf] but '",
-                                                 array_value_type_id,
+            throw format_error{detail::to_string("The second character in the numerical id of a "
+                                                 "SAM tag must be one of [A,i,Z,H,B,f] but '",
+                                                 type_id,
                                                  "' was given.")};
         }
-        break;
-    }
-    default:
-        throw format_error{detail::to_string("The second character in the numerical id of a "
-                                             "SAM tag must be one of [A,i,Z,H,B,f] but '",
-                                             type_id,
-                                             "' was given.")};
     }
 }
 
 /*!\brief Parses a cigar string into a vector of operation-count pairs (e.g. (M, 3)).
- * \tparam cigar_input_type The type of a single pass input view over the cigar string; must model
- *                          std::ranges::input_range.
- * \param[in] cigar_input The single pass input view over the cigar string to parse.
- * \param[in] n_cigar_op  The number of cigar elements to read from the cigar_input.
+ * \param[in] cigar_str A std::string_view that points to the information of the CIGAR string in the BAM file.
  *
- * \returns A tuple of size three containing (1) std::vector over seqan3::cigar, that describes
- *          the alignment, (2) the aligned reference length, (3) the aligned query sequence length.
- *
- * \details
- *
- * For example, the view over the cigar string "1H4M1D2M2S" will return
- * `{[(H,1), (M,4), (D,1), (M,2), (S,2)], 7, 6}`.
+ * \returns A std::vector over seqan3::cigar, that describes the alignment.
  */
-template <typename cigar_input_type>
-inline auto format_bam::parse_binary_cigar(cigar_input_type && cigar_input, uint16_t n_cigar_op) const
+inline std::vector<cigar> format_bam::parse_binary_cigar(std::string_view const cigar_str) const
 {
-    std::vector<cigar> operations{};
+    // The cigar operation is encoded in 4 bits.
+    constexpr std::array<char, 16>
+        cigar_operation_mapping{'M', 'I', 'D', 'N', 'S', 'H', 'P', '=', 'X', '*', '*', '*', '*', '*', '*', '*'};
+    // The rightmost 4 bits encode the operation, the other bits encode the count.
+    constexpr uint32_t cigar_operation_mask = 0x0f; // rightmost 4 bits are set to one
+
+    std::vector<cigar> cigar_vector{};
     char operation{'\0'};
     uint32_t count{};
-    int32_t ref_length{}, seq_length{};
-    uint32_t operation_and_count{}; // in BAM operation and count values are stored within one 32 bit integer
-    constexpr char const * cigar_mapping = "MIDNSHP=X*******";
-    constexpr uint32_t cigar_mask = 0x0f; // 0000000000001111
+    uint32_t operation_and_count{}; // In BAM, operation and count values are stored within one 32 bit integer.
 
-    if (n_cigar_op == 0) // [[unlikely]]
-        return std::tuple{operations, ref_length, seq_length};
+    assert(cigar_str.size() % 4 == 0); // One cigar letter is stored in 4 bytes (uint32_t).
 
-    // parse the rest of the cigar
-    // -------------------------------------------------------------------------------------------------------------
-    while (n_cigar_op > 0) // until stream is not empty
+    for (auto it = cigar_str.begin(); it != cigar_str.end(); it += sizeof(operation_and_count))
     {
-        std::ranges::copy_n(std::ranges::begin(cigar_input),
-                            sizeof(operation_and_count),
-                            reinterpret_cast<char *>(&operation_and_count));
-        operation = cigar_mapping[operation_and_count & cigar_mask];
+        std::memcpy(&operation_and_count, it, sizeof(operation_and_count));
+        operation = cigar_operation_mapping[operation_and_count & cigar_operation_mask];
         count = operation_and_count >> 4;
 
-        detail::update_alignment_lengths(ref_length, seq_length, operation, count);
-        operations.emplace_back(count, cigar::operation{}.assign_char(operation));
-        --n_cigar_op;
+        cigar_vector.emplace_back(count, seqan3::assign_char_strictly_to(operation, cigar::operation{}));
     }
 
-    return std::tuple{operations, ref_length, seq_length};
+    return cigar_vector;
 }
 
 /*!\brief Writes the optional fields of the seqan3::sam_tag_dictionary.

--- a/include/seqan3/io/sam_file/format_bam.hpp
+++ b/include/seqan3/io/sam_file/format_bam.hpp
@@ -158,6 +158,8 @@ private:
         int32_t tlen;             //!< The template length of the read and its mate.
     };
 
+    static_assert(sizeof(alignment_record_core) == 36);
+
     // clang-format off
     //!\brief Converts a cigar op character to the rank according to the official BAM specifications.
     static constexpr std::array<uint8_t, 256> char_to_sam_rank

--- a/include/seqan3/io/sam_file/format_sam.hpp
+++ b/include/seqan3/io/sam_file/format_sam.hpp
@@ -227,6 +227,9 @@ private:
     //!\brief Tracks whether reference information (\@SR tag) were found in the SAM header
     bool ref_info_present_in_header{false};
 
+    //!\brief A buffer to store a raw record pointing into the stream buffer of the input.
+    std::array<std::string_view, 11> raw_record{};
+
     //!brief Returns a reference to dummy if passed a std::ignore.
     std::string_view const & default_or(detail::ignore_t) const noexcept
     {
@@ -240,15 +243,12 @@ private:
         return std::forward<t>(v);
     }
 
-    template <typename stream_view_type, arithmetic value_type>
-    void
-    read_sam_dict_vector(seqan3::detail::sam_tag_variant & variant, stream_view_type && stream_view, value_type value);
+    template <arithmetic value_type>
+    void read_sam_dict_vector(seqan3::detail::sam_tag_variant & variant, std::string_view const str, value_type value);
 
-    template <typename stream_view_type>
-    void read_sam_byte_vector(seqan3::detail::sam_tag_variant & variant, stream_view_type && stream_view);
+    void read_sam_byte_vector(seqan3::detail::sam_tag_variant & variant, std::string_view const str);
 
-    template <typename stream_view_type>
-    void read_sam_dict_field(stream_view_type && stream_view, sam_tag_dictionary & target);
+    void read_sam_dict(std::string_view const tag_str, sam_tag_dictionary & target);
 
     template <typename stream_it_t, std::ranges::forward_range field_type>
     void write_range_or_asterisk(stream_it_t & stream_it, field_type && field_value);
@@ -384,15 +384,16 @@ format_sam::read_alignment_record(stream_type & stream,
                       || detail::is_type_specialisation_of_v<ref_offset_type, std::optional>,
                   "The ref_offset must be a specialisation of std::optional.");
 
+    auto stream_it = detail::fast_istreambuf_iterator{*stream.rdbuf()};
+
     auto stream_view = detail::istreambuf(stream);
-    auto field_view = stream_view | detail::take_until_or_throw_and_consume(is_char<'\t'>);
 
     int32_t ref_offset_tmp{}; // needed to read the ref_offset (int) beofre storing it in std::optional<uint32_t>
     std::ranges::range_value_t<decltype(header.ref_ids())> ref_id_tmp{}; // in case mate is requested but ref_offset not
 
     // Header
     // -------------------------------------------------------------------------------------------------------------
-    if (is_char<'@'>(*std::ranges::begin(stream_view))) // we always read the header if present
+    if (is_char<'@'>(*stream_it)) // we always read the header if present
     {
         read_header(stream_view, header, ref_seqs);
 
@@ -403,21 +404,24 @@ format_sam::read_alignment_record(stream_type & stream,
     // Store the current file position in the buffer.
     position_buffer = stream.tellg();
 
+    // We don't know wether we have 11 or 12 fields, since the tags are optional.
+    // The last field will thus contain either the quality sequence
+    // or the quality sequence AND tags. This will be handled at the respective fields below.
+    stream_it.cache_record_into('\n', '\t', raw_record);
+
     // Fields 1-5: ID FLAG REF_ID REF_OFFSET MAPQ
     // -------------------------------------------------------------------------------------------------------------
     if constexpr (!detail::decays_to_ignore_v<id_type>)
-        read_forward_range_field(field_view, id);
-    else
-        detail::consume(field_view);
+        read_forward_range_field(raw_record[0], id);
 
     uint16_t flag_integral{};
-    read_arithmetic_field(field_view, flag_integral);
+    read_arithmetic_field(raw_record[1], flag_integral);
     flag = sam_flag{flag_integral};
 
-    read_forward_range_field(field_view, ref_id_tmp);
+    read_forward_range_field(raw_record[2], ref_id_tmp);
     check_and_assign_ref_id(ref_id, ref_id_tmp, header, ref_seqs);
 
-    read_arithmetic_field(field_view, ref_offset_tmp);
+    read_arithmetic_field(raw_record[3], ref_offset_tmp);
     --ref_offset_tmp; // SAM format is 1-based but SeqAn operates 0-based
 
     if (ref_offset_tmp == -1)
@@ -428,35 +432,19 @@ format_sam::read_alignment_record(stream_type & stream,
         throw format_error{"No negative values are allowed for field::ref_offset."};
 
     if constexpr (!detail::decays_to_ignore_v<mapq_type>)
-        read_arithmetic_field(field_view, mapq);
-    else
-        detail::consume(field_view);
+        read_arithmetic_field(raw_record[4], mapq);
 
     // Field 6: CIGAR
     // -------------------------------------------------------------------------------------------------------------
     if constexpr (!detail::decays_to_ignore_v<cigar_type>)
-    {
-        if (!is_char<'*'>(*std::ranges::begin(stream_view))) // no cigar information given
-        {
-            int32_t ref_length{}, seq_length{}; // length of aligned part for ref and query
-            std::tie(cigar_vector, ref_length, seq_length) = detail::parse_cigar(field_view);
-        }
-        else
-        {
-            ++std::ranges::begin(field_view); // skip '*'
-        }
-    }
-    else
-    {
-        detail::consume(field_view);
-    }
+        cigar_vector = detail::parse_cigar(raw_record[5]);
 
     // Field 7-9: (RNEXT PNEXT TLEN) = MATE
     // -------------------------------------------------------------------------------------------------------------
     if constexpr (!detail::decays_to_ignore_v<mate_type>)
     {
         std::ranges::range_value_t<decltype(header.ref_ids())> tmp_mate_ref_id{};
-        read_forward_range_field(field_view, tmp_mate_ref_id); // RNEXT
+        read_forward_range_field(raw_record[6], tmp_mate_ref_id); // RNEXT
 
         if (tmp_mate_ref_id == "=") // indicates "same as ref id"
         {
@@ -471,7 +459,7 @@ format_sam::read_alignment_record(stream_type & stream,
         }
 
         int32_t tmp_pnext{};
-        read_arithmetic_field(field_view, tmp_pnext); // PNEXT
+        read_arithmetic_field(raw_record[7], tmp_pnext); // PNEXT
 
         if (tmp_pnext > 0)
             get<1>(mate) = --tmp_pnext; // SAM format is 1-based but SeqAn operates 0-based.
@@ -479,55 +467,44 @@ format_sam::read_alignment_record(stream_type & stream,
             throw format_error{"No negative values are allowed at the mate mapping position."};
         // tmp_pnext == 0 indicates an unmapped mate -> do not fill std::optional get<1>(mate)
 
-        read_arithmetic_field(field_view, get<2>(mate)); // TLEN
-    }
-    else
-    {
-        for (size_t i = 0; i < 3u; ++i)
-        {
-            detail::consume(field_view);
-        }
+        read_arithmetic_field(raw_record[8], get<2>(mate)); // TLEN
     }
 
     // Field 10: Sequence
     // -------------------------------------------------------------------------------------------------------------
-    if (!is_char<'*'>(*std::ranges::begin(stream_view))) // sequence information is given
+    if constexpr (!detail::decays_to_ignore_v<seq_type>)
     {
-        constexpr auto is_legal_alph = char_is_valid_for<seq_legal_alph_type>;
-        auto seq_stream =
-            field_view
-            | std::views::transform(
-                [is_legal_alph](char const c) // enforce legal alphabet
-                {
-                    if (!is_legal_alph(c))
-                        throw parse_error{std::string{"Encountered an unexpected letter: "} + "char_is_valid_for<"
-                                          + detail::type_name_as_string<seq_legal_alph_type>
-                                          + "> evaluated to false on " + detail::make_printable(c)};
-                    return c;
-                });
+        std::string_view const seq_str = raw_record[9];
 
-        if constexpr (detail::decays_to_ignore_v<seq_type>)
+        if (!seq_str.starts_with('*')) // * indicates missing sequence information
         {
-            detail::consume(seq_stream);
+            seq.resize(seq_str.size());
+            constexpr auto is_legal_alph = char_is_valid_for<seq_legal_alph_type>;
+
+            for (size_t i = 0; i < seq_str.size(); ++i)
+            {
+                if (!is_legal_alph(seq_str[i]))
+                    throw parse_error{std::string{"Encountered an unexpected letter: "} + "char_is_valid_for<"
+                                      + detail::type_name_as_string<seq_legal_alph_type>
+                                      + "> evaluated to false on " + detail::make_printable(seq_str[i])};
+
+                seq[i] = assign_char_to(seq_str[i], std::ranges::range_value_t<seq_type>{});
+            }
         }
-        else
-        {
-            read_forward_range_field(seq_stream, seq);
-        }
-    }
-    else
-    {
-        ++std::ranges::begin(field_view); // skip '*'
     }
 
     // Field 11:  Quality
     // -------------------------------------------------------------------------------------------------------------
-    auto const tab_or_end = is_char<'\t'> || is_char<'\r'> || is_char<'\n'>;
-    auto qual_view = stream_view | detail::take_until_or_throw(tab_or_end);
+    // We don't know wether we have 11 or 12 fields, since the tags are optional.
+    // The last field will thus contain either the quality sequence
+    // or the quality sequence AND tags.
+    size_t tag_begin_pos = raw_record[10].find('\t');
+
+    std::string_view qualities =
+        (tag_begin_pos == std::string_view::npos) ? raw_record[10] : raw_record[10].substr(0, tag_begin_pos);
+
     if constexpr (!detail::decays_to_ignore_v<qual_type>)
-        read_forward_range_field(qual_view, qual);
-    else
-        detail::consume(qual_view);
+        read_forward_range_field(qualities, qual);
 
     if constexpr (!detail::decays_to_ignore_v<seq_type> && !detail::decays_to_ignore_v<qual_type>)
     {
@@ -544,17 +521,25 @@ format_sam::read_alignment_record(stream_type & stream,
 
     // All remaining optional fields if any: SAM tags dictionary
     // -------------------------------------------------------------------------------------------------------------
-    while (is_char<'\t'>(*std::ranges::begin(stream_view))) // read all tags if present
+    if constexpr (!detail::decays_to_ignore_v<tag_dict_type>)
     {
-        ++std::ranges::begin(stream_view); // skip tab
-        auto stream_until_tab_or_end = stream_view | detail::take_until_or_throw(tab_or_end);
-        if constexpr (!detail::decays_to_ignore_v<tag_dict_type>)
-            read_sam_dict_field(stream_until_tab_or_end, tag_dict);
-        else
-            detail::consume(stream_until_tab_or_end);
+        while (tag_begin_pos != std::string_view::npos) // read all tags if present
+        {
+            ++tag_begin_pos; // skip '\t'
+            size_t const tag_end_pos = raw_record[10].find('\t', tag_begin_pos);
+
+            char const * tag_begin = raw_record[10].begin() + tag_begin_pos;
+            char const * tag_end =
+                (tag_end_pos == std::string_view::npos) ? raw_record[10].end() : raw_record[10].begin() + tag_end_pos;
+
+            read_sam_dict(std::string_view{tag_begin, tag_end}, tag_dict);
+
+            tag_begin_pos = tag_end_pos;
+        }
     }
 
-    detail::consume(stream_view | detail::take_until(!(is_char<'\r'> || is_char<'\n'>))); // consume new line
+    assert(stream_it == std::default_sentinel_t{} || *stream_it == '\n');
+    ++stream_it; // Move from end of record to the beginning of the next or to the end of the stream.
 }
 
 //!\copydoc sam_file_output_format::write_alignment_record
@@ -809,11 +794,10 @@ inline void format_sam::write_alignment_record(stream_type & stream,
 }
 
 /*!\brief Reads a list of values separated by comma as it is the case for SAM tag arrays.
- * \tparam stream_view_type The type of the stream as a view.
  * \tparam value_type       The type of values to be stored in the tag array.
  *
  * \param[in, out] variant      A std::variant object to store the tag arrays.
- * \param[in, out] stream_view  The stream view to iterate over.
+ * \param[in, out] str          The string_view to parse.
  * \param[in]      value        A temporary value that determines the underlying type of the tag array.
  *
  * \details
@@ -825,28 +809,30 @@ inline void format_sam::write_alignment_record(stream_type & stream,
  * format is not in a correct state (e.g. required fields are not given), but throwing might occur downstream of
  * the actual error.
  */
-template <typename stream_view_type, arithmetic value_type>
+template <arithmetic value_type>
 inline void format_sam::read_sam_dict_vector(seqan3::detail::sam_tag_variant & variant,
-                                             stream_view_type && stream_view,
+                                             std::string_view const str,
                                              value_type value)
 {
-    std::vector<value_type> tmp_vector;
-    while (std::ranges::begin(stream_view) != std::ranges::end(stream_view)) // not fully consumed yet
+    std::vector<value_type> tmp_vector{};
+    size_t start_pos{0};
+    size_t end_pos{0};
+
+    while (start_pos != std::string_view::npos)
     {
-        read_arithmetic_field(stream_view | detail::take_until(is_char<','>), value);
+        end_pos = str.find(',', start_pos);
+        auto end = (end_pos == std::string_view::npos) ? str.end() : str.begin() + end_pos;
+        read_arithmetic_field(std::string_view{str.begin() + start_pos, end}, value);
         tmp_vector.push_back(value);
 
-        if (is_char<','>(*std::ranges::begin(stream_view)))
-            ++std::ranges::begin(stream_view); // skip ','
+        start_pos = (end_pos == std::string_view::npos) ? end_pos : end_pos + 1;
     }
     variant = std::move(tmp_vector);
 }
 
 /*!\brief Reads a list of byte pairs as it is the case for SAM tag byte arrays.
- * \tparam stream_view_type The type of the stream as a view.
- *
  * \param[in, out] variant      A std::variant object to store the tag arrays.
- * \param[in, out] stream_view  The stream view to iterate over.
+ * \param[in, out] str          The string_view to parse.
  *
  * \details
  *
@@ -855,33 +841,37 @@ inline void format_sam::read_sam_dict_vector(seqan3::detail::sam_tag_variant & v
  *
  * The function throws a seqan3::format_error if there was an uneven number of bytes.
  */
-template <typename stream_view_type>
-inline void format_sam::read_sam_byte_vector(seqan3::detail::sam_tag_variant & variant, stream_view_type && stream_view)
+inline void format_sam::read_sam_byte_vector(seqan3::detail::sam_tag_variant & variant, std::string_view const str)
 {
-    std::vector<std::byte> tmp_vector;
-    std::byte value;
+    std::vector<std::byte> tmp_vector{};
+    // std::from_chars cannot directly parse into a std::byte
+    uint8_t dummy_byte{};
 
-    while (std::ranges::begin(stream_view) != std::ranges::end(stream_view)) // not fully consumed yet
+    if (str.size() % 2 != 0)
+        throw format_error{"[CORRUPTED SAM FILE]  Hexadecimal tag must have even number of digits."};
+
+    // H encodes bytes in a hexadecimal format. Two hex values are stored for each byte as characters.
+    // E.g., '1' and 'A' need one byte each and are read as `\x1A`, which is 27 in decimal.
+    for (auto hex_begin = str.begin(), hex_end = str.begin() + 2; hex_begin != str.end(); hex_begin += 2, hex_end += 2)
     {
-        try
-        {
-            read_byte_field(stream_view | detail::take_exactly_or_throw(2), value);
-        }
-        catch (std::exception const & e)
-        {
-            throw format_error{"Hexadecimal tag has an uneven number of digits!"};
-        }
+        auto res = std::from_chars(hex_begin, hex_end, dummy_byte, 16);
 
-        tmp_vector.push_back(value);
+        if (res.ec == std::errc::invalid_argument)
+            throw format_error{std::string("[CORRUPTED SAM FILE] The string '") + std::string(hex_begin, hex_end)
+                               + "' could not be cast into type uint8_t."};
+
+        if (res.ec == std::errc::result_out_of_range)
+            throw format_error{std::string("[CORRUPTED SAM FILE] Casting '") + std::string(str)
+                               + "' into type uint8_t would cause an overflow."};
+
+        tmp_vector.push_back(std::byte{dummy_byte});
     }
 
     variant = std::move(tmp_vector);
 }
 
 /*!\brief Reads the optional tag fields into the seqan3::sam_tag_dictionary.
- * \tparam stream_view_type   The type of the stream as a view.
- *
- * \param[in, out] stream_view  The stream view to iterate over.
+ * \param[in, out] tag_str      The string_view to parse for the sam_tag_dictionary entries.
  * \param[in, out] target       The seqan3::sam_tag_dictionary to store the tag information.
  *
  * \throws seqan3::format_error if any unexpected character or format is encountered.
@@ -895,83 +885,79 @@ inline void format_sam::read_sam_byte_vector(seqan3::detail::sam_tag_variant & v
  * format is not in a correct state (e.g. required fields are not given), but throwing might occur downstream of
  * the actual error.
  */
-template <typename stream_view_type>
-inline void format_sam::read_sam_dict_field(stream_view_type && stream_view, sam_tag_dictionary & target)
+inline void format_sam::read_sam_dict(std::string_view const tag_str, sam_tag_dictionary & target)
 {
     /* Every SAM tag has the format "[TAG]:[TYPE_ID]:[VALUE]", where TAG is a two letter
        name tag which is converted to a unique integer identifier and TYPE_ID is one character in [A,i,Z,H,B,f]
        describing the type for the upcoming VALUES. If TYPE_ID=='B' it signals an array of comma separated
        VALUE's and the inner value type is identified by the character following ':', one of [cCsSiIf].
     */
-    uint16_t tag = static_cast<uint16_t>(*std::ranges::begin(stream_view)) << 8;
-    ++std::ranges::begin(stream_view); // skip char read before
-    tag += static_cast<uint16_t>(*std::ranges::begin(stream_view));
-    ++std::ranges::begin(stream_view); // skip char read before
-    ++std::ranges::begin(stream_view); // skip ':'
-    char type_id = *std::ranges::begin(stream_view);
-    ++std::ranges::begin(stream_view); // skip char read before
-    ++std::ranges::begin(stream_view); // skip ':'
+    assert(tag_str.size() > 5);
+
+    uint16_t tag = static_cast<uint16_t>(tag_str[0]) << 8;
+    tag += static_cast<uint16_t>(tag_str[1]);
+
+    char type_id = tag_str[3];
 
     switch (type_id)
     {
     case 'A': // char
     {
-        target[tag] = static_cast<char>(*std::ranges::begin(stream_view));
-        ++std::ranges::begin(stream_view); // skip char that has been read
+        assert(tag_str.size() == 6);
+        target[tag] = tag_str[5];
         break;
     }
     case 'i': // int32_t
     {
         int32_t tmp;
-        read_arithmetic_field(stream_view, tmp);
+        read_arithmetic_field(tag_str.substr(5), tmp);
         target[tag] = tmp;
         break;
     }
     case 'f': // float
     {
         float tmp;
-        read_arithmetic_field(stream_view, tmp);
+        read_arithmetic_field(tag_str.substr(5), tmp);
         target[tag] = tmp;
         break;
     }
     case 'Z': // string
     {
-        target[tag] = stream_view | ranges::to<std::string>();
+        target[tag] = std::string{tag_str.substr(5)};
         break;
     }
     case 'H':
     {
-        read_sam_byte_vector(target[tag], stream_view);
+        read_sam_byte_vector(target[tag], tag_str.substr(5));
         break;
     }
     case 'B': // Array. Value type depends on second char [cCsSiIf]
     {
-        char array_value_type_id = *std::ranges::begin(stream_view);
-        ++std::ranges::begin(stream_view); // skip char read before
-        ++std::ranges::begin(stream_view); // skip first ','
+        assert(tag_str.size() > 6);
+        char array_value_type_id = tag_str[5];
 
         switch (array_value_type_id)
         {
         case 'c': // int8_t
-            read_sam_dict_vector(target[tag], stream_view, int8_t{});
+            read_sam_dict_vector(target[tag], tag_str.substr(7), int8_t{});
             break;
         case 'C': // uint8_t
-            read_sam_dict_vector(target[tag], stream_view, uint8_t{});
+            read_sam_dict_vector(target[tag], tag_str.substr(7), uint8_t{});
             break;
         case 's': // int16_t
-            read_sam_dict_vector(target[tag], stream_view, int16_t{});
+            read_sam_dict_vector(target[tag], tag_str.substr(7), int16_t{});
             break;
         case 'S': // uint16_t
-            read_sam_dict_vector(target[tag], stream_view, uint16_t{});
+            read_sam_dict_vector(target[tag], tag_str.substr(7), uint16_t{});
             break;
         case 'i': // int32_t
-            read_sam_dict_vector(target[tag], stream_view, int32_t{});
+            read_sam_dict_vector(target[tag], tag_str.substr(7), int32_t{});
             break;
         case 'I': // uint32_t
-            read_sam_dict_vector(target[tag], stream_view, uint32_t{});
+            read_sam_dict_vector(target[tag], tag_str.substr(7), uint32_t{});
             break;
         case 'f': // float
-            read_sam_dict_vector(target[tag], stream_view, float{});
+            read_sam_dict_vector(target[tag], tag_str.substr(7), float{});
             break;
         default:
             throw format_error{std::string("The first character in the numerical ")
@@ -982,7 +968,7 @@ inline void format_sam::read_sam_dict_field(stream_view_type && stream_view, sam
     }
     default:
         throw format_error{std::string("The second character in the numerical id of a "
-                                       "SAM tag must be one of [A,i,Z,H,B,f] but '")
+                                       "SAM tag ([TAG]:[TYPE_ID]:[VALUE]) must be one of [A,i,Z,H,B,f] but '")
                            + type_id + "' was given."};
     }
 }

--- a/include/seqan3/io/stream/detail/fast_istreambuf_iterator.hpp
+++ b/include/seqan3/io/stream/detail/fast_istreambuf_iterator.hpp
@@ -13,8 +13,11 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cassert>
 #include <iterator>
+#include <string>
+#include <vector>
 
 #include <seqan3/io/stream/detail/stream_buffer_exposer.hpp>
 
@@ -38,6 +41,9 @@ class fast_istreambuf_iterator
 private:
     //!\brief Down-cast pointer to the stream-buffer.
     stream_buffer_exposer<char_t, traits_t> * stream_buf = nullptr;
+
+    //!\brief Place to store a range of characters that overlaps stream buffer boundaries.
+    std::string overflow_buffer{};
 
 public:
     /*!\name Associated types
@@ -71,6 +77,132 @@ public:
     }
     //!\}
 
+    //!\brief Cache until `raw_record.size() - 1` occurrences of `field_sep` followed by `record_end` were found.
+    template <typename record_type>
+        requires std::same_as<std::ranges::range_value_t<record_type>, std::string_view>
+    void cache_record_into(char const record_end, char const field_sep, record_type & raw_record)
+    {
+        bool has_overflowed = false;
+        size_t old_count = 0;
+        char * data_begin = stream_buf->gptr(); // point into stream buffer by default
+        size_t const number_of_fields = raw_record.size();
+        size_t number_of_seen_fields = 0;
+        std::vector<size_t> field_positions(number_of_fields, 0u);
+
+        char const * ptr = stream_buf->gptr();
+
+        auto overflow_into_buffer = [&]()
+        {
+            size_t count = stream_buf->egptr() - stream_buf->gptr();
+            has_overflowed = true;
+            overflow_buffer.resize(old_count + count);
+            std::ranges::copy(stream_buf->gptr(), stream_buf->egptr(), overflow_buffer.data() + old_count);
+
+            old_count += count;
+            stream_buf->gbump(count);
+            stream_buf->underflow();
+        };
+
+        while (number_of_seen_fields < number_of_fields - 1)
+        {
+            ptr = std::find(ptr, static_cast<char const *>(stream_buf->egptr()), field_sep);
+
+            if (ptr != stream_buf->egptr()) // found an end of field
+            {
+                field_positions[number_of_seen_fields] = ptr - stream_buf->gptr() + old_count;
+                ++ptr;
+                ++number_of_seen_fields;
+            }
+            else
+            {
+                overflow_into_buffer();
+                assert(stream_buf->gptr() != stream_buf->egptr()); // stream is not at end after overflow
+                ptr = stream_buf->gptr();
+            }
+        }
+
+        size_t count = 0;
+
+        while (true) // Note: Might run idefinitely in release mode if no record_end is in input.
+        {
+            ptr = std::find(ptr, static_cast<char const *>(stream_buf->egptr()), record_end);
+
+            if (ptr == stream_buf->egptr()) // stop_chr could not be found in current buffer
+            {
+                overflow_into_buffer();
+                assert(stream_buf->gptr() != stream_buf->egptr()); // stream is not at end after overflow
+                ptr = stream_buf->gptr();
+            }
+            else
+            {
+                count = ptr - stream_buf->gptr(); // processed characters until stop_chr has been found
+                break;
+            }
+        }
+
+        if (has_overflowed)
+        {
+            // need to copy last data
+            overflow_buffer.resize(old_count + count);
+            std::ranges::copy(stream_buf->gptr(), stream_buf->gptr() + count, overflow_buffer.data() + old_count);
+
+            // make data pointer point into overflow
+            data_begin = overflow_buffer.data();
+        }
+
+        stream_buf->gbump(count);
+
+        // instantiate string_views in raw_record
+        field_positions.back() = old_count + count;
+        raw_record[0] = std::string_view{data_begin, field_positions[0]};
+        for (size_t i = 1; i < number_of_fields; ++i)
+            raw_record[i] = std::string_view{data_begin + field_positions[i - 1] + 1, data_begin + field_positions[i]};
+    }
+
+    //!\brief Cache `size` bytes from input stream.
+    std::string_view cache_bytes(int32_t const size)
+    {
+        std::string_view result;
+
+        if (stream_buf->egptr() - stream_buf->gptr() >= size)
+        {
+            result = std::string_view{stream_buf->gptr(), stream_buf->gptr() + size};
+            stream_buf->gbump(size);
+        }
+        else
+        {
+            overflow_buffer.resize(size);
+
+            int32_t remaining_bytes{size};
+
+            while (stream_buf->egptr() - stream_buf->gptr() < remaining_bytes) // still not fully in buffer
+            {
+                std::ranges::copy(stream_buf->gptr(),
+                                  stream_buf->egptr(),
+                                  overflow_buffer.data() + size - remaining_bytes);
+                size_t const number_of_copied_bytes = stream_buf->egptr() - stream_buf->gptr();
+                remaining_bytes -= number_of_copied_bytes;
+                stream_buf->gbump(number_of_copied_bytes);
+                stream_buf->underflow();
+                assert((remaining_bytes == 0 || stream_buf->egptr() != stream_buf->gptr())
+                       && "I still need to read characters but my stream is at end.");
+            }
+
+            if (remaining_bytes != 0) // In stream_buf but not yet copied to overflow_buffer
+            {
+                std::ranges::copy(stream_buf->gptr(),
+                                  stream_buf->gptr() + remaining_bytes,
+                                  overflow_buffer.data() + size - remaining_bytes);
+
+                stream_buf->gbump(remaining_bytes);
+            }
+
+            result = {overflow_buffer.begin(), overflow_buffer.end()};
+        }
+
+        return result;
+    }
+
     /*!\name Arithmetic operators
      * \{
      */
@@ -78,6 +210,7 @@ public:
     fast_istreambuf_iterator & operator++()
     {
         assert(stream_buf != nullptr);
+
         if ((stream_buf->gptr() + 1) == stream_buf->egptr())
             stream_buf->snextc(); // move right, then underflow()
         else

--- a/include/seqan3/io/stream/detail/fast_istreambuf_iterator.hpp
+++ b/include/seqan3/io/stream/detail/fast_istreambuf_iterator.hpp
@@ -65,7 +65,9 @@ public:
         stream_buf{reinterpret_cast<stream_buffer_exposer<char_t, traits_t> *>(&ibuf)}
     {
         assert(stream_buf != nullptr);
-        stream_buf->underflow(); // ensure the stream buffer has content on construction
+
+        if (stream_buf->gptr() == stream_buf->egptr()) // If current get area is empty,
+            stream_buf->underflow();                   // ensure the stream buffer has content on construction.
     }
     //!\}
 

--- a/test/include/seqan3/test/literal/cigar_literal.hpp
+++ b/test/include/seqan3/test/literal/cigar_literal.hpp
@@ -21,7 +21,7 @@ namespace seqan3::test
 
 SEQAN3_WORKAROUND_LITERAL std::vector<cigar> operator""_cigar(char const * s, std::size_t n)
 {
-    return std::get<0>(seqan3::detail::parse_cigar(std::string_view{s, n}));
+    return seqan3::detail::parse_cigar(std::string_view{s, n});
 }
 
 } // namespace seqan3::test

--- a/test/include/seqan3/test/streambuf.hpp
+++ b/test/include/seqan3/test/streambuf.hpp
@@ -1,0 +1,65 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2022, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2022, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides a stream class with a custom sized underlying buffer.
+ * \author Svenja Mehringer <svenja.mehringer AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <array>
+#include <streambuf>
+
+#include <seqan3/core/platform.hpp>
+
+namespace seqan3::test
+{
+
+/*!\brief Utility class to use a input streambuffer with custom buffer size.
+ *
+ * \attention Currently, this streambuf class only uses the small buffer for the get area (when using input streams).
+ *            The class is extendable for output streams if needed.
+ *
+ * When workin with streams, it is sometimes necessary to test code with a small buffer s.t. edge cases are covered.
+ * An edge case for SAM file IO is, for example, that a record spans the buffer boundary.
+ *
+ * ### input stream usage
+ *
+ * Use the class like this:
+ *
+ * ```
+ * std::istringstream input{"This is what I want to read"};
+ * std::istream & in{input};
+ * std::streambuf * orig = in.rdbuf();
+ * seqan3::test::small_buffer buf(orig);
+ * in.rdbuf(&buf);
+ *
+ * // now use `in` whereever you would normally use `input` directly.
+ * ```
+ */
+template <std::streamsize buffer_size>
+class streambuf_with_custom_buffer_size : public std::streambuf
+{
+    std::streambuf * original_buffer;
+    std::array<char, buffer_size> internal_buffer{};
+
+public:
+    streambuf_with_custom_buffer_size(std::streambuf * buf) : original_buffer(buf)
+    {
+        setg(internal_buffer.data(), internal_buffer.data() + buffer_size, internal_buffer.data() + buffer_size);
+    }
+
+    int underflow()
+    {
+        std::streamsize number_of_characters_read = original_buffer->sgetn(internal_buffer.data(), buffer_size);
+        setg(internal_buffer.data(), internal_buffer.data(), internal_buffer.data() + number_of_characters_read);
+        return (number_of_characters_read == buffer_size) ? *internal_buffer.data() : traits_type::eof();
+    }
+};
+
+} // namespace seqan3::test

--- a/test/unit/io/sam_file/format_bam_test.cpp
+++ b/test/unit/io/sam_file/format_bam_test.cpp
@@ -366,7 +366,7 @@ struct sam_file_read<seqan3::format_bam> : public sam_file_data
         '\x42', '\x41', '\x4D', '\x01', '\x12', '\x00', '\x00', '\x00', '\x40', '\x53', '\x51', '\x09', '\x53', '\x4E',
         '\x3A', '\x72', '\x65', '\x66', '\x09', '\x4C', '\x4E', '\x3A', '\x31', '\x35', '\x30', '\x0A', '\x01', '\x00',
         '\x00', '\x00', '\x04', '\x00', '\x00', '\x00', '\x72', '\x65', '\x66', '\x00', '\x96', '\x00', '\x00', '\x00',
-        '\x4A', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x06', '\x3D',
+        '\x49', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x06', '\x3D',
         '\x49', '\x12', '\x05', '\x00', '\x29', '\x00', '\x04', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00',
         '\x09', '\x00', '\x00', '\x00', '\x2C', '\x01', '\x00', '\x00', '\x72', '\x65', '\x61', '\x64', '\x31', '\x00',
         '\x14', '\x00', '\x00', '\x00', '\x10', '\x00', '\x00', '\x00', '\x12', '\x00', '\x00', '\x00', '\x10', '\x00',
@@ -519,7 +519,7 @@ TEST_F(bam_format, invalid_cigar_op)
 
         std::istringstream stream{wrong_char_in_tag};
         seqan3::sam_file_input fin{stream, this->ref_ids, this->ref_sequences, seqan3::format_bam{}};
-        EXPECT_THROW(fin.begin(), seqan3::format_error);
+        EXPECT_THROW(fin.begin(), seqan3::invalid_char_assignment);
     }
 }
 

--- a/test/unit/io/sam_file/format_sam_test.cpp
+++ b/test/unit/io/sam_file/format_sam_test.cpp
@@ -319,7 +319,7 @@ TEST_F(sam_format, format_error_invalid_cigar)
     std::istringstream istream(std::string("*\t0\t*\t0\t0\t5Z\t*\t0\t0\t*\t*\n"));
     {
         seqan3::sam_file_input fin{istream, seqan3::format_sam{}};
-        EXPECT_THROW(fin.begin(), seqan3::format_error);
+        EXPECT_THROW(fin.begin(), seqan3::invalid_char_assignment);
     }
     // negative number as operation count
     {

--- a/test/unit/io/stream/detail/fast_istreambuf_iterator_test.cpp
+++ b/test/unit/io/stream/detail/fast_istreambuf_iterator_test.cpp
@@ -10,6 +10,7 @@
 #include <iterator>
 
 #include <seqan3/io/stream/detail/fast_istreambuf_iterator.hpp>
+#include <seqan3/test/streambuf.hpp>
 
 TEST(fast_istreambuf_iterator, concept)
 {
@@ -54,3 +55,134 @@ TEST(fast_istreambuf_iterator, comparison)
     EXPECT_TRUE(it != std::default_sentinel);
     EXPECT_TRUE(std::default_sentinel != it);
 }
+
+TEST(fast_istreambuf_iterator, cache_record_into)
+{
+    std::istringstream str{"record\tAAA\tBBB\tCCC\nrecord2\tXXX\tYYY\tZZZ\n"};
+    seqan3::detail::fast_istreambuf_iterator<char> it{*str.rdbuf()};
+
+    std::array<std::string_view, 4> raw_record;
+
+    it.cache_record_into('\n', '\t', raw_record);
+    ++it; // skip newline
+
+    EXPECT_EQ(raw_record[0], "record");
+    EXPECT_EQ(raw_record[1], "AAA");
+    EXPECT_EQ(raw_record[2], "BBB");
+    EXPECT_EQ(raw_record[3], "CCC");
+
+    it.cache_record_into('\n', '\t', raw_record);
+    ++it; // skip newline
+
+    EXPECT_EQ(raw_record[0], "record2");
+    EXPECT_EQ(raw_record[1], "XXX");
+    EXPECT_EQ(raw_record[2], "YYY");
+    EXPECT_EQ(raw_record[3], "ZZZ");
+
+    EXPECT_TRUE(std::default_sentinel == it); // reached end
+}
+
+TEST(fast_istreambuf_iterator, cache_record_into_small_streambuffer)
+{
+    std::istringstream str{"record\tAAA\tBBB\tCCC\nrecord2\tXXX\tYYY\tZZZ\n"};
+    std::istream & in{str};
+    std::streambuf * orig = in.rdbuf();
+    seqan3::test::streambuf_with_custom_buffer_size<3> buf(orig);
+    in.rdbuf(&buf);
+
+    seqan3::detail::fast_istreambuf_iterator<char> it{*in.rdbuf()};
+
+    std::array<std::string_view, 4> raw_record;
+
+    it.cache_record_into('\n', '\t', raw_record);
+    ++it; // skip newline
+
+    EXPECT_EQ(raw_record[0], "record");
+    EXPECT_EQ(raw_record[1], "AAA");
+    EXPECT_EQ(raw_record[2], "BBB");
+    EXPECT_EQ(raw_record[3], "CCC");
+
+    it.cache_record_into('\n', '\t', raw_record);
+    ++it; // skip newline
+
+    EXPECT_EQ(raw_record[0], "record2");
+    EXPECT_EQ(raw_record[1], "XXX");
+    EXPECT_EQ(raw_record[2], "YYY");
+    EXPECT_EQ(raw_record[3], "ZZZ");
+
+    EXPECT_TRUE(std::default_sentinel == it); // reached end
+}
+
+#ifndef NDEBUG
+TEST(debug_fast_istreambuf_iterator, no_record_end_sign_found_after_last_field)
+{
+    std::istringstream str{"record\tAAA\tBBB\tCCC___oh_oh_here_is_no_newline"};
+    seqan3::detail::fast_istreambuf_iterator<char> it{*str.rdbuf()};
+
+    std::array<std::string_view, 4> raw_record;
+
+    EXPECT_DEATH(it.cache_record_into('\n', '\t', raw_record), "");
+}
+
+TEST(debug_fast_istreambuf_iterator, not_enough_field_separation_signs_found)
+{
+    std::istringstream str{"record\tAAA\tBBB___oh_oh_here_is_a_tab_missing_here__CCC\n"};
+    seqan3::detail::fast_istreambuf_iterator<char> it{*str.rdbuf()};
+
+    std::array<std::string_view, 4> raw_record;
+
+    EXPECT_DEATH(it.cache_record_into('\n', '\t', raw_record), "");
+}
+#endif
+
+TEST(fast_istreambuf_iterator, cache_bytes)
+{
+    std::istringstream str{"ABCDEFGHIJKLMNOPQRSTUVWXYZ"};
+    seqan3::detail::fast_istreambuf_iterator<char> it{*str.rdbuf()};
+
+    std::string_view bytes = it.cache_bytes(5);
+    EXPECT_EQ(bytes, "ABCDE");
+
+    bytes = it.cache_bytes(5);
+    EXPECT_EQ(bytes, "FGHIJ");
+}
+
+TEST(fast_istreambuf_iterator, cache_bytes_small_streambuffer)
+{
+    std::istringstream str{"ABCDEFGHIJKLMNOPQRSTUVWXYZ"};
+    std::istream & in{str};
+    std::streambuf * orig = in.rdbuf();
+    seqan3::test::streambuf_with_custom_buffer_size<3> buf(orig);
+    in.rdbuf(&buf);
+
+    seqan3::detail::fast_istreambuf_iterator<char> it{*in.rdbuf()};
+
+    std::string_view bytes = it.cache_bytes(5);
+    EXPECT_EQ(bytes, "ABCDE");
+
+    bytes = it.cache_bytes(5);
+    EXPECT_EQ(bytes, "FGHIJ");
+}
+
+#ifndef NDEBUG
+TEST(debug_fast_istreambuf_iterator, cache_bytes_too_many_bytes)
+{
+    std::istringstream str{"ABCDE"};
+    seqan3::detail::fast_istreambuf_iterator<char> it{*str.rdbuf()};
+
+    EXPECT_DEATH(it.cache_bytes(10), "");
+}
+
+TEST(debug_fast_istreambuf_iterator, cache_bytes_too_many_bytes_small_streambuffer)
+{
+    std::istringstream str{"ABCDE"};
+    std::istream & in{str};
+    std::streambuf * orig = in.rdbuf();
+    seqan3::test::streambuf_with_custom_buffer_size<3> buf(orig);
+    in.rdbuf(&buf);
+
+    seqan3::detail::fast_istreambuf_iterator<char> it{*in.rdbuf()};
+
+    EXPECT_DEATH(it.cache_bytes(10), "");
+}
+#endif


### PR DESCRIPTION
:crossed_fingers: 

### SAM

Benchmark a small SAM file (`/group/ag_abi/gene/benchmark-files/io-test.bam` as SAM):
Before: `Elapsed (wall clock) time (h:mm:ss or m:ss): 0:10.33`
After:  `Elapsed (wall clock) time (h:mm:ss or m:ss): 0:07.60`
Seqan2: `Elapsed (wall clock) time (h:mm:ss or m:ss): 0:06.19`

### BAM

Benchmark a small BAM file (`/group/ag_abi/gene/benchmark-files/io-test.bam`):
Before: `Elapsed (wall clock) time (h:mm:ss or m:ss): 0:07.42`
After:  `Elapsed (wall clock) time (h:mm:ss or m:ss): 0:02.66`
Seqan2: `Elapsed (wall clock) time (h:mm:ss or m:ss): 0:01.47`

Looks like I need to make this pretty s.t. it can be merged.

