### PR TITLE
FEATURE: add seqan3::default_printer

### DIFF
--- a/include/seqan3/alignment/aligned_sequence/debug_stream_alignment.hpp
+++ b/include/seqan3/alignment/aligned_sequence/debug_stream_alignment.hpp
@@ -101,13 +101,6 @@ namespace seqan3
  *
  * \return The given stream to which the alignment representation is appended.
  */
-#if 0
-template <typename char_t, typename alignment_t>
-    requires (detail::debug_streamable_tuple<alignment_t>
-              && detail::all_model_aligned_seq<detail::tuple_type_list_t<std::remove_cvref_t<alignment_t>>>)
-inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & stream, alignment_t && alignment)
-{
-#else
 template <typename alignment_t>
     requires (tuple_like<std::remove_cvref_t<alignment_t>> && detail::all_model_aligned_seq<detail::tuple_type_list_t<std::remove_cvref_t<alignment_t>>>)
 struct alignment_printer<alignment_t>
@@ -121,10 +114,5 @@ struct alignment_printer<alignment_t>
     detail::stream_alignment(stream, alignment, std::make_index_sequence<sequence_count - 1>{});
     };
 };
-#endif
-#if 0
-    return stream;
-}
-#endif
 
 } // namespace seqan3

--- a/include/seqan3/alignment/aligned_sequence/debug_stream_alignment.hpp
+++ b/include/seqan3/alignment/aligned_sequence/debug_stream_alignment.hpp
@@ -102,16 +102,17 @@ namespace seqan3
  * \return The given stream to which the alignment representation is appended.
  */
 template <typename alignment_t>
-    requires (tuple_like<std::remove_cvref_t<alignment_t>> && detail::all_model_aligned_seq<detail::tuple_type_list_t<std::remove_cvref_t<alignment_t>>>)
+    requires (tuple_like<std::remove_cvref_t<alignment_t>>
+              && detail::all_model_aligned_seq<detail::tuple_type_list_t<std::remove_cvref_t<alignment_t>>>)
 struct alignment_printer<alignment_t>
 {
-    constexpr static auto print = [](auto & stream, auto && alignment)
+    static constexpr auto print = [](auto & stream, auto && alignment)
     {
-    constexpr size_t sequence_count = std::tuple_size_v<std::remove_cvref_t<alignment_t>>;
+        constexpr size_t sequence_count = std::tuple_size_v<std::remove_cvref_t<alignment_t>>;
 
-    static_assert(sequence_count >= 2, "An alignment requires at least two sequences.");
+        static_assert(sequence_count >= 2, "An alignment requires at least two sequences.");
 
-    detail::stream_alignment(stream, alignment, std::make_index_sequence<sequence_count - 1>{});
+        detail::stream_alignment(stream, alignment, std::make_index_sequence<sequence_count - 1>{});
     };
 };
 

--- a/include/seqan3/alignment/aligned_sequence/debug_stream_alignment.hpp
+++ b/include/seqan3/alignment/aligned_sequence/debug_stream_alignment.hpp
@@ -101,17 +101,30 @@ namespace seqan3
  *
  * \return The given stream to which the alignment representation is appended.
  */
+#if 0
 template <typename char_t, typename alignment_t>
     requires (detail::debug_streamable_tuple<alignment_t>
               && detail::all_model_aligned_seq<detail::tuple_type_list_t<std::remove_cvref_t<alignment_t>>>)
 inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & stream, alignment_t && alignment)
 {
+#else
+template <typename alignment_t>
+    requires (tuple_like<std::remove_cvref_t<alignment_t>> && detail::all_model_aligned_seq<detail::tuple_type_list_t<std::remove_cvref_t<alignment_t>>>)
+struct alignment_printer<alignment_t>
+{
+    constexpr static auto print = [](auto & stream, auto && alignment)
+    {
     constexpr size_t sequence_count = std::tuple_size_v<std::remove_cvref_t<alignment_t>>;
 
     static_assert(sequence_count >= 2, "An alignment requires at least two sequences.");
 
     detail::stream_alignment(stream, alignment, std::make_index_sequence<sequence_count - 1>{});
+    };
+};
+#endif
+#if 0
     return stream;
 }
+#endif
 
 } // namespace seqan3

--- a/include/seqan3/alignment/matrix/detail/advanceable_alignment_coordinate.hpp
+++ b/include/seqan3/alignment/matrix/detail/advanceable_alignment_coordinate.hpp
@@ -304,13 +304,27 @@ namespace seqan3
  *
  * Prints the alignment coordinate as a tuple.
  */
+#if 0
 template <typename char_t, typename coordinate_type>
     requires detail::is_value_specialisation_of_v<std::remove_cvref_t<coordinate_type>,
                                                   detail::advanceable_alignment_coordinate>
 inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, coordinate_type && c)
 {
+#else
+template <typename coordinate_type>
+    requires detail::is_value_specialisation_of_v<std::remove_cvref_t<coordinate_type>,
+                                                  detail::advanceable_alignment_coordinate>
+struct advanceable_alignment_coordinate_printer<coordinate_type>
+{
+    constexpr static auto print = [](auto & s, coordinate_type const & c)
+    {
     s << std::tie(c.first, c.second);
+    };
+};
+#endif
+#if 0
     return s;
 }
+#endif
 
 } // namespace seqan3

--- a/include/seqan3/alignment/matrix/detail/advanceable_alignment_coordinate.hpp
+++ b/include/seqan3/alignment/matrix/detail/advanceable_alignment_coordinate.hpp
@@ -309,9 +309,9 @@ template <typename coordinate_type>
                                                   detail::advanceable_alignment_coordinate>
 struct advanceable_alignment_coordinate_printer<coordinate_type>
 {
-    constexpr static auto print = [](auto & s, coordinate_type const & c)
+    static constexpr auto print = [](auto & s, coordinate_type const & c)
     {
-    s << std::tie(c.first, c.second);
+        s << std::tie(c.first, c.second);
     };
 };
 

--- a/include/seqan3/alignment/matrix/detail/advanceable_alignment_coordinate.hpp
+++ b/include/seqan3/alignment/matrix/detail/advanceable_alignment_coordinate.hpp
@@ -304,13 +304,6 @@ namespace seqan3
  *
  * Prints the alignment coordinate as a tuple.
  */
-#if 0
-template <typename char_t, typename coordinate_type>
-    requires detail::is_value_specialisation_of_v<std::remove_cvref_t<coordinate_type>,
-                                                  detail::advanceable_alignment_coordinate>
-inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, coordinate_type && c)
-{
-#else
 template <typename coordinate_type>
     requires detail::is_value_specialisation_of_v<std::remove_cvref_t<coordinate_type>,
                                                   detail::advanceable_alignment_coordinate>
@@ -321,10 +314,5 @@ struct advanceable_alignment_coordinate_printer<coordinate_type>
     s << std::tie(c.first, c.second);
     };
 };
-#endif
-#if 0
-    return s;
-}
-#endif
 
 } // namespace seqan3

--- a/include/seqan3/alignment/matrix/detail/debug_matrix.hpp
+++ b/include/seqan3/alignment/matrix/detail/debug_matrix.hpp
@@ -476,11 +476,6 @@ namespace seqan3
  *
  * This prints out an alignment matrix which can be a score matrix or a trace matrix.
  */
-#if 0
-template <typename char_t, detail::matrix alignment_matrix_t>
-inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, alignment_matrix_t && matrix)
-{
-#else
 template <typename alignment_matrix_t>
     requires detail::matrix<std::remove_cvref_t<alignment_matrix_t>>
 struct alignment_matrix_printer<alignment_matrix_t>
@@ -494,20 +489,5 @@ struct alignment_matrix_printer<alignment_matrix_t>
     s << sstream.str();
     };
 };
-#endif
-#if 0
-    return s;
-}
-#endif
-
-#if 0
-//!\overload
-template <typename char_t, std::ranges::input_range alignment_matrix_t>
-    requires detail::debug_stream_range_guard<alignment_matrix_t> && detail::matrix<alignment_matrix_t>
-inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, alignment_matrix_t && matrix)
-{
-    return s << detail::debug_matrix{std::forward<alignment_matrix_t>(matrix)};
-}
-#endif
 
 } // namespace seqan3

--- a/include/seqan3/alignment/matrix/detail/debug_matrix.hpp
+++ b/include/seqan3/alignment/matrix/detail/debug_matrix.hpp
@@ -480,13 +480,13 @@ template <typename alignment_matrix_t>
     requires detail::matrix<std::remove_cvref_t<alignment_matrix_t>>
 struct alignment_matrix_printer<alignment_matrix_t>
 {
-    constexpr static auto print = [](auto & s, auto && matrix)
+    static constexpr auto print = [](auto & s, auto && matrix)
     {
-    detail::debug_matrix debug{std::forward<alignment_matrix_t>(matrix)};
+        detail::debug_matrix debug{std::forward<alignment_matrix_t>(matrix)};
 
-    std::stringstream sstream{};
-    debug.stream_matrix(sstream, s.flags2());
-    s << sstream.str();
+        std::stringstream sstream{};
+        debug.stream_matrix(sstream, s.flags2());
+        s << sstream.str();
     };
 };
 

