### PR TITLE
fix,doc: condition of the max number of 1s inside a shape.

### DIFF
--- a/include/seqan3/search/views/kmer_hash.hpp
+++ b/include/seqan3/search/views/kmer_hash.hpp
@@ -709,7 +709,7 @@ namespace seqan3::views
  *
  * \attention
  * For the alphabet size \f$\sigma\f$ of the alphabet of `urange` and the number of 1s \f$s\f$ of `shape` it must hold
- * that \f$s>\frac{64}{\log_2\sigma}\f$, i.e. hashes resulting from the shape/alphabet combination can be represented
+ * that \f$s \le \frac{64}{\log_2\sigma}\f$, i.e. hashes resulting from the shape/alphabet combination can be represented
  * in an `uint64_t`.
  *
  * ### View properties


### PR DESCRIPTION
Addresses a documentation issue that showed up in issue: #3242

The Attention box describes the number of 1s inside an shape. The condition is the wrong way. They described the
rejection criteria, not the accept criteria: 
https://docs.seqan.de/seqan3/3.4.0/group__search__views.html#ga6e598d6a021868f704d39df73252974f