### PR TITLE
[FIX] Missing include

### DIFF
--- a/include/seqan3/io/sam_file/format_bam.hpp
+++ b/include/seqan3/io/sam_file/format_bam.hpp
@@ -18,6 +18,7 @@
 
 #include <seqan3/alphabet/nucleotide/dna16sam.hpp>
 #include <seqan3/core/debug_stream/optional.hpp>
+#include <seqan3/core/debug_stream/tuple.hpp>
 #include <seqan3/io/sam_file/detail/cigar.hpp>
 #include <seqan3/io/sam_file/detail/format_sam_base.hpp>
 #include <seqan3/io/sam_file/header.hpp>

--- a/include/seqan3/search/dream_index/interleaved_bloom_filter.hpp
+++ b/include/seqan3/search/dream_index/interleaved_bloom_filter.hpp
@@ -189,7 +189,7 @@ public:
 
     class membership_agent_type; // documented upon definition below
 
-    template <std::integral value_t>
+    template <typename value_t>
     class counting_agent_type; // documented upon definition below
 
     /*!\name Constructors, destructor and assignment
@@ -960,10 +960,12 @@ private:
  * \include test/snippet/search/dream_index/counting_agent.cpp
  */
 template <data_layout data_layout_mode>
-template <std::integral value_t>
+template <typename value_t>
 class interleaved_bloom_filter<data_layout_mode>::counting_agent_type
 {
 private:
+    static_assert(std::integral<value_t>, "The value type must model std::integral.");
+
     //!\brief The type of the augmented seqan3::interleaved_bloom_filter.
     using ibf_t = interleaved_bloom_filter<data_layout_mode>;
 

--- a/test/unit/io/sam_file/CMakeLists.txt
+++ b/test/unit/io/sam_file/CMakeLists.txt
@@ -5,6 +5,7 @@
 seqan3_test (format_bam_test.cpp CYCLIC_DEPENDING_INCLUDES include-seqan3-io-sam_file-format_sam.hpp)
 seqan3_test (format_sam_test.cpp CYCLIC_DEPENDING_INCLUDES include-seqan3-io-sam_file-format_bam.hpp)
 seqan3_test (sam_file_input_test.cpp)
+seqan3_test (sam_file_output_include_test.cpp)
 seqan3_test (sam_file_output_test.cpp)
 seqan3_test (sam_file_record_test.cpp)
 seqan3_test (sam_file_seek_test.cpp)

--- a/test/unit/io/sam_file/sam_file_output_include_test.cpp
+++ b/test/unit/io/sam_file/sam_file_output_include_test.cpp
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2006-2024 Knut Reinert & Freie Universität Berlin
+// SPDX-FileCopyrightText: 2016-2024 Knut Reinert & MPI für molekulare Genetik
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <gtest/gtest.h>
+
+// seqan3/io/sam_file/format_bam.hpp did not include core/debug_stream/tuple.hpp
+// having only the following include leads to a compile error
+#include <seqan3/io/sam_file/output.hpp>
+
+TEST(sam_file_output, include)
+{
+    using sam_file_output_t = seqan3::sam_file_output<seqan3::fields<seqan3::field::id>,
+                                                      seqan3::type_list<seqan3::format_sam, seqan3::format_bam>,
+                                                      std::vector<std::string>>;
+    std::string buffer{};
+    std::ostringstream stream{buffer};
+    {
+        sam_file_output_t out{stream, std::vector<std::string>{}, std::vector<size_t>{}, seqan3::format_sam{}};
+        out.emplace_back(std::string{});
+    }
+    {
+        sam_file_output_t out{stream, std::vector<std::string>{}, std::vector<size_t>{}, seqan3::format_bam{}};
+        out.emplace_back(std::string{});
+    }
+}


### PR DESCRIPTION
Trying to write a BAM file while only using the `<seqan3/io/sam_file/output.hpp>` include leads to a compile error.

The reference dictionary (`header.ref_dict`) needs to be printed for an error message:
https://github.com/seqan/seqan3/blob/f489f67d9aaa6e72dc42c59a1e5ef8fc27fec9d6/include/seqan3/io/sam_file/format_bam.hpp#L708-L713

But the corresponding `debug_stream` include, required by `to_string`, is missing.

I added a separate test for this issue as we need to include only this one header.

The header tests probably do not catch this because they do not instantiate the templates.