--- a/include/seqan3/alignment/matrix/detail/debug_matrix.hpp
+++ b/include/seqan3/alignment/matrix/detail/debug_matrix.hpp
@@ -476,17 +476,31 @@ namespace seqan3
  *
  * This prints out an alignment matrix which can be a score matrix or a trace matrix.
  */
+#if 0
 template <typename char_t, detail::matrix alignment_matrix_t>
 inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, alignment_matrix_t && matrix)
 {
+#else
+template <typename alignment_matrix_t>
+    requires detail::matrix<std::remove_cvref_t<alignment_matrix_t>>
+struct alignment_matrix_printer<alignment_matrix_t>
+{
+    constexpr static auto print = [](auto & s, auto && matrix)
+    {
     detail::debug_matrix debug{std::forward<alignment_matrix_t>(matrix)};
 
     std::stringstream sstream{};
     debug.stream_matrix(sstream, s.flags2());
     s << sstream.str();
+    };
+};
+#endif
+#if 0
     return s;
 }
+#endif
 
+#if 0
 //!\overload
 template <typename char_t, std::ranges::input_range alignment_matrix_t>
     requires detail::debug_stream_range_guard<alignment_matrix_t> && detail::matrix<alignment_matrix_t>
@@ -494,5 +508,6 @@ inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, ali
 {
     return s << detail::debug_matrix{std::forward<alignment_matrix_t>(matrix)};
 }
+#endif
 
 } // namespace seqan3

--- a/include/seqan3/alignment/matrix/detail/trace_directions.hpp
+++ b/include/seqan3/alignment/matrix/detail/trace_directions.hpp
@@ -72,11 +72,6 @@ inline constexpr bool add_enum_bitwise_operators<seqan3::detail::trace_direction
  * | seqan3::detail::trace_directions::left_open | ←    | L     |
  * | seqan3::detail::trace_directions::left      | ⇠    | l     |
  */
-#if 0
-template <typename char_t>
-inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, detail::trace_directions const trace)
-{
-#else
 template <typename trace_directions_t>
     requires std::is_same_v<std::remove_cvref_t<trace_directions_t>, detail::trace_directions>
 struct trace_directions_printer<trace_directions_t>
@@ -97,10 +92,5 @@ struct trace_directions_printer<trace_directions_t>
     s << trace_dir[static_cast<size_t>(trace)];
     };
 };
-#endif
-#if 0
-    return s;
-}
-#endif
 
 } // namespace seqan3

--- a/include/seqan3/alignment/matrix/detail/trace_directions.hpp
+++ b/include/seqan3/alignment/matrix/detail/trace_directions.hpp
@@ -72,9 +72,17 @@ inline constexpr bool add_enum_bitwise_operators<seqan3::detail::trace_direction
  * | seqan3::detail::trace_directions::left_open | ←    | L     |
  * | seqan3::detail::trace_directions::left      | ⇠    | l     |
  */
+#if 0
 template <typename char_t>
 inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, detail::trace_directions const trace)
 {
+#else
+template <typename trace_directions_t>
+    requires std::is_same_v<std::remove_cvref_t<trace_directions_t>, detail::trace_directions>
+struct trace_directions_printer<trace_directions_t>
+{
+    constexpr static auto print = [](auto & s, detail::trace_directions const trace)
+    {
     static char const * unicode[32]{"↺",   "↖",    "↑",   "↖↑",  "⇡",    "↖⇡",   "↑⇡",  "↖↑⇡",  "←",    "↖←",   "↑←",
                                     "↖↑←", "⇡←",   "↖⇡←", "↑⇡←", "↖↑⇡←", "⇠",    "↖⇠",  "↑⇠",   "↖↑⇠",  "⇡⇠",   "↖⇡⇠",
                                     "↑⇡⇠", "↖↑⇡⇠", "←⇠",  "↖←⇠", "↑←⇠",  "↖↑←⇠", "⇡←⇠", "↖⇡←⇠", "↑⇡←⇠", "↖↑⇡←⇠"};
@@ -87,7 +95,12 @@ inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, det
     auto const & trace_dir = is_unicode ? unicode : csv;
 
     s << trace_dir[static_cast<size_t>(trace)];
+    };
+};
+#endif
+#if 0
     return s;
 }
+#endif
 
 } // namespace seqan3

--- a/include/seqan3/alignment/matrix/detail/trace_directions.hpp
+++ b/include/seqan3/alignment/matrix/detail/trace_directions.hpp
@@ -76,20 +76,21 @@ template <typename trace_directions_t>
     requires std::is_same_v<std::remove_cvref_t<trace_directions_t>, detail::trace_directions>
 struct trace_directions_printer<trace_directions_t>
 {
-    constexpr static auto print = [](auto & s, detail::trace_directions const trace)
+    static constexpr auto print = [](auto & s, detail::trace_directions const trace)
     {
-    static char const * unicode[32]{"↺",   "↖",    "↑",   "↖↑",  "⇡",    "↖⇡",   "↑⇡",  "↖↑⇡",  "←",    "↖←",   "↑←",
-                                    "↖↑←", "⇡←",   "↖⇡←", "↑⇡←", "↖↑⇡←", "⇠",    "↖⇠",  "↑⇠",   "↖↑⇠",  "⇡⇠",   "↖⇡⇠",
-                                    "↑⇡⇠", "↖↑⇡⇠", "←⇠",  "↖←⇠", "↑←⇠",  "↖↑←⇠", "⇡←⇠", "↖⇡←⇠", "↑⇡←⇠", "↖↑⇡←⇠"};
+        static char const * unicode[32]{"↺",  "↖",   "↑",   "↖↑",   "⇡",   "↖⇡",   "↑⇡",   "↖↑⇡",
+                                        "←",  "↖←",  "↑←",  "↖↑←",  "⇡←",  "↖⇡←",  "↑⇡←",  "↖↑⇡←",
+                                        "⇠",  "↖⇠",  "↑⇠",  "↖↑⇠",  "⇡⇠",  "↖⇡⇠",  "↑⇡⇠",  "↖↑⇡⇠",
+                                        "←⇠", "↖←⇠", "↑←⇠", "↖↑←⇠", "⇡←⇠", "↖⇡←⇠", "↑⇡←⇠", "↖↑⇡←⇠"};
 
-    static char const * csv[32]{"N",   "D",    "U",   "DU",  "u",    "Du",   "Uu",  "DUu",  "L",    "DL",   "UL",
-                                "DUL", "uL",   "DuL", "UuL", "DUuL", "l",    "Dl",  "Ul",   "DUl",  "ul",   "Dul",
-                                "Uul", "DUul", "Ll",  "DLl", "ULl",  "DULl", "uLl", "DuLl", "UuLl", "DUuLl"};
+        static char const * csv[32]{"N",   "D",    "U",   "DU",  "u",    "Du",   "Uu",  "DUu",  "L",    "DL",   "UL",
+                                    "DUL", "uL",   "DuL", "UuL", "DUuL", "l",    "Dl",  "Ul",   "DUl",  "ul",   "Dul",
+                                    "Uul", "DUul", "Ll",  "DLl", "ULl",  "DULl", "uLl", "DuLl", "UuLl", "DUuLl"};
 
-    bool is_unicode = (s.flags2() & fmtflags2::utf8) == fmtflags2::utf8;
-    auto const & trace_dir = is_unicode ? unicode : csv;
+        bool is_unicode = (s.flags2() & fmtflags2::utf8) == fmtflags2::utf8;
+        auto const & trace_dir = is_unicode ? unicode : csv;
 
-    s << trace_dir[static_cast<size_t>(trace)];
+        s << trace_dir[static_cast<size_t>(trace)];
     };
 };
 

--- a/include/seqan3/alignment/pairwise/alignment_result.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_result.hpp
@@ -412,50 +412,55 @@ namespace seqan3
 template <typename T>
     requires (!std::is_same_v<T, std::remove_cvref_t<T>>)
 struct alignment_result_printer<T> : public alignment_result_printer<std::remove_cvref_t<T>>
