### PR TITLE
[FIX] invalid redeclaration

### DIFF
--- a/include/seqan3/alignment/matrix/detail/two_dimensional_matrix.hpp
+++ b/include/seqan3/alignment/matrix/detail/two_dimensional_matrix.hpp
@@ -333,7 +333,6 @@ private:
 
     //!\brief Befriend the base crtp class.
     template <typename derived_t, matrix_major_order other_order>
-        requires is_value_specialisation_of_v<derived_t, basic_iterator> && (other_order == order)
     friend class two_dimensional_matrix_iterator_base;
 
     //!\brief Befriend the corresponding const iterator.

--- a/include/seqan3/alignment/matrix/detail/two_dimensional_matrix_iterator_base.hpp
+++ b/include/seqan3/alignment/matrix/detail/two_dimensional_matrix_iterator_base.hpp
@@ -81,7 +81,6 @@ private:
 
     //!\brief Befriend other base class types for const iterator compatibility.
     template <typename other_derived_t, matrix_major_order other_order>
-        requires (order == other_order)
     friend class two_dimensional_matrix_iterator_base;
 
     /*!\name Constructors, destructor and assignment

--- a/include/seqan3/utility/views/pairwise_combine.hpp
+++ b/include/seqan3/utility/views/pairwise_combine.hpp
@@ -254,7 +254,6 @@ class pairwise_combine_view<underlying_range_type>::basic_iterator :
 private:
     //!\brief Friend declaration for iterator with different range const-ness.
     template <typename other_range_type>
-        requires std::same_as<std::remove_const_t<range_type>, std::remove_const_t<other_range_type>>
     friend class basic_iterator;
 
     //!\brief Alias type for the iterator over the passed range type.


### PR DESCRIPTION
> A constrained declaration may only be redeclared using the same syntactic form. No diagnostic is required.

Resolves #3138 