### PR TITLE
[FIX] CPP23

### DIFF
--- a/include/seqan3/core/platform.hpp
+++ b/include/seqan3/core/platform.hpp
@@ -238,6 +238,17 @@ static_assert(sdsl::sdsl_version_major == 3, "Only version 3 of the SDSL is supp
 #    endif
 #endif
 
+/*!\brief Workaround for variable template specialisations not being emitted.
+ * \see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=114013
+ */
+#ifndef SEQAN3_WORKAROUND_GCC_114013
+#    if SEQAN3_COMPILER_IS_GCC && (__GNUC__ == 14)
+#        define SEQAN3_WORKAROUND_GCC_114013 constexpr
+#    else
+#        define SEQAN3_WORKAROUND_GCC_114013 inline constexpr
+#    endif
+#endif
+
 /*!\brief This is needed to support CentOS 7 or RHEL 7; Newer CentOS's include a more modern default-gcc version making
  *        this macro obsolete.
  *

--- a/include/seqan3/search/detail/search_scheme_precomputed.hpp
+++ b/include/seqan3/search/detail/search_scheme_precomputed.hpp
@@ -24,7 +24,7 @@ template <uint8_t nbr_blocks>
 struct search
 {
     //!\brief Type for storing the length of blocks
-    typedef std::array<size_t, nbr_blocks> blocks_length_type;
+    using blocks_length_type = std::array<size_t, nbr_blocks>;
 
     //!\brief Order of blocks
     std::array<uint8_t, nbr_blocks> pi;
@@ -46,7 +46,7 @@ struct search
 struct search_dyn
 {
     //!\brief Type for storing the length of blocks
-    typedef std::vector<size_t> blocks_length_type;
+    using blocks_length_type = std::vector<size_t>;
 
     //!\brief Order of blocks
     std::vector<uint8_t> pi;
@@ -81,60 +81,63 @@ using search_scheme_dyn_type = std::vector<search_dyn>;
  *          seems to be a good greedy approach.
  */
 template <uint8_t min_error, uint8_t max_error>
-inline constexpr int optimum_search_scheme{0};
+SEQAN3_WORKAROUND_GCC_114013 int optimum_search_scheme{0};
 
 //!\cond
 
 template <>
-inline constexpr search_scheme_type<1, 1> optimum_search_scheme<0, 0>{{{{1}, {0}, {0}}}};
+SEQAN3_WORKAROUND_GCC_114013 search_scheme_type<1, 1> optimum_search_scheme<0, 0>{{{{1}, {0}, {0}}}};
 
 template <>
-inline constexpr search_scheme_type<2, 2> optimum_search_scheme<0, 1>{
+SEQAN3_WORKAROUND_GCC_114013 search_scheme_type<2, 2> optimum_search_scheme<0, 1>{
     {{{1, 2}, {0, 0}, {0, 1}}, {{2, 1}, {0, 1}, {0, 1}}}};
 
 template <>
-inline constexpr search_scheme_type<2, 2> optimum_search_scheme<1, 1>{
+SEQAN3_WORKAROUND_GCC_114013 search_scheme_type<2, 2> optimum_search_scheme<1, 1>{
     {{{1, 2}, {0, 1}, {0, 1}}, {{2, 1}, {0, 1}, {0, 1}}}};
 
 template <>
-inline constexpr search_scheme_type<3, 4> optimum_search_scheme<0, 2>{{{{1, 2, 3, 4}, {0, 0, 1, 1}, {0, 0, 2, 2}},
-                                                                       {{3, 2, 1, 4}, {0, 0, 0, 0}, {0, 1, 1, 2}},
-                                                                       {{4, 3, 2, 1}, {0, 0, 0, 2}, {0, 1, 2, 2}}}};
+SEQAN3_WORKAROUND_GCC_114013 search_scheme_type<3, 4> optimum_search_scheme<0, 2>{
+    {{{1, 2, 3, 4}, {0, 0, 1, 1}, {0, 0, 2, 2}},
+     {{3, 2, 1, 4}, {0, 0, 0, 0}, {0, 1, 1, 2}},
+     {{4, 3, 2, 1}, {0, 0, 0, 2}, {0, 1, 2, 2}}}};
 
 template <>
-inline constexpr search_scheme_type<3, 4> optimum_search_scheme<1, 2>{{{{1, 2, 3, 4}, {0, 0, 0, 1}, {0, 0, 2, 2}},
-                                                                       {{3, 2, 1, 4}, {0, 0, 1, 1}, {0, 1, 1, 2}},
-                                                                       {{4, 3, 2, 1}, {0, 0, 0, 2}, {0, 1, 2, 2}}}};
+SEQAN3_WORKAROUND_GCC_114013 search_scheme_type<3, 4> optimum_search_scheme<1, 2>{
+    {{{1, 2, 3, 4}, {0, 0, 0, 1}, {0, 0, 2, 2}},
+     {{3, 2, 1, 4}, {0, 0, 1, 1}, {0, 1, 1, 2}},
+     {{4, 3, 2, 1}, {0, 0, 0, 2}, {0, 1, 2, 2}}}};
 
 template <>
-inline constexpr search_scheme_type<3, 4> optimum_search_scheme<2, 2>{{{{4, 3, 2, 1}, {0, 0, 1, 2}, {0, 0, 2, 2}},
-                                                                       {{2, 3, 4, 1}, {0, 0, 0, 2}, {0, 1, 1, 2}},
-                                                                       {{1, 2, 3, 4}, {0, 0, 0, 2}, {0, 1, 2, 2}}}};
+SEQAN3_WORKAROUND_GCC_114013 search_scheme_type<3, 4> optimum_search_scheme<2, 2>{
+    {{{4, 3, 2, 1}, {0, 0, 1, 2}, {0, 0, 2, 2}},
+     {{2, 3, 4, 1}, {0, 0, 0, 2}, {0, 1, 1, 2}},
+     {{1, 2, 3, 4}, {0, 0, 0, 2}, {0, 1, 2, 2}}}};
 
+// TODO: benchmark whether the first search is really the fastest one (see \details of optimum_search_scheme)
 template <>
-inline constexpr search_scheme_type<4, 5> optimum_search_scheme<0, 3>{
-    {// TODO: benchmark whether the first search is really the fastest one (see \details of optimum_search_scheme)
-     {{5, 4, 3, 2, 1}, {0, 0, 0, 0, 0}, {0, 0, 3, 3, 3}},
+SEQAN3_WORKAROUND_GCC_114013 search_scheme_type<4, 5> optimum_search_scheme<0, 3>{
+    {{{5, 4, 3, 2, 1}, {0, 0, 0, 0, 0}, {0, 0, 3, 3, 3}},
      {{3, 4, 5, 2, 1}, {0, 0, 1, 1, 1}, {0, 1, 1, 2, 3}},
      {{2, 3, 4, 5, 1}, {0, 0, 0, 2, 2}, {0, 1, 2, 2, 3}},
      {{1, 2, 3, 4, 5}, {0, 0, 0, 0, 3}, {0, 2, 2, 3, 3}}}};
 
 template <>
-inline constexpr search_scheme_type<4, 5> optimum_search_scheme<1, 3>{
+SEQAN3_WORKAROUND_GCC_114013 search_scheme_type<4, 5> optimum_search_scheme<1, 3>{
     {{{5, 4, 3, 2, 1}, {0, 0, 0, 0, 1}, {0, 0, 3, 3, 3}},
      {{3, 4, 5, 2, 1}, {0, 0, 1, 1, 1}, {0, 1, 1, 2, 3}},
      {{2, 3, 4, 5, 1}, {0, 0, 0, 2, 2}, {0, 1, 2, 2, 3}},
      {{1, 2, 3, 4, 5}, {0, 0, 0, 0, 3}, {0, 2, 2, 3, 3}}}};
 
 template <>
-inline constexpr search_scheme_type<4, 5> optimum_search_scheme<2, 3>{
+SEQAN3_WORKAROUND_GCC_114013 search_scheme_type<4, 5> optimum_search_scheme<2, 3>{
     {{{5, 4, 3, 2, 1}, {0, 0, 0, 0, 2}, {0, 0, 3, 3, 3}},
      {{3, 4, 5, 2, 1}, {0, 0, 1, 1, 2}, {0, 1, 1, 2, 3}},
      {{2, 3, 4, 5, 1}, {0, 0, 0, 2, 2}, {0, 1, 2, 2, 3}},
      {{1, 2, 3, 4, 5}, {0, 0, 0, 0, 3}, {0, 2, 2, 3, 3}}}};
 
 template <>
-inline constexpr search_scheme_type<4, 5> optimum_search_scheme<3, 3>{
+SEQAN3_WORKAROUND_GCC_114013 search_scheme_type<4, 5> optimum_search_scheme<3, 3>{
     {{{5, 4, 3, 2, 1}, {0, 0, 0, 0, 3}, {0, 0, 3, 3, 3}},
      {{3, 4, 5, 2, 1}, {0, 0, 1, 1, 3}, {0, 1, 1, 2, 3}},
      {{2, 3, 4, 5, 1}, {0, 0, 0, 2, 3}, {0, 1, 2, 2, 3}},

--- a/test/documentation/seqan3_doxygen_cfg.in
+++ b/test/documentation/seqan3_doxygen_cfg.in
@@ -354,7 +354,8 @@ PREDEFINED             = CEREAL_SERIALIZE_FUNCTION_NAME=serialize \
                          __cpp_lib_three_way_comparison=1 \
                          SEQAN3_WORKAROUND_LITERAL=constexpr
 EXPAND_AS_DEFINED      = SEQAN3_CPO_OVERLOAD_BODY \
-                         SEQAN3_CPO_OVERLOAD
+                         SEQAN3_CPO_OVERLOAD \
+                         SEQAN3_WORKAROUND_GCC_114013
 SKIP_FUNCTION_MACROS   = NO
 #---------------------------------------------------------------------------
 # Configuration options related to external references


### PR DESCRIPTION
I don't know why the nightlies only fail now, even though these changes have been in GCC for a few months :)

https://cdash.seqan.de/index.php?project=SeqAn3

### Commit 1

Things like [std::apply](https://en.cppreference.com/w/cpp/utility/apply) require [tuple-like](https://en.cppreference.com/w/cpp/utility/tuple/tuple-like).

It also kinda means that CPP23 breaks most of our custom tuple stuff; at least when you want to use it like a `std::tuple`. In the future, `std::get` is supposed to get a CPO.

```cpp
#include <vector>

#include <seqan3/alphabet/nucleotide/dna5.hpp>
#include <seqan3/alphabet/quality/phred42.hpp>
#include <seqan3/io/record.hpp>
#include <seqan3/utility/tuple/pod_tuple.hpp>
#include <seqan3/utility/type_list/type_list.hpp>

// Would work, but not allowed.
// namespace std
// {
//     template <typename... T>
//     inline constexpr bool __is_tuple_like_v<seqan3::pod_tuple<T...>> = true;
// }

int main()
{
    using seq_t = std::vector<seqan3::dna5>;
    using id_t = std::string;
    using qual_t = std::vector<seqan3::phred42>;
    using type_list_t = seqan3::type_list<seq_t, id_t, qual_t>;
    using fields_t = seqan3::fields<seqan3::field::seq, seqan3::field::id, seqan3::field::qual>;
    using record_t = seqan3::record<type_list_t, fields_t> &;

    static_assert(std::__tuple_like<record_t>); // Fails
    static_assert(std::__tuple_like<seqan3::pod_tuple<int, float, int>>); // Fails
}
```

### Commit 2


```
/usr/bin/ld: read_mapper_step2.cpp.o: warning: relocation against `_ZN6seqan36detail21optimum_search_schemeILh0ELh2EEE' in read-only section `.text._ZN6seqan36detail23search_scheme_algorithmINS_13configurationIJNS_10search_cfg15max_error_totalENS3_12hit_all_bestENS3_15output_query_idENS3_19output_reference_idENS3_31output_reference_begin_positionENS3_6detail11result_typeINS_13search_resultImNS0_10empty_typeEmmEEEEEEENS_11bi_fm_indexINS_4dna5ELNS_11text_layoutE1EN4sdsl6csa_wtINSJ_5wt_pcINSJ_14balanced_shapeENSJ_10int_vectorILh1EEENSJ_14rank_support_vILh1ELh1EEENSJ_19select_support_scanILh1ELh1EEENSR_ILh0ELh1EEENSJ_9byte_treeILb0EEEEELj16ELj10000000ENSJ_20sa_order_sa_samplingILh0EEENSJ_12isa_samplingILh0EEENSJ_19plain_byte_alphabetEEEEEJNS0_16policy_max_errorENS0_28policy_search_result_builderISF_EEEE14search_algo_biILb0ESt6vectorISH_SaISH_EERKZNS17_clISt5tupleIJmRS1B_EESt8functionIFvSD_EEEEvOT_OT0_EUlRKS1J_E_EEvRS1L_NS0_12search_paramEOT1_[_ZN6seqan36detail23search_scheme_algorithmINS_13configurationIJNS_10search_cfg15max_error_totalENS3_12hit_all_bestENS3_15output_query_idENS3_19output_reference_idENS3_31output_reference_begin_positionENS3_6detail11result_typeINS_13search_resultImNS0_10empty_typeEmmEEEEEEENS_11bi_fm_indexINS_4dna5ELNS_11text_layoutE1EN4sdsl6csa_wtINSJ_5wt_pcINSJ_14balanced_shapeENSJ_10int_vectorILh1EEENSJ_14rank_support_vILh1ELh1EEENSJ_19select_support_scanILh1ELh1EEENSR_ILh0ELh1EEENSJ_9byte_treeILb0EEEEELj16ELj10000000ENSJ_20sa_order_sa_samplingILh0EEENSJ_12isa_samplingILh0EEENSJ_19plain_byte_alphabetEEEEEJNS0_16policy_max_errorENS0_28policy_search_result_builderISF_EEEE14search_algo_biILb0ESt6vectorISH_SaISH_EERKZNS17_clISt5tupleIJmRS1B_EESt8functionIFvSD_EEEEvOT_OT0_EUlRKS1J_E_EEvRS1L_NS0_12search_paramEOT1_]'
/usr/bin/ld: read_mapper_step2.cpp.o: in function `void seqan3::detail::search_scheme_algorithm<seqan3::configuration<seqan3::search_cfg::max_error_total, seqan3::search_cfg::hit_all_best, seqan3::search_cfg::output_query_id, seqan3::search_cfg::output_reference_id, seqan3::search_cfg::output_reference_begin_position, seqan3::search_cfg::detail::result_type<seqan3::search_result<unsigned long, seqan3::detail::empty_type, unsigned long, unsigned long> > >, seqan3::bi_fm_index<seqan3::dna5, (seqan3::text_layout)1, sdsl::csa_wt<sdsl::wt_pc<sdsl::balanced_shape, sdsl::int_vector<(unsigned char)1>, sdsl::rank_support_v<(unsigned char)1, (unsigned char)1>, sdsl::select_support_scan<(unsigned char)1, (unsigned char)1>, sdsl::select_support_scan<(unsigned char)0, (unsigned char)1>, sdsl::byte_tree<false> >, 16u, 10000000u, sdsl::sa_order_sa_sampling<(unsigned char)0>, sdsl::isa_sampling<(unsigned char)0>, sdsl::plain_byte_alphabet> >, seqan3::detail::policy_max_error, seqan3::detail::policy_search_result_builder<seqan3::configuration<seqan3::search_cfg::max_error_total, seqan3::search_cfg::hit_all_best, seqan3::search_cfg::output_query_id, seqan3::search_cfg::output_reference_id, seqan3::search_cfg::output_reference_begin_position, seqan3::search_cfg::detail::result_type<seqan3::search_result<unsigned long, seqan3::detail::empty_type, unsigned long, unsigned long> > > > >::search_algo_bi<false, std::vector<seqan3::dna5, std::allocator<seqan3::dna5> >, seqan3::detail::search_scheme_algorithm<seqan3::configuration<seqan3::search_cfg::max_error_total, seqan3::search_cfg::hit_all_best, seqan3::search_cfg::output_query_id, seqan3::search_cfg::output_reference_id, seqan3::search_cfg::output_reference_begin_position, seqan3::search_cfg::detail::result_type<seqan3::search_result<unsigned long, seqan3::detail::empty_type, unsigned long, unsigned long> > >, seqan3::bi_fm_index<seqan3::dna5, (seqan3::text_layout)1, sdsl::csa_wt<sdsl::wt_pc<sdsl::balanced_shape, sdsl::int_vector<(unsigned char)1>, sdsl::rank_support_v<(unsigned char)1, (unsigned char)1>, sdsl::select_support_scan<(unsigned char)1, (unsigned char)1>, sdsl::select_support_scan<(unsigned char)0, (unsigned char)1>, sdsl::byte_tree<false> >, 16u, 10000000u, sdsl::sa_order_sa_sampling<(unsigned char)0>, sdsl::isa_sampling<(unsigned char)0>, sdsl::plain_byte_alphabet> >, seqan3::detail::policy_max_error, seqan3::detail::policy_search_result_builder<seqan3::configuration<seqan3::search_cfg::max_error_total, seqan3::search_cfg::hit_all_best, seqan3::search_cfg::output_query_id, seqan3::search_cfg::output_reference_id, seqan3::search_cfg::output_reference_begin_position, seqan3::search_cfg::detail::result_type<seqan3::search_result<unsigned long, seqan3::detail::empty_type, unsigned long, unsigned long> > > > >::operator()<std::tuple<unsigned long, std::vector<seqan3::dna5, std::allocator<seqan3::dna5> >&>, std::function<void (seqan3::search_result<unsigned long, seqan3::detail::empty_type, unsigned long, unsigned long>)> >(std::tuple<unsigned long, std::vector<seqan3::dna5, std::allocator<seqan3::dna5> >&>&&, std::function<void (seqan3::search_result<unsigned long, seqan3::detail::empty_type, unsigned long, unsigned long>)>&&)::{lambda(auto:1 const&)#1} const&>(std::function<void (seqan3::search_result<unsigned long, seqan3::detail::empty_type, unsigned long, unsigned long>)>&, seqan3::detail::search_param, seqan3::detail::search_scheme_algorithm<seqan3::configuration<seqan3::search_cfg::max_error_total, seqan3::search_cfg::hit_all_best, seqan3::search_cfg::output_query_id, seqan3::search_cfg::output_reference_id, seqan3::search_cfg::output_reference_begin_position, seqan3::search_cfg::detail::result_type<seqan3::search_result<unsigned long, seqan3::detail::empty_type, unsigned long, unsigned long> > >, seqan3::bi_fm_index<seqan3::dna5, (seqan3::text_layout)1, sdsl::csa_wt<sdsl::wt_pc<sdsl::balanced_shape, sdsl::int_vector<(unsigned char)1>, sdsl::rank_support_v<(unsigned char)1, (unsigned char)1>, sdsl::select_support_scan<(unsigned char)1, (unsigned char)1>, sdsl::select_support_scan<(unsigned char)0, (unsigned char)1>, sdsl::byte_tree<false> >, 16u, 10000000u, sdsl::sa_order_sa_sampling<(unsigned char)0>, sdsl::isa_sampling<(unsigned char)0>, sdsl::plain_byte_alphabet> >, seqan3::detail::policy_max_error, seqan3::detail::policy_search_result_builder<seqan3::configuration<seqan3::search_cfg::max_error_total, seqan3::search_cfg::hit_all_best, seqan3::search_cfg::output_query_id, seqan3::search_cfg::output_reference_id, seqan3::search_cfg::output_reference_begin_position, seqan3::search_cfg::detail::result_type<seqan3::search_result<unsigned long, seqan3::detail::empty_type, unsigned long, unsigned long> > > > >::operator()<std::tuple<unsigned long, std::vector<seqan3::dna5, std::allocator<seqan3::dna5> >&>, std::function<void (seqan3::search_result<unsigned long, seqan3::detail::empty_type, unsigned long, unsigned long>)> >(std::tuple<unsigned long, std::vector<seqan3::dna5, std::allocator<seqan3::dna5> >&>&&, std::function<void (seqan3::search_result<unsigned long, seqan3::detail::empty_type, unsigned long, unsigned long>)>&&)::{lambda(auto:1 const&)#1} const&)':
seqan3/search/detail/search_scheme_algorithm.hpp:839: undefined reference to `seqan3::detail::optimum_search_scheme<(unsigned char)0, (unsigned char)0>'
/usr/bin/ld: seqan3/search/detail/search_scheme_algorithm.hpp:842: undefined reference to `seqan3::detail::optimum_search_scheme<(unsigned char)0, (unsigned char)1>'
/usr/bin/ld: seqan3/search/detail/search_scheme_algorithm.hpp:845: undefined reference to `seqan3::detail::optimum_search_scheme<(unsigned char)0, (unsigned char)2>'
/usr/bin/ld: seqan3/search/detail/search_scheme_algorithm.hpp:848: undefined reference to `seqan3::detail::optimum_search_scheme<(unsigned char)0, (unsigned char)3>'
/usr/bin/ld: warning: creating DT_TEXTREL in a PIE
collect2: error: ld returned 1 exit status
gmake[3]: *** [CMakeFiles/read_mapper_step2_snippet.dir/build.make:100: tutorial/11_read_mapper/read_mapper_step2_snippet] Error 1
```

Adding a `WORKAROUND` macro is a bit verbose, but I don't want the linker error to mask other potential issues.

