### PR TITLE
doc,fix: variable bgzf_thread_count is no longer static

### DIFF
--- a/include/seqan3/contrib/stream/bgzf.hpp
+++ b/include/seqan3/contrib/stream/bgzf.hpp
@@ -14,7 +14,7 @@
 namespace seqan3::contrib
 {
 
-/*!\brief A static variable indicating the number of threads to use for the bgzf-streams. Defaults to 4.
+/*!\brief A global variable indicating the number of threads to use for the bgzf-streams. Defaults to 4.
  */
 [[maybe_unused]] inline uint64_t bgzf_thread_count = 4;
 


### PR DESCRIPTION
Fixes #3237

Changes in the definition of bgzf_thread_count in PR #3042 introduced the difference of documentation and actual code.
