### PR TITLE
[MISC] Use correct comparison.

### DIFF
--- a/include/seqan3/search/views/minimiser.hpp
+++ b/include/seqan3/search/views/minimiser.hpp
@@ -460,7 +460,7 @@ private:
             return true;
         }
 
-        if (new_value < minimiser_value)
+        if (new_value <= minimiser_value)
         {
             minimiser_value = new_value;
             minimiser_position_offset = window_values.size() - 1;
@@ -507,8 +507,6 @@ struct minimiser_fn
     template <std::ranges::range urng1_t>
     constexpr auto operator()(urng1_t && urange1, size_t const window_size) const
     {
-        static_assert(std::ranges::viewable_range<urng1_t>,
-                      "The range parameter to views::minimiser cannot be a temporary of a non-view range.");
         static_assert(std::ranges::forward_range<urng1_t>,
                       "The range parameter to views::minimiser must model std::ranges::forward_range.");
 


### PR DESCRIPTION
I think, we need to use "<=" as we use everywhere else ´std::less_equal´, but I could not think about an easy example where we could test the difference.

The second change I added because I am running with minions in that static assert and as I implemented the minimiser and don't really know why the statis assert is there to begin with, I was hoping, we could just delete it? :)