### PR TITLE
spin_delay.hpp: fix for Darwin PPC

### DIFF
--- a/include/seqan3/utility/parallel/detail/spin_delay.hpp
+++ b/include/seqan3/utility/parallel/detail/spin_delay.hpp
@@ -87,8 +87,12 @@ private:
         __asm__ __volatile__("yield" ::: "memory");
 #elif defined(__ia64__)                                            // IA64
         __asm__ __volatile__("hint @pause");
-#elif defined(__powerpc__) || defined(__ppc__) || defined(__PPC__) // PowerPC
+#elif defined(__powerpc__) || defined(__ppc__) || defined(__PPC__) || defined(__ppc64__) // PowerPC
+    #ifdef __APPLE__
+        __asm__ volatile("or r27,r27,r27" ::: "memory");
+    #else
         __asm__ __volatile__("or 27,27,27" ::: "memory");
+    #endif
 #else                                                              // everything else.
         asm volatile("nop" ::: "memory"); // default operation - does nothing => Might lead to passive spinning.
 #endif

--- a/include/seqan3/utility/parallel/detail/spin_delay.hpp
+++ b/include/seqan3/utility/parallel/detail/spin_delay.hpp
@@ -83,17 +83,17 @@ private:
 #elif defined(__armel__)                                                                                               \
     || defined(__ARMEL__) // arm, but broken? ; repeat of default case as armel also defines __arm__
         asm volatile("nop" ::: "memory"); // default operation - does nothing => Might lead to passive spinning.
-#elif defined(__arm__) || defined(__aarch64__)                     // arm big endian / arm64
+#elif defined(__arm__) || defined(__aarch64__)                                           // arm big endian / arm64
         __asm__ __volatile__("yield" ::: "memory");
-#elif defined(__ia64__)                                            // IA64
+#elif defined(__ia64__)                                                                  // IA64
         __asm__ __volatile__("hint @pause");
 #elif defined(__powerpc__) || defined(__ppc__) || defined(__PPC__) || defined(__ppc64__) // PowerPC
-    #ifdef __APPLE__
+#    ifdef __APPLE__
         __asm__ volatile("or r27,r27,r27" ::: "memory");
-    #else
+#    else
         __asm__ __volatile__("or 27,27,27" ::: "memory");
-    #endif
-#else                                                              // everything else.
+#    endif
+#else // everything else.
         asm volatile("nop" ::: "memory"); // default operation - does nothing => Might lead to passive spinning.
 #endif
     }


### PR DESCRIPTION
Current assembler is wrong for Darwin PPC, it won’t work and even build. In addition to accommodate ppc64 on Darwin, `__ppc64__` should be added (or otherwise `__POWERPC__`).