-{
-};
+{};
 
 template <typename result_value_t>
 struct alignment_result_printer<alignment_result<result_value_t>>
 {
-    constexpr static auto print = [](auto & stream, alignment_result<result_value_t> const & result)
+    static constexpr auto print = [](auto & stream, alignment_result<result_value_t> const & result)
     {
-    using alignment_result_t = alignment_result<result_value_t>;
-    using disabled_t = std::nullopt_t *;
-    using result_data_t =
-        typename detail::alignment_result_value_type_accessor<std::remove_cvref_t<alignment_result_t>>::type;
+        using alignment_result_t = alignment_result<result_value_t>;
+        using disabled_t = std::nullopt_t *;
+        using result_data_t =
+            typename detail::alignment_result_value_type_accessor<std::remove_cvref_t<alignment_result_t>>::type;
 
-    constexpr bool has_sequence1_id = !std::is_same_v<decltype(std::declval<result_data_t>().sequence1_id), disabled_t>;
-    constexpr bool has_sequence2_id = !std::is_same_v<decltype(std::declval<result_data_t>().sequence2_id), disabled_t>;
-    constexpr bool has_score = !std::is_same_v<decltype(std::declval<result_data_t>().score), disabled_t>;
-    constexpr bool has_end_positions =
-        !std::is_same_v<decltype(std::declval<result_data_t>().end_positions), disabled_t>;
-    constexpr bool has_begin_positions =
-        !std::is_same_v<decltype(std::declval<result_data_t>().begin_positions), disabled_t>;
-    constexpr bool has_alignment = !std::is_same_v<decltype(std::declval<result_data_t>().alignment), disabled_t>;
+        constexpr bool has_sequence1_id =
+            !std::is_same_v<decltype(std::declval<result_data_t>().sequence1_id), disabled_t>;
+        constexpr bool has_sequence2_id =
+            !std::is_same_v<decltype(std::declval<result_data_t>().sequence2_id), disabled_t>;
+        constexpr bool has_score = !std::is_same_v<decltype(std::declval<result_data_t>().score), disabled_t>;
+        constexpr bool has_end_positions =
+            !std::is_same_v<decltype(std::declval<result_data_t>().end_positions), disabled_t>;
+        constexpr bool has_begin_positions =
+            !std::is_same_v<decltype(std::declval<result_data_t>().begin_positions), disabled_t>;
+        constexpr bool has_alignment = !std::is_same_v<decltype(std::declval<result_data_t>().alignment), disabled_t>;
 
-    bool prepend_comma = false;
-    auto append_to_stream = [&](auto &&... args)
-    {
-        ((stream << (prepend_comma ? std::string{", "} : std::string{})) << ... << std::forward<decltype(args)>(args));
-        prepend_comma = true;
-    };
+        bool prepend_comma = false;
+        auto append_to_stream = [&](auto &&... args)
+        {
+            ((stream << (prepend_comma ? std::string{", "} : std::string{}))
+             << ... << std::forward<decltype(args)>(args));
+            prepend_comma = true;
+        };
 
-    stream << '{';
-    if constexpr (has_sequence1_id)
-        append_to_stream("sequence1 id: ", result.sequence1_id());
-    if constexpr (has_sequence2_id)
-        append_to_stream("sequence2 id: ", result.sequence2_id());
-    if constexpr (has_score)
-        append_to_stream("score: ", result.score());
-    if constexpr (has_begin_positions)
-        append_to_stream("begin: (", result.sequence1_begin_position(), ",", result.sequence2_begin_position(), ")");
-    if constexpr (has_end_positions)
-        append_to_stream("end: (", result.sequence1_end_position(), ",", result.sequence2_end_position(), ")");
-    if constexpr (has_alignment)
-        append_to_stream("\nalignment:\n", result.alignment());
-    stream << '}';
-
+        stream << '{';
+        if constexpr (has_sequence1_id)
+            append_to_stream("sequence1 id: ", result.sequence1_id());
+        if constexpr (has_sequence2_id)
+            append_to_stream("sequence2 id: ", result.sequence2_id());
+        if constexpr (has_score)
+            append_to_stream("score: ", result.score());
+        if constexpr (has_begin_positions)
+            append_to_stream("begin: (",
+                             result.sequence1_begin_position(),
+                             ",",
+                             result.sequence2_begin_position(),
+                             ")");
+        if constexpr (has_end_positions)
+            append_to_stream("end: (", result.sequence1_end_position(), ",", result.sequence2_end_position(), ")");
+        if constexpr (has_alignment)
+            append_to_stream("\nalignment:\n", result.alignment());
+        stream << '}';
     };
 };
 

--- a/include/seqan3/alignment/pairwise/alignment_result.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_result.hpp
@@ -409,10 +409,24 @@ namespace seqan3
  * \param[in] result The alignment result to print.
  * \relates seqan3::debug_stream_type
  */
+#if 0
 template <typename char_t, typename alignment_result_t>
     requires detail::is_type_specialisation_of_v<std::remove_cvref_t<alignment_result_t>, alignment_result>
 inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & stream, alignment_result_t && result)
 {
+#else
+template <typename T>
+    requires (!std::is_same_v<T, std::remove_cvref_t<T>>)
+struct alignment_result_printer<T> : public alignment_result_printer<std::remove_cvref_t<T>>
+{
+};
+
+template <typename result_value_t>
+struct alignment_result_printer<alignment_result<result_value_t>>
+{
+    constexpr static auto print = [](auto & stream, alignment_result<result_value_t> const & result)
+    {
+    using alignment_result_t = alignment_result<result_value_t>;
     using disabled_t = std::nullopt_t *;
     using result_data_t =
         typename detail::alignment_result_value_type_accessor<std::remove_cvref_t<alignment_result_t>>::type;
@@ -448,6 +462,11 @@ inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & stream
         append_to_stream("\nalignment:\n", result.alignment());
     stream << '}';
 
+    };
+};
+#endif
+#if 0
     return stream;
 }
+#endif
 } // namespace seqan3

--- a/include/seqan3/alignment/pairwise/alignment_result.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_result.hpp
@@ -409,12 +409,6 @@ namespace seqan3
  * \param[in] result The alignment result to print.
  * \relates seqan3::debug_stream_type
  */
-#if 0
-template <typename char_t, typename alignment_result_t>
-    requires detail::is_type_specialisation_of_v<std::remove_cvref_t<alignment_result_t>, alignment_result>
-inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & stream, alignment_result_t && result)
-{
-#else
 template <typename T>
     requires (!std::is_same_v<T, std::remove_cvref_t<T>>)
 struct alignment_result_printer<T> : public alignment_result_printer<std::remove_cvref_t<T>>
@@ -464,9 +458,5 @@ struct alignment_result_printer<alignment_result<result_value_t>>
 
     };
 };
-#endif
-#if 0
-    return stream;
-}
-#endif
+
 } // namespace seqan3

--- a/include/seqan3/alphabet/cigar/cigar.hpp
+++ b/include/seqan3/alphabet/cigar/cigar.hpp
@@ -207,6 +207,7 @@ public:
     //!\}
 };
 
+#if 1
 //!\brief Overload for the seqan3::debug_stream's operator.
 template <typename char_t>
 inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, cigar const c)
@@ -214,6 +215,7 @@ inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, cig
     s << c.to_string();
     return s;
 }
+#endif
 
 inline namespace literals
 {

--- a/include/seqan3/alphabet/detail/debug_stream_alphabet.hpp
+++ b/include/seqan3/alphabet/detail/debug_stream_alphabet.hpp
@@ -15,7 +15,6 @@
 
 namespace seqan3
 {
-#if 0
 /*!\name Formatted output overloads
  * \{
  */
@@ -25,13 +24,6 @@ namespace seqan3
  * \param l The alphabet letter.
  * \relates seqan3::debug_stream_type
  */
-template <typename char_t, alphabet alphabet_t>
-inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, alphabet_t && l)
-    requires (!output_stream_over<std::basic_ostream<char_t>, alphabet_t>)
-{
-    return s << to_char(l);
-}
-#else
 template <typename alphabet_t>
     requires alphabet<alphabet_t>
 struct alphabet_printer<alphabet_t>
@@ -41,27 +33,16 @@ struct alphabet_printer<alphabet_t>
         s << to_char(l);
     };
 };
-#endif
 
 // forward declare seqan3::mask
 class mask;
 
-#if 0
 /*!\brief Overload for the seqan3::mask alphabet.
  * \tparam char_t Type char type of the debug_stream.
  * \param s The seqan3::debug_stream.
  * \param l The mask alphabet letter.
  * \relates seqan3::debug_stream_type
  */
-template <typename char_t, seqan3::semialphabet alphabet_t>
-inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, alphabet_t && l)
-    requires std::same_as<std::remove_cvref_t<alphabet_t>, mask>
-{
-    return s << (l == alphabet_t{} ? "UNMASKED" : "MASKED");
-}
-
-//!\}
-#else
 template <typename alphabet_t>
     requires std::same_as<std::remove_cvref_t<alphabet_t>, mask>
 struct mask_printer<alphabet_t>
@@ -71,6 +52,7 @@ struct mask_printer<alphabet_t>
         s << (l == std::remove_cvref_t<alphabet_t>{} ? "UNMASKED" : "MASKED");
     };
 };
-#endif
+
+//!\}
 
 } // namespace seqan3

