### PR TITLE
[INFRA] Make CMake more flexible

### DIFF
--- a/.github/workflows/cron_latest_libraries.yml
+++ b/.github/workflows/cron_latest_libraries.yml
@@ -52,15 +52,15 @@ jobs:
 
       - name: Update googletest
         run: |
-          grep 'gtest_git_tag ".*"' seqan3/test/cmake/seqan3_require_test.cmake
-          sed -i 's/gtest_git_tag ".*"/gtest_git_tag "main"/' seqan3/test/cmake/seqan3_require_test.cmake
-          grep 'gtest_git_tag ".*"' seqan3/test/cmake/seqan3_require_test.cmake
+          grep 'SEQAN3_GTEST_TAG ".*"' seqan3/test/cmake/seqan3_require_test.cmake
+          sed -i 's/SEQAN3_GTEST_TAG ".*"/SEQAN3_GTEST_TAG "main"/' seqan3/test/cmake/seqan3_require_test.cmake
+          grep 'SEQAN3_GTEST_TAG ".*"' seqan3/test/cmake/seqan3_require_test.cmake
 
       - name: Update googlebenchmark
         run: |
-          grep 'gbenchmark_git_tag ".*"' seqan3/test/cmake/seqan3_require_benchmark.cmake
-          sed -i 's/gbenchmark_git_tag ".*"/gbenchmark_git_tag "main"/' seqan3/test/cmake/seqan3_require_benchmark.cmake
-          grep 'gbenchmark_git_tag ".*"' seqan3/test/cmake/seqan3_require_benchmark.cmake
+          grep 'SEQAN3_BENCHMARK_TAG ".*"' seqan3/test/cmake/seqan3_require_benchmark.cmake
+          sed -i 's/SEQAN3_BENCHMARK_TAG ".*"/SEQAN3_BENCHMARK_TAG "main"/' seqan3/test/cmake/seqan3_require_benchmark.cmake
+          grep 'SEQAN3_BENCHMARK_TAG ".*"' seqan3/test/cmake/seqan3_require_benchmark.cmake
 
       - name: Checkout SeqAn2
         uses: actions/checkout@v3

--- a/test/cmake/seqan3_require_benchmark.cmake
+++ b/test/cmake/seqan3_require_benchmark.cmake
@@ -12,25 +12,25 @@ cmake_minimum_required (VERSION 3.16)
 macro (seqan3_require_benchmark)
     enable_testing ()
 
-    set (benchmark_version "1.8.2")
-    set (gbenchmark_git_tag "v${benchmark_version}")
+    set (SEQAN3_BENCHMARK_TAG "v1.8.2")
 
-    find_package (benchmark ${benchmark_version} EXACT QUIET)
+    find_package (benchmark QUIET)
 
-    if (NOT benchmark_FOUND)
-        message (STATUS "Fetching Google Benchmark ${benchmark_version}")
+    # Also ensure that Google Benchmark if fetched for the latest library cron, which sets the tag to "main".
+    if (NOT benchmark_FOUND OR "${SEQAN3_BENCHMARK_TAG}" STREQUAL "main")
+        message (STATUS "Fetching Google Benchmark ${SEQAN3_BENCHMARK_TAG}")
 
         include (FetchContent)
         FetchContent_Declare (
             gbenchmark_fetch_content
             GIT_REPOSITORY "https://github.com/google/benchmark.git"
-            GIT_TAG "${gbenchmark_git_tag}")
+            GIT_TAG "${SEQAN3_BENCHMARK_TAG}")
         option (BENCHMARK_ENABLE_TESTING "" OFF)
         option (BENCHMARK_ENABLE_WERROR "" OFF) # Does not apply to Debug builds.
         option (BENCHMARK_ENABLE_INSTALL "" OFF)
         FetchContent_MakeAvailable (gbenchmark_fetch_content)
     else ()
-        message (STATUS "Found Google Benchmark ${benchmark_version}")
+        message (STATUS "  Test dependency:            Google Benchmark ${benchmark_VERSION} found.")
     endif ()
 
     # NOTE: google benchmark's CMakeLists.txt already defines Shlwapi

