### PR TITLE
[FIX] deprecated const& version of benchmark::DoNotOptimize

### DIFF
--- a/test/performance/alphabet/alphabet_assign_char_benchmark.cpp
+++ b/test/performance/alphabet/alphabet_assign_char_benchmark.cpp
@@ -78,8 +78,13 @@ void assign_char_seqan2(benchmark::State & state)
 
     alphabet_t a{};
     for (auto _ : state)
+    {
         for (char c : chars)
-            benchmark::DoNotOptimize(a = c);
+        {
+            a = c;
+            benchmark::DoNotOptimize(a);
+        }
+    }
 }
 
 BENCHMARK_TEMPLATE(assign_char_seqan2, seqan::Dna);

--- a/test/performance/alphabet/alphabet_assign_rank_benchmark.cpp
+++ b/test/performance/alphabet/alphabet_assign_rank_benchmark.cpp
@@ -87,8 +87,13 @@ void assign_rank_seqan2(benchmark::State & state)
 
     alphabet_t a{};
     for (auto _ : state)
+    {
         for (rank_t r : ranks)
-            benchmark::DoNotOptimize(a = r);
+        {
+            a = r;
+            benchmark::DoNotOptimize(a);
+        }
+    }
 }
 
 BENCHMARK_TEMPLATE(assign_rank_seqan2, seqan::Dna);

--- a/test/performance/alphabet/alphabet_to_char_benchmark.cpp
+++ b/test/performance/alphabet/alphabet_to_char_benchmark.cpp
@@ -51,8 +51,13 @@ void to_char(benchmark::State & state)
     std::array<alphabet_t, 256> alphs = create_alphabet_array<alphabet_t, false>();
 
     for (auto _ : state)
+    {
         for (alphabet_t a : alphs)
-            benchmark::DoNotOptimize(seqan3::to_char(a));
+        {
+            char c = seqan3::to_char(a);
+            benchmark::DoNotOptimize(c);
+        }
+    }
 }
 
 /* regular alphabets, sorted by size */
@@ -96,8 +101,13 @@ void to_char_seqan2(benchmark::State & state)
     std::array<alphabet_t, 256> alphs = create_alphabet_array<alphabet_t, true>();
 
     for (auto _ : state)
+    {
         for (alphabet_t a : alphs)
-            benchmark::DoNotOptimize(static_cast<char>(a));
+        {
+            char c = static_cast<char>(a);
+            benchmark::DoNotOptimize(c);
+        }
+    }
 }
 
 BENCHMARK_TEMPLATE(to_char_seqan2, seqan::Dna);

--- a/test/performance/alphabet/alphabet_to_rank_benchmark.cpp
+++ b/test/performance/alphabet/alphabet_to_rank_benchmark.cpp
@@ -45,8 +45,13 @@ void to_rank(benchmark::State & state)
     std::array<alphabet_t, 256> alphs = create_alphabet_array<alphabet_t, false>(seqan3::alphabet_size<alphabet_t>);
 
     for (auto _ : state)
+    {
         for (alphabet_t a : alphs)
-            benchmark::DoNotOptimize(seqan3::to_rank(a));
+        {
+            auto rank = seqan3::to_rank(a);
+            benchmark::DoNotOptimize(rank);
+        }
+    }
 }
 
 /* regular alphabets, sorted by size */
@@ -90,8 +95,13 @@ void to_rank_seqan2(benchmark::State & state)
     std::array<alphabet_t, 256> alphs = create_alphabet_array<alphabet_t, true>(seqan::ValueSize<alphabet_t>::VALUE);
 
     for (auto _ : state)
+    {
         for (alphabet_t a : alphs)
-            benchmark::DoNotOptimize(seqan::ordValue(a));
+        {
+            auto ord_value = seqan::ordValue(a);
+            benchmark::DoNotOptimize(ord_value);
+        }
+    }
 }
 
 BENCHMARK_TEMPLATE(to_rank_seqan2, seqan::Dna);

--- a/test/performance/alphabet/views/view_translate_1D_benchmark.cpp
+++ b/test/performance/alphabet/views/view_translate_1D_benchmark.cpp
@@ -36,8 +36,13 @@ template <typename rng_t>
 void sequential_read_impl(benchmark::State & state, rng_t && rng)
 {
     for (auto _ : state)
+    {
         for (seqan3::aa27 c : rng)
-            benchmark::DoNotOptimize(c.to_rank());
+        {
+            auto rank = c.to_rank();
+            benchmark::DoNotOptimize(rank);
+        }
+    }
 }
 
 template <typename tag_t>