--- a/include/seqan3/alphabet/detail/debug_stream_alphabet.hpp
+++ b/include/seqan3/alphabet/detail/debug_stream_alphabet.hpp
@@ -28,7 +28,7 @@ template <typename alphabet_t>
     requires alphabet<alphabet_t>
 struct alphabet_printer<alphabet_t>
 {
-    constexpr static auto print = [](auto & s, alphabet_t l)
+    static constexpr auto print = [](auto & s, alphabet_t l)
     {
         s << to_char(l);
     };
@@ -47,7 +47,7 @@ template <typename alphabet_t>
     requires std::same_as<std::remove_cvref_t<alphabet_t>, mask>
 struct mask_printer<alphabet_t>
 {
-    constexpr static auto print = [](auto & s, alphabet_t const l)
+    static constexpr auto print = [](auto & s, alphabet_t const l)
     {
         s << (l == std::remove_cvref_t<alphabet_t>{} ? "UNMASKED" : "MASKED");
     };

--- a/include/seqan3/alphabet/detail/debug_stream_alphabet.hpp
+++ b/include/seqan3/alphabet/detail/debug_stream_alphabet.hpp
@@ -15,6 +15,7 @@
 
 namespace seqan3
 {
+#if 0
 /*!\name Formatted output overloads
  * \{
  */
@@ -30,10 +31,22 @@ inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, alp
 {
     return s << to_char(l);
 }
+#else
+template <typename alphabet_t>
+    requires alphabet<alphabet_t>
+struct alphabet_printer<alphabet_t>
+{
+    constexpr static auto print = [](auto & s, alphabet_t l)
+    {
+        s << to_char(l);
+    };
+};
+#endif
 
 // forward declare seqan3::mask
 class mask;
 
+#if 0
 /*!\brief Overload for the seqan3::mask alphabet.
  * \tparam char_t Type char type of the debug_stream.
  * \param s The seqan3::debug_stream.
@@ -48,5 +61,16 @@ inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, alp
 }
 
 //!\}
+#else
+template <typename alphabet_t>
+    requires std::same_as<std::remove_cvref_t<alphabet_t>, mask>
+struct mask_printer<alphabet_t>
+{
+    constexpr static auto print = [](auto & s, alphabet_t const l)
+    {
+        s << (l == std::remove_cvref_t<alphabet_t>{} ? "UNMASKED" : "MASKED");
+    };
+};
+#endif
 
 } // namespace seqan3

--- a/include/seqan3/argument_parser/auxiliary.hpp
+++ b/include/seqan3/argument_parser/auxiliary.hpp
@@ -219,6 +219,7 @@ concept argument_parser_compatible_option =
  * This searches the seqan3::enumeration_names of the respective type for the value \p op and prints the
  * respective string if found or '\<UNKNOWN_VALUE\>' if the value cannot be found in the map.
  */
+#if 1
 template <typename char_t, typename option_type>
     requires named_enumeration<std::remove_cvref_t<option_type>>
 inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, option_type && op)
@@ -231,6 +232,7 @@ inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, opt
 
     return s << "<UNKNOWN_VALUE>";
 }
+#endif
 //!\}
 
 /*!\brief Used to further specify argument_parser options/flags.

--- a/include/seqan3/core/debug_stream/byte.hpp
+++ b/include/seqan3/core/debug_stream/byte.hpp
@@ -25,6 +25,7 @@ namespace seqan3
  * \param[in] arg           The std::byte.
  * \relates seqan3::debug_stream_type
  */
+#if 1
 template <typename char_t, typename byte_type>
     requires std::same_as<std::remove_cvref_t<byte_type>, std::byte>
 inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, byte_type && arg)
@@ -32,6 +33,7 @@ inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, byt
     s << std::to_integer<uint8_t>(arg);
     return s;
 }
+#endif
 
 //!\}
 

--- a/include/seqan3/core/debug_stream/debug_stream_type.hpp
+++ b/include/seqan3/core/debug_stream/debug_stream_type.hpp
@@ -127,9 +127,12 @@ public:
     {
         using t_ = std::remove_cvref_t<t>;
 
-        if constexpr(default_printer::is_printable<t_>) {
+        if constexpr (default_printer::is_printable<t_>)
+        {
             default_printer::print(s, v);
-        } else {
+        }
+        else
+        {
             std::string const msg = std::string{"debug_stream has no print overload for type: "} + typeid(v).name();
             throw std::runtime_error{msg};
         }
@@ -145,10 +148,10 @@ public:
 
     //!\}
 
-    template<typename T>
+    template <typename T>
     friend struct debug_stream_printer;
 
-    template<typename T>
+    template <typename T>
     friend struct std_printer;
 
     //!\brief This type is std::ios_base::fmtflags
@@ -224,7 +227,9 @@ private:
 };
 
 template <typename value_t>
-    requires (std::is_same_v<std::remove_cvref_t<value_t>, int8_t> || std::is_same_v<std::remove_cvref_t<value_t>, uint8_t> || std::is_same_v<std::remove_cvref_t<value_t>, fmtflags2>)
+    requires (std::is_same_v<std::remove_cvref_t<value_t>, int8_t>
+              || std::is_same_v<std::remove_cvref_t<value_t>, uint8_t>
+              || std::is_same_v<std::remove_cvref_t<value_t>, fmtflags2>)
 struct debug_stream_printer<value_t>
 {
     struct print_fn

--- a/include/seqan3/core/debug_stream/debug_stream_type.hpp
+++ b/include/seqan3/core/debug_stream/debug_stream_type.hpp
@@ -123,9 +123,6 @@ public:
      */
     //!\brief Forwards to the underlying stream object.
     template <typename other_char_t, typename t>
-#if 0
-    friend debug_stream_type<other_char_t> & operator<<(debug_stream_type<other_char_t> & s, t && v);
-#else
     friend debug_stream_type<other_char_t> & operator<<(debug_stream_type<other_char_t> & s, t && v)
     {
         using t_ = std::remove_cvref_t<t>;
@@ -138,7 +135,6 @@ public:
         }
         return s;
     }
-#endif
 
     //!\brief This overloads enables forwarding std::endl and other manipulators.
     debug_stream_type & operator<<(std::ostream & (*fp)(std::ostream &))
@@ -147,36 +143,13 @@ public:
         return *this;
     }
 
-#if 0
-    //!\cond
-    debug_stream_type & operator<<(int8_t const v)
-    {
-        if ((flags2() & fmtflags2::small_int_as_number) == fmtflags2::small_int_as_number)
-            *stream << static_cast<int>(v);
-        else
-            *stream << v;
-        return *this;
-    }
-
-    debug_stream_type & operator<<(uint8_t const v)
-    {
-        if ((flags2() & fmtflags2::small_int_as_number) == fmtflags2::small_int_as_number)
-            *stream << static_cast<unsigned>(v);
-        else
-            *stream << v;
-        return *this;
-    }
-#else
+    //!\}
 
     template<typename T>
     friend struct debug_stream_printer;
 
     template<typename T>
     friend struct std_printer;
-
-#endif
-    //!\endcond
-    //!\}
 
     //!\brief This type is std::ios_base::fmtflags
     using fmtflags = typename std::basic_ostream<char_t>::fmtflags;
@@ -209,20 +182,7 @@ public:
         stream->unsetf(flag);
     }
 
-// fmtflags is an enum in libstdc++ and an unsigned in libc++
-#ifdef _LIBCPP_VERSION
-    static_assert(std::same_as<fmtflags, unsigned>);
-#else
-#if 0
-    //!\copybrief setf()
-    debug_stream_type & operator<<(fmtflags const flag)
-    {
-        setf(flag);
-        return *this;
-    }
-#endif
     //!\}
