### PR TITLE
[INFRA] Add IntelLLVM CI

### DIFF
--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -62,6 +62,12 @@ jobs:
             build: unit
             build_type: Release
 
+          - name: "IntelLLVM"
+            compiler: "intel"
+            build: unit
+            build_type: Release
+            cxx_flags: "-fp-model=strict"
+
     steps:
       - name: Checkout SeqAn3
         uses: actions/checkout@v4
@@ -84,6 +90,7 @@ jobs:
           ccache_size: 75M
 
       - name: Install CMake
+        if: contains(matrix.compiler, 'intel') == false
         uses: seqan/actions/setup-cmake@main
         with:
           cmake: 3.16.9

--- a/.github/workflows/ci_misc.yml
+++ b/.github/workflows/ci_misc.yml
@@ -48,6 +48,13 @@ jobs:
             build_type: Release
             test_threads: 1 # snippets create and delete files and some separate tests create/delete the same files
 
+          - name: "Snippet IntelLLVM"
+            compiler: "intel"
+            build: snippet
+            build_type: Release
+            test_threads: 1 # snippets create and delete files and some separate tests create/delete the same files
+            cxx_flags: "-fp-model=strict"
+
           - name: "Performance clang17 libc++"
             compiler: "clang-17"
             build: performance
@@ -60,6 +67,13 @@ jobs:
             build: performance
             build_type: Release
             test_threads: 2
+
+          - name: "Performance IntelLLVM"
+            compiler: "intel"
+            build: performance
+            build_type: Release
+            test_threads: 2
+            cxx_flags: "-fp-model=strict"
 
           - name: "Header clang17 libc++"
             compiler: "clang-17"
@@ -96,6 +110,7 @@ jobs:
           fetch-depth: 1
 
       - name: Install CMake
+        if: contains(matrix.compiler, 'intel') == false
         uses: seqan/actions/setup-cmake@main
         with:
           cmake: 3.16.9

--- a/test/performance/alignment/global_affine_alignment_parallel_benchmark.cpp
+++ b/test/performance/alignment/global_affine_alignment_parallel_benchmark.cpp
@@ -157,8 +157,8 @@ void seqan2_affine_dna4_parallel(benchmark::State & state)
 BENCHMARK_TEMPLATE(seqan2_affine_dna4_parallel, score)->UseRealTime();
 #endif // SEQAN3_HAS_SEQAN2
 
-// Crashes with libc++
-#if defined(SEQAN3_HAS_SEQAN2) && defined(_OPENMP) && !defined(_LIBCPP_VERSION)
+// Crashes with libc++ or IntelLLVM
+#if defined(SEQAN3_HAS_SEQAN2) && defined(_OPENMP) && !defined(_LIBCPP_VERSION) && !defined(__INTEL_LLVM_COMPILER)
 template <typename result_t>
 void seqan2_affine_dna4_omp_for(benchmark::State & state)
 {
@@ -199,7 +199,7 @@ void seqan2_affine_dna4_omp_for(benchmark::State & state)
 
 BENCHMARK_TEMPLATE(seqan2_affine_dna4_omp_for, score)->UseRealTime();
 BENCHMARK_TEMPLATE(seqan2_affine_dna4_omp_for, trace)->UseRealTime();
-#endif // defined(SEQAN3_HAS_SEQAN2) && defined(_OPENMP) && !defined(_LIBCPP_VERSION)
+#endif // defined(SEQAN3_HAS_SEQAN2) && defined(_OPENMP) && !defined(_LIBCPP_VERSION) && !defined(__INTEL_LLVM_COMPILER)
 
 // ============================================================================
 //  instantiate tests

--- a/test/seqan3-test.cmake
+++ b/test/seqan3-test.cmake
@@ -11,6 +11,7 @@ cmake_minimum_required (VERSION 3.10)
 # require SeqAn3 package
 find_package (SeqAn3 REQUIRED HINTS ${CMAKE_CURRENT_LIST_DIR}/../build_system)
 
+include (CheckCXXCompilerFlag)
 include (CheckCXXSourceCompiles)
 include (FindPackageHandleStandardArgs)
 include (FindPackageMessage)
@@ -80,7 +81,8 @@ if (NOT TARGET seqan3::test::performance)
     # std::views::join is experimental in libc++
     target_compile_definitions (seqan3_test_performance INTERFACE _LIBCPP_ENABLE_EXPERIMENTAL)
 
-    if (SEQAN3_BENCHMARK_ALIGN_LOOPS)
+    check_cxx_compiler_flag ("-falign-loops=32" SEQAN3_HAS_FALIGN_LOOPS)
+    if (SEQAN3_BENCHMARK_ALIGN_LOOPS AND SEQAN3_HAS_FALIGN_LOOPS)
         target_compile_options (seqan3_test_performance INTERFACE "-falign-loops=32")
     endif ()
 


### PR DESCRIPTION
Second commit:

The result of
```cpp
to_little_endian(*reinterpret_cast<uint16_t const *>(&header[10]))
```
is erroneous due to some optimization (the Intel compiler uses some more aggressive optimization by default). The cast is probably undefined (or at least unspecified) behavior.

Usually, this is because the value is not properly bound to `in` in
```cpp
template <std::integral type>
constexpr type to_little_endian(type const in) noexcept
```

This also occasionally happens with other compilers.

My solution is to either use the left or right byte, depending on the endianness. Since we cast to `uint16_t`, and only compare one byte, the correct byte should be either of the two. Currently, we do not officially support / test big endian archs.