@@ -69,8 +74,13 @@ template <typename rng_t>
 void random_access_impl(benchmark::State & state, rng_t && rng, std::vector<size_t> const & access_positions)
 {
     for (auto _ : state)
+    {
         for (auto pos : access_positions)
-            benchmark::DoNotOptimize(rng[pos].to_rank());
+        {
+            auto access = rng[pos].to_rank();
+            benchmark::DoNotOptimize(access);
+        }
+    }
 }
 
 template <typename tag_t>

--- a/test/performance/alphabet/views/view_translate_2D_1D_benchmark.cpp
+++ b/test/performance/alphabet/views/view_translate_2D_1D_benchmark.cpp
@@ -40,9 +40,16 @@ template <typename rng_t>
 void sequential_read_impl(benchmark::State & state, rng_t && rng)
 {
     for (auto _ : state)
+    {
         for (auto && outer : rng)
+        {
             for (seqan3::aa27 inner : outer)
-                benchmark::DoNotOptimize(inner.to_rank());
+            {
+                auto rank = inner.to_rank();
+                benchmark::DoNotOptimize(rank);
+            }
+        }
+    }
 }
 
 template <typename tag_t>
@@ -88,9 +95,16 @@ void random_access_impl(benchmark::State & state,
                         std::vector<size_t> const & access_positions_inner)
 {
     for (auto _ : state)
+    {
         for (auto outer : access_positions_outer)
+        {
             for (auto inner : access_positions_inner)
-                benchmark::DoNotOptimize(rng[outer][inner].to_rank());
+            {
+                auto access = rng[outer][inner].to_rank();
+                benchmark::DoNotOptimize(access);
+            }
+        }
+    }
 }
 
 template <typename tag_t>

--- a/test/performance/alphabet/views/view_translate_2D_benchmark.cpp
+++ b/test/performance/alphabet/views/view_translate_2D_benchmark.cpp
@@ -40,8 +40,13 @@ template <typename rng_t>
 void sequential_read_impl(benchmark::State & state, rng_t && rng)
 {
     for (auto _ : state)
+    {
         for (auto && outer : rng)
-            benchmark::DoNotOptimize(outer[0].to_rank());
+        {
+            auto rank = outer[0].to_rank();
+            benchmark::DoNotOptimize(rank);
+        }
+    }
 }
 
 template <typename tag_t>
@@ -84,8 +89,13 @@ template <typename rng_t>
 void random_access_impl(benchmark::State & state, rng_t && rng, std::vector<size_t> const & access_positions)
 {
     for (auto _ : state)
+    {
         for (auto pos : access_positions)
-            benchmark::DoNotOptimize(rng[pos][0].to_rank());
+        {
+            auto access = rng[pos][0].to_rank();
+            benchmark::DoNotOptimize(access);
+        }
+    }
 }
 
 template <typename tag_t>

--- a/test/performance/range/container_assignment_benchmark.cpp
+++ b/test/performance/range/container_assignment_benchmark.cpp
@@ -43,15 +43,16 @@ struct assignment_functor
         requires (id == tag::std_copy)
     static constexpr void call(container_t & to, container_t const & from) noexcept
     {
-        benchmark::DoNotOptimize(std::copy(std::ranges::begin(from), std::ranges::end(from), std::ranges::begin(to)));
+        std::copy(std::ranges::begin(from), std::ranges::end(from), std::ranges::begin(to));
+        benchmark::DoNotOptimize(to);
     }
 
     template <typename container_t>
         requires (id == tag::uninitialized_copy)
     static constexpr void call(container_t & to, container_t const & from) noexcept
     {
-        benchmark::DoNotOptimize(
-            std::uninitialized_copy(std::ranges::begin(from), std::ranges::end(from), std::ranges::begin(to)));
+        std::uninitialized_copy(std::ranges::begin(from), std::ranges::end(from), std::ranges::begin(to));
+        benchmark::DoNotOptimize(to);
     }
 };
 

--- a/test/performance/range/gap_decorator_rand_read_benchmark.cpp
+++ b/test/performance/range/gap_decorator_rand_read_benchmark.cpp
@@ -68,7 +68,10 @@ void read_random(benchmark::State & state)
     for (auto _ : state)
     {
         for (k = 0; k < 10; ++k)
-            benchmark::DoNotOptimize(gap_decorator[access_positions[j + k]]);
+        {
+            auto access = gap_decorator[access_positions[j + k]];
+            benchmark::DoNotOptimize(access);
+        }
         ++j;
         j %= (1 << 10) - 10;
     }

