### PR TITLE
[FIX] Relax sequence_file_input_traits

### DIFF
--- a/include/seqan3/io/sequence_file/input.hpp
+++ b/include/seqan3/io/sequence_file/input.hpp
@@ -64,8 +64,8 @@ namespace seqan3
  * \brief Alphabet of the characters for the seqan3::field::seq; must satisfy seqan3::alphabet.
  */
 /*!\typedef using sequence_legal_alphabet
- * \brief Intermediate alphabet for seqan3::field::seq; must satisfy seqan3::alphabet and be convertible to
- * `sequence_alphabet`.
+ * \brief Intermediate alphabet for seqan3::field::seq; must satisfy seqan3::alphabet and be either convertible to
+ * `sequence_alphabet` or a character type.
  *
  * \details
  *
@@ -99,7 +99,8 @@ concept sequence_file_input_traits =
     requires (t v) {
         requires writable_alphabet<typename t::sequence_alphabet>;
         requires writable_alphabet<typename t::sequence_legal_alphabet>;
-        requires explicitly_convertible_to<typename t::sequence_legal_alphabet, typename t::sequence_alphabet>;
+        requires detail::is_char_adaptation_v<typename t::sequence_alphabet>
+                     || explicitly_convertible_to<typename t::sequence_legal_alphabet, typename t::sequence_alphabet>;
         requires sequence_container<typename t::template sequence_container<typename t::sequence_alphabet>>;
 
         requires writable_alphabet<typename t::id_alphabet>;
@@ -228,7 +229,8 @@ public:
     using field_ids = fields<field::seq, field::id, field::qual>;
 
     static_assert(
-        []() constexpr {
+        []() constexpr
+        {
             for (field f : selected_field_ids::as_array)
                 if (!field_ids::contains(f))
                     return false;

--- a/test/unit/io/sequence_file/sequence_file_format_fasta_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_format_fasta_test.cpp
@@ -119,7 +119,7 @@ TEST_F(read, whitespace_in_seq)
 struct char_traits : public seqan3::sequence_file_input_default_traits_dna
 {
     using sequence_alphabet = char;
-    using sequence_legal_alphabet = char;
+    using sequence_legal_alphabet = seqan3::dna4;
 };
 using sequence_file_type = seqan3::sequence_file_input<char_traits,
                                                        seqan3::fields<seqan3::field::id, seqan3::field::seq>,


### PR DESCRIPTION
`explicitly_convertible_to<typename t::sequence_legal_alphabet, typename t::sequence_alphabet>` is meant for allowing, e.g.:

```cpp
using sequence_alphabet = seqan3::dna4;
using sequence_legal_alphabet = seqan3::dna15; // or even seqan3::rna15
```
but not stuff like
```cpp
using sequence_alphabet = seqan3::dna4;
using sequence_legal_alphabet = seqan3::aa27;
```

However, this constraint is also checked for `using sequence_alphabet = char`. Our alphabets are not (explicitly/implicitly) convertible to char.
The rationale of the alphabets being compatible doesn't apply for `sequence_alphabet = char`, so we should just allow it.

```cpp
using sequence_alphabet = char;
using sequence_legal_alphabet = seqan3::dna4;
```
means: Only allow characters of `seqan3::dna4`, but store them as `char`.