-#endif
 
     /*!\name Format flags (seqan3::fmtflags2)
      * \brief SeqAn specific debug flags for the debug stream.
@@ -253,15 +213,7 @@ public:
         flgs2 &= ~flag;
     }
 
-#if 0
-    //!\copybrief setf()
-    debug_stream_type & operator<<(fmtflags2 const flag)
-    {
-        setf(flag);
-        return *this;
-    }
     //!\}
-#endif
 
 private:
     //!\brief Pointer to the output stream.
@@ -304,15 +256,5 @@ struct debug_stream_printer<value_t>
 
     static constexpr print_fn print{};
 };
-
-#if 0
-//!\brief Forwards to the underlying stream object.
-template <typename char_t, typename t>
-debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, t && v)
-{
-    (*s.stream) << v;
-    return s;
-}
-#endif
 
 } // namespace seqan3

--- a/include/seqan3/core/debug_stream/default_printer.hpp
+++ b/include/seqan3/core/debug_stream/default_printer.hpp
@@ -1,0 +1,117 @@
+#pragma once
+
+#include <iosfwd>
+#include <utility>
+#include <tuple>
+
+#include <seqan3/core/platform.hpp>
+
+namespace seqan3
+{
+
+struct no_printer_found{};
+template <typename> struct advanceable_alignment_coordinate_printer {};
+template <typename> struct alignment_matrix_printer {};
+template <typename> struct alignment_printer {};
+template <typename> struct alignment_result_printer {};
+template <typename> struct alphabet_printer {};
+template <typename> struct debug_stream_printer {};
+template <typename> struct input_range_printer {};
+template <typename> struct integer_sequence_printer {};
+template <typename> struct integral_printer {};
+template <typename> struct mask_printer {};
+template <typename> struct optional_printer {};
+template <typename> struct sequence_printer {};
+template <typename> struct std_printer {};
+template <typename> struct char_sequence_printer {};
+template <typename> struct trace_directions_printer {};
+template <typename> struct tuple_printer {};
+
+template <typename printer_t>
+concept printable = requires() { { printer_t::print }; };
+
+template <typename type_t>
+    requires requires(std::ostream & cout, type_t value)
+    {
+        {cout << value};
+    }
+struct std_printer<type_t>
+{
+    static constexpr auto print = [](auto & s, auto && value)
+    {
+        *s.stream << std::forward<decltype(value)>(value);
+    };
+};
+
+template <typename integral_t>
+    requires std::integral<std::remove_cvref_t<integral_t>>
+struct integral_printer<integral_t>
+{
+    static constexpr auto print = [](auto & s, auto const value)
+    {
+        // note that we assume here that we always can print all std::integral's,
+        // but this is not correct since std::cout << char32_t{5}; is not possible.
+        // since char32_t is also an alphabet, we avoid infinite recursion here.
+        if constexpr(printable<std_printer<integral_t>>)
+            std_printer<integral_t>::print(s, value);
+        else
+            static_assert(std::same_as<integral_t, void>, "This type is not printable.");
+    };
+};
+
+template <template<typename> typename ...printers_t>
+struct printer_order
+{
+    template <typename type_t, typename ...types>
+    static constexpr std::ptrdiff_t find_index()
+    {
+            std::ptrdiff_t i = 0;
+            return ((printable<types> ? false : ++i) && ...) ? -1 : i;
+    }
+
+    template <typename type_t, std::ptrdiff_t i = find_index<type_t, printers_t<type_t>...>()>
+    using printer_for_t = std::tuple_element_t<
+        i == -1 ? sizeof...(printers_t) : i,
+        std::tuple<printers_t<type_t>..., no_printer_found>>;
+
+    // std::tuple<...> list of all printers that can print type_t
+    // NOTE: printer_order<...> might be nicer but is more complicated to write
+    template <typename type_t>
+    using printers_for_t = decltype(std::tuple_cat(std::conditional_t<printable<printers_t<type_t>>, std::tuple<printers_t<type_t>>, std::tuple<>>{}...));
+
+    template <typename type_t>
+    static constexpr bool is_printable = printable<printer_for_t<type_t>>;
+
+    static constexpr auto print = [](auto & s, auto && arg)
+    {
+        using printer_t = printer_for_t<decltype(arg)>;
+        printer_t::print(s, std::forward<decltype(arg)>(arg));
+    };
+};
+
+struct default_printer : printer_order<
+    debug_stream_printer,
+
+    alignment_result_printer, // type seqan3::alignment_result<>
+    alignment_printer, // concept seqan3::tuple_like<>
+    advanceable_alignment_coordinate_printer, // type seqan3::detail::advanceable_alignment_coordinate<>
+    alignment_matrix_printer, // concept seqan3::detail::matrix<>
+    trace_directions_printer, // type seqan3::detail::trace_directions
+
+    mask_printer, // type seqan3::mask
+    integral_printer, // concept std::integral
+    // NOTE: alphabet_printer needs the integral_printer overload, otherwise might have infinite recursion due to char and uint beeing an alphabet
+    alphabet_printer, // concept seqan3::alphabet
+
+    char_sequence_printer, // concept std::range::input_range<> with char value_type
+    integer_sequence_printer, // concept std::range::input_range<> with std::integral value_type
+    sequence_printer, // concept seqan3::sequence<>, i.e. std::range::input_range<> with seqan3::alphabet value_type
+    input_range_printer, // concept std::range::input_range<>
+
+    optional_printer, // type std::optional<> or std::nullopt_t
+    tuple_printer, // concept seqan3::tuple_like<>
+    std_printer // anything that can be printed by std::ostream
+>
+{};
+
+} // namespace seqan3

--- a/include/seqan3/core/debug_stream/default_printer.hpp
+++ b/include/seqan3/core/debug_stream/default_printer.hpp
@@ -1,14 +1,27 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2023, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2023, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \author Marcel Ehrhardt <marcel.ehrhardt AT fu-berlin.de>
+ * \brief Provides seqan3::default_printer.
+ */
+
 #pragma once
 
 #include <iosfwd>
-#include <utility>
 #include <tuple>
+#include <utility>
 
 #include <seqan3/core/platform.hpp>
 
 namespace seqan3
 {
 
+// clang-format off
 struct no_printer_found{};
 template <typename> struct advanceable_alignment_coordinate_printer {};
 template <typename> struct alignment_matrix_printer {};
@@ -26,15 +39,21 @@ template <typename> struct std_printer {};
 template <typename> struct char_sequence_printer {};
 template <typename> struct trace_directions_printer {};
 template <typename> struct tuple_printer {};
+// clang-format on
 
 template <typename printer_t>
-concept printable = requires() { { printer_t::print }; };
+concept printable = requires () {
+                        {
+                            printer_t::print
+                        };
+                    };
 
 template <typename type_t>
-    requires requires(std::ostream & cout, type_t value)
-    {
-        {cout << value};
-    }
+    requires requires (std::ostream & cout, type_t value) {
+                 {
+                     cout << value
+                 };
+             }
 struct std_printer<type_t>
 {
     static constexpr auto print = [](auto & s, auto && value)
@@ -52,32 +71,32 @@ struct integral_printer<integral_t>
         // note that we assume here that we always can print all std::integral's,
         // but this is not correct since std::cout << char32_t{5}; is not possible.
         // since char32_t is also an alphabet, we avoid infinite recursion here.
-        if constexpr(printable<std_printer<integral_t>>)
+        if constexpr (printable<std_printer<integral_t>>)
             std_printer<integral_t>::print(s, value);
         else
             static_assert(std::same_as<integral_t, void>, "This type is not printable.");
     };
 };
 
-template <template<typename> typename ...printers_t>
+template <template <typename> typename... printers_t>
 struct printer_order
 {
-    template <typename type_t, typename ...types>
+    template <typename type_t, typename... types>
     static constexpr std::ptrdiff_t find_index()
     {
-            std::ptrdiff_t i = 0;
-            return ((printable<types> ? false : ++i) && ...) ? -1 : i;
+        std::ptrdiff_t i = 0;
+        return ((printable<types> ? false : ++i) && ...) ? -1 : i;
     }
 
     template <typename type_t, std::ptrdiff_t i = find_index<type_t, printers_t<type_t>...>()>
-    using printer_for_t = std::tuple_element_t<
-        i == -1 ? sizeof...(printers_t) : i,
-        std::tuple<printers_t<type_t>..., no_printer_found>>;
+    using printer_for_t =
+        std::tuple_element_t<i == -1 ? sizeof...(printers_t) : i, std::tuple<printers_t<type_t>..., no_printer_found>>;
 
     // std::tuple<...> list of all printers that can print type_t
     // NOTE: printer_order<...> might be nicer but is more complicated to write
     template <typename type_t>
-    using printers_for_t = decltype(std::tuple_cat(std::conditional_t<printable<printers_t<type_t>>, std::tuple<printers_t<type_t>>, std::tuple<>>{}...));
+    using printers_for_t = decltype(std::tuple_cat(
+        std::conditional_t<printable<printers_t<type_t>>, std::tuple<printers_t<type_t>>, std::tuple<>>{}...));
 
     template <typename type_t>
     static constexpr bool is_printable = printable<printer_for_t<type_t>>;
@@ -89,29 +108,27 @@ struct printer_order
     };
 };
 
-struct default_printer : printer_order<
-    debug_stream_printer,
-
-    alignment_result_printer, // type seqan3::alignment_result<>
-    alignment_printer, // concept seqan3::tuple_like<>
-    advanceable_alignment_coordinate_printer, // type seqan3::detail::advanceable_alignment_coordinate<>
-    alignment_matrix_printer, // concept seqan3::detail::matrix<>
-    trace_directions_printer, // type seqan3::detail::trace_directions
-
-    mask_printer, // type seqan3::mask
-    integral_printer, // concept std::integral
-    // NOTE: alphabet_printer needs the integral_printer overload, otherwise might have infinite recursion due to char and uint beeing an alphabet
-    alphabet_printer, // concept seqan3::alphabet
-
-    char_sequence_printer, // concept std::range::input_range<> with char value_type
-    integer_sequence_printer, // concept std::range::input_range<> with std::integral value_type
-    sequence_printer, // concept seqan3::sequence<>, i.e. std::range::input_range<> with seqan3::alphabet value_type
-    input_range_printer, // concept std::range::input_range<>
-
-    optional_printer, // type std::optional<> or std::nullopt_t
-    tuple_printer, // concept seqan3::tuple_like<>
-    std_printer // anything that can be printed by std::ostream
->
+struct default_printer :
+    printer_order<
+        debug_stream_printer,
+        alignment_result_printer,                 // type seqan3::alignment_result<>
+        alignment_printer,                        // concept seqan3::tuple_like<>
+        advanceable_alignment_coordinate_printer, // type seqan3::detail::advanceable_alignment_coordinate<>
+        alignment_matrix_printer,                 // concept seqan3::detail::matrix<>
+        trace_directions_printer,                 // type seqan3::detail::trace_directions
+        mask_printer,                             // type seqan3::mask
+        integral_printer,                         // concept std::integral
+        // NOTE: alphabet_printer needs the integral_printer overload, otherwise it might have infinite recursion due to
+        // char and uint being an alphabet
+        alphabet_printer,         // concept seqan3::alphabet
+        char_sequence_printer,    // concept std::range::input_range<> with char value_type
+        integer_sequence_printer, // concept std::range::input_range<> with std::integral value_type
+        sequence_printer, // concept seqan3::sequence<>, i.e. std::range::input_range<> with seqan3::alphabet value_type
+        input_range_printer, // concept std::range::input_range<>
+        optional_printer,    // type std::optional<> or std::nullopt_t
+        tuple_printer,       // concept seqan3::tuple_like<>
+        std_printer          // anything that can be printed by std::ostream
+        >
 {};
 
 } // namespace seqan3

