### PR TITLE
[FIX] Forward ref_ids to initialise_header_information() in constructors

### DIFF
--- a/include/seqan3/io/sam_file/output.hpp
+++ b/include/seqan3/io/sam_file/output.hpp
@@ -300,7 +300,8 @@ public:
         sam_file_output{filename, selected_field_ids{}}
 
     {
-        initialise_header_information(std::forward<ref_ids_type_>(ref_ids), std::forward<ref_lengths_type>(ref_lengths));
+        initialise_header_information(std::forward<ref_ids_type_>(ref_ids),
+                                      std::forward<ref_lengths_type>(ref_lengths));
     }
 
     /*!\brief Construct from an existing stream and with specified format.
@@ -336,7 +337,8 @@ public:
                     selected_field_ids const & SEQAN3_DOXYGEN_ONLY(fields_tag) = selected_field_ids{}) :
         sam_file_output{std::forward<stream_type>(stream), file_format{}, selected_field_ids{}}
     {
-        initialise_header_information(std::forward<ref_ids_type_>(ref_ids), std::forward<ref_lengths_type>(ref_lengths));
+        initialise_header_information(std::forward<ref_ids_type_>(ref_ids),
+                                      std::forward<ref_lengths_type>(ref_lengths));
     }
     //!\}
 

--- a/include/seqan3/io/sam_file/output.hpp
+++ b/include/seqan3/io/sam_file/output.hpp
@@ -300,7 +300,7 @@ public:
         sam_file_output{filename, selected_field_ids{}}
 
     {
-        initialise_header_information(ref_ids, ref_lengths);
+        initialise_header_information(std::forward<ref_ids_type>(ref_ids), std::forward<ref_lengths_type>(ref_lengths));
     }
 
     /*!\brief Construct from an existing stream and with specified format.
@@ -336,7 +336,7 @@ public:
                     selected_field_ids const & SEQAN3_DOXYGEN_ONLY(fields_tag) = selected_field_ids{}) :
         sam_file_output{std::forward<stream_type>(stream), file_format{}, selected_field_ids{}}
     {
-        initialise_header_information(ref_ids, ref_lengths);
+        initialise_header_information(std::forward<ref_ids_type>(ref_ids), std::forward<ref_lengths_type>(ref_lengths));
     }
     //!\}
 

--- a/include/seqan3/io/sam_file/output.hpp
+++ b/include/seqan3/io/sam_file/output.hpp
@@ -658,7 +658,7 @@ protected:
 
         header_ptr = std::make_unique<sam_file_header<ref_ids_type>>(std::forward<ref_ids_type_>(ref_ids));
 
-        for (int32_t idx = 0; idx < std::ranges::distance(ref_ids); ++idx)
+        for (int32_t idx = 0; idx < std::ranges::distance(header_ptr->ref_ids()); ++idx)
         {
             header_ptr->ref_id_info.emplace_back(ref_lengths[idx], "");
 

--- a/include/seqan3/io/sam_file/output.hpp
+++ b/include/seqan3/io/sam_file/output.hpp
@@ -300,7 +300,7 @@ public:
         sam_file_output{filename, selected_field_ids{}}
 
     {
-        initialise_header_information(std::forward<ref_ids_type>(ref_ids), std::forward<ref_lengths_type>(ref_lengths));
+        initialise_header_information(std::forward<ref_ids_type_>(ref_ids), std::forward<ref_lengths_type>(ref_lengths));
     }
 
     /*!\brief Construct from an existing stream and with specified format.
@@ -336,7 +336,7 @@ public:
                     selected_field_ids const & SEQAN3_DOXYGEN_ONLY(fields_tag) = selected_field_ids{}) :
         sam_file_output{std::forward<stream_type>(stream), file_format{}, selected_field_ids{}}
     {
-        initialise_header_information(std::forward<ref_ids_type>(ref_ids), std::forward<ref_lengths_type>(ref_lengths));
+        initialise_header_information(std::forward<ref_ids_type_>(ref_ids), std::forward<ref_lengths_type>(ref_lengths));
     }
     //!\}
 

--- a/test/unit/io/sam_file/sam_file_output_test.cpp
+++ b/test/unit/io/sam_file/sam_file_output_test.cpp
@@ -370,6 +370,29 @@ TEST(row, print_header_in_file)
     EXPECT_EQ(reinterpret_cast<std::ostringstream &>(fout.get_stream()).str(), expected_out);
 }
 
+// https://github.com/seqan/seqan3/pull/3125
+TEST(row, issue3125)
+{
+    seqan3::sam_file_output fout{std::ostringstream{},
+                                 std::vector<std::string>{"ref1", "ref2"},
+                                 std::vector<int32_t>{234511, 243243},
+                                 seqan3::format_sam{},
+                                 seqan3::fields<seqan3::field::id>{}};
+
+    fout.emplace_back(std::string("read1"));
+
+    fout.get_stream().flush();
+
+    std::string const expected_out{
+        "@HD\tVN:1.6\n"
+        "@SQ\tSN:ref1\tLN:234511\n"
+        "@SQ\tSN:ref2\tLN:243243\n"
+        "read1\t0\t*\t0\t0\t*\t*\t0\t0\t*\t*\n" // empty read
+    };
+
+    EXPECT_EQ(reinterpret_cast<std::ostringstream &>(fout.get_stream()).str(), expected_out);
+}
+
 TEST(row, print_header_in_record)
 {
     std::vector<std::string> const ref_ids{"ref1", "ref2"};

--- a/test/unit/io/sam_file/sam_file_output_test.cpp
+++ b/test/unit/io/sam_file/sam_file_output_test.cpp
@@ -370,8 +370,8 @@ TEST(row, print_header_in_file)
     EXPECT_EQ(reinterpret_cast<std::ostringstream &>(fout.get_stream()).str(), expected_out);
 }
 
-// https://github.com/seqan/seqan3/pull/3125
-TEST(row, issue3125)
+// https://github.com/seqan/seqan3/issues/3124
+TEST(row, issue3124)
 {
     seqan3::sam_file_output fout{std::ostringstream{},
                                  std::vector<std::string>{"ref1", "ref2"},


### PR DESCRIPTION
– The passed value needs to be forwarded since it can be an rvalue reference.

<!--
Please see https://github.com/seqan/seqan3/blob/master/CONTRIBUTING.md for a general overview.

Please allow edits from maintainers:
https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests

Once you create the PR, clang-format will be run on the PR, and any formatting changes will be pushed to your fork.
Subsequently, the actual CI will start.

****************************************************************************************************
** Attention: This means that you will have to `git pull` the changes before pushing new commits. **
****************************************************************************************************

Each of your commits will trigger a clang-format commit if there are formatting changes.


While the following guide on rebasing formatting changes is intended for internal use by SeqAn members, and in no way
necessary for contributors, it may still be an interesting read: https://github.com/seqan/seqan3/wiki/Rebasing-clang-format-commits-with-git-absorb
-->
