### PR TITLE
[MISC] gcc 13: silence bogus warnings

### DIFF
--- a/test/unit/alignment/matrix/detail/debug_matrix_test.cpp
+++ b/test/unit/alignment/matrix/detail/debug_matrix_test.cpp
@@ -220,6 +220,7 @@ struct debug_matrix_traits<seqan3::detail::debug_matrix<matrix_t, first_sequence
 };
 
 #pragma GCC diagnostic push
+// Ignore bogus warnings in fortified gcc13 build
 #if defined(_FORTIFY_SOURCE) && (_FORTIFY_SOURCE == 2) // _FORTIFY_SOURCE=2 may cause conforming programs to fail
 #    pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif

--- a/test/unit/alignment/matrix/detail/debug_matrix_test.cpp
+++ b/test/unit/alignment/matrix/detail/debug_matrix_test.cpp
@@ -219,6 +219,11 @@ struct debug_matrix_traits<seqan3::detail::debug_matrix<matrix_t, first_sequence
     using second_sequence_type = second_sequence_t;
 };
 
+#pragma GCC diagnostic push
+#if defined(_FORTIFY_SOURCE) && (_FORTIFY_SOURCE == 2) // _FORTIFY_SOURCE=2 may cause conforming programs to fail
+#    pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+
 TEST_F(debug_matrix_test, matrix_concept)
 {
     EXPECT_TRUE((seqan3::detail::matrix<seqan3::detail::row_wise_matrix<int>>));
@@ -620,3 +625,5 @@ TEST_F(trace_matrix_test, transpose_matrix_rvalue)
 
     EXPECT_EQ(transpose_matrix, transposed_trace_matrix);
 }
+
+#pragma GCC diagnostic pop


### PR DESCRIPTION
Part of https://github.com/seqan/seqan3/issues/3138

Locally,
```
global_affine_banded_collection_simd_test.cpp
global_affine_unbanded_collection_simd_test.cpp
global_affine_unbanded_collection_simd_aa27_test.cpp
```
still fail with ICE:
```
/seqan3/test/unit/alignment/pairwise/global_affine_unbanded_collection_simd_aa27_test.cpp:64:96: error: type variant with ‘TYPE_ALIAS_SET_KNOWN_P’
   64 |                                pairwise_collection_simd_global_affine_unbanded_testing_types, );
      |                                                                                                ^
 <vector_type 0x7f349293cb28
    type <integer_type 0x7f349ba255e8 int sizes-gimplified asm_written public type_6 SI
        size <integer_cst 0x7f349ba27210 constant 32>
        unit-size <integer_cst 0x7f349ba27228 constant 4>
        align:32 warn_if_not_align:0 symtab:-1754356800 alias-set 37 canonical-type 0x7f349ba255e8 precision:32 min <integer_cst 0x7f349ba271c8 -2147483648> max <integer_cst 0x7f349ba271e0 2147483647>
        pointer_to_this <pointer_type 0x7f349ba2db28> reference_to_this <reference_type 0x7f349a92ebd0>>
    sizes-gimplified asm_written type_6 V1SI size <integer_cst 0x7f349ba27210 32> unit-size <integer_cst 0x7f349ba27228 4>
    align:32 warn_if_not_align:0 symtab:-2009639760 alias-set 37 canonical-type 0x7f349293cb28 nunits:1
    pointer_to_this <pointer_type 0x7f3492715498> reference_to_this <reference_type 0x7f3484e5ef18>>
 <vector_type 0x7f3482b283f0
    type <integer_type 0x7f349ba255e8 int sizes-gimplified asm_written public type_6 SI
        size <integer_cst 0x7f349ba27210 constant 32>
        unit-size <integer_cst 0x7f349ba27228 constant 4>
        align:32 warn_if_not_align:0 symtab:-1754356800 alias-set 37 canonical-type 0x7f349ba255e8 precision:32 min <integer_cst 0x7f349ba271c8 -2147483648> max <integer_cst 0x7f349ba271e0 2147483647>
        pointer_to_this <pointer_type 0x7f349ba2db28> reference_to_this <reference_type 0x7f349a92ebd0>>
    sizes-gimplified type_6 V1SI size <integer_cst 0x7f349ba27210 32> unit-size <integer_cst 0x7f349ba27228 4>
    align:32 warn_if_not_align:0 symtab:0 alias-set 37 canonical-type 0x7f349293cb28 nunits:1>
during IPA pass: *free_lang_data
/seqan3/test/unit/alignment/pairwise/global_affine_unbanded_collection_simd_aa27_test.cpp:64:96: internal compiler error: ‘verify_type’ failed
0x155b06e verify_type(tree_node const*)
        /home/infri/compiler/gcc/gcc/tree.cc:14286
0x2198887 free_lang_data
        /home/infri/compiler/gcc/gcc/ipa-free-lang-data.cc:1134
0x2198887 execute
        /home/infri/compiler/gcc/gcc/ipa-free-lang-data.cc:1176
Please submit a full bug report, with preprocessed source (by using -freport-bug).
Please include the complete backtrace with any bug report.
See <https://gcc.gnu.org/bugzilla/> for instructions.
gmake[3]: *** [alignment/pairwise/CMakeFiles/global_affine_unbanded_collection_simd_aa27_test.dir/build.make:76: alignment/pairwise/CMakeFiles/global_affine_unbanded_collection_simd_aa27_test.dir/global_affine_unbanded_collection_simd_aa27_test.cpp.o] Error 1
gmake[3]: Target 'alignment/pairwise/CMakeFiles/global_affine_unbanded_collection_simd_aa27_test.dir/build' not remade because of errors.
gmake[2]: *** [CMakeFiles/Makefile2:3592: alignment/pairwise/CMakeFiles/global_affine_unbanded_collection_simd_aa27_test.dir/all] Error 2
gmake[1]: *** [CMakeFiles/Makefile2:3599: alignment/pairwise/CMakeFiles/global_affine_unbanded_collection_simd_aa27_test.dir/rule] Error 2
gmake[1]: Target 'global_affine_unbanded_collection_simd_aa27_test' not remade because of errors.
gmake: *** [Makefile:940: global_affine_unbanded_collection_simd_aa27_test] Error 2
```

Might be related to `-flto` being used in the fedora-nightlies.