### PR TITLE
[FIX] Disable SeqAn2 OpenMP benchmark on clang

### DIFF
--- a/test/performance/alignment/global_affine_alignment_parallel_benchmark.cpp
+++ b/test/performance/alignment/global_affine_alignment_parallel_benchmark.cpp
@@ -160,7 +160,8 @@ void seqan2_affine_dna4_parallel(benchmark::State & state)
 BENCHMARK_TEMPLATE(seqan2_affine_dna4_parallel, score)->UseRealTime();
 #endif // SEQAN3_HAS_SEQAN2
 
-#if defined(SEQAN3_HAS_SEQAN2) && defined(_OPENMP)
+// Crashes with libc++
+#if defined(SEQAN3_HAS_SEQAN2) && defined(_OPENMP) && !defined(_LIBCPP_VERSION)
 template <typename result_t>
 void seqan2_affine_dna4_omp_for(benchmark::State & state)
 {
@@ -201,7 +202,7 @@ void seqan2_affine_dna4_omp_for(benchmark::State & state)
 
 BENCHMARK_TEMPLATE(seqan2_affine_dna4_omp_for, score)->UseRealTime();
 BENCHMARK_TEMPLATE(seqan2_affine_dna4_omp_for, trace)->UseRealTime();
-#endif // defined(SEQAN3_HAS_SEQAN2) && defined(_OPENMP)
+#endif // defined(SEQAN3_HAS_SEQAN2) && defined(_OPENMP) && !defined(_LIBCPP_VERSION)
 
 // ============================================================================
 //  instantiate tests


### PR DESCRIPTION
<!--
Please see https://github.com/seqan/seqan3/blob/master/CONTRIBUTING.md for a general overview.

Please allow edits from maintainers:
https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests

Once you create the PR, clang-format will be run on the PR, and any formatting changes will be pushed to your fork.
Subsequently, the actual CI will start.

****************************************************************************************************
** Attention: This means that you will have to `git pull` the changes before pushing new commits. **
****************************************************************************************************

Each of your commits will trigger a clang-format commit if there are formatting changes.


While the following guide on rebasing formatting changes is intended for internal use by SeqAn members, and in no way
necessary for contributors, it may still be an interesting read: https://github.com/seqan/seqan3/wiki/Rebasing-clang-format-commits-with-git-absorb
-->