--- a/include/seqan3/core/debug_stream/default_printer.hpp
+++ b/include/seqan3/core/debug_stream/default_printer.hpp
@@ -1,9 +1,6 @@
-// -----------------------------------------------------------------------------------------------------
-// Copyright (c) 2006-2023, Knut Reinert & Freie Universität Berlin
-// Copyright (c) 2016-2023, Knut Reinert & MPI für molekulare Genetik
-// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
-// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
-// -----------------------------------------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2006-2024 Knut Reinert & Freie Universität Berlin
+// SPDX-FileCopyrightText: 2016-2024 Knut Reinert & MPI für molekulare Genetik
+// SPDX-License-Identifier: BSD-3-Clause
 
 /*!\file
  * \author Marcel Ehrhardt <marcel.ehrhardt AT fu-berlin.de>

--- a/include/seqan3/core/debug_stream/optional.hpp
+++ b/include/seqan3/core/debug_stream/optional.hpp
@@ -26,6 +26,7 @@ namespace seqan3
  * \param[in] arg           This is std::nullopt.
  * \relates seqan3::debug_stream_type
  */
+#if 0
 template <typename char_t>
 inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, std::nullopt_t SEQAN3_DOXYGEN_ONLY(arg))
 {
@@ -49,6 +50,34 @@ inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, opt
         s << "<VALUELESS_OPTIONAL>";
     return s;
 }
+#else
+template <typename T>
+    requires (!std::is_same_v<T, std::remove_cvref_t<T>>)
+struct optional_printer<T> : public optional_printer<std::remove_cvref_t<T>>
+{
+};
+
+template <>
+struct optional_printer<std::nullopt_t>
+{
+    constexpr static auto print = [](auto & s, std::nullopt_t SEQAN3_DOXYGEN_ONLY(arg))
+    {
+        s << "<VALUELESS_OPTIONAL>";
+    };
+};
+
+template <typename T>
+struct optional_printer<std::optional<T>>
+{
+    constexpr static auto print = [](auto & s, auto && arg)
+    {
+        if (arg.has_value())
+            s << *arg;
+        else
+            s << "<VALUELESS_OPTIONAL>";
+    };
+};
+#endif
 
 //!\}
 

--- a/include/seqan3/core/debug_stream/optional.hpp
+++ b/include/seqan3/core/debug_stream/optional.hpp
@@ -20,43 +20,19 @@ namespace seqan3
 /*!\name Formatted output overloads
  * \{
  */
-/*!\brief Make std::nullopt_t printable.
- * \tparam    optional_type This is std::nullopt_t.
- * \param[in] s             The seqan3::debug_stream.
- * \param[in] arg           This is std::nullopt.
- * \relates seqan3::debug_stream_type
- */
-#if 0
-template <typename char_t>
-inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, std::nullopt_t SEQAN3_DOXYGEN_ONLY(arg))
-{
-    s << "<VALUELESS_OPTIONAL>";
-    return s;
-}
 
-/*!\brief A std::optional can be printed by printing its value or nothing if valueless.
- * \tparam    optional_type The type of the optional.
- * \param[in] s             The seqan3::debug_stream.
- * \param[in] arg           The std::optional.
- * \relates seqan3::debug_stream_type
- */
-template <typename char_t, typename optional_type>
-    requires detail::is_type_specialisation_of_v<std::remove_cvref_t<optional_type>, std::optional>
-inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, optional_type && arg)
-{
-    if (arg.has_value())
-        s << *arg;
-    else
-        s << "<VALUELESS_OPTIONAL>";
-    return s;
-}
-#else
 template <typename T>
     requires (!std::is_same_v<T, std::remove_cvref_t<T>>)
 struct optional_printer<T> : public optional_printer<std::remove_cvref_t<T>>
 {
 };
 
+/*!\brief Make std::nullopt_t printable.
+ * \tparam    optional_type This is std::nullopt_t.
+ * \param[in] s             The seqan3::debug_stream.
+ * \param[in] arg           This is std::nullopt.
+ * \relates seqan3::debug_stream_type
+ */
 template <>
 struct optional_printer<std::nullopt_t>
 {
@@ -66,6 +42,12 @@ struct optional_printer<std::nullopt_t>
     };
 };
 
+/*!\brief A std::optional can be printed by printing its value or nothing if valueless.
+ * \tparam    optional_type The type of the optional.
+ * \param[in] s             The seqan3::debug_stream.
+ * \param[in] arg           The std::optional.
+ * \relates seqan3::debug_stream_type
+ */
 template <typename T>
 struct optional_printer<std::optional<T>>
 {
@@ -77,7 +59,6 @@ struct optional_printer<std::optional<T>>
             s << "<VALUELESS_OPTIONAL>";
     };
 };
-#endif
 
 //!\}
 

--- a/include/seqan3/core/debug_stream/optional.hpp
+++ b/include/seqan3/core/debug_stream/optional.hpp
@@ -24,8 +24,7 @@ namespace seqan3
 template <typename T>
     requires (!std::is_same_v<T, std::remove_cvref_t<T>>)
 struct optional_printer<T> : public optional_printer<std::remove_cvref_t<T>>
-{
-};
+{};
 
 /*!\brief Make std::nullopt_t printable.
  * \tparam    optional_type This is std::nullopt_t.
@@ -36,7 +35,7 @@ struct optional_printer<T> : public optional_printer<std::remove_cvref_t<T>>
 template <>
 struct optional_printer<std::nullopt_t>
 {
-    constexpr static auto print = [](auto & s, std::nullopt_t SEQAN3_DOXYGEN_ONLY(arg))
+    static constexpr auto print = [](auto & s, std::nullopt_t SEQAN3_DOXYGEN_ONLY(arg))
     {
         s << "<VALUELESS_OPTIONAL>";
     };
@@ -51,7 +50,7 @@ struct optional_printer<std::nullopt_t>
 template <typename T>
 struct optional_printer<std::optional<T>>
 {
-    constexpr static auto print = [](auto & s, auto && arg)
+    static constexpr auto print = [](auto & s, auto && arg)
     {
         if (arg.has_value())
             s << *arg;

--- a/include/seqan3/core/debug_stream/range.hpp
+++ b/include/seqan3/core/debug_stream/range.hpp
@@ -71,7 +71,8 @@ namespace seqan3
 
 // e.g. std::filesystem
 template <typename rng_t>
-concept nonrecursive_range = !std::same_as<std::remove_cvref_t<std::ranges::range_reference_t<rng_t>>, std::remove_cvref_t<rng_t>>;
+concept nonrecursive_range = !
+std::same_as<std::remove_cvref_t<std::ranges::range_reference_t<rng_t>>, std::remove_cvref_t<rng_t>>;
 
 /*!\name Formatted output overloads
  * \{
@@ -99,24 +100,23 @@ template <typename rng_t>
     requires std::ranges::input_range<rng_t> && nonrecursive_range<rng_t>
 struct input_range_printer<rng_t>
 {
-    constexpr static auto print = [](auto & s, auto && r)
+    static constexpr auto print = [](auto & s, auto && r)
     {
-
-    s << '[';
-    auto b = std::ranges::begin(r);
-    auto e = std::ranges::end(r);
-    if (b != e)
-    {
-        s << *b;
-        ++b;
-    }
-    while (b != e)
-    {
-        s << ',';
-        s << *b;
-        ++b;
-    }
-    s << ']';
+        s << '[';
+        auto b = std::ranges::begin(r);
+        auto e = std::ranges::end(r);
+        if (b != e)
+        {
+            s << *b;
+            ++b;
+        }
+        while (b != e)
+        {
+            s << ',';
+            s << *b;
+            ++b;
+        }
+        s << ']';
     };
 };
 
@@ -140,36 +140,38 @@ template <typename sequence_t>
     requires sequence<sequence_t>
 struct sequence_printer<sequence_t>
 {
-    constexpr static auto print = [](auto & s, auto && sequence)
+    static constexpr auto print = [](auto & s, auto && sequence)
     {
-    for (auto && chr : sequence)
-        s << chr;
+        for (auto && chr : sequence)
+            s << chr;
     };
 };
 
 // basically same as is_char_adaptation_v
 template <typename type>
-static constexpr bool is_char_type_v = std::same_as<type, char> || std::same_as<type, char16_t> || std::same_as<type, char32_t> || std::same_as<type, wchar_t>;
+static constexpr bool is_char_type_v = std::same_as<type, char> || std::same_as<type, char16_t>
+                                    || std::same_as<type, char32_t> || std::same_as<type, wchar_t>;
 
 template <typename char_sequence_t>
-    requires std::ranges::input_range<char_sequence_t> && (is_char_type_v<std::remove_cvref_t<std::ranges::range_reference_t<char_sequence_t>>>)
+    requires std::ranges::input_range<char_sequence_t>
+          && (is_char_type_v<std::remove_cvref_t<std::ranges::range_reference_t<char_sequence_t>>>)
 struct char_sequence_printer<char_sequence_t>
 {
-    constexpr static auto print = [](auto & s, auto && sequence)
+    static constexpr auto print = [](auto & s, auto && sequence)
     {
-    if constexpr(std::is_pointer_v<std::decay_t<char_sequence_t>>)
-        return std_printer<char_sequence_t>::print(s, sequence);
+        if constexpr (std::is_pointer_v<std::decay_t<char_sequence_t>>)
+            return std_printer<char_sequence_t>::print(s, sequence);
 
-    for (auto && chr : sequence)
-        s << chr;
+        for (auto && chr : sequence)
+            s << chr;
     };
 };
 
 template <typename integer_sequence_t>
-    requires std::ranges::input_range<integer_sequence_t> && std::integral<std::remove_cvref_t<std::ranges::range_reference_t<integer_sequence_t>>>
+    requires std::ranges::input_range<integer_sequence_t>
+          && std::integral<std::remove_cvref_t<std::ranges::range_reference_t<integer_sequence_t>>>
 struct integer_sequence_printer<integer_sequence_t> : public input_range_printer<integer_sequence_t>
-{
-};
+{};
 
 //!\}
 

--- a/include/seqan3/core/debug_stream/range.hpp
+++ b/include/seqan3/core/debug_stream/range.hpp
@@ -68,6 +68,11 @@ constexpr bool reference_type_is_streamable_v<rng_t, char_t> = true;
 
 namespace seqan3
 {
+
+// e.g. std::filesystem
+template <typename rng_t>
+concept nonrecursive_range = !std::same_as<std::remove_cvref_t<std::ranges::range_reference_t<rng_t>>, std::remove_cvref_t<rng_t>>;
+
 /*!\name Formatted output overloads
  * \{
  */