--- a/test/cmake/seqan3_require_test.cmake
+++ b/test/cmake/seqan3_require_test.cmake
@@ -12,24 +12,24 @@ cmake_minimum_required (VERSION 3.16)
 macro (seqan3_require_test)
     enable_testing ()
 
-    set (gtest_version "1.13.0")
-    set (gtest_git_tag "v${gtest_version}")
+    set (SEQAN3_GTEST_TAG "v1.13.0")
 
-    find_package (GTest ${gtest_version} EXACT QUIET)
+    find_package (GTest QUIET)
 
-    if (NOT GTest_FOUND)
-        message (STATUS "Fetching Google Test ${gtest_version}")
+    # Also ensure that Google Test if fetched for the latest library cron, which sets the tag to "main".
+    if (NOT GTest_FOUND OR "${SEQAN3_GTEST_TAG}" STREQUAL "main")
+        message (STATUS "Fetching Google Test ${SEQAN3_GTEST_TAG}")
 
         include (FetchContent)
         FetchContent_Declare (
             gtest_fetch_content
             GIT_REPOSITORY "https://github.com/google/googletest.git"
-            GIT_TAG "${gtest_git_tag}")
+            GIT_TAG "${SEQAN3_GTEST_TAG}")
         option (BUILD_GMOCK "" OFF)
         option (INSTALL_GTEST "" OFF)
         FetchContent_MakeAvailable (gtest_fetch_content)
     else ()
-        message (STATUS "Found Google Test ${gtest_version}")
+        message (STATUS "  Test dependency:            Google Test ${GTest_VERSION} found.")
     endif ()
 
     if (NOT TARGET gtest_build)

--- a/test/documentation/seqan3-doxygen.cmake
+++ b/test/documentation/seqan3-doxygen.cmake
@@ -47,20 +47,40 @@ if (SEQAN3_VERCEL_PREVIEW_DOC)
 endif ()
 
 ### Download and extract cppreference-doxygen-web.tag.xml for std:: documentation links
