### PR TITLE
[FIX] std::result_of_t

### DIFF
--- a/include/seqan3/io/views/detail/take_until_view.hpp
+++ b/include/seqan3/io/views/detail/take_until_view.hpp
@@ -54,7 +54,7 @@ private:
     static_assert(std::invocable<fun_t, std::ranges::range_reference_t<urng_t>>,
                   "The functor type for detail::take_until must model"
                   "std::invocable<fun_t, std::ranges::range_reference_t<urng_t>>.");
-    static_assert(std::convertible_to<std::result_of_t<fun_t && (std::ranges::range_reference_t<urng_t>)>, bool>,
+    static_assert(std::convertible_to<std::invoke_result_t<fun_t &&, std::ranges::range_reference_t<urng_t>>, bool>,
                   "The result type of the functor for detail::take_until must be a boolean.");
 
     //!\brief The underlying range.


### PR DESCRIPTION
deprecated since c++17, removed in c++20

<!--
Please see https://github.com/seqan/seqan3/blob/master/CONTRIBUTING.md for a general overview.

Please allow edits from maintainers:
https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests

Once you create the PR, clang-format will be run on the PR, and any formatting changes will be pushed to your fork.
Subsequently, the actual CI will start.

****************************************************************************************************
** Attention: This means that you will have to `git pull` the changes before pushing new commits. **
****************************************************************************************************

Each of your commits will trigger a clang-format commit if there are formatting changes.


While the following guide on rebasing formatting changes is intended for internal use by SeqAn members, and in no way
necessary for contributors, it may still be an interesting read: https://github.com/seqan/seqan3/wiki/Rebasing-clang-format-commits-with-git-absorb
-->
