### PR TITLE
[FIX] skip newlines when reading FASTA with char.

### DIFF
--- a/include/seqan3/io/sequence_file/format_fasta.hpp
+++ b/include/seqan3/io/sequence_file/format_fasta.hpp
@@ -309,13 +309,13 @@ private:
 
             for (; (it != e) && ((!is_id)(*it)); ++it)
             {
-                if (is_legal_alph(*it))
-                {
-                    seq.push_back(assign_char_to(*it, std::ranges::range_value_t<seq_type>{}));
-                }
-                else if ((is_space || is_digit)(*it))
+                if ((is_space || is_digit)(*it))
                 {
                     continue;
+                }
+                else if (is_legal_alph(*it))
+                {
+                    seq.push_back(assign_char_to(*it, std::ranges::range_value_t<seq_type>{}));
                 }
                 else
                 {


### PR DESCRIPTION
This error was introduced by https://github.com/seqan/seqan3/pull/3104

Fixes #3126 

<!--
Please see https://github.com/seqan/seqan3/blob/master/CONTRIBUTING.md for a general overview.

Please allow edits from maintainers:
https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests

Once you create the PR, clang-format will be run on the PR, and any formatting changes will be pushed to your fork.
Subsequently, the actual CI will start.

****************************************************************************************************
** Attention: This means that you will have to `git pull` the changes before pushing new commits. **
****************************************************************************************************

Each of your commits will trigger a clang-format commit if there are formatting changes.


While the following guide on rebasing formatting changes is intended for internal use by SeqAn members, and in no way
necessary for contributors, it may still be an interesting read: https://github.com/seqan/seqan3/wiki/Rebasing-clang-format-commits-with-git-absorb
-->