-set (SEQAN3_DOXYGEN_STD_TAGFILE "${PROJECT_BINARY_DIR}/cppreference-doxygen-web.tag.xml")
-include (ExternalProject)
-ExternalProject_Add (
-    download-cppreference-doxygen-web-tag
-    URL "https://github.com/PeterFeicht/cppreference-doc/releases/download/v20220730/html-book-20220730.tar.xz"
-    URL_HASH SHA256=71f15003c168b8dc5a00cbaf19b6480a9b3e87ab7e462aa39edb63d7511c028b
-    TLS_VERIFY ON
-    DOWNLOAD_DIR "${PROJECT_BINARY_DIR}"
-    DOWNLOAD_NAME "html-book.tar.xz"
-    DOWNLOAD_NO_EXTRACT YES
-    BINARY_DIR "${PROJECT_BINARY_DIR}"
-    CONFIGURE_COMMAND /bin/sh -c "xzcat html-book.tar.xz | tar -xf - cppreference-doxygen-web.tag.xml"
-    BUILD_COMMAND rm "html-book.tar.xz"
-    INSTALL_COMMAND "")
+# SEQAN3_DOXYGEN_STD_TAGFILE can be used to point to an existing tag file (cppreference-doxygen-web.tag.xml).
+# If SEQAN3_DOXYGEN_STD_TAGFILE is set by the user and the file exists, it will be copied.
+# If SEQAN3_DOXYGEN_STD_TAGFILE is not set by the user, or it is set by the user, but the file does not exist,
+# the tag file will be downloaded.
+set (SEQAN3_DEFAULT_DOXYGEN_STD_TAGFILE "${PROJECT_BINARY_DIR}/cppreference-doxygen-web.tag.xml")
+set (SEQAN3_DOXYGEN_STD_TAGFILE
+     "${SEQAN3_DEFAULT_DOXYGEN_STD_TAGFILE}"
+     CACHE STRING "Path to cppreference-doxygen-web.tag.xml")
+if (NOT EXISTS "${SEQAN3_DOXYGEN_STD_TAGFILE}" OR SEQAN3_DOXYGEN_STD_TAGFILE STREQUAL
+                                                  "${SEQAN3_DEFAULT_DOXYGEN_STD_TAGFILE}")
+    message (STATUS "Tag file will be fetched.")
+    # Reset path in case it was set from the outside, but does not exist.
+    set (SEQAN3_DOXYGEN_STD_TAGFILE "${SEQAN3_DEFAULT_DOXYGEN_STD_TAGFILE}")
+    include (ExternalProject)
+    ExternalProject_Add (
+        download-cppreference-doxygen-web-tag
+        URL "https://github.com/PeterFeicht/cppreference-doc/releases/download/v20220730/html-book-20220730.tar.xz"
+        URL_HASH SHA256=71f15003c168b8dc5a00cbaf19b6480a9b3e87ab7e462aa39edb63d7511c028b
+        TLS_VERIFY ON
+        DOWNLOAD_DIR "${PROJECT_BINARY_DIR}"
+        DOWNLOAD_NAME "html-book.tar.xz"
+        DOWNLOAD_NO_EXTRACT YES
+        BINARY_DIR "${PROJECT_BINARY_DIR}"
+        BUILD_BYPRODUCTS "${SEQAN3_DOXYGEN_STD_TAGFILE}"
+        CONFIGURE_COMMAND /bin/sh -c "xzcat html-book.tar.xz | tar -xf - cppreference-doxygen-web.tag.xml"
+        BUILD_COMMAND rm "html-book.tar.xz"
+        INSTALL_COMMAND "")
+else ()
+    message (STATUS "Copying existing tag file: ${SEQAN3_DOXYGEN_STD_TAGFILE}")
+    # Copy tag file such that it is present in the built documentation. This is useful if the documentation is
+    # subsequently deployed to a server.
+    configure_file ("${SEQAN3_DOXYGEN_STD_TAGFILE}" "${SEQAN3_DEFAULT_DOXYGEN_STD_TAGFILE}" COPYONLY)
+    set (SEQAN3_DOXYGEN_STD_TAGFILE "${SEQAN3_DEFAULT_DOXYGEN_STD_TAGFILE}")
+endif ()
 
 ### TEST HELPER
 


### PR DESCRIPTION
https://salsa.debian.org/med-team/seqan3/-/tree/40f5a781a90f31c0fd7df199405e4f9bb3989a0a/debian/patches

Commit 1 makes `find_package` accept any Google Test and Google Benchmark version.
`find_package(GTest)` ignores the version specifier anyway.
[Relevant patch](https://salsa.debian.org/med-team/seqan3/-/blob/40f5a781a90f31c0fd7df199405e4f9bb3989a0a/debian/patches/better_gtest_benchmark_finding)

Commit 2 adds an option to pass a path to a tag file, which is then copied.
[Relevant patch](https://salsa.debian.org/med-team/seqan3/-/blob/40f5a781a90f31c0fd7df199405e4f9bb3989a0a/debian/patches/debian_cppreference)
CMake solution:
```bash
cmake [...] -DSEQAN3_DOXYGEN_STD_TAGFILE=/usr/share/devhelp/books/cppreference-doxygen-web.tag.xml
```

Other patches:
* [Doxygen config patch](https://salsa.debian.org/med-team/seqan3/-/blob/40f5a781a90f31c0fd7df199405e4f9bb3989a0a/debian/patches/docs_fix): This is due to mismatching doxygen versions. We kinda only support the version we currently use, because doxygen often has breaking changes.
* [Post-install test license dir](https://salsa.debian.org/med-team/seqan3/-/blob/40f5a781a90f31c0fd7df199405e4f9bb3989a0a/debian/patches/fix_autopkgtests): IMO this should be resolvable via passing `-DSEQAN3_CLONE_DIR=...` to CMake.