@@ -90,27 +95,12 @@ namespace seqan3
  * to avoid ambiguous function calls.
  * \endif
  */
-#if 0
-template <typename char_t, std::ranges::input_range rng_t>
-inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, rng_t && r)
-    requires detail::debug_stream_range_guard<rng_t>
-{
-#else
-
-// e.g. std::filesystem
-template <typename rng_t>
-concept nonrecursive_range = !std::same_as<std::remove_cvref_t<std::ranges::range_reference_t<rng_t>>, std::remove_cvref_t<rng_t>>;
-
 template <typename rng_t>
     requires std::ranges::input_range<rng_t> && nonrecursive_range<rng_t>
 struct input_range_printer<rng_t>
 {
     constexpr static auto print = [](auto & s, auto && r)
     {
-#if 0
-    static_assert(detail::reference_type_is_streamable_v<rng_t, char_t>,
-                  "The reference type of the passed range cannot be streamed into the debug_stream.");
-#endif
 
     s << '[';
     auto b = std::ranges::begin(r);
@@ -129,12 +119,6 @@ struct input_range_printer<rng_t>
     s << ']';
     };
 };
-#endif
-#if 0
-
-    return s;
-}
-#endif
 
 /*!\brief All biological sequences can be printed to the seqan3::debug_stream.
  * \tparam sequence_t Type of the (biological) sequence to be printed; must model seqan3::sequence.
@@ -152,13 +136,6 @@ struct input_range_printer<rng_t>
  * to avoid ambiguous function calls.
  * \endif
  */
-#if 0
-template <typename char_t, sequence sequence_t>
-inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, sequence_t && sequence)
-    requires detail::debug_stream_range_guard<sequence_t>
-          && (!detail::is_uint_adaptation_v<std::remove_cvref_t<std::ranges::range_reference_t<sequence_t>>>)
-{
-#else
 template <typename sequence_t>
     requires sequence<sequence_t>
 struct sequence_printer<sequence_t>
@@ -169,11 +146,6 @@ struct sequence_printer<sequence_t>
         s << chr;
     };
 };
-#endif
-#if 0
-    return s;
-}
-#endif
 
 // basically same as is_char_adaptation_v
 template <typename type>

--- a/include/seqan3/core/debug_stream/tuple.hpp
+++ b/include/seqan3/core/debug_stream/tuple.hpp
@@ -57,18 +57,12 @@ std::ranges::input_range<tuple_t> && !alphabet<tuple_t> && // exclude alphabet_t
 namespace seqan3
 {
 
-#if 0
 /*!\brief All tuples can be printed by printing their elements separately.
  * \tparam tuple_t Type of the tuple to be printed; must model seqan3::tuple_like.
  * \param s The seqan3::debug_stream.
  * \param t The tuple.
  * \relates seqan3::debug_stream_type
  */
-template <typename char_t, typename tuple_t>
-    requires (detail::debug_streamable_tuple<tuple_t>)
-inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, tuple_t && t)
-{
-#else
 template <typename tuple_type>
     requires tuple_like<tuple_type>
 struct tuple_printer<tuple_type>
@@ -81,11 +75,6 @@ struct tuple_printer<tuple_type>
                         std::make_index_sequence<std::tuple_size_v<std::remove_cvref_t<tuple_t>>>{});
     };
 };
-#endif
-#if 0
-    return s;
-}
-#endif
 
 //!\}
 

--- a/include/seqan3/core/debug_stream/tuple.hpp
+++ b/include/seqan3/core/debug_stream/tuple.hpp
@@ -57,6 +57,7 @@ std::ranges::input_range<tuple_t> && !alphabet<tuple_t> && // exclude alphabet_t
 namespace seqan3
 {
 
+#if 0
 /*!\brief All tuples can be printed by printing their elements separately.
  * \tparam tuple_t Type of the tuple to be printed; must model seqan3::tuple_like.
  * \param s The seqan3::debug_stream.
@@ -67,11 +68,24 @@ template <typename char_t, typename tuple_t>
     requires (detail::debug_streamable_tuple<tuple_t>)
 inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, tuple_t && t)
 {
+#else
+template <typename tuple_type>
+    requires tuple_like<tuple_type>
+struct tuple_printer<tuple_type>
+{
+    constexpr static auto print = [](auto & s, auto && t)
+    {
+    using tuple_t = decltype(t);
     detail::print_tuple(s,
                         std::forward<tuple_t>(t),
                         std::make_index_sequence<std::tuple_size_v<std::remove_cvref_t<tuple_t>>>{});
+    };
+};
+#endif
+#if 0
     return s;
 }
+#endif
 
 //!\}
 

--- a/include/seqan3/core/debug_stream/tuple.hpp
+++ b/include/seqan3/core/debug_stream/tuple.hpp
@@ -67,12 +67,12 @@ template <typename tuple_type>
     requires tuple_like<tuple_type>
 struct tuple_printer<tuple_type>
 {
-    constexpr static auto print = [](auto & s, auto && t)
+    static constexpr auto print = [](auto & s, auto && t)
     {
-    using tuple_t = decltype(t);
-    detail::print_tuple(s,
-                        std::forward<tuple_t>(t),
-                        std::make_index_sequence<std::tuple_size_v<std::remove_cvref_t<tuple_t>>>{});
+        using tuple_t = decltype(t);
+        detail::print_tuple(s,
+                            std::forward<tuple_t>(t),
+                            std::make_index_sequence<std::tuple_size_v<std::remove_cvref_t<tuple_t>>>{});
     };
 };
 

--- a/include/seqan3/core/debug_stream/variant.hpp
+++ b/include/seqan3/core/debug_stream/variant.hpp
@@ -30,6 +30,7 @@ namespace seqan3
  *
  * Note that in case the variant is valueless(_by_exception), nothing is printed.
  */
+#if 1
 template <typename char_t, typename variant_type>
     requires detail::is_type_specialisation_of_v<std::remove_cvref_t<variant_type>, std::variant>
 inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, variant_type && v)
@@ -45,6 +46,7 @@ inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, var
         s << "<VALUELESS_VARIANT>";
     return s;
 }
+#endif
 
 //!\}
 

--- a/include/seqan3/core/detail/strong_type.hpp
+++ b/include/seqan3/core/detail/strong_type.hpp
@@ -472,12 +472,14 @@ private:
  *
  * \returns `stream_t &` A reference to the given stream.
  */
+#if 1
 template <typename char_t, derived_from_strong_type strong_type_t>
 debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & stream, strong_type_t && value)
 {
     stream << value.get();
     return stream;
 }
+#endif
 //!\}
 
 } // namespace seqan3::detail

--- a/include/seqan3/io/sam_file/sam_flag.hpp
+++ b/include/seqan3/io/sam_file/sam_flag.hpp
@@ -100,10 +100,12 @@ inline constexpr bool add_enum_bitwise_operators<sam_flag> = true;
  * \param flag The flag to print.
  * \relates seqan3::debug_stream_type
  */
+#if 1
 template <typename char_t>
 inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & stream, sam_flag const flag)
 {
     return stream << static_cast<int16_t>(flag);
 }
+#endif
 
 } // namespace seqan3

--- a/include/seqan3/search/search_result.hpp
+++ b/include/seqan3/search/search_result.hpp
@@ -188,6 +188,7 @@ public:
  * \param result The search result to print.
  * \relates seqan3::debug_stream_type
  */