--- a/test/performance/range/gap_decorator_seq_read_benchmark.cpp
+++ b/test/performance/range/gap_decorator_seq_read_benchmark.cpp
@@ -54,7 +54,8 @@ void read_left2right(benchmark::State & state)
     auto it = std::ranges::begin(gap_decorator);
     for (auto _ : state)
     {
-        benchmark::DoNotOptimize(*it++);
+        auto deref_postincrement = *it++;
+        benchmark::DoNotOptimize(deref_postincrement);
         if (it == std::ranges::end(gap_decorator))
             it = std::ranges::begin(gap_decorator);
     }

--- a/test/performance/std/bit_benchmark.cpp
+++ b/test/performance/std/bit_benchmark.cpp
@@ -19,11 +19,20 @@ static void is_power_of_two_popcount(benchmark::State & state)
     {
         n = std::rand();
         if constexpr (std::is_same_v<size_type, unsigned long long>)
-            benchmark::DoNotOptimize(__builtin_popcountll(n) == 1);
+        {
+            bool result = __builtin_popcountll(n) == 1;
+            benchmark::DoNotOptimize(result);
+        }
         else if constexpr (std::is_same_v<size_type, unsigned long>)
-            benchmark::DoNotOptimize(__builtin_popcountl(n) == 1);
+        {
+            bool result = __builtin_popcountl(n) == 1;
+            benchmark::DoNotOptimize(result);
+        }
         else if constexpr (std::is_same_v<size_type, unsigned>)
-            benchmark::DoNotOptimize(__builtin_popcount(n) == 1);
+        {
+            bool result = __builtin_popcount(n) == 1;
+            benchmark::DoNotOptimize(result);
+        }
         else
             static_assert(std::is_same_v<size_type, void>, "FAILED");
     }
@@ -39,7 +48,8 @@ static void is_power_of_two_arithmetic(benchmark::State & state)
     for (auto _ : state)
     {
         n = std::rand();
-        benchmark::DoNotOptimize(n > 0 && (n & (n - 1)) == 0);
+        bool result = n > 0 && (n & (n - 1)) == 0;
+        benchmark::DoNotOptimize(result);
     }
 }
 BENCHMARK(is_power_of_two_arithmetic);
@@ -51,7 +61,8 @@ static void is_power_of_two_std(benchmark::State & state)
     for (auto _ : state)
     {
         n = std::rand();
-        benchmark::DoNotOptimize(std::has_single_bit(n));
+        bool result = std::has_single_bit(n);
+        benchmark::DoNotOptimize(result);
     }
 }
 BENCHMARK(is_power_of_two_std);
@@ -63,7 +74,8 @@ static void next_power_of_two_std(benchmark::State & state)
     for (auto _ : state)
     {
         n = std::rand();
-        benchmark::DoNotOptimize(std::bit_ceil(n));
+        bool result = std::bit_ceil(n);
+        benchmark::DoNotOptimize(result);
     }
 }
 BENCHMARK(next_power_of_two_std);

--- a/test/performance/utility/bloom_filter/bloom_filter_benchmark.cpp
+++ b/test/performance/utility/bloom_filter/bloom_filter_benchmark.cpp
@@ -76,7 +76,10 @@ void contains_benchmark(::benchmark::State & state)
     for (auto _ : state)
     {
         for (auto hash : hash_values)
-            benchmark::DoNotOptimize(bf.contains(hash));
+        {
+            bool result = bf.contains(hash);
+            benchmark::DoNotOptimize(result);
+        }
     }
 
     state.counters["hashes/sec"] = hashes_per_second(std::ranges::size(hash_values));
@@ -89,7 +92,8 @@ void count_benchmark(::benchmark::State & state)
 
     for (auto _ : state)
     {
-        benchmark::DoNotOptimize(bf.count(hash_values));
+        size_t result = bf.count(hash_values);
+        benchmark::DoNotOptimize(result);
     }
 
     state.counters["hashes/sec"] = hashes_per_second(std::ranges::size(hash_values));


### PR DESCRIPTION
Resolves #2747 

Change: https://github.com/google/benchmark/commit/53df805dc820d720734d6538032f6b73f31f13ba
Example of fix: https://github.com/google/benchmark/commit/f15f332fd1ae10ae6d13d816af9bcf3b196974cc