### PR TITLE
[MISC] Remove gcc14 workaround

### DIFF
--- a/include/seqan3/alignment/configuration/detail.hpp
+++ b/include/seqan3/alignment/configuration/detail.hpp
@@ -50,8 +50,8 @@ enum struct align_config_id : uint8_t
  *                           this table to allow validation checks.
  */
 template <>
-SEQAN3_WORKAROUND_GCC_114013 std::array<std::array<bool, static_cast<uint8_t>(align_config_id::SIZE)>,
-                                        static_cast<uint8_t>(align_config_id::SIZE)>
+inline constexpr std::array<std::array<bool, static_cast<uint8_t>(align_config_id::SIZE)>,
+                            static_cast<uint8_t>(align_config_id::SIZE)>
     compatibility_table<align_config_id>{{
         //band
         //|  debug

--- a/include/seqan3/core/platform.hpp
+++ b/include/seqan3/core/platform.hpp
@@ -238,17 +238,6 @@ static_assert(sdsl::sdsl_version_major == 3, "Only version 3 of the SDSL is supp
 #    endif
 #endif
 
-/*!\brief Workaround for variable template specialisations not being emitted.
- * \see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=114013
- */
-#ifndef SEQAN3_WORKAROUND_GCC_114013
-#    if SEQAN3_COMPILER_IS_GCC && (__GNUC__ == 14)
-#        define SEQAN3_WORKAROUND_GCC_114013 constexpr
-#    else
-#        define SEQAN3_WORKAROUND_GCC_114013 inline constexpr
-#    endif
-#endif
-
 /*!\brief This is needed to support CentOS 7 or RHEL 7; Newer CentOS's include a more modern default-gcc version making
  *        this macro obsolete.
  *

--- a/include/seqan3/search/configuration/detail.hpp
+++ b/include/seqan3/search/configuration/detail.hpp
@@ -72,8 +72,8 @@ enum struct search_config_id : uint8_t
  * determined by the enum value `SIZE` of seqan3::detail::search_config_id.
  */
 template <>
-SEQAN3_WORKAROUND_GCC_114013 std::array<std::array<bool, static_cast<uint8_t>(search_config_id::SIZE)>,
-                                        static_cast<uint8_t>(search_config_id::SIZE)>
+inline constexpr std::array<std::array<bool, static_cast<uint8_t>(search_config_id::SIZE)>,
+                            static_cast<uint8_t>(search_config_id::SIZE)>
     compatibility_table<search_config_id> = {{
         // max_error_total,
         // |  max_error_substitution,

--- a/include/seqan3/search/detail/search_scheme_precomputed.hpp
+++ b/include/seqan3/search/detail/search_scheme_precomputed.hpp
@@ -81,63 +81,60 @@ using search_scheme_dyn_type = std::vector<search_dyn>;
  *          seems to be a good greedy approach.
  */
 template <uint8_t min_error, uint8_t max_error>
-SEQAN3_WORKAROUND_GCC_114013 int optimum_search_scheme{0};
+inline constexpr int optimum_search_scheme{0};
 
 //!\cond
 
 template <>
-SEQAN3_WORKAROUND_GCC_114013 search_scheme_type<1, 1> optimum_search_scheme<0, 0>{{{{1}, {0}, {0}}}};
+inline constexpr search_scheme_type<1, 1> optimum_search_scheme<0, 0>{{{{1}, {0}, {0}}}};
 
 template <>
-SEQAN3_WORKAROUND_GCC_114013 search_scheme_type<2, 2> optimum_search_scheme<0, 1>{
+inline constexpr search_scheme_type<2, 2> optimum_search_scheme<0, 1>{
     {{{1, 2}, {0, 0}, {0, 1}}, {{2, 1}, {0, 1}, {0, 1}}}};
 
 template <>
-SEQAN3_WORKAROUND_GCC_114013 search_scheme_type<2, 2> optimum_search_scheme<1, 1>{
+inline constexpr search_scheme_type<2, 2> optimum_search_scheme<1, 1>{
     {{{1, 2}, {0, 1}, {0, 1}}, {{2, 1}, {0, 1}, {0, 1}}}};
 
 template <>
-SEQAN3_WORKAROUND_GCC_114013 search_scheme_type<3, 4> optimum_search_scheme<0, 2>{
-    {{{1, 2, 3, 4}, {0, 0, 1, 1}, {0, 0, 2, 2}},
-     {{3, 2, 1, 4}, {0, 0, 0, 0}, {0, 1, 1, 2}},
-     {{4, 3, 2, 1}, {0, 0, 0, 2}, {0, 1, 2, 2}}}};
+inline constexpr search_scheme_type<3, 4> optimum_search_scheme<0, 2>{{{{1, 2, 3, 4}, {0, 0, 1, 1}, {0, 0, 2, 2}},
+                                                                       {{3, 2, 1, 4}, {0, 0, 0, 0}, {0, 1, 1, 2}},
+                                                                       {{4, 3, 2, 1}, {0, 0, 0, 2}, {0, 1, 2, 2}}}};
 
 template <>
-SEQAN3_WORKAROUND_GCC_114013 search_scheme_type<3, 4> optimum_search_scheme<1, 2>{
-    {{{1, 2, 3, 4}, {0, 0, 0, 1}, {0, 0, 2, 2}},
-     {{3, 2, 1, 4}, {0, 0, 1, 1}, {0, 1, 1, 2}},
-     {{4, 3, 2, 1}, {0, 0, 0, 2}, {0, 1, 2, 2}}}};
+inline constexpr search_scheme_type<3, 4> optimum_search_scheme<1, 2>{{{{1, 2, 3, 4}, {0, 0, 0, 1}, {0, 0, 2, 2}},
+                                                                       {{3, 2, 1, 4}, {0, 0, 1, 1}, {0, 1, 1, 2}},
+                                                                       {{4, 3, 2, 1}, {0, 0, 0, 2}, {0, 1, 2, 2}}}};
 
 template <>
-SEQAN3_WORKAROUND_GCC_114013 search_scheme_type<3, 4> optimum_search_scheme<2, 2>{
-    {{{4, 3, 2, 1}, {0, 0, 1, 2}, {0, 0, 2, 2}},
-     {{2, 3, 4, 1}, {0, 0, 0, 2}, {0, 1, 1, 2}},
-     {{1, 2, 3, 4}, {0, 0, 0, 2}, {0, 1, 2, 2}}}};
+inline constexpr search_scheme_type<3, 4> optimum_search_scheme<2, 2>{{{{4, 3, 2, 1}, {0, 0, 1, 2}, {0, 0, 2, 2}},
+                                                                       {{2, 3, 4, 1}, {0, 0, 0, 2}, {0, 1, 1, 2}},
+                                                                       {{1, 2, 3, 4}, {0, 0, 0, 2}, {0, 1, 2, 2}}}};
 
 // TODO: benchmark whether the first search is really the fastest one (see \details of optimum_search_scheme)
 template <>
-SEQAN3_WORKAROUND_GCC_114013 search_scheme_type<4, 5> optimum_search_scheme<0, 3>{
+inline constexpr search_scheme_type<4, 5> optimum_search_scheme<0, 3>{
     {{{5, 4, 3, 2, 1}, {0, 0, 0, 0, 0}, {0, 0, 3, 3, 3}},
      {{3, 4, 5, 2, 1}, {0, 0, 1, 1, 1}, {0, 1, 1, 2, 3}},
      {{2, 3, 4, 5, 1}, {0, 0, 0, 2, 2}, {0, 1, 2, 2, 3}},
      {{1, 2, 3, 4, 5}, {0, 0, 0, 0, 3}, {0, 2, 2, 3, 3}}}};
 
 template <>
-SEQAN3_WORKAROUND_GCC_114013 search_scheme_type<4, 5> optimum_search_scheme<1, 3>{
+inline constexpr search_scheme_type<4, 5> optimum_search_scheme<1, 3>{
     {{{5, 4, 3, 2, 1}, {0, 0, 0, 0, 1}, {0, 0, 3, 3, 3}},
      {{3, 4, 5, 2, 1}, {0, 0, 1, 1, 1}, {0, 1, 1, 2, 3}},
      {{2, 3, 4, 5, 1}, {0, 0, 0, 2, 2}, {0, 1, 2, 2, 3}},
      {{1, 2, 3, 4, 5}, {0, 0, 0, 0, 3}, {0, 2, 2, 3, 3}}}};
 
 template <>
-SEQAN3_WORKAROUND_GCC_114013 search_scheme_type<4, 5> optimum_search_scheme<2, 3>{
+inline constexpr search_scheme_type<4, 5> optimum_search_scheme<2, 3>{
     {{{5, 4, 3, 2, 1}, {0, 0, 0, 0, 2}, {0, 0, 3, 3, 3}},
      {{3, 4, 5, 2, 1}, {0, 0, 1, 1, 2}, {0, 1, 1, 2, 3}},
      {{2, 3, 4, 5, 1}, {0, 0, 0, 2, 2}, {0, 1, 2, 2, 3}},
      {{1, 2, 3, 4, 5}, {0, 0, 0, 0, 3}, {0, 2, 2, 3, 3}}}};
 
 template <>
-SEQAN3_WORKAROUND_GCC_114013 search_scheme_type<4, 5> optimum_search_scheme<3, 3>{
+inline constexpr search_scheme_type<4, 5> optimum_search_scheme<3, 3>{
     {{{5, 4, 3, 2, 1}, {0, 0, 0, 0, 3}, {0, 0, 3, 3, 3}},
      {{3, 4, 5, 2, 1}, {0, 0, 1, 1, 3}, {0, 1, 1, 2, 3}},
      {{2, 3, 4, 5, 1}, {0, 0, 0, 2, 3}, {0, 1, 2, 2, 3}},


### PR DESCRIPTION
Fixed upstream

<!--
Please see https://github.com/seqan/seqan3/blob/main/CONTRIBUTING.md for a general overview.

Please allow edits from maintainers:
https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests

Once you create the PR, clang-format will be run on the PR, and any formatting changes will be pushed to your fork.
Subsequently, the actual CI will start.

****************************************************************************************************
** Attention: This means that you will have to `git pull` the changes before pushing new commits. **
****************************************************************************************************

Each of your commits will trigger a clang-format commit if there are formatting changes.


While the following guide on rebasing formatting changes is intended for internal use by SeqAn members, and in no way
necessary for contributors, it may still be an interesting read: https://github.com/seqan/seqan3/wiki/Rebasing-clang-format-commits-with-git-absorb
-->