+#if 1
 template <typename char_t, typename search_result_t>
     requires detail::is_type_specialisation_of_v<std::remove_cvref_t<search_result_t>, search_result>
 inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & stream, search_result_t && result)
@@ -207,5 +208,6 @@ inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & stream
 
     return stream;
 }
+#endif
 
 } // namespace seqan3

--- a/include/seqan3/utility/container/dynamic_bitset.hpp
+++ b/include/seqan3/utility/container/dynamic_bitset.hpp
@@ -1936,6 +1936,7 @@ public:
      *
      * \experimentalapi{Experimental since version 3.1.}
      */
+#if 1
     template <typename char_t>
     friend debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, dynamic_bitset arg)
     {
@@ -1943,6 +1944,7 @@ public:
               | ranges::to<std::string>());
         return s;
     }
+#endif
     //!\}
 
     //!\cond DEV

--- a/include/seqan3/utility/simd/detail/debug_stream_simd.hpp
+++ b/include/seqan3/utility/simd/detail/debug_stream_simd.hpp
@@ -20,6 +20,7 @@ namespace seqan3
 /*!\brief Overload for debug_stream for simd types.
  * \ingroup utility_simd
  */
+#if 1
 template <typename char_t, typename simd_t>
     requires simd::simd_concept<std::remove_cvref_t<simd_t>>
 inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, simd_t && simd)
@@ -34,5 +35,6 @@ inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, sim
     s << array;
     return s;
 }
+#endif
 
 } // namespace seqan3

--- a/test/snippet/search/kmer_index/shape.cpp
+++ b/test/snippet/search/kmer_index/shape.cpp
@@ -9,6 +9,22 @@
 
 using namespace seqan3::literals;
 
+#if 1
+// this case is fun, as seqan3::shape has no explicit std::cout/debug_stream overload.
+// * if we have
+//   printer_order<debug_stream_printer, std_printer, input_range_printer>
+//   the std::cout overload of seqan3::dynamic_bitset will win as it is the most specific
+//   seqan3::debug_stream << s0; will print 11111
+// * if we have
+//   printer_order<debug_stream_printer, input_range_printer, std_printer>
+//   the input_range_printer will win since seqan3::dynamic_bitset is an input_range
+//   seqan3::debug_stream << s0; will print [1,1,1,1,1]
+//
+// Interestingly seqan3::dynamic_bitset has also an debug_stream overload, but this one will
+// only be active if the type is seqan3::dynamic_bitset
+// seqan3::debug_stream << (seqan3::dynamic_bitset<58>&)s0; will print 1'1111
+#endif
+
 int main()
 {
     seqan3::shape s0{seqan3::ungapped{5}};                 // represents "11111", i.e. ungapped 5-mer

--- a/test/unit/io/record_test.cpp
+++ b/test/unit/io/record_test.cpp
@@ -21,12 +21,14 @@ using default_fields = seqan3::fields<seqan3::field::seq, seqan3::field::id, seq
 // This is needed for EXPECT_RANGE_EQ:
 namespace seqan3
 {
+#if 1
 template <typename char_t>
 inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & stream, field f)
 {
     stream << "<field: " << static_cast<size_t>(f) << ">";
     return stream;
 }
+#endif
 } // namespace seqan3
 
 // ----------------------------------------------------------------------------

--- a/test/unit/search/helper.hpp
+++ b/test/unit/search/helper.hpp
@@ -15,6 +15,7 @@
 
 namespace seqan3
 {
+#if 1
 template <typename char_t, typename index_t>
 inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, seqan3::fm_index_cursor<index_t> const &)
 {
@@ -27,6 +28,7 @@ inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s,
 {
     return s << ("bi_fm_index_cursor");
 }
+#endif
 
 template <typename result_range_t>
 std::vector<std::ranges::range_value_t<result_range_t>> uniquify(result_range_t && result_range)

--- a/test/unit/test/pretty_printing_test.cpp
+++ b/test/unit/test/pretty_printing_test.cpp
@@ -118,6 +118,7 @@ struct my_type
 namespace seqan3
 {
 
+#if 1
 template <typename char_t, typename my_type>
     requires std::same_as<std::decay_t<my_type>, detail::my_type>
 inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, my_type && m)
@@ -125,6 +126,7 @@ inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, my_
     s << m.str;
     return s;
 }
+#endif
 
 } // namespace seqan3
 
@@ -141,6 +143,7 @@ namespace seqan3
 struct your_type : public detail::my_type
 {};
 
+#if 1
 template <typename char_t, typename your_type>
     requires std::same_as<std::decay_t<your_type>, ::seqan3::your_type>
 inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, your_type && m)
@@ -148,6 +151,7 @@ inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, you
     s << m.str;
     return s;
 }
+#endif
 
 } // namespace seqan3
 


### PR DESCRIPTION
This PR will resolve seqan/product_backlog#63.

This issue is a long-standing open to-do of mine. I hope that you can take it over and push it over the finishing line. The state of the current PR is just a draft of an idea.

I'll comment on multiple code locations to point out the advantages of the new design.

# The old design

The major idea of the design is due to the following observation:

> We use overload resolution and in particular overload ordering via concepts to determine the order in which we should print

Just to give a small example (the more down, the more specialized):

```cpp
  std::cout //-printable [1]
< seqan3::tuple_like // [4]
< std::ranges::input_range // [2]
< std::vector<uint8_t> // [3]
< seqan3::sequence // [3]
< char * // [2]

  std::cout //-printable [1]
< char // [5]
< seqan3::tuple_like // [4]
< seqan3::alphabet // [5]
< seqan3::mask // [6]
```

NOTE: that using concepts as overload resolution always uses a partially ordered set, which can be depicted by as a [Hasse Diagram](https://en.wikipedia.org/wiki/Hasse_diagram), and by using the except clauses via `requires` we give it a total order.

# The new design

### Before anything, note that the new design does not break any existing code. As existing `seqan3::debugstream << ` overloads, still take place in overload resolution.

The idea is simple:
* Have a list of printers.
* The order of the printers dictates in which order an object should be printed.
* We allow that multiple printers might be viable to print a type.
* Each `printer<type>` either has a function object / lambda `print` or not; depending on whether the `printer` can print that `type` or not (implemented by [template specialization](https://en.cppreference.com/w/cpp/language/template_specialization))
* We can explicitly use `printer` in other printer's, if we know that only that overload should be used,

So put together: For a given type, ask every printer in order whether it can print that type and the first one to answer yes, is the selected printer.

----

[1] If all overloads do not work, use `std::ostream` https://github.com/seqan/seqan3/blob/6b681fb2eae5ab2997d293e99fc6a7f869a20316/include/seqan3/core/debug_stream/debug_stream_type.hpp#L242-L247 [2] Use this for all `std::ranges::input_range`s except if type is something like `std::filesystem` (type == range_value_t) or `char *` https://github.com/seqan/seqan3/blob/6b681fb2eae5ab2997d293e99fc6a7f869a20316/include/seqan3/core/debug_stream/range.hpp#L96-L98 https://github.com/seqan/seqan3/blob/6b681fb2eae5ab2997d293e99fc6a7f869a20316/include/seqan3/core/debug_stream/range.hpp#L38-L45 [3] Same as [2] where value_type is an alphabet but only if the alphabet is not an `unsigned int` (this condition has no test case?!) https://github.com/seqan/seqan3/blob/6b681fb2eae5ab2997d293e99fc6a7f869a20316/include/seqan3/core/debug_stream/range.hpp#L138-L141 [4] Use this for all `std::tuple`-like types except if it is a `std::ranges::input_range` (what is a tuple and ranges at the same time?!) and an `seqan3::alphabet` (basically `seqan3::alphabet_tuple_base` derived types) https://github.com/seqan/seqan3/blob/6b681fb2eae5ab2997d293e99fc6a7f869a20316/include/seqan3/core/debug_stream/tuple.hpp#L53-L56 [5] Use this for all `seqan3::alphabet`s except if it can be printed by `std::cout` (like `char`) https://github.com/seqan/seqan3/blob/6b681fb2eae5ab2997d293e99fc6a7f869a20316/include/seqan3/alphabet/detail/debug_stream_alphabet.hpp#L30-L32 [6] Type must be `seqan3::semialphabet` and `seqan3::mask` https://github.com/seqan/seqan3/blob/6b681fb2eae5ab2997d293e99fc6a7f869a20316/include/seqan3/alphabet/detail/debug_stream_alphabet.hpp#L46-L48

<!--
Please see https://github.com/seqan/seqan3/blob/master/CONTRIBUTING.md for a general overview.

Please allow edits from maintainers:
https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests

Once you create the PR, clang-format will be run on the PR, and any formatting changes will be pushed to your fork.
Subsequently, the actual CI will start.

****************************************************************************************************
** Attention: This means that you will have to `git pull` the changes before pushing new commits. **
****************************************************************************************************

Each of your commits will trigger a clang-format commit if there are formatting changes.


While the following guide on rebasing formatting changes is intended for internal use by SeqAn members, and in no way
necessary for contributors, it may still be an interesting read: https://github.com/seqan/seqan3/wiki/Rebasing-clang-format-commits-with-git-absorb